### PR TITLE
feat(aws): clock-driven async state settling (pending/creating/RUNNING/PENDING_VALIDATION)

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -62,6 +62,25 @@ type Options struct {
 	// StorageEngine optionally persists object-storage bytes to a real backing
 	// (opt-in). Nil (the default) keeps object bytes in-memory.
 	StorageEngine StorageEngine
+
+	// AsyncSettle, when true, makes resources report a realistic intermediate
+	// state (pending/creating/PENDING_VALIDATION/RUNNING) for a short settle
+	// window after creation before their final state. Default false, which keeps
+	// every resource reporting its terminal state immediately (the historical
+	// behavior). See internal/settle.
+	AsyncSettle bool
+}
+
+// SettleDuration returns d when asynchronous state settling is enabled and 0
+// when it is not, so a provider can write `settle.Pending(state, now,
+// o.SettleDuration(settle.DefaultInstanceSettle))` at one call site and have the
+// window be inactive (immediate final state) unless the caller opted in.
+func (o *Options) SettleDuration(d time.Duration) time.Duration {
+	if o.AsyncSettle {
+		return d
+	}
+
+	return 0
 }
 
 // OCIRegion returns the region OCI services should use, substituting an OCI
@@ -152,6 +171,16 @@ func WithStorageEngine(e StorageEngine) Option {
 func WithClock(c Clock) Option {
 	return func(o *Options) {
 		o.Clock = c
+	}
+}
+
+// WithAsyncSettle enables realistic post-creation state settling (resources
+// report an intermediate state for a short window before their final state).
+// Off by default. Pair with a FakeClock to drive the transition deterministically
+// in tests. See internal/settle.
+func WithAsyncSettle() Option {
+	return func(o *Options) {
+		o.AsyncSettle = true
 	}
 }
 

--- a/internal/settle/settle.go
+++ b/internal/settle/settle.go
@@ -1,0 +1,69 @@
+// Package settle models AWS asynchronous resource-state transitions
+// (pending->running, creating->available, PENDING_VALIDATION->ISSUED, ...) as a
+// lazy, read-time overlay driven purely by a clock.
+//
+// A resource stores its FINAL settled state (what the logical state machine and
+// internal consumers expect) plus a Window recording an intermediate state and
+// the instant it settles. Describe/Get emits Window.Observe(clock.Now(), final):
+// the intermediate value until readyAt, then the final value. Observe never
+// mutates, so it composes with a provider's existing read lock with no
+// escalation, and it uses no goroutines or timers — advancing a FakeClock (in
+// tests) or wall-clock (under `cloudemu serve`) is what moves the observed
+// state. The zero-value Window is inactive: Observe returns the final state
+// unconditionally, which preserves the synchronous behavior callers had before
+// any settling was configured.
+package settle
+
+import "time"
+
+// Default settle durations per resource type. They are deliberately small so a
+// real SDK waiter (whose minimum poll delay is 15-30s) succeeds on its first
+// poll, while an immediate Describe still observes the intermediate state.
+const (
+	DefaultInstanceSettle    = 2 * time.Second // EC2 instance pending->running
+	DefaultVolumeSettle      = 1 * time.Second // EBS volume creating->available
+	DefaultDBInstanceSettle  = 3 * time.Second // RDS instance creating->available
+	DefaultDBSnapshotSettle  = 2 * time.Second // RDS snapshot creating->available
+	DefaultDBRebootSettle    = 1 * time.Second // RDS available->rebooting->available
+	DefaultCertificateSettle = 2 * time.Second // ACM PENDING_VALIDATION->ISSUED
+	DefaultExecutionSettle   = 1 * time.Second // SFN RUNNING->SUCCEEDED
+)
+
+// Window is a read-time overlay describing a resource still settling into its
+// final state. The zero value is inactive.
+type Window struct {
+	// Intermediate is the state observed before the window elapses (e.g.
+	// "pending", "creating", "PENDING_VALIDATION", "RUNNING", "rebooting").
+	Intermediate string
+	// ReadyAt is when the final state becomes observable.
+	ReadyAt time.Time
+	active  bool
+}
+
+// Pending builds a window that shows intermediate until createdAt+d, then the
+// final state. A non-positive d yields an inactive (zero-equivalent) window, so
+// a single call site cleanly expresses "async disabled".
+func Pending(intermediate string, createdAt time.Time, d time.Duration) Window {
+	if d <= 0 {
+		return Window{}
+	}
+
+	return Window{Intermediate: intermediate, ReadyAt: createdAt.Add(d), active: true}
+}
+
+// Observe returns the state to report at now: the intermediate value while the
+// window is active and unelapsed, otherwise final.
+func (w Window) Observe(now time.Time, final string) string {
+	if w.active && now.Before(w.ReadyAt) {
+		return w.Intermediate
+	}
+
+	return final
+}
+
+// Settled reports whether the window has elapsed (or was never active). Useful
+// for progress fields such as RDS snapshot PercentProgress (0 while unsettled,
+// 100 once settled).
+func (w Window) Settled(now time.Time) bool {
+	return !(w.active && now.Before(w.ReadyAt))
+}

--- a/internal/settle/settle_test.go
+++ b/internal/settle/settle_test.go
@@ -1,0 +1,60 @@
+package settle_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+)
+
+var base = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func TestPendingObservesIntermediateThenFinal(t *testing.T) {
+	t.Parallel()
+
+	w := settle.Pending("pending", base, 2*time.Second)
+
+	if got := w.Observe(base, "running"); got != "pending" {
+		t.Fatalf("at create: Observe = %q, want pending", got)
+	}
+	if got := w.Observe(base.Add(time.Second), "running"); got != "pending" {
+		t.Fatalf("before readyAt: Observe = %q, want pending", got)
+	}
+	if got := w.Observe(base.Add(2*time.Second), "running"); got != "running" {
+		t.Fatalf("at readyAt: Observe = %q, want running", got)
+	}
+	if got := w.Observe(base.Add(time.Hour), "running"); got != "running" {
+		t.Fatalf("after readyAt: Observe = %q, want running", got)
+	}
+}
+
+func TestSettled(t *testing.T) {
+	t.Parallel()
+
+	w := settle.Pending("creating", base, time.Second)
+	if w.Settled(base) {
+		t.Fatal("Settled at create = true, want false")
+	}
+	if !w.Settled(base.Add(time.Second)) {
+		t.Fatal("Settled at readyAt = false, want true")
+	}
+}
+
+func TestZeroWindowIsInactive(t *testing.T) {
+	t.Parallel()
+
+	// The zero value (and a non-positive duration) must report the final state
+	// immediately — this is what preserves the synchronous default behavior.
+	var zero settle.Window
+	if got := zero.Observe(base, "available"); got != "available" {
+		t.Fatalf("zero Observe = %q, want available", got)
+	}
+	if !zero.Settled(base) {
+		t.Fatal("zero Settled = false, want true")
+	}
+
+	disabled := settle.Pending("creating", base, 0)
+	if got := disabled.Observe(base, "available"); got != "available" {
+		t.Fatalf("d<=0 Observe = %q, want available", got)
+	}
+}

--- a/providers/aws/acm/acm.go
+++ b/providers/aws/acm/acm.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	"github.com/stackshy/cloudemu/v2/services/acm/driver"
 )
 
@@ -38,7 +39,29 @@ type Mock struct {
 // certData is a certificate plus its own lock.
 type certData struct {
 	cert driver.Certificate
-	mu   sync.RWMutex
+	// settle overlays a PENDING_VALIDATION window over the stored (ISSUED) status
+	// on the Describe/List surface under AsyncSettle; zero-value reports ISSUED
+	// immediately. While pending, each domain-validation option also reports
+	// PENDING_VALIDATION so a caller sees the CNAME it must create.
+	settle settle.Window
+	mu     sync.RWMutex
+}
+
+// observeCert returns a deep copy of cert with the PENDING_VALIDATION window
+// overlaid: while the window is unelapsed the certificate and every domain
+// validation report PENDING_VALIDATION; once elapsed the stored (ISSUED) status
+// shows through.
+func observeCert(cert *driver.Certificate, w settle.Window, now time.Time) driver.Certificate {
+	out := copyCert(cert)
+
+	if observed := w.Observe(now, out.Status); observed != out.Status {
+		out.Status = observed
+		for i := range out.DomainValidationOptions {
+			out.DomainValidationOptions[i].ValidationStatus = observed
+		}
+	}
+
+	return out
 }
 
 // New creates a new ACM mock with the given configuration options.

--- a/providers/aws/acm/acm_test.go
+++ b/providers/aws/acm/acm_test.go
@@ -113,3 +113,30 @@ func TestAsyncSettleCertificate(t *testing.T) {
 		t.Fatalf("PENDING_VALIDATION filter after settle returned %d, want 0", len(pending))
 	}
 }
+
+// TestAsyncSettleGetCertificateGated pins that GetCertificate returns no
+// material while the certificate is observably PENDING_VALIDATION, then the
+// issued PEM once the settle window elapses.
+func TestAsyncSettleGetCertificateGated(t *testing.T) {
+	fc := config.NewFakeClock(time.Unix(0, 0))
+	m := acm.New(config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"),
+		config.WithAccountID("000000000000"), config.WithAsyncSettle()))
+	ctx := context.Background()
+
+	arn, err := m.RequestCertificate(ctx, driver.RequestCertificateInput{
+		DomainName: "example.com", ValidationMethod: driver.ValidationDNS,
+	})
+	if err != nil {
+		t.Fatalf("RequestCertificate: %v", err)
+	}
+
+	if _, _, err := m.GetCertificate(ctx, arn); err == nil {
+		t.Fatal("GetCertificate while pending should error, got nil")
+	}
+
+	fc.Advance(3 * time.Second)
+	pem, _, err := m.GetCertificate(ctx, arn)
+	if err != nil || pem == "" {
+		t.Fatalf("GetCertificate after settle = %q (err %v), want issued PEM", pem, err)
+	}
+}

--- a/providers/aws/acm/acm_test.go
+++ b/providers/aws/acm/acm_test.go
@@ -69,3 +69,47 @@ func TestDeleteInUseGuard(t *testing.T) {
 		t.Fatalf("deleting missing cert should be NotFound, got %v", err)
 	}
 }
+
+// TestAsyncSettleCertificate pins that under AsyncSettle a DNS-validated
+// certificate reports PENDING_VALIDATION (with its CNAME record to create) until
+// the settle window elapses, then ISSUED; and that ListCertificates filtered by
+// PENDING_VALIDATION reflects the transition.
+func TestAsyncSettleCertificate(t *testing.T) {
+	fc := config.NewFakeClock(time.Unix(0, 0))
+	m := acm.New(config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"),
+		config.WithAccountID("000000000000"), config.WithAsyncSettle()))
+	ctx := context.Background()
+
+	arn, err := m.RequestCertificate(ctx, driver.RequestCertificateInput{
+		DomainName: "example.com", ValidationMethod: driver.ValidationDNS,
+	})
+	if err != nil {
+		t.Fatalf("RequestCertificate: %v", err)
+	}
+
+	cert, _ := m.DescribeCertificate(ctx, arn)
+	if cert.Status != driver.StatusPendingValidation {
+		t.Fatalf("status = %q, want PENDING_VALIDATION", cert.Status)
+	}
+	if len(cert.DomainValidationOptions) == 0 || cert.DomainValidationOptions[0].ResourceRecordN == "" {
+		t.Fatal("expected a DNS validation ResourceRecord (CNAME) to create")
+	}
+	if cert.DomainValidationOptions[0].ValidationStatus != driver.StatusPendingValidation {
+		t.Fatalf("dv status = %q, want PENDING_VALIDATION", cert.DomainValidationOptions[0].ValidationStatus)
+	}
+
+	pending, _ := m.ListCertificates(ctx, driver.ListFilter{Statuses: []string{driver.StatusPendingValidation}})
+	if len(pending) != 1 {
+		t.Fatalf("PENDING_VALIDATION filter returned %d, want 1", len(pending))
+	}
+
+	fc.Advance(3 * time.Second) // past DefaultCertificateSettle (2s)
+	cert, _ = m.DescribeCertificate(ctx, arn)
+	if cert.Status != driver.StatusIssued {
+		t.Fatalf("status after settle = %q, want ISSUED", cert.Status)
+	}
+	pending, _ = m.ListCertificates(ctx, driver.ListFilter{Statuses: []string{driver.StatusPendingValidation}})
+	if len(pending) != 0 {
+		t.Fatalf("PENDING_VALIDATION filter after settle returned %d, want 0", len(pending))
+	}
+}

--- a/providers/aws/acm/certificates.go
+++ b/providers/aws/acm/certificates.go
@@ -184,6 +184,13 @@ func (m *Mock) GetCertificate(_ context.Context, arn string) (certPEM, chainPEM 
 	cd.mu.RLock()
 	defer cd.mu.RUnlock()
 
+	// While the certificate is still observably PENDING_VALIDATION, its material
+	// is not yet retrievable — real ACM answers RequestInProgressException.
+	if !cd.settle.Settled(m.now()) {
+		return "", "", errors.Newf(errors.FailedPrecondition,
+			"certificate %q is pending validation and has no issued material yet", arn)
+	}
+
 	if cd.cert.CertificatePEM == "" {
 		return "", "", errors.Newf(errors.FailedPrecondition, "certificate %q has no issued material yet", arn)
 	}

--- a/providers/aws/acm/certificates.go
+++ b/providers/aws/acm/certificates.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	"github.com/stackshy/cloudemu/v2/services/acm/driver"
 )
 
@@ -81,7 +82,9 @@ func (m *Mock) RequestCertificate(_ context.Context, in driver.RequestCertificat
 		PrivateKeyPEM:           mat.keyPEM,
 	}
 
-	m.certs.Set(arn, &certData{cert: cert})
+	window := settle.Pending(driver.StatusPendingValidation, now,
+		m.opts.SettleDuration(settle.DefaultCertificateSettle))
+	m.certs.Set(arn, &certData{cert: cert, settle: window})
 
 	return arn, nil
 }
@@ -121,7 +124,7 @@ func (m *Mock) DescribeCertificate(_ context.Context, arn string) (*driver.Certi
 	cd.mu.RLock()
 	defer cd.mu.RUnlock()
 
-	out := copyCert(&cd.cert)
+	out := observeCert(&cd.cert, cd.settle, m.now())
 
 	return &out, nil
 }
@@ -131,12 +134,16 @@ func (m *Mock) ListCertificates(_ context.Context, filter driver.ListFilter) ([]
 	all := m.certs.All()
 	out := make([]driver.Certificate, 0, len(all))
 
+	now := m.now()
+
 	for _, cd := range all {
 		cd.mu.RLock()
-		if statusMatches(cd.cert.Status, filter.Statuses) {
-			out = append(out, copyCert(&cd.cert))
-		}
+		oc := observeCert(&cd.cert, cd.settle, now)
 		cd.mu.RUnlock()
+
+		if statusMatches(oc.Status, filter.Statuses) {
+			out = append(out, oc)
+		}
 	}
 
 	return out, nil

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -26,6 +26,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	"github.com/stackshy/cloudemu/v2/internal/statemachine"
 	"github.com/stackshy/cloudemu/v2/services/compute"
 	"github.com/stackshy/cloudemu/v2/services/compute/computeengine"
@@ -47,6 +48,7 @@ var (
 const (
 	ipSegmentSize  = 256
 	stateAvailable = "available"
+	stateCreating  = "creating"
 	stateInUse     = "in-use"
 
 	// visibilityHidden and visibilityVisible are the account-level
@@ -173,6 +175,10 @@ type instanceData struct {
 	// monitoring is the CloudWatch detailed-monitoring state
 	// ("disabled"/"enabled"); defaults to "disabled" at launch.
 	monitoring string
+	// settle overlays a post-launch "pending" window over the stored (running)
+	// State on the Describe surface when AsyncSettle is enabled; zero-value
+	// (default) reports the stored State immediately.
+	settle settle.Window
 }
 
 // operatorData records service-provider managed-resource ownership.
@@ -197,17 +203,22 @@ type Mock struct {
 	// AWS-specific, so this store backs the LaunchTemplateVersioner capability.
 	templateVersions *memstore.Store[*driver.LaunchTemplateVersion]
 	volumes          *memstore.Store[*driver.VolumeInfo]
-	snapshots        *memstore.Store[*driver.SnapshotInfo]
-	images           *memstore.Store[*driver.ImageInfo]
-	keyPairs         *memstore.Store[*driver.KeyPairInfo]
-	sm               *statemachine.Machine
-	opts             *config.Options
-	ipCounter        atomic.Int64
-	volCounter       atomic.Int64
-	snapCounter      atomic.Int64
-	amiCounter       atomic.Int64
-	keyCounter       atomic.Int64
-	monitoring       mondriver.Monitoring
+	// volSettle overlays a "creating" window over a volume's stored (available)
+	// State on the Describe surface, keyed by volume id. It lives beside volumes
+	// rather than on the shared driver.VolumeInfo struct (which azure/gcp also
+	// use), keeping settling AWS-internal. Empty/absent = report State directly.
+	volSettle   *memstore.Store[settle.Window]
+	snapshots   *memstore.Store[*driver.SnapshotInfo]
+	images      *memstore.Store[*driver.ImageInfo]
+	keyPairs    *memstore.Store[*driver.KeyPairInfo]
+	sm          *statemachine.Machine
+	opts        *config.Options
+	ipCounter   atomic.Int64
+	volCounter  atomic.Int64
+	snapCounter atomic.Int64
+	amiCounter  atomic.Int64
+	keyCounter  atomic.Int64
+	monitoring  mondriver.Monitoring
 	// subnetResolver derives an instance's VPC from its subnet at launch, so
 	// instances created with a --subnet-id carry the VPCID that connectivity
 	// analysis and VPC teardown depend on. nil until wired by the provider.
@@ -299,6 +310,7 @@ func New(opts *config.Options) *Mock {
 		templates:        memstore.New[*driver.LaunchTemplate](),
 		templateVersions: memstore.New[*driver.LaunchTemplateVersion](),
 		volumes:          memstore.New[*driver.VolumeInfo](),
+		volSettle:        memstore.New[settle.Window](),
 		snapshots:        memstore.New[*driver.SnapshotInfo](),
 		images:           memstore.New[*driver.ImageInfo](),
 		keyPairs:         memstore.New[*driver.KeyPairInfo](),
@@ -319,7 +331,7 @@ func (m *Mock) nextIP() string {
 // toInstance converts stored instance data to the driver shape. hidden is the
 // account-level managed-resource-visibility ("hidden") resolved once by the
 // caller, so this never touches m.mu (avoiding nested read locks).
-func toInstance(d *instanceData, hidden bool) driver.Instance {
+func toInstance(d *instanceData, hidden bool, now time.Time) driver.Instance {
 	sg := make([]string, len(d.SecurityGroups))
 	copy(sg, d.SecurityGroups)
 
@@ -339,7 +351,7 @@ func toInstance(d *instanceData, hidden bool) driver.Instance {
 	}
 
 	return driver.Instance{
-		ID: d.ID, ImageID: d.ImageID, InstanceType: d.InstanceType, State: d.State,
+		ID: d.ID, ImageID: d.ImageID, InstanceType: d.InstanceType, State: d.settle.Observe(now, d.State),
 		PrivateIP: d.PrivateIP, PublicIP: d.PublicIP, SubnetID: d.SubnetID, VPCID: d.VPCID,
 		SecurityGroups: sg, Tags: tags, LaunchTime: d.LaunchTime,
 		ReservationID: d.reservationID, KeyName: d.keyName, Monitoring: d.monitoring,
@@ -430,7 +442,9 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 		m.sm.SetState(id, compute.StatePending)
 		_ = m.sm.Transition(id, compute.StateRunning)
 		inst.State = compute.StateRunning
-		results = append(results, toInstance(inst, hidden))
+		inst.settle = settle.Pending(compute.StatePending, m.opts.Clock.Now(),
+			m.opts.SettleDuration(settle.DefaultInstanceSettle))
+		results = append(results, toInstance(inst, hidden, m.opts.Clock.Now()))
 		created = append(created, inst)
 
 		// Managed (service-owned) instances are hidden from Describe, so
@@ -466,7 +480,7 @@ func (m *Mock) instancesForClientToken(token string) ([]driver.Instance, bool) {
 
 	for _, id := range ids {
 		if inst, found := m.instances.Get(id); found {
-			out = append(out, toInstance(inst, hidden))
+			out = append(out, toInstance(inst, hidden, m.opts.Clock.Now()))
 		}
 	}
 
@@ -703,7 +717,7 @@ func (m *Mock) DescribeInstances(
 		}
 
 		if matchesFilters(inst, filters) {
-			results = append(results, toInstance(inst, hidden))
+			results = append(results, toInstance(inst, hidden, m.opts.Clock.Now()))
 		}
 	}
 
@@ -1016,7 +1030,12 @@ func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver
 
 	m.volumes.Set(id, vol)
 
+	now := m.opts.Clock.Now()
+	window := settle.Pending(stateCreating, now, m.opts.SettleDuration(settle.DefaultVolumeSettle))
+	m.volSettle.Set(id, window)
+
 	result := *vol
+	result.State = window.Observe(now, result.State)
 
 	return &result, nil
 }
@@ -1033,6 +1052,7 @@ func (m *Mock) DeleteVolume(_ context.Context, id string) error {
 	}
 
 	m.volumes.Delete(id)
+	m.volSettle.Delete(id)
 
 	return nil
 }
@@ -1047,7 +1067,16 @@ func (m *Mock) DescribeVolumes(_ context.Context, ids []string) ([]driver.Volume
 		}
 	}
 
-	return describeResources(m.volumes, ids), nil
+	out := describeResources(m.volumes, ids)
+
+	now := m.opts.Clock.Now()
+	for i := range out {
+		if w, ok := m.volSettle.Get(out[i].ID); ok {
+			out[i].State = w.Observe(now, out[i].State)
+		}
+	}
+
+	return out, nil
 }
 
 // AttachVolume attaches a volume to an instance.

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -601,6 +601,9 @@ func (m *Mock) transitionInstances(ctx context.Context, instanceIDs []string, t 
 		inst.State = t.intermediateState
 		_ = m.sm.Transition(id, t.finalState)
 		inst.State = t.finalState
+		// A lifecycle transition supersedes any post-launch settle window, so the
+		// instance reports its new terminal state rather than a stale "pending".
+		inst.settle = settle.Window{}
 
 		// Managed instances are hidden from Describe; keep them out of metrics
 		// too so a hidden instance isn't observable via CloudWatch.
@@ -716,7 +719,7 @@ func (m *Mock) DescribeInstances(
 			continue
 		}
 
-		if matchesFilters(inst, filters) {
+		if matchesFilters(inst, filters, m.opts.Clock.Now()) {
 			results = append(results, toInstance(inst, hidden, m.opts.Clock.Now()))
 		}
 	}
@@ -779,9 +782,9 @@ func (m *Mock) visibility() string {
 	return m.managedResourceVisibility
 }
 
-func matchesFilters(inst *instanceData, filters []driver.DescribeFilter) bool {
+func matchesFilters(inst *instanceData, filters []driver.DescribeFilter, now time.Time) bool {
 	for _, f := range filters {
-		if !matchesSingleFilter(inst, f) {
+		if !matchesSingleFilter(inst, f, now) {
 			return false
 		}
 	}
@@ -789,14 +792,16 @@ func matchesFilters(inst *instanceData, filters []driver.DescribeFilter) bool {
 	return true
 }
 
-func matchesSingleFilter(inst *instanceData, f driver.DescribeFilter) bool {
+func matchesSingleFilter(inst *instanceData, f driver.DescribeFilter, now time.Time) bool {
 	switch f.Name {
 	case "instance-id":
 		return containsValue(f.Values, inst.ID)
 	case "instance-type":
 		return containsValue(f.Values, inst.InstanceType)
 	case "instance-state-name":
-		return containsValue(f.Values, inst.State)
+		// Filter on the observed state so it agrees with the state Describe
+		// renders (both go through the settle overlay under AsyncSettle).
+		return containsValue(f.Values, inst.settle.Observe(now, inst.State))
 	default:
 		return matchesTagFilter(inst, f)
 	}

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -1070,6 +1070,7 @@ func (m *Mock) DescribeVolumes(_ context.Context, ids []string) ([]driver.Volume
 	out := describeResources(m.volumes, ids)
 
 	now := m.opts.Clock.Now()
+
 	for i := range out {
 		if w, ok := m.volSettle.Get(out[i].ID); ok {
 			out[i].State = w.Observe(now, out[i].State)

--- a/providers/aws/ec2/ec2_test.go
+++ b/providers/aws/ec2/ec2_test.go
@@ -339,7 +339,7 @@ func TestMatchesFilters(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := matchesFilters(inst, tc.filters)
+			result := matchesFilters(inst, tc.filters, time.Now())
 			assertEqual(t, tc.expect, result)
 		})
 	}

--- a/providers/aws/ec2/ec2_test.go
+++ b/providers/aws/ec2/ec2_test.go
@@ -27,6 +27,45 @@ func newTestMock() *Mock {
 	return New(opts)
 }
 
+// TestAsyncSettleInstanceAndVolume pins that with WithAsyncSettle a freshly
+// created instance/volume reports the intermediate state until the settle
+// window elapses on the FakeClock, then the final state. Default (no
+// WithAsyncSettle) behavior is covered by every other test reporting terminal
+// state immediately.
+func TestAsyncSettleInstanceAndVolume(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"), config.WithAsyncSettle())
+	m := New(opts)
+	ctx := context.Background()
+
+	run, err := m.RunInstances(ctx, defaultConfig(), 1)
+	requireNoError(t, err)
+	// RunInstances response reports pending (matches real EC2).
+	assertEqual(t, "pending", run[0].State)
+
+	got, err := m.DescribeInstances(ctx, []string{run[0].ID}, nil, driver.DescribeInstancesOptions{})
+	requireNoError(t, err)
+	assertEqual(t, "pending", got[0].State)
+
+	fc.Advance(3 * time.Second) // past DefaultInstanceSettle (2s)
+	got, err = m.DescribeInstances(ctx, []string{run[0].ID}, nil, driver.DescribeInstancesOptions{})
+	requireNoError(t, err)
+	assertEqual(t, "running", got[0].State)
+
+	vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	requireNoError(t, err)
+	assertEqual(t, "creating", vol.State)
+
+	dv, err := m.DescribeVolumes(ctx, []string{vol.ID})
+	requireNoError(t, err)
+	assertEqual(t, "creating", dv[0].State)
+
+	fc.Advance(2 * time.Second) // past DefaultVolumeSettle (1s)
+	dv, err = m.DescribeVolumes(ctx, []string{vol.ID})
+	requireNoError(t, err)
+	assertEqual(t, "available", dv[0].State)
+}
+
 func defaultConfig() driver.InstanceConfig {
 	return driver.InstanceConfig{
 		ImageID:      "ami-12345",

--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -19,6 +19,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	dbengine "github.com/stackshy/cloudemu/v2/services/relationaldb/dbengine"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
@@ -111,6 +112,14 @@ type Mock struct {
 	// logged.
 	rootPasswords map[string]string
 
+	// instSettle / snapSettle overlay a "creating"/"rebooting" window over an
+	// instance's or snapshot's stored (available) State on the Describe surface,
+	// keyed by id and guarded by mu. They live beside the stores rather than on
+	// the shared rdsdriver structs (which Azure flexible-server/SQL also use),
+	// keeping settling AWS-internal. Absent = report the stored State directly.
+	instSettle map[string]settle.Window
+	snapSettle map[string]settle.Window
+
 	opts           *config.Options
 	subnetResolver SubnetResolver
 	monitoring     mondriver.Monitoring
@@ -134,8 +143,30 @@ func New(opts *config.Options) *Mock {
 		clusterCreds:       map[string]clusterCred{},
 		groupTags:          map[string]map[string]string{},
 		rootPasswords:      map[string]string{},
+		instSettle:         map[string]settle.Window{},
+		snapSettle:         map[string]settle.Window{},
 		opts:               opts,
 	}
+}
+
+// settleInstanceState overlays the instance's settle window (if any) onto its
+// stored final state. The caller must hold at least m.mu.RLock.
+func (m *Mock) settleInstanceState(id, final string) string {
+	if w, ok := m.instSettle[id]; ok {
+		return w.Observe(m.opts.Clock.Now(), final)
+	}
+
+	return final
+}
+
+// settleSnapshotState overlays the snapshot's settle window (if any) onto its
+// stored final state. The caller must hold at least m.mu.RLock.
+func (m *Mock) settleSnapshotState(id, final string) string {
+	if w, ok := m.snapSettle[id]; ok {
+		return w.Observe(m.opts.Clock.Now(), final)
+	}
+
+	return final
 }
 
 // SetMonitoring wires a CloudWatch-style backend for auto-metric emission.
@@ -330,6 +361,10 @@ func (m *Mock) CreateInstance(ctx context.Context, cfg rdsdriver.InstanceConfig)
 
 	m.emitInstanceMetrics(cfg.ID, cfg.Engine, cpuMetricRunning, connectionsRunning)
 
+	m.mu.RLock()
+	out.State = m.settleInstanceState(cfg.ID, out.State)
+	m.mu.RUnlock()
+
 	return &out, nil
 }
 
@@ -354,6 +389,8 @@ func (m *Mock) reserveInstance(cfg rdsdriver.InstanceConfig) (rdsdriver.Instance
 
 	inst := m.newInstance(cfg)
 	m.instances.Set(cfg.ID, inst)
+	m.instSettle[cfg.ID] = settle.Pending(rdsdriver.StateCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultDBInstanceSettle))
 	m.rootPasswords[cfg.ID] = cfg.MasterUserPassword
 
 	if cfg.ClusterID != "" {
@@ -534,7 +571,9 @@ func (m *Mock) DescribeInstances(_ context.Context, ids []string) ([]rdsdriver.I
 
 		//nolint:gocritic // map values are large structs but we need a flat slice for the API.
 		for _, v := range all {
-			out = append(out, cloneInstance(v))
+			c := cloneInstance(v)
+			c.State = m.settleInstanceState(c.ID, c.State)
+			out = append(out, c)
 		}
 
 		return out, nil
@@ -548,7 +587,9 @@ func (m *Mock) DescribeInstances(_ context.Context, ids []string) ([]rdsdriver.I
 			return nil, cerrors.Newf(cerrors.NotFound, "DB instance %q not found", id)
 		}
 
-		out = append(out, cloneInstance(inst))
+		c := cloneInstance(inst)
+		c.State = m.settleInstanceState(c.ID, c.State)
+		out = append(out, c)
 	}
 
 	return out, nil
@@ -768,6 +809,7 @@ func (m *Mock) DeleteInstance(ctx context.Context, id string) error {
 
 	m.instances.Delete(id)
 	delete(m.rootPasswords, id)
+	delete(m.instSettle, id)
 
 	return nil
 }
@@ -799,6 +841,10 @@ func (m *Mock) RebootInstance(_ context.Context, id string) error {
 
 	inst.State = rdsdriver.StateAvailable
 	m.instances.Set(id, inst)
+	// The logical state stays available; a fresh "rebooting" window makes Describe
+	// report the available->rebooting->available transient dip under AsyncSettle.
+	m.instSettle[id] = settle.Pending(rdsdriver.StateRebooting, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultDBRebootSettle))
 
 	m.emitInstanceMetrics(id, inst.Engine, cpuMetricRunning, connectionsRunning)
 
@@ -1081,9 +1127,17 @@ func (m *Mock) CreateSnapshot(_ context.Context, cfg rdsdriver.SnapshotConfig) (
 		Tags:             copyTags(cfg.Tags),
 	}
 
+	now := m.opts.Clock.Now()
 	m.snapshots.Set(cfg.ID, snap)
+	m.snapSettle[cfg.ID] = settle.Pending(rdsdriver.SnapshotCreating, now,
+		m.opts.SettleDuration(settle.DefaultDBSnapshotSettle))
+	// The source instance briefly reports "backing-up" while the snapshot settles,
+	// matching real RDS; its logical state stays available.
+	m.instSettle[cfg.InstanceID] = settle.Pending(rdsdriver.StateBackingUp, now,
+		m.opts.SettleDuration(settle.DefaultDBSnapshotSettle))
 
 	out := snap
+	out.State = m.settleSnapshotState(cfg.ID, out.State)
 
 	return &out, nil
 }
@@ -1115,6 +1169,7 @@ func (m *Mock) DescribeSnapshots(
 		}
 
 		snap.Tags = copyTags(snap.Tags)
+		snap.State = m.settleSnapshotState(snap.ID, snap.State)
 		out = append(out, snap)
 	}
 
@@ -1129,6 +1184,8 @@ func (m *Mock) DeleteSnapshot(_ context.Context, id string) error {
 	if !m.snapshots.Delete(id) {
 		return cerrors.Newf(cerrors.NotFound, "DB snapshot %q not found", id)
 	}
+
+	delete(m.snapSettle, id)
 
 	return nil
 }

--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -869,6 +869,9 @@ func (m *Mock) transitionInstance(id, from, to string, cpu, conns float64, verb 
 
 	inst.State = to
 	m.instances.Set(id, inst)
+	// A lifecycle transition (start/stop) supersedes any post-create settle
+	// window so the instance reports its new state, not a stale "creating".
+	delete(m.instSettle, id)
 
 	m.emitInstanceMetrics(id, inst.Engine, cpu, conns)
 

--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -559,8 +559,6 @@ func (m *Mock) rollbackReserved(id, clusterID string) {
 }
 
 // DescribeInstances returns all instances if ids is empty, else only matching ones.
-//
-//nolint:dupl // structurally similar to DescribeClusters but operates on a different store/type.
 func (m *Mock) DescribeInstances(_ context.Context, ids []string) ([]rdsdriver.Instance, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -943,8 +941,6 @@ func (m *Mock) CreateCluster(_ context.Context, cfg rdsdriver.ClusterConfig) (*r
 }
 
 // DescribeClusters returns all clusters if ids is empty, else only matching ones.
-//
-//nolint:dupl // structurally similar to DescribeInstances but operates on a different store/type.
 func (m *Mock) DescribeClusters(_ context.Context, ids []string) ([]rdsdriver.Cluster, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -1143,8 +1139,6 @@ func (m *Mock) CreateSnapshot(_ context.Context, cfg rdsdriver.SnapshotConfig) (
 }
 
 // DescribeSnapshots returns snapshots filtered by ids and/or instance.
-//
-//nolint:dupl // structurally similar to DescribeClusterSnapshots but operates on a different store/type.
 func (m *Mock) DescribeSnapshots(
 	_ context.Context, ids []string, instanceID string,
 ) ([]rdsdriver.Snapshot, error) {
@@ -1304,8 +1298,6 @@ func (m *Mock) CreateClusterSnapshot(
 }
 
 // DescribeClusterSnapshots returns cluster snapshots filtered by ids and/or cluster.
-//
-//nolint:dupl // structurally similar to DescribeSnapshots but operates on a different store/type.
 func (m *Mock) DescribeClusterSnapshots(
 	_ context.Context, ids []string, clusterID string,
 ) ([]rdsdriver.ClusterSnapshot, error) {

--- a/providers/aws/rds/rds_test.go
+++ b/providers/aws/rds/rds_test.go
@@ -340,3 +340,56 @@ func assertTrue(t *testing.T, val bool, msg string) {
 		t.Errorf("expected true: %s", msg)
 	}
 }
+
+// TestAsyncSettleInstanceSnapshotReboot pins the AsyncSettle transitions:
+// instance creating->available, snapshot creating->available, and the
+// reboot available->rebooting->available transient dip, all driven by the
+// FakeClock. Default (settle off) behavior is covered by the other tests.
+func TestAsyncSettleInstanceSnapshotReboot(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	m := New(config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"),
+		config.WithAccountID("123456789012"), config.WithAsyncSettle()))
+	ctx := context.Background()
+
+	created, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "db1", Engine: "mysql", MasterUsername: "admin"})
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+	if created.State != rdsdriver.StateCreating {
+		t.Fatalf("create response State = %q, want creating", created.State)
+	}
+
+	got, err := m.DescribeInstances(ctx, []string{"db1"})
+	if err != nil || got[0].State != rdsdriver.StateCreating {
+		t.Fatalf("describe before settle = %q (err %v), want creating", got[0].State, err)
+	}
+
+	fc.Advance(4 * time.Second) // past DefaultDBInstanceSettle (3s)
+	got, _ = m.DescribeInstances(ctx, []string{"db1"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("describe after settle = %q, want available", got[0].State)
+	}
+
+	snap, err := m.CreateSnapshot(ctx, rdsdriver.SnapshotConfig{ID: "snap1", InstanceID: "db1"})
+	if err != nil || snap.State != rdsdriver.SnapshotCreating {
+		t.Fatalf("snapshot create State = %q (err %v), want creating", snap.State, err)
+	}
+	fc.Advance(3 * time.Second) // past DefaultDBSnapshotSettle (2s)
+	snaps, _ := m.DescribeSnapshots(ctx, []string{"snap1"}, "")
+	if snaps[0].State != rdsdriver.SnapshotAvailable {
+		t.Fatalf("snapshot after settle = %q, want available", snaps[0].State)
+	}
+
+	if err := m.RebootInstance(ctx, "db1"); err != nil {
+		t.Fatalf("RebootInstance: %v", err)
+	}
+	got, _ = m.DescribeInstances(ctx, []string{"db1"})
+	if got[0].State != rdsdriver.StateRebooting {
+		t.Fatalf("describe during reboot = %q, want rebooting", got[0].State)
+	}
+	fc.Advance(2 * time.Second) // past DefaultDBRebootSettle (1s)
+	got, _ = m.DescribeInstances(ctx, []string{"db1"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("describe after reboot = %q, want available", got[0].State)
+	}
+}

--- a/providers/aws/rds/rds_test.go
+++ b/providers/aws/rds/rds_test.go
@@ -392,4 +392,18 @@ func TestAsyncSettleInstanceSnapshotReboot(t *testing.T) {
 	if got[0].State != rdsdriver.StateAvailable {
 		t.Fatalf("describe after reboot = %q, want available", got[0].State)
 	}
+
+	// A lifecycle stop must clear the create window: a fresh instance stopped
+	// mid-settle reports stopped, not a stale creating.
+	fresh, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "db2", Engine: "mysql", MasterUsername: "admin"})
+	if err != nil || fresh.State != rdsdriver.StateCreating {
+		t.Fatalf("CreateInstance db2 = %q (err %v), want creating", fresh.State, err)
+	}
+	if err := m.StopInstance(ctx, "db2"); err != nil {
+		t.Fatalf("StopInstance: %v", err)
+	}
+	got, _ = m.DescribeInstances(ctx, []string{"db2"})
+	if got[0].State != rdsdriver.StateStopped {
+		t.Fatalf("stopped db2 = %q, want stopped (window must be cleared)", got[0].State)
+	}
 }

--- a/providers/aws/sfn/executions.go
+++ b/providers/aws/sfn/executions.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
 )
 
@@ -62,13 +63,29 @@ func (m *Mock) runExecution(in driver.StartExecutionInput) (*driver.Execution, e
 		StartDate: now, StopDate: now,
 	}
 
-	if !m.executions.SetIfAbsent(arn, &execData{exec: exec}) {
+	window := settle.Pending(driver.ExecStatusRunning, now,
+		m.opts.SettleDuration(settle.DefaultExecutionSettle))
+
+	if !m.executions.SetIfAbsent(arn, &execData{exec: exec, settle: window}) {
 		return nil, execAlreadyExists(name)
 	}
 
-	out := exec
+	out := observedExec(exec, window, now)
 
 	return &out, nil
+}
+
+// observedExec overlays a RUNNING settle window onto a stored (terminal)
+// execution: while the window is unelapsed the execution reports RUNNING with no
+// stop date and no output yet, exactly as a real in-flight execution does.
+func observedExec(exec driver.Execution, w settle.Window, now time.Time) driver.Execution {
+	if observed := w.Observe(now, exec.Status); observed != exec.Status {
+		exec.Status = observed
+		exec.StopDate = time.Time{}
+		exec.Output = ""
+	}
+
+	return exec
 }
 
 func (m *Mock) StartExecution(_ context.Context, in driver.StartExecutionInput) (*driver.Execution, error) {
@@ -88,7 +105,7 @@ func (m *Mock) DescribeExecution(_ context.Context, arn string) (*driver.Executi
 	ed.mu.RLock()
 	defer ed.mu.RUnlock()
 
-	out := ed.exec
+	out := observedExec(ed.exec, ed.settle, m.now())
 
 	return &out, nil
 }
@@ -99,12 +116,22 @@ func (m *Mock) StopExecution(_ context.Context, arn, _, _ string) (time.Time, er
 		return time.Time{}, err
 	}
 
-	ed.mu.RLock()
-	defer ed.mu.RUnlock()
+	ed.mu.Lock()
+	defer ed.mu.Unlock()
 
-	// Executions complete synchronously (SUCCEEDED) in the emulator — there is no
-	// RUNNING execution to abort — so StopExecution is a no-op that returns the
-	// execution's actual recorded stop date rather than a fabricated timestamp.
+	now := m.now()
+
+	// While an execution is still settling (observably RUNNING under AsyncSettle),
+	// Stop aborts it: ABORTED with a stop date and no output, and the window is
+	// cleared so it stays aborted. An already-settled (terminal) execution is not
+	// re-stopped — StopExecution returns its recorded stop date.
+	if !ed.settle.Settled(now) {
+		ed.exec.Status = driver.ExecStatusAborted
+		ed.exec.StopDate = now
+		ed.exec.Output = ""
+		ed.settle = settle.Window{}
+	}
+
 	return ed.exec.StopDate, nil
 }
 
@@ -116,9 +143,11 @@ func (m *Mock) ListExecutions(_ context.Context, stateMachineArn, statusFilter s
 	all := m.executions.SortedValues()
 	out := make([]driver.Execution, 0, len(all))
 
+	now := m.now()
+
 	for _, ed := range all {
 		ed.mu.RLock()
-		exec := ed.exec
+		exec := observedExec(ed.exec, ed.settle, now)
 		ed.mu.RUnlock()
 
 		if exec.StateMachineArn != stateMachineArn {

--- a/providers/aws/sfn/executions.go
+++ b/providers/aws/sfn/executions.go
@@ -34,7 +34,7 @@ func (m *Mock) getExec(arn string) (*execData, error) {
 // runExecution builds and stores a synchronously-completed execution. The
 // emulator does not interpret the ASL definition: the execution starts RUNNING
 // and immediately transitions to SUCCEEDED with output echoing the input.
-func (m *Mock) runExecution(in driver.StartExecutionInput) (*driver.Execution, error) {
+func (m *Mock) runExecution(in driver.StartExecutionInput, async bool) (*driver.Execution, error) {
 	sd, err := m.getSM(in.StateMachineArn)
 	if err != nil {
 		return nil, err
@@ -63,8 +63,14 @@ func (m *Mock) runExecution(in driver.StartExecutionInput) (*driver.Execution, e
 		StartDate: now, StopDate: now,
 	}
 
-	window := settle.Pending(driver.ExecStatusRunning, now,
-		m.opts.SettleDuration(settle.DefaultExecutionSettle))
+	// A synchronous execution (StartSyncExecution) returns its terminal result
+	// immediately, so it carries no settle window; only the asynchronous
+	// StartExecution settles RUNNING -> SUCCEEDED.
+	var window settle.Window
+	if async {
+		window = settle.Pending(driver.ExecStatusRunning, now,
+			m.opts.SettleDuration(settle.DefaultExecutionSettle))
+	}
 
 	if !m.executions.SetIfAbsent(arn, &execData{exec: exec, settle: window}) {
 		return nil, execAlreadyExists(name)
@@ -90,11 +96,11 @@ func observedExec(exec *driver.Execution, w settle.Window, now time.Time) driver
 }
 
 func (m *Mock) StartExecution(_ context.Context, in driver.StartExecutionInput) (*driver.Execution, error) {
-	return m.runExecution(in)
+	return m.runExecution(in, true)
 }
 
 func (m *Mock) StartSyncExecution(_ context.Context, in driver.StartExecutionInput) (*driver.Execution, error) {
-	return m.runExecution(in)
+	return m.runExecution(in, false)
 }
 
 func (m *Mock) DescribeExecution(_ context.Context, arn string) (*driver.Execution, error) {
@@ -176,9 +182,21 @@ func (m *Mock) GetExecutionHistory(_ context.Context, arn string, reverse bool) 
 
 	ed.mu.RLock()
 	exec := ed.exec
+	settled := ed.settle.Settled(m.now())
 	ed.mu.RUnlock()
 
 	ts := exec.StartDate
+	// While an execution is still observably RUNNING, only the start event has
+	// happened; the terminal ExecutionSucceeded is not yet in the history,
+	// matching the RUNNING status the Describe surface reports.
+	if !settled {
+		events := []driver.HistoryEvent{
+			{ID: 1, PreviousEventID: 0, Type: "ExecutionStarted", Timestamp: ts, Input: exec.Input},
+		}
+
+		return events, nil
+	}
+
 	events := []driver.HistoryEvent{
 		{ID: 1, PreviousEventID: 0, Type: "ExecutionStarted", Timestamp: ts, Input: exec.Input},
 		{ID: 2, PreviousEventID: 1, Type: "PassStateEntered", Timestamp: ts, StateName: passStateName, Input: exec.Input},

--- a/providers/aws/sfn/executions.go
+++ b/providers/aws/sfn/executions.go
@@ -70,7 +70,7 @@ func (m *Mock) runExecution(in driver.StartExecutionInput) (*driver.Execution, e
 		return nil, execAlreadyExists(name)
 	}
 
-	out := observedExec(exec, window, now)
+	out := observedExec(&exec, window, now)
 
 	return &out, nil
 }
@@ -78,14 +78,15 @@ func (m *Mock) runExecution(in driver.StartExecutionInput) (*driver.Execution, e
 // observedExec overlays a RUNNING settle window onto a stored (terminal)
 // execution: while the window is unelapsed the execution reports RUNNING with no
 // stop date and no output yet, exactly as a real in-flight execution does.
-func observedExec(exec driver.Execution, w settle.Window, now time.Time) driver.Execution {
-	if observed := w.Observe(now, exec.Status); observed != exec.Status {
-		exec.Status = observed
-		exec.StopDate = time.Time{}
-		exec.Output = ""
+func observedExec(exec *driver.Execution, w settle.Window, now time.Time) driver.Execution {
+	out := *exec
+	if observed := w.Observe(now, out.Status); observed != out.Status {
+		out.Status = observed
+		out.StopDate = time.Time{}
+		out.Output = ""
 	}
 
-	return exec
+	return out
 }
 
 func (m *Mock) StartExecution(_ context.Context, in driver.StartExecutionInput) (*driver.Execution, error) {
@@ -105,7 +106,7 @@ func (m *Mock) DescribeExecution(_ context.Context, arn string) (*driver.Executi
 	ed.mu.RLock()
 	defer ed.mu.RUnlock()
 
-	out := observedExec(ed.exec, ed.settle, m.now())
+	out := observedExec(&ed.exec, ed.settle, m.now())
 
 	return &out, nil
 }
@@ -147,7 +148,7 @@ func (m *Mock) ListExecutions(_ context.Context, stateMachineArn, statusFilter s
 
 	for _, ed := range all {
 		ed.mu.RLock()
-		exec := observedExec(ed.exec, ed.settle, now)
+		exec := observedExec(&ed.exec, ed.settle, now)
 		ed.mu.RUnlock()
 
 		if exec.StateMachineArn != stateMachineArn {

--- a/providers/aws/sfn/sfn.go
+++ b/providers/aws/sfn/sfn.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
 )
 
@@ -56,7 +57,11 @@ type smData struct {
 // execData is an execution plus its own lock.
 type execData struct {
 	exec driver.Execution
-	mu   sync.RWMutex
+	// settle overlays a RUNNING window over the stored (terminal) status on the
+	// Describe surface under AsyncSettle; zero-value reports the stored status
+	// immediately. A running execution has no stop date or output yet.
+	settle settle.Window
+	mu     sync.RWMutex
 }
 
 // actData is an activity plus its own lock.

--- a/providers/aws/sfn/sfn_test.go
+++ b/providers/aws/sfn/sfn_test.go
@@ -449,3 +449,43 @@ func TestInvalidArnFormats(t *testing.T) {
 		t.Fatalf("malformed execution ARN should be InvalidArgument, got %v", err)
 	}
 }
+
+// TestAsyncSettleExecution pins that under AsyncSettle an execution reports
+// RUNNING (no stop date, no output) until the settle window elapses, then
+// SUCCEEDED; and that StopExecution during the RUNNING window aborts it.
+func TestAsyncSettleExecution(t *testing.T) {
+	fc := config.NewFakeClock(time.Unix(0, 0))
+	m := sfn.New(config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"),
+		config.WithAccountID("000000000000"), config.WithAsyncSettle()))
+	ctx := context.Background()
+	arn := createSM(t, m, "sm")
+
+	start, err := m.StartExecution(ctx, driver.StartExecutionInput{StateMachineArn: arn, Name: "e1", Input: "{}"})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+	if start.Status != driver.ExecStatusRunning {
+		t.Fatalf("start status = %q, want RUNNING", start.Status)
+	}
+
+	got, _ := m.DescribeExecution(ctx, start.ARN)
+	if got.Status != driver.ExecStatusRunning || !got.StopDate.IsZero() || got.Output != "" {
+		t.Fatalf("running describe = %+v, want RUNNING/no-stop/no-output", got)
+	}
+
+	fc.Advance(2 * time.Second) // past DefaultExecutionSettle (1s)
+	got, _ = m.DescribeExecution(ctx, start.ARN)
+	if got.Status != driver.ExecStatusSucceeded || got.StopDate.IsZero() {
+		t.Fatalf("settled describe = %+v, want SUCCEEDED with stop date", got)
+	}
+
+	// Stop during the RUNNING window aborts.
+	start2, _ := m.StartExecution(ctx, driver.StartExecutionInput{StateMachineArn: arn, Name: "e2", Input: "{}"})
+	if _, err := m.StopExecution(ctx, start2.ARN, "", ""); err != nil {
+		t.Fatalf("StopExecution: %v", err)
+	}
+	got2, _ := m.DescribeExecution(ctx, start2.ARN)
+	if got2.Status != driver.ExecStatusAborted {
+		t.Fatalf("stopped status = %q, want ABORTED", got2.Status)
+	}
+}

--- a/providers/aws/sfn/sfn_test.go
+++ b/providers/aws/sfn/sfn_test.go
@@ -489,3 +489,43 @@ func TestAsyncSettleExecution(t *testing.T) {
 		t.Fatalf("stopped status = %q, want ABORTED", got2.Status)
 	}
 }
+
+// TestAsyncSettleSyncExecutionAndHistory pins that StartSyncExecution bypasses
+// the settle overlay (returns the terminal SUCCEEDED result immediately), and
+// that GetExecutionHistory omits the terminal event while an async execution is
+// still observably RUNNING.
+func TestAsyncSettleSyncExecutionAndHistory(t *testing.T) {
+	fc := config.NewFakeClock(time.Unix(0, 0))
+	m := sfn.New(config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"),
+		config.WithAccountID("000000000000"), config.WithAsyncSettle()))
+	ctx := context.Background()
+	arn := createSM(t, m, "sm")
+
+	// Synchronous execution returns terminal SUCCEEDED with output, not RUNNING.
+	sync, err := m.StartSyncExecution(ctx, driver.StartExecutionInput{StateMachineArn: arn, Name: "sync1", Input: `{"k":1}`})
+	if err != nil {
+		t.Fatalf("StartSyncExecution: %v", err)
+	}
+	if sync.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("sync status = %q, want SUCCEEDED", sync.Status)
+	}
+	if sync.Output == "" || sync.StopDate.IsZero() {
+		t.Fatalf("sync execution missing output/stopDate: %+v", sync)
+	}
+
+	// Async execution: history has only ExecutionStarted while RUNNING.
+	start, _ := m.StartExecution(ctx, driver.StartExecutionInput{StateMachineArn: arn, Name: "a1", Input: "{}"})
+	hist, err := m.GetExecutionHistory(ctx, start.ARN, false)
+	if err != nil {
+		t.Fatalf("GetExecutionHistory: %v", err)
+	}
+	if len(hist) != 1 || hist[0].Type != "ExecutionStarted" {
+		t.Fatalf("running history = %+v, want only ExecutionStarted", hist)
+	}
+
+	fc.Advance(2 * time.Second)
+	hist, _ = m.GetExecutionHistory(ctx, start.ARN, false)
+	if len(hist) != 4 || hist[len(hist)-1].Type != "ExecutionSucceeded" {
+		t.Fatalf("settled history len = %d, want 4 ending ExecutionSucceeded", len(hist))
+	}
+}

--- a/server/aws/acm/async_settle_test.go
+++ b/server/aws/acm/async_settle_test.go
@@ -1,0 +1,80 @@
+package acm_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsacm "github.com/aws/aws-sdk-go-v2/service/acm"
+	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	cloudconfig "github.com/stackshy/cloudemu/v2/config"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// TestAsyncSettleWireACM pins that a real SDK client sees a DNS-validated
+// certificate as PENDING_VALIDATION (with its CNAME record) until the settle
+// window elapses, then ISSUED, and that ListCertificates filtered by
+// PENDING_VALIDATION follows the transition — all over the wire.
+func TestAsyncSettleWireACM(t *testing.T) {
+	fc := cloudconfig.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloud := cloudemu.NewAWS(cloudconfig.WithClock(fc), cloudconfig.WithAsyncSettle())
+	ts := httptest.NewServer(awsserver.New(awsserver.Drivers{ACM: cloud.ACM}))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")))
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+	c := awsacm.NewFromConfig(cfg, func(o *awsacm.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+	ctx := context.Background()
+
+	req, err := c.RequestCertificate(ctx, &awsacm.RequestCertificateInput{
+		DomainName: aws.String("example.com"), ValidationMethod: acmtypes.ValidationMethodDns,
+	})
+	if err != nil {
+		t.Fatalf("RequestCertificate: %v", err)
+	}
+
+	desc, err := c.DescribeCertificate(ctx, &awsacm.DescribeCertificateInput{CertificateArn: req.CertificateArn})
+	if err != nil {
+		t.Fatalf("DescribeCertificate: %v", err)
+	}
+	if desc.Certificate.Status != acmtypes.CertificateStatusPendingValidation {
+		t.Fatalf("status = %q, want PENDING_VALIDATION", desc.Certificate.Status)
+	}
+	if len(desc.Certificate.DomainValidationOptions) == 0 ||
+		desc.Certificate.DomainValidationOptions[0].ResourceRecord == nil {
+		t.Fatal("expected a DNS validation ResourceRecord (CNAME) while pending")
+	}
+
+	list, err := c.ListCertificates(ctx, &awsacm.ListCertificatesInput{
+		CertificateStatuses: []acmtypes.CertificateStatus{acmtypes.CertificateStatusPendingValidation},
+	})
+	if err != nil {
+		t.Fatalf("ListCertificates: %v", err)
+	}
+	if len(list.CertificateSummaryList) != 1 {
+		t.Fatalf("PENDING_VALIDATION filter returned %d, want 1", len(list.CertificateSummaryList))
+	}
+
+	fc.Advance(3 * time.Second) // past DefaultCertificateSettle (2s)
+
+	desc, _ = c.DescribeCertificate(ctx, &awsacm.DescribeCertificateInput{CertificateArn: req.CertificateArn})
+	if desc.Certificate.Status != acmtypes.CertificateStatusIssued {
+		t.Fatalf("status after settle = %q, want ISSUED", desc.Certificate.Status)
+	}
+	list, _ = c.ListCertificates(ctx, &awsacm.ListCertificatesInput{
+		CertificateStatuses: []acmtypes.CertificateStatus{acmtypes.CertificateStatusPendingValidation},
+	})
+	if len(list.CertificateSummaryList) != 0 {
+		t.Fatalf("PENDING_VALIDATION filter after settle = %d, want 0", len(list.CertificateSummaryList))
+	}
+}

--- a/server/aws/ec2/async_settle_test.go
+++ b/server/aws/ec2/async_settle_test.go
@@ -1,0 +1,143 @@
+package ec2_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	cloudconfig "github.com/stackshy/cloudemu/v2/config"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newAsyncEC2 wires a full in-process AWS server with AsyncSettle enabled and a
+// FakeClock the test controls, and returns a real aws-sdk-go-v2 EC2 client plus
+// the clock. This exercises the actual wire protocol a real user hits.
+func newAsyncEC2(t *testing.T) (*ec2.Client, *cloudconfig.FakeClock) {
+	t.Helper()
+
+	fc := cloudconfig.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloud := cloudemu.NewAWS(cloudconfig.WithClock(fc), cloudconfig.WithAsyncSettle())
+	ts := httptest.NewServer(awsserver.New(awsserver.DriversFrom(cloud)))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	cfg.BaseEndpoint = aws.String(ts.URL)
+
+	return ec2.NewFromConfig(cfg), fc
+}
+
+// TestAsyncSettleWireEC2 pins that a real SDK client sees pending->running and
+// creating->available through the wire when AsyncSettle is on, driven by the
+// FakeClock. This is the real-user counterpart to the provider-level test.
+func TestAsyncSettleWireEC2(t *testing.T) {
+	ctx := context.Background()
+	client, fc := newAsyncEC2(t)
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId: aws.String("ami-12345"), InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	id := aws.ToString(run.Instances[0].InstanceId)
+	// RunInstances response reports pending, as real EC2 does.
+	if got := run.Instances[0].State.Name; got != ec2types.InstanceStateNamePending {
+		t.Fatalf("RunInstances state = %q, want pending", got)
+	}
+
+	desc, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{InstanceIds: []string{id}})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+	if got := desc.Reservations[0].Instances[0].State.Name; got != ec2types.InstanceStateNamePending {
+		t.Fatalf("describe before settle = %q, want pending", got)
+	}
+
+	fc.Advance(3 * time.Second) // past DefaultInstanceSettle (2s)
+
+	desc, err = client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{InstanceIds: []string{id}})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+	if got := desc.Reservations[0].Instances[0].State.Name; got != ec2types.InstanceStateNameRunning {
+		t.Fatalf("describe after settle = %q, want running", got)
+	}
+
+	// A second, still-settling instance: the instance-state-name filter must
+	// agree with the rendered state (both observe the overlay).
+	run2, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId: aws.String("ami-12345"), InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances#2: %v", err)
+	}
+	id2 := aws.ToString(run2.Instances[0].InstanceId)
+
+	pendingFilter := &ec2.DescribeInstancesInput{Filters: []ec2types.Filter{
+		{Name: aws.String("instance-state-name"), Values: []string{"pending"}},
+	}}
+	fd, err := client.DescribeInstances(ctx, pendingFilter)
+	if err != nil {
+		t.Fatalf("DescribeInstances(filter): %v", err)
+	}
+	if n := countInstances(fd); n != 1 {
+		t.Fatalf("instance-state-name=pending returned %d instances, want 1 (the settling one)", n)
+	}
+
+	// Stopping the settling instance must clear the launch window: it reports
+	// stopped, not a stale pending.
+	if _, err := client.StopInstances(ctx, &ec2.StopInstancesInput{InstanceIds: []string{id2}}); err != nil {
+		t.Fatalf("StopInstances: %v", err)
+	}
+	sd, _ := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{InstanceIds: []string{id2}})
+	if got := sd.Reservations[0].Instances[0].State.Name; got != ec2types.InstanceStateNameStopped {
+		t.Fatalf("stopped instance state = %q, want stopped (window must be cleared)", got)
+	}
+
+	// Volume creating->available over the wire.
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"), Size: aws.Int32(10),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+	if vol.State != ec2types.VolumeStateCreating {
+		t.Fatalf("CreateVolume state = %q, want creating", vol.State)
+	}
+
+	fc.Advance(2 * time.Second) // past DefaultVolumeSettle (1s)
+
+	dv, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{VolumeIds: []string{aws.ToString(vol.VolumeId)}})
+	if err != nil {
+		t.Fatalf("DescribeVolumes: %v", err)
+	}
+	if dv.Volumes[0].State != ec2types.VolumeStateAvailable {
+		t.Fatalf("volume after settle = %q, want available", dv.Volumes[0].State)
+	}
+}
+
+func countInstances(out *ec2.DescribeInstancesOutput) int {
+	n := 0
+	for _, r := range out.Reservations {
+		n += len(r.Instances)
+	}
+	return n
+}

--- a/server/aws/rds/async_settle_test.go
+++ b/server/aws/rds/async_settle_test.go
@@ -1,0 +1,72 @@
+package rds_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+
+	"github.com/stackshy/cloudemu/v2"
+	cloudconfig "github.com/stackshy/cloudemu/v2/config"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// TestAsyncSettleWireRDS pins that a real SDK client sees a DB instance as
+// creating->available and a reboot as available->rebooting->available through
+// the wire when AsyncSettle is on, driven by the FakeClock.
+func TestAsyncSettleWireRDS(t *testing.T) {
+	fc := cloudconfig.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloud := cloudemu.NewAWS(cloudconfig.WithClock(fc), cloudconfig.WithAsyncSettle())
+	ts := httptest.NewServer(awsserver.New(awsserver.Drivers{RDS: cloud.RDS}))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")))
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+	c := awsrds.NewFromConfig(cfg, func(o *awsrds.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+	ctx := context.Background()
+
+	if _, err := c.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("db1"), Engine: aws.String("mysql"),
+		DBInstanceClass: aws.String("db.t3.micro"), MasterUsername: aws.String("admin"),
+		MasterUserPassword: aws.String("password123"), AllocatedStorage: aws.Int32(20),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	desc, err := c.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{DBInstanceIdentifier: aws.String("db1")})
+	if err != nil {
+		t.Fatalf("DescribeDBInstances: %v", err)
+	}
+	if got := aws.ToString(desc.DBInstances[0].DBInstanceStatus); got != "creating" {
+		t.Fatalf("status before settle = %q, want creating", got)
+	}
+
+	fc.Advance(4 * time.Second) // past DefaultDBInstanceSettle (3s)
+	desc, _ = c.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{DBInstanceIdentifier: aws.String("db1")})
+	if got := aws.ToString(desc.DBInstances[0].DBInstanceStatus); got != "available" {
+		t.Fatalf("status after settle = %q, want available", got)
+	}
+
+	if _, err := c.RebootDBInstance(ctx, &awsrds.RebootDBInstanceInput{DBInstanceIdentifier: aws.String("db1")}); err != nil {
+		t.Fatalf("RebootDBInstance: %v", err)
+	}
+	desc, _ = c.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{DBInstanceIdentifier: aws.String("db1")})
+	if got := aws.ToString(desc.DBInstances[0].DBInstanceStatus); got != "rebooting" {
+		t.Fatalf("status during reboot = %q, want rebooting", got)
+	}
+
+	fc.Advance(2 * time.Second) // past DefaultDBRebootSettle (1s)
+	desc, _ = c.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{DBInstanceIdentifier: aws.String("db1")})
+	if got := aws.ToString(desc.DBInstances[0].DBInstanceStatus); got != "available" {
+		t.Fatalf("status after reboot = %q, want available", got)
+	}
+}

--- a/server/aws/sfn/async_settle_test.go
+++ b/server/aws/sfn/async_settle_test.go
@@ -1,0 +1,78 @@
+package sfn_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awssfn "github.com/aws/aws-sdk-go-v2/service/sfn"
+	sfntypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	cloudconfig "github.com/stackshy/cloudemu/v2/config"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// TestAsyncSettleWireSFN pins that a real SDK client sees an execution as
+// RUNNING (no stop date) until the settle window elapses, then SUCCEEDED, and
+// that StopExecution during the RUNNING window aborts it — all over the wire.
+func TestAsyncSettleWireSFN(t *testing.T) {
+	fc := cloudconfig.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloud := cloudemu.NewAWS(cloudconfig.WithClock(fc), cloudconfig.WithAsyncSettle())
+	ts := httptest.NewServer(awsserver.New(awsserver.Drivers{SFN: cloud.SFN}))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")))
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+	c := awssfn.NewFromConfig(cfg, func(o *awssfn.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+	ctx := context.Background()
+
+	sm, err := c.CreateStateMachine(ctx, &awssfn.CreateStateMachineInput{
+		Name: aws.String("sm"), Definition: aws.String(definition),
+		RoleArn: aws.String("arn:aws:iam::000000000000:role/r"),
+	})
+	if err != nil {
+		t.Fatalf("CreateStateMachine: %v", err)
+	}
+
+	start, err := c.StartExecution(ctx, &awssfn.StartExecutionInput{
+		StateMachineArn: sm.StateMachineArn, Name: aws.String("e1"), Input: aws.String("{}"),
+	})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	got, err := c.DescribeExecution(ctx, &awssfn.DescribeExecutionInput{ExecutionArn: start.ExecutionArn})
+	if err != nil {
+		t.Fatalf("DescribeExecution: %v", err)
+	}
+	if got.Status != sfntypes.ExecutionStatusRunning {
+		t.Fatalf("status before settle = %q, want RUNNING", got.Status)
+	}
+
+	fc.Advance(2 * time.Second) // past DefaultExecutionSettle (1s)
+	got, _ = c.DescribeExecution(ctx, &awssfn.DescribeExecutionInput{ExecutionArn: start.ExecutionArn})
+	if got.Status != sfntypes.ExecutionStatusSucceeded {
+		t.Fatalf("status after settle = %q, want SUCCEEDED", got.Status)
+	}
+
+	// Stop during the RUNNING window -> ABORTED.
+	start2, _ := c.StartExecution(ctx, &awssfn.StartExecutionInput{
+		StateMachineArn: sm.StateMachineArn, Name: aws.String("e2"), Input: aws.String("{}"),
+	})
+	if _, err := c.StopExecution(ctx, &awssfn.StopExecutionInput{ExecutionArn: start2.ExecutionArn}); err != nil {
+		t.Fatalf("StopExecution: %v", err)
+	}
+	got2, _ := c.DescribeExecution(ctx, &awssfn.DescribeExecutionInput{ExecutionArn: start2.ExecutionArn})
+	if got2.Status != sfntypes.ExecutionStatusAborted {
+		t.Fatalf("stopped status = %q, want ABORTED", got2.Status)
+	}
+}


### PR DESCRIPTION
## Summary
Adds realistic post-creation state transitions for AWS resources that real clouds settle asynchronously, via a shared **lazy, read-time** mechanism driven purely by `config.Clock` — no goroutines or timers. **Off by default** (`config.WithAsyncSettle()`), so it's a zero-behavior-change addition; every existing test stays green unedited.

### Mechanism — `internal/settle`
A `settle.Window{Intermediate, ReadyAt}` whose `Observe(clock.Now(), final)` returns the intermediate state until `readyAt = createdAt + settleDuration`, then the stored final state. It's a pure function (no mutation on read, composes with existing RLocks), and it's an *overlay* on top of the existing event-driven `statemachine/` — the logical/stored state stays terminal (what internal consumers and transition-legality checks expect); only the Describe surface reports the intermediate. `config.Options.AsyncSettle` gates it (`SettleDuration` returns 0 when off ⇒ inactive window ⇒ immediate final state). Durations are small (1–3s) so a real SDK waiter succeeds on its first poll while an immediate Describe still observes the intermediate.

### Wirings (6 findings)
| Service | Transition |
|---|---|
| ec2 | RunInstances `pending → running`; CreateVolume `creating → available` |
| rds | CreateDBInstance `creating → available`; CreateDBSnapshot `creating → available` (+ source `backing-up` dip, PercentProgress 0→100); RebootDBInstance `available → rebooting → available` |
| sfn | StartExecution `RUNNING → SUCCEEDED`; StopExecution during RUNNING → `ABORTED` (was a no-op) |
| acm | RequestCertificate `PENDING_VALIDATION → ISSUED`, exposing the DNS-validation CNAME while pending; ListCertificates filter follows the transition |

### Architecture
- No new methods on any shared driver interface → **no Azure/GCP/OCI mirrors, coverage docs unchanged.**
- Where a resource is stored as a shared cross-cloud driver struct (EC2 volumes, RDS instances/snapshots — used by Azure flex/SQL), settling lives in an AWS-provider-internal parallel store, not on the shared struct. Where there's an AWS-internal wrapper (ec2 instanceData, sfn execData, acm certData), it's a single field on that wrapper.
- `Observe` is reserved for the Describe surface; stored state stays logical.

Each transition has a FakeClock-driven test asserting intermediate → final. Full suite green (286 pkgs), compat suite green, coverage + terraform-tidy gates clean.