### PR TITLE
fix(ec2): MaxResults/NextToken pagination for VPC-family Describe*

### DIFF
--- a/server/aws/ec2/internet_gateway.go
+++ b/server/aws/ec2/internet_gateway.go
@@ -39,6 +39,7 @@ type describeInternetGatewaysResponseXML struct {
 	Xmlns              string               `xml:"xmlns,attr"`
 	RequestID          string               `xml:"requestId"`
 	InternetGatewaySet []internetGatewayXML `xml:"internetGatewaySet>item"`
+	NextToken          string               `xml:"nextToken,omitempty"`
 }
 
 type attachInternetGatewayResponseXML struct {
@@ -137,10 +138,15 @@ func (h *Handler) describeInternetGateways(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	page, next := pageNetworkingXML(
+		filterXML(igws, filters, igwMatchesFilters, toInternetGatewayXML), r,
+		func(igw internetGatewayXML) string { return igw.InternetGatewayID })
+
 	awsquery.WriteXMLResponse(w, describeInternetGatewaysResponseXML{
 		Xmlns:              awsquery.Namespace,
 		RequestID:          awsquery.RequestID,
-		InternetGatewaySet: filterXML(igws, filters, igwMatchesFilters, toInternetGatewayXML),
+		InternetGatewaySet: page,
+		NextToken:          next,
 	})
 }
 

--- a/server/aws/ec2/internet_gateway_test.go
+++ b/server/aws/ec2/internet_gateway_test.go
@@ -101,3 +101,59 @@ func TestInternetGatewayAttachmentStateFilter(t *testing.T) {
 		t.Fatalf("attachment.state=available returned %d gateways, want only %s", len(out.InternetGateways), igwID)
 	}
 }
+
+// TestDescribeInternetGatewaysPaginatesAllOnce pins that
+// DescribeInternetGateways honors MaxResults/NextToken, paging every gateway
+// exactly once with no duplicates across pages.
+func TestDescribeInternetGatewaysPaginatesAllOnce(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	want := map[string]int{}
+	for range 3 {
+		igw, err := c.CreateInternetGateway(ctx, &ec2.CreateInternetGatewayInput{})
+		if err != nil {
+			t.Fatalf("CreateInternetGateway: %v", err)
+		}
+
+		want[aws.ToString(igw.InternetGateway.InternetGatewayId)] = 0
+	}
+
+	seen := map[string]int{}
+
+	var token *string
+
+	for {
+		out, err := c.DescribeInternetGateways(ctx, &ec2.DescribeInternetGatewaysInput{
+			MaxResults: aws.Int32(1),
+			NextToken:  token,
+		})
+		if err != nil {
+			t.Fatalf("DescribeInternetGateways: %v", err)
+		}
+
+		if len(out.InternetGateways) > 1 {
+			t.Fatalf("page returned %d gateways, want at most 1", len(out.InternetGateways))
+		}
+
+		for _, igw := range out.InternetGateways {
+			seen[aws.ToString(igw.InternetGatewayId)]++
+		}
+
+		if aws.ToString(out.NextToken) == "" {
+			break
+		}
+
+		token = out.NextToken
+	}
+
+	if len(seen) != len(want) {
+		t.Fatalf("paged through %d gateways, want %d", len(seen), len(want))
+	}
+
+	for id, n := range seen {
+		if n != 1 {
+			t.Fatalf("gateway %s seen %d times across pages, want 1", id, n)
+		}
+	}
+}

