### PR TITLE
fix(vpc): DeleteVpc DependencyViolation scan + auto-created default security group

### DIFF
--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -21,6 +21,13 @@ const (
 	defaultFlowLogRecordLimit = 10
 )
 
+// Default security group identity. EC2 gives every VPC a group named "default"
+// with this exact description; users can edit its rules but not delete it.
+const (
+	defaultSGName        = "default"
+	defaultSGDescription = "default VPC security group"
+)
+
 // Compile-time checks. The optional capabilities are asserted too: without
 // this a signature drifting out of shape would silently stop satisfying the
 // interface and every call would answer InvalidAction at runtime instead of
@@ -166,6 +173,9 @@ type sgData struct {
 	IngressRules []driver.SecurityRule
 	EgressRules  []driver.SecurityRule
 	Tags         map[string]string
+	// IsDefault marks the group EC2 auto-creates with every VPC. It cannot be
+	// deleted on its own (Client.CannotDelete) and disappears with the VPC.
+	IsDefault bool
 }
 
 // New creates a new VPC mock with the given configuration options.
@@ -254,12 +264,36 @@ func (m *Mock) CreateVPC(_ context.Context, cfg driver.VPCConfig) (*driver.VPCIn
 	m.vpcs.Set(id, v)
 
 	m.createMainRouteTable(id, cfg.CIDRBlock)
+	m.createDefaultSecurityGroup(id)
 
 	m.mu.RLock()
 	info := toVPCInfo(v)
 	m.mu.RUnlock()
 
 	return &info, nil
+}
+
+// createDefaultSecurityGroup gives the new VPC the group EC2 auto-creates for
+// it: name "default", an allow-all egress rule, and a self-referencing ingress
+// rule that permits all traffic between members of the group. The group cannot
+// be deleted directly and is removed when the VPC is deleted.
+func (m *Mock) createDefaultSecurityGroup(vpcID string) {
+	id := idgen.GenerateID("sg-")
+
+	m.securityGroups.Set(id, &sgData{
+		ID:          id,
+		Name:        defaultSGName,
+		Description: defaultSGDescription,
+		VPCID:       vpcID,
+		IsDefault:   true,
+		IngressRules: []driver.SecurityRule{{
+			Protocol:          allTrafficProtocol,
+			ReferencedGroupID: id,
+			RuleID:            idgen.GenerateID("sgr-"),
+		}},
+		EgressRules: []driver.SecurityRule{newDefaultEgressRule()},
+		Tags:        map[string]string{},
+	})
 }
 
 // createMainRouteTable gives the new VPC the route table EC2 creates for it,
@@ -308,10 +342,27 @@ func (m *Mock) DeleteVPC(_ context.Context, id string) error {
 			"DependencyViolation: network interface %q is still attached in vpc %q", eni, id)
 	}
 
-	m.vpcs.Delete(id)
+	// Real EC2 refuses the delete while user-managed dependencies remain and
+	// auto-removes the ones it created (main route table, default security
+	// group). An active peering connection does not block — it is deleted with
+	// the VPC — so it is deliberately absent from the dependency scan.
+	if dep, blocked := m.vpcDependency(id); blocked {
+		return errors.Newf(errors.FailedPrecondition,
+			"DependencyViolation: the vpc %q has dependencies and cannot be deleted (%s)", id, dep)
+	}
 
+	m.vpcs.Delete(id)
+	m.deleteMainRouteTable(id)
+	m.deleteDefaultSecurityGroup(id)
+	m.markVPCPeeringsDeleted(id)
+
+	return nil
+}
+
+// deleteMainRouteTable removes the VPC's main route table and its association.
+func (m *Mock) deleteMainRouteTable(vpcID string) {
 	for rtID, rt := range m.routeTables.All() {
-		if rt.VPCID != id || !rt.IsMain {
+		if rt.VPCID != vpcID || !rt.IsMain {
 			continue
 		}
 
@@ -323,8 +374,91 @@ func (m *Mock) DeleteVPC(_ context.Context, id string) error {
 			}
 		}
 	}
+}
 
