### PR TITLE
fix(sqs): dispatch AddPermission/RemovePermission

### DIFF
--- a/providers/aws/sqs/permissions.go
+++ b/providers/aws/sqs/permissions.go
@@ -1,0 +1,150 @@
+package sqs
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+)
+
+// AddPermission adds an Allow statement (Sid=label) granting the given accounts
+// the given SQS actions on the queue, mutating the stored access policy. It is
+// AWS-specific and used directly by the SQS wire handler.
+func (m *Mock) AddPermission(_ context.Context, queueURL, label string, accountIDs, actions []string) error {
+	qd, ok := m.queues.Get(queueURL)
+	if !ok {
+		return errors.Newf(errors.NotFound, "queue %q not found", queueURL)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	doc, err := queuePolicyDoc(qd)
+	if err != nil {
+		return errors.Newf(errors.InvalidArgument, "queue policy is not valid JSON: %v", err)
+	}
+
+	for i := range doc.Statement {
+		if doc.Statement[i].Sid == label {
+			return errors.Newf(errors.InvalidArgument, "label %q already exists", label)
+		}
+	}
+
+	principals := make([]string, 0, len(accountIDs))
+	for _, acct := range accountIDs {
+		principals = append(principals, "arn:aws:iam::"+acct+":root")
+	}
+
+	qualified := make([]string, 0, len(actions))
+	for _, a := range actions {
+		qualified = append(qualified, "SQS:"+a)
+	}
+
+	doc.Statement = append(doc.Statement, policyStatement{
+		Sid:       label,
+		Effect:    "Allow",
+		Principal: map[string]any{"AWS": principals},
+		Action:    qualified,
+		Resource:  qd.info.ARN,
+	})
+
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		return errors.Newf(errors.Internal, "encode policy: %v", err)
+	}
+
+	qd.policy = string(encoded)
+	qd.lastModifiedAt = m.opts.Clock.Now()
+
+	return nil
+}
+
+// RemovePermission removes the statement whose Sid equals label. It is
+// AWS-specific and used directly by the SQS wire handler.
+func (m *Mock) RemovePermission(_ context.Context, queueURL, label string) error {
+	qd, ok := m.queues.Get(queueURL)
+	if !ok {
+		return errors.Newf(errors.NotFound, "queue %q not found", queueURL)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	if qd.policy == "" {
+		return errors.Newf(errors.InvalidArgument, "label %q not found", label)
+	}
+
+	doc, err := decodeQueuePolicy(qd.policy)
+	if err != nil {
+		return errors.Newf(errors.InvalidArgument, "queue policy is not valid JSON: %v", err)
+	}
+
+	kept := doc.Statement[:0]
+	removed := false
+
+	for _, st := range doc.Statement {
+		if st.Sid == label {
+			removed = true
+			continue
+		}
+
+		kept = append(kept, st)
+	}
+
+	if !removed {
+		return errors.Newf(errors.InvalidArgument, "label %q not found", label)
+	}
+
+	doc.Statement = kept
+
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		return errors.Newf(errors.Internal, "encode policy: %v", err)
+	}
+
+	qd.policy = string(encoded)
+	qd.lastModifiedAt = m.opts.Clock.Now()
+
+	return nil
+}
+
+// policyDoc / policyStatement model just enough of an SQS access policy to add
+// and remove statements while round-tripping unknown fields verbatim.
+type policyDoc struct {
+	Version   string            `json:"Version"`
+	ID        string            `json:"Id,omitempty"`
+	Statement []policyStatement `json:"Statement"`
+}
+
+type policyStatement struct {
+	Sid       string         `json:"Sid,omitempty"`
+	Effect    string         `json:"Effect"`
+	Principal any            `json:"Principal,omitempty"`
+	Action    any            `json:"Action,omitempty"`
+	Resource  any            `json:"Resource,omitempty"`
+	Condition map[string]any `json:"Condition,omitempty"`
+}
+
+func decodeQueuePolicy(s string) (*policyDoc, error) {
+	var doc policyDoc
+	if err := json.Unmarshal([]byte(s), &doc); err != nil {
+		return nil, err
+	}
+
+	return &doc, nil
+}
+
+// queuePolicyDoc returns the queue's stored policy as a decoded document, or a
+// fresh default document when none is stored (matching SQS AddPermission, which
+// seeds a default policy id derived from the queue ARN).
+func queuePolicyDoc(qd *queueData) (*policyDoc, error) {
+	if qd.policy != "" {
+		return decodeQueuePolicy(qd.policy)
+	}
+
+	return &policyDoc{
+		Version:   "2008-10-17",
+		ID:        qd.info.ARN + "/SQSDefaultPolicy",
+		Statement: []policyStatement{},
+	}, nil
+}

