### PR TITLE
fix(iam): match real AWS behavior for delete guards and group/user policies

### DIFF
--- a/providers/aws/iam/group_policy.go
+++ b/providers/aws/iam/group_policy.go
@@ -1,0 +1,131 @@
+package iam
+
+import (
+	"context"
+	"sort"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+)
+
+// AttachGroupPolicy attaches a managed policy to a group (IAM
+// AttachGroupPolicy).
+func (m *Mock) AttachGroupPolicy(_ context.Context, groupName, policyARN string) error {
+	return m.attachPolicy(m.groups, groupName, policyARN, m.groupPolicies, "group")
+}
+
+// DetachGroupPolicy detaches a managed policy from a group (IAM
+// DetachGroupPolicy).
+func (m *Mock) DetachGroupPolicy(_ context.Context, groupName, policyARN string) error {
+	if !m.groups.Has(groupName) {
+		return errors.Newf(errors.NotFound, "group %q not found", groupName)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	policies, ok := m.groupPolicies[groupName]
+	if !ok || !policies[policyARN] {
+		return errors.Newf(errors.NotFound, "policy %q is not attached to group %q", policyARN, groupName)
+	}
+
+	delete(policies, policyARN)
+
+	return nil
+}
+
+// ListAttachedGroupPolicies returns the ARNs of managed policies attached to
+// the given group (IAM ListAttachedGroupPolicies).
+func (m *Mock) ListAttachedGroupPolicies(_ context.Context, groupName string) ([]string, error) {
+	if !m.groups.Has(groupName) {
+		return nil, errors.Newf(errors.NotFound, "group %q not found", groupName)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	policies := m.groupPolicies[groupName]
+	result := make([]string, 0, len(policies))
+
+	for arn := range policies {
+		result = append(result, arn)
+	}
+
+	sort.Strings(result)
+
+	return result, nil
+}
+
+// PutGroupPolicy adds or replaces an inline policy on a group (IAM
+// PutGroupPolicy).
+func (m *Mock) PutGroupPolicy(_ context.Context, groupName, policyName, policyDocument string) error {
+	if !m.groups.Has(groupName) {
+		return errors.Newf(errors.NotFound, "group %q not found", groupName)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.groupInlinePolicies[groupName] == nil {
+		m.groupInlinePolicies[groupName] = make(map[string]string)
+	}
+
+	m.groupInlinePolicies[groupName][policyName] = policyDocument
+
+	return nil
+}
+
+// GetGroupPolicy returns an inline policy document by name (IAM GetGroupPolicy).
+func (m *Mock) GetGroupPolicy(_ context.Context, groupName, policyName string) (string, error) {
+	if !m.groups.Has(groupName) {
+		return "", errors.Newf(errors.NotFound, "group %q not found", groupName)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	doc, ok := m.groupInlinePolicies[groupName][policyName]
+	if !ok {
+		return "", errors.Newf(errors.NotFound, "policy %q not found on group %q", policyName, groupName)
+	}
+
+	return doc, nil
+}
+
+// DeleteGroupPolicy removes an inline policy from a group (IAM
+// DeleteGroupPolicy).
+func (m *Mock) DeleteGroupPolicy(_ context.Context, groupName, policyName string) error {
+	if !m.groups.Has(groupName) {
+		return errors.Newf(errors.NotFound, "group %q not found", groupName)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.groupInlinePolicies[groupName][policyName]; !ok {
+		return errors.Newf(errors.NotFound, "policy %q not found on group %q", policyName, groupName)
+	}
+
+	delete(m.groupInlinePolicies[groupName], policyName)
+
+	return nil
+}
+
+// ListGroupPolicies returns the names of a group's inline policies, sorted (IAM
+// ListGroupPolicies).
+func (m *Mock) ListGroupPolicies(_ context.Context, groupName string) ([]string, error) {
+	if !m.groups.Has(groupName) {
+		return nil, errors.Newf(errors.NotFound, "group %q not found", groupName)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	names := make([]string, 0, len(m.groupInlinePolicies[groupName]))
+	for name := range m.groupInlinePolicies[groupName] {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names, nil
+}

--- a/providers/aws/iam/iam.go
+++ b/providers/aws/iam/iam.go
@@ -33,10 +33,14 @@ type Mock struct {
 	accessKeys       *memstore.Store[*accessKeyData]
 	instanceProfiles *memstore.Store[*driver.InstanceProfileInfo]
 
-	mu           sync.RWMutex
-	userPolicies map[string]map[string]bool // userName -> set of policy ARNs
-	rolePolicies map[string]map[string]bool // roleName -> set of policy ARNs
-	groupUsers   map[string]map[string]bool // groupName -> set of userNames
+	mu            sync.RWMutex
+	userPolicies  map[string]map[string]bool // userName -> set of managed policy ARNs
+	rolePolicies  map[string]map[string]bool // roleName -> set of managed policy ARNs
+	groupPolicies map[string]map[string]bool // groupName -> set of managed policy ARNs
+	groupUsers    map[string]map[string]bool // groupName -> set of userNames
+
+	userInlinePolicies  map[string]map[string]string // userName -> policyName -> document
+	groupInlinePolicies map[string]map[string]string // groupName -> policyName -> document
 
 	opts *config.Options
 }
@@ -100,16 +104,19 @@ type accessKeyData struct {
 // New creates a new IAM mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		users:            memstore.New[*userData](),
-		roles:            memstore.New[*roleData](),
-		policies:         memstore.New[*policyData](),
-		groups:           memstore.New[*groupData](),
-		accessKeys:       memstore.New[*accessKeyData](),
-		instanceProfiles: memstore.New[*driver.InstanceProfileInfo](),
-		userPolicies:     make(map[string]map[string]bool),
-		rolePolicies:     make(map[string]map[string]bool),
-		groupUsers:       make(map[string]map[string]bool),
-		opts:             opts,
+		users:               memstore.New[*userData](),
+		roles:               memstore.New[*roleData](),
+		policies:            memstore.New[*policyData](),
+		groups:              memstore.New[*groupData](),
+		accessKeys:          memstore.New[*accessKeyData](),
+		instanceProfiles:    memstore.New[*driver.InstanceProfileInfo](),
+		userPolicies:        make(map[string]map[string]bool),
+		rolePolicies:        make(map[string]map[string]bool),
+		groupPolicies:       make(map[string]map[string]bool),
+		groupUsers:          make(map[string]map[string]bool),
+		userInlinePolicies:  make(map[string]map[string]string),
+		groupInlinePolicies: make(map[string]map[string]string),
+		opts:                opts,
 	}
 }
 
@@ -164,6 +171,11 @@ func (m *Mock) DeleteUser(_ context.Context, name string) error {
 			"cannot delete user %q: managed policies are still attached (detach them first)", name)
 	}
 
+	if len(m.userInlinePolicies[name]) > 0 {
+		return errors.Newf(errors.FailedPrecondition,
+			"cannot delete user %q: inline policies still exist (delete them first)", name)
+	}
+
 	for _, members := range m.groupUsers {
 		if members[name] {
 			return errors.Newf(errors.FailedPrecondition,
@@ -180,6 +192,7 @@ func (m *Mock) DeleteUser(_ context.Context, name string) error {
 
 	m.users.Delete(name)
 	delete(m.userPolicies, name)
+	delete(m.userInlinePolicies, name)
 
 	return nil
 }
@@ -270,6 +283,14 @@ func (m *Mock) DeleteRole(_ context.Context, name string) error {
 	if len(role.inlinePolicies) > 0 {
 		return errors.Newf(errors.FailedPrecondition,
 			"cannot delete role %q: inline policies still exist (delete them first)", name)
+	}
+
+	for _, p := range m.instanceProfiles.All() {
+		if p.RoleName == name {
+			return errors.Newf(errors.FailedPrecondition,
+				"cannot delete role %q: it is still associated with instance profile %q "+
+					"(remove it with RemoveRoleFromInstanceProfile first)", name, p.Name)
+		}
 	}
 
 	m.roles.Delete(name)
@@ -898,15 +919,34 @@ func (m *Mock) CreateGroup(
 
 // DeleteGroup deletes the IAM group with the given name.
 func (m *Mock) DeleteGroup(_ context.Context, name string) error {
-	if !m.groups.Delete(name) {
+	if !m.groups.Has(name) {
 		return errors.Newf(
 			errors.NotFound, "group %q not found", name,
 		)
 	}
 
 	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(m.groupUsers[name]) > 0 {
+		return errors.Newf(errors.FailedPrecondition,
+			"cannot delete group %q: it still has member users (remove them first)", name)
+	}
+
+	if len(m.groupPolicies[name]) > 0 {
+		return errors.Newf(errors.FailedPrecondition,
+			"cannot delete group %q: managed policies are still attached (detach them first)", name)
+	}
+
+	if len(m.groupInlinePolicies[name]) > 0 {
+		return errors.Newf(errors.FailedPrecondition,
+			"cannot delete group %q: inline policies still exist (delete them first)", name)
+	}
+
+	m.groups.Delete(name)
 	delete(m.groupUsers, name)
-	m.mu.Unlock()
+	delete(m.groupPolicies, name)
+	delete(m.groupInlinePolicies, name)
 
 	return nil
 }
@@ -1181,12 +1221,21 @@ func (m *Mock) CreateInstanceProfile(
 func (m *Mock) DeleteInstanceProfile(
 	_ context.Context, name string,
 ) error {
-	if !m.instanceProfiles.Delete(name) {
+	p, ok := m.instanceProfiles.Get(name)
+	if !ok {
 		return errors.Newf(
 			errors.NotFound,
 			"instance profile %q not found", name,
 		)
 	}
+
+	if p.RoleName != "" {
+		return errors.Newf(errors.FailedPrecondition,
+			"cannot delete instance profile %q: role %q is still associated "+
+				"(remove it with RemoveRoleFromInstanceProfile first)", name, p.RoleName)
+	}
+
+	m.instanceProfiles.Delete(name)
 
 	return nil
 }

--- a/providers/aws/iam/user_policy.go
+++ b/providers/aws/iam/user_policy.go
@@ -1,0 +1,83 @@
+package iam
+
+import (
+	"context"
+	"sort"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+)
+
+// PutUserPolicy adds or replaces an inline policy on a user (IAM
+// PutUserPolicy). Inline policies are embedded in the user, distinct from the
+// managed policies attached via AttachUserPolicy.
+func (m *Mock) PutUserPolicy(_ context.Context, userName, policyName, policyDocument string) error {
+	if !m.users.Has(userName) {
+		return errors.Newf(errors.NotFound, "user %q not found", userName)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.userInlinePolicies[userName] == nil {
+		m.userInlinePolicies[userName] = make(map[string]string)
+	}
+
+	m.userInlinePolicies[userName][policyName] = policyDocument
+
+	return nil
+}
+
+// GetUserPolicy returns an inline policy document by name (IAM GetUserPolicy).
+func (m *Mock) GetUserPolicy(_ context.Context, userName, policyName string) (string, error) {
+	if !m.users.Has(userName) {
+		return "", errors.Newf(errors.NotFound, "user %q not found", userName)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	doc, ok := m.userInlinePolicies[userName][policyName]
+	if !ok {
+		return "", errors.Newf(errors.NotFound, "policy %q not found on user %q", policyName, userName)
+	}
+
+	return doc, nil
+}
+
+// DeleteUserPolicy removes an inline policy from a user (IAM DeleteUserPolicy).
+func (m *Mock) DeleteUserPolicy(_ context.Context, userName, policyName string) error {
+	if !m.users.Has(userName) {
+		return errors.Newf(errors.NotFound, "user %q not found", userName)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.userInlinePolicies[userName][policyName]; !ok {
+		return errors.Newf(errors.NotFound, "policy %q not found on user %q", policyName, userName)
+	}
+
+	delete(m.userInlinePolicies[userName], policyName)
+
+	return nil
+}
+
+// ListUserPolicies returns the names of a user's inline policies, sorted (IAM
+// ListUserPolicies).
+func (m *Mock) ListUserPolicies(_ context.Context, userName string) ([]string, error) {
+	if !m.users.Has(userName) {
+		return nil, errors.Newf(errors.NotFound, "user %q not found", userName)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	names := make([]string, 0, len(m.userInlinePolicies[userName]))
+	for name := range m.userInlinePolicies[userName] {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names, nil
+}

--- a/server/aws/iam/deletion_guards_test.go
+++ b/server/aws/iam/deletion_guards_test.go
@@ -1,0 +1,137 @@
+package iam_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// TestSDKDeleteRoleWithInstanceProfile locks in that DeleteRole fails with
+// DeleteConflictException while the role is still associated with an instance
+// profile, matching API_DeleteRole (the caller must
+// RemoveRoleFromInstanceProfile first).
+func TestSDKDeleteRoleWithInstanceProfile(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("r1"),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	if _, err := client.CreateInstanceProfile(ctx, &iam.CreateInstanceProfileInput{
+		InstanceProfileName: aws.String("ip1"),
+	}); err != nil {
+		t.Fatalf("CreateInstanceProfile: %v", err)
+	}
+
+	if _, err := client.AddRoleToInstanceProfile(ctx, &iam.AddRoleToInstanceProfileInput{
+		InstanceProfileName: aws.String("ip1"),
+		RoleName:            aws.String("r1"),
+	}); err != nil {
+		t.Fatalf("AddRoleToInstanceProfile: %v", err)
+	}
+
+	_, err := client.DeleteRole(ctx, &iam.DeleteRoleInput{RoleName: aws.String("r1")})
+
+	var conflict *iamtypes.DeleteConflictException
+	if !errors.As(err, &conflict) {
+		t.Fatalf("DeleteRole while in instance profile: want DeleteConflictException, got %v", err)
+	}
+
+	// After removing the association the role should delete cleanly.
+	if _, err := client.RemoveRoleFromInstanceProfile(ctx, &iam.RemoveRoleFromInstanceProfileInput{
+		InstanceProfileName: aws.String("ip1"),
+		RoleName:            aws.String("r1"),
+	}); err != nil {
+		t.Fatalf("RemoveRoleFromInstanceProfile: %v", err)
+	}
+
+	if _, err := client.DeleteRole(ctx, &iam.DeleteRoleInput{RoleName: aws.String("r1")}); err != nil {
+		t.Fatalf("DeleteRole after removal: %v", err)
+	}
+}
+
+// TestSDKDeleteInstanceProfileWithRole locks in that DeleteInstanceProfile
+// fails with DeleteConflictException while a role is still associated, matching
+// API_DeleteInstanceProfile.
+func TestSDKDeleteInstanceProfileWithRole(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("r1"),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	if _, err := client.CreateInstanceProfile(ctx, &iam.CreateInstanceProfileInput{
+		InstanceProfileName: aws.String("ip1"),
+	}); err != nil {
+		t.Fatalf("CreateInstanceProfile: %v", err)
+	}
+
+	if _, err := client.AddRoleToInstanceProfile(ctx, &iam.AddRoleToInstanceProfileInput{
+		InstanceProfileName: aws.String("ip1"),
+		RoleName:            aws.String("r1"),
+	}); err != nil {
+		t.Fatalf("AddRoleToInstanceProfile: %v", err)
+	}
+
+	_, err := client.DeleteInstanceProfile(ctx, &iam.DeleteInstanceProfileInput{
+		InstanceProfileName: aws.String("ip1"),
+	})
+
+	var conflict *iamtypes.DeleteConflictException
+	if !errors.As(err, &conflict) {
+		t.Fatalf("DeleteInstanceProfile while role attached: want DeleteConflictException, got %v", err)
+	}
+
+	// The profile must still exist after the refused delete.
+	if _, err := client.GetInstanceProfile(ctx, &iam.GetInstanceProfileInput{
+		InstanceProfileName: aws.String("ip1"),
+	}); err != nil {
+		t.Fatalf("GetInstanceProfile after refused delete: %v", err)
+	}
+}
+
+// TestSDKDeleteGroupWithMember locks in that DeleteGroup fails with
+// DeleteConflictException while the group still has member users, matching
+// API_DeleteGroup.
+func TestSDKDeleteGroupWithMember(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateGroup(ctx, &iam.CreateGroupInput{GroupName: aws.String("g1")}); err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("u1")}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.AddUserToGroup(ctx, &iam.AddUserToGroupInput{
+		GroupName: aws.String("g1"), UserName: aws.String("u1"),
+	}); err != nil {
+		t.Fatalf("AddUserToGroup: %v", err)
+	}
+
+	_, err := client.DeleteGroup(ctx, &iam.DeleteGroupInput{GroupName: aws.String("g1")})
+
+	var conflict *iamtypes.DeleteConflictException
+	if !errors.As(err, &conflict) {
+		t.Fatalf("DeleteGroup with member: want DeleteConflictException, got %v", err)
+	}
+
+	// Group must survive the refused delete.
+	if _, err := client.GetGroup(ctx, &iam.GetGroupInput{GroupName: aws.String("g1")}); err != nil {
+		t.Fatalf("GetGroup after refused delete: %v", err)
+	}
+}

--- a/server/aws/iam/group_policy.go
+++ b/server/aws/iam/group_policy.go
@@ -1,0 +1,216 @@
+package iam
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+)
+
+type attachGroupPolicyResponse struct {
+	XMLName  xml.Name         `xml:"AttachGroupPolicyResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type detachGroupPolicyResponse struct {
+	XMLName  xml.Name         `xml:"DetachGroupPolicyResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type listAttachedGroupPoliciesResult struct {
+	AttachedPolicies attachedPoliciesXML `xml:"AttachedPolicies"`
+	IsTruncated      bool                `xml:"IsTruncated"`
+}
+
+type listAttachedGroupPoliciesResponse struct {
+	XMLName  xml.Name                        `xml:"ListAttachedGroupPoliciesResponse"`
+	Xmlns    string                          `xml:"xmlns,attr"`
+	Result   listAttachedGroupPoliciesResult `xml:"ListAttachedGroupPoliciesResult"`
+	Metadata responseMetadata                `xml:"ResponseMetadata"`
+}
+
+type putGroupPolicyResponse struct {
+	XMLName  xml.Name         `xml:"PutGroupPolicyResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type deleteGroupPolicyResponse struct {
+	XMLName  xml.Name         `xml:"DeleteGroupPolicyResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type getGroupPolicyResult struct {
+	GroupName      string `xml:"GroupName"`
+	PolicyName     string `xml:"PolicyName"`
+	PolicyDocument string `xml:"PolicyDocument"`
+}
+
+type getGroupPolicyResponse struct {
+	XMLName  xml.Name             `xml:"GetGroupPolicyResponse"`
+	Xmlns    string               `xml:"xmlns,attr"`
+	Result   getGroupPolicyResult `xml:"GetGroupPolicyResult"`
+	Metadata responseMetadata     `xml:"ResponseMetadata"`
+}
+
+type listGroupPoliciesResult struct {
+	PolicyNames []string `xml:"PolicyNames>member"`
+}
+
+type listGroupPoliciesResponse struct {
+	XMLName  xml.Name                `xml:"ListGroupPoliciesResponse"`
+	Xmlns    string                  `xml:"xmlns,attr"`
+	Result   listGroupPoliciesResult `xml:"ListGroupPoliciesResult"`
+	Metadata responseMetadata        `xml:"ResponseMetadata"`
+}
+
+func (h *Handler) groupPolicies() (groupPolicyManager, bool) {
+	pm, ok := h.iam.(groupPolicyManager)
+
+	return pm, ok
+}
+
+//nolint:dupl // per-entity policy wire handlers share shape but bind distinct actions/form fields and response envelopes.
+func (h *Handler) attachGroupPolicy(w http.ResponseWriter, r *http.Request) {
+	pm, ok := h.groupPolicies()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "group policies not supported"))
+		return
+	}
+
+	if err := pm.AttachGroupPolicy(r.Context(), r.Form.Get("GroupName"), r.Form.Get("PolicyArn")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, attachGroupPolicyResponse{
+		Xmlns: Namespace, Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+//nolint:dupl // per-entity policy wire handlers share shape but bind distinct actions/form fields and response envelopes.
+func (h *Handler) detachGroupPolicy(w http.ResponseWriter, r *http.Request) {
+	pm, ok := h.groupPolicies()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "group policies not supported"))
+		return
+	}
+
+	if err := pm.DetachGroupPolicy(r.Context(), r.Form.Get("GroupName"), r.Form.Get("PolicyArn")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, detachGroupPolicyResponse{
+		Xmlns: Namespace, Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) listAttachedGroupPolicies(w http.ResponseWriter, r *http.Request) {
+	pm, ok := h.groupPolicies()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "group policies not supported"))
+		return
+	}
+
+	arns, err := pm.ListAttachedGroupPolicies(r.Context(), r.Form.Get("GroupName"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, listAttachedGroupPoliciesResponse{
+		Xmlns: Namespace,
+		Result: listAttachedGroupPoliciesResult{
+			AttachedPolicies: attachedPoliciesFromARNs(arns),
+			IsTruncated:      false,
+		},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+//nolint:dupl // per-entity policy wire handlers share shape but bind distinct actions/form fields and response envelopes.
+func (h *Handler) putGroupPolicy(w http.ResponseWriter, r *http.Request) {
+	pm, ok := h.groupPolicies()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "group policies not supported"))
+		return
+	}
+
+	if err := pm.PutGroupPolicy(r.Context(),
+		r.Form.Get("GroupName"), r.Form.Get("PolicyName"), r.Form.Get("PolicyDocument")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, putGroupPolicyResponse{
+		Xmlns: Namespace, Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) getGroupPolicy(w http.ResponseWriter, r *http.Request) {
+	pm, ok := h.groupPolicies()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "group policies not supported"))
+		return
+	}
+
+	groupName := r.Form.Get("GroupName")
+	policyName := r.Form.Get("PolicyName")
+
+	doc, err := pm.GetGroupPolicy(r.Context(), groupName, policyName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, getGroupPolicyResponse{
+		Xmlns: Namespace,
+		Result: getGroupPolicyResult{
+			GroupName: groupName, PolicyName: policyName, PolicyDocument: doc,
+		},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+//nolint:dupl // per-entity policy wire handlers share shape but bind distinct actions/form fields and response envelopes.
+func (h *Handler) deleteGroupPolicy(w http.ResponseWriter, r *http.Request) {
+	pm, ok := h.groupPolicies()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "group policies not supported"))
+		return
+	}
+
+	if err := pm.DeleteGroupPolicy(r.Context(), r.Form.Get("GroupName"), r.Form.Get("PolicyName")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteGroupPolicyResponse{
+		Xmlns: Namespace, Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) listGroupPolicies(w http.ResponseWriter, r *http.Request) {
+	pm, ok := h.groupPolicies()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "group policies not supported"))
+		return
+	}
+
+	names, err := pm.ListGroupPolicies(r.Context(), r.Form.Get("GroupName"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, listGroupPoliciesResponse{
+		Xmlns:    Namespace,
+		Result:   listGroupPoliciesResult{PolicyNames: names},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}

--- a/server/aws/iam/group_policy_test.go
+++ b/server/aws/iam/group_policy_test.go
@@ -1,0 +1,117 @@
+package iam_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// TestSDKGroupManagedPolicy exercises AttachGroupPolicy /
+// ListAttachedGroupPolicies / DetachGroupPolicy end to end. Before the fix
+// these actions returned InvalidAction.
+func TestSDKGroupManagedPolicy(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateGroup(ctx, &iam.CreateGroupInput{GroupName: aws.String("g1")}); err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+
+	const arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+
+	if _, err := client.AttachGroupPolicy(ctx, &iam.AttachGroupPolicyInput{
+		GroupName: aws.String("g1"), PolicyArn: aws.String(arn),
+	}); err != nil {
+		t.Fatalf("AttachGroupPolicy: %v", err)
+	}
+
+	list, err := client.ListAttachedGroupPolicies(ctx, &iam.ListAttachedGroupPoliciesInput{
+		GroupName: aws.String("g1"),
+	})
+	if err != nil {
+		t.Fatalf("ListAttachedGroupPolicies: %v", err)
+	}
+
+	if len(list.AttachedPolicies) != 1 || aws.ToString(list.AttachedPolicies[0].PolicyArn) != arn {
+		t.Fatalf("ListAttachedGroupPolicies = %v", list.AttachedPolicies)
+	}
+
+	// DeleteGroup must be refused while a managed policy is attached.
+	_, err = client.DeleteGroup(ctx, &iam.DeleteGroupInput{GroupName: aws.String("g1")})
+
+	var conflict *iamtypes.DeleteConflictException
+	if !errors.As(err, &conflict) {
+		t.Fatalf("DeleteGroup with attached policy: want DeleteConflictException, got %v", err)
+	}
+
+	if _, err := client.DetachGroupPolicy(ctx, &iam.DetachGroupPolicyInput{
+		GroupName: aws.String("g1"), PolicyArn: aws.String(arn),
+	}); err != nil {
+		t.Fatalf("DetachGroupPolicy: %v", err)
+	}
+
+	if _, err := client.DeleteGroup(ctx, &iam.DeleteGroupInput{GroupName: aws.String("g1")}); err != nil {
+		t.Fatalf("DeleteGroup after detach: %v", err)
+	}
+}
+
+// TestSDKGroupInlinePolicy exercises PutGroupPolicy / GetGroupPolicy /
+// ListGroupPolicies / DeleteGroupPolicy end to end.
+func TestSDKGroupInlinePolicy(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateGroup(ctx, &iam.CreateGroupInput{GroupName: aws.String("g1")}); err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+
+	if _, err := client.PutGroupPolicy(ctx, &iam.PutGroupPolicyInput{
+		GroupName:      aws.String("g1"),
+		PolicyName:     aws.String("s3access"),
+		PolicyDocument: aws.String(samplePolicy),
+	}); err != nil {
+		t.Fatalf("PutGroupPolicy: %v", err)
+	}
+
+	list, err := client.ListGroupPolicies(ctx, &iam.ListGroupPoliciesInput{GroupName: aws.String("g1")})
+	if err != nil {
+		t.Fatalf("ListGroupPolicies: %v", err)
+	}
+
+	if len(list.PolicyNames) != 1 || list.PolicyNames[0] != "s3access" {
+		t.Fatalf("ListGroupPolicies = %v", list.PolicyNames)
+	}
+
+	got, err := client.GetGroupPolicy(ctx, &iam.GetGroupPolicyInput{
+		GroupName: aws.String("g1"), PolicyName: aws.String("s3access"),
+	})
+	if err != nil {
+		t.Fatalf("GetGroupPolicy: %v", err)
+	}
+
+	if aws.ToString(got.PolicyDocument) == "" {
+		t.Fatal("GetGroupPolicy returned empty document")
+	}
+
+	// DeleteGroup must be refused while an inline policy exists.
+	_, err = client.DeleteGroup(ctx, &iam.DeleteGroupInput{GroupName: aws.String("g1")})
+
+	var conflict *iamtypes.DeleteConflictException
+	if !errors.As(err, &conflict) {
+		t.Fatalf("DeleteGroup with inline policy: want DeleteConflictException, got %v", err)
+	}
+
+	if _, err := client.DeleteGroupPolicy(ctx, &iam.DeleteGroupPolicyInput{
+		GroupName: aws.String("g1"), PolicyName: aws.String("s3access"),
+	}); err != nil {
+		t.Fatalf("DeleteGroupPolicy: %v", err)
+	}
+
+	if _, err := client.DeleteGroup(ctx, &iam.DeleteGroupInput{GroupName: aws.String("g1")}); err != nil {
+		t.Fatalf("DeleteGroup after inline delete: %v", err)
+	}
+}

--- a/server/aws/iam/handler.go
+++ b/server/aws/iam/handler.go
@@ -80,6 +80,17 @@ var iamActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup
 	"GetRolePolicy":                  {},
 	"DeleteRolePolicy":               {},
 	"ListRolePolicies":               {},
+	"AttachGroupPolicy":              {},
+	"DetachGroupPolicy":              {},
+	"ListAttachedGroupPolicies":      {},
+	"PutGroupPolicy":                 {},
+	"GetGroupPolicy":                 {},
+	"DeleteGroupPolicy":              {},
+	"ListGroupPolicies":              {},
+	"PutUserPolicy":                  {},
+	"GetUserPolicy":                  {},
+	"DeleteUserPolicy":               {},
+	"ListUserPolicies":               {},
 	"TagRole":                        {},
 	"UntagRole":                      {},
 	"ListRoleTags":                   {},
@@ -104,6 +115,28 @@ type rolePolicyManager interface {
 	GetRolePolicy(ctx context.Context, roleName, policyName string) (string, error)
 	DeleteRolePolicy(ctx context.Context, roleName, policyName string) error
 	ListRolePolicies(ctx context.Context, roleName string) ([]string, error)
+}
+
+// groupPolicyManager is the AWS-specific group managed- and inline-policy
+// surface. It's not part of the portable IAM driver, so the handler
+// type-asserts for it.
+type groupPolicyManager interface {
+	AttachGroupPolicy(ctx context.Context, groupName, policyARN string) error
+	DetachGroupPolicy(ctx context.Context, groupName, policyARN string) error
+	ListAttachedGroupPolicies(ctx context.Context, groupName string) ([]string, error)
+	PutGroupPolicy(ctx context.Context, groupName, policyName, policyDocument string) error
+	GetGroupPolicy(ctx context.Context, groupName, policyName string) (string, error)
+	DeleteGroupPolicy(ctx context.Context, groupName, policyName string) error
+	ListGroupPolicies(ctx context.Context, groupName string) ([]string, error)
+}
+
+// userPolicyManager is the AWS-specific inline-user-policy surface. It's not
+// part of the portable IAM driver, so the handler type-asserts for it.
+type userPolicyManager interface {
+	PutUserPolicy(ctx context.Context, userName, policyName, policyDocument string) error
+	GetUserPolicy(ctx context.Context, userName, policyName string) (string, error)
+	DeleteUserPolicy(ctx context.Context, userName, policyName string) error
+	ListUserPolicies(ctx context.Context, userName string) ([]string, error)
 }
 
 // defaultAccountID is used when the server was configured without one, so a
@@ -252,6 +285,28 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.deleteRolePolicy(w, r)
 	case "ListRolePolicies":
 		h.listRolePolicies(w, r)
+	case "AttachGroupPolicy":
+		h.attachGroupPolicy(w, r)
+	case "DetachGroupPolicy":
+		h.detachGroupPolicy(w, r)
+	case "ListAttachedGroupPolicies":
+		h.listAttachedGroupPolicies(w, r)
+	case "PutGroupPolicy":
+		h.putGroupPolicy(w, r)
+	case "GetGroupPolicy":
+		h.getGroupPolicy(w, r)
+	case "DeleteGroupPolicy":
+		h.deleteGroupPolicy(w, r)
+	case "ListGroupPolicies":
+		h.listGroupPolicies(w, r)
+	case "PutUserPolicy":
+		h.putUserPolicy(w, r)
+	case "GetUserPolicy":
+		h.getUserPolicy(w, r)
+	case "DeleteUserPolicy":
+		h.deleteUserPolicy(w, r)
+	case "ListUserPolicies":
+		h.listUserPolicies(w, r)
 	case "TagRole":
 		h.tagRole(w, r)
 	case "UntagRole":

--- a/server/aws/iam/user_policy.go
+++ b/server/aws/iam/user_policy.go
@@ -1,0 +1,132 @@
+//nolint:dupl // inline user-policy handlers mirror the role variant but bind distinct actions, form fields, and response envelopes.
+package iam
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+)
+
+type putUserPolicyResponse struct {
+	XMLName  xml.Name         `xml:"PutUserPolicyResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type deleteUserPolicyResponse struct {
+	XMLName  xml.Name         `xml:"DeleteUserPolicyResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type getUserPolicyResult struct {
+	UserName       string `xml:"UserName"`
+	PolicyName     string `xml:"PolicyName"`
+	PolicyDocument string `xml:"PolicyDocument"`
+}
+
+type getUserPolicyResponse struct {
+	XMLName  xml.Name            `xml:"GetUserPolicyResponse"`
+	Xmlns    string              `xml:"xmlns,attr"`
+	Result   getUserPolicyResult `xml:"GetUserPolicyResult"`
+	Metadata responseMetadata    `xml:"ResponseMetadata"`
+}
+
+type listUserPoliciesResult struct {
+	PolicyNames []string `xml:"PolicyNames>member"`
+}
+
+type listUserPoliciesResponse struct {
+	XMLName  xml.Name               `xml:"ListUserPoliciesResponse"`
+	Xmlns    string                 `xml:"xmlns,attr"`
+	Result   listUserPoliciesResult `xml:"ListUserPoliciesResult"`
+	Metadata responseMetadata       `xml:"ResponseMetadata"`
+}
+
+func (h *Handler) userPolicies() (userPolicyManager, bool) {
+	pm, ok := h.iam.(userPolicyManager)
+
+	return pm, ok
+}
+
+func (h *Handler) putUserPolicy(w http.ResponseWriter, r *http.Request) {
+	pm, ok := h.userPolicies()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "inline user policies not supported"))
+		return
+	}
+
+	if err := pm.PutUserPolicy(r.Context(),
+		r.Form.Get("UserName"), r.Form.Get("PolicyName"), r.Form.Get("PolicyDocument")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, putUserPolicyResponse{
+		Xmlns: Namespace, Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) getUserPolicy(w http.ResponseWriter, r *http.Request) {
+	pm, ok := h.userPolicies()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "inline user policies not supported"))
+		return
+	}
+
+	userName := r.Form.Get("UserName")
+	policyName := r.Form.Get("PolicyName")
+
+	doc, err := pm.GetUserPolicy(r.Context(), userName, policyName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, getUserPolicyResponse{
+		Xmlns: Namespace,
+		Result: getUserPolicyResult{
+			UserName: userName, PolicyName: policyName, PolicyDocument: doc,
+		},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) deleteUserPolicy(w http.ResponseWriter, r *http.Request) {
+	pm, ok := h.userPolicies()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "inline user policies not supported"))
+		return
+	}
+
+	if err := pm.DeleteUserPolicy(r.Context(), r.Form.Get("UserName"), r.Form.Get("PolicyName")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteUserPolicyResponse{
+		Xmlns: Namespace, Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) listUserPolicies(w http.ResponseWriter, r *http.Request) {
+	pm, ok := h.userPolicies()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "inline user policies not supported"))
+		return
+	}
+
+	names, err := pm.ListUserPolicies(r.Context(), r.Form.Get("UserName"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, listUserPoliciesResponse{
+		Xmlns:    Namespace,
+		Result:   listUserPoliciesResult{PolicyNames: names},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}

--- a/server/aws/iam/user_policy_test.go
+++ b/server/aws/iam/user_policy_test.go
@@ -1,0 +1,70 @@
+package iam_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// TestSDKUserInlinePolicy exercises PutUserPolicy / GetUserPolicy /
+// ListUserPolicies / DeleteUserPolicy end to end. Before the fix these actions
+// returned InvalidAction, and DeleteUser could not enforce the inline-policy
+// guard.
+func TestSDKUserInlinePolicy(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("u1")}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+		UserName:       aws.String("u1"),
+		PolicyName:     aws.String("s3access"),
+		PolicyDocument: aws.String(samplePolicy),
+	}); err != nil {
+		t.Fatalf("PutUserPolicy: %v", err)
+	}
+
+	list, err := client.ListUserPolicies(ctx, &iam.ListUserPoliciesInput{UserName: aws.String("u1")})
+	if err != nil {
+		t.Fatalf("ListUserPolicies: %v", err)
+	}
+
+	if len(list.PolicyNames) != 1 || list.PolicyNames[0] != "s3access" {
+		t.Fatalf("ListUserPolicies = %v", list.PolicyNames)
+	}
+
+	got, err := client.GetUserPolicy(ctx, &iam.GetUserPolicyInput{
+		UserName: aws.String("u1"), PolicyName: aws.String("s3access"),
+	})
+	if err != nil {
+		t.Fatalf("GetUserPolicy: %v", err)
+	}
+
+	if aws.ToString(got.PolicyDocument) == "" {
+		t.Fatal("GetUserPolicy returned empty document")
+	}
+
+	// DeleteUser must be refused while an inline policy exists.
+	_, err = client.DeleteUser(ctx, &iam.DeleteUserInput{UserName: aws.String("u1")})
+
+	var conflict *iamtypes.DeleteConflictException
+	if !errors.As(err, &conflict) {
+		t.Fatalf("DeleteUser with inline policy: want DeleteConflictException, got %v", err)
+	}
+
+	if _, err := client.DeleteUserPolicy(ctx, &iam.DeleteUserPolicyInput{
+		UserName: aws.String("u1"), PolicyName: aws.String("s3access"),
+	}); err != nil {
+		t.Fatalf("DeleteUserPolicy: %v", err)
+	}
+
+	if _, err := client.DeleteUser(ctx, &iam.DeleteUserInput{UserName: aws.String("u1")}); err != nil {
+		t.Fatalf("DeleteUser after inline delete: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes four confirmed real-AWS divergences in IAM found by the end-to-end audit. Each fix is covered by an aws-sdk-go-v2 round-trip test that fails without the change.

## Findings fixed

1. **DeleteRole — missing instance-profile guard.** Real IAM returns `DeleteConflict` (HTTP 409) while a role is still associated with an instance profile (the caller must `RemoveRoleFromInstanceProfile` first). cloudemu deleted the role and orphaned the profile. Added an instance-profile association check in `providers/aws/iam/iam.go` DeleteRole.

2. **DeleteInstanceProfile — missing role guard.** Real IAM returns `DeleteConflict` while a role is still associated ("The instance profile must not have an associated role."). cloudemu deleted it unconditionally. DeleteInstanceProfile now checks `RoleName` before deleting.

3. **DeleteGroup — missing member/policy guards.** Real IAM returns `DeleteConflict` while a group still has member users or attached/inline policies. cloudemu silently dropped the membership set and deleted the group. DeleteGroup now guards on member users, attached managed policies, and inline policies. DeleteUser likewise now guards on inline user policies.

4. **Group managed policies + group/user inline policies were unregistered wire actions.** `AttachGroupPolicy`, `DetachGroupPolicy`, `ListAttachedGroupPolicies`, `PutGroupPolicy`, `GetGroupPolicy`, `DeleteGroupPolicy`, `ListGroupPolicies`, `PutUserPolicy`, `GetUserPolicy`, `DeleteUserPolicy`, `ListUserPolicies` all returned `InvalidAction`. These are first-class IAM actions heavily used by IaC (Terraform `aws_iam_group_policy_attachment`, `aws_iam_user_policy`, `aws_iam_group_policy`). Implemented backend state + wire handlers for all of them. This is also what lets guards (3) enforce the "no attached policies" rules.

## Layering

- State, validation, and deletion/dependency guards: `providers/aws/iam`.
- Wire dispatch, serialization, error codes: `server/aws/iam`.
- The new group/user policy capabilities are AWS-only, exposed as type-asserted optional interfaces in `server/aws/iam/handler.go` (mirroring the existing `rolePolicyManager`) — no change to the shared `services/iam/driver` interface, so no coverage regeneration required.

Error mapping is unchanged: `FailedPrecondition` -> `DeleteConflict` (HTTP 409), matching the SDK's `DeleteConflictException`.

## Tests

- `server/aws/iam/deletion_guards_test.go` — DeleteRole/DeleteInstanceProfile/DeleteGroup conflict + recovery.
- `server/aws/iam/group_policy_test.go` — group managed + inline policy round-trips and delete guards.
- `server/aws/iam/user_policy_test.go` — user inline policy round-trip and delete guard.

Gates: `go build ./...`, `go test ./providers/aws/iam/... ./server/aws/iam/...`, and the compat suite `go test ./compat/...` all pass.
