### PR TITLE
fix(ec2): enforce VPC deletion dependency guards (SG/route-table/EIP)

### DIFF
--- a/providers/aws/vpc/nat_gateway.go
+++ b/providers/aws/vpc/nat_gateway.go
@@ -68,6 +68,14 @@ func (m *Mock) CreateNATGateway(_ context.Context, cfg driver.NATGatewayConfig) 
 	// A private NAT gateway has no public/Elastic IP address.
 	if connectivity == natConnectivityPublic {
 		nat.PublicIP = mockPublicIP(id)
+
+		// The NAT gateway holds the Elastic IP, so real EC2 refuses to release it
+		// until the NAT gateway is deleted (InvalidIPAddress.InUse).
+		if cfg.AllocationID != "" {
+			if eip, ok := m.eips.Get(cfg.AllocationID); ok {
+				eip.AssociationID = idgen.GenerateID("eipassoc-")
+			}
+		}
 	}
 
 	m.natGateways.Set(id, nat)
@@ -79,11 +87,20 @@ func (m *Mock) CreateNATGateway(_ context.Context, cfg driver.NATGatewayConfig) 
 
 // DeleteNATGateway deletes the NAT gateway with the given ID.
 func (m *Mock) DeleteNATGateway(_ context.Context, id string) error {
-	if !m.natGateways.Delete(id) {
+	nat, ok := m.natGateways.Get(id)
+	if !ok {
 		return errors.Newf(errors.NotFound, "NAT gateway %q not found", id)
 	}
 
+	m.natGateways.Delete(id)
 	m.releaseManagedENIs(natENIDescription(id))
+
+	// Releasing the NAT gateway frees its Elastic IP so it can be released.
+	if nat.AllocationID != "" {
+		if eip, ok := m.eips.Get(nat.AllocationID); ok {
+			eip.AssociationID = ""
+		}
+	}
 
 	return nil
 }

--- a/providers/aws/vpc/network_interface.go
+++ b/providers/aws/vpc/network_interface.go
@@ -15,20 +15,22 @@ const (
 )
 
 type eniData struct {
-	ID           string
-	VPCID        string
-	SubnetID     string
-	Status       string
-	AttachmentID string
-	Description  string
-	Tags         map[string]string
+	ID             string
+	VPCID          string
+	SubnetID       string
+	Status         string
+	AttachmentID   string
+	Description    string
+	SecurityGroups []string
+	Tags           map[string]string
 }
 
 // CreateNetworkInterface creates a standalone, unattached ENI in the given
 // subnet (ec2:CreateNetworkInterface). The VPC is resolved from the subnet, so
-// an unknown subnet is NotFound.
+// an unknown subnet is NotFound. groups records the security groups the ENI is
+// in, so DeleteSecurityGroup can refuse to delete one still attached.
 func (m *Mock) CreateNetworkInterface(
-	_ context.Context, subnetID, description string, tags map[string]string,
+	_ context.Context, subnetID, description string, groups []string, tags map[string]string,
 ) (*driver.NetworkInterface, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -40,12 +42,13 @@ func (m *Mock) CreateNetworkInterface(
 
 	id := idgen.GenerateID("eni-")
 	eni := &eniData{
-		ID:          id,
-		VPCID:       sub.VPCID,
-		SubnetID:    subnetID,
-		Status:      ENIStatusAvailable,
-		Description: description,
-		Tags:        copyTags(tags),
+		ID:             id,
+		VPCID:          sub.VPCID,
+		SubnetID:       subnetID,
+		Status:         ENIStatusAvailable,
+		Description:    description,
+		SecurityGroups: append([]string(nil), groups...),
+		Tags:           copyTags(tags),
 	}
 	m.enis.Set(id, eni)
 

--- a/providers/aws/vpc/route_table.go
+++ b/providers/aws/vpc/route_table.go
@@ -70,8 +70,17 @@ func (m *Mock) DeleteRouteTable(_ context.Context, id string) error {
 	}
 
 	if rt.IsMain {
-		return errors.Newf(errors.InvalidArgument,
-			"cannot delete the main route table %q of vpc %q", id, rt.VPCID)
+		return errors.Newf(errors.FailedPrecondition,
+			"DependencyViolation: cannot delete the main route table %q of vpc %q", id, rt.VPCID)
+	}
+
+	// Real EC2 refuses to delete a route table still associated with a subnet;
+	// the caller must DisassociateRouteTable first.
+	for _, a := range m.rtAssocs.All() {
+		if a.RouteTableID == id && !a.Main {
+			return errors.Newf(errors.FailedPrecondition,
+				"DependencyViolation: route table %q has a subnet association %q and cannot be deleted", id, a.ID)
+		}
 	}
 
 	m.routeTables.Delete(id)

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -715,9 +715,51 @@ func (m *Mock) DeleteSecurityGroup(_ context.Context, id string) error {
 			"CannotDelete: default security group %q cannot be deleted", id)
 	}
 
+	// Real EC2 refuses to delete a security group that is still attached to a
+	// network interface or referenced by another security group in the VPC.
+	if dep, blocked := m.securityGroupInUse(id); blocked {
+		return errors.Newf(errors.FailedPrecondition,
+			"DependencyViolation: security group %q is in use by %s", id, dep)
+	}
+
 	m.securityGroups.Delete(id)
 
 	return nil
+}
+
+// securityGroupInUse reports the first network interface using the group or the
+// first other security group whose rules reference it.
+func (m *Mock) securityGroupInUse(id string) (string, bool) {
+	for _, eni := range m.enis.All() {
+		for _, g := range eni.SecurityGroups {
+			if g == id {
+				return "network interface " + eni.ID, true
+			}
+		}
+	}
+
+	for _, other := range m.securityGroups.All() {
+		if other.ID == id {
+			continue
+		}
+
+		if sgReferencesGroup(other.IngressRules, id) || sgReferencesGroup(other.EgressRules, id) {
+			return "security group " + other.ID, true
+		}
+	}
+
+	return "", false
+}
+
+// sgReferencesGroup reports whether any rule references the group id.
+func sgReferencesGroup(rules []driver.SecurityRule, id string) bool {
+	for i := range rules {
+		if rules[i].ReferencedGroupID == id {
+			return true
+		}
+	}
+
+	return false
 }
 
 // DescribeSecurityGroups returns security groups matching the given IDs, or all if ids is empty.

--- a/providers/oci/vcn/race_test.go
+++ b/providers/oci/vcn/race_test.go
@@ -227,7 +227,7 @@ func TestConcurrentAssociateAddressKeepsOneToOne(t *testing.T) {
 	subnet, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: parent.ID, CIDRBlock: subnetCIDR})
 	require.NoError(t, err)
 
