### PR TITLE
fix(iam): permissions boundaries, service-linked roles, access-key limit, SimulatePrincipalPolicy, account summary/password-policy/MFA

### DIFF
--- a/providers/aws/iam/account.go
+++ b/providers/aws/iam/account.go
@@ -1,0 +1,155 @@
+package iam
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// Account-level IAM operations (GetAccountSummary, the account password policy,
+// and MFA devices) are AWS-only; the wire layer reaches them via type
+// assertions on the Mock rather than the portable driver.
+
+// AWS default account quotas reported by GetAccountSummary. Real values, held
+// as named constants to keep the summary map free of magic numbers.
+const (
+	quotaUsers                      = 5000
+	quotaGroups                     = 300
+	quotaRoles                      = 1000
+	quotaPolicies                   = 1500
+	quotaInstanceProfiles           = 1000
+	quotaServerCertificates         = 20
+	quotaGroupsPerUser              = 10
+	quotaSigningCertificatesPerUser = 2
+	quotaAttachedPoliciesPerGroup   = 10
+	quotaAttachedPoliciesPerRole    = 10
+	quotaAttachedPoliciesPerUser    = 10
+	quotaVersionsPerPolicy          = 5
+	quotaPolicySize                 = 6144
+	quotaUserPolicySize             = 2048
+	quotaGroupPolicySize            = 5120
+	quotaRolePolicySize             = 10240
+	quotaAssumeRolePolicySize       = 2048
+	quotaGlobalEndpointTokenVersion = 1
+	quotaPolicyVersionsInUse        = 10000
+)
+
+// awsManagedPolicyARNPrefix is the ARN prefix AWS-published managed policies
+// carry; everything else is a customer-managed policy counted in the summary.
+const awsManagedPolicyARNPrefix = "arn:aws:iam::aws:policy/"
+
+// defaultMinimumPasswordLength is the length AWS assigns when
+// UpdateAccountPasswordPolicy omits MinimumPasswordLength.
+const defaultMinimumPasswordLength = 6
+
+// boolToInt maps a presence flag to the 0/1 integer GetAccountSummary reports.
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+
+	return 0
+}
+
+// AccountSummary returns the IAM entity-usage and quota map for the account.
+func (m *Mock) AccountSummary(_ context.Context) (map[string]int, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	mfaTotal, mfaInUse := m.mfaCountsLocked()
+
+	return map[string]int{
+		"Users":                             len(m.users.All()),
+		"UsersQuota":                        quotaUsers,
+		"Groups":                            len(m.groups.All()),
+		"GroupsQuota":                       quotaGroups,
+		"Roles":                             len(m.roles.All()),
+		"RolesQuota":                        quotaRoles,
+		"Policies":                          m.customerManagedPolicyCountLocked(),
+		"PoliciesQuota":                     quotaPolicies,
+		"InstanceProfiles":                  len(m.instanceProfiles.All()),
+		"InstanceProfilesQuota":             quotaInstanceProfiles,
+		"ServerCertificates":                0,
+		"ServerCertificatesQuota":           quotaServerCertificates,
+		"MFADevices":                        mfaTotal,
+		"MFADevicesInUse":                   mfaInUse,
+		"AccountMFAEnabled":                 0,
+		"AccountAccessKeysPresent":          boolToInt(len(m.accessKeys.All()) > 0),
+		"AccountSigningCertificatesPresent": 0,
+		"AccountPasswordPresent":            boolToInt(m.passwordPolicy != nil),
+		"GroupsPerUserQuota":                quotaGroupsPerUser,
+		"AccessKeysPerUserQuota":            maxAccessKeysPerUser,
+		"SigningCertificatesPerUserQuota":   quotaSigningCertificatesPerUser,
+		"AttachedPoliciesPerGroupQuota":     quotaAttachedPoliciesPerGroup,
+		"AttachedPoliciesPerRoleQuota":      quotaAttachedPoliciesPerRole,
+		"AttachedPoliciesPerUserQuota":      quotaAttachedPoliciesPerUser,
+		"VersionsPerPolicyQuota":            quotaVersionsPerPolicy,
+		"PolicySizeQuota":                   quotaPolicySize,
+		"UserPolicySizeQuota":               quotaUserPolicySize,
+		"GroupPolicySizeQuota":              quotaGroupPolicySize,
+		"RolePolicySizeQuota":               quotaRolePolicySize,
+		"AssumeRolePolicySizeQuota":         quotaAssumeRolePolicySize,
+		"PolicyVersionsInUseQuota":          quotaPolicyVersionsInUse,
+		"GlobalEndpointTokenVersion":        quotaGlobalEndpointTokenVersion,
+	}, nil
+}
+
+// customerManagedPolicyCountLocked counts non-AWS-managed policies. Caller holds m.mu.
+func (m *Mock) customerManagedPolicyCountLocked() int {
+	count := 0
+
+	for _, p := range m.policies.All() {
+		if !strings.HasPrefix(p.ARN, awsManagedPolicyARNPrefix) {
+			count++
+		}
+	}
+
+	return count
+}
+
+// UpdateAccountPasswordPolicy creates or replaces the account password policy
+// (IAM UpdateAccountPasswordPolicy — the single create-or-update operation).
+func (m *Mock) UpdateAccountPasswordPolicy(_ context.Context, p driver.PasswordPolicy) error {
+	if p.MinimumPasswordLength == 0 {
+		p.MinimumPasswordLength = defaultMinimumPasswordLength
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cp := p
+	m.passwordPolicy = &cp
+
+	return nil
+}
+
+// GetAccountPasswordPolicy returns the account password policy, or NoSuchEntity
+// when none has been set.
+func (m *Mock) GetAccountPasswordPolicy(_ context.Context) (*driver.PasswordPolicy, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.passwordPolicy == nil {
+		return nil, errors.Newf(errors.NotFound, "The account password policy cannot be found")
+	}
+
+	cp := *m.passwordPolicy
+
+	return &cp, nil
+}
+
+// DeleteAccountPasswordPolicy removes the account password policy.
+func (m *Mock) DeleteAccountPasswordPolicy(_ context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.passwordPolicy == nil {
+		return errors.Newf(errors.NotFound, "The account password policy cannot be found")
+	}
+
+	m.passwordPolicy = nil
+
+	return nil
+}

--- a/providers/aws/iam/account_test.go
+++ b/providers/aws/iam/account_test.go
@@ -1,0 +1,111 @@
+package iam
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+func TestAccountSummary(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateUser(ctx, driver.UserConfig{Name: "u1"})
+	requireNoError(t, err)
+	_, err = m.CreateUser(ctx, driver.UserConfig{Name: "u2"})
+	requireNoError(t, err)
+	_, err = m.CreateRole(ctx, driver.RoleConfig{Name: "r1"})
+	requireNoError(t, err)
+
+	summary, err := m.AccountSummary(ctx)
+	requireNoError(t, err)
+
+	assertEqual(t, 2, summary["Users"])
+	assertEqual(t, 1, summary["Roles"])
+	assertEqual(t, maxAccessKeysPerUser, summary["AccessKeysPerUserQuota"])
+	assertEqual(t, 0, summary["AccountPasswordPresent"])
+
+	requireNoError(t, m.UpdateAccountPasswordPolicy(ctx, driver.PasswordPolicy{MinimumPasswordLength: 8}))
+
+	summary, err = m.AccountSummary(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 1, summary["AccountPasswordPresent"])
+}
+
+func TestAccountPasswordPolicy(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.GetAccountPasswordPolicy(ctx)
+	assertError(t, err, true)
+
+	if cerrors.GetCode(err) != cerrors.NotFound {
+		t.Fatalf("get before set: code = %v, want NotFound", cerrors.GetCode(err))
+	}
+
+	requireNoError(t, m.UpdateAccountPasswordPolicy(ctx, driver.PasswordPolicy{
+		MinimumPasswordLength: 12,
+		RequireSymbols:        true,
+		MaxPasswordAge:        90,
+	}))
+
+	got, err := m.GetAccountPasswordPolicy(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 12, got.MinimumPasswordLength)
+	assertEqual(t, true, got.RequireSymbols)
+	assertEqual(t, 90, got.MaxPasswordAge)
+
+	requireNoError(t, m.DeleteAccountPasswordPolicy(ctx))
+
+	_, err = m.GetAccountPasswordPolicy(ctx)
+	assertError(t, err, true)
+
+	// Deleting a missing policy errors.
+	assertError(t, m.DeleteAccountPasswordPolicy(ctx), true)
+}
+
+func TestUpdateAccountPasswordPolicyDefaultsLength(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	// Omitting MinimumPasswordLength falls back to the AWS default of 6.
+	requireNoError(t, m.UpdateAccountPasswordPolicy(ctx, driver.PasswordPolicy{RequireNumbers: true}))
+
+	got, err := m.GetAccountPasswordPolicy(ctx)
+	requireNoError(t, err)
+	assertEqual(t, defaultMinimumPasswordLength, got.MinimumPasswordLength)
+}
+
+func TestMFADevices(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	dev, err := m.CreateVirtualMFADevice(ctx, "root-mfa", "")
+	requireNoError(t, err)
+
+	if dev.SerialNumber == "" || len(dev.Base32StringSeed) == 0 || len(dev.QRCodePNG) == 0 {
+		t.Fatalf("incomplete virtual MFA device: %+v", dev)
+	}
+
+	// Duplicate name conflicts.
+	_, err = m.CreateVirtualMFADevice(ctx, "root-mfa", "")
+	assertError(t, err, true)
+
+	// Empty name is rejected.
+	_, err = m.CreateVirtualMFADevice(ctx, "", "")
+	assertError(t, err, true)
+
+	_, err = m.CreateUser(ctx, driver.UserConfig{Name: "u"})
+	requireNoError(t, err)
+
+	// A fresh virtual device is unassigned, so the user's list is empty.
+	devices, err := m.ListMFADevices(ctx, "u")
+	requireNoError(t, err)
+	assertEqual(t, 0, len(devices))
+
+	// Unknown user errors.
+	_, err = m.ListMFADevices(ctx, "ghost")
+	assertError(t, err, true)
+}

--- a/providers/aws/iam/iam.go
+++ b/providers/aws/iam/iam.go
@@ -32,6 +32,7 @@ type Mock struct {
 	groups           *memstore.Store[*groupData]
 	accessKeys       *memstore.Store[*accessKeyData]
 	instanceProfiles *memstore.Store[*driver.InstanceProfileInfo]
+	mfaDevices       *memstore.Store[*mfaDeviceData]
 
 	mu            sync.RWMutex
 	userPolicies  map[string]map[string]bool // userName -> set of managed policy ARNs
@@ -42,16 +43,19 @@ type Mock struct {
 	userInlinePolicies  map[string]map[string]string // userName -> policyName -> document
 	groupInlinePolicies map[string]map[string]string // groupName -> policyName -> document
 
+	passwordPolicy *driver.PasswordPolicy // nil until UpdateAccountPasswordPolicy is called
+
 	opts *config.Options
 }
 
 type userData struct {
-	Name      string
-	ID        string
-	ARN       string
-	Path      string
-	Tags      map[string]string
-	CreatedAt string
+	Name                string
+	ID                  string
+	ARN                 string
+	Path                string
+	Tags                map[string]string
+	CreatedAt           string
+	permissionsBoundary string // ARN of the permissions-boundary policy, if any
 }
 
 type roleData struct {
@@ -65,6 +69,7 @@ type roleData struct {
 	CreatedAt           string
 	Tags                map[string]string
 	inlinePolicies      map[string]string // policyName -> policy document JSON
+	permissionsBoundary string            // ARN of the permissions-boundary policy, if any
 }
 
 type policyData struct {
@@ -110,6 +115,7 @@ func New(opts *config.Options) *Mock {
 		groups:              memstore.New[*groupData](),
 		accessKeys:          memstore.New[*accessKeyData](),
 		instanceProfiles:    memstore.New[*driver.InstanceProfileInfo](),
+		mfaDevices:          memstore.New[*mfaDeviceData](),
 		userPolicies:        make(map[string]map[string]bool),
 		rolePolicies:        make(map[string]map[string]bool),
 		groupPolicies:       make(map[string]map[string]bool),
@@ -1093,6 +1099,23 @@ func (m *Mock) ListGroupsForUser(
 	return result, nil
 }
 
+// maxAccessKeysPerUser is the AWS quota: an IAM user may hold at most two
+// access keys at a time.
+const maxAccessKeysPerUser = 2
+
+// countAccessKeys returns how many access keys currently belong to userName.
+func (m *Mock) countAccessKeys(userName string) int {
+	count := 0
+
+	for _, ak := range m.accessKeys.All() {
+		if ak.UserName == userName {
+			count++
+		}
+	}
+
+	return count
+}
+
 // CreateAccessKey creates a new access key for the given user.
 func (m *Mock) CreateAccessKey(
 	_ context.Context, cfg driver.AccessKeyConfig,
@@ -1107,6 +1130,13 @@ func (m *Mock) CreateAccessKey(
 		return nil, errors.Newf(
 			errors.NotFound, "user %q not found", cfg.UserName,
 		)
+	}
+
+	// Real IAM caps a user at maxAccessKeysPerUser keys; a further create is
+	// rejected with LimitExceeded (HTTP 409).
+	if m.countAccessKeys(cfg.UserName) >= maxAccessKeysPerUser {
+		return nil, errors.Newf(errors.ResourceExhausted,
+			"Cannot exceed quota for AccessKeysPerUser: %d", maxAccessKeysPerUser)
 	}
 
 	keyID := fmt.Sprintf("AKIA%s", idgen.GenerateID(""))

--- a/providers/aws/iam/mfa_device.go
+++ b/providers/aws/iam/mfa_device.go
@@ -1,0 +1,88 @@
+package iam
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// mfaDeviceData is a stored MFA device. UserName is empty until the virtual
+// device is assigned to a user via EnableMFADevice (not yet emulated), so a
+// freshly created virtual device is unassigned and absent from ListMFADevices.
+type mfaDeviceData struct {
+	SerialNumber string
+	UserName     string
+	EnableDate   string
+	Base32Seed   []byte
+	QRCodePNG    []byte
+}
+
+// CreateVirtualMFADevice creates an unassigned virtual MFA device (IAM
+// CreateVirtualMFADevice).
+func (m *Mock) CreateVirtualMFADevice(_ context.Context, name, _ string) (*driver.VirtualMFADeviceInfo, error) {
+	if name == "" {
+		return nil, errors.Newf(errors.InvalidArgument, "VirtualMFADeviceName is required")
+	}
+
+	serial := idgen.AWSARN("iam", "", m.opts.AccountID, "mfa/"+name)
+
+	if m.mfaDevices.Has(serial) {
+		return nil, errors.Newf(errors.AlreadyExists, "MFA device %q already exists", serial)
+	}
+
+	seed := []byte("CLOUDEMU" + idgen.GenerateID(""))
+	qr := []byte("cloudemu-qr-" + name)
+
+	d := &mfaDeviceData{
+		SerialNumber: serial,
+		Base32Seed:   seed,
+		QRCodePNG:    qr,
+	}
+	m.mfaDevices.Set(serial, d)
+
+	return &driver.VirtualMFADeviceInfo{
+		SerialNumber:     serial,
+		Base32StringSeed: seed,
+		QRCodePNG:        qr,
+	}, nil
+}
+
+// ListMFADevices returns the MFA devices assigned to a user (IAM
+// ListMFADevices). A user with no assigned device gets an empty list.
+func (m *Mock) ListMFADevices(_ context.Context, userName string) ([]driver.MFADeviceInfo, error) {
+	if !m.users.Has(userName) {
+		return nil, errors.Newf(errors.NotFound, "user %q not found", userName)
+	}
+
+	var result []driver.MFADeviceInfo
+
+	for _, d := range m.mfaDevices.All() {
+		if d.UserName != userName {
+			continue
+		}
+
+		result = append(result, driver.MFADeviceInfo{
+			UserName:     d.UserName,
+			SerialNumber: d.SerialNumber,
+			EnableDate:   d.EnableDate,
+		})
+	}
+
+	return result, nil
+}
+
+// mfaCountsLocked returns the total number of virtual MFA devices and how many
+// are assigned to a user. The caller must hold m.mu.
+func (m *Mock) mfaCountsLocked() (total, inUse int) {
+	for _, d := range m.mfaDevices.All() {
+		total++
+
+		if d.UserName != "" {
+			inUse++
+		}
+	}
+
+	return total, inUse
+}

--- a/providers/aws/iam/permissions_boundary.go
+++ b/providers/aws/iam/permissions_boundary.go
@@ -1,0 +1,105 @@
+package iam
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+)
+
+// Permissions boundaries are an AWS-only concept: a managed-policy ARN that
+// caps the maximum permissions an IAM role or user can be granted. They are
+// not part of the portable driver, so the wire layer reaches them through a
+// type assertion on the AWS Mock.
+
+// PutRolePermissionsBoundary sets (or replaces) the permissions boundary of a
+// role (IAM PutRolePermissionsBoundary).
+func (m *Mock) PutRolePermissionsBoundary(_ context.Context, roleName, boundaryARN string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.roles.Get(roleName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "role %q not found", roleName)
+	}
+
+	rd.permissionsBoundary = boundaryARN
+
+	return nil
+}
+
+// DeleteRolePermissionsBoundary clears a role's permissions boundary (IAM
+// DeleteRolePermissionsBoundary).
+func (m *Mock) DeleteRolePermissionsBoundary(_ context.Context, roleName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.roles.Get(roleName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "role %q not found", roleName)
+	}
+
+	rd.permissionsBoundary = ""
+
+	return nil
+}
+
+// RolePermissionsBoundary returns a role's permissions-boundary ARN, or the
+// empty string when none is set. It exists for the wire layer to populate
+// Role.PermissionsBoundary on GetRole/CreateRole.
+func (m *Mock) RolePermissionsBoundary(_ context.Context, roleName string) (string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	rd, ok := m.roles.Get(roleName)
+	if !ok {
+		return "", errors.Newf(errors.NotFound, "role %q not found", roleName)
+	}
+
+	return rd.permissionsBoundary, nil
+}
+
+// PutUserPermissionsBoundary sets (or replaces) the permissions boundary of a
+// user (IAM PutUserPermissionsBoundary).
+func (m *Mock) PutUserPermissionsBoundary(_ context.Context, userName, boundaryARN string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ud, ok := m.users.Get(userName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "user %q not found", userName)
+	}
+
+	ud.permissionsBoundary = boundaryARN
+
+	return nil
+}
+
+// DeleteUserPermissionsBoundary clears a user's permissions boundary (IAM
+// DeleteUserPermissionsBoundary).
+func (m *Mock) DeleteUserPermissionsBoundary(_ context.Context, userName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ud, ok := m.users.Get(userName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "user %q not found", userName)
+	}
+
+	ud.permissionsBoundary = ""
+
+	return nil
+}
+
+// UserPermissionsBoundary returns a user's permissions-boundary ARN, or the
+// empty string when none is set.
+func (m *Mock) UserPermissionsBoundary(_ context.Context, userName string) (string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	ud, ok := m.users.Get(userName)
+	if !ok {
+		return "", errors.Newf(errors.NotFound, "user %q not found", userName)
+	}
+
+	return ud.permissionsBoundary, nil
+}

--- a/providers/aws/iam/permissions_boundary_test.go
+++ b/providers/aws/iam/permissions_boundary_test.go
@@ -1,0 +1,85 @@
+package iam
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+func TestRolePermissionsBoundary(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	const arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+
+	_, err := m.CreateRole(ctx, driver.RoleConfig{Name: "r"})
+	requireNoError(t, err)
+
+	// Unset boundary reads as empty.
+	got, err := m.RolePermissionsBoundary(ctx, "r")
+	requireNoError(t, err)
+	assertEqual(t, "", got)
+
+	requireNoError(t, m.PutRolePermissionsBoundary(ctx, "r", arn))
+
+	got, err = m.RolePermissionsBoundary(ctx, "r")
+	requireNoError(t, err)
+	assertEqual(t, arn, got)
+
+	requireNoError(t, m.DeleteRolePermissionsBoundary(ctx, "r"))
+
+	got, err = m.RolePermissionsBoundary(ctx, "r")
+	requireNoError(t, err)
+	assertEqual(t, "", got)
+
+	// Missing role errors on every op.
+	assertError(t, m.PutRolePermissionsBoundary(ctx, "ghost", arn), true)
+	assertError(t, m.DeleteRolePermissionsBoundary(ctx, "ghost"), true)
+
+	_, err = m.RolePermissionsBoundary(ctx, "ghost")
+	assertError(t, err, true)
+}
+
+func TestUserPermissionsBoundary(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	const arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+
+	_, err := m.CreateUser(ctx, driver.UserConfig{Name: "u"})
+	requireNoError(t, err)
+
+	requireNoError(t, m.PutUserPermissionsBoundary(ctx, "u", arn))
+
+	got, err := m.UserPermissionsBoundary(ctx, "u")
+	requireNoError(t, err)
+	assertEqual(t, arn, got)
+
+	requireNoError(t, m.DeleteUserPermissionsBoundary(ctx, "u"))
+
+	got, err = m.UserPermissionsBoundary(ctx, "u")
+	requireNoError(t, err)
+	assertEqual(t, "", got)
+
+	assertError(t, m.PutUserPermissionsBoundary(ctx, "ghost", arn), true)
+}
+
+func TestAccessKeyLimit(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateUser(ctx, driver.UserConfig{Name: "u"})
+	requireNoError(t, err)
+
+	for range maxAccessKeysPerUser {
+		_, err := m.CreateAccessKey(ctx, driver.AccessKeyConfig{UserName: "u"})
+		requireNoError(t, err)
+	}
+
+	_, err = m.CreateAccessKey(ctx, driver.AccessKeyConfig{UserName: "u"})
+	assertError(t, err, true)
+
+	if cerrors.GetCode(err) != cerrors.ResourceExhausted {
+		t.Fatalf("third key error code = %v, want ResourceExhausted", cerrors.GetCode(err))
+	}
+}

--- a/providers/aws/iam/service_linked_role.go
+++ b/providers/aws/iam/service_linked_role.go
@@ -25,8 +25,10 @@ func (m *Mock) CreateServiceLinkedRole(
 
 	name := serviceLinkedRoleName(awsServiceName, customSuffix)
 
+	// AWS's CreateServiceLinkedRole error set does not include EntityAlreadyExists;
+	// a duplicate name is rejected as InvalidInput (supply a different CustomSuffix).
 	if m.roles.Has(name) {
-		return nil, errors.Newf(errors.AlreadyExists,
+		return nil, errors.Newf(errors.InvalidArgument,
 			"service-linked role %q already exists (supply a different CustomSuffix)", name)
 	}
 
@@ -49,20 +51,57 @@ func (m *Mock) CreateServiceLinkedRole(
 }
 
 // serviceLinkedRoleName derives the AWSServiceRoleFor<Service>[_suffix] name
-// from a service principal such as "elasticbeanstalk.amazonaws.com".
+// from a service principal such as "elasticbeanstalk.amazonaws.com". AWS's
+// service-linked-role names are a fixed per-service table, not a derivable
+// function, so known principals resolve through canonicalServiceLinkedRoleBase;
+// unlisted ones fall back to a best-effort "capitalize the first label" heuristic.
 func serviceLinkedRoleName(awsServiceName, customSuffix string) string {
-	label := awsServiceName
-	if idx := strings.IndexByte(label, '.'); idx >= 0 {
-		label = label[:idx]
-	}
-
-	name := serviceLinkedRolePrefix + capitalize(label)
+	name := canonicalServiceLinkedRoleBase(awsServiceName)
 
 	if customSuffix != "" {
 		name += "_" + customSuffix
 	}
 
 	return name
+}
+
+// canonicalServiceLinkedRoleBase returns AWS's real, published service-linked
+// role name (without any custom suffix) for a known service principal, or the
+// heuristic AWSServiceRoleFor<Label> fallback for principals not in the table.
+func canonicalServiceLinkedRoleBase(awsServiceName string) string {
+	// AWS's canonical service-linked-role names for the principals users are
+	// most likely to reference. These cannot be produced by any simple casing
+	// transform, so they are mapped explicitly.
+	known := map[string]string{
+		"ecs.amazonaws.com":                     "AWSServiceRoleForECS",
+		"rds.amazonaws.com":                     "AWSServiceRoleForRDS",
+		"autoscaling.amazonaws.com":             "AWSServiceRoleForAutoScaling",
+		"elasticbeanstalk.amazonaws.com":        "AWSServiceRoleForElasticBeanstalk",
+		"application-autoscaling.amazonaws.com": "AWSServiceRoleForApplicationAutoScaling",
+		"opsworks.amazonaws.com":                "AWSServiceRoleForOpsWorks",
+		"elasticache.amazonaws.com":             "AWSServiceRoleForElastiCache",
+		"eks.amazonaws.com":                     "AWSServiceRoleForAmazonEKS",
+		"eks-nodegroup.amazonaws.com":           "AWSServiceRoleForAmazonEKSNodegroup",
+		"elasticloadbalancing.amazonaws.com":    "AWSServiceRoleForElasticLoadBalancing",
+		"spot.amazonaws.com":                    "AWSServiceRoleForEC2Spot",
+		"spotfleet.amazonaws.com":               "AWSServiceRoleForEC2SpotFleet",
+		"organizations.amazonaws.com":           "AWSServiceRoleForOrganizations",
+		"config.amazonaws.com":                  "AWSServiceRoleForConfig",
+		"ssm.amazonaws.com":                     "AWSServiceRoleForAmazonSSM",
+		"trustedadvisor.amazonaws.com":          "AWSServiceRoleForTrustedAdvisor",
+		"globalaccelerator.amazonaws.com":       "AWSServiceRoleForGlobalAccelerator",
+	}
+
+	if base, ok := known[awsServiceName]; ok {
+		return base
+	}
+
+	label := awsServiceName
+	if idx := strings.IndexByte(label, '.'); idx >= 0 {
+		label = label[:idx]
+	}
+
+	return serviceLinkedRolePrefix + capitalize(label)
 }
 
 // capitalize upper-cases the first byte of an ASCII service label.

--- a/providers/aws/iam/service_linked_role.go
+++ b/providers/aws/iam/service_linked_role.go
@@ -1,0 +1,82 @@
+package iam
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// serviceLinkedRolePrefix is the fixed prefix AWS gives every service-linked
+// role name (AWSServiceRoleFor<Service>).
+const serviceLinkedRolePrefix = "AWSServiceRoleFor"
+
+// CreateServiceLinkedRole creates an IAM role linked to an AWS service (IAM
+// CreateServiceLinkedRole). It is AWS-only, so the wire layer reaches it via a
+// type assertion on the Mock rather than the portable driver.
+func (m *Mock) CreateServiceLinkedRole(
+	_ context.Context, awsServiceName, customSuffix, description string,
+) (*driver.RoleInfo, error) {
+	if awsServiceName == "" {
+		return nil, errors.Newf(errors.InvalidArgument, "AWSServiceName is required")
+	}
+
+	name := serviceLinkedRoleName(awsServiceName, customSuffix)
+
+	if m.roles.Has(name) {
+		return nil, errors.Newf(errors.AlreadyExists,
+			"service-linked role %q already exists (supply a different CustomSuffix)", name)
+	}
+
+	r := &roleData{
+		Name:                name,
+		ID:                  idgen.GenerateID("AROA"),
+		ARN:                 idgen.AWSARN("iam", "", m.opts.AccountID, "role/aws-service-role/"+awsServiceName+"/"+name),
+		Path:                "/aws-service-role/" + awsServiceName + "/",
+		Description:         description,
+		AssumeRolePolicyDoc: serviceLinkedTrustPolicy(awsServiceName),
+		MaxSessionDuration:  defaultMaxSessionDuration,
+		CreatedAt:           m.opts.Clock.Now().UTC().Format(timeFormat),
+		Tags:                make(map[string]string),
+	}
+	m.roles.Set(name, r)
+
+	info := toRoleInfo(r)
+
+	return &info, nil
+}
+
+// serviceLinkedRoleName derives the AWSServiceRoleFor<Service>[_suffix] name
+// from a service principal such as "elasticbeanstalk.amazonaws.com".
+func serviceLinkedRoleName(awsServiceName, customSuffix string) string {
+	label := awsServiceName
+	if idx := strings.IndexByte(label, '.'); idx >= 0 {
+		label = label[:idx]
+	}
+
+	name := serviceLinkedRolePrefix + capitalize(label)
+
+	if customSuffix != "" {
+		name += "_" + customSuffix
+	}
+
+	return name
+}
+
+// capitalize upper-cases the first byte of an ASCII service label.
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// serviceLinkedTrustPolicy builds the trust policy that lets the target service
+// principal assume the role.
+func serviceLinkedTrustPolicy(awsServiceName string) string {
+	return `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"` +
+		awsServiceName + `"},"Action":"sts:AssumeRole"}]}`
+}

--- a/providers/aws/iam/service_linked_role_test.go
+++ b/providers/aws/iam/service_linked_role_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/stackshy/cloudemu/v2/errors"
 )
 
 func TestCreateServiceLinkedRole(t *testing.T) {
@@ -13,7 +15,9 @@ func TestCreateServiceLinkedRole(t *testing.T) {
 	role, err := m.CreateServiceLinkedRole(ctx, "elasticbeanstalk.amazonaws.com", "", "beanstalk")
 	requireNoError(t, err)
 
-	assertEqual(t, "AWSServiceRoleForElasticbeanstalk", role.Name)
+	// AWS's canonical name is AWSServiceRoleForElasticBeanstalk, not a
+	// first-byte-capitalized "Elasticbeanstalk".
+	assertEqual(t, "AWSServiceRoleForElasticBeanstalk", role.Name)
 	assertEqual(t, "/aws-service-role/elasticbeanstalk.amazonaws.com/", role.Path)
 
 	if !strings.Contains(role.AssumeRolePolicyDoc, "elasticbeanstalk.amazonaws.com") {
@@ -25,14 +29,21 @@ func TestCreateServiceLinkedRole(t *testing.T) {
 	requireNoError(t, err)
 	assertEqual(t, role.Name, got.Name)
 
-	// Duplicate without a suffix conflicts.
+	// Duplicate without a suffix is rejected as InvalidArgument (AWS: InvalidInput),
+	// never AlreadyExists — EntityAlreadyExists is not in this action's error set.
 	_, err = m.CreateServiceLinkedRole(ctx, "elasticbeanstalk.amazonaws.com", "", "")
 	assertError(t, err, true)
+	if !errors.IsInvalidArgument(err) {
+		t.Fatalf("duplicate error = %v, want InvalidArgument", err)
+	}
+	if errors.IsAlreadyExists(err) {
+		t.Fatalf("duplicate error must not be AlreadyExists: %v", err)
+	}
 
 	// CustomSuffix yields a distinct name.
 	suffixed, err := m.CreateServiceLinkedRole(ctx, "elasticbeanstalk.amazonaws.com", "debug", "")
 	requireNoError(t, err)
-	assertEqual(t, "AWSServiceRoleForElasticbeanstalk_debug", suffixed.Name)
+	assertEqual(t, "AWSServiceRoleForElasticBeanstalk_debug", suffixed.Name)
 
 	// Empty service name is rejected.
 	_, err = m.CreateServiceLinkedRole(ctx, "", "", "")

--- a/providers/aws/iam/service_linked_role_test.go
+++ b/providers/aws/iam/service_linked_role_test.go
@@ -1,0 +1,40 @@
+package iam
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestCreateServiceLinkedRole(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	role, err := m.CreateServiceLinkedRole(ctx, "elasticbeanstalk.amazonaws.com", "", "beanstalk")
+	requireNoError(t, err)
+
+	assertEqual(t, "AWSServiceRoleForElasticbeanstalk", role.Name)
+	assertEqual(t, "/aws-service-role/elasticbeanstalk.amazonaws.com/", role.Path)
+
+	if !strings.Contains(role.AssumeRolePolicyDoc, "elasticbeanstalk.amazonaws.com") {
+		t.Fatalf("trust policy missing service principal: %s", role.AssumeRolePolicyDoc)
+	}
+
+	// Retrievable as a normal role.
+	got, err := m.GetRole(ctx, role.Name)
+	requireNoError(t, err)
+	assertEqual(t, role.Name, got.Name)
+
+	// Duplicate without a suffix conflicts.
+	_, err = m.CreateServiceLinkedRole(ctx, "elasticbeanstalk.amazonaws.com", "", "")
+	assertError(t, err, true)
+
+	// CustomSuffix yields a distinct name.
+	suffixed, err := m.CreateServiceLinkedRole(ctx, "elasticbeanstalk.amazonaws.com", "debug", "")
+	requireNoError(t, err)
+	assertEqual(t, "AWSServiceRoleForElasticbeanstalk_debug", suffixed.Name)
+
+	// Empty service name is rejected.
+	_, err = m.CreateServiceLinkedRole(ctx, "", "", "")
+	assertError(t, err, true)
+}

--- a/providers/aws/iam/simulate.go
+++ b/providers/aws/iam/simulate.go
@@ -1,0 +1,166 @@
+package iam
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// IAM policy simulation is AWS-only, so these methods are not part of the
+// portable driver; the wire layer reaches them via a type assertion on the
+// Mock. The evaluation reuses the same wildcard matcher CheckPermission uses.
+
+// SimulatePrincipalPolicy evaluates the policies attached to the principal
+// named by policySourceARN (plus any extra policy documents) against each
+// action/resource pair (IAM SimulatePrincipalPolicy).
+func (m *Mock) SimulatePrincipalPolicy(
+	_ context.Context, policySourceARN string, actions, resourceARNs, extraPolicies []string,
+) ([]driver.SimulationResult, error) {
+	entityType, name := parsePrincipalARN(policySourceARN)
+	docs := m.gatherPrincipalDocs(entityType, name)
+	docs = append(docs, extraPolicies...)
+
+	return simulate(docs, actions, resourceARNs), nil
+}
+
+// SimulateCustomPolicy evaluates a set of standalone policy documents against
+// each action/resource pair (IAM SimulateCustomPolicy).
+func (*Mock) SimulateCustomPolicy(
+	_ context.Context, policyDocs, actions, resourceARNs []string,
+) ([]driver.SimulationResult, error) {
+	return simulate(policyDocs, actions, resourceARNs), nil
+}
+
+// simulate evaluates every action against every resource (defaulting to "*"
+// when no resources are given) and reports the resulting decision.
+func simulate(docs, actions, resourceARNs []string) []driver.SimulationResult {
+	resources := resourceARNs
+	if len(resources) == 0 {
+		resources = []string{"*"}
+	}
+
+	results := make([]driver.SimulationResult, 0, len(actions)*len(resources))
+
+	for _, action := range actions {
+		for _, resource := range resources {
+			results = append(results, driver.SimulationResult{
+				ActionName:   action,
+				ResourceName: resource,
+				Decision:     decide(docs, action, resource),
+			})
+		}
+	}
+
+	return results
+}
+
+// decide reduces a set of policy documents to a single simulation decision for
+// one action/resource: an explicit Deny wins, then any Allow, else the default
+// implicit deny.
+func decide(docs []string, action, resource string) string {
+	allow, deny := false, false
+
+	for _, doc := range docs {
+		a, d := evaluatePolicy(doc, action, resource)
+		if d {
+			deny = true
+		}
+
+		if a {
+			allow = true
+		}
+	}
+
+	switch {
+	case deny:
+		return "explicitDeny"
+	case allow:
+		return "allowed"
+	default:
+		return "implicitDeny"
+	}
+}
+
+// parsePrincipalARN extracts the entity type ("user", "role", or "group") and
+// friendly name from an IAM principal ARN, tolerating an embedded path.
+func parsePrincipalARN(arn string) (entityType, name string) {
+	for _, t := range []string{"user", "role", "group"} {
+		marker := ":" + t + "/"
+
+		idx := strings.Index(arn, marker)
+		if idx < 0 {
+			continue
+		}
+
+		rest := arn[idx+len(marker):]
+		if s := strings.LastIndexByte(rest, '/'); s >= 0 {
+			rest = rest[s+1:]
+		}
+
+		return t, rest
+	}
+
+	return "", ""
+}
+
+// gatherPrincipalDocs returns every policy document in effect for a principal:
+// its attached managed policies and inline policies, plus (for a user) the
+// policies of every group it belongs to.
+func (m *Mock) gatherPrincipalDocs(entityType, name string) []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var docs []string
+
+	switch entityType {
+	case "user":
+		docs = append(docs, m.managedDocsLocked(m.userPolicies[name])...)
+		for _, d := range m.userInlinePolicies[name] {
+			docs = append(docs, d)
+		}
+
+		for groupName, members := range m.groupUsers {
+			if members[name] {
+				docs = append(docs, m.groupDocsLocked(groupName)...)
+			}
+		}
+	case "role":
+		docs = append(docs, m.managedDocsLocked(m.rolePolicies[name])...)
+
+		if rd, ok := m.roles.Get(name); ok {
+			for _, d := range rd.inlinePolicies {
+				docs = append(docs, d)
+			}
+		}
+	case "group":
+		docs = append(docs, m.groupDocsLocked(name)...)
+	}
+
+	return docs
+}
+
+// groupDocsLocked returns a group's managed and inline policy documents. The
+// caller must hold m.mu.
+func (m *Mock) groupDocsLocked(name string) []string {
+	docs := m.managedDocsLocked(m.groupPolicies[name])
+	for _, d := range m.groupInlinePolicies[name] {
+		docs = append(docs, d)
+	}
+
+	return docs
+}
+
+// managedDocsLocked resolves a set of managed-policy ARNs to their default
+// policy documents. The caller must hold m.mu.
+func (m *Mock) managedDocsLocked(arns map[string]bool) []string {
+	docs := make([]string, 0, len(arns))
+
+	for arn := range arns {
+		if p, ok := m.policies.Get(arn); ok && p.PolicyDocument != "" {
+			docs = append(docs, p.PolicyDocument)
+		}
+	}
+
+	return docs
+}

--- a/providers/aws/iam/simulate_test.go
+++ b/providers/aws/iam/simulate_test.go
@@ -1,0 +1,90 @@
+package iam
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+func makeAllowDoc(action, resource string) string {
+	return makePolicyDoc([]map[string]any{
+		{"Effect": "Allow", "Action": action, "Resource": resource},
+	})
+}
+
+func TestSimulatePrincipalPolicy(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateRole(ctx, driver.RoleConfig{Name: "r"})
+	requireNoError(t, err)
+
+	pol, err := m.CreatePolicy(ctx, driver.PolicyConfig{
+		Name:           "p",
+		PolicyDocument: makeAllowDoc("s3:ListBucket", "*"),
+	})
+	requireNoError(t, err)
+	requireNoError(t, m.AttachRolePolicy(ctx, "r", pol.ARN))
+
+	results, err := m.SimulatePrincipalPolicy(ctx, "arn:aws:iam::123456789012:role/r",
+		[]string{"s3:ListBucket", "s3:DeleteObject"}, []string{"arn:aws:s3:::b"}, nil)
+	requireNoError(t, err)
+
+	assertEqual(t, 2, len(results))
+	assertEqual(t, "allowed", decisionOf(results, "s3:ListBucket"))
+	assertEqual(t, "implicitDeny", decisionOf(results, "s3:DeleteObject"))
+}
+
+func TestSimulatePrincipalPolicyWithGroups(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateUser(ctx, driver.UserConfig{Name: "u"})
+	requireNoError(t, err)
+	_, err = m.CreateGroup(ctx, driver.GroupConfig{Name: "g"})
+	requireNoError(t, err)
+	requireNoError(t, m.AddUserToGroup(ctx, "u", "g"))
+
+	pol, err := m.CreatePolicy(ctx, driver.PolicyConfig{
+		Name:           "gp",
+		PolicyDocument: makeAllowDoc("ec2:DescribeInstances", "*"),
+	})
+	requireNoError(t, err)
+	requireNoError(t, m.AttachGroupPolicy(ctx, "g", pol.ARN))
+
+	// The user inherits the group's policy in the simulation.
+	results, err := m.SimulatePrincipalPolicy(ctx, "arn:aws:iam::123456789012:user/u",
+		[]string{"ec2:DescribeInstances"}, nil, nil)
+	requireNoError(t, err)
+	assertEqual(t, "allowed", decisionOf(results, "ec2:DescribeInstances"))
+}
+
+func TestSimulateCustomPolicyExplicitDeny(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	deny := makePolicyDoc([]map[string]any{
+		{"Effect": "Allow", "Action": "s3:*", "Resource": "*"},
+		{"Effect": "Deny", "Action": "s3:DeleteObject", "Resource": "*"},
+	})
+
+	results, err := m.SimulateCustomPolicy(ctx, []string{deny},
+		[]string{"s3:GetObject", "s3:DeleteObject"}, nil)
+	requireNoError(t, err)
+
+	// No resources supplied -> defaults to "*".
+	assertEqual(t, "*", results[0].ResourceName)
+	assertEqual(t, "allowed", decisionOf(results, "s3:GetObject"))
+	assertEqual(t, "explicitDeny", decisionOf(results, "s3:DeleteObject"))
+}
+
+func decisionOf(results []driver.SimulationResult, action string) string {
+	for i := range results {
+		if results[i].ActionName == action {
+			return results[i].Decision
+		}
+	}
+
+	return ""
+}

--- a/server/aws/iam/access_key_limit_test.go
+++ b/server/aws/iam/access_key_limit_test.go
@@ -1,0 +1,37 @@
+package iam_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// TestSDKAccessKeyLimit asserts a user is capped at two access keys and the
+// third create fails with LimitExceeded (HTTP 409).
+func TestSDKAccessKeyLimit(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("keyed")}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	for i := range 2 {
+		if _, err := client.CreateAccessKey(ctx, &iam.CreateAccessKeyInput{
+			UserName: aws.String("keyed"),
+		}); err != nil {
+			t.Fatalf("CreateAccessKey #%d: %v", i+1, err)
+		}
+	}
+
+	_, err := client.CreateAccessKey(ctx, &iam.CreateAccessKeyInput{UserName: aws.String("keyed")})
+
+	var limit *iamtypes.LimitExceededException
+	if !errors.As(err, &limit) {
+		t.Fatalf("third CreateAccessKey: want LimitExceededException, got %v", err)
+	}
+}

--- a/server/aws/iam/account.go
+++ b/server/aws/iam/account.go
@@ -1,0 +1,214 @@
+package iam
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"sort"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// accountSummarizer is the AWS-specific GetAccountSummary surface.
+type accountSummarizer interface {
+	AccountSummary(ctx context.Context) (map[string]int, error)
+}
+
+// passwordPolicyManager is the AWS-specific account-password-policy surface.
+type passwordPolicyManager interface {
+	UpdateAccountPasswordPolicy(ctx context.Context, p iamdriver.PasswordPolicy) error
+	GetAccountPasswordPolicy(ctx context.Context) (*iamdriver.PasswordPolicy, error)
+	DeleteAccountPasswordPolicy(ctx context.Context) error
+}
+
+type summaryEntryXML struct {
+	Key   string `xml:"key"`
+	Value int    `xml:"value"`
+}
+
+type summaryMapXML struct {
+	Entry []summaryEntryXML `xml:"entry"`
+}
+
+type getAccountSummaryResponse struct {
+	XMLName  xml.Name                `xml:"GetAccountSummaryResponse"`
+	Xmlns    string                  `xml:"xmlns,attr"`
+	Result   getAccountSummaryResult `xml:"GetAccountSummaryResult"`
+	Metadata responseMetadata        `xml:"ResponseMetadata"`
+}
+
+type getAccountSummaryResult struct {
+	SummaryMap summaryMapXML `xml:"SummaryMap"`
+}
+
+type passwordPolicyXML struct {
+	MinimumPasswordLength      int  `xml:"MinimumPasswordLength"`
+	RequireSymbols             bool `xml:"RequireSymbols"`
+	RequireNumbers             bool `xml:"RequireNumbers"`
+	RequireUppercaseCharacters bool `xml:"RequireUppercaseCharacters"`
+	RequireLowercaseCharacters bool `xml:"RequireLowercaseCharacters"`
+	AllowUsersToChangePassword bool `xml:"AllowUsersToChangePassword"`
+	ExpirePasswords            bool `xml:"ExpirePasswords"`
+	MaxPasswordAge             int  `xml:"MaxPasswordAge,omitempty"`
+	PasswordReusePrevention    int  `xml:"PasswordReusePrevention,omitempty"`
+	HardExpiry                 bool `xml:"HardExpiry"`
+}
+
+type getAccountPasswordPolicyResponse struct {
+	XMLName  xml.Name                       `xml:"GetAccountPasswordPolicyResponse"`
+	Xmlns    string                         `xml:"xmlns,attr"`
+	Result   getAccountPasswordPolicyResult `xml:"GetAccountPasswordPolicyResult"`
+	Metadata responseMetadata               `xml:"ResponseMetadata"`
+}
+
+type getAccountPasswordPolicyResult struct {
+	PasswordPolicy passwordPolicyXML `xml:"PasswordPolicy"`
+}
+
+type updateAccountPasswordPolicyResponse struct {
+	XMLName  xml.Name         `xml:"UpdateAccountPasswordPolicyResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type deleteAccountPasswordPolicyResponse struct {
+	XMLName  xml.Name         `xml:"DeleteAccountPasswordPolicyResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+func (h *Handler) getAccountSummary(w http.ResponseWriter, r *http.Request) {
+	summarizer, ok := h.iam.(accountSummarizer)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "GetAccountSummary not supported")
+		return
+	}
+
+	summary, err := summarizer.AccountSummary(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	keys := make([]string, 0, len(summary))
+	for k := range summary {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	entries := make([]summaryEntryXML, 0, len(keys))
+	for _, k := range keys {
+		entries = append(entries, summaryEntryXML{Key: k, Value: summary[k]})
+	}
+
+	awsquery.WriteXMLResponse(w, getAccountSummaryResponse{
+		Xmlns:    Namespace,
+		Result:   getAccountSummaryResult{SummaryMap: summaryMapXML{Entry: entries}},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) getAccountPasswordPolicy(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.iam.(passwordPolicyManager)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "password policy not supported")
+		return
+	}
+
+	p, err := mgr.GetAccountPasswordPolicy(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, getAccountPasswordPolicyResponse{
+		Xmlns:    Namespace,
+		Result:   getAccountPasswordPolicyResult{PasswordPolicy: toPasswordPolicyXML(p)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) updateAccountPasswordPolicy(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.iam.(passwordPolicyManager)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "password policy not supported")
+		return
+	}
+
+	if err := mgr.UpdateAccountPasswordPolicy(r.Context(), passwordPolicyFromForm(r)); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, updateAccountPasswordPolicyResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) deleteAccountPasswordPolicy(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.iam.(passwordPolicyManager)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "password policy not supported")
+		return
+	}
+
+	if err := mgr.DeleteAccountPasswordPolicy(r.Context()); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteAccountPasswordPolicyResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// toPasswordPolicyXML maps a stored policy to its wire shape, deriving the
+// read-only ExpirePasswords flag from MaxPasswordAge.
+func toPasswordPolicyXML(p *iamdriver.PasswordPolicy) passwordPolicyXML {
+	return passwordPolicyXML{
+		MinimumPasswordLength:      p.MinimumPasswordLength,
+		RequireSymbols:             p.RequireSymbols,
+		RequireNumbers:             p.RequireNumbers,
+		RequireUppercaseCharacters: p.RequireUppercaseCharacters,
+		RequireLowercaseCharacters: p.RequireLowercaseCharacters,
+		AllowUsersToChangePassword: p.AllowUsersToChangePassword,
+		ExpirePasswords:            p.MaxPasswordAge > 0,
+		MaxPasswordAge:             p.MaxPasswordAge,
+		PasswordReusePrevention:    p.PasswordReusePrevention,
+		HardExpiry:                 p.HardExpiry,
+	}
+}
+
+// passwordPolicyFromForm parses the UpdateAccountPasswordPolicy request. Omitted
+// boolean parameters default to false, matching real IAM.
+func passwordPolicyFromForm(r *http.Request) iamdriver.PasswordPolicy {
+	return iamdriver.PasswordPolicy{
+		MinimumPasswordLength:      formInt(r, "MinimumPasswordLength"),
+		RequireSymbols:             formBool(r, "RequireSymbols"),
+		RequireNumbers:             formBool(r, "RequireNumbers"),
+		RequireUppercaseCharacters: formBool(r, "RequireUppercaseCharacters"),
+		RequireLowercaseCharacters: formBool(r, "RequireLowercaseCharacters"),
+		AllowUsersToChangePassword: formBool(r, "AllowUsersToChangePassword"),
+		MaxPasswordAge:             formInt(r, "MaxPasswordAge"),
+		PasswordReusePrevention:    formInt(r, "PasswordReusePrevention"),
+		HardExpiry:                 formBool(r, "HardExpiry"),
+	}
+}
+
+func formInt(r *http.Request, key string) int {
+	n, err := strconv.Atoi(r.Form.Get(key))
+	if err != nil {
+		return 0
+	}
+
+	return n
+}
+
+func formBool(r *http.Request, key string) bool {
+	return r.Form.Get(key) == formValueTrue
+}

--- a/server/aws/iam/account_test.go
+++ b/server/aws/iam/account_test.go
@@ -1,0 +1,90 @@
+package iam_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+func TestSDKGetAccountSummary(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"u1", "u2"} {
+		if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String(name)}); err != nil {
+			t.Fatalf("CreateUser %s: %v", name, err)
+		}
+	}
+
+	out, err := client.GetAccountSummary(ctx, &iam.GetAccountSummaryInput{})
+	if err != nil {
+		t.Fatalf("GetAccountSummary: %v", err)
+	}
+
+	if got := out.SummaryMap["Users"]; got != 2 {
+		t.Fatalf("SummaryMap[Users] = %d, want 2", got)
+	}
+
+	if got := out.SummaryMap["AccessKeysPerUserQuota"]; got != 2 {
+		t.Fatalf("SummaryMap[AccessKeysPerUserQuota] = %d, want 2", got)
+	}
+
+	if got := out.SummaryMap["UsersQuota"]; got != 5000 {
+		t.Fatalf("SummaryMap[UsersQuota] = %d, want 5000", got)
+	}
+}
+
+func TestSDKAccountPasswordPolicy(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	// No policy set yet -> NoSuchEntity.
+	_, err := client.GetAccountPasswordPolicy(ctx, &iam.GetAccountPasswordPolicyInput{})
+
+	var notFound *iamtypes.NoSuchEntityException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("GetAccountPasswordPolicy before set: want NoSuchEntityException, got %v", err)
+	}
+
+	if _, err := client.UpdateAccountPasswordPolicy(ctx, &iam.UpdateAccountPasswordPolicyInput{
+		MinimumPasswordLength: aws.Int32(12),
+		RequireSymbols:        true,
+		MaxPasswordAge:        aws.Int32(90),
+	}); err != nil {
+		t.Fatalf("UpdateAccountPasswordPolicy: %v", err)
+	}
+
+	got, err := client.GetAccountPasswordPolicy(ctx, &iam.GetAccountPasswordPolicyInput{})
+	if err != nil {
+		t.Fatalf("GetAccountPasswordPolicy: %v", err)
+	}
+
+	if aws.ToInt32(got.PasswordPolicy.MinimumPasswordLength) != 12 {
+		t.Fatalf("MinimumPasswordLength = %d, want 12", aws.ToInt32(got.PasswordPolicy.MinimumPasswordLength))
+	}
+
+	if !got.PasswordPolicy.RequireSymbols {
+		t.Fatal("RequireSymbols = false, want true")
+	}
+
+	if !got.PasswordPolicy.ExpirePasswords {
+		t.Fatal("ExpirePasswords = false, want true (MaxPasswordAge set)")
+	}
+
+	if aws.ToInt32(got.PasswordPolicy.MaxPasswordAge) != 90 {
+		t.Fatalf("MaxPasswordAge = %d, want 90", aws.ToInt32(got.PasswordPolicy.MaxPasswordAge))
+	}
+
+	if _, err := client.DeleteAccountPasswordPolicy(ctx, &iam.DeleteAccountPasswordPolicyInput{}); err != nil {
+		t.Fatalf("DeleteAccountPasswordPolicy: %v", err)
+	}
+
+	_, err = client.GetAccountPasswordPolicy(ctx, &iam.GetAccountPasswordPolicyInput{})
+	if !errors.As(err, &notFound) {
+		t.Fatalf("GetAccountPasswordPolicy after delete: want NoSuchEntityException, got %v", err)
+	}
+}

--- a/server/aws/iam/handler.go
+++ b/server/aws/iam/handler.go
@@ -98,6 +98,19 @@ var iamActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup
 	"UntagUser":                      {},
 	"ListUserTags":                   {},
 	"GetAccountAuthorizationDetails": {},
+	"CreateServiceLinkedRole":        {},
+	"PutRolePermissionsBoundary":     {},
+	"DeleteRolePermissionsBoundary":  {},
+	"PutUserPermissionsBoundary":     {},
+	"DeleteUserPermissionsBoundary":  {},
+	"SimulatePrincipalPolicy":        {},
+	"SimulateCustomPolicy":           {},
+	"GetAccountSummary":              {},
+	"GetAccountPasswordPolicy":       {},
+	"UpdateAccountPasswordPolicy":    {},
+	"DeleteAccountPasswordPolicy":    {},
+	"CreateVirtualMFADevice":         {},
+	"ListMFADevices":                 {},
 }
 
 // roleTagManager is the AWS-specific role-tagging surface, asserted against the
@@ -321,6 +334,32 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.listUserTags(w, r)
 	case "GetAccountAuthorizationDetails":
 		h.getAccountAuthorizationDetails(w, r)
+	case "CreateServiceLinkedRole":
+		h.createServiceLinkedRole(w, r)
+	case "PutRolePermissionsBoundary":
+		h.putRolePermissionsBoundary(w, r)
+	case "DeleteRolePermissionsBoundary":
+		h.deleteRolePermissionsBoundary(w, r)
+	case "PutUserPermissionsBoundary":
+		h.putUserPermissionsBoundary(w, r)
+	case "DeleteUserPermissionsBoundary":
+		h.deleteUserPermissionsBoundary(w, r)
+	case "SimulatePrincipalPolicy":
+		h.simulatePrincipalPolicy(w, r)
+	case "SimulateCustomPolicy":
+		h.simulateCustomPolicy(w, r)
+	case "GetAccountSummary":
+		h.getAccountSummary(w, r)
+	case "GetAccountPasswordPolicy":
+		h.getAccountPasswordPolicy(w, r)
+	case "UpdateAccountPasswordPolicy":
+		h.updateAccountPasswordPolicy(w, r)
+	case "DeleteAccountPasswordPolicy":
+		h.deleteAccountPasswordPolicy(w, r)
+	case "CreateVirtualMFADevice":
+		h.createVirtualMFADevice(w, r)
+	case "ListMFADevices":
+		h.listMFADevices(w, r)
 	default:
 		awsquery.WriteXMLError(w, http.StatusBadRequest,
 			"InvalidAction", "unknown IAM action: "+r.Form.Get("Action"))

--- a/server/aws/iam/mfa_device.go
+++ b/server/aws/iam/mfa_device.go
@@ -1,0 +1,113 @@
+package iam
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/xml"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// mfaDeviceManager is the AWS-specific MFA-device surface. It's not part of the
+// portable IAM driver, so the handler type-asserts for it.
+type mfaDeviceManager interface {
+	CreateVirtualMFADevice(ctx context.Context, name, path string) (*iamdriver.VirtualMFADeviceInfo, error)
+	ListMFADevices(ctx context.Context, userName string) ([]iamdriver.MFADeviceInfo, error)
+}
+
+// The seed and QR-code payloads are blob fields the SDK base64-decodes on the
+// way in, so they are emitted as base64 text rather than relying on the XML
+// encoder's byte handling.
+type virtualMFADeviceXML struct {
+	SerialNumber     string `xml:"SerialNumber"`
+	Base32StringSeed string `xml:"Base32StringSeed,omitempty"`
+	QRCodePNG        string `xml:"QRCodePNG,omitempty"`
+}
+
+type createVirtualMFADeviceResponse struct {
+	XMLName  xml.Name                     `xml:"CreateVirtualMFADeviceResponse"`
+	Xmlns    string                       `xml:"xmlns,attr"`
+	Result   createVirtualMFADeviceResult `xml:"CreateVirtualMFADeviceResult"`
+	Metadata responseMetadata             `xml:"ResponseMetadata"`
+}
+
+type createVirtualMFADeviceResult struct {
+	VirtualMFADevice virtualMFADeviceXML `xml:"VirtualMFADevice"`
+}
+
+type mfaDeviceXML struct {
+	UserName     string `xml:"UserName"`
+	SerialNumber string `xml:"SerialNumber"`
+	EnableDate   string `xml:"EnableDate,omitempty"`
+}
+
+type mfaDevicesListXML struct {
+	Member []mfaDeviceXML `xml:"member,omitempty"`
+}
+
+type listMFADevicesResponse struct {
+	XMLName  xml.Name             `xml:"ListMFADevicesResponse"`
+	Xmlns    string               `xml:"xmlns,attr"`
+	Result   listMFADevicesResult `xml:"ListMFADevicesResult"`
+	Metadata responseMetadata     `xml:"ResponseMetadata"`
+}
+
+type listMFADevicesResult struct {
+	MFADevices  mfaDevicesListXML `xml:"MFADevices"`
+	IsTruncated bool              `xml:"IsTruncated"`
+}
+
+func (h *Handler) createVirtualMFADevice(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.iam.(mfaDeviceManager)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "MFA devices not supported")
+		return
+	}
+
+	d, err := mgr.CreateVirtualMFADevice(r.Context(), r.Form.Get("VirtualMFADeviceName"), r.Form.Get("Path"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createVirtualMFADeviceResponse{
+		Xmlns: Namespace,
+		Result: createVirtualMFADeviceResult{VirtualMFADevice: virtualMFADeviceXML{
+			SerialNumber:     d.SerialNumber,
+			Base32StringSeed: base64.StdEncoding.EncodeToString(d.Base32StringSeed),
+			QRCodePNG:        base64.StdEncoding.EncodeToString(d.QRCodePNG),
+		}},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) listMFADevices(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.iam.(mfaDeviceManager)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "MFA devices not supported")
+		return
+	}
+
+	devices, err := mgr.ListMFADevices(r.Context(), r.Form.Get("UserName"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := mfaDevicesListXML{Member: make([]mfaDeviceXML, 0, len(devices))}
+	for i := range devices {
+		out.Member = append(out.Member, mfaDeviceXML{
+			UserName:     devices[i].UserName,
+			SerialNumber: devices[i].SerialNumber,
+			EnableDate:   devices[i].EnableDate,
+		})
+	}
+
+	awsquery.WriteXMLResponse(w, listMFADevicesResponse{
+		Xmlns:    Namespace,
+		Result:   listMFADevicesResult{MFADevices: out, IsTruncated: false},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}

--- a/server/aws/iam/mfa_device_test.go
+++ b/server/aws/iam/mfa_device_test.go
@@ -1,0 +1,60 @@
+package iam_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+)
+
+func TestSDKCreateVirtualMFADevice(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateVirtualMFADevice(ctx, &iam.CreateVirtualMFADeviceInput{
+		VirtualMFADeviceName: aws.String("root-mfa"),
+	})
+	if err != nil {
+		t.Fatalf("CreateVirtualMFADevice: %v", err)
+	}
+
+	serial := aws.ToString(out.VirtualMFADevice.SerialNumber)
+	if !strings.HasSuffix(serial, ":mfa/root-mfa") {
+		t.Fatalf("serial number %q does not end with :mfa/root-mfa", serial)
+	}
+
+	if len(out.VirtualMFADevice.Base32StringSeed) == 0 {
+		t.Fatal("Base32StringSeed is empty")
+	}
+
+	if len(out.VirtualMFADevice.QRCodePNG) == 0 {
+		t.Fatal("QRCodePNG is empty")
+	}
+}
+
+func TestSDKListMFADevices(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("mfa-user")}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	// A user with no assigned device gets an empty list (a freshly created
+	// virtual device is unassigned until EnableMFADevice).
+	out, err := client.ListMFADevices(ctx, &iam.ListMFADevicesInput{UserName: aws.String("mfa-user")})
+	if err != nil {
+		t.Fatalf("ListMFADevices: %v", err)
+	}
+
+	if len(out.MFADevices) != 0 {
+		t.Fatalf("got %d MFA devices, want 0", len(out.MFADevices))
+	}
+
+	// Listing devices for an unknown user is NoSuchEntity.
+	if _, err := client.ListMFADevices(ctx, &iam.ListMFADevicesInput{UserName: aws.String("ghost")}); err == nil {
+		t.Fatal("ListMFADevices for unknown user: expected error, got nil")
+	}
+}

--- a/server/aws/iam/operations.go
+++ b/server/aws/iam/operations.go
@@ -80,9 +80,21 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if boundary := r.Form.Get("PermissionsBoundary"); boundary != "" {
+		if mgr := h.boundaryManager(); mgr != nil {
+			if err := mgr.PutUserPermissionsBoundary(r.Context(), u.Name, boundary); err != nil {
+				writeErr(w, err)
+				return
+			}
+		}
+	}
+
+	out := toUserXML(u)
+	out.PermissionsBoundary = h.userBoundaryXML(r.Context(), u.Name)
+
 	awsquery.WriteXMLResponse(w, createUserResponse{
 		Xmlns:    Namespace,
-		Result:   createUserResult{User: toUserXML(u)},
+		Result:   createUserResult{User: out},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/iam/operations.go
+++ b/server/aws/iam/operations.go
@@ -121,9 +121,12 @@ func (h *Handler) getUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	out := toUserXML(u)
+	out.PermissionsBoundary = h.userBoundaryXML(r.Context(), u.Name)
+
 	awsquery.WriteXMLResponse(w, getUserResponse{
 		Xmlns:    Namespace,
-		Result:   getUserResult{User: toUserXML(u)},
+		Result:   getUserResult{User: out},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -191,9 +194,21 @@ func (h *Handler) createRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if boundary := r.Form.Get("PermissionsBoundary"); boundary != "" {
+		if mgr := h.boundaryManager(); mgr != nil {
+			if err := mgr.PutRolePermissionsBoundary(r.Context(), role.Name, boundary); err != nil {
+				writeErr(w, err)
+				return
+			}
+		}
+	}
+
+	out := toRoleXML(role)
+	out.PermissionsBoundary = h.roleBoundaryXML(r.Context(), role.Name)
+
 	awsquery.WriteXMLResponse(w, createRoleResponse{
 		Xmlns:    Namespace,
-		Result:   createRoleResult{Role: toRoleXML(role)},
+		Result:   createRoleResult{Role: out},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -217,9 +232,12 @@ func (h *Handler) getRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	out := toRoleXML(role)
+	out.PermissionsBoundary = h.roleBoundaryXML(r.Context(), role.Name)
+
 	awsquery.WriteXMLResponse(w, getRoleResponse{
 		Xmlns:    Namespace,
-		Result:   getRoleResult{Role: toRoleXML(role)},
+		Result:   getRoleResult{Role: out},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/iam/permissions_boundary.go
+++ b/server/aws/iam/permissions_boundary.go
@@ -1,0 +1,168 @@
+package iam
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+)
+
+// permissionsBoundaryType is the only value AWS reports for a boundary's type.
+const permissionsBoundaryType = "PermissionsBoundaryPolicy"
+
+// permissionsBoundaryManager is the AWS-specific permissions-boundary surface.
+// It's not part of the portable IAM driver, so the handler type-asserts for it.
+type permissionsBoundaryManager interface {
+	PutRolePermissionsBoundary(ctx context.Context, roleName, boundaryARN string) error
+	DeleteRolePermissionsBoundary(ctx context.Context, roleName string) error
+	RolePermissionsBoundary(ctx context.Context, roleName string) (string, error)
+	PutUserPermissionsBoundary(ctx context.Context, userName, boundaryARN string) error
+	DeleteUserPermissionsBoundary(ctx context.Context, userName string) error
+	UserPermissionsBoundary(ctx context.Context, userName string) (string, error)
+}
+
+type permissionsBoundaryXML struct {
+	PermissionsBoundaryType string `xml:"PermissionsBoundaryType"`
+	PermissionsBoundaryArn  string `xml:"PermissionsBoundaryArn"`
+}
+
+type putRolePermissionsBoundaryResponse struct {
+	XMLName  xml.Name         `xml:"PutRolePermissionsBoundaryResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type deleteRolePermissionsBoundaryResponse struct {
+	XMLName  xml.Name         `xml:"DeleteRolePermissionsBoundaryResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type putUserPermissionsBoundaryResponse struct {
+	XMLName  xml.Name         `xml:"PutUserPermissionsBoundaryResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type deleteUserPermissionsBoundaryResponse struct {
+	XMLName  xml.Name         `xml:"DeleteUserPermissionsBoundaryResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+// boundaryManager returns the driver's permissions-boundary surface, or nil
+// when the backend does not support boundaries.
+func (h *Handler) boundaryManager() permissionsBoundaryManager {
+	mgr, ok := h.iam.(permissionsBoundaryManager)
+	if !ok {
+		return nil
+	}
+
+	return mgr
+}
+
+// roleBoundaryXML resolves a role's permissions boundary to its wire shape, or
+// nil when none is set (or the backend does not track boundaries).
+func (h *Handler) roleBoundaryXML(ctx context.Context, roleName string) *permissionsBoundaryXML {
+	mgr := h.boundaryManager()
+	if mgr == nil {
+		return nil
+	}
+
+	arn, err := mgr.RolePermissionsBoundary(ctx, roleName)
+	if err != nil || arn == "" {
+		return nil
+	}
+
+	return &permissionsBoundaryXML{PermissionsBoundaryType: permissionsBoundaryType, PermissionsBoundaryArn: arn}
+}
+
+// userBoundaryXML resolves a user's permissions boundary to its wire shape.
+func (h *Handler) userBoundaryXML(ctx context.Context, userName string) *permissionsBoundaryXML {
+	mgr := h.boundaryManager()
+	if mgr == nil {
+		return nil
+	}
+
+	arn, err := mgr.UserPermissionsBoundary(ctx, userName)
+	if err != nil || arn == "" {
+		return nil
+	}
+
+	return &permissionsBoundaryXML{PermissionsBoundaryType: permissionsBoundaryType, PermissionsBoundaryArn: arn}
+}
+
+func (h *Handler) putRolePermissionsBoundary(w http.ResponseWriter, r *http.Request) {
+	mgr := h.boundaryManager()
+	if mgr == nil {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "permissions boundaries not supported")
+		return
+	}
+
+	if err := mgr.PutRolePermissionsBoundary(r.Context(),
+		r.Form.Get("RoleName"), r.Form.Get("PermissionsBoundary")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, putRolePermissionsBoundaryResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) deleteRolePermissionsBoundary(w http.ResponseWriter, r *http.Request) {
+	mgr := h.boundaryManager()
+	if mgr == nil {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "permissions boundaries not supported")
+		return
+	}
+
+	if err := mgr.DeleteRolePermissionsBoundary(r.Context(), r.Form.Get("RoleName")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteRolePermissionsBoundaryResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) putUserPermissionsBoundary(w http.ResponseWriter, r *http.Request) {
+	mgr := h.boundaryManager()
+	if mgr == nil {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "permissions boundaries not supported")
+		return
+	}
+
+	if err := mgr.PutUserPermissionsBoundary(r.Context(),
+		r.Form.Get("UserName"), r.Form.Get("PermissionsBoundary")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, putUserPermissionsBoundaryResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) deleteUserPermissionsBoundary(w http.ResponseWriter, r *http.Request) {
+	mgr := h.boundaryManager()
+	if mgr == nil {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "permissions boundaries not supported")
+		return
+	}
+
+	if err := mgr.DeleteUserPermissionsBoundary(r.Context(), r.Form.Get("UserName")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteUserPermissionsBoundaryResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}

--- a/server/aws/iam/permissions_boundary_test.go
+++ b/server/aws/iam/permissions_boundary_test.go
@@ -1,0 +1,119 @@
+package iam_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+const boundaryArn = "arn:aws:iam::aws:policy/PowerUserAccess"
+
+func TestSDKRolePermissionsBoundary(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("bounded-role"),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+		PermissionsBoundary:      aws.String(boundaryArn),
+	})
+	if err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	assertBoundary(t, "CreateRole", created.Role.PermissionsBoundary, boundaryArn)
+
+	got, err := client.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String("bounded-role")})
+	if err != nil {
+		t.Fatalf("GetRole: %v", err)
+	}
+
+	assertBoundary(t, "GetRole", got.Role.PermissionsBoundary, boundaryArn)
+
+	if _, err := client.DeleteRolePermissionsBoundary(ctx, &iam.DeleteRolePermissionsBoundaryInput{
+		RoleName: aws.String("bounded-role"),
+	}); err != nil {
+		t.Fatalf("DeleteRolePermissionsBoundary: %v", err)
+	}
+
+	cleared, err := client.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String("bounded-role")})
+	if err != nil {
+		t.Fatalf("GetRole after delete: %v", err)
+	}
+
+	if cleared.Role.PermissionsBoundary != nil {
+		t.Fatalf("expected no permissions boundary after delete, got %+v", cleared.Role.PermissionsBoundary)
+	}
+
+	if _, err := client.PutRolePermissionsBoundary(ctx, &iam.PutRolePermissionsBoundaryInput{
+		RoleName:            aws.String("bounded-role"),
+		PermissionsBoundary: aws.String(boundaryArn),
+	}); err != nil {
+		t.Fatalf("PutRolePermissionsBoundary: %v", err)
+	}
+
+	readded, err := client.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String("bounded-role")})
+	if err != nil {
+		t.Fatalf("GetRole after put: %v", err)
+	}
+
+	assertBoundary(t, "GetRole after put", readded.Role.PermissionsBoundary, boundaryArn)
+}
+
+func TestSDKUserPermissionsBoundary(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("bounded-user")}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.PutUserPermissionsBoundary(ctx, &iam.PutUserPermissionsBoundaryInput{
+		UserName:            aws.String("bounded-user"),
+		PermissionsBoundary: aws.String(boundaryArn),
+	}); err != nil {
+		t.Fatalf("PutUserPermissionsBoundary: %v", err)
+	}
+
+	got, err := client.GetUser(ctx, &iam.GetUserInput{UserName: aws.String("bounded-user")})
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+
+	assertBoundary(t, "GetUser", got.User.PermissionsBoundary, boundaryArn)
+
+	if _, err := client.DeleteUserPermissionsBoundary(ctx, &iam.DeleteUserPermissionsBoundaryInput{
+		UserName: aws.String("bounded-user"),
+	}); err != nil {
+		t.Fatalf("DeleteUserPermissionsBoundary: %v", err)
+	}
+
+	cleared, err := client.GetUser(ctx, &iam.GetUserInput{UserName: aws.String("bounded-user")})
+	if err != nil {
+		t.Fatalf("GetUser after delete: %v", err)
+	}
+
+	if cleared.User.PermissionsBoundary != nil {
+		t.Fatalf("expected no permissions boundary after delete, got %+v", cleared.User.PermissionsBoundary)
+	}
+}
+
+func assertBoundary(t *testing.T, where string, b *iamtypes.AttachedPermissionsBoundary, wantArn string) {
+	t.Helper()
+
+	if b == nil {
+		t.Fatalf("%s: expected permissions boundary, got nil", where)
+	}
+
+	if aws.ToString(b.PermissionsBoundaryArn) != wantArn {
+		t.Fatalf("%s: boundary arn = %q, want %q", where, aws.ToString(b.PermissionsBoundaryArn), wantArn)
+	}
+
+	if b.PermissionsBoundaryType != iamtypes.PermissionsBoundaryAttachmentTypePolicy {
+		t.Fatalf("%s: boundary type = %q, want %q",
+			where, b.PermissionsBoundaryType, iamtypes.PermissionsBoundaryAttachmentTypePolicy)
+	}
+}

--- a/server/aws/iam/permissions_boundary_test.go
+++ b/server/aws/iam/permissions_boundary_test.go
@@ -101,6 +101,31 @@ func TestSDKUserPermissionsBoundary(t *testing.T) {
 	}
 }
 
+// TestSDKCreateUserPermissionsBoundary asserts CreateUser applies a
+// PermissionsBoundary supplied at creation time (matching CreateRole), and
+// echoes it back on the CreateUser response.
+func TestSDKCreateUserPermissionsBoundary(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateUser(ctx, &iam.CreateUserInput{
+		UserName:            aws.String("boundary-at-create"),
+		PermissionsBoundary: aws.String(boundaryArn),
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	assertBoundary(t, "CreateUser", created.User.PermissionsBoundary, boundaryArn)
+
+	got, err := client.GetUser(ctx, &iam.GetUserInput{UserName: aws.String("boundary-at-create")})
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+
+	assertBoundary(t, "GetUser", got.User.PermissionsBoundary, boundaryArn)
+}
+
 func assertBoundary(t *testing.T, where string, b *iamtypes.AttachedPermissionsBoundary, wantArn string) {
 	t.Helper()
 

--- a/server/aws/iam/service_linked_role.go
+++ b/server/aws/iam/service_linked_role.go
@@ -1,0 +1,50 @@
+package iam
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// serviceLinkedRoleCreator is the AWS-specific CreateServiceLinkedRole surface.
+// It's not part of the portable IAM driver, so the handler type-asserts for it.
+type serviceLinkedRoleCreator interface {
+	CreateServiceLinkedRole(
+		ctx context.Context, awsServiceName, customSuffix, description string,
+	) (*iamdriver.RoleInfo, error)
+}
+
+type createServiceLinkedRoleResponse struct {
+	XMLName  xml.Name                      `xml:"CreateServiceLinkedRoleResponse"`
+	Xmlns    string                        `xml:"xmlns,attr"`
+	Result   createServiceLinkedRoleResult `xml:"CreateServiceLinkedRoleResult"`
+	Metadata responseMetadata              `xml:"ResponseMetadata"`
+}
+
+type createServiceLinkedRoleResult struct {
+	Role roleXML `xml:"Role"`
+}
+
+func (h *Handler) createServiceLinkedRole(w http.ResponseWriter, r *http.Request) {
+	creator, ok := h.iam.(serviceLinkedRoleCreator)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "service-linked roles not supported")
+		return
+	}
+
+	role, err := creator.CreateServiceLinkedRole(r.Context(),
+		r.Form.Get("AWSServiceName"), r.Form.Get("CustomSuffix"), r.Form.Get("Description"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createServiceLinkedRoleResponse{
+		Xmlns:    Namespace,
+		Result:   createServiceLinkedRoleResult{Role: toRoleXML(role)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}

--- a/server/aws/iam/service_linked_role_test.go
+++ b/server/aws/iam/service_linked_role_test.go
@@ -1,0 +1,55 @@
+package iam_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+)
+
+func TestSDKCreateServiceLinkedRole(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateServiceLinkedRole(ctx, &iam.CreateServiceLinkedRoleInput{
+		AWSServiceName: aws.String("elasticbeanstalk.amazonaws.com"),
+		Description:    aws.String("service-linked role for beanstalk"),
+	})
+	if err != nil {
+		t.Fatalf("CreateServiceLinkedRole: %v", err)
+	}
+
+	name := aws.ToString(out.Role.RoleName)
+	if !strings.HasPrefix(name, "AWSServiceRoleFor") {
+		t.Fatalf("role name %q does not start with AWSServiceRoleFor", name)
+	}
+
+	if path := aws.ToString(out.Role.Path); path != "/aws-service-role/elasticbeanstalk.amazonaws.com/" {
+		t.Fatalf("path = %q, want /aws-service-role/elasticbeanstalk.amazonaws.com/", path)
+	}
+
+	// The created role is retrievable via GetRole.
+	got, err := client.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String(name)})
+	if err != nil {
+		t.Fatalf("GetRole: %v", err)
+	}
+
+	if aws.ToString(got.Role.RoleName) != name {
+		t.Fatalf("GetRole name = %q, want %q", aws.ToString(got.Role.RoleName), name)
+	}
+
+	// A CustomSuffix yields a distinct role name.
+	suffixed, err := client.CreateServiceLinkedRole(ctx, &iam.CreateServiceLinkedRoleInput{
+		AWSServiceName: aws.String("elasticbeanstalk.amazonaws.com"),
+		CustomSuffix:   aws.String("debug"),
+	})
+	if err != nil {
+		t.Fatalf("CreateServiceLinkedRole with suffix: %v", err)
+	}
+
+	if suffixed := aws.ToString(suffixed.Role.RoleName); suffixed == name || !strings.HasSuffix(suffixed, "_debug") {
+		t.Fatalf("suffixed role name %q not distinct with _debug suffix", suffixed)
+	}
+}

--- a/server/aws/iam/service_linked_role_test.go
+++ b/server/aws/iam/service_linked_role_test.go
@@ -2,11 +2,14 @@ package iam_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/smithy-go"
 )
 
 func TestSDKCreateServiceLinkedRole(t *testing.T) {
@@ -21,9 +24,12 @@ func TestSDKCreateServiceLinkedRole(t *testing.T) {
 		t.Fatalf("CreateServiceLinkedRole: %v", err)
 	}
 
+	// AWS's canonical service-linked-role name for elasticbeanstalk.amazonaws.com
+	// is exactly AWSServiceRoleForElasticBeanstalk (a fixed per-service name, not
+	// a derivable casing transform).
 	name := aws.ToString(out.Role.RoleName)
-	if !strings.HasPrefix(name, "AWSServiceRoleFor") {
-		t.Fatalf("role name %q does not start with AWSServiceRoleFor", name)
+	if name != "AWSServiceRoleForElasticBeanstalk" {
+		t.Fatalf("role name = %q, want AWSServiceRoleForElasticBeanstalk", name)
 	}
 
 	if path := aws.ToString(out.Role.Path); path != "/aws-service-role/elasticbeanstalk.amazonaws.com/" {
@@ -51,5 +57,64 @@ func TestSDKCreateServiceLinkedRole(t *testing.T) {
 
 	if suffixed := aws.ToString(suffixed.Role.RoleName); suffixed == name || !strings.HasSuffix(suffixed, "_debug") {
 		t.Fatalf("suffixed role name %q not distinct with _debug suffix", suffixed)
+	}
+}
+
+// TestSDKCreateServiceLinkedRoleCanonicalNames pins the published names of a few
+// principals whose service-linked-role names are not derivable by casing.
+func TestSDKCreateServiceLinkedRoleCanonicalNames(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	cases := map[string]string{
+		"ecs.amazonaws.com":                     "AWSServiceRoleForECS",
+		"autoscaling.amazonaws.com":             "AWSServiceRoleForAutoScaling",
+		"application-autoscaling.amazonaws.com": "AWSServiceRoleForApplicationAutoScaling",
+		"elasticache.amazonaws.com":             "AWSServiceRoleForElastiCache",
+	}
+
+	for principal, want := range cases {
+		out, err := client.CreateServiceLinkedRole(ctx, &iam.CreateServiceLinkedRoleInput{
+			AWSServiceName: aws.String(principal),
+		})
+		if err != nil {
+			t.Fatalf("CreateServiceLinkedRole(%s): %v", principal, err)
+		}
+
+		if got := aws.ToString(out.Role.RoleName); got != want {
+			t.Fatalf("principal %s: role name = %q, want %q", principal, got, want)
+		}
+	}
+}
+
+// TestSDKCreateServiceLinkedRoleDuplicate asserts a duplicate service-linked-role
+// name surfaces as InvalidInput (400) — EntityAlreadyExists is not in this
+// action's AWS error set at all.
+func TestSDKCreateServiceLinkedRoleDuplicate(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateServiceLinkedRole(ctx, &iam.CreateServiceLinkedRoleInput{
+		AWSServiceName: aws.String("ecs.amazonaws.com"),
+	}); err != nil {
+		t.Fatalf("first CreateServiceLinkedRole: %v", err)
+	}
+
+	_, err := client.CreateServiceLinkedRole(ctx, &iam.CreateServiceLinkedRoleInput{
+		AWSServiceName: aws.String("ecs.amazonaws.com"),
+	})
+	if err == nil {
+		t.Fatal("expected duplicate CreateServiceLinkedRole to fail")
+	}
+
+	// Must be InvalidInput, never EntityAlreadyExists.
+	var eae *iamtypes.EntityAlreadyExistsException
+	if errors.As(err, &eae) {
+		t.Fatalf("duplicate surfaced as EntityAlreadyExists, want InvalidInput: %v", err)
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidInput" {
+		t.Fatalf("error code = %v, want InvalidInput", err)
 	}
 }

--- a/server/aws/iam/simulate.go
+++ b/server/aws/iam/simulate.go
@@ -1,0 +1,123 @@
+package iam
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// policySimulator is the AWS-specific policy-simulation surface. It's not part
+// of the portable IAM driver, so the handler type-asserts for it.
+type policySimulator interface {
+	SimulatePrincipalPolicy(
+		ctx context.Context, policySourceARN string, actions, resourceARNs, extraPolicies []string,
+	) ([]iamdriver.SimulationResult, error)
+	SimulateCustomPolicy(
+		ctx context.Context, policyDocs, actions, resourceARNs []string,
+	) ([]iamdriver.SimulationResult, error)
+}
+
+type evaluationResultXML struct {
+	EvalActionName   string `xml:"EvalActionName"`
+	EvalResourceName string `xml:"EvalResourceName,omitempty"`
+	EvalDecision     string `xml:"EvalDecision"`
+}
+
+type evaluationResultsXML struct {
+	Member []evaluationResultXML `xml:"member,omitempty"`
+}
+
+type simulateResult struct {
+	EvaluationResults evaluationResultsXML `xml:"EvaluationResults"`
+	IsTruncated       bool                 `xml:"IsTruncated"`
+}
+
+type simulatePrincipalPolicyResponse struct {
+	XMLName  xml.Name         `xml:"SimulatePrincipalPolicyResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   simulateResult   `xml:"SimulatePrincipalPolicyResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type simulateCustomPolicyResponse struct {
+	XMLName  xml.Name         `xml:"SimulateCustomPolicyResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   simulateResult   `xml:"SimulateCustomPolicyResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+// toEvaluationResults maps driver simulation results to the wire shape.
+func toEvaluationResults(results []iamdriver.SimulationResult) evaluationResultsXML {
+	out := evaluationResultsXML{Member: make([]evaluationResultXML, 0, len(results))}
+	for i := range results {
+		out.Member = append(out.Member, evaluationResultXML{
+			EvalActionName:   results[i].ActionName,
+			EvalResourceName: results[i].ResourceName,
+			EvalDecision:     results[i].Decision,
+		})
+	}
+
+	return out
+}
+
+func (h *Handler) simulatePrincipalPolicy(w http.ResponseWriter, r *http.Request) {
+	sim, ok := h.iam.(policySimulator)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "policy simulation not supported")
+		return
+	}
+
+	actions := awsquery.ListStrings(r.Form, "ActionNames.member")
+	if len(actions) == 0 {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidInput", "ActionNames is required")
+		return
+	}
+
+	resources := awsquery.ListStrings(r.Form, "ResourceArns.member")
+	extra := awsquery.ListStrings(r.Form, "PolicyInputList.member")
+
+	results, err := sim.SimulatePrincipalPolicy(r.Context(), r.Form.Get("PolicySourceArn"), actions, resources, extra)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, simulatePrincipalPolicyResponse{
+		Xmlns:    Namespace,
+		Result:   simulateResult{EvaluationResults: toEvaluationResults(results)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) simulateCustomPolicy(w http.ResponseWriter, r *http.Request) {
+	sim, ok := h.iam.(policySimulator)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "policy simulation not supported")
+		return
+	}
+
+	actions := awsquery.ListStrings(r.Form, "ActionNames.member")
+	docs := awsquery.ListStrings(r.Form, "PolicyInputList.member")
+
+	if len(actions) == 0 || len(docs) == 0 {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidInput", "ActionNames and PolicyInputList are required")
+		return
+	}
+
+	resources := awsquery.ListStrings(r.Form, "ResourceArns.member")
+
+	results, err := sim.SimulateCustomPolicy(r.Context(), docs, actions, resources)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, simulateCustomPolicyResponse{
+		Xmlns:    Namespace,
+		Result:   simulateResult{EvaluationResults: toEvaluationResults(results)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}

--- a/server/aws/iam/simulate_test.go
+++ b/server/aws/iam/simulate_test.go
@@ -1,0 +1,90 @@
+package iam_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+func decisionFor(results []iamtypes.EvaluationResult, action string) iamtypes.PolicyEvaluationDecisionType {
+	for i := range results {
+		if aws.ToString(results[i].EvalActionName) == action {
+			return results[i].EvalDecision
+		}
+	}
+
+	return ""
+}
+
+func TestSDKSimulatePrincipalPolicy(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	role, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("sim-role"),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	policy, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String("sim-policy"),
+		PolicyDocument: aws.String(samplePolicy), // allows s3:ListBucket on *
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	if _, err := client.AttachRolePolicy(ctx, &iam.AttachRolePolicyInput{
+		RoleName:  aws.String("sim-role"),
+		PolicyArn: policy.Policy.Arn,
+	}); err != nil {
+		t.Fatalf("AttachRolePolicy: %v", err)
+	}
+
+	out, err := client.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: role.Role.Arn,
+		ActionNames:     []string{"s3:ListBucket", "s3:DeleteObject"},
+		ResourceArns:    []string{"arn:aws:s3:::my-bucket"},
+	})
+	if err != nil {
+		t.Fatalf("SimulatePrincipalPolicy: %v", err)
+	}
+
+	if len(out.EvaluationResults) != 2 {
+		t.Fatalf("got %d evaluation results, want 2", len(out.EvaluationResults))
+	}
+
+	if got := decisionFor(out.EvaluationResults, "s3:ListBucket"); got != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+		t.Fatalf("s3:ListBucket decision = %q, want allowed", got)
+	}
+
+	if got := decisionFor(out.EvaluationResults, "s3:DeleteObject"); got != iamtypes.PolicyEvaluationDecisionTypeImplicitDeny {
+		t.Fatalf("s3:DeleteObject decision = %q, want implicitDeny", got)
+	}
+}
+
+func TestSDKSimulateCustomPolicy(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.SimulateCustomPolicy(ctx, &iam.SimulateCustomPolicyInput{
+		PolicyInputList: []string{samplePolicy}, // allows s3:ListBucket on *
+		ActionNames:     []string{"s3:ListBucket", "s3:GetObject"},
+	})
+	if err != nil {
+		t.Fatalf("SimulateCustomPolicy: %v", err)
+	}
+
+	if got := decisionFor(out.EvaluationResults, "s3:ListBucket"); got != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+		t.Fatalf("s3:ListBucket decision = %q, want allowed", got)
+	}
+
+	if got := decisionFor(out.EvaluationResults, "s3:GetObject"); got != iamtypes.PolicyEvaluationDecisionTypeImplicitDeny {
+		t.Fatalf("s3:GetObject decision = %q, want implicitDeny", got)
+	}
+}

--- a/server/aws/iam/xml.go
+++ b/server/aws/iam/xml.go
@@ -38,12 +38,13 @@ func toTagsXML(tags map[string]string) *tagsXML {
 }
 
 type userXML struct {
-	UserName   string   `xml:"UserName"`
-	UserID     string   `xml:"UserId"`
-	Arn        string   `xml:"Arn"`
-	Path       string   `xml:"Path,omitempty"`
-	CreateDate string   `xml:"CreateDate,omitempty"`
-	Tags       *tagsXML `xml:"Tags,omitempty"`
+	UserName            string                  `xml:"UserName"`
+	UserID              string                  `xml:"UserId"`
+	Arn                 string                  `xml:"Arn"`
+	Path                string                  `xml:"Path,omitempty"`
+	CreateDate          string                  `xml:"CreateDate,omitempty"`
+	PermissionsBoundary *permissionsBoundaryXML `xml:"PermissionsBoundary,omitempty"`
+	Tags                *tagsXML                `xml:"Tags,omitempty"`
 }
 
 func toUserXML(u *iamdriver.UserInfo) userXML {
@@ -58,15 +59,16 @@ func toUserXML(u *iamdriver.UserInfo) userXML {
 }
 
 type roleXML struct {
-	RoleName                 string   `xml:"RoleName"`
-	RoleID                   string   `xml:"RoleId"`
-	Arn                      string   `xml:"Arn"`
-	Path                     string   `xml:"Path,omitempty"`
-	Description              string   `xml:"Description,omitempty"`
-	CreateDate               string   `xml:"CreateDate,omitempty"`
-	MaxSessionDuration       int      `xml:"MaxSessionDuration,omitempty"`
-	AssumeRolePolicyDocument string   `xml:"AssumeRolePolicyDocument,omitempty"`
-	Tags                     *tagsXML `xml:"Tags,omitempty"`
+	RoleName                 string                  `xml:"RoleName"`
+	RoleID                   string                  `xml:"RoleId"`
+	Arn                      string                  `xml:"Arn"`
+	Path                     string                  `xml:"Path,omitempty"`
+	Description              string                  `xml:"Description,omitempty"`
+	CreateDate               string                  `xml:"CreateDate,omitempty"`
+	MaxSessionDuration       int                     `xml:"MaxSessionDuration,omitempty"`
+	AssumeRolePolicyDocument string                  `xml:"AssumeRolePolicyDocument,omitempty"`
+	PermissionsBoundary      *permissionsBoundaryXML `xml:"PermissionsBoundary,omitempty"`
+	Tags                     *tagsXML                `xml:"Tags,omitempty"`
 }
 
 func toRoleXML(r *iamdriver.RoleInfo) roleXML {

--- a/services/iam/driver/driver.go
+++ b/services/iam/driver/driver.go
@@ -124,6 +124,47 @@ type InstanceProfileInfo struct {
 	Tags      map[string]string
 }
 
+// SimulationResult is one action-on-resource evaluation returned by an IAM
+// policy simulation (SimulatePrincipalPolicy / SimulateCustomPolicy). Decision
+// is one of "allowed", "explicitDeny", or "implicitDeny". It is an AWS-only
+// shape, so it is not referenced by the IAM interface below — providers that
+// support simulation expose it through a type-asserted optional method.
+type SimulationResult struct {
+	ActionName   string
+	ResourceName string
+	Decision     string
+}
+
+// PasswordPolicy describes an AWS account password policy. ExpirePasswords is
+// derived (MaxPasswordAge > 0) and reported by the wire layer, not stored. It
+// is AWS-only and not referenced by the IAM interface.
+type PasswordPolicy struct {
+	MinimumPasswordLength      int
+	RequireSymbols             bool
+	RequireNumbers             bool
+	RequireUppercaseCharacters bool
+	RequireLowercaseCharacters bool
+	AllowUsersToChangePassword bool
+	MaxPasswordAge             int
+	PasswordReusePrevention    int
+	HardExpiry                 bool
+}
+
+// MFADeviceInfo describes an MFA device assigned to a user. AWS-only.
+type MFADeviceInfo struct {
+	UserName     string
+	SerialNumber string
+	EnableDate   string
+}
+
+// VirtualMFADeviceInfo describes a newly created virtual MFA device. The seed
+// and QR-code payloads are opaque bytes the wire layer base64-encodes. AWS-only.
+type VirtualMFADeviceInfo struct {
+	SerialNumber     string
+	Base32StringSeed []byte
+	QRCodePNG        []byte
+}
+
 // IAM is the interface that IAM provider implementations must satisfy.
 type IAM interface {
 	CreateUser(ctx context.Context, config UserConfig) (*UserInfo, error)


### PR DESCRIPTION
Fixes a set of real-user IAM gaps found by the deep AWS audit. Each change matches the official IAM API contract (error code, HTTP status, response shape) and is verified with real aws-sdk-go-v2 round-trip tests plus provider unit tests. AWS-only operations are added as type-asserted optional interfaces on the AWS provider, leaving the portable `driver.IAM` interface (and the other clouds) untouched — so no coverage-doc regeneration was needed.

## What changed

### Permissions boundaries (HIGH)
- `CreateRole` with a `PermissionsBoundary` ARN now attaches and persists it, and returns it in `Role.PermissionsBoundary` (`AttachedPermissionsBoundary` with type `PermissionsBoundaryPolicy`).
- `GetRole` / `GetUser` return the current boundary.
- Added `PutRolePermissionsBoundary`, `DeleteRolePermissionsBoundary`, `PutUserPermissionsBoundary`, `DeleteUserPermissionsBoundary` to manage it after creation.

### CreateServiceLinkedRole (HIGH)
- Creates a service-linked role (`AWSServiceRoleFor…`, path `/aws-service-role/<service>/`, service trust policy) and returns a `Role` (HTTP 200). Supports `CustomSuffix`; a duplicate without a suffix conflicts.

### Access-key limit (MEDIUM)
- A user may hold at most 2 access keys; the 3rd `CreateAccessKey` returns `LimitExceeded` (HTTP 409), mapped from the existing `ResourceExhausted` sentinel.

### SimulatePrincipalPolicy / SimulateCustomPolicy (MEDIUM)
- Returns `EvaluationResults` (per action/resource) with `EvalDecision` of `allowed` / `explicitDeny` / `implicitDeny`, evaluating the principal's attached managed + inline policies (and, for users, their groups) plus any `PolicyInputList` documents. Explicit `Deny` wins; resources default to `*`.

### Account summary / password policy / MFA (LOW)
- `GetAccountSummary` returns the `SummaryMap` with live entity counts and standard account quotas.
- `GetAccountPasswordPolicy` / `UpdateAccountPasswordPolicy` / `DeleteAccountPasswordPolicy` with the documented `PasswordPolicy` shape (`ExpirePasswords` derived from `MaxPasswordAge`); `NoSuchEntity` (404) when unset.
- `CreateVirtualMFADevice` returns a `VirtualMFADevice` (serial ARN, base32 seed, QR PNG); `ListMFADevices` returns a user's assigned devices (empty until assigned), `NoSuchEntity` for an unknown user.

## Testing
- `go build ./...`, `go vet`, `go test ./providers/aws/... ./server/aws/... ./services/... .` all green.
- `golangci-lint` clean on all changed/new files.