--- a/server/aws/ec2/network_acl.go
+++ b/server/aws/ec2/network_acl.go
@@ -42,6 +42,7 @@ type describeNetworkACLsResponseXML struct {
 	Xmlns         string          `xml:"xmlns,attr"`
 	RequestID     string          `xml:"requestId"`
 	NetworkACLSet []networkACLXML `xml:"networkAclSet>item"`
+	NextToken     string          `xml:"nextToken,omitempty"`
 }
 
 type deleteNetworkACLResponseXML struct {
@@ -101,7 +102,6 @@ func (h *Handler) deleteNetworkACL(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // per-resource describe pattern
 func (h *Handler) describeNetworkACLs(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "NetworkAclId")
 
@@ -116,10 +116,13 @@ func (h *Handler) describeNetworkACLs(w http.ResponseWriter, r *http.Request) {
 		out = append(out, toNetworkACLXML(&acls[i]))
 	}
 
+	page, next := pageNetworkingXML(out, r, func(a networkACLXML) string { return a.NetworkACLID })
+
 	awsquery.WriteXMLResponse(w, describeNetworkACLsResponseXML{
 		Xmlns:         awsquery.Namespace,
 		RequestID:     awsquery.RequestID,
-		NetworkACLSet: out,
+		NetworkACLSet: page,
+		NextToken:     next,
 	})
 }
 

--- a/server/aws/ec2/network_acl_test.go
+++ b/server/aws/ec2/network_acl_test.go
@@ -114,3 +114,60 @@ func findACLEntry(entries []ec2types.NetworkAclEntry, ruleNumber int32, egress b
 
 	return nil
 }
+
+// TestDescribeNetworkAclsPaginatesAllOnce pins that DescribeNetworkAcls honors
+// MaxResults/NextToken, paging every ACL exactly once with no duplicates.
+func TestDescribeNetworkAclsPaginatesAllOnce(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpcID := mkVPC(ctx, t, c, "10.0.0.0/16")
+
+	want := map[string]int{}
+	for range 3 {
+		acl, err := c.CreateNetworkAcl(ctx, &ec2.CreateNetworkAclInput{VpcId: aws.String(vpcID)})
+		if err != nil {
+			t.Fatalf("CreateNetworkAcl: %v", err)
+		}
+
+		want[aws.ToString(acl.NetworkAcl.NetworkAclId)] = 0
+	}
+
+	seen := map[string]int{}
+
+	var token *string
+
+	for {
+		out, err := c.DescribeNetworkAcls(ctx, &ec2.DescribeNetworkAclsInput{
+			MaxResults: aws.Int32(1),
+			NextToken:  token,
+		})
+		if err != nil {
+			t.Fatalf("DescribeNetworkAcls: %v", err)
+		}
+
+		if len(out.NetworkAcls) > 1 {
+			t.Fatalf("page returned %d ACLs, want at most 1", len(out.NetworkAcls))
+		}
+
+		for _, a := range out.NetworkAcls {
+			seen[aws.ToString(a.NetworkAclId)]++
+		}
+
+		if aws.ToString(out.NextToken) == "" {
+			break
+		}
+
+		token = out.NextToken
+	}
+
+	if len(seen) != len(want) {
+		t.Fatalf("paged through %d ACLs, want %d", len(seen), len(want))
+	}
+
+	for id, n := range seen {
+		if n != 1 {
+			t.Fatalf("ACL %s seen %d times across pages, want 1", id, n)
+		}
+	}
+}

--- a/server/aws/ec2/networking_common.go
+++ b/server/aws/ec2/networking_common.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"encoding/xml"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
@@ -39,6 +40,18 @@ func filterXML[T any, X any](
 	}
 
 	return out
+}
+
+// pageNetworkingXML stable-sorts the already-filtered items by their id, then
+// applies the request's MaxResults/NextToken paging, returning the page and the
+// NextToken to echo (empty on the last page). The VPC-family Describe handlers
+// share it so every resource paginates identically. The driver/memstore iterate
+// in map order, so sorting first is what makes the base64 cursor stable across
+// calls (matching how groupReservations sorts before paging DescribeInstances).
+func pageNetworkingXML[X any](items []X, r *http.Request, idOf func(X) string) (page []X, next string) {
+	sort.Slice(items, func(i, j int) bool { return idOf(items[i]) < idOf(items[j]) })
+
+	return paginateXML(items, r.Form.Get("MaxResults"), r.Form.Get("NextToken"), idOf)
 }
 
 // tagFilterMatch evaluates a "tag:<key>" or "tag-key" filter against a resource's

