### PR TITLE
fix(azure-compute): idempotent VM/disk/snapshot/image PUT, InstanceView, PowerOff vs Deallocate, disk createOption, ssh private key

### DIFF
--- a/docs/coverage/aws/ec2.md
+++ b/docs/coverage/aws/ec2.md
@@ -49,6 +49,16 @@ AWS's `compute` service · portable interface `driver.Compute` · [AWS index](./
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureVMController
+
+AzureVMController is an optional Azure-only capability supporting the ARM
+
+| Operation | Description |
+| --- | --- |
+| `Deallocate` | Deallocate stops the guest and releases the allocated compute |
+| `PowerOff` | PowerOff stops the guest OS while keeping the VM allocated |
+| `UpdateInstance` | UpdateInstance overwrites the mutable configuration of an existing |
+
 ### ConsoleReader
 
 ConsoleReader is an optional capability a Compute implementation may provide
@@ -64,6 +74,14 @@ ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
 | Operation | Description |
 | --- | --- |
 | `RegisterImage` |  |
+
+### KeyPairGenerator
+
+KeyPairGenerator is an optional Azure-only capability for the ARM
+
+| Operation | Description |
+| --- | --- |
+| `GenerateKeyPair` |  |
 
 ### KeyPairImporter
 

--- a/docs/coverage/azure/virtualmachines.md
+++ b/docs/coverage/azure/virtualmachines.md
@@ -49,6 +49,16 @@ Azure's `compute` service · portable interface `driver.Compute` · [Azure index
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureVMController
+
+AzureVMController is an optional Azure-only capability supporting the ARM
+
+| Operation | Description |
+| --- | --- |
+| `Deallocate` | Deallocate stops the guest and releases the allocated compute |
+| `PowerOff` | PowerOff stops the guest OS while keeping the VM allocated |
+| `UpdateInstance` | UpdateInstance overwrites the mutable configuration of an existing |
+
 ### ConsoleReader
 
 ConsoleReader is an optional capability a Compute implementation may provide
@@ -64,6 +74,14 @@ ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
 | Operation | Description |
 | --- | --- |
 | `RegisterImage` |  |
+
+### KeyPairGenerator
+
+KeyPairGenerator is an optional Azure-only capability for the ARM
+
+| Operation | Description |
+| --- | --- |
+| `GenerateKeyPair` |  |
 
 ### KeyPairImporter
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -1958,6 +1958,24 @@
     ],
     "optionalCapabilities": [
       {
+        "name": "AzureVMController",
+        "doc": "AzureVMController is an optional Azure-only capability supporting the ARM",
+        "operations": [
+          {
+            "name": "Deallocate",
+            "doc": "Deallocate stops the guest and releases the allocated compute"
+          },
+          {
+            "name": "PowerOff",
+            "doc": "PowerOff stops the guest OS while keeping the VM allocated"
+          },
+          {
+            "name": "UpdateInstance",
+            "doc": "UpdateInstance overwrites the mutable configuration of an existing"
+          }
+        ]
+      },
+      {
         "name": "ConsoleReader",
         "doc": "ConsoleReader is an optional capability a Compute implementation may provide",
         "operations": [
@@ -1972,6 +1990,15 @@
         "operations": [
           {
             "name": "RegisterImage"
+          }
+        ]
+      },
+      {
+        "name": "KeyPairGenerator",
+        "doc": "KeyPairGenerator is an optional Azure-only capability for the ARM",
+        "operations": [
+          {
+            "name": "GenerateKeyPair"
           }
         ]
       },

--- a/docs/coverage/gcp/gce.md
+++ b/docs/coverage/gcp/gce.md
@@ -49,6 +49,16 @@ GCP's `compute` service · portable interface `driver.Compute` · [GCP index](./
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureVMController
+
+AzureVMController is an optional Azure-only capability supporting the ARM
+
+| Operation | Description |
+| --- | --- |
+| `Deallocate` | Deallocate stops the guest and releases the allocated compute |
+| `PowerOff` | PowerOff stops the guest OS while keeping the VM allocated |
+| `UpdateInstance` | UpdateInstance overwrites the mutable configuration of an existing |
+
 ### ConsoleReader
 
 ConsoleReader is an optional capability a Compute implementation may provide
@@ -64,6 +74,14 @@ ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
 | Operation | Description |
 | --- | --- |
 | `RegisterImage` |  |
+
+### KeyPairGenerator
+
+KeyPairGenerator is an optional Azure-only capability for the ARM
+
+| Operation | Description |
+| --- | --- |
+| `GenerateKeyPair` |  |
 
 ### KeyPairImporter
 

--- a/providers/azure/virtualmachines/powerstate_test.go
+++ b/providers/azure/virtualmachines/powerstate_test.go
@@ -1,0 +1,106 @@
+package virtualmachines
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/compute"
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPowerOffKeepsAllocated(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{InstanceType: "Standard_B1s"}, 1)
+	require.NoError(t, err)
+
+	id := insts[0].ID
+	require.NoError(t, m.PowerOff(ctx, id))
+
+	got, err := m.DescribeInstances(ctx, []string{id}, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	assert.Equal(t, compute.StateStopped, got[0].State)
+	assert.Equal(t, "stopped", got[0].PowerState)
+}
+
+func TestDeallocateReleasesCompute(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{InstanceType: "Standard_B1s"}, 1)
+	require.NoError(t, err)
+
+	id := insts[0].ID
+	require.NoError(t, m.Deallocate(ctx, id))
+
+	got, err := m.DescribeInstances(ctx, []string{id}, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	assert.Equal(t, compute.StateStopped, got[0].State)
+	assert.Equal(t, "deallocated", got[0].PowerState)
+}
+
+func TestUpdateInstanceInPlace(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{
+		InstanceType: "Standard_B1s",
+		Tags:         map[string]string{"env": "dev"},
+	}, 1)
+	require.NoError(t, err)
+
+	id := insts[0].ID
+
+	err = m.UpdateInstance(ctx, id, driver.InstanceConfig{
+		InstanceType: "Standard_D2s_v3",
+		Tags:         map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	got, err := m.DescribeInstances(ctx, []string{id}, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "update must not create a duplicate")
+
+	assert.Equal(t, id, got[0].ID, "ID preserved across in-place update")
+	assert.Equal(t, "Standard_D2s_v3", got[0].InstanceType)
+	assert.Equal(t, "prod", got[0].Tags["env"])
+}
+
+func TestUpdateInstanceNotFound(t *testing.T) {
+	m := newTestMock()
+	err := m.UpdateInstance(context.Background(), "missing", driver.InstanceConfig{})
+	assert.Error(t, err)
+}
+
+func TestGenerateKeyPairReturnsRealKeys(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateKeyPair(ctx, driver.KeyPairConfig{Name: "key-1"})
+	require.NoError(t, err)
+
+	got, err := m.GenerateKeyPair(ctx, "key-1")
+	require.NoError(t, err)
+
+	assert.Contains(t, got.PrivateKey, "PRIVATE KEY")
+	assert.Contains(t, got.PublicKey, "ssh-rsa ")
+
+	// The generated public key is persisted so a later describe reflects it.
+	keys, err := m.DescribeKeyPairs(ctx, []string{"key-1"})
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, got.PublicKey, keys[0].PublicKey)
+}
+
+func TestGenerateKeyPairMissing(t *testing.T) {
+	m := newTestMock()
+	_, err := m.GenerateKeyPair(context.Background(), "nope")
+	assert.Error(t, err)
+}

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -3,10 +3,16 @@ package virtualmachines
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
+
+	"golang.org/x/crypto/ssh"
 
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -22,8 +28,10 @@ import (
 // Compile-time checks that Mock implements driver.Compute and, when a real
 // compute engine is wired, the optional driver.ConsoleReader capability.
 var (
-	_ driver.Compute       = (*Mock)(nil)
-	_ driver.ConsoleReader = (*Mock)(nil)
+	_ driver.Compute           = (*Mock)(nil)
+	_ driver.ConsoleReader     = (*Mock)(nil)
+	_ driver.AzureVMController = (*Mock)(nil)
+	_ driver.KeyPairGenerator  = (*Mock)(nil)
 )
 
 const (
@@ -37,6 +45,9 @@ type lifecycleTransition struct {
 	finalState        string
 	metricValues      []float64
 	errVerb           string
+	// powerState is the Azure power state the instance settles into after the
+	// transition ("running"/"stopped"/"deallocated"). Empty leaves it unchanged.
+	powerState string
 }
 
 var (
@@ -48,18 +59,35 @@ var (
 		finalState:        compute.StateRunning,
 		metricValues:      runningMetricValues,
 		errVerb:           "start",
+		powerState:        powerStateRunning,
 	}
 	stopTransition = lifecycleTransition{ //nolint:gochecknoglobals // package-level config
 		intermediateState: compute.StateStopping,
 		finalState:        compute.StateStopped,
 		metricValues:      zeroMetricValues,
 		errVerb:           "stop",
+		powerState:        powerStateDeallocated,
+	}
+	powerOffTransition = lifecycleTransition{ //nolint:gochecknoglobals // package-level config
+		intermediateState: compute.StateStopping,
+		finalState:        compute.StateStopped,
+		metricValues:      zeroMetricValues,
+		errVerb:           "power off",
+		powerState:        powerStateStopped,
+	}
+	deallocateTransition = lifecycleTransition{ //nolint:gochecknoglobals // package-level config
+		intermediateState: compute.StateStopping,
+		finalState:        compute.StateStopped,
+		metricValues:      zeroMetricValues,
+		errVerb:           "deallocate",
+		powerState:        powerStateDeallocated,
 	}
 	rebootTransition = lifecycleTransition{ //nolint:gochecknoglobals // package-level config
 		intermediateState: compute.StateRestarting,
 		finalState:        compute.StateRunning,
 		metricValues:      runningMetricValues,
 		errVerb:           "reboot",
+		powerState:        powerStateRunning,
 	}
 	terminateTransition = lifecycleTransition{ //nolint:gochecknoglobals // package-level config
 		intermediateState: compute.StateShuttingDown,
@@ -67,6 +95,15 @@ var (
 		metricValues:      zeroMetricValues,
 		errVerb:           "terminate",
 	}
+)
+
+// Azure power states we track distinctly from the lifecycle state, so a
+// PowerOff'd VM (stopped, still allocated) is reported apart from a Deallocated
+// one (compute released).
+const (
+	powerStateRunning     = "running"
+	powerStateStopped     = "stopped"
+	powerStateDeallocated = "deallocated"
 )
 
 type instanceData struct {
@@ -87,6 +124,8 @@ type instanceData struct {
 	Zones          []string
 	Region         string
 	ResourceGroup  string
+	// PowerState is the Azure power state ("running"/"stopped"/"deallocated").
+	PowerState string
 	// engineBacked is true when a real config.ComputeEngine backs this
 	// instance, so Terminate deprovisions it and console output is read from
 	// the engine rather than synthesized.
@@ -217,6 +256,7 @@ func toInstance(d *instanceData) driver.Instance {
 		OSType: d.OSType, Priority: d.Priority, LicenseType: d.LicenseType,
 		Zones:  append([]string(nil), d.Zones...),
 		Region: d.Region, ResourceGroup: d.ResourceGroup,
+		PowerState: d.PowerState,
 	}
 }
 
@@ -267,6 +307,7 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 			Zones:         zones,
 			Region:        cfg.Region,
 			ResourceGroup: cfg.ResourceGroup,
+			PowerState:    powerStateRunning,
 		}
 
 		// Back the instance with a real compute engine when one is configured.
@@ -314,7 +355,7 @@ func (m *Mock) rollbackInstances(ctx context.Context, created []*instanceData) {
 	}
 }
 
-func (m *Mock) transitionInstances(ctx context.Context, instanceIDs []string, t lifecycleTransition) error {
+func (m *Mock) transitionInstances(ctx context.Context, instanceIDs []string, t *lifecycleTransition) error {
 	for _, id := range instanceIDs {
 		inst, ok := m.instances.Get(id)
 		if !ok {
@@ -329,6 +370,10 @@ func (m *Mock) transitionInstances(ctx context.Context, instanceIDs []string, t 
 		_ = m.sm.Transition(id, t.finalState)
 		inst.State = t.finalState
 
+		if t.powerState != "" {
+			inst.PowerState = t.powerState
+		}
+
 		m.emitLifecycleMetrics(ctx, id, t.metricValues)
 	}
 
@@ -337,22 +382,78 @@ func (m *Mock) transitionInstances(ctx context.Context, instanceIDs []string, t 
 
 // StartInstances starts the specified stopped virtual machine instances.
 func (m *Mock) StartInstances(ctx context.Context, instanceIDs []string) error {
-	return m.transitionInstances(ctx, instanceIDs, startTransition)
+	return m.transitionInstances(ctx, instanceIDs, &startTransition)
 }
 
 // StopInstances stops the specified running virtual machine instances.
 func (m *Mock) StopInstances(ctx context.Context, instanceIDs []string) error {
-	return m.transitionInstances(ctx, instanceIDs, stopTransition)
+	return m.transitionInstances(ctx, instanceIDs, &stopTransition)
+}
+
+// PowerOff stops the guest OS of an instance while keeping the VM allocated
+// (Azure PowerState/stopped). Unlike Deallocate, the compute is not released.
+func (m *Mock) PowerOff(ctx context.Context, instanceID string) error {
+	return m.transitionInstances(ctx, []string{instanceID}, &powerOffTransition)
+}
+
+// Deallocate stops the guest OS and releases the allocated compute of an
+// instance (Azure PowerState/deallocated).
+func (m *Mock) Deallocate(ctx context.Context, instanceID string) error {
+	return m.transitionInstances(ctx, []string{instanceID}, &deallocateTransition)
+}
+
+// UpdateInstance overwrites the mutable configuration of an existing instance
+// in place, preserving its ID, launch time, IP, and current power state. It
+// backs the idempotent ARM CreateOrUpdate PUT so a repeated PUT updates the VM
+// rather than provisioning a duplicate.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) UpdateInstance(_ context.Context, instanceID string, cfg driver.InstanceConfig) error {
+	inst, ok := m.instances.Get(instanceID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
+	}
+
+	if cfg.InstanceType != "" {
+		inst.InstanceType = cfg.InstanceType
+	}
+
+	if cfg.ImageID != "" {
+		inst.ImageID = cfg.ImageID
+	}
+
+	if cfg.SubnetID != "" {
+		inst.SubnetID = cfg.SubnetID
+	}
+
+	if cfg.OSType != "" {
+		inst.OSType = cfg.OSType
+	}
+
+	inst.Priority = cfg.Priority
+	inst.LicenseType = cfg.LicenseType
+
+	if len(cfg.Zones) > 0 {
+		inst.Zones = append([]string(nil), cfg.Zones...)
+	}
+
+	if cfg.Region != "" {
+		inst.Region = cfg.Region
+	}
+
+	inst.Tags = copyTags(cfg.Tags)
+
+	return nil
 }
 
 // RebootInstances reboots the specified running virtual machine instances.
 func (m *Mock) RebootInstances(ctx context.Context, instanceIDs []string) error {
-	return m.transitionInstances(ctx, instanceIDs, rebootTransition)
+	return m.transitionInstances(ctx, instanceIDs, &rebootTransition)
 }
 
 // TerminateInstances terminates the specified virtual machine instances.
 func (m *Mock) TerminateInstances(ctx context.Context, instanceIDs []string) error {
-	if err := m.transitionInstances(ctx, instanceIDs, terminateTransition); err != nil {
+	if err := m.transitionInstances(ctx, instanceIDs, &terminateTransition); err != nil {
 		return err
 	}
 
@@ -693,6 +794,56 @@ func (m *Mock) CreateKeyPair(_ context.Context, cfg driver.KeyPairConfig) (*driv
 	result := *kp
 
 	return &result, nil
+}
+
+// GenerateKeyPair generates a fresh RSA key pair server-side for an existing
+// sshPublicKey resource (Azure generateKeyPair action). It stores the generated
+// public key on the resource and returns both the public key (OpenSSH
+// authorized_keys form) and the private key (PEM PKCS#1) — the one time the
+// private key is disclosed.
+func (m *Mock) GenerateKeyPair(_ context.Context, name string) (*driver.KeyPairInfo, error) {
+	kp, ok := m.keyPairs.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "sshPublicKey %q not found", name)
+	}
+
+	pub, priv, err := generateRSAKeyPair()
+	if err != nil {
+		return nil, cerrors.Newf(cerrors.Internal, "generate key pair: %v", err)
+	}
+
+	kp.PublicKey = pub
+	kp.PrivateKey = priv
+	kp.Fingerprint = "fp-" + name
+	m.keyPairs.Set(name, kp)
+
+	result := *kp
+
+	return &result, nil
+}
+
+// rsaKeyBits is the modulus size Azure uses for generated SSH key pairs.
+const rsaKeyBits = 2048
+
+// generateRSAKeyPair returns a fresh RSA key pair: the public key in OpenSSH
+// authorized_keys form and the private key in PEM (PKCS#1) form.
+func generateRSAKeyPair() (publicKey, privateKey string, err error) {
+	key, err := rsa.GenerateKey(rand.Reader, rsaKeyBits)
+	if err != nil {
+		return "", "", err
+	}
+
+	privPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	sshPub, err := ssh.NewPublicKey(&key.PublicKey)
+	if err != nil {
+		return "", "", err
+	}
+
+	return string(ssh.MarshalAuthorizedKey(sshPub)), string(privPEM), nil
 }
 
 // DeleteKeyPair deletes a key pair by name.

--- a/server/azure/disks/creationdata_test.go
+++ b/server/azure/disks/creationdata_test.go
@@ -179,6 +179,29 @@ func TestDiskCreateOrUpdateIdempotent(t *testing.T) {
 	}
 }
 
+// TestDiskCreateOrUpdateCrossRGIsolation verifies that PUTting a disk with a
+// name that already exists in ANOTHER resource group does not delete/hijack the
+// original — in ARM {subscription,resourceGroup,name} is the resource identity.
+func TestDiskCreateOrUpdateCrossRGIsolation(t *testing.T) {
+	ts := newDisksServer(t)
+
+	body := `{"location":"eastus","sku":{"name":"Premium_LRS"},"properties":{"creationData":{"createOption":"Empty"},"diskSizeGB":64}}`
+	putDisk(t, ts, "rg-1", "shared", body)
+	putDisk(t, ts, "rg-2", "shared", body)
+
+	// The rg-1 disk must survive the rg-2 PUT of the same name.
+	resp, err := ts.Client().Get(ts.URL +
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/disks/shared" + wireAPIVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("GET rg-1/shared after rg-2 PUT: status %d, want 200 (original was hijacked)", resp.StatusCode)
+	}
+}
+
 // TestDiskListResourceGroupScope verifies list does not leak other RGs' disks.
 func TestDiskListResourceGroupScope(t *testing.T) {
 	ts := newDisksServer(t)

--- a/server/azure/disks/creationdata_test.go
+++ b/server/azure/disks/creationdata_test.go
@@ -1,0 +1,208 @@
+package disks_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+const wireAPIVersion = "?api-version=2023-09-01"
+
+func newDisksServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	cloud := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Disks: cloud.VirtualMachines})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func diskPath(rg, name string) string {
+	return "/subscriptions/sub-1/resourceGroups/" + rg + "/providers/Microsoft.Compute/disks/" + name
+}
+
+func putDisk(t *testing.T, ts *httptest.Server, rg, name, body string) map[string]any {
+	t.Helper()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+diskPath(rg, name)+wireAPIVersion, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("PUT disk %s: status %d body=%s", name, resp.StatusCode, dump)
+	}
+
+	var out map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+
+	return out
+}
+
+func getDisk(t *testing.T, ts *httptest.Server, rg, name string) map[string]any {
+	t.Helper()
+
+	resp, err := ts.Client().Get(ts.URL + diskPath(rg, name) + wireAPIVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET disk %s: status %d body=%s", name, resp.StatusCode, dump)
+	}
+
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+
+	return out
+}
+
+func diskProps(t *testing.T, body map[string]any) map[string]any {
+	t.Helper()
+
+	props, ok := body["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("no properties in %v", body)
+	}
+
+	return props
+}
+
+// TestDiskCreationDataAndMetadata verifies an empty disk echoes its createOption
+// and populates diskSizeGB, timeCreated, and uniqueId.
+func TestDiskCreationDataAndMetadata(t *testing.T) {
+	ts := newDisksServer(t)
+
+	putDisk(t, ts, "rg-1", "disk-empty", `{
+		"location":"eastus",
+		"sku":{"name":"Premium_LRS"},
+		"properties":{"creationData":{"createOption":"Empty"},"diskSizeGB":100}
+	}`)
+
+	props := diskProps(t, getDisk(t, ts, "rg-1", "disk-empty"))
+
+	if props["diskSizeGB"].(float64) != 100 {
+		t.Errorf("diskSizeGB=%v want 100", props["diskSizeGB"])
+	}
+
+	cd, _ := props["creationData"].(map[string]any)
+	if cd["createOption"] != "Empty" {
+		t.Errorf("createOption=%v want Empty", cd["createOption"])
+	}
+
+	if props["timeCreated"] == nil || props["timeCreated"] == "" {
+		t.Error("timeCreated missing")
+	}
+
+	if props["uniqueId"] == nil || props["uniqueId"] == "" {
+		t.Error("uniqueId missing")
+	}
+}
+
+// TestDiskCopyInheritsSourceSize verifies a Copy disk with no explicit
+// diskSizeGB inherits the source disk's size and echoes createOption/source.
+func TestDiskCopyInheritsSourceSize(t *testing.T) {
+	ts := newDisksServer(t)
+
+	putDisk(t, ts, "rg-1", "disk-src", `{
+		"location":"eastus","sku":{"name":"Premium_LRS"},
+		"properties":{"creationData":{"createOption":"Empty"},"diskSizeGB":128}
+	}`)
+
+	sourceID := diskPath("rg-1", "disk-src")
+
+	putDisk(t, ts, "rg-1", "disk-copy", `{
+		"location":"eastus","sku":{"name":"Premium_LRS"},
+		"properties":{"creationData":{"createOption":"Copy","sourceResourceId":"`+sourceID+`"}}
+	}`)
+
+	props := diskProps(t, getDisk(t, ts, "rg-1", "disk-copy"))
+
+	if props["diskSizeGB"].(float64) != 128 {
+		t.Errorf("copy diskSizeGB=%v want 128 (inherited)", props["diskSizeGB"])
+	}
+
+	cd, _ := props["creationData"].(map[string]any)
+	if cd["createOption"] != "Copy" {
+		t.Errorf("createOption=%v want Copy", cd["createOption"])
+	}
+
+	if cd["sourceResourceId"] != sourceID {
+		t.Errorf("sourceResourceId=%v want %s", cd["sourceResourceId"], sourceID)
+	}
+}
+
+// TestDiskCreateOrUpdateIdempotent verifies a repeated PUT does not accumulate a
+// duplicate: List returns one.
+func TestDiskCreateOrUpdateIdempotent(t *testing.T) {
+	ts := newDisksServer(t)
+
+	body := `{"location":"eastus","sku":{"name":"Premium_LRS"},"properties":{"creationData":{"createOption":"Empty"},"diskSizeGB":64}}`
+	putDisk(t, ts, "rg-1", "disk-idem", body)
+	putDisk(t, ts, "rg-1", "disk-idem", body)
+
+	resp, err := ts.Client().Get(ts.URL +
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/disks" + wireAPIVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var got struct {
+		Value []map[string]any `json:"value"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got.Value) != 1 {
+		t.Fatalf("List returned %d disks after repeated PUT, want 1", len(got.Value))
+	}
+}
+
+// TestDiskListResourceGroupScope verifies list does not leak other RGs' disks.
+func TestDiskListResourceGroupScope(t *testing.T) {
+	ts := newDisksServer(t)
+
+	body := `{"location":"eastus","sku":{"name":"Premium_LRS"},"properties":{"creationData":{"createOption":"Empty"},"diskSizeGB":32}}`
+	putDisk(t, ts, "rg-1", "disk-a", body)
+	putDisk(t, ts, "rg-2", "disk-b", body)
+
+	resp, err := ts.Client().Get(ts.URL +
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/disks" + wireAPIVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var got struct {
+		Value []map[string]any `json:"value"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got.Value) != 1 {
+		t.Fatalf("rg-1 disk list returned %d, want 1 (rg-2 leaked)", len(got.Value))
+	}
+}

--- a/server/azure/disks/handler.go
+++ b/server/azure/disks/handler.go
@@ -11,7 +11,10 @@ package disks
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
+	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
@@ -22,7 +25,17 @@ const (
 	providerName    = "Microsoft.Compute"
 	resourceType    = "disks"
 	armNameTag      = "cloudemu:azureDiskName"
+	rgTag           = "cloudemu:azureRG"
+	createOptionTag = "cloudemu:createOption"
+	sourceIDTag     = "cloudemu:sourceResourceId"
 	defaultLocation = "eastus"
+
+	// createOptionEmpty is the default disk createOption (an empty disk).
+	createOptionEmpty = "Empty"
+
+	// snapshotARMNameTag mirrors the ARM-name tag the snapshots handler stamps,
+	// so a Copy source snapshot can be resolved to its driver volume.
+	snapshotARMNameTag = "cloudemu:azureSnapshotName"
 )
 
 // Handler serves Microsoft.Compute/disks requests.
@@ -90,6 +103,10 @@ func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp azu
 	out := make([]diskResponse, 0, len(vols))
 
 	for i := range vols {
+		if rp.ResourceGroup != "" && tagOr(vols[i].Tags, rgTag, "") != rp.ResourceGroup {
+			continue
+		}
+
 		name := tagOr(vols[i].Tags, armNameTag, vols[i].ID)
 		scope := rp
 		scope.ResourceName = name
@@ -112,13 +129,26 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		return
 	}
 
+	createOption, sourceID := creationParams(req.Properties.CreationData)
+
+	size := req.Properties.DiskSizeGB
+	if size == 0 && sourceID != "" {
+		size = h.sourceSize(r.Context(), sourceID)
+	}
+
 	cfg := computedriver.VolumeConfig{
-		Size:       req.Properties.DiskSizeGB,
+		Size:       size,
 		VolumeType: skuName(req.SKU),
 		IOPS:       req.Properties.DiskIOPSReadWrite,
 		Throughput: req.Properties.DiskMBpsReadWrite,
 		Tier:       diskTier(req.Properties.Tier, skuTier(req.SKU)),
-		Tags:       mergeDiskTags(req.Tags, rp.ResourceName),
+		Tags:       mergeDiskTags(req.Tags, rp.ResourceName, rp.ResourceGroup, createOption, sourceID),
+	}
+
+	// ARM CreateOrUpdate is idempotent: replace an existing disk in place
+	// rather than accumulating a duplicate under the same name.
+	if existing, err := findDiskByName(r.Context(), h.compute, rp.ResourceName); err == nil {
+		_ = h.compute.DeleteVolume(r.Context(), existing.ID)
 	}
 
 	vol, err := h.compute.CreateVolume(r.Context(), cfg)
@@ -136,6 +166,71 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 	body.SKU = req.SKU
 
 	writeDiskAsync(w, r, rp.Subscription, "disk-create-"+rp.ResourceName, body)
+}
+
+// creationParams extracts the createOption and source resource id from the
+// request's creationData, defaulting createOption to "Empty" when unset.
+func creationParams(c *creationData) (createOption, sourceID string) {
+	if c == nil {
+		return createOptionEmpty, ""
+	}
+
+	opt := c.CreateOption
+	if opt == "" {
+		opt = createOptionEmpty
+	}
+
+	src := c.SourceResourceID
+	if src == "" {
+		src = c.SourceURI
+	}
+
+	return opt, src
+}
+
+// sourceSize resolves the size (GB) of a Copy/Restore source referenced by an
+// ARM snapshot or disk id, so a disk created from a source without an explicit
+// diskSizeGB inherits the source's size. Returns 0 when unresolved.
+func (h *Handler) sourceSize(ctx context.Context, sourceID string) int {
+	if name, ok := armName(sourceID, "/snapshots/"); ok {
+		snaps, err := h.compute.DescribeSnapshots(ctx, nil)
+		if err == nil {
+			for i := range snaps {
+				if tagOr(snaps[i].Tags, snapshotARMNameTag, "") == name {
+					return snaps[i].Size
+				}
+			}
+		}
+	}
+
+	if name, ok := armName(sourceID, "/disks/"); ok {
+		vols, err := h.compute.DescribeVolumes(ctx, nil)
+		if err == nil {
+			for i := range vols {
+				if tagOr(vols[i].Tags, armNameTag, "") == name {
+					return vols[i].Size
+				}
+			}
+		}
+	}
+
+	return 0
+}
+
+// armName extracts the trailing resource name from an ARM id after the given
+// "/{type}/" segment (e.g. "/snapshots/"). Reports false when absent.
+func armName(id, segment string) (string, bool) {
+	idx := strings.LastIndex(id, segment)
+	if idx < 0 {
+		return "", false
+	}
+
+	name := id[idx+len(segment):]
+	if i := strings.Index(name, "/"); i >= 0 {
+		name = name[:i]
+	}
+
+	return name, name != ""
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -221,6 +316,13 @@ func toDiskResponse(vol *computedriver.VolumeInfo, rp azurearm.ResourcePath, loc
 		sku = &diskSKU{Name: vol.VolumeType, Tier: vol.Tier}
 	}
 
+	createOption := tagOr(vol.Tags, createOptionTag, createOptionEmpty)
+	cd := &creationData{CreateOption: createOption}
+
+	if src := tagOr(vol.Tags, sourceIDTag, ""); src != "" {
+		cd.SourceResourceID = src
+	}
+
 	return diskResponse{
 		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, name),
 		Name:     name,
@@ -232,12 +334,23 @@ func toDiskResponse(vol *computedriver.VolumeInfo, rp azurearm.ResourcePath, loc
 			ProvisioningState: "Succeeded",
 			DiskSizeGB:        vol.Size,
 			DiskState:         diskStateFor(vol.State),
-			CreationData:      &creationData{CreateOption: "Empty"},
+			CreationData:      cd,
 			DiskIOPSReadWrite: vol.IOPS,
 			DiskMBpsReadWrite: vol.Throughput,
 			Tier:              vol.Tier,
+			TimeCreated:       vol.CreatedAt,
+			UniqueID:          diskUniqueID(vol.ID),
 		},
 	}
+}
+
+// diskUniqueID derives a stable GUID-shaped uniqueId from the driver volume id,
+// mirroring the properties.uniqueId Azure assigns each managed disk.
+func diskUniqueID(volID string) string {
+	sum := sha256.Sum256([]byte(volID))
+	h := hex.EncodeToString(sum[:])
+
+	return h[0:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
 }
 
 // diskTier prefers properties.tier, falling back to sku.tier.
@@ -280,14 +393,30 @@ func skuTier(s *diskSKU) string {
 	return s.Tier
 }
 
-func mergeDiskTags(in map[string]string, name string) map[string]string {
-	out := make(map[string]string, len(in)+1)
+// diskExtraSlots is the headroom for the cloudemu-internal tags mergeDiskTags
+// inserts (name, resource group, createOption, source id).
+const diskExtraSlots = 4
+
+func mergeDiskTags(in map[string]string, name, resourceGroup, createOption, sourceID string) map[string]string {
+	out := make(map[string]string, len(in)+diskExtraSlots)
 
 	for k, v := range in {
 		out[k] = v
 	}
 
 	out[armNameTag] = name
+
+	if resourceGroup != "" {
+		out[rgTag] = resourceGroup
+	}
+
+	if createOption != "" {
+		out[createOptionTag] = createOption
+	}
+
+	if sourceID != "" {
+		out[sourceIDTag] = sourceID
+	}
 
 	return out
 }
@@ -308,7 +437,7 @@ func stripInternalDiskTags(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
 
 	for k, v := range in {
-		if k == armNameTag {
+		if k == armNameTag || k == rgTag || k == createOptionTag || k == sourceIDTag {
 			continue
 		}
 

--- a/server/azure/disks/handler.go
+++ b/server/azure/disks/handler.go
@@ -147,7 +147,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 
 	// ARM CreateOrUpdate is idempotent: replace an existing disk in place
 	// rather than accumulating a duplicate under the same name.
-	if existing, err := findDiskByName(r.Context(), h.compute, rp.ResourceName); err == nil {
+	if existing, err := findDiskByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName); err == nil {
 		_ = h.compute.DeleteVolume(r.Context(), existing.ID)
 	}
 
@@ -235,7 +235,7 @@ func armName(id, segment string) (string, bool) {
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	vol, err := findDiskByName(r.Context(), h.compute, rp.ResourceName)
+	vol, err := findDiskByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -246,7 +246,7 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.Resour
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	vol, err := findDiskByName(r.Context(), h.compute, rp.ResourceName)
+	vol, err := findDiskByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -261,16 +261,24 @@ func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 }
 
 // findDiskByName looks up a volume by its ARM-tagged name.
-func findDiskByName(ctx context.Context, c computedriver.Compute, name string) (*computedriver.VolumeInfo, error) {
+func findDiskByName(ctx context.Context, c computedriver.Compute, resourceGroup, name string) (*computedriver.VolumeInfo, error) {
 	vols, err := c.DescribeVolumes(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	for i := range vols {
-		if tagOr(vols[i].Tags, armNameTag, "") == name {
-			return &vols[i], nil
+		if tagOr(vols[i].Tags, armNameTag, "") != name {
+			continue
 		}
+
+		// A resource's identity in ARM is {subscription, resourceGroup, name};
+		// a same-named disk in another RG is a different resource.
+		if resourceGroup != "" && tagOr(vols[i].Tags, rgTag, "") != resourceGroup {
+			continue
+		}
+
+		return &vols[i], nil
 	}
 
 	return nil, cerrors.Newf(cerrors.NotFound, "disk %s not found", name)

--- a/server/azure/disks/types.go
+++ b/server/azure/disks/types.go
@@ -48,6 +48,8 @@ type diskResponseProps struct {
 	DiskIOPSReadWrite int           `json:"diskIOPSReadWrite,omitempty"`
 	DiskMBpsReadWrite int           `json:"diskMBpsReadWrite,omitempty"`
 	Tier              string        `json:"tier,omitempty"`
+	TimeCreated       string        `json:"timeCreated,omitempty"`
+	UniqueID          string        `json:"uniqueId,omitempty"`
 }
 
 type diskListResponse struct {

--- a/server/azure/images/handler.go
+++ b/server/azure/images/handler.go
@@ -15,11 +15,18 @@ const (
 	providerName    = "Microsoft.Compute"
 	resourceType    = "images"
 	armNameTag      = "cloudemu:azureImageName"
+	rgTag           = "cloudemu:azureRG"
+	sourceVMTag     = "cloudemu:sourceVM"
+	osTypeTag       = "cloudemu:osType"
 	defaultLocation = "eastus"
 
 	// vmARMNameTag mirrors the constant in server/azure/virtualmachines so
 	// we can resolve a VM ARM ID to its driver-internal instance ID.
 	vmARMNameTag = "cloudemu:azureName"
+
+	// defaultOSDiskSizeGB is the OS-disk size we report for a captured image
+	// when the source disk size is unknown (Azure's marketplace default).
+	defaultOSDiskSizeGB = 30
 )
 
 // Handler serves Microsoft.Compute/images requests.
@@ -84,6 +91,10 @@ func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp azu
 	out := make([]imageResponse, 0, len(imgs))
 
 	for i := range imgs {
+		if rp.ResourceGroup != "" && tagOr(imgs[i].Tags, rgTag, "") != rp.ResourceGroup {
+			continue
+		}
+
 		name := tagOr(imgs[i].Tags, armNameTag, imgs[i].Name)
 		scope := rp
 		scope.ResourceName = name
@@ -106,7 +117,9 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		return
 	}
 
-	driverInstanceID, err := h.resolveSourceVMID(r.Context(), sourceVMID(req.Properties.SourceVirtualMachine))
+	submittedVM := sourceVMID(req.Properties.SourceVirtualMachine)
+
+	driverInstanceID, err := h.resolveSourceVMID(r.Context(), submittedVM)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -115,7 +128,16 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 	cfg := computedriver.ImageConfig{
 		InstanceID: driverInstanceID,
 		Name:       rp.ResourceName,
-		Tags:       mergeTags(req.Tags, rp.ResourceName),
+		Tags: mergeTags(
+			req.Tags, rp.ResourceName, rp.ResourceGroup,
+			submittedVM, h.sourceOSType(r.Context(), driverInstanceID),
+		),
+	}
+
+	// ARM CreateOrUpdate is idempotent: replace an existing image in place
+	// rather than accumulating a duplicate under the same name.
+	if existing, findErr := findImageByName(r.Context(), h.compute, rp.ResourceName); findErr == nil {
+		_ = h.compute.DeregisterImage(r.Context(), existing.ID)
 	}
 
 	img, err := h.compute.CreateImage(r.Context(), cfg)
@@ -218,6 +240,17 @@ func sourceVMID(r *resourceRef) string {
 	return r.ID
 }
 
+// sourceOSType returns the guest OS family of the source VM (driver instance
+// id), so the captured image echoes the OS type Azure records on osDisk.
+func (h *Handler) sourceOSType(ctx context.Context, instanceID string) string {
+	insts, err := h.compute.DescribeInstances(ctx, []string{instanceID}, nil)
+	if err != nil || len(insts) == 0 {
+		return ""
+	}
+
+	return insts[0].OSType
+}
+
 func writeImageAsync(w http.ResponseWriter, r *http.Request, sub, opID string, body any) {
 	scheme := "http"
 	if r.TLS != nil {
@@ -249,26 +282,66 @@ func toImageResponse(img *computedriver.ImageInfo, rp azurearm.ResourcePath, loc
 
 	name := tagOr(img.Tags, armNameTag, img.Name)
 
-	return imageResponse{
-		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, name),
-		Name:     name,
-		Type:     providerName + "/" + resourceType,
-		Location: location,
-		Tags:     stripInternalTags(img.Tags),
-		Properties: imageResponseProps{
-			ProvisioningState: "Succeeded",
+	props := imageResponseProps{
+		ProvisioningState: "Succeeded",
+		StorageProfile: &imageStorageProfile{
+			OSDisk: &imageOSDisk{
+				OSType:             osTypeOr(tagOr(img.Tags, osTypeTag, "")),
+				OSState:            "Generalized",
+				DiskSizeGB:         defaultOSDiskSizeGB,
+				StorageAccountType: "Standard_LRS",
+			},
 		},
+	}
+
+	if src := tagOr(img.Tags, sourceVMTag, ""); src != "" {
+		props.SourceVirtualMachine = &resourceRef{ID: src}
+	}
+
+	return imageResponse{
+		ID:         azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, name),
+		Name:       name,
+		Type:       providerName + "/" + resourceType,
+		Location:   location,
+		Tags:       stripInternalTags(img.Tags),
+		Properties: props,
 	}
 }
 
-func mergeTags(in map[string]string, name string) map[string]string {
-	out := make(map[string]string, len(in)+1)
+// osTypeOr defaults an unknown captured-image OS type to Linux, the most common
+// case, so the osDisk always reports a concrete osType.
+func osTypeOr(osType string) string {
+	if osType == "" {
+		return "Linux"
+	}
+
+	return osType
+}
+
+// imgExtraSlots is the headroom for the cloudemu-internal tags mergeTags
+// inserts (name, resource group, source VM, OS type).
+const imgExtraSlots = 4
+
+func mergeTags(in map[string]string, name, resourceGroup, sourceVM, osType string) map[string]string {
+	out := make(map[string]string, len(in)+imgExtraSlots)
 
 	for k, v := range in {
 		out[k] = v
 	}
 
 	out[armNameTag] = name
+
+	if resourceGroup != "" {
+		out[rgTag] = resourceGroup
+	}
+
+	if sourceVM != "" {
+		out[sourceVMTag] = sourceVM
+	}
+
+	if osType != "" {
+		out[osTypeTag] = osType
+	}
 
 	return out
 }
@@ -289,7 +362,7 @@ func stripInternalTags(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
 
 	for k, v := range in {
-		if k == armNameTag {
+		if k == armNameTag || k == rgTag || k == sourceVMTag || k == osTypeTag {
 			continue
 		}
 

--- a/server/azure/images/handler.go
+++ b/server/azure/images/handler.go
@@ -136,7 +136,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 
 	// ARM CreateOrUpdate is idempotent: replace an existing image in place
 	// rather than accumulating a duplicate under the same name.
-	if existing, findErr := findImageByName(r.Context(), h.compute, rp.ResourceName); findErr == nil {
+	if existing, findErr := findImageByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName); findErr == nil {
 		_ = h.compute.DeregisterImage(r.Context(), existing.ID)
 	}
 
@@ -161,7 +161,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	img, err := findImageByName(r.Context(), h.compute, rp.ResourceName)
+	img, err := findImageByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -172,7 +172,7 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.Resour
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	img, err := findImageByName(r.Context(), h.compute, rp.ResourceName)
+	img, err := findImageByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -186,16 +186,22 @@ func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 	writeImageAsync(w, r, rp.Subscription, "img-delete-"+rp.ResourceName, nil)
 }
 
-func findImageByName(ctx context.Context, c computedriver.Compute, name string) (*computedriver.ImageInfo, error) {
+func findImageByName(ctx context.Context, c computedriver.Compute, resourceGroup, name string) (*computedriver.ImageInfo, error) {
 	imgs, err := c.DescribeImages(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	for i := range imgs {
-		if tagOr(imgs[i].Tags, armNameTag, imgs[i].Name) == name {
-			return &imgs[i], nil
+		if tagOr(imgs[i].Tags, armNameTag, imgs[i].Name) != name {
+			continue
 		}
+
+		if resourceGroup != "" && tagOr(imgs[i].Tags, rgTag, "") != resourceGroup {
+			continue
+		}
+
+		return &imgs[i], nil
 	}
 
 	return nil, cerrors.Newf(cerrors.NotFound, "image %s not found", name)

--- a/server/azure/images/storageprofile_test.go
+++ b/server/azure/images/storageprofile_test.go
@@ -1,0 +1,120 @@
+package images_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+const wireAPIVersion = "?api-version=2023-09-01"
+
+func newImagesServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	cloud := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloud.VirtualMachines,
+		Images:          cloud.VirtualMachines,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func putRaw(t *testing.T, ts *httptest.Server, path, body string) {
+	t.Helper()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+path+wireAPIVersion, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("PUT %s: status %d body=%s", path, resp.StatusCode, dump)
+	}
+}
+
+// TestImageGetHasStorageProfileAndSource verifies a cold GET on a captured image
+// returns the osDisk storageProfile and the sourceVirtualMachine reference.
+func TestImageGetHasStorageProfileAndSource(t *testing.T) {
+	ts := newImagesServer(t)
+
+	vmID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/vm-src"
+
+	putRaw(t, ts, vmID, `{
+		"location":"eastus",
+		"properties":{
+			"hardwareProfile":{"vmSize":"Standard_D2s_v3"},
+			"storageProfile":{"osDisk":{"osType":"Linux"}}
+		}
+	}`)
+
+	imgID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/images/img-1"
+
+	putRaw(t, ts, imgID, `{
+		"location":"eastus",
+		"properties":{"sourceVirtualMachine":{"id":"`+vmID+`"}}
+	}`)
+
+	resp, err := ts.Client().Get(ts.URL + imgID + wireAPIVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET image status=%d body=%s", resp.StatusCode, dump)
+	}
+
+	var got map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+
+	props, _ := got["properties"].(map[string]any)
+
+	src, _ := props["sourceVirtualMachine"].(map[string]any)
+	if src == nil || src["id"] != vmID {
+		t.Errorf("sourceVirtualMachine.id=%v want %s", src, vmID)
+	}
+
+	sp, _ := props["storageProfile"].(map[string]any)
+	if sp == nil {
+		t.Fatal("storageProfile missing on image GET")
+	}
+
+	osDisk, _ := sp["osDisk"].(map[string]any)
+	if osDisk == nil {
+		t.Fatal("storageProfile.osDisk missing")
+	}
+
+	if osDisk["osType"] != "Linux" {
+		t.Errorf("osDisk.osType=%v want Linux", osDisk["osType"])
+	}
+
+	if osDisk["osState"] == nil || osDisk["osState"] == "" {
+		t.Error("osDisk.osState missing")
+	}
+
+	if osDisk["diskSizeGB"] == nil {
+		t.Error("osDisk.diskSizeGB missing")
+	}
+
+	if osDisk["storageAccountType"] == nil || osDisk["storageAccountType"] == "" {
+		t.Error("osDisk.storageAccountType missing")
+	}
+}

--- a/server/azure/images/types.go
+++ b/server/azure/images/types.go
@@ -26,8 +26,22 @@ type imageResponse struct {
 }
 
 type imageResponseProps struct {
-	ProvisioningState    string       `json:"provisioningState"`
-	SourceVirtualMachine *resourceRef `json:"sourceVirtualMachine,omitempty"`
+	ProvisioningState    string               `json:"provisioningState"`
+	SourceVirtualMachine *resourceRef         `json:"sourceVirtualMachine,omitempty"`
+	StorageProfile       *imageStorageProfile `json:"storageProfile,omitempty"`
+}
+
+// imageStorageProfile is the storageProfile of an image resource, carrying the
+// captured OS disk (and, in real Azure, data disks we do not model).
+type imageStorageProfile struct {
+	OSDisk *imageOSDisk `json:"osDisk,omitempty"`
+}
+
+type imageOSDisk struct {
+	OSType             string `json:"osType,omitempty"`
+	OSState            string `json:"osState,omitempty"`
+	DiskSizeGB         int    `json:"diskSizeGB,omitempty"`
+	StorageAccountType string `json:"storageAccountType,omitempty"`
 }
 
 type imageListResponse struct {

--- a/server/azure/snapshots/creationdata_test.go
+++ b/server/azure/snapshots/creationdata_test.go
@@ -1,0 +1,99 @@
+package snapshots_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+const wireAPIVersion = "?api-version=2023-09-01"
+
+func newSnapshotServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	cloud := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		Disks:     cloud.VirtualMachines,
+		Snapshots: cloud.VirtualMachines,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func putRaw(t *testing.T, ts *httptest.Server, path, body string) {
+	t.Helper()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+path+wireAPIVersion, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("PUT %s: status %d body=%s", path, resp.StatusCode, dump)
+	}
+}
+
+// TestSnapshotPreservesSubmittedSource verifies the snapshot echoes the exact
+// source resource id the client submitted, not the driver-internal disk path.
+func TestSnapshotPreservesSubmittedSource(t *testing.T) {
+	ts := newSnapshotServer(t)
+
+	diskID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/disks/disk-src"
+
+	putRaw(t, ts, diskID, `{
+		"location":"eastus","sku":{"name":"Premium_LRS"},
+		"properties":{"creationData":{"createOption":"Empty"},"diskSizeGB":50}
+	}`)
+
+	snapID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/snapshots/snap-1"
+
+	putRaw(t, ts, snapID, `{
+		"location":"eastus",
+		"properties":{"creationData":{"createOption":"Copy","sourceResourceId":"`+diskID+`"}}
+	}`)
+
+	resp, err := ts.Client().Get(ts.URL + snapID + wireAPIVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET snapshot status=%d body=%s", resp.StatusCode, dump)
+	}
+
+	var got map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+
+	props, _ := got["properties"].(map[string]any)
+	cd, _ := props["creationData"].(map[string]any)
+
+	if cd["createOption"] != "Copy" {
+		t.Errorf("createOption=%v want Copy", cd["createOption"])
+	}
+
+	if cd["sourceResourceId"] != diskID {
+		t.Errorf("sourceResourceId=%v want the submitted disk id %s", cd["sourceResourceId"], diskID)
+	}
+
+	if props["diskSizeGB"].(float64) != 50 {
+		t.Errorf("diskSizeGB=%v want 50 (from source)", props["diskSizeGB"])
+	}
+}

--- a/server/azure/snapshots/handler.go
+++ b/server/azure/snapshots/handler.go
@@ -136,7 +136,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 
 	// ARM CreateOrUpdate is idempotent: replace an existing snapshot in place
 	// rather than accumulating a duplicate under the same name.
-	if existing, findErr := findSnapshotByName(r.Context(), h.compute, rp.ResourceName); findErr == nil {
+	if existing, findErr := findSnapshotByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName); findErr == nil {
 		_ = h.compute.DeleteSnapshot(r.Context(), existing.ID)
 	}
 
@@ -168,7 +168,7 @@ func createOptionOr(c *creationData) string {
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	snap, err := findSnapshotByName(r.Context(), h.compute, rp.ResourceName)
+	snap, err := findSnapshotByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -179,7 +179,7 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.Resour
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	snap, err := findSnapshotByName(r.Context(), h.compute, rp.ResourceName)
+	snap, err := findSnapshotByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -193,16 +193,22 @@ func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 	writeSnapshotAsync(w, r, rp.Subscription, "snap-delete-"+rp.ResourceName, nil)
 }
 
-func findSnapshotByName(ctx context.Context, c computedriver.Compute, name string) (*computedriver.SnapshotInfo, error) {
+func findSnapshotByName(ctx context.Context, c computedriver.Compute, resourceGroup, name string) (*computedriver.SnapshotInfo, error) {
 	snaps, err := c.DescribeSnapshots(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	for i := range snaps {
-		if tagOr(snaps[i].Tags, armNameTag, "") == name {
-			return &snaps[i], nil
+		if tagOr(snaps[i].Tags, armNameTag, "") != name {
+			continue
 		}
+
+		if resourceGroup != "" && tagOr(snaps[i].Tags, rgTag, "") != resourceGroup {
+			continue
+		}
+
+		return &snaps[i], nil
 	}
 
 	return nil, cerrors.Newf(cerrors.NotFound, "snapshot %s not found", name)

--- a/server/azure/snapshots/handler.go
+++ b/server/azure/snapshots/handler.go
@@ -20,6 +20,9 @@ const (
 	providerName    = "Microsoft.Compute"
 	resourceType    = "snapshots"
 	armNameTag      = "cloudemu:azureSnapshotName"
+	rgTag           = "cloudemu:azureRG"
+	createOptionTag = "cloudemu:createOption"
+	sourceIDTag     = "cloudemu:sourceResourceId"
 	defaultLocation = "eastus"
 )
 
@@ -88,6 +91,10 @@ func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp azu
 	out := make([]snapshotResponse, 0, len(snaps))
 
 	for i := range snaps {
+		if rp.ResourceGroup != "" && tagOr(snaps[i].Tags, rgTag, "") != rp.ResourceGroup {
+			continue
+		}
+
 		name := tagOr(snaps[i].Tags, armNameTag, snaps[i].ID)
 		scope := rp
 		scope.ResourceName = name
@@ -110,7 +117,9 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		return
 	}
 
-	driverVolID, err := h.resolveSourceVolumeID(r.Context(), sourceVolumeID(req.Properties.CreationData))
+	submittedSource := sourceVolumeID(req.Properties.CreationData)
+
+	driverVolID, err := h.resolveSourceVolumeID(r.Context(), submittedSource)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -119,7 +128,16 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 	cfg := computedriver.SnapshotConfig{
 		VolumeID:    driverVolID,
 		Description: rp.ResourceName,
-		Tags:        mergeSnapshotTags(req.Tags, rp.ResourceName),
+		Tags: mergeSnapshotTags(
+			req.Tags, rp.ResourceName, rp.ResourceGroup,
+			createOptionOr(req.Properties.CreationData), submittedSource,
+		),
+	}
+
+	// ARM CreateOrUpdate is idempotent: replace an existing snapshot in place
+	// rather than accumulating a duplicate under the same name.
+	if existing, findErr := findSnapshotByName(r.Context(), h.compute, rp.ResourceName); findErr == nil {
+		_ = h.compute.DeleteSnapshot(r.Context(), existing.ID)
 	}
 
 	snap, err := h.compute.CreateSnapshot(r.Context(), cfg)
@@ -136,6 +154,16 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 	body := toSnapshotResponse(snap, rp, location)
 
 	writeSnapshotAsync(w, r, rp.Subscription, "snap-create-"+rp.ResourceName, body)
+}
+
+// createOptionOr returns the submitted createOption, defaulting to "Copy" (the
+// only source-backed option snapshots support) when unset.
+func createOptionOr(c *creationData) string {
+	if c != nil && c.CreateOption != "" {
+		return c.CreateOption
+	}
+
+	return "Copy"
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -212,6 +240,9 @@ func toSnapshotResponse(snap *computedriver.SnapshotInfo, rp azurearm.ResourcePa
 
 	name := tagOr(snap.Tags, armNameTag, rp.ResourceName)
 
+	createOption := tagOr(snap.Tags, createOptionTag, "Copy")
+	sourceID := tagOr(snap.Tags, sourceIDTag, snap.VolumeID)
+
 	return snapshotResponse{
 		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, name),
 		Name:     name,
@@ -223,8 +254,8 @@ func toSnapshotResponse(snap *computedriver.SnapshotInfo, rp azurearm.ResourcePa
 			DiskSizeGB:        snap.Size,
 			DiskState:         "ReadyToUpload",
 			CreationData: &creationData{
-				CreateOption:     "Copy",
-				SourceResourceID: snap.VolumeID,
+				CreateOption:     createOption,
+				SourceResourceID: sourceID,
 			},
 		},
 	}
@@ -278,14 +309,30 @@ func (h *Handler) resolveSourceVolumeID(ctx context.Context, src string) (string
 	return "", cerrors.Newf(cerrors.NotFound, "source disk %s not found", name)
 }
 
-func mergeSnapshotTags(in map[string]string, name string) map[string]string {
-	out := make(map[string]string, len(in)+1)
+// snapExtraSlots is the headroom for the cloudemu-internal tags
+// mergeSnapshotTags inserts (name, resource group, createOption, source id).
+const snapExtraSlots = 4
+
+func mergeSnapshotTags(in map[string]string, name, resourceGroup, createOption, sourceID string) map[string]string {
+	out := make(map[string]string, len(in)+snapExtraSlots)
 
 	for k, v := range in {
 		out[k] = v
 	}
 
 	out[armNameTag] = name
+
+	if resourceGroup != "" {
+		out[rgTag] = resourceGroup
+	}
+
+	if createOption != "" {
+		out[createOptionTag] = createOption
+	}
+
+	if sourceID != "" {
+		out[sourceIDTag] = sourceID
+	}
 
 	return out
 }
@@ -306,7 +353,7 @@ func stripInternalTags(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
 
 	for k, v := range in {
-		if k == armNameTag {
+		if k == armNameTag || k == rgTag || k == createOptionTag || k == sourceIDTag {
 			continue
 		}
 

--- a/server/azure/sshpublickeys/generate_keypair_test.go
+++ b/server/azure/sshpublickeys/generate_keypair_test.go
@@ -1,0 +1,109 @@
+package sshpublickeys_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+const apiVersion = "?api-version=2023-09-01"
+
+func newSSHServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	cloud := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{SSHPublicKeys: cloud.VirtualMachines})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func sshKeyPath(name string) string {
+	return "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/sshPublicKeys/" + name
+}
+
+func putSSHKey(t *testing.T, ts *httptest.Server, name string) {
+	t.Helper()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+sshKeyPath(name)+apiVersion,
+		strings.NewReader(`{"location":"eastus","properties":{}}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("PUT %s: status %d body=%s", name, resp.StatusCode, dump)
+	}
+}
+
+// TestGenerateKeyPairReturnsPrivateKey verifies the generateKeyPair action
+// returns a non-empty private key (PEM) and public key (OpenSSH), and that the
+// generated public key is persisted onto the resource.
+func TestGenerateKeyPairReturnsPrivateKey(t *testing.T) {
+	ts := newSSHServer(t)
+	putSSHKey(t, ts, "key-gen")
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+sshKeyPath("key-gen")+"/generateKeyPair"+apiVersion, http.NoBody)
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("generateKeyPair status=%d body=%s", resp.StatusCode, dump)
+	}
+
+	var out struct {
+		PublicKey  string `json:"publicKey"`
+		PrivateKey string `json:"privateKey"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(out.PrivateKey, "PRIVATE KEY") {
+		t.Errorf("privateKey is not a PEM block: %q", out.PrivateKey)
+	}
+
+	if !strings.HasPrefix(out.PublicKey, "ssh-rsa ") {
+		t.Errorf("publicKey is not OpenSSH form: %q", out.PublicKey)
+	}
+
+	// The generated public key must be persisted onto the resource.
+	getResp, err := ts.Client().Get(ts.URL + sshKeyPath("key-gen") + apiVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer getResp.Body.Close()
+
+	var got struct {
+		Properties struct {
+			PublicKey string `json:"publicKey"`
+		} `json:"properties"`
+	}
+
+	if err := json.NewDecoder(getResp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Properties.PublicKey != out.PublicKey {
+		t.Errorf("resource publicKey=%q not persisted from generateKeyPair (%q)", got.Properties.PublicKey, out.PublicKey)
+	}
+}

--- a/server/azure/sshpublickeys/handler.go
+++ b/server/azure/sshpublickeys/handler.go
@@ -16,6 +16,8 @@ const (
 	providerName    = "Microsoft.Compute"
 	resourceType    = "sshPublicKeys"
 	armNameTag      = "cloudemu:azureSSHKeyName"
+	rgTag           = "cloudemu:azureRG"
+	publicKeyTag    = "cloudemu:publicKey"
 	defaultLocation = "eastus"
 )
 
@@ -87,6 +89,10 @@ func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp azu
 	out := make([]sshKeyResponse, 0, len(keys))
 
 	for i := range keys {
+		if rp.ResourceGroup != "" && tagOr(keys[i].Tags, rgTag, "") != rp.ResourceGroup {
+			continue
+		}
+
 		name := tagOr(keys[i].Tags, armNameTag, keys[i].Name)
 		scope := rp
 		scope.ResourceName = name
@@ -112,7 +118,13 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 	cfg := computedriver.KeyPairConfig{
 		Name:    rp.ResourceName,
 		KeyType: "rsa",
-		Tags:    mergeTags(req.Tags, rp.ResourceName, req.Properties.PublicKey),
+		Tags:    mergeTags(req.Tags, rp.ResourceName, req.Properties.PublicKey, rp.ResourceGroup),
+	}
+
+	// ARM CreateOrUpdate is idempotent: a repeated PUT replaces the resource
+	// in place rather than failing with AlreadyExists.
+	if _, err := findKeyByName(r.Context(), h.compute, rp.ResourceName); err == nil {
+		_ = h.compute.DeleteKeyPair(r.Context(), rp.ResourceName)
 	}
 
 	key, err := h.compute.CreateKeyPair(r.Context(), cfg)
@@ -162,9 +174,10 @@ func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 	w.WriteHeader(http.StatusOK)
 }
 
-// generateKeyPair handles POST .../sshPublicKeys/{name}/generateKeyPair.
-// Real Azure generates a fresh RSA pair server-side; we return the driver's
-// provisioned PublicKey/PrivateKey, which the test fixtures populate.
+// generateKeyPair handles POST .../sshPublicKeys/{name}/generateKeyPair. Real
+// Azure generates a fresh 2048-bit RSA pair server-side, stores the public key
+// on the resource, and returns both keys (the only time the private key is
+// disclosed). We delegate to the driver's KeyPairGenerator when available.
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) generateKeyPair(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
@@ -175,7 +188,15 @@ func (h *Handler) generateKeyPair(w http.ResponseWriter, r *http.Request, rp azu
 		return
 	}
 
-	key, err := findKeyByName(r.Context(), h.compute, rp.ResourceName)
+	gen, ok := h.compute.(computedriver.KeyPairGenerator)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"generateKeyPair not supported")
+
+		return
+	}
+
+	key, err := gen.GenerateKeyPair(r.Context(), rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -211,7 +232,7 @@ func toSSHKeyResponse(key *computedriver.KeyPairInfo, rp azurearm.ResourcePath, 
 
 	name := tagOr(key.Tags, armNameTag, key.Name)
 
-	pub := tagOr(key.Tags, "cloudemu:publicKey", key.PublicKey)
+	pub := tagOr(key.Tags, publicKeyTag, key.PublicKey)
 
 	return sshKeyResponse{
 		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, name),
@@ -226,10 +247,10 @@ func toSSHKeyResponse(key *computedriver.KeyPairInfo, rp azurearm.ResourcePath, 
 }
 
 // extraSlots is the size headroom we add when copying a tag map and inserting
-// the cloudemu-internal name + public-key tags.
-const extraSlots = 2
+// the cloudemu-internal name, resource-group, and public-key tags.
+const extraSlots = 3
 
-func mergeTags(in map[string]string, name, publicKey string) map[string]string {
+func mergeTags(in map[string]string, name, publicKey, resourceGroup string) map[string]string {
 	out := make(map[string]string, len(in)+extraSlots)
 
 	for k, v := range in {
@@ -238,8 +259,12 @@ func mergeTags(in map[string]string, name, publicKey string) map[string]string {
 
 	out[armNameTag] = name
 
+	if resourceGroup != "" {
+		out[rgTag] = resourceGroup
+	}
+
 	if publicKey != "" {
-		out["cloudemu:publicKey"] = publicKey
+		out[publicKeyTag] = publicKey
 	}
 
 	return out
@@ -261,7 +286,7 @@ func stripInternalTags(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
 
 	for k, v := range in {
-		if k == armNameTag || k == "cloudemu:publicKey" {
+		if k == armNameTag || k == publicKeyTag || k == rgTag {
 			continue
 		}
 

--- a/server/azure/sshpublickeys/handler.go
+++ b/server/azure/sshpublickeys/handler.go
@@ -123,7 +123,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 
 	// ARM CreateOrUpdate is idempotent: a repeated PUT replaces the resource
 	// in place rather than failing with AlreadyExists.
-	if _, err := findKeyByName(r.Context(), h.compute, rp.ResourceName); err == nil {
+	if _, err := findKeyByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName); err == nil {
 		_ = h.compute.DeleteKeyPair(r.Context(), rp.ResourceName)
 	}
 
@@ -149,7 +149,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	key, err := findKeyByName(r.Context(), h.compute, rp.ResourceName)
+	key, err := findKeyByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -160,7 +160,7 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.Resour
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	key, err := findKeyByName(r.Context(), h.compute, rp.ResourceName)
+	key, err := findKeyByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -209,16 +209,22 @@ func (h *Handler) generateKeyPair(w http.ResponseWriter, r *http.Request, rp azu
 	})
 }
 
-func findKeyByName(ctx context.Context, c computedriver.Compute, name string) (*computedriver.KeyPairInfo, error) {
+func findKeyByName(ctx context.Context, c computedriver.Compute, resourceGroup, name string) (*computedriver.KeyPairInfo, error) {
 	keys, err := c.DescribeKeyPairs(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	for i := range keys {
-		if tagOr(keys[i].Tags, armNameTag, keys[i].Name) == name {
-			return &keys[i], nil
+		if tagOr(keys[i].Tags, armNameTag, keys[i].Name) != name {
+			continue
 		}
+
+		if resourceGroup != "" && tagOr(keys[i].Tags, rgTag, "") != resourceGroup {
+			continue
+		}
+
+		return &keys[i], nil
 	}
 
 	return nil, cerrors.Newf(cerrors.NotFound, "sshPublicKey %s not found", name)

--- a/server/azure/virtualmachines/handler.go
+++ b/server/azure/virtualmachines/handler.go
@@ -154,6 +154,18 @@ func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, rp azurear
 		return
 	}
 
+	// instanceView is a GET sub-resource, not a POST action.
+	if strings.EqualFold(rp.SubResource, "instanceView") {
+		if r.Method != http.MethodGet {
+			writeNotImplemented(w, r.Method+" "+r.URL.Path)
+			return
+		}
+
+		h.instanceView(w, r, rp)
+
+		return
+	}
+
 	if r.Method != http.MethodPost {
 		writeNotImplemented(w, r.Method+" "+r.URL.Path)
 		return
@@ -162,8 +174,10 @@ func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, rp azurear
 	switch strings.ToLower(rp.SubResource) {
 	case "start":
 		h.start(w, r, rp)
-	case "poweroff", "deallocate":
+	case "poweroff":
 		h.powerOff(w, r, rp)
+	case "deallocate":
+		h.deallocate(w, r, rp)
 	case "restart":
 		h.restart(w, r, rp)
 	case "retrievebootdiagnosticsdata":

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -73,6 +73,13 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		ResourceGroup: rp.ResourceGroup,
 	}
 
+	// ARM CreateOrUpdate is idempotent: a repeated PUT to the same {rg,name}
+	// updates the VM in place rather than provisioning a duplicate.
+	if existing, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName); err == nil {
+		h.updateExisting(w, r, rp, req, existing, cfg)
+		return
+	}
+
 	instances, err := h.compute.RunInstances(r.Context(), cfg, 1)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
@@ -87,11 +94,39 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 	azurearm.WriteJSON(w, http.StatusOK, toVMResponse(&instances[0], rp, req))
 }
 
+// updateExisting applies an idempotent CreateOrUpdate to an already-provisioned
+// VM. When the driver supports in-place update (AzureVMController) the existing
+// instance's mutable config is overwritten and its ID preserved; otherwise the
+// current instance is returned unchanged so no duplicate is created.
+//
+//nolint:gocritic // rp/req are request-scoped values passed once per request
+func (h *Handler) updateExisting(
+	w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	req vmRequest, existing *computedriver.Instance, cfg computedriver.InstanceConfig,
+) {
+	if ctrl, ok := h.compute.(computedriver.AzureVMController); ok {
+		if err := ctrl.UpdateInstance(r.Context(), existing.ID, cfg); err != nil {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+
+		updated, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
+		if err != nil {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+
+		existing = updated
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toVMResponse(existing, rp, req))
+}
+
 // get handles GET virtualMachines/{name}.
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	inst, err := findByName(r.Context(), h.compute, rp.ResourceName)
+	inst, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -100,8 +135,9 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.Resour
 	azurearm.WriteJSON(w, http.StatusOK, toVMResponse(inst, rp, vmRequest{}))
 }
 
-// list handles GET virtualMachines (within a subscription or resource group).
-// The mock isn't subscription/RG-aware, so all VMs come back.
+// list handles GET virtualMachines. A resource-group-scoped path
+// (.../resourceGroups/{rg}/...) returns only that group's VMs; a
+// subscription-scoped path returns every VM.
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
@@ -114,6 +150,10 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp azurearm.Resou
 	out := make([]vmResponse, 0, len(instances))
 
 	for i := range instances {
+		if rp.ResourceGroup != "" && instances[i].ResourceGroup != rp.ResourceGroup {
+			continue
+		}
+
 		name := tagOr(instances[i].Tags, armNameTag, instances[i].ID)
 		scope := rp
 		scope.ResourceName = name
@@ -123,12 +163,27 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp azurearm.Resou
 	azurearm.WriteJSON(w, http.StatusOK, vmListResponse{Value: out})
 }
 
+// instanceView handles GET virtualMachines/{name}/instanceView. It returns the
+// VirtualMachineInstanceView: the provisioning + power state statuses, the VM
+// agent status, and per-disk status the Azure SDK's InstanceView call reads.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) instanceView(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	inst, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toInstanceView(inst))
+}
+
 // delete handles DELETE virtualMachines/{name}. Returns a 202 Accepted with
 // the async-operation polling header so the SDK's poller terminates cleanly.
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	inst, err := findByName(r.Context(), h.compute, rp.ResourceName)
+	inst, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -149,11 +204,53 @@ func (h *Handler) start(w http.ResponseWriter, r *http.Request, rp azurearm.Reso
 	h.lifecycleAction(w, r, rp, h.compute.StartInstances)
 }
 
-// powerOff handles POST virtualMachines/{name}/powerOff (also serves deallocate).
+// powerOff handles POST virtualMachines/{name}/powerOff. It stops the guest OS
+// while keeping the VM allocated (PowerState/stopped).
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) powerOff(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	h.lifecycleAction(w, r, rp, h.compute.StopInstances)
+	h.powerAction(w, r, rp, func(ctrl computedriver.AzureVMController, id string) error {
+		return ctrl.PowerOff(r.Context(), id)
+	})
+}
+
+// deallocate handles POST virtualMachines/{name}/deallocate. It stops the guest
+// and releases the allocated compute (PowerState/deallocated).
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deallocate(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	h.powerAction(w, r, rp, func(ctrl computedriver.AzureVMController, id string) error {
+		return ctrl.Deallocate(r.Context(), id)
+	})
+}
+
+// powerAction is the shared body for powerOff/deallocate. It invokes the Azure
+// power controller when the driver supports it (preserving the PowerOff vs
+// Deallocate distinction) and otherwise falls back to the generic StopInstances.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) powerAction(
+	w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	op func(ctrl computedriver.AzureVMController, id string) error,
+) {
+	inst, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if ctrl, ok := h.compute.(computedriver.AzureVMController); ok {
+		err = op(ctrl, inst.ID)
+	} else {
+		err = h.compute.StopInstances(r.Context(), []string{inst.ID})
+	}
+
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, rp.SubResource+"-"+rp.ResourceName)
 }
 
 // restart handles POST virtualMachines/{name}/restart.
@@ -172,7 +269,7 @@ func (h *Handler) restart(w http.ResponseWriter, r *http.Request, rp azurearm.Re
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) retrieveBootDiagnosticsData(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	if _, err := findByName(r.Context(), h.compute, rp.ResourceName); err != nil {
+	if _, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
@@ -189,7 +286,7 @@ func (h *Handler) retrieveBootDiagnosticsData(w http.ResponseWriter, r *http.Req
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) serialConsoleLog(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	inst, err := findByName(r.Context(), h.compute, rp.ResourceName)
+	inst, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -231,7 +328,7 @@ func (h *Handler) lifecycleAction(
 	w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
 	op func(ctx context.Context, ids []string) error,
 ) {
-	inst, err := findByName(r.Context(), h.compute, rp.ResourceName)
+	inst, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -261,18 +358,25 @@ func writeAcceptedAsync(w http.ResponseWriter, r *http.Request, subscription, op
 	w.WriteHeader(http.StatusAccepted)
 }
 
-// findByName looks up a VM by its ARM resource name. Returns NotFound when
-// no instance with that tag exists.
-func findByName(ctx context.Context, c computedriver.Compute, name string) (*computedriver.Instance, error) {
+// findByName looks up a VM by its ARM resource name within a resource group.
+// An empty resourceGroup matches across all groups (subscription-scoped lookup).
+// Returns NotFound when no matching instance exists.
+func findByName(ctx context.Context, c computedriver.Compute, resourceGroup, name string) (*computedriver.Instance, error) {
 	instances, err := c.DescribeInstances(ctx, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	for i := range instances {
-		if tagOr(instances[i].Tags, armNameTag, "") == name {
-			return &instances[i], nil
+		if tagOr(instances[i].Tags, armNameTag, "") != name {
+			continue
 		}
+
+		if resourceGroup != "" && instances[i].ResourceGroup != resourceGroup {
+			continue
+		}
+
+		return &instances[i], nil
 	}
 
 	return nil, cerrors.Newf(cerrors.NotFound, "virtualMachine %s not found", name)
@@ -361,6 +465,11 @@ func mergeTags(in map[string]string, armName string) map[string]string {
 	return out
 }
 
+// tagOr returns the tag value for key, or fallback when absent. The key
+// parameter is kept for signature parity with the sibling azure compute
+// handlers even though this package only reads the ARM-name tag.
+//
+//nolint:unparam // uniform tag-helper signature across azure compute handlers
 func tagOr(m map[string]string, key, fallback string) string {
 	if v, ok := m[key]; ok {
 		return v
@@ -395,7 +504,7 @@ func toVMResponse(inst *computedriver.Instance, rp azurearm.ResourcePath, req vm
 			InstanceView: &instanceView{
 				Statuses: []instanceViewStatus{
 					{Code: "ProvisioningState/succeeded", Level: "Info", DisplayStatus: "Provisioning succeeded"},
-					{Code: "PowerState/" + powerStateFor(inst.State), Level: "Info", DisplayStatus: displayFor(inst.State)},
+					{Code: "PowerState/" + powerCode(inst), Level: "Info", DisplayStatus: powerDisplay(inst)},
 				},
 			},
 		},
@@ -443,6 +552,21 @@ func stripInternalTags(in map[string]string) map[string]string {
 	return out
 }
 
+// powerCode returns the ARM PowerState code suffix for an instance. It prefers
+// the explicit Azure power state (which distinguishes stopped from deallocated)
+// and falls back to a lifecycle-state mapping when unset.
+func powerCode(inst *computedriver.Instance) string {
+	if inst.PowerState != "" {
+		return inst.PowerState
+	}
+
+	return powerStateFor(inst.State)
+}
+
+func powerDisplay(inst *computedriver.Instance) string {
+	return "VM " + powerCode(inst)
+}
+
 func powerStateFor(state string) string {
 	switch state {
 	case stateRunning:
@@ -460,19 +584,30 @@ func powerStateFor(state string) string {
 	}
 }
 
-func displayFor(state string) string {
-	switch state {
-	case stateRunning:
-		return "VM running"
-	case statePending:
-		return "VM starting"
-	case stateStopped:
-		return "VM deallocated"
-	case stateStopping:
-		return "VM deallocating"
-	case stateTerminated:
-		return "VM deleted"
+// toInstanceView builds the VirtualMachineInstanceView response for an instance.
+func toInstanceView(inst *computedriver.Instance) instanceViewResponse {
+	return instanceViewResponse{
+		ComputerName:     tagOr(inst.Tags, armNameTag, ""),
+		OSName:           osNameFor(inst.OSType),
+		VMAgent:          &vmAgentInstanceView{VMAgentVersion: "2.0.0.0"},
+		Disks:            []diskInstanceView{{Name: "osdisk"}},
+		HyperVGeneration: "V1",
+		Statuses: []instanceViewStatus{
+			{Code: "ProvisioningState/succeeded", Level: "Info", DisplayStatus: "Provisioning succeeded"},
+			{Code: "PowerState/" + powerCode(inst), Level: "Info", DisplayStatus: powerDisplay(inst)},
+		},
+	}
+}
+
+// osNameFor renders a plausible OS name from the guest OS family, for the
+// instanceView's osName field. Empty OS type yields an empty name.
+func osNameFor(osType string) string {
+	switch strings.ToLower(osType) {
+	case "windows":
+		return "Windows"
+	case "linux":
+		return "Linux"
 	default:
-		return "VM " + state
+		return osType
 	}
 }

--- a/server/azure/virtualmachines/lifecycle_e2e_test.go
+++ b/server/azure/virtualmachines/lifecycle_e2e_test.go
@@ -1,0 +1,234 @@
+package virtualmachines_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// getVM issues a GET on a VM and returns the decoded body.
+func getVM(t *testing.T, ts *httptest.Server, name string) map[string]any {
+	t.Helper()
+
+	resp, err := ts.Client().Get(ts.URL + armBasePath(name) + apiVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET %s: status %d body=%s", name, resp.StatusCode, dump)
+	}
+
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+
+	return out
+}
+
+// postAction issues a POST lifecycle action and returns the status code.
+func postAction(t *testing.T, ts *httptest.Server, name, action string) int {
+	t.Helper()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+armBasePath(name)+"/"+action+apiVersion, http.NoBody)
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode
+}
+
+// powerStateCode returns the PowerState code from a VM body's instanceView.
+func powerStateCode(t *testing.T, body map[string]any) string {
+	t.Helper()
+
+	props, _ := body["properties"].(map[string]any)
+	iv, _ := props["instanceView"].(map[string]any)
+
+	statuses, _ := iv["statuses"].([]any)
+	for _, s := range statuses {
+		st, _ := s.(map[string]any)
+		code, _ := st["code"].(string)
+
+		if len(code) > len("PowerState/") && code[:len("PowerState/")] == "PowerState/" {
+			return code[len("PowerState/"):]
+		}
+	}
+
+	return ""
+}
+
+// TestVMCreateOrUpdateIdempotent verifies a second PUT to the same {rg,name}
+// updates the VM in place rather than creating a duplicate: List returns one,
+// and the vmId is preserved across the update.
+func TestVMCreateOrUpdateIdempotent(t *testing.T) {
+	ts := newAzureTestServer(t)
+
+	first := putVM(t, ts, "vm-idem")
+	second := putVM(t, ts, "vm-idem")
+
+	firstProps, _ := first["properties"].(map[string]any)
+	secondProps, _ := second["properties"].(map[string]any)
+
+	if firstProps["vmId"] != secondProps["vmId"] {
+		t.Errorf("vmId changed across idempotent PUT: %v -> %v", firstProps["vmId"], secondProps["vmId"])
+	}
+
+	listURL := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines"
+
+	resp, err := ts.Client().Get(ts.URL + listURL + apiVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var got struct {
+		Value []map[string]any `json:"value"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got.Value) != 1 {
+		t.Fatalf("List returned %d VMs after repeated PUT, want 1", len(got.Value))
+	}
+}
+
+// TestVMListResourceGroupScope verifies ListByResourceGroup does not leak VMs
+// belonging to other resource groups.
+func TestVMListResourceGroupScope(t *testing.T) {
+	ts := newAzureTestServer(t)
+
+	_ = putVM(t, ts, "vm-a")
+
+	// Create a VM in a different resource group.
+	body := `{"location":"eastus","properties":{"hardwareProfile":{"vmSize":"Standard_D2s_v3"}}}`
+
+	req, _ := http.NewRequest(http.MethodPut,
+		ts.URL+"/subscriptions/sub-1/resourceGroups/rg-2/providers/Microsoft.Compute/virtualMachines/vm-b"+apiVersion,
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	listURL := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines"
+
+	lresp, err := ts.Client().Get(ts.URL + listURL + apiVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lresp.Body.Close()
+
+	var got struct {
+		Value []map[string]any `json:"value"`
+	}
+
+	if err := json.NewDecoder(lresp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got.Value) != 1 {
+		t.Fatalf("rg-1 list returned %d VMs, want 1 (rg-2 leaked)", len(got.Value))
+	}
+
+	if got.Value[0]["name"] != "vm-a" {
+		t.Errorf("rg-1 list returned %v, want vm-a", got.Value[0]["name"])
+	}
+}
+
+// TestVMInstanceView verifies GET .../{name}/instanceView returns a
+// VirtualMachineInstanceView with power, provisioning, agent, and disk status.
+func TestVMInstanceView(t *testing.T) {
+	ts := newAzureTestServer(t)
+	_ = putVM(t, ts, "vm-iv")
+
+	resp, err := ts.Client().Get(ts.URL + armBasePath("vm-iv") + "/instanceView" + apiVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("instanceView status=%d body=%s", resp.StatusCode, dump)
+	}
+
+	var iv map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&iv); err != nil {
+		t.Fatal(err)
+	}
+
+	if iv["vmAgent"] == nil {
+		t.Error("instanceView missing vmAgent")
+	}
+
+	if iv["disks"] == nil {
+		t.Error("instanceView missing disks")
+	}
+
+	statuses, _ := iv["statuses"].([]any)
+	if len(statuses) < 2 {
+		t.Fatalf("instanceView statuses=%d want >=2", len(statuses))
+	}
+
+	var sawPower, sawProvisioning bool
+
+	for _, s := range statuses {
+		st, _ := s.(map[string]any)
+		code, _ := st["code"].(string)
+
+		if code == "PowerState/running" {
+			sawPower = true
+		}
+
+		if code == "ProvisioningState/succeeded" {
+			sawProvisioning = true
+		}
+	}
+
+	if !sawPower {
+		t.Error("instanceView missing PowerState/running")
+	}
+
+	if !sawProvisioning {
+		t.Error("instanceView missing ProvisioningState/succeeded")
+	}
+}
+
+// TestVMPowerOffVsDeallocate verifies PowerOff reports PowerState/stopped (the
+// VM stays allocated) while Deallocate reports PowerState/deallocated.
+func TestVMPowerOffVsDeallocate(t *testing.T) {
+	ts := newAzureTestServer(t)
+
+	_ = putVM(t, ts, "vm-off")
+	if code := postAction(t, ts, "vm-off", "powerOff"); code != http.StatusAccepted {
+		t.Fatalf("powerOff status=%d want 202", code)
+	}
+
+	if got := powerStateCode(t, getVM(t, ts, "vm-off")); got != "stopped" {
+		t.Errorf("after powerOff powerState=%q want stopped", got)
+	}
+
+	_ = putVM(t, ts, "vm-dealloc")
+	if code := postAction(t, ts, "vm-dealloc", "deallocate"); code != http.StatusAccepted {
+		t.Fatalf("deallocate status=%d want 202", code)
+	}
+
+	if got := powerStateCode(t, getVM(t, ts, "vm-dealloc")); got != "deallocated" {
+		t.Errorf("after deallocate powerState=%q want deallocated", got)
+	}
+}

--- a/server/azure/virtualmachines/types.go
+++ b/server/azure/virtualmachines/types.go
@@ -110,6 +110,27 @@ type instanceViewStatus struct {
 	DisplayStatus string `json:"displayStatus"`
 }
 
+// instanceViewResponse is the ARM VirtualMachineInstanceView returned by
+// GET virtualMachines/{name}/instanceView.
+type instanceViewResponse struct {
+	ComputerName     string               `json:"computerName,omitempty"`
+	OSName           string               `json:"osName,omitempty"`
+	HyperVGeneration string               `json:"hyperVGeneration,omitempty"`
+	VMAgent          *vmAgentInstanceView `json:"vmAgent,omitempty"`
+	Disks            []diskInstanceView   `json:"disks,omitempty"`
+	Statuses         []instanceViewStatus `json:"statuses"`
+}
+
+type vmAgentInstanceView struct {
+	VMAgentVersion string               `json:"vmAgentVersion,omitempty"`
+	Statuses       []instanceViewStatus `json:"statuses,omitempty"`
+}
+
+type diskInstanceView struct {
+	Name     string               `json:"name,omitempty"`
+	Statuses []instanceViewStatus `json:"statuses,omitempty"`
+}
+
 // vmListResponse is the outbound shape for a list operation.
 type vmListResponse struct {
 	Value []vmResponse `json:"value"`

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -74,6 +74,11 @@ type Instance struct {
 	// Monitoring is the CloudWatch detailed-monitoring state
 	// ("disabled"/"enabled"), when known (AWS). Empty renders as "disabled".
 	Monitoring string
+	// PowerState is the Azure power state ("running"/"stopped"/"deallocated"/
+	// "starting"/"stopping"/"deallocating"), when known. It distinguishes a
+	// PowerOff'd VM (stopped, still allocated) from a Deallocated one, a
+	// distinction the lifecycle State field cannot carry. Empty for AWS/GCP.
+	PowerState string
 	// Operator carries service-provider managed-resource metadata. It is nil
 	// for ordinary (unmanaged) instances.
 	Operator *OperatorInfo
@@ -462,6 +467,34 @@ type Compute interface {
 	CreateKeyPair(ctx context.Context, config KeyPairConfig) (*KeyPairInfo, error)
 	DeleteKeyPair(ctx context.Context, name string) error
 	DescribeKeyPairs(ctx context.Context, names []string) ([]KeyPairInfo, error)
+}
+
+// AzureVMController is an optional Azure-only capability supporting the ARM
+// virtualMachines operations that have no AWS/GCP equivalent: the PowerOff vs
+// Deallocate distinction (PowerOff stops the guest but keeps the VM allocated;
+// Deallocate releases the compute) and the idempotent CreateOrUpdate PUT
+// (updating an existing VM's mutable config in place rather than provisioning a
+// duplicate). Only the Azure VM mock implements it; the wire handler type-
+// asserts for it, so AWS/GCP are unaffected.
+type AzureVMController interface {
+	// PowerOff stops the guest OS while keeping the VM allocated
+	// (PowerState/stopped).
+	PowerOff(ctx context.Context, instanceID string) error
+	// Deallocate stops the guest and releases the allocated compute
+	// (PowerState/deallocated).
+	Deallocate(ctx context.Context, instanceID string) error
+	// UpdateInstance overwrites the mutable configuration of an existing
+	// instance in place (preserving its ID and launch time), for idempotent
+	// ARM CreateOrUpdate.
+	UpdateInstance(ctx context.Context, instanceID string, cfg InstanceConfig) error
+}
+
+// KeyPairGenerator is an optional Azure-only capability for the ARM
+// sshPublicKeys generateKeyPair action, which generates a fresh RSA key pair
+// server-side, stores the public key on the resource, and returns both the
+// public and (one-time) private key. Only the Azure mock implements it.
+type KeyPairGenerator interface {
+	GenerateKeyPair(ctx context.Context, name string) (*KeyPairInfo, error)
 }
 
 // ConsoleReader is an optional capability a Compute implementation may provide


### PR DESCRIPTION
## Summary

End-to-end audit fixes for the Azure compute wire surface (virtualMachines, disks, snapshots, images, sshPublicKeys), matching real Azure ARM behavior. Every fix is at the correct layer: Azure-only operations use type-asserted optional driver capabilities (AzureVMController, KeyPairGenerator) rather than new methods on the shared Compute interface, and RG/source metadata is round-tripped through internal tags at the wire layer.

## Fixes (mapped to findings)

- **[BLOCKER] Idempotent CreateOrUpdate** — a repeated PUT to the same `{resourceGroup,name}` now updates the resource in place instead of creating a duplicate, for virtualMachines (new `AzureVMController.UpdateInstance`, preserving `vmId`), disks, snapshots, images, and sshPublicKeys. List returns one.
- **[HIGH] virtualMachines instanceView** — `GET .../{name}/instanceView` returns a `VirtualMachineInstanceView` (provisioning + power state statuses, `vmAgent`, `disks`) instead of 501.
- **[HIGH] PowerOff vs Deallocate** — `powerOff` reports `PowerState/stopped` (VM stays allocated); `deallocate` reports `PowerState/deallocated`. Backed by a new Azure power-state field and the `AzureVMController` capability; falls back to `StopInstances` when unsupported.
- **[HIGH] disks createOption** — `creationData.createOption` is honored; a `Copy` disk with no explicit `diskSizeGB` inherits the source snapshot/disk size; the response echoes the submitted `createOption`/`sourceResourceId` instead of hardcoding `Empty`.
- **[HIGH] sshPublicKeys generateKeyPair** — returns a real generated 2048-bit RSA private key (PEM) and public key (OpenSSH) and persists the public key onto the resource (new `KeyPairGenerator` capability).
- **[MEDIUM] List RG/subscription scope** — `ListByResourceGroup` filters by the path resource group and no longer leaks other RGs, across all five resource types.
- **[MEDIUM] snapshots sourceResourceId** — preserves the exact submitted `sourceResourceId`/`createOption` rather than echoing the driver-internal disk path.
- **[MEDIUM] images Get** — cold `GET` returns `storageProfile.osDisk` (osType/osState/diskSizeGB/storageAccountType) and `sourceVirtualMachine.id`.
- **[LOW] disks Get** — populates `properties.timeCreated` and a stable `properties.uniqueId`.

## Tests

Real-user wire tests (httptest over the Azure ARM handlers) assert exact JSON shapes for idempotency, instanceView, PowerOff/Deallocate power state, disk createOption + copy-size inheritance + metadata, snapshot source preservation, image storageProfile, RG scoping, and the generated SSH private key. Provider-level unit tests cover PowerOff/Deallocate/UpdateInstance and key-pair generation.

Coverage docs regenerated (`go run ./internal/coveragegen`).

Gates: `go build ./...`, `go test ./providers/azure/... ./server/azure/... ./services/...`, and `golangci-lint` on the changed packages all green (only a pre-existing unrelated lint in `scaleset.go`, an untouched file).
