### PR TITLE
fix(ecs-ecr-eks): StopTask/ListServices/DescribeServices cluster scoping, ECR scan-findings/policy error codes, EKS delete guard

### DIFF
--- a/providers/aws/ecr/ecr.go
+++ b/providers/aws/ecr/ecr.go
@@ -349,12 +349,12 @@ func (m *Mock) EvaluateLifecyclePolicy(_ context.Context, repository string) ([]
 func (m *Mock) StartImageScan(_ context.Context, repository, reference string) (*driver.ScanResult, error) {
 	rd, ok := m.repos.Get(repository)
 	if !ok {
-		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+		return nil, apiErrf(excRepositoryNotFound, "repository %q not found", repository)
 	}
 
 	img := findImage(rd, reference)
 	if img == nil {
-		return nil, errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
+		return nil, apiErrf(excImageNotFound, "image %q not found in repository %q", reference, repository)
 	}
 
 	scan := generateScanResult(repository, img.detail.Digest, m.opts.Clock.Now())
@@ -371,17 +371,18 @@ func (m *Mock) GetImageScanResults(
 ) (*driver.ScanResult, error) {
 	rd, ok := m.repos.Get(repository)
 	if !ok {
-		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+		return nil, apiErrf(excRepositoryNotFound, "repository %q not found", repository)
 	}
 
 	img := findImage(rd, reference)
 	if img == nil {
-		return nil, errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
+		return nil, apiErrf(excImageNotFound, "image %q not found in repository %q", reference, repository)
 	}
 
 	scan, ok := rd.scans.Get(img.detail.Digest)
 	if !ok {
-		return nil, errors.Newf(errors.NotFound, "no scan results for image %q in repository %q", reference, repository)
+		return nil, apiErrf(excScanNotFound,
+			"no scan results for image %q in repository %q", reference, repository)
 	}
 
 	result := *scan

--- a/providers/aws/ecr/errors.go
+++ b/providers/aws/ecr/errors.go
@@ -1,0 +1,43 @@
+package ecr
+
+import "github.com/stackshy/cloudemu/v2/errors"
+
+// ECR exception names surfaced on the wire. Several ECR operations return the
+// canonical NotFound code for distinct real-AWS exceptions (a missing
+// repository, a missing image, a missing scan, a missing repository policy), so
+// the provider tags the error with the precise exception name the server should
+// surface rather than letting the generic code-based mapping collapse them all
+// to RepositoryNotFoundException.
+const (
+	excRepositoryNotFound       = "RepositoryNotFoundException"
+	excImageNotFound            = "ImageNotFoundException"
+	excScanNotFound             = "ScanNotFoundException"
+	excRepositoryPolicyNotFound = "RepositoryPolicyNotFoundException"
+)
+
+// apiError pairs a canonical cloudemu error with the precise ECR exception name
+// the server should surface. It unwraps to the underlying *errors.Error so the
+// errors.IsX predicates keep classifying it, while exposing ECRException() for
+// the server's error mapper.
+type apiError struct {
+	err       *errors.Error
+	exception string
+}
+
+// Error implements the error interface.
+func (e *apiError) Error() string { return e.err.Error() }
+
+// ECRException returns the AWS exception name for this error.
+func (e *apiError) ECRException() string { return e.exception }
+
+// Unwrap exposes the canonical error so errors.As(&*errors.Error) matches and
+// errors.GetCode reads the right code.
+func (e *apiError) Unwrap() error { return e.err }
+
+// apiErrf builds a NotFound apiError with a formatted message. Every ECR
+// exception that needs a precise name here (repository, image, scan, or
+// repository-policy not found) is a NotFound-category error, so the canonical
+// code is fixed; the exception argument carries the AWS distinction.
+func apiErrf(exception, format string, args ...any) error {
+	return &apiError{err: errors.Newf(errors.NotFound, format, args...), exception: exception}
+}

--- a/providers/aws/ecr/repo_policy.go
+++ b/providers/aws/ecr/repo_policy.go
@@ -1,10 +1,6 @@
 package ecr
 
-import (
-	"context"
-
-	"github.com/stackshy/cloudemu/v2/errors"
-)
+import "context"
 
 // SetRepositoryPolicy stores a repository's resource (permissions) policy.
 func (m *Mock) SetRepositoryPolicy(_ context.Context, repository, policyText string) (string, error) {
@@ -13,7 +9,7 @@ func (m *Mock) SetRepositoryPolicy(_ context.Context, repository, policyText str
 
 	rd, ok := m.repos.Get(repository)
 	if !ok {
-		return "", errors.Newf(errors.NotFound, "repository %q not found", repository)
+		return "", apiErrf(excRepositoryNotFound, "repository %q not found", repository)
 	}
 
 	rd.repoPolicy = policyText
@@ -29,11 +25,11 @@ func (m *Mock) GetRepositoryPolicy(_ context.Context, repository string) (string
 
 	rd, ok := m.repos.Get(repository)
 	if !ok {
-		return "", errors.Newf(errors.NotFound, "repository %q not found", repository)
+		return "", apiErrf(excRepositoryNotFound, "repository %q not found", repository)
 	}
 
 	if rd.repoPolicy == "" {
-		return "", errors.Newf(errors.NotFound, "no repository policy for %q", repository)
+		return "", apiErrf(excRepositoryPolicyNotFound, "no repository policy for %q", repository)
 	}
 
 	return rd.repoPolicy, nil
@@ -46,11 +42,11 @@ func (m *Mock) DeleteRepositoryPolicy(_ context.Context, repository string) (str
 
 	rd, ok := m.repos.Get(repository)
 	if !ok {
-		return "", errors.Newf(errors.NotFound, "repository %q not found", repository)
+		return "", apiErrf(excRepositoryNotFound, "repository %q not found", repository)
 	}
 
 	if rd.repoPolicy == "" {
-		return "", errors.Newf(errors.NotFound, "no repository policy for %q", repository)
+		return "", apiErrf(excRepositoryPolicyNotFound, "no repository policy for %q", repository)
 	}
 
 	policy := rd.repoPolicy

--- a/providers/aws/ecs/services.go
+++ b/providers/aws/ecs/services.go
@@ -454,6 +454,9 @@ func applyServiceRefs(svc *driver.Service, in *driver.UpdateServiceInput) {
 // ListServices returns services in a cluster in deterministic order.
 func (m *Mock) ListServices(_ context.Context, cluster string) ([]driver.Service, error) {
 	want := resolveClusterName(cluster)
+	if !m.clusterExists(want) {
+		return nil, apiErrf(errors.NotFound, excClusterNotFound, "cluster %q not found", want)
+	}
 
 	all := m.services.SortedValues()
 
@@ -474,6 +477,9 @@ func (m *Mock) ListServices(_ context.Context, cluster string) ([]driver.Service
 // DescribeServices resolves services by name or ARN; unresolved ids become failures.
 func (m *Mock) DescribeServices(_ context.Context, cluster string, ids []string) ([]driver.Service, []driver.Failure, error) {
 	want := resolveClusterName(cluster)
+	if !m.clusterExists(want) {
+		return nil, nil, apiErrf(errors.NotFound, excClusterNotFound, "cluster %q not found", want)
+	}
 
 	found := make([]driver.Service, 0, len(ids))
 	failures := make([]driver.Failure, 0, len(ids))

--- a/providers/aws/ecs/tasks.go
+++ b/providers/aws/ecs/tasks.go
@@ -334,12 +334,22 @@ func containersFor(td *driver.TaskDefinition) []driver.Container {
 // reserved back to the instance. Releasing is guarded by placeMu (shared with
 // placement) and skipped for an already-stopped task, so a repeated StopTask can
 // never double-credit an instance.
-func (m *Mock) StopTask(ctx context.Context, _, task, reason string) (*driver.Task, error) {
+func (m *Mock) StopTask(ctx context.Context, cluster, task, reason string) (*driver.Task, error) {
 	m.placeMu.Lock()
 	defer m.placeMu.Unlock()
 
+	// The cluster scopes the task lookup: a missing cluster is
+	// ClusterNotFoundException, matching real ECS (StopTask lists
+	// ClusterNotFoundException + InvalidParameterException).
+	want := resolveClusterName(cluster)
+	if !m.clusterExists(want) {
+		return nil, apiErrf(errors.NotFound, excClusterNotFound, "cluster %q not found", want)
+	}
+
+	// A task that resolves but lives in a different cluster is not visible to this
+	// StopTask, same as a task that does not exist at all: InvalidParameterException.
 	t, ok := m.resolveTask(task)
-	if !ok {
+	if !ok || clusterNameFromARN(t.ClusterARN) != want {
 		return nil, apiErrf(errors.NotFound, excInvalidParameter, "task %q not found", task)
 	}
 

--- a/providers/aws/eks/eks.go
+++ b/providers/aws/eks/eks.go
@@ -456,24 +456,21 @@ func (m *Mock) DeleteCluster(_ context.Context, name string) (*eksdriver.Cluster
 	//nolint:gocritic // Store.All copies values out anyway; the per-iter copy here is no extra cost.
 	for _, ng := range m.nodegroups.All() {
 		if ng.ClusterName == name {
-			return nil, cerrors.Newf(cerrors.FailedPrecondition,
-				"cluster %q still has nodegroup %q attached", name, ng.NodegroupName)
+			return nil, resourceInUseErrf("cluster %q still has nodegroup %q attached", name, ng.NodegroupName)
 		}
 	}
 
 	//nolint:gocritic // Store.All copies values out anyway; the per-iter copy here is no extra cost.
 	for _, fp := range m.fargateProfiles.All() {
 		if fp.ClusterName == name {
-			return nil, cerrors.Newf(cerrors.FailedPrecondition,
-				"cluster %q still has Fargate profile %q attached", name, fp.FargateProfileName)
+			return nil, resourceInUseErrf("cluster %q still has Fargate profile %q attached", name, fp.FargateProfileName)
 		}
 	}
 
 	//nolint:gocritic // Store.All copies values out anyway; the per-iter copy here is no extra cost.
 	for _, ad := range m.addons.All() {
 		if ad.ClusterName == name {
-			return nil, cerrors.Newf(cerrors.FailedPrecondition,
-				"cluster %q still has add-on %q installed", name, ad.AddonName)
+			return nil, resourceInUseErrf("cluster %q still has add-on %q installed", name, ad.AddonName)
 		}
 	}
 

--- a/providers/aws/eks/errors.go
+++ b/providers/aws/eks/errors.go
@@ -1,0 +1,42 @@
+package eks
+
+import (
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// apiError pairs a canonical cloudemu error with the precise EKS exception name
+// and HTTP status the server should surface. It unwraps to the underlying
+// *cerrors.Error so the cerrors.IsX predicates keep classifying it, while
+// exposing EKSException() for the server's error mapper.
+//
+// It is used where the generic code-based mapping would surface the wrong
+// exception: deleting a cluster that still has managed node groups, Fargate
+// profiles, or add-ons attached is a ResourceInUseException with HTTP 409, not
+// the InvalidRequestException (400) a bare FailedPrecondition maps to.
+type apiError struct {
+	err       *cerrors.Error
+	exception string
+	status    int
+}
+
+// Error implements the error interface.
+func (e *apiError) Error() string { return e.err.Error() }
+
+// EKSException returns the AWS exception name and HTTP status for this error.
+func (e *apiError) EKSException() (exception string, status int) { return e.exception, e.status }
+
+// Unwrap exposes the canonical error so errors.As(&*cerrors.Error) matches and
+// cerrors.GetCode reads the right code.
+func (e *apiError) Unwrap() error { return e.err }
+
+// resourceInUseErrf builds a ResourceInUseException (HTTP 409) carrying a
+// FailedPrecondition canonical code.
+func resourceInUseErrf(format string, args ...any) error {
+	return &apiError{
+		err:       cerrors.Newf(cerrors.FailedPrecondition, format, args...),
+		exception: "ResourceInUseException",
+		status:    http.StatusConflict,
+	}
+}

--- a/server/aws/ecr/handler.go
+++ b/server/aws/ecr/handler.go
@@ -9,6 +9,7 @@ package ecr
 
 import (
 	"context"
+	stderrors "errors"
 	"net/http"
 	"strings"
 	"time"
@@ -136,6 +137,16 @@ func writePutImageErr(w http.ResponseWriter, err error) {
 // returns errors as HTTP 400 with a "__type" body the SDK maps to a typed
 // exception.
 func writeErr(w http.ResponseWriter, err error) {
+	// A provider error may carry a precise ECR exception name (e.g.
+	// ImageNotFoundException vs ScanNotFoundException vs
+	// RepositoryPolicyNotFoundException), which the generic code-based mapping
+	// below would otherwise collapse to RepositoryNotFoundException.
+	var ex interface{ ECRException() string }
+	if stderrors.As(err, &ex) {
+		wire.WriteJSONError(w, http.StatusBadRequest, ex.ECRException(), err.Error())
+		return
+	}
+
 	switch {
 	case cerrors.IsNotFound(err):
 		wire.WriteJSONError(w, http.StatusBadRequest, "RepositoryNotFoundException", err.Error())

--- a/server/aws/ecr/image_scan_test.go
+++ b/server/aws/ecr/image_scan_test.go
@@ -1,0 +1,146 @@
+package ecr_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsecr "github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+)
+
+// TestSDKDescribeImageScanFindingsMissingImage guards that, for an existing
+// repository but an imageId that resolves to no image, DescribeImageScanFindings
+// returns ImageNotFoundException — not RepositoryNotFoundException (the finding
+// was that the generic NotFound→RepositoryNotFoundException mapping mislabeled a
+// missing image as a missing repository).
+func TestSDKDescribeImageScanFindingsMissingImage(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("scan-repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	_, err := client.DescribeImageScanFindings(ctx, &awsecr.DescribeImageScanFindingsInput{
+		RepositoryName: aws.String("scan-repo"),
+		ImageId:        &ecrtypes.ImageIdentifier{ImageTag: aws.String("ghost")},
+	})
+
+	var imgNF *ecrtypes.ImageNotFoundException
+	if !errors.As(err, &imgNF) {
+		t.Fatalf("DescribeImageScanFindings(missing image) err = %v, want ImageNotFoundException", err)
+	}
+}
+
+// TestSDKDescribeImageScanFindingsNoScan guards that, for an image that exists
+// but has no scan results (scanOnPush disabled, StartImageScan never called),
+// DescribeImageScanFindings returns ScanNotFoundException so callers can tell
+// "no scan" apart from "no repository".
+func TestSDKDescribeImageScanFindingsNoScan(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("scan-repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	if _, err := client.PutImage(ctx, &awsecr.PutImageInput{
+		RepositoryName: aws.String("scan-repo"),
+		ImageManifest:  aws.String(sampleManifest),
+		ImageTag:       aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("PutImage: %v", err)
+	}
+
+	_, err := client.DescribeImageScanFindings(ctx, &awsecr.DescribeImageScanFindingsInput{
+		RepositoryName: aws.String("scan-repo"),
+		ImageId:        &ecrtypes.ImageIdentifier{ImageTag: aws.String("v1")},
+	})
+
+	var scanNF *ecrtypes.ScanNotFoundException
+	if !errors.As(err, &scanNF) {
+		t.Fatalf("DescribeImageScanFindings(no scan) err = %v, want ScanNotFoundException", err)
+	}
+}
+
+// TestSDKDescribeImageScanFindingsMissingRepo guards that a genuinely missing
+// repository still surfaces RepositoryNotFoundException (the image/scan
+// distinction must not swallow the repository case).
+func TestSDKDescribeImageScanFindingsMissingRepo(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	_, err := client.DescribeImageScanFindings(ctx, &awsecr.DescribeImageScanFindingsInput{
+		RepositoryName: aws.String("ghost-repo"),
+		ImageId:        &ecrtypes.ImageIdentifier{ImageTag: aws.String("v1")},
+	})
+
+	var repoNF *ecrtypes.RepositoryNotFoundException
+	if !errors.As(err, &repoNF) {
+		t.Fatalf("DescribeImageScanFindings(missing repo) err = %v, want RepositoryNotFoundException", err)
+	}
+}
+
+// TestSDKStartImageScanMissingImage guards that StartImageScan for an imageId
+// that does not resolve in an existing repository returns ImageNotFoundException
+// rather than RepositoryNotFoundException.
+func TestSDKStartImageScanMissingImage(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("scan-repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	_, err := client.StartImageScan(ctx, &awsecr.StartImageScanInput{
+		RepositoryName: aws.String("scan-repo"),
+		ImageId:        &ecrtypes.ImageIdentifier{ImageTag: aws.String("ghost")},
+	})
+
+	var imgNF *ecrtypes.ImageNotFoundException
+	if !errors.As(err, &imgNF) {
+		t.Fatalf("StartImageScan(missing image) err = %v, want ImageNotFoundException", err)
+	}
+}
+
+// TestSDKDeleteRepositoryPolicyNoPolicy guards that DeleteRepositoryPolicy on an
+// existing repository that has no policy set returns
+// RepositoryPolicyNotFoundException — consistent with GetRepositoryPolicy, and
+// not RepositoryNotFoundException.
+func TestSDKDeleteRepositoryPolicyNoPolicy(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("policy-repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	_, err := client.DeleteRepositoryPolicy(ctx, &awsecr.DeleteRepositoryPolicyInput{
+		RepositoryName: aws.String("policy-repo"),
+	})
+
+	var polNF *ecrtypes.RepositoryPolicyNotFoundException
+	if !errors.As(err, &polNF) {
+		t.Fatalf("DeleteRepositoryPolicy(no policy) err = %v, want RepositoryPolicyNotFoundException", err)
+	}
+
+	// A genuinely missing repository still reports RepositoryNotFoundException.
+	_, err = client.DeleteRepositoryPolicy(ctx, &awsecr.DeleteRepositoryPolicyInput{
+		RepositoryName: aws.String("ghost-repo"),
+	})
+
+	var repoNF *ecrtypes.RepositoryNotFoundException
+	if !errors.As(err, &repoNF) {
+		t.Fatalf("DeleteRepositoryPolicy(missing repo) err = %v, want RepositoryNotFoundException", err)
+	}
+}

--- a/server/aws/ecr/repo_policy.go
+++ b/server/aws/ecr/repo_policy.go
@@ -48,39 +48,25 @@ func (h *Handler) setRepositoryPolicy(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) getRepositoryPolicy(w http.ResponseWriter, r *http.Request) {
-	mgr, ok := h.repoPolicyMgr()
-	if !ok {
-		writeErr(w, cerrors.New(cerrors.Unimplemented, "repository policies not supported"))
-		return
-	}
-
-	var req struct {
-		RepositoryName string `json:"repositoryName"`
-	}
-
-	if !wire.DecodeJSON(w, r, &req) {
-		return
-	}
-
-	policy, err := mgr.GetRepositoryPolicy(r.Context(), req.RepositoryName)
-	if err != nil {
-		// Distinguish a missing repository from a repository that simply has no
-		// policy: real ECR returns RepositoryPolicyNotFoundException for the
-		// latter, RepositoryNotFoundException for the former.
-		if _, repoErr := h.registry.GetRepository(r.Context(), req.RepositoryName); repoErr != nil {
-			writeErr(w, repoErr)
-			return
-		}
-
-		wire.WriteJSONError(w, http.StatusBadRequest, "RepositoryPolicyNotFoundException", err.Error())
-
-		return
-	}
-
-	wire.WriteJSON(w, map[string]any{"repositoryName": req.RepositoryName, "policyText": policy})
+	// The provider tags a missing repository (RepositoryNotFoundException) and a
+	// repository with no policy (RepositoryPolicyNotFoundException) with the
+	// precise exception name, which writeErr surfaces.
+	h.runRepoPolicyOp(w, r, repoPolicyManager.GetRepositoryPolicy)
 }
 
 func (h *Handler) deleteRepositoryPolicy(w http.ResponseWriter, r *http.Request) {
+	// A repository with no policy is RepositoryPolicyNotFoundException, a missing
+	// repository is RepositoryNotFoundException — both carried by the provider's
+	// tagged error and surfaced by writeErr.
+	h.runRepoPolicyOp(w, r, repoPolicyManager.DeleteRepositoryPolicy)
+}
+
+// runRepoPolicyOp runs a repository-name-only policy operation (get or delete)
+// and writes the resulting policyText, sharing the manager guard, request
+// decode, and error mapping between the two handlers.
+func (h *Handler) runRepoPolicyOp(
+	w http.ResponseWriter, r *http.Request, op func(repoPolicyManager, context.Context, string) (string, error),
+) {
 	mgr, ok := h.repoPolicyMgr()
 	if !ok {
 		writeErr(w, cerrors.New(cerrors.Unimplemented, "repository policies not supported"))
@@ -95,7 +81,7 @@ func (h *Handler) deleteRepositoryPolicy(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	policy, err := mgr.DeleteRepositoryPolicy(r.Context(), req.RepositoryName)
+	policy, err := op(mgr, r.Context(), req.RepositoryName)
 	if err != nil {
 		writeErr(w, err)
 		return

--- a/server/aws/ecs/cluster_scoping_test.go
+++ b/server/aws/ecs/cluster_scoping_test.go
@@ -1,0 +1,146 @@
+package ecs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+)
+
+// TestSDKStopTaskClusterScoping guards that StopTask honors its cluster
+// argument: a task is scoped to the cluster that owns it, so stopping it against
+// a nonexistent cluster is ClusterNotFoundException and stopping it against a
+// different (existing) cluster is InvalidParameterException — matching the
+// StopTask Errors section. The task must survive both rejected calls.
+func TestSDKStopTaskClusterScoping(t *testing.T) {
+	client, cloud := newECSServer(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"prod", "staging"} {
+		if _, err := client.CreateCluster(ctx, &awsecs.CreateClusterInput{ClusterName: aws.String(name)}); err != nil {
+			t.Fatalf("CreateCluster(%s): %v", name, err)
+		}
+	}
+
+	registerNginx(t, client, ctx)
+	cloud.ECS.SeedContainerInstance("prod", "i-scope")
+
+	run, err := client.RunTask(ctx, &awsecs.RunTaskInput{
+		Cluster:        aws.String("prod"),
+		TaskDefinition: aws.String("web"),
+	})
+	if err != nil {
+		t.Fatalf("RunTask: %v", err)
+	}
+
+	if len(run.Tasks) != 1 {
+		t.Fatalf("RunTask = %d tasks, want 1 (failures %+v)", len(run.Tasks), run.Failures)
+	}
+
+	taskARN := aws.ToString(run.Tasks[0].TaskArn)
+
+	// A cluster that was never created is ClusterNotFoundException.
+	_, err = client.StopTask(ctx, &awsecs.StopTaskInput{
+		Cluster: aws.String("ghost"),
+		Task:    aws.String(taskARN),
+	})
+
+	var cnf *ecstypes.ClusterNotFoundException
+	if !errorsAs(err, &cnf) {
+		t.Fatalf("StopTask(ghost cluster) err = %v, want ClusterNotFoundException", err)
+	}
+
+	// An existing cluster that does not own the task is InvalidParameterException.
+	_, err = client.StopTask(ctx, &awsecs.StopTaskInput{
+		Cluster: aws.String("staging"),
+		Task:    aws.String(taskARN),
+	})
+
+	var ipe *ecstypes.InvalidParameterException
+	if !errorsAs(err, &ipe) {
+		t.Fatalf("StopTask(wrong cluster) err = %v, want InvalidParameterException", err)
+	}
+
+	// The task must be untouched by the two rejected calls.
+	desc, err := client.DescribeTasks(ctx, &awsecs.DescribeTasksInput{
+		Cluster: aws.String("prod"),
+		Tasks:   []string{taskARN},
+	})
+	if err != nil {
+		t.Fatalf("DescribeTasks: %v", err)
+	}
+
+	if len(desc.Tasks) != 1 || aws.ToString(desc.Tasks[0].LastStatus) != "RUNNING" {
+		t.Fatalf("task after rejected StopTasks = %+v, want a single RUNNING task", desc.Tasks)
+	}
+
+	// The correct cluster stops it.
+	stopped, err := client.StopTask(ctx, &awsecs.StopTaskInput{
+		Cluster: aws.String("prod"),
+		Task:    aws.String(taskARN),
+		Reason:  aws.String("done"),
+	})
+	if err != nil {
+		t.Fatalf("StopTask(prod): %v", err)
+	}
+
+	if aws.ToString(stopped.Task.LastStatus) != "STOPPED" {
+		t.Fatalf("StopTask(prod) status = %q, want STOPPED", aws.ToString(stopped.Task.LastStatus))
+	}
+}
+
+// TestSDKListServicesMissingCluster guards that ListServices against a
+// nonexistent cluster returns ClusterNotFoundException rather than an empty
+// list, as documented in the ListServices Errors section.
+func TestSDKListServicesMissingCluster(t *testing.T) {
+	client := newECSClient(t)
+	ctx := context.Background()
+
+	_, err := client.ListServices(ctx, &awsecs.ListServicesInput{Cluster: aws.String("ghost")})
+
+	var cnf *ecstypes.ClusterNotFoundException
+	if !errorsAs(err, &cnf) {
+		t.Fatalf("ListServices(ghost) err = %v, want ClusterNotFoundException", err)
+	}
+}
+
+// TestSDKDescribeServicesMissingCluster guards that DescribeServices against a
+// nonexistent cluster returns ClusterNotFoundException rather than an empty
+// services list with a MISSING failure.
+func TestSDKDescribeServicesMissingCluster(t *testing.T) {
+	client := newECSClient(t)
+	ctx := context.Background()
+
+	_, err := client.DescribeServices(ctx, &awsecs.DescribeServicesInput{
+		Cluster:  aws.String("ghost"),
+		Services: []string{"svc"},
+	})
+
+	var cnf *ecstypes.ClusterNotFoundException
+	if !errorsAs(err, &cnf) {
+		t.Fatalf("DescribeServices(ghost) err = %v, want ClusterNotFoundException", err)
+	}
+}
+
+// TestSDKListServicesEmptyClusterExists guards that ListServices against a real
+// but empty cluster still succeeds with an empty list (the guard rejects only
+// missing clusters, not empty ones).
+func TestSDKListServicesEmptyClusterExists(t *testing.T) {
+	client, _ := newECSServer(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsecs.CreateClusterInput{ClusterName: aws.String("prod")}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	out, err := client.ListServices(ctx, &awsecs.ListServicesInput{Cluster: aws.String("prod")})
+	if err != nil {
+		t.Fatalf("ListServices(prod): %v", err)
+	}
+
+	if len(out.ServiceArns) != 0 {
+		t.Fatalf("ListServices(empty prod) = %v, want no services", out.ServiceArns)
+	}
+}

--- a/server/aws/eks/delete_cluster_test.go
+++ b/server/aws/eks/delete_cluster_test.go
@@ -1,0 +1,74 @@
+package eks_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+)
+
+// TestSDKDeleteClusterWithNodegroupInUse guards that deleting a cluster that
+// still has a managed node group attached returns ResourceInUseException with
+// HTTP status 409 (per the DeleteCluster API reference), and that the surfaced
+// message does not leak the internal canonical-code prefix. Deleting the node
+// group first must then let the cluster delete.
+func TestSDKDeleteClusterWithNodegroupInUse(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awseks.CreateClusterInput{
+		Name:               aws.String("c1"),
+		RoleArn:            aws.String("arn:aws:iam::1:role/r"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{SubnetIds: []string{"subnet-1"}},
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := client.CreateNodegroup(ctx, &awseks.CreateNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+		NodeRole:      aws.String("arn:aws:iam::1:role/r"),
+		Subnets:       []string{"subnet-1"},
+	}); err != nil {
+		t.Fatalf("CreateNodegroup: %v", err)
+	}
+
+	_, err := client.DeleteCluster(ctx, &awseks.DeleteClusterInput{Name: aws.String("c1")})
+
+	var inUse *ekstypes.ResourceInUseException
+	if !errors.As(err, &inUse) {
+		t.Fatalf("DeleteCluster(with nodegroup) err = %v, want ResourceInUseException", err)
+	}
+
+	// HTTP 409 Conflict, not 400.
+	var httpErr interface{ HTTPStatusCode() int }
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("DeleteCluster error carries no HTTP status: %v", err)
+	}
+
+	if got := httpErr.HTTPStatusCode(); got != 409 {
+		t.Fatalf("DeleteCluster(with nodegroup) HTTP status = %d, want 409", got)
+	}
+
+	// The message must read like real AWS, not leak the "FailedPrecondition:"
+	// canonical-code prefix.
+	if msg := inUse.ErrorMessage(); strings.Contains(msg, "FailedPrecondition") {
+		t.Fatalf("DeleteCluster message leaks canonical-code prefix: %q", msg)
+	}
+
+	// Removing the node group unblocks the delete.
+	if _, err := client.DeleteNodegroup(ctx, &awseks.DeleteNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+	}); err != nil {
+		t.Fatalf("DeleteNodegroup: %v", err)
+	}
+
+	if _, err := client.DeleteCluster(ctx, &awseks.DeleteClusterInput{Name: aws.String("c1")}); err != nil {
+		t.Fatalf("DeleteCluster after draining nodegroup: %v", err)
+	}
+}

--- a/server/aws/eks/errors.go
+++ b/server/aws/eks/errors.go
@@ -2,6 +2,7 @@ package eks
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"net/http"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -28,6 +29,21 @@ func writeError(w http.ResponseWriter, status int, errType, msg string) {
 
 // writeErr maps cloudemu canonical errors to EKS-shaped error responses.
 func writeErr(w http.ResponseWriter, err error) {
+	// A provider error may carry a precise EKS exception name and HTTP status
+	// (e.g. ResourceInUseException/409 for deleting a cluster that still has
+	// node groups, Fargate profiles, or add-ons attached), which the generic
+	// code-based mapping below would otherwise surface as InvalidRequestException.
+	var ex interface {
+		EKSException() (string, int)
+	}
+
+	if stderrors.As(err, &ex) {
+		name, status := ex.EKSException()
+		writeError(w, status, name, wireMessage(err))
+
+		return
+	}
+
 	switch {
 	case cerrors.IsNotFound(err):
 		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
@@ -40,4 +56,16 @@ func writeErr(w http.ResponseWriter, err error) {
 	default:
 		writeError(w, http.StatusInternalServerError, "ServerException", err.Error())
 	}
+}
+
+// wireMessage returns the bare error message for the wire, stripping the
+// internal "<Code>: " prefix that cerrors.Error.Error() adds so the surfaced
+// exception message reads like real AWS rather than leaking the canonical code.
+func wireMessage(err error) string {
+	var ce *cerrors.Error
+	if stderrors.As(err, &ce) {
+		return ce.Message
+	}
+
+	return err.Error()
 }


### PR DESCRIPTION
## Summary

Round-3 real-user AWS audit fixes for the ecs-ecr-eks cluster. Each change is a wire-fidelity error-code/scoping fix verified against the official AWS API references, with real aws-sdk-go-v2 client tests over an httptest server.

### ECS — cluster scoping (findings 1-3)
- **StopTask** now honors its `cluster` argument. A missing cluster returns `ClusterNotFoundException`; a task that resolves but lives in a different cluster returns `InvalidParameterException`. Previously the cluster was ignored and the task was resolved globally by ARN, so `StopTask(cluster="ghost")` stopped the task.
- **ListServices** against a nonexistent cluster returns `ClusterNotFoundException` instead of HTTP 200 with an empty list.
- **DescribeServices** against a nonexistent cluster returns `ClusterNotFoundException` instead of HTTP 200 with a MISSING failure.

These mirror the existing `ListTasks`/`DescribeTasks`/`DeleteService` guards (`clusterExists`).

### ECR — precise not-found exceptions (findings 4-6, 8)
The provider previously returned a generic `NotFound` for four distinct real-ECR exceptions, which the server collapsed to `RepositoryNotFoundException`. Added an ECR exceptioner (`providers/aws/ecr/errors.go`) so the provider tags each case, and the server `writeErr` surfaces it:
- **DescribeImageScanFindings** / **StartImageScan** — missing image is `ImageNotFoundException`; an image with no scan is `ScanNotFoundException`; a missing repository stays `RepositoryNotFoundException`.
- **DeleteRepositoryPolicy** — a repo with no policy is `RepositoryPolicyNotFoundException` (now consistent with `GetRepositoryPolicy`).

`getRepositoryPolicy` and `deleteRepositoryPolicy` now share a single handler helper.

### EKS — DeleteCluster in-use guard (finding 7)
Deleting a cluster that still has a managed node group, Fargate profile, or add-on attached now returns `ResourceInUseException` with **HTTP 409** (was `InvalidRequestException`/400). The surfaced message no longer leaks the internal `FailedPrecondition:` canonical-code prefix (new `wireMessage` stripper mirroring ECS).

## Tests
Real aws-sdk-go-v2 client assertions on exact typed exceptions / HTTP status:
- `server/aws/ecs/cluster_scoping_test.go`
- `server/aws/ecr/image_scan_test.go`
- `server/aws/eks/delete_cluster_test.go`

No driver interface changed, so `docs/coverage` is unaffected.

## Gates
`go build ./...`, `go vet`, and `go test ./providers/aws/... ./server/aws/... .` pass. Lint is clean on all changed code (one pre-existing `wsl` warning in `providers/aws/eks/eks.go:345` predates this branch and is left untouched).