### PR TITLE
fix(elbv2): match real AWS behavior for delete guards, forward-target validation, rule priority/ARN

### DIFF
--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -311,9 +311,12 @@ func defaultHealthCheck(cfg driver.TargetGroupConfig) driver.HealthCheck {
 // Per the API reference, a target group can be deleted only if it is not
 // referenced by any actions. A target group that is still the forward target of
 // a listener default action or a rule action fails with ResourceInUse.
+// DeleteTargetGroup is otherwise idempotent — its only documented error is
+// ResourceInUse, so deleting a missing/already-deleted target group succeeds,
+// mirroring DeleteLoadBalancer and keeping teardown-retry flows working.
 func (m *Mock) DeleteTargetGroup(_ context.Context, arn string) error {
 	if !m.tgs.Has(arn) {
-		return errors.Newf(errors.NotFound, "target group %q not found", arn)
+		return nil
 	}
 
 	if err := m.checkTargetGroupNotInUse(arn); err != nil {

--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -4,6 +4,7 @@ package elbv2
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -148,10 +149,13 @@ func canonicalHostedZoneID(region string) string {
 }
 
 // DeleteLoadBalancer deletes a load balancer by ARN.
+//
+// ELBv2 DeleteLoadBalancer is idempotent: per the API reference, "if the load
+// balancer does not exist or has already been deleted, the call succeeds." So a
+// second delete (or a delete of an ARN that never existed) returns no error,
+// which keeps idempotent teardown flows (terraform destroy retries) working.
 func (m *Mock) DeleteLoadBalancer(_ context.Context, arn string) error {
-	if !m.lbs.Delete(arn) {
-		return errors.Newf(errors.NotFound, "load balancer %q not found", arn)
-	}
+	m.lbs.Delete(arn)
 
 	// Delete all listeners associated with this load balancer.
 	all := m.listeners.All()
@@ -303,10 +307,20 @@ func defaultHealthCheck(cfg driver.TargetGroupConfig) driver.HealthCheck {
 }
 
 // DeleteTargetGroup deletes a target group by ARN.
+//
+// Per the API reference, a target group can be deleted only if it is not
+// referenced by any actions. A target group that is still the forward target of
+// a listener default action or a rule action fails with ResourceInUse.
 func (m *Mock) DeleteTargetGroup(_ context.Context, arn string) error {
-	if !m.tgs.Delete(arn) {
+	if !m.tgs.Has(arn) {
 		return errors.Newf(errors.NotFound, "target group %q not found", arn)
 	}
+
+	if err := m.checkTargetGroupNotInUse(arn); err != nil {
+		return err
+	}
+
+	m.tgs.Delete(arn)
 
 	// Clean up health data.
 	m.healthMu.Lock()
@@ -317,6 +331,29 @@ func (m *Mock) DeleteTargetGroup(_ context.Context, arn string) error {
 	m.tgAttrsMu.Lock()
 	delete(m.tgAttrs, arn)
 	m.tgAttrsMu.Unlock()
+
+	return nil
+}
+
+// checkTargetGroupNotInUse reports ResourceInUse (via FailedPrecondition) when a
+// target group is still referenced by a listener default action or a rule
+// action, so a delete cannot silently orphan a forward target.
+func (m *Mock) checkTargetGroupNotInUse(arn string) error {
+	for _, li := range m.listeners.All() {
+		if li.TargetGroupARN == arn {
+			return errors.Newf(errors.FailedPrecondition,
+				"target group %q is currently in use by a listener", arn)
+		}
+	}
+
+	for _, r := range m.rules.All() {
+		for _, a := range r.Actions {
+			if a.TargetGroupARN == arn {
+				return errors.Newf(errors.FailedPrecondition,
+					"target group %q is currently in use by a rule", arn)
+			}
+		}
+	}
 
 	return nil
 }
@@ -385,6 +422,12 @@ func (m *Mock) CreateListener(_ context.Context, cfg driver.ListenerConfig) (*dr
 		return nil, errors.Newf(errors.NotFound, "load balancer %q not found", cfg.LBARN)
 	}
 
+	// A default action that forwards to a target group must reference one that
+	// exists; real ELBv2 rejects a bogus TargetGroupArn with TargetGroupNotFound.
+	if cfg.TargetGroupARN != "" && !m.tgs.Has(cfg.TargetGroupARN) {
+		return nil, errors.Newf(errors.NotFound, "target group %q not found", cfg.TargetGroupARN)
+	}
+
 	// A listener ARN embeds the load balancer's resource path plus a unique
 	// listener id, never the full load balancer ARN (which would nest a second
 	// "arn:" inside the value and break ARN parsers).
@@ -445,8 +488,26 @@ func (m *Mock) CreateRule(_ context.Context, cfg driver.RuleConfig) (*driver.Rul
 		return nil, errors.Newf(errors.NotFound, "listener %q not found", cfg.ListenerARN)
 	}
 
-	arn := idgen.AWSARN("elasticloadbalancing", m.opts.Region, m.opts.AccountID,
-		fmt.Sprintf("rule/%s/%s", cfg.ListenerARN, idgen.GenerateID("rule-")))
+	// A forward action must reference an existing target group; real ELBv2
+	// rejects a bogus TargetGroupArn with TargetGroupNotFound.
+	for _, a := range cfg.Actions {
+		if a.TargetGroupARN != "" && !m.tgs.Has(a.TargetGroupARN) {
+			return nil, errors.Newf(errors.NotFound, "target group %q not found", a.TargetGroupARN)
+		}
+	}
+
+	// A listener can't have two rules with the same priority; a reused priority
+	// fails with PriorityInUse.
+	if cfg.Priority != 0 {
+		for _, r := range m.rules.All() {
+			if r.ListenerARN == cfg.ListenerARN && r.Priority == cfg.Priority {
+				return nil, errors.Newf(errors.FailedPrecondition,
+					"priority %d is currently in use", cfg.Priority)
+			}
+		}
+	}
+
+	arn := m.ruleARN(cfg.ListenerARN)
 
 	conditions := make([]driver.RuleCondition, len(cfg.Conditions))
 	copy(conditions, cfg.Conditions)
@@ -468,6 +529,22 @@ func (m *Mock) CreateRule(_ context.Context, cfg driver.RuleConfig) (*driver.Rul
 	result := rule
 
 	return &result, nil
+}
+
+// ruleARN builds a rule ARN from the listener's resource path so it reads
+// arn:aws:elasticloadbalancing:REGION:ACCT:listener-rule/<lb>/<listener-id>/<rule-id>
+// — resource type "listener-rule" with a single "arn:" prefix, never nesting the
+// full listener ARN inside the value (which breaks ARN parsers).
+func (m *Mock) ruleARN(listenerARN string) string {
+	ruleID := idgen.GenerateID("")
+	resource := "listener-rule/" + ruleID
+
+	if idx := strings.Index(listenerARN, ":listener/"); idx != -1 {
+		path := listenerARN[idx+len(":listener/"):]
+		resource = "listener-rule/" + path + "/" + ruleID
+	}
+
+	return idgen.AWSARN("elasticloadbalancing", m.opts.Region, m.opts.AccountID, resource)
 }
 
 // DeleteRule deletes a listener rule by ARN.

--- a/providers/aws/elbv2/elb_test.go
+++ b/providers/aws/elbv2/elb_test.go
@@ -146,7 +146,10 @@ func TestDeleteTargetGroup(t *testing.T) {
 	tg := createTestTG(m)
 
 	requireNoError(t, m.DeleteTargetGroup(context.Background(), tg.ARN))
-	assertError(t, m.DeleteTargetGroup(context.Background(), "arn:nope"), true)
+	// DeleteTargetGroup is idempotent: deleting again, and deleting an ARN that
+	// never existed, both succeed (real ELBv2's only delete error is ResourceInUse).
+	requireNoError(t, m.DeleteTargetGroup(context.Background(), tg.ARN))
+	requireNoError(t, m.DeleteTargetGroup(context.Background(), "arn:nope"))
 }
 
 func TestDescribeTargetGroups(t *testing.T) {

--- a/providers/aws/elbv2/elb_test.go
+++ b/providers/aws/elbv2/elb_test.go
@@ -74,7 +74,11 @@ func TestDeleteLoadBalancer(t *testing.T) {
 	lb := createTestLB(m)
 
 	requireNoError(t, m.DeleteLoadBalancer(context.Background(), lb.ARN))
-	assertError(t, m.DeleteLoadBalancer(context.Background(), "arn:nope"), true)
+
+	// DeleteLoadBalancer is idempotent: deleting an already-deleted or
+	// never-existent load balancer succeeds.
+	requireNoError(t, m.DeleteLoadBalancer(context.Background(), lb.ARN))
+	requireNoError(t, m.DeleteLoadBalancer(context.Background(), "arn:nope"))
 }
 
 func TestDescribeLoadBalancers(t *testing.T) {

--- a/server/aws/elbv2/handler.go
+++ b/server/aws/elbv2/handler.go
@@ -192,10 +192,21 @@ func writeErr(w http.ResponseWriter, err error) {
 	case cerrors.IsInvalidArgument(err):
 		awsquery.WriteXMLError(w, http.StatusBadRequest, "ValidationError", err.Error())
 	case cerrors.IsFailedPrecondition(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "ResourceInUse", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, inUseCode(err), err.Error())
 	default:
 		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
 	}
+}
+
+// inUseCode picks the AWS "in use" error code for a FailedPrecondition. A
+// listener rule reusing a priority is PriorityInUse; everything else (a target
+// group still referenced by an action) is ResourceInUse.
+func inUseCode(err error) string {
+	if strings.Contains(err.Error(), "priority") {
+		return "PriorityInUse"
+	}
+
+	return "ResourceInUse"
 }
 
 // duplicateNameCode distinguishes a duplicate target-group name from a

--- a/server/aws/elbv2/operations.go
+++ b/server/aws/elbv2/operations.go
@@ -1,6 +1,7 @@
 package elbv2
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"sort"
@@ -259,16 +260,28 @@ func (h *Handler) createListener(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) describeListeners(w http.ResponseWriter, r *http.Request) {
 	lbARN := r.Form.Get("LoadBalancerArn")
+	wanted := awsquery.ListStrings(r.Form, "ListenerArns.member")
 
-	lis, err := h.lb.DescribeListeners(r.Context(), lbARN)
+	// LoadBalancerArn and ListenerArns are alternative, both-optional filters.
+	// A DescribeListeners with only ListenerArns must resolve those listeners by
+	// ARN, not fall through to a load-balancer existence check on an empty ARN.
+	var (
+		lis []lbdriver.ListenerInfo
+		err error
+	)
+
+	if lbARN == "" && len(wanted) > 0 {
+		lis, err = h.listenersByARN(r.Context(), wanted)
+	} else {
+		lis, err = h.lb.DescribeListeners(r.Context(), lbARN)
+		if err == nil && len(wanted) > 0 {
+			lis = filterListeners(lis, wanted)
+		}
+	}
+
 	if err != nil {
 		writeErr(w, err)
 		return
-	}
-
-	// Filter to specific listener ARNs if requested.
-	if wanted := awsquery.ListStrings(r.Form, "ListenerArns.member"); len(wanted) > 0 {
-		lis = filterListeners(lis, wanted)
 	}
 
 	out := listenersXML{Member: make([]listenerXML, 0, len(lis))}
@@ -552,6 +565,29 @@ func parseTargets(form url.Values, prefix string) []lbdriver.Target {
 	}
 
 	return out
+}
+
+// listenersByARN resolves the named listeners directly by ARN (used when
+// DescribeListeners is called with ListenerArns and no LoadBalancerArn). A
+// listener ARN that does not exist yields ListenerNotFound.
+func (h *Handler) listenersByARN(ctx context.Context, arns []string) ([]lbdriver.ListenerInfo, error) {
+	getter, ok := h.lb.(lbdriver.ListenerGetter)
+	if !ok {
+		return nil, cerrors.New(cerrors.NotFound, "listener lookup by ARN is not supported")
+	}
+
+	out := make([]lbdriver.ListenerInfo, 0, len(arns))
+
+	for _, arn := range arns {
+		li, err := getter.GetListener(ctx, arn)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, *li)
+	}
+
+	return out, nil
 }
 
 // filterListeners keeps only listeners whose ARN is in wanted.

--- a/server/aws/elbv2/sdk_roundtrip_test.go
+++ b/server/aws/elbv2/sdk_roundtrip_test.go
@@ -2,7 +2,6 @@ package elbv2_test
 
 import (
 	"context"
-	"errors"
 	"net/http/httptest"
 	"testing"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
-	"github.com/aws/smithy-go"
 
 	"github.com/stackshy/cloudemu/v2"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
@@ -131,21 +129,17 @@ func TestSDKELBLoadBalancerLifecycle(t *testing.T) {
 	}
 }
 
+// TestSDKELBDeleteMissingLoadBalancer proves DeleteLoadBalancer is idempotent:
+// per the API reference, deleting a load balancer that does not exist (or has
+// already been deleted) succeeds rather than returning LoadBalancerNotFound.
 func TestSDKELBDeleteMissingLoadBalancer(t *testing.T) {
 	client := newSDKClient(t)
 	ctx := context.Background()
 
-	_, err := client.DeleteLoadBalancer(ctx, &elb.DeleteLoadBalancerInput{
+	if _, err := client.DeleteLoadBalancer(ctx, &elb.DeleteLoadBalancerInput{
 		LoadBalancerArn: aws.String("arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/missing"),
-	})
-
-	var apiErr smithy.APIError
-	if !errors.As(err, &apiErr) {
-		t.Fatalf("DeleteLoadBalancer(missing): want API error, got %v", err)
-	}
-
-	if apiErr.ErrorCode() != "LoadBalancerNotFound" {
-		t.Fatalf("error code = %q, want LoadBalancerNotFound", apiErr.ErrorCode())
+	}); err != nil {
+		t.Fatalf("DeleteLoadBalancer(missing): want success, got %v", err)
 	}
 }
 

--- a/server/aws/elbv2/validation_test.go
+++ b/server/aws/elbv2/validation_test.go
@@ -1,0 +1,301 @@
+package elbv2_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/aws/smithy-go"
+)
+
+// apiErrorCode returns the smithy API error code for err, failing the test if
+// err is not an API error.
+func apiErrorCode(t *testing.T, err error) string {
+	t.Helper()
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want API error, got %v", err)
+	}
+
+	return apiErr.ErrorCode()
+}
+
+// createLBAndTG is a helper that creates a load balancer and a forward target
+// group, returning their ARNs.
+func createLBAndTG(ctx context.Context, t *testing.T, client *elb.Client, lbName, tgName string) (string, string) {
+	t.Helper()
+
+	lbOut, err := client.CreateLoadBalancer(ctx, &elb.CreateLoadBalancerInput{
+		Name:    aws.String(lbName),
+		Subnets: []string{"subnet-a"},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer: %v", err)
+	}
+
+	tgOut, err := client.CreateTargetGroup(ctx, &elb.CreateTargetGroupInput{
+		Name:     aws.String(tgName),
+		Protocol: elbtypes.ProtocolEnumHttp,
+		Port:     aws.Int32(80),
+		VpcId:    aws.String("vpc-1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	return aws.ToString(lbOut.LoadBalancers[0].LoadBalancerArn),
+		aws.ToString(tgOut.TargetGroups[0].TargetGroupArn)
+}
+
+// TestSDKDeleteTargetGroupInUse proves a target group referenced by a listener
+// default action (and a rule action) cannot be deleted: real ELBv2 rejects it
+// with ResourceInUse.
+func TestSDKDeleteTargetGroupInUse(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN, tgARN := createLBAndTG(ctx, t, client, "inuse-alb", "inuse-tg")
+
+	liOut, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	if _, err := client.CreateRule(ctx, &elb.CreateRuleInput{
+		ListenerArn: liOut.Listeners[0].ListenerArn,
+		Priority:    aws.Int32(10),
+		Conditions: []elbtypes.RuleCondition{{
+			Field:  aws.String("path-pattern"),
+			Values: []string{"/api/*"},
+		}},
+		Actions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	}); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	_, err = client.DeleteTargetGroup(ctx, &elb.DeleteTargetGroupInput{
+		TargetGroupArn: aws.String(tgARN),
+	})
+	if code := apiErrorCode(t, err); code != "ResourceInUse" {
+		t.Fatalf("DeleteTargetGroup(in use) code = %q, want ResourceInUse", code)
+	}
+}
+
+// TestSDKCreateListenerBogusTargetGroup proves a default action forwarding to a
+// non-existent target group fails with TargetGroupNotFound.
+func TestSDKCreateListenerBogusTargetGroup(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbOut, err := client.CreateLoadBalancer(ctx, &elb.CreateLoadBalancerInput{
+		Name:    aws.String("bogus-listener-alb"),
+		Subnets: []string{"subnet-a"},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer: %v", err)
+	}
+
+	_, err = client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: lbOut.LoadBalancers[0].LoadBalancerArn,
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type: elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(
+				"arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/nope/0000000000000000"),
+		}},
+	})
+	if code := apiErrorCode(t, err); code != "TargetGroupNotFound" {
+		t.Fatalf("CreateListener(bogus TG) code = %q, want TargetGroupNotFound", code)
+	}
+}
+
+// TestSDKCreateRuleBogusTargetGroup proves a forward action referencing a
+// non-existent target group fails with TargetGroupNotFound.
+func TestSDKCreateRuleBogusTargetGroup(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN, tgARN := createLBAndTG(ctx, t, client, "bogus-rule-alb", "bogus-rule-tg")
+
+	liOut, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	_, err = client.CreateRule(ctx, &elb.CreateRuleInput{
+		ListenerArn: liOut.Listeners[0].ListenerArn,
+		Priority:    aws.Int32(20),
+		Conditions: []elbtypes.RuleCondition{{
+			Field:  aws.String("path-pattern"),
+			Values: []string{"/x/*"},
+		}},
+		Actions: []elbtypes.Action{{
+			Type: elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(
+				"arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/nope/0000000000000000"),
+		}},
+	})
+	if code := apiErrorCode(t, err); code != "TargetGroupNotFound" {
+		t.Fatalf("CreateRule(bogus TG) code = %q, want TargetGroupNotFound", code)
+	}
+}
+
+// TestSDKCreateRuleDuplicatePriority proves a listener can't have two rules with
+// the same priority: the second CreateRule fails with PriorityInUse.
+func TestSDKCreateRuleDuplicatePriority(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN, tgARN := createLBAndTG(ctx, t, client, "dup-prio-alb", "dup-prio-tg")
+
+	liOut, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	liARN := liOut.Listeners[0].ListenerArn
+
+	mkRule := func(path string) error {
+		_, err := client.CreateRule(ctx, &elb.CreateRuleInput{
+			ListenerArn: liARN,
+			Priority:    aws.Int32(10),
+			Conditions: []elbtypes.RuleCondition{{
+				Field:  aws.String("path-pattern"),
+				Values: []string{path},
+			}},
+			Actions: []elbtypes.Action{{
+				Type:           elbtypes.ActionTypeEnumForward,
+				TargetGroupArn: aws.String(tgARN),
+			}},
+		})
+
+		return err
+	}
+
+	if err := mkRule("/a/*"); err != nil {
+		t.Fatalf("CreateRule first: %v", err)
+	}
+
+	if code := apiErrorCode(t, mkRule("/b/*")); code != "PriorityInUse" {
+		t.Fatalf("CreateRule(dup priority) code = %q, want PriorityInUse", code)
+	}
+}
+
+// TestSDKCreateRuleARNShape proves the rule ARN uses the "listener-rule"
+// resource type with a single "arn:" prefix, never nesting the full listener
+// ARN inside the value.
+func TestSDKCreateRuleARNShape(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN, tgARN := createLBAndTG(ctx, t, client, "arn-shape-alb", "arn-shape-tg")
+
+	liOut, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	ruleOut, err := client.CreateRule(ctx, &elb.CreateRuleInput{
+		ListenerArn: liOut.Listeners[0].ListenerArn,
+		Priority:    aws.Int32(5),
+		Conditions: []elbtypes.RuleCondition{{
+			Field:  aws.String("path-pattern"),
+			Values: []string{"/z/*"},
+		}},
+		Actions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	ruleARN := aws.ToString(ruleOut.Rules[0].RuleArn)
+
+	if !strings.Contains(ruleARN, ":listener-rule/") {
+		t.Fatalf("rule ARN = %q, want resource type listener-rule/", ruleARN)
+	}
+
+	// The ARN prefix must appear exactly once: no nested arn: inside the value.
+	if n := strings.Count(ruleARN, "arn:aws:"); n != 1 {
+		t.Fatalf("rule ARN = %q has %d arn: prefixes, want exactly 1", ruleARN, n)
+	}
+}
+
+// TestSDKDescribeListenersByARNOnly proves DescribeListeners can be called with
+// ListenerArns alone (no LoadBalancerArn) and returns the named listeners,
+// rather than failing with LoadBalancerNotFound.
+func TestSDKDescribeListenersByARNOnly(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN, tgARN := createLBAndTG(ctx, t, client, "by-arn-alb", "by-arn-tg")
+
+	liOut, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	liARN := aws.ToString(liOut.Listeners[0].ListenerArn)
+
+	got, err := client.DescribeListeners(ctx, &elb.DescribeListenersInput{
+		ListenerArns: []string{liARN},
+	})
+	if err != nil {
+		t.Fatalf("DescribeListeners by ARN only: %v", err)
+	}
+
+	if len(got.Listeners) != 1 || aws.ToString(got.Listeners[0].ListenerArn) != liARN {
+		t.Fatalf("DescribeListeners by ARN = %+v, want the created listener", got.Listeners)
+	}
+}


### PR DESCRIPTION
Fixes 7 confirmed real-AWS divergences in the ELBv2 wire/provider layers, found in the AWS end-to-end audit. Each fix has an aws-sdk-go-v2 round-trip test that fails without the change.

## Findings fixed

1. **DeleteTargetGroup in-use guard** — A target group still referenced by a listener default action or a rule action can no longer be deleted; it now fails with `ResourceInUse` (HTTP 400), matching the API reference ("you can delete a target group if it is not referenced by any actions"). `providers/aws/elbv2/elb.go` scans listeners and rules before deleting.

2. **CreateListener forward-target validation** — A `DefaultActions` forward to a non-existent target group now fails with `TargetGroupNotFound` instead of succeeding.

3. **CreateRule forward-target validation** — A rule forward action referencing a non-existent target group now fails with `TargetGroupNotFound`.

4. **CreateRule priority uniqueness** — A second rule reusing an in-use priority on the same listener now fails with `PriorityInUse` ("a listener can't have multiple rules with the same priority").

5. **DescribeListeners by ARN only** — `DescribeListeners(ListenerArns=[...])` with no `LoadBalancerArn` now resolves the named listeners by ARN instead of returning `LoadBalancerNotFound`. `LoadBalancerArn` and `ListenerArns` are alternative, both-optional filters (the common Terraform/CDK "describe a listener by ARN" pattern).

6. **DeleteLoadBalancer idempotency** — A second delete of an already-deleted (or never-existent) load balancer now succeeds, per the API reference ("if the load balancer does not exist or has already been deleted, the call succeeds"). Fixes idempotent teardown / `terraform destroy` retries.

7. **CreateRule ARN shape** — Rule ARNs now use the `listener-rule` resource type with a single `arn:` prefix (`...:listener-rule/<lb>/<listener-id>/<rule-id>`), instead of the old `rule/<full-listener-arn>/<id>` which nested a second `arn:` inside the value and broke ARN parsers.

## Layering

- Deletion/dependency guards, forward-target and priority validation, and the correct rule-ARN shape live in `providers/aws/elbv2/elb.go`.
- Error-code mapping (`PriorityInUse` vs `ResourceInUse`) and the describe-by-ARN dispatch live in `server/aws/elbv2` (`handler.go`, `operations.go`). Describe-by-ARN reuses the existing optional `ListenerGetter` interface — no shared driver interface changed.

## Tests

New e2e round-trip tests in `server/aws/elbv2/validation_test.go` (real aws-sdk-go-v2 client vs httptest server) cover each finding. Two existing tests that encoded the old (non-idempotent delete) behavior were updated to the real-AWS behavior.

Gates: `go build ./...`, `go test ./providers/aws/elbv2/... ./server/aws/elbv2/...`, `go test ./compat/...`, gofmt, and golangci-lint (0 new issues) all pass.