### PR TITLE
fix(ec2-compute): match real AWS behavior for launch templates, snapshot/volume/keypair semantics

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -7952,7 +7952,7 @@ func testBucketTagging(t *testing.T, ctx context.Context, d storagedriver.Bucket
 }
 
 // testKeyPairOperations is a shared helper that tests key pair CRUD operations.
-func testKeyPairOperations(t *testing.T, ctx context.Context, c computedriver.Compute) {
+func testKeyPairOperations(t *testing.T, ctx context.Context, c computedriver.Compute, deleteMissingIsIdempotent bool) {
 	t.Helper()
 
 	// Create a key pair
@@ -8056,9 +8056,14 @@ func testKeyPairOperations(t *testing.T, ctx context.Context, c computedriver.Co
 		t.Fatalf("DeleteKeyPair: %v", err)
 	}
 
-	// Delete again should fail
+	// Delete again: AWS DeleteKeyPair is idempotent (returns success for a
+	// missing key), matching real EC2; other providers still error.
 	err = c.DeleteKeyPair(ctx, "test-key")
-	if err == nil {
+	if deleteMissingIsIdempotent {
+		if err != nil {
+			t.Errorf("DeleteKeyPair of a missing key should be idempotent, got %v", err)
+		}
+	} else if err == nil {
 		t.Error("expected error deleting non-existent key pair")
 	}
 
@@ -8076,19 +8081,19 @@ func testKeyPairOperations(t *testing.T, ctx context.Context, c computedriver.Co
 func TestKeyPairAWS(t *testing.T) {
 	ctx := context.Background()
 	p := NewAWS()
-	testKeyPairOperations(t, ctx, p.EC2)
+	testKeyPairOperations(t, ctx, p.EC2, true)
 }
 
 func TestKeyPairAzure(t *testing.T) {
 	ctx := context.Background()
 	p := NewAzure()
-	testKeyPairOperations(t, ctx, p.VirtualMachines)
+	testKeyPairOperations(t, ctx, p.VirtualMachines, false)
 }
 
 func TestKeyPairGCP(t *testing.T) {
 	ctx := context.Background()
 	p := NewGCP()
-	testKeyPairOperations(t, ctx, p.GCE)
+	testKeyPairOperations(t, ctx, p.GCE, false)
 }
 
 // ─── Global Secondary Indexes ───────────────────────────────────────────

--- a/docs/coverage/aws/ec2.md
+++ b/docs/coverage/aws/ec2.md
@@ -73,6 +73,14 @@ KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair
 | --- | --- |
 | `ImportKeyPair` |  |
 
+### LaunchTemplateModifier
+
+LaunchTemplateModifier is an AWS-only optional capability implementing
+
+| Operation | Description |
+| --- | --- |
+| `ModifyLaunchTemplate` |  |
+
 ### LaunchTemplateVersioner
 
 LaunchTemplateVersioner is an AWS-only optional capability implementing launch

--- a/docs/coverage/azure/virtualmachines.md
+++ b/docs/coverage/azure/virtualmachines.md
@@ -73,6 +73,14 @@ KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair
 | --- | --- |
 | `ImportKeyPair` |  |
 
+### LaunchTemplateModifier
+
+LaunchTemplateModifier is an AWS-only optional capability implementing
+
+| Operation | Description |
+| --- | --- |
+| `ModifyLaunchTemplate` |  |
+
 ### LaunchTemplateVersioner
 
 LaunchTemplateVersioner is an AWS-only optional capability implementing launch

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -1985,6 +1985,15 @@
         ]
       },
       {
+        "name": "LaunchTemplateModifier",
+        "doc": "LaunchTemplateModifier is an AWS-only optional capability implementing",
+        "operations": [
+          {
+            "name": "ModifyLaunchTemplate"
+          }
+        ]
+      },
+      {
         "name": "LaunchTemplateVersioner",
         "doc": "LaunchTemplateVersioner is an AWS-only optional capability implementing launch",
         "operations": [

--- a/docs/coverage/gcp/gce.md
+++ b/docs/coverage/gcp/gce.md
@@ -73,6 +73,14 @@ KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair
 | --- | --- |
 | `ImportKeyPair` |  |
 
+### LaunchTemplateModifier
+
+LaunchTemplateModifier is an AWS-only optional capability implementing
+
+| Operation | Description |
+| --- | --- |
+| `ModifyLaunchTemplate` |  |
+
 ### LaunchTemplateVersioner
 
 LaunchTemplateVersioner is an AWS-only optional capability implementing launch

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -1100,6 +1100,16 @@ func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device stri
 		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
 	}
 
+	// A volume can only attach to an instance in the SAME Availability Zone
+	// (real EC2 InvalidVolume.ZoneMismatch). Instances aren't placed in an
+	// explicit zone here, so they occupy the region's default zone, which is
+	// what CreateVolume also defaults to — an explicit cross-AZ volume mismatches.
+	if instZone := m.opts.Region + "a"; vol.AvailabilityZone != "" && vol.AvailabilityZone != instZone {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"ZoneMismatch: volume %q is in availability zone %q but instance %q is in %q",
+			volumeID, vol.AvailabilityZone, instanceID, instZone)
+	}
+
 	vol.State = stateInUse
 	vol.AttachedTo = instanceID
 	vol.Device = device
@@ -1154,13 +1164,37 @@ func (m *Mock) CreateSnapshot(_ context.Context, cfg driver.SnapshotConfig) (*dr
 	return &result, nil
 }
 
-// DeleteSnapshot deletes a snapshot.
+// DeleteSnapshot deletes a snapshot. A snapshot referenced by a registered
+// AMI's block device mapping cannot be deleted until the AMI is deregistered
+// (real EC2 InvalidSnapshot.InUse), so we guard against orphaning an AMI whose
+// backing snapshot was removed.
 func (m *Mock) DeleteSnapshot(_ context.Context, id string) error {
-	if !m.snapshots.Delete(id) {
+	if !m.snapshots.Has(id) {
 		return cerrors.Newf(cerrors.NotFound, "snapshot %q not found", id)
 	}
 
+	if ami := m.imageUsingSnapshot(id); ami != "" {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"InUse: snapshot %q is currently in use by %s", id, ami)
+	}
+
+	m.snapshots.Delete(id)
+
 	return nil
+}
+
+// imageUsingSnapshot returns the id of a registered AMI whose block device
+// mapping references the snapshot, or "" if none does.
+func (m *Mock) imageUsingSnapshot(snapshotID string) string {
+	for _, img := range m.images.All() {
+		for _, bdm := range img.BlockDeviceMappings {
+			if bdm.SnapshotID == snapshotID {
+				return img.ID
+			}
+		}
+	}
+
+	return ""
 }
 
 // DescribeSnapshots returns snapshots matching the given IDs. An explicit ID
@@ -1287,11 +1321,12 @@ func (m *Mock) CreateKeyPair(_ context.Context, cfg driver.KeyPairConfig) (*driv
 	return &result, nil
 }
 
-// DeleteKeyPair deletes a key pair by name.
+// DeleteKeyPair deletes a key pair by name. It is idempotent: deleting a key
+// pair that does not exist still succeeds (real EC2 DeleteKeyPair returns
+// <return>true</return> for a missing key), so Terraform destroy re-runs and
+// cleanup scripts don't fail on an already-deleted key.
 func (m *Mock) DeleteKeyPair(_ context.Context, name string) error {
-	if !m.keyPairs.Delete(name) {
-		return cerrors.Newf(cerrors.NotFound, "key pair %q not found", name)
-	}
+	m.keyPairs.Delete(name)
 
 	return nil
 }

--- a/providers/aws/ec2/template.go
+++ b/providers/aws/ec2/template.go
@@ -10,7 +10,10 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/compute/driver"
 )
 
-var _ driver.LaunchTemplateVersioner = (*Mock)(nil)
+var (
+	_ driver.LaunchTemplateVersioner = (*Mock)(nil)
+	_ driver.LaunchTemplateModifier  = (*Mock)(nil)
+)
 
 // templateVersionKey is the store key for one launch-template version.
 func templateVersionKey(name string, version int) string {
@@ -242,6 +245,37 @@ func mergeInstanceConfig(base, override driver.InstanceConfig) driver.InstanceCo
 	}
 
 	return out
+}
+
+// ModifyLaunchTemplate promotes an existing version to the template's default,
+// matching AWS EC2 ModifyLaunchTemplate (SetDefaultVersion). The version must
+// already exist.
+func (m *Mock) ModifyLaunchTemplate(
+	_ context.Context, input driver.ModifyLaunchTemplateInput,
+) (*driver.LaunchTemplate, error) {
+	tmpl, err := m.resolveTemplate(input.Name, input.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if input.DefaultVersion != "" {
+		n, err := resolveVersionNumber(tmpl, input.DefaultVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		if n < 1 || !m.templateVersions.Has(templateVersionKey(tmpl.Name, n)) {
+			return nil, cerrors.Newf(cerrors.InvalidArgument,
+				"launch template version %q does not exist", input.DefaultVersion)
+		}
+
+		tmpl.DefaultVersion = n
+		m.templates.Set(tmpl.Name, tmpl)
+	}
+
+	result := *tmpl
+
+	return &result, nil
 }
 
 // DescribeLaunchTemplateVersions returns a template's versions, filtered by the

--- a/server/aws/ec2/ec2_phase3_test.go
+++ b/server/aws/ec2/ec2_phase3_test.go
@@ -130,14 +130,17 @@ func TestRouteKeyPairsDispatch(t *testing.T) {
 	}
 }
 
-func TestKeyPairOpsUnknownIDReturnsError(t *testing.T) {
+// TestDeleteUnknownKeyPairIsIdempotent pins that deleting a non-existent key
+// pair succeeds — real EC2 DeleteKeyPair returns <return>true</return> for a
+// missing key (idempotent cleanup / Terraform destroy re-runs).
+func TestDeleteUnknownKeyPairIsIdempotent(t *testing.T) {
 	h := newFullHandler()
 
 	rr := do(t, h, http.MethodPost, "/", url.Values{
 		"Action": {"DeleteKeyPair"}, "KeyName": {"ghost-key"},
 	})
-	if rr.Code == http.StatusOK {
-		t.Errorf("DeleteKeyPair ghost-key should error, got 200")
+	if rr.Code != http.StatusOK {
+		t.Errorf("DeleteKeyPair ghost-key = %d, want 200 (idempotent)", rr.Code)
 	}
 }
 

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -255,6 +255,8 @@ func (h *Handler) routeLaunchTemplates(w http.ResponseWriter, r *http.Request, a
 		h.deleteLaunchTemplate(w, r)
 	case "DescribeLaunchTemplates":
 		h.describeLaunchTemplates(w, r)
+	case "ModifyLaunchTemplate":
+		h.modifyLaunchTemplate(w, r)
 	case "CreateLaunchTemplateVersion":
 		h.createLaunchTemplateVersion(w, r)
 	case "DescribeLaunchTemplateVersions":
@@ -390,7 +392,6 @@ func (h *Handler) routeVPC(w http.ResponseWriter, r *http.Request, action string
 	return h.routeVPCRouteTable(w, r, action)
 }
 
-//nolint:dupl // action-dispatch switch; every route* function has this shape by design
 func (h *Handler) routeVPCResource(w http.ResponseWriter, r *http.Request, action string) bool {
 	switch action {
 	case "CreateVpc":

--- a/server/aws/ec2/key_pair_test.go
+++ b/server/aws/ec2/key_pair_test.go
@@ -207,6 +207,20 @@ func TestImportKeyPairDuplicateRejected(t *testing.T) {
 	}
 }
 
+// TestDeleteKeyPairIdempotent pins that deleting a non-existent key pair
+// succeeds (real EC2 DeleteKeyPair returns true for a missing key), so
+// Terraform destroy re-runs and cleanup scripts don't fail.
+func TestDeleteKeyPairIdempotent(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	if _, err := client.DeleteKeyPair(ctx, &ec2.DeleteKeyPairInput{
+		KeyName: aws.String("does-not-exist"),
+	}); err != nil {
+		t.Fatalf("DeleteKeyPair(missing) = %v, want success", err)
+	}
+}
+
 // colonHexTest formats bytes as colon-separated lowercase hex, matching the
 // server's fingerprint encoding.
 func colonHexTest(b []byte) string {

--- a/server/aws/ec2/launch_template.go
+++ b/server/aws/ec2/launch_template.go
@@ -67,6 +67,13 @@ type deleteLaunchTemplateResponseXML struct {
 	LaunchTemplate launchTemplateXML `xml:"launchTemplate"`
 }
 
+type modifyLaunchTemplateResponseXML struct {
+	XMLName        xml.Name          `xml:"ModifyLaunchTemplateResponse"`
+	Xmlns          string            `xml:"xmlns,attr"`
+	RequestID      string            `xml:"requestId"`
+	LaunchTemplate launchTemplateXML `xml:"launchTemplate"`
+}
+
 type createLaunchTemplateVersionResponseXML struct {
 	XMLName               xml.Name                 `xml:"CreateLaunchTemplateVersionResponse"`
 	Xmlns                 string                   `xml:"xmlns,attr"`
@@ -133,6 +140,36 @@ func (h *Handler) deleteLaunchTemplate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	awsquery.WriteXMLResponse(w, resp)
+}
+
+// modifyLaunchTemplate handles Action=ModifyLaunchTemplate. It promotes the
+// version named by SetDefaultVersion to the template's default and echoes the
+// updated launch template. Served by the AWS-only LaunchTemplateModifier
+// capability.
+func (h *Handler) modifyLaunchTemplate(w http.ResponseWriter, r *http.Request) {
+	modifier, ok := h.compute.(computedriver.LaunchTemplateModifier)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction",
+			"ModifyLaunchTemplate is not supported")
+
+		return
+	}
+
+	info, err := modifier.ModifyLaunchTemplate(r.Context(), computedriver.ModifyLaunchTemplateInput{
+		Name:           r.Form.Get("LaunchTemplateName"),
+		ID:             r.Form.Get("LaunchTemplateId"),
+		DefaultVersion: r.Form.Get("SetDefaultVersion"),
+	})
+	if err != nil {
+		writeLaunchTemplateErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, modifyLaunchTemplateResponseXML{
+		Xmlns:          awsquery.Namespace,
+		RequestID:      awsquery.RequestID,
+		LaunchTemplate: toLaunchTemplateXML(info),
+	})
 }
 
 func (h *Handler) describeLaunchTemplates(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/ec2/launch_template_test.go
+++ b/server/aws/ec2/launch_template_test.go
@@ -170,6 +170,90 @@ func TestGetLaunchTemplateDataFromRunningInstance(t *testing.T) {
 	}
 }
 
+// TestRunInstancesFromLaunchTemplate pins that RunInstances given a
+// LaunchTemplate reference resolves the template's default version and applies
+// its data (ImageId/InstanceType) to the launched instance — previously the
+// template was silently ignored and ImageId came back empty.
+func TestRunInstancesFromLaunchTemplate(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	if _, err := client.CreateLaunchTemplate(ctx, &ec2.CreateLaunchTemplateInput{
+		LaunchTemplateName: aws.String("audit-lt"),
+		LaunchTemplateData: &ec2types.RequestLaunchTemplateData{
+			ImageId:      aws.String("ami-55555"),
+			InstanceType: ec2types.InstanceTypeT3Small,
+		},
+	}); err != nil {
+		t.Fatalf("CreateLaunchTemplate: %v", err)
+	}
+
+	out, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		LaunchTemplate: &ec2types.LaunchTemplateSpecification{
+			LaunchTemplateName: aws.String("audit-lt"),
+		},
+		MinCount: aws.Int32(1),
+		MaxCount: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	if len(out.Instances) != 1 {
+		t.Fatalf("got %d instances, want 1", len(out.Instances))
+	}
+	if got := aws.ToString(out.Instances[0].ImageId); got != "ami-55555" {
+		t.Errorf("ImageId = %q, want ami-55555 (launch template applied)", got)
+	}
+	if got := out.Instances[0].InstanceType; got != ec2types.InstanceTypeT3Small {
+		t.Errorf("InstanceType = %q, want t3.small", got)
+	}
+}
+
+// TestModifyLaunchTemplateSetsDefaultVersion pins that ModifyLaunchTemplate
+// promotes a version to the default and that a subsequent RunInstances with no
+// explicit version resolves the new default's data.
+func TestModifyLaunchTemplateSetsDefaultVersion(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	if _, err := client.CreateLaunchTemplate(ctx, &ec2.CreateLaunchTemplateInput{
+		LaunchTemplateName: aws.String("audit-lt"),
+		LaunchTemplateData: &ec2types.RequestLaunchTemplateData{ImageId: aws.String("ami-55555")},
+	}); err != nil {
+		t.Fatalf("CreateLaunchTemplate: %v", err)
+	}
+
+	if _, err := client.CreateLaunchTemplateVersion(ctx, &ec2.CreateLaunchTemplateVersionInput{
+		LaunchTemplateName: aws.String("audit-lt"),
+		LaunchTemplateData: &ec2types.RequestLaunchTemplateData{ImageId: aws.String("ami-66666")},
+	}); err != nil {
+		t.Fatalf("CreateLaunchTemplateVersion: %v", err)
+	}
+
+	mod, err := client.ModifyLaunchTemplate(ctx, &ec2.ModifyLaunchTemplateInput{
+		LaunchTemplateName: aws.String("audit-lt"),
+		DefaultVersion:     aws.String("2"),
+	})
+	if err != nil {
+		t.Fatalf("ModifyLaunchTemplate: %v", err)
+	}
+	if got := aws.ToInt64(mod.LaunchTemplate.DefaultVersionNumber); got != 2 {
+		t.Fatalf("DefaultVersionNumber = %d, want 2", got)
+	}
+
+	out, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		LaunchTemplate: &ec2types.LaunchTemplateSpecification{LaunchTemplateName: aws.String("audit-lt")},
+		MinCount:       aws.Int32(1),
+		MaxCount:       aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	if got := aws.ToString(out.Instances[0].ImageId); got != "ami-66666" {
+		t.Errorf("ImageId = %q, want ami-66666 (new default version)", got)
+	}
+}
+
 // TestCreateDuplicateLaunchTemplateErrors pins the EC2-specific
 // InvalidLaunchTemplateName.AlreadyExistsException code for a duplicate name.
 func TestCreateDuplicateLaunchTemplateErrors(t *testing.T) {

--- a/server/aws/ec2/operations.go
+++ b/server/aws/ec2/operations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -64,16 +65,16 @@ func (h *Handler) runInstances(w http.ResponseWriter, r *http.Request) {
 
 	count := instanceCount(form.Get("MinCount"), form.Get("MaxCount"))
 
-	cfg := computedriver.InstanceConfig{
-		ImageID:        form.Get("ImageId"),
-		InstanceType:   form.Get("InstanceType"),
-		SubnetID:       form.Get("SubnetId"),
-		SecurityGroups: awsquery.ListStrings(form, "SecurityGroupId"),
-		KeyName:        form.Get("KeyName"),
-		UserData:       decodeUserData(form.Get("UserData")),
-		ClientToken:    form.Get("ClientToken"),
-		Tags:           mergeTagSpecs(awsquery.TagSpecs(form), "instance"),
+	// A LaunchTemplate reference supplies the base instance parameters (real EC2
+	// resolves the template's default/requested version). Explicit RunInstances
+	// parameters below override the template's data.
+	cfg, err := h.launchTemplateBaseConfig(r.Context(), form)
+	if err != nil {
+		writeLaunchTemplateErr(w, err)
+		return
 	}
+
+	applyRunInstancesForm(&cfg, form)
 
 	instances, err := h.compute.RunInstances(r.Context(), cfg, count)
 	if err != nil {
@@ -95,6 +96,81 @@ func (h *Handler) runInstances(w http.ResponseWriter, r *http.Request) {
 		OwnerID:       ownerID,
 		Instances:     h.toInstanceXMLs(r.Context(), instances),
 	})
+}
+
+// launchTemplateBaseConfig resolves the InstanceConfig a RunInstances call
+// inherits from its LaunchTemplate reference. It returns a zero config when no
+// template is referenced (or the provider has no launch-template versioning).
+// LaunchTemplate.Version selects a specific version; absent, the template's
+// default version is used.
+func (h *Handler) launchTemplateBaseConfig(ctx context.Context, form url.Values) (computedriver.InstanceConfig, error) {
+	name := form.Get("LaunchTemplate.LaunchTemplateName")
+	id := form.Get("LaunchTemplate.LaunchTemplateId")
+
+	if name == "" && id == "" {
+		return computedriver.InstanceConfig{}, nil
+	}
+
+	versioner, ok := h.compute.(computedriver.LaunchTemplateVersioner)
+	if !ok {
+		return computedriver.InstanceConfig{}, nil
+	}
+
+	version := form.Get("LaunchTemplate.Version")
+	if version == "" {
+		version = "$Default"
+	}
+
+	versions, err := versioner.DescribeLaunchTemplateVersions(ctx, computedriver.DescribeLaunchTemplateVersionsInput{
+		Name:     name,
+		ID:       id,
+		Versions: []string{version},
+	})
+	if err != nil {
+		return computedriver.InstanceConfig{}, err
+	}
+
+	if len(versions) == 0 {
+		return computedriver.InstanceConfig{}, cerrors.Newf(cerrors.NotFound,
+			"launch template version %q not found", version)
+	}
+
+	return versions[0].InstanceConfig, nil
+}
+
+// applyRunInstancesForm overlays the explicit RunInstances request parameters
+// onto cfg (which may already carry launch-template data). A present parameter
+// overrides the template; an absent one leaves the template value in place.
+func applyRunInstancesForm(cfg *computedriver.InstanceConfig, form url.Values) {
+	if v := form.Get("ImageId"); v != "" {
+		cfg.ImageID = v
+	}
+
+	if v := form.Get("InstanceType"); v != "" {
+		cfg.InstanceType = v
+	}
+
+	if v := form.Get("SubnetId"); v != "" {
+		cfg.SubnetID = v
+	}
+
+	if sgs := awsquery.ListStrings(form, "SecurityGroupId"); len(sgs) > 0 {
+		cfg.SecurityGroups = sgs
+	}
+
+	if v := form.Get("KeyName"); v != "" {
+		cfg.KeyName = v
+	}
+
+	if v := form.Get("UserData"); v != "" {
+		cfg.UserData = decodeUserData(v)
+	}
+
+	cfg.ClientToken = form.Get("ClientToken")
+
+	if tags := mergeTagSpecs(awsquery.TagSpecs(form), "instance"); len(tags) > 0 {
+		cfg.Tags = tags
+	}
 }
 
 // reservationIDFor returns the instance's reservation id, falling back to a

--- a/server/aws/ec2/snapshot.go
+++ b/server/aws/ec2/snapshot.go
@@ -114,7 +114,15 @@ func (h *Handler) createSnapshot(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) deleteSnapshot(w http.ResponseWriter, r *http.Request) {
 	if err := h.compute.DeleteSnapshot(r.Context(), r.Form.Get("SnapshotId")); err != nil {
+		// A snapshot referenced by a registered AMI cannot be deleted until the
+		// AMI is deregistered; real EC2 answers InvalidSnapshot.InUse.
+		if cerrors.IsFailedPrecondition(err) {
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSnapshot.InUse", err.Error())
+			return
+		}
+
 		writeSnapshotErr(w, err)
+
 		return
 	}
 

--- a/server/aws/ec2/snapshot_test.go
+++ b/server/aws/ec2/snapshot_test.go
@@ -212,6 +212,44 @@ func TestCopySnapshotMissingSourceIsNotFound(t *testing.T) {
 	}
 }
 
+// TestDeleteSnapshotInUseByImage pins that a snapshot referenced by a
+// registered AMI's block device mapping cannot be deleted — real EC2 answers
+// InvalidSnapshot.InUse until the AMI is deregistered.
+func TestDeleteSnapshotInUseByImage(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	volumeID := createSnapshotVolume(t, ctx, client)
+
+	snap, err := client.CreateSnapshot(ctx, &ec2.CreateSnapshotInput{
+		VolumeId: aws.String(volumeID),
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	snapID := aws.ToString(snap.SnapshotId)
+
+	if _, err := client.RegisterImage(ctx, &ec2.RegisterImageInput{
+		Name: aws.String("audit-ami"),
+		BlockDeviceMappings: []ec2types.BlockDeviceMapping{{
+			DeviceName: aws.String("/dev/sda1"),
+			Ebs:        &ec2types.EbsBlockDevice{SnapshotId: aws.String(snapID)},
+		}},
+	}); err != nil {
+		t.Fatalf("RegisterImage: %v", err)
+	}
+
+	_, err = client.DeleteSnapshot(ctx, &ec2.DeleteSnapshotInput{SnapshotId: aws.String(snapID)})
+	if err == nil {
+		t.Fatal("DeleteSnapshot(in use by AMI) succeeded, want error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidSnapshot.InUse" {
+		t.Fatalf("DeleteSnapshot(in use) error = %v, want InvalidSnapshot.InUse", err)
+	}
+}
+
 // hasTag reports whether tags contains key=value.
 func hasTag(tags []ec2types.Tag, key, value string) bool {
 	for _, tg := range tags {

--- a/server/aws/ec2/volume.go
+++ b/server/aws/ec2/volume.go
@@ -141,7 +141,15 @@ func (h *Handler) createVolume(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) deleteVolume(w http.ResponseWriter, r *http.Request) {
 	if err := h.compute.DeleteVolume(r.Context(), r.Form.Get("VolumeId")); err != nil {
+		// An attached volume cannot be deleted; real EC2 answers VolumeInUse
+		// rather than the generic IncorrectState.
+		if cerrors.IsFailedPrecondition(err) {
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "VolumeInUse", err.Error())
+			return
+		}
+
 		writeVolumeErr(w, err)
+
 		return
 	}
 
@@ -241,7 +249,15 @@ func (h *Handler) attachVolume(w http.ResponseWriter, r *http.Request) {
 	device := r.Form.Get("Device")
 
 	if err := h.compute.AttachVolume(r.Context(), volID, instID, device); err != nil {
+		// A volume and the instance it attaches to must share an Availability
+		// Zone; real EC2 answers InvalidVolume.ZoneMismatch for a cross-AZ attach.
+		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "ZoneMismatch:") {
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidVolume.ZoneMismatch", err.Error())
+			return
+		}
+
 		writeVolumeErr(w, err)
+
 		return
 	}
 

--- a/server/aws/ec2/volume_test.go
+++ b/server/aws/ec2/volume_test.go
@@ -277,3 +277,86 @@ func TestModifyVolumeMissingIsNotFound(t *testing.T) {
 		t.Fatalf("ModifyVolume(missing) error = %v, want InvalidVolume.NotFound", err)
 	}
 }
+
+// TestAttachVolumeCrossAZRejected pins that attaching a volume to an instance
+// in a different Availability Zone is rejected with InvalidVolume.ZoneMismatch,
+// matching real EC2 (a volume and its instance must share an AZ).
+func TestAttachVolumeCrossAZRejected(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:  aws.String("ami-123"),
+		MinCount: aws.Int32(1),
+		MaxCount: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	instID := aws.ToString(run.Instances[0].InstanceId)
+
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-west-2b"),
+		Size:             aws.Int32(10),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+
+	_, err = client.AttachVolume(ctx, &ec2.AttachVolumeInput{
+		VolumeId:   vol.VolumeId,
+		InstanceId: aws.String(instID),
+		Device:     aws.String("/dev/sdf"),
+	})
+	if err == nil {
+		t.Fatal("cross-AZ AttachVolume succeeded, want error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidVolume.ZoneMismatch" {
+		t.Fatalf("cross-AZ AttachVolume error = %v, want InvalidVolume.ZoneMismatch", err)
+	}
+}
+
+// TestDeleteAttachedVolumeReturnsVolumeInUse pins that deleting an attached
+// volume is rejected with the VolumeInUse code (not the generic IncorrectState).
+func TestDeleteAttachedVolumeReturnsVolumeInUse(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:  aws.String("ami-123"),
+		MinCount: aws.Int32(1),
+		MaxCount: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	instID := aws.ToString(run.Instances[0].InstanceId)
+
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(10),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+
+	if _, err := client.AttachVolume(ctx, &ec2.AttachVolumeInput{
+		VolumeId:   vol.VolumeId,
+		InstanceId: aws.String(instID),
+		Device:     aws.String("/dev/sdf"),
+	}); err != nil {
+		t.Fatalf("AttachVolume: %v", err)
+	}
+
+	_, err = client.DeleteVolume(ctx, &ec2.DeleteVolumeInput{VolumeId: vol.VolumeId})
+	if err == nil {
+		t.Fatal("DeleteVolume(attached) succeeded, want error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "VolumeInUse" {
+		t.Fatalf("DeleteVolume(attached) error = %v, want VolumeInUse", err)
+	}
+}

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -252,6 +252,23 @@ type LaunchTemplateVersioner interface {
 	GetLaunchTemplateData(ctx context.Context, instanceID string) (*InstanceConfig, error)
 }
 
+// ModifyLaunchTemplateInput carries the parameters for ModifyLaunchTemplate.
+// Exactly one of Name/ID identifies the template; DefaultVersion is the version
+// number (or "$Latest"/"$Default") to promote to the template's default.
+type ModifyLaunchTemplateInput struct {
+	Name           string
+	ID             string
+	DefaultVersion string
+}
+
+// LaunchTemplateModifier is an AWS-only optional capability implementing
+// ModifyLaunchTemplate (promoting a template version to the default). Only the
+// EC2 provider implements it; the wire handler type-asserts for it, so
+// providers without launch templates (Azure, GCP) are unaffected.
+type LaunchTemplateModifier interface {
+	ModifyLaunchTemplate(ctx context.Context, input ModifyLaunchTemplateInput) (*LaunchTemplate, error)
+}
+
 // VolumeConfig describes a volume to create.
 type VolumeConfig struct {
 	Size             int


### PR DESCRIPTION
Fixes confirmed real-AWS divergences found in the EC2/compute end-to-end audit. Each fix has an aws-sdk-go-v2 round-trip test that fails without the change.

## Findings fixed

1. **RunInstances with a LaunchTemplate is now applied** (`server/aws/ec2/operations.go`). The handler resolves the referenced template's default (or requested) version via `DescribeLaunchTemplateVersions` and uses its `LaunchTemplateData` as the base config; explicit RunInstances parameters override the template. Previously the LaunchTemplate parameter was ignored and the instance launched with `ImageId=""`.

2. **ModifyLaunchTemplate (SetDefaultVersion) implemented** (`server/aws/ec2/handler.go`, `launch_template.go`, `providers/aws/ec2/template.go`). Added the wire route + handler and a provider method behind a new AWS-only optional `LaunchTemplateModifier` interface in `services/compute/driver`. Promotes an existing version to the template's default and echoes the updated template. Previously returned `InvalidAction`.

3. **DeleteSnapshot guards snapshots referenced by a registered AMI** (`providers/aws/ec2/ec2.go`, `server/aws/ec2/snapshot.go`). Deleting a snapshot still referenced by an AMI's block device mapping now returns `InvalidSnapshot.InUse`. Previously it succeeded and orphaned the AMI.

4. **AttachVolume rejects cross-AZ attach** (`providers/aws/ec2/ec2.go`, `server/aws/ec2/volume.go`). A volume in a different Availability Zone than the instance is rejected with `InvalidVolume.ZoneMismatch`.

5. **DeleteKeyPair is idempotent** (`providers/aws/ec2/ec2.go`). Deleting a non-existent key pair now succeeds (real EC2 returns `true`), matching Terraform destroy re-runs. Previously returned `InvalidKeyPair.NotFound`.

6. **DeleteVolume on an attached volume returns VolumeInUse** (`server/aws/ec2/volume.go`). The guard already existed; the wire error code was corrected from `IncorrectState` to `VolumeInUse`.

## Finding skipped

- **RunInstances with a nonexistent ImageId → InvalidAMIID.NotFound** — skipped as an acceptable emulator simplification. The emulator has no public-AMI catalog, so it cannot distinguish a valid real-world public AMI id (which unmodified user code, Terraform configs, and SDK examples legitimately reference) from a typo. Enforcing local-registration existence would reject the far more common valid case — and every existing test and the compat suite launch from unregistered AMI ids. The lenient behavior is deliberate.

## Notes

- Added an AWS-only optional interface (`LaunchTemplateModifier`) in the shared `services/compute/driver` package (type-asserted, no Azure/GCP/OCI mirror). Regenerated `docs/coverage` via `go generate`.
- Gates: `go build ./...`, `go test ./providers/aws/ec2/... ./server/aws/ec2/...`, and the compat suite `go test ./compat/...` all pass. `git diff docs/compat` is clean.
