### PR TITLE
fix(cloudwatchlogs): paginate describes, stream ARN, real IngestionTime

### DIFF
--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -230,12 +230,28 @@ func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, eve
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	ingestedAt := m.opts.Clock.Now().UTC()
+
 	copied := make([]driver.LogEvent, len(events))
-	copy(copied, events)
+	for i := range events {
+		copied[i] = events[i]
+		copied[i].IngestionTime = ingestedAt
+	}
 
 	s.events = append(s.events, copied...)
 
 	if len(events) > 0 {
+		earliest := events[0].Timestamp
+		for i := range events {
+			if events[i].Timestamp.Before(earliest) {
+				earliest = events[i].Timestamp
+			}
+		}
+
+		if s.info.FirstEvent == "" {
+			s.info.FirstEvent = earliest.UTC().Format(time.RFC3339)
+		}
+
 		s.info.LastEvent = events[len(events)-1].Timestamp.UTC().Format(time.RFC3339)
 	}
 
@@ -414,9 +430,10 @@ func (*Mock) matchEvents(
 		}
 
 		results = append(results, driver.FilteredLogEvent{
-			LogStream: streamName,
-			Timestamp: e.Timestamp,
-			Message:   e.Message,
+			LogStream:     streamName,
+			Timestamp:     e.Timestamp,
+			IngestionTime: e.IngestionTime,
+			Message:       e.Message,
 		})
 	}
 

--- a/server/aws/cloudwatchlogs/operations.go
+++ b/server/aws/cloudwatchlogs/operations.go
@@ -1,13 +1,66 @@
 package cloudwatchlogs
 
 import (
-	"github.com/stackshy/cloudemu/v2/services/scope"
+	"encoding/base64"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
+
+// defaultDescribeLimit is the page size CloudWatch Logs applies to
+// DescribeLogGroups / DescribeLogStreams when the caller omits limit.
+const defaultDescribeLimit = 50
+
+// decodeOffsetToken parses a nextToken produced by encodeOffsetToken back into a
+// slice offset. An empty token means "start from the beginning"; a malformed
+// token is treated as offset 0 so a stray token never wedges pagination.
+func decodeOffsetToken(tok string) int {
+	if tok == "" {
+		return 0
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(tok)
+	if err != nil {
+		return 0
+	}
+
+	n, err := strconv.Atoi(string(raw))
+	if err != nil || n < 0 {
+		return 0
+	}
+
+	return n
+}
+
+// encodeOffsetToken renders a slice offset as an opaque nextToken.
+func encodeOffsetToken(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}
+
+// pageBounds resolves [start,end) and the next-page offset for a slice of the
+// given length, honoring a caller limit (falling back to defaultDescribeLimit).
+// next is 0 when no further page remains.
+func pageBounds(total, start int, limit int32) (from, to, next int) {
+	size := int(limit)
+	if size <= 0 {
+		size = defaultDescribeLimit
+	}
+
+	if start > total {
+		start = total
+	}
+
+	end := start + size
+	if end >= total {
+		return start, total, 0
+	}
+
+	return start, end, end
+}
 
 // --- log groups ---
 
@@ -41,17 +94,29 @@ func (h *Handler) describeLogGroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]logGroupJSON, 0, len(infos))
+	matched := make([]logdriver.LogGroupInfo, 0, len(infos))
 
 	for i := range infos {
 		if req.LogGroupNamePrefix != "" && !strings.HasPrefix(infos[i].Name, req.LogGroupNamePrefix) {
 			continue
 		}
 
-		out = append(out, toLogGroupJSON(&infos[i]))
+		matched = append(matched, infos[i])
 	}
 
-	wire.WriteJSON(w, describeLogGroupsResponse{LogGroups: out})
+	from, to, next := pageBounds(len(matched), decodeOffsetToken(req.NextToken), req.Limit)
+
+	out := make([]logGroupJSON, 0, to-from)
+	for i := from; i < to; i++ {
+		out = append(out, toLogGroupJSON(&matched[i]))
+	}
+
+	resp := describeLogGroupsResponse{LogGroups: out}
+	if next > 0 {
+		resp.NextToken = encodeOffsetToken(next)
+	}
+
+	wire.WriteJSON(w, resp)
 }
 
 func (h *Handler) deleteLogGroup(w http.ResponseWriter, r *http.Request) {
@@ -96,12 +161,26 @@ func (h *Handler) describeLogStreams(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]logStreamJSON, 0, len(infos))
-	for i := range infos {
-		out = append(out, toLogStreamJSON(&infos[i]))
+	// The stream ARN is derived from the owning group's ARN, which the driver
+	// carries on the group, not the stream.
+	groupARN := ""
+	if g, gerr := h.logs.GetLogGroup(r.Context(), req.LogGroupName); gerr == nil {
+		groupARN = g.ResourceID
 	}
 
-	wire.WriteJSON(w, describeLogStreamsResponse{LogStreams: out})
+	from, to, next := pageBounds(len(infos), decodeOffsetToken(req.NextToken), req.Limit)
+
+	out := make([]logStreamJSON, 0, to-from)
+	for i := from; i < to; i++ {
+		out = append(out, toLogStreamJSON(&infos[i], groupARN))
+	}
+
+	resp := describeLogStreamsResponse{LogStreams: out}
+	if next > 0 {
+		resp.NextToken = encodeOffsetToken(next)
+	}
+
+	wire.WriteJSON(w, resp)
 }
 
 func (h *Handler) deleteLogStream(w http.ResponseWriter, r *http.Request) {
@@ -167,7 +246,7 @@ func (h *Handler) getLogEvents(w http.ResponseWriter, r *http.Request) {
 		out = append(out, outputLogEvent{
 			Timestamp:     epochMillis(e.Timestamp),
 			Message:       e.Message,
-			IngestionTime: epochMillis(e.Timestamp),
+			IngestionTime: ingestionMillis(e.IngestionTime, e.Timestamp),
 		})
 	}
 
@@ -211,7 +290,7 @@ func (h *Handler) filterLogEvents(w http.ResponseWriter, r *http.Request) {
 			LogStreamName: e.LogStream,
 			Timestamp:     epochMillis(e.Timestamp),
 			Message:       e.Message,
-			IngestionTime: epochMillis(e.Timestamp),
+			IngestionTime: ingestionMillis(e.IngestionTime, e.Timestamp),
 		})
 	}
 

--- a/server/aws/cloudwatchlogs/sdk_roundtrip_test.go
+++ b/server/aws/cloudwatchlogs/sdk_roundtrip_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -194,6 +195,178 @@ func TestSDKPutAndGetLogEvents(t *testing.T) {
 		LogStreamName: aws.String("instance-1"),
 	}); err != nil {
 		t.Fatalf("DeleteLogStream: %v", err)
+	}
+}
+
+// TestSDKDescribeLogGroupsPagination guards that DescribeLogGroups honors Limit
+// and hands back a NextToken the SDK paginator can follow. Without pagination
+// the first page returns all groups and NextToken is nil, wedging the paginator.
+func TestSDKDescribeLogGroupsPagination(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	names := []string{"/page/a", "/page/b", "/page/c"}
+	for _, n := range names {
+		if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String(n)}); err != nil {
+			t.Fatalf("CreateLogGroup(%s): %v", n, err)
+		}
+	}
+
+	first, err := client.DescribeLogGroups(ctx, &cwl.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String("/page"),
+		Limit:              aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("DescribeLogGroups page 1: %v", err)
+	}
+
+	if len(first.LogGroups) != 2 {
+		t.Fatalf("page 1 = %d groups, want 2 (Limit ignored?)", len(first.LogGroups))
+	}
+
+	if aws.ToString(first.NextToken) == "" {
+		t.Fatalf("page 1 NextToken empty, want a token to fetch the third group")
+	}
+
+	second, err := client.DescribeLogGroups(ctx, &cwl.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String("/page"),
+		Limit:              aws.Int32(2),
+		NextToken:          first.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("DescribeLogGroups page 2: %v", err)
+	}
+
+	if len(second.LogGroups) != 1 || aws.ToString(second.LogGroups[0].LogGroupName) != "/page/c" {
+		t.Fatalf("page 2 = %+v, want one group /page/c", second.LogGroups)
+	}
+
+	if aws.ToString(second.NextToken) != "" {
+		t.Fatalf("page 2 NextToken = %q, want empty (pagination finished)", aws.ToString(second.NextToken))
+	}
+}
+
+// TestSDKDescribeLogStreamsArnAndPagination guards that log streams carry an ARN
+// (Terraform's aws_cloudwatch_log_stream reads it) and that DescribeLogStreams
+// honors Limit + NextToken.
+func TestSDKDescribeLogStreamsArnAndPagination(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String("/streams/grp")}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	for _, s := range []string{"s-a", "s-b", "s-c"} {
+		if _, err := client.CreateLogStream(ctx, &cwl.CreateLogStreamInput{
+			LogGroupName: aws.String("/streams/grp"), LogStreamName: aws.String(s),
+		}); err != nil {
+			t.Fatalf("CreateLogStream(%s): %v", s, err)
+		}
+	}
+
+	first, err := client.DescribeLogStreams(ctx, &cwl.DescribeLogStreamsInput{
+		LogGroupName: aws.String("/streams/grp"),
+		Limit:        aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("DescribeLogStreams page 1: %v", err)
+	}
+
+	if len(first.LogStreams) != 2 {
+		t.Fatalf("page 1 = %d streams, want 2 (Limit ignored?)", len(first.LogStreams))
+	}
+
+	arn := aws.ToString(first.LogStreams[0].Arn)
+	if !strings.HasPrefix(arn, "arn:aws:logs:") ||
+		!strings.Contains(arn, ":log-group:/streams/grp:log-stream:s-a") {
+		t.Fatalf("stream ARN = %q, want arn:aws:logs:...:log-group:/streams/grp:log-stream:s-a", arn)
+	}
+
+	if aws.ToString(first.NextToken) == "" {
+		t.Fatalf("page 1 NextToken empty, want a token for the third stream")
+	}
+
+	second, err := client.DescribeLogStreams(ctx, &cwl.DescribeLogStreamsInput{
+		LogGroupName: aws.String("/streams/grp"),
+		Limit:        aws.Int32(2),
+		NextToken:    first.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("DescribeLogStreams page 2: %v", err)
+	}
+
+	if len(second.LogStreams) != 1 || aws.ToString(second.LogStreams[0].LogStreamName) != "s-c" {
+		t.Fatalf("page 2 = %+v, want one stream s-c", second.LogStreams)
+	}
+}
+
+// TestSDKLogStreamFirstEventAndIngestionTime guards that a stream reports its
+// FirstEventTimestamp and that events carry a wall-clock IngestionTime distinct
+// from the caller's event timestamp. The event is stamped an hour in the past;
+// without the fix IngestionTime echoes that stale timestamp instead of "now".
+func TestSDKLogStreamFirstEventAndIngestionTime(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String("/ingest/grp")}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	if _, err := client.CreateLogStream(ctx, &cwl.CreateLogStreamInput{
+		LogGroupName: aws.String("/ingest/grp"), LogStreamName: aws.String("s1"),
+	}); err != nil {
+		t.Fatalf("CreateLogStream: %v", err)
+	}
+
+	eventTime := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	before := time.Now().UTC().Add(-time.Minute)
+
+	if _, err := client.PutLogEvents(ctx, &cwl.PutLogEventsInput{
+		LogGroupName:  aws.String("/ingest/grp"),
+		LogStreamName: aws.String("s1"),
+		LogEvents: []cwltypes.InputLogEvent{
+			{Timestamp: aws.Int64(eventTime.UnixMilli()), Message: aws.String("aged event")},
+		},
+	}); err != nil {
+		t.Fatalf("PutLogEvents: %v", err)
+	}
+
+	got, err := client.GetLogEvents(ctx, &cwl.GetLogEventsInput{
+		LogGroupName: aws.String("/ingest/grp"), LogStreamName: aws.String("s1"),
+	})
+	if err != nil {
+		t.Fatalf("GetLogEvents: %v", err)
+	}
+
+	if len(got.Events) != 1 {
+		t.Fatalf("got %d events, want 1", len(got.Events))
+	}
+
+	if aws.ToInt64(got.Events[0].Timestamp) != eventTime.UnixMilli() {
+		t.Fatalf("event timestamp = %d, want %d", aws.ToInt64(got.Events[0].Timestamp), eventTime.UnixMilli())
+	}
+
+	ingestion := aws.ToInt64(got.Events[0].IngestionTime)
+	if ingestion < before.UnixMilli() {
+		t.Fatalf("IngestionTime = %d, want a wall-clock time >= %d (not the stale event ts %d)",
+			ingestion, before.UnixMilli(), eventTime.UnixMilli())
+	}
+
+	streams, err := client.DescribeLogStreams(ctx, &cwl.DescribeLogStreamsInput{
+		LogGroupName: aws.String("/ingest/grp"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeLogStreams: %v", err)
+	}
+
+	if len(streams.LogStreams) != 1 {
+		t.Fatalf("got %d streams, want 1", len(streams.LogStreams))
+	}
+
+	if aws.ToInt64(streams.LogStreams[0].FirstEventTimestamp) != eventTime.UnixMilli() {
+		t.Fatalf("FirstEventTimestamp = %d, want %d",
+			aws.ToInt64(streams.LogStreams[0].FirstEventTimestamp), eventTime.UnixMilli())
 	}
 }
 

--- a/server/aws/cloudwatchlogs/types.go
+++ b/server/aws/cloudwatchlogs/types.go
@@ -16,6 +16,7 @@ type createLogGroupRequest struct {
 type describeLogGroupsRequest struct {
 	LogGroupNamePrefix string `json:"logGroupNamePrefix"`
 	Limit              int32  `json:"limit"`
+	NextToken          string `json:"nextToken"`
 }
 
 type deleteLogGroupRequest struct {
@@ -30,6 +31,7 @@ type createLogStreamRequest struct {
 type describeLogStreamsRequest struct {
 	LogGroupName string `json:"logGroupName"`
 	Limit        int32  `json:"limit"`
+	NextToken    string `json:"nextToken"`
 }
 
 type deleteLogStreamRequest struct {
@@ -80,18 +82,22 @@ type logGroupJSON struct {
 
 type describeLogGroupsResponse struct {
 	LogGroups []logGroupJSON `json:"logGroups"`
+	NextToken string         `json:"nextToken,omitempty"`
 }
 
 type logStreamJSON struct {
 	LogStreamName       string `json:"logStreamName"`
+	Arn                 string `json:"arn,omitempty"`
 	CreationTime        int64  `json:"creationTime"`
 	LastEventTimestamp  int64  `json:"lastEventTimestamp,omitempty"`
 	LastIngestionTime   int64  `json:"lastIngestionTime,omitempty"`
 	FirstEventTimestamp int64  `json:"firstEventTimestamp,omitempty"`
+	StoredBytes         int64  `json:"storedBytes"`
 }
 
 type describeLogStreamsResponse struct {
 	LogStreams []logStreamJSON `json:"logStreams"`
+	NextToken  string          `json:"nextToken,omitempty"`
 }
 
 type putLogEventsResponse struct {
@@ -131,6 +137,17 @@ func epochMillis(t time.Time) int64 {
 	return t.UnixMilli()
 }
 
+// ingestionMillis renders an event's ingestion time as epoch milliseconds,
+// falling back to the event's own timestamp when the ingestion time is unknown
+// (zero) so the wire field is never blank.
+func ingestionMillis(ingestion, eventTS time.Time) int64 {
+	if ingestion.IsZero() {
+		return epochMillis(eventTS)
+	}
+
+	return epochMillis(ingestion)
+}
+
 // millisToTime is the inverse of epochMillis: epoch milliseconds to time. Zero
 // yields the zero time so callers can distinguish "unset".
 func millisToTime(ms int64) time.Time {
@@ -167,13 +184,23 @@ func toLogGroupJSON(info *logdriver.LogGroupInfo) logGroupJSON {
 	}
 }
 
-func toLogStreamJSON(info *logdriver.LogStreamInfo) logStreamJSON {
+// toLogStreamJSON renders a driver log stream. groupARN is the owning log
+// group's ARN, used to derive the stream ARN Terraform's
+// aws_cloudwatch_log_stream reads; empty groupARN omits the arn field.
+func toLogStreamJSON(info *logdriver.LogStreamInfo, groupARN string) logStreamJSON {
 	last := isoToEpochMillis(info.LastEvent)
 
-	return logStreamJSON{
-		LogStreamName:      info.Name,
-		CreationTime:       isoToEpochMillis(info.CreatedAt),
-		LastEventTimestamp: last,
-		LastIngestionTime:  last,
+	js := logStreamJSON{
+		LogStreamName:       info.Name,
+		CreationTime:        isoToEpochMillis(info.CreatedAt),
+		LastEventTimestamp:  last,
+		LastIngestionTime:   last,
+		FirstEventTimestamp: isoToEpochMillis(info.FirstEvent),
 	}
+
+	if groupARN != "" {
+		js.Arn = groupARN + ":log-stream:" + info.Name
+	}
+
+	return js
 }

--- a/services/logging/driver/driver.go
+++ b/services/logging/driver/driver.go
@@ -32,15 +32,20 @@ type LogGroupInfo struct {
 
 // LogStreamInfo describes a log stream within a log group.
 type LogStreamInfo struct {
-	Name      string
-	CreatedAt string
-	LastEvent string
+	Name       string
+	CreatedAt  string
+	FirstEvent string
+	LastEvent  string
 }
 
 // LogEvent represents a single log entry.
 type LogEvent struct {
 	Timestamp time.Time
-	Message   string
+	// IngestionTime is the wall-clock time the event was received by the
+	// service (set at PutLogEvents), distinct from the caller-supplied
+	// Timestamp. Zero when unknown.
+	IngestionTime time.Time
+	Message       string
 }
 
 // LogQueryInput configures a log query operation.
@@ -67,7 +72,10 @@ type FilterLogEventsInput struct {
 type FilteredLogEvent struct {
 	LogStream string
 	Timestamp time.Time
-	Message   string
+	// IngestionTime is the wall-clock time the event was received by the
+	// service, distinct from the caller-supplied Timestamp. Zero when unknown.
+	IngestionTime time.Time
+	Message       string
 }
 
 // MetricFilterConfig describes a metric filter to create.


### PR DESCRIPTION
CloudWatch Logs fidelity: DescribeLogGroups/DescribeLogStreams honor Limit + return NextToken (offset-token pagination); DescribeLogStreams emits stream Arn (log-group:<grp>:log-stream:<stream>, read by Terraform) + storedBytes; FirstEventTimestamp populated and GetLogEvents/FilterLogEvents IngestionTime is real wall-clock set at PutLogEvents. Kinesis/Kafka findings were already resolved by #469. SDK round-trip tests per fix; compat suite clean.