### PR TITLE
fix(ecs): require explicit revision for DeregisterTaskDefinition

### DIFF
--- a/providers/aws/ecs/taskdefs.go
+++ b/providers/aws/ecs/taskdefs.go
@@ -237,8 +237,17 @@ func (m *Mock) DescribeTaskDefinition(_ context.Context, id string) (*driver.Tas
 	return &out, nil
 }
 
-// DeregisterTaskDefinition marks a task-definition revision INACTIVE.
+// DeregisterTaskDefinition marks a task-definition revision INACTIVE. Unlike
+// DescribeTaskDefinition, it requires an explicit revision: AWS rejects a bare
+// family name because it will not pick a revision to deregister on the caller's
+// behalf.
 func (m *Mock) DeregisterTaskDefinition(_ context.Context, id string) (*driver.TaskDefinition, error) {
+	if !taskDefHasRevision(id) {
+		return nil, apiErrf(errors.InvalidArgument, excClient,
+			"Deregister task definition: the task definition must be specified as a family and revision "+
+				"(family:revision) or full ARN. You must specify a revision.")
+	}
+
 	td, ok := m.resolveTaskDef(id)
 	if !ok {
 		return nil, apiErrf(errors.NotFound, excClient, "task definition %q not found", id)
@@ -253,6 +262,18 @@ func (m *Mock) DeregisterTaskDefinition(_ context.Context, id string) (*driver.T
 	out := cloneTaskDef(&updated)
 
 	return &out, nil
+}
+
+// taskDefHasRevision reports whether id names a specific revision — either
+// "family:revision" or an ARN whose "task-definition/family:revision" segment
+// carries a revision. A bare family name has no revision.
+func taskDefHasRevision(id string) bool {
+	key := id
+	if strings.Contains(id, "task-definition/") {
+		key = id[strings.LastIndex(id, "task-definition/")+len("task-definition/"):]
+	}
+
+	return strings.Contains(key, ":")
 }
 
 // resolveTaskDef looks up a task definition by family, family:revision, or ARN.

--- a/server/aws/ecs/taskdefs_test.go
+++ b/server/aws/ecs/taskdefs_test.go
@@ -107,3 +107,51 @@ func hasRequiredAttr(list []ecstypes.Attribute, name string) bool {
 
 	return false
 }
+
+// TestSDKDeregisterTaskDefinitionRequiresRevision guards that DeregisterTaskDefinition
+// rejects a bare family name. Real ECS requires a specific revision (family:revision
+// or a full ARN) and will not pick one on the caller's behalf, returning a
+// ClientException; cloudemu previously deregistered the latest ACTIVE revision
+// silently.
+func TestSDKDeregisterTaskDefinitionRequiresRevision(t *testing.T) {
+	client := newECSClient(t)
+	ctx := context.Background()
+
+	registerNginx(t, client, ctx)
+
+	_, err := client.DeregisterTaskDefinition(ctx, &awsecs.DeregisterTaskDefinitionInput{
+		TaskDefinition: aws.String("web"),
+	})
+	if err == nil {
+		t.Fatalf("DeregisterTaskDefinition(bare family) = nil error, want ClientException")
+	}
+
+	var ce *ecstypes.ClientException
+	if !errorsAs(err, &ce) {
+		t.Fatalf("DeregisterTaskDefinition error = %T (%v), want *ClientException", err, err)
+	}
+
+	// The named revision must remain ACTIVE — nothing was deregistered.
+	desc, err := client.DescribeTaskDefinition(ctx, &awsecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String("web:1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeTaskDefinition(web:1): %v", err)
+	}
+
+	if desc.TaskDefinition.Status != ecstypes.TaskDefinitionStatusActive {
+		t.Fatalf("web:1 status = %v, want ACTIVE (untouched)", desc.TaskDefinition.Status)
+	}
+
+	// A specific revision still deregisters normally.
+	dereg, err := client.DeregisterTaskDefinition(ctx, &awsecs.DeregisterTaskDefinitionInput{
+		TaskDefinition: aws.String("web:1"),
+	})
+	if err != nil {
+		t.Fatalf("DeregisterTaskDefinition(web:1): %v", err)
+	}
+
+	if dereg.TaskDefinition.Status != ecstypes.TaskDefinitionStatusInactive {
+		t.Fatalf("web:1 status = %v, want INACTIVE after deregister", dereg.TaskDefinition.Status)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a confirmed real-AWS divergence in ECS `DeregisterTaskDefinition`.

### DeregisterTaskDefinition must specify a revision
- **AWS behavior:** the `taskDefinition` argument must be `family:revision` or a full ARN — the API doc states "You must specify a revision." A bare family name is rejected with a `ClientException`; AWS will not pick a revision on the caller's behalf.
- **cloudemu before:** `DeregisterTaskDefinition({TaskDefinition:"web"})` returned HTTP 200 and silently deregistered the latest ACTIVE revision (`resolveTaskDef` fell through to `latestActive()` for a bare family), flipping a revision the caller never named to INACTIVE.
- **Fix:** `providers/aws/ecs/taskdefs.go` now guards `DeregisterTaskDefinition` with a new `taskDefHasRevision` check. A bare family (no `:` after stripping any `task-definition/` ARN prefix) returns a `ClientException`. `family:revision` and full ARNs deregister as before; `DescribeTaskDefinition`'s bare-family-resolves-to-latest-ACTIVE behavior is unchanged (AWS allows that on Describe).

### Test
- Added `TestSDKDeregisterTaskDefinitionRequiresRevision` (aws-sdk-go-v2 round-trip): bare family returns `*ClientException` and leaves `web:1` ACTIVE; `web:1` still deregisters to INACTIVE. Fails without the fix.

### Gates
- `go build ./...`, `go test ./providers/aws/ecs/... ./server/aws/ecs/...`, `go test ./compat/...`, gofmt, golangci-lint (0 new issues) all green.