### PR TITLE
fix(ec2): ModifySecurityGroupRules + UpdateSecurityGroupRuleDescriptions

### DIFF
--- a/providers/aws/vpc/security_group.go
+++ b/providers/aws/vpc/security_group.go
@@ -1,0 +1,106 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// ModifySecurityGroupRule replaces the permission fields (protocol, port range,
+// single target, and description) of the ingress/egress rule identified by
+// ruleID within groupID, preserving the rule's RuleID, egress side, and Tags.
+// It backs the AWS-only ec2:ModifySecurityGroupRules action and is exposed via
+// the wire layer's optional sgRuleMutator interface — Azure/GCP/OCI have no
+// concept of an sgr- rule id, so this is deliberately not on the shared driver.
+//
+// A missing group is NotFound (mapped to InvalidGroup.NotFound); an absent
+// ruleID is a NotFound naming the rule (mapped to
+// InvalidSecurityGroupRuleId.NotFound).
+//
+//nolint:gocritic // hugeParam: updated mirrors the driver's by-value SecurityRule shape.
+func (m *Mock) ModifySecurityGroupRule(_ context.Context, groupID, ruleID string, updated driver.SecurityRule) error {
+	if !m.securityGroups.Has(groupID) {
+		return errors.Newf(errors.NotFound, "security group %q not found", groupID)
+	}
+
+	found := false
+
+	m.securityGroups.Update(groupID, func(sg *sgData) *sgData {
+		if applyRuleUpdate(sg.IngressRules, ruleID, updated) || applyRuleUpdate(sg.EgressRules, ruleID, updated) {
+			found = true
+		}
+
+		return sg
+	})
+
+	if !found {
+		return errors.Newf(errors.NotFound, "security group rule %q not found", ruleID)
+	}
+
+	return nil
+}
+
+// applyRuleUpdate overwrites the permission fields of the rule in rules whose
+// RuleID equals ruleID, keeping its RuleID and Tags. It reports whether a
+// matching rule was found.
+//
+//nolint:gocritic // hugeParam: updated mirrors the driver's by-value SecurityRule shape.
+func applyRuleUpdate(rules []driver.SecurityRule, ruleID string, updated driver.SecurityRule) bool {
+	for i := range rules {
+		if rules[i].RuleID != ruleID {
+			continue
+		}
+
+		rules[i].Protocol = updated.Protocol
+		rules[i].FromPort = updated.FromPort
+		rules[i].ToPort = updated.ToPort
+		rules[i].CIDR = updated.CIDR
+		rules[i].IPv6CIDR = updated.IPv6CIDR
+		rules[i].PrefixListID = updated.PrefixListID
+		rules[i].ReferencedGroupID = updated.ReferencedGroupID
+		rules[i].ReferencedGroupOwnerID = updated.ReferencedGroupOwnerID
+		rules[i].Description = updated.Description
+
+		return true
+	}
+
+	return false
+}
+
+// SetSecurityGroupRuleDescription sets (or clears, when description is empty)
+// the free-text description of the rule identified by ruleID on the ingress or
+// egress list of groupID, per egress. It backs
+// ec2:UpdateSecurityGroupRuleDescriptions{Ingress,Egress} and, like
+// ModifySecurityGroupRule, is exposed only through the AWS-only optional
+// interface. Direction is honored: an egress rule id passed with egress=false
+// misses and yields a rule-not-found error.
+func (m *Mock) SetSecurityGroupRuleDescription(_ context.Context, groupID, ruleID string, egress bool, description string) error {
+	if !m.securityGroups.Has(groupID) {
+		return errors.Newf(errors.NotFound, "security group %q not found", groupID)
+	}
+
+	found := false
+
+	m.securityGroups.Update(groupID, func(sg *sgData) *sgData {
+		rules := sg.IngressRules
+		if egress {
+			rules = sg.EgressRules
+		}
+
+		for i := range rules {
+			if rules[i].RuleID == ruleID {
+				rules[i].Description = description
+				found = true
+			}
+		}
+
+		return sg
+	})
+
+	if !found {
+		return errors.Newf(errors.NotFound, "security group rule %q not found", ruleID)
+	}
+
+	return nil
+}

--- a/providers/aws/vpc/security_group_test.go
+++ b/providers/aws/vpc/security_group_test.go
@@ -1,0 +1,112 @@
+package vpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// sgWithRules creates a security group holding one ingress and one egress rule,
+// each carrying a known sgr- id and a tag, and returns the group id.
+func sgWithRules(t *testing.T, m *Mock) string {
+	t.Helper()
+
+	ctx := context.Background()
+	v := createTestVPC(m)
+
+	sg, err := m.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{Name: "sg", Description: "sg", VPCID: v.ID})
+	requireNoError(t, err)
+
+	requireNoError(t, m.AddIngressRule(ctx, sg.ID, driver.SecurityRule{
+		Protocol: "tcp", FromPort: 22, ToPort: 22, CIDR: "0.0.0.0/0",
+		Description: "old", RuleID: "sgr-ingress", Tags: map[string]string{"env": "test"},
+	}))
+
+	requireNoError(t, m.AddEgressRule(ctx, sg.ID, driver.SecurityRule{
+		Protocol: "tcp", FromPort: 443, ToPort: 443, CIDR: "10.0.0.0/16",
+		RuleID: "sgr-egress",
+	}))
+
+	return sg.ID
+}
+
+// ruleByID returns the ingress-or-egress rule with the given sgr- id.
+func ruleByID(t *testing.T, m *Mock, groupID, ruleID string) driver.SecurityRule {
+	t.Helper()
+
+	sgs, err := m.DescribeSecurityGroups(context.Background(), []string{groupID})
+	requireNoError(t, err)
+
+	for _, r := range append(sgs[0].IngressRules, sgs[0].EgressRules...) {
+		if r.RuleID == ruleID {
+			return r
+		}
+	}
+
+	t.Fatalf("rule %q not found in group %q", ruleID, groupID)
+
+	return driver.SecurityRule{}
+}
+
+// TestModifySecurityGroupRulePreservesRuleIDAndTags covers the full-replace of a
+// rule's permission fields while its RuleID and Tags are preserved.
+func TestModifySecurityGroupRulePreservesRuleIDAndTags(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	groupID := sgWithRules(t, m)
+
+	requireNoError(t, m.ModifySecurityGroupRule(ctx, groupID, "sgr-ingress", driver.SecurityRule{
+		Protocol: "udp", FromPort: 53, ToPort: 53, CIDR: "192.168.0.0/24", Description: "dns",
+	}))
+
+	got := ruleByID(t, m, groupID, "sgr-ingress")
+	assertEqual(t, "sgr-ingress", got.RuleID)
+	assertEqual(t, "udp", got.Protocol)
+	assertEqual(t, 53, got.FromPort)
+	assertEqual(t, "192.168.0.0/24", got.CIDR)
+	assertEqual(t, "dns", got.Description)
+	assertEqual(t, "test", got.Tags["env"])
+}
+
+// TestModifySecurityGroupRuleNotFound covers the group- and rule-level
+// not-found errors.
+func TestModifySecurityGroupRuleNotFound(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	groupID := sgWithRules(t, m)
+
+	if err := m.ModifySecurityGroupRule(ctx, "sg-missing", "sgr-ingress",
+		driver.SecurityRule{CIDR: "0.0.0.0/0"}); !isNotFound(err) {
+		t.Fatalf("missing group = %v, want NotFound", err)
+	}
+
+	if err := m.ModifySecurityGroupRule(ctx, groupID, "sgr-nope",
+		driver.SecurityRule{CIDR: "0.0.0.0/0"}); !isNotFound(err) {
+		t.Fatalf("missing rule = %v, want NotFound", err)
+	}
+}
+
+// TestSetSecurityGroupRuleDescriptionByDirection covers setting/clearing a
+// description on the correct list and the direction-mismatch miss (an egress id
+// passed as ingress is not found).
+func TestSetSecurityGroupRuleDescriptionByDirection(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	groupID := sgWithRules(t, m)
+
+	requireNoError(t, m.SetSecurityGroupRuleDescription(ctx, groupID, "sgr-ingress", false, "ssh"))
+	assertEqual(t, "ssh", ruleByID(t, m, groupID, "sgr-ingress").Description)
+
+	// Empty clears it.
+	requireNoError(t, m.SetSecurityGroupRuleDescription(ctx, groupID, "sgr-ingress", false, ""))
+	assertEqual(t, "", ruleByID(t, m, groupID, "sgr-ingress").Description)
+
+	// Direction is honored: an egress id searched on the ingress list misses.
+	if err := m.SetSecurityGroupRuleDescription(ctx, groupID, "sgr-egress", false, "x"); !isNotFound(err) {
+		t.Fatalf("egress id on ingress list = %v, want NotFound", err)
+	}
+
+	requireNoError(t, m.SetSecurityGroupRuleDescription(ctx, groupID, "sgr-egress", true, "internal"))
+	assertEqual(t, "internal", ruleByID(t, m, groupID, "sgr-egress").Description)
+}

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -363,6 +363,10 @@ func (h *Handler) routeVPC(w http.ResponseWriter, r *http.Request, action string
 		return true
 	}
 
+	if h.routeVPCSecurityGroupRule(w, r, action) {
+		return true
+	}
+
 	if h.routeVPCInternetGateway(w, r, action) {
 		return true
 	}
@@ -438,6 +442,24 @@ func (h *Handler) routeVPCSecurityGroup(w http.ResponseWriter, r *http.Request, 
 		h.revokeSecurityGroupIngress(w, r)
 	case "RevokeSecurityGroupEgress":
 		h.revokeSecurityGroupEgress(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// routeVPCSecurityGroupRule dispatches the AWS-only security-group rule-mutation
+// actions (rule full-replace + description updates). It is kept separate from
+// routeVPCSecurityGroup so each dispatch table stays small.
+func (h *Handler) routeVPCSecurityGroupRule(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
+	case "ModifySecurityGroupRules":
+		h.modifySecurityGroupRules(w, r)
+	case "UpdateSecurityGroupRuleDescriptionsIngress":
+		h.updateSecurityGroupRuleDescriptions(w, r, false)
+	case "UpdateSecurityGroupRuleDescriptionsEgress":
+		h.updateSecurityGroupRuleDescriptions(w, r, true)
 	default:
 		return false
 	}

--- a/server/aws/ec2/security_group.go
+++ b/server/aws/ec2/security_group.go
@@ -867,3 +867,238 @@ func writeSimpleSGResponse(w http.ResponseWriter, rootName string) {
 func writeSGErr(w http.ResponseWriter, err error) {
 	writeErrWithNotFound(w, err, "InvalidGroup.NotFound", "DependencyViolation")
 }
+
+// sgRuleMutator is the AWS-only optional interface the VPC mock satisfies to
+// back the rule-mutation actions (ModifySecurityGroupRules,
+// UpdateSecurityGroupRuleDescriptions{Ingress,Egress}). These identify a rule by
+// its "sgr-" id, a concept Azure/GCP/OCI do not share, so they are type-asserted
+// here rather than added to the cross-cloud Networking driver.
+type sgRuleMutator interface {
+	ModifySecurityGroupRule(ctx context.Context, groupID, ruleID string, updated netdriver.SecurityRule) error
+	SetSecurityGroupRuleDescription(ctx context.Context, groupID, ruleID string, egress bool, description string) error
+}
+
+// modifySecurityGroupRules backs ec2:ModifySecurityGroupRules: it full-replaces
+// the permission fields of each identified rule (keeping its id, side, and
+// tags) and answers the trivial <return>true</return> envelope.
+func (h *Handler) modifySecurityGroupRules(w http.ResponseWriter, r *http.Request) {
+	mutator, ok := h.vpc.(sgRuleMutator)
+	if !ok {
+		writeSGErr(w, newInvalidParameterErr("security group rule modification is not supported"))
+		return
+	}
+
+	groupID := r.Form.Get("GroupId")
+	if groupID == "" {
+		writeSGErr(w, errMissingGroupID())
+		return
+	}
+
+	const prefix = "SecurityGroupRule"
+
+	indices := awsquery.CollectIndices(r.Form, prefix)
+	if len(indices) == 0 {
+		writeSGErr(w, newInvalidParameterErr("at least one SecurityGroupRule update is required"))
+		return
+	}
+
+	for _, idx := range indices {
+		base := prefix + "." + strconv.Itoa(idx)
+
+		ruleID := r.Form.Get(base + ".SecurityGroupRuleId")
+		if ruleID == "" {
+			writeSGErr(w, newInvalidParameterErr("SecurityGroupRuleId is required for each update"))
+			return
+		}
+
+		updated, err := parseSecurityGroupRuleRequest(r.Form, base+".SecurityGroupRule")
+		if err != nil {
+			writeSGErr(w, err)
+			return
+		}
+
+		if err := mutator.ModifySecurityGroupRule(r.Context(), groupID, ruleID, updated); err != nil {
+			writeSGRuleErr(w, err)
+			return
+		}
+	}
+
+	writeSimpleSGResponse(w, "ModifySecurityGroupRulesResponse")
+}
+
+// parseSecurityGroupRuleRequest reads the single nested SecurityGroupRuleRequest
+// object at base into a SecurityRule, enforcing AWS's "exactly one target"
+// rule across CidrIpv4/CidrIpv6/PrefixListId/ReferencedGroupId.
+func parseSecurityGroupRuleRequest(form url.Values, base string) (netdriver.SecurityRule, error) {
+	fromPort, _ := strconv.Atoi(form.Get(base + ".FromPort"))
+	toPort, _ := strconv.Atoi(form.Get(base + ".ToPort"))
+
+	rule := netdriver.SecurityRule{
+		Protocol:          form.Get(base + ".IpProtocol"),
+		FromPort:          fromPort,
+		ToPort:            toPort,
+		CIDR:              form.Get(base + ".CidrIpv4"),
+		IPv6CIDR:          form.Get(base + ".CidrIpv6"),
+		PrefixListID:      form.Get(base + ".PrefixListId"),
+		ReferencedGroupID: form.Get(base + ".ReferencedGroupId"),
+		Description:       form.Get(base + ".Description"),
+	}
+
+	targets := 0
+
+	for _, t := range []string{rule.CIDR, rule.IPv6CIDR, rule.PrefixListID, rule.ReferencedGroupID} {
+		if t != "" {
+			targets++
+		}
+	}
+
+	if targets != 1 {
+		return netdriver.SecurityRule{}, newInvalidParameterErr(
+			"exactly one of CidrIpv4, CidrIpv6, PrefixListId or ReferencedGroupId must be specified")
+	}
+
+	return rule, nil
+}
+
+// updateSecurityGroupRuleDescriptions backs
+// ec2:UpdateSecurityGroupRuleDescriptions{Ingress,Egress}. Rules are identified
+// either directly by SecurityGroupRuleDescription.N.SecurityGroupRuleId or,
+// classically, by an IpPermissions match resolved against the group's rules in
+// the selected direction. Omitting a Description clears it.
+func (h *Handler) updateSecurityGroupRuleDescriptions(w http.ResponseWriter, r *http.Request, egress bool) {
+	mutator, ok := h.vpc.(sgRuleMutator)
+	if !ok {
+		writeSGErr(w, newInvalidParameterErr("security group rule modification is not supported"))
+		return
+	}
+
+	groupID := r.Form.Get("GroupId")
+	if groupID == "" {
+		writeSGErr(w, errMissingGroupID())
+		return
+	}
+
+	descByID := parseRuleDescriptions(r.Form)
+	perms := parseIPPermissions(r.Form)
+
+	if len(descByID) == 0 && len(perms) == 0 {
+		writeSGErr(w, newInvalidParameterErr(
+			"either IpPermissions or SecurityGroupRuleDescription must be specified"))
+		return
+	}
+
+	for _, d := range descByID {
+		if err := mutator.SetSecurityGroupRuleDescription(r.Context(), groupID, d.ruleID, egress, d.description); err != nil {
+			writeSGRuleErr(w, err)
+			return
+		}
+	}
+
+	if len(perms) > 0 {
+		if err := h.applyPermissionDescriptions(r.Context(), mutator, groupID, egress, perms); err != nil {
+			writeSGRuleErr(w, err)
+			return
+		}
+	}
+
+	name := "UpdateSecurityGroupRuleDescriptionsIngressResponse"
+	if egress {
+		name = "UpdateSecurityGroupRuleDescriptionsEgressResponse"
+	}
+
+	writeSimpleSGResponse(w, name)
+}
+
+// applyPermissionDescriptions resolves each parsed IpPermission to the matching
+// rule id in the selected direction and sets that rule's description, matching
+// how real EC2 accepts the classic (pre-sgr-id) description-update form.
+func (h *Handler) applyPermissionDescriptions(
+	ctx context.Context,
+	mutator sgRuleMutator,
+	groupID string,
+	egress bool,
+	perms []netdriver.SecurityRule,
+) error {
+	sgs, err := h.vpc.DescribeSecurityGroups(ctx, []string{groupID})
+	if err != nil {
+		return err
+	}
+
+	if len(sgs) == 0 {
+		return cerrors.Newf(cerrors.NotFound, "security group %q not found", groupID)
+	}
+
+	current := sgs[0].IngressRules
+	if egress {
+		current = sgs[0].EgressRules
+	}
+
+	for i := range perms {
+		ruleID, found := resolveRuleID(current, &perms[i])
+		if !found {
+			return cerrors.New(cerrors.NotFound, "the specified security group rule does not exist")
+		}
+
+		if err := mutator.SetSecurityGroupRuleDescription(ctx, groupID, ruleID, egress, perms[i].Description); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// resolveRuleID returns the id of the rule in current that matches perm's
+// permission fields (protocol/ports/target), ignoring description.
+func resolveRuleID(current []netdriver.SecurityRule, perm *netdriver.SecurityRule) (string, bool) {
+	for i := range current {
+		if current[i].Matches(perm) {
+			return current[i].RuleID, true
+		}
+	}
+
+	return "", false
+}
+
+// ruleDescription is one parsed SecurityGroupRuleDescription.N entry.
+type ruleDescription struct {
+	ruleID      string
+	description string
+}
+
+// parseRuleDescriptions reads the SecurityGroupRuleDescription.N array
+// (SecurityGroupRuleId + optional Description) from the wire form.
+func parseRuleDescriptions(form url.Values) []ruleDescription {
+	const prefix = "SecurityGroupRuleDescription"
+
+	indices := awsquery.CollectIndices(form, prefix)
+	if len(indices) == 0 {
+		return nil
+	}
+
+	out := make([]ruleDescription, 0, len(indices))
+
+	for _, idx := range indices {
+		base := prefix + "." + strconv.Itoa(idx)
+
+		id := form.Get(base + ".SecurityGroupRuleId")
+		if id == "" {
+			continue
+		}
+
+		out = append(out, ruleDescription{ruleID: id, description: form.Get(base + ".Description")})
+	}
+
+	return out
+}
+
+// writeSGRuleErr maps a rule-level not-found (a rule id that names no rule in
+// the group) to InvalidSecurityGroupRuleId.NotFound, falling back to the
+// group-level SG error mapping for everything else.
+func writeSGRuleErr(w http.ResponseWriter, err error) {
+	if cerrors.IsNotFound(err) && strings.Contains(err.Error(), "rule") {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSecurityGroupRuleId.NotFound", err.Error())
+		return
+	}
+
+	writeSGErr(w, err)
+}

--- a/server/aws/ec2/security_group_test.go
+++ b/server/aws/ec2/security_group_test.go
@@ -666,3 +666,230 @@ func describeSGRuleByID(t *testing.T, ctx context.Context, c *ec2.Client, ruleID
 
 	return out.SecurityGroupRules[0]
 }
+
+// authorizeIngressRuleID authorizes one ingress rule on a fresh group and
+// returns the group id and the minted sgr- rule id, so the rule-mutation
+// actions have a concrete target to operate on.
+func authorizeIngressRuleID(t *testing.T, ctx context.Context, c *ec2.Client) (groupID, ruleID string) {
+	t.Helper()
+
+	groupID = authorizeIngressSG(t, ctx, c)
+
+	out, err := c.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(groupID),
+		IpPermissions: []ec2types.IpPermission{{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   aws.Int32(22),
+			ToPort:     aws.Int32(22),
+			IpRanges:   []ec2types.IpRange{{CidrIp: aws.String("0.0.0.0/0"), Description: aws.String("old")}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("AuthorizeSecurityGroupIngress: %v", err)
+	}
+
+	return groupID, aws.ToString(out.SecurityGroupRules[0].SecurityGroupRuleId)
+}
+
+// TestModifySecurityGroupRulesOverWire pins ec2:ModifySecurityGroupRules: the
+// rule's permission fields (protocol, ports, target CIDR, description) are
+// full-replaced while its sgr- id is preserved, matching real EC2.
+func TestModifySecurityGroupRulesOverWire(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	groupID, ruleID := authorizeIngressRuleID(t, ctx, c)
+
+	if _, err := c.ModifySecurityGroupRules(ctx, &ec2.ModifySecurityGroupRulesInput{
+		GroupId: aws.String(groupID),
+		SecurityGroupRules: []ec2types.SecurityGroupRuleUpdate{{
+			SecurityGroupRuleId: aws.String(ruleID),
+			SecurityGroupRule: &ec2types.SecurityGroupRuleRequest{
+				IpProtocol:  aws.String("tcp"),
+				FromPort:    aws.Int32(8080),
+				ToPort:      aws.Int32(8080),
+				CidrIpv4:    aws.String("10.0.0.0/24"),
+				Description: aws.String("new"),
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("ModifySecurityGroupRules: %v", err)
+	}
+
+	got := describeSGRuleByID(t, ctx, c, ruleID)
+	if aws.ToString(got.SecurityGroupRuleId) != ruleID {
+		t.Fatalf("rule id changed: got %q, want %q", aws.ToString(got.SecurityGroupRuleId), ruleID)
+	}
+
+	if p := aws.ToInt32(got.FromPort); p != 8080 {
+		t.Fatalf("FromPort = %d, want 8080", p)
+	}
+
+	if p := aws.ToInt32(got.ToPort); p != 8080 {
+		t.Fatalf("ToPort = %d, want 8080", p)
+	}
+
+	if cidr := aws.ToString(got.CidrIpv4); cidr != "10.0.0.0/24" {
+		t.Fatalf("CidrIpv4 = %q, want 10.0.0.0/24", cidr)
+	}
+
+	if d := aws.ToString(got.Description); d != "new" {
+		t.Fatalf("Description = %q, want new", d)
+	}
+}
+
+// TestModifySecurityGroupRulesUnknownRuleId pins that modifying an unknown rule
+// id answers InvalidSecurityGroupRuleId.NotFound, distinct from the group-level
+// InvalidGroup.NotFound.
+func TestModifySecurityGroupRulesUnknownRuleId(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	groupID := authorizeIngressSG(t, ctx, c)
+
+	_, err := c.ModifySecurityGroupRules(ctx, &ec2.ModifySecurityGroupRulesInput{
+		GroupId: aws.String(groupID),
+		SecurityGroupRules: []ec2types.SecurityGroupRuleUpdate{{
+			SecurityGroupRuleId: aws.String("sgr-doesnotexist"),
+			SecurityGroupRule: &ec2types.SecurityGroupRuleRequest{
+				IpProtocol: aws.String("tcp"),
+				FromPort:   aws.Int32(22),
+				ToPort:     aws.Int32(22),
+				CidrIpv4:   aws.String("0.0.0.0/0"),
+			},
+		}},
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidSecurityGroupRuleId.NotFound" {
+		t.Fatalf("err = %v, want InvalidSecurityGroupRuleId.NotFound", err)
+	}
+}
+
+// TestModifySecurityGroupRulesMultipleTargets pins that a SecurityGroupRuleRequest
+// naming more than one target is rejected with InvalidParameterValue, matching
+// AWS's "exactly one target" rule.
+func TestModifySecurityGroupRulesMultipleTargets(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	groupID, ruleID := authorizeIngressRuleID(t, ctx, c)
+
+	_, err := c.ModifySecurityGroupRules(ctx, &ec2.ModifySecurityGroupRulesInput{
+		GroupId: aws.String(groupID),
+		SecurityGroupRules: []ec2types.SecurityGroupRuleUpdate{{
+			SecurityGroupRuleId: aws.String(ruleID),
+			SecurityGroupRule: &ec2types.SecurityGroupRuleRequest{
+				IpProtocol: aws.String("tcp"),
+				FromPort:   aws.Int32(22),
+				ToPort:     aws.Int32(22),
+				CidrIpv4:   aws.String("0.0.0.0/0"),
+				CidrIpv6:   aws.String("::/0"),
+			},
+		}},
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("err = %v, want InvalidParameterValue", err)
+	}
+}
+
+// TestUpdateSecurityGroupRuleDescriptionsIngressByRuleId pins setting then
+// clearing a rule's description by its sgr- id (omitting Description clears it).
+func TestUpdateSecurityGroupRuleDescriptionsIngressByRuleId(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	groupID, ruleID := authorizeIngressRuleID(t, ctx, c)
+
+	if _, err := c.UpdateSecurityGroupRuleDescriptionsIngress(ctx,
+		&ec2.UpdateSecurityGroupRuleDescriptionsIngressInput{
+			GroupId: aws.String(groupID),
+			SecurityGroupRuleDescriptions: []ec2types.SecurityGroupRuleDescription{{
+				SecurityGroupRuleId: aws.String(ruleID),
+				Description:         aws.String("ssh access"),
+			}},
+		}); err != nil {
+		t.Fatalf("UpdateSecurityGroupRuleDescriptionsIngress (set): %v", err)
+	}
+
+	if d := aws.ToString(describeSGRuleByID(t, ctx, c, ruleID).Description); d != "ssh access" {
+		t.Fatalf("Description = %q, want ssh access", d)
+	}
+
+	// Omitting Description clears it.
+	if _, err := c.UpdateSecurityGroupRuleDescriptionsIngress(ctx,
+		&ec2.UpdateSecurityGroupRuleDescriptionsIngressInput{
+			GroupId: aws.String(groupID),
+			SecurityGroupRuleDescriptions: []ec2types.SecurityGroupRuleDescription{{
+				SecurityGroupRuleId: aws.String(ruleID),
+			}},
+		}); err != nil {
+		t.Fatalf("UpdateSecurityGroupRuleDescriptionsIngress (clear): %v", err)
+	}
+
+	if d := aws.ToString(describeSGRuleByID(t, ctx, c, ruleID).Description); d != "" {
+		t.Fatalf("Description = %q, want empty after clear", d)
+	}
+}
+
+// TestUpdateSecurityGroupRuleDescriptionsEgressByIpPermissions pins the classic
+// permission-match path: the egress rule is resolved by its IpPermissions and
+// its description is set, on the egress list only.
+func TestUpdateSecurityGroupRuleDescriptionsEgressByIpPermissions(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	groupID := authorizeIngressSG(t, ctx, c)
+
+	auth, err := c.AuthorizeSecurityGroupEgress(ctx, &ec2.AuthorizeSecurityGroupEgressInput{
+		GroupId: aws.String(groupID),
+		IpPermissions: []ec2types.IpPermission{{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   aws.Int32(443),
+			ToPort:     aws.Int32(443),
+			IpRanges:   []ec2types.IpRange{{CidrIp: aws.String("10.0.0.0/16")}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("AuthorizeSecurityGroupEgress: %v", err)
+	}
+
+	ruleID := aws.ToString(auth.SecurityGroupRules[0].SecurityGroupRuleId)
+
+	if _, err := c.UpdateSecurityGroupRuleDescriptionsEgress(ctx,
+		&ec2.UpdateSecurityGroupRuleDescriptionsEgressInput{
+			GroupId: aws.String(groupID),
+			IpPermissions: []ec2types.IpPermission{{
+				IpProtocol: aws.String("tcp"),
+				FromPort:   aws.Int32(443),
+				ToPort:     aws.Int32(443),
+				IpRanges: []ec2types.IpRange{{
+					CidrIp:      aws.String("10.0.0.0/16"),
+					Description: aws.String("internal https"),
+				}},
+			}},
+		}); err != nil {
+		t.Fatalf("UpdateSecurityGroupRuleDescriptionsEgress: %v", err)
+	}
+
+	if d := aws.ToString(describeSGRuleByID(t, ctx, c, ruleID).Description); d != "internal https" {
+		t.Fatalf("Description = %q, want internal https", d)
+	}
+}
+
+// TestUpdateSecurityGroupRuleDescriptionsMissingGroupId pins that a missing
+// GroupId is rejected with InvalidParameterValue.
+func TestUpdateSecurityGroupRuleDescriptionsMissingGroupId(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+
+	_, err := c.UpdateSecurityGroupRuleDescriptionsIngress(ctx,
+		&ec2.UpdateSecurityGroupRuleDescriptionsIngressInput{
+			SecurityGroupRuleDescriptions: []ec2types.SecurityGroupRuleDescription{{
+				SecurityGroupRuleId: aws.String("sgr-x"),
+				Description:         aws.String("d"),
+			}},
+		})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("err = %v, want InvalidParameterValue", err)
+	}
+}


### PR DESCRIPTION
Wires the three undispatched SG-rule mutation actions (build on #489's sgr- rule IDs). ModifySecurityGroupRules full-replaces a rule's protocol/ports/single-target/description (preserving sgr- id, egress side, tags); UpdateSecurityGroupRuleDescriptions{Ingress,Egress} set/clear descriptions by sgr- id or IpPermissions match. AWS-only optional sgRuleMutator interface (no shared driver method); provider mutates rules in place under Update(). Error codes: InvalidSecurityGroupRuleId.NotFound / InvalidGroup.NotFound. SDK + provider tests. compat suite clean.