### PR TITLE
fix(lambda): match real AWS behavior for CreateFunction defaults/validation and async Invoke

### DIFF
--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -32,6 +32,14 @@ const (
 	timeFormat       = "2006-01-02T15:04:05Z"
 )
 
+// AWS Lambda create-time defaults applied when the client omits the field:
+// MemorySize defaults to 128 MB and Timeout to 3 seconds. See
+// https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunction.html
+const (
+	defaultMemoryMB    = 128
+	defaultTimeoutSecs = 3
+)
+
 type versionData struct {
 	config     driver.FunctionConfig
 	version    string
@@ -105,6 +113,17 @@ func New(opts *config.Options) *Mock {
 func (m *Mock) CreateFunction(ctx context.Context, cfg driver.FunctionConfig) (*driver.FunctionInfo, error) {
 	if _, ok := m.funcs.Get(cfg.Name); ok {
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "function %s already exists", cfg.Name)
+	}
+
+	// AWS applies documented create-time defaults when the client omits these:
+	// MemorySize -> 128 MB, Timeout -> 3 s. Terraform/CDK read these back and see
+	// a perpetual diff if the response reports 0.
+	if cfg.Memory == 0 {
+		cfg.Memory = defaultMemoryMB
+	}
+
+	if cfg.Timeout == 0 {
+		cfg.Timeout = defaultTimeoutSecs
 	}
 
 	arn := idgen.AWSARN("lambda", m.opts.Region, m.opts.AccountID, "function:"+cfg.Name)

--- a/server/aws/lambda/create_defaults_test.go
+++ b/server/aws/lambda/create_defaults_test.go
@@ -1,0 +1,102 @@
+package lambda_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKCreateFunctionDefaultMemoryAndTimeout covers CreateFunction applying
+// AWS's documented create-time defaults when the client omits them: MemorySize
+// defaults to 128 MB and Timeout to 3 seconds. Before the fix both came back 0,
+// causing perpetual Terraform/CDK drift.
+func TestSDKCreateFunctionDefaultMemoryAndTimeout(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("defaults"),
+		Runtime:      lambdatypes.RuntimePython39,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("index.handler"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+	})
+	if err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	if out.MemorySize == nil || *out.MemorySize != 128 {
+		t.Fatalf("create MemorySize = %v, want 128", out.MemorySize)
+	}
+	if out.Timeout == nil || *out.Timeout != 3 {
+		t.Fatalf("create Timeout = %v, want 3", out.Timeout)
+	}
+
+	got, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("defaults"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConfiguration: %v", err)
+	}
+	if got.MemorySize == nil || *got.MemorySize != 128 {
+		t.Fatalf("get MemorySize = %v, want 128", got.MemorySize)
+	}
+	if got.Timeout == nil || *got.Timeout != 3 {
+		t.Fatalf("get Timeout = %v, want 3", got.Timeout)
+	}
+}
+
+// TestSDKCreateFunctionZipRequiresRuntimeAndHandler covers AWS rejecting a .zip
+// package CreateFunction that omits Runtime or Handler with
+// InvalidParameterValueException. Before the fix cloudemu accepted it (201) and
+// stored empty runtime/handler.
+func TestSDKCreateFunctionZipRequiresRuntimeAndHandler(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		in   *awslambda.CreateFunctionInput
+	}{
+		{
+			name: "no-runtime",
+			in: &awslambda.CreateFunctionInput{
+				FunctionName: aws.String("noruntime"),
+				Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+				Handler:      aws.String("index.handler"),
+				Code:         &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+			},
+		},
+		{
+			name: "no-handler",
+			in: &awslambda.CreateFunctionInput{
+				FunctionName: aws.String("nohandler"),
+				Runtime:      lambdatypes.RuntimePython39,
+				Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+				Code:         &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := client.CreateFunction(ctx, tc.in)
+			if err == nil {
+				t.Fatalf("CreateFunction with a .zip package and missing runtime/handler succeeded, want InvalidParameterValueException")
+			}
+
+			var apiErr smithy.APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("error %v is not an API error", err)
+			}
+			if apiErr.ErrorCode() != "InvalidParameterValueException" {
+				t.Fatalf("ErrorCode = %q, want InvalidParameterValueException", apiErr.ErrorCode())
+			}
+		})
+	}
+}

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -74,6 +74,20 @@ const (
 // latestVersion is the symbolic version for a function's mutable current code.
 const latestVersion = "$LATEST"
 
+// packageTypeZip is the default deployment-package type. AWS requires Runtime
+// and Handler for a Zip package (but not for an Image package).
+const packageTypeZip = "Zip"
+
+// invocationTypeEvent is the async (fire-and-forget) invocation type. AWS
+// returns HTTP 202 with an empty body for it, versus 200 for RequestResponse.
+const invocationTypeEvent = "Event"
+
+// lastUpdateStatusSuccessful is the terminal LastUpdateStatus real AWS reports
+// once a create/update completes. cloudemu settles synchronously, so every
+// config response carries it — this is the value the FunctionUpdatedV2 waiter
+// (SAM/CDK/Terraform) polls for.
+const lastUpdateStatusSuccessful = "Successful"
+
 const (
 	contentTypeJSON = "application/json"
 	maxBodyBytes    = 6 << 20 // 6 MiB — Lambda's sync invocation payload limit.
@@ -668,6 +682,24 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// For a .zip file archive package (the default when PackageType is omitted or
+	// "Zip"), AWS requires both Runtime and Handler and rejects a create that omits
+	// either with InvalidParameterValueException. Image packages carry the runtime
+	// in the container, so they don't.
+	if req.PackageType == "" || req.PackageType == packageTypeZip {
+		if req.Runtime == "" {
+			writeError(w, http.StatusBadRequest, "InvalidParameterValueException",
+				"Runtime is required if the deployment package is a .zip file archive.")
+			return
+		}
+
+		if req.Handler == "" {
+			writeError(w, http.StatusBadRequest, "InvalidParameterValueException",
+				"Handler is required if the deployment package is a .zip file archive.")
+			return
+		}
+	}
+
 	cfg := sdrv.FunctionConfig{
 		Name:        req.FunctionName,
 		Runtime:     req.Runtime,
@@ -799,13 +831,22 @@ func (h *Handler) invoke(w http.ResponseWriter, r *http.Request, name string) {
 		return
 	}
 
+	invokeType := r.Header.Get("X-Amz-Invocation-Type")
+
 	out, err := h.fn.Invoke(r.Context(), sdrv.InvokeInput{
 		FunctionName: name,
 		Payload:      payload,
-		InvokeType:   r.Header.Get("X-Amz-Invocation-Type"),
+		InvokeType:   invokeType,
 	})
 	if err != nil {
 		writeErr(w, err)
+		return
+	}
+
+	// An asynchronous (Event) invocation is fire-and-forget: AWS queues it and
+	// returns HTTP 202 with an empty body — no payload, no function-error header.
+	if invokeType == invocationTypeEvent {
+		w.WriteHeader(http.StatusAccepted)
 		return
 	}
 
@@ -866,21 +907,22 @@ func toConfiguration(info *sdrv.FunctionInfo) functionConfiguration {
 	}
 
 	cfg := functionConfiguration{
-		FunctionName: info.Name,
-		FunctionArn:  info.ARN,
-		Runtime:      info.Runtime,
-		Role:         info.Role,
-		Handler:      info.Handler,
-		Description:  info.Description,
-		MemorySize:   info.Memory,
-		Timeout:      info.Timeout,
-		LastModified: info.LastModified,
-		State:        info.State,
-		PackageType:  "Zip",
-		CodeSha256:   info.CodeSHA256,
-		CodeSize:     info.CodeSize,
-		Version:      version,
-		RevisionID:   info.RevisionID,
+		FunctionName:     info.Name,
+		FunctionArn:      info.ARN,
+		Runtime:          info.Runtime,
+		Role:             info.Role,
+		Handler:          info.Handler,
+		Description:      info.Description,
+		MemorySize:       info.Memory,
+		Timeout:          info.Timeout,
+		LastModified:     info.LastModified,
+		State:            info.State,
+		LastUpdateStatus: lastUpdateStatusSuccessful,
+		PackageType:      packageTypeZip,
+		CodeSha256:       info.CodeSHA256,
+		CodeSize:         info.CodeSize,
+		Version:          version,
+		RevisionID:       info.RevisionID,
 	}
 
 	if len(info.Environment) > 0 {

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -82,6 +82,10 @@ const packageTypeZip = "Zip"
 // returns HTTP 202 with an empty body for it, versus 200 for RequestResponse.
 const invocationTypeEvent = "Event"
 
+// invocationTypeDryRun validates parameters and permissions without running the
+// function. AWS returns HTTP 204 No Content (nothing is executed).
+const invocationTypeDryRun = "DryRun"
+
 // lastUpdateStatusSuccessful is the terminal LastUpdateStatus real AWS reports
 // once a create/update completes. cloudemu settles synchronously, so every
 // config response carries it — this is the value the FunctionUpdatedV2 waiter
@@ -832,6 +836,20 @@ func (h *Handler) invoke(w http.ResponseWriter, r *http.Request, name string) {
 	}
 
 	invokeType := r.Header.Get("X-Amz-Invocation-Type")
+
+	// A DryRun invocation validates the request without executing the function:
+	// confirm the function exists, then return 204 No Content (real Lambda runs
+	// nothing and returns no payload).
+	if invokeType == invocationTypeDryRun {
+		if _, err = h.fn.GetFunction(r.Context(), name); err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+
+		return
+	}
 
 	out, err := h.fn.Invoke(r.Context(), sdrv.InvokeInput{
 		FunctionName: name,

--- a/server/aws/lambda/invoke_async_test.go
+++ b/server/aws/lambda/invoke_async_test.go
@@ -46,6 +46,39 @@ func TestSDKInvokeEventReturns202(t *testing.T) {
 	}
 }
 
+// TestSDKInvokeDryRunReturns204 covers InvocationType=DryRun: AWS validates the
+// request without executing the function and returns HTTP 204 with no payload.
+func TestSDKInvokeDryRunReturns204(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("dry"),
+		Runtime:      lambdatypes.RuntimePython39,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("index.handler"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+	}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	resp, err := client.Invoke(ctx, &awslambda.InvokeInput{
+		FunctionName:   aws.String("dry"),
+		InvocationType: lambdatypes.InvocationTypeDryRun,
+		Payload:        []byte(`{"k":1}`),
+	})
+	if err != nil {
+		t.Fatalf("Invoke(DryRun): %v", err)
+	}
+
+	if resp.StatusCode != 204 {
+		t.Fatalf("StatusCode = %d, want 204 for DryRun invocation", resp.StatusCode)
+	}
+	if len(resp.Payload) != 0 {
+		t.Fatalf("Payload = %q, want empty body for DryRun invocation", resp.Payload)
+	}
+}
+
 // TestSDKInvokeRequestResponseReturns200 guards that a synchronous invoke still
 // returns 200 with the payload after the async 202 branch was added.
 func TestSDKInvokeRequestResponseReturns200(t *testing.T) {

--- a/server/aws/lambda/invoke_async_test.go
+++ b/server/aws/lambda/invoke_async_test.go
@@ -1,0 +1,127 @@
+package lambda_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+)
+
+// TestSDKInvokeEventReturns202 covers an asynchronous (InvocationType=Event)
+// invoke returning HTTP 202 with an empty body. Before the fix cloudemu always
+// wrote 200 and echoed the request payload back regardless of invocation type.
+func TestSDKInvokeEventReturns202(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("async"),
+		Runtime:      lambdatypes.RuntimePython39,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("index.handler"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+	}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	resp, err := client.Invoke(ctx, &awslambda.InvokeInput{
+		FunctionName:   aws.String("async"),
+		InvocationType: lambdatypes.InvocationTypeEvent,
+		Payload:        []byte(`{"k":1}`),
+	})
+	if err != nil {
+		t.Fatalf("Invoke(Event): %v", err)
+	}
+
+	if resp.StatusCode != 202 {
+		t.Fatalf("StatusCode = %d, want 202 for async Event invocation", resp.StatusCode)
+	}
+	if len(resp.Payload) != 0 {
+		t.Fatalf("Payload = %q, want empty body for async Event invocation", resp.Payload)
+	}
+	if resp.FunctionError != nil && *resp.FunctionError != "" {
+		t.Fatalf("FunctionError = %q, want empty for async Event invocation", *resp.FunctionError)
+	}
+}
+
+// TestSDKInvokeRequestResponseReturns200 guards that a synchronous invoke still
+// returns 200 with the payload after the async 202 branch was added.
+func TestSDKInvokeRequestResponseReturns200(t *testing.T) {
+	client, cloud := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("sync"),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+	}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	cloud.Lambda.RegisterHandler("sync", func(_ context.Context, payload []byte) ([]byte, error) {
+		return payload, nil
+	})
+
+	resp, err := client.Invoke(ctx, &awslambda.InvokeInput{
+		FunctionName:   aws.String("sync"),
+		InvocationType: lambdatypes.InvocationTypeRequestResponse,
+		Payload:        []byte(`"ok"`),
+	})
+	if err != nil {
+		t.Fatalf("Invoke(RequestResponse): %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("StatusCode = %d, want 200 for RequestResponse", resp.StatusCode)
+	}
+	if string(resp.Payload) != `"ok"` {
+		t.Fatalf("Payload = %q, want \"ok\"", resp.Payload)
+	}
+}
+
+// TestSDKCreateFunctionLastUpdateStatus covers config responses carrying
+// LastUpdateStatus=Successful (the field FunctionUpdatedV2 waiters poll). Before
+// the fix it was empty on create/update, hanging every SAM/CDK/Terraform deploy
+// that waits for the update to settle.
+func TestSDKCreateFunctionLastUpdateStatus(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("status"),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+	})
+	if err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+	if created.LastUpdateStatus != lambdatypes.LastUpdateStatusSuccessful {
+		t.Fatalf("create LastUpdateStatus = %q, want Successful", created.LastUpdateStatus)
+	}
+
+	updated, err := client.UpdateFunctionConfiguration(ctx, &awslambda.UpdateFunctionConfigurationInput{
+		FunctionName: aws.String("status"),
+		Description:  aws.String("changed"),
+	})
+	if err != nil {
+		t.Fatalf("UpdateFunctionConfiguration: %v", err)
+	}
+	if updated.LastUpdateStatus != lambdatypes.LastUpdateStatusSuccessful {
+		t.Fatalf("update LastUpdateStatus = %q, want Successful", updated.LastUpdateStatus)
+	}
+
+	got, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("status"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConfiguration: %v", err)
+	}
+	if got.LastUpdateStatus != lambdatypes.LastUpdateStatusSuccessful {
+		t.Fatalf("get LastUpdateStatus = %q, want Successful", got.LastUpdateStatus)
+	}
+}

--- a/server/aws/lambda/lambda_test.go
+++ b/server/aws/lambda/lambda_test.go
@@ -139,7 +139,7 @@ func TestListFunctions(t *testing.T) {
 	srv, _ := newServer(t)
 
 	for _, name := range []string{"a", "b", "c"} {
-		body := `{"FunctionName":"` + name + `","Runtime":"go1.x"}`
+		body := `{"FunctionName":"` + name + `","Runtime":"go1.x","Handler":"main"}`
 
 		resp := postJSON(t, srv.URL+"/2015-03-31/functions", body)
 		if resp.StatusCode != http.StatusCreated {
@@ -170,7 +170,7 @@ func TestListFunctions(t *testing.T) {
 func TestDeleteFunction(t *testing.T) {
 	srv, _ := newServer(t)
 
-	body := `{"FunctionName":"goner","Runtime":"go1.x"}`
+	body := `{"FunctionName":"goner","Runtime":"go1.x","Handler":"main"}`
 	if r := postJSON(t, srv.URL+"/2015-03-31/functions", body); r.StatusCode != http.StatusCreated {
 		t.Fatalf("create: %d", r.StatusCode)
 	}
@@ -204,7 +204,7 @@ func TestDeleteFunction(t *testing.T) {
 func TestInvokeReturnsHandlerPayload(t *testing.T) {
 	srv, cloud := newServer(t)
 
-	body := `{"FunctionName":"echo","Runtime":"go1.x"}`
+	body := `{"FunctionName":"echo","Runtime":"go1.x","Handler":"main"}`
 	if r := postJSON(t, srv.URL+"/2015-03-31/functions", body); r.StatusCode != http.StatusCreated {
 		t.Fatalf("create: %d", r.StatusCode)
 	}
@@ -243,7 +243,7 @@ func TestInvokeNoHandlerEchoesStub(t *testing.T) {
 	srv, _ := newServer(t)
 
 	if r := postJSON(t, srv.URL+"/2015-03-31/functions",
-		`{"FunctionName":"nohandler","Runtime":"go1.x"}`); r.StatusCode != http.StatusCreated {
+		`{"FunctionName":"nohandler","Runtime":"go1.x","Handler":"main"}`); r.StatusCode != http.StatusCreated {
 		t.Fatalf("create: %d", r.StatusCode)
 	}
 
@@ -275,7 +275,7 @@ func TestEventSourceMappings(t *testing.T) {
 	srv, _ := newServer(t)
 
 	if r := postJSON(t, srv.URL+"/2015-03-31/functions",
-		`{"FunctionName":"fx","Runtime":"go1.x"}`); r.StatusCode != http.StatusCreated {
+		`{"FunctionName":"fx","Runtime":"go1.x","Handler":"main"}`); r.StatusCode != http.StatusCreated {
 		t.Fatalf("create fn: %d", r.StatusCode)
 	}
 
@@ -330,7 +330,7 @@ func TestInvokeOnMissingFunctionReturns404(t *testing.T) {
 func TestEnvironmentRoundTrip(t *testing.T) {
 	srv, _ := newServer(t)
 
-	body := `{"FunctionName":"envfn","Runtime":"go1.x","Environment":{"Variables":{"K":"V"}}}`
+	body := `{"FunctionName":"envfn","Runtime":"go1.x","Handler":"main","Environment":{"Variables":{"K":"V"}}}`
 	if r := postJSON(t, srv.URL+"/2015-03-31/functions", body); r.StatusCode != http.StatusCreated {
 		t.Fatalf("create: %d", r.StatusCode)
 	}

--- a/server/aws/lambda/types.go
+++ b/server/aws/lambda/types.go
@@ -8,22 +8,25 @@ type envEnvelope struct {
 // functionConfiguration is the response body shared by Create / Get / Update.
 // Field set is the minimum the AWS SDK populates for a function description.
 type functionConfiguration struct {
-	FunctionName string       `json:"FunctionName"`
-	FunctionArn  string       `json:"FunctionArn"`
-	Runtime      string       `json:"Runtime,omitempty"`
-	Role         string       `json:"Role,omitempty"`
-	Handler      string       `json:"Handler,omitempty"`
-	Description  string       `json:"Description,omitempty"`
-	MemorySize   int          `json:"MemorySize,omitempty"`
-	Timeout      int          `json:"Timeout,omitempty"`
-	LastModified string       `json:"LastModified,omitempty"`
-	State        string       `json:"State,omitempty"`
-	CodeSha256   string       `json:"CodeSha256,omitempty"`
-	CodeSize     int64        `json:"CodeSize,omitempty"`
-	RevisionID   string       `json:"RevisionId,omitempty"`
-	Environment  *envEnvelope `json:"Environment,omitempty"`
-	PackageType  string       `json:"PackageType,omitempty"`
-	Version      string       `json:"Version,omitempty"`
+	FunctionName string `json:"FunctionName"`
+	FunctionArn  string `json:"FunctionArn"`
+	Runtime      string `json:"Runtime,omitempty"`
+	Role         string `json:"Role,omitempty"`
+	Handler      string `json:"Handler,omitempty"`
+	Description  string `json:"Description,omitempty"`
+	MemorySize   int    `json:"MemorySize,omitempty"`
+	Timeout      int    `json:"Timeout,omitempty"`
+	LastModified string `json:"LastModified,omitempty"`
+	State        string `json:"State,omitempty"`
+	// LastUpdateStatus is the terminal status of the last create/update ("Successful").
+	// SDK waiters (FunctionUpdatedV2) poll GetFunctionConfiguration for it.
+	LastUpdateStatus string       `json:"LastUpdateStatus,omitempty"`
+	CodeSha256       string       `json:"CodeSha256,omitempty"`
+	CodeSize         int64        `json:"CodeSize,omitempty"`
+	RevisionID       string       `json:"RevisionId,omitempty"`
+	Environment      *envEnvelope `json:"Environment,omitempty"`
+	PackageType      string       `json:"PackageType,omitempty"`
+	Version          string       `json:"Version,omitempty"`
 }
 
 // updateFunctionConfigurationRequest captures the mutable fields of


### PR DESCRIPTION
## Summary

Fixes five confirmed real-AWS divergences in the Lambda control plane surfaced by an end-to-end SDK audit. Each fix is landed at the correct architecture layer and is covered by an aws-sdk-go-v2 round-trip test that fails without the change.

## Findings fixed

1. **CreateFunction default MemorySize (128 MB).** AWS defaults MemorySize to 128 MB when omitted; cloudemu stored/echoed 0, causing perpetual Terraform/CDK diff. Now defaulted in the AWS provider `CreateFunction` (state layer).

2. **CreateFunction default Timeout (3 s).** Same class of bug; Timeout now defaults to 3 seconds in the provider when omitted.

3. **Invoke async (InvocationType=Event) returns 202 with empty body.** AWS returns HTTP 202 and no body for fire-and-forget async invokes; the handler previously always wrote 200 and echoed the payload regardless of invocation type. The wire handler now branches on `X-Amz-Invocation-Type: Event` and returns 202 with an empty body.

4. **LastUpdateStatus emitted as `Successful`.** Config responses (create/update/get-configuration) never set LastUpdateStatus, so the FunctionUpdatedV2 waiter (SAM/CDK/Terraform) spun until timeout. cloudemu settles synchronously, so `toConfiguration` now always reports `Successful`.

5. **Zip package requires Runtime and Handler.** For a .zip deployment package (the default PackageType), AWS rejects a create that omits Runtime or Handler with `InvalidParameterValueException`; cloudemu accepted it (201). The wire `create()` now validates and returns `InvalidParameterValueException` (HTTP 400).

## Layering

- Defaults/state -> `providers/aws/lambda/lambda.go`
- Request validation, async-invoke response shaping, LastUpdateStatus serialization -> `server/aws/lambda/handler.go` + `types.go`
- No shared driver interface changed; no coverage docs regeneration needed.

## Tests

- `server/aws/lambda/create_defaults_test.go` — default memory/timeout round-trip; zip-without-runtime/handler rejection.
- `server/aws/lambda/invoke_async_test.go` — Event->202/empty, RequestResponse->200/payload guard, LastUpdateStatus=Successful across create/update/get.
- Updated existing `lambda_test.go` fixtures that created zip functions without a Handler (which real AWS also rejects).

## Gates

`go build ./...`, `go test ./providers/aws/lambda/... ./server/aws/lambda/...`, and the compat suite `go test ./compat/...` all pass; gofmt clean; golangci-lint adds 0 new issues in changed files.