### PR TITLE
fix(s3): UploadPartCopy, CopyObject metadata-directive/versioned-source/conditional/self-copy, delete-marker GET, GetBucketLocation

### DIFF
--- a/docs/coverage/aws/s3.md
+++ b/docs/coverage/aws/s3.md
@@ -55,6 +55,14 @@ BucketAttributes is an OPTIONAL capability, discovered by type assertion (like
 | --- | --- |
 | `BucketAttributes` |  |
 
+### ObjectCopier
+
+ObjectCopier is an OPTIONAL capability (discovered by type assertion, like
+
+| Operation | Description |
+| --- | --- |
+| `CopyObjectV2` |  |
+
 ### RawBucketConfig
 
 RawBucketConfig is an OPTIONAL capability (discovered by type assertion, like
@@ -64,6 +72,14 @@ RawBucketConfig is an OPTIONAL capability (discovered by type assertion, like
 | `DeleteBucketConfig` | DeleteBucketConfig removes the stored document (idempotent). |
 | `GetBucketConfig` | GetBucketConfig returns the stored document, or NotFound when none was set. |
 | `PutBucketConfig` | PutBucketConfig stores document body under the sub-resource name (e.g. |
+
+### RegionalBucket
+
+RegionalBucket is an OPTIONAL capability a storage provider implements to
+
+| Operation | Description |
+| --- | --- |
+| `CreateBucketInRegion` |  |
 
 ### VersionedBucket
 

--- a/docs/coverage/azure/blobstorage.md
+++ b/docs/coverage/azure/blobstorage.md
@@ -55,6 +55,14 @@ BucketAttributes is an OPTIONAL capability, discovered by type assertion (like
 | --- | --- |
 | `BucketAttributes` |  |
 
+### ObjectCopier
+
+ObjectCopier is an OPTIONAL capability (discovered by type assertion, like
+
+| Operation | Description |
+| --- | --- |
+| `CopyObjectV2` |  |
+
 ### RawBucketConfig
 
 RawBucketConfig is an OPTIONAL capability (discovered by type assertion, like
@@ -64,6 +72,14 @@ RawBucketConfig is an OPTIONAL capability (discovered by type assertion, like
 | `DeleteBucketConfig` | DeleteBucketConfig removes the stored document (idempotent). |
 | `GetBucketConfig` | GetBucketConfig returns the stored document, or NotFound when none was set. |
 | `PutBucketConfig` | PutBucketConfig stores document body under the sub-resource name (e.g. |
+
+### RegionalBucket
+
+RegionalBucket is an OPTIONAL capability a storage provider implements to
+
+| Operation | Description |
+| --- | --- |
+| `CreateBucketInRegion` |  |
 
 ### VersionedBucket
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -9881,6 +9881,15 @@
         ]
       },
       {
+        "name": "ObjectCopier",
+        "doc": "ObjectCopier is an OPTIONAL capability (discovered by type assertion, like",
+        "operations": [
+          {
+            "name": "CopyObjectV2"
+          }
+        ]
+      },
+      {
         "name": "RawBucketConfig",
         "doc": "RawBucketConfig is an OPTIONAL capability (discovered by type assertion, like",
         "operations": [
@@ -9895,6 +9904,15 @@
           {
             "name": "PutBucketConfig",
             "doc": "PutBucketConfig stores document body under the sub-resource name (e.g."
+          }
+        ]
+      },
+      {
+        "name": "RegionalBucket",
+        "doc": "RegionalBucket is an OPTIONAL capability a storage provider implements to",
+        "operations": [
+          {
+            "name": "CreateBucketInRegion"
           }
         ]
       },

--- a/docs/coverage/gcp/gcs.md
+++ b/docs/coverage/gcp/gcs.md
@@ -55,6 +55,14 @@ BucketAttributes is an OPTIONAL capability, discovered by type assertion (like
 | --- | --- |
 | `BucketAttributes` |  |
 
+### ObjectCopier
+
+ObjectCopier is an OPTIONAL capability (discovered by type assertion, like
+
+| Operation | Description |
+| --- | --- |
+| `CopyObjectV2` |  |
+
 ### RawBucketConfig
 
 RawBucketConfig is an OPTIONAL capability (discovered by type assertion, like
@@ -64,6 +72,14 @@ RawBucketConfig is an OPTIONAL capability (discovered by type assertion, like
 | `DeleteBucketConfig` | DeleteBucketConfig removes the stored document (idempotent). |
 | `GetBucketConfig` | GetBucketConfig returns the stored document, or NotFound when none was set. |
 | `PutBucketConfig` | PutBucketConfig stores document body under the sub-resource name (e.g. |
+
+### RegionalBucket
+
+RegionalBucket is an OPTIONAL capability a storage provider implements to
+
+| Operation | Description |
+| --- | --- |
+| `CreateBucketInRegion` |  |
 
 ### VersionedBucket
 

--- a/providers/aws/s3/copy_test.go
+++ b/providers/aws/s3/copy_test.go
@@ -1,0 +1,208 @@
+package s3
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// TestCopyObjectV2MetadataReplace verifies REPLACE swaps metadata + content
+// type while COPY (default) carries the source's.
+func TestCopyObjectV2MetadataReplace(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "b"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	if err := m.PutObject(ctx, "b", "src", []byte("data"), "text/plain", map[string]string{"k": "src"}); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	res, err := m.CopyObjectV2(ctx, &driver.CopyObjectRequest{
+		DstBucket: "b", DstKey: "replaced", Src: driver.CopySource{Bucket: "b", Key: "src"},
+		ReplaceMetadata: true, Metadata: map[string]string{"k": "new"}, ContentType: "application/json",
+	})
+	if err != nil {
+		t.Fatalf("CopyObjectV2 REPLACE: %v", err)
+	}
+
+	if res.ETag == "" {
+		t.Fatal("CopyObjectV2 returned empty ETag")
+	}
+
+	info, err := m.HeadObject(ctx, "b", "replaced")
+	if err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+
+	if info.Metadata["k"] != "new" || info.ContentType != "application/json" {
+		t.Fatalf("REPLACE mismatch: meta=%v ct=%q", info.Metadata, info.ContentType)
+	}
+}
+
+// TestCopyObjectV2Preconditions verifies a failed copy-source precondition is a
+// FailedPrecondition error and leaves the destination untouched.
+func TestCopyObjectV2Preconditions(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "b"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	if err := m.PutObject(ctx, "b", "src", []byte("data"), "text/plain", nil); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	info, err := m.HeadObject(ctx, "b", "src")
+	if err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+
+	_, err = m.CopyObjectV2(ctx, &driver.CopyObjectRequest{
+		DstBucket: "b", DstKey: "dst", Src: driver.CopySource{Bucket: "b", Key: "src"},
+		IfMatch: "deadbeef",
+	})
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("if-match mismatch err = %v, want FailedPrecondition", err)
+	}
+
+	if _, err := m.HeadObject(ctx, "b", "dst"); !cerrors.IsNotFound(err) {
+		t.Fatal("destination created despite failed precondition")
+	}
+
+	// A matching if-match copies.
+	if _, err := m.CopyObjectV2(ctx, &driver.CopyObjectRequest{
+		DstBucket: "b", DstKey: "dst", Src: driver.CopySource{Bucket: "b", Key: "src"},
+		IfMatch: info.ETag,
+	}); err != nil {
+		t.Fatalf("CopyObjectV2 matching if-match: %v", err)
+	}
+}
+
+// TestCopyObjectV2VersionedSource copies a specific older version of a source
+// object on a versioning-enabled bucket.
+func TestCopyObjectV2VersionedSource(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "b"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	if err := m.SetVersioningStatus(ctx, "b", versioningEnabled); err != nil {
+		t.Fatalf("SetVersioningStatus: %v", err)
+	}
+
+	if err := m.PutObject(ctx, "b", "k", []byte("one"), "text/plain", nil); err != nil {
+		t.Fatalf("PutObject v1: %v", err)
+	}
+
+	v1, err := m.HeadObject(ctx, "b", "k")
+	if err != nil {
+		t.Fatalf("HeadObject v1: %v", err)
+	}
+
+	oldVersion := v1.VersionID
+
+	if err := m.PutObject(ctx, "b", "k", []byte("two"), "text/plain", nil); err != nil {
+		t.Fatalf("PutObject v2: %v", err)
+	}
+
+	res, err := m.CopyObjectV2(ctx, &driver.CopyObjectRequest{
+		DstBucket: "b", DstKey: "restored", Src: driver.CopySource{Bucket: "b", Key: "k"},
+		SrcVersionID: oldVersion,
+	})
+	if err != nil {
+		t.Fatalf("CopyObjectV2 versioned source: %v", err)
+	}
+
+	if res.SourceVersionID != oldVersion {
+		t.Fatalf("SourceVersionID = %q, want %q", res.SourceVersionID, oldVersion)
+	}
+
+	obj, err := m.GetObject(ctx, "b", "restored")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+
+	if string(obj.Data) != "one" {
+		t.Fatalf("copied body = %q, want 'one'", string(obj.Data))
+	}
+}
+
+// TestGetObjectVersionDeleteMarker verifies a delete-marker version yields
+// driver.ErrDeleteMarker (so the wire layer can answer 405), while a genuinely
+// missing version stays NotFound.
+func TestGetObjectVersionDeleteMarker(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "b"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	if err := m.SetVersioningStatus(ctx, "b", versioningEnabled); err != nil {
+		t.Fatalf("SetVersioningStatus: %v", err)
+	}
+
+	if err := m.PutObject(ctx, "b", "k", []byte("v1"), "text/plain", nil); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	markerID, marker, err := m.DeleteObjectVersion(ctx, "b", "k", "")
+	if err != nil || !marker {
+		t.Fatalf("DeleteObjectVersion delete-marker: id=%q marker=%v err=%v", markerID, marker, err)
+	}
+
+	if _, err := m.GetObjectVersion(ctx, "b", "k", markerID); !errors.Is(err, driver.ErrDeleteMarker) {
+		t.Fatalf("GetObjectVersion(delete marker) err = %v, want ErrDeleteMarker", err)
+	}
+
+	if _, err := m.HeadObjectVersion(ctx, "b", "k", markerID); !errors.Is(err, driver.ErrDeleteMarker) {
+		t.Fatalf("HeadObjectVersion(delete marker) err = %v, want ErrDeleteMarker", err)
+	}
+
+	if _, err := m.GetObjectVersion(ctx, "b", "k", "no-such-version"); !cerrors.IsNotFound(err) ||
+		errors.Is(err, driver.ErrDeleteMarker) {
+		t.Fatalf("GetObjectVersion(missing) err = %v, want plain NotFound", err)
+	}
+}
+
+// TestCreateBucketInRegion records a caller-specified region so
+// GetBucketLocation can report it, and falls back to the default otherwise.
+func TestCreateBucketInRegion(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucketInRegion(ctx, "west", "us-west-2"); err != nil {
+		t.Fatalf("CreateBucketInRegion: %v", err)
+	}
+
+	if err := m.CreateBucket(ctx, "east"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	buckets, err := m.ListBuckets(ctx)
+	if err != nil {
+		t.Fatalf("ListBuckets: %v", err)
+	}
+
+	regions := map[string]string{}
+	for _, b := range buckets {
+		regions[b.Name] = b.Region
+	}
+
+	if regions["west"] != "us-west-2" {
+		t.Fatalf("west region = %q, want us-west-2", regions["west"])
+	}
+
+	if regions["east"] != "us-east-1" {
+		t.Fatalf("east region = %q, want us-east-1 (default)", regions["east"])
+	}
+}

--- a/providers/aws/s3/copy_test.go
+++ b/providers/aws/s3/copy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/storage/driver"
@@ -82,6 +83,21 @@ func TestCopyObjectV2Preconditions(t *testing.T) {
 		IfMatch: info.ETag,
 	}); err != nil {
 		t.Fatalf("CopyObjectV2 matching if-match: %v", err)
+	}
+
+	// Documented override: with both headers present and if-match true, a false
+	// if-unmodified-since (a time before the source's last modification) does not
+	// block the copy — if-match takes precedence and S3 returns 200 OK.
+	mod, perr := time.Parse(s3TimeFormat, info.LastModified)
+	if perr != nil {
+		t.Fatalf("parse LastModified %q: %v", info.LastModified, perr)
+	}
+
+	if _, err := m.CopyObjectV2(ctx, &driver.CopyObjectRequest{
+		DstBucket: "b", DstKey: "override", Src: driver.CopySource{Bucket: "b", Key: "src"},
+		IfMatch: info.ETag, IfUnmodifiedSince: mod.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("CopyObjectV2 if-match overriding if-unmodified-since: %v", err)
 	}
 }
 

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -781,12 +781,21 @@ func (m *Mock) resolveCopySourceVersion(
 
 // checkCopyPreconditions evaluates the four x-amz-copy-source-if-* headers
 // against the source, returning FailedPrecondition when one is not satisfied.
+//
+// AWS's CopyObject API reference documents a combined-precedence override: when
+// both x-amz-copy-source-if-match and x-amz-copy-source-if-unmodified-since are
+// present and if-match evaluates true, S3 returns 200 OK and copies the data
+// even if if-unmodified-since evaluates false. if-match therefore overrides the
+// if-unmodified-since result rather than the two being independently ANDed.
 func checkCopyPreconditions(req *driver.CopyObjectRequest, src *copySrcSnapshot) error {
+	etag := strings.Trim(src.etag, `"`)
+	skipUnmodified := req.IfMatch != "" && !req.IfUnmodifiedSince.IsZero() && etagMatches(req.IfMatch, etag)
+
 	if err := checkCopyETagPreconditions(req, src.etag); err != nil {
 		return err
 	}
 
-	return checkCopyTimePreconditions(req, src.lastModified)
+	return checkCopyTimePreconditions(req, src.lastModified, skipUnmodified)
 }
 
 func checkCopyETagPreconditions(req *driver.CopyObjectRequest, etag string) error {
@@ -803,7 +812,10 @@ func checkCopyETagPreconditions(req *driver.CopyObjectRequest, etag string) erro
 	return nil
 }
 
-func checkCopyTimePreconditions(req *driver.CopyObjectRequest, lastModified string) error {
+// checkCopyTimePreconditions evaluates the two time-based copy-source headers.
+// skipUnmodified suppresses the if-unmodified-since check when a true if-match
+// header has taken precedence over it (see checkCopyPreconditions).
+func checkCopyTimePreconditions(req *driver.CopyObjectRequest, lastModified string, skipUnmodified bool) error {
 	if req.IfUnmodifiedSince.IsZero() && req.IfModifiedSince.IsZero() {
 		return nil
 	}
@@ -813,7 +825,7 @@ func checkCopyTimePreconditions(req *driver.CopyObjectRequest, lastModified stri
 		return nil // an unparseable timestamp can't be evaluated; do not block the copy
 	}
 
-	if !req.IfUnmodifiedSince.IsZero() && mod.After(req.IfUnmodifiedSince) {
+	if !skipUnmodified && !req.IfUnmodifiedSince.IsZero() && mod.After(req.IfUnmodifiedSince) {
 		return cerrors.New(cerrors.FailedPrecondition, "x-amz-copy-source-if-unmodified-since precondition failed")
 	}
 
@@ -1236,7 +1248,7 @@ func (m *Mock) GetObjectVersion(ctx context.Context, bucket, key, versionID stri
 	}
 
 	if v.deleteMarker {
-		return nil, driver.ErrDeleteMarker
+		return nil, &driver.DeleteMarkerError{LastModified: v.lastModified}
 	}
 
 	data, err := m.engineLoad(ctx, config.StorageRef{Bucket: bucket, Key: key, Version: versionID}, v.data)
@@ -1270,7 +1282,7 @@ func (m *Mock) HeadObjectVersion(ctx context.Context, bucket, key, versionID str
 	}
 
 	if v.deleteMarker {
-		return nil, driver.ErrDeleteMarker
+		return nil, &driver.DeleteMarkerError{LastModified: v.lastModified}
 	}
 
 	info := infoFromVersion(key, v)

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -35,6 +35,8 @@ var (
 	_ driver.Bucket          = (*Mock)(nil)
 	_ driver.VersionedBucket = (*Mock)(nil)
 	_ driver.RawBucketConfig = (*Mock)(nil)
+	_ driver.ObjectCopier    = (*Mock)(nil)
+	_ driver.RegionalBucket  = (*Mock)(nil)
 )
 
 type s3Object struct {
@@ -185,7 +187,14 @@ func New(opts *config.Options) *Mock {
 	}
 }
 
-func (m *Mock) CreateBucket(_ context.Context, name string) error {
+func (m *Mock) CreateBucket(ctx context.Context, name string) error {
+	return m.CreateBucketInRegion(ctx, name, "")
+}
+
+// CreateBucketInRegion creates a bucket, recording region when non-empty
+// (S3 CreateBucketConfiguration.LocationConstraint). An empty region falls back
+// to the mock's default region, so GetBucketLocation reports it back correctly.
+func (m *Mock) CreateBucketInRegion(_ context.Context, name, region string) error {
 	if name == "" {
 		return cerrors.New(cerrors.InvalidArgument, "bucket name cannot be empty")
 	}
@@ -194,9 +203,13 @@ func (m *Mock) CreateBucket(_ context.Context, name string) error {
 		return cerrors.Newf(cerrors.AlreadyExists, "bucket %q already exists", name)
 	}
 
+	if region == "" {
+		region = m.opts.Region
+	}
+
 	m.buckets.Set(name, &bucketMeta{
 		Name:       name,
-		Region:     m.opts.Region,
+		Region:     region,
 		CreatedAt:  m.opts.Clock.Now().UTC().Format(s3TimeFormat),
 		objects:    memstore.New[*s3Object](),
 		multiparts: memstore.New[*multipartUpload](),
@@ -640,6 +653,186 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 	return nil
 }
 
+// copySrcSnapshot is the resolved source object for a server-side copy.
+type copySrcSnapshot struct {
+	data         []byte
+	size         int64
+	contentType  string
+	etag         string
+	lastModified string
+	metadata     map[string]string
+	versionID    string
+}
+
+// CopyObjectV2 performs a full-fidelity S3 server-side copy: it honors a
+// versioned source, the COPY/REPLACE metadata directive, and copy-source
+// preconditions (a failed precondition aborts with FailedPrecondition; a
+// delete-marker source version with InvalidArgument). The destination inherits
+// the source ETag exactly (COPY) unless REPLACE supplies new metadata.
+func (m *Mock) CopyObjectV2(ctx context.Context, req *driver.CopyObjectRequest) (*driver.CopyObjectResult, error) {
+	src, err := m.resolveCopySource(ctx, req.Src, req.SrcVersionID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := checkCopyPreconditions(req, src); err != nil {
+		return nil, err
+	}
+
+	dstBkt, ok := m.buckets.Get(req.DstBucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "destination bucket %q not found", req.DstBucket)
+	}
+
+	metadata, contentType := src.metadata, src.contentType
+	if req.ReplaceMetadata {
+		metadata = req.Metadata
+		contentType = req.ContentType
+
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+	}
+
+	dataCopy := make([]byte, len(src.data))
+	copy(dataCopy, src.data)
+
+	dstObj := &s3Object{
+		Key: req.DstKey, Data: dataCopy, Size: src.size, ContentType: contentType,
+		ETag: src.etag, LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
+		Metadata: maps.Clone(metadata),
+	}
+	m.storeObject(dstBkt, req.DstKey, dstObj)
+
+	if err := m.engineStore(ctx, req.DstBucket, req.DstKey, dstObj.VersionID, contentType, dataCopy, metadata); err != nil {
+		return nil, err
+	}
+
+	if m.opts.StorageEngine != nil {
+		dstObj.Data = nil
+	}
+
+	dims := map[string]string{"BucketName": req.DstBucket}
+	m.emitMetric("AllRequests", 1, "Count", dims)
+	m.emitMetric("CopyRequests", 1, "Count", dims)
+
+	m.notifyObjectCreated(dstBkt, req.DstBucket, req.DstKey, src.size)
+
+	return &driver.CopyObjectResult{
+		ETag: dstObj.ETag, LastModified: dstObj.LastModified,
+		VersionID: dstObj.VersionID, SourceVersionID: src.versionID,
+	}, nil
+}
+
+// resolveCopySource loads the source object for a copy: a specific version when
+// versionID is set (a delete-marker version is rejected with InvalidArgument),
+// otherwise the current object.
+func (m *Mock) resolveCopySource(ctx context.Context, src driver.CopySource, versionID string) (*copySrcSnapshot, error) {
+	srcBkt, ok := m.buckets.Get(src.Bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "source bucket %q not found", src.Bucket)
+	}
+
+	if versionID != "" {
+		return m.resolveCopySourceVersion(ctx, srcBkt, src, versionID)
+	}
+
+	srcObj, ok := srcBkt.objects.Get(src.Key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "source object %q not found", src.Key)
+	}
+
+	data, err := m.engineLoad(ctx, config.StorageRef{Bucket: src.Bucket, Key: src.Key, Version: srcObj.VersionID}, srcObj.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &copySrcSnapshot{
+		data: data, size: srcObj.Size, contentType: srcObj.ContentType, etag: srcObj.ETag,
+		lastModified: srcObj.LastModified, metadata: srcObj.Metadata, versionID: srcObj.VersionID,
+	}, nil
+}
+
+func (m *Mock) resolveCopySourceVersion(
+	ctx context.Context, srcBkt *bucketMeta, src driver.CopySource, versionID string,
+) (*copySrcSnapshot, error) {
+	srcBkt.versionsMu.Lock()
+	v := findVersion(srcBkt, src.Key, versionID)
+	srcBkt.versionsMu.Unlock()
+
+	if v == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "source version %q of %q not found", versionID, src.Key)
+	}
+
+	if v.deleteMarker {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "source version %q of %q is a delete marker", versionID, src.Key)
+	}
+
+	data, err := m.engineLoad(ctx, config.StorageRef{Bucket: src.Bucket, Key: src.Key, Version: versionID}, v.data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &copySrcSnapshot{
+		data: data, size: v.size, contentType: v.contentType, etag: v.etag,
+		lastModified: v.lastModified, metadata: v.metadata, versionID: versionID,
+	}, nil
+}
+
+// checkCopyPreconditions evaluates the four x-amz-copy-source-if-* headers
+// against the source, returning FailedPrecondition when one is not satisfied.
+func checkCopyPreconditions(req *driver.CopyObjectRequest, src *copySrcSnapshot) error {
+	if err := checkCopyETagPreconditions(req, src.etag); err != nil {
+		return err
+	}
+
+	return checkCopyTimePreconditions(req, src.lastModified)
+}
+
+func checkCopyETagPreconditions(req *driver.CopyObjectRequest, etag string) error {
+	etag = strings.Trim(etag, `"`)
+
+	if req.IfMatch != "" && !etagMatches(req.IfMatch, etag) {
+		return cerrors.New(cerrors.FailedPrecondition, "x-amz-copy-source-if-match precondition failed")
+	}
+
+	if req.IfNoneMatch != "" && etagMatches(req.IfNoneMatch, etag) {
+		return cerrors.New(cerrors.FailedPrecondition, "x-amz-copy-source-if-none-match precondition failed")
+	}
+
+	return nil
+}
+
+func checkCopyTimePreconditions(req *driver.CopyObjectRequest, lastModified string) error {
+	if req.IfUnmodifiedSince.IsZero() && req.IfModifiedSince.IsZero() {
+		return nil
+	}
+
+	mod, err := time.Parse(s3TimeFormat, lastModified)
+	if err != nil {
+		return nil // an unparseable timestamp can't be evaluated; do not block the copy
+	}
+
+	if !req.IfUnmodifiedSince.IsZero() && mod.After(req.IfUnmodifiedSince) {
+		return cerrors.New(cerrors.FailedPrecondition, "x-amz-copy-source-if-unmodified-since precondition failed")
+	}
+
+	if !req.IfModifiedSince.IsZero() && !mod.After(req.IfModifiedSince) {
+		return cerrors.New(cerrors.FailedPrecondition, "x-amz-copy-source-if-modified-since precondition failed")
+	}
+
+	return nil
+}
+
+// etagMatches reports whether an If-[None-]Match header value matches the
+// object ETag: "*" matches any object; otherwise a quote-insensitive,
+// case-insensitive comparison.
+func etagMatches(header, etag string) bool {
+	header = strings.Trim(header, `"`)
+
+	return header == "*" || strings.EqualFold(header, etag)
+}
+
 // GeneratePresignedURL generates a mock presigned URL.
 // Note: expiry is tracked in the URL but not enforced on use — this is a mock limitation.
 func (m *Mock) GeneratePresignedURL(_ context.Context, req driver.PresignedURLRequest) (*driver.PresignedURL, error) {
@@ -1038,8 +1231,12 @@ func (m *Mock) GetObjectVersion(ctx context.Context, bucket, key, versionID stri
 	v := findVersion(bkt, key, versionID)
 	bkt.versionsMu.Unlock()
 
-	if v == nil || v.deleteMarker {
+	if v == nil {
 		return nil, cerrors.Newf(cerrors.NotFound, "version %q of %q not found", versionID, key)
+	}
+
+	if v.deleteMarker {
+		return nil, driver.ErrDeleteMarker
 	}
 
 	data, err := m.engineLoad(ctx, config.StorageRef{Bucket: bucket, Key: key, Version: versionID}, v.data)
@@ -1068,8 +1265,12 @@ func (m *Mock) HeadObjectVersion(ctx context.Context, bucket, key, versionID str
 	v := findVersion(bkt, key, versionID)
 	bkt.versionsMu.Unlock()
 
-	if v == nil || v.deleteMarker {
+	if v == nil {
 		return nil, cerrors.Newf(cerrors.NotFound, "version %q of %q not found", versionID, key)
+	}
+
+	if v.deleteMarker {
+		return nil, driver.ErrDeleteMarker
 	}
 
 	info := infoFromVersion(key, v)

--- a/server/aws/s3/bucket_config.go
+++ b/server/aws/s3/bucket_config.go
@@ -9,6 +9,9 @@ import (
 	"github.com/stackshy/cloudemu/v2/server/wire"
 )
 
+// subLocation is the ?location sub-resource key (GetBucketLocation).
+const subLocation = "location"
+
 // maxConfigBody caps a bucket-configuration document. Real S3 bucket policies
 // top out at 20 KB; this is a generous ceiling covering cors/lifecycle/website
 // XML as well.
@@ -40,7 +43,7 @@ var notConfiguredErr = map[string]string{
 var configSubresources = []string{
 	"policy", "cors", "website", "lifecycle", "replication", "encryption",
 	"object-lock", "publicAccessBlock", "ownershipControls",
-	"requestPayment", "accelerate", "logging", "location", "policyStatus",
+	"requestPayment", "accelerate", "logging", subLocation, "policyStatus",
 }
 
 // configSubresourceKey returns the read-only config sub-resource query key
@@ -114,6 +117,20 @@ func (h *Handler) deleteBucketConfig(w http.ResponseWriter, r *http.Request, buc
 // getBucketConfig echoes a stored document, or returns the AWS "not
 // configured"/default response when the sub-resource was never set.
 func (h *Handler) getBucketConfig(w http.ResponseWriter, r *http.Request, bucket, sub string) {
+	// GetBucketLocation reports the region the bucket was created in
+	// (CreateBucketConfiguration.LocationConstraint); us-east-1 is the empty
+	// constraint. It is derived from bucket state, never a stored document.
+	if sub == subLocation {
+		region := h.bucketRegion(r.Context(), bucket)
+		if region == usEast1 {
+			region = ""
+		}
+
+		wire.WriteXML(w, http.StatusOK, locationXML{Xmlns: xmlns, Location: region})
+
+		return
+	}
+
 	if h.rawConfig != nil {
 		if body, err := h.rawConfig.GetBucketConfig(r.Context(), bucket, sub); err == nil {
 			writeRawBucketConfig(w, sub, body)
@@ -153,7 +170,7 @@ func writeConfigDefault(w http.ResponseWriter, sub string) {
 		wire.WriteXML(w, http.StatusOK, accelerateXML{Xmlns: xmlns})
 	case "logging":
 		wire.WriteXML(w, http.StatusOK, loggingXML{Xmlns: xmlns})
-	case "location":
+	case subLocation:
 		// An empty LocationConstraint denotes us-east-1.
 		wire.WriteXML(w, http.StatusOK, locationXML{Xmlns: xmlns})
 	case "policyStatus":
@@ -182,6 +199,8 @@ type loggingXML struct {
 type locationXML struct {
 	XMLName xml.Name `xml:"LocationConstraint"`
 	Xmlns   string   `xml:"xmlns,attr"`
+	// Location is the region name (character data); empty denotes us-east-1.
+	Location string `xml:",chardata"`
 }
 
 type policyStatusXML struct {

--- a/server/aws/s3/bucket_config.go
+++ b/server/aws/s3/bucket_config.go
@@ -121,6 +121,11 @@ func (h *Handler) getBucketConfig(w http.ResponseWriter, r *http.Request, bucket
 	// (CreateBucketConfiguration.LocationConstraint); us-east-1 is the empty
 	// constraint. It is derived from bucket state, never a stored document.
 	if sub == subLocation {
+		if !h.bucketExists(r.Context(), bucket) {
+			writeError(w, http.StatusNotFound, "NoSuchBucket", "The specified bucket does not exist")
+			return
+		}
+
 		region := h.bucketRegion(r.Context(), bucket)
 		if region == usEast1 {
 			region = ""

--- a/server/aws/s3/bucket_location_sdk_test.go
+++ b/server/aws/s3/bucket_location_sdk_test.go
@@ -1,0 +1,49 @@
+package s3_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// TestSDKGetBucketLocation verifies GetBucketLocation reports the region the
+// bucket was created in via CreateBucketConfiguration.LocationConstraint, and
+// the empty constraint for a us-east-1 bucket.
+func TestSDKGetBucketLocation(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	// A bucket created with an explicit LocationConstraint reports that region.
+	if _, err := client.CreateBucket(ctx, &awss3.CreateBucketInput{
+		Bucket: aws.String("west-bucket"),
+		CreateBucketConfiguration: &types.CreateBucketConfiguration{
+			LocationConstraint: types.BucketLocationConstraintUsWest2,
+		},
+	}); err != nil {
+		t.Fatalf("CreateBucket (us-west-2): %v", err)
+	}
+
+	west, err := client.GetBucketLocation(ctx, &awss3.GetBucketLocationInput{Bucket: aws.String("west-bucket")})
+	if err != nil {
+		t.Fatalf("GetBucketLocation (west): %v", err)
+	}
+
+	if west.LocationConstraint != types.BucketLocationConstraintUsWest2 {
+		t.Fatalf("LocationConstraint = %q, want us-west-2", west.LocationConstraint)
+	}
+
+	// A default (us-east-1) bucket reports the empty constraint.
+	mustCreateBucket(t, client, "east-bucket")
+
+	east, err := client.GetBucketLocation(ctx, &awss3.GetBucketLocationInput{Bucket: aws.String("east-bucket")})
+	if err != nil {
+		t.Fatalf("GetBucketLocation (east): %v", err)
+	}
+
+	if east.LocationConstraint != "" {
+		t.Fatalf("LocationConstraint = %q, want empty (us-east-1)", east.LocationConstraint)
+	}
+}

--- a/server/aws/s3/bucket_location_sdk_test.go
+++ b/server/aws/s3/bucket_location_sdk_test.go
@@ -2,9 +2,11 @@ package s3_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
@@ -45,5 +47,26 @@ func TestSDKGetBucketLocation(t *testing.T) {
 
 	if east.LocationConstraint != "" {
 		t.Fatalf("LocationConstraint = %q, want empty (us-east-1)", east.LocationConstraint)
+	}
+}
+
+// TestSDKGetBucketLocationNoSuchBucket verifies GetBucketLocation on a bucket
+// that does not exist returns 404 NoSuchBucket, not a bogus us-east-1 200.
+func TestSDKGetBucketLocationNoSuchBucket(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.GetBucketLocation(ctx, &awss3.GetBucketLocationInput{Bucket: aws.String("no-such-bucket")})
+	if err == nil {
+		t.Fatal("GetBucketLocation(nonexistent) succeeded, want NoSuchBucket 404")
+	}
+
+	var re *awshttp.ResponseError
+	if !errors.As(err, &re) {
+		t.Fatalf("GetBucketLocation(nonexistent) error = %T %v, want *awshttp.ResponseError", err, err)
+	}
+
+	if re.HTTPStatusCode() != 404 {
+		t.Fatalf("GetBucketLocation(nonexistent) status = %d, want 404", re.HTTPStatusCode())
 	}
 }

--- a/server/aws/s3/copy_sdk_test.go
+++ b/server/aws/s3/copy_sdk_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
@@ -290,6 +291,82 @@ func TestSDKCopyObjectConditional(t *testing.T) {
 		CopySourceIfNoneMatch: aws.String(etag),
 	})
 	assertAPICode(t, err, "PreconditionFailed")
+}
+
+// TestSDKCopyObjectIfMatchOverridesUnmodifiedSince verifies AWS's documented
+// combined-precedence override: with both x-amz-copy-source-if-match and
+// x-amz-copy-source-if-unmodified-since present and if-match true, S3 returns
+// 200 OK and copies even though if-unmodified-since evaluates false (the source
+// was modified after the supplied time). The two headers are not independent.
+func TestSDKCopyObjectIfMatchOverridesUnmodifiedSince(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateBucket(t, client, "ovr")
+	putObject(t, client, "ovr", "src", "data", "", nil)
+
+	head, err := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: aws.String("ovr"), Key: aws.String("src")})
+	if err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+
+	// A time before the source's last modification: if-unmodified-since alone
+	// evaluates false (the source was modified since) and would fail with 412.
+	past := aws.ToTime(head.LastModified).Add(-1 * time.Hour)
+
+	if _, err := client.CopyObject(ctx, &awss3.CopyObjectInput{
+		Bucket: aws.String("ovr"), Key: aws.String("dst"), CopySource: aws.String("ovr/src"),
+		CopySourceIfMatch:           head.ETag,
+		CopySourceIfUnmodifiedSince: aws.Time(past),
+	}); err != nil {
+		t.Fatalf("CopyObject (if-match overrides if-unmodified-since): %v", err)
+	}
+
+	if got := getBody(t, client, "ovr", "dst"); got != "data" {
+		t.Fatalf("override copy body = %q, want data", got)
+	}
+}
+
+// TestSDKUploadPartCopyConditional verifies UploadPartCopy honours the same
+// copy-source preconditions as CopyObject: a mismatched if-match fails the part
+// copy with 412 PreconditionFailed.
+func TestSDKUploadPartCopyConditional(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateBucket(t, client, "upcc")
+	putObject(t, client, "upcc", "src", "COPIED-PART-DATA", "", nil)
+
+	created, err := client.CreateMultipartUpload(ctx, &awss3.CreateMultipartUploadInput{
+		Bucket: aws.String("upcc"), Key: aws.String("dst"),
+	})
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	uploadID := aws.ToString(created.UploadId)
+
+	_, err = client.UploadPartCopy(ctx, &awss3.UploadPartCopyInput{
+		Bucket: aws.String("upcc"), Key: aws.String("dst"), UploadId: aws.String(uploadID),
+		PartNumber: aws.Int32(1), CopySource: aws.String("upcc/src"),
+		CopySourceIfMatch: aws.String("\"0000000000000000000000000000dead\""),
+	})
+	assertAPICode(t, err, "PreconditionFailed")
+	assertStatus(t, err, 412)
+
+	// A matching if-match lets the part copy proceed.
+	head, err := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: aws.String("upcc"), Key: aws.String("src")})
+	if err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+
+	if _, err := client.UploadPartCopy(ctx, &awss3.UploadPartCopyInput{
+		Bucket: aws.String("upcc"), Key: aws.String("dst"), UploadId: aws.String(uploadID),
+		PartNumber: aws.Int32(1), CopySource: aws.String("upcc/src"),
+		CopySourceIfMatch: head.ETag,
+	}); err != nil {
+		t.Fatalf("UploadPartCopy (matching if-match): %v", err)
+	}
 }
 
 // TestSDKCopyObjectSelfCopy verifies self-copy with the default COPY directive

--- a/server/aws/s3/copy_sdk_test.go
+++ b/server/aws/s3/copy_sdk_test.go
@@ -1,0 +1,348 @@
+package s3_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+)
+
+// putObject is a small helper for the copy tests.
+func putObject(t *testing.T, c *awss3.Client, bucket, key, body, contentType string, meta map[string]string) {
+	t.Helper()
+
+	in := &awss3.PutObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String(key),
+		Body: bytes.NewReader([]byte(body)), Metadata: meta,
+	}
+	if contentType != "" {
+		in.ContentType = aws.String(contentType)
+	}
+
+	if _, err := c.PutObject(context.Background(), in); err != nil {
+		t.Fatalf("PutObject %s/%s: %v", bucket, key, err)
+	}
+}
+
+func getBody(t *testing.T, c *awss3.Client, bucket, key string) string {
+	t.Helper()
+
+	out, err := c.GetObject(context.Background(), &awss3.GetObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String(key),
+	})
+	if err != nil {
+		t.Fatalf("GetObject %s/%s: %v", bucket, key, err)
+	}
+	defer out.Body.Close()
+
+	b, _ := io.ReadAll(out.Body)
+
+	return string(b)
+}
+
+// TestSDKUploadPartCopy drives the high-level copy path: part 2 of a multipart
+// upload is filled by copying an existing object via UploadPartCopy.
+func TestSDKUploadPartCopy(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateBucket(t, client, "upc")
+	putObject(t, client, "upc", "src", "COPIED-PART-DATA", "", nil)
+
+	created, err := client.CreateMultipartUpload(ctx, &awss3.CreateMultipartUploadInput{
+		Bucket: aws.String("upc"), Key: aws.String("dst"),
+	})
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	uploadID := aws.ToString(created.UploadId)
+
+	part1 := bytes.Repeat([]byte("A"), 8)
+	up1, err := client.UploadPart(ctx, &awss3.UploadPartInput{
+		Bucket: aws.String("upc"), Key: aws.String("dst"), UploadId: aws.String(uploadID),
+		PartNumber: aws.Int32(1), Body: bytes.NewReader(part1),
+	})
+	if err != nil {
+		t.Fatalf("UploadPart: %v", err)
+	}
+
+	upc, err := client.UploadPartCopy(ctx, &awss3.UploadPartCopyInput{
+		Bucket: aws.String("upc"), Key: aws.String("dst"), UploadId: aws.String(uploadID),
+		PartNumber: aws.Int32(2), CopySource: aws.String("upc/src"),
+	})
+	if err != nil {
+		t.Fatalf("UploadPartCopy: %v", err)
+	}
+
+	if upc.CopyPartResult == nil || aws.ToString(upc.CopyPartResult.ETag) == "" {
+		t.Fatalf("UploadPartCopy returned no CopyPartResult ETag: %+v", upc.CopyPartResult)
+	}
+
+	_, err = client.CompleteMultipartUpload(ctx, &awss3.CompleteMultipartUploadInput{
+		Bucket: aws.String("upc"), Key: aws.String("dst"), UploadId: aws.String(uploadID),
+		MultipartUpload: &types.CompletedMultipartUpload{Parts: []types.CompletedPart{
+			{ETag: up1.ETag, PartNumber: aws.Int32(1)},
+			{ETag: upc.CopyPartResult.ETag, PartNumber: aws.Int32(2)},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteMultipartUpload: %v", err)
+	}
+
+	if got := getBody(t, client, "upc", "dst"); got != "AAAAAAAACOPIED-PART-DATA" {
+		t.Fatalf("assembled object = %q, want AAAAAAAACOPIED-PART-DATA", got)
+	}
+}
+
+// TestSDKUploadPartCopyRange reconstructs an object from two byte-range part
+// copies, verifying x-amz-copy-source-range is honored exactly.
+func TestSDKUploadPartCopyRange(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateBucket(t, client, "upcr")
+	putObject(t, client, "upcr", "src", "0123456789ABCDEFGHIJ", "", nil) // 20 bytes
+
+	created, err := client.CreateMultipartUpload(ctx, &awss3.CreateMultipartUploadInput{
+		Bucket: aws.String("upcr"), Key: aws.String("dst"),
+	})
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	uploadID := aws.ToString(created.UploadId)
+
+	ranges := []string{"bytes=0-9", "bytes=10-19"}
+	parts := make([]types.CompletedPart, 0, len(ranges))
+
+	for i, rng := range ranges {
+		partNum := int32(i + 1) //nolint:gosec // small loop index
+
+		out, cErr := client.UploadPartCopy(ctx, &awss3.UploadPartCopyInput{
+			Bucket: aws.String("upcr"), Key: aws.String("dst"), UploadId: aws.String(uploadID),
+			PartNumber: aws.Int32(partNum), CopySource: aws.String("upcr/src"),
+			CopySourceRange: aws.String(rng),
+		})
+		if cErr != nil {
+			t.Fatalf("UploadPartCopy %s: %v", rng, cErr)
+		}
+
+		parts = append(parts, types.CompletedPart{ETag: out.CopyPartResult.ETag, PartNumber: aws.Int32(partNum)})
+	}
+
+	if _, err = client.CompleteMultipartUpload(ctx, &awss3.CompleteMultipartUploadInput{
+		Bucket: aws.String("upcr"), Key: aws.String("dst"), UploadId: aws.String(uploadID),
+		MultipartUpload: &types.CompletedMultipartUpload{Parts: parts},
+	}); err != nil {
+		t.Fatalf("CompleteMultipartUpload: %v", err)
+	}
+
+	if got := getBody(t, client, "upcr", "dst"); got != "0123456789ABCDEFGHIJ" {
+		t.Fatalf("range-assembled object = %q, want the full source", got)
+	}
+}
+
+// TestSDKCopyObjectMetadataDirective covers COPY (carry source metadata) vs
+// REPLACE (take request metadata + content-type).
+func TestSDKCopyObjectMetadataDirective(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateBucket(t, client, "mdb")
+	putObject(t, client, "mdb", "src", "payload", "text/plain", map[string]string{"origin": "source"})
+
+	// Default directive COPY carries the source metadata + content type.
+	if _, err := client.CopyObject(ctx, &awss3.CopyObjectInput{
+		Bucket: aws.String("mdb"), Key: aws.String("copied"), CopySource: aws.String("mdb/src"),
+	}); err != nil {
+		t.Fatalf("CopyObject (COPY): %v", err)
+	}
+
+	head, err := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: aws.String("mdb"), Key: aws.String("copied")})
+	if err != nil {
+		t.Fatalf("HeadObject (copied): %v", err)
+	}
+
+	if head.Metadata["origin"] != "source" || aws.ToString(head.ContentType) != "text/plain" {
+		t.Fatalf("COPY did not carry metadata/content-type: meta=%v ct=%q", head.Metadata, aws.ToString(head.ContentType))
+	}
+
+	// REPLACE overrides metadata and content type from the request.
+	if _, err := client.CopyObject(ctx, &awss3.CopyObjectInput{
+		Bucket: aws.String("mdb"), Key: aws.String("replaced"), CopySource: aws.String("mdb/src"),
+		MetadataDirective: types.MetadataDirectiveReplace,
+		Metadata:          map[string]string{"origin": "request"},
+		ContentType:       aws.String("application/json"),
+	}); err != nil {
+		t.Fatalf("CopyObject (REPLACE): %v", err)
+	}
+
+	head, err = client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: aws.String("mdb"), Key: aws.String("replaced")})
+	if err != nil {
+		t.Fatalf("HeadObject (replaced): %v", err)
+	}
+
+	if head.Metadata["origin"] != "request" || aws.ToString(head.ContentType) != "application/json" {
+		t.Fatalf("REPLACE did not apply request metadata/content-type: meta=%v ct=%q",
+			head.Metadata, aws.ToString(head.ContentType))
+	}
+}
+
+// TestSDKCopyObjectVersionedSource copies a specific (non-current) source
+// version by appending ?versionId to the copy source.
+func TestSDKCopyObjectVersionedSource(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateBucket(t, client, "vsrc")
+
+	if _, err := client.PutBucketVersioning(ctx, &awss3.PutBucketVersioningInput{
+		Bucket: aws.String("vsrc"),
+		VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusEnabled},
+	}); err != nil {
+		t.Fatalf("PutBucketVersioning: %v", err)
+	}
+
+	v1, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket: aws.String("vsrc"), Key: aws.String("k"), Body: bytes.NewReader([]byte("one")),
+	})
+	if err != nil {
+		t.Fatalf("PutObject v1: %v", err)
+	}
+
+	if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket: aws.String("vsrc"), Key: aws.String("k"), Body: bytes.NewReader([]byte("two")),
+	}); err != nil {
+		t.Fatalf("PutObject v2: %v", err)
+	}
+
+	oldVersion := aws.ToString(v1.VersionId)
+	if oldVersion == "" {
+		t.Fatal("first PutObject returned no version id")
+	}
+
+	out, err := client.CopyObject(ctx, &awss3.CopyObjectInput{
+		Bucket: aws.String("vsrc"), Key: aws.String("restored"),
+		CopySource: aws.String("vsrc/k?versionId=" + oldVersion),
+	})
+	if err != nil {
+		t.Fatalf("CopyObject (versioned source): %v", err)
+	}
+
+	if aws.ToString(out.CopySourceVersionId) != oldVersion {
+		t.Fatalf("CopySourceVersionId = %q, want %q", aws.ToString(out.CopySourceVersionId), oldVersion)
+	}
+
+	if got := getBody(t, client, "vsrc", "restored"); got != "one" {
+		t.Fatalf("versioned copy body = %q, want the older version 'one'", got)
+	}
+}
+
+// TestSDKCopyObjectConditional verifies copy-source preconditions: a mismatched
+// if-match returns 412 and does not copy; a matching one succeeds.
+func TestSDKCopyObjectConditional(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateBucket(t, client, "cond")
+	putObject(t, client, "cond", "src", "data", "", nil)
+
+	head, err := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: aws.String("cond"), Key: aws.String("src")})
+	if err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+
+	etag := aws.ToString(head.ETag)
+
+	_, err = client.CopyObject(ctx, &awss3.CopyObjectInput{
+		Bucket: aws.String("cond"), Key: aws.String("dst"), CopySource: aws.String("cond/src"),
+		CopySourceIfMatch: aws.String("\"0000000000000000000000000000dead\""),
+	})
+	assertAPICode(t, err, "PreconditionFailed")
+	assertStatus(t, err, 412)
+
+	// The failed precondition must not have created the destination object.
+	if _, err := client.HeadObject(ctx, &awss3.HeadObjectInput{
+		Bucket: aws.String("cond"), Key: aws.String("dst"),
+	}); err == nil {
+		t.Fatal("destination object exists after a failed-precondition copy")
+	}
+
+	// A matching if-match succeeds.
+	if _, err := client.CopyObject(ctx, &awss3.CopyObjectInput{
+		Bucket: aws.String("cond"), Key: aws.String("dst"), CopySource: aws.String("cond/src"),
+		CopySourceIfMatch: aws.String(etag),
+	}); err != nil {
+		t.Fatalf("CopyObject (matching if-match): %v", err)
+	}
+
+	// A matching if-none-match must fail with 412.
+	_, err = client.CopyObject(ctx, &awss3.CopyObjectInput{
+		Bucket: aws.String("cond"), Key: aws.String("dst2"), CopySource: aws.String("cond/src"),
+		CopySourceIfNoneMatch: aws.String(etag),
+	})
+	assertAPICode(t, err, "PreconditionFailed")
+}
+
+// TestSDKCopyObjectSelfCopy verifies self-copy with the default COPY directive
+// is rejected (InvalidRequest), while REPLACE makes it legal.
+func TestSDKCopyObjectSelfCopy(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateBucket(t, client, "self")
+	putObject(t, client, "self", "k", "data", "", nil)
+
+	_, err := client.CopyObject(ctx, &awss3.CopyObjectInput{
+		Bucket: aws.String("self"), Key: aws.String("k"), CopySource: aws.String("self/k"),
+	})
+	assertAPICode(t, err, "InvalidRequest")
+	assertStatus(t, err, 400)
+
+	// The same self-copy is legal when it changes metadata (REPLACE).
+	if _, err := client.CopyObject(ctx, &awss3.CopyObjectInput{
+		Bucket: aws.String("self"), Key: aws.String("k"), CopySource: aws.String("self/k"),
+		MetadataDirective: types.MetadataDirectiveReplace,
+		Metadata:          map[string]string{"changed": "yes"},
+	}); err != nil {
+		t.Fatalf("self-copy with REPLACE: %v", err)
+	}
+}
+
+func assertAPICode(t *testing.T, err error, want string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("expected error with code %q, got nil", want)
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T %v, want smithy.APIError", err, err)
+	}
+
+	if apiErr.ErrorCode() != want {
+		t.Fatalf("error code = %q, want %q", apiErr.ErrorCode(), want)
+	}
+}
+
+func assertStatus(t *testing.T, err error, want int) {
+	t.Helper()
+
+	var re *awshttp.ResponseError
+	if !errors.As(err, &re) {
+		t.Fatalf("error = %T %v, want *awshttp.ResponseError", err, err)
+	}
+
+	if re.HTTPStatusCode() != want {
+		t.Fatalf("HTTP status = %d, want %d", re.HTTPStatusCode(), want)
+	}
+}

--- a/server/aws/s3/delete_marker_sdk_test.go
+++ b/server/aws/s3/delete_marker_sdk_test.go
@@ -1,0 +1,72 @@
+package s3_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// TestSDKGetDeleteMarkerVersion verifies that a version-addressed GET/HEAD of a
+// delete marker returns 405 MethodNotAllowed with x-amz-delete-marker: true,
+// not 404 — a delete marker has no retrievable content.
+func TestSDKGetDeleteMarkerVersion(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateBucket(t, client, "dmb")
+
+	if _, err := client.PutBucketVersioning(ctx, &awss3.PutBucketVersioningInput{
+		Bucket: aws.String("dmb"),
+		VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusEnabled},
+	}); err != nil {
+		t.Fatalf("PutBucketVersioning: %v", err)
+	}
+
+	if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket: aws.String("dmb"), Key: aws.String("k"), Body: bytes.NewReader([]byte("v1")),
+	}); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	del, err := client.DeleteObject(ctx, &awss3.DeleteObjectInput{Bucket: aws.String("dmb"), Key: aws.String("k")})
+	if err != nil {
+		t.Fatalf("DeleteObject: %v", err)
+	}
+
+	markerID := aws.ToString(del.VersionId)
+	if markerID == "" || !aws.ToBool(del.DeleteMarker) {
+		t.Fatalf("DeleteObject did not report a delete marker: id=%q marker=%v", markerID, aws.ToBool(del.DeleteMarker))
+	}
+
+	_, err = client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket: aws.String("dmb"), Key: aws.String("k"), VersionId: aws.String(markerID),
+	})
+
+	var re *awshttp.ResponseError
+	if !errors.As(err, &re) {
+		t.Fatalf("GetObject(delete-marker version) error = %T %v, want *awshttp.ResponseError", err, err)
+	}
+
+	if re.HTTPStatusCode() != 405 {
+		t.Fatalf("GetObject(delete-marker version) status = %d, want 405", re.HTTPStatusCode())
+	}
+
+	if re.Response.Header.Get("x-amz-delete-marker") != "true" {
+		t.Fatalf("missing x-amz-delete-marker: true header; got %q", re.Response.Header.Get("x-amz-delete-marker"))
+	}
+
+	// HEAD of the same delete-marker version is likewise a 405.
+	_, err = client.HeadObject(ctx, &awss3.HeadObjectInput{
+		Bucket: aws.String("dmb"), Key: aws.String("k"), VersionId: aws.String(markerID),
+	})
+
+	if !errors.As(err, &re) || re.HTTPStatusCode() != 405 {
+		t.Fatalf("HeadObject(delete-marker version) = %v, want 405", err)
+	}
+}

--- a/server/aws/s3/delete_marker_sdk_test.go
+++ b/server/aws/s3/delete_marker_sdk_test.go
@@ -61,6 +61,12 @@ func TestSDKGetDeleteMarkerVersion(t *testing.T) {
 		t.Fatalf("missing x-amz-delete-marker: true header; got %q", re.Response.Header.Get("x-amz-delete-marker"))
 	}
 
+	// S3 documents the delete marker's Last-Modified timestamp as part of the 405
+	// response for a version-addressed GET of a delete marker.
+	if re.Response.Header.Get("Last-Modified") == "" {
+		t.Fatalf("missing Last-Modified header on delete-marker 405 response")
+	}
+
 	// HEAD of the same delete-marker version is likewise a 405.
 	_, err = client.HeadObject(ctx, &awss3.HeadObjectInput{
 		Bucket: aws.String("dmb"), Key: aws.String("k"), VersionId: aws.String(markerID),

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -45,6 +46,13 @@ type Handler struct {
 	// the handler then round-trips PUT/GET/DELETE on them instead of treating a
 	// write as a no-op.
 	rawConfig driver.RawBucketConfig
+	// copier is set when the driver supports a full-fidelity server-side copy
+	// (versioned source, metadata directive, copy-source preconditions); the
+	// handler routes CopyObject/UploadPartCopy through it when present.
+	copier driver.ObjectCopier
+	// regional is set when the driver can create a bucket in a caller-specified
+	// region (CreateBucketConfiguration.LocationConstraint).
+	regional driver.RegionalBucket
 }
 
 // New returns an S3 handler backed by b.
@@ -56,6 +64,14 @@ func New(b driver.Bucket) *Handler {
 
 	if rc, ok := b.(driver.RawBucketConfig); ok {
 		h.rawConfig = rc
+	}
+
+	if oc, ok := b.(driver.ObjectCopier); ok {
+		h.copier = oc
+	}
+
+	if rb, ok := b.(driver.RegionalBucket); ok {
+		h.regional = rb
 	}
 
 	return h
@@ -334,13 +350,18 @@ func validBucketNameChar(name string, i int) bool {
 	return c != '.' || name[i-1] != '.'
 }
 
+// maxCreateBucketBody caps the CreateBucketConfiguration document.
+const maxCreateBucketBody = 1 << 16
+
 func (h *Handler) createBucket(w http.ResponseWriter, r *http.Request, bucket string) {
 	if !validBucketName(bucket) {
 		writeError(w, http.StatusBadRequest, "InvalidBucketName", "The specified bucket is not valid.")
 		return
 	}
 
-	if err := h.bucket.CreateBucket(r.Context(), bucket); err != nil {
+	region := parseLocationConstraint(r)
+
+	if err := h.createBucketInRegion(r.Context(), bucket, region); err != nil {
 		// In us-east-1 (the global endpoint) re-creating a bucket you already own
 		// is idempotent and returns 200; every other region returns 409
 		// BucketAlreadyOwnedByYou. cloudemu models a single account, so an existing
@@ -356,6 +377,33 @@ func (h *Handler) createBucket(w http.ResponseWriter, r *http.Request, bucket st
 
 	w.Header().Set("Location", "/"+bucket)
 	w.WriteHeader(http.StatusOK)
+}
+
+// createBucketInRegion honors a CreateBucketConfiguration.LocationConstraint
+// when the driver supports RegionalBucket, so GetBucketLocation reports it back.
+func (h *Handler) createBucketInRegion(ctx context.Context, bucket, region string) error {
+	if region != "" && h.regional != nil {
+		return h.regional.CreateBucketInRegion(ctx, bucket, region)
+	}
+
+	return h.bucket.CreateBucket(ctx, bucket)
+}
+
+// parseLocationConstraint extracts CreateBucketConfiguration.LocationConstraint
+// from a CreateBucket body, or "" when absent/unparseable (which denotes
+// us-east-1).
+func parseLocationConstraint(r *http.Request) string {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxCreateBucketBody))
+	if err != nil || len(body) == 0 {
+		return ""
+	}
+
+	var cfg createBucketConfiguration
+	if err := xml.Unmarshal(body, &cfg); err != nil {
+		return ""
+	}
+
+	return cfg.LocationConstraint
 }
 
 // bucketRegion returns the region of an existing bucket, or "" if it can't be
@@ -541,12 +589,19 @@ func (h *Handler) getObject(w http.ResponseWriter, r *http.Request, bucket, key 
 		obj *driver.Object
 		err error
 	)
-	if versionID := r.URL.Query().Get("versionId"); versionID != "" && h.versioned != nil {
+
+	versionID := r.URL.Query().Get("versionId")
+
+	if versionID != "" && h.versioned != nil {
 		obj, err = h.versioned.GetObjectVersion(r.Context(), bucket, key, versionID)
 	} else {
 		obj, err = h.bucket.GetObject(r.Context(), bucket, key)
 	}
+
 	if err != nil {
+		if writeDeleteMarker(w, err, versionID) {
+			return
+		}
 		writeErr(w, err)
 		return
 	}
@@ -675,12 +730,19 @@ func (h *Handler) headObject(w http.ResponseWriter, r *http.Request, bucket, key
 		info *driver.ObjectInfo
 		err  error
 	)
-	if versionID := r.URL.Query().Get("versionId"); versionID != "" && h.versioned != nil {
+
+	versionID := r.URL.Query().Get("versionId")
+
+	if versionID != "" && h.versioned != nil {
 		info, err = h.versioned.HeadObjectVersion(r.Context(), bucket, key, versionID)
 	} else {
 		info, err = h.bucket.HeadObject(r.Context(), bucket, key)
 	}
+
 	if err != nil {
+		if writeDeleteMarker(w, err, versionID) {
+			return
+		}
 		writeErr(w, err)
 		return
 	}
@@ -875,18 +937,86 @@ func (h *Handler) deleteOneObject(ctx context.Context, bucket, key, versionID st
 }
 
 func (h *Handler) copyObject(w http.ResponseWriter, r *http.Request, bucket, key string) {
-	src := r.Header.Get("X-Amz-Copy-Source")
-	src = strings.TrimPrefix(src, "/")
-
-	srcBucket, srcKey := parsePath(src)
+	srcBucket, srcKey, srcVersionID := parseCopySource(r.Header.Get("X-Amz-Copy-Source"))
 	if srcBucket == "" || srcKey == "" {
 		writeError(w, http.StatusBadRequest, "InvalidArgument", "invalid copy source")
 		return
 	}
 
-	if err := h.bucket.CopyObject(r.Context(), bucket, key, driver.CopySource{
-		Bucket: srcBucket, Key: srcKey,
-	}); err != nil {
+	replace := strings.EqualFold(r.Header.Get("X-Amz-Metadata-Directive"), "REPLACE")
+
+	// Copying an object onto itself with the default COPY directive, the current
+	// version, and no metadata change is illegal — S3 answers 400 InvalidRequest.
+	if isIllegalSelfCopy(replace, srcVersionID, srcBucket, srcKey, bucket, key) {
+		writeError(w, http.StatusBadRequest, "InvalidRequest",
+			"This copy request is illegal because it is trying to copy an object to itself without "+
+				"changing the object's metadata, storage class, website redirect location or encryption attributes.")
+		return
+	}
+
+	if h.copier == nil {
+		h.copyObjectFallback(w, r, bucket, key, srcBucket, srcKey)
+		return
+	}
+
+	req := buildCopyRequest(r, bucket, key, driver.CopySource{Bucket: srcBucket, Key: srcKey}, srcVersionID, replace)
+
+	res, err := h.copier.CopyObjectV2(r.Context(), req)
+	if err != nil {
+		writeCopyErr(w, err)
+		return
+	}
+
+	writeCopyResult(w, res)
+}
+
+// isIllegalSelfCopy reports whether a copy is a no-op self-copy: same key, the
+// default COPY directive, and the current source version — which S3 rejects.
+func isIllegalSelfCopy(replace bool, srcVersionID, srcBucket, srcKey, dstBucket, dstKey string) bool {
+	return !replace && srcVersionID == "" && srcBucket == dstBucket && srcKey == dstKey
+}
+
+// buildCopyRequest assembles a CopyObjectRequest from the copy headers: the
+// metadata directive and (for REPLACE) the replacement metadata/content-type,
+// plus the copy-source preconditions.
+func buildCopyRequest(
+	r *http.Request, dstBucket, dstKey string, src driver.CopySource, srcVersionID string, replace bool,
+) *driver.CopyObjectRequest {
+	req := &driver.CopyObjectRequest{
+		DstBucket: dstBucket, DstKey: dstKey, Src: src,
+		SrcVersionID: srcVersionID, ReplaceMetadata: replace,
+	}
+
+	if replace {
+		req.Metadata = extractMetadata(r.Header)
+		req.ContentType = r.Header.Get("Content-Type")
+	}
+
+	applyCopyConditions(req, r.Header)
+
+	return req
+}
+
+// writeCopyResult writes a CopyObject success: the version-id headers plus the
+// <CopyObjectResult> body.
+func writeCopyResult(w http.ResponseWriter, res *driver.CopyObjectResult) {
+	if res.SourceVersionID != "" {
+		w.Header().Set("X-Amz-Copy-Source-Version-Id", res.SourceVersionID)
+	}
+
+	if res.VersionID != "" {
+		w.Header().Set("X-Amz-Version-Id", res.VersionID)
+	}
+
+	wire.WriteXML(w, http.StatusOK, copyObjectResult{
+		Xmlns: xmlns, ETag: fmt.Sprintf("%q", res.ETag), LastModified: res.LastModified,
+	})
+}
+
+// copyObjectFallback runs the basic copy (current version, COPY directive, no
+// preconditions) for drivers that don't implement ObjectCopier.
+func (h *Handler) copyObjectFallback(w http.ResponseWriter, r *http.Request, bucket, key, srcBucket, srcKey string) {
+	if err := h.bucket.CopyObject(r.Context(), bucket, key, driver.CopySource{Bucket: srcBucket, Key: srcKey}); err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -898,10 +1028,176 @@ func (h *Handler) copyObject(w http.ResponseWriter, r *http.Request, bucket, key
 	}
 
 	wire.WriteXML(w, http.StatusOK, copyObjectResult{
-		Xmlns:        xmlns,
-		ETag:         fmt.Sprintf("%q", obj.ETag),
-		LastModified: obj.LastModified,
+		Xmlns: xmlns, ETag: fmt.Sprintf("%q", obj.ETag), LastModified: obj.LastModified,
 	})
+}
+
+// parseCopySource splits an x-amz-copy-source header into its source bucket,
+// key, and optional versionId. A leading slash is tolerated and the path is
+// URL-decoded, per the S3 contract; a "?versionId=<id>" suffix selects a
+// specific source version.
+func parseCopySource(header string) (bucket, key, versionID string) {
+	header = strings.TrimPrefix(header, "/")
+
+	if i := strings.IndexByte(header, '?'); i >= 0 {
+		if q, err := url.ParseQuery(header[i+1:]); err == nil {
+			versionID = q.Get("versionId")
+		}
+
+		header = header[:i]
+	}
+
+	if decoded, err := url.PathUnescape(header); err == nil {
+		header = decoded
+	}
+
+	bucket, key = parsePath(header)
+
+	return bucket, key, versionID
+}
+
+// applyCopyConditions maps the x-amz-copy-source-if-* request headers onto the
+// copy request's preconditions.
+func applyCopyConditions(req *driver.CopyObjectRequest, hdr http.Header) {
+	req.IfMatch = hdr.Get("X-Amz-Copy-Source-If-Match")
+	req.IfNoneMatch = hdr.Get("X-Amz-Copy-Source-If-None-Match")
+
+	if v := hdr.Get("X-Amz-Copy-Source-If-Modified-Since"); v != "" {
+		if t, err := http.ParseTime(v); err == nil {
+			req.IfModifiedSince = t
+		}
+	}
+
+	if v := hdr.Get("X-Amz-Copy-Source-If-Unmodified-Since"); v != "" {
+		if t, err := http.ParseTime(v); err == nil {
+			req.IfUnmodifiedSince = t
+		}
+	}
+}
+
+// writeCopyErr maps a copy driver error: a failed copy-source precondition is
+// 412 PreconditionFailed; everything else follows the standard mapping.
+func writeCopyErr(w http.ResponseWriter, err error) {
+	if cerrors.IsFailedPrecondition(err) {
+		writeError(w, http.StatusPreconditionFailed, "PreconditionFailed",
+			"At least one of the preconditions you specified did not hold.")
+		return
+	}
+
+	writeErr(w, err)
+}
+
+// uploadPartCopy implements UploadPartCopy: PUT a part whose bytes are copied
+// from an existing object (optionally a byte range of it), returning a
+// <CopyPartResult> with the new part's ETag.
+func (h *Handler) uploadPartCopy(w http.ResponseWriter, r *http.Request, bucket, key, uploadID string) {
+	partNumber, ok := parsePartNumber(r.URL.Query())
+	if !ok {
+		writeError(w, http.StatusBadRequest, "InvalidArgument",
+			"Part number must be an integer between 1 and 10000, inclusive")
+		return
+	}
+
+	srcBucket, srcKey, srcVersionID := parseCopySource(r.Header.Get("X-Amz-Copy-Source"))
+	if srcBucket == "" || srcKey == "" {
+		writeError(w, http.StatusBadRequest, "InvalidArgument", "invalid copy source")
+		return
+	}
+
+	obj, err := h.copySourceObject(r.Context(), srcBucket, srcKey, srcVersionID)
+	if err != nil {
+		writeCopyErr(w, err)
+		return
+	}
+
+	data, ok := sliceCopySourceRange(r.Header.Get("X-Amz-Copy-Source-Range"), obj.Data)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "InvalidArgument",
+			"The x-amz-copy-source-range value must be of the form bytes=first-last")
+		return
+	}
+
+	part, err := h.bucket.UploadPart(r.Context(), bucket, key, uploadID, partNumber, data)
+	if err != nil {
+		writeMultipartErr(w, err)
+		return
+	}
+
+	if obj.Info.VersionID != "" {
+		w.Header().Set("X-Amz-Copy-Source-Version-Id", obj.Info.VersionID)
+	}
+
+	wire.WriteXML(w, http.StatusOK, copyPartResult{
+		Xmlns: xmlns, ETag: fmt.Sprintf("%q", part.ETag), LastModified: obj.Info.LastModified,
+	})
+}
+
+// parsePartNumber reads and validates the partNumber query parameter (1–10000).
+func parsePartNumber(q url.Values) (int, bool) {
+	n, err := strconv.Atoi(q.Get("partNumber"))
+	if err != nil || n < 1 || n > maxUploadPartNumber {
+		return 0, false
+	}
+
+	return n, true
+}
+
+// sliceCopySourceRange returns the bytes an UploadPartCopy should copy: the full
+// object when no range header is present, otherwise the requested inclusive
+// byte range. ok is false when the range header is malformed or out of bounds.
+func sliceCopySourceRange(header string, data []byte) ([]byte, bool) {
+	if header == "" {
+		return data, true
+	}
+
+	start, end, ok := copySourceRange(header, int64(len(data)))
+	if !ok {
+		return nil, false
+	}
+
+	return data[start : end+1], true
+}
+
+// copySourceObject fetches the source object for a part copy: a specific
+// version when requested (a delete-marker version is an InvalidArgument), else
+// the current object.
+func (h *Handler) copySourceObject(ctx context.Context, srcBucket, srcKey, srcVersionID string) (*driver.Object, error) {
+	if srcVersionID != "" && h.versioned != nil {
+		obj, err := h.versioned.GetObjectVersion(ctx, srcBucket, srcKey, srcVersionID)
+		if errors.Is(err, driver.ErrDeleteMarker) {
+			return nil, cerrors.New(cerrors.InvalidArgument, "cannot specify a delete marker as a copy source version")
+		}
+
+		return obj, err
+	}
+
+	return h.bucket.GetObject(ctx, srcBucket, srcKey)
+}
+
+// copySourceRange parses an x-amz-copy-source-range header ("bytes=first-last",
+// zero-based inclusive). Both offsets are required and must fall within the
+// source; a malformed or out-of-bounds range returns ok=false.
+func copySourceRange(header string, total int64) (start, end int64, ok bool) {
+	const prefix = "bytes="
+	if !strings.HasPrefix(header, prefix) {
+		return 0, 0, false
+	}
+
+	spec := strings.TrimPrefix(header, prefix)
+
+	dash := strings.IndexByte(spec, '-')
+	if dash <= 0 || dash == len(spec)-1 {
+		return 0, 0, false
+	}
+
+	start, err1 := strconv.ParseInt(spec[:dash], 10, 64)
+	end, err2 := strconv.ParseInt(spec[dash+1:], 10, 64)
+
+	if err1 != nil || err2 != nil || start < 0 || end < start || end >= total {
+		return 0, 0, false
+	}
+
+	return start, end, true
 }
 
 // multipartUploadOp dispatches operations on an in-progress multipart upload
@@ -909,7 +1205,11 @@ func (h *Handler) copyObject(w http.ResponseWriter, r *http.Request, bucket, key
 func (h *Handler) multipartUploadOp(w http.ResponseWriter, r *http.Request, bucket, key, uploadID string) {
 	switch r.Method {
 	case http.MethodPut:
-		h.uploadPart(w, r, bucket, key, uploadID)
+		if r.Header.Get("X-Amz-Copy-Source") != "" {
+			h.uploadPartCopy(w, r, bucket, key, uploadID)
+		} else {
+			h.uploadPart(w, r, bucket, key, uploadID)
+		}
 	case http.MethodPost:
 		h.completeMultipartUpload(w, r, bucket, key, uploadID)
 	case http.MethodDelete:
@@ -1277,6 +1577,28 @@ func extractMetadata(h http.Header) map[string]string {
 	}
 
 	return meta
+}
+
+// writeDeleteMarker answers a version-addressed GET/HEAD of a delete marker
+// with 405 MethodNotAllowed and x-amz-delete-marker: true, as S3 does — a
+// delete marker has no retrievable content. It returns false when err is not a
+// delete marker, leaving the caller to handle it normally.
+func writeDeleteMarker(w http.ResponseWriter, err error, versionID string) bool {
+	if !errors.Is(err, driver.ErrDeleteMarker) {
+		return false
+	}
+
+	w.Header().Set("X-Amz-Delete-Marker", "true")
+	w.Header().Set("Allow", "DELETE")
+
+	if versionID != "" {
+		w.Header().Set("X-Amz-Version-Id", versionID)
+	}
+
+	writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed",
+		"The specified method is not allowed against this resource.")
+
+	return true
 }
 
 // writeError writes an S3-format XML error response.

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -970,6 +970,7 @@ func (h *Handler) copyObject(w http.ResponseWriter, r *http.Request, bucket, key
 		writeError(w, http.StatusBadRequest, "InvalidRequest",
 			"This copy request is illegal because it is trying to copy an object to itself without "+
 				"changing the object's metadata, storage class, website redirect location or encryption attributes.")
+
 		return
 	}
 

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire"
@@ -424,6 +425,23 @@ func (h *Handler) bucketRegion(ctx context.Context, bucket string) string {
 	}
 
 	return ""
+}
+
+// bucketExists reports whether a bucket with the given name exists. Used by
+// bucket-scoped sub-resources that must 404 NoSuchBucket for an absent bucket.
+func (h *Handler) bucketExists(ctx context.Context, bucket string) bool {
+	buckets, err := h.bucket.ListBuckets(ctx)
+	if err != nil {
+		return false
+	}
+
+	for _, b := range buckets {
+		if b.Name == bucket {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (h *Handler) deleteBucket(w http.ResponseWriter, r *http.Request, bucket string) {
@@ -1076,6 +1094,61 @@ func applyCopyConditions(req *driver.CopyObjectRequest, hdr http.Header) {
 	}
 }
 
+// evalCopySourceConditions evaluates the x-amz-copy-source-if-* request headers
+// against a resolved source object, returning a FailedPrecondition error (mapped
+// to 412 by writeCopyErr) when a precondition is not satisfied. UploadPartCopy
+// honors the same four copy-source conditions — and the same documented
+// combined-precedence override, where a true if-match overrides a false
+// if-unmodified-since — as CopyObject.
+func evalCopySourceConditions(hdr http.Header, etag, lastModified string) error {
+	etag = strings.Trim(etag, `"`)
+	ifMatch := hdr.Get("X-Amz-Copy-Source-If-Match")
+	ifNoneMatch := hdr.Get("X-Amz-Copy-Source-If-None-Match")
+
+	if ifMatch != "" && !copySourceETagMatches(ifMatch, etag) {
+		return cerrors.New(cerrors.FailedPrecondition, "x-amz-copy-source-if-match precondition failed")
+	}
+
+	if ifNoneMatch != "" && copySourceETagMatches(ifNoneMatch, etag) {
+		return cerrors.New(cerrors.FailedPrecondition, "x-amz-copy-source-if-none-match precondition failed")
+	}
+
+	skipUnmodified := ifMatch != "" && copySourceETagMatches(ifMatch, etag)
+
+	return evalCopySourceTimeConditions(hdr, lastModified, skipUnmodified)
+}
+
+// evalCopySourceTimeConditions evaluates the two time-based copy-source headers.
+func evalCopySourceTimeConditions(hdr http.Header, lastModified string, skipUnmodified bool) error {
+	mod, err := time.Parse(time.RFC3339, lastModified)
+	if err != nil {
+		return nil // an unparseable timestamp can't be evaluated; don't block the copy
+	}
+
+	if v := hdr.Get("X-Amz-Copy-Source-If-Unmodified-Since"); v != "" && !skipUnmodified {
+		if t, perr := http.ParseTime(v); perr == nil && mod.After(t) {
+			return cerrors.New(cerrors.FailedPrecondition, "x-amz-copy-source-if-unmodified-since precondition failed")
+		}
+	}
+
+	if v := hdr.Get("X-Amz-Copy-Source-If-Modified-Since"); v != "" {
+		if t, perr := http.ParseTime(v); perr == nil && !mod.After(t) {
+			return cerrors.New(cerrors.FailedPrecondition, "x-amz-copy-source-if-modified-since precondition failed")
+		}
+	}
+
+	return nil
+}
+
+// copySourceETagMatches reports whether a copy-source-if-[none-]match header
+// value matches the source ETag: "*" matches any object; otherwise a
+// quote-insensitive, case-insensitive comparison.
+func copySourceETagMatches(header, etag string) bool {
+	header = strings.Trim(header, `"`)
+
+	return header == "*" || strings.EqualFold(header, etag)
+}
+
 // writeCopyErr maps a copy driver error: a failed copy-source precondition is
 // 412 PreconditionFailed; everything else follows the standard mapping.
 func writeCopyErr(w http.ResponseWriter, err error) {
@@ -1108,6 +1181,11 @@ func (h *Handler) uploadPartCopy(w http.ResponseWriter, r *http.Request, bucket,
 	obj, err := h.copySourceObject(r.Context(), srcBucket, srcKey, srcVersionID)
 	if err != nil {
 		writeCopyErr(w, err)
+		return
+	}
+
+	if condErr := evalCopySourceConditions(r.Header, obj.Info.ETag, obj.Info.LastModified); condErr != nil {
+		writeCopyErr(w, condErr)
 		return
 	}
 
@@ -1592,6 +1670,12 @@ func writeDeleteMarker(w http.ResponseWriter, err error, versionID string) bool 
 
 	w.Header().Set("X-Amz-Delete-Marker", "true")
 	w.Header().Set("Allow", "DELETE")
+
+	// S3 returns the delete marker's Last-Modified timestamp in the 405 response.
+	var dm *driver.DeleteMarkerError
+	if errors.As(err, &dm) && dm.LastModified != "" {
+		w.Header().Set("Last-Modified", wire.ToHTTPDate(dm.LastModified))
+	}
 
 	if versionID != "" {
 		w.Header().Set("X-Amz-Version-Id", versionID)

--- a/server/aws/s3/xml.go
+++ b/server/aws/s3/xml.go
@@ -58,6 +58,21 @@ type copyObjectResult struct {
 	LastModified string   `xml:"LastModified"`
 }
 
+// copyPartResult is the XML response for UploadPartCopy.
+type copyPartResult struct {
+	XMLName      xml.Name `xml:"CopyPartResult"`
+	Xmlns        string   `xml:"xmlns,attr"`
+	ETag         string   `xml:"ETag"`
+	LastModified string   `xml:"LastModified"`
+}
+
+// createBucketConfiguration is the XML request body for CreateBucket, carrying
+// the region in LocationConstraint (empty/absent denotes us-east-1).
+type createBucketConfiguration struct {
+	XMLName            xml.Name `xml:"CreateBucketConfiguration"`
+	LocationConstraint string   `xml:"LocationConstraint"`
+}
+
 // initiateMultipartUploadResult is the XML response for CreateMultipartUpload.
 type initiateMultipartUploadResult struct {
 	XMLName  xml.Name `xml:"InitiateMultipartUploadResult"`

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -15,6 +15,19 @@ import (
 // response instead of NoSuchKey.
 var ErrDeleteMarker = cerrors.New(cerrors.NotFound, "the specified version is a delete marker")
 
+// DeleteMarkerError carries the delete marker's LastModified timestamp alongside
+// the ErrDeleteMarker sentinel. S3 returns that timestamp in the Last-Modified
+// header of the 405 response for a version-addressed GET/HEAD of a delete marker,
+// so providers return this (it unwraps to ErrDeleteMarker, so errors.Is still
+// matches) to let the wire layer emit the header.
+type DeleteMarkerError struct {
+	LastModified string
+}
+
+func (*DeleteMarkerError) Error() string { return ErrDeleteMarker.Error() }
+
+func (*DeleteMarkerError) Unwrap() error { return ErrDeleteMarker }
+
 // BucketInfo describes a storage bucket.
 type BucketInfo struct {
 	Name      string

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -4,7 +4,16 @@ package driver
 import (
 	"context"
 	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 )
+
+// ErrDeleteMarker is returned by GetObjectVersion/HeadObjectVersion when the
+// requested version is a delete marker. S3 answers a version-addressed GET/HEAD
+// of a delete marker with 405 Method Not Allowed and x-amz-delete-marker: true
+// (not 404), so the wire layer matches this with errors.Is to emit that exact
+// response instead of NoSuchKey.
+var ErrDeleteMarker = cerrors.New(cerrors.NotFound, "the specified version is a delete marker")
 
 // BucketInfo describes a storage bucket.
 type BucketInfo struct {
@@ -139,6 +148,58 @@ type RawBucketConfig interface {
 type CopySource struct {
 	Bucket string
 	Key    string
+}
+
+// CopyObjectRequest describes an S3 server-side copy with the semantics the
+// basic CopyObject cannot express: a versioned source, a metadata directive
+// (COPY vs REPLACE), and copy-source preconditions. Carried by the optional
+// ObjectCopier capability.
+type CopyObjectRequest struct {
+	DstBucket string
+	DstKey    string
+	Src       CopySource
+	// SrcVersionID selects a specific source version ("" = current version).
+	SrcVersionID string
+	// ReplaceMetadata is true for x-amz-metadata-directive: REPLACE — the
+	// destination takes Metadata and ContentType from the request instead of
+	// inheriting the source object's.
+	ReplaceMetadata bool
+	Metadata        map[string]string
+	ContentType     string
+	// Copy-source preconditions; a zero value means the header was absent. A
+	// failed precondition must abort the copy with a FailedPrecondition error.
+	IfMatch           string
+	IfNoneMatch       string
+	IfModifiedSince   time.Time
+	IfUnmodifiedSince time.Time
+}
+
+// CopyObjectResult reports the outcome of an ObjectCopier copy.
+type CopyObjectResult struct {
+	ETag         string
+	LastModified string
+	// VersionID is the destination version id ("" when the destination bucket
+	// is unversioned); SourceVersionID is the source version actually copied.
+	VersionID       string
+	SourceVersionID string
+}
+
+// ObjectCopier is an OPTIONAL capability (discovered by type assertion, like
+// VersionedBucket) for a full-fidelity S3 server-side copy: a versioned source,
+// the COPY/REPLACE metadata directive, and copy-source preconditions. A failed
+// precondition is reported as a FailedPrecondition error; a delete-marker source
+// version as an InvalidArgument error. Providers without it fall back to the
+// basic Bucket.CopyObject (current version, COPY directive, no preconditions).
+type ObjectCopier interface {
+	CopyObjectV2(ctx context.Context, req *CopyObjectRequest) (*CopyObjectResult, error)
+}
+
+// RegionalBucket is an OPTIONAL capability a storage provider implements to
+// create a bucket in a caller-specified region (S3
+// CreateBucketConfiguration.LocationConstraint), so GetBucketLocation reports
+// that region back. Providers without it create buckets in their default region.
+type RegionalBucket interface {
+	CreateBucketInRegion(ctx context.Context, name, region string) error
 }
 
 // PresignedURLRequest describes a presigned URL to generate.


### PR DESCRIPTION
## Summary

Fixes a cluster of S3 copy/versioning/location gaps found by the deep real-user audit. All changes are verified with real aws-sdk-go-v2 clients against an httptest server over the S3 wire handler, plus provider unit tests.

### Fixed

1. **UploadPartCopy** (`PUT /{bucket}/{key}?partNumber=N&uploadId=X` + `x-amz-copy-source`) — copies bytes from an existing object into a multipart part and returns `200` with a `<CopyPartResult>` (ETag + LastModified). Honors `x-amz-copy-source-range` (used by the SDK/TransferManager large-object copier) and a versioned `?versionId` source, echoing `x-amz-copy-source-version-id`.
2. **CopyObject `x-amz-metadata-directive: REPLACE`** — replaces the destination's user metadata and Content-Type with the request values; default `COPY` still carries source metadata.
3. **Versioned copy source** — `x-amz-copy-source: bucket/key?versionId=…` copies that specific source version (CopyObject and UploadPartCopy).
4. **Conditional CopyObject** — `x-amz-copy-source-if-match / -if-none-match / -if-modified-since / -if-unmodified-since`; a failed precondition returns `412 PreconditionFailed` and does not perform the copy.
5. **Self-copy with no change** — `COPY` directive onto the same key returns `400 InvalidRequest` with the canonical message.
6. **GET/HEAD of a delete-marker version** — returns `405 MethodNotAllowed` with `x-amz-delete-marker: true` instead of 404.
7. **GetBucketLocation** — returns the region a bucket was created in via `CreateBucketConfiguration.LocationConstraint` (empty for us-east-1).

### Design

- Full-fidelity copy (versioned source, metadata directive, preconditions) is a new **optional `ObjectCopier` driver capability** (type-asserted, like `VersionedBucket`), keeping the shared `CopyObject` intact for other providers; the wire handler falls back to basic copy when it's absent.
- Delete-marker signaling uses a new `driver.ErrDeleteMarker` sentinel matched with `errors.Is`, so the wire layer emits the 405 without changing method signatures.
- Region-at-create is a new optional `RegionalBucket` capability.
- Capability docs regenerated via `go run ./internal/coveragegen`.

### Gates

`go build ./...`, `go vet`, `go test` (providers/aws/s3, server/aws/s3, services/storage, root `cloudemu_test`) all green, including `-race`; `golangci-lint` clean on the changed code.