-	vnic, err := m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil)
+	vnic, err := m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil, nil)
 	require.NoError(t, err)
 
 	privateIPs, err := m.DescribePrivateIPs(ctx, nil)

--- a/providers/oci/vcn/vcn_test.go
+++ b/providers/oci/vcn/vcn_test.go
@@ -476,7 +476,7 @@ func TestOCIDShapePerResourceType(t *testing.T) {
 	ip, err := m.AllocateAddress(ctx, driver.ElasticIPConfig{})
 	require.NoError(t, err)
 
-	vnic, err := m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil)
+	vnic, err := m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil, nil)
 	require.NoError(t, err)
 
 	privateIPs, err := m.DescribePrivateIPs(ctx, nil)
@@ -585,7 +585,7 @@ func TestSecurityGroupDeleteRefusesWithMembers(t *testing.T) {
 	nsg, err := m.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{Name: "web", VPCID: parent.ID})
 	require.NoError(t, err)
 
-	vnic, err := m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil)
+	vnic, err := m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil, nil)
 	require.NoError(t, err)
 
 	_, err = m.UpdateVNIC(ctx, vnic.ID, nil, nil, []string{nsg.ID})
@@ -883,7 +883,7 @@ func TestPublicIPAssignment(t *testing.T) {
 	subnet, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: parent.ID, CIDRBlock: subnetCIDR})
 	require.NoError(t, err)
 
