### PR TITLE
fix(ec2): wire fidelity across instances, storage, security-groups, vpc/subnet, routing (34 findings)

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -7977,8 +7977,10 @@ func testKeyPairOperations(t *testing.T, ctx context.Context, c computedriver.Co
 		t.Error("expected non-empty ID")
 	}
 
-	if kp.Fingerprint != "fp-test-key" {
-		t.Errorf("expected fingerprint 'fp-test-key', got %q", kp.Fingerprint)
+	// Fingerprint format is provider-specific; AWS emits a real colon-hex digest
+	// (see server/aws/ec2 key_pair_test.go for the exact-shape assertion).
+	if kp.Fingerprint == "" {
+		t.Error("expected non-empty fingerprint")
 	}
 
 	if kp.PrivateKey == "" {

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -11,6 +11,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -115,6 +116,13 @@ type instanceData struct {
 	// instance, so Terminate deprovisions it and console output is read from
 	// the engine rather than synthesized.
 	engineBacked bool
+	// disableAPITermination is the termination-protection flag set via
+	// ModifyInstanceAttribute(DisableApiTermination). When true, real EC2
+	// rejects TerminateInstances with OperationNotPermitted.
+	disableAPITermination bool
+	// sourceDestCheck mirrors the instance's source/destination check flag
+	// (default true), toggled via ModifyInstanceAttribute(SourceDestCheck).
+	sourceDestCheck bool
 }
 
 // operatorData records service-provider managed-resource ownership.
@@ -310,7 +318,8 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 			State: compute.StatePending, PrivateIP: m.nextIP(), SubnetID: cfg.SubnetID,
 			VPCID:          m.resolveSubnetVPC(ctx, cfg.SubnetID),
 			SecurityGroups: sg, Tags: tags,
-			LaunchTime: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+			LaunchTime:      m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+			sourceDestCheck: true,
 		}
 
 		if cfg.Managed {
@@ -424,6 +433,15 @@ func (m *Mock) RebootInstances(ctx context.Context, instanceIDs []string) error 
 }
 
 func (m *Mock) TerminateInstances(ctx context.Context, instanceIDs []string) error {
+	// Termination protection: real EC2 rejects the whole call with
+	// OperationNotPermitted if any target has DisableApiTermination set.
+	for _, id := range instanceIDs {
+		if inst, ok := m.instances.Get(id); ok && inst.disableAPITermination {
+			return cerrors.Newf(cerrors.PermissionDenied,
+				"instance %q may not be terminated: termination protection is enabled", id)
+		}
+	}
+
 	if err := m.transitionInstances(ctx, instanceIDs, terminateTransition); err != nil {
 		return err
 	}
@@ -626,6 +644,60 @@ func (m *Mock) ModifyInstance(_ context.Context, instanceID string, input driver
 	}
 
 	return nil
+}
+
+// Instance-attribute names honored by SetInstanceAttribute / GetInstanceAttribute.
+// These match the ModifyInstanceAttribute / DescribeInstanceAttribute attribute
+// element names on the AWS wire.
+const (
+	attrDisableAPITermination = "disableApiTermination"
+	attrSourceDestCheck       = "sourceDestCheck"
+	attrInstanceType          = "instanceType"
+)
+
+// SetInstanceAttribute updates a single instance attribute in place. It backs
+// the AWS wire ModifyInstanceAttribute for attributes (DisableApiTermination,
+// SourceDestCheck) that real EC2 permits on a running instance and that are not
+// part of the portable Compute driver. Unlike ModifyInstance it does not
+// require the instance to be stopped.
+func (m *Mock) SetInstanceAttribute(_ context.Context, instanceID, name, value string) error {
+	inst, ok := m.instances.Get(instanceID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
+	}
+
+	b, _ := strconv.ParseBool(value)
+
+	switch name {
+	case attrDisableAPITermination:
+		inst.disableAPITermination = b
+	case attrSourceDestCheck:
+		inst.sourceDestCheck = b
+	default:
+		return cerrors.Newf(cerrors.InvalidArgument, "unsupported instance attribute %q", name)
+	}
+
+	return nil
+}
+
+// GetInstanceAttribute reads a single instance attribute, backing the AWS wire
+// DescribeInstanceAttribute so ModifyInstanceAttribute changes are verifiable.
+func (m *Mock) GetInstanceAttribute(_ context.Context, instanceID, name string) (string, error) {
+	inst, ok := m.instances.Get(instanceID)
+	if !ok {
+		return "", cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
+	}
+
+	switch name {
+	case attrDisableAPITermination:
+		return strconv.FormatBool(inst.disableAPITermination), nil
+	case attrSourceDestCheck:
+		return strconv.FormatBool(inst.sourceDestCheck), nil
+	case attrInstanceType:
+		return inst.InstanceType, nil
+	default:
+		return "", cerrors.Newf(cerrors.InvalidArgument, "unsupported instance attribute %q", name)
+	}
 }
 
 // SetInstanceVPC sets the VPC ID on an existing instance. This is a test

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -2,8 +2,16 @@ package ec2
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1" //nolint:gosec // AWS defines RSA key-pair fingerprints as SHA-1 digests
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -30,6 +38,19 @@ const (
 	// managed-resource-visibility settings.
 	visibilityHidden  = "hidden"
 	visibilityVisible = "visible"
+
+	// awsAccountID is the fixed owner account for resources this mock creates,
+	// echoed as ownerId on volumes/snapshots/images.
+	awsAccountID = "123456789012"
+	// defaultEBSKeyID is the stub KMS key id used when an encrypted volume is
+	// created without an explicit KmsKeyId (real EC2 substitutes the account's
+	// default EBS key).
+	defaultEBSKeyID = "abcd1234-a123-456a-a12b-a123b4cd56ef"
+	// imageRootDeviceSize is the default root EBS volume size (GiB) recorded in
+	// an AMI's block device mapping when created from a running instance.
+	imageRootDeviceSize = 8
+	// rsaKeyBits is the modulus size for generated RSA key pairs.
+	rsaKeyBits = 2048
 )
 
 type lifecycleTransition struct {
@@ -123,6 +144,7 @@ type Mock struct {
 	volCounter   atomic.Int64
 	snapCounter  atomic.Int64
 	amiCounter   atomic.Int64
+	keyCounter   atomic.Int64
 	monitoring   mondriver.Monitoring
 	// subnetResolver derives an instance's VPC from its subnet at launch, so
 	// instances created with a --subnet-id carry the VPCID that connectivity
@@ -659,6 +681,8 @@ func (m *Mock) SetManagedResourceVisibility(v string) error {
 }
 
 // CreateVolume creates a new EBS volume.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver.VolumeInfo, error) {
 	id := fmt.Sprintf("vol-%012d", m.volCounter.Add(1))
 
@@ -672,6 +696,11 @@ func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver
 		az = m.opts.Region + "a"
 	}
 
+	kmsKeyID := cfg.KmsKeyID
+	if cfg.Encrypted && kmsKeyID == "" {
+		kmsKeyID = idgen.AWSARN("kms", m.opts.Region, awsAccountID, "key/"+defaultEBSKeyID)
+	}
+
 	vol := &driver.VolumeInfo{
 		ID:               id,
 		Size:             cfg.Size,
@@ -683,6 +712,9 @@ func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver
 		IOPS:             cfg.IOPS,
 		Throughput:       cfg.Throughput,
 		Tier:             cfg.Tier,
+		Encrypted:        cfg.Encrypted,
+		SnapshotID:       cfg.SnapshotID,
+		KmsKeyID:         kmsKeyID,
 	}
 
 	m.volumes.Set(id, vol)
@@ -778,6 +810,9 @@ func (m *Mock) CreateSnapshot(_ context.Context, cfg driver.SnapshotConfig) (*dr
 		Size:        vol.Size,
 		CreatedAt:   m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
 		Tags:        copyTags(cfg.Tags),
+		OwnerID:     awsAccountID,
+		Progress:    "100%",
+		Encrypted:   vol.Encrypted,
 	}
 
 	m.snapshots.Set(id, snap)
@@ -796,8 +831,15 @@ func (m *Mock) DeleteSnapshot(_ context.Context, id string) error {
 	return nil
 }
 
-// DescribeSnapshots returns snapshots matching the given IDs.
+// DescribeSnapshots returns snapshots matching the given IDs. An explicit ID
+// that does not exist yields InvalidSnapshot.NotFound, matching real EC2.
 func (m *Mock) DescribeSnapshots(_ context.Context, ids []string) ([]driver.SnapshotInfo, error) {
+	for _, id := range ids {
+		if !m.snapshots.Has(id) {
+			return nil, cerrors.Newf(cerrors.NotFound, "snapshot %q not found", id)
+		}
+	}
+
 	return describeResources(m.snapshots, ids), nil
 }
 
@@ -808,14 +850,43 @@ func (m *Mock) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.I
 	}
 
 	id := fmt.Sprintf("ami-%012d", m.amiCounter.Add(1))
+	now := m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z")
+
+	// A real CreateImage snapshots the instance's root volume and references
+	// that snapshot from the AMI's block device mapping.
+	snapID := fmt.Sprintf("snap-%012d", m.snapCounter.Add(1))
+	m.snapshots.Set(snapID, &driver.SnapshotInfo{
+		ID:          snapID,
+		State:       "completed",
+		Description: "Created by CreateImage for " + id,
+		Size:        imageRootDeviceSize,
+		CreatedAt:   now,
+		OwnerID:     awsAccountID,
+		Progress:    "100%",
+	})
 
 	img := &driver.ImageInfo{
-		ID:          id,
-		Name:        cfg.Name,
-		State:       "available",
-		Description: cfg.Description,
-		CreatedAt:   m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
-		Tags:        copyTags(cfg.Tags),
+		ID:                 id,
+		Name:               cfg.Name,
+		State:              stateAvailable,
+		Description:        cfg.Description,
+		CreatedAt:          now,
+		Tags:               copyTags(cfg.Tags),
+		OwnerID:            awsAccountID,
+		Architecture:       "x86_64",
+		RootDeviceType:     "ebs",
+		RootDeviceName:     "/dev/sda1",
+		VirtualizationType: "hvm",
+		Hypervisor:         "xen",
+		ImageType:          "machine",
+		PlatformDetails:    "Linux/UNIX",
+		BlockDeviceMappings: []driver.ImageBlockDeviceMapping{{
+			DeviceName:          "/dev/sda1",
+			SnapshotID:          snapID,
+			VolumeSize:          imageRootDeviceSize,
+			VolumeType:          "gp2",
+			DeleteOnTermination: true,
+		}},
 	}
 
 	m.images.Set(id, img)
@@ -834,8 +905,15 @@ func (m *Mock) DeregisterImage(_ context.Context, id string) error {
 	return nil
 }
 
-// DescribeImages returns images matching the given IDs.
+// DescribeImages returns images matching the given IDs. An explicit ID that
+// does not exist yields InvalidAMIID.NotFound, matching real EC2.
 func (m *Mock) DescribeImages(_ context.Context, ids []string) ([]driver.ImageInfo, error) {
+	for _, id := range ids {
+		if !m.images.Has(id) {
+			return nil, cerrors.Newf(cerrors.NotFound, "image %q not found", id)
+		}
+	}
+
 	return describeResources(m.images, ids), nil
 }
 
@@ -854,13 +932,18 @@ func (m *Mock) CreateKeyPair(_ context.Context, cfg driver.KeyPairConfig) (*driv
 		keyType = "rsa"
 	}
 
+	mat, err := generateKeyMaterial(keyType)
+	if err != nil {
+		return nil, cerrors.Newf(cerrors.Internal, "generate key material: %v", err)
+	}
+
 	kp := &driver.KeyPairInfo{
-		ID:          idgen.AWSARN("ec2", m.opts.Region, "123456789012", "key-pair/"+cfg.Name),
+		ID:          fmt.Sprintf("key-%016x", m.keyCounter.Add(1)),
 		Name:        cfg.Name,
-		Fingerprint: "fp-" + cfg.Name,
+		Fingerprint: mat.fingerprint,
 		KeyType:     keyType,
-		PublicKey:   "mock-public-key-" + cfg.Name,
-		PrivateKey:  "mock-private-key-" + cfg.Name,
+		PublicKey:   mat.publicPEM,
+		PrivateKey:  mat.privatePEM,
 		CreatedAt:   m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
 		Tags:        copyTags(cfg.Tags),
 	}
@@ -896,17 +979,91 @@ func (m *Mock) DescribeKeyPairs(_ context.Context, names []string) ([]driver.Key
 		return result, nil
 	}
 
-	var result []driver.KeyPairInfo
+	result := make([]driver.KeyPairInfo, 0, len(names))
 
 	for _, name := range names {
-		if kp, ok := m.keyPairs.Get(name); ok {
-			cp := *kp
-			cp.PrivateKey = ""
-			result = append(result, cp)
+		kp, ok := m.keyPairs.Get(name)
+		if !ok {
+			return nil, cerrors.Newf(cerrors.NotFound, "key pair %q not found", name)
 		}
+
+		cp := *kp
+		cp.PrivateKey = ""
+		result = append(result, cp)
 	}
 
 	return result, nil
+}
+
+// keyMaterial bundles the PEM-encoded key pair and its fingerprint.
+type keyMaterial struct {
+	privatePEM  string
+	publicPEM   string
+	fingerprint string
+}
+
+// generateKeyMaterial returns a PEM-encoded key pair and its fingerprint. RSA
+// fingerprints are the SHA-1 digest of the DER private key as colon-separated
+// hex, matching CreateKeyPair on real EC2; ed25519 keys use a SHA-256 digest.
+func generateKeyMaterial(keyType string) (keyMaterial, error) {
+	if keyType == "ed25519" {
+		pub, priv, gerr := ed25519.GenerateKey(rand.Reader)
+		if gerr != nil {
+			return keyMaterial{}, gerr
+		}
+
+		der, merr := x509.MarshalPKCS8PrivateKey(priv)
+		if merr != nil {
+			return keyMaterial{}, merr
+		}
+
+		sum := sha256.Sum256(der)
+
+		return keyMaterial{
+			privatePEM:  pemEncode("PRIVATE KEY", der),
+			publicPEM:   pkixPublicPEM(pub),
+			fingerprint: colonHex(sum[:]),
+		}, nil
+	}
+
+	key, gerr := rsa.GenerateKey(rand.Reader, rsaKeyBits)
+	if gerr != nil {
+		return keyMaterial{}, gerr
+	}
+
+	der := x509.MarshalPKCS1PrivateKey(key)
+	sum := sha1.Sum(der) //nolint:gosec // AWS defines RSA key-pair fingerprints as SHA-1 digests
+
+	return keyMaterial{
+		privatePEM:  pemEncode("RSA PRIVATE KEY", der),
+		publicPEM:   pkixPublicPEM(key.Public()),
+		fingerprint: colonHex(sum[:]),
+	}, nil
+}
+
+func pemEncode(blockType string, der []byte) string {
+	return string(pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der}))
+}
+
+// pkixPublicPEM PEM-encodes a public key, returning "" if it cannot be marshaled.
+func pkixPublicPEM(pub any) string {
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return ""
+	}
+
+	return pemEncode("PUBLIC KEY", der)
+}
+
+// colonHex formats bytes as colon-separated lowercase hex (aa:bb:cc), the
+// shape AWS uses for key fingerprints.
+func colonHex(b []byte) string {
+	parts := make([]string, len(b))
+	for i, x := range b {
+		parts[i] = fmt.Sprintf("%02x", x)
+	}
+
+	return strings.Join(parts, ":")
 }
 
 func describeResources[T any](store *memstore.Store[*T], ids []string) []T {

--- a/providers/aws/ec2/ec2_test.go
+++ b/providers/aws/ec2/ec2_test.go
@@ -555,10 +555,10 @@ func TestDeleteSnapshot(t *testing.T) {
 		err = m.DeleteSnapshot(ctx, snap.ID)
 		requireNoError(t, err)
 
-		// Should be gone
-		snaps, err := m.DescribeSnapshots(ctx, []string{snap.ID})
-		requireNoError(t, err)
-		assertEqual(t, 0, len(snaps))
+		// Should be gone: describing the deleted ID now yields NotFound,
+		// matching real EC2 (InvalidSnapshot.NotFound) rather than empty success.
+		_, err = m.DescribeSnapshots(ctx, []string{snap.ID})
+		assertError(t, err, true)
 	})
 
 	t.Run("not found", func(t *testing.T) {
@@ -653,10 +653,10 @@ func TestDeregisterImage(t *testing.T) {
 		err = m.DeregisterImage(ctx, img.ID)
 		requireNoError(t, err)
 
-		// Should be gone
-		imgs, err := m.DescribeImages(ctx, []string{img.ID})
-		requireNoError(t, err)
-		assertEqual(t, 0, len(imgs))
+		// Should be gone: describing the deleted ID now yields NotFound,
+		// matching real EC2 (InvalidAMIID.NotFound) rather than empty success.
+		_, err = m.DescribeImages(ctx, []string{img.ID})
+		assertError(t, err, true)
 	})
 
 	t.Run("not found", func(t *testing.T) {

--- a/providers/aws/vpc/dhcp_options.go
+++ b/providers/aws/vpc/dhcp_options.go
@@ -50,6 +50,13 @@ func (m *Mock) AssociateDHCPOptions(_ context.Context, dhcpOptionsID, vpcID stri
 		return errors.Newf(errors.NotFound, "dhcp options %q not found", dhcpOptionsID)
 	}
 
+	// Persist the association so DescribeVpcs reflects it. "default" resets the
+	// VPC to the Amazon-provided set.
+	m.vpcs.Update(vpcID, func(v *vpcData) *vpcData {
+		v.DhcpOptionsID = dhcpOptionsID
+		return v
+	})
+
 	return nil
 }
 

--- a/providers/aws/vpc/nat_gateway.go
+++ b/providers/aws/vpc/nat_gateway.go
@@ -8,20 +8,27 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
-// NAT gateway state constants.
+// NAT gateway state and connectivity constants.
 const (
 	NATStateAvailable = "available"
 	NATStateDeleted   = "deleted"
+
+	natConnectivityPublic  = "public"
+	natConnectivityPrivate = "private"
 )
 
 type natGatewayData struct {
-	ID        string
-	SubnetID  string
-	VPCID     string
-	PublicIP  string
-	State     string
-	CreatedAt string
-	Tags      map[string]string
+	ID                 string
+	SubnetID           string
+	VPCID              string
+	PublicIP           string
+	PrivateIP          string
+	AllocationID       string
+	NetworkInterfaceID string
+	ConnectivityType   string
+	State              string
+	CreatedAt          string
+	Tags               map[string]string
 }
 
 // CreateNATGateway creates a NAT gateway in the specified subnet.
@@ -36,20 +43,34 @@ func (m *Mock) CreateNATGateway(_ context.Context, cfg driver.NATGatewayConfig) 
 	}
 
 	id := idgen.GenerateID("nat-")
-	nat := &natGatewayData{
-		ID:        id,
-		SubnetID:  cfg.SubnetID,
-		VPCID:     subnet.VPCID,
-		PublicIP:  mockPublicIP(id),
-		State:     NATStateAvailable,
-		CreatedAt: m.opts.Clock.Now().Format(timeFormat),
-		Tags:      copyTags(cfg.Tags),
-	}
-	m.natGateways.Set(id, nat)
 
 	// A real NAT gateway occupies an ENI in its subnet for as long as it
 	// lives, and that ENI is what refuses a VPC delete issued too early.
-	m.attachManagedENI(subnet.VPCID, cfg.SubnetID, natENIDescription(id))
+	eni := m.attachManagedENI(subnet.VPCID, cfg.SubnetID, natENIDescription(id))
+
+	connectivity := natConnectivityPublic
+	if cfg.ConnectivityType == natConnectivityPrivate {
+		connectivity = natConnectivityPrivate
+	}
+
+	nat := &natGatewayData{
+		ID:                 id,
+		SubnetID:           cfg.SubnetID,
+		VPCID:              subnet.VPCID,
+		PrivateIP:          mockPublicIP(id + "-private"),
+		AllocationID:       cfg.AllocationID,
+		NetworkInterfaceID: eni.ID,
+		ConnectivityType:   connectivity,
+		State:              NATStateAvailable,
+		CreatedAt:          m.opts.Clock.Now().Format(timeFormat),
+		Tags:               copyTags(cfg.Tags),
+	}
+	// A private NAT gateway has no public/Elastic IP address.
+	if connectivity == natConnectivityPublic {
+		nat.PublicIP = mockPublicIP(id)
+	}
+
+	m.natGateways.Set(id, nat)
 
 	info := toNATGatewayInfo(nat)
 
@@ -78,12 +99,16 @@ func (m *Mock) DescribeNATGateways(_ context.Context, ids []string) ([]driver.NA
 
 func toNATGatewayInfo(n *natGatewayData) driver.NATGateway {
 	return driver.NATGateway{
-		ID:        n.ID,
-		SubnetID:  n.SubnetID,
-		VPCID:     n.VPCID,
-		PublicIP:  n.PublicIP,
-		State:     n.State,
-		CreatedAt: n.CreatedAt,
-		Tags:      copyTags(n.Tags),
+		ID:                 n.ID,
+		SubnetID:           n.SubnetID,
+		VPCID:              n.VPCID,
+		PublicIP:           n.PublicIP,
+		PrivateIP:          n.PrivateIP,
+		AllocationID:       n.AllocationID,
+		NetworkInterfaceID: n.NetworkInterfaceID,
+		ConnectivityType:   n.ConnectivityType,
+		State:              n.State,
+		CreatedAt:          n.CreatedAt,
+		Tags:               copyTags(n.Tags),
 	}
 }

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -3,6 +3,7 @@ package vpc
 
 import (
 	"context"
+	"net"
 	"sync"
 	"time"
 
@@ -28,6 +29,7 @@ var (
 	_ driver.Networking                 = (*Mock)(nil)
 	_ driver.NetworkInterfaces          = (*Mock)(nil)
 	_ driver.VPCAttributes              = (*Mock)(nil)
+	_ driver.SubnetAttributes           = (*Mock)(nil)
 	_ driver.TransitGateways            = (*Mock)(nil)
 	_ driver.VPNConnections             = (*Mock)(nil)
 	_ driver.DHCPOptionSets             = (*Mock)(nil)
@@ -142,15 +144,17 @@ type vpcData struct {
 	Tags               map[string]string
 	EnableDNSSupport   bool
 	EnableDNSHostnames bool
+	DhcpOptionsID      string
 }
 
 type subnetData struct {
-	ID               string
-	VPCID            string
-	CIDRBlock        string
-	AvailabilityZone string
-	State            string
-	Tags             map[string]string
+	ID                  string
+	VPCID               string
+	CIDRBlock           string
+	AvailabilityZone    string
+	State               string
+	Tags                map[string]string
+	MapPublicIPOnLaunch bool
 }
 
 type sgData struct {
@@ -350,6 +354,13 @@ func (m *Mock) CreateSubnet(_ context.Context, cfg driver.SubnetConfig) (*driver
 		return nil, errors.Newf(errors.NotFound, "vpc %q not found", cfg.VPCID)
 	}
 
+	if conflict, err := m.subnetCIDRConflict(cfg.VPCID, cfg.CIDRBlock); err != nil {
+		return nil, err
+	} else if conflict != "" {
+		return nil, errors.Newf(errors.AlreadyExists,
+			"InvalidSubnet.Conflict: subnet CIDR %q conflicts with existing subnet %q", cfg.CIDRBlock, conflict)
+	}
+
 	id := idgen.GenerateID("subnet-")
 	tags := copyTags(cfg.Tags)
 
@@ -370,19 +381,82 @@ func (m *Mock) CreateSubnet(_ context.Context, cfg driver.SubnetConfig) (*driver
 
 // DeleteSubnet deletes the subnet with the given ID.
 func (m *Mock) DeleteSubnet(_ context.Context, id string) error {
-	sub, ok := m.subnets.Get(id)
-	if !ok {
+	if !m.subnets.Has(id) {
 		return errors.Newf(errors.NotFound, "subnet %q not found", id)
 	}
 
-	// Same contract as DeleteVPC, one level down: a managed resource holding
-	// an interface in this subnet keeps it alive.
-	if eni, blocked := m.attachedENIIn(sub.VPCID, id); blocked {
+	// Real EC2 refuses to delete a subnet while ANY network interface still
+	// resides in it — an unattached (available) ENI counts, not just an attached
+	// one. Accepting the delete otherwise lets a broken drain pass unnoticed.
+	if eni, blocked := m.eniInSubnet(id); blocked {
 		return errors.Newf(errors.FailedPrecondition,
-			"DependencyViolation: network interface %q is still attached in subnet %q", eni, id)
+			"DependencyViolation: network interface %q still resides in subnet %q", eni, id)
 	}
 
 	m.subnets.Delete(id)
+
+	return nil
+}
+
+// eniInSubnet reports the first network interface residing in the given subnet,
+// whether attached or available. Real EC2 blocks DeleteSubnet on either.
+func (m *Mock) eniInSubnet(subnetID string) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, eni := range m.enis.All() {
+		if eni.SubnetID == subnetID {
+			return eni.ID, true
+		}
+	}
+
+	return "", false
+}
+
+// subnetCIDRConflict reports an existing subnet in the same VPC whose CIDR
+// overlaps the candidate, or an error if either CIDR is malformed. An empty id
+// with a nil error means no conflict.
+func (m *Mock) subnetCIDRConflict(vpcID, cidr string) (string, error) {
+	_, candidate, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", errors.Newf(errors.InvalidArgument, "invalid CIDR block %q", cidr)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, s := range m.subnets.All() {
+		if s.VPCID != vpcID {
+			continue
+		}
+
+		_, existing, perr := net.ParseCIDR(s.CIDRBlock)
+		if perr != nil {
+			continue
+		}
+
+		if existing.Contains(candidate.IP) || candidate.Contains(existing.IP) {
+			return s.ID, nil
+		}
+	}
+
+	return "", nil
+}
+
+// ModifySubnetAttribute changes one subnet launch attribute (the AWS-specific
+// SubnetAttributes optional capability). A nil pointer leaves that attribute
+// untouched, matching an API that accepts one attribute per call.
+func (m *Mock) ModifySubnetAttribute(_ context.Context, id string, update driver.SubnetAttributeUpdate) error {
+	if update.MapPublicIPOnLaunch == nil {
+		return nil
+	}
+
+	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
+		s.MapPublicIPOnLaunch = *update.MapPublicIPOnLaunch
+		return s
+	}) {
+		return errors.Newf(errors.NotFound, "subnet %q not found", id)
+	}
 
 	return nil
 }
@@ -704,17 +778,19 @@ func toVPCInfo(v *vpcData) driver.VPCInfo {
 		Tags:               copyTags(v.Tags),
 		EnableDNSSupport:   v.EnableDNSSupport,
 		EnableDNSHostnames: v.EnableDNSHostnames,
+		DhcpOptionsID:      v.DhcpOptionsID,
 	}
 }
 
 func toSubnetInfo(s *subnetData) driver.SubnetInfo {
 	return driver.SubnetInfo{
-		ID:               s.ID,
-		VPCID:            s.VPCID,
-		CIDRBlock:        s.CIDRBlock,
-		AvailabilityZone: s.AvailabilityZone,
-		State:            s.State,
-		Tags:             copyTags(s.Tags),
+		ID:                  s.ID,
+		VPCID:               s.VPCID,
+		CIDRBlock:           s.CIDRBlock,
+		AvailabilityZone:    s.AvailabilityZone,
+		State:               s.State,
+		Tags:                copyTags(s.Tags),
+		MapPublicIPOnLaunch: s.MapPublicIPOnLaunch,
 	}
 }
 

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -514,6 +514,7 @@ func containsValue(values []string, target string) bool {
 	return false
 }
 
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver.VolumeInfo, error) {
 	id := fmt.Sprintf("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/disks/disk-%d",
 		m.volCounter.Add(1))

--- a/providers/gcp/compute/gce.go
+++ b/providers/gcp/compute/gce.go
@@ -525,6 +525,7 @@ func (m *Mock) SetInstanceVPC(instanceID, vpcID string) error {
 	return nil
 }
 
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver.VolumeInfo, error) {
 	id := fmt.Sprintf("projects/%s/zones/%s/disks/disk-%d",
 		m.opts.ProjectID, m.opts.Region, m.volCounter.Add(1))

--- a/server/aws/ec2/ec2_phase2_test.go
+++ b/server/aws/ec2/ec2_phase2_test.go
@@ -398,7 +398,9 @@ func TestToInternetGatewayXMLAttachment(t *testing.T) {
 		t.Fatalf("attached IGW should have 1 attachment, got %d", len(got.Attachments))
 	}
 
-	if got.Attachments[0].VpcID != "vpc-1" || got.Attachments[0].State != "attached" {
+	// An attached internet gateway reports attachment state "available", the
+	// wire value AWS uses (not the driver's internal "attached" marker).
+	if got.Attachments[0].VpcID != "vpc-1" || got.Attachments[0].State != "available" {
 		t.Errorf("attachment wrong: %+v", got.Attachments[0])
 	}
 }

--- a/server/aws/ec2/ec2_phase2_test.go
+++ b/server/aws/ec2/ec2_phase2_test.go
@@ -527,7 +527,8 @@ func TestCreateAndDeleteTags(t *testing.T) {
 		t.Fatalf("DeleteTags result wrong: %s", desc)
 	}
 
-	// Unknown ID -> InvalidID.NotFound.
+	// Unknown VPC ID -> generic InvalidID.NotFound (instance ids get the
+	// resource-specific InvalidInstanceID.NotFound; see tag_error_test.go).
 	bad := do(t, h, http.MethodPost, "/", url.Values{
 		"Action": {"CreateTags"}, "ResourceId.1": {"vpc-deadbeef"},
 		"Tag.1.Key": {"a"}, "Tag.1.Value": {"b"},

--- a/server/aws/ec2/ec2_phase2_test.go
+++ b/server/aws/ec2/ec2_phase2_test.go
@@ -80,12 +80,17 @@ func TestRouteVPCDispatchesAllActions(t *testing.T) {
 		t.Errorf("AuthorizeSecurityGroupIngress = %d: %s", rr.Code, rr.Body.String())
 	}
 
-	// Egress, Revoke variants use the same parser path.
+	// Egress, Revoke variants use the same parser path. Use a distinct rule
+	// (not protocol -1 to 0.0.0.0/0, which the SG already carries as its
+	// seeded default egress rule) so this exercises the parser rather than
+	// tripping InvalidPermission.Duplicate.
 	rr = do(t, h, http.MethodPost, "/", url.Values{
 		"Action":                            {"AuthorizeSecurityGroupEgress"},
 		"GroupId":                           {sgID},
-		"IpPermissions.1.IpProtocol":        {"-1"},
-		"IpPermissions.1.IpRanges.1.CidrIp": {"0.0.0.0/0"},
+		"IpPermissions.1.IpProtocol":        {"tcp"},
+		"IpPermissions.1.FromPort":          {"443"},
+		"IpPermissions.1.ToPort":            {"443"},
+		"IpPermissions.1.IpRanges.1.CidrIp": {"10.0.0.0/16"},
 	})
 	if rr.Code != http.StatusOK {
 		t.Errorf("AuthorizeSecurityGroupEgress = %d", rr.Code)

--- a/server/aws/ec2/ec2_phase2_test.go
+++ b/server/aws/ec2/ec2_phase2_test.go
@@ -372,14 +372,16 @@ func TestToVpcXMLStateDefaults(t *testing.T) {
 func TestToSubnetXMLStateDefaults(t *testing.T) {
 	in := &netdriver.SubnetInfo{ID: "subnet-x", VPCID: "vpc-x"}
 
-	got := toSubnetXML(in)
+	got := toSubnetXML(in, "us-east-1")
 	if got.State != "available" {
 		t.Errorf("default state: %q", got.State)
 	}
 
-	if got.AvailableIPCount != subnetAvailableIPs {
+	// No CIDR set falls back to a /24's usable-address count.
+	const fallbackAvailableIPs = 251
+	if got.AvailableIPCount != fallbackAvailableIPs {
 		t.Errorf("AvailableIPCount = %d, want %d",
-			got.AvailableIPCount, subnetAvailableIPs)
+			got.AvailableIPCount, fallbackAvailableIPs)
 	}
 }
 

--- a/server/aws/ec2/ec2_test.go
+++ b/server/aws/ec2/ec2_test.go
@@ -325,21 +325,24 @@ func TestToDriverFiltersNilForEmpty(t *testing.T) {
 	}
 }
 
-func TestStateChanges(t *testing.T) {
+func TestStateChangesFrom(t *testing.T) {
 	cur := instanceState{Code: stateCodeStopping, Name: "stopping"}
-	prev := instanceState{Code: stateCodeRunning, Name: "running"}
+	prev := map[string]instanceState{
+		"i-1": {Code: stateCodeRunning, Name: "running"},
+		"i-2": {Code: stateCodeStopped, Name: "stopped"},
+	}
 
-	got := stateChanges([]string{"i-1", "i-2"}, cur, prev)
+	got := stateChangesFrom([]string{"i-1", "i-2"}, prev, cur)
 
 	if len(got) != 2 {
 		t.Fatalf("len=%d want 2", len(got))
 	}
 
-	if got[0].InstanceID != "i-1" || got[0].CurrentState != cur || got[0].PreviousState != prev {
+	if got[0].InstanceID != "i-1" || got[0].CurrentState != cur || got[0].PreviousState != prev["i-1"] {
 		t.Errorf("i-1 wrong: %+v", got[0])
 	}
 
-	if got[1].InstanceID != "i-2" {
+	if got[1].InstanceID != "i-2" || got[1].PreviousState != prev["i-2"] {
 		t.Errorf("i-2 wrong: %+v", got[1])
 	}
 }

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -23,6 +23,10 @@ const formContentType = "application/x-www-form-urlencoded"
 // plenty of headroom while preventing memory-exhaustion attacks.
 const maxFormBodyBytes = 1 << 20
 
+// codeInvalidInstanceID is the EC2 error code for a request naming a
+// non-existent instance id.
+const codeInvalidInstanceID = "InvalidInstanceID.NotFound"
+
 // Handler serves EC2 query-protocol requests. Real AWS EC2 serves both
 // compute and VPC/networking on one endpoint, so the handler holds both
 // drivers and dispatches based on the Action parameter.
@@ -248,7 +252,6 @@ func (h *Handler) routeLaunchTemplates(w http.ResponseWriter, r *http.Request, a
 	return true
 }
 
-//nolint:dupl // action-dispatch switch; every route* function has this shape by design
 func (h *Handler) routeAutoScaling(w http.ResponseWriter, r *http.Request, action string) bool {
 	switch action {
 	case "CreateAutoScalingGroup":
@@ -276,8 +279,6 @@ func (h *Handler) routeAutoScaling(w http.ResponseWriter, r *http.Request, actio
 
 // routeInstances dispatches instance-lifecycle actions backed by the compute
 // driver. Returns true if the action was handled.
-//
-//nolint:dupl // action-dispatch switch; every route* function has this shape by design
 func (h *Handler) routeInstances(w http.ResponseWriter, r *http.Request, action string) bool {
 	switch action {
 	case "RunInstances":
@@ -294,6 +295,8 @@ func (h *Handler) routeInstances(w http.ResponseWriter, r *http.Request, action 
 		h.terminateInstances(w, r)
 	case "ModifyInstanceAttribute":
 		h.modifyInstanceAttribute(w, r)
+	case "DescribeInstanceAttribute":
+		h.describeInstanceAttribute(w, r)
 	case "GetConsoleOutput":
 		h.getConsoleOutput(w, r)
 	default:
@@ -486,7 +489,7 @@ func (h *Handler) routeVPCRouteTable(w http.ResponseWriter, r *http.Request, act
 // VPC ops should use writeErrWithNotFound to emit resource-specific codes like
 // "InvalidVpcID.NotFound" or "InvalidSubnetID.NotFound".
 func writeErr(w http.ResponseWriter, err error) {
-	writeErrWithNotFound(w, err, "InvalidInstanceID.NotFound", "IncorrectInstanceState")
+	writeErrWithNotFound(w, err, codeInvalidInstanceID, "IncorrectInstanceState")
 }
 
 // writeErrWithNotFound writes an error with caller-supplied NotFound and

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -126,6 +126,8 @@ func (h *Handler) routeSnapshots(w http.ResponseWriter, r *http.Request, action 
 		h.deleteSnapshot(w, r)
 	case "DescribeSnapshots":
 		h.describeSnapshots(w, r)
+	case "ModifySnapshotAttribute":
+		h.modifySnapshotAttribute(w, r)
 	default:
 		return false
 	}
@@ -141,6 +143,8 @@ func (h *Handler) routeImages(w http.ResponseWriter, r *http.Request, action str
 		h.deregisterImage(w, r)
 	case "DescribeImages":
 		h.describeImages(w, r)
+	case "DescribeImageAttribute":
+		h.describeImageAttribute(w, r)
 	default:
 		return false
 	}
@@ -311,6 +315,8 @@ func (h *Handler) routeVolumes(w http.ResponseWriter, r *http.Request, action st
 		h.attachVolume(w, r)
 	case "DetachVolume":
 		h.detachVolume(w, r)
+	case "DescribeVolumeStatus":
+		h.describeVolumeStatus(w, r)
 	default:
 		return false
 	}

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -177,6 +177,8 @@ func (h *Handler) routeVpcPeering(w http.ResponseWriter, r *http.Request, action
 		h.createVpcPeeringConnection(w, r)
 	case "AcceptVpcPeeringConnection":
 		h.acceptVpcPeeringConnection(w, r)
+	case "RejectVpcPeeringConnection":
+		h.rejectVpcPeeringConnection(w, r)
 	case "DeleteVpcPeeringConnection":
 		h.deleteVpcPeeringConnection(w, r)
 	case "DescribeVpcPeeringConnections":
@@ -213,6 +215,8 @@ func (h *Handler) routeNetworkACLs(w http.ResponseWriter, r *http.Request, actio
 		h.describeNetworkACLs(w, r)
 	case "CreateNetworkAclEntry":
 		h.createNetworkACLEntry(w, r)
+	case "ReplaceNetworkAclEntry":
+		h.replaceNetworkACLEntry(w, r)
 	case "DeleteNetworkAclEntry":
 		h.deleteNetworkACLEntry(w, r)
 	default:

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -405,6 +405,8 @@ func (h *Handler) routeVPCSubnet(w http.ResponseWriter, r *http.Request, action 
 		h.deleteSubnet(w, r)
 	case "DescribeSubnets":
 		h.describeSubnets(w, r)
+	case "ModifySubnetAttribute":
+		h.modifySubnetAttribute(w, r)
 	default:
 		return false
 	}

--- a/server/aws/ec2/image.go
+++ b/server/aws/ec2/image.go
@@ -8,15 +8,31 @@ import (
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 )
 
+type imageBlockDeviceMappingXML struct {
+	DeviceName          string `xml:"deviceName"`
+	SnapshotID          string `xml:"ebs>snapshotId"`
+	VolumeSize          int    `xml:"ebs>volumeSize"`
+	VolumeType          string `xml:"ebs>volumeType"`
+	DeleteOnTermination bool   `xml:"ebs>deleteOnTermination"`
+}
+
 type imageXML struct {
-	ImageID      string    `xml:"imageId"`
-	State        string    `xml:"imageState"`
-	Name         string    `xml:"name,omitempty"`
-	Description  string    `xml:"description,omitempty"`
-	CreationDate string    `xml:"creationDate,omitempty"`
-	Architecture string    `xml:"architecture"`
-	Public       bool      `xml:"isPublic"`
-	Tags         []tagItem `xml:"tagSet>item,omitempty"`
+	ImageID             string                       `xml:"imageId"`
+	State               string                       `xml:"imageState"`
+	OwnerID             string                       `xml:"imageOwnerId,omitempty"`
+	Name                string                       `xml:"name,omitempty"`
+	Description         string                       `xml:"description,omitempty"`
+	CreationDate        string                       `xml:"creationDate,omitempty"`
+	Architecture        string                       `xml:"architecture"`
+	ImageType           string                       `xml:"imageType,omitempty"`
+	Public              bool                         `xml:"isPublic"`
+	RootDeviceType      string                       `xml:"rootDeviceType,omitempty"`
+	RootDeviceName      string                       `xml:"rootDeviceName,omitempty"`
+	VirtualizationType  string                       `xml:"virtualizationType,omitempty"`
+	Hypervisor          string                       `xml:"hypervisor,omitempty"`
+	PlatformDetails     string                       `xml:"platformDetails,omitempty"`
+	BlockDeviceMappings []imageBlockDeviceMappingXML `xml:"blockDeviceMapping>item,omitempty"`
+	Tags                []tagItem                    `xml:"tagSet>item,omitempty"`
 }
 
 type createImageResponseXML struct {
@@ -74,9 +90,15 @@ func (h *Handler) deregisterImage(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // per-resource describe pattern; siblings in vpc/subnet/sg/igw/route_table/volume/keypair/snapshot
+//nolint:dupl // per-resource describe+filter pattern; siblings in volume/snapshot
 func (h *Handler) describeImages(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "ImageId")
+	filters := awsquery.Filters(r.Form)
+
+	if err := validateImageFilters(filters); err != nil {
+		writeImageErr(w, err)
+		return
+	}
 
 	imgs, err := h.compute.DescribeImages(r.Context(), ids)
 	if err != nil {
@@ -85,8 +107,11 @@ func (h *Handler) describeImages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	out := make([]imageXML, 0, len(imgs))
+
 	for i := range imgs {
-		out = append(out, toImageXML(&imgs[i]))
+		if imageMatchesFilters(&imgs[i], filters) {
+			out = append(out, toImageXML(&imgs[i]))
+		}
 	}
 
 	awsquery.WriteXMLResponse(w, describeImagesResponseXML{
@@ -96,21 +121,143 @@ func (h *Handler) describeImages(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func validateImageFilters(filters []awsquery.Filter) error {
+	for _, f := range filters {
+		if isStorageTagFilter(f.Name) {
+			continue
+		}
+
+		switch f.Name {
+		case filterImageID, filterName, filterState, filterOwnerID, filterArchitecture,
+			filterRootDeviceType, filterVirtualizationType, filterHypervisor, filterImageType:
+		default:
+			return newInvalidParameterErr("The filter '" + f.Name + "' is invalid")
+		}
+	}
+
+	return nil
+}
+
+func imageMatchesFilters(img *computedriver.ImageInfo, filters []awsquery.Filter) bool {
+	for _, f := range filters {
+		if !imageMatchesFilter(img, f) {
+			return false
+		}
+	}
+
+	return true
+}
+
+//nolint:gocyclo // flat field dispatch; one case per supported DescribeImages filter
+func imageMatchesFilter(img *computedriver.ImageInfo, f awsquery.Filter) bool {
+	if matched, isTag := matchStorageTagFilter(img.Tags, f); isTag {
+		return matched
+	}
+
+	switch f.Name {
+	case filterImageID:
+		return containsString(f.Values, img.ID)
+	case filterName:
+		return containsString(f.Values, img.Name)
+	case filterState:
+		return containsString(f.Values, nonEmpty(img.State, stateAvailable))
+	case filterOwnerID:
+		return containsString(f.Values, img.OwnerID)
+	case filterArchitecture:
+		return containsString(f.Values, nonEmpty(img.Architecture, "x86_64"))
+	case filterRootDeviceType:
+		return containsString(f.Values, img.RootDeviceType)
+	case filterVirtualizationType:
+		return containsString(f.Values, img.VirtualizationType)
+	case filterHypervisor:
+		return containsString(f.Values, img.Hypervisor)
+	case filterImageType:
+		return containsString(f.Values, img.ImageType)
+	default:
+		return false
+	}
+}
+
+type describeImageAttributeResponseXML struct {
+	XMLName   xml.Name  `xml:"DescribeImageAttributeResponse"`
+	Xmlns     string    `xml:"xmlns,attr"`
+	RequestID string    `xml:"requestId"`
+	ImageID   string    `xml:"imageId"`
+	Desc      *valueXML `xml:"description,omitempty"`
+	BootMode  *valueXML `xml:"bootMode,omitempty"`
+}
+
+type valueXML struct {
+	Value string `xml:"value"`
+}
+
+// describeImageAttribute returns a single AMI attribute. Only the attributes
+// the emulator models (description, bootMode) carry a value; others return the
+// image id with an empty attribute, matching the SDK's single-attribute shape.
+func (h *Handler) describeImageAttribute(w http.ResponseWriter, r *http.Request) {
+	id := r.Form.Get("ImageId")
+
+	imgs, err := h.compute.DescribeImages(r.Context(), []string{id})
+	if err != nil {
+		writeImageErr(w, err)
+		return
+	}
+
+	resp := describeImageAttributeResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		ImageID:   id,
+	}
+
+	switch r.Form.Get("Attribute") {
+	case filterDescription:
+		resp.Desc = &valueXML{Value: imgs[0].Description}
+	case "bootMode":
+		resp.BootMode = &valueXML{Value: ""}
+	}
+
+	awsquery.WriteXMLResponse(w, resp)
+}
+
 func toImageXML(img *computedriver.ImageInfo) imageXML {
 	state := img.State
 	if state == "" {
 		state = stateAvailable
 	}
 
+	arch := img.Architecture
+	if arch == "" {
+		arch = "x86_64"
+	}
+
+	bdms := make([]imageBlockDeviceMappingXML, 0, len(img.BlockDeviceMappings))
+	for _, b := range img.BlockDeviceMappings {
+		bdms = append(bdms, imageBlockDeviceMappingXML{
+			DeviceName:          b.DeviceName,
+			SnapshotID:          b.SnapshotID,
+			VolumeSize:          b.VolumeSize,
+			VolumeType:          b.VolumeType,
+			DeleteOnTermination: b.DeleteOnTermination,
+		})
+	}
+
 	return imageXML{
-		ImageID:      img.ID,
-		State:        state,
-		Name:         img.Name,
-		Description:  img.Description,
-		CreationDate: img.CreatedAt,
-		Architecture: "x86_64",
-		Public:       false,
-		Tags:         toTagItems(img.Tags),
+		ImageID:             img.ID,
+		State:               state,
+		OwnerID:             img.OwnerID,
+		Name:                img.Name,
+		Description:         img.Description,
+		CreationDate:        img.CreatedAt,
+		Architecture:        arch,
+		ImageType:           img.ImageType,
+		Public:              false,
+		RootDeviceType:      img.RootDeviceType,
+		RootDeviceName:      img.RootDeviceName,
+		VirtualizationType:  img.VirtualizationType,
+		Hypervisor:          img.Hypervisor,
+		PlatformDetails:     img.PlatformDetails,
+		BlockDeviceMappings: bdms,
+		Tags:                toTagItems(img.Tags),
 	}
 }
 

--- a/server/aws/ec2/image_test.go
+++ b/server/aws/ec2/image_test.go
@@ -11,7 +11,7 @@ import (
 	smithy "github.com/aws/smithy-go"
 )
 
-func runOneInstance(t *testing.T, ctx context.Context, client *ec2.Client) string {
+func launchInstanceForImage(t *testing.T, ctx context.Context, client *ec2.Client) string {
 	t.Helper()
 
 	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
@@ -33,7 +33,7 @@ func runOneInstance(t *testing.T, ctx context.Context, client *ec2.Client) strin
 func TestCreateImagePopulatesRootDeviceAndMapping(t *testing.T) {
 	ctx := context.Background()
 	client := newEC2(t)
-	instID := runOneInstance(t, ctx, client)
+	instID := launchInstanceForImage(t, ctx, client)
 
 	img, err := client.CreateImage(ctx, &ec2.CreateImageInput{
 		InstanceId: aws.String(instID),
@@ -73,7 +73,7 @@ func TestCreateImagePopulatesRootDeviceAndMapping(t *testing.T) {
 func TestDescribeImagesReportsMetadata(t *testing.T) {
 	ctx := context.Background()
 	client := newEC2(t)
-	instID := runOneInstance(t, ctx, client)
+	instID := launchInstanceForImage(t, ctx, client)
 
 	img, err := client.CreateImage(ctx, &ec2.CreateImageInput{
 		InstanceId: aws.String(instID),
@@ -113,7 +113,7 @@ func TestDescribeImagesReportsMetadata(t *testing.T) {
 func TestDescribeImagesOwnerFilter(t *testing.T) {
 	ctx := context.Background()
 	client := newEC2(t)
-	instID := runOneInstance(t, ctx, client)
+	instID := launchInstanceForImage(t, ctx, client)
 
 	img, err := client.CreateImage(ctx, &ec2.CreateImageInput{
 		InstanceId: aws.String(instID),
@@ -176,7 +176,7 @@ func TestDescribeImagesUnknownIDErrors(t *testing.T) {
 func TestDescribeImageAttribute(t *testing.T) {
 	ctx := context.Background()
 	client := newEC2(t)
-	instID := runOneInstance(t, ctx, client)
+	instID := launchInstanceForImage(t, ctx, client)
 
 	img, err := client.CreateImage(ctx, &ec2.CreateImageInput{
 		InstanceId:  aws.String(instID),

--- a/server/aws/ec2/image_test.go
+++ b/server/aws/ec2/image_test.go
@@ -1,0 +1,200 @@
+package ec2_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+func runOneInstance(t *testing.T, ctx context.Context, client *ec2.Client) string {
+	t.Helper()
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-base"),
+		InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	return aws.ToString(run.Instances[0].InstanceId)
+}
+
+// TestCreateImagePopulatesRootDeviceAndMapping pins that an AMI created from a
+// running instance carries a root device and a block device mapping that
+// references the backing snapshot — both were empty before.
+func TestCreateImagePopulatesRootDeviceAndMapping(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+	instID := runOneInstance(t, ctx, client)
+
+	img, err := client.CreateImage(ctx, &ec2.CreateImageInput{
+		InstanceId: aws.String(instID),
+		Name:       aws.String("backup-ami"),
+	})
+	if err != nil {
+		t.Fatalf("CreateImage: %v", err)
+	}
+
+	desc, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{
+		ImageIds: []string{aws.ToString(img.ImageId)},
+	})
+	if err != nil {
+		t.Fatalf("DescribeImages: %v", err)
+	}
+	if len(desc.Images) != 1 {
+		t.Fatalf("DescribeImages = %d, want 1", len(desc.Images))
+	}
+
+	im := desc.Images[0]
+	if aws.ToString(im.RootDeviceName) != "/dev/sda1" {
+		t.Errorf("RootDeviceName = %q, want /dev/sda1", aws.ToString(im.RootDeviceName))
+	}
+	if im.RootDeviceType != ec2types.DeviceTypeEbs {
+		t.Errorf("RootDeviceType = %q, want ebs", im.RootDeviceType)
+	}
+	if len(im.BlockDeviceMappings) != 1 {
+		t.Fatalf("BlockDeviceMappings = %d, want 1", len(im.BlockDeviceMappings))
+	}
+	if im.BlockDeviceMappings[0].Ebs == nil || aws.ToString(im.BlockDeviceMappings[0].Ebs.SnapshotId) == "" {
+		t.Errorf("block device mapping missing backing snapshot: %+v", im.BlockDeviceMappings[0])
+	}
+}
+
+// TestDescribeImagesReportsMetadata pins the metadata fields that were empty or
+// hardcoded: OwnerId, VirtualizationType, Hypervisor, ImageType, PlatformDetails.
+func TestDescribeImagesReportsMetadata(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+	instID := runOneInstance(t, ctx, client)
+
+	img, err := client.CreateImage(ctx, &ec2.CreateImageInput{
+		InstanceId: aws.String(instID),
+		Name:       aws.String("meta-ami"),
+	})
+	if err != nil {
+		t.Fatalf("CreateImage: %v", err)
+	}
+
+	desc, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{
+		ImageIds: []string{aws.ToString(img.ImageId)},
+	})
+	if err != nil {
+		t.Fatalf("DescribeImages: %v", err)
+	}
+
+	im := desc.Images[0]
+	if aws.ToString(im.OwnerId) == "" {
+		t.Errorf("OwnerId is empty")
+	}
+	if im.VirtualizationType != ec2types.VirtualizationTypeHvm {
+		t.Errorf("VirtualizationType = %q, want hvm", im.VirtualizationType)
+	}
+	if im.Hypervisor != ec2types.HypervisorTypeXen {
+		t.Errorf("Hypervisor = %q, want xen", im.Hypervisor)
+	}
+	if im.ImageType != ec2types.ImageTypeValuesMachine {
+		t.Errorf("ImageType = %q, want machine", im.ImageType)
+	}
+	if aws.ToString(im.PlatformDetails) == "" {
+		t.Errorf("PlatformDetails is empty")
+	}
+}
+
+// TestDescribeImagesOwnerFilter pins that the owner-id filter matches on the
+// image's owner rather than being ignored.
+func TestDescribeImagesOwnerFilter(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+	instID := runOneInstance(t, ctx, client)
+
+	img, err := client.CreateImage(ctx, &ec2.CreateImageInput{
+		InstanceId: aws.String(instID),
+		Name:       aws.String("owned-ami"),
+	})
+	if err != nil {
+		t.Fatalf("CreateImage: %v", err)
+	}
+
+	desc, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{
+		ImageIds: []string{aws.ToString(img.ImageId)},
+	})
+	if err != nil {
+		t.Fatalf("DescribeImages: %v", err)
+	}
+	owner := aws.ToString(desc.Images[0].OwnerId)
+
+	match, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("owner-id"), Values: []string{owner}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeImages(owner match): %v", err)
+	}
+	if len(match.Images) != 1 {
+		t.Fatalf("owner-id match returned %d images, want 1", len(match.Images))
+	}
+
+	none, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("owner-id"), Values: []string{"999999999999"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeImages(owner nomatch): %v", err)
+	}
+	if len(none.Images) != 0 {
+		t.Fatalf("owner-id nomatch returned %d images, want 0", len(none.Images))
+	}
+}
+
+// TestDescribeImagesUnknownIDErrors pins that an explicit unknown AMI id
+// returns InvalidAMIID.NotFound rather than an empty success.
+func TestDescribeImagesUnknownIDErrors(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	_, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{
+		ImageIds: []string{"ami-000000000000"},
+	})
+	if err == nil {
+		t.Fatalf("DescribeImages(unknown) returned no error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidAMIID.NotFound" {
+		t.Fatalf("error code = %v, want InvalidAMIID.NotFound", err)
+	}
+}
+
+// TestDescribeImageAttribute pins that the previously-undispatched
+// DescribeImageAttribute action returns the AMI's description attribute.
+func TestDescribeImageAttribute(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+	instID := runOneInstance(t, ctx, client)
+
+	img, err := client.CreateImage(ctx, &ec2.CreateImageInput{
+		InstanceId:  aws.String(instID),
+		Name:        aws.String("attr-ami"),
+		Description: aws.String("golden image"),
+	})
+	if err != nil {
+		t.Fatalf("CreateImage: %v", err)
+	}
+
+	out, err := client.DescribeImageAttribute(ctx, &ec2.DescribeImageAttributeInput{
+		ImageId:   img.ImageId,
+		Attribute: ec2types.ImageAttributeNameDescription,
+	})
+	if err != nil {
+		t.Fatalf("DescribeImageAttribute: %v", err)
+	}
+	if out.Description == nil || aws.ToString(out.Description.Value) != "golden image" {
+		t.Errorf("description attribute = %+v, want golden image", out.Description)
+	}
+}

--- a/server/aws/ec2/instance_attribute_test.go
+++ b/server/aws/ec2/instance_attribute_test.go
@@ -1,0 +1,150 @@
+package ec2_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newEC2Client wires a full in-process AWS server and returns a real
+// aws-sdk-go-v2 EC2 client pointed at it.
+func newEC2Client(t *testing.T) *ec2.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	ts := httptest.NewServer(awsserver.New(awsserver.DriversFrom(cloud)))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	cfg.BaseEndpoint = aws.String(ts.URL)
+
+	return ec2.NewFromConfig(cfg)
+}
+
+func runOneInstance(t *testing.T, c *ec2.Client) string {
+	t.Helper()
+
+	run, err := c.RunInstances(context.Background(), &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-123"),
+		InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	return aws.ToString(run.Instances[0].InstanceId)
+}
+
+// TestModifyDisableApiTerminationTakesEffect pins that
+// ModifyInstanceAttribute(DisableApiTermination=true) is honored: it is
+// verifiable via DescribeInstanceAttribute and blocks TerminateInstances with
+// OperationNotPermitted (previously accepted-and-discarded — a false success
+// dangerous for IaC termination protection).
+func TestModifyDisableApiTerminationTakesEffect(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+	id := runOneInstance(t, c)
+
+	if _, err := c.ModifyInstanceAttribute(ctx, &ec2.ModifyInstanceAttributeInput{
+		InstanceId:            aws.String(id),
+		DisableApiTermination: &ec2types.AttributeBooleanValue{Value: aws.Bool(true)},
+	}); err != nil {
+		t.Fatalf("ModifyInstanceAttribute: %v", err)
+	}
+
+	attr, err := c.DescribeInstanceAttribute(ctx, &ec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String(id),
+		Attribute:  ec2types.InstanceAttributeNameDisableApiTermination,
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstanceAttribute: %v", err)
+	}
+
+	if attr.DisableApiTermination == nil || !aws.ToBool(attr.DisableApiTermination.Value) {
+		t.Fatalf("disableApiTermination not persisted: %+v", attr.DisableApiTermination)
+	}
+
+	_, err = c.TerminateInstances(ctx, &ec2.TerminateInstancesInput{InstanceIds: []string{id}})
+	if err == nil {
+		t.Fatal("TerminateInstances succeeded despite termination protection")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "OperationNotPermitted" {
+		t.Fatalf("want OperationNotPermitted, got %v", err)
+	}
+
+	// Clearing protection lets the terminate through.
+	if _, err := c.ModifyInstanceAttribute(ctx, &ec2.ModifyInstanceAttributeInput{
+		InstanceId:            aws.String(id),
+		DisableApiTermination: &ec2types.AttributeBooleanValue{Value: aws.Bool(false)},
+	}); err != nil {
+		t.Fatalf("ModifyInstanceAttribute clear: %v", err)
+	}
+
+	if _, err := c.TerminateInstances(ctx,
+		&ec2.TerminateInstancesInput{InstanceIds: []string{id}}); err != nil {
+		t.Fatalf("TerminateInstances after clearing protection: %v", err)
+	}
+}
+
+// TestModifySourceDestCheckRoundTrips pins that SourceDestCheck defaults to true
+// and a ModifyInstanceAttribute(SourceDestCheck=false) is honored and readable
+// back via DescribeInstanceAttribute.
+func TestModifySourceDestCheckRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+	id := runOneInstance(t, c)
+
+	got, err := c.DescribeInstanceAttribute(ctx, &ec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String(id),
+		Attribute:  ec2types.InstanceAttributeNameSourceDestCheck,
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstanceAttribute: %v", err)
+	}
+
+	if got.SourceDestCheck == nil || !aws.ToBool(got.SourceDestCheck.Value) {
+		t.Fatalf("sourceDestCheck default should be true, got %+v", got.SourceDestCheck)
+	}
+
+	if _, err := c.ModifyInstanceAttribute(ctx, &ec2.ModifyInstanceAttributeInput{
+		InstanceId:      aws.String(id),
+		SourceDestCheck: &ec2types.AttributeBooleanValue{Value: aws.Bool(false)},
+	}); err != nil {
+		t.Fatalf("ModifyInstanceAttribute: %v", err)
+	}
+
+	got, err = c.DescribeInstanceAttribute(ctx, &ec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String(id),
+		Attribute:  ec2types.InstanceAttributeNameSourceDestCheck,
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstanceAttribute: %v", err)
+	}
+
+	if got.SourceDestCheck == nil || aws.ToBool(got.SourceDestCheck.Value) {
+		t.Fatalf("sourceDestCheck should be false after modify, got %+v", got.SourceDestCheck)
+	}
+}

--- a/server/aws/ec2/instance_lifecycle_test.go
+++ b/server/aws/ec2/instance_lifecycle_test.go
@@ -1,0 +1,79 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestLifecyclePreviousStateDerived pins that Stop/Start report the real prior
+// state in previousState rather than a hardcoded value: stopping a running
+// instance reports previousState=running, and starting the now-stopped instance
+// reports previousState=stopped.
+func TestLifecyclePreviousStateDerived(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+	id := runOneInstance(t, c)
+
+	stop, err := c.StopInstances(ctx, &ec2.StopInstancesInput{InstanceIds: []string{id}})
+	if err != nil {
+		t.Fatalf("StopInstances: %v", err)
+	}
+
+	if len(stop.StoppingInstances) != 1 {
+		t.Fatalf("StoppingInstances len=%d", len(stop.StoppingInstances))
+	}
+
+	if got := stop.StoppingInstances[0].PreviousState.Name; got != ec2types.InstanceStateNameRunning {
+		t.Fatalf("stop previousState = %q, want running", got)
+	}
+
+	if got := stop.StoppingInstances[0].CurrentState.Name; got != ec2types.InstanceStateNameStopping {
+		t.Fatalf("stop currentState = %q, want stopping", got)
+	}
+
+	// Stopping the already-stopped instance is idempotent; the derived
+	// previousState must be the actual prior state (stopped), not the old
+	// hardcoded "running".
+	stop2, err := c.StopInstances(ctx, &ec2.StopInstancesInput{InstanceIds: []string{id}})
+	if err != nil {
+		t.Fatalf("StopInstances (idempotent): %v", err)
+	}
+
+	if got := stop2.StoppingInstances[0].PreviousState.Name; got != ec2types.InstanceStateNameStopped {
+		t.Fatalf("idempotent stop previousState = %q, want stopped", got)
+	}
+
+	start, err := c.StartInstances(ctx, &ec2.StartInstancesInput{InstanceIds: []string{id}})
+	if err != nil {
+		t.Fatalf("StartInstances: %v", err)
+	}
+
+	if got := start.StartingInstances[0].PreviousState.Name; got != ec2types.InstanceStateNameStopped {
+		t.Fatalf("start previousState = %q, want stopped", got)
+	}
+}
+
+// TestTerminatePreviousStateDerived pins that TerminateInstances reports the
+// real prior state (stopped, here) in previousState rather than a hardcoded
+// "running".
+func TestTerminatePreviousStateDerived(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+	id := runOneInstance(t, c)
+
+	if _, err := c.StopInstances(ctx, &ec2.StopInstancesInput{InstanceIds: []string{id}}); err != nil {
+		t.Fatalf("StopInstances: %v", err)
+	}
+
+	term, err := c.TerminateInstances(ctx, &ec2.TerminateInstancesInput{InstanceIds: []string{id}})
+	if err != nil {
+		t.Fatalf("TerminateInstances: %v", err)
+	}
+
+	if got := term.TerminatingInstances[0].PreviousState.Name; got != ec2types.InstanceStateNameStopped {
+		t.Fatalf("terminate previousState = %q, want stopped", got)
+	}
+}

--- a/server/aws/ec2/instance_status.go
+++ b/server/aws/ec2/instance_status.go
@@ -56,8 +56,16 @@ func (h *Handler) monitorInstances(w http.ResponseWriter, r *http.Request, state
 	})
 }
 
-type statusDetailXML struct {
+// statusCheckDetailXML is one <details><item> entry (e.g. the reachability
+// check) inside a system/instance status summary.
+type statusCheckDetailXML struct {
+	Name   string `xml:"name"`
 	Status string `xml:"status"`
+}
+
+type statusDetailXML struct {
+	Status  string                 `xml:"status"`
+	Details []statusCheckDetailXML `xml:"details>item,omitempty"`
 }
 
 type instanceStatusItemXML struct {
@@ -105,11 +113,18 @@ func (h *Handler) describeInstanceStatus(w http.ResponseWriter, r *http.Request)
 }
 
 func statusItem(inst *computedriver.Instance) instanceStatusItemXML {
-	// Checks are "ok" only once the instance is running; otherwise
+	// Checks are "ok"/"passed" only once the instance is running; otherwise
 	// "not-applicable", matching real EC2's status-check semantics.
-	check := "not-applicable"
+	notApplicable := "not-applicable"
+	summary, reachability := notApplicable, notApplicable
+
 	if inst.State == stateRunning {
-		check = "ok"
+		summary, reachability = "ok", "passed"
+	}
+
+	detail := statusDetailXML{
+		Status:  summary,
+		Details: []statusCheckDetailXML{{Name: "reachability", Status: reachability}},
 	}
 
 	az := ""
@@ -121,7 +136,7 @@ func statusItem(inst *computedriver.Instance) instanceStatusItemXML {
 		InstanceID:     inst.ID,
 		AvailZone:      az,
 		InstanceState:  instanceState{Code: stateCode(inst.State), Name: inst.State},
-		SystemStatus:   statusDetailXML{Status: check},
-		InstanceStatus: statusDetailXML{Status: check},
+		SystemStatus:   detail,
+		InstanceStatus: detail,
 	}
 }

--- a/server/aws/ec2/instance_status_test.go
+++ b/server/aws/ec2/instance_status_test.go
@@ -1,0 +1,55 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestDescribeInstanceStatusReachabilityDetail pins that a running instance's
+// system/instance status summaries carry the reachability status-check detail
+// (previously the <details> children were omitted, so SDK consumers reading
+// the reachability check saw nothing).
+func TestDescribeInstanceStatusReachabilityDetail(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+	id := runOneInstance(t, c)
+
+	out, err := c.DescribeInstanceStatus(ctx, &ec2.DescribeInstanceStatusInput{
+		InstanceIds: []string{id},
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstanceStatus: %v", err)
+	}
+
+	if len(out.InstanceStatuses) != 1 {
+		t.Fatalf("InstanceStatuses len=%d, want 1", len(out.InstanceStatuses))
+	}
+
+	st := out.InstanceStatuses[0]
+	assertReachabilityPassed(t, "systemStatus", st.SystemStatus)
+	assertReachabilityPassed(t, "instanceStatus", st.InstanceStatus)
+}
+
+func assertReachabilityPassed(t *testing.T, label string, s *ec2types.InstanceStatusSummary) {
+	t.Helper()
+
+	if s == nil {
+		t.Fatalf("%s summary nil", label)
+	}
+
+	if len(s.Details) == 0 {
+		t.Fatalf("%s has no status-check details", label)
+	}
+
+	d := s.Details[0]
+	if d.Name != ec2types.StatusNameReachability {
+		t.Fatalf("%s detail name = %q, want reachability", label, d.Name)
+	}
+
+	if d.Status != ec2types.StatusTypePassed {
+		t.Fatalf("%s reachability status = %q, want passed", label, d.Status)
+	}
+}

--- a/server/aws/ec2/internet_gateway.go
+++ b/server/aws/ec2/internet_gateway.go
@@ -177,10 +177,23 @@ func igwFilterMatch(igw *netdriver.InternetGateway, f awsquery.Filter) (matched,
 	case "attachment.vpc-id":
 		return igw.VpcID != "" && containsString(f.Values, igw.VpcID), true
 	case "attachment.state":
-		return igw.VpcID != "" && containsString(f.Values, nonEmpty(igw.State, stateAttached)), true
+		return igw.VpcID != "" && containsString(f.Values, igwAttachmentState(igw)), true
 	default:
 		return tagFilterMatch(f.Name, f.Values, igw.Tags)
 	}
+}
+
+// igwAttachmentState maps the driver's internal attachment bookkeeping to the
+// AWS wire value. An attached internet gateway reports "available" (not the
+// internal "attached"); a detached one reports "detached". Both the filter and
+// the describe output go through this so filtering by attachment.state=available
+// matches what describe returns.
+func igwAttachmentState(igw *netdriver.InternetGateway) string {
+	if igw.State == stateDetached {
+		return stateDetached
+	}
+
+	return stateAvailable
 }
 
 func toInternetGatewayXML(igw *netdriver.InternetGateway) internetGatewayXML {
@@ -191,15 +204,7 @@ func toInternetGatewayXML(igw *netdriver.InternetGateway) internetGatewayXML {
 	}
 
 	if igw.VpcID != "" {
-		// An internet-gateway attachment reports state "available" once attached
-		// to a VPC (the driver's internal "attached"/"detached" bookkeeping is
-		// not the wire value). See the EC2 InternetGatewayAttachment reference.
-		state := stateAvailable
-		if igw.State == stateDetached {
-			state = stateDetached
-		}
-
-		xi.Attachments = []igwAttachmentXML{{VpcID: igw.VpcID, State: state}}
+		xi.Attachments = []igwAttachmentXML{{VpcID: igw.VpcID, State: igwAttachmentState(igw)}}
 	}
 
 	return xi

--- a/server/aws/ec2/internet_gateway.go
+++ b/server/aws/ec2/internet_gateway.go
@@ -8,9 +8,12 @@ import (
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
-// stateAttached is the attachment state shared by internet gateways and
-// network interfaces.
-const stateAttached = "attached"
+// stateAttached is the network-interface attachment state. stateDetached is the
+// driver's internal "not attached to a VPC" marker for internet gateways.
+const (
+	stateAttached = "attached"
+	stateDetached = "detached"
+)
 
 type igwAttachmentXML struct {
 	VpcID string `xml:"vpcId"`
@@ -188,9 +191,12 @@ func toInternetGatewayXML(igw *netdriver.InternetGateway) internetGatewayXML {
 	}
 
 	if igw.VpcID != "" {
-		state := igw.State
-		if state == "" {
-			state = stateAttached
+		// An internet-gateway attachment reports state "available" once attached
+		// to a VPC (the driver's internal "attached"/"detached" bookkeeping is
+		// not the wire value). See the EC2 InternetGatewayAttachment reference.
+		state := stateAvailable
+		if igw.State == stateDetached {
+			state = stateDetached
 		}
 
 		xi.Attachments = []igwAttachmentXML{{VpcID: igw.VpcID, State: state}}

--- a/server/aws/ec2/internet_gateway.go
+++ b/server/aws/ec2/internet_gateway.go
@@ -19,6 +19,7 @@ type igwAttachmentXML struct {
 
 type internetGatewayXML struct {
 	InternetGatewayID string             `xml:"internetGatewayId"`
+	OwnerID           string             `xml:"ownerId"`
 	Attachments       []igwAttachmentXML `xml:"attachmentSet>item,omitempty"`
 	Tags              []tagItem          `xml:"tagSet>item,omitempty"`
 }
@@ -117,7 +118,7 @@ func (h *Handler) deleteInternetGateway(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
-//nolint:dupl // per-resource describe pattern; siblings in vpc/subnet/sg/route_table
+//nolint:dupl // per-resource describe+filter pattern; sibling in vpc
 func (h *Handler) describeInternetGateways(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "InternetGatewayId")
 
@@ -127,21 +128,62 @@ func (h *Handler) describeInternetGateways(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	out := make([]internetGatewayXML, 0, len(igws))
-	for i := range igws {
-		out = append(out, toInternetGatewayXML(&igws[i]))
+	filters := awsquery.Filters(r.Form)
+	if err := validateIGWFilters(filters); err != nil {
+		writeIGWErr(w, err)
+		return
 	}
 
 	awsquery.WriteXMLResponse(w, describeInternetGatewaysResponseXML{
 		Xmlns:              awsquery.Namespace,
 		RequestID:          awsquery.RequestID,
-		InternetGatewaySet: out,
+		InternetGatewaySet: filterXML(igws, filters, igwMatchesFilters, toInternetGatewayXML),
 	})
+}
+
+// validateIGWFilters rejects filter names DescribeInternetGateways does not
+// model, matching the sibling Describe handlers.
+func validateIGWFilters(filters []awsquery.Filter) error {
+	var probe netdriver.InternetGateway
+
+	for _, f := range filters {
+		if _, known := igwFilterMatch(&probe, f); !known {
+			return newInvalidParameterErr("The filter '" + f.Name + "' is invalid")
+		}
+	}
+
+	return nil
+}
+
+func igwMatchesFilters(igw *netdriver.InternetGateway, filters []awsquery.Filter) bool {
+	for _, f := range filters {
+		if matched, _ := igwFilterMatch(igw, f); !matched {
+			return false
+		}
+	}
+
+	return true
+}
+
+// igwFilterMatch reports whether igw satisfies filter f and whether f is a
+// filter DescribeInternetGateways recognizes.
+func igwFilterMatch(igw *netdriver.InternetGateway, f awsquery.Filter) (matched, known bool) {
+	switch f.Name {
+	case "internet-gateway-id":
+		return containsString(f.Values, igw.ID), true
+	case "attachment.vpc-id":
+		return igw.VpcID != "" && containsString(f.Values, igw.VpcID), true
+	case "attachment.state":
+		return igw.VpcID != "" && containsString(f.Values, nonEmpty(igw.State, stateAttached)), true
+	default:
+		return tagFilterMatch(f.Name, f.Values, igw.Tags)
+	}
 }
 
 func toInternetGatewayXML(igw *netdriver.InternetGateway) internetGatewayXML {
 	xi := internetGatewayXML{
 		InternetGatewayID: igw.ID,
+		OwnerID:           ownerID,
 		Tags:              toTagItems(igw.Tags),
 	}
 

--- a/server/aws/ec2/internet_gateway_test.go
+++ b/server/aws/ec2/internet_gateway_test.go
@@ -1,0 +1,63 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+// TestInternetGatewayAttachmentAvailable pins that an attached internet gateway
+// reports attachment state "available" (not "attached"). Terraform's
+// aws_internet_gateway_attachment waiter blocks until it sees "available", so
+// reporting "attached" hangs the attach until it times out.
+func TestInternetGatewayAttachmentAvailable(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	vpcID := aws.ToString(vpc.Vpc.VpcId)
+
+	igw, err := c.CreateInternetGateway(ctx, &ec2.CreateInternetGatewayInput{})
+	if err != nil {
+		t.Fatalf("CreateInternetGateway: %v", err)
+	}
+
+	igwID := aws.ToString(igw.InternetGateway.InternetGatewayId)
+
+	if _, err := c.AttachInternetGateway(ctx, &ec2.AttachInternetGatewayInput{
+		InternetGatewayId: aws.String(igwID),
+		VpcId:             aws.String(vpcID),
+	}); err != nil {
+		t.Fatalf("AttachInternetGateway: %v", err)
+	}
+
+	desc, err := c.DescribeInternetGateways(ctx, &ec2.DescribeInternetGatewaysInput{
+		InternetGatewayIds: []string{igwID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeInternetGateways: %v", err)
+	}
+
+	if len(desc.InternetGateways) != 1 {
+		t.Fatalf("DescribeInternetGateways = %d, want 1", len(desc.InternetGateways))
+	}
+
+	atts := desc.InternetGateways[0].Attachments
+	if len(atts) != 1 {
+		t.Fatalf("attachments = %d, want 1", len(atts))
+	}
+
+	if got := string(atts[0].State); got != "available" {
+		t.Errorf("attachment state = %q, want available", got)
+	}
+
+	if aws.ToString(atts[0].VpcId) != vpcID {
+		t.Errorf("attachment vpcId = %q, want %q", aws.ToString(atts[0].VpcId), vpcID)
+	}
+}

--- a/server/aws/ec2/internet_gateway_test.go
+++ b/server/aws/ec2/internet_gateway_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
 // TestInternetGatewayAttachmentAvailable pins that an attached internet gateway
@@ -59,5 +60,44 @@ func TestInternetGatewayAttachmentAvailable(t *testing.T) {
 
 	if aws.ToString(atts[0].VpcId) != vpcID {
 		t.Errorf("attachment vpcId = %q, want %q", aws.ToString(atts[0].VpcId), vpcID)
+	}
+}
+
+// TestInternetGatewayAttachmentStateFilter pins that filtering by the AWS-documented
+// attachment.state value ("available") matches an attached gateway. The filter must
+// use the same wire value the describe output reports, not the internal "attached".
+func TestInternetGatewayAttachmentStateFilter(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	vpcID := aws.ToString(vpc.Vpc.VpcId)
+
+	igw, err := c.CreateInternetGateway(ctx, &ec2.CreateInternetGatewayInput{})
+	if err != nil {
+		t.Fatalf("CreateInternetGateway: %v", err)
+	}
+
+	igwID := aws.ToString(igw.InternetGateway.InternetGatewayId)
+
+	if _, err := c.AttachInternetGateway(ctx, &ec2.AttachInternetGatewayInput{
+		InternetGatewayId: aws.String(igwID), VpcId: aws.String(vpcID),
+	}); err != nil {
+		t.Fatalf("AttachInternetGateway: %v", err)
+	}
+
+	out, err := c.DescribeInternetGateways(ctx, &ec2.DescribeInternetGatewaysInput{
+		Filters: []ec2types.Filter{{Name: aws.String("attachment.state"), Values: []string{"available"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeInternetGateways: %v", err)
+	}
+
+	if len(out.InternetGateways) != 1 || aws.ToString(out.InternetGateways[0].InternetGatewayId) != igwID {
+		t.Fatalf("attachment.state=available returned %d gateways, want only %s", len(out.InternetGateways), igwID)
 	}
 }

--- a/server/aws/ec2/key_pair.go
+++ b/server/aws/ec2/key_pair.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 )
@@ -15,6 +16,7 @@ type keyPairSummaryXML struct {
 	KeyName        string    `xml:"keyName"`
 	KeyFingerprint string    `xml:"keyFingerprint"`
 	KeyType        string    `xml:"keyType,omitempty"`
+	CreateTime     string    `xml:"createTime,omitempty"`
 	Tags           []tagItem `xml:"tagSet>item,omitempty"`
 }
 
@@ -110,10 +112,19 @@ func toKeyPairSummaryXML(kp *computedriver.KeyPairInfo) keyPairSummaryXML {
 		KeyName:        kp.Name,
 		KeyFingerprint: kp.Fingerprint,
 		KeyType:        kp.KeyType,
+		CreateTime:     kp.CreatedAt,
 		Tags:           toTagItems(kp.Tags),
 	}
 }
 
+// writeKeyPairErr maps a duplicate create to the EC2-specific
+// InvalidKeyPair.Duplicate code (the SDK's DuplicateKeyPair error) rather than
+// the generic ResourceAlreadyExists; other codes use the shared mapping.
 func writeKeyPairErr(w http.ResponseWriter, err error) {
+	if cerrors.IsAlreadyExists(err) {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidKeyPair.Duplicate", err.Error())
+		return
+	}
+
 	writeErrWithNotFound(w, err, "InvalidKeyPair.NotFound", "IncorrectState")
 }

--- a/server/aws/ec2/key_pair_test.go
+++ b/server/aws/ec2/key_pair_test.go
@@ -1,0 +1,109 @@
+package ec2_test
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestCreateKeyPairReturnsKeyIDAndUsablePEM pins that keyPairId is a real
+// key-... id (not an ARN) and that KeyMaterial parses as a PEM RSA private key
+// — the old 20-byte stub broke every SSH-connect flow.
+func TestCreateKeyPairReturnsKeyIDAndUsablePEM(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	kp, err := client.CreateKeyPair(ctx, &ec2.CreateKeyPairInput{
+		KeyName: aws.String("web"),
+	})
+	if err != nil {
+		t.Fatalf("CreateKeyPair: %v", err)
+	}
+
+	if id := aws.ToString(kp.KeyPairId); !strings.HasPrefix(id, "key-") {
+		t.Errorf("KeyPairId = %q, want a key-... id", id)
+	}
+
+	block, _ := pem.Decode([]byte(aws.ToString(kp.KeyMaterial)))
+	if block == nil {
+		t.Fatalf("KeyMaterial is not PEM: %q", aws.ToString(kp.KeyMaterial))
+	}
+	if _, err := x509.ParsePKCS1PrivateKey(block.Bytes); err != nil {
+		t.Fatalf("KeyMaterial is not a usable RSA private key: %v", err)
+	}
+
+	if fp := aws.ToString(kp.KeyFingerprint); !strings.Contains(fp, ":") {
+		t.Errorf("KeyFingerprint = %q, want colon-separated hex", fp)
+	}
+}
+
+// TestCreateDuplicateKeyPairErrors pins the EC2-specific InvalidKeyPair.Duplicate
+// code rather than the generic ResourceAlreadyExists.
+func TestCreateDuplicateKeyPairErrors(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	if _, err := client.CreateKeyPair(ctx, &ec2.CreateKeyPairInput{KeyName: aws.String("dup")}); err != nil {
+		t.Fatalf("first CreateKeyPair: %v", err)
+	}
+
+	_, err := client.CreateKeyPair(ctx, &ec2.CreateKeyPairInput{KeyName: aws.String("dup")})
+	if err == nil {
+		t.Fatalf("duplicate CreateKeyPair returned no error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidKeyPair.Duplicate" {
+		t.Fatalf("error code = %v, want InvalidKeyPair.Duplicate", err)
+	}
+}
+
+// TestDescribeKeyPairsReportsCreateTime pins that DescribeKeyPairs carries a
+// non-nil CreateTime.
+func TestDescribeKeyPairsReportsCreateTime(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	if _, err := client.CreateKeyPair(ctx, &ec2.CreateKeyPairInput{KeyName: aws.String("timed")}); err != nil {
+		t.Fatalf("CreateKeyPair: %v", err)
+	}
+
+	out, err := client.DescribeKeyPairs(ctx, &ec2.DescribeKeyPairsInput{
+		KeyNames: []string{"timed"},
+	})
+	if err != nil {
+		t.Fatalf("DescribeKeyPairs: %v", err)
+	}
+	if len(out.KeyPairs) != 1 {
+		t.Fatalf("DescribeKeyPairs = %d, want 1", len(out.KeyPairs))
+	}
+	if out.KeyPairs[0].CreateTime == nil {
+		t.Errorf("CreateTime is nil")
+	}
+}
+
+// TestDescribeKeyPairsUnknownNameErrors pins that an unknown key name returns
+// InvalidKeyPair.NotFound rather than an empty success.
+func TestDescribeKeyPairsUnknownNameErrors(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	_, err := client.DescribeKeyPairs(ctx, &ec2.DescribeKeyPairsInput{
+		KeyNames: []string{"ghost"},
+	})
+	if err == nil {
+		t.Fatalf("DescribeKeyPairs(unknown) returned no error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidKeyPair.NotFound" {
+		t.Fatalf("error code = %v, want InvalidKeyPair.NotFound", err)
+	}
+}

--- a/server/aws/ec2/managed_prefix_list_test.go
+++ b/server/aws/ec2/managed_prefix_list_test.go
@@ -1,0 +1,91 @@
+package ec2_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestManagedPrefixListArnAndOwner pins that CreateManagedPrefixList returns a
+// prefixListArn and ownerId. Terraform's aws_ec2_managed_prefix_list stores the
+// ARN as its resource arn attribute, and rules that reference the list by ARN
+// need it populated.
+func TestManagedPrefixListArnAndOwner(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	out, err := c.CreateManagedPrefixList(ctx, &ec2.CreateManagedPrefixListInput{
+		PrefixListName: aws.String("corp-nets"),
+		AddressFamily:  aws.String("IPv4"),
+		MaxEntries:     aws.Int32(5),
+		Entries: []ec2types.AddPrefixListEntry{
+			{Cidr: aws.String("10.0.0.0/16"), Description: aws.String("hq")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedPrefixList: %v", err)
+	}
+
+	pl := out.PrefixList
+	arn := aws.ToString(pl.PrefixListArn)
+
+	if !strings.Contains(arn, "prefix-list/"+aws.ToString(pl.PrefixListId)) {
+		t.Errorf("prefixListArn = %q, want it to reference the id", arn)
+	}
+
+	if !strings.HasPrefix(arn, "arn:aws:ec2:us-east-1:") {
+		t.Errorf("prefixListArn = %q, want an ec2 us-east-1 arn", arn)
+	}
+
+	if aws.ToString(pl.OwnerId) == "" {
+		t.Error("ownerId is empty")
+	}
+}
+
+// TestManagedPrefixListVersionCheck pins the optimistic-concurrency guard: a
+// ModifyManagedPrefixList carrying a stale CurrentVersion is rejected, while the
+// matching version succeeds. Terraform sends CurrentVersion on every update, and
+// a skipped check would let concurrent updates clobber each other silently.
+func TestManagedPrefixListVersionCheck(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	create, err := c.CreateManagedPrefixList(ctx, &ec2.CreateManagedPrefixListInput{
+		PrefixListName: aws.String("corp-nets"),
+		AddressFamily:  aws.String("IPv4"),
+		MaxEntries:     aws.Int32(5),
+		Entries: []ec2types.AddPrefixListEntry{
+			{Cidr: aws.String("10.0.0.0/16")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedPrefixList: %v", err)
+	}
+
+	id := create.PrefixList.PrefixListId
+	version := aws.ToInt64(create.PrefixList.Version)
+
+	if _, err := c.ModifyManagedPrefixList(ctx, &ec2.ModifyManagedPrefixListInput{
+		PrefixListId:   id,
+		CurrentVersion: aws.Int64(version + 99),
+		AddEntries: []ec2types.AddPrefixListEntry{
+			{Cidr: aws.String("10.1.0.0/16")},
+		},
+	}); err == nil {
+		t.Fatal("ModifyManagedPrefixList with stale CurrentVersion should fail, got nil error")
+	}
+
+	if _, err := c.ModifyManagedPrefixList(ctx, &ec2.ModifyManagedPrefixListInput{
+		PrefixListId:   id,
+		CurrentVersion: aws.Int64(version),
+		AddEntries: []ec2types.AddPrefixListEntry{
+			{Cidr: aws.String("10.1.0.0/16")},
+		},
+	}); err != nil {
+		t.Fatalf("ModifyManagedPrefixList with matching CurrentVersion: %v", err)
+	}
+}

--- a/server/aws/ec2/nat_gateway.go
+++ b/server/aws/ec2/nat_gateway.go
@@ -8,13 +8,22 @@ import (
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
+type natGatewayAddressXML struct {
+	AllocationID       string `xml:"allocationId,omitempty"`
+	NetworkInterfaceID string `xml:"networkInterfaceId,omitempty"`
+	PrivateIP          string `xml:"privateIp,omitempty"`
+	PublicIP           string `xml:"publicIp,omitempty"`
+}
+
 type natGatewayXML struct {
-	NatGatewayID string    `xml:"natGatewayId"`
-	VpcID        string    `xml:"vpcId"`
-	SubnetID     string    `xml:"subnetId"`
-	State        string    `xml:"state"`
-	CreateTime   string    `xml:"createTime,omitempty"`
-	Tags         []tagItem `xml:"tagSet>item,omitempty"`
+	NatGatewayID     string                 `xml:"natGatewayId"`
+	VpcID            string                 `xml:"vpcId"`
+	SubnetID         string                 `xml:"subnetId"`
+	State            string                 `xml:"state"`
+	ConnectivityType string                 `xml:"connectivityType,omitempty"`
+	CreateTime       string                 `xml:"createTime,omitempty"`
+	Addresses        []natGatewayAddressXML `xml:"natGatewayAddressSet>item,omitempty"`
+	Tags             []tagItem              `xml:"tagSet>item,omitempty"`
 }
 
 type createNatGatewayResponseXML struct {
@@ -39,12 +48,12 @@ type deleteNatGatewayResponseXML struct {
 }
 
 func (h *Handler) createNatGateway(w http.ResponseWriter, r *http.Request) {
-	cfg := netdriver.NATGatewayConfig{
-		SubnetID: r.Form.Get("SubnetId"),
-		Tags:     mergeTagSpecs(awsquery.TagSpecs(r.Form), "natgateway"),
-	}
-
-	info, err := h.vpc.CreateNATGateway(r.Context(), cfg)
+	info, err := h.vpc.CreateNATGateway(r.Context(), netdriver.NATGatewayConfig{
+		SubnetID:         r.Form.Get("SubnetId"),
+		AllocationID:     r.Form.Get("AllocationId"),
+		ConnectivityType: r.Form.Get("ConnectivityType"),
+		Tags:             mergeTagSpecs(awsquery.TagSpecs(r.Form), "natgateway"),
+	})
 	if err != nil {
 		writeNatErr(w, err)
 		return
@@ -101,12 +110,19 @@ func toNatGatewayXML(n *netdriver.NATGateway) natGatewayXML {
 	}
 
 	return natGatewayXML{
-		NatGatewayID: n.ID,
-		VpcID:        n.VPCID,
-		SubnetID:     n.SubnetID,
-		State:        state,
-		CreateTime:   n.CreatedAt,
-		Tags:         toTagItems(n.Tags),
+		NatGatewayID:     n.ID,
+		VpcID:            n.VPCID,
+		SubnetID:         n.SubnetID,
+		State:            state,
+		ConnectivityType: n.ConnectivityType,
+		CreateTime:       n.CreatedAt,
+		Addresses: []natGatewayAddressXML{{
+			AllocationID:       n.AllocationID,
+			NetworkInterfaceID: n.NetworkInterfaceID,
+			PrivateIP:          n.PrivateIP,
+			PublicIP:           n.PublicIP,
+		}},
+		Tags: toTagItems(n.Tags),
 	}
 }
 

--- a/server/aws/ec2/nat_gateway_test.go
+++ b/server/aws/ec2/nat_gateway_test.go
@@ -1,0 +1,160 @@
+package ec2_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newRoutingEdgeEC2 wires a full AWS server and returns an EC2 client pointed at
+// it, for the routing-edge (route table / NAT / peering / ACL / IGW / prefix
+// list) round-trip tests.
+func newRoutingEdgeEC2(t *testing.T) *ec2.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	ts := httptest.NewServer(awsserver.New(awsserver.DriversFrom(cloud)))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	cfg.BaseEndpoint = aws.String(ts.URL)
+
+	return ec2.NewFromConfig(cfg)
+}
+
+// mkVPCSubnet creates a VPC + subnet and returns their ids.
+func mkVPCSubnet(t *testing.T, c *ec2.Client) (vpcID, subnetID string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	vpcID = aws.ToString(vpc.Vpc.VpcId)
+
+	sub, err := c.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId:     aws.String(vpcID),
+		CidrBlock: aws.String("10.0.1.0/24"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSubnet: %v", err)
+	}
+
+	return vpcID, aws.ToString(sub.Subnet.SubnetId)
+}
+
+// TestNatGatewayAddressSetRoundTrip pins that a public NAT gateway reports its
+// address set (allocationId, networkInterfaceId, privateIp, publicIp) and
+// connectivityType, both on create and describe. Terraform's aws_nat_gateway
+// reads network_interface_id and public_ip off this set; without it those
+// attributes come back empty and the resource never converges.
+func TestNatGatewayAddressSetRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	_, subnetID := mkVPCSubnet(t, c)
+
+	created, err := c.CreateNatGateway(ctx, &ec2.CreateNatGatewayInput{
+		SubnetId:     aws.String(subnetID),
+		AllocationId: aws.String("eipalloc-12345678"),
+	})
+	if err != nil {
+		t.Fatalf("CreateNatGateway: %v", err)
+	}
+
+	natID := aws.ToString(created.NatGateway.NatGatewayId)
+	assertNatAddresses(t, "create", created.NatGateway)
+
+	desc, err := c.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+		NatGatewayIds: []string{natID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNatGateways: %v", err)
+	}
+
+	if len(desc.NatGateways) != 1 {
+		t.Fatalf("DescribeNatGateways returned %d, want 1", len(desc.NatGateways))
+	}
+
+	assertNatAddresses(t, "describe", &desc.NatGateways[0])
+}
+
+func assertNatAddresses(t *testing.T, phase string, n *ec2types.NatGateway) {
+	t.Helper()
+
+	if got := string(n.ConnectivityType); got != "public" {
+		t.Errorf("%s: connectivityType = %q, want public", phase, got)
+	}
+
+	if len(n.NatGatewayAddresses) != 1 {
+		t.Fatalf("%s: NatGatewayAddresses = %d, want 1", phase, len(n.NatGatewayAddresses))
+	}
+
+	addr := n.NatGatewayAddresses[0]
+	if aws.ToString(addr.AllocationId) != "eipalloc-12345678" {
+		t.Errorf("%s: allocationId = %q, want eipalloc-12345678", phase, aws.ToString(addr.AllocationId))
+	}
+
+	if aws.ToString(addr.NetworkInterfaceId) == "" {
+		t.Errorf("%s: networkInterfaceId is empty", phase)
+	}
+
+	if aws.ToString(addr.PublicIp) == "" {
+		t.Errorf("%s: publicIp is empty", phase)
+	}
+
+	if aws.ToString(addr.PrivateIp) == "" {
+		t.Errorf("%s: privateIp is empty", phase)
+	}
+}
+
+// TestNatGatewayPrivateConnectivity pins that a private NAT gateway echoes
+// connectivityType=private and carries no public/Elastic IP.
+func TestNatGatewayPrivateConnectivity(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	_, subnetID := mkVPCSubnet(t, c)
+
+	created, err := c.CreateNatGateway(ctx, &ec2.CreateNatGatewayInput{
+		SubnetId:         aws.String(subnetID),
+		ConnectivityType: ec2types.ConnectivityTypePrivate,
+	})
+	if err != nil {
+		t.Fatalf("CreateNatGateway: %v", err)
+	}
+
+	if got := string(created.NatGateway.ConnectivityType); got != "private" {
+		t.Errorf("connectivityType = %q, want private", got)
+	}
+
+	if len(created.NatGateway.NatGatewayAddresses) != 1 {
+		t.Fatalf("NatGatewayAddresses = %d, want 1", len(created.NatGateway.NatGatewayAddresses))
+	}
+
+	if ip := aws.ToString(created.NatGateway.NatGatewayAddresses[0].PublicIp); ip != "" {
+		t.Errorf("private NAT gateway publicIp = %q, want empty", ip)
+	}
+
+	if aws.ToString(created.NatGateway.NatGatewayAddresses[0].PrivateIp) == "" {
+		t.Error("private NAT gateway privateIp is empty")
+	}
+}

--- a/server/aws/ec2/network_acl.go
+++ b/server/aws/ec2/network_acl.go
@@ -64,6 +64,13 @@ type deleteNetworkACLEntryResponseXML struct {
 	Return    bool     `xml:"return"`
 }
 
+type replaceNetworkACLEntryResponseXML struct {
+	XMLName   xml.Name `xml:"ReplaceNetworkAclEntryResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
 func (h *Handler) createNetworkACL(w http.ResponseWriter, r *http.Request) {
 	tags := mergeTagSpecs(awsquery.TagSpecs(r.Form), "network-acl")
 
@@ -137,6 +144,45 @@ func (h *Handler) createNetworkACLEntry(w http.ResponseWriter, r *http.Request) 
 	}
 
 	awsquery.WriteXMLResponse(w, createNetworkACLEntryResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Return:    true,
+	})
+}
+
+// replaceNetworkACLEntry swaps the rule at (RuleNumber, Egress) for the new one
+// the caller supplied. Real EC2 requires the entry to already exist, so the
+// remove step's NotFound is the correct error when it does not. Modeled as
+// remove-then-add because the driver keys rules by number and has no in-place
+// replace.
+func (h *Handler) replaceNetworkACLEntry(w http.ResponseWriter, r *http.Request) {
+	ruleNum, _ := strconv.Atoi(r.Form.Get("RuleNumber"))
+	fromPort, _ := strconv.Atoi(r.Form.Get("PortRange.From"))
+	toPort, _ := strconv.Atoi(r.Form.Get("PortRange.To"))
+	egress := r.Form.Get("Egress") == formTrue
+	aclID := r.Form.Get("NetworkAclId")
+
+	if err := h.vpc.RemoveNetworkACLRule(r.Context(), aclID, ruleNum, egress); err != nil {
+		writeNetworkACLErr(w, err)
+		return
+	}
+
+	rule := &netdriver.NetworkACLRule{
+		RuleNumber: ruleNum,
+		Protocol:   r.Form.Get("Protocol"),
+		Action:     r.Form.Get("RuleAction"),
+		CIDR:       r.Form.Get("CidrBlock"),
+		FromPort:   fromPort,
+		ToPort:     toPort,
+		Egress:     egress,
+	}
+
+	if err := h.vpc.AddNetworkACLRule(r.Context(), aclID, rule); err != nil {
+		writeNetworkACLErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, replaceNetworkACLEntryResponseXML{
 		Xmlns:     awsquery.Namespace,
 		RequestID: awsquery.RequestID,
 		Return:    true,

--- a/server/aws/ec2/network_acl_test.go
+++ b/server/aws/ec2/network_acl_test.go
@@ -1,0 +1,83 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestReplaceNetworkAclEntry pins the previously-undispatched
+// ReplaceNetworkAclEntry action: it swaps the rule at (ruleNumber, egress) in
+// place, so a caller updating an existing entry (Terraform aws_network_acl_rule
+// on update) sees the new CIDR and action rather than an InvalidAction error.
+func TestReplaceNetworkAclEntry(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	acl, err := c.CreateNetworkAcl(ctx, &ec2.CreateNetworkAclInput{VpcId: vpc.Vpc.VpcId})
+	if err != nil {
+		t.Fatalf("CreateNetworkAcl: %v", err)
+	}
+
+	aclID := aws.ToString(acl.NetworkAcl.NetworkAclId)
+
+	if _, err := c.CreateNetworkAclEntry(ctx, &ec2.CreateNetworkAclEntryInput{
+		NetworkAclId: aws.String(aclID),
+		RuleNumber:   aws.Int32(200),
+		Egress:       aws.Bool(false),
+		Protocol:     aws.String("-1"),
+		RuleAction:   ec2types.RuleActionAllow,
+		CidrBlock:    aws.String("10.10.0.0/16"),
+	}); err != nil {
+		t.Fatalf("CreateNetworkAclEntry: %v", err)
+	}
+
+	if _, err := c.ReplaceNetworkAclEntry(ctx, &ec2.ReplaceNetworkAclEntryInput{
+		NetworkAclId: aws.String(aclID),
+		RuleNumber:   aws.Int32(200),
+		Egress:       aws.Bool(false),
+		Protocol:     aws.String("-1"),
+		RuleAction:   ec2types.RuleActionDeny,
+		CidrBlock:    aws.String("20.20.0.0/16"),
+	}); err != nil {
+		t.Fatalf("ReplaceNetworkAclEntry: %v", err)
+	}
+
+	desc, err := c.DescribeNetworkAcls(ctx, &ec2.DescribeNetworkAclsInput{
+		NetworkAclIds: []string{aclID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNetworkAcls: %v", err)
+	}
+
+	entry := findACLEntry(desc.NetworkAcls[0].Entries, 200, false)
+	if entry == nil {
+		t.Fatalf("rule 200 not found after replace; entries: %+v", desc.NetworkAcls[0].Entries)
+	}
+
+	if aws.ToString(entry.CidrBlock) != "20.20.0.0/16" {
+		t.Errorf("replaced cidr = %q, want 20.20.0.0/16", aws.ToString(entry.CidrBlock))
+	}
+
+	if entry.RuleAction != ec2types.RuleActionDeny {
+		t.Errorf("replaced action = %q, want deny", entry.RuleAction)
+	}
+}
+
+func findACLEntry(entries []ec2types.NetworkAclEntry, ruleNumber int32, egress bool) *ec2types.NetworkAclEntry {
+	for i := range entries {
+		if aws.ToInt32(entries[i].RuleNumber) == ruleNumber && aws.ToBool(entries[i].Egress) == egress {
+			return &entries[i]
+		}
+	}
+
+	return nil
+}

--- a/server/aws/ec2/networking_common.go
+++ b/server/aws/ec2/networking_common.go
@@ -3,9 +3,64 @@ package ec2
 import (
 	"encoding/xml"
 	"net/http"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 )
+
+// Shared EC2 Describe filter names, reused across the VPC-family handlers.
+const (
+	tagFilterPrefix = "tag:"
+	filterTagKey    = "tag-key"
+	filterVPCID     = "vpc-id"
+	filterSubnetID  = "subnet-id"
+	filterCIDR      = "cidr"
+	filterCIDRBlock = "cidr-block"
+	filterState     = "state"
+)
+
+// filterXML keeps the items that satisfy every filter and projects them to
+// their XML form. The VPC-family Describe handlers share it so each is just
+// "parse ids -> driver Describe -> validate filters -> filterXML -> write".
+func filterXML[T any, X any](
+	items []T,
+	filters []awsquery.Filter,
+	match func(*T, []awsquery.Filter) bool,
+	toXML func(*T) X,
+) []X {
+	out := make([]X, 0, len(items))
+
+	for i := range items {
+		if !match(&items[i], filters) {
+			continue
+		}
+
+		out = append(out, toXML(&items[i]))
+	}
+
+	return out
+}
+
+// tagFilterMatch evaluates a "tag:<key>" or "tag-key" filter against a resource's
+// tags. The second result reports whether name was a tag filter at all, so a
+// caller can fall through to its own non-tag filters.
+func tagFilterMatch(name string, values []string, tags map[string]string) (matched, isTag bool) {
+	switch {
+	case strings.HasPrefix(name, tagFilterPrefix):
+		v, ok := tags[strings.TrimPrefix(name, tagFilterPrefix)]
+		return ok && containsString(values, v), true
+	case name == filterTagKey:
+		for k := range tags {
+			if containsString(values, k) {
+				return true, true
+			}
+		}
+
+		return false, true
+	default:
+		return false, false
+	}
+}
 
 // writeReturnTrue writes the common EC2 "<return>true</return>" acknowledgement
 // with a caller-supplied response root element (set at runtime via xml.Name).

--- a/server/aws/ec2/operations.go
+++ b/server/aws/ec2/operations.go
@@ -1,6 +1,7 @@
 package ec2
 
 import (
+	"context"
 	"encoding/base64"
 	"net/http"
 	"strconv"
@@ -9,6 +10,23 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+// instanceAttributer is an AWS-specific optional capability for reading and
+// writing instance attributes (DisableApiTermination, SourceDestCheck, …) that
+// are not part of the portable Compute driver. The handler type-asserts for it
+// so providers that don't support these attributes are unaffected.
+type instanceAttributer interface {
+	SetInstanceAttribute(ctx context.Context, id, name, value string) error
+	GetInstanceAttribute(ctx context.Context, id, name string) (string, error)
+}
+
+// Attribute element names shared by ModifyInstanceAttribute (Name.Value on the
+// wire) and DescribeInstanceAttribute (Attribute= selector).
+const (
+	attrDisableAPITermination = "disableApiTermination"
+	attrSourceDestCheck       = "sourceDestCheck"
+	attrInstanceType          = "instanceType"
 )
 
 // reservationPrefix is our own reservation ID prefix. Real AWS uses "r-".
@@ -90,6 +108,8 @@ func (h *Handler) describeInstances(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) startInstances(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "InstanceId")
 
+	prev := h.priorStates(r.Context(), ids)
+
 	if err := h.compute.StartInstances(r.Context(), ids); err != nil {
 		writeErr(w, err)
 		return
@@ -98,15 +118,16 @@ func (h *Handler) startInstances(w http.ResponseWriter, r *http.Request) {
 	awsquery.WriteXMLResponse(w, startInstancesResponse{
 		Xmlns:     awsquery.Namespace,
 		RequestID: awsquery.RequestID,
-		Changes: stateChanges(ids,
-			instanceState{Code: stateCodePending, Name: "pending"},
-			instanceState{Code: stateCodeStopped, Name: "stopped"}),
+		Changes: stateChangesFrom(ids, prev,
+			instanceState{Code: stateCodePending, Name: "pending"}),
 	})
 }
 
 // stopInstances handles Action=StopInstances.
 func (h *Handler) stopInstances(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "InstanceId")
+
+	prev := h.priorStates(r.Context(), ids)
 
 	if err := h.compute.StopInstances(r.Context(), ids); err != nil {
 		writeErr(w, err)
@@ -116,9 +137,8 @@ func (h *Handler) stopInstances(w http.ResponseWriter, r *http.Request) {
 	awsquery.WriteXMLResponse(w, stopInstancesResponse{
 		Xmlns:     awsquery.Namespace,
 		RequestID: awsquery.RequestID,
-		Changes: stateChanges(ids,
-			instanceState{Code: stateCodeStopping, Name: "stopping"},
-			instanceState{Code: stateCodeRunning, Name: stateRunning}),
+		Changes: stateChangesFrom(ids, prev,
+			instanceState{Code: stateCodeStopping, Name: "stopping"}),
 	})
 }
 
@@ -142,41 +162,46 @@ func (h *Handler) rebootInstances(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) terminateInstances(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "InstanceId")
 
+	prev := h.priorStates(r.Context(), ids)
+
 	if err := h.compute.TerminateInstances(r.Context(), ids); err != nil {
+		// Termination protection surfaces as OperationNotPermitted, not the
+		// generic instance-state error.
+		if cerrors.IsPermissionDenied(err) {
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "OperationNotPermitted", err.Error())
+			return
+		}
+
 		writeErr(w, err)
+
 		return
 	}
 
 	awsquery.WriteXMLResponse(w, terminateInstancesResponse{
 		Xmlns:     awsquery.Namespace,
 		RequestID: awsquery.RequestID,
-		Changes: stateChanges(ids,
-			instanceState{Code: stateCodeShuttingDown, Name: "shutting-down"},
-			instanceState{Code: stateCodeRunning, Name: stateRunning}),
+		Changes: stateChangesFrom(ids, prev,
+			instanceState{Code: stateCodeShuttingDown, Name: "shutting-down"}),
 	})
 }
 
-// modifyInstanceAttribute handles Action=ModifyInstanceAttribute.
-// Phase 1 scope: InstanceType only. Other attributes land in later phases.
+// modifyInstanceAttribute handles Action=ModifyInstanceAttribute. InstanceType
+// changes route through the portable driver (which enforces the stopped
+// precondition); DisableApiTermination / SourceDestCheck route through the
+// AWS-specific instanceAttributer so they take effect (previously accepted and
+// silently discarded — a false success dangerous for IaC).
 func (h *Handler) modifyInstanceAttribute(w http.ResponseWriter, r *http.Request) {
 	id := r.Form.Get("InstanceId")
 
-	input := computedriver.ModifyInstanceInput{
-		InstanceType: r.Form.Get("InstanceType.Value"),
+	if instanceType := r.Form.Get("InstanceType.Value"); instanceType != "" {
+		if err := h.compute.ModifyInstance(r.Context(),
+			id, computedriver.ModifyInstanceInput{InstanceType: instanceType}); err != nil {
+			writeErr(w, err)
+			return
+		}
 	}
 
-	// If nothing to modify, still return success (real EC2 behavior).
-	if input.InstanceType == "" {
-		awsquery.WriteXMLResponse(w, modifyInstanceAttributeResponse{
-			Xmlns:     awsquery.Namespace,
-			RequestID: awsquery.RequestID,
-			Return:    true,
-		})
-
-		return
-	}
-
-	if err := h.compute.ModifyInstance(r.Context(), id, input); err != nil {
+	if err := h.applyInstanceAttributes(r, id); err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -186,6 +211,75 @@ func (h *Handler) modifyInstanceAttribute(w http.ResponseWriter, r *http.Request
 		RequestID: awsquery.RequestID,
 		Return:    true,
 	})
+}
+
+// applyInstanceAttributes writes the boolean instance attributes present in the
+// request through the instanceAttributer capability.
+func (h *Handler) applyInstanceAttributes(r *http.Request, id string) error {
+	attributer, ok := h.compute.(instanceAttributer)
+	if !ok {
+		return nil
+	}
+
+	for _, name := range []string{attrDisableAPITermination, attrSourceDestCheck} {
+		if v := r.Form.Get(attrForm(name) + ".Value"); v != "" {
+			if err := attributer.SetInstanceAttribute(r.Context(), id, name, v); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// describeInstanceAttribute handles Action=DescribeInstanceAttribute, returning
+// the single attribute named by Attribute= so ModifyInstanceAttribute changes
+// are verifiable.
+func (h *Handler) describeInstanceAttribute(w http.ResponseWriter, r *http.Request) {
+	id := r.Form.Get("InstanceId")
+	attr := r.Form.Get("Attribute")
+
+	attributer, ok := h.compute.(instanceAttributer)
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "instance attributes are not supported"))
+		return
+	}
+
+	val, err := attributer.GetInstanceAttribute(r.Context(), id, attr)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	resp := describeInstanceAttributeResponse{
+		Xmlns:      awsquery.Namespace,
+		RequestID:  awsquery.RequestID,
+		InstanceID: id,
+	}
+
+	switch attr {
+	case attrDisableAPITermination:
+		resp.DisableAPITermination = &attributeBooleanValueXML{Value: val == formTrue}
+	case attrSourceDestCheck:
+		resp.SourceDestCheck = &attributeBooleanValueXML{Value: val == formTrue}
+	case attrInstanceType:
+		resp.InstanceType = &attributeValueXML{Value: val}
+	}
+
+	awsquery.WriteXMLResponse(w, resp)
+}
+
+// attrForm maps an attribute element name (lowerCamel, as on the response) to
+// the request parameter's PascalCase prefix used by ModifyInstanceAttribute.
+func attrForm(name string) string {
+	switch name {
+	case attrDisableAPITermination:
+		return "DisableApiTermination"
+	case attrSourceDestCheck:
+		return "SourceDestCheck"
+	default:
+		return name
+	}
 }
 
 // getConsoleOutput handles Action=GetConsoleOutput. The console output is read
@@ -330,15 +424,35 @@ func toDriverFilters(in []awsquery.Filter) []computedriver.DescribeFilter {
 	return out
 }
 
-// stateChanges builds a transition record for each id, reporting the same
-// current/previous states. Real AWS returns these exact codes for each op.
-func stateChanges(ids []string, current, previous instanceState) []stateChangeXML {
+// priorStates captures each instance's state before a lifecycle operation so
+// the response can report the real previousState (rather than a hardcoded one).
+// A describe error yields an empty map; callers fall back to a zero previous.
+func (h *Handler) priorStates(ctx context.Context, ids []string) map[string]instanceState {
+	out := make(map[string]instanceState, len(ids))
+
+	instances, err := h.compute.DescribeInstances(ctx, ids, nil)
+	if err != nil {
+		return out
+	}
+
+	for i := range instances {
+		out[instances[i].ID] = instanceState{
+			Code: stateCode(instances[i].State), Name: instances[i].State,
+		}
+	}
+
+	return out
+}
+
+// stateChangesFrom builds a transition record for each id, deriving
+// previousState from the states captured before the operation ran.
+func stateChangesFrom(ids []string, previous map[string]instanceState, current instanceState) []stateChangeXML {
 	out := make([]stateChangeXML, 0, len(ids))
 	for _, id := range ids {
 		out = append(out, stateChangeXML{
 			InstanceID:    id,
 			CurrentState:  current,
-			PreviousState: previous,
+			PreviousState: previous[id],
 		})
 	}
 

--- a/server/aws/ec2/peering.go
+++ b/server/aws/ec2/peering.go
@@ -9,7 +9,8 @@ import (
 )
 
 type peeringStatusXML struct {
-	Code string `xml:"code"`
+	Code    string `xml:"code"`
+	Message string `xml:"message,omitempty"`
 }
 
 type peeringConnectionXML struct {
@@ -22,7 +23,10 @@ type peeringConnectionXML struct {
 }
 
 type peeringVpcInfo struct {
-	VpcID string `xml:"vpcId"`
+	VpcID     string `xml:"vpcId"`
+	OwnerID   string `xml:"ownerId,omitempty"`
+	CidrBlock string `xml:"cidrBlock,omitempty"`
+	Region    string `xml:"region,omitempty"`
 }
 
 type createPeeringResponseXML struct {
@@ -41,6 +45,13 @@ type acceptPeeringResponseXML struct {
 
 type deletePeeringResponseXML struct {
 	XMLName   xml.Name `xml:"DeleteVpcPeeringConnectionResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
+type rejectPeeringResponseXML struct {
+	XMLName   xml.Name `xml:"RejectVpcPeeringConnectionResponse"`
 	Xmlns     string   `xml:"xmlns,attr"`
 	RequestID string   `xml:"requestId"`
 	Return    bool     `xml:"return"`
@@ -87,13 +98,27 @@ func (h *Handler) acceptVpcPeeringConnection(w http.ResponseWriter, r *http.Requ
 	var p peeringConnectionXML
 
 	if len(peerings) > 0 {
-		p = toPeeringXML(&peerings[0])
+		p = h.enrichedPeeringXML(r, &peerings[0])
 	}
 
 	awsquery.WriteXMLResponse(w, acceptPeeringResponseXML{
 		Xmlns:                awsquery.Namespace,
 		RequestID:            awsquery.RequestID,
 		VpcPeeringConnection: p,
+	})
+}
+
+func (h *Handler) rejectVpcPeeringConnection(w http.ResponseWriter, r *http.Request) {
+	if err := h.vpc.RejectPeeringConnection(r.Context(),
+		r.Form.Get("VpcPeeringConnectionId")); err != nil {
+		writePeeringErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, rejectPeeringResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Return:    true,
 	})
 }
 
@@ -111,7 +136,6 @@ func (h *Handler) deleteVpcPeeringConnection(w http.ResponseWriter, r *http.Requ
 	})
 }
 
-//nolint:dupl // per-resource describe pattern
 func (h *Handler) describeVpcPeeringConnections(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "VpcPeeringConnectionId")
 
@@ -123,7 +147,7 @@ func (h *Handler) describeVpcPeeringConnections(w http.ResponseWriter, r *http.R
 
 	out := make([]peeringConnectionXML, 0, len(peerings))
 	for i := range peerings {
-		out = append(out, toPeeringXML(&peerings[i]))
+		out = append(out, h.enrichedPeeringXML(r, &peerings[i]))
 	}
 
 	awsquery.WriteXMLResponse(w, describePeeringResponseXML{
@@ -141,6 +165,56 @@ func toPeeringXML(p *netdriver.PeeringConnection) peeringConnectionXML {
 		Status:                 peeringStatusXML{Code: p.Status},
 		CreationTime:           p.CreatedAt,
 		Tags:                   toTagItems(p.Tags),
+	}
+}
+
+// enrichedPeeringXML is the Describe/Accept projection: it fills the
+// requester/accepter VpcInfo (ownerId, cidrBlock, region) and the status
+// message that IaC reads back, resolving each VPC's CIDR from the driver.
+func (h *Handler) enrichedPeeringXML(r *http.Request, p *netdriver.PeeringConnection) peeringConnectionXML {
+	region := regionFromRequest(r)
+
+	return peeringConnectionXML{
+		VpcPeeringConnectionID: p.ID,
+		RequesterVpcInfo:       h.peeringVpcInfo(r, p.RequesterVPC, region),
+		AccepterVpcInfo:        h.peeringVpcInfo(r, p.AccepterVPC, region),
+		Status:                 peeringStatusXML{Code: p.Status, Message: peeringStatusMessage(p.Status)},
+		CreationTime:           p.CreatedAt,
+		Tags:                   toTagItems(p.Tags),
+	}
+}
+
+// peeringVpcInfo fills the requester/accepter block AWS returns, resolving the
+// VPC's CIDR from the networking driver so IaC that reads accepter/requester
+// CIDRs (Terraform aws_vpc_peering_connection) sees real values.
+func (h *Handler) peeringVpcInfo(r *http.Request, vpcID, region string) peeringVpcInfo {
+	info := peeringVpcInfo{VpcID: vpcID, OwnerID: ownerID, Region: region}
+	if vpcID == "" {
+		return info
+	}
+
+	vpcs, err := h.vpc.DescribeVPCs(r.Context(), []string{vpcID})
+	if err == nil && len(vpcs) > 0 {
+		info.CidrBlock = vpcs[0].CIDRBlock
+	}
+
+	return info
+}
+
+// peeringStatusMessage mirrors the human-readable status message AWS attaches to
+// each peering status code.
+func peeringStatusMessage(code string) string {
+	switch code {
+	case "pending-acceptance":
+		return "Pending Acceptance by " + ownerID
+	case "active":
+		return "Active"
+	case "rejected":
+		return "Inactive"
+	case "deleted":
+		return "Deleted"
+	default:
+		return ""
 	}
 }
 

--- a/server/aws/ec2/prefix_list.go
+++ b/server/aws/ec2/prefix_list.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
@@ -17,11 +18,13 @@ func (h *Handler) prefixLists() (netdriver.PrefixLists, bool) {
 
 type prefixListXML struct {
 	PrefixListID   string    `xml:"prefixListId"`
+	PrefixListArn  string    `xml:"prefixListArn,omitempty"`
 	PrefixListName string    `xml:"prefixListName"`
 	AddressFamily  string    `xml:"addressFamily"`
 	MaxEntries     int       `xml:"maxEntries"`
 	State          string    `xml:"state"`
 	Version        int       `xml:"version"`
+	OwnerID        string    `xml:"ownerId,omitempty"`
 	Tags           []tagItem `xml:"tagSet>item,omitempty"`
 }
 
@@ -74,7 +77,7 @@ func (*Handler) createPrefixList(w http.ResponseWriter, r *http.Request, p netdr
 		Xmlns   string        `xml:"xmlns,attr"`
 		Req     string        `xml:"requestId"`
 		PL      prefixListXML `xml:"prefixList"`
-	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: toPrefixListXML(out)})
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: toPrefixListXML(regionFromRequest(r), out)})
 }
 
 func (*Handler) deletePrefixList(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
@@ -89,10 +92,9 @@ func (*Handler) deletePrefixList(w http.ResponseWriter, r *http.Request, p netdr
 		Xmlns   string        `xml:"xmlns,attr"`
 		Req     string        `xml:"requestId"`
 		PL      prefixListXML `xml:"prefixList"`
-	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: toPrefixListXML(out)})
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: toPrefixListXML(regionFromRequest(r), out)})
 }
 
-//nolint:dupl // parallel per-resource marshaling
 func (*Handler) describePrefixLists(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
 	items, err := p.DescribeManagedPrefixLists(r.Context(), awsquery.ListStrings(r.Form, "PrefixListId"))
 	if err != nil {
@@ -100,9 +102,11 @@ func (*Handler) describePrefixLists(w http.ResponseWriter, r *http.Request, p ne
 		return
 	}
 
+	region := regionFromRequest(r)
+
 	out := make([]prefixListXML, 0, len(items))
 	for i := range items {
-		out = append(out, toPrefixListXML(&items[i]))
+		out = append(out, toPrefixListXML(region, &items[i]))
 	}
 
 	awsquery.WriteXMLResponse(w, struct {
@@ -134,8 +138,15 @@ func (*Handler) getPrefixListEntries(w http.ResponseWriter, r *http.Request, p n
 }
 
 func (*Handler) modifyPrefixList(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
+	id := r.Form.Get("PrefixListId")
+
+	if err := checkPrefixListVersion(r, p, id); err != nil {
+		writePrefixListErr(w, err)
+		return
+	}
+
 	out, err := p.ModifyManagedPrefixList(r.Context(),
-		r.Form.Get("PrefixListId"), parseAddPrefixListEntries(r), parseRemovePrefixListCIDRs(r))
+		id, parseAddPrefixListEntries(r), parseRemovePrefixListCIDRs(r))
 	if err != nil {
 		writePrefixListErr(w, err)
 		return
@@ -146,7 +157,39 @@ func (*Handler) modifyPrefixList(w http.ResponseWriter, r *http.Request, p netdr
 		Xmlns   string        `xml:"xmlns,attr"`
 		Req     string        `xml:"requestId"`
 		PL      prefixListXML `xml:"prefixList"`
-	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: toPrefixListXML(out)})
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: toPrefixListXML(regionFromRequest(r), out)})
+}
+
+// checkPrefixListVersion enforces the optimistic-concurrency guard AWS applies
+// to ModifyManagedPrefixList: when the caller passes CurrentVersion it must
+// match the list's current version, else the modify is rejected as an
+// IncorrectState. Callers that omit CurrentVersion skip the check.
+func checkPrefixListVersion(r *http.Request, p netdriver.PrefixLists, id string) error {
+	raw := r.Form.Get("CurrentVersion")
+	if raw == "" {
+		return nil
+	}
+
+	want, err := strconv.Atoi(raw)
+	if err != nil {
+		return newInvalidParameterErr("CurrentVersion must be an integer")
+	}
+
+	lists, err := p.DescribeManagedPrefixLists(r.Context(), []string{id})
+	if err != nil {
+		return err
+	}
+
+	if len(lists) == 0 {
+		return cerrors.Newf(cerrors.NotFound, "managed prefix list %q not found", id)
+	}
+
+	if lists[0].Version != want {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"prefix list %q has version %d, not the requested %d", id, lists[0].Version, want)
+	}
+
+	return nil
 }
 
 func parseAddPrefixListEntries(r *http.Request) []netdriver.PrefixListEntry {
@@ -221,11 +264,23 @@ func parsePrefixListEntries(r *http.Request) []netdriver.PrefixListEntry {
 	return nil
 }
 
-func toPrefixListXML(p *netdriver.PrefixList) prefixListXML {
+func toPrefixListXML(region string, p *netdriver.PrefixList) prefixListXML {
 	return prefixListXML{
-		PrefixListID: p.ID, PrefixListName: p.Name, AddressFamily: p.AddressFamily,
-		MaxEntries: p.MaxEntries, State: p.State, Version: p.Version, Tags: toTagItems(p.Tags),
+		PrefixListID: p.ID, PrefixListArn: prefixListARN(region, p.ID),
+		PrefixListName: p.Name, AddressFamily: p.AddressFamily,
+		MaxEntries: p.MaxEntries, State: p.State, Version: p.Version,
+		OwnerID: ownerID, Tags: toTagItems(p.Tags),
 	}
+}
+
+// prefixListARN builds the managed-prefix-list ARN AWS returns; the SDK and
+// Terraform read prefixListArn to reference the list in policies and rules.
+func prefixListARN(region, id string) string {
+	if id == "" {
+		return ""
+	}
+
+	return "arn:aws:ec2:" + region + ":" + ownerID + ":prefix-list/" + id
 }
 
 func writePrefixListErr(w http.ResponseWriter, err error) {

--- a/server/aws/ec2/route_table.go
+++ b/server/aws/ec2/route_table.go
@@ -14,6 +14,13 @@ const (
 	targetTypeGateway    = "gateway"
 	targetTypeNatGateway = "nat-gateway"
 	targetTypePeering    = "peering"
+	targetTypeLocal      = "local"
+
+	// routeOriginCreateRouteTable is the origin AWS reports for the implicit
+	// local route created with the table; routeOriginCreateRoute is what it
+	// reports for routes a caller added afterward.
+	routeOriginCreateRouteTable = "CreateRouteTable"
+	routeOriginCreateRoute      = "CreateRoute"
 )
 
 type routeXML struct {
@@ -22,6 +29,7 @@ type routeXML struct {
 	NatGatewayID         string `xml:"natGatewayId,omitempty"`
 	VpcPeeringConnection string `xml:"vpcPeeringConnectionId,omitempty"`
 	State                string `xml:"state"`
+	Origin               string `xml:"origin,omitempty"`
 }
 
 type rtAssociationStateXML struct {
@@ -356,6 +364,7 @@ func toRouteTableXML(rt *netdriver.RouteTable) routeTableXML {
 		rx := routeXML{
 			DestinationCIDR: route.DestinationCIDR,
 			State:           nonEmpty(route.State, "active"),
+			Origin:          routeOrigin(route.TargetType),
 		}
 
 		switch route.TargetType {
@@ -365,12 +374,26 @@ func toRouteTableXML(rt *netdriver.RouteTable) routeTableXML {
 			rx.NatGatewayID = route.TargetID
 		case targetTypePeering:
 			rx.VpcPeeringConnection = route.TargetID
+		case targetTypeLocal:
+			// The VPC-local route reports gatewayId "local", not the internal
+			// target id the driver stores.
+			rx.GatewayID = targetTypeLocal
 		}
 
 		x.Routes = append(x.Routes, rx)
 	}
 
 	return x
+}
+
+// routeOrigin reports how a route was created: the implicit local route comes
+// from CreateRouteTable, every other target type is a route a caller added.
+func routeOrigin(targetType string) string {
+	if targetType == targetTypeLocal {
+		return routeOriginCreateRouteTable
+	}
+
+	return routeOriginCreateRoute
 }
 
 func nonEmpty(s, fallback string) string {

--- a/server/aws/ec2/route_table_test.go
+++ b/server/aws/ec2/route_table_test.go
@@ -1,0 +1,72 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestRouteTableLocalRoute pins that a new route table's implicit VPC-local
+// route reports gatewayId "local" and origin CreateRouteTable. Terraform's
+// aws_route_table and aws_default_route_table read these to distinguish the
+// local route from managed routes; an empty gatewayId makes the local route
+// look like an unmanaged one they then try to delete.
+func TestRouteTableLocalRoute(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	vpcID := aws.ToString(vpc.Vpc.VpcId)
+
+	rt, err := c.CreateRouteTable(ctx, &ec2.CreateRouteTableInput{VpcId: aws.String(vpcID)})
+	if err != nil {
+		t.Fatalf("CreateRouteTable: %v", err)
+	}
+
+	rtID := aws.ToString(rt.RouteTable.RouteTableId)
+
+	desc, err := c.DescribeRouteTables(ctx, &ec2.DescribeRouteTablesInput{
+		RouteTableIds: []string{rtID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeRouteTables: %v", err)
+	}
+
+	if len(desc.RouteTables) != 1 {
+		t.Fatalf("DescribeRouteTables = %d, want 1", len(desc.RouteTables))
+	}
+
+	local := findLocalRoute(desc.RouteTables[0].Routes)
+	if local == nil {
+		t.Fatalf("no local route found; routes: %+v", desc.RouteTables[0].Routes)
+	}
+
+	if got := aws.ToString(local.GatewayId); got != "local" {
+		t.Errorf("local route gatewayId = %q, want local", got)
+	}
+
+	if local.Origin != ec2types.RouteOriginCreateRouteTable {
+		t.Errorf("local route origin = %q, want CreateRouteTable", local.Origin)
+	}
+
+	if got := aws.ToString(local.DestinationCidrBlock); got != "10.0.0.0/16" {
+		t.Errorf("local route destination = %q, want 10.0.0.0/16", got)
+	}
+}
+
+func findLocalRoute(routes []ec2types.Route) *ec2types.Route {
+	for i := range routes {
+		if aws.ToString(routes[i].GatewayId) == "local" {
+			return &routes[i]
+		}
+	}
+
+	return nil
+}

--- a/server/aws/ec2/security_group.go
+++ b/server/aws/ec2/security_group.go
@@ -7,11 +7,16 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
+
+// tagKeyFilter is the DescribeSecurityGroups filter that matches on the
+// presence of a tag key (as opposed to "tag:<key>", which matches a value).
+const tagKeyFilter = "tag-key"
 
 func errMissingGroupID() error {
 	return cerrors.New(cerrors.InvalidArgument, "GroupId is required")
@@ -50,11 +55,12 @@ type securityGroupXML struct {
 }
 
 type createSecurityGroupResponseXML struct {
-	XMLName   xml.Name `xml:"CreateSecurityGroupResponse"`
-	Xmlns     string   `xml:"xmlns,attr"`
-	RequestID string   `xml:"requestId"`
-	GroupID   string   `xml:"groupId"`
-	Return    bool     `xml:"return"`
+	XMLName   xml.Name  `xml:"CreateSecurityGroupResponse"`
+	Xmlns     string    `xml:"xmlns,attr"`
+	RequestID string    `xml:"requestId"`
+	GroupID   string    `xml:"groupId"`
+	Tags      []tagItem `xml:"tagSet>item,omitempty"`
+	Return    bool      `xml:"return"`
 }
 
 type describeSecurityGroupsResponseXML struct {
@@ -72,6 +78,15 @@ func (h *Handler) createSecurityGroup(w http.ResponseWriter, r *http.Request) {
 		Tags:        mergeTagSpecs(awsquery.TagSpecs(r.Form), "security-group"),
 	}
 
+	// Group names must be unique within a VPC — real EC2 answers
+	// InvalidGroup.Duplicate. The driver accepts duplicates, so enforce it
+	// here at the wire layer where the AWS-shaped error code lives.
+	if dup := h.duplicateGroupName(r.Context(), cfg.Name, cfg.VPCID); dup {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidGroup.Duplicate",
+			fmt.Sprintf("The security group '%s' already exists for VPC '%s'", cfg.Name, cfg.VPCID))
+		return
+	}
+
 	info, err := h.vpc.CreateSecurityGroup(r.Context(), cfg)
 	if err != nil {
 		writeSGErr(w, err)
@@ -82,8 +97,31 @@ func (h *Handler) createSecurityGroup(w http.ResponseWriter, r *http.Request) {
 		Xmlns:     awsquery.Namespace,
 		RequestID: awsquery.RequestID,
 		GroupID:   info.ID,
+		Tags:      toTagItems(info.Tags),
 		Return:    true,
 	})
+}
+
+// duplicateGroupName reports whether a security group with the same name
+// already exists in the same VPC. A blank name or VPC (EC2-Classic) is never
+// treated as a duplicate.
+func (h *Handler) duplicateGroupName(ctx context.Context, name, vpcID string) bool {
+	if name == "" || vpcID == "" {
+		return false
+	}
+
+	sgs, err := h.vpc.DescribeSecurityGroups(ctx, nil)
+	if err != nil {
+		return false
+	}
+
+	for i := range sgs {
+		if sgs[i].VPCID == vpcID && sgs[i].Name == name {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (h *Handler) deleteSecurityGroup(w http.ResponseWriter, r *http.Request) {
@@ -103,9 +141,14 @@ func (h *Handler) deleteSecurityGroup(w http.ResponseWriter, r *http.Request) {
 	writeSimpleSGResponse(w, "DeleteSecurityGroupResponse")
 }
 
-//nolint:dupl // per-resource describe pattern; siblings in vpc/subnet/igw/route_table
 func (h *Handler) describeSecurityGroups(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "GroupId")
+
+	filters := awsquery.Filters(r.Form)
+	if err := validateSGFilters(filters); err != nil {
+		writeSGErr(w, err)
+		return
+	}
 
 	sgs, err := h.vpc.DescribeSecurityGroups(r.Context(), ids)
 	if err != nil {
@@ -114,7 +157,12 @@ func (h *Handler) describeSecurityGroups(w http.ResponseWriter, r *http.Request)
 	}
 
 	out := make([]securityGroupXML, 0, len(sgs))
+
 	for i := range sgs {
+		if !sgMatchesFilters(&sgs[i], filters) {
+			continue
+		}
+
 		out = append(out, toSecurityGroupXML(&sgs[i]))
 	}
 
@@ -125,20 +173,107 @@ func (h *Handler) describeSecurityGroups(w http.ResponseWriter, r *http.Request)
 	})
 }
 
+// sgScalarFilterField maps a supported scalar filter name to the group field it
+// selects on. The second result reports whether the name is a recognized scalar
+// filter (tag filters are handled separately in sgMatchesFilters).
+func sgScalarFilterField(sg *netdriver.SecurityGroupInfo, name string) (string, bool) {
+	switch name {
+	case "group-id":
+		return sg.ID, true
+	case "group-name":
+		return sg.Name, true
+	case "vpc-id":
+		return sg.VPCID, true
+	case "description":
+		return sg.Description, true
+	default:
+		return "", false
+	}
+}
+
+// isSGTagFilter reports whether a filter name targets tags: "tag-key" matches
+// on the presence of a key, and "tag:<key>" matches a specific key's value.
+func isSGTagFilter(name string) bool {
+	return name == tagKeyFilter || strings.HasPrefix(name, "tag:")
+}
+
+// validateSGFilters rejects filter names this emulator does not implement, the
+// same way real EC2 answers InvalidParameterValue for an unknown filter.
+func validateSGFilters(filters []awsquery.Filter) error {
+	for _, f := range filters {
+		if isSGTagFilter(f.Name) {
+			continue
+		}
+
+		if _, ok := sgScalarFilterField(&netdriver.SecurityGroupInfo{}, f.Name); !ok {
+			return newInvalidParameterErr(fmt.Sprintf("The filter '%s' is invalid", f.Name))
+		}
+	}
+
+	return nil
+}
+
+func sgMatchesFilters(sg *netdriver.SecurityGroupInfo, filters []awsquery.Filter) bool {
+	for _, f := range filters {
+		if !sgMatchesFilter(sg, f) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func sgMatchesFilter(sg *netdriver.SecurityGroupInfo, f awsquery.Filter) bool {
+	if f.Name == tagKeyFilter {
+		for key := range sg.Tags {
+			if containsString(f.Values, key) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	if key, ok := strings.CutPrefix(f.Name, "tag:"); ok {
+		return containsString(f.Values, sg.Tags[key])
+	}
+
+	field, ok := sgScalarFilterField(sg, f.Name)
+	if !ok {
+		return false
+	}
+
+	return containsString(f.Values, field)
+}
+
 func (h *Handler) authorizeSecurityGroupIngress(w http.ResponseWriter, r *http.Request) {
-	h.applyRules(w, r, h.vpc.AddIngressRule, "AuthorizeSecurityGroupIngressResponse")
+	h.applyRules(w, r, ruleApply{
+		apply:        h.vpc.AddIngressRule,
+		responseName: "AuthorizeSecurityGroupIngressResponse",
+		existing:     func(sg *netdriver.SecurityGroupInfo) []netdriver.SecurityRule { return sg.IngressRules },
+	})
 }
 
 func (h *Handler) authorizeSecurityGroupEgress(w http.ResponseWriter, r *http.Request) {
-	h.applyRules(w, r, h.vpc.AddEgressRule, "AuthorizeSecurityGroupEgressResponse")
+	h.applyRules(w, r, ruleApply{
+		apply:        h.vpc.AddEgressRule,
+		responseName: "AuthorizeSecurityGroupEgressResponse",
+		existing:     func(sg *netdriver.SecurityGroupInfo) []netdriver.SecurityRule { return sg.EgressRules },
+	})
 }
 
 func (h *Handler) revokeSecurityGroupIngress(w http.ResponseWriter, r *http.Request) {
-	h.applyRules(w, r, tolerateMissingRule(h.vpc.RemoveIngressRule), "RevokeSecurityGroupIngressResponse")
+	h.applyRules(w, r, ruleApply{
+		apply:        tolerateMissingRule(h.vpc.RemoveIngressRule),
+		responseName: "RevokeSecurityGroupIngressResponse",
+	})
 }
 
 func (h *Handler) revokeSecurityGroupEgress(w http.ResponseWriter, r *http.Request) {
-	h.applyRules(w, r, tolerateMissingRule(h.vpc.RemoveEgressRule), "RevokeSecurityGroupEgressResponse")
+	h.applyRules(w, r, ruleApply{
+		apply:        tolerateMissingRule(h.vpc.RemoveEgressRule),
+		responseName: "RevokeSecurityGroupEgressResponse",
+	})
 }
 
 // tolerateMissingRule makes a Revoke idempotent: real EC2 does not fail when a
@@ -159,16 +294,20 @@ func tolerateMissingRule(remove ruleFunc) ruleFunc {
 // RemoveIngressRule / RemoveEgressRule on the Networking driver.
 type ruleFunc func(ctx context.Context, groupID string, rule netdriver.SecurityRule) error
 
+// ruleApply parameterizes the shared Authorize/Revoke path. existing is set only
+// for Authorize: it selects the current rule set (ingress or egress) so a
+// duplicate can be rejected with InvalidPermission.Duplicate the way real EC2
+// does. It is nil for Revoke, which is idempotent.
+type ruleApply struct {
+	apply        ruleFunc
+	responseName string
+	existing     func(*netdriver.SecurityGroupInfo) []netdriver.SecurityRule
+}
+
 // applyRules is the shared Authorize/Revoke path. The driver takes one rule
 // at a time; we unroll the IpPermissions.N.IpRanges.M matrix into a flat
-// list and apply each entry. The receiver is unused — apply is already bound
-// to the caller's driver — kept for API symmetry with other routeVPC methods.
-func (*Handler) applyRules(
-	w http.ResponseWriter,
-	r *http.Request,
-	apply ruleFunc,
-	responseName string,
-) {
+// list and apply each entry.
+func (h *Handler) applyRules(w http.ResponseWriter, r *http.Request, spec ruleApply) {
 	groupID := r.Form.Get("GroupId")
 	if groupID == "" {
 		writeSGErr(w, errMissingGroupID())
@@ -181,14 +320,46 @@ func (*Handler) applyRules(
 		return
 	}
 
+	if spec.existing != nil && h.hasDuplicateRule(r.Context(), groupID, rules, spec.existing) {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidPermission.Duplicate",
+			"the specified rule already exists")
+		return
+	}
+
 	for _, rule := range rules {
-		if err := apply(r.Context(), groupID, rule); err != nil {
+		if err := spec.apply(r.Context(), groupID, rule); err != nil {
 			writeSGErr(w, err)
 			return
 		}
 	}
 
-	writeSimpleSGResponse(w, responseName)
+	writeSimpleSGResponse(w, spec.responseName)
+}
+
+// hasDuplicateRule reports whether any of the rules being authorized already
+// exists in the group's current rule set (as selected by existing).
+func (h *Handler) hasDuplicateRule(
+	ctx context.Context,
+	groupID string,
+	rules []netdriver.SecurityRule,
+	existing func(*netdriver.SecurityGroupInfo) []netdriver.SecurityRule,
+) bool {
+	sgs, err := h.vpc.DescribeSecurityGroups(ctx, []string{groupID})
+	if err != nil || len(sgs) == 0 {
+		return false
+	}
+
+	current := existing(&sgs[0])
+
+	for _, rule := range rules {
+		for i := range current {
+			if current[i] == rule {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // parseIPPermissions flattens the nested AWS wire form

--- a/server/aws/ec2/security_group_test.go
+++ b/server/aws/ec2/security_group_test.go
@@ -1,0 +1,210 @@
+package ec2_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+func newSGServer(t *testing.T) *ec2.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	ts := httptest.NewServer(awsserver.New(awsserver.DriversFrom(cloud)))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	cfg.BaseEndpoint = aws.String(ts.URL)
+
+	return ec2.NewFromConfig(cfg)
+}
+
+func createSGTestVPC(t *testing.T, ctx context.Context, c *ec2.Client, cidr string) string {
+	t.Helper()
+
+	out, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String(cidr)})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	return aws.ToString(out.Vpc.VpcId)
+}
+
+// TestCreateSecurityGroupReturnsTags pins that CreateSecurityGroup echoes the
+// tags applied via TagSpecifications back in its response, matching real EC2.
+func TestCreateSecurityGroupReturnsTags(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	vpcID := createSGTestVPC(t, ctx, c, "10.0.0.0/16")
+
+	out, err := c.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String("web-sg"),
+		Description: aws.String("web tier"),
+		VpcId:       aws.String(vpcID),
+		TagSpecifications: []ec2types.TagSpecification{{
+			ResourceType: ec2types.ResourceTypeSecurityGroup,
+			Tags: []ec2types.Tag{
+				{Key: aws.String("Name"), Value: aws.String("web-1")},
+				{Key: aws.String("env"), Value: aws.String("prod")},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSecurityGroup: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, tag := range out.Tags {
+		got[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+	}
+
+	if got["Name"] != "web-1" || got["env"] != "prod" {
+		t.Fatalf("CreateSecurityGroup response tags = %v, want Name=web-1 env=prod", got)
+	}
+}
+
+// TestCreateSecurityGroupDuplicateName pins InvalidGroup.Duplicate when a group
+// name is reused within one VPC, and that the same name in a different VPC is
+// allowed.
+func TestCreateSecurityGroupDuplicateName(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	vpcID := createSGTestVPC(t, ctx, c, "10.0.0.0/16")
+
+	mk := func(vpc string) error {
+		_, err := c.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+			GroupName:   aws.String("dup-sg"),
+			Description: aws.String("d"),
+			VpcId:       aws.String(vpc),
+		})
+
+		return err
+	}
+
+	if err := mk(vpcID); err != nil {
+		t.Fatalf("first CreateSecurityGroup: %v", err)
+	}
+
+	if err := mk(vpcID); err == nil {
+		t.Fatalf("duplicate group name in same VPC should fail with InvalidGroup.Duplicate")
+	}
+
+	otherVPC := createSGTestVPC(t, ctx, c, "10.1.0.0/16")
+	if err := mk(otherVPC); err != nil {
+		t.Fatalf("same name in a different VPC should succeed, got: %v", err)
+	}
+}
+
+// TestDescribeSecurityGroupsFilters pins that Describe honors group-name,
+// vpc-id, and tag filters instead of returning every group across all VPCs.
+func TestDescribeSecurityGroupsFilters(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	vpcA := createSGTestVPC(t, ctx, c, "10.0.0.0/16")
+	vpcB := createSGTestVPC(t, ctx, c, "10.1.0.0/16")
+
+	mk := func(name, vpc, team string) {
+		_, err := c.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+			GroupName:   aws.String(name),
+			Description: aws.String(name),
+			VpcId:       aws.String(vpc),
+			TagSpecifications: []ec2types.TagSpecification{{
+				ResourceType: ec2types.ResourceTypeSecurityGroup,
+				Tags:         []ec2types.Tag{{Key: aws.String("team"), Value: aws.String(team)}},
+			}},
+		})
+		if err != nil {
+			t.Fatalf("CreateSecurityGroup %s: %v", name, err)
+		}
+	}
+
+	mk("app-a", vpcA, "payments")
+	mk("app-b", vpcB, "billing")
+
+	byVPC, err := c.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcA}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSecurityGroups vpc-id: %v", err)
+	}
+
+	if len(byVPC.SecurityGroups) != 1 || aws.ToString(byVPC.SecurityGroups[0].GroupName) != "app-a" {
+		t.Fatalf("vpc-id filter = %d groups, want only app-a", len(byVPC.SecurityGroups))
+	}
+
+	byName, err := c.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("group-name"), Values: []string{"app-b"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSecurityGroups group-name: %v", err)
+	}
+
+	if len(byName.SecurityGroups) != 1 || aws.ToString(byName.SecurityGroups[0].VpcId) != vpcB {
+		t.Fatalf("group-name filter = %d groups, want only app-b", len(byName.SecurityGroups))
+	}
+
+	byTag, err := c.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("tag:team"), Values: []string{"payments"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSecurityGroups tag: %v", err)
+	}
+
+	if len(byTag.SecurityGroups) != 1 || aws.ToString(byTag.SecurityGroups[0].GroupName) != "app-a" {
+		t.Fatalf("tag:team filter = %d groups, want only app-a", len(byTag.SecurityGroups))
+	}
+}
+
+// TestAuthorizeSecurityGroupIngressDuplicate pins InvalidPermission.Duplicate
+// when the same ingress rule is authorized twice.
+func TestAuthorizeSecurityGroupIngressDuplicate(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	vpcID := createSGTestVPC(t, ctx, c, "10.0.0.0/16")
+
+	sg, err := c.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String("sg"),
+		Description: aws.String("sg"),
+		VpcId:       aws.String(vpcID),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecurityGroup: %v", err)
+	}
+
+	perm := ec2types.IpPermission{
+		IpProtocol: aws.String("tcp"),
+		FromPort:   aws.Int32(443),
+		ToPort:     aws.Int32(443),
+		IpRanges:   []ec2types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
+	}
+
+	auth := &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId:       sg.GroupId,
+		IpPermissions: []ec2types.IpPermission{perm},
+	}
+
+	if _, err := c.AuthorizeSecurityGroupIngress(ctx, auth); err != nil {
+		t.Fatalf("first AuthorizeSecurityGroupIngress: %v", err)
+	}
+
+	if _, err := c.AuthorizeSecurityGroupIngress(ctx, auth); err == nil {
+		t.Fatalf("duplicate ingress rule should fail with InvalidPermission.Duplicate")
+	}
+}

--- a/server/aws/ec2/snapshot.go
+++ b/server/aws/ec2/snapshot.go
@@ -13,8 +13,11 @@ type snapshotXML struct {
 	VolumeID    string    `xml:"volumeId"`
 	State       string    `xml:"status"`
 	StartTime   string    `xml:"startTime,omitempty"`
+	Progress    string    `xml:"progress,omitempty"`
+	OwnerID     string    `xml:"ownerId,omitempty"`
 	Description string    `xml:"description,omitempty"`
 	VolumeSize  int       `xml:"volumeSize"`
+	Encrypted   bool      `xml:"encrypted"`
 	Tags        []tagItem `xml:"tagSet>item,omitempty"`
 }
 
@@ -34,6 +37,13 @@ type describeSnapshotsResponseXML struct {
 
 type deleteSnapshotResponseXML struct {
 	XMLName   xml.Name `xml:"DeleteSnapshotResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
+type modifySnapshotAttributeResponseXML struct {
+	XMLName   xml.Name `xml:"ModifySnapshotAttributeResponse"`
 	Xmlns     string   `xml:"xmlns,attr"`
 	RequestID string   `xml:"requestId"`
 	Return    bool     `xml:"return"`
@@ -73,9 +83,15 @@ func (h *Handler) deleteSnapshot(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // per-resource describe pattern; siblings in vpc/subnet/sg/igw/route_table/volume/keypair
+//nolint:dupl // per-resource describe+filter pattern; siblings in volume/image
 func (h *Handler) describeSnapshots(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "SnapshotId")
+	filters := awsquery.Filters(r.Form)
+
+	if err := validateSnapshotFilters(filters); err != nil {
+		writeSnapshotErr(w, err)
+		return
+	}
 
 	snaps, err := h.compute.DescribeSnapshots(r.Context(), ids)
 	if err != nil {
@@ -84,14 +100,83 @@ func (h *Handler) describeSnapshots(w http.ResponseWriter, r *http.Request) {
 	}
 
 	out := make([]snapshotXML, 0, len(snaps))
+
 	for i := range snaps {
-		out = append(out, toSnapshotXML(&snaps[i]))
+		if snapshotMatchesFilters(&snaps[i], filters) {
+			out = append(out, toSnapshotXML(&snaps[i]))
+		}
 	}
 
 	awsquery.WriteXMLResponse(w, describeSnapshotsResponseXML{
 		Xmlns:       awsquery.Namespace,
 		RequestID:   awsquery.RequestID,
 		SnapshotSet: out,
+	})
+}
+
+func validateSnapshotFilters(filters []awsquery.Filter) error {
+	for _, f := range filters {
+		if isStorageTagFilter(f.Name) {
+			continue
+		}
+
+		switch f.Name {
+		case filterSnapshotID, filterVolumeID, filterStatus, filterOwnerID, filterEncrypted, filterDescription:
+		default:
+			return newInvalidParameterErr("The filter '" + f.Name + "' is invalid")
+		}
+	}
+
+	return nil
+}
+
+func snapshotMatchesFilters(s *computedriver.SnapshotInfo, filters []awsquery.Filter) bool {
+	for _, f := range filters {
+		if !snapshotMatchesFilter(s, f) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func snapshotMatchesFilter(s *computedriver.SnapshotInfo, f awsquery.Filter) bool {
+	if matched, isTag := matchStorageTagFilter(s.Tags, f); isTag {
+		return matched
+	}
+
+	switch f.Name {
+	case filterSnapshotID:
+		return containsString(f.Values, s.ID)
+	case filterVolumeID:
+		return containsString(f.Values, s.VolumeID)
+	case filterStatus:
+		return containsString(f.Values, nonEmpty(s.State, "completed"))
+	case filterOwnerID:
+		return containsString(f.Values, s.OwnerID)
+	case filterEncrypted:
+		return containsString(f.Values, boolFilterValue(s.Encrypted))
+	case filterDescription:
+		return containsString(f.Values, s.Description)
+	default:
+		return false
+	}
+}
+
+// modifySnapshotAttribute accepts createVolumePermission / productCode changes.
+// The emulator does not model snapshot sharing, so it acknowledges the request
+// without persisting the attribute (Terraform's aws_snapshot_create_volume_
+// permission only needs the 200).
+func (h *Handler) modifySnapshotAttribute(w http.ResponseWriter, r *http.Request) {
+	if _, err := h.compute.DescribeSnapshots(r.Context(), []string{r.Form.Get("SnapshotId")}); err != nil {
+		writeSnapshotErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, modifySnapshotAttributeResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Return:    true,
 	})
 }
 
@@ -106,8 +191,11 @@ func toSnapshotXML(s *computedriver.SnapshotInfo) snapshotXML {
 		VolumeID:    s.VolumeID,
 		State:       state,
 		StartTime:   s.CreatedAt,
+		Progress:    s.Progress,
+		OwnerID:     s.OwnerID,
 		Description: s.Description,
 		VolumeSize:  s.Size,
+		Encrypted:   s.Encrypted,
 		Tags:        toTagItems(s.Tags),
 	}
 }

--- a/server/aws/ec2/snapshot_test.go
+++ b/server/aws/ec2/snapshot_test.go
@@ -1,0 +1,133 @@
+package ec2_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+func createSnapshotVolume(t *testing.T, ctx context.Context, client *ec2.Client) string {
+	t.Helper()
+
+	cre, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(10),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+
+	return aws.ToString(cre.VolumeId)
+}
+
+// TestCreateSnapshotReportsOwnerAndProgress pins that a snapshot carries an
+// OwnerId and a Progress value — empty ownerId breaks owner queries and empty
+// progress breaks the SnapshotCompleted waiter.
+func TestCreateSnapshotReportsOwnerAndProgress(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+	volID := createSnapshotVolume(t, ctx, client)
+
+	snap, err := client.CreateSnapshot(ctx, &ec2.CreateSnapshotInput{
+		VolumeId:    aws.String(volID),
+		Description: aws.String("backup"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	if aws.ToString(snap.OwnerId) == "" {
+		t.Errorf("CreateSnapshot OwnerId is empty")
+	}
+	if aws.ToString(snap.Progress) == "" {
+		t.Errorf("CreateSnapshot Progress is empty")
+	}
+
+	desc, err := client.DescribeSnapshots(ctx, &ec2.DescribeSnapshotsInput{
+		SnapshotIds: []string{aws.ToString(snap.SnapshotId)},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSnapshots: %v", err)
+	}
+	if len(desc.Snapshots) != 1 {
+		t.Fatalf("DescribeSnapshots = %d, want 1", len(desc.Snapshots))
+	}
+	if aws.ToString(desc.Snapshots[0].OwnerId) == "" {
+		t.Errorf("DescribeSnapshots OwnerId is empty")
+	}
+}
+
+// TestDescribeSnapshotsUnknownIDErrors pins that an explicit unknown snapshot
+// id returns InvalidSnapshot.NotFound rather than an empty success.
+func TestDescribeSnapshotsUnknownIDErrors(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	_, err := client.DescribeSnapshots(ctx, &ec2.DescribeSnapshotsInput{
+		SnapshotIds: []string{"snap-000000000000"},
+	})
+	if err == nil {
+		t.Fatalf("DescribeSnapshots(unknown) returned no error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidSnapshot.NotFound" {
+		t.Fatalf("error code = %v, want InvalidSnapshot.NotFound", err)
+	}
+}
+
+// TestDescribeSnapshotsTagFilter pins snapshot tag filtering.
+func TestDescribeSnapshotsTagFilter(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+	volID := createSnapshotVolume(t, ctx, client)
+
+	for _, name := range []string{"keep", "other"} {
+		if _, err := client.CreateSnapshot(ctx, &ec2.CreateSnapshotInput{
+			VolumeId: aws.String(volID),
+			TagSpecifications: []ec2types.TagSpecification{{
+				ResourceType: ec2types.ResourceTypeSnapshot,
+				Tags:         []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String(name)}},
+			}},
+		}); err != nil {
+			t.Fatalf("CreateSnapshot(%s): %v", name, err)
+		}
+	}
+
+	out, err := client.DescribeSnapshots(ctx, &ec2.DescribeSnapshotsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("tag:Name"), Values: []string{"keep"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSnapshots: %v", err)
+	}
+	if len(out.Snapshots) != 1 {
+		t.Fatalf("tag:Name=keep returned %d snapshots, want 1", len(out.Snapshots))
+	}
+}
+
+// TestModifySnapshotAttributeAccepted pins that the previously-undispatched
+// ModifySnapshotAttribute action succeeds for an existing snapshot.
+func TestModifySnapshotAttributeAccepted(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+	volID := createSnapshotVolume(t, ctx, client)
+
+	snap, err := client.CreateSnapshot(ctx, &ec2.CreateSnapshotInput{VolumeId: aws.String(volID)})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	if _, err := client.ModifySnapshotAttribute(ctx, &ec2.ModifySnapshotAttributeInput{
+		SnapshotId:    snap.SnapshotId,
+		Attribute:     ec2types.SnapshotAttributeNameCreateVolumePermission,
+		OperationType: ec2types.OperationTypeAdd,
+		GroupNames:    []string{"all"},
+	}); err != nil {
+		t.Fatalf("ModifySnapshotAttribute: %v", err)
+	}
+}

--- a/server/aws/ec2/subnet.go
+++ b/server/aws/ec2/subnet.go
@@ -2,15 +2,22 @@ package ec2
 
 import (
 	"encoding/xml"
+	"net"
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
-// subnetAvailableIPs is the count reported to SDK clients. Real AWS varies
-// it by CIDR size; our emulator doesn't track allocation, so a constant fits.
-const subnetAvailableIPs = 251
+// AWS reserves 5 addresses in every subnet CIDR (network, VPC router, DNS,
+// future use, broadcast), so a /24 reports 251 usable addresses.
+const subnetReservedIPs = 5
+
+// ipv4Bits is the address width used to size a subnet's host space from its
+// prefix length.
+const ipv4Bits = 32
 
 type subnetXML struct {
 	SubnetID            string    `xml:"subnetId"`
@@ -19,8 +26,11 @@ type subnetXML struct {
 	CidrBlock           string    `xml:"cidrBlock"`
 	AvailableIPCount    int       `xml:"availableIpAddressCount"`
 	AvailabilityZone    string    `xml:"availabilityZone"`
+	AvailabilityZoneID  string    `xml:"availabilityZoneId,omitempty"`
 	DefaultForAz        bool      `xml:"defaultForAz"`
 	MapPublicIPOnLaunch bool      `xml:"mapPublicIpOnLaunch"`
+	SubnetArn           string    `xml:"subnetArn,omitempty"`
+	OwnerID             string    `xml:"ownerId"`
 	Tags                []tagItem `xml:"tagSet>item,omitempty"`
 }
 
@@ -45,6 +55,13 @@ type deleteSubnetResponseXML struct {
 	Return    bool     `xml:"return"`
 }
 
+type modifySubnetAttributeResponseXML struct {
+	XMLName   xml.Name `xml:"ModifySubnetAttributeResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
 func (h *Handler) createSubnet(w http.ResponseWriter, r *http.Request) {
 	cfg := netdriver.SubnetConfig{
 		VPCID:            r.Form.Get("VpcId"),
@@ -55,14 +72,14 @@ func (h *Handler) createSubnet(w http.ResponseWriter, r *http.Request) {
 
 	info, err := h.vpc.CreateSubnet(r.Context(), cfg)
 	if err != nil {
-		writeSubnetErr(w, err)
+		writeCreateSubnetErr(w, err)
 		return
 	}
 
 	awsquery.WriteXMLResponse(w, createSubnetResponseXML{
 		Xmlns:     awsquery.Namespace,
 		RequestID: awsquery.RequestID,
-		Subnet:    toSubnetXML(info),
+		Subnet:    toSubnetXML(info, regionFromRequest(r)),
 	})
 }
 
@@ -79,7 +96,6 @@ func (h *Handler) deleteSubnet(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // per-resource describe pattern; siblings in vpc/sg/igw/route_table
 func (h *Handler) describeSubnets(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "SubnetId")
 
@@ -89,35 +105,175 @@ func (h *Handler) describeSubnets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]subnetXML, 0, len(subnets))
-	for i := range subnets {
-		out = append(out, toSubnetXML(&subnets[i]))
+	filters := awsquery.Filters(r.Form)
+	if err := validateSubnetFilters(filters); err != nil {
+		writeSubnetErr(w, err)
+		return
 	}
+
+	region := regionFromRequest(r)
+	toXML := func(s *netdriver.SubnetInfo) subnetXML { return toSubnetXML(s, region) }
 
 	awsquery.WriteXMLResponse(w, describeSubnetsResponseXML{
 		Xmlns:     awsquery.Namespace,
 		RequestID: awsquery.RequestID,
-		SubnetSet: out,
+		SubnetSet: filterXML(subnets, filters, subnetMatchesFilters, toXML),
 	})
 }
 
-func toSubnetXML(s *netdriver.SubnetInfo) subnetXML {
+// modifySubnetAttribute flips a subnet launch attribute. MapPublicIpOnLaunch is
+// the only way to make a subnet hand out public IPv4 addresses, so IaC tools
+// building a public subnet depend on it.
+func (h *Handler) modifySubnetAttribute(w http.ResponseWriter, r *http.Request) {
+	attrs, ok := h.vpc.(netdriver.SubnetAttributes)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction",
+			"this driver does not model subnet attributes")
+
+		return
+	}
+
+	err := attrs.ModifySubnetAttribute(r.Context(), r.Form.Get("SubnetId"),
+		netdriver.SubnetAttributeUpdate{
+			MapPublicIPOnLaunch: boolAttributeValue(r, "MapPublicIpOnLaunch"),
+		})
+	if err != nil {
+		writeSubnetErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, modifySubnetAttributeResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Return:    true,
+	})
+}
+
+func toSubnetXML(s *netdriver.SubnetInfo, region string) subnetXML {
 	state := s.State
 	if state == "" {
 		state = stateAvailable
 	}
 
-	return subnetXML{
-		SubnetID:         s.ID,
-		State:            state,
-		VpcID:            s.VPCID,
-		CidrBlock:        s.CIDRBlock,
-		AvailableIPCount: subnetAvailableIPs,
-		AvailabilityZone: s.AvailabilityZone,
-		Tags:             toTagItems(s.Tags),
+	x := subnetXML{
+		SubnetID:            s.ID,
+		State:               state,
+		VpcID:               s.VPCID,
+		CidrBlock:           s.CIDRBlock,
+		AvailableIPCount:    availableIPCount(s.CIDRBlock),
+		AvailabilityZone:    s.AvailabilityZone,
+		AvailabilityZoneID:  zoneIDFor(s.AvailabilityZone),
+		MapPublicIPOnLaunch: s.MapPublicIPOnLaunch,
+		OwnerID:             ownerID,
+		Tags:                toTagItems(s.Tags),
+	}
+
+	if s.ID != "" {
+		x.SubnetArn = idgen.AWSARN("ec2", region, ownerID, "subnet/"+s.ID)
+	}
+
+	return x
+}
+
+// availableIPCount reports the usable-address count AWS advertises for a CIDR:
+// the host space minus the five addresses AWS reserves. A malformed or missing
+// CIDR falls back to a /24's 251 rather than zero.
+func availableIPCount(cidr string) int {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return (1 << (ipv4Bits - 24)) - subnetReservedIPs
+	}
+
+	ones, bits := ipnet.Mask.Size()
+	if bits != ipv4Bits {
+		return 0
+	}
+
+	total := 1 << (ipv4Bits - ones)
+	if total <= subnetReservedIPs {
+		return 0
+	}
+
+	return total - subnetReservedIPs
+}
+
+// zoneIDFor maps an availability-zone name to its zone id (us-east-1a ->
+// us-east-1-az1), matching DescribeAvailabilityZones. Returns "" for an unset
+// or unrecognized zone rather than inventing an id.
+func zoneIDFor(zone string) string {
+	if zone == "" {
+		return ""
+	}
+
+	last := zone[len(zone)-1]
+	if last < 'a' || last > 'z' {
+		return ""
+	}
+
+	return zone[:len(zone)-1] + "-az" + string(rune('1'+(last-'a')))
+}
+
+// validateSubnetFilters rejects filter names DescribeSubnets does not model, so
+// a data-source lookup is never silently told a subnet is absent.
+func validateSubnetFilters(filters []awsquery.Filter) error {
+	var probe netdriver.SubnetInfo
+
+	for _, f := range filters {
+		if _, known := subnetFilterMatch(&probe, f); !known {
+			return newInvalidParameterErr("The filter '" + f.Name + "' is invalid")
+		}
+	}
+
+	return nil
+}
+
+func subnetMatchesFilters(s *netdriver.SubnetInfo, filters []awsquery.Filter) bool {
+	for _, f := range filters {
+		if matched, _ := subnetFilterMatch(s, f); !matched {
+			return false
+		}
+	}
+
+	return true
+}
+
+// subnetFilterMatch reports whether s satisfies filter f and whether f is a
+// filter DescribeSubnets recognizes.
+func subnetFilterMatch(s *netdriver.SubnetInfo, f awsquery.Filter) (matched, known bool) {
+	switch f.Name {
+	case filterSubnetID:
+		return containsString(f.Values, s.ID), true
+	case filterVPCID:
+		return containsString(f.Values, s.VPCID), true
+	case filterCIDR, filterCIDRBlock, "cidrBlock":
+		return containsString(f.Values, s.CIDRBlock), true
+	case "availability-zone", "availabilityZone":
+		return containsString(f.Values, s.AvailabilityZone), true
+	case "availability-zone-id":
+		return containsString(f.Values, zoneIDFor(s.AvailabilityZone)), true
+	case filterState:
+		return containsString(f.Values, nonEmpty(s.State, stateAvailable)), true
+	case "default-for-az", "defaultForAz":
+		return containsString(f.Values, boolFilterValue(false)), true
+	case "map-public-ip-on-launch":
+		return containsString(f.Values, boolFilterValue(s.MapPublicIPOnLaunch)), true
+	default:
+		return tagFilterMatch(f.Name, f.Values, s.Tags)
 	}
 }
 
 func writeSubnetErr(w http.ResponseWriter, err error) {
 	writeErrWithNotFound(w, err, "InvalidSubnetID.NotFound", "DependencyViolation")
+}
+
+// writeCreateSubnetErr adds the CreateSubnet-only InvalidSubnet.Conflict code
+// for an overlapping CIDR (surfaced as AlreadyExists by the driver), falling
+// back to the shared subnet error mapping otherwise.
+func writeCreateSubnetErr(w http.ResponseWriter, err error) {
+	if cerrors.IsAlreadyExists(err) {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSubnet.Conflict", err.Error())
+		return
+	}
+
+	writeSubnetErr(w, err)
 }

--- a/server/aws/ec2/subnet_test.go
+++ b/server/aws/ec2/subnet_test.go
@@ -2,42 +2,13 @@ package ec2_test
 
 import (
 	"context"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-
-	"github.com/stackshy/cloudemu/v2"
-	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 )
-
-// newEC2Client wires a full AWS server and returns a real aws-sdk-go-v2 EC2
-// client pointed at it (dummy creds, us-east-1).
-func newEC2Client(t *testing.T) *ec2.Client {
-	t.Helper()
-
-	cloud := cloudemu.NewAWS()
-	ts := httptest.NewServer(awsserver.New(awsserver.DriversFrom(cloud)))
-	t.Cleanup(ts.Close)
-
-	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
-		awsconfig.WithRegion("us-east-1"),
-		awsconfig.WithCredentialsProvider(
-			credentials.NewStaticCredentialsProvider("test", "test", "")),
-	)
-	if err != nil {
-		t.Fatalf("load config: %v", err)
-	}
-
-	cfg.BaseEndpoint = aws.String(ts.URL)
-
-	return ec2.NewFromConfig(cfg)
-}
 
 func mkVPC(ctx context.Context, t *testing.T, c *ec2.Client, cidr string) string {
 	t.Helper()

--- a/server/aws/ec2/subnet_test.go
+++ b/server/aws/ec2/subnet_test.go
@@ -1,0 +1,221 @@
+package ec2_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newEC2Client wires a full AWS server and returns a real aws-sdk-go-v2 EC2
+// client pointed at it (dummy creds, us-east-1).
+func newEC2Client(t *testing.T) *ec2.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	ts := httptest.NewServer(awsserver.New(awsserver.DriversFrom(cloud)))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	cfg.BaseEndpoint = aws.String(ts.URL)
+
+	return ec2.NewFromConfig(cfg)
+}
+
+func mkVPC(ctx context.Context, t *testing.T, c *ec2.Client, cidr string) string {
+	t.Helper()
+
+	out, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String(cidr)})
+	if err != nil {
+		t.Fatalf("CreateVpc(%s): %v", cidr, err)
+	}
+
+	return aws.ToString(out.Vpc.VpcId)
+}
+
+func mkSubnet(ctx context.Context, t *testing.T, c *ec2.Client, vpcID, cidr, az string) *ec2types.Subnet {
+	t.Helper()
+
+	in := &ec2.CreateSubnetInput{VpcId: aws.String(vpcID), CidrBlock: aws.String(cidr)}
+	if az != "" {
+		in.AvailabilityZone = aws.String(az)
+	}
+
+	out, err := c.CreateSubnet(ctx, in)
+	if err != nil {
+		t.Fatalf("CreateSubnet(%s): %v", cidr, err)
+	}
+
+	return out.Subnet
+}
+
+// TestCreateSubnetReportsArnZoneIDAndUsableIPs pins that a created subnet carries
+// a real subnetArn, the zone id matching the requested AZ, and an
+// availableIpAddressCount computed from the CIDR (a /25 has 128-5 = 123 usable),
+// not a hardcoded 251.
+func TestCreateSubnetReportsArnZoneIDAndUsableIPs(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	vpcID := mkVPC(ctx, t, c, "10.0.0.0/16")
+	sub := mkSubnet(ctx, t, c, vpcID, "10.0.1.0/25", "us-east-1a")
+
+	if got := aws.ToInt32(sub.AvailableIpAddressCount); got != 123 {
+		t.Errorf("AvailableIpAddressCount = %d, want 123 for a /25", got)
+	}
+
+	wantArnSuffix := ":subnet/" + aws.ToString(sub.SubnetId)
+	arn := aws.ToString(sub.SubnetArn)
+	if !strings.HasPrefix(arn, "arn:aws:ec2:us-east-1:123456789012:subnet/") ||
+		!strings.HasSuffix(arn, wantArnSuffix) {
+		t.Errorf("SubnetArn = %q, want arn:aws:ec2:us-east-1:123456789012%s", arn, wantArnSuffix)
+	}
+
+	if got := aws.ToString(sub.AvailabilityZoneId); got != "us-east-1-az1" {
+		t.Errorf("AvailabilityZoneId = %q, want us-east-1-az1", got)
+	}
+
+	if got := aws.ToString(sub.OwnerId); got != "123456789012" {
+		t.Errorf("OwnerId = %q, want 123456789012", got)
+	}
+}
+
+// TestModifySubnetAttributeMakesSubnetPublic pins that MapPublicIpOnLaunch is
+// off by default and that ModifySubnetAttribute flips it — the only way to build
+// a public subnet. Without the fix the attribute is undispatched and the flag
+// stays false forever.
+func TestModifySubnetAttributeMakesSubnetPublic(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	vpcID := mkVPC(ctx, t, c, "10.0.0.0/16")
+	sub := mkSubnet(ctx, t, c, vpcID, "10.0.1.0/24", "us-east-1a")
+	subnetID := aws.ToString(sub.SubnetId)
+
+	if aws.ToBool(sub.MapPublicIpOnLaunch) {
+		t.Fatalf("new subnet should default MapPublicIpOnLaunch off")
+	}
+
+	if _, err := c.ModifySubnetAttribute(ctx, &ec2.ModifySubnetAttributeInput{
+		SubnetId:            aws.String(subnetID),
+		MapPublicIpOnLaunch: &ec2types.AttributeBooleanValue{Value: aws.Bool(true)},
+	}); err != nil {
+		t.Fatalf("ModifySubnetAttribute: %v", err)
+	}
+
+	desc, err := c.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{SubnetIds: []string{subnetID}})
+	if err != nil {
+		t.Fatalf("DescribeSubnets: %v", err)
+	}
+
+	if len(desc.Subnets) != 1 || !aws.ToBool(desc.Subnets[0].MapPublicIpOnLaunch) {
+		t.Fatalf("MapPublicIpOnLaunch not persisted: %+v", desc.Subnets)
+	}
+}
+
+// TestDescribeSubnetsFilters pins that the vpc-id and cidr filters narrow the
+// result to the matching subnet instead of returning subnets from every VPC.
+func TestDescribeSubnetsFilters(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	vpcA := mkVPC(ctx, t, c, "10.0.0.0/16")
+	vpcB := mkVPC(ctx, t, c, "10.1.0.0/16")
+	subA := aws.ToString(mkSubnet(ctx, t, c, vpcA, "10.0.1.0/24", "us-east-1a").SubnetId)
+	mkSubnet(ctx, t, c, vpcB, "10.1.1.0/24", "us-east-1a")
+
+	byVPC, err := c.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcA}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSubnets(vpc-id): %v", err)
+	}
+
+	if len(byVPC.Subnets) != 1 || aws.ToString(byVPC.Subnets[0].SubnetId) != subA {
+		t.Fatalf("vpc-id filter returned %d subnets, want only %s", len(byVPC.Subnets), subA)
+	}
+
+	byCIDR, err := c.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("cidr-block"), Values: []string{"10.1.1.0/24"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSubnets(cidr-block): %v", err)
+	}
+
+	if len(byCIDR.Subnets) != 1 || aws.ToString(byCIDR.Subnets[0].VpcId) != vpcB {
+		t.Fatalf("cidr-block filter returned %d subnets, want only vpcB's", len(byCIDR.Subnets))
+	}
+}
+
+// TestDeleteSubnetBlockedByResidentENI pins that an available (unattached) ENI
+// in a subnet blocks its deletion with DependencyViolation, matching real EC2.
+func TestDeleteSubnetBlockedByResidentENI(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	vpcID := mkVPC(ctx, t, c, "10.0.0.0/16")
+	subnetID := aws.ToString(mkSubnet(ctx, t, c, vpcID, "10.0.1.0/24", "us-east-1a").SubnetId)
+
+	eni, err := c.CreateNetworkInterface(ctx, &ec2.CreateNetworkInterfaceInput{
+		SubnetId: aws.String(subnetID),
+	})
+	if err != nil {
+		t.Fatalf("CreateNetworkInterface: %v", err)
+	}
+
+	if _, err := c.DeleteSubnet(ctx, &ec2.DeleteSubnetInput{SubnetId: aws.String(subnetID)}); err == nil {
+		t.Fatalf("DeleteSubnet should fail while an ENI resides in the subnet")
+	} else if !strings.Contains(err.Error(), "DependencyViolation") {
+		t.Errorf("DeleteSubnet error = %v, want DependencyViolation", err)
+	}
+
+	// Draining the ENI lets the delete through — the refusal must be recoverable.
+	if _, err := c.DeleteNetworkInterface(ctx, &ec2.DeleteNetworkInterfaceInput{
+		NetworkInterfaceId: eni.NetworkInterface.NetworkInterfaceId,
+	}); err != nil {
+		t.Fatalf("DeleteNetworkInterface: %v", err)
+	}
+
+	if _, err := c.DeleteSubnet(ctx, &ec2.DeleteSubnetInput{SubnetId: aws.String(subnetID)}); err != nil {
+		t.Errorf("DeleteSubnet after drain: %v", err)
+	}
+}
+
+// TestCreateSubnetRejectsOverlappingCIDR pins that a second subnet whose CIDR
+// overlaps an existing one in the same VPC is rejected with InvalidSubnet.Conflict.
+func TestCreateSubnetRejectsOverlappingCIDR(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	vpcID := mkVPC(ctx, t, c, "10.0.0.0/16")
+	mkSubnet(ctx, t, c, vpcID, "10.0.1.0/24", "us-east-1a")
+
+	_, err := c.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId:     aws.String(vpcID),
+		CidrBlock: aws.String("10.0.1.0/25"),
+	})
+	if err == nil {
+		t.Fatalf("overlapping subnet CIDR should be rejected")
+	}
+
+	if !strings.Contains(err.Error(), "InvalidSubnet.Conflict") {
+		t.Errorf("error = %v, want InvalidSubnet.Conflict", err)
+	}
+}

--- a/server/aws/ec2/tag_error_test.go
+++ b/server/aws/ec2/tag_error_test.go
@@ -1,0 +1,33 @@
+package ec2_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestCreateTagsUnknownInstanceErrorCode pins that CreateTags on a non-existent
+// instance id returns InvalidInstanceID.NotFound (the resource-specific code
+// real EC2 uses), not the generic InvalidID.NotFound.
+func TestCreateTagsUnknownInstanceErrorCode(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	_, err := c.CreateTags(ctx, &ec2.CreateTagsInput{
+		Resources: []string{"i-deadbeefdeadbeef0"},
+		Tags:      []ec2types.Tag{{Key: aws.String("k"), Value: aws.String("v")}},
+	})
+	if err == nil {
+		t.Fatal("CreateTags on unknown instance id should fail")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidInstanceID.NotFound" {
+		t.Fatalf("want InvalidInstanceID.NotFound, got %v", err)
+	}
+}

--- a/server/aws/ec2/tags.go
+++ b/server/aws/ec2/tags.go
@@ -220,7 +220,7 @@ func (h *Handler) createTags(w http.ResponseWriter, r *http.Request) {
 
 	for _, id := range ids {
 		if err := h.tagResource(r.Context(), id, tags); err != nil {
-			writeErrWithNotFound(w, err, "InvalidID.NotFound", "IncorrectState")
+			writeErrWithNotFound(w, err, tagNotFoundCode(id), "IncorrectState")
 			return
 		}
 	}
@@ -240,12 +240,24 @@ func (h *Handler) deleteTags(w http.ResponseWriter, r *http.Request) {
 
 	for _, id := range ids {
 		if err := h.untagResource(r.Context(), id, keys); err != nil {
-			writeErrWithNotFound(w, err, "InvalidID.NotFound", "IncorrectState")
+			writeErrWithNotFound(w, err, tagNotFoundCode(id), "IncorrectState")
 			return
 		}
 	}
 
 	awsquery.WriteXMLResponse(w, deleteTagsResponseXML{Return: true, RequestID: "cloudemu"})
+}
+
+// tagNotFoundCode returns the "…NotFound" error code real EC2 emits when
+// CreateTags/DeleteTags names a non-existent resource. An instance id yields the
+// resource-specific InvalidInstanceID.NotFound; other resource types fall back
+// to the generic InvalidID.NotFound.
+func tagNotFoundCode(id string) string {
+	if strings.HasPrefix(id, "i-") {
+		return codeInvalidInstanceID
+	}
+
+	return "InvalidID.NotFound"
 }
 
 func (h *Handler) tagResource(ctx context.Context, id string, tags map[string]string) error {

--- a/server/aws/ec2/volume.go
+++ b/server/aws/ec2/volume.go
@@ -14,8 +14,8 @@ import (
 const defaultVolumeType = "gp3"
 
 // Storage describe filter names shared across volume/snapshot/image handlers.
+// filterTagKey and filterState are defined in networking_common.go (shared).
 const (
-	filterTagKey             = "tag-key"
 	filterAvailabilityZone   = "availability-zone"
 	filterSize               = "size"
 	filterEncrypted          = "encrypted"
@@ -30,7 +30,6 @@ const (
 	filterImageID            = "image-id"
 	filterImageType          = "image-type"
 	filterName               = "name"
-	filterState              = "state"
 	filterRootDeviceType     = "root-device-type"
 	filterVirtualizationType = "virtualization-type"
 )

--- a/server/aws/ec2/volume.go
+++ b/server/aws/ec2/volume.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
@@ -11,6 +12,28 @@ import (
 
 // Default volume type AWS uses when the caller omits VolumeType.
 const defaultVolumeType = "gp3"
+
+// Storage describe filter names shared across volume/snapshot/image handlers.
+const (
+	filterTagKey             = "tag-key"
+	filterAvailabilityZone   = "availability-zone"
+	filterSize               = "size"
+	filterEncrypted          = "encrypted"
+	filterArchitecture       = "architecture"
+	filterHypervisor         = "hypervisor"
+	filterVolumeID           = "volume-id"
+	filterStatus             = "status"
+	filterVolumeType         = "volume-type"
+	filterSnapshotID         = "snapshot-id"
+	filterOwnerID            = "owner-id"
+	filterDescription        = "description"
+	filterImageID            = "image-id"
+	filterImageType          = "image-type"
+	filterName               = "name"
+	filterState              = "state"
+	filterRootDeviceType     = "root-device-type"
+	filterVirtualizationType = "virtualization-type"
+)
 
 type volumeAttachmentXML struct {
 	VolumeID   string `xml:"volumeId"`
@@ -23,11 +46,15 @@ type volumeAttachmentXML struct {
 type volumeXML struct {
 	VolumeID         string                `xml:"volumeId"`
 	Size             int                   `xml:"size"`
+	SnapshotID       string                `xml:"snapshotId"`
 	Status           string                `xml:"status"`
 	VolumeType       string                `xml:"volumeType"`
 	AvailabilityZone string                `xml:"availabilityZone"`
 	CreateTime       string                `xml:"createTime,omitempty"`
+	Iops             int                   `xml:"iops,omitempty"`
+	Throughput       int                   `xml:"throughput,omitempty"`
 	Encrypted        bool                  `xml:"encrypted"`
+	KmsKeyID         string                `xml:"kmsKeyId,omitempty"`
 	Attachments      []volumeAttachmentXML `xml:"attachmentSet>item,omitempty"`
 	Tags             []tagItem             `xml:"tagSet>item,omitempty"`
 }
@@ -84,11 +111,19 @@ func (h *Handler) createVolume(w http.ResponseWriter, r *http.Request) {
 		vt = defaultVolumeType
 	}
 
+	iops, _ := strconv.Atoi(r.Form.Get("Iops"))
+	throughput, _ := strconv.Atoi(r.Form.Get("Throughput"))
+
 	cfg := computedriver.VolumeConfig{
 		Size:             size,
 		VolumeType:       vt,
 		AvailabilityZone: r.Form.Get("AvailabilityZone"),
 		Tags:             mergeTagSpecs(awsquery.TagSpecs(r.Form), "volume"),
+		IOPS:             iops,
+		Throughput:       throughput,
+		Encrypted:        r.Form.Get("Encrypted") == formTrue,
+		SnapshotID:       r.Form.Get("SnapshotId"),
+		KmsKeyID:         r.Form.Get("KmsKeyId"),
 	}
 
 	info, err := h.compute.CreateVolume(r.Context(), cfg)
@@ -117,9 +152,15 @@ func (h *Handler) deleteVolume(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // per-resource describe pattern; siblings in vpc/subnet/sg/igw/route_table
+//nolint:dupl // per-resource describe+filter pattern; siblings in snapshot/image
 func (h *Handler) describeVolumes(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "VolumeId")
+	filters := awsquery.Filters(r.Form)
+
+	if err := validateVolumeFilters(filters); err != nil {
+		writeVolumeErr(w, err)
+		return
+	}
 
 	vols, err := h.compute.DescribeVolumes(r.Context(), ids)
 	if err != nil {
@@ -128,8 +169,11 @@ func (h *Handler) describeVolumes(w http.ResponseWriter, r *http.Request) {
 	}
 
 	out := make([]volumeXML, 0, len(vols))
+
 	for i := range vols {
-		out = append(out, toVolumeXML(&vols[i]))
+		if volumeMatchesFilters(&vols[i], filters) {
+			out = append(out, toVolumeXML(&vols[i]))
+		}
 	}
 
 	awsquery.WriteXMLResponse(w, describeVolumesResponseXML{
@@ -137,6 +181,58 @@ func (h *Handler) describeVolumes(w http.ResponseWriter, r *http.Request) {
 		RequestID: awsquery.RequestID,
 		VolumeSet: out,
 	})
+}
+
+func validateVolumeFilters(filters []awsquery.Filter) error {
+	for _, f := range filters {
+		if isStorageTagFilter(f.Name) {
+			continue
+		}
+
+		switch f.Name {
+		case filterVolumeID, filterStatus, filterAvailabilityZone, filterVolumeType,
+			filterEncrypted, filterSnapshotID, filterSize:
+		default:
+			return newInvalidParameterErr("The filter '" + f.Name + "' is invalid")
+		}
+	}
+
+	return nil
+}
+
+func volumeMatchesFilters(v *computedriver.VolumeInfo, filters []awsquery.Filter) bool {
+	for _, f := range filters {
+		if !volumeMatchesFilter(v, f) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func volumeMatchesFilter(v *computedriver.VolumeInfo, f awsquery.Filter) bool {
+	if matched, isTag := matchStorageTagFilter(v.Tags, f); isTag {
+		return matched
+	}
+
+	switch f.Name {
+	case filterVolumeID:
+		return containsString(f.Values, v.ID)
+	case filterStatus:
+		return containsString(f.Values, nonEmpty(v.State, stateAvailable))
+	case filterAvailabilityZone:
+		return containsString(f.Values, v.AvailabilityZone)
+	case filterVolumeType:
+		return containsString(f.Values, v.VolumeType)
+	case filterEncrypted:
+		return containsString(f.Values, boolFilterValue(v.Encrypted))
+	case filterSnapshotID:
+		return containsString(f.Values, v.SnapshotID)
+	case filterSize:
+		return containsString(f.Values, strconv.Itoa(v.Size))
+	default:
+		return false
+	}
 }
 
 func (h *Handler) attachVolume(w http.ResponseWriter, r *http.Request) {
@@ -186,10 +282,15 @@ func toVolumeXML(v *computedriver.VolumeInfo) volumeXML {
 	x := volumeXML{
 		VolumeID:         v.ID,
 		Size:             v.Size,
+		SnapshotID:       v.SnapshotID,
 		Status:           state,
 		VolumeType:       v.VolumeType,
 		AvailabilityZone: v.AvailabilityZone,
 		CreateTime:       v.CreatedAt,
+		Iops:             v.IOPS,
+		Throughput:       v.Throughput,
+		Encrypted:        v.Encrypted,
+		KmsKeyID:         v.KmsKeyID,
 		Tags:             toTagItems(v.Tags),
 	}
 
@@ -208,4 +309,73 @@ func toVolumeXML(v *computedriver.VolumeInfo) volumeXML {
 
 func writeVolumeErr(w http.ResponseWriter, err error) {
 	writeErrWithNotFound(w, err, "InvalidVolume.NotFound", "IncorrectState")
+}
+
+// isStorageTagFilter reports whether name is a tag-based filter (tag:<key> or
+// tag-key) shared by volume/snapshot/image describes.
+func isStorageTagFilter(name string) bool {
+	return name == filterTagKey || strings.HasPrefix(name, "tag:")
+}
+
+// matchStorageTagFilter evaluates a tag:<key> or tag-key filter against a
+// resource's tags. The second return reports whether the filter was a tag
+// filter at all, so callers can fall through to resource-specific fields.
+func matchStorageTagFilter(tags map[string]string, f awsquery.Filter) (matched, isTag bool) {
+	switch {
+	case strings.HasPrefix(f.Name, "tag:"):
+		key := strings.TrimPrefix(f.Name, "tag:")
+		v, ok := tags[key]
+
+		return ok && containsString(f.Values, v), true
+	case f.Name == filterTagKey:
+		for k := range tags {
+			if containsString(f.Values, k) {
+				return true, true
+			}
+		}
+
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+type volumeStatusItemXML struct {
+	VolumeID         string `xml:"volumeId"`
+	AvailabilityZone string `xml:"availabilityZone"`
+	Status           string `xml:"volumeStatus>status"`
+}
+
+type describeVolumeStatusResponseXML struct {
+	XMLName         xml.Name              `xml:"DescribeVolumeStatusResponse"`
+	Xmlns           string                `xml:"xmlns,attr"`
+	RequestID       string                `xml:"requestId"`
+	VolumeStatusSet []volumeStatusItemXML `xml:"volumeStatusSet>item"`
+}
+
+// describeVolumeStatus reports per-volume health. The emulator has no failure
+// modes, so every existing volume reports "ok".
+func (h *Handler) describeVolumeStatus(w http.ResponseWriter, r *http.Request) {
+	ids := awsquery.ListStrings(r.Form, "VolumeId")
+
+	vols, err := h.compute.DescribeVolumes(r.Context(), ids)
+	if err != nil {
+		writeVolumeErr(w, err)
+		return
+	}
+
+	out := make([]volumeStatusItemXML, 0, len(vols))
+	for i := range vols {
+		out = append(out, volumeStatusItemXML{
+			VolumeID:         vols[i].ID,
+			AvailabilityZone: vols[i].AvailabilityZone,
+			Status:           "ok",
+		})
+	}
+
+	awsquery.WriteXMLResponse(w, describeVolumeStatusResponseXML{
+		Xmlns:           awsquery.Namespace,
+		RequestID:       awsquery.RequestID,
+		VolumeStatusSet: out,
+	})
 }

--- a/server/aws/ec2/volume_test.go
+++ b/server/aws/ec2/volume_test.go
@@ -1,0 +1,163 @@
+package ec2_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newEC2 wires a full in-process AWS server and returns a real aws-sdk-go-v2
+// EC2 client pointed at it.
+func newEC2(t *testing.T) *ec2.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	ts := httptest.NewServer(awsserver.New(awsserver.DriversFrom(cloud)))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	cfg.BaseEndpoint = aws.String(ts.URL)
+
+	return ec2.NewFromConfig(cfg)
+}
+
+// TestCreateVolumeEchoesEncryptionAndPerformance pins that Encrypted, Iops,
+// Throughput, and KmsKeyId survive the round-trip. Dropping them makes
+// Terraform's aws_ebs_volume see perpetual drift / forced replacement.
+func TestCreateVolumeEchoesEncryptionAndPerformance(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	const kmsKey = "arn:aws:kms:us-east-1:123456789012:key/abcd1234-a123-456a-a12b-a123b4cd56ef"
+
+	cre, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(100),
+		VolumeType:       ec2types.VolumeTypeGp3,
+		Iops:             aws.Int32(4000),
+		Throughput:       aws.Int32(250),
+		Encrypted:        aws.Bool(true),
+		KmsKeyId:         aws.String(kmsKey),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+
+	if !aws.ToBool(cre.Encrypted) {
+		t.Errorf("CreateVolume Encrypted = false, want true")
+	}
+	if aws.ToInt32(cre.Iops) != 4000 {
+		t.Errorf("CreateVolume Iops = %d, want 4000", aws.ToInt32(cre.Iops))
+	}
+	if aws.ToInt32(cre.Throughput) != 250 {
+		t.Errorf("CreateVolume Throughput = %d, want 250", aws.ToInt32(cre.Throughput))
+	}
+	if aws.ToString(cre.KmsKeyId) != kmsKey {
+		t.Errorf("CreateVolume KmsKeyId = %q, want %q", aws.ToString(cre.KmsKeyId), kmsKey)
+	}
+
+	desc, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		VolumeIds: []string{aws.ToString(cre.VolumeId)},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVolumes: %v", err)
+	}
+	if len(desc.Volumes) != 1 {
+		t.Fatalf("DescribeVolumes = %d, want 1", len(desc.Volumes))
+	}
+
+	v := desc.Volumes[0]
+	if !aws.ToBool(v.Encrypted) || aws.ToInt32(v.Iops) != 4000 ||
+		aws.ToInt32(v.Throughput) != 250 || aws.ToString(v.KmsKeyId) != kmsKey {
+		t.Errorf("DescribeVolumes dropped attributes: encrypted=%v iops=%d throughput=%d kms=%q",
+			aws.ToBool(v.Encrypted), aws.ToInt32(v.Iops), aws.ToInt32(v.Throughput), aws.ToString(v.KmsKeyId))
+	}
+}
+
+// TestDescribeVolumesHonoursTagFilter pins that a tag:Name filter narrows the
+// result set instead of being ignored (which returned every volume).
+func TestDescribeVolumesHonoursTagFilter(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	mk := func(name string) {
+		if _, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+			AvailabilityZone: aws.String("us-east-1a"),
+			Size:             aws.Int32(10),
+			TagSpecifications: []ec2types.TagSpecification{{
+				ResourceType: ec2types.ResourceTypeVolume,
+				Tags:         []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String(name)}},
+			}},
+		}); err != nil {
+			t.Fatalf("CreateVolume(%s): %v", name, err)
+		}
+	}
+
+	mk("keep")
+	mk("other")
+
+	out, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("tag:Name"), Values: []string{"keep"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVolumes: %v", err)
+	}
+	if len(out.Volumes) != 1 {
+		t.Fatalf("tag:Name=keep returned %d volumes, want 1", len(out.Volumes))
+	}
+
+	none, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("tag:Name"), Values: []string{"nomatch"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVolumes(nomatch): %v", err)
+	}
+	if len(none.Volumes) != 0 {
+		t.Fatalf("tag:Name=nomatch returned %d volumes, want 0", len(none.Volumes))
+	}
+}
+
+// TestDescribeVolumeStatusReturnsOK pins that the previously-undispatched
+// DescribeVolumeStatus action reports a status for an existing volume.
+func TestDescribeVolumeStatusReturnsOK(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	cre, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(8),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+
+	out, err := client.DescribeVolumeStatus(ctx, &ec2.DescribeVolumeStatusInput{
+		VolumeIds: []string{aws.ToString(cre.VolumeId)},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVolumeStatus: %v", err)
+	}
+	if len(out.VolumeStatuses) != 1 {
+		t.Fatalf("VolumeStatuses = %d, want 1", len(out.VolumeStatuses))
+	}
+	if got := out.VolumeStatuses[0].VolumeStatus.Status; got != ec2types.VolumeStatusInfoStatusOk {
+		t.Errorf("volume status = %q, want ok", got)
+	}
+}

--- a/server/aws/ec2/vpc.go
+++ b/server/aws/ec2/vpc.go
@@ -13,6 +13,10 @@ import (
 // and most VPC resources in AWS.
 const stateAvailable = "available"
 
+// dhcpDefault is the id EC2 reports for a VPC using the Amazon-provided DHCP
+// option set (no explicit set associated).
+const dhcpDefault = "default"
+
 type vpcXML struct {
 	VpcID           string    `xml:"vpcId"`
 	State           string    `xml:"state"`
@@ -20,6 +24,7 @@ type vpcXML struct {
 	DhcpOptionsID   string    `xml:"dhcpOptionsId"`
 	InstanceTenancy string    `xml:"instanceTenancy"`
 	IsDefault       bool      `xml:"isDefault"`
+	OwnerID         string    `xml:"ownerId"`
 	Tags            []tagItem `xml:"tagSet>item,omitempty"`
 }
 
@@ -76,7 +81,7 @@ func (h *Handler) deleteVpc(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // per-resource describe pattern; siblings in subnet/sg/igw/route_table
+//nolint:dupl // per-resource describe+filter pattern; sibling in internet_gateway
 func (h *Handler) describeVpcs(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "VpcId")
 
@@ -86,15 +91,16 @@ func (h *Handler) describeVpcs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]vpcXML, 0, len(vpcs))
-	for i := range vpcs {
-		out = append(out, toVpcXML(&vpcs[i]))
+	filters := awsquery.Filters(r.Form)
+	if err := validateVpcFilters(filters); err != nil {
+		writeVPCErr(w, err)
+		return
 	}
 
 	awsquery.WriteXMLResponse(w, describeVpcsResponseXML{
 		Xmlns:     awsquery.Namespace,
 		RequestID: awsquery.RequestID,
-		VpcSet:    out,
+		VpcSet:    filterXML(vpcs, filters, vpcMatchesFilters, toVpcXML),
 	})
 }
 
@@ -108,10 +114,55 @@ func toVpcXML(v *netdriver.VPCInfo) vpcXML {
 		VpcID:           v.ID,
 		State:           state,
 		CidrBlock:       v.CIDRBlock,
-		DhcpOptionsID:   "default",
+		DhcpOptionsID:   nonEmpty(v.DhcpOptionsID, dhcpDefault),
 		InstanceTenancy: "default",
 		IsDefault:       false,
+		OwnerID:         ownerID,
 		Tags:            toTagItems(v.Tags),
+	}
+}
+
+// validateVpcFilters rejects filter names DescribeVpcs does not model. Silently
+// matching nothing would tell a data-source lookup the VPC is absent.
+func validateVpcFilters(filters []awsquery.Filter) error {
+	var probe netdriver.VPCInfo
+
+	for _, f := range filters {
+		if _, known := vpcFilterMatch(&probe, f); !known {
+			return newInvalidParameterErr("The filter '" + f.Name + "' is invalid")
+		}
+	}
+
+	return nil
+}
+
+func vpcMatchesFilters(v *netdriver.VPCInfo, filters []awsquery.Filter) bool {
+	for _, f := range filters {
+		if matched, _ := vpcFilterMatch(v, f); !matched {
+			return false
+		}
+	}
+
+	return true
+}
+
+// vpcFilterMatch reports whether v satisfies filter f and whether f is a filter
+// DescribeVpcs recognizes. Keeping the two answers in one function means each
+// filter name is written exactly once.
+func vpcFilterMatch(v *netdriver.VPCInfo, f awsquery.Filter) (matched, known bool) {
+	switch f.Name {
+	case filterVPCID:
+		return containsString(f.Values, v.ID), true
+	case filterCIDR, filterCIDRBlock, "cidr-block-association.cidr-block":
+		return containsString(f.Values, v.CIDRBlock), true
+	case filterState:
+		return containsString(f.Values, nonEmpty(v.State, stateAvailable)), true
+	case "dhcp-options-id":
+		return containsString(f.Values, nonEmpty(v.DhcpOptionsID, dhcpDefault)), true
+	case "isDefault", "is-default":
+		return containsString(f.Values, boolFilterValue(false)), true
+	default:
+		return tagFilterMatch(f.Name, f.Values, v.Tags)
 	}
 }
 

--- a/server/aws/ec2/vpc_describe_test.go
+++ b/server/aws/ec2/vpc_describe_test.go
@@ -1,0 +1,147 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestDescribeVpcsCIDRFilterNarrows pins that DescribeVpcs honors the cidr filter,
+// returning only the matching VPC instead of every VPC. This is the Terraform /
+// CLI data-source lookup the audit flagged as broken.
+func TestDescribeVpcsCIDRFilterNarrows(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	vpcA := mkVPC(ctx, t, c, "10.0.0.0/16")
+	mkVPC(ctx, t, c, "10.1.0.0/16")
+
+	out, err := c.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("cidr"), Values: []string{"10.0.0.0/16"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVpcs: %v", err)
+	}
+
+	if len(out.Vpcs) != 1 || aws.ToString(out.Vpcs[0].VpcId) != vpcA {
+		t.Fatalf("cidr filter returned %d vpcs, want only %s", len(out.Vpcs), vpcA)
+	}
+
+	if got := aws.ToString(out.Vpcs[0].OwnerId); got != "123456789012" {
+		t.Errorf("VPC OwnerId = %q, want 123456789012", got)
+	}
+}
+
+// TestDescribeVpcsTagFilter pins the tag:<key> filter on DescribeVpcs.
+func TestDescribeVpcsTagFilter(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	tagged, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{
+		CidrBlock: aws.String("10.2.0.0/16"),
+		TagSpecifications: []ec2types.TagSpecification{{
+			ResourceType: ec2types.ResourceTypeVpc,
+			Tags:         []ec2types.Tag{{Key: aws.String("Env"), Value: aws.String("prod")}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	mkVPC(ctx, t, c, "10.3.0.0/16")
+
+	out, err := c.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("tag:Env"), Values: []string{"prod"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVpcs(tag): %v", err)
+	}
+
+	if len(out.Vpcs) != 1 || aws.ToString(out.Vpcs[0].VpcId) != aws.ToString(tagged.Vpc.VpcId) {
+		t.Fatalf("tag filter returned %d vpcs, want only the tagged one", len(out.Vpcs))
+	}
+}
+
+// TestAssociateDhcpOptionsReflectedOnVpc pins that AssociateDhcpOptions actually
+// changes the VPC's dhcpOptionsId, rather than the VPC forever reporting
+// "default".
+func TestAssociateDhcpOptionsReflectedOnVpc(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	vpcID := mkVPC(ctx, t, c, "10.0.0.0/16")
+
+	opts, err := c.CreateDhcpOptions(ctx, &ec2.CreateDhcpOptionsInput{
+		DhcpConfigurations: []ec2types.NewDhcpConfiguration{{
+			Key:    aws.String("domain-name-servers"),
+			Values: []string{"10.0.0.2"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateDhcpOptions: %v", err)
+	}
+
+	doptID := aws.ToString(opts.DhcpOptions.DhcpOptionsId)
+
+	if _, err := c.AssociateDhcpOptions(ctx, &ec2.AssociateDhcpOptionsInput{
+		DhcpOptionsId: aws.String(doptID),
+		VpcId:         aws.String(vpcID),
+	}); err != nil {
+		t.Fatalf("AssociateDhcpOptions: %v", err)
+	}
+
+	out, err := c.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{VpcIds: []string{vpcID}})
+	if err != nil {
+		t.Fatalf("DescribeVpcs: %v", err)
+	}
+
+	if got := aws.ToString(out.Vpcs[0].DhcpOptionsId); got != doptID {
+		t.Fatalf("VPC DhcpOptionsId = %q, want %q", got, doptID)
+	}
+}
+
+// TestDescribeInternetGatewaysAttachmentFilter pins the attachment.vpc-id filter
+// and the ownerId field on internet gateways.
+func TestDescribeInternetGatewaysAttachmentFilter(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	vpcID := mkVPC(ctx, t, c, "10.0.0.0/16")
+
+	igw, err := c.CreateInternetGateway(ctx, &ec2.CreateInternetGatewayInput{})
+	if err != nil {
+		t.Fatalf("CreateInternetGateway: %v", err)
+	}
+
+	igwID := aws.ToString(igw.InternetGateway.InternetGatewayId)
+
+	if _, err := c.AttachInternetGateway(ctx, &ec2.AttachInternetGatewayInput{
+		InternetGatewayId: aws.String(igwID),
+		VpcId:             aws.String(vpcID),
+	}); err != nil {
+		t.Fatalf("AttachInternetGateway: %v", err)
+	}
+
+	// A second, unattached IGW must be filtered out by attachment.vpc-id.
+	if _, err := c.CreateInternetGateway(ctx, &ec2.CreateInternetGatewayInput{}); err != nil {
+		t.Fatalf("CreateInternetGateway(2): %v", err)
+	}
+
+	out, err := c.DescribeInternetGateways(ctx, &ec2.DescribeInternetGatewaysInput{
+		Filters: []ec2types.Filter{{Name: aws.String("attachment.vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeInternetGateways: %v", err)
+	}
+
+	if len(out.InternetGateways) != 1 || aws.ToString(out.InternetGateways[0].InternetGatewayId) != igwID {
+		t.Fatalf("attachment.vpc-id filter returned %d gateways, want only %s", len(out.InternetGateways), igwID)
+	}
+
+	if got := aws.ToString(out.InternetGateways[0].OwnerId); got != "123456789012" {
+		t.Errorf("IGW OwnerId = %q, want 123456789012", got)
+	}
+}

--- a/server/aws/ec2/vpc_peering_test.go
+++ b/server/aws/ec2/vpc_peering_test.go
@@ -1,0 +1,123 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+// TestVpcPeeringVpcInfoRoundTrip pins that DescribeVpcPeeringConnections fills
+// the requester/accepter VpcInfo (ownerId, cidrBlock, region) and a status
+// message. Terraform's aws_vpc_peering_connection reads accepter/requester CIDR
+// and owner id off these blocks; empty values leave the resource unable to
+// compute its cross-account/cross-region attributes.
+func TestVpcPeeringVpcInfoRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	reqVPC := mkPeeringVPC(t, c, "10.0.0.0/16")
+	accVPC := mkPeeringVPC(t, c, "10.1.0.0/16")
+
+	created, err := c.CreateVpcPeeringConnection(ctx, &ec2.CreateVpcPeeringConnectionInput{
+		VpcId:     aws.String(reqVPC),
+		PeerVpcId: aws.String(accVPC),
+	})
+	if err != nil {
+		t.Fatalf("CreateVpcPeeringConnection: %v", err)
+	}
+
+	pcxID := aws.ToString(created.VpcPeeringConnection.VpcPeeringConnectionId)
+
+	desc, err := c.DescribeVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
+		VpcPeeringConnectionIds: []string{pcxID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVpcPeeringConnections: %v", err)
+	}
+
+	if len(desc.VpcPeeringConnections) != 1 {
+		t.Fatalf("DescribeVpcPeeringConnections = %d, want 1", len(desc.VpcPeeringConnections))
+	}
+
+	pcx := desc.VpcPeeringConnections[0]
+
+	req := pcx.RequesterVpcInfo
+	if aws.ToString(req.VpcId) != reqVPC {
+		t.Errorf("requester vpcId = %q, want %q", aws.ToString(req.VpcId), reqVPC)
+	}
+
+	if aws.ToString(req.CidrBlock) != "10.0.0.0/16" {
+		t.Errorf("requester cidrBlock = %q, want 10.0.0.0/16", aws.ToString(req.CidrBlock))
+	}
+
+	if aws.ToString(req.OwnerId) == "" {
+		t.Error("requester ownerId is empty")
+	}
+
+	if aws.ToString(req.Region) != "us-east-1" {
+		t.Errorf("requester region = %q, want us-east-1", aws.ToString(req.Region))
+	}
+
+	if aws.ToString(pcx.AccepterVpcInfo.CidrBlock) != "10.1.0.0/16" {
+		t.Errorf("accepter cidrBlock = %q, want 10.1.0.0/16", aws.ToString(pcx.AccepterVpcInfo.CidrBlock))
+	}
+
+	if aws.ToString(pcx.Status.Message) == "" {
+		t.Errorf("status message is empty; code=%q", string(pcx.Status.Code))
+	}
+}
+
+// TestRejectVpcPeeringConnection pins that the previously-undispatched
+// RejectVpcPeeringConnection action reaches the driver and moves the connection
+// to the rejected state.
+func TestRejectVpcPeeringConnection(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	reqVPC := mkPeeringVPC(t, c, "10.0.0.0/16")
+	accVPC := mkPeeringVPC(t, c, "10.2.0.0/16")
+
+	created, err := c.CreateVpcPeeringConnection(ctx, &ec2.CreateVpcPeeringConnectionInput{
+		VpcId:     aws.String(reqVPC),
+		PeerVpcId: aws.String(accVPC),
+	})
+	if err != nil {
+		t.Fatalf("CreateVpcPeeringConnection: %v", err)
+	}
+
+	pcxID := aws.ToString(created.VpcPeeringConnection.VpcPeeringConnectionId)
+
+	if _, err := c.RejectVpcPeeringConnection(ctx, &ec2.RejectVpcPeeringConnectionInput{
+		VpcPeeringConnectionId: aws.String(pcxID),
+	}); err != nil {
+		t.Fatalf("RejectVpcPeeringConnection: %v", err)
+	}
+
+	desc, err := c.DescribeVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
+		VpcPeeringConnectionIds: []string{pcxID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVpcPeeringConnections: %v", err)
+	}
+
+	if len(desc.VpcPeeringConnections) != 1 {
+		t.Fatalf("DescribeVpcPeeringConnections = %d, want 1", len(desc.VpcPeeringConnections))
+	}
+
+	if got := string(desc.VpcPeeringConnections[0].Status.Code); got != "rejected" {
+		t.Errorf("status code = %q, want rejected", got)
+	}
+}
+
+func mkPeeringVPC(t *testing.T, c *ec2.Client, cidr string) string {
+	t.Helper()
+
+	vpc, err := c.CreateVpc(context.Background(), &ec2.CreateVpcInput{CidrBlock: aws.String(cidr)})
+	if err != nil {
+		t.Fatalf("CreateVpc(%s): %v", cidr, err)
+	}
+
+	return aws.ToString(vpc.Vpc.VpcId)
+}

--- a/server/aws/ec2/xml.go
+++ b/server/aws/ec2/xml.go
@@ -158,6 +158,28 @@ type modifyInstanceAttributeResponse struct {
 	Return    bool     `xml:"return"`
 }
 
+// attributeBooleanValueXML / attributeValueXML wrap a single attribute value in
+// DescribeInstanceAttribute responses. The SDK reads the nested <value>.
+type attributeBooleanValueXML struct {
+	Value bool `xml:"value"`
+}
+
+type attributeValueXML struct {
+	Value string `xml:"value"`
+}
+
+// describeInstanceAttributeResponse carries exactly one requested attribute
+// (the others stay nil / omitted), matching real EC2's per-attribute response.
+type describeInstanceAttributeResponse struct {
+	XMLName               xml.Name                  `xml:"DescribeInstanceAttributeResponse"`
+	Xmlns                 string                    `xml:"xmlns,attr"`
+	RequestID             string                    `xml:"requestId"`
+	InstanceID            string                    `xml:"instanceId"`
+	DisableAPITermination *attributeBooleanValueXML `xml:"disableApiTermination,omitempty"`
+	SourceDestCheck       *attributeBooleanValueXML `xml:"sourceDestCheck,omitempty"`
+	InstanceType          *attributeValueXML        `xml:"instanceType,omitempty"`
+}
+
 // getConsoleOutputResponse carries the base64-encoded console output for an
 // instance. Output mirrors real EC2's base64 <output> field.
 type getConsoleOutputResponse struct {

--- a/server/aws/ec2_test.go
+++ b/server/aws/ec2_test.go
@@ -1269,11 +1269,13 @@ func TestEC2AuthorizeEgress(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// A new SG already carries the default allow-all egress rule, so add a
+	// distinct rule (real AWS rejects re-adding the default as a duplicate).
 	_, err = client.AuthorizeSecurityGroupEgress(ctx, &ec2.AuthorizeSecurityGroupEgressInput{
 		GroupId: sg.GroupId,
 		IpPermissions: []ec2types.IpPermission{{
-			IpProtocol: aws.String("-1"), FromPort: aws.Int32(0), ToPort: aws.Int32(0),
-			IpRanges: []ec2types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
+			IpProtocol: aws.String("tcp"), FromPort: aws.Int32(443), ToPort: aws.Int32(443),
+			IpRanges: []ec2types.IpRange{{CidrIp: aws.String("10.0.0.0/16")}},
 		}},
 	})
 	require.NoError(t, err)
@@ -1282,7 +1284,7 @@ func TestEC2AuthorizeEgress(t *testing.T) {
 		GroupIds: []string{aws.ToString(sg.GroupId)},
 	})
 	require.NoError(t, err)
-	assert.Len(t, desc.SecurityGroups[0].IpPermissionsEgress, 1)
+	assert.Len(t, desc.SecurityGroups[0].IpPermissionsEgress, 2)
 }
 
 func TestEC2DeleteSecurityGroup(t *testing.T) {

--- a/services/compute/compute.go
+++ b/services/compute/compute.go
@@ -362,6 +362,8 @@ func (c *Compute) ListLaunchTemplates(ctx context.Context) ([]driver.LaunchTempl
 }
 
 // CreateVolume creates a new block storage volume.
+//
+//nolint:gocritic // hugeParam: config passed by value to match driver.Compute interface pattern
 func (c *Compute) CreateVolume(ctx context.Context, cfg driver.VolumeConfig) (*driver.VolumeInfo, error) {
 	out, err := c.do(ctx, "CreateVolume", cfg, func() (any, error) { return c.driver.CreateVolume(ctx, cfg) })
 	if err != nil {

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -184,6 +184,13 @@ type VolumeConfig struct {
 	// Tier is the performance tier (Azure P10/P4, or a storage tier name),
 	// echoed as properties.tier / sku.tier for cost tiering.
 	Tier string
+	// Encrypted requests an encrypted volume (AWS EBS). Echoed back so
+	// Terraform's aws_ebs_volume does not see perpetual drift.
+	Encrypted bool
+	// SnapshotID is the source snapshot the volume is restored from, when set.
+	SnapshotID string
+	// KmsKeyID is the KMS key protecting the volume's encryption key, when set.
+	KmsKeyID string
 }
 
 // VolumeInfo describes a block storage volume.
@@ -203,6 +210,12 @@ type VolumeInfo struct {
 	Throughput int
 	// Tier is the performance tier (e.g. Azure P10/P4), when set.
 	Tier string
+	// Encrypted indicates the volume is encrypted (AWS EBS).
+	Encrypted bool
+	// SnapshotID is the source snapshot the volume was restored from, when set.
+	SnapshotID string
+	// KmsKeyID is the KMS key protecting the volume's encryption key, when set.
+	KmsKeyID string
 }
 
 // SnapshotConfig describes a snapshot to create.
@@ -221,6 +234,12 @@ type SnapshotInfo struct {
 	Size        int
 	CreatedAt   string
 	Tags        map[string]string
+	// OwnerID is the account that owns the snapshot (AWS ownerId).
+	OwnerID string
+	// Progress is the completion percentage (e.g. "100%"), for waiters.
+	Progress string
+	// Encrypted indicates the snapshot is encrypted.
+	Encrypted bool
 }
 
 // ImageConfig describes a machine image to create.
@@ -239,6 +258,33 @@ type ImageInfo struct {
 	Description string
 	CreatedAt   string
 	Tags        map[string]string
+	// OwnerID is the account that owns the image (AWS imageOwnerId).
+	OwnerID string
+	// Architecture is the CPU architecture (e.g. "x86_64", "arm64").
+	Architecture string
+	// RootDeviceType is "ebs" or "instance-store".
+	RootDeviceType string
+	// RootDeviceName is the root device (e.g. "/dev/sda1").
+	RootDeviceName string
+	// VirtualizationType is "hvm" or "paravirtual".
+	VirtualizationType string
+	// Hypervisor is "xen" or "ovm".
+	Hypervisor string
+	// ImageType is "machine", "kernel", or "ramdisk".
+	ImageType string
+	// PlatformDetails is the billing platform detail (e.g. "Linux/UNIX").
+	PlatformDetails string
+	// BlockDeviceMappings are the image's block device mappings.
+	BlockDeviceMappings []ImageBlockDeviceMapping
+}
+
+// ImageBlockDeviceMapping is one entry in an image's block device mapping set.
+type ImageBlockDeviceMapping struct {
+	DeviceName          string
+	SnapshotID          string
+	VolumeSize          int
+	VolumeType          string
+	DeleteOnTermination bool
 }
 
 // KeyPairConfig describes a key pair to create.

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -100,12 +100,24 @@ type NATGateway struct {
 	State     string // "pending", "available", "deleting", "deleted", "failed"
 	CreatedAt string
 	Tags      map[string]string
+	// AllocationID is the Elastic IP allocation bound to a public NAT gateway;
+	// PrivateIP and NetworkInterfaceID describe the ENI it occupies. These
+	// populate the NatGatewayAddress set AWS returns. ConnectivityType is
+	// "public" or "private".
+	AllocationID       string
+	PrivateIP          string
+	NetworkInterfaceID string
+	ConnectivityType   string
 }
 
 // NATGatewayConfig configures a NAT gateway.
 type NATGatewayConfig struct {
 	SubnetID string
 	Tags     map[string]string
+	// AllocationID echoes the Elastic IP the caller bound to a public NAT
+	// gateway; ConnectivityType selects "public" (default) or "private".
+	AllocationID     string
+	ConnectivityType string
 }
 
 // FlowLog represents a VPC flow log configuration.

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -19,6 +19,9 @@ type VPCInfo struct {
 	// EC2 defaults DNS support on and DNS hostnames off for a new VPC.
 	EnableDNSSupport   bool
 	EnableDNSHostnames bool
+	// DhcpOptionsID is the DHCP option set associated with the VPC. Empty means
+	// the Amazon-provided default set; AssociateDhcpOptions changes it.
+	DhcpOptionsID string
 }
 
 // SubnetConfig describes a subnet to create.
@@ -37,6 +40,11 @@ type SubnetInfo struct {
 	AvailabilityZone string
 	State            string
 	Tags             map[string]string
+	// MapPublicIPOnLaunch reports whether instances launched into the subnet
+	// receive a public IPv4 address by default. Real EC2 defaults it off for a
+	// non-default subnet and lets ModifySubnetAttribute flip it — the only way
+	// to turn a subnet public.
+	MapPublicIPOnLaunch bool
 }
 
 // SecurityGroupConfig describes a security group to create.
@@ -374,6 +382,21 @@ type VPCAttributeUpdate struct {
 // than forcing them to carry a method they cannot implement meaningfully.
 type VPCAttributes interface {
 	ModifyVPCAttribute(ctx context.Context, id string, update VPCAttributeUpdate) error
+}
+
+// SubnetAttributeUpdate carries the subnet attributes a caller wants changed. A
+// nil pointer leaves that attribute alone, matching an API that accepts one
+// attribute per ModifySubnetAttribute call.
+type SubnetAttributeUpdate struct {
+	MapPublicIPOnLaunch *bool
+}
+
+// SubnetAttributes is an OPTIONAL capability, discovered by type assertion.
+// Per-subnet launch attributes (map-public-ip-on-launch) are an AWS concept;
+// kept out of the Networking interface so providers that do not model them are
+// not forced to carry an implementation.
+type SubnetAttributes interface {
+	ModifySubnetAttribute(ctx context.Context, id string, update SubnetAttributeUpdate) error
 }
 
 // NetworkInterfaces is an OPTIONAL capability, discovered by type assertion.


### PR DESCRIPTION
Closes 34 of the 55 EC2 audit findings, integrated from 5 area-aligned work streams (instances, storage, security-groups, vpc/subnet, routing/edge). Wire+provider only where possible.

**Instances** — ModifyInstanceAttribute (DisableApiTermination/SourceDestCheck) + termination protection; DescribeInstanceAttribute; instance-status reachability details; tag ops NotFound; derived previousState.
**Storage** — CreateVolume/DescribeVolumes echo Iops/Throughput/Encrypted/SnapshotId/KmsKeyId; Describe filters (tag/tag-key/resource fields); DescribeImages device/owner/virtualization fields; real key-pair ids + usable PEM + fingerprints; CreateImage backing snapshot; NotFound codes; snapshot OwnerId/Progress; InvalidKeyPair.Duplicate; ModifySnapshotAttribute/DescribeImageAttribute/DescribeVolumeStatus dispatched.
**Security groups** — Describe filters + unknown-filter rejection; duplicate-name InvalidGroup.Duplicate; duplicate-rule InvalidPermission.Duplicate; CreateSecurityGroup tagSet.
**VPC/subnet** — VPC/subnet/IGW filters; ModifySubnetAttribute (optional interface); DhcpOptionsID + MapPublicIpOnLaunch identity fields.
**Routing/edge** — NAT address set, peering VpcInfo, local route, IGW state, NACL replace, prefix-list ARN.

Deferred (flagged): launch-template versioning, RunInstances ClientToken idempotency, ModifyVolume/CopySnapshot/RegisterImage/ImportKeyPair (need new driver methods), reservation pagination, async lifecycle transitions.

Optional type-asserted interfaces added (SetInstanceAttribute, SubnetAttributes) — AWS Mock only, Azure/GCP/OCI unaffected; compat suite + docs clean. SDK round-trip tests per fix. All 228 server/provider/root packages + all 3 compat suites pass.