### PR TITLE
fix(eventbridge-sns): event-pattern matching (nested/content-operators), InputTransformer/Input/InputPath targets, SNS FilterPolicy + RawMessageDelivery

### DIFF
--- a/internal/eventmatch/eventmatch.go
+++ b/internal/eventmatch/eventmatch.go
@@ -1,0 +1,319 @@
+// Package eventmatch implements the content-filtering semantics shared by
+// EventBridge event patterns and SNS subscription filter policies. Both use the
+// same leaf model: a field constraint is a JSON array whose elements are either
+// plain values (exact match) or single-key operator objects (prefix, suffix,
+// anything-but, exists, numeric, cidr, equals-ignore-case, wildcard). Provider
+// mocks own their storage and wiring; this package is only the matcher.
+package eventmatch
+
+import (
+	"encoding/json"
+	"math"
+	"net"
+	"strings"
+)
+
+// MatchEvent reports whether the parsed event object satisfies the parsed
+// pattern object. Every key in the pattern must be present in the event and
+// match: a pattern value that is a nested object recurses into the event's
+// nested object; a pattern value that is an array is a leaf constraint. Any
+// other pattern shape is treated as non-matching.
+func MatchEvent(pattern, event map[string]any) bool {
+	for key, pv := range pattern {
+		ev, present := event[key]
+
+		switch p := pv.(type) {
+		case []any:
+			if !MatchLeaf(p, ev, present) {
+				return false
+			}
+		case map[string]any:
+			child, ok := ev.(map[string]any)
+			if !ok || !MatchEvent(p, child) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+
+	return true
+}
+
+// MatchLeaf reports whether a concrete event value (present or absent) satisfies
+// at least one entry of a leaf constraint array. When the event value is itself
+// an array, the constraint matches if any element matches.
+func MatchLeaf(allowed []any, value any, present bool) bool {
+	// When the event value is an array, the leaf matches if any element does;
+	// otherwise fall through so exists-style operators can evaluate presence.
+	if arr, ok := value.([]any); ok && present {
+		for _, el := range arr {
+			if matchAnyEntry(allowed, el, true) {
+				return true
+			}
+		}
+	}
+
+	return matchAnyEntry(allowed, value, present)
+}
+
+func matchAnyEntry(allowed []any, value any, present bool) bool {
+	for _, a := range allowed {
+		if matchEntry(a, value, present) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func matchEntry(allowed, value any, present bool) bool {
+	switch a := allowed.(type) {
+	case map[string]any:
+		return matchOperator(a, value, present)
+	case nil:
+		return present && value == nil
+	default:
+		return present && equalScalar(a, value)
+	}
+}
+
+func matchOperator(op map[string]any, value any, present bool) bool {
+	for name, spec := range op {
+		if !matchNamedOperator(name, spec, value, present) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func matchNamedOperator(name string, spec, value any, present bool) bool {
+	// exists is the only operator that evaluates the absent case; every other
+	// operator requires a present value.
+	if name == "exists" {
+		want, _ := spec.(bool)
+
+		return want == present
+	}
+
+	return present && matchPresentOperator(name, spec, value)
+}
+
+func matchPresentOperator(name string, spec, value any) bool {
+	switch name {
+	case "prefix":
+		return matchAffix(spec, value, strings.HasPrefix)
+	case "suffix":
+		return matchAffix(spec, value, strings.HasSuffix)
+	case "equals-ignore-case":
+		return matchEqualsIgnoreCase(spec, value)
+	case "anything-but":
+		return matchAnythingBut(spec, value)
+	case "numeric":
+		return matchNumeric(spec, value)
+	case "cidr":
+		return matchCIDR(spec, value)
+	case "wildcard":
+		return matchWildcard(spec, value)
+	default:
+		return false
+	}
+}
+
+func matchAffix(spec, value any, test func(s, affix string) bool) bool {
+	s, ok := value.(string)
+	if !ok {
+		return false
+	}
+
+	switch p := spec.(type) {
+	case string:
+		return test(s, p)
+	case map[string]any:
+		if ic, ok := p["equals-ignore-case"].(string); ok {
+			return test(strings.ToLower(s), strings.ToLower(ic))
+		}
+	}
+
+	return false
+}
+
+func matchEqualsIgnoreCase(spec, value any) bool {
+	want, ok := spec.(string)
+	if !ok {
+		return false
+	}
+
+	got, ok := value.(string)
+
+	return ok && strings.EqualFold(got, want)
+}
+
+func matchAnythingBut(spec, value any) bool {
+	switch s := spec.(type) {
+	case []any:
+		for _, e := range s {
+			if equalScalar(e, value) {
+				return false
+			}
+		}
+
+		return true
+	case map[string]any:
+		return !matchOperator(s, value, true)
+	default:
+		return !equalScalar(spec, value)
+	}
+}
+
+func matchNumeric(spec, value any) bool {
+	v, ok := toFloat(value)
+	if !ok {
+		return false
+	}
+
+	arr, ok := spec.([]any)
+	if !ok {
+		return false
+	}
+
+	for i := 0; i+1 < len(arr); i += 2 {
+		opStr, ok := arr[i].(string)
+		if !ok {
+			return false
+		}
+
+		bound, ok := toFloat(arr[i+1])
+		if !ok || !numCompare(v, opStr, bound) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func numCompare(v float64, op string, bound float64) bool {
+	const eps = 1e-9
+
+	switch op {
+	case "=":
+		return math.Abs(v-bound) < eps
+	case "!=":
+		return math.Abs(v-bound) >= eps
+	case "<":
+		return v < bound
+	case "<=":
+		return v <= bound
+	case ">":
+		return v > bound
+	case ">=":
+		return v >= bound
+	default:
+		return false
+	}
+}
+
+func matchCIDR(spec, value any) bool {
+	cidr, ok := spec.(string)
+	if !ok {
+		return false
+	}
+
+	ipStr, ok := value.(string)
+	if !ok {
+		return false
+	}
+
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false
+	}
+
+	ip := net.ParseIP(ipStr)
+
+	return ip != nil && network.Contains(ip)
+}
+
+func matchWildcard(spec, value any) bool {
+	pattern, ok := spec.(string)
+	if !ok {
+		return false
+	}
+
+	s, ok := value.(string)
+	if !ok {
+		return false
+	}
+
+	return wildcardMatch(pattern, s)
+}
+
+// wildcardMatch reports whether s matches pattern, where '*' matches any run of
+// characters. Segments between '*' must appear in order.
+func wildcardMatch(pattern, s string) bool {
+	parts := strings.Split(pattern, "*")
+	if len(parts) == 1 {
+		return pattern == s
+	}
+
+	if !strings.HasPrefix(s, parts[0]) {
+		return false
+	}
+
+	rest := s[len(parts[0]):]
+
+	for _, mid := range parts[1 : len(parts)-1] {
+		idx := strings.Index(rest, mid)
+		if idx < 0 {
+			return false
+		}
+
+		rest = rest[idx+len(mid):]
+	}
+
+	return strings.HasSuffix(rest, parts[len(parts)-1])
+}
+
+func equalScalar(a, value any) bool {
+	if an, ok := toFloat(a); ok {
+		if vn, ok := toFloat(value); ok {
+			return an == vn
+		}
+
+		return false
+	}
+
+	return a == value
+}
+
+func toFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case json.Number:
+		f, err := n.Float64()
+
+		return f, err == nil
+	case int:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+// ParsePattern decodes a JSON event pattern / filter policy into the object form
+// MatchEvent and MatchLeaf consume. It returns false when the JSON is not a
+// well-formed object.
+func ParsePattern(raw string) (map[string]any, bool) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, false
+	}
+
+	var p map[string]any
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		return nil, false
+	}
+
+	return p, true
+}

--- a/internal/eventmatch/eventmatch.go
+++ b/internal/eventmatch/eventmatch.go
@@ -13,6 +13,18 @@ import (
 	"strings"
 )
 
+// Leaf operator names shared by the matcher and reserved-keyword checks.
+const (
+	opPrefix           = "prefix"
+	opSuffix           = "suffix"
+	opAnythingBut      = "anything-but"
+	opExists           = "exists"
+	opNumeric          = "numeric"
+	opCIDR             = "cidr"
+	opEqualsIgnoreCase = "equals-ignore-case"
+	opWildcard         = "wildcard"
+)
+
 // MatchEvent reports whether the parsed event object satisfies the parsed
 // pattern object. Every key in the pattern must be present in the event and
 // match: a pattern value that is a nested object recurses into the event's
@@ -20,24 +32,79 @@ import (
 // other pattern shape is treated as non-matching.
 func MatchEvent(pattern, event map[string]any) bool {
 	for key, pv := range pattern {
-		ev, present := event[key]
-
-		switch p := pv.(type) {
-		case []any:
-			if !MatchLeaf(p, ev, present) {
-				return false
-			}
-		case map[string]any:
-			child, ok := ev.(map[string]any)
-			if !ok || !MatchEvent(p, child) {
-				return false
-			}
-		default:
+		if !matchPatternKey(key, pv, event) {
 			return false
 		}
 	}
 
 	return true
+}
+
+func matchPatternKey(key string, pv any, event map[string]any) bool {
+	if key == "$or" {
+		if subs, ok := pv.([]any); ok && IsOrClause(subs) {
+			return matchOrClause(subs, event)
+		}
+	}
+
+	ev, present := event[key]
+
+	switch p := pv.(type) {
+	case []any:
+		return MatchLeaf(p, ev, present)
+	case map[string]any:
+		child, ok := ev.(map[string]any)
+
+		return ok && MatchEvent(p, child)
+	default:
+		return false
+	}
+}
+
+// IsOrClause reports whether a "$or" value is a genuine logical-OR clause: a list
+// of at least two sub-pattern objects, none of which name a reserved leaf
+// operator as a field. AWS documents `$or` as a first-class operator whose value
+// is an array of independent sub-patterns, matched if any one of them matches.
+func IsOrClause(subs []any) bool {
+	const minOrBranches = 2
+	if len(subs) < minOrBranches {
+		return false
+	}
+
+	for _, s := range subs {
+		sub, ok := s.(map[string]any)
+		if !ok {
+			return false
+		}
+
+		for k := range sub {
+			if isReservedOperator(k) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func matchOrClause(subs []any, event map[string]any) bool {
+	for _, s := range subs {
+		if sub, ok := s.(map[string]any); ok && MatchEvent(sub, event) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isReservedOperator(name string) bool {
+	switch name {
+	case opPrefix, opSuffix, opAnythingBut, opExists,
+		opNumeric, opCIDR, opEqualsIgnoreCase, opWildcard:
+		return true
+	default:
+		return false
+	}
 }
 
 // MatchLeaf reports whether a concrete event value (present or absent) satisfies
@@ -91,7 +158,7 @@ func matchOperator(op map[string]any, value any, present bool) bool {
 func matchNamedOperator(name string, spec, value any, present bool) bool {
 	// exists is the only operator that evaluates the absent case; every other
 	// operator requires a present value.
-	if name == "exists" {
+	if name == opExists {
 		want, _ := spec.(bool)
 
 		return want == present
@@ -102,19 +169,19 @@ func matchNamedOperator(name string, spec, value any, present bool) bool {
 
 func matchPresentOperator(name string, spec, value any) bool {
 	switch name {
-	case "prefix":
+	case opPrefix:
 		return matchAffix(spec, value, strings.HasPrefix)
-	case "suffix":
+	case opSuffix:
 		return matchAffix(spec, value, strings.HasSuffix)
-	case "equals-ignore-case":
+	case opEqualsIgnoreCase:
 		return matchEqualsIgnoreCase(spec, value)
-	case "anything-but":
+	case opAnythingBut:
 		return matchAnythingBut(spec, value)
-	case "numeric":
+	case opNumeric:
 		return matchNumeric(spec, value)
-	case "cidr":
+	case opCIDR:
 		return matchCIDR(spec, value)
-	case "wildcard":
+	case opWildcard:
 		return matchWildcard(spec, value)
 	default:
 		return false
@@ -130,8 +197,14 @@ func matchAffix(spec, value any, test func(s, affix string) bool) bool {
 	switch p := spec.(type) {
 	case string:
 		return test(s, p)
+	case []any:
+		for _, e := range p {
+			if matchAffix(e, value, test) {
+				return true
+			}
+		}
 	case map[string]any:
-		if ic, ok := p["equals-ignore-case"].(string); ok {
+		if ic, ok := p[opEqualsIgnoreCase].(string); ok {
 			return test(strings.ToLower(s), strings.ToLower(ic))
 		}
 	}
@@ -140,6 +213,16 @@ func matchAffix(spec, value any, test func(s, affix string) bool) bool {
 }
 
 func matchEqualsIgnoreCase(spec, value any) bool {
+	if list, ok := spec.([]any); ok {
+		for _, e := range list {
+			if matchEqualsIgnoreCase(e, value) {
+				return true
+			}
+		}
+
+		return false
+	}
+
 	want, ok := spec.(string)
 	if !ok {
 		return false
@@ -236,6 +319,16 @@ func matchCIDR(spec, value any) bool {
 }
 
 func matchWildcard(spec, value any) bool {
+	if list, ok := spec.([]any); ok {
+		for _, e := range list {
+			if matchWildcard(e, value) {
+				return true
+			}
+		}
+
+		return false
+	}
+
 	pattern, ok := spec.(string)
 	if !ok {
 		return false

--- a/internal/eventmatch/eventmatch_test.go
+++ b/internal/eventmatch/eventmatch_test.go
@@ -94,6 +94,100 @@ func TestMatchEventContentOperators(t *testing.T) {
 	}
 }
 
+// TestMatchEventOrOperator asserts AWS's documented `$or` logical-OR operator:
+// the pattern matches when any one of the sub-patterns matches, in addition to
+// every non-$or key. See eb-event-patterns-content-based-filtering.html.
+func TestMatchEventOrOperator(t *testing.T) {
+	pattern := mustPattern(t, `{"source":["aws.cloudwatch"],"$or":[{"metricName":["CPUUtilization"]},{"namespace":["AWS/EC2"]}]}`)
+
+	cases := []struct {
+		name  string
+		event map[string]any
+		want  bool
+	}{
+		{
+			name:  "first branch matches",
+			event: map[string]any{"source": "aws.cloudwatch", "metricName": "CPUUtilization", "namespace": "other"},
+			want:  true,
+		},
+		{
+			name:  "second branch matches",
+			event: map[string]any{"source": "aws.cloudwatch", "metricName": "other", "namespace": "AWS/EC2"},
+			want:  true,
+		},
+		{
+			name:  "neither branch matches",
+			event: map[string]any{"source": "aws.cloudwatch", "metricName": "other", "namespace": "other"},
+			want:  false,
+		},
+		{
+			name:  "non-or key fails despite branch match",
+			event: map[string]any{"source": "aws.ec2", "metricName": "CPUUtilization"},
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := eventmatch.MatchEvent(pattern, tc.event); got != tc.want {
+				t.Fatalf("MatchEvent = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMatchEventNestedOr asserts a `$or` nested inside the detail object, mixing
+// numeric branches as AWS documents in the complex $or example.
+func TestMatchEventNestedOr(t *testing.T) {
+	pattern := mustPattern(t, `{"detail":{"$or":[{"c-count":[{"numeric":[">",0,"<=",5]}]},{"d-count":[{"numeric":["<",10]}]}]}}`)
+
+	match := map[string]any{"detail": map[string]any{"c-count": float64(3), "d-count": float64(99)}}
+	if !eventmatch.MatchEvent(pattern, match) {
+		t.Fatal("expected c-count branch to match")
+	}
+
+	noMatch := map[string]any{"detail": map[string]any{"c-count": float64(99), "d-count": float64(99)}}
+	if eventmatch.MatchEvent(pattern, noMatch) {
+		t.Fatal("expected no branch to match")
+	}
+}
+
+// TestMatchAnythingButNestedLists asserts the AWS list forms for nested
+// anything-but operators (prefix/suffix/equals-ignore-case/wildcard): the value
+// matches only when it satisfies NONE of the listed sub-specs.
+func TestMatchAnythingButNestedLists(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern string
+		value   any
+		want    bool
+	}{
+		{"anything-but prefix list excludes init", `{"state":[{"anything-but":{"prefix":["init","stop"]}}]}`, "init-foo", false},
+		{"anything-but prefix list excludes stop", `{"state":[{"anything-but":{"prefix":["init","stop"]}}]}`, "stopped", false},
+		{"anything-but prefix list allows other", `{"state":[{"anything-but":{"prefix":["init","stop"]}}]}`, "running", true},
+		{"anything-but suffix list excludes txt", `{"f":[{"anything-but":{"suffix":[".txt",".rtf"]}}]}`, "a.txt", false},
+		{"anything-but suffix list allows png", `{"f":[{"anything-but":{"suffix":[".txt",".rtf"]}}]}`, "a.png", true},
+		{"anything-but ignore-case list excludes", `{"state":[{"anything-but":{"equals-ignore-case":["initializing","stopped"]}}]}`, "INITIALIZING", false},
+		{"anything-but ignore-case list allows", `{"state":[{"anything-but":{"equals-ignore-case":["initializing","stopped"]}}]}`, "running", true},
+		{"anything-but wildcard list excludes lib", `{"p":[{"anything-but":{"wildcard":["*/lib/*","*/bin/*"]}}]}`, "/usr/lib/x", false},
+		{"anything-but wildcard list allows other", `{"p":[{"anything-but":{"wildcard":["*/lib/*","*/bin/*"]}}]}`, "/usr/share/x", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := mustPattern(t, tc.pattern)
+			var allowed []any
+			for _, v := range p {
+				allowed, _ = v.([]any)
+			}
+
+			if got := eventmatch.MatchLeaf(allowed, tc.value, true); got != tc.want {
+				t.Fatalf("MatchLeaf = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestMatchEventArrayValueIntersection(t *testing.T) {
 	pattern := mustPattern(t, `{"resources":["arn:2"]}`)
 	event := map[string]any{"resources": []any{"arn:1", "arn:2"}}

--- a/internal/eventmatch/eventmatch_test.go
+++ b/internal/eventmatch/eventmatch_test.go
@@ -1,0 +1,114 @@
+package eventmatch_test
+
+import (
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/internal/eventmatch"
+)
+
+func mustPattern(t *testing.T, raw string) map[string]any {
+	t.Helper()
+
+	p, ok := eventmatch.ParsePattern(raw)
+	if !ok {
+		t.Fatalf("ParsePattern(%q) failed", raw)
+	}
+
+	return p
+}
+
+func TestMatchEventNestedDetail(t *testing.T) {
+	pattern := mustPattern(t, `{"source":["my.app"],"detail":{"state":["running"]}}`)
+
+	cases := []struct {
+		name  string
+		event map[string]any
+		want  bool
+	}{
+		{
+			name:  "matches nested detail",
+			event: map[string]any{"source": "my.app", "detail": map[string]any{"state": "running"}},
+			want:  true,
+		},
+		{
+			name:  "nested detail value differs",
+			event: map[string]any{"source": "my.app", "detail": map[string]any{"state": "stopped"}},
+			want:  false,
+		},
+		{
+			name:  "nested detail field missing",
+			event: map[string]any{"source": "my.app", "detail": map[string]any{"other": "x"}},
+			want:  false,
+		},
+		{
+			name:  "source differs",
+			event: map[string]any{"source": "other.app", "detail": map[string]any{"state": "running"}},
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := eventmatch.MatchEvent(pattern, tc.event); got != tc.want {
+				t.Fatalf("MatchEvent = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchEventContentOperators(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern string
+		value   any
+		present bool
+		want    bool
+	}{
+		{"prefix hit", `{"source":[{"prefix":"aws."}]}`, "aws.ec2", true, true},
+		{"prefix miss", `{"source":[{"prefix":"aws."}]}`, "gcp.gce", true, false},
+		{"suffix hit", `{"source":[{"suffix":".png"}]}`, "photo.png", true, true},
+		{"anything-but hit", `{"source":[{"anything-but":"init"}]}`, "running", true, true},
+		{"anything-but miss", `{"source":[{"anything-but":"init"}]}`, "init", true, false},
+		{"anything-but list", `{"source":[{"anything-but":["a","b"]}]}`, "c", true, true},
+		{"exists true present", `{"source":[{"exists":true}]}`, "x", true, true},
+		{"exists true absent", `{"source":[{"exists":true}]}`, nil, false, false},
+		{"exists false absent", `{"source":[{"exists":false}]}`, nil, false, true},
+		{"numeric in range", `{"source":[{"numeric":[">",0,"<=",5]}]}`, float64(3), true, true},
+		{"numeric out of range", `{"source":[{"numeric":[">",0,"<=",5]}]}`, float64(9), true, false},
+		{"cidr hit", `{"source":[{"cidr":"10.0.0.0/24"}]}`, "10.0.0.5", true, true},
+		{"cidr miss", `{"source":[{"cidr":"10.0.0.0/24"}]}`, "10.0.1.5", true, false},
+		{"equals-ignore-case hit", `{"source":[{"equals-ignore-case":"AWS.ec2"}]}`, "aws.EC2", true, true},
+		{"wildcard hit", `{"source":[{"wildcard":"aws.*.event"}]}`, "aws.ec2.event", true, true},
+		{"wildcard miss", `{"source":[{"wildcard":"aws.*.event"}]}`, "aws.ec2.notice", true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := mustPattern(t, tc.pattern)
+			allowed, _ := p["source"].([]any)
+
+			if got := eventmatch.MatchLeaf(allowed, tc.value, tc.present); got != tc.want {
+				t.Fatalf("MatchLeaf = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchEventArrayValueIntersection(t *testing.T) {
+	pattern := mustPattern(t, `{"resources":["arn:2"]}`)
+	event := map[string]any{"resources": []any{"arn:1", "arn:2"}}
+
+	if !eventmatch.MatchEvent(pattern, event) {
+		t.Fatal("expected array intersection to match")
+	}
+}
+
+func TestParsePatternRejectsGarbage(t *testing.T) {
+	if _, ok := eventmatch.ParsePattern("not json"); ok {
+		t.Fatal("expected garbage pattern to fail parse")
+	}
+
+	if _, ok := eventmatch.ParsePattern(""); ok {
+		t.Fatal("expected empty pattern to fail parse")
+	}
+}

--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/eventmatch"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
@@ -463,12 +464,17 @@ func (m *Mock) PutEvents(ctx context.Context, events []driver.Event) (*driver.Pu
 	return result, nil
 }
 
-// deliverToTargets delivers an event to the SQS targets of matched rules,
-// wrapping it in the standard EventBridge event envelope.
+// deliverToTargets delivers an event to the SQS targets of matched rules. The
+// body delivered to each target is the event envelope by default, but is
+// replaced by the target's Input (constant), InputPath (selected subtree), or
+// InputTransformer (templated) when one is configured — matching how real
+// EventBridge shapes each target's payload independently.
 func (m *Mock) deliverToTargets(ctx context.Context, matched []driver.Rule, event *driver.Event) {
 	if m.sqs == nil {
 		return
 	}
+
+	envelope := m.eventEnvelope(event)
 
 	for i := range matched {
 		for _, t := range matched[i].Targets {
@@ -476,29 +482,36 @@ func (m *Mock) deliverToTargets(ctx context.Context, matched []driver.Rule, even
 				continue
 			}
 
-			detail := json.RawMessage(event.Detail)
-			if len(detail) == 0 {
-				detail = json.RawMessage("{}")
-			}
+			body := targetBody(&t, envelope)
 
-			body, err := json.Marshal(map[string]any{
-				"version":     "0",
-				"id":          event.ID,
-				"detail-type": event.DetailType,
-				"source":      event.Source,
-				"account":     m.opts.AccountID,
-				"time":        event.Time.UTC().Format(time.RFC3339),
-				"region":      m.opts.Region,
-				"resources":   event.Resources,
-				"detail":      detail,
-			})
-			if err != nil {
-				continue
-			}
-
-			_ = m.sqs.DeliverExternal(ctx, t.ARN, string(body))
+			_ = m.sqs.DeliverExternal(ctx, t.ARN, body)
 		}
 	}
+}
+
+// eventEnvelope renders the standard EventBridge delivery envelope for an event.
+func (m *Mock) eventEnvelope(event *driver.Event) []byte {
+	detail := json.RawMessage(event.Detail)
+	if len(detail) == 0 {
+		detail = json.RawMessage("{}")
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"version":     "0",
+		"id":          event.ID,
+		"detail-type": event.DetailType,
+		"source":      event.Source,
+		"account":     m.opts.AccountID,
+		"time":        event.Time.UTC().Format(time.RFC3339),
+		"region":      m.opts.Region,
+		"resources":   event.Resources,
+		"detail":      detail,
+	})
+	if err != nil {
+		return []byte("{}")
+	}
+
+	return body
 }
 
 // GetEventHistory retrieves event history for an event bus.
@@ -561,44 +574,50 @@ func generateEventID(event *driver.Event, now time.Time, index int) string {
 	return fmt.Sprintf("%x", hash[:16])
 }
 
+// matchesPattern reports whether an event satisfies an EventBridge event
+// pattern. An empty pattern matches everything (schedule-only rules). The
+// pattern is evaluated against the full event envelope — source, detail-type,
+// resources, and the nested detail object — using the shared content-filtering
+// engine (exact, nested, prefix/suffix/anything-but/exists/numeric/cidr/wildcard).
 func matchesPattern(event *driver.Event, pattern string) bool {
 	if pattern == "" {
 		return true
 	}
 
-	var p map[string]any
-	if err := json.Unmarshal([]byte(pattern), &p); err != nil {
-		return false
-	}
-
-	if sources, ok := p["source"]; ok {
-		if !matchesField(event.Source, sources) {
-			return false
-		}
-	}
-
-	if detailTypes, ok := p["detail-type"]; ok {
-		if !matchesField(event.DetailType, detailTypes) {
-			return false
-		}
-	}
-
-	return true
-}
-
-func matchesField(value string, allowed any) bool {
-	arr, ok := allowed.([]any)
+	p, ok := eventmatch.ParsePattern(pattern)
 	if !ok {
 		return false
 	}
 
-	for _, v := range arr {
-		if fmt.Sprintf("%v", v) == value {
-			return true
+	return eventmatch.MatchEvent(p, eventObject(event))
+}
+
+// eventObject renders an event into the JSON object shape EventBridge patterns
+// match against. The detail body is parsed so nested "detail" constraints can
+// reach into it; an unparsable detail is treated as an empty object.
+func eventObject(event *driver.Event) map[string]any {
+	obj := map[string]any{
+		"source":      event.Source,
+		"detail-type": event.DetailType,
+	}
+
+	if len(event.Resources) > 0 {
+		res := make([]any, len(event.Resources))
+		for i, r := range event.Resources {
+			res[i] = r
+		}
+
+		obj["resources"] = res
+	}
+
+	if event.Detail != "" {
+		var detail any
+		if err := json.Unmarshal([]byte(event.Detail), &detail); err == nil {
+			obj["detail"] = detail
 		}
 	}
 
-	return false
+	return obj
 }
 
 // UpdateEventBus replaces the mutable fields of an existing event bus —

--- a/providers/aws/eventbridge/filtering_test.go
+++ b/providers/aws/eventbridge/filtering_test.go
@@ -1,0 +1,89 @@
+package eventbridge_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	ebprovider "github.com/stackshy/cloudemu/v2/providers/aws/eventbridge"
+	sqsprovider "github.com/stackshy/cloudemu/v2/providers/aws/sqs"
+	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+)
+
+// deliveredCount publishes one event and reports how many messages landed in the
+// queue, exercising the full match -> deliver path.
+func deliveredCount(t *testing.T, pattern, source, detail string) int {
+	t.Helper()
+
+	ctx := context.Background()
+	opts := config.NewOptions()
+
+	sqs := sqsprovider.New(opts)
+	eb := ebprovider.New(opts)
+	eb.SetSQSDeliverer(sqs)
+
+	q, err := sqs.CreateQueue(ctx, mqdriver.QueueConfig{Name: "target"})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	if _, err := eb.PutRule(ctx, &ebdriver.RuleConfig{Name: "r", EventPattern: pattern}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if err := eb.PutTargets(ctx, "", "r", []ebdriver.Target{{ID: "1", ARN: q.ARN}}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, []ebdriver.Event{
+		{Source: source, DetailType: "t", Detail: detail},
+	}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	msgs, err := sqs.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: q.URL, MaxMessages: 10})
+	if err != nil {
+		t.Fatalf("ReceiveMessages: %v", err)
+	}
+
+	return len(msgs)
+}
+
+func TestEventBridgeNestedDetailFilter(t *testing.T) {
+	const pattern = `{"source":["my.app"],"detail":{"state":["running"]}}`
+
+	if got := deliveredCount(t, pattern, "my.app", `{"state":"running"}`); got != 1 {
+		t.Fatalf("matching detail: delivered %d, want 1", got)
+	}
+
+	if got := deliveredCount(t, pattern, "my.app", `{"state":"stopped"}`); got != 0 {
+		t.Fatalf("non-matching detail: delivered %d, want 0", got)
+	}
+}
+
+func TestEventBridgeContentOperatorFilter(t *testing.T) {
+	if got := deliveredCount(t, `{"source":[{"prefix":"aws."}]}`, "aws.ec2", `{}`); got != 1 {
+		t.Fatalf("prefix hit: delivered %d, want 1", got)
+	}
+
+	if got := deliveredCount(t, `{"source":[{"prefix":"aws."}]}`, "gcp.gce", `{}`); got != 0 {
+		t.Fatalf("prefix miss: delivered %d, want 0", got)
+	}
+
+	if got := deliveredCount(t, `{"detail":{"count":[{"numeric":[">",10]}]}}`, "app", `{"count":42}`); got != 1 {
+		t.Fatalf("numeric hit: delivered %d, want 1", got)
+	}
+
+	if got := deliveredCount(t, `{"detail":{"count":[{"numeric":[">",10]}]}}`, "app", `{"count":5}`); got != 0 {
+		t.Fatalf("numeric miss: delivered %d, want 0", got)
+	}
+
+	if got := deliveredCount(t, `{"detail":{"state":[{"exists":true}]}}`, "app", `{"state":"x"}`); got != 1 {
+		t.Fatalf("exists hit: delivered %d, want 1", got)
+	}
+
+	if got := deliveredCount(t, `{"detail":{"state":[{"exists":true}]}}`, "app", `{"other":"x"}`); got != 0 {
+		t.Fatalf("exists miss: delivered %d, want 0", got)
+	}
+}

--- a/providers/aws/eventbridge/target_input.go
+++ b/providers/aws/eventbridge/target_input.go
@@ -1,0 +1,131 @@
+package eventbridge
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+)
+
+// targetBody computes the payload EventBridge delivers to a single target given
+// the rendered event envelope. Precedence mirrors real EventBridge, where a
+// target carries at most one of these: InputTransformer > Input > InputPath >
+// the raw envelope.
+func targetBody(t *driver.Target, envelope []byte) string {
+	if t.InputTransformer != "" {
+		if body, ok := applyInputTransformer(t.InputTransformer, envelope); ok {
+			return body
+		}
+	}
+
+	if t.Input != "" {
+		return t.Input
+	}
+
+	if t.InputPath != "" {
+		if sub, ok := extractPath(envelope, t.InputPath); ok {
+			return jsonToString(sub)
+		}
+	}
+
+	return string(envelope)
+}
+
+type inputTransformer struct {
+	InputPathsMap map[string]string `json:"InputPathsMap"`
+	InputTemplate string            `json:"InputTemplate"`
+}
+
+// applyInputTransformer substitutes each InputPathsMap variable (extracted from
+// the envelope by its JSONPath) into InputTemplate. When the template is a JSON
+// string literal, the delivered body is its unquoted value — matching how
+// EventBridge delivers a quoted transformer template.
+func applyInputTransformer(raw string, envelope []byte) (string, bool) {
+	var it inputTransformer
+	if err := json.Unmarshal([]byte(raw), &it); err != nil || it.InputTemplate == "" {
+		return "", false
+	}
+
+	result := it.InputTemplate
+
+	for name, path := range it.InputPathsMap {
+		val, ok := extractPath(envelope, path)
+		if !ok {
+			val = json.RawMessage("null")
+		}
+
+		result = strings.ReplaceAll(result, "<"+name+">", templateText(val))
+	}
+
+	trimmed := strings.TrimSpace(it.InputTemplate)
+	if strings.HasPrefix(trimmed, "\"") && strings.HasSuffix(trimmed, "\"") {
+		var unquoted string
+		if err := json.Unmarshal([]byte(result), &unquoted); err == nil {
+			return unquoted, true
+		}
+	}
+
+	return result, true
+}
+
+// templateText renders an extracted JSON value for substitution into a
+// transformer template: a JSON string yields its raw (unquoted) content, so a
+// quoted placeholder such as "<st>" stays valid JSON; any other value yields
+// its compact JSON form.
+func templateText(val json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(val, &s); err == nil {
+		return s
+	}
+
+	return string(val)
+}
+
+// extractPath resolves a dotted JSONPath (e.g. "$.detail.state") against the
+// envelope, returning the selected value as raw JSON. Only the "$"-rooted
+// dotted form EventBridge transformers use is supported.
+func extractPath(envelope []byte, path string) (json.RawMessage, bool) {
+	if path == "" {
+		return nil, false
+	}
+
+	var cur any
+	if err := json.Unmarshal(envelope, &cur); err != nil {
+		return nil, false
+	}
+
+	segments := strings.Split(strings.TrimPrefix(path, "$"), ".")
+	for _, seg := range segments {
+		if seg == "" {
+			continue
+		}
+
+		obj, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+
+		cur, ok = obj[seg]
+		if !ok {
+			return nil, false
+		}
+	}
+
+	out, err := json.Marshal(cur)
+	if err != nil {
+		return nil, false
+	}
+
+	return out, true
+}
+
+// jsonToString renders selected JSON for delivery: a JSON string is delivered as
+// its unquoted content; any other value as its compact JSON form.
+func jsonToString(val json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(val, &s); err == nil {
+		return s
+	}
+
+	return string(val)
+}

--- a/providers/aws/eventbridge/target_input_test.go
+++ b/providers/aws/eventbridge/target_input_test.go
@@ -1,0 +1,105 @@
+package eventbridge_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	ebprovider "github.com/stackshy/cloudemu/v2/providers/aws/eventbridge"
+	sqsprovider "github.com/stackshy/cloudemu/v2/providers/aws/sqs"
+	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+)
+
+// deliverWithTarget publishes one event to a rule with the given target and
+// returns the single delivered body.
+func deliverWithTarget(t *testing.T, target ebdriver.Target, source, detail string) string {
+	t.Helper()
+
+	ctx := context.Background()
+	opts := config.NewOptions()
+
+	sqs := sqsprovider.New(opts)
+	eb := ebprovider.New(opts)
+	eb.SetSQSDeliverer(sqs)
+
+	q, err := sqs.CreateQueue(ctx, mqdriver.QueueConfig{Name: "target"})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	target.ARN = q.ARN
+
+	if _, err := eb.PutRule(ctx, &ebdriver.RuleConfig{Name: "r", EventPattern: `{"source":["` + source + `"]}`}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if err := eb.PutTargets(ctx, "", "r", []ebdriver.Target{target}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, []ebdriver.Event{
+		{Source: source, DetailType: "t", Detail: detail},
+	}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	msgs, err := sqs.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: q.URL, MaxMessages: 10})
+	if err != nil {
+		t.Fatalf("ReceiveMessages: %v", err)
+	}
+
+	if len(msgs) != 1 {
+		t.Fatalf("delivered %d messages, want 1", len(msgs))
+	}
+
+	return msgs[0].Body
+}
+
+func TestEventBridgeInputTransformer(t *testing.T) {
+	it, _ := json.Marshal(map[string]any{
+		"InputPathsMap": map[string]string{"st": "$.detail.state"},
+		"InputTemplate": `"state is <st>"`,
+	})
+
+	body := deliverWithTarget(t, ebdriver.Target{ID: "1", InputTransformer: string(it)}, "app", `{"state":"ok"}`)
+
+	if body != "state is ok" {
+		t.Fatalf("InputTransformer body = %q, want %q", body, "state is ok")
+	}
+}
+
+func TestEventBridgeConstantInput(t *testing.T) {
+	body := deliverWithTarget(t, ebdriver.Target{ID: "1", Input: `{"hello":"world"}`}, "app", `{"state":"ok"}`)
+
+	if body != `{"hello":"world"}` {
+		t.Fatalf("constant Input body = %q, want the constant", body)
+	}
+}
+
+func TestEventBridgeInputPath(t *testing.T) {
+	body := deliverWithTarget(t, ebdriver.Target{ID: "1", InputPath: "$.detail"}, "app", `{"state":"ok"}`)
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("InputPath body not JSON: %v (%s)", err, body)
+	}
+
+	if got["state"] != "ok" || len(got) != 1 {
+		t.Fatalf("InputPath body = %s, want just the detail subtree", body)
+	}
+}
+
+func TestEventBridgeDefaultEnvelopeUnchanged(t *testing.T) {
+	body := deliverWithTarget(t, ebdriver.Target{ID: "1"}, "app", `{"state":"ok"}`)
+
+	var env map[string]any
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("envelope not JSON: %v", err)
+	}
+
+	if env["source"] != "app" || env["detail-type"] != "t" {
+		t.Fatalf("default envelope malformed: %s", body)
+	}
+}

--- a/providers/aws/sns/filter_policy.go
+++ b/providers/aws/sns/filter_policy.go
@@ -1,0 +1,67 @@
+package sns
+
+import (
+	"encoding/json"
+
+	"github.com/stackshy/cloudemu/v2/internal/eventmatch"
+	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+)
+
+// rawDeliveryEnabled reports whether the subscription has RawMessageDelivery set
+// to "true", in which case SNS delivers the bare message body to the endpoint.
+func rawDeliveryEnabled(sub *driver.SubscriptionInfo) bool {
+	return sub.Attributes["RawMessageDelivery"] == "true"
+}
+
+// subscriptionAccepts reports whether a publish satisfies the subscription's
+// filter policy. A subscription with no filter policy accepts every message.
+// FilterPolicyScope selects whether the policy is matched against the message
+// attributes (default) or the JSON message body.
+func subscriptionAccepts(sub *driver.SubscriptionInfo, input *driver.PublishInput) bool {
+	raw := sub.Attributes["FilterPolicy"]
+	if raw == "" {
+		return true
+	}
+
+	policy, ok := eventmatch.ParsePattern(raw)
+	if !ok {
+		return true
+	}
+
+	if sub.Attributes["FilterPolicyScope"] == "MessageBody" {
+		return matchesMessageBody(policy, input.Message)
+	}
+
+	return matchesMessageAttributes(policy, input.Attributes)
+}
+
+// matchesMessageAttributes evaluates a filter policy against the message
+// attributes. Each policy key must name an attribute whose value satisfies the
+// key's constraint list; a key absent from the message only matches via an
+// {"exists": false} constraint.
+func matchesMessageAttributes(policy map[string]any, attrs map[string]string) bool {
+	for key, constraint := range policy {
+		allowed, ok := constraint.([]any)
+		if !ok {
+			return false
+		}
+
+		value, present := attrs[key]
+		if !eventmatch.MatchLeaf(allowed, value, present) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// matchesMessageBody evaluates a filter policy against the JSON message body,
+// recursing into nested body properties like an EventBridge pattern.
+func matchesMessageBody(policy map[string]any, message string) bool {
+	var body map[string]any
+	if err := json.Unmarshal([]byte(message), &body); err != nil {
+		return false
+	}
+
+	return eventmatch.MatchEvent(policy, body)
+}

--- a/providers/aws/sns/filter_policy.go
+++ b/providers/aws/sns/filter_policy.go
@@ -41,6 +41,16 @@ func subscriptionAccepts(sub *driver.SubscriptionInfo, input *driver.PublishInpu
 // {"exists": false} constraint.
 func matchesMessageAttributes(policy map[string]any, attrs map[string]string) bool {
 	for key, constraint := range policy {
+		if key == "$or" {
+			if subs, ok := constraint.([]any); ok && eventmatch.IsOrClause(subs) {
+				if !anySubAttributes(subs, attrs) {
+					return false
+				}
+
+				continue
+			}
+		}
+
 		allowed, ok := constraint.([]any)
 		if !ok {
 			return false
@@ -53,6 +63,17 @@ func matchesMessageAttributes(policy map[string]any, attrs map[string]string) bo
 	}
 
 	return true
+}
+
+// anySubAttributes reports whether any $or sub-policy matches the attributes.
+func anySubAttributes(subs []any, attrs map[string]string) bool {
+	for _, s := range subs {
+		if sub, ok := s.(map[string]any); ok && matchesMessageAttributes(sub, attrs) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // matchesMessageBody evaluates a filter policy against the JSON message body,

--- a/providers/aws/sns/filter_policy_test.go
+++ b/providers/aws/sns/filter_policy_test.go
@@ -1,0 +1,107 @@
+package sns_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	snsprovider "github.com/stackshy/cloudemu/v2/providers/aws/sns"
+	sqsprovider "github.com/stackshy/cloudemu/v2/providers/aws/sqs"
+	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+	sndriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+)
+
+// snsToSQS wires an SNS topic to an SQS queue, applies the given subscription
+// attributes, publishes one message, and returns the delivered bodies.
+func snsToSQS(t *testing.T, subAttrs map[string]string, msg string, attrs map[string]string) []string {
+	t.Helper()
+
+	ctx := context.Background()
+	opts := config.NewOptions()
+
+	sqs := sqsprovider.New(opts)
+	sns := snsprovider.New(opts)
+	sns.SetSQSDeliverer(sqs)
+
+	q, err := sqs.CreateQueue(ctx, mqdriver.QueueConfig{Name: "inbox"})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	topic, err := sns.CreateTopic(ctx, sndriver.TopicConfig{Name: "feed"})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	sub, err := sns.Subscribe(ctx, sndriver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "sqs", Endpoint: q.ARN,
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	for k, v := range subAttrs {
+		if err := sns.SetSubscriptionAttribute(ctx, sub.ID, k, v); err != nil {
+			t.Fatalf("SetSubscriptionAttribute(%s): %v", k, err)
+		}
+	}
+
+	if _, err := sns.Publish(ctx, sndriver.PublishInput{
+		TopicID: topic.Name, Message: msg, Attributes: attrs,
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	msgs, err := sqs.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: q.URL, MaxMessages: 10})
+	if err != nil {
+		t.Fatalf("ReceiveMessages: %v", err)
+	}
+
+	bodies := make([]string, len(msgs))
+	for i := range msgs {
+		bodies[i] = msgs[i].Body
+	}
+
+	return bodies
+}
+
+func TestSNSFilterPolicyGatesDelivery(t *testing.T) {
+	attrs := map[string]string{"FilterPolicy": `{"color":["red"]}`}
+
+	if got := snsToSQS(t, attrs, "hi", map[string]string{"color": "red"}); len(got) != 1 {
+		t.Fatalf("matching attribute: delivered %d, want 1", len(got))
+	}
+
+	if got := snsToSQS(t, attrs, "hi", map[string]string{"color": "blue"}); len(got) != 0 {
+		t.Fatalf("non-matching attribute: delivered %d, want 0", len(got))
+	}
+
+	if got := snsToSQS(t, attrs, "hi", nil); len(got) != 0 {
+		t.Fatalf("absent attribute: delivered %d, want 0", len(got))
+	}
+}
+
+func TestSNSRawMessageDelivery(t *testing.T) {
+	attrs := map[string]string{"RawMessageDelivery": "true"}
+
+	got := snsToSQS(t, attrs, "hello-raw", map[string]string{"env": "prod"})
+	if len(got) != 1 {
+		t.Fatalf("delivered %d, want 1", len(got))
+	}
+
+	if got[0] != "hello-raw" {
+		t.Fatalf("raw delivery body = %q, want %q", got[0], "hello-raw")
+	}
+
+	// A non-raw subscription still receives the Notification envelope.
+	env := snsToSQS(t, nil, "hello-env", nil)
+	if len(env) != 1 {
+		t.Fatalf("envelope delivery count = %d, want 1", len(env))
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(env[0]), &parsed); err != nil || parsed["Type"] != "Notification" {
+		t.Fatalf("non-raw body should be the Notification envelope: %s", env[0])
+	}
+}

--- a/providers/aws/sns/filter_policy_test.go
+++ b/providers/aws/sns/filter_policy_test.go
@@ -82,6 +82,24 @@ func TestSNSFilterPolicyGatesDelivery(t *testing.T) {
 	}
 }
 
+// TestSNSFilterPolicyOrOperator asserts the AWS `$or` operator across message
+// attributes: delivery happens when any $or branch matches. See and-or-logic.html.
+func TestSNSFilterPolicyOrOperator(t *testing.T) {
+	attrs := map[string]string{"FilterPolicy": `{"$or":[{"color":["red"]},{"size":["large"]}]}`}
+
+	if got := snsToSQS(t, attrs, "hi", map[string]string{"color": "red"}); len(got) != 1 {
+		t.Fatalf("first branch: delivered %d, want 1", len(got))
+	}
+
+	if got := snsToSQS(t, attrs, "hi", map[string]string{"size": "large"}); len(got) != 1 {
+		t.Fatalf("second branch: delivered %d, want 1", len(got))
+	}
+
+	if got := snsToSQS(t, attrs, "hi", map[string]string{"color": "blue", "size": "small"}); len(got) != 0 {
+		t.Fatalf("no branch matches: delivered %d, want 0", len(got))
+	}
+}
+
 func TestSNSRawMessageDelivery(t *testing.T) {
 	attrs := map[string]string{"RawMessageDelivery": "true"}
 

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -363,31 +363,56 @@ func (m *Mock) fanOutToSQS(ctx context.Context, td *topicData, msgID string, inp
 			continue
 		}
 
-		env := map[string]any{
-			"Type":      "Notification",
-			"MessageId": msgID,
-			"TopicArn":  td.info.ResourceID,
-			"Subject":   input.Subject,
-			"Message":   input.Message,
-			"Timestamp": m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		// A filter policy gates delivery: the message reaches the subscriber
+		// only when its attributes (or body) satisfy the policy.
+		if !subscriptionAccepts(&sub, &input) {
+			continue
 		}
 
-		// Real SNS carries publish MessageAttributes into the SQS envelope as
-		// {name: {"Type": "String", "Value": v}}; preserve them end-to-end.
-		if len(input.Attributes) > 0 {
-			attrs := make(map[string]any, len(input.Attributes))
-			for k, v := range input.Attributes {
-				attrs[k] = map[string]string{"Type": "String", "Value": v}
-			}
+		// With raw message delivery enabled, SNS strips its metadata and sends
+		// the published message body as-is instead of the Notification envelope.
+		if rawDeliveryEnabled(&sub) {
+			_ = m.sqs.DeliverExternal(ctx, sub.Endpoint, input.Message)
 
-			env["MessageAttributes"] = attrs
+			continue
 		}
 
-		envelope, err := json.Marshal(env)
+		envelope, err := m.notificationEnvelope(td, msgID, input)
 		if err != nil {
 			continue
 		}
 
-		_ = m.sqs.DeliverExternal(ctx, sub.Endpoint, string(envelope))
+		_ = m.sqs.DeliverExternal(ctx, sub.Endpoint, envelope)
 	}
+}
+
+// notificationEnvelope builds the SNS Notification JSON that wraps a published
+// message for a non-raw SQS subscription.
+func (m *Mock) notificationEnvelope(td *topicData, msgID string, input driver.PublishInput) (string, error) {
+	env := map[string]any{
+		"Type":      "Notification",
+		"MessageId": msgID,
+		"TopicArn":  td.info.ResourceID,
+		"Subject":   input.Subject,
+		"Message":   input.Message,
+		"Timestamp": m.opts.Clock.Now().UTC().Format(time.RFC3339),
+	}
+
+	// Real SNS carries publish MessageAttributes into the SQS envelope as
+	// {name: {"Type": "String", "Value": v}}; preserve them end-to-end.
+	if len(input.Attributes) > 0 {
+		attrs := make(map[string]any, len(input.Attributes))
+		for k, v := range input.Attributes {
+			attrs[k] = map[string]string{"Type": "String", "Value": v}
+		}
+
+		env["MessageAttributes"] = attrs
+	}
+
+	body, err := json.Marshal(env)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
 }

--- a/server/aws/eventbridge/delivery_sdk_test.go
+++ b/server/aws/eventbridge/delivery_sdk_test.go
@@ -1,0 +1,208 @@
+package eventbridge_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newEBAndSQS wires a single wire server serving both EventBridge and SQS from
+// one cloud, so PutEvents can fan out to a real SQS queue over the SDKs.
+func newEBAndSQS(t *testing.T) (*awseb.Client, *awssqs.Client) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{EventBridge: cloud.EventBridge, SQS: cloud.SQS})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	eb := awseb.NewFromConfig(cfg, func(o *awseb.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+	sqs := awssqs.NewFromConfig(cfg, func(o *awssqs.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+
+	return eb, sqs
+}
+
+func makeQueue(t *testing.T, sqs *awssqs.Client, name string) (url, arn string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	q, err := sqs.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String(name)})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	attrs, err := sqs.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       q.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameQueueArn},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes: %v", err)
+	}
+
+	return aws.ToString(q.QueueUrl), attrs.Attributes["QueueArn"]
+}
+
+func receiveOne(t *testing.T, sqs *awssqs.Client, url string) (body string, count int) {
+	t.Helper()
+
+	out, err := sqs.ReceiveMessage(context.Background(), &awssqs.ReceiveMessageInput{
+		QueueUrl:            aws.String(url),
+		MaxNumberOfMessages: 10,
+	})
+	if err != nil {
+		t.Fatalf("ReceiveMessage: %v", err)
+	}
+
+	if len(out.Messages) == 0 {
+		return "", 0
+	}
+
+	return aws.ToString(out.Messages[0].Body), len(out.Messages)
+}
+
+func TestSDKEventBridgeNestedDetailDelivery(t *testing.T) {
+	eb, sqs := newEBAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := makeQueue(t, sqs, "eb-detail")
+
+	if _, err := eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventPattern: aws.String(`{"source":["my.app"],"detail":{"state":["running"]}}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule:    aws.String("r"),
+		Targets: []ebtypes.Target{{Id: aws.String("1"), Arn: aws.String(arn)}},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	// Non-matching detail must not be delivered.
+	if _, err := eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("my.app"), DetailType: aws.String("t"), Detail: aws.String(`{"state":"stopped"}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents(stopped): %v", err)
+	}
+
+	if _, count := receiveOne(t, sqs, url); count != 0 {
+		t.Fatalf("non-matching detail delivered %d messages, want 0", count)
+	}
+
+	// Matching detail is delivered.
+	if _, err := eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("my.app"), DetailType: aws.String("t"), Detail: aws.String(`{"state":"running"}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents(running): %v", err)
+	}
+
+	if _, count := receiveOne(t, sqs, url); count != 1 {
+		t.Fatalf("matching detail delivered %d messages, want 1", count)
+	}
+}
+
+func TestSDKEventBridgeInputTransformerDelivery(t *testing.T) {
+	eb, sqs := newEBAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := makeQueue(t, sqs, "eb-transform")
+
+	if _, err := eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventPattern: aws.String(`{"source":["app"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule: aws.String("r"),
+		Targets: []ebtypes.Target{{
+			Id:  aws.String("1"),
+			Arn: aws.String(arn),
+			InputTransformer: &ebtypes.InputTransformer{
+				InputPathsMap: map[string]string{"st": "$.detail.state"},
+				InputTemplate: aws.String(`"state is <st>"`),
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("app"), DetailType: aws.String("t"), Detail: aws.String(`{"state":"ok"}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	body, count := receiveOne(t, sqs, url)
+	if count != 1 {
+		t.Fatalf("delivered %d messages, want 1", count)
+	}
+
+	if body != "state is ok" {
+		t.Fatalf("transformed body = %q, want %q", body, "state is ok")
+	}
+}
+
+func TestSDKEventBridgeConstantInputDelivery(t *testing.T) {
+	eb, sqs := newEBAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := makeQueue(t, sqs, "eb-const")
+
+	if _, err := eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventPattern: aws.String(`{"source":["app"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule: aws.String("r"),
+		Targets: []ebtypes.Target{{
+			Id:    aws.String("1"),
+			Arn:   aws.String(arn),
+			Input: aws.String(`{"hello":"world"}`),
+		}},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("app"), DetailType: aws.String("t"), Detail: aws.String(`{"state":"ok"}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	body, count := receiveOne(t, sqs, url)
+	if count != 1 {
+		t.Fatalf("delivered %d messages, want 1", count)
+	}
+
+	if body != `{"hello":"world"}` {
+		t.Fatalf("constant input body = %q, want the constant", body)
+	}
+}

--- a/server/aws/sns/filter_sdk_test.go
+++ b/server/aws/sns/filter_sdk_test.go
@@ -1,0 +1,188 @@
+package sns_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+func newSNSAndSQS(t *testing.T) (*awssns.Client, *awssqs.Client) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{SNS: cloud.SNS, SQS: cloud.SQS})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	sns := awssns.NewFromConfig(cfg, func(o *awssns.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+	sqs := awssqs.NewFromConfig(cfg, func(o *awssqs.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+
+	return sns, sqs
+}
+
+func snsQueue(t *testing.T, sqs *awssqs.Client, name string) (url, arn string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	q, err := sqs.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String(name)})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	attrs, err := sqs.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       q.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameQueueArn},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes: %v", err)
+	}
+
+	return aws.ToString(q.QueueUrl), attrs.Attributes["QueueArn"]
+}
+
+func drain(t *testing.T, sqs *awssqs.Client, url string) []string {
+	t.Helper()
+
+	out, err := sqs.ReceiveMessage(context.Background(), &awssqs.ReceiveMessageInput{
+		QueueUrl:            aws.String(url),
+		MaxNumberOfMessages: 10,
+	})
+	if err != nil {
+		t.Fatalf("ReceiveMessage: %v", err)
+	}
+
+	bodies := make([]string, len(out.Messages))
+	for i := range out.Messages {
+		bodies[i] = aws.ToString(out.Messages[i].Body)
+	}
+
+	return bodies
+}
+
+func TestSDKSNSFilterPolicyGatesDelivery(t *testing.T) {
+	sns, sqs := newSNSAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := snsQueue(t, sqs, "filtered")
+
+	topic, err := sns.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("feed")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	sub, err := sns.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn:              topic.TopicArn,
+		Protocol:              aws.String("sqs"),
+		Endpoint:              aws.String(arn),
+		ReturnSubscriptionArn: true,
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if _, err := sns.SetSubscriptionAttributes(ctx, &awssns.SetSubscriptionAttributesInput{
+		SubscriptionArn: sub.SubscriptionArn,
+		AttributeName:   aws.String("FilterPolicy"),
+		AttributeValue:  aws.String(`{"color":["red"]}`),
+	}); err != nil {
+		t.Fatalf("SetSubscriptionAttributes: %v", err)
+	}
+
+	publish := func(color string) {
+		if _, err := sns.Publish(ctx, &awssns.PublishInput{
+			TopicArn: topic.TopicArn,
+			Message:  aws.String("hi"),
+			MessageAttributes: map[string]snstypes.MessageAttributeValue{
+				"color": {DataType: aws.String("String"), StringValue: aws.String(color)},
+			},
+		}); err != nil {
+			t.Fatalf("Publish(%s): %v", color, err)
+		}
+	}
+
+	publish("blue")
+
+	if got := drain(t, sqs, url); len(got) != 0 {
+		t.Fatalf("blue message delivered %d, want 0 (filtered out)", len(got))
+	}
+
+	publish("red")
+
+	if got := drain(t, sqs, url); len(got) != 1 {
+		t.Fatalf("red message delivered %d, want 1", len(got))
+	}
+}
+
+func TestSDKSNSRawMessageDelivery(t *testing.T) {
+	sns, sqs := newSNSAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := snsQueue(t, sqs, "raw")
+
+	topic, err := sns.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("feed")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	sub, err := sns.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn:              topic.TopicArn,
+		Protocol:              aws.String("sqs"),
+		Endpoint:              aws.String(arn),
+		ReturnSubscriptionArn: true,
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if _, err := sns.SetSubscriptionAttributes(ctx, &awssns.SetSubscriptionAttributesInput{
+		SubscriptionArn: sub.SubscriptionArn,
+		AttributeName:   aws.String("RawMessageDelivery"),
+		AttributeValue:  aws.String("true"),
+	}); err != nil {
+		t.Fatalf("SetSubscriptionAttributes: %v", err)
+	}
+
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn: topic.TopicArn,
+		Message:  aws.String("hello-raw"),
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	got := drain(t, sqs, url)
+	if len(got) != 1 {
+		t.Fatalf("delivered %d, want 1", len(got))
+	}
+
+	if got[0] != "hello-raw" {
+		t.Fatalf("raw body = %q, want %q (no Notification envelope)", got[0], "hello-raw")
+	}
+
+	// Sanity: the raw body must not be the JSON envelope.
+	var env map[string]any
+	if json.Unmarshal([]byte(got[0]), &env) == nil && env["Type"] == "Notification" {
+		t.Fatalf("raw delivery still wrapped in envelope: %s", got[0])
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a batch of AWS-parity bugs in EventBridge and SNS message routing found by the deep real-user audit. All routing decisions and payload shaping now match the real AWS wire contract, verified with real aws-sdk-go-v2 clients against an in-process wire server.

A shared content-filtering engine (`internal/eventmatch`) implements the leaf model both services share (arrays of exact values / single-key operator objects), so EventBridge patterns and SNS filter policies evaluate identically.

## Findings addressed

1. **[BLOCKER] EventBridge nested `detail` matching** — patterns are now evaluated against the full event envelope (`source`, `detail-type`, `resources`, and the parsed nested `detail`). A `detail` constraint that the event does not satisfy means the event is not delivered.
2. **[BLOCKER] SNS FilterPolicy gates delivery** — a subscription's `FilterPolicy` is matched against the publish's message attributes (default scope) or JSON message body (`FilterPolicyScope=MessageBody`). A message that doesn't satisfy the policy is not delivered to that subscriber. `{"color":["red"]}` no longer receives `color=blue`.
3. **[HIGH] EventBridge InputTransformer** — targets with an `InputTransformer` deliver the transformed body: `InputPathsMap` variables are extracted by JSONPath and substituted into `InputTemplate`; a quoted template is delivered as its unquoted value.
4. **[HIGH] EventBridge content-filter operators** — `prefix`, `suffix`, `anything-but`, `exists`, `numeric`, `cidr`, `equals-ignore-case`, and `wildcard` are evaluated with real operator semantics (e.g. source `aws.ec2` matches `{"prefix":"aws."}`).
5. **[HIGH] SNS RawMessageDelivery** — with `RawMessageDelivery=true` on an SQS subscription, the bare message body is delivered instead of the JSON `Notification` envelope.
6. **[MEDIUM] EventBridge constant `Input` / `InputPath`** — a target with a constant `Input` receives exactly that constant; with `InputPath` it receives only the selected JSON subtree.

## Layering

No driver interface changed — the wire layer already parsed `Input`/`InputPath`/`InputTransformer` and `FilterPolicy`/`RawMessageDelivery` into existing driver fields; the fixes are in the provider mocks plus the new shared matcher. No coverage-doc regeneration required.

## Tests

- `internal/eventmatch`: unit tests for nested matching, every operator, and array intersection.
- Provider-level: EventBridge nested/content-operator gating, target Input/InputPath/InputTransformer delivery; SNS FilterPolicy gating and RawMessageDelivery.
- Real-SDK end-to-end: EventBridge + SQS and SNS + SQS wired into one wire server, asserting delivery counts and exact bodies over aws-sdk-go-v2.

Gates: `go build ./...`, `go vet`, `go test` (changed packages + root integration), `golangci-lint` all green.