-	return nil
+// deleteDefaultSecurityGroup removes the group EC2 auto-created with the VPC.
+func (m *Mock) deleteDefaultSecurityGroup(vpcID string) {
+	for sgID, sg := range m.securityGroups.All() {
+		if sg.VPCID == vpcID && sg.IsDefault {
+			m.securityGroups.Delete(sgID)
+		}
+	}
+}
+
+// markVPCPeeringsDeleted transitions any peering that referenced the VPC to
+// deleted, mirroring real EC2's Deleting -> Deleted cascade. Peering never
+// blocks the delete, so this runs after the VPC is gone.
+func (m *Mock) markVPCPeeringsDeleted(vpcID string) {
+	for _, p := range m.peerings.All() {
+		if p.RequesterVPC == vpcID || p.AccepterVPC == vpcID {
+			p.Status = PeeringStatusDeleted
+		}
+	}
+}
+
+// vpcDependency reports the first user-managed resource that blocks deleting
+// the VPC, in the order real EC2 surfaces them. The main route table, the
+// default security group, and the default network ACL are excluded because EC2
+// removes them with the VPC; active peering connections are excluded because
+// they are deleted alongside it. Live NAT gateways, running instances, and
+// interface endpoints are already caught by the attached-ENI check in DeleteVPC.
+func (m *Mock) vpcDependency(id string) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, s := range m.subnets.All() {
+		if s.VPCID == id {
+			return "subnet " + s.ID, true
+		}
+	}
+
+	for _, sg := range m.securityGroups.All() {
+		if sg.VPCID == id && !sg.IsDefault {
+			return "security group " + sg.ID, true
+		}
+	}
+
+	if dep, blocked := m.vpcRoutingDependency(id); blocked {
+		return dep, true
+	}
+
+	return m.vpcGatewayDependency(id)
+}
+
+// vpcRoutingDependency reports a blocking non-main route table or non-default
+// network ACL in the VPC.
+func (m *Mock) vpcRoutingDependency(id string) (string, bool) {
+	for _, rt := range m.routeTables.All() {
+		if rt.VPCID == id && !rt.IsMain {
+			return "route table " + rt.ID, true
+		}
+	}
+
+	for _, acl := range m.networkACLs.All() {
+		if acl.VPCID == id && !acl.IsDefault {
+			return "network ACL " + acl.ID, true
+		}
+	}
+
+	return "", false
+}
+
+// vpcGatewayDependency reports a blocking attached internet gateway or VPC
+// endpoint (gateway endpoints hold no ENI, so they need an explicit scan).
+func (m *Mock) vpcGatewayDependency(id string) (string, bool) {
+	for _, igw := range m.igws.All() {
+		if igw.VpcID == id && igw.State == IGWStateAttached {
+			return "internet gateway " + igw.ID, true
+		}
+	}
+
+	for _, ep := range m.endpoints.All() {
+		if ep.VPCID == id {
+			return "vpc endpoint " + ep.ID, true
+		}
+	}
+
+	return "", false
 }
 
 // DescribeVPCs returns VPCs matching the given IDs, or all VPCs if ids is empty.
@@ -551,11 +685,21 @@ func (m *Mock) CreateSecurityGroup(_ context.Context, cfg driver.SecurityGroupCo
 	return &info, nil
 }
 
