### PR TITLE
fix(sqs): add MessageMoveTask DLQ-redrive family

### DIFF
--- a/providers/aws/sqs/movetask.go
+++ b/providers/aws/sqs/movetask.go
@@ -54,6 +54,12 @@ func (m *Mock) StartMessageMoveTask(_ context.Context, sourceARN, destARN string
 		return "", errors.Newf(errors.NotFound, "no queue found for source arn %q", sourceARN)
 	}
 
+	// Real SQS requires the source to be a dead-letter queue that some other queue
+	// redrives to. cloudemu deliberately relaxes this: it accepts any existing
+	// queue as a redrive source, so a user can seed a queue and redrive it without
+	// first configuring a maxReceiveCount RedrivePolicy. This is a permissive
+	// divergence (cloudemu accepts what AWS would reject), never the reverse.
+
 	var destURL string
 
 	if destARN != "" {
@@ -120,7 +126,10 @@ func (m *Mock) drainSourceQueue(sourceURL, destURL string) (moved, toMove int64,
 
 	toMove = int64(len(pending))
 
-	var remaining []*sqsMessage
+	// Track the exact messages successfully moved (by pointer identity) rather
+	// than rebuilding the source from a stale snapshot: messages delivered to the
+	// DLQ while the move is in flight must survive, not be clobbered.
+	movedSet := make(map[*sqsMessage]struct{}, len(pending))
 
 	for _, msg := range pending {
 		target := destURL
@@ -131,16 +140,23 @@ func (m *Mock) drainSourceQueue(sourceURL, destURL string) (moved, toMove int64,
 		if target == "" || !m.appendMessageToQueue(target, msg) {
 			failure = "no destination queue for one or more messages"
 
-			remaining = append(remaining, msg)
-
 			continue
 		}
 
+		movedSet[msg] = struct{}{}
 		moved++
 	}
 
 	src.mu.Lock()
-	src.messages = remaining
+
+	kept := make([]*sqsMessage, 0, len(src.messages))
+	for _, msg := range src.messages {
+		if _, done := movedSet[msg]; !done {
+			kept = append(kept, msg)
+		}
+	}
+
+	src.messages = kept
 	src.mu.Unlock()
 
 	return moved, toMove, failure
@@ -255,8 +271,16 @@ func (m *Mock) ListMessageMoveTasks(_ context.Context, sourceARN string, maxResu
 
 	out := make([]driver.MessageMoveTask, 0, len(tasks))
 	for _, t := range tasks {
+		// Real SQS only returns a TaskHandle for a RUNNING task (the handle exists
+		// to cancel it); terminal tasks omit it. cloudemu completes moves
+		// synchronously, so listed tasks are terminal and carry no handle.
+		handle := ""
+		if t.status == moveTaskRunning {
+			handle = t.handle
+		}
+
 		out = append(out, driver.MessageMoveTask{
-			TaskHandle:                   t.handle,
+			TaskHandle:                   handle,
 			SourceARN:                    t.sourceARN,
 			DestinationARN:               t.destARN,
 			MaxNumberOfMessagesPerSecond: t.maxRate,

--- a/providers/aws/sqs/movetask.go
+++ b/providers/aws/sqs/movetask.go
@@ -1,0 +1,283 @@
+package sqs
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"sort"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+)
+
+// Message move task status values, matching the AWS SQS API.
+const (
+	moveTaskRunning   = "RUNNING"
+	moveTaskCompleted = "COMPLETED"
+	moveTaskCancelled = "CANCELLED" //nolint:misspell // AWS SQS API status literal (British spelling).
+	moveTaskFailed    = "FAILED"
+)
+
+const (
+	listMoveTasksDefault = 1
+	listMoveTasksMax     = 10
+)
+
+// moveTask is the internal record for an SQS DLQ redrive task.
+type moveTask struct {
+	handle        string
+	sourceARN     string
+	sourceURL     string
+	destARN       string
+	maxRate       int
+	status        string
+	moved         int64
+	toMove        int64
+	failureReason string
+	startedAt     time.Time
+}
+
+// StartMessageMoveTask starts an SQS message move (DLQ redrive) task. cloudemu
+// runs the move synchronously: it drains the source (dead-letter) queue into the
+// destination queue -- or, when destARN is empty, back to each message's original
+// source queue -- and records a COMPLETED task. It is AWS-specific and reached
+// via the SQS wire handler's optional messageMover interface.
+func (m *Mock) StartMessageMoveTask(_ context.Context, sourceARN, destARN string, maxRate int) (string, error) {
+	if sourceARN == "" {
+		return "", errors.New(errors.InvalidArgument, "SourceArn is required")
+	}
+
+	sourceURL := m.urlForARN(sourceARN)
+	if sourceURL == "" {
+		return "", errors.Newf(errors.NotFound, "no queue found for source arn %q", sourceARN)
+	}
+
+	var destURL string
+
+	if destARN != "" {
+		destURL = m.urlForARN(destARN)
+		if destURL == "" {
+			return "", errors.Newf(errors.NotFound, "no queue found for destination arn %q", destARN)
+		}
+	}
+
+	if err := m.rejectActiveMoveTask(sourceARN); err != nil {
+		return "", err
+	}
+
+	moved, toMove, failure := m.drainSourceQueue(sourceURL, destURL)
+
+	status := moveTaskCompleted
+	if failure != "" {
+		status = moveTaskFailed
+	}
+
+	handle := moveTaskHandle(idgen.GenerateID("mmt-"), sourceARN)
+
+	m.moveTasks.Set(handle, &moveTask{
+		handle:        handle,
+		sourceARN:     sourceARN,
+		sourceURL:     sourceURL,
+		destARN:       destARN,
+		maxRate:       maxRate,
+		status:        status,
+		moved:         moved,
+		toMove:        toMove,
+		failureReason: failure,
+		startedAt:     m.opts.Clock.Now(),
+	})
+
+	return handle, nil
+}
+
+// rejectActiveMoveTask returns FailedPrecondition if a non-terminal move task
+// already exists for the given source (SQS allows one active task per source).
+func (m *Mock) rejectActiveMoveTask(sourceARN string) error {
+	for _, t := range m.moveTasks.SortedValues() {
+		if t.sourceARN == sourceARN && t.status == moveTaskRunning {
+			return errors.Newf(errors.FailedPrecondition, "a message move task is already running for source %q", sourceARN)
+		}
+	}
+
+	return nil
+}
+
+// drainSourceQueue moves every message out of the source queue into the
+// destination (or, when destURL is empty, each message's recorded origin queue).
+// It returns the number moved, the total that was queued to move, and a failure
+// reason for any message with no resolvable destination.
+func (m *Mock) drainSourceQueue(sourceURL, destURL string) (moved, toMove int64, failure string) {
+	src, ok := m.queues.Get(sourceURL)
+	if !ok {
+		return 0, 0, ""
+	}
+
+	src.mu.Lock()
+	pending := append([]*sqsMessage(nil), src.messages...)
+	src.mu.Unlock()
+
+	toMove = int64(len(pending))
+
+	var remaining []*sqsMessage
+
+	for _, msg := range pending {
+		target := destURL
+		if target == "" {
+			target = m.redriveTargetURL(msg, sourceURL)
+		}
+
+		if target == "" || !m.appendMessageToQueue(target, msg) {
+			failure = "no destination queue for one or more messages"
+
+			remaining = append(remaining, msg)
+
+			continue
+		}
+
+		moved++
+	}
+
+	src.mu.Lock()
+	src.messages = remaining
+	src.mu.Unlock()
+
+	return moved, toMove, failure
+}
+
+// redriveTargetURL resolves where a DLQ message should be redriven when no
+// explicit destination is given: its recorded origin queue, else the single
+// queue whose RedrivePolicy targets this DLQ.
+func (m *Mock) redriveTargetURL(msg *sqsMessage, dlqURL string) string {
+	if msg.sourceQueueURL != "" {
+		return msg.sourceQueueURL
+	}
+
+	for _, qd := range m.queues.SortedValues() {
+		qd.mu.Lock()
+		match := qd.dlqConfig != nil && qd.dlqConfig.TargetQueueURL == dlqURL
+		qd.mu.Unlock()
+
+		if match {
+			return qd.info.URL
+		}
+	}
+
+	return ""
+}
+
+// appendMessageToQueue appends a copy of msg to the queue at url, resetting the
+// visibility/receipt state so it is immediately receivable. Returns false if the
+// target queue does not exist.
+func (m *Mock) appendMessageToQueue(url string, msg *sqsMessage) bool {
+	qd, ok := m.queues.Get(url)
+	if !ok {
+		return false
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	now := m.opts.Clock.Now()
+
+	qd.messages = append(qd.messages, &sqsMessage{
+		ID:                msg.ID,
+		Body:              msg.Body,
+		GroupID:           msg.GroupID,
+		DeduplicationID:   msg.DeduplicationID,
+		Attributes:        msg.Attributes,
+		MessageAttributes: msg.MessageAttributes,
+		SenderID:          msg.SenderID,
+		SequenceNumber:    msg.SequenceNumber,
+		VisibleAt:         now,
+		SentAt:            now,
+	})
+
+	return true
+}
+
+// CancelMessageMoveTask cancels a RUNNING move task and returns the number of
+// messages already moved. Because cloudemu completes moves synchronously, tasks
+// are terminal (COMPLETED/FAILED) by the time a caller sees the handle, so this
+// returns NotFound for any already-finished or unknown handle -- matching SQS,
+// which only cancels tasks in the RUNNING state.
+func (m *Mock) CancelMessageMoveTask(_ context.Context, taskHandle string) (int64, error) {
+	task, ok := m.moveTasks.Get(taskHandle)
+	if !ok {
+		return 0, errors.Newf(errors.NotFound, "no message move task found for handle %q", taskHandle)
+	}
+
+	if task.status != moveTaskRunning {
+		return 0, errors.Newf(errors.NotFound, "message move task %q is not running", taskHandle)
+	}
+
+	task.status = moveTaskCancelled
+
+	return task.moved, nil
+}
+
+// ListMessageMoveTasks returns the move tasks for a source ARN, newest first,
+// bounded by maxResults (default 1, max 10).
+func (m *Mock) ListMessageMoveTasks(_ context.Context, sourceARN string, maxResults int) ([]driver.MessageMoveTask, error) {
+	if sourceARN == "" {
+		return nil, errors.New(errors.InvalidArgument, "SourceArn is required")
+	}
+
+	if m.urlForARN(sourceARN) == "" {
+		return nil, errors.Newf(errors.NotFound, "no queue found for source arn %q", sourceARN)
+	}
+
+	limit := maxResults
+	if limit <= 0 {
+		limit = listMoveTasksDefault
+	}
+
+	if limit > listMoveTasksMax {
+		limit = listMoveTasksMax
+	}
+
+	var tasks []*moveTask
+
+	for _, t := range m.moveTasks.SortedValues() {
+		if t.sourceARN == sourceARN {
+			tasks = append(tasks, t)
+		}
+	}
+
+	sort.SliceStable(tasks, func(i, j int) bool {
+		return tasks[i].startedAt.After(tasks[j].startedAt)
+	})
+
+	if len(tasks) > limit {
+		tasks = tasks[:limit]
+	}
+
+	out := make([]driver.MessageMoveTask, 0, len(tasks))
+	for _, t := range tasks {
+		out = append(out, driver.MessageMoveTask{
+			TaskHandle:                   t.handle,
+			SourceARN:                    t.sourceARN,
+			DestinationARN:               t.destARN,
+			MaxNumberOfMessagesPerSecond: t.maxRate,
+			Status:                       t.status,
+			ApproxMessagesMoved:          t.moved,
+			ApproxMessagesToMove:         t.toMove,
+			FailureReason:                t.failureReason,
+			StartedAt:                    t.startedAt,
+		})
+	}
+
+	return out, nil
+}
+
+// moveTaskHandle builds the opaque task handle real SQS returns: base64 of a
+// small JSON object carrying the task id and source ARN.
+func moveTaskHandle(taskID, sourceARN string) string {
+	raw, _ := json.Marshal(struct {
+		TaskID    string `json:"taskId"`
+		SourceArn string `json:"sourceArn"`
+	}{TaskID: taskID, SourceArn: sourceARN})
+
+	return base64.StdEncoding.EncodeToString(raw)
+}

--- a/providers/aws/sqs/movetask_test.go
+++ b/providers/aws/sqs/movetask_test.go
@@ -1,0 +1,195 @@
+package sqs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+)
+
+func sendN(t *testing.T, m *Mock, url string, n int) {
+	t.Helper()
+
+	for i := 0; i < n; i++ {
+		if _, err := m.SendMessage(context.Background(), driver.SendMessageInput{
+			QueueURL: url, Body: fmt.Sprintf("body-%d", i),
+		}); err != nil {
+			t.Fatalf("SendMessage: %v", err)
+		}
+	}
+}
+
+func visibleCount(t *testing.T, m *Mock, url string) int {
+	t.Helper()
+
+	attrs, err := m.GetQueueAttributes(context.Background(), url)
+	requireNoError(t, err)
+
+	return attrs.ApproximateMessageCount
+}
+
+func redrivePolicy(dlqARN string, maxReceive int) string {
+	b, _ := json.Marshal(map[string]any{
+		"deadLetterTargetArn": dlqARN,
+		"maxReceiveCount":     maxReceive,
+	})
+
+	return string(b)
+}
+
+func TestStartMessageMoveTaskExplicitDestination(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	dlq := createStdQueue(m, "dlq")
+	dest := createStdQueue(m, "dest")
+	sendN(t, m, dlq.URL, 3)
+
+	handle, err := m.StartMessageMoveTask(ctx, dlq.ARN, dest.ARN, 0)
+	requireNoError(t, err)
+	assertNotEmpty(t, handle)
+
+	assertEqual(t, 0, visibleCount(t, m, dlq.URL))
+	assertEqual(t, 3, visibleCount(t, m, dest.URL))
+
+	tasks, err := m.ListMessageMoveTasks(ctx, dlq.ARN, 0)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(tasks))
+	assertEqual(t, moveTaskCompleted, tasks[0].Status)
+	assertEqual(t, int64(3), tasks[0].ApproxMessagesMoved)
+	assertEqual(t, int64(3), tasks[0].ApproxMessagesToMove)
+	assertEqual(t, dest.ARN, tasks[0].DestinationARN)
+}
+
+func TestStartMessageMoveTaskRedriveToConfiguredSource(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	dlq := createStdQueue(m, "dlq")
+	src, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "src", RedrivePolicy: redrivePolicy(dlq.ARN, 3)})
+	requireNoError(t, err)
+
+	sendN(t, m, dlq.URL, 2)
+
+	_, err = m.StartMessageMoveTask(ctx, dlq.ARN, "", 0)
+	requireNoError(t, err)
+
+	assertEqual(t, 0, visibleCount(t, m, dlq.URL))
+	assertEqual(t, 2, visibleCount(t, m, src.URL))
+}
+
+func TestStartMessageMoveTaskRedriveToOriginAfterDLQ(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+
+	dlq := createStdQueue(m, "dlq")
+	src, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "src", RedrivePolicy: redrivePolicy(dlq.ARN, 1)})
+	requireNoError(t, err)
+
+	sendN(t, m, src.URL, 1)
+
+	// Receive twice so the message exceeds maxReceiveCount=1 and lands in the DLQ,
+	// carrying its origin queue URL. Advance past the visibility timeout so the
+	// message is receivable again on the second call.
+	if _, err = m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: src.URL, VisibilityTimeout: 1}); err != nil {
+		t.Fatalf("first receive: %v", err)
+	}
+
+	fc.Advance(2 * time.Second)
+
+	if _, err = m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: src.URL, VisibilityTimeout: 1}); err != nil {
+		t.Fatalf("second receive: %v", err)
+	}
+
+	assertEqual(t, 1, visibleCount(t, m, dlq.URL))
+
+	_, err = m.StartMessageMoveTask(ctx, dlq.ARN, "", 0)
+	requireNoError(t, err)
+
+	assertEqual(t, 0, visibleCount(t, m, dlq.URL))
+	assertEqual(t, 1, visibleCount(t, m, src.URL))
+}
+
+func TestStartMessageMoveTaskUnknownArns(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	dlq := createStdQueue(m, "dlq")
+
+	if _, err := m.StartMessageMoveTask(ctx, "arn:aws:sqs:us-east-1:123456789012:nope", "", 0); err == nil {
+		t.Fatal("StartMessageMoveTask with unknown source: want error, got nil")
+	}
+
+	if _, err := m.StartMessageMoveTask(ctx, dlq.ARN, "arn:aws:sqs:us-east-1:123456789012:nope", 0); err == nil {
+		t.Fatal("StartMessageMoveTask with unknown destination: want error, got nil")
+	}
+}
+
+func TestListMessageMoveTasksNewestFirstBounded(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+
+	dlq := createStdQueue(m, "dlq")
+	dest := createStdQueue(m, "dest")
+
+	var handles []string
+
+	for i := 0; i < 3; i++ {
+		sendN(t, m, dlq.URL, 1)
+
+		h, err := m.StartMessageMoveTask(ctx, dlq.ARN, dest.ARN, 0)
+		requireNoError(t, err)
+
+		handles = append(handles, h)
+		fc.Advance(time.Second) // so StartedTimestamps are strictly increasing
+	}
+
+	all, err := m.ListMessageMoveTasks(ctx, dlq.ARN, 10)
+	requireNoError(t, err)
+	assertEqual(t, 3, len(all))
+	// Newest first: the last-created handle comes first.
+	assertEqual(t, handles[2], all[0].TaskHandle)
+	assertEqual(t, handles[0], all[2].TaskHandle)
+
+	bounded, err := m.ListMessageMoveTasks(ctx, dlq.ARN, 1)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(bounded))
+	assertEqual(t, handles[2], bounded[0].TaskHandle)
+
+	// Default (MaxResults=0) returns a single most-recent task.
+	def, err := m.ListMessageMoveTasks(ctx, dlq.ARN, 0)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(def))
+}
+
+func TestListMessageMoveTasksUnknownSource(t *testing.T) {
+	m, _ := newTestMock()
+
+	if _, err := m.ListMessageMoveTasks(context.Background(), "arn:aws:sqs:us-east-1:123456789012:nope", 0); err == nil {
+		t.Fatal("ListMessageMoveTasks with unknown source: want error, got nil")
+	}
+}
+
+func TestCancelMessageMoveTaskUnknownOrCompleted(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	dlq := createStdQueue(m, "dlq")
+	dest := createStdQueue(m, "dest")
+	sendN(t, m, dlq.URL, 1)
+
+	handle, err := m.StartMessageMoveTask(ctx, dlq.ARN, dest.ARN, 0)
+	requireNoError(t, err)
+
+	// Task completed synchronously, so cancel finds no RUNNING task.
+	if _, err := m.CancelMessageMoveTask(ctx, handle); err == nil {
+		t.Fatal("CancelMessageMoveTask on completed task: want error, got nil")
+	}
+
+	if _, err := m.CancelMessageMoveTask(ctx, "unknown-handle"); err == nil {
+		t.Fatal("CancelMessageMoveTask on unknown handle: want error, got nil")
+	}
+}

--- a/providers/aws/sqs/movetask_test.go
+++ b/providers/aws/sqs/movetask_test.go
@@ -135,29 +135,32 @@ func TestListMessageMoveTasksNewestFirstBounded(t *testing.T) {
 	dlq := createStdQueue(m, "dlq")
 	dest := createStdQueue(m, "dest")
 
-	var handles []string
-
 	for i := 0; i < 3; i++ {
 		sendN(t, m, dlq.URL, 1)
 
-		h, err := m.StartMessageMoveTask(ctx, dlq.ARN, dest.ARN, 0)
+		_, err := m.StartMessageMoveTask(ctx, dlq.ARN, dest.ARN, 0)
 		requireNoError(t, err)
 
-		handles = append(handles, h)
 		fc.Advance(time.Second) // so StartedTimestamps are strictly increasing
 	}
 
 	all, err := m.ListMessageMoveTasks(ctx, dlq.ARN, 10)
 	requireNoError(t, err)
 	assertEqual(t, 3, len(all))
-	// Newest first: the last-created handle comes first.
-	assertEqual(t, handles[2], all[0].TaskHandle)
-	assertEqual(t, handles[0], all[2].TaskHandle)
+	// Newest first: StartedAt strictly decreasing down the list.
+	if !all[0].StartedAt.After(all[1].StartedAt) || !all[1].StartedAt.After(all[2].StartedAt) {
+		t.Fatalf("tasks not newest-first: %v, %v, %v", all[0].StartedAt, all[1].StartedAt, all[2].StartedAt)
+	}
+	// Synchronous moves are terminal (COMPLETED), so no TaskHandle is returned.
+	for _, tk := range all {
+		assertEqual(t, moveTaskCompleted, tk.Status)
+		assertEqual(t, "", tk.TaskHandle)
+	}
 
 	bounded, err := m.ListMessageMoveTasks(ctx, dlq.ARN, 1)
 	requireNoError(t, err)
 	assertEqual(t, 1, len(bounded))
-	assertEqual(t, handles[2], bounded[0].TaskHandle)
+	assertEqual(t, all[0].StartedAt, bounded[0].StartedAt)
 
 	// Default (MaxResults=0) returns a single most-recent task.
 	def, err := m.ListMessageMoveTasks(ctx, dlq.ARN, 0)

--- a/providers/aws/sqs/sqs.go
+++ b/providers/aws/sqs/sqs.go
@@ -47,6 +47,10 @@ type sqsMessage struct {
 	SentAt            time.Time
 	FirstReceivedAt   time.Time
 	ReceiveCount      int
+	// sourceQueueURL records the queue a message was redriven from when it lands
+	// in a DLQ, so a DLQ redrive (StartMessageMoveTask without a DestinationArn)
+	// can return it to its original source.
+	sourceQueueURL string
 }
 
 // queueData holds the internal state of a single SQS queue.
@@ -77,6 +81,7 @@ type LambdaTrigger func(queueURL string, message driver.Message)
 // Mock is an in-memory mock implementation of the AWS SQS service.
 type Mock struct {
 	queues     *memstore.Store[*queueData]
+	moveTasks  *memstore.Store[*moveTask]
 	opts       *config.Options
 	mu         sync.RWMutex
 	triggers   map[string]LambdaTrigger // queueURL -> trigger
@@ -102,9 +107,10 @@ func (m *Mock) emitMetric(metricName string, value float64, unit string, dims ma
 // New creates a new SQS mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		queues:   memstore.New[*queueData](),
-		opts:     opts,
-		triggers: make(map[string]LambdaTrigger),
+		queues:    memstore.New[*queueData](),
+		moveTasks: memstore.New[*moveTask](),
+		opts:      opts,
+		triggers:  make(map[string]LambdaTrigger),
 	}
 }
 
@@ -574,7 +580,7 @@ func (m *Mock) collectVisibleMessages(
 
 		// Check if message exceeded max receive count - move to DLQ.
 		if qd.dlqConfig != nil && qd.dlqConfig.MaxReceiveCount > 0 && msg.ReceiveCount > qd.dlqConfig.MaxReceiveCount {
-			m.moveToDLQ(qd.dlqConfig.TargetQueueURL, msg)
+			m.moveToDLQ(qd.dlqConfig.TargetQueueURL, qd.info.URL, msg)
 
 			toRemove = append(toRemove, i)
 
@@ -632,8 +638,9 @@ func buildReceivedMessage(msg *sqsMessage, visibilityTimeout int, now time.Time)
 	}
 }
 
-// moveToDLQ moves a message to the dead-letter queue.
-func (m *Mock) moveToDLQ(dlqURL string, msg *sqsMessage) {
+// moveToDLQ moves a message to the dead-letter queue, recording the source
+// queue URL so a later DLQ redrive can return it to its origin.
+func (m *Mock) moveToDLQ(dlqURL, sourceURL string, msg *sqsMessage) {
 	dlq, ok := m.queues.Get(dlqURL)
 	if !ok {
 		return
@@ -651,6 +658,7 @@ func (m *Mock) moveToDLQ(dlqURL string, msg *sqsMessage) {
 		SenderID:          msg.SenderID,
 		VisibleAt:         m.opts.Clock.Now(),
 		SentAt:            m.opts.Clock.Now(),
+		sourceQueueURL:    sourceURL,
 	}
 
 	dlq.messages = append(dlq.messages, dlqMsg)

--- a/server/aws/sqs/handler.go
+++ b/server/aws/sqs/handler.go
@@ -87,6 +87,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.addPermission(w, r)
 	case "RemovePermission":
 		h.removePermission(w, r)
+	case "StartMessageMoveTask":
+		h.startMessageMoveTask(w, r)
+	case "CancelMessageMoveTask":
+		h.cancelMessageMoveTask(w, r)
+	case "ListMessageMoveTasks":
+		h.listMessageMoveTasks(w, r)
 	default:
 		wire.WriteJSONError(w, http.StatusBadRequest,
 			"UnknownOperationException", "unknown operation: "+op)
@@ -623,6 +629,7 @@ func (h *Handler) untagQueue(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, map[string]any{})
 }
 
+//nolint:dupl // uniform optional-interface handler shape; distinct SQS operation.
 func (h *Handler) listQueueTags(w http.ResponseWriter, r *http.Request) {
 	tagger, ok := h.mq.(queueTagger)
 	if !ok {
@@ -664,6 +671,141 @@ type dlqSourceLister interface {
 type queuePermissioner interface {
 	AddPermission(ctx context.Context, queueURL, label string, accountIDs, actions []string) error
 	RemovePermission(ctx context.Context, queueURL, label string) error
+}
+
+// messageMover exposes the SQS dead-letter-queue redrive surface
+// (StartMessageMoveTask/CancelMessageMoveTask/ListMessageMoveTasks). It is
+// AWS-specific and not part of the portable MessageQueue driver, so the handler
+// type-asserts for it.
+type messageMover interface {
+	StartMessageMoveTask(ctx context.Context, sourceARN, destARN string, maxRate int) (string, error)
+	CancelMessageMoveTask(ctx context.Context, taskHandle string) (int64, error)
+	ListMessageMoveTasks(ctx context.Context, sourceARN string, maxResults int) ([]mqdriver.MessageMoveTask, error)
+}
+
+func (h *Handler) startMessageMoveTask(w http.ResponseWriter, r *http.Request) {
+	mover, ok := h.mq.(messageMover)
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "StartMessageMoveTask not supported"))
+		return
+	}
+
+	var req struct {
+		SourceArn                    string `json:"SourceArn"`
+		DestinationArn               string `json:"DestinationArn"`
+		MaxNumberOfMessagesPerSecond int    `json:"MaxNumberOfMessagesPerSecond"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	handle, err := mover.StartMessageMoveTask(r.Context(), req.SourceArn, req.DestinationArn, req.MaxNumberOfMessagesPerSecond)
+	if err != nil {
+		writeMoveTaskErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"TaskHandle": handle})
+}
+
+//nolint:dupl // uniform optional-interface handler shape; distinct SQS operation.
+func (h *Handler) cancelMessageMoveTask(w http.ResponseWriter, r *http.Request) {
+	mover, ok := h.mq.(messageMover)
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "CancelMessageMoveTask not supported"))
+		return
+	}
+
+	var req struct {
+		TaskHandle string `json:"TaskHandle"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	moved, err := mover.CancelMessageMoveTask(r.Context(), req.TaskHandle)
+	if err != nil {
+		writeMoveTaskErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"ApproximateNumberOfMessagesMoved": moved})
+}
+
+func (h *Handler) listMessageMoveTasks(w http.ResponseWriter, r *http.Request) {
+	mover, ok := h.mq.(messageMover)
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "ListMessageMoveTasks not supported"))
+		return
+	}
+
+	var req struct {
+		SourceArn  string `json:"SourceArn"`
+		MaxResults int    `json:"MaxResults"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	tasks, err := mover.ListMessageMoveTasks(r.Context(), req.SourceArn, req.MaxResults)
+	if err != nil {
+		writeMoveTaskErr(w, err)
+		return
+	}
+
+	results := make([]map[string]any, 0, len(tasks))
+	for i := range tasks {
+		results = append(results, moveTaskResult(&tasks[i]))
+	}
+
+	wire.WriteJSON(w, map[string]any{"Results": results})
+}
+
+// moveTaskResult shapes one move task into its SQS ListMessageMoveTasks wire
+// entry, omitting the optional fields real SQS leaves out when unset.
+func moveTaskResult(t *mqdriver.MessageMoveTask) map[string]any {
+	entry := map[string]any{
+		"ApproximateNumberOfMessagesMoved":  t.ApproxMessagesMoved,
+		"ApproximateNumberOfMessagesToMove": t.ApproxMessagesToMove,
+		"SourceArn":                         t.SourceARN,
+		"Status":                            t.Status,
+		"StartedTimestamp":                  t.StartedAt.UnixMilli(),
+	}
+
+	if t.TaskHandle != "" {
+		entry["TaskHandle"] = t.TaskHandle
+	}
+
+	if t.DestinationARN != "" {
+		entry["DestinationArn"] = t.DestinationARN
+	}
+
+	if t.MaxNumberOfMessagesPerSecond > 0 {
+		entry["MaxNumberOfMessagesPerSecond"] = t.MaxNumberOfMessagesPerSecond
+	}
+
+	if t.FailureReason != "" {
+		entry["FailureReason"] = t.FailureReason
+	}
+
+	return entry
+}
+
+// writeMoveTaskErr maps canonical errors to the SQS message-move error codes.
+func writeMoveTaskErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "UnsupportedOperation", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValue", err.Error())
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalError", err.Error())
+	}
 }
 
 func (h *Handler) addPermission(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/sqs/messagemovetask_test.go
+++ b/server/aws/sqs/messagemovetask_test.go
@@ -1,0 +1,139 @@
+package sqs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+)
+
+// queueArn resolves a queue's ARN via GetQueueAttributes.
+func queueArn(t *testing.T, client *awssqs.Client, url *string) string {
+	t.Helper()
+
+	attrs, err := client.GetQueueAttributes(context.Background(), &awssqs.GetQueueAttributesInput{
+		QueueUrl:       url,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameQueueArn},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes: %v", err)
+	}
+
+	return attrs.Attributes["QueueArn"]
+}
+
+func TestSDKSQSMessageMoveTaskRoundTrip(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	dlq, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("dlq")})
+	if err != nil {
+		t.Fatalf("CreateQueue dlq: %v", err)
+	}
+
+	dest, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("dest")})
+	if err != nil {
+		t.Fatalf("CreateQueue dest: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := client.SendMessage(ctx, &awssqs.SendMessageInput{
+			QueueUrl: dlq.QueueUrl, MessageBody: aws.String("stuck"),
+		}); err != nil {
+			t.Fatalf("SendMessage: %v", err)
+		}
+	}
+
+	dlqArn := queueArn(t, client, dlq.QueueUrl)
+	destArn := queueArn(t, client, dest.QueueUrl)
+
+	start, err := client.StartMessageMoveTask(ctx, &awssqs.StartMessageMoveTaskInput{
+		SourceArn:      aws.String(dlqArn),
+		DestinationArn: aws.String(destArn),
+	})
+	if err != nil {
+		t.Fatalf("StartMessageMoveTask: %v", err)
+	}
+
+	if aws.ToString(start.TaskHandle) == "" {
+		t.Fatal("StartMessageMoveTask returned empty TaskHandle")
+	}
+
+	list, err := client.ListMessageMoveTasks(ctx, &awssqs.ListMessageMoveTasksInput{
+		SourceArn: aws.String(dlqArn),
+	})
+	if err != nil {
+		t.Fatalf("ListMessageMoveTasks: %v", err)
+	}
+
+	if len(list.Results) != 1 {
+		t.Fatalf("ListMessageMoveTasks returned %d results, want 1", len(list.Results))
+	}
+
+	res := list.Results[0]
+	if aws.ToString(res.Status) != "COMPLETED" {
+		t.Fatalf("Status = %q, want COMPLETED", aws.ToString(res.Status))
+	}
+
+	if res.ApproximateNumberOfMessagesMoved != 3 {
+		t.Fatalf("ApproximateNumberOfMessagesMoved = %d, want 3", res.ApproximateNumberOfMessagesMoved)
+	}
+
+	if aws.ToInt64(res.ApproximateNumberOfMessagesToMove) != 3 {
+		t.Fatalf("ApproximateNumberOfMessagesToMove = %d, want 3", aws.ToInt64(res.ApproximateNumberOfMessagesToMove))
+	}
+
+	// The destination queue now holds the redriven messages.
+	rcv, err := client.ReceiveMessage(ctx, &awssqs.ReceiveMessageInput{
+		QueueUrl: dest.QueueUrl, MaxNumberOfMessages: 10,
+	})
+	if err != nil {
+		t.Fatalf("ReceiveMessage: %v", err)
+	}
+
+	if len(rcv.Messages) != 3 {
+		t.Fatalf("destination has %d messages, want 3", len(rcv.Messages))
+	}
+}
+
+func TestSDKSQSCancelMessageMoveTaskCompleted(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	dlq, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("dlq")})
+	if err != nil {
+		t.Fatalf("CreateQueue dlq: %v", err)
+	}
+
+	dest, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("dest")})
+	if err != nil {
+		t.Fatalf("CreateQueue dest: %v", err)
+	}
+
+	if _, err := client.SendMessage(ctx, &awssqs.SendMessageInput{
+		QueueUrl: dlq.QueueUrl, MessageBody: aws.String("x"),
+	}); err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+
+	dlqArn := queueArn(t, client, dlq.QueueUrl)
+	destArn := queueArn(t, client, dest.QueueUrl)
+
+	start, err := client.StartMessageMoveTask(ctx, &awssqs.StartMessageMoveTaskInput{
+		SourceArn:      aws.String(dlqArn),
+		DestinationArn: aws.String(destArn),
+	})
+	if err != nil {
+		t.Fatalf("StartMessageMoveTask: %v", err)
+	}
+
+	// Synchronous completion means the task is already COMPLETED, so canceling it
+	// returns ResourceNotFoundException.
+	if _, err := client.CancelMessageMoveTask(ctx, &awssqs.CancelMessageMoveTaskInput{
+		TaskHandle: start.TaskHandle,
+	}); err == nil {
+		t.Fatal("CancelMessageMoveTask on completed task returned nil error, want ResourceNotFoundException")
+	}
+}

--- a/services/messagequeue/driver/driver.go
+++ b/services/messagequeue/driver/driver.go
@@ -160,6 +160,23 @@ type QueueAttributes struct {
 	KmsMasterKeyID                string
 }
 
+// MessageMoveTask describes an SQS dead-letter-queue redrive task, as reported
+// by StartMessageMoveTask / ListMessageMoveTasks. It is an AWS-specific concept
+// (not part of the portable MessageQueue interface); only the AWS provider
+// populates it, and the SQS wire handler type-asserts for the optional
+// interface that returns it.
+type MessageMoveTask struct {
+	TaskHandle                   string
+	SourceARN                    string
+	DestinationARN               string
+	MaxNumberOfMessagesPerSecond int
+	Status                       string // AWS SQS task status, e.g. RUNNING, COMPLETED, FAILED
+	ApproxMessagesMoved          int64
+	ApproxMessagesToMove         int64
+	FailureReason                string
+	StartedAt                    time.Time
+}
+
 // MessageQueue is the interface that message queue provider implementations must satisfy.
 type MessageQueue interface {
 	CreateQueue(ctx context.Context, config QueueConfig) (*QueueInfo, error)


### PR DESCRIPTION
## Summary
Dispatches `StartMessageMoveTask` / `CancelMessageMoveTask` / `ListMessageMoveTasks` — DLQ redrive that moves messages from a source (DLQ) ARN back to the destination queue and tracks task status/progress. Previously undispatched.

Modeled via an AWS-only `messageMover` optional interface on the messagequeue driver. The move is synchronous (no RUNNING/CANCELLING intermediate — that's deferred to the async-state-machine tier). SDK round-trip test: start→list→cancel plus message movement verification.