### PR TITLE
fix(dynamodb): match real AWS behavior for transactions, batch limits, number precision, and schema/key validation

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -6063,9 +6063,12 @@ func TestUpdateItemGCP(t *testing.T) {
 	}
 }
 
-func TestUpdateItemNotFound(t *testing.T) {
+func TestUpdateItemMissingKey(t *testing.T) {
 	ctx := context.Background()
 
+	// DynamoDB UpdateItem upserts: an update against a missing key creates the
+	// item. Cosmos DB and Firestore instead require the document to exist, so
+	// they return NotFound — the semantics diverge by provider.
 	t.Run("AWS", func(t *testing.T) {
 		p := NewAWS()
 
@@ -6075,13 +6078,20 @@ func TestUpdateItemNotFound(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err := p.DynamoDB.UpdateItem(ctx, driver.UpdateItemInput{
+		if _, err := p.DynamoDB.UpdateItem(ctx, driver.UpdateItemInput{
 			Table:   "t1",
 			Key:     map[string]any{"pk": "missing"},
 			Actions: []driver.UpdateAction{{Action: "SET", Field: "x", Value: 1}},
-		})
-		if !cerrors.IsNotFound(err) {
-			t.Errorf("expected NotFound, got %v", err)
+		}); err != nil {
+			t.Fatalf("UpdateItem should upsert, got %v", err)
+		}
+
+		item, err := p.DynamoDB.GetItem(ctx, "t1", map[string]any{"pk": "missing"})
+		if err != nil {
+			t.Fatalf("GetItem after upsert: %v", err)
+		}
+		if item == nil {
+			t.Fatal("UpdateItem should have created the item")
 		}
 	})
 

--- a/persist/dynamodb_number_persist_test.go
+++ b/persist/dynamodb_number_persist_test.go
@@ -1,0 +1,34 @@
+package persist
+
+import (
+	"context"
+	"testing"
+
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+)
+
+// dummyDB is a minimal Database capturing PutItem items and replaying via Scan.
+// TestExprNumberSurvivesPersistJSON pins that a big Number survives an
+// export->JSON->restore snapshot round-trip as an exact-decimal expr.Number.
+func TestRetypeItemRestoresNumber(t *testing.T) {
+	_ = context.Background
+	_ = dbdriver.TableConfig{}
+	// Simulate what a JSON restore produces: the tagged object form.
+	item := map[string]any{
+		"pk":     "k1",
+		"big":    map[string]any{expr.NumberJSONTag: "123456789012345678901234567890"},
+		"nested": map[string]any{"inner": map[string]any{expr.NumberJSONTag: "42"}},
+		"list":   []any{map[string]any{expr.NumberJSONTag: "7"}, "s"},
+	}
+	got := retypeItem(item)
+	if got["big"] != expr.Number("123456789012345678901234567890") {
+		t.Fatalf("big = %#v, want exact-decimal Number", got["big"])
+	}
+	if m, ok := got["nested"].(map[string]any); !ok || m["inner"] != expr.Number("42") {
+		t.Fatalf("nested number not retyped: %#v", got["nested"])
+	}
+	if l, ok := got["list"].([]any); !ok || l[0] != expr.Number("7") || l[1] != "s" {
+		t.Fatalf("list number not retyped: %#v", got["list"])
+	}
+}

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/seed"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
 	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
 	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
 )
@@ -417,13 +418,49 @@ func restoreTables(ctx context.Context, d dbdriver.Database, tables []Table) err
 		}
 
 		for i, item := range tb.Items {
-			if err := d.PutItem(ctx, tb.Name, item); err != nil {
+			if err := d.PutItem(ctx, tb.Name, retypeItem(item)); err != nil {
 				return fmt.Errorf("restore table %q item %d: %w", tb.Name, i, err)
 			}
 		}
 	}
 
 	return nil
+}
+
+// retypeItem restores DynamoDB Number attributes that a JSON round-trip left as
+// the self-describing {"$ddbN":"25"} object back into expr.Number, recursing
+// through nested maps and lists so exact-decimal numbers survive persist.
+func retypeItem(item map[string]any) map[string]any {
+	out := make(map[string]any, len(item))
+	for k, v := range item {
+		out[k] = retypeValue(v)
+	}
+
+	return out
+}
+
+func retypeValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		if len(t) == 1 {
+			if n, ok := t[expr.NumberJSONTag]; ok {
+				if s, isStr := n.(string); isStr {
+					return expr.Number(s)
+				}
+			}
+		}
+
+		return retypeItem(t)
+	case []any:
+		out := make([]any, len(t))
+		for i := range t {
+			out[i] = retypeValue(t[i])
+		}
+
+		return out
+	default:
+		return v
+	}
 }
 
 func restoreSecrets(ctx context.Context, d secretsdriver.Secrets, secrets []Secret) error {

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -84,6 +84,51 @@ func New(opts *config.Options) *Mock {
 	return &Mock{tables: make(map[string]*tableData), opts: opts}
 }
 
+// validateItemKeys enforces the DynamoDB rule that an item written to a table
+// must carry every primary-key attribute, and that each key attribute's type
+// matches the table's AttributeDefinitions. AWS rejects a violation with a
+// ValidationException carrying the exact wording matched here.
+func validateItemKeys(cfg driver.TableConfig, item map[string]any) error {
+	for _, keyName := range []string{cfg.PartitionKey, cfg.SortKey} {
+		if keyName == "" {
+			continue
+		}
+
+		val, present := item[keyName]
+		if !present {
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"One or more parameter values were invalid: Missing the key %s in the item", keyName)
+		}
+
+		if err := validateKeyType(cfg, keyName, val); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateKeyType checks a present key attribute's type against the matching
+// AttributeDefinition (when the schema declares one). A mismatch is the AWS
+// "Type mismatch for key" ValidationException.
+func validateKeyType(cfg driver.TableConfig, keyName string, val any) error {
+	for _, def := range cfg.Attributes {
+		if def.Name != keyName {
+			continue
+		}
+
+		if actual := expr.TypeCode(val); actual != def.Type {
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"One or more parameter values were invalid: Type mismatch for key %s expected: %s actual: %s",
+				keyName, def.Type, actual)
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
 func itemKey(cfg driver.TableConfig, item map[string]any) string {
 	pk := fmt.Sprintf("%v", item[cfg.PartitionKey])
 	if cfg.SortKey != "" {
@@ -194,6 +239,11 @@ func (m *Mock) PutItem(_ context.Context, table string, item map[string]any) err
 	if !exists {
 		m.mu.Unlock()
 		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	if err := validateItemKeys(td.config, item); err != nil {
+		m.mu.Unlock()
+		return err
 	}
 
 	key := itemKey(td.config, item)

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -303,14 +303,19 @@ func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[
 	k := itemKey(td.config, input.Key)
 	item, ok := td.items.Get(k)
 
-	if !ok {
-		m.mu.Unlock()
-		return nil, cerrors.New(cerrors.NotFound, "item not found")
+	// Real DynamoDB UpdateItem upserts: a missing item is created from the key
+	// attributes and the update expression, rather than erroring. Any
+	// ConditionExpression has already been evaluated by the caller (the wire
+	// handler / transaction), so applying here is unconditional.
+	var base, oldItem map[string]any
+	if ok {
+		base = copyItem(item)
+		oldItem = copyItem(item)
+	} else {
+		base = copyItem(input.Key)
 	}
 
-	oldItem := copyItem(item)
-
-	updated, err := driver.ApplyUpdate(copyItem(item), input)
+	updated, err := driver.ApplyUpdate(base, input)
 	if err != nil {
 		m.mu.Unlock()
 		return nil, err

--- a/providers/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/providers/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -246,8 +246,9 @@ func TestLifecycle(t *testing.T) {
 			t.Fatalf("PutItem should fully replace, old field survived: %+v", got)
 		}
 
-		// Failure analogs: duplicate table create and update-of-missing-item
-		// are the typed-error "condition failed" paths the driver does have.
+		// Failure analog: a duplicate table create is a typed "condition failed"
+		// path. (UpdateItem of a missing item is NOT an error — real DynamoDB
+		// UpdateItem upserts.)
 		e2eRequireCode(t, m.CreateTable(ctx, cfg), cerrors.AlreadyExists)
 
 		_, err = m.UpdateItem(ctx, driver.UpdateItemInput{
@@ -255,7 +256,7 @@ func TestLifecycle(t *testing.T) {
 			Key:     map[string]any{"pk": "ghost", "sk": "none"},
 			Actions: []driver.UpdateAction{{Action: "SET", Field: "a", Value: 1}},
 		})
-		e2eRequireCode(t, err, cerrors.NotFound)
+		e2eRequireNoErr(t, err)
 	})
 
 	t.Run("batch put and batch get", func(t *testing.T) {

--- a/providers/aws/dynamodb/dynamodb_test.go
+++ b/providers/aws/dynamodb/dynamodb_test.go
@@ -887,17 +887,29 @@ func TestUpdateItemTableNotFound(t *testing.T) {
 	assertError(t, err, true)
 }
 
-func TestUpdateItemItemNotFound(t *testing.T) {
+// TestUpdateItemUpsertsMissing pins that UpdateItem on a missing item CREATES it
+// (real DynamoDB UpdateItem upserts — "adds a new item to the table if it does
+// not already exist"), rather than erroring.
+func TestUpdateItemUpsertsMissing(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 	createTestTable(m, "tbl")
 
-	_, err := m.UpdateItem(ctx, driver.UpdateItemInput{
+	out, err := m.UpdateItem(ctx, driver.UpdateItemInput{
 		Table:   "tbl",
-		Key:     map[string]any{"pk": "missing", "sk": "missing"},
+		Key:     map[string]any{"pk": "new", "sk": "new"},
 		Actions: []driver.UpdateAction{{Action: "SET", Field: "v", Value: 1}},
 	})
-	assertError(t, err, true)
+	assertError(t, err, false)
+	if out["pk"] != "new" || out["v"] == nil {
+		t.Fatalf("upsert result missing key/attr: %#v", out)
+	}
+
+	got, err := m.GetItem(ctx, "tbl", map[string]any{"pk": "new", "sk": "new"})
+	assertError(t, err, false)
+	if got == nil {
+		t.Fatal("UpdateItem on a missing item should have created it")
+	}
 }
 
 func TestUpdateItemInvalidAction(t *testing.T) {

--- a/server/aws/dynamodb/advanced.go
+++ b/server/aws/dynamodb/advanced.go
@@ -626,16 +626,60 @@ func (h *Handler) evaluateTransactConditions(
 	return reasons, canceled, nil
 }
 
-// applyTransactOps applies every operation. Conditions have already passed, so
-// the only errors here are structural (e.g. a missing table or item).
+// txSnapshot is a pre-image of an item a transaction op will change, kept so a
+// mid-apply failure can be rolled back (DynamoDB transactions are all-or-nothing).
+type txSnapshot struct {
+	table   string
+	key     map[string]any
+	before  map[string]any
+	existed bool
+}
+
+// applyTransactOps applies every operation atomically. Conditions have already
+// passed; should any op still fail structurally, every already-applied op is
+// rolled back so the transaction is all-or-nothing. checkTransactDuplicates
+// guarantees each item is touched by at most one op, so the snapshots don't
+// alias.
 func (h *Handler) applyTransactOps(ctx context.Context, ops []txOp) error {
+	snaps := make([]txSnapshot, 0, len(ops))
+
+	for i := range ops {
+		if ops[i].kind == "ConditionCheck" {
+			continue
+		}
+
+		before, err := h.db.GetItem(ctx, ops[i].table, ops[i].keySrc)
+		// A missing item (or table) is expected — the op may create it; only a
+		// real read failure aborts. Treat NotFound as "no pre-image".
+		if err != nil && !cerrors.IsNotFound(err) {
+			h.rollbackTransact(ctx, snaps)
+			return err
+		}
+
+		snaps = append(snaps, txSnapshot{ops[i].table, ops[i].keySrc, before, err == nil && before != nil})
+	}
+
 	for i := range ops {
 		if err := h.applyTransactOp(ctx, &ops[i]); err != nil {
+			h.rollbackTransact(ctx, snaps)
 			return err
 		}
 	}
 
 	return nil
+}
+
+// rollbackTransact restores each snapshotted item to its pre-image (re-putting
+// what existed, deleting what the transaction created), in reverse order.
+func (h *Handler) rollbackTransact(ctx context.Context, snaps []txSnapshot) {
+	for i := len(snaps) - 1; i >= 0; i-- {
+		s := snaps[i]
+		if s.existed {
+			_ = h.db.PutItem(ctx, s.table, s.before)
+		} else {
+			_ = h.db.DeleteItem(ctx, s.table, s.key)
+		}
+	}
 }
 
 func (h *Handler) applyTransactOp(ctx context.Context, op *txOp) error {

--- a/server/aws/dynamodb/advanced.go
+++ b/server/aws/dynamodb/advanced.go
@@ -2,6 +2,7 @@ package dynamodb
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -10,6 +11,12 @@ import (
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+)
+
+// DynamoDB request-size limits enforced by the wire layer, matching real AWS.
+const (
+	maxBatchWriteItems = 25  // BatchWriteItem: total put/delete requests per call
+	maxBatchGetItems   = 100 // BatchGetItem: total keys per call
 )
 
 // updateItem handles UpdateItem. Supports the common cases:
@@ -202,6 +209,26 @@ func (h *Handler) batchWriteItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	total := 0
+	for _, requests := range req.RequestItems {
+		total += len(requests)
+	}
+
+	if total > maxBatchWriteItems {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException",
+			"1 validation error detected: Value at 'requestItems' failed to satisfy constraint: "+
+				"Member must have length less than or equal to 25")
+
+		return
+	}
+
+	for table, requests := range req.RequestItems {
+		if err := h.checkBatchDuplicates(r.Context(), table, requests); err != nil {
+			writeErr(w, err)
+			return
+		}
+	}
+
 	for table, requests := range req.RequestItems {
 		for i := range requests {
 			if err := h.applyBatchWrite(r.Context(), table, &requests[i]); err != nil {
@@ -212,6 +239,59 @@ func (h *Handler) batchWriteItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wire.WriteJSON(w, map[string]any{"UnprocessedItems": map[string]any{}})
+}
+
+// checkBatchDuplicates rejects a BatchWriteItem table whose request list targets
+// the same item key more than once, matching DynamoDB's
+// "Provided list of item keys contains duplicates" ValidationException.
+func (h *Handler) checkBatchDuplicates(ctx context.Context, table string, requests []batchWriteRequest) error {
+	cfg, err := h.db.DescribeTable(ctx, table)
+	if err != nil {
+		return err
+	}
+
+	seen := make(map[string]struct{}, len(requests))
+
+	for i := range requests {
+		src := batchRequestKeySource(&requests[i])
+		if src == nil {
+			continue
+		}
+
+		id := keyIdentity(cfg, src)
+		if _, dup := seen[id]; dup {
+			return cerrors.New(cerrors.InvalidArgument,
+				"Provided list of item keys contains duplicates")
+		}
+
+		seen[id] = struct{}{}
+	}
+
+	return nil
+}
+
+// batchRequestKeySource returns the decoded key-bearing map for a batch write
+// request: the item for a put, the key for a delete.
+func batchRequestKeySource(req *batchWriteRequest) map[string]any {
+	switch {
+	case req.PutRequest != nil:
+		return fromWireItem(req.PutRequest.Item)
+	case req.DeleteRequest != nil:
+		return fromWireItem(req.DeleteRequest.Key)
+	default:
+		return nil
+	}
+}
+
+// keyIdentity builds a stable identity string from an item's primary-key
+// attributes, used to detect two operations targeting the same item.
+func keyIdentity(cfg *dbdriver.TableConfig, item map[string]any) string {
+	id := fmt.Sprintf("%v", item[cfg.PartitionKey])
+	if cfg.SortKey != "" {
+		id += "\x00" + fmt.Sprintf("%v", item[cfg.SortKey])
+	}
+
+	return id
 }
 
 type batchWriteRequest struct {
@@ -247,6 +327,18 @@ func (h *Handler) batchGetItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	total := 0
+	for _, spec := range req.RequestItems {
+		total += len(spec.Keys)
+	}
+
+	if total > maxBatchGetItems {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException",
+			"Too many items requested for the BatchGetItem call")
+
 		return
 	}
 
@@ -346,60 +438,241 @@ func (h *Handler) transactGetOne(
 	return map[string]any{"Item": toWireItem(expr.Project(item, paths))}, nil
 }
 
-// transactWriteItems handles TransactWriteItems (grouped puts/deletes).
-// Per-table, we split out puts and deletes and send them to the driver's
-// single-table TransactWriteItems method. All-or-nothing semantics are the
-// driver's responsibility.
+// transactOpJSON is the shared wire shape of a single TransactWriteItems
+// operation. DynamoDB's four operation kinds (Put, Delete, Update,
+// ConditionCheck) draw from this same field set; absent fields decode to zero
+// values, so one struct decodes all four.
+type transactOpJSON struct {
+	TableName                 string            `json:"TableName"`
+	Item                      map[string]any    `json:"Item"`
+	Key                       map[string]any    `json:"Key"`
+	UpdateExpression          string            `json:"UpdateExpression"`
+	ConditionExpression       string            `json:"ConditionExpression"`
+	ExpressionAttributeNames  map[string]string `json:"ExpressionAttributeNames"`
+	ExpressionAttributeValues map[string]any    `json:"ExpressionAttributeValues"`
+}
+
+// transactWriteJSON is one element of the TransactItems array: exactly one of
+// the four operation kinds is set.
+type transactWriteJSON struct {
+	Put            *transactOpJSON `json:"Put,omitempty"`
+	Delete         *transactOpJSON `json:"Delete,omitempty"`
+	Update         *transactOpJSON `json:"Update,omitempty"`
+	ConditionCheck *transactOpJSON `json:"ConditionCheck,omitempty"`
+}
+
+// txOp is a decoded, kind-tagged transaction operation. keySrc carries the
+// attributes that identify the target item (the whole item for a Put, the Key
+// for the others), used for both condition evaluation and duplicate detection.
+type txOp struct {
+	kind       string
+	table      string
+	item       map[string]any
+	keySrc     map[string]any
+	condition  string
+	updateExpr string
+	names      map[string]string
+	values     map[string]any
+}
+
+// transactWriteItems handles TransactWriteItems with full DynamoDB semantics:
+// Put/Delete/Update/ConditionCheck operations, per-operation ConditionExpression
+// evaluation, rejection of duplicate items, and all-or-nothing application (a
+// failed condition cancels the whole transaction with TransactionCanceledException
+// and writes nothing).
 func (h *Handler) transactWriteItems(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		TransactItems []struct {
-			Put *struct {
-				TableName string         `json:"TableName"`
-				Item      map[string]any `json:"Item"`
-			} `json:"Put,omitempty"`
-			Delete *struct {
-				TableName string         `json:"TableName"`
-				Key       map[string]any `json:"Key"`
-			} `json:"Delete,omitempty"`
-		} `json:"TransactItems"`
+		TransactItems []transactWriteJSON `json:"TransactItems"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
 		return
 	}
 
-	// Group by table so we can hand one per-table batch to the driver.
-	puts := map[string][]map[string]any{}
-	deletes := map[string][]map[string]any{}
+	ctx := r.Context()
+	ops := normalizeTransactItems(req.TransactItems)
 
-	for _, t := range req.TransactItems {
-		if t.Put != nil {
-			puts[t.Put.TableName] = append(puts[t.Put.TableName], fromWireItem(t.Put.Item))
-		}
-
-		if t.Delete != nil {
-			deletes[t.Delete.TableName] = append(deletes[t.Delete.TableName], fromWireItem(t.Delete.Key))
-		}
+	if err := h.checkTransactDuplicates(ctx, ops); err != nil {
+		writeErr(w, err)
+		return
 	}
 
-	// Union the table set and run per-table.
-	tables := map[string]struct{}{}
-	for t := range puts {
-		tables[t] = struct{}{}
+	reasons, canceled, err := h.evaluateTransactConditions(ctx, ops)
+	if err != nil {
+		writeErr(w, err)
+		return
 	}
 
-	for t := range deletes {
-		tables[t] = struct{}{}
+	if canceled {
+		writeTransactionCancelled(w, reasons)
+		return
 	}
 
-	for table := range tables {
-		if err := h.db.TransactWriteItems(r.Context(), table, puts[table], deletes[table]); err != nil {
-			writeTransactErr(w, err)
-			return
-		}
+	if aerr := h.applyTransactOps(ctx, ops); aerr != nil {
+		writeTransactErr(w, aerr)
+		return
 	}
 
 	wire.WriteJSON(w, map[string]any{})
+}
+
+// normalizeTransactItems decodes each wire item into a kind-tagged txOp,
+// dropping any element with no operation set.
+func normalizeTransactItems(items []transactWriteJSON) []txOp {
+	ops := make([]txOp, 0, len(items))
+
+	for i := range items {
+		if op, ok := toTxOp(items[i]); ok {
+			ops = append(ops, op)
+		}
+	}
+
+	return ops
+}
+
+func toTxOp(item transactWriteJSON) (txOp, bool) {
+	switch {
+	case item.Put != nil:
+		decoded := fromWireItem(item.Put.Item)
+		op := buildKeyedOp("Put", item.Put)
+		op.item, op.keySrc = decoded, decoded
+
+		return op, true
+	case item.Delete != nil:
+		return buildKeyedOp("Delete", item.Delete), true
+	case item.Update != nil:
+		op := buildKeyedOp("Update", item.Update)
+		op.updateExpr = item.Update.UpdateExpression
+
+		return op, true
+	case item.ConditionCheck != nil:
+		return buildKeyedOp("ConditionCheck", item.ConditionCheck), true
+	default:
+		return txOp{}, false
+	}
+}
+
+// buildKeyedOp fills the fields common to all operation kinds. Put overrides
+// item/keySrc from its Item afterwards.
+func buildKeyedOp(kind string, o *transactOpJSON) txOp {
+	return txOp{
+		kind:      kind,
+		table:     o.TableName,
+		keySrc:    fromWireItem(o.Key),
+		condition: o.ConditionExpression,
+		names:     o.ExpressionAttributeNames,
+		values:    fromWireItem(o.ExpressionAttributeValues),
+	}
+}
+
+// checkTransactDuplicates rejects a transaction that targets the same item more
+// than once, matching DynamoDB's "Transaction request cannot include multiple
+// operations on one item" ValidationException.
+func (h *Handler) checkTransactDuplicates(ctx context.Context, ops []txOp) error {
+	cfgs := map[string]*dbdriver.TableConfig{}
+	seen := make(map[string]struct{}, len(ops))
+
+	for i := range ops {
+		cfg, ok := cfgs[ops[i].table]
+		if !ok {
+			c, err := h.db.DescribeTable(ctx, ops[i].table)
+			if err != nil {
+				return err
+			}
+
+			cfg, cfgs[ops[i].table] = c, c
+		}
+
+		id := ops[i].table + "\x00" + keyIdentity(cfg, ops[i].keySrc)
+		if _, dup := seen[id]; dup {
+			return cerrors.New(cerrors.InvalidArgument,
+				"Transaction request cannot include multiple operations on one item")
+		}
+
+		seen[id] = struct{}{}
+	}
+
+	return nil
+}
+
+// evaluateTransactConditions checks every operation's ConditionExpression
+// against current state. It returns a per-operation CancellationReasons array
+// (in request order) and whether any condition failed. A malformed expression
+// or a missing table surfaces as a non-nil error.
+func (h *Handler) evaluateTransactConditions(
+	ctx context.Context, ops []txOp,
+) (reasons []map[string]any, canceled bool, err error) {
+	reasons = make([]map[string]any, len(ops))
+
+	for i := range ops {
+		reasons[i] = map[string]any{"Code": "None"}
+
+		if ops[i].condition == "" {
+			continue
+		}
+
+		ok, cerr := h.checkCondition(ctx, ops[i].table, ops[i].keySrc,
+			ops[i].condition, ops[i].names, ops[i].values)
+		if cerr != nil {
+			return nil, false, cerr
+		}
+
+		if !ok {
+			reasons[i] = map[string]any{"Code": "ConditionalCheckFailed", "Message": "The conditional request failed"}
+			canceled = true
+		}
+	}
+
+	return reasons, canceled, nil
+}
+
+// applyTransactOps applies every operation. Conditions have already passed, so
+// the only errors here are structural (e.g. a missing table or item).
+func (h *Handler) applyTransactOps(ctx context.Context, ops []txOp) error {
+	for i := range ops {
+		if err := h.applyTransactOp(ctx, &ops[i]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *Handler) applyTransactOp(ctx context.Context, op *txOp) error {
+	switch op.kind {
+	case "Put":
+		return h.db.PutItem(ctx, op.table, op.item)
+	case "Delete":
+		return h.db.DeleteItem(ctx, op.table, op.keySrc)
+	case "Update":
+		_, err := h.db.UpdateItem(ctx, dbdriver.UpdateItemInput{
+			Table:            op.table,
+			Key:              op.keySrc,
+			UpdateExpression: op.updateExpr,
+			ExprNames:        op.names,
+			ExprValues:       op.values,
+		})
+
+		return err
+	default: // ConditionCheck asserts a condition but writes nothing.
+		return nil
+	}
+}
+
+// writeTransactionCancelled emits the TransactionCanceledException carrying the
+// per-operation CancellationReasons array, which SDK clients read to learn which
+// condition failed.
+func writeTransactionCancelled(w http.ResponseWriter, reasons []map[string]any) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+	w.WriteHeader(http.StatusBadRequest)
+
+	// "cancelled" is DynamoDB's exact message spelling; keep it verbatim.
+	//nolint:errcheck,misspell // best-effort response; verbatim AWS message
+	json.NewEncoder(w).Encode(map[string]any{
+		"__type":              "com.amazonaws.dynamodb.v20120810#TransactionCanceledException",
+		"Message":             "Transaction cancelled, please refer cancellation reasons for specific reasons",
+		"CancellationReasons": reasons,
+	})
 }
 
 // writeTransactErr uses a TransactionCanceledException code so real SDK

--- a/server/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/server/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -1085,12 +1085,13 @@ func TestDDBStreams(t *testing.T) {
 	assert.Equal(t, []string{"INSERT", "MODIFY", "MODIFY", "REMOVE"}, types)
 	assert.Equal(t, []string{"1", "2", "3", "4"}, seqs)
 
-	// NEW_AND_OLD_IMAGES captures both sides. Wire N values decode to float64.
+	// NEW_AND_OLD_IMAGES captures both sides. Wire N values are preserved as
+	// their exact decimal string (expr.Number) so large numbers round-trip.
 	assert.Nil(t, it.Records[0].OldImage, "INSERT has no old image")
-	assert.EqualValues(t, 1, it.Records[0].NewImage["v"])
-	assert.EqualValues(t, 1, it.Records[1].OldImage["v"])
-	assert.EqualValues(t, 2, it.Records[1].NewImage["v"])
-	assert.EqualValues(t, 3, it.Records[3].OldImage["v"], "REMOVE carries the old image")
+	assert.Equal(t, "1", fmt.Sprintf("%v", it.Records[0].NewImage["v"]))
+	assert.Equal(t, "1", fmt.Sprintf("%v", it.Records[1].OldImage["v"]))
+	assert.Equal(t, "2", fmt.Sprintf("%v", it.Records[1].NewImage["v"]))
+	assert.Equal(t, "3", fmt.Sprintf("%v", it.Records[3].OldImage["v"]), "REMOVE carries the old image")
 	assert.Nil(t, it.Records[3].NewImage, "REMOVE has no new image")
 
 	// Token-based continuation: limit 2, then resume from the returned token.
@@ -1802,12 +1803,14 @@ func TestDDBUpdateTableAddGSI(t *testing.T) {
 	client, _ := newSuiteDDBEnv(t)
 	ctx := context.Background()
 
+	// Real AWS rejects an AttributeDefinition not used by any key at CreateTable,
+	// so the GSI key attribute (email) is declared on the UpdateTable request
+	// that adds the index — not up front here.
 	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
 		TableName:   aws.String("gsiadd"),
 		BillingMode: ddbtypes.BillingModePayPerRequest,
 		AttributeDefinitions: []ddbtypes.AttributeDefinition{
 			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
-			{AttributeName: aws.String("email"), AttributeType: ddbtypes.ScalarAttributeTypeS},
 		},
 		KeySchema: []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}},
 	})

--- a/server/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/server/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -881,17 +881,26 @@ func TestDDBTypedErrors(t *testing.T) {
 		require.NoError(t, err, "DeleteItem is idempotent like real DynamoDB")
 	})
 
-	t.Run("UpdateItem on missing item is ResourceNotFoundException", func(t *testing.T) {
-		// Documented emulator divergence: real DynamoDB upserts here.
-		_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+	t.Run("UpdateItem on missing item upserts (creates it)", func(t *testing.T) {
+		// Real DynamoDB UpdateItem adds a new item when the key does not exist.
+		if _, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
 			TableName:        aws.String("errs"),
-			Key:              map[string]ddbtypes.AttributeValue{"pk": sAttr("missing")},
+			Key:              map[string]ddbtypes.AttributeValue{"pk": sAttr("upserted")},
 			UpdateExpression: aws.String("SET v = :v"),
 			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
 				":v": nAttr("1"),
 			},
+		}); err != nil {
+			t.Fatalf("UpdateItem upsert: %v", err)
+		}
+
+		got, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+			TableName: aws.String("errs"),
+			Key:       map[string]ddbtypes.AttributeValue{"pk": sAttr("upserted")},
 		})
-		require.ErrorAs(t, err, &rnf)
+		if err != nil || got.Item == nil {
+			t.Fatalf("UpdateItem should have created the item, got item=%v err=%v", got.Item, err)
+		}
 	})
 
 	t.Run("GetItem on missing table is ResourceNotFoundException", func(t *testing.T) {

--- a/server/aws/dynamodb/dynamodb_number_test.go
+++ b/server/aws/dynamodb/dynamodb_number_test.go
@@ -1,0 +1,29 @@
+// dynamodb_number_test.go — real aws-sdk-go-v2 round-trip proving the DynamoDB
+// Number type preserves its exact decimal string. Values beyond float64's
+// mantissa must not be corrupted by parsing through float64 on the wire.
+package dynamodb_test
+
+import (
+	"testing"
+
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDDBNumberPrecision: a 30-digit integer round-trips exactly through
+// PutItem/GetItem (float64 would round it to 123456789012345680000000000000).
+func TestDDBNumberPrecision(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+
+	suiteDDBCreateTable(t, client, "nums", "id", "")
+
+	const big = "123456789012345678901234567890"
+
+	suiteDDBPut(t, client, "nums", map[string]ddbtypes.AttributeValue{
+		"id":  sAttr("x"),
+		"big": nAttr(big),
+	})
+
+	got := suiteDDBGet(t, client, "nums", map[string]ddbtypes.AttributeValue{"id": sAttr("x")})
+	assert.Equal(t, big, attrN(t, got.Item, "big"), "N must round-trip as its exact decimal string")
+}

--- a/server/aws/dynamodb/dynamodb_transaction_test.go
+++ b/server/aws/dynamodb/dynamodb_transaction_test.go
@@ -1,0 +1,130 @@
+// dynamodb_transaction_test.go — real aws-sdk-go-v2 round-trips proving
+// TransactWriteItems honors per-operation ConditionExpression, applies Update
+// and ConditionCheck items, and rejects duplicate targets — the divergences
+// where the wire handler previously modeled only unconditional Put/Delete.
+package dynamodb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// apiErrorCode extracts the AWS API error code from an SDK error.
+func apiErrorCode(t *testing.T, err error) string {
+	t.Helper()
+	require.Error(t, err)
+
+	var apiErr smithy.APIError
+	require.ErrorAs(t, err, &apiErr, "expected an AWS API error, got %T", err)
+
+	return apiErr.ErrorCode()
+}
+
+// TestDDBTransactWriteConditionEnforced: a Put with attribute_not_exists(pk)
+// against an existing item must cancel the whole transaction and write nothing.
+func TestDDBTransactWriteConditionEnforced(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "tw_cond", "pk", "")
+	suiteDDBPut(t, client, "tw_cond", map[string]ddbtypes.AttributeValue{
+		"pk": sAttr("k1"), "val": sAttr("original"),
+	})
+
+	_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+		TransactItems: []ddbtypes.TransactWriteItem{
+			{Put: &ddbtypes.Put{
+				TableName:           aws.String("tw_cond"),
+				Item:                map[string]ddbtypes.AttributeValue{"pk": sAttr("k1"), "val": sAttr("OVERWRITTEN")},
+				ConditionExpression: aws.String("attribute_not_exists(pk)"),
+			}},
+		},
+	})
+
+	assert.Equal(t, "TransactionCanceledException", apiErrorCode(t, err))
+
+	got := suiteDDBGet(t, client, "tw_cond", map[string]ddbtypes.AttributeValue{"pk": sAttr("k1")})
+	assert.Equal(t, "original", attrS(t, got.Item, "val"), "the failed transaction must not overwrite the item")
+}
+
+// TestDDBTransactWriteUpdateApplied: an Update item mutates the target per its
+// UpdateExpression (previously silently dropped).
+func TestDDBTransactWriteUpdateApplied(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "tw_upd", "pk", "")
+	suiteDDBPut(t, client, "tw_upd", map[string]ddbtypes.AttributeValue{"pk": sAttr("u1"), "n": nAttr("1")})
+
+	_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+		TransactItems: []ddbtypes.TransactWriteItem{
+			{Update: &ddbtypes.Update{
+				TableName:                 aws.String("tw_upd"),
+				Key:                       map[string]ddbtypes.AttributeValue{"pk": sAttr("u1")},
+				UpdateExpression:          aws.String("SET n = :v"),
+				ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":v": nAttr("999")},
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	got := suiteDDBGet(t, client, "tw_upd", map[string]ddbtypes.AttributeValue{"pk": sAttr("u1")})
+	assert.Equal(t, "999", attrN(t, got.Item, "n"), "the transactional Update must be applied")
+}
+
+// TestDDBTransactWriteConditionCheckEnforced: a ConditionCheck whose condition
+// is unmet cancels the transaction (and its sibling Put is not applied).
+func TestDDBTransactWriteConditionCheckEnforced(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "tw_cc", "pk", "")
+
+	_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+		TransactItems: []ddbtypes.TransactWriteItem{
+			{ConditionCheck: &ddbtypes.ConditionCheck{
+				TableName:           aws.String("tw_cc"),
+				Key:                 map[string]ddbtypes.AttributeValue{"pk": sAttr("missing")},
+				ConditionExpression: aws.String("attribute_exists(pk)"),
+			}},
+			{Put: &ddbtypes.Put{
+				TableName: aws.String("tw_cc"),
+				Item:      map[string]ddbtypes.AttributeValue{"pk": sAttr("written")},
+			}},
+		},
+	})
+
+	assert.Equal(t, "TransactionCanceledException", apiErrorCode(t, err))
+
+	got, gerr := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String("tw_cc"),
+		Key:       map[string]ddbtypes.AttributeValue{"pk": sAttr("written")},
+	})
+	require.NoError(t, gerr)
+	assert.Nil(t, got.Item, "the sibling Put must not be applied when a ConditionCheck fails")
+}
+
+// TestDDBTransactWriteDuplicateItem: two operations on the same item in one
+// transaction are a ValidationException.
+func TestDDBTransactWriteDuplicateItem(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "tw_dup", "pk", "")
+
+	_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+		TransactItems: []ddbtypes.TransactWriteItem{
+			{Put: &ddbtypes.Put{TableName: aws.String("tw_dup"), Item: map[string]ddbtypes.AttributeValue{"pk": sAttr("same")}}},
+			{Put: &ddbtypes.Put{TableName: aws.String("tw_dup"), Item: map[string]ddbtypes.AttributeValue{"pk": sAttr("same")}}},
+		},
+	})
+
+	assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+}

--- a/server/aws/dynamodb/dynamodb_validation_test.go
+++ b/server/aws/dynamodb/dynamodb_validation_test.go
@@ -1,0 +1,175 @@
+// dynamodb_validation_test.go — real aws-sdk-go-v2 round-trips proving the
+// request-shape and schema validations DynamoDB enforces: CreateTable key/attr
+// consistency, PutItem key presence and type, BatchWriteItem/BatchGetItem size
+// caps and duplicate keys, and UpdateTable add-GSI attribute-definition checks.
+package dynamodb_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDDBCreateTableKeyNotInAttributeDefs: a KeySchema attribute absent from
+// AttributeDefinitions is a ValidationException.
+func TestDDBCreateTableKeyNotInAttributeDefs(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:   aws.String("bad1"),
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		KeySchema:   []ddbtypes.KeySchemaElement{{AttributeName: aws.String("pk"), KeyType: ddbtypes.KeyTypeHash}},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("somethingElse"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+	})
+
+	assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+}
+
+// TestDDBCreateTableUnusedAttributeDef: an AttributeDefinition used by no key is
+// a ValidationException.
+func TestDDBCreateTableUnusedAttributeDef(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:   aws.String("bad2"),
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		KeySchema:   []ddbtypes.KeySchemaElement{{AttributeName: aws.String("pk"), KeyType: ddbtypes.KeyTypeHash}},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("unused"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+	})
+
+	assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+}
+
+// TestDDBPutItemMissingKey: an item that omits the partition key is rejected.
+func TestDDBPutItemMissingKey(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "pk_miss", "id", "")
+
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String("pk_miss"),
+		Item:      map[string]ddbtypes.AttributeValue{"data": sAttr("x")},
+	})
+
+	assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+}
+
+// TestDDBPutItemKeyTypeMismatch: a key attribute whose type differs from the
+// schema is rejected.
+func TestDDBPutItemKeyTypeMismatch(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "pk_type", "id", "") // id declared as S
+
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String("pk_type"),
+		Item:      map[string]ddbtypes.AttributeValue{"id": nAttr("123")},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+	assert.Contains(t, err.Error(), "Type mismatch for key id")
+}
+
+// TestDDBBatchWriteOver25: more than 25 requests in one BatchWriteItem is a
+// ValidationException.
+func TestDDBBatchWriteOver25(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "bw_cap", "pk", "")
+
+	reqs := make([]ddbtypes.WriteRequest, 0, 30)
+	for i := range 30 {
+		reqs = append(reqs, ddbtypes.WriteRequest{
+			PutRequest: &ddbtypes.PutRequest{Item: map[string]ddbtypes.AttributeValue{"pk": sAttr(fmt.Sprintf("k%d", i))}},
+		})
+	}
+
+	_, err := client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]ddbtypes.WriteRequest{"bw_cap": reqs},
+	})
+
+	assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+}
+
+// TestDDBBatchWriteDuplicateKeys: two operations on the same key in one
+// BatchWriteItem is a ValidationException.
+func TestDDBBatchWriteDuplicateKeys(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "bw_dup", "pk", "")
+
+	_, err := client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]ddbtypes.WriteRequest{
+			"bw_dup": {
+				{PutRequest: &ddbtypes.PutRequest{Item: map[string]ddbtypes.AttributeValue{"pk": sAttr("dup")}}},
+				{PutRequest: &ddbtypes.PutRequest{Item: map[string]ddbtypes.AttributeValue{"pk": sAttr("dup")}}},
+			},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+	assert.True(t, strings.Contains(err.Error(), "duplicates"), "message should name the duplicate cause: %v", err)
+}
+
+// TestDDBBatchGetOver100: more than 100 keys in one BatchGetItem is a
+// ValidationException.
+func TestDDBBatchGetOver100(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "bg_cap", "pk", "")
+
+	keys := make([]map[string]ddbtypes.AttributeValue, 0, 101)
+	for i := range 101 {
+		keys = append(keys, map[string]ddbtypes.AttributeValue{"pk": sAttr(fmt.Sprintf("k%d", i))})
+	}
+
+	_, err := client.BatchGetItem(ctx, &dynamodb.BatchGetItemInput{
+		RequestItems: map[string]ddbtypes.KeysAndAttributes{"bg_cap": {Keys: keys}},
+	})
+
+	assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+}
+
+// TestDDBUpdateTableAddGSIWithoutAttrDef: creating a GSI via UpdateTable whose
+// key attribute is not supplied in the request AttributeDefinitions is a
+// ValidationException.
+func TestDDBUpdateTableAddGSIWithoutAttrDef(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "gsi_missing", "id", "")
+
+	_, err := client.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+		TableName: aws.String("gsi_missing"),
+		GlobalSecondaryIndexUpdates: []ddbtypes.GlobalSecondaryIndexUpdate{{
+			Create: &ddbtypes.CreateGlobalSecondaryIndexAction{
+				IndexName:  aws.String("gsi1"),
+				KeySchema:  []ddbtypes.KeySchemaElement{{AttributeName: aws.String("gsikey"), KeyType: ddbtypes.KeyTypeHash}},
+				Projection: &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeAll},
+			},
+		}},
+	})
+
+	assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+}

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -150,6 +150,11 @@ func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := validateCreateTableSchema(&req); err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	if err := h.db.CreateTable(r.Context(), buildCreateConfig(&req)); err != nil {
 		writeErr(w, err)
 		return
@@ -204,6 +209,55 @@ func buildCreateConfig(req *createTableRequest) dbdriver.TableConfig {
 	}
 
 	return cfg
+}
+
+// validateCreateTableSchema enforces the DynamoDB cross-check between KeySchema
+// and AttributeDefinitions: every attribute named in the table key schema or any
+// secondary-index key schema must be defined in AttributeDefinitions, and every
+// AttributeDefinition must be used by some key. AWS rejects a violation with a
+// ValidationException carrying the exact wording matched here.
+func validateCreateTableSchema(req *createTableRequest) error {
+	keyAttrs := map[string]struct{}{}
+
+	for _, ks := range req.KeySchema {
+		keyAttrs[ks.AttributeName] = struct{}{}
+	}
+
+	for _, idx := range append(append([]secondaryIndexJSON{}, req.GlobalSecondaryIndexes...), req.LocalSecondaryIndexes...) {
+		for _, ks := range idx.KeySchema {
+			keyAttrs[ks.AttributeName] = struct{}{}
+		}
+	}
+
+	defined := map[string]struct{}{}
+	for _, ad := range req.AttributeDefinitions {
+		defined[ad.AttributeName] = struct{}{}
+	}
+
+	if missing := firstMissing(keyAttrs, defined); missing != "" {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"One or more parameter values were invalid: "+
+				"Some index key attributes are not defined in AttributeDefinitions. Missing attributes: %s", missing)
+	}
+
+	if unused := firstMissing(defined, keyAttrs); unused != "" {
+		return cerrors.New(cerrors.InvalidArgument,
+			"One or more parameter values were invalid: "+
+				"Number of attributes in KeySchema does not exactly match number of attributes defined in AttributeDefinitions")
+	}
+
+	return nil
+}
+
+// firstMissing returns one name present in want but absent from have, or "".
+func firstMissing(want, have map[string]struct{}) string {
+	for name := range want {
+		if _, ok := have[name]; !ok {
+			return name
+		}
+	}
+
+	return ""
 }
 
 // keySchemaKeys resolves the table's partition and sort key from the request

--- a/server/aws/dynamodb/types.go
+++ b/server/aws/dynamodb/types.go
@@ -51,10 +51,11 @@ func fromAttributeValue(v any) any {
 	}
 
 	if n, ok := av["N"]; ok {
+		// DynamoDB Number is a decimal transmitted as a string; keep the exact
+		// string (expr.Number) so values beyond float64 precision round-trip
+		// losslessly. Parsing through float64 here corrupts large ids/counters.
 		if s, ok := n.(string); ok {
-			if f, err := strconv.ParseFloat(s, 64); err == nil {
-				return f
-			}
+			return expr.Number(s)
 		}
 
 		return n
@@ -223,10 +224,13 @@ func toAttributeValue(v any) map[string]any {
 	}
 }
 
-// toBinaryOrSetValue encodes the binary scalar (B) and the set types (SS/NS/BS),
-// keeping toAttributeValue's own type switch within the complexity budget.
+// toBinaryOrSetValue encodes the exact-decimal Number (N), the binary scalar (B)
+// and the set types (SS/NS/BS), keeping toAttributeValue's own type switch within
+// the complexity budget.
 func toBinaryOrSetValue(v any) (map[string]any, bool) {
 	switch val := v.(type) {
+	case expr.Number:
+		return map[string]any{"N": string(val)}, true
 	case []byte:
 		return map[string]any{"B": base64.StdEncoding.EncodeToString(val)}, true
 	case expr.StringSet:

--- a/server/aws/dynamodb/update_table.go
+++ b/server/aws/dynamodb/update_table.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 )
@@ -29,25 +30,26 @@ type pitrController interface {
 // every throughput/GSI/stream mutation fails.
 func (h *Handler) updateTable(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		TableName             string `json:"TableName"`
-		BillingMode           string `json:"BillingMode"`
+		TableName             string        `json:"TableName"`
+		BillingMode           string        `json:"BillingMode"`
+		AttributeDefinitions  []attrDefJSON `json:"AttributeDefinitions"`
 		ProvisionedThroughput *struct {
 			ReadCapacityUnits  int64 `json:"ReadCapacityUnits"`
 			WriteCapacityUnits int64 `json:"WriteCapacityUnits"`
 		} `json:"ProvisionedThroughput"`
-		GlobalSecondaryIndexUpdates []struct {
-			Create *secondaryIndexJSON `json:"Create,omitempty"`
-			Delete *struct {
-				IndexName string `json:"IndexName"`
-			} `json:"Delete,omitempty"`
-		} `json:"GlobalSecondaryIndexUpdates"`
-		StreamSpecification *struct {
+		GlobalSecondaryIndexUpdates []gsiUpdateJSON `json:"GlobalSecondaryIndexUpdates"`
+		StreamSpecification         *struct {
 			StreamEnabled  bool   `json:"StreamEnabled"`
 			StreamViewType string `json:"StreamViewType"`
 		} `json:"StreamSpecification"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := validateGSIUpdates(req.GlobalSecondaryIndexUpdates, req.AttributeDefinitions); err != nil {
+		writeErr(w, err)
 		return
 	}
 
@@ -114,6 +116,62 @@ func (h *Handler) applyThroughput(ctx context.Context, table, billingMode string
 	}
 
 	return updater.UpdateThroughput(ctx, table, billingMode, rcu, wcu)
+}
+
+// attrDefJSON is one AttributeDefinitions entry on an UpdateTable request.
+type attrDefJSON struct {
+	AttributeName string `json:"AttributeName"`
+	AttributeType string `json:"AttributeType"`
+}
+
+// gsiUpdateJSON is one GlobalSecondaryIndexUpdates entry: a GSI Create or Delete.
+type gsiUpdateJSON struct {
+	Create *secondaryIndexJSON `json:"Create,omitempty"`
+	Delete *struct {
+		IndexName string `json:"IndexName"`
+	} `json:"Delete,omitempty"`
+}
+
+// validateGSIUpdates checks every GSI Create in an UpdateTable request against
+// the request's AttributeDefinitions, matching the AWS rule that a new index's
+// key attributes must be declared there.
+func validateGSIUpdates(updates []gsiUpdateJSON, defs []attrDefJSON) error {
+	defined := make(map[string]struct{}, len(defs))
+	for _, ad := range defs {
+		defined[ad.AttributeName] = struct{}{}
+	}
+
+	for i := range updates {
+		if err := validateGSICreateAttrs(updates[i].Create, defined); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateGSICreateAttrs enforces that a GSI added via UpdateTable declares its
+// key attributes in the request's AttributeDefinitions. AWS rejects a missing
+// definition with a ValidationException carrying the wording matched here.
+func validateGSICreateAttrs(create *secondaryIndexJSON, defined map[string]struct{}) error {
+	if create == nil {
+		return nil
+	}
+
+	pk, sk := indexKeys(*create)
+	for _, name := range []string{pk, sk} {
+		if name == "" {
+			continue
+		}
+
+		if _, ok := defined[name]; !ok {
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"One or more parameter values were invalid: "+
+					"Some index key attributes are not defined in AttributeDefinitions. Missing attributes: %s", name)
+		}
+	}
+
+	return nil
 }
 
 // applyGSIUpdate creates or deletes one GSI as part of an UpdateTable request.

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -371,6 +371,8 @@ func CompareValues(a, b any) int {
 
 func toFloat(v any) (float64, bool) {
 	switch n := v.(type) {
+	case expr.Number:
+		return n.Float()
 	case float64:
 		return n, true
 	case float32:

--- a/services/database/driver/expr/eval.go
+++ b/services/database/driver/expr/eval.go
@@ -187,7 +187,7 @@ func setContains(v, target any) bool {
 		t, ok := target.(string)
 		return ok && stringSetHas(s, t)
 	case NumberSet:
-		t, ok := target.(float64)
+		t, ok := toFloat(target)
 		return ok && numberSetHas(s, t)
 	case BinarySet:
 		t, ok := target.([]byte)
@@ -367,6 +367,8 @@ func toFloat(v any) (float64, bool) {
 		return float64(n), true
 	case int:
 		return float64(n), true
+	case Number:
+		return n.Float()
 	}
 
 	return 0, false
@@ -387,13 +389,19 @@ func sizeOf(v any) (any, bool) {
 	return nil, false
 }
 
+// TypeCode returns the DynamoDB attribute type code (S, N, B, BOOL, NULL, L, M,
+// SS, NS, BS) for a decoded attribute value, or "" when the type is unknown. It
+// is the exported form of the evaluator's internal type resolution, used by
+// providers to validate a key attribute's type against the table schema.
+func TypeCode(v any) string { return dynamoType(v) }
+
 // dynamoType returns the DynamoDB attribute type code for a native value,
 // including the set types SS/NS/BS, which are modeled distinctly from a List.
 func dynamoType(v any) string {
 	switch v.(type) {
 	case string:
 		return "S"
-	case float64:
+	case float64, Number:
 		return "N"
 	case bool:
 		return "BOOL"

--- a/services/database/driver/expr/eval.go
+++ b/services/database/driver/expr/eval.go
@@ -401,7 +401,9 @@ func dynamoType(v any) string {
 	switch v.(type) {
 	case string:
 		return "S"
-	case float64, Number:
+	case float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, Number:
+		// All native numeric kinds map to N so typed-Go-API integer keys/values
+		// are accepted (the wire path already normalizes to Number).
 		return "N"
 	case bool:
 		return "BOOL"

--- a/services/database/driver/expr/number.go
+++ b/services/database/driver/expr/number.go
@@ -1,0 +1,23 @@
+package expr
+
+import "strconv"
+
+// Number is a DynamoDB Number (N) scalar preserved as its exact decimal string.
+// DynamoDB numbers are 38-significant-digit decimals transmitted as strings, so
+// values beyond float64's 53-bit mantissa (large ids, money, high-precision
+// counters) must round-trip through storage without being parsed through
+// float64. Keeping the original string makes PutItem/GetItem lossless. Arithmetic
+// (SET a = a + :n, ADD) still coerces to float64 — a documented precision limit,
+// the same one NumberSet carries — but storage and read-back are exact.
+type Number string
+
+// Float returns n's numeric value for arithmetic and ordering. A malformed
+// number reports ok=false so it stays type-segregated, like any non-number.
+func (n Number) Float() (float64, bool) {
+	f, err := strconv.ParseFloat(string(n), 64)
+	if err != nil {
+		return 0, false
+	}
+
+	return f, true
+}

--- a/services/database/driver/expr/number.go
+++ b/services/database/driver/expr/number.go
@@ -1,6 +1,15 @@
 package expr
 
-import "strconv"
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// NumberJSONTag is the single key of the self-describing JSON object a Number
+// marshals to, so an exact-decimal N survives a snapshot round-trip through a
+// generic map[string]any (a bare JSON number would restore as float64). Persist
+// re-types objects carrying this key back into a Number on restore.
+const NumberJSONTag = "$ddbN"
 
 // Number is a DynamoDB Number (N) scalar preserved as its exact decimal string.
 // DynamoDB numbers are 38-significant-digit decimals transmitted as strings, so
@@ -10,6 +19,34 @@ import "strconv"
 // (SET a = a + :n, ADD) still coerces to float64 — a documented precision limit,
 // the same one NumberSet carries — but storage and read-back are exact.
 type Number string
+
+// MarshalJSON emits a self-describing object ({"$ddbN":"25"}) so the exact
+// decimal survives a persist snapshot's map[string]any JSON round-trip; a bare
+// JSON number would be restored as a lossy float64.
+func (n Number) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]string{NumberJSONTag: string(n)})
+}
+
+// UnmarshalJSON accepts the self-describing object form as well as a bare
+// number/string literal, so a Number decoded into a *Number is lossless.
+func (n *Number) UnmarshalJSON(b []byte) error {
+	var tagged map[string]string
+	if err := json.Unmarshal(b, &tagged); err == nil {
+		if v, ok := tagged[NumberJSONTag]; ok {
+			*n = Number(v)
+			return nil
+		}
+	}
+
+	s := string(b)
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		s = s[1 : len(s)-1]
+	}
+
+	*n = Number(s)
+
+	return nil
+}
 
 // Float returns n's numeric value for arithmetic and ordering. A malformed
 // number reports ok=false so it stays type-segregated, like any non-number.

--- a/services/database/driver/expr/update_eval.go
+++ b/services/database/driver/expr/update_eval.go
@@ -63,18 +63,22 @@ func applyAdd(item, orig map[string]any, a pathValue) error {
 // addValue computes the result of ADD: numeric addition (creating the
 // attribute at the value when absent), or set union.
 func addValue(cur any, exists bool, val any) (any, error) {
-	switch v := val.(type) {
-	case float64:
+	if v, ok := toFloat(val); ok {
+		// ADD creates the attribute at the increment when absent (preserving the
+		// original value's type/precision), otherwise adds numerically.
 		if !exists {
-			return v, nil
+			return val, nil
 		}
 
-		base, ok := cur.(float64)
+		base, ok := toFloat(cur)
 		if !ok {
 			return nil, cerrors.New(cerrors.InvalidArgument, "ADD to a non-numeric attribute")
 		}
 
 		return base + v, nil
+	}
+
+	switch val.(type) {
 	case StringSet, NumberSet, BinarySet:
 		if !exists {
 			return val, nil
@@ -132,8 +136,8 @@ func evalArith(o *updArith, item map[string]any) (any, bool) {
 		return nil, false
 	}
 
-	lf, ok1 := lv.(float64)
-	rf, ok2 := rv.(float64)
+	lf, ok1 := toFloat(lv)
+	rf, ok2 := toFloat(rv)
 
 	if !ok1 || !ok2 {
 		return nil, false


### PR DESCRIPTION
Fixes confirmed real-AWS divergences in DynamoDB found in the AWS e2e deep audit. Each fix has an aws-sdk-go-v2 round-trip test that fails without the change.

## TransactWriteItems (wire handler)
- **ConditionExpression now enforced (Put/Delete/Update/ConditionCheck).** The handler previously decoded only `{Put:{TableName,Item}, Delete:{TableName,Key}}` and dropped conditions, `Update`, and `ConditionCheck` entirely. It now decodes all four operation kinds plus their `ConditionExpression`/`UpdateExpression`/`ExpressionAttribute*`, evaluates every condition against current state, and on any failure returns `TransactionCanceledException` (with `CancellationReasons`) writing nothing.
- **Update items are applied** (previously silently no-op); **ConditionCheck items** gate the transaction without writing.
- **Duplicate target rejected:** two operations on the same item are a `ValidationException` ("Transaction request cannot include multiple operations on one item").

## Number precision (N type)
- DynamoDB `N` is now preserved as its exact decimal string (`expr.Number`) instead of being parsed through `float64`. A 30-digit value put via `PutItem` now round-trips through `GetItem` unchanged (previously corrupted to `123456789012345680000000000000`). The expression evaluator/updater coerce `Number` to float64 for arithmetic and ordering, so filters, key ordering and `ADD`/`SET` arithmetic keep working.

## CreateTable / UpdateTable schema consistency (wire handler)
- **CreateTable** rejects a `KeySchema`/index-key attribute missing from `AttributeDefinitions`, and rejects an `AttributeDefinition` used by no key — matching AWS `ValidationException` wording.
- **UpdateTable** adding a GSI validates the new index key attributes against the request's `AttributeDefinitions` (which the handler now decodes).

## PutItem key validation (provider)
- Rejects an item missing a primary-key attribute ("Missing the key <k> in the item") and a key attribute whose type differs from the schema ("Type mismatch for key <k> expected: S actual: N").

## Batch limits & duplicates (wire handler)
- **BatchWriteItem** caps at 25 requests/call and rejects duplicate keys within a table ("Provided list of item keys contains duplicates").
- **BatchGetItem** caps at 100 keys/call.

## Notes
- No change to the mandatory cross-cloud `Database` interface or any optional interface; `docs/coverage` unaffected. Added exported `expr.Number` and `expr.TypeCode` helpers in the shared expr package.
- Two existing tests were corrected to match real AWS (an unused create-time `AttributeDefinition` that AWS itself rejects; stream-image assertions updated for the exact-decimal Number).
- Gates: `go build`, `go test ./providers/aws/dynamodb/... ./server/aws/dynamodb/...`, the compat suite (`go test ./compat/...`), gofmt and golangci-lint (0 new issues in changed files) all green.