--- a/server/aws/ec2/networking_pagination_test.go
+++ b/server/aws/ec2/networking_pagination_test.go
@@ -1,0 +1,115 @@
+package ec2
+
+import (
+	"encoding/base64"
+	"strconv"
+	"testing"
+)
+
+// idOfString is the identity id-selector used by the paginateXML unit tests.
+func idOfString(s string) string { return s }
+
+func pageIDs(items []string) []string { return items }
+
+// TestPaginateXMLFullSetWhenNoLimit pins that an empty, zero, or unparsable
+// MaxResults returns the whole set with no NextToken (DescribeInstances parity).
+func TestPaginateXMLFullSetWhenNoLimit(t *testing.T) {
+	items := []string{"a", "b", "c"}
+
+	for _, max := range []string{"", "0", "-1", "abc"} {
+		page, next := paginateXML(items, max, "", idOfString)
+		if len(page) != 3 || next != "" {
+			t.Fatalf("MaxResults=%q: page=%v next=%q, want full set and empty token", max, page, next)
+		}
+	}
+}
+
+// TestPaginateXMLPageAndToken pins that a limit smaller than the set returns
+// exactly that many items plus a NextToken pointing at the next item's id.
+func TestPaginateXMLPageAndToken(t *testing.T) {
+	items := []string{"a", "b", "c"}
+
+	page, next := paginateXML(items, "2", "", idOfString)
+	if len(page) != 2 || page[0] != "a" || page[1] != "b" {
+		t.Fatalf("page = %v, want [a b]", page)
+	}
+
+	wantToken := base64.StdEncoding.EncodeToString([]byte("c"))
+	if next != wantToken {
+		t.Fatalf("next = %q, want %q (base64 of the first item on the next page)", next, wantToken)
+	}
+}
+
+// TestPaginateXMLRoundTripResumesAndTerminates pins that following the emitted
+// NextToken resumes at the correct offset and the final page carries no token.
+func TestPaginateXMLRoundTripResumesAndTerminates(t *testing.T) {
+	items := []string{"a", "b", "c", "d", "e"}
+
+	var seen []string
+
+	token := ""
+	for range items {
+		page, next := paginateXML(items, "2", token, idOfString)
+		seen = append(seen, pageIDs(page)...)
+
+		if next == "" {
+			break
+		}
+
+		token = next
+	}
+
+	if got := len(seen); got != len(items) {
+		t.Fatalf("paged through %d items, want %d (no dupes/gaps)", got, len(items))
+	}
+
+	for i := range items {
+		if seen[i] != items[i] {
+			t.Fatalf("page-through order = %v, want %v", seen, items)
+		}
+	}
+}
+
+// TestPaginateXMLBoundaryLimitEqualsLen pins that a limit equal to the set size
+// returns everything with no NextToken (there is no next page).
+func TestPaginateXMLBoundaryLimitEqualsLen(t *testing.T) {
+	items := []string{"a", "b", "c"}
+
+	page, next := paginateXML(items, "3", "", idOfString)
+	if len(page) != 3 || next != "" {
+		t.Fatalf("limit==len: page=%v next=%q, want full set and empty token", page, next)
+	}
+}
+
+// TestPaginateXMLUnknownTokenStartsAtZero pins that a garbage or non-base64
+// NextToken restarts from the beginning rather than erroring or skipping.
+func TestPaginateXMLUnknownTokenStartsAtZero(t *testing.T) {
+	items := []string{"a", "b", "c"}
+
+	for _, tok := range []string{"!!!not-base64!!!", base64.StdEncoding.EncodeToString([]byte("zzz"))} {
+		page, _ := paginateXML(items, "1", tok, idOfString)
+		if len(page) != 1 || page[0] != "a" {
+			t.Fatalf("token=%q: page=%v, want to restart at [a]", tok, page)
+		}
+	}
+}
+
+// TestPaginateXMLCapsAtMaxDescribeResults pins that a MaxResults above the 1000
+// cap is clamped, so an over-large limit still emits a NextToken when more items
+// remain rather than returning everything.
+func TestPaginateXMLCapsAtMaxDescribeResults(t *testing.T) {
+	items := make([]string, maxDescribeResults+1)
+	for i := range items {
+		// zero-padded so lexical order matches numeric order.
+		items[i] = strconv.Itoa(1000000 + i)
+	}
+
+	page, next := paginateXML(items, strconv.Itoa(maxDescribeResults+500), "", idOfString)
+	if len(page) != maxDescribeResults {
+		t.Fatalf("page size = %d, want cap %d", len(page), maxDescribeResults)
+	}
+
+	if next == "" {
+		t.Fatalf("next token empty, want a cursor to the %dth item", maxDescribeResults)
+	}
+}

