### PR TITLE
fix(eventbridge): reject DeleteRule while rule still has targets

### DIFF
--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -254,9 +254,20 @@ func (m *Mock) DeleteRule(_ context.Context, eventBus, ruleName string) error {
 		return errors.Newf(errors.NotFound, "event bus %q not found", busName)
 	}
 
-	if !bd.rules.Delete(ruleName) {
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
 		return errors.Newf(errors.NotFound, "rule %q not found on event bus %q", ruleName, busName)
 	}
+
+	// Real EventBridge refuses to delete a rule that still has targets: the
+	// caller must RemoveTargets first. (Force applies only to managed rules,
+	// which this mock does not model, so it never bypasses this guard.)
+	if rd.targets.Len() > 0 {
+		//nolint:revive // exact AWS ValidationException wording, surfaced verbatim to the SDK
+		return errors.New(errors.InvalidArgument, "Rule can't be deleted since it has targets.")
+	}
+
+	bd.rules.Delete(ruleName)
 
 	return nil
 }

--- a/server/aws/eventbridge/delete_rule_test.go
+++ b/server/aws/eventbridge/delete_rule_test.go
@@ -1,0 +1,62 @@
+package eventbridge_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+	"github.com/aws/smithy-go"
+)
+
+// Real EventBridge refuses to delete a rule that still has targets: the caller
+// must RemoveTargets first, otherwise DeleteRule returns a ValidationException.
+func TestSDKEventBridgeDeleteRuleWithTargetsRejected(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	if _, err := client.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("has-targets"),
+		EventPattern: aws.String(`{"source":["app"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := client.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule: aws.String("has-targets"),
+		Targets: []ebtypes.Target{
+			{Id: aws.String("t1"), Arn: aws.String("arn:aws:sqs:us-east-1:000000000000:q")},
+		},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	_, err := client.DeleteRule(ctx, &awseb.DeleteRuleInput{Name: aws.String("has-targets")})
+	if err == nil {
+		t.Fatal("DeleteRule with targets present should fail, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ValidationException" {
+		t.Fatalf("want ValidationException, got %T: %v", err, err)
+	}
+
+	// The rule must still exist after the rejected delete.
+	if _, err := client.DescribeRule(ctx, &awseb.DescribeRuleInput{Name: aws.String("has-targets")}); err != nil {
+		t.Fatalf("rule should survive rejected DeleteRule: %v", err)
+	}
+
+	// After removing targets, DeleteRule succeeds.
+	if _, err := client.RemoveTargets(ctx, &awseb.RemoveTargetsInput{
+		Rule: aws.String("has-targets"),
+		Ids:  []string{"t1"},
+	}); err != nil {
+		t.Fatalf("RemoveTargets: %v", err)
+	}
+
+	if _, err := client.DeleteRule(ctx, &awseb.DeleteRuleInput{Name: aws.String("has-targets")}); err != nil {
+		t.Fatalf("DeleteRule after RemoveTargets: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a confirmed real-AWS divergence in EventBridge `DeleteRule`.

## Finding fixed

**DeleteRule succeeded even when the rule still had targets.** Real EventBridge refuses this: the caller must `RemoveTargets` first, otherwise the API returns a `ValidationException` ("Rule can't be deleted since it has targets."). cloudemu previously ran `bd.rules.Delete(ruleName)` unconditionally and returned success.

### Fix
- `providers/aws/eventbridge/eventbridge.go` — `DeleteRule` now looks up the rule, and if it has one or more targets returns `InvalidArgument` with the exact AWS wording (maps to `ValidationException` at the wire layer). Force is not modeled since it applies only to managed rules, which this mock does not have, so it never bypasses the guard. Non-target deletes and not-found behavior are unchanged.

### Test
- `server/aws/eventbridge/delete_rule_test.go` — aws-sdk-go-v2 round-trip: PutRule + PutTargets, assert `DeleteRule` fails with `ValidationException` and the rule survives; then RemoveTargets and assert DeleteRule succeeds. Fails without the fix.

## Gates
- `go build ./...` ok
- `go test ./providers/aws/eventbridge/... ./server/aws/eventbridge/...` ok
- `go test ./compat/...` ok (suite green)
- gofmt clean; golangci-lint adds 0 new issues in changed files