### PR TITLE
fix(rds): match real AWS behavior for deletion protection, cluster final-snapshot, and in-use group fault codes

### DIFF
--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -930,6 +930,7 @@ func (m *Mock) CreateCluster(_ context.Context, cfg rdsdriver.ClusterConfig) (*r
 		DBClusterResourceID:         resourceID("cluster-", cfg.ID),
 		AllocatedStorage:            allocatedStorage,
 		StorageEncrypted:            cfg.StorageEncrypted,
+		DeletionProtection:          cfg.DeletionProtection,
 		AvailabilityZones:           availabilityZones(m.opts.Region),
 		CreatedAt:                   m.opts.Clock.Now().UTC(),
 		Tags:                        copyTags(cfg.Tags),
@@ -1001,6 +1002,10 @@ func (m *Mock) ModifyCluster(
 
 	if input.DBClusterParameterGroupName != "" {
 		cluster.DBClusterParameterGroupName = input.DBClusterParameterGroupName
+	}
+
+	if input.DeletionProtection != nil {
+		cluster.DeletionProtection = *input.DeletionProtection
 	}
 
 	if input.Tags != nil {

--- a/server/aws/rds/deletion_protection_sdk_roundtrip_test.go
+++ b/server/aws/rds/deletion_protection_sdk_roundtrip_test.go
@@ -1,0 +1,186 @@
+package rds_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestSDKRDSDeleteInstanceDeletionProtection asserts that a deletion-protected
+// DB instance cannot be deleted: real RDS rejects with InvalidParameterCombination
+// and leaves the instance intact.
+func TestSDKRDSDeleteInstanceDeletionProtection(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("protected-db"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		AllocatedStorage:     aws.Int32(20),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	if _, err := client.ModifyDBInstance(ctx, &awsrds.ModifyDBInstanceInput{
+		DBInstanceIdentifier: aws.String("protected-db"),
+		DeletionProtection:   aws.Bool(true),
+		ApplyImmediately:     aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("ModifyDBInstance: %v", err)
+	}
+
+	desc, err := client.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String("protected-db"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBInstances: %v", err)
+	}
+
+	if !aws.ToBool(desc.DBInstances[0].DeletionProtection) {
+		t.Fatal("expected DeletionProtection=true after modify")
+	}
+
+	_, err = client.DeleteDBInstance(ctx, &awsrds.DeleteDBInstanceInput{
+		DBInstanceIdentifier: aws.String("protected-db"),
+		SkipFinalSnapshot:    aws.Bool(true),
+	})
+	if err == nil {
+		t.Fatal("delete protected instance: want InvalidParameterCombination, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterCombination" {
+		t.Fatalf("delete protected instance: got %v, want InvalidParameterCombination", err)
+	}
+
+	// The instance must still exist.
+	if _, err := client.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String("protected-db"),
+	}); err != nil {
+		t.Fatalf("instance was deleted despite protection: %v", err)
+	}
+
+	// Disabling protection lets the delete succeed.
+	if _, err := client.ModifyDBInstance(ctx, &awsrds.ModifyDBInstanceInput{
+		DBInstanceIdentifier: aws.String("protected-db"),
+		DeletionProtection:   aws.Bool(false),
+		ApplyImmediately:     aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("ModifyDBInstance disable: %v", err)
+	}
+
+	if _, err := client.DeleteDBInstance(ctx, &awsrds.DeleteDBInstanceInput{
+		DBInstanceIdentifier: aws.String("protected-db"),
+		SkipFinalSnapshot:    aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("DeleteDBInstance after disabling protection: %v", err)
+	}
+}
+
+// TestSDKRDSDeleteClusterDeletionProtection asserts DeletionProtection round-trips
+// on a DB cluster and blocks deletion with InvalidParameterCombination.
+func TestSDKRDSDeleteClusterDeletionProtection(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBCluster(ctx, &awsrds.CreateDBClusterInput{
+		DBClusterIdentifier: aws.String("aud-cluster"),
+		Engine:              aws.String("aurora-mysql"),
+		MasterUsername:      aws.String("admin"),
+		MasterUserPassword:  aws.String("supersecret"),
+	}); err != nil {
+		t.Fatalf("CreateDBCluster: %v", err)
+	}
+
+	if _, err := client.ModifyDBCluster(ctx, &awsrds.ModifyDBClusterInput{
+		DBClusterIdentifier: aws.String("aud-cluster"),
+		DeletionProtection:  aws.Bool(true),
+		ApplyImmediately:    aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("ModifyDBCluster: %v", err)
+	}
+
+	desc, err := client.DescribeDBClusters(ctx, &awsrds.DescribeDBClustersInput{
+		DBClusterIdentifier: aws.String("aud-cluster"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBClusters: %v", err)
+	}
+
+	if !aws.ToBool(desc.DBClusters[0].DeletionProtection) {
+		t.Fatal("expected cluster DeletionProtection=true after modify")
+	}
+
+	_, err = client.DeleteDBCluster(ctx, &awsrds.DeleteDBClusterInput{
+		DBClusterIdentifier: aws.String("aud-cluster"),
+		SkipFinalSnapshot:   aws.Bool(true),
+	})
+	if err == nil {
+		t.Fatal("delete protected cluster: want InvalidParameterCombination, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterCombination" {
+		t.Fatalf("delete protected cluster: got %v, want InvalidParameterCombination", err)
+	}
+
+	// Cluster must still exist.
+	if _, err := client.DescribeDBClusters(ctx, &awsrds.DescribeDBClustersInput{
+		DBClusterIdentifier: aws.String("aud-cluster"),
+	}); err != nil {
+		t.Fatalf("cluster was deleted despite protection: %v", err)
+	}
+}
+
+// TestSDKRDSDeleteClusterFinalSnapshotRequired asserts that DeleteDBCluster with
+// neither SkipFinalSnapshot nor FinalDBSnapshotIdentifier fails with
+// InvalidParameterCombination, mirroring DeleteDBInstance.
+func TestSDKRDSDeleteClusterFinalSnapshotRequired(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBCluster(ctx, &awsrds.CreateDBClusterInput{
+		DBClusterIdentifier: aws.String("aud-cluster2"),
+		Engine:              aws.String("aurora-mysql"),
+		MasterUsername:      aws.String("admin"),
+		MasterUserPassword:  aws.String("supersecret"),
+	}); err != nil {
+		t.Fatalf("CreateDBCluster: %v", err)
+	}
+
+	_, err := client.DeleteDBCluster(ctx, &awsrds.DeleteDBClusterInput{
+		DBClusterIdentifier: aws.String("aud-cluster2"),
+	})
+	if err == nil {
+		t.Fatal("delete cluster without skip or final id: want InvalidParameterCombination, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterCombination" {
+		t.Fatalf("delete cluster without skip or final id: got %v, want InvalidParameterCombination", err)
+	}
+
+	// Providing a final snapshot id creates the snapshot before deleting.
+	if _, err := client.DeleteDBCluster(ctx, &awsrds.DeleteDBClusterInput{
+		DBClusterIdentifier:       aws.String("aud-cluster2"),
+		FinalDBSnapshotIdentifier: aws.String("aud-cluster2-final"),
+	}); err != nil {
+		t.Fatalf("DeleteDBCluster with final snapshot: %v", err)
+	}
+
+	snaps, err := client.DescribeDBClusterSnapshots(ctx, &awsrds.DescribeDBClusterSnapshotsInput{
+		DBClusterSnapshotIdentifier: aws.String("aud-cluster2-final"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBClusterSnapshots: %v", err)
+	}
+
+	if len(snaps.DBClusterSnapshots) != 1 {
+		t.Fatalf("got %d final cluster snapshots, want 1", len(snaps.DBClusterSnapshots))
+	}
+}

--- a/server/aws/rds/handler.go
+++ b/server/aws/rds/handler.go
@@ -413,12 +413,17 @@ var alreadyExistsFaults = []faultMapping{
 }
 
 // invalidStateFaults maps an illegal-state error to the AWS-shaped fault code.
-// Real AWS distinguishes cluster-state faults from instance-state faults, so a
-// message naming a DB cluster gets InvalidDBClusterStateFault; everything else
-// falls back to InvalidDBInstanceState.
+// Real AWS distinguishes per-resource state faults, so an in-use parameter /
+// subnet / option group each gets its own fault code; a message naming a DB
+// cluster gets InvalidDBClusterStateFault; everything else falls back to
+// InvalidDBInstanceState. Ordered most-specific-first: the group entries must
+// precede "DB instance"/"DB cluster", whose keyword their messages also contain.
 //
 //nolint:gochecknoglobals // ordered static lookup table
 var invalidStateFaults = []faultMapping{
+	{"parameter group", "InvalidDBParameterGroupState"},
+	{"subnet group", "InvalidDBSubnetGroupStateFault"},
+	{"option group", "InvalidOptionGroupStateFault"},
 	{"DB cluster", "InvalidDBClusterStateFault"},
 	{"DB instance", "InvalidDBInstanceState"},
 }

--- a/server/aws/rds/inuse_fault_codes_sdk_roundtrip_test.go
+++ b/server/aws/rds/inuse_fault_codes_sdk_roundtrip_test.go
@@ -1,0 +1,125 @@
+package rds_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+)
+
+// TestSDKRDSDeleteParameterGroupInUseFault asserts that deleting a parameter
+// group still attached to a DB instance surfaces the typed
+// InvalidDBParameterGroupStateFault (not InvalidDBInstanceState).
+func TestSDKRDSDeleteParameterGroupInUseFault(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBParameterGroup(ctx, &awsrds.CreateDBParameterGroupInput{
+		DBParameterGroupName:   aws.String("mypg"),
+		DBParameterGroupFamily: aws.String("mysql8.0"),
+		Description:            aws.String("test pg"),
+	}); err != nil {
+		t.Fatalf("CreateDBParameterGroup: %v", err)
+	}
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("pg-user-db"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		AllocatedStorage:     aws.Int32(20),
+		DBParameterGroupName: aws.String("mypg"),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	_, err := client.DeleteDBParameterGroup(ctx, &awsrds.DeleteDBParameterGroupInput{
+		DBParameterGroupName: aws.String("mypg"),
+	})
+	if err == nil {
+		t.Fatal("delete in-use parameter group: want InvalidDBParameterGroupStateFault, got nil")
+	}
+
+	var state *rdstypes.InvalidDBParameterGroupStateFault
+	if !errors.As(err, &state) {
+		t.Fatalf("delete in-use parameter group: got %v, want InvalidDBParameterGroupStateFault", err)
+	}
+}
+
+// TestSDKRDSDeleteSubnetGroupInUseFault asserts that deleting a subnet group
+// still used by a DB instance surfaces InvalidDBSubnetGroupStateFault.
+func TestSDKRDSDeleteSubnetGroupInUseFault(t *testing.T) {
+	ctx := context.Background()
+	rdsc, ec2c := newSubnetGroupClients(t)
+	_, subnetIDs := mkSubnets(t, ec2c)
+
+	if _, err := rdsc.CreateDBSubnetGroup(ctx, &awsrds.CreateDBSubnetGroupInput{
+		DBSubnetGroupName:        aws.String("aud-sng"),
+		DBSubnetGroupDescription: aws.String("test group"),
+		SubnetIds:                subnetIDs,
+	}); err != nil {
+		t.Fatalf("CreateDBSubnetGroup: %v", err)
+	}
+
+	if _, err := rdsc.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("sng-user"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		AllocatedStorage:     aws.Int32(20),
+		DBSubnetGroupName:    aws.String("aud-sng"),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	_, err := rdsc.DeleteDBSubnetGroup(ctx, &awsrds.DeleteDBSubnetGroupInput{
+		DBSubnetGroupName: aws.String("aud-sng"),
+	})
+	if err == nil {
+		t.Fatal("delete in-use subnet group: want InvalidDBSubnetGroupStateFault, got nil")
+	}
+
+	var state *rdstypes.InvalidDBSubnetGroupStateFault
+	if !errors.As(err, &state) {
+		t.Fatalf("delete in-use subnet group: got %v, want InvalidDBSubnetGroupStateFault", err)
+	}
+}
+
+// TestSDKRDSDeleteOptionGroupInUseFault asserts that deleting an option group
+// still associated with a DB instance surfaces InvalidOptionGroupStateFault.
+func TestSDKRDSDeleteOptionGroupInUseFault(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateOptionGroup(ctx, &awsrds.CreateOptionGroupInput{
+		OptionGroupName:        aws.String("aud-og"),
+		EngineName:             aws.String("mysql"),
+		MajorEngineVersion:     aws.String("8.0"),
+		OptionGroupDescription: aws.String("test og"),
+	}); err != nil {
+		t.Fatalf("CreateOptionGroup: %v", err)
+	}
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("og-user"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		AllocatedStorage:     aws.Int32(20),
+		OptionGroupName:      aws.String("aud-og"),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	_, err := client.DeleteOptionGroup(ctx, &awsrds.DeleteOptionGroupInput{
+		OptionGroupName: aws.String("aud-og"),
+	})
+	if err == nil {
+		t.Fatal("delete in-use option group: want InvalidOptionGroupStateFault, got nil")
+	}
+
+	var state *rdstypes.InvalidOptionGroupStateFault
+	if !errors.As(err, &state) {
+		t.Fatalf("delete in-use option group: got %v, want InvalidOptionGroupStateFault", err)
+	}
+}

--- a/server/aws/rds/operations.go
+++ b/server/aws/rds/operations.go
@@ -257,6 +257,16 @@ func (h *Handler) deleteDBInstance(w http.ResponseWriter, r *http.Request) {
 	last := insts[0]
 	last.State = rdsdriver.StateDeleting
 
+	// A deletion-protected instance cannot be deleted; the flag must be cleared
+	// via ModifyDBInstance first. Real RDS rejects with InvalidParameterCombination
+	// and leaves the instance untouched.
+	if last.DeletionProtection {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterCombination",
+			"Cannot delete protected DB Instance, please disable deletion protection and try again.")
+
+		return
+	}
+
 	// A standalone instance takes a final snapshot unless SkipFinalSnapshot is
 	// set. When a final snapshot is requested, FinalDBSnapshotIdentifier is
 	// mandatory (InvalidParameterCombination otherwise). Cluster members carry no
@@ -372,6 +382,7 @@ func (h *Handler) createDBCluster(w http.ResponseWriter, r *http.Request) {
 		EngineMode:                  form.Get("EngineMode"),
 		StorageEncrypted:            formBool(form.Get("StorageEncrypted")),
 		AllocatedStorage:            formInt(form.Get("AllocatedStorage")),
+		DeletionProtection:          formBool(form.Get("DeletionProtection")),
 		Tags:                        parseRDSTags(form),
 	}
 
@@ -426,6 +437,11 @@ func (h *Handler) modifyDBCluster(w http.ResponseWriter, r *http.Request) {
 		Tags:                        parseRDSTags(form),
 	}
 
+	if v := form.Get("DeletionProtection"); v != "" {
+		b := formBool(v)
+		input.DeletionProtection = &b
+	}
+
 	cluster, err := h.db.ModifyCluster(r.Context(), id, input)
 	if err != nil {
 		writeErr(w, err)
@@ -455,6 +471,34 @@ func (h *Handler) deleteDBCluster(w http.ResponseWriter, r *http.Request) {
 
 	last := clusters[0]
 	last.State = rdsdriver.StateDeleting
+
+	// A deletion-protected cluster cannot be deleted; the flag must be cleared via
+	// ModifyDBCluster first. Real RDS rejects with InvalidParameterCombination.
+	if last.DeletionProtection {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterCombination",
+			"Cannot delete protected DB Cluster, please disable deletion protection and try again.")
+
+		return
+	}
+
+	// A cluster takes a final snapshot unless SkipFinalSnapshot is set. When a
+	// final snapshot is requested, FinalDBSnapshotIdentifier is mandatory
+	// (InvalidParameterCombination otherwise), mirroring DeleteDBInstance.
+	if !formBool(r.Form.Get("SkipFinalSnapshot")) {
+		finalID := r.Form.Get("FinalDBSnapshotIdentifier")
+		if finalID == "" {
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterCombination",
+				"FinalDBSnapshotIdentifier is required unless SkipFinalSnapshot is true")
+
+			return
+		}
+
+		if _, err := h.db.CreateClusterSnapshot(r.Context(),
+			rdsdriver.ClusterSnapshotConfig{ID: finalID, ClusterID: id}); err != nil {
+			writeErr(w, err)
+			return
+		}
+	}
 
 	if err := h.db.DeleteCluster(r.Context(), id); err != nil {
 		writeErr(w, err)

--- a/server/aws/rds/xml.go
+++ b/server/aws/rds/xml.go
@@ -141,6 +141,7 @@ type dbClusterXML struct {
 	DBClusterResourceID string                `xml:"DbClusterResourceId,omitempty"`
 	AllocatedStorage    int                   `xml:"AllocatedStorage,omitempty"`
 	StorageEncrypted    bool                  `xml:"StorageEncrypted"`
+	DeletionProtection  bool                  `xml:"DeletionProtection"`
 	AvailabilityZones   *availabilityZonesXML `xml:"AvailabilityZones,omitempty"`
 	ClusterCreateTime   string                `xml:"ClusterCreateTime,omitempty"`
 	DBClusterMembers    *dbClusterMembersXML  `xml:"DBClusterMembers,omitempty"`
@@ -475,6 +476,7 @@ func toClusterXML(cluster *rdsdriver.Cluster) dbClusterXML {
 		DBClusterResourceID: cluster.DBClusterResourceID,
 		AllocatedStorage:    cluster.AllocatedStorage,
 		StorageEncrypted:    cluster.StorageEncrypted,
+		DeletionProtection:  cluster.DeletionProtection,
 		AvailabilityZones:   toAvailabilityZonesXML(cluster.AvailabilityZones),
 		ClusterCreateTime:   cluster.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
 		DBClusterMembers:    &members,

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -202,6 +202,10 @@ type ClusterConfig struct {
 	EngineMode       string
 	StorageEncrypted bool
 	AllocatedStorage int
+	// DeletionProtection guards an Aurora DB cluster from deletion while set; it
+	// echoes the AWS RDS DBCluster attribute and defaults to false. Zero for
+	// non-AWS engines.
+	DeletionProtection bool
 	// Redshift-specific create inputs carried on the shared config (following the
 	// Azure HighAvailabilityMode precedent); zero for RDS/Aurora/Azure/GCP.
 	NodeType           string
@@ -236,6 +240,9 @@ type Cluster struct {
 	AllocatedStorage    int
 	StorageEncrypted    bool
 	AvailabilityZones   []string
+	// DeletionProtection guards the cluster from deletion while set; echoes the
+	// AWS RDS DBCluster attribute and defaults to false for non-AWS engines.
+	DeletionProtection bool
 	// NodeType / NumberOfNodes / Encrypted / PubliclyAccessible /
 	// AvailabilityZone / VpcID are Redshift-specific cluster attributes carried
 	// on the shared struct (Azure HighAvailabilityMode precedent); zero for


### PR DESCRIPTION
Fixes six confirmed real-AWS divergences in the RDS wire layer, each covered by an aws-sdk-go-v2 round-trip test that fails without the change.

## Findings fixed

1. **DeleteDBInstance (deletion protection)** — a deletion-protected instance was deleted anyway (the flag was cosmetic). `deleteDBInstance` now rejects with `InvalidParameterCombination` ("Cannot delete protected DB Instance, please disable deletion protection and try again.") and leaves the instance intact.

2. **DeleteDBCluster (deletion protection)** — the cluster model could not even hold the flag. Added `DeletionProtection` to `driver.Cluster` / `driver.ClusterConfig`, wired it through `CreateCluster`/`ModifyCluster`, echoed it on the cluster XML, and `deleteDBCluster` now rejects a protected cluster with `InvalidParameterCombination`.

3. **DeleteDBCluster (final-snapshot requirement)** — deleting a cluster with neither `SkipFinalSnapshot` nor `FinalDBSnapshotIdentifier` succeeded silently. It now returns `InvalidParameterCombination` ("FinalDBSnapshotIdentifier is required unless SkipFinalSnapshot is true"), and creates the cluster snapshot when a final id is supplied — mirroring DeleteDBInstance.

4. **DeleteDBParameterGroup (in-use)** — the blocked delete surfaced `InvalidDBInstanceState` instead of `InvalidDBParameterGroupState`.

5. **DeleteDBSubnetGroup (in-use)** — surfaced `InvalidDBInstanceState` instead of `InvalidDBSubnetGroupStateFault`.

6. **DeleteOptionGroup (in-use)** — surfaced `InvalidDBInstanceState` instead of `InvalidOptionGroupStateFault`.

Findings 4-6 are fixed by adding per-resource entries (ordered most-specific-first) to the `invalidStateFaults` table in `server/aws/rds/handler.go`, so `errors.As` against the typed SDK faults now matches and Terraform's destroy retries work.

## Notes
- Driver change is struct-field-only (`DeletionProtection` on `Cluster`/`ClusterConfig`); no shared interface method changed, so `go generate` produces no coverage diff.
- Gates: `go build ./...`, `go test ./server/aws/rds/... ./providers/aws/rds/...`, and the compat suite (`go test ./compat/...`) all pass. The two pre-existing `dupl` findings in `parameter_group.go` are untouched.