--- a/server/aws/ec2/operations.go
+++ b/server/aws/ec2/operations.go
@@ -176,11 +176,23 @@ const maxDescribeResults = 1000
 // page and a NextToken (the id of the first reservation on the following page,
 // base64-encoded). An empty/invalid maxResults returns everything.
 func paginateReservations(reservations []reservationXML, maxResultsStr, token string) (page []reservationXML, next string) {
-	start := decodeReservationToken(token, reservations)
+	return paginateXML(reservations, maxResultsStr, token,
+		func(r reservationXML) string { return r.ReservationID })
+}
+
+// paginateXML slices items to at most maxResults, returning the page and a
+// NextToken (the base64-encoded id of the first item on the following page).
+// An empty/invalid maxResults returns everything from the token offset, and the
+// NextToken is empty on the last page. idOf yields each item's stable id, which
+// is both the cursor and the value callers sort on before paging. The EC2
+// Describe* handlers share it so pagination behaves identically across the VPC
+// family and DescribeInstances.
+func paginateXML[X any](items []X, maxResultsStr, token string, idOf func(X) string) (page []X, next string) {
+	start := decodePageToken(token, items, idOf)
 
 	limit, err := strconv.Atoi(maxResultsStr)
 	if err != nil || limit <= 0 {
-		return reservations[start:], ""
+		return items[start:], ""
 	}
 
 	if limit > maxDescribeResults {
@@ -188,16 +200,16 @@ func paginateReservations(reservations []reservationXML, maxResultsStr, token st
 	}
 
 	end := start + limit
-	if end >= len(reservations) {
-		return reservations[start:], ""
+	if end >= len(items) {
+		return items[start:], ""
 	}
 
-	return reservations[start:end], encodeReservationToken(reservations[end].ReservationID)
+	return items[start:end], encodePageToken(idOf(items[end]))
 }
 
-// decodeReservationToken maps a NextToken back to a start index. An unknown or
-// empty token starts at the beginning.
-func decodeReservationToken(token string, reservations []reservationXML) int {
+// decodePageToken maps a NextToken back to a start index. An unknown or empty
+// token starts at the beginning.
+func decodePageToken[X any](token string, items []X, idOf func(X) string) int {
 	if token == "" {
 		return 0
 	}
@@ -207,8 +219,8 @@ func decodeReservationToken(token string, reservations []reservationXML) int {
 		return 0
 	}
 
-	for i := range reservations {
-		if reservations[i].ReservationID == string(raw) {
+	for i := range items {
+		if idOf(items[i]) == string(raw) {
 			return i
 		}
 	}
@@ -216,9 +228,9 @@ func decodeReservationToken(token string, reservations []reservationXML) int {
 	return 0
 }
 
-// encodeReservationToken base64-encodes a reservation id for use as a NextToken.
-func encodeReservationToken(reservationID string) string {
-	return base64.StdEncoding.EncodeToString([]byte(reservationID))
+// encodePageToken base64-encodes an item id for use as a NextToken.
+func encodePageToken(id string) string {
+	return base64.StdEncoding.EncodeToString([]byte(id))
 }
 
 // startInstances handles Action=StartInstances.

--- a/server/aws/ec2/route_table.go
+++ b/server/aws/ec2/route_table.go
@@ -65,6 +65,7 @@ type describeRouteTablesResponseXML struct {
 	Xmlns         string          `xml:"xmlns,attr"`
 	RequestID     string          `xml:"requestId"`
 	RouteTableSet []routeTableXML `xml:"routeTableSet>item"`
+	NextToken     string          `xml:"nextToken,omitempty"`
 }
 
 type createRouteResponseXML struct {
@@ -153,10 +154,13 @@ func (h *Handler) describeRouteTables(w http.ResponseWriter, r *http.Request) {
 		out = append(out, toRouteTableXML(&rts[i]))
 	}
 
+	page, next := pageNetworkingXML(out, r, func(rt routeTableXML) string { return rt.RouteTableID })
+
 	awsquery.WriteXMLResponse(w, describeRouteTablesResponseXML{
 		Xmlns:         awsquery.Namespace,
 		RequestID:     awsquery.RequestID,
-		RouteTableSet: out,
+		RouteTableSet: page,
+		NextToken:     next,
 	})
 }
 

--- a/server/aws/ec2/route_table_test.go
+++ b/server/aws/ec2/route_table_test.go
@@ -207,3 +207,70 @@ func findLocalRoute(routes []ec2types.Route) *ec2types.Route {
 
 	return nil
 }
+
+// TestDescribeRouteTablesPaginatesAllOnce pins that DescribeRouteTables honors
+// MaxResults/NextToken, paging every table (the VPC's main table plus the two
+// created here) exactly once with no duplicates across pages.
+func TestDescribeRouteTablesPaginatesAllOnce(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpcID := mkVPC(ctx, t, c, "10.0.0.0/16")
+
+	created := map[string]bool{}
+	for range 2 {
+		rt, err := c.CreateRouteTable(ctx, &ec2.CreateRouteTableInput{VpcId: aws.String(vpcID)})
+		if err != nil {
+			t.Fatalf("CreateRouteTable: %v", err)
+		}
+
+		created[aws.ToString(rt.RouteTable.RouteTableId)] = true
+	}
+
+	seen := map[string]int{}
+	pages := 0
+
+	var token *string
+
+	for {
+		out, err := c.DescribeRouteTables(ctx, &ec2.DescribeRouteTablesInput{
+			MaxResults: aws.Int32(1),
+			NextToken:  token,
+		})
+		if err != nil {
+			t.Fatalf("DescribeRouteTables: %v", err)
+		}
+
+		if len(out.RouteTables) > 1 {
+			t.Fatalf("page returned %d route tables, want at most 1", len(out.RouteTables))
+		}
+
+		for _, rt := range out.RouteTables {
+			seen[aws.ToString(rt.RouteTableId)]++
+		}
+
+		pages++
+
+		if aws.ToString(out.NextToken) == "" {
+			break
+		}
+
+		token = out.NextToken
+	}
+
+	if pages < 3 {
+		t.Fatalf("paged in %d pages, want >=3 (one table per page)", pages)
+	}
+
+	for id := range created {
+		if seen[id] != 1 {
+			t.Fatalf("created route table %s seen %d times, want exactly 1", id, seen[id])
+		}
+	}
+
+	for id, n := range seen {
+		if n != 1 {
+			t.Fatalf("route table %s seen %d times across pages, want 1", id, n)
+		}
+	}
+}

--- a/server/aws/ec2/security_group.go
+++ b/server/aws/ec2/security_group.go
@@ -121,6 +121,7 @@ type describeSecurityGroupsResponseXML struct {
 	Xmlns            string             `xml:"xmlns,attr"`
 	RequestID        string             `xml:"requestId"`
 	SecurityGroupSet []securityGroupXML `xml:"securityGroupInfo>item"`
+	NextToken        string             `xml:"nextToken,omitempty"`
 }
 
 // authorizeSecurityGroupResponseXML is the Authorize{Ingress,Egress} response.
@@ -226,10 +227,13 @@ func (h *Handler) describeSecurityGroups(w http.ResponseWriter, r *http.Request)
 		out = append(out, toSecurityGroupXML(&sgs[i]))
 	}
 
+	page, next := pageNetworkingXML(out, r, func(sg securityGroupXML) string { return sg.GroupID })
+
 	awsquery.WriteXMLResponse(w, describeSecurityGroupsResponseXML{
 		Xmlns:            awsquery.Namespace,
 		RequestID:        awsquery.RequestID,
-		SecurityGroupSet: out,
+		SecurityGroupSet: page,
+		NextToken:        next,
 	})
 }
 

--- a/server/aws/ec2/security_group_test.go
+++ b/server/aws/ec2/security_group_test.go
@@ -666,3 +666,71 @@ func describeSGRuleByID(t *testing.T, ctx context.Context, c *ec2.Client, ruleID
 
 	return out.SecurityGroupRules[0]
 }
+
+// TestDescribeSecurityGroupsPaginatesFilteredSet pins that MaxResults paginates
+// the FILTERED set, not the raw one: with a tag filter selecting only the two
+// tagged groups, paging MaxResults=1 returns exactly those two (one per page)
+// and never the VPC's auto-created default group, which the filter excludes.
+func TestDescribeSecurityGroupsPaginatesFilteredSet(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+
+	vpcID := createSGTestVPC(t, ctx, c, "10.0.0.0/16")
+
+	want := map[string]int{}
+	for _, name := range []string{"web", "db"} {
+		out, err := c.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+			GroupName:   aws.String(name),
+			Description: aws.String(name + " group"),
+			VpcId:       aws.String(vpcID),
+			TagSpecifications: []ec2types.TagSpecification{{
+				ResourceType: ec2types.ResourceTypeSecurityGroup,
+				Tags:         []ec2types.Tag{{Key: aws.String("Team"), Value: aws.String("net")}},
+			}},
+		})
+		if err != nil {
+			t.Fatalf("CreateSecurityGroup(%s): %v", name, err)
+		}
+
+		want[aws.ToString(out.GroupId)] = 0
+	}
+
+	seen := map[string]int{}
+
+	var token *string
+
+	for {
+		out, err := c.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+			Filters:    []ec2types.Filter{{Name: aws.String("tag:Team"), Values: []string{"net"}}},
+			MaxResults: aws.Int32(1),
+			NextToken:  token,
+		})
+		if err != nil {
+			t.Fatalf("DescribeSecurityGroups: %v", err)
+		}
+
+		if len(out.SecurityGroups) > 1 {
+			t.Fatalf("page returned %d groups, want at most 1", len(out.SecurityGroups))
+		}
+
+		for _, sg := range out.SecurityGroups {
+			seen[aws.ToString(sg.GroupId)]++
+		}
+
+		if aws.ToString(out.NextToken) == "" {
+			break
+		}
+
+		token = out.NextToken
+	}
+
+	if len(seen) != len(want) {
+		t.Fatalf("paged through %d groups, want only the %d tagged ones (default group leaked in?)", len(seen), len(want))
+	}
+
+	for id := range want {
+		if seen[id] != 1 {
+			t.Fatalf("tagged group %s seen %d times, want exactly 1", id, seen[id])
+		}
+	}
+}

--- a/server/aws/ec2/subnet.go
+++ b/server/aws/ec2/subnet.go
@@ -46,6 +46,7 @@ type describeSubnetsResponseXML struct {
 	Xmlns     string      `xml:"xmlns,attr"`
 	RequestID string      `xml:"requestId"`
 	SubnetSet []subnetXML `xml:"subnetSet>item"`
+	NextToken string      `xml:"nextToken,omitempty"`
 }
 
 type deleteSubnetResponseXML struct {
@@ -114,10 +115,15 @@ func (h *Handler) describeSubnets(w http.ResponseWriter, r *http.Request) {
 	region := regionFromRequest(r)
 	toXML := func(s *netdriver.SubnetInfo) subnetXML { return toSubnetXML(s, region) }
 
+	page, next := pageNetworkingXML(
+		filterXML(subnets, filters, subnetMatchesFilters, toXML), r,
+		func(s subnetXML) string { return s.SubnetID })
+
 	awsquery.WriteXMLResponse(w, describeSubnetsResponseXML{
 		Xmlns:     awsquery.Namespace,
 		RequestID: awsquery.RequestID,
-		SubnetSet: filterXML(subnets, filters, subnetMatchesFilters, toXML),
+		SubnetSet: page,
+		NextToken: next,
 	})
 }
 

--- a/server/aws/ec2/subnet_test.go
+++ b/server/aws/ec2/subnet_test.go
@@ -190,3 +190,56 @@ func TestCreateSubnetRejectsOverlappingCIDR(t *testing.T) {
 		t.Errorf("error = %v, want InvalidSubnet.Conflict", err)
 	}
 }
+
+// TestDescribeSubnetsPaginatesAllOnce pins that paging DescribeSubnets with
+// MaxResults=1 walks every subnet exactly once, with no duplicates or gaps
+// across pages (a stable cursor over the filtered, sorted set).
+func TestDescribeSubnetsPaginatesAllOnce(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	vpcID := mkVPC(ctx, t, c, "10.0.0.0/16")
+
+	want := map[string]int{}
+	for _, cidr := range []string{"10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"} {
+		want[aws.ToString(mkSubnet(ctx, t, c, vpcID, cidr, "us-east-1a").SubnetId)] = 0
+	}
+
+	seen := map[string]int{}
+
+	var token *string
+
+	for {
+		out, err := c.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+			MaxResults: aws.Int32(1),
+			NextToken:  token,
+		})
+		if err != nil {
+			t.Fatalf("DescribeSubnets: %v", err)
+		}
+
+		if len(out.Subnets) > 1 {
+			t.Fatalf("page returned %d subnets, want at most 1", len(out.Subnets))
+		}
+
+		for _, s := range out.Subnets {
+			seen[aws.ToString(s.SubnetId)]++
+		}
+
+		if aws.ToString(out.NextToken) == "" {
+			break
+		}
+
+		token = out.NextToken
+	}
+
+	if len(seen) != len(want) {
+		t.Fatalf("paged through %d subnets, want %d", len(seen), len(want))
+	}
+
+	for id, n := range seen {
+		if n != 1 {
+			t.Fatalf("subnet %s seen %d times across pages, want exactly 1", id, n)
+		}
+	}
+}

--- a/server/aws/ec2/vpc.go
+++ b/server/aws/ec2/vpc.go
@@ -63,6 +63,7 @@ type describeVpcsResponseXML struct {
 	Xmlns     string   `xml:"xmlns,attr"`
 	RequestID string   `xml:"requestId"`
 	VpcSet    []vpcXML `xml:"vpcSet>item"`
+	NextToken string   `xml:"nextToken,omitempty"`
 }
 
 type deleteVpcResponseXML struct {
@@ -120,10 +121,15 @@ func (h *Handler) describeVpcs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	page, next := pageNetworkingXML(
+		filterXML(vpcs, filters, vpcMatchesFilters, toVpcXML), r,
+		func(v vpcXML) string { return v.VpcID })
+
 	awsquery.WriteXMLResponse(w, describeVpcsResponseXML{
 		Xmlns:     awsquery.Namespace,
 		RequestID: awsquery.RequestID,
-		VpcSet:    filterXML(vpcs, filters, vpcMatchesFilters, toVpcXML),
+		VpcSet:    page,
+		NextToken: next,
 	})
 }
 

--- a/server/aws/ec2/vpc_describe_test.go
+++ b/server/aws/ec2/vpc_describe_test.go
@@ -98,6 +98,59 @@ func TestDescribeVpcsCidrBlockAssociationSet(t *testing.T) {
 	}
 }
 
+// TestDescribeVpcsPaginates pins that MaxResults caps the page and returns a
+// NextToken, and that following the token returns the remaining VPCs with an
+// empty final token. Without honoring MaxResults every call returns the full
+// set, which breaks SDK paginators that page by NextToken.
+func TestDescribeVpcsPaginates(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	want := map[string]bool{}
+	for _, cidr := range []string{"10.0.0.0/16", "10.1.0.0/16", "10.2.0.0/16"} {
+		want[mkVPC(ctx, t, c, cidr)] = true
+	}
+
+	first, err := c.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{MaxResults: aws.Int32(1)})
+	if err != nil {
+		t.Fatalf("DescribeVpcs(page1): %v", err)
+	}
+
+	if len(first.Vpcs) != 1 {
+		t.Fatalf("page1 returned %d vpcs, want 1", len(first.Vpcs))
+	}
+
+	if aws.ToString(first.NextToken) == "" {
+		t.Fatalf("page1 NextToken empty, want a cursor with 2 vpcs left")
+	}
+
+	seen := map[string]bool{aws.ToString(first.Vpcs[0].VpcId): true}
+	token := first.NextToken
+
+	for token != nil && aws.ToString(token) != "" {
+		next, err := c.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{MaxResults: aws.Int32(1), NextToken: token})
+		if err != nil {
+			t.Fatalf("DescribeVpcs(page): %v", err)
+		}
+
+		for _, v := range next.Vpcs {
+			seen[aws.ToString(v.VpcId)] = true
+		}
+
+		token = next.NextToken
+	}
+
+	if len(seen) != len(want) {
+		t.Fatalf("paged through %d vpcs, want %d unique", len(seen), len(want))
+	}
+
+	for id := range want {
+		if !seen[id] {
+			t.Fatalf("vpc %s missing from page-through", id)
+		}
+	}
+}
+
 // TestDhcpOptionsOwnerID pins that DHCP option sets report their owning account
 // id, which Terraform's aws_vpc_dhcp_options reads.
 func TestDhcpOptionsOwnerID(t *testing.T) {


### PR DESCRIPTION
DescribeVpcs/Subnets/RouteTables/SecurityGroups/NetworkAcls/InternetGateways now honor MaxResults/NextToken. Generalized the reservation pagination into a reusable server-layer paginateXML[X] helper (offset + base64 id cursor, cap 1000, invalid/<=0 returns full set); refactored DescribeInstances to delegate to it. Paginates AFTER filtering, stable-sorts by id before paging. Pure server-layer, no driver/provider change. SDK tests page-through each resource; compat suite clean.