### PR TITLE
fix(s3): match real AWS behavior for CreateBucket, DeleteBucket, CompleteMultipartUpload

### DIFF
--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -215,9 +215,32 @@ func (m *Mock) DeleteBucket(_ context.Context, name string) error {
 		return cerrors.Newf(cerrors.FailedPrecondition, "bucket %q is not empty", name)
 	}
 
+	// A versioning-enabled/suspended bucket may hold no current objects yet still
+	// retain noncurrent versions and/or delete markers. Real S3 requires every
+	// object version (including delete markers) to be removed before the bucket
+	// can be deleted, so a non-empty version history also fails DeleteBucket.
+	if bkt.hasVersionHistory() {
+		return cerrors.Newf(cerrors.FailedPrecondition, "bucket %q is not empty", name)
+	}
+
 	m.buckets.Delete(name)
 
 	return nil
+}
+
+// hasVersionHistory reports whether the bucket retains any object version or
+// delete marker in its version history.
+func (b *bucketMeta) hasVersionHistory() bool {
+	b.versionsMu.Lock()
+	defer b.versionsMu.Unlock()
+
+	for _, chain := range b.versions {
+		if len(chain) > 0 {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (m *Mock) ListBuckets(_ context.Context) ([]driver.BucketInfo, error) {
@@ -831,9 +854,19 @@ func (m *Mock) CompleteMultipartUpload(ctx context.Context, bucket, key, uploadI
 
 	mp.mu.Lock()
 	for _, p := range parts {
-		if _, exists := mp.parts[p.PartNumber]; !exists {
+		stored, exists := mp.parts[p.PartNumber]
+		if !exists {
 			mp.mu.Unlock()
 			return cerrors.Newf(cerrors.InvalidArgument, "part %d not found in upload %q", p.PartNumber, uploadID)
+		}
+
+		// Real S3 validates each supplied part ETag against the stored part and
+		// rejects a mismatch with InvalidPart. An empty client ETag skips the
+		// check (some callers omit it); a non-empty one must match the stored
+		// part's MD5, case-insensitively.
+		if p.ETag != "" && !strings.EqualFold(strings.Trim(p.ETag, `"`), md5Hex(stored)) {
+			mp.mu.Unlock()
+			return cerrors.Newf(cerrors.InvalidArgument, "part %d ETag does not match the uploaded part in upload %q", p.PartNumber, uploadID)
 		}
 	}
 

--- a/server/aws/s3/create_bucket_test.go
+++ b/server/aws/s3/create_bucket_test.go
@@ -1,0 +1,67 @@
+package s3_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKCreateBucketInvalidName asserts CreateBucket rejects names that violate
+// S3's general-purpose bucket naming rules with 400 InvalidBucketName, matching
+// real S3. Without the wire-layer validation these all succeed with 200.
+func TestSDKCreateBucketInvalidName(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		bucket string
+	}{
+		{"uppercase", "UPPERCASE"},
+		{"too-short", "ab"},
+		{"underscore", "under_score"},
+		{"adjacent-dots", "bad..dots"},
+		{"leading-hyphen", "-badname"},
+		{"trailing-hyphen", "badname-"},
+		{"ip-address", "192.168.5.4"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := client.CreateBucket(ctx, &awss3.CreateBucketInput{
+				Bucket: aws.String(tc.bucket),
+			})
+			if err == nil {
+				t.Fatalf("CreateBucket(%q) succeeded, want InvalidBucketName", tc.bucket)
+			}
+
+			var apiErr smithy.APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("CreateBucket(%q) error = %T %v, want smithy.APIError", tc.bucket, err, err)
+			}
+
+			if apiErr.ErrorCode() != "InvalidBucketName" {
+				t.Fatalf("CreateBucket(%q) code = %q, want InvalidBucketName", tc.bucket, apiErr.ErrorCode())
+			}
+		})
+	}
+}
+
+// TestSDKCreateBucketValidName asserts a conforming name still succeeds, guarding
+// against the validation rejecting legal bucket names.
+func TestSDKCreateBucketValidName(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"abc", "my-bucket", "my.bucket.name", "a1b2c3"} {
+		if _, err := client.CreateBucket(ctx, &awss3.CreateBucketInput{
+			Bucket: aws.String(name),
+		}); err != nil {
+			t.Fatalf("CreateBucket(%q) failed: %v", name, err)
+		}
+	}
+}

--- a/server/aws/s3/delete_bucket_test.go
+++ b/server/aws/s3/delete_bucket_test.go
@@ -1,0 +1,81 @@
+package s3_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKDeleteBucketVersionedNotEmpty asserts DeleteBucket fails with
+// BucketNotEmpty when a versioning-enabled bucket still retains noncurrent
+// object versions and delete markers, even though no current object is visible.
+// Real S3 requires every version (including delete markers) to be removed first.
+func TestSDKDeleteBucketVersionedNotEmpty(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "ver-del-bucket"
+	const key = "obj.txt"
+
+	mustCreateBucket(t, client, bucket)
+
+	if _, err := client.PutBucketVersioning(ctx, &awss3.PutBucketVersioningInput{
+		Bucket: aws.String(bucket),
+		VersioningConfiguration: &types.VersioningConfiguration{
+			Status: types.BucketVersioningStatusEnabled,
+		},
+	}); err != nil {
+		t.Fatalf("PutBucketVersioning: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+			Body:   bytes.NewReader([]byte("payload")),
+		}); err != nil {
+			t.Fatalf("PutObject %d: %v", i, err)
+		}
+	}
+
+	// Top-level delete records a delete marker; the current-object view is now
+	// empty while the version history holds 2 versions + 1 marker.
+	if _, err := client.DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	}); err != nil {
+		t.Fatalf("DeleteObject: %v", err)
+	}
+
+	versions, err := client.ListObjectVersions(ctx, &awss3.ListObjectVersionsInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatalf("ListObjectVersions: %v", err)
+	}
+
+	if len(versions.Versions) != 2 || len(versions.DeleteMarkers) != 1 {
+		t.Fatalf("version history = %d versions, %d markers; want 2 and 1",
+			len(versions.Versions), len(versions.DeleteMarkers))
+	}
+
+	_, err = client.DeleteBucket(ctx, &awss3.DeleteBucketInput{Bucket: aws.String(bucket)})
+	if err == nil {
+		t.Fatal("DeleteBucket succeeded on a bucket with retained versions; want BucketNotEmpty")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("DeleteBucket error = %T %v, want smithy.APIError", err, err)
+	}
+
+	if apiErr.ErrorCode() != "BucketNotEmpty" {
+		t.Fatalf("DeleteBucket code = %q, want BucketNotEmpty", apiErr.ErrorCode())
+	}
+}

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"sort"
 	"strconv"
@@ -28,6 +29,9 @@ const (
 	maxPutObjectSize = 5 << 30
 	// maxUploadPartNumber is S3's upper bound on multipart part numbers.
 	maxUploadPartNumber = 10000
+	// minBucketNameLen / maxBucketNameLen bound a general-purpose bucket name.
+	minBucketNameLen = 3
+	maxBucketNameLen = 63
 )
 
 // Handler serves S3 REST requests against a storage.Bucket driver.
@@ -286,7 +290,56 @@ func (h *Handler) bucketTaggingOp(w http.ResponseWriter, r *http.Request, bucket
 // usEast1 is the region where CreateBucket is idempotent for the owner.
 const usEast1 = "us-east-1"
 
+// validBucketName reports whether name satisfies S3's general-purpose bucket
+// naming rules: 3-63 chars; lowercase letters, digits, hyphens and dots only;
+// begins and ends with a letter or digit; no adjacent periods; not formatted as
+// an IP address. See
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+func validBucketName(name string) bool {
+	if len(name) < minBucketNameLen || len(name) > maxBucketNameLen {
+		return false
+	}
+
+	if net.ParseIP(name) != nil {
+		return false
+	}
+
+	for i := 0; i < len(name); i++ {
+		if !validBucketNameChar(name, i) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// validBucketNameChar reports whether name[i] is legal at its position: an
+// interior-only hyphen/dot (no leading/trailing, no adjacent periods) or a
+// lowercase alphanumeric.
+func validBucketNameChar(name string, i int) bool {
+	c := name[i]
+
+	if c >= 'a' && c <= 'z' || c >= '0' && c <= '9' {
+		return true
+	}
+
+	if c != '-' && c != '.' {
+		return false
+	}
+
+	if i == 0 || i == len(name)-1 {
+		return false
+	}
+
+	return c != '.' || name[i-1] != '.'
+}
+
 func (h *Handler) createBucket(w http.ResponseWriter, r *http.Request, bucket string) {
+	if !validBucketName(bucket) {
+		writeError(w, http.StatusBadRequest, "InvalidBucketName", "The specified bucket is not valid.")
+		return
+	}
+
 	if err := h.bucket.CreateBucket(r.Context(), bucket); err != nil {
 		// In us-east-1 (the global endpoint) re-creating a bucket you already own
 		// is idempotent and returns 200; every other region returns 409
@@ -935,7 +988,7 @@ func (h *Handler) completeMultipartUpload(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := h.bucket.CompleteMultipartUpload(r.Context(), bucket, key, uploadID, parts); err != nil {
-		writeMultipartErr(w, err)
+		writeCompleteMultipartErr(w, err)
 		return
 	}
 
@@ -1240,6 +1293,20 @@ func writeMultipartErr(w http.ResponseWriter, err error) {
 		return
 	}
 	writeErr(w, err)
+}
+
+// writeCompleteMultipartErr maps a CompleteMultipartUpload driver error. A
+// missing upload is NoSuchUpload; a bad part reference (unknown part number or
+// an ETag that does not match the stored part) is InvalidPart in real S3.
+func writeCompleteMultipartErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeError(w, http.StatusNotFound, "NoSuchUpload", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "InvalidPart", err.Error())
+	default:
+		writeErr(w, err)
+	}
 }
 
 // bucketMissing reports whether a NotFound error names a bucket rather

--- a/server/aws/s3/multipart_test.go
+++ b/server/aws/s3/multipart_test.go
@@ -1,0 +1,71 @@
+package s3_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKCompleteMultipartWrongETag asserts CompleteMultipartUpload rejects a
+// part whose supplied ETag does not match the uploaded part with 400
+// InvalidPart, matching real S3. Without the ETag check the object completes
+// silently with a corrupted-part reference.
+func TestSDKCompleteMultipartWrongETag(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "mp-etag-bucket"
+	const key = "obj"
+
+	mustCreateBucket(t, client, bucket)
+
+	created, err := client.CreateMultipartUpload(ctx, &awss3.CreateMultipartUploadInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	uploadID := aws.ToString(created.UploadId)
+
+	if _, err := client.UploadPart(ctx, &awss3.UploadPartInput{
+		Bucket:     aws.String(bucket),
+		Key:        aws.String(key),
+		UploadId:   aws.String(uploadID),
+		PartNumber: aws.Int32(1),
+		Body:       bytes.NewReader(bytes.Repeat([]byte("A"), 16)),
+	}); err != nil {
+		t.Fatalf("UploadPart: %v", err)
+	}
+
+	_, err = client.CompleteMultipartUpload(ctx, &awss3.CompleteMultipartUploadInput{
+		Bucket:   aws.String(bucket),
+		Key:      aws.String(key),
+		UploadId: aws.String(uploadID),
+		MultipartUpload: &types.CompletedMultipartUpload{
+			Parts: []types.CompletedPart{{
+				PartNumber: aws.Int32(1),
+				ETag:       aws.String(`"00000000000000000000000000000000"`),
+			}},
+		},
+	})
+	if err == nil {
+		t.Fatal("CompleteMultipartUpload accepted a wrong part ETag; want InvalidPart")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("CompleteMultipartUpload error = %T %v, want smithy.APIError", err, err)
+	}
+
+	if apiErr.ErrorCode() != "InvalidPart" {
+		t.Fatalf("CompleteMultipartUpload code = %q, want InvalidPart", apiErr.ErrorCode())
+	}
+}


### PR DESCRIPTION
## Summary

Fixes three confirmed real-AWS divergences in the S3 emulator, found in the AWS e2e deep audit. Each fix ships with an aws-sdk-go-v2 round-trip test that fails without the change.

## Findings fixed

### 1. DeleteBucket ignored retained object versions (BLOCKER)
Per API_DeleteBucket, all object versions and delete markers must be removed before a bucket can be deleted. `providers/aws/s3` only checked the current-object view (`objects.Len()`), so a versioning-enabled bucket that still held noncurrent versions and delete markers was silently deleted, destroying the version history.

Fix: `DeleteBucket` now also fails with `BucketNotEmpty` (409) when the bucket retains any version history, via a new `bucketMeta.hasVersionHistory()` guard.

### 2. CompleteMultipartUpload accepted wrong part ETags (MAJOR)
Real S3 validates each supplied `CompletedPart.ETag` against the stored part and rejects a mismatch with `InvalidPart` (400). The emulator only checked part-number existence and ignored the ETag, so a corrupted/incorrect ETag completed successfully.

Fix: the provider compares each non-empty client ETag against the stored part's MD5 (case-insensitive); the wire handler maps the resulting error to `InvalidPart` via `writeCompleteMultipartErr`. An empty ETag still skips the check (preserving existing part-not-found behavior, which real S3 also reports as InvalidPart).

### 3. CreateBucket accepted invalid bucket names (MAJOR)
S3 enforces general-purpose bucket naming rules and rejects invalid names with `InvalidBucketName` (400). The emulator only rejected an empty name, so `UPPERCASE`, `ab`, `under_score`, `bad..dots`, leading/trailing hyphens, and IP-formatted names all succeeded — breaking IaC and validation-dependent paths.

Fix: the wire handler validates the name (3-63 chars; lowercase alphanumerics, hyphens, dots; interior-only hyphen/dot; no adjacent periods; not an IP address) and returns `InvalidBucketName` before dispatch.

## Layering
- State/lifecycle guards (version-history check, part-ETag comparison) live in `providers/aws/s3`.
- Error-code mapping and request-syntax validation (`InvalidPart`, `InvalidBucketName`) live in `server/aws/s3`.
- No shared driver interface changed.

## Tests
- `server/aws/s3/delete_bucket_test.go` — TestSDKDeleteBucketVersionedNotEmpty
- `server/aws/s3/multipart_test.go` — TestSDKCompleteMultipartWrongETag
- `server/aws/s3/create_bucket_test.go` — TestSDKCreateBucketInvalidName / TestSDKCreateBucketValidName

Gates: `go build`, `go test ./providers/aws/s3/... ./server/aws/s3/...`, and the compat suite (`go test ./compat/...`) all pass.