--- a/server/aws/sqs/handler.go
+++ b/server/aws/sqs/handler.go
@@ -83,6 +83,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.untagQueue(w, r)
 	case "ListQueueTags":
 		h.listQueueTags(w, r)
+	case "AddPermission":
+		h.addPermission(w, r)
+	case "RemovePermission":
+		h.removePermission(w, r)
 	default:
 		wire.WriteJSONError(w, http.StatusBadRequest,
 			"UnknownOperationException", "unknown operation: "+op)
@@ -653,6 +657,63 @@ type attrConfigurator interface {
 // dlqSourceLister exposes ListDeadLetterSourceQueues (AWS-specific).
 type dlqSourceLister interface {
 	ListDeadLetterSourceQueues(ctx context.Context, dlqURL string) ([]string, error)
+}
+
+// queuePermissioner exposes the SQS AddPermission/RemovePermission access-policy
+// surface (AWS-specific). The handler type-asserts for it.
+type queuePermissioner interface {
+	AddPermission(ctx context.Context, queueURL, label string, accountIDs, actions []string) error
+	RemovePermission(ctx context.Context, queueURL, label string) error
+}
+
+func (h *Handler) addPermission(w http.ResponseWriter, r *http.Request) {
+	perm, ok := h.mq.(queuePermissioner)
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "AddPermission not supported"))
+		return
+	}
+
+	var req struct {
+		QueueURL      string   `json:"QueueUrl"`
+		Label         string   `json:"Label"`
+		AWSAccountIDs []string `json:"AWSAccountIds"`
+		Actions       []string `json:"Actions"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := perm.AddPermission(r.Context(), req.QueueURL, req.Label, req.AWSAccountIDs, req.Actions); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
+}
+
+func (h *Handler) removePermission(w http.ResponseWriter, r *http.Request) {
+	perm, ok := h.mq.(queuePermissioner)
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "RemovePermission not supported"))
+		return
+	}
+
+	var req struct {
+		QueueURL string `json:"QueueUrl"`
+		Label    string `json:"Label"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := perm.RemovePermission(r.Context(), req.QueueURL, req.Label); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
 }
 
 // atoiAttr parses a string attribute as an int, returning 0 when absent or invalid.

--- a/server/aws/sqs/sdk_roundtrip_test.go
+++ b/server/aws/sqs/sdk_roundtrip_test.go
@@ -3,12 +3,14 @@ package sqs_test
 import (
 	"context"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 
 	"github.com/stackshy/cloudemu/v2"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
@@ -154,5 +156,64 @@ func TestSDKSQSDeleteQueue(t *testing.T) {
 		QueueName: aws.String("doomed"),
 	}); err == nil {
 		t.Fatal("GetQueueUrl after delete returned nil error, want QueueDoesNotExist")
+	}
+}
+
+func TestSDKSQSAddRemovePermission(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	q, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{
+		QueueName: aws.String("perm-q"),
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	if _, err := client.AddPermission(ctx, &awssqs.AddPermissionInput{
+		QueueUrl:      q.QueueUrl,
+		Label:         aws.String("grant-send"),
+		AWSAccountIds: []string{"123456789012"},
+		Actions:       []string{"SendMessage"},
+	}); err != nil {
+		t.Fatalf("AddPermission: %v", err)
+	}
+
+	attrs, err := client.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       q.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNamePolicy},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes: %v", err)
+	}
+
+	policy := attrs.Attributes["Policy"]
+	if policy == "" {
+		t.Fatal("Policy is empty after AddPermission")
+	}
+
+	for _, want := range []string{"grant-send", "SQS:SendMessage", "arn:aws:iam::123456789012:root"} {
+		if !strings.Contains(policy, want) {
+			t.Fatalf("Policy %q missing %q", policy, want)
+		}
+	}
+
+	if _, err := client.RemovePermission(ctx, &awssqs.RemovePermissionInput{
+		QueueUrl: q.QueueUrl,
+		Label:    aws.String("grant-send"),
+	}); err != nil {
+		t.Fatalf("RemovePermission: %v", err)
+	}
+
+	attrs2, err := client.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       q.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNamePolicy},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes after remove: %v", err)
+	}
+
+	if strings.Contains(attrs2.Attributes["Policy"], "grant-send") {
+		t.Fatalf("Policy still contains grant-send after RemovePermission: %q", attrs2.Attributes["Policy"])
 	}
 }


### PR DESCRIPTION
Adds AddPermission/RemovePermission wire dispatch + provider methods that build/mutate the queue access policy (Sid=Label, Effect Allow, Principal account-root ARNs, Action SQS:<action>, Resource=QueueArn). AWS-specific ops via a type-asserted queuePermissioner interface (matches the SNS/dlqSourceLister convention) — no portable driver change, compat clean. The other 8 sqs findings were already resolved by #463. SDK round-trip test asserts policy contents after Add and absence after Remove.