-// DeleteSecurityGroup deletes the security group with the given ID.
+// DeleteSecurityGroup deletes the security group with the given ID. The group
+// EC2 auto-creates for a VPC cannot be deleted directly; real EC2 answers
+// Client.CannotDelete, which the wire layer maps from this FailedPrecondition.
 func (m *Mock) DeleteSecurityGroup(_ context.Context, id string) error {
-	if !m.securityGroups.Delete(id) {
+	sg, ok := m.securityGroups.Get(id)
+	if !ok {
 		return errors.Newf(errors.NotFound, "security group %q not found", id)
 	}
+
+	if sg.IsDefault {
+		return errors.Newf(errors.FailedPrecondition,
+			"CannotDelete: default security group %q cannot be deleted", id)
+	}
+
+	m.securityGroups.Delete(id)
 
 	return nil
 }

--- a/providers/aws/vpc/vpc_test.go
+++ b/providers/aws/vpc/vpc_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
@@ -207,6 +208,185 @@ func TestDeleteSecurityGroup(t *testing.T) {
 	assertError(t, m.DeleteSecurityGroup(context.Background(), "sg-nope"), true)
 }
 
+// defaultSG returns the auto-created "default" security group for a VPC.
+func defaultSG(t *testing.T, m *Mock, vpcID string) driver.SecurityGroupInfo {
+	t.Helper()
+
+	sgs, err := m.DescribeSecurityGroups(context.Background(), nil)
+	requireNoError(t, err)
+
+	for _, sg := range sgs {
+		if sg.VPCID == vpcID && sg.Name == defaultSGName {
+			return sg
+		}
+	}
+
+	t.Fatalf("vpc %s has no default security group: %+v", vpcID, sgs)
+
+	return driver.SecurityGroupInfo{}
+}
+
+// TestCreateVPCCreatesDefaultSecurityGroup pins the group EC2 auto-creates with
+// every VPC: name "default", allow-all egress, and a self-referencing ingress
+// rule permitting all traffic between members of the group (no CIDR ingress).
+func TestCreateVPCCreatesDefaultSecurityGroup(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+
+	sgs, err := m.DescribeSecurityGroups(ctx, nil)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(sgs))
+
+	sg := defaultSG(t, m, v.ID)
+	assertEqual(t, defaultSGName, sg.Name)
+	assertEqual(t, "default VPC security group", sg.Description)
+	assertEqual(t, v.ID, sg.VPCID)
+
+	assertEqual(t, 1, len(sg.EgressRules))
+	assertEqual(t, "-1", sg.EgressRules[0].Protocol)
+	assertEqual(t, "0.0.0.0/0", sg.EgressRules[0].CIDR)
+
+	assertEqual(t, 1, len(sg.IngressRules))
+	assertEqual(t, "-1", sg.IngressRules[0].Protocol)
+	assertEqual(t, "", sg.IngressRules[0].CIDR)
+	assertEqual(t, sg.ID, sg.IngressRules[0].ReferencedGroupID)
+}
+
+// TestDefaultSecurityGroupCannotBeDeleted pins Client.CannotDelete semantics:
+// the default group refuses a direct delete with FailedPrecondition.
+func TestDefaultSecurityGroupCannotBeDeleted(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+
+	sg := defaultSG(t, m, v.ID)
+
+	err := m.DeleteSecurityGroup(ctx, sg.ID)
+	assertError(t, err, true)
+
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("want FailedPrecondition, got %v", err)
+	}
+}
+
+// TestDeleteVPCRemovesDefaultSecurityGroup pins the cascade: the default group
+// disappears with the VPC rather than stranding an undeletable row.
+func TestDeleteVPCRemovesDefaultSecurityGroup(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+
+	requireNoError(t, m.DeleteVPC(ctx, v.ID))
+
+	sgs, err := m.DescribeSecurityGroups(ctx, nil)
+	requireNoError(t, err)
+	assertEqual(t, 0, len(sgs))
+}
+
+// TestDeleteVPCBlocksOnDependencies walks the resource types real EC2 refuses to
+// delete a VPC around: each one blocks with DependencyViolation, and removing it
+// lets the delete proceed. The auto-created default SG never blocks.
+func TestDeleteVPCBlocksOnDependencies(t *testing.T) {
+	ctx := context.Background()
+
+	assertBlocks := func(t *testing.T, m *Mock, vpcID string) {
+		t.Helper()
+
+		err := m.DeleteVPC(ctx, vpcID)
+		assertError(t, err, true)
+
+		if !cerrors.IsFailedPrecondition(err) {
+			t.Fatalf("want FailedPrecondition (DependencyViolation), got %v", err)
+		}
+	}
+
+	t.Run("subnet", func(t *testing.T) {
+		m := newTestMock()
+		v := createTestVPC(m)
+
+		sub, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+		requireNoError(t, err)
+
+		assertBlocks(t, m, v.ID)
+		requireNoError(t, m.DeleteSubnet(ctx, sub.ID))
+		requireNoError(t, m.DeleteVPC(ctx, v.ID))
+	})
+
+	t.Run("non-default security group", func(t *testing.T) {
+		m := newTestMock()
+		v := createTestVPC(m)
+
+		sg, err := m.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{Name: "app", VPCID: v.ID})
+		requireNoError(t, err)
+
+		assertBlocks(t, m, v.ID)
+		requireNoError(t, m.DeleteSecurityGroup(ctx, sg.ID))
+		requireNoError(t, m.DeleteVPC(ctx, v.ID))
+	})
+
+	t.Run("non-main route table", func(t *testing.T) {
+		m := newTestMock()
+		v := createTestVPC(m)
+
+		rt, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: v.ID})
+		requireNoError(t, err)
+
+		assertBlocks(t, m, v.ID)
+		requireNoError(t, m.DeleteRouteTable(ctx, rt.ID))
+		requireNoError(t, m.DeleteVPC(ctx, v.ID))
+	})
+
+	t.Run("network ACL", func(t *testing.T) {
+		m := newTestMock()
+		v := createTestVPC(m)
+
+		acl, err := m.CreateNetworkACL(ctx, v.ID, nil)
+		requireNoError(t, err)
+
+		assertBlocks(t, m, v.ID)
+		requireNoError(t, m.DeleteNetworkACL(ctx, acl.ID))
+		requireNoError(t, m.DeleteVPC(ctx, v.ID))
+	})
+
+	t.Run("attached internet gateway", func(t *testing.T) {
+		m := newTestMock()
+		v := createTestVPC(m)
+
+		igw, err := m.CreateInternetGateway(ctx, driver.InternetGatewayConfig{})
+		requireNoError(t, err)
+		requireNoError(t, m.AttachInternetGateway(ctx, igw.ID, v.ID))
+
+		assertBlocks(t, m, v.ID)
+		requireNoError(t, m.DetachInternetGateway(ctx, igw.ID, v.ID))
+		requireNoError(t, m.DeleteVPC(ctx, v.ID))
+	})
+}
+
+// TestDeleteVPCNotBlockedByActivePeering pins the real-EC2 rule that an active
+// peering connection is deleted alongside the VPC and never blocks the delete.
+func TestDeleteVPCNotBlockedByActivePeering(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	a := createTestVPC(m)
+
+	b, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.1.0.0/16"})
+	requireNoError(t, err)
+
+	p, err := m.CreatePeeringConnection(ctx, driver.PeeringConfig{RequesterVPC: a.ID, AccepterVPC: b.ID})
+	requireNoError(t, err)
+	requireNoError(t, m.AcceptPeeringConnection(ctx, p.ID))
+
+	// The active peering does not block the delete; it transitions to deleted.
+	requireNoError(t, m.DeleteVPC(ctx, a.ID))
+
+	peers, err := m.DescribePeeringConnections(ctx, []string{p.ID})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(peers))
+	assertEqual(t, PeeringStatusDeleted, peers[0].Status)
+}
+
 func TestDescribeSecurityGroups(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
@@ -217,7 +397,8 @@ func TestDescribeSecurityGroups(t *testing.T) {
 	t.Run("all", func(t *testing.T) {
 		sgs, err := m.DescribeSecurityGroups(ctx, nil)
 		requireNoError(t, err)
-		assertEqual(t, 2, len(sgs))
+		// sg1 + sg2 + the VPC's auto-created default security group.
+		assertEqual(t, 3, len(sgs))
 	})
 
 	t.Run("by ID", func(t *testing.T) {

--- a/server/aws/ec2/security_group.go
+++ b/server/aws/ec2/security_group.go
@@ -185,7 +185,15 @@ func (h *Handler) deleteSecurityGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.vpc.DeleteSecurityGroup(r.Context(), id); err != nil {
+		// The default security group is non-deletable: EC2 answers a distinct
+		// Client.CannotDelete code rather than the generic DependencyViolation.
+		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "CannotDelete:") {
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "Client.CannotDelete", err.Error())
+			return
+		}
+
 		writeSGErr(w, err)
+
 		return
 	}
 

--- a/server/aws/ec2/security_group_test.go
+++ b/server/aws/ec2/security_group_test.go
@@ -2,6 +2,7 @@ package ec2_test
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
 
 	"github.com/stackshy/cloudemu/v2"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
@@ -46,6 +48,57 @@ func createSGTestVPC(t *testing.T, ctx context.Context, c *ec2.Client, cidr stri
 	}
 
 	return aws.ToString(out.Vpc.VpcId)
+}
+
+// TestDefaultSecurityGroupOverWire pins that a freshly-created VPC surfaces its
+// auto-created "default" group on DescribeSecurityGroups — allow-all egress and
+// a self-referencing ingress rule (UserIdGroupPairs) — and that the group is
+// non-deletable, answering Client.CannotDelete just like real EC2.
+func TestDefaultSecurityGroupOverWire(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	vpcID := createSGTestVPC(t, ctx, c, "10.0.0.0/16")
+
+	out, err := c.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSecurityGroups: %v", err)
+	}
+
+	if len(out.SecurityGroups) != 1 {
+		t.Fatalf("new VPC = %d security groups, want 1 (default)", len(out.SecurityGroups))
+	}
+
+	sg := out.SecurityGroups[0]
+	if aws.ToString(sg.GroupName) != "default" {
+		t.Fatalf("GroupName = %q, want default", aws.ToString(sg.GroupName))
+	}
+
+	if aws.ToString(sg.Description) != "default VPC security group" {
+		t.Fatalf("Description = %q, want default VPC security group", aws.ToString(sg.Description))
+	}
+
+	if len(sg.IpPermissionsEgress) != 1 || aws.ToString(sg.IpPermissionsEgress[0].IpProtocol) != "-1" ||
+		len(sg.IpPermissionsEgress[0].IpRanges) != 1 ||
+		aws.ToString(sg.IpPermissionsEgress[0].IpRanges[0].CidrIp) != "0.0.0.0/0" {
+		t.Fatalf("egress = %+v, want single allow-all 0.0.0.0/0", sg.IpPermissionsEgress)
+	}
+
+	if len(sg.IpPermissions) != 1 || len(sg.IpPermissions[0].UserIdGroupPairs) != 1 ||
+		aws.ToString(sg.IpPermissions[0].UserIdGroupPairs[0].GroupId) != aws.ToString(sg.GroupId) {
+		t.Fatalf("ingress = %+v, want single self-referencing UserIdGroupPair", sg.IpPermissions)
+	}
+
+	_, err = c.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{GroupId: sg.GroupId})
+	if err == nil {
+		t.Fatal("deleting the default security group should be refused")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "Client.CannotDelete" {
+		t.Fatalf("delete error = %v, want Client.CannotDelete", err)
+	}
 }
 
 // TestCreateSecurityGroupReturnsTags pins that CreateSecurityGroup echoes the
