### PR TITLE
feat(cloudtrail): LookupEvents records real API activity

### DIFF
--- a/docs/coverage/aws/cloudtrail.md
+++ b/docs/coverage/aws/cloudtrail.md
@@ -68,6 +68,18 @@ AWS's `cloudtrail` service · portable interface `driver.CloudTrail` · [AWS ind
 | `UpdateEventDataStore` |  |
 | `UpdateTrail` |  |
 
+## Optional capabilities
+
+Discovered by type assertion; only some providers implement these.
+
+### EventRecorder
+
+EventRecorder is an OPTIONAL capability, discovered by type assertion. The
+
+| Operation | Description |
+| --- | --- |
+| `RecordEvent` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -1817,6 +1817,17 @@
         "name": "UpdateTrail"
       }
     ],
+    "optionalCapabilities": [
+      {
+        "name": "EventRecorder",
+        "doc": "EventRecorder is an OPTIONAL capability, discovered by type assertion. The",
+        "operations": [
+          {
+            "name": "RecordEvent"
+          }
+        ]
+      }
+    ],
     "providers": {
       "aws": "CloudTrail"
     }

--- a/providers/aws/cloudtrail/cloudtrail.go
+++ b/providers/aws/cloudtrail/cloudtrail.go
@@ -94,6 +94,12 @@ type Mock struct {
 	orgMu     sync.Mutex
 	delegated map[string]struct{}
 
+	// eventsMu guards events, the bounded, newest-last log of management events
+	// LookupEvents queries. Fed by RecordEvent as API activity flows through the
+	// wire server (real CloudTrail records management events for API calls).
+	eventsMu sync.RWMutex
+	events   []driver.Event
+
 	opts *config.Options
 }
 

--- a/providers/aws/cloudtrail/events.go
+++ b/providers/aws/cloudtrail/events.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -57,8 +56,10 @@ func (m *Mock) RecordEvent(e *driver.Event) {
 	defer m.eventsMu.Unlock()
 
 	m.events = append(m.events, *e)
-	if len(m.events) > maxRecordedEvents {
-		// Drop the oldest, keeping the newest maxRecordedEvents.
+	// Amortized trim: only re-slice once the log reaches the high-water mark
+	// (2x cap), then drop back to cap. This keeps the common append O(1) instead
+	// of copying the whole slice under the lock on every request past the cap.
+	if len(m.events) > 2*maxRecordedEvents {
 		m.events = append([]driver.Event(nil), m.events[len(m.events)-maxRecordedEvents:]...)
 	}
 }
@@ -103,8 +104,15 @@ func (m *Mock) LookupEvents(_ context.Context, in driver.LookupInput) ([]driver.
 	all := append([]driver.Event(nil), m.events...)
 	m.eventsMu.RUnlock()
 
-	// Newest first, matching the API's default ordering.
-	sort.SliceStable(all, func(i, j int) bool { return all[i].EventTime.After(all[j].EventTime) })
+	// Newest first, with the event id as a stable tiebreak so a total order holds
+	// even when events share a timestamp (e.g. under a FakeClock).
+	sort.Slice(all, func(i, j int) bool {
+		if !all[i].EventTime.Equal(all[j].EventTime) {
+			return all[i].EventTime.After(all[j].EventTime)
+		}
+
+		return all[i].EventID > all[j].EventID
+	})
 
 	matched := make([]driver.Event, 0, len(all))
 
@@ -114,27 +122,42 @@ func (m *Mock) LookupEvents(_ context.Context, in driver.LookupInput) ([]driver.
 		}
 	}
 
-	start := decodeLookupToken(in.NextToken)
-	if start > len(matched) {
-		start = len(matched)
+	start, end := lookupWindow(matched, in.NextToken, in.MaxResults)
+
+	next := ""
+	if end < len(matched) {
+		next = matched[end-1].EventID
 	}
 
-	limit := int(in.MaxResults)
+	return matched[start:end], next, nil
+}
+
+// lookupWindow resolves the [start,end) page for a cursor token. It resumes
+// strictly after the cursor event (keyed by id), not a positional offset, so
+// front-insertions between pages (including a LookupEvents call recording
+// itself) don't shift the boundary — a paginate-through-all scan never
+// duplicates or skips events.
+func lookupWindow(matched []driver.Event, token string, maxResults int32) (start, end int) {
+	if token != "" {
+		for i := range matched {
+			if matched[i].EventID == token {
+				start = i + 1
+				break
+			}
+		}
+	}
+
+	limit := int(maxResults)
 	if limit <= 0 || limit > maxLookupResults {
 		limit = defaultLookupResults
 	}
 
-	end := start + limit
+	end = start + limit
 	if end > len(matched) {
 		end = len(matched)
 	}
 
-	next := ""
-	if end < len(matched) {
-		next = strconv.Itoa(end)
-	}
-
-	return matched[start:end], next, nil
+	return start, end
 }
 
 // eventMatches reports whether an event satisfies the lookup's time window and
@@ -178,17 +201,4 @@ func attributeMatches(e *driver.Event, key, value string) bool {
 	default:
 		return false
 	}
-}
-
-func decodeLookupToken(token string) int {
-	if token == "" {
-		return 0
-	}
-
-	n, err := strconv.Atoi(token)
-	if err != nil || n < 0 {
-		return 0
-	}
-
-	return n
 }

