### PR TITLE
fix(ec2): dispatch snapshot/image/keypair/volume ops + launch-template versioning

### DIFF
--- a/contrib/terraform/go.mod
+++ b/contrib/terraform/go.mod
@@ -40,7 +40,9 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/zclconf/go-cty v1.16.2 // indirect
+	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect

--- a/docs/coverage/aws/ec2.md
+++ b/docs/coverage/aws/ec2.md
@@ -57,37 +57,15 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
-### ImageRegistrar
+### LaunchTemplateVersioner
 
-ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
-
-| Operation | Description |
-| --- | --- |
-| `RegisterImage` |  |
-
-### KeyPairImporter
-
-KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair
+LaunchTemplateVersioner is an AWS-only optional capability implementing launch
 
 | Operation | Description |
 | --- | --- |
-| `ImportKeyPair` |  |
-
-### SnapshotCopier
-
-SnapshotCopier is an optional AWS-only capability for EC2 CopySnapshot. It is
-
-| Operation | Description |
-| --- | --- |
-| `CopySnapshot` |  |
-
-### VolumeModifier
-
-VolumeModifier is an optional AWS-only capability for EC2 ModifyVolume
-
-| Operation | Description |
-| --- | --- |
-| `ModifyVolume` |  |
+| `CreateLaunchTemplateVersion` | CreateLaunchTemplateVersion appends a new immutable version to a template. |
+| `DescribeLaunchTemplateVersions` | DescribeLaunchTemplateVersions returns a template's versions (filtered, |
+| `GetLaunchTemplateData` | GetLaunchTemplateData synthesizes launch-template data from a running |
 
 ## Not in scope
 

--- a/docs/coverage/aws/ec2.md
+++ b/docs/coverage/aws/ec2.md
@@ -57,6 +57,38 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
+### ImageRegistrar
+
+ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
+
+| Operation | Description |
+| --- | --- |
+| `RegisterImage` |  |
+
+### KeyPairImporter
+
+KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair
+
+| Operation | Description |
+| --- | --- |
+| `ImportKeyPair` |  |
+
+### SnapshotCopier
+
+SnapshotCopier is an optional AWS-only capability for EC2 CopySnapshot. It is
+
+| Operation | Description |
+| --- | --- |
+| `CopySnapshot` |  |
+
+### VolumeModifier
+
+VolumeModifier is an optional AWS-only capability for EC2 ModifyVolume
+
+| Operation | Description |
+| --- | --- |
+| `ModifyVolume` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/aws/ec2.md
+++ b/docs/coverage/aws/ec2.md
@@ -57,6 +57,22 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
+### ImageRegistrar
+
+ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
+
+| Operation | Description |
+| --- | --- |
+| `RegisterImage` |  |
+
+### KeyPairImporter
+
+KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair
+
+| Operation | Description |
+| --- | --- |
+| `ImportKeyPair` |  |
+
 ### LaunchTemplateVersioner
 
 LaunchTemplateVersioner is an AWS-only optional capability implementing launch
@@ -66,6 +82,22 @@ LaunchTemplateVersioner is an AWS-only optional capability implementing launch
 | `CreateLaunchTemplateVersion` | CreateLaunchTemplateVersion appends a new immutable version to a template. |
 | `DescribeLaunchTemplateVersions` | DescribeLaunchTemplateVersions returns a template's versions (filtered, |
 | `GetLaunchTemplateData` | GetLaunchTemplateData synthesizes launch-template data from a running |
+
+### SnapshotCopier
+
+SnapshotCopier is an optional AWS-only capability for EC2 CopySnapshot. It is
+
+| Operation | Description |
+| --- | --- |
+| `CopySnapshot` |  |
+
+### VolumeModifier
+
+VolumeModifier is an optional AWS-only capability for EC2 ModifyVolume
+
+| Operation | Description |
+| --- | --- |
+| `ModifyVolume` |  |
 
 ## Not in scope
 

--- a/docs/coverage/azure/virtualmachines.md
+++ b/docs/coverage/azure/virtualmachines.md
@@ -57,37 +57,15 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
-### ImageRegistrar
+### LaunchTemplateVersioner
 
-ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
-
-| Operation | Description |
-| --- | --- |
-| `RegisterImage` |  |
-
-### KeyPairImporter
-
-KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair
+LaunchTemplateVersioner is an AWS-only optional capability implementing launch
 
 | Operation | Description |
 | --- | --- |
-| `ImportKeyPair` |  |
-
-### SnapshotCopier
-
-SnapshotCopier is an optional AWS-only capability for EC2 CopySnapshot. It is
-
-| Operation | Description |
-| --- | --- |
-| `CopySnapshot` |  |
-
-### VolumeModifier
-
-VolumeModifier is an optional AWS-only capability for EC2 ModifyVolume
-
-| Operation | Description |
-| --- | --- |
-| `ModifyVolume` |  |
+| `CreateLaunchTemplateVersion` | CreateLaunchTemplateVersion appends a new immutable version to a template. |
+| `DescribeLaunchTemplateVersions` | DescribeLaunchTemplateVersions returns a template's versions (filtered, |
+| `GetLaunchTemplateData` | GetLaunchTemplateData synthesizes launch-template data from a running |
 
 ## Not in scope
 

--- a/docs/coverage/azure/virtualmachines.md
+++ b/docs/coverage/azure/virtualmachines.md
@@ -57,6 +57,38 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
+### ImageRegistrar
+
+ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
+
+| Operation | Description |
+| --- | --- |
+| `RegisterImage` |  |
+
+### KeyPairImporter
+
+KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair
+
+| Operation | Description |
+| --- | --- |
+| `ImportKeyPair` |  |
+
+### SnapshotCopier
+
+SnapshotCopier is an optional AWS-only capability for EC2 CopySnapshot. It is
+
+| Operation | Description |
+| --- | --- |
+| `CopySnapshot` |  |
+
+### VolumeModifier
+
+VolumeModifier is an optional AWS-only capability for EC2 ModifyVolume
+
+| Operation | Description |
+| --- | --- |
+| `ModifyVolume` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/azure/virtualmachines.md
+++ b/docs/coverage/azure/virtualmachines.md
@@ -57,6 +57,22 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
+### ImageRegistrar
+
+ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
+
+| Operation | Description |
+| --- | --- |
+| `RegisterImage` |  |
+
+### KeyPairImporter
+
+KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair
+
+| Operation | Description |
+| --- | --- |
+| `ImportKeyPair` |  |
+
 ### LaunchTemplateVersioner
 
 LaunchTemplateVersioner is an AWS-only optional capability implementing launch
@@ -66,6 +82,22 @@ LaunchTemplateVersioner is an AWS-only optional capability implementing launch
 | `CreateLaunchTemplateVersion` | CreateLaunchTemplateVersion appends a new immutable version to a template. |
 | `DescribeLaunchTemplateVersions` | DescribeLaunchTemplateVersions returns a template's versions (filtered, |
 | `GetLaunchTemplateData` | GetLaunchTemplateData synthesizes launch-template data from a running |
+
+### SnapshotCopier
+
+SnapshotCopier is an optional AWS-only capability for EC2 CopySnapshot. It is
+
+| Operation | Description |
+| --- | --- |
+| `CopySnapshot` |  |
+
+### VolumeModifier
+
+VolumeModifier is an optional AWS-only capability for EC2 ModifyVolume
+
+| Operation | Description |
+| --- | --- |
+| `ModifyVolume` |  |
 
 ## Not in scope
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -1956,6 +1956,24 @@
         ]
       },
       {
+        "name": "ImageRegistrar",
+        "doc": "ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage",
+        "operations": [
+          {
+            "name": "RegisterImage"
+          }
+        ]
+      },
+      {
+        "name": "KeyPairImporter",
+        "doc": "KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair",
+        "operations": [
+          {
+            "name": "ImportKeyPair"
+          }
+        ]
+      },
+      {
         "name": "LaunchTemplateVersioner",
         "doc": "LaunchTemplateVersioner is an AWS-only optional capability implementing launch",
         "operations": [
@@ -1970,6 +1988,24 @@
           {
             "name": "GetLaunchTemplateData",
             "doc": "GetLaunchTemplateData synthesizes launch-template data from a running"
+          }
+        ]
+      },
+      {
+        "name": "SnapshotCopier",
+        "doc": "SnapshotCopier is an optional AWS-only capability for EC2 CopySnapshot. It is",
+        "operations": [
+          {
+            "name": "CopySnapshot"
+          }
+        ]
+      },
+      {
+        "name": "VolumeModifier",
+        "doc": "VolumeModifier is an optional AWS-only capability for EC2 ModifyVolume",
+        "operations": [
+          {
+            "name": "ModifyVolume"
           }
         ]
       }

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -1956,38 +1956,20 @@
         ]
       },
       {
-        "name": "ImageRegistrar",
-        "doc": "ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage",
+        "name": "LaunchTemplateVersioner",
+        "doc": "LaunchTemplateVersioner is an AWS-only optional capability implementing launch",
         "operations": [
           {
-            "name": "RegisterImage"
-          }
-        ]
-      },
-      {
-        "name": "KeyPairImporter",
-        "doc": "KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair",
-        "operations": [
+            "name": "CreateLaunchTemplateVersion",
+            "doc": "CreateLaunchTemplateVersion appends a new immutable version to a template."
+          },
           {
-            "name": "ImportKeyPair"
-          }
-        ]
-      },
-      {
-        "name": "SnapshotCopier",
-        "doc": "SnapshotCopier is an optional AWS-only capability for EC2 CopySnapshot. It is",
-        "operations": [
+            "name": "DescribeLaunchTemplateVersions",
+            "doc": "DescribeLaunchTemplateVersions returns a template's versions (filtered,"
+          },
           {
-            "name": "CopySnapshot"
-          }
-        ]
-      },
-      {
-        "name": "VolumeModifier",
-        "doc": "VolumeModifier is an optional AWS-only capability for EC2 ModifyVolume",
-        "operations": [
-          {
-            "name": "ModifyVolume"
+            "name": "GetLaunchTemplateData",
+            "doc": "GetLaunchTemplateData synthesizes launch-template data from a running"
           }
         ]
       }

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -1954,6 +1954,42 @@
             "name": "GetConsoleOutput"
           }
         ]
+      },
+      {
+        "name": "ImageRegistrar",
+        "doc": "ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage",
+        "operations": [
+          {
+            "name": "RegisterImage"
+          }
+        ]
+      },
+      {
+        "name": "KeyPairImporter",
+        "doc": "KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair",
+        "operations": [
+          {
+            "name": "ImportKeyPair"
+          }
+        ]
+      },
+      {
+        "name": "SnapshotCopier",
+        "doc": "SnapshotCopier is an optional AWS-only capability for EC2 CopySnapshot. It is",
+        "operations": [
+          {
+            "name": "CopySnapshot"
+          }
+        ]
+      },
+      {
+        "name": "VolumeModifier",
+        "doc": "VolumeModifier is an optional AWS-only capability for EC2 ModifyVolume",
+        "operations": [
+          {
+            "name": "ModifyVolume"
+          }
+        ]
       }
     ],
     "providers": {

--- a/docs/coverage/gcp/gce.md
+++ b/docs/coverage/gcp/gce.md
@@ -57,37 +57,15 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
-### ImageRegistrar
+### LaunchTemplateVersioner
 
-ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
-
-| Operation | Description |
-| --- | --- |
-| `RegisterImage` |  |
-
-### KeyPairImporter
-
-KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair
+LaunchTemplateVersioner is an AWS-only optional capability implementing launch
 
 | Operation | Description |
 | --- | --- |
-| `ImportKeyPair` |  |
-
-### SnapshotCopier
-
-SnapshotCopier is an optional AWS-only capability for EC2 CopySnapshot. It is
-
-| Operation | Description |
-| --- | --- |
-| `CopySnapshot` |  |
-
-### VolumeModifier
-
-VolumeModifier is an optional AWS-only capability for EC2 ModifyVolume
-
-| Operation | Description |
-| --- | --- |
-| `ModifyVolume` |  |
+| `CreateLaunchTemplateVersion` | CreateLaunchTemplateVersion appends a new immutable version to a template. |
+| `DescribeLaunchTemplateVersions` | DescribeLaunchTemplateVersions returns a template's versions (filtered, |
+| `GetLaunchTemplateData` | GetLaunchTemplateData synthesizes launch-template data from a running |
 
 ## Not in scope
 

--- a/docs/coverage/gcp/gce.md
+++ b/docs/coverage/gcp/gce.md
@@ -57,6 +57,38 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
+### ImageRegistrar
+
+ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
+
+| Operation | Description |
+| --- | --- |
+| `RegisterImage` |  |
+
+### KeyPairImporter
+
+KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair
+
+| Operation | Description |
+| --- | --- |
+| `ImportKeyPair` |  |
+
+### SnapshotCopier
+
+SnapshotCopier is an optional AWS-only capability for EC2 CopySnapshot. It is
+
+| Operation | Description |
+| --- | --- |
+| `CopySnapshot` |  |
+
+### VolumeModifier
+
+VolumeModifier is an optional AWS-only capability for EC2 ModifyVolume
+
+| Operation | Description |
+| --- | --- |
+| `ModifyVolume` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/gcp/gce.md
+++ b/docs/coverage/gcp/gce.md
@@ -57,6 +57,22 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
+### ImageRegistrar
+
+ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
+
+| Operation | Description |
+| --- | --- |
+| `RegisterImage` |  |
+
+### KeyPairImporter
+
+KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair
+
+| Operation | Description |
+| --- | --- |
+| `ImportKeyPair` |  |
+
 ### LaunchTemplateVersioner
 
 LaunchTemplateVersioner is an AWS-only optional capability implementing launch
@@ -66,6 +82,22 @@ LaunchTemplateVersioner is an AWS-only optional capability implementing launch
 | `CreateLaunchTemplateVersion` | CreateLaunchTemplateVersion appends a new immutable version to a template. |
 | `DescribeLaunchTemplateVersions` | DescribeLaunchTemplateVersions returns a template's versions (filtered, |
 | `GetLaunchTemplateData` | GetLaunchTemplateData synthesizes launch-template data from a running |
+
+### SnapshotCopier
+
+SnapshotCopier is an optional AWS-only capability for EC2 CopySnapshot. It is
+
+| Operation | Description |
+| --- | --- |
+| `CopySnapshot` |  |
+
+### VolumeModifier
+
+VolumeModifier is an optional AWS-only capability for EC2 ModifyVolume
+
+| Operation | Description |
+| --- | --- |
+| `ModifyVolume` |  |
 
 ## Not in scope
 

--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.1
 	github.com/google/gnostic-models v0.6.8
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/crypto v0.54.0
 	google.golang.org/api v0.291.0
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
@@ -179,7 +180,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
-	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.57.0 // indirect

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -187,18 +187,22 @@ type Mock struct {
 	asgs         *memstore.Store[*asgData]
 	spotRequests *memstore.Store[*driver.SpotInstanceRequest]
 	templates    *memstore.Store[*driver.LaunchTemplate]
-	volumes      *memstore.Store[*driver.VolumeInfo]
-	snapshots    *memstore.Store[*driver.SnapshotInfo]
-	images       *memstore.Store[*driver.ImageInfo]
-	keyPairs     *memstore.Store[*driver.KeyPairInfo]
-	sm           *statemachine.Machine
-	opts         *config.Options
-	ipCounter    atomic.Int64
-	volCounter   atomic.Int64
-	snapCounter  atomic.Int64
-	amiCounter   atomic.Int64
-	keyCounter   atomic.Int64
-	monitoring   mondriver.Monitoring
+	// templateVersions holds every launch-template version keyed by
+	// "<name>#<version>" (see templateVersionKey). Launch-template versioning is
+	// AWS-specific, so this store backs the LaunchTemplateVersioner capability.
+	templateVersions *memstore.Store[*driver.LaunchTemplateVersion]
+	volumes          *memstore.Store[*driver.VolumeInfo]
+	snapshots        *memstore.Store[*driver.SnapshotInfo]
+	images           *memstore.Store[*driver.ImageInfo]
+	keyPairs         *memstore.Store[*driver.KeyPairInfo]
+	sm               *statemachine.Machine
+	opts             *config.Options
+	ipCounter        atomic.Int64
+	volCounter       atomic.Int64
+	snapCounter      atomic.Int64
+	amiCounter       atomic.Int64
+	keyCounter       atomic.Int64
+	monitoring       mondriver.Monitoring
 	// subnetResolver derives an instance's VPC from its subnet at launch, so
 	// instances created with a --subnet-id carry the VPCID that connectivity
 	// analysis and VPC teardown depend on. nil until wired by the provider.
@@ -284,16 +288,17 @@ func (m *Mock) emitLifecycleMetrics(ctx context.Context, instanceID string, valu
 // New creates a new EC2 mock.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		instances:    memstore.New[*instanceData](),
-		asgs:         memstore.New[*asgData](),
-		spotRequests: memstore.New[*driver.SpotInstanceRequest](),
-		templates:    memstore.New[*driver.LaunchTemplate](),
-		volumes:      memstore.New[*driver.VolumeInfo](),
-		snapshots:    memstore.New[*driver.SnapshotInfo](),
-		images:       memstore.New[*driver.ImageInfo](),
-		keyPairs:     memstore.New[*driver.KeyPairInfo](),
-		sm:           statemachine.New(compute.VMTransitions()),
-		opts:         opts,
+		instances:        memstore.New[*instanceData](),
+		asgs:             memstore.New[*asgData](),
+		spotRequests:     memstore.New[*driver.SpotInstanceRequest](),
+		templates:        memstore.New[*driver.LaunchTemplate](),
+		templateVersions: memstore.New[*driver.LaunchTemplateVersion](),
+		volumes:          memstore.New[*driver.VolumeInfo](),
+		snapshots:        memstore.New[*driver.SnapshotInfo](),
+		images:           memstore.New[*driver.ImageInfo](),
+		keyPairs:         memstore.New[*driver.KeyPairInfo](),
+		sm:               statemachine.New(compute.VMTransitions()),
+		opts:             opts,
 
 		managedResourceVisibility: visibilityVisible,
 		clientTokens:              make(map[string][]string),

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha1" //nolint:gosec // AWS defines RSA key-pair fingerprints as SHA-1 digests
 	"crypto/sha256"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -69,6 +70,10 @@ const (
 	// generates and imports.
 	keyTypeRSA     = "rsa"
 	keyTypeEd25519 = "ed25519"
+
+	// copiedSnapshotVolumeID is the placeholder volume id real EC2 reports for a
+	// snapshot created by CopySnapshot, which has no owning volume.
+	copiedSnapshotVolumeID = "vol-ffffffff"
 
 	// monitoringDisabled / monitoringEnabled are the stored detailed-monitoring
 	// states for an instance.
@@ -1301,8 +1306,11 @@ func (m *Mock) CopySnapshot(_ context.Context, in driver.CopySnapshotInput) (*dr
 	id := fmt.Sprintf("snap-%012d", m.snapCounter.Add(1))
 
 	snap := &driver.SnapshotInfo{
-		ID:          id,
-		VolumeID:    src.VolumeID,
+		ID: id,
+		// A copied snapshot is not associated with the source volume, so real EC2
+		// reports the decoupled placeholder rather than the source's volume id;
+		// inheriting it would make a volume-id snapshot filter return the copy too.
+		VolumeID:    copiedSnapshotVolumeID,
 		State:       "completed",
 		Description: in.Description,
 		Size:        src.Size,
@@ -1456,9 +1464,9 @@ func (m *Mock) ModifyVolume(_ context.Context, in driver.ModifyVolumeInput) (*dr
 	}, nil
 }
 
-// importedKeyFingerprint computes the AWS ImportKeyPair fingerprint: the MD5
-// digest of the DER-encoded public key as colon-separated hex. It accepts
-// OpenSSH ("ssh-rsa AAAA...") and PEM (PKIX or PKCS1) public-key material.
+// importedKeyFingerprint computes the AWS ImportKeyPair fingerprint. It accepts
+// OpenSSH ("ssh-rsa AAAA...") and PEM (PKIX or PKCS1) public-key material, and
+// fingerprints per AWS's per-algorithm rule (see importedPublicKeyFingerprint).
 func importedKeyFingerprint(material []byte) (fingerprint, keyType string, err error) {
 	if pub, _, _, _, perr := ssh.ParseAuthorizedKey(material); perr == nil {
 		cpk, ok := pub.(ssh.CryptoPublicKey)
@@ -1466,38 +1474,41 @@ func importedKeyFingerprint(material []byte) (fingerprint, keyType string, err e
 			return "", "", cerrors.New(cerrors.InvalidArgument, "unsupported public key type")
 		}
 
-		return derMD5Fingerprint(cpk.CryptoPublicKey())
+		return importedPublicKeyFingerprint(cpk.CryptoPublicKey())
 	}
 
 	if block, _ := pem.Decode(material); block != nil {
 		if key, kerr := x509.ParsePKIXPublicKey(block.Bytes); kerr == nil {
-			return derMD5Fingerprint(key)
+			return importedPublicKeyFingerprint(key)
 		}
 
 		if key, kerr := x509.ParsePKCS1PublicKey(block.Bytes); kerr == nil {
-			return derMD5Fingerprint(key)
+			return importedPublicKeyFingerprint(key)
 		}
 	}
 
 	return "", "", cerrors.New(cerrors.InvalidArgument, "unrecognized public key format")
 }
 
-// derMD5Fingerprint marshals a parsed public key to PKIX DER and returns its
-// MD5 digest as colon-hex plus the inferred key type.
-func derMD5Fingerprint(pub any) (fingerprint, keyType string, err error) {
+// importedPublicKeyFingerprint marshals a parsed public key to PKIX DER and
+// fingerprints it the way real EC2 ImportKeyPair does: an imported ed25519 key
+// yields the base64-encoded SHA-256 digest of the DER, while an imported RSA key
+// yields the MD5 digest of the DER as colon-separated hex.
+func importedPublicKeyFingerprint(pub any) (fingerprint, keyType string, err error) {
 	der, err := x509.MarshalPKIXPublicKey(pub)
 	if err != nil {
 		return "", "", err
 	}
 
-	sum := md5.Sum(der) //nolint:gosec // AWS defines imported key fingerprints as MD5 of the public key DER
-
-	kt := keyTypeRSA
 	if _, ok := pub.(ed25519.PublicKey); ok {
-		kt = keyTypeEd25519
+		sum := sha256.Sum256(der)
+
+		return base64.StdEncoding.EncodeToString(sum[:]), keyTypeEd25519, nil
 	}
 
-	return colonHex(sum[:]), kt, nil
+	sum := md5.Sum(der) //nolint:gosec // AWS defines imported RSA key fingerprints as MD5 of the public key DER
+
+	return colonHex(sum[:]), keyTypeRSA, nil
 }
 
 // keyMaterial bundles the PEM-encoded key pair and its fingerprint.

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"context"
 	"crypto/ed25519"
+	"crypto/md5" //nolint:gosec // AWS defines imported key-pair fingerprints as MD5 digests of the public key
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1" //nolint:gosec // AWS defines RSA key-pair fingerprints as SHA-1 digests
@@ -18,6 +19,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/crypto/ssh"
+
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
@@ -30,6 +33,15 @@ import (
 )
 
 var _ driver.Compute = (*Mock)(nil)
+
+// The AWS EC2 mock also serves these optional AWS-only capabilities, which the
+// wire handler discovers by type assertion (no Azure/GCP/OCI mirror).
+var (
+	_ driver.SnapshotCopier  = (*Mock)(nil)
+	_ driver.ImageRegistrar  = (*Mock)(nil)
+	_ driver.KeyPairImporter = (*Mock)(nil)
+	_ driver.VolumeModifier  = (*Mock)(nil)
+)
 
 const (
 	ipSegmentSize  = 256
@@ -53,6 +65,10 @@ const (
 	imageRootDeviceSize = 8
 	// rsaKeyBits is the modulus size for generated RSA key pairs.
 	rsaKeyBits = 2048
+	// keyTypeRSA / keyTypeEd25519 are the two key-pair algorithms the mock
+	// generates and imports.
+	keyTypeRSA     = "rsa"
+	keyTypeEd25519 = "ed25519"
 
 	// monitoringDisabled / monitoringEnabled are the stored detailed-monitoring
 	// states for an instance.
@@ -1200,7 +1216,7 @@ func (m *Mock) CreateKeyPair(_ context.Context, cfg driver.KeyPairConfig) (*driv
 
 	keyType := cfg.KeyType
 	if keyType == "" {
-		keyType = "rsa"
+		keyType = keyTypeRSA
 	}
 
 	mat, err := generateKeyMaterial(keyType)
@@ -1266,6 +1282,219 @@ func (m *Mock) DescribeKeyPairs(_ context.Context, names []string) ([]driver.Key
 	return result, nil
 }
 
+// CopySnapshot clones an existing snapshot into a new snap-id, matching AWS EC2
+// CopySnapshot. The single-region emulator ignores SourceRegion but still
+// requires the source snapshot to exist.
+//
+//nolint:gocritic // hugeParam: capability method signature is fixed by the interface.
+func (m *Mock) CopySnapshot(_ context.Context, in driver.CopySnapshotInput) (*driver.SnapshotInfo, error) {
+	src, ok := m.snapshots.Get(in.SourceSnapshotID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "snapshot %q not found", in.SourceSnapshotID)
+	}
+
+	id := fmt.Sprintf("snap-%012d", m.snapCounter.Add(1))
+
+	snap := &driver.SnapshotInfo{
+		ID:          id,
+		VolumeID:    src.VolumeID,
+		State:       "completed",
+		Description: in.Description,
+		Size:        src.Size,
+		CreatedAt:   m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Tags:        copyTags(in.Tags),
+		OwnerID:     awsAccountID,
+		Progress:    "100%",
+		Encrypted:   src.Encrypted || in.Encrypted,
+	}
+
+	m.snapshots.Set(id, snap)
+
+	result := *snap
+
+	return &result, nil
+}
+
+// RegisterImage registers an AMI from caller-supplied block device mappings,
+// matching AWS EC2 RegisterImage. Names are unique per account; a referenced
+// snapshot must exist.
+//
+//nolint:gocritic // hugeParam: capability method signature is fixed by the interface.
+func (m *Mock) RegisterImage(_ context.Context, in driver.RegisterImageInput) (*driver.ImageInfo, error) {
+	if in.Name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "image name must not be empty")
+	}
+
+	for _, img := range m.images.All() {
+		if img.Name == in.Name {
+			return nil, cerrors.Newf(cerrors.AlreadyExists, "image name %q is already in use", in.Name)
+		}
+	}
+
+	for _, b := range in.BlockDeviceMappings {
+		if b.SnapshotID != "" && !m.snapshots.Has(b.SnapshotID) {
+			return nil, cerrors.Newf(cerrors.NotFound, "snapshot %q not found", b.SnapshotID)
+		}
+	}
+
+	img := &driver.ImageInfo{
+		ID:                  fmt.Sprintf("ami-%012d", m.amiCounter.Add(1)),
+		Name:                in.Name,
+		State:               stateAvailable,
+		Description:         in.Description,
+		CreatedAt:           m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Tags:                copyTags(in.Tags),
+		OwnerID:             awsAccountID,
+		Architecture:        nonEmpty(in.Architecture, "x86_64"),
+		RootDeviceType:      "ebs",
+		RootDeviceName:      nonEmpty(in.RootDeviceName, "/dev/sda1"),
+		VirtualizationType:  nonEmpty(in.VirtualizationType, "hvm"),
+		Hypervisor:          "xen",
+		ImageType:           "machine",
+		PlatformDetails:     "Linux/UNIX",
+		BlockDeviceMappings: append([]driver.ImageBlockDeviceMapping(nil), in.BlockDeviceMappings...),
+	}
+
+	m.images.Set(img.ID, img)
+
+	result := *img
+
+	return &result, nil
+}
+
+// ImportKeyPair stores an externally-generated public key, matching AWS EC2
+// ImportKeyPair. Imported keys carry an MD5 fingerprint of the DER-encoded
+// public key (distinct from CreateKeyPair's SHA-1 private-key fingerprint) and
+// never expose private-key material.
+func (m *Mock) ImportKeyPair(_ context.Context, in driver.ImportKeyPairInput) (*driver.KeyPairInfo, error) {
+	if in.Name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "key pair name must not be empty")
+	}
+
+	if _, ok := m.keyPairs.Get(in.Name); ok {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "key pair %q already exists", in.Name)
+	}
+
+	fingerprint, keyType, err := importedKeyFingerprint(in.PublicKeyMaterial)
+	if err != nil {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid public key material: %v", err)
+	}
+
+	kp := &driver.KeyPairInfo{
+		ID:          fmt.Sprintf("key-%016x", m.keyCounter.Add(1)),
+		Name:        in.Name,
+		Fingerprint: fingerprint,
+		KeyType:     keyType,
+		PublicKey:   string(in.PublicKeyMaterial),
+		CreatedAt:   m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Tags:        copyTags(in.Tags),
+	}
+
+	m.keyPairs.Set(in.Name, kp)
+
+	result := *kp
+
+	return &result, nil
+}
+
+// ModifyVolume applies an elastic-volume change (size / IOPS / throughput /
+// type), matching AWS EC2 ModifyVolume. Size may only grow. Original values are
+// captured before mutation and returned alongside the requested targets.
+func (m *Mock) ModifyVolume(_ context.Context, in driver.ModifyVolumeInput) (*driver.VolumeModification, error) {
+	vol, ok := m.volumes.Get(in.VolumeID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "volume %q not found", in.VolumeID)
+	}
+
+	orig := *vol
+
+	targetSize := orig.Size
+	if in.Size != 0 {
+		targetSize = in.Size
+	}
+
+	if targetSize < orig.Size {
+		return nil, cerrors.Newf(cerrors.InvalidArgument,
+			"New size %d GiB is smaller than current size %d GiB", targetSize, orig.Size)
+	}
+
+	targetType := nonEmpty(in.VolumeType, orig.VolumeType)
+
+	targetIOPS := orig.IOPS
+	if in.IOPS != 0 {
+		targetIOPS = in.IOPS
+	}
+
+	targetThroughput := orig.Throughput
+	if in.Throughput != 0 {
+		targetThroughput = in.Throughput
+	}
+
+	vol.Size = targetSize
+	vol.VolumeType = targetType
+	vol.IOPS = targetIOPS
+	vol.Throughput = targetThroughput
+
+	return &driver.VolumeModification{
+		VolumeID:           in.VolumeID,
+		ModificationState:  "modifying",
+		StartTime:          m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Progress:           0,
+		OriginalSize:       orig.Size,
+		OriginalIOPS:       orig.IOPS,
+		OriginalThroughput: orig.Throughput,
+		OriginalVolumeType: orig.VolumeType,
+		TargetSize:         targetSize,
+		TargetIOPS:         targetIOPS,
+		TargetThroughput:   targetThroughput,
+		TargetVolumeType:   targetType,
+	}, nil
+}
+
+// importedKeyFingerprint computes the AWS ImportKeyPair fingerprint: the MD5
+// digest of the DER-encoded public key as colon-separated hex. It accepts
+// OpenSSH ("ssh-rsa AAAA...") and PEM (PKIX or PKCS1) public-key material.
+func importedKeyFingerprint(material []byte) (fingerprint, keyType string, err error) {
+	if pub, _, _, _, perr := ssh.ParseAuthorizedKey(material); perr == nil {
+		cpk, ok := pub.(ssh.CryptoPublicKey)
+		if !ok {
+			return "", "", cerrors.New(cerrors.InvalidArgument, "unsupported public key type")
+		}
+
+		return derMD5Fingerprint(cpk.CryptoPublicKey())
+	}
+
+	if block, _ := pem.Decode(material); block != nil {
+		if key, kerr := x509.ParsePKIXPublicKey(block.Bytes); kerr == nil {
+			return derMD5Fingerprint(key)
+		}
+
+		if key, kerr := x509.ParsePKCS1PublicKey(block.Bytes); kerr == nil {
+			return derMD5Fingerprint(key)
+		}
+	}
+
+	return "", "", cerrors.New(cerrors.InvalidArgument, "unrecognized public key format")
+}
+
+// derMD5Fingerprint marshals a parsed public key to PKIX DER and returns its
+// MD5 digest as colon-hex plus the inferred key type.
+func derMD5Fingerprint(pub any) (fingerprint, keyType string, err error) {
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", "", err
+	}
+
+	sum := md5.Sum(der) //nolint:gosec // AWS defines imported key fingerprints as MD5 of the public key DER
+
+	kt := keyTypeRSA
+	if _, ok := pub.(ed25519.PublicKey); ok {
+		kt = keyTypeEd25519
+	}
+
+	return colonHex(sum[:]), kt, nil
+}
+
 // keyMaterial bundles the PEM-encoded key pair and its fingerprint.
 type keyMaterial struct {
 	privatePEM  string
@@ -1277,7 +1506,7 @@ type keyMaterial struct {
 // fingerprints are the SHA-1 digest of the DER private key as colon-separated
 // hex, matching CreateKeyPair on real EC2; ed25519 keys use a SHA-256 digest.
 func generateKeyMaterial(keyType string) (keyMaterial, error) {
-	if keyType == "ed25519" {
+	if keyType == keyTypeEd25519 {
 		pub, priv, gerr := ed25519.GenerateKey(rand.Reader)
 		if gerr != nil {
 			return keyMaterial{}, gerr
@@ -1324,6 +1553,15 @@ func pkixPublicPEM(pub any) string {
 	}
 
 	return pemEncode("PUBLIC KEY", der)
+}
+
+// nonEmpty returns s when it is non-empty, otherwise fallback.
+func nonEmpty(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+
+	return s
 }
 
 // colonHex formats bytes as colon-separated lowercase hex (aa:bb:cc), the

--- a/providers/aws/ec2/ec2_test.go
+++ b/providers/aws/ec2/ec2_test.go
@@ -2,8 +2,12 @@ package ec2
 
 import (
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -736,6 +740,9 @@ func TestCopySnapshotClonesSource(t *testing.T) {
 	assertEqual(t, true, cp.Encrypted)
 	assertEqual(t, "copy", cp.Description)
 	assertEqual(t, "v", cp.Tags["k"])
+	// The copy is decoupled from the source volume, so it must not inherit the
+	// source's volume id (a volume-id snapshot filter would otherwise match both).
+	assertEqual(t, "vol-ffffffff", cp.VolumeID)
 
 	_, err = m.CopySnapshot(ctx, driver.CopySnapshotInput{SourceSnapshotID: "snap-missing"})
 	assertError(t, err, true)
@@ -822,6 +829,32 @@ func TestImportKeyPairStoresPublicKey(t *testing.T) {
 	assertError(t, err, true)
 	if !cerrors.IsInvalidArgument(err) {
 		t.Fatalf("ImportKeyPair(bad material) err = %v, want InvalidArgument", err)
+	}
+}
+
+// TestImportKeyPairEd25519Fingerprint pins that an imported ed25519 key is
+// fingerprinted as the base64-encoded SHA-256 digest of the DER public key (real
+// EC2's rule for ed25519), not the MD5-of-DER colon-hex used for RSA.
+func TestImportKeyPairEd25519Fingerprint(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	requireNoError(t, err)
+	sshPub, err := ssh.NewPublicKey(pub)
+	requireNoError(t, err)
+	authKey := ssh.MarshalAuthorizedKey(sshPub)
+
+	kp, err := m.ImportKeyPair(ctx, driver.ImportKeyPairInput{Name: "ed", PublicKeyMaterial: authKey})
+	requireNoError(t, err)
+
+	if strings.Contains(kp.Fingerprint, ":") {
+		t.Fatalf("ed25519 fingerprint = %q, want base64 SHA-256 (no colon-hex MD5)", kp.Fingerprint)
+	}
+
+	raw, derr := base64.StdEncoding.DecodeString(kp.Fingerprint)
+	if derr != nil || len(raw) != sha256.Size {
+		t.Fatalf("ed25519 fingerprint = %q, want a base64-encoded 32-byte SHA-256 digest", kp.Fingerprint)
 	}
 }
 

--- a/providers/aws/ec2/ec2_test.go
+++ b/providers/aws/ec2/ec2_test.go
@@ -1952,7 +1952,7 @@ func TestCreateLaunchTemplate(t *testing.T) {
 		assertError(t, err, true)
 	})
 
-	t.Run("version numbering increments", func(t *testing.T) {
+	t.Run("each template starts at version 1", func(t *testing.T) {
 		m := newTestMock()
 		ctx := context.Background()
 
@@ -1968,7 +1968,12 @@ func TestCreateLaunchTemplate(t *testing.T) {
 		})
 		requireNoError(t, err)
 
-		assertTrue(t, tmpl2.Version > tmpl1.Version, "second template version should be greater")
+		// Real AWS numbers versions per-template: every template's first version
+		// is 1 (the old package-global counter bled numbers across templates).
+		assertEqual(t, 1, tmpl1.Version)
+		assertEqual(t, 1, tmpl2.Version)
+		assertEqual(t, 1, tmpl1.DefaultVersion)
+		assertEqual(t, 1, tmpl1.LatestVersion)
 	})
 }
 

--- a/providers/aws/ec2/ec2_test.go
+++ b/providers/aws/ec2/ec2_test.go
@@ -2,9 +2,13 @@ package ec2
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"sync"
 	"testing"
 	"time"
+
+	"golang.org/x/crypto/ssh"
 
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -702,6 +706,167 @@ func TestDescribeImages(t *testing.T) {
 
 	// Keep img2 referenced
 	assertNotEmpty(t, img2.ID)
+}
+
+// TestCopySnapshotClonesSource pins that CopySnapshot copies the source size,
+// encryption, description, and tags into a fresh snap-id, and reports NotFound
+// for a missing source.
+func TestCopySnapshotClonesSource(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 15, Encrypted: true})
+	requireNoError(t, err)
+
+	src, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{VolumeID: vol.ID, Description: "orig"})
+	requireNoError(t, err)
+
+	cp, err := m.CopySnapshot(ctx, driver.CopySnapshotInput{
+		SourceRegion:     "us-east-1",
+		SourceSnapshotID: src.ID,
+		Description:      "copy",
+		Tags:             map[string]string{"k": "v"},
+	})
+	requireNoError(t, err)
+
+	if cp.ID == src.ID || cp.ID == "" {
+		t.Fatalf("copy id = %q, want fresh id != source %q", cp.ID, src.ID)
+	}
+	assertEqual(t, 15, cp.Size)
+	assertEqual(t, true, cp.Encrypted)
+	assertEqual(t, "copy", cp.Description)
+	assertEqual(t, "v", cp.Tags["k"])
+
+	_, err = m.CopySnapshot(ctx, driver.CopySnapshotInput{SourceSnapshotID: "snap-missing"})
+	assertError(t, err, true)
+	if !cerrors.IsNotFound(err) {
+		t.Fatalf("CopySnapshot(missing) err = %v, want NotFound", err)
+	}
+}
+
+// TestRegisterImageStoresMappings pins that RegisterImage records the supplied
+// architecture, root device, and block device mappings, rejects duplicate
+// names, and rejects references to a missing snapshot.
+func TestRegisterImageStoresMappings(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 20})
+	requireNoError(t, err)
+	snap, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{VolumeID: vol.ID})
+	requireNoError(t, err)
+
+	img, err := m.RegisterImage(ctx, driver.RegisterImageInput{
+		Name:           "custom",
+		Architecture:   "arm64",
+		RootDeviceName: "/dev/xvda",
+		BlockDeviceMappings: []driver.ImageBlockDeviceMapping{{
+			DeviceName:          "/dev/xvda",
+			SnapshotID:          snap.ID,
+			VolumeSize:          20,
+			VolumeType:          "gp3",
+			DeleteOnTermination: true,
+		}},
+	})
+	requireNoError(t, err)
+	assertEqual(t, "arm64", img.Architecture)
+	assertEqual(t, "/dev/xvda", img.RootDeviceName)
+	assertEqual(t, 1, len(img.BlockDeviceMappings))
+	assertEqual(t, snap.ID, img.BlockDeviceMappings[0].SnapshotID)
+
+	_, err = m.RegisterImage(ctx, driver.RegisterImageInput{Name: "custom"})
+	assertError(t, err, true)
+	if !cerrors.IsAlreadyExists(err) {
+		t.Fatalf("RegisterImage(dup) err = %v, want AlreadyExists", err)
+	}
+
+	_, err = m.RegisterImage(ctx, driver.RegisterImageInput{
+		Name:                "refs-missing",
+		BlockDeviceMappings: []driver.ImageBlockDeviceMapping{{DeviceName: "/dev/sda1", SnapshotID: "snap-missing"}},
+	})
+	assertError(t, err, true)
+	if !cerrors.IsNotFound(err) {
+		t.Fatalf("RegisterImage(missing snapshot) err = %v, want NotFound", err)
+	}
+}
+
+// TestImportKeyPairStoresPublicKey pins that ImportKeyPair computes a
+// colon-hex fingerprint, stores the public key, never retains private material,
+// rejects duplicates, and rejects unparseable material.
+func TestImportKeyPairStoresPublicKey(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	requireNoError(t, err)
+	sshPub, err := ssh.NewPublicKey(&priv.PublicKey)
+	requireNoError(t, err)
+	authKey := ssh.MarshalAuthorizedKey(sshPub)
+
+	kp, err := m.ImportKeyPair(ctx, driver.ImportKeyPairInput{Name: "k", PublicKeyMaterial: authKey})
+	requireNoError(t, err)
+
+	if len(kp.Fingerprint) != len("aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99") {
+		t.Errorf("fingerprint = %q, want 16 colon-hex byte pairs (MD5)", kp.Fingerprint)
+	}
+	assertEqual(t, "", kp.PrivateKey)
+	assertEqual(t, string(authKey), kp.PublicKey)
+
+	_, err = m.ImportKeyPair(ctx, driver.ImportKeyPairInput{Name: "k", PublicKeyMaterial: authKey})
+	assertError(t, err, true)
+	if !cerrors.IsAlreadyExists(err) {
+		t.Fatalf("ImportKeyPair(dup) err = %v, want AlreadyExists", err)
+	}
+
+	_, err = m.ImportKeyPair(ctx, driver.ImportKeyPairInput{Name: "bad", PublicKeyMaterial: []byte("not a key")})
+	assertError(t, err, true)
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("ImportKeyPair(bad material) err = %v, want InvalidArgument", err)
+	}
+}
+
+// TestModifyVolumeGrowsAndValidates pins that ModifyVolume captures originals,
+// mutates the stored volume, rejects shrink, and reports NotFound for a missing
+// volume.
+func TestModifyVolumeGrowsAndValidates(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 20, VolumeType: "gp3", IOPS: 3000})
+	requireNoError(t, err)
+
+	mod, err := m.ModifyVolume(ctx, driver.ModifyVolumeInput{
+		VolumeID:   vol.ID,
+		Size:       50,
+		IOPS:       6000,
+		VolumeType: "io2",
+	})
+	requireNoError(t, err)
+	assertEqual(t, "modifying", mod.ModificationState)
+	assertEqual(t, 20, mod.OriginalSize)
+	assertEqual(t, 50, mod.TargetSize)
+	assertEqual(t, 3000, mod.OriginalIOPS)
+	assertEqual(t, 6000, mod.TargetIOPS)
+	assertEqual(t, "gp3", mod.OriginalVolumeType)
+	assertEqual(t, "io2", mod.TargetVolumeType)
+
+	vols, err := m.DescribeVolumes(ctx, []string{vol.ID})
+	requireNoError(t, err)
+	assertEqual(t, 50, vols[0].Size)
+	assertEqual(t, 6000, vols[0].IOPS)
+	assertEqual(t, "io2", vols[0].VolumeType)
+
+	_, err = m.ModifyVolume(ctx, driver.ModifyVolumeInput{VolumeID: vol.ID, Size: 10})
+	assertError(t, err, true)
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("ModifyVolume(shrink) err = %v, want InvalidArgument", err)
+	}
+
+	_, err = m.ModifyVolume(ctx, driver.ModifyVolumeInput{VolumeID: "vol-missing", Size: 100})
+	assertError(t, err, true)
+	if !cerrors.IsNotFound(err) {
+		t.Fatalf("ModifyVolume(missing) err = %v, want NotFound", err)
+	}
 }
 
 func requireNoError(t *testing.T, err error) {

--- a/providers/aws/ec2/launch_template_test.go
+++ b/providers/aws/ec2/launch_template_test.go
@@ -1,0 +1,193 @@
+package ec2
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+// TestCreateLaunchTemplateVersionSequential pins that each template numbers its
+// versions independently starting at 2 (v1 is the create), so two templates do
+// not share a counter (regression for the old package-global atomic).
+func TestCreateLaunchTemplateVersionSequential(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name:           "web",
+		InstanceConfig: driver.InstanceConfig{ImageID: "ami-1", InstanceType: "t2.micro"},
+	})
+	requireNoError(t, err)
+
+	_, err = m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name:           "db",
+		InstanceConfig: driver.InstanceConfig{ImageID: "ami-9", InstanceType: "m5.large"},
+	})
+	requireNoError(t, err)
+
+	v2, err := m.CreateLaunchTemplateVersion(ctx, driver.CreateLaunchTemplateVersionInput{
+		Name:           "web",
+		InstanceConfig: driver.InstanceConfig{ImageID: "ami-2", InstanceType: "t2.small"},
+	})
+	requireNoError(t, err)
+	assertEqual(t, 2, v2.VersionNumber)
+
+	v3, err := m.CreateLaunchTemplateVersion(ctx, driver.CreateLaunchTemplateVersionInput{
+		Name:           "web",
+		InstanceConfig: driver.InstanceConfig{ImageID: "ami-3"},
+	})
+	requireNoError(t, err)
+	assertEqual(t, 3, v3.VersionNumber)
+
+	// "db" must still be on its own version 1 -> its next version is 2, not 4.
+	dbV2, err := m.CreateLaunchTemplateVersion(ctx, driver.CreateLaunchTemplateVersionInput{
+		Name:           "db",
+		InstanceConfig: driver.InstanceConfig{InstanceType: "m5.xlarge"},
+	})
+	requireNoError(t, err)
+	assertEqual(t, 2, dbV2.VersionNumber)
+
+	web, err := m.GetLaunchTemplate(ctx, "web")
+	requireNoError(t, err)
+	assertEqual(t, 3, web.LatestVersion)
+	assertEqual(t, 1, web.DefaultVersion)
+}
+
+// TestCreateLaunchTemplateVersionSourceInherit pins that SourceVersion inherits
+// the source's parameters and only the explicitly-set fields are overwritten.
+func TestCreateLaunchTemplateVersionSourceInherit(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name: "app",
+		InstanceConfig: driver.InstanceConfig{
+			ImageID:      "ami-base",
+			InstanceType: "t2.micro",
+			KeyName:      "my-key",
+		},
+	})
+	requireNoError(t, err)
+
+	// Overwrite only the instance type; ImageID and KeyName inherit from v1.
+	v2, err := m.CreateLaunchTemplateVersion(ctx, driver.CreateLaunchTemplateVersionInput{
+		Name:           "app",
+		SourceVersion:  "1",
+		InstanceConfig: driver.InstanceConfig{InstanceType: "c5.large"},
+	})
+	requireNoError(t, err)
+	assertEqual(t, "ami-base", v2.InstanceConfig.ImageID)
+	assertEqual(t, "my-key", v2.InstanceConfig.KeyName)
+	assertEqual(t, "c5.large", v2.InstanceConfig.InstanceType)
+
+	// Without a SourceVersion the new version inherits nothing.
+	v3, err := m.CreateLaunchTemplateVersion(ctx, driver.CreateLaunchTemplateVersionInput{
+		Name:           "app",
+		InstanceConfig: driver.InstanceConfig{ImageID: "ami-fresh"},
+	})
+	requireNoError(t, err)
+	assertEqual(t, "ami-fresh", v3.InstanceConfig.ImageID)
+	assertEqual(t, "", v3.InstanceConfig.KeyName)
+	assertEqual(t, "", v3.InstanceConfig.InstanceType)
+}
+
+// TestDescribeLaunchTemplateVersionsFilter pins explicit version selection and
+// Min/Max bounds against a template with several versions.
+func TestDescribeLaunchTemplateVersionsFilter(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name:           "multi",
+		InstanceConfig: driver.InstanceConfig{ImageID: "ami-1"},
+	})
+	requireNoError(t, err)
+
+	for i := 2; i <= 5; i++ {
+		_, verr := m.CreateLaunchTemplateVersion(ctx, driver.CreateLaunchTemplateVersionInput{
+			Name:           "multi",
+			InstanceConfig: driver.InstanceConfig{ImageID: "ami-x"},
+		})
+		requireNoError(t, verr)
+	}
+
+	all, err := m.DescribeLaunchTemplateVersions(ctx, driver.DescribeLaunchTemplateVersionsInput{Name: "multi"})
+	requireNoError(t, err)
+	assertEqual(t, 5, len(all))
+	assertEqual(t, 1, all[0].VersionNumber)
+	assertTrue(t, all[0].DefaultVersion, "version 1 is the default")
+
+	only, err := m.DescribeLaunchTemplateVersions(ctx, driver.DescribeLaunchTemplateVersionsInput{
+		Name:     "multi",
+		Versions: []string{"2", "4"},
+	})
+	requireNoError(t, err)
+	assertEqual(t, 2, len(only))
+	assertEqual(t, 2, only[0].VersionNumber)
+	assertEqual(t, 4, only[1].VersionNumber)
+
+	bounded, err := m.DescribeLaunchTemplateVersions(ctx, driver.DescribeLaunchTemplateVersionsInput{
+		Name:       "multi",
+		MinVersion: "3",
+		MaxVersion: "4",
+	})
+	requireNoError(t, err)
+	assertEqual(t, 2, len(bounded))
+	assertEqual(t, 3, bounded[0].VersionNumber)
+	assertEqual(t, 4, bounded[1].VersionNumber)
+
+	latest, err := m.DescribeLaunchTemplateVersions(ctx, driver.DescribeLaunchTemplateVersionsInput{
+		Name:     "multi",
+		Versions: []string{"$Latest"},
+	})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(latest))
+	assertEqual(t, 5, latest[0].VersionNumber)
+}
+
+// TestGetLaunchTemplateDataFromInstance pins that launch-template data is
+// synthesized from a running instance's configuration.
+func TestGetLaunchTemplateDataFromInstance(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-run",
+		InstanceType: "t3.medium",
+		KeyName:      "kp",
+	}, 1)
+	requireNoError(t, err)
+
+	cfg, err := m.GetLaunchTemplateData(ctx, instances[0].ID)
+	requireNoError(t, err)
+	assertEqual(t, "ami-run", cfg.ImageID)
+	assertEqual(t, "t3.medium", cfg.InstanceType)
+	assertEqual(t, "kp", cfg.KeyName)
+
+	_, err = m.GetLaunchTemplateData(ctx, "i-missing")
+	assertError(t, err, true)
+	assertTrue(t, cerrors.IsNotFound(err), "missing instance is NotFound")
+}
+
+// TestCreateLaunchTemplateDuplicateIsAlreadyExists pins that a duplicate name
+// yields an AlreadyExists error (the wire layer maps it to
+// InvalidLaunchTemplateName.AlreadyExistsException).
+func TestCreateLaunchTemplateDuplicateIsAlreadyExists(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name:           "dup",
+		InstanceConfig: driver.InstanceConfig{ImageID: "ami-1"},
+	})
+	requireNoError(t, err)
+
+	_, err = m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name:           "dup",
+		InstanceConfig: driver.InstanceConfig{ImageID: "ami-2"},
+	})
+	assertError(t, err, true)
+	assertTrue(t, cerrors.IsAlreadyExists(err), "duplicate name is AlreadyExists")
+}

--- a/providers/aws/ec2/template.go
+++ b/providers/aws/ec2/template.go
@@ -2,17 +2,22 @@ package ec2
 
 import (
 	"context"
-	"sync/atomic"
+	"sort"
+	"strconv"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/services/compute/driver"
 )
 
-//nolint:gochecknoglobals // atomic counter for template versioning
-var templateVersion uint64
+var _ driver.LaunchTemplateVersioner = (*Mock)(nil)
 
-// CreateLaunchTemplate creates a new launch template.
+// templateVersionKey is the store key for one launch-template version.
+func templateVersionKey(name string, version int) string {
+	return name + "#" + strconv.Itoa(version)
+}
+
+// CreateLaunchTemplate creates a new launch template with an initial version 1.
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateLaunchTemplate(
@@ -26,28 +31,50 @@ func (m *Mock) CreateLaunchTemplate(
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "template %q already exists", cfg.Name)
 	}
 
-	ver := int(atomic.AddUint64(&templateVersion, 1)) //nolint:gosec // overflow impossible in mock
+	now := m.opts.Clock.Now().UTC().Format(timeFormat)
+	createdBy := idgen.AWSARN("iam", "", awsAccountID, "root")
 
 	tmpl := &driver.LaunchTemplate{
 		ID:             idgen.GenerateID("lt-"),
 		Name:           cfg.Name,
-		Version:        ver,
+		Version:        1,
 		InstanceConfig: cfg.InstanceConfig,
-		CreatedAt:      m.opts.Clock.Now().UTC().Format(timeFormat),
+		CreatedAt:      now,
+		DefaultVersion: 1,
+		LatestVersion:  1,
+		CreatedBy:      createdBy,
+		Tags:           copyTags(cfg.Tags),
 	}
 
 	m.templates.Set(cfg.Name, tmpl)
+	m.templateVersions.Set(templateVersionKey(cfg.Name, 1), &driver.LaunchTemplateVersion{
+		LaunchTemplateID:   tmpl.ID,
+		LaunchTemplateName: tmpl.Name,
+		VersionNumber:      1,
+		DefaultVersion:     true,
+		CreatedBy:          createdBy,
+		CreateTime:         now,
+		VersionDescription: cfg.VersionDescription,
+		InstanceConfig:     cfg.InstanceConfig,
+	})
 
 	result := *tmpl
 
 	return &result, nil
 }
 
-// DeleteLaunchTemplate deletes a launch template by name.
+// DeleteLaunchTemplate deletes a launch template by name and all its versions.
 func (m *Mock) DeleteLaunchTemplate(_ context.Context, name string) error {
-	if !m.templates.Delete(name) {
+	tmpl, ok := m.templates.Get(name)
+	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "template %q not found", name)
 	}
+
+	for v := 1; v <= tmpl.LatestVersion; v++ {
+		m.templateVersions.Delete(templateVersionKey(name, v))
+	}
+
+	m.templates.Delete(name)
 
 	return nil
 }
@@ -74,4 +101,260 @@ func (m *Mock) ListLaunchTemplates(_ context.Context) ([]driver.LaunchTemplate, 
 	}
 
 	return results, nil
+}
+
+// resolveTemplate finds a template by name (preferred) or by id. Real EC2
+// accepts either LaunchTemplateName or LaunchTemplateId on the versioning ops.
+func (m *Mock) resolveTemplate(name, id string) (*driver.LaunchTemplate, error) {
+	if name != "" {
+		tmpl, ok := m.templates.Get(name)
+		if !ok {
+			return nil, cerrors.Newf(cerrors.NotFound, "template %q not found", name)
+		}
+
+		return tmpl, nil
+	}
+
+	if id != "" {
+		for _, tmpl := range m.templates.All() {
+			if tmpl.ID == id {
+				return tmpl, nil
+			}
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "template %q not found", id)
+}
+
+// CreateLaunchTemplateVersion appends a new immutable version to a template.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateLaunchTemplateVersion(
+	_ context.Context, input driver.CreateLaunchTemplateVersionInput,
+) (*driver.LaunchTemplateVersion, error) {
+	tmpl, err := m.resolveTemplate(input.Name, input.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	base, err := m.sourceInstanceConfig(tmpl, input.SourceVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := mergeInstanceConfig(base, input.InstanceConfig)
+	next := tmpl.LatestVersion + 1
+	now := m.opts.Clock.Now().UTC().Format(timeFormat)
+
+	ver := &driver.LaunchTemplateVersion{
+		LaunchTemplateID:   tmpl.ID,
+		LaunchTemplateName: tmpl.Name,
+		VersionNumber:      next,
+		DefaultVersion:     next == tmpl.DefaultVersion,
+		CreatedBy:          tmpl.CreatedBy,
+		CreateTime:         now,
+		VersionDescription: input.VersionDescription,
+		InstanceConfig:     merged,
+	}
+
+	m.templateVersions.Set(templateVersionKey(tmpl.Name, next), ver)
+	tmpl.LatestVersion = next
+	tmpl.Version = next
+	m.templates.Set(tmpl.Name, tmpl)
+
+	result := *ver
+
+	return &result, nil
+}
+
+// sourceInstanceConfig returns the InstanceConfig a new version inherits from.
+// An empty SourceVersion inherits nothing (real EC2 builds the version solely
+// from the supplied data).
+func (m *Mock) sourceInstanceConfig(tmpl *driver.LaunchTemplate, sourceVersion string) (driver.InstanceConfig, error) {
+	if sourceVersion == "" {
+		return driver.InstanceConfig{}, nil
+	}
+
+	n, err := resolveVersionNumber(tmpl, sourceVersion)
+	if err != nil {
+		return driver.InstanceConfig{}, err
+	}
+
+	src, ok := m.templateVersions.Get(templateVersionKey(tmpl.Name, n))
+	if !ok {
+		return driver.InstanceConfig{}, cerrors.Newf(cerrors.NotFound, "launch template version %q not found", sourceVersion)
+	}
+
+	return src.InstanceConfig, nil
+}
+
+// resolveVersionNumber maps a version token ("$Latest", "$Default", or a
+// numeric string) to a concrete version number for the template.
+func resolveVersionNumber(tmpl *driver.LaunchTemplate, token string) (int, error) {
+	switch token {
+	case "$Latest":
+		return tmpl.LatestVersion, nil
+	case "$Default":
+		return tmpl.DefaultVersion, nil
+	default:
+		n, err := strconv.Atoi(token)
+		if err != nil {
+			return 0, cerrors.Newf(cerrors.InvalidArgument, "invalid launch template version %q", token)
+		}
+
+		return n, nil
+	}
+}
+
+// mergeInstanceConfig overlays the non-zero fields of override onto base, so a
+// version inheriting from a source only replaces the parameters explicitly set.
+//
+//nolint:gocritic // hugeParam: value semantics are intentional for the overlay.
+func mergeInstanceConfig(base, override driver.InstanceConfig) driver.InstanceConfig {
+	out := base
+
+	if override.ImageID != "" {
+		out.ImageID = override.ImageID
+	}
+
+	if override.InstanceType != "" {
+		out.InstanceType = override.InstanceType
+	}
+
+	if override.KeyName != "" {
+		out.KeyName = override.KeyName
+	}
+
+	if override.SubnetID != "" {
+		out.SubnetID = override.SubnetID
+	}
+
+	if override.UserData != "" {
+		out.UserData = override.UserData
+	}
+
+	if len(override.SecurityGroups) > 0 {
+		out.SecurityGroups = override.SecurityGroups
+	}
+
+	if len(override.Tags) > 0 {
+		out.Tags = override.Tags
+	}
+
+	return out
+}
+
+// DescribeLaunchTemplateVersions returns a template's versions, filtered by the
+// input's explicit version list and Min/Max bounds, sorted ascending.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) DescribeLaunchTemplateVersions(
+	_ context.Context, input driver.DescribeLaunchTemplateVersionsInput,
+) ([]driver.LaunchTemplateVersion, error) {
+	tmpl, err := m.resolveTemplate(input.Name, input.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	wanted, err := explicitVersions(tmpl, input.Versions)
+	if err != nil {
+		return nil, err
+	}
+
+	minV, maxV, err := versionBounds(input.MinVersion, input.MaxVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []driver.LaunchTemplateVersion
+
+	for v := 1; v <= tmpl.LatestVersion; v++ {
+		if wanted != nil {
+			if _, ok := wanted[v]; !ok {
+				continue
+			}
+		}
+
+		if v < minV || v > maxV {
+			continue
+		}
+
+		ver, ok := m.templateVersions.Get(templateVersionKey(tmpl.Name, v))
+		if !ok {
+			continue
+		}
+
+		copyVer := *ver
+		copyVer.DefaultVersion = v == tmpl.DefaultVersion
+		out = append(out, copyVer)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].VersionNumber < out[j].VersionNumber })
+
+	return out, nil
+}
+
+// explicitVersions resolves the request's Version list into a set of concrete
+// version numbers. A nil result means "all versions".
+func explicitVersions(tmpl *driver.LaunchTemplate, tokens []string) (map[int]struct{}, error) {
+	if len(tokens) == 0 {
+		return nil, nil //nolint:nilnil // nil set means "no explicit filter"; matches caller contract
+	}
+
+	set := make(map[int]struct{}, len(tokens))
+
+	for _, tok := range tokens {
+		n, err := resolveVersionNumber(tmpl, tok)
+		if err != nil {
+			return nil, err
+		}
+
+		set[n] = struct{}{}
+	}
+
+	return set, nil
+}
+
+// versionBounds parses MinVersion/MaxVersion, defaulting to the full range.
+func versionBounds(minStr, maxStr string) (minV, maxV int, err error) {
+	minV, maxV = 1, int(^uint(0)>>1)
+
+	if minStr != "" {
+		minV, err = strconv.Atoi(minStr)
+		if err != nil {
+			return 0, 0, cerrors.Newf(cerrors.InvalidArgument, "invalid MinVersion %q", minStr)
+		}
+	}
+
+	if maxStr != "" {
+		maxV, err = strconv.Atoi(maxStr)
+		if err != nil {
+			return 0, 0, cerrors.Newf(cerrors.InvalidArgument, "invalid MaxVersion %q", maxStr)
+		}
+	}
+
+	return minV, maxV, nil
+}
+
+// GetLaunchTemplateData synthesizes launch-template data from a running
+// instance, matching the AWS EC2 GetLaunchTemplateData operation.
+func (m *Mock) GetLaunchTemplateData(_ context.Context, instanceID string) (*driver.InstanceConfig, error) {
+	inst, ok := m.instances.Get(instanceID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
+	}
+
+	sg := make([]string, len(inst.SecurityGroups))
+	copy(sg, inst.SecurityGroups)
+
+	cfg := &driver.InstanceConfig{
+		ImageID:        inst.ImageID,
+		InstanceType:   inst.InstanceType,
+		KeyName:        inst.keyName,
+		SubnetID:       inst.SubnetID,
+		SecurityGroups: sg,
+		Tags:           copyTags(inst.Tags),
+	}
+
+	return cfg, nil
 }

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -253,6 +253,12 @@ func (h *Handler) routeLaunchTemplates(w http.ResponseWriter, r *http.Request, a
 		h.deleteLaunchTemplate(w, r)
 	case "DescribeLaunchTemplates":
 		h.describeLaunchTemplates(w, r)
+	case "CreateLaunchTemplateVersion":
+		h.createLaunchTemplateVersion(w, r)
+	case "DescribeLaunchTemplateVersions":
+		h.describeLaunchTemplateVersions(w, r)
+	case "GetLaunchTemplateData":
+		h.getLaunchTemplateData(w, r)
 	default:
 		return false
 	}

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -555,6 +555,11 @@ func writeErrWithNotFound(w http.ResponseWriter, err error, notFoundCode, precon
 	case cerrors.IsFailedPrecondition(err):
 		awsquery.WriteXMLError(w, http.StatusBadRequest,
 			preconditionCode, err.Error())
+	case cerrors.GetCode(err) == cerrors.Unimplemented:
+		// An unsupported optional op is a client-facing 400 InvalidAction, not a
+		// 500 — matching how the launch-template ops answer an absent capability.
+		awsquery.WriteXMLError(w, http.StatusBadRequest,
+			"InvalidAction", err.Error())
 	default:
 		awsquery.WriteXMLError(w, http.StatusInternalServerError,
 			"InternalError", err.Error())

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -132,6 +132,8 @@ func (h *Handler) routeSnapshots(w http.ResponseWriter, r *http.Request, action 
 		h.describeSnapshots(w, r)
 	case "ModifySnapshotAttribute":
 		h.modifySnapshotAttribute(w, r)
+	case "CopySnapshot":
+		h.copySnapshot(w, r)
 	default:
 		return false
 	}
@@ -143,6 +145,8 @@ func (h *Handler) routeImages(w http.ResponseWriter, r *http.Request, action str
 	switch action {
 	case "CreateImage":
 		h.createImage(w, r)
+	case "RegisterImage":
+		h.registerImage(w, r)
 	case "DeregisterImage":
 		h.deregisterImage(w, r)
 	case "DescribeImages":
@@ -325,6 +329,8 @@ func (h *Handler) routeVolumes(w http.ResponseWriter, r *http.Request, action st
 		h.detachVolume(w, r)
 	case "DescribeVolumeStatus":
 		h.describeVolumeStatus(w, r)
+	case "ModifyVolume":
+		h.modifyVolume(w, r)
 	default:
 		return false
 	}
@@ -336,6 +342,8 @@ func (h *Handler) routeKeyPairs(w http.ResponseWriter, r *http.Request, action s
 	switch action {
 	case "CreateKeyPair":
 		h.createKeyPair(w, r)
+	case "ImportKeyPair":
+		h.importKeyPair(w, r)
 	case "DeleteKeyPair":
 		h.deleteKeyPair(w, r)
 	case "DescribeKeyPairs":

--- a/server/aws/ec2/image.go
+++ b/server/aws/ec2/image.go
@@ -3,7 +3,9 @@ package ec2
 import (
 	"encoding/xml"
 	"net/http"
+	"strconv"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 )
@@ -75,6 +77,82 @@ func (h *Handler) createImage(w http.ResponseWriter, r *http.Request) {
 		RequestID: awsquery.RequestID,
 		ImageID:   info.ID,
 	})
+}
+
+type registerImageResponseXML struct {
+	XMLName   xml.Name `xml:"RegisterImageResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	ImageID   string   `xml:"imageId"`
+}
+
+// registerImage handles Action=RegisterImage. It is served by the AWS-only
+// ImageRegistrar capability; a compute driver that does not implement it
+// reports Unimplemented.
+func (h *Handler) registerImage(w http.ResponseWriter, r *http.Request) {
+	registrar, ok := h.compute.(computedriver.ImageRegistrar)
+	if !ok {
+		writeImageErr(w, cerrors.New(cerrors.Unimplemented, "RegisterImage is not supported"))
+		return
+	}
+
+	info, err := registrar.RegisterImage(r.Context(), computedriver.RegisterImageInput{
+		Name:                r.Form.Get("Name"),
+		Description:         r.Form.Get("Description"),
+		Architecture:        r.Form.Get("Architecture"),
+		RootDeviceName:      r.Form.Get("RootDeviceName"),
+		VirtualizationType:  r.Form.Get("VirtualizationType"),
+		BlockDeviceMappings: parseImageBlockDeviceMappings(r),
+		Tags:                mergeTagSpecs(awsquery.TagSpecs(r.Form), "image"),
+	})
+	if err != nil {
+		writeRegisterImageErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, registerImageResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		ImageID:   info.ID,
+	})
+}
+
+// parseImageBlockDeviceMappings reads the BlockDeviceMapping.N.* query groups
+// RegisterImage carries (DeviceName + nested Ebs.* fields).
+func parseImageBlockDeviceMappings(r *http.Request) []computedriver.ImageBlockDeviceMapping {
+	indices := awsquery.CollectIndices(r.Form, "BlockDeviceMapping")
+	if len(indices) == 0 {
+		return nil
+	}
+
+	out := make([]computedriver.ImageBlockDeviceMapping, 0, len(indices))
+
+	for _, i := range indices {
+		base := "BlockDeviceMapping." + strconv.Itoa(i)
+		size, _ := strconv.Atoi(r.Form.Get(base + ".Ebs.VolumeSize"))
+
+		out = append(out, computedriver.ImageBlockDeviceMapping{
+			DeviceName:          r.Form.Get(base + ".DeviceName"),
+			SnapshotID:          r.Form.Get(base + ".Ebs.SnapshotId"),
+			VolumeSize:          size,
+			VolumeType:          r.Form.Get(base + ".Ebs.VolumeType"),
+			DeleteOnTermination: r.Form.Get(base+".Ebs.DeleteOnTermination") == formTrue,
+		})
+	}
+
+	return out
+}
+
+// writeRegisterImageErr maps RegisterImage failures to their AWS codes: a
+// duplicate Name is InvalidAMIName.Duplicate, and a missing referenced snapshot
+// is InvalidSnapshot.NotFound (RegisterImage never reports InvalidAMIID).
+func writeRegisterImageErr(w http.ResponseWriter, err error) {
+	if cerrors.IsAlreadyExists(err) {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAMIName.Duplicate", err.Error())
+		return
+	}
+
+	writeErrWithNotFound(w, err, "InvalidSnapshot.NotFound", "IncorrectState")
 }
 
 func (h *Handler) deregisterImage(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/ec2/image_test.go
+++ b/server/aws/ec2/image_test.go
@@ -198,3 +198,114 @@ func TestDescribeImageAttribute(t *testing.T) {
 		t.Errorf("description attribute = %+v, want golden image", out.Description)
 	}
 }
+
+// TestRegisterImageDescribableAndBootable pins that RegisterImage (previously
+// undispatched) stores the caller-supplied architecture, root device, and block
+// device mapping, that DescribeImages reflects them, and that RunInstances can
+// launch from the registered AMI.
+func TestRegisterImageDescribableAndBootable(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	// A backing snapshot the AMI's block device mapping references.
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(20),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+	snap, err := client.CreateSnapshot(ctx, &ec2.CreateSnapshotInput{VolumeId: vol.VolumeId})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	reg, err := client.RegisterImage(ctx, &ec2.RegisterImageInput{
+		Name:               aws.String("custom-ami"),
+		Architecture:       ec2types.ArchitectureValuesArm64,
+		RootDeviceName:     aws.String("/dev/xvda"),
+		VirtualizationType: aws.String("hvm"),
+		BlockDeviceMappings: []ec2types.BlockDeviceMapping{{
+			DeviceName: aws.String("/dev/xvda"),
+			Ebs: &ec2types.EbsBlockDevice{
+				SnapshotId:          snap.SnapshotId,
+				VolumeSize:          aws.Int32(20),
+				VolumeType:          ec2types.VolumeTypeGp3,
+				DeleteOnTermination: aws.Bool(true),
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("RegisterImage: %v", err)
+	}
+	amiID := aws.ToString(reg.ImageId)
+	if amiID == "" {
+		t.Fatal("RegisterImage returned empty ImageId")
+	}
+
+	desc, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{ImageIds: []string{amiID}})
+	if err != nil {
+		t.Fatalf("DescribeImages: %v", err)
+	}
+	if len(desc.Images) != 1 {
+		t.Fatalf("DescribeImages = %d, want 1", len(desc.Images))
+	}
+
+	im := desc.Images[0]
+	if im.Architecture != ec2types.ArchitectureValuesArm64 {
+		t.Errorf("Architecture = %q, want arm64", im.Architecture)
+	}
+	if aws.ToString(im.RootDeviceName) != "/dev/xvda" {
+		t.Errorf("RootDeviceName = %q, want /dev/xvda", aws.ToString(im.RootDeviceName))
+	}
+	if len(im.BlockDeviceMappings) != 1 {
+		t.Fatalf("BlockDeviceMappings = %d, want 1", len(im.BlockDeviceMappings))
+	}
+	bdm := im.BlockDeviceMappings[0]
+	if bdm.Ebs == nil || aws.ToString(bdm.Ebs.SnapshotId) != aws.ToString(snap.SnapshotId) {
+		t.Errorf("block device mapping snapshot = %+v, want %q", bdm.Ebs, aws.ToString(snap.SnapshotId))
+	}
+	if aws.ToInt32(bdm.Ebs.VolumeSize) != 20 {
+		t.Errorf("block device mapping size = %d, want 20", aws.ToInt32(bdm.Ebs.VolumeSize))
+	}
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String(amiID),
+		InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances(registered AMI): %v", err)
+	}
+	if len(run.Instances) != 1 || aws.ToString(run.Instances[0].ImageId) != amiID {
+		t.Fatalf("RunInstances did not launch from registered AMI %q: %+v", amiID, run.Instances)
+	}
+}
+
+// TestRegisterImageDuplicateNameRejected pins the AWS error code for reusing an
+// AMI name that is already registered.
+func TestRegisterImageDuplicateNameRejected(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	if _, err := client.RegisterImage(ctx, &ec2.RegisterImageInput{
+		Name:         aws.String("dup-ami"),
+		Architecture: ec2types.ArchitectureValuesX8664,
+	}); err != nil {
+		t.Fatalf("RegisterImage(first): %v", err)
+	}
+
+	_, err := client.RegisterImage(ctx, &ec2.RegisterImageInput{
+		Name:         aws.String("dup-ami"),
+		Architecture: ec2types.ArchitectureValuesX8664,
+	})
+	if err == nil {
+		t.Fatal("RegisterImage(duplicate name) succeeded, want error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidAMIName.Duplicate" {
+		t.Fatalf("RegisterImage error = %v, want InvalidAMIName.Duplicate", err)
+	}
+}

--- a/server/aws/ec2/key_pair.go
+++ b/server/aws/ec2/key_pair.go
@@ -1,6 +1,7 @@
 package ec2
 
 import (
+	"encoding/base64"
 	"encoding/xml"
 	"net/http"
 
@@ -68,6 +69,55 @@ func (h *Handler) createKeyPair(w http.ResponseWriter, r *http.Request) {
 		KeyFingerprint: info.Fingerprint,
 		KeyMaterial:    info.PrivateKey,
 		KeyType:        info.KeyType,
+	})
+}
+
+// importKeyPairResponseXML is the ImportKeyPair response. Unlike CreateKeyPair
+// it carries NO keyMaterial — the caller already holds the private key.
+type importKeyPairResponseXML struct {
+	XMLName        xml.Name  `xml:"ImportKeyPairResponse"`
+	Xmlns          string    `xml:"xmlns,attr"`
+	RequestID      string    `xml:"requestId"`
+	KeyPairID      string    `xml:"keyPairId"`
+	KeyName        string    `xml:"keyName"`
+	KeyFingerprint string    `xml:"keyFingerprint"`
+	Tags           []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+// importKeyPair handles Action=ImportKeyPair. It is served by the AWS-only
+// KeyPairImporter capability; a compute driver that does not implement it
+// reports Unimplemented. PublicKeyMaterial arrives base64-encoded on the wire.
+func (h *Handler) importKeyPair(w http.ResponseWriter, r *http.Request) {
+	importer, ok := h.compute.(computedriver.KeyPairImporter)
+	if !ok {
+		writeKeyPairErr(w, cerrors.New(cerrors.Unimplemented, "ImportKeyPair is not supported"))
+		return
+	}
+
+	material, err := base64.StdEncoding.DecodeString(r.Form.Get("PublicKeyMaterial"))
+	if err != nil {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue",
+			"PublicKeyMaterial is not valid base64")
+		return
+	}
+
+	info, err := importer.ImportKeyPair(r.Context(), computedriver.ImportKeyPairInput{
+		Name:              r.Form.Get("KeyName"),
+		PublicKeyMaterial: material,
+		Tags:              mergeTagSpecs(awsquery.TagSpecs(r.Form), "key-pair"),
+	})
+	if err != nil {
+		writeKeyPairErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, importKeyPairResponseXML{
+		Xmlns:          awsquery.Namespace,
+		RequestID:      awsquery.RequestID,
+		KeyPairID:      info.ID,
+		KeyName:        info.Name,
+		KeyFingerprint: info.Fingerprint,
+		Tags:           toTagItems(info.Tags),
 	})
 }
 

--- a/server/aws/ec2/key_pair_test.go
+++ b/server/aws/ec2/key_pair_test.go
@@ -2,15 +2,20 @@ package ec2_test
 
 import (
 	"context"
+	"crypto/md5" //nolint:gosec // AWS defines imported key fingerprints as MD5 of the public key DER
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	smithy "github.com/aws/smithy-go"
+	"golang.org/x/crypto/ssh"
 )
 
 // TestCreateKeyPairReturnsKeyIDAndUsablePEM pins that keyPairId is a real
@@ -106,4 +111,109 @@ func TestDescribeKeyPairsUnknownNameErrors(t *testing.T) {
 	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidKeyPair.NotFound" {
 		t.Fatalf("error code = %v, want InvalidKeyPair.NotFound", err)
 	}
+}
+
+// TestImportKeyPairFingerprintAndDescribe pins that ImportKeyPair (previously
+// undispatched) returns the MD5-of-DER public-key fingerprint AWS uses for
+// imported keys, assigns a key-... id, and is visible to DescribeKeyPairs.
+func TestImportKeyPairFingerprintAndDescribe(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	sshPub, err := ssh.NewPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatalf("ssh.NewPublicKey: %v", err)
+	}
+	authKey := ssh.MarshalAuthorizedKey(sshPub) // "ssh-rsa AAAA...\n"
+
+	der, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey: %v", err)
+	}
+	sum := md5.Sum(der) //nolint:gosec // matches AWS imported-key fingerprint definition
+	want := colonHexTest(sum[:])
+
+	out, err := client.ImportKeyPair(ctx, &ec2.ImportKeyPairInput{
+		KeyName:           aws.String("imported"),
+		PublicKeyMaterial: authKey,
+	})
+	if err != nil {
+		t.Fatalf("ImportKeyPair: %v", err)
+	}
+
+	if id := aws.ToString(out.KeyPairId); !strings.HasPrefix(id, "key-") {
+		t.Errorf("KeyPairId = %q, want a key-... id", id)
+	}
+	if got := aws.ToString(out.KeyFingerprint); got != want {
+		t.Errorf("KeyFingerprint = %q, want MD5-of-DER %q", got, want)
+	}
+	if aws.ToString(out.KeyName) != "imported" {
+		t.Errorf("KeyName = %q, want imported", aws.ToString(out.KeyName))
+	}
+
+	desc, err := client.DescribeKeyPairs(ctx, &ec2.DescribeKeyPairsInput{
+		KeyNames: []string{"imported"},
+	})
+	if err != nil {
+		t.Fatalf("DescribeKeyPairs: %v", err)
+	}
+	if len(desc.KeyPairs) != 1 {
+		t.Fatalf("DescribeKeyPairs = %d, want 1", len(desc.KeyPairs))
+	}
+	if got := aws.ToString(desc.KeyPairs[0].KeyFingerprint); got != want {
+		t.Errorf("described fingerprint = %q, want %q", got, want)
+	}
+}
+
+// TestImportKeyPairDuplicateRejected pins the AWS error code for importing a key
+// whose name already exists.
+func TestImportKeyPairDuplicateRejected(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	sshPub, err := ssh.NewPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatalf("ssh.NewPublicKey: %v", err)
+	}
+	authKey := ssh.MarshalAuthorizedKey(sshPub)
+
+	if _, err := client.ImportKeyPair(ctx, &ec2.ImportKeyPairInput{
+		KeyName:           aws.String("dup-import"),
+		PublicKeyMaterial: authKey,
+	}); err != nil {
+		t.Fatalf("ImportKeyPair(first): %v", err)
+	}
+
+	_, err = client.ImportKeyPair(ctx, &ec2.ImportKeyPairInput{
+		KeyName:           aws.String("dup-import"),
+		PublicKeyMaterial: authKey,
+	})
+	if err == nil {
+		t.Fatal("ImportKeyPair(duplicate) succeeded, want error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidKeyPair.Duplicate" {
+		t.Fatalf("ImportKeyPair error = %v, want InvalidKeyPair.Duplicate", err)
+	}
+}
+
+// colonHexTest formats bytes as colon-separated lowercase hex, matching the
+// server's fingerprint encoding.
+func colonHexTest(b []byte) string {
+	parts := make([]string, len(b))
+	for i, x := range b {
+		parts[i] = fmt.Sprintf("%02x", x)
+	}
+
+	return strings.Join(parts, ":")
 }

--- a/server/aws/ec2/launch_template.go
+++ b/server/aws/ec2/launch_template.go
@@ -3,16 +3,47 @@ package ec2
 import (
 	"encoding/xml"
 	"net/http"
+	"net/url"
+	"strconv"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 )
 
+// launchTemplateDataXML is the nested <launchTemplateData> element echoed on
+// version responses, carrying the instance parameters a version pins.
+type launchTemplateDataXML struct {
+	ImageID          string    `xml:"imageId,omitempty"`
+	InstanceType     string    `xml:"instanceType,omitempty"`
+	KeyName          string    `xml:"keyName,omitempty"`
+	SubnetID         string    `xml:"subnetId,omitempty"`
+	UserData         string    `xml:"userData,omitempty"`
+	SecurityGroupIDs []string  `xml:"securityGroupIdSet>item,omitempty"`
+	TagSpec          []tagItem `xml:"tagSpecificationSet>item>tagSet>item,omitempty"`
+}
+
 type launchTemplateXML struct {
-	LaunchTemplateID   string `xml:"launchTemplateId"`
-	LaunchTemplateName string `xml:"launchTemplateName"`
-	Version            int    `xml:"versionNumber"`
-	CreateTime         string `xml:"createTime,omitempty"`
+	LaunchTemplateID     string    `xml:"launchTemplateId"`
+	LaunchTemplateName   string    `xml:"launchTemplateName"`
+	Version              int       `xml:"versionNumber"`
+	DefaultVersionNumber int       `xml:"defaultVersionNumber"`
+	LatestVersionNumber  int       `xml:"latestVersionNumber"`
+	CreatedBy            string    `xml:"createdBy,omitempty"`
+	CreateTime           string    `xml:"createTime,omitempty"`
+	Tags                 []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+// launchTemplateVersionXML is one <launchTemplateVersion> element.
+type launchTemplateVersionXML struct {
+	LaunchTemplateID   string                `xml:"launchTemplateId"`
+	LaunchTemplateName string                `xml:"launchTemplateName"`
+	VersionNumber      int                   `xml:"versionNumber"`
+	DefaultVersion     bool                  `xml:"defaultVersion"`
+	CreatedBy          string                `xml:"createdBy,omitempty"`
+	CreateTime         string                `xml:"createTime,omitempty"`
+	VersionDescription string                `xml:"versionDescription,omitempty"`
+	LaunchTemplateData launchTemplateDataXML `xml:"launchTemplateData"`
 }
 
 type createLaunchTemplateResponseXML struct {
@@ -36,13 +67,34 @@ type deleteLaunchTemplateResponseXML struct {
 	LaunchTemplate launchTemplateXML `xml:"launchTemplate"`
 }
 
+type createLaunchTemplateVersionResponseXML struct {
+	XMLName               xml.Name                 `xml:"CreateLaunchTemplateVersionResponse"`
+	Xmlns                 string                   `xml:"xmlns,attr"`
+	RequestID             string                   `xml:"requestId"`
+	LaunchTemplateVersion launchTemplateVersionXML `xml:"launchTemplateVersion"`
+}
+
+type describeLaunchTemplateVersionsResponseXML struct {
+	XMLName   xml.Name                   `xml:"DescribeLaunchTemplateVersionsResponse"`
+	Xmlns     string                     `xml:"xmlns,attr"`
+	RequestID string                     `xml:"requestId"`
+	Versions  []launchTemplateVersionXML `xml:"launchTemplateVersionSet>item"`
+	NextToken string                     `xml:"nextToken,omitempty"`
+}
+
+type getLaunchTemplateDataResponseXML struct {
+	XMLName            xml.Name              `xml:"GetLaunchTemplateDataResponse"`
+	Xmlns              string                `xml:"xmlns,attr"`
+	RequestID          string                `xml:"requestId"`
+	LaunchTemplateData launchTemplateDataXML `xml:"launchTemplateData"`
+}
+
 func (h *Handler) createLaunchTemplate(w http.ResponseWriter, r *http.Request) {
 	cfg := computedriver.LaunchTemplateConfig{
-		Name: r.Form.Get("LaunchTemplateName"),
-		InstanceConfig: computedriver.InstanceConfig{
-			ImageID:      r.Form.Get("LaunchTemplateData.ImageId"),
-			InstanceType: r.Form.Get("LaunchTemplateData.InstanceType"),
-		},
+		Name:               r.Form.Get("LaunchTemplateName"),
+		InstanceConfig:     parseLaunchTemplateData(r.Form, "LaunchTemplateData"),
+		Tags:               mergeTagSpecs(awsquery.TagSpecs(r.Form), "launch-template"),
+		VersionDescription: r.Form.Get("VersionDescription"),
 	}
 
 	info, err := h.compute.CreateLaunchTemplate(r.Context(), cfg)
@@ -120,15 +172,155 @@ func (h *Handler) describeLaunchTemplates(w http.ResponseWriter, r *http.Request
 	})
 }
 
-func toLaunchTemplateXML(lt *computedriver.LaunchTemplate) launchTemplateXML {
-	return launchTemplateXML{
-		LaunchTemplateID:   lt.ID,
-		LaunchTemplateName: lt.Name,
-		Version:            lt.Version,
-		CreateTime:         lt.CreatedAt,
+func (h *Handler) createLaunchTemplateVersion(w http.ResponseWriter, r *http.Request) {
+	lt, ok := h.compute.(computedriver.LaunchTemplateVersioner)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction",
+			"CreateLaunchTemplateVersion is not supported")
+
+		return
+	}
+
+	ver, err := lt.CreateLaunchTemplateVersion(r.Context(), computedriver.CreateLaunchTemplateVersionInput{
+		Name:               r.Form.Get("LaunchTemplateName"),
+		ID:                 r.Form.Get("LaunchTemplateId"),
+		SourceVersion:      r.Form.Get("SourceVersion"),
+		VersionDescription: r.Form.Get("VersionDescription"),
+		InstanceConfig:     parseLaunchTemplateData(r.Form, "LaunchTemplateData"),
+	})
+	if err != nil {
+		writeLaunchTemplateErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createLaunchTemplateVersionResponseXML{
+		Xmlns:                 awsquery.Namespace,
+		RequestID:             awsquery.RequestID,
+		LaunchTemplateVersion: toLaunchTemplateVersionXML(ver),
+	})
+}
+
+func (h *Handler) describeLaunchTemplateVersions(w http.ResponseWriter, r *http.Request) {
+	lt, ok := h.compute.(computedriver.LaunchTemplateVersioner)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction",
+			"DescribeLaunchTemplateVersions is not supported")
+
+		return
+	}
+
+	versions, err := lt.DescribeLaunchTemplateVersions(r.Context(), computedriver.DescribeLaunchTemplateVersionsInput{
+		Name:       r.Form.Get("LaunchTemplateName"),
+		ID:         r.Form.Get("LaunchTemplateId"),
+		Versions:   awsquery.ListStrings(r.Form, "LaunchTemplateVersion"),
+		MinVersion: r.Form.Get("MinVersion"),
+		MaxVersion: r.Form.Get("MaxVersion"),
+	})
+	if err != nil {
+		writeLaunchTemplateErr(w, err)
+		return
+	}
+
+	page, next := paginateXML(versions, r.Form.Get("MaxResults"), r.Form.Get("NextToken"),
+		func(v computedriver.LaunchTemplateVersion) string { return strconv.Itoa(v.VersionNumber) })
+
+	out := make([]launchTemplateVersionXML, 0, len(page))
+	for i := range page {
+		out = append(out, toLaunchTemplateVersionXML(&page[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeLaunchTemplateVersionsResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Versions:  out,
+		NextToken: next,
+	})
+}
+
+func (h *Handler) getLaunchTemplateData(w http.ResponseWriter, r *http.Request) {
+	lt, ok := h.compute.(computedriver.LaunchTemplateVersioner)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction",
+			"GetLaunchTemplateData is not supported")
+
+		return
+	}
+
+	cfg, err := lt.GetLaunchTemplateData(r.Context(), r.Form.Get("InstanceId"))
+	if err != nil {
+		writeLaunchTemplateErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, getLaunchTemplateDataResponseXML{
+		Xmlns:              awsquery.Namespace,
+		RequestID:          awsquery.RequestID,
+		LaunchTemplateData: toLaunchTemplateDataXML(*cfg),
+	})
+}
+
+// parseLaunchTemplateData reads the LaunchTemplateData.* parameter group into an
+// InstanceConfig. prefix is "LaunchTemplateData".
+func parseLaunchTemplateData(form url.Values, prefix string) computedriver.InstanceConfig {
+	return computedriver.InstanceConfig{
+		ImageID:        form.Get(prefix + ".ImageId"),
+		InstanceType:   form.Get(prefix + ".InstanceType"),
+		KeyName:        form.Get(prefix + ".KeyName"),
+		SubnetID:       form.Get(prefix + ".SubnetId"),
+		UserData:       form.Get(prefix + ".UserData"),
+		SecurityGroups: awsquery.ListStrings(form, prefix+".SecurityGroupId"),
 	}
 }
 
+func toLaunchTemplateXML(lt *computedriver.LaunchTemplate) launchTemplateXML {
+	return launchTemplateXML{
+		LaunchTemplateID:     lt.ID,
+		LaunchTemplateName:   lt.Name,
+		Version:              lt.Version,
+		DefaultVersionNumber: lt.DefaultVersion,
+		LatestVersionNumber:  lt.LatestVersion,
+		CreatedBy:            lt.CreatedBy,
+		CreateTime:           lt.CreatedAt,
+		Tags:                 toTagItems(lt.Tags),
+	}
+}
+
+func toLaunchTemplateVersionXML(v *computedriver.LaunchTemplateVersion) launchTemplateVersionXML {
+	return launchTemplateVersionXML{
+		LaunchTemplateID:   v.LaunchTemplateID,
+		LaunchTemplateName: v.LaunchTemplateName,
+		VersionNumber:      v.VersionNumber,
+		DefaultVersion:     v.DefaultVersion,
+		CreatedBy:          v.CreatedBy,
+		CreateTime:         v.CreateTime,
+		VersionDescription: v.VersionDescription,
+		LaunchTemplateData: toLaunchTemplateDataXML(v.InstanceConfig),
+	}
+}
+
+//nolint:gocritic // hugeParam: value copy of a small config for read-only projection.
+func toLaunchTemplateDataXML(cfg computedriver.InstanceConfig) launchTemplateDataXML {
+	return launchTemplateDataXML{
+		ImageID:          cfg.ImageID,
+		InstanceType:     cfg.InstanceType,
+		KeyName:          cfg.KeyName,
+		SubnetID:         cfg.SubnetID,
+		UserData:         cfg.UserData,
+		SecurityGroupIDs: cfg.SecurityGroups,
+		TagSpec:          toTagItems(cfg.Tags),
+	}
+}
+
+// writeLaunchTemplateErr maps a duplicate create to the EC2-specific
+// InvalidLaunchTemplateName.AlreadyExistsException code rather than the generic
+// ResourceAlreadyExists; other codes use the shared mapping.
 func writeLaunchTemplateErr(w http.ResponseWriter, err error) {
+	if cerrors.IsAlreadyExists(err) {
+		awsquery.WriteXMLError(w, http.StatusBadRequest,
+			"InvalidLaunchTemplateName.AlreadyExistsException", err.Error())
+
+		return
+	}
+
 	writeErrWithNotFound(w, err, "InvalidLaunchTemplateId.NotFound", "IncorrectState")
 }

--- a/server/aws/ec2/launch_template_test.go
+++ b/server/aws/ec2/launch_template_test.go
@@ -1,0 +1,196 @@
+package ec2_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestCreateLaunchTemplateEnrichedResponse pins that CreateLaunchTemplate echoes
+// the default/latest version numbers, a createdBy ARN, and resource tags, and
+// that the KeyName inside LaunchTemplateData survives the round-trip.
+func TestCreateLaunchTemplateEnrichedResponse(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	out, err := client.CreateLaunchTemplate(ctx, &ec2.CreateLaunchTemplateInput{
+		LaunchTemplateName: aws.String("web"),
+		LaunchTemplateData: &ec2types.RequestLaunchTemplateData{
+			ImageId:      aws.String("ami-123"),
+			InstanceType: ec2types.InstanceTypeT2Micro,
+			KeyName:      aws.String("my-key"),
+		},
+		TagSpecifications: []ec2types.TagSpecification{{
+			ResourceType: ec2types.ResourceTypeLaunchTemplate,
+			Tags:         []ec2types.Tag{{Key: aws.String("env"), Value: aws.String("prod")}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateLaunchTemplate: %v", err)
+	}
+
+	lt := out.LaunchTemplate
+	if got := aws.ToInt64(lt.DefaultVersionNumber); got != 1 {
+		t.Errorf("DefaultVersionNumber = %d, want 1", got)
+	}
+	if got := aws.ToInt64(lt.LatestVersionNumber); got != 1 {
+		t.Errorf("LatestVersionNumber = %d, want 1", got)
+	}
+	if aws.ToString(lt.CreatedBy) == "" {
+		t.Errorf("CreatedBy is empty, want an ARN")
+	}
+
+	var env string
+	for _, tg := range lt.Tags {
+		if aws.ToString(tg.Key) == "env" {
+			env = aws.ToString(tg.Value)
+		}
+	}
+	if env != "prod" {
+		t.Errorf("tag env = %q, want prod", env)
+	}
+}
+
+// TestCreateLaunchTemplateVersionRoundTrip pins that a new version increments the
+// number, inherits from SourceVersion, and shows up in DescribeLaunchTemplateVersions
+// with correct default-version selection.
+func TestCreateLaunchTemplateVersionRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	if _, err := client.CreateLaunchTemplate(ctx, &ec2.CreateLaunchTemplateInput{
+		LaunchTemplateName: aws.String("app"),
+		LaunchTemplateData: &ec2types.RequestLaunchTemplateData{
+			ImageId:      aws.String("ami-base"),
+			InstanceType: ec2types.InstanceTypeT2Micro,
+			KeyName:      aws.String("kp"),
+		},
+	}); err != nil {
+		t.Fatalf("CreateLaunchTemplate: %v", err)
+	}
+
+	ver, err := client.CreateLaunchTemplateVersion(ctx, &ec2.CreateLaunchTemplateVersionInput{
+		LaunchTemplateName: aws.String("app"),
+		SourceVersion:      aws.String("1"),
+		VersionDescription: aws.String("bigger box"),
+		LaunchTemplateData: &ec2types.RequestLaunchTemplateData{
+			InstanceType: ec2types.InstanceTypeC5Large,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateLaunchTemplateVersion: %v", err)
+	}
+
+	ltv := ver.LaunchTemplateVersion
+	if got := aws.ToInt64(ltv.VersionNumber); got != 2 {
+		t.Fatalf("VersionNumber = %d, want 2", got)
+	}
+	if aws.ToBool(ltv.DefaultVersion) {
+		t.Errorf("version 2 DefaultVersion = true, want false")
+	}
+	// Instance type overwritten; image + key inherited from v1.
+	if ltv.LaunchTemplateData == nil {
+		t.Fatalf("LaunchTemplateData is nil")
+	}
+	if got := ltv.LaunchTemplateData.InstanceType; got != ec2types.InstanceTypeC5Large {
+		t.Errorf("InstanceType = %q, want c5.large", got)
+	}
+	if got := aws.ToString(ltv.LaunchTemplateData.ImageId); got != "ami-base" {
+		t.Errorf("inherited ImageId = %q, want ami-base", got)
+	}
+	if got := aws.ToString(ltv.LaunchTemplateData.KeyName); got != "kp" {
+		t.Errorf("inherited KeyName = %q, want kp", got)
+	}
+
+	desc, err := client.DescribeLaunchTemplateVersions(ctx, &ec2.DescribeLaunchTemplateVersionsInput{
+		LaunchTemplateName: aws.String("app"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeLaunchTemplateVersions: %v", err)
+	}
+	if len(desc.LaunchTemplateVersions) != 2 {
+		t.Fatalf("got %d versions, want 2", len(desc.LaunchTemplateVersions))
+	}
+
+	var defaults int
+	for _, v := range desc.LaunchTemplateVersions {
+		if aws.ToBool(v.DefaultVersion) {
+			defaults++
+			if aws.ToInt64(v.VersionNumber) != 1 {
+				t.Errorf("default version = %d, want 1", aws.ToInt64(v.VersionNumber))
+			}
+		}
+	}
+	if defaults != 1 {
+		t.Errorf("got %d default versions, want exactly 1", defaults)
+	}
+}
+
+// TestGetLaunchTemplateDataFromRunningInstance pins that GetLaunchTemplateData
+// synthesizes data from a running instance.
+func TestGetLaunchTemplateDataFromRunningInstance(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-run"),
+		InstanceType: ec2types.InstanceTypeT3Medium,
+		KeyName:      aws.String("kp"),
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	id := aws.ToString(run.Instances[0].InstanceId)
+
+	data, err := client.GetLaunchTemplateData(ctx, &ec2.GetLaunchTemplateDataInput{
+		InstanceId: aws.String(id),
+	})
+	if err != nil {
+		t.Fatalf("GetLaunchTemplateData: %v", err)
+	}
+	if data.LaunchTemplateData == nil {
+		t.Fatalf("LaunchTemplateData is nil")
+	}
+	if got := aws.ToString(data.LaunchTemplateData.ImageId); got != "ami-run" {
+		t.Errorf("ImageId = %q, want ami-run", got)
+	}
+	if got := data.LaunchTemplateData.InstanceType; got != ec2types.InstanceTypeT3Medium {
+		t.Errorf("InstanceType = %q, want t3.medium", got)
+	}
+	if got := aws.ToString(data.LaunchTemplateData.KeyName); got != "kp" {
+		t.Errorf("KeyName = %q, want kp", got)
+	}
+}
+
+// TestCreateDuplicateLaunchTemplateErrors pins the EC2-specific
+// InvalidLaunchTemplateName.AlreadyExistsException code for a duplicate name.
+func TestCreateDuplicateLaunchTemplateErrors(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	in := &ec2.CreateLaunchTemplateInput{
+		LaunchTemplateName: aws.String("dup"),
+		LaunchTemplateData: &ec2types.RequestLaunchTemplateData{ImageId: aws.String("ami-1")},
+	}
+	if _, err := client.CreateLaunchTemplate(ctx, in); err != nil {
+		t.Fatalf("first CreateLaunchTemplate: %v", err)
+	}
+
+	_, err := client.CreateLaunchTemplate(ctx, in)
+	if err == nil {
+		t.Fatalf("duplicate CreateLaunchTemplate returned no error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidLaunchTemplateName.AlreadyExistsException" {
+		t.Fatalf("error code = %v, want InvalidLaunchTemplateName.AlreadyExistsException", err)
+	}
+}

--- a/server/aws/ec2/snapshot.go
+++ b/server/aws/ec2/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 )
@@ -47,6 +48,47 @@ type modifySnapshotAttributeResponseXML struct {
 	Xmlns     string   `xml:"xmlns,attr"`
 	RequestID string   `xml:"requestId"`
 	Return    bool     `xml:"return"`
+}
+
+// copySnapshotResponseXML mirrors AWS CopySnapshot: the new snapshot id plus
+// any tags applied by TagSpecification.N.
+type copySnapshotResponseXML struct {
+	XMLName    xml.Name  `xml:"CopySnapshotResponse"`
+	Xmlns      string    `xml:"xmlns,attr"`
+	RequestID  string    `xml:"requestId"`
+	SnapshotID string    `xml:"snapshotId"`
+	Tags       []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+// copySnapshot handles Action=CopySnapshot. It is served by the AWS-only
+// SnapshotCopier capability; a compute driver that does not implement it
+// reports Unimplemented.
+func (h *Handler) copySnapshot(w http.ResponseWriter, r *http.Request) {
+	copier, ok := h.compute.(computedriver.SnapshotCopier)
+	if !ok {
+		writeSnapshotErr(w, cerrors.New(cerrors.Unimplemented, "CopySnapshot is not supported"))
+		return
+	}
+
+	info, err := copier.CopySnapshot(r.Context(), computedriver.CopySnapshotInput{
+		SourceRegion:     r.Form.Get("SourceRegion"),
+		SourceSnapshotID: r.Form.Get("SourceSnapshotId"),
+		Description:      r.Form.Get("Description"),
+		Encrypted:        r.Form.Get("Encrypted") == formTrue,
+		KmsKeyID:         r.Form.Get("KmsKeyId"),
+		Tags:             mergeTagSpecs(awsquery.TagSpecs(r.Form), "snapshot"),
+	})
+	if err != nil {
+		writeSnapshotErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, copySnapshotResponseXML{
+		Xmlns:      awsquery.Namespace,
+		RequestID:  awsquery.RequestID,
+		SnapshotID: info.ID,
+		Tags:       toTagItems(info.Tags),
+	})
 }
 
 //nolint:dupl // per-resource create pattern; mirrors peering/flow-log shape

--- a/server/aws/ec2/snapshot_test.go
+++ b/server/aws/ec2/snapshot_test.go
@@ -131,3 +131,94 @@ func TestModifySnapshotAttributeAccepted(t *testing.T) {
 		t.Fatalf("ModifySnapshotAttribute: %v", err)
 	}
 }
+
+// TestCopySnapshotClonesSourceAndTags pins that CopySnapshot (previously
+// undispatched) returns a fresh snapshot id, copies the source size, applies
+// the requested description and tags, and leaves the source untouched.
+func TestCopySnapshotClonesSourceAndTags(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+	volID := createSnapshotVolume(t, ctx, client)
+
+	src, err := client.CreateSnapshot(ctx, &ec2.CreateSnapshotInput{
+		VolumeId:    aws.String(volID),
+		Description: aws.String("orig"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	cp, err := client.CopySnapshot(ctx, &ec2.CopySnapshotInput{
+		SourceRegion:     aws.String("us-east-1"),
+		SourceSnapshotId: src.SnapshotId,
+		Description:      aws.String("copy"),
+		TagSpecifications: []ec2types.TagSpecification{{
+			ResourceType: ec2types.ResourceTypeSnapshot,
+			Tags:         []ec2types.Tag{{Key: aws.String("env"), Value: aws.String("prod")}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CopySnapshot: %v", err)
+	}
+
+	newID := aws.ToString(cp.SnapshotId)
+	if newID == "" || newID == aws.ToString(src.SnapshotId) {
+		t.Fatalf("CopySnapshot id = %q, want fresh id != source %q", newID, aws.ToString(src.SnapshotId))
+	}
+
+	if !hasTag(cp.Tags, "env", "prod") {
+		t.Errorf("CopySnapshot response tags = %+v, want env=prod", cp.Tags)
+	}
+
+	desc, err := client.DescribeSnapshots(ctx, &ec2.DescribeSnapshotsInput{
+		SnapshotIds: []string{newID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSnapshots(copy): %v", err)
+	}
+	if len(desc.Snapshots) != 1 {
+		t.Fatalf("DescribeSnapshots = %d, want 1", len(desc.Snapshots))
+	}
+
+	s := desc.Snapshots[0]
+	if aws.ToInt32(s.VolumeSize) != 10 {
+		t.Errorf("copy VolumeSize = %d, want 10 (source size)", aws.ToInt32(s.VolumeSize))
+	}
+	if aws.ToString(s.Description) != "copy" {
+		t.Errorf("copy Description = %q, want %q", aws.ToString(s.Description), "copy")
+	}
+	if !hasTag(s.Tags, "env", "prod") {
+		t.Errorf("copy tags = %+v, want env=prod", s.Tags)
+	}
+}
+
+// TestCopySnapshotMissingSourceIsNotFound pins the AWS error code for a copy of
+// a non-existent source snapshot.
+func TestCopySnapshotMissingSourceIsNotFound(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	_, err := client.CopySnapshot(ctx, &ec2.CopySnapshotInput{
+		SourceRegion:     aws.String("us-east-1"),
+		SourceSnapshotId: aws.String("snap-000000000000"),
+	})
+	if err == nil {
+		t.Fatal("CopySnapshot(missing source) succeeded, want error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidSnapshot.NotFound" {
+		t.Fatalf("CopySnapshot error = %v, want InvalidSnapshot.NotFound", err)
+	}
+}
+
+// hasTag reports whether tags contains key=value.
+func hasTag(tags []ec2types.Tag, key, value string) bool {
+	for _, tg := range tags {
+		if aws.ToString(tg.Key) == key && aws.ToString(tg.Value) == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/aws/ec2/volume.go
+++ b/server/aws/ec2/volume.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 )
@@ -269,6 +270,76 @@ func (h *Handler) detachVolume(w http.ResponseWriter, r *http.Request) {
 		InstanceID: r.Form.Get("InstanceId"),
 		Device:     r.Form.Get("Device"),
 		Status:     "detaching",
+	})
+}
+
+// volumeModificationXML mirrors the AWS EC2 VolumeModification structure
+// returned by ModifyVolume.
+type volumeModificationXML struct {
+	VolumeID           string `xml:"volumeId"`
+	ModificationState  string `xml:"modificationState"`
+	StartTime          string `xml:"startTime,omitempty"`
+	Progress           int    `xml:"progress"`
+	OriginalSize       int    `xml:"originalSize"`
+	OriginalIops       int    `xml:"originalIops,omitempty"`
+	OriginalThroughput int    `xml:"originalThroughput,omitempty"`
+	OriginalVolumeType string `xml:"originalVolumeType"`
+	TargetSize         int    `xml:"targetSize"`
+	TargetIops         int    `xml:"targetIops,omitempty"`
+	TargetThroughput   int    `xml:"targetThroughput,omitempty"`
+	TargetVolumeType   string `xml:"targetVolumeType"`
+}
+
+type modifyVolumeResponseXML struct {
+	XMLName            xml.Name              `xml:"ModifyVolumeResponse"`
+	Xmlns              string                `xml:"xmlns,attr"`
+	RequestID          string                `xml:"requestId"`
+	VolumeModification volumeModificationXML `xml:"volumeModification"`
+}
+
+// modifyVolume handles Action=ModifyVolume. It is served by the AWS-only
+// VolumeModifier capability; a compute driver that does not implement it
+// reports Unimplemented.
+func (h *Handler) modifyVolume(w http.ResponseWriter, r *http.Request) {
+	modifier, ok := h.compute.(computedriver.VolumeModifier)
+	if !ok {
+		writeVolumeErr(w, cerrors.New(cerrors.Unimplemented, "ModifyVolume is not supported"))
+		return
+	}
+
+	size, _ := strconv.Atoi(r.Form.Get("Size"))
+	iops, _ := strconv.Atoi(r.Form.Get("Iops"))
+	throughput, _ := strconv.Atoi(r.Form.Get("Throughput"))
+
+	mod, err := modifier.ModifyVolume(r.Context(), computedriver.ModifyVolumeInput{
+		VolumeID:   r.Form.Get("VolumeId"),
+		Size:       size,
+		IOPS:       iops,
+		Throughput: throughput,
+		VolumeType: r.Form.Get("VolumeType"),
+	})
+	if err != nil {
+		writeVolumeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, modifyVolumeResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		VolumeModification: volumeModificationXML{
+			VolumeID:           mod.VolumeID,
+			ModificationState:  mod.ModificationState,
+			StartTime:          mod.StartTime,
+			Progress:           mod.Progress,
+			OriginalSize:       mod.OriginalSize,
+			OriginalIops:       mod.OriginalIOPS,
+			OriginalThroughput: mod.OriginalThroughput,
+			OriginalVolumeType: mod.OriginalVolumeType,
+			TargetSize:         mod.TargetSize,
+			TargetIops:         mod.TargetIOPS,
+			TargetThroughput:   mod.TargetThroughput,
+			TargetVolumeType:   mod.TargetVolumeType,
+		},
 	})
 }
 

--- a/server/aws/ec2/volume_test.go
+++ b/server/aws/ec2/volume_test.go
@@ -2,6 +2,7 @@ package ec2_test
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
 
 	"github.com/stackshy/cloudemu/v2"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
@@ -159,5 +161,119 @@ func TestDescribeVolumeStatusReturnsOK(t *testing.T) {
 	}
 	if got := out.VolumeStatuses[0].VolumeStatus.Status; got != ec2types.VolumeStatusInfoStatusOk {
 		t.Errorf("volume status = %q, want ok", got)
+	}
+}
+
+// TestModifyVolumeGrowsAndReportsModification pins that ModifyVolume (previously
+// undispatched) returns a VolumeModification with matching original/target
+// fields and that DescribeVolumes reflects the new size, IOPS, and type.
+func TestModifyVolumeGrowsAndReportsModification(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	cre, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(20),
+		VolumeType:       ec2types.VolumeTypeGp3,
+		Iops:             aws.Int32(3000),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+	volID := aws.ToString(cre.VolumeId)
+
+	mod, err := client.ModifyVolume(ctx, &ec2.ModifyVolumeInput{
+		VolumeId:   aws.String(volID),
+		Size:       aws.Int32(50),
+		Iops:       aws.Int32(6000),
+		VolumeType: ec2types.VolumeTypeIo2,
+	})
+	if err != nil {
+		t.Fatalf("ModifyVolume: %v", err)
+	}
+
+	vm := mod.VolumeModification
+	if vm == nil {
+		t.Fatal("ModifyVolume returned nil VolumeModification")
+	}
+	if aws.ToString(vm.VolumeId) != volID {
+		t.Errorf("VolumeModification VolumeId = %q, want %q", aws.ToString(vm.VolumeId), volID)
+	}
+	if vm.ModificationState == "" {
+		t.Error("VolumeModification ModificationState is empty")
+	}
+	if aws.ToInt32(vm.OriginalSize) != 20 || aws.ToInt32(vm.TargetSize) != 50 {
+		t.Errorf("size original=%d target=%d, want 20 -> 50",
+			aws.ToInt32(vm.OriginalSize), aws.ToInt32(vm.TargetSize))
+	}
+	if aws.ToInt32(vm.TargetIops) != 6000 {
+		t.Errorf("TargetIops = %d, want 6000", aws.ToInt32(vm.TargetIops))
+	}
+	if vm.OriginalVolumeType != ec2types.VolumeTypeGp3 || vm.TargetVolumeType != ec2types.VolumeTypeIo2 {
+		t.Errorf("volume type original=%q target=%q, want gp3 -> io2",
+			vm.OriginalVolumeType, vm.TargetVolumeType)
+	}
+
+	desc, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{VolumeIds: []string{volID}})
+	if err != nil {
+		t.Fatalf("DescribeVolumes: %v", err)
+	}
+	v := desc.Volumes[0]
+	if aws.ToInt32(v.Size) != 50 {
+		t.Errorf("post-modify Size = %d, want 50", aws.ToInt32(v.Size))
+	}
+	if aws.ToInt32(v.Iops) != 6000 {
+		t.Errorf("post-modify Iops = %d, want 6000", aws.ToInt32(v.Iops))
+	}
+	if v.VolumeType != ec2types.VolumeTypeIo2 {
+		t.Errorf("post-modify VolumeType = %q, want io2", v.VolumeType)
+	}
+}
+
+// TestModifyVolumeShrinkRejected pins that shrinking a volume is rejected with
+// InvalidParameterValue rather than silently succeeding.
+func TestModifyVolumeShrinkRejected(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	cre, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(30),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+
+	_, err = client.ModifyVolume(ctx, &ec2.ModifyVolumeInput{
+		VolumeId: cre.VolumeId,
+		Size:     aws.Int32(10),
+	})
+	if err == nil {
+		t.Fatal("ModifyVolume(shrink) succeeded, want error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("ModifyVolume(shrink) error = %v, want InvalidParameterValue", err)
+	}
+}
+
+// TestModifyVolumeMissingIsNotFound pins the AWS error code for modifying a
+// non-existent volume.
+func TestModifyVolumeMissingIsNotFound(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	_, err := client.ModifyVolume(ctx, &ec2.ModifyVolumeInput{
+		VolumeId: aws.String("vol-000000000000"),
+		Size:     aws.Int32(100),
+	})
+	if err == nil {
+		t.Fatal("ModifyVolume(missing) succeeded, want error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidVolume.NotFound" {
+		t.Fatalf("ModifyVolume(missing) error = %v, want InvalidVolume.NotFound", err)
 	}
 }

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -175,12 +175,81 @@ type LaunchTemplate struct {
 	Version        int
 	InstanceConfig InstanceConfig
 	CreatedAt      string
+	// DefaultVersion is the version number RunInstances uses when no version is
+	// named (AWS defaultVersionNumber). LatestVersion is the highest version
+	// number created so far (AWS latestVersionNumber). CreatedBy is the ARN of
+	// the principal that created the template. Tags are the template-level
+	// resource tags. These are populated by AWS EC2; providers with no launch
+	// template versioning leave them zero.
+	DefaultVersion int
+	LatestVersion  int
+	CreatedBy      string
+	Tags           map[string]string
 }
 
 // LaunchTemplateConfig configures a launch template.
 type LaunchTemplateConfig struct {
 	Name           string
 	InstanceConfig InstanceConfig
+	// Tags are template-level resource tags (AWS TagSpecification on the
+	// launch-template resource). VersionDescription annotates the initial (v1)
+	// version. Both are AWS-specific and ignored by providers without launch
+	// template versioning.
+	Tags               map[string]string
+	VersionDescription string
+}
+
+// LaunchTemplateVersion is one immutable version of a launch template (AWS EC2).
+// Versions are numbered sequentially per template starting at 1.
+type LaunchTemplateVersion struct {
+	LaunchTemplateID   string
+	LaunchTemplateName string
+	VersionNumber      int
+	DefaultVersion     bool
+	CreatedBy          string
+	CreateTime         string
+	VersionDescription string
+	InstanceConfig     InstanceConfig
+}
+
+// CreateLaunchTemplateVersionInput carries the parameters for
+// CreateLaunchTemplateVersion. Exactly one of Name/ID identifies the template.
+// When SourceVersion is set the new version inherits that version's parameters,
+// with the non-zero fields of InstanceConfig overlaid on top.
+type CreateLaunchTemplateVersionInput struct {
+	Name               string
+	ID                 string
+	SourceVersion      string
+	VersionDescription string
+	InstanceConfig     InstanceConfig
+}
+
+// DescribeLaunchTemplateVersionsInput carries the filters for
+// DescribeLaunchTemplateVersions. Exactly one of Name/ID identifies the
+// template. Versions is an explicit version-number list (also accepting the
+// "$Latest"/"$Default" tokens); MinVersion/MaxVersion bound the range. Paging
+// (MaxResults/NextToken) is applied by the wire layer.
+type DescribeLaunchTemplateVersionsInput struct {
+	Name       string
+	ID         string
+	Versions   []string
+	MinVersion string
+	MaxVersion string
+}
+
+// LaunchTemplateVersioner is an AWS-only optional capability implementing launch
+// template versioning. Only the EC2 provider implements it; the wire handler
+// type-asserts for it, so providers without versioning (Azure, GCP) are
+// unaffected.
+type LaunchTemplateVersioner interface {
+	// CreateLaunchTemplateVersion appends a new immutable version to a template.
+	CreateLaunchTemplateVersion(ctx context.Context, input CreateLaunchTemplateVersionInput) (*LaunchTemplateVersion, error)
+	// DescribeLaunchTemplateVersions returns a template's versions (filtered,
+	// sorted ascending by version number).
+	DescribeLaunchTemplateVersions(ctx context.Context, input DescribeLaunchTemplateVersionsInput) ([]LaunchTemplateVersion, error)
+	// GetLaunchTemplateData synthesizes launch-template data from a running
+	// instance's configuration.
+	GetLaunchTemplateData(ctx context.Context, instanceID string) (*InstanceConfig, error)
 }
 
 // VolumeConfig describes a volume to create.

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -386,3 +386,86 @@ type Compute interface {
 type ConsoleReader interface {
 	GetConsoleOutput(ctx context.Context, instanceID string) ([]byte, error)
 }
+
+// CopySnapshotInput describes an AWS EC2 CopySnapshot request. SourceRegion is
+// required by the API but ignored by the single-region emulator.
+type CopySnapshotInput struct {
+	SourceRegion     string
+	SourceSnapshotID string
+	Description      string
+	Encrypted        bool
+	KmsKeyID         string
+	Tags             map[string]string
+}
+
+// RegisterImageInput describes an AWS EC2 RegisterImage request.
+type RegisterImageInput struct {
+	Name                string
+	Description         string
+	Architecture        string
+	RootDeviceName      string
+	VirtualizationType  string
+	BlockDeviceMappings []ImageBlockDeviceMapping
+	Tags                map[string]string
+}
+
+// ImportKeyPairInput describes an AWS EC2 ImportKeyPair request. PublicKeyMaterial
+// is the decoded public key (OpenSSH or PEM), not the base64 wire form.
+type ImportKeyPairInput struct {
+	Name              string
+	PublicKeyMaterial []byte
+	Tags              map[string]string
+}
+
+// ModifyVolumeInput describes an AWS EC2 ModifyVolume request. A zero numeric
+// field or empty VolumeType means "leave unchanged".
+type ModifyVolumeInput struct {
+	VolumeID   string
+	Size       int
+	IOPS       int
+	Throughput int
+	VolumeType string
+}
+
+// VolumeModification describes the state of an in-progress AWS EC2 ModifyVolume,
+// mirroring the API's VolumeModification structure.
+type VolumeModification struct {
+	VolumeID           string
+	ModificationState  string // "modifying", "optimizing", "completed", "failed"
+	StartTime          string
+	Progress           int
+	OriginalSize       int
+	OriginalIOPS       int
+	OriginalThroughput int
+	OriginalVolumeType string
+	TargetSize         int
+	TargetIOPS         int
+	TargetThroughput   int
+	TargetVolumeType   string
+}
+
+// SnapshotCopier is an optional AWS-only capability for EC2 CopySnapshot. It is
+// discovered by type assertion; clouds that do not model EBS snapshot copies
+// (Azure, GCP, OCI) simply do not implement it.
+type SnapshotCopier interface {
+	CopySnapshot(ctx context.Context, input CopySnapshotInput) (*SnapshotInfo, error)
+}
+
+// ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
+// (registering an AMI from block device mappings). Discovered by type assertion.
+type ImageRegistrar interface {
+	RegisterImage(ctx context.Context, input RegisterImageInput) (*ImageInfo, error)
+}
+
+// KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair
+// (importing an externally-generated public key). Discovered by type assertion.
+type KeyPairImporter interface {
+	ImportKeyPair(ctx context.Context, input ImportKeyPairInput) (*KeyPairInfo, error)
+}
+
+// VolumeModifier is an optional AWS-only capability for EC2 ModifyVolume
+// (elastic volume resize / IOPS / throughput / type change). Discovered by
+// type assertion.
+type VolumeModifier interface {
+	ModifyVolume(ctx context.Context, input ModifyVolumeInput) (*VolumeModification, error)
+}


### PR DESCRIPTION
## Summary
Closes AWS parity gaps in EC2 storage/image operations and launch-template versioning, all via type-asserted **AWS-only optional interfaces** on `services/compute/driver` (no cross-cloud mirror stubs).

### EC2 storage & image ops
- **CopySnapshot** — new snapshot from a source (cross-region allowed) via `SnapshotCopier`
- **RegisterImage** — AMI from block-device mappings / snapshot via `ImageRegistrar`
- **ImportKeyPair** — stores caller-supplied public key; MD5-of-DER fingerprint, no private material returned, via `KeyPairImporter`
- **ModifyVolume** — mutates size/iops/throughput/type, returns `VolumeModification`, via `VolumeModifier`
- Correct AWS error codes: `InvalidSnapshot.NotFound`, `InvalidAMIName.Duplicate`, `InvalidKeyPair.Duplicate`, `InvalidVolume.NotFound`

### Launch-template versioning
- **CreateLaunchTemplateVersion / DescribeLaunchTemplateVersions / GetLaunchTemplateData** dispatched via `LaunchTemplateVersioner`
- `CreateLaunchTemplate` now preserves full launch data (KeyName + rest), populates `DefaultVersionNumber`/`LatestVersionNumber`/`CreatedBy`/`Tags`; per-template version numbering
- Duplicate name → `InvalidLaunchTemplateName.AlreadyExistsException`

Coverage docs regenerated for both interface sets. SDK round-trip tests exercise every new op and its interaction with existing ops (ModifyVolume→DescribeVolumes, RegisterImage→RunInstances, ImportKeyPair→DescribeKeyPairs, CreateLaunchTemplateVersion→default selection).