### PR TITLE
fix(secrets-kms): match real AWS DeleteSecret/DescribeSecret/GetSecretValue/CreateSecret lifecycle behavior

### DIFF
--- a/providers/aws/secretsmanager/secretsmanager.go
+++ b/providers/aws/secretsmanager/secretsmanager.go
@@ -20,8 +20,18 @@ type secretData struct {
 	info      driver.SecretInfo
 	versions  []driver.SecretVersion
 	deletedAt time.Time
-	mu        sync.RWMutex
+	// recoveryWindow is the number of days between the delete request and the
+	// scheduled deletion date, captured from DeleteSecret's RecoveryWindowInDays.
+	recoveryWindow int
+	mu             sync.RWMutex
 }
+
+// DeleteSecret recovery-window bounds, matching the real service.
+const (
+	minRecoveryWindowDays     = 7
+	maxRecoveryWindowDays     = 30
+	defaultRecoveryWindowDays = 30
+)
 
 // Mock is an in-memory mock implementation of the AWS Secrets Manager service.
 type Mock struct {
@@ -43,7 +53,16 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 		return nil, errors.New(errors.InvalidArgument, "secret name is required")
 	}
 
-	if m.secrets.Has(cfg.Name) {
+	if existing, ok := m.secrets.Get(cfg.Name); ok {
+		existing.mu.RLock()
+		scheduledForDeletion := !existing.deletedAt.IsZero()
+		existing.mu.RUnlock()
+
+		if scheduledForDeletion {
+			return nil, errors.New(errors.FailedPrecondition,
+				"a secret with this name is already scheduled for deletion")
+		}
+
 		return nil, errors.Newf(errors.AlreadyExists, "secret %q already exists", cfg.Name)
 	}
 
@@ -88,23 +107,70 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 	return &result, nil
 }
 
-// DeleteSecret soft-deletes a secret by name, scheduling it for deletion after a recovery window.
-func (m *Mock) DeleteSecret(_ context.Context, name string) error {
+// DeleteSecret soft-deletes a secret by name, scheduling it for deletion after
+// the default recovery window. It satisfies the portable driver; the AWS wire
+// layer uses DeleteSecretWithOptions to honor RecoveryWindowInDays and
+// ForceDeleteWithoutRecovery.
+func (m *Mock) DeleteSecret(ctx context.Context, name string) error {
+	_, _, err := m.DeleteSecretWithOptions(ctx, name, nil, false)
+
+	return err
+}
+
+// DeleteSecretWithOptions is the AWS DeleteSecret surface. A nil recoveryWindow
+// applies the 30-day default; ForceDeleteWithoutRecovery removes the secret
+// permanently (no recovery window, unrecoverable). It returns the deleted
+// secret's metadata plus the scheduled DeletionDate (RFC3339). Passing both a
+// recovery window and force, or a window outside 7-30, is rejected.
+func (m *Mock) DeleteSecretWithOptions(
+	_ context.Context, name string, recoveryWindow *int64, force bool,
+) (*driver.SecretInfo, string, error) {
+	if force && recoveryWindow != nil {
+		return nil, "", errors.New(errors.InvalidArgument,
+			"RecoveryWindowInDays can't be used together with ForceDeleteWithoutRecovery")
+	}
+
+	window := defaultRecoveryWindowDays
+
+	if recoveryWindow != nil {
+		if *recoveryWindow < minRecoveryWindowDays || *recoveryWindow > maxRecoveryWindowDays {
+			return nil, "", errors.New(errors.InvalidArgument,
+				"RecoveryWindowInDays must be between 7 and 30 days")
+		}
+
+		window = int(*recoveryWindow)
+	}
+
 	sd, ok := m.secrets.Get(name)
 	if !ok {
-		return errors.Newf(errors.NotFound, "secret %q not found", name)
+		return nil, "", errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	now := m.opts.Clock.Now().UTC()
+
+	if force {
+		sd.mu.RLock()
+		info := sd.info
+		sd.mu.RUnlock()
+
+		m.secrets.Delete(name)
+
+		return &info, now.Format(time.RFC3339), nil
 	}
 
 	sd.mu.Lock()
 	defer sd.mu.Unlock()
 
 	if !sd.deletedAt.IsZero() {
-		return errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+		return nil, "", errors.Newf(errors.FailedPrecondition,
+			"You can't perform this operation on the secret because it was marked for deletion.")
 	}
 
-	sd.deletedAt = m.opts.Clock.Now().UTC()
+	sd.deletedAt = now
+	sd.recoveryWindow = window
+	info := sd.info
 
-	return nil
+	return &info, now.AddDate(0, 0, window).Format(time.RFC3339), nil
 }
 
 // GetSecret retrieves secret metadata by name.
@@ -118,7 +184,8 @@ func (m *Mock) GetSecret(_ context.Context, name string) (*driver.SecretInfo, er
 	defer sd.mu.RUnlock()
 
 	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+		return nil, errors.New(errors.FailedPrecondition,
+			"secret is scheduled for deletion, so this operation is not allowed")
 	}
 
 	result := sd.info
@@ -154,7 +221,8 @@ func (m *Mock) PutSecretValue(_ context.Context, name string, value []byte) (*dr
 	defer sd.mu.Unlock()
 
 	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+		return nil, errors.New(errors.FailedPrecondition,
+			"secret is scheduled for deletion, so this operation is not allowed")
 	}
 
 	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
@@ -194,7 +262,8 @@ func (m *Mock) GetSecretValue(_ context.Context, name, versionID string) (*drive
 	defer sd.mu.RUnlock()
 
 	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+		return nil, errors.New(errors.FailedPrecondition,
+			"secret is scheduled for deletion, so this operation is not allowed")
 	}
 
 	for _, v := range sd.versions {
@@ -233,7 +302,8 @@ func (m *Mock) ListSecretVersions(_ context.Context, name string) ([]driver.Secr
 	defer sd.mu.RUnlock()
 
 	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+		return nil, errors.New(errors.FailedPrecondition,
+			"secret is scheduled for deletion, so this operation is not allowed")
 	}
 
 	versions := make([]driver.SecretVersion, len(sd.versions))

--- a/providers/aws/secretsmanager/staging.go
+++ b/providers/aws/secretsmanager/staging.go
@@ -9,13 +9,10 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
 )
 
-// Version stage labels and the default soft-delete recovery window, matching
-// real Secrets Manager staging and DeleteSecret semantics.
+// Version stage labels, matching real Secrets Manager staging semantics.
 const (
 	stageCurrent  = "AWSCURRENT"
 	stagePrevious = "AWSPREVIOUS"
-
-	recoveryWindowDays = 30
 )
 
 // currentIndex returns the index of the current version, or -1 if none.
@@ -64,7 +61,8 @@ func (m *Mock) GetSecretValueStage(_ context.Context, name, versionID, stage str
 	defer sd.mu.RUnlock()
 
 	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+		return nil, errors.New(errors.FailedPrecondition,
+			"secret is scheduled for deletion, so this operation is not allowed")
 	}
 
 	if versionID != "" {
@@ -136,7 +134,25 @@ func (m *Mock) SecretDeletionDate(_ context.Context, name string) (string, bool)
 		return "", false
 	}
 
-	return sd.deletedAt.AddDate(0, 0, recoveryWindowDays).UTC().Format(time.RFC3339), true
+	return sd.deletedAt.AddDate(0, 0, sd.recoveryWindow).UTC().Format(time.RFC3339), true
+}
+
+// SecretMetadata returns a secret's metadata even when it is scheduled for
+// deletion, so DescribeSecret can report a soft-deleted secret (real Secrets
+// Manager keeps DescribeSecret working, returning DeletedDate, until the secret
+// is permanently removed). ResourceNotFoundException only for a missing secret.
+func (m *Mock) SecretMetadata(_ context.Context, name string) (*driver.SecretInfo, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	result := sd.info
+
+	return &result, nil
 }
 
 // RestoreSecret cancels a scheduled deletion, making the secret usable again.
@@ -170,7 +186,8 @@ func (m *Mock) RotateSecret(_ context.Context, name string) (*driver.SecretVersi
 	defer sd.mu.Unlock()
 
 	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+		return nil, errors.New(errors.FailedPrecondition,
+			"secret is scheduled for deletion, so this operation is not allowed")
 	}
 
 	cur := currentIndex(sd.versions)

--- a/providers/aws/secretsmanager/update.go
+++ b/providers/aws/secretsmanager/update.go
@@ -23,7 +23,8 @@ func (m *Mock) UpdateSecret(_ context.Context, name, description string, value [
 	defer sd.mu.Unlock()
 
 	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+		return nil, errors.New(errors.FailedPrecondition,
+			"secret is scheduled for deletion, so this operation is not allowed")
 	}
 
 	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)

--- a/server/aws/secretsmanager/delete_secret_test.go
+++ b/server/aws/secretsmanager/delete_secret_test.go
@@ -1,0 +1,197 @@
+package secretsmanager_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssm "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+)
+
+// TestSDKDescribeSecretScheduledForDeletion guards that DescribeSecret keeps
+// working for a secret scheduled for deletion, returning 200 with DeletedDate
+// set rather than ResourceNotFoundException.
+func TestSDKDescribeSecretScheduledForDeletion(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("svc/db"), SecretString: aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	if _, err := client.DeleteSecret(ctx, &awssm.DeleteSecretInput{SecretId: aws.String("svc/db")}); err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+
+	desc, err := client.DescribeSecret(ctx, &awssm.DescribeSecretInput{SecretId: aws.String("svc/db")})
+	if err != nil {
+		t.Fatalf("DescribeSecret on scheduled-for-deletion secret: %v", err)
+	}
+
+	if desc.DeletedDate == nil {
+		t.Fatal("DescribeSecret: DeletedDate not set for a scheduled-for-deletion secret")
+	}
+}
+
+// TestSDKGetPutValueScheduledForDeletion guards that GetSecretValue and
+// PutSecretValue on a secret scheduled for deletion return
+// InvalidRequestException, not ResourceNotFoundException.
+func TestSDKGetPutValueScheduledForDeletion(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("svc/db"), SecretString: aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	if _, err := client.DeleteSecret(ctx, &awssm.DeleteSecretInput{SecretId: aws.String("svc/db")}); err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+
+	var invalidReq *smtypes.InvalidRequestException
+
+	if _, err := client.GetSecretValue(ctx, &awssm.GetSecretValueInput{
+		SecretId: aws.String("svc/db"),
+	}); !errors.As(err, &invalidReq) {
+		t.Fatalf("GetSecretValue(scheduled for deletion): got %v, want InvalidRequestException", err)
+	}
+
+	if _, err := client.PutSecretValue(ctx, &awssm.PutSecretValueInput{
+		SecretId: aws.String("svc/db"), SecretString: aws.String("v2"),
+	}); !errors.As(err, &invalidReq) {
+		t.Fatalf("PutSecretValue(scheduled for deletion): got %v, want InvalidRequestException", err)
+	}
+}
+
+// TestSDKForceDeleteWithoutRecovery guards that ForceDeleteWithoutRecovery
+// permanently removes the secret so RestoreSecret afterwards fails.
+func TestSDKForceDeleteWithoutRecovery(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("force/me"), SecretString: aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	if _, err := client.DeleteSecret(ctx, &awssm.DeleteSecretInput{
+		SecretId: aws.String("force/me"), ForceDeleteWithoutRecovery: aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("DeleteSecret(force): %v", err)
+	}
+
+	var notFound *smtypes.ResourceNotFoundException
+
+	if _, err := client.RestoreSecret(ctx, &awssm.RestoreSecretInput{
+		SecretId: aws.String("force/me"),
+	}); !errors.As(err, &notFound) {
+		t.Fatalf("RestoreSecret after force delete: got %v, want ResourceNotFoundException", err)
+	}
+}
+
+// TestSDKDeleteSecretRecoveryWindowHonored guards that RecoveryWindowInDays
+// drives the returned DeletionDate: a 7-day and a 30-day window produce
+// DeletionDates ~23 days apart.
+func TestSDKDeleteSecretRecoveryWindowHonored(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("win/me"), SecretString: aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	del7, err := client.DeleteSecret(ctx, &awssm.DeleteSecretInput{
+		SecretId: aws.String("win/me"), RecoveryWindowInDays: aws.Int64(7),
+	})
+	if err != nil {
+		t.Fatalf("DeleteSecret(7): %v", err)
+	}
+
+	if _, err := client.RestoreSecret(ctx, &awssm.RestoreSecretInput{SecretId: aws.String("win/me")}); err != nil {
+		t.Fatalf("RestoreSecret: %v", err)
+	}
+
+	del30, err := client.DeleteSecret(ctx, &awssm.DeleteSecretInput{
+		SecretId: aws.String("win/me"), RecoveryWindowInDays: aws.Int64(30),
+	})
+	if err != nil {
+		t.Fatalf("DeleteSecret(30): %v", err)
+	}
+
+	if del7.DeletionDate == nil || del30.DeletionDate == nil {
+		t.Fatal("DeleteSecret returned nil DeletionDate")
+	}
+
+	delta := del30.DeletionDate.Sub(*del7.DeletionDate)
+	if delta < 22*24*time.Hour || delta > 24*24*time.Hour {
+		t.Fatalf("DeletionDate delta between 7 and 30 day window = %v, want ~23 days", delta)
+	}
+}
+
+// TestSDKDeleteSecretParameterValidation guards the two DeleteSecret parameter
+// rules: RecoveryWindowInDays and ForceDeleteWithoutRecovery are mutually
+// exclusive, and RecoveryWindowInDays must be within 7-30.
+func TestSDKDeleteSecretParameterValidation(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"both/me", "range/me"} {
+		if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+			Name: aws.String(name), SecretString: aws.String("v1"),
+		}); err != nil {
+			t.Fatalf("CreateSecret(%s): %v", name, err)
+		}
+	}
+
+	var invalidParam *smtypes.InvalidParameterException
+
+	if _, err := client.DeleteSecret(ctx, &awssm.DeleteSecretInput{
+		SecretId:                   aws.String("both/me"),
+		RecoveryWindowInDays:       aws.Int64(10),
+		ForceDeleteWithoutRecovery: aws.Bool(true),
+	}); !errors.As(err, &invalidParam) {
+		t.Fatalf("DeleteSecret(both params): got %v, want InvalidParameterException", err)
+	}
+
+	if _, err := client.DeleteSecret(ctx, &awssm.DeleteSecretInput{
+		SecretId: aws.String("range/me"), RecoveryWindowInDays: aws.Int64(3),
+	}); !errors.As(err, &invalidParam) {
+		t.Fatalf("DeleteSecret(window=3): got %v, want InvalidParameterException", err)
+	}
+}
+
+// TestSDKCreateSecretScheduledForDeletion guards that CreateSecret for a name
+// currently scheduled for deletion returns InvalidRequestException, not
+// ResourceExistsException.
+func TestSDKCreateSecretScheduledForDeletion(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("svc/db"), SecretString: aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	if _, err := client.DeleteSecret(ctx, &awssm.DeleteSecretInput{SecretId: aws.String("svc/db")}); err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+
+	var invalidReq *smtypes.InvalidRequestException
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("svc/db"), SecretString: aws.String("v2"),
+	}); !errors.As(err, &invalidReq) {
+		t.Fatalf("CreateSecret(name scheduled for deletion): got %v, want InvalidRequestException", err)
+	}
+}

--- a/server/aws/secretsmanager/handler.go
+++ b/server/aws/secretsmanager/handler.go
@@ -37,6 +37,10 @@ type secretStager interface {
 	GetSecretValueStage(ctx context.Context, name, versionID, stage string) (*secretsdriver.SecretVersion, error)
 	SecretVersionStages(ctx context.Context, name string) (map[string][]string, error)
 	SecretDeletionDate(ctx context.Context, name string) (string, bool)
+	SecretMetadata(ctx context.Context, name string) (*secretsdriver.SecretInfo, error)
+	DeleteSecretWithOptions(
+		ctx context.Context, name string, recoveryWindow *int64, force bool,
+	) (*secretsdriver.SecretInfo, string, error)
 	RestoreSecret(ctx context.Context, name string) (*secretsdriver.SecretInfo, error)
 	RotateSecret(ctx context.Context, name string) (*secretsdriver.SecretVersion, error)
 }

--- a/server/aws/secretsmanager/operations.go
+++ b/server/aws/secretsmanager/operations.go
@@ -41,15 +41,34 @@ func (h *Handler) createSecret(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) deleteSecret(w http.ResponseWriter, r *http.Request) {
-	var req secretIDRequest
+	var req deleteSecretRequest
 	if !wire.DecodeJSON(w, r, &req) {
 		return
 	}
 
 	name := resolveSecretID(req.SecretID)
 
-	// Secrets Manager echoes the deleted secret's ARN and name, so capture
-	// them before removal.
+	// The AWS provider honors RecoveryWindowInDays / ForceDeleteWithoutRecovery
+	// and validates them; drivers without the stager surface fall back to a
+	// plain soft delete.
+	st, ok := h.secrets.(secretStager)
+	if !ok {
+		h.deleteSecretFallback(w, r, name)
+		return
+	}
+
+	info, date, err := st.DeleteSecretWithOptions(r.Context(), name, req.RecoveryWindowInDays, req.ForceDeleteWithoutRecovery)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, deleteSecretResponse{ARN: info.ResourceID, Name: info.Name, DeletionDate: epochSeconds(date)})
+}
+
+// deleteSecretFallback handles DeleteSecret for drivers that don't implement the
+// AWS stager surface (Azure/GCP), using the portable soft delete.
+func (h *Handler) deleteSecretFallback(w http.ResponseWriter, r *http.Request, name string) {
 	info, err := h.secrets.GetSecret(r.Context(), name)
 	if err != nil {
 		writeErr(w, err)
@@ -61,15 +80,7 @@ func (h *Handler) deleteSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := deleteSecretResponse{ARN: info.ResourceID, Name: info.Name}
-
-	if st, ok := h.secrets.(secretStager); ok {
-		if date, deleted := st.SecretDeletionDate(r.Context(), name); deleted {
-			out.DeletionDate = epochSeconds(date)
-		}
-	}
-
-	wire.WriteJSON(w, out)
+	wire.WriteJSON(w, deleteSecretResponse{ARN: info.ResourceID, Name: info.Name})
 }
 
 func (h *Handler) describeSecret(w http.ResponseWriter, r *http.Request) {
@@ -80,7 +91,22 @@ func (h *Handler) describeSecret(w http.ResponseWriter, r *http.Request) {
 
 	name := resolveSecretID(req.SecretID)
 
-	info, err := h.secrets.GetSecret(r.Context(), name)
+	// DescribeSecret keeps working for a secret scheduled for deletion (returning
+	// a DeletedDate); only a missing secret is ResourceNotFoundException. Use the
+	// stager's metadata read, which does not error on the soft-deleted state.
+	st, isStager := h.secrets.(secretStager)
+
+	var (
+		info *secretsdriver.SecretInfo
+		err  error
+	)
+
+	if isStager {
+		info, err = st.SecretMetadata(r.Context(), name)
+	} else {
+		info, err = h.secrets.GetSecret(r.Context(), name)
+	}
+
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -88,9 +114,13 @@ func (h *Handler) describeSecret(w http.ResponseWriter, r *http.Request) {
 
 	out := toSecretListEntry(info)
 
-	if st, ok := h.secrets.(secretStager); ok {
+	if isStager {
 		if stages, serr := st.SecretVersionStages(r.Context(), name); serr == nil {
 			out.VersionIDsToStages = stages
+		}
+
+		if date, deleted := st.SecretDeletionDate(r.Context(), name); deleted {
+			out.DeletedDate = epochSeconds(date)
 		}
 	}
 

--- a/server/aws/secretsmanager/sdk_roundtrip_test.go
+++ b/server/aws/secretsmanager/sdk_roundtrip_test.go
@@ -91,8 +91,15 @@ func TestSDKSecretLifecycle(t *testing.T) {
 		t.Fatalf("DeleteSecret echoed name %q", aws.ToString(deleted.Name))
 	}
 
-	if _, err := client.DescribeSecret(ctx, &awssm.DescribeSecretInput{SecretId: aws.String("db-password")}); err == nil {
-		t.Fatal("DescribeSecret after delete: want error, got nil")
+	// DescribeSecret keeps working after DeleteSecret and reports DeletedDate;
+	// only a never-created secret is ResourceNotFoundException.
+	descDeleted, err := client.DescribeSecret(ctx, &awssm.DescribeSecretInput{SecretId: aws.String("db-password")})
+	if err != nil {
+		t.Fatalf("DescribeSecret after delete: %v", err)
+	}
+
+	if descDeleted.DeletedDate == nil {
+		t.Fatal("DescribeSecret after delete: DeletedDate not set")
 	}
 }
 

--- a/server/aws/secretsmanager/types.go
+++ b/server/aws/secretsmanager/types.go
@@ -26,6 +26,9 @@ type secretListEntryJSON struct {
 	Tags            []tagJSON `json:"Tags,omitempty"`
 	CreatedDate     float64   `json:"CreatedDate,omitempty"`
 	LastChangedDate float64   `json:"LastChangedDate,omitempty"`
+	// DeletedDate is set only for a secret scheduled for deletion: the date the
+	// secret is scheduled to be removed (delete request + RecoveryWindowInDays).
+	DeletedDate float64 `json:"DeletedDate,omitempty"`
 
 	VersionIDsToStages map[string][]string `json:"VersionIdsToStages,omitempty"`
 }
@@ -48,6 +51,15 @@ type createSecretRequest struct {
 
 type secretIDRequest struct {
 	SecretID string `json:"SecretId"`
+}
+
+type deleteSecretRequest struct {
+	SecretID string `json:"SecretId"`
+	// RecoveryWindowInDays is a pointer so an absent field (nil) is
+	// distinguishable from an explicit 0 — the latter is an invalid value AWS
+	// rejects, while nil applies the default recovery window.
+	RecoveryWindowInDays       *int64 `json:"RecoveryWindowInDays"`
+	ForceDeleteWithoutRecovery bool   `json:"ForceDeleteWithoutRecovery"`
 }
 
 type getSecretValueRequest struct {


### PR DESCRIPTION
## Summary

Fixes six confirmed real-AWS divergences in Secrets Manager, all around the scheduled-for-deletion lifecycle and `DeleteSecret` parameters. State/lifecycle/validation live in the provider; wire parsing/dispatch in the server handler. No shared driver interface changed — the AWS-only surface is added to the local `secretStager` optional interface in the wire package.

## Findings fixed

1. **DescribeSecret on a scheduled-for-deletion secret** now returns HTTP 200 with `DeletedDate` set instead of `ResourceNotFoundException`. Added `SecretMetadata` (reads metadata even when soft-deleted) and a `DeletedDate` response field; `ResourceNotFoundException` is now reserved for a secret that never existed.
2. **GetSecretValue / PutSecretValue on a scheduled-for-deletion secret** now return `InvalidRequestException` (was `ResourceNotFoundException`). The provider's "scheduled for deletion" errors are now `FailedPrecondition`, which the handler maps to `InvalidRequestException`.
3. **DeleteSecret ForceDeleteWithoutRecovery=true** now permanently removes the secret; a subsequent `RestoreSecret` fails with `ResourceNotFoundException` (previously the flag was silently dropped and the secret stayed fully recoverable).
4. **DeleteSecret RecoveryWindowInDays** is now honored: `DeletionDate = now + RecoveryWindowInDays` (7-30, default 30). A 7-day and a 30-day request now produce DeletionDates ~23 days apart (was hard-coded to 30).
5. **DeleteSecret parameter validation**: supplying both `RecoveryWindowInDays` and `ForceDeleteWithoutRecovery`, or a window outside 7-30, now returns `InvalidParameterException` (both were previously accepted with 200 because neither field was decoded).
6. **CreateSecret for a name currently scheduled for deletion** now returns `InvalidRequestException` (was `ResourceExistsException`).

## How

- `providers/aws/secretsmanager`: added `DeleteSecretWithOptions` (recovery-window + force, with validation), `SecretMetadata`; per-secret recovery window stored on `secretData`; `CreateSecret` distinguishes a soft-deleted name; "scheduled for deletion" errors switched to `FailedPrecondition`.
- `server/aws/secretsmanager`: `DeleteSecret` handler decodes `RecoveryWindowInDays`/`ForceDeleteWithoutRecovery` and routes through the stager; `DescribeSecret` reads metadata for soft-deleted secrets and emits `DeletedDate`.
- The mandatory portable `driver.Secrets` interface is unchanged; the AWS-only methods are type-asserted via the wire-local `secretStager`.

## Tests

Added `server/aws/secretsmanager/delete_secret_test.go` — aws-sdk-go-v2 round-trip tests against `httptest` covering each finding; each fails without the corresponding fix. Updated the existing lifecycle assertion that encoded the old (wrong) describe-after-delete behavior.

Gates: `go build ./...`, provider + server package tests, and the compat suite (`go test ./compat/...`) all pass; golangci-lint adds 0 new issues on the changed packages.