-	vnic, err := m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil)
+	vnic, err := m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil, nil)
 	require.NoError(t, err)
 
 	privateIPs, err := m.DescribePrivateIPs(ctx, nil)
@@ -920,7 +920,7 @@ func TestPrivateIPs(t *testing.T) {
 	subnet, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: parent.ID, CIDRBlock: subnetCIDR})
 	require.NoError(t, err)
 
-	vnic, err := m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil)
+	vnic, err := m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil, nil)
 	require.NoError(t, err)
 
 	secondary, err := m.CreatePrivateIP(ctx, vnic.ID, "", "second", "host2")
@@ -957,7 +957,7 @@ func TestAutoPrivateIPNeverRepeatsAnAddress(t *testing.T) {
 	subnet, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: parent.ID, CIDRBlock: subnetCIDR})
 	require.NoError(t, err)
 
-	vnic, err := m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil)
+	vnic, err := m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil, nil)
 	require.NoError(t, err)
 
 	third, err := m.CreatePrivateIP(ctx, vnic.ID, "", "third", "")
@@ -996,7 +996,7 @@ func TestPrivateIPAllocationStopsAtTheSubnetEdge(t *testing.T) {
 	subnet, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: parent.ID, CIDRBlock: "10.0.1.0/30"})
 	require.NoError(t, err)
 
-	vnic, err := m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil)
+	vnic, err := m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil, nil)
 	require.NoError(t, err)
 
 	_, err = m.CreatePrivateIP(ctx, vnic.ID, "", "second", "")
@@ -1015,7 +1015,7 @@ func TestPublicIPAssignsOneToOne(t *testing.T) {
 	subnet, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: parent.ID, CIDRBlock: subnetCIDR})
 	require.NoError(t, err)
 
-	_, err = m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil)
+	_, err = m.CreateNetworkInterface(ctx, subnet.ID, "primary", nil, nil)
 	require.NoError(t, err)
 
 	privateIPs, err := m.DescribePrivateIPs(ctx, nil)

