### PR TITLE
fix(elasticache): match real AWS behavior for subnet-group/snapshot/cluster/replication-group ops

### DIFF
--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -45,7 +45,33 @@ const (
 
 	defaultRedisVersion     = "7.1"
 	defaultMemcachedVersion = "1.6.22"
+
+	// maxMemcachedNodes is the ElastiCache ceiling on Memcached nodes per cluster;
+	// Redis/Valkey clusters must have exactly one node.
+	maxMemcachedNodes = 40
 )
+
+// validateNodeCount enforces the per-engine NumCacheNodes limits real
+// ElastiCache applies: Memcached allows 1-40 nodes, while Redis/Valkey clusters
+// must have exactly 1 (a larger count is InvalidParameterValue, not silently
+// accepted).
+func validateNodeCount(engine string, numNodes int) error {
+	if engine == engineMemcached {
+		if numNodes > maxMemcachedNodes {
+			return errors.Newf(errors.InvalidArgument,
+				"NumCacheNodes must be between 1 and %d for Memcached", maxMemcachedNodes)
+		}
+
+		return nil
+	}
+
+	if numNodes > 1 {
+		return errors.Newf(errors.InvalidArgument,
+			"NumCacheNodes must be 1 for engine %q", engine)
+	}
+
+	return nil
+}
 
 // cacheARN builds an ElastiCache cluster ARN.
 func (m *Mock) cacheARN(name string) string {
@@ -144,6 +170,10 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 	numNodes := cfg.NumCacheNodes
 	if numNodes < 1 {
 		numNodes = 1
+	}
+
+	if err := validateNodeCount(engine, numNodes); err != nil {
+		return nil, err
 	}
 
 	endpoint := fmt.Sprintf("%s.%s.cache.amazonaws.com:%d", cfg.Name, m.opts.Region, defaultRedisPort)

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -39,6 +39,7 @@ type cacheData struct {
 // replication groups so the two cannot drift apart.
 const (
 	defaultEngine   = "redis"
+	engineMemcached = "memcached"
 	defaultNodeType = "cache.t3.micro"
 	statusAvailable = "available"
 
@@ -54,7 +55,7 @@ func (m *Mock) cacheARN(name string) string {
 // defaultEngineVersion returns the ElastiCache default engine version for an
 // engine, matching what real ElastiCache assigns when the caller omits it.
 func defaultEngineVersion(engine string) string {
-	if engine == "memcached" {
+	if engine == engineMemcached {
 		return defaultMemcachedVersion
 	}
 
@@ -140,6 +141,11 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 		engineVersion = defaultEngineVersion(engine)
 	}
 
+	numNodes := cfg.NumCacheNodes
+	if numNodes < 1 {
+		numNodes = 1
+	}
+
 	endpoint := fmt.Sprintf("%s.%s.cache.amazonaws.com:%d", cfg.Name, m.opts.Region, defaultRedisPort)
 
 	tags := make(map[string]string, len(cfg.Tags))
@@ -148,16 +154,18 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 	}
 
 	info := driver.CacheInfo{
-		Name:          cfg.Name,
-		Scope:         cfg.Scope,
-		NodeType:      nodeType,
-		Engine:        engine,
-		EngineVersion: engineVersion,
-		Status:        statusAvailable,
-		Endpoint:      endpoint,
-		ARN:           m.cacheARN(cfg.Name),
-		CreatedAt:     m.opts.Clock.Now().UTC().Format(time.RFC3339),
-		Tags:          tags,
+		Name:            cfg.Name,
+		Scope:           cfg.Scope,
+		NodeType:        nodeType,
+		Engine:          engine,
+		EngineVersion:   engineVersion,
+		Status:          statusAvailable,
+		Endpoint:        endpoint,
+		ARN:             m.cacheARN(cfg.Name),
+		CreatedAt:       m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:            tags,
+		NumCacheNodes:   numNodes,
+		SubnetGroupName: cfg.SubnetGroupName,
 	}
 
 	// Opt-in: back the cache with a real server, replacing the synthetic

--- a/providers/aws/elasticache/engine_test.go
+++ b/providers/aws/elasticache/engine_test.go
@@ -74,7 +74,7 @@ func TestCreateReplicationGroupUsesEngineForRedis(t *testing.T) {
 		t.Fatalf("unexpected provision calls: %+v", eng.provisioned)
 	}
 
-	if err := m.DeleteReplicationGroup(ctx, "rg1"); err != nil {
+	if err := m.DeleteReplicationGroup(ctx, "rg1", driver.DeleteReplicationGroupOptions{}); err != nil {
 		t.Fatalf("DeleteReplicationGroup: %v", err)
 	}
 

--- a/providers/aws/elasticache/replication_group.go
+++ b/providers/aws/elasticache/replication_group.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	cacheengine "github.com/stackshy/cloudemu/v2/services/cache/cacheengine"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
 )
@@ -156,13 +158,34 @@ func (m *Mock) ModifyReplicationGroup(
 	return &rg, nil
 }
 
-// DeleteReplicationGroup deletes a replication group, tearing down the real
-// Redis server backing its primary (if any) via the shared cacheengine helper.
-func (m *Mock) DeleteReplicationGroup(ctx context.Context, id string) error {
+// DeleteReplicationGroup deletes a replication group. When
+// opts.FinalSnapshotIdentifier is set it first takes a final snapshot of the
+// group (which then shows up in DescribeSnapshots, as real ElastiCache does).
+// When opts.RetainPrimaryCluster is set the primary node group is kept as a
+// standalone cache cluster instead of being torn down.
+func (m *Mock) DeleteReplicationGroup(
+	ctx context.Context, id string, opts cachedriver.DeleteReplicationGroupOptions,
+) error {
 	rg, ok := m.replicationGroups.Get(id)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound,
 			"ReplicationGroupNotFoundFault: replication group %q not found", id)
+	}
+
+	if opts.FinalSnapshotIdentifier != "" {
+		if _, err := m.CreateSnapshot(ctx, cachedriver.SnapshotConfig{
+			SnapshotName:       opts.FinalSnapshotIdentifier,
+			ReplicationGroupID: id,
+		}); err != nil {
+			return err
+		}
+	}
+
+	if opts.RetainPrimaryCluster {
+		m.retainPrimaryCluster(&rg)
+		m.replicationGroups.Delete(id)
+
+		return nil
 	}
 
 	info := cachedriver.CacheInfo{Name: rg.ID, Engine: rg.Engine}
@@ -173,4 +196,28 @@ func (m *Mock) DeleteReplicationGroup(ctx context.Context, id string) error {
 	m.replicationGroups.Delete(id)
 
 	return nil
+}
+
+// retainPrimaryCluster keeps the primary node group of a deleted replication
+// group as a standalone cache cluster, so DescribeCacheClusters still returns
+// it. The backing engine (if any) is handed over untouched.
+func (m *Mock) retainPrimaryCluster(rg *cachedriver.ReplicationGroup) {
+	if m.caches.Has(rg.ID) {
+		return
+	}
+
+	info := cachedriver.CacheInfo{
+		Name:            rg.ID,
+		NodeType:        rg.NodeType,
+		Engine:          rg.Engine,
+		EngineVersion:   rg.EngineVersion,
+		Status:          statusAvailable,
+		Endpoint:        net.JoinHostPort(rg.PrimaryAddress, strconv.Itoa(rg.PrimaryPort)),
+		ARN:             m.cacheARN(rg.ID),
+		CreatedAt:       m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		NumCacheNodes:   1,
+		SubnetGroupName: rg.SubnetGroupName,
+	}
+
+	m.caches.Set(rg.ID, &cacheData{info: info, items: memstore.New[cacheItem]()})
 }

--- a/providers/aws/elasticache/snapshot.go
+++ b/providers/aws/elasticache/snapshot.go
@@ -59,11 +59,19 @@ func (m *Mock) fillSnapshotSource(cfg cachedriver.SnapshotConfig, snap *cachedri
 				"CacheClusterNotFound: cache cluster %q not found", cfg.CacheClusterID)
 		}
 
+		if err := checkSnapshotSupported(cd.info.Engine, cd.info.NodeType); err != nil {
+			return err
+		}
+
 		snap.CacheClusterID = cfg.CacheClusterID
 		snap.Engine = cd.info.Engine
 		snap.EngineVersion = cd.info.EngineVersion
 		snap.NodeType = cd.info.NodeType
 		snap.ParameterGroupName = paramGroupName(cd.info.Engine)
+
+		if cd.info.NumCacheNodes > 0 {
+			snap.NumCacheNodes = cd.info.NumCacheNodes
+		}
 	case cfg.ReplicationGroupID != "":
 		rg, ok := m.replicationGroups.Get(cfg.ReplicationGroupID)
 		if !ok {
@@ -80,6 +88,23 @@ func (m *Mock) fillSnapshotSource(cfg cachedriver.SnapshotConfig, snap *cachedri
 		if rg.PrimaryPort != 0 {
 			snap.Port = rg.PrimaryPort
 		}
+	}
+
+	return nil
+}
+
+// checkSnapshotSupported enforces that snapshots are valid for Valkey/Redis OSS
+// only. Real ElastiCache rejects a snapshot of a Memcached cluster or one
+// running on a cache.t1.micro node with SnapshotFeatureNotSupportedFault.
+func checkSnapshotSupported(engine, nodeType string) error {
+	if engine == engineMemcached {
+		return cerrors.New(cerrors.FailedPrecondition,
+			"SnapshotFeatureNotSupportedFault: snapshots are not supported for Memcached clusters")
+	}
+
+	if nodeType == "cache.t1.micro" {
+		return cerrors.New(cerrors.FailedPrecondition,
+			"SnapshotFeatureNotSupportedFault: snapshots are not supported for cache.t1.micro nodes")
 	}
 
 	return nil

--- a/providers/aws/elasticache/subnet_group.go
+++ b/providers/aws/elasticache/subnet_group.go
@@ -77,9 +77,17 @@ func (m *Mock) DescribeCacheSubnetGroups(
 
 // DeleteCacheSubnetGroup deletes a cache subnet group.
 func (m *Mock) DeleteCacheSubnetGroup(_ context.Context, name string) error {
-	// Real ElastiCache refuses while a replication group is still placed in
-	// the group; a teardown that skipped this would leave the group deleted
-	// and the replication group pointing at nothing.
+	// Real ElastiCache refuses to delete a subnet group associated with any
+	// clusters — standalone cache clusters count, not only replication groups.
+	// A teardown that skipped this would leave the group deleted and a live
+	// cluster pointing at nothing.
+	for _, cd := range m.caches.All() {
+		if cd.info.SubnetGroupName == name {
+			return cerrors.Newf(cerrors.FailedPrecondition,
+				"CacheSubnetGroupInUse: cache subnet group %q is in use by %q", name, cd.info.Name)
+		}
+	}
+
 	for _, rg := range m.replicationGroups.All() {
 		if rg.SubnetGroupName == name {
 			return cerrors.Newf(cerrors.FailedPrecondition,

--- a/server/aws/elasticache/handler.go
+++ b/server/aws/elasticache/handler.go
@@ -208,9 +208,27 @@ func writeErr(w http.ResponseWriter, err error) {
 	case cerrors.IsInvalidArgument(err):
 		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", err.Error())
 	case cerrors.IsFailedPrecondition(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidCacheClusterState", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, failedPreconditionCode(err), err.Error())
 	default:
 		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
+	}
+}
+
+// failedPreconditionCode picks the AWS-shaped error code for a failed
+// precondition. The driver encodes the intended fault as a prefix on the
+// message (a subnet group still in use, or an unsupported snapshot); a caller
+// matching the SDK's typed errors sees the code, not the message, so it has to
+// be surfaced as the wire Code. Anything else is a cache-cluster state error.
+func failedPreconditionCode(err error) string {
+	msg := err.Error()
+
+	switch {
+	case strings.Contains(msg, "CacheSubnetGroupInUse"):
+		return "CacheSubnetGroupInUse"
+	case strings.Contains(msg, "SnapshotFeatureNotSupportedFault"):
+		return "SnapshotFeatureNotSupportedFault"
+	default:
+		return "InvalidCacheClusterState"
 	}
 }
 

--- a/server/aws/elasticache/operations.go
+++ b/server/aws/elasticache/operations.go
@@ -34,12 +34,20 @@ func parseTags(form url.Values) map[string]string {
 func (h *Handler) createCacheCluster(w http.ResponseWriter, r *http.Request) {
 	form := r.Form
 
+	nodes, err := parseNodeCount("NumCacheNodes", form.Get("NumCacheNodes"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	cfg := cachedriver.CacheConfig{
-		Name:          form.Get("CacheClusterId"),
-		NodeType:      form.Get("CacheNodeType"),
-		Engine:        form.Get("Engine"),
-		EngineVersion: form.Get("EngineVersion"),
-		Tags:          parseTags(form),
+		Name:            form.Get("CacheClusterId"),
+		NodeType:        form.Get("CacheNodeType"),
+		Engine:          form.Get("Engine"),
+		EngineVersion:   form.Get("EngineVersion"),
+		NumCacheNodes:   nodes,
+		SubnetGroupName: form.Get("CacheSubnetGroupName"),
+		Tags:            parseTags(form),
 	}
 
 	info, err := h.cache.CreateCache(r.Context(), cfg)

--- a/server/aws/elasticache/replication_group.go
+++ b/server/aws/elasticache/replication_group.go
@@ -74,7 +74,7 @@ func (h *Handler) createReplicationGroup(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	nodes, err := parseNodeCount(r.Form.Get("NumCacheClusters"))
+	nodes, err := parseNodeCount("NumCacheClusters", r.Form.Get("NumCacheClusters"))
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -140,7 +140,7 @@ func (h *Handler) modifyReplicationGroup(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	nodes, err := parseNodeCount(r.Form.Get("NumCacheClusters"))
+	nodes, err := parseNodeCount("NumCacheClusters", r.Form.Get("NumCacheClusters"))
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -179,7 +179,12 @@ func (h *Handler) deleteReplicationGroup(w http.ResponseWriter, r *http.Request)
 
 	last := groups[0]
 
-	if err := store.DeleteReplicationGroup(r.Context(), id); err != nil {
+	opts := cachedriver.DeleteReplicationGroupOptions{
+		RetainPrimaryCluster:    r.Form.Get("RetainPrimaryCluster") == "true",
+		FinalSnapshotIdentifier: r.Form.Get("FinalSnapshotIdentifier"),
+	}
+
+	if err := store.DeleteReplicationGroup(r.Context(), id, opts); err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -193,11 +198,12 @@ func (h *Handler) deleteReplicationGroup(w http.ResponseWriter, r *http.Request)
 	})
 }
 
-// parseNodeCount reads NumCacheClusters. Absent means "unspecified" and the
-// driver picks a default; present-but-unparseable is a caller error, and
-// coercing it to a node count silently builds something other than what was
-// asked for.
-func parseNodeCount(raw string) (int, error) {
+// parseNodeCount reads a node-count form field (NumCacheClusters for
+// replication groups, NumCacheNodes for cache clusters). Absent means
+// "unspecified" and the driver picks a default; present-but-unparseable is a
+// caller error, and coercing it to a node count silently builds something other
+// than what was asked for.
+func parseNodeCount(field, raw string) (int, error) {
 	if raw == "" {
 		return 0, nil
 	}
@@ -205,7 +211,7 @@ func parseNodeCount(raw string) (int, error) {
 	n, err := strconv.Atoi(raw)
 	if err != nil {
 		return 0, cerrors.Newf(cerrors.InvalidArgument,
-			"NumCacheClusters must be a number, got %q", raw)
+			"%s must be a number, got %q", field, raw)
 	}
 
 	return n, nil

--- a/server/aws/elasticache/replicationgroup_sdk_roundtrip_test.go
+++ b/server/aws/elasticache/replicationgroup_sdk_roundtrip_test.go
@@ -108,6 +108,80 @@ func TestReplicationGroupSDKRoundTrip(t *testing.T) {
 	}
 }
 
+// TestDeleteReplicationGroupFinalSnapshot guards that DeleteReplicationGroup
+// with FinalSnapshotIdentifier takes a final snapshot before deletion — real
+// ElastiCache does, and the snapshot then shows up in DescribeSnapshots.
+func TestDeleteReplicationGroupFinalSnapshot(t *testing.T) {
+	ctx := context.Background()
+	c := newReplicationGroupClient(t)
+
+	if _, err := c.CreateReplicationGroup(ctx, &awselasticache.CreateReplicationGroupInput{
+		ReplicationGroupId:          aws.String("drg"),
+		ReplicationGroupDescription: aws.String("group to snapshot on delete"),
+		CacheNodeType:               aws.String("cache.t3.micro"),
+		Engine:                      aws.String("redis"),
+	}); err != nil {
+		t.Fatalf("CreateReplicationGroup: %v", err)
+	}
+
+	if _, err := c.DeleteReplicationGroup(ctx, &awselasticache.DeleteReplicationGroupInput{
+		ReplicationGroupId:      aws.String("drg"),
+		FinalSnapshotIdentifier: aws.String("finalsnap"),
+	}); err != nil {
+		t.Fatalf("DeleteReplicationGroup: %v", err)
+	}
+
+	got, err := c.DescribeSnapshots(ctx, &awselasticache.DescribeSnapshotsInput{
+		SnapshotName: aws.String("finalsnap"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeSnapshots: %v", err)
+	}
+
+	if len(got.Snapshots) != 1 {
+		t.Fatalf("snapshots = %d, want 1 (final snapshot on delete)", len(got.Snapshots))
+	}
+
+	if id := aws.ToString(got.Snapshots[0].ReplicationGroupId); id != "drg" {
+		t.Errorf("snapshot ReplicationGroupId = %q, want drg", id)
+	}
+}
+
+// TestDeleteReplicationGroupRetainPrimary guards that RetainPrimaryCluster keeps
+// the primary node group as a standalone cache cluster instead of tearing it
+// down.
+func TestDeleteReplicationGroupRetainPrimary(t *testing.T) {
+	ctx := context.Background()
+	c := newReplicationGroupClient(t)
+
+	if _, err := c.CreateReplicationGroup(ctx, &awselasticache.CreateReplicationGroupInput{
+		ReplicationGroupId:          aws.String("keeprg"),
+		ReplicationGroupDescription: aws.String("retain primary on delete"),
+		CacheNodeType:               aws.String("cache.t3.micro"),
+		Engine:                      aws.String("redis"),
+	}); err != nil {
+		t.Fatalf("CreateReplicationGroup: %v", err)
+	}
+
+	if _, err := c.DeleteReplicationGroup(ctx, &awselasticache.DeleteReplicationGroupInput{
+		ReplicationGroupId:   aws.String("keeprg"),
+		RetainPrimaryCluster: aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("DeleteReplicationGroup: %v", err)
+	}
+
+	got, err := c.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String("keeprg"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheClusters: %v", err)
+	}
+
+	if len(got.CacheClusters) != 1 {
+		t.Fatalf("retained clusters = %d, want 1", len(got.CacheClusters))
+	}
+}
+
 // Callers string-match these two codes: AlreadyExists to make a re-run
 // idempotent, NotFoundFault to treat an absent group as already deleted.
 // Losing either turns a safe path into a failure.

--- a/server/aws/elasticache/sdk_roundtrip_test.go
+++ b/server/aws/elasticache/sdk_roundtrip_test.go
@@ -83,6 +83,42 @@ func TestSDKModifyCacheCluster(t *testing.T) {
 	}
 }
 
+// TestSDKCreateCacheClusterNumCacheNodes guards that a multi-node Memcached
+// cluster is created and echoed back with the requested node count and one
+// CacheNode per node — real ElastiCache defines a Memcached cluster by its node
+// count, and reporting a 3-node request as a 1-node cluster is wrong.
+func TestSDKCreateCacheClusterNumCacheNodes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("mc"), Engine: aws.String("memcached"),
+		CacheNodeType: aws.String("cache.t3.micro"), NumCacheNodes: aws.Int32(3),
+	})
+	if err != nil {
+		t.Fatalf("CreateCacheCluster: %v", err)
+	}
+
+	if got := aws.ToInt32(created.CacheCluster.NumCacheNodes); got != 3 {
+		t.Fatalf("create NumCacheNodes = %d, want 3", got)
+	}
+
+	got, err := client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String("mc"), ShowCacheNodeInfo: aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheClusters: %v", err)
+	}
+
+	if n := aws.ToInt32(got.CacheClusters[0].NumCacheNodes); n != 3 {
+		t.Fatalf("describe NumCacheNodes = %d, want 3", n)
+	}
+
+	if nodes := got.CacheClusters[0].CacheNodes; len(nodes) != 3 {
+		t.Fatalf("CacheNodes = %d, want 3", len(nodes))
+	}
+}
+
 func TestSDKElastiCacheLifecycle(t *testing.T) {
 	client := newSDKClient(t)
 	ctx := context.Background()

--- a/server/aws/elasticache/sdk_roundtrip_test.go
+++ b/server/aws/elasticache/sdk_roundtrip_test.go
@@ -200,6 +200,33 @@ func TestSDKElastiCacheLifecycle(t *testing.T) {
 	}
 }
 
+// TestSDKCreateCacheClusterRejectsMultiNodeRedis proves the per-engine
+// NumCacheNodes limits: Redis/Valkey clusters must have exactly one node, and a
+// Memcached cluster cannot exceed 40 — both surface as InvalidParameterValue.
+func TestSDKCreateCacheClusterRejectsMultiNodeRedis(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("r"), Engine: aws.String("redis"),
+		CacheNodeType: aws.String("cache.t3.micro"), NumCacheNodes: aws.Int32(3),
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("CreateCacheCluster(redis, 3 nodes): got %v, want InvalidParameterValue", err)
+	}
+
+	_, err = client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("mc-big"), Engine: aws.String("memcached"),
+		CacheNodeType: aws.String("cache.t3.micro"), NumCacheNodes: aws.Int32(41),
+	})
+
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("CreateCacheCluster(memcached, 41 nodes): got %v, want InvalidParameterValue", err)
+	}
+}
+
 func TestSDKElastiCacheNotFound(t *testing.T) {
 	client := newSDKClient(t)
 

--- a/server/aws/elasticache/snapshot_sdk_roundtrip_test.go
+++ b/server/aws/elasticache/snapshot_sdk_roundtrip_test.go
@@ -51,6 +51,36 @@ func mustCreateCluster(t *testing.T, c *awselasticache.Client, id string) {
 	}
 }
 
+// TestCreateSnapshotMemcachedUnsupported guards that snapshotting a Memcached
+// cluster is rejected — real ElastiCache snapshots are "valid for Valkey or
+// Redis OSS only" and return SnapshotFeatureNotSupportedFault.
+func TestCreateSnapshotMemcachedUnsupported(t *testing.T) {
+	ctx := context.Background()
+	c := newSnapshotClient(t)
+
+	if _, err := c.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("mcs"),
+		Engine:         aws.String("memcached"),
+		CacheNodeType:  aws.String("cache.t3.micro"),
+		NumCacheNodes:  aws.Int32(1),
+	}); err != nil {
+		t.Fatalf("CreateCacheCluster: %v", err)
+	}
+
+	_, err := c.CreateSnapshot(ctx, &awselasticache.CreateSnapshotInput{
+		SnapshotName:   aws.String("snap-mc"),
+		CacheClusterId: aws.String("mcs"),
+	})
+	if err == nil {
+		t.Fatal("snapshotting a Memcached cluster should fail")
+	}
+
+	var unsupported *ectypes.SnapshotFeatureNotSupportedFault
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("error = %v, want *SnapshotFeatureNotSupportedFault", err)
+	}
+}
+
 func TestCreateSnapshotSDKRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	c := newSnapshotClient(t)

--- a/server/aws/elasticache/subnetgroup_sdk_roundtrip_test.go
+++ b/server/aws/elasticache/subnetgroup_sdk_roundtrip_test.go
@@ -2,6 +2,7 @@ package elasticache_test
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+	ectypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 
 	"github.com/stackshy/cloudemu/v2"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
@@ -102,6 +104,106 @@ func TestCacheSubnetGroupSDKRoundTrip(t *testing.T) {
 	if len(after.CacheSubnetGroups) != 0 {
 		t.Errorf("group survived delete: %+v", after.CacheSubnetGroups)
 	}
+}
+
+// TestDeleteCacheSubnetGroupInUseByCluster guards that a subnet group
+// associated with a standalone cache cluster cannot be deleted — real
+// ElastiCache refuses to delete a group associated with "any clusters", not
+// only replication groups, and returns CacheSubnetGroupInUse.
+func TestDeleteCacheSubnetGroupInUseByCluster(t *testing.T) {
+	ctx := context.Background()
+	cachec, ec2c := newCacheSubnetGroupClients(t)
+
+	subnetID := makeSubnet(ctx, t, ec2c)
+
+	if _, err := cachec.CreateCacheSubnetGroup(ctx, &awselasticache.CreateCacheSubnetGroupInput{
+		CacheSubnetGroupName:        aws.String("sng-incluster"),
+		CacheSubnetGroupDescription: aws.String("test"),
+		SubnetIds:                   []string{subnetID},
+	}); err != nil {
+		t.Fatalf("CreateCacheSubnetGroup: %v", err)
+	}
+
+	if _, err := cachec.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId:       aws.String("incluster"),
+		Engine:               aws.String("redis"),
+		CacheNodeType:        aws.String("cache.t3.micro"),
+		NumCacheNodes:        aws.Int32(1),
+		CacheSubnetGroupName: aws.String("sng-incluster"),
+	}); err != nil {
+		t.Fatalf("CreateCacheCluster: %v", err)
+	}
+
+	_, err := cachec.DeleteCacheSubnetGroup(ctx, &awselasticache.DeleteCacheSubnetGroupInput{
+		CacheSubnetGroupName: aws.String("sng-incluster"),
+	})
+	if err == nil {
+		t.Fatal("deleting a subnet group in use by a cache cluster should fail")
+	}
+
+	var inUse *ectypes.CacheSubnetGroupInUse
+	if !errors.As(err, &inUse) {
+		t.Fatalf("error = %v, want *CacheSubnetGroupInUse", err)
+	}
+}
+
+// TestDeleteCacheSubnetGroupInUseErrorCode guards that the in-use error surfaces
+// as the typed CacheSubnetGroupInUse fault (not InvalidCacheClusterState) so
+// callers and Terraform can branch on it.
+func TestDeleteCacheSubnetGroupInUseErrorCode(t *testing.T) {
+	ctx := context.Background()
+	cachec, ec2c := newCacheSubnetGroupClients(t)
+
+	subnetID := makeSubnet(ctx, t, ec2c)
+
+	if _, err := cachec.CreateCacheSubnetGroup(ctx, &awselasticache.CreateCacheSubnetGroupInput{
+		CacheSubnetGroupName:        aws.String("sng-inrg"),
+		CacheSubnetGroupDescription: aws.String("test"),
+		SubnetIds:                   []string{subnetID},
+	}); err != nil {
+		t.Fatalf("CreateCacheSubnetGroup: %v", err)
+	}
+
+	if _, err := cachec.CreateReplicationGroup(ctx, &awselasticache.CreateReplicationGroupInput{
+		ReplicationGroupId:          aws.String("rg-inrg"),
+		ReplicationGroupDescription: aws.String("test"),
+		Engine:                      aws.String("redis"),
+		CacheNodeType:               aws.String("cache.t3.micro"),
+		CacheSubnetGroupName:        aws.String("sng-inrg"),
+	}); err != nil {
+		t.Fatalf("CreateReplicationGroup: %v", err)
+	}
+
+	_, err := cachec.DeleteCacheSubnetGroup(ctx, &awselasticache.DeleteCacheSubnetGroupInput{
+		CacheSubnetGroupName: aws.String("sng-inrg"),
+	})
+	if err == nil {
+		t.Fatal("deleting a subnet group in use by a replication group should fail")
+	}
+
+	var inUse *ectypes.CacheSubnetGroupInUse
+	if !errors.As(err, &inUse) {
+		t.Fatalf("error = %v, want *CacheSubnetGroupInUse", err)
+	}
+}
+
+// makeSubnet creates a VPC + subnet and returns the subnet id.
+func makeSubnet(ctx context.Context, t *testing.T, ec2c *awsec2.Client) string {
+	t.Helper()
+
+	vpc, err := ec2c.CreateVpc(ctx, &awsec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	sub, err := ec2c.CreateSubnet(ctx, &awsec2.CreateSubnetInput{
+		VpcId: vpc.Vpc.VpcId, CidrBlock: aws.String("10.0.1.0/24"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSubnet: %v", err)
+	}
+
+	return aws.ToString(sub.Subnet.SubnetId)
 }
 
 func TestDeleteUnknownCacheSubnetGroupFails(t *testing.T) {

--- a/server/aws/elasticache/types.go
+++ b/server/aws/elasticache/types.go
@@ -2,6 +2,7 @@ package elasticache
 
 import (
 	"encoding/xml"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -229,17 +230,23 @@ func splitEndpoint(endpoint string) *endpointXML {
 }
 
 // toCacheClusterXML converts a driver CacheInfo into its ElastiCache XML shape.
-// The driver models a single-node cache, so one CacheNode carrying the endpoint
-// is emitted (DescribeCacheClusters populates it only when ShowCacheNodeInfo is
-// set, but including it unconditionally is harmless).
+// A Memcached cluster reports NumCacheNodes nodes (Redis reports 1); a
+// CacheNode carrying the endpoint is emitted per node (DescribeCacheClusters
+// populates them only when ShowCacheNodeInfo is set, but including them
+// unconditionally is harmless).
 func toCacheClusterXML(info *cachedriver.CacheInfo) cacheClusterXML {
+	numNodes := info.NumCacheNodes
+	if numNodes < 1 {
+		numNodes = 1
+	}
+
 	out := cacheClusterXML{
 		CacheClusterID:       info.Name,
 		CacheClusterStatus:   info.Status,
 		CacheNodeType:        info.NodeType,
 		Engine:               info.Engine,
 		EngineVersion:        info.EngineVersion,
-		NumCacheNodes:        1,
+		NumCacheNodes:        numNodes,
 		CacheClusterCreateAt: info.CreatedAt,
 		ARN:                  info.ARN,
 	}
@@ -253,11 +260,17 @@ func toCacheClusterXML(info *cachedriver.CacheInfo) cacheClusterXML {
 
 	if ep := splitEndpoint(info.Endpoint); ep != nil {
 		out.ConfigurationEndpt = ep
-		out.CacheNodes = &cacheNodesXML{CacheNode: []cacheNodeXML{{
-			CacheNodeID:     "0001",
-			CacheNodeStatus: info.Status,
-			Endpoint:        ep,
-		}}}
+
+		nodes := make([]cacheNodeXML, 0, numNodes)
+		for i := 1; i <= numNodes; i++ {
+			nodes = append(nodes, cacheNodeXML{
+				CacheNodeID:     fmt.Sprintf("%04d", i),
+				CacheNodeStatus: info.Status,
+				Endpoint:        ep,
+			})
+		}
+
+		out.CacheNodes = &cacheNodesXML{CacheNode: nodes}
 	}
 
 	return out

--- a/services/cache/driver/driver.go
+++ b/services/cache/driver/driver.go
@@ -42,6 +42,14 @@ type CacheInfo struct {
 	SKUCapacity        int
 	ShardCount         int
 	ReplicasPerPrimary int
+
+	// NumCacheNodes / SubnetGroupName are populated by the AWS ElastiCache
+	// backend. NumCacheNodes is the number of nodes in a Memcached cluster (1
+	// for Redis); SubnetGroupName is the cache subnet group the cluster is
+	// placed in, and deleting that group is refused while a cluster references
+	// it. Both are empty/zero for non-AWS providers.
+	NumCacheNodes   int
+	SubnetGroupName string
 }
 
 // CacheConfig describes a cache instance to create.
@@ -63,6 +71,13 @@ type CacheConfig struct {
 	SKUCapacity        int
 	ShardCount         int
 	ReplicasPerPrimary int
+
+	// NumCacheNodes is the requested node count for an AWS Memcached cluster
+	// (1-40); zero means unspecified and the backend defaults it to 1.
+	// SubnetGroupName names the cache subnet group the cluster is placed in.
+	// Both are AWS-only and left zero/empty by other callers.
+	NumCacheNodes   int
+	SubnetGroupName string
 }
 
 // Cache is the interface that cache provider implementations must satisfy.
@@ -148,6 +163,16 @@ type ReplicationGroupConfig struct {
 	SecurityGroupIDs []string
 }
 
+// DeleteReplicationGroupOptions carries the optional delete-time behaviors of
+// ElastiCache DeleteReplicationGroup. FinalSnapshotIdentifier, when set, takes a
+// final snapshot of the group before it is removed; RetainPrimaryCluster, when
+// set, keeps the primary node group as a standalone cache cluster instead of
+// deleting it.
+type DeleteReplicationGroupOptions struct {
+	RetainPrimaryCluster    bool
+	FinalSnapshotIdentifier string
+}
+
 // ReplicationGroups is an OPTIONAL capability, discovered by type assertion.
 // Replication groups are an AWS ElastiCache concept; drivers for other clouds
 // do not model them.
@@ -155,7 +180,7 @@ type ReplicationGroups interface {
 	CreateReplicationGroup(ctx context.Context, cfg ReplicationGroupConfig) (*ReplicationGroup, error)
 	DescribeReplicationGroups(ctx context.Context, ids []string) ([]ReplicationGroup, error)
 	ModifyReplicationGroup(ctx context.Context, id string, numCacheNodes int) (*ReplicationGroup, error)
-	DeleteReplicationGroup(ctx context.Context, id string) error
+	DeleteReplicationGroup(ctx context.Context, id string, opts DeleteReplicationGroupOptions) error
 }
 
 // Snapshot is a point-in-time backup of an ElastiCache cluster or replication


### PR DESCRIPTION
Fixes 5 confirmed real-AWS divergences in ElastiCache, each with an aws-sdk-go-v2 round-trip test that fails without the fix.

## Findings fixed

1. **DeleteCacheSubnetGroup ignored standalone clusters.** The in-use guard only iterated replication groups, and CreateCacheCluster never read `CacheSubnetGroupName`, so a subnet group could be deleted out from under a live cache cluster. CreateCacheCluster now stores the subnet-group association (new `CacheConfig.SubnetGroupName` / `CacheInfo.SubnetGroupName`), and the delete guard also refuses when any standalone cache cluster references the group — AWS `CacheSubnetGroupInUse`.

2. **Wrong wire error code for an in-use subnet group.** `writeErr` mapped every `FailedPrecondition` to `InvalidCacheClusterState`, so the in-use case never surfaced as `CacheSubnetGroupInUse` and `errors.As(err, *CacheSubnetGroupInUse)` was false. Added `failedPreconditionCode` which reads the driver's intended fault prefix and emits `CacheSubnetGroupInUse` (HTTP 400).

3. **CreateSnapshot accepted Memcached.** Snapshots are valid for Valkey/Redis OSS only. Added `checkSnapshotSupported`, which rejects a Memcached source or a `cache.t1.micro` node with `SnapshotFeatureNotSupportedFault` (HTTP 400).

4. **NumCacheNodes was dropped.** CreateCacheCluster never read `NumCacheNodes` and the XML hard-coded `NumCacheNodes=1` with a single node. Now the request's node count is parsed, stored (`CacheConfig`/`CacheInfo`), echoed back, and one `CacheNode` (0001..000N) is emitted per node.

5. **DeleteReplicationGroup ignored FinalSnapshotIdentifier / RetainPrimaryCluster.** The driver contract took only an id. Changed the optional `ReplicationGroups.DeleteReplicationGroup` signature to take `DeleteReplicationGroupOptions`; the handler now reads both fields. `FinalSnapshotIdentifier` takes a final snapshot before deletion (visible in DescribeSnapshots); `RetainPrimaryCluster` keeps the primary as a standalone cache cluster.

## Notes
- Changed the optional (type-asserted) `ReplicationGroups` interface signature in `services/cache/driver`. `go generate ./...` produced no `docs/coverage` diff (method set unchanged). Only AWS implements this optional interface.
- Gates: `go build ./...`, `go test ./providers/aws/elasticache/... ./server/aws/elasticache/...`, full `go test ./...`, and the `./compat/...` suite all pass. Zero new golangci-lint issues in changed files.
