### PR TITLE
fix(ecr+eks+ecs+memorydb): registryId consistency, nodegroup/endpoint, task-def fields, create-time tags

### DIFF
--- a/providers/aws/ecs/ecs.go
+++ b/providers/aws/ecs/ecs.go
@@ -100,6 +100,12 @@ func (m *Mock) arn(resource string) string {
 	return idgen.AWSARN("ecs", m.opts.Region, m.opts.AccountID, resource)
 }
 
+// rootPrincipalARN is the account-root IAM principal ECS records as a service's
+// createdBy when the request carries no more specific caller identity.
+func (m *Mock) rootPrincipalARN() string {
+	return "arn:aws:iam::" + m.opts.AccountID + ":root"
+}
+
 // hexID returns a 32-character hex id with no dashes, matching the ECS
 // resource-id shape used in task and container-instance ARNs. idgen.GenerateID
 // emits 8 hex digits per call, so four calls yield the 32-char id.

--- a/providers/aws/ecs/services.go
+++ b/providers/aws/ecs/services.go
@@ -90,7 +90,7 @@ func (m *Mock) CreateService(ctx context.Context, in driver.CreateServiceInput) 
 			"desiredCount must not be specified for a DAEMON service")
 	}
 
-	svc := serviceFromInput(&in, m.arn, cluster, m.now())
+	svc := serviceFromInput(&in, m.arn, cluster, m.now(), m.rootPrincipalARN())
 
 	if err := m.reserveServiceName(serviceKey(cluster, in.ServiceName), svc); err != nil {
 		return nil, err
@@ -107,7 +107,10 @@ func (m *Mock) CreateService(ctx context.Context, in driver.CreateServiceInput) 
 
 // serviceFromInput builds the service record (without convergence) from the
 // create input, defaulting the scheduling strategy and deployment controller.
-func serviceFromInput(in *driver.CreateServiceInput, arn func(string) string, cluster, now string) *driver.Service {
+// createdBy is the creating principal ECS records on the service.
+func serviceFromInput(
+	in *driver.CreateServiceInput, arn func(string) string, cluster, now, createdBy string,
+) *driver.Service {
 	sched := in.SchedulingStrategy
 	if sched == "" {
 		sched = schedReplica
@@ -123,6 +126,8 @@ func serviceFromInput(in *driver.CreateServiceInput, arn func(string) string, cl
 		Name:                          in.ServiceName,
 		ClusterARN:                    arn("cluster/" + cluster),
 		TaskDefinition:                in.TaskDefinition,
+		RoleARN:                       in.Role,
+		CreatedBy:                     createdBy,
 		DesiredCount:                  in.DesiredCount,
 		Status:                        statusActive,
 		LaunchType:                    in.LaunchType,

--- a/providers/aws/memorydb/clusters.go
+++ b/providers/aws/memorydb/clusters.go
@@ -344,6 +344,14 @@ func (m *Mock) reserveCluster(cfg *mdbdriver.CreateClusterConfig) (*mdbdriver.Cl
 	}
 
 	m.clusters.Set(cfg.Name, cluster)
+
+	// Create-time tags must be addressable by ListTags(arn), which reads m.tags;
+	// without this they would live only on cluster.Tags and be invisible until a
+	// later TagResource call.
+	if len(cfg.Tags) > 0 {
+		m.tags[cluster.ARN] = copyTags(cfg.Tags)
+	}
+
 	m.linkACLCluster(acl, cfg.Name, true)
 
 	if cfg.MultiRegionClusterName != "" {

--- a/server/aws/ecr/lifecycle_policy.go
+++ b/server/aws/ecr/lifecycle_policy.go
@@ -55,10 +55,16 @@ func (h *Handler) putLifecyclePolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wire.WriteJSON(w, map[string]any{
+	resp := map[string]any{
 		"repositoryName":      req.RepositoryName,
 		"lifecyclePolicyText": req.LifecyclePolicyText,
-	})
+	}
+
+	if repo, err := h.registry.GetRepository(r.Context(), req.RepositoryName); err == nil {
+		resp["registryId"] = repo.RegistryID
+	}
+
+	wire.WriteJSON(w, resp)
 }
 
 func (h *Handler) getLifecyclePolicy(w http.ResponseWriter, r *http.Request) {
@@ -90,10 +96,18 @@ func (h *Handler) getLifecyclePolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wire.WriteJSON(w, map[string]any{
+	resp := map[string]any{
 		"repositoryName":      req.RepositoryName,
 		"lifecyclePolicyText": text,
-	})
+	}
+
+	// The policy lookup already proved the repository exists, so echo its
+	// registryId (real ECR always returns it).
+	if repo, repoErr := h.registry.GetRepository(r.Context(), req.RepositoryName); repoErr == nil {
+		resp["registryId"] = repo.RegistryID
+	}
+
+	wire.WriteJSON(w, resp)
 }
 
 func parseLifecyclePolicyText(text string) (crdriver.LifecyclePolicy, error) {

--- a/server/aws/ecr/lifecycle_policy_test.go
+++ b/server/aws/ecr/lifecycle_policy_test.go
@@ -1,0 +1,54 @@
+package ecr_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsecr "github.com/aws/aws-sdk-go-v2/service/ecr"
+)
+
+const lifecyclePolicyDoc = `{"rules":[{"rulePriority":1,"description":"expire",` +
+	`"selection":{"tagStatus":"untagged","countType":"imageCountMoreThan","countNumber":10},` +
+	`"action":{"type":"expire"}}]}`
+
+// TestSDKECRLifecyclePolicyRegistryID guards that Put/GetLifecyclePolicy echo the
+// owning registryId (the account id), which the real ECR API always returns and
+// IaC tooling reads.
+func TestSDKECRLifecyclePolicyRegistryID(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("lc-repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	put, err := client.PutLifecyclePolicy(ctx, &awsecr.PutLifecyclePolicyInput{
+		RepositoryName:      aws.String("lc-repo"),
+		LifecyclePolicyText: aws.String(lifecyclePolicyDoc),
+	})
+	if err != nil {
+		t.Fatalf("PutLifecyclePolicy: %v", err)
+	}
+
+	if aws.ToString(put.RegistryId) != "123456789012" {
+		t.Fatalf("PutLifecyclePolicy registryId = %q, want 123456789012", aws.ToString(put.RegistryId))
+	}
+
+	got, err := client.GetLifecyclePolicy(ctx, &awsecr.GetLifecyclePolicyInput{
+		RepositoryName: aws.String("lc-repo"),
+	})
+	if err != nil {
+		t.Fatalf("GetLifecyclePolicy: %v", err)
+	}
+
+	if aws.ToString(got.RegistryId) != "123456789012" {
+		t.Fatalf("GetLifecyclePolicy registryId = %q, want 123456789012", aws.ToString(got.RegistryId))
+	}
+
+	if aws.ToString(got.RepositoryName) != "lc-repo" {
+		t.Fatalf("GetLifecyclePolicy repositoryName = %q, want lc-repo", aws.ToString(got.RepositoryName))
+	}
+}

--- a/server/aws/ecs/services.go
+++ b/server/aws/ecs/services.go
@@ -33,6 +33,7 @@ func (h *Handler) createService(w http.ResponseWriter, r *http.Request) {
 		TaskDefinition                string                             `json:"taskDefinition"`
 		DesiredCount                  int                                `json:"desiredCount"`
 		LaunchType                    string                             `json:"launchType"`
+		Role                          string                             `json:"role"`
 		SchedulingStrategy            string                             `json:"schedulingStrategy"`
 		PlatformVersion               string                             `json:"platformVersion"`
 		PropagateTags                 string                             `json:"propagateTags"`
@@ -57,6 +58,7 @@ func (h *Handler) createService(w http.ResponseWriter, r *http.Request) {
 		TaskDefinition:                req.TaskDefinition,
 		DesiredCount:                  req.DesiredCount,
 		LaunchType:                    req.LaunchType,
+		Role:                          req.Role,
 		SchedulingStrategy:            req.SchedulingStrategy,
 		DeploymentController:          deploymentControllerType(req.DeploymentController),
 		PlatformVersion:               req.PlatformVersion,

--- a/server/aws/ecs/services_test.go
+++ b/server/aws/ecs/services_test.go
@@ -1,0 +1,67 @@
+package ecs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
+
+	provecs "github.com/stackshy/cloudemu/v2/providers/aws/ecs"
+)
+
+// TestSDKServiceRoleAndCreatedBy guards that CreateService echoes the caller's
+// role ARN as service.roleArn and records the creating principal as
+// service.createdBy, both of which real ECS returns and DescribeServices must
+// preserve.
+func TestSDKServiceRoleAndCreatedBy(t *testing.T) {
+	client, cloud := newECSServer(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsecs.CreateClusterInput{ClusterName: aws.String("prod")}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	cloud.ECS.SeedContainerInstance("prod", "i-svc", provecs.WithCapacity(8192, 16384))
+	registerNginx(t, client, ctx)
+
+	const roleARN = "arn:aws:iam::123456789012:role/ecsServiceRole"
+
+	created, err := client.CreateService(ctx, &awsecs.CreateServiceInput{
+		Cluster:        aws.String("prod"),
+		ServiceName:    aws.String("web-svc"),
+		TaskDefinition: aws.String("web"),
+		DesiredCount:   aws.Int32(1),
+		Role:           aws.String(roleARN),
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	if aws.ToString(created.Service.RoleArn) != roleARN {
+		t.Fatalf("CreateService roleArn = %q, want %q", aws.ToString(created.Service.RoleArn), roleARN)
+	}
+
+	if aws.ToString(created.Service.CreatedBy) != "arn:aws:iam::123456789012:root" {
+		t.Fatalf("CreateService createdBy = %q, want account-root principal", aws.ToString(created.Service.CreatedBy))
+	}
+
+	desc, err := client.DescribeServices(ctx, &awsecs.DescribeServicesInput{
+		Cluster: aws.String("prod"), Services: []string{"web-svc"},
+	})
+	if err != nil {
+		t.Fatalf("DescribeServices: %v", err)
+	}
+
+	if len(desc.Services) != 1 {
+		t.Fatalf("DescribeServices returned %d services, want 1", len(desc.Services))
+	}
+
+	if aws.ToString(desc.Services[0].RoleArn) != roleARN {
+		t.Fatalf("DescribeServices roleArn = %q, want %q", aws.ToString(desc.Services[0].RoleArn), roleARN)
+	}
+
+	if aws.ToString(desc.Services[0].CreatedBy) != "arn:aws:iam::123456789012:root" {
+		t.Fatalf("DescribeServices createdBy = %q, want account-root principal", aws.ToString(desc.Services[0].CreatedBy))
+	}
+}

--- a/server/aws/ecs/taskdefs_test.go
+++ b/server/aws/ecs/taskdefs_test.go
@@ -1,0 +1,109 @@
+package ecs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+)
+
+// TestSDKTaskDefinitionCompatibilities guards the derived compatibilities and
+// requiresAttributes fields real ECS returns on a registered task definition
+// (distinct from the caller's requiresCompatibilities). An EC2 task def with
+// role ARNs must advertise EC2 compatibility and the docker-remote-api,
+// task-iam-role, and execution-role-ecr-pull required attributes; a Fargate-only
+// awsvpc def must advertise both FARGATE and EC2 compatibility and no attributes.
+func TestSDKTaskDefinitionCompatibilities(t *testing.T) {
+	client := newECSClient(t)
+	ctx := context.Background()
+
+	reg, err := client.RegisterTaskDefinition(ctx, &awsecs.RegisterTaskDefinitionInput{
+		Family: aws.String("ec2app"),
+		ContainerDefinitions: []ecstypes.ContainerDefinition{{
+			Name: aws.String("app"), Image: aws.String("app:latest"), Memory: aws.Int32(256),
+		}},
+		TaskRoleArn:      aws.String("arn:aws:iam::123456789012:role/task"),
+		ExecutionRoleArn: aws.String("arn:aws:iam::123456789012:role/exec"),
+	})
+	if err != nil {
+		t.Fatalf("RegisterTaskDefinition: %v", err)
+	}
+
+	td := reg.TaskDefinition
+
+	if !hasCompatibility(td.Compatibilities, ecstypes.CompatibilityEc2) {
+		t.Fatalf("compatibilities = %v, want EC2 present", td.Compatibilities)
+	}
+
+	if !hasRequiredAttr(td.RequiresAttributes, "com.amazonaws.ecs.capability.docker-remote-api.1.18") {
+		t.Fatalf("requiresAttributes = %v, want docker-remote-api", td.RequiresAttributes)
+	}
+
+	if !hasRequiredAttr(td.RequiresAttributes, "com.amazonaws.ecs.capability.task-iam-role") {
+		t.Fatalf("requiresAttributes = %v, want task-iam-role (TaskRoleArn set)", td.RequiresAttributes)
+	}
+
+	if !hasRequiredAttr(td.RequiresAttributes, "ecs.capability.execution-role-ecr-pull") {
+		t.Fatalf("requiresAttributes = %v, want execution-role-ecr-pull (ExecutionRoleArn set)", td.RequiresAttributes)
+	}
+
+	// A Fargate-only awsvpc def: FARGATE (derived) and EC2 (always) compatible,
+	// and no requiresAttributes.
+	fgReg, err := client.RegisterTaskDefinition(ctx, &awsecs.RegisterTaskDefinitionInput{
+		Family: aws.String("fgapp"),
+		ContainerDefinitions: []ecstypes.ContainerDefinition{{
+			Name: aws.String("app"), Image: aws.String("app:latest"),
+		}},
+		Cpu:                     aws.String("256"),
+		Memory:                  aws.String("512"),
+		NetworkMode:             ecstypes.NetworkModeAwsvpc,
+		RequiresCompatibilities: []ecstypes.Compatibility{ecstypes.CompatibilityFargate},
+	})
+	if err != nil {
+		t.Fatalf("RegisterTaskDefinition (fargate): %v", err)
+	}
+
+	fg := fgReg.TaskDefinition
+
+	if !hasCompatibility(fg.Compatibilities, ecstypes.CompatibilityFargate) {
+		t.Fatalf("fargate compatibilities = %v, want FARGATE present", fg.Compatibilities)
+	}
+
+	if len(fg.RequiresAttributes) != 0 {
+		t.Fatalf("fargate-only requiresAttributes = %v, want none", fg.RequiresAttributes)
+	}
+
+	// The derived fields must survive DescribeTaskDefinition too.
+	desc, err := client.DescribeTaskDefinition(ctx, &awsecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String("ec2app"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeTaskDefinition: %v", err)
+	}
+
+	if !hasCompatibility(desc.TaskDefinition.Compatibilities, ecstypes.CompatibilityEc2) {
+		t.Fatalf("describe compatibilities = %v, want EC2", desc.TaskDefinition.Compatibilities)
+	}
+}
+
+func hasCompatibility(list []ecstypes.Compatibility, want ecstypes.Compatibility) bool {
+	for _, c := range list {
+		if c == want {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasRequiredAttr(list []ecstypes.Attribute, name string) bool {
+	for i := range list {
+		if aws.ToString(list[i].Name) == name {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/aws/ecs/types.go
+++ b/server/aws/ecs/types.go
@@ -180,6 +180,8 @@ type wireTaskDef struct {
 	Memory                  string                     `json:"memory,omitempty"`
 	NetworkMode             string                     `json:"networkMode,omitempty"`
 	RequiresCompatibilities []string                   `json:"requiresCompatibilities,omitempty"`
+	Compatibilities         []string                   `json:"compatibilities,omitempty"`
+	RequiresAttributes      []wireAttribute            `json:"requiresAttributes,omitempty"`
 	TaskRoleArn             string                     `json:"taskRoleArn,omitempty"`
 	ExecutionRoleArn        string                     `json:"executionRoleArn,omitempty"`
 	Volumes                 []wireVolume               `json:"volumes,omitempty"`
@@ -338,6 +340,8 @@ type wireService struct {
 	ServiceName                   string                       `json:"serviceName"`
 	ClusterArn                    string                       `json:"clusterArn"`
 	TaskDefinition                string                       `json:"taskDefinition,omitempty"`
+	RoleArn                       string                       `json:"roleArn,omitempty"`
+	CreatedBy                     string                       `json:"createdBy,omitempty"`
 	DesiredCount                  int                          `json:"desiredCount"`
 	RunningCount                  int                          `json:"runningCount"`
 	PendingCount                  int                          `json:"pendingCount"`
@@ -1066,6 +1070,87 @@ func fromAccountSettings(in []driver.AccountSetting) []wireAccountSetting {
 	return out
 }
 
+// Launch-type and derived-attribute constants for the compatibilities and
+// requiresAttributes fields ECS derives (not stored) for a task definition.
+const (
+	launchTypeEC2      = "EC2"
+	launchTypeFargate  = "FARGATE"
+	launchTypeExternal = "EXTERNAL"
+	networkModeAwsvpc  = "awsvpc"
+
+	attrDockerRemoteAPI = "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+	attrTaskIAMRole     = "com.amazonaws.ecs.capability.task-iam-role"
+	attrExecRoleECRPull = "ecs.capability.execution-role-ecr-pull"
+)
+
+// deriveCompatibilities computes the launch types a task definition is
+// compatible with (distinct from the caller's requiresCompatibilities): EC2 is
+// always compatible, plus every explicitly required type, plus FARGATE when the
+// definition satisfies the Fargate requirements (awsvpc networking with task
+// cpu and memory). The result is emitted in a stable EC2, FARGATE, EXTERNAL order.
+func deriveCompatibilities(t *driver.TaskDefinition) []string {
+	set := map[string]bool{launchTypeEC2: true}
+	for _, c := range t.RequiresCompatibilities {
+		set[c] = true
+	}
+
+	if t.NetworkMode == networkModeAwsvpc && t.CPU != "" && t.Memory != "" {
+		set[launchTypeFargate] = true
+	}
+
+	out := make([]string, 0, len(set))
+
+	for _, lt := range []string{launchTypeEC2, launchTypeFargate, launchTypeExternal} {
+		if set[lt] {
+			out = append(out, lt)
+		}
+	}
+
+	return out
+}
+
+// isFargateOnly reports whether a task definition targets only Fargate, i.e. it
+// requires FARGATE and no EC2/EXTERNAL launch type. Such definitions carry no
+// requiresAttributes on the wire.
+func isFargateOnly(t *driver.TaskDefinition) bool {
+	requiresFargate := false
+
+	for _, c := range t.RequiresCompatibilities {
+		if c == launchTypeEC2 || c == launchTypeExternal {
+			return false
+		}
+
+		if c == launchTypeFargate {
+			requiresFargate = true
+		}
+	}
+
+	return requiresFargate
+}
+
+// deriveRequiresAttributes computes the minimal set of container-agent
+// attributes ECS reports a task definition requires. Fargate-only definitions
+// report none; others always require the docker-remote-api capability, plus the
+// task-iam-role / execution-role-ecr-pull capabilities when the corresponding
+// role ARNs are set.
+func deriveRequiresAttributes(t *driver.TaskDefinition) []wireAttribute {
+	if isFargateOnly(t) {
+		return nil
+	}
+
+	attrs := []wireAttribute{{Name: attrDockerRemoteAPI}}
+
+	if t.TaskRoleARN != "" {
+		attrs = append(attrs, wireAttribute{Name: attrTaskIAMRole})
+	}
+
+	if t.ExecutionRoleARN != "" {
+		attrs = append(attrs, wireAttribute{Name: attrExecRoleECRPull})
+	}
+
+	return attrs
+}
+
 func taskDefToWire(t *driver.TaskDefinition) wireTaskDef {
 	return wireTaskDef{
 		TaskDefinitionArn:       t.ARN,
@@ -1077,6 +1162,8 @@ func taskDefToWire(t *driver.TaskDefinition) wireTaskDef {
 		Memory:                  t.Memory,
 		NetworkMode:             t.NetworkMode,
 		RequiresCompatibilities: t.RequiresCompatibilities,
+		Compatibilities:         deriveCompatibilities(t),
+		RequiresAttributes:      deriveRequiresAttributes(t),
 		TaskRoleArn:             t.TaskRoleARN,
 		ExecutionRoleArn:        t.ExecutionRoleARN,
 		Volumes:                 fromVolumes(t.Volumes),
@@ -1165,6 +1252,8 @@ func serviceToWire(s *driver.Service) wireService {
 		ServiceName:                   s.Name,
 		ClusterArn:                    s.ClusterARN,
 		TaskDefinition:                s.TaskDefinition,
+		RoleArn:                       s.RoleARN,
+		CreatedBy:                     s.CreatedBy,
 		DesiredCount:                  s.DesiredCount,
 		RunningCount:                  s.RunningCount,
 		PendingCount:                  s.PendingCount,

--- a/server/aws/eks/nodegroup_health_test.go
+++ b/server/aws/eks/nodegroup_health_test.go
@@ -1,0 +1,93 @@
+package eks_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+)
+
+// TestSDKEKSNodegroupHealthAndResources guards the wire fidelity of a
+// nodegroup's health and resources blocks: real EKS always returns a (non-nil,
+// empty-when-healthy) health.issues list and a resources.autoScalingGroups list
+// naming at least one managed ASG. The ASG name must be stable across Describe.
+func TestSDKEKSNodegroupHealthAndResources(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awseks.CreateClusterInput{
+		Name:               aws.String("c1"),
+		RoleArn:            aws.String("arn:aws:iam::1:role/r"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{SubnetIds: []string{"subnet-1"}},
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	created, err := client.CreateNodegroup(ctx, &awseks.CreateNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+		NodeRole:      aws.String("arn:aws:iam::1:role/r"),
+		Subnets:       []string{"subnet-1"},
+	})
+	if err != nil {
+		t.Fatalf("CreateNodegroup: %v", err)
+	}
+
+	assertNodegroupHealthResources(t, created.Nodegroup)
+
+	got, err := client.DescribeNodegroup(ctx, &awseks.DescribeNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeNodegroup: %v", err)
+	}
+
+	assertNodegroupHealthResources(t, got.Nodegroup)
+
+	// The synthetic ASG name must be deterministic: create and describe agree.
+	if createdASG(created.Nodegroup) != createdASG(got.Nodegroup) {
+		t.Fatalf("ASG name not stable: create=%q describe=%q",
+			createdASG(created.Nodegroup), createdASG(got.Nodegroup))
+	}
+}
+
+func assertNodegroupHealthResources(t *testing.T, ng *ekstypes.Nodegroup) {
+	t.Helper()
+
+	if ng.Health == nil {
+		t.Fatal("expected non-nil health block")
+	}
+
+	if ng.Health.Issues == nil {
+		t.Fatal("expected non-nil (empty) health.issues for a healthy nodegroup")
+	}
+
+	if len(ng.Health.Issues) != 0 {
+		t.Fatalf("expected no health issues, got %+v", ng.Health.Issues)
+	}
+
+	if ng.Resources == nil {
+		t.Fatal("expected non-nil resources block")
+	}
+
+	if len(ng.Resources.AutoScalingGroups) != 1 {
+		t.Fatalf("expected exactly one managed ASG, got %+v", ng.Resources.AutoScalingGroups)
+	}
+
+	name := createdASG(ng)
+	if !strings.HasPrefix(name, "eks-ng1-") {
+		t.Fatalf("ASG name = %q, want eks-ng1-<uuid>", name)
+	}
+}
+
+func createdASG(ng *ekstypes.Nodegroup) string {
+	if ng.Resources == nil || len(ng.Resources.AutoScalingGroups) == 0 {
+		return ""
+	}
+
+	return aws.ToString(ng.Resources.AutoScalingGroups[0].Name)
+}

--- a/server/aws/eks/operations.go
+++ b/server/aws/eks/operations.go
@@ -1,6 +1,8 @@
 package eks
 
 import (
+	"crypto/sha1" //nolint:gosec // used only for a deterministic, non-security id
+	"encoding/hex"
 	"math"
 	"net/http"
 	"strconv"
@@ -604,7 +606,28 @@ func toNodegroupJSON(n *eksdriver.Nodegroup) nodegroupJSON {
 		out.DiskSize = &disk
 	}
 
+	// Real EKS always reports a health block (empty issues when healthy) and a
+	// resources block naming at least one managed Auto Scaling group. The mock
+	// synthesizes both deterministically so Describe is stable across calls.
+	out.Health = &nodegroupHealthJSON{Issues: []nodegroupIssueJSON{}}
+	out.Resources = &nodegroupResourcesJSON{
+		AutoScalingGroups: []autoScalingGroupJSON{{Name: syntheticNodegroupASG(n.ClusterName, n.NodegroupName)}},
+	}
+
 	return out
+}
+
+// syntheticNodegroupASG builds the deterministic Auto Scaling group name EKS
+// provisions for a managed nodegroup ("eks-<nodegroup>-<uuid>"). The uuid-shaped
+// suffix is derived from the cluster+nodegroup so it stays stable across
+// Describe calls without any provider state.
+func syntheticNodegroupASG(clusterName, nodegroupName string) string {
+	sum := sha1.Sum([]byte(clusterName + "/" + nodegroupName)) //nolint:gosec // non-cryptographic deterministic id
+	h := hex.EncodeToString(sum[:])
+
+	uuid := h[0:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+
+	return "eks-" + nodegroupName + "-" + uuid
 }
 
 func toFargateProfileJSON(fp *eksdriver.FargateProfile) fargateProfileJSON {

--- a/server/aws/eks/types.go
+++ b/server/aws/eks/types.go
@@ -84,7 +84,34 @@ type nodegroupJSON struct {
 	NodeRole       string                      `json:"nodeRole,omitempty"`
 	Labels         map[string]string           `json:"labels,omitempty"`
 	DiskSize       *int32                      `json:"diskSize,omitempty"`
+	Health         *nodegroupHealthJSON        `json:"health,omitempty"`
+	Resources      *nodegroupResourcesJSON     `json:"resources,omitempty"`
 	Tags           map[string]string           `json:"tags,omitempty"`
+}
+
+// nodegroupHealthJSON carries a nodegroup's health issues. A healthy nodegroup
+// reports an empty (but non-nil) issues list, matching real EKS.
+type nodegroupHealthJSON struct {
+	Issues []nodegroupIssueJSON `json:"issues"`
+}
+
+// nodegroupIssueJSON is one health issue on a nodegroup.
+type nodegroupIssueJSON struct {
+	Code        string   `json:"code,omitempty"`
+	Message     string   `json:"message,omitempty"`
+	ResourceIDs []string `json:"resourceIds,omitempty"`
+}
+
+// nodegroupResourcesJSON describes the managed resources EKS provisions for a
+// nodegroup: at least one Auto Scaling group and an optional remote-access SG.
+type nodegroupResourcesJSON struct {
+	AutoScalingGroups         []autoScalingGroupJSON `json:"autoScalingGroups,omitempty"`
+	RemoteAccessSecurityGroup string                 `json:"remoteAccessSecurityGroup,omitempty"`
+}
+
+// autoScalingGroupJSON names one Auto Scaling group backing a nodegroup.
+type autoScalingGroupJSON struct {
+	Name string `json:"name"`
 }
 
 // fargateProfileSelectorJSON matches Pods to a Fargate profile.

--- a/server/aws/memorydb/catalogs_tags_test.go
+++ b/server/aws/memorydb/catalogs_tags_test.go
@@ -1,0 +1,50 @@
+package memorydb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsmemorydb "github.com/aws/aws-sdk-go-v2/service/memorydb"
+	mdbtypes "github.com/aws/aws-sdk-go-v2/service/memorydb/types"
+)
+
+// TestSDKListTagsReturnsCreateTimeTags guards that tags supplied at CreateCluster
+// are addressable by ListTags(arn). They previously lived only on the cluster
+// record and stayed invisible to ListTags until a later TagResource call.
+func TestSDKListTagsReturnsCreateTimeTags(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateCluster(ctx, &awsmemorydb.CreateClusterInput{
+		ClusterName: aws.String("tagged"),
+		NodeType:    aws.String("db.r6g.large"),
+		ACLName:     aws.String("open-access"),
+		Tags: []mdbtypes.Tag{
+			{Key: aws.String("env"), Value: aws.String("prod")},
+			{Key: aws.String("team"), Value: aws.String("orders")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	arn := aws.ToString(created.Cluster.ARN)
+	if arn == "" {
+		t.Fatal("CreateCluster returned empty ARN")
+	}
+
+	out, err := client.ListTags(ctx, &awsmemorydb.ListTagsInput{ResourceArn: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("ListTags: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, tag := range out.TagList {
+		got[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+	}
+
+	if got["env"] != "prod" || got["team"] != "orders" {
+		t.Fatalf("ListTags = %+v, want create-time tags env=prod team=orders", got)
+	}
+}

--- a/services/ecs/driver/driver.go
+++ b/services/ecs/driver/driver.go
@@ -392,6 +392,8 @@ type Service struct {
 	Name                          string
 	ClusterARN                    string
 	TaskDefinition                string
+	RoleARN                       string
+	CreatedBy                     string
 	DesiredCount                  int
 	RunningCount                  int
 	PendingCount                  int
@@ -493,6 +495,7 @@ type CreateServiceInput struct {
 	TaskDefinition                string
 	DesiredCount                  int
 	LaunchType                    string
+	Role                          string
 	SchedulingStrategy            string
 	DeploymentController          string
 	PlatformVersion               string


### PR DESCRIPTION
Container-service wire fidelity per AWS docs: ECR registryId on lifecycle/repo responses; EKS Nodegroup health/resources + real-shaped endpoint; ECS RegisterTaskDefinition requiresAttributes/compatibilities + CreateService fields; MemoryDB create-time tags. compat suite clean; SDK tests per fix.