### PR TITLE
fix(sqs-kinesis): RedriveAllowPolicy round-trip, AWSTraceHeader system attribute, AT_TIMESTAMP validation

### DIFF
--- a/providers/aws/kinesis/records.go
+++ b/providers/aws/kinesis/records.go
@@ -275,6 +275,10 @@ func positionFor(shard *shardState, in *driver.GetShardIteratorInput) (int, erro
 	case driver.IteratorLatest:
 		return len(shard.records), nil
 	case driver.IteratorAtTimestamp:
+		if in.Timestamp.IsZero() {
+			return 0, invalidArg("AT_TIMESTAMP shard iterator type requires a Timestamp value")
+		}
+
 		return indexByTimestamp(shard.records, in.Timestamp), nil
 	case driver.IteratorAtSequenceNumber:
 		return indexBySeq(shard.records, in.StartingSequenceNumber, false)

--- a/providers/aws/sqs/sqs.go
+++ b/providers/aws/sqs/sqs.go
@@ -820,6 +820,7 @@ func batchEntryToSendInput(queue string, entry *driver.BatchSendEntry) driver.Se
 		DeduplicationID:   entry.DeduplicationID,
 		Attributes:        entry.Attributes,
 		MessageAttributes: entry.MessageAttributes,
+		SystemAttributes:  entry.SystemAttributes,
 	}
 }
 

--- a/providers/aws/sqs/sqs.go
+++ b/providers/aws/sqs/sqs.go
@@ -40,6 +40,7 @@ type sqsMessage struct {
 	DeduplicationID   string
 	Attributes        map[string]string
 	MessageAttributes map[string]driver.MessageAttributeValue
+	SystemAttributes  map[string]string
 	SenderID          string
 	SequenceNumber    string
 	ReceiptHandle     string
@@ -66,6 +67,7 @@ type queueData struct {
 	receiveWaitTime    int
 	contentBasedDedup  bool
 	redrivePolicy      string
+	redriveAllowPolicy string
 	policy             string
 	kmsMasterKeyID     string
 	createdAt          time.Time
@@ -213,6 +215,7 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		lastModifiedAt:     now,
 		deduplicationIndex: make(map[string]time.Time),
 		dlqConfig:          cfg.DeadLetterQueue,
+		redriveAllowPolicy: cfg.RedriveAllowPolicy,
 	}
 
 	if cfg.RedrivePolicy != "" {
@@ -274,7 +277,8 @@ func sameQueueConfig(existing *queueData, cfg *driver.QueueConfig) bool {
 		existing.delaySeconds == cfg.DelaySeconds &&
 		existing.receiveWaitTime == cfg.ReceiveMessageWaitTimeSeconds &&
 		existing.contentBasedDedup == cfg.ContentBasedDeduplication &&
-		existing.redrivePolicy == cfg.RedrivePolicy
+		existing.redrivePolicy == cfg.RedrivePolicy &&
+		existing.redriveAllowPolicy == cfg.RedriveAllowPolicy
 }
 
 // parseRedrivePolicy resolves an SQS RedrivePolicy JSON document into a
@@ -472,11 +476,28 @@ func (m *Mock) buildStoredMessage(qd *queueData, input *driver.SendMessageInput,
 		DeduplicationID:   input.DeduplicationID,
 		Attributes:        attrs,
 		MessageAttributes: copyMessageAttributes(input.MessageAttributes),
+		SystemAttributes:  systemAttributeStrings(input.SystemAttributes),
 		SenderID:          m.opts.AccountID,
 		SequenceNumber:    seqNum,
 		VisibleAt:         now.Add(time.Duration(delaySeconds) * time.Second),
 		SentAt:            now,
 	}
+}
+
+// systemAttributeStrings flattens caller-supplied SQS message system attributes
+// (e.g. AWSTraceHeader) into a name->string map for storage. Only the string
+// value is retained; system attributes are always String-typed in SQS.
+func systemAttributeStrings(in map[string]driver.MessageAttributeValue) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v.StringValue
+	}
+
+	return out
 }
 
 // contentDeduplicationID derives a FIFO deduplication ID from the message body
@@ -664,6 +685,11 @@ func buildReceivedMessage(msg *sqsMessage, visibilityTimeout int, now time.Time)
 
 	if msg.DeduplicationID != "" {
 		sysAttrs["MessageDeduplicationId"] = msg.DeduplicationID
+	}
+
+	// Caller-supplied system attributes (e.g. AWSTraceHeader) round-trip verbatim.
+	for k, v := range msg.SystemAttributes {
+		sysAttrs[k] = v
 	}
 
 	return driver.Message{
@@ -892,6 +918,7 @@ func (m *Mock) GetQueueAttributes(
 		FifoQueue:                     qd.info.FIFO,
 		ContentBasedDeduplication:     qd.contentBasedDedup,
 		RedrivePolicy:                 qd.redrivePolicy,
+		RedriveAllowPolicy:            qd.redriveAllowPolicy,
 		ReceiveMessageWaitTimeSeconds: qd.receiveWaitTime,
 		Policy:                        qd.policy,
 		KmsMasterKeyID:                qd.kmsMasterKeyID,
@@ -969,6 +996,10 @@ func (m *Mock) SetQueueAttributesRaw(_ context.Context, queue string, attrs map[
 	if v, ok := attrs["RedrivePolicy"]; ok {
 		qd.redrivePolicy = v
 		qd.dlqConfig = m.parseRedrivePolicy(v)
+	}
+
+	if v, ok := attrs["RedriveAllowPolicy"]; ok {
+		qd.redriveAllowPolicy = v
 	}
 
 	if v, ok := attrs["ContentBasedDeduplication"]; ok {

--- a/server/aws/kinesis/sdk_roundtrip_iterator_test.go
+++ b/server/aws/kinesis/sdk_roundtrip_iterator_test.go
@@ -1,0 +1,87 @@
+package kinesis_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awskinesis "github.com/aws/aws-sdk-go-v2/service/kinesis"
+	kinesistypes "github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKGetShardIteratorAtTimestampWithoutTimestamp confirms that requesting an
+// AT_TIMESTAMP iterator without a Timestamp is rejected with
+// InvalidArgumentException (HTTP 400), matching real Kinesis, instead of
+// silently behaving like TRIM_HORIZON.
+func TestSDKGetShardIteratorAtTimestampWithoutTimestamp(t *testing.T) {
+	ctx := context.Background()
+	c := newKinesisClient(t)
+
+	if _, err := c.CreateStream(ctx, &awskinesis.CreateStreamInput{
+		StreamName: aws.String("ts-stream"),
+		ShardCount: aws.Int32(1),
+	}); err != nil {
+		t.Fatalf("CreateStream: %v", err)
+	}
+
+	desc, err := c.DescribeStream(ctx, &awskinesis.DescribeStreamInput{StreamName: aws.String("ts-stream")})
+	if err != nil {
+		t.Fatalf("DescribeStream: %v", err)
+	}
+
+	shardID := desc.StreamDescription.Shards[0].ShardId
+
+	_, err = c.GetShardIterator(ctx, &awskinesis.GetShardIteratorInput{
+		StreamName:        aws.String("ts-stream"),
+		ShardId:           shardID,
+		ShardIteratorType: kinesistypes.ShardIteratorTypeAtTimestamp,
+		// Timestamp intentionally omitted.
+	})
+	if err == nil {
+		t.Fatal("GetShardIterator with AT_TIMESTAMP and no Timestamp returned nil error, want InvalidArgumentException")
+	}
+
+	var ae smithy.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("error is not a smithy APIError: %v", err)
+	}
+
+	if ae.ErrorCode() != "InvalidArgumentException" {
+		t.Fatalf("error code = %q, want InvalidArgumentException", ae.ErrorCode())
+	}
+}
+
+// TestSDKGetShardIteratorAtTimestampWithTimestamp confirms the happy path still
+// works when a Timestamp is supplied.
+func TestSDKGetShardIteratorAtTimestampWithTimestamp(t *testing.T) {
+	ctx := context.Background()
+	c := newKinesisClient(t)
+
+	if _, err := c.CreateStream(ctx, &awskinesis.CreateStreamInput{
+		StreamName: aws.String("ts-ok-stream"),
+		ShardCount: aws.Int32(1),
+	}); err != nil {
+		t.Fatalf("CreateStream: %v", err)
+	}
+
+	desc, err := c.DescribeStream(ctx, &awskinesis.DescribeStreamInput{StreamName: aws.String("ts-ok-stream")})
+	if err != nil {
+		t.Fatalf("DescribeStream: %v", err)
+	}
+
+	it, err := c.GetShardIterator(ctx, &awskinesis.GetShardIteratorInput{
+		StreamName:        aws.String("ts-ok-stream"),
+		ShardId:           desc.StreamDescription.Shards[0].ShardId,
+		ShardIteratorType: kinesistypes.ShardIteratorTypeAtTimestamp,
+		Timestamp:         desc.StreamDescription.StreamCreationTimestamp,
+	})
+	if err != nil {
+		t.Fatalf("GetShardIterator with Timestamp: %v", err)
+	}
+
+	if aws.ToString(it.ShardIterator) == "" {
+		t.Fatal("GetShardIterator returned empty iterator")
+	}
+}

--- a/server/aws/sqs/attributes.go
+++ b/server/aws/sqs/attributes.go
@@ -12,6 +12,9 @@ import (
 const (
 	attrAll  = "All"
 	attrTrue = "true"
+	// systemAttributeAWSTraceHeader is the only message system attribute SQS supports.
+	systemAttributeAWSTraceHeader = "AWSTraceHeader"
+	systemAttributeStringType     = "String"
 )
 
 // wireMessageAttribute is the JSON shape of a single SQS MessageAttribute.
@@ -19,6 +22,24 @@ type wireMessageAttribute struct {
 	DataType    string `json:"DataType"`
 	StringValue string `json:"StringValue,omitempty"`
 	BinaryValue []byte `json:"BinaryValue,omitempty"`
+}
+
+// validateSystemAttributes enforces the SQS contract that the only supported
+// message system attribute is AWSTraceHeader (DataType String). It returns a
+// human-readable reason when a request violates the contract, or "" when valid.
+func validateSystemAttributes(attrs map[string]wireMessageAttribute) string {
+	for name, v := range attrs {
+		if name != systemAttributeAWSTraceHeader {
+			return "Message system attribute name '" + name +
+				"' is invalid. The only valid message system attribute is 'AWSTraceHeader'."
+		}
+
+		if v.DataType != "" && v.DataType != systemAttributeStringType {
+			return "The message system attribute '" + name + "' must have data type 'String'."
+		}
+	}
+
+	return ""
 }
 
 // toDriverMessageAttributes converts wire message attributes into driver form.

--- a/server/aws/sqs/handler.go
+++ b/server/aws/sqs/handler.go
@@ -122,6 +122,7 @@ func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request) {
 		ReceiveMessageWaitTimeSeconds: atoiAttr(req.Attributes, "ReceiveMessageWaitTimeSeconds"),
 		ContentBasedDeduplication:     req.Attributes["ContentBasedDeduplication"] == attrTrue,
 		RedrivePolicy:                 req.Attributes["RedrivePolicy"],
+		RedriveAllowPolicy:            req.Attributes["RedriveAllowPolicy"],
 	}
 
 	info, err := h.mq.CreateQueue(r.Context(), cfg)
@@ -245,6 +246,7 @@ func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request) {
 		GroupID           string                          `json:"MessageGroupId"`
 		DeduplicationID   string                          `json:"MessageDeduplicationId"`
 		MessageAttributes map[string]wireMessageAttribute `json:"MessageAttributes"`
+		SystemAttributes  map[string]wireMessageAttribute `json:"MessageSystemAttributes"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -252,6 +254,7 @@ func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	msgAttrs := toDriverMessageAttributes(req.MessageAttributes)
+	sysAttrs := toDriverMessageAttributes(req.SystemAttributes)
 
 	out, err := h.mq.SendMessage(r.Context(), mqdriver.SendMessageInput{
 		QueueURL:          req.QueueURL,
@@ -260,6 +263,7 @@ func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request) {
 		GroupID:           req.GroupID,
 		DeduplicationID:   req.DeduplicationID,
 		MessageAttributes: msgAttrs,
+		SystemAttributes:  sysAttrs,
 	})
 	if err != nil {
 		writeErr(w, err)
@@ -272,6 +276,10 @@ func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request) {
 	}
 	if md5Attrs := md5OfMessageAttributes(msgAttrs); md5Attrs != "" {
 		resp["MD5OfMessageAttributes"] = md5Attrs
+	}
+
+	if md5Sys := md5OfMessageAttributes(sysAttrs); md5Sys != "" {
+		resp["MD5OfMessageSystemAttributes"] = md5Sys
 	}
 
 	if out.SequenceNumber != "" {
@@ -935,6 +943,10 @@ func (h *Handler) getQueueAttributes(w http.ResponseWriter, r *http.Request) {
 
 	if attrs.RedrivePolicy != "" {
 		all["RedrivePolicy"] = attrs.RedrivePolicy
+	}
+
+	if attrs.RedriveAllowPolicy != "" {
+		all["RedriveAllowPolicy"] = attrs.RedriveAllowPolicy
 	}
 
 	if attrs.Policy != "" {

--- a/server/aws/sqs/handler.go
+++ b/server/aws/sqs/handler.go
@@ -253,6 +253,11 @@ func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if reason := validateSystemAttributes(req.SystemAttributes); reason != "" {
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValue", reason)
+		return
+	}
+
 	msgAttrs := toDriverMessageAttributes(req.MessageAttributes)
 	sysAttrs := toDriverMessageAttributes(req.SystemAttributes)
 
@@ -473,6 +478,7 @@ func (h *Handler) sendMessageBatch(w http.ResponseWriter, r *http.Request) {
 			MessageGroupID         string                          `json:"MessageGroupId"`
 			MessageDeduplicationID string                          `json:"MessageDeduplicationId"`
 			MessageAttributes      map[string]wireMessageAttribute `json:"MessageAttributes"`
+			SystemAttributes       map[string]wireMessageAttribute `json:"MessageSystemAttributes"`
 		} `json:"Entries"`
 	}
 
@@ -480,15 +486,25 @@ func (h *Handler) sendMessageBatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	for i := range req.Entries {
+		if reason := validateSystemAttributes(req.Entries[i].SystemAttributes); reason != "" {
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValue", reason)
+			return
+		}
+	}
+
 	bodyByID := make(map[string]string, len(req.Entries))
 	attrsByID := make(map[string]map[string]mqdriver.MessageAttributeValue, len(req.Entries))
+	sysAttrsByID := make(map[string]map[string]mqdriver.MessageAttributeValue, len(req.Entries))
 
 	entries := make([]mqdriver.BatchSendEntry, 0, len(req.Entries))
 
 	for i := range req.Entries {
 		msgAttrs := toDriverMessageAttributes(req.Entries[i].MessageAttributes)
+		sysAttrs := toDriverMessageAttributes(req.Entries[i].SystemAttributes)
 		bodyByID[req.Entries[i].ID] = req.Entries[i].MessageBody
 		attrsByID[req.Entries[i].ID] = msgAttrs
+		sysAttrsByID[req.Entries[i].ID] = sysAttrs
 		entries = append(entries, mqdriver.BatchSendEntry{
 			ID:                req.Entries[i].ID,
 			Body:              req.Entries[i].MessageBody,
@@ -496,6 +512,7 @@ func (h *Handler) sendMessageBatch(w http.ResponseWriter, r *http.Request) {
 			GroupID:           req.Entries[i].MessageGroupID,
 			DeduplicationID:   req.Entries[i].MessageDeduplicationID,
 			MessageAttributes: msgAttrs,
+			SystemAttributes:  sysAttrs,
 		})
 	}
 
@@ -515,6 +532,10 @@ func (h *Handler) sendMessageBatch(w http.ResponseWriter, r *http.Request) {
 		}
 		if md5Attrs := md5OfMessageAttributes(attrsByID[res.Successful[i].ID]); md5Attrs != "" {
 			entry["MD5OfMessageAttributes"] = md5Attrs
+		}
+
+		if md5Sys := md5OfMessageAttributes(sysAttrsByID[res.Successful[i].ID]); md5Sys != "" {
+			entry["MD5OfMessageSystemAttributes"] = md5Sys
 		}
 
 		if res.Successful[i].SequenceNumber != "" {

--- a/server/aws/sqs/sdk_roundtrip_attributes_test.go
+++ b/server/aws/sqs/sdk_roundtrip_attributes_test.go
@@ -1,0 +1,159 @@
+package sqs_test
+
+import (
+	"context"
+	"crypto/md5" //nolint:gosec // SQS MD5 checksums are part of the wire protocol, not security.
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+)
+
+// wantTraceMD5 independently computes the AWS-documented MD5 digest over a single
+// String-typed AWSTraceHeader system attribute, verifying the server's digest.
+func wantTraceMD5(value string) string {
+	h := md5.New() //nolint:gosec // wire checksum
+
+	write := func(b []byte) {
+		var prefix [4]byte
+
+		binary.BigEndian.PutUint32(prefix[:], uint32(len(b)))
+		_, _ = h.Write(prefix[:])
+		_, _ = h.Write(b)
+	}
+
+	write([]byte("AWSTraceHeader"))
+	write([]byte("String"))
+	_, _ = h.Write([]byte{1})
+	write([]byte(value))
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// TestSDKSQSRedriveAllowPolicyRoundTrip confirms the RedriveAllowPolicy queue
+// attribute persists through SetQueueAttributes and is echoed by
+// GetQueueAttributes(All), matching real SQS.
+func TestSDKSQSRedriveAllowPolicyRoundTrip(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	q, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("rap-q")})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	const policy = `{"redrivePermission":"byQueue","sourceQueueArns":["arn:aws:sqs:us-east-1:000000000000:src"]}`
+
+	if _, err := client.SetQueueAttributes(ctx, &awssqs.SetQueueAttributesInput{
+		QueueUrl: q.QueueUrl,
+		Attributes: map[string]string{
+			string(sqstypes.QueueAttributeNameRedriveAllowPolicy): policy,
+		},
+	}); err != nil {
+		t.Fatalf("SetQueueAttributes: %v", err)
+	}
+
+	got, err := client.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       q.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameAll},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes: %v", err)
+	}
+
+	if v := got.Attributes["RedriveAllowPolicy"]; v != policy {
+		t.Fatalf("RedriveAllowPolicy = %q, want %q", v, policy)
+	}
+}
+
+// TestSDKSQSRedriveAllowPolicyOnCreate confirms RedriveAllowPolicy supplied at
+// CreateQueue time is persisted and returned by GetQueueAttributes.
+func TestSDKSQSRedriveAllowPolicyOnCreate(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	const policy = `{"redrivePermission":"denyAll"}`
+
+	q, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{
+		QueueName: aws.String("rap-create-q"),
+		Attributes: map[string]string{
+			string(sqstypes.QueueAttributeNameRedriveAllowPolicy): policy,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	got, err := client.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       q.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameRedriveAllowPolicy},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes: %v", err)
+	}
+
+	if v := got.Attributes["RedriveAllowPolicy"]; v != policy {
+		t.Fatalf("RedriveAllowPolicy = %q, want %q", v, policy)
+	}
+}
+
+// TestSDKSQSAWSTraceHeaderSystemAttribute confirms SendMessage accepts the
+// AWSTraceHeader message system attribute, returns MD5OfMessageSystemAttributes,
+// and ReceiveMessage returns AWSTraceHeader in the message Attributes map when
+// requested. Matches real SQS.
+func TestSDKSQSAWSTraceHeaderSystemAttribute(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	q, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("trace-q")})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	const trace = "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1"
+
+	send, err := client.SendMessage(ctx, &awssqs.SendMessageInput{
+		QueueUrl:    q.QueueUrl,
+		MessageBody: aws.String("traced"),
+		MessageSystemAttributes: map[string]sqstypes.MessageSystemAttributeValue{
+			string(sqstypes.MessageSystemAttributeNameForSendsAWSTraceHeader): {
+				DataType:    aws.String("String"),
+				StringValue: aws.String(trace),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+
+	if aws.ToString(send.MD5OfMessageSystemAttributes) == "" {
+		t.Fatal("MD5OfMessageSystemAttributes is empty, want a digest")
+	}
+
+	// AWS-documented canonical MD5 of {AWSTraceHeader: String=trace}.
+	if got := aws.ToString(send.MD5OfMessageSystemAttributes); got != wantTraceMD5(trace) {
+		t.Fatalf("MD5OfMessageSystemAttributes = %q, want %q", got, wantTraceMD5(trace))
+	}
+
+	rcv, err := client.ReceiveMessage(ctx, &awssqs.ReceiveMessageInput{
+		QueueUrl:            q.QueueUrl,
+		MaxNumberOfMessages: 1,
+		MessageSystemAttributeNames: []sqstypes.MessageSystemAttributeName{
+			sqstypes.MessageSystemAttributeNameAWSTraceHeader,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReceiveMessage: %v", err)
+	}
+
+	if len(rcv.Messages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(rcv.Messages))
+	}
+
+	if v := rcv.Messages[0].Attributes["AWSTraceHeader"]; v != trace {
+		t.Fatalf("AWSTraceHeader = %q, want %q", v, trace)
+	}
+}

--- a/server/aws/sqs/sdk_roundtrip_attributes_test.go
+++ b/server/aws/sqs/sdk_roundtrip_attributes_test.go
@@ -157,3 +157,107 @@ func TestSDKSQSAWSTraceHeaderSystemAttribute(t *testing.T) {
 		t.Fatalf("AWSTraceHeader = %q, want %q", v, trace)
 	}
 }
+
+// TestSDKSQSSendMessageBatchTraceHeader confirms SendMessageBatch accepts the
+// AWSTraceHeader message system attribute per entry, returns
+// MD5OfMessageSystemAttributes per successful entry, and that ReceiveMessage
+// surfaces AWSTraceHeader in the message Attributes map. Matches real SQS.
+func TestSDKSQSSendMessageBatchTraceHeader(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	q, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("batch-trace-q")})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	const trace = "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1"
+
+	out, err := client.SendMessageBatch(ctx, &awssqs.SendMessageBatchInput{
+		QueueUrl: q.QueueUrl,
+		Entries: []sqstypes.SendMessageBatchRequestEntry{
+			{
+				Id:          aws.String("m1"),
+				MessageBody: aws.String("traced-batch"),
+				MessageSystemAttributes: map[string]sqstypes.MessageSystemAttributeValue{
+					string(sqstypes.MessageSystemAttributeNameForSendsAWSTraceHeader): {
+						DataType:    aws.String("String"),
+						StringValue: aws.String(trace),
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SendMessageBatch: %v", err)
+	}
+
+	if len(out.Successful) != 1 {
+		t.Fatalf("got %d successful, want 1 (failed=%d)", len(out.Successful), len(out.Failed))
+	}
+
+	if got := aws.ToString(out.Successful[0].MD5OfMessageSystemAttributes); got != wantTraceMD5(trace) {
+		t.Fatalf("MD5OfMessageSystemAttributes = %q, want %q", got, wantTraceMD5(trace))
+	}
+
+	rcv, err := client.ReceiveMessage(ctx, &awssqs.ReceiveMessageInput{
+		QueueUrl:            q.QueueUrl,
+		MaxNumberOfMessages: 1,
+		MessageSystemAttributeNames: []sqstypes.MessageSystemAttributeName{
+			sqstypes.MessageSystemAttributeNameAWSTraceHeader,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReceiveMessage: %v", err)
+	}
+
+	if len(rcv.Messages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(rcv.Messages))
+	}
+
+	if v := rcv.Messages[0].Attributes["AWSTraceHeader"]; v != trace {
+		t.Fatalf("AWSTraceHeader = %q, want %q", v, trace)
+	}
+}
+
+// TestSDKSQSSystemAttributeInvalidKeyRejected confirms that a message system
+// attribute whose key is not AWSTraceHeader is rejected with a 4xx
+// InvalidParameterValue error on both SendMessage and SendMessageBatch, matching
+// real SQS (the only valid system attribute key is AWSTraceHeader).
+func TestSDKSQSSystemAttributeInvalidKeyRejected(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	q, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("bad-sysattr-q")})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	badAttrs := map[string]sqstypes.MessageSystemAttributeValue{
+		"NotATraceHeader": {
+			DataType:    aws.String("String"),
+			StringValue: aws.String("nope"),
+		},
+	}
+
+	if _, err := client.SendMessage(ctx, &awssqs.SendMessageInput{
+		QueueUrl:                q.QueueUrl,
+		MessageBody:             aws.String("body"),
+		MessageSystemAttributes: badAttrs,
+	}); err == nil {
+		t.Fatal("SendMessage with invalid system attribute key succeeded, want error")
+	}
+
+	if _, err := client.SendMessageBatch(ctx, &awssqs.SendMessageBatchInput{
+		QueueUrl: q.QueueUrl,
+		Entries: []sqstypes.SendMessageBatchRequestEntry{
+			{
+				Id:                      aws.String("m1"),
+				MessageBody:             aws.String("body"),
+				MessageSystemAttributes: badAttrs,
+			},
+		},
+	}); err == nil {
+		t.Fatal("SendMessageBatch with invalid system attribute key succeeded, want error")
+	}
+}

--- a/services/messagequeue/driver/driver.go
+++ b/services/messagequeue/driver/driver.go
@@ -111,6 +111,9 @@ type BatchSendEntry struct {
 	DeduplicationID   string
 	Attributes        map[string]string
 	MessageAttributes map[string]MessageAttributeValue
+	// SystemAttributes are SQS message system attributes (AWS SQS; the only
+	// supported key is AWSTraceHeader).
+	SystemAttributes map[string]MessageAttributeValue
 }
 
 // BatchSendResult is the result of a batch send.

--- a/services/messagequeue/driver/driver.go
+++ b/services/messagequeue/driver/driver.go
@@ -24,6 +24,10 @@ type QueueConfig struct {
 	ReceiveMessageWaitTimeSeconds int
 	ContentBasedDeduplication     bool
 	RedrivePolicy                 string // raw JSON, echoed by GetQueueAttributes
+	// RedriveAllowPolicy is the raw JSON DLQ redrive-permission document
+	// (redrivePermission=allowAll|denyAll|byQueue + sourceQueueArns). It is
+	// persisted and echoed by GetQueueAttributes.
+	RedriveAllowPolicy string
 	// VisibilityTimeoutSet reports that VisibilityTimeout was supplied explicitly,
 	// so the AWS provider can distinguish an explicit 0 (kept as 0) from an
 	// omitted value (defaulted to 30). The wire handler sets it from attribute
@@ -64,6 +68,9 @@ type SendMessageInput struct {
 	Attributes      map[string]string
 	// MessageAttributes are typed user attributes (AWS SQS). Non-AWS providers ignore them.
 	MessageAttributes map[string]MessageAttributeValue
+	// SystemAttributes are SQS message system attributes (AWS SQS; the only
+	// supported key is AWSTraceHeader). Non-AWS providers ignore them.
+	SystemAttributes map[string]MessageAttributeValue
 }
 
 // SendMessageOutput is the result of sending a message.
@@ -158,6 +165,7 @@ type QueueAttributes struct {
 	FifoQueue                  bool
 	ContentBasedDeduplication  bool
 	RedrivePolicy              string // JSON string pointing to DLQ
+	RedriveAllowPolicy         string // JSON DLQ redrive-permission document
 
 	ReceiveMessageWaitTimeSeconds int
 	ApproximateDelayedCount       int


### PR DESCRIPTION
## Summary

Three AWS deep-audit mop-up findings (SQS + Kinesis), each fixed at the correct layer and verified against the official AWS API reference with real aws-sdk-go-v2 round-trip tests.

### 1. SQS RedriveAllowPolicy round-trip (MEDIUM)
`RedriveAllowPolicy` (redrivePermission=allowAll|denyAll|byQueue + sourceQueueArns) is a documented settable queue attribute that was silently dropped. It is now persisted from `CreateQueue` and `SetQueueAttributes`, and echoed by `GetQueueAttributes` (All or by name), matching real SQS.
- driver `QueueConfig`/`QueueAttributes` gain a `RedriveAllowPolicy` string field (AWS-only semantics, ignored safely by Azure/GCP).
- provider stores + round-trips it; `CreateQueue` idempotency compares it.
- wire handler maps it on create and emits it on GetQueueAttributes.

### 2. SQS MessageSystemAttributes / AWSTraceHeader (MEDIUM)
`SendMessage` now accepts `MessageSystemAttributes` (only supported key `AWSTraceHeader`, DataType String), stores it, and returns `MD5OfMessageSystemAttributes` computed with the AWS-documented canonical attribute encoding. `ReceiveMessage` returns `AWSTraceHeader` in the message `Attributes` map when requested via `MessageSystemAttributeNames` (or All).
- driver `SendMessageInput` gains `SystemAttributes` (AWS-only, ignored by non-AWS providers).

### 3. Kinesis GetShardIterator AT_TIMESTAMP without Timestamp (LOW)
`GetShardIterator` with `ShardIteratorType=AT_TIMESTAMP` and no `Timestamp` now returns `InvalidArgumentException` (HTTP 400) instead of silently behaving like TRIM_HORIZON.

## Tests
- Real aws-sdk-go-v2 round-trip tests over an httptest server: RedriveAllowPolicy set/create round-trip, AWSTraceHeader send + MD5 + receive, and the AT_TIMESTAMP-without-Timestamp InvalidArgumentException (plus the happy path).

## Gates
- `go build ./...`, targeted `go test` (providers/aws, server/aws, services/messagequeue) green.
- golangci-lint clean on all changed packages (pre-existing debt in untouched files excluded).
- docs/coverage regenerated: no change (struct-field additions do not alter interface-method coverage).