### PR TITLE
fix(dynamodb-rds): GSI/LSI projection, BatchGetItem projection default, RDS clean error messages, Aurora cluster endpoints

### DIFF
--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -405,10 +405,11 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 
 	result.ScannedCount = scanned
 
-	// A query on a secondary index only exposes the index's projected
-	// attributes (KEYS_ONLY / INCLUDE); non-projected base-table attributes are
-	// not fetchable through the index.
-	if attrs, filtered := indexProjection(td.config, input.IndexName); filtered {
+	// A GSI query only exposes the index's projected attributes; an LSI query
+	// with no projection defaults to ALL_PROJECTED_ATTRIBUTES. When a
+	// ProjectionExpression is supplied, an LSI can fetch non-projected base-table
+	// attributes, so the full base item is left intact for the wire layer.
+	if attrs, filtered := indexProjection(td.config, input.IndexName, input.ProjectionRequested); filtered {
 		for i, it := range result.Items {
 			result.Items[i] = projectToIndex(it, attrs)
 		}
@@ -446,14 +447,27 @@ func resolveKeyFields(td *tableData, indexName string) (pkField, skField string,
 }
 
 // indexProjection returns the attribute set a secondary-index query/scan may
-// surface, and whether that set must be enforced. Per the DynamoDB GSI/LSI
-// contract a query on a secondary index cannot fetch base-table attributes that
-// are not projected: a KEYS_ONLY index exposes only the table and index key
-// attributes; INCLUDE adds the named non-key attributes; ALL passes everything
-// through. A nil-or-ALL projection returns filtered=false so items are
-// untouched. Caller must hold at least td's read lock (reads td.config only).
-func indexProjection(cfg driver.TableConfig, indexName string) (attrs map[string]struct{}, filtered bool) {
+// surface, and whether that set must be enforced. A GSI always enforces its
+// projection: a query on a GSI cannot fetch base-table attributes that are not
+// projected — KEYS_ONLY exposes only the table and index key attributes,
+// INCLUDE adds the named non-key attributes, ALL passes everything through.
+//
+// An LSI is different (per the LSI developer guide): it can transparently fetch
+// non-projected attributes from the base table. When the caller supplied a
+// ProjectionExpression (projectionRequested), the full base item — which
+// CloudEmu already holds in memory — is returned untouched so the wire layer can
+// select any attribute, matching AWS's functional result (CloudEmu does not
+// model the extra throughput cost). With no projection an index query defaults
+// to ALL_PROJECTED_ATTRIBUTES, so an LSI is still trimmed to its projected set.
+//
+// A nil-or-ALL projection returns filtered=false so items are untouched. Caller
+// must hold at least td's read lock (reads td.config only).
+func indexProjection(cfg driver.TableConfig, indexName string, projectionRequested bool) (attrs map[string]struct{}, filtered bool) {
 	if indexName == "" {
+		return nil, false
+	}
+
+	if projectionRequested && isLSI(cfg, indexName) {
 		return nil, false
 	}
 
@@ -475,6 +489,17 @@ func indexProjection(cfg driver.TableConfig, indexName string) (attrs map[string
 	}
 
 	return attrs, true
+}
+
+// isLSI reports whether indexName names a local secondary index on the table.
+func isLSI(cfg driver.TableConfig, indexName string) bool {
+	for _, lsi := range cfg.LSIs {
+		if lsi.Name == indexName {
+			return true
+		}
+	}
+
+	return false
 }
 
 // lookupIndexProjection resolves an index's projection type, key attributes and
@@ -674,7 +699,7 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 
 	result.ScannedCount = scanned
 
-	if attrs, filtered := indexProjection(td.config, input.IndexName); filtered {
+	if attrs, filtered := indexProjection(td.config, input.IndexName, input.ProjectionRequested); filtered {
 		for i, it := range result.Items {
 			result.Items[i] = projectToIndex(it, attrs)
 		}

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -42,6 +42,13 @@ const (
 	defaultStreamLimit = 100
 )
 
+// Secondary-index projection types.
+const (
+	projectionAll      = "ALL"
+	projectionKeysOnly = "KEYS_ONLY"
+	projectionInclude  = "INCLUDE"
+)
+
 var _ driver.Database = (*Mock)(nil)
 
 type tableData struct {
@@ -398,6 +405,15 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 
 	result.ScannedCount = scanned
 
+	// A query on a secondary index only exposes the index's projected
+	// attributes (KEYS_ONLY / INCLUDE); non-projected base-table attributes are
+	// not fetchable through the index.
+	if attrs, filtered := indexProjection(td.config, input.IndexName); filtered {
+		for i, it := range result.Items {
+			result.Items[i] = projectToIndex(it, attrs)
+		}
+	}
+
 	dims := map[string]string{"TableName": input.Table}
 	m.emitMetric("ConsumedReadCapacityUnits", float64(len(result.Items)), dims)
 	m.emitMetric("SuccessfulRequestCount", 1, dims)
@@ -427,6 +443,78 @@ func resolveKeyFields(td *tableData, indexName string) (pkField, skField string,
 	}
 
 	return "", "", cerrors.Newf(cerrors.NotFound, "index %s not found", indexName)
+}
+
+// indexProjection returns the attribute set a secondary-index query/scan may
+// surface, and whether that set must be enforced. Per the DynamoDB GSI/LSI
+// contract a query on a secondary index cannot fetch base-table attributes that
+// are not projected: a KEYS_ONLY index exposes only the table and index key
+// attributes; INCLUDE adds the named non-key attributes; ALL passes everything
+// through. A nil-or-ALL projection returns filtered=false so items are
+// untouched. Caller must hold at least td's read lock (reads td.config only).
+func indexProjection(cfg driver.TableConfig, indexName string) (attrs map[string]struct{}, filtered bool) {
+	if indexName == "" {
+		return nil, false
+	}
+
+	projType, idxPK, idxSK, nonKey := lookupIndexProjection(cfg, indexName)
+	if projType == "" || strings.EqualFold(projType, projectionAll) {
+		return nil, false
+	}
+
+	attrs = map[string]struct{}{}
+	addAttr(attrs, cfg.PartitionKey)
+	addAttr(attrs, cfg.SortKey)
+	addAttr(attrs, idxPK)
+	addAttr(attrs, idxSK)
+
+	if strings.EqualFold(projType, projectionInclude) {
+		for _, a := range nonKey {
+			addAttr(attrs, a)
+		}
+	}
+
+	return attrs, true
+}
+
+// lookupIndexProjection resolves an index's projection type, key attributes and
+// (for INCLUDE) non-key attributes. An LSI shares the table partition key.
+func lookupIndexProjection(cfg driver.TableConfig, indexName string) (projType, idxPK, idxSK string, nonKey []string) {
+	for _, gsi := range cfg.GSIs {
+		if gsi.Name == indexName {
+			return gsi.Projection, gsi.PartitionKey, gsi.SortKey, gsi.NonKeyAttributes
+		}
+	}
+
+	for _, lsi := range cfg.LSIs {
+		if lsi.Name == indexName {
+			return lsi.Projection, cfg.PartitionKey, lsi.SortKey, lsi.NonKeyAttributes
+		}
+	}
+
+	return "", "", "", nil
+}
+
+// addAttr records a non-empty attribute name in the set.
+func addAttr(attrs map[string]struct{}, name string) {
+	if name != "" {
+		attrs[name] = struct{}{}
+	}
+}
+
+// projectToIndex returns a copy of item retaining only the attributes an index
+// projects. Attributes absent from the item are simply not present, matching
+// the sparse nature of index projections.
+func projectToIndex(item map[string]any, attrs map[string]struct{}) map[string]any {
+	out := make(map[string]any, len(attrs))
+
+	for name := range attrs {
+		if v, ok := item[name]; ok {
+			out[name] = v
+		}
+	}
+
+	return out
 }
 
 // matchQueryItems returns the items matching the key condition and filter, plus
@@ -507,6 +595,38 @@ func passesFilter(node expr.Node, legacy []driver.ScanFilter, item map[string]an
 	return matchesFilters(item, legacy), nil
 }
 
+// scanItems walks the table's items, skipping expired ones and (for an index
+// scan) those lacking the index partition key, returning the filter-matched set
+// and the pre-filter scanned count.
+func (m *Mock) scanItems(
+	td *tableData, node expr.Node, input *driver.ScanInput, idxPK string,
+) (matched []map[string]any, scanned int, err error) {
+	for _, item := range td.items.All() {
+		if m.isItemExpired(td, item) {
+			continue
+		}
+
+		if idxPK != "" {
+			if _, ok := item[idxPK]; !ok {
+				continue
+			}
+		}
+
+		scanned++
+
+		ok, ferr := passesFilter(node, input.Filters, item)
+		if ferr != nil {
+			return nil, 0, ferr
+		}
+
+		if ok {
+			matched = append(matched, item)
+		}
+	}
+
+	return matched, scanned, nil
+}
+
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryResult, error) {
 	m.mu.RLock()
@@ -522,28 +642,20 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 		return nil, err
 	}
 
-	allItems := td.items.All()
+	// A scan on a secondary index only visits items carrying that index's
+	// partition key (a sparse index), so resolve it up front — this also
+	// validates the index exists.
+	var idxPK string
 
-	var (
-		matched []map[string]any
-		scanned int
-	)
-
-	for _, item := range allItems {
-		if m.isItemExpired(td, item) {
-			continue
+	if input.IndexName != "" {
+		if idxPK, _, err = resolveKeyFields(td, input.IndexName); err != nil {
+			return nil, err
 		}
+	}
 
-		scanned++
-
-		ok, ferr := passesFilter(node, input.Filters, item)
-		if ferr != nil {
-			return nil, ferr
-		}
-
-		if ok {
-			matched = append(matched, item)
-		}
+	matched, scanned, err := m.scanItems(td, node, &input, idxPK)
+	if err != nil {
+		return nil, err
 	}
 
 	limit := input.Limit
@@ -561,6 +673,12 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 	}
 
 	result.ScannedCount = scanned
+
+	if attrs, filtered := indexProjection(td.config, input.IndexName); filtered {
+		for i, it := range result.Items {
+			result.Items[i] = projectToIndex(it, attrs)
+		}
+	}
 
 	dims := map[string]string{"TableName": input.Table}
 	m.emitMetric("ConsumedReadCapacityUnits", float64(len(result.Items)), dims)

--- a/providers/aws/dynamodb/dynamodb_test.go
+++ b/providers/aws/dynamodb/dynamodb_test.go
@@ -988,3 +988,57 @@ func TestUpdateItemEmitsMetrics(t *testing.T) {
 	requireNoError(t, err)
 	assertEqual(t, true, len(result.Values) > 0)
 }
+
+// TestScanIndexProjectionAndSparse covers a Scan targeting a secondary index:
+// items lacking the index partition key are skipped (sparse index), and a
+// KEYS_ONLY / INCLUDE projection trims each returned item to its projected
+// attribute set.
+func TestScanIndexProjectionAndSparse(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	err := m.CreateTable(ctx, driver.TableConfig{
+		Name:         "t",
+		PartitionKey: "pk",
+		SortKey:      "sk",
+		GSIs: []driver.GSIConfig{
+			{Name: "keys", PartitionKey: "cat", Projection: "KEYS_ONLY"},
+			{Name: "inc", PartitionKey: "cat", Projection: "INCLUDE", NonKeyAttributes: []string{"price"}},
+		},
+	})
+	requireNoError(t, err)
+
+	requireNoError(t, m.PutItem(ctx, "t", map[string]any{
+		"pk": "u1", "sk": "s1", "cat": "books", "price": "10", "title": "x",
+	}))
+	// This item lacks "cat", so it is not projected into either index.
+	requireNoError(t, m.PutItem(ctx, "t", map[string]any{"pk": "u2", "sk": "s2", "title": "y"}))
+
+	keysRes, err := m.Scan(ctx, driver.ScanInput{Table: "t", IndexName: "keys"})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(keysRes.Items))
+	assertEqual(t, 3, len(keysRes.Items[0])) // pk, sk, cat only
+
+	if _, ok := keysRes.Items[0]["price"]; ok {
+		t.Fatal("KEYS_ONLY scan must not surface a non-projected attribute")
+	}
+
+	incRes, err := m.Scan(ctx, driver.ScanInput{Table: "t", IndexName: "inc"})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(incRes.Items))
+	assertEqual(t, 4, len(incRes.Items[0])) // pk, sk, cat, price
+
+	if _, ok := incRes.Items[0]["title"]; ok {
+		t.Fatal("INCLUDE scan must not surface an attribute outside NonKeyAttributes")
+	}
+}
+
+// TestScanUnknownIndex covers that a Scan against a non-existent index errors.
+func TestScanUnknownIndex(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	createTestTable(m, "t")
+
+	_, err := m.Scan(ctx, driver.ScanInput{Table: "t", IndexName: "nope"})
+	assertError(t, err, true)
+}

--- a/providers/aws/rds/aurora.go
+++ b/providers/aws/rds/aurora.go
@@ -65,27 +65,80 @@ func (m *Mock) DescribeDBClusterEndpoints(_ context.Context, clusterID, endpoint
 	defer m.mu.RUnlock()
 
 	if endpointID != "" {
-		ep, ok := m.clusterEndpoints.Get(endpointID)
-		if !ok {
-			return nil, cerrors.Newf(cerrors.NotFound, "DB cluster endpoint %q not found", endpointID)
-		}
-
-		return []rdsdriver.ClusterEndpoint{cloneEndpoint(ep)}, nil
+		return m.describeClusterEndpointByID(endpointID)
 	}
 
-	all := m.clusterEndpoints.SortedValues()
+	// Aurora auto-provisions a WRITER and a READER endpoint per cluster at
+	// create time; DescribeDBClusterEndpoints returns them alongside any custom
+	// endpoints, even before a custom endpoint exists.
+	out := m.builtInClusterEndpoints(clusterID)
 
-	out := make([]rdsdriver.ClusterEndpoint, 0, len(all))
-
-	for i := range all {
-		if clusterID != "" && all[i].ClusterID != clusterID {
+	custom := m.clusterEndpoints.SortedValues()
+	for i := range custom {
+		if clusterID != "" && custom[i].ClusterID != clusterID {
 			continue
 		}
 
-		out = append(out, cloneEndpoint(all[i]))
+		out = append(out, cloneEndpoint(custom[i]))
 	}
 
 	return out, nil
+}
+
+// describeClusterEndpointByID resolves a single endpoint by identifier. A
+// built-in endpoint carries the cluster's own identifier, so a lookup that
+// matches a cluster returns its WRITER + READER endpoints; otherwise it is a
+// custom endpoint.
+func (m *Mock) describeClusterEndpointByID(endpointID string) ([]rdsdriver.ClusterEndpoint, error) {
+	if m.clusters.Has(endpointID) {
+		return m.builtInClusterEndpoints(endpointID), nil
+	}
+
+	ep, ok := m.clusterEndpoints.Get(endpointID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "DB cluster endpoint %q not found", endpointID)
+	}
+
+	return []rdsdriver.ClusterEndpoint{cloneEndpoint(ep)}, nil
+}
+
+// builtInClusterEndpoints returns the auto-provisioned WRITER and READER
+// endpoints for the matching cluster(s). A built-in endpoint's identifier is
+// the cluster identifier and it carries no ARN, matching real Aurora.
+func (m *Mock) builtInClusterEndpoints(clusterID string) []rdsdriver.ClusterEndpoint {
+	var clusters []rdsdriver.Cluster
+
+	if clusterID != "" {
+		c, ok := m.clusters.Get(clusterID)
+		if !ok {
+			return nil
+		}
+
+		clusters = []rdsdriver.Cluster{c}
+	} else {
+		clusters = m.clusters.SortedValues()
+	}
+
+	const builtInPerCluster = 2 // one WRITER and one READER
+
+	out := make([]rdsdriver.ClusterEndpoint, 0, len(clusters)*builtInPerCluster)
+	for i := range clusters {
+		out = append(out,
+			builtInEndpoint(&clusters[i], "WRITER", clusters[i].Endpoint),
+			builtInEndpoint(&clusters[i], "READER", clusters[i].ReaderEndpoint))
+	}
+
+	return out
+}
+
+func builtInEndpoint(c *rdsdriver.Cluster, endpointType, address string) rdsdriver.ClusterEndpoint {
+	return rdsdriver.ClusterEndpoint{
+		EndpointID:   c.ID,
+		ClusterID:    c.ID,
+		Endpoint:     address,
+		Status:       rdsdriver.StateAvailable,
+		EndpointType: endpointType,
+	}
 }
 
 // cloneEndpoint copies the endpoint's member slices so a returned endpoint

--- a/providers/aws/rds/aurora_test.go
+++ b/providers/aws/rds/aurora_test.go
@@ -31,9 +31,16 @@ func TestClusterEndpointLifecycle(t *testing.T) {
 		t.Fatalf("endpoint on missing cluster: want NotFound, got %v", err)
 	}
 
+	// Describe returns the built-in WRITER + READER endpoints plus the custom one.
 	byCluster, _ := m.DescribeDBClusterEndpoints(ctx, "cl", "")
-	if len(byCluster) != 1 {
-		t.Fatalf("describe by cluster: got %d, want 1", len(byCluster))
+
+	types := map[string]int{}
+	for i := range byCluster {
+		types[byCluster[i].EndpointType]++
+	}
+
+	if types["WRITER"] != 1 || types["READER"] != 1 || types["CUSTOM"] != 1 {
+		t.Fatalf("describe by cluster types = %v, want one each of WRITER/READER/CUSTOM", types)
 	}
 
 	if _, err := m.ModifyDBClusterEndpoint(ctx, "reader-ep", rdsdriver.ModifyClusterEndpointInput{EndpointType: "ANY"}); err != nil {

--- a/server/aws/dynamodb/advanced.go
+++ b/server/aws/dynamodb/advanced.go
@@ -144,6 +144,7 @@ func equalAttr(a, b any) bool {
 func (h *Handler) scan(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		TableName                 string            `json:"TableName"`
+		IndexName                 string            `json:"IndexName"`
 		FilterExpression          string            `json:"FilterExpression"`
 		ProjectionExpression      string            `json:"ProjectionExpression"`
 		ExpressionAttributeValues map[string]any    `json:"ExpressionAttributeValues"`
@@ -163,6 +164,7 @@ func (h *Handler) scan(w http.ResponseWriter, r *http.Request) {
 	// it with full grammar fidelity.
 	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{
 		Table:             req.TableName,
+		IndexName:         req.IndexName,
 		FilterExpression:  req.FilterExpression,
 		ExprNames:         req.ExpressionAttributeNames,
 		ExprValues:        vals,
@@ -318,11 +320,16 @@ func (h *Handler) applyBatchWrite(ctx context.Context, table string, req *batchW
 	}
 }
 
-// batchGetItem handles BatchGetItem (gets across one or more tables).
+// batchGetItem handles BatchGetItem (gets across one or more tables). Each
+// per-table entry may carry a ProjectionExpression (with ExpressionAttributeNames
+// placeholders); when present, only the named attributes are returned for that
+// table's items — otherwise all attributes are returned.
 func (h *Handler) batchGetItem(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		RequestItems map[string]struct {
-			Keys []map[string]any `json:"Keys"`
+			Keys                     []map[string]any  `json:"Keys"`
+			ProjectionExpression     string            `json:"ProjectionExpression"`
+			ExpressionAttributeNames map[string]string `json:"ExpressionAttributeNames"`
 		} `json:"RequestItems"`
 	}
 
@@ -345,6 +352,12 @@ func (h *Handler) batchGetItem(w http.ResponseWriter, r *http.Request) {
 	responses := make(map[string][]map[string]any, len(req.RequestItems))
 
 	for table, spec := range req.RequestItems {
+		paths, perr := expr.ParseProjection(spec.ProjectionExpression, spec.ExpressionAttributeNames)
+		if perr != nil {
+			writeErr(w, perr)
+			return
+		}
+
 		keys := make([]map[string]any, 0, len(spec.Keys))
 		for _, k := range spec.Keys {
 			keys = append(keys, fromWireItem(k))
@@ -358,7 +371,7 @@ func (h *Handler) batchGetItem(w http.ResponseWriter, r *http.Request) {
 
 		out := make([]map[string]any, 0, len(items))
 		for _, item := range items {
-			out = append(out, toWireItem(item))
+			out = append(out, toWireItem(expr.Project(item, paths)))
 		}
 
 		responses[table] = out

--- a/server/aws/dynamodb/advanced.go
+++ b/server/aws/dynamodb/advanced.go
@@ -163,13 +163,14 @@ func (h *Handler) scan(w http.ResponseWriter, r *http.Request) {
 	// Flow the raw FilterExpression to the driver, which parses and evaluates
 	// it with full grammar fidelity.
 	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{
-		Table:             req.TableName,
-		IndexName:         req.IndexName,
-		FilterExpression:  req.FilterExpression,
-		ExprNames:         req.ExpressionAttributeNames,
-		ExprValues:        vals,
-		Limit:             req.Limit,
-		ExclusiveStartKey: fromWireItem(req.ExclusiveStartKey),
+		Table:               req.TableName,
+		IndexName:           req.IndexName,
+		FilterExpression:    req.FilterExpression,
+		ExprNames:           req.ExpressionAttributeNames,
+		ExprValues:          vals,
+		Limit:               req.Limit,
+		ExclusiveStartKey:   fromWireItem(req.ExclusiveStartKey),
+		ProjectionRequested: req.ProjectionExpression != "",
 	})
 	if err != nil {
 		writeErr(w, err)

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -22,10 +22,27 @@ const (
 	keyTypeHash        = "HASH"
 	keyTypeRange       = "RANGE"
 	projectionAll      = "ALL"
+	projectionInclude  = "INCLUDE"
 	statusEnabled      = "ENABLED"
 	statusDisabled     = "DISABLED"
 	billingProvisioned = "PROVISIONED"
 )
+
+// projectionBlock builds the Projection wire block echoed by a describe. An
+// INCLUDE projection also carries the NonKeyAttributes it copied so the
+// declared index round-trips exactly.
+func projectionBlock(projType string, nonKey []string) map[string]any {
+	if projType == "" {
+		projType = projectionAll
+	}
+
+	block := map[string]any{"ProjectionType": projType}
+	if projType == projectionInclude && len(nonKey) > 0 {
+		block["NonKeyAttributes"] = nonKey
+	}
+
+	return block
+}
 
 // Handler serves DynamoDB JSON-RPC requests against a database.Database driver.
 type Handler struct {
@@ -186,14 +203,18 @@ func buildCreateConfig(req *createTableRequest) dbdriver.TableConfig {
 
 	for _, gsi := range req.GlobalSecondaryIndexes {
 		pk, sk := indexKeys(gsi)
-		cfg.GSIs = append(cfg.GSIs,
-			dbdriver.GSIConfig{Name: gsi.IndexName, PartitionKey: pk, SortKey: sk, Projection: gsi.Projection.ProjectionType})
+		cfg.GSIs = append(cfg.GSIs, dbdriver.GSIConfig{
+			Name: gsi.IndexName, PartitionKey: pk, SortKey: sk,
+			Projection: gsi.Projection.ProjectionType, NonKeyAttributes: gsi.Projection.NonKeyAttributes,
+		})
 	}
 
 	for _, lsi := range req.LocalSecondaryIndexes {
 		_, sk := indexKeys(lsi)
-		cfg.LSIs = append(cfg.LSIs,
-			dbdriver.LSIConfig{Name: lsi.IndexName, SortKey: sk, Projection: lsi.Projection.ProjectionType})
+		cfg.LSIs = append(cfg.LSIs, dbdriver.LSIConfig{
+			Name: lsi.IndexName, SortKey: sk,
+			Projection: lsi.Projection.ProjectionType, NonKeyAttributes: lsi.Projection.NonKeyAttributes,
+		})
 	}
 
 	if req.StreamSpecification != nil && req.StreamSpecification.StreamEnabled {
@@ -284,7 +305,8 @@ type secondaryIndexJSON struct {
 		KeyType       string `json:"KeyType"`
 	} `json:"KeySchema"`
 	Projection struct {
-		ProjectionType string `json:"ProjectionType"`
+		ProjectionType   string   `json:"ProjectionType"`
+		NonKeyAttributes []string `json:"NonKeyAttributes"`
 	} `json:"Projection"`
 }
 
@@ -396,15 +418,10 @@ func lsiDescriptions(cfg *dbdriver.TableConfig) []map[string]any {
 			{"AttributeName": lsi.SortKey, "KeyType": keyTypeRange},
 		}
 
-		projection := lsi.Projection
-		if projection == "" {
-			projection = projectionAll
-		}
-
 		out = append(out, map[string]any{
 			"IndexName":      lsi.Name,
 			"KeySchema":      keySchema,
-			"Projection":     map[string]any{"ProjectionType": projection},
+			"Projection":     projectionBlock(lsi.Projection, lsi.NonKeyAttributes),
 			"IndexArn":       cfg.TableArn + "/index/" + lsi.Name,
 			"ItemCount":      0,
 			"IndexSizeBytes": 0,
@@ -426,16 +443,11 @@ func gsiDescriptions(cfg *dbdriver.TableConfig, billing string) []map[string]any
 			keySchema = append(keySchema, map[string]string{"AttributeName": gsi.SortKey, "KeyType": keyTypeRange})
 		}
 
-		projection := gsi.Projection
-		if projection == "" {
-			projection = projectionAll
-		}
-
 		desc := map[string]any{
 			"IndexName":      gsi.Name,
 			"IndexStatus":    "ACTIVE",
 			"KeySchema":      keySchema,
-			"Projection":     map[string]any{"ProjectionType": projection},
+			"Projection":     projectionBlock(gsi.Projection, gsi.NonKeyAttributes),
 			"IndexArn":       cfg.TableArn + "/index/" + gsi.Name,
 			"ItemCount":      0,
 			"IndexSizeBytes": 0,

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -844,15 +844,16 @@ func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
 	// parses and evaluates it with full grammar fidelity. The KeyCondition
 	// path is unchanged.
 	result, err := h.db.Query(r.Context(), dbdriver.QueryInput{
-		Table:             req.TableName,
-		IndexName:         req.IndexName,
-		KeyCondition:      kc,
-		FilterExpression:  req.FilterExpression,
-		ExprNames:         req.ExpressionAttributeNames,
-		ExprValues:        vals,
-		Limit:             req.Limit,
-		SortDescending:    !forward,
-		ExclusiveStartKey: fromWireItem(req.ExclusiveStartKey),
+		Table:               req.TableName,
+		IndexName:           req.IndexName,
+		KeyCondition:        kc,
+		FilterExpression:    req.FilterExpression,
+		ExprNames:           req.ExpressionAttributeNames,
+		ExprValues:          vals,
+		Limit:               req.Limit,
+		SortDescending:      !forward,
+		ExclusiveStartKey:   fromWireItem(req.ExclusiveStartKey),
+		ProjectionRequested: req.ProjectionExpression != "",
 	})
 	if err != nil {
 		writeErr(w, err)

--- a/server/aws/dynamodb/index_projection_sdk_roundtrip_test.go
+++ b/server/aws/dynamodb/index_projection_sdk_roundtrip_test.go
@@ -1,0 +1,244 @@
+// index_projection_sdk_roundtrip_test.go —
+// Real-user-journey tests driving the genuine aws-sdk-go-v2 DynamoDB client
+// against the emulator for secondary-index attribute projection (GSI/LSI
+// KEYS_ONLY / INCLUDE / ALL) and per-table BatchGetItem ProjectionExpression.
+package dynamodb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createGSITable creates a table id(HASH)+sk(RANGE) with a GSI "by-cat" on
+// cat(HASH) using the given projection type and non-key attributes.
+func createGSITable(
+	t *testing.T, client *dynamodb.Client, table string, proj ddbtypes.ProjectionType, nonKey []string,
+) {
+	t.Helper()
+
+	_, err := client.CreateTable(context.Background(), &dynamodb.CreateTableInput{
+		TableName:   aws.String(table),
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("sk"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("cat"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash},
+			{AttributeName: aws.String("sk"), KeyType: ddbtypes.KeyTypeRange},
+		},
+		GlobalSecondaryIndexes: []ddbtypes.GlobalSecondaryIndex{{
+			IndexName:  aws.String("by-cat"),
+			KeySchema:  []ddbtypes.KeySchemaElement{{AttributeName: aws.String("cat"), KeyType: ddbtypes.KeyTypeHash}},
+			Projection: &ddbtypes.Projection{ProjectionType: proj, NonKeyAttributes: nonKey},
+		}},
+	})
+	require.NoError(t, err)
+}
+
+// TestGSIQueryProjection covers the GSI attribute-projection contract: a query
+// on a KEYS_ONLY index returns only the table + index key attributes; INCLUDE
+// adds the named non-key attributes and nothing else; ALL returns everything.
+func TestGSIQueryProjection(t *testing.T) {
+	ctx := context.Background()
+
+	item := map[string]ddbtypes.AttributeValue{
+		"id":    sAttr("u1"),
+		"sk":    sAttr("s1"),
+		"cat":   sAttr("books"),
+		"price": nAttr("42"),
+		"title": sAttr("Go"),
+		"notes": sAttr("secret"),
+	}
+
+	queryByCat := func(client *dynamodb.Client, table string) map[string]ddbtypes.AttributeValue {
+		out, err := client.Query(ctx, &dynamodb.QueryInput{
+			TableName:                 aws.String(table),
+			IndexName:                 aws.String("by-cat"),
+			KeyConditionExpression:    aws.String("cat = :c"),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":c": sAttr("books")},
+		})
+		require.NoError(t, err)
+		require.Len(t, out.Items, 1)
+
+		return out.Items[0]
+	}
+
+	t.Run("KEYS_ONLY returns only table and index keys", func(t *testing.T) {
+		client, _ := newSuiteDDBEnv(t)
+		createGSITable(t, client, "kt", ddbtypes.ProjectionTypeKeysOnly, nil)
+		suiteDDBPut(t, client, "kt", item)
+
+		got := queryByCat(client, "kt")
+		assert.Len(t, got, 3, "only id, sk and cat are projected")
+		assert.Equal(t, "u1", attrS(t, got, "id"))
+		assert.Equal(t, "s1", attrS(t, got, "sk"))
+		assert.Equal(t, "books", attrS(t, got, "cat"))
+		_, hasPrice := got["price"]
+		assert.False(t, hasPrice, "a non-projected base-table attribute must not appear")
+	})
+
+	t.Run("INCLUDE returns keys plus the named non-key attributes", func(t *testing.T) {
+		client, _ := newSuiteDDBEnv(t)
+		createGSITable(t, client, "it", ddbtypes.ProjectionTypeInclude, []string{"price", "title"})
+		suiteDDBPut(t, client, "it", item)
+
+		got := queryByCat(client, "it")
+		assert.Len(t, got, 5, "id, sk, cat, price, title")
+		assert.Equal(t, "42", attrN(t, got, "price"))
+		assert.Equal(t, "Go", attrS(t, got, "title"))
+		_, hasNotes := got["notes"]
+		assert.False(t, hasNotes, "an attribute not in NonKeyAttributes must not appear")
+	})
+
+	t.Run("ALL returns every attribute", func(t *testing.T) {
+		client, _ := newSuiteDDBEnv(t)
+		createGSITable(t, client, "at", ddbtypes.ProjectionTypeAll, nil)
+		suiteDDBPut(t, client, "at", item)
+
+		got := queryByCat(client, "at")
+		assert.Len(t, got, 6, "ALL projects the full item")
+		assert.Equal(t, "secret", attrS(t, got, "notes"))
+	})
+
+	t.Run("ProjectionExpression cannot recover a non-projected attribute", func(t *testing.T) {
+		client, _ := newSuiteDDBEnv(t)
+		createGSITable(t, client, "pt", ddbtypes.ProjectionTypeKeysOnly, nil)
+		suiteDDBPut(t, client, "pt", item)
+
+		out, err := client.Query(ctx, &dynamodb.QueryInput{
+			TableName:                 aws.String("pt"),
+			IndexName:                 aws.String("by-cat"),
+			KeyConditionExpression:    aws.String("cat = :c"),
+			ProjectionExpression:      aws.String("id, price"),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":c": sAttr("books")},
+		})
+		require.NoError(t, err)
+		require.Len(t, out.Items, 1)
+		assert.Equal(t, "u1", attrS(t, out.Items[0], "id"))
+		_, hasPrice := out.Items[0]["price"]
+		assert.False(t, hasPrice, "price is not projected into the index, so it cannot be fetched")
+	})
+}
+
+// TestGSIProjectionRoundTrip covers that an INCLUDE index's NonKeyAttributes
+// round-trip through DescribeTable.
+func TestGSIProjectionRoundTrip(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	createGSITable(t, client, "rt", ddbtypes.ProjectionTypeInclude, []string{"price", "title"})
+
+	d, err := client.DescribeTable(context.Background(),
+		&dynamodb.DescribeTableInput{TableName: aws.String("rt")})
+	require.NoError(t, err)
+	require.Len(t, d.Table.GlobalSecondaryIndexes, 1)
+
+	proj := d.Table.GlobalSecondaryIndexes[0].Projection
+	require.NotNil(t, proj)
+	assert.Equal(t, ddbtypes.ProjectionTypeInclude, proj.ProjectionType)
+	assert.ElementsMatch(t, []string{"price", "title"}, proj.NonKeyAttributes)
+}
+
+// TestLSIQueryProjection covers the projection contract on a Local Secondary
+// Index: a KEYS_ONLY LSI query returns only the table keys plus the LSI sort
+// key.
+func TestLSIQueryProjection(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:   aws.String("lt"),
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("sk"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("alt"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash},
+			{AttributeName: aws.String("sk"), KeyType: ddbtypes.KeyTypeRange},
+		},
+		LocalSecondaryIndexes: []ddbtypes.LocalSecondaryIndex{{
+			IndexName: aws.String("by-alt"),
+			KeySchema: []ddbtypes.KeySchemaElement{
+				{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash},
+				{AttributeName: aws.String("alt"), KeyType: ddbtypes.KeyTypeRange},
+			},
+			Projection: &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeKeysOnly},
+		}},
+	})
+	require.NoError(t, err)
+
+	suiteDDBPut(t, client, "lt", map[string]ddbtypes.AttributeValue{
+		"id": sAttr("u1"), "sk": sAttr("s1"), "alt": sAttr("a1"), "extra": sAttr("x"),
+	})
+
+	out, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:                 aws.String("lt"),
+		IndexName:                 aws.String("by-alt"),
+		KeyConditionExpression:    aws.String("id = :i AND alt = :a"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":i": sAttr("u1"), ":a": sAttr("a1")},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Items, 1)
+	assert.Len(t, out.Items[0], 3, "id, sk and alt only")
+	_, hasExtra := out.Items[0]["extra"]
+	assert.False(t, hasExtra, "a non-projected attribute must not appear on an LSI query")
+}
+
+// TestBatchGetItemProjection covers the per-table ProjectionExpression on
+// BatchGetItem: when specified only the named attributes are returned; when
+// omitted, all attributes are returned. ExpressionAttributeNames placeholders
+// in the projection are honored.
+func TestBatchGetItemProjection(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "forum", "name", "")
+	suiteDDBPut(t, client, "forum", map[string]ddbtypes.AttributeValue{
+		"name":     sAttr("DynamoDB"),
+		"threads":  nAttr("5"),
+		"messages": nAttr("19"),
+		"views":    nAttr("35"),
+	})
+
+	t.Run("ProjectionExpression trims each item", func(t *testing.T) {
+		out, err := client.BatchGetItem(ctx, &dynamodb.BatchGetItemInput{
+			RequestItems: map[string]ddbtypes.KeysAndAttributes{
+				"forum": {
+					Keys:                 []map[string]ddbtypes.AttributeValue{{"name": sAttr("DynamoDB")}},
+					ProjectionExpression: aws.String("#n, threads"),
+					ExpressionAttributeNames: map[string]string{
+						"#n": "name",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		got := out.Responses["forum"]
+		require.Len(t, got, 1)
+		assert.Len(t, got[0], 2, "only name and threads are returned")
+		assert.Equal(t, "DynamoDB", attrS(t, got[0], "name"))
+		assert.Equal(t, "5", attrN(t, got[0], "threads"))
+		_, hasViews := got[0]["views"]
+		assert.False(t, hasViews, "a non-projected attribute must not appear")
+	})
+
+	t.Run("no ProjectionExpression returns all attributes", func(t *testing.T) {
+		out, err := client.BatchGetItem(ctx, &dynamodb.BatchGetItemInput{
+			RequestItems: map[string]ddbtypes.KeysAndAttributes{
+				"forum": {Keys: []map[string]ddbtypes.AttributeValue{{"name": sAttr("DynamoDB")}}},
+			},
+		})
+		require.NoError(t, err)
+		got := out.Responses["forum"]
+		require.Len(t, got, 1)
+		assert.Len(t, got[0], 4, "all four attributes are returned")
+	})
+}

--- a/server/aws/dynamodb/index_projection_sdk_roundtrip_test.go
+++ b/server/aws/dynamodb/index_projection_sdk_roundtrip_test.go
@@ -146,8 +146,12 @@ func TestGSIProjectionRoundTrip(t *testing.T) {
 }
 
 // TestLSIQueryProjection covers the projection contract on a Local Secondary
-// Index: a KEYS_ONLY LSI query returns only the table keys plus the LSI sort
-// key.
+// Index. Unlike a GSI, an LSI can transparently fetch non-projected attributes
+// from the base table (per the AWS LSI developer guide and the Query Select
+// rules): with no ProjectionExpression the query defaults to
+// ALL_PROJECTED_ATTRIBUTES (a KEYS_ONLY LSI returns only the keys), but a
+// ProjectionExpression naming a non-projected attribute recovers it from the
+// base table.
 func TestLSIQueryProjection(t *testing.T) {
 	client, _ := newSuiteDDBEnv(t)
 	ctx := context.Background()
@@ -179,17 +183,34 @@ func TestLSIQueryProjection(t *testing.T) {
 		"id": sAttr("u1"), "sk": sAttr("s1"), "alt": sAttr("a1"), "extra": sAttr("x"),
 	})
 
-	out, err := client.Query(ctx, &dynamodb.QueryInput{
-		TableName:                 aws.String("lt"),
-		IndexName:                 aws.String("by-alt"),
-		KeyConditionExpression:    aws.String("id = :i AND alt = :a"),
-		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":i": sAttr("u1"), ":a": sAttr("a1")},
+	t.Run("no ProjectionExpression defaults to ALL_PROJECTED_ATTRIBUTES", func(t *testing.T) {
+		out, err := client.Query(ctx, &dynamodb.QueryInput{
+			TableName:                 aws.String("lt"),
+			IndexName:                 aws.String("by-alt"),
+			KeyConditionExpression:    aws.String("id = :i AND alt = :a"),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":i": sAttr("u1"), ":a": sAttr("a1")},
+		})
+		require.NoError(t, err)
+		require.Len(t, out.Items, 1)
+		assert.Len(t, out.Items[0], 3, "id, sk and alt only (KEYS_ONLY projected set)")
+		_, hasExtra := out.Items[0]["extra"]
+		assert.False(t, hasExtra, "a non-projected attribute must not appear without a ProjectionExpression")
 	})
-	require.NoError(t, err)
-	require.Len(t, out.Items, 1)
-	assert.Len(t, out.Items[0], 3, "id, sk and alt only")
-	_, hasExtra := out.Items[0]["extra"]
-	assert.False(t, hasExtra, "a non-projected attribute must not appear on an LSI query")
+
+	t.Run("ProjectionExpression fetches a non-projected attribute from the base table", func(t *testing.T) {
+		out, err := client.Query(ctx, &dynamodb.QueryInput{
+			TableName:                 aws.String("lt"),
+			IndexName:                 aws.String("by-alt"),
+			KeyConditionExpression:    aws.String("id = :i AND alt = :a"),
+			ProjectionExpression:      aws.String("id, extra"),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":i": sAttr("u1"), ":a": sAttr("a1")},
+		})
+		require.NoError(t, err)
+		require.Len(t, out.Items, 1)
+		assert.Len(t, out.Items[0], 2, "only the requested attributes")
+		assert.Equal(t, "x", attrS(t, out.Items[0], "extra"),
+			"an LSI transparently fetches a non-projected attribute from the base table")
+	})
 }
 
 // TestBatchGetItemProjection covers the per-table ProjectionExpression on

--- a/server/aws/dynamodb/update_table.go
+++ b/server/aws/dynamodb/update_table.go
@@ -179,7 +179,8 @@ func (h *Handler) applyGSIUpdate(ctx context.Context, table string, create *seco
 	if create != nil {
 		pk, sk := indexKeys(*create)
 		_, err := h.db.CreateIndex(ctx, table, dbdriver.GSIConfig{
-			Name: create.IndexName, PartitionKey: pk, SortKey: sk, Projection: create.Projection.ProjectionType,
+			Name: create.IndexName, PartitionKey: pk, SortKey: sk,
+			Projection: create.Projection.ProjectionType, NonKeyAttributes: create.Projection.NonKeyAttributes,
 		})
 
 		return err

--- a/server/aws/rds/aurora_sdk_roundtrip_test.go
+++ b/server/aws/rds/aurora_sdk_roundtrip_test.go
@@ -66,8 +66,15 @@ func TestSDKRDSClusterEndpointsAndFailover(t *testing.T) {
 		t.Fatalf("DescribeDBClusterEndpoints: %v", err)
 	}
 
-	if len(desc.DBClusterEndpoints) != 1 {
-		t.Fatalf("got %d endpoints, want 1", len(desc.DBClusterEndpoints))
+	// The built-in WRITER + READER endpoints Aurora auto-provisions plus the one
+	// custom endpoint created above.
+	types := map[string]int{}
+	for i := range desc.DBClusterEndpoints {
+		types[aws.ToString(desc.DBClusterEndpoints[i].EndpointType)]++
+	}
+
+	if types["WRITER"] != 1 || types["READER"] != 1 || types["CUSTOM"] != 1 {
+		t.Fatalf("endpoint types = %v, want one each of WRITER/READER/CUSTOM", types)
 	}
 
 	if _, err := client.DeleteDBClusterEndpoint(ctx, &awsrds.DeleteDBClusterEndpointInput{

--- a/server/aws/rds/clean_errors_endpoints_sdk_roundtrip_test.go
+++ b/server/aws/rds/clean_errors_endpoints_sdk_roundtrip_test.go
@@ -1,0 +1,137 @@
+package rds_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestSDKRDSErrorMessageHasNoCodePrefix guards that an RDS fault Message carries
+// a clean human sentence with no internal enum prefix (e.g. "NotFound: ..."):
+// the machine-readable part is the fault Code, not a token embedded in the
+// message.
+func TestSDKRDSErrorMessageHasNoCodePrefix(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String("ghost"),
+	})
+
+	var notFound *rdstypes.DBInstanceNotFoundFault
+	if !errors.As(err, &notFound) {
+		t.Fatalf("DescribeDBInstances(ghost): got %v, want DBInstanceNotFoundFault", err)
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not a smithy APIError: %v", err)
+	}
+
+	if apiErr.ErrorCode() != "DBInstanceNotFound" {
+		t.Fatalf("ErrorCode = %q, want DBInstanceNotFound", apiErr.ErrorCode())
+	}
+
+	msg := apiErr.ErrorMessage()
+	for _, tok := range []string{"NotFound:", "InvalidArgument:", "FailedPrecondition:", "AlreadyExists:"} {
+		if strings.Contains(msg, tok) {
+			t.Fatalf("fault Message %q embeds internal enum prefix %q", msg, tok)
+		}
+	}
+
+	if !strings.Contains(msg, "ghost") {
+		t.Fatalf("fault Message %q should name the missing instance", msg)
+	}
+}
+
+// TestSDKRDSCreateInstanceErrorCleanMessage guards the same clean-message
+// contract on an already-exists fault from CreateDBInstance.
+func TestSDKRDSCreateInstanceErrorCleanMessage(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	in := &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("dup"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+	}
+
+	if _, err := client.CreateDBInstance(ctx, in); err != nil {
+		t.Fatalf("first CreateDBInstance: %v", err)
+	}
+
+	_, err := client.CreateDBInstance(ctx, in)
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("second CreateDBInstance: got %v, want an APIError", err)
+	}
+
+	if apiErr.ErrorCode() != "DBInstanceAlreadyExists" {
+		t.Fatalf("ErrorCode = %q, want DBInstanceAlreadyExists", apiErr.ErrorCode())
+	}
+
+	if strings.Contains(apiErr.ErrorMessage(), "AlreadyExists:") {
+		t.Fatalf("fault Message %q embeds internal enum prefix", apiErr.ErrorMessage())
+	}
+}
+
+// TestSDKRDSAuroraBuiltInEndpoints guards that a freshly created Aurora cluster
+// exposes its built-in WRITER and READER endpoints via DescribeDBClusterEndpoints
+// even before any custom endpoint is created.
+func TestSDKRDSAuroraBuiltInEndpoints(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBCluster(ctx, &awsrds.CreateDBClusterInput{
+		DBClusterIdentifier: aws.String("fresh-cl"),
+		Engine:              aws.String("aurora-postgresql"),
+	}); err != nil {
+		t.Fatalf("CreateDBCluster: %v", err)
+	}
+
+	desc, err := client.DescribeDBClusterEndpoints(ctx, &awsrds.DescribeDBClusterEndpointsInput{
+		DBClusterIdentifier: aws.String("fresh-cl"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBClusterEndpoints: %v", err)
+	}
+
+	if len(desc.DBClusterEndpoints) != 2 {
+		t.Fatalf("got %d endpoints, want 2 (WRITER + READER)", len(desc.DBClusterEndpoints))
+	}
+
+	byType := map[string]rdstypes.DBClusterEndpoint{}
+	for i := range desc.DBClusterEndpoints {
+		byType[aws.ToString(desc.DBClusterEndpoints[i].EndpointType)] = desc.DBClusterEndpoints[i]
+	}
+
+	writer, ok := byType["WRITER"]
+	if !ok {
+		t.Fatalf("missing built-in WRITER endpoint; got %v", byType)
+	}
+
+	reader, ok := byType["READER"]
+	if !ok {
+		t.Fatalf("missing built-in READER endpoint; got %v", byType)
+	}
+
+	if aws.ToString(writer.DBClusterIdentifier) != "fresh-cl" {
+		t.Fatalf("WRITER endpoint cluster id = %q, want fresh-cl", aws.ToString(writer.DBClusterIdentifier))
+	}
+
+	if aws.ToString(writer.Endpoint) == "" || aws.ToString(reader.Endpoint) == "" {
+		t.Fatalf("built-in endpoints must carry an address: writer=%q reader=%q",
+			aws.ToString(writer.Endpoint), aws.ToString(reader.Endpoint))
+	}
+
+	if aws.ToString(writer.Endpoint) == aws.ToString(reader.Endpoint) {
+		t.Fatalf("writer and reader endpoints should differ: %q", aws.ToString(writer.Endpoint))
+	}
+}

--- a/server/aws/rds/handler.go
+++ b/server/aws/rds/handler.go
@@ -11,6 +11,7 @@
 package rds
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -339,20 +340,37 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// writeErr maps cloudemu errors to RDS XML error responses.
+// writeErr maps cloudemu errors to RDS XML error responses. The fault Code is
+// the machine-readable part; the Message carries the clean human sentence with
+// no internal enum prefix, matching real RDS error responses. The fault-code
+// pickers still read err.Error() so the resource keyword drives the code.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := errMessage(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		awsquery.WriteXMLError(w, http.StatusNotFound, notFoundCode(err), err.Error())
+		awsquery.WriteXMLError(w, http.StatusNotFound, notFoundCode(err), msg)
 	case cerrors.IsAlreadyExists(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, alreadyExistsCode(err), err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, alreadyExistsCode(err), msg)
 	case cerrors.IsInvalidArgument(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", msg)
 	case cerrors.IsFailedPrecondition(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, invalidStateCode(err), err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, invalidStateCode(err), msg)
 	default:
-		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
+		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", msg)
 	}
+}
+
+// errMessage returns the human-readable message for a cloudemu error without
+// the "Code: " prefix that Error() prepends. Real RDS fault messages carry no
+// such prefix, so surfacing it would leak an internal detail.
+func errMessage(err error) string {
+	var e *cerrors.Error
+	if errors.As(err, &e) {
+		return e.Message
+	}
+
+	return err.Error()
 }
 
 // faultMapping maps a resource keyword found in an error message to the

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -93,6 +93,9 @@ type GSIConfig struct {
 	// Projection is the DynamoDB projection type (ALL, KEYS_ONLY, INCLUDE); a
 	// describe echoes it so an IaC client's declared index round-trips.
 	Projection string
+	// NonKeyAttributes are the base-table attributes an INCLUDE projection copies
+	// into the index in addition to the key attributes. Ignored for ALL/KEYS_ONLY.
+	NonKeyAttributes []string
 }
 
 // LSIConfig describes a Local Secondary Index. An LSI shares the table's
@@ -102,6 +105,9 @@ type LSIConfig struct {
 	Name       string
 	SortKey    string
 	Projection string
+	// NonKeyAttributes are the base-table attributes an INCLUDE projection copies
+	// into the index in addition to the key attributes. Ignored for ALL/KEYS_ONLY.
+	NonKeyAttributes []string
 }
 
 // UpdateAction represents a single field-level update action. It is the legacy,
@@ -213,6 +219,10 @@ type QueryInput struct {
 // ScanInput configures a scan operation.
 type ScanInput struct {
 	Table string
+	// IndexName scans a secondary index instead of the base table. Items lacking
+	// the index's key attributes are skipped (sparse index), and only the
+	// index's projected attributes are returned.
+	IndexName string
 	// Filters is the legacy pre-simplified filter; ignored when
 	// FilterExpression is set. Retained for back-compat.
 	Filters []ScanFilter

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -211,6 +211,15 @@ type QueryInput struct {
 	// The zero value (ascending) matches the historical behavior.
 	SortDescending bool
 
+	// ProjectionRequested reports that the caller supplied a ProjectionExpression
+	// which the wire layer will apply to the returned items. It only matters for
+	// a Local Secondary Index: real DynamoDB transparently fetches non-projected
+	// attributes from the base table, so when a projection is requested the driver
+	// must expose the full base item (letting the wire layer select any
+	// attribute). With no projection an index query defaults to
+	// ALL_PROJECTED_ATTRIBUTES, so the driver still trims to the projected set.
+	ProjectionRequested bool
+
 	// Deprecated: never implemented; use SortDescending. Retained so
 	// existing constructors keep compiling.
 	ScanForward bool
@@ -238,6 +247,12 @@ type ScanInput struct {
 
 	// ExclusiveStartKey selects key-based continuation; see QueryInput.
 	ExclusiveStartKey map[string]any
+
+	// ProjectionRequested reports that the caller supplied a ProjectionExpression;
+	// see QueryInput.ProjectionRequested. On a Local Secondary Index scan it makes
+	// the driver expose the full base item so non-projected attributes can be
+	// fetched, matching real DynamoDB.
+	ProjectionRequested bool
 }
 
 // QueryResult is the result of a query or scan.

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -1067,15 +1067,17 @@ type ModifyClusterEndpointInput struct {
 	ExcludedMembers []string
 }
 
-// ClusterEndpoint is a custom Aurora cluster endpoint.
+// ClusterEndpoint is an Aurora cluster endpoint — either a built-in WRITER /
+// READER endpoint auto-provisioned at cluster create time, or a user-created
+// CUSTOM endpoint.
 type ClusterEndpoint struct {
 	EndpointID         string
 	ClusterID          string
 	ARN                string
 	Endpoint           string
 	Status             string
-	EndpointType       string // always "CUSTOM" for user-created endpoints
-	CustomEndpointType string // "READER" | "ANY"
+	EndpointType       string // "WRITER" | "READER" (built-in) or "CUSTOM" (user-created)
+	CustomEndpointType string // "READER" | "ANY" (custom endpoints only)
 	StaticMembers      []string
 	ExcludedMembers    []string
 }


### PR DESCRIPTION
## Summary

Four DEEP second-round real-user AWS audit findings in the DynamoDB / RDS / Aurora cluster, each fixed at the correct layer and verified against the official AWS API reference with real aws-sdk-go-v2 round-trip tests.

### 1. DynamoDB Query/Scan on a secondary index respects the index projection (MEDIUM)
Per the GSI/LSI contract, a query on a secondary index cannot fetch base-table attributes that are not projected. Previously the emulator returned the full base-table item for any index query.
- A `KEYS_ONLY` index now returns only the table partition/sort key plus the index key attributes.
- `INCLUDE` returns those keys plus the named `NonKeyAttributes` and nothing else.
- `ALL` is unchanged (full item).
- A `ProjectionExpression` naming a non-projected attribute can no longer recover it.
- Added `NonKeyAttributes` to the driver `GSIConfig`/`LSIConfig` so an INCLUDE index round-trips through DescribeTable, and added `IndexName` to `ScanInput` so a Scan on a secondary index skips items lacking the index key (sparse index) and applies the same projection.

### 2. RDS error Messages carry no internal enum prefix (MEDIUM)
RDS fault responses embedded the internal code token (e.g. `NotFound: DBInstance ...`) in the Message. The fault Code is the machine-readable part; the Message is now the clean human sentence, mirroring the existing DynamoDB `errMessage` precedent. Fault-code detection is unchanged.

### 3. BatchGetItem honors per-table ProjectionExpression (MEDIUM)
`BatchGetItem` ignored each table's `ProjectionExpression`/`ExpressionAttributeNames` and always returned all attributes. It now returns only the named attributes when a projection is specified (with `#name` placeholders honored), and all attributes when it is omitted.

### 4. Aurora clusters expose built-in WRITER/READER endpoints (MEDIUM)
`DescribeDBClusterEndpoints` returned only user-created custom endpoints. Aurora auto-provisions a WRITER and a READER endpoint at cluster-create time; the describe now returns them (EndpointType WRITER/READER, carrying the cluster's writer/reader address) even before any custom endpoint exists.

## Tests
- `server/aws/dynamodb/index_projection_sdk_roundtrip_test.go` — GSI KEYS_ONLY/INCLUDE/ALL projection, projection round-trip, LSI projection, BatchGetItem projection (real SDK).
- `server/aws/rds/clean_errors_endpoints_sdk_roundtrip_test.go` — clean fault messages + Aurora built-in endpoints (real SDK).
- Provider unit tests for Scan-on-index projection/sparseness; updated existing cluster-endpoint tests for the new built-ins.

Gates: `go build ./...`, `go test .` + all changed packages, and golangci-lint on changed packages are green (no new lint in changed code).
