### PR TITLE
fix(rds+redshift): DBInstance/DBCluster + Cluster/snapshot field completeness, pagination, GetClusterCredentials

### DIFF
--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -9,7 +9,10 @@ package rds
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -32,6 +35,18 @@ const (
 	cpuMetricRunning     = 25.0
 	connectionsRunning   = 5.0
 	cpuMetricStopped     = 0.0
+)
+
+// Defaults RDS applies to a new DBInstance/DBCluster that real AWS reports on
+// read even when the caller did not set them.
+const (
+	defaultBackupRetention   = 1
+	defaultCACertIdentifier  = "rds-ca-rsa2048-g1"
+	defaultBackupWindow      = "07:00-07:30" //nolint:gosec // a maintenance-window time range, not a credential.
+	defaultMaintenanceWindow = "sun:05:00-sun:05:30"
+	defaultEngineMode        = "provisioned"
+	auroraAllocatedStorage   = 1
+	resourceIDLen            = 20
 )
 
 // Metric namespaces for engines that share the RDS wire protocol but emit
@@ -196,8 +211,28 @@ func instanceARN(region, accountID, id string) string {
 	return idgen.AWSARN("rds", region, accountID, "db:"+id)
 }
 
+// resourceID derives a stable, region-unique RDS resource id (e.g.
+// "db-ABCDEF...", "cluster-ABCDEF...") from a prefix and the resource id. Real
+// AWS assigns an opaque immutable id; a deterministic hash keeps it stable
+// across Describe calls without persisting a random value.
+func resourceID(prefix, id string) string {
+	sum := sha256.Sum256([]byte(id))
+	return prefix + strings.ToUpper(hex.EncodeToString(sum[:])[:resourceIDLen])
+}
+
 func clusterARN(region, accountID, id string) string {
 	return idgen.AWSARN("rds", region, accountID, "cluster:"+id)
+}
+
+// availabilityZones synthesizes the three AZ names AWS spreads an Aurora
+// cluster across (region + a/b/c), matching the DBCluster AvailabilityZones
+// array real RDS returns.
+func availabilityZones(region string) []string {
+	if region == "" {
+		return nil
+	}
+
+	return []string{region + "a", region + "b", region + "c"}
 }
 
 func snapshotARN(region, accountID, id string) string {
@@ -236,6 +271,7 @@ func cloneCluster(c rdsdriver.Cluster) rdsdriver.Cluster {
 	c.Tags = copyTags(c.Tags)
 	c.Members = cloneSlice(c.Members)
 	c.VPCSecurityGroups = cloneSlice(c.VPCSecurityGroups)
+	c.AvailabilityZones = cloneSlice(c.AvailabilityZones)
 
 	return c
 }
@@ -360,28 +396,34 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 	}
 
 	return rdsdriver.Instance{
-		ID:                   cfg.ID,
-		ARN:                  instanceARN(m.opts.Region, m.opts.AccountID, cfg.ID),
-		Engine:               cfg.Engine,
-		EngineVersion:        engineVersion,
-		InstanceClass:        instanceClass,
-		AllocatedStorage:     storage,
-		StorageType:          storageType,
-		MasterUsername:       cfg.MasterUsername,
-		DBName:               cfg.DBName,
-		Endpoint:             endpointFor(cfg.ID, m.opts.Region, "abcd1234"),
-		Port:                 port,
-		State:                rdsdriver.StateAvailable,
-		MultiAZ:              cfg.MultiAZ,
-		PubliclyAccessible:   cfg.PubliclyAccessible,
-		VPCSecurityGroups:    append([]string(nil), cfg.VPCSecurityGroups...),
-		SubnetGroupName:      cfg.SubnetGroupName,
-		DBParameterGroupName: cfg.DBParameterGroupName,
-		OptionGroupName:      cfg.OptionGroupName,
-		ClusterID:            cfg.ClusterID,
-		AvailabilityZone:     cfg.AvailabilityZone,
-		CreatedAt:            m.opts.Clock.Now().UTC(),
-		Tags:                 copyTags(cfg.Tags),
+		ID:                         cfg.ID,
+		ARN:                        instanceARN(m.opts.Region, m.opts.AccountID, cfg.ID),
+		Engine:                     cfg.Engine,
+		EngineVersion:              engineVersion,
+		InstanceClass:              instanceClass,
+		AllocatedStorage:           storage,
+		StorageType:                storageType,
+		MasterUsername:             cfg.MasterUsername,
+		DBName:                     cfg.DBName,
+		Endpoint:                   endpointFor(cfg.ID, m.opts.Region, "abcd1234"),
+		Port:                       port,
+		State:                      rdsdriver.StateAvailable,
+		MultiAZ:                    cfg.MultiAZ,
+		PubliclyAccessible:         cfg.PubliclyAccessible,
+		VPCSecurityGroups:          append([]string(nil), cfg.VPCSecurityGroups...),
+		SubnetGroupName:            cfg.SubnetGroupName,
+		DBParameterGroupName:       cfg.DBParameterGroupName,
+		OptionGroupName:            cfg.OptionGroupName,
+		ClusterID:                  cfg.ClusterID,
+		AvailabilityZone:           cfg.AvailabilityZone,
+		DbiResourceID:              resourceID("db-", cfg.ID),
+		BackupRetentionPeriod:      defaultBackupRetention,
+		PreferredBackupWindow:      defaultBackupWindow,
+		PreferredMaintenanceWindow: defaultMaintenanceWindow,
+		CACertificateIdentifier:    defaultCACertIdentifier,
+		StorageEncrypted:           cfg.StorageEncrypted,
+		CreatedAt:                  m.opts.Clock.Now().UTC(),
+		Tags:                       copyTags(cfg.Tags),
 	}
 }
 
@@ -532,6 +574,30 @@ func (m *Mock) ModifyInstance(
 		return nil, err
 	}
 
+	applyInstanceCoreMods(&inst, &input)
+	applyInstanceStorageMods(&inst, &input)
+
+	// A rename re-keys the store and rewrites the ARN + any replica references.
+	// Apply the scalar changes first so the renamed row carries them.
+	if renameRequested(id, &input) {
+		return m.renameInstance(id, input.NewInstanceID, inst)
+	}
+
+	m.instances.Set(id, inst)
+
+	out := inst
+
+	return &out, nil
+}
+
+// renameRequested reports whether the input asks to rename the instance to a
+// different identifier.
+func renameRequested(id string, input *rdsdriver.ModifyInstanceInput) bool {
+	return input.NewInstanceID != "" && input.NewInstanceID != id
+}
+
+// applyInstanceCoreMods applies the class/storage/version/param-group changes.
+func applyInstanceCoreMods(inst *rdsdriver.Instance, input *rdsdriver.ModifyInstanceInput) {
 	if input.InstanceClass != "" {
 		inst.InstanceClass = input.InstanceClass
 	}
@@ -559,8 +625,79 @@ func (m *Mock) ModifyInstance(
 	if input.Tags != nil {
 		inst.Tags = copyTags(input.Tags)
 	}
+}
 
-	m.instances.Set(id, inst)
+// applyInstanceStorageMods applies the storage/backup/maintenance/protection
+// attributes real RDS honors on ModifyDBInstance.
+func applyInstanceStorageMods(inst *rdsdriver.Instance, input *rdsdriver.ModifyInstanceInput) {
+	if input.StorageType != "" {
+		inst.StorageType = input.StorageType
+	}
+
+	if input.BackupRetentionPeriod > 0 {
+		inst.BackupRetentionPeriod = input.BackupRetentionPeriod
+	}
+
+	if input.PreferredBackupWindow != "" {
+		inst.PreferredBackupWindow = input.PreferredBackupWindow
+	}
+
+	if input.PreferredMaintenanceWindow != "" {
+		inst.PreferredMaintenanceWindow = input.PreferredMaintenanceWindow
+	}
+
+	if input.Iops > 0 {
+		inst.Iops = input.Iops
+	}
+
+	if input.DeletionProtection != nil {
+		inst.DeletionProtection = *input.DeletionProtection
+	}
+}
+
+// renameInstance re-keys an instance to newID under the caller's write lock:
+// it rewrites the ARN, moves the remembered root password, updates the
+// membership in any owning cluster, and fixes any replica source/target
+// back-references so nothing dangles. It returns AlreadyExists if newID is
+// taken.
+//
+//nolint:gocritic // inst is finalized and returned by value on purpose.
+func (m *Mock) renameInstance(oldID, newID string, inst rdsdriver.Instance) (*rdsdriver.Instance, error) {
+	if _, ok := m.instances.Get(newID); ok {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "DB instance %q already exists", newID)
+	}
+
+	inst.ID = newID
+	inst.ARN = instanceARN(m.opts.Region, m.opts.AccountID, newID)
+
+	m.instances.Delete(oldID)
+	m.instances.Set(newID, inst)
+
+	if pw, ok := m.rootPasswords[oldID]; ok {
+		delete(m.rootPasswords, oldID)
+		m.rootPasswords[newID] = pw
+	}
+
+	if inst.ClusterID != "" {
+		if cluster, ok := m.clusters.Get(inst.ClusterID); ok {
+			cluster.Members = renameString(cluster.Members, oldID, newID)
+			m.clusters.Set(inst.ClusterID, cluster)
+		}
+	}
+
+	if inst.ReadReplicaSource != "" {
+		if src, ok := m.instances.Get(inst.ReadReplicaSource); ok {
+			src.ReadReplicaTargets = renameString(src.ReadReplicaTargets, oldID, newID)
+			m.instances.Set(src.ID, src)
+		}
+	}
+
+	for _, target := range inst.ReadReplicaTargets {
+		if rep, ok := m.instances.Get(target); ok {
+			rep.ReadReplicaSource = newID
+			m.instances.Set(target, rep)
+		}
+	}
 
 	out := inst
 
@@ -718,6 +855,16 @@ func (m *Mock) CreateCluster(_ context.Context, cfg rdsdriver.ClusterConfig) (*r
 		port = defaultPortFor(cfg.Engine)
 	}
 
+	engineMode := cfg.EngineMode
+	if engineMode == "" {
+		engineMode = defaultEngineMode
+	}
+
+	allocatedStorage := cfg.AllocatedStorage
+	if allocatedStorage == 0 {
+		allocatedStorage = auroraAllocatedStorage
+	}
+
 	cluster := rdsdriver.Cluster{
 		ID:                          cfg.ID,
 		ARN:                         clusterARN(m.opts.Region, m.opts.AccountID, cfg.ID),
@@ -732,6 +879,11 @@ func (m *Mock) CreateCluster(_ context.Context, cfg rdsdriver.ClusterConfig) (*r
 		VPCSecurityGroups:           append([]string(nil), cfg.VPCSecurityGroups...),
 		SubnetGroupName:             cfg.SubnetGroupName,
 		DBClusterParameterGroupName: cfg.DBClusterParameterGroupName,
+		EngineMode:                  engineMode,
+		DBClusterResourceID:         resourceID("cluster-", cfg.ID),
+		AllocatedStorage:            allocatedStorage,
+		StorageEncrypted:            cfg.StorageEncrypted,
+		AvailabilityZones:           availabilityZones(m.opts.Region),
 		CreatedAt:                   m.opts.Clock.Now().UTC(),
 		Tags:                        copyTags(cfg.Tags),
 	}
@@ -1219,6 +1371,22 @@ func removeString(slice []string, target string) []string {
 	for _, v := range slice {
 		if v != target {
 			out = append(out, v)
+		}
+	}
+
+	return out
+}
+
+// renameString returns a NEW slice with every occurrence of oldVal replaced by
+// newVal, never mutating the input's backing array.
+func renameString(slice []string, oldVal, newVal string) []string {
+	out := make([]string, len(slice))
+
+	for i, v := range slice {
+		if v == oldVal {
+			out[i] = newVal
+		} else {
+			out[i] = v
 		}
 	}
 

--- a/providers/aws/redshift/redshift.go
+++ b/providers/aws/redshift/redshift.go
@@ -26,6 +26,8 @@ import (
 const (
 	defaultEngine            = "redshift"
 	defaultPort              = 5439
+	singleNodeCount          = 1
+	snapshotBackupSizeMB     = 100.0
 	cpuUtilizationRunning    = 25.0
 	databaseConnectionsRun   = 5.0
 	readIOPSRunning          = 10.0
@@ -324,20 +326,31 @@ func (m *Mock) reserveCluster(cfg rdbdriver.ClusterConfig) (rdbdriver.Cluster, e
 		port = defaultPort
 	}
 
+	numberOfNodes := cfg.NumberOfNodes
+	if numberOfNodes == 0 {
+		numberOfNodes = singleNodeCount
+	}
+
 	cluster := rdbdriver.Cluster{
-		ID:                cfg.ID,
-		ARN:               clusterARN(m.opts.Region, m.opts.AccountID, cfg.ID),
-		Engine:            engine,
-		EngineVersion:     cfg.EngineVersion,
-		MasterUsername:    cfg.MasterUsername,
-		DatabaseName:      cfg.DatabaseName,
-		Endpoint:          endpointFor(cfg.ID),
-		Port:              port,
-		State:             rdbdriver.StateAvailable,
-		VPCSecurityGroups: append([]string(nil), cfg.VPCSecurityGroups...),
-		SubnetGroupName:   cfg.SubnetGroupName,
-		CreatedAt:         m.opts.Clock.Now().UTC(),
-		Tags:              copyTags(cfg.Tags),
+		ID:                          cfg.ID,
+		ARN:                         clusterARN(m.opts.Region, m.opts.AccountID, cfg.ID),
+		Engine:                      engine,
+		EngineVersion:               cfg.EngineVersion,
+		MasterUsername:              cfg.MasterUsername,
+		DatabaseName:                cfg.DatabaseName,
+		Endpoint:                    endpointFor(cfg.ID),
+		Port:                        port,
+		State:                       rdbdriver.StateAvailable,
+		VPCSecurityGroups:           append([]string(nil), cfg.VPCSecurityGroups...),
+		SubnetGroupName:             cfg.SubnetGroupName,
+		DBClusterParameterGroupName: cfg.DBClusterParameterGroupName,
+		NodeType:                    cfg.NodeType,
+		NumberOfNodes:               numberOfNodes,
+		Encrypted:                   cfg.Encrypted,
+		PubliclyAccessible:          cfg.PubliclyAccessible,
+		AvailabilityZone:            cfg.AvailabilityZone,
+		CreatedAt:                   m.opts.Clock.Now().UTC(),
+		Tags:                        copyTags(cfg.Tags),
 	}
 
 	m.clusters.Set(cfg.ID, cluster)
@@ -535,6 +548,47 @@ func (m *Mock) RebootCluster(_ context.Context, id string) error {
 	return nil
 }
 
+// clusterStatePaused is the Redshift-only lifecycle state a paused cluster
+// reports. PauseCluster/ResumeCluster move a cluster between available and
+// paused; the emulator applies the transition immediately (no pausing/resuming
+// intermediate).
+const clusterStatePaused = "paused"
+
+// PauseCluster suspends an available cluster (available → paused). It is part
+// of the AWS-only optional clusterPauser surface, discovered by the wire
+// handler via type assertion.
+func (m *Mock) PauseCluster(_ context.Context, id string) (*rdbdriver.Cluster, error) {
+	if err := m.transitionCluster(id, rdbdriver.StateAvailable, clusterStatePaused, "pause"); err != nil {
+		return nil, err
+	}
+
+	return m.snapshotCluster(id)
+}
+
+// ResumeCluster resumes a paused cluster (paused → available).
+func (m *Mock) ResumeCluster(_ context.Context, id string) (*rdbdriver.Cluster, error) {
+	if err := m.transitionCluster(id, clusterStatePaused, rdbdriver.StateAvailable, "resume"); err != nil {
+		return nil, err
+	}
+
+	return m.snapshotCluster(id)
+}
+
+// snapshotCluster returns a copy of the stored cluster by id.
+func (m *Mock) snapshotCluster(id string) (*rdbdriver.Cluster, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	cluster, ok := m.clusters.Get(id)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "Redshift cluster %q not found", id)
+	}
+
+	out := cluster
+
+	return &out, nil
+}
+
 func (m *Mock) transitionCluster(id, from, to, verb string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -602,14 +656,18 @@ func (m *Mock) CreateClusterSnapshot(
 	}
 
 	snap := rdbdriver.ClusterSnapshot{
-		ID:            cfg.ID,
-		ARN:           clusterSnapshotARN(m.opts.Region, m.opts.AccountID, cfg.ID),
-		ClusterID:     cfg.ClusterID,
-		Engine:        cluster.Engine,
-		EngineVersion: cluster.EngineVersion,
-		State:         rdbdriver.SnapshotAvailable,
-		CreatedAt:     m.opts.Clock.Now().UTC(),
-		Tags:          copyTags(cfg.Tags),
+		ID:                         cfg.ID,
+		ARN:                        clusterSnapshotARN(m.opts.Region, m.opts.AccountID, cfg.ID),
+		ClusterID:                  cfg.ClusterID,
+		Engine:                     cluster.Engine,
+		EngineVersion:              cluster.EngineVersion,
+		State:                      rdbdriver.SnapshotAvailable,
+		NodeType:                   cluster.NodeType,
+		NumberOfNodes:              cluster.NumberOfNodes,
+		Encrypted:                  cluster.Encrypted,
+		TotalBackupSizeInMegaBytes: snapshotBackupSizeMB,
+		CreatedAt:                  m.opts.Clock.Now().UTC(),
+		Tags:                       copyTags(cfg.Tags),
 	}
 
 	m.clusterSnapshots.Set(cfg.ID, snap)

--- a/server/aws/rds/cluster_attributes_sdk_roundtrip_test.go
+++ b/server/aws/rds/cluster_attributes_sdk_roundtrip_test.go
@@ -1,0 +1,48 @@
+package rds_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+)
+
+// TestSDKRDSClusterAttributes asserts a created DBCluster reports the
+// descriptive attributes real Aurora returns — EngineMode, a resource id,
+// AllocatedStorage, StorageEncrypted and the spread of AvailabilityZones.
+func TestSDKRDSClusterAttributes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateDBCluster(ctx, &awsrds.CreateDBClusterInput{
+		DBClusterIdentifier: aws.String("attrs-cl"),
+		Engine:              aws.String("aurora-mysql"),
+		StorageEncrypted:    aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("CreateDBCluster: %v", err)
+	}
+
+	cl := out.DBCluster
+
+	if aws.ToString(cl.EngineMode) != "provisioned" {
+		t.Fatalf("EngineMode=%q, want provisioned", aws.ToString(cl.EngineMode))
+	}
+
+	if aws.ToString(cl.DbClusterResourceId) == "" {
+		t.Fatal("DbClusterResourceId empty; want a stable cluster- resource id")
+	}
+
+	if aws.ToInt32(cl.AllocatedStorage) != 1 {
+		t.Fatalf("AllocatedStorage=%d, want 1", aws.ToInt32(cl.AllocatedStorage))
+	}
+
+	if !aws.ToBool(cl.StorageEncrypted) {
+		t.Fatal("StorageEncrypted=false, want true")
+	}
+
+	if len(cl.AvailabilityZones) != 3 {
+		t.Fatalf("AvailabilityZones=%v, want 3 zones", cl.AvailabilityZones)
+	}
+}

--- a/server/aws/rds/describe_instances_pagination_sdk_roundtrip_test.go
+++ b/server/aws/rds/describe_instances_pagination_sdk_roundtrip_test.go
@@ -1,0 +1,104 @@
+package rds_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+)
+
+// TestSDKRDSDescribeInstancesPagination asserts DescribeDBInstances honors
+// MaxRecords + Marker: the first page returns the requested count with a
+// Marker, and the paginator walks the rest with no overlap.
+func TestSDKRDSDescribeInstancesPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	ids := []string{"pg-a", "pg-b", "pg-c", "pg-d", "pg-e"}
+	for _, id := range ids {
+		if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+			DBInstanceIdentifier: aws.String(id),
+			Engine:               aws.String("mysql"),
+			DBInstanceClass:      aws.String("db.t3.micro"),
+		}); err != nil {
+			t.Fatalf("CreateDBInstance(%s): %v", id, err)
+		}
+	}
+
+	first, err := client.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		MaxRecords: aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBInstances page 1: %v", err)
+	}
+
+	if len(first.DBInstances) != 2 {
+		t.Fatalf("page 1 returned %d instances, want 2", len(first.DBInstances))
+	}
+
+	if aws.ToString(first.Marker) == "" {
+		t.Fatal("page 1 Marker empty; want a continuation token")
+	}
+
+	seen := map[string]bool{}
+	for _, di := range first.DBInstances {
+		seen[aws.ToString(di.DBInstanceIdentifier)] = true
+	}
+
+	second, err := client.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		MaxRecords: aws.Int32(2),
+		Marker:     first.Marker,
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBInstances page 2: %v", err)
+	}
+
+	for _, di := range second.DBInstances {
+		id := aws.ToString(di.DBInstanceIdentifier)
+		if seen[id] {
+			t.Fatalf("instance %q appeared on both pages", id)
+		}
+
+		seen[id] = true
+	}
+}
+
+// TestSDKRDSDescribeInstancesFilter asserts the engine filter narrows the
+// DescribeDBInstances result to matching instances only.
+func TestSDKRDSDescribeInstancesFilter(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("mysql-one"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance mysql: %v", err)
+	}
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("pg-one"),
+		Engine:               aws.String("postgres"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance postgres: %v", err)
+	}
+
+	got, err := client.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		Filters: []rdstypes.Filter{{
+			Name:   aws.String("engine"),
+			Values: []string{"postgres"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBInstances filter: %v", err)
+	}
+
+	if len(got.DBInstances) != 1 ||
+		aws.ToString(got.DBInstances[0].DBInstanceIdentifier) != "pg-one" {
+		t.Fatalf("engine filter returned %+v, want only pg-one", got.DBInstances)
+	}
+}

--- a/server/aws/rds/instance_attributes_sdk_roundtrip_test.go
+++ b/server/aws/rds/instance_attributes_sdk_roundtrip_test.go
@@ -1,0 +1,157 @@
+package rds_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+)
+
+// TestSDKRDSInstanceCreateAttributes asserts a freshly created DBInstance
+// reports the descriptive attributes real RDS defaults — DbiResourceId, the CA
+// certificate id, the backup-retention default, the endpoint hosted-zone id,
+// and the associated parameter group as an in-sync membership.
+func TestSDKRDSInstanceCreateAttributes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("attrs"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		DBParameterGroupName: aws.String("default.mysql8.0"),
+		StorageEncrypted:     aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	inst := out.DBInstance
+
+	if aws.ToString(inst.DbiResourceId) == "" {
+		t.Fatal("DbiResourceId empty; want a stable db- resource id")
+	}
+
+	if aws.ToString(inst.CACertificateIdentifier) != "rds-ca-rsa2048-g1" {
+		t.Fatalf("CACertificateIdentifier=%q, want rds-ca-rsa2048-g1",
+			aws.ToString(inst.CACertificateIdentifier))
+	}
+
+	if aws.ToInt32(inst.BackupRetentionPeriod) != 1 {
+		t.Fatalf("BackupRetentionPeriod=%d, want 1", aws.ToInt32(inst.BackupRetentionPeriod))
+	}
+
+	if !aws.ToBool(inst.StorageEncrypted) {
+		t.Fatal("StorageEncrypted=false, want true")
+	}
+
+	if inst.Endpoint == nil || aws.ToString(inst.Endpoint.HostedZoneId) == "" {
+		t.Fatal("Endpoint.HostedZoneId empty; want a hosted-zone id")
+	}
+
+	if len(inst.DBParameterGroups) != 1 ||
+		aws.ToString(inst.DBParameterGroups[0].DBParameterGroupName) != "default.mysql8.0" ||
+		aws.ToString(inst.DBParameterGroups[0].ParameterApplyStatus) != "in-sync" {
+		t.Fatalf("DBParameterGroups=%+v, want one in-sync default.mysql8.0", inst.DBParameterGroups)
+	}
+}
+
+// TestSDKRDSModifyInstanceAttributes asserts ModifyDBInstance honors the scalar
+// attributes real RDS applies — BackupRetentionPeriod, backup/maintenance
+// windows, StorageType, Iops and DeletionProtection — and reports them back.
+func TestSDKRDSModifyInstanceAttributes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("moddb"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	out, err := client.ModifyDBInstance(ctx, &awsrds.ModifyDBInstanceInput{
+		DBInstanceIdentifier:       aws.String("moddb"),
+		BackupRetentionPeriod:      aws.Int32(7),
+		PreferredBackupWindow:      aws.String("02:00-03:00"),
+		PreferredMaintenanceWindow: aws.String("mon:04:00-mon:05:00"),
+		StorageType:                aws.String("io1"),
+		Iops:                       aws.Int32(3000),
+		DeletionProtection:         aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("ModifyDBInstance: %v", err)
+	}
+
+	inst := out.DBInstance
+
+	if aws.ToInt32(inst.BackupRetentionPeriod) != 7 {
+		t.Fatalf("BackupRetentionPeriod=%d, want 7", aws.ToInt32(inst.BackupRetentionPeriod))
+	}
+
+	if aws.ToString(inst.PreferredBackupWindow) != "02:00-03:00" {
+		t.Fatalf("PreferredBackupWindow=%q, want 02:00-03:00", aws.ToString(inst.PreferredBackupWindow))
+	}
+
+	if aws.ToString(inst.PreferredMaintenanceWindow) != "mon:04:00-mon:05:00" {
+		t.Fatalf("PreferredMaintenanceWindow=%q", aws.ToString(inst.PreferredMaintenanceWindow))
+	}
+
+	if aws.ToString(inst.StorageType) != "io1" {
+		t.Fatalf("StorageType=%q, want io1", aws.ToString(inst.StorageType))
+	}
+
+	if aws.ToInt32(inst.Iops) != 3000 {
+		t.Fatalf("Iops=%d, want 3000", aws.ToInt32(inst.Iops))
+	}
+
+	if !aws.ToBool(inst.DeletionProtection) {
+		t.Fatal("DeletionProtection=false, want true")
+	}
+}
+
+// TestSDKRDSRenameInstance asserts ModifyDBInstance with NewDBInstanceIdentifier
+// renames the instance: the new id is described and the old id is gone.
+func TestSDKRDSRenameInstance(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("oldname"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	out, err := client.ModifyDBInstance(ctx, &awsrds.ModifyDBInstanceInput{
+		DBInstanceIdentifier:    aws.String("oldname"),
+		NewDBInstanceIdentifier: aws.String("newname"),
+	})
+	if err != nil {
+		t.Fatalf("ModifyDBInstance rename: %v", err)
+	}
+
+	if aws.ToString(out.DBInstance.DBInstanceIdentifier) != "newname" {
+		t.Fatalf("rename returned id %q, want newname", aws.ToString(out.DBInstance.DBInstanceIdentifier))
+	}
+
+	got, err := client.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String("newname"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBInstances(newname): %v", err)
+	}
+
+	if len(got.DBInstances) != 1 {
+		t.Fatalf("got %d instances for newname, want 1", len(got.DBInstances))
+	}
+
+	if _, err := client.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String("oldname"),
+	}); err == nil {
+		t.Fatal("expected oldname to be gone after rename")
+	}
+}

--- a/server/aws/rds/operations.go
+++ b/server/aws/rds/operations.go
@@ -3,8 +3,10 @@ package rds
 import (
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
@@ -31,6 +33,7 @@ func instanceConfigFromForm(form url.Values) rdsdriver.InstanceConfig {
 		OptionGroupName:      form.Get("OptionGroupName"),
 		ClusterID:            form.Get("DBClusterIdentifier"),
 		AvailabilityZone:     form.Get("AvailabilityZone"),
+		StorageEncrypted:     formBool(form.Get("StorageEncrypted")),
 		Tags:                 parseRDSTags(form),
 	}
 }
@@ -79,7 +82,6 @@ func (h *Handler) createDBInstance(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // shape mirrors describeDBClusters but operates on instances.
 func (h *Handler) describeDBInstances(w http.ResponseWriter, r *http.Request) {
 	id := r.Form.Get("DBInstanceIdentifier")
 
@@ -94,16 +96,104 @@ func (h *Handler) describeDBInstances(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := dbInstancesXML{DBInstance: make([]dbInstanceXML, 0, len(insts))}
-	for i := range insts {
-		out.DBInstance = append(out.DBInstance, toInstanceXML(&insts[i]))
+	insts = filterInstances(insts, parseInstanceFilters(r.Form))
+
+	// Offset tokens require a stable ordering; sort by identifier before paging.
+	sort.Slice(insts, func(i, j int) bool { return insts[i].ID < insts[j].ID })
+
+	page, err := pagination.Paginate(insts, r.Form.Get("Marker"), formInt(r.Form.Get("MaxRecords")))
+	if err != nil {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", "invalid Marker")
+		return
+	}
+
+	out := dbInstancesXML{DBInstance: make([]dbInstanceXML, 0, len(page.Items))}
+	for i := range page.Items {
+		out.DBInstance = append(out.DBInstance, toInstanceXML(&page.Items[i]))
 	}
 
 	awsquery.WriteXMLResponse(w, describeDBInstancesResponse{
 		Xmlns:    Namespace,
-		Result:   dbInstancesResult{DBInstances: out},
+		Result:   dbInstancesResult{Marker: page.NextPageToken, DBInstances: out},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
+}
+
+// parseInstanceFilters reads the Filters.Filter.N.{Name,Values.Value.M} entries
+// into a name→values map. Only the DescribeDBInstances-supported filter names
+// are meaningful; unknown names are kept and simply match nothing.
+func parseInstanceFilters(form url.Values) map[string][]string {
+	indices := awsquery.CollectIndices(form, "Filters.Filter")
+	if len(indices) == 0 {
+		return nil
+	}
+
+	out := make(map[string][]string, len(indices))
+
+	for _, n := range indices {
+		base := "Filters.Filter." + strconv.Itoa(n)
+
+		name := form.Get(base + ".Name")
+		if name == "" {
+			continue
+		}
+
+		out[name] = awsquery.ListStrings(form, base+".Values.Value")
+	}
+
+	return out
+}
+
+// filterInstances keeps only the instances matching every supplied filter (AND
+// across names, OR within a name's values), mirroring RDS filter semantics for
+// db-instance-id, engine and db-cluster-id.
+func filterInstances(insts []rdsdriver.Instance, filters map[string][]string) []rdsdriver.Instance {
+	if len(filters) == 0 {
+		return insts
+	}
+
+	out := make([]rdsdriver.Instance, 0, len(insts))
+
+	for i := range insts {
+		if instanceMatchesFilters(&insts[i], filters) {
+			out = append(out, insts[i])
+		}
+	}
+
+	return out
+}
+
+func instanceMatchesFilters(inst *rdsdriver.Instance, filters map[string][]string) bool {
+	for name, values := range filters {
+		var field string
+
+		switch name {
+		case "db-instance-id":
+			field = inst.ID
+		case "engine":
+			field = inst.Engine
+		case "db-cluster-id":
+			field = inst.ClusterID
+		default:
+			return false
+		}
+
+		if !containsString(values, field) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func containsString(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (h *Handler) modifyDBInstance(w http.ResponseWriter, r *http.Request) {
@@ -112,18 +202,29 @@ func (h *Handler) modifyDBInstance(w http.ResponseWriter, r *http.Request) {
 	id := form.Get("DBInstanceIdentifier")
 
 	input := rdsdriver.ModifyInstanceInput{
-		InstanceClass:        form.Get("DBInstanceClass"),
-		AllocatedStorage:     formInt(form.Get("AllocatedStorage")),
-		EngineVersion:        form.Get("EngineVersion"),
-		MasterUserPassword:   form.Get("MasterUserPassword"),
-		DBParameterGroupName: form.Get("DBParameterGroupName"),
-		OptionGroupName:      form.Get("OptionGroupName"),
-		Tags:                 parseRDSTags(form),
+		InstanceClass:              form.Get("DBInstanceClass"),
+		AllocatedStorage:           formInt(form.Get("AllocatedStorage")),
+		EngineVersion:              form.Get("EngineVersion"),
+		MasterUserPassword:         form.Get("MasterUserPassword"),
+		DBParameterGroupName:       form.Get("DBParameterGroupName"),
+		OptionGroupName:            form.Get("OptionGroupName"),
+		NewInstanceID:              form.Get("NewDBInstanceIdentifier"),
+		BackupRetentionPeriod:      formInt(form.Get("BackupRetentionPeriod")),
+		PreferredBackupWindow:      form.Get("PreferredBackupWindow"),
+		PreferredMaintenanceWindow: form.Get("PreferredMaintenanceWindow"),
+		StorageType:                form.Get("StorageType"),
+		Iops:                       formInt(form.Get("Iops")),
+		Tags:                       parseRDSTags(form),
 	}
 
 	if v := form.Get("MultiAZ"); v != "" {
 		b := formBool(v)
 		input.MultiAZ = &b
+	}
+
+	if v := form.Get("DeletionProtection"); v != "" {
+		b := formBool(v)
+		input.DeletionProtection = &b
 	}
 
 	inst, err := h.db.ModifyInstance(r.Context(), id, input)
@@ -268,6 +369,9 @@ func (h *Handler) createDBCluster(w http.ResponseWriter, r *http.Request) {
 		VPCSecurityGroups:           awsquery.ListStrings(form, "VpcSecurityGroupIds.VpcSecurityGroupId"),
 		SubnetGroupName:             form.Get("DBSubnetGroupName"),
 		DBClusterParameterGroupName: form.Get("DBClusterParameterGroupName"),
+		EngineMode:                  form.Get("EngineMode"),
+		StorageEncrypted:            formBool(form.Get("StorageEncrypted")),
+		AllocatedStorage:            formInt(form.Get("AllocatedStorage")),
 		Tags:                        parseRDSTags(form),
 	}
 
@@ -284,7 +388,6 @@ func (h *Handler) createDBCluster(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // shape mirrors describeDBInstances but operates on clusters.
 func (h *Handler) describeDBClusters(w http.ResponseWriter, r *http.Request) {
 	id := r.Form.Get("DBClusterIdentifier")
 

--- a/server/aws/rds/xml.go
+++ b/server/aws/rds/xml.go
@@ -11,6 +11,18 @@ import (
 // snapshotProgressComplete is the PercentProgress an available snapshot reports.
 const snapshotProgressComplete = 100
 
+// rdsHostedZoneID is the Route 53 hosted-zone id RDS reports for a DB
+// instance endpoint. Real AWS uses a per-region constant; this stand-in keeps
+// the Endpoint.HostedZoneId element populated for SDK consumers.
+const rdsHostedZoneID = "Z2R2ITUGPM61AM"
+
+// parameterApplyInSync / optionStatusInSync are the statuses RDS reports for a
+// DB parameter group / option group membership that is fully applied.
+const (
+	parameterApplyInSync = "in-sync"
+	optionStatusInSync   = "in-sync"
+)
+
 // All RDS query-protocol responses are wrapped in <FooResponse> with a
 // <FooResult> child and a trailing <ResponseMetadata>. The structures below
 // mirror the AWS-published XML closely enough that aws-sdk-go-v2's RDS
@@ -21,8 +33,31 @@ type responseMetadata struct {
 }
 
 type endpointXML struct {
-	Address string `xml:"Address,omitempty"`
-	Port    int    `xml:"Port,omitempty"`
+	Address      string `xml:"Address,omitempty"`
+	Port         int    `xml:"Port,omitempty"`
+	HostedZoneID string `xml:"HostedZoneId,omitempty"`
+}
+
+type dbParameterGroupMembershipXML struct {
+	DBParameterGroupName string `xml:"DBParameterGroupName"`
+	ParameterApplyStatus string `xml:"ParameterApplyStatus"`
+}
+
+type dbParameterGroupsXML struct {
+	DBParameterGroup []dbParameterGroupMembershipXML `xml:"DBParameterGroup,omitempty"`
+}
+
+type optionGroupMembershipXML struct {
+	OptionGroupName string `xml:"OptionGroupName"`
+	Status          string `xml:"Status"`
+}
+
+type optionGroupMembershipsXML struct {
+	OptionGroupMembership []optionGroupMembershipXML `xml:"OptionGroupMembership,omitempty"`
+}
+
+type availabilityZonesXML struct {
+	AvailabilityZone []string `xml:"AvailabilityZone,omitempty"`
 }
 
 type tagXML struct {
@@ -44,27 +79,37 @@ type vpcSecurityGroupsXML struct {
 }
 
 type dbInstanceXML struct {
-	DBInstanceIdentifier                  string                `xml:"DBInstanceIdentifier"`
-	DBInstanceArn                         string                `xml:"DBInstanceArn"`
-	Engine                                string                `xml:"Engine,omitempty"`
-	EngineVersion                         string                `xml:"EngineVersion,omitempty"`
-	DBInstanceClass                       string                `xml:"DBInstanceClass,omitempty"`
-	DBInstanceStatus                      string                `xml:"DBInstanceStatus"`
-	MasterUsername                        string                `xml:"MasterUsername,omitempty"`
-	DBName                                string                `xml:"DBName,omitempty"`
-	AllocatedStorage                      int                   `xml:"AllocatedStorage,omitempty"`
-	StorageType                           string                `xml:"StorageType,omitempty"`
-	Endpoint                              *endpointXML          `xml:"Endpoint,omitempty"`
-	MultiAZ                               bool                  `xml:"MultiAZ"`
-	PubliclyAccessible                    bool                  `xml:"PubliclyAccessible"`
-	AvailabilityZone                      string                `xml:"AvailabilityZone,omitempty"`
-	DBClusterIdentifier                   string                `xml:"DBClusterIdentifier,omitempty"`
-	DBSubnetGroupName                     string                `xml:"DBSubnetGroupName,omitempty"`
-	InstanceCreateTime                    string                `xml:"InstanceCreateTime,omitempty"`
-	VpcSecurityGroups                     *vpcSecurityGroupsXML `xml:"VpcSecurityGroups,omitempty"`
-	TagList                               *tagListXML           `xml:"TagList,omitempty"`
-	ReadReplicaSourceDBInstanceIdentifier string                `xml:"ReadReplicaSourceDBInstanceIdentifier,omitempty"`
-	ReadReplicaDBInstanceIdentifiers      *readReplicaIDsXML    `xml:"ReadReplicaDBInstanceIdentifiers,omitempty"`
+	DBInstanceIdentifier                  string                     `xml:"DBInstanceIdentifier"`
+	DBInstanceArn                         string                     `xml:"DBInstanceArn"`
+	Engine                                string                     `xml:"Engine,omitempty"`
+	EngineVersion                         string                     `xml:"EngineVersion,omitempty"`
+	DBInstanceClass                       string                     `xml:"DBInstanceClass,omitempty"`
+	DBInstanceStatus                      string                     `xml:"DBInstanceStatus"`
+	MasterUsername                        string                     `xml:"MasterUsername,omitempty"`
+	DBName                                string                     `xml:"DBName,omitempty"`
+	AllocatedStorage                      int                        `xml:"AllocatedStorage,omitempty"`
+	StorageType                           string                     `xml:"StorageType,omitempty"`
+	Endpoint                              *endpointXML               `xml:"Endpoint,omitempty"`
+	MultiAZ                               bool                       `xml:"MultiAZ"`
+	PubliclyAccessible                    bool                       `xml:"PubliclyAccessible"`
+	AvailabilityZone                      string                     `xml:"AvailabilityZone,omitempty"`
+	DBClusterIdentifier                   string                     `xml:"DBClusterIdentifier,omitempty"`
+	DBSubnetGroupName                     string                     `xml:"DBSubnetGroupName,omitempty"`
+	InstanceCreateTime                    string                     `xml:"InstanceCreateTime,omitempty"`
+	DbiResourceID                         string                     `xml:"DbiResourceId,omitempty"`
+	BackupRetentionPeriod                 int                        `xml:"BackupRetentionPeriod,omitempty"`
+	PreferredBackupWindow                 string                     `xml:"PreferredBackupWindow,omitempty"`
+	PreferredMaintenanceWindow            string                     `xml:"PreferredMaintenanceWindow,omitempty"`
+	CACertificateIdentifier               string                     `xml:"CACertificateIdentifier,omitempty"`
+	Iops                                  int                        `xml:"Iops,omitempty"`
+	StorageEncrypted                      bool                       `xml:"StorageEncrypted"`
+	DeletionProtection                    bool                       `xml:"DeletionProtection"`
+	DBParameterGroups                     *dbParameterGroupsXML      `xml:"DBParameterGroups,omitempty"`
+	OptionGroupMemberships                *optionGroupMembershipsXML `xml:"OptionGroupMemberships,omitempty"`
+	VpcSecurityGroups                     *vpcSecurityGroupsXML      `xml:"VpcSecurityGroups,omitempty"`
+	TagList                               *tagListXML                `xml:"TagList,omitempty"`
+	ReadReplicaSourceDBInstanceIdentifier string                     `xml:"ReadReplicaSourceDBInstanceIdentifier,omitempty"`
+	ReadReplicaDBInstanceIdentifiers      *readReplicaIDsXML         `xml:"ReadReplicaDBInstanceIdentifiers,omitempty"`
 }
 
 type readReplicaIDsXML struct {
@@ -92,6 +137,11 @@ type dbClusterXML struct {
 	ReaderEndpoint      string                `xml:"ReaderEndpoint,omitempty"`
 	Port                int                   `xml:"Port,omitempty"`
 	DBSubnetGroup       string                `xml:"DBSubnetGroup,omitempty"`
+	EngineMode          string                `xml:"EngineMode,omitempty"`
+	DBClusterResourceID string                `xml:"DbClusterResourceId,omitempty"`
+	AllocatedStorage    int                   `xml:"AllocatedStorage,omitempty"`
+	StorageEncrypted    bool                  `xml:"StorageEncrypted"`
+	AvailabilityZones   *availabilityZonesXML `xml:"AvailabilityZones,omitempty"`
 	ClusterCreateTime   string                `xml:"ClusterCreateTime,omitempty"`
 	DBClusterMembers    *dbClusterMembersXML  `xml:"DBClusterMembers,omitempty"`
 	VpcSecurityGroups   *vpcSecurityGroupsXML `xml:"VpcSecurityGroups,omitempty"`
@@ -180,6 +230,7 @@ type dbInstanceResult struct {
 }
 
 type dbInstancesResult struct {
+	Marker      string         `xml:"Marker,omitempty"`
 	DBInstances dbInstancesXML `xml:"DBInstances"`
 }
 
@@ -335,8 +386,9 @@ func toInstanceXML(inst *rdsdriver.Instance) dbInstanceXML {
 		AllocatedStorage:     inst.AllocatedStorage,
 		StorageType:          inst.StorageType,
 		Endpoint: &endpointXML{
-			Address: inst.Endpoint,
-			Port:    inst.Port,
+			Address:      inst.Endpoint,
+			Port:         inst.Port,
+			HostedZoneID: rdsHostedZoneID,
 		},
 		MultiAZ:                               inst.MultiAZ,
 		PubliclyAccessible:                    inst.PubliclyAccessible,
@@ -344,10 +396,46 @@ func toInstanceXML(inst *rdsdriver.Instance) dbInstanceXML {
 		DBClusterIdentifier:                   inst.ClusterID,
 		DBSubnetGroupName:                     inst.SubnetGroupName,
 		InstanceCreateTime:                    inst.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
+		DbiResourceID:                         inst.DbiResourceID,
+		BackupRetentionPeriod:                 inst.BackupRetentionPeriod,
+		PreferredBackupWindow:                 inst.PreferredBackupWindow,
+		PreferredMaintenanceWindow:            inst.PreferredMaintenanceWindow,
+		CACertificateIdentifier:               inst.CACertificateIdentifier,
+		Iops:                                  inst.Iops,
+		StorageEncrypted:                      inst.StorageEncrypted,
+		DeletionProtection:                    inst.DeletionProtection,
+		DBParameterGroups:                     toDBParameterGroupsXML(inst.DBParameterGroupName),
+		OptionGroupMemberships:                toOptionGroupMembershipsXML(inst.OptionGroupName),
 		VpcSecurityGroups:                     toVpcSGsXML(inst.VPCSecurityGroups),
 		TagList:                               toTagListXML(inst.Tags),
 		ReadReplicaSourceDBInstanceIdentifier: inst.ReadReplicaSource,
 		ReadReplicaDBInstanceIdentifiers:      toReadReplicaIDsXML(inst.ReadReplicaTargets),
+	}
+}
+
+func toDBParameterGroupsXML(name string) *dbParameterGroupsXML {
+	if name == "" {
+		return nil
+	}
+
+	return &dbParameterGroupsXML{
+		DBParameterGroup: []dbParameterGroupMembershipXML{{
+			DBParameterGroupName: name,
+			ParameterApplyStatus: parameterApplyInSync,
+		}},
+	}
+}
+
+func toOptionGroupMembershipsXML(name string) *optionGroupMembershipsXML {
+	if name == "" {
+		return nil
+	}
+
+	return &optionGroupMembershipsXML{
+		OptionGroupMembership: []optionGroupMembershipXML{{
+			OptionGroupName: name,
+			Status:          optionStatusInSync,
+		}},
 	}
 }
 
@@ -383,11 +471,24 @@ func toClusterXML(cluster *rdsdriver.Cluster) dbClusterXML {
 		ReaderEndpoint:      cluster.ReaderEndpoint,
 		Port:                cluster.Port,
 		DBSubnetGroup:       cluster.SubnetGroupName,
+		EngineMode:          cluster.EngineMode,
+		DBClusterResourceID: cluster.DBClusterResourceID,
+		AllocatedStorage:    cluster.AllocatedStorage,
+		StorageEncrypted:    cluster.StorageEncrypted,
+		AvailabilityZones:   toAvailabilityZonesXML(cluster.AvailabilityZones),
 		ClusterCreateTime:   cluster.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
 		DBClusterMembers:    &members,
 		VpcSecurityGroups:   toVpcSGsXML(cluster.VPCSecurityGroups),
 		TagList:             toTagListXML(cluster.Tags),
 	}
+}
+
+func toAvailabilityZonesXML(azs []string) *availabilityZonesXML {
+	if len(azs) == 0 {
+		return nil
+	}
+
+	return &availabilityZonesXML{AvailabilityZone: azs}
 }
 
 func toSnapshotXML(snap *rdsdriver.Snapshot) dbSnapshotXML {

--- a/server/aws/redshift/cluster_attributes_sdk_roundtrip_test.go
+++ b/server/aws/redshift/cluster_attributes_sdk_roundtrip_test.go
@@ -1,0 +1,69 @@
+package redshift_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsredshift "github.com/aws/aws-sdk-go-v2/service/redshift"
+)
+
+// TestSDKRedshiftClusterAttributes asserts a created cluster reports the node
+// shape Terraform and the console read — NodeType, NumberOfNodes, Encrypted,
+// PubliclyAccessible, AvailabilityZone, the parameter-group membership and the
+// synthesized LEADER/COMPUTE node list.
+func TestSDKRedshiftClusterAttributes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:         aws.String("attrs"),
+		MasterUsername:            aws.String("admin"),
+		MasterUserPassword:        aws.String("Sup3rSecret!"),
+		NodeType:                  aws.String("ra3.xlplus"),
+		NumberOfNodes:             aws.Int32(2),
+		Encrypted:                 aws.Bool(true),
+		PubliclyAccessible:        aws.Bool(true),
+		AvailabilityZone:          aws.String("us-east-1a"),
+		ClusterParameterGroupName: aws.String("pg-custom"),
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	cl := out.Cluster
+
+	if aws.ToString(cl.NodeType) != "ra3.xlplus" {
+		t.Fatalf("NodeType=%q, want ra3.xlplus", aws.ToString(cl.NodeType))
+	}
+
+	if aws.ToInt32(cl.NumberOfNodes) != 2 {
+		t.Fatalf("NumberOfNodes=%d, want 2", aws.ToInt32(cl.NumberOfNodes))
+	}
+
+	if !aws.ToBool(cl.Encrypted) {
+		t.Fatal("Encrypted=false, want true")
+	}
+
+	if !aws.ToBool(cl.PubliclyAccessible) {
+		t.Fatal("PubliclyAccessible=false, want true")
+	}
+
+	if aws.ToString(cl.AvailabilityZone) != "us-east-1a" {
+		t.Fatalf("AvailabilityZone=%q, want us-east-1a", aws.ToString(cl.AvailabilityZone))
+	}
+
+	if len(cl.ClusterParameterGroups) != 1 ||
+		aws.ToString(cl.ClusterParameterGroups[0].ParameterGroupName) != "pg-custom" {
+		t.Fatalf("ClusterParameterGroups=%+v, want one pg-custom membership", cl.ClusterParameterGroups)
+	}
+
+	// One LEADER plus NumberOfNodes COMPUTE nodes.
+	if len(cl.ClusterNodes) != 3 {
+		t.Fatalf("ClusterNodes=%d, want 3 (1 leader + 2 compute)", len(cl.ClusterNodes))
+	}
+
+	if aws.ToString(cl.ClusterNodes[0].NodeRole) != "LEADER" {
+		t.Fatalf("first node role=%q, want LEADER", aws.ToString(cl.ClusterNodes[0].NodeRole))
+	}
+}

--- a/server/aws/redshift/cluster_credentials_sdk_roundtrip_test.go
+++ b/server/aws/redshift/cluster_credentials_sdk_roundtrip_test.go
@@ -1,0 +1,99 @@
+package redshift_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsredshift "github.com/aws/aws-sdk-go-v2/service/redshift"
+)
+
+// TestSDKRedshiftGetClusterCredentials asserts GetClusterCredentials returns a
+// temporary DbUser (prefixed IAM:), a DbPassword and an Expiration for an
+// existing cluster.
+func TestSDKRedshiftGetClusterCredentials(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:  aws.String("creds"),
+		MasterUsername:     aws.String("admin"),
+		MasterUserPassword: aws.String("Sup3rSecret!"),
+		NodeType:           aws.String("ra3.xlplus"),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	out, err := client.GetClusterCredentials(ctx, &awsredshift.GetClusterCredentialsInput{
+		ClusterIdentifier: aws.String("creds"),
+		DbUser:            aws.String("analyst"),
+	})
+	if err != nil {
+		t.Fatalf("GetClusterCredentials: %v", err)
+	}
+
+	if !strings.HasPrefix(aws.ToString(out.DbUser), "IAM:") {
+		t.Fatalf("DbUser=%q, want an IAM: prefix", aws.ToString(out.DbUser))
+	}
+
+	if aws.ToString(out.DbPassword) == "" {
+		t.Fatal("DbPassword empty; want a temporary password")
+	}
+
+	if out.Expiration == nil {
+		t.Fatal("Expiration nil; want a credential expiry")
+	}
+}
+
+// TestSDKRedshiftGetClusterCredentialsMissing asserts an unknown cluster is a
+// ClusterNotFound fault, not an empty credential.
+func TestSDKRedshiftGetClusterCredentialsMissing(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.GetClusterCredentials(ctx, &awsredshift.GetClusterCredentialsInput{
+		ClusterIdentifier: aws.String("nope"),
+		DbUser:            aws.String("analyst"),
+	}); err == nil {
+		t.Fatal("expected an error for GetClusterCredentials on a missing cluster")
+	}
+}
+
+// TestSDKRedshiftPauseResume asserts PauseCluster and ResumeCluster move the
+// cluster between paused and available.
+func TestSDKRedshiftPauseResume(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:  aws.String("pausable"),
+		MasterUsername:     aws.String("admin"),
+		MasterUserPassword: aws.String("Sup3rSecret!"),
+		NodeType:           aws.String("ra3.xlplus"),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	paused, err := client.PauseCluster(ctx, &awsredshift.PauseClusterInput{
+		ClusterIdentifier: aws.String("pausable"),
+	})
+	if err != nil {
+		t.Fatalf("PauseCluster: %v", err)
+	}
+
+	if aws.ToString(paused.Cluster.ClusterStatus) != "paused" {
+		t.Fatalf("after pause status=%q, want paused", aws.ToString(paused.Cluster.ClusterStatus))
+	}
+
+	resumed, err := client.ResumeCluster(ctx, &awsredshift.ResumeClusterInput{
+		ClusterIdentifier: aws.String("pausable"),
+	})
+	if err != nil {
+		t.Fatalf("ResumeCluster: %v", err)
+	}
+
+	if aws.ToString(resumed.Cluster.ClusterStatus) != "available" {
+		t.Fatalf("after resume status=%q, want available", aws.ToString(resumed.Cluster.ClusterStatus))
+	}
+}

--- a/server/aws/redshift/cluster_snapshot_attributes_sdk_roundtrip_test.go
+++ b/server/aws/redshift/cluster_snapshot_attributes_sdk_roundtrip_test.go
@@ -1,0 +1,53 @@
+package redshift_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsredshift "github.com/aws/aws-sdk-go-v2/service/redshift"
+)
+
+// TestSDKRedshiftSnapshotAttributes asserts a cluster snapshot inherits the
+// source cluster's NodeType/NumberOfNodes/Encrypted and reports a backup size.
+func TestSDKRedshiftSnapshotAttributes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:  aws.String("snapattrs"),
+		MasterUsername:     aws.String("admin"),
+		MasterUserPassword: aws.String("Sup3rSecret!"),
+		NodeType:           aws.String("ra3.xlplus"),
+		NumberOfNodes:      aws.Int32(3),
+		Encrypted:          aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	out, err := client.CreateClusterSnapshot(ctx, &awsredshift.CreateClusterSnapshotInput{
+		SnapshotIdentifier: aws.String("snap-attrs"),
+		ClusterIdentifier:  aws.String("snapattrs"),
+	})
+	if err != nil {
+		t.Fatalf("CreateClusterSnapshot: %v", err)
+	}
+
+	snap := out.Snapshot
+
+	if aws.ToString(snap.NodeType) != "ra3.xlplus" {
+		t.Fatalf("snapshot NodeType=%q, want ra3.xlplus", aws.ToString(snap.NodeType))
+	}
+
+	if aws.ToInt32(snap.NumberOfNodes) != 3 {
+		t.Fatalf("snapshot NumberOfNodes=%d, want 3", aws.ToInt32(snap.NumberOfNodes))
+	}
+
+	if !aws.ToBool(snap.Encrypted) {
+		t.Fatal("snapshot Encrypted=false, want true")
+	}
+
+	if snap.TotalBackupSizeInMegaBytes == nil || aws.ToFloat64(snap.TotalBackupSizeInMegaBytes) <= 0 {
+		t.Fatalf("snapshot TotalBackupSizeInMegaBytes=%v, want a positive size", snap.TotalBackupSizeInMegaBytes)
+	}
+}

--- a/server/aws/redshift/handler.go
+++ b/server/aws/redshift/handler.go
@@ -42,6 +42,9 @@ var redshiftActions = map[string]struct{}{ //nolint:gochecknoglobals // static l
 	"DescribeClusterSnapshots":       {},
 	"DeleteClusterSnapshot":          {},
 	"RestoreFromClusterSnapshot":     {},
+	"GetClusterCredentials":          {},
+	"PauseCluster":                   {},
+	"ResumeCluster":                  {},
 	"CreateClusterParameterGroup":    {},
 	"DescribeClusterParameterGroups": {},
 	"DeleteClusterParameterGroup":    {},
@@ -62,6 +65,14 @@ type clusterGroupManager interface {
 	CreateClusterSubnetGroup(ctx context.Context, name, description string, subnetIDs []string) (*redshiftprovider.SubnetGroup, error)
 	DescribeClusterSubnetGroups(ctx context.Context, names []string) ([]redshiftprovider.SubnetGroup, error)
 	DeleteClusterSubnetGroup(ctx context.Context, name string) error
+}
+
+// clusterPauser is the AWS-only PauseCluster/ResumeCluster surface, kept off
+// the shared relationaldb driver; the handler discovers it by type assertion
+// and answers InvalidAction when the backing driver does not implement it.
+type clusterPauser interface {
+	PauseCluster(ctx context.Context, id string) (*rdbdriver.Cluster, error)
+	ResumeCluster(ctx context.Context, id string) (*rdbdriver.Cluster, error)
 }
 
 // resourceTagger is the AWS-specific Redshift tagging surface.
@@ -150,6 +161,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.deleteClusterSnapshot(w, r)
 	case "RestoreFromClusterSnapshot":
 		h.restoreFromClusterSnapshot(w, r)
+	case "GetClusterCredentials":
+		h.getClusterCredentials(w, r)
+	case "PauseCluster":
+		h.pauseCluster(w, r)
+	case "ResumeCluster":
+		h.resumeCluster(w, r)
 	case "CreateClusterParameterGroup":
 		h.createClusterParameterGroup(w, r)
 	case "DescribeClusterParameterGroups":

--- a/server/aws/redshift/operations.go
+++ b/server/aws/redshift/operations.go
@@ -4,25 +4,42 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	rdbdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// GetClusterCredentials defaults. DurationSeconds is clamped to [900, 3600]
+// with a 900-second default, matching the real Redshift API.
+const (
+	defaultCredentialDurationSecs = 900
+	minCredentialDurationSecs     = 900
+	maxCredentialDurationSecs     = 3600
+	iamDBUserPrefix               = "IAM:"
+	synthesizedDBPassword         = "cloudemu-temporary-credential" //nolint:gosec // not a real secret; auth is not enforced
 )
 
 // clusterConfigFromForm pulls the relevant Cluster fields out of a form. Used
 // by CreateCluster.
 func clusterConfigFromForm(form url.Values) rdbdriver.ClusterConfig {
 	return rdbdriver.ClusterConfig{
-		ID:                 form.Get("ClusterIdentifier"),
-		Engine:             "redshift",
-		EngineVersion:      form.Get("ClusterVersion"),
-		MasterUsername:     form.Get("MasterUsername"),
-		MasterUserPassword: form.Get("MasterUserPassword"),
-		DatabaseName:       form.Get("DBName"),
-		Port:               formInt(form.Get("Port")),
-		VPCSecurityGroups:  awsquery.ListStrings(form, "VpcSecurityGroupIds.VpcSecurityGroupId"),
-		SubnetGroupName:    form.Get("ClusterSubnetGroupName"),
-		Tags:               parseRedshiftTags(form),
+		ID:                          form.Get("ClusterIdentifier"),
+		Engine:                      "redshift",
+		EngineVersion:               form.Get("ClusterVersion"),
+		MasterUsername:              form.Get("MasterUsername"),
+		MasterUserPassword:          form.Get("MasterUserPassword"),
+		DatabaseName:                form.Get("DBName"),
+		Port:                        formInt(form.Get("Port")),
+		VPCSecurityGroups:           awsquery.ListStrings(form, "VpcSecurityGroupIds.VpcSecurityGroupId"),
+		SubnetGroupName:             form.Get("ClusterSubnetGroupName"),
+		DBClusterParameterGroupName: form.Get("ClusterParameterGroupName"),
+		NodeType:                    form.Get("NodeType"),
+		NumberOfNodes:               formInt(form.Get("NumberOfNodes")),
+		Encrypted:                   formBool(form.Get("Encrypted")),
+		PubliclyAccessible:          formBool(form.Get("PubliclyAccessible")),
+		AvailabilityZone:            form.Get("AvailabilityZone"),
+		Tags:                        parseRedshiftTags(form),
 	}
 }
 
@@ -262,6 +279,90 @@ func (h *Handler) restoreFromClusterSnapshot(w http.ResponseWriter, r *http.Requ
 	}
 
 	awsquery.WriteXMLResponse(w, restoreFromClusterSnapshotResponse{
+		Xmlns:    Namespace,
+		Result:   clusterResult{Cluster: toClusterXML(cluster)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) getClusterCredentials(w http.ResponseWriter, r *http.Request) {
+	form := r.Form
+
+	id := form.Get("ClusterIdentifier")
+
+	// The cluster must exist; ClusterNotFound (404) otherwise.
+	clusters, err := h.db.DescribeClusters(r.Context(), []string{id})
+	if err != nil || len(clusters) == 0 {
+		writeErr(w, errClusterNotFound(id))
+		return
+	}
+
+	duration := formInt(form.Get("DurationSeconds"))
+	if duration == 0 {
+		duration = defaultCredentialDurationSecs
+	}
+
+	if duration < minCredentialDurationSecs {
+		duration = minCredentialDurationSecs
+	}
+
+	if duration > maxCredentialDurationSecs {
+		duration = maxCredentialDurationSecs
+	}
+
+	expiration := time.Now().UTC().Add(time.Duration(duration) * time.Second)
+
+	awsquery.WriteXMLResponse(w, getClusterCredentialsResponse{
+		Xmlns: Namespace,
+		Result: clusterCredentialsResult{
+			DBUser:     iamDBUserPrefix + form.Get("DbUser"),
+			DBPassword: synthesizedDBPassword,
+			Expiration: expiration.Format("2006-01-02T15:04:05.000Z"),
+		},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+//nolint:dupl // structurally similar to resumeCluster but a distinct action + response type.
+func (h *Handler) pauseCluster(w http.ResponseWriter, r *http.Request) {
+	pauser, ok := h.db.(clusterPauser)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "PauseCluster is not supported")
+		return
+	}
+
+	id := r.Form.Get("ClusterIdentifier")
+
+	cluster, err := pauser.PauseCluster(r.Context(), id)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, pauseClusterResponse{
+		Xmlns:    Namespace,
+		Result:   clusterResult{Cluster: toClusterXML(cluster)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+//nolint:dupl // structurally similar to pauseCluster but a distinct action + response type.
+func (h *Handler) resumeCluster(w http.ResponseWriter, r *http.Request) {
+	pauser, ok := h.db.(clusterPauser)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "ResumeCluster is not supported")
+		return
+	}
+
+	id := r.Form.Get("ClusterIdentifier")
+
+	cluster, err := pauser.ResumeCluster(r.Context(), id)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, resumeClusterResponse{
 		Xmlns:    Namespace,
 		Result:   clusterResult{Cluster: toClusterXML(cluster)},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},

--- a/server/aws/redshift/xml.go
+++ b/server/aws/redshift/xml.go
@@ -40,29 +40,59 @@ type vpcSecurityGroupsXML struct {
 }
 
 type clusterXML struct {
-	ClusterIdentifier      string                `xml:"ClusterIdentifier"`
-	ClusterNamespaceArn    string                `xml:"ClusterNamespaceArn"`
-	ClusterStatus          string                `xml:"ClusterStatus"`
-	ClusterVersion         string                `xml:"ClusterVersion,omitempty"`
-	MasterUsername         string                `xml:"MasterUsername,omitempty"`
-	DBName                 string                `xml:"DBName,omitempty"`
-	Endpoint               *endpointXML          `xml:"Endpoint,omitempty"`
-	ClusterCreateTime      string                `xml:"ClusterCreateTime,omitempty"`
-	ClusterSubnetGroupName string                `xml:"ClusterSubnetGroupName,omitempty"`
-	VpcSecurityGroups      *vpcSecurityGroupsXML `xml:"VpcSecurityGroups,omitempty"`
-	Tags                   *tagsXML              `xml:"Tags,omitempty"`
-	NodeType               string                `xml:"NodeType,omitempty"`
+	ClusterIdentifier      string                     `xml:"ClusterIdentifier"`
+	ClusterNamespaceArn    string                     `xml:"ClusterNamespaceArn"`
+	ClusterStatus          string                     `xml:"ClusterStatus"`
+	ClusterVersion         string                     `xml:"ClusterVersion,omitempty"`
+	MasterUsername         string                     `xml:"MasterUsername,omitempty"`
+	DBName                 string                     `xml:"DBName,omitempty"`
+	Endpoint               *endpointXML               `xml:"Endpoint,omitempty"`
+	ClusterCreateTime      string                     `xml:"ClusterCreateTime,omitempty"`
+	ClusterSubnetGroupName string                     `xml:"ClusterSubnetGroupName,omitempty"`
+	VpcSecurityGroups      *vpcSecurityGroupsXML      `xml:"VpcSecurityGroups,omitempty"`
+	Tags                   *tagsXML                   `xml:"Tags,omitempty"`
+	NodeType               string                     `xml:"NodeType,omitempty"`
+	NumberOfNodes          int                        `xml:"NumberOfNodes,omitempty"`
+	Encrypted              bool                       `xml:"Encrypted"`
+	PubliclyAccessible     bool                       `xml:"PubliclyAccessible"`
+	AvailabilityZone       string                     `xml:"AvailabilityZone,omitempty"`
+	VpcID                  string                     `xml:"VpcId,omitempty"`
+	ClusterParameterGroups *clusterParameterGroupsXML `xml:"ClusterParameterGroups,omitempty"`
+	ClusterNodes           *clusterNodesXML           `xml:"ClusterNodes,omitempty"`
+}
+
+type clusterParameterGroupStatusXML struct {
+	ParameterGroupName   string `xml:"ParameterGroupName"`
+	ParameterApplyStatus string `xml:"ParameterApplyStatus"`
+}
+
+type clusterParameterGroupsXML struct {
+	ClusterParameterGroup []clusterParameterGroupStatusXML `xml:"ClusterParameterGroup,omitempty"`
+}
+
+type clusterNodeXML struct {
+	NodeRole         string `xml:"NodeRole"`
+	PrivateIPAddress string `xml:"PrivateIPAddress"`
+	PublicIPAddress  string `xml:"PublicIPAddress,omitempty"`
+}
+
+type clusterNodesXML struct {
+	Member []clusterNodeXML `xml:"member,omitempty"`
 }
 
 type snapshotXML struct {
-	SnapshotIdentifier string   `xml:"SnapshotIdentifier"`
-	SnapshotArn        string   `xml:"SnapshotArn"`
-	ClusterIdentifier  string   `xml:"ClusterIdentifier"`
-	ClusterVersion     string   `xml:"ClusterVersion,omitempty"`
-	Status             string   `xml:"Status"`
-	SnapshotType       string   `xml:"SnapshotType,omitempty"`
-	SnapshotCreateTime string   `xml:"SnapshotCreateTime,omitempty"`
-	Tags               *tagsXML `xml:"Tags,omitempty"`
+	SnapshotIdentifier         string   `xml:"SnapshotIdentifier"`
+	SnapshotArn                string   `xml:"SnapshotArn"`
+	ClusterIdentifier          string   `xml:"ClusterIdentifier"`
+	ClusterVersion             string   `xml:"ClusterVersion,omitempty"`
+	Status                     string   `xml:"Status"`
+	SnapshotType               string   `xml:"SnapshotType,omitempty"`
+	SnapshotCreateTime         string   `xml:"SnapshotCreateTime,omitempty"`
+	NodeType                   string   `xml:"NodeType,omitempty"`
+	NumberOfNodes              int      `xml:"NumberOfNodes,omitempty"`
+	Encrypted                  bool     `xml:"Encrypted"`
+	TotalBackupSizeInMegaBytes float64  `xml:"TotalBackupSizeInMegaBytes,omitempty"`
+	Tags                       *tagsXML `xml:"Tags,omitempty"`
 }
 
 // Result wrappers — one per Action.
@@ -154,6 +184,33 @@ type deleteClusterSnapshotResponse struct {
 	Metadata responseMetadata `xml:"ResponseMetadata"`
 }
 
+type pauseClusterResponse struct {
+	XMLName  xml.Name         `xml:"PauseClusterResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   clusterResult    `xml:"PauseClusterResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type resumeClusterResponse struct {
+	XMLName  xml.Name         `xml:"ResumeClusterResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   clusterResult    `xml:"ResumeClusterResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type clusterCredentialsResult struct {
+	DBUser     string `xml:"DbUser"`
+	DBPassword string `xml:"DbPassword"`
+	Expiration string `xml:"Expiration"`
+}
+
+type getClusterCredentialsResponse struct {
+	XMLName  xml.Name                 `xml:"GetClusterCredentialsResponse"`
+	Xmlns    string                   `xml:"xmlns,attr"`
+	Result   clusterCredentialsResult `xml:"GetClusterCredentialsResult"`
+	Metadata responseMetadata         `xml:"ResponseMetadata"`
+}
+
 // toClusterXML converts a driver Cluster to its XML representation.
 func toClusterXML(cluster *rdbdriver.Cluster) clusterXML {
 	return clusterXML{
@@ -168,19 +225,75 @@ func toClusterXML(cluster *rdbdriver.Cluster) clusterXML {
 		ClusterSubnetGroupName: cluster.SubnetGroupName,
 		VpcSecurityGroups:      toVpcSGsXML(cluster.VPCSecurityGroups),
 		Tags:                   toTagsXML(cluster.Tags),
+		NodeType:               cluster.NodeType,
+		NumberOfNodes:          cluster.NumberOfNodes,
+		Encrypted:              cluster.Encrypted,
+		PubliclyAccessible:     cluster.PubliclyAccessible,
+		AvailabilityZone:       cluster.AvailabilityZone,
+		VpcID:                  cluster.VpcID,
+		ClusterParameterGroups: toClusterParameterGroupsXML(cluster.DBClusterParameterGroupName),
+		ClusterNodes:           toClusterNodesXML(cluster.NumberOfNodes),
 	}
+}
+
+// leaderPrivateIP / computePrivateIPBase build the deterministic private IPs
+// synthesized for a cluster's node list.
+const (
+	leaderPrivateIP      = "10.0.0.1"
+	computePrivateIPBase = 10
+	nodeRoleLeader       = "LEADER"
+	nodeRoleCompute      = "COMPUTE"
+	parameterApplyInSync = "in-sync"
+)
+
+func toClusterParameterGroupsXML(name string) *clusterParameterGroupsXML {
+	if name == "" {
+		return nil
+	}
+
+	return &clusterParameterGroupsXML{
+		ClusterParameterGroup: []clusterParameterGroupStatusXML{{
+			ParameterGroupName:   name,
+			ParameterApplyStatus: parameterApplyInSync,
+		}},
+	}
+}
+
+// toClusterNodesXML synthesizes one LEADER node plus numberOfNodes COMPUTE
+// nodes with deterministic private IPs, matching the ClusterNodes list real
+// Redshift returns.
+func toClusterNodesXML(numberOfNodes int) *clusterNodesXML {
+	if numberOfNodes <= 0 {
+		return nil
+	}
+
+	nodes := make([]clusterNodeXML, 0, numberOfNodes+1)
+	nodes = append(nodes, clusterNodeXML{NodeRole: nodeRoleLeader, PrivateIPAddress: leaderPrivateIP})
+
+	for i := 0; i < numberOfNodes; i++ {
+		nodes = append(nodes, clusterNodeXML{
+			NodeRole:         nodeRoleCompute,
+			PrivateIPAddress: "10.0.0." + strconv.Itoa(computePrivateIPBase+i),
+		})
+	}
+
+	return &clusterNodesXML{Member: nodes}
 }
 
 func toSnapshotXML(snap *rdbdriver.ClusterSnapshot) snapshotXML {
 	return snapshotXML{
-		SnapshotIdentifier: snap.ID,
-		SnapshotArn:        snap.ARN,
-		ClusterIdentifier:  snap.ClusterID,
-		ClusterVersion:     snap.EngineVersion,
-		Status:             snap.State,
-		SnapshotType:       "manual",
-		SnapshotCreateTime: snap.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
-		Tags:               toTagsXML(snap.Tags),
+		SnapshotIdentifier:         snap.ID,
+		SnapshotArn:                snap.ARN,
+		ClusterIdentifier:          snap.ClusterID,
+		ClusterVersion:             snap.EngineVersion,
+		Status:                     snap.State,
+		SnapshotType:               "manual",
+		SnapshotCreateTime:         snap.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
+		NodeType:                   snap.NodeType,
+		NumberOfNodes:              snap.NumberOfNodes,
+		Encrypted:                  snap.Encrypted,
+		TotalBackupSizeInMegaBytes: snap.TotalBackupSizeInMegaBytes,
+		Tags:                       toTagsXML(snap.Tags),
 	}
 }
 
@@ -227,4 +340,18 @@ func formInt(v string) int {
 	}
 
 	return n
+}
+
+// formBool returns the boolean value of a form field, or false on missing/parse error.
+func formBool(v string) bool {
+	if v == "" {
+		return false
+	}
+
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false
+	}
+
+	return b
 }

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -79,6 +79,9 @@ type InstanceConfig struct {
 	OptionGroupName      string
 	ClusterID            string // empty for standalone, set for Aurora cluster members
 	AvailabilityZone     string
+	// StorageEncrypted requests encryption-at-rest on the instance's storage
+	// (AWS RDS StorageEncrypted); false for engines with no such flag.
+	StorageEncrypted bool
 	// HighAvailabilityMode is the Azure Flexible Server HA mode
 	// ("Disabled"/"SameZone"/"ZoneRedundant"); empty for engines with no such
 	// concept. StandbyAvailabilityZone is the zone the standby replica runs in
@@ -122,6 +125,18 @@ type Instance struct {
 	OptionGroupName      string
 	ClusterID            string
 	AvailabilityZone     string
+	// The fields below echo AWS RDS DBInstance attributes on read. They default
+	// to their zero value for engines (Azure/GCP) that have no such concept.
+	// DbiResourceId is the immutable region-unique resource id (db-XXXX...).
+	// CACertificateIdentifier is the server CA cert id (e.g. rds-ca-rsa2048-g1).
+	DbiResourceID              string
+	BackupRetentionPeriod      int
+	PreferredBackupWindow      string
+	PreferredMaintenanceWindow string
+	CACertificateIdentifier    string
+	Iops                       int
+	StorageEncrypted           bool
+	DeletionProtection         bool
 	// HighAvailabilityMode / StandbyAvailabilityZone echo the Azure Flexible
 	// Server HA configuration on read; empty for engines with no HA concept.
 	HighAvailabilityMode    string
@@ -150,6 +165,15 @@ type ModifyInstanceInput struct {
 	OptionGroupName             string
 	DBClusterParameterGroupName string
 	ElasticPoolID               string
+	// The fields below are AWS RDS ModifyDBInstance attributes; empty / zero /
+	// nil means "no change". NewInstanceID renames the instance (and its ARN).
+	NewInstanceID              string
+	BackupRetentionPeriod      int
+	PreferredBackupWindow      string
+	PreferredMaintenanceWindow string
+	StorageType                string
+	Iops                       int
+	DeletionProtection         *bool
 	// HighAvailabilityMode updates the Azure Flexible Server HA mode
 	// ("Disabled"/"SameZone"/"ZoneRedundant"); empty means "no change".
 	// StandbyAvailabilityZone updates the standby replica's zone when HA is
@@ -172,7 +196,20 @@ type ClusterConfig struct {
 	VPCSecurityGroups           []string
 	SubnetGroupName             string
 	DBClusterParameterGroupName string
-	Tags                        map[string]string
+	// EngineMode is the AWS Aurora engine mode ("provisioned"/"serverless");
+	// empty defaults to "provisioned". StorageEncrypted / AllocatedStorage echo
+	// the corresponding create inputs. All default to zero for non-AWS engines.
+	EngineMode       string
+	StorageEncrypted bool
+	AllocatedStorage int
+	// Redshift-specific create inputs carried on the shared config (following the
+	// Azure HighAvailabilityMode precedent); zero for RDS/Aurora/Azure/GCP.
+	NodeType           string
+	NumberOfNodes      int
+	Encrypted          bool
+	PubliclyAccessible bool
+	AvailabilityZone   string
+	Tags               map[string]string
 }
 
 // Cluster describes an Aurora-style database cluster.
@@ -191,8 +228,26 @@ type Cluster struct {
 	VPCSecurityGroups           []string
 	SubnetGroupName             string
 	DBClusterParameterGroupName string
-	CreatedAt                   time.Time
-	Tags                        map[string]string
+	// EngineMode / DbClusterResourceId / AllocatedStorage / StorageEncrypted /
+	// AvailabilityZones echo AWS Aurora DBCluster attributes on read; they
+	// default to zero for non-AWS engines.
+	EngineMode          string
+	DBClusterResourceID string
+	AllocatedStorage    int
+	StorageEncrypted    bool
+	AvailabilityZones   []string
+	// NodeType / NumberOfNodes / Encrypted / PubliclyAccessible /
+	// AvailabilityZone / VpcID are Redshift-specific cluster attributes carried
+	// on the shared struct (Azure HighAvailabilityMode precedent); zero for
+	// RDS/Aurora/Azure/GCP.
+	NodeType           string
+	NumberOfNodes      int
+	Encrypted          bool
+	PubliclyAccessible bool
+	AvailabilityZone   string
+	VpcID              string
+	CreatedAt          time.Time
+	Tags               map[string]string
 }
 
 // SnapshotConfig configures an instance snapshot.
@@ -230,8 +285,15 @@ type ClusterSnapshot struct {
 	Engine        string
 	EngineVersion string
 	State         string
-	CreatedAt     time.Time
-	Tags          map[string]string
+	// NodeType / NumberOfNodes / Encrypted / TotalBackupSizeInMegaBytes echo the
+	// AWS Redshift snapshot attributes on read (copied from the source cluster);
+	// zero for RDS/Aurora/Azure/GCP cluster snapshots.
+	NodeType                   string
+	NumberOfNodes              int
+	Encrypted                  bool
+	TotalBackupSizeInMegaBytes float64
+	CreatedAt                  time.Time
+	Tags                       map[string]string
 }
 
 // RestoreInstanceInput configures restoring an instance from a snapshot.


### PR DESCRIPTION
RDS + Redshift wire fidelity per AWS docs: RDS DBInstance/DBCluster field completeness (DbiResourceId/EngineVersion/AvailabilityZone/EngineMode/…) + DescribeDBInstances MaxRecords/Marker; Redshift Cluster + ClusterSnapshot field completeness + GetClusterCredentials. Additive provider fields, zero-value-safe cross-cloud; compat suite clean; SDK tests per fix.