### PR TITLE
fix(azure-functions-aci): config/appsettings/host-keys sub-routes, containerinstances lifecycle/logs

### DIFF
--- a/docs/coverage/README.md
+++ b/docs/coverage/README.md
@@ -21,7 +21,7 @@ capability the code does not implement. Machine-readable: [`coverage.json`](./co
 | `cloudtrail` | [CloudTrail](./aws/cloudtrail.md) | — | — | — | 60 |
 | `compute` | [EC2](./aws/ec2.md) | [VirtualMachines](./azure/virtualmachines.md) | [GCE](./gcp/gce.md) | — | 37 |
 | `configservice` | [Config](./aws/config.md) | — | — | — | 102 |
-| `containerinstances` | — | [ContainerInstances](./azure/containerinstances.md) | — | — | 5 |
+| `containerinstances` | — | [ContainerInstances](./azure/containerinstances.md) | — | — | 9 |
 | `containerregistry` | [ECR](./aws/ecr.md) | [ACR](./azure/acr.md) | [ArtifactRegistry](./gcp/artifactregistry.md) | — | 14 |
 | `cosmospostgresql` | — | [CosmosPostgreSQL](./azure/cosmospostgresql.md) | — | — | 34 |
 | `database` | [DynamoDB](./aws/dynamodb.md) | [CosmosDB](./azure/cosmosdb.md) | [Firestore](./gcp/firestore.md) | — | 24 |

--- a/docs/coverage/azure/README.md
+++ b/docs/coverage/azure/README.md
@@ -9,7 +9,7 @@ Services cloudemu emulates for Azure, by native name. Back to the [cross-provide
 | [AI](./ai.md) | `azureai` | 92 |
 | [BlobStorage](./blobstorage.md) | `storage` | 35 |
 | [Cache](./cache.md) | `cache` | 17 |
-| [ContainerInstances](./containerinstances.md) | `containerinstances` | 5 |
+| [ContainerInstances](./containerinstances.md) | `containerinstances` | 9 |
 | [CosmosDB](./cosmosdb.md) | `database` | 24 |
 | [CosmosPostgreSQL](./cosmospostgresql.md) | `cosmospostgresql` | 34 |
 | [DNS](./dns.md) | `dns` | 16 |

--- a/docs/coverage/azure/containerinstances.md
+++ b/docs/coverage/azure/containerinstances.md
@@ -3,15 +3,19 @@
 
 Azure's `containerinstances` service · portable interface `driver.ContainerInstances` · [Azure index](./README.md)
 
-## Operations (5)
+## Operations (9)
 
 | Operation | Description |
 | --- | --- |
 | `ContainerLogs` | ContainerLogs returns the captured stdout/stderr for one container in the |
 | `CreateContainerGroup` | CreateContainerGroup creates the group, or replaces it when one of the |
 | `DeleteContainerGroup` | DeleteContainerGroup removes the group, tearing down any engine-backed |
+| `ExecContainer` | ExecContainer opens an exec session on one container in the group and |
 | `GetContainerGroup` | GetContainerGroup returns the recorded group, or a NotFound error. |
 | `ListContainerGroups` | ListContainerGroups returns the groups visible under filter. |
+| `RestartContainerGroup` | RestartContainerGroup restarts all containers in the group. Returns NotFound |
+| `StartContainerGroup` | StartContainerGroup starts all containers in a stopped group, allocating |
+| `StopContainerGroup` | StopContainerGroup stops all containers in the group and deallocates |
 
 ## Not in scope
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -2411,12 +2411,28 @@
         "doc": "DeleteContainerGroup removes the group, tearing down any engine-backed"
       },
       {
+        "name": "ExecContainer",
+        "doc": "ExecContainer opens an exec session on one container in the group and"
+      },
+      {
         "name": "GetContainerGroup",
         "doc": "GetContainerGroup returns the recorded group, or a NotFound error."
       },
       {
         "name": "ListContainerGroups",
         "doc": "ListContainerGroups returns the groups visible under filter."
+      },
+      {
+        "name": "RestartContainerGroup",
+        "doc": "RestartContainerGroup restarts all containers in the group. Returns NotFound"
+      },
+      {
+        "name": "StartContainerGroup",
+        "doc": "StartContainerGroup starts all containers in a stopped group, allocating"
+      },
+      {
+        "name": "StopContainerGroup",
+        "doc": "StopContainerGroup stops all containers in the group and deallocates"
       }
     ],
     "providers": {

--- a/providers/azure/containerinstances/containerinstances.go
+++ b/providers/azure/containerinstances/containerinstances.go
@@ -39,6 +39,7 @@ const (
 	groupStateRunning   = "Running"
 	groupStateSucceeded = "Succeeded"
 	groupStateFailed    = "Failed"
+	groupStateStopped   = "Stopped"
 
 	// Per-container instanceView.currentState states (ACI vocabulary).
 	containerStateRunning    = "Running"
@@ -95,6 +96,7 @@ func (m *Mock) CreateContainerGroup(ctx context.Context, cfg driver.ContainerGro
 		ProvisioningState: provisioningStateSucceeded,
 		State:             groupStateRunning,
 		Containers:        synthContainers(cfg.Containers),
+		IPAddress:         assignIPAddress(cfg.IPAddress, cfg.Location),
 		Tags:              cfg.Tags,
 		Scope:             cfg.Scope,
 	}

--- a/providers/azure/containerinstances/lifecycle.go
+++ b/providers/azure/containerinstances/lifecycle.go
@@ -1,0 +1,225 @@
+package containerinstances
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"hash/fnv"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/container/containerengine"
+	"github.com/stackshy/cloudemu/v2/services/containerinstances/driver"
+)
+
+const (
+	// aciDNSSuffix is the DNS zone ACI assigns public container-group FQDNs under.
+	aciDNSSuffix = "azurecontainer.io"
+	// defaultIPLocation is used when a Public group is created without a location.
+	defaultIPLocation = "eastus"
+
+	octetMask     = 0xFF
+	octetCount    = 4
+	octetShift    = 8
+	passwordBytes = 16
+)
+
+// assignIPAddress echoes back the requested IP configuration and, for a Public
+// group with a DNS name label, assigns a public IP and computes the FQDN Azure
+// would hand out (<label>.<location>.azurecontainer.io).
+func assignIPAddress(in *driver.IPAddress, location string) *driver.IPAddress {
+	if in == nil {
+		return nil
+	}
+
+	out := *in
+	out.Ports = append([]driver.Port(nil), in.Ports...)
+
+	if !strings.EqualFold(out.Type, "Public") {
+		return &out
+	}
+
+	if out.IP == "" {
+		out.IP = synthPublicIP(out.DNSNameLabel + location)
+	}
+
+	if out.DNSNameLabel != "" && out.FQDN == "" {
+		loc := location
+		if loc == "" {
+			loc = defaultIPLocation
+		}
+
+		out.FQDN = out.DNSNameLabel + "." + loc + "." + aciDNSSuffix
+	}
+
+	return &out
+}
+
+// synthPublicIP derives a stable, non-routable-looking public IP from seed so a
+// group keeps the same address across reads.
+func synthPublicIP(seed string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(seed))
+	v := h.Sum32()
+
+	octets := make([]string, octetCount)
+	for i := 0; i < octetCount; i++ {
+		octets[i] = fmt.Sprintf("%d", (v>>(octetShift*uint(i)))&octetMask)
+	}
+
+	// Keep the leading octet away from 0 so it reads as a real address.
+	if octets[0] == "0" {
+		octets[0] = "20"
+	}
+
+	return strings.Join(octets, ".")
+}
+
+// StartContainerGroup restarts the group's workload and returns it to Running.
+func (m *Mock) StartContainerGroup(ctx context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	data, ok := m.groups.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container group %q not found", name)
+	}
+
+	return m.runGroup(ctx, data)
+}
+
+// StopContainerGroup tears down the workload and marks the group Stopped.
+func (m *Mock) StopContainerGroup(ctx context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	data, ok := m.groups.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container group %q not found", name)
+	}
+
+	m.stopWorkload(ctx, data)
+	data.engineBacked = false
+	data.handle = ""
+	data.group.State = groupStateStopped
+
+	for i := range data.group.Containers {
+		data.group.Containers[i].Current = driver.ContainerState{State: containerStateTerminated}
+	}
+
+	m.groups.Set(name, data)
+
+	return nil
+}
+
+// RestartContainerGroup tears the workload down and runs it again.
+func (m *Mock) RestartContainerGroup(ctx context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	data, ok := m.groups.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container group %q not found", name)
+	}
+
+	m.stopWorkload(ctx, data)
+
+	return m.runGroup(ctx, data)
+}
+
+// runGroup resets the group to a fresh Running state and re-runs it on the
+// engine (a no-op when none is configured), reflecting the observed state back.
+func (m *Mock) runGroup(ctx context.Context, data *groupData) error {
+	cfg := driver.ContainerGroupConfig{
+		Name:          data.group.Name,
+		RestartPolicy: data.group.RestartPolicy,
+		Containers:    configsFromInstances(data.group.Containers),
+	}
+
+	data.group.State = groupStateRunning
+	data.group.Containers = synthContainers(cfg.Containers)
+	data.engineBacked = false
+	data.handle = ""
+
+	if err := m.backWithEngine(ctx, &cfg, data); err != nil {
+		return err
+	}
+
+	m.groups.Set(cfg.Name, data)
+
+	return nil
+}
+
+// ExecContainer opens an exec session on one container. When the group is
+// engine-backed the command runs for real on the engine before the session
+// descriptor is returned.
+func (m *Mock) ExecContainer(
+	ctx context.Context, group, container string, command []string,
+) (*driver.ExecSession, error) {
+	data, ok := m.groups.Get(group)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container group %q not found", group)
+	}
+
+	if !containerExists(&data.group, container) {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found in group %q", container, group)
+	}
+
+	if data.engineBacked {
+		if _, err := containerengine.Exec(ctx, m.opts.ContainerEngine, data.handle, container, command); err != nil {
+			return nil, cerrors.Newf(cerrors.Internal, "exec in container %q: %v", container, err)
+		}
+	}
+
+	loc := data.group.Location
+	if loc == "" {
+		loc = defaultIPLocation
+	}
+
+	return &driver.ExecSession{
+		WebSocketURI: "wss://" + loc + "." + aciDNSSuffix + "/exec/" + group + "/" + container,
+		Password:     randomToken(),
+	}, nil
+}
+
+// containerExists reports whether the group holds a container of the given name.
+func containerExists(g *driver.ContainerGroup, name string) bool {
+	for i := range g.Containers {
+		if g.Containers[i].Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// configsFromInstances rebuilds the create-time container configs from a group's
+// recorded instances, so a stopped group can be run again.
+func configsFromInstances(in []driver.ContainerInstance) []driver.ContainerConfig {
+	out := make([]driver.ContainerConfig, 0, len(in))
+
+	for i := range in {
+		c := &in[i]
+		out = append(out, driver.ContainerConfig{
+			Name:       c.Name,
+			Image:      c.Image,
+			Command:    append([]string(nil), c.Command...),
+			CPU:        c.CPU,
+			MemoryInGB: c.MemoryInGB,
+			Env:        append([]driver.EnvVar(nil), c.Env...),
+		})
+	}
+
+	return out
+}
+
+// randomToken returns a hex secret for an exec session password.
+func randomToken() string {
+	buf := make([]byte, passwordBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "cloudemu-exec-password"
+	}
+
+	return hex.EncodeToString(buf)
+}

--- a/providers/azure/containerinstances/lifecycle_test.go
+++ b/providers/azure/containerinstances/lifecycle_test.go
@@ -1,0 +1,138 @@
+package containerinstances
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/containerinstances/driver"
+)
+
+// execEngine records exec calls so tests can assert the engine is driven.
+type execEngine struct {
+	recordingEngine
+	execContainers []string
+}
+
+func (e *execEngine) Exec(_ context.Context, _, container string, _ []string) (config.ExecResult, error) {
+	e.execContainers = append(e.execContainers, container)
+
+	return config.ExecResult{Stdout: "ok"}, nil
+}
+
+func TestAssignsPublicIPAddress(t *testing.T) {
+	m := New(config.NewOptions())
+
+	cfg := sampleConfig()
+	cfg.Location = "westus2"
+	cfg.IPAddress = &driver.IPAddress{
+		Type:         "Public",
+		DNSNameLabel: "myapp",
+		Ports:        []driver.Port{{Port: 80, Protocol: "TCP"}},
+	}
+
+	group, err := m.CreateContainerGroup(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if group.IPAddress == nil || group.IPAddress.IP == "" {
+		t.Fatalf("public group got no assigned ip: %+v", group.IPAddress)
+	}
+
+	if group.IPAddress.FQDN != "myapp.westus2.azurecontainer.io" {
+		t.Fatalf("fqdn = %q, want myapp.westus2.azurecontainer.io", group.IPAddress.FQDN)
+	}
+}
+
+func TestPrivateIPAddressGetsNoFQDN(t *testing.T) {
+	m := New(config.NewOptions())
+
+	cfg := sampleConfig()
+	cfg.IPAddress = &driver.IPAddress{Type: "Private"}
+
+	group, err := m.CreateContainerGroup(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if group.IPAddress.IP != "" || group.IPAddress.FQDN != "" {
+		t.Fatalf("private group should get no public ip/fqdn: %+v", group.IPAddress)
+	}
+}
+
+func TestStopStartRestartStateTransitions(t *testing.T) {
+	m := New(config.NewOptions())
+	ctx := context.Background()
+
+	if _, err := m.CreateContainerGroup(ctx, sampleConfig()); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if err := m.StopContainerGroup(ctx, "cg1"); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	g, _ := m.GetContainerGroup(ctx, "cg1")
+	if g.State != groupStateStopped || g.Containers[0].Current.State != containerStateTerminated {
+		t.Fatalf("after stop: group=%q container=%q", g.State, g.Containers[0].Current.State)
+	}
+
+	if err := m.StartContainerGroup(ctx, "cg1"); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	g, _ = m.GetContainerGroup(ctx, "cg1")
+	if g.State != groupStateRunning {
+		t.Fatalf("after start: group state = %q, want Running", g.State)
+	}
+
+	if err := m.RestartContainerGroup(ctx, "cg1"); err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+
+	// Missing group → NotFound for each verb.
+	for _, err := range []error{
+		m.StopContainerGroup(ctx, "ghost"),
+		m.StartContainerGroup(ctx, "ghost"),
+		m.RestartContainerGroup(ctx, "ghost"),
+	} {
+		if !cerrors.IsNotFound(err) {
+			t.Fatalf("lifecycle on missing group = %v, want NotFound", err)
+		}
+	}
+}
+
+func TestExecValidatesAndDrivesEngine(t *testing.T) {
+	eng := &execEngine{recordingEngine: recordingEngine{handle: "h1"}}
+	m := New(config.NewOptions(config.WithContainerEngine(eng)))
+	ctx := context.Background()
+
+	if _, err := m.CreateContainerGroup(ctx, sampleConfig()); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	session, err := m.ExecContainer(ctx, "cg1", "app", []string{"ls", "-la"})
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+
+	if session.WebSocketURI == "" || session.Password == "" {
+		t.Fatalf("exec session incomplete: %+v", session)
+	}
+
+	if len(eng.execContainers) != 1 || eng.execContainers[0] != "app" {
+		t.Fatalf("engine exec not driven: %v", eng.execContainers)
+	}
+
+	// Unknown container → NotFound.
+	if _, err := m.ExecContainer(ctx, "cg1", "ghost", []string{"ls"}); !cerrors.IsNotFound(err) {
+		t.Fatalf("exec on missing container = %v, want NotFound", err)
+	}
+
+	// Unknown group → NotFound.
+	if _, err := m.ExecContainer(ctx, "ghost", "app", []string{"ls"}); !cerrors.IsNotFound(err) {
+		t.Fatalf("exec on missing group = %v, want NotFound", err)
+	}
+}

--- a/providers/azure/functions/functions.go
+++ b/providers/azure/functions/functions.go
@@ -63,11 +63,13 @@ type Mock struct {
 	layers     *memstore.Store[*layerData]
 	mappings   *memstore.Store[*driver.EventSourceMappingInfo]
 	plans      *memstore.Store[*AppServicePlan]
+	sites      *memstore.Store[*SiteMeta]
 	opts       *config.Options
 	handlersMu sync.RWMutex
 	handlers   map[string]driver.HandlerFunc
 	monitoring mondriver.Monitoring
-	mu         sync.Mutex // guards PublishVersion read-modify-write on funcData
+	mu         sync.Mutex   // guards PublishVersion read-modify-write on funcData
+	sitesMu    sync.RWMutex // guards SiteMeta read-modify-write
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -104,6 +106,7 @@ func New(opts *config.Options) *Mock {
 		layers:   memstore.New[*layerData](),
 		mappings: memstore.New[*driver.EventSourceMappingInfo](),
 		plans:    memstore.New[*AppServicePlan](),
+		sites:    memstore.New[*SiteMeta](),
 		opts:     opts,
 		handlers: make(map[string]driver.HandlerFunc),
 	}

--- a/providers/azure/functions/site_meta.go
+++ b/providers/azure/functions/site_meta.go
@@ -1,0 +1,272 @@
+package functions
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"maps"
+	"sort"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// keyBytes is the entropy of a generated function/host key before base64.
+const keyBytes = 32
+
+// defaultKeyName is the name of the default key Azure provisions for a host and
+// for each function.
+const defaultKeyName = "default"
+
+// SiteFunction is one function deployed to a function app
+// (Microsoft.Web/sites/functions). Azure discovers these from the deployed
+// code; here they are created explicitly via the ARM CreateFunction PUT.
+type SiteFunction struct {
+	Name       string
+	Config     map[string]any
+	Language   string
+	IsDisabled bool
+	Keys       map[string]string
+}
+
+// SiteMeta holds the Azure-specific state of a function app that the portable
+// serverless FunctionInfo does not model: the region it was created in, its
+// plan/HTTPS flags, the app settings (with values), and the host/function keys.
+// It is stored alongside the portable function so a Microsoft.Web/sites request
+// can reconstruct the full ARM site resource.
+type SiteMeta struct {
+	Name              string
+	Subscription      string
+	ResourceGroup     string
+	Location          string
+	ServerFarmID      string
+	HTTPSOnly         bool
+	Reserved          bool
+	LinuxFxVersion    string
+	ProvisioningState string
+	AppSettings       map[string]string
+	MasterKey         string
+	HostFunctionKeys  map[string]string
+	SystemKeys        map[string]string
+	Functions         map[string]*SiteFunction
+}
+
+// clone returns a deep copy safe to hand outside the store lock.
+func (s *SiteMeta) clone() *SiteMeta {
+	out := *s
+	out.AppSettings = maps.Clone(s.AppSettings)
+	out.HostFunctionKeys = maps.Clone(s.HostFunctionKeys)
+	out.SystemKeys = maps.Clone(s.SystemKeys)
+	out.Functions = make(map[string]*SiteFunction, len(s.Functions))
+
+	for name, fn := range s.Functions {
+		out.Functions[name] = fn.clone()
+	}
+
+	return &out
+}
+
+func (f *SiteFunction) clone() *SiteFunction {
+	out := *f
+	out.Config = maps.Clone(f.Config)
+	out.Keys = maps.Clone(f.Keys)
+
+	return &out
+}
+
+// UpsertSiteMeta creates the site metadata on first call and updates the mutable
+// fields on subsequent calls, preserving generated keys and deployed functions.
+//
+//nolint:gocritic // in is the by-value request payload, cloned on store.
+func (m *Mock) UpsertSiteMeta(_ context.Context, in SiteMeta) (*SiteMeta, error) {
+	m.sitesMu.Lock()
+	defer m.sitesMu.Unlock()
+
+	if existing, ok := m.sites.Get(in.Name); ok {
+		existing.Location = in.Location
+		existing.ServerFarmID = in.ServerFarmID
+		existing.HTTPSOnly = in.HTTPSOnly
+		existing.Reserved = in.Reserved
+		existing.LinuxFxVersion = in.LinuxFxVersion
+		existing.AppSettings = maps.Clone(in.AppSettings)
+		m.sites.Set(in.Name, existing)
+
+		return existing.clone(), nil
+	}
+
+	meta := in.clone()
+	meta.ProvisioningState = "Succeeded"
+	meta.MasterKey = generateKey()
+	meta.HostFunctionKeys = map[string]string{defaultKeyName: generateKey()}
+	meta.SystemKeys = map[string]string{}
+
+	if meta.Functions == nil {
+		meta.Functions = map[string]*SiteFunction{}
+	}
+
+	m.sites.Set(in.Name, meta)
+
+	return meta.clone(), nil
+}
+
+// GetSiteMeta returns the site metadata, or NotFound.
+func (m *Mock) GetSiteMeta(_ context.Context, name string) (*SiteMeta, error) {
+	m.sitesMu.RLock()
+	defer m.sitesMu.RUnlock()
+
+	meta, ok := m.sites.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "site %s not found", name)
+	}
+
+	return meta.clone(), nil
+}
+
+// DeleteSiteMeta removes the site metadata. Missing sites are ignored so it can
+// trail a portable DeleteFunction without racing.
+func (m *Mock) DeleteSiteMeta(_ context.Context, name string) error {
+	m.sitesMu.Lock()
+	defer m.sitesMu.Unlock()
+
+	m.sites.Delete(name)
+
+	return nil
+}
+
+// ListSiteMeta returns the sites in the given resource group, or all sites in
+// the subscription when resourceGroup is empty.
+func (m *Mock) ListSiteMeta(_ context.Context, subscription, resourceGroup string) ([]SiteMeta, error) {
+	m.sitesMu.RLock()
+	defer m.sitesMu.RUnlock()
+
+	all := m.sites.All()
+	out := make([]SiteMeta, 0, len(all))
+
+	for _, meta := range all {
+		if subscription != "" && meta.Subscription != subscription {
+			continue
+		}
+
+		if resourceGroup != "" && meta.ResourceGroup != resourceGroup {
+			continue
+		}
+
+		out = append(out, *meta.clone())
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+
+	return out, nil
+}
+
+// CreateSiteFunction adds a function to a site, generating its default key.
+func (m *Mock) CreateSiteFunction(_ context.Context, site string, fn SiteFunction) (*SiteFunction, error) {
+	m.sitesMu.Lock()
+	defer m.sitesMu.Unlock()
+
+	meta, ok := m.sites.Get(site)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "site %s not found", site)
+	}
+
+	stored := fn.clone()
+	if len(stored.Keys) == 0 {
+		stored.Keys = map[string]string{defaultKeyName: generateKey()}
+	}
+
+	meta.Functions[fn.Name] = stored
+	m.sites.Set(site, meta)
+
+	return stored.clone(), nil
+}
+
+// GetSiteFunction returns one function of a site, or NotFound.
+func (m *Mock) GetSiteFunction(_ context.Context, site, name string) (*SiteFunction, error) {
+	m.sitesMu.RLock()
+	defer m.sitesMu.RUnlock()
+
+	fn, err := m.lookupFunction(site, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return fn.clone(), nil
+}
+
+// ListSiteFunctions returns a site's functions sorted by name, or NotFound when
+// the site does not exist.
+func (m *Mock) ListSiteFunctions(_ context.Context, site string) ([]SiteFunction, error) {
+	m.sitesMu.RLock()
+	defer m.sitesMu.RUnlock()
+
+	meta, ok := m.sites.Get(site)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "site %s not found", site)
+	}
+
+	out := make([]SiteFunction, 0, len(meta.Functions))
+	for _, fn := range meta.Functions {
+		out = append(out, *fn.clone())
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+
+	return out, nil
+}
+
+// DeleteSiteFunction removes a function from a site.
+func (m *Mock) DeleteSiteFunction(_ context.Context, site, name string) error {
+	m.sitesMu.Lock()
+	defer m.sitesMu.Unlock()
+
+	meta, ok := m.sites.Get(site)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "site %s not found", site)
+	}
+
+	if _, ok := meta.Functions[name]; !ok {
+		return cerrors.Newf(cerrors.NotFound, "function %s not found", name)
+	}
+
+	delete(meta.Functions, name)
+	m.sites.Set(site, meta)
+
+	return nil
+}
+
+// FunctionKeys returns the keys of one function, or NotFound.
+func (m *Mock) FunctionKeys(_ context.Context, site, name string) (map[string]string, error) {
+	m.sitesMu.RLock()
+	defer m.sitesMu.RUnlock()
+
+	fn, err := m.lookupFunction(site, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return maps.Clone(fn.Keys), nil
+}
+
+// lookupFunction resolves a function within a site under the caller's lock.
+func (m *Mock) lookupFunction(site, name string) (*SiteFunction, error) {
+	meta, ok := m.sites.Get(site)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "site %s not found", site)
+	}
+
+	fn, ok := meta.Functions[name]
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", name)
+	}
+
+	return fn, nil
+}
+
+// generateKey returns a URL-safe base64 secret used for host and function keys.
+func generateKey() string {
+	buf := make([]byte, keyBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "cloudemu-key"
+	}
+
+	return base64.RawURLEncoding.EncodeToString(buf)
+}

--- a/providers/azure/functions/site_meta_test.go
+++ b/providers/azure/functions/site_meta_test.go
@@ -1,0 +1,140 @@
+package functions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+func newMetaMock() *Mock {
+	return New(config.NewOptions(config.WithAccountID("test-sub")))
+}
+
+func TestUpsertSiteMetaGeneratesAndPreservesKeys(t *testing.T) {
+	m := newMetaMock()
+	ctx := context.Background()
+
+	created, err := m.UpsertSiteMeta(ctx, SiteMeta{
+		Name: "app1", Subscription: "sub1", ResourceGroup: "rgA",
+		Location: "westus2", AppSettings: map[string]string{"FOO": "bar"},
+	})
+	if err != nil {
+		t.Fatalf("upsert create: %v", err)
+	}
+
+	if created.MasterKey == "" || created.HostFunctionKeys["default"] == "" {
+		t.Fatalf("keys not generated: %+v", created)
+	}
+
+	if created.ProvisioningState != "Succeeded" {
+		t.Fatalf("provisioningState = %q", created.ProvisioningState)
+	}
+
+	masterKey := created.MasterKey
+
+	// An update keeps the generated keys and updates the mutable fields.
+	updated, err := m.UpsertSiteMeta(ctx, SiteMeta{
+		Name: "app1", Subscription: "sub1", ResourceGroup: "rgA",
+		Location: "eastus", AppSettings: map[string]string{"FOO": "baz"},
+	})
+	if err != nil {
+		t.Fatalf("upsert update: %v", err)
+	}
+
+	if updated.MasterKey != masterKey {
+		t.Fatalf("master key changed on update: %q -> %q", masterKey, updated.MasterKey)
+	}
+
+	if updated.Location != "eastus" || updated.AppSettings["FOO"] != "baz" {
+		t.Fatalf("mutable fields not updated: %+v", updated)
+	}
+}
+
+func TestListSiteMetaFiltersByScope(t *testing.T) {
+	m := newMetaMock()
+	ctx := context.Background()
+
+	put := func(name, rg string) {
+		if _, err := m.UpsertSiteMeta(ctx, SiteMeta{Name: name, Subscription: "sub1", ResourceGroup: rg}); err != nil {
+			t.Fatalf("upsert %s: %v", name, err)
+		}
+	}
+	put("a1", "rgA")
+	put("a2", "rgA")
+	put("b1", "rgB")
+
+	inRG, err := m.ListSiteMeta(ctx, "sub1", "rgA")
+	if err != nil {
+		t.Fatalf("list rgA: %v", err)
+	}
+
+	if len(inRG) != 2 {
+		t.Fatalf("rgA list = %d, want 2", len(inRG))
+	}
+
+	subWide, err := m.ListSiteMeta(ctx, "sub1", "")
+	if err != nil {
+		t.Fatalf("list sub-wide: %v", err)
+	}
+
+	if len(subWide) != 3 {
+		t.Fatalf("sub-wide list = %d, want 3", len(subWide))
+	}
+}
+
+func TestSiteFunctionsLifecycle(t *testing.T) {
+	m := newMetaMock()
+	ctx := context.Background()
+
+	if _, err := m.UpsertSiteMeta(ctx, SiteMeta{Name: "app1", Subscription: "sub1", ResourceGroup: "rgA"}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// A fresh app has no functions and a missing one is NotFound.
+	fns, err := m.ListSiteFunctions(ctx, "app1")
+	if err != nil {
+		t.Fatalf("list functions: %v", err)
+	}
+
+	if len(fns) != 0 {
+		t.Fatalf("fresh app functions = %d, want 0", len(fns))
+	}
+
+	if _, err := m.GetSiteFunction(ctx, "app1", "ghost"); !cerrors.IsNotFound(err) {
+		t.Fatalf("get missing function = %v, want NotFound", err)
+	}
+
+	// Create one and read it back with a generated default key.
+	created, err := m.CreateSiteFunction(ctx, "app1", SiteFunction{Name: "fn1", Language: "python"})
+	if err != nil {
+		t.Fatalf("create function: %v", err)
+	}
+
+	if created.Keys["default"] == "" {
+		t.Fatalf("function default key not generated: %+v", created)
+	}
+
+	keys, err := m.FunctionKeys(ctx, "app1", "fn1")
+	if err != nil {
+		t.Fatalf("function keys: %v", err)
+	}
+
+	if keys["default"] != created.Keys["default"] {
+		t.Fatalf("function keys mismatch")
+	}
+
+	if err := m.DeleteSiteFunction(ctx, "app1", "fn1"); err != nil {
+		t.Fatalf("delete function: %v", err)
+	}
+
+	if _, err := m.GetSiteFunction(ctx, "app1", "fn1"); !cerrors.IsNotFound(err) {
+		t.Fatalf("get deleted function = %v, want NotFound", err)
+	}
+
+	// Operations on a missing site are NotFound.
+	if _, err := m.CreateSiteFunction(ctx, "ghost", SiteFunction{Name: "fn"}); !cerrors.IsNotFound(err) {
+		t.Fatalf("create on missing site = %v, want NotFound", err)
+	}
+}

--- a/server/azure/containerinstances/handler.go
+++ b/server/azure/containerinstances/handler.go
@@ -26,10 +26,17 @@ const (
 	providerName        = "Microsoft.ContainerInstance"
 	typeContainerGroups = "containerGroups"
 
-	// subResourceContainers and subActionLogs identify the per-container logs
-	// sub-path .../containerGroups/{cg}/containers/{c}/logs.
+	// subResourceContainers identifies the per-container sub-path
+	// .../containerGroups/{cg}/containers/{c}/{action}; subActionLogs and
+	// subActionExec are the actions served on it.
 	subResourceContainers = "containers"
 	subActionLogs         = "logs"
+	subActionExec         = "exec"
+
+	// Container-group lifecycle POST verbs .../containerGroups/{cg}/{verb}.
+	subActionStart   = "start"
+	subActionStop    = "stop"
+	subActionRestart = "restart"
 )
 
 // Handler serves Microsoft.ContainerInstance/containerGroups ARM requests
@@ -64,9 +71,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Per-container logs: .../containerGroups/{cg}/containers/{c}/logs
-	if rp.SubResource == subResourceContainers && rp.SubResourceAction == subActionLogs {
-		h.containerLogs(w, r, &rp)
+	// Per-container sub-paths: .../containers/{c}/logs and .../containers/{c}/exec.
+	if rp.SubResource == subResourceContainers {
+		h.serveContainerAction(w, r, &rp)
+
+		return
+	}
+
+	// Group lifecycle verbs: .../containerGroups/{cg}/{start|stop|restart}.
+	if rp.ResourceName != "" && rp.SubResource != "" {
+		h.serveGroupAction(w, r, &rp)
 
 		return
 	}
@@ -91,6 +105,34 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.getGroup(w, r, &rp)
 	case http.MethodDelete:
 		h.deleteGroup(w, r, &rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+// serveContainerAction routes the per-container sub-paths (logs, exec).
+func (h *Handler) serveContainerAction(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	switch rp.SubResourceAction {
+	case subActionLogs:
+		h.containerLogs(w, r, rp)
+	case subActionExec:
+		h.execContainer(w, r, rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+// serveGroupAction routes the container-group lifecycle POST verbs.
+func (h *Handler) serveGroupAction(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+
+		return
+	}
+
+	switch rp.SubResource {
+	case subActionStart, subActionStop, subActionRestart:
+		h.lifecycleGroup(w, r, rp)
 	default:
 		writeMethodNotAllowed(w)
 	}

--- a/server/azure/containerinstances/lifecycle_test.go
+++ b/server/azure/containerinstances/lifecycle_test.go
@@ -1,0 +1,126 @@
+package containerinstances_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+	"net/http/httptest"
+)
+
+func TestContainerGroupUpdateReturns200(t *testing.T) {
+	cloud := cloudemu.NewAzure()
+	srv := httptest.NewServer(azureserver.New(azureserver.DriversFrom(cloud)))
+	t.Cleanup(srv.Close)
+
+	// First PUT creates → 201.
+	doReq(t, srv.URL, http.MethodPut, groupURL("cg2")+apiVer, strings.NewReader(createBody), http.StatusCreated)
+	// Second PUT is an in-place update → 200.
+	doReq(t, srv.URL, http.MethodPut, groupURL("cg2")+apiVer, strings.NewReader(createBody), http.StatusOK)
+}
+
+func TestContainerGroupLifecycleVerbs(t *testing.T) {
+	cloud := cloudemu.NewAzure()
+	srv := httptest.NewServer(azureserver.New(azureserver.DriversFrom(cloud)))
+	t.Cleanup(srv.Close)
+
+	doReq(t, srv.URL, http.MethodPut, groupURL("cg1")+apiVer, strings.NewReader(createBody), http.StatusCreated)
+
+	// Stop → 204, group reports Stopped.
+	doReq(t, srv.URL, http.MethodPost, groupURL("cg1")+"/stop"+apiVer, nil, http.StatusNoContent)
+
+	got := decodeGroup(t, doReq(t, srv.URL, http.MethodGet, groupURL("cg1")+apiVer, nil, http.StatusOK))
+	if got.Properties.InstanceView.State != "Stopped" {
+		t.Fatalf("after stop, group state = %q, want Stopped", got.Properties.InstanceView.State)
+	}
+
+	// Start → 204, group reports Running again.
+	doReq(t, srv.URL, http.MethodPost, groupURL("cg1")+"/start"+apiVer, nil, http.StatusNoContent)
+
+	got = decodeGroup(t, doReq(t, srv.URL, http.MethodGet, groupURL("cg1")+apiVer, nil, http.StatusOK))
+	if got.Properties.InstanceView.State != "Running" {
+		t.Fatalf("after start, group state = %q, want Running", got.Properties.InstanceView.State)
+	}
+
+	// Restart → 204.
+	doReq(t, srv.URL, http.MethodPost, groupURL("cg1")+"/restart"+apiVer, nil, http.StatusNoContent)
+
+	// A lifecycle verb on a missing group → 404.
+	doReq(t, srv.URL, http.MethodPost, groupURL("missing")+"/stop"+apiVer, nil, http.StatusNotFound)
+}
+
+func TestContainerExecReturnsSession(t *testing.T) {
+	eng := &recordingEngine{logs: "out"}
+	cloud := cloudemu.NewAzure(config.WithContainerEngine(eng))
+	srv := httptest.NewServer(azureserver.New(azureserver.DriversFrom(cloud)))
+	t.Cleanup(srv.Close)
+
+	doReq(t, srv.URL, http.MethodPut, groupURL("cg1")+apiVer, strings.NewReader(createBody), http.StatusCreated)
+
+	execBody := `{"command":"/bin/sh -c ls","terminalSize":{"rows":24,"cols":80}}`
+	body := doReq(t, srv.URL, http.MethodPost,
+		groupURL("cg1")+"/containers/app/exec"+apiVer, strings.NewReader(execBody), http.StatusOK)
+
+	var got struct {
+		WebSocketURI string `json:"webSocketUri"`
+		Password     string `json:"password"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode exec response: %v", err)
+	}
+
+	if got.WebSocketURI == "" || !strings.HasPrefix(got.WebSocketURI, "wss://") {
+		t.Fatalf("webSocketUri = %q, want a wss:// uri", got.WebSocketURI)
+	}
+
+	if got.Password == "" {
+		t.Fatalf("password is empty")
+	}
+
+	// Exec on a container that isn't in the group → 404.
+	doReq(t, srv.URL, http.MethodPost,
+		groupURL("cg1")+"/containers/ghost/exec"+apiVer, strings.NewReader(execBody), http.StatusNotFound)
+}
+
+func TestPublicIPAddressAssigned(t *testing.T) {
+	cloud := cloudemu.NewAzure()
+	srv := httptest.NewServer(azureserver.New(azureserver.DriversFrom(cloud)))
+	t.Cleanup(srv.Close)
+
+	body := `{
+      "location": "westus2",
+      "properties": {
+        "osType": "Linux",
+        "ipAddress": {"type": "Public", "dnsNameLabel": "myapp", "ports": [{"port": 80, "protocol": "TCP"}]},
+        "containers": [{"name": "app", "properties": {"image": "nginx"}}]
+      }
+    }`
+
+	raw := doReq(t, srv.URL, http.MethodPut, groupURL("pub")+apiVer, strings.NewReader(body), http.StatusCreated)
+
+	var got struct {
+		Properties struct {
+			IPAddress struct {
+				Type         string `json:"type"`
+				IP           string `json:"ip"`
+				FQDN         string `json:"fqdn"`
+				DNSNameLabel string `json:"dnsNameLabel"`
+			} `json:"ipAddress"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got.Properties.IPAddress.IP == "" {
+		t.Fatalf("public group got no assigned ip: %s", raw)
+	}
+
+	if got.Properties.IPAddress.FQDN != "myapp.westus2.azurecontainer.io" {
+		t.Fatalf("fqdn = %q, want myapp.westus2.azurecontainer.io", got.Properties.IPAddress.FQDN)
+	}
+}

--- a/server/azure/containerinstances/operations.go
+++ b/server/azure/containerinstances/operations.go
@@ -3,19 +3,24 @@ package containerinstances
 import (
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // createOrUpdateGroup handles PUT — ContainerGroups.BeginCreateOrUpdate. The LRO
-// completes inline: returning 201 with the resource body terminates the SDK's
-// poller on the first response.
+// completes inline: returning the resource body terminates the SDK's poller on
+// the first response. A fresh create answers 201, an in-place update 200 —
+// matching ARM PUT.
 func (h *Handler) createOrUpdateGroup(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body containerGroupJSON
 	if !azurearm.DecodeJSON(w, r, &body) {
 		return
 	}
+
+	_, getErr := h.aci.GetContainerGroup(r.Context(), rp.ResourceName)
+	existed := getErr == nil
 
 	group, err := h.aci.CreateContainerGroup(r.Context(), toConfig(rp, &body))
 	if err != nil {
@@ -24,7 +29,62 @@ func (h *Handler) createOrUpdateGroup(w http.ResponseWriter, r *http.Request, rp
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusCreated, toGroupJSON(rp, group))
+	status := http.StatusCreated
+	if existed {
+		status = http.StatusOK
+	}
+
+	azurearm.WriteJSON(w, status, toGroupJSON(rp, group))
+}
+
+// lifecycleGroup handles the POST start/stop/restart verbs. All three complete
+// inline and answer 204 No Content, terminating the SDK's begin-poller.
+func (h *Handler) lifecycleGroup(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var err error
+
+	switch rp.SubResource {
+	case subActionStart:
+		err = h.aci.StartContainerGroup(r.Context(), rp.ResourceName)
+	case subActionStop:
+		err = h.aci.StopContainerGroup(r.Context(), rp.ResourceName)
+	case subActionRestart:
+		err = h.aci.RestartContainerGroup(r.Context(), rp.ResourceName)
+	}
+
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// execContainer handles POST .../containers/{c}/exec — Containers.ExecuteCommand.
+// It returns the exec websocket URI and one-time password.
+func (h *Handler) execContainer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+
+		return
+	}
+
+	var req execRequest
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	session, err := h.aci.ExecContainer(r.Context(), rp.ResourceName, rp.SubResourceName, strings.Fields(req.Command))
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, execResponse{
+		WebSocketURI: session.WebSocketURI,
+		Password:     session.Password,
+	})
 }
 
 // getGroup handles GET on a single resource — ContainerGroups.Get.

--- a/server/azure/containerinstances/response.go
+++ b/server/azure/containerinstances/response.go
@@ -30,9 +30,30 @@ func toGroupJSON(rp *azurearm.ResourcePath, g *driver.ContainerGroup) containerG
 			RestartPolicy:     g.RestartPolicy,
 			ProvisioningState: g.ProvisioningState,
 			Containers:        toContainerJSONs(g.Containers),
+			IPAddress:         toIPAddressJSON(g.IPAddress),
 			InstanceView:      &groupInstanceView{State: g.State, Events: []any{}},
 		},
 	}
+}
+
+// toIPAddressJSON maps the group's assigned IP configuration onto the ARM shape.
+func toIPAddressJSON(in *driver.IPAddress) *ipAddressJSON {
+	if in == nil {
+		return nil
+	}
+
+	out := &ipAddressJSON{
+		Type:         in.Type,
+		IP:           in.IP,
+		DNSNameLabel: in.DNSNameLabel,
+		FQDN:         in.FQDN,
+	}
+
+	for _, p := range in.Ports {
+		out.Ports = append(out.Ports, portJSON{Port: p.Port, Protocol: p.Protocol})
+	}
+
+	return out
 }
 
 // toContainerJSONs maps the group's containers (with their observed state) onto

--- a/server/azure/containerinstances/types.go
+++ b/server/azure/containerinstances/types.go
@@ -29,7 +29,42 @@ type containerGroupProperties struct {
 	RestartPolicy     string             `json:"restartPolicy,omitempty"`
 	ProvisioningState string             `json:"provisioningState,omitempty"`
 	Containers        []containerJSON    `json:"containers,omitempty"`
+	IPAddress         *ipAddressJSON     `json:"ipAddress,omitempty"`
 	InstanceView      *groupInstanceView `json:"instanceView,omitempty"`
+}
+
+// ipAddressJSON mirrors IpAddress: decoded on input (requested type/ports/label)
+// and encoded on output (with the server-assigned ip and computed fqdn).
+type ipAddressJSON struct {
+	Type         string     `json:"type,omitempty"`
+	Ports        []portJSON `json:"ports,omitempty"`
+	IP           string     `json:"ip,omitempty"`
+	DNSNameLabel string     `json:"dnsNameLabel,omitempty"`
+	FQDN         string     `json:"fqdn,omitempty"`
+}
+
+// portJSON mirrors a Port entry on an ipAddress.
+type portJSON struct {
+	Port     int    `json:"port,omitempty"`
+	Protocol string `json:"protocol,omitempty"`
+}
+
+// execRequest mirrors ContainerExecRequest (POST body of ExecuteCommand).
+type execRequest struct {
+	Command      string            `json:"command"`
+	TerminalSize *execTerminalJSON `json:"terminalSize,omitempty"`
+}
+
+// execTerminalJSON mirrors ContainerExecRequestTerminalSize.
+type execTerminalJSON struct {
+	Rows int `json:"rows,omitempty"`
+	Cols int `json:"cols,omitempty"`
+}
+
+// execResponse mirrors ContainerExecResponse.
+type execResponse struct {
+	WebSocketURI string `json:"webSocketUri"`
+	Password     string `json:"password"`
 }
 
 // groupInstanceView mirrors the group-level instanceView.
@@ -112,9 +147,29 @@ func toConfig(rp *azurearm.ResourcePath, body *containerGroupJSON) driver.Contai
 		cfg.OSType = body.Properties.OSType
 		cfg.RestartPolicy = body.Properties.RestartPolicy
 		cfg.Containers = toContainerConfigs(body.Properties.Containers)
+		cfg.IPAddress = toIPAddress(body.Properties.IPAddress)
 	}
 
 	return cfg
+}
+
+// toIPAddress maps the request's ipAddress block onto the driver config.
+func toIPAddress(in *ipAddressJSON) *driver.IPAddress {
+	if in == nil {
+		return nil
+	}
+
+	out := &driver.IPAddress{
+		Type:         in.Type,
+		DNSNameLabel: in.DNSNameLabel,
+		IP:           in.IP,
+	}
+
+	for _, p := range in.Ports {
+		out.Ports = append(out.Ports, driver.Port{Port: p.Port, Protocol: p.Protocol})
+	}
+
+	return out
 }
 
 // toContainerConfigs maps the request's container entries onto driver configs.

--- a/server/azure/functions/functions_subroutes.go
+++ b/server/azure/functions/functions_subroutes.go
@@ -1,0 +1,132 @@
+package functions
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	azfunctions "github.com/stackshy/cloudemu/v2/providers/azure/functions"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+// serveFunctions routes the deployed-function sub-tree: the functions
+// collection, a single function (get/create/delete), and its keys.
+//
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func (*Handler) serveFunctions(
+	w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps,
+) {
+	switch {
+	case rp.SubResourceName == "":
+		listFunctions(w, r, rp, store)
+	case rp.SubResourceAction == actionListKeys:
+		listFunctionKeys(w, r, rp, store)
+	case rp.SubResourceAction == "":
+		serveFunctionResource(w, r, rp, store)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "unsupported function route")
+	}
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func serveFunctionResource(
+	w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps,
+) {
+	switch r.Method {
+	case http.MethodGet:
+		getFunction(w, r, rp, store)
+	case http.MethodPut:
+		createFunction(w, r, rp, store)
+	case http.MethodDelete:
+		deleteFunction(w, r, rp, store)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func listFunctions(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps) {
+	if r.Method != http.MethodGet {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	fns, err := store.ListSiteFunctions(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]functionEnvelope, 0, len(fns))
+	for i := range fns {
+		out = append(out, toFunctionEnvelope(rp, &fns[i]))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, functionEnvelopeCollection{Value: out})
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func getFunction(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps) {
+	fn, err := store.GetSiteFunction(r.Context(), rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toFunctionEnvelope(rp, fn))
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func createFunction(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxControlBytes)
+
+	var req createFunctionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidRequestContent", err.Error())
+		return
+	}
+
+	fn, err := store.CreateSiteFunction(r.Context(), rp.ResourceName, azfunctions.SiteFunction{
+		Name:       rp.SubResourceName,
+		Config:     req.Properties.Config,
+		Language:   req.Properties.Language,
+		IsDisabled: req.Properties.IsDisabled,
+	})
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusCreated, toFunctionEnvelope(rp, fn))
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func deleteFunction(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps) {
+	if err := store.DeleteSiteFunction(r.Context(), rp.ResourceName, rp.SubResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func listFunctionKeys(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps) {
+	if r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "listkeys requires POST")
+		return
+	}
+
+	keys, err := store.FunctionKeys(r.Context(), rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, stringDictionary{
+		ID:         siteID(rp) + "/functions/" + rp.SubResourceName + "/keys",
+		Name:       rp.SubResourceName,
+		Type:       functionResourceType,
+		Properties: nonNilMap(keys),
+	})
+}

--- a/server/azure/functions/handler.go
+++ b/server/azure/functions/handler.go
@@ -65,6 +65,23 @@ type appServicePlanStore interface {
 	ListAppServicePlans(ctx context.Context) ([]azfunctions.AppServicePlan, error)
 }
 
+// azureFunctionApps is the Azure-only site surface the handler layers on top of
+// the portable serverless driver: region/plan metadata, app settings, host and
+// function keys, and deployed functions. Only the Azure provider Mock
+// (*azfunctions.Mock) satisfies it; other backends fall through to the generic
+// portable behavior (or 501 for Azure-only sub-routes).
+type azureFunctionApps interface {
+	UpsertSiteMeta(ctx context.Context, in azfunctions.SiteMeta) (*azfunctions.SiteMeta, error)
+	GetSiteMeta(ctx context.Context, name string) (*azfunctions.SiteMeta, error)
+	DeleteSiteMeta(ctx context.Context, name string) error
+	ListSiteMeta(ctx context.Context, subscription, resourceGroup string) ([]azfunctions.SiteMeta, error)
+	CreateSiteFunction(ctx context.Context, site string, fn azfunctions.SiteFunction) (*azfunctions.SiteFunction, error)
+	GetSiteFunction(ctx context.Context, site, name string) (*azfunctions.SiteFunction, error)
+	ListSiteFunctions(ctx context.Context, site string) ([]azfunctions.SiteFunction, error)
+	DeleteSiteFunction(ctx context.Context, site, name string) error
+	FunctionKeys(ctx context.Context, site, name string) (map[string]string, error)
+}
+
 // Handler serves ARM JSON requests for Microsoft.Web/sites and direct invoke
 // requests at /api/{name}.
 type Handler struct {
@@ -74,6 +91,13 @@ type Handler struct {
 // New returns a Functions handler backed by fn.
 func New(fn sdrv.Serverless) *Handler {
 	return &Handler{fn: fn}
+}
+
+// siteStore returns the Azure site surface when the backend provides it.
+func (h *Handler) siteStore() (azureFunctionApps, bool) {
+	s, ok := h.fn.(azureFunctionApps)
+
+	return s, ok
 }
 
 // Matches accepts ARM Microsoft.Web/sites paths plus the non-ARM /api/{name}
@@ -138,6 +162,14 @@ func (h *Handler) serveResource(w http.ResponseWriter, r *http.Request, rp azure
 		return
 	}
 
+	// config/appsettings/list, config/web, host/default/listkeys, functions[/...],
+	// and the restart verb are Azure-only site sub-routes.
+	if rp.SubResource != "" {
+		h.serveSiteSubResource(w, r, rp)
+
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPut:
 		h.createOrUpdate(w, r, rp)
@@ -179,7 +211,6 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 	// from the settings the function sees, so it never leaks as a literal env
 	// var (and isn't echoed back in the response).
 	handler, settings := extractHandlerSetting(req.Properties.SiteConfig.AppSettings)
-	req.Properties.SiteConfig.AppSettings = settings
 
 	cfg := sdrv.FunctionConfig{
 		Name:        rp.ResourceName,
@@ -195,7 +226,45 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toSiteResource(rp, info, req))
+	meta := h.upsertSiteMeta(r, rp, req, settings)
+
+	azurearm.WriteJSON(w, http.StatusOK, toSiteResource(rp, info, meta))
+}
+
+// upsertSiteMeta records the Azure-only site metadata (region, plan flags, app
+// settings) when the backend supports it, returning the stored view used to
+// build the response. Returns nil for backends without the site surface.
+//
+//nolint:gocritic // rp/req travel the dispatch chain once per request.
+func (h *Handler) upsertSiteMeta(
+	r *http.Request, rp azurearm.ResourcePath, req createSiteRequest, settings []nameValue,
+) *azfunctions.SiteMeta {
+	store, ok := h.siteStore()
+	if !ok {
+		return nil
+	}
+
+	location := req.Location
+	if location == "" {
+		location = defaultLocation
+	}
+
+	meta, err := store.UpsertSiteMeta(r.Context(), azfunctions.SiteMeta{
+		Name:           rp.ResourceName,
+		Subscription:   rp.Subscription,
+		ResourceGroup:  rp.ResourceGroup,
+		Location:       location,
+		ServerFarmID:   req.Properties.ServerFarmID,
+		HTTPSOnly:      req.Properties.HTTPSOnly,
+		Reserved:       req.Properties.Reserved,
+		LinuxFxVersion: req.Properties.SiteConfig.LinuxFxVersion,
+		AppSettings:    appSettingsToMap(settings),
+	})
+	if err != nil {
+		return nil
+	}
+
+	return meta
 }
 
 //nolint:gocritic // rp travels the dispatch chain once per request.
@@ -206,11 +275,32 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.Resour
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toSiteResource(rp, info, createSiteRequest{}))
+	azurearm.WriteJSON(w, http.StatusOK, toSiteResource(rp, info, h.siteMeta(r, rp.ResourceName)))
+}
+
+// siteMeta fetches the stored Azure metadata for a site, or nil when absent.
+func (h *Handler) siteMeta(r *http.Request, name string) *azfunctions.SiteMeta {
+	store, ok := h.siteStore()
+	if !ok {
+		return nil
+	}
+
+	meta, err := store.GetSiteMeta(r.Context(), name)
+	if err != nil {
+		return nil
+	}
+
+	return meta
 }
 
 //nolint:gocritic // rp travels the dispatch chain once per request.
 func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if store, ok := h.siteStore(); ok {
+		h.listFromMeta(w, r, rp, store)
+
+		return
+	}
+
 	infos, err := h.fn.ListFunctions(r.Context())
 	if err != nil {
 		azurearm.WriteCErr(w, err)
@@ -222,7 +312,40 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp azurearm.Resou
 	for i := range infos {
 		scope := rp
 		scope.ResourceName = infos[i].Name
-		out = append(out, toSiteResource(scope, &infos[i], createSiteRequest{}))
+		out = append(out, toSiteResource(scope, &infos[i], nil))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, siteListResponse{Value: out})
+}
+
+// listFromMeta lists sites filtered by the request scope (resource group, or the
+// whole subscription for a sub-wide list), building each id from the site's true
+// scope so a sub-wide list never emits an empty resourceGroups segment.
+//
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func (h *Handler) listFromMeta(
+	w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps,
+) {
+	metas, err := store.ListSiteMeta(r.Context(), rp.Subscription, rp.ResourceGroup)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]siteResource, 0, len(metas))
+
+	for i := range metas {
+		info, gerr := h.fn.GetFunction(r.Context(), metas[i].Name)
+		if gerr != nil {
+			continue
+		}
+
+		scope := azurearm.ResourcePath{
+			Subscription:  metas[i].Subscription,
+			ResourceGroup: metas[i].ResourceGroup,
+			ResourceName:  metas[i].Name,
+		}
+		out = append(out, toSiteResource(scope, info, &metas[i]))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, siteListResponse{Value: out})
@@ -233,6 +356,10 @@ func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 	if err := h.fn.DeleteFunction(r.Context(), rp.ResourceName); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
+	}
+
+	if store, ok := h.siteStore(); ok {
+		_ = store.DeleteSiteMeta(r.Context(), rp.ResourceName)
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -285,8 +412,12 @@ func (h *Handler) servePlan(w http.ResponseWriter, r *http.Request, rp azurearm.
 	}
 
 	if rp.ResourceName == "" {
-		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed",
-			"serverfarms collection operations are not supported")
+		if r.Method == http.MethodGet {
+			listPlans(w, r, rp, store)
+		} else {
+			azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		}
+
 		return
 	}
 
@@ -298,6 +429,28 @@ func (h *Handler) servePlan(w http.ResponseWriter, r *http.Request, rp azurearm.
 	default:
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
+}
+
+// listPlans serves the serverfarms collection GET — Plans.List /
+// ListByResourceGroup.
+//
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func listPlans(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store appServicePlanStore) {
+	plans, err := store.ListAppServicePlans(r.Context())
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]serverFarmResource, 0, len(plans))
+
+	for i := range plans {
+		scope := rp
+		scope.ResourceName = plans[i].Name
+		out = append(out, toServerFarmResource(scope, &plans[i]))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, serverFarmListResponse{Value: out})
 }
 
 //nolint:gocritic // rp travels the dispatch chain once per request.
@@ -317,6 +470,7 @@ func createPlan(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath
 
 	plan, err := store.CreateAppServicePlan(r.Context(), azfunctions.AppServicePlan{
 		Name:     rp.ResourceName,
+		Location: req.Location,
 		SKUName:  req.SKU.Name,
 		SKUTier:  req.SKU.Tier,
 		Kind:     req.Kind,
@@ -440,22 +594,34 @@ func upsertFunction(r *http.Request, fn sdrv.Serverless, cfg sdrv.FunctionConfig
 	return fn.UpdateFunction(r.Context(), cfg.Name, cfg)
 }
 
+// toSiteResource renders the ARM site resource. meta carries the Azure-only
+// fields (region, provisioning state, plan flags); it is nil for backends
+// without the site surface, in which case the region defaults and the plan flags
+// are zero. App-setting values are never echoed here — real Azure returns them
+// only via the config/appsettings/list POST — so a plain GET does not leak
+// secrets.
+//
 //nolint:gocritic // rp is request-scoped.
-func toSiteResource(rp azurearm.ResourcePath, info *sdrv.FunctionInfo, req createSiteRequest) siteResource {
-	location := req.Location
-	if location == "" {
-		location = defaultLocation
+func toSiteResource(rp azurearm.ResourcePath, info *sdrv.FunctionInfo, meta *azfunctions.SiteMeta) siteResource {
+	location := defaultLocation
+	provisioningState := "Succeeded"
+
+	var serverFarmID string
+
+	var httpsOnly, reserved bool
+
+	if meta != nil {
+		location = meta.Location
+		provisioningState = meta.ProvisioningState
+		serverFarmID = meta.ServerFarmID
+		httpsOnly = meta.HTTPSOnly
+		reserved = meta.Reserved
 	}
 
 	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup,
 		providerName, resourceType, rp.ResourceName)
 
 	hostName := info.Name + ".azurewebsites.net"
-
-	settings := req.Properties.SiteConfig.AppSettings
-	if len(settings) == 0 {
-		settings = mapToAppSettings(info.Environment)
-	}
 
 	return siteResource{
 		ID:       id,
@@ -465,16 +631,20 @@ func toSiteResource(rp azurearm.ResourcePath, info *sdrv.FunctionInfo, req creat
 		Location: location,
 		Tags:     info.Tags,
 		Properties: siteProperties{
-			State:           "Running",
-			HostNames:       []string{hostName},
-			DefaultHostName: hostName,
+			State:             "Running",
+			ProvisioningState: provisioningState,
+			HostNames:         []string{hostName},
+			DefaultHostName:   hostName,
+			// AppSettings is deliberately emitted (as null) so the server's
+			// unmodeled-property echo treats it as owned and never reflects the
+			// request's app settings — including secret values — back onto a plain
+			// GET. The values are read only via config/appsettings/list.
 			SiteConfig: siteConfig{
 				LinuxFxVersion: info.Runtime,
-				AppSettings:    settings,
 			},
-			ServerFarmID:        req.Properties.ServerFarmID,
-			HTTPSOnly:           req.Properties.HTTPSOnly,
-			Reserved:            req.Properties.Reserved,
+			ServerFarmID:        serverFarmID,
+			HTTPSOnly:           httpsOnly,
+			Reserved:            reserved,
 			LastModifiedTimeUtc: time.Now().UTC().Format(time.RFC3339),
 		},
 	}
@@ -510,19 +680,6 @@ func appSettingsToMap(settings []nameValue) map[string]string {
 	out := make(map[string]string, len(settings))
 	for _, kv := range settings {
 		out[kv.Name] = kv.Value
-	}
-
-	return out
-}
-
-func mapToAppSettings(env map[string]string) []nameValue {
-	if len(env) == 0 {
-		return nil
-	}
-
-	out := make([]nameValue, 0, len(env))
-	for k, v := range env {
-		out = append(out, nameValue{Name: k, Value: v})
 	}
 
 	return out

--- a/server/azure/functions/sites_sdk_test.go
+++ b/server/azure/functions/sites_sdk_test.go
@@ -1,0 +1,111 @@
+package functions_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3"
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKAppSettingsHostKeysRestart drives the new site sub-routes through the
+// real armappservice WebAppsClient, the way an app operator would.
+func TestSDKAppSettingsHostKeysRestart(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{Functions: cloudP.Functions}))
+	t.Cleanup(ts.Close)
+
+	client := newWebAppsClient(t, ts)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rgName, "sdk-keys",
+		armappservice.Site{
+			Kind:     to.Ptr("functionapp"),
+			Location: to.Ptr("westus2"),
+			Properties: &armappservice.SiteProperties{
+				SiteConfig: &armappservice.SiteConfig{
+					LinuxFxVersion: to.Ptr("Python|3.11"),
+					AppSettings: []*armappservice.NameValuePair{
+						{Name: to.Ptr("FOO"), Value: to.Ptr("bar")},
+					},
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err = poller.PollUntilDone(ctx, &runtimePollerOptions); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	settings, err := client.ListApplicationSettings(ctx, rgName, "sdk-keys", nil)
+	if err != nil {
+		t.Fatalf("ListApplicationSettings: %v", err)
+	}
+
+	if got := settings.Properties["FOO"]; got == nil || *got != "bar" {
+		t.Fatalf("app setting FOO = %v, want bar", got)
+	}
+
+	keys, err := client.ListHostKeys(ctx, rgName, "sdk-keys", nil)
+	if err != nil {
+		t.Fatalf("ListHostKeys: %v", err)
+	}
+
+	if keys.MasterKey == nil || *keys.MasterKey == "" {
+		t.Fatalf("master key missing: %+v", keys)
+	}
+
+	if _, err = client.Restart(ctx, rgName, "sdk-keys", nil); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+}
+
+// TestSDKListFunctions drives ListFunctions/GetFunction through the real client:
+// a fresh app lists no functions and a missing function is a 404.
+func TestSDKListFunctions(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{Functions: cloudP.Functions}))
+	t.Cleanup(ts.Close)
+
+	client := newWebAppsClient(t, ts)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rgName, "sdk-fns",
+		armappservice.Site{
+			Kind:       to.Ptr("functionapp"),
+			Location:   to.Ptr("eastus"),
+			Properties: &armappservice.SiteProperties{SiteConfig: &armappservice.SiteConfig{}},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err = poller.PollUntilDone(ctx, &runtimePollerOptions); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	pager := client.NewListFunctionsPager(rgName, "sdk-fns", nil)
+
+	total := 0
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("ListFunctions page: %v", perr)
+		}
+
+		total += len(page.Value)
+	}
+
+	if total != 0 {
+		t.Fatalf("fresh app functions = %d, want 0", total)
+	}
+
+	if _, err = client.GetFunction(ctx, rgName, "sdk-fns", "ghost", nil); err == nil {
+		t.Fatal("GetFunction(ghost) returned nil error, want 404")
+	}
+}

--- a/server/azure/functions/sites_subroutes.go
+++ b/server/azure/functions/sites_subroutes.go
@@ -1,0 +1,192 @@
+package functions
+
+import (
+	"net/http"
+
+	azfunctions "github.com/stackshy/cloudemu/v2/providers/azure/functions"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+const (
+	subResourceConfig    = "config"
+	subResourceHost      = "host"
+	subResourceFunctions = "functions"
+	subResourceRestart   = "restart"
+
+	configNameWeb         = "web"
+	configNameAppSettings = "appsettings"
+	actionList            = "list"
+	hostNameDefault       = "default"
+	actionListKeys        = "listkeys"
+
+	configResourceType   = providerName + "/" + resourceType + "/config"
+	functionResourceType = providerName + "/" + resourceType + "/functions"
+)
+
+// serveSiteSubResource dispatches the Azure-only site sub-routes: config
+// (appsettings/web), host keys, deployed functions, and the restart verb.
+//
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func (h *Handler) serveSiteSubResource(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	store, ok := h.siteStore()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"function-app sub-resources not supported by this backend")
+
+		return
+	}
+
+	switch rp.SubResource {
+	case subResourceConfig:
+		h.serveConfig(w, r, rp, store)
+	case subResourceHost:
+		h.serveHostKeys(w, r, rp, store)
+	case subResourceFunctions:
+		h.serveFunctions(w, r, rp, store)
+	case subResourceRestart:
+		h.serveRestart(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "unsupported sub-resource")
+	}
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func (*Handler) serveConfig(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps) {
+	switch {
+	case rp.SubResourceName == configNameWeb && r.Method == http.MethodGet:
+		getConfigWeb(w, r, rp, store)
+	case rp.SubResourceName == configNameAppSettings && rp.SubResourceAction == actionList && r.Method == http.MethodPost:
+		listAppSettings(w, r, rp, store)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "unsupported config route")
+	}
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func getConfigWeb(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps) {
+	meta, err := store.GetSiteMeta(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, siteConfigResource{
+		ID:   siteID(rp) + "/config/web",
+		Name: configNameWeb,
+		Type: configResourceType,
+		Properties: siteConfig{
+			LinuxFxVersion: meta.LinuxFxVersion,
+			AppSettings:    appSettingsSlice(meta.AppSettings),
+		},
+	})
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func listAppSettings(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps) {
+	meta, err := store.GetSiteMeta(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	settings := meta.AppSettings
+	if settings == nil {
+		settings = map[string]string{}
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, stringDictionary{
+		ID:         siteID(rp) + "/config/appsettings",
+		Name:       configNameAppSettings,
+		Type:       configResourceType,
+		Kind:       "app",
+		Properties: settings,
+	})
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func (*Handler) serveHostKeys(
+	w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps,
+) {
+	if rp.SubResourceName != hostNameDefault || rp.SubResourceAction != actionListKeys || r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "unsupported host route")
+		return
+	}
+
+	meta, err := store.GetSiteMeta(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, hostKeys{
+		MasterKey:    meta.MasterKey,
+		FunctionKeys: nonNilMap(meta.HostFunctionKeys),
+		SystemKeys:   nonNilMap(meta.SystemKeys),
+	})
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func (h *Handler) serveRestart(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "restart requires POST")
+		return
+	}
+
+	if _, err := h.fn.GetFunction(r.Context(), rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// siteID builds the parent site's ARM resource id.
+//
+//nolint:gocritic // rp is request-scoped.
+func siteID(rp azurearm.ResourcePath) string {
+	return azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, rp.ResourceName)
+}
+
+// appSettingsSlice renders a settings map as ARM name/value pairs.
+func appSettingsSlice(settings map[string]string) []nameValue {
+	if len(settings) == 0 {
+		return nil
+	}
+
+	out := make([]nameValue, 0, len(settings))
+	for k, v := range settings {
+		out = append(out, nameValue{Name: k, Value: v})
+	}
+
+	return out
+}
+
+// nonNilMap returns m, or an empty map so the JSON encodes {} rather than null.
+func nonNilMap(m map[string]string) map[string]string {
+	if m == nil {
+		return map[string]string{}
+	}
+
+	return m
+}
+
+// toFunctionEnvelope renders a deployed function as its ARM FunctionEnvelope.
+//
+//nolint:gocritic // rp is request-scoped.
+func toFunctionEnvelope(rp azurearm.ResourcePath, fn *azfunctions.SiteFunction) functionEnvelope {
+	site := rp.ResourceName
+
+	return functionEnvelope{
+		ID:   siteID(rp) + "/functions/" + fn.Name,
+		Name: fn.Name,
+		Type: functionResourceType,
+		Properties: functionEnvelopeProps{
+			Name:          fn.Name,
+			FunctionAppID: siteID(rp),
+			Config:        fn.Config,
+			Href:          "https://" + site + ".azurewebsites.net/admin/functions/" + fn.Name,
+			Language:      fn.Language,
+			IsDisabled:    fn.IsDisabled,
+		},
+	}
+}

--- a/server/azure/functions/sites_test.go
+++ b/server/azure/functions/sites_test.go
@@ -1,0 +1,284 @@
+package functions_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func newFuncServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	cloud := cloudemu.NewAzure()
+	srv := httptest.NewServer(azureserver.New(azureserver.Drivers{Functions: cloud.Functions}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func siteInRG(rg, name string) string {
+	return "/subscriptions/" + subID + "/resourceGroups/" + rg + "/providers/Microsoft.Web/sites/" + name
+}
+
+// TestSiteLocationAndProvisioningState covers findings 1 and 2: the creation
+// region survives a GET and provisioningState is present.
+func TestSiteLocationAndProvisioningState(t *testing.T) {
+	srv := newFuncServer(t)
+
+	body := `{"kind":"functionapp","location":"westus2","properties":{"siteConfig":{"linuxFxVersion":"Python|3.11"}}}`
+	doRequest(t, srv, http.MethodPut, sitesURL("loc")+apiVer, body)
+
+	var site struct {
+		Location   string `json:"location"`
+		Properties struct {
+			ProvisioningState string `json:"provisioningState"`
+		} `json:"properties"`
+	}
+	decodeInto(t, doRequest(t, srv, http.MethodGet, sitesURL("loc")+apiVer, ""), &site)
+
+	if site.Location != "westus2" {
+		t.Fatalf("GET location = %q, want westus2", site.Location)
+	}
+
+	if site.Properties.ProvisioningState != "Succeeded" {
+		t.Fatalf("provisioningState = %q, want Succeeded", site.Properties.ProvisioningState)
+	}
+}
+
+// TestListApplicationSettingsAndConfigWeb covers finding 4.
+func TestListApplicationSettingsAndConfigWeb(t *testing.T) {
+	srv := newFuncServer(t)
+
+	body := `{"kind":"functionapp","location":"eastus","properties":{"siteConfig":{"linuxFxVersion":"Node|20","appSettings":[{"name":"FOO","value":"bar"}]}}}`
+	doRequest(t, srv, http.MethodPut, sitesURL("cfg")+apiVer, body)
+
+	var dict struct {
+		Type       string            `json:"type"`
+		Properties map[string]string `json:"properties"`
+	}
+	decodeInto(t, doRequest(t, srv, http.MethodPost, sitesURL("cfg")+"/config/appsettings/list"+apiVer, ""), &dict)
+
+	if dict.Type != "Microsoft.Web/sites/config" {
+		t.Fatalf("appsettings type = %q", dict.Type)
+	}
+
+	if dict.Properties["FOO"] != "bar" {
+		t.Fatalf("appsettings FOO = %q, want bar", dict.Properties["FOO"])
+	}
+
+	var cfg struct {
+		Type       string `json:"type"`
+		Properties struct {
+			LinuxFxVersion string `json:"linuxFxVersion"`
+		} `json:"properties"`
+	}
+	decodeInto(t, doRequest(t, srv, http.MethodGet, sitesURL("cfg")+"/config/web"+apiVer, ""), &cfg)
+
+	if cfg.Properties.LinuxFxVersion != "Node|20" {
+		t.Fatalf("config/web linuxFxVersion = %q, want Node|20", cfg.Properties.LinuxFxVersion)
+	}
+}
+
+// TestListHostKeys covers finding 5 (host keys).
+func TestListHostKeys(t *testing.T) {
+	srv := newFuncServer(t)
+
+	doRequest(t, srv, http.MethodPut, sitesURL("keys")+apiVer,
+		`{"kind":"functionapp","location":"eastus","properties":{"siteConfig":{}}}`)
+
+	var hk struct {
+		MasterKey    string            `json:"masterKey"`
+		FunctionKeys map[string]string `json:"functionKeys"`
+	}
+	decodeInto(t, doRequest(t, srv, http.MethodPost, sitesURL("keys")+"/host/default/listkeys"+apiVer, ""), &hk)
+
+	if hk.MasterKey == "" {
+		t.Fatalf("masterKey is empty")
+	}
+
+	if hk.FunctionKeys["default"] == "" {
+		t.Fatalf("host default function key is empty: %+v", hk.FunctionKeys)
+	}
+}
+
+// TestFunctionsCRUD covers finding 3 (list/get/404) and finding 5 (function keys).
+func TestFunctionsCRUD(t *testing.T) {
+	srv := newFuncServer(t)
+
+	doRequest(t, srv, http.MethodPut, sitesURL("fns")+apiVer,
+		`{"kind":"functionapp","location":"eastus","properties":{"siteConfig":{}}}`)
+
+	// No functions deployed yet → empty collection, not the site body.
+	var empty struct {
+		Value []json.RawMessage `json:"value"`
+	}
+	decodeInto(t, doRequest(t, srv, http.MethodGet, sitesURL("fns")+"/functions"+apiVer, ""), &empty)
+
+	if len(empty.Value) != 0 {
+		t.Fatalf("expected 0 functions, got %d", len(empty.Value))
+	}
+
+	// A non-existent function → 404 (not a bogus 200).
+	if r := doRequest(t, srv, http.MethodGet, sitesURL("fns")+"/functions/ghost"+apiVer, ""); r.StatusCode != http.StatusNotFound {
+		t.Fatalf("GET missing function = %d, want 404", r.StatusCode)
+	}
+
+	// Create a function → 201.
+	created := doRequest(t, srv, http.MethodPut, sitesURL("fns")+"/functions/httpTrigger"+apiVer,
+		`{"properties":{"language":"python","config":{"bindings":[]}}}`)
+	if created.StatusCode != http.StatusCreated {
+		t.Fatalf("create function = %d, want 201", created.StatusCode)
+	}
+
+	var env struct {
+		Name       string `json:"name"`
+		Type       string `json:"type"`
+		Properties struct {
+			Name string `json:"name"`
+		} `json:"properties"`
+	}
+	decodeInto(t, doRequest(t, srv, http.MethodGet, sitesURL("fns")+"/functions/httpTrigger"+apiVer, ""), &env)
+
+	if env.Name != "httpTrigger" || env.Type != "Microsoft.Web/sites/functions" {
+		t.Fatalf("function envelope = %+v", env)
+	}
+
+	// List now returns the one function.
+	decodeInto(t, doRequest(t, srv, http.MethodGet, sitesURL("fns")+"/functions"+apiVer, ""), &empty)
+	if len(empty.Value) != 1 {
+		t.Fatalf("expected 1 function after create, got %d", len(empty.Value))
+	}
+
+	// Function keys → 200 with a default key.
+	var fk struct {
+		Properties map[string]string `json:"properties"`
+	}
+	decodeInto(t, doRequest(t, srv, http.MethodPost,
+		sitesURL("fns")+"/functions/httpTrigger/listkeys"+apiVer, ""), &fk)
+
+	if fk.Properties["default"] == "" {
+		t.Fatalf("function default key is empty: %+v", fk.Properties)
+	}
+}
+
+// TestRestart covers finding 11.
+func TestRestart(t *testing.T) {
+	srv := newFuncServer(t)
+
+	doRequest(t, srv, http.MethodPut, sitesURL("rst")+apiVer,
+		`{"kind":"functionapp","location":"eastus","properties":{"siteConfig":{}}}`)
+
+	if r := doRequest(t, srv, http.MethodPost, sitesURL("rst")+"/restart"+apiVer, ""); r.StatusCode != http.StatusOK {
+		t.Fatalf("restart = %d, want 200", r.StatusCode)
+	}
+
+	if r := doRequest(t, srv, http.MethodPost, sitesURL("missing")+"/restart"+apiVer, ""); r.StatusCode != http.StatusNotFound {
+		t.Fatalf("restart missing = %d, want 404", r.StatusCode)
+	}
+}
+
+// TestListFiltersByResourceGroup covers findings 9 and 10.
+func TestListFiltersByResourceGroup(t *testing.T) {
+	srv := newFuncServer(t)
+
+	putSite := func(rg, name string) {
+		doRequest(t, srv, http.MethodPut, siteInRG(rg, name)+apiVer,
+			`{"kind":"functionapp","location":"eastus","properties":{"siteConfig":{}}}`)
+	}
+	putSite("rgA", "a1")
+	putSite("rgA", "a2")
+	putSite("rgB", "b1")
+
+	// RG-scoped list returns only rgA's sites.
+	var rgList struct {
+		Value []struct {
+			ID string `json:"id"`
+		} `json:"value"`
+	}
+	rgURL := "/subscriptions/" + subID + "/resourceGroups/rgA/providers/Microsoft.Web/sites"
+	decodeInto(t, doRequest(t, srv, http.MethodGet, rgURL+apiVer, ""), &rgList)
+
+	if len(rgList.Value) != 2 {
+		t.Fatalf("rgA list = %d entries, want 2", len(rgList.Value))
+	}
+
+	for _, e := range rgList.Value {
+		if !strings.Contains(e.ID, "/resourceGroups/rgA/") {
+			t.Fatalf("rgA list leaked a foreign id: %s", e.ID)
+		}
+	}
+
+	// Subscription-wide list preserves each site's true RG (no empty segment).
+	subURL := "/subscriptions/" + subID + "/providers/Microsoft.Web/sites"
+	decodeInto(t, doRequest(t, srv, http.MethodGet, subURL+apiVer, ""), &rgList)
+
+	if len(rgList.Value) != 3 {
+		t.Fatalf("sub-wide list = %d entries, want 3", len(rgList.Value))
+	}
+
+	for _, e := range rgList.Value {
+		if strings.Contains(e.ID, "resourceGroups//") {
+			t.Fatalf("sub-wide id has empty resourceGroups segment: %s", e.ID)
+		}
+	}
+}
+
+// TestPlainGetDoesNotEchoSecrets covers finding 13.
+func TestPlainGetDoesNotEchoSecrets(t *testing.T) {
+	srv := newFuncServer(t)
+
+	body := `{"kind":"functionapp","location":"eastus","properties":{"siteConfig":{"appSettings":[{"name":"SECRET","value":"topsecret"}]}}}`
+	doRequest(t, srv, http.MethodPut, sitesURL("sec")+apiVer, body)
+
+	raw := readBody(t, doRequest(t, srv, http.MethodGet, sitesURL("sec")+apiVer, ""))
+	if strings.Contains(raw, "topsecret") {
+		t.Fatalf("secret app-setting value leaked into plain GET: %s", raw)
+	}
+}
+
+// TestPlanLocationAndCollection covers findings 6 and 14.
+func TestPlanLocationAndCollection(t *testing.T) {
+	srv := newFuncServer(t)
+
+	planURL := "/subscriptions/" + subID + "/resourceGroups/" + rgName + "/providers/Microsoft.Web/serverfarms/plan1"
+	doRequest(t, srv, http.MethodPut, planURL+apiVer,
+		`{"location":"westeurope","sku":{"name":"EP1","tier":"ElasticPremium"}}`)
+
+	var plan struct {
+		Location string `json:"location"`
+	}
+	decodeInto(t, doRequest(t, srv, http.MethodGet, planURL+apiVer, ""), &plan)
+
+	if plan.Location != "westeurope" {
+		t.Fatalf("plan location = %q, want westeurope", plan.Location)
+	}
+
+	collURL := "/subscriptions/" + subID + "/resourceGroups/" + rgName + "/providers/Microsoft.Web/serverfarms"
+
+	var coll struct {
+		Value []json.RawMessage `json:"value"`
+	}
+	resp := doRequest(t, srv, http.MethodGet, collURL+apiVer, "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("serverfarms collection = %d, want 200", resp.StatusCode)
+	}
+
+	decodeInto(t, resp, &coll)
+	if len(coll.Value) != 1 {
+		t.Fatalf("serverfarms collection = %d entries, want 1", len(coll.Value))
+	}
+}
+
+func decodeInto(t *testing.T, resp *http.Response, v any) {
+	t.Helper()
+	defer resp.Body.Close() //nolint:errcheck // test cleanup
+
+	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+}

--- a/server/azure/functions/types.go
+++ b/server/azure/functions/types.go
@@ -16,6 +16,7 @@ type siteResource struct {
 
 type siteProperties struct {
 	State               string            `json:"state"`
+	ProvisioningState   string            `json:"provisioningState,omitempty"`
 	HostNames           []string          `json:"hostNames"`
 	DefaultHostName     string            `json:"defaultHostName"`
 	SiteConfig          siteConfig        `json:"siteConfig"`
@@ -27,9 +28,13 @@ type siteProperties struct {
 }
 
 type siteConfig struct {
-	LinuxFxVersion      string      `json:"linuxFxVersion,omitempty"`
-	NetFrameworkVersion string      `json:"netFrameworkVersion,omitempty"`
-	AppSettings         []nameValue `json:"appSettings,omitempty"`
+	LinuxFxVersion      string `json:"linuxFxVersion,omitempty"`
+	NetFrameworkVersion string `json:"netFrameworkVersion,omitempty"`
+	// AppSettings has no omitempty: a plain site GET emits it as null so the
+	// server's unmodeled-property echo does not reflect the request's app
+	// settings (secret values included) back onto the response. The dedicated
+	// config/web and config/appsettings/list routes populate it explicitly.
+	AppSettings []nameValue `json:"appSettings"`
 }
 
 type nameValue struct {
@@ -88,10 +93,75 @@ type serverFarmProperties struct {
 	Status            string `json:"status,omitempty"`
 }
 
+// serverFarmListResponse is the {value:[...]} envelope for the serverfarms
+// collection GET.
+type serverFarmListResponse struct {
+	Value []serverFarmResource `json:"value"`
+}
+
 // createServerFarmRequest captures the fields read from a serverfarms PUT body.
 type createServerFarmRequest struct {
 	Kind     string            `json:"kind"`
 	Location string            `json:"location"`
 	Tags     map[string]string `json:"tags"`
 	SKU      serverFarmSKU     `json:"sku"`
+}
+
+// stringDictionary is the ARM StringDictionary shape returned by
+// listApplicationSettings and listFunctionKeys.
+type stringDictionary struct {
+	ID         string            `json:"id,omitempty"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Kind       string            `json:"kind,omitempty"`
+	Properties map[string]string `json:"properties"`
+}
+
+// hostKeys is the ARM HostKeys shape returned by listHostKeys.
+type hostKeys struct {
+	MasterKey    string            `json:"masterKey"`
+	FunctionKeys map[string]string `json:"functionKeys"`
+	SystemKeys   map[string]string `json:"systemKeys"`
+}
+
+// siteConfigResource is the ARM SiteConfigResource returned by GET config/web.
+type siteConfigResource struct {
+	ID         string     `json:"id,omitempty"`
+	Name       string     `json:"name"`
+	Type       string     `json:"type"`
+	Properties siteConfig `json:"properties"`
+}
+
+// functionEnvelope is the ARM FunctionEnvelope for one deployed function.
+type functionEnvelope struct {
+	ID         string                `json:"id"`
+	Name       string                `json:"name"`
+	Type       string                `json:"type"`
+	Properties functionEnvelopeProps `json:"properties"`
+}
+
+// functionEnvelopeProps carries the function's config and hrefs.
+type functionEnvelopeProps struct {
+	Name          string         `json:"name"`
+	FunctionAppID string         `json:"function_app_id,omitempty"`
+	Config        map[string]any `json:"config,omitempty"`
+	Href          string         `json:"href,omitempty"`
+	Language      string         `json:"language,omitempty"`
+	IsDisabled    bool           `json:"isDisabled,omitempty"`
+}
+
+// functionEnvelopeCollection is the {value:[...]} envelope for listFunctions.
+type functionEnvelopeCollection struct {
+	Value []functionEnvelope `json:"value"`
+}
+
+// createFunctionRequest captures the fields read from a function PUT body.
+type createFunctionRequest struct {
+	Properties createFunctionProps `json:"properties"`
+}
+
+type createFunctionProps struct {
+	Config     map[string]any `json:"config"`
+	Language   string         `json:"language"`
+	IsDisabled bool           `json:"isDisabled"`
 }

--- a/services/containerinstances/driver/driver.go
+++ b/services/containerinstances/driver/driver.go
@@ -28,6 +28,24 @@ type ContainerConfig struct {
 	Env        []EnvVar
 }
 
+// Port is a single port exposed on a container group's public/private IP.
+type Port struct {
+	Port     int
+	Protocol string // "TCP" or "UDP"
+}
+
+// IPAddress is a container group's requested/assigned IP configuration
+// (Microsoft.ContainerInstance/containerGroups properties.ipAddress). Type is
+// "Public" or "Private". For a Public group with a DNSNameLabel the provider
+// assigns an IP and computes an FQDN.
+type IPAddress struct {
+	Type         string // "Public" or "Private"
+	Ports        []Port
+	DNSNameLabel string
+	IP           string // server-assigned for a Public group
+	FQDN         string // computed from DNSNameLabel for a Public group
+}
+
 // ContainerGroupConfig describes a container group to create or update. It maps
 // the request body of a Microsoft.ContainerInstance/containerGroups PUT onto
 // the fields the provider records.
@@ -37,8 +55,17 @@ type ContainerGroupConfig struct {
 	OSType        string // "Linux" or "Windows"
 	RestartPolicy string // "Always", "OnFailure", or "Never"
 	Containers    []ContainerConfig
+	IPAddress     *IPAddress
 	Tags          map[string]string
 	Scope         scope.Scope
+}
+
+// ExecSession is the connection descriptor returned by ExecContainer, mirroring
+// ACI's ContainerExecResponse: a websocket URI to attach to and a one-time
+// password to authenticate the exec stream.
+type ExecSession struct {
+	WebSocketURI string
+	Password     string
 }
 
 // ContainerState is the observed lifecycle state of a single container, mirroring
@@ -71,8 +98,9 @@ type ContainerGroup struct {
 	OSType            string
 	RestartPolicy     string
 	ProvisioningState string // "Succeeded"
-	State             string // group-level instanceView.state ("Running", "Succeeded")
+	State             string // group-level instanceView.state ("Running", "Succeeded", "Stopped")
 	Containers        []ContainerInstance
+	IPAddress         *IPAddress
 	Tags              map[string]string
 	Scope             scope.Scope
 }
@@ -96,6 +124,25 @@ type ContainerInstances interface {
 
 	// ListContainerGroups returns the groups visible under filter.
 	ListContainerGroups(ctx context.Context, filter scope.Scope) ([]ContainerGroup, error)
+
+	// StartContainerGroup starts all containers in a stopped group, allocating
+	// compute again. Returns NotFound when the group does not exist.
+	StartContainerGroup(ctx context.Context, name string) error
+
+	// StopContainerGroup stops all containers in the group and deallocates
+	// compute, tearing down any engine-backed workload. Returns NotFound when the
+	// group does not exist.
+	StopContainerGroup(ctx context.Context, name string) error
+
+	// RestartContainerGroup restarts all containers in the group. Returns NotFound
+	// when the group does not exist.
+	RestartContainerGroup(ctx context.Context, name string) error
+
+	// ExecContainer opens an exec session on one container in the group and
+	// returns its websocket URI and password. When the group is engine-backed the
+	// command is run for real on the engine. Returns NotFound when the group or
+	// container does not exist.
+	ExecContainer(ctx context.Context, group, container string, command []string) (*ExecSession, error)
 
 	// ContainerLogs returns the captured stdout/stderr for one container in the
 	// group. A non-positive tail returns the full log. It is empty for a group


### PR DESCRIPTION
## Summary

End-to-end audit fixes for Azure Functions (`Microsoft.Web/sites`) and Container Instances against the official Azure REST contracts. Researched each endpoint on Microsoft Learn (shape, HTTP status, resource-id casing) before implementing; verified with real `azure-sdk-for-go` (`armappservice`) clients and raw data-plane HTTP over an httptest server.

Azure-only Function-App operations are layered onto the portable serverless driver through a type-asserted optional interface (`azureFunctionApps`, implemented by the Azure provider Mock), so no method is forced onto AWS/GCP — mirroring the existing `appServicePlanStore` pattern. Container Instances is an Azure-only single-provider service, so its lifecycle/exec methods were added directly to its driver interface (coverage docs regenerated).

## Functions (`Microsoft.Web/sites`)

- **[HIGH] Location** — a site now persists and returns its creation region; a PUT `westus2` → GET returns `westus2` (was `eastus`). *(finding 1)*
- **[HIGH] provisioningState** — added to the site body. *(finding 2)*
- **[HIGH] Functions collection** — `GET .../functions` returns a `FunctionEnvelopeCollection` (was the site resource); `GET/.../functions/{fn}` is `404` for an unknown function (was a bogus 200); added `PUT`/`DELETE` to deploy/remove a function. *(finding 3)*
- **[HIGH] App settings / config** — `POST config/appsettings/list` returns a `StringDictionary` (was 405); `GET config/web` returns a real `SiteConfigResource` with the runtime and settings (was the whole site decoded as all-nil `SiteConfig`). *(finding 4)*
- **[HIGH] Host / function keys** — `POST host/default/listkeys` (HostKeys) and `POST functions/{fn}/listkeys` (StringDictionary) are served (were 405). *(finding 5)*
- **[HIGH] Plan location** — `serverfarms` PUT now echoes the submitted region (was `us-east-1` from the AWS default). *(finding 6)*
- **[MEDIUM] ListByResourceGroup** now filters by RG. *(finding 9)*
- **[MEDIUM] Subscription-wide list** builds ids from each site's true scope — no empty `resourceGroups//` segment. *(finding 10)*
- **[MEDIUM] Restart** — `POST .../restart` returns 200 (was 405). *(finding 11)*
- **[LOW] Secret exposure** — a plain site GET no longer echoes app-setting values (values are read only via `config/appsettings/list`). This also required emitting the `appSettings` key explicitly so the server's unmodeled-property echo does not reflect the request's raw settings back. *(finding 13)*
- **[LOW] Plans collection** — `GET serverfarms` collection is served. *(finding 14)*

## Container Instances (`Microsoft.ContainerInstance/containerGroups`)

- **[HIGH] Lifecycle** — `start` / `stop` / `restart` POST verbs accept POST, return 204, and change running state (were 405). *(finding 7)*
- **[HIGH] Exec** — `POST containers/{c}/exec` returns `{webSocketUri, password}`, driving the container engine's `Exec` when engine-backed and 404-ing on an unknown group/container (was 405). *(finding 8)*
- **[MEDIUM] ipAddress** — a Public group with a `dnsNameLabel` is assigned a public IP and a computed `<label>.<location>.azurecontainer.io` FQDN. *(finding 12)*
- **[LOW] Update status** — an in-place PUT returns 200 (was 201). *(finding 15)*

## Tests

- Real `armappservice` SDK: `ListApplicationSettings`, `ListHostKeys`, `Restart`, `ListFunctions`, `GetFunction`.
- Raw ARM HTTP for every finding on both services (location roundtrip, provisioningState, appsettings/list, config/web, host/function keys, functions CRUD + 404, RG filtering, sub-wide ids, restart, plan location/collection, secret non-echo; ACI lifecycle 204 + state, exec session, public IP/FQDN, 200-on-update).
- Provider-level tests for the ACI lifecycle/exec/IP and the Functions site-metadata store.

## Gates

`go build ./...`, `go test ./...`, and `golangci-lint` on the changed packages are all green. `docs/coverage` regenerated for the ContainerInstances driver additions.