--- a/providers/oci/vcn/vnic.go
+++ b/providers/oci/vcn/vnic.go
@@ -72,7 +72,7 @@ type PrivateIP struct {
 // CreateNetworkInterface creates a VNIC in a subnet, along with the primary
 // private IP OCI gives every VNIC.
 func (m *Mock) CreateNetworkInterface(
-	_ context.Context, subnetID, description string, tags map[string]string,
+	_ context.Context, subnetID, description string, _ []string, tags map[string]string,
 ) (*driver.NetworkInterface, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/server/aws/ec2/address.go
+++ b/server/aws/ec2/address.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
@@ -82,6 +83,13 @@ func (h *Handler) releaseAddress(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.vpc.ReleaseAddress(r.Context(), id); err != nil {
+		// An Elastic IP still associated (e.g. held by a NAT gateway) can't be
+		// released; real EC2 answers InvalidIPAddress.InUse.
+		if cerrors.IsFailedPrecondition(err) {
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidIPAddress.InUse", err.Error())
+			return
+		}
+
 		writeVPCErr(w, err)
 
 		return

--- a/server/aws/ec2/deletion_guards_test.go
+++ b/server/aws/ec2/deletion_guards_test.go
@@ -1,0 +1,135 @@
+package ec2_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+func apiCode(t *testing.T, err error) string {
+	t.Helper()
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected an API error, got %v", err)
+	}
+	return apiErr.ErrorCode()
+}
+
+// TestDeletionGuardsMatchAWS pins the real-AWS deletion/dependency semantics the
+// e2e audit found missing: a security group in use by an ENI, a route table with
+// a subnet association (and the main route table), and an Elastic IP held by a
+// NAT gateway all refuse deletion with the correct error code.
+func TestDeletionGuardsMatchAWS(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	vpcID, subnetID := mkVPCSubnet(t, c)
+
+	// (1) SecurityGroup in use by an ENI -> DependencyViolation.
+	sg, err := c.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+		GroupName: aws.String("g1"), Description: aws.String("d"), VpcId: aws.String(vpcID),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecurityGroup: %v", err)
+	}
+	sgID := aws.ToString(sg.GroupId)
+
+	eni, err := c.CreateNetworkInterface(ctx, &ec2.CreateNetworkInterfaceInput{
+		SubnetId: aws.String(subnetID), Groups: []string{sgID},
+	})
+	if err != nil {
+		t.Fatalf("CreateNetworkInterface: %v", err)
+	}
+
+	if _, err := c.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{GroupId: aws.String(sgID)}); err == nil {
+		t.Fatal("DeleteSecurityGroup of an in-use SG should fail")
+	} else if code := apiCode(t, err); code != "DependencyViolation" {
+		t.Fatalf("DeleteSecurityGroup(in-use) code = %q, want DependencyViolation", code)
+	}
+	// After removing the ENI, the SG deletes.
+	if _, err := c.DeleteNetworkInterface(ctx, &ec2.DeleteNetworkInterfaceInput{
+		NetworkInterfaceId: eni.NetworkInterface.NetworkInterfaceId,
+	}); err != nil {
+		t.Fatalf("DeleteNetworkInterface: %v", err)
+	}
+	if _, err := c.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{GroupId: aws.String(sgID)}); err != nil {
+		t.Fatalf("DeleteSecurityGroup after ENI removed: %v", err)
+	}
+
+	// (2) Route table with a subnet association -> DependencyViolation.
+	rt, err := c.CreateRouteTable(ctx, &ec2.CreateRouteTableInput{VpcId: aws.String(vpcID)})
+	if err != nil {
+		t.Fatalf("CreateRouteTable: %v", err)
+	}
+	rtID := aws.ToString(rt.RouteTable.RouteTableId)
+	assoc, err := c.AssociateRouteTable(ctx, &ec2.AssociateRouteTableInput{
+		RouteTableId: aws.String(rtID), SubnetId: aws.String(subnetID),
+	})
+	if err != nil {
+		t.Fatalf("AssociateRouteTable: %v", err)
+	}
+	if _, err := c.DeleteRouteTable(ctx, &ec2.DeleteRouteTableInput{RouteTableId: aws.String(rtID)}); err == nil {
+		t.Fatal("DeleteRouteTable with a subnet association should fail")
+	} else if code := apiCode(t, err); code != "DependencyViolation" {
+		t.Fatalf("DeleteRouteTable(associated) code = %q, want DependencyViolation", code)
+	}
+	// Disassociate, then it deletes.
+	if _, err := c.DisassociateRouteTable(ctx, &ec2.DisassociateRouteTableInput{AssociationId: assoc.AssociationId}); err != nil {
+		t.Fatalf("DisassociateRouteTable: %v", err)
+	}
+	if _, err := c.DeleteRouteTable(ctx, &ec2.DeleteRouteTableInput{RouteTableId: aws.String(rtID)}); err != nil {
+		t.Fatalf("DeleteRouteTable after disassociate: %v", err)
+	}
+
+	// (3) Main route table -> DependencyViolation.
+	rts, err := c.DescribeRouteTables(ctx, &ec2.DescribeRouteTablesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeRouteTables: %v", err)
+	}
+	var mainRT string
+	for _, r := range rts.RouteTables {
+		for _, a := range r.Associations {
+			if aws.ToBool(a.Main) {
+				mainRT = aws.ToString(r.RouteTableId)
+			}
+		}
+	}
+	if mainRT == "" {
+		t.Fatal("no main route table found")
+	}
+	if _, err := c.DeleteRouteTable(ctx, &ec2.DeleteRouteTableInput{RouteTableId: aws.String(mainRT)}); err == nil {
+		t.Fatal("DeleteRouteTable of the main table should fail")
+	} else if code := apiCode(t, err); code != "DependencyViolation" {
+		t.Fatalf("DeleteRouteTable(main) code = %q, want DependencyViolation", code)
+	}
+
+	// (4) Elastic IP held by a NAT gateway -> InvalidIPAddress.InUse.
+	eip, err := c.AllocateAddress(ctx, &ec2.AllocateAddressInput{Domain: ec2types.DomainTypeVpc})
+	if err != nil {
+		t.Fatalf("AllocateAddress: %v", err)
+	}
+	nat, err := c.CreateNatGateway(ctx, &ec2.CreateNatGatewayInput{
+		SubnetId: aws.String(subnetID), AllocationId: eip.AllocationId,
+	})
+	if err != nil {
+		t.Fatalf("CreateNatGateway: %v", err)
+	}
+	if _, err := c.ReleaseAddress(ctx, &ec2.ReleaseAddressInput{AllocationId: eip.AllocationId}); err == nil {
+		t.Fatal("ReleaseAddress of an in-use EIP should fail")
+	} else if code := apiCode(t, err); code != "InvalidIPAddress.InUse" {
+		t.Fatalf("ReleaseAddress(in-use) code = %q, want InvalidIPAddress.InUse", code)
+	}
+	// After the NAT gateway is gone, the EIP releases.
+	if _, err := c.DeleteNatGateway(ctx, &ec2.DeleteNatGatewayInput{NatGatewayId: nat.NatGateway.NatGatewayId}); err != nil {
+		t.Fatalf("DeleteNatGateway: %v", err)
+	}
+	if _, err := c.ReleaseAddress(ctx, &ec2.ReleaseAddressInput{AllocationId: eip.AllocationId}); err != nil {
+		t.Fatalf("ReleaseAddress after NAT deleted: %v", err)
+	}
+}

--- a/server/aws/ec2/network_interface.go
+++ b/server/aws/ec2/network_interface.go
@@ -177,6 +177,7 @@ func (h *Handler) createNetworkInterface(w http.ResponseWriter, r *http.Request)
 	}
 
 	eni, err := creator.CreateNetworkInterface(r.Context(), subnetID, r.Form.Get("Description"),
+		awsquery.ListStrings(r.Form, "SecurityGroupId"),
 		mergeTagSpecs(awsquery.TagSpecs(r.Form), "network-interface"))
 	if err != nil {
 		writeENIErr(w, err)

--- a/server/oci/vcn/handler_test.go
+++ b/server/oci/vcn/handler_test.go
@@ -703,7 +703,7 @@ func TestVNICAndIPOperations(t *testing.T) {
 
 	// VNICs come from Compute's attachments, so the fixture uses the driver's
 	// creation capability directly.
-	vnic, err := f.mock.CreateNetworkInterface(t.Context(), subnetID, "primary", nil)
+	vnic, err := f.mock.CreateNetworkInterface(t.Context(), subnetID, "primary", nil, nil)
 	require.NoError(t, err)
 
 	t.Run("get vnic", func(t *testing.T) {
@@ -803,10 +803,10 @@ func TestEphemeralPublicIPLifetime(t *testing.T) {
 	f := newFixture(t)
 	subnetID := f.newSubnet(f.newVCN())
 
-	vnic, err := f.mock.CreateNetworkInterface(t.Context(), subnetID, "host", nil)
+	vnic, err := f.mock.CreateNetworkInterface(t.Context(), subnetID, "host", nil, nil)
 	require.NoError(t, err)
 
-	other, err := f.mock.CreateNetworkInterface(t.Context(), subnetID, "other", nil)
+	other, err := f.mock.CreateNetworkInterface(t.Context(), subnetID, "other", nil, nil)
 	require.NoError(t, err)
 
 	target := f.primaryPrivateIP(vnic.ID)
@@ -914,10 +914,10 @@ func TestPublicIPRollsBackOnFailedAssign(t *testing.T) {
 
 	// Two VNICs, so their primary private IPs give an occupied target and a
 	// separate address to move around.
-	firstVNIC, err := f.mock.CreateNetworkInterface(t.Context(), subnetID, "first", nil)
+	firstVNIC, err := f.mock.CreateNetworkInterface(t.Context(), subnetID, "first", nil, nil)
 	require.NoError(t, err)
 
-	secondVNIC, err := f.mock.CreateNetworkInterface(t.Context(), subnetID, "second", nil)
+	secondVNIC, err := f.mock.CreateNetworkInterface(t.Context(), subnetID, "second", nil, nil)
 	require.NoError(t, err)
 
 	first := f.primaryPrivateIP(firstVNIC.ID)
@@ -987,10 +987,10 @@ func TestProhibitPublicIPOnVnicIsEnforced(t *testing.T) {
 	privateSubnetID, _ := decode(t, private)["id"].(string)
 	publicSubnetID := f.newSubnet(vcnID)
 
-	privateVNIC, err := f.mock.CreateNetworkInterface(t.Context(), privateSubnetID, "private", nil)
+	privateVNIC, err := f.mock.CreateNetworkInterface(t.Context(), privateSubnetID, "private", nil, nil)
 	require.NoError(t, err)
 
-	publicVNIC, err := f.mock.CreateNetworkInterface(t.Context(), publicSubnetID, "public", nil)
+	publicVNIC, err := f.mock.CreateNetworkInterface(t.Context(), publicSubnetID, "public", nil, nil)
 	require.NoError(t, err)
 
 	blockedTarget := f.primaryPrivateIP(privateVNIC.ID)

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -494,5 +494,5 @@ type NetworkInterfaces interface {
 // out of NetworkInterfaces so that adding it doesn't break subset assertions
 // (e.g. resourcediscovery's read-only walker, which only needs Describe).
 type NetworkInterfaceCreator interface {
-	CreateNetworkInterface(ctx context.Context, subnetID, description string, tags map[string]string) (*NetworkInterface, error)
+	CreateNetworkInterface(ctx context.Context, subnetID, description string, groups []string, tags map[string]string) (*NetworkInterface, error)
 }


### PR DESCRIPTION
## Summary
End-to-end real-user audit (real aws-sdk-go-v2 vs a live cloudemu server) found deletes that succeed where real AWS blocks them. Fixes 4 confirmed divergences, all doc-verified:

- **DeleteSecurityGroup** on an SG attached to an ENI (or referenced by another SG in the VPC) now returns **DependencyViolation**. ENIs track their security groups end-to-end (new `groups` arg on the AWS-only `NetworkInterfaceCreator.CreateNetworkInterface`, wired through the CreateNetworkInterface handler).
- **DeleteRouteTable** with a live subnet association → **DependencyViolation** (must DisassociateRouteTable first); the main route table now also returns **DependencyViolation** (was InvalidParameterValue).
- **ReleaseAddress** on an Elastic IP held by a NAT gateway → **InvalidIPAddress.InUse**. CreateNatGateway now records the EIP association and DeleteNATGateway clears it.

Each resource deletes cleanly once its dependency is removed — matching the cloud. Real-user SDK wire test (`TestDeletionGuardsMatchAWS`) asserts every error code + the successful delete-after-remove path. No cross-cloud mirror needed (NetworkInterfaceCreator is AWS-specific; OCI's stub updated to match). Full suite green, compat green.