### PR TITLE
fix(ec2): security-group rule tagging (sgr-) + tag/tag-key filters

### DIFF
--- a/providers/aws/vpc/tags.go
+++ b/providers/aws/vpc/tags.go
@@ -61,7 +61,41 @@ func (m *Mock) mutateResourceTags(id string, transform func(map[string]string) m
 			v.Tags = transform(v.Tags)
 			return v
 		})
+	case strings.HasPrefix(id, "sgr-"):
+		return m.mutateRuleTags(id, transform)
 	default:
 		return false
 	}
+}
+
+// mutateRuleTags applies transform to the tag map of the ingress/egress rule
+// whose RuleID equals id, mutating it by slice index under the owning group's
+// store lock (rules live by value inside sgData). It reports whether a rule
+// with that id was found.
+func (m *Mock) mutateRuleTags(id string, transform func(map[string]string) map[string]string) bool {
+	found := false
+
+	for _, groupID := range m.securityGroups.Keys() {
+		if m.securityGroups.Update(groupID, func(sg *sgData) *sgData {
+			for i := range sg.IngressRules {
+				if sg.IngressRules[i].RuleID == id {
+					sg.IngressRules[i].Tags = transform(sg.IngressRules[i].Tags)
+					found = true
+				}
+			}
+
+			for i := range sg.EgressRules {
+				if sg.EgressRules[i].RuleID == id {
+					sg.EgressRules[i].Tags = transform(sg.EgressRules[i].Tags)
+					found = true
+				}
+			}
+
+			return sg
+		}) && found {
+			return true
+		}
+	}
+
+	return false
 }

--- a/providers/aws/vpc/tags_test.go
+++ b/providers/aws/vpc/tags_test.go
@@ -45,6 +45,49 @@ func TestNetworkResourceTagger(t *testing.T) {
 	}
 }
 
+// TestSecurityGroupRuleTagger covers tagging a security-group rule by its sgr-
+// id through the optional NetworkResourceTagger interface: the tag lands on the
+// owning rule, delete removes the key, and an unknown sgr- id is NotFound.
+func TestSecurityGroupRuleTagger(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	v := createTestVPC(m)
+
+	sg, err := m.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{Name: "sg", Description: "sg", VPCID: v.ID})
+	requireNoError(t, err)
+
+	requireNoError(t, m.AddIngressRule(ctx, sg.ID, driver.SecurityRule{
+		Protocol: "tcp", FromPort: 443, ToPort: 443, CIDR: "0.0.0.0/0", RuleID: "sgr-abc123",
+	}))
+
+	requireNoError(t, m.UpdateResourceTags(ctx, "sgr-abc123", map[string]string{"env": "prod"}))
+	assertEqual(t, "prod", securityGroupRuleTag(t, m, sg.ID, "sgr-abc123", "env"))
+
+	requireNoError(t, m.RemoveResourceTags(ctx, "sgr-abc123", []string{"env"}))
+	assertEqual(t, "", securityGroupRuleTag(t, m, sg.ID, "sgr-abc123", "env"))
+
+	if err := m.UpdateResourceTags(ctx, "sgr-missing", map[string]string{"k": "v"}); !isNotFound(err) {
+		t.Fatalf("UpdateResourceTags on missing sgr- id = %v, want NotFound", err)
+	}
+}
+
+func securityGroupRuleTag(t *testing.T, m *Mock, groupID, ruleID, key string) string {
+	t.Helper()
+
+	sgs, err := m.DescribeSecurityGroups(context.Background(), []string{groupID})
+	requireNoError(t, err)
+
+	for i := range sgs[0].IngressRules {
+		if sgs[0].IngressRules[i].RuleID == ruleID {
+			return sgs[0].IngressRules[i].Tags[key]
+		}
+	}
+
+	t.Fatalf("rule %s not found in group %s", ruleID, groupID)
+
+	return ""
+}
+
 func routeTableTag(t *testing.T, m *Mock, id, key string) string {
 	t.Helper()
 

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -274,7 +274,7 @@ func (m *Mock) RemoveIngressRule(_ context.Context, groupID string, rule driver.
 	}
 
 	for i, r := range sg.IngressRules {
-		if r == rule {
+		if r.Equal(&rule) {
 			sg.IngressRules = append(sg.IngressRules[:i], sg.IngressRules[i+1:]...)
 			return nil
 		}
@@ -291,7 +291,7 @@ func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.S
 	}
 
 	for i, r := range sg.EgressRules {
-		if r == rule {
+		if r.Equal(&rule) {
 			sg.EgressRules = append(sg.EgressRules[:i], sg.EgressRules[i+1:]...)
 			return nil
 		}

--- a/providers/gcp/vpc/vpc.go
+++ b/providers/gcp/vpc/vpc.go
@@ -272,7 +272,7 @@ func (m *Mock) RemoveIngressRule(_ context.Context, groupID string, rule driver.
 	}
 
 	for i, r := range sg.IngressRules {
-		if r == rule {
+		if r.Equal(&rule) {
 			sg.IngressRules = append(sg.IngressRules[:i], sg.IngressRules[i+1:]...)
 
 			return nil
@@ -290,7 +290,7 @@ func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.S
 	}
 
 	for i, r := range sg.EgressRules {
-		if r == rule {
+		if r.Equal(&rule) {
 			sg.EgressRules = append(sg.EgressRules[:i], sg.EgressRules[i+1:]...)
 
 			return nil

--- a/providers/oci/vcn/nsg.go
+++ b/providers/oci/vcn/nsg.go
@@ -192,7 +192,7 @@ func addRule(
 	rules []driver.SecurityRule, rule driver.SecurityRule, direction, groupID string,
 ) ([]driver.SecurityRule, error) {
 	for _, r := range rules {
-		if r == rule {
+		if r.Equal(&rule) {
 			return nil, cerrors.Newf(cerrors.AlreadyExists,
 				"%s rule already exists in network security group %q", direction, groupID)
 		}
@@ -204,7 +204,7 @@ func addRule(
 // dropRule removes the first rule equal to want, reporting whether it was there.
 func dropRule(rules []driver.SecurityRule, want driver.SecurityRule) ([]driver.SecurityRule, bool) {
 	for i, r := range rules {
-		if r == want {
+		if r.Equal(&want) {
 			return removeAt(rules, i), true
 		}
 	}

--- a/server/aws/ec2/operations.go
+++ b/server/aws/ec2/operations.go
@@ -537,6 +537,21 @@ func mergeTagSpecs(specs []awsquery.TagSpec, resource string) map[string]string 
 	return out
 }
 
+// copyTagMap returns a shallow copy of tags, or nil for an empty input, so each
+// consumer owns its own tag map.
+func copyTagMap(tags map[string]string) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(tags))
+	for k, v := range tags {
+		out[k] = v
+	}
+
+	return out
+}
+
 // toInstanceXMLs converts driver instances to their XML wire form, resolving
 // security-group names once for the whole batch.
 func (h *Handler) toInstanceXMLs(ctx context.Context, instances []computedriver.Instance) []instanceXML {

--- a/server/aws/ec2/security_group.go
+++ b/server/aws/ec2/security_group.go
@@ -93,6 +93,7 @@ type securityGroupRuleXML struct {
 	PrefixListID        string                  `xml:"prefixListId,omitempty"`
 	ReferencedGroupInfo *referencedGroupInfoXML `xml:"referencedGroupInfo,omitempty"`
 	Description         string                  `xml:"description,omitempty"`
+	Tags                []tagItem               `xml:"tagSet>item,omitempty"`
 }
 
 type securityGroupXML struct {
@@ -333,8 +334,8 @@ func (h *Handler) describeSecurityGroupRules(w http.ResponseWriter, r *http.Requ
 			continue
 		}
 
-		items = appendSGRuleXMLs(items, sg.ID, false, sg.IngressRules, wantRuleIDs)
-		items = appendSGRuleXMLs(items, sg.ID, true, sg.EgressRules, wantRuleIDs)
+		items = appendSGRuleXMLs(items, sg.ID, false, sg.IngressRules, wantRuleIDs, filters)
+		items = appendSGRuleXMLs(items, sg.ID, true, sg.EgressRules, wantRuleIDs, filters)
 	}
 
 	awsquery.WriteXMLResponse(w, describeSecurityGroupRulesResponseXML{
@@ -352,9 +353,14 @@ func appendSGRuleXMLs(
 	egress bool,
 	rules []netdriver.SecurityRule,
 	wantRuleIDs []string,
+	filters []awsquery.Filter,
 ) []securityGroupRuleXML {
 	for i := range rules {
 		if len(wantRuleIDs) > 0 && !containsString(wantRuleIDs, rules[i].RuleID) {
+			continue
+		}
+
+		if !ruleMatchesTagFilters(&rules[i], filters) {
 			continue
 		}
 
@@ -382,6 +388,10 @@ func sgRuleFilterValues(filters []awsquery.Filter, name string) []string {
 // emulator does not implement, matching real EC2's InvalidParameterValue.
 func validateSGRuleFilters(filters []awsquery.Filter) error {
 	for _, f := range filters {
+		if isSGTagFilter(f.Name) {
+			continue
+		}
+
 		switch f.Name {
 		case groupIDFilter, securityGroupRuleIDFilter:
 		default:
@@ -390,6 +400,44 @@ func validateSGRuleFilters(filters []awsquery.Filter) error {
 	}
 
 	return nil
+}
+
+// ruleMatchesTagFilters reports whether a rule satisfies every tag filter: a
+// "tag-key" filter matches on the presence of a listed key, and a "tag:<key>"
+// filter matches when the rule's value for <key> is one of the listed values.
+// Non-tag filters are ignored here (handled by the group/rule-id selectors).
+func ruleMatchesTagFilters(rule *netdriver.SecurityRule, filters []awsquery.Filter) bool {
+	for _, f := range filters {
+		if !isSGTagFilter(f.Name) {
+			continue
+		}
+
+		if f.Name == tagKeyFilter {
+			if !anyTagKeyPresent(rule.Tags, f.Values) {
+				return false
+			}
+
+			continue
+		}
+
+		key, _ := strings.CutPrefix(f.Name, "tag:")
+		if !containsString(f.Values, rule.Tags[key]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// anyTagKeyPresent reports whether tags contains any of the listed keys.
+func anyTagKeyPresent(tags map[string]string, keys []string) bool {
+	for k := range tags {
+		if containsString(keys, k) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (h *Handler) authorizeSecurityGroupEgress(w http.ResponseWriter, r *http.Request) {
@@ -468,6 +516,12 @@ func (h *Handler) applyRules(w http.ResponseWriter, r *http.Request, spec ruleAp
 		return
 	}
 
+	// Only the Authorize path (existing != nil) applies TagSpecifications to the
+	// minted rules; Revoke ignores them.
+	if spec.existing != nil {
+		applyRuleTagSpecs(r.Form, rules)
+	}
+
 	for i := range rules {
 		if err := spec.apply(r.Context(), groupID, rules[i]); err != nil {
 			writeSGErr(w, err)
@@ -483,6 +537,20 @@ func (h *Handler) applyRules(w http.ResponseWriter, r *http.Request, spec ruleAp
 	}
 
 	writeSimpleSGResponse(w, spec.responseName)
+}
+
+// applyRuleTagSpecs assigns the TagSpecifications(security-group-rule) tags to
+// every minted rule, giving each rule its own copy so rules from one Authorize
+// don't share a single tag map.
+func applyRuleTagSpecs(form url.Values, rules []netdriver.SecurityRule) {
+	ruleTags := mergeTagSpecs(awsquery.TagSpecs(form), "security-group-rule")
+	if ruleTags == nil {
+		return
+	}
+
+	for i := range rules {
+		rules[i].Tags = copyTagMap(ruleTags)
+	}
 }
 
 // writeAuthorizeSGResponse emits <return>true</return> plus the
@@ -518,6 +586,7 @@ func toSecurityGroupRuleXML(groupID string, egress bool, rule *netdriver.Securit
 		CidrIPv6:            rule.IPv6CIDR,
 		PrefixListID:        rule.PrefixListID,
 		Description:         rule.Description,
+		Tags:                toTagItems(rule.Tags),
 	}
 
 	if rule.ReferencedGroupID != "" {

--- a/server/aws/ec2/security_group_test.go
+++ b/server/aws/ec2/security_group_test.go
@@ -371,6 +371,10 @@ func TestDescribeSecurityGroupRules(t *testing.T) {
 			ToPort:     aws.Int32(443),
 			IpRanges:   []ec2types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
 		}},
+		TagSpecifications: []ec2types.TagSpecification{{
+			ResourceType: ec2types.ResourceTypeSecurityGroupRule,
+			Tags:         []ec2types.Tag{{Key: aws.String("env"), Value: aws.String("prod")}},
+		}},
 	}); err != nil {
 		t.Fatalf("AuthorizeSecurityGroupIngress: %v", err)
 	}
@@ -397,6 +401,10 @@ func TestDescribeSecurityGroupRules(t *testing.T) {
 			haveEgress = true
 		} else {
 			haveIngress = true
+
+			if got := tagValue(r.Tags, "env"); got != "prod" {
+				t.Fatalf("ingress rule env tag = %q, want prod: %+v", got, r.Tags)
+			}
 		}
 	}
 
@@ -417,4 +425,176 @@ func TestDescribeSecurityGroupRules(t *testing.T) {
 	if len(one.SecurityGroupRules) != 1 || aws.ToString(one.SecurityGroupRules[0].SecurityGroupRuleId) != oneID {
 		t.Fatalf("rule-id filter = %+v, want only %s", one.SecurityGroupRules, oneID)
 	}
+}
+
+// TestAuthorizeSecurityGroupRuleTags pins that Authorize{Ingress,Egress} accepts
+// TagSpecifications(security-group-rule) and echoes the tags on each returned
+// SecurityGroupRule, matching real EC2.
+func TestAuthorizeSecurityGroupRuleTags(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	groupID := authorizeIngressSG(t, ctx, c)
+
+	out, err := c.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(groupID),
+		IpPermissions: []ec2types.IpPermission{{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   aws.Int32(22),
+			ToPort:     aws.Int32(22),
+			IpRanges:   []ec2types.IpRange{{CidrIp: aws.String("10.0.0.0/8")}},
+		}},
+		TagSpecifications: []ec2types.TagSpecification{{
+			ResourceType: ec2types.ResourceTypeSecurityGroupRule,
+			Tags: []ec2types.Tag{
+				{Key: aws.String("Name"), Value: aws.String("ssh")},
+				{Key: aws.String("team"), Value: aws.String("platform")},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("AuthorizeSecurityGroupIngress: %v", err)
+	}
+
+	if len(out.SecurityGroupRules) != 1 {
+		t.Fatalf("Authorize returned %d rules, want 1: %+v", len(out.SecurityGroupRules), out.SecurityGroupRules)
+	}
+
+	rule := out.SecurityGroupRules[0]
+	if got := tagValue(rule.Tags, "Name"); got != "ssh" {
+		t.Fatalf("rule Name tag = %q, want ssh: %+v", got, rule.Tags)
+	}
+
+	if got := tagValue(rule.Tags, "team"); got != "platform" {
+		t.Fatalf("rule team tag = %q, want platform: %+v", got, rule.Tags)
+	}
+}
+
+// TestDescribeSecurityGroupRulesTagFilter pins that DescribeSecurityGroupRules
+// selects rules by tag:<key> value and tag-key presence, ignoring untagged and
+// non-matching rules.
+func TestDescribeSecurityGroupRulesTagFilter(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	groupID := authorizeIngressSG(t, ctx, c)
+
+	// A tagged rule and an untagged rule in the same group.
+	tagged, err := c.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(groupID),
+		IpPermissions: []ec2types.IpPermission{{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   aws.Int32(443),
+			ToPort:     aws.Int32(443),
+			IpRanges:   []ec2types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
+		}},
+		TagSpecifications: []ec2types.TagSpecification{{
+			ResourceType: ec2types.ResourceTypeSecurityGroupRule,
+			Tags:         []ec2types.Tag{{Key: aws.String("tier"), Value: aws.String("web")}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("AuthorizeSecurityGroupIngress (tagged): %v", err)
+	}
+
+	if _, err := c.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(groupID),
+		IpPermissions: []ec2types.IpPermission{{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   aws.Int32(22),
+			ToPort:     aws.Int32(22),
+			IpRanges:   []ec2types.IpRange{{CidrIp: aws.String("10.0.0.0/8")}},
+		}},
+	}); err != nil {
+		t.Fatalf("AuthorizeSecurityGroupIngress (untagged): %v", err)
+	}
+
+	wantID := aws.ToString(tagged.SecurityGroupRules[0].SecurityGroupRuleId)
+
+	// tag:<key>=value selects only the tagged rule.
+	byValue, err := c.DescribeSecurityGroupRules(ctx, &ec2.DescribeSecurityGroupRulesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("tag:tier"), Values: []string{"web"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSecurityGroupRules tag:tier: %v", err)
+	}
+
+	if len(byValue.SecurityGroupRules) != 1 || aws.ToString(byValue.SecurityGroupRules[0].SecurityGroupRuleId) != wantID {
+		t.Fatalf("tag:tier filter = %+v, want only %s", byValue.SecurityGroupRules, wantID)
+	}
+
+	// tag-key presence selects only the tagged rule.
+	byKey, err := c.DescribeSecurityGroupRules(ctx, &ec2.DescribeSecurityGroupRulesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("tag-key"), Values: []string{"tier"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSecurityGroupRules tag-key: %v", err)
+	}
+
+	if len(byKey.SecurityGroupRules) != 1 || aws.ToString(byKey.SecurityGroupRules[0].SecurityGroupRuleId) != wantID {
+		t.Fatalf("tag-key filter = %+v, want only %s", byKey.SecurityGroupRules, wantID)
+	}
+}
+
+// TestCreateTagsSecurityGroupRule pins that CreateTags/DeleteTags address a
+// security-group rule by its sgr- id, verified through DescribeSecurityGroupRules.
+func TestCreateTagsSecurityGroupRule(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	groupID := authorizeIngressSG(t, ctx, c)
+
+	authz, err := c.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(groupID),
+		IpPermissions: []ec2types.IpPermission{{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   aws.Int32(443),
+			ToPort:     aws.Int32(443),
+			IpRanges:   []ec2types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("AuthorizeSecurityGroupIngress: %v", err)
+	}
+
+	ruleID := aws.ToString(authz.SecurityGroupRules[0].SecurityGroupRuleId)
+
+	if _, err := c.CreateTags(ctx, &ec2.CreateTagsInput{
+		Resources: []string{ruleID},
+		Tags:      []ec2types.Tag{{Key: aws.String("owner"), Value: aws.String("net")}},
+	}); err != nil {
+		t.Fatalf("CreateTags: %v", err)
+	}
+
+	rule := describeSGRuleByID(t, ctx, c, ruleID)
+	if got := tagValue(rule.Tags, "owner"); got != "net" {
+		t.Fatalf("after CreateTags owner tag = %q, want net: %+v", got, rule.Tags)
+	}
+
+	if _, err := c.DeleteTags(ctx, &ec2.DeleteTagsInput{
+		Resources: []string{ruleID},
+		Tags:      []ec2types.Tag{{Key: aws.String("owner")}},
+	}); err != nil {
+		t.Fatalf("DeleteTags: %v", err)
+	}
+
+	rule = describeSGRuleByID(t, ctx, c, ruleID)
+	if got := tagValue(rule.Tags, "owner"); got != "" {
+		t.Fatalf("after DeleteTags owner tag = %q, want empty: %+v", got, rule.Tags)
+	}
+}
+
+// describeSGRuleByID returns the single rule with the given sgr- id.
+func describeSGRuleByID(t *testing.T, ctx context.Context, c *ec2.Client, ruleID string) ec2types.SecurityGroupRule {
+	t.Helper()
+
+	out, err := c.DescribeSecurityGroupRules(ctx, &ec2.DescribeSecurityGroupRulesInput{
+		SecurityGroupRuleIds: []string{ruleID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSecurityGroupRules by id %s: %v", ruleID, err)
+	}
+
+	if len(out.SecurityGroupRules) != 1 {
+		t.Fatalf("DescribeSecurityGroupRules by id %s = %d rules, want 1", ruleID, len(out.SecurityGroupRules))
+	}
+
+	return out.SecurityGroupRules[0]
 }

--- a/server/aws/ec2/tags.go
+++ b/server/aws/ec2/tags.go
@@ -159,9 +159,21 @@ func (h *Handler) collectNetworkTags(ctx context.Context, recs []tagRecord) []ta
 	}
 
 	if sgs, err := h.vpc.DescribeSecurityGroups(ctx, nil); err == nil {
-		for _, sg := range sgs {
-			recs = appendTagRecords(recs, sg.ID, "security-group", sg.Tags)
+		for i := range sgs {
+			recs = appendTagRecords(recs, sgs[i].ID, "security-group", sgs[i].Tags)
+			recs = appendSGRuleTagRecords(recs, sgs[i].IngressRules)
+			recs = appendSGRuleTagRecords(recs, sgs[i].EgressRules)
 		}
+	}
+
+	return recs
+}
+
+// appendSGRuleTagRecords appends tag records for each security-group rule that
+// carries tags, keyed by the rule's sgr- id.
+func appendSGRuleTagRecords(recs []tagRecord, rules []netdriver.SecurityRule) []tagRecord {
+	for i := range rules {
+		recs = appendTagRecords(recs, rules[i].RuleID, "security-group-rule", rules[i].Tags)
 	}
 
 	return recs
@@ -254,11 +266,14 @@ func (h *Handler) deleteTags(w http.ResponseWriter, r *http.Request) {
 // resource-specific InvalidInstanceID.NotFound; other resource types fall back
 // to the generic InvalidID.NotFound.
 func tagNotFoundCode(id string) string {
-	if strings.HasPrefix(id, "i-") {
+	switch {
+	case strings.HasPrefix(id, "i-"):
 		return codeInvalidInstanceID
+	case strings.HasPrefix(id, "sgr-"):
+		return "InvalidSecurityGroupRuleId.NotFound"
+	default:
+		return "InvalidID.NotFound"
 	}
-
-	return "InvalidID.NotFound"
 }
 
 // networkResourceTagPrefixes are the VPC-family id prefixes whose tags the
@@ -267,7 +282,7 @@ func tagNotFoundCode(id string) string {
 // their own methods and are handled separately.
 //
 //nolint:gochecknoglobals // static id-prefix routing table
-var networkResourceTagPrefixes = []string{"rtb-", "igw-", "nat-", "acl-", "dopt-", "pcx-", "pl-", "eigw-"}
+var networkResourceTagPrefixes = []string{"rtb-", "igw-", "nat-", "acl-", "dopt-", "pcx-", "pl-", "eigw-", "sgr-"}
 
 // networkTaggableID reports whether id belongs to a resource tagged via the
 // NetworkResourceTagger optional interface.

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -87,6 +87,12 @@ type SecurityRule struct {
 	// RuleID is the service-assigned "sgr-" identifier for the rule. It is empty
 	// for rules created outside the AWS wire layer (Azure/GCP, portable API).
 	RuleID string
+	// Tags are the service-assigned tags applied to the rule. They are populated
+	// only via the AWS wire layer (AuthorizeSecurityGroup* TagSpecifications /
+	// CreateTags on the sgr- id) and are nil for Azure/GCP/OCI and the portable
+	// API. Tags are not part of a rule's identity — Matches() ignores them, the
+	// same as RuleID and Description.
+	Tags map[string]string
 }
 
 // Matches reports whether two rules describe the same permission, ignoring the
@@ -100,6 +106,19 @@ func (r *SecurityRule) Matches(o *SecurityRule) bool {
 		r.IPv6CIDR == o.IPv6CIDR &&
 		r.PrefixListID == o.PrefixListID &&
 		r.ReferencedGroupID == o.ReferencedGroupID
+}
+
+// Equal reports whether two rules are identical in every field except the
+// service-assigned Tags map. Tags is a map (not comparable with ==) and is not
+// part of a rule's identity, so it is excluded. Equal preserves the exact
+// full-struct equality that Azure/GCP/OCI relied on before Tags was added,
+// which — unlike Matches — also distinguishes RuleID, Description and the
+// referenced-group owner.
+func (r *SecurityRule) Equal(o *SecurityRule) bool {
+	return r.Matches(o) &&
+		r.ReferencedGroupOwnerID == o.ReferencedGroupOwnerID &&
+		r.Description == o.Description &&
+		r.RuleID == o.RuleID
 }
 
 // PeeringConnection represents a VPC peering connection.


### PR DESCRIPTION
Security-group RULES are first-class taggable AWS resources (sgr- ids, resource type 'security-group-rule'). Researched against official EC2 API docs.

- SecurityRule gains a Tags map (AWS-wire-only; nil for Azure/GCP/OCI; excluded from Matches() identity)
- Authorize* accept TagSpecifications(security-group-rule); tagSet emitted in the SecurityGroupRule wire shape (Authorize + DescribeSecurityGroupRules)
- DescribeSecurityGroupRules accepts tag:/tag-key filters (keeps group-id/security-group-rule-id)
- CreateTags/DeleteTags route sgr- ids through the existing AWS-only NetworkResourceTagger; DescribeTags surfaces rule tags

Adding a map field made SecurityRule non-comparable (broke == in azure/gcp/oci); preserved exact prior identity via a SecurityRule.Equal method (compares all fields except the tags map) — revoke/dedup semantics byte-for-byte unchanged. No shared interface method changed; compat suite clean. SDK + provider tests per behavior.