@@ -146,8 +199,23 @@ func TestDescribeSecurityGroupsFilters(t *testing.T) {
 		t.Fatalf("DescribeSecurityGroups vpc-id: %v", err)
 	}
 
-	if len(byVPC.SecurityGroups) != 1 || aws.ToString(byVPC.SecurityGroups[0].GroupName) != "app-a" {
-		t.Fatalf("vpc-id filter = %d groups, want only app-a", len(byVPC.SecurityGroups))
+	// vpcA holds its auto-created "default" group plus app-a.
+	if len(byVPC.SecurityGroups) != 2 {
+		t.Fatalf("vpc-id filter = %d groups, want 2 (default + app-a)", len(byVPC.SecurityGroups))
+	}
+
+	var haveAppA, haveDefault bool
+	for _, sg := range byVPC.SecurityGroups {
+		switch aws.ToString(sg.GroupName) {
+		case "app-a":
+			haveAppA = true
+		case "default":
+			haveDefault = true
+		}
+	}
+
+	if !haveAppA || !haveDefault {
+		t.Fatalf("vpc-id filter groups = %+v, want default + app-a", byVPC.SecurityGroups)
 	}
 
 	byName, err := c.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{

--- a/services/resourcediscovery/engine_test.go
+++ b/services/resourcediscovery/engine_test.go
@@ -214,6 +214,10 @@ func TestARNShapes(t *testing.T) {
 		case TypeFunction:
 			// Lambda mock builds its own ARN; we just require non-empty.
 			assert.NotEmpty(t, r.ARN)
+		case TypeSecurityGroup:
+			// Every VPC surfaces its auto-created default security group.
+			assert.True(t, strings.HasPrefix(r.ARN, "arn:aws:ec2:us-east-1:123456789012:security-group/"),
+				"unexpected security group ARN: %s", r.ARN)
 		case TypeRouteTable:
 			assert.True(t, strings.HasPrefix(r.ARN, "arn:aws:ec2:us-east-1:123456789012:route-table/"),
 				"unexpected route table ARN: %s", r.ARN)


### PR DESCRIPTION
Two coupled VPC-teardown fixes, researched against official AWS docs (API_DeleteVpc + default-security-group user guide), provider-layer (wire already maps FailedPrecondition→DependencyViolation).

**DeleteVpc DependencyViolation:** DeleteVPC now blocks (DependencyViolation/400) on subnets, non-default SGs, non-main route tables, non-default NACLs, attached IGWs, VPC endpoints — while keeping the existing attached-ENI check (covers live NAT gateways/instances) and **NOT** blocking on active VPC peering (real AWS auto-deletes it; the compat suite deletes a VPC with active peering and must succeed — verified green). Main RT + default SG are cascaded on delete.

**Default security group:** CreateVPC now auto-creates the 'default' SG (description 'default VPC security group', allow-all egress, self-referencing ingress via ReferencedGroupID); it cannot be user-deleted (→ Client.CannotDelete) and is cascaded on VPC delete. Count-assertion tests updated to real AWS behavior (a VPC now has its default SG).

No shared driver interface method changed. compat suite + coverage docs clean. SDK + provider tests per behavior.