### PR TITLE
fix(azure): implement Microsoft.Network/networkInterfaces (subnet→NIC→VM bridge)

### DIFF
--- a/docs/coverage/aws/vpc.md
+++ b/docs/coverage/aws/vpc.md
@@ -69,6 +69,17 @@ AWS's `networking` service · portable interface `driver.Networking` · [AWS ind
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureNetworkInterfaces
+
+AzureNetworkInterfaces is the Azure-specific network-interface surface,
+
+| Operation | Description |
+| --- | --- |
+| `CreateOrUpdateNetworkInterface` |  |
+| `DeleteNetworkInterface` |  |
+| `GetNetworkInterface` |  |
+| `ListNetworkInterfaces` |  |
+
 ### ClientVPN
 
 ClientVPN is an OPTIONAL AWS capability (type-asserted).

--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -69,6 +69,17 @@ Azure's `networking` service · portable interface `driver.Networking` · [Azure
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureNetworkInterfaces
+
+AzureNetworkInterfaces is the Azure-specific network-interface surface,
+
+| Operation | Description |
+| --- | --- |
+| `CreateOrUpdateNetworkInterface` |  |
+| `DeleteNetworkInterface` |  |
+| `GetNetworkInterface` |  |
+| `ListNetworkInterfaces` |  |
+
 ### ClientVPN
 
 ClientVPN is an OPTIONAL AWS capability (type-asserted).

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -6154,6 +6154,24 @@
     ],
     "optionalCapabilities": [
       {
+        "name": "AzureNetworkInterfaces",
+        "doc": "AzureNetworkInterfaces is the Azure-specific network-interface surface,",
+        "operations": [
+          {
+            "name": "CreateOrUpdateNetworkInterface"
+          },
+          {
+            "name": "DeleteNetworkInterface"
+          },
+          {
+            "name": "GetNetworkInterface"
+          },
+          {
+            "name": "ListNetworkInterfaces"
+          }
+        ]
+      },
+      {
         "name": "ClientVPN",
         "doc": "ClientVPN is an OPTIONAL AWS capability (type-asserted).",
         "operations": [

--- a/docs/coverage/gcp/vpc.md
+++ b/docs/coverage/gcp/vpc.md
@@ -69,6 +69,17 @@ GCP's `networking` service · portable interface `driver.Networking` · [GCP ind
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureNetworkInterfaces
+
+AzureNetworkInterfaces is the Azure-specific network-interface surface,
+
+| Operation | Description |
+| --- | --- |
+| `CreateOrUpdateNetworkInterface` |  |
+| `DeleteNetworkInterface` |  |
+| `GetNetworkInterface` |  |
+| `ListNetworkInterfaces` |  |
+
 ### ClientVPN
 
 ClientVPN is an OPTIONAL AWS capability (type-asserted).

--- a/docs/coverage/oci/vcn.md
+++ b/docs/coverage/oci/vcn.md
@@ -69,6 +69,17 @@ OCI's `networking` service · portable interface `driver.Networking` · [OCI ind
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureNetworkInterfaces
+
+AzureNetworkInterfaces is the Azure-specific network-interface surface,
+
+| Operation | Description |
+| --- | --- |
+| `CreateOrUpdateNetworkInterface` |  |
+| `DeleteNetworkInterface` |  |
+| `GetNetworkInterface` |  |
+| `ListNetworkInterfaces` |  |
+
 ### ClientVPN
 
 ClientVPN is an OPTIONAL AWS capability (type-asserted).

--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -192,7 +192,7 @@ All handlers speak ARM JSON over HTTPS unless noted.
 | **Disks / Snapshots / Images / SSH Public Keys** | `Microsoft.Compute/{disks,snapshots,images,sshPublicKeys}` — full CRUD |
 | **Blob Storage** *(data plane)* | Containers + Blobs: Create/Delete/List, PutBlob, GetBlob, DeleteBlob, CopyBlob |
 | **Cosmos DB** *(data plane)* | Databases, Containers, Documents — full CRUD with `x-ms-documentdb-*` headers |
-| **Virtual Network** | `Microsoft.Network/virtualNetworks` — CRUD + subnets |
+| **Virtual Network** | `Microsoft.Network/{virtualNetworks,networkSecurityGroups,publicIPAddresses,networkInterfaces}` — CRUD + nested subnets; NICs bind a subnet and get a private IP |
 | **Azure Monitor** | `microsoft.insights/metricAlerts` and metric data ingest/read |
 | **Functions** | `Microsoft.Web/sites` (Function Apps): CreateOrUpdate, Get, List, Delete + non-ARM `/api/{name}` invoke |
 | **Service Bus** | `Microsoft.ServiceBus/namespaces[/queues]` ARM CRUD + raw-HTTP REST data plane (`POST /{ns}/{queue}/messages`, `DELETE /messages/head`) |

--- a/providers/azure/vnet/network_interface.go
+++ b/providers/azure/vnet/network_interface.go
@@ -3,6 +3,7 @@ package vnet
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"net"
 	"strings"
 
@@ -146,7 +147,9 @@ func (m *Mock) ListNetworkInterfaces(_ context.Context, resourceGroup string) ([
 
 	out := make([]driver.AzureNIC, 0)
 
-	for _, nic := range m.nics.All() {
+	// SortedValues (not All) so list ordering is deterministic across calls,
+	// matching real ARM list semantics.
+	for _, nic := range m.nics.SortedValues() {
 		if resourceGroup != "" && !strings.EqualFold(nic.ResourceGroup, resourceGroup) {
 			continue
 		}
@@ -283,27 +286,37 @@ func toAzureNIC(n *nicData) driver.AzureNIC {
 	}
 }
 
-// generateMAC returns a deterministic locally-administered MAC using Azure's
-// 00-0D-3A OUI prefix, so tests under a fake clock stay reproducible.
+// generateMAC returns a distinct locally-administered MAC under Azure's
+// 00-0D-3A OUI prefix. The last three octets come from a hash of a unique id,
+// so every NIC gets its own address (a plain counter's %08x string is a fixed
+// length, which is why the octets must derive from the id's content, not len).
 func generateMAC() string {
-	id := idgen.GenerateID("")
+	h := fmt.Sprintf("%08x", fnvHash32(idgen.GenerateID("mac-")))
 
-	return fmt.Sprintf("00-0D-3A-%02X-%02X-%02X",
-		len(id)%maxOctetValue, (len(id)*7)%maxOctetValue, (len(id)*13)%maxOctetValue)
+	return fmt.Sprintf("00-0D-3A-%s-%s-%s", h[0:2], h[2:4], h[4:6])
 }
 
-// generateGUID returns a GUID-shaped identifier for resourceGuid fields.
+// generateGUID returns a distinct GUID-shaped identifier for resourceGuid
+// fields, built by hex-slicing two hashes of unique ids (string slicing avoids
+// any narrowing integer conversion).
 func generateGUID() string {
-	return fmt.Sprintf("%s-0000-0000-0000-000000000000", padHex(idgen.GenerateID("")))
+	a := fmt.Sprintf("%016x", fnvHash64(idgen.GenerateID("guid-")))
+	b := fmt.Sprintf("%016x", fnvHash64(idgen.GenerateID("guid2-")))
+	hx := a + b
+
+	return fmt.Sprintf("%s-%s-%s-%s-%s", hx[0:8], hx[8:12], hx[12:16], hx[16:20], hx[20:32])
 }
 
-func padHex(s string) string {
-	const width = 8
+func fnvHash32(s string) uint32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(s))
 
-	h := fmt.Sprintf("%x", s)
-	if len(h) >= width {
-		return h[:width]
-	}
+	return h.Sum32()
+}
 
-	return strings.Repeat("0", width-len(h)) + h
+func fnvHash64(s string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(s))
+
+	return h.Sum64()
 }

--- a/providers/azure/vnet/network_interface.go
+++ b/providers/azure/vnet/network_interface.go
@@ -1,0 +1,309 @@
+package vnet
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// Compile-time check that Mock serves the Azure network-interface surface.
+var _ driver.AzureNetworkInterfaces = (*Mock)(nil)
+
+// Azure reserves the first four host addresses of every subnet (the network
+// address, the default gateway, and two for Azure-internal use), so the first
+// assignable private IP is the fourth host. (Azure VNet subnet-address FAQ.)
+const azureReservedHosts = 4
+
+// Allocation methods for an ipConfiguration's private IP.
+const (
+	allocationDynamic = "Dynamic"
+	allocationStatic  = "Static"
+)
+
+// nicData is the stored Azure network interface, keyed by (resourceGroup, name).
+type nicData struct {
+	Name              string
+	ResourceGroup     string
+	Location          string
+	Tags              map[string]string
+	IPConfigs         []driver.AzureIPConfig
+	IPForwarding      bool
+	MACAddress        string
+	ResourceGUID      string
+	ProvisioningState string
+	ETag              string
+	VirtualMachineID  string
+}
+
+// nicKey composes the store key from the ARM addressing pair. Resource-group
+// names are case-insensitive in Azure, so it is lower-cased; the interface name
+// is preserved as-is.
+func nicKey(resourceGroup, name string) string {
+	return strings.ToLower(resourceGroup) + "/" + name
+}
+
+// CreateOrUpdateNetworkInterface creates a NIC or updates it in place. It is
+// idempotent by (resourceGroup, name): a second PUT to the same pair updates
+// the existing interface rather than creating a duplicate, matching ARM.
+func (m *Mock) CreateOrUpdateNetworkInterface(
+	_ context.Context, resourceGroup, name string, cfg driver.AzureNICConfig,
+) (*driver.AzureNIC, error) {
+	if resourceGroup == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "resource group is required")
+	}
+
+	if name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "network interface name is required")
+	}
+
+	m.nicMu.Lock()
+	defer m.nicMu.Unlock()
+
+	key := nicKey(resourceGroup, name)
+	existing, isUpdate := m.nics.Get(key)
+
+	ipConfigs, err := m.resolveIPConfigs(cfg.IPConfigs, key)
+	if err != nil {
+		return nil, err
+	}
+
+	nic := &nicData{
+		Name:              name,
+		ResourceGroup:     resourceGroup,
+		Location:          cfg.Location,
+		Tags:              copyTags(cfg.Tags),
+		IPConfigs:         ipConfigs,
+		IPForwarding:      cfg.IPForwarding,
+		ProvisioningState: "Succeeded",
+		ETag:              `W/"` + idgen.GenerateID("etag-") + `"`,
+	}
+
+	if isUpdate {
+		// Preserve server-assigned identity across updates, matching ARM.
+		nic.MACAddress = existing.MACAddress
+		nic.ResourceGUID = existing.ResourceGUID
+		nic.VirtualMachineID = existing.VirtualMachineID
+	} else {
+		nic.MACAddress = generateMAC()
+		nic.ResourceGUID = generateGUID()
+	}
+
+	m.nics.Set(key, nic)
+
+	out := toAzureNIC(nic)
+
+	return &out, nil
+}
+
+// GetNetworkInterface returns the NIC identified by (resourceGroup, name).
+func (m *Mock) GetNetworkInterface(_ context.Context, resourceGroup, name string) (*driver.AzureNIC, error) {
+	m.nicMu.RLock()
+	defer m.nicMu.RUnlock()
+
+	nic, ok := m.nics.Get(nicKey(resourceGroup, name))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "network interface %q not found in resource group %q", name, resourceGroup)
+	}
+
+	out := toAzureNIC(nic)
+
+	return &out, nil
+}
+
+// DeleteNetworkInterface removes a NIC. A NIC attached to a VM cannot be
+// deleted, matching ARM's InUseNetworkInterfaceCannotBeDeleted.
+func (m *Mock) DeleteNetworkInterface(_ context.Context, resourceGroup, name string) error {
+	m.nicMu.Lock()
+	defer m.nicMu.Unlock()
+
+	key := nicKey(resourceGroup, name)
+
+	nic, ok := m.nics.Get(key)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "network interface %q not found in resource group %q", name, resourceGroup)
+	}
+
+	if nic.VirtualMachineID != "" {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"network interface %q cannot be deleted because it is attached to %q", name, nic.VirtualMachineID)
+	}
+
+	m.nics.Delete(key)
+
+	return nil
+}
+
+// ListNetworkInterfaces returns NICs in a resource group, or all when
+// resourceGroup is empty (subscription-wide list).
+func (m *Mock) ListNetworkInterfaces(_ context.Context, resourceGroup string) ([]driver.AzureNIC, error) {
+	m.nicMu.RLock()
+	defer m.nicMu.RUnlock()
+
+	out := make([]driver.AzureNIC, 0)
+
+	for _, nic := range m.nics.All() {
+		if resourceGroup != "" && !strings.EqualFold(nic.ResourceGroup, resourceGroup) {
+			continue
+		}
+
+		out = append(out, toAzureNIC(nic))
+	}
+
+	return out, nil
+}
+
+// resolveIPConfigs fills in a private IP for every Dynamic ipConfiguration by
+// allocating the next free host from the referenced subnet's prefix, leaving
+// Static configs' submitted address untouched. selfKey is excluded from the
+// in-use scan so a re-PUT of the same NIC doesn't collide with its own IPs.
+func (m *Mock) resolveIPConfigs(configs []driver.AzureIPConfig, selfKey string) ([]driver.AzureIPConfig, error) {
+	out := make([]driver.AzureIPConfig, 0, len(configs))
+
+	for i := range configs {
+		cfg := configs[i]
+
+		method := cfg.AllocationMethod
+		if method == "" {
+			method = allocationDynamic
+		}
+
+		cfg.AllocationMethod = method
+
+		if method == allocationStatic {
+			if cfg.PrivateIP == "" {
+				return nil, cerrors.New(cerrors.InvalidArgument,
+					"a Static ipConfiguration requires privateIPAddress")
+			}
+
+			out = append(out, cfg)
+
+			continue
+		}
+
+		// Dynamic: allocate from the subnet prefix if one was resolved.
+		if cfg.SubnetCIDR != "" && cfg.PrivateIP == "" {
+			ip, err := m.allocatePrivateIP(cfg.SubnetID, cfg.SubnetCIDR, selfKey)
+			if err != nil {
+				return nil, err
+			}
+
+			cfg.PrivateIP = ip
+		}
+
+		out = append(out, cfg)
+	}
+
+	return out, nil
+}
+
+// allocatePrivateIP returns the lowest free host in cidr (starting past Azure's
+// reserved addresses) that no other NIC's ipConfiguration in the same subnet
+// already holds.
+func (m *Mock) allocatePrivateIP(subnetID, cidr, selfKey string) (string, error) {
+	baseIP, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", cerrors.Newf(cerrors.InvalidArgument, "invalid subnet CIDR %q: %v", cidr, err)
+	}
+
+	used := m.usedPrivateIPs(subnetID, selfKey)
+
+	candidate := make(net.IP, len(baseIP.To4()))
+	copy(candidate, baseIP.To4())
+
+	for host := azureReservedHosts; ; host++ {
+		ip := addHost(candidate, host)
+		if !ipNet.Contains(ip) {
+			return "", cerrors.Newf(cerrors.ResourceExhausted, "subnet %q has no free private IP", subnetID)
+		}
+
+		s := ip.String()
+		if !used[s] {
+			return s, nil
+		}
+	}
+}
+
+// usedPrivateIPs collects the private IPs already assigned in subnetID across
+// every stored NIC except the one being updated (selfKey).
+func (m *Mock) usedPrivateIPs(subnetID, selfKey string) map[string]bool {
+	used := make(map[string]bool)
+
+	for key, nic := range m.nics.All() {
+		if key == selfKey {
+			continue
+		}
+
+		for _, ipc := range nic.IPConfigs {
+			if ipc.SubnetID == subnetID && ipc.PrivateIP != "" {
+				used[ipc.PrivateIP] = true
+			}
+		}
+	}
+
+	return used
+}
+
+// addHost returns base (an IPv4 network address) plus n host addresses.
+func addHost(base net.IP, n int) net.IP {
+	v4 := base.To4()
+	out := make(net.IP, len(v4))
+	copy(out, v4)
+
+	carry := n
+	for i := len(out) - 1; i >= 0 && carry > 0; i-- {
+		sum := int(out[i]) + carry
+		out[i] = byte(sum % maxOctetValue) //nolint:gosec // sum % 256 is always within byte range
+		carry = sum / maxOctetValue
+	}
+
+	return out
+}
+
+func toAzureNIC(n *nicData) driver.AzureNIC {
+	configs := make([]driver.AzureIPConfig, len(n.IPConfigs))
+	copy(configs, n.IPConfigs)
+
+	return driver.AzureNIC{
+		Name:              n.Name,
+		ResourceGroup:     n.ResourceGroup,
+		Location:          n.Location,
+		Tags:              copyTags(n.Tags),
+		IPConfigs:         configs,
+		IPForwarding:      n.IPForwarding,
+		MACAddress:        n.MACAddress,
+		ResourceGUID:      n.ResourceGUID,
+		ProvisioningState: n.ProvisioningState,
+		ETag:              n.ETag,
+		VirtualMachineID:  n.VirtualMachineID,
+	}
+}
+
+// generateMAC returns a deterministic locally-administered MAC using Azure's
+// 00-0D-3A OUI prefix, so tests under a fake clock stay reproducible.
+func generateMAC() string {
+	id := idgen.GenerateID("")
+
+	return fmt.Sprintf("00-0D-3A-%02X-%02X-%02X",
+		len(id)%maxOctetValue, (len(id)*7)%maxOctetValue, (len(id)*13)%maxOctetValue)
+}
+
+// generateGUID returns a GUID-shaped identifier for resourceGuid fields.
+func generateGUID() string {
+	return fmt.Sprintf("%s-0000-0000-0000-000000000000", padHex(idgen.GenerateID("")))
+}
+
+func padHex(s string) string {
+	const width = 8
+
+	h := fmt.Sprintf("%x", s)
+	if len(h) >= width {
+		return h[:width]
+	}
+
+	return strings.Repeat("0", width-len(h)) + h
+}

--- a/providers/azure/vnet/network_interface_test.go
+++ b/providers/azure/vnet/network_interface_test.go
@@ -168,6 +168,19 @@ func TestNICDistinctMACAndGUID(t *testing.T) {
 	}
 }
 
+func TestNICSubnetExhaustedIsResourceExhausted(t *testing.T) {
+	m := newNICMock(t)
+	ctx := context.Background()
+
+	// A /30 has hosts .0-.3, all reserved by Azure, so the first assignable
+	// host (.4) is already outside the block — allocation must report exhaustion
+	// (which the wire layer maps to HTTP 400, not 500).
+	_, err := m.CreateOrUpdateNetworkInterface(ctx, "rg-1", "nic-tight", dynamicConfig("subnet-tiny", "10.0.0.0/30"))
+	if cerrors.GetCode(err) != cerrors.ResourceExhausted {
+		t.Errorf("err=%v want ResourceExhausted for a /30 with no assignable host", err)
+	}
+}
+
 func TestNICDeleteAttachedIsRejected(t *testing.T) {
 	m := newNICMock(t)
 	ctx := context.Background()

--- a/providers/azure/vnet/network_interface_test.go
+++ b/providers/azure/vnet/network_interface_test.go
@@ -1,0 +1,168 @@
+package vnet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func newNICMock(t *testing.T) *Mock {
+	t.Helper()
+
+	return New(config.NewOptions())
+}
+
+func dynamicConfig(subnetID, cidr string) driver.AzureNICConfig {
+	return driver.AzureNICConfig{
+		Location: "eastus",
+		IPConfigs: []driver.AzureIPConfig{{
+			Name:       "ipconfig1",
+			SubnetID:   subnetID,
+			SubnetCIDR: cidr,
+			Primary:    true,
+		}},
+	}
+}
+
+func TestNICCreateAllocatesPrivateIP(t *testing.T) {
+	m := newNICMock(t)
+	ctx := context.Background()
+
+	nic, err := m.CreateOrUpdateNetworkInterface(ctx, "rg-1", "nic-a", dynamicConfig("subnet-1", "10.0.1.0/24"))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if got := nic.IPConfigs[0].PrivateIP; got != "10.0.1.4" {
+		t.Errorf("privateIP=%q want 10.0.1.4", got)
+	}
+
+	if nic.IPConfigs[0].AllocationMethod != "Dynamic" {
+		t.Errorf("allocationMethod=%q want Dynamic (default)", nic.IPConfigs[0].AllocationMethod)
+	}
+
+	if nic.MACAddress == "" || nic.ResourceGUID == "" || nic.ETag == "" {
+		t.Errorf("server-assigned fields empty: mac=%q guid=%q etag=%q", nic.MACAddress, nic.ResourceGUID, nic.ETag)
+	}
+}
+
+func TestNICAllocationIsSequentialAndCollisionFree(t *testing.T) {
+	m := newNICMock(t)
+	ctx := context.Background()
+
+	a, _ := m.CreateOrUpdateNetworkInterface(ctx, "rg-1", "nic-a", dynamicConfig("subnet-1", "10.0.1.0/24"))
+	b, _ := m.CreateOrUpdateNetworkInterface(ctx, "rg-1", "nic-b", dynamicConfig("subnet-1", "10.0.1.0/24"))
+
+	if a.IPConfigs[0].PrivateIP != "10.0.1.4" || b.IPConfigs[0].PrivateIP != "10.0.1.5" {
+		t.Errorf("IPs = %q, %q; want 10.0.1.4, 10.0.1.5", a.IPConfigs[0].PrivateIP, b.IPConfigs[0].PrivateIP)
+	}
+
+	// A NIC in a different subnet starts its own range.
+	c, _ := m.CreateOrUpdateNetworkInterface(ctx, "rg-1", "nic-c", dynamicConfig("subnet-2", "10.0.2.0/24"))
+	if c.IPConfigs[0].PrivateIP != "10.0.2.4" {
+		t.Errorf("subnet-2 IP=%q want 10.0.2.4", c.IPConfigs[0].PrivateIP)
+	}
+}
+
+func TestNICIdempotentUpdateKeepsIdentityAndIP(t *testing.T) {
+	m := newNICMock(t)
+	ctx := context.Background()
+
+	first, _ := m.CreateOrUpdateNetworkInterface(ctx, "rg-1", "nic-a", dynamicConfig("subnet-1", "10.0.1.0/24"))
+	second, err := m.CreateOrUpdateNetworkInterface(ctx, "rg-1", "nic-a", dynamicConfig("subnet-1", "10.0.1.0/24"))
+	if err != nil {
+		t.Fatalf("re-put: %v", err)
+	}
+
+	list, _ := m.ListNetworkInterfaces(ctx, "rg-1")
+	if len(list) != 1 {
+		t.Fatalf("list=%d want 1 (idempotent PUT must not duplicate)", len(list))
+	}
+
+	if second.ResourceGUID != first.ResourceGUID {
+		t.Errorf("resourceGuid changed on update: %q -> %q", first.ResourceGUID, second.ResourceGUID)
+	}
+
+	if second.IPConfigs[0].PrivateIP != "10.0.1.4" {
+		t.Errorf("re-PUT reallocated a different IP %q, want stable 10.0.1.4", second.IPConfigs[0].PrivateIP)
+	}
+}
+
+func TestNICStaticAllocation(t *testing.T) {
+	m := newNICMock(t)
+	ctx := context.Background()
+
+	cfg := driver.AzureNICConfig{
+		Location: "eastus",
+		IPConfigs: []driver.AzureIPConfig{{
+			Name:             "ipconfig1",
+			SubnetID:         "subnet-1",
+			SubnetCIDR:       "10.0.1.0/24",
+			AllocationMethod: "Static",
+			PrivateIP:        "10.0.1.50",
+		}},
+	}
+
+	nic, err := m.CreateOrUpdateNetworkInterface(ctx, "rg-1", "nic-static", cfg)
+	if err != nil {
+		t.Fatalf("create static: %v", err)
+	}
+
+	if nic.IPConfigs[0].PrivateIP != "10.0.1.50" {
+		t.Errorf("static IP=%q want 10.0.1.50 (submitted value must be kept)", nic.IPConfigs[0].PrivateIP)
+	}
+}
+
+func TestNICStaticRequiresAddress(t *testing.T) {
+	m := newNICMock(t)
+
+	cfg := driver.AzureNICConfig{
+		IPConfigs: []driver.AzureIPConfig{{Name: "ipconfig1", AllocationMethod: "Static"}},
+	}
+
+	_, err := m.CreateOrUpdateNetworkInterface(context.Background(), "rg-1", "nic-bad", cfg)
+	if !cerrors.IsInvalidArgument(err) {
+		t.Errorf("err=%v want InvalidArgument for Static without privateIPAddress", err)
+	}
+}
+
+func TestNICResourceGroupScoping(t *testing.T) {
+	m := newNICMock(t)
+	ctx := context.Background()
+
+	_, _ = m.CreateOrUpdateNetworkInterface(ctx, "rg-1", "nic-a", dynamicConfig("subnet-1", "10.0.1.0/24"))
+	_, _ = m.CreateOrUpdateNetworkInterface(ctx, "rg-2", "nic-b", dynamicConfig("subnet-9", "10.9.1.0/24"))
+
+	rg1, _ := m.ListNetworkInterfaces(ctx, "rg-1")
+	if len(rg1) != 1 || rg1[0].Name != "nic-a" {
+		t.Errorf("ListNetworkInterfaces(rg-1)=%v want just nic-a", rg1)
+	}
+
+	// A NIC in rg-1 must not be resolvable from rg-2.
+	if _, err := m.GetNetworkInterface(ctx, "rg-2", "nic-a"); !cerrors.IsNotFound(err) {
+		t.Errorf("cross-RG Get err=%v want NotFound", err)
+	}
+
+	all, _ := m.ListNetworkInterfaces(ctx, "")
+	if len(all) != 2 {
+		t.Errorf("subscription-wide list=%d want 2", len(all))
+	}
+}
+
+func TestNICDeleteAttachedIsRejected(t *testing.T) {
+	m := newNICMock(t)
+	ctx := context.Background()
+
+	_, _ = m.CreateOrUpdateNetworkInterface(ctx, "rg-1", "nic-a", dynamicConfig("subnet-1", "10.0.1.0/24"))
+
+	// Simulate attachment to a VM.
+	nic, _ := m.nics.Get(nicKey("rg-1", "nic-a"))
+	nic.VirtualMachineID = "/subscriptions/s/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/vm-a"
+
+	if err := m.DeleteNetworkInterface(ctx, "rg-1", "nic-a"); !cerrors.IsFailedPrecondition(err) {
+		t.Errorf("delete attached err=%v want FailedPrecondition", err)
+	}
+}

--- a/providers/azure/vnet/network_interface_test.go
+++ b/providers/azure/vnet/network_interface_test.go
@@ -152,6 +152,22 @@ func TestNICResourceGroupScoping(t *testing.T) {
 	}
 }
 
+func TestNICDistinctMACAndGUID(t *testing.T) {
+	m := newNICMock(t)
+	ctx := context.Background()
+
+	a, _ := m.CreateOrUpdateNetworkInterface(ctx, "rg-1", "nic-a", dynamicConfig("subnet-1", "10.0.1.0/24"))
+	b, _ := m.CreateOrUpdateNetworkInterface(ctx, "rg-1", "nic-b", dynamicConfig("subnet-1", "10.0.1.0/24"))
+
+	if a.MACAddress == b.MACAddress {
+		t.Errorf("both NICs got the same MAC %q; each NIC must get a distinct address", a.MACAddress)
+	}
+
+	if a.ResourceGUID == b.ResourceGUID {
+		t.Errorf("both NICs got the same resourceGuid %q; must be distinct", a.ResourceGUID)
+	}
+}
+
 func TestNICDeleteAttachedIsRejected(t *testing.T) {
 	m := newNICMock(t)
 	ctx := context.Background()

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -3,6 +3,7 @@ package vnet
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -62,7 +63,12 @@ type Mock struct {
 	eips           *memstore.Store[*eipData]
 	rtAssocs       *memstore.Store[*rtAssocData]
 	endpoints      *memstore.Store[*driver.VPCEndpoint]
-	opts           *config.Options
+	nics           *memstore.Store[*nicData]
+	// nicMu serializes network-interface create/update, whose private-IP
+	// allocation is a read-modify-write across the nics store (memstore is
+	// per-op safe but can't make that sequence atomic).
+	nicMu sync.RWMutex
+	opts  *config.Options
 }
 
 // New creates a new Azure Virtual Network mock.
@@ -80,6 +86,7 @@ func New(opts *config.Options) *Mock {
 		eips:           memstore.New[*eipData](),
 		rtAssocs:       memstore.New[*rtAssocData](),
 		endpoints:      memstore.New[*driver.VPCEndpoint](),
+		nics:           memstore.New[*nicData](),
 		opts:           opts,
 	}
 }

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -12,6 +12,8 @@
 //	GET .../virtualNetworks/{vn}/subnets                 — list subnets
 //	PUT/GET/DELETE  .../networkSecurityGroups/{name}     — NSG CRUD
 //	GET .../networkSecurityGroups                        — list NSGs
+//	PUT/GET/DELETE  .../networkInterfaces/{name}         — NIC CRUD
+//	GET .../networkInterfaces                            — list NICs
 package vnet
 
 import (
@@ -62,7 +64,7 @@ func (*Handler) Matches(r *http.Request) bool {
 	}
 
 	switch rp.ResourceType {
-	case typeVNet, typeNSG, typePublicIP, typeLocations:
+	case typeVNet, typeNSG, typePublicIP, typeNIC, typeLocations:
 		return true
 	}
 
@@ -93,6 +95,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routeNSG(w, r, rp)
 	case typePublicIP:
 		h.routePublicIP(w, r, rp)
+	case typeNIC:
+		h.routeNIC(w, r, rp)
 	default:
 		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
 			"unsupported resource type: "+rp.ResourceType)

--- a/server/azure/vnet/network_interface.go
+++ b/server/azure/vnet/network_interface.go
@@ -165,7 +165,15 @@ func (*Handler) deleteNIC(w http.ResponseWriter, r *http.Request, rp azurearm.Re
 	svc netdriver.AzureNetworkInterfaces,
 ) {
 	if err := svc.DeleteNetworkInterface(r.Context(), rp.ResourceGroup, rp.ResourceName); err != nil {
+		// A NIC attached to a VM: ARM answers 400 with this specific code, which
+		// armnetwork clients switch on — not the generic 409 WriteCErr would emit.
+		if cerrors.IsFailedPrecondition(err) {
+			azurearm.WriteError(w, http.StatusBadRequest, "InUseNetworkInterfaceCannotBeDeleted", err.Error())
+			return
+		}
+
 		azurearm.WriteCErr(w, err)
+
 		return
 	}
 
@@ -223,6 +231,12 @@ func (h *Handler) buildIPConfigs(ctx context.Context, in []nicIPConfigRequest) (
 		}
 
 		if p.PublicIPAddress != nil {
+			pipName := lastSegment(p.PublicIPAddress.ID)
+			if _, err := findPublicIPByName(ctx, h.net, pipName); err != nil {
+				return nil, cerrors.Newf(cerrors.InvalidArgument,
+					"ipConfiguration references public IP %q which does not exist", pipName)
+			}
+
 			cfg.PublicIPID = p.PublicIPAddress.ID
 		}
 
@@ -235,18 +249,33 @@ func (h *Handler) buildIPConfigs(ctx context.Context, in []nicIPConfigRequest) (
 // subnetCIDR resolves the address prefix of the subnet named by an ARM subnet
 // resource id (.../virtualNetworks/{vn}/subnets/{name}).
 func (h *Handler) subnetCIDR(ctx context.Context, subnetID string) (string, error) {
-	name := lastSegment(subnetID)
-	if name == "" {
+	// Resolve scoped by (vnet, subnet): subnet names are only unique within a
+	// vnet, so a name-only lookup would allocate from the wrong address space
+	// when two vnets share a subnet name (e.g. every vnet has a "default").
+	sp, ok := azurearm.ParsePath(subnetID)
+	if !ok || sp.ResourceType != typeVNet || sp.SubResource != subResSubnets || sp.SubResourceName == "" {
 		return "", cerrors.Newf(cerrors.InvalidArgument, "malformed subnet id %q", subnetID)
 	}
 
-	info, err := findSubnetByName(ctx, h.net, name)
+	vnet, err := findVNetByName(ctx, h.net, sp.ResourceName)
 	if err != nil {
 		return "", cerrors.Newf(cerrors.InvalidArgument,
-			"ipConfiguration references subnet %q which does not exist", name)
+			"ipConfiguration references vnet %q which does not exist", sp.ResourceName)
 	}
 
-	return info.CIDRBlock, nil
+	subs, err := h.net.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return "", err
+	}
+
+	for i := range subs {
+		if subs[i].VPCID == vnet.ID && tagOr(subs[i].Tags, armSubnetTag, "") == sp.SubResourceName {
+			return subs[i].CIDRBlock, nil
+		}
+	}
+
+	return "", cerrors.Newf(cerrors.InvalidArgument,
+		"ipConfiguration references subnet %q which does not exist in vnet %q", sp.SubResourceName, sp.ResourceName)
 }
 
 func lastSegment(id string) string {

--- a/server/azure/vnet/network_interface.go
+++ b/server/azure/vnet/network_interface.go
@@ -1,0 +1,314 @@
+package vnet
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+const typeNIC = "networkInterfaces"
+
+// ARM JSON shapes for Microsoft.Network/networkInterfaces.
+
+type nicRequest struct {
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties nicRequestProps   `json:"properties"`
+}
+
+type nicRequestProps struct {
+	IPConfigurations   []nicIPConfigRequest `json:"ipConfigurations"`
+	EnableIPForwarding bool                 `json:"enableIPForwarding,omitempty"`
+}
+
+type nicIPConfigRequest struct {
+	Name       string                  `json:"name"`
+	Properties nicIPConfigRequestProps `json:"properties"`
+}
+
+type nicIPConfigRequestProps struct {
+	PrivateIPAddress          string    `json:"privateIPAddress,omitempty"`
+	PrivateIPAllocationMethod string    `json:"privateIPAllocationMethod,omitempty"`
+	Primary                   bool      `json:"primary,omitempty"`
+	Subnet                    *armIDRef `json:"subnet,omitempty"`
+	PublicIPAddress           *armIDRef `json:"publicIPAddress,omitempty"`
+}
+
+type armIDRef struct {
+	ID string `json:"id"`
+}
+
+type nicResponse struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	ETag       string            `json:"etag,omitempty"`
+	Properties nicResponseProps  `json:"properties"`
+}
+
+type nicResponseProps struct {
+	ProvisioningState  string                `json:"provisioningState"`
+	ResourceGUID       string                `json:"resourceGuid,omitempty"`
+	MACAddress         string                `json:"macAddress,omitempty"`
+	EnableIPForwarding bool                  `json:"enableIPForwarding"`
+	IPConfigurations   []nicIPConfigResponse `json:"ipConfigurations"`
+	VirtualMachine     *armIDRef             `json:"virtualMachine,omitempty"`
+}
+
+type nicIPConfigResponse struct {
+	Name       string                   `json:"name"`
+	Properties nicIPConfigResponseProps `json:"properties"`
+}
+
+type nicIPConfigResponseProps struct {
+	ProvisioningState         string    `json:"provisioningState"`
+	PrivateIPAddress          string    `json:"privateIPAddress,omitempty"`
+	PrivateIPAllocationMethod string    `json:"privateIPAllocationMethod"`
+	Primary                   bool      `json:"primary"`
+	Subnet                    *armIDRef `json:"subnet,omitempty"`
+	PublicIPAddress           *armIDRef `json:"publicIPAddress,omitempty"`
+}
+
+type nicListResponse struct {
+	Value []nicResponse `json:"value"`
+}
+
+// routeNIC dispatches Microsoft.Network/networkInterfaces requests. The
+// networking driver serves NICs through the Azure-specific optional capability;
+// a driver that doesn't implement it reports NotImplemented.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) routeNIC(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	svc, ok := h.net.(netdriver.AzureNetworkInterfaces)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"network interfaces are not supported by this networking driver")
+
+		return
+	}
+
+	if rp.ResourceName == "" {
+		h.listNICs(w, r, rp, svc)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createNIC(w, r, rp, svc)
+	case http.MethodGet:
+		h.getNIC(w, r, rp, svc)
+	case http.MethodDelete:
+		h.deleteNIC(w, r, rp, svc)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) createNIC(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkInterfaces,
+) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	var req nicRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	ipConfigs, err := h.buildIPConfigs(r.Context(), req.Properties.IPConfigurations)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	cfg := netdriver.AzureNICConfig{
+		Location:     req.Location,
+		Tags:         req.Tags,
+		IPConfigs:    ipConfigs,
+		IPForwarding: req.Properties.EnableIPForwarding,
+	}
+
+	nic, err := svc.CreateOrUpdateNetworkInterface(r.Context(), rp.ResourceGroup, rp.ResourceName, cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "nic-create-"+rp.ResourceName, toNICResponse(nic, rp))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) getNIC(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkInterfaces,
+) {
+	nic, err := svc.GetNetworkInterface(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toNICResponse(nic, rp))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) deleteNIC(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkInterfaces,
+) {
+	if err := svc.DeleteNetworkInterface(r.Context(), rp.ResourceGroup, rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "nic-delete-"+rp.ResourceName, nil)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) listNICs(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkInterfaces,
+) {
+	// An empty ResourceGroup in the path means a subscription-wide list.
+	nics, err := svc.ListNetworkInterfaces(r.Context(), rp.ResourceGroup)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := nicListResponse{Value: make([]nicResponse, 0, len(nics))}
+
+	for i := range nics {
+		scope := rp
+		scope.ResourceGroup = nics[i].ResourceGroup
+		scope.ResourceName = nics[i].Name
+		out.Value = append(out.Value, toNICResponse(&nics[i], scope))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+// buildIPConfigs maps the wire ipConfigurations to driver configs, resolving
+// each referenced subnet to its address prefix so the mock can allocate a
+// dynamic private IP from the right range.
+func (h *Handler) buildIPConfigs(ctx context.Context, in []nicIPConfigRequest) ([]netdriver.AzureIPConfig, error) {
+	out := make([]netdriver.AzureIPConfig, 0, len(in))
+
+	for i := range in {
+		p := in[i].Properties
+
+		cfg := netdriver.AzureIPConfig{
+			Name:             in[i].Name,
+			PrivateIP:        p.PrivateIPAddress,
+			AllocationMethod: p.PrivateIPAllocationMethod,
+			Primary:          p.Primary,
+		}
+
+		if p.Subnet != nil {
+			cfg.SubnetID = p.Subnet.ID
+
+			cidr, err := h.subnetCIDR(ctx, p.Subnet.ID)
+			if err != nil {
+				return nil, err
+			}
+
+			cfg.SubnetCIDR = cidr
+		}
+
+		if p.PublicIPAddress != nil {
+			cfg.PublicIPID = p.PublicIPAddress.ID
+		}
+
+		out = append(out, cfg)
+	}
+
+	return out, nil
+}
+
+// subnetCIDR resolves the address prefix of the subnet named by an ARM subnet
+// resource id (.../virtualNetworks/{vn}/subnets/{name}).
+func (h *Handler) subnetCIDR(ctx context.Context, subnetID string) (string, error) {
+	name := lastSegment(subnetID)
+	if name == "" {
+		return "", cerrors.Newf(cerrors.InvalidArgument, "malformed subnet id %q", subnetID)
+	}
+
+	info, err := findSubnetByName(ctx, h.net, name)
+	if err != nil {
+		return "", cerrors.Newf(cerrors.InvalidArgument,
+			"ipConfiguration references subnet %q which does not exist", name)
+	}
+
+	return info.CIDRBlock, nil
+}
+
+func lastSegment(id string) string {
+	id = strings.TrimRight(id, "/")
+
+	if i := strings.LastIndexByte(id, '/'); i >= 0 {
+		return id[i+1:]
+	}
+
+	return id
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toNICResponse(nic *netdriver.AzureNIC, rp azurearm.ResourcePath) nicResponse {
+	loc := nic.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	out := nicResponse{
+		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeNIC, rp.ResourceName),
+		Name:     rp.ResourceName,
+		Type:     providerName + "/" + typeNIC,
+		Location: loc,
+		Tags:     nic.Tags,
+		ETag:     nic.ETag,
+		Properties: nicResponseProps{
+			ProvisioningState:  nic.ProvisioningState,
+			ResourceGUID:       nic.ResourceGUID,
+			MACAddress:         nic.MACAddress,
+			EnableIPForwarding: nic.IPForwarding,
+			IPConfigurations:   make([]nicIPConfigResponse, 0, len(nic.IPConfigs)),
+		},
+	}
+
+	for i := range nic.IPConfigs {
+		c := nic.IPConfigs[i]
+
+		rc := nicIPConfigResponse{
+			Name: c.Name,
+			Properties: nicIPConfigResponseProps{
+				ProvisioningState:         "Succeeded",
+				PrivateIPAddress:          c.PrivateIP,
+				PrivateIPAllocationMethod: c.AllocationMethod,
+				Primary:                   c.Primary,
+			},
+		}
+
+		if c.SubnetID != "" {
+			rc.Properties.Subnet = &armIDRef{ID: c.SubnetID}
+		}
+
+		if c.PublicIPID != "" {
+			rc.Properties.PublicIPAddress = &armIDRef{ID: c.PublicIPID}
+		}
+
+		out.Properties.IPConfigurations = append(out.Properties.IPConfigurations, rc)
+	}
+
+	if nic.VirtualMachineID != "" {
+		out.Properties.VirtualMachine = &armIDRef{ID: nic.VirtualMachineID}
+	}
+
+	return out
+}

--- a/server/azure/vnet/network_interface_test.go
+++ b/server/azure/vnet/network_interface_test.go
@@ -175,6 +175,94 @@ func TestSDKNetworkInterfaceRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSDKNetworkInterfaceCrossVnetSubnetScoping guards the fix for subnet names
+// that collide across vnets: a NIC that references vnet-b's "subnet-1" must get
+// an IP from vnet-b's address space, not vnet-a's.
+func TestSDKNetworkInterfaceCrossVnetSubnetScoping(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Network: cloudP.VNet})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	opts := clientOpts(ts)
+	poll := &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}
+
+	vnetClient, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subnetClient, err := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Two vnets, each with a subnet named "subnet-1" but in different ranges.
+	for _, v := range []struct{ name, vnetCIDR, subnetCIDR string }{
+		{"vnet-a", "10.0.0.0/16", "10.0.1.0/24"},
+		{"vnet-b", "10.9.0.0/16", "10.9.1.0/24"},
+	} {
+		vp, cErr := vnetClient.BeginCreateOrUpdate(ctx, "rg-1", v.name, armnetwork.VirtualNetwork{
+			Location: to.Ptr("eastus"),
+			Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+				AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr(v.vnetCIDR)}},
+			},
+		}, nil)
+		if cErr != nil {
+			t.Fatalf("%s create: %v", v.name, cErr)
+		}
+
+		if _, cErr = vp.PollUntilDone(ctx, poll); cErr != nil {
+			t.Fatalf("%s poll: %v", v.name, cErr)
+		}
+
+		sp, sErr := subnetClient.BeginCreateOrUpdate(ctx, "rg-1", v.name, "subnet-1", armnetwork.Subnet{
+			Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr(v.subnetCIDR)},
+		}, nil)
+		if sErr != nil {
+			t.Fatalf("%s subnet create: %v", v.name, sErr)
+		}
+
+		if _, sErr = sp.PollUntilDone(ctx, poll); sErr != nil {
+			t.Fatalf("%s subnet poll: %v", v.name, sErr)
+		}
+	}
+
+	nicClient, err := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subnetBID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/" +
+		"virtualNetworks/vnet-b/subnets/subnet-1"
+
+	np, err := nicClient.BeginCreateOrUpdate(ctx, "rg-1", "nic-b", armnetwork.Interface{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig1"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					Subnet: &armnetwork.Subnet{ID: to.Ptr(subnetBID)},
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("nic create: %v", err)
+	}
+
+	created, err := np.PollUntilDone(ctx, poll)
+	if err != nil {
+		t.Fatalf("nic poll: %v", err)
+	}
+
+	if ip := privateIP(created.Properties); ip != "10.9.1.4" {
+		t.Errorf("privateIP=%q want 10.9.1.4 (from vnet-b's subnet, not vnet-a's 10.0.1.x)", ip)
+	}
+}
+
 // TestSDKNetworkInterfaceUnknownSubnet confirms a NIC referencing a subnet that
 // does not exist is rejected rather than silently created with no IP.
 func TestSDKNetworkInterfaceUnknownSubnet(t *testing.T) {

--- a/server/azure/vnet/network_interface_test.go
+++ b/server/azure/vnet/network_interface_test.go
@@ -1,0 +1,248 @@
+package vnet_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKNetworkInterfaceRoundTrip drives the real armnetwork InterfacesClient
+// through the subnet→NIC bridge from the audit: create a vnet + subnet, then a
+// NIC that references the subnet, and confirm a private IP is allocated from
+// the subnet prefix, the resource round-trips, PUT is idempotent, and delete
+// works.
+func TestSDKNetworkInterfaceRoundTrip(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Network: cloudP.VNet})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	opts := clientOpts(ts)
+	poll := &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}
+
+	// Seed a vnet + subnet the NIC will bind to.
+	vnetClient, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vp, err := vnetClient.BeginCreateOrUpdate(ctx, "rg-1", "vnet-1", armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("vnet create: %v", err)
+	}
+
+	if _, err = vp.PollUntilDone(ctx, poll); err != nil {
+		t.Fatalf("vnet poll: %v", err)
+	}
+
+	subnetClient, err := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sp, err := subnetClient.BeginCreateOrUpdate(ctx, "rg-1", "vnet-1", "subnet-1", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("subnet create: %v", err)
+	}
+
+	if _, err = sp.PollUntilDone(ctx, poll); err != nil {
+		t.Fatalf("subnet poll: %v", err)
+	}
+
+	subnetID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/" +
+		"virtualNetworks/vnet-1/subnets/subnet-1"
+
+	nicClient, err := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nicBody := armnetwork.Interface{
+		Location: to.Ptr("westus2"),
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig1"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					Subnet:                    &armnetwork.Subnet{ID: to.Ptr(subnetID)},
+					PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+					Primary:                   to.Ptr(true),
+				},
+			}},
+		},
+	}
+
+	np, err := nicClient.BeginCreateOrUpdate(ctx, "rg-1", "nic1", nicBody, nil)
+	if err != nil {
+		t.Fatalf("nic BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := np.PollUntilDone(ctx, poll)
+	if err != nil {
+		t.Fatalf("nic poll: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "nic1" {
+		t.Fatalf("name=%v want nic1", created.Name)
+	}
+
+	if created.Location == nil || *created.Location != "westus2" {
+		t.Errorf("location=%v want westus2 (submitted region must round-trip)", created.Location)
+	}
+
+	if got := provisioningState(created.Properties); got != "Succeeded" {
+		t.Errorf("provisioningState=%q want Succeeded", got)
+	}
+
+	ip := privateIP(created.Properties)
+	if ip != "10.0.1.4" {
+		t.Errorf("privateIPAddress=%q want 10.0.1.4 (first assignable host in 10.0.1.0/24)", ip)
+	}
+
+	if sid := subnetRef(created.Properties); sid != subnetID {
+		t.Errorf("ipConfig subnet id=%q want %q", sid, subnetID)
+	}
+
+	// GET round-trips the same NIC + allocated IP.
+	got, err := nicClient.Get(ctx, "rg-1", "nic1", nil)
+	if err != nil {
+		t.Fatalf("nic Get: %v", err)
+	}
+
+	if privateIP(got.Interface.Properties) != "10.0.1.4" {
+		t.Errorf("GET privateIP=%q want 10.0.1.4", privateIP(got.Interface.Properties))
+	}
+
+	if got.Interface.Tags["env"] == nil || *got.Interface.Tags["env"] != "prod" {
+		t.Errorf("GET tags[env]=%v want prod", got.Interface.Tags["env"])
+	}
+
+	// Idempotent PUT: a second create-or-update updates in place, no duplicate.
+	np2, err := nicClient.BeginCreateOrUpdate(ctx, "rg-1", "nic1", nicBody, nil)
+	if err != nil {
+		t.Fatalf("nic re-PUT: %v", err)
+	}
+
+	if _, err = np2.PollUntilDone(ctx, poll); err != nil {
+		t.Fatalf("nic re-PUT poll: %v", err)
+	}
+
+	count := 0
+	pager := nicClient.NewListPager("rg-1", nil)
+
+	for pager.More() {
+		page, pErr := pager.NextPage(ctx)
+		if pErr != nil {
+			t.Fatalf("nic list: %v", pErr)
+		}
+
+		count += len(page.Value)
+	}
+
+	if count != 1 {
+		t.Errorf("List after idempotent re-PUT returned %d NICs, want 1", count)
+	}
+
+	// Delete.
+	dp, err := nicClient.BeginDelete(ctx, "rg-1", "nic1", nil)
+	if err != nil {
+		t.Fatalf("nic BeginDelete: %v", err)
+	}
+
+	if _, err = dp.PollUntilDone(ctx, poll); err != nil {
+		t.Fatalf("nic delete poll: %v", err)
+	}
+
+	if _, err = nicClient.Get(ctx, "rg-1", "nic1", nil); err == nil {
+		t.Error("Get after delete succeeded, want NotFound")
+	}
+}
+
+// TestSDKNetworkInterfaceUnknownSubnet confirms a NIC referencing a subnet that
+// does not exist is rejected rather than silently created with no IP.
+func TestSDKNetworkInterfaceUnknownSubnet(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Network: cloudP.VNet})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	nicClient, err := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ghost := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/" +
+		"virtualNetworks/vnet-x/subnets/nope"
+
+	_, err = nicClient.BeginCreateOrUpdate(ctx, "rg-1", "nic-bad", armnetwork.Interface{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig1"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					Subnet: &armnetwork.Subnet{ID: to.Ptr(ghost)},
+				},
+			}},
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("NIC create against a missing subnet succeeded, want error")
+	}
+}
+
+// Helpers to read nested NIC response fields without repeating nil checks.
+
+func provisioningState(p *armnetwork.InterfacePropertiesFormat) string {
+	if p == nil || p.ProvisioningState == nil {
+		return ""
+	}
+
+	return string(*p.ProvisioningState)
+}
+
+func privateIP(p *armnetwork.InterfacePropertiesFormat) string {
+	if p == nil || len(p.IPConfigurations) == 0 {
+		return ""
+	}
+
+	ipc := p.IPConfigurations[0]
+	if ipc.Properties == nil || ipc.Properties.PrivateIPAddress == nil {
+		return ""
+	}
+
+	return *ipc.Properties.PrivateIPAddress
+}
+
+func subnetRef(p *armnetwork.InterfacePropertiesFormat) string {
+	if p == nil || len(p.IPConfigurations) == 0 {
+		return ""
+	}
+
+	ipc := p.IPConfigurations[0]
+	if ipc.Properties == nil || ipc.Properties.Subnet == nil || ipc.Properties.Subnet.ID == nil {
+		return ""
+	}
+
+	return *ipc.Properties.Subnet.ID
+}

--- a/server/wire/azurearm/azurearm.go
+++ b/server/wire/azurearm/azurearm.go
@@ -161,6 +161,9 @@ func WriteCErr(w http.ResponseWriter, err error) {
 		WriteError(w, http.StatusBadRequest, "InvalidParameter", err.Error())
 	case cerrors.IsFailedPrecondition(err):
 		WriteError(w, http.StatusConflict, "PreconditionFailed", err.Error())
+	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
+		// e.g. a subnet with no free private IP — ARM answers 400, not 500.
+		WriteError(w, http.StatusBadRequest, "InvalidParameter", err.Error())
 	default:
 		WriteError(w, http.StatusInternalServerError, "InternalError", err.Error())
 	}

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -323,6 +323,58 @@ type NetworkInterface struct {
 	Tags         map[string]string
 }
 
+// Azure network interface (Microsoft.Network/networkInterfaces) is an
+// Azure-specific optional capability, kept out of the cross-cloud Networking
+// interface (Azure NICs carry ipConfigurations, a location, and per-config
+// private-IP allocation that the AWS-shaped ENI model does not). A provider
+// exposes it by implementing AzureNetworkInterfaces; the wire handler reaches
+// it by type assertion, mirroring the AWS-specific NetworkInterfaceCreator
+// surface below.
+
+// AzureIPConfig is one ipConfiguration on an Azure network interface.
+type AzureIPConfig struct {
+	Name             string
+	SubnetID         string // ARM resource id of the referenced subnet
+	SubnetCIDR       string // resolved address prefix, used to allocate a dynamic private IP
+	PrivateIP        string // set for Static; assigned by the mock for Dynamic
+	AllocationMethod string // "Dynamic" (default) or "Static"
+	PublicIPID       string // ARM resource id of an associated public IP, optional
+	Primary          bool
+}
+
+// AzureNICConfig is the create-or-update payload for an Azure network interface.
+type AzureNICConfig struct {
+	Location     string
+	Tags         map[string]string
+	IPConfigs    []AzureIPConfig
+	IPForwarding bool
+}
+
+// AzureNIC is the stored/returned Azure network interface.
+type AzureNIC struct {
+	Name              string
+	ResourceGroup     string
+	Location          string
+	Tags              map[string]string
+	IPConfigs         []AzureIPConfig
+	IPForwarding      bool
+	MACAddress        string
+	ResourceGUID      string
+	ProvisioningState string
+	ETag              string
+	VirtualMachineID  string // set while attached to a VM
+}
+
+// AzureNetworkInterfaces is the Azure-specific network-interface surface,
+// keyed by (resourceGroup, name) to match ARM's addressing and give idempotent
+// createOrUpdate. Nil resource group on List means subscription-wide.
+type AzureNetworkInterfaces interface {
+	CreateOrUpdateNetworkInterface(ctx context.Context, resourceGroup, name string, cfg AzureNICConfig) (*AzureNIC, error)
+	GetNetworkInterface(ctx context.Context, resourceGroup, name string) (*AzureNIC, error)
+	DeleteNetworkInterface(ctx context.Context, resourceGroup, name string) error
+	ListNetworkInterfaces(ctx context.Context, resourceGroup string) ([]AzureNIC, error)
+}
+
 // VPCEndpointConfig describes a VPC endpoint to create.
 type VPCEndpointConfig struct {
 	VPCID            string


### PR DESCRIPTION
**Azure audit — Top-15 #1 (BLOCKER).** Fixes the `networkInterfaces.CreateOrUpdate` finding: `PUT .../networkInterfaces/{name}` returned 501 (no handler or mock existed), so the mandatory **subnet → NIC → VM** bridge — the whole canonical Azure compute lifecycle — could not complete with the real `armnetwork` SDK.

## Approach

Research-first (real Azure `Microsoft.Network/networkInterfaces`): a NIC is a top-level RG resource whose `ipConfigurations[]` reference a subnet and receive a **private IP allocated from that subnet's prefix**; it's what a VM's `networkProfile` points at.

Since `driver.NetworkInterface` is documented as the *AWS-specific ENI shape*, NICs are modeled **natively in the `vnet` mock** (state lives in the provider, per `architecture.md`) with Azure's real shape — not bolted onto the cross-cloud driver. The wire handler reaches the native store via a **type-asserted optional capability** (`AzureNetworkInterfaces`), the same precedent the driver already sets with the AWS-specific `NetworkInterfaceCreator`. AWS/GCP are untouched.

## Behavior (parity with real Azure)

- **Idempotent** `CreateOrUpdate` by `(resourceGroup, name)` — a re-PUT updates in place (no duplicate; List stays 1). This sidesteps the non-idempotent-PUT defect the vnet/NSG paths still have (separate findings).
- **Dynamic private-IP allocation** from the subnet prefix, past Azure's 4 reserved host addresses (`.4` first), collision-free and sequential per subnet; **Static** keeps the submitted address.
- **location / tags / etag / macAddress / resourceGuid / provisioningState** round-trip — submitted region preserved (not stamped `eastus`).
- **RG-scoped** Get/List; subscription-wide List when the RG segment is empty.
- **Delete** refuses a NIC still attached to a VM (`FailedPrecondition` → ARM in-use error); unknown subnet on create is rejected (not a silent no-IP NIC).

## Files

- `services/networking/driver/driver.go` — `AzureNetworkInterfaces` optional capability + Azure NIC types.
- `providers/azure/vnet/network_interface.go` — native `nics` store + CRUD + IP allocator.
- `server/azure/vnet/network_interface.go` + `handler.go` — ARM routing + DTOs; resolves each ipConfig's subnet → CIDR.
- Coverage regenerated (`docs/coverage/**`); `docs/sdk-server.md` updated.

## Tests

- **Real `armnetwork.InterfacesClient` round-trip** (`server/azure/vnet/network_interface_test.go`): create a vnet+subnet, then a NIC referencing the subnet → private IP `10.0.1.4`, `westus2` round-trips, `provisioningState=Succeeded`, idempotent re-PUT keeps List at 1, delete → NotFound; a NIC against a missing subnet is rejected.
- **Mock unit tests** (`providers/azure/vnet/network_interface_test.go`): allocation sequence (.4/.5, per-subnet ranges), idempotent update keeps identity+IP, Static keeps/validates address, RG scoping + cross-RG isolation, attached-delete rejected.
- `go build ./...`, `go vet`, `-race` all green; changed files are lint-clean (the 6 remaining scoped lint issues are pre-existing on `development`, in files this PR doesn't modify).

Next in the loop: idempotent PUT for vnet/NSG, then `location/tags` persistence — both share the leaky ARM↔driver-adapter root cause this PR avoided.