### PR TITLE
feat(ec2): ReplaceNetworkAclAssociation + subnet↔NACL association model

### DIFF
--- a/docs/coverage/aws/vpc.md
+++ b/docs/coverage/aws/vpc.md
@@ -241,6 +241,14 @@ IPAMResources is an OPTIONAL AWS capability exposing IPAM's view of the
 | `GetIpamResourceCidrs` |  |
 | `ModifyIpamResourceCidr` |  |
 
+### NetworkACLAssociator
+
+NetworkACLAssociator is an OPTIONAL capability, discovered by type assertion.
+
+| Operation | Description |
+| --- | --- |
+| `ReplaceNetworkACLAssociation` |  |
+
 ### NetworkInsights
 
 NetworkInsights is an OPTIONAL AWS capability (type-asserted). It covers both

--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -241,6 +241,14 @@ IPAMResources is an OPTIONAL AWS capability exposing IPAM's view of the
 | `GetIpamResourceCidrs` |  |
 | `ModifyIpamResourceCidr` |  |
 
+### NetworkACLAssociator
+
+NetworkACLAssociator is an OPTIONAL capability, discovered by type assertion.
+
+| Operation | Description |
+| --- | --- |
+| `ReplaceNetworkACLAssociation` |  |
+
 ### NetworkInsights
 
 NetworkInsights is an OPTIONAL AWS capability (type-asserted). It covers both

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -6479,6 +6479,15 @@
         ]
       },
       {
+        "name": "NetworkACLAssociator",
+        "doc": "NetworkACLAssociator is an OPTIONAL capability, discovered by type assertion.",
+        "operations": [
+          {
+            "name": "ReplaceNetworkACLAssociation"
+          }
+        ]
+      },
+      {
         "name": "NetworkInsights",
         "doc": "NetworkInsights is an OPTIONAL AWS capability (type-asserted). It covers both",
         "operations": [

--- a/docs/coverage/gcp/vpc.md
+++ b/docs/coverage/gcp/vpc.md
@@ -241,6 +241,14 @@ IPAMResources is an OPTIONAL AWS capability exposing IPAM's view of the
 | `GetIpamResourceCidrs` |  |
 | `ModifyIpamResourceCidr` |  |
 
+### NetworkACLAssociator
+
+NetworkACLAssociator is an OPTIONAL capability, discovered by type assertion.
+
+| Operation | Description |
+| --- | --- |
+| `ReplaceNetworkACLAssociation` |  |
+
 ### NetworkInsights
 
 NetworkInsights is an OPTIONAL AWS capability (type-asserted). It covers both

--- a/docs/coverage/oci/vcn.md
+++ b/docs/coverage/oci/vcn.md
@@ -241,6 +241,14 @@ IPAMResources is an OPTIONAL AWS capability exposing IPAM's view of the
 | `GetIpamResourceCidrs` |  |
 | `ModifyIpamResourceCidr` |  |
 
+### NetworkACLAssociator
+
+NetworkACLAssociator is an OPTIONAL capability, discovered by type assertion.
+
+| Operation | Description |
+| --- | --- |
+| `ReplaceNetworkACLAssociation` |  |
+
 ### NetworkInsights
 
 NetworkInsights is an OPTIONAL AWS capability (type-asserted). It covers both

--- a/providers/aws/vpc/acl.go
+++ b/providers/aws/vpc/acl.go
@@ -81,14 +81,27 @@ func (m *Mock) DeleteNetworkACL(_ context.Context, id string) error {
 		return errors.Newf(errors.FailedPrecondition, "cannot delete default network ACL %q", id)
 	}
 
+	// Real EC2 refuses to delete an ACL still associated with a subnet; the
+	// caller must move the subnet (ReplaceNetworkAclAssociation) first.
+	if m.aclHasAssociation(id) {
+		return errors.Newf(errors.FailedPrecondition,
+			"DependencyViolation: network ACL %q is associated with a subnet", id)
+	}
+
 	m.networkACLs.Delete(id)
 
 	return nil
 }
 
-// DescribeNetworkACLs returns network ACLs matching the given IDs, or all if empty.
+// DescribeNetworkACLs returns network ACLs matching the given IDs, or all if
+// empty, each with its subnet associations attached.
 func (m *Mock) DescribeNetworkACLs(_ context.Context, ids []string) ([]driver.NetworkACL, error) {
-	return describeResources(m.networkACLs, ids, toNetworkACLInfo), nil
+	acls := describeResources(m.networkACLs, ids, toNetworkACLInfo)
+	for i := range acls {
+		acls[i].Associations = m.aclAssociationsFor(acls[i].ID)
+	}
+
+	return acls, nil
 }
 
 // AddNetworkACLRule adds a rule to the specified network ACL, keeping rules sorted by number.
@@ -134,4 +147,111 @@ func toNetworkACLInfo(acl *networkACLData) driver.NetworkACL {
 		Tags:      copyTags(acl.Tags),
 		IsDefault: acl.IsDefault,
 	}
+}
+
+// aclAssocData binds a subnet to a network ACL. Replacing the ACL for a subnet
+// deletes the old binding and creates a new one with a fresh id.
+type aclAssocData struct {
+	ID           string
+	NetworkACLID string
+	SubnetID     string
+}
+
+// createDefaultNetworkACL creates the default network ACL EC2 auto-creates with
+// every VPC (allow-all rules, IsDefault). New subnets associate with it.
+func (m *Mock) createDefaultNetworkACL(vpcID string) {
+	id := idgen.GenerateID("acl-")
+	m.networkACLs.Set(id, &networkACLData{
+		ID:        id,
+		VPCID:     vpcID,
+		Rules:     defaultACLRules(),
+		Tags:      map[string]string{},
+		IsDefault: true,
+	})
+}
+
+// deleteDefaultNetworkACL removes the VPC's default ACL and its associations
+// when the VPC is torn down.
+func (m *Mock) deleteDefaultNetworkACL(vpcID string) {
+	for aclID, acl := range m.networkACLs.All() {
+		if acl.VPCID != vpcID || !acl.IsDefault {
+			continue
+		}
+
+		m.networkACLs.Delete(aclID)
+
+		for assocID, a := range m.aclAssocs.All() {
+			if a.NetworkACLID == aclID {
+				m.aclAssocs.Delete(assocID)
+			}
+		}
+	}
+}
+
+// associateDefaultNetworkACL binds a new subnet to its VPC's default ACL.
+func (m *Mock) associateDefaultNetworkACL(vpcID, subnetID string) {
+	var aclID string
+
+	for _, acl := range m.networkACLs.All() {
+		if acl.VPCID == vpcID && acl.IsDefault {
+			aclID = acl.ID
+			break
+		}
+	}
+
+	if aclID == "" {
+		return
+	}
+
+	id := idgen.GenerateID("aclassoc-")
+	m.aclAssocs.Set(id, &aclAssocData{ID: id, NetworkACLID: aclID, SubnetID: subnetID})
+}
+
+// aclHasAssociation reports whether any subnet is associated with the ACL.
+func (m *Mock) aclHasAssociation(aclID string) bool {
+	for _, a := range m.aclAssocs.All() {
+		if a.NetworkACLID == aclID {
+			return true
+		}
+	}
+
+	return false
+}
+
+// aclAssociationsFor returns the subnet associations of the ACL, sorted by id.
+func (m *Mock) aclAssociationsFor(aclID string) []driver.NetworkACLAssociation {
+	var out []driver.NetworkACLAssociation
+
+	for _, a := range m.aclAssocs.All() {
+		if a.NetworkACLID == aclID {
+			out = append(out, driver.NetworkACLAssociation{ID: a.ID, NetworkACLID: a.NetworkACLID, SubnetID: a.SubnetID})
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+
+	return out
+}
+
+// ReplaceNetworkACLAssociation moves the subnet in associationID onto newACLID,
+// returning the new association (a fresh id). It is idempotent, matching real
+// EC2: re-associating to the same ACL still yields a new association id.
+func (m *Mock) ReplaceNetworkACLAssociation(
+	_ context.Context, associationID, newACLID string,
+) (*driver.NetworkACLAssociation, error) {
+	assoc, ok := m.aclAssocs.Get(associationID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "network ACL association %q not found", associationID)
+	}
+
+	if !m.networkACLs.Has(newACLID) {
+		return nil, errors.Newf(errors.NotFound, "network ACL %q not found", newACLID)
+	}
+
+	m.aclAssocs.Delete(associationID)
+
+	id := idgen.GenerateID("aclassoc-")
+	m.aclAssocs.Set(id, &aclAssocData{ID: id, NetworkACLID: newACLID, SubnetID: assoc.SubnetID})
+
+	return &driver.NetworkACLAssociation{ID: id, NetworkACLID: newACLID, SubnetID: assoc.SubnetID}, nil
 }

--- a/providers/aws/vpc/acl.go
+++ b/providers/aws/vpc/acl.go
@@ -244,8 +244,15 @@ func (m *Mock) ReplaceNetworkACLAssociation(
 		return nil, errors.Newf(errors.NotFound, "network ACL association %q not found", associationID)
 	}
 
-	if !m.networkACLs.Has(newACLID) {
+	acl, ok := m.networkACLs.Get(newACLID)
+	if !ok {
 		return nil, errors.Newf(errors.NotFound, "network ACL %q not found", newACLID)
+	}
+
+	// Real EC2 requires the network ACL and the subnet to be in the same VPC.
+	if sub, ok := m.subnets.Get(assoc.SubnetID); ok && sub.VPCID != acl.VPCID {
+		return nil, errors.Newf(errors.InvalidArgument,
+			"the network ACL %q and subnet %q are not in the same VPC", newACLID, assoc.SubnetID)
 	}
 
 	m.aclAssocs.Delete(associationID)

--- a/providers/aws/vpc/acl_association_test.go
+++ b/providers/aws/vpc/acl_association_test.go
@@ -1,0 +1,89 @@
+package vpc
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// TestNetworkACLAssociationLifecycle pins the default-ACL + association model:
+// a new VPC gets a default ACL, a new subnet auto-associates with it,
+// ReplaceNetworkACLAssociation moves the subnet (fresh id), the moved-onto ACL
+// can't be deleted while associated, and the errors are NotFound-typed.
+func TestNetworkACLAssociationLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	vpc := createTestVPC(m)
+
+	// The VPC has exactly one default ACL.
+	acls, _ := m.DescribeNetworkACLs(ctx, nil)
+	var defACL string
+	defCount := 0
+	for _, a := range acls {
+		if a.VPCID == vpc.ID && a.IsDefault {
+			defACL = a.ID
+			defCount++
+		}
+	}
+	if defCount != 1 {
+		t.Fatalf("VPC has %d default ACLs, want 1", defCount)
+	}
+
+	// A new subnet auto-associates with the default ACL.
+	sub, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpc.ID, CIDRBlock: "10.0.1.0/24"})
+	if err != nil {
+		t.Fatalf("CreateSubnet: %v", err)
+	}
+
+	acls, _ = m.DescribeNetworkACLs(ctx, []string{defACL})
+	if len(acls) != 1 || len(acls[0].Associations) != 1 || acls[0].Associations[0].SubnetID != sub.ID {
+		t.Fatalf("default ACL associations = %+v, want one for subnet %s", acls[0].Associations, sub.ID)
+	}
+	assocID := acls[0].Associations[0].ID
+
+	// A custom ACL and a move onto it.
+	custom, _ := m.CreateNetworkACL(ctx, vpc.ID, nil)
+
+	newAssoc, err := m.ReplaceNetworkACLAssociation(ctx, assocID, custom.ID)
+	if err != nil {
+		t.Fatalf("ReplaceNetworkACLAssociation: %v", err)
+	}
+	if newAssoc.ID == assocID || newAssoc.NetworkACLID != custom.ID || newAssoc.SubnetID != sub.ID {
+		t.Fatalf("new association = %+v, want fresh id on custom ACL for the subnet", newAssoc)
+	}
+
+	// The default ACL no longer lists the subnet; the custom one does.
+	acls, _ = m.DescribeNetworkACLs(ctx, []string{defACL})
+	if len(acls[0].Associations) != 0 {
+		t.Fatalf("default ACL still has associations: %+v", acls[0].Associations)
+	}
+	acls, _ = m.DescribeNetworkACLs(ctx, []string{custom.ID})
+	if len(acls[0].Associations) != 1 || acls[0].Associations[0].ID != newAssoc.ID {
+		t.Fatalf("custom ACL associations = %+v, want the new one", acls[0].Associations)
+	}
+
+	// The custom ACL is now un-deletable while associated.
+	if err := m.DeleteNetworkACL(ctx, custom.ID); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("DeleteNetworkACL(associated) = %v, want FailedPrecondition", err)
+	}
+
+	// Error typing.
+	if _, err := m.ReplaceNetworkACLAssociation(ctx, "aclassoc-missing", custom.ID); !cerrors.IsNotFound(err) {
+		t.Fatalf("replace with bad association = %v, want NotFound", err)
+	}
+	if _, err := m.ReplaceNetworkACLAssociation(ctx, newAssoc.ID, "acl-missing"); !cerrors.IsNotFound(err) {
+		t.Fatalf("replace onto bad ACL = %v, want NotFound", err)
+	}
+
+	// Deleting the subnet clears its association.
+	if err := m.DeleteSubnet(ctx, sub.ID); err != nil {
+		t.Fatalf("DeleteSubnet: %v", err)
+	}
+	acls, _ = m.DescribeNetworkACLs(ctx, []string{custom.ID})
+	if len(acls[0].Associations) != 0 {
+		t.Fatalf("custom ACL still associated after subnet delete: %+v", acls[0].Associations)
+	}
+}

--- a/providers/aws/vpc/acl_association_test.go
+++ b/providers/aws/vpc/acl_association_test.go
@@ -78,6 +78,13 @@ func TestNetworkACLAssociationLifecycle(t *testing.T) {
 		t.Fatalf("replace onto bad ACL = %v, want NotFound", err)
 	}
 
+	// The ACL must be in the subnet's VPC: an ACL in another VPC is rejected.
+	otherVPC := createTestVPC(m)
+	otherACL, _ := m.CreateNetworkACL(ctx, otherVPC.ID, nil)
+	if _, err := m.ReplaceNetworkACLAssociation(ctx, newAssoc.ID, otherACL.ID); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("cross-VPC replace = %v, want InvalidArgument", err)
+	}
+
 	// Deleting the subnet clears its association.
 	if err := m.DeleteSubnet(ctx, sub.ID); err != nil {
 		t.Fatalf("DeleteSubnet: %v", err)

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -35,6 +35,7 @@ const (
 var (
 	_ driver.Networking                 = (*Mock)(nil)
 	_ driver.NetworkInterfaces          = (*Mock)(nil)
+	_ driver.NetworkACLAssociator       = (*Mock)(nil)
 	_ driver.VPCAttributes              = (*Mock)(nil)
 	_ driver.SubnetAttributes           = (*Mock)(nil)
 	_ driver.TransitGateways            = (*Mock)(nil)
@@ -76,6 +77,7 @@ type Mock struct {
 	flowLogs       *memstore.Store[*flowLogData]
 	routeTables    *memstore.Store[*routeTableData]
 	networkACLs    *memstore.Store[*networkACLData]
+	aclAssocs      *memstore.Store[*aclAssocData]
 	igws           *memstore.Store[*igwData]
 	eips           *memstore.Store[*eipData]
 	rtAssocs       *memstore.Store[*rtAssocData]
@@ -189,6 +191,7 @@ func New(opts *config.Options) *Mock {
 		flowLogs:       memstore.New[*flowLogData](),
 		routeTables:    memstore.New[*routeTableData](),
 		networkACLs:    memstore.New[*networkACLData](),
+		aclAssocs:      memstore.New[*aclAssocData](),
 		igws:           memstore.New[*igwData](),
 		eips:           memstore.New[*eipData](),
 		rtAssocs:       memstore.New[*rtAssocData](),
@@ -265,6 +268,7 @@ func (m *Mock) CreateVPC(_ context.Context, cfg driver.VPCConfig) (*driver.VPCIn
 
 	m.createMainRouteTable(id, cfg.CIDRBlock)
 	m.createDefaultSecurityGroup(id)
+	m.createDefaultNetworkACL(id)
 
 	m.mu.RLock()
 	info := toVPCInfo(v)
@@ -354,6 +358,7 @@ func (m *Mock) DeleteVPC(_ context.Context, id string) error {
 	m.vpcs.Delete(id)
 	m.deleteMainRouteTable(id)
 	m.deleteDefaultSecurityGroup(id)
+	m.deleteDefaultNetworkACL(id)
 	m.markVPCPeeringsDeleted(id)
 
 	return nil
@@ -509,6 +514,11 @@ func (m *Mock) CreateSubnet(_ context.Context, cfg driver.SubnetConfig) (*driver
 	}
 	m.subnets.Set(id, s)
 
+	// A new subnet is automatically associated with its VPC's default network
+	// ACL, matching real EC2 (this is the association ReplaceNetworkAclAssociation
+	// later moves to a different ACL).
+	m.associateDefaultNetworkACL(cfg.VPCID, id)
+
 	info := toSubnetInfo(s)
 
 	return &info, nil
@@ -529,6 +539,12 @@ func (m *Mock) DeleteSubnet(_ context.Context, id string) error {
 	}
 
 	m.subnets.Delete(id)
+
+	for assocID, a := range m.aclAssocs.All() {
+		if a.SubnetID == id {
+			m.aclAssocs.Delete(assocID)
+		}
+	}
 
 	return nil
 }

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -221,6 +221,8 @@ func (h *Handler) routeNetworkACLs(w http.ResponseWriter, r *http.Request, actio
 		h.createNetworkACLEntry(w, r)
 	case "ReplaceNetworkAclEntry":
 		h.replaceNetworkACLEntry(w, r)
+	case "ReplaceNetworkAclAssociation":
+		h.replaceNetworkACLAssociation(w, r)
 	case "DeleteNetworkAclEntry":
 		h.deleteNetworkACLEntry(w, r)
 	default:

--- a/server/aws/ec2/network_acl.go
+++ b/server/aws/ec2/network_acl.go
@@ -258,12 +258,19 @@ func (h *Handler) replaceNetworkACLAssociation(w http.ResponseWriter, r *http.Re
 // real EC2 uses: a missing NetworkAclId -> InvalidNetworkAclID.NotFound, a
 // missing AssociationId -> InvalidAssociationID.NotFound.
 func writeNetworkACLAssocErr(w http.ResponseWriter, err error) {
-	if cerrors.IsNotFound(err) && !strings.Contains(err.Error(), "association") {
+	switch {
+	case cerrors.IsInvalidArgument(err):
+		// Cross-VPC association attempt.
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", err.Error())
+	case cerrors.IsNotFound(err) && !strings.Contains(err.Error(), "network ACL association"):
+		// A missing ACL, not a missing association. Matching the contiguous fixed
+		// phrase "network ACL association" is robust: the ACL-not-found message is
+		// `network ACL "<id>" not found`, so a caller-supplied id containing
+		// "association" cannot forge the phrase (the quote breaks it).
 		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidNetworkAclID.NotFound", err.Error())
-		return
+	default:
+		writeErrWithNotFound(w, err, "InvalidAssociationID.NotFound", "DependencyViolation")
 	}
-
-	writeErrWithNotFound(w, err, "InvalidAssociationID.NotFound", "DependencyViolation")
 }
 
 func toNetworkACLXML(a *netdriver.NetworkACL) networkACLXML {

--- a/server/aws/ec2/network_acl.go
+++ b/server/aws/ec2/network_acl.go
@@ -4,7 +4,9 @@ import (
 	"encoding/xml"
 	"net/http"
 	"strconv"
+	"strings"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
@@ -21,13 +23,27 @@ type networkACLEntryXML struct {
 	} `xml:"portRange,omitempty"`
 }
 
+type networkACLAssociationXML struct {
+	NetworkACLAssociationID string `xml:"networkAclAssociationId"`
+	NetworkACLID            string `xml:"networkAclId"`
+	SubnetID                string `xml:"subnetId"`
+}
+
 type networkACLXML struct {
-	NetworkACLID string               `xml:"networkAclId"`
-	VpcID        string               `xml:"vpcId"`
-	OwnerID      string               `xml:"ownerId"`
-	IsDefault    bool                 `xml:"default"`
-	Entries      []networkACLEntryXML `xml:"entrySet>item,omitempty"`
-	Tags         []tagItem            `xml:"tagSet>item,omitempty"`
+	NetworkACLID string                     `xml:"networkAclId"`
+	VpcID        string                     `xml:"vpcId"`
+	OwnerID      string                     `xml:"ownerId"`
+	IsDefault    bool                       `xml:"default"`
+	Entries      []networkACLEntryXML       `xml:"entrySet>item,omitempty"`
+	Associations []networkACLAssociationXML `xml:"associationSet>item,omitempty"`
+	Tags         []tagItem                  `xml:"tagSet>item,omitempty"`
+}
+
+type replaceNetworkACLAssociationResponseXML struct {
+	XMLName          xml.Name `xml:"ReplaceNetworkAclAssociationResponse"`
+	Xmlns            string   `xml:"xmlns,attr"`
+	RequestID        string   `xml:"requestId"`
+	NewAssociationID string   `xml:"newAssociationId"`
 }
 
 type createNetworkACLResponseXML struct {
@@ -211,6 +227,45 @@ func (h *Handler) deleteNetworkACLEntry(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+// replaceNetworkACLAssociation moves a subnet from its current network ACL to
+// the one named, returning a fresh association id. Subnet<->ACL associations are
+// an AWS-only concept, so the backend serves it via the optional
+// NetworkACLAssociator interface.
+func (h *Handler) replaceNetworkACLAssociation(w http.ResponseWriter, r *http.Request) {
+	assoc, ok := h.vpc.(netdriver.NetworkACLAssociator)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction",
+			"ReplaceNetworkAclAssociation is not supported")
+
+		return
+	}
+
+	out, err := assoc.ReplaceNetworkACLAssociation(r.Context(),
+		r.Form.Get("AssociationId"), r.Form.Get("NetworkAclId"))
+	if err != nil {
+		writeNetworkACLAssocErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, replaceNetworkACLAssociationResponseXML{
+		Xmlns:            awsquery.Namespace,
+		RequestID:        awsquery.RequestID,
+		NewAssociationID: out.ID,
+	})
+}
+
+// writeNetworkACLAssocErr maps the two distinct not-found cases to the codes
+// real EC2 uses: a missing NetworkAclId -> InvalidNetworkAclID.NotFound, a
+// missing AssociationId -> InvalidAssociationID.NotFound.
+func writeNetworkACLAssocErr(w http.ResponseWriter, err error) {
+	if cerrors.IsNotFound(err) && !strings.Contains(err.Error(), "association") {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidNetworkAclID.NotFound", err.Error())
+		return
+	}
+
+	writeErrWithNotFound(w, err, "InvalidAssociationID.NotFound", "DependencyViolation")
+}
+
 func toNetworkACLXML(a *netdriver.NetworkACL) networkACLXML {
 	x := networkACLXML{
 		NetworkACLID: a.ID,
@@ -218,6 +273,14 @@ func toNetworkACLXML(a *netdriver.NetworkACL) networkACLXML {
 		OwnerID:      ownerID,
 		IsDefault:    a.IsDefault,
 		Tags:         toTagItems(a.Tags),
+	}
+
+	for _, assoc := range a.Associations {
+		x.Associations = append(x.Associations, networkACLAssociationXML{
+			NetworkACLAssociationID: assoc.ID,
+			NetworkACLID:            assoc.NetworkACLID,
+			SubnetID:                assoc.SubnetID,
+		})
 	}
 
 	for _, rule := range a.Rules {

--- a/server/aws/ec2/network_acl_association_test.go
+++ b/server/aws/ec2/network_acl_association_test.go
@@ -1,0 +1,107 @@
+package ec2_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	smithy "github.com/aws/smithy-go"
+)
+
+// findSubnetAssociation returns the association id and acl id for a subnet by
+// scanning every ACL's associationSet, the way a real user reads it.
+func findSubnetAssociation(t *testing.T, c *ec2.Client, subnetID string) (assocID, aclID string) {
+	t.Helper()
+
+	out, err := c.DescribeNetworkAcls(context.Background(), &ec2.DescribeNetworkAclsInput{})
+	if err != nil {
+		t.Fatalf("DescribeNetworkAcls: %v", err)
+	}
+
+	for _, acl := range out.NetworkAcls {
+		for _, a := range acl.Associations {
+			if aws.ToString(a.SubnetId) == subnetID {
+				return aws.ToString(a.NetworkAclAssociationId), aws.ToString(a.NetworkAclId)
+			}
+		}
+	}
+
+	return "", ""
+}
+
+// TestReplaceNetworkAclAssociationWire drives the real AWS SDK through the wire:
+// a fresh subnet is associated with the VPC's default ACL, and
+// ReplaceNetworkAclAssociation moves it to a custom ACL, yielding a new
+// association id and flipping which ACL DescribeNetworkAcls reports for it.
+func TestReplaceNetworkAclAssociationWire(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	vpcID, subnetID := mkVPCSubnet(t, c)
+
+	// The subnet starts associated with its VPC's default ACL.
+	assocID, defaultACLID := findSubnetAssociation(t, c, subnetID)
+	if assocID == "" {
+		t.Fatal("new subnet has no default network-ACL association")
+	}
+
+	// A custom ACL to move the subnet onto.
+	custom, err := c.CreateNetworkAcl(ctx, &ec2.CreateNetworkAclInput{VpcId: aws.String(vpcID)})
+	if err != nil {
+		t.Fatalf("CreateNetworkAcl: %v", err)
+	}
+	customACLID := aws.ToString(custom.NetworkAcl.NetworkAclId)
+
+	rep, err := c.ReplaceNetworkAclAssociation(ctx, &ec2.ReplaceNetworkAclAssociationInput{
+		AssociationId: aws.String(assocID),
+		NetworkAclId:  aws.String(customACLID),
+	})
+	if err != nil {
+		t.Fatalf("ReplaceNetworkAclAssociation: %v", err)
+	}
+
+	newAssoc := aws.ToString(rep.NewAssociationId)
+	if newAssoc == "" || newAssoc == assocID {
+		t.Fatalf("newAssociationId = %q, want a fresh id != %q", newAssoc, assocID)
+	}
+
+	// The subnet is now on the custom ACL, no longer the default.
+	gotAssoc, gotACL := findSubnetAssociation(t, c, subnetID)
+	if gotACL != customACLID {
+		t.Fatalf("subnet now on ACL %q, want %q", gotACL, customACLID)
+	}
+	if gotAssoc != newAssoc {
+		t.Fatalf("subnet association = %q, want the new %q", gotAssoc, newAssoc)
+	}
+	if gotACL == defaultACLID {
+		t.Fatal("subnet still reports the default ACL after replace")
+	}
+
+	// The old association id no longer exists.
+	_, err = c.ReplaceNetworkAclAssociation(ctx, &ec2.ReplaceNetworkAclAssociationInput{
+		AssociationId: aws.String(assocID),
+		NetworkAclId:  aws.String(customACLID),
+	})
+	if err == nil {
+		t.Fatal("replacing a stale association id should error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidAssociationID.NotFound" {
+		t.Fatalf("stale association error = %v, want InvalidAssociationID.NotFound", err)
+	}
+
+	// A bad target ACL id is a distinct error code.
+	assoc2, _ := findSubnetAssociation(t, c, subnetID)
+	_, err = c.ReplaceNetworkAclAssociation(ctx, &ec2.ReplaceNetworkAclAssociationInput{
+		AssociationId: aws.String(assoc2),
+		NetworkAclId:  aws.String("acl-does-not-exist"),
+	})
+	if err == nil {
+		t.Fatal("replacing onto a missing ACL should error")
+	}
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidNetworkAclID.NotFound" {
+		t.Fatalf("bad ACL error = %v, want InvalidNetworkAclID.NotFound", err)
+	}
+}

--- a/server/aws/ec2/network_acl_test.go
+++ b/server/aws/ec2/network_acl_test.go
@@ -123,14 +123,22 @@ func TestDescribeNetworkAclsPaginatesAllOnce(t *testing.T) {
 
 	vpcID := mkVPC(ctx, t, c, "10.0.0.0/16")
 
-	want := map[string]int{}
 	for range 3 {
-		acl, err := c.CreateNetworkAcl(ctx, &ec2.CreateNetworkAclInput{VpcId: aws.String(vpcID)})
-		if err != nil {
+		if _, err := c.CreateNetworkAcl(ctx, &ec2.CreateNetworkAclInput{VpcId: aws.String(vpcID)}); err != nil {
 			t.Fatalf("CreateNetworkAcl: %v", err)
 		}
+	}
 
-		want[aws.ToString(acl.NetworkAcl.NetworkAclId)] = 0
+	// The expected set is every ACL in the account — the 3 just created plus the
+	// VPC's auto-created default ACL — captured via an unpaginated describe.
+	all, err := c.DescribeNetworkAcls(ctx, &ec2.DescribeNetworkAclsInput{})
+	if err != nil {
+		t.Fatalf("DescribeNetworkAcls(all): %v", err)
+	}
+
+	want := map[string]int{}
+	for _, a := range all.NetworkAcls {
+		want[aws.ToString(a.NetworkAclId)] = 0
 	}
 
 	seen := map[string]int{}

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -228,11 +228,23 @@ type RouteTableConfig struct {
 
 // NetworkACL represents a network ACL.
 type NetworkACL struct {
-	ID        string
-	VPCID     string
-	Rules     []NetworkACLRule
-	Tags      map[string]string
-	IsDefault bool
+	ID    string
+	VPCID string
+	Rules []NetworkACLRule
+	Tags  map[string]string
+	// Associations lists the subnets this ACL is associated with. It is an AWS
+	// concept the AWS backend populates; other clouds leave it empty.
+	Associations []NetworkACLAssociation
+	IsDefault    bool
+}
+
+// NetworkACLAssociation binds a subnet to a network ACL. Replacing the ACL for a
+// subnet yields a new association ID. This is an AWS concept (see
+// NetworkACLAssociator); other clouds do not populate it.
+type NetworkACLAssociation struct {
+	ID           string
+	NetworkACLID string
+	SubnetID     string
 }
 
 // NetworkACLRule represents a rule in a network ACL.
@@ -263,7 +275,7 @@ type InternetGateway struct {
 type ElasticIPConfig struct {
 	Tags map[string]string
 	// SKU (Azure public IP: Basic/Standard) and AllocationMethod (Static/
-	// Dynamic) are cost/behaviour inputs a discoverer reads; optional.
+	// Dynamic) are cost/behavior inputs a discoverer reads; optional.
 	SKU              string
 	AllocationMethod string
 }
@@ -441,6 +453,14 @@ type VPCAttributeUpdate struct {
 // than forcing them to carry a method they cannot implement meaningfully.
 type VPCAttributes interface {
 	ModifyVPCAttribute(ctx context.Context, id string, update VPCAttributeUpdate) error
+}
+
+// NetworkACLAssociator is an OPTIONAL capability, discovered by type assertion.
+// Moving a subnet from one network ACL to another (yielding a new association
+// ID) is an AWS concept; other clouds model network security differently, so it
+// is kept out of the Networking interface rather than forcing a mirror.
+type NetworkACLAssociator interface {
+	ReplaceNetworkACLAssociation(ctx context.Context, associationID, newACLID string) (*NetworkACLAssociation, error)
 }
 
 // SubnetAttributeUpdate carries the subnet attributes a caller wants changed. A


### PR DESCRIPTION
## Summary
Implements `ec2.ReplaceNetworkAclAssociation` — the last undispatched op of its tracker line — by introducing the subnet↔network-ACL **association** concept that was missing at every layer.

### Official AWS contract (API reference)
`AssociationId` + `NetworkAclId` (both required) → `newAssociationId`; idempotent; errors `InvalidAssociationID.NotFound` / `InvalidNetworkAclID.NotFound`. "By default when you create a subnet, it's automatically associated with the default network ACL."

### Architecture fit
- **Driver** (`services/networking/driver`): new `NetworkACLAssociation` type + `Associations` field on `NetworkACL`; new **`NetworkACLAssociator` optional interface** (type-asserted, AWS-only → no Azure/GCP/OCI mirrors), mirroring the existing `VPCAttributes`/`SubnetAttributes` optional pattern.
- **AWS provider** (`providers/aws/vpc`): a default NACL is auto-created per VPC (mirroring default-SG / main-route-table); new subnets auto-associate with it; `ReplaceNetworkACLAssociation` moves a subnet with a fresh id; `DescribeNetworkACLs` returns associations; VPC/subnet teardown cleans them up; a subnet-associated NACL can't be deleted (DependencyViolation). The association store mirrors the existing `rtAssocs` route-table pattern.
- **Wire** (`server/aws/ec2`): dispatch + `<associationSet>` on `DescribeNetworkAcls` + `<newAssociationId>` response; the two not-found cases map to their distinct AWS codes.

### Blast radius
Introducing default NACLs (which the teardown code already anticipated via its `!acl.IsDefault` guards) touched one pagination test, updated to expect the default. Topology, compat, and all provider tests pass unchanged.

Tests: provider-level lifecycle + a real-user `aws-sdk-go-v2` round-trip through the wire (create VPC+subnet → default association → replace onto custom ACL → new id → describe reflects it → both error codes). Full suite green (286 pkgs), compat green, coverage regenerated.