### PR TITLE
fix(cloudwatch-logs): GetMetricStatistics/PutMetricData, DescribeLogStreams ordering, retention, PutMetricAlarm

### DIFF
--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -4,7 +4,6 @@ package cloudwatch
 import (
 	"context"
 	"fmt"
-	"math"
 	"sort"
 	"strings"
 	"sync"
@@ -75,24 +74,24 @@ func (m *Mock) PutMetricData(_ context.Context, data []driver.MetricDatum) error
 	}
 
 	m.mu.Lock()
-	for _, d := range data {
+	for i := range data {
 		key := metricKey{
-			Namespace:  d.Namespace,
-			MetricName: d.MetricName,
+			Namespace:  data[i].Namespace,
+			MetricName: data[i].MetricName,
 		}
-		m.metrics[key] = append(m.metrics[key], d)
+		m.metrics[key] = append(m.metrics[key], data[i])
 	}
 	m.mu.Unlock()
 
 	// Evaluate alarms for each unique namespace/metric pair that was updated.
 	seen := make(map[metricKey]bool)
 
-	for _, d := range data {
-		mk := metricKey{Namespace: d.Namespace, MetricName: d.MetricName}
+	for i := range data {
+		mk := metricKey{Namespace: data[i].Namespace, MetricName: data[i].MetricName}
 		if !seen[mk] {
 			seen[mk] = true
 
-			m.evaluateAlarms(d.Namespace, d.MetricName)
+			m.evaluateAlarms(data[i].Namespace, data[i].MetricName)
 		}
 	}
 
@@ -141,13 +140,13 @@ func (m *Mock) evaluateSingleAlarm(alarm *alarmData, namespace, metricName strin
 	windowDur := time.Duration(period*evalPeriods) * time.Second
 	windowStart := now.Add(-windowDur)
 
-	filtered := m.collectFilteredValues(namespace, metricName, alarm.Dimensions, windowStart, now)
+	filtered := m.collectFilteredDatums(namespace, metricName, alarm.Dimensions, windowStart, now)
 
 	if len(filtered) == 0 {
 		return
 	}
 
-	stat := computeStat(filtered, alarm.Stat)
+	stat := aggregateDatums(filtered).stat(alarm.Stat)
 
 	var newState, reason string
 	if evaluateComparison(stat, alarm.ComparisonOperator, alarm.Threshold) {
@@ -176,16 +175,19 @@ func (m *Mock) evaluateSingleAlarm(alarm *alarmData, namespace, metricName strin
 	alarm.StateReason = reason
 }
 
-func (m *Mock) collectFilteredValues(namespace, metricName string, dims map[string]string, windowStart, now time.Time) []float64 {
+func (m *Mock) collectFilteredDatums(
+	namespace, metricName string, dims map[string]string, windowStart, now time.Time,
+) []driver.MetricDatum {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	key := metricKey{Namespace: namespace, MetricName: metricName}
 	dataPoints := m.metrics[key]
 
-	var filtered []float64
+	var filtered []driver.MetricDatum
 
-	for _, d := range dataPoints {
+	for i := range dataPoints {
+		d := &dataPoints[i]
 		if d.Timestamp.Before(windowStart) || d.Timestamp.After(now) {
 			continue
 		}
@@ -194,7 +196,7 @@ func (m *Mock) collectFilteredValues(namespace, metricName string, dims map[stri
 			continue
 		}
 
-		filtered = append(filtered, d.Value)
+		filtered = append(filtered, *d)
 	}
 
 	return filtered
@@ -232,7 +234,8 @@ func (m *Mock) GetMetricData(_ context.Context, input driver.GetMetricInput) (*d
 func filterByTimeAndDimensions(dataPoints []driver.MetricDatum, startTime, endTime time.Time, dims map[string]string) []driver.MetricDatum {
 	var filtered []driver.MetricDatum
 
-	for _, d := range dataPoints {
+	for i := range dataPoints {
+		d := &dataPoints[i]
 		if d.Timestamp.Before(startTime) || !d.Timestamp.Before(endTime) {
 			continue
 		}
@@ -241,7 +244,7 @@ func filterByTimeAndDimensions(dataPoints []driver.MetricDatum, startTime, endTi
 			continue
 		}
 
-		filtered = append(filtered, d)
+		filtered = append(filtered, *d)
 	}
 
 	return filtered
@@ -266,13 +269,13 @@ func buildMetricResult(filtered []driver.MetricDatum, startTime, endTime time.Ti
 	// Walk through periods from StartTime to EndTime.
 	for periodStart := startTime; periodStart.Before(endTime); periodStart = periodStart.Add(periodDur) {
 		periodEnd := periodStart.Add(periodDur)
-		periodValues := collectPeriodValues(filtered, periodStart, periodEnd)
+		periodDatums := collectPeriodDatums(filtered, periodStart, periodEnd)
 
-		if len(periodValues) == 0 {
+		if len(periodDatums) == 0 {
 			continue
 		}
 
-		s := computeStat(periodValues, stat)
+		s := aggregateDatums(periodDatums).stat(stat)
 
 		result.Timestamps = append(result.Timestamps, periodStart)
 		result.Values = append(result.Values, s)
@@ -289,25 +292,25 @@ func buildMetricResult(filtered []driver.MetricDatum, startTime, endTime time.Ti
 // unitOf returns the first non-empty unit among the data points, or "" if none
 // carry a unit.
 func unitOf(data []driver.MetricDatum) string {
-	for _, d := range data {
-		if d.Unit != "" {
-			return d.Unit
+	for i := range data {
+		if data[i].Unit != "" {
+			return data[i].Unit
 		}
 	}
 
 	return ""
 }
 
-func collectPeriodValues(filtered []driver.MetricDatum, periodStart, periodEnd time.Time) []float64 {
-	var values []float64
+func collectPeriodDatums(filtered []driver.MetricDatum, periodStart, periodEnd time.Time) []driver.MetricDatum {
+	var datums []driver.MetricDatum
 
-	for _, d := range filtered {
-		if !d.Timestamp.Before(periodStart) && d.Timestamp.Before(periodEnd) {
-			values = append(values, d.Value)
+	for i := range filtered {
+		if !filtered[i].Timestamp.Before(periodStart) && filtered[i].Timestamp.Before(periodEnd) {
+			datums = append(datums, filtered[i])
 		}
 	}
 
-	return values
+	return datums
 }
 
 // ListMetrics returns unique metric names for the given namespace.
@@ -673,58 +676,87 @@ func matchDimensions(dataDims, filterDims map[string]string) bool {
 	return true
 }
 
-// computeStat computes the requested statistic over a slice of values.
-func computeStat(values []float64, stat string) float64 {
-	if len(values) == 0 {
+// statAgg accumulates SampleCount / Sum / Minimum / Maximum across a set of
+// metric datums so any requested statistic can be derived. It treats a plain
+// Value, a pre-aggregated StatisticValues set, and paired Values/Counts arrays
+// uniformly, matching how real CloudWatch folds all three into one series.
+type statAgg struct {
+	count float64
+	sum   float64
+	min   float64
+	max   float64
+	seen  bool
+}
+
+// add folds one observation (or sub-aggregate) into the accumulator: count
+// samples summing to sum, whose smallest and largest observed values are low
+// and high. Non-positive counts contribute nothing, matching AWS.
+func (a *statAgg) add(count, sum, low, high float64) {
+	if count <= 0 {
+		return
+	}
+
+	a.count += count
+	a.sum += sum
+
+	if !a.seen || low < a.min {
+		a.min = low
+	}
+
+	if !a.seen || high > a.max {
+		a.max = high
+	}
+
+	a.seen = true
+}
+
+// stat returns the requested statistic, or 0 when no data was accumulated.
+func (a statAgg) stat(stat string) float64 {
+	if !a.seen {
 		return 0
 	}
 
 	switch stat {
 	case "Sum":
-		return sumValues(values)
+		return a.sum
 	case "Min", "Minimum":
-		return minValue(values)
+		return a.min
 	case "Max", "Maximum":
-		return maxValue(values)
+		return a.max
 	case "SampleCount":
-		return float64(len(values))
+		return a.count
 	default: // "Average" or unspecified
-		return sumValues(values) / float64(len(values))
+		return a.sum / a.count
 	}
 }
 
-func sumValues(values []float64) float64 {
-	sum := 0.0
+// aggregateDatums folds every datum — plain Value, StatisticValues set, or
+// Values/Counts arrays — into a single accumulator.
+func aggregateDatums(datums []driver.MetricDatum) statAgg {
+	var a statAgg
 
-	for _, v := range values {
-		sum += v
-	}
+	for i := range datums {
+		d := &datums[i]
 
-	return sum
-}
+		switch {
+		case d.StatisticValues != nil:
+			s := d.StatisticValues
+			a.add(s.SampleCount, s.Sum, s.Minimum, s.Maximum)
+		case len(d.Values) > 0:
+			for j, v := range d.Values {
+				count := 1.0
+				if j < len(d.Counts) {
+					count = d.Counts[j]
+				}
 
-func minValue(values []float64) float64 {
-	result := math.MaxFloat64
-
-	for _, v := range values {
-		if v < result {
-			result = v
+				a.add(count, v*count, v, v)
+			}
+		default:
+			a.add(1, d.Value, d.Value, d.Value)
 		}
 	}
 
-	return result
-}
-
-func maxValue(values []float64) float64 {
-	result := -math.MaxFloat64
-
-	for _, v := range values {
-		if v > result {
-			result = v
-		}
-	}
-
-	return result
+	return a
 }
 
 func toAlarmInfo(a *alarmData) driver.AlarmInfo {

--- a/providers/aws/cloudwatch/statistic_set_test.go
+++ b/providers/aws/cloudwatch/statistic_set_test.go
@@ -1,0 +1,80 @@
+package cloudwatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// TestGetMetricDataStatisticSet verifies that a datum published as a
+// pre-aggregated StatisticValues set (SampleCount/Sum/Min/Max) is folded into
+// the series so every statistic reflects the supplied aggregate.
+func TestGetMetricDataStatisticSet(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	base := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	requireNoError(t, m.PutMetricData(ctx, []driver.MetricDatum{{
+		Namespace:  "NS",
+		MetricName: "Batch",
+		Timestamp:  base,
+		StatisticValues: &driver.StatisticSet{
+			SampleCount: 4,
+			Sum:         100,
+			Minimum:     10,
+			Maximum:     40,
+		},
+	}}))
+
+	get := func(stat string) float64 {
+		res, err := m.GetMetricData(ctx, driver.GetMetricInput{
+			Namespace: "NS", MetricName: "Batch",
+			StartTime: base, EndTime: base.Add(time.Minute), Period: 60, Stat: stat,
+		})
+		requireNoError(t, err)
+		assertEqual(t, 1, len(res.Values))
+
+		return res.Values[0]
+	}
+
+	assertEqual(t, 100.0, get("Sum"))
+	assertEqual(t, 25.0, get("Average"))
+	assertEqual(t, 10.0, get("Minimum"))
+	assertEqual(t, 40.0, get("Maximum"))
+	assertEqual(t, 4.0, get("SampleCount"))
+}
+
+// TestGetMetricDataValuesCounts verifies that paired Values/Counts arrays weight
+// each observation by its count when the series is aggregated.
+func TestGetMetricDataValuesCounts(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	base := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	requireNoError(t, m.PutMetricData(ctx, []driver.MetricDatum{{
+		Namespace:  "NS",
+		MetricName: "Weighted",
+		Timestamp:  base,
+		Values:     []float64{1, 2, 3},
+		Counts:     []float64{4, 1, 1},
+	}}))
+
+	get := func(stat string) float64 {
+		res, err := m.GetMetricData(ctx, driver.GetMetricInput{
+			Namespace: "NS", MetricName: "Weighted",
+			StartTime: base, EndTime: base.Add(time.Minute), Period: 60, Stat: stat,
+		})
+		requireNoError(t, err)
+		assertEqual(t, 1, len(res.Values))
+
+		return res.Values[0]
+	}
+
+	assertEqual(t, 9.0, get("Sum"))         // 1*4 + 2 + 3
+	assertEqual(t, 6.0, get("SampleCount")) // 4 + 1 + 1
+	assertEqual(t, 1.5, get("Average"))     // 9 / 6
+	assertEqual(t, 1.0, get("Minimum"))
+	assertEqual(t, 3.0, get("Maximum"))
+}

--- a/server/aws/cloudwatch/metric_statistics_test.go
+++ b/server/aws/cloudwatch/metric_statistics_test.go
@@ -1,0 +1,215 @@
+package cloudwatch_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awscw "github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestSDKGetMetricStatisticsMultipleStatistics covers the multi-statistic
+// finding: when several statistics are requested, every returned datapoint must
+// populate all of them simultaneously, not just the first.
+func TestSDKGetMetricStatisticsMultipleStatistics(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	now := time.Now().UTC()
+	for _, v := range []float64{10, 20, 30} {
+		if _, err := client.PutMetricData(ctx, &awscw.PutMetricDataInput{
+			Namespace: aws.String("MyApp"),
+			MetricData: []cwtypes.MetricDatum{{
+				MetricName: aws.String("Latency"),
+				Value:      aws.Float64(v),
+				Timestamp:  aws.Time(now),
+			}},
+		}); err != nil {
+			t.Fatalf("PutMetricData: %v", err)
+		}
+	}
+
+	out, err := client.GetMetricStatistics(ctx, &awscw.GetMetricStatisticsInput{
+		Namespace:  aws.String("MyApp"),
+		MetricName: aws.String("Latency"),
+		StartTime:  aws.Time(now.Add(-time.Hour)),
+		EndTime:    aws.Time(now.Add(time.Hour)),
+		Period:     aws.Int32(3600),
+		Statistics: []cwtypes.Statistic{
+			cwtypes.StatisticAverage,
+			cwtypes.StatisticSum,
+			cwtypes.StatisticMaximum,
+			cwtypes.StatisticMinimum,
+			cwtypes.StatisticSampleCount,
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetMetricStatistics: %v", err)
+	}
+
+	if len(out.Datapoints) != 1 {
+		t.Fatalf("datapoints = %+v, want exactly 1", out.Datapoints)
+	}
+
+	dp := out.Datapoints[0]
+	assertStat(t, "Average", dp.Average, 20)
+	assertStat(t, "Sum", dp.Sum, 60)
+	assertStat(t, "Maximum", dp.Maximum, 30)
+	assertStat(t, "Minimum", dp.Minimum, 10)
+	assertStat(t, "SampleCount", dp.SampleCount, 3)
+}
+
+// TestSDKPutMetricDataStatisticValues covers the pre-aggregated finding: a datum
+// carrying StatisticValues (SampleCount/Sum/Min/Max) instead of Value must be
+// aggregated into the series so GetMetricStatistics reflects the supplied Sum.
+func TestSDKPutMetricDataStatisticValues(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	now := time.Now().UTC()
+	if _, err := client.PutMetricData(ctx, &awscw.PutMetricDataInput{
+		Namespace: aws.String("MyApp"),
+		MetricData: []cwtypes.MetricDatum{{
+			MetricName: aws.String("Batch"),
+			Timestamp:  aws.Time(now),
+			StatisticValues: &cwtypes.StatisticSet{
+				SampleCount: aws.Float64(4),
+				Sum:         aws.Float64(100),
+				Minimum:     aws.Float64(10),
+				Maximum:     aws.Float64(40),
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("PutMetricData: %v", err)
+	}
+
+	out, err := client.GetMetricStatistics(ctx, &awscw.GetMetricStatisticsInput{
+		Namespace:  aws.String("MyApp"),
+		MetricName: aws.String("Batch"),
+		StartTime:  aws.Time(now.Add(-time.Hour)),
+		EndTime:    aws.Time(now.Add(time.Hour)),
+		Period:     aws.Int32(3600),
+		Statistics: []cwtypes.Statistic{
+			cwtypes.StatisticSum,
+			cwtypes.StatisticAverage,
+			cwtypes.StatisticMinimum,
+			cwtypes.StatisticMaximum,
+			cwtypes.StatisticSampleCount,
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetMetricStatistics: %v", err)
+	}
+
+	if len(out.Datapoints) != 1 {
+		t.Fatalf("datapoints = %+v, want exactly 1", out.Datapoints)
+	}
+
+	dp := out.Datapoints[0]
+	assertStat(t, "Sum", dp.Sum, 100)
+	assertStat(t, "Average", dp.Average, 25)
+	assertStat(t, "Minimum", dp.Minimum, 10)
+	assertStat(t, "Maximum", dp.Maximum, 40)
+	assertStat(t, "SampleCount", dp.SampleCount, 4)
+}
+
+// TestSDKPutMetricDataValuesCounts covers the Values/Counts finding: each
+// Values[i] is observed Counts[i] times and must weight the aggregation.
+func TestSDKPutMetricDataValuesCounts(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	now := time.Now().UTC()
+	if _, err := client.PutMetricData(ctx, &awscw.PutMetricDataInput{
+		Namespace: aws.String("MyApp"),
+		MetricData: []cwtypes.MetricDatum{{
+			MetricName: aws.String("Weighted"),
+			Timestamp:  aws.Time(now),
+			Values:     []float64{1, 2, 3},
+			Counts:     []float64{4, 1, 1},
+		}},
+	}); err != nil {
+		t.Fatalf("PutMetricData: %v", err)
+	}
+
+	out, err := client.GetMetricStatistics(ctx, &awscw.GetMetricStatisticsInput{
+		Namespace:  aws.String("MyApp"),
+		MetricName: aws.String("Weighted"),
+		StartTime:  aws.Time(now.Add(-time.Hour)),
+		EndTime:    aws.Time(now.Add(time.Hour)),
+		Period:     aws.Int32(3600),
+		Statistics: []cwtypes.Statistic{
+			cwtypes.StatisticSum,
+			cwtypes.StatisticSampleCount,
+			cwtypes.StatisticAverage,
+			cwtypes.StatisticMaximum,
+			cwtypes.StatisticMinimum,
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetMetricStatistics: %v", err)
+	}
+
+	if len(out.Datapoints) != 1 {
+		t.Fatalf("datapoints = %+v, want exactly 1", out.Datapoints)
+	}
+
+	dp := out.Datapoints[0]
+	assertStat(t, "Sum", dp.Sum, 9)         // 1*4 + 2*1 + 3*1
+	assertStat(t, "SampleCount", dp.SampleCount, 6)
+	assertStat(t, "Average", dp.Average, 1.5) // 9 / 6
+	assertStat(t, "Maximum", dp.Maximum, 3)
+	assertStat(t, "Minimum", dp.Minimum, 1)
+}
+
+// TestSDKPutMetricAlarmInvalidComparisonOperator covers the enum-validation
+// finding: an unrecognized ComparisonOperator must be rejected with a
+// ValidationError, not silently stored as a never-firing alarm.
+func TestSDKPutMetricAlarmInvalidComparisonOperator(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	_, err := client.PutMetricAlarm(ctx, &awscw.PutMetricAlarmInput{
+		AlarmName:          aws.String("bogus"),
+		Namespace:          aws.String("MyApp"),
+		MetricName:         aws.String("Errors"),
+		ComparisonOperator: cwtypes.ComparisonOperator("NotAnOperator"),
+		Threshold:          aws.Float64(1),
+		EvaluationPeriods:  aws.Int32(1),
+		Period:             aws.Int32(60),
+		Statistic:          cwtypes.StatisticAverage,
+	})
+	if err == nil {
+		t.Fatalf("PutMetricAlarm with invalid ComparisonOperator: got nil error, want ValidationError")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ValidationError" {
+		t.Fatalf("PutMetricAlarm error = %v, want ValidationError", err)
+	}
+
+	// A valid operator must still be accepted.
+	if _, err := client.PutMetricAlarm(ctx, &awscw.PutMetricAlarmInput{
+		AlarmName:          aws.String("ok"),
+		Namespace:          aws.String("MyApp"),
+		MetricName:         aws.String("Errors"),
+		ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+		Threshold:          aws.Float64(1),
+		EvaluationPeriods:  aws.Int32(1),
+		Period:             aws.Int32(60),
+		Statistic:          cwtypes.StatisticAverage,
+	}); err != nil {
+		t.Fatalf("PutMetricAlarm valid operator: %v", err)
+	}
+}
+
+func assertStat(t *testing.T, name string, got *float64, want float64) {
+	t.Helper()
+
+	if got == nil {
+		t.Fatalf("%s statistic = nil, want %v", name, want)
+	}
+
+	if *got != want {
+		t.Fatalf("%s statistic = %v, want %v", name, *got, want)
+	}
+}

--- a/server/aws/cloudwatch/ops.go
+++ b/server/aws/cloudwatch/ops.go
@@ -30,12 +30,22 @@ type putMetricDataInput struct {
 	MetricData []putMetricDatumCBR `cbor:"MetricData"`
 }
 
+type statisticSetCBR struct {
+	SampleCount float64 `cbor:"SampleCount"`
+	Sum         float64 `cbor:"Sum"`
+	Minimum     float64 `cbor:"Minimum"`
+	Maximum     float64 `cbor:"Maximum"`
+}
+
 type putMetricDatumCBR struct {
-	MetricName string         `cbor:"MetricName"`
-	Value      float64        `cbor:"Value"`
-	Unit       string         `cbor:"Unit,omitempty"`
-	Timestamp  *time.Time     `cbor:"Timestamp,omitempty"`
-	Dimensions []dimensionCBR `cbor:"Dimensions,omitempty"`
+	MetricName      string           `cbor:"MetricName"`
+	Value           float64          `cbor:"Value"`
+	Unit            string           `cbor:"Unit,omitempty"`
+	Timestamp       *time.Time       `cbor:"Timestamp,omitempty"`
+	Dimensions      []dimensionCBR   `cbor:"Dimensions,omitempty"`
+	StatisticValues *statisticSetCBR `cbor:"StatisticValues,omitempty"`
+	Values          []float64        `cbor:"Values,omitempty"`
+	Counts          []float64        `cbor:"Counts,omitempty"`
 }
 
 type dimensionCBR struct {
@@ -52,7 +62,8 @@ func (h *Handler) putMetricData(w http.ResponseWriter, r *http.Request, body []b
 
 	data := make([]mondriver.MetricDatum, 0, len(in.MetricData))
 
-	for _, d := range in.MetricData {
+	for i := range in.MetricData {
+		d := &in.MetricData[i]
 		// AWS defaults an omitted timestamp to request-receipt time; storing the
 		// Go zero value instead would make the datapoint unqueryable and leave
 		// alarms stuck in INSUFFICIENT_DATA.
@@ -61,14 +72,27 @@ func (h *Handler) putMetricData(w http.ResponseWriter, r *http.Request, body []b
 			ts = *d.Timestamp
 		}
 
-		data = append(data, mondriver.MetricDatum{
+		datum := mondriver.MetricDatum{
 			Namespace:  in.Namespace,
 			MetricName: d.MetricName,
 			Value:      d.Value,
 			Unit:       d.Unit,
 			Dimensions: toDimensionMap(d.Dimensions),
 			Timestamp:  ts,
-		})
+			Values:     d.Values,
+			Counts:     d.Counts,
+		}
+
+		if d.StatisticValues != nil {
+			datum.StatisticValues = &mondriver.StatisticSet{
+				SampleCount: d.StatisticValues.SampleCount,
+				Sum:         d.StatisticValues.Sum,
+				Minimum:     d.StatisticValues.Minimum,
+				Maximum:     d.StatisticValues.Maximum,
+			}
+		}
+
+		data = append(data, datum)
 	}
 
 	if err := h.monitoring.PutMetricData(r.Context(), data); err != nil {
@@ -112,9 +136,12 @@ func (h *Handler) getMetricStatistics(w http.ResponseWriter, r *http.Request, bo
 		return
 	}
 
-	stat := statAverage
-	if len(in.Statistics) > 0 {
-		stat = in.Statistics[0]
+	// Every requested statistic is returned on each datapoint. Callers routinely
+	// ask for several (e.g. Average, Sum, Maximum) in one call and expect all of
+	// them populated, so fall back to Average only when none was requested.
+	stats := in.Statistics
+	if len(stats) == 0 {
+		stats = []string{statAverage}
 	}
 
 	start := time.Time{}
@@ -128,42 +155,52 @@ func (h *Handler) getMetricStatistics(w http.ResponseWriter, r *http.Request, bo
 	}
 
 	if h.ipam != nil && in.Namespace == netdriver.IpamMetricNamespace {
-		h.getIpamMetricStatistics(w, r, in.MetricName, toDimensionMap(in.Dimensions), stat)
+		h.getIpamMetricStatistics(w, r, in.MetricName, toDimensionMap(in.Dimensions), stats)
 		return
 	}
 
-	input := mondriver.GetMetricInput{
-		Namespace:  in.Namespace,
-		MetricName: in.MetricName,
-		Dimensions: toDimensionMap(in.Dimensions),
-		StartTime:  start,
-		EndTime:    end,
-		Period:     in.Period,
-		Stat:       stat,
-	}
+	dims := toDimensionMap(in.Dimensions)
+	acc := newDatapointAcc()
 
-	result, err := h.monitoring.GetMetricData(r.Context(), input)
-	if err != nil {
-		writeDriverErr(w, err)
-		return
+	for _, stat := range stats {
+		result, err := h.monitoring.GetMetricData(r.Context(), mondriver.GetMetricInput{
+			Namespace:  in.Namespace,
+			MetricName: in.MetricName,
+			Dimensions: dims,
+			StartTime:  start,
+			EndTime:    end,
+			Period:     in.Period,
+			Stat:       stat,
+		})
+		if err != nil {
+			writeDriverErr(w, err)
+			return
+		}
+
+		acc.add(result, stat)
 	}
 
 	writeCBORResponse(w, getMetricStatisticsOutput{
 		Label:      in.MetricName,
-		Datapoints: toDatapointsCBR(result, stat),
+		Datapoints: acc.datapoints(),
 	})
 }
 
 // getIpamMetricStatistics returns a single datapoint for a derived AWS/IPAM
-// metric, matched by name and (if supplied) dimensions.
-func (h *Handler) getIpamMetricStatistics(w http.ResponseWriter, r *http.Request, name string, dims map[string]string, stat string) {
+// metric, matched by name and (if supplied) dimensions, populating every
+// requested statistic.
+func (h *Handler) getIpamMetricStatistics(
+	w http.ResponseWriter, r *http.Request, name string, dims map[string]string, stats []string,
+) {
 	for _, mtr := range h.ipam.IpamMetrics(r.Context()) {
 		if mtr.MetricName != name || !dimensionsMatch(mtr.Dimensions, dims) {
 			continue
 		}
 
 		dp := datapointCBR{Timestamp: time.Unix(0, 0).UTC(), Unit: mtr.Unit}
-		setDatapointStat(&dp, stat, mtr.Value)
+		for _, stat := range stats {
+			setDatapointStat(&dp, stat, mtr.Value)
+		}
 
 		writeCBORResponse(w, getMetricStatisticsOutput{Label: name, Datapoints: []datapointCBR{dp}})
 
@@ -171,6 +208,65 @@ func (h *Handler) getIpamMetricStatistics(w http.ResponseWriter, r *http.Request
 	}
 
 	writeCBORResponse(w, getMetricStatisticsOutput{Label: name, Datapoints: nil})
+}
+
+// datapointAcc merges per-statistic MetricDataResults into one datapoint per
+// timestamp, so a multi-statistic GetMetricStatistics call returns each
+// datapoint with all requested statistics populated.
+type datapointAcc struct {
+	byTS  map[int64]*datapointCBR
+	order []int64
+	unit  string
+}
+
+func newDatapointAcc() *datapointAcc {
+	return &datapointAcc{byTS: map[int64]*datapointCBR{}}
+}
+
+// add folds one statistic's result into the accumulator.
+func (a *datapointAcc) add(res *mondriver.MetricDataResult, stat string) {
+	if res == nil {
+		return
+	}
+
+	if a.unit == "" {
+		a.unit = res.Unit
+	}
+
+	for i := range res.Timestamps {
+		ts := res.Timestamps[i].UTC()
+		key := ts.UnixNano()
+
+		dp, ok := a.byTS[key]
+		if !ok {
+			dp = &datapointCBR{Timestamp: ts}
+			a.byTS[key] = dp
+			a.order = append(a.order, key)
+		}
+
+		setDatapointStat(dp, stat, res.Values[i])
+	}
+}
+
+// datapoints returns the merged datapoints in ascending timestamp order, each
+// stamped with the resolved unit.
+func (a *datapointAcc) datapoints() []datapointCBR {
+	unit := a.unit
+	if unit == "" {
+		unit = defaultMetricUnit
+	}
+
+	sort.Slice(a.order, func(i, j int) bool { return a.order[i] < a.order[j] })
+
+	out := make([]datapointCBR, 0, len(a.order))
+
+	for _, key := range a.order {
+		dp := a.byTS[key]
+		dp.Unit = unit
+		out = append(out, *dp)
+	}
+
+	return out
 }
 
 // dimensionsMatch reports whether every requested dimension is present in have.
@@ -409,10 +505,37 @@ type putMetricAlarmInput struct {
 	Tags                    []tagCBR       `cbor:"Tags,omitempty"`
 }
 
+// validComparisonOperators is the closed CloudWatch ComparisonOperator enum. A
+// value outside this set is rejected with a ValidationError, matching AWS,
+// rather than silently stored (which would leave the alarm unable to fire).
+//
+//nolint:gochecknoglobals // fixed lookup table for a closed enum.
+var validComparisonOperators = map[string]bool{
+	"GreaterThanOrEqualToThreshold":            true,
+	"GreaterThanThreshold":                     true,
+	"LessThanThreshold":                        true,
+	"LessThanOrEqualToThreshold":               true,
+	"LessThanLowerOrGreaterThanUpperThreshold": true,
+	"LessThanLowerThreshold":                   true,
+	"GreaterThanUpperThreshold":                true,
+}
+
+// comparisonOperatorValid reports whether op is empty (unset — AWS allows metric-
+// math/anomaly alarms to omit it) or a member of the closed enum.
+func comparisonOperatorValid(op string) bool {
+	return op == "" || validComparisonOperators[op]
+}
+
 func (h *Handler) putMetricAlarm(w http.ResponseWriter, r *http.Request, body []byte) {
 	var in putMetricAlarmInput
 	if err := cbor.Unmarshal(body, &in); err != nil {
 		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	if !comparisonOperatorValid(in.ComparisonOperator) {
+		writeCBORError(w, http.StatusBadRequest, "ValidationError",
+			"Invalid ComparisonOperator: "+in.ComparisonOperator)
 		return
 	}
 
@@ -679,45 +802,6 @@ func toDimensionMap(dims []dimensionCBR) map[string]string {
 		if d.Name != "" {
 			out[d.Name] = d.Value
 		}
-	}
-
-	return out
-}
-
-func toDatapointsCBR(res *mondriver.MetricDataResult, stat string) []datapointCBR {
-	if res == nil {
-		return nil
-	}
-
-	unit := res.Unit
-	if unit == "" {
-		unit = defaultMetricUnit
-	}
-
-	out := make([]datapointCBR, 0, len(res.Timestamps))
-
-	for i := range res.Timestamps {
-		dp := datapointCBR{
-			Timestamp: res.Timestamps[i].UTC(),
-			Unit:      unit,
-		}
-
-		v := res.Values[i]
-
-		switch stat {
-		case statSum:
-			dp.Sum = v
-		case statMinimum:
-			dp.Minimum = v
-		case statMaximum:
-			dp.Maximum = v
-		case statSampleCount:
-			dp.SampleCount = v
-		default:
-			dp.Average = v
-		}
-
-		out = append(out, dp)
 	}
 
 	return out

--- a/server/aws/cloudwatch/query.go
+++ b/server/aws/cloudwatch/query.go
@@ -9,6 +9,7 @@ package cloudwatch
 import (
 	"encoding/xml"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -88,10 +89,15 @@ func (h *Handler) queryPutMetricData(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		data = append(data, mondriver.MetricDatum{
+		datum := mondriver.MetricDatum{
 			Namespace: ns, MetricName: name, Value: val, Unit: r.Form.Get(p + "Unit"),
 			Dimensions: queryDimensions(r, p+"Dimensions.member."), Timestamp: ts,
-		})
+			StatisticValues: queryStatisticValues(r, p+"StatisticValues."),
+			Values:          queryFloatList(r, p+"Values.member."),
+			Counts:          queryFloatList(r, p+"Counts.member."),
+		}
+
+		data = append(data, datum)
 	}
 
 	if err := h.monitoring.PutMetricData(r.Context(), data); err != nil {
@@ -120,51 +126,105 @@ func (h *Handler) queryListMetrics(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) queryGetMetricStatistics(w http.ResponseWriter, r *http.Request) {
-	stat := r.Form.Get("Statistics.member.1")
-	if stat == "" {
-		stat = statAverage
+	stats := queryStringList(r, "Statistics.member.")
+	if len(stats) == 0 {
+		stats = []string{statAverage}
 	}
 
 	start, _ := time.Parse(time.RFC3339, r.Form.Get("StartTime"))
 	end, _ := time.Parse(time.RFC3339, r.Form.Get("EndTime"))
 	period, _ := strconv.Atoi(r.Form.Get("Period"))
+	dims := queryDimensions(r, "Dimensions.member.")
 
-	res, err := h.monitoring.GetMetricData(r.Context(), mondriver.GetMetricInput{
-		Namespace: r.Form.Get("Namespace"), MetricName: r.Form.Get("MetricName"),
-		Dimensions: queryDimensions(r, "Dimensions.member."), StartTime: start, EndTime: end,
-		Period: period, Stat: stat,
-	})
-	if err != nil {
-		writeQueryDriverErr(w, err)
+	acc := newQueryDatapointAcc()
+
+	for _, stat := range stats {
+		res, err := h.monitoring.GetMetricData(r.Context(), mondriver.GetMetricInput{
+			Namespace: r.Form.Get("Namespace"), MetricName: r.Form.Get("MetricName"),
+			Dimensions: dims, StartTime: start, EndTime: end, Period: period, Stat: stat,
+		})
+		if err != nil {
+			writeQueryDriverErr(w, err)
+			return
+		}
+
+		acc.add(res, stat)
+	}
+
+	writeQueryResponse(w, "GetMetricStatisticsResponse",
+		getStatsResultXML{Label: r.Form.Get("MetricName"), Datapoints: acc.datapoints()})
+}
+
+// queryDatapointAcc merges per-statistic results into one XML datapoint per
+// timestamp so a multi-statistic GetMetricStatistics returns every requested
+// statistic on each datapoint.
+type queryDatapointAcc struct {
+	byTS  map[int64]*datapointXML
+	order []int64
+	unit  string
+}
+
+func newQueryDatapointAcc() *queryDatapointAcc {
+	return &queryDatapointAcc{byTS: map[int64]*datapointXML{}}
+}
+
+func (a *queryDatapointAcc) add(res *mondriver.MetricDataResult, stat string) {
+	if res == nil {
 		return
 	}
 
-	var dps []datapointXML
-
-	if res != nil {
-		unit := res.Unit
-		if unit == "" {
-			unit = defaultMetricUnit
-		}
-
-		for i := range res.Timestamps {
-			dp := datapointXML{Timestamp: res.Timestamps[i].UTC().Format(time.RFC3339), Unit: unit}
-			setQueryStat(&dp, stat, res.Values[i])
-			dps = append(dps, dp)
-		}
+	if a.unit == "" {
+		a.unit = res.Unit
 	}
 
-	writeQueryResponse(w, "GetMetricStatisticsResponse", getStatsResultXML{Label: r.Form.Get("MetricName"), Datapoints: dps})
+	for i := range res.Timestamps {
+		ts := res.Timestamps[i].UTC()
+		key := ts.UnixNano()
+
+		dp, ok := a.byTS[key]
+		if !ok {
+			dp = &datapointXML{Timestamp: ts.Format(time.RFC3339)}
+			a.byTS[key] = dp
+			a.order = append(a.order, key)
+		}
+
+		setQueryStat(dp, stat, res.Values[i])
+	}
+}
+
+func (a *queryDatapointAcc) datapoints() []datapointXML {
+	unit := a.unit
+	if unit == "" {
+		unit = defaultMetricUnit
+	}
+
+	sort.Slice(a.order, func(i, j int) bool { return a.order[i] < a.order[j] })
+
+	out := make([]datapointXML, 0, len(a.order))
+
+	for _, key := range a.order {
+		dp := a.byTS[key]
+		dp.Unit = unit
+		out = append(out, *dp)
+	}
+
+	return out
 }
 
 func (h *Handler) queryPutMetricAlarm(w http.ResponseWriter, r *http.Request) {
+	comparisonOperator := r.Form.Get("ComparisonOperator")
+	if !comparisonOperatorValid(comparisonOperator) {
+		writeQueryError(w, http.StatusBadRequest, "ValidationError", "Invalid ComparisonOperator: "+comparisonOperator)
+		return
+	}
+
 	threshold, _ := strconv.ParseFloat(r.Form.Get("Threshold"), 64)
 	period, _ := strconv.Atoi(r.Form.Get("Period"))
 	evalPeriods, _ := strconv.Atoi(r.Form.Get("EvaluationPeriods"))
 
 	err := h.monitoring.CreateAlarm(r.Context(), mondriver.AlarmConfig{
 		Name: r.Form.Get("AlarmName"), Namespace: r.Form.Get("Namespace"), MetricName: r.Form.Get("MetricName"),
-		Dimensions: queryDimensions(r, "Dimensions.member."), ComparisonOperator: r.Form.Get("ComparisonOperator"),
+		Dimensions: queryDimensions(r, "Dimensions.member."), ComparisonOperator: comparisonOperator,
 		Threshold: threshold, Period: period, EvaluationPeriods: evalPeriods, Stat: r.Form.Get("Statistic"),
 		AlarmActions: queryStringList(r, "AlarmActions.member."), OKActions: queryStringList(r, "OKActions.member."),
 	})
@@ -231,6 +291,40 @@ func queryDimensions(r *http.Request, prefix string) map[string]string {
 		}
 
 		out[name] = r.Form.Get(prefix + strconv.Itoa(i) + ".Value")
+	}
+
+	return out
+}
+
+// queryStatisticValues parses a StatisticSet (SampleCount/Sum/Minimum/Maximum)
+// from the query-protocol form, returning nil when no SampleCount is present.
+func queryStatisticValues(r *http.Request, prefix string) *mondriver.StatisticSet {
+	raw := r.Form.Get(prefix + "SampleCount")
+	if raw == "" {
+		return nil
+	}
+
+	sampleCount, _ := strconv.ParseFloat(raw, 64)
+	sum, _ := strconv.ParseFloat(r.Form.Get(prefix+"Sum"), 64)
+	minimum, _ := strconv.ParseFloat(r.Form.Get(prefix+"Minimum"), 64)
+	maximum, _ := strconv.ParseFloat(r.Form.Get(prefix+"Maximum"), 64)
+
+	return &mondriver.StatisticSet{SampleCount: sampleCount, Sum: sum, Minimum: minimum, Maximum: maximum}
+}
+
+// queryFloatList parses a 1-indexed list of floats (Values.member.N /
+// Counts.member.N) from the query-protocol form.
+func queryFloatList(r *http.Request, prefix string) []float64 {
+	var out []float64
+
+	for i := 1; ; i++ {
+		v := r.Form.Get(prefix + strconv.Itoa(i))
+		if v == "" {
+			break
+		}
+
+		f, _ := strconv.ParseFloat(v, 64)
+		out = append(out, f)
 	}
 
 	return out

--- a/server/aws/cloudwatchlogs/describe_streams_test.go
+++ b/server/aws/cloudwatchlogs/describe_streams_test.go
@@ -1,0 +1,98 @@
+package cloudwatchlogs_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cwl "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+)
+
+// TestSDKDescribeLogStreamsPrefix covers the logStreamNamePrefix finding:
+// DescribeLogStreams must filter streams to those whose name starts with the
+// prefix, not silently ignore it and return every stream.
+func TestSDKDescribeLogStreamsPrefix(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{
+		LogGroupName: aws.String("grp"),
+	}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	for _, name := range []string{"app-1", "app-2", "worker-1"} {
+		if _, err := client.CreateLogStream(ctx, &cwl.CreateLogStreamInput{
+			LogGroupName:  aws.String("grp"),
+			LogStreamName: aws.String(name),
+		}); err != nil {
+			t.Fatalf("CreateLogStream(%s): %v", name, err)
+		}
+	}
+
+	out, err := client.DescribeLogStreams(ctx, &cwl.DescribeLogStreamsInput{
+		LogGroupName:        aws.String("grp"),
+		LogStreamNamePrefix: aws.String("app-"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeLogStreams: %v", err)
+	}
+
+	if len(out.LogStreams) != 2 {
+		t.Fatalf("streams = %d, want 2 (only app-* streams)", len(out.LogStreams))
+	}
+
+	for _, s := range out.LogStreams {
+		if got := aws.ToString(s.LogStreamName); got != "app-1" && got != "app-2" {
+			t.Fatalf("unexpected stream %q returned for prefix app-", got)
+		}
+	}
+}
+
+// TestSDKPutRetentionPolicyInvalid covers the retention-validation finding: a
+// retentionInDays value outside the allowed set must be rejected with
+// InvalidParameterException, not accepted and stored.
+func TestSDKPutRetentionPolicyInvalid(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{
+		LogGroupName: aws.String("grp"),
+	}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	_, err := client.PutRetentionPolicy(ctx, &cwl.PutRetentionPolicyInput{
+		LogGroupName:    aws.String("grp"),
+		RetentionInDays: aws.Int32(17),
+	})
+	if err == nil {
+		t.Fatalf("PutRetentionPolicy(17): got nil error, want InvalidParameterException")
+	}
+
+	var invalid *cwltypes.InvalidParameterException
+	if !errors.As(err, &invalid) {
+		t.Fatalf("PutRetentionPolicy(17) error = %v, want InvalidParameterException", err)
+	}
+
+	// A valid value must still be accepted and reflected on the group.
+	if _, err := client.PutRetentionPolicy(ctx, &cwl.PutRetentionPolicyInput{
+		LogGroupName:    aws.String("grp"),
+		RetentionInDays: aws.Int32(30),
+	}); err != nil {
+		t.Fatalf("PutRetentionPolicy(30): %v", err)
+	}
+
+	out, err := client.DescribeLogGroups(ctx, &cwl.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String("grp"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeLogGroups: %v", err)
+	}
+
+	if len(out.LogGroups) != 1 || aws.ToInt32(out.LogGroups[0].RetentionInDays) != 30 {
+		t.Fatalf("retention = %+v, want 30", out.LogGroups)
+	}
+}

--- a/server/aws/cloudwatchlogs/handler.go
+++ b/server/aws/cloudwatchlogs/handler.go
@@ -96,6 +96,12 @@ func (h *Handler) putRetentionPolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !validRetentionInDays[req.RetentionInDays] {
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException",
+			"retentionInDays is not a valid value")
+		return
+	}
+
 	if _, err := h.logs.UpdateLogGroup(r.Context(), logdriver.LogGroupConfig{
 		Name: req.LogGroupName, RetentionDays: req.RetentionInDays,
 	}); err != nil {
@@ -104,6 +110,16 @@ func (h *Handler) putRetentionPolicy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wire.WriteJSON(w, struct{}{})
+}
+
+// validRetentionInDays is the closed set of retentionInDays values CloudWatch
+// Logs accepts; any other value is rejected with InvalidParameterException.
+//
+//nolint:gochecknoglobals // fixed lookup table for a closed enum.
+var validRetentionInDays = map[int]bool{
+	1: true, 3: true, 5: true, 7: true, 14: true, 30: true, 60: true, 90: true,
+	120: true, 150: true, 180: true, 365: true, 400: true, 545: true, 731: true,
+	1096: true, 1827: true, 2192: true, 2557: true, 2922: true, 3288: true, 3653: true,
 }
 
 // writeErr maps canonical cloudemu errors to CloudWatch Logs JSON error

--- a/server/aws/cloudwatchlogs/operations.go
+++ b/server/aws/cloudwatchlogs/operations.go
@@ -187,6 +187,21 @@ func (h *Handler) describeLogStreams(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// logStreamNamePrefix filters to streams whose name starts with the prefix.
+	// ListLogStreams already returns streams ordered by name (the default
+	// orderBy=LogStreamName), so filtering the slice keeps that order.
+	if req.LogStreamNamePrefix != "" {
+		filtered := make([]logdriver.LogStreamInfo, 0, len(infos))
+
+		for i := range infos {
+			if strings.HasPrefix(infos[i].Name, req.LogStreamNamePrefix) {
+				filtered = append(filtered, infos[i])
+			}
+		}
+
+		infos = filtered
+	}
+
 	// The stream ARN is derived from the owning group's ARN, which the driver
 	// carries on the group, not the stream.
 	groupARN := ""

--- a/server/aws/cloudwatchlogs/types.go
+++ b/server/aws/cloudwatchlogs/types.go
@@ -29,9 +29,10 @@ type createLogStreamRequest struct {
 }
 
 type describeLogStreamsRequest struct {
-	LogGroupName string `json:"logGroupName"`
-	Limit        int32  `json:"limit"`
-	NextToken    string `json:"nextToken"`
+	LogGroupName        string `json:"logGroupName"`
+	LogStreamNamePrefix string `json:"logStreamNamePrefix"`
+	Limit               int32  `json:"limit"`
+	NextToken           string `json:"nextToken"`
 }
 
 type deleteLogStreamRequest struct {

--- a/services/monitoring/driver/driver.go
+++ b/services/monitoring/driver/driver.go
@@ -15,14 +15,31 @@ type MetricIdentifier struct {
 	Dimensions map[string]string
 }
 
-// MetricDatum is a single metric data point.
+// StatisticSet is a pre-aggregated metric sample: the SampleCount/Sum/Minimum/
+// Maximum a caller supplies via PutMetricData's StatisticValues instead of a
+// single Value. It lets the series answer every statistic without the raw
+// observations.
+type StatisticSet struct {
+	SampleCount float64
+	Sum         float64
+	Minimum     float64
+	Maximum     float64
+}
+
+// MetricDatum is a single metric data point. A datum carries either a single
+// Value, a pre-aggregated StatisticValues set, or paired Values/Counts arrays
+// (each Values[i] observed Counts[i] times); the later two let a caller publish
+// aggregated data without the individual observations.
 type MetricDatum struct {
-	Namespace  string
-	MetricName string
-	Value      float64
-	Unit       string
-	Dimensions map[string]string
-	Timestamp  time.Time
+	Namespace       string
+	MetricName      string
+	Value           float64
+	Unit            string
+	Dimensions      map[string]string
+	Timestamp       time.Time
+	StatisticValues *StatisticSet
+	Values          []float64
+	Counts          []float64
 }
 
 // GetMetricInput configures a metric retrieval operation.


### PR DESCRIPTION
## Summary

Fixes five real-user AWS parity findings across CloudWatch and CloudWatch Logs, all matched to the exact AWS wire contracts (error codes, HTTP status, response shapes).

### CloudWatch

1. **GetMetricStatistics multi-statistic** — When several statistics are requested (e.g. `Average,Sum,Maximum`), every returned datapoint now populates all of them. Previously the handler used only `Statistics[0]`, so `Sum`/`Maximum` came back nil. Fixed on both the rpc-v2-cbor and query (CLI) paths by querying each statistic and merging results per timestamp.

2. **PutMetricData StatisticValues / Values+Counts** — A `MetricDatum` may carry a pre-aggregated `StatisticValues` set (SampleCount/Sum/Min/Max) or paired `Values`/`Counts` arrays instead of a single `Value`. These are now decoded (CBOR + query) and folded into the series, so a `StatisticValues`-only datum reports the supplied `Sum` instead of 0. Aggregation treats plain values, statistic sets, and weighted values/counts uniformly.

3. **PutMetricAlarm ComparisonOperator validation** — An unrecognized `ComparisonOperator` is now rejected with a `ValidationError` (HTTP 400) instead of being stored as an alarm that can never fire. The closed enum is validated on both wire paths.

### CloudWatch Logs

4. **DescribeLogStreams logStreamNamePrefix** — The `logStreamNamePrefix` parameter is now decoded and filters returned streams to those whose name starts with the prefix (default `orderBy=LogStreamName`). It was previously ignored, returning every stream.

5. **PutRetentionPolicy retentionInDays validation** — `retentionInDays` is validated against the allowed set (1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653). An invalid value now returns `InvalidParameterException` (HTTP 400) instead of being accepted.

## Layering

- The pre-aggregated statistic representation is a struct-field addition to `services/monitoring/driver.MetricDatum` (`StatisticSet`, `Values`, `Counts`); aggregation lives in the AWS provider. No interface method changed, so generated `docs/coverage` is unaffected.
- Enum/prefix/retention validation lives at the wire layer where the AWS-specific enums belong.

## Tests

Real aws-sdk-go-v2 tests over an httptest server assert exact statistics, error codes, and filtering, plus provider unit tests for statistic-set and values/counts aggregation.