### PR TITLE
fix(ec2): wire fidelity — instance fields, reservations, SG rules, VPC ownerId/CIDR, tags, ReplaceRoute (16 fixes)

### DIFF
--- a/docs/coverage/aws/vpc.md
+++ b/docs/coverage/aws/vpc.md
@@ -280,6 +280,15 @@ NetworkInterfaces is an OPTIONAL capability, discovered by type assertion.
 | `DescribeNetworkInterfaces` |  |
 | `DetachNetworkInterface` |  |
 
+### NetworkResourceTagger
+
+NetworkResourceTagger is an OPTIONAL AWS capability (type-asserted).
+
+| Operation | Description |
+| --- | --- |
+| `RemoveResourceTags` |  |
+| `UpdateResourceTags` |  |
+
 ### PrefixLists
 
 PrefixLists is an OPTIONAL AWS capability (type-asserted).

--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -280,6 +280,15 @@ NetworkInterfaces is an OPTIONAL capability, discovered by type assertion.
 | `DescribeNetworkInterfaces` |  |
 | `DetachNetworkInterface` |  |
 
+### NetworkResourceTagger
+
+NetworkResourceTagger is an OPTIONAL AWS capability (type-asserted).
+
+| Operation | Description |
+| --- | --- |
+| `RemoveResourceTags` |  |
+| `UpdateResourceTags` |  |
+
 ### PrefixLists
 
 PrefixLists is an OPTIONAL AWS capability (type-asserted).

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -6485,6 +6485,18 @@
         ]
       },
       {
+        "name": "NetworkResourceTagger",
+        "doc": "NetworkResourceTagger is an OPTIONAL AWS capability (type-asserted).",
+        "operations": [
+          {
+            "name": "RemoveResourceTags"
+          },
+          {
+            "name": "UpdateResourceTags"
+          }
+        ]
+      },
+      {
         "name": "PrefixLists",
         "doc": "PrefixLists is an OPTIONAL AWS capability (type-asserted).",
         "operations": [

--- a/docs/coverage/gcp/vpc.md
+++ b/docs/coverage/gcp/vpc.md
@@ -280,6 +280,15 @@ NetworkInterfaces is an OPTIONAL capability, discovered by type assertion.
 | `DescribeNetworkInterfaces` |  |
 | `DetachNetworkInterface` |  |
 
+### NetworkResourceTagger
+
+NetworkResourceTagger is an OPTIONAL AWS capability (type-asserted).
+
+| Operation | Description |
+| --- | --- |
+| `RemoveResourceTags` |  |
+| `UpdateResourceTags` |  |
+
 ### PrefixLists
 
 PrefixLists is an OPTIONAL AWS capability (type-asserted).

--- a/docs/coverage/oci/vcn.md
+++ b/docs/coverage/oci/vcn.md
@@ -280,6 +280,15 @@ NetworkInterfaces is an OPTIONAL capability, discovered by type assertion.
 | `DescribeNetworkInterfaces` |  |
 | `DetachNetworkInterface` |  |
 
+### NetworkResourceTagger
+
+NetworkResourceTagger is an OPTIONAL AWS capability (type-asserted).
+
+| Operation | Description |
+| --- | --- |
+| `RemoveResourceTags` |  |
+| `UpdateResourceTags` |  |
+
 ### PrefixLists
 
 PrefixLists is an OPTIONAL AWS capability (type-asserted).

--- a/features/chaos/wrappers_test.go
+++ b/features/chaos/wrappers_test.go
@@ -427,6 +427,7 @@ type computeConfigCompat = struct {
 	Zones          []string
 	Region         string
 	ResourceGroup  string
+	ClientToken    string
 }
 
 // computeInstanceConfig reproduces the helper used elsewhere in the package

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -11,6 +11,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"sync"
@@ -52,6 +53,19 @@ const (
 	imageRootDeviceSize = 8
 	// rsaKeyBits is the modulus size for generated RSA key pairs.
 	rsaKeyBits = 2048
+
+	// monitoringDisabled / monitoringEnabled are the stored detailed-monitoring
+	// states for an instance.
+	monitoringDisabled = "disabled"
+	monitoringEnabled  = "enabled"
+
+	// subnetFirstHost is the first assignable host offset within a subnet CIDR.
+	// AWS reserves the first four addresses (.0-.3) of every subnet, so host
+	// allocation starts at .4.
+	subnetFirstHost = 4
+
+	// reservationPrefix is the AWS reservation-id prefix (r-xxxx).
+	reservationPrefix = "r-"
 )
 
 type lifecycleTransition struct {
@@ -123,6 +137,21 @@ type instanceData struct {
 	// sourceDestCheck mirrors the instance's source/destination check flag
 	// (default true), toggled via ModifyInstanceAttribute(SourceDestCheck).
 	sourceDestCheck bool
+	// userData is the base64 user-data blob set via
+	// ModifyInstanceAttribute(UserData) and read back by
+	// DescribeInstanceAttribute(userData).
+	userData string
+	// ebsOptimized is the EBS-optimized flag toggled via
+	// ModifyInstanceAttribute(EbsOptimized).
+	ebsOptimized bool
+	// reservationID groups all instances launched by one RunInstances call under
+	// a shared AWS reservation (r-xxxx).
+	reservationID string
+	// keyName is the key pair the instance was launched with, echoed as keyName.
+	keyName string
+	// monitoring is the CloudWatch detailed-monitoring state
+	// ("disabled"/"enabled"); defaults to "disabled" at launch.
+	monitoring string
 }
 
 // operatorData records service-provider managed-resource ownership.
@@ -158,13 +187,22 @@ type Mock struct {
 	// instances created with a --subnet-id carry the VPCID that connectivity
 	// analysis and VPC teardown depend on. nil until wired by the provider.
 	subnetResolver SubnetResolver
-	// mu guards managedResourceVisibility, which is scalar shared state that
-	// (unlike the memstores) has no internal locking of its own.
+	// mu guards managedResourceVisibility, clientTokens and subnetIPCounters,
+	// which are scalar/map shared state that (unlike the memstores) has no
+	// internal locking of their own.
 	mu sync.RWMutex
 	// managedResourceVisibility is "visible" or "hidden". When "hidden",
 	// service-provider-managed instances are omitted from DescribeInstances
 	// unless the request opts in with IncludeManagedResources.
 	managedResourceVisibility string
+	// clientTokens maps a RunInstances ClientToken to the instance ids it
+	// launched, so a retry with the same token returns those instances instead
+	// of double-provisioning (AWS idempotency). Permanent — an emulator needs no
+	// expiry window.
+	clientTokens map[string][]string
+	// subnetIPCounters is the per-subnet host counter used to allocate private
+	// IPv4 addresses from the subnet's CIDR range.
+	subnetIPCounters map[string]int
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -242,6 +280,8 @@ func New(opts *config.Options) *Mock {
 		opts:         opts,
 
 		managedResourceVisibility: visibilityVisible,
+		clientTokens:              make(map[string][]string),
+		subnetIPCounters:          make(map[string]int),
 	}
 }
 
@@ -275,7 +315,9 @@ func toInstance(d *instanceData, hidden bool) driver.Instance {
 	return driver.Instance{
 		ID: d.ID, ImageID: d.ImageID, InstanceType: d.InstanceType, State: d.State,
 		PrivateIP: d.PrivateIP, PublicIP: d.PublicIP, SubnetID: d.SubnetID, VPCID: d.VPCID,
-		SecurityGroups: sg, Tags: tags, LaunchTime: d.LaunchTime, Operator: operator,
+		SecurityGroups: sg, Tags: tags, LaunchTime: d.LaunchTime,
+		ReservationID: d.reservationID, KeyName: d.keyName, Monitoring: d.monitoring,
+		Operator: operator,
 	}
 }
 
@@ -292,8 +334,21 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "count %d exceeds the maximum of %d per call", count, maxRunInstances)
 	}
 
+	// Idempotency: a retry carrying a ClientToken we've already served returns the
+	// same instances rather than launching new ones (real EC2 RunInstances).
+	if dup, ok := m.instancesForClientToken(cfg.ClientToken); ok {
+		return dup, nil
+	}
+
 	results := make([]driver.Instance, 0, count)
 	hidden := m.visibility() == visibilityHidden
+
+	// One reservation groups every instance launched by this call (AWS r-xxxx).
+	reservationID := idgen.GenerateID(reservationPrefix)
+
+	// Resolve the target subnet once so both the VPC id and the CIDR-scoped
+	// private-IP allocation reuse a single lookup.
+	vpcID, subnetCIDR := m.resolveSubnet(ctx, cfg.SubnetID)
 
 	// created tracks the instances already fully provisioned in this batch, so a
 	// mid-batch engine failure can roll them back rather than orphaning live
@@ -315,11 +370,15 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 
 		inst := &instanceData{
 			ID: id, ImageID: cfg.ImageID, InstanceType: cfg.InstanceType,
-			State: compute.StatePending, PrivateIP: m.nextIP(), SubnetID: cfg.SubnetID,
-			VPCID:          m.resolveSubnetVPC(ctx, cfg.SubnetID),
+			State: compute.StatePending, PrivateIP: m.allocatePrivateIP(cfg.SubnetID, subnetCIDR),
+			SubnetID: cfg.SubnetID, VPCID: vpcID,
 			SecurityGroups: sg, Tags: tags,
 			LaunchTime:      m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
 			sourceDestCheck: true,
+			reservationID:   reservationID,
+			keyName:         cfg.KeyName,
+			userData:        cfg.UserData,
+			monitoring:      monitoringDisabled,
 		}
 
 		if cfg.Managed {
@@ -356,7 +415,110 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 		}
 	}
 
+	m.recordClientToken(cfg.ClientToken, created)
+
 	return results, nil
+}
+
+// instancesForClientToken returns the instances previously launched under token
+// (rendered fresh from the store) when token is non-empty and already recorded.
+func (m *Mock) instancesForClientToken(token string) ([]driver.Instance, bool) {
+	if token == "" {
+		return nil, false
+	}
+
+	m.mu.RLock()
+	ids, ok := m.clientTokens[token]
+	m.mu.RUnlock()
+
+	if !ok {
+		return nil, false
+	}
+
+	hidden := m.visibility() == visibilityHidden
+	out := make([]driver.Instance, 0, len(ids))
+
+	for _, id := range ids {
+		if inst, found := m.instances.Get(id); found {
+			out = append(out, toInstance(inst, hidden))
+		}
+	}
+
+	return out, true
+}
+
+// recordClientToken remembers which instances a ClientToken launched so a retry
+// is served idempotently. A no-op for the empty token.
+func (m *Mock) recordClientToken(token string, created []*instanceData) {
+	if token == "" {
+		return
+	}
+
+	ids := make([]string, 0, len(created))
+	for _, inst := range created {
+		ids = append(ids, inst.ID)
+	}
+
+	m.mu.Lock()
+	m.clientTokens[token] = ids
+	m.mu.Unlock()
+}
+
+// resolveSubnet returns the VPC that owns subnetID and the subnet's CIDR block
+// in a single resolver lookup. Both are "" when there is no subnet, no resolver,
+// or the subnet can't be found.
+func (m *Mock) resolveSubnet(ctx context.Context, subnetID string) (vpcID, cidr string) {
+	if subnetID == "" || m.subnetResolver == nil {
+		return "", ""
+	}
+
+	subs, err := m.subnetResolver.DescribeSubnets(ctx, []string{subnetID})
+	if err != nil || len(subs) == 0 {
+		return "", ""
+	}
+
+	return subs[0].VPCID, subs[0].CIDRBlock
+}
+
+// allocatePrivateIP hands out the next private IPv4 inside the subnet's CIDR
+// (AWS allocates from the target subnet, e.g. 10.0.1.0/24 -> 10.0.1.x). It falls
+// back to the global 10.0.<n> pool when there is no subnet CIDR to draw from.
+func (m *Mock) allocatePrivateIP(subnetID, cidr string) string {
+	if subnetID == "" || cidr == "" {
+		return m.nextIP()
+	}
+
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return m.nextIP()
+	}
+
+	base := ipNet.IP.To4()
+	if base == nil {
+		return m.nextIP()
+	}
+
+	m.mu.Lock()
+	offset := m.subnetIPCounters[subnetID] + subnetFirstHost
+	m.subnetIPCounters[subnetID]++
+	m.mu.Unlock()
+
+	host := make(net.IP, len(base))
+	copy(host, base)
+
+	// Add offset into the low-order bytes of the network address.
+	carry := offset
+	for i := len(host) - 1; i >= 0 && carry > 0; i-- {
+		sum := int(host[i]) + carry
+		host[i] = byte(sum % ipSegmentSize) //nolint:gosec // sum%256 is always in [0,255]
+		carry = sum / ipSegmentSize
+	}
+
+	if !ipNet.Contains(host) {
+		return m.nextIP()
+	}
+
+	return host.String()
 }
 
 // rollbackInstances best-effort tears down instances already provisioned earlier
@@ -653,6 +815,9 @@ const (
 	attrDisableAPITermination = "disableApiTermination"
 	attrSourceDestCheck       = "sourceDestCheck"
 	attrInstanceType          = "instanceType"
+	attrUserData              = "userData"
+	attrEbsOptimized          = "ebsOptimized"
+	attrMonitoring            = "monitoring"
 )
 
 // SetInstanceAttribute updates a single instance attribute in place. It backs
@@ -666,16 +831,44 @@ func (m *Mock) SetInstanceAttribute(_ context.Context, instanceID, name, value s
 		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
 	}
 
-	b, _ := strconv.ParseBool(value)
-
 	switch name {
 	case attrDisableAPITermination:
-		inst.disableAPITermination = b
+		inst.disableAPITermination = parseBool(value)
 	case attrSourceDestCheck:
-		inst.sourceDestCheck = b
+		inst.sourceDestCheck = parseBool(value)
+	case attrEbsOptimized:
+		inst.ebsOptimized = parseBool(value)
+	case attrUserData:
+		inst.userData = value
+	case attrMonitoring:
+		inst.monitoring = value
 	default:
 		return cerrors.Newf(cerrors.InvalidArgument, "unsupported instance attribute %q", name)
 	}
+
+	return nil
+}
+
+// parseBool interprets an attribute value as a boolean, treating an unparsable
+// value as false (real EC2 rejects malformed values upstream at the wire layer).
+func parseBool(value string) bool {
+	b, _ := strconv.ParseBool(value)
+
+	return b
+}
+
+// SetInstanceSecurityGroups overwrites an instance's security-group membership,
+// backing ModifyInstanceAttribute(Groups) for VPC instances. It replaces the set
+// rather than merging, matching AWS's GroupId.N semantics.
+func (m *Mock) SetInstanceSecurityGroups(_ context.Context, instanceID string, groupIDs []string) error {
+	inst, ok := m.instances.Get(instanceID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
+	}
+
+	sg := make([]string, len(groupIDs))
+	copy(sg, groupIDs)
+	inst.SecurityGroups = sg
 
 	return nil
 }
@@ -693,8 +886,14 @@ func (m *Mock) GetInstanceAttribute(_ context.Context, instanceID, name string) 
 		return strconv.FormatBool(inst.disableAPITermination), nil
 	case attrSourceDestCheck:
 		return strconv.FormatBool(inst.sourceDestCheck), nil
+	case attrEbsOptimized:
+		return strconv.FormatBool(inst.ebsOptimized), nil
 	case attrInstanceType:
 		return inst.InstanceType, nil
+	case attrUserData:
+		return inst.userData, nil
+	case attrMonitoring:
+		return inst.monitoring, nil
 	default:
 		return "", cerrors.Newf(cerrors.InvalidArgument, "unsupported instance attribute %q", name)
 	}

--- a/providers/aws/ec2/subnet_resolver.go
+++ b/providers/aws/ec2/subnet_resolver.go
@@ -19,18 +19,3 @@ type SubnetResolver interface {
 func (m *Mock) SetSubnetResolver(r SubnetResolver) {
 	m.subnetResolver = r
 }
-
-// resolveSubnetVPC returns the VPC that owns subnetID, or "" when there is no
-// subnet, no resolver, or the subnet can't be found.
-func (m *Mock) resolveSubnetVPC(ctx context.Context, subnetID string) string {
-	if subnetID == "" || m.subnetResolver == nil {
-		return ""
-	}
-
-	subs, err := m.subnetResolver.DescribeSubnets(ctx, []string{subnetID})
-	if err != nil || len(subs) == 0 {
-		return ""
-	}
-
-	return subs[0].VPCID
-}

--- a/providers/aws/vpc/tags.go
+++ b/providers/aws/vpc/tags.go
@@ -1,0 +1,67 @@
+package vpc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// UpdateResourceTags merges tags onto a VPC-family resource that has no
+// dedicated Update*Tags method — route tables, internet gateways, NAT
+// gateways, network ACLs, DHCP option sets, peering connections, managed
+// prefix lists, and egress-only internet gateways. An unknown or missing id
+// is NotFound, so the wire layer can map it to the InvalidID.NotFound code
+// real EC2 returns for CreateTags on a non-existent resource.
+func (m *Mock) UpdateResourceTags(_ context.Context, id string, tags map[string]string) error {
+	if !m.mutateResourceTags(id, func(existing map[string]string) map[string]string {
+		return mergeTagMap(existing, tags)
+	}) {
+		return errors.Newf(errors.NotFound, "resource %q not found", id)
+	}
+
+	return nil
+}
+
+// RemoveResourceTags drops the given tag keys from a VPC-family resource, the
+// DeleteTags counterpart to UpdateResourceTags.
+func (m *Mock) RemoveResourceTags(_ context.Context, id string, keys []string) error {
+	if !m.mutateResourceTags(id, func(existing map[string]string) map[string]string {
+		return removeTagMapKeys(existing, keys)
+	}) {
+		return errors.Newf(errors.NotFound, "resource %q not found", id)
+	}
+
+	return nil
+}
+
+// mutateResourceTags routes an id to the store that owns it and applies
+// transform to that record's tag map inside memstore.Update, so the store lock
+// covers the read-modify-write. It reports whether the id matched a known
+// prefix and an existing record.
+func (m *Mock) mutateResourceTags(id string, transform func(map[string]string) map[string]string) bool {
+	switch {
+	case strings.HasPrefix(id, "rtb-"):
+		return m.routeTables.Update(id, func(v *routeTableData) *routeTableData { v.Tags = transform(v.Tags); return v })
+	case strings.HasPrefix(id, "igw-"):
+		return m.igws.Update(id, func(v *igwData) *igwData { v.Tags = transform(v.Tags); return v })
+	case strings.HasPrefix(id, "nat-"):
+		return m.natGateways.Update(id, func(v *natGatewayData) *natGatewayData { v.Tags = transform(v.Tags); return v })
+	case strings.HasPrefix(id, "acl-"):
+		return m.networkACLs.Update(id, func(v *networkACLData) *networkACLData { v.Tags = transform(v.Tags); return v })
+	case strings.HasPrefix(id, "dopt-"):
+		return m.dhcpOptions.Update(id, func(v *driver.DHCPOptions) *driver.DHCPOptions { v.Tags = transform(v.Tags); return v })
+	case strings.HasPrefix(id, "pcx-"):
+		return m.peerings.Update(id, func(v *peeringData) *peeringData { v.Tags = transform(v.Tags); return v })
+	case strings.HasPrefix(id, "pl-"):
+		return m.prefixLists.Update(id, func(v *driver.PrefixList) *driver.PrefixList { v.Tags = transform(v.Tags); return v })
+	case strings.HasPrefix(id, "eigw-"):
+		return m.egressOnlyIGWs.Update(id, func(v *driver.EgressOnlyInternetGateway) *driver.EgressOnlyInternetGateway {
+			v.Tags = transform(v.Tags)
+			return v
+		})
+	default:
+		return false
+	}
+}

--- a/providers/aws/vpc/tags_test.go
+++ b/providers/aws/vpc/tags_test.go
@@ -1,0 +1,59 @@
+package vpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// TestNetworkResourceTagger covers UpdateResourceTags/RemoveResourceTags for the
+// VPC-family resources routed through the optional interface: the tag lands on
+// the owning store, delete removes it, and an unknown id is NotFound.
+func TestNetworkResourceTagger(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	v := createTestVPC(m)
+
+	rt, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: v.ID})
+	requireNoError(t, err)
+
+	igw, err := m.CreateInternetGateway(ctx, driver.InternetGatewayConfig{})
+	requireNoError(t, err)
+
+	dopt, err := m.CreateDHCPOptions(ctx, driver.DHCPOptionsConfig{
+		Configuration: map[string][]string{"domain-name-servers": {"10.0.0.2"}},
+	})
+	requireNoError(t, err)
+
+	for _, id := range []string{rt.ID, igw.ID, dopt.ID} {
+		requireNoError(t, m.UpdateResourceTags(ctx, id, map[string]string{"Name": "n"}))
+	}
+
+	assertEqual(t, "n", routeTableTag(t, m, rt.ID, "Name"))
+
+	requireNoError(t, m.RemoveResourceTags(ctx, rt.ID, []string{"Name"}))
+	assertEqual(t, "", routeTableTag(t, m, rt.ID, "Name"))
+
+	if err := m.UpdateResourceTags(ctx, "rtb-missing", map[string]string{"k": "v"}); !isNotFound(err) {
+		t.Fatalf("UpdateResourceTags on missing id = %v, want NotFound", err)
+	}
+
+	if err := m.RemoveResourceTags(ctx, "vol-notnetwork", []string{"k"}); !isNotFound(err) {
+		t.Fatalf("RemoveResourceTags on non-network id = %v, want NotFound", err)
+	}
+}
+
+func routeTableTag(t *testing.T, m *Mock, id, key string) string {
+	t.Helper()
+
+	rts, err := m.DescribeRouteTables(context.Background(), []string{id})
+	requireNoError(t, err)
+
+	return rts[0].Tags[key]
+}
+
+func isNotFound(err error) bool {
+	return err != nil && errors.IsNotFound(err)
+}

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -49,6 +49,7 @@ var (
 	_ driver.TrafficMirroring           = (*Mock)(nil)
 	_ driver.NetworkInsights            = (*Mock)(nil)
 	_ driver.VPCBlockPublicAccess       = (*Mock)(nil)
+	_ driver.NetworkResourceTagger      = (*Mock)(nil)
 )
 
 // Mock is an in-memory mock implementation of the AWS VPC networking service.

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -493,8 +493,15 @@ func (m *Mock) DescribeSubnets(_ context.Context, ids []string) ([]driver.Subnet
 // defaultEgressRule is the allow-all outbound rule real EC2 attaches to every
 // new security group (protocol -1, 0.0.0.0/0, all ports).
 //
-//nolint:gochecknoglobals // static default, mirrors real EC2
-var defaultEgressRule = driver.SecurityRule{Protocol: allTrafficProtocol, CIDR: allTrafficCIDR}
+// newDefaultEgressRule builds the allow-all outbound rule with a freshly minted
+// "sgr-" id so each group's default egress rule is individually identifiable.
+func newDefaultEgressRule() driver.SecurityRule {
+	return driver.SecurityRule{
+		Protocol: allTrafficProtocol,
+		CIDR:     allTrafficCIDR,
+		RuleID:   idgen.GenerateID("sgr-"),
+	}
+}
 
 func (m *Mock) CreateSecurityGroup(_ context.Context, cfg driver.SecurityGroupConfig) (*driver.SecurityGroupInfo, error) {
 	if cfg.Name == "" {
@@ -532,7 +539,9 @@ func (m *Mock) CreateSecurityGroup(_ context.Context, cfg driver.SecurityGroupCo
 		// (no ingress). IaC tools rely on it — Terraform revokes this default
 		// before applying the egress blocks in the config — and the topology
 		// engine otherwise reports a fresh SG as denying all outbound traffic.
-		EgressRules: []driver.SecurityRule{defaultEgressRule},
+		// The rule gets its own "sgr-" id so DescribeSecurityGroupRules can
+		// return and filter it the way real EC2 does.
+		EgressRules: []driver.SecurityRule{newDefaultEgressRule()},
 		Tags:        tags,
 	}
 	m.securityGroups.Set(id, sg)
@@ -592,6 +601,8 @@ func describeResources[T any, R any](store *memstore.Store[T], ids []string, toI
 }
 
 // AddIngressRule adds an ingress rule to the specified security group.
+//
+//nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (m *Mock) AddIngressRule(_ context.Context, groupID string, rule driver.SecurityRule) error {
 	sg, ok := m.securityGroups.Get(groupID)
 	if !ok {
@@ -604,6 +615,8 @@ func (m *Mock) AddIngressRule(_ context.Context, groupID string, rule driver.Sec
 }
 
 // AddEgressRule adds an egress rule to the specified security group.
+//
+//nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (m *Mock) AddEgressRule(_ context.Context, groupID string, rule driver.SecurityRule) error {
 	sg, ok := m.securityGroups.Get(groupID)
 	if !ok {
@@ -616,14 +629,16 @@ func (m *Mock) AddEgressRule(_ context.Context, groupID string, rule driver.Secu
 }
 
 // RemoveIngressRule removes a matching ingress rule from the specified security group.
+//
+//nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (m *Mock) RemoveIngressRule(_ context.Context, groupID string, rule driver.SecurityRule) error {
 	sg, ok := m.securityGroups.Get(groupID)
 	if !ok {
 		return errors.Newf(errors.NotFound, "security group %q not found", groupID)
 	}
 
-	for i, r := range sg.IngressRules {
-		if r == rule {
+	for i := range sg.IngressRules {
+		if sg.IngressRules[i].Matches(&rule) {
 			sg.IngressRules = append(sg.IngressRules[:i], sg.IngressRules[i+1:]...)
 			return nil
 		}
@@ -633,14 +648,16 @@ func (m *Mock) RemoveIngressRule(_ context.Context, groupID string, rule driver.
 }
 
 // RemoveEgressRule removes a matching egress rule from the specified security group.
+//
+//nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.SecurityRule) error {
 	sg, ok := m.securityGroups.Get(groupID)
 	if !ok {
 		return errors.Newf(errors.NotFound, "security group %q not found", groupID)
 	}
 
-	for i, r := range sg.EgressRules {
-		if r == rule {
+	for i := range sg.EgressRules {
+		if sg.EgressRules[i].Matches(&rule) {
 			sg.EgressRules = append(sg.EgressRules[:i], sg.EgressRules[i+1:]...)
 			return nil
 		}

--- a/server/aws/ec2/dhcp_options.go
+++ b/server/aws/ec2/dhcp_options.go
@@ -27,6 +27,7 @@ type dhcpConfigXML struct {
 
 type dhcpOptionsXML struct {
 	DhcpOptionsID      string          `xml:"dhcpOptionsId"`
+	OwnerID            string          `xml:"ownerId"`
 	DhcpConfigurations []dhcpConfigXML `xml:"dhcpConfigurationSet>item,omitempty"`
 	Tags               []tagItem       `xml:"tagSet>item,omitempty"`
 }
@@ -149,7 +150,7 @@ func toDHCPOptionsXML(d *netdriver.DHCPOptions) dhcpOptionsXML {
 		cfgs = append(cfgs, dhcpConfigXML{Key: k, Values: vals})
 	}
 
-	return dhcpOptionsXML{DhcpOptionsID: d.ID, DhcpConfigurations: cfgs, Tags: toTagItems(d.Tags)}
+	return dhcpOptionsXML{DhcpOptionsID: d.ID, OwnerID: ownerID, DhcpConfigurations: cfgs, Tags: toTagItems(d.Tags)}
 }
 
 func writeDHCPErr(w http.ResponseWriter, err error) {

--- a/server/aws/ec2/ec2_phase2_test.go
+++ b/server/aws/ec2/ec2_phase2_test.go
@@ -578,7 +578,9 @@ func TestCreateNetworkInterfaceAndInstanceStatus(t *testing.T) {
 	mon := do(t, h, http.MethodPost, "/", url.Values{
 		"Action": {"MonitorInstances"}, "InstanceId.1": {instID},
 	})
-	if mon.Code != http.StatusOK || !strings.Contains(mon.Body.String(), "<state>enabled</state>") {
+	// MonitorInstances echoes the transitional "pending" state (real EC2), not
+	// the settled "enabled".
+	if mon.Code != http.StatusOK || !strings.Contains(mon.Body.String(), "<state>pending</state>") {
 		t.Fatalf("MonitorInstances: code=%d body=%s", mon.Code, mon.Body.String())
 	}
 

--- a/server/aws/ec2/ec2_test.go
+++ b/server/aws/ec2/ec2_test.go
@@ -275,7 +275,7 @@ func TestToInstanceXMLs(t *testing.T) {
 		Tags:           map[string]string{"k": "v"},
 	}}
 
-	got := toInstanceXMLs(in)
+	got := New(nil, nil).toInstanceXMLs(context.Background(), in)
 
 	if len(got) != 1 {
 		t.Fatalf("len=%d want 1", len(got))
@@ -292,7 +292,7 @@ func TestToInstanceXMLs(t *testing.T) {
 }
 
 func TestToInstanceXMLsEmpty(t *testing.T) {
-	got := toInstanceXMLs(nil)
+	got := New(nil, nil).toInstanceXMLs(context.Background(), nil)
 	if len(got) != 0 {
 		t.Errorf("empty input should give empty result, got %v", got)
 	}

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -256,6 +256,7 @@ func (h *Handler) routeLaunchTemplates(w http.ResponseWriter, r *http.Request, a
 	return true
 }
 
+//nolint:dupl // action-dispatch switch; every route* function has this shape by design
 func (h *Handler) routeAutoScaling(w http.ResponseWriter, r *http.Request, action string) bool {
 	switch action {
 	case "CreateAutoScalingGroup":
@@ -418,6 +419,7 @@ func (h *Handler) routeVPCSubnet(w http.ResponseWriter, r *http.Request, action 
 	return true
 }
 
+//nolint:dupl // action-dispatch switch; every route* function has this shape by design
 func (h *Handler) routeVPCSecurityGroup(w http.ResponseWriter, r *http.Request, action string) bool {
 	switch action {
 	case "CreateSecurityGroup":
@@ -426,6 +428,8 @@ func (h *Handler) routeVPCSecurityGroup(w http.ResponseWriter, r *http.Request, 
 		h.deleteSecurityGroup(w, r)
 	case "DescribeSecurityGroups":
 		h.describeSecurityGroups(w, r)
+	case "DescribeSecurityGroupRules":
+		h.describeSecurityGroupRules(w, r)
 	case "AuthorizeSecurityGroupIngress":
 		h.authorizeSecurityGroupIngress(w, r)
 	case "AuthorizeSecurityGroupEgress":

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -472,6 +472,8 @@ func (h *Handler) routeVPCRouteTable(w http.ResponseWriter, r *http.Request, act
 		h.createRoute(w, r)
 	case "DeleteRoute":
 		h.deleteRoute(w, r)
+	case "ReplaceRoute":
+		h.replaceRoute(w, r)
 	case "AssociateRouteTable":
 		h.associateRouteTable(w, r)
 	case "DisassociateRouteTable":

--- a/server/aws/ec2/instance_attribute_test.go
+++ b/server/aws/ec2/instance_attribute_test.go
@@ -2,6 +2,7 @@ package ec2_test
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"net/http/httptest"
 	"testing"
@@ -146,5 +147,115 @@ func TestModifySourceDestCheckRoundTrips(t *testing.T) {
 
 	if got.SourceDestCheck == nil || aws.ToBool(got.SourceDestCheck.Value) {
 		t.Fatalf("sourceDestCheck should be false after modify, got %+v", got.SourceDestCheck)
+	}
+}
+
+// TestModifyUserDataRoundTrips pins that ModifyInstanceAttribute(UserData) is
+// honored and read back as the base64 blob via DescribeInstanceAttribute
+// (previously accepted and silently discarded).
+func TestModifyUserDataRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+	id := runOneInstance(t, c)
+
+	// UserData changes require a stopped instance on real EC2.
+	if _, err := c.StopInstances(ctx, &ec2.StopInstancesInput{InstanceIds: []string{id}}); err != nil {
+		t.Fatalf("StopInstances: %v", err)
+	}
+
+	userData := []byte("#!/bin/bash\necho hello")
+	if _, err := c.ModifyInstanceAttribute(ctx, &ec2.ModifyInstanceAttributeInput{
+		InstanceId: aws.String(id),
+		UserData:   &ec2types.BlobAttributeValue{Value: userData},
+	}); err != nil {
+		t.Fatalf("ModifyInstanceAttribute(UserData): %v", err)
+	}
+
+	got, err := c.DescribeInstanceAttribute(ctx, &ec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String(id),
+		Attribute:  ec2types.InstanceAttributeNameUserData,
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstanceAttribute(UserData): %v", err)
+	}
+
+	want := base64.StdEncoding.EncodeToString(userData)
+	if got.UserData == nil || aws.ToString(got.UserData.Value) != want {
+		t.Fatalf("userData not persisted: got %+v want %q", got.UserData, want)
+	}
+}
+
+// TestModifyEbsOptimizedRoundTrips pins that
+// ModifyInstanceAttribute(EbsOptimized=true) is honored and read back via
+// DescribeInstanceAttribute.
+func TestModifyEbsOptimizedRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+	id := runOneInstance(t, c)
+
+	if _, err := c.ModifyInstanceAttribute(ctx, &ec2.ModifyInstanceAttributeInput{
+		InstanceId:   aws.String(id),
+		EbsOptimized: &ec2types.AttributeBooleanValue{Value: aws.Bool(true)},
+	}); err != nil {
+		t.Fatalf("ModifyInstanceAttribute(EbsOptimized): %v", err)
+	}
+
+	got, err := c.DescribeInstanceAttribute(ctx, &ec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String(id),
+		Attribute:  ec2types.InstanceAttributeNameEbsOptimized,
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstanceAttribute(EbsOptimized): %v", err)
+	}
+
+	if got.EbsOptimized == nil || !aws.ToBool(got.EbsOptimized.Value) {
+		t.Fatalf("ebsOptimized not persisted: %+v", got.EbsOptimized)
+	}
+}
+
+// TestModifyInstanceGroupsRoundTrips pins that ModifyInstanceAttribute(Groups)
+// replaces the instance's security-group membership and is read back via
+// DescribeInstanceAttribute(groupSet) with the resolved group name.
+func TestModifyInstanceGroupsRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+	id := runOneInstance(t, c)
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	sg, err := c.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String("modify-groups-sg"),
+		Description: aws.String("test"),
+		VpcId:       vpc.Vpc.VpcId,
+	})
+	if err != nil {
+		t.Fatalf("CreateSecurityGroup: %v", err)
+	}
+
+	sgID := aws.ToString(sg.GroupId)
+	if _, err := c.ModifyInstanceAttribute(ctx, &ec2.ModifyInstanceAttributeInput{
+		InstanceId: aws.String(id),
+		Groups:     []string{sgID},
+	}); err != nil {
+		t.Fatalf("ModifyInstanceAttribute(Groups): %v", err)
+	}
+
+	got, err := c.DescribeInstanceAttribute(ctx, &ec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String(id),
+		Attribute:  ec2types.InstanceAttributeNameGroupSet,
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstanceAttribute(groupSet): %v", err)
+	}
+
+	if len(got.Groups) != 1 || aws.ToString(got.Groups[0].GroupId) != sgID {
+		t.Fatalf("group membership not applied: %+v", got.Groups)
+	}
+
+	if aws.ToString(got.Groups[0].GroupName) != "modify-groups-sg" {
+		t.Fatalf("group name not resolved: %+v", got.Groups[0])
 	}
 }

--- a/server/aws/ec2/instance_describe_test.go
+++ b/server/aws/ec2/instance_describe_test.go
@@ -1,0 +1,310 @@
+package ec2_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestDescribeInstanceReportsHardwareDetail pins the static/derived instance
+// facts real EC2 returns on a DescribeInstances item — architecture, hypervisor,
+// virtualization/root-device, placement, monitoring, private DNS name, and a
+// primary network interface — which SDKs and IaC read.
+func TestDescribeInstanceReportsHardwareDetail(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+	id := runOneInstance(t, c)
+
+	out, err := c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{InstanceIds: []string{id}})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	inst := out.Reservations[0].Instances[0]
+
+	if inst.Architecture != ec2types.ArchitectureValuesX8664 {
+		t.Errorf("architecture = %q, want x86_64", inst.Architecture)
+	}
+
+	if inst.Hypervisor != ec2types.HypervisorTypeXen {
+		t.Errorf("hypervisor = %q, want xen", inst.Hypervisor)
+	}
+
+	if inst.VirtualizationType != ec2types.VirtualizationTypeHvm {
+		t.Errorf("virtualizationType = %q, want hvm", inst.VirtualizationType)
+	}
+
+	if inst.RootDeviceType != ec2types.DeviceTypeEbs {
+		t.Errorf("rootDeviceType = %q, want ebs", inst.RootDeviceType)
+	}
+
+	if aws.ToString(inst.RootDeviceName) != "/dev/xvda" {
+		t.Errorf("rootDeviceName = %q, want /dev/xvda", aws.ToString(inst.RootDeviceName))
+	}
+
+	if inst.Placement == nil || aws.ToString(inst.Placement.AvailabilityZone) == "" {
+		t.Errorf("placement availabilityZone missing: %+v", inst.Placement)
+	}
+
+	if inst.Placement == nil || inst.Placement.Tenancy != ec2types.TenancyDefault {
+		t.Errorf("placement tenancy = %+v, want default", inst.Placement)
+	}
+
+	if inst.Monitoring == nil || inst.Monitoring.State != ec2types.MonitoringStateDisabled {
+		t.Errorf("monitoring state = %+v, want disabled", inst.Monitoring)
+	}
+
+	if !strings.HasPrefix(aws.ToString(inst.PrivateDnsName), "ip-") {
+		t.Errorf("privateDnsName = %q, want ip-...", aws.ToString(inst.PrivateDnsName))
+	}
+
+	if len(inst.NetworkInterfaces) != 1 {
+		t.Fatalf("networkInterfaces len = %d, want 1", len(inst.NetworkInterfaces))
+	}
+
+	if inst.NetworkInterfaces[0].Attachment == nil ||
+		aws.ToInt32(inst.NetworkInterfaces[0].Attachment.DeviceIndex) != 0 {
+		t.Errorf("primary ENI deviceIndex != 0: %+v", inst.NetworkInterfaces[0].Attachment)
+	}
+}
+
+// TestDescribeInstancesGroupsReservation pins that all instances launched by one
+// RunInstances call share a single reservation, and a second call produces a
+// distinct reservation (real EC2 <reservationSet> grouping).
+func TestDescribeInstancesGroupsReservation(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	batch, err := c.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-123"),
+		InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount:     aws.Int32(3),
+		MaxCount:     aws.Int32(3),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	ids := make([]string, 0, 3)
+	for i := range batch.Instances {
+		ids = append(ids, aws.ToString(batch.Instances[i].InstanceId))
+	}
+
+	out, err := c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{InstanceIds: ids})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	if len(out.Reservations) != 1 {
+		t.Fatalf("reservations = %d, want 1 shared reservation", len(out.Reservations))
+	}
+
+	if len(out.Reservations[0].Instances) != 3 {
+		t.Fatalf("instances in reservation = %d, want 3", len(out.Reservations[0].Instances))
+	}
+
+	other := runOneInstance(t, c)
+	all, err := c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: append(ids, other),
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstances (all): %v", err)
+	}
+
+	if len(all.Reservations) != 2 {
+		t.Fatalf("reservations = %d, want 2 distinct reservations", len(all.Reservations))
+	}
+}
+
+// TestDescribeInstancesPaginates pins that DescribeInstances honors MaxResults
+// and NextToken, walking the reservation set one page at a time.
+func TestDescribeInstancesPaginates(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	const reservations = 3
+	for i := 0; i < reservations; i++ {
+		runOneInstance(t, c)
+	}
+
+	seen := 0
+	pages := 0
+
+	var token *string
+
+	for {
+		out, err := c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+			MaxResults: aws.Int32(5),
+			NextToken:  token,
+		})
+		if err != nil {
+			t.Fatalf("DescribeInstances page %d: %v", pages, err)
+		}
+
+		pages++
+		for range out.Reservations {
+			seen++
+		}
+
+		if aws.ToString(out.NextToken) == "" {
+			break
+		}
+
+		token = out.NextToken
+
+		if pages > reservations+1 {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+
+	// MaxResults=5 with 3 reservations fits on one page (no token).
+	if seen != reservations {
+		t.Fatalf("saw %d reservations across pages, want %d", seen, reservations)
+	}
+}
+
+// TestDescribeInstancesPaginatesOnePerPage pins the multi-page path: MaxResults=1
+// yields one reservation per page with a NextToken until exhausted.
+func TestDescribeInstancesPaginatesOnePerPage(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	const reservations = 3
+	for i := 0; i < reservations; i++ {
+		runOneInstance(t, c)
+	}
+
+	seen := 0
+	pages := 0
+
+	var token *string
+
+	for {
+		out, err := c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+			MaxResults: aws.Int32(1),
+			NextToken:  token,
+		})
+		if err != nil {
+			t.Fatalf("DescribeInstances page %d: %v", pages, err)
+		}
+
+		pages++
+		seen += len(out.Reservations)
+
+		if aws.ToString(out.NextToken) == "" {
+			break
+		}
+
+		token = out.NextToken
+
+		if pages > reservations+1 {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+
+	if pages != reservations {
+		t.Fatalf("pages = %d, want %d (one reservation per page)", pages, reservations)
+	}
+
+	if seen != reservations {
+		t.Fatalf("saw %d reservations, want %d", seen, reservations)
+	}
+}
+
+// TestRunInstancesAllocatesIPFromSubnet pins that an instance launched into a
+// subnet draws its primary private IPv4 from that subnet's CIDR (real EC2), not
+// the global 10.0.<n> pool.
+func TestRunInstancesAllocatesIPFromSubnet(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	subnet, err := c.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId:     vpc.Vpc.VpcId,
+		CidrBlock: aws.String("10.0.5.0/24"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSubnet: %v", err)
+	}
+
+	run, err := c.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-123"),
+		InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		SubnetId:     subnet.Subnet.SubnetId,
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	ip := aws.ToString(run.Instances[0].PrivateIpAddress)
+	if !strings.HasPrefix(ip, "10.0.5.") {
+		t.Fatalf("private IP %q not allocated from subnet CIDR 10.0.5.0/24", ip)
+	}
+}
+
+// TestDescribeInstanceReportsKeyNameAndGroupName pins that a DescribeInstances
+// item echoes the launch key pair and resolves security-group names alongside
+// ids (both read by SDK clients).
+func TestDescribeInstanceReportsKeyNameAndGroupName(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	if _, err := c.CreateKeyPair(ctx, &ec2.CreateKeyPairInput{KeyName: aws.String("launch-key")}); err != nil {
+		t.Fatalf("CreateKeyPair: %v", err)
+	}
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	sg, err := c.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String("web-sg"),
+		Description: aws.String("test"),
+		VpcId:       vpc.Vpc.VpcId,
+	})
+	if err != nil {
+		t.Fatalf("CreateSecurityGroup: %v", err)
+	}
+
+	run, err := c.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:          aws.String("ami-123"),
+		InstanceType:     ec2types.InstanceTypeT2Micro,
+		MinCount:         aws.Int32(1),
+		MaxCount:         aws.Int32(1),
+		KeyName:          aws.String("launch-key"),
+		SecurityGroupIds: []string{aws.ToString(sg.GroupId)},
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	id := aws.ToString(run.Instances[0].InstanceId)
+	out, err := c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{InstanceIds: []string{id}})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	inst := out.Reservations[0].Instances[0]
+	if aws.ToString(inst.KeyName) != "launch-key" {
+		t.Errorf("keyName = %q, want launch-key", aws.ToString(inst.KeyName))
+	}
+
+	if len(inst.SecurityGroups) != 1 {
+		t.Fatalf("securityGroups len = %d, want 1", len(inst.SecurityGroups))
+	}
+
+	if aws.ToString(inst.SecurityGroups[0].GroupName) != "web-sg" {
+		t.Errorf("group name = %q, want web-sg", aws.ToString(inst.SecurityGroups[0].GroupName))
+	}
+}

--- a/server/aws/ec2/instance_idempotency_test.go
+++ b/server/aws/ec2/instance_idempotency_test.go
@@ -1,0 +1,62 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestRunInstancesClientTokenIdempotent pins that a RunInstances retry carrying
+// the same ClientToken returns the already-launched instances instead of
+// provisioning new ones (real EC2 idempotency), so a retried request does not
+// double-provision.
+func TestRunInstancesClientTokenIdempotent(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	input := &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-123"),
+		InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		ClientToken:  aws.String("fixed-token-abc"),
+	}
+
+	first, err := c.RunInstances(ctx, input)
+	if err != nil {
+		t.Fatalf("RunInstances (first): %v", err)
+	}
+
+	second, err := c.RunInstances(ctx, input)
+	if err != nil {
+		t.Fatalf("RunInstances (retry): %v", err)
+	}
+
+	if len(first.Instances) != 1 || len(second.Instances) != 1 {
+		t.Fatalf("unexpected instance counts: first=%d second=%d",
+			len(first.Instances), len(second.Instances))
+	}
+
+	if got, want := aws.ToString(second.Instances[0].InstanceId),
+		aws.ToString(first.Instances[0].InstanceId); got != want {
+		t.Fatalf("retry launched a new instance %q, want same as %q", got, want)
+	}
+
+	// The account must hold exactly one instance, not two.
+	all, err := c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	total := 0
+	for i := range all.Reservations {
+		total += len(all.Reservations[i].Instances)
+	}
+
+	if total != 1 {
+		t.Fatalf("account holds %d instances, want 1 (no double-provisioning)", total)
+	}
+}

--- a/server/aws/ec2/instance_status.go
+++ b/server/aws/ec2/instance_status.go
@@ -8,12 +8,22 @@ import (
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 )
 
+// Detailed-monitoring wire states (Instance.Monitoring.State enum). MonitorInstances
+// transitions to "pending" and UnmonitorInstances to "disabling"; a settled
+// instance reports "enabled" or "disabled".
+const (
+	monitorStateDisabled  = "disabled"
+	monitorStateDisabling = "disabling"
+	monitorStateEnabled   = "enabled"
+	monitorStatePending   = "pending"
+)
+
 func (h *Handler) routeInstanceStatus(w http.ResponseWriter, r *http.Request, action string) bool {
 	switch action {
 	case "MonitorInstances":
-		h.monitorInstances(w, r, "enabled")
+		h.monitorInstances(w, r, true)
 	case "UnmonitorInstances":
-		h.monitorInstances(w, r, "disabled")
+		h.monitorInstances(w, r, false)
 	case "DescribeInstanceStatus":
 		h.describeInstanceStatus(w, r)
 	default:
@@ -36,9 +46,10 @@ type monitorInstancesResponseXML struct {
 }
 
 // monitorInstances answers Monitor/UnmonitorInstances. It validates each
-// requested instance exists (InvalidInstanceID.NotFound otherwise) and echoes
-// the resulting monitoring state.
-func (h *Handler) monitorInstances(w http.ResponseWriter, r *http.Request, state string) {
+// requested instance exists (InvalidInstanceID.NotFound otherwise), persists the
+// new monitoring state, and echoes the transitional wire state: MonitorInstances
+// returns "pending" and UnmonitorInstances "disabling" (not the settled value).
+func (h *Handler) monitorInstances(w http.ResponseWriter, r *http.Request, enable bool) {
 	ids := awsquery.ListStrings(r.Form, "InstanceId")
 
 	if _, err := h.compute.DescribeInstances(r.Context(), ids, nil); err != nil {
@@ -46,9 +57,23 @@ func (h *Handler) monitorInstances(w http.ResponseWriter, r *http.Request, state
 		return
 	}
 
+	stored, echo := monitorStateDisabled, monitorStateDisabling
+	if enable {
+		stored, echo = monitorStateEnabled, monitorStatePending
+	}
+
+	if attributer, ok := h.compute.(instanceAttributer); ok {
+		for _, id := range ids {
+			if err := attributer.SetInstanceAttribute(r.Context(), id, attrMonitoring, stored); err != nil {
+				writeErr(w, err)
+				return
+			}
+		}
+	}
+
 	items := make([]monitorItemXML, 0, len(ids))
 	for _, id := range ids {
-		items = append(items, monitorItemXML{InstanceID: id, State: state})
+		items = append(items, monitorItemXML{InstanceID: id, State: echo})
 	}
 
 	awsquery.WriteXMLResponse(w, monitorInstancesResponseXML{

--- a/server/aws/ec2/instance_status_test.go
+++ b/server/aws/ec2/instance_status_test.go
@@ -53,3 +53,61 @@ func assertReachabilityPassed(t *testing.T, label string, s *ec2types.InstanceSt
 		t.Fatalf("%s reachability status = %q, want passed", label, d.Status)
 	}
 }
+
+// TestMonitoringStateTransitions pins the detailed-monitoring lifecycle: a fresh
+// instance reports "disabled"; MonitorInstances echoes the transitional
+// "pending" and DescribeInstances then reports "enabled"; UnmonitorInstances
+// echoes "disabling" and DescribeInstances returns to "disabled".
+func TestMonitoringStateTransitions(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+	id := runOneInstance(t, c)
+
+	if got := describeMonitoringState(t, c, id); got != ec2types.MonitoringStateDisabled {
+		t.Fatalf("initial monitoring state = %q, want disabled", got)
+	}
+
+	mon, err := c.MonitorInstances(ctx, &ec2.MonitorInstancesInput{InstanceIds: []string{id}})
+	if err != nil {
+		t.Fatalf("MonitorInstances: %v", err)
+	}
+
+	if mon.InstanceMonitorings[0].Monitoring.State != ec2types.MonitoringStatePending {
+		t.Fatalf("MonitorInstances echo = %q, want pending", mon.InstanceMonitorings[0].Monitoring.State)
+	}
+
+	if got := describeMonitoringState(t, c, id); got != ec2types.MonitoringStateEnabled {
+		t.Fatalf("monitoring state after MonitorInstances = %q, want enabled", got)
+	}
+
+	unmon, err := c.UnmonitorInstances(ctx, &ec2.UnmonitorInstancesInput{InstanceIds: []string{id}})
+	if err != nil {
+		t.Fatalf("UnmonitorInstances: %v", err)
+	}
+
+	if unmon.InstanceMonitorings[0].Monitoring.State != ec2types.MonitoringStateDisabling {
+		t.Fatalf("UnmonitorInstances echo = %q, want disabling", unmon.InstanceMonitorings[0].Monitoring.State)
+	}
+
+	if got := describeMonitoringState(t, c, id); got != ec2types.MonitoringStateDisabled {
+		t.Fatalf("monitoring state after UnmonitorInstances = %q, want disabled", got)
+	}
+}
+
+func describeMonitoringState(t *testing.T, c *ec2.Client, id string) ec2types.MonitoringState {
+	t.Helper()
+
+	out, err := c.DescribeInstances(context.Background(), &ec2.DescribeInstancesInput{
+		InstanceIds: []string{id},
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	m := out.Reservations[0].Instances[0].Monitoring
+	if m == nil {
+		t.Fatalf("instance %q has no monitoring block", id)
+	}
+
+	return m.State
+}

--- a/server/aws/ec2/instance_types_test.go
+++ b/server/aws/ec2/instance_types_test.go
@@ -1,0 +1,79 @@
+package ec2_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestDescribeInstanceTypesRejectsUnknown pins that an explicitly requested,
+// unrecognized instance type is rejected with InvalidInstanceType (real EC2),
+// not answered with a fabricated {2 vCPU, 4096 MiB} spec.
+func TestDescribeInstanceTypesRejectsUnknown(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	_, err := c.DescribeInstanceTypes(ctx, &ec2.DescribeInstanceTypesInput{
+		InstanceTypes: []ec2types.InstanceType{"z9.mega"},
+	})
+	if err == nil {
+		t.Fatal("DescribeInstanceTypes(z9.mega) succeeded, want InvalidInstanceType")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidInstanceType" {
+		t.Fatalf("want InvalidInstanceType, got %v", err)
+	}
+}
+
+// TestDescribeInstanceTypesReportsProcessorAndNetwork pins that a known type
+// carries currentGeneration, processorInfo (architecture + clock) and networkInfo
+// (performance, max ENIs, IPs per ENI) — fields real DescribeInstanceTypes
+// returns and capacity planners read.
+func TestDescribeInstanceTypesReportsProcessorAndNetwork(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	out, err := c.DescribeInstanceTypes(ctx, &ec2.DescribeInstanceTypesInput{
+		InstanceTypes: []ec2types.InstanceType{ec2types.InstanceTypeT3Micro},
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstanceTypes: %v", err)
+	}
+
+	if len(out.InstanceTypes) != 1 {
+		t.Fatalf("InstanceTypes len = %d, want 1", len(out.InstanceTypes))
+	}
+
+	it := out.InstanceTypes[0]
+	if !aws.ToBool(it.CurrentGeneration) {
+		t.Error("currentGeneration = false, want true for t3.micro")
+	}
+
+	if it.ProcessorInfo == nil ||
+		len(it.ProcessorInfo.SupportedArchitectures) == 0 ||
+		it.ProcessorInfo.SupportedArchitectures[0] != ec2types.ArchitectureTypeX8664 {
+		t.Errorf("processorInfo architecture missing/wrong: %+v", it.ProcessorInfo)
+	}
+
+	if it.ProcessorInfo == nil || aws.ToFloat64(it.ProcessorInfo.SustainedClockSpeedInGhz) <= 0 {
+		t.Errorf("processorInfo clock speed not set: %+v", it.ProcessorInfo)
+	}
+
+	if it.NetworkInfo == nil || aws.ToString(it.NetworkInfo.NetworkPerformance) == "" {
+		t.Errorf("networkInfo networkPerformance missing: %+v", it.NetworkInfo)
+	}
+
+	if it.NetworkInfo == nil || aws.ToInt32(it.NetworkInfo.MaximumNetworkInterfaces) <= 0 {
+		t.Errorf("networkInfo maximumNetworkInterfaces not set: %+v", it.NetworkInfo)
+	}
+
+	if it.NetworkInfo == nil || aws.ToInt32(it.NetworkInfo.Ipv4AddressesPerInterface) <= 0 {
+		t.Errorf("networkInfo ipv4AddressesPerInterface not set: %+v", it.NetworkInfo)
+	}
+}

--- a/server/aws/ec2/metadata.go
+++ b/server/aws/ec2/metadata.go
@@ -66,25 +66,30 @@ func (*Handler) describeRegions(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// instanceTypeSpec is the vCPU/memory profile reported for an instance type.
+// instanceTypeSpec is the profile reported for an instance type: vCPU/memory
+// plus the processor and network facts real DescribeInstanceTypes returns.
 type instanceTypeSpec struct {
-	vcpus     int
-	memoryMiB int
+	vcpus       int
+	memoryMiB   int
+	clockGHz    float64
+	networkPerf string
+	maxENIs     int
+	ipsPerENI   int
 }
 
-// knownInstanceTypes maps the common instance types to their specs. An
-// unrecognized type still gets a response (small default) so validation calls
-// don't fail on a type the emulator hasn't enumerated.
+// knownInstanceTypes maps the common instance types to their specs. Unlike
+// before, an unrecognized *explicitly requested* type is rejected with
+// InvalidInstanceType (matching real EC2) rather than fabricated.
 var knownInstanceTypes = map[string]instanceTypeSpec{ //nolint:gochecknoglobals // static lookup table
-	"t2.micro":  {1, 1024},
-	"t2.small":  {1, 2048},
-	"t3.micro":  {2, 1024},
-	"t3.small":  {2, 2048},
-	"t3.medium": {2, 4096},
-	"m5.large":  {2, 8192},
-	"m5.xlarge": {4, 16384},
-	"c5.large":  {2, 4096},
-	"r5.large":  {2, 16384},
+	"t2.micro":  {vcpus: 1, memoryMiB: 1024, clockGHz: 3.3, networkPerf: "Low to Moderate", maxENIs: 2, ipsPerENI: 2},
+	"t2.small":  {vcpus: 1, memoryMiB: 2048, clockGHz: 3.3, networkPerf: "Low to Moderate", maxENIs: 3, ipsPerENI: 4},
+	"t3.micro":  {vcpus: 2, memoryMiB: 1024, clockGHz: 3.1, networkPerf: "Up to 5 Gigabit", maxENIs: 2, ipsPerENI: 2},
+	"t3.small":  {vcpus: 2, memoryMiB: 2048, clockGHz: 3.1, networkPerf: "Up to 5 Gigabit", maxENIs: 3, ipsPerENI: 4},
+	"t3.medium": {vcpus: 2, memoryMiB: 4096, clockGHz: 3.1, networkPerf: "Up to 5 Gigabit", maxENIs: 3, ipsPerENI: 6},
+	"m5.large":  {vcpus: 2, memoryMiB: 8192, clockGHz: 3.1, networkPerf: "Up to 10 Gigabit", maxENIs: 3, ipsPerENI: 10},
+	"m5.xlarge": {vcpus: 4, memoryMiB: 16384, clockGHz: 3.1, networkPerf: "Up to 10 Gigabit", maxENIs: 4, ipsPerENI: 15},
+	"c5.large":  {vcpus: 2, memoryMiB: 4096, clockGHz: 3.4, networkPerf: "Up to 10 Gigabit", maxENIs: 3, ipsPerENI: 10},
+	"r5.large":  {vcpus: 2, memoryMiB: 16384, clockGHz: 3.1, networkPerf: "Up to 10 Gigabit", maxENIs: 3, ipsPerENI: 10},
 }
 
 type vCPUInfoXML struct {
@@ -95,10 +100,24 @@ type memoryInfoXML struct {
 	SizeInMiB int `xml:"sizeInMiB"`
 }
 
+type processorInfoXML struct {
+	SupportedArchitectures   []string `xml:"supportedArchitectures>item"`
+	SustainedClockSpeedInGhz float64  `xml:"sustainedClockSpeedInGhz"`
+}
+
+type networkInfoXML struct {
+	NetworkPerformance        string `xml:"networkPerformance"`
+	MaximumNetworkInterfaces  int    `xml:"maximumNetworkInterfaces"`
+	Ipv4AddressesPerInterface int    `xml:"ipv4AddressesPerInterface"`
+}
+
 type instanceTypeInfoXML struct {
-	InstanceType string        `xml:"instanceType"`
-	VCPUInfo     vCPUInfoXML   `xml:"vCpuInfo"`
-	MemoryInfo   memoryInfoXML `xml:"memoryInfo"`
+	InstanceType      string           `xml:"instanceType"`
+	CurrentGeneration bool             `xml:"currentGeneration"`
+	VCPUInfo          vCPUInfoXML      `xml:"vCpuInfo"`
+	MemoryInfo        memoryInfoXML    `xml:"memoryInfo"`
+	ProcessorInfo     processorInfoXML `xml:"processorInfo"`
+	NetworkInfo       networkInfoXML   `xml:"networkInfo"`
 }
 
 type describeInstanceTypesResponseXML struct {
@@ -109,8 +128,9 @@ type describeInstanceTypesResponseXML struct {
 }
 
 // describeInstanceTypes answers ec2:DescribeInstanceTypes. Explicit
-// InstanceType.N values are echoed with their (or a default) spec; with none
-// supplied, the known set is reported.
+// InstanceType.N values are echoed with their spec; an unrecognized explicit
+// type is rejected with InvalidInstanceType (real EC2). With none supplied, the
+// whole known set is reported.
 func (*Handler) describeInstanceTypes(w http.ResponseWriter, r *http.Request) {
 	requested := awsquery.ListStrings(r.Form, "InstanceType")
 
@@ -126,13 +146,26 @@ func (*Handler) describeInstanceTypes(w http.ResponseWriter, r *http.Request) {
 	for _, name := range names {
 		spec, ok := knownInstanceTypes[name]
 		if !ok {
-			spec = instanceTypeSpec{vcpus: 2, memoryMiB: 4096}
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidInstanceType",
+				"The instance type '"+name+"' is not supported")
+
+			return
 		}
 
 		out = append(out, instanceTypeInfoXML{
-			InstanceType: name,
-			VCPUInfo:     vCPUInfoXML{DefaultVCpus: spec.vcpus},
-			MemoryInfo:   memoryInfoXML{SizeInMiB: spec.memoryMiB},
+			InstanceType:      name,
+			CurrentGeneration: true,
+			VCPUInfo:          vCPUInfoXML{DefaultVCpus: spec.vcpus},
+			MemoryInfo:        memoryInfoXML{SizeInMiB: spec.memoryMiB},
+			ProcessorInfo: processorInfoXML{
+				SupportedArchitectures:   []string{archX86},
+				SustainedClockSpeedInGhz: spec.clockGHz,
+			},
+			NetworkInfo: networkInfoXML{
+				NetworkPerformance:        spec.networkPerf,
+				MaximumNetworkInterfaces:  spec.maxENIs,
+				Ipv4AddressesPerInterface: spec.ipsPerENI,
+			},
 		})
 	}
 

--- a/server/aws/ec2/network_acl.go
+++ b/server/aws/ec2/network_acl.go
@@ -24,6 +24,7 @@ type networkACLEntryXML struct {
 type networkACLXML struct {
 	NetworkACLID string               `xml:"networkAclId"`
 	VpcID        string               `xml:"vpcId"`
+	OwnerID      string               `xml:"ownerId"`
 	IsDefault    bool                 `xml:"default"`
 	Entries      []networkACLEntryXML `xml:"entrySet>item,omitempty"`
 	Tags         []tagItem            `xml:"tagSet>item,omitempty"`
@@ -211,6 +212,7 @@ func toNetworkACLXML(a *netdriver.NetworkACL) networkACLXML {
 	x := networkACLXML{
 		NetworkACLID: a.ID,
 		VpcID:        a.VPCID,
+		OwnerID:      ownerID,
 		IsDefault:    a.IsDefault,
 		Tags:         toTagItems(a.Tags),
 	}

--- a/server/aws/ec2/network_acl_test.go
+++ b/server/aws/ec2/network_acl_test.go
@@ -9,6 +9,39 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
+// TestNetworkACLOwnerID pins that a network ACL reports its owning account id.
+// Terraform's aws_network_acl and aws_default_network_acl read ownerId; an empty
+// value makes the ACL look cross-account.
+func TestNetworkACLOwnerID(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	acl, err := c.CreateNetworkAcl(ctx, &ec2.CreateNetworkAclInput{VpcId: vpc.Vpc.VpcId})
+	if err != nil {
+		t.Fatalf("CreateNetworkAcl: %v", err)
+	}
+
+	if got := aws.ToString(acl.NetworkAcl.OwnerId); got != "123456789012" {
+		t.Errorf("CreateNetworkAcl OwnerId = %q, want 123456789012", got)
+	}
+
+	desc, err := c.DescribeNetworkAcls(ctx, &ec2.DescribeNetworkAclsInput{
+		NetworkAclIds: []string{aws.ToString(acl.NetworkAcl.NetworkAclId)},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNetworkAcls: %v", err)
+	}
+
+	if got := aws.ToString(desc.NetworkAcls[0].OwnerId); got != "123456789012" {
+		t.Errorf("DescribeNetworkAcls OwnerId = %q, want 123456789012", got)
+	}
+}
+
 // TestReplaceNetworkAclEntry pins the previously-undispatched
 // ReplaceNetworkAclEntry action: it swaps the rule at (ruleNumber, egress) in
 // place, so a caller updating an existing entry (Terraform aws_network_acl_rule

--- a/server/aws/ec2/operations.go
+++ b/server/aws/ec2/operations.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/base64"
 	"net/http"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -19,6 +21,7 @@ import (
 type instanceAttributer interface {
 	SetInstanceAttribute(ctx context.Context, id, name, value string) error
 	GetInstanceAttribute(ctx context.Context, id, name string) (string, error)
+	SetInstanceSecurityGroups(ctx context.Context, id string, groupIDs []string) error
 }
 
 // Attribute element names shared by ModifyInstanceAttribute (Name.Value on the
@@ -27,10 +30,33 @@ const (
 	attrDisableAPITermination = "disableApiTermination"
 	attrSourceDestCheck       = "sourceDestCheck"
 	attrInstanceType          = "instanceType"
+	attrUserData              = "userData"
+	attrEbsOptimized          = "ebsOptimized"
+	attrGroupSet              = "groupSet"
+	attrMonitoring            = "monitoring"
 )
 
-// reservationPrefix is our own reservation ID prefix. Real AWS uses "r-".
+// reservationPrefix is the AWS reservation ID prefix (r-xxxx).
 const reservationPrefix = "r-"
+
+// Static instance facts real EC2 reports for the Linux/x86 instances this
+// emulator launches. They are fixed rather than modeled because no cloudemu
+// behavior depends on them, but SDK clients and IaC read them.
+const (
+	archX86            = "x86_64"
+	hypervisorXen      = "xen"
+	virtualizationHVM  = "hvm"
+	rootDeviceTypeEBS  = "ebs"
+	rootDeviceNameXVDA = "/dev/xvda"
+	tenancyDefault     = "default"
+	defaultZone        = "us-east-1a"
+	// eniAttachedStatus / primaryDeviceIndex describe the primary ENI's
+	// attachment.
+	eniAttachedStatus  = "attached"
+	primaryDeviceIndex = 0
+	// internalDNSSuffix is the private-DNS suffix EC2 uses in us-east-1.
+	internalDNSSuffix = ".ec2.internal"
+)
 
 // runInstances handles Action=RunInstances.
 func (h *Handler) runInstances(w http.ResponseWriter, r *http.Request) {
@@ -45,6 +71,7 @@ func (h *Handler) runInstances(w http.ResponseWriter, r *http.Request) {
 		SecurityGroups: awsquery.ListStrings(form, "SecurityGroupId"),
 		KeyName:        form.Get("KeyName"),
 		UserData:       decodeUserData(form.Get("UserData")),
+		ClientToken:    form.Get("ClientToken"),
 		Tags:           mergeTagSpecs(awsquery.TagSpecs(form), "instance"),
 	}
 
@@ -64,10 +91,20 @@ func (h *Handler) runInstances(w http.ResponseWriter, r *http.Request) {
 	awsquery.WriteXMLResponse(w, runInstancesResponse{
 		Xmlns:         awsquery.Namespace,
 		RequestID:     awsquery.RequestID,
-		ReservationID: reservationPrefix + stripInstancePrefix(instances[0].ID),
+		ReservationID: reservationIDFor(&instances[0]),
 		OwnerID:       ownerID,
-		Instances:     toInstanceXMLs(instances),
+		Instances:     h.toInstanceXMLs(r.Context(), instances),
 	})
+}
+
+// reservationIDFor returns the instance's reservation id, falling back to a
+// per-instance reservation for providers (Azure/GCP) that don't group launches.
+func reservationIDFor(inst *computedriver.Instance) string {
+	if inst.ReservationID != "" {
+		return inst.ReservationID
+	}
+
+	return reservationPrefix + stripInstancePrefix(inst.ID)
 }
 
 // describeInstances handles Action=DescribeInstances.
@@ -86,22 +123,102 @@ func (h *Handler) describeInstances(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// We don't track real reservation groupings — each instance gets its own
-	// singleton reservation. SDK clients are happy with this shape.
-	reservations := make([]reservationXML, 0, len(instances))
-	for i := range instances {
-		reservations = append(reservations, reservationXML{
-			ReservationID: reservationPrefix + stripInstancePrefix(instances[i].ID),
-			OwnerID:       ownerID,
-			Instances:     toInstanceXMLs(instances[i : i+1]),
-		})
-	}
+	// Group instances launched by one RunInstances call under a shared
+	// reservation, preserving first-seen order (real EC2 <reservationSet>).
+	reservations := h.groupReservations(r.Context(), instances)
+
+	page, next := paginateReservations(reservations, form.Get("MaxResults"), form.Get("NextToken"))
 
 	awsquery.WriteXMLResponse(w, describeInstancesResponse{
 		Xmlns:        awsquery.Namespace,
 		RequestID:    awsquery.RequestID,
-		Reservations: reservations,
+		Reservations: page,
+		NextToken:    next,
 	})
+}
+
+// groupReservations collapses instances into reservations by ReservationID,
+// keeping the order reservations were first seen so paging is stable.
+func (h *Handler) groupReservations(ctx context.Context, instances []computedriver.Instance) []reservationXML {
+	order := make([]string, 0)
+	byID := make(map[string]*reservationXML)
+
+	for i := range instances {
+		rid := reservationIDFor(&instances[i])
+
+		res, ok := byID[rid]
+		if !ok {
+			order = append(order, rid)
+			byID[rid] = &reservationXML{ReservationID: rid, OwnerID: ownerID}
+			res = byID[rid]
+		}
+
+		res.Instances = append(res.Instances, h.toInstanceXMLs(ctx, instances[i:i+1])...)
+	}
+
+	out := make([]reservationXML, 0, len(order))
+	for _, rid := range order {
+		out = append(out, *byID[rid])
+	}
+
+	// Sort by reservation id so the paging cursor is stable across calls (the
+	// underlying store iterates in map order). Ids are monotonic, so this is
+	// also launch order.
+	sort.Slice(out, func(i, j int) bool { return out[i].ReservationID < out[j].ReservationID })
+
+	return out
+}
+
+// maxDescribeResults bounds a page when the request omits a valid MaxResults.
+const maxDescribeResults = 1000
+
+// paginateReservations slices reservations to at most maxResults, returning the
+// page and a NextToken (the id of the first reservation on the following page,
+// base64-encoded). An empty/invalid maxResults returns everything.
+func paginateReservations(reservations []reservationXML, maxResultsStr, token string) (page []reservationXML, next string) {
+	start := decodeReservationToken(token, reservations)
+
+	limit, err := strconv.Atoi(maxResultsStr)
+	if err != nil || limit <= 0 {
+		return reservations[start:], ""
+	}
+
+	if limit > maxDescribeResults {
+		limit = maxDescribeResults
+	}
+
+	end := start + limit
+	if end >= len(reservations) {
+		return reservations[start:], ""
+	}
+
+	return reservations[start:end], encodeReservationToken(reservations[end].ReservationID)
+}
+
+// decodeReservationToken maps a NextToken back to a start index. An unknown or
+// empty token starts at the beginning.
+func decodeReservationToken(token string, reservations []reservationXML) int {
+	if token == "" {
+		return 0
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return 0
+	}
+
+	for i := range reservations {
+		if reservations[i].ReservationID == string(raw) {
+			return i
+		}
+	}
+
+	return 0
+}
+
+// encodeReservationToken base64-encodes a reservation id for use as a NextToken.
+func encodeReservationToken(reservationID string) string {
+	return base64.StdEncoding.EncodeToString([]byte(reservationID))
 }
 
 // startInstances handles Action=StartInstances.
@@ -213,19 +330,28 @@ func (h *Handler) modifyInstanceAttribute(w http.ResponseWriter, r *http.Request
 	})
 }
 
-// applyInstanceAttributes writes the boolean instance attributes present in the
-// request through the instanceAttributer capability.
+// applyInstanceAttributes writes the single-value instance attributes and the
+// security-group membership present in the request through the
+// instanceAttributer capability. Each ModifyInstanceAttribute call carries at
+// most one attribute, so absent parameters are simply skipped.
 func (h *Handler) applyInstanceAttributes(r *http.Request, id string) error {
 	attributer, ok := h.compute.(instanceAttributer)
 	if !ok {
 		return nil
 	}
 
-	for _, name := range []string{attrDisableAPITermination, attrSourceDestCheck} {
+	for _, name := range []string{attrDisableAPITermination, attrSourceDestCheck, attrEbsOptimized, attrUserData} {
 		if v := r.Form.Get(attrForm(name) + ".Value"); v != "" {
 			if err := attributer.SetInstanceAttribute(r.Context(), id, name, v); err != nil {
 				return err
 			}
+		}
+	}
+
+	// GroupId.N (VPC instances) replaces the instance's security-group set.
+	if groups := awsquery.ListStrings(r.Form, "GroupId"); len(groups) > 0 {
+		if err := attributer.SetInstanceSecurityGroups(r.Context(), id, groups); err != nil {
+			return err
 		}
 	}
 
@@ -245,16 +371,29 @@ func (h *Handler) describeInstanceAttribute(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	val, err := attributer.GetInstanceAttribute(r.Context(), id, attr)
-	if err != nil {
-		writeErr(w, err)
-		return
-	}
-
 	resp := describeInstanceAttributeResponse{
 		Xmlns:      awsquery.Namespace,
 		RequestID:  awsquery.RequestID,
 		InstanceID: id,
+	}
+
+	// groupSet is a list, not a single scalar, so it is read from the instance's
+	// membership rather than the scalar GetInstanceAttribute path.
+	if attr == attrGroupSet {
+		if err := h.attachInstanceGroups(r.Context(), id, &resp); err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		awsquery.WriteXMLResponse(w, resp)
+
+		return
+	}
+
+	val, err := attributer.GetInstanceAttribute(r.Context(), id, attr)
+	if err != nil {
+		writeErr(w, err)
+		return
 	}
 
 	switch attr {
@@ -262,11 +401,35 @@ func (h *Handler) describeInstanceAttribute(w http.ResponseWriter, r *http.Reque
 		resp.DisableAPITermination = &attributeBooleanValueXML{Value: val == formTrue}
 	case attrSourceDestCheck:
 		resp.SourceDestCheck = &attributeBooleanValueXML{Value: val == formTrue}
+	case attrEbsOptimized:
+		resp.EBSOptimized = &attributeBooleanValueXML{Value: val == formTrue}
 	case attrInstanceType:
 		resp.InstanceType = &attributeValueXML{Value: val}
+	case attrUserData:
+		resp.UserData = &attributeValueXML{Value: val}
 	}
 
 	awsquery.WriteXMLResponse(w, resp)
+}
+
+// attachInstanceGroups populates resp.Groups from the instance's current
+// security-group membership (with resolved names) for the groupSet attribute.
+func (h *Handler) attachInstanceGroups(ctx context.Context, id string, resp *describeInstanceAttributeResponse) error {
+	instances, err := h.compute.DescribeInstances(ctx, []string{id}, nil)
+	if err != nil {
+		return err
+	}
+
+	if len(instances) == 0 {
+		return cerrors.Newf(cerrors.NotFound, "instance %q not found", id)
+	}
+
+	names := h.securityGroupNames(ctx, instances[0].SecurityGroups)
+	for _, sg := range instances[0].SecurityGroups {
+		resp.Groups = append(resp.Groups, groupItem{GroupID: sg, GroupName: names[sg]})
+	}
+
+	return nil
 }
 
 // attrForm maps an attribute element name (lowerCamel, as on the response) to
@@ -277,6 +440,10 @@ func attrForm(name string) string {
 		return "DisableApiTermination"
 	case attrSourceDestCheck:
 		return "SourceDestCheck"
+	case attrEbsOptimized:
+		return "EbsOptimized"
+	case attrUserData:
+		return "UserData"
 	default:
 		return name
 	}
@@ -370,44 +537,164 @@ func mergeTagSpecs(specs []awsquery.TagSpec, resource string) map[string]string 
 	return out
 }
 
-// toInstanceXMLs converts driver instances to their XML wire form.
-func toInstanceXMLs(instances []computedriver.Instance) []instanceXML {
+// toInstanceXMLs converts driver instances to their XML wire form, resolving
+// security-group names once for the whole batch.
+func (h *Handler) toInstanceXMLs(ctx context.Context, instances []computedriver.Instance) []instanceXML {
+	names := h.securityGroupNames(ctx, collectSecurityGroups(instances))
+
 	out := make([]instanceXML, 0, len(instances))
-
 	for i := range instances {
-		inst := &instances[i]
-		xi := instanceXML{
-			InstanceID:   inst.ID,
-			ImageID:      inst.ImageID,
-			InstanceType: inst.InstanceType,
-			State:        instanceState{Code: stateCode(inst.State), Name: inst.State},
-			LaunchTime:   inst.LaunchTime,
-			SubnetID:     inst.SubnetID,
-			VPCID:        inst.VPCID,
-			PrivateIP:    inst.PrivateIP,
-			PublicIP:     inst.PublicIP,
-		}
-
-		for _, sg := range inst.SecurityGroups {
-			xi.Groups = append(xi.Groups, groupItem{GroupID: sg})
-		}
-
-		for k, v := range inst.Tags {
-			xi.Tags = append(xi.Tags, tagItem{Key: k, Value: v})
-		}
-
-		if inst.Operator != nil {
-			xi.Operator = &operatorXML{
-				Managed:         inst.Operator.Managed,
-				Principal:       inst.Operator.Principal,
-				HiddenByDefault: inst.Operator.HiddenByDefault,
-			}
-		}
-
-		out = append(out, xi)
+		out = append(out, instanceXMLFor(&instances[i], names))
 	}
 
 	return out
+}
+
+// instanceXMLFor builds the wire shape for one instance, including the static
+// facts and derived placement / DNS / primary-ENI fields real EC2 reports.
+func instanceXMLFor(inst *computedriver.Instance, names map[string]string) instanceXML {
+	xi := instanceXML{
+		InstanceID:         inst.ID,
+		ImageID:            inst.ImageID,
+		InstanceType:       inst.InstanceType,
+		State:              instanceState{Code: stateCode(inst.State), Name: inst.State},
+		LaunchTime:         inst.LaunchTime,
+		SubnetID:           inst.SubnetID,
+		VPCID:              inst.VPCID,
+		PrivateIP:          inst.PrivateIP,
+		PublicIP:           inst.PublicIP,
+		PrivateDNSName:     privateDNSName(inst.PrivateIP),
+		PublicDNSName:      publicDNSName(inst.PublicIP),
+		KeyName:            inst.KeyName,
+		AmiLaunchIndex:     0,
+		Architecture:       archX86,
+		RootDeviceType:     rootDeviceTypeEBS,
+		RootDeviceName:     rootDeviceNameXVDA,
+		VirtualizationType: virtualizationHVM,
+		Hypervisor:         hypervisorXen,
+		Placement:          &placementXML{AvailabilityZone: instanceZone(inst), Tenancy: tenancyDefault},
+		Monitoring:         &monitoringXML{State: monitoringState(inst.Monitoring)},
+	}
+
+	for _, sg := range inst.SecurityGroups {
+		xi.Groups = append(xi.Groups, groupItem{GroupID: sg, GroupName: names[sg]})
+	}
+
+	if eni := primaryENI(inst, xi.Groups); eni != nil {
+		xi.NetworkInterfaces = []instanceENIXML{*eni}
+	}
+
+	for k, v := range inst.Tags {
+		xi.Tags = append(xi.Tags, tagItem{Key: k, Value: v})
+	}
+
+	if inst.Operator != nil {
+		xi.Operator = &operatorXML{
+			Managed:         inst.Operator.Managed,
+			Principal:       inst.Operator.Principal,
+			HiddenByDefault: inst.Operator.HiddenByDefault,
+		}
+	}
+
+	return xi
+}
+
+// primaryENI synthesizes the instance's single primary network interface from
+// its subnet/VPC/private-IP/security-groups, or nil when there is nothing to
+// describe (no subnet, VPC, or private IP).
+func primaryENI(inst *computedriver.Instance, groups []groupItem) *instanceENIXML {
+	if inst.SubnetID == "" && inst.VPCID == "" && inst.PrivateIP == "" {
+		return nil
+	}
+
+	return &instanceENIXML{
+		SubnetID:   inst.SubnetID,
+		VPCID:      inst.VPCID,
+		PrivateIP:  inst.PrivateIP,
+		Groups:     groups,
+		Attachment: instanceENIAttachmentXML{DeviceIndex: primaryDeviceIndex, Status: eniAttachedStatus},
+	}
+}
+
+// instanceZone returns the instance's availability zone, defaulting to a stable
+// zone when the provider does not track placement.
+func instanceZone(inst *computedriver.Instance) string {
+	if len(inst.Zones) > 0 && inst.Zones[0] != "" {
+		return inst.Zones[0]
+	}
+
+	return defaultZone
+}
+
+// monitoringState maps a stored monitoring value to the wire enum, defaulting to
+// "disabled" (basic monitoring) when unset.
+func monitoringState(state string) string {
+	if state == "" {
+		return monitorStateDisabled
+	}
+
+	return state
+}
+
+// collectSecurityGroups returns the de-duplicated security-group ids across the
+// batch so names are resolved in a single networking lookup.
+func collectSecurityGroups(instances []computedriver.Instance) []string {
+	seen := make(map[string]struct{})
+
+	var ids []string
+
+	for i := range instances {
+		for _, sg := range instances[i].SecurityGroups {
+			if _, ok := seen[sg]; !ok {
+				seen[sg] = struct{}{}
+
+				ids = append(ids, sg)
+			}
+		}
+	}
+
+	return ids
+}
+
+// securityGroupNames resolves security-group ids to their names via the
+// networking driver. It returns an empty map when no networking driver is wired
+// or the lookup fails, so name resolution is best-effort (ids still render).
+func (h *Handler) securityGroupNames(ctx context.Context, ids []string) map[string]string {
+	names := make(map[string]string)
+	if h.vpc == nil || len(ids) == 0 {
+		return names
+	}
+
+	groups, err := h.vpc.DescribeSecurityGroups(ctx, ids)
+	if err != nil {
+		return names
+	}
+
+	for i := range groups {
+		names[groups[i].ID] = groups[i].Name
+	}
+
+	return names
+}
+
+// privateDNSName derives the EC2 internal DNS name from a private IPv4
+// (10.0.0.5 -> ip-10-0-0-5.ec2.internal). Empty for an instance with no IP.
+func privateDNSName(ip string) string {
+	if ip == "" {
+		return ""
+	}
+
+	return "ip-" + strings.ReplaceAll(ip, ".", "-") + internalDNSSuffix
+}
+
+// publicDNSName derives the public DNS name from a public IPv4
+// (52.1.2.3 -> ec2-52-1-2-3.compute-1.amazonaws.com). Empty when no public IP.
+func publicDNSName(ip string) string {
+	if ip == "" {
+		return ""
+	}
+
+	return "ec2-" + strings.ReplaceAll(ip, ".", "-") + ".compute-1.amazonaws.com"
 }
 
 // toDriverFilters converts parsed filters to the driver's filter shape.

--- a/server/aws/ec2/route_table.go
+++ b/server/aws/ec2/route_table.go
@@ -47,6 +47,7 @@ type rtAssociationXML struct {
 type routeTableXML struct {
 	RouteTableID string             `xml:"routeTableId"`
 	VpcID        string             `xml:"vpcId"`
+	OwnerID      string             `xml:"ownerId"`
 	Routes       []routeXML         `xml:"routeSet>item,omitempty"`
 	Associations []rtAssociationXML `xml:"associationSet>item,omitempty"`
 	Tags         []tagItem          `xml:"tagSet>item,omitempty"`
@@ -75,6 +76,13 @@ type createRouteResponseXML struct {
 
 type deleteRouteResponseXML struct {
 	XMLName   xml.Name `xml:"DeleteRouteResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
+type replaceRouteResponseXML struct {
+	XMLName   xml.Name `xml:"ReplaceRouteResponse"`
 	Xmlns     string   `xml:"xmlns,attr"`
 	RequestID string   `xml:"requestId"`
 	Return    bool     `xml:"return"`
@@ -173,6 +181,40 @@ func (h *Handler) createRoute(w http.ResponseWriter, r *http.Request) {
 	}
 
 	awsquery.WriteXMLResponse(w, createRouteResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Return:    true,
+	})
+}
+
+// replaceRoute swaps the target of an existing route, keyed by its destination
+// CIDR. Real EC2 requires the route to already exist (a miss is
+// InvalidRoute.NotFound), so it is modeled as DeleteRoute-then-CreateRoute: the
+// delete step's NotFound is exactly the "route must exist" precondition, and the
+// create step re-adds it with the new target.
+func (h *Handler) replaceRoute(w http.ResponseWriter, r *http.Request) {
+	target, targetType := resolveRouteTarget(r)
+	if target == "" {
+		writeReplaceRouteErr(w, newInvalidParameterErr(
+			"one of GatewayId / NatGatewayId / VpcPeeringConnectionId is required"))
+
+		return
+	}
+
+	routeTableID := r.Form.Get("RouteTableId")
+	destinationCIDR := r.Form.Get("DestinationCidrBlock")
+
+	if err := h.vpc.DeleteRoute(r.Context(), routeTableID, destinationCIDR); err != nil {
+		writeReplaceRouteErr(w, err)
+		return
+	}
+
+	if err := h.vpc.CreateRoute(r.Context(), routeTableID, destinationCIDR, target, targetType); err != nil {
+		writeReplaceRouteErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, replaceRouteResponseXML{
 		Xmlns:     awsquery.Namespace,
 		RequestID: awsquery.RequestID,
 		Return:    true,
@@ -347,6 +389,7 @@ func toRouteTableXML(rt *netdriver.RouteTable) routeTableXML {
 	x := routeTableXML{
 		RouteTableID: rt.ID,
 		VpcID:        rt.VPCID,
+		OwnerID:      ownerID,
 		Tags:         toTagItems(rt.Tags),
 	}
 
@@ -406,4 +449,11 @@ func nonEmpty(s, fallback string) string {
 
 func writeRouteTableErr(w http.ResponseWriter, err error) {
 	writeErrWithNotFound(w, err, "InvalidRouteTableID.NotFound", "DependencyViolation")
+}
+
+// writeReplaceRouteErr maps a NotFound to InvalidRoute.NotFound: ReplaceRoute's
+// precondition is that the route already exists, so the delete-step miss reports
+// the missing route, matching real EC2, rather than the route-table code.
+func writeReplaceRouteErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidRoute.NotFound", "DependencyViolation")
 }

--- a/server/aws/ec2/route_table.go
+++ b/server/aws/ec2/route_table.go
@@ -204,6 +204,16 @@ func (h *Handler) replaceRoute(w http.ResponseWriter, r *http.Request) {
 	routeTableID := r.Form.Get("RouteTableId")
 	destinationCIDR := r.Form.Get("DestinationCidrBlock")
 
+	// A missing route TABLE is InvalidRouteTableID.NotFound; a missing ROUTE on an
+	// existing table is InvalidRoute.NotFound. DeleteRoute conflates the two, so
+	// resolve the table first.
+	if rts, _ := h.vpc.DescribeRouteTables(r.Context(), []string{routeTableID}); len(rts) == 0 {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidRouteTableID.NotFound",
+			"The route table ID '"+routeTableID+"' does not exist")
+
+		return
+	}
+
 	if err := h.vpc.DeleteRoute(r.Context(), routeTableID, destinationCIDR); err != nil {
 		writeReplaceRouteErr(w, err)
 		return

--- a/server/aws/ec2/route_table_test.go
+++ b/server/aws/ec2/route_table_test.go
@@ -111,6 +111,16 @@ func TestReplaceRoute(t *testing.T) {
 	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidRoute.NotFound" {
 		t.Fatalf("want InvalidRoute.NotFound, got %v", err)
 	}
+
+	// A missing route TABLE is a different error code than a missing route.
+	_, err = c.ReplaceRoute(ctx, &ec2.ReplaceRouteInput{
+		RouteTableId:         aws.String("rtb-doesnotexist"),
+		DestinationCidrBlock: aws.String("10.0.0.0/16"),
+		GatewayId:            aws.String(igw2),
+	})
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidRouteTableID.NotFound" {
+		t.Fatalf("want InvalidRouteTableID.NotFound for a bogus route table, got %v", err)
+	}
 }
 
 // mkIGW creates an internet gateway and returns its id.

--- a/server/aws/ec2/route_table_test.go
+++ b/server/aws/ec2/route_table_test.go
@@ -2,12 +2,139 @@ package ec2_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
 )
+
+// TestRouteTableOwnerID pins that a route table reports its owning account id.
+// Terraform's aws_route_table and aws_default_route_table read ownerId; an empty
+// value makes the resource look cross-account and breaks import/refresh.
+func TestRouteTableOwnerID(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	rt, err := c.CreateRouteTable(ctx, &ec2.CreateRouteTableInput{VpcId: vpc.Vpc.VpcId})
+	if err != nil {
+		t.Fatalf("CreateRouteTable: %v", err)
+	}
+
+	if got := aws.ToString(rt.RouteTable.OwnerId); got != "123456789012" {
+		t.Errorf("CreateRouteTable OwnerId = %q, want 123456789012", got)
+	}
+
+	desc, err := c.DescribeRouteTables(ctx, &ec2.DescribeRouteTablesInput{
+		RouteTableIds: []string{aws.ToString(rt.RouteTable.RouteTableId)},
+	})
+	if err != nil {
+		t.Fatalf("DescribeRouteTables: %v", err)
+	}
+
+	if got := aws.ToString(desc.RouteTables[0].OwnerId); got != "123456789012" {
+		t.Errorf("DescribeRouteTables OwnerId = %q, want 123456789012", got)
+	}
+}
+
+// TestReplaceRoute pins ReplaceRoute: it swaps the target of an existing route
+// keyed by destination CIDR, and returns InvalidRoute.NotFound when the route
+// does not already exist (its documented precondition).
+func TestReplaceRoute(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	vpcID := aws.ToString(vpc.Vpc.VpcId)
+
+	igw1 := mkIGW(ctx, t, c)
+	igw2 := mkIGW(ctx, t, c)
+
+	rt, err := c.CreateRouteTable(ctx, &ec2.CreateRouteTableInput{VpcId: aws.String(vpcID)})
+	if err != nil {
+		t.Fatalf("CreateRouteTable: %v", err)
+	}
+
+	rtID := aws.ToString(rt.RouteTable.RouteTableId)
+
+	if _, err := c.CreateRoute(ctx, &ec2.CreateRouteInput{
+		RouteTableId:         aws.String(rtID),
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		GatewayId:            aws.String(igw1),
+	}); err != nil {
+		t.Fatalf("CreateRoute: %v", err)
+	}
+
+	if _, err := c.ReplaceRoute(ctx, &ec2.ReplaceRouteInput{
+		RouteTableId:         aws.String(rtID),
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		GatewayId:            aws.String(igw2),
+	}); err != nil {
+		t.Fatalf("ReplaceRoute: %v", err)
+	}
+
+	desc, err := c.DescribeRouteTables(ctx, &ec2.DescribeRouteTablesInput{RouteTableIds: []string{rtID}})
+	if err != nil {
+		t.Fatalf("DescribeRouteTables: %v", err)
+	}
+
+	route := findRouteByCIDR(desc.RouteTables[0].Routes, "0.0.0.0/0")
+	if route == nil {
+		t.Fatalf("route 0.0.0.0/0 not found after replace; routes: %+v", desc.RouteTables[0].Routes)
+	}
+
+	if got := aws.ToString(route.GatewayId); got != igw2 {
+		t.Errorf("route gatewayId = %q, want %q (replaced target)", got, igw2)
+	}
+
+	_, err = c.ReplaceRoute(ctx, &ec2.ReplaceRouteInput{
+		RouteTableId:         aws.String(rtID),
+		DestinationCidrBlock: aws.String("192.168.0.0/16"),
+		GatewayId:            aws.String(igw2),
+	})
+	if err == nil {
+		t.Fatal("ReplaceRoute on a non-existent route should fail")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidRoute.NotFound" {
+		t.Fatalf("want InvalidRoute.NotFound, got %v", err)
+	}
+}
+
+// mkIGW creates an internet gateway and returns its id.
+func mkIGW(ctx context.Context, t *testing.T, c *ec2.Client) string {
+	t.Helper()
+
+	igw, err := c.CreateInternetGateway(ctx, &ec2.CreateInternetGatewayInput{})
+	if err != nil {
+		t.Fatalf("CreateInternetGateway: %v", err)
+	}
+
+	return aws.ToString(igw.InternetGateway.InternetGatewayId)
+}
+
+// findRouteByCIDR returns the route with the given destination CIDR, or nil.
+func findRouteByCIDR(routes []ec2types.Route, cidr string) *ec2types.Route {
+	for i := range routes {
+		if aws.ToString(routes[i].DestinationCidrBlock) == cidr {
+			return &routes[i]
+		}
+	}
+
+	return nil
+}
 
 // TestRouteTableLocalRoute pins that a new route table's implicit VPC-local
 // route reports gatewayId "local" and origin CreateRouteTable. Terraform's

--- a/server/aws/ec2/security_group.go
+++ b/server/aws/ec2/security_group.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
@@ -17,6 +18,13 @@ import (
 // tagKeyFilter is the DescribeSecurityGroups filter that matches on the
 // presence of a tag key (as opposed to "tag:<key>", which matches a value).
 const tagKeyFilter = "tag-key"
+
+// groupIDFilter and securityGroupRuleIDFilter are the filter names shared by
+// DescribeSecurityGroups and DescribeSecurityGroupRules.
+const (
+	groupIDFilter             = "group-id"
+	securityGroupRuleIDFilter = "security-group-rule-id"
+)
 
 func errMissingGroupID() error {
 	return cerrors.New(cerrors.InvalidArgument, "GroupId is required")
@@ -33,14 +41,58 @@ func newInvalidParameterErr(msg string) error {
 }
 
 type ipRangeXML struct {
-	CidrIP string `xml:"cidrIp"`
+	CidrIP      string `xml:"cidrIp"`
+	Description string `xml:"description,omitempty"`
+}
+
+type ipv6RangeXML struct {
+	CidrIPv6    string `xml:"cidrIpv6"`
+	Description string `xml:"description,omitempty"`
+}
+
+type prefixListIDXML struct {
+	PrefixListID string `xml:"prefixListId"`
+	Description  string `xml:"description,omitempty"`
+}
+
+type userIDGroupPairXML struct {
+	GroupID     string `xml:"groupId"`
+	UserID      string `xml:"userId,omitempty"`
+	Description string `xml:"description,omitempty"`
 }
 
 type ipPermissionXML struct {
-	IPProtocol string       `xml:"ipProtocol"`
-	FromPort   int          `xml:"fromPort"`
-	ToPort     int          `xml:"toPort"`
-	IPRanges   []ipRangeXML `xml:"ipRanges>item,omitempty"`
+	IPProtocol    string               `xml:"ipProtocol"`
+	FromPort      int                  `xml:"fromPort"`
+	ToPort        int                  `xml:"toPort"`
+	IPRanges      []ipRangeXML         `xml:"ipRanges>item,omitempty"`
+	IPv6Ranges    []ipv6RangeXML       `xml:"ipv6Ranges>item,omitempty"`
+	PrefixListIDs []prefixListIDXML    `xml:"prefixListIds>item,omitempty"`
+	Groups        []userIDGroupPairXML `xml:"groups>item,omitempty"`
+}
+
+// referencedGroupInfoXML is the ReferencedSecurityGroup shape nested inside a
+// SecurityGroupRule when the rule targets another security group.
+type referencedGroupInfoXML struct {
+	GroupID string `xml:"groupId,omitempty"`
+	UserID  string `xml:"userId,omitempty"`
+}
+
+// securityGroupRuleXML is the flat SecurityGroupRule shape returned by
+// Authorize*/DescribeSecurityGroupRules (one item per resolved target).
+type securityGroupRuleXML struct {
+	SecurityGroupRuleID string                  `xml:"securityGroupRuleId"`
+	GroupID             string                  `xml:"groupId"`
+	GroupOwnerID        string                  `xml:"groupOwnerId"`
+	IsEgress            bool                    `xml:"isEgress"`
+	IPProtocol          string                  `xml:"ipProtocol"`
+	FromPort            int                     `xml:"fromPort"`
+	ToPort              int                     `xml:"toPort"`
+	CidrIPv4            string                  `xml:"cidrIpv4,omitempty"`
+	CidrIPv6            string                  `xml:"cidrIpv6,omitempty"`
+	PrefixListID        string                  `xml:"prefixListId,omitempty"`
+	ReferencedGroupInfo *referencedGroupInfoXML `xml:"referencedGroupInfo,omitempty"`
+	Description         string                  `xml:"description,omitempty"`
 }
 
 type securityGroupXML struct {
@@ -68,6 +120,24 @@ type describeSecurityGroupsResponseXML struct {
 	Xmlns            string             `xml:"xmlns,attr"`
 	RequestID        string             `xml:"requestId"`
 	SecurityGroupSet []securityGroupXML `xml:"securityGroupInfo>item"`
+}
+
+// authorizeSecurityGroupResponseXML is the Authorize{Ingress,Egress} response.
+// Its root element differs per op (Ingress vs Egress), so XMLName is set at
+// runtime rather than fixed by a struct tag.
+type authorizeSecurityGroupResponseXML struct {
+	XMLName              xml.Name
+	Xmlns                string                 `xml:"xmlns,attr"`
+	RequestID            string                 `xml:"requestId"`
+	Return               bool                   `xml:"return"`
+	SecurityGroupRuleSet []securityGroupRuleXML `xml:"securityGroupRuleSet>item,omitempty"`
+}
+
+type describeSecurityGroupRulesResponseXML struct {
+	XMLName              xml.Name               `xml:"DescribeSecurityGroupRulesResponse"`
+	Xmlns                string                 `xml:"xmlns,attr"`
+	RequestID            string                 `xml:"requestId"`
+	SecurityGroupRuleSet []securityGroupRuleXML `xml:"securityGroupRuleSet>item"`
 }
 
 func (h *Handler) createSecurityGroup(w http.ResponseWriter, r *http.Request) {
@@ -159,7 +229,7 @@ func (h *Handler) describeSecurityGroups(w http.ResponseWriter, r *http.Request)
 // filter (tag filters are handled separately in sgMatchesFilters).
 func sgScalarFilterField(sg *netdriver.SecurityGroupInfo, name string) (string, bool) {
 	switch name {
-	case "group-id":
+	case groupIDFilter:
 		return sg.ID, true
 	case "group-name":
 		return sg.Name, true
@@ -235,11 +305,99 @@ func (h *Handler) authorizeSecurityGroupIngress(w http.ResponseWriter, r *http.R
 	})
 }
 
+// describeSecurityGroupRules flattens every group's ingress + egress rules into
+// the SecurityGroupRule shape, honoring the group-id / security-group-rule-id
+// filters and the SecurityGroupRuleId.N selector.
+func (h *Handler) describeSecurityGroupRules(w http.ResponseWriter, r *http.Request) {
+	filters := awsquery.Filters(r.Form)
+	if err := validateSGRuleFilters(filters); err != nil {
+		writeSGErr(w, err)
+		return
+	}
+
+	sgs, err := h.vpc.DescribeSecurityGroups(r.Context(), nil)
+	if err != nil {
+		writeSGErr(w, err)
+		return
+	}
+
+	wantGroups := sgRuleFilterValues(filters, groupIDFilter)
+	wantRuleIDs := append(awsquery.ListStrings(r.Form, "SecurityGroupRuleId"),
+		sgRuleFilterValues(filters, securityGroupRuleIDFilter)...)
+
+	items := make([]securityGroupRuleXML, 0)
+
+	for i := range sgs {
+		sg := &sgs[i]
+		if len(wantGroups) > 0 && !containsString(wantGroups, sg.ID) {
+			continue
+		}
+
+		items = appendSGRuleXMLs(items, sg.ID, false, sg.IngressRules, wantRuleIDs)
+		items = appendSGRuleXMLs(items, sg.ID, true, sg.EgressRules, wantRuleIDs)
+	}
+
+	awsquery.WriteXMLResponse(w, describeSecurityGroupRulesResponseXML{
+		Xmlns:                awsquery.Namespace,
+		RequestID:            awsquery.RequestID,
+		SecurityGroupRuleSet: items,
+	})
+}
+
+// appendSGRuleXMLs appends the rules to out as SecurityGroupRule items, keeping
+// only those whose id is in wantRuleIDs when that selector is non-empty.
+func appendSGRuleXMLs(
+	out []securityGroupRuleXML,
+	groupID string,
+	egress bool,
+	rules []netdriver.SecurityRule,
+	wantRuleIDs []string,
+) []securityGroupRuleXML {
+	for i := range rules {
+		if len(wantRuleIDs) > 0 && !containsString(wantRuleIDs, rules[i].RuleID) {
+			continue
+		}
+
+		out = append(out, toSecurityGroupRuleXML(groupID, egress, &rules[i]))
+	}
+
+	return out
+}
+
+// sgRuleFilterValues returns the accumulated values of every filter with the
+// given name.
+func sgRuleFilterValues(filters []awsquery.Filter, name string) []string {
+	var out []string
+
+	for _, f := range filters {
+		if f.Name == name {
+			out = append(out, f.Values...)
+		}
+	}
+
+	return out
+}
+
+// validateSGRuleFilters rejects DescribeSecurityGroupRules filter names this
+// emulator does not implement, matching real EC2's InvalidParameterValue.
+func validateSGRuleFilters(filters []awsquery.Filter) error {
+	for _, f := range filters {
+		switch f.Name {
+		case groupIDFilter, securityGroupRuleIDFilter:
+		default:
+			return newInvalidParameterErr(fmt.Sprintf("The filter '%s' is invalid", f.Name))
+		}
+	}
+
+	return nil
+}
+
 func (h *Handler) authorizeSecurityGroupEgress(w http.ResponseWriter, r *http.Request) {
 	h.applyRules(w, r, ruleApply{
 		apply:        h.vpc.AddEgressRule,
 		responseName: "AuthorizeSecurityGroupEgressResponse",
 		existing:     func(sg *netdriver.SecurityGroupInfo) []netdriver.SecurityRule { return sg.EgressRules },
+		egress:       true,
 	})
 }
 
@@ -283,6 +441,9 @@ type ruleApply struct {
 	apply        ruleFunc
 	responseName string
 	existing     func(*netdriver.SecurityGroupInfo) []netdriver.SecurityRule
+	// egress marks the Authorize path as egress so the returned
+	// SecurityGroupRule items carry isEgress=true.
+	egress bool
 }
 
 // applyRules is the shared Authorize/Revoke path. The driver takes one rule
@@ -307,14 +468,68 @@ func (h *Handler) applyRules(w http.ResponseWriter, r *http.Request, spec ruleAp
 		return
 	}
 
-	for _, rule := range rules {
-		if err := spec.apply(r.Context(), groupID, rule); err != nil {
+	for i := range rules {
+		if err := spec.apply(r.Context(), groupID, rules[i]); err != nil {
 			writeSGErr(w, err)
 			return
 		}
 	}
 
+	// Authorize (existing != nil) echoes the created SecurityGroupRule set; the
+	// idempotent Revoke path carries no payload.
+	if spec.existing != nil {
+		writeAuthorizeSGResponse(w, spec.responseName, groupID, spec.egress, rules)
+		return
+	}
+
 	writeSimpleSGResponse(w, spec.responseName)
+}
+
+// writeAuthorizeSGResponse emits <return>true</return> plus the
+// securityGroupRuleSet AWS returns from Authorize{Ingress,Egress}.
+func writeAuthorizeSGResponse(w http.ResponseWriter, name, groupID string, egress bool, rules []netdriver.SecurityRule) {
+	items := make([]securityGroupRuleXML, 0, len(rules))
+	for i := range rules {
+		items = append(items, toSecurityGroupRuleXML(groupID, egress, &rules[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, authorizeSecurityGroupResponseXML{
+		XMLName:              xml.Name{Local: name},
+		Xmlns:                awsquery.Namespace,
+		RequestID:            awsquery.RequestID,
+		Return:               true,
+		SecurityGroupRuleSet: items,
+	})
+}
+
+// toSecurityGroupRuleXML maps one stored rule to the flat SecurityGroupRule
+// wire shape, emitting exactly the target element (cidrIpv4/cidrIpv6/
+// prefixListId/referencedGroupInfo) the rule carries.
+func toSecurityGroupRuleXML(groupID string, egress bool, rule *netdriver.SecurityRule) securityGroupRuleXML {
+	x := securityGroupRuleXML{
+		SecurityGroupRuleID: rule.RuleID,
+		GroupID:             groupID,
+		GroupOwnerID:        ownerID,
+		IsEgress:            egress,
+		IPProtocol:          rule.Protocol,
+		FromPort:            rule.FromPort,
+		ToPort:              rule.ToPort,
+		CidrIPv4:            rule.CIDR,
+		CidrIPv6:            rule.IPv6CIDR,
+		PrefixListID:        rule.PrefixListID,
+		Description:         rule.Description,
+	}
+
+	if rule.ReferencedGroupID != "" {
+		userID := rule.ReferencedGroupOwnerID
+		if userID == "" {
+			userID = ownerID
+		}
+
+		x.ReferencedGroupInfo = &referencedGroupInfoXML{GroupID: rule.ReferencedGroupID, UserID: userID}
+	}
+
+	return x
 }
 
 // hasDuplicateRule reports whether any of the rules being authorized already
@@ -332,9 +547,9 @@ func (h *Handler) hasDuplicateRule(
 
 	current := existing(&sgs[0])
 
-	for _, rule := range rules {
-		for i := range current {
-			if current[i] == rule {
+	for i := range rules {
+		for j := range current {
+			if current[j].Matches(&rules[i]) {
 				return true
 			}
 		}
@@ -364,43 +579,113 @@ func parseIPPermissions(form url.Values) []netdriver.SecurityRule {
 
 	for _, idx := range indices {
 		base := prefix + "." + strconv.Itoa(idx)
-		proto := form.Get(base + ".IpProtocol")
-		fromPort, _ := strconv.Atoi(form.Get(base + ".FromPort"))
-		toPort, _ := strconv.Atoi(form.Get(base + ".ToPort"))
-		cidrs := cidrsFromNested(form, base+".IpRanges")
-
-		if len(cidrs) == 0 {
-			rules = append(rules, netdriver.SecurityRule{
-				Protocol: proto, FromPort: fromPort, ToPort: toPort,
-			})
-
-			continue
-		}
-
-		for _, cidr := range cidrs {
-			rules = append(rules, netdriver.SecurityRule{
-				Protocol: proto, FromPort: fromPort, ToPort: toPort, CIDR: cidr,
-			})
-		}
+		rules = append(rules, rulesForPermission(form, base)...)
 	}
 
 	return rules
 }
 
-// cidrsFromNested reads IpRanges.M.CidrIp values for a given base prefix.
-func cidrsFromNested(form url.Values, prefix string) []string {
+// rulesForPermission unrolls one IpPermissions.N block into one SecurityRule
+// per target (IpRanges / Ipv6Ranges / PrefixListIds / Groups), minting an
+// "sgr-" id for each. A block with no target yields a single target-less rule.
+func rulesForPermission(form url.Values, base string) []netdriver.SecurityRule {
+	proto := form.Get(base + ".IpProtocol")
+	fromPort, _ := strconv.Atoi(form.Get(base + ".FromPort"))
+	toPort, _ := strconv.Atoi(form.Get(base + ".ToPort"))
+
+	mk := func(target netdriver.SecurityRule) netdriver.SecurityRule {
+		target.Protocol = proto
+		target.FromPort = fromPort
+		target.ToPort = toPort
+		target.RuleID = idgen.GenerateID("sgr-")
+
+		return target
+	}
+
+	var out []netdriver.SecurityRule
+
+	for _, e := range rangesFromNested(form, base+".IpRanges", "CidrIp") {
+		out = append(out, mk(netdriver.SecurityRule{CIDR: e.value, Description: e.description}))
+	}
+
+	for _, e := range rangesFromNested(form, base+".Ipv6Ranges", "CidrIpv6") {
+		out = append(out, mk(netdriver.SecurityRule{IPv6CIDR: e.value, Description: e.description}))
+	}
+
+	for _, e := range rangesFromNested(form, base+".PrefixListIds", "PrefixListId") {
+		out = append(out, mk(netdriver.SecurityRule{PrefixListID: e.value, Description: e.description}))
+	}
+
+	for _, g := range groupsFromNested(form, base+".Groups") {
+		out = append(out, mk(netdriver.SecurityRule{
+			ReferencedGroupID:      g.groupID,
+			ReferencedGroupOwnerID: g.ownerID,
+			Description:            g.description,
+		}))
+	}
+
+	if len(out) == 0 {
+		out = append(out, mk(netdriver.SecurityRule{}))
+	}
+
+	return out
+}
+
+// rangeEntry is a single nested range/prefix-list entry with its description.
+type rangeEntry struct {
+	value       string
+	description string
+}
+
+// rangesFromNested reads <prefix>.M.<valueField> (+ optional .Description) for
+// the IpRanges / Ipv6Ranges / PrefixListIds groups.
+func rangesFromNested(form url.Values, prefix, valueField string) []rangeEntry {
 	indices := awsquery.CollectIndices(form, prefix)
 	if len(indices) == 0 {
 		return nil
 	}
 
-	out := make([]string, 0, len(indices))
+	out := make([]rangeEntry, 0, len(indices))
 
 	for _, idx := range indices {
-		key := prefix + "." + strconv.Itoa(idx) + ".CidrIp"
-		if v := form.Get(key); v != "" {
-			out = append(out, v)
+		b := prefix + "." + strconv.Itoa(idx)
+		if v := form.Get(b + "." + valueField); v != "" {
+			out = append(out, rangeEntry{value: v, description: form.Get(b + ".Description")})
 		}
+	}
+
+	return out
+}
+
+// referencedGroup is one parsed UserIdGroupPairs (Groups.M) source reference.
+type referencedGroup struct {
+	groupID     string
+	ownerID     string
+	description string
+}
+
+// groupsFromNested reads Groups.M.GroupId (+ optional .UserId / .Description).
+func groupsFromNested(form url.Values, prefix string) []referencedGroup {
+	indices := awsquery.CollectIndices(form, prefix)
+	if len(indices) == 0 {
+		return nil
+	}
+
+	out := make([]referencedGroup, 0, len(indices))
+
+	for _, idx := range indices {
+		b := prefix + "." + strconv.Itoa(idx)
+
+		gid := form.Get(b + ".GroupId")
+		if gid == "" {
+			continue
+		}
+
+		out = append(out, referencedGroup{
+			groupID:     gid,
+			ownerID:     form.Get(b + ".UserId"),
+			description: form.Get(b + ".Description"),
+		})
 	}
 
 	return out
@@ -436,24 +721,23 @@ func toIPPermissionXMLs(rules []netdriver.SecurityRule) []ipPermissionXML {
 	byKey := make(map[key]*ipPermissionXML)
 	order := []key{}
 
-	for _, rule := range rules {
+	for i := range rules {
+		rule := &rules[i]
 		k := key{protocol: rule.Protocol, from: rule.FromPort, to: rule.ToPort}
 
-		existing, ok := byKey[k]
+		perm, ok := byKey[k]
 		if !ok {
-			existing = &ipPermissionXML{
+			perm = &ipPermissionXML{
 				IPProtocol: rule.Protocol,
 				FromPort:   rule.FromPort,
 				ToPort:     rule.ToPort,
 			}
-			byKey[k] = existing
+			byKey[k] = perm
 
 			order = append(order, k)
 		}
 
-		if rule.CIDR != "" {
-			existing.IPRanges = append(existing.IPRanges, ipRangeXML{CidrIP: rule.CIDR})
-		}
+		addRuleTarget(perm, rule)
 	}
 
 	out := make([]ipPermissionXML, 0, len(order))
@@ -462,6 +746,28 @@ func toIPPermissionXMLs(rules []netdriver.SecurityRule) []ipPermissionXML {
 	}
 
 	return out
+}
+
+// addRuleTarget appends the rule's single target (IPv4 / IPv6 / prefix list /
+// referenced group) to the matching sub-list of the IpPermission.
+func addRuleTarget(perm *ipPermissionXML, rule *netdriver.SecurityRule) {
+	switch {
+	case rule.CIDR != "":
+		perm.IPRanges = append(perm.IPRanges, ipRangeXML{CidrIP: rule.CIDR, Description: rule.Description})
+	case rule.IPv6CIDR != "":
+		perm.IPv6Ranges = append(perm.IPv6Ranges, ipv6RangeXML{CidrIPv6: rule.IPv6CIDR, Description: rule.Description})
+	case rule.PrefixListID != "":
+		perm.PrefixListIDs = append(perm.PrefixListIDs,
+			prefixListIDXML{PrefixListID: rule.PrefixListID, Description: rule.Description})
+	case rule.ReferencedGroupID != "":
+		userID := rule.ReferencedGroupOwnerID
+		if userID == "" {
+			userID = ownerID
+		}
+
+		perm.Groups = append(perm.Groups,
+			userIDGroupPairXML{GroupID: rule.ReferencedGroupID, UserID: userID, Description: rule.Description})
+	}
 }
 
 // writeSimpleSGResponse writes a <return>true</return>-shaped response for

--- a/server/aws/ec2/security_group_test.go
+++ b/server/aws/ec2/security_group_test.go
@@ -3,6 +3,7 @@ package ec2_test
 import (
 	"context"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -206,5 +207,214 @@ func TestAuthorizeSecurityGroupIngressDuplicate(t *testing.T) {
 
 	if _, err := c.AuthorizeSecurityGroupIngress(ctx, auth); err == nil {
 		t.Fatalf("duplicate ingress rule should fail with InvalidPermission.Duplicate")
+	}
+}
+
+// authorizeIngressSG creates a group and returns its id.
+func authorizeIngressSG(t *testing.T, ctx context.Context, c *ec2.Client) string {
+	t.Helper()
+
+	vpcID := createSGTestVPC(t, ctx, c, "10.0.0.0/16")
+
+	sg, err := c.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String("sg"),
+		Description: aws.String("sg"),
+		VpcId:       aws.String(vpcID),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecurityGroup: %v", err)
+	}
+
+	return aws.ToString(sg.GroupId)
+}
+
+// TestAuthorizeSecurityGroupIngressReturnsRuleSet pins that Authorize returns
+// the created SecurityGroupRule set (sgr- id, isEgress=false, target fields),
+// matching real EC2's response so IaC tools can track the rule by id.
+func TestAuthorizeSecurityGroupIngressReturnsRuleSet(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	groupID := authorizeIngressSG(t, ctx, c)
+
+	out, err := c.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(groupID),
+		IpPermissions: []ec2types.IpPermission{{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   aws.Int32(443),
+			ToPort:     aws.Int32(443),
+			IpRanges:   []ec2types.IpRange{{CidrIp: aws.String("0.0.0.0/0"), Description: aws.String("https")}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("AuthorizeSecurityGroupIngress: %v", err)
+	}
+
+	if len(out.SecurityGroupRules) != 1 {
+		t.Fatalf("Authorize returned %d rules, want 1", len(out.SecurityGroupRules))
+	}
+
+	rule := out.SecurityGroupRules[0]
+	if id := aws.ToString(rule.SecurityGroupRuleId); !strings.HasPrefix(id, "sgr-") {
+		t.Fatalf("SecurityGroupRuleId = %q, want sgr- prefix", id)
+	}
+
+	if aws.ToBool(rule.IsEgress) {
+		t.Fatalf("ingress rule reported isEgress=true")
+	}
+
+	if got := aws.ToString(rule.CidrIpv4); got != "0.0.0.0/0" {
+		t.Fatalf("CidrIpv4 = %q, want 0.0.0.0/0", got)
+	}
+
+	if got := aws.ToString(rule.Description); got != "https" {
+		t.Fatalf("Description = %q, want https", got)
+	}
+}
+
+// TestAuthorizeSecurityGroupIngressReferencedGroup pins that a source-group
+// reference (UserIdGroupPairs) round-trips: Authorize returns referencedGroupInfo
+// and DescribeSecurityGroups surfaces it under the permission's <groups>.
+func TestAuthorizeSecurityGroupIngressReferencedGroup(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	groupID := authorizeIngressSG(t, ctx, c)
+
+	out, err := c.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(groupID),
+		IpPermissions: []ec2types.IpPermission{{
+			IpProtocol:       aws.String("tcp"),
+			FromPort:         aws.Int32(80),
+			ToPort:           aws.Int32(80),
+			UserIdGroupPairs: []ec2types.UserIdGroupPair{{GroupId: aws.String("sg-source123")}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("AuthorizeSecurityGroupIngress: %v", err)
+	}
+
+	if len(out.SecurityGroupRules) != 1 || out.SecurityGroupRules[0].ReferencedGroupInfo == nil {
+		t.Fatalf("Authorize did not return referencedGroupInfo: %+v", out.SecurityGroupRules)
+	}
+
+	if got := aws.ToString(out.SecurityGroupRules[0].ReferencedGroupInfo.GroupId); got != "sg-source123" {
+		t.Fatalf("referencedGroupInfo.GroupId = %q, want sg-source123", got)
+	}
+
+	desc, err := c.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{GroupIds: []string{groupID}})
+	if err != nil {
+		t.Fatalf("DescribeSecurityGroups: %v", err)
+	}
+
+	if len(desc.SecurityGroups) != 1 || len(desc.SecurityGroups[0].IpPermissions) != 1 {
+		t.Fatalf("unexpected Describe shape: %+v", desc.SecurityGroups)
+	}
+
+	pairs := desc.SecurityGroups[0].IpPermissions[0].UserIdGroupPairs
+	if len(pairs) != 1 || aws.ToString(pairs[0].GroupId) != "sg-source123" {
+		t.Fatalf("Describe UserIdGroupPairs = %+v, want sg-source123", pairs)
+	}
+}
+
+// TestAuthorizeSecurityGroupIngressIPv6AndPrefixList pins that IPv6 ranges and
+// prefix-list targets round-trip through Authorize and DescribeSecurityGroups.
+func TestAuthorizeSecurityGroupIngressIPv6AndPrefixList(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	groupID := authorizeIngressSG(t, ctx, c)
+
+	if _, err := c.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(groupID),
+		IpPermissions: []ec2types.IpPermission{{
+			IpProtocol:    aws.String("tcp"),
+			FromPort:      aws.Int32(22),
+			ToPort:        aws.Int32(22),
+			Ipv6Ranges:    []ec2types.Ipv6Range{{CidrIpv6: aws.String("::/0"), Description: aws.String("v6")}},
+			PrefixListIds: []ec2types.PrefixListId{{PrefixListId: aws.String("pl-12345")}},
+		}},
+	}); err != nil {
+		t.Fatalf("AuthorizeSecurityGroupIngress: %v", err)
+	}
+
+	desc, err := c.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{GroupIds: []string{groupID}})
+	if err != nil {
+		t.Fatalf("DescribeSecurityGroups: %v", err)
+	}
+
+	perm := desc.SecurityGroups[0].IpPermissions[0]
+
+	if len(perm.Ipv6Ranges) != 1 || aws.ToString(perm.Ipv6Ranges[0].CidrIpv6) != "::/0" {
+		t.Fatalf("Ipv6Ranges = %+v, want ::/0", perm.Ipv6Ranges)
+	}
+
+	if got := aws.ToString(perm.Ipv6Ranges[0].Description); got != "v6" {
+		t.Fatalf("Ipv6Ranges[0].Description = %q, want v6", got)
+	}
+
+	if len(perm.PrefixListIds) != 1 || aws.ToString(perm.PrefixListIds[0].PrefixListId) != "pl-12345" {
+		t.Fatalf("PrefixListIds = %+v, want pl-12345", perm.PrefixListIds)
+	}
+}
+
+// TestDescribeSecurityGroupRules pins the DescribeSecurityGroupRules action:
+// it flattens ingress + egress rules (including the default egress rule) into
+// SecurityGroupRule items and honors the group-id filter.
+func TestDescribeSecurityGroupRules(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	groupID := authorizeIngressSG(t, ctx, c)
+
+	if _, err := c.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(groupID),
+		IpPermissions: []ec2types.IpPermission{{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   aws.Int32(443),
+			ToPort:     aws.Int32(443),
+			IpRanges:   []ec2types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
+		}},
+	}); err != nil {
+		t.Fatalf("AuthorizeSecurityGroupIngress: %v", err)
+	}
+
+	out, err := c.DescribeSecurityGroupRules(ctx, &ec2.DescribeSecurityGroupRulesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("group-id"), Values: []string{groupID}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSecurityGroupRules: %v", err)
+	}
+
+	// One ingress rule just added + one default egress rule.
+	if len(out.SecurityGroupRules) != 2 {
+		t.Fatalf("DescribeSecurityGroupRules = %d rules, want 2: %+v", len(out.SecurityGroupRules), out.SecurityGroupRules)
+	}
+
+	var haveIngress, haveEgress bool
+	for _, r := range out.SecurityGroupRules {
+		if !strings.HasPrefix(aws.ToString(r.SecurityGroupRuleId), "sgr-") {
+			t.Fatalf("rule missing sgr- id: %+v", r)
+		}
+
+		if aws.ToBool(r.IsEgress) {
+			haveEgress = true
+		} else {
+			haveIngress = true
+		}
+	}
+
+	if !haveIngress || !haveEgress {
+		t.Fatalf("want both ingress and egress rules, got ingress=%v egress=%v", haveIngress, haveEgress)
+	}
+
+	// Filtering by a single rule id returns just that rule.
+	oneID := aws.ToString(out.SecurityGroupRules[0].SecurityGroupRuleId)
+
+	one, err := c.DescribeSecurityGroupRules(ctx, &ec2.DescribeSecurityGroupRulesInput{
+		SecurityGroupRuleIds: []string{oneID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSecurityGroupRules by id: %v", err)
+	}
+
+	if len(one.SecurityGroupRules) != 1 || aws.ToString(one.SecurityGroupRules[0].SecurityGroupRuleId) != oneID {
+		t.Fatalf("rule-id filter = %+v, want only %s", one.SecurityGroupRules, oneID)
 	}
 }

--- a/server/aws/ec2/tags.go
+++ b/server/aws/ec2/tags.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
 // computeTagger is the AWS-specific compute-resource tagging surface
@@ -260,6 +261,26 @@ func tagNotFoundCode(id string) string {
 	return "InvalidID.NotFound"
 }
 
+// networkResourceTagPrefixes are the VPC-family id prefixes whose tags the
+// networking driver owns through the NetworkResourceTagger optional interface
+// (resources without a dedicated Update*Tags method). vpc-/subnet-/sg- keep
+// their own methods and are handled separately.
+//
+//nolint:gochecknoglobals // static id-prefix routing table
+var networkResourceTagPrefixes = []string{"rtb-", "igw-", "nat-", "acl-", "dopt-", "pcx-", "pl-", "eigw-"}
+
+// networkTaggableID reports whether id belongs to a resource tagged via the
+// NetworkResourceTagger optional interface.
+func networkTaggableID(id string) bool {
+	for _, p := range networkResourceTagPrefixes {
+		if strings.HasPrefix(id, p) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (h *Handler) tagResource(ctx context.Context, id string, tags map[string]string) error {
 	switch {
 	case strings.HasPrefix(id, "vpc-"):
@@ -268,6 +289,12 @@ func (h *Handler) tagResource(ctx context.Context, id string, tags map[string]st
 		return h.vpc.UpdateSubnetTags(ctx, id, tags)
 	case strings.HasPrefix(id, "sg-"):
 		return h.vpc.UpdateSecurityGroupTags(ctx, id, tags)
+	case networkTaggableID(id):
+		if tagger, ok := h.vpc.(netdriver.NetworkResourceTagger); ok {
+			return tagger.UpdateResourceTags(ctx, id, tags)
+		}
+
+		return nil
 	default:
 		if tagger, ok := h.compute.(computeTagger); ok {
 			return tagger.TagResource(ctx, id, tags)
@@ -285,6 +312,12 @@ func (h *Handler) untagResource(ctx context.Context, id string, keys []string) e
 		return h.vpc.RemoveSubnetTags(ctx, id, keys)
 	case strings.HasPrefix(id, "sg-"):
 		return h.vpc.RemoveSecurityGroupTags(ctx, id, keys)
+	case networkTaggableID(id):
+		if tagger, ok := h.vpc.(netdriver.NetworkResourceTagger); ok {
+			return tagger.RemoveResourceTags(ctx, id, keys)
+		}
+
+		return nil
 	default:
 		if tagger, ok := h.compute.(computeTagger); ok {
 			return tagger.UntagResource(ctx, id, keys)

--- a/server/aws/ec2/tags_test.go
+++ b/server/aws/ec2/tags_test.go
@@ -1,0 +1,132 @@
+package ec2_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestCreateTagsOnRouteTable pins that CreateTags/DeleteTags reach VPC-family
+// resources that have no dedicated Update*Tags method (route tables here). The
+// tag must be visible on DescribeRouteTables and gone after DeleteTags —
+// previously these id prefixes fell through to the compute tagger and the tag
+// was silently dropped.
+func TestCreateTagsOnRouteTable(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	rt, err := c.CreateRouteTable(ctx, &ec2.CreateRouteTableInput{VpcId: vpc.Vpc.VpcId})
+	if err != nil {
+		t.Fatalf("CreateRouteTable: %v", err)
+	}
+
+	rtID := aws.ToString(rt.RouteTable.RouteTableId)
+
+	if _, err := c.CreateTags(ctx, &ec2.CreateTagsInput{
+		Resources: []string{rtID},
+		Tags:      []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String("public")}},
+	}); err != nil {
+		t.Fatalf("CreateTags: %v", err)
+	}
+
+	if got := routeTableTagValue(ctx, t, c, rtID, "Name"); got != "public" {
+		t.Fatalf("route table tag Name = %q, want public", got)
+	}
+
+	if _, err := c.DeleteTags(ctx, &ec2.DeleteTagsInput{
+		Resources: []string{rtID},
+		Tags:      []ec2types.Tag{{Key: aws.String("Name")}},
+	}); err != nil {
+		t.Fatalf("DeleteTags: %v", err)
+	}
+
+	if got := routeTableTagValue(ctx, t, c, rtID, "Name"); got != "" {
+		t.Fatalf("route table tag Name = %q after delete, want empty", got)
+	}
+}
+
+// TestCreateTagsOnDhcpOptions pins tagging on a second store (DHCP option sets)
+// so the id-prefix routing is exercised beyond route tables.
+func TestCreateTagsOnDhcpOptions(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	opts, err := c.CreateDhcpOptions(ctx, &ec2.CreateDhcpOptionsInput{
+		DhcpConfigurations: []ec2types.NewDhcpConfiguration{{
+			Key:    aws.String("domain-name-servers"),
+			Values: []string{"10.0.0.2"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateDhcpOptions: %v", err)
+	}
+
+	doptID := aws.ToString(opts.DhcpOptions.DhcpOptionsId)
+
+	if _, err := c.CreateTags(ctx, &ec2.CreateTagsInput{
+		Resources: []string{doptID},
+		Tags:      []ec2types.Tag{{Key: aws.String("Env"), Value: aws.String("prod")}},
+	}); err != nil {
+		t.Fatalf("CreateTags: %v", err)
+	}
+
+	desc, err := c.DescribeDhcpOptions(ctx, &ec2.DescribeDhcpOptionsInput{DhcpOptionsIds: []string{doptID}})
+	if err != nil {
+		t.Fatalf("DescribeDhcpOptions: %v", err)
+	}
+
+	if got := tagValue(desc.DhcpOptions[0].Tags, "Env"); got != "prod" {
+		t.Fatalf("dhcp options tag Env = %q, want prod", got)
+	}
+}
+
+// TestCreateTagsUnknownRouteTableErrorCode pins that CreateTags on a non-existent
+// VPC-family id returns InvalidID.NotFound rather than silently succeeding.
+func TestCreateTagsUnknownRouteTableErrorCode(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	_, err := c.CreateTags(ctx, &ec2.CreateTagsInput{
+		Resources: []string{"rtb-doesnotexist0"},
+		Tags:      []ec2types.Tag{{Key: aws.String("k"), Value: aws.String("v")}},
+	})
+	if err == nil {
+		t.Fatal("CreateTags on unknown route table id should fail")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidID.NotFound" {
+		t.Fatalf("want InvalidID.NotFound, got %v", err)
+	}
+}
+
+func routeTableTagValue(ctx context.Context, t *testing.T, c *ec2.Client, rtID, key string) string {
+	t.Helper()
+
+	desc, err := c.DescribeRouteTables(ctx, &ec2.DescribeRouteTablesInput{RouteTableIds: []string{rtID}})
+	if err != nil {
+		t.Fatalf("DescribeRouteTables: %v", err)
+	}
+
+	return tagValue(desc.RouteTables[0].Tags, key)
+}
+
+func tagValue(tags []ec2types.Tag, key string) string {
+	for i := range tags {
+		if aws.ToString(tags[i].Key) == key {
+			return aws.ToString(tags[i].Value)
+		}
+	}
+
+	return ""
+}

--- a/server/aws/ec2/vpc.go
+++ b/server/aws/ec2/vpc.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
@@ -17,15 +18,37 @@ const stateAvailable = "available"
 // option set (no explicit set associated).
 const dhcpDefault = "default"
 
+// cidrAssocIDPrefix is the id prefix AWS assigns to a VPC's primary-CIDR
+// association in cidrBlockAssociationSet.
+const cidrAssocIDPrefix = "vpc-cidr-assoc-"
+
+// cidrStateAssociated is the terminal state AWS reports for an in-use VPC CIDR
+// association.
+const cidrStateAssociated = "associated"
+
+type vpcCidrBlockStateXML struct {
+	State string `xml:"state"`
+}
+
+// vpcCidrAssocXML is one entry in a VPC's cidrBlockAssociationSet. AWS returns
+// the primary CIDR both flat (cidrBlock) and here; IaC tools read the
+// association id and state from this set.
+type vpcCidrAssocXML struct {
+	AssociationID  string               `xml:"associationId"`
+	CidrBlock      string               `xml:"cidrBlock"`
+	CidrBlockState vpcCidrBlockStateXML `xml:"cidrBlockState"`
+}
+
 type vpcXML struct {
-	VpcID           string    `xml:"vpcId"`
-	State           string    `xml:"state"`
-	CidrBlock       string    `xml:"cidrBlock"`
-	DhcpOptionsID   string    `xml:"dhcpOptionsId"`
-	InstanceTenancy string    `xml:"instanceTenancy"`
-	IsDefault       bool      `xml:"isDefault"`
-	OwnerID         string    `xml:"ownerId"`
-	Tags            []tagItem `xml:"tagSet>item,omitempty"`
+	VpcID                   string            `xml:"vpcId"`
+	State                   string            `xml:"state"`
+	CidrBlock               string            `xml:"cidrBlock"`
+	DhcpOptionsID           string            `xml:"dhcpOptionsId"`
+	InstanceTenancy         string            `xml:"instanceTenancy"`
+	IsDefault               bool              `xml:"isDefault"`
+	OwnerID                 string            `xml:"ownerId"`
+	CidrBlockAssociationSet []vpcCidrAssocXML `xml:"cidrBlockAssociationSet>item,omitempty"`
+	Tags                    []tagItem         `xml:"tagSet>item,omitempty"`
 }
 
 type createVpcResponseXML struct {
@@ -111,15 +134,32 @@ func toVpcXML(v *netdriver.VPCInfo) vpcXML {
 	}
 
 	return vpcXML{
-		VpcID:           v.ID,
-		State:           state,
-		CidrBlock:       v.CIDRBlock,
-		DhcpOptionsID:   nonEmpty(v.DhcpOptionsID, dhcpDefault),
-		InstanceTenancy: "default",
-		IsDefault:       false,
-		OwnerID:         ownerID,
-		Tags:            toTagItems(v.Tags),
+		VpcID:                   v.ID,
+		State:                   state,
+		CidrBlock:               v.CIDRBlock,
+		DhcpOptionsID:           nonEmpty(v.DhcpOptionsID, dhcpDefault),
+		InstanceTenancy:         "default",
+		IsDefault:               false,
+		OwnerID:                 ownerID,
+		CidrBlockAssociationSet: vpcCidrAssociationSet(v),
+		Tags:                    toTagItems(v.Tags),
 	}
+}
+
+// vpcCidrAssociationSet synthesizes the single primary-CIDR association AWS
+// returns for a VPC. The association id is derived deterministically from the
+// VPC id so it is stable across Describe calls (real AWS ids are stable too).
+// IPv6 associations are not modeled, so ipv6CidrBlockAssociationSet stays empty.
+func vpcCidrAssociationSet(v *netdriver.VPCInfo) []vpcCidrAssocXML {
+	if v.CIDRBlock == "" {
+		return nil
+	}
+
+	return []vpcCidrAssocXML{{
+		AssociationID:  cidrAssocIDPrefix + strings.TrimPrefix(v.ID, "vpc-"),
+		CidrBlock:      v.CIDRBlock,
+		CidrBlockState: vpcCidrBlockStateXML{State: cidrStateAssociated},
+	}}
 }
 
 // validateVpcFilters rejects filter names DescribeVpcs does not model. Silently

--- a/server/aws/ec2/vpc_describe_test.go
+++ b/server/aws/ec2/vpc_describe_test.go
@@ -65,6 +65,67 @@ func TestDescribeVpcsTagFilter(t *testing.T) {
 	}
 }
 
+// TestDescribeVpcsCidrBlockAssociationSet pins that a VPC reports its primary
+// CIDR in cidrBlockAssociationSet with a stable vpc-cidr-assoc- id and an
+// "associated" state, alongside the flat cidrBlock. Terraform's aws_vpc reads
+// this set; an empty set makes the VPC look like it has no CIDR association.
+func TestDescribeVpcsCidrBlockAssociationSet(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	vpcID := mkVPC(ctx, t, c, "10.0.0.0/16")
+
+	out, err := c.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{VpcIds: []string{vpcID}})
+	if err != nil {
+		t.Fatalf("DescribeVpcs: %v", err)
+	}
+
+	assocs := out.Vpcs[0].CidrBlockAssociationSet
+	if len(assocs) != 1 {
+		t.Fatalf("cidrBlockAssociationSet = %d entries, want 1", len(assocs))
+	}
+
+	if got := aws.ToString(assocs[0].CidrBlock); got != "10.0.0.0/16" {
+		t.Errorf("association cidrBlock = %q, want 10.0.0.0/16", got)
+	}
+
+	if got := aws.ToString(assocs[0].AssociationId); got == "" || got[:len("vpc-cidr-assoc-")] != "vpc-cidr-assoc-" {
+		t.Errorf("association id = %q, want vpc-cidr-assoc- prefix", got)
+	}
+
+	if assocs[0].CidrBlockState == nil || assocs[0].CidrBlockState.State != ec2types.VpcCidrBlockStateCodeAssociated {
+		t.Errorf("association state = %+v, want associated", assocs[0].CidrBlockState)
+	}
+}
+
+// TestDhcpOptionsOwnerID pins that DHCP option sets report their owning account
+// id, which Terraform's aws_vpc_dhcp_options reads.
+func TestDhcpOptionsOwnerID(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	opts, err := c.CreateDhcpOptions(ctx, &ec2.CreateDhcpOptionsInput{
+		DhcpConfigurations: []ec2types.NewDhcpConfiguration{{
+			Key:    aws.String("domain-name-servers"),
+			Values: []string{"10.0.0.2"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateDhcpOptions: %v", err)
+	}
+
+	doptID := aws.ToString(opts.DhcpOptions.DhcpOptionsId)
+
+	desc, err := c.DescribeDhcpOptions(ctx, &ec2.DescribeDhcpOptionsInput{DhcpOptionsIds: []string{doptID}})
+	if err != nil {
+		t.Fatalf("DescribeDhcpOptions: %v", err)
+	}
+
+	if got := aws.ToString(desc.DhcpOptions[0].OwnerId); got != "123456789012" {
+		t.Errorf("DhcpOptions OwnerId = %q, want 123456789012", got)
+	}
+}
+
 // TestAssociateDhcpOptionsReflectedOnVpc pins that AssociateDhcpOptions actually
 // changes the VPC's dhcpOptionsId, rather than the VPC forever reporting
 // "default".

--- a/server/aws/ec2/xml.go
+++ b/server/aws/ec2/xml.go
@@ -53,8 +53,42 @@ type tagItem struct {
 }
 
 // groupItem is one <groupSet><item>…</item></groupSet> entry (security group).
+// VPC instances report both the id and the resolved name.
 type groupItem struct {
-	GroupID string `xml:"groupId"`
+	GroupID   string `xml:"groupId"`
+	GroupName string `xml:"groupName,omitempty"`
+}
+
+// placementXML is the nested <placement> element carrying the instance's
+// availability zone and tenancy.
+type placementXML struct {
+	AvailabilityZone string `xml:"availabilityZone,omitempty"`
+	Tenancy          string `xml:"tenancy,omitempty"`
+}
+
+// monitoringXML is the nested <monitoring> element carrying the detailed-
+// monitoring state (disabled/disabling/enabled/pending).
+type monitoringXML struct {
+	State string `xml:"state"`
+}
+
+// instanceENIAttachmentXML is the primary ENI's <attachment> (deviceIndex 0).
+type instanceENIAttachmentXML struct {
+	DeviceIndex int    `xml:"deviceIndex"`
+	Status      string `xml:"status"`
+}
+
+// instanceENIXML is one <networkInterfaceSet><item> describing the instance's
+// primary elastic network interface, as embedded in a DescribeInstances item.
+// It is distinct from the standalone networkInterfaceXML (DescribeNetworkInterfaces)
+// because the embedded shape carries privateIpAddress, groupSet and deviceIndex.
+type instanceENIXML struct {
+	NetworkInterfaceID string                   `xml:"networkInterfaceId,omitempty"`
+	SubnetID           string                   `xml:"subnetId,omitempty"`
+	VPCID              string                   `xml:"vpcId,omitempty"`
+	PrivateIP          string                   `xml:"privateIpAddress,omitempty"`
+	Groups             []groupItem              `xml:"groupSet>item,omitempty"`
+	Attachment         instanceENIAttachmentXML `xml:"attachment"`
 }
 
 // operatorXML is the nested <operator> element carrying managed-resource
@@ -72,19 +106,30 @@ type operatorXML struct {
 // DescribeInstances responses. We populate only the fields the SDK reliably
 // consumes and real apps actually read; unused AWS fields are omitted.
 type instanceXML struct {
-	InstanceID   string        `xml:"instanceId"`
-	ImageID      string        `xml:"imageId"`
-	State        instanceState `xml:"instanceState"`
-	InstanceType string        `xml:"instanceType"`
-	LaunchTime   string        `xml:"launchTime,omitempty"`
-	SubnetID     string        `xml:"subnetId,omitempty"`
-	VPCID        string        `xml:"vpcId,omitempty"`
-	PrivateIP    string        `xml:"privateIpAddress,omitempty"`
-	PublicIP     string        `xml:"ipAddress,omitempty"`
-	KeyName      string        `xml:"keyName,omitempty"`
-	Groups       []groupItem   `xml:"groupSet>item,omitempty"`
-	Tags         []tagItem     `xml:"tagSet>item,omitempty"`
-	Operator     *operatorXML  `xml:"operator,omitempty"`
+	InstanceID         string           `xml:"instanceId"`
+	ImageID            string           `xml:"imageId"`
+	State              instanceState    `xml:"instanceState"`
+	InstanceType       string           `xml:"instanceType"`
+	LaunchTime         string           `xml:"launchTime,omitempty"`
+	SubnetID           string           `xml:"subnetId,omitempty"`
+	VPCID              string           `xml:"vpcId,omitempty"`
+	PrivateIP          string           `xml:"privateIpAddress,omitempty"`
+	PublicIP           string           `xml:"ipAddress,omitempty"`
+	PrivateDNSName     string           `xml:"privateDnsName,omitempty"`
+	PublicDNSName      string           `xml:"dnsName,omitempty"`
+	KeyName            string           `xml:"keyName,omitempty"`
+	AmiLaunchIndex     int              `xml:"amiLaunchIndex"`
+	Architecture       string           `xml:"architecture,omitempty"`
+	RootDeviceType     string           `xml:"rootDeviceType,omitempty"`
+	RootDeviceName     string           `xml:"rootDeviceName,omitempty"`
+	VirtualizationType string           `xml:"virtualizationType,omitempty"`
+	Hypervisor         string           `xml:"hypervisor,omitempty"`
+	Placement          *placementXML    `xml:"placement,omitempty"`
+	Monitoring         *monitoringXML   `xml:"monitoring,omitempty"`
+	Groups             []groupItem      `xml:"groupSet>item,omitempty"`
+	NetworkInterfaces  []instanceENIXML `xml:"networkInterfaceSet>item,omitempty"`
+	Tags               []tagItem        `xml:"tagSet>item,omitempty"`
+	Operator           *operatorXML     `xml:"operator,omitempty"`
 }
 
 // runInstancesResponse is the XML body for RunInstances.
@@ -110,6 +155,7 @@ type describeInstancesResponse struct {
 	Xmlns        string           `xml:"xmlns,attr"`
 	RequestID    string           `xml:"requestId"`
 	Reservations []reservationXML `xml:"reservationSet>item"`
+	NextToken    string           `xml:"nextToken,omitempty"`
 }
 
 // stateChangeXML is one item in Start/Stop/Terminate responses.
@@ -177,7 +223,10 @@ type describeInstanceAttributeResponse struct {
 	InstanceID            string                    `xml:"instanceId"`
 	DisableAPITermination *attributeBooleanValueXML `xml:"disableApiTermination,omitempty"`
 	SourceDestCheck       *attributeBooleanValueXML `xml:"sourceDestCheck,omitempty"`
+	EBSOptimized          *attributeBooleanValueXML `xml:"ebsOptimized,omitempty"`
 	InstanceType          *attributeValueXML        `xml:"instanceType,omitempty"`
+	UserData              *attributeValueXML        `xml:"userData,omitempty"`
+	Groups                []groupItem               `xml:"groupSet>item,omitempty"`
 }
 
 // getConsoleOutputResponse carries the base64-encoded console output for an

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -32,6 +32,10 @@ type InstanceConfig struct {
 	// rather than the emulator defaults.
 	Region        string
 	ResourceGroup string
+	// ClientToken provides idempotency for RunInstances (AWS): a retry with the
+	// same case-sensitive token returns the already-launched instances instead
+	// of provisioning new ones. Empty disables dedup. Ignored by Azure/GCP.
+	ClientToken string
 }
 
 // Instance describes a running virtual machine.
@@ -61,6 +65,15 @@ type Instance struct {
 	// resource group), when known; empty falls back to the emulator defaults.
 	Region        string
 	ResourceGroup string
+	// ReservationID groups instances launched by one RunInstances call under a
+	// shared AWS reservation (r-xxxx). Empty for providers with no reservation
+	// concept; the wire layer then falls back to a per-instance reservation.
+	ReservationID string
+	// KeyName is the key pair the instance was launched with (AWS), when set.
+	KeyName string
+	// Monitoring is the CloudWatch detailed-monitoring state
+	// ("disabled"/"enabled"), when known (AWS). Empty renders as "disabled".
+	Monitoring string
 	// Operator carries service-provider managed-resource metadata. It is nil
 	// for ordinary (unmanaged) instances.
 	Operator *OperatorInfo

--- a/services/networking/driver/aws_capabilities.go
+++ b/services/networking/driver/aws_capabilities.go
@@ -662,3 +662,16 @@ type VPCBlockPublicAccess interface {
 	DeleteVPCBlockPublicAccessExclusion(ctx context.Context, id string) (*VPCBlockPublicAccessExclusion, error)
 	DescribeVPCBlockPublicAccessExclusions(ctx context.Context, ids []string) ([]VPCBlockPublicAccessExclusion, error)
 }
+
+// ---- Network-resource tagging ----
+
+// NetworkResourceTagger is an OPTIONAL AWS capability (type-asserted).
+//
+// It tags VPC-family resources that have no dedicated Update*Tags method on the
+// portable Networking interface: route tables, internet gateways, NAT gateways,
+// network ACLs, DHCP option sets, peering connections, managed prefix lists, and
+// egress-only internet gateways. The EC2 tag handler routes those id prefixes here.
+type NetworkResourceTagger interface {
+	UpdateResourceTags(ctx context.Context, id string, tags map[string]string) error
+	RemoveResourceTags(ctx context.Context, id string, keys []string) error
+}

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -72,6 +72,34 @@ type SecurityRule struct {
 	FromPort int
 	ToPort   int
 	CIDR     string
+	// IPv6CIDR is an IPv6 source/destination range (Ipv6Ranges.CidrIpv6),
+	// PrefixListID references a managed prefix list (PrefixListIds.PrefixListId),
+	// and ReferencedGroupID / ReferencedGroupOwnerID capture a source-group
+	// reference (UserIdGroupPairs). Exactly one of CIDR, IPv6CIDR, PrefixListID
+	// or ReferencedGroupID identifies a single rule's target on the AWS wire.
+	IPv6CIDR               string
+	PrefixListID           string
+	ReferencedGroupID      string
+	ReferencedGroupOwnerID string
+	// Description is the optional free-text note attached to a rule. It is not
+	// part of a rule's identity — AWS ignores it when revoking or deduplicating.
+	Description string
+	// RuleID is the service-assigned "sgr-" identifier for the rule. It is empty
+	// for rules created outside the AWS wire layer (Azure/GCP, portable API).
+	RuleID string
+}
+
+// Matches reports whether two rules describe the same permission, ignoring the
+// service-assigned RuleID and the free-text Description — the fields AWS does
+// not treat as part of a rule's identity when revoking or deduplicating.
+func (r *SecurityRule) Matches(o *SecurityRule) bool {
+	return r.Protocol == o.Protocol &&
+		r.FromPort == o.FromPort &&
+		r.ToPort == o.ToPort &&
+		r.CIDR == o.CIDR &&
+		r.IPv6CIDR == o.IPv6CIDR &&
+		r.PrefixListID == o.PrefixListID &&
+		r.ReferencedGroupID == o.ReferencedGroupID
 }
 
 // PeeringConnection represents a VPC peering connection.

--- a/services/networking/networking.go
+++ b/services/networking/networking.go
@@ -161,6 +161,7 @@ func (n *Networking) DescribeSecurityGroups(ctx context.Context, ids []string) (
 	return out.([]driver.SecurityGroupInfo), nil
 }
 
+//nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (n *Networking) AddIngressRule(ctx context.Context, groupID string, rule driver.SecurityRule) error {
 	_, err := n.do(ctx, "AddIngressRule", rule, func() (any, error) {
 		return nil, n.driver.AddIngressRule(ctx, groupID, rule)
@@ -169,6 +170,7 @@ func (n *Networking) AddIngressRule(ctx context.Context, groupID string, rule dr
 	return err
 }
 
+//nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (n *Networking) AddEgressRule(ctx context.Context, groupID string, rule driver.SecurityRule) error {
 	_, err := n.do(ctx, "AddEgressRule", rule, func() (any, error) {
 		return nil, n.driver.AddEgressRule(ctx, groupID, rule)
@@ -177,6 +179,7 @@ func (n *Networking) AddEgressRule(ctx context.Context, groupID string, rule dri
 	return err
 }
 
+//nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (n *Networking) RemoveIngressRule(ctx context.Context, groupID string, rule driver.SecurityRule) error {
 	_, err := n.do(ctx, "RemoveIngressRule", rule, func() (any, error) {
 		return nil, n.driver.RemoveIngressRule(ctx, groupID, rule)
@@ -185,6 +188,7 @@ func (n *Networking) RemoveIngressRule(ctx context.Context, groupID string, rule
 	return err
 }
 
+//nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (n *Networking) RemoveEgressRule(ctx context.Context, groupID string, rule driver.SecurityRule) error {
 	_, err := n.do(ctx, "RemoveEgressRule", rule, func() (any, error) {
 		return nil, n.driver.RemoveEgressRule(ctx, groupID, rule)


### PR DESCRIPTION
EC2 wire-fidelity, researched against official AWS API docs, landed at the correct layer (serialization→wire, state→provider, AWS-only ops→type-asserted optional interfaces — no shared-interface changes). Integrated from 3 area streams (instances/networking/security-groups).

**Instances (8):** DescribeInstances field completeness (placement/monitoring/rootDevice/architecture/hypervisor/virtualizationType/DNS/networkInterfaceSet/groupSet GroupName + KeyName); reservation grouping (one r- per RunInstances batch) + MaxResults/NextToken; MonitorInstances→pending; ModifyInstanceAttribute Groups/UserData/EbsOptimized now take effect; DescribeInstanceTypes→InvalidInstanceType + processorInfo/networkInfo; subnet-CIDR private-IP allocation; ClientToken idempotency.
**Networking (4):** ownerId on RouteTable/NetworkAcl/DhcpOptions; Vpc cidrBlockAssociationSet; ReplaceRoute dispatch; CreateTags/DeleteTags for rtb-/igw-/nat-/acl-/dopt-/pcx-/pl-/eigw- (new AWS-only NetworkResourceTagger optional interface).
**Security groups (4):** Authorize responses return securityGroupRuleSet with sgr- rule IDs; UserIdGroupPairs; IPv6/prefix-list/descriptions; DescribeSecurityGroupRules + ModifySecurityGroupRules.

Additive struct fields are zero-value-safe for Azure/GCP (keyed literals). Coverage docs regenerated for the new optional interface; compat suite + docs clean. SDK round-trip tests per fix. Deferred (feature-scale, would break the compat suite or need async): DeleteVpc dependency scan, default-SG-on-CreateVpc.