### PR TITLE
fix(rds): DescribeDBParameters returns the engine-default parameter set

### DIFF
--- a/providers/aws/rds/engine_defaults.go
+++ b/providers/aws/rds/engine_defaults.go
@@ -1,0 +1,142 @@
+package rds
+
+import (
+	"sort"
+	"strings"
+
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// Real RDS parameter groups always report the engine's full default parameter
+// set (hundreds of entries) overlaid with any user modifications. Modeling every
+// parameter is neither useful nor maintainable, so we seed a curated,
+// representative set of the parameters IaC tooling and operators most commonly
+// read/tune per engine family. DescribeDBParameters returns these
+// engine-defaults merged with the group's user-modified values.
+
+const (
+	sourceEngineDefault = "engine-default"
+	sourceUser          = "user"
+	applyDynamic        = "dynamic"
+	applyStatic         = "static"
+	dataInteger         = "integer"
+	dataString          = "string"
+	dataBoolean         = "boolean"
+	baseMySQL           = "mysql"
+	basePostgres        = "postgres"
+)
+
+// engineDefaultParameters returns the curated engine-default parameters for a
+// parameter-group family (e.g. "mysql8.0", "aurora-postgresql16"). Unknown
+// families fall back to a small generic set so the result is never empty,
+// matching real RDS which never returns an empty parameter list.
+func engineDefaultParameters(family string) []rdsdriver.Parameter {
+	switch familyBase(family) {
+	case basePostgres:
+		return append([]rdsdriver.Parameter(nil), postgresDefaults...)
+	case baseMySQL:
+		return append([]rdsdriver.Parameter(nil), mysqlDefaults...)
+	default:
+		return append([]rdsdriver.Parameter(nil), genericDefaults...)
+	}
+}
+
+// familyBase reduces a parameter-group family to the base engine whose default
+// set applies. Aurora and MariaDB share the MySQL/PostgreSQL parameter surface.
+func familyBase(family string) string {
+	switch {
+	case strings.Contains(family, basePostgres):
+		return basePostgres
+	case strings.Contains(family, baseMySQL), strings.Contains(family, "mariadb"):
+		return baseMySQL
+	default:
+		return ""
+	}
+}
+
+//nolint:gochecknoglobals // static engine-default parameter table
+var mysqlDefaults = []rdsdriver.Parameter{
+	p("autocommit", "1", applyDynamic, dataBoolean, "The autocommit mode."),
+	p("character_set_server", "latin1", applyDynamic, dataString, "The server's default character set."),
+	p("collation_server", "latin1_swedish_ci", applyDynamic, dataString, "The server's default collation."),
+	p("innodb_buffer_pool_size", "{DBInstanceClassMemory*3/4}", applyDynamic, dataInteger, "The size in bytes of the InnoDB buffer pool."),
+	p("innodb_flush_log_at_trx_commit", "1", applyDynamic, dataInteger, "Controls InnoDB redo-log flush behavior on commit."),
+	p("innodb_lock_wait_timeout", "50", applyDynamic, dataInteger, "InnoDB row-lock wait timeout in seconds."),
+	p("log_bin_trust_function_creators", "0", applyDynamic, dataBoolean, "Relaxes binary-logging checks on stored functions."),
+	p("long_query_time", "10", applyDynamic, dataString, "Slow-query threshold in seconds."),
+	p("lower_case_table_names", "0", applyStatic, dataInteger, "Table-name case sensitivity."),
+	p("max_allowed_packet", "4194304", applyDynamic, dataInteger, "Maximum size of one packet/row."),
+	p("max_connections", "{DBInstanceClassMemory/12582880}", applyDynamic, dataInteger, "Maximum simultaneous client connections."),
+	p("slow_query_log", "0", applyDynamic, dataBoolean, "Whether the slow query log is enabled."),
+	p("sql_mode", "", applyDynamic, dataString, "The current SQL server mode."),
+	p("time_zone", "UTC", applyDynamic, dataString, "The server time zone."),
+}
+
+//nolint:gochecknoglobals // static engine-default parameter table
+var postgresDefaults = []rdsdriver.Parameter{
+	p("autovacuum", "1", applyDynamic, dataBoolean, "Starts the autovacuum subprocess."),
+	p("effective_cache_size", "{DBInstanceClassMemory/16384}", applyDynamic, dataInteger, "Planner estimate of total cache size."),
+	p("idle_in_transaction_session_timeout", "86400000", applyDynamic, dataInteger, "Idle-in-transaction timeout (ms)."),
+	p("log_min_duration_statement", "-1", applyDynamic, dataInteger, "Logs statements running at least this long (ms); -1 disables."),
+	p("log_statement", "none", applyDynamic, dataString, "Sets the type of statements logged."),
+	p("maintenance_work_mem", "65536", applyDynamic, dataInteger, "Maximum memory for maintenance operations (kB)."),
+	p("max_connections", "LEAST({DBInstanceClassMemory/9531392},5000)", applyStatic, dataInteger, "Maximum concurrent connections."),
+	p("max_wal_size", "2048", applyDynamic, dataInteger, "Sets the WAL size that triggers a checkpoint (MB)."),
+	p("shared_buffers", "{DBInstanceClassMemory/32768}", applyStatic, dataInteger, "Number of shared memory buffers."),
+	p("ssl", "1", applyStatic, dataBoolean, "Enables SSL connections."),
+	p("statement_timeout", "0", applyDynamic, dataInteger, "Aborts any statement taking over this many ms; 0 disables."),
+	p("timezone", "UTC", applyDynamic, dataString, "Sets the time zone for displaying and interpreting timestamps."),
+	p("work_mem", "4096", applyDynamic, dataInteger, "Sets the maximum memory for query workspaces (kB)."),
+}
+
+//nolint:gochecknoglobals // static engine-default parameter table
+var genericDefaults = []rdsdriver.Parameter{
+	p("max_connections", "100", applyDynamic, dataInteger, "The maximum permitted number of simultaneous client connections."),
+	p("time_zone", "UTC", applyDynamic, dataString, "The server time zone."),
+}
+
+// p builds an engine-default parameter (Source is always engine-default).
+func p(name, value, applyType, dataType, desc string) rdsdriver.Parameter {
+	return rdsdriver.Parameter{
+		Name:        name,
+		Value:       value,
+		ApplyMethod: "pending-reboot",
+		Source:      sourceEngineDefault,
+		ApplyType:   applyType,
+		DataType:    dataType,
+		Description: desc,
+	}
+}
+
+// mergedParameters overlays a group's user-modified parameters onto the engine
+// defaults for its family. A modified parameter keeps the default's metadata but
+// reports the user's value and Source=user; a user parameter with no matching
+// default still appears. The result is sorted by name.
+func mergedParameters(family string, userParams map[string]rdsdriver.Parameter) []rdsdriver.Parameter {
+	byName := make(map[string]rdsdriver.Parameter)
+
+	for _, d := range engineDefaultParameters(family) {
+		byName[d.Name] = d
+	}
+
+	for name, up := range userParams {
+		base, ok := byName[name]
+		if !ok {
+			base = rdsdriver.Parameter{Name: name, ApplyType: applyStatic, DataType: dataString}
+		}
+
+		base.Value = up.Value
+		base.ApplyMethod = applyMethodOrDefault(up.ApplyMethod)
+		base.Source = sourceUser
+		byName[name] = base
+	}
+
+	out := make([]rdsdriver.Parameter, 0, len(byName))
+	for _, param := range byName {
+		out = append(out, param)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+
+	return out
+}

--- a/providers/aws/rds/parameter_group.go
+++ b/providers/aws/rds/parameter_group.go
@@ -2,7 +2,6 @@ package rds
 
 import (
 	"context"
-	"sort"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -52,34 +51,6 @@ func errParameterGroupNotFound(name string) error {
 
 func errClusterParameterGroupNotFound(name string) error {
 	return cerrors.Newf(cerrors.NotFound, "DB cluster parameter group %q not found", name)
-}
-
-// paramsToDriver renders a stored parameter map as sorted driver Parameters,
-// tagging each as user-set (the only kind the emulator tracks) and preserving
-// each parameter's apply method.
-func paramsToDriver(params map[string]rdsdriver.Parameter) []rdsdriver.Parameter {
-	names := make([]string, 0, len(params))
-	for name := range params {
-		names = append(names, name)
-	}
-
-	sort.Strings(names)
-
-	out := make([]rdsdriver.Parameter, 0, len(names))
-
-	for _, name := range names {
-		p := params[name]
-		out = append(out, rdsdriver.Parameter{
-			Name:        name,
-			Value:       p.Value,
-			ApplyMethod: applyMethodOrDefault(p.ApplyMethod),
-			Source:      "user",
-			ApplyType:   "static",
-			DataType:    "string",
-		})
-	}
-
-	return out
 }
 
 func applyMethodOrDefault(m string) string {
@@ -212,16 +183,37 @@ func (m *Mock) DeleteDBParameterGroup(_ context.Context, name string) error {
 	return nil
 }
 
+// DescribeDBParameters returns the group's full parameter set: the engine
+// defaults for its family overlaid with any user modifications, matching real
+// RDS (which never returns an empty list). A "default.<family>" group name that
+// was never explicitly created is synthesized from the family in its name, so
+// the always-present default parameter groups resolve too.
 func (m *Mock) DescribeDBParameters(_ context.Context, name string) ([]rdsdriver.Parameter, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	pg, ok := m.paramGroups.Get(name)
 	if !ok {
+		if family, isDefault := defaultGroupFamily(name); isDefault {
+			return mergedParameters(family, nil), nil
+		}
+
 		return nil, errParameterGroupNotFound(name)
 	}
 
-	return paramsToDriver(pg.Parameters), nil
+	return mergedParameters(pg.Family, pg.Parameters), nil
+}
+
+// defaultGroupFamily extracts the family from a "default.<family>" group name
+// (e.g. "default.mysql8.0" -> "mysql8.0"). RDS provides one such always-present
+// group per engine family.
+func defaultGroupFamily(name string) (string, bool) {
+	const prefix = "default."
+	if !strings.HasPrefix(name, prefix) {
+		return "", false
+	}
+
+	return strings.TrimPrefix(name, prefix), true
 }
 
 //nolint:dupl // structurally mirrors its sibling per-resource block by design.
@@ -388,16 +380,23 @@ func (m *Mock) DeleteDBClusterParameterGroup(_ context.Context, name string) err
 	return nil
 }
 
+// DescribeDBClusterParameters mirrors DescribeDBParameters for Aurora cluster
+// parameter groups: the family's engine defaults overlaid with user changes,
+// with "default.<family>" cluster groups synthesized from their name.
 func (m *Mock) DescribeDBClusterParameters(_ context.Context, name string) ([]rdsdriver.Parameter, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	pg, ok := m.clusterParamGroups.Get(name)
 	if !ok {
+		if family, isDefault := defaultGroupFamily(name); isDefault {
+			return mergedParameters(family, nil), nil
+		}
+
 		return nil, errClusterParameterGroupNotFound(name)
 	}
 
-	return paramsToDriver(pg.Parameters), nil
+	return mergedParameters(pg.Family, pg.Parameters), nil
 }
 
 //nolint:dupl // structurally mirrors its sibling per-resource block by design.

--- a/providers/aws/rds/parameter_group_test.go
+++ b/providers/aws/rds/parameter_group_test.go
@@ -48,30 +48,44 @@ func TestDBParameterGroupLifecycle(t *testing.T) {
 		t.Fatalf("DescribeDBParameters: %v", err)
 	}
 
-	if len(params) != 2 {
-		t.Fatalf("got %d params, want 2", len(params))
+	// Describe returns the full engine-default set with the two modifications
+	// overlaid as user-sourced (real RDS never returns an empty list).
+	if len(params) < 10 {
+		t.Fatalf("got %d params, want the full engine-default set", len(params))
+	}
+	if mc := findParam(params, "max_connections"); mc == nil || mc.Value != "200" || mc.Source != "user" {
+		t.Fatalf("max_connections = %+v, want value 200 source user", mc)
+	}
+	if sq := findParam(params, "slow_query_log"); sq == nil || sq.Value != "1" || sq.Source != "user" {
+		t.Fatalf("slow_query_log = %+v, want value 1 source user", sq)
+	}
+	if cs := findParam(params, "character_set_server"); cs == nil || cs.Source != "engine-default" {
+		t.Fatalf("unmodified character_set_server = %+v, want engine-default", cs)
 	}
 
-	if params[0].Source != "user" {
-		t.Errorf("param source = %q, want user", params[0].Source)
-	}
-
-	// Reset a named parameter.
+	// Resetting a named parameter reverts it to engine-default; the other stays.
 	if _, err := m.ResetDBParameterGroup(ctx, "pg-1", []string{"slow_query_log"}, false); err != nil {
 		t.Fatalf("ResetDBParameterGroup: %v", err)
 	}
 
-	if params, _ := m.DescribeDBParameters(ctx, "pg-1"); len(params) != 1 {
-		t.Fatalf("after reset one: got %d params, want 1", len(params))
+	params, _ = m.DescribeDBParameters(ctx, "pg-1")
+	if sq := findParam(params, "slow_query_log"); sq == nil || sq.Source != "engine-default" {
+		t.Fatalf("slow_query_log after reset = %+v, want engine-default", sq)
+	}
+	if mc := findParam(params, "max_connections"); mc == nil || mc.Source != "user" {
+		t.Fatalf("max_connections after resetting a different param = %+v, want still user", mc)
 	}
 
-	// Reset all.
+	// Reset all: every parameter reverts to engine-default.
 	if _, err := m.ResetDBParameterGroup(ctx, "pg-1", nil, true); err != nil {
 		t.Fatalf("ResetDBParameterGroup all: %v", err)
 	}
 
-	if params, _ := m.DescribeDBParameters(ctx, "pg-1"); len(params) != 0 {
-		t.Fatalf("after reset all: got %d params, want 0", len(params))
+	params, _ = m.DescribeDBParameters(ctx, "pg-1")
+	for i := range params {
+		if params[i].Source == "user" {
+			t.Fatalf("after reset all, %s is still user-sourced", params[i].Name)
+		}
 	}
 
 	// Delete, then describe-missing is NotFound.
@@ -103,9 +117,21 @@ func TestDBParameterGroupApplyMethodRoundTrips(t *testing.T) {
 		t.Fatalf("DescribeDBParameters: %v", err)
 	}
 
-	if len(params) != 1 || params[0].ApplyMethod != "immediate" {
-		t.Fatalf("ApplyMethod not preserved: %+v", params)
+	mc := findParam(params, "max_connections")
+	if mc == nil || mc.ApplyMethod != "immediate" || mc.Source != "user" {
+		t.Fatalf("ApplyMethod/source not preserved for max_connections: %+v", mc)
 	}
+}
+
+// findParam returns the parameter with the given name, or nil.
+func findParam(params []rdsdriver.Parameter, name string) *rdsdriver.Parameter {
+	for i := range params {
+		if params[i].Name == name {
+			return &params[i]
+		}
+	}
+
+	return nil
 }
 
 func TestDBParameterGroupCopy(t *testing.T) {
@@ -129,9 +155,10 @@ func TestDBParameterGroupCopy(t *testing.T) {
 		t.Errorf("copy metadata wrong: %+v", cp)
 	}
 
-	// The copy carries the source's parameters.
-	if params, _ := m.DescribeDBParameters(ctx, "dst"); len(params) != 1 || params[0].Name != "work_mem" {
-		t.Fatalf("copy did not carry params: %+v", params)
+	// The copy carries the source's user modification (over the engine defaults).
+	if params, _ := m.DescribeDBParameters(ctx, "dst"); findParam(params, "work_mem") == nil ||
+		findParam(params, "work_mem").Value != "64MB" || findParam(params, "work_mem").Source != "user" {
+		t.Fatalf("copy did not carry the work_mem modification: %+v", params)
 	}
 
 	// Copying onto an existing target is rejected.
@@ -283,8 +310,11 @@ func TestDBClusterParameterGroupLifecycle(t *testing.T) {
 		t.Fatalf("ModifyDBClusterParameterGroup: %v", err)
 	}
 
-	if params, _ := m.DescribeDBClusterParameters(ctx, "cpg-1"); len(params) != 1 {
-		t.Fatalf("got %d cluster params, want 1", len(params))
+	// Aurora-mysql defaults are returned with the modification overlaid.
+	if params, _ := m.DescribeDBClusterParameters(ctx, "cpg-1"); findParam(params, "character_set_server") == nil ||
+		findParam(params, "character_set_server").Value != "utf8mb4" ||
+		findParam(params, "character_set_server").Source != "user" {
+		t.Fatalf("cluster params missing the modification: got %d", len(params))
 	}
 
 	groups, err := m.DescribeDBClusterParameterGroups(ctx, nil)

--- a/server/aws/rds/parametergroup_sdk_roundtrip_test.go
+++ b/server/aws/rds/parametergroup_sdk_roundtrip_test.go
@@ -51,8 +51,13 @@ func TestSDKRDSParameterGroupLifecycle(t *testing.T) {
 		t.Fatalf("DescribeDBParameters: %v", err)
 	}
 
-	if len(params.Parameters) != 1 || aws.ToString(params.Parameters[0].ParameterName) != "max_connections" {
-		t.Fatalf("unexpected params: %+v", params.Parameters)
+	// The full engine-default set is returned with the modification overlaid.
+	mc := findSDKParam(params.Parameters, "max_connections")
+	if mc == nil || aws.ToString(mc.ParameterValue) != "200" || aws.ToString(mc.Source) != "user" {
+		t.Fatalf("max_connections = %+v, want value 200 source user", mc)
+	}
+	if len(params.Parameters) < 10 {
+		t.Fatalf("got %d params, want the full engine-default set", len(params.Parameters))
 	}
 
 	if _, err := client.ResetDBParameterGroup(ctx, &awsrds.ResetDBParameterGroupInput{
@@ -62,10 +67,17 @@ func TestSDKRDSParameterGroupLifecycle(t *testing.T) {
 		t.Fatalf("ResetDBParameterGroup: %v", err)
 	}
 
-	if params, _ := client.DescribeDBParameters(ctx, &awsrds.DescribeDBParametersInput{
+	// After reset-all the engine defaults remain, but nothing is user-sourced.
+	after, _ := client.DescribeDBParameters(ctx, &awsrds.DescribeDBParametersInput{
 		DBParameterGroupName: aws.String("pg-1"),
-	}); len(params.Parameters) != 0 {
-		t.Fatalf("after reset-all: got %d params, want 0", len(params.Parameters))
+	})
+	if len(after.Parameters) == 0 {
+		t.Fatal("after reset-all: engine defaults should still be returned")
+	}
+	for i := range after.Parameters {
+		if aws.ToString(after.Parameters[i].Source) == "user" {
+			t.Fatalf("after reset-all, %s is still user-sourced", aws.ToString(after.Parameters[i].ParameterName))
+		}
 	}
 
 	copied, err := client.CopyDBParameterGroup(ctx, &awsrds.CopyDBParameterGroupInput{
@@ -116,8 +128,9 @@ func TestSDKRDSClusterParameterGroupLifecycle(t *testing.T) {
 		t.Fatalf("DescribeDBClusterParameters: %v", err)
 	}
 
-	if len(params.Parameters) != 1 {
-		t.Fatalf("got %d cluster params, want 1", len(params.Parameters))
+	if cs := findSDKParam(params.Parameters, "character_set_server"); cs == nil ||
+		aws.ToString(cs.ParameterValue) != "utf8mb4" || aws.ToString(cs.Source) != "user" {
+		t.Fatalf("cluster params missing the modification: got %d", len(params.Parameters))
 	}
 
 	desc, err := client.DescribeDBClusterParameterGroups(ctx, &awsrds.DescribeDBClusterParameterGroupsInput{})
@@ -133,5 +146,39 @@ func TestSDKRDSClusterParameterGroupLifecycle(t *testing.T) {
 		DBClusterParameterGroupName: aws.String("cpg-1"),
 	}); err != nil {
 		t.Fatalf("DeleteDBClusterParameterGroup: %v", err)
+	}
+}
+
+func findSDKParam(params []awsrdstypes.Parameter, name string) *awsrdstypes.Parameter {
+	for i := range params {
+		if aws.ToString(params[i].ParameterName) == name {
+			return &params[i]
+		}
+	}
+
+	return nil
+}
+
+// TestSDKRDSDescribeDefaultParameters pins that DescribeDBParameters on the
+// always-present default parameter group (never explicitly created) returns the
+// engine-default set — real RDS never returns an empty parameter list.
+func TestSDKRDSDescribeDefaultParameters(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.DescribeDBParameters(ctx, &awsrds.DescribeDBParametersInput{
+		DBParameterGroupName: aws.String("default.mysql8.0"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBParameters(default.mysql8.0): %v", err)
+	}
+
+	if len(out.Parameters) < 10 {
+		t.Fatalf("default group returned %d params, want the engine-default set", len(out.Parameters))
+	}
+
+	mc := findSDKParam(out.Parameters, "max_connections")
+	if mc == nil || aws.ToString(mc.Source) != "engine-default" || aws.ToString(mc.ParameterValue) == "" {
+		t.Fatalf("max_connections in default group = %+v, want an engine-default value", mc)
 	}
 }


### PR DESCRIPTION
## Summary
`DescribeDBParameters` (and its cluster sibling `DescribeDBClusterParameters`) returned only the user-modified parameters — 0 for a fresh group — where real RDS always returns the engine's full default parameter set overlaid with user changes.

### Approach
A curated, representative engine-default table (`engine_defaults.go`) keyed by parameter-group family: MySQL-family (mysql/mariadb/aurora-mysql) and PostgreSQL-family (postgres/aurora-postgresql) each get ~13–14 of the parameters IaC tooling and operators most commonly read/tune (max_connections, character_set_server, shared_buffers, work_mem, …) with realistic default values, `ApplyType`/`DataType`/`Description`/`Source=engine-default`; a small generic fallback keeps any family non-empty. Modeling all several-hundred real parameters isn't useful or maintainable — this is the faithful, pragmatic middle.

- `DescribeDBParameters` now returns `mergedParameters(family, userParams)`: engine defaults with user modifications overlaid (`Source=user`, keeping the default's metadata).
- Always-present `default.<family>` groups (never explicitly created) are synthesized from the family in their name, so `DescribeDBParameters("default.mysql8.0")` resolves.
- `ResetDBParameterGroup` now correctly reverts parameters to `engine-default`; the cluster variant mirrors all of this.
- Removed the now-unused `paramsToDriver` (no dead code).

No driver-interface change (provider-internal), so no cross-cloud impact; coverage unchanged. Provider + SDK-wire tests updated to the correct behavior, plus a new real-user test asserting the default group returns engine defaults. Full suite green (286 pkgs), compat green.