### PR TITLE
fix(azure-storage): storageaccount keys/location/tags + blobstorage comp-routing (block/metadata/properties/tier/snapshot/append)

### DIFF
--- a/docs/coverage/aws/s3.md
+++ b/docs/coverage/aws/s3.md
@@ -47,6 +47,24 @@ AWS's `storage` service · portable interface `driver.Bucket` · [AWS index](./R
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureBlobExtensions
+
+AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
+
+| Operation | Description |
+| --- | --- |
+| `AppendBlock` | AppendBlock appends a block to the end of an append blob (Append Block, |
+| `CommitBlockList` | CommitBlockList assembles a block blob (Put Block List, ?comp=blocklist) |
+| `ContainerMetadata` | ContainerMetadata returns a container's metadata (Get Container Properties / |
+| `CreateAppendBlob` | CreateAppendBlob creates an empty append blob (Put Blob with |
+| `CreateBlobSnapshot` | CreateBlobSnapshot captures an immutable snapshot (Snapshot Blob, |
+| `GetBlobSnapshot` | GetBlobSnapshot reads a previously captured snapshot (GET ?snapshot=…). |
+| `SetBlobMetadata` | SetBlobMetadata replaces only a blob's metadata (Set Blob Metadata, |
+| `SetBlobProperties` | SetBlobProperties replaces only a blob's system properties (Set Blob |
+| `SetBlobTier` | SetBlobTier sets a blob's access tier (Set Blob Tier, ?comp=tier), |
+| `SetContainerMetadata` | SetContainerMetadata replaces a container's metadata (Set Container |
+| `StageBlock` | StageBlock buffers an uncommitted block (Put Block, ?comp=block) for a blob |
+
 ### BucketAttributes
 
 BucketAttributes is an OPTIONAL capability, discovered by type assertion (like
@@ -64,6 +82,15 @@ RawBucketConfig is an OPTIONAL capability (discovered by type assertion, like
 | `DeleteBucketConfig` | DeleteBucketConfig removes the stored document (idempotent). |
 | `GetBucketConfig` | GetBucketConfig returns the stored document, or NotFound when none was set. |
 | `PutBucketConfig` | PutBucketConfig stores document body under the sub-resource name (e.g. |
+
+### StorageAccountKeys
+
+StorageAccountKeys is an OPTIONAL Azure-specific capability, discovered by
+
+| Operation | Description |
+| --- | --- |
+| `ListStorageAccountKeys` | ListStorageAccountKeys returns the account's access keys, generating a |
+| `RegenerateStorageAccountKey` | RegenerateStorageAccountKey rotates the value of the named key (key1/key2) |
 
 ### VersionedBucket
 

--- a/docs/coverage/azure/blobstorage.md
+++ b/docs/coverage/azure/blobstorage.md
@@ -47,6 +47,24 @@ Azure's `storage` service · portable interface `driver.Bucket` · [Azure index]
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureBlobExtensions
+
+AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
+
+| Operation | Description |
+| --- | --- |
+| `AppendBlock` | AppendBlock appends a block to the end of an append blob (Append Block, |
+| `CommitBlockList` | CommitBlockList assembles a block blob (Put Block List, ?comp=blocklist) |
+| `ContainerMetadata` | ContainerMetadata returns a container's metadata (Get Container Properties / |
+| `CreateAppendBlob` | CreateAppendBlob creates an empty append blob (Put Blob with |
+| `CreateBlobSnapshot` | CreateBlobSnapshot captures an immutable snapshot (Snapshot Blob, |
+| `GetBlobSnapshot` | GetBlobSnapshot reads a previously captured snapshot (GET ?snapshot=…). |
+| `SetBlobMetadata` | SetBlobMetadata replaces only a blob's metadata (Set Blob Metadata, |
+| `SetBlobProperties` | SetBlobProperties replaces only a blob's system properties (Set Blob |
+| `SetBlobTier` | SetBlobTier sets a blob's access tier (Set Blob Tier, ?comp=tier), |
+| `SetContainerMetadata` | SetContainerMetadata replaces a container's metadata (Set Container |
+| `StageBlock` | StageBlock buffers an uncommitted block (Put Block, ?comp=block) for a blob |
+
 ### BucketAttributes
 
 BucketAttributes is an OPTIONAL capability, discovered by type assertion (like
@@ -64,6 +82,15 @@ RawBucketConfig is an OPTIONAL capability (discovered by type assertion, like
 | `DeleteBucketConfig` | DeleteBucketConfig removes the stored document (idempotent). |
 | `GetBucketConfig` | GetBucketConfig returns the stored document, or NotFound when none was set. |
 | `PutBucketConfig` | PutBucketConfig stores document body under the sub-resource name (e.g. |
+
+### StorageAccountKeys
+
+StorageAccountKeys is an OPTIONAL Azure-specific capability, discovered by
+
+| Operation | Description |
+| --- | --- |
+| `ListStorageAccountKeys` | ListStorageAccountKeys returns the account's access keys, generating a |
+| `RegenerateStorageAccountKey` | RegenerateStorageAccountKey rotates the value of the named key (key1/key2) |
 
 ### VersionedBucket
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -9872,6 +9872,56 @@
     ],
     "optionalCapabilities": [
       {
+        "name": "AzureBlobExtensions",
+        "doc": "AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,",
+        "operations": [
+          {
+            "name": "AppendBlock",
+            "doc": "AppendBlock appends a block to the end of an append blob (Append Block,"
+          },
+          {
+            "name": "CommitBlockList",
+            "doc": "CommitBlockList assembles a block blob (Put Block List, ?comp=blocklist)"
+          },
+          {
+            "name": "ContainerMetadata",
+            "doc": "ContainerMetadata returns a container's metadata (Get Container Properties /"
+          },
+          {
+            "name": "CreateAppendBlob",
+            "doc": "CreateAppendBlob creates an empty append blob (Put Blob with"
+          },
+          {
+            "name": "CreateBlobSnapshot",
+            "doc": "CreateBlobSnapshot captures an immutable snapshot (Snapshot Blob,"
+          },
+          {
+            "name": "GetBlobSnapshot",
+            "doc": "GetBlobSnapshot reads a previously captured snapshot (GET ?snapshot=…)."
+          },
+          {
+            "name": "SetBlobMetadata",
+            "doc": "SetBlobMetadata replaces only a blob's metadata (Set Blob Metadata,"
+          },
+          {
+            "name": "SetBlobProperties",
+            "doc": "SetBlobProperties replaces only a blob's system properties (Set Blob"
+          },
+          {
+            "name": "SetBlobTier",
+            "doc": "SetBlobTier sets a blob's access tier (Set Blob Tier, ?comp=tier),"
+          },
+          {
+            "name": "SetContainerMetadata",
+            "doc": "SetContainerMetadata replaces a container's metadata (Set Container"
+          },
+          {
+            "name": "StageBlock",
+            "doc": "StageBlock buffers an uncommitted block (Put Block, ?comp=block) for a blob"
+          }
+        ]
+      },
+      {
         "name": "BucketAttributes",
         "doc": "BucketAttributes is an OPTIONAL capability, discovered by type assertion (like",
         "operations": [
@@ -9895,6 +9945,20 @@
           {
             "name": "PutBucketConfig",
             "doc": "PutBucketConfig stores document body under the sub-resource name (e.g."
+          }
+        ]
+      },
+      {
+        "name": "StorageAccountKeys",
+        "doc": "StorageAccountKeys is an OPTIONAL Azure-specific capability, discovered by",
+        "operations": [
+          {
+            "name": "ListStorageAccountKeys",
+            "doc": "ListStorageAccountKeys returns the account's access keys, generating a"
+          },
+          {
+            "name": "RegenerateStorageAccountKey",
+            "doc": "RegenerateStorageAccountKey rotates the value of the named key (key1/key2)"
           }
         ]
       },

--- a/docs/coverage/gcp/gcs.md
+++ b/docs/coverage/gcp/gcs.md
@@ -47,6 +47,24 @@ GCP's `storage` service · portable interface `driver.Bucket` · [GCP index](./R
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureBlobExtensions
+
+AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
+
+| Operation | Description |
+| --- | --- |
+| `AppendBlock` | AppendBlock appends a block to the end of an append blob (Append Block, |
+| `CommitBlockList` | CommitBlockList assembles a block blob (Put Block List, ?comp=blocklist) |
+| `ContainerMetadata` | ContainerMetadata returns a container's metadata (Get Container Properties / |
+| `CreateAppendBlob` | CreateAppendBlob creates an empty append blob (Put Blob with |
+| `CreateBlobSnapshot` | CreateBlobSnapshot captures an immutable snapshot (Snapshot Blob, |
+| `GetBlobSnapshot` | GetBlobSnapshot reads a previously captured snapshot (GET ?snapshot=…). |
+| `SetBlobMetadata` | SetBlobMetadata replaces only a blob's metadata (Set Blob Metadata, |
+| `SetBlobProperties` | SetBlobProperties replaces only a blob's system properties (Set Blob |
+| `SetBlobTier` | SetBlobTier sets a blob's access tier (Set Blob Tier, ?comp=tier), |
+| `SetContainerMetadata` | SetContainerMetadata replaces a container's metadata (Set Container |
+| `StageBlock` | StageBlock buffers an uncommitted block (Put Block, ?comp=block) for a blob |
+
 ### BucketAttributes
 
 BucketAttributes is an OPTIONAL capability, discovered by type assertion (like
@@ -64,6 +82,15 @@ RawBucketConfig is an OPTIONAL capability (discovered by type assertion, like
 | `DeleteBucketConfig` | DeleteBucketConfig removes the stored document (idempotent). |
 | `GetBucketConfig` | GetBucketConfig returns the stored document, or NotFound when none was set. |
 | `PutBucketConfig` | PutBucketConfig stores document body under the sub-resource name (e.g. |
+
+### StorageAccountKeys
+
+StorageAccountKeys is an OPTIONAL Azure-specific capability, discovered by
+
+| Operation | Description |
+| --- | --- |
+| `ListStorageAccountKeys` | ListStorageAccountKeys returns the account's access keys, generating a |
+| `RegenerateStorageAccountKey` | RegenerateStorageAccountKey rotates the value of the named key (key1/key2) |
 
 ### VersionedBucket
 

--- a/providers/azure/blobstorage/account_keys.go
+++ b/providers/azure/blobstorage/account_keys.go
@@ -1,0 +1,81 @@
+package blobstorage
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// storageKeyBytes is the length of a raw Azure storage account key. Real keys
+// are 64-byte secrets rendered as base64.
+const storageKeyBytes = 64
+
+// Compile-time check that Mock satisfies the optional StorageAccountKeys
+// capability the ARM storage-account handler reaches by type assertion.
+var _ driver.StorageAccountKeys = (*Mock)(nil)
+
+// ListStorageAccountKeys returns the account's access keys, generating a stable
+// key1/key2 pair on first access so a data-plane SharedKeyCredential can be
+// built and later matched against a regenerate.
+func (m *Mock) ListStorageAccountKeys(_ context.Context, account string) ([]driver.AccountKey, error) {
+	if keys, ok := m.accountKeys.Get(account); ok {
+		return cloneKeys(keys), nil
+	}
+
+	keys := []driver.AccountKey{
+		m.newAccountKey("key1"),
+		m.newAccountKey("key2"),
+	}
+	m.accountKeys.Set(account, keys)
+
+	return cloneKeys(keys), nil
+}
+
+// RegenerateStorageAccountKey rotates the value of the named key and returns the
+// full, updated key list.
+func (m *Mock) RegenerateStorageAccountKey(ctx context.Context, account, keyName string) ([]driver.AccountKey, error) {
+	if keyName != "key1" && keyName != "key2" {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid key name %q, want key1 or key2", keyName)
+	}
+
+	// Ensure a base pair exists before rotating one of them.
+	if _, err := m.ListStorageAccountKeys(ctx, account); err != nil {
+		return nil, err
+	}
+
+	keys, _ := m.accountKeys.Get(account)
+	rotated := cloneKeys(keys)
+
+	for i := range rotated {
+		if rotated[i].KeyName == keyName {
+			rotated[i] = m.newAccountKey(keyName)
+		}
+	}
+
+	m.accountKeys.Set(account, rotated)
+
+	return cloneKeys(rotated), nil
+}
+
+// newAccountKey mints a fresh access key with a random base64 value.
+func (m *Mock) newAccountKey(name string) driver.AccountKey {
+	raw := make([]byte, storageKeyBytes)
+	_, _ = rand.Read(raw)
+
+	return driver.AccountKey{
+		KeyName:      name,
+		Value:        base64.StdEncoding.EncodeToString(raw),
+		Permissions:  "Full",
+		CreationTime: m.opts.Clock.Now().UTC().Format(blobTimeFormat),
+	}
+}
+
+func cloneKeys(keys []driver.AccountKey) []driver.AccountKey {
+	out := make([]driver.AccountKey, len(keys))
+	copy(out, keys)
+
+	return out
+}

--- a/providers/azure/blobstorage/account_keys_test.go
+++ b/providers/azure/blobstorage/account_keys_test.go
@@ -1,0 +1,51 @@
+package blobstorage
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListStorageAccountKeys(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	keys, err := m.ListStorageAccountKeys(ctx, "acct1")
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
+	assert.Equal(t, "key1", keys[0].KeyName)
+	assert.Equal(t, "key2", keys[1].KeyName)
+	assert.NotEmpty(t, keys[0].Value)
+	assert.Equal(t, "Full", keys[0].Permissions)
+
+	// Keys are stable across calls.
+	again, err := m.ListStorageAccountKeys(ctx, "acct1")
+	require.NoError(t, err)
+	assert.Equal(t, keys[0].Value, again[0].Value)
+}
+
+func TestRegenerateStorageAccountKey(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	before, err := m.ListStorageAccountKeys(ctx, "acct1")
+	require.NoError(t, err)
+
+	after, err := m.RegenerateStorageAccountKey(ctx, "acct1", "key1")
+	require.NoError(t, err)
+	require.Len(t, after, 2)
+	assert.NotEqual(t, before[0].Value, after[0].Value, "key1 rotates")
+	assert.Equal(t, before[1].Value, after[1].Value, "key2 unchanged")
+}
+
+func TestRegenerateStorageAccountKeyInvalidName(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.RegenerateStorageAccountKey(ctx, "acct1", "key9")
+	require.Error(t, err)
+	assert.True(t, cerrors.IsInvalidArgument(err))
+}

--- a/providers/azure/blobstorage/blob_extensions.go
+++ b/providers/azure/blobstorage/blob_extensions.go
@@ -1,0 +1,349 @@
+package blobstorage
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"maps"
+	"sort"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+	"github.com/stackshy/cloudemu/v2/services/storage/storageengine"
+)
+
+const (
+	blobTypeBlock  = "BlockBlob"
+	blobTypeAppend = "AppendBlob"
+	snapshotFormat = "2006-01-02T15:04:05."
+	octetStream    = "application/octet-stream"
+)
+
+// Compile-time check that Mock satisfies the optional AzureBlobExtensions
+// capability the blob wire handler reaches by type assertion.
+var _ driver.AzureBlobExtensions = (*Mock)(nil)
+
+// StageBlock buffers an uncommitted block for a blob under blockID.
+func (m *Mock) StageBlock(_ context.Context, container, blob, blockID string, data []byte) error {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+	}
+
+	stg, ok := ctr.staging.Get(blob)
+	if !ok {
+		stg = &blockStaging{blocks: make(map[string][]byte)}
+		ctr.staging.Set(blob, stg)
+	}
+
+	dataCopy := make([]byte, len(data))
+	copy(dataCopy, data)
+
+	stg.mu.Lock()
+	stg.blocks[blockID] = dataCopy
+	stg.mu.Unlock()
+
+	return nil
+}
+
+// CommitBlockList assembles a block blob from previously-staged blocks.
+func (m *Mock) CommitBlockList(
+	ctx context.Context, container, blob string, blockIDs []string, contentType string, metadata map[string]string,
+) (*driver.ObjectInfo, error) {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+	}
+
+	data, err := assembleStagedBlocks(ctr, blob, blockIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	if contentType == "" {
+		contentType = octetStream
+	}
+
+	obj := &blobObject{
+		Key: blob, Size: int64(len(data)), ContentType: contentType,
+		LastModified: m.opts.Clock.Now().UTC().Format(blobTimeFormat),
+		Metadata:     maps.Clone(metadata), BlobType: blobTypeBlock,
+	}
+	obj.ETag = fmt.Sprintf("%x", sha256.Sum256(data))
+
+	if m.opts.StorageEngine != nil {
+		if err := storageengine.Put(ctx, m.opts.StorageEngine, config.StorageObject{
+			Bucket: container, Key: blob, Data: data, ContentType: contentType, Metadata: obj.Metadata,
+		}); err != nil {
+			return nil, err
+		}
+	} else {
+		obj.Data = data
+	}
+
+	ctr.objects.Set(blob, obj)
+	ctr.staging.Delete(blob)
+
+	m.emitMetric(container, map[string]float64{"Transactions": 1, "Ingress": float64(len(data))})
+
+	info := objectInfo(obj)
+
+	return &info, nil
+}
+
+// assembleStagedBlocks concatenates the named staged blocks in order.
+func assembleStagedBlocks(ctr *containerMeta, blob string, blockIDs []string) ([]byte, error) {
+	stg, ok := ctr.staging.Get(blob)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "no staged blocks for blob %q", blob)
+	}
+
+	stg.mu.Lock()
+	defer stg.mu.Unlock()
+
+	var data []byte
+
+	for _, id := range blockIDs {
+		block, ok := stg.blocks[id]
+		if !ok {
+			return nil, cerrors.Newf(cerrors.InvalidArgument, "block %q not staged for blob %q", id, blob)
+		}
+
+		data = append(data, block...)
+	}
+
+	return data, nil
+}
+
+// SetBlobMetadata replaces only a blob's metadata, preserving its content.
+func (m *Mock) SetBlobMetadata(_ context.Context, container, blob string, metadata map[string]string) (*driver.ObjectInfo, error) {
+	obj, err := m.getBlobObject(container, blob)
+	if err != nil {
+		return nil, err
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	obj.Metadata = maps.Clone(metadata)
+	obj.LastModified = m.opts.Clock.Now().UTC().Format(blobTimeFormat)
+	obj.ETag = computeBlobETag(obj)
+
+	info := objectInfo(obj)
+
+	return &info, nil
+}
+
+// SetBlobProperties replaces only a blob's system properties.
+func (m *Mock) SetBlobProperties(_ context.Context, container, blob string, props *driver.BlobProperties) (*driver.ObjectInfo, error) {
+	obj, err := m.getBlobObject(container, blob)
+	if err != nil {
+		return nil, err
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	obj.ContentType = props.ContentType
+	obj.ContentEncoding = props.ContentEncoding
+	obj.ContentLanguage = props.ContentLanguage
+	obj.ContentDisposition = props.ContentDisposition
+	obj.CacheControl = props.CacheControl
+	obj.LastModified = m.opts.Clock.Now().UTC().Format(blobTimeFormat)
+	obj.ETag = computeBlobETag(obj)
+
+	info := objectInfo(obj)
+
+	return &info, nil
+}
+
+// SetBlobTier sets a blob's access tier, preserving its content and ETag.
+func (m *Mock) SetBlobTier(_ context.Context, container, blob, tier string) error {
+	obj, err := m.getBlobObject(container, blob)
+	if err != nil {
+		return err
+	}
+
+	obj.mu.Lock()
+	obj.AccessTier = tier
+	obj.mu.Unlock()
+
+	return nil
+}
+
+// CreateBlobSnapshot captures an immutable snapshot of a blob. Snapshots are
+// stored on the container so they outlive a base-blob overwrite.
+func (m *Mock) CreateBlobSnapshot(_ context.Context, container, blob string) (string, *driver.ObjectInfo, error) {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return "", nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+	}
+
+	obj, ok := ctr.objects.Get(blob)
+	if !ok {
+		return "", nil, cerrors.Newf(cerrors.NotFound, "blob %q not found in container %q", blob, container)
+	}
+
+	ctr.mu.Lock()
+	ctr.snapshotSeq++
+	seq := ctr.snapshotSeq
+	ctr.mu.Unlock()
+
+	now := m.opts.Clock.Now().UTC()
+	snapshotID := now.Format(snapshotFormat) + fmt.Sprintf("%07dZ", seq)
+
+	obj.mu.Lock()
+	snap := &blobObject{
+		Key: obj.Key, Data: append([]byte(nil), obj.Data...), Size: obj.Size,
+		ContentType: obj.ContentType, ETag: obj.ETag, LastModified: obj.LastModified,
+		Metadata: maps.Clone(obj.Metadata), BlobType: obj.BlobType, AccessTier: obj.AccessTier,
+		ContentEncoding: obj.ContentEncoding, ContentLanguage: obj.ContentLanguage,
+		ContentDisposition: obj.ContentDisposition, CacheControl: obj.CacheControl,
+	}
+	info := objectInfo(obj)
+	obj.mu.Unlock()
+
+	ctr.snapshots.Set(snapshotKey(blob, snapshotID), snap)
+
+	return snapshotID, &info, nil
+}
+
+// GetBlobSnapshot reads a previously captured snapshot.
+func (m *Mock) GetBlobSnapshot(_ context.Context, container, blob, snapshot string) (*driver.Object, error) {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+	}
+
+	snap, ok := ctr.snapshots.Get(snapshotKey(blob, snapshot))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "snapshot %q not found for blob %q", snapshot, blob)
+	}
+
+	return &driver.Object{Info: objectInfo(snap), Data: append([]byte(nil), snap.Data...)}, nil
+}
+
+// snapshotKey namespaces a snapshot by its blob so distinct blobs don't collide.
+func snapshotKey(blob, snapshot string) string {
+	return blob + "\x00" + snapshot
+}
+
+// CreateAppendBlob creates an empty append blob.
+func (m *Mock) CreateAppendBlob(
+	_ context.Context, container, blob, contentType string, metadata map[string]string,
+) (*driver.ObjectInfo, error) {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+	}
+
+	if contentType == "" {
+		contentType = octetStream
+	}
+
+	obj := &blobObject{
+		Key: blob, Data: []byte{}, Size: 0, ContentType: contentType,
+		LastModified: m.opts.Clock.Now().UTC().Format(blobTimeFormat),
+		Metadata:     maps.Clone(metadata), BlobType: blobTypeAppend,
+	}
+	obj.ETag = computeBlobETag(obj)
+
+	ctr.objects.Set(blob, obj)
+
+	info := objectInfo(obj)
+
+	return &info, nil
+}
+
+// AppendBlock appends a block to the end of an append blob.
+func (m *Mock) AppendBlock(
+	_ context.Context, container, blob string, data []byte,
+) (offset int64, committedBlocks int, info *driver.ObjectInfo, err error) {
+	obj, err := m.getBlobObject(container, blob)
+	if err != nil {
+		return 0, 0, nil, err
+	}
+
+	if obj.BlobType != blobTypeAppend {
+		return 0, 0, nil, cerrors.Newf(cerrors.FailedPrecondition, "blob %q is not an append blob", blob)
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	offset = obj.Size
+	obj.Data = append(obj.Data, data...)
+	obj.Size = int64(len(obj.Data))
+	obj.appendBlocks++
+	obj.LastModified = m.opts.Clock.Now().UTC().Format(blobTimeFormat)
+	obj.ETag = computeBlobETag(obj)
+
+	m.emitMetric(container, map[string]float64{"Transactions": 1, "Ingress": float64(len(data))})
+
+	out := objectInfo(obj)
+
+	return offset, obj.appendBlocks, &out, nil
+}
+
+// SetContainerMetadata replaces a container's metadata.
+func (m *Mock) SetContainerMetadata(_ context.Context, container string, metadata map[string]string) error {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+	}
+
+	ctr.metadata = maps.Clone(metadata)
+
+	return nil
+}
+
+// ContainerMetadata returns a container's metadata.
+func (m *Mock) ContainerMetadata(_ context.Context, container string) (map[string]string, error) {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+	}
+
+	return maps.Clone(ctr.metadata), nil
+}
+
+// getBlobObject fetches a blob's in-memory record, erroring if the container or
+// blob is absent.
+func (m *Mock) getBlobObject(container, blob string) (*blobObject, error) {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+	}
+
+	obj, ok := ctr.objects.Get(blob)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "blob %q not found in container %q", blob, container)
+	}
+
+	return obj, nil
+}
+
+// computeBlobETag derives an ETag from a blob's content and mutable system
+// state, so a metadata/property/append update yields a changed ETag (as real
+// Azure does) while a pure content write stays sha256(content)-derived.
+func computeBlobETag(obj *blobObject) string {
+	h := sha256.New()
+	h.Write(obj.Data)
+	fmt.Fprintf(h, "\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s",
+		obj.BlobType, obj.ContentType, obj.ContentEncoding,
+		obj.ContentLanguage, obj.ContentDisposition, obj.CacheControl)
+
+	keys := make([]string, 0, len(obj.Metadata))
+	for k := range obj.Metadata {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		fmt.Fprintf(h, "\x00%s=%s", k, obj.Metadata[k])
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil))
+}

--- a/providers/azure/blobstorage/blob_extensions_test.go
+++ b/providers/azure/blobstorage/blob_extensions_test.go
@@ -1,0 +1,117 @@
+package blobstorage
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStageAndCommitBlockList(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+
+	require.NoError(t, m.StageBlock(ctx, "c1", "k1", "b1", []byte("foo")))
+	require.NoError(t, m.StageBlock(ctx, "c1", "k1", "b2", []byte("bar")))
+
+	info, err := m.CommitBlockList(ctx, "c1", "k1", []string{"b1", "b2"}, "text/plain", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(6), info.Size)
+
+	obj, err := m.GetObject(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, "foobar", string(obj.Data))
+	assert.Equal(t, "text/plain", obj.Info.ContentType)
+}
+
+func TestCommitBlockListMissingBlock(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+	require.NoError(t, m.StageBlock(ctx, "c1", "k1", "b1", []byte("foo")))
+
+	_, err := m.CommitBlockList(ctx, "c1", "k1", []string{"b1", "missing"}, "", nil)
+	require.Error(t, err)
+	assert.True(t, cerrors.IsInvalidArgument(err))
+}
+
+func TestSetBlobMetadataPreservesContent(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+	require.NoError(t, m.PutObject(ctx, "c1", "k1", []byte("payload"), "text/plain", nil))
+
+	before, err := m.HeadObject(ctx, "c1", "k1")
+	require.NoError(t, err)
+
+	info, err := m.SetBlobMetadata(ctx, "c1", "k1", map[string]string{"a": "b"})
+	require.NoError(t, err)
+	assert.NotEqual(t, before.ETag, info.ETag, "metadata update must change the ETag")
+
+	obj, err := m.GetObject(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, "payload", string(obj.Data))
+	assert.Equal(t, "b", obj.Info.Metadata["a"])
+}
+
+func TestAppendBlockRequiresAppendBlob(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+	require.NoError(t, m.PutObject(ctx, "c1", "k1", []byte("block"), "text/plain", nil))
+
+	_, _, _, err := m.AppendBlock(ctx, "c1", "k1", []byte("more"))
+	require.Error(t, err)
+	assert.True(t, cerrors.IsFailedPrecondition(err))
+}
+
+func TestAppendBlobLifecycle(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+
+	_, err := m.CreateAppendBlob(ctx, "c1", "k1", "text/plain", nil)
+	require.NoError(t, err)
+
+	offset, count, _, err := m.AppendBlock(ctx, "c1", "k1", []byte("one"))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), offset)
+	assert.Equal(t, 1, count)
+
+	offset, count, _, err = m.AppendBlock(ctx, "c1", "k1", []byte("two"))
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), offset)
+	assert.Equal(t, 2, count)
+
+	obj, err := m.GetObject(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, "onetwo", string(obj.Data))
+	assert.Equal(t, blobTypeAppend, obj.Info.BlobType)
+}
+
+func TestSnapshotSurvivesOverwrite(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+	require.NoError(t, m.PutObject(ctx, "c1", "k1", []byte("v1"), "text/plain", nil))
+
+	// Two snapshots at the same (fake) instant must get distinct IDs.
+	id1, _, err := m.CreateBlobSnapshot(ctx, "c1", "k1")
+	require.NoError(t, err)
+	id2, _, err := m.CreateBlobSnapshot(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.NotEqual(t, id1, id2)
+
+	require.NoError(t, m.PutObject(ctx, "c1", "k1", []byte("v2"), "text/plain", nil))
+
+	snap, err := m.GetBlobSnapshot(ctx, "c1", "k1", id1)
+	require.NoError(t, err)
+	assert.Equal(t, "v1", string(snap.Data), "snapshot must survive base overwrite")
+
+	base, err := m.GetObject(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, "v2", string(base.Data))
+}

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -42,6 +42,22 @@ type blobObject struct {
 	LastModified string
 	Metadata     map[string]string
 	Tags         map[string]string
+	// BlobType is "BlockBlob" (default, empty) or "AppendBlob".
+	BlobType string
+	// AccessTier is the blob access tier (Hot/Cool/Cold/Archive), set by Set Blob
+	// Tier; empty when unset.
+	AccessTier string
+	// Content* are additional system properties settable via Set Blob Properties.
+	ContentEncoding    string
+	ContentLanguage    string
+	ContentDisposition string
+	CacheControl       string
+	// mu guards the in-place mutations of the new Azure ops (append, metadata /
+	// property / tier updates). Whole-object replacements via the container store
+	// don't need it.
+	mu sync.Mutex
+	// appendBlocks counts committed Append Block operations (append blobs only).
+	appendBlocks int
 }
 
 type blobMultipartUpload struct {
@@ -67,14 +83,35 @@ type containerMeta struct {
 	corsConfig *driver.CORSConfig
 	encryption *driver.EncryptionConfig
 	tags       map[string]string
+	// metadata is the container's x-ms-meta-* metadata (Set Container Metadata).
+	metadata map[string]string
+	// staging holds uncommitted blocks (Put Block) keyed by blob name.
+	staging *memstore.Store[*blockStaging]
+	// snapshots holds immutable blob snapshots keyed by snapshotKey(blob, id).
+	// Snapshots live at the container level so they survive a base-blob
+	// overwrite, matching real Azure snapshot lifetime.
+	snapshots *memstore.Store[*blobObject]
+	// mu guards snapshotSeq (and any future container-scoped counters).
+	mu          sync.Mutex
+	snapshotSeq int
+}
+
+// blockStaging buffers the uncommitted blocks staged for one blob before a
+// Put Block List commits them.
+type blockStaging struct {
+	mu     sync.Mutex
+	blocks map[string][]byte
 }
 
 // Mock is an in-memory mock implementation of Azure Blob Storage.
 type Mock struct {
 	containers *memstore.Store[*containerMeta]
-	// bucketAttrs holds Azure storage-account attributes (SKU/kind/access tier)
-	// per container, for the BucketAttributes discovery capability.
+	// bucketAttrs holds Azure storage-account attributes (SKU/kind/access tier/
+	// location/tags) per container, for the BucketAttributes discovery capability.
 	bucketAttrs *memstore.Store[driver.AccountAttributes]
+	// accountKeys holds the shared access keys per storage account, generated
+	// lazily on first ListStorageAccountKeys.
+	accountKeys *memstore.Store[[]driver.AccountKey]
 	opts        *config.Options
 	monitoring  mondriver.Monitoring
 }
@@ -116,6 +153,7 @@ func New(opts *config.Options) *Mock {
 	return &Mock{
 		containers:  memstore.New[*containerMeta](),
 		bucketAttrs: memstore.New[driver.AccountAttributes](),
+		accountKeys: memstore.New[[]driver.AccountKey](),
 		opts:        opts,
 	}
 }
@@ -166,6 +204,8 @@ func (m *Mock) CreateBucket(_ context.Context, name string) error {
 		CreatedAt:  m.opts.Clock.Now().UTC().Format(blobTimeFormat),
 		objects:    memstore.New[*blobObject](),
 		multiparts: memstore.New[*blobMultipartUpload](),
+		staging:    memstore.New[*blockStaging](),
+		snapshots:  memstore.New[*blobObject](),
 	})
 
 	return nil
@@ -269,12 +309,18 @@ func (m *Mock) GetObject(ctx context.Context, bucket, key string) (*driver.Objec
 	m.emitMetric(bucket, map[string]float64{"Transactions": 1, "Egress": float64(obj.Size)})
 
 	return &driver.Object{
-		Info: driver.ObjectInfo{
-			Key: obj.Key, Size: obj.Size, ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
-		},
+		Info: objectInfo(obj),
 		Data: data,
 	}, nil
+}
+
+// objectInfo renders a blobObject as a driver.ObjectInfo with cloned metadata.
+func objectInfo(obj *blobObject) driver.ObjectInfo {
+	return driver.ObjectInfo{
+		Key: obj.Key, Size: obj.Size, ContentType: obj.ContentType,
+		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
+		BlobType: obj.BlobType, AccessTier: obj.AccessTier,
+	}
 }
 
 // loadObjectData returns the object's bytes: from the wired StorageEngine when
@@ -333,10 +379,9 @@ func (m *Mock) HeadObject(_ context.Context, bucket, key string) (*driver.Object
 		return nil, cerrors.Newf(cerrors.NotFound, "blob %q not found in container %q", key, bucket)
 	}
 
-	return &driver.ObjectInfo{
-		Key: obj.Key, Size: obj.Size, ContentType: obj.ContentType,
-		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
-	}, nil
+	info := objectInfo(obj)
+
+	return &info, nil
 }
 
 // ListObjects lists blobs in a container with optional prefix/delimiter filtering.
@@ -376,6 +421,7 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 		matchedObjects = append(matchedObjects, driver.ObjectInfo{
 			Key: obj.Key, Size: obj.Size, ContentType: obj.ContentType,
 			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+			BlobType: obj.BlobType, AccessTier: obj.AccessTier,
 		})
 	}
 

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -435,7 +435,8 @@ func (h *Handler) listObjects(w http.ResponseWriter, r *http.Request, bucket str
 		resp.NextContinuationToken = result.NextPageToken
 	}
 
-	for _, obj := range result.Objects {
+	for i := range result.Objects {
+		obj := &result.Objects[i]
 		resp.Contents = append(resp.Contents, objectXML{
 			Key:          obj.Key,
 			LastModified: obj.LastModified,
@@ -1246,7 +1247,8 @@ func (h *Handler) listObjectVersions(w http.ResponseWriter, r *http.Request, buc
 		return
 	}
 
-	for _, obj := range result.Objects {
+	for i := range result.Objects {
+		obj := &result.Objects[i]
 		resp.Versions = append(resp.Versions, objectVersionXML{
 			Key: obj.Key, VersionID: "null", IsLatest: true, LastModified: obj.LastModified,
 			ETag: fmt.Sprintf("%q", obj.ETag), Size: obj.Size, StorageClass: "STANDARD",

--- a/server/azure/blobstorage/blob_comp_test.go
+++ b/server/azure/blobstorage/blob_comp_test.go
@@ -1,0 +1,348 @@
+package blobstorage_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/appendblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// blobEnv is an httptest server over the Azure blob wire handler plus the
+// transport and a no-credential service client the real azblob sub-clients
+// share, so tests exercise the actual data-plane wire protocol.
+type blobEnv struct {
+	base string
+	tr   policy.Transporter
+	svc  *azblob.Client
+}
+
+func newBlobEnv(t *testing.T) *blobEnv {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{BlobStorage: cloudP.BlobStorage})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	tr := ts.Client()
+
+	svc, err := azblob.NewClientWithNoCredential(ts.URL+"/", &azblob.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: tr, Retry: policy.RetryOptions{MaxRetries: -1}},
+	})
+	if err != nil {
+		t.Fatalf("NewClientWithNoCredential: %v", err)
+	}
+
+	if _, err := svc.CreateContainer(context.Background(), "c1", nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	return &blobEnv{base: ts.URL, tr: tr, svc: svc}
+}
+
+func (e *blobEnv) clientOpts() policy.ClientOptions {
+	return policy.ClientOptions{Transport: e.tr, Retry: policy.RetryOptions{MaxRetries: -1}}
+}
+
+func (e *blobEnv) blockBlob(t *testing.T, path string) *blockblob.Client {
+	t.Helper()
+
+	c, err := blockblob.NewClientWithNoCredential(e.base+path, &blockblob.ClientOptions{ClientOptions: e.clientOpts()})
+	if err != nil {
+		t.Fatalf("blockblob.NewClient: %v", err)
+	}
+
+	return c
+}
+
+func (e *blobEnv) blob(t *testing.T, path string) *blob.Client {
+	t.Helper()
+
+	c, err := blob.NewClientWithNoCredential(e.base+path, &blob.ClientOptions{ClientOptions: e.clientOpts()})
+	if err != nil {
+		t.Fatalf("blob.NewClient: %v", err)
+	}
+
+	return c
+}
+
+// download reads a blob's content through the service client.
+func (e *blobEnv) download(t *testing.T, key string) string {
+	t.Helper()
+
+	dl, err := e.svc.DownloadStream(context.Background(), "c1", key, nil)
+	if err != nil {
+		t.Fatalf("DownloadStream %q: %v", key, err)
+	}
+
+	data, err := io.ReadAll(dl.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	return string(data)
+}
+
+func TestSDKStageAndCommitBlockList(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	bb := e.blockBlob(t, "/c1/k1")
+
+	blocks := [][]byte{[]byte("Hello, "), []byte("block "), []byte("world")}
+	ids := make([]string, len(blocks))
+
+	for i, b := range blocks {
+		id := base64.StdEncoding.EncodeToString([]byte("block-" + string(rune('a'+i))))
+		ids[i] = id
+
+		if _, err := bb.StageBlock(ctx, id, streaming.NopCloser(bytes.NewReader(b)), nil); err != nil {
+			t.Fatalf("StageBlock %d: %v", i, err)
+		}
+	}
+
+	if _, err := bb.CommitBlockList(ctx, ids, nil); err != nil {
+		t.Fatalf("CommitBlockList: %v", err)
+	}
+
+	if got := e.download(t, "k1"); got != "Hello, block world" {
+		t.Errorf("committed blob = %q, want %q", got, "Hello, block world")
+	}
+}
+
+func TestSDKSetMetadataPreservesContent(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	body := []byte("do not wipe me")
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", body, nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+
+	resp, err := bc.SetMetadata(ctx, map[string]*string{"stage": to.Ptr("qa")}, nil)
+	if err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+
+	if resp.ETag == nil {
+		t.Error("SetMetadata returned no ETag")
+	}
+
+	if got := e.download(t, "k1"); got != string(body) {
+		t.Errorf("content after SetMetadata = %q, want %q", got, body)
+	}
+
+	props, err := bc.GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties: %v", err)
+	}
+
+	// HTTP canonicalizes the x-ms-meta-<name> suffix, so the round-tripped key
+	// comes back title-cased ("Stage").
+	if props.Metadata["Stage"] == nil || *props.Metadata["Stage"] != "qa" {
+		t.Errorf("metadata not persisted: %v", props.Metadata)
+	}
+}
+
+func TestSDKSetHTTPHeadersPreservesContent(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	body := []byte("keep this body intact")
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", body, nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+
+	if _, err := bc.SetHTTPHeaders(ctx, blob.HTTPHeaders{BlobContentType: to.Ptr("text/plain")}, nil); err != nil {
+		t.Fatalf("SetHTTPHeaders: %v", err)
+	}
+
+	if got := e.download(t, "k1"); got != string(body) {
+		t.Errorf("content after SetHTTPHeaders = %q, want %q", got, body)
+	}
+
+	props, err := bc.GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties: %v", err)
+	}
+
+	if props.ContentType == nil || *props.ContentType != "text/plain" {
+		t.Errorf("content type = %v, want text/plain", props.ContentType)
+	}
+}
+
+func TestSDKSetTierPreservesContent(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	body := []byte("tiered content")
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", body, nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+
+	if _, err := bc.SetTier(ctx, blob.AccessTierCool, nil); err != nil {
+		t.Fatalf("SetTier: %v", err)
+	}
+
+	if got := e.download(t, "k1"); got != string(body) {
+		t.Errorf("content after SetTier = %q, want %q", got, body)
+	}
+
+	props, err := bc.GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties: %v", err)
+	}
+
+	if props.AccessTier == nil || *props.AccessTier != "Cool" {
+		t.Errorf("access tier = %v, want Cool", props.AccessTier)
+	}
+}
+
+func TestSDKConditionalPutIfNoneMatch(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	bb := e.blockBlob(t, "/c1/k1")
+
+	cond := &blockblob.UploadOptions{
+		AccessConditions: &blob.AccessConditions{
+			ModifiedAccessConditions: &blob.ModifiedAccessConditions{IfNoneMatch: to.Ptr(azcore.ETagAny)},
+		},
+	}
+
+	if _, err := bb.Upload(ctx, streaming.NopCloser(bytes.NewReader([]byte("first"))), cond); err != nil {
+		t.Fatalf("first conditional upload: %v", err)
+	}
+
+	if _, err := bb.Upload(ctx, streaming.NopCloser(bytes.NewReader([]byte("second"))), cond); err == nil {
+		t.Fatal("second conditional upload should have failed on existing blob")
+	}
+
+	if got := e.download(t, "k1"); got != "first" {
+		t.Errorf("blob overwritten despite If-None-Match:* : %q", got)
+	}
+}
+
+func TestSDKCreateSnapshot(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("version-1"), nil); err != nil {
+		t.Fatalf("UploadBuffer v1: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+
+	snap, err := bc.CreateSnapshot(ctx, nil)
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	if snap.Snapshot == nil || *snap.Snapshot == "" {
+		t.Fatal("CreateSnapshot returned empty x-ms-snapshot")
+	}
+
+	// Overwrite the base blob; the snapshot must still read the original bytes.
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("version-2"), nil); err != nil {
+		t.Fatalf("UploadBuffer v2: %v", err)
+	}
+
+	if got := e.download(t, "k1"); got != "version-2" {
+		t.Errorf("base blob = %q, want version-2", got)
+	}
+
+	snapClient, err := bc.WithSnapshot(*snap.Snapshot)
+	if err != nil {
+		t.Fatalf("WithSnapshot: %v", err)
+	}
+
+	dl, err := snapClient.DownloadStream(ctx, nil)
+	if err != nil {
+		t.Fatalf("snapshot DownloadStream: %v", err)
+	}
+
+	got, _ := io.ReadAll(dl.Body)
+	if string(got) != "version-1" {
+		t.Errorf("snapshot content = %q, want version-1", got)
+	}
+}
+
+func TestSDKAppendBlob(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	ac, err := appendblob.NewClientWithNoCredential(e.base+"/c1/k1", &appendblob.ClientOptions{ClientOptions: e.clientOpts()})
+	if err != nil {
+		t.Fatalf("appendblob.NewClient: %v", err)
+	}
+
+	if _, err := ac.Create(ctx, nil); err != nil {
+		t.Fatalf("Create append blob: %v", err)
+	}
+
+	for _, part := range []string{"one ", "two ", "three"} {
+		if _, err := ac.AppendBlock(ctx, streaming.NopCloser(bytes.NewReader([]byte(part))), nil); err != nil {
+			t.Fatalf("AppendBlock %q: %v", part, err)
+		}
+	}
+
+	if got := e.download(t, "k1"); got != "one two three" {
+		t.Errorf("append blob content = %q, want %q", got, "one two three")
+	}
+
+	props, err := ac.GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties: %v", err)
+	}
+
+	if props.BlobType == nil || *props.BlobType != blob.BlobTypeAppendBlob {
+		t.Errorf("blob type = %v, want AppendBlob", props.BlobType)
+	}
+}
+
+func TestSDKSetContainerMetadata(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	cc, err := container.NewClientWithNoCredential(e.base+"/c1", &container.ClientOptions{ClientOptions: e.clientOpts()})
+	if err != nil {
+		t.Fatalf("container.NewClient: %v", err)
+	}
+
+	if _, err := cc.SetMetadata(ctx, &container.SetMetadataOptions{
+		Metadata: map[string]*string{"team": to.Ptr("platform")},
+	}); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+
+	props, err := cc.GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties: %v", err)
+	}
+
+	if props.Metadata["Team"] == nil || *props.Metadata["Team"] != "platform" {
+		t.Errorf("container metadata = %v, want team=platform", props.Metadata)
+	}
+}

--- a/server/azure/blobstorage/blob_extensions.go
+++ b/server/azure/blobstorage/blob_extensions.go
@@ -1,0 +1,246 @@
+package blobstorage
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// blobExt is the Azure-specific blob capability, aliased for brevity.
+type blobExt = storagedriver.AzureBlobExtensions
+
+// stageBlock handles PUT /{container}/{blob}?comp=block&blockid=….
+func (*Handler) stageBlock(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	blockID := r.URL.Query().Get("blockid")
+	if blockID == "" {
+		writeError(w, http.StatusBadRequest, "InvalidQueryParameterValue", "missing blockid")
+		return
+	}
+
+	data, ok := readLimitedBody(w, r)
+	if !ok {
+		return
+	}
+
+	if err := ext.StageBlock(r.Context(), container, blob, blockID, data); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.Header().Set("X-Ms-Request-Server-Encrypted", "true")
+	w.WriteHeader(http.StatusCreated)
+}
+
+// commitBlockList handles PUT /{container}/{blob}?comp=blocklist.
+func (*Handler) commitBlockList(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	body, ok := readLimitedBody(w, r)
+	if !ok {
+		return
+	}
+
+	blockIDs, err := parseBlockListXML(body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidBlockList", err.Error())
+		return
+	}
+
+	info, err := ext.CommitBlockList(r.Context(), container, blob, blockIDs, blobContentType(r), extractMetadata(r.Header))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeWriteResult(w, info, http.StatusCreated)
+}
+
+// setBlobMetadata handles PUT /{container}/{blob}?comp=metadata.
+func (*Handler) setBlobMetadata(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	info, err := ext.SetBlobMetadata(r.Context(), container, blob, extractMetadata(r.Header))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeWriteResult(w, info, http.StatusOK)
+}
+
+// setBlobProperties handles PUT /{container}/{blob}?comp=properties.
+func (*Handler) setBlobProperties(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	props := &storagedriver.BlobProperties{
+		ContentType:        r.Header.Get("x-ms-blob-content-type"),
+		ContentEncoding:    r.Header.Get("x-ms-blob-content-encoding"),
+		ContentLanguage:    r.Header.Get("x-ms-blob-content-language"),
+		ContentDisposition: r.Header.Get("x-ms-blob-content-disposition"),
+		CacheControl:       r.Header.Get("x-ms-blob-cache-control"),
+	}
+
+	info, err := ext.SetBlobProperties(r.Context(), container, blob, props)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeWriteResult(w, info, http.StatusOK)
+}
+
+// setBlobTier handles PUT /{container}/{blob}?comp=tier.
+func (*Handler) setBlobTier(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	tier := r.Header.Get("x-ms-access-tier")
+	if tier == "" {
+		writeError(w, http.StatusBadRequest, "MissingRequiredHeader", "x-ms-access-tier is required")
+		return
+	}
+
+	if err := ext.SetBlobTier(r.Context(), container, blob, tier); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// snapshotBlob handles PUT /{container}/{blob}?comp=snapshot.
+func (*Handler) snapshotBlob(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	snapshot, info, err := ext.CreateBlobSnapshot(r.Context(), container, blob)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.Header().Set("X-Ms-Snapshot", snapshot)
+	writeWriteResult(w, info, http.StatusCreated)
+}
+
+// createAppendBlob handles PUT /{container}/{blob} with x-ms-blob-type: AppendBlob.
+func (*Handler) createAppendBlob(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	info, err := ext.CreateAppendBlob(r.Context(), container, blob, blobContentType(r), extractMetadata(r.Header))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.Header().Set("X-Ms-Request-Server-Encrypted", "true")
+	writeWriteResult(w, info, http.StatusCreated)
+}
+
+// appendBlock handles PUT /{container}/{blob}?comp=appendblock.
+func (*Handler) appendBlock(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	data, ok := readLimitedBody(w, r)
+	if !ok {
+		return
+	}
+
+	offset, committed, info, err := ext.AppendBlock(r.Context(), container, blob, data)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.Header().Set("X-Ms-Blob-Append-Offset", strconv.FormatInt(offset, 10))
+	w.Header().Set("X-Ms-Blob-Committed-Block-Count", strconv.Itoa(committed))
+	writeWriteResult(w, info, http.StatusCreated)
+}
+
+// setContainerMetadata handles PUT /{container}?restype=container&comp=metadata.
+func (h *Handler) setContainerMetadata(w http.ResponseWriter, r *http.Request, container string) {
+	ext, ok := h.bucket.(blobExt)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "container metadata not supported")
+		return
+	}
+
+	if err := ext.SetContainerMetadata(r.Context(), container, extractMetadata(r.Header)); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	created, _ := h.containerCreatedAt(r, container)
+	w.Header().Set("ETag", containerETag(container, created))
+	w.Header().Set("Last-Modified", httpDate(created))
+	w.WriteHeader(http.StatusOK)
+}
+
+// writeWriteResult writes the ETag/Last-Modified headers common to blob write
+// responses and the status code.
+func writeWriteResult(w http.ResponseWriter, info *storagedriver.ObjectInfo, status int) {
+	if info != nil {
+		w.Header().Set("ETag", fmt.Sprintf("%q", info.ETag))
+		w.Header().Set("Last-Modified", httpDate(info.LastModified))
+	}
+
+	w.Header().Set("X-Ms-Request-Server-Encrypted", "true")
+	w.WriteHeader(status)
+}
+
+// blobContentType resolves a blob's content type from x-ms-blob-content-type,
+// falling back to the request Content-Type.
+func blobContentType(r *http.Request) string {
+	if ct := r.Header.Get("x-ms-blob-content-type"); ct != "" {
+		return ct
+	}
+
+	return r.Header.Get("Content-Type")
+}
+
+// readLimitedBody reads the (capped) request body, writing a 400 on error.
+func readLimitedBody(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+	data, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxPutBodyBytes))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidInput", "could not read body")
+		return nil, false
+	}
+
+	return data, true
+}
+
+// parseBlockListXML extracts the ordered block IDs from a Put Block List body,
+// preserving document order across Latest/Committed/Uncommitted elements.
+func parseBlockListXML(body []byte) ([]string, error) {
+	dec := xml.NewDecoder(bytes.NewReader(body))
+
+	var (
+		ids     []string
+		capture bool
+	)
+
+	for {
+		tok, err := dec.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			capture = isBlockElement(t.Name.Local)
+		case xml.CharData:
+			if capture {
+				if id := string(bytes.TrimSpace([]byte(t))); id != "" {
+					ids = append(ids, id)
+				}
+			}
+		case xml.EndElement:
+			capture = false
+		}
+	}
+
+	if len(ids) == 0 {
+		return nil, cerrors.New(cerrors.InvalidArgument, "block list is empty")
+	}
+
+	return ids, nil
+}
+
+func isBlockElement(name string) bool {
+	return name == "Latest" || name == "Committed" || name == "Uncommitted"
+}

--- a/server/azure/blobstorage/handler.go
+++ b/server/azure/blobstorage/handler.go
@@ -47,6 +47,18 @@ const (
 
 	// compList is the value of the ?comp= parameter for list operations.
 	compList = "list"
+
+	// blobTypeBlockBlob is the default Azure blob type.
+	blobTypeBlockBlob = "BlockBlob"
+
+	// comp* are the ?comp= sub-operation selectors on a blob PUT.
+	compBlock       = "block"
+	compBlockList   = "blocklist"
+	compMetadata    = "metadata"
+	compProperties  = "properties"
+	compTier        = "tier"
+	compSnapshot    = "snapshot"
+	compAppendBlock = "appendblock"
 )
 
 // Handler serves Azure Blob Storage REST requests against a storage.Bucket
@@ -115,6 +127,11 @@ func parseBlobPath(path string) (container, blob string) {
 func (h *Handler) containerOp(w http.ResponseWriter, r *http.Request, container string, q url.Values) {
 	switch r.Method {
 	case http.MethodPut:
+		if q.Get("comp") == compMetadata {
+			h.setContainerMetadata(w, r, container)
+			return
+		}
+
 		h.createContainer(w, r, container)
 	case http.MethodDelete:
 		h.deleteContainer(w, r, container)
@@ -133,12 +150,7 @@ func (h *Handler) containerOp(w http.ResponseWriter, r *http.Request, container 
 func (h *Handler) blobOp(w http.ResponseWriter, r *http.Request, container, blob string) {
 	switch r.Method {
 	case http.MethodPut:
-		if r.Header.Get("X-Ms-Copy-Source") != "" {
-			h.copyBlob(w, r, container, blob)
-			return
-		}
-
-		h.putBlob(w, r, container, blob)
+		h.putBlobOp(w, r, container, blob)
 	case http.MethodGet:
 		h.getBlob(w, r, container, blob)
 	case http.MethodHead:
@@ -148,6 +160,58 @@ func (h *Handler) blobOp(w http.ResponseWriter, r *http.Request, container, blob
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
+}
+
+// putBlobOp dispatches a PUT on a blob by its ?comp= sub-operation. Azure
+// overloads PUT: plain Put Blob writes content, but comp=block/blocklist/
+// metadata/properties/tier/snapshot/appendblock each mean something different
+// and must NOT be treated as a content write (doing so corrupts the blob).
+func (h *Handler) putBlobOp(w http.ResponseWriter, r *http.Request, container, blob string) {
+	comp := r.URL.Query().Get("comp")
+
+	ext, hasExt := h.bucket.(storagedriver.AzureBlobExtensions)
+	if comp != "" && hasExt && h.dispatchBlobComp(w, r, ext, container, blob, comp) {
+		return
+	}
+
+	if r.Header.Get("X-Ms-Copy-Source") != "" {
+		h.copyBlob(w, r, container, blob)
+		return
+	}
+
+	if strings.EqualFold(r.Header.Get("x-ms-blob-type"), "AppendBlob") && hasExt {
+		h.createAppendBlob(w, r, ext, container, blob)
+		return
+	}
+
+	h.putBlob(w, r, container, blob)
+}
+
+// dispatchBlobComp routes a PUT comp sub-operation to its handler, returning
+// true when it handled the request and false for an unrecognized comp value.
+func (h *Handler) dispatchBlobComp(
+	w http.ResponseWriter, r *http.Request, ext storagedriver.AzureBlobExtensions, container, blob, comp string,
+) bool {
+	switch comp {
+	case compBlock:
+		h.stageBlock(w, r, ext, container, blob)
+	case compBlockList:
+		h.commitBlockList(w, r, ext, container, blob)
+	case compMetadata:
+		h.setBlobMetadata(w, r, ext, container, blob)
+	case compProperties:
+		h.setBlobProperties(w, r, ext, container, blob)
+	case compTier:
+		h.setBlobTier(w, r, ext, container, blob)
+	case compSnapshot:
+		h.snapshotBlob(w, r, ext, container, blob)
+	case compAppendBlock:
+		h.appendBlock(w, r, ext, container, blob)
+	default:
+		return false
+	}
+
+	return true
 }
 
 func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request) {
@@ -238,8 +302,8 @@ func (h *Handler) emptyContainer(r *http.Request, container string) error {
 		if len(list.Objects) == 0 {
 			return nil
 		}
-		for _, obj := range list.Objects {
-			err := h.bucket.DeleteObject(r.Context(), container, obj.Key)
+		for i := range list.Objects {
+			err := h.bucket.DeleteObject(r.Context(), container, list.Objects[i].Key)
 			if err != nil && !cerrors.IsNotFound(err) {
 				return err
 			}
@@ -258,6 +322,15 @@ func (h *Handler) getContainerProperties(w http.ResponseWriter, r *http.Request,
 	}
 	w.Header().Set("ETag", containerETag(container, created))
 	w.Header().Set("Last-Modified", httpDate(created))
+
+	if ext, ok := h.bucket.(storagedriver.AzureBlobExtensions); ok {
+		if meta, err := ext.ContainerMetadata(r.Context(), container); err == nil {
+			for k, v := range meta {
+				w.Header().Set("x-ms-meta-"+k, v)
+			}
+		}
+	}
+
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -291,7 +364,14 @@ func (h *Handler) listBlobs(w http.ResponseWriter, r *http.Request, container st
 		NextMarker:    result.NextPageToken,
 	}
 
-	for _, obj := range result.Objects {
+	for i := range result.Objects {
+		obj := &result.Objects[i]
+
+		blobType := obj.BlobType
+		if blobType == "" {
+			blobType = blobTypeBlockBlob
+		}
+
 		out.Blobs.Blobs = append(out.Blobs.Blobs, blobXML{
 			Name: obj.Key,
 			Properties: blobPropsXML{
@@ -299,7 +379,7 @@ func (h *Handler) listBlobs(w http.ResponseWriter, r *http.Request, container st
 				ETag:          fmt.Sprintf("%q", obj.ETag),
 				ContentLength: obj.Size,
 				ContentType:   obj.ContentType,
-				BlobType:      "BlockBlob",
+				BlobType:      blobType,
 			},
 		})
 	}
@@ -314,6 +394,10 @@ func (h *Handler) listBlobs(w http.ResponseWriter, r *http.Request, container st
 const defaultMaxResults = 5000
 
 func (h *Handler) putBlob(w http.ResponseWriter, r *http.Request, container, blob string) {
+	if h.conditionFailed(w, r, container, blob) {
+		return
+	}
+
 	limited := http.MaxBytesReader(w, r.Body, maxPutBodyBytes)
 
 	data, err := io.ReadAll(limited)
@@ -356,7 +440,79 @@ func (h *Handler) putBlob(w http.ResponseWriter, r *http.Request, container, blo
 	w.WriteHeader(http.StatusCreated)
 }
 
+// conditionFailed evaluates the If-None-Match / If-Match conditional write
+// headers against the current blob and, if a condition is not met, writes the
+// Azure error and returns true. Real Azure Put Blob returns 409 when
+// If-None-Match:* hits an existing blob (create-if-absent conflict) and 412
+// when If-Match does not match the current ETag.
+func (h *Handler) conditionFailed(w http.ResponseWriter, r *http.Request, container, blob string) bool {
+	ifNoneMatch := r.Header.Get("If-None-Match")
+	ifMatch := r.Header.Get("If-Match")
+
+	if ifNoneMatch == "" && ifMatch == "" {
+		return false
+	}
+
+	var curETag string
+
+	exists := false
+	if info, err := h.bucket.HeadObject(r.Context(), container, blob); err == nil {
+		exists = true
+		curETag = info.ETag
+	}
+
+	status, code := evalWriteConditions(ifNoneMatch, ifMatch, curETag, exists)
+	if status == 0 {
+		return false
+	}
+
+	writeError(w, status, code, conditionMessage(status))
+
+	return true
+}
+
+// evalWriteConditions evaluates the If-None-Match / If-Match write conditions
+// against the current blob state. It returns the HTTP status and Azure error
+// code to fail with, or (0, "") when the write may proceed.
+func evalWriteConditions(ifNoneMatch, ifMatch, curETag string, exists bool) (status int, code string) {
+	const conditionNotMet = "ConditionNotMet"
+
+	if ifNoneMatch == "*" && exists {
+		return http.StatusConflict, "BlobAlreadyExists"
+	}
+
+	if ifMatch != "" && (!exists || !etagMatches(ifMatch, curETag)) {
+		return http.StatusPreconditionFailed, conditionNotMet
+	}
+
+	if ifNoneMatch != "" && exists && etagMatches(ifNoneMatch, curETag) {
+		return http.StatusPreconditionFailed, conditionNotMet
+	}
+
+	return 0, ""
+}
+
+// conditionMessage maps a conditional-failure status to its Azure message.
+func conditionMessage(status int) string {
+	if status == http.StatusConflict {
+		return "the specified blob already exists"
+	}
+
+	return "the condition specified using HTTP conditional header(s) is not met"
+}
+
+// etagMatches compares a conditional-header ETag (which may be quoted) with a
+// stored raw ETag.
+func etagMatches(header, stored string) bool {
+	return strings.Trim(header, `"`) == strings.Trim(stored, `"`)
+}
+
 func (h *Handler) getBlob(w http.ResponseWriter, r *http.Request, container, blob string) {
+	if snapshot := r.URL.Query().Get("snapshot"); snapshot != "" {
+		h.getBlobSnapshot(w, r, container, blob, snapshot)
+		return
+	}
+
 	obj, err := h.bucket.GetObject(r.Context(), container, blob)
 	if err != nil {
 		writeErr(w, err)
@@ -366,6 +522,27 @@ func (h *Handler) getBlob(w http.ResponseWriter, r *http.Request, container, blo
 	writeBlobHeaders(w, &obj.Info, int64(len(obj.Data)))
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(obj.Data) //nolint:gosec // raw object bytes
+}
+
+// getBlobSnapshot serves GET /{container}/{blob}?snapshot=… reading an
+// immutable snapshot captured by Snapshot Blob.
+func (h *Handler) getBlobSnapshot(w http.ResponseWriter, r *http.Request, container, blob, snapshot string) {
+	ext, ok := h.bucket.(storagedriver.AzureBlobExtensions)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "snapshots not supported")
+		return
+	}
+
+	obj, err := ext.GetBlobSnapshot(r.Context(), container, blob, snapshot)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.Header().Set("X-Ms-Snapshot", snapshot)
+	writeBlobHeaders(w, &obj.Info, int64(len(obj.Data)))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(obj.Data) //nolint:gosec // raw snapshot bytes
 }
 
 func (h *Handler) headBlob(w http.ResponseWriter, r *http.Request, container, blob string) {
@@ -384,7 +561,17 @@ func writeBlobHeaders(w http.ResponseWriter, info *storagedriver.ObjectInfo, siz
 	w.Header().Set("ETag", fmt.Sprintf("%q", info.ETag))
 	w.Header().Set("Last-Modified", httpDate(info.LastModified))
 	w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
-	w.Header().Set("X-Ms-Blob-Type", "BlockBlob")
+
+	blobType := info.BlobType
+	if blobType == "" {
+		blobType = blobTypeBlockBlob
+	}
+
+	w.Header().Set("X-Ms-Blob-Type", blobType)
+
+	if info.AccessTier != "" {
+		w.Header().Set("X-Ms-Access-Tier", info.AccessTier)
+	}
 
 	for k, v := range info.Metadata {
 		w.Header().Set("x-ms-meta-"+k, v)

--- a/server/azure/storageaccount/account_keys_test.go
+++ b/server/azure/storageaccount/account_keys_test.go
@@ -1,0 +1,98 @@
+package storageaccount_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createAccount is a helper that provisions an account so the key operations
+// have a target.
+func createAccount(t *testing.T, client *armstorage.AccountsClient, name string) {
+	t.Helper()
+
+	poller, err := client.BeginCreate(context.Background(), "rg-1", name, armstorage.AccountCreateParameters{
+		Location: to.Ptr("eastus"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = poller.PollUntilDone(context.Background(), nil)
+	require.NoError(t, err)
+}
+
+// TestSDKStorageAccountListKeys proves POST .../listKeys returns a two-key
+// result the data plane can build a SharedKeyCredential from.
+func TestSDKStorageAccountListKeys(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+	createAccount(t, client, "acct1")
+
+	resp, err := client.ListKeys(ctx, "rg-1", "acct1", nil)
+	require.NoError(t, err)
+	require.Len(t, resp.Keys, 2)
+
+	names := map[string]string{}
+	for _, k := range resp.Keys {
+		require.NotNil(t, k.KeyName)
+		require.NotNil(t, k.Value)
+		assert.NotEmpty(t, *k.Value, "key value must not be empty")
+		require.NotNil(t, k.Permissions)
+		assert.Equal(t, armstorage.KeyPermissionFull, *k.Permissions)
+		names[*k.KeyName] = *k.Value
+	}
+
+	assert.Contains(t, names, "key1")
+	assert.Contains(t, names, "key2")
+
+	// Keys are stable across repeated list calls.
+	again, err := client.ListKeys(ctx, "rg-1", "acct1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, *resp.Keys[0].Value, *again.Keys[0].Value)
+}
+
+// TestSDKStorageAccountRegenerateKey proves regenerateKey rotates only the named
+// key and returns the full, updated list.
+func TestSDKStorageAccountRegenerateKey(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+	createAccount(t, client, "acct1")
+
+	before, err := client.ListKeys(ctx, "rg-1", "acct1", nil)
+	require.NoError(t, err)
+
+	key1Before := keyValue(before.Keys, "key1")
+	key2Before := keyValue(before.Keys, "key2")
+
+	resp, err := client.RegenerateKey(ctx, "rg-1", "acct1", armstorage.AccountRegenerateKeyParameters{
+		KeyName: to.Ptr("key1"),
+	}, nil)
+	require.NoError(t, err)
+	require.Len(t, resp.Keys, 2)
+
+	assert.NotEqual(t, key1Before, keyValue(resp.Keys, "key1"), "key1 should have rotated")
+	assert.Equal(t, key2Before, keyValue(resp.Keys, "key2"), "key2 should be unchanged")
+}
+
+// TestSDKStorageAccountListKeysMissing rejects key ops on an unknown account.
+func TestSDKStorageAccountListKeysMissing(t *testing.T) {
+	client := newAccountsClient(t)
+
+	_, err := client.ListKeys(context.Background(), "rg-1", "nope", nil)
+	require.Error(t, err)
+}
+
+func keyValue(keys []*armstorage.AccountKey, name string) string {
+	for _, k := range keys {
+		if k.KeyName != nil && *k.KeyName == name && k.Value != nil {
+			return *k.Value
+		}
+	}
+
+	return ""
+}

--- a/server/azure/storageaccount/account_properties_test.go
+++ b/server/azure/storageaccount/account_properties_test.go
@@ -1,0 +1,85 @@
+package storageaccount_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSDKStorageAccountLocationAndTags proves the submitted region and tags
+// survive an independent GET (previously the account always reported eastus and
+// dropped its tags).
+func TestSDKStorageAccountLocationAndTags(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acct1", armstorage.AccountCreateParameters{
+		Location: to.Ptr("westus2"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+		Tags:     map[string]*string{"env": to.Ptr("prod"), "team": to.Ptr("platform")},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	got, err := client.GetProperties(ctx, "rg-1", "acct1", nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, got.Location)
+	assert.Equal(t, "westus2", *got.Location)
+
+	require.NotNil(t, got.Tags["env"])
+	assert.Equal(t, "prod", *got.Tags["env"])
+	require.NotNil(t, got.Tags["team"])
+	assert.Equal(t, "platform", *got.Tags["team"])
+}
+
+// TestSDKStorageAccountPropertiesCompleteness proves the GET response is
+// populated with the endpoints/location/encryption fields SDK consumers expect.
+func TestSDKStorageAccountPropertiesCompleteness(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acct1", armstorage.AccountCreateParameters{
+		Location: to.Ptr("westeurope"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	got, err := client.GetProperties(ctx, "rg-1", "acct1", nil)
+	require.NoError(t, err)
+
+	props := got.Properties
+	require.NotNil(t, props)
+
+	require.NotNil(t, props.PrimaryLocation)
+	assert.Equal(t, "westeurope", *props.PrimaryLocation)
+
+	require.NotNil(t, props.StatusOfPrimary)
+	assert.Equal(t, armstorage.AccountStatusAvailable, *props.StatusOfPrimary)
+
+	require.NotNil(t, props.CreationTime)
+
+	require.NotNil(t, props.PrimaryEndpoints)
+	require.NotNil(t, props.PrimaryEndpoints.Blob)
+	assert.True(t, strings.Contains(*props.PrimaryEndpoints.Blob, "acct1.blob.core.windows.net"),
+		"blob endpoint = %q", *props.PrimaryEndpoints.Blob)
+	require.NotNil(t, props.PrimaryEndpoints.Queue)
+	require.NotNil(t, props.PrimaryEndpoints.Table)
+	require.NotNil(t, props.PrimaryEndpoints.File)
+
+	require.NotNil(t, props.Encryption)
+	require.NotNil(t, props.Encryption.KeySource)
+	assert.Equal(t, armstorage.KeySourceMicrosoftStorage, *props.Encryption.KeySource)
+}

--- a/server/azure/storageaccount/handler.go
+++ b/server/azure/storageaccount/handler.go
@@ -51,7 +51,8 @@ type attrBackend interface {
 // storage bucket driver.
 type Handler struct {
 	bucket storagedriver.Bucket
-	attrs  attrBackend // nil when the driver doesn't expose account attributes
+	attrs  attrBackend                      // nil when the driver doesn't expose account attributes
+	keys   storagedriver.StorageAccountKeys // nil when the driver doesn't expose access keys
 }
 
 // New returns a storage-account handler backed by b.
@@ -59,6 +60,10 @@ func New(b storagedriver.Bucket) *Handler {
 	h := &Handler{bucket: b}
 	if a, ok := b.(attrBackend); ok {
 		h.attrs = a
+	}
+
+	if k, ok := b.(storagedriver.StorageAccountKeys); ok {
+		h.keys = k
 	}
 
 	return h
@@ -94,6 +99,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// POST .../storageAccounts/{name}/{action} — key management (listKeys,
+	// regenerateKey). These carry a sub-resource action segment.
+	if r.Method == http.MethodPost && rp.SubResource != "" {
+		h.serveAction(w, r, &rp)
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPut:
 		h.createOrUpdate(w, r, &rp)
@@ -104,6 +116,73 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
+}
+
+// serveAction routes the POST action sub-resources (listKeys, regenerateKey).
+func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if !h.bucketExists(r.Context(), rp.ResourceName) {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound",
+			"storage account "+rp.ResourceName+" not found")
+		return
+	}
+
+	switch strings.ToLower(rp.SubResource) {
+	case "listkeys":
+		h.listKeys(w, r, rp)
+	case "regeneratekey":
+		h.regenerateKey(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "unknown action "+rp.SubResource)
+	}
+}
+
+// listKeys serves POST .../storageAccounts/{name}/listKeys.
+func (h *Handler) listKeys(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if h.keys == nil {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented", "key management not supported")
+		return
+	}
+
+	keys, err := h.keys.ListStorageAccountKeys(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMKeyList(keys))
+}
+
+// regenerateKey serves POST .../storageAccounts/{name}/regenerateKey.
+func (h *Handler) regenerateKey(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if h.keys == nil {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented", "key management not supported")
+		return
+	}
+
+	var body armRegenerateKey
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	keys, err := h.keys.RegenerateStorageAccountKey(r.Context(), rp.ResourceName, body.KeyName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMKeyList(keys))
+}
+
+// toARMKeyList maps driver keys to the ARM StorageAccountListKeysResult shape.
+func toARMKeyList(keys []storagedriver.AccountKey) armKeyList {
+	out := armKeyList{Keys: make([]armKey, 0, len(keys))}
+	for _, k := range keys {
+		out.Keys = append(out.Keys, armKey{
+			KeyName: k.KeyName, Value: k.Value, Permissions: k.Permissions, CreationTime: k.CreationTime,
+		})
+	}
+
+	return out
 }
 
 // serveCollection lists storage accounts at the subscription or resource-group
@@ -134,7 +213,7 @@ func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp *az
 			scope.ResourceGroup = "default"
 		}
 
-		out = append(out, h.toARMAccount(r.Context(), &scope, defaultLocation, nil))
+		out = append(out, h.toARMAccount(r.Context(), &scope))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, armAccountList{Value: out})
@@ -155,7 +234,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 		return
 	}
 
-	attrs := storagedriver.AccountAttributes{Kind: body.Kind}
+	attrs := storagedriver.AccountAttributes{Kind: body.Kind, Location: body.Location, Tags: body.Tags}
 	if body.SKU != nil {
 		attrs.SKU = body.SKU.Name
 	}
@@ -168,7 +247,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 		h.attrs.SetBucketAttributes(name, attrs)
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), rp, body.Location, body.Tags))
+	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), rp))
 }
 
 func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
@@ -178,7 +257,7 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp *azurearm.Resou
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), rp, defaultLocation, nil))
+	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), rp))
 }
 
 func (h *Handler) deleteAccount(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
@@ -206,10 +285,9 @@ func (h *Handler) bucketExists(ctx context.Context, name string) bool {
 }
 
 // toARMAccount renders the ARM storage-account wire shape, reading the stored
-// cost attributes (SKU / kind / access tier) back through the driver.
-func (h *Handler) toARMAccount(
-	ctx context.Context, rp *azurearm.ResourcePath, location string, tags map[string]string,
-) armAccount {
+// attributes (SKU / kind / access tier / location / tags) back through the
+// driver.
+func (h *Handler) toARMAccount(ctx context.Context, rp *azurearm.ResourcePath) armAccount {
 	attrs := storagedriver.AccountAttributes{SKU: "Standard_LRS", Kind: "StorageV2", AccessTier: "Hot"}
 	if h.attrs != nil {
 		if a, err := h.attrs.BucketAttributes(ctx, rp.ResourceName); err == nil {
@@ -217,6 +295,7 @@ func (h *Handler) toARMAccount(
 		}
 	}
 
+	location := attrs.Location
 	if location == "" {
 		location = defaultLocation
 	}
@@ -227,13 +306,58 @@ func (h *Handler) toARMAccount(
 		Type:     providerName + "/" + resourceType,
 		Location: location,
 		Kind:     attrs.Kind,
-		Tags:     tags,
+		Tags:     attrs.Tags,
 		SKU:      &armSKU{Name: attrs.SKU, Tier: skuTier(attrs.SKU)},
 		Properties: &armAccountProps{
 			AccessTier:        attrs.AccessTier,
 			ProvisioningState: "Succeeded",
+			PrimaryLocation:   location,
+			StatusOfPrimary:   "available",
+			CreationTime:      h.accountCreatedAt(ctx, rp.ResourceName),
+			PrimaryEndpoints:  accountEndpoints(rp.ResourceName),
+			Encryption:        defaultEncryption(),
 		},
 	}
+}
+
+// accountEndpoints builds the primaryEndpoints service URLs for an account.
+func accountEndpoints(account string) *armEndpoints {
+	return &armEndpoints{
+		Blob:  "https://" + account + ".blob.core.windows.net/",
+		Queue: "https://" + account + ".queue.core.windows.net/",
+		Table: "https://" + account + ".table.core.windows.net/",
+		File:  "https://" + account + ".file.core.windows.net/",
+	}
+}
+
+// defaultEncryption returns the always-on service-side encryption block real
+// Azure storage accounts report.
+func defaultEncryption() *armEncryption {
+	svc := &armEncryptionService{Enabled: true, KeyType: "Account"}
+
+	return &armEncryption{
+		KeySource: "Microsoft.Storage",
+		Services:  &armEncryptionServices{Blob: svc, File: svc},
+	}
+}
+
+// accountCreatedAt returns the account's creation timestamp from the backing
+// bucket, falling back to a stable default when unavailable.
+func (h *Handler) accountCreatedAt(ctx context.Context, name string) string {
+	const fallback = "2020-01-01T00:00:00.0000000Z"
+
+	buckets, err := h.bucket.ListBuckets(ctx)
+	if err != nil {
+		return fallback
+	}
+
+	for _, b := range buckets {
+		if b.Name == name && b.CreatedAt != "" {
+			return b.CreatedAt
+		}
+	}
+
+	return fallback
 }
 
 // skuTier derives the read-only SKU tier from the SKU name (Standard_LRS ->

--- a/server/azure/storageaccount/types.go
+++ b/server/azure/storageaccount/types.go
@@ -39,6 +39,55 @@ type armAccountList struct {
 }
 
 type armAccountProps struct {
-	AccessTier        string `json:"accessTier,omitempty"`
-	ProvisioningState string `json:"provisioningState,omitempty"`
+	AccessTier        string         `json:"accessTier,omitempty"`
+	ProvisioningState string         `json:"provisioningState,omitempty"`
+	PrimaryEndpoints  *armEndpoints  `json:"primaryEndpoints,omitempty"`
+	PrimaryLocation   string         `json:"primaryLocation,omitempty"`
+	StatusOfPrimary   string         `json:"statusOfPrimary,omitempty"`
+	CreationTime      string         `json:"creationTime,omitempty"`
+	Encryption        *armEncryption `json:"encryption,omitempty"`
+}
+
+// armEndpoints is the primaryEndpoints object (blob/queue/table/file service
+// URLs) on a storage account's properties.
+type armEndpoints struct {
+	Blob  string `json:"blob,omitempty"`
+	Queue string `json:"queue,omitempty"`
+	Table string `json:"table,omitempty"`
+	File  string `json:"file,omitempty"`
+}
+
+// armEncryption is the account encryption block: service-side encryption is
+// always on for Azure storage, keyed by Microsoft.Storage.
+type armEncryption struct {
+	Services  *armEncryptionServices `json:"services,omitempty"`
+	KeySource string                 `json:"keySource,omitempty"`
+}
+
+type armEncryptionServices struct {
+	Blob *armEncryptionService `json:"blob,omitempty"`
+	File *armEncryptionService `json:"file,omitempty"`
+}
+
+type armEncryptionService struct {
+	Enabled bool   `json:"enabled"`
+	KeyType string `json:"keyType,omitempty"`
+}
+
+// armKeyList is the StorageAccountListKeysResult returned by listKeys /
+// regenerateKey: {"keys":[{keyName,value,permissions}]}.
+type armKeyList struct {
+	Keys []armKey `json:"keys"`
+}
+
+type armKey struct {
+	KeyName      string `json:"keyName"`
+	Value        string `json:"value"`
+	Permissions  string `json:"permissions"`
+	CreationTime string `json:"creationTime,omitempty"`
+}
+
+// armRegenerateKey is the regenerateKey request body.
+type armRegenerateKey struct {
+	KeyName string `json:"keyName"`
 }

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -470,8 +470,8 @@ func (h *Handler) listObjects(w http.ResponseWriter, r *http.Request, bucket str
 		NextPageToken: result.NextPageToken,
 	}
 
-	for _, obj := range result.Objects {
-		out.Items = append(out.Items, toObjectResourceFromInfo(&obj, bucket, r))
+	for i := range result.Objects {
+		out.Items = append(out.Items, toObjectResourceFromInfo(&result.Objects[i], bucket, r))
 	}
 
 	writeJSON(w, http.StatusOK, out)

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -20,6 +20,96 @@ type AccountAttributes struct {
 	SKU        string // e.g. Standard_LRS, Premium_LRS
 	Kind       string // e.g. StorageV2, BlobStorage
 	AccessTier string // Hot / Cool
+	// Location is the account's region (e.g. westus2). Empty until an ARM
+	// create-or-update stamps it; the handler falls back to a default.
+	Location string
+	// Tags are the ARM resource tags submitted on create-or-update, round-tripped
+	// back on GET / list.
+	Tags map[string]string
+}
+
+// AccountKey is one access key of an Azure storage account (Microsoft.Storage
+// ListKeys / RegenerateKey). Value is a base64-encoded secret.
+type AccountKey struct {
+	KeyName      string
+	Value        string
+	Permissions  string // "Full" or "Read"
+	CreationTime string // RFC3339
+}
+
+// StorageAccountKeys is an OPTIONAL Azure-specific capability, discovered by
+// type assertion (like the networking AzureNetworkInterfaces surface). An Azure
+// storage-account backend exposes its shared access keys so a data-plane client
+// building a SharedKeyCredential can fetch and rotate them. S3/GCS buckets have
+// no equivalent and don't implement it.
+type StorageAccountKeys interface {
+	// ListStorageAccountKeys returns the account's access keys, generating a
+	// stable key1/key2 pair on first access.
+	ListStorageAccountKeys(ctx context.Context, account string) ([]AccountKey, error)
+	// RegenerateStorageAccountKey rotates the value of the named key (key1/key2)
+	// and returns the full, updated key list.
+	RegenerateStorageAccountKey(ctx context.Context, account, keyName string) ([]AccountKey, error)
+}
+
+// BlobProperties are the settable system (HTTP) properties of a blob, updated by
+// the Azure Set Blob Properties operation (?comp=properties). Empty fields clear
+// the corresponding property, matching Azure semantics.
+type BlobProperties struct {
+	ContentType        string
+	ContentEncoding    string
+	ContentLanguage    string
+	ContentDisposition string
+	CacheControl       string
+}
+
+// AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
+// discovered by type assertion. It covers operations with no AWS/GCS equivalent
+// (block staging + commit, metadata/properties/tier updates, snapshots, append
+// blobs, container metadata) so they are not forced onto the shared Bucket
+// interface every provider implements.
+type AzureBlobExtensions interface {
+	// StageBlock buffers an uncommitted block (Put Block, ?comp=block) for a blob
+	// under blockID; the blob need not exist yet.
+	StageBlock(ctx context.Context, container, blob, blockID string, data []byte) error
+	// CommitBlockList assembles a block blob (Put Block List, ?comp=blocklist)
+	// from the previously-staged blocks named by blockIDs, in the given order.
+	CommitBlockList(
+		ctx context.Context, container, blob string, blockIDs []string, contentType string, metadata map[string]string,
+	) (*ObjectInfo, error)
+
+	// SetBlobMetadata replaces only a blob's metadata (Set Blob Metadata,
+	// ?comp=metadata), preserving its content, and returns the new info.
+	SetBlobMetadata(ctx context.Context, container, blob string, metadata map[string]string) (*ObjectInfo, error)
+	// SetBlobProperties replaces only a blob's system properties (Set Blob
+	// Properties, ?comp=properties), preserving its content.
+	SetBlobProperties(ctx context.Context, container, blob string, props *BlobProperties) (*ObjectInfo, error)
+	// SetBlobTier sets a blob's access tier (Set Blob Tier, ?comp=tier),
+	// preserving its content and ETag.
+	SetBlobTier(ctx context.Context, container, blob, tier string) error
+
+	// CreateBlobSnapshot captures an immutable snapshot (Snapshot Blob,
+	// ?comp=snapshot) of a blob, preserving the base blob, and returns the
+	// snapshot's opaque timestamp identifier.
+	CreateBlobSnapshot(ctx context.Context, container, blob string) (snapshot string, info *ObjectInfo, err error)
+	// GetBlobSnapshot reads a previously captured snapshot (GET ?snapshot=…).
+	GetBlobSnapshot(ctx context.Context, container, blob, snapshot string) (*Object, error)
+
+	// CreateAppendBlob creates an empty append blob (Put Blob with
+	// x-ms-blob-type: AppendBlob).
+	CreateAppendBlob(ctx context.Context, container, blob, contentType string, metadata map[string]string) (*ObjectInfo, error)
+	// AppendBlock appends a block to the end of an append blob (Append Block,
+	// ?comp=appendblock). offset is the byte position the block was committed at;
+	// committedBlocks is the total number of blocks appended so far.
+	AppendBlock(
+		ctx context.Context, container, blob string, data []byte,
+	) (offset int64, committedBlocks int, info *ObjectInfo, err error)
+
+	// SetContainerMetadata replaces a container's metadata (Set Container
+	// Metadata, ?restype=container&comp=metadata).
+	SetContainerMetadata(ctx context.Context, container string, metadata map[string]string) error
+	// ContainerMetadata returns a container's metadata (Get Container Properties /
+	// Get Container Metadata).
+	ContainerMetadata(ctx context.Context, container string) (map[string]string, error)
 }
 
 // BucketAttributes is an OPTIONAL capability, discovered by type assertion (like
@@ -44,6 +134,12 @@ type ObjectInfo struct {
 	VersionID string
 	// DeleteMarker reports whether this version is a delete marker.
 	DeleteMarker bool
+	// BlobType is the Azure blob type ("BlockBlob" or "AppendBlob"). Empty is
+	// treated as BlockBlob; non-Azure providers leave it empty.
+	BlobType string
+	// AccessTier is the Azure blob access tier (Hot/Cool/Cold/Archive), set by
+	// Set Blob Tier. Empty when unset; non-Azure providers leave it empty.
+	AccessTier string
 }
 
 // Object is an object with its data.


### PR DESCRIPTION
## Summary

End-to-end fixes for Azure storage against the real azure-sdk-for-go clients, driven over an httptest wire server. Two areas: the storage-account ARM control plane and the blob data plane.

### Storage account (Microsoft.Storage/storageAccounts)
- **ListKeys** — `POST .../listKeys` now returns `{keys:[{keyName,value,permissions}]}` (was 405), unblocking every SharedKeyCredential/data-plane flow.
- **RegenerateKey** — `POST .../regenerateKey` rotates only the named key (key1/key2) and returns the full updated list (was 405).
- **Location** — the created region (e.g. `westus2`) is now persisted and echoed on GET/list (previously always `eastus`).
- **Tags** — submitted resource tags round-trip on GET/list (previously dropped).
- **Properties completeness** — GET now populates `primaryEndpoints` (blob/queue/table/file), `creationTime`, `primaryLocation`, `statusOfPrimary`, and `encryption`.

Keys are surfaced through a new optional `StorageAccountKeys` driver capability, discovered by type assertion (mirrors the existing `BucketAttributes` pattern).

### Blob data plane
PUT was being treated as Put Blob regardless of `?comp=`, corrupting blobs or returning wrong status. Now routed on `comp`:
- **StageBlock + CommitBlockList** (`comp=block` / `comp=blocklist`) — blocks are staged and the committed blob is assembled from the block list (was storing the literal BlockList XML as the blob body).
- **SetBlobMetadata** (`comp=metadata`) — updates only metadata, preserves content, returns 200 + new ETag (was wiping content via a misrouted Put Blob).
- **SetHTTPHeaders** (`comp=properties`) — updates only system properties, preserves data.
- **SetTier** (`comp=tier`) — sets access tier, preserves data/ETag; reported back on GetProperties.
- **CreateSnapshot** (`comp=snapshot`) — creates a container-scoped snapshot, returns `x-ms-snapshot`, preserves and outlives the base blob; readable via `GET ?snapshot=`.
- **Append blobs** — `x-ms-blob-type: AppendBlob` creates an append blob; `comp=appendblock` appends (with `x-ms-blob-append-offset` / committed-block-count); GetProperties reports `AppendBlob`.
- **Conditional Put Blob** — `If-None-Match: *` → 409 on an existing blob; `If-Match` mismatch → 412.
- **Set Container Metadata** (`restype=container&comp=metadata`) — returns 200 and updates metadata (was misrouted to CreateContainer → 409).

New blob behavior lives on an optional Azure-specific `AzureBlobExtensions` driver capability; `ObjectInfo` gains `BlobType`/`AccessTier` so the generic read path can report them.

### Collateral
- s3/gcs list-loop iteration switched to index-based because the shared `ObjectInfo` grew past the value-copy lint threshold. No behavior change.
- Coverage docs regenerated from the driver interfaces.

## Testing
- Real-SDK wire tests: `armstorage.AccountsClient` (ListKeys/RegenerateKey/location/tags/properties) and `azblob` sub-clients (StageBlock/CommitBlockList, SetMetadata/HTTPHeaders/Tier, conditional upload, CreateSnapshot, append blob, container metadata) over an httptest server.
- Provider unit tests for the new state/logic (block assembly, snapshot survival, append counting, key rotation).
- `go build ./...`, `go test ./...`, and golangci-lint on the changed packages are green.