### PR TITLE
fix(route53-sfn): SetIdentifier record DELETE, DeleteHostedZone guard, ALIAS + latency/failover/geo routing, SFN StartExecution idempotency

### DIFF
--- a/providers/aws/route53/route53.go
+++ b/providers/aws/route53/route53.go
@@ -148,10 +148,11 @@ func (m *Mock) DeleteZone(_ context.Context, id string) error {
 		return errors.Newf(errors.NotFound, "zone %q not found", id)
 	}
 
-	// Delete all records belonging to this zone.
+	// Delete all records belonging to this zone. Index by key rather than
+	// ranging the value so a grown RecordInfo isn't copied each iteration.
 	all := m.records.All()
-	for key, rec := range all {
-		if rec.ZoneID == id {
+	for key := range all {
+		if all[key].ZoneID == id {
 			m.records.Delete(key)
 		}
 	}
@@ -248,20 +249,7 @@ func (m *Mock) CreateRecord(_ context.Context, cfg driver.RecordConfig) (*driver
 		return nil, errors.Newf(errors.AlreadyExists, "record %q already exists in zone %q", cfg.Name, cfg.ZoneID)
 	}
 
-	values := make([]string, len(cfg.Values))
-	copy(values, cfg.Values)
-
-	weight := copyWeight(cfg.Weight)
-
-	rec := driver.RecordInfo{
-		ZoneID: cfg.ZoneID,
-		Name:   cfg.Name,
-		Type:   cfg.Type,
-		TTL:    cfg.TTL,
-		Values: values,
-		Weight: weight,
-		SetID:  cfg.SetID,
-	}
+	rec := recordFromConfig(cfg)
 
 	m.records.Set(key, rec)
 
@@ -276,43 +264,30 @@ func (m *Mock) CreateRecord(_ context.Context, cfg driver.RecordConfig) (*driver
 	return &result, nil
 }
 
-// DeleteRecord deletes a DNS record from the specified zone.
-func (m *Mock) DeleteRecord(_ context.Context, zoneID, name, recordType string) error {
+// DeleteRecord deletes a DNS record from the specified zone. It targets the
+// record set with no SetIdentifier (a simple, non-routing record); routing
+// record sets are addressed by SetIdentifier via DeleteRecordSet.
+func (m *Mock) DeleteRecord(ctx context.Context, zoneID, name, recordType string) error {
+	return m.DeleteRecordSet(ctx, zoneID, name, recordType, "")
+}
+
+// DeleteRecordSet deletes the single record set identified by
+// zoneID+name+type+setID. It never touches sibling record sets that share the
+// same name+type but carry a different SetIdentifier — a DELETE of one
+// weighted/latency/failover/geo record must leave its siblings intact.
+func (m *Mock) DeleteRecordSet(_ context.Context, zoneID, name, recordType, setID string) error {
 	if _, ok := m.zones.Get(zoneID); !ok {
 		return errors.Newf(errors.NotFound, "zone %q not found", zoneID)
 	}
 
-	key := recordKey(zoneID, name, recordType, "")
+	key := recordKey(zoneID, name, recordType, setID)
 
-	// Try without set ID first. If not found, search for any matching record with a set ID.
-	if m.records.Delete(key) {
-		m.zones.Update(zoneID, func(z driver.ZoneInfo) driver.ZoneInfo {
-			z.RecordCount--
-			return z
-		})
-
-		return nil
-	}
-
-	// Search for weighted records with a set ID.
-	prefix := zoneID + ":" + name + ":" + recordType + ":"
-	all := m.records.All()
-	deleted := 0
-
-	for k := range all {
-		if strings.HasPrefix(k, prefix) {
-			m.records.Delete(k)
-
-			deleted++
-		}
-	}
-
-	if deleted == 0 {
+	if !m.records.Delete(key) {
 		return errors.Newf(errors.NotFound, "record %q of type %q not found in zone %q", name, recordType, zoneID)
 	}
 
 	m.zones.Update(zoneID, func(z driver.ZoneInfo) driver.ZoneInfo {
-		z.RecordCount -= deleted
+		z.RecordCount--
 		return z
 	})
 
@@ -337,9 +312,11 @@ func (m *Mock) GetRecord(_ context.Context, zoneID, name, recordType string) (*d
 	// sorted-key order and return the lowest set ID, so a name+type with
 	// several weighted records resolves to the same record every call rather
 	// than a map-order-random one (#259).
-	for _, r := range m.records.SortedValues() {
+	sorted := m.records.SortedValues()
+	for i := range sorted {
+		r := &sorted[i]
 		if r.ZoneID == zoneID && r.Name == name && r.Type == recordType && r.SetID != "" {
-			result := r
+			result := *r
 			return &result, nil
 		}
 	}
@@ -359,9 +336,9 @@ func (m *Mock) ListRecords(_ context.Context, zoneID string) ([]driver.RecordInf
 	all := m.records.SortedValues()
 
 	records := make([]driver.RecordInfo, 0, len(all))
-	for _, rec := range all {
-		if rec.ZoneID == zoneID {
-			records = append(records, rec)
+	for i := range all {
+		if all[i].ZoneID == zoneID {
+			records = append(records, all[i])
 		}
 	}
 
@@ -382,26 +359,39 @@ func (m *Mock) UpdateRecord(_ context.Context, cfg driver.RecordConfig) (*driver
 		return nil, errors.Newf(errors.NotFound, "record %q of type %q not found in zone %q", cfg.Name, cfg.Type, cfg.ZoneID)
 	}
 
-	values := make([]string, len(cfg.Values))
-	copy(values, cfg.Values)
-
-	weight := copyWeight(cfg.Weight)
-
-	rec := driver.RecordInfo{
-		ZoneID: cfg.ZoneID,
-		Name:   cfg.Name,
-		Type:   cfg.Type,
-		TTL:    cfg.TTL,
-		Values: values,
-		Weight: weight,
-		SetID:  cfg.SetID,
-	}
+	rec := recordFromConfig(cfg)
 
 	m.records.Set(key, rec)
 
 	result := rec
 
 	return &result, nil
+}
+
+// recordFromConfig builds a stored RecordInfo from a RecordConfig, deep-copying
+// the slice and pointer fields so a later caller mutation cannot reach into the
+// store.
+//
+//nolint:gocritic // hugeParam: value copy is intentional to detach from caller.
+func recordFromConfig(cfg driver.RecordConfig) driver.RecordInfo {
+	values := make([]string, len(cfg.Values))
+	copy(values, cfg.Values)
+
+	return driver.RecordInfo{
+		ZoneID:           cfg.ZoneID,
+		Name:             cfg.Name,
+		Type:             cfg.Type,
+		TTL:              cfg.TTL,
+		Values:           values,
+		Weight:           copyWeight(cfg.Weight),
+		SetID:            cfg.SetID,
+		Failover:         cfg.Failover,
+		Region:           cfg.Region,
+		HealthCheckID:    cfg.HealthCheckID,
+		MultiValueAnswer: copyBool(cfg.MultiValueAnswer),
+		GeoLocation:      copyGeo(cfg.GeoLocation),
+		AliasTarget:      copyAlias(cfg.AliasTarget),
+	}
 }
 
 // copyWeight creates a copy of a weight pointer.
@@ -411,6 +401,39 @@ func copyWeight(w *int) *int {
 	}
 
 	v := *w
+
+	return &v
+}
+
+// copyBool copies a *bool so stored records don't alias caller memory.
+func copyBool(b *bool) *bool {
+	if b == nil {
+		return nil
+	}
+
+	v := *b
+
+	return &v
+}
+
+// copyGeo copies a *GeoLocation so stored records don't alias caller memory.
+func copyGeo(g *driver.GeoLocation) *driver.GeoLocation {
+	if g == nil {
+		return nil
+	}
+
+	v := *g
+
+	return &v
+}
+
+// copyAlias copies a *AliasTarget so stored records don't alias caller memory.
+func copyAlias(a *driver.AliasTarget) *driver.AliasTarget {
+	if a == nil {
+		return nil
+	}
+
+	v := *a
 
 	return &v
 }

--- a/providers/aws/route53/route53_test.go
+++ b/providers/aws/route53/route53_test.go
@@ -330,6 +330,46 @@ func TestWeightedRecords(t *testing.T) {
 	assertNotEmpty(t, rec.Name)
 }
 
+func TestDeleteRecordSetKeepsSiblings(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	z := createTestZone(m)
+
+	w := 10
+	for _, id := range []string{"blue", "green", "red"} {
+		_, err := m.CreateRecord(ctx, driver.RecordConfig{
+			ZoneID: z.ID, Name: "app.example.com", Type: "A",
+			TTL: 60, Values: []string{"1.1.1.1"}, Weight: &w, SetID: id,
+		})
+		requireNoError(t, err)
+	}
+
+	// Deleting one SetIdentifier must leave the other two intact.
+	requireNoError(t, m.DeleteRecordSet(ctx, z.ID, "app.example.com", "A", "green"))
+
+	records, err := m.ListRecords(ctx, z.ID)
+	requireNoError(t, err)
+
+	var setIDs []string
+
+	for i := range records {
+		if records[i].Name == "app.example.com" {
+			setIDs = append(setIDs, records[i].SetID)
+		}
+	}
+
+	assertEqual(t, 2, len(setIDs))
+
+	for _, id := range setIDs {
+		if id == "green" {
+			t.Fatalf("green survived DeleteRecordSet: %v", setIDs)
+		}
+	}
+
+	// Deleting a missing SetIdentifier is a not-found, not a silent no-op.
+	assertError(t, m.DeleteRecordSet(ctx, z.ID, "app.example.com", "A", "green"), true)
+}
+
 func TestDeleteZoneCascadesRecords(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/providers/aws/sfn/executions.go
+++ b/providers/aws/sfn/executions.go
@@ -42,6 +42,7 @@ func (m *Mock) runExecution(in driver.StartExecutionInput, async bool) (*driver.
 
 	sd.mu.RLock()
 	smName := sd.sm.Name
+	smType := sd.sm.Type
 	sd.mu.RUnlock()
 
 	name := in.Name
@@ -73,12 +74,36 @@ func (m *Mock) runExecution(in driver.StartExecutionInput, async bool) (*driver.
 	}
 
 	if !m.executions.SetIfAbsent(arn, &execData{exec: exec, settle: window}) {
-		return nil, execAlreadyExists(name)
+		return m.idempotentReuse(arn, name, smType, in.Input, async, now)
 	}
 
 	out := observedExec(&exec, window, now)
 
 	return &out, nil
+}
+
+// idempotentReuse resolves a StartExecution name collision. StartExecution is
+// idempotent for STANDARD workflows: reusing the name of a still-running
+// execution with the *same* input succeeds and returns that execution. A
+// different input, a closed (settled) execution, or an EXPRESS workflow all
+// yield ExecutionAlreadyExists.
+func (m *Mock) idempotentReuse(arn, name, smType, input string, async bool, now time.Time) (*driver.Execution, error) {
+	ed, ok := m.executions.Get(arn)
+	if !ok || !async || smType != driver.TypeStandard {
+		return nil, execAlreadyExists(name)
+	}
+
+	ed.mu.RLock()
+	sameInput := ed.exec.Input == input
+	running := !ed.settle.Settled(now)
+	out := observedExec(&ed.exec, ed.settle, now)
+	ed.mu.RUnlock()
+
+	if sameInput && running {
+		return &out, nil
+	}
+
+	return nil, execAlreadyExists(name)
 }
 
 // observedExec overlays a RUNNING settle window onto a stored (terminal)

--- a/server/aws/route53/delete_hosted_zone_test.go
+++ b/server/aws/route53/delete_hosted_zone_test.go
@@ -1,0 +1,54 @@
+package route53_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+// TestSDKDeleteHostedZoneNotEmpty pins the non-empty guard: a zone holding a
+// user record cannot be deleted (400 HostedZoneNotEmpty), and once that record
+// is removed the same delete succeeds.
+func TestSDKDeleteHostedZoneNotEmpty(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+	zoneID := createRoutingZone(t, client, "guard.com.")
+
+	changeRecordSet(t, client, zoneID, r53types.ChangeActionCreate, &r53types.ResourceRecordSet{
+		Name: aws.String("www.guard.com."), Type: r53types.RRTypeA, TTL: aws.Int64(300),
+		ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.1")}},
+	})
+
+	_, err := client.DeleteHostedZone(ctx, &awsr53.DeleteHostedZoneInput{Id: aws.String(zoneID)})
+
+	var notEmpty *r53types.HostedZoneNotEmpty
+	if !errors.As(err, &notEmpty) {
+		t.Fatalf("DeleteHostedZone(non-empty) = %v, want HostedZoneNotEmpty", err)
+	}
+
+	// The zone (and its record) must still be there.
+	if _, gerr := client.GetHostedZone(ctx, &awsr53.GetHostedZoneInput{Id: aws.String(zoneID)}); gerr != nil {
+		t.Fatalf("zone should survive a rejected delete, GetHostedZone: %v", gerr)
+	}
+
+	// Remove the user record; only the default SOA + NS remain, so delete works.
+	changeRecordSet(t, client, zoneID, r53types.ChangeActionDelete, &r53types.ResourceRecordSet{
+		Name: aws.String("www.guard.com."), Type: r53types.RRTypeA, TTL: aws.Int64(300),
+		ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.1")}},
+	})
+
+	if _, err := client.DeleteHostedZone(ctx, &awsr53.DeleteHostedZoneInput{Id: aws.String(zoneID)}); err != nil {
+		t.Fatalf("DeleteHostedZone(now empty): %v", err)
+	}
+
+	_, err = client.GetHostedZone(ctx, &awsr53.GetHostedZoneInput{Id: aws.String(zoneID)})
+
+	var notFound *r53types.NoSuchHostedZone
+	if !errors.As(err, &notFound) {
+		t.Fatalf("GetHostedZone after delete = %v, want NoSuchHostedZone", err)
+	}
+}

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -1,6 +1,7 @@
 package route53
 
 import (
+	"context"
 	"encoding/xml"
 	"net/http"
 	"sort"
@@ -120,7 +121,31 @@ func (h *Handler) listHostedZones(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) deleteHostedZone(w http.ResponseWriter, r *http.Request, id string) {
-	if err := h.dns.DeleteZone(r.Context(), trimZonePrefix(id)); err != nil {
+	zoneID := trimZonePrefix(id)
+
+	zone, err := h.dns.GetZone(r.Context(), zoneID)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	// Real Route 53 deletes a hosted zone only when it holds nothing but the
+	// default SOA and apex NS records; any other record set returns a 400
+	// HostedZoneNotEmpty and deletes nothing.
+	records, err := h.dns.ListRecords(r.Context(), zoneID)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if extra := extraRecordName(zone.Name, records); extra != "" {
+		writeError(w, http.StatusBadRequest, "HostedZoneNotEmpty",
+			"The hosted zone contains resource records that are not SOA or NS records, or a custom NS record: "+extra)
+
+		return
+	}
+
+	if err := h.dns.DeleteZone(r.Context(), zoneID); err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -129,6 +154,28 @@ func (h *Handler) deleteHostedZone(w http.ResponseWriter, r *http.Request, id st
 		Xmlns:      xmlns,
 		ChangeInfo: newChangeInfo(),
 	})
+}
+
+// extraRecordName returns the name of the first record set that blocks deletion
+// (any record beyond the default apex SOA and apex NS), or "" when the zone is
+// empty enough to delete. Matching is case-insensitive and trailing-dot
+// insensitive so an apex name written either way is recognized.
+func extraRecordName(zoneName string, records []dnsdriver.RecordInfo) string {
+	apex := strings.ToLower(strings.TrimSuffix(zoneName, "."))
+
+	for i := range records {
+		rec := &records[i]
+		name := strings.ToLower(strings.TrimSuffix(rec.Name, "."))
+		isApex := name == apex
+
+		if isApex && (rec.Type == "SOA" || rec.Type == "NS") {
+			continue
+		}
+
+		return rec.Name
+	}
+
+	return ""
 }
 
 // changeResourceRecordSets applies a CREATE/UPSERT/DELETE batch against the
@@ -225,7 +272,7 @@ func (h *Handler) applyChange(r *http.Request, zoneID string, ch *changeItem) er
 
 	switch ch.Action {
 	case actionDelete:
-		return h.dns.DeleteRecord(r.Context(), zoneID, rr.Name, rr.Type)
+		return h.deleteRecordSet(r, zoneID, rr)
 	case actionCreate:
 		_, err := h.dns.CreateRecord(r.Context(), cfg)
 		return err
@@ -236,19 +283,37 @@ func (h *Handler) applyChange(r *http.Request, zoneID string, ch *changeItem) er
 	}
 }
 
-// upsertRecord updates the record if it already exists, otherwise creates it —
-// Route 53's UPSERT semantics. Only a genuine not-found routes to create; any
-// other GetRecord error (e.g. an injected/transient failure) is propagated so
-// an existing record isn't misrouted into a create → spurious conflict.
+// recordSetDeleter is the AWS-only extension a Route 53 backend implements to
+// delete one record set addressed by SetIdentifier, leaving weighted/latency/
+// failover/geo siblings at the same name+type untouched. Backends without it
+// fall back to the SetIdentifier-less DeleteRecord.
+type recordSetDeleter interface {
+	DeleteRecordSet(ctx context.Context, zoneID, name, recordType, setID string) error
+}
+
+// deleteRecordSet removes exactly the record set identified by name+type+
+// SetIdentifier. A weighted/latency/failover/geo DELETE must not disturb its
+// siblings, so the SetIdentifier is honored when the backend supports it.
+func (h *Handler) deleteRecordSet(r *http.Request, zoneID string, rr *resourceRecordSetXML) error {
+	if d, ok := h.dns.(recordSetDeleter); ok {
+		return d.DeleteRecordSet(r.Context(), zoneID, rr.Name, rr.Type, rr.SetIdentifier)
+	}
+
+	return h.dns.DeleteRecord(r.Context(), zoneID, rr.Name, rr.Type)
+}
+
+// upsertRecord creates the record set, and on an exact-key conflict updates it
+// instead — Route 53's UPSERT semantics keyed by name+type+SetIdentifier. Going
+// through CreateRecord first keeps a new weighted/geo sibling from being
+// misrouted into an update of a different SetIdentifier's record.
 func (h *Handler) upsertRecord(r *http.Request, cfg dnsdriver.RecordConfig) error {
-	_, err := h.dns.GetRecord(r.Context(), cfg.ZoneID, cfg.Name, cfg.Type)
+	_, err := h.dns.CreateRecord(r.Context(), cfg)
 	switch {
 	case err == nil:
+		return nil
+	case cerrors.IsAlreadyExists(err):
 		_, uerr := h.dns.UpdateRecord(r.Context(), cfg)
 		return uerr
-	case cerrors.IsNotFound(err):
-		_, cerr := h.dns.CreateRecord(r.Context(), cfg)
-		return cerr
 	default:
 		return err
 	}
@@ -342,11 +407,15 @@ func recordConfig(zoneID string, rr *resourceRecordSetXML) dnsdriver.RecordConfi
 	}
 
 	cfg := dnsdriver.RecordConfig{
-		ZoneID: zoneID,
-		Name:   rr.Name,
-		Type:   rr.Type,
-		Values: values,
-		SetID:  rr.SetIdentifier,
+		ZoneID:           zoneID,
+		Name:             rr.Name,
+		Type:             rr.Type,
+		Values:           values,
+		SetID:            rr.SetIdentifier,
+		Region:           rr.Region,
+		Failover:         rr.Failover,
+		HealthCheckID:    rr.HealthCheckId,
+		MultiValueAnswer: rr.MultiValueAnswer,
 	}
 
 	if rr.TTL != nil {
@@ -356,6 +425,22 @@ func recordConfig(zoneID string, rr *resourceRecordSetXML) dnsdriver.RecordConfi
 	if rr.Weight != nil {
 		w := int(*rr.Weight)
 		cfg.Weight = &w
+	}
+
+	if rr.GeoLocation != nil {
+		cfg.GeoLocation = &dnsdriver.GeoLocation{
+			ContinentCode:   rr.GeoLocation.ContinentCode,
+			CountryCode:     rr.GeoLocation.CountryCode,
+			SubdivisionCode: rr.GeoLocation.SubdivisionCode,
+		}
+	}
+
+	if rr.AliasTarget != nil {
+		cfg.AliasTarget = &dnsdriver.AliasTarget{
+			DNSName:              rr.AliasTarget.DNSName,
+			HostedZoneID:         rr.AliasTarget.HostedZoneId,
+			EvaluateTargetHealth: rr.AliasTarget.EvaluateTargetHealth,
+		}
 	}
 
 	return cfg

--- a/server/aws/route53/record_set_routing_test.go
+++ b/server/aws/route53/record_set_routing_test.go
@@ -1,0 +1,199 @@
+package route53_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+// changeRecordSet applies a single-change batch, failing the test on error.
+func changeRecordSet(
+	t *testing.T, client *awsr53.Client, zoneID string,
+	action r53types.ChangeAction, rr *r53types.ResourceRecordSet,
+) {
+	t.Helper()
+
+	_, err := client.ChangeResourceRecordSets(context.Background(), &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{
+			Changes: []r53types.Change{{Action: action, ResourceRecordSet: rr}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ChangeResourceRecordSets(%s %s): %v", action, aws.ToString(rr.SetIdentifier), err)
+	}
+}
+
+func createRoutingZone(t *testing.T, client *awsr53.Client, name string) string {
+	t.Helper()
+
+	created, err := client.CreateHostedZone(context.Background(), &awsr53.CreateHostedZoneInput{
+		Name: aws.String(name), CallerReference: aws.String(name),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+
+	return aws.ToString(created.HostedZone.Id)
+}
+
+// weightedSetIdentifiers returns the SetIdentifiers of all A record sets at name.
+func weightedSetIdentifiers(
+	t *testing.T, client *awsr53.Client, zoneID, name string,
+) []string {
+	t.Helper()
+
+	sets, err := client.ListResourceRecordSets(context.Background(), &awsr53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if err != nil {
+		t.Fatalf("ListResourceRecordSets: %v", err)
+	}
+
+	var ids []string
+
+	for i := range sets.ResourceRecordSets {
+		rr := &sets.ResourceRecordSets[i]
+		if aws.ToString(rr.Name) == name && rr.Type == r53types.RRTypeA {
+			ids = append(ids, aws.ToString(rr.SetIdentifier))
+		}
+	}
+
+	return ids
+}
+
+// TestSDKWeightedDeleteBySetIdentifier pins that DELETE of one weighted record
+// set removes ONLY that SetIdentifier — the sibling weighted records sharing the
+// same name+type are untouched.
+func TestSDKWeightedDeleteBySetIdentifier(t *testing.T) {
+	client := newRoute53Client(t)
+	zoneID := createRoutingZone(t, client, "wtd.com.")
+	name := "app.wtd.com."
+
+	for id, w := range map[string]int64{"blue": 10, "green": 20, "red": 30} {
+		changeRecordSet(t, client, zoneID, r53types.ChangeActionCreate, &r53types.ResourceRecordSet{
+			Name: aws.String(name), Type: r53types.RRTypeA, TTL: aws.Int64(60),
+			SetIdentifier: aws.String(id), Weight: aws.Int64(w),
+			ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.1")}},
+		})
+	}
+
+	if got := weightedSetIdentifiers(t, client, zoneID, name); len(got) != 3 {
+		t.Fatalf("before delete = %v, want 3 weighted sets", got)
+	}
+
+	// Delete only SetIdentifier=green.
+	changeRecordSet(t, client, zoneID, r53types.ChangeActionDelete, &r53types.ResourceRecordSet{
+		Name: aws.String(name), Type: r53types.RRTypeA, TTL: aws.Int64(60),
+		SetIdentifier: aws.String("green"), Weight: aws.Int64(20),
+		ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.1")}},
+	})
+
+	got := weightedSetIdentifiers(t, client, zoneID, name)
+	if len(got) != 2 {
+		t.Fatalf("after delete green = %v, want blue+red to survive", got)
+	}
+
+	for _, id := range got {
+		if id == "green" {
+			t.Fatalf("green still present after delete: %v", got)
+		}
+	}
+}
+
+// TestSDKAliasRecordRoundTrip pins that an ALIAS record (AliasTarget, no TTL, no
+// ResourceRecords) is stored and returned intact.
+func TestSDKAliasRecordRoundTrip(t *testing.T) {
+	client := newRoute53Client(t)
+	zoneID := createRoutingZone(t, client, "alias.com.")
+	name := "cdn.alias.com."
+
+	changeRecordSet(t, client, zoneID, r53types.ChangeActionCreate, &r53types.ResourceRecordSet{
+		Name: aws.String(name), Type: r53types.RRTypeA,
+		AliasTarget: &r53types.AliasTarget{
+			DNSName:              aws.String("d123.cloudfront.net."),
+			HostedZoneId:         aws.String("Z2FDTNDATAQYW2"),
+			EvaluateTargetHealth: true,
+		},
+	})
+
+	rr := findRecordSet(t, listRecordSets(t, client, zoneID), name, r53types.RRTypeA)
+	if rr.AliasTarget == nil {
+		t.Fatalf("alias record read back with nil AliasTarget: %+v", rr)
+	}
+	if got := aws.ToString(rr.AliasTarget.DNSName); got != "d123.cloudfront.net." {
+		t.Fatalf("AliasTarget.DNSName = %q, want d123.cloudfront.net.", got)
+	}
+	if got := aws.ToString(rr.AliasTarget.HostedZoneId); got != "Z2FDTNDATAQYW2" {
+		t.Fatalf("AliasTarget.HostedZoneId = %q, want Z2FDTNDATAQYW2", got)
+	}
+	if !rr.AliasTarget.EvaluateTargetHealth {
+		t.Fatalf("AliasTarget.EvaluateTargetHealth = false, want true")
+	}
+	if rr.TTL != nil {
+		t.Fatalf("alias record TTL = %v, want nil", rr.TTL)
+	}
+	if len(rr.ResourceRecords) != 0 {
+		t.Fatalf("alias record ResourceRecords = %v, want empty", rr.ResourceRecords)
+	}
+}
+
+// TestSDKRoutingPolicyRoundTrip pins that latency (Region), failover, and
+// geolocation routing metadata survive a create/list round-trip.
+func TestSDKRoutingPolicyRoundTrip(t *testing.T) {
+	client := newRoute53Client(t)
+	zoneID := createRoutingZone(t, client, "routing.com.")
+
+	changeRecordSet(t, client, zoneID, r53types.ChangeActionCreate, &r53types.ResourceRecordSet{
+		Name: aws.String("lat.routing.com."), Type: r53types.RRTypeA, TTL: aws.Int64(60),
+		SetIdentifier:   aws.String("us-east"),
+		Region:          r53types.ResourceRecordSetRegionUsEast1,
+		ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.10")}},
+	})
+	changeRecordSet(t, client, zoneID, r53types.ChangeActionCreate, &r53types.ResourceRecordSet{
+		Name: aws.String("fo.routing.com."), Type: r53types.RRTypeA, TTL: aws.Int64(60),
+		SetIdentifier:   aws.String("primary"),
+		Failover:        r53types.ResourceRecordSetFailoverPrimary,
+		ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.20")}},
+	})
+	changeRecordSet(t, client, zoneID, r53types.ChangeActionCreate, &r53types.ResourceRecordSet{
+		Name: aws.String("geo.routing.com."), Type: r53types.RRTypeA, TTL: aws.Int64(60),
+		SetIdentifier:   aws.String("in"),
+		GeoLocation:     &r53types.GeoLocation{CountryCode: aws.String("IN")},
+		ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.30")}},
+	})
+
+	sets := listRecordSets(t, client, zoneID)
+
+	lat := findRecordSet(t, sets, "lat.routing.com.", r53types.RRTypeA)
+	if lat.Region != r53types.ResourceRecordSetRegionUsEast1 {
+		t.Fatalf("latency Region = %q, want us-east-1", lat.Region)
+	}
+
+	fo := findRecordSet(t, sets, "fo.routing.com.", r53types.RRTypeA)
+	if fo.Failover != r53types.ResourceRecordSetFailoverPrimary {
+		t.Fatalf("Failover = %q, want PRIMARY", fo.Failover)
+	}
+
+	geo := findRecordSet(t, sets, "geo.routing.com.", r53types.RRTypeA)
+	if geo.GeoLocation == nil || aws.ToString(geo.GeoLocation.CountryCode) != "IN" {
+		t.Fatalf("GeoLocation = %+v, want CountryCode IN", geo.GeoLocation)
+	}
+}
+
+// listRecordSets returns all record sets in a zone.
+func listRecordSets(t *testing.T, client *awsr53.Client, zoneID string) []r53types.ResourceRecordSet {
+	t.Helper()
+
+	out, err := client.ListResourceRecordSets(context.Background(), &awsr53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if err != nil {
+		t.Fatalf("ListResourceRecordSets: %v", err)
+	}
+
+	return out.ResourceRecordSets
+}

--- a/server/aws/route53/types.go
+++ b/server/aws/route53/types.go
@@ -28,14 +28,35 @@ type resourceRecordXML struct {
 	Value string `xml:"Value"`
 }
 
+// aliasTargetXML is the Route 53 AliasTarget element (an A/AAAA record that
+// points at another AWS resource instead of carrying a TTL + ResourceRecords).
+type aliasTargetXML struct {
+	HostedZoneId         string `xml:"HostedZoneId"`
+	DNSName              string `xml:"DNSName"`
+	EvaluateTargetHealth bool   `xml:"EvaluateTargetHealth"`
+}
+
+// geoLocationXML is the Route 53 GeoLocation element for geolocation routing.
+type geoLocationXML struct {
+	ContinentCode   string `xml:"ContinentCode,omitempty"`
+	CountryCode     string `xml:"CountryCode,omitempty"`
+	SubdivisionCode string `xml:"SubdivisionCode,omitempty"`
+}
+
 // resourceRecordSetXML is the Route 53 ResourceRecordSet element.
 type resourceRecordSetXML struct {
-	Name            string              `xml:"Name"`
-	Type            string              `xml:"Type"`
-	SetIdentifier   string              `xml:"SetIdentifier,omitempty"`
-	Weight          *int64              `xml:"Weight,omitempty"`
-	TTL             *int64              `xml:"TTL,omitempty"`
-	ResourceRecords []resourceRecordXML `xml:"ResourceRecords>ResourceRecord,omitempty"`
+	Name             string              `xml:"Name"`
+	Type             string              `xml:"Type"`
+	SetIdentifier    string              `xml:"SetIdentifier,omitempty"`
+	Weight           *int64              `xml:"Weight,omitempty"`
+	Region           string              `xml:"Region,omitempty"`
+	Failover         string              `xml:"Failover,omitempty"`
+	GeoLocation      *geoLocationXML     `xml:"GeoLocation,omitempty"`
+	MultiValueAnswer *bool               `xml:"MultiValueAnswer,omitempty"`
+	HealthCheckId    string              `xml:"HealthCheckId,omitempty"`
+	TTL              *int64              `xml:"TTL,omitempty"`
+	ResourceRecords  []resourceRecordXML `xml:"ResourceRecords>ResourceRecord,omitempty"`
+	AliasTarget      *aliasTargetXML     `xml:"AliasTarget,omitempty"`
 }
 
 // --- hosted zone elements ---
@@ -211,26 +232,49 @@ func toHostedZoneXML(info *dnsdriver.ZoneInfo) hostedZoneXML {
 	}
 }
 
-// toRecordSetXML converts a driver record into its Route 53 element.
+// toRecordSetXML converts a driver record into its Route 53 element. An alias
+// record carries an AliasTarget instead of a TTL and ResourceRecords, so those
+// are omitted when AliasTarget is present (matching real Route 53).
 func toRecordSetXML(rec *dnsdriver.RecordInfo) resourceRecordSetXML {
-	ttl := int64(rec.TTL)
-
-	rrs := make([]resourceRecordXML, 0, len(rec.Values))
-	for _, v := range rec.Values {
-		rrs = append(rrs, resourceRecordXML{Value: v})
+	out := resourceRecordSetXML{
+		Name:             rec.Name,
+		Type:             rec.Type,
+		SetIdentifier:    rec.SetID,
+		Region:           rec.Region,
+		Failover:         rec.Failover,
+		HealthCheckId:    rec.HealthCheckID,
+		MultiValueAnswer: rec.MultiValueAnswer,
 	}
 
-	out := resourceRecordSetXML{
-		Name:            rec.Name,
-		Type:            rec.Type,
-		SetIdentifier:   rec.SetID,
-		TTL:             &ttl,
-		ResourceRecords: rrs,
+	if rec.AliasTarget != nil {
+		out.AliasTarget = &aliasTargetXML{
+			HostedZoneId:         rec.AliasTarget.HostedZoneID,
+			DNSName:              rec.AliasTarget.DNSName,
+			EvaluateTargetHealth: rec.AliasTarget.EvaluateTargetHealth,
+		}
+	} else {
+		ttl := int64(rec.TTL)
+		out.TTL = &ttl
+
+		rrs := make([]resourceRecordXML, 0, len(rec.Values))
+		for _, v := range rec.Values {
+			rrs = append(rrs, resourceRecordXML{Value: v})
+		}
+
+		out.ResourceRecords = rrs
 	}
 
 	if rec.Weight != nil {
 		w := int64(*rec.Weight)
 		out.Weight = &w
+	}
+
+	if rec.GeoLocation != nil {
+		out.GeoLocation = &geoLocationXML{
+			ContinentCode:   rec.GeoLocation.ContinentCode,
+			CountryCode:     rec.GeoLocation.CountryCode,
+			SubdivisionCode: rec.GeoLocation.SubdivisionCode,
+		}
 	}
 
 	return out

--- a/server/aws/sfn/execution_idempotency_test.go
+++ b/server/aws/sfn/execution_idempotency_test.go
@@ -1,0 +1,90 @@
+package sfn_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awssfn "github.com/aws/aws-sdk-go-v2/service/sfn"
+	sfntypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	cloudconfig "github.com/stackshy/cloudemu/v2/config"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// TestSDKStartExecutionIdempotent pins Route 53's STANDARD idempotency contract:
+// reusing a running execution's name with the SAME input returns the SAME
+// execution (200), a DIFFERENT input returns 400 ExecutionAlreadyExists, and
+// once the execution has closed the name can no longer be reused.
+func TestSDKStartExecutionIdempotent(t *testing.T) {
+	fc := cloudconfig.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloud := cloudemu.NewAWS(cloudconfig.WithClock(fc), cloudconfig.WithAsyncSettle())
+	ts := httptest.NewServer(awsserver.New(awsserver.Drivers{SFN: cloud.SFN}))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")))
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+	c := awssfn.NewFromConfig(cfg, func(o *awssfn.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+	ctx := context.Background()
+
+	sm, err := c.CreateStateMachine(ctx, &awssfn.CreateStateMachineInput{
+		Name: aws.String("sm"), Definition: aws.String(definition),
+		RoleArn: aws.String("arn:aws:iam::000000000000:role/r"),
+	})
+	if err != nil {
+		t.Fatalf("CreateStateMachine: %v", err)
+	}
+
+	first, err := c.StartExecution(ctx, &awssfn.StartExecutionInput{
+		StateMachineArn: sm.StateMachineArn, Name: aws.String("dedup"), Input: aws.String(`{"a":1}`),
+	})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	// Same name + same input while the execution is still RUNNING: idempotent,
+	// returns the identical executionArn and startDate.
+	again, err := c.StartExecution(ctx, &awssfn.StartExecutionInput{
+		StateMachineArn: sm.StateMachineArn, Name: aws.String("dedup"), Input: aws.String(`{"a":1}`),
+	})
+	if err != nil {
+		t.Fatalf("StartExecution(same name+input) should be idempotent, got: %v", err)
+	}
+	if aws.ToString(again.ExecutionArn) != aws.ToString(first.ExecutionArn) {
+		t.Fatalf("idempotent executionArn = %q, want %q",
+			aws.ToString(again.ExecutionArn), aws.ToString(first.ExecutionArn))
+	}
+	if !again.StartDate.Equal(*first.StartDate) {
+		t.Fatalf("idempotent startDate = %v, want %v", again.StartDate, first.StartDate)
+	}
+
+	// Same name + DIFFERENT input while running: 400 ExecutionAlreadyExists.
+	_, err = c.StartExecution(ctx, &awssfn.StartExecutionInput{
+		StateMachineArn: sm.StateMachineArn, Name: aws.String("dedup"), Input: aws.String(`{"a":2}`),
+	})
+	var already *sfntypes.ExecutionAlreadyExists
+	if !errors.As(err, &already) {
+		t.Fatalf("StartExecution(same name, diff input) = %v, want ExecutionAlreadyExists", err)
+	}
+
+	// Once the execution has closed (settle window elapsed), reusing the name —
+	// even with the same input — is rejected.
+	fc.Advance(2 * time.Second)
+
+	_, err = c.StartExecution(ctx, &awssfn.StartExecutionInput{
+		StateMachineArn: sm.StateMachineArn, Name: aws.String("dedup"), Input: aws.String(`{"a":1}`),
+	})
+	if !errors.As(err, &already) {
+		t.Fatalf("StartExecution(reuse closed name) = %v, want ExecutionAlreadyExists", err)
+	}
+}

--- a/services/dns/driver/driver.go
+++ b/services/dns/driver/driver.go
@@ -29,6 +29,23 @@ type ZoneInfo struct {
 	Scope scope.Scope
 }
 
+// AliasTarget describes an AWS Route 53 alias target (an A/AAAA record that
+// points at another AWS resource instead of an IP). Other providers leave it
+// nil.
+type AliasTarget struct {
+	DNSName              string
+	HostedZoneID         string
+	EvaluateTargetHealth bool
+}
+
+// GeoLocation describes an AWS Route 53 geolocation routing constraint. Other
+// providers leave it nil.
+type GeoLocation struct {
+	ContinentCode   string
+	CountryCode     string
+	SubdivisionCode string
+}
+
 // RecordConfig describes a DNS record.
 type RecordConfig struct {
 	ZoneID string
@@ -38,6 +55,15 @@ type RecordConfig struct {
 	Values []string
 	Weight *int // for weighted routing, nil means not weighted
 	SetID  string
+	// Routing/alias attributes below are AWS Route 53 specific; other providers
+	// leave them zero. They round-trip on a record set the same way Weight/SetID
+	// do so weighted/latency/failover/geo/alias records are faithful.
+	Failover         string // "PRIMARY" | "SECONDARY", empty when not a failover record
+	Region           string // latency-based routing region, empty otherwise
+	HealthCheckID    string
+	MultiValueAnswer *bool
+	GeoLocation      *GeoLocation
+	AliasTarget      *AliasTarget
 }
 
 // RecordInfo describes a DNS record.
@@ -49,6 +75,13 @@ type RecordInfo struct {
 	Values []string
 	Weight *int
 	SetID  string
+	// AWS Route 53 routing/alias attributes; other providers leave them zero.
+	Failover         string
+	Region           string
+	HealthCheckID    string
+	MultiValueAnswer *bool
+	GeoLocation      *GeoLocation
+	AliasTarget      *AliasTarget
 }
 
 // HealthCheckConfig describes a health check to create.


### PR DESCRIPTION
Fixes five real-AWS parity gaps found in a round-3 real-user audit of Route 53 and Step Functions.

## Route 53

**SetIdentifier-scoped record DELETE (BLOCKER).** A DELETE of one weighted/latency/failover/geo record set identified by name+type+SetIdentifier now removes ONLY that set; siblings sharing the same name+type are untouched. Previously the provider prefix-deleted every key matching name+type when the SetIdentifier-less key was absent, so deleting `green` wiped `blue`/`green`/`red`. The wire DELETE now passes the SetIdentifier through a new AWS-only `DeleteRecordSet(zoneID,name,type,setID)` (type-asserted optional interface); the shared `DeleteRecord` no longer wipes siblings.

**DeleteHostedZone non-empty guard (HIGH).** DeleteHostedZone now returns `400 HostedZoneNotEmpty` and deletes nothing when the zone holds any record beyond the default apex SOA and NS. Only a zone with just those defaults is deletable.

**ALIAS records / AliasTarget (HIGH).** An A/AAAA record with an `AliasTarget{DNSName,HostedZoneId,EvaluateTargetHealth}` (no TTL, no ResourceRecords) now round-trips. ListResourceRecordSets returns the AliasTarget and omits TTL/ResourceRecords, matching real Route 53.

**Latency / failover / geolocation routing (MEDIUM).** `Region`, `Failover`, `GeoLocation`, `HealthCheckId`, and `MultiValueAnswer` now persist and round-trip on a record set (previously only Weight+SetIdentifier survived).

Routing/alias attributes are carried as optional fields on the shared DNS `RecordConfig`/`RecordInfo` (the same way Weight/SetID already are); other providers leave them zero.

## Step Functions

**StartExecution STANDARD idempotency (MEDIUM).** Reusing a still-running execution's name with the SAME input now succeeds and returns the same executionArn/startDate. A different input, a closed (settled) execution, or an EXPRESS workflow yields `400 ExecutionAlreadyExists`. Previously any name reuse was rejected.

## Tests
Real aws-sdk-go-v2 clients over an httptest server: weighted DELETE-by-SetIdentifier keeps siblings, ALIAS round-trip, latency/failover/geo round-trip, DeleteHostedZone HostedZoneNotEmpty then delete-when-empty, and SFN StartExecution idempotency (same-input reuse vs different-input vs closed). Plus a provider unit test for DeleteRecordSet.