### PR TITLE
fix(ec2-vpc): VolumeInUse/DHCP-dependency/flow-log-idempotency/peering-notfound + VPC endpoints, placement groups, ENI attach, IMDS, AMI copy/share

### DIFF
--- a/docs/coverage/aws/ec2.md
+++ b/docs/coverage/aws/ec2.md
@@ -57,6 +57,23 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
+### ImageAttributeModifier
+
+ImageAttributeModifier is an optional AWS-only capability for the EC2 AMI
+
+| Operation | Description |
+| --- | --- |
+| `DescribeImageLaunchPermissions` |  |
+| `ModifyImageAttribute` |  |
+
+### ImageCopier
+
+ImageCopier is an optional AWS-only capability for EC2 CopyImage (aws_ami_copy).
+
+| Operation | Description |
+| --- | --- |
+| `CopyImage` |  |
+
 ### ImageRegistrar
 
 ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
@@ -64,6 +81,14 @@ ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
 | Operation | Description |
 | --- | --- |
 | `RegisterImage` |  |
+
+### InstanceMetadataModifier
+
+InstanceMetadataModifier is an optional AWS-only capability for
+
+| Operation | Description |
+| --- | --- |
+| `ModifyInstanceMetadataOptions` |  |
 
 ### KeyPairImporter
 
@@ -90,6 +115,25 @@ LaunchTemplateVersioner is an AWS-only optional capability implementing launch
 | `CreateLaunchTemplateVersion` | CreateLaunchTemplateVersion appends a new immutable version to a template. |
 | `DescribeLaunchTemplateVersions` | DescribeLaunchTemplateVersions returns a template's versions (filtered, |
 | `GetLaunchTemplateData` | GetLaunchTemplateData synthesizes launch-template data from a running |
+
+### PlacementGroups
+
+PlacementGroups is an optional AWS-only capability for EC2 placement groups
+
+| Operation | Description |
+| --- | --- |
+| `CreatePlacementGroup` |  |
+| `DeletePlacementGroup` |  |
+| `DescribePlacementGroups` |  |
+
+### SnapshotAttributeModifier
+
+SnapshotAttributeModifier is an optional AWS-only capability for the EC2
+
+| Operation | Description |
+| --- | --- |
+| `DescribeSnapshotVolumePermissions` |  |
+| `ModifySnapshotAttribute` |  |
 
 ### SnapshotCopier
 

--- a/docs/coverage/aws/vpc.md
+++ b/docs/coverage/aws/vpc.md
@@ -281,6 +281,14 @@ NetworkInsights is an OPTIONAL AWS capability (type-asserted). It covers both
 | `StartNetworkInsightsAccessScopeAnalysis` |  |
 | `StartNetworkInsightsAnalysis` |  |
 
+### NetworkInterfaceAttacher
+
+NetworkInterfaceAttacher is the AWS-specific ENI attach surface
+
+| Operation | Description |
+| --- | --- |
+| `AttachNetworkInterface` |  |
+
 ### NetworkInterfaceCreator
 
 NetworkInterfaceCreator is the AWS-specific ENI-creation surface. It's kept

--- a/docs/coverage/azure/virtualmachines.md
+++ b/docs/coverage/azure/virtualmachines.md
@@ -57,6 +57,23 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
+### ImageAttributeModifier
+
+ImageAttributeModifier is an optional AWS-only capability for the EC2 AMI
+
+| Operation | Description |
+| --- | --- |
+| `DescribeImageLaunchPermissions` |  |
+| `ModifyImageAttribute` |  |
+
+### ImageCopier
+
+ImageCopier is an optional AWS-only capability for EC2 CopyImage (aws_ami_copy).
+
+| Operation | Description |
+| --- | --- |
+| `CopyImage` |  |
+
 ### ImageRegistrar
 
 ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
@@ -64,6 +81,14 @@ ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
 | Operation | Description |
 | --- | --- |
 | `RegisterImage` |  |
+
+### InstanceMetadataModifier
+
+InstanceMetadataModifier is an optional AWS-only capability for
+
+| Operation | Description |
+| --- | --- |
+| `ModifyInstanceMetadataOptions` |  |
 
 ### KeyPairImporter
 
@@ -90,6 +115,25 @@ LaunchTemplateVersioner is an AWS-only optional capability implementing launch
 | `CreateLaunchTemplateVersion` | CreateLaunchTemplateVersion appends a new immutable version to a template. |
 | `DescribeLaunchTemplateVersions` | DescribeLaunchTemplateVersions returns a template's versions (filtered, |
 | `GetLaunchTemplateData` | GetLaunchTemplateData synthesizes launch-template data from a running |
+
+### PlacementGroups
+
+PlacementGroups is an optional AWS-only capability for EC2 placement groups
+
+| Operation | Description |
+| --- | --- |
+| `CreatePlacementGroup` |  |
+| `DeletePlacementGroup` |  |
+| `DescribePlacementGroups` |  |
+
+### SnapshotAttributeModifier
+
+SnapshotAttributeModifier is an optional AWS-only capability for the EC2
+
+| Operation | Description |
+| --- | --- |
+| `DescribeSnapshotVolumePermissions` |  |
+| `ModifySnapshotAttribute` |  |
 
 ### SnapshotCopier
 

--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -281,6 +281,14 @@ NetworkInsights is an OPTIONAL AWS capability (type-asserted). It covers both
 | `StartNetworkInsightsAccessScopeAnalysis` |  |
 | `StartNetworkInsightsAnalysis` |  |
 
+### NetworkInterfaceAttacher
+
+NetworkInterfaceAttacher is the AWS-specific ENI attach surface
+
+| Operation | Description |
+| --- | --- |
+| `AttachNetworkInterface` |  |
+
 ### NetworkInterfaceCreator
 
 NetworkInterfaceCreator is the AWS-specific ENI-creation surface. It's kept

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -1967,11 +1967,41 @@
         ]
       },
       {
+        "name": "ImageAttributeModifier",
+        "doc": "ImageAttributeModifier is an optional AWS-only capability for the EC2 AMI",
+        "operations": [
+          {
+            "name": "DescribeImageLaunchPermissions"
+          },
+          {
+            "name": "ModifyImageAttribute"
+          }
+        ]
+      },
+      {
+        "name": "ImageCopier",
+        "doc": "ImageCopier is an optional AWS-only capability for EC2 CopyImage (aws_ami_copy).",
+        "operations": [
+          {
+            "name": "CopyImage"
+          }
+        ]
+      },
+      {
         "name": "ImageRegistrar",
         "doc": "ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage",
         "operations": [
           {
             "name": "RegisterImage"
+          }
+        ]
+      },
+      {
+        "name": "InstanceMetadataModifier",
+        "doc": "InstanceMetadataModifier is an optional AWS-only capability for",
+        "operations": [
+          {
+            "name": "ModifyInstanceMetadataOptions"
           }
         ]
       },
@@ -2008,6 +2038,33 @@
           {
             "name": "GetLaunchTemplateData",
             "doc": "GetLaunchTemplateData synthesizes launch-template data from a running"
+          }
+        ]
+      },
+      {
+        "name": "PlacementGroups",
+        "doc": "PlacementGroups is an optional AWS-only capability for EC2 placement groups",
+        "operations": [
+          {
+            "name": "CreatePlacementGroup"
+          },
+          {
+            "name": "DeletePlacementGroup"
+          },
+          {
+            "name": "DescribePlacementGroups"
+          }
+        ]
+      },
+      {
+        "name": "SnapshotAttributeModifier",
+        "doc": "SnapshotAttributeModifier is an optional AWS-only capability for the EC2",
+        "operations": [
+          {
+            "name": "DescribeSnapshotVolumePermissions"
+          },
+          {
+            "name": "ModifySnapshotAttribute"
           }
         ]
       },
@@ -6570,6 +6627,15 @@
           },
           {
             "name": "StartNetworkInsightsAnalysis"
+          }
+        ]
+      },
+      {
+        "name": "NetworkInterfaceAttacher",
+        "doc": "NetworkInterfaceAttacher is the AWS-specific ENI attach surface",
+        "operations": [
+          {
+            "name": "AttachNetworkInterface"
           }
         ]
       },

--- a/docs/coverage/gcp/gce.md
+++ b/docs/coverage/gcp/gce.md
@@ -57,6 +57,23 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
+### ImageAttributeModifier
+
+ImageAttributeModifier is an optional AWS-only capability for the EC2 AMI
+
+| Operation | Description |
+| --- | --- |
+| `DescribeImageLaunchPermissions` |  |
+| `ModifyImageAttribute` |  |
+
+### ImageCopier
+
+ImageCopier is an optional AWS-only capability for EC2 CopyImage (aws_ami_copy).
+
+| Operation | Description |
+| --- | --- |
+| `CopyImage` |  |
+
 ### ImageRegistrar
 
 ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
@@ -64,6 +81,14 @@ ImageRegistrar is an optional AWS-only capability for EC2 RegisterImage
 | Operation | Description |
 | --- | --- |
 | `RegisterImage` |  |
+
+### InstanceMetadataModifier
+
+InstanceMetadataModifier is an optional AWS-only capability for
+
+| Operation | Description |
+| --- | --- |
+| `ModifyInstanceMetadataOptions` |  |
 
 ### KeyPairImporter
 
@@ -90,6 +115,25 @@ LaunchTemplateVersioner is an AWS-only optional capability implementing launch
 | `CreateLaunchTemplateVersion` | CreateLaunchTemplateVersion appends a new immutable version to a template. |
 | `DescribeLaunchTemplateVersions` | DescribeLaunchTemplateVersions returns a template's versions (filtered, |
 | `GetLaunchTemplateData` | GetLaunchTemplateData synthesizes launch-template data from a running |
+
+### PlacementGroups
+
+PlacementGroups is an optional AWS-only capability for EC2 placement groups
+
+| Operation | Description |
+| --- | --- |
+| `CreatePlacementGroup` |  |
+| `DeletePlacementGroup` |  |
+| `DescribePlacementGroups` |  |
+
+### SnapshotAttributeModifier
+
+SnapshotAttributeModifier is an optional AWS-only capability for the EC2
+
+| Operation | Description |
+| --- | --- |
+| `DescribeSnapshotVolumePermissions` |  |
+| `ModifySnapshotAttribute` |  |
 
 ### SnapshotCopier
 

--- a/docs/coverage/gcp/vpc.md
+++ b/docs/coverage/gcp/vpc.md
@@ -281,6 +281,14 @@ NetworkInsights is an OPTIONAL AWS capability (type-asserted). It covers both
 | `StartNetworkInsightsAccessScopeAnalysis` |  |
 | `StartNetworkInsightsAnalysis` |  |
 
+### NetworkInterfaceAttacher
+
+NetworkInterfaceAttacher is the AWS-specific ENI attach surface
+
+| Operation | Description |
+| --- | --- |
+| `AttachNetworkInterface` |  |
+
 ### NetworkInterfaceCreator
 
 NetworkInterfaceCreator is the AWS-specific ENI-creation surface. It's kept

--- a/docs/coverage/oci/vcn.md
+++ b/docs/coverage/oci/vcn.md
@@ -281,6 +281,14 @@ NetworkInsights is an OPTIONAL AWS capability (type-asserted). It covers both
 | `StartNetworkInsightsAccessScopeAnalysis` |  |
 | `StartNetworkInsightsAnalysis` |  |
 
+### NetworkInterfaceAttacher
+
+NetworkInterfaceAttacher is the AWS-specific ENI attach surface
+
+| Operation | Description |
+| --- | --- |
+| `AttachNetworkInterface` |  |
+
 ### NetworkInterfaceCreator
 
 NetworkInterfaceCreator is the AWS-specific ENI-creation surface. It's kept

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -51,6 +51,10 @@ const (
 	stateCreating  = "creating"
 	stateInUse     = "in-use"
 
+	// operationTypeRemove is the ModifySnapshotAttribute / ModifyImageAttribute
+	// OperationType that revokes (rather than grants) a permission.
+	operationTypeRemove = "remove"
+
 	// visibilityHidden and visibilityVisible are the account-level
 	// managed-resource-visibility settings.
 	visibilityHidden  = "hidden"
@@ -175,6 +179,9 @@ type instanceData struct {
 	// monitoring is the CloudWatch detailed-monitoring state
 	// ("disabled"/"enabled"); defaults to "disabled" at launch.
 	monitoring string
+	// metadataOptions is the instance's IMDS configuration, defaulted at launch
+	// and changed by ModifyInstanceMetadataOptions.
+	metadataOptions driver.MetadataOptions
 	// settle overlays a post-launch "pending" window over the stored (running)
 	// State on the Describe surface when AsyncSettle is enabled; zero-value
 	// (default) reports the stored State immediately.
@@ -207,18 +214,22 @@ type Mock struct {
 	// State on the Describe surface, keyed by volume id. It lives beside volumes
 	// rather than on the shared driver.VolumeInfo struct (which azure/gcp also
 	// use), keeping settling AWS-internal. Empty/absent = report State directly.
-	volSettle   *memstore.Store[settle.Window]
-	snapshots   *memstore.Store[*driver.SnapshotInfo]
-	images      *memstore.Store[*driver.ImageInfo]
-	keyPairs    *memstore.Store[*driver.KeyPairInfo]
-	sm          *statemachine.Machine
-	opts        *config.Options
-	ipCounter   atomic.Int64
-	volCounter  atomic.Int64
-	snapCounter atomic.Int64
-	amiCounter  atomic.Int64
-	keyCounter  atomic.Int64
-	monitoring  mondriver.Monitoring
+	volSettle *memstore.Store[settle.Window]
+	snapshots *memstore.Store[*driver.SnapshotInfo]
+	images    *memstore.Store[*driver.ImageInfo]
+	keyPairs  *memstore.Store[*driver.KeyPairInfo]
+	// placementGroups holds EC2 placement groups keyed by group name. Placement
+	// groups are AWS-specific, so this store backs the PlacementGroups capability.
+	placementGroups *memstore.Store[*driver.PlacementGroup]
+	pgCounter       atomic.Int64
+	sm              *statemachine.Machine
+	opts            *config.Options
+	ipCounter       atomic.Int64
+	volCounter      atomic.Int64
+	snapCounter     atomic.Int64
+	amiCounter      atomic.Int64
+	keyCounter      atomic.Int64
+	monitoring      mondriver.Monitoring
 	// subnetResolver derives an instance's VPC from its subnet at launch, so
 	// instances created with a --subnet-id carry the VPCID that connectivity
 	// analysis and VPC teardown depend on. nil until wired by the provider.
@@ -314,6 +325,7 @@ func New(opts *config.Options) *Mock {
 		snapshots:        memstore.New[*driver.SnapshotInfo](),
 		images:           memstore.New[*driver.ImageInfo](),
 		keyPairs:         memstore.New[*driver.KeyPairInfo](),
+		placementGroups:  memstore.New[*driver.PlacementGroup](),
 		sm:               statemachine.New(compute.VMTransitions()),
 		opts:             opts,
 
@@ -355,8 +367,67 @@ func toInstance(d *instanceData, hidden bool, now time.Time) driver.Instance {
 		PrivateIP: d.PrivateIP, PublicIP: d.PublicIP, SubnetID: d.SubnetID, VPCID: d.VPCID,
 		SecurityGroups: sg, Tags: tags, LaunchTime: d.LaunchTime,
 		ReservationID: d.reservationID, KeyName: d.keyName, Monitoring: d.monitoring,
-		Operator: operator,
+		Operator: operator, MetadataOptions: d.metadataOptions,
 	}
+}
+
+// defaultMetadataOptions is the IMDS configuration a freshly launched instance
+// carries, matching real EC2 defaults (IMDSv1+v2 optional, one hop, enabled).
+func defaultMetadataOptions() driver.MetadataOptions {
+	return driver.MetadataOptions{
+		State:                   "applied",
+		HTTPTokens:              "optional",
+		HTTPPutResponseHopLimit: 1,
+		HTTPEndpoint:            "enabled",
+		HTTPProtocolIPv6:        "disabled",
+		InstanceMetadataTags:    "disabled",
+	}
+}
+
+// ModifyInstanceMetadataOptions updates an instance's IMDS settings
+// (ec2:ModifyInstanceMetadataOptions). A zero-value field leaves that setting
+// unchanged; it returns the resulting options.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) ModifyInstanceMetadataOptions(
+	_ context.Context, instanceID string, update driver.MetadataOptions,
+) (*driver.MetadataOptions, error) {
+	inst, ok := m.instances.Get(instanceID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
+	}
+
+	opts := inst.metadataOptions
+	if opts.State == "" {
+		opts = defaultMetadataOptions()
+	}
+
+	if update.HTTPTokens != "" {
+		opts.HTTPTokens = update.HTTPTokens
+	}
+
+	if update.HTTPPutResponseHopLimit != 0 {
+		opts.HTTPPutResponseHopLimit = update.HTTPPutResponseHopLimit
+	}
+
+	if update.HTTPEndpoint != "" {
+		opts.HTTPEndpoint = update.HTTPEndpoint
+	}
+
+	if update.HTTPProtocolIPv6 != "" {
+		opts.HTTPProtocolIPv6 = update.HTTPProtocolIPv6
+	}
+
+	if update.InstanceMetadataTags != "" {
+		opts.InstanceMetadataTags = update.InstanceMetadataTags
+	}
+
+	opts.State = "applied"
+	inst.metadataOptions = opts
+
+	result := opts
+
+	return &result, nil
 }
 
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
@@ -417,6 +488,7 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 			keyName:         cfg.KeyName,
 			userData:        cfg.UserData,
 			monitoring:      monitoringDisabled,
+			metadataOptions: defaultMetadataOptions(),
 		}
 
 		if cfg.Managed {
@@ -1093,7 +1165,8 @@ func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device stri
 	}
 
 	if vol.State == stateInUse {
-		return cerrors.Newf(cerrors.FailedPrecondition, "volume %q already attached", volumeID)
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"VolumeInUse: volume %q is attached to instance %q", volumeID, vol.AttachedTo)
 	}
 
 	if _, ok := m.instances.Get(instanceID); !ok {
@@ -1209,6 +1282,85 @@ func (m *Mock) DescribeSnapshots(_ context.Context, ids []string) ([]driver.Snap
 	return describeResources(m.snapshots, ids), nil
 }
 
+// ModifySnapshotAttribute adds or removes createVolumePermission grants on a
+// snapshot (EC2 snapshot sharing). The grants persist so
+// DescribeSnapshotVolumePermissions reads them back.
+//
+//nolint:dupl,gocritic // parallel snapshot/image attribute-modify; hugeParam interface signature is fixed
+func (m *Mock) ModifySnapshotAttribute(_ context.Context, input driver.ModifySnapshotAttributeInput) error {
+	snap, ok := m.snapshots.Get(input.SnapshotID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "snapshot %q not found", input.SnapshotID)
+	}
+
+	grants := make([]driver.SnapshotCreateVolumePermission, 0, len(input.Groups)+len(input.UserIDs))
+	for _, g := range input.Groups {
+		grants = append(grants, driver.SnapshotCreateVolumePermission{Group: g})
+	}
+
+	for _, u := range input.UserIDs {
+		grants = append(grants, driver.SnapshotCreateVolumePermission{UserID: u})
+	}
+
+	if input.OperationType == operationTypeRemove {
+		snap.CreateVolumePermissions = removePermissions(snap.CreateVolumePermissions, grants)
+		return nil
+	}
+
+	snap.CreateVolumePermissions = addPermissions(snap.CreateVolumePermissions, grants)
+
+	return nil
+}
+
+// DescribeSnapshotVolumePermissions returns the snapshot's persisted
+// createVolumePermission grants.
+func (m *Mock) DescribeSnapshotVolumePermissions(
+	_ context.Context, snapshotID string,
+) ([]driver.SnapshotCreateVolumePermission, error) {
+	snap, ok := m.snapshots.Get(snapshotID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "snapshot %q not found", snapshotID)
+	}
+
+	return append([]driver.SnapshotCreateVolumePermission(nil), snap.CreateVolumePermissions...), nil
+}
+
+// addPermissions returns cur with each grant in add that it does not already
+// hold appended. It is shared by snapshot createVolumePermission and image
+// launchPermission (both comparable grant structs).
+func addPermissions[T comparable](cur, add []T) []T {
+	for _, g := range add {
+		if !containsPermission(cur, g) {
+			cur = append(cur, g)
+		}
+	}
+
+	return cur
+}
+
+// removePermissions returns cur with every grant present in remove dropped.
+func removePermissions[T comparable](cur, remove []T) []T {
+	out := cur[:0]
+
+	for _, g := range cur {
+		if !containsPermission(remove, g) {
+			out = append(out, g)
+		}
+	}
+
+	return out
+}
+
+func containsPermission[T comparable](set []T, want T) bool {
+	for _, g := range set {
+		if g == want {
+			return true
+		}
+	}
+
+	return false
+}
+
 // CreateImage creates a machine image from an instance.
 func (m *Mock) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.ImageInfo, error) {
 	if _, ok := m.instances.Get(cfg.InstanceID); !ok {
@@ -1281,6 +1433,82 @@ func (m *Mock) DescribeImages(_ context.Context, ids []string) ([]driver.ImageIn
 	}
 
 	return describeResources(m.images, ids), nil
+}
+
+// CopyImage creates a new AMI that is a copy of an existing source AMI
+// (aws_ami_copy). The copy owns a fresh id and (optionally) a new name and
+// description; all other attributes are inherited from the source.
+func (m *Mock) CopyImage(_ context.Context, input driver.CopyImageInput) (*driver.ImageInfo, error) {
+	src, ok := m.images.Get(input.SourceImageID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "image %q not found", input.SourceImageID)
+	}
+
+	id := fmt.Sprintf("ami-%012d", m.amiCounter.Add(1))
+
+	copyImg := *src
+	copyImg.ID = id
+	copyImg.CreatedAt = m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z")
+	copyImg.OwnerID = awsAccountID
+	copyImg.LaunchPermissions = nil
+	copyImg.Tags = copyTags(input.Tags)
+
+	copyImg.BlockDeviceMappings = append([]driver.ImageBlockDeviceMapping(nil), src.BlockDeviceMappings...)
+
+	if input.Name != "" {
+		copyImg.Name = input.Name
+	}
+
+	if input.Description != "" {
+		copyImg.Description = input.Description
+	}
+
+	m.images.Set(id, &copyImg)
+
+	result := copyImg
+
+	return &result, nil
+}
+
+// ModifyImageAttribute adds or removes launchPermission grants on an AMI (AMI
+// sharing). Grants persist so DescribeImageLaunchPermissions reads them back.
+//
+//nolint:dupl,gocritic // parallel snapshot/image attribute-modify; hugeParam interface signature is fixed
+func (m *Mock) ModifyImageAttribute(_ context.Context, input driver.ModifyImageAttributeInput) error {
+	img, ok := m.images.Get(input.ImageID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "image %q not found", input.ImageID)
+	}
+
+	grants := make([]driver.ImageLaunchPermission, 0, len(input.Groups)+len(input.UserIDs))
+	for _, g := range input.Groups {
+		grants = append(grants, driver.ImageLaunchPermission{Group: g})
+	}
+
+	for _, u := range input.UserIDs {
+		grants = append(grants, driver.ImageLaunchPermission{UserID: u})
+	}
+
+	if input.OperationType == operationTypeRemove {
+		img.LaunchPermissions = removePermissions(img.LaunchPermissions, grants)
+		return nil
+	}
+
+	img.LaunchPermissions = addPermissions(img.LaunchPermissions, grants)
+
+	return nil
+}
+
+// DescribeImageLaunchPermissions returns the AMI's persisted launchPermission grants.
+func (m *Mock) DescribeImageLaunchPermissions(
+	_ context.Context, imageID string,
+) ([]driver.ImageLaunchPermission, error) {
+	img, ok := m.images.Get(imageID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "image %q not found", imageID)
+	}
+
+	return append([]driver.ImageLaunchPermission(nil), img.LaunchPermissions...), nil
 }
 
 // CreateKeyPair creates a new key pair.

--- a/providers/aws/ec2/placement_group.go
+++ b/providers/aws/ec2/placement_group.go
@@ -1,0 +1,114 @@
+package ec2
+
+import (
+	"context"
+	"fmt"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+// Placement group strategy constants.
+const (
+	placementStrategyCluster   = "cluster"
+	placementStrategySpread    = "spread"
+	placementStrategyPartition = "partition"
+	defaultPartitionCount      = 2
+)
+
+// CreatePlacementGroup creates an EC2 placement group (aws_placement_group). The
+// name must be unique; a duplicate is AlreadyExists (InvalidPlacementGroup.Duplicate).
+func (m *Mock) CreatePlacementGroup(
+	_ context.Context, cfg driver.PlacementGroupConfig,
+) (*driver.PlacementGroup, error) {
+	if cfg.Name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "placement group name must not be empty")
+	}
+
+	if err := validatePlacementStrategy(cfg.Strategy); err != nil {
+		return nil, err
+	}
+
+	if m.placementGroups.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "placement group %q already exists", cfg.Name)
+	}
+
+	partitionCount := cfg.PartitionCount
+	if cfg.Strategy == placementStrategyPartition && partitionCount == 0 {
+		partitionCount = defaultPartitionCount
+	}
+
+	pg := &driver.PlacementGroup{
+		ID:             fmt.Sprintf("pg-%016x", m.pgCounter.Add(1)),
+		Name:           cfg.Name,
+		Strategy:       cfg.Strategy,
+		State:          "available",
+		PartitionCount: partitionCount,
+		SpreadLevel:    cfg.SpreadLevel,
+		Tags:           copyTags(cfg.Tags),
+	}
+	m.placementGroups.Set(cfg.Name, pg)
+
+	result := *pg
+
+	return &result, nil
+}
+
+// DeletePlacementGroup deletes a placement group by name.
+func (m *Mock) DeletePlacementGroup(_ context.Context, name string) error {
+	if !m.placementGroups.Delete(name) {
+		return cerrors.Newf(cerrors.NotFound, "placement group %q not found", name)
+	}
+
+	return nil
+}
+
+// DescribePlacementGroups returns placement groups matching the given names or
+// group ids, or all groups when both are empty. An explicitly named group that
+// does not exist is NotFound, matching real EC2.
+func (m *Mock) DescribePlacementGroups(
+	_ context.Context, names, ids []string,
+) ([]driver.PlacementGroup, error) {
+	for _, name := range names {
+		if !m.placementGroups.Has(name) {
+			return nil, cerrors.Newf(cerrors.NotFound, "placement group %q not found", name)
+		}
+	}
+
+	idSet := map[string]bool{}
+	for _, id := range ids {
+		idSet[id] = true
+	}
+
+	nameSet := map[string]bool{}
+	for _, name := range names {
+		nameSet[name] = true
+	}
+
+	out := make([]driver.PlacementGroup, 0)
+
+	for _, pg := range m.placementGroups.All() {
+		if len(names) > 0 && !nameSet[pg.Name] {
+			continue
+		}
+
+		if len(ids) > 0 && !idSet[pg.ID] {
+			continue
+		}
+
+		copyPG := *pg
+		copyPG.Tags = copyTags(pg.Tags)
+		out = append(out, copyPG)
+	}
+
+	return out, nil
+}
+
+func validatePlacementStrategy(strategy string) error {
+	switch strategy {
+	case placementStrategyCluster, placementStrategySpread, placementStrategyPartition:
+		return nil
+	default:
+		return cerrors.Newf(cerrors.InvalidArgument, "invalid placement group strategy %q", strategy)
+	}
+}

--- a/providers/aws/ec2/placement_group_test.go
+++ b/providers/aws/ec2/placement_group_test.go
@@ -1,0 +1,118 @@
+package ec2
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+func TestCreatePlacementGroupDuplicate(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cfg := driver.PlacementGroupConfig{Name: "pg", Strategy: "cluster"}
+	if _, err := m.CreatePlacementGroup(ctx, cfg); err != nil {
+		t.Fatalf("CreatePlacementGroup: %v", err)
+	}
+
+	_, err := m.CreatePlacementGroup(ctx, cfg)
+	if !cerrors.IsAlreadyExists(err) {
+		t.Fatalf("duplicate CreatePlacementGroup err = %v, want AlreadyExists", err)
+	}
+}
+
+func TestCreatePlacementGroupInvalidStrategy(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.CreatePlacementGroup(context.Background(),
+		driver.PlacementGroupConfig{Name: "pg", Strategy: "bogus"})
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("invalid strategy err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestDescribePlacementGroupsUnknownNameNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.DescribePlacementGroups(context.Background(), []string{"missing"}, nil)
+	if !cerrors.IsNotFound(err) {
+		t.Fatalf("unknown name err = %v, want NotFound", err)
+	}
+}
+
+func TestDeletePlacementGroupUnknownNotFound(t *testing.T) {
+	m := newTestMock()
+
+	err := m.DeletePlacementGroup(context.Background(), "missing")
+	if !cerrors.IsNotFound(err) {
+		t.Fatalf("delete unknown err = %v, want NotFound", err)
+	}
+}
+
+func TestSnapshotCreateVolumePermissionAddRemove(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10, AvailabilityZone: "us-east-1a"})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+
+	snap, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{VolumeID: vol.ID})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	if err := m.ModifySnapshotAttribute(ctx, driver.ModifySnapshotAttributeInput{
+		SnapshotID: snap.ID, OperationType: "add", Groups: []string{"all"},
+	}); err != nil {
+		t.Fatalf("ModifySnapshotAttribute add: %v", err)
+	}
+
+	perms, err := m.DescribeSnapshotVolumePermissions(ctx, snap.ID)
+	if err != nil {
+		t.Fatalf("DescribeSnapshotVolumePermissions: %v", err)
+	}
+	if len(perms) != 1 || perms[0].Group != "all" {
+		t.Fatalf("perms after add = %+v, want one group=all", perms)
+	}
+
+	if err := m.ModifySnapshotAttribute(ctx, driver.ModifySnapshotAttributeInput{
+		SnapshotID: snap.ID, OperationType: "remove", Groups: []string{"all"},
+	}); err != nil {
+		t.Fatalf("ModifySnapshotAttribute remove: %v", err)
+	}
+
+	perms, err = m.DescribeSnapshotVolumePermissions(ctx, snap.ID)
+	if err != nil {
+		t.Fatalf("DescribeSnapshotVolumePermissions: %v", err)
+	}
+	if len(perms) != 0 {
+		t.Fatalf("perms after remove = %+v, want empty", perms)
+	}
+}
+
+func TestModifyInstanceMetadataOptionsLeavesUnsetUnchanged(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{ImageID: "ami-1"}, 1)
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	id := insts[0].ID
+
+	// Only change HttpTokens; the hop limit default (1) must survive.
+	opts, err := m.ModifyInstanceMetadataOptions(ctx, id, driver.MetadataOptions{HTTPTokens: "required"})
+	if err != nil {
+		t.Fatalf("ModifyInstanceMetadataOptions: %v", err)
+	}
+	if opts.HTTPTokens != "required" {
+		t.Errorf("HTTPTokens = %q, want required", opts.HTTPTokens)
+	}
+	if opts.HTTPPutResponseHopLimit != 1 {
+		t.Errorf("HTTPPutResponseHopLimit = %d, want 1 (unchanged default)", opts.HTTPPutResponseHopLimit)
+	}
+}

--- a/providers/aws/vpc/dhcp_options.go
+++ b/providers/aws/vpc/dhcp_options.go
@@ -23,18 +23,40 @@ func (m *Mock) CreateDHCPOptions(_ context.Context, cfg driver.DHCPOptionsConfig
 }
 
 // DeleteDHCPOptions deletes a DHCP option set.
+//
+// A set still associated with a VPC cannot be deleted; real EC2 answers
+// DependencyViolation and the caller must first re-associate the VPC with
+// another set (or the Amazon-provided default).
 func (m *Mock) DeleteDHCPOptions(_ context.Context, id string) error {
-	if !m.dhcpOptions.Delete(id) {
+	if !m.dhcpOptions.Has(id) {
 		return errors.Newf(errors.NotFound, "dhcp options %q not found", id)
 	}
+
+	for _, v := range m.vpcs.All() {
+		if v.DhcpOptionsID == id {
+			return errors.Newf(errors.FailedPrecondition,
+				"DependencyViolation: dhcp options %q is associated with vpc %q", id, v.ID)
+		}
+	}
+
+	m.dhcpOptions.Delete(id)
 
 	return nil
 }
 
 // DescribeDHCPOptions returns DHCP option sets matching ids.
+//
+// An explicitly named dopt- ID that does not exist is NotFound rather than an
+// empty list, matching real EC2 (InvalidDhcpOptionID.NotFound).
 func (m *Mock) DescribeDHCPOptions(_ context.Context, ids []string) ([]driver.DHCPOptions, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+
+	for _, id := range ids {
+		if !m.dhcpOptions.Has(id) {
+			return nil, errors.Newf(errors.NotFound, "dhcp options %q not found", id)
+		}
+	}
 
 	return describeResources(m.dhcpOptions, ids, cloneDHCPOptions), nil
 }

--- a/providers/aws/vpc/dhcp_options_test.go
+++ b/providers/aws/vpc/dhcp_options_test.go
@@ -1,0 +1,95 @@
+package vpc
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func TestDeleteDHCPOptionsAssociatedIsDependencyViolation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	vpc := createTestVPC(m)
+
+	opt, err := m.CreateDHCPOptions(ctx, driver.DHCPOptionsConfig{
+		Configuration: map[string][]string{"domain-name-servers": {"10.0.0.2"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateDHCPOptions: %v", err)
+	}
+
+	if err := m.AssociateDHCPOptions(ctx, opt.ID, vpc.ID); err != nil {
+		t.Fatalf("AssociateDHCPOptions: %v", err)
+	}
+
+	err = m.DeleteDHCPOptions(ctx, opt.ID)
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("delete associated err = %v, want FailedPrecondition", err)
+	}
+
+	// Re-associate to default frees it.
+	if err := m.AssociateDHCPOptions(ctx, "default", vpc.ID); err != nil {
+		t.Fatalf("AssociateDHCPOptions(default): %v", err)
+	}
+	if err := m.DeleteDHCPOptions(ctx, opt.ID); err != nil {
+		t.Fatalf("DeleteDHCPOptions after re-associate: %v", err)
+	}
+}
+
+func TestDescribeDHCPOptionsUnknownNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.DescribeDHCPOptions(context.Background(), []string{"dopt-missing"})
+	if !cerrors.IsNotFound(err) {
+		t.Fatalf("unknown dhcp options err = %v, want NotFound", err)
+	}
+}
+
+func TestDescribePeeringConnectionsUnknownNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.DescribePeeringConnections(context.Background(), []string{"pcx-missing"})
+	if !cerrors.IsNotFound(err) {
+		t.Fatalf("unknown peering err = %v, want NotFound", err)
+	}
+}
+
+func TestAttachNetworkInterfaceRecordsAttachment(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	vpc := createTestVPC(m)
+	subnet, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpc.ID, CIDRBlock: "10.0.1.0/24"})
+	if err != nil {
+		t.Fatalf("CreateSubnet: %v", err)
+	}
+
+	eni, err := m.CreateNetworkInterface(ctx, subnet.ID, "", nil, nil)
+	if err != nil {
+		t.Fatalf("CreateNetworkInterface: %v", err)
+	}
+
+	attachmentID, err := m.AttachNetworkInterface(ctx, eni.ID, "i-123", 1)
+	if err != nil {
+		t.Fatalf("AttachNetworkInterface: %v", err)
+	}
+	if attachmentID == "" {
+		t.Fatal("AttachNetworkInterface returned empty attachment id")
+	}
+
+	// A second attach of the same in-use ENI is rejected.
+	if _, err := m.AttachNetworkInterface(ctx, eni.ID, "i-456", 2); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("re-attach err = %v, want FailedPrecondition", err)
+	}
+
+	got, err := m.DescribeNetworkInterfaces(ctx, []string{eni.ID})
+	if err != nil {
+		t.Fatalf("DescribeNetworkInterfaces: %v", err)
+	}
+	if got[0].Status != ENIStatusInUse || got[0].InstanceID != "i-123" {
+		t.Fatalf("ENI after attach = %+v, want in-use on i-123", got[0])
+	}
+}

--- a/providers/aws/vpc/endpoint.go
+++ b/providers/aws/vpc/endpoint.go
@@ -79,9 +79,20 @@ func (m *Mock) DeleteVPCEndpoint(
 
 // DescribeVPCEndpoints returns VPC endpoints matching the
 // given IDs, or all endpoints if ids is empty.
+//
+// An explicitly named vpce- ID that does not exist is NotFound rather than an
+// empty list, matching real EC2 (InvalidVpcEndpointId.NotFound).
 func (m *Mock) DescribeVPCEndpoints(
 	_ context.Context, ids []string,
 ) ([]driver.VPCEndpoint, error) {
+	for _, id := range ids {
+		if !m.endpoints.Has(id) {
+			return nil, errors.Newf(
+				errors.NotFound, "vpc endpoint %q not found", id,
+			)
+		}
+	}
+
 	return describeResources(
 		m.endpoints, ids, toEndpointInfo,
 	), nil

--- a/providers/aws/vpc/network_interface.go
+++ b/providers/aws/vpc/network_interface.go
@@ -20,6 +20,8 @@ type eniData struct {
 	SubnetID       string
 	Status         string
 	AttachmentID   string
+	InstanceID     string
+	DeviceIndex    int
 	Description    string
 	SecurityGroups []string
 	Tags           map[string]string
@@ -77,6 +79,35 @@ func (m *Mock) DescribeNetworkInterfaces(_ context.Context, ids []string) ([]dri
 	return describeResources(m.enis, ids, toENIInfo), nil
 }
 
+// AttachNetworkInterface attaches an available ENI to an instance and returns
+// the new attachment id (ec2:AttachNetworkInterface). An interface already in
+// use cannot be re-attached; real EC2 answers InvalidNetworkInterface.InUse.
+func (m *Mock) AttachNetworkInterface(
+	_ context.Context, networkInterfaceID, instanceID string, deviceIndex int,
+) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	eni, ok := m.enis.Get(networkInterfaceID)
+	if !ok {
+		return "", errors.Newf(errors.NotFound, "network interface %q not found", networkInterfaceID)
+	}
+
+	if eni.AttachmentID != "" {
+		return "", errors.Newf(errors.FailedPrecondition,
+			"InvalidNetworkInterface.InUse: network interface %q is already attached to instance %q",
+			networkInterfaceID, eni.InstanceID)
+	}
+
+	attachmentID := idgen.GenerateID("eni-attach-")
+	eni.AttachmentID = attachmentID
+	eni.InstanceID = instanceID
+	eni.DeviceIndex = deviceIndex
+	eni.Status = ENIStatusInUse
+
+	return attachmentID, nil
+}
+
 // DetachNetworkInterface detaches the ENI carrying the given attachment ID.
 //
 // force is accepted and ignored: the emulator has no in-flight traffic for a
@@ -91,6 +122,8 @@ func (m *Mock) DetachNetworkInterface(_ context.Context, attachmentID string, _ 
 		}
 
 		eni.AttachmentID = ""
+		eni.InstanceID = ""
+		eni.DeviceIndex = 0
 		eni.Status = ENIStatusAvailable
 
 		return nil
@@ -162,6 +195,8 @@ func toENIInfo(e *eniData) driver.NetworkInterface {
 		SubnetID:     e.SubnetID,
 		Status:       e.Status,
 		AttachmentID: e.AttachmentID,
+		InstanceID:   e.InstanceID,
+		DeviceIndex:  e.DeviceIndex,
 		Description:  e.Description,
 		Tags:         copyTags(e.Tags),
 	}

--- a/providers/aws/vpc/peering.go
+++ b/providers/aws/vpc/peering.go
@@ -114,9 +114,19 @@ func (m *Mock) DeletePeeringConnection(_ context.Context, peeringID string) erro
 }
 
 // DescribePeeringConnections returns peering connections matching the given IDs.
+//
+// An explicitly named pcx- ID that does not exist is NotFound rather than an
+// empty list, matching real EC2 (InvalidVpcPeeringConnectionID.NotFound) and
+// the convention DescribeVpcs/DescribeVolumes already follow.
 func (m *Mock) DescribePeeringConnections(
 	_ context.Context, ids []string,
 ) ([]driver.PeeringConnection, error) {
+	for _, id := range ids {
+		if !m.peerings.Has(id) {
+			return nil, errors.Newf(errors.NotFound, "peering connection %q not found", id)
+		}
+	}
+
 	return describeResources(m.peerings, ids, toPeeringInfo), nil
 }
 

--- a/server/aws/ec2/dhcp_options_test.go
+++ b/server/aws/ec2/dhcp_options_test.go
@@ -1,0 +1,87 @@
+package ec2_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestDeleteDhcpOptionsInUseDependencyViolation pins that a DHCP option set
+// still associated with a VPC cannot be deleted (DependencyViolation), and that
+// re-associating the VPC with the default set frees it for deletion.
+func TestDeleteDhcpOptionsInUseDependencyViolation(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	vpc, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+	vpcID := aws.ToString(vpc.Vpc.VpcId)
+
+	opts, err := client.CreateDhcpOptions(ctx, &ec2.CreateDhcpOptionsInput{
+		DhcpConfigurations: []ec2types.NewDhcpConfiguration{{
+			Key:    aws.String("domain-name-servers"),
+			Values: []string{"10.0.0.2"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateDhcpOptions: %v", err)
+	}
+	optID := aws.ToString(opts.DhcpOptions.DhcpOptionsId)
+
+	if _, err := client.AssociateDhcpOptions(ctx, &ec2.AssociateDhcpOptionsInput{
+		DhcpOptionsId: aws.String(optID),
+		VpcId:         aws.String(vpcID),
+	}); err != nil {
+		t.Fatalf("AssociateDhcpOptions: %v", err)
+	}
+
+	_, err = client.DeleteDhcpOptions(ctx, &ec2.DeleteDhcpOptionsInput{DhcpOptionsId: aws.String(optID)})
+	if err == nil {
+		t.Fatal("DeleteDhcpOptions(in-use) succeeded, want DependencyViolation")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "DependencyViolation" {
+		t.Fatalf("DeleteDhcpOptions(in-use) error = %v, want DependencyViolation", err)
+	}
+
+	// Re-associate the VPC with the Amazon-provided default set, then delete.
+	if _, err := client.AssociateDhcpOptions(ctx, &ec2.AssociateDhcpOptionsInput{
+		DhcpOptionsId: aws.String("default"),
+		VpcId:         aws.String(vpcID),
+	}); err != nil {
+		t.Fatalf("AssociateDhcpOptions(default): %v", err)
+	}
+
+	if _, err := client.DeleteDhcpOptions(ctx, &ec2.DeleteDhcpOptionsInput{
+		DhcpOptionsId: aws.String(optID),
+	}); err != nil {
+		t.Fatalf("DeleteDhcpOptions after re-associate: %v", err)
+	}
+}
+
+// TestDescribeDhcpOptionsUnknownIDNotFound pins that an explicit, non-existent
+// dopt- id is InvalidDhcpOptionID.NotFound.
+func TestDescribeDhcpOptionsUnknownIDNotFound(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	_, err := client.DescribeDhcpOptions(ctx, &ec2.DescribeDhcpOptionsInput{
+		DhcpOptionsIds: []string{"dopt-00000000000000000"},
+	})
+	if err == nil {
+		t.Fatal("DescribeDhcpOptions(unknown) succeeded, want error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidDhcpOptionID.NotFound" {
+		t.Fatalf("error = %v, want InvalidDhcpOptionID.NotFound", err)
+	}
+}

--- a/server/aws/ec2/endpoint.go
+++ b/server/aws/ec2/endpoint.go
@@ -1,0 +1,229 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// defaultVPCEndpointType is what real EC2 assumes when CreateVpcEndpoint omits
+// VpcEndpointType.
+const defaultVPCEndpointType = "Gateway"
+
+type vpcEndpointXML struct {
+	VpcEndpointID   string    `xml:"vpcEndpointId"`
+	VpcEndpointType string    `xml:"vpcEndpointType"`
+	VpcID           string    `xml:"vpcId"`
+	ServiceName     string    `xml:"serviceName"`
+	State           string    `xml:"state"`
+	RouteTableIDs   []string  `xml:"routeTableIdSet>item,omitempty"`
+	SubnetIDs       []string  `xml:"subnetIdSet>item,omitempty"`
+	Groups          []string  `xml:"groupSet>item,omitempty"`
+	CreationTime    string    `xml:"creationTimestamp,omitempty"`
+	Tags            []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+func (h *Handler) routeVPCEndpoints(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
+	case "CreateVpcEndpoint":
+		h.createVPCEndpoint(w, r)
+	case "DeleteVpcEndpoints":
+		h.deleteVPCEndpoints(w, r)
+	case "DescribeVpcEndpoints":
+		h.describeVPCEndpoints(w, r)
+	case "ModifyVpcEndpoint":
+		h.modifyVPCEndpoint(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) createVPCEndpoint(w http.ResponseWriter, r *http.Request) {
+	endpointType := r.Form.Get("VpcEndpointType")
+	if endpointType == "" {
+		endpointType = defaultVPCEndpointType
+	}
+
+	ep, err := h.vpc.CreateVPCEndpoint(r.Context(), netdriver.VPCEndpointConfig{
+		VPCID:            r.Form.Get("VpcId"),
+		ServiceName:      r.Form.Get("ServiceName"),
+		EndpointType:     endpointType,
+		SubnetIDs:        awsquery.ListStrings(r.Form, "SubnetId"),
+		SecurityGroupIDs: awsquery.ListStrings(r.Form, "SecurityGroupId"),
+		RouteTableIDs:    awsquery.ListStrings(r.Form, "RouteTableId"),
+		Tags:             mergeTagSpecs(awsquery.TagSpecs(r.Form), "vpc-endpoint"),
+	})
+	if err != nil {
+		writeVPCEndpointErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName  xml.Name       `xml:"CreateVpcEndpointResponse"`
+		Xmlns    string         `xml:"xmlns,attr"`
+		Req      string         `xml:"requestId"`
+		Endpoint vpcEndpointXML `xml:"vpcEndpoint"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Endpoint: toVPCEndpointXML(ep)})
+}
+
+// deleteVPCEndpoints is idempotent: like real EC2 it always returns HTTP 200
+// and reports ids it could not delete (including unknown vpce-... ids) as
+// entries in the <unsuccessful> set rather than a top-level error.
+func (h *Handler) deleteVPCEndpoints(w http.ResponseWriter, r *http.Request) {
+	var unsuccessful []unsuccessfulItemXML
+
+	for _, id := range awsquery.ListStrings(r.Form, "VpcEndpointId") {
+		if err := h.vpc.DeleteVPCEndpoint(r.Context(), id); err != nil {
+			item := unsuccessfulItemXML{ResourceID: id}
+			item.Error.Code = "InvalidVpcEndpointId.NotFound"
+			item.Error.Message = err.Error()
+			unsuccessful = append(unsuccessful, item)
+		}
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name              `xml:"DeleteVpcEndpointsResponse"`
+		Xmlns   string                `xml:"xmlns,attr"`
+		Req     string                `xml:"requestId"`
+		Unsucc  []unsuccessfulItemXML `xml:"unsuccessful>item,omitempty"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Unsucc: unsuccessful})
+}
+
+func (h *Handler) describeVPCEndpoints(w http.ResponseWriter, r *http.Request) {
+	items, err := h.vpc.DescribeVPCEndpoints(r.Context(), awsquery.ListStrings(r.Form, "VpcEndpointId"))
+	if err != nil {
+		writeVPCEndpointErr(w, err)
+		return
+	}
+
+	filters := awsquery.Filters(r.Form)
+
+	out := make([]vpcEndpointXML, 0, len(items))
+
+	for i := range items {
+		if vpcEndpointMatchesFilters(&items[i], filters) {
+			out = append(out, toVPCEndpointXML(&items[i]))
+		}
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name         `xml:"DescribeVpcEndpointsResponse"`
+		Xmlns   string           `xml:"xmlns,attr"`
+		Req     string           `xml:"requestId"`
+		Set     []vpcEndpointXML `xml:"vpcEndpointSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+// modifyVPCEndpoint applies the Add*/Remove* set mutations real EC2 uses to
+// change an endpoint's subnets, route tables, and security groups.
+func (h *Handler) modifyVPCEndpoint(w http.ResponseWriter, r *http.Request) {
+	id := r.Form.Get("VpcEndpointId")
+
+	current, err := h.vpc.DescribeVPCEndpoints(r.Context(), []string{id})
+	if err != nil {
+		writeVPCEndpointErr(w, err)
+		return
+	}
+
+	cur := current[0]
+	cfg := netdriver.VPCEndpointConfig{
+		SubnetIDs:        applySetMutation(cur.SubnetIDs, r, "AddSubnetId", "RemoveSubnetId"),
+		RouteTableIDs:    applySetMutation(cur.RouteTableIDs, r, "AddRouteTableId", "RemoveRouteTableId"),
+		SecurityGroupIDs: applySetMutation(cur.SecurityGroupIDs, r, "AddSecurityGroupId", "RemoveSecurityGroupId"),
+	}
+
+	if _, err := h.vpc.ModifyVPCEndpoint(r.Context(), id, cfg); err != nil {
+		writeVPCEndpointErr(w, err)
+		return
+	}
+
+	writeReturnTrue(w, "ModifyVpcEndpointResponse")
+}
+
+// applySetMutation returns cur with the Add* ids appended and the Remove* ids
+// dropped, matching how ModifyVpcEndpoint edits an endpoint's id sets.
+func applySetMutation(cur []string, r *http.Request, addParam, removeParam string) []string {
+	remove := map[string]bool{}
+	for _, id := range awsquery.ListStrings(r.Form, removeParam) {
+		remove[id] = true
+	}
+
+	seen := map[string]bool{}
+	out := make([]string, 0, len(cur))
+
+	for _, id := range cur {
+		if remove[id] || seen[id] {
+			continue
+		}
+
+		seen[id] = true
+
+		out = append(out, id)
+	}
+
+	for _, id := range awsquery.ListStrings(r.Form, addParam) {
+		if remove[id] || seen[id] {
+			continue
+		}
+
+		seen[id] = true
+
+		out = append(out, id)
+	}
+
+	return out
+}
+
+func vpcEndpointMatchesFilters(ep *netdriver.VPCEndpoint, filters []awsquery.Filter) bool {
+	for _, f := range filters {
+		if !vpcEndpointMatchesFilter(ep, f) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func vpcEndpointMatchesFilter(ep *netdriver.VPCEndpoint, f awsquery.Filter) bool {
+	if matched, isTag := matchStorageTagFilter(ep.Tags, f); isTag {
+		return matched
+	}
+
+	switch f.Name {
+	case filterVPCID:
+		return containsString(f.Values, ep.VPCID)
+	case "service-name":
+		return containsString(f.Values, ep.ServiceName)
+	case "vpc-endpoint-id":
+		return containsString(f.Values, ep.ID)
+	case "vpc-endpoint-type":
+		return containsString(f.Values, ep.EndpointType)
+	case "vpc-endpoint-state":
+		return containsString(f.Values, ep.State)
+	default:
+		return false
+	}
+}
+
+func toVPCEndpointXML(ep *netdriver.VPCEndpoint) vpcEndpointXML {
+	return vpcEndpointXML{
+		VpcEndpointID:   ep.ID,
+		VpcEndpointType: nonEmpty(ep.EndpointType, defaultVPCEndpointType),
+		VpcID:           ep.VPCID,
+		ServiceName:     ep.ServiceName,
+		State:           nonEmpty(ep.State, stateAvailable),
+		RouteTableIDs:   ep.RouteTableIDs,
+		SubnetIDs:       ep.SubnetIDs,
+		Groups:          ep.SecurityGroupIDs,
+		CreationTime:    ep.CreatedAt,
+		Tags:            toTagItems(ep.Tags),
+	}
+}
+
+func writeVPCEndpointErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidVpcEndpointId.NotFound", "DependencyViolation")
+}

--- a/server/aws/ec2/flow_log.go
+++ b/server/aws/ec2/flow_log.go
@@ -33,10 +33,10 @@ type describeFlowLogsResponseXML struct {
 }
 
 type deleteFlowLogsResponseXML struct {
-	XMLName      xml.Name `xml:"DeleteFlowLogsResponse"`
-	Xmlns        string   `xml:"xmlns,attr"`
-	RequestID    string   `xml:"requestId"`
-	Unsuccessful []string `xml:"unsuccessful>item,omitempty"`
+	XMLName      xml.Name              `xml:"DeleteFlowLogsResponse"`
+	Xmlns        string                `xml:"xmlns,attr"`
+	RequestID    string                `xml:"requestId"`
+	Unsuccessful []unsuccessfulItemXML `xml:"unsuccessful>item,omitempty"`
 }
 
 func (h *Handler) createFlowLogs(w http.ResponseWriter, r *http.Request) {
@@ -72,19 +72,28 @@ func (h *Handler) createFlowLogs(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// deleteFlowLogs is idempotent: like real EC2, it always returns HTTP 200 and
+// reports ids it could not delete (including unknown fl-... ids) as entries in
+// the <unsuccessful> set rather than as a top-level error, so a destroy that
+// re-runs over an already-gone flow log still succeeds.
 func (h *Handler) deleteFlowLogs(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "FlowLogId")
 
+	var unsuccessful []unsuccessfulItemXML
+
 	for _, id := range ids {
 		if err := h.vpc.DeleteFlowLog(r.Context(), id); err != nil {
-			writeFlowLogErr(w, err)
-			return
+			item := unsuccessfulItemXML{ResourceID: id}
+			item.Error.Code = "InvalidFlowLogId.NotFound"
+			item.Error.Message = err.Error()
+			unsuccessful = append(unsuccessful, item)
 		}
 	}
 
 	awsquery.WriteXMLResponse(w, deleteFlowLogsResponseXML{
-		Xmlns:     awsquery.Namespace,
-		RequestID: awsquery.RequestID,
+		Xmlns:        awsquery.Namespace,
+		RequestID:    awsquery.RequestID,
+		Unsuccessful: unsuccessful,
 	})
 }
 

--- a/server/aws/ec2/flow_log_test.go
+++ b/server/aws/ec2/flow_log_test.go
@@ -1,0 +1,76 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestDeleteFlowLogsIsIdempotent pins that DeleteFlowLogs returns HTTP 200 with
+// unknown ids reported in the Unsuccessful set rather than a top-level error, so
+// a destroy that re-runs over an already-gone flow log still succeeds.
+func TestDeleteFlowLogsIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	out, err := client.DeleteFlowLogs(ctx, &ec2.DeleteFlowLogsInput{
+		FlowLogIds: []string{"fl-00000000000000000"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteFlowLogs(unknown) returned top-level error: %v", err)
+	}
+	if len(out.Unsuccessful) != 1 {
+		t.Fatalf("Unsuccessful = %d, want 1", len(out.Unsuccessful))
+	}
+	if code := aws.ToString(out.Unsuccessful[0].Error.Code); code != "InvalidFlowLogId.NotFound" {
+		t.Errorf("Unsuccessful error code = %q, want InvalidFlowLogId.NotFound", code)
+	}
+	if rid := aws.ToString(out.Unsuccessful[0].ResourceId); rid != "fl-00000000000000000" {
+		t.Errorf("Unsuccessful resourceId = %q, want fl-00000000000000000", rid)
+	}
+}
+
+// TestDeleteFlowLogsRealThenReDelete pins that deleting a real flow log succeeds
+// with no Unsuccessful entries, and a second delete of the same id is reported
+// as unsuccessful rather than erroring.
+func TestDeleteFlowLogsRealThenReDelete(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	vpc, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	fl, err := client.CreateFlowLogs(ctx, &ec2.CreateFlowLogsInput{
+		ResourceIds:  []string{aws.ToString(vpc.Vpc.VpcId)},
+		ResourceType: ec2types.FlowLogsResourceTypeVpc,
+		TrafficType:  ec2types.TrafficTypeAll,
+	})
+	if err != nil {
+		t.Fatalf("CreateFlowLogs: %v", err)
+	}
+	if len(fl.FlowLogIds) != 1 {
+		t.Fatalf("CreateFlowLogs ids = %d, want 1", len(fl.FlowLogIds))
+	}
+	id := fl.FlowLogIds[0]
+
+	first, err := client.DeleteFlowLogs(ctx, &ec2.DeleteFlowLogsInput{FlowLogIds: []string{id}})
+	if err != nil {
+		t.Fatalf("DeleteFlowLogs: %v", err)
+	}
+	if len(first.Unsuccessful) != 0 {
+		t.Fatalf("first delete Unsuccessful = %d, want 0", len(first.Unsuccessful))
+	}
+
+	second, err := client.DeleteFlowLogs(ctx, &ec2.DeleteFlowLogsInput{FlowLogIds: []string{id}})
+	if err != nil {
+		t.Fatalf("second DeleteFlowLogs returned top-level error: %v", err)
+	}
+	if len(second.Unsuccessful) != 1 {
+		t.Fatalf("second delete Unsuccessful = %d, want 1", len(second.Unsuccessful))
+	}
+}

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -97,6 +97,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routePrefixLists,
 		h.routeEgressOnlyIGW,
 		h.routeEndpointServices,
+		h.routeVPCEndpoints,
 		h.routeClientVPN,
 		h.routeIPAM,
 		h.routeIPAMResources,
@@ -107,6 +108,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routeTrafficMirroring,
 		h.routeNetworkInsights,
 		h.routeVPCBlockPublicAccess,
+		h.routePlacementGroups,
 		h.routeVPC,
 		h.routeTags,
 		h.routeMetadata,
@@ -132,6 +134,8 @@ func (h *Handler) routeSnapshots(w http.ResponseWriter, r *http.Request, action 
 		h.describeSnapshots(w, r)
 	case "ModifySnapshotAttribute":
 		h.modifySnapshotAttribute(w, r)
+	case "DescribeSnapshotAttribute":
+		h.describeSnapshotAttribute(w, r)
 	case "CopySnapshot":
 		h.copySnapshot(w, r)
 	default:
@@ -153,6 +157,10 @@ func (h *Handler) routeImages(w http.ResponseWriter, r *http.Request, action str
 		h.describeImages(w, r)
 	case "DescribeImageAttribute":
 		h.describeImageAttribute(w, r)
+	case "CopyImage":
+		h.copyImage(w, r)
+	case "ModifyImageAttribute":
+		h.modifyImageAttribute(w, r)
 	default:
 		return false
 	}
@@ -521,10 +529,21 @@ func (h *Handler) routeVPCRouteTable(w http.ResponseWriter, r *http.Request, act
 		h.associateRouteTable(w, r)
 	case "DisassociateRouteTable":
 		h.disassociateRouteTable(w, r)
+	default:
+		return h.routeVPCNetworkInterfaces(w, r, action)
+	}
+
+	return true
+}
+
+func (h *Handler) routeVPCNetworkInterfaces(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
 	case "CreateNetworkInterface":
 		h.createNetworkInterface(w, r)
 	case "DescribeNetworkInterfaces":
 		h.describeNetworkInterfaces(w, r)
+	case "AttachNetworkInterface":
+		h.attachNetworkInterface(w, r)
 	case "DetachNetworkInterface":
 		h.detachNetworkInterface(w, r)
 	case "DeleteNetworkInterface":

--- a/server/aws/ec2/image.go
+++ b/server/aws/ec2/image.go
@@ -10,6 +10,12 @@ import (
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 )
 
+const launchPermissionAttr = "launchPermission"
+
+// permissionOpRemove is the ModifySnapshotAttribute / ModifyImageAttribute
+// OperationType that revokes (rather than grants) a permission.
+const permissionOpRemove = "remove"
+
 type imageBlockDeviceMappingXML struct {
 	DeviceName          string `xml:"deviceName"`
 	SnapshotID          string `xml:"ebs>snapshotId"`
@@ -256,13 +262,19 @@ func imageMatchesFilter(img *computedriver.ImageInfo, f awsquery.Filter) bool {
 	}
 }
 
+type launchPermissionXML struct {
+	Group  string `xml:"group,omitempty"`
+	UserID string `xml:"userId,omitempty"`
+}
+
 type describeImageAttributeResponseXML struct {
-	XMLName   xml.Name  `xml:"DescribeImageAttributeResponse"`
-	Xmlns     string    `xml:"xmlns,attr"`
-	RequestID string    `xml:"requestId"`
-	ImageID   string    `xml:"imageId"`
-	Desc      *valueXML `xml:"description,omitempty"`
-	BootMode  *valueXML `xml:"bootMode,omitempty"`
+	XMLName          xml.Name              `xml:"DescribeImageAttributeResponse"`
+	Xmlns            string                `xml:"xmlns,attr"`
+	RequestID        string                `xml:"requestId"`
+	ImageID          string                `xml:"imageId"`
+	Desc             *valueXML             `xml:"description,omitempty"`
+	BootMode         *valueXML             `xml:"bootMode,omitempty"`
+	LaunchPermission []launchPermissionXML `xml:"launchPermission>item,omitempty"`
 }
 
 type valueXML struct {
@@ -270,8 +282,9 @@ type valueXML struct {
 }
 
 // describeImageAttribute returns a single AMI attribute. Only the attributes
-// the emulator models (description, bootMode) carry a value; others return the
-// image id with an empty attribute, matching the SDK's single-attribute shape.
+// the emulator models (description, bootMode, launchPermission) carry a value;
+// others return the image id with an empty attribute, matching the SDK's
+// single-attribute shape.
 func (h *Handler) describeImageAttribute(w http.ResponseWriter, r *http.Request) {
 	id := r.Form.Get("ImageId")
 
@@ -292,9 +305,139 @@ func (h *Handler) describeImageAttribute(w http.ResponseWriter, r *http.Request)
 		resp.Desc = &valueXML{Value: imgs[0].Description}
 	case "bootMode":
 		resp.BootMode = &valueXML{Value: ""}
+	case launchPermissionAttr:
+		resp.LaunchPermission = h.imageLaunchPermissionXML(r, id)
 	}
 
 	awsquery.WriteXMLResponse(w, resp)
+}
+
+// imageLaunchPermissionXML reads the AMI's persisted launchPermission grants
+// when the compute driver models them.
+func (h *Handler) imageLaunchPermissionXML(r *http.Request, id string) []launchPermissionXML {
+	modifier, ok := h.compute.(computedriver.ImageAttributeModifier)
+	if !ok {
+		return nil
+	}
+
+	perms, err := modifier.DescribeImageLaunchPermissions(r.Context(), id)
+	if err != nil {
+		return nil
+	}
+
+	out := make([]launchPermissionXML, 0, len(perms))
+	for _, p := range perms {
+		out = append(out, launchPermissionXML{Group: p.Group, UserID: p.UserID})
+	}
+
+	return out
+}
+
+type copyImageResponseXML struct {
+	XMLName   xml.Name `xml:"CopyImageResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	ImageID   string   `xml:"imageId"`
+}
+
+// copyImage handles Action=CopyImage (aws_ami_copy). Served by the AWS-only
+// ImageCopier capability; a driver that does not implement it reports Unimplemented.
+func (h *Handler) copyImage(w http.ResponseWriter, r *http.Request) {
+	copier, ok := h.compute.(computedriver.ImageCopier)
+	if !ok {
+		writeImageErr(w, cerrors.New(cerrors.Unimplemented, "CopyImage is not supported"))
+		return
+	}
+
+	info, err := copier.CopyImage(r.Context(), computedriver.CopyImageInput{
+		SourceRegion:  r.Form.Get("SourceRegion"),
+		SourceImageID: r.Form.Get("SourceImageId"),
+		Name:          r.Form.Get("Name"),
+		Description:   r.Form.Get("Description"),
+		Tags:          mergeTagSpecs(awsquery.TagSpecs(r.Form), "image"),
+	})
+	if err != nil {
+		writeImageErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, copyImageResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		ImageID:   info.ID,
+	})
+}
+
+// modifyImageAttribute applies launchPermission add/remove grants (AMI sharing).
+func (h *Handler) modifyImageAttribute(w http.ResponseWriter, r *http.Request) {
+	id := r.Form.Get("ImageId")
+
+	if _, err := h.compute.DescribeImages(r.Context(), []string{id}); err != nil {
+		writeImageErr(w, err)
+		return
+	}
+
+	if modifier, ok := h.compute.(computedriver.ImageAttributeModifier); ok {
+		if err := applyImagePermissionChanges(r, modifier, id); err != nil {
+			writeImageErr(w, err)
+			return
+		}
+	}
+
+	writeReturnTrue(w, "ModifyImageAttributeResponse")
+}
+
+// applyImagePermissionChanges reads the launchPermission Add/Remove modifications
+// and persists each non-empty side. It supports both the structured
+// LaunchPermission.Add.N.* form the SDK sends and the flat OperationType form.
+func applyImagePermissionChanges(
+	r *http.Request, modifier computedriver.ImageAttributeModifier, imageID string,
+) error {
+	addGroups, addUsers := imagePermissionGrants(r, "Add")
+	removeGroups, removeUsers := imagePermissionGrants(r, "Remove")
+
+	if op := r.Form.Get("OperationType"); op != "" && r.Form.Get("Attribute") == launchPermissionAttr {
+		groups := awsquery.ListStrings(r.Form, "UserGroup")
+		users := awsquery.ListStrings(r.Form, "UserId")
+
+		if op == permissionOpRemove {
+			removeGroups, removeUsers = append(removeGroups, groups...), append(removeUsers, users...)
+		} else {
+			addGroups, addUsers = append(addGroups, groups...), append(addUsers, users...)
+		}
+	}
+
+	if len(addGroups) > 0 || len(addUsers) > 0 {
+		if err := modifier.ModifyImageAttribute(r.Context(), computedriver.ModifyImageAttributeInput{
+			ImageID: imageID, OperationType: "add", Groups: addGroups, UserIDs: addUsers,
+		}); err != nil {
+			return err
+		}
+	}
+
+	if len(removeGroups) > 0 || len(removeUsers) > 0 {
+		return modifier.ModifyImageAttribute(r.Context(), computedriver.ModifyImageAttributeInput{
+			ImageID: imageID, OperationType: "remove", Groups: removeGroups, UserIDs: removeUsers,
+		})
+	}
+
+	return nil
+}
+
+// imagePermissionGrants reads LaunchPermission.<side>.N.Group / .UserId.
+func imagePermissionGrants(r *http.Request, side string) (groups, users []string) {
+	for _, i := range awsquery.CollectIndices(r.Form, "LaunchPermission."+side) {
+		base := "LaunchPermission." + side + "." + strconv.Itoa(i)
+		if g := r.Form.Get(base + ".Group"); g != "" {
+			groups = append(groups, g)
+		}
+
+		if u := r.Form.Get(base + ".UserId"); u != "" {
+			users = append(users, u)
+		}
+	}
+
+	return groups, users
 }
 
 func toImageXML(img *computedriver.ImageInfo) imageXML {
@@ -328,7 +471,7 @@ func toImageXML(img *computedriver.ImageInfo) imageXML {
 		CreationDate:        img.CreatedAt,
 		Architecture:        arch,
 		ImageType:           img.ImageType,
-		Public:              false,
+		Public:              imageIsPublic(img),
 		RootDeviceType:      img.RootDeviceType,
 		RootDeviceName:      img.RootDeviceName,
 		VirtualizationType:  img.VirtualizationType,
@@ -337,6 +480,18 @@ func toImageXML(img *computedriver.ImageInfo) imageXML {
 		BlockDeviceMappings: bdms,
 		Tags:                toTagItems(img.Tags),
 	}
+}
+
+// imageIsPublic reports whether the AMI has a launchPermission grant to the
+// "all" group, which is what makes an AMI public.
+func imageIsPublic(img *computedriver.ImageInfo) bool {
+	for _, p := range img.LaunchPermissions {
+		if p.Group == "all" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func writeImageErr(w http.ResponseWriter, err error) {

--- a/server/aws/ec2/image_test.go
+++ b/server/aws/ec2/image_test.go
@@ -309,3 +309,87 @@ func TestRegisterImageDuplicateNameRejected(t *testing.T) {
 		t.Fatalf("RegisterImage error = %v, want InvalidAMIName.Duplicate", err)
 	}
 }
+
+// TestCopyImageCreatesIndependentAMI pins that CopyImage (aws_ami_copy) returns
+// a new AMI id distinct from the source and carrying the requested name.
+func TestCopyImageCreatesIndependentAMI(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+	instID := launchInstanceForImage(t, ctx, client)
+
+	src, err := client.CreateImage(ctx, &ec2.CreateImageInput{
+		InstanceId: aws.String(instID),
+		Name:       aws.String("source-ami"),
+	})
+	if err != nil {
+		t.Fatalf("CreateImage: %v", err)
+	}
+	srcID := aws.ToString(src.ImageId)
+
+	cp, err := client.CopyImage(ctx, &ec2.CopyImageInput{
+		SourceRegion:  aws.String("us-east-1"),
+		SourceImageId: aws.String(srcID),
+		Name:          aws.String("copied-ami"),
+	})
+	if err != nil {
+		t.Fatalf("CopyImage: %v", err)
+	}
+	copyID := aws.ToString(cp.ImageId)
+	if copyID == "" || copyID == srcID {
+		t.Fatalf("CopyImage id = %q, want a new id distinct from %q", copyID, srcID)
+	}
+
+	desc, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{ImageIds: []string{copyID}})
+	if err != nil {
+		t.Fatalf("DescribeImages: %v", err)
+	}
+	if len(desc.Images) != 1 || aws.ToString(desc.Images[0].Name) != "copied-ami" {
+		t.Fatalf("copied image = %+v, want name copied-ami", desc.Images)
+	}
+}
+
+// TestModifyImageAttributeLaunchPermission pins the AMI-sharing round-trip
+// aws_ami_launch_permission relies on: adding a launchPermission group=all makes
+// the AMI public and DescribeImageAttribute(launchPermission) returns the grant.
+func TestModifyImageAttributeLaunchPermission(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+	instID := launchInstanceForImage(t, ctx, client)
+
+	img, err := client.CreateImage(ctx, &ec2.CreateImageInput{
+		InstanceId: aws.String(instID),
+		Name:       aws.String("shared-ami"),
+	})
+	if err != nil {
+		t.Fatalf("CreateImage: %v", err)
+	}
+	imgID := aws.ToString(img.ImageId)
+
+	if _, err := client.ModifyImageAttribute(ctx, &ec2.ModifyImageAttributeInput{
+		ImageId: aws.String(imgID),
+		LaunchPermission: &ec2types.LaunchPermissionModifications{
+			Add: []ec2types.LaunchPermission{{Group: ec2types.PermissionGroupAll}},
+		},
+	}); err != nil {
+		t.Fatalf("ModifyImageAttribute: %v", err)
+	}
+
+	attr, err := client.DescribeImageAttribute(ctx, &ec2.DescribeImageAttributeInput{
+		ImageId:   aws.String(imgID),
+		Attribute: ec2types.ImageAttributeNameLaunchPermission,
+	})
+	if err != nil {
+		t.Fatalf("DescribeImageAttribute: %v", err)
+	}
+	if len(attr.LaunchPermissions) != 1 || attr.LaunchPermissions[0].Group != ec2types.PermissionGroupAll {
+		t.Fatalf("LaunchPermissions = %+v, want one grant group=all", attr.LaunchPermissions)
+	}
+
+	desc, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{ImageIds: []string{imgID}})
+	if err != nil {
+		t.Fatalf("DescribeImages: %v", err)
+	}
+	if !aws.ToBool(desc.Images[0].Public) {
+		t.Error("image Public = false after launchPermission group=all, want true")
+	}
+}

--- a/server/aws/ec2/instance_metadata_test.go
+++ b/server/aws/ec2/instance_metadata_test.go
@@ -1,0 +1,65 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestModifyInstanceMetadataOptionsEnforcesIMDSv2 pins that
+// ModifyInstanceMetadataOptions(HttpTokens=required) updates the instance's IMDS
+// settings and that DescribeInstances reflects the change — the round-trip a
+// security baseline / Terraform aws_instance metadata_options update relies on.
+func TestModifyInstanceMetadataOptionsEnforcesIMDSv2(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:  aws.String("ami-123"),
+		MinCount: aws.Int32(1),
+		MaxCount: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	instID := aws.ToString(run.Instances[0].InstanceId)
+
+	// A freshly launched instance defaults to IMDSv1+v2 (optional).
+	if got := run.Instances[0].MetadataOptions; got == nil || got.HttpTokens != ec2types.HttpTokensStateOptional {
+		t.Fatalf("launch HttpTokens = %v, want optional", run.Instances[0].MetadataOptions)
+	}
+
+	mod, err := client.ModifyInstanceMetadataOptions(ctx, &ec2.ModifyInstanceMetadataOptionsInput{
+		InstanceId:              aws.String(instID),
+		HttpTokens:              ec2types.HttpTokensStateRequired,
+		HttpPutResponseHopLimit: aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("ModifyInstanceMetadataOptions: %v", err)
+	}
+	if mod.InstanceMetadataOptions == nil ||
+		mod.InstanceMetadataOptions.HttpTokens != ec2types.HttpTokensStateRequired {
+		t.Fatalf("Modify response HttpTokens = %v, want required", mod.InstanceMetadataOptions)
+	}
+
+	desc, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: []string{instID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	opts := desc.Reservations[0].Instances[0].MetadataOptions
+	if opts == nil {
+		t.Fatal("DescribeInstances MetadataOptions is nil after modify")
+	}
+	if opts.HttpTokens != ec2types.HttpTokensStateRequired {
+		t.Errorf("HttpTokens = %q, want required", opts.HttpTokens)
+	}
+	if aws.ToInt32(opts.HttpPutResponseHopLimit) != 2 {
+		t.Errorf("HttpPutResponseHopLimit = %d, want 2", aws.ToInt32(opts.HttpPutResponseHopLimit))
+	}
+}

--- a/server/aws/ec2/metadata.go
+++ b/server/aws/ec2/metadata.go
@@ -3,8 +3,11 @@ package ec2
 import (
 	"encoding/xml"
 	"net/http"
+	"strconv"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 )
 
 // commonRegions is the representative region set DescribeRegions reports. Tools
@@ -35,11 +38,54 @@ func (h *Handler) routeMetadata(w http.ResponseWriter, r *http.Request, action s
 		h.describeRegions(w, r)
 	case "DescribeInstanceTypes":
 		h.describeInstanceTypes(w, r)
+	case "ModifyInstanceMetadataOptions":
+		h.modifyInstanceMetadataOptions(w, r)
 	default:
 		return false
 	}
 
 	return true
+}
+
+type modifyInstanceMetadataOptionsResponseXML struct {
+	XMLName    xml.Name            `xml:"ModifyInstanceMetadataOptionsResponse"`
+	Xmlns      string              `xml:"xmlns,attr"`
+	RequestID  string              `xml:"requestId"`
+	InstanceID string              `xml:"instanceId"`
+	Options    *metadataOptionsXML `xml:"instanceMetadataOptions"`
+}
+
+// modifyInstanceMetadataOptions updates an instance's IMDS settings (e.g.
+// HttpTokens=required to enforce IMDSv2). Served by the AWS-only
+// InstanceMetadataModifier capability; a driver without it reports Unimplemented.
+func (h *Handler) modifyInstanceMetadataOptions(w http.ResponseWriter, r *http.Request) {
+	modifier, ok := h.compute.(computedriver.InstanceMetadataModifier)
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "ModifyInstanceMetadataOptions is not supported"))
+		return
+	}
+
+	instanceID := r.Form.Get("InstanceId")
+	hopLimit, _ := strconv.Atoi(r.Form.Get("HttpPutResponseHopLimit"))
+
+	opts, err := modifier.ModifyInstanceMetadataOptions(r.Context(), instanceID, computedriver.MetadataOptions{
+		HTTPTokens:              r.Form.Get("HttpTokens"),
+		HTTPPutResponseHopLimit: hopLimit,
+		HTTPEndpoint:            r.Form.Get("HttpEndpoint"),
+		HTTPProtocolIPv6:        r.Form.Get("HttpProtocolIpv6"),
+		InstanceMetadataTags:    r.Form.Get("InstanceMetadataTags"),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, modifyInstanceMetadataOptionsResponseXML{
+		Xmlns:      awsquery.Namespace,
+		RequestID:  awsquery.RequestID,
+		InstanceID: instanceID,
+		Options:    metadataOptionsXMLFor(opts),
+	})
 }
 
 // describeRegions answers ec2:DescribeRegions. If explicit RegionName.N filters

--- a/server/aws/ec2/network_interface.go
+++ b/server/aws/ec2/network_interface.go
@@ -3,6 +3,8 @@ package ec2
 import (
 	"encoding/xml"
 	"net/http"
+	"strconv"
+	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
@@ -11,6 +13,8 @@ import (
 
 type eniAttachmentXML struct {
 	AttachmentID string `xml:"attachmentId"`
+	InstanceID   string `xml:"instanceId,omitempty"`
+	DeviceIndex  int    `xml:"deviceIndex"`
 	Status       string `xml:"status"`
 }
 
@@ -36,6 +40,14 @@ type createNetworkInterfaceResponseXML struct {
 	Xmlns            string              `xml:"xmlns,attr"`
 	RequestID        string              `xml:"requestId"`
 	NetworkInterface networkInterfaceXML `xml:"networkInterface"`
+}
+
+type attachNetworkInterfaceResponseXML struct {
+	XMLName          xml.Name `xml:"AttachNetworkInterfaceResponse"`
+	Xmlns            string   `xml:"xmlns,attr"`
+	RequestID        string   `xml:"requestId"`
+	AttachmentID     string   `xml:"attachmentId"`
+	NetworkCardIndex int      `xml:"networkCardIndex"`
 }
 
 type detachNetworkInterfaceResponseXML struct {
@@ -97,7 +109,7 @@ func (h *Handler) describeNetworkInterfaces(w http.ResponseWriter, r *http.Reque
 // The second result reports whether the filter is recognized at all.
 func eniFilterField(eni *netdriver.NetworkInterface, name string) (string, bool) {
 	switch name {
-	case "vpc-id":
+	case filterVPCID:
 		return eni.VPCID, true
 	case "subnet-id":
 		return eni.SubnetID, true
@@ -105,7 +117,7 @@ func eniFilterField(eni *netdriver.NetworkInterface, name string) (string, bool)
 		return eni.Status, true
 	case "network-interface-id":
 		return eni.ID, true
-	case "description":
+	case filterDescription:
 		return eni.Description, true
 	case "group-id":
 		// ENIs don't model security-group membership, so this filter is
@@ -191,6 +203,55 @@ func (h *Handler) createNetworkInterface(w http.ResponseWriter, r *http.Request)
 	})
 }
 
+// attachNetworkInterface attaches an existing ENI to an instance
+// (ec2:AttachNetworkInterface). The instance's existence is verified against
+// the compute driver here — the networking provider does not model instances —
+// so an unknown instance answers InvalidInstanceID.NotFound.
+func (h *Handler) attachNetworkInterface(w http.ResponseWriter, r *http.Request) {
+	attacher, ok := h.vpc.(netdriver.NetworkInterfaceAttacher)
+	if !ok {
+		writeUnsupportedENI(w)
+		return
+	}
+
+	instanceID := r.Form.Get("InstanceId")
+	if h.compute != nil {
+		insts, err := h.compute.DescribeInstances(r.Context(), []string{instanceID}, nil)
+		if err != nil || len(insts) == 0 {
+			awsquery.WriteXMLError(w, http.StatusBadRequest, codeInvalidInstanceID,
+				"instance "+instanceID+" not found")
+
+			return
+		}
+	}
+
+	deviceIndex, _ := strconv.Atoi(r.Form.Get("DeviceIndex"))
+
+	attachmentID, err := attacher.AttachNetworkInterface(r.Context(),
+		r.Form.Get("NetworkInterfaceId"), instanceID, deviceIndex)
+	if err != nil {
+		writeENIAttachErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, attachNetworkInterfaceResponseXML{
+		Xmlns:        awsquery.Namespace,
+		RequestID:    awsquery.RequestID,
+		AttachmentID: attachmentID,
+	})
+}
+
+// writeENIAttachErr maps an already-attached interface to InvalidNetworkInterface.InUse
+// (real EC2's code), falling back to the shared ENI error mapping otherwise.
+func writeENIAttachErr(w http.ResponseWriter, err error) {
+	if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "InvalidNetworkInterface.InUse:") {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidNetworkInterface.InUse", err.Error())
+		return
+	}
+
+	writeENIErr(w, err)
+}
+
 func (h *Handler) detachNetworkInterface(w http.ResponseWriter, r *http.Request) {
 	force := r.Form.Get("Force") == formTrue
 
@@ -242,7 +303,12 @@ func toNetworkInterfaceXML(e *netdriver.NetworkInterface) networkInterfaceXML {
 	}
 
 	if e.AttachmentID != "" {
-		x.Attachment = &eniAttachmentXML{AttachmentID: e.AttachmentID, Status: stateAttached}
+		x.Attachment = &eniAttachmentXML{
+			AttachmentID: e.AttachmentID,
+			InstanceID:   e.InstanceID,
+			DeviceIndex:  e.DeviceIndex,
+			Status:       stateAttached,
+		}
 	}
 
 	return x

--- a/server/aws/ec2/network_interface_attach_test.go
+++ b/server/aws/ec2/network_interface_attach_test.go
@@ -1,0 +1,121 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+// TestAttachNetworkInterfaceLifecycle exercises the ENI attach/detach lifecycle
+// aws_network_interface_attachment drives: create an ENI, attach it to an
+// instance (getting an attachmentId), see the attachment on Describe, then
+// detach it.
+func TestAttachNetworkInterfaceLifecycle(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	vpc, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	subnet, err := client.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId:     vpc.Vpc.VpcId,
+		CidrBlock: aws.String("10.0.1.0/24"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSubnet: %v", err)
+	}
+	subnetID := aws.ToString(subnet.Subnet.SubnetId)
+
+	eni, err := client.CreateNetworkInterface(ctx, &ec2.CreateNetworkInterfaceInput{
+		SubnetId: aws.String(subnetID),
+	})
+	if err != nil {
+		t.Fatalf("CreateNetworkInterface: %v", err)
+	}
+	eniID := aws.ToString(eni.NetworkInterface.NetworkInterfaceId)
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:  aws.String("ami-123"),
+		MinCount: aws.Int32(1),
+		MaxCount: aws.Int32(1),
+		SubnetId: aws.String(subnetID),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	instID := aws.ToString(run.Instances[0].InstanceId)
+
+	attach, err := client.AttachNetworkInterface(ctx, &ec2.AttachNetworkInterfaceInput{
+		NetworkInterfaceId: aws.String(eniID),
+		InstanceId:         aws.String(instID),
+		DeviceIndex:        aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("AttachNetworkInterface: %v", err)
+	}
+	attachmentID := aws.ToString(attach.AttachmentId)
+	if attachmentID == "" {
+		t.Fatal("AttachNetworkInterface returned empty attachmentId")
+	}
+
+	desc, err := client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		NetworkInterfaceIds: []string{eniID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNetworkInterfaces: %v", err)
+	}
+
+	got := desc.NetworkInterfaces[0]
+	if got.Status != "in-use" {
+		t.Errorf("ENI status = %q, want in-use", got.Status)
+	}
+	if got.Attachment == nil || aws.ToString(got.Attachment.InstanceId) != instID {
+		t.Errorf("attachment instanceId = %+v, want %s", got.Attachment, instID)
+	}
+
+	if _, err := client.DetachNetworkInterface(ctx, &ec2.DetachNetworkInterfaceInput{
+		AttachmentId: aws.String(attachmentID),
+	}); err != nil {
+		t.Fatalf("DetachNetworkInterface: %v", err)
+	}
+}
+
+// TestAttachNetworkInterfaceUnknownInstance pins that attaching to a
+// non-existent instance answers InvalidInstanceID.NotFound.
+func TestAttachNetworkInterfaceUnknownInstance(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	vpc, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	subnet, err := client.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId:     vpc.Vpc.VpcId,
+		CidrBlock: aws.String("10.0.1.0/24"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSubnet: %v", err)
+	}
+
+	eni, err := client.CreateNetworkInterface(ctx, &ec2.CreateNetworkInterfaceInput{
+		SubnetId: subnet.Subnet.SubnetId,
+	})
+	if err != nil {
+		t.Fatalf("CreateNetworkInterface: %v", err)
+	}
+
+	_, err = client.AttachNetworkInterface(ctx, &ec2.AttachNetworkInterfaceInput{
+		NetworkInterfaceId: eni.NetworkInterface.NetworkInterfaceId,
+		InstanceId:         aws.String("i-00000000000000000"),
+		DeviceIndex:        aws.Int32(1),
+	})
+	if err == nil {
+		t.Fatal("AttachNetworkInterface(unknown instance) succeeded, want error")
+	}
+}

--- a/server/aws/ec2/operations.go
+++ b/server/aws/ec2/operations.go
@@ -677,6 +677,7 @@ func instanceXMLFor(inst *computedriver.Instance, names map[string]string) insta
 		Hypervisor:         hypervisorXen,
 		Placement:          &placementXML{AvailabilityZone: instanceZone(inst), Tenancy: tenancyDefault},
 		Monitoring:         &monitoringXML{State: monitoringState(inst.Monitoring)},
+		MetadataOptions:    metadataOptionsXMLFor(&inst.MetadataOptions),
 	}
 
 	for _, sg := range inst.SecurityGroups {
@@ -700,6 +701,24 @@ func instanceXMLFor(inst *computedriver.Instance, names map[string]string) insta
 	}
 
 	return xi
+}
+
+// metadataOptionsXMLFor renders an instance's IMDS configuration, filling in the
+// EC2 defaults for any field an older stored instance left unset.
+func metadataOptionsXMLFor(o *computedriver.MetadataOptions) *metadataOptionsXML {
+	hopLimit := o.HTTPPutResponseHopLimit
+	if hopLimit == 0 {
+		hopLimit = 1
+	}
+
+	return &metadataOptionsXML{
+		State:                   nonEmpty(o.State, "applied"),
+		HTTPTokens:              nonEmpty(o.HTTPTokens, "optional"),
+		HTTPPutResponseHopLimit: hopLimit,
+		HTTPEndpoint:            nonEmpty(o.HTTPEndpoint, "enabled"),
+		HTTPProtocolIPv6:        nonEmpty(o.HTTPProtocolIPv6, "disabled"),
+		InstanceMetadataTags:    nonEmpty(o.InstanceMetadataTags, "disabled"),
+	}
 }
 
 // primaryENI synthesizes the instance's single primary network interface from

--- a/server/aws/ec2/placement_group.go
+++ b/server/aws/ec2/placement_group.go
@@ -1,0 +1,121 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strconv"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+type placementGroupXML struct {
+	GroupName      string    `xml:"groupName"`
+	GroupID        string    `xml:"groupId"`
+	Strategy       string    `xml:"strategy"`
+	State          string    `xml:"state"`
+	PartitionCount int       `xml:"partitionCount,omitempty"`
+	SpreadLevel    string    `xml:"spreadLevel,omitempty"`
+	Tags           []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+func (h *Handler) placementGroups() (computedriver.PlacementGroups, bool) {
+	pg, ok := h.compute.(computedriver.PlacementGroups)
+
+	return pg, ok
+}
+
+func (h *Handler) routePlacementGroups(w http.ResponseWriter, r *http.Request, action string) bool {
+	pg, ok := h.placementGroups()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "CreatePlacementGroup":
+		h.createPlacementGroup(w, r, pg)
+	case "DeletePlacementGroup":
+		h.deletePlacementGroup(w, r, pg)
+	case "DescribePlacementGroups":
+		h.describePlacementGroups(w, r, pg)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (*Handler) createPlacementGroup(w http.ResponseWriter, r *http.Request, pg computedriver.PlacementGroups) {
+	partitionCount, _ := strconv.Atoi(r.Form.Get("PartitionCount"))
+
+	out, err := pg.CreatePlacementGroup(r.Context(), computedriver.PlacementGroupConfig{
+		Name:           r.Form.Get("GroupName"),
+		Strategy:       r.Form.Get("Strategy"),
+		PartitionCount: partitionCount,
+		SpreadLevel:    r.Form.Get("SpreadLevel"),
+		Tags:           mergeTagSpecs(awsquery.TagSpecs(r.Form), "placement-group"),
+	})
+	if err != nil {
+		writePlacementGroupErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name          `xml:"CreatePlacementGroupResponse"`
+		Xmlns   string            `xml:"xmlns,attr"`
+		Req     string            `xml:"requestId"`
+		Group   placementGroupXML `xml:"placementGroup"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Group: toPlacementGroupXML(out)})
+}
+
+func (*Handler) deletePlacementGroup(w http.ResponseWriter, r *http.Request, pg computedriver.PlacementGroups) {
+	if err := pg.DeletePlacementGroup(r.Context(), r.Form.Get("GroupName")); err != nil {
+		writePlacementGroupErr(w, err)
+		return
+	}
+
+	writeReturnTrue(w, "DeletePlacementGroupResponse")
+}
+
+func (*Handler) describePlacementGroups(w http.ResponseWriter, r *http.Request, pg computedriver.PlacementGroups) {
+	items, err := pg.DescribePlacementGroups(r.Context(),
+		awsquery.ListStrings(r.Form, "GroupName"), awsquery.ListStrings(r.Form, "GroupId"))
+	if err != nil {
+		writePlacementGroupErr(w, err)
+		return
+	}
+
+	out := make([]placementGroupXML, 0, len(items))
+	for i := range items {
+		out = append(out, toPlacementGroupXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name            `xml:"DescribePlacementGroupsResponse"`
+		Xmlns   string              `xml:"xmlns,attr"`
+		Req     string              `xml:"requestId"`
+		Set     []placementGroupXML `xml:"placementGroupSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func toPlacementGroupXML(pg *computedriver.PlacementGroup) placementGroupXML {
+	return placementGroupXML{
+		GroupName:      pg.Name,
+		GroupID:        pg.ID,
+		Strategy:       pg.Strategy,
+		State:          nonEmpty(pg.State, stateAvailable),
+		PartitionCount: pg.PartitionCount,
+		SpreadLevel:    pg.SpreadLevel,
+		Tags:           toTagItems(pg.Tags),
+	}
+}
+
+func writePlacementGroupErr(w http.ResponseWriter, err error) {
+	if cerrors.IsAlreadyExists(err) {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidPlacementGroup.Duplicate", err.Error())
+		return
+	}
+
+	writeErrWithNotFound(w, err, "InvalidPlacementGroup.Unknown", "DependencyViolation")
+}

--- a/server/aws/ec2/placement_group_test.go
+++ b/server/aws/ec2/placement_group_test.go
@@ -1,0 +1,74 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestPlacementGroupLifecycle exercises the aws_placement_group flow: create a
+// cluster group, read it back by name, and delete it.
+func TestPlacementGroupLifecycle(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	create, err := client.CreatePlacementGroup(ctx, &ec2.CreatePlacementGroupInput{
+		GroupName: aws.String("web-cluster"),
+		Strategy:  ec2types.PlacementStrategyCluster,
+	})
+	if err != nil {
+		t.Fatalf("CreatePlacementGroup: %v", err)
+	}
+
+	pg := create.PlacementGroup
+	if aws.ToString(pg.GroupName) != "web-cluster" {
+		t.Errorf("GroupName = %q, want web-cluster", aws.ToString(pg.GroupName))
+	}
+	if pg.Strategy != ec2types.PlacementStrategyCluster {
+		t.Errorf("Strategy = %q, want cluster", pg.Strategy)
+	}
+	if aws.ToString(pg.GroupId) == "" {
+		t.Error("CreatePlacementGroup returned empty GroupId")
+	}
+	if pg.State != ec2types.PlacementGroupStateAvailable {
+		t.Errorf("State = %q, want available", pg.State)
+	}
+
+	desc, err := client.DescribePlacementGroups(ctx, &ec2.DescribePlacementGroupsInput{
+		GroupNames: []string{"web-cluster"},
+	})
+	if err != nil {
+		t.Fatalf("DescribePlacementGroups: %v", err)
+	}
+	if len(desc.PlacementGroups) != 1 {
+		t.Fatalf("DescribePlacementGroups = %d, want 1", len(desc.PlacementGroups))
+	}
+
+	if _, err := client.DeletePlacementGroup(ctx, &ec2.DeletePlacementGroupInput{
+		GroupName: aws.String("web-cluster"),
+	}); err != nil {
+		t.Fatalf("DeletePlacementGroup: %v", err)
+	}
+}
+
+// TestPlacementGroupPartitionCountDefaults pins that a partition-strategy group
+// gets the AWS default partition count when the caller omits it.
+func TestPlacementGroupPartitionCountDefaults(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	create, err := client.CreatePlacementGroup(ctx, &ec2.CreatePlacementGroupInput{
+		GroupName: aws.String("part"),
+		Strategy:  ec2types.PlacementStrategyPartition,
+	})
+	if err != nil {
+		t.Fatalf("CreatePlacementGroup: %v", err)
+	}
+
+	if got := aws.ToInt32(create.PlacementGroup.PartitionCount); got != 2 {
+		t.Errorf("PartitionCount = %d, want 2 (default)", got)
+	}
+}

--- a/server/aws/ec2/snapshot.go
+++ b/server/aws/ec2/snapshot.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"encoding/xml"
 	"net/http"
+	"strconv"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
@@ -213,14 +214,23 @@ func snapshotMatchesFilter(s *computedriver.SnapshotInfo, f awsquery.Filter) boo
 	}
 }
 
-// modifySnapshotAttribute accepts createVolumePermission / productCode changes.
-// The emulator does not model snapshot sharing, so it acknowledges the request
-// without persisting the attribute (Terraform's aws_snapshot_create_volume_
-// permission only needs the 200).
+// modifySnapshotAttribute applies createVolumePermission add/remove grants
+// (snapshot sharing). When the compute driver models the attribute it persists
+// the grants so DescribeSnapshotAttribute reads them back; otherwise the request
+// is acknowledged without persistence.
 func (h *Handler) modifySnapshotAttribute(w http.ResponseWriter, r *http.Request) {
-	if _, err := h.compute.DescribeSnapshots(r.Context(), []string{r.Form.Get("SnapshotId")}); err != nil {
+	snapshotID := r.Form.Get("SnapshotId")
+
+	if _, err := h.compute.DescribeSnapshots(r.Context(), []string{snapshotID}); err != nil {
 		writeSnapshotErr(w, err)
 		return
+	}
+
+	if modifier, ok := h.compute.(computedriver.SnapshotAttributeModifier); ok {
+		if err := applySnapshotPermissionChanges(r, modifier, snapshotID); err != nil {
+			writeSnapshotErr(w, err)
+			return
+		}
 	}
 
 	awsquery.WriteXMLResponse(w, modifySnapshotAttributeResponseXML{
@@ -228,6 +238,106 @@ func (h *Handler) modifySnapshotAttribute(w http.ResponseWriter, r *http.Request
 		RequestID: awsquery.RequestID,
 		Return:    true,
 	})
+}
+
+// applySnapshotPermissionChanges reads the createVolumePermission Add/Remove
+// modifications from the request and persists each non-empty side. It supports
+// both the structured CreateVolumePermission.Add.N.* form the SDK sends and the
+// flat OperationType + UserGroup.N / UserId.N form.
+func applySnapshotPermissionChanges(
+	r *http.Request, modifier computedriver.SnapshotAttributeModifier, snapshotID string,
+) error {
+	addGroups, addUsers := snapshotPermissionGrants(r, "Add")
+	removeGroups, removeUsers := snapshotPermissionGrants(r, "Remove")
+
+	if op := r.Form.Get("OperationType"); op != "" {
+		groups := awsquery.ListStrings(r.Form, "UserGroup")
+		users := awsquery.ListStrings(r.Form, "UserId")
+
+		if op == permissionOpRemove {
+			removeGroups, removeUsers = append(removeGroups, groups...), append(removeUsers, users...)
+		} else {
+			addGroups, addUsers = append(addGroups, groups...), append(addUsers, users...)
+		}
+	}
+
+	if len(addGroups) > 0 || len(addUsers) > 0 {
+		if err := modifier.ModifySnapshotAttribute(r.Context(), computedriver.ModifySnapshotAttributeInput{
+			SnapshotID: snapshotID, OperationType: "add", Groups: addGroups, UserIDs: addUsers,
+		}); err != nil {
+			return err
+		}
+	}
+
+	if len(removeGroups) > 0 || len(removeUsers) > 0 {
+		return modifier.ModifySnapshotAttribute(r.Context(), computedriver.ModifySnapshotAttributeInput{
+			SnapshotID: snapshotID, OperationType: "remove", Groups: removeGroups, UserIDs: removeUsers,
+		})
+	}
+
+	return nil
+}
+
+// snapshotPermissionGrants reads CreateVolumePermission.<side>.N.Group / .UserId.
+func snapshotPermissionGrants(r *http.Request, side string) (groups, users []string) {
+	for _, i := range awsquery.CollectIndices(r.Form, "CreateVolumePermission."+side) {
+		base := "CreateVolumePermission." + side + "." + strconv.Itoa(i)
+		if g := r.Form.Get(base + ".Group"); g != "" {
+			groups = append(groups, g)
+		}
+
+		if u := r.Form.Get(base + ".UserId"); u != "" {
+			users = append(users, u)
+		}
+	}
+
+	return groups, users
+}
+
+type createVolumePermissionXML struct {
+	Group  string `xml:"group,omitempty"`
+	UserID string `xml:"userId,omitempty"`
+}
+
+type describeSnapshotAttributeResponseXML struct {
+	XMLName                 xml.Name                    `xml:"DescribeSnapshotAttributeResponse"`
+	Xmlns                   string                      `xml:"xmlns,attr"`
+	RequestID               string                      `xml:"requestId"`
+	SnapshotID              string                      `xml:"snapshotId"`
+	CreateVolumePermissions []createVolumePermissionXML `xml:"createVolumePermission>item,omitempty"`
+}
+
+// describeSnapshotAttribute returns the createVolumePermission grants persisted
+// by ModifySnapshotAttribute, completing the snapshot-sharing round-trip.
+func (h *Handler) describeSnapshotAttribute(w http.ResponseWriter, r *http.Request) {
+	snapshotID := r.Form.Get("SnapshotId")
+
+	if _, err := h.compute.DescribeSnapshots(r.Context(), []string{snapshotID}); err != nil {
+		writeSnapshotErr(w, err)
+		return
+	}
+
+	resp := describeSnapshotAttributeResponseXML{
+		Xmlns:      awsquery.Namespace,
+		RequestID:  awsquery.RequestID,
+		SnapshotID: snapshotID,
+	}
+
+	if modifier, ok := h.compute.(computedriver.SnapshotAttributeModifier); ok &&
+		r.Form.Get("Attribute") == "createVolumePermission" {
+		perms, err := modifier.DescribeSnapshotVolumePermissions(r.Context(), snapshotID)
+		if err != nil {
+			writeSnapshotErr(w, err)
+			return
+		}
+
+		for _, p := range perms {
+			resp.CreateVolumePermissions = append(resp.CreateVolumePermissions,
+				createVolumePermissionXML{Group: p.Group, UserID: p.UserID})
+		}
+	}
+
+	awsquery.WriteXMLResponse(w, resp)
 }
 
 func toSnapshotXML(s *computedriver.SnapshotInfo) snapshotXML {

--- a/server/aws/ec2/snapshot_test.go
+++ b/server/aws/ec2/snapshot_test.go
@@ -260,3 +260,41 @@ func hasTag(tags []ec2types.Tag, key, value string) bool {
 
 	return false
 }
+
+// TestSnapshotCreateVolumePermissionRoundTrip pins the snapshot-sharing
+// round-trip aws_snapshot_create_volume_permission relies on:
+// ModifySnapshotAttribute(createVolumePermission Add group=all) persists, and
+// DescribeSnapshotAttribute(createVolumePermission) returns the added grant.
+func TestSnapshotCreateVolumePermissionRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+	volID := createSnapshotVolume(t, ctx, client)
+
+	snap, err := client.CreateSnapshot(ctx, &ec2.CreateSnapshotInput{VolumeId: aws.String(volID)})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	snapID := aws.ToString(snap.SnapshotId)
+
+	if _, err := client.ModifySnapshotAttribute(ctx, &ec2.ModifySnapshotAttributeInput{
+		SnapshotId: aws.String(snapID),
+		Attribute:  ec2types.SnapshotAttributeNameCreateVolumePermission,
+		CreateVolumePermission: &ec2types.CreateVolumePermissionModifications{
+			Add: []ec2types.CreateVolumePermission{{Group: ec2types.PermissionGroupAll}},
+		},
+	}); err != nil {
+		t.Fatalf("ModifySnapshotAttribute: %v", err)
+	}
+
+	desc, err := client.DescribeSnapshotAttribute(ctx, &ec2.DescribeSnapshotAttributeInput{
+		SnapshotId: aws.String(snapID),
+		Attribute:  ec2types.SnapshotAttributeNameCreateVolumePermission,
+	})
+	if err != nil {
+		t.Fatalf("DescribeSnapshotAttribute: %v", err)
+	}
+	if len(desc.CreateVolumePermissions) != 1 ||
+		desc.CreateVolumePermissions[0].Group != ec2types.PermissionGroupAll {
+		t.Fatalf("CreateVolumePermissions = %+v, want one grant group=all", desc.CreateVolumePermissions)
+	}
+}

--- a/server/aws/ec2/volume.go
+++ b/server/aws/ec2/volume.go
@@ -256,6 +256,13 @@ func (h *Handler) attachVolume(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// A volume already attached to an instance cannot be re-attached; real
+		// EC2 answers VolumeInUse rather than the generic IncorrectState.
+		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "VolumeInUse:") {
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "VolumeInUse", err.Error())
+			return
+		}
+
 		writeVolumeErr(w, err)
 
 		return

--- a/server/aws/ec2/volume_test.go
+++ b/server/aws/ec2/volume_test.go
@@ -360,3 +360,51 @@ func TestDeleteAttachedVolumeReturnsVolumeInUse(t *testing.T) {
 		t.Fatalf("DeleteVolume(attached) error = %v, want VolumeInUse", err)
 	}
 }
+
+// TestAttachAlreadyAttachedVolumeReturnsVolumeInUse pins that attaching a volume
+// that is already attached to an instance is rejected with the VolumeInUse code
+// (not the generic IncorrectState).
+func TestAttachAlreadyAttachedVolumeReturnsVolumeInUse(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:  aws.String("ami-123"),
+		MinCount: aws.Int32(1),
+		MaxCount: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	instID := aws.ToString(run.Instances[0].InstanceId)
+
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(10),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+
+	if _, err := client.AttachVolume(ctx, &ec2.AttachVolumeInput{
+		VolumeId:   vol.VolumeId,
+		InstanceId: aws.String(instID),
+		Device:     aws.String("/dev/sdf"),
+	}); err != nil {
+		t.Fatalf("AttachVolume(first): %v", err)
+	}
+
+	_, err = client.AttachVolume(ctx, &ec2.AttachVolumeInput{
+		VolumeId:   vol.VolumeId,
+		InstanceId: aws.String(instID),
+		Device:     aws.String("/dev/sdg"),
+	})
+	if err == nil {
+		t.Fatal("AttachVolume(already attached) succeeded, want error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "VolumeInUse" {
+		t.Fatalf("AttachVolume(already attached) error = %v, want VolumeInUse", err)
+	}
+}

--- a/server/aws/ec2/vpc_endpoint_test.go
+++ b/server/aws/ec2/vpc_endpoint_test.go
@@ -1,0 +1,156 @@
+package ec2_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestVPCEndpointGatewayLifecycle exercises the consumer gateway-endpoint flow
+// Terraform's aws_vpc_endpoint drives: create against a VPC, read it back, and
+// delete it.
+func TestVPCEndpointGatewayLifecycle(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	vpc, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+	vpcID := aws.ToString(vpc.Vpc.VpcId)
+
+	create, err := client.CreateVpcEndpoint(ctx, &ec2.CreateVpcEndpointInput{
+		VpcId:           aws.String(vpcID),
+		ServiceName:     aws.String("com.amazonaws.us-east-1.s3"),
+		VpcEndpointType: ec2types.VpcEndpointTypeGateway,
+	})
+	if err != nil {
+		t.Fatalf("CreateVpcEndpoint: %v", err)
+	}
+
+	ep := create.VpcEndpoint
+	epID := aws.ToString(ep.VpcEndpointId)
+
+	if epID == "" {
+		t.Fatal("CreateVpcEndpoint returned empty endpoint id")
+	}
+	if ep.VpcEndpointType != ec2types.VpcEndpointTypeGateway {
+		t.Errorf("VpcEndpointType = %q, want Gateway", ep.VpcEndpointType)
+	}
+	if aws.ToString(ep.VpcId) != vpcID {
+		t.Errorf("VpcId = %q, want %q", aws.ToString(ep.VpcId), vpcID)
+	}
+	if string(ep.State) != "available" {
+		t.Errorf("State = %q, want available", ep.State)
+	}
+
+	desc, err := client.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
+		VpcEndpointIds: []string{epID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVpcEndpoints: %v", err)
+	}
+	if len(desc.VpcEndpoints) != 1 || aws.ToString(desc.VpcEndpoints[0].VpcEndpointId) != epID {
+		t.Fatalf("DescribeVpcEndpoints = %+v, want one endpoint %q", desc.VpcEndpoints, epID)
+	}
+
+	if _, err := client.DeleteVpcEndpoints(ctx, &ec2.DeleteVpcEndpointsInput{
+		VpcEndpointIds: []string{epID},
+	}); err != nil {
+		t.Fatalf("DeleteVpcEndpoints: %v", err)
+	}
+}
+
+// TestVPCEndpointInterfaceCarriesSubnetsAndGroups pins that an interface
+// endpoint (SSM/ECR style) retains the subnets and security groups it was
+// created with — Terraform reads these back to avoid drift.
+func TestVPCEndpointInterfaceCarriesSubnetsAndGroups(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	vpc, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+	vpcID := aws.ToString(vpc.Vpc.VpcId)
+
+	subnet, err := client.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId:     aws.String(vpcID),
+		CidrBlock: aws.String("10.0.1.0/24"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSubnet: %v", err)
+	}
+	subnetID := aws.ToString(subnet.Subnet.SubnetId)
+
+	sg, err := client.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String("ep-sg"),
+		Description: aws.String("endpoint sg"),
+		VpcId:       aws.String(vpcID),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecurityGroup: %v", err)
+	}
+	sgID := aws.ToString(sg.GroupId)
+
+	create, err := client.CreateVpcEndpoint(ctx, &ec2.CreateVpcEndpointInput{
+		VpcId:            aws.String(vpcID),
+		ServiceName:      aws.String("com.amazonaws.us-east-1.ssm"),
+		VpcEndpointType:  ec2types.VpcEndpointTypeInterface,
+		SubnetIds:        []string{subnetID},
+		SecurityGroupIds: []string{sgID},
+	})
+	if err != nil {
+		t.Fatalf("CreateVpcEndpoint: %v", err)
+	}
+
+	ep := create.VpcEndpoint
+	if len(ep.SubnetIds) != 1 || ep.SubnetIds[0] != subnetID {
+		t.Errorf("SubnetIds = %v, want [%s]", ep.SubnetIds, subnetID)
+	}
+}
+
+// TestDeleteVpcEndpointsIsIdempotent pins that deleting an unknown endpoint id
+// returns HTTP 200 with the id in the Unsuccessful set (not a top-level error),
+// so a re-run of a destroy over an already-gone endpoint still succeeds.
+func TestDeleteVpcEndpointsIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	out, err := client.DeleteVpcEndpoints(ctx, &ec2.DeleteVpcEndpointsInput{
+		VpcEndpointIds: []string{"vpce-00000000000000000"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteVpcEndpoints(unknown) returned top-level error: %v", err)
+	}
+	if len(out.Unsuccessful) != 1 {
+		t.Fatalf("Unsuccessful = %d, want 1", len(out.Unsuccessful))
+	}
+	if code := aws.ToString(out.Unsuccessful[0].Error.Code); code != "InvalidVpcEndpointId.NotFound" {
+		t.Errorf("Unsuccessful error code = %q, want InvalidVpcEndpointId.NotFound", code)
+	}
+}
+
+// TestDescribeVpcEndpointsUnknownIDNotFound pins that an explicit, well-formed
+// but non-existent endpoint id is InvalidVpcEndpointId.NotFound.
+func TestDescribeVpcEndpointsUnknownIDNotFound(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	_, err := client.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
+		VpcEndpointIds: []string{"vpce-00000000000000000"},
+	})
+	if err == nil {
+		t.Fatal("DescribeVpcEndpoints(unknown) succeeded, want error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidVpcEndpointId.NotFound" {
+		t.Fatalf("error = %v, want InvalidVpcEndpointId.NotFound", err)
+	}
+}

--- a/server/aws/ec2/vpc_peering_test.go
+++ b/server/aws/ec2/vpc_peering_test.go
@@ -2,10 +2,12 @@ package ec2_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	smithy "github.com/aws/smithy-go"
 )
 
 // TestVpcPeeringVpcInfoRoundTrip pins that DescribeVpcPeeringConnections fills
@@ -120,4 +122,24 @@ func mkPeeringVPC(t *testing.T, c *ec2.Client, cidr string) string {
 	}
 
 	return aws.ToString(vpc.Vpc.VpcId)
+}
+
+// TestDescribeVpcPeeringConnectionsUnknownIDNotFound pins that an explicit,
+// well-formed but non-existent pcx- id is InvalidVpcPeeringConnectionID.NotFound,
+// matching the convention DescribeVpcs/DescribeVolumes already follow.
+func TestDescribeVpcPeeringConnectionsUnknownIDNotFound(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	_, err := client.DescribeVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
+		VpcPeeringConnectionIds: []string{"pcx-00000000000000000"},
+	})
+	if err == nil {
+		t.Fatal("DescribeVpcPeeringConnections(unknown) succeeded, want error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidVpcPeeringConnectionID.NotFound" {
+		t.Fatalf("error = %v, want InvalidVpcPeeringConnectionID.NotFound", err)
+	}
 }

--- a/server/aws/ec2/xml.go
+++ b/server/aws/ec2/xml.go
@@ -72,6 +72,17 @@ type monitoringXML struct {
 	State string `xml:"state"`
 }
 
+// metadataOptionsXML is the nested <metadataOptions> element carrying an
+// instance's IMDS configuration.
+type metadataOptionsXML struct {
+	State                   string `xml:"state,omitempty"`
+	HTTPTokens              string `xml:"httpTokens,omitempty"`
+	HTTPPutResponseHopLimit int    `xml:"httpPutResponseHopLimit,omitempty"`
+	HTTPEndpoint            string `xml:"httpEndpoint,omitempty"`
+	HTTPProtocolIPv6        string `xml:"httpProtocolIpv6,omitempty"`
+	InstanceMetadataTags    string `xml:"instanceMetadataTags,omitempty"`
+}
+
 // instanceENIAttachmentXML is the primary ENI's <attachment> (deviceIndex 0).
 type instanceENIAttachmentXML struct {
 	DeviceIndex int    `xml:"deviceIndex"`
@@ -106,30 +117,31 @@ type operatorXML struct {
 // DescribeInstances responses. We populate only the fields the SDK reliably
 // consumes and real apps actually read; unused AWS fields are omitted.
 type instanceXML struct {
-	InstanceID         string           `xml:"instanceId"`
-	ImageID            string           `xml:"imageId"`
-	State              instanceState    `xml:"instanceState"`
-	InstanceType       string           `xml:"instanceType"`
-	LaunchTime         string           `xml:"launchTime,omitempty"`
-	SubnetID           string           `xml:"subnetId,omitempty"`
-	VPCID              string           `xml:"vpcId,omitempty"`
-	PrivateIP          string           `xml:"privateIpAddress,omitempty"`
-	PublicIP           string           `xml:"ipAddress,omitempty"`
-	PrivateDNSName     string           `xml:"privateDnsName,omitempty"`
-	PublicDNSName      string           `xml:"dnsName,omitempty"`
-	KeyName            string           `xml:"keyName,omitempty"`
-	AmiLaunchIndex     int              `xml:"amiLaunchIndex"`
-	Architecture       string           `xml:"architecture,omitempty"`
-	RootDeviceType     string           `xml:"rootDeviceType,omitempty"`
-	RootDeviceName     string           `xml:"rootDeviceName,omitempty"`
-	VirtualizationType string           `xml:"virtualizationType,omitempty"`
-	Hypervisor         string           `xml:"hypervisor,omitempty"`
-	Placement          *placementXML    `xml:"placement,omitempty"`
-	Monitoring         *monitoringXML   `xml:"monitoring,omitempty"`
-	Groups             []groupItem      `xml:"groupSet>item,omitempty"`
-	NetworkInterfaces  []instanceENIXML `xml:"networkInterfaceSet>item,omitempty"`
-	Tags               []tagItem        `xml:"tagSet>item,omitempty"`
-	Operator           *operatorXML     `xml:"operator,omitempty"`
+	InstanceID         string              `xml:"instanceId"`
+	ImageID            string              `xml:"imageId"`
+	State              instanceState       `xml:"instanceState"`
+	InstanceType       string              `xml:"instanceType"`
+	LaunchTime         string              `xml:"launchTime,omitempty"`
+	SubnetID           string              `xml:"subnetId,omitempty"`
+	VPCID              string              `xml:"vpcId,omitempty"`
+	PrivateIP          string              `xml:"privateIpAddress,omitempty"`
+	PublicIP           string              `xml:"ipAddress,omitempty"`
+	PrivateDNSName     string              `xml:"privateDnsName,omitempty"`
+	PublicDNSName      string              `xml:"dnsName,omitempty"`
+	KeyName            string              `xml:"keyName,omitempty"`
+	AmiLaunchIndex     int                 `xml:"amiLaunchIndex"`
+	Architecture       string              `xml:"architecture,omitempty"`
+	RootDeviceType     string              `xml:"rootDeviceType,omitempty"`
+	RootDeviceName     string              `xml:"rootDeviceName,omitempty"`
+	VirtualizationType string              `xml:"virtualizationType,omitempty"`
+	Hypervisor         string              `xml:"hypervisor,omitempty"`
+	Placement          *placementXML       `xml:"placement,omitempty"`
+	Monitoring         *monitoringXML      `xml:"monitoring,omitempty"`
+	MetadataOptions    *metadataOptionsXML `xml:"metadataOptions,omitempty"`
+	Groups             []groupItem         `xml:"groupSet>item,omitempty"`
+	NetworkInterfaces  []instanceENIXML    `xml:"networkInterfaceSet>item,omitempty"`
+	Tags               []tagItem           `xml:"tagSet>item,omitempty"`
+	Operator           *operatorXML        `xml:"operator,omitempty"`
 }
 
 // runInstancesResponse is the XML body for RunInstances.

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -77,6 +77,20 @@ type Instance struct {
 	// Operator carries service-provider managed-resource metadata. It is nil
 	// for ordinary (unmanaged) instances.
 	Operator *OperatorInfo
+	// MetadataOptions is the instance's IMDS configuration (AWS). The zero value
+	// means "not set"; the wire layer fills in EC2 defaults when rendering.
+	MetadataOptions MetadataOptions
+}
+
+// MetadataOptions is an instance's IMDS (instance metadata service)
+// configuration, set at launch and changed by ModifyInstanceMetadataOptions.
+type MetadataOptions struct {
+	State                   string // "applied", "pending"
+	HTTPTokens              string // "optional" (IMDSv1+v2), "required" (IMDSv2-only)
+	HTTPPutResponseHopLimit int
+	HTTPEndpoint            string // "enabled", "disabled"
+	HTTPProtocolIPv6        string // "enabled", "disabled"
+	InstanceMetadataTags    string // "enabled", "disabled"
 }
 
 // OperatorInfo describes the service-provider ownership of a managed resource.
@@ -339,6 +353,26 @@ type SnapshotInfo struct {
 	Progress string
 	// Encrypted indicates the snapshot is encrypted.
 	Encrypted bool
+	// CreateVolumePermissions holds the createVolumePermission attribute set by
+	// ModifySnapshotAttribute (snapshot sharing). Empty means private.
+	CreateVolumePermissions []SnapshotCreateVolumePermission
+}
+
+// SnapshotCreateVolumePermission is one createVolumePermission grant: either a
+// Group ("all" for public) or a specific UserID (account id).
+type SnapshotCreateVolumePermission struct {
+	Group  string
+	UserID string
+}
+
+// ModifySnapshotAttributeInput describes an AWS EC2 ModifySnapshotAttribute
+// request for the createVolumePermission attribute. OperationType is "add" or
+// "remove"; Groups and UserIDs are the grants added or removed.
+type ModifySnapshotAttributeInput struct {
+	SnapshotID    string
+	OperationType string
+	Groups        []string
+	UserIDs       []string
 }
 
 // ImageConfig describes a machine image to create.
@@ -375,6 +409,35 @@ type ImageInfo struct {
 	PlatformDetails string
 	// BlockDeviceMappings are the image's block device mappings.
 	BlockDeviceMappings []ImageBlockDeviceMapping
+	// LaunchPermissions holds the launchPermission attribute set by
+	// ModifyImageAttribute (AMI sharing). Empty means private.
+	LaunchPermissions []ImageLaunchPermission
+}
+
+// ImageLaunchPermission is one launchPermission grant on an AMI: either a Group
+// ("all" for public) or a specific UserID (account id).
+type ImageLaunchPermission struct {
+	Group  string
+	UserID string
+}
+
+// CopyImageInput describes an AWS EC2 CopyImage request. SourceRegion is
+// required by the API but ignored by the single-region emulator.
+type CopyImageInput struct {
+	SourceRegion  string
+	SourceImageID string
+	Name          string
+	Description   string
+	Tags          map[string]string
+}
+
+// ModifyImageAttributeInput describes an AWS EC2 ModifyImageAttribute request
+// for the launchPermission attribute. OperationType is "add" or "remove".
+type ModifyImageAttributeInput struct {
+	ImageID       string
+	OperationType string
+	Groups        []string
+	UserIDs       []string
 }
 
 // ImageBlockDeviceMapping is one entry in an image's block device mapping set.
@@ -464,6 +527,14 @@ type Compute interface {
 	DescribeKeyPairs(ctx context.Context, names []string) ([]KeyPairInfo, error)
 }
 
+// InstanceMetadataModifier is an optional AWS-only capability for
+// ec2:ModifyInstanceMetadataOptions (IMDS settings, e.g. enforcing IMDSv2 via
+// HttpTokens=required). A zero-value field in the update means "leave
+// unchanged". Discovered by type assertion.
+type InstanceMetadataModifier interface {
+	ModifyInstanceMetadataOptions(ctx context.Context, instanceID string, update MetadataOptions) (*MetadataOptions, error)
+}
+
 // ConsoleReader is an optional capability a Compute implementation may provide
 // to return an instance's console output. It is served by the real
 // config.ComputeEngine backing an instance; a provider with no engine wired
@@ -541,6 +612,58 @@ type SnapshotCopier interface {
 // (registering an AMI from block device mappings). Discovered by type assertion.
 type ImageRegistrar interface {
 	RegisterImage(ctx context.Context, input RegisterImageInput) (*ImageInfo, error)
+}
+
+// SnapshotAttributeModifier is an optional AWS-only capability for the EC2
+// snapshot-sharing round-trip: ModifySnapshotAttribute persists the
+// createVolumePermission attribute and DescribeSnapshotAttribute reads it back.
+// Discovered by type assertion.
+type SnapshotAttributeModifier interface {
+	ModifySnapshotAttribute(ctx context.Context, input ModifySnapshotAttributeInput) error
+	DescribeSnapshotVolumePermissions(ctx context.Context, snapshotID string) ([]SnapshotCreateVolumePermission, error)
+}
+
+// ImageCopier is an optional AWS-only capability for EC2 CopyImage (aws_ami_copy).
+// Discovered by type assertion.
+type ImageCopier interface {
+	CopyImage(ctx context.Context, input CopyImageInput) (*ImageInfo, error)
+}
+
+// PlacementGroupConfig describes an EC2 placement group to create.
+type PlacementGroupConfig struct {
+	Name           string
+	Strategy       string // "cluster", "spread", or "partition"
+	PartitionCount int
+	SpreadLevel    string
+	Tags           map[string]string
+}
+
+// PlacementGroup describes an EC2 placement group.
+type PlacementGroup struct {
+	ID             string
+	Name           string
+	Strategy       string
+	State          string // "available", "pending", "deleting", "deleted"
+	PartitionCount int
+	SpreadLevel    string
+	Tags           map[string]string
+}
+
+// PlacementGroups is an optional AWS-only capability for EC2 placement groups
+// (aws_placement_group). Discovered by type assertion.
+type PlacementGroups interface {
+	CreatePlacementGroup(ctx context.Context, config PlacementGroupConfig) (*PlacementGroup, error)
+	DeletePlacementGroup(ctx context.Context, name string) error
+	DescribePlacementGroups(ctx context.Context, names, ids []string) ([]PlacementGroup, error)
+}
+
+// ImageAttributeModifier is an optional AWS-only capability for the EC2 AMI
+// launchPermission round-trip: ModifyImageAttribute persists launchPermission
+// grants (aws_ami_launch_permission) and DescribeImageAttribute reads them back.
+// Discovered by type assertion.
+type ImageAttributeModifier interface {
+	ModifyImageAttribute(ctx context.Context, input ModifyImageAttributeInput) error
+	DescribeImageLaunchPermissions(ctx context.Context, imageID string) ([]ImageLaunchPermission, error)
 }
 
 // KeyPairImporter is an optional AWS-only capability for EC2 ImportKeyPair

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -321,6 +321,11 @@ type NetworkInterface struct {
 	AttachmentID string
 	Description  string
 	Tags         map[string]string
+	// InstanceID and DeviceIndex describe the attachment when the interface is
+	// attached to an instance (ec2:AttachNetworkInterface); both are empty/zero
+	// for an available interface.
+	InstanceID  string
+	DeviceIndex int
 }
 
 // Azure network interface (Microsoft.Network/networkInterfaces) is an
@@ -547,4 +552,13 @@ type NetworkInterfaces interface {
 // (e.g. resourcediscovery's read-only walker, which only needs Describe).
 type NetworkInterfaceCreator interface {
 	CreateNetworkInterface(ctx context.Context, subnetID, description string, groups []string, tags map[string]string) (*NetworkInterface, error)
+}
+
+// NetworkInterfaceAttacher is the AWS-specific ENI attach surface
+// (ec2:AttachNetworkInterface), completing the ENI attach/detach lifecycle. It
+// returns the new attachment id. The instance's existence is verified by the
+// wire layer (which holds the compute driver); the networking provider only
+// records the attachment.
+type NetworkInterfaceAttacher interface {
+	AttachNetworkInterface(ctx context.Context, networkInterfaceID, instanceID string, deviceIndex int) (string, error)
 }


### PR DESCRIPTION
Round-2 real-user audit fixes for the ec2-vpc-advanced cluster. Each change matches the real AWS wire contract (error code + HTTP status + response shape), verified against the EC2 API reference, and ships with real aws-sdk-go-v2 round-trip tests plus provider unit tests.

## Error-semantics fixes
- **AttachVolume** on a volume already attached to an instance now returns `VolumeInUse` (HTTP 400), mirroring the existing DeleteVolume precedent, instead of the generic `IncorrectState`.
- **DeleteFlowLogs** is idempotent: unknown/undeletable `fl-` ids are reported in the `<unsuccessful>` set with `InvalidFlowLogId.NotFound` and the call returns HTTP 200, so destroy/cleanup can safely re-run.
- **DeleteDhcpOptions** on a set still associated with a VPC returns `DependencyViolation` (HTTP 400); re-associating the VPC with the default set frees it for deletion.
- **DescribeDhcpOptions** / **DescribeVpcPeeringConnections** given an explicit, well-formed but non-existent id now return `InvalidDhcpOptionID.NotFound` / `InvalidVpcPeeringConnectionID.NotFound`, matching the convention already used by DescribeVpcs/DescribeVolumes.

## New operations
- **VPC endpoints**: `CreateVpcEndpoint` / `DeleteVpcEndpoints` / `DescribeVpcEndpoints` / `ModifyVpcEndpoint` (gateway + interface). Delete is idempotent; Describe is not-found for explicit ids; Modify applies the Add*/Remove* set mutations.
- **Placement groups**: `CreatePlacementGroup` / `DeletePlacementGroup` / `DescribePlacementGroups` (cluster/spread/partition; duplicate name → `InvalidPlacementGroup.Duplicate`).
- **AttachNetworkInterface** completes the ENI attach/detach lifecycle, verifying the instance against the compute driver and returning an `attachmentId`.
- **ModifyInstanceMetadataOptions** updates an instance's IMDS settings (e.g. `HttpTokens=required` to enforce IMDSv2); the change is reflected in `DescribeInstances`.
- **CopyImage** (aws_ami_copy) and **ModifyImageAttribute**/**DescribeImageAttribute** launchPermission (AMI sharing; `group=all` makes the AMI public).
- **ModifySnapshotAttribute** now persists `createVolumePermission`, read back by **DescribeSnapshotAttribute**.

## Notes
AWS-only operations are added as type-asserted optional interfaces on the shared compute/networking drivers, not as new methods every cloud must implement. Capability docs under `docs/coverage/` were regenerated from the driver interfaces.
