### PR TITLE
fix(elasticache): CreateSnapshot/DescribeSnapshots (dispatch-shadowing fix + snapshot model)

### DIFF
--- a/docs/coverage/aws/elasticache.md
+++ b/docs/coverage/aws/elasticache.md
@@ -40,6 +40,15 @@ ReplicationGroups is an OPTIONAL capability, discovered by type assertion.
 | `DescribeReplicationGroups` |  |
 | `ModifyReplicationGroup` |  |
 
+### Snapshots
+
+Snapshots is an OPTIONAL capability, discovered by type assertion. Snapshots
+
+| Operation | Description |
+| --- | --- |
+| `CreateSnapshot` |  |
+| `DescribeSnapshots` |  |
+
 ### SubnetGroups
 
 SubnetGroups is an OPTIONAL capability, discovered by type assertion. Cache

--- a/docs/coverage/aws/elasticache.md
+++ b/docs/coverage/aws/elasticache.md
@@ -42,7 +42,7 @@ ReplicationGroups is an OPTIONAL capability, discovered by type assertion.
 
 ### Snapshots
 
-Snapshots is an OPTIONAL capability, discovered by type assertion. Snapshots
+Snapshots is an OPTIONAL capability, discovered by type assertion.
 
 | Operation | Description |
 | --- | --- |

--- a/docs/coverage/azure/cache.md
+++ b/docs/coverage/azure/cache.md
@@ -40,6 +40,15 @@ ReplicationGroups is an OPTIONAL capability, discovered by type assertion.
 | `DescribeReplicationGroups` |  |
 | `ModifyReplicationGroup` |  |
 
+### Snapshots
+
+Snapshots is an OPTIONAL capability, discovered by type assertion. Snapshots
+
+| Operation | Description |
+| --- | --- |
+| `CreateSnapshot` |  |
+| `DescribeSnapshots` |  |
+
 ### SubnetGroups
 
 SubnetGroups is an OPTIONAL capability, discovered by type assertion. Cache

--- a/docs/coverage/azure/cache.md
+++ b/docs/coverage/azure/cache.md
@@ -42,7 +42,7 @@ ReplicationGroups is an OPTIONAL capability, discovered by type assertion.
 
 ### Snapshots
 
-Snapshots is an OPTIONAL capability, discovered by type assertion. Snapshots
+Snapshots is an OPTIONAL capability, discovered by type assertion.
 
 | Operation | Description |
 | --- | --- |

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -1554,7 +1554,7 @@
       },
       {
         "name": "Snapshots",
-        "doc": "Snapshots is an OPTIONAL capability, discovered by type assertion. Snapshots",
+        "doc": "Snapshots is an OPTIONAL capability, discovered by type assertion.",
         "operations": [
           {
             "name": "CreateSnapshot"

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -1553,6 +1553,18 @@
         ]
       },
       {
+        "name": "Snapshots",
+        "doc": "Snapshots is an OPTIONAL capability, discovered by type assertion. Snapshots",
+        "operations": [
+          {
+            "name": "CreateSnapshot"
+          },
+          {
+            "name": "DescribeSnapshots"
+          }
+        ]
+      },
+      {
         "name": "SubnetGroups",
         "doc": "SubnetGroups is an OPTIONAL capability, discovered by type assertion. Cache",
         "operations": [

--- a/docs/coverage/gcp/memorystore.md
+++ b/docs/coverage/gcp/memorystore.md
@@ -40,6 +40,15 @@ ReplicationGroups is an OPTIONAL capability, discovered by type assertion.
 | `DescribeReplicationGroups` |  |
 | `ModifyReplicationGroup` |  |
 
+### Snapshots
+
+Snapshots is an OPTIONAL capability, discovered by type assertion. Snapshots
+
+| Operation | Description |
+| --- | --- |
+| `CreateSnapshot` |  |
+| `DescribeSnapshots` |  |
+
 ### SubnetGroups
 
 SubnetGroups is an OPTIONAL capability, discovered by type assertion. Cache

--- a/docs/coverage/gcp/memorystore.md
+++ b/docs/coverage/gcp/memorystore.md
@@ -42,7 +42,7 @@ ReplicationGroups is an OPTIONAL capability, discovered by type assertion.
 
 ### Snapshots
 
-Snapshots is an OPTIONAL capability, discovered by type assertion. Snapshots
+Snapshots is an OPTIONAL capability, discovered by type assertion.
 
 | Operation | Description |
 | --- | --- |

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -67,6 +67,7 @@ type Mock struct {
 	subnetGroups      *memstore.Store[driver.SubnetGroup]
 	replicationGroups *memstore.Store[driver.ReplicationGroup]
 	parameterGroups   *memstore.Store[ParameterGroup]
+	snapshots         *memstore.Store[driver.Snapshot]
 	subnetResolver    SubnetResolver
 	opts              *config.Options
 	monitoring        mondriver.Monitoring
@@ -108,6 +109,7 @@ func New(opts *config.Options) *Mock {
 		subnetGroups:      memstore.New[driver.SubnetGroup](),
 		replicationGroups: memstore.New[driver.ReplicationGroup](),
 		parameterGroups:   memstore.New[ParameterGroup](),
+		snapshots:         memstore.New[driver.Snapshot](),
 		tagsByARN:         make(map[string]map[string]string),
 		opts:              opts,
 	}

--- a/providers/aws/elasticache/snapshot.go
+++ b/providers/aws/elasticache/snapshot.go
@@ -1,0 +1,131 @@
+package elasticache
+
+import (
+	"context"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+)
+
+// snapshotARN builds an ElastiCache snapshot ARN.
+func (m *Mock) snapshotARN(name string) string {
+	return "arn:aws:elasticache:" + m.opts.Region + ":" + m.opts.AccountID + ":snapshot:" + name
+}
+
+// CreateSnapshot takes a point-in-time backup of a cache cluster or replication
+// group. Real ElastiCache lowercases the snapshot name and rejects a duplicate
+// with SnapshotAlreadyExistsFault; the identity of the source (engine, node
+// type, version, port, node count) is copied into the snapshot so a restore can
+// recreate a like-for-like cluster.
+func (m *Mock) CreateSnapshot(_ context.Context, cfg cachedriver.SnapshotConfig) (*cachedriver.Snapshot, error) {
+	name := strings.ToLower(cfg.SnapshotName)
+	if name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "SnapshotName is required")
+	}
+
+	if m.snapshots.Has(name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists,
+			"SnapshotAlreadyExistsFault: snapshot %q already exists", name)
+	}
+
+	snap := cachedriver.Snapshot{
+		Name:          name,
+		Status:        statusAvailable,
+		Source:        "manual",
+		Port:          defaultRedisPort,
+		NumCacheNodes: 1,
+		CreatedAt:     m.opts.Clock.Now().UTC(),
+		ARN:           m.snapshotARN(name),
+	}
+
+	if err := m.fillSnapshotSource(cfg, &snap); err != nil {
+		return nil, err
+	}
+
+	m.snapshots.Set(name, snap)
+
+	return &snap, nil
+}
+
+// fillSnapshotSource resolves the snapshot's source cluster or replication group
+// and copies its identity onto snap.
+func (m *Mock) fillSnapshotSource(cfg cachedriver.SnapshotConfig, snap *cachedriver.Snapshot) error {
+	switch {
+	case cfg.CacheClusterID != "":
+		cd, ok := m.caches.Get(cfg.CacheClusterID)
+		if !ok {
+			return cerrors.Newf(cerrors.NotFound,
+				"CacheClusterNotFound: cache cluster %q not found", cfg.CacheClusterID)
+		}
+
+		snap.CacheClusterID = cfg.CacheClusterID
+		snap.Engine = cd.info.Engine
+		snap.EngineVersion = cd.info.EngineVersion
+		snap.NodeType = cd.info.NodeType
+		snap.ParameterGroupName = paramGroupName(cd.info.Engine)
+	case cfg.ReplicationGroupID != "":
+		rg, ok := m.replicationGroups.Get(cfg.ReplicationGroupID)
+		if !ok {
+			return cerrors.Newf(cerrors.NotFound,
+				"ReplicationGroupNotFoundFault: replication group %q not found", cfg.ReplicationGroupID)
+		}
+
+		snap.ReplicationGroupID = cfg.ReplicationGroupID
+		snap.Engine = rg.Engine
+		snap.EngineVersion = rg.EngineVersion
+		snap.NodeType = rg.NodeType
+		snap.ParameterGroupName = paramGroupName(rg.Engine)
+
+		if rg.PrimaryPort != 0 {
+			snap.Port = rg.PrimaryPort
+		}
+	}
+
+	return nil
+}
+
+// paramGroupName derives the default cache parameter group name for an engine,
+// e.g. "default.redis". Empty for an unspecified engine.
+func paramGroupName(engine string) string {
+	if engine == "" {
+		return ""
+	}
+
+	return "default." + engine
+}
+
+// DescribeSnapshots returns all snapshots, narrowed by the non-empty filter
+// fields. An explicit SnapshotName that matches nothing reports
+// SnapshotNotFoundFault, as real ElastiCache does.
+func (m *Mock) DescribeSnapshots(
+	_ context.Context, filter cachedriver.SnapshotFilter,
+) ([]cachedriver.Snapshot, error) {
+	if name := strings.ToLower(filter.SnapshotName); name != "" {
+		snap, ok := m.snapshots.Get(name)
+		if !ok {
+			return nil, cerrors.Newf(cerrors.NotFound,
+				"SnapshotNotFoundFault: snapshot %q not found", name)
+		}
+
+		return []cachedriver.Snapshot{snap}, nil
+	}
+
+	all := m.snapshots.SortedValues()
+
+	out := make([]cachedriver.Snapshot, 0, len(all))
+
+	for i := range all {
+		if filter.CacheClusterID != "" && all[i].CacheClusterID != filter.CacheClusterID {
+			continue
+		}
+
+		if filter.ReplicationGroupID != "" && all[i].ReplicationGroupID != filter.ReplicationGroupID {
+			continue
+		}
+
+		out = append(out, all[i])
+	}
+
+	return out, nil
+}

--- a/providers/aws/elasticache/snapshot_test.go
+++ b/providers/aws/elasticache/snapshot_test.go
@@ -1,0 +1,137 @@
+package elasticache
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateSnapshotFromCluster(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCache(ctx, driver.CacheConfig{
+		Name: "cluster-1", Engine: "redis", NodeType: "cache.t3.small",
+	})
+	require.NoError(t, err)
+
+	snap, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{
+		SnapshotName: "Snap-1", CacheClusterID: "cluster-1",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "snap-1", snap.Name, "name should be lowercased")
+	assert.Equal(t, "cluster-1", snap.CacheClusterID)
+	assert.Equal(t, statusAvailable, snap.Status)
+	assert.Equal(t, "manual", snap.Source)
+	assert.Equal(t, "redis", snap.Engine)
+	assert.Equal(t, "cache.t3.small", snap.NodeType)
+	assert.Equal(t, 1, snap.NumCacheNodes)
+	assert.Equal(t, defaultRedisPort, snap.Port)
+	assert.NotEmpty(t, snap.ARN)
+	assert.False(t, snap.CreatedAt.IsZero())
+}
+
+func TestCreateSnapshotRequiresName(t *testing.T) {
+	m, _ := newTestMock()
+
+	_, err := m.CreateSnapshot(context.Background(), driver.SnapshotConfig{CacheClusterID: "c"})
+	require.Error(t, err)
+	assert.True(t, cerrors.IsInvalidArgument(err))
+}
+
+func TestCreateSnapshotDuplicateFails(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCache(ctx, driver.CacheConfig{Name: "c1"})
+	require.NoError(t, err)
+
+	_, err = m.CreateSnapshot(ctx, driver.SnapshotConfig{SnapshotName: "dup", CacheClusterID: "c1"})
+	require.NoError(t, err)
+
+	_, err = m.CreateSnapshot(ctx, driver.SnapshotConfig{SnapshotName: "dup", CacheClusterID: "c1"})
+	require.Error(t, err)
+	assert.True(t, cerrors.IsAlreadyExists(err))
+}
+
+func TestCreateSnapshotUnknownClusterFails(t *testing.T) {
+	m, _ := newTestMock()
+
+	_, err := m.CreateSnapshot(context.Background(), driver.SnapshotConfig{
+		SnapshotName: "s", CacheClusterID: "missing",
+	})
+	require.Error(t, err)
+	assert.True(t, cerrors.IsNotFound(err))
+}
+
+func TestCreateSnapshotUnknownReplicationGroupFails(t *testing.T) {
+	m, _ := newTestMock()
+
+	_, err := m.CreateSnapshot(context.Background(), driver.SnapshotConfig{
+		SnapshotName: "s", ReplicationGroupID: "missing",
+	})
+	require.Error(t, err)
+	assert.True(t, cerrors.IsNotFound(err))
+}
+
+func TestCreateSnapshotFromReplicationGroup(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateReplicationGroup(ctx, driver.ReplicationGroupConfig{
+		ID: "rg-1", Engine: "redis", NodeType: "cache.r6g.large",
+	})
+	require.NoError(t, err)
+
+	snap, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{
+		SnapshotName: "rg-snap", ReplicationGroupID: "rg-1",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "rg-1", snap.ReplicationGroupID)
+	assert.Empty(t, snap.CacheClusterID)
+	assert.Equal(t, "cache.r6g.large", snap.NodeType)
+	assert.Equal(t, defaultRedisPort, snap.Port)
+}
+
+func TestDescribeSnapshotsFilters(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	for _, id := range []string{"ca", "cb"} {
+		_, err := m.CreateCache(ctx, driver.CacheConfig{Name: id})
+		require.NoError(t, err)
+	}
+
+	_, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{SnapshotName: "sa", CacheClusterID: "ca"})
+	require.NoError(t, err)
+	_, err = m.CreateSnapshot(ctx, driver.SnapshotConfig{SnapshotName: "sb", CacheClusterID: "cb"})
+	require.NoError(t, err)
+
+	all, err := m.DescribeSnapshots(ctx, driver.SnapshotFilter{})
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+
+	byName, err := m.DescribeSnapshots(ctx, driver.SnapshotFilter{SnapshotName: "sa"})
+	require.NoError(t, err)
+	require.Len(t, byName, 1)
+	assert.Equal(t, "sa", byName[0].Name)
+
+	byCluster, err := m.DescribeSnapshots(ctx, driver.SnapshotFilter{CacheClusterID: "cb"})
+	require.NoError(t, err)
+	require.Len(t, byCluster, 1)
+	assert.Equal(t, "cb", byCluster[0].CacheClusterID)
+}
+
+func TestDescribeSnapshotsUnknownNameFails(t *testing.T) {
+	m, _ := newTestMock()
+
+	_, err := m.DescribeSnapshots(context.Background(), driver.SnapshotFilter{SnapshotName: "ghost"})
+	require.Error(t, err)
+	assert.True(t, cerrors.IsNotFound(err))
+}

--- a/server/aws/elasticache/dispatch_test.go
+++ b/server/aws/elasticache/dispatch_test.go
@@ -47,3 +47,43 @@ func TestMatchesScopeGatesSharedTagActions(t *testing.T) {
 		})
 	}
 }
+
+// TestElastiCacheClaimsScopedSnapshotActions verifies CreateSnapshot /
+// DescribeSnapshots — Action names shared with EC2's EBS snapshots — are only
+// claimed when the SigV4 credential scope names "elasticache". Critically, an
+// EC2-scoped CreateSnapshot must NOT be claimed so it still routes to the EC2
+// EBS handler; ElastiCache registers before EC2, so a missing gate here would
+// steal every EBS snapshot call.
+func TestElastiCacheClaimsScopedSnapshotActions(t *testing.T) {
+	h := elasticache.New(nil)
+
+	const (
+		ec2Scope   = "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ec2/aws4_request, Signature=x"
+		cacheScope = "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/elasticache/aws4_request, Signature=x"
+	)
+
+	cases := []struct {
+		name   string
+		action string
+		auth   string
+		want   bool
+	}{
+		{"CreateSnapshot under ec2 scope falls through", "CreateSnapshot", ec2Scope, false},
+		{"CreateSnapshot under elasticache scope is claimed", "CreateSnapshot", cacheScope, true},
+		{"DescribeSnapshots under ec2 scope falls through", "DescribeSnapshots", ec2Scope, false},
+		{"DescribeSnapshots under elasticache scope is claimed", "DescribeSnapshots", cacheScope, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := "Action=" + tc.action + "&Version=2015-02-02"
+			req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Set("Authorization", tc.auth)
+
+			if got := h.Matches(req); got != tc.want {
+				t.Fatalf("Matches(%s, scope in %q) = %v, want %v", tc.action, tc.auth, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/aws/elasticache/handler.go
+++ b/server/aws/elasticache/handler.go
@@ -59,6 +59,8 @@ var elastiCacheActions = map[string]struct{}{ //nolint:gochecknoglobals // stati
 	"DescribeReplicationGroups":    {},
 	"ModifyReplicationGroup":       {},
 	"DeleteReplicationGroup":       {},
+	"CreateSnapshot":               {},
+	"DescribeSnapshots":            {},
 }
 
 // sharedTagActions are the generic tag verbs ElastiCache shares with other
@@ -69,6 +71,17 @@ var sharedTagActions = map[string]struct{}{ //nolint:gochecknoglobals // static 
 	"AddTagsToResource":      {},
 	"ListTagsForResource":    {},
 	"RemoveTagsFromResource": {},
+}
+
+// sharedSnapshotActions are the snapshot verbs whose Action names collide with
+// EC2's EBS snapshots (CreateSnapshot / DescribeSnapshots) on the same query
+// wire. ElastiCache registers before EC2 (first-match-wins), so without a scope
+// gate this handler would steal every EBS snapshot call. Matches claims them
+// only when the SigV4 credential scope names "elasticache"; otherwise they fall
+// through to the EC2 EBS handler.
+var sharedSnapshotActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup table
+	"CreateSnapshot":    {},
+	"DescribeSnapshots": {},
 }
 
 // scopeElastiCache is the SigV4 credential-scope service name for ElastiCache.
@@ -120,6 +133,13 @@ func (*Handler) Matches(r *http.Request) bool {
 		return awsquery.CredentialScopeService(r.Header.Get("Authorization")) == scopeElastiCache
 	}
 
+	// The snapshot verbs collide with EC2's EBS snapshots. Claim them only when
+	// the SigV4 credential scope names "elasticache"; an EC2-scoped call falls
+	// through to the EC2 EBS handler.
+	if _, shared := sharedSnapshotActions[action]; shared {
+		return awsquery.CredentialScopeService(r.Header.Get("Authorization")) == scopeElastiCache
+	}
+
 	return true
 }
 
@@ -168,6 +188,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.deleteCacheParameterGroup(w, r)
 	case "DescribeCacheEngineVersions":
 		h.describeCacheEngineVersions(w, r)
+	case "CreateSnapshot":
+		h.createSnapshot(w, r)
+	case "DescribeSnapshots":
+		h.describeSnapshots(w, r)
 	default:
 		awsquery.WriteXMLError(w, http.StatusBadRequest,
 			"InvalidAction", "unknown ElastiCache action: "+r.Form.Get("Action"))
@@ -201,6 +225,8 @@ func notFoundCode(err error) string {
 	msg := err.Error()
 
 	switch {
+	case strings.Contains(msg, "snapshot"):
+		return "SnapshotNotFoundFault"
 	case strings.Contains(msg, "replication group"):
 		return "ReplicationGroupNotFoundFault"
 	case strings.Contains(msg, "cache subnet group"):
@@ -219,6 +245,8 @@ func alreadyExistsCode(err error) string {
 	msg := err.Error()
 
 	switch {
+	case strings.Contains(msg, "snapshot"):
+		return "SnapshotAlreadyExistsFault"
 	case strings.Contains(msg, "replication group"):
 		return "ReplicationGroupAlreadyExists"
 	case strings.Contains(msg, "cache subnet group"):

--- a/server/aws/elasticache/snapshot.go
+++ b/server/aws/elasticache/snapshot.go
@@ -1,0 +1,70 @@
+package elasticache
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+)
+
+// snapshots reports the snapshot capability, if the driver implements it.
+func (h *Handler) snapshots() (cachedriver.Snapshots, bool) {
+	s, ok := h.cache.(cachedriver.Snapshots)
+
+	return s, ok
+}
+
+func (h *Handler) createSnapshot(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.snapshots()
+	if !ok {
+		writeUnsupported(w, "snapshots")
+		return
+	}
+
+	snap, err := store.CreateSnapshot(r.Context(), cachedriver.SnapshotConfig{
+		SnapshotName:       r.Form.Get("SnapshotName"),
+		CacheClusterID:     r.Form.Get("CacheClusterId"),
+		ReplicationGroupID: r.Form.Get("ReplicationGroupId"),
+		KmsKeyID:           r.Form.Get("KmsKeyId"),
+		Tags:               parseTags(r.Form),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createSnapshotResponse{
+		Xmlns:    Namespace,
+		Result:   snapshotResult{Snapshot: toSnapshotXML(snap)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) describeSnapshots(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.snapshots()
+	if !ok {
+		writeUnsupported(w, "snapshots")
+		return
+	}
+
+	snaps, err := store.DescribeSnapshots(r.Context(), cachedriver.SnapshotFilter{
+		SnapshotName:       r.Form.Get("SnapshotName"),
+		CacheClusterID:     r.Form.Get("CacheClusterId"),
+		ReplicationGroupID: r.Form.Get("ReplicationGroupId"),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]snapshotXML, 0, len(snaps))
+	for i := range snaps {
+		out = append(out, toSnapshotXML(&snaps[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeSnapshotsResponse{
+		Xmlns:    Namespace,
+		Result:   describeSnapshotsResult{Snapshots: snapshotsListXML{Snapshot: out}},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}

--- a/server/aws/elasticache/snapshot_sdk_roundtrip_test.go
+++ b/server/aws/elasticache/snapshot_sdk_roundtrip_test.go
@@ -1,0 +1,211 @@
+package elasticache_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+	ectypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+func newSnapshotClient(t *testing.T) *awselasticache.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	ts := httptest.NewServer(awsserver.New(awsserver.DriversFrom(cloud)))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	cfg.BaseEndpoint = aws.String(ts.URL)
+
+	return awselasticache.NewFromConfig(cfg)
+}
+
+func mustCreateCluster(t *testing.T, c *awselasticache.Client, id string) {
+	t.Helper()
+
+	_, err := c.CreateCacheCluster(context.Background(), &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String(id),
+		Engine:         aws.String("redis"),
+		CacheNodeType:  aws.String("cache.t3.micro"),
+		NumCacheNodes:  aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("CreateCacheCluster(%s): %v", id, err)
+	}
+}
+
+func TestCreateSnapshotSDKRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c := newSnapshotClient(t)
+
+	mustCreateCluster(t, c, "cluster-1")
+
+	out, err := c.CreateSnapshot(ctx, &awselasticache.CreateSnapshotInput{
+		SnapshotName:   aws.String("snap-1"),
+		CacheClusterId: aws.String("cluster-1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	s := out.Snapshot
+	if s == nil {
+		t.Fatal("CreateSnapshot returned nil Snapshot")
+	}
+
+	if got := aws.ToString(s.SnapshotName); got != "snap-1" {
+		t.Errorf("SnapshotName = %q, want snap-1", got)
+	}
+	if got := aws.ToString(s.CacheClusterId); got != "cluster-1" {
+		t.Errorf("CacheClusterId = %q, want cluster-1", got)
+	}
+	if got := aws.ToString(s.SnapshotStatus); got != "available" {
+		t.Errorf("SnapshotStatus = %q, want available", got)
+	}
+	if got := aws.ToString(s.SnapshotSource); got != "manual" {
+		t.Errorf("SnapshotSource = %q, want manual", got)
+	}
+	if got := aws.ToString(s.Engine); got != "redis" {
+		t.Errorf("Engine = %q, want redis", got)
+	}
+	if got := aws.ToString(s.CacheNodeType); got != "cache.t3.micro" {
+		t.Errorf("CacheNodeType = %q, want cache.t3.micro", got)
+	}
+	if got := aws.ToInt32(s.NumCacheNodes); got != 1 {
+		t.Errorf("NumCacheNodes = %d, want 1", got)
+	}
+	if got := aws.ToInt32(s.Port); got != 6379 {
+		t.Errorf("Port = %d, want 6379", got)
+	}
+	if aws.ToString(s.ARN) == "" {
+		t.Error("ARN is empty")
+	}
+}
+
+func TestDescribeSnapshotsSDKRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c := newSnapshotClient(t)
+
+	mustCreateCluster(t, c, "cluster-a")
+	mustCreateCluster(t, c, "cluster-b")
+
+	for _, in := range []awselasticache.CreateSnapshotInput{
+		{SnapshotName: aws.String("snap-a"), CacheClusterId: aws.String("cluster-a")},
+		{SnapshotName: aws.String("snap-b"), CacheClusterId: aws.String("cluster-b")},
+	} {
+		if _, err := c.CreateSnapshot(ctx, &in); err != nil {
+			t.Fatalf("CreateSnapshot(%s): %v", aws.ToString(in.SnapshotName), err)
+		}
+	}
+
+	all, err := c.DescribeSnapshots(ctx, &awselasticache.DescribeSnapshotsInput{})
+	if err != nil {
+		t.Fatalf("DescribeSnapshots: %v", err)
+	}
+	if len(all.Snapshots) != 2 {
+		t.Fatalf("DescribeSnapshots returned %d, want 2", len(all.Snapshots))
+	}
+
+	byName, err := c.DescribeSnapshots(ctx, &awselasticache.DescribeSnapshotsInput{
+		SnapshotName: aws.String("snap-a"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeSnapshots by name: %v", err)
+	}
+	if len(byName.Snapshots) != 1 {
+		t.Fatalf("filter by name returned %d, want 1", len(byName.Snapshots))
+	}
+	if got := aws.ToString(byName.Snapshots[0].SnapshotName); got != "snap-a" {
+		t.Errorf("filtered name = %q, want snap-a", got)
+	}
+
+	byCluster, err := c.DescribeSnapshots(ctx, &awselasticache.DescribeSnapshotsInput{
+		CacheClusterId: aws.String("cluster-b"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeSnapshots by cluster: %v", err)
+	}
+	if len(byCluster.Snapshots) != 1 {
+		t.Fatalf("filter by cluster returned %d, want 1", len(byCluster.Snapshots))
+	}
+	if got := aws.ToString(byCluster.Snapshots[0].CacheClusterId); got != "cluster-b" {
+		t.Errorf("filtered cluster = %q, want cluster-b", got)
+	}
+}
+
+func TestCreateSnapshotDuplicateReturnsSnapshotAlreadyExistsFault(t *testing.T) {
+	ctx := context.Background()
+	c := newSnapshotClient(t)
+
+	mustCreateCluster(t, c, "cluster-dup")
+
+	in := &awselasticache.CreateSnapshotInput{
+		SnapshotName:   aws.String("snap-dup"),
+		CacheClusterId: aws.String("cluster-dup"),
+	}
+	if _, err := c.CreateSnapshot(ctx, in); err != nil {
+		t.Fatalf("first CreateSnapshot: %v", err)
+	}
+
+	_, err := c.CreateSnapshot(ctx, in)
+	if err == nil {
+		t.Fatal("duplicate CreateSnapshot should fail")
+	}
+
+	var already *ectypes.SnapshotAlreadyExistsFault
+	if !errors.As(err, &already) {
+		t.Fatalf("error = %v, want SnapshotAlreadyExistsFault", err)
+	}
+}
+
+func TestCreateSnapshotMissingClusterReturnsCacheClusterNotFound(t *testing.T) {
+	ctx := context.Background()
+	c := newSnapshotClient(t)
+
+	_, err := c.CreateSnapshot(ctx, &awselasticache.CreateSnapshotInput{
+		SnapshotName:   aws.String("snap-x"),
+		CacheClusterId: aws.String("no-such-cluster"),
+	})
+	if err == nil {
+		t.Fatal("CreateSnapshot for a missing cluster should fail")
+	}
+
+	var notFound *ectypes.CacheClusterNotFoundFault
+	if !errors.As(err, &notFound) {
+		t.Fatalf("error = %v, want CacheClusterNotFoundFault", err)
+	}
+}
+
+func TestDescribeSnapshotsUnknownNameReturnsSnapshotNotFoundFault(t *testing.T) {
+	ctx := context.Background()
+	c := newSnapshotClient(t)
+
+	_, err := c.DescribeSnapshots(ctx, &awselasticache.DescribeSnapshotsInput{
+		SnapshotName: aws.String("ghost"),
+	})
+	if err == nil {
+		t.Fatal("DescribeSnapshots for an unknown name should fail")
+	}
+
+	var notFound *ectypes.SnapshotNotFoundFault
+	if !errors.As(err, &notFound) {
+		t.Fatalf("error = %v, want SnapshotNotFoundFault", err)
+	}
+}

--- a/server/aws/elasticache/types.go
+++ b/server/aws/elasticache/types.go
@@ -107,6 +107,90 @@ type describeCacheClustersResponse struct {
 	Metadata responseMetadata            `xml:"ResponseMetadata"`
 }
 
+// nodeSnapshotXML mirrors AWS's NodeSnapshot — the per-node backup record a
+// caller reads to size a restore.
+type nodeSnapshotXML struct {
+	CacheNodeID         string `xml:"CacheNodeId,omitempty"`
+	CacheNodeCreateTime string `xml:"CacheNodeCreateTime,omitempty"`
+	SnapshotCreateTime  string `xml:"SnapshotCreateTime,omitempty"`
+	CacheSize           string `xml:"CacheSize,omitempty"`
+}
+
+// snapshotXML mirrors AWS's Snapshot resource. Only the fields the cache driver
+// can populate are emitted; the rest are omitted.
+type snapshotXML struct {
+	SnapshotName            string            `xml:"SnapshotName"`
+	CacheClusterID          string            `xml:"CacheClusterId,omitempty"`
+	ReplicationGroupID      string            `xml:"ReplicationGroupId,omitempty"`
+	SnapshotStatus          string            `xml:"SnapshotStatus,omitempty"`
+	SnapshotSource          string            `xml:"SnapshotSource,omitempty"`
+	Engine                  string            `xml:"Engine,omitempty"`
+	EngineVersion           string            `xml:"EngineVersion,omitempty"`
+	CacheNodeType           string            `xml:"CacheNodeType,omitempty"`
+	NumCacheNodes           int               `xml:"NumCacheNodes,omitempty"`
+	Port                    int               `xml:"Port,omitempty"`
+	CacheParameterGroupName string            `xml:"CacheParameterGroupName,omitempty"`
+	SnapshotRetentionLimit  int               `xml:"SnapshotRetentionLimit,omitempty"`
+	SnapshotWindow          string            `xml:"SnapshotWindow,omitempty"`
+	ARN                     string            `xml:"ARN,omitempty"`
+	NodeSnapshots           []nodeSnapshotXML `xml:"NodeSnapshots>NodeSnapshot,omitempty"`
+}
+
+type snapshotResult struct {
+	Snapshot snapshotXML `xml:"Snapshot"`
+}
+
+type createSnapshotResponse struct {
+	XMLName  xml.Name         `xml:"CreateSnapshotResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   snapshotResult   `xml:"CreateSnapshotResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type snapshotsListXML struct {
+	Snapshot []snapshotXML `xml:"Snapshot,omitempty"`
+}
+
+type describeSnapshotsResult struct {
+	Marker    string           `xml:"Marker,omitempty"`
+	Snapshots snapshotsListXML `xml:"Snapshots"`
+}
+
+type describeSnapshotsResponse struct {
+	XMLName  xml.Name                `xml:"DescribeSnapshotsResponse"`
+	Xmlns    string                  `xml:"xmlns,attr"`
+	Result   describeSnapshotsResult `xml:"DescribeSnapshotsResult"`
+	Metadata responseMetadata        `xml:"ResponseMetadata"`
+}
+
+// toSnapshotXML converts a driver Snapshot into its ElastiCache XML shape.
+func toSnapshotXML(s *cachedriver.Snapshot) snapshotXML {
+	created := s.CreatedAt.UTC().Format("2006-01-02T15:04:05Z")
+
+	return snapshotXML{
+		SnapshotName:            s.Name,
+		CacheClusterID:          s.CacheClusterID,
+		ReplicationGroupID:      s.ReplicationGroupID,
+		SnapshotStatus:          s.Status,
+		SnapshotSource:          s.Source,
+		Engine:                  s.Engine,
+		EngineVersion:           s.EngineVersion,
+		CacheNodeType:           s.NodeType,
+		NumCacheNodes:           s.NumCacheNodes,
+		Port:                    s.Port,
+		CacheParameterGroupName: s.ParameterGroupName,
+		SnapshotRetentionLimit:  s.RetentionLimit,
+		SnapshotWindow:          s.SnapshotWindow,
+		ARN:                     s.ARN,
+		NodeSnapshots: []nodeSnapshotXML{{
+			CacheNodeID:         "0001",
+			CacheNodeCreateTime: created,
+			SnapshotCreateTime:  created,
+			CacheSize:           "0",
+		}},
+	}
+}
+
 // defaultParamGroupName derives the default cache parameter group name AWS
 // assigns to a cluster, e.g. "default.redis7" or "default.memcached1.6". For
 // redis the family is engine + major version; for memcached it is major.minor.

--- a/services/cache/driver/driver.go
+++ b/services/cache/driver/driver.go
@@ -157,3 +157,49 @@ type ReplicationGroups interface {
 	ModifyReplicationGroup(ctx context.Context, id string, numCacheNodes int) (*ReplicationGroup, error)
 	DeleteReplicationGroup(ctx context.Context, id string) error
 }
+
+// Snapshot is a point-in-time backup of an ElastiCache cluster or replication
+// group. It captures the source's engine/node identity so a restore can
+// recreate a like-for-like cluster.
+type Snapshot struct {
+	Name               string
+	CacheClusterID     string
+	ReplicationGroupID string
+	Status             string
+	Source             string
+	Engine             string
+	EngineVersion      string
+	NodeType           string
+	NumCacheNodes      int
+	Port               int
+	ParameterGroupName string
+	SnapshotWindow     string
+	RetentionLimit     int
+	ARN                string
+	CreatedAt          time.Time
+}
+
+// SnapshotConfig describes a snapshot to create. Exactly one of CacheClusterID
+// or ReplicationGroupID identifies the source.
+type SnapshotConfig struct {
+	SnapshotName       string
+	CacheClusterID     string
+	ReplicationGroupID string
+	KmsKeyID           string
+	Tags               map[string]string
+}
+
+// SnapshotFilter narrows a DescribeSnapshots call. Empty fields do not filter.
+type SnapshotFilter struct {
+	SnapshotName       string
+	CacheClusterID     string
+	ReplicationGroupID string
+}
+
+// Snapshots is an OPTIONAL capability, discovered by type assertion. Snapshots
+// are an AWS ElastiCache concept (Redis/Valkey only); drivers for other clouds
+// do not model them and answering InvalidAction is the truthful response there.
+type Snapshots interface {
+	CreateSnapshot(ctx context.Context, cfg SnapshotConfig) (*Snapshot, error)
+	DescribeSnapshots(ctx context.Context, filter SnapshotFilter) ([]Snapshot, error)
+}

--- a/services/cache/driver/driver.go
+++ b/services/cache/driver/driver.go
@@ -196,9 +196,9 @@ type SnapshotFilter struct {
 	ReplicationGroupID string
 }
 
-// Snapshots is an OPTIONAL capability, discovered by type assertion. Snapshots
-// are an AWS ElastiCache concept (Redis/Valkey only); drivers for other clouds
-// do not model them and answering InvalidAction is the truthful response there.
+// Snapshots is an OPTIONAL capability, discovered by type assertion.
+// ElastiCache snapshots are an AWS concept (Redis/Valkey only); drivers for other
+// clouds do not model them and answering InvalidAction is the truthful response.
 type Snapshots interface {
 	CreateSnapshot(ctx context.Context, cfg SnapshotConfig) (*Snapshot, error)
 	DescribeSnapshots(ctx context.Context, filter SnapshotFilter) ([]Snapshot, error)


### PR DESCRIPTION
Fixes a dispatch-shadowing bug: CreateSnapshot/DescribeSnapshots are Action-name collisions with EC2 EBS snapshots; elasticache registers before ec2, so they fell through to the EC2 catch-all and returned EBS-shaped XML the SDK couldn't deserialize. Fix adds them to elastiCacheActions and scope-gates them (sharedSnapshotActions, mirroring the existing sharedTagActions) so an elasticache-scoped call is claimed while an ec2-scoped CreateSnapshot still routes to EC2 EBS (dispatch test guards this). AWS-only optional Snapshots interface + provider snapshot model. Coverage docs regenerated (repo's coveragegen documents optional interfaces). SDK + provider tests; compat suite clean.