### PR TITLE
fix(cloudwatch): DescribeAlarms filters+pagination, ListMetrics dimensions, Logs tokens

### DIFF
--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -281,7 +281,7 @@ func (m *Mock) GetLogEvents(_ context.Context, input *driver.LogQueryInput) ([]d
 	}
 
 	limit := input.Limit
-	if limit <= 0 {
+	if limit == 0 {
 		limit = defaultLogLimit
 	}
 
@@ -300,7 +300,9 @@ func (m *Mock) GetLogEvents(_ context.Context, input *driver.LogQueryInput) ([]d
 		}
 	}
 
-	if len(results) > limit {
+	// A negative limit means "no cap" — the wire handler fetches the full
+	// ordered set and paginates it itself.
+	if limit > 0 && len(results) > limit {
 		results = results[:limit]
 	}
 
@@ -366,7 +368,7 @@ func (m *Mock) FilterLogEvents(
 	}
 
 	limit := input.Limit
-	if limit <= 0 {
+	if limit == 0 {
 		limit = defaultLogLimit
 	}
 
@@ -381,7 +383,9 @@ func (m *Mock) FilterLogEvents(
 		}
 	}
 
-	if len(results) > limit {
+	// A negative limit means "no cap" — the wire handler fetches the full
+	// ordered set and paginates it itself.
+	if limit > 0 && len(results) > limit {
 		results = results[:limit]
 	}
 

--- a/server/aws/cloudwatch/alarm_metadata_test.go
+++ b/server/aws/cloudwatch/alarm_metadata_test.go
@@ -125,6 +125,45 @@ func TestSDKDescribeAlarmsFilters(t *testing.T) {
 	}
 }
 
+// TestSDKDescribeAlarmsPagination guards that DescribeAlarms honors MaxRecords
+// and hands back a NextToken the caller can follow. Without pagination the first
+// page returns everything and NextToken is empty, wedging the SDK paginator.
+func TestSDKDescribeAlarmsPagination(t *testing.T) {
+	client, ctx := newCWClient(t)
+	putAlarm(t, client, "pg-a")
+	putAlarm(t, client, "pg-b")
+	putAlarm(t, client, "pg-c")
+
+	first, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{MaxRecords: aws.Int32(2)})
+	if err != nil {
+		t.Fatalf("DescribeAlarms page 1: %v", err)
+	}
+
+	if len(first.MetricAlarms) != 2 {
+		t.Fatalf("page 1 = %d alarms, want 2 (MaxRecords ignored?)", len(first.MetricAlarms))
+	}
+
+	if aws.ToString(first.NextToken) == "" {
+		t.Fatalf("page 1 NextToken empty, want a token for the third alarm")
+	}
+
+	second, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{
+		MaxRecords: aws.Int32(2),
+		NextToken:  first.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("DescribeAlarms page 2: %v", err)
+	}
+
+	if len(second.MetricAlarms) != 1 || aws.ToString(second.MetricAlarms[0].AlarmName) != "pg-c" {
+		t.Fatalf("page 2 = %+v, want one alarm pg-c", second.MetricAlarms)
+	}
+
+	if aws.ToString(second.NextToken) != "" {
+		t.Fatalf("page 2 NextToken = %q, want empty (pagination finished)", aws.ToString(second.NextToken))
+	}
+}
+
 // TestSDKDescribeAlarmHistory covers finding 4: transition history recorded on
 // state changes must be readable via DescribeAlarmHistory.
 func TestSDKDescribeAlarmHistory(t *testing.T) {

--- a/server/aws/cloudwatch/metric_data_test.go
+++ b/server/aws/cloudwatch/metric_data_test.go
@@ -2,6 +2,7 @@ package cloudwatch_test
 
 import (
 	"context"
+	"fmt"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -256,5 +257,66 @@ func TestSDKListMetricsDimensions(t *testing.T) {
 
 	if len(filtered.Metrics) != 1 || aws.ToString(filtered.Metrics[0].Dimensions[0].Value) != "i-aaa" {
 		t.Fatalf("filtered metrics = %+v, want only i-aaa", filtered.Metrics)
+	}
+}
+
+// TestSDKListMetricsPagination guards that ListMetrics pages at 500 metrics and
+// hands back a NextToken. Without pagination every metric comes back on the
+// first page and NextToken is empty, wedging the SDK paginator.
+func TestSDKListMetricsPagination(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	// AWS pages ListMetrics at 500; put 501 distinct metrics in one call so the
+	// first page must spill into a second.
+	const total = 501
+
+	// PutMetricData accepts up to 1000 datums per call; send in batches of 100 to
+	// stay well within any single-request limits.
+	const batch = 100
+
+	for start := 0; start < total; start += batch {
+		data := make([]cwtypes.MetricDatum, 0, batch)
+		for i := start; i < start+batch && i < total; i++ {
+			data = append(data, cwtypes.MetricDatum{
+				MetricName: aws.String(fmt.Sprintf("m-%04d", i)),
+				Value:      aws.Float64(1),
+			})
+		}
+
+		if _, err := client.PutMetricData(ctx, &awscw.PutMetricDataInput{
+			Namespace:  aws.String("Paged/Metrics"),
+			MetricData: data,
+		}); err != nil {
+			t.Fatalf("PutMetricData: %v", err)
+		}
+	}
+
+	first, err := client.ListMetrics(ctx, &awscw.ListMetricsInput{Namespace: aws.String("Paged/Metrics")})
+	if err != nil {
+		t.Fatalf("ListMetrics page 1: %v", err)
+	}
+
+	if len(first.Metrics) != 500 {
+		t.Fatalf("page 1 = %d metrics, want 500 (pagination missing?)", len(first.Metrics))
+	}
+
+	if aws.ToString(first.NextToken) == "" {
+		t.Fatalf("page 1 NextToken empty, want a token for the 501st metric")
+	}
+
+	second, err := client.ListMetrics(ctx, &awscw.ListMetricsInput{
+		Namespace: aws.String("Paged/Metrics"),
+		NextToken: first.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("ListMetrics page 2: %v", err)
+	}
+
+	if len(second.Metrics) != 1 {
+		t.Fatalf("page 2 = %d metrics, want 1", len(second.Metrics))
+	}
+
+	if aws.ToString(second.NextToken) != "" {
+		t.Fatalf("page 2 NextToken = %q, want empty (pagination finished)", aws.ToString(second.NextToken))
 	}
 }

--- a/server/aws/cloudwatch/offset_token.go
+++ b/server/aws/cloudwatch/offset_token.go
@@ -1,0 +1,48 @@
+package cloudwatch
+
+import (
+	"encoding/base64"
+	"strconv"
+)
+
+// decodeOffsetToken parses a NextToken produced by encodeOffsetToken back into a
+// slice offset. An empty token means "start from the beginning"; a malformed
+// token is treated as offset 0 so a stray token never wedges pagination.
+func decodeOffsetToken(tok string) int {
+	if tok == "" {
+		return 0
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(tok)
+	if err != nil {
+		return 0
+	}
+
+	n, err := strconv.Atoi(string(raw))
+	if err != nil || n < 0 {
+		return 0
+	}
+
+	return n
+}
+
+// encodeOffsetToken renders a slice offset as an opaque NextToken.
+func encodeOffsetToken(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}
+
+// pageWindow resolves [from,to) and the next-page offset for a slice of the
+// given length, paged in fixed-size chunks. next is 0 when no further page
+// remains.
+func pageWindow(total, start, size int) (from, to, next int) {
+	if start > total {
+		start = total
+	}
+
+	end := start + size
+	if end >= total {
+		return start, total, 0
+	}
+
+	return start, end, end
+}

--- a/server/aws/cloudwatch/ops.go
+++ b/server/aws/cloudwatch/ops.go
@@ -208,6 +208,7 @@ type listMetricsInput struct {
 	Namespace  string               `cbor:"Namespace,omitempty"`
 	MetricName string               `cbor:"MetricName,omitempty"`
 	Dimensions []dimensionFilterCBR `cbor:"Dimensions,omitempty"`
+	NextToken  string               `cbor:"NextToken,omitempty"`
 }
 
 type metricCBR struct {
@@ -217,8 +218,12 @@ type metricCBR struct {
 }
 
 type listMetricsOutput struct {
-	Metrics []metricCBR `cbor:"Metrics"`
+	Metrics   []metricCBR `cbor:"Metrics"`
+	NextToken string      `cbor:"NextToken,omitempty"`
 }
+
+// listMetricsPageSize is the number of metrics AWS returns per ListMetrics page.
+const listMetricsPageSize = 500
 
 func (h *Handler) listMetrics(w http.ResponseWriter, r *http.Request, body []byte) {
 	var in listMetricsInput
@@ -243,7 +248,32 @@ func (h *Handler) listMetrics(w http.ResponseWriter, r *http.Request, body []byt
 		rows = append(rows, h.ipamMetricRows(r)...)
 	}
 
-	writeCBORResponse(w, listMetricsOutput{Metrics: filterMetricRows(rows, in)})
+	matched := filterMetricRows(rows, in)
+	sort.SliceStable(matched, func(i, j int) bool {
+		return metricRowKey(matched[i]) < metricRowKey(matched[j])
+	})
+
+	from, to, next := pageWindow(len(matched), decodeOffsetToken(in.NextToken), listMetricsPageSize)
+
+	resp := listMetricsOutput{Metrics: matched[from:to]}
+	if next > 0 {
+		resp.NextToken = encodeOffsetToken(next)
+	}
+
+	writeCBORResponse(w, resp)
+}
+
+// metricRowKey renders a metric row as a stable sort key over namespace, metric
+// name, then its sorted dimension pairs — a deterministic order for paging.
+func metricRowKey(m metricCBR) string {
+	parts := make([]string, 0, len(m.Dimensions))
+	for _, d := range m.Dimensions {
+		parts = append(parts, d.Name+"="+d.Value)
+	}
+
+	sort.Strings(parts)
+
+	return m.Namespace + "\x00" + m.MetricName + "\x00" + strings.Join(parts, ",")
 }
 
 // filterMetricRows applies the ListMetrics namespace / metric-name / dimension
@@ -431,7 +461,12 @@ type describeAlarmsInput struct {
 	StateValue      string   `cbor:"StateValue,omitempty"`
 	ActionPrefix    string   `cbor:"ActionPrefix,omitempty"`
 	MaxRecords      int      `cbor:"MaxRecords,omitempty"`
+	NextToken       string   `cbor:"NextToken,omitempty"`
 }
+
+// maxAlarmPageSize is the AWS cap on DescribeAlarms MaxRecords, used as the page
+// size when a caller pages with a NextToken but omits MaxRecords.
+const maxAlarmPageSize = 100
 
 type metricAlarmCBR struct {
 	AlarmName               string         `cbor:"AlarmName"`
@@ -456,6 +491,7 @@ type metricAlarmCBR struct {
 
 type describeAlarmsOutput struct {
 	MetricAlarms []metricAlarmCBR `cbor:"MetricAlarms"`
+	NextToken    string           `cbor:"NextToken,omitempty"`
 }
 
 func (h *Handler) describeAlarms(w http.ResponseWriter, r *http.Request, body []byte) {
@@ -471,21 +507,41 @@ func (h *Handler) describeAlarms(w http.ResponseWriter, r *http.Request, body []
 		return
 	}
 
-	out := make([]metricAlarmCBR, 0, len(alarms))
+	matched := make([]metricAlarmCBR, 0, len(alarms))
 
 	for i := range alarms {
 		if !alarmMatchesFilters(&alarms[i], &in) {
 			continue
 		}
 
-		out = append(out, toMetricAlarmCBR(&alarms[i]))
-
-		if in.MaxRecords > 0 && len(out) >= in.MaxRecords {
-			break
-		}
+		matched = append(matched, toMetricAlarmCBR(&alarms[i]))
 	}
 
-	writeCBORResponse(w, describeAlarmsOutput{MetricAlarms: out})
+	// Without paging inputs, preserve the historical "return everything" shape so
+	// existing callers are unaffected. Deterministic ordering only matters once a
+	// caller pages, so sort just in that branch.
+	if in.MaxRecords == 0 && in.NextToken == "" {
+		writeCBORResponse(w, describeAlarmsOutput{MetricAlarms: matched})
+		return
+	}
+
+	sort.SliceStable(matched, func(i, j int) bool {
+		return matched[i].AlarmName < matched[j].AlarmName
+	})
+
+	size := in.MaxRecords
+	if size <= 0 {
+		size = maxAlarmPageSize
+	}
+
+	from, to, next := pageWindow(len(matched), decodeOffsetToken(in.NextToken), size)
+
+	resp := describeAlarmsOutput{MetricAlarms: matched[from:to]}
+	if next > 0 {
+		resp.NextToken = encodeOffsetToken(next)
+	}
+
+	writeCBORResponse(w, resp)
 }
 
 // alarmMatchesFilters applies the DescribeAlarms filter fields (name prefix,

--- a/server/aws/cloudwatchlogs/operations.go
+++ b/server/aws/cloudwatchlogs/operations.go
@@ -249,19 +249,47 @@ func (h *Handler) putLogEvents(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, putLogEventsResponse{NextSequenceToken: "0"})
 }
 
+// getLogEventsWindowStart picks the slice offset for a GetLogEvents page over an
+// ascending (oldest→newest) event set. A continuation token carries an absolute
+// position and wins; otherwise the AWS default (startFromHead false) windows from
+// the tail (latest events first) and startFromHead=true windows from the head.
+func getLogEventsWindowStart(nextToken string, startFromHead *bool, total, size int) int {
+	var start int
+
+	switch {
+	case nextToken != "":
+		start = decodePositionToken(nextToken)
+	case startFromHead != nil && *startFromHead:
+		start = 0
+	default:
+		start = total - size
+	}
+
+	if start < 0 {
+		start = 0
+	}
+
+	if start > total {
+		start = total
+	}
+
+	return start
+}
+
 func (h *Handler) getLogEvents(w http.ResponseWriter, r *http.Request) {
 	var req getLogEventsRequest
 	if !wire.DecodeJSON(w, r, &req) {
 		return
 	}
 
-	// Fetch the full ordered slice (Limit 0) and page it here so the forward /
-	// backward tokens can carry a real position.
+	// Fetch the full ordered slice (Limit -1 = no cap) and page it here so the
+	// forward / backward tokens can carry a real position across all events.
 	events, err := h.logs.GetLogEvents(r.Context(), &logdriver.LogQueryInput{
 		LogGroup:  req.LogGroupName,
 		LogStream: req.LogStreamName,
 		StartTime: millisToTime(req.StartTime),
 		EndTime:   millisToTime(req.EndTime),
+		Limit:     -1,
 	})
 	if err != nil {
 		writeErr(w, err)
@@ -273,10 +301,7 @@ func (h *Handler) getLogEvents(w http.ResponseWriter, r *http.Request) {
 		size = defaultEventLimit
 	}
 
-	start := decodePositionToken(req.NextToken)
-	if start > len(events) {
-		start = len(events)
-	}
+	start := getLogEventsWindowStart(req.NextToken, req.StartFromHead, len(events), size)
 
 	end := start + size
 	if end > len(events) {
@@ -314,13 +339,15 @@ func (h *Handler) filterLogEvents(w http.ResponseWriter, r *http.Request) {
 		stream = req.LogStreamNames[0]
 	}
 
-	// Fetch every match (Limit 0) and page here so a NextToken can be handed back.
+	// Fetch every match (Limit -1 = no cap) and page here so a NextToken can be
+	// handed back across all matches.
 	events, err := h.logs.FilterLogEvents(r.Context(), &logdriver.FilterLogEventsInput{
 		LogGroup:      req.LogGroupName,
 		LogStream:     stream,
 		FilterPattern: req.FilterPattern,
 		StartTime:     millisToTime(req.StartTime),
 		EndTime:       millisToTime(req.EndTime),
+		Limit:         -1,
 	})
 	if err != nil {
 		writeErr(w, err)

--- a/server/aws/cloudwatchlogs/operations.go
+++ b/server/aws/cloudwatchlogs/operations.go
@@ -15,6 +15,32 @@ import (
 // DescribeLogGroups / DescribeLogStreams when the caller omits limit.
 const defaultDescribeLimit = 50
 
+// defaultEventLimit is the page size CloudWatch Logs applies to GetLogEvents /
+// FilterLogEvents when the caller omits limit (AWS caps a page at 10000 events).
+const defaultEventLimit = 10000
+
+// forwardTokenPrefix / backwardTokenPrefix mark the GetLogEvents cursor
+// direction; AWS forward tokens are "f/<...>" and backward tokens "b/<...>".
+const (
+	forwardTokenPrefix  = "f/"
+	backwardTokenPrefix = "b/"
+)
+
+// encodePositionToken renders a slice offset as a direction-prefixed GetLogEvents
+// token (e.g. "f/<base64>").
+func encodePositionToken(prefix string, offset int) string {
+	return prefix + encodeOffsetToken(offset)
+}
+
+// decodePositionToken parses a GetLogEvents forward/backward token back into a
+// slice offset, tolerating either direction prefix.
+func decodePositionToken(tok string) int {
+	tok = strings.TrimPrefix(tok, forwardTokenPrefix)
+	tok = strings.TrimPrefix(tok, backwardTokenPrefix)
+
+	return decodeOffsetToken(tok)
+}
+
 // decodeOffsetToken parses a nextToken produced by encodeOffsetToken back into a
 // slice offset. An empty token means "start from the beginning"; a malformed
 // token is treated as offset 0 so a stray token never wedges pagination.
@@ -229,20 +255,36 @@ func (h *Handler) getLogEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Fetch the full ordered slice (Limit 0) and page it here so the forward /
+	// backward tokens can carry a real position.
 	events, err := h.logs.GetLogEvents(r.Context(), &logdriver.LogQueryInput{
 		LogGroup:  req.LogGroupName,
 		LogStream: req.LogStreamName,
 		StartTime: millisToTime(req.StartTime),
 		EndTime:   millisToTime(req.EndTime),
-		Limit:     int(req.Limit),
 	})
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	out := make([]outputLogEvent, 0, len(events))
-	for _, e := range events {
+	size := int(req.Limit)
+	if size <= 0 {
+		size = defaultEventLimit
+	}
+
+	start := decodePositionToken(req.NextToken)
+	if start > len(events) {
+		start = len(events)
+	}
+
+	end := start + size
+	if end > len(events) {
+		end = len(events)
+	}
+
+	out := make([]outputLogEvent, 0, end-start)
+	for _, e := range events[start:end] {
 		out = append(out, outputLogEvent{
 			Timestamp:     epochMillis(e.Timestamp),
 			Message:       e.Message,
@@ -250,11 +292,12 @@ func (h *Handler) getLogEvents(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// Token values are opaque to the SDK; a stable pair terminates paging.
+	// Tokens are never null. When the cursor is at the end, the forward token
+	// equals the one the caller passed in, which is how the SDK paginator stops.
 	wire.WriteJSON(w, getLogEventsResponse{
 		Events:            out,
-		NextForwardToken:  "f/0",
-		NextBackwardToken: "b/0",
+		NextForwardToken:  encodePositionToken(forwardTokenPrefix, end),
+		NextBackwardToken: encodePositionToken(backwardTokenPrefix, start),
 	})
 }
 
@@ -271,21 +314,28 @@ func (h *Handler) filterLogEvents(w http.ResponseWriter, r *http.Request) {
 		stream = req.LogStreamNames[0]
 	}
 
+	// Fetch every match (Limit 0) and page here so a NextToken can be handed back.
 	events, err := h.logs.FilterLogEvents(r.Context(), &logdriver.FilterLogEventsInput{
 		LogGroup:      req.LogGroupName,
 		LogStream:     stream,
 		FilterPattern: req.FilterPattern,
 		StartTime:     millisToTime(req.StartTime),
 		EndTime:       millisToTime(req.EndTime),
-		Limit:         int(req.Limit),
 	})
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	out := make([]filteredLogEvent, 0, len(events))
-	for _, e := range events {
+	limit := req.Limit
+	if limit <= 0 {
+		limit = defaultEventLimit
+	}
+
+	from, to, next := pageBounds(len(events), decodeOffsetToken(req.NextToken), limit)
+
+	out := make([]filteredLogEvent, 0, to-from)
+	for _, e := range events[from:to] {
 		out = append(out, filteredLogEvent{
 			LogStreamName: e.LogStream,
 			Timestamp:     epochMillis(e.Timestamp),
@@ -294,5 +344,11 @@ func (h *Handler) filterLogEvents(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	wire.WriteJSON(w, filterLogEventsResponse{Events: out})
+	// searchedLogStreams is an always-empty list on modern AWS (deprecated 2020).
+	resp := filterLogEventsResponse{Events: out, SearchedLogStreams: []searchedLogStreamJSON{}}
+	if next > 0 {
+		resp.NextToken = encodeOffsetToken(next)
+	}
+
+	wire.WriteJSON(w, resp)
 }

--- a/server/aws/cloudwatchlogs/operations.go
+++ b/server/aws/cloudwatchlogs/operations.go
@@ -249,20 +249,25 @@ func (h *Handler) putLogEvents(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, putLogEventsResponse{NextSequenceToken: "0"})
 }
 
-// getLogEventsWindowStart picks the slice offset for a GetLogEvents page over an
-// ascending (oldest→newest) event set. A continuation token carries an absolute
-// position and wins; otherwise the AWS default (startFromHead false) windows from
-// the tail (latest events first) and startFromHead=true windows from the head.
-func getLogEventsWindowStart(nextToken string, startFromHead *bool, total, size int) int {
-	var start int
-
+// getLogEventsWindow picks the [start,end) slice bounds for a GetLogEvents page
+// over an ascending (oldest→newest) event set. A continuation token wins and is
+// direction-aware: a forward token marks the START of the next page, a backward
+// token marks the END (exclusive) of the previous page — so following the
+// backward token yields the older window, not the current one. With no token the
+// AWS default (startFromHead false) returns the tail (latest events first) and
+// startFromHead=true returns the head.
+func getLogEventsWindow(nextToken string, startFromHead *bool, total, size int) (start, end int) {
 	switch {
+	case strings.HasPrefix(nextToken, backwardTokenPrefix):
+		end = decodePositionToken(nextToken)
+		start = end - size
 	case nextToken != "":
 		start = decodePositionToken(nextToken)
+		end = start + size
 	case startFromHead != nil && *startFromHead:
-		start = 0
+		start, end = 0, size
 	default:
-		start = total - size
+		start, end = total-size, total
 	}
 
 	if start < 0 {
@@ -273,7 +278,15 @@ func getLogEventsWindowStart(nextToken string, startFromHead *bool, total, size 
 		start = total
 	}
 
-	return start
+	if end > total {
+		end = total
+	}
+
+	if end < start {
+		end = start
+	}
+
+	return start, end
 }
 
 func (h *Handler) getLogEvents(w http.ResponseWriter, r *http.Request) {
@@ -301,12 +314,7 @@ func (h *Handler) getLogEvents(w http.ResponseWriter, r *http.Request) {
 		size = defaultEventLimit
 	}
 
-	start := getLogEventsWindowStart(req.NextToken, req.StartFromHead, len(events), size)
-
-	end := start + size
-	if end > len(events) {
-		end = len(events)
-	}
+	start, end := getLogEventsWindow(req.NextToken, req.StartFromHead, len(events), size)
 
 	out := make([]outputLogEvent, 0, end-start)
 	for _, e := range events[start:end] {

--- a/server/aws/cloudwatchlogs/sdk_roundtrip_test.go
+++ b/server/aws/cloudwatchlogs/sdk_roundtrip_test.go
@@ -405,8 +405,11 @@ func TestSDKGetLogEventsPagination(t *testing.T) {
 		t.Fatalf("PutLogEvents: %v", err)
 	}
 
+	// StartFromHead=true walks oldest→newest; the AWS default (false) returns the
+	// latest events first, which TestSDKGetLogEventsStartFromHeadDefault covers.
 	first, err := client.GetLogEvents(ctx, &cwl.GetLogEventsInput{
-		LogGroupName: aws.String("/pg/g"), LogStreamName: aws.String("s1"), Limit: aws.Int32(2),
+		LogGroupName: aws.String("/pg/g"), LogStreamName: aws.String("s1"),
+		Limit: aws.Int32(2), StartFromHead: aws.Bool(true),
 	})
 	if err != nil {
 		t.Fatalf("GetLogEvents page 1: %v", err)
@@ -448,6 +451,103 @@ func TestSDKGetLogEventsPagination(t *testing.T) {
 	if aws.ToString(third.NextForwardToken) != aws.ToString(second.NextForwardToken) {
 		t.Fatalf("terminal forward token = %q, want same as %q",
 			aws.ToString(third.NextForwardToken), aws.ToString(second.NextForwardToken))
+	}
+}
+
+func mustLogGroupStream(t *testing.T, client *cwl.Client, group, stream string) {
+	t.Helper()
+
+	ctx := context.Background()
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String(group)}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	if _, err := client.CreateLogStream(ctx, &cwl.CreateLogStreamInput{
+		LogGroupName: aws.String(group), LogStreamName: aws.String(stream),
+	}); err != nil {
+		t.Fatalf("CreateLogStream: %v", err)
+	}
+}
+
+// TestSDKGetLogEventsStartFromHeadDefault pins the AWS default: with
+// startFromHead unset (false), GetLogEvents returns the LATEST events first.
+func TestSDKGetLogEventsStartFromHeadDefault(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	mustLogGroupStream(t, client, "/h/g", "s1")
+
+	base := time.Now().UTC().Truncate(time.Millisecond)
+	events := make([]cwltypes.InputLogEvent, 0, 3)
+	for i := 0; i < 3; i++ {
+		events = append(events, cwltypes.InputLogEvent{
+			Timestamp: aws.Int64(base.Add(time.Duration(i) * time.Second).UnixMilli()),
+			Message:   aws.String(fmt.Sprintf("e%d", i)),
+		})
+	}
+	if _, err := client.PutLogEvents(ctx, &cwl.PutLogEventsInput{
+		LogGroupName: aws.String("/h/g"), LogStreamName: aws.String("s1"), LogEvents: events,
+	}); err != nil {
+		t.Fatalf("PutLogEvents: %v", err)
+	}
+
+	out, err := client.GetLogEvents(ctx, &cwl.GetLogEventsInput{
+		LogGroupName: aws.String("/h/g"), LogStreamName: aws.String("s1"), Limit: aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("GetLogEvents: %v", err)
+	}
+
+	if len(out.Events) != 2 || aws.ToString(out.Events[0].Message) != "e1" ||
+		aws.ToString(out.Events[1].Message) != "e2" {
+		t.Fatalf("default page = %+v, want the latest two [e1 e2]", out.Events)
+	}
+}
+
+// TestSDKGetLogEventsBeyond100 pins that streams with more than the internal
+// default page size are fully reachable via pagination (no silent 100-event cap).
+func TestSDKGetLogEventsBeyond100(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	mustLogGroupStream(t, client, "/big/g", "s1")
+
+	const total = 150
+	base := time.Now().UTC().Truncate(time.Millisecond)
+	events := make([]cwltypes.InputLogEvent, 0, total)
+	for i := 0; i < total; i++ {
+		events = append(events, cwltypes.InputLogEvent{
+			Timestamp: aws.Int64(base.Add(time.Duration(i) * time.Millisecond).UnixMilli()),
+			Message:   aws.String(fmt.Sprintf("e%d", i)),
+		})
+	}
+	if _, err := client.PutLogEvents(ctx, &cwl.PutLogEventsInput{
+		LogGroupName: aws.String("/big/g"), LogStreamName: aws.String("s1"), LogEvents: events,
+	}); err != nil {
+		t.Fatalf("PutLogEvents: %v", err)
+	}
+
+	// Walk head→tail and confirm all 150 events are seen (the last one, e149,
+	// is only reachable if the internal 100 cap is gone).
+	seen := 0
+	var token *string
+	for page := 0; page < 20; page++ {
+		out, err := client.GetLogEvents(ctx, &cwl.GetLogEventsInput{
+			LogGroupName: aws.String("/big/g"), LogStreamName: aws.String("s1"),
+			Limit: aws.Int32(40), StartFromHead: aws.Bool(true), NextToken: token,
+		})
+		if err != nil {
+			t.Fatalf("GetLogEvents page %d: %v", page, err)
+		}
+		if len(out.Events) == 0 {
+			break
+		}
+		seen += len(out.Events)
+		token = out.NextForwardToken
+	}
+
+	if seen != total {
+		t.Fatalf("paginated walk saw %d events, want %d (100-event cap regression?)", seen, total)
 	}
 }
 

--- a/server/aws/cloudwatchlogs/sdk_roundtrip_test.go
+++ b/server/aws/cloudwatchlogs/sdk_roundtrip_test.go
@@ -3,6 +3,7 @@ package cloudwatchlogs_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -367,6 +368,151 @@ func TestSDKLogStreamFirstEventAndIngestionTime(t *testing.T) {
 	if aws.ToInt64(streams.LogStreams[0].FirstEventTimestamp) != eventTime.UnixMilli() {
 		t.Fatalf("FirstEventTimestamp = %d, want %d",
 			aws.ToInt64(streams.LogStreams[0].FirstEventTimestamp), eventTime.UnixMilli())
+	}
+}
+
+// TestSDKGetLogEventsPagination guards that GetLogEvents honors Limit + nextToken
+// and returns real forward/backward tokens (never the hardcoded "f/0"/"b/0"): the
+// second page must advance past the first, and the terminal call echoes the same
+// forward token so the SDK paginator stops.
+func TestSDKGetLogEventsPagination(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String("/pg/g")}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	if _, err := client.CreateLogStream(ctx, &cwl.CreateLogStreamInput{
+		LogGroupName: aws.String("/pg/g"), LogStreamName: aws.String("s1"),
+	}); err != nil {
+		t.Fatalf("CreateLogStream: %v", err)
+	}
+
+	base := time.Now().UTC().Truncate(time.Millisecond)
+
+	events := make([]cwltypes.InputLogEvent, 0, 3)
+	for i := 0; i < 3; i++ {
+		events = append(events, cwltypes.InputLogEvent{
+			Timestamp: aws.Int64(base.Add(time.Duration(i) * time.Second).UnixMilli()),
+			Message:   aws.String(fmt.Sprintf("e%d", i)),
+		})
+	}
+
+	if _, err := client.PutLogEvents(ctx, &cwl.PutLogEventsInput{
+		LogGroupName: aws.String("/pg/g"), LogStreamName: aws.String("s1"), LogEvents: events,
+	}); err != nil {
+		t.Fatalf("PutLogEvents: %v", err)
+	}
+
+	first, err := client.GetLogEvents(ctx, &cwl.GetLogEventsInput{
+		LogGroupName: aws.String("/pg/g"), LogStreamName: aws.String("s1"), Limit: aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("GetLogEvents page 1: %v", err)
+	}
+
+	if len(first.Events) != 2 || aws.ToString(first.Events[0].Message) != "e0" {
+		t.Fatalf("page 1 = %+v, want [e0 e1]", first.Events)
+	}
+
+	if aws.ToString(first.NextForwardToken) == "" || aws.ToString(first.NextForwardToken) == "f/0" {
+		t.Fatalf("page 1 NextForwardToken = %q, want a real cursor", aws.ToString(first.NextForwardToken))
+	}
+
+	second, err := client.GetLogEvents(ctx, &cwl.GetLogEventsInput{
+		LogGroupName: aws.String("/pg/g"), LogStreamName: aws.String("s1"),
+		Limit: aws.Int32(2), NextToken: first.NextForwardToken,
+	})
+	if err != nil {
+		t.Fatalf("GetLogEvents page 2: %v", err)
+	}
+
+	if len(second.Events) != 1 || aws.ToString(second.Events[0].Message) != "e2" {
+		t.Fatalf("page 2 = %+v, want [e2] (nextToken ignored?)", second.Events)
+	}
+
+	// Terminal page: no more events, forward token echoes the one we passed in.
+	third, err := client.GetLogEvents(ctx, &cwl.GetLogEventsInput{
+		LogGroupName: aws.String("/pg/g"), LogStreamName: aws.String("s1"),
+		Limit: aws.Int32(2), NextToken: second.NextForwardToken,
+	})
+	if err != nil {
+		t.Fatalf("GetLogEvents page 3: %v", err)
+	}
+
+	if len(third.Events) != 0 {
+		t.Fatalf("page 3 = %+v, want no events", third.Events)
+	}
+
+	if aws.ToString(third.NextForwardToken) != aws.ToString(second.NextForwardToken) {
+		t.Fatalf("terminal forward token = %q, want same as %q",
+			aws.ToString(third.NextForwardToken), aws.ToString(second.NextForwardToken))
+	}
+}
+
+// TestSDKFilterLogEventsPagination guards that FilterLogEvents honors Limit and
+// hands back a nextToken for the remainder. Without pagination the first page
+// returns every match and nextToken is empty, wedging the SDK paginator.
+func TestSDKFilterLogEventsPagination(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String("/pf/g")}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	if _, err := client.CreateLogStream(ctx, &cwl.CreateLogStreamInput{
+		LogGroupName: aws.String("/pf/g"), LogStreamName: aws.String("s1"),
+	}); err != nil {
+		t.Fatalf("CreateLogStream: %v", err)
+	}
+
+	base := time.Now().UTC().Truncate(time.Millisecond)
+
+	events := make([]cwltypes.InputLogEvent, 0, 3)
+	for i := 0; i < 3; i++ {
+		events = append(events, cwltypes.InputLogEvent{
+			Timestamp: aws.Int64(base.Add(time.Duration(i) * time.Second).UnixMilli()),
+			Message:   aws.String(fmt.Sprintf("match %d", i)),
+		})
+	}
+
+	if _, err := client.PutLogEvents(ctx, &cwl.PutLogEventsInput{
+		LogGroupName: aws.String("/pf/g"), LogStreamName: aws.String("s1"), LogEvents: events,
+	}); err != nil {
+		t.Fatalf("PutLogEvents: %v", err)
+	}
+
+	first, err := client.FilterLogEvents(ctx, &cwl.FilterLogEventsInput{
+		LogGroupName: aws.String("/pf/g"), FilterPattern: aws.String("match"), Limit: aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("FilterLogEvents page 1: %v", err)
+	}
+
+	if len(first.Events) != 2 {
+		t.Fatalf("page 1 = %d events, want 2 (Limit ignored?)", len(first.Events))
+	}
+
+	if aws.ToString(first.NextToken) == "" {
+		t.Fatalf("page 1 NextToken empty, want a token for the third match")
+	}
+
+	second, err := client.FilterLogEvents(ctx, &cwl.FilterLogEventsInput{
+		LogGroupName: aws.String("/pf/g"), FilterPattern: aws.String("match"),
+		Limit: aws.Int32(2), NextToken: first.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("FilterLogEvents page 2: %v", err)
+	}
+
+	if len(second.Events) != 1 {
+		t.Fatalf("page 2 = %d events, want 1", len(second.Events))
+	}
+
+	if aws.ToString(second.NextToken) != "" {
+		t.Fatalf("page 2 NextToken = %q, want empty (pagination finished)", aws.ToString(second.NextToken))
 	}
 }
 

--- a/server/aws/cloudwatchlogs/sdk_roundtrip_test.go
+++ b/server/aws/cloudwatchlogs/sdk_roundtrip_test.go
@@ -502,6 +502,33 @@ func TestSDKGetLogEventsStartFromHeadDefault(t *testing.T) {
 		aws.ToString(out.Events[1].Message) != "e2" {
 		t.Fatalf("default page = %+v, want the latest two [e1 e2]", out.Events)
 	}
+
+	// Backward pagination (the default latest-first direction) must reach OLDER
+	// events, not repeat the current page. Follow NextBackwardToken to page 2.
+	older, err := client.GetLogEvents(ctx, &cwl.GetLogEventsInput{
+		LogGroupName: aws.String("/h/g"), LogStreamName: aws.String("s1"),
+		Limit: aws.Int32(2), NextToken: out.NextBackwardToken,
+	})
+	if err != nil {
+		t.Fatalf("GetLogEvents backward page: %v", err)
+	}
+
+	if len(older.Events) != 1 || aws.ToString(older.Events[0].Message) != "e0" {
+		t.Fatalf("backward page = %+v, want the older event [e0] (backward token repeats page?)", older.Events)
+	}
+
+	// One more backward step stabilizes (no events, token echoes).
+	last, err := client.GetLogEvents(ctx, &cwl.GetLogEventsInput{
+		LogGroupName: aws.String("/h/g"), LogStreamName: aws.String("s1"),
+		Limit: aws.Int32(2), NextToken: older.NextBackwardToken,
+	})
+	if err != nil {
+		t.Fatalf("GetLogEvents backward terminal: %v", err)
+	}
+
+	if len(last.Events) != 0 {
+		t.Fatalf("backward terminal page = %+v, want no events", last.Events)
+	}
 }
 
 // TestSDKGetLogEventsBeyond100 pins that streams with more than the internal

--- a/server/aws/cloudwatchlogs/types.go
+++ b/server/aws/cloudwatchlogs/types.go
@@ -56,6 +56,8 @@ type getLogEventsRequest struct {
 	StartTime     int64  `json:"startTime"`
 	EndTime       int64  `json:"endTime"`
 	Limit         int32  `json:"limit"`
+	NextToken     string `json:"nextToken"`
+	StartFromHead *bool  `json:"startFromHead"`
 }
 
 type filterLogEventsRequest struct {
@@ -65,6 +67,7 @@ type filterLogEventsRequest struct {
 	StartTime      int64    `json:"startTime"`
 	EndTime        int64    `json:"endTime"`
 	Limit          int32    `json:"limit"`
+	NextToken      string   `json:"nextToken"`
 }
 
 // --- response envelopes ---
@@ -123,8 +126,18 @@ type filteredLogEvent struct {
 	IngestionTime int64  `json:"ingestionTime"`
 }
 
+// searchedLogStreamJSON is the FilterLogEvents searchedLogStreams element. AWS
+// deprecated the field to an always-empty list on 2020-05-15, so it is never
+// populated; the type exists only to emit the shape the SDK expects.
+type searchedLogStreamJSON struct {
+	LogStreamName      string `json:"logStreamName"`
+	SearchedCompletely bool   `json:"searchedCompletely"`
+}
+
 type filterLogEventsResponse struct {
-	Events []filteredLogEvent `json:"events"`
+	Events             []filteredLogEvent      `json:"events"`
+	SearchedLogStreams []searchedLogStreamJSON `json:"searchedLogStreams"`
+	NextToken          string                  `json:"nextToken,omitempty"`
 }
 
 // epochMillis converts a time to Unix epoch milliseconds, the form the AWS JSON


### PR DESCRIPTION
CloudWatch/Logs wire fidelity per AWS docs: DescribeAlarms honors AlarmNamePrefix/StateValue/ActionPrefix/MaxRecords/NextToken; ListMetrics returns Dimensions; CloudWatch Logs GetLogEvents/FilterLogEvents token fidelity. compat suite clean; SDK tests per fix.