### PR TITLE
fix(azure-cosmos): account listKeys/regenerate/connstrings/documentEndpoint + cosmosdb custom partition key, offers, conflict, db isolation

### DIFF
--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -70,6 +71,8 @@ type Mock struct {
 var _ driver.TableAttributes = (*Mock)(nil)
 
 // SetTableAttributes seeds the Cosmos-account cost attributes for a table.
+//
+//nolint:gocritic // hugeParam: attrs mirrors the optional-capability signature.
 func (m *Mock) SetTableAttributes(table string, attrs driver.AccountAttributes) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -79,6 +82,25 @@ func (m *Mock) SetTableAttributes(table string, attrs driver.AccountAttributes) 
 	}
 
 	m.accountAttrs[table] = attrs
+}
+
+// AccountTables returns the names of tables that have been registered as Cosmos
+// DB accounts (i.e. had account attributes seeded through SetTableAttributes),
+// sorted for a deterministic listing. Data-plane containers, which never carry
+// account attributes, are excluded — so an ARM account list returns only real
+// accounts, not the SQL containers sharing this driver.
+func (m *Mock) AccountTables() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	names := make([]string, 0, len(m.accountAttrs))
+	for name := range m.accountAttrs {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
 }
 
 // TableAttributes implements the database TableAttributes optional capability,

--- a/server/azure/cosmosaccount/handler.go
+++ b/server/azure/cosmosaccount/handler.go
@@ -6,15 +6,20 @@
 //
 // This is the management-plane counterpart to the cosmos SQL data-plane
 // handler: an account name maps to a driver table, and the account's kind /
-// offer-type / free-tier / capabilities cost attributes are stored via the
+// offer-type / free-tier / capabilities / location / tags are stored via the
 // driver's optional TableAttributes capability so a discovery + cost consumer
 // can price it.
 //
 // Coverage:
 //
-//	PUT    .../providers/Microsoft.DocumentDB/databaseAccounts/{name} — create/update
-//	GET    .../providers/Microsoft.DocumentDB/databaseAccounts/{name} — get
-//	DELETE .../providers/Microsoft.DocumentDB/databaseAccounts/{name} — delete
+//	PUT    .../databaseAccounts/{name}                        — create/update
+//	GET    .../databaseAccounts/{name}                        — get
+//	DELETE .../databaseAccounts/{name}                        — delete
+//	GET    .../databaseAccounts                               — list (byRG/subscription)
+//	POST   .../databaseAccounts/{name}/listKeys              — read-write + read-only keys
+//	POST   .../databaseAccounts/{name}/readonlykeys         — read-only keys
+//	POST   .../databaseAccounts/{name}/listConnectionStrings — connection strings
+//	POST   .../databaseAccounts/{name}/regenerateKey        — rotate a key
 //
 // Create is a long-running operation in real Azure; the emulator completes it
 // synchronously by returning 200 with the resource body inline so the SDK's LRO
@@ -42,6 +47,10 @@ const (
 type attrBackend interface {
 	SetTableAttributes(table string, attrs dbdriver.AccountAttributes)
 	TableAttributes(ctx context.Context, table string) (dbdriver.AccountAttributes, error)
+	// AccountTables lists the tables registered as Cosmos accounts, so List
+	// returns only accounts and never the data-plane SQL containers that share
+	// this driver.
+	AccountTables() []string
 }
 
 // Handler serves Microsoft.DocumentDB/databaseAccounts ARM requests against a
@@ -83,8 +92,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Collection path (no account name): List / ListByResourceGroup.
 	if rp.ResourceName == "" {
-		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "database account name required")
+		h.list(w, r, &rp)
+		return
+	}
+
+	// POST action sub-resources: listKeys, listConnectionStrings, regenerateKey…
+	if rp.SubResource != "" {
+		h.serveAction(w, r, &rp)
 		return
 	}
 
@@ -97,6 +113,39 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.deleteAccount(w, r, &rp)
 	default:
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+// serveAction dispatches the POST action sub-resources hung off an account.
+func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	if _, err := h.db.DescribeTable(r.Context(), rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	switch strings.ToLower(rp.SubResource) {
+	case "listkeys":
+		azurearm.WriteJSON(w, http.StatusOK, listKeysResult(rp.ResourceName))
+	case "readonlykeys":
+		azurearm.WriteJSON(w, http.StatusOK, readOnlyKeysResult(rp.ResourceName))
+	case "listconnectionstrings":
+		azurearm.WriteJSON(w, http.StatusOK, connectionStringsResult(rp.ResourceName))
+	case "regeneratekey":
+		var body armRegenerateKey
+		if !azurearm.DecodeJSON(w, r, &body) {
+			return
+		}
+		// Regeneration is a long-running op in real Azure; complete it
+		// synchronously with an empty 200 so the SDK's poller terminates. Keys
+		// are deterministic per account, so there is nothing to persist.
+		w.WriteHeader(http.StatusOK)
+	default:
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unsupported action: "+rp.SubResource)
 	}
 }
 
@@ -116,7 +165,17 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 		return
 	}
 
-	attrs := dbdriver.AccountAttributes{Kind: body.Kind}
+	location := body.Location
+	if location == "" {
+		location = accountRegion(body.Properties)
+	}
+
+	attrs := dbdriver.AccountAttributes{
+		Kind:          body.Kind,
+		Location:      location,
+		ResourceGroup: rp.ResourceGroup,
+		Tags:          body.Tags,
+	}
 	if body.Properties != nil {
 		attrs.OfferType = body.Properties.DatabaseAccountOfferType
 		attrs.EnableFreeTier = body.Properties.EnableFreeTier
@@ -127,7 +186,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 		h.attrs.SetTableAttributes(name, attrs)
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), rp, body.Location, body.Tags))
+	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), rp))
 }
 
 func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
@@ -136,7 +195,39 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp *azurearm.Resou
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), rp, defaultLocation, nil))
+	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), rp))
+}
+
+// list serves the collection paths: GET .../databaseAccounts (subscription) and
+// GET .../resourceGroups/{rg}/.../databaseAccounts (resource group).
+func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	out := armAccountList{Value: []armAccount{}}
+
+	if h.attrs == nil {
+		azurearm.WriteJSON(w, http.StatusOK, out)
+		return
+	}
+
+	for _, name := range h.attrs.AccountTables() {
+		attrs, err := h.attrs.TableAttributes(r.Context(), name)
+		if err != nil {
+			continue
+		}
+
+		// ListByResourceGroup filters to the requested group.
+		if rp.ResourceGroup != "" && !strings.EqualFold(attrs.ResourceGroup, rp.ResourceGroup) {
+			continue
+		}
+
+		out.Value = append(out.Value, renderAccount(rp.Subscription, name, attrs))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
 }
 
 func (h *Handler) deleteAccount(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
@@ -149,11 +240,9 @@ func (h *Handler) deleteAccount(w http.ResponseWriter, r *http.Request, rp *azur
 }
 
 // toARMAccount renders the ARM databaseAccounts wire shape, reading the stored
-// cost attributes (kind / offer type / free tier / capabilities) back through
-// the driver.
-func (h *Handler) toARMAccount(
-	ctx context.Context, rp *azurearm.ResourcePath, location string, tags map[string]string,
-) armAccount {
+// attributes (kind / offer type / free tier / capabilities / location / tags)
+// back through the driver.
+func (h *Handler) toARMAccount(ctx context.Context, rp *azurearm.ResourcePath) armAccount {
 	attrs := dbdriver.AccountAttributes{Kind: "GlobalDocumentDB", OfferType: "Standard"}
 	if h.attrs != nil {
 		if a, err := h.attrs.TableAttributes(ctx, rp.ResourceName); err == nil {
@@ -161,23 +250,99 @@ func (h *Handler) toARMAccount(
 		}
 	}
 
+	// The resource group comes from the request path (a create/get always
+	// carries it); the stored copy is used only for byRG list filtering.
+	if attrs.ResourceGroup == "" {
+		attrs.ResourceGroup = rp.ResourceGroup
+	}
+
+	return renderAccount(rp.Subscription, rp.ResourceName, attrs)
+}
+
+// renderAccount builds the ARM account body from stored attributes. Used by
+// get/create (path-derived subscription) and by list.
+//
+//nolint:gocritic // attrs mirrors the driver value type.
+func renderAccount(subscription, name string, attrs dbdriver.AccountAttributes) armAccount {
+	location := attrs.Location
 	if location == "" {
 		location = defaultLocation
 	}
 
 	return armAccount{
-		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, rp.ResourceName),
-		Name:     rp.ResourceName,
+		ID:       azurearm.BuildResourceID(subscription, attrs.ResourceGroup, providerName, resourceType, name),
+		Name:     name,
 		Type:     providerName + "/" + resourceType,
 		Location: location,
-		Kind:     attrs.Kind,
-		Tags:     tags,
+		Kind:     kindOrDefault(attrs.Kind),
+		Tags:     attrs.Tags,
 		Properties: &armAccountProps{
-			DatabaseAccountOfferType: attrs.OfferType,
+			DatabaseAccountOfferType: offerOrDefault(attrs.OfferType),
 			EnableFreeTier:           attrs.EnableFreeTier,
 			Capabilities:             toCapabilities(attrs.Capabilities),
 			ProvisioningState:        "Succeeded",
+			DocumentEndpoint:         documentEndpoint(name),
+			Locations:                []armLocation{regionEntry(name, location)},
+			ReadLocations:            []armLocation{regionEntry(name, location)},
+			WriteLocations:           []armLocation{regionEntry(name, location)},
+			FailoverPolicies:         []armFailover{failoverEntry(name, location)},
 		},
+	}
+}
+
+func kindOrDefault(kind string) string {
+	if kind == "" {
+		return "GlobalDocumentDB"
+	}
+
+	return kind
+}
+
+func offerOrDefault(offer string) string {
+	if offer == "" {
+		return "Standard"
+	}
+
+	return offer
+}
+
+// accountRegion returns the first declared location's name, if any.
+func accountRegion(props *armAccountCreateProps) string {
+	if props == nil {
+		return ""
+	}
+
+	for _, l := range props.Locations {
+		if l.LocationName != "" {
+			return l.LocationName
+		}
+	}
+
+	return ""
+}
+
+// documentEndpoint is the account's global connection endpoint.
+func documentEndpoint(name string) string {
+	return "https://" + name + ".documents.azure.com:443/"
+}
+
+// regionEntry builds a single-region Location record for the account's
+// read/write/location arrays.
+func regionEntry(name, location string) armLocation {
+	return armLocation{
+		ID:                name + "-" + location,
+		LocationName:      location,
+		DocumentEndpoint:  "https://" + name + "-" + location + ".documents.azure.com:443/",
+		ProvisioningState: "Succeeded",
+		FailoverPriority:  0,
+	}
+}
+
+func failoverEntry(name, location string) armFailover {
+	return armFailover{
+		ID:               name + "-" + location,
+		LocationName:     location,
+		FailoverPriority: 0,
 	}
 }
 

--- a/server/azure/cosmosaccount/keys.go
+++ b/server/azure/cosmosaccount/keys.go
@@ -1,0 +1,64 @@
+package cosmosaccount
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+// Key roles used to derive the four deterministic master keys an account
+// exposes. Real Cosmos keys are opaque base64 blobs; the emulator derives them
+// from the account name so ListKeys is stable across calls and every key is
+// distinct.
+const (
+	rolePrimary           = "primary"
+	roleSecondary         = "secondary"
+	rolePrimaryReadonly   = "primary-readonly"
+	roleSecondaryReadonly = "secondary-readonly"
+)
+
+// accountKey derives a stable, base64 pseudo-key for one role of an account.
+func accountKey(name, role string) string {
+	sum := sha256.Sum256([]byte(name + ":" + role))
+
+	return base64.StdEncoding.EncodeToString(sum[:])
+}
+
+// listKeysResult builds the DatabaseAccountListKeysResult (all four keys).
+func listKeysResult(name string) armListKeysResult {
+	return armListKeysResult{
+		PrimaryMasterKey:           accountKey(name, rolePrimary),
+		SecondaryMasterKey:         accountKey(name, roleSecondary),
+		PrimaryReadonlyMasterKey:   accountKey(name, rolePrimaryReadonly),
+		SecondaryReadonlyMasterKey: accountKey(name, roleSecondaryReadonly),
+	}
+}
+
+// readOnlyKeysResult builds the DatabaseAccountListReadOnlyKeysResult.
+func readOnlyKeysResult(name string) armReadOnlyKeysResult {
+	return armReadOnlyKeysResult{
+		PrimaryReadonlyMasterKey:   accountKey(name, rolePrimaryReadonly),
+		SecondaryReadonlyMasterKey: accountKey(name, roleSecondaryReadonly),
+	}
+}
+
+// connectionStringsResult builds the four SQL-API connection strings, one per
+// key kind, matching the DatabaseAccountListConnectionStringsResult shape.
+func connectionStringsResult(name string) armConnectionStringsResult {
+	entry := func(desc, key, kind string) armConnectionString {
+		return armConnectionString{
+			ConnectionString: "AccountEndpoint=" + documentEndpoint(name) + ";AccountKey=" + key + ";",
+			Description:      desc,
+			KeyKind:          kind,
+			Type:             "Sql",
+		}
+	}
+
+	return armConnectionStringsResult{
+		ConnectionStrings: []armConnectionString{
+			entry("Primary SQL Connection String", accountKey(name, rolePrimary), "Primary"),
+			entry("Secondary SQL Connection String", accountKey(name, roleSecondary), "Secondary"),
+			entry("Primary Read-Only SQL Connection String", accountKey(name, rolePrimaryReadonly), "PrimaryReadonly"),
+			entry("Secondary Read-Only SQL Connection String", accountKey(name, roleSecondaryReadonly), "SecondaryReadonly"),
+		},
+	}
+}

--- a/server/azure/cosmosaccount/sdk_test.go
+++ b/server/azure/cosmosaccount/sdk_test.go
@@ -124,3 +124,153 @@ func TestSDKDatabaseAccountGetMissing(t *testing.T) {
 	_, err := client.Get(ctx, "rg-1", "nope", nil)
 	require.Error(t, err)
 }
+
+// createAccount is a helper that provisions an account and returns its client.
+func createAccount(t *testing.T, client *armcosmos.DatabaseAccountsClient, rg, name, region string) {
+	t.Helper()
+
+	poller, err := client.BeginCreateOrUpdate(context.Background(), rg, name, armcosmos.DatabaseAccountCreateUpdateParameters{
+		Location: to.Ptr(region),
+		Kind:     to.Ptr(armcosmos.DatabaseAccountKindGlobalDocumentDB),
+		Properties: &armcosmos.DatabaseAccountCreateUpdateProperties{
+			DatabaseAccountOfferType: to.Ptr("Standard"),
+			Locations: []*armcosmos.Location{
+				{LocationName: to.Ptr(region), FailoverPriority: to.Ptr[int32](0)},
+			},
+		},
+		Tags: map[string]*string{"team": to.Ptr("data")},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(context.Background(), nil)
+	require.NoError(t, err)
+}
+
+// TestSDKDatabaseAccountGetEndpointAndTags asserts the Get response carries the
+// creation region, tags, the global documentEndpoint, and the read/write/
+// location arrays a real account exposes.
+func TestSDKDatabaseAccountGetEndpointAndTags(t *testing.T) {
+	ctx := context.Background()
+	client := newDatabaseAccountsClient(t)
+	createAccount(t, client, "rg-1", "cosmos-ep", "westeurope")
+
+	got, err := client.Get(ctx, "rg-1", "cosmos-ep", nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, got.Location)
+	assert.Equal(t, "westeurope", *got.Location)
+
+	require.NotNil(t, got.Tags["team"])
+	assert.Equal(t, "data", *got.Tags["team"])
+
+	require.NotNil(t, got.Properties)
+	require.NotNil(t, got.Properties.DocumentEndpoint)
+	assert.Equal(t, "https://cosmos-ep.documents.azure.com:443/", *got.Properties.DocumentEndpoint)
+
+	require.Len(t, got.Properties.WriteLocations, 1)
+	require.NotNil(t, got.Properties.WriteLocations[0].LocationName)
+	assert.Equal(t, "westeurope", *got.Properties.WriteLocations[0].LocationName)
+
+	require.Len(t, got.Properties.ReadLocations, 1)
+	require.Len(t, got.Properties.Locations, 1)
+	require.Len(t, got.Properties.FailoverPolicies, 1)
+}
+
+// TestSDKDatabaseAccountListKeys drives ListKeys and the read-only keys.
+func TestSDKDatabaseAccountListKeys(t *testing.T) {
+	ctx := context.Background()
+	client := newDatabaseAccountsClient(t)
+	createAccount(t, client, "rg-1", "cosmos-keys", "eastus")
+
+	keys, err := client.ListKeys(ctx, "rg-1", "cosmos-keys", nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, keys.PrimaryMasterKey)
+	require.NotNil(t, keys.SecondaryMasterKey)
+	require.NotNil(t, keys.PrimaryReadonlyMasterKey)
+	require.NotNil(t, keys.SecondaryReadonlyMasterKey)
+
+	assert.NotEmpty(t, *keys.PrimaryMasterKey)
+	assert.NotEqual(t, *keys.PrimaryMasterKey, *keys.SecondaryMasterKey)
+	assert.NotEqual(t, *keys.PrimaryMasterKey, *keys.PrimaryReadonlyMasterKey)
+
+	ro, err := client.ListReadOnlyKeys(ctx, "rg-1", "cosmos-keys", nil)
+	require.NoError(t, err)
+	require.NotNil(t, ro.PrimaryReadonlyMasterKey)
+	assert.Equal(t, *keys.PrimaryReadonlyMasterKey, *ro.PrimaryReadonlyMasterKey)
+}
+
+// TestSDKDatabaseAccountListConnectionStrings drives ListConnectionStrings.
+func TestSDKDatabaseAccountListConnectionStrings(t *testing.T) {
+	ctx := context.Background()
+	client := newDatabaseAccountsClient(t)
+	createAccount(t, client, "rg-1", "cosmos-conn", "eastus")
+
+	res, err := client.ListConnectionStrings(ctx, "rg-1", "cosmos-conn", nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, res.ConnectionStrings)
+	first := res.ConnectionStrings[0]
+	require.NotNil(t, first.ConnectionString)
+	assert.Contains(t, *first.ConnectionString, "AccountEndpoint=https://cosmos-conn.documents.azure.com:443/")
+	require.NotNil(t, first.KeyKind)
+	assert.Equal(t, armcosmos.KindPrimary, *first.KeyKind)
+	require.NotNil(t, first.Type)
+	assert.Equal(t, armcosmos.TypeSQL, *first.Type)
+}
+
+// TestSDKDatabaseAccountRegenerateKey drives the BeginRegenerateKey LRO.
+func TestSDKDatabaseAccountRegenerateKey(t *testing.T) {
+	ctx := context.Background()
+	client := newDatabaseAccountsClient(t)
+	createAccount(t, client, "rg-1", "cosmos-regen", "eastus")
+
+	poller, err := client.BeginRegenerateKey(ctx, "rg-1", "cosmos-regen", armcosmos.DatabaseAccountRegenerateKeyParameters{
+		KeyKind: to.Ptr(armcosmos.KeyKindPrimary),
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+}
+
+// TestSDKDatabaseAccountList drives List (subscription) and ListByResourceGroup.
+func TestSDKDatabaseAccountList(t *testing.T) {
+	ctx := context.Background()
+	client := newDatabaseAccountsClient(t)
+
+	createAccount(t, client, "rg-a", "acct-a1", "eastus")
+	createAccount(t, client, "rg-a", "acct-a2", "eastus")
+	createAccount(t, client, "rg-b", "acct-b1", "westus")
+
+	names := map[string]bool{}
+	pager := client.NewListPager(nil)
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		require.NoError(t, err)
+
+		for _, acc := range page.Value {
+			require.NotNil(t, acc.Name)
+			names[*acc.Name] = true
+		}
+	}
+
+	assert.True(t, names["acct-a1"] && names["acct-a2"] && names["acct-b1"],
+		"subscription list should return all three accounts, got %v", names)
+
+	// ListByResourceGroup filters to rg-a only.
+	rgNames := map[string]bool{}
+	rgPager := client.NewListByResourceGroupPager("rg-a", nil)
+
+	for rgPager.More() {
+		page, err := rgPager.NextPage(ctx)
+		require.NoError(t, err)
+
+		for _, acc := range page.Value {
+			rgNames[*acc.Name] = true
+		}
+	}
+
+	assert.True(t, rgNames["acct-a1"] && rgNames["acct-a2"], "rg-a list missing accounts: %v", rgNames)
+	assert.False(t, rgNames["acct-b1"], "rg-a list must not include rg-b's account")
+}

--- a/server/azure/cosmosaccount/types.go
+++ b/server/azure/cosmosaccount/types.go
@@ -14,6 +14,7 @@ type armAccountCreateProps struct {
 	DatabaseAccountOfferType string          `json:"databaseAccountOfferType,omitempty"`
 	EnableFreeTier           bool            `json:"enableFreeTier,omitempty"`
 	Capabilities             []armCapability `json:"capabilities,omitempty"`
+	Locations                []armLocation   `json:"locations,omitempty"`
 }
 
 // armCapability is the ARM capability shape ([{name}]).
@@ -37,4 +38,64 @@ type armAccountProps struct {
 	EnableFreeTier           bool            `json:"enableFreeTier,omitempty"`
 	Capabilities             []armCapability `json:"capabilities,omitempty"`
 	ProvisioningState        string          `json:"provisioningState,omitempty"`
+	DocumentEndpoint         string          `json:"documentEndpoint,omitempty"`
+	Locations                []armLocation   `json:"locations,omitempty"`
+	ReadLocations            []armLocation   `json:"readLocations,omitempty"`
+	WriteLocations           []armLocation   `json:"writeLocations,omitempty"`
+	FailoverPolicies         []armFailover   `json:"failoverPolicies,omitempty"`
+}
+
+// armLocation is a region entry in a database account's location arrays.
+type armLocation struct {
+	ID                string `json:"id,omitempty"`
+	LocationName      string `json:"locationName,omitempty"`
+	DocumentEndpoint  string `json:"documentEndpoint,omitempty"`
+	ProvisioningState string `json:"provisioningState,omitempty"`
+	FailoverPriority  int32  `json:"failoverPriority"`
+	IsZoneRedundant   bool   `json:"isZoneRedundant"`
+}
+
+// armFailover is an entry in the account failoverPolicies array.
+type armFailover struct {
+	ID               string `json:"id,omitempty"`
+	LocationName     string `json:"locationName,omitempty"`
+	FailoverPriority int32  `json:"failoverPriority"`
+}
+
+// armAccountList is the {value:[...]} envelope for List / ListByResourceGroup.
+type armAccountList struct {
+	Value []armAccount `json:"value"`
+}
+
+// armListKeysResult is the DatabaseAccountListKeysResult wire shape.
+type armListKeysResult struct {
+	PrimaryMasterKey           string `json:"primaryMasterKey"`
+	SecondaryMasterKey         string `json:"secondaryMasterKey"`
+	PrimaryReadonlyMasterKey   string `json:"primaryReadonlyMasterKey"`
+	SecondaryReadonlyMasterKey string `json:"secondaryReadonlyMasterKey"`
+}
+
+// armReadOnlyKeysResult is the DatabaseAccountListReadOnlyKeysResult shape.
+type armReadOnlyKeysResult struct {
+	PrimaryReadonlyMasterKey   string `json:"primaryReadonlyMasterKey"`
+	SecondaryReadonlyMasterKey string `json:"secondaryReadonlyMasterKey"`
+}
+
+// armConnectionString is one entry in a ListConnectionStrings result.
+type armConnectionString struct {
+	ConnectionString string `json:"connectionString"`
+	Description      string `json:"description"`
+	KeyKind          string `json:"keyKind"`
+	Type             string `json:"type"`
+}
+
+// armConnectionStringsResult is the DatabaseAccountListConnectionStringsResult
+// wire shape.
+type armConnectionStringsResult struct {
+	ConnectionStrings []armConnectionString `json:"connectionStrings"`
+}
+
+// armRegenerateKey is the DatabaseAccountRegenerateKeyParameters request body.
+type armRegenerateKey struct {
+	KeyKind string `json:"keyKind"`
 }

--- a/server/azure/cosmosdb/cosmos_lifecycle_test.go
+++ b/server/azure/cosmosdb/cosmos_lifecycle_test.go
@@ -11,15 +11,14 @@
 // journeys mix SDK writes with direct driver calls on the same provider, per
 // the suite SDK-test-setup notes.
 //
+// Item identity is (partition key, id), matching real Cosmos: a duplicate-id
+// create returns 409, and two documents with the same partition key but
+// different ids coexist and point-read independently.
+//
 // Emulator divergences from real Cosmos that these tests pin down (asserting
 // the emulator's actual, documented behavior, marked DIVERGENCE below):
-//   - CreateItem with a duplicate id succeeds (blind upsert; real Cosmos: 409).
 //   - ReplaceItem ignores IfMatchEtag (real Cosmos: 412 on stale etag).
 //   - DeleteItem on a missing document returns 204 (real Cosmos: 404).
-//   - Queries evaluate the SQL WHERE/ORDER BY/projection but treat the
-//     partition key as advisory (cross-partition), since item identity is the
-//     partition-key value only, so two docs with the same pk but different ids
-//     collide (real Cosmos keys on (pk, id)).
 //   - PATCH (PatchItem) is not routed at all (405 MethodNotAllowed).
 //   - NOT over a composite predicate (AND/OR of several fields) uses two-valued
 //     logic, so an absent field is not excluded; NOT over a single-field
@@ -89,8 +88,7 @@ func newCosmosEnv(t *testing.T, opts ...config.Option) *cosmosEnv {
 }
 
 // container creates database db (virtual) and container name with partition
-// key path "/pk" (required — per-document GETs/DELETEs hardcode the "pk"
-// attribute) and returns its client.
+// key path "/pk" and returns its client.
 func (e *cosmosEnv) container(ctx context.Context, t *testing.T, db, name string) *azcosmos.ContainerClient {
 	t.Helper()
 
@@ -346,11 +344,12 @@ func TestCosmosTypedErrors(t *testing.T) {
 	wantRespErr(t, err, 400, "CreateItem without id")
 }
 
-// TestCosmosWriteDivergences pins down the emulator's write
-// semantics where they knowingly diverge from real Cosmos (see file header):
-// duplicate create succeeds, etag preconditions are ignored, deleting a
-// missing document succeeds, PATCH is not routed, and item identity collides
-// on the partition-key value alone.
+// TestCosmosWriteDivergences pins down the emulator's write semantics: the
+// (partition key, id) identity model — duplicate create 409s, an upsert of the
+// same id succeeds, and same-pk/different-id documents coexist — plus the
+// remaining knowing divergences from real Cosmos (see file header): etag
+// preconditions are ignored, deleting a missing document succeeds, and PATCH is
+// not routed.
 func TestCosmosWriteDivergences(t *testing.T) {
 	ctx := context.Background()
 	env := newCosmosEnv(t)
@@ -359,22 +358,28 @@ func TestCosmosWriteDivergences(t *testing.T) {
 	pk := azcosmos.NewPartitionKeyString("team-a")
 	createDoc(ctx, t, cc, "team-a", map[string]any{"id": "u1", "pk": "team-a", "name": "Alice", "rev": 1})
 
-	// DIVERGENCE: creating the same id again is a blind upsert and succeeds
-	// with 201 (real Cosmos returns 409 Conflict). "Conditional write
-	// failure" is therefore unreachable on this emulator.
+	// Creating the same (pk, id) again is a Conflict, matching real Cosmos.
 	dup, _ := json.Marshal(map[string]any{"id": "u1", "pk": "team-a", "name": "Alice-2", "rev": 2})
 
-	resp, err := cc.CreateItem(ctx, pk, dup, nil)
-	if err != nil {
-		t.Fatalf("duplicate CreateItem (emulator upserts): %v", err)
+	if _, err := cc.CreateItem(ctx, pk, dup, nil); err == nil {
+		t.Fatal("duplicate CreateItem: expected 409 Conflict, got nil error")
+	} else {
+		wantRespErr(t, err, 409, "duplicate CreateItem")
 	}
 
-	if resp.RawResponse.StatusCode != 201 {
-		t.Errorf("duplicate CreateItem status=%d want 201", resp.RawResponse.StatusCode)
+	// The original document is untouched by the rejected create.
+	if got := readDoc(ctx, t, cc, "team-a", "u1"); got["rev"] != float64(1) {
+		t.Errorf("rev=%v want 1 (rejected create must not overwrite)", got["rev"])
+	}
+
+	// UpsertItem with the same id is a create-or-replace and succeeds.
+	ups, _ := json.Marshal(map[string]any{"id": "u1", "pk": "team-a", "name": "Alice-2", "rev": 2})
+	if _, err := cc.UpsertItem(ctx, pk, ups, nil); err != nil {
+		t.Fatalf("UpsertItem same id: %v", err)
 	}
 
 	if got := readDoc(ctx, t, cc, "team-a", "u1"); got["rev"] != float64(2) {
-		t.Errorf("rev=%v want 2 (second create should have overwritten)", got["rev"])
+		t.Errorf("rev=%v want 2 (upsert should have overwritten)", got["rev"])
 	}
 
 	// DIVERGENCE: ReplaceItem with a deliberately stale IfMatchEtag succeeds
@@ -395,8 +400,8 @@ func TestCosmosWriteDivergences(t *testing.T) {
 	// supports partial document updates).
 	patch := azcosmos.PatchOperations{}
 	patch.AppendSet("/name", "Patched")
-	_, err = cc.PatchItem(ctx, pk, "u1", patch, nil)
-	wantRespErr(t, err, 405, "PatchItem (unrouted PATCH)")
+	_, patchErr := cc.PatchItem(ctx, pk, "u1", patch, nil)
+	wantRespErr(t, patchErr, 405, "PatchItem (unrouted PATCH)")
 
 	// DIVERGENCE: deleting a document that does not exist succeeds with 204
 	// (real Cosmos returns 404) — the driver delete is idempotent.
@@ -409,16 +414,17 @@ func TestCosmosWriteDivergences(t *testing.T) {
 		t.Errorf("DeleteItem missing doc status=%d want 204", delResp.RawResponse.StatusCode)
 	}
 
-	// DIVERGENCE: item identity is the partition-key value only. Two docs
-	// with the same pk but different ids share one slot, and a point read for
-	// the first id returns the second document (real Cosmos keys on (pk,id)).
+	// Item identity is (pk, id): two docs with the same partition key but
+	// different ids coexist, and each point-reads back independently.
 	createDoc(ctx, t, cc, "shared", map[string]any{"id": "doc-a", "pk": "shared", "who": "first"})
 	createDoc(ctx, t, cc, "shared", map[string]any{"id": "doc-b", "pk": "shared", "who": "second"})
 
-	got := readDoc(ctx, t, cc, "shared", "doc-a")
-	if got["id"] != "doc-b" || got["who"] != "second" {
-		t.Errorf("pk-collision read got id=%v who=%v; emulator keys items by pk only, expected doc-b/second",
-			got["id"], got["who"])
+	if got := readDoc(ctx, t, cc, "shared", "doc-a"); got["id"] != "doc-a" || got["who"] != "first" {
+		t.Errorf("(pk,id) read got id=%v who=%v; want doc-a/first", got["id"], got["who"])
+	}
+
+	if got := readDoc(ctx, t, cc, "shared", "doc-b"); got["id"] != "doc-b" || got["who"] != "second" {
+		t.Errorf("(pk,id) read got id=%v who=%v; want doc-b/second", got["id"], got["who"])
 	}
 }
 
@@ -615,8 +621,9 @@ func TestCosmosTTL(t *testing.T) {
 	wantRespErr(t, err, 404, "ReadItem expired session")
 
 	// Documented quirk: BatchGetItems does NOT check TTL, so the expired s2
-	// (never point-read since expiry) is still returned by a batch get.
-	batch, err := drv.BatchGetItems(ctx, "sessions", []map[string]any{{"pk": "s2"}})
+	// (never point-read since expiry) is still returned by a batch get. The key
+	// carries the full (pk, id) identity the container uses.
+	batch, err := drv.BatchGetItems(ctx, "sessions", []map[string]any{{"pk": "s2", "id": "s2"}})
 	if err != nil {
 		t.Fatalf("BatchGetItems: %v", err)
 	}

--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -17,11 +17,13 @@
 package cosmosdb
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -32,28 +34,49 @@ import (
 const (
 	contentTypeJSON = "application/json"
 	maxBodyBytes    = 5 << 20
+	// idAttr is the Cosmos document id attribute, which also serves as the
+	// driver sort key so a document's identity is (partition key, id).
+	idAttr = "id"
+	// offersPath / offersPathPrefix address the /offers throughput resource.
+	offersPath       = "/offers"
+	offersPathPrefix = "/offers/"
 )
 
 // Handler serves Cosmos DB SQL API requests against a database driver.
 type Handler struct {
 	db dbdriver.Database
+
+	// offers holds the provisioned throughput declared at container-create time,
+	// keyed by the container's resource id ("_rid"). Throughput is a Cosmos-only
+	// concept with no generic driver method, so the wire handler tracks it.
+	offerMu sync.RWMutex
+	offers  map[string]offerState
 }
 
 // New returns a Cosmos handler backed by db.
 func New(db dbdriver.Database) *Handler {
-	return &Handler{db: db}
+	return &Handler{db: db, offers: make(map[string]offerState)}
 }
 
 // Matches returns true for the Cosmos data plane URLs we serve: the account
-// root probe (GET /) and the /dbs/... resource tree.
+// root probe (GET /), the /dbs/... resource tree, and the /offers throughput
+// resource.
 func (*Handler) Matches(r *http.Request) bool {
-	return r.URL.Path == "/" || r.URL.Path == "/dbs" || strings.HasPrefix(r.URL.Path, "/dbs/")
+	p := r.URL.Path
+
+	return p == "/" || p == "/dbs" || strings.HasPrefix(p, "/dbs/") ||
+		p == offersPath || strings.HasPrefix(p, offersPathPrefix)
 }
 
 // ServeHTTP routes the request based on URL path shape.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == "/" {
 		h.accountProperties(w, r)
+		return
+	}
+
+	if r.URL.Path == offersPath || strings.HasPrefix(r.URL.Path, offersPathPrefix) {
+		h.serveOffers(w, r)
 		return
 	}
 
@@ -105,7 +128,7 @@ func (*Handler) accountProperties(w http.ResponseWriter, r *http.Request) {
 	endpoint := scheme + "://" + r.Host + "/"
 
 	props := map[string]any{
-		"id":                           "cloudemu",
+		idAttr:                         "cloudemu",
 		"_rid":                         "cloudemu",
 		"_self":                        "",
 		"_etag":                        `"cloudemu"`,
@@ -201,15 +224,27 @@ func (h *Handler) createContainer(w http.ResponseWriter, r *http.Request, db str
 		return
 	}
 
+	pkAttr := partitionKeyAttribute(body.PartitionKey)
+
 	cfg := dbdriver.TableConfig{
 		Name:         body.ID,
-		PartitionKey: partitionKeyAttribute(body.PartitionKey),
+		PartitionKey: pkAttr,
+	}
+
+	// Cosmos identifies a document by (partition-key value, id). The generic
+	// driver keys an item by PartitionKey (+ SortKey), so we map the document id
+	// onto the sort key to get that composite identity. When the partition key
+	// path is /id the two coincide, so no sort key is needed.
+	if pkAttr != idAttr {
+		cfg.SortKey = idAttr
 	}
 
 	if err := h.db.CreateTable(r.Context(), cfg); err != nil {
 		writeErr(w, err)
 		return
 	}
+
+	h.recordOffer(body.ID, r)
 
 	writeJSON(w, http.StatusCreated, makeContainerResource(db, body.ID, body.PartitionKey))
 }
@@ -261,6 +296,7 @@ func (h *Handler) containerResource(w http.ResponseWriter, r *http.Request, db, 
 			return
 		}
 
+		h.deleteOffer(coll)
 		w.WriteHeader(http.StatusNoContent)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
@@ -291,8 +327,22 @@ func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, _, coll
 		return
 	}
 
-	if _, exists := item["id"]; !exists {
+	if _, exists := item[idAttr]; !exists {
 		writeError(w, http.StatusBadRequest, "BadRequest", "item must contain an id field")
+		return
+	}
+
+	cfg, err := h.db.DescribeTable(r.Context(), coll)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	// A plain create (not an upsert) must fail if a document with the same
+	// (partition key, id) already exists, matching real Cosmos's 409 Conflict.
+	if !isUpsert(r) && h.documentExists(r.Context(), coll, cfg, item) {
+		writeError(w, http.StatusConflict, "Conflict",
+			"Resource with specified id or name already exists.")
 		return
 	}
 
@@ -303,6 +353,21 @@ func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, _, coll
 
 	addSystemProps(item)
 	writeJSON(w, http.StatusCreated, item)
+}
+
+// documentExists reports whether a document with item's (partition key, id)
+// identity is already stored in coll.
+func (h *Handler) documentExists(
+	ctx context.Context, coll string, cfg *dbdriver.TableConfig, item map[string]any,
+) bool {
+	key := map[string]any{idAttr: item[idAttr]}
+	if cfg != nil && cfg.PartitionKey != "" && cfg.PartitionKey != idAttr {
+		key[cfg.PartitionKey] = item[cfg.PartitionKey]
+	}
+
+	_, err := h.db.GetItem(ctx, coll, key)
+
+	return err == nil
 }
 
 func (h *Handler) listDocuments(w http.ResponseWriter, r *http.Request, coll string) {
@@ -380,8 +445,14 @@ func (h *Handler) queryDocuments(w http.ResponseWriter, r *http.Request, coll st
 }
 
 func (h *Handler) documentResource(w http.ResponseWriter, r *http.Request, _, coll, id string) {
+	cfg, derr := h.db.DescribeTable(r.Context(), coll)
+	if derr != nil {
+		writeErr(w, derr)
+		return
+	}
+
 	pk := docPartitionKey(r)
-	keyMap := buildKey(coll, pk, id)
+	keyMap := buildKey(cfg.PartitionKey, pk, id)
 
 	switch r.Method {
 	case http.MethodGet:
@@ -400,8 +471,8 @@ func (h *Handler) documentResource(w http.ResponseWriter, r *http.Request, _, co
 			return
 		}
 
-		if _, exists := item["id"]; !exists {
-			item["id"] = id
+		if _, exists := item[idAttr]; !exists {
+			item[idAttr] = id
 		}
 
 		if err := h.db.PutItem(r.Context(), coll, item); err != nil {
@@ -459,20 +530,30 @@ func docPartitionKey(r *http.Request) string {
 	return fmt.Sprintf("%v", parsed[0])
 }
 
-// buildKey constructs the key map our driver expects to look up a document.
-// The driver uses the partition-key attribute name to find the right item;
-// for items where the table has no explicit partition key we fall back to id.
-func buildKey(_, pk, id string) map[string]any {
-	if pk == "" {
-		return map[string]any{"id": id}
+// buildKey constructs the key map the driver expects to look up a document by
+// its (partition key, id) identity. pkAttr is the container's declared
+// partition-key attribute name (e.g. "pk", "category"); pkVal is the value from
+// the x-ms-documentdb-partitionkey header. When the partition key is /id (or
+// unset) the id alone identifies the document.
+func buildKey(pkAttr, pkVal, id string) map[string]any {
+	key := map[string]any{idAttr: id}
+	if pkAttr != "" && pkAttr != idAttr {
+		key[pkAttr] = pkVal
 	}
 
-	return map[string]any{"id": id, "pk": pk}
+	return key
+}
+
+// isUpsert reports whether a document write carries the Cosmos upsert flag,
+// which turns a create (POST /docs) into a create-or-replace and suppresses the
+// duplicate-id conflict.
+func isUpsert(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get("X-Ms-Documentdb-Is-Upsert"), "true")
 }
 
 func partitionKeyAttribute(pk *partitionKeyDef) string {
 	if pk == nil || len(pk.Paths) == 0 {
-		return "id"
+		return idAttr
 	}
 
 	// Cosmos paths look like "/myKey" — strip the leading slash.
@@ -530,7 +611,7 @@ func addSystemProps(item map[string]any) {
 		return
 	}
 
-	id, _ := item["id"].(string)
+	id, _ := item[idAttr].(string)
 
 	if _, ok := item["_rid"]; !ok {
 		item["_rid"] = "rid-" + id

--- a/server/azure/cosmosdb/offers.go
+++ b/server/azure/cosmosdb/offers.go
@@ -1,0 +1,237 @@
+package cosmosdb
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// offerState is the provisioned throughput recorded for a container.
+type offerState struct {
+	manualThroughput int32
+	autoscaleMax     int32
+	autoscale        bool
+}
+
+// containerRID mirrors the "_rid" makeContainerResource assigns a container, so
+// the offer store and the SDK (which reads a container's _rid, then queries the
+// offer by that resource id) agree on the key.
+func containerRID(coll string) string {
+	return "rid-" + coll
+}
+
+// recordOffer captures the throughput a container was created with. Real Cosmos
+// only materializes a dedicated offer when throughput is provisioned on the
+// container; a container created without it (shared/serverless) has no offer,
+// so ReadThroughput 404s — which the empty-store path reproduces.
+func (h *Handler) recordOffer(coll string, r *http.Request) {
+	st, ok := parseOfferHeaders(r)
+	if !ok {
+		return
+	}
+
+	h.offerMu.Lock()
+	h.offers[containerRID(coll)] = st
+	h.offerMu.Unlock()
+}
+
+func (h *Handler) deleteOffer(coll string) {
+	h.offerMu.Lock()
+	delete(h.offers, containerRID(coll))
+	h.offerMu.Unlock()
+}
+
+// parseOfferHeaders reads the manual (x-ms-offer-throughput) or autoscale
+// (x-ms-cosmos-offer-autopilot-settings) throughput headers the SDK sets on a
+// container create.
+func parseOfferHeaders(r *http.Request) (offerState, bool) {
+	if v := r.Header.Get("X-Ms-Offer-Throughput"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 32); err == nil && n > 0 {
+			return offerState{manualThroughput: int32(n)}, true
+		}
+	}
+
+	if v := r.Header.Get("X-Ms-Cosmos-Offer-Autopilot-Settings"); v != "" {
+		var settings struct {
+			MaxThroughput int32 `json:"maxThroughput"`
+		}
+
+		if err := json.Unmarshal([]byte(v), &settings); err == nil && settings.MaxThroughput > 0 {
+			return offerState{autoscaleMax: settings.MaxThroughput, autoscale: true}, true
+		}
+	}
+
+	return offerState{}, false
+}
+
+// serveOffers routes the /offers throughput resource: POST /offers is the
+// offer query the SDK fires to locate a container's offer; GET/PUT /offers/{id}
+// read and replace it.
+func (h *Handler) serveOffers(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == offersPath {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+			return
+		}
+
+		h.queryOffers(w, r)
+
+		return
+	}
+
+	rid := strings.TrimPrefix(r.URL.Path, offersPathPrefix)
+
+	switch r.Method {
+	case http.MethodGet:
+		h.readOffer(w, rid)
+	case http.MethodPut:
+		h.replaceOffer(w, r, rid)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+// queryOffers answers the SDK's offer lookup. It returns the single offer whose
+// offerResourceId matches the container rid named in the WHERE clause, in the
+// {"Offers":[...]} envelope ReadThroughputIfExists expects. No match yields an
+// empty list, which the SDK maps to 404 (no dedicated throughput).
+func (h *Handler) queryOffers(w http.ResponseWriter, r *http.Request) {
+	body, ok := decodeQueryBody(w, r)
+	if !ok {
+		return
+	}
+
+	rid := offerResourceIDFromQuery(body.Query)
+
+	offers := []map[string]any{}
+
+	if rid != "" {
+		h.offerMu.RLock()
+		st, found := h.offers[rid]
+		h.offerMu.RUnlock()
+
+		if found {
+			offers = append(offers, offerDocument(rid, st))
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"_rid":   "cloudemu",
+		"Offers": offers,
+		"_count": len(offers),
+	})
+}
+
+func (h *Handler) readOffer(w http.ResponseWriter, rid string) {
+	h.offerMu.RLock()
+	st, found := h.offers[rid]
+	h.offerMu.RUnlock()
+
+	if !found {
+		writeError(w, http.StatusNotFound, "NotFound", "offer not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, offerDocument(rid, st))
+}
+
+func (h *Handler) replaceOffer(w http.ResponseWriter, r *http.Request, rid string) {
+	h.offerMu.RLock()
+	_, found := h.offers[rid]
+	h.offerMu.RUnlock()
+
+	if !found {
+		writeError(w, http.StatusNotFound, "NotFound", "offer not found")
+		return
+	}
+
+	item, ok := decodeAnyJSON(w, r)
+	if !ok {
+		return
+	}
+
+	st := offerFromBody(item)
+
+	h.offerMu.Lock()
+	h.offers[rid] = st
+	h.offerMu.Unlock()
+
+	writeJSON(w, http.StatusOK, offerDocument(rid, st))
+}
+
+// offerFromBody reads the throughput out of a replace request's Throughput
+// properties body ({"content":{"offerThroughput":N}} or autopilot settings).
+func offerFromBody(item map[string]any) offerState {
+	content, _ := item["content"].(map[string]any)
+	if content == nil {
+		return offerState{}
+	}
+
+	if v, ok := numericValue(content["offerThroughput"]); ok && v > 0 {
+		return offerState{manualThroughput: int32(v)}
+	}
+
+	if settings, ok := content["offerAutopilotSettings"].(map[string]any); ok {
+		if v, ok := numericValue(settings["maxThroughput"]); ok && v > 0 {
+			return offerState{autoscaleMax: int32(v), autoscale: true}
+		}
+	}
+
+	return offerState{}
+}
+
+// offerDocument renders one offer resource in the V2 wire shape the azcosmos
+// ThroughputProperties unmarshaller reads.
+func offerDocument(rid string, st offerState) map[string]any {
+	content := map[string]any{}
+	if st.autoscale {
+		content["offerAutopilotSettings"] = map[string]any{"maxThroughput": st.autoscaleMax}
+	} else {
+		content["offerThroughput"] = st.manualThroughput
+	}
+
+	self := "offers/" + rid
+
+	return map[string]any{
+		"id":              rid,
+		"_rid":            rid,
+		"_self":           self,
+		"_etag":           `"` + rid + `"`,
+		"_ts":             time.Now().Unix(),
+		"resource":        "colls/" + rid + "/",
+		"offerResourceId": rid,
+		"offerType":       "Invalid",
+		"offerVersion":    "V2",
+		"content":         content,
+	}
+}
+
+// offerResourceIDFromQuery extracts the value bound to offerResourceId in the
+// SDK's offer lookup query, e.g. SELECT * FROM c WHERE c.offerResourceId =
+// 'rid-users'. Returns "" when the clause is absent.
+func offerResourceIDFromQuery(query string) string {
+	const marker = "offerResourceId"
+
+	i := strings.Index(query, marker)
+	if i < 0 {
+		return ""
+	}
+
+	rest := query[i+len(marker):]
+
+	start := strings.IndexByte(rest, '\'')
+	if start < 0 {
+		return ""
+	}
+
+	rest = rest[start+1:]
+
+	end := strings.IndexByte(rest, '\'')
+	if end < 0 {
+		return ""
+	}
+
+	return rest[:end]
+}

--- a/server/azure/cosmosdb/offers_test.go
+++ b/server/azure/cosmosdb/offers_test.go
@@ -1,0 +1,138 @@
+package cosmosdb_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// newThroughputClient mounts a fresh Azure Cosmos data plane and returns a real
+// azcosmos client pointed at it.
+func newThroughputClient(t *testing.T) *azcosmos.Client {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{CosmosDB: cloudP.CosmosDB})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	cred, err := azcosmos.NewKeyCredential(fakeKey)
+	if err != nil {
+		t.Fatalf("NewKeyCredential: %v", err)
+	}
+
+	client, err := azcosmos.NewClientWithKey(ts.URL, cred, &azcosmos.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewClientWithKey: %v", err)
+	}
+
+	return client
+}
+
+// TestSDKContainerThroughput drives the azcosmos ReadThroughput / ReplaceThroughput
+// flow end-to-end against the /offers resource: a container created with manual
+// throughput reports it back, and a replace round-trips the new value.
+func TestSDKContainerThroughput(t *testing.T) {
+	ctx := context.Background()
+	client := newThroughputClient(t)
+
+	if _, err := client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: "tpdb"}, nil); err != nil {
+		t.Fatalf("CreateDatabase: %v", err)
+	}
+
+	dbClient, err := client.NewDatabase("tpdb")
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	props := azcosmos.ContainerProperties{
+		ID:                     "metered",
+		PartitionKeyDefinition: azcosmos.PartitionKeyDefinition{Paths: []string{"/pk"}},
+	}
+	manual := azcosmos.NewManualThroughputProperties(400)
+
+	if _, err := dbClient.CreateContainer(ctx, props, &azcosmos.CreateContainerOptions{
+		ThroughputProperties: &manual,
+	}); err != nil {
+		t.Fatalf("CreateContainer with throughput: %v", err)
+	}
+
+	cc, err := dbClient.NewContainer("metered")
+	if err != nil {
+		t.Fatalf("NewContainer: %v", err)
+	}
+
+	// ReadThroughput reflects the provisioned RU/s.
+	readResp, err := cc.ReadThroughput(ctx, nil)
+	if err != nil {
+		t.Fatalf("ReadThroughput: %v", err)
+	}
+
+	got, ok := readResp.ThroughputProperties.ManualThroughput()
+	if !ok || got != 400 {
+		t.Errorf("ReadThroughput manual=%d ok=%v want 400", got, ok)
+	}
+
+	// ReplaceThroughput to 1000 and read it back.
+	updated := azcosmos.NewManualThroughputProperties(1000)
+	if _, err := cc.ReplaceThroughput(ctx, updated, nil); err != nil {
+		t.Fatalf("ReplaceThroughput: %v", err)
+	}
+
+	after, err := cc.ReadThroughput(ctx, nil)
+	if err != nil {
+		t.Fatalf("ReadThroughput after replace: %v", err)
+	}
+
+	got, ok = after.ThroughputProperties.ManualThroughput()
+	if !ok || got != 1000 {
+		t.Errorf("post-replace manual=%d ok=%v want 1000", got, ok)
+	}
+}
+
+// TestSDKContainerThroughputAbsent asserts that a container created without
+// provisioned throughput has no dedicated offer, so ReadThroughput 404s — the
+// same behavior the real service exposes for shared/serverless containers.
+func TestSDKContainerThroughputAbsent(t *testing.T) {
+	ctx := context.Background()
+	client := newThroughputClient(t)
+
+	if _, err := client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: "shareddb"}, nil); err != nil {
+		t.Fatalf("CreateDatabase: %v", err)
+	}
+
+	dbClient, err := client.NewDatabase("shareddb")
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	props := azcosmos.ContainerProperties{
+		ID:                     "unmetered",
+		PartitionKeyDefinition: azcosmos.PartitionKeyDefinition{Paths: []string{"/pk"}},
+	}
+	if _, err := dbClient.CreateContainer(ctx, props, nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	cc, err := dbClient.NewContainer("unmetered")
+	if err != nil {
+		t.Fatalf("NewContainer: %v", err)
+	}
+
+	if _, err := cc.ReadThroughput(ctx, nil); err == nil {
+		t.Fatal("ReadThroughput on a container with no offer: expected error, got nil")
+	}
+}

--- a/server/azure/cosmosdb/partition_key_test.go
+++ b/server/azure/cosmosdb/partition_key_test.go
@@ -1,0 +1,172 @@
+package cosmosdb_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// pkTestContainer creates a container with the given partition-key path and
+// returns its client. Used to exercise partition keys other than /pk and /id.
+func pkTestContainer(t *testing.T, db, name, pkPath string) *azcosmos.ContainerClient {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{CosmosDB: cloudP.CosmosDB})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	cred, err := azcosmos.NewKeyCredential(fakeKey)
+	if err != nil {
+		t.Fatalf("NewKeyCredential: %v", err)
+	}
+
+	client, err := azcosmos.NewClientWithKey(ts.URL, cred, &azcosmos.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewClientWithKey: %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: db}, nil); err != nil {
+		t.Fatalf("CreateDatabase: %v", err)
+	}
+
+	dbClient, err := client.NewDatabase(db)
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	props := azcosmos.ContainerProperties{
+		ID:                     name,
+		PartitionKeyDefinition: azcosmos.PartitionKeyDefinition{Paths: []string{pkPath}},
+	}
+	if _, err := dbClient.CreateContainer(ctx, props, nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	cc, err := dbClient.NewContainer(name)
+	if err != nil {
+		t.Fatalf("NewContainer: %v", err)
+	}
+
+	return cc
+}
+
+// TestSDKCustomPartitionKeyPointOps exercises a container whose partition key
+// is a custom attribute (/category, not /pk or /id): point reads and deletes
+// must resolve by the real partition-key value plus the document id, and two
+// documents sharing a partition key but differing in id must be independent.
+func TestSDKCustomPartitionKeyPointOps(t *testing.T) {
+	ctx := context.Background()
+	cc := pkTestContainer(t, "catalogdb", "products", "/category")
+
+	pk := azcosmos.NewPartitionKeyString("books")
+
+	for _, d := range []map[string]any{
+		{"id": "p1", "category": "books", "title": "Go in Practice"},
+		{"id": "p2", "category": "books", "title": "The Go Programming Language"},
+	} {
+		b, _ := json.Marshal(d)
+		if _, err := cc.CreateItem(ctx, pk, b, nil); err != nil {
+			t.Fatalf("CreateItem(%v): %v", d["id"], err)
+		}
+	}
+
+	// Point read by (category, id) returns the right document, not a collision.
+	resp, err := cc.ReadItem(ctx, pk, "p1", nil)
+	if err != nil {
+		t.Fatalf("ReadItem p1: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(resp.Value, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got["id"] != "p1" || got["title"] != "Go in Practice" {
+		t.Errorf("ReadItem p1 = id:%v title:%v want p1/Go in Practice", got["id"], got["title"])
+	}
+
+	// The sibling under the same partition key is independent.
+	resp2, err := cc.ReadItem(ctx, pk, "p2", nil)
+	if err != nil {
+		t.Fatalf("ReadItem p2: %v", err)
+	}
+
+	var got2 map[string]any
+	if err := json.Unmarshal(resp2.Value, &got2); err != nil {
+		t.Fatalf("unmarshal p2: %v", err)
+	}
+
+	if got2["id"] != "p2" {
+		t.Errorf("ReadItem p2 id=%v want p2", got2["id"])
+	}
+
+	// Delete p1; it is gone and p2 survives.
+	if _, err := cc.DeleteItem(ctx, pk, "p1", nil); err != nil {
+		t.Fatalf("DeleteItem p1: %v", err)
+	}
+
+	if _, err := cc.ReadItem(ctx, pk, "p1", nil); err == nil {
+		t.Error("ReadItem p1 after delete: expected 404, got nil error")
+	} else {
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode != 404 {
+			t.Errorf("ReadItem p1 after delete status=%d want 404", respErr.StatusCode)
+		}
+	}
+
+	if _, err := cc.ReadItem(ctx, pk, "p2", nil); err != nil {
+		t.Errorf("ReadItem p2 after deleting p1: %v (p2 must survive)", err)
+	}
+}
+
+// TestSDKIDPartitionKeyPointOps exercises a container whose partition key is
+// /id — the value and the document id coincide — proving that path still reads
+// and deletes correctly.
+func TestSDKIDPartitionKeyPointOps(t *testing.T) {
+	ctx := context.Background()
+	cc := pkTestContainer(t, "iddb", "widgets", "/id")
+
+	b, _ := json.Marshal(map[string]any{"id": "w1", "color": "blue"})
+	if _, err := cc.CreateItem(ctx, azcosmos.NewPartitionKeyString("w1"), b, nil); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	resp, err := cc.ReadItem(ctx, azcosmos.NewPartitionKeyString("w1"), "w1", nil)
+	if err != nil {
+		t.Fatalf("ReadItem: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(resp.Value, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got["color"] != "blue" {
+		t.Errorf("color=%v want blue", got["color"])
+	}
+
+	if _, err := cc.DeleteItem(ctx, azcosmos.NewPartitionKeyString("w1"), "w1", nil); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+
+	if _, err := cc.ReadItem(ctx, azcosmos.NewPartitionKeyString("w1"), "w1", nil); err == nil {
+		t.Error("ReadItem after delete: expected error, got nil")
+	}
+}

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -255,15 +255,17 @@ type IndexInfo struct {
 	Status       string // "ACTIVE", "CREATING", "DELETING"
 }
 
-// Database is the interface that database provider implementations must satisfy.
 // AccountAttributes are the Cosmos-DB-account cost/identity attributes a real
 // Azure `documentdb/databaseaccounts` resource carries but a DynamoDB/Firestore
 // table does not. Surfaced through the optional TableAttributes capability.
 type AccountAttributes struct {
-	Kind           string   // GlobalDocumentDB / MongoDB
-	OfferType      string   // databaseAccountOfferType (Standard)
-	EnableFreeTier bool     // free-tier flag (cost)
-	Capabilities   []string // e.g. EnableServerless (cost)
+	Kind           string            // GlobalDocumentDB / MongoDB
+	OfferType      string            // databaseAccountOfferType (Standard)
+	EnableFreeTier bool              // free-tier flag (cost)
+	Capabilities   []string          // e.g. EnableServerless (cost)
+	Location       string            // creation region (e.g. eastus)
+	ResourceGroup  string            // owning resource group (for byRG listing)
+	Tags           map[string]string // user-supplied resource tags
 }
 
 // TableAttributes is an OPTIONAL capability, discovered by type assertion (like
@@ -274,6 +276,7 @@ type TableAttributes interface {
 	TableAttributes(ctx context.Context, table string) (AccountAttributes, error)
 }
 
+// Database is the interface that database provider implementations must satisfy.
 type Database interface {
 	CreateTable(ctx context.Context, config TableConfig) error
 	DeleteTable(ctx context.Context, name string) error


### PR DESCRIPTION
## Summary

Fixes a batch of Azure Cosmos DB e2e defects across the ARM account control plane (`Microsoft.DocumentDB/databaseAccounts`) and the SQL data plane, matching the real Azure wire contract (verified against the Azure REST reference and the `armcosmos` v3 / `azcosmos` SDKs).

### Account control plane (`server/azure/cosmosaccount`)
- **ListKeys** — `POST .../listKeys` was 405 (POST sub-resources never dispatched). Now routed; returns `primaryMasterKey` / `secondaryMasterKey` / `primaryReadonlyMasterKey` / `secondaryReadonlyMasterKey` (plus `readonlykeys`).
- **ListConnectionStrings** — `POST .../listConnectionStrings` now returns the SQL connection strings (`connectionString`/`description`/`keyKind`/`type`).
- **RegenerateKey** — `POST .../regenerateKey` now completes the LRO with 200 instead of 405.
- **List / ListByResourceGroup** — collection `GET` returned 404 "database account name required"; now returns the `{value:[...]}` envelope, enumerating only real accounts (not the data-plane containers sharing the driver) and filtering by resource group.
- **Get location/tags** — submitted `location` and `tags` were dropped; now persisted (via the account attributes capability) and returned.
- **documentEndpoint / locations** — were nil/empty; now returns `https://{name}.documents.azure.com:443/` plus populated `readLocations` / `writeLocations` / `locations` / `failoverPolicies`.

### SQL data plane (`server/azure/cosmosdb`)
- **Custom partition-key point read/delete** — `buildKey()` hardcoded the attribute name `pk`, so a read/delete against any other partition-key path (`/category`, …) 404'd (read) or silently no-op'd (delete). Documents are now identified by their true `(partition key value, id)`: the container's declared partition-key path is the partition key and the document `id` becomes the sort key, so point ops resolve correctly and two documents sharing a partition key but differing in `id` coexist.
- **Duplicate-id create → 409** — a plain create now returns `409 Conflict` on a duplicate `(pk, id)`; an upsert (`x-ms-documentdb-is-upsert`) still overwrites.
- **Throughput / offers** — `ReadThroughput` / `ReplaceThroughput` were unrouted (the `/offers` resource 501'd) and `x-ms-offer-throughput` on container create was ignored. The `/offers` resource is now served (offer query + get + replace), throughput provisioned at create is recorded, and a container created without throughput reports no offer (404), as real Cosmos does for shared/serverless containers.

### Deferred
- **Per-database isolation** (`{db}` segment ignored; DeleteDatabase is a no-op): deferred. The data-plane and account handlers share one driver whose table names are a flat namespace also reached directly by driver-level tests (TTL/change-feed); enforcing `db/coll` qualification safely needs broader provider + test rework than fits cleanly with these fixes, so it is left for a focused follow-up.

## Tests
Real-user SDK round-trips drive the official `armcosmos` / `azcosmos` clients against an httptest TLS server over the wire handlers:
- account: ListKeys, ListConnectionStrings, BeginRegenerateKey, List + ListByResourceGroup, and Get (endpoint/tags/locations).
- data plane: custom-partition-key point ops (`/category`, `/id`), ReadThroughput/ReplaceThroughput, and the updated `(pk, id)` identity + duplicate-create-409 divergence tests.

Gates: `go build ./...`, `go test ./providers/azure/... ./server/... ./services/...`, and `golangci-lint` on the changed packages all pass.
