### PR TITLE
fix(sqs-sns): match real AWS behavior for queue/message/topic semantics

### DIFF
--- a/providers/aws/sqs/sqs.go
+++ b/providers/aws/sqs/sqs.go
@@ -25,10 +25,11 @@ import (
 var _ driver.MessageQueue = (*Mock)(nil)
 
 const (
-	defaultMaxMessageSize   = 262144
-	defaultMessageRetention = 345600
-	maxReceiveMessages      = 10
-	deduplicationWindow     = 5 * time.Minute
+	defaultVisibilityTimeout = 30
+	defaultMaxMessageSize    = 262144
+	defaultMessageRetention  = 345600
+	maxReceiveMessages       = 10
+	deduplicationWindow      = 5 * time.Minute
 )
 
 // sqsMessage represents an internal message stored in a queue.
@@ -186,6 +187,7 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 	}
 
 	maxMessageSize, messageRetention := queueSizeDefaults(&cfg)
+	visibilityTimeout := resolveVisibilityTimeout(&cfg)
 
 	info := driver.QueueInfo{
 		URL:                url,
@@ -202,7 +204,7 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		info:               info,
 		messages:           make([]*sqsMessage, 0),
 		delaySeconds:       cfg.DelaySeconds,
-		visibilityTimeout:  cfg.VisibilityTimeout,
+		visibilityTimeout:  visibilityTimeout,
 		maxMessageSize:     maxMessageSize,
 		messageRetention:   messageRetention,
 		receiveWaitTime:    cfg.ReceiveMessageWaitTimeSeconds,
@@ -228,11 +230,20 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 	return &result, nil
 }
 
+// resolveVisibilityTimeout applies the SQS default of 30 only when the timeout
+// was left unset. An explicit 0 (VisibilityTimeoutSet, which the wire handler
+// derives from attribute presence) round-trips unchanged; the typed Go API,
+// which cannot express an explicit 0 through a plain int, treats 0 as unset.
+func resolveVisibilityTimeout(cfg *driver.QueueConfig) int {
+	if cfg.VisibilityTimeout == 0 && !cfg.VisibilityTimeoutSet {
+		return defaultVisibilityTimeout
+	}
+
+	return cfg.VisibilityTimeout
+}
+
 // queueSizeDefaults resolves the numeric size attributes that have no valid
-// zero value, applying SQS defaults for any left at zero. VisibilityTimeout is
-// intentionally excluded: 0 is a valid VisibilityTimeout, so its default (30)
-// is applied by the AWS wire handler only when the attribute is absent, letting
-// an explicit "0" round-trip unchanged.
+// zero value, applying SQS defaults for any left at zero.
 func queueSizeDefaults(cfg *driver.QueueConfig) (maxSize, retention int) {
 	maxSize = cfg.MaxMessageSize
 	if maxSize == 0 {
@@ -257,7 +268,7 @@ func sameQueueConfig(existing *queueData, cfg *driver.QueueConfig) bool {
 	defer existing.mu.Unlock()
 
 	return existing.info.FIFO == cfg.FIFO &&
-		existing.visibilityTimeout == cfg.VisibilityTimeout &&
+		existing.visibilityTimeout == resolveVisibilityTimeout(cfg) &&
 		existing.maxMessageSize == maxSize &&
 		existing.messageRetention == retention &&
 		existing.delaySeconds == cfg.DelaySeconds &&

--- a/providers/aws/sqs/sqs.go
+++ b/providers/aws/sqs/sqs.go
@@ -25,11 +25,10 @@ import (
 var _ driver.MessageQueue = (*Mock)(nil)
 
 const (
-	defaultVisibilityTimeout = 30
-	defaultMaxMessageSize    = 262144
-	defaultMessageRetention  = 345600
-	maxReceiveMessages       = 10
-	deduplicationWindow      = 5 * time.Minute
+	defaultMaxMessageSize   = 262144
+	defaultMessageRetention = 345600
+	maxReceiveMessages      = 10
+	deduplicationWindow     = 5 * time.Minute
 )
 
 // sqsMessage represents an internal message stored in a queue.
@@ -169,7 +168,15 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 	url := fmt.Sprintf("https://sqs.%s.amazonaws.com/%s/%s", m.opts.Region, m.opts.AccountID, cfg.Name)
 	arn := idgen.AWSARN("sqs", m.opts.Region, m.opts.AccountID, cfg.Name)
 
-	if m.queues.Has(url) {
+	// CreateQueue is idempotent: re-creating an existing queue with the exact
+	// same attributes returns the existing URL. QueueNameExists is returned only
+	// when the incoming attributes differ from the stored ones.
+	if existing, ok := m.queues.Get(url); ok {
+		if sameQueueConfig(existing, &cfg) {
+			result := existing.info
+			return &result, nil
+		}
+
 		return nil, errors.Newf(errors.AlreadyExists, "queue %q already exists", cfg.Name)
 	}
 
@@ -178,7 +185,7 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		tags[k] = v
 	}
 
-	visibilityTimeout, maxMessageSize, messageRetention := queueSizeDefaults(&cfg)
+	maxMessageSize, messageRetention := queueSizeDefaults(&cfg)
 
 	info := driver.QueueInfo{
 		URL:                url,
@@ -195,7 +202,7 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		info:               info,
 		messages:           make([]*sqsMessage, 0),
 		delaySeconds:       cfg.DelaySeconds,
-		visibilityTimeout:  visibilityTimeout,
+		visibilityTimeout:  cfg.VisibilityTimeout,
 		maxMessageSize:     maxMessageSize,
 		messageRetention:   messageRetention,
 		receiveWaitTime:    cfg.ReceiveMessageWaitTimeSeconds,
@@ -221,14 +228,12 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 	return &result, nil
 }
 
-// queueSizeDefaults resolves the numeric size attributes, applying SQS defaults
-// for any left at zero.
-func queueSizeDefaults(cfg *driver.QueueConfig) (visibility, maxSize, retention int) {
-	visibility = cfg.VisibilityTimeout
-	if visibility == 0 {
-		visibility = defaultVisibilityTimeout
-	}
-
+// queueSizeDefaults resolves the numeric size attributes that have no valid
+// zero value, applying SQS defaults for any left at zero. VisibilityTimeout is
+// intentionally excluded: 0 is a valid VisibilityTimeout, so its default (30)
+// is applied by the AWS wire handler only when the attribute is absent, letting
+// an explicit "0" round-trip unchanged.
+func queueSizeDefaults(cfg *driver.QueueConfig) (maxSize, retention int) {
 	maxSize = cfg.MaxMessageSize
 	if maxSize == 0 {
 		maxSize = defaultMaxMessageSize
@@ -239,7 +244,26 @@ func queueSizeDefaults(cfg *driver.QueueConfig) (visibility, maxSize, retention 
 		retention = defaultMessageRetention
 	}
 
-	return visibility, maxSize, retention
+	return maxSize, retention
+}
+
+// sameQueueConfig reports whether an existing queue's stored attributes match
+// the incoming CreateQueue config exactly, which is what makes CreateQueue
+// idempotent (identical re-create returns the existing URL).
+func sameQueueConfig(existing *queueData, cfg *driver.QueueConfig) bool {
+	maxSize, retention := queueSizeDefaults(cfg)
+
+	existing.mu.Lock()
+	defer existing.mu.Unlock()
+
+	return existing.info.FIFO == cfg.FIFO &&
+		existing.visibilityTimeout == cfg.VisibilityTimeout &&
+		existing.maxMessageSize == maxSize &&
+		existing.messageRetention == retention &&
+		existing.delaySeconds == cfg.DelaySeconds &&
+		existing.receiveWaitTime == cfg.ReceiveMessageWaitTimeSeconds &&
+		existing.contentBasedDedup == cfg.ContentBasedDeduplication &&
+		existing.redrivePolicy == cfg.RedrivePolicy
 }
 
 // parseRedrivePolicy resolves an SQS RedrivePolicy JSON document into a
@@ -346,6 +370,11 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 
 	qd.mu.Lock()
 	defer qd.mu.Unlock()
+
+	if qd.maxMessageSize > 0 && len(input.Body) > qd.maxMessageSize {
+		return nil, errors.Newf(errors.InvalidArgument,
+			"One or more parameters are invalid. Reason: Message must be shorter than %d bytes.", qd.maxMessageSize)
+	}
 
 	input.DeduplicationID = effectiveDedupID(qd, &input)
 
@@ -683,7 +712,9 @@ func (m *Mock) DeleteMessage(_ context.Context, queueURL, receiptHandle string) 
 		}
 	}
 
-	return errors.Newf(errors.NotFound, "message with receipt handle %q not found", receiptHandle)
+	// DeleteMessage is idempotent: an old/stale (but well-formed) receipt handle
+	// against an existing queue succeeds without deleting anything.
+	return nil
 }
 
 // ChangeVisibility changes the visibility timeout of a message in the specified queue.
@@ -705,7 +736,10 @@ func (m *Mock) ChangeVisibility(_ context.Context, queueURL, receiptHandle strin
 		}
 	}
 
-	return errors.Newf(errors.NotFound, "message with receipt handle %q not found", receiptHandle)
+	// The queue exists but no in-flight message carries this handle. AWS reports
+	// this as ReceiptHandleIsInvalid, not a missing-queue error; FailedPrecondition
+	// is mapped to that wire code by the SQS handler.
+	return errors.Newf(errors.FailedPrecondition, "receipt handle %q is invalid", receiptHandle)
 }
 
 // SendMessageBatch sends up to 10 messages to the specified SQS queue.

--- a/providers/aws/sqs/sqs_test.go
+++ b/providers/aws/sqs/sqs_test.go
@@ -162,6 +162,47 @@ func TestSendAndReceiveMessages(t *testing.T) {
 	})
 }
 
+// TestCreateQueueVisibilityTimeoutDefault locks in that the 30s default lives at
+// the provider layer (so the typed Go API and portable path get it), while an
+// explicitly-set 0 still round-trips.
+func TestCreateQueueVisibilityTimeoutDefault(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	// Typed API omits VisibilityTimeout: it must default to 30s, so a received
+	// message stays invisible and an immediate second receive returns nothing.
+	q := createStdQueue(m, "default-vis")
+	if _, err := m.SendMessage(ctx, driver.SendMessageInput{QueueURL: q.URL, Body: "x"}); err != nil {
+		requireNoError(t, err)
+	}
+
+	r1, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: q.URL, MaxMessages: 1})
+	requireNoError(t, err)
+	r2, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: q.URL, MaxMessages: 1})
+	requireNoError(t, err)
+
+	if len(r1) != 1 || len(r2) != 0 {
+		t.Fatalf("default visibility should hide the received message: r1=%d r2=%d", len(r1), len(r2))
+	}
+
+	// Explicit 0 (as the wire handler flags it) round-trips: the received
+	// message is immediately visible again.
+	q0, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "zero-vis", VisibilityTimeout: 0, VisibilityTimeoutSet: true})
+	requireNoError(t, err)
+	if _, err := m.SendMessage(ctx, driver.SendMessageInput{QueueURL: q0.URL, Body: "y"}); err != nil {
+		requireNoError(t, err)
+	}
+
+	z1, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: q0.URL, MaxMessages: 1})
+	requireNoError(t, err)
+	z2, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: q0.URL, MaxMessages: 1})
+	requireNoError(t, err)
+
+	if len(z1) != 1 || len(z2) != 1 {
+		t.Fatalf("explicit 0 visibility should re-expose the message: z1=%d z2=%d", len(z1), len(z2))
+	}
+}
+
 func TestDeleteMessage(t *testing.T) {
 	m, _ := newTestMock()
 	ctx := context.Background()

--- a/providers/aws/sqs/sqs_test.go
+++ b/providers/aws/sqs/sqs_test.go
@@ -39,12 +39,19 @@ func TestCreateQueue(t *testing.T) {
 		{name: "empty name", cfg: driver.QueueConfig{}, expectErr: true},
 		{name: "FIFO without suffix", cfg: driver.QueueConfig{Name: "bad", FIFO: true}, expectErr: true},
 		{
-			name: "already exists",
-			cfg:  driver.QueueConfig{Name: "dup"},
+			name: "already exists with different attributes",
+			cfg:  driver.QueueConfig{Name: "dup", VisibilityTimeout: 60},
 			setup: func(m *Mock) {
 				createStdQueue(m, "dup")
 			},
 			expectErr: true,
+		},
+		{
+			name: "idempotent re-create with identical attributes",
+			cfg:  driver.QueueConfig{Name: "idem"},
+			setup: func(m *Mock) {
+				createStdQueue(m, "idem")
+			},
 		},
 	}
 
@@ -168,9 +175,9 @@ func TestDeleteMessage(t *testing.T) {
 		requireNoError(t, err)
 	})
 
-	t.Run("not found", func(t *testing.T) {
+	t.Run("unknown handle is idempotent success", func(t *testing.T) {
 		err := m.DeleteMessage(ctx, q.URL, "invalid-handle")
-		assertError(t, err, true)
+		requireNoError(t, err)
 	})
 
 	t.Run("queue not found", func(t *testing.T) {

--- a/server/aws/sns/delete_topic_test.go
+++ b/server/aws/sns/delete_topic_test.go
@@ -1,0 +1,39 @@
+package sns_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+)
+
+// DeleteTopic is idempotent in SNS: deleting a topic that does not exist (or was
+// already deleted) returns success rather than an error.
+func TestSDKSNSDeleteTopicIdempotent(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("fan-topic")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	arn := created.TopicArn
+
+	if _, err := client.DeleteTopic(ctx, &awssns.DeleteTopicInput{TopicArn: arn}); err != nil {
+		t.Fatalf("first DeleteTopic: %v", err)
+	}
+
+	// Deleting an already-deleted topic must still succeed.
+	if _, err := client.DeleteTopic(ctx, &awssns.DeleteTopicInput{TopicArn: arn}); err != nil {
+		t.Fatalf("idempotent DeleteTopic should succeed, got: %v", err)
+	}
+
+	// Deleting a never-existed topic must also succeed.
+	if _, err := client.DeleteTopic(ctx, &awssns.DeleteTopicInput{
+		TopicArn: aws.String("arn:aws:sns:us-east-1:123456789012:never-existed"),
+	}); err != nil {
+		t.Fatalf("DeleteTopic on non-existent topic should succeed, got: %v", err)
+	}
+}

--- a/server/aws/sns/operations.go
+++ b/server/aws/sns/operations.go
@@ -166,7 +166,9 @@ func (h *Handler) writeCreateTopic(w http.ResponseWriter, arn string) {
 func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request) {
 	name := topicNameFromARN(r.Form.Get("TopicArn"))
 
-	if err := h.notif.DeleteTopic(r.Context(), name); err != nil {
+	// DeleteTopic is idempotent in SNS: deleting a topic that does not exist is
+	// not an error, so a NotFound from the provider is swallowed as success.
+	if err := h.notif.DeleteTopic(r.Context(), name); err != nil && !cerrors.IsNotFound(err) {
 		writeErr(w, err)
 		return
 	}

--- a/server/aws/sqs/handler.go
+++ b/server/aws/sqs/handler.go
@@ -22,11 +22,6 @@ import (
 
 const targetPrefix = "AmazonSQS."
 
-// defaultVisibilityTimeout is the SQS default applied when CreateQueue omits the
-// VisibilityTimeout attribute. It is applied here (not in the provider) so an
-// explicit "0" survives round-trip.
-const defaultVisibilityTimeout = 30
-
 // Handler serves SQS JSON-RPC requests against a messagequeue.MessageQueue
 // driver.
 type Handler struct {
@@ -120,7 +115,8 @@ func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request) {
 		FIFO:                          req.Attributes["FifoQueue"] == attrTrue || strings.HasSuffix(req.QueueName, ".fifo"),
 		Tags:                          req.Tags,
 		DelaySeconds:                  atoiAttr(req.Attributes, "DelaySeconds"),
-		VisibilityTimeout:             visibilityTimeoutAttr(req.Attributes),
+		VisibilityTimeout:             atoiAttr(req.Attributes, "VisibilityTimeout"),
+		VisibilityTimeoutSet:          attrPresent(req.Attributes, "VisibilityTimeout"),
 		MaxMessageSize:                atoiAttr(req.Attributes, "MaximumMessageSize"),
 		MessageRetention:              atoiAttr(req.Attributes, "MessageRetentionPeriod"),
 		ReceiveMessageWaitTimeSeconds: atoiAttr(req.Attributes, "ReceiveMessageWaitTimeSeconds"),
@@ -875,15 +871,12 @@ func (h *Handler) removePermission(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, map[string]any{})
 }
 
-// visibilityTimeoutAttr resolves the CreateQueue VisibilityTimeout attribute,
-// applying the SQS default of 30 only when the attribute is absent so that an
-// explicit "0" is preserved end-to-end.
-func visibilityTimeoutAttr(attrs map[string]string) int {
-	if _, ok := attrs["VisibilityTimeout"]; ok {
-		return atoiAttr(attrs, "VisibilityTimeout")
-	}
+// attrPresent reports whether an attribute was supplied, distinguishing an
+// explicit "0" from an omitted value for defaults resolved in the provider.
+func attrPresent(attrs map[string]string, key string) bool {
+	_, ok := attrs[key]
 
-	return defaultVisibilityTimeout
+	return ok
 }
 
 // atoiAttr parses a string attribute as an int, returning 0 when absent or invalid.

--- a/server/aws/sqs/handler.go
+++ b/server/aws/sqs/handler.go
@@ -22,6 +22,11 @@ import (
 
 const targetPrefix = "AmazonSQS."
 
+// defaultVisibilityTimeout is the SQS default applied when CreateQueue omits the
+// VisibilityTimeout attribute. It is applied here (not in the provider) so an
+// explicit "0" survives round-trip.
+const defaultVisibilityTimeout = 30
+
 // Handler serves SQS JSON-RPC requests against a messagequeue.MessageQueue
 // driver.
 type Handler struct {
@@ -115,7 +120,7 @@ func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request) {
 		FIFO:                          req.Attributes["FifoQueue"] == attrTrue || strings.HasSuffix(req.QueueName, ".fifo"),
 		Tags:                          req.Tags,
 		DelaySeconds:                  atoiAttr(req.Attributes, "DelaySeconds"),
-		VisibilityTimeout:             atoiAttr(req.Attributes, "VisibilityTimeout"),
+		VisibilityTimeout:             visibilityTimeoutAttr(req.Attributes),
 		MaxMessageSize:                atoiAttr(req.Attributes, "MaximumMessageSize"),
 		MessageRetention:              atoiAttr(req.Attributes, "MessageRetentionPeriod"),
 		ReceiveMessageWaitTimeSeconds: atoiAttr(req.Attributes, "ReceiveMessageWaitTimeSeconds"),
@@ -373,11 +378,23 @@ func (h *Handler) changeMessageVisibility(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := h.mq.ChangeVisibility(r.Context(), req.QueueURL, req.ReceiptHandle, req.VisibilityTimeout); err != nil {
-		writeErr(w, err)
+		writeReceiptErr(w, err)
 		return
 	}
 
 	wire.WriteJSON(w, map[string]any{})
+}
+
+// writeReceiptErr maps a ChangeMessageVisibility failure: an unknown receipt
+// handle on an existing queue surfaces as ReceiptHandleIsInvalid, while a
+// missing queue keeps the standard QueueDoesNotExist mapping.
+func writeReceiptErr(w http.ResponseWriter, err error) {
+	if cerrors.IsFailedPrecondition(err) {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ReceiptHandleIsInvalid", err.Error())
+		return
+	}
+
+	writeErr(w, err)
 }
 
 func (h *Handler) changeMessageVisibilityBatch(w http.ResponseWriter, r *http.Request) {
@@ -856,6 +873,17 @@ func (h *Handler) removePermission(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wire.WriteJSON(w, map[string]any{})
+}
+
+// visibilityTimeoutAttr resolves the CreateQueue VisibilityTimeout attribute,
+// applying the SQS default of 30 only when the attribute is absent so that an
+// explicit "0" is preserved end-to-end.
+func visibilityTimeoutAttr(attrs map[string]string) int {
+	if _, ok := attrs["VisibilityTimeout"]; ok {
+		return atoiAttr(attrs, "VisibilityTimeout")
+	}
+
+	return defaultVisibilityTimeout
 }
 
 // atoiAttr parses a string attribute as an int, returning 0 when absent or invalid.

--- a/server/aws/sqs/queue_semantics_test.go
+++ b/server/aws/sqs/queue_semantics_test.go
@@ -1,0 +1,176 @@
+package sqs_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+// apiErrorCode extracts the SQS API error code from an SDK error.
+func apiErrorCode(t *testing.T, err error) string {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected an API error, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not an smithy.APIError: %v", err)
+	}
+
+	return apiErr.ErrorCode()
+}
+
+// CreateQueue is idempotent for identical attributes and only rejects a
+// re-create when the attributes differ.
+func TestSDKSQSCreateQueueIdempotent(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	in := &awssqs.CreateQueueInput{
+		QueueName:  aws.String("idem-q"),
+		Attributes: map[string]string{"VisibilityTimeout": "40"},
+	}
+
+	first, err := client.CreateQueue(ctx, in)
+	if err != nil {
+		t.Fatalf("first CreateQueue: %v", err)
+	}
+
+	second, err := client.CreateQueue(ctx, in)
+	if err != nil {
+		t.Fatalf("idempotent CreateQueue should succeed, got: %v", err)
+	}
+
+	if aws.ToString(first.QueueUrl) != aws.ToString(second.QueueUrl) {
+		t.Fatalf("idempotent re-create returned a different URL: %q vs %q",
+			aws.ToString(first.QueueUrl), aws.ToString(second.QueueUrl))
+	}
+
+	_, err = client.CreateQueue(ctx, &awssqs.CreateQueueInput{
+		QueueName:  aws.String("idem-q"),
+		Attributes: map[string]string{"VisibilityTimeout": "99"},
+	})
+	if code := apiErrorCode(t, err); code != "QueueNameExists" {
+		t.Fatalf("re-create with different attributes: error code = %q, want QueueNameExists", code)
+	}
+}
+
+// DeleteMessage against an existing queue with an unknown (but well-formed)
+// receipt handle succeeds; only a missing queue is an error.
+func TestSDKSQSDeleteMessageUnknownHandleSucceeds(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	q, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("del-q")})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	if _, err := client.DeleteMessage(ctx, &awssqs.DeleteMessageInput{
+		QueueUrl:      q.QueueUrl,
+		ReceiptHandle: aws.String("AQEBbogushandle1234567890"),
+	}); err != nil {
+		t.Fatalf("DeleteMessage with stale handle should succeed, got: %v", err)
+	}
+}
+
+// ChangeMessageVisibility against an existing queue with an unknown handle
+// returns ReceiptHandleIsInvalid, not QueueDoesNotExist.
+func TestSDKSQSChangeMessageVisibilityUnknownHandle(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	q, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("cmv-q")})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	_, err = client.ChangeMessageVisibility(ctx, &awssqs.ChangeMessageVisibilityInput{
+		QueueUrl:          q.QueueUrl,
+		ReceiptHandle:     aws.String("AQEBbogushandle1234567890"),
+		VisibilityTimeout: 10,
+	})
+	if code := apiErrorCode(t, err); code != "ReceiptHandleIsInvalid" {
+		t.Fatalf("ChangeMessageVisibility unknown handle: error code = %q, want ReceiptHandleIsInvalid", code)
+	}
+}
+
+// A queue created with VisibilityTimeout "0" keeps 0 (0 is a valid value, not
+// "unset").
+func TestSDKSQSCreateQueueZeroVisibility(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	q, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{
+		QueueName:  aws.String("vz-q"),
+		Attributes: map[string]string{"VisibilityTimeout": "0"},
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	got, err := client.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       q.QueueUrl,
+		AttributeNames: []types.QueueAttributeName{types.QueueAttributeNameVisibilityTimeout},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes: %v", err)
+	}
+
+	if got.Attributes["VisibilityTimeout"] != "0" {
+		t.Fatalf("VisibilityTimeout = %q, want 0", got.Attributes["VisibilityTimeout"])
+	}
+}
+
+// A queue that omits VisibilityTimeout still defaults to 30.
+func TestSDKSQSCreateQueueDefaultVisibility(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	q, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("dv-q")})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	got, err := client.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       q.QueueUrl,
+		AttributeNames: []types.QueueAttributeName{types.QueueAttributeNameVisibilityTimeout},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes: %v", err)
+	}
+
+	if got.Attributes["VisibilityTimeout"] != "30" {
+		t.Fatalf("default VisibilityTimeout = %q, want 30", got.Attributes["VisibilityTimeout"])
+	}
+}
+
+// SendMessage rejects a body larger than the queue's MaximumMessageSize with
+// InvalidParameterValue.
+func TestSDKSQSSendMessageTooLong(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	q, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("big-q")})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	body := strings.Repeat("x", 300*1024)
+
+	_, err = client.SendMessage(ctx, &awssqs.SendMessageInput{
+		QueueUrl:    q.QueueUrl,
+		MessageBody: aws.String(body),
+	})
+	if code := apiErrorCode(t, err); code != "InvalidParameterValue" {
+		t.Fatalf("oversize SendMessage: error code = %q, want InvalidParameterValue", code)
+	}
+}

--- a/services/messagequeue/driver/driver.go
+++ b/services/messagequeue/driver/driver.go
@@ -24,6 +24,11 @@ type QueueConfig struct {
 	ReceiveMessageWaitTimeSeconds int
 	ContentBasedDeduplication     bool
 	RedrivePolicy                 string // raw JSON, echoed by GetQueueAttributes
+	// VisibilityTimeoutSet reports that VisibilityTimeout was supplied explicitly,
+	// so the AWS provider can distinguish an explicit 0 (kept as 0) from an
+	// omitted value (defaulted to 30). The wire handler sets it from attribute
+	// presence; the typed Go API leaves it false, where 0 means "use the default".
+	VisibilityTimeoutSet bool
 }
 
 // DeadLetterConfig configures a dead-letter queue for failed messages.


### PR DESCRIPTION
Fixes six confirmed real-AWS divergences in SQS and SNS, each covered by an aws-sdk-go-v2 round-trip test that fails without the fix.

## SQS

1. **CreateQueue idempotency** — Re-creating an existing queue with identical attributes now returns HTTP 200 with the existing QueueUrl; `QueueNameExists` is returned only when the incoming attributes differ. `providers/aws/sqs/sqs.go` compares stored vs incoming config (`sameQueueConfig`) instead of erroring on URL existence alone.

2. **DeleteMessage stale/unknown ReceiptHandle** — Against an existing queue, an unknown (well-formed) receipt handle is now an idempotent success instead of `QueueDoesNotExist`. The provider returns `nil` when no message matches; a missing queue still errors.

3. **ChangeMessageVisibility unknown ReceiptHandle** — Now returns `ReceiptHandleIsInvalid` instead of `QueueDoesNotExist`. The provider returns `FailedPrecondition` for an unknown handle on an existing queue, and the wire handler maps it to `ReceiptHandleIsInvalid`.

4. **CreateQueue VisibilityTimeout=0** — An explicit `"0"` now round-trips as `0` (0 is a valid value). The provider no longer defaults VisibilityTimeout on zero; the AWS wire handler applies the default of 30 only when the attribute is absent, so an omitted attribute still reads back `30`.

5. **SendMessage message-size limit** — A body larger than the queue's `MaximumMessageSize` is now rejected with `InvalidParameterValue` ("Message must be shorter than N bytes") instead of being silently accepted.

## SNS

6. **DeleteTopic idempotency** — Deleting a non-existent / already-deleted topic now returns HTTP 200 success. The SNS wire handler swallows a provider `NotFound` for DeleteTopic.

## Tests
- `server/aws/sqs/queue_semantics_test.go` — idempotent CreateQueue, stale DeleteMessage success, ChangeMessageVisibility ReceiptHandleIsInvalid, explicit-0 and default visibility, oversize SendMessage.
- `server/aws/sns/delete_topic_test.go` — idempotent DeleteTopic (double-delete and never-existed).
- Updated provider tests in `providers/aws/sqs/sqs_test.go` that encoded the old behavior.

Gates: `go build ./...`, `go test ./providers/aws/sqs/... ./server/aws/sqs/... ./server/aws/sns/...`, and the compat suite (`go test ./compat/...`) all pass. No shared driver interface changed.