--- a/providers/aws/cloudtrail/events.go
+++ b/providers/aws/cloudtrail/events.go
@@ -1,0 +1,194 @@
+package cloudtrail
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/cloudtrail/driver"
+)
+
+const (
+	// maxRecordedEvents bounds the in-memory management-event log. Real CloudTrail
+	// keeps 90 days of LookupEvents history; the emulator keeps the most recent
+	// maxRecordedEvents and drops the oldest, so a long-lived process is bounded.
+	maxRecordedEvents = 2000
+	// defaultLookupResults / maxLookupResults mirror the LookupEvents API, whose
+	// MaxResults defaults to and is capped at 50.
+	defaultLookupResults = 50
+	maxLookupResults     = 50
+)
+
+// LookupAttribute keys accepted by LookupEvents, matching the AWS API.
+const (
+	attrEventID      = "EventId"
+	attrEventName    = "EventName"
+	attrEventSource  = "EventSource"
+	attrUsername     = "Username"
+	attrReadOnly     = "ReadOnly"
+	attrAccessKeyID  = "AccessKeyId"
+	attrResourceType = "ResourceType"
+	attrResourceName = "ResourceName"
+)
+
+// RecordEvent appends a management event to the bounded event log LookupEvents
+// reads. It is called by the wire server as API activity flows through it, so
+// the emulator's audit trail reflects real API calls rather than staying empty.
+// It is part of the AWS-only EventRecorder capability (see the driver package).
+func (m *Mock) RecordEvent(e *driver.Event) {
+	now := m.now()
+
+	// The recorder owns the timestamp, id, and the CloudTrailEvent JSON blob so
+	// the clock (FakeClock in tests) and region stay in the provider.
+	e.EventTime = now
+	if e.EventID == "" {
+		e.EventID = idgen.GenerateID("")
+	}
+
+	if e.CloudTrailEvent == "" {
+		e.CloudTrailEvent = m.cloudTrailEventJSON(e, now)
+	}
+
+	m.eventsMu.Lock()
+	defer m.eventsMu.Unlock()
+
+	m.events = append(m.events, *e)
+	if len(m.events) > maxRecordedEvents {
+		// Drop the oldest, keeping the newest maxRecordedEvents.
+		m.events = append([]driver.Event(nil), m.events[len(m.events)-maxRecordedEvents:]...)
+	}
+}
+
+// cloudTrailEventJSON renders the JSON document real CloudTrail returns in the
+// CloudTrailEvent field of a LookupEvents result — the full event record.
+func (m *Mock) cloudTrailEventJSON(e *driver.Event, now time.Time) string {
+	doc := map[string]any{
+		"eventVersion":       "1.08",
+		"eventID":            e.EventID,
+		"eventTime":          now.Format(time.RFC3339),
+		"eventName":          e.EventName,
+		"eventSource":        e.EventSource,
+		"awsRegion":          m.opts.Region,
+		"readOnly":           e.ReadOnly == "true",
+		"managementEvent":    true,
+		"eventCategory":      "Management",
+		"recipientAccountId": m.opts.AccountID,
+		"userIdentity": map[string]any{
+			"type":        "IAMUser",
+			"accountId":   m.opts.AccountID,
+			"accessKeyId": e.AccessKeyID,
+			"userName":    e.Username,
+		},
+	}
+
+	b, err := json.Marshal(doc)
+	if err != nil {
+		return ""
+	}
+
+	return string(b)
+}
+
+// LookupEvents returns management events matching the request's attribute and
+// time filters, newest first, paginated. Real CloudTrail LookupEvents queries
+// the last 90 days of management events; here it queries the recorded log.
+//
+//nolint:gocritic // in matches the driver LookupEvents signature (taken by value)
+func (m *Mock) LookupEvents(_ context.Context, in driver.LookupInput) ([]driver.Event, string, error) {
+	m.eventsMu.RLock()
+	all := append([]driver.Event(nil), m.events...)
+	m.eventsMu.RUnlock()
+
+	// Newest first, matching the API's default ordering.
+	sort.SliceStable(all, func(i, j int) bool { return all[i].EventTime.After(all[j].EventTime) })
+
+	matched := make([]driver.Event, 0, len(all))
+
+	for i := range all {
+		if eventMatches(&all[i], &in) {
+			matched = append(matched, all[i])
+		}
+	}
+
+	start := decodeLookupToken(in.NextToken)
+	if start > len(matched) {
+		start = len(matched)
+	}
+
+	limit := int(in.MaxResults)
+	if limit <= 0 || limit > maxLookupResults {
+		limit = defaultLookupResults
+	}
+
+	end := start + limit
+	if end > len(matched) {
+		end = len(matched)
+	}
+
+	next := ""
+	if end < len(matched) {
+		next = strconv.Itoa(end)
+	}
+
+	return matched[start:end], next, nil
+}
+
+// eventMatches reports whether an event satisfies the lookup's time window and
+// every supplied attribute filter (AWS matches on the attributes given).
+func eventMatches(e *driver.Event, in *driver.LookupInput) bool {
+	if !in.StartTime.IsZero() && e.EventTime.Before(in.StartTime) {
+		return false
+	}
+
+	if !in.EndTime.IsZero() && e.EventTime.After(in.EndTime) {
+		return false
+	}
+
+	for _, a := range in.LookupAttributes {
+		if !attributeMatches(e, a.AttributeKey, a.AttributeValue) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func attributeMatches(e *driver.Event, key, value string) bool {
+	switch key {
+	case attrEventID:
+		return e.EventID == value
+	case attrEventName:
+		return e.EventName == value
+	case attrEventSource:
+		return e.EventSource == value
+	case attrUsername:
+		return e.Username == value
+	case attrAccessKeyID:
+		return e.AccessKeyID == value
+	case attrReadOnly:
+		return strings.EqualFold(e.ReadOnly, value)
+	case attrResourceType, attrResourceName:
+		// Resources are not modeled on recorded events; nothing matches, matching
+		// real CloudTrail returning no events for an unmatched resource filter.
+		return false
+	default:
+		return false
+	}
+}
+
+func decodeLookupToken(token string) int {
+	if token == "" {
+		return 0
+	}
+
+	n, err := strconv.Atoi(token)
+	if err != nil || n < 0 {
+		return 0
+	}
+
+	return n
+}

--- a/providers/aws/cloudtrail/events_test.go
+++ b/providers/aws/cloudtrail/events_test.go
@@ -2,7 +2,6 @@ package cloudtrail
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -74,14 +73,17 @@ func TestLookupEventsRingBufferBounded(t *testing.T) {
 	m := newMock()
 	ctx := context.Background()
 
-	for i := 0; i < maxRecordedEvents+50; i++ {
-		m.RecordEvent(&driver.Event{EventName: "Op" + strings.Repeat("x", 0), EventSource: "ec2.amazonaws.com"})
+	// Record well past the high-water mark so the amortized trim fires.
+	for i := 0; i < 3*maxRecordedEvents; i++ {
+		m.RecordEvent(&driver.Event{EventName: "Op", EventSource: "ec2.amazonaws.com"})
 	}
 
 	m.eventsMu.RLock()
 	n := len(m.events)
 	m.eventsMu.RUnlock()
-	assert.Equal(t, maxRecordedEvents, n, "event log must stay bounded")
+	// The log is bounded: the amortized trim keeps it at or below the 2x cap.
+	assert.LessOrEqual(t, n, 2*maxRecordedEvents, "event log must stay bounded")
+	assert.GreaterOrEqual(t, n, maxRecordedEvents, "trim keeps at least cap events")
 
 	page, _, err := m.LookupEvents(ctx, driver.LookupInput{MaxResults: maxLookupResults})
 	require.NoError(t, err)
@@ -90,3 +92,49 @@ func TestLookupEventsRingBufferBounded(t *testing.T) {
 
 // EventRecorder is satisfied by the Mock.
 var _ driver.EventRecorder = (*Mock)(nil)
+
+// TestLookupEventsPaginationNoDuplicates pins that paginating through all events
+// never duplicates or skips, even when new events are recorded between pages
+// (the cursor is keyed on the event id, not a positional offset).
+func TestLookupEventsPaginationStableAcrossInserts(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	m := New(config.NewOptions(config.WithClock(fc)))
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		fc.Advance(time.Second)
+		m.RecordEvent(&driver.Event{EventName: "Op", EventSource: "ec2.amazonaws.com"})
+	}
+
+	seen := map[string]int{}
+	var token string
+	pages := 0
+
+	for {
+		fc.Advance(time.Second)
+		// A new event is inserted at the front between every page.
+		m.RecordEvent(&driver.Event{EventName: "Noise", EventSource: "ec2.amazonaws.com"})
+
+		out, next, err := m.LookupEvents(ctx, driver.LookupInput{
+			MaxResults:       2,
+			NextToken:        token,
+			LookupAttributes: []driver.LookupAttribute{{AttributeKey: "EventName", AttributeValue: "Op"}},
+		})
+		require.NoError(t, err)
+
+		for i := range out {
+			seen[out[i].EventID]++
+		}
+
+		pages++
+		if next == "" || pages > 10 {
+			break
+		}
+		token = next
+	}
+
+	require.Len(t, seen, 5, "should page through exactly the 5 Op events")
+	for id, n := range seen {
+		assert.Equal(t, 1, n, "event %s returned %d times, want exactly once", id, n)
+	}
+}

--- a/providers/aws/cloudtrail/events_test.go
+++ b/providers/aws/cloudtrail/events_test.go
@@ -1,0 +1,92 @@
+package cloudtrail
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/services/cloudtrail/driver"
+)
+
+func TestRecordAndLookupEvents(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	m := New(config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"), config.WithAccountID("123456789012")))
+	ctx := context.Background()
+
+	m.RecordEvent(&driver.Event{EventName: "RunInstances", EventSource: "ec2.amazonaws.com", ReadOnly: "false", AccessKeyID: "AKIDTEST"})
+	fc.Advance(time.Second)
+	m.RecordEvent(&driver.Event{EventName: "DescribeInstances", EventSource: "ec2.amazonaws.com", ReadOnly: "true"})
+	fc.Advance(time.Second)
+	m.RecordEvent(&driver.Event{EventName: "CreateBucket", EventSource: "s3.amazonaws.com", ReadOnly: "false"})
+
+	// Newest first, all fields populated.
+	all, next, err := m.LookupEvents(ctx, driver.LookupInput{})
+	require.NoError(t, err)
+	assert.Empty(t, next)
+	require.Len(t, all, 3)
+	assert.Equal(t, "CreateBucket", all[0].EventName)
+	assert.Equal(t, "RunInstances", all[2].EventName)
+	assert.False(t, all[0].EventTime.IsZero())
+	assert.NotEmpty(t, all[0].EventID)
+	assert.Contains(t, all[0].CloudTrailEvent, "CreateBucket")
+	assert.Contains(t, all[2].CloudTrailEvent, "AKIDTEST")
+
+	// Filter by EventName.
+	byName, _, _ := m.LookupEvents(ctx, driver.LookupInput{
+		LookupAttributes: []driver.LookupAttribute{{AttributeKey: "EventName", AttributeValue: "RunInstances"}},
+	})
+	require.Len(t, byName, 1)
+	assert.Equal(t, "RunInstances", byName[0].EventName)
+
+	// Filter by ReadOnly.
+	ro, _, _ := m.LookupEvents(ctx, driver.LookupInput{
+		LookupAttributes: []driver.LookupAttribute{{AttributeKey: "ReadOnly", AttributeValue: "true"}},
+	})
+	require.Len(t, ro, 1)
+	assert.Equal(t, "DescribeInstances", ro[0].EventName)
+
+	// Filter by EventSource.
+	s3ev, _, _ := m.LookupEvents(ctx, driver.LookupInput{
+		LookupAttributes: []driver.LookupAttribute{{AttributeKey: "EventSource", AttributeValue: "s3.amazonaws.com"}},
+	})
+	require.Len(t, s3ev, 1)
+	assert.Equal(t, "CreateBucket", s3ev[0].EventName)
+
+	// Time window: only events at/after the second record.
+	windowed, _, _ := m.LookupEvents(ctx, driver.LookupInput{StartTime: all[1].EventTime})
+	require.Len(t, windowed, 2)
+
+	// Pagination.
+	p1, tok, _ := m.LookupEvents(ctx, driver.LookupInput{MaxResults: 1})
+	require.Len(t, p1, 1)
+	require.NotEmpty(t, tok)
+	p2, _, _ := m.LookupEvents(ctx, driver.LookupInput{MaxResults: 1, NextToken: tok})
+	require.Len(t, p2, 1)
+	assert.NotEqual(t, p1[0].EventID, p2[0].EventID)
+}
+
+func TestLookupEventsRingBufferBounded(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	for i := 0; i < maxRecordedEvents+50; i++ {
+		m.RecordEvent(&driver.Event{EventName: "Op" + strings.Repeat("x", 0), EventSource: "ec2.amazonaws.com"})
+	}
+
+	m.eventsMu.RLock()
+	n := len(m.events)
+	m.eventsMu.RUnlock()
+	assert.Equal(t, maxRecordedEvents, n, "event log must stay bounded")
+
+	page, _, err := m.LookupEvents(ctx, driver.LookupInput{MaxResults: maxLookupResults})
+	require.NoError(t, err)
+	assert.Len(t, page, maxLookupResults)
+}
+
+// EventRecorder is satisfied by the Mock.
+var _ driver.EventRecorder = (*Mock)(nil)

--- a/providers/aws/cloudtrail/events_test.go
+++ b/providers/aws/cloudtrail/events_test.go
@@ -93,27 +93,33 @@ func TestLookupEventsRingBufferBounded(t *testing.T) {
 // EventRecorder is satisfied by the Mock.
 var _ driver.EventRecorder = (*Mock)(nil)
 
-// TestLookupEventsPaginationNoDuplicates pins that paginating through all events
-// never duplicates or skips, even when new events are recorded between pages
-// (the cursor is keyed on the event id, not a positional offset).
+// TestLookupEventsPaginationStableAcrossInserts pins that paginating through the
+// events present at scan-start returns each exactly once even when NEWER matching
+// events are recorded (front-inserted into the result window) between pages. The
+// cursor is keyed on the event id, so a positional-offset implementation would
+// return the original events more than once here and fail.
 func TestLookupEventsPaginationStableAcrossInserts(t *testing.T) {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 	m := New(config.NewOptions(config.WithClock(fc)))
 	ctx := context.Background()
 
+	// Record five events and capture their ids (RecordEvent stamps EventID).
+	original := map[string]int{}
 	for i := 0; i < 5; i++ {
 		fc.Advance(time.Second)
-		m.RecordEvent(&driver.Event{EventName: "Op", EventSource: "ec2.amazonaws.com"})
+		e := driver.Event{EventName: "Op", EventSource: "ec2.amazonaws.com"}
+		m.RecordEvent(&e)
+		original[e.EventID] = 0
 	}
 
-	seen := map[string]int{}
 	var token string
 	pages := 0
 
 	for {
 		fc.Advance(time.Second)
-		// A new event is inserted at the front between every page.
-		m.RecordEvent(&driver.Event{EventName: "Noise", EventSource: "ec2.amazonaws.com"})
+		// A NEWER matching event is front-inserted into the window between pages.
+		ne := driver.Event{EventName: "Op", EventSource: "ec2.amazonaws.com"}
+		m.RecordEvent(&ne)
 
 		out, next, err := m.LookupEvents(ctx, driver.LookupInput{
 			MaxResults:       2,
@@ -123,18 +129,20 @@ func TestLookupEventsPaginationStableAcrossInserts(t *testing.T) {
 		require.NoError(t, err)
 
 		for i := range out {
-			seen[out[i].EventID]++
+			if _, isOriginal := original[out[i].EventID]; isOriginal {
+				original[out[i].EventID]++
+			}
 		}
 
 		pages++
-		if next == "" || pages > 10 {
+		if next == "" || pages > 30 {
 			break
 		}
 		token = next
 	}
 
-	require.Len(t, seen, 5, "should page through exactly the 5 Op events")
-	for id, n := range seen {
-		assert.Equal(t, 1, n, "event %s returned %d times, want exactly once", id, n)
+	// Every original event was paged through exactly once — no duplicate, no skip.
+	for id, n := range original {
+		assert.Equal(t, 1, n, "original event %s returned %d times, want exactly once", id, n)
 	}
 }

--- a/providers/aws/cloudtrail/misc.go
+++ b/providers/aws/cloudtrail/misc.go
@@ -77,15 +77,6 @@ func (m *Mock) DeregisterOrganizationDelegatedAdmin(_ context.Context, delegated
 	return nil
 }
 
-// LookupEvents returns management events for the account. The emulator records
-// no real event stream, so this returns an empty page (documented). The
-// requested filters are accepted and ignored.
-//
-//nolint:gocritic // in matches the driver LookupEvents signature (taken by value)
-func (*Mock) LookupEvents(_ context.Context, _ driver.LookupInput) ([]driver.Event, string, error) {
-	return []driver.Event{}, "", nil
-}
-
 // ListPublicKeys returns the digest-signing public keys for a time range. The
 // emulator does not sign digest files, so this returns an empty list
 // (documented).

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -7,6 +7,8 @@
 package aws
 
 import (
+	"net/http"
+
 	awsprovider "github.com/stackshy/cloudemu/v2/providers/aws"
 	eksdriver "github.com/stackshy/cloudemu/v2/providers/aws/eks/driver"
 	"github.com/stackshy/cloudemu/v2/server"
@@ -637,6 +639,13 @@ func New(d Drivers) *server.Server {
 
 	if d.S3 != nil {
 		srv.Register(s3.New(d.S3))
+	}
+
+	// When the CloudTrail backend can record events, observe every served
+	// request and log a management event so LookupEvents reflects real API
+	// activity. This is the one cross-service hook CloudTrail needs.
+	if rec, ok := d.CloudTrail.(cloudtraildriver.EventRecorder); ok {
+		srv.SetObserver(func(r *http.Request) { recordManagementEvent(rec, r) })
 	}
 
 	return srv

--- a/server/aws/cloudtrail/lookupevents_wire_test.go
+++ b/server/aws/cloudtrail/lookupevents_wire_test.go
@@ -1,0 +1,98 @@
+package cloudtrail_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsct "github.com/aws/aws-sdk-go-v2/service/cloudtrail"
+	cttypes "github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// TestLookupEventsRecordsAPIActivity drives real SDK clients through the wire:
+// EC2 API calls are recorded as CloudTrail management events, and LookupEvents
+// returns them with EventName/EventSource/EventTime populated — the real-user
+// proof that the audit trail reflects activity instead of staying empty.
+func TestLookupEventsRecordsAPIActivity(t *testing.T) {
+	ctx := context.Background()
+
+	cloud := cloudemu.NewAWS()
+	ts := httptest.NewServer(awsserver.New(awsserver.DriversFrom(cloud)))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")))
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+	cfg.BaseEndpoint = aws.String(ts.URL)
+
+	ec2c := ec2.NewFromConfig(cfg)
+	ctc := awsct.NewFromConfig(cfg)
+
+	// Two EC2 API calls: one write, one read.
+	if _, err := ec2c.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId: aws.String("ami-123"), InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1),
+	}); err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	if _, err := ec2c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{}); err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	out, err := ctc.LookupEvents(ctx, &awsct.LookupEventsInput{})
+	if err != nil {
+		t.Fatalf("LookupEvents: %v", err)
+	}
+	if len(out.Events) < 2 {
+		t.Fatalf("LookupEvents returned %d events, want the EC2 activity", len(out.Events))
+	}
+
+	run := findEvent(out.Events, "RunInstances")
+	if run == nil {
+		t.Fatal("RunInstances not recorded")
+	}
+	if aws.ToString(run.EventSource) != "ec2.amazonaws.com" {
+		t.Errorf("RunInstances EventSource = %q, want ec2.amazonaws.com", aws.ToString(run.EventSource))
+	}
+	if run.EventTime == nil {
+		t.Error("RunInstances EventTime is nil")
+	}
+	if aws.ToString(run.CloudTrailEvent) == "" {
+		t.Error("RunInstances CloudTrailEvent JSON is empty")
+	}
+
+	// Attribute filter narrows to the one event.
+	filtered, err := ctc.LookupEvents(ctx, &awsct.LookupEventsInput{
+		LookupAttributes: []cttypes.LookupAttribute{{
+			AttributeKey:   cttypes.LookupAttributeKeyEventName,
+			AttributeValue: aws.String("RunInstances"),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("LookupEvents(filter): %v", err)
+	}
+	if len(filtered.Events) != 1 || aws.ToString(filtered.Events[0].EventName) != "RunInstances" {
+		t.Fatalf("EventName filter returned %d events, want exactly RunInstances", len(filtered.Events))
+	}
+}
+
+func findEvent(events []cttypes.Event, name string) *cttypes.Event {
+	for i := range events {
+		if aws.ToString(events[i].EventName) == name {
+			return &events[i]
+		}
+	}
+
+	return nil
+}

--- a/server/aws/cloudtrail/misc_ops.go
+++ b/server/aws/cloudtrail/misc_ops.go
@@ -215,30 +215,82 @@ func (h *Handler) deregisterOrgAdmin(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) lookupEvents(w http.ResponseWriter, r *http.Request) {
 	dispatch(h, w, r, func(h *Handler, ctx context.Context, req *struct {
-		NextToken  string `json:"NextToken"`
-		MaxResults int32  `json:"MaxResults"`
+		LookupAttributes []struct {
+			AttributeKey   string `json:"AttributeKey"`
+			AttributeValue string `json:"AttributeValue"`
+		} `json:"LookupAttributes"`
+		StartTime     *float64 `json:"StartTime"`
+		EndTime       *float64 `json:"EndTime"`
+		EventCategory string   `json:"EventCategory"`
+		NextToken     string   `json:"NextToken"`
+		MaxResults    int32    `json:"MaxResults"`
 	},
 	) (any, error) {
-		events, next, err := h.ct.LookupEvents(ctx, ctdriver.LookupInput{NextToken: req.NextToken, MaxResults: req.MaxResults})
+		in := ctdriver.LookupInput{
+			NextToken:     req.NextToken,
+			MaxResults:    req.MaxResults,
+			EventCategory: req.EventCategory,
+		}
+
+		if req.StartTime != nil {
+			in.StartTime = time.Unix(int64(*req.StartTime), 0).UTC()
+		}
+
+		if req.EndTime != nil {
+			in.EndTime = time.Unix(int64(*req.EndTime), 0).UTC()
+		}
+
+		for _, a := range req.LookupAttributes {
+			in.LookupAttributes = append(in.LookupAttributes,
+				ctdriver.LookupAttribute{AttributeKey: a.AttributeKey, AttributeValue: a.AttributeValue})
+		}
+
+		events, next, err := h.ct.LookupEvents(ctx, in)
 		if err != nil {
 			return nil, err
 		}
 
-		type eventJSON struct {
-			EventID   string `json:"EventId,omitempty"`
-			EventName string `json:"EventName,omitempty"`
-		}
-
-		list := make([]eventJSON, 0, len(events))
+		list := make([]lookupEventJSON, 0, len(events))
 		for i := range events {
-			list = append(list, eventJSON{EventID: events[i].EventID, EventName: events[i].EventName})
+			list = append(list, toLookupEventJSON(&events[i]))
 		}
 
 		return struct {
-			Events    []eventJSON `json:"Events"`
-			NextToken string      `json:"NextToken,omitempty"`
+			Events    []lookupEventJSON `json:"Events"`
+			NextToken string            `json:"NextToken,omitempty"`
 		}{Events: list, NextToken: next}, nil
 	})
+}
+
+// lookupEventJSON is the LookupEvents result-event wire shape.
+type lookupEventJSON struct {
+	EventID         string   `json:"EventId,omitempty"`
+	EventName       string   `json:"EventName,omitempty"`
+	ReadOnly        string   `json:"ReadOnly,omitempty"`
+	AccessKeyID     string   `json:"AccessKeyId,omitempty"`
+	EventTime       *float64 `json:"EventTime,omitempty"`
+	EventSource     string   `json:"EventSource,omitempty"`
+	Username        string   `json:"Username,omitempty"`
+	CloudTrailEvent string   `json:"CloudTrailEvent,omitempty"`
+}
+
+func toLookupEventJSON(e *ctdriver.Event) lookupEventJSON {
+	out := lookupEventJSON{
+		EventID:         e.EventID,
+		EventName:       e.EventName,
+		ReadOnly:        e.ReadOnly,
+		AccessKeyID:     e.AccessKeyID,
+		EventSource:     e.EventSource,
+		Username:        e.Username,
+		CloudTrailEvent: e.CloudTrailEvent,
+	}
+
+	if !e.EventTime.IsZero() {
+		secs := float64(e.EventTime.Unix())
+		out.EventTime = &secs
+	}
+
+	return out
 }
 
 func (h *Handler) listPublicKeys(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/cloudtrail_recording.go
+++ b/server/aws/cloudtrail_recording.go
@@ -20,9 +20,19 @@ func recordManagementEvent(rec cloudtraildriver.EventRecorder, r *http.Request) 
 	}
 
 	auth := r.Header.Get("Authorization")
+	svc := awsquery.CredentialScopeService(auth)
+	readOnly := isReadOnlyEvent(name)
+
+	// Don't record CloudTrail's own read-only operations (LookupEvents polling,
+	// ListTrails, ...). Otherwise a client polling LookupEvents would fill and
+	// evict the bounded log with its own reads, crowding out the API activity it
+	// is trying to observe.
+	if svc == "cloudtrail" && readOnly {
+		return
+	}
 
 	source := ""
-	if svc := awsquery.CredentialScopeService(auth); svc != "" {
+	if svc != "" {
 		source = svc + ".amazonaws.com"
 	}
 
@@ -30,7 +40,7 @@ func recordManagementEvent(rec cloudtraildriver.EventRecorder, r *http.Request) 
 		EventName:   name,
 		EventSource: source,
 		AccessKeyID: credentialAccessKeyID(auth),
-		ReadOnly:    strconv.FormatBool(isReadOnlyEvent(name)),
+		ReadOnly:    strconv.FormatBool(readOnly),
 	})
 }
 

--- a/server/aws/cloudtrail_recording.go
+++ b/server/aws/cloudtrail_recording.go
@@ -1,0 +1,82 @@
+package aws
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	cloudtraildriver "github.com/stackshy/cloudemu/v2/services/cloudtrail/driver"
+)
+
+// recordManagementEvent derives a CloudTrail management event from a served
+// request and records it. It runs as the server's post-dispatch observer, so
+// LookupEvents reflects real API activity. Requests whose operation cannot be
+// determined (e.g. an unrecognized shape) are skipped rather than logged blank.
+func recordManagementEvent(rec cloudtraildriver.EventRecorder, r *http.Request) {
+	name := requestEventName(r)
+	if name == "" {
+		return
+	}
+
+	auth := r.Header.Get("Authorization")
+
+	source := ""
+	if svc := awsquery.CredentialScopeService(auth); svc != "" {
+		source = svc + ".amazonaws.com"
+	}
+
+	rec.RecordEvent(&cloudtraildriver.Event{
+		EventName:   name,
+		EventSource: source,
+		AccessKeyID: credentialAccessKeyID(auth),
+		ReadOnly:    strconv.FormatBool(isReadOnlyEvent(name)),
+	})
+}
+
+// requestEventName extracts the API operation name (the CloudTrail EventName)
+// from a request: the operation after the prefix in an X-Amz-Target JSON-RPC
+// header, else the Action parameter of a query-protocol request.
+func requestEventName(r *http.Request) string {
+	if target := r.Header.Get("X-Amz-Target"); target != "" {
+		if i := strings.LastIndex(target, "."); i >= 0 && i+1 < len(target) {
+			return target[i+1:]
+		}
+
+		return target
+	}
+
+	if a := r.Form.Get("Action"); a != "" {
+		return a
+	}
+
+	return r.URL.Query().Get("Action")
+}
+
+// credentialAccessKeyID extracts the access-key id from a SigV4 Authorization
+// header's credential scope (Credential=AKID/DATE/REGION/SERVICE/aws4_request).
+func credentialAccessKeyID(auth string) string {
+	i := strings.Index(auth, "Credential=")
+	if i < 0 {
+		return ""
+	}
+
+	rest := auth[i+len("Credential="):]
+	if j := strings.IndexByte(rest, '/'); j >= 0 {
+		return rest[:j]
+	}
+
+	return ""
+}
+
+// isReadOnlyEvent classifies an operation as read-only by its verb prefix, the
+// same heuristic CloudTrail's readOnly flag reflects for management events.
+func isReadOnlyEvent(name string) bool {
+	for _, prefix := range []string{"Describe", "List", "Get", "Lookup", "Search", "BatchGet", "Query", "Scan", "Head"} {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/server.go
+++ b/server/server.go
@@ -22,6 +22,10 @@ type Handler interface {
 // implements http.Handler, so httptest.NewServer(srv) works.
 type Server struct {
 	handlers []Handler
+	// observer, when set, is called after a handler serves a request. It is a
+	// generic post-dispatch hook (protocol-agnostic) used, for example, to record
+	// API activity for CloudTrail. Nil by default, so it adds no behavior.
+	observer func(*http.Request)
 }
 
 // New creates a Server preloaded with the given handlers. Additional handlers
@@ -36,12 +40,23 @@ func (s *Server) Register(h Handler) {
 	s.handlers = append(s.handlers, h)
 }
 
+// SetObserver installs a post-dispatch hook called with each request a handler
+// served. It is generic and optional; passing nil disables it.
+func (s *Server) SetObserver(fn func(*http.Request)) {
+	s.observer = fn
+}
+
 // ServeHTTP dispatches to the first handler whose Matches returns true, or
 // responds 501 Not Implemented if no handler matches.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, h := range s.handlers {
 		if h.Matches(r) {
 			h.ServeHTTP(w, r)
+
+			if s.observer != nil {
+				s.observer(r)
+			}
+
 			return
 		}
 	}

--- a/services/cloudtrail/driver/driver.go
+++ b/services/cloudtrail/driver/driver.go
@@ -280,6 +280,14 @@ type PublicKey struct {
 	ValidityEndTime   time.Time
 }
 
+// EventRecorder is an OPTIONAL capability, discovered by type assertion. The
+// wire server calls RecordEvent to feed the management-event log LookupEvents
+// reads, so the emulator's audit trail reflects real API activity. Recording is
+// AWS-specific, so it is kept off the mandatory CloudTrail interface.
+type EventRecorder interface {
+	RecordEvent(e *Event)
+}
+
 // CloudTrail is the interface a CloudTrail backend implements.
 type CloudTrail interface {
 	// Trails.


### PR DESCRIPTION
## Summary
`cloudtrail.LookupEvents` always returned 0 events and the event wire shape modeled only EventId/EventName. Now the wire server records a CloudTrail management event for every served API request, and LookupEvents queries them with the full attribute/time filters, pagination, and complete event fields.

### Architecture fit
- **Generic observer on the core dispatcher** (`server/server.go`): an optional `SetObserver(func(*http.Request))` post-dispatch hook — protocol-agnostic, nil by default (zero behavior change). The core stays service-agnostic; it does not know about CloudTrail.
- **AWS-only `EventRecorder` optional interface** (`services/cloudtrail/driver`, type-asserted → no cross-cloud mirrors). `server/aws.New` wires the observer to it when CloudTrail is present, deriving EventName (X-Amz-Target op or query Action), EventSource + AccessKeyId (SigV4 credential scope), and a ReadOnly heuristic.
- **Provider** (`providers/aws/cloudtrail`): `RecordEvent` stamps EventTime/EventID and builds the CloudTrailEvent JSON (clock + region stay in the provider); a bounded ring buffer (2000) keeps a long-lived process bounded. `LookupEvents` filters by EventName/EventSource/Username/ReadOnly/AccessKeyId/EventId + time window, newest-first, paginated (MaxResults capped at 50).
- **Wire** (`server/aws/cloudtrail`): parses LookupAttributes/StartTime/EndTime and serializes EventTime/EventSource/Username/ReadOnly/AccessKeyId/CloudTrailEvent (was EventId/EventName only).

Tests: provider (record/lookup/filters/pagination/ring-buffer) + a real-user `aws-sdk-go-v2` round-trip (EC2 RunInstances/DescribeInstances → LookupEvents returns them with EventSource/EventTime/CloudTrailEvent, filter narrows to one). Full suite green (286 pkgs), compat green, coverage regenerated.