### PR TITLE
fix(azure-sql-db): location/tags/sku round-trip, database/firewall-rule lifecycle, server props, flexible-server zones

### DIFF
--- a/providers/azure/managedcassandra/data_centers.go
+++ b/providers/azure/managedcassandra/data_centers.go
@@ -37,7 +37,9 @@ func (m *Mock) CreateOrUpdateDataCenter(_ context.Context, cfg mcdriver.CreateDa
 
 	cluster, ok := m.clusters.Get(clusterKey(cfg.ResourceGroup, cfg.ClusterName))
 	if !ok {
-		return nil, cerrors.Newf(cerrors.InvalidArgument, "managed cassandra cluster %q not found", cfg.ClusterName)
+		// A datacenter is a child of a cluster: real Azure returns 404
+		// ParentResourceNotFound when the parent cluster does not exist.
+		return nil, cerrors.Newf(cerrors.NotFound, "managed cassandra cluster %q not found", cfg.ClusterName)
 	}
 
 	if err := validateNodeCount(cfg.NodeCount); err != nil {

--- a/providers/azure/managedcassandra/managedcassandra_test.go
+++ b/providers/azure/managedcassandra/managedcassandra_test.go
@@ -78,11 +78,11 @@ func TestDataCenterParentLinkage(t *testing.T) {
 	ctx := context.Background()
 	mustCluster(t, m, "rg1", "cass")
 
-	// A datacenter under a missing cluster is rejected.
+	// A datacenter under a missing cluster is rejected as a missing parent.
 	if _, err := m.CreateOrUpdateDataCenter(ctx, mcdriver.CreateDataCenterConfig{
 		ClusterName: "ghost", ResourceGroup: "rg1", Name: "dc1",
-	}); !cerrors.IsInvalidArgument(err) {
-		t.Fatalf("dc under missing cluster: got %v, want InvalidArgument", err)
+	}); !cerrors.IsNotFound(err) {
+		t.Fatalf("dc under missing cluster: got %v, want NotFound", err)
 	}
 
 	dc, err := m.CreateOrUpdateDataCenter(ctx, mcdriver.CreateDataCenterConfig{

--- a/providers/azure/mysqlflex/mysqlflex.go
+++ b/providers/azure/mysqlflex/mysqlflex.go
@@ -195,7 +195,7 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		tier = defaultSKU
 	}
 
-	region := cfg.AvailabilityZone
+	region := cfg.Location
 	if region == "" {
 		region = m.opts.Region
 	}
@@ -217,7 +217,8 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		PubliclyAccessible:      cfg.PubliclyAccessible,
 		VPCSecurityGroups:       append([]string(nil), cfg.VPCSecurityGroups...),
 		SubnetGroupName:         cfg.SubnetGroupName,
-		AvailabilityZone:        region,
+		Location:                region,
+		AvailabilityZone:        cfg.AvailabilityZone,
 		HighAvailabilityMode:    cfg.HighAvailabilityMode,
 		StandbyAvailabilityZone: cfg.StandbyAvailabilityZone,
 		CreatedAt:               m.opts.Clock.Now().UTC(),
@@ -606,7 +607,7 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 		Endpoint:         input.NewInstanceID + endpointSuffix,
 		Port:             defaultPort,
 		State:            rdsdriver.StateAvailable,
-		AvailabilityZone: m.opts.Region,
+		Location:         m.opts.Region,
 		CreatedAt:        now,
 		Tags:             copyTags(input.Tags),
 	}

--- a/providers/azure/mysqlflex/subresources.go
+++ b/providers/azure/mysqlflex/subresources.go
@@ -80,6 +80,8 @@ func (m *Mock) requireServer(server string) error {
 // ---- Databases ----
 
 // CreateDatabase adds a logical database to a server.
+//
+//nolint:gocritic // cfg matches the Databases capability interface signature.
 func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (*rdsdriver.Database, error) {
 	if cfg.Name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "database name is required")
@@ -143,9 +145,10 @@ func (m *Mock) ListDatabases(_ context.Context, server string) ([]rdsdriver.Data
 
 	out := []rdsdriver.Database{}
 
-	for _, db := range m.databases.SortedValues() {
-		if db.Server == server {
-			out = append(out, db)
+	vals := m.databases.SortedValues()
+	for i := range vals {
+		if vals[i].Server == server {
+			out = append(out, vals[i])
 		}
 	}
 

--- a/providers/azure/postgresflex/postgresflex.go
+++ b/providers/azure/postgresflex/postgresflex.go
@@ -206,7 +206,7 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		sku = defaultSKU
 	}
 
-	region := cfg.AvailabilityZone
+	region := cfg.Location
 	if region == "" {
 		region = m.opts.Region
 	}
@@ -228,7 +228,8 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		PubliclyAccessible:      cfg.PubliclyAccessible,
 		VPCSecurityGroups:       append([]string(nil), cfg.VPCSecurityGroups...),
 		SubnetGroupName:         cfg.SubnetGroupName,
-		AvailabilityZone:        region,
+		Location:                region,
+		AvailabilityZone:        cfg.AvailabilityZone,
 		HighAvailabilityMode:    cfg.HighAvailabilityMode,
 		StandbyAvailabilityZone: cfg.StandbyAvailabilityZone,
 		CreatedAt:               m.opts.Clock.Now().UTC(),
@@ -614,7 +615,7 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 		Endpoint:         flexibleServerEndpoint(input.NewInstanceID),
 		Port:             defaultPort,
 		State:            rdsdriver.StateAvailable,
-		AvailabilityZone: m.opts.Region,
+		Location:         m.opts.Region,
 		CreatedAt:        now,
 		Tags:             copyTags(input.Tags),
 	}

--- a/providers/azure/postgresflex/postgresflex_test.go
+++ b/providers/azure/postgresflex/postgresflex_test.go
@@ -359,6 +359,27 @@ func TestSetConfigurationValidatesParameter(t *testing.T) {
 		t.Errorf("expected catalog default for max_connections, got %+v", def)
 	}
 
+	// Both the value and the defaultValue are populated for an unset parameter.
+	if def.DefaultValue != def.Value {
+		t.Errorf("unset param defaultValue = %q, want %q", def.DefaultValue, def.Value)
+	}
+
+	// A user override still reports the catalog default in defaultValue.
+	if _, err := m.SetConfiguration(ctx, rdsdriver.ConfigurationConfig{
+		Server: "srv", Name: "max_connections", Value: "200",
+	}); err != nil {
+		t.Fatalf("SetConfiguration: %v", err)
+	}
+
+	overridden, err := m.GetConfiguration(ctx, "srv", "max_connections")
+	if err != nil {
+		t.Fatalf("GetConfiguration after override: %v", err)
+	}
+
+	if overridden.Value != "200" || overridden.DefaultValue != def.Value {
+		t.Errorf("override = %+v, want value 200 and defaultValue %q", overridden, def.Value)
+	}
+
 	if _, err := m.GetConfiguration(ctx, "srv", "not_a_real_param"); err == nil {
 		t.Error("GetConfiguration for unknown param: expected NotFound")
 	}

--- a/providers/azure/postgresflex/subresources.go
+++ b/providers/azure/postgresflex/subresources.go
@@ -50,15 +50,40 @@ var knownServerParameters = map[string]string{
 	"work_mem":                            "4096",
 	"maintenance_work_mem":                "65536",
 	"effective_cache_size":                "524288",
+	"effective_io_concurrency":            "1",
+	"random_page_cost":                    "4",
 	"log_statement":                       "none",
 	"log_min_duration_statement":          "-1",
+	"log_connections":                     "off",
+	"log_disconnections":                  "off",
+	"log_duration":                        "off",
+	"log_lock_waits":                      "off",
+	"log_checkpoints":                     "on",
 	"autovacuum":                          "on",
+	"autovacuum_max_workers":              "3",
+	"autovacuum_naptime":                  "60",
+	"autovacuum_vacuum_scale_factor":      "0.2",
+	"autovacuum_analyze_scale_factor":     "0.1",
 	"statement_timeout":                   "0",
-	"timezone":                            "UTC",
-	"max_wal_size":                        "1024",
-	"wal_level":                           "replica",
-	"max_prepared_transactions":           "0",
+	"lock_timeout":                        "0",
 	"idle_in_transaction_session_timeout": "0",
+	"timezone":                            "UTC",
+	"datestyle":                           "ISO, MDY",
+	"max_wal_size":                        "1024",
+	"min_wal_size":                        "80",
+	"wal_level":                           "replica",
+	"wal_buffers":                         "-1",
+	"checkpoint_timeout":                  "300",
+	"checkpoint_completion_target":        "0.9",
+	"max_prepared_transactions":           "0",
+	"max_worker_processes":                "8",
+	"max_parallel_workers":                "8",
+	"max_parallel_workers_per_gather":     "2",
+	"default_transaction_isolation":       "read committed",
+	"deadlock_timeout":                    "1000",
+	"temp_buffers":                        "8192",
+	"max_locks_per_transaction":           "64",
+	"ssl":                                 "on",
 }
 
 func childKey(server, name string) string { return server + "/" + name }
@@ -80,6 +105,8 @@ func (m *Mock) requireServer(server string) error {
 // ---- Databases ----
 
 // CreateDatabase adds a logical database to a server.
+//
+//nolint:gocritic // cfg matches the Databases capability interface signature.
 func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (*rdsdriver.Database, error) {
 	if cfg.Name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "database name is required")
@@ -148,9 +175,10 @@ func (m *Mock) ListDatabases(_ context.Context, server string) ([]rdsdriver.Data
 
 	out := []rdsdriver.Database{}
 
-	for _, db := range m.databases.SortedValues() {
-		if db.Server == server {
-			out = append(out, db)
+	vals := m.databases.SortedValues()
+	for i := range vals {
+		if vals[i].Server == server {
+			out = append(out, vals[i])
 		}
 	}
 
@@ -287,10 +315,11 @@ func (m *Mock) SetConfiguration(
 	conf, ok := m.configurations.Get(key)
 	if !ok {
 		conf = rdsdriver.Configuration{
-			Server:   cfg.Server,
-			Name:     cfg.Name,
-			DataType: "String",
-			ARN:      m.childARN(cfg.Server, "configurations", cfg.Name),
+			Server:       cfg.Server,
+			Name:         cfg.Name,
+			DataType:     "String",
+			DefaultValue: knownServerParameters[cfg.Name],
+			ARN:          m.childARN(cfg.Server, "configurations", cfg.Name),
 		}
 	}
 
@@ -328,12 +357,13 @@ func (m *Mock) GetConfiguration(_ context.Context, server, name string) (*rdsdri
 // defaultConfiguration builds the system-default view of a known parameter.
 func (m *Mock) defaultConfiguration(server, name, value string) *rdsdriver.Configuration {
 	return &rdsdriver.Configuration{
-		Server:   server,
-		Name:     name,
-		Value:    value,
-		Source:   "system-default",
-		DataType: "String",
-		ARN:      m.childARN(server, "configurations", name),
+		Server:       server,
+		Name:         name,
+		Value:        value,
+		Source:       "system-default",
+		DataType:     "String",
+		DefaultValue: value,
+		ARN:          m.childARN(server, "configurations", name),
 	}
 }
 

--- a/providers/azure/sql/databases.go
+++ b/providers/azure/sql/databases.go
@@ -20,6 +20,13 @@ func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 		return nil, cerrors.New(cerrors.InvalidArgument, "server and database name are required")
 	}
 
+	// A database is a child of a logical server: real Azure returns
+	// ParentResourceNotFound (404) when the server has not been created.
+	server, ok := m.clusters.Get(cfg.Server)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "Azure SQL server %q not found", cfg.Server)
+	}
+
 	key := dbKey(cfg.Server, cfg.Name)
 	if _, ok := m.databases.Get(key); ok {
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "database %q already exists on server %q", cfg.Name, cfg.Server)
@@ -41,6 +48,8 @@ func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 		Charset:       cfg.Charset,
 		Collation:     cfg.Collation,
 		ARN:           serverDatabaseResourceID(m.opts.Region, cfg.Server, cfg.Name),
+		Location:      orDefault(cfg.Location, server.Location),
+		Tags:          copyTags(cfg.Tags),
 		SKUName:       skuName,
 		SKUTier:       skuTier,
 		ZoneRedundant: cfg.ZoneRedundant,
@@ -60,6 +69,7 @@ func (m *Mock) GetDatabase(_ context.Context, server, name string) (*rdsdriver.D
 	}
 
 	out := db
+	out.Tags = copyTags(db.Tags)
 
 	return &out, nil
 }
@@ -68,8 +78,11 @@ func (m *Mock) GetDatabase(_ context.Context, server, name string) (*rdsdriver.D
 func (m *Mock) ListDatabases(_ context.Context, server string) ([]rdsdriver.Database, error) {
 	out := []rdsdriver.Database{}
 
-	for _, db := range m.databases.SortedValues() {
-		if db.Server == server {
+	vals := m.databases.SortedValues()
+	for i := range vals {
+		if vals[i].Server == server {
+			db := vals[i]
+			db.Tags = copyTags(db.Tags)
 			out = append(out, db)
 		}
 	}

--- a/providers/azure/sql/databases_cost_test.go
+++ b/providers/azure/sql/databases_cost_test.go
@@ -4,16 +4,31 @@ import (
 	"context"
 	"testing"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
+
+// mustServer creates a logical server so a database has a parent to hang off.
+func mustServer(t *testing.T, m *Mock, ids ...string) {
+	t.Helper()
+
+	for _, id := range ids {
+		if _, err := m.CreateCluster(context.Background(), rdsdriver.ClusterConfig{ID: id}); err != nil {
+			t.Fatalf("CreateCluster %q: %v", id, err)
+		}
+	}
+}
 
 func TestCreateDatabaseCarriesSKUAndZoneRedundancy(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
+	mustServer(t, m, "srv1")
 
 	db, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{
 		Server:        "srv1",
 		Name:          "db1",
+		Location:      "westus2",
+		Tags:          map[string]string{"team": "data"},
 		SKUName:       "GP_Gen5_4",
 		SKUTier:       "GeneralPurpose",
 		ZoneRedundant: true,
@@ -22,15 +37,27 @@ func TestCreateDatabaseCarriesSKUAndZoneRedundancy(t *testing.T) {
 
 	assertEqual(t, "srv1", db.Server)
 	assertEqual(t, "db1", db.Name)
+	assertEqual(t, "westus2", db.Location)
+	assertEqual(t, "data", db.Tags["team"])
 	assertEqual(t, "GP_Gen5_4", db.SKUName)
 	assertEqual(t, "GeneralPurpose", db.SKUTier)
 	assertEqual(t, true, db.ZoneRedundant)
 	assertNotEmpty(t, db.ARN)
 }
 
+func TestCreateDatabaseUnderMissingServerNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.CreateDatabase(context.Background(), rdsdriver.DatabaseConfig{Server: "ghostsrv", Name: "db1"})
+	if !cerrors.IsNotFound(err) {
+		t.Fatalf("CreateDatabase under missing server: got %v, want NotFound", err)
+	}
+}
+
 func TestCreateDatabaseDefaultsSKU(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
+	mustServer(t, m, "srv1")
 
 	db, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv1", Name: "db1"})
 	requireNoError(t, err)
@@ -42,6 +69,7 @@ func TestCreateDatabaseDefaultsSKU(t *testing.T) {
 func TestDatabaseGetListRoundTrip(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
+	mustServer(t, m, "srv1", "srv2")
 
 	if _, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv1", Name: "db1"}); err != nil {
 		t.Fatalf("CreateDatabase srv1/db1: %v", err)
@@ -77,6 +105,7 @@ func TestDatabaseGetListRoundTrip(t *testing.T) {
 func TestCreateDatabaseDuplicateRejected(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
+	mustServer(t, m, "srv1")
 
 	if _, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv1", Name: "db1"}); err != nil {
 		t.Fatalf("CreateDatabase: %v", err)
@@ -90,6 +119,7 @@ func TestCreateDatabaseDuplicateRejected(t *testing.T) {
 func TestGetAndDeleteDatabaseMissing(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
+	mustServer(t, m, "srv1")
 
 	if _, err := m.GetDatabase(ctx, "srv1", "ghost"); err == nil {
 		t.Error("GetDatabase on missing database: expected NotFound")

--- a/providers/azure/sql/sql.go
+++ b/providers/azure/sql/sql.go
@@ -241,7 +241,7 @@ func (m *Mock) CreateInstance(_ context.Context, cfg rdsdriver.InstanceConfig) (
 		State:            rdsdriver.StateAvailable,
 		ClusterID:        cfg.ClusterID,
 		ElasticPoolID:    cfg.ElasticPoolID,
-		AvailabilityZone: server.SubnetGroupName, // re-use as region carrier
+		Location:         server.Location,
 		CreatedAt:        m.opts.Clock.Now().UTC(),
 		Tags:             copyTags(cfg.Tags),
 	}
@@ -465,11 +465,9 @@ func (m *Mock) CreateCluster(_ context.Context, cfg rdsdriver.ClusterConfig) (*r
 		Endpoint:       cfg.ID + ".database.windows.net",
 		Port:           defaultPort,
 		State:          rdsdriver.StateAvailable,
-		// Stash region in SubnetGroupName since the field exists; consumers
-		// can read it back from there.
-		SubnetGroupName: m.opts.Region,
-		CreatedAt:       m.opts.Clock.Now().UTC(),
-		Tags:            copyTags(cfg.Tags),
+		Location:       orDefault(cfg.Location, m.opts.Region),
+		CreatedAt:      m.opts.Clock.Now().UTC(),
+		Tags:           copyTags(cfg.Tags),
 	}
 
 	m.clusters.Set(cfg.ID, cluster)

--- a/server/azure/managedcassandra/data_centers.go
+++ b/server/azure/managedcassandra/data_centers.go
@@ -3,6 +3,7 @@ package managedcassandra
 import (
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	mcdriver "github.com/stackshy/cloudemu/v2/services/managedcassandra/driver"
 )
@@ -39,7 +40,15 @@ func (h *Handler) createOrUpdateDataCenter(w http.ResponseWriter, r *http.Reques
 
 	dc, err := h.db.CreateOrUpdateDataCenter(r.Context(), cfg)
 	if err != nil {
+		if cerrors.IsNotFound(err) {
+			// The only NotFound this create raises is a missing parent cluster;
+			// real Azure answers 404 ParentResourceNotFound.
+			azurearm.WriteParentNotFound(w, err)
+			return
+		}
+
 		azurearm.WriteCErr(w, err)
+
 		return
 	}
 

--- a/server/azure/managedcassandra/sdk_roundtrip_test.go
+++ b/server/azure/managedcassandra/sdk_roundtrip_test.go
@@ -299,7 +299,7 @@ func TestSDKTypedErrorsAndStart(t *testing.T) {
 		t.Fatalf("get missing cluster: got %v, want 404 ResponseError", err)
 	}
 
-	// Datacenter create under a missing cluster → typed 400.
+	// Datacenter create under a missing cluster → typed 404 ParentResourceNotFound.
 	dcPoller, err := dcc.BeginCreateUpdate(ctx, "rg1", "ghost", "dc1", armcosmos.DataCenterResource{
 		Properties: &armcosmos.DataCenterResourceProperties{NodeCount: to.Ptr[int32](3)},
 	}, nil)
@@ -307,8 +307,12 @@ func TestSDKTypedErrorsAndStart(t *testing.T) {
 		_, err = dcPoller.PollUntilDone(ctx, nil)
 	}
 
-	if !errors.As(err, &respErr) || respErr.StatusCode != 400 {
-		t.Fatalf("dc under missing cluster: got %v, want 400 ResponseError", err)
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("dc under missing cluster: got %v, want 404 ResponseError", err)
+	}
+
+	if respErr.ErrorCode != "ParentResourceNotFound" {
+		t.Fatalf("dc under missing cluster: got code %q, want ParentResourceNotFound", respErr.ErrorCode)
 	}
 
 	// Deallocate → Start round-trips (Start shares the async path).

--- a/server/azure/mysqlflex/availability_zone_test.go
+++ b/server/azure/mysqlflex/availability_zone_test.go
@@ -1,0 +1,98 @@
+package mysqlflex_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers"
+)
+
+// TestSDKMySQLFlexZoneAndLocationRoundTrip asserts that properties.availabilityZone
+// (the compute zone id "1"/"2"/"3") round-trips separately from the top-level
+// location (the Azure region).
+func TestSDKMySQLFlexZoneAndLocationRoundTrip(t *testing.T) {
+	servers := newSDKClient(t)
+	ctx := context.Background()
+
+	poller, err := servers.BeginCreate(ctx, "rg-1", "zsrv", armmysqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+		Properties: &armmysqlflexibleservers.ServerProperties{
+			AvailabilityZone: to.Ptr("3"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	got, err := servers.Get(ctx, "rg-1", "zsrv", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Server.Location == nil || *got.Server.Location != "eastus" {
+		t.Fatalf("location = %v, want eastus", got.Server.Location)
+	}
+
+	az := got.Server.Properties.AvailabilityZone
+	if az == nil || *az != "3" {
+		t.Fatalf("availabilityZone = %v, want 3", az)
+	}
+}
+
+// TestSDKMySQLFlexRePutAppliesUpdate covers the idempotent-PUT upsert: a second
+// BeginCreate with changed storage/SKU must apply the change rather than
+// returning the stale record.
+func TestSDKMySQLFlexRePutAppliesUpdate(t *testing.T) {
+	servers := newSDKClient(t)
+	ctx := context.Background()
+
+	first, err := servers.BeginCreate(ctx, "rg-1", "reput", armmysqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+		SKU:      &armmysqlflexibleservers.SKU{Name: to.Ptr("Standard_B1ms")},
+		Properties: &armmysqlflexibleservers.ServerProperties{
+			Storage: &armmysqlflexibleservers.Storage{StorageSizeGB: to.Ptr(int32(64))},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := first.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("first PollUntilDone: %v", err)
+	}
+
+	second, err := servers.BeginCreate(ctx, "rg-1", "reput", armmysqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+		SKU:      &armmysqlflexibleservers.SKU{Name: to.Ptr("Standard_D2ds_v4")},
+		Properties: &armmysqlflexibleservers.ServerProperties{
+			Storage: &armmysqlflexibleservers.Storage{StorageSizeGB: to.Ptr(int32(256))},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("re-PUT BeginCreate: %v", err)
+	}
+
+	if _, err := second.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("re-PUT PollUntilDone: %v", err)
+	}
+
+	got, err := servers.Get(ctx, "rg-1", "reput", nil)
+	if err != nil {
+		t.Fatalf("Get after re-PUT: %v", err)
+	}
+
+	if got.Server.SKU == nil || *got.Server.SKU.Name != "Standard_D2ds_v4" {
+		t.Fatalf("SKU after re-PUT = %+v, want Standard_D2ds_v4", got.Server.SKU)
+	}
+
+	if got.Server.Properties == nil || got.Server.Properties.Storage == nil ||
+		got.Server.Properties.Storage.StorageSizeGB == nil ||
+		*got.Server.Properties.Storage.StorageSizeGB != 256 {
+		t.Fatalf("storage after re-PUT != 256")
+	}
+}

--- a/server/azure/mysqlflex/error_masking_test.go
+++ b/server/azure/mysqlflex/error_masking_test.go
@@ -1,0 +1,98 @@
+package mysqlflex_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	azmysql "github.com/stackshy/cloudemu/v2/providers/azure/mysqlflex"
+	"github.com/stackshy/cloudemu/v2/server/azure/mysqlflex"
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// createFailingDB wraps a real provider Mock but makes CreateInstance fail with a
+// non-AlreadyExists error, and records whether the PUT handler falls through to
+// ModifyInstance.
+type createFailingDB struct {
+	*azmysql.Mock
+	createErr    error
+	modifyCalled bool
+}
+
+//nolint:gocritic // signature matches the rdsdriver.RelationalDB interface.
+func (d *createFailingDB) CreateInstance(_ context.Context, _ rdsdriver.InstanceConfig) (*rdsdriver.Instance, error) {
+	return nil, d.createErr
+}
+
+func (d *createFailingDB) ModifyInstance(
+	ctx context.Context, id string, in rdsdriver.ModifyInstanceInput,
+) (*rdsdriver.Instance, error) {
+	d.modifyCalled = true
+
+	return d.Mock.ModifyInstance(ctx, id, in)
+}
+
+func newFailingDB(createErr error) *createFailingDB {
+	opts := config.NewOptions(
+		config.WithClock(config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))),
+		config.WithRegion("eastus"),
+	)
+
+	return &createFailingDB{Mock: azmysql.New(opts), createErr: createErr}
+}
+
+// A genuine (non-AlreadyExists) CreateInstance failure on PUT must surface its
+// own error, not be masked by an idempotent-PUT ModifyInstance fallback that
+// returns a fabricated 404. Real Azure ARM returns 400 for a validation failure.
+func TestPutServerCreateErrorNotMasked(t *testing.T) {
+	db := newFailingDB(cerrors.New(cerrors.InvalidArgument, "sku is not available in this region"))
+	h := mysqlflex.New(db)
+
+	const path = "/subscriptions/sub-1/resourceGroups/rg-1/providers/" +
+		"Microsoft.DBforMySQL/flexibleServers/srv1"
+
+	req := httptest.NewRequest(http.MethodPut, path, strings.NewReader(`{"location":"eastus","properties":{}}`))
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (original InvalidArgument preserved); body: %s", rec.Code, rec.Body.String())
+	}
+
+	if db.modifyCalled {
+		t.Error("ModifyInstance was called for a non-AlreadyExists create error; the original error was masked")
+	}
+}
+
+// The idempotent-PUT upsert path is unchanged: an AlreadyExists create still
+// falls through to ModifyInstance and returns 200.
+func TestPutServerAlreadyExistsUpserts(t *testing.T) {
+	db := newFailingDB(cerrors.New(cerrors.AlreadyExists, "server already exists"))
+	if _, err := db.Mock.CreateInstance(context.Background(), rdsdriver.InstanceConfig{ID: "srv1"}); err != nil {
+		t.Fatalf("seed CreateInstance: %v", err)
+	}
+
+	h := mysqlflex.New(db)
+
+	const path = "/subscriptions/sub-1/resourceGroups/rg-1/providers/" +
+		"Microsoft.DBforMySQL/flexibleServers/srv1"
+
+	req := httptest.NewRequest(http.MethodPut, path, strings.NewReader(`{"location":"eastus","properties":{}}`))
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+
+	if !db.modifyCalled {
+		t.Error("ModifyInstance was not called for an AlreadyExists create; upsert path broken")
+	}
+}

--- a/server/azure/mysqlflex/operations.go
+++ b/server/azure/mysqlflex/operations.go
@@ -39,10 +39,10 @@ func (h *Handler) createServer(w http.ResponseWriter, r *http.Request, rp *azure
 	}
 
 	cfg := rdsdriver.InstanceConfig{
-		ID:               rp.ResourceName,
-		Engine:           "MySQL",
-		AvailabilityZone: body.Location,
-		Tags:             body.Tags,
+		ID:       rp.ResourceName,
+		Engine:   "MySQL",
+		Location: body.Location,
+		Tags:     body.Tags,
 	}
 
 	if body.SKU != nil {
@@ -53,6 +53,7 @@ func (h *Handler) createServer(w http.ResponseWriter, r *http.Request, rp *azure
 		cfg.MasterUsername = body.Properties.AdministratorLogin
 		cfg.MasterUserPassword = body.Properties.AdministratorLoginPassword
 		cfg.EngineVersion = body.Properties.Version
+		cfg.AvailabilityZone = body.Properties.AvailabilityZone
 
 		if body.Properties.Storage != nil {
 			cfg.AllocatedStorage = body.Properties.Storage.StorageSizeGB
@@ -67,32 +68,22 @@ func (h *Handler) createServer(w http.ResponseWriter, r *http.Request, rp *azure
 
 	inst, err := h.db.CreateInstance(r.Context(), cfg)
 	if err != nil {
-		// Idempotent PUT: if the server already exists, fall back to a get.
-		existing, getErr := h.db.DescribeInstances(r.Context(), []string{rp.ResourceName})
-		if getErr != nil || len(existing) != 1 {
+		// Idempotent PUT: a create against an existing server applies the body's
+		// storage/sku/version/HA rather than returning the stale record.
+		inst, err = h.db.ModifyInstance(r.Context(), rp.ResourceName, modifyInputFromBody(&body))
+		if err != nil {
 			azurearm.WriteCErr(w, err)
 			return
 		}
-
-		inst = &existing[0]
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, toARMServer(inst, rp.Subscription, rp.ResourceGroup))
 }
 
-func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	var body armServer
-	if !azurearm.DecodeJSON(w, r, &body) {
-		return
-	}
-
-	if rejectInvalidHAMode(w, &body) {
-		return
-	}
-
-	input := rdsdriver.ModifyInstanceInput{
-		Tags: body.Tags,
-	}
+// modifyInputFromBody maps a MySQL Flex server body to the portable modify
+// input. Shared by PATCH (updateServer) and the re-PUT upsert path.
+func modifyInputFromBody(body *armServer) rdsdriver.ModifyInstanceInput {
+	input := rdsdriver.ModifyInstanceInput{Tags: body.Tags}
 
 	if body.SKU != nil {
 		input.InstanceClass = body.SKU.Name
@@ -111,7 +102,20 @@ func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azure
 		}
 	}
 
-	inst, err := h.db.ModifyInstance(r.Context(), rp.ResourceName, input)
+	return input
+}
+
+func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body armServer
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	if rejectInvalidHAMode(w, &body) {
+		return
+	}
+
+	inst, err := h.db.ModifyInstance(r.Context(), rp.ResourceName, modifyInputFromBody(&body))
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/mysqlflex/operations.go
+++ b/server/azure/mysqlflex/operations.go
@@ -3,6 +3,7 @@ package mysqlflex
 import (
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
@@ -68,6 +69,11 @@ func (h *Handler) createServer(w http.ResponseWriter, r *http.Request, rp *azure
 
 	inst, err := h.db.CreateInstance(r.Context(), cfg)
 	if err != nil {
+		if !cerrors.IsAlreadyExists(err) {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+
 		// Idempotent PUT: a create against an existing server applies the body's
 		// storage/sku/version/HA rather than returning the stale record.
 		inst, err = h.db.ModifyInstance(r.Context(), rp.ResourceName, modifyInputFromBody(&body))

--- a/server/azure/mysqlflex/types.go
+++ b/server/azure/mysqlflex/types.go
@@ -70,7 +70,7 @@ func toARMServer(inst *rdsdriver.Instance, subscription, resourceGroup string) a
 		ID:       armServerID(subscription, resourceGroup, inst.ID),
 		Name:     inst.ID,
 		Type:     providerName + "/" + resourceFlexServers,
-		Location: inst.AvailabilityZone,
+		Location: inst.Location,
 		Tags:     inst.Tags,
 		SKU: &armSKU{
 			Name: inst.InstanceClass,

--- a/server/azure/postgresflex/availability_zone_test.go
+++ b/server/azure/postgresflex/availability_zone_test.go
@@ -1,0 +1,99 @@
+package postgresflex_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers"
+)
+
+// TestSDKPostgresFlexZoneAndLocationRoundTrip asserts that properties.availabilityZone
+// (the compute zone id "1"/"2"/"3") round-trips separately from the top-level
+// location (the Azure region), rather than the zone being overwritten with the
+// region string.
+func TestSDKPostgresFlexZoneAndLocationRoundTrip(t *testing.T) {
+	servers := newSDKClient(t)
+	ctx := context.Background()
+
+	poller, err := servers.BeginCreate(ctx, "rg-1", "zsrv", armpostgresqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+		Properties: &armpostgresqlflexibleservers.ServerProperties{
+			AvailabilityZone: to.Ptr("2"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	got, err := servers.Get(ctx, "rg-1", "zsrv", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Server.Location == nil || *got.Server.Location != "eastus" {
+		t.Fatalf("location = %v, want eastus", got.Server.Location)
+	}
+
+	az := got.Server.Properties.AvailabilityZone
+	if az == nil || *az != "2" {
+		t.Fatalf("availabilityZone = %v, want 2", az)
+	}
+}
+
+// TestSDKPostgresFlexRePutAppliesUpdate covers the idempotent-PUT upsert: a
+// second BeginCreate with changed storage/SKU must apply the change rather than
+// returning the stale record.
+func TestSDKPostgresFlexRePutAppliesUpdate(t *testing.T) {
+	servers := newSDKClient(t)
+	ctx := context.Background()
+
+	first, err := servers.BeginCreate(ctx, "rg-1", "reput", armpostgresqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+		SKU:      &armpostgresqlflexibleservers.SKU{Name: to.Ptr("Standard_B1ms")},
+		Properties: &armpostgresqlflexibleservers.ServerProperties{
+			Storage: &armpostgresqlflexibleservers.Storage{StorageSizeGB: to.Ptr(int32(64))},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := first.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("first PollUntilDone: %v", err)
+	}
+
+	second, err := servers.BeginCreate(ctx, "rg-1", "reput", armpostgresqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+		SKU:      &armpostgresqlflexibleservers.SKU{Name: to.Ptr("Standard_D2s_v3")},
+		Properties: &armpostgresqlflexibleservers.ServerProperties{
+			Storage: &armpostgresqlflexibleservers.Storage{StorageSizeGB: to.Ptr(int32(128))},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("re-PUT BeginCreate: %v", err)
+	}
+
+	if _, err := second.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("re-PUT PollUntilDone: %v", err)
+	}
+
+	got, err := servers.Get(ctx, "rg-1", "reput", nil)
+	if err != nil {
+		t.Fatalf("Get after re-PUT: %v", err)
+	}
+
+	if got.Server.SKU == nil || *got.Server.SKU.Name != "Standard_D2s_v3" {
+		t.Fatalf("SKU after re-PUT = %+v, want Standard_D2s_v3", got.Server.SKU)
+	}
+
+	if got.Server.Properties == nil || got.Server.Properties.Storage == nil ||
+		got.Server.Properties.Storage.StorageSizeGB == nil ||
+		*got.Server.Properties.Storage.StorageSizeGB != 128 {
+		t.Fatalf("storage after re-PUT != 128")
+	}
+}

--- a/server/azure/postgresflex/error_masking_test.go
+++ b/server/azure/postgresflex/error_masking_test.go
@@ -1,0 +1,98 @@
+package postgresflex_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	azpg "github.com/stackshy/cloudemu/v2/providers/azure/postgresflex"
+	"github.com/stackshy/cloudemu/v2/server/azure/postgresflex"
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// createFailingDB wraps a real provider Mock but makes CreateInstance fail with a
+// non-AlreadyExists error, and records whether the PUT handler falls through to
+// ModifyInstance.
+type createFailingDB struct {
+	*azpg.Mock
+	createErr    error
+	modifyCalled bool
+}
+
+//nolint:gocritic // signature matches the rdsdriver.RelationalDB interface.
+func (d *createFailingDB) CreateInstance(_ context.Context, _ rdsdriver.InstanceConfig) (*rdsdriver.Instance, error) {
+	return nil, d.createErr
+}
+
+func (d *createFailingDB) ModifyInstance(
+	ctx context.Context, id string, in rdsdriver.ModifyInstanceInput,
+) (*rdsdriver.Instance, error) {
+	d.modifyCalled = true
+
+	return d.Mock.ModifyInstance(ctx, id, in)
+}
+
+func newFailingDB(createErr error) *createFailingDB {
+	opts := config.NewOptions(
+		config.WithClock(config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))),
+		config.WithRegion("eastus"),
+	)
+
+	return &createFailingDB{Mock: azpg.New(opts), createErr: createErr}
+}
+
+// A genuine (non-AlreadyExists) CreateInstance failure on PUT must surface its
+// own error, not be masked by an idempotent-PUT ModifyInstance fallback that
+// returns a fabricated 404. Real Azure ARM returns 400 for a validation failure.
+func TestPutServerCreateErrorNotMasked(t *testing.T) {
+	db := newFailingDB(cerrors.New(cerrors.InvalidArgument, "sku is not available in this region"))
+	h := postgresflex.New(db)
+
+	const path = "/subscriptions/sub-1/resourceGroups/rg-1/providers/" +
+		"Microsoft.DBforPostgreSQL/flexibleServers/srv1"
+
+	req := httptest.NewRequest(http.MethodPut, path, strings.NewReader(`{"location":"eastus","properties":{}}`))
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (original InvalidArgument preserved); body: %s", rec.Code, rec.Body.String())
+	}
+
+	if db.modifyCalled {
+		t.Error("ModifyInstance was called for a non-AlreadyExists create error; the original error was masked")
+	}
+}
+
+// The idempotent-PUT upsert path is unchanged: an AlreadyExists create still
+// falls through to ModifyInstance and returns 200.
+func TestPutServerAlreadyExistsUpserts(t *testing.T) {
+	db := newFailingDB(cerrors.New(cerrors.AlreadyExists, "server already exists"))
+	if _, err := db.Mock.CreateInstance(context.Background(), rdsdriver.InstanceConfig{ID: "srv1"}); err != nil {
+		t.Fatalf("seed CreateInstance: %v", err)
+	}
+
+	h := postgresflex.New(db)
+
+	const path = "/subscriptions/sub-1/resourceGroups/rg-1/providers/" +
+		"Microsoft.DBforPostgreSQL/flexibleServers/srv1"
+
+	req := httptest.NewRequest(http.MethodPut, path, strings.NewReader(`{"location":"eastus","properties":{}}`))
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+
+	if !db.modifyCalled {
+		t.Error("ModifyInstance was not called for an AlreadyExists create; upsert path broken")
+	}
+}

--- a/server/azure/postgresflex/operations.go
+++ b/server/azure/postgresflex/operations.go
@@ -3,6 +3,7 @@ package postgresflex
 import (
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
@@ -79,6 +80,11 @@ func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, r
 
 	inst, err := h.db.CreateInstance(r.Context(), cfg)
 	if err != nil {
+		if !cerrors.IsAlreadyExists(err) {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+
 		// Idempotent PUT: a create against an existing server applies the body's
 		// storage/sku/version/HA rather than returning the stale record.
 		inst, err = h.db.ModifyInstance(r.Context(), rp.ResourceName, modifyInputFromBody(&body))

--- a/server/azure/postgresflex/operations.go
+++ b/server/azure/postgresflex/operations.go
@@ -30,9 +30,9 @@ func rejectInvalidHAMode(w http.ResponseWriter, body *armServer) bool {
 // to the portable driver shape.
 func instanceFromBody(body *armServer) rdsdriver.InstanceConfig {
 	cfg := rdsdriver.InstanceConfig{
-		Engine:           "Postgres",
-		AvailabilityZone: body.Location,
-		Tags:             body.Tags,
+		Engine:   "Postgres",
+		Location: body.Location,
+		Tags:     body.Tags,
 	}
 
 	if body.SKU != nil {
@@ -43,6 +43,7 @@ func instanceFromBody(body *armServer) rdsdriver.InstanceConfig {
 		cfg.MasterUsername = body.Properties.AdministratorLogin
 		cfg.MasterUserPassword = body.Properties.AdministratorLoginPassword
 		cfg.EngineVersion = body.Properties.Version
+		cfg.AvailabilityZone = body.Properties.AvailabilityZone
 
 		if body.Properties.Storage != nil && body.Properties.Storage.StorageSizeGB > 0 {
 			cfg.AllocatedStorage = body.Properties.Storage.StorageSizeGB
@@ -78,17 +79,41 @@ func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, r
 
 	inst, err := h.db.CreateInstance(r.Context(), cfg)
 	if err != nil {
-		// Idempotent PUT: if the server already exists, treat as a get.
-		existing, getErr := h.db.DescribeInstances(r.Context(), []string{rp.ResourceName})
-		if getErr != nil || len(existing) != 1 {
+		// Idempotent PUT: a create against an existing server applies the body's
+		// storage/sku/version/HA rather than returning the stale record.
+		inst, err = h.db.ModifyInstance(r.Context(), rp.ResourceName, modifyInputFromBody(&body))
+		if err != nil {
 			azurearm.WriteCErr(w, err)
 			return
 		}
-
-		inst = &existing[0]
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, toARMServer(inst, rp.Subscription, rp.ResourceGroup))
+}
+
+// modifyInputFromBody maps a Postgres Flex server body to the portable modify
+// input. Shared by PATCH (updateServer) and the re-PUT upsert path.
+func modifyInputFromBody(body *armServer) rdsdriver.ModifyInstanceInput {
+	input := rdsdriver.ModifyInstanceInput{Tags: body.Tags}
+
+	if body.SKU != nil {
+		input.InstanceClass = body.SKU.Name
+	}
+
+	if body.Properties != nil {
+		input.EngineVersion = body.Properties.Version
+
+		if body.Properties.Storage != nil && body.Properties.Storage.StorageSizeGB > 0 {
+			input.AllocatedStorage = body.Properties.Storage.StorageSizeGB
+		}
+
+		if ha := body.Properties.HighAvailability; ha != nil {
+			input.HighAvailabilityMode = ha.Mode
+			input.StandbyAvailabilityZone = ha.StandbyAvailabilityZone
+		}
+	}
+
+	return input
 }
 
 func (h *Handler) restoreServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, body *armServer) {
@@ -121,28 +146,7 @@ func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azure
 		return
 	}
 
-	input := rdsdriver.ModifyInstanceInput{
-		Tags: body.Tags,
-	}
-
-	if body.SKU != nil {
-		input.InstanceClass = body.SKU.Name
-	}
-
-	if body.Properties != nil {
-		input.EngineVersion = body.Properties.Version
-
-		if body.Properties.Storage != nil && body.Properties.Storage.StorageSizeGB > 0 {
-			input.AllocatedStorage = body.Properties.Storage.StorageSizeGB
-		}
-
-		if ha := body.Properties.HighAvailability; ha != nil {
-			input.HighAvailabilityMode = ha.Mode
-			input.StandbyAvailabilityZone = ha.StandbyAvailabilityZone
-		}
-	}
-
-	inst, err := h.db.ModifyInstance(r.Context(), rp.ResourceName, input)
+	inst, err := h.db.ModifyInstance(r.Context(), rp.ResourceName, modifyInputFromBody(&body))
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/postgresflex/types.go
+++ b/server/azure/postgresflex/types.go
@@ -85,7 +85,7 @@ func toARMServer(inst *rdsdriver.Instance, subscription, resourceGroup string) a
 		ID:       azurearm.BuildResourceID(subscription, resourceGroup, providerName, resourceFlexibleServers, inst.ID),
 		Name:     inst.ID,
 		Type:     providerName + "/" + resourceFlexibleServers,
-		Location: inst.AvailabilityZone,
+		Location: inst.Location,
 		Tags:     inst.Tags,
 		SKU: &armSKU{
 			Name: inst.InstanceClass,

--- a/server/azure/sql/location_tags_test.go
+++ b/server/azure/sql/location_tags_test.go
@@ -1,0 +1,111 @@
+package sql_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
+)
+
+// TestSDKAzureSQLServerEchoesLocation asserts the submitted region round-trips
+// instead of leaking an AWS-style default region.
+func TestSDKAzureSQLServerEchoesLocation(t *testing.T) {
+	servers, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	poller, err := servers.BeginCreateOrUpdate(ctx, "rg-1", "loc1", armsql.Server{
+		Location: to.Ptr("westus2"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	got, err := servers.Get(ctx, "rg-1", "loc1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Server.Location == nil || *got.Server.Location != "westus2" {
+		t.Fatalf("server location = %v, want westus2", got.Server.Location)
+	}
+}
+
+// TestSDKAzureSQLDatabaseEchoesLocationAndTags asserts a database round-trips
+// its submitted location and tags.
+func TestSDKAzureSQLDatabaseEchoesLocationAndTags(t *testing.T) {
+	servers, dbs := newSDKClients(t)
+	ctx := context.Background()
+
+	srvPoller, err := servers.BeginCreateOrUpdate(ctx, "rg-1", "srv1", armsql.Server{
+		Location: to.Ptr("westus2"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("Server BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := srvPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Server PollUntilDone: %v", err)
+	}
+
+	dbPoller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "appdb", armsql.Database{
+		Location: to.Ptr("westus2"),
+		Tags:     map[string]*string{"team": to.Ptr("data")},
+		SKU:      &armsql.SKU{Name: to.Ptr("S0")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("DB BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := dbPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("DB PollUntilDone: %v", err)
+	}
+
+	got, err := dbs.Get(ctx, "rg-1", "srv1", "appdb", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Database.Location == nil || *got.Database.Location != "westus2" {
+		t.Fatalf("database location = %v, want westus2", got.Database.Location)
+	}
+
+	tag, ok := got.Database.Tags["team"]
+	if !ok || tag == nil || *tag != "data" {
+		t.Fatalf("database tag team = %v, want data", got.Database.Tags)
+	}
+}
+
+// TestSDKAzureSQLDatabaseUnderMissingServer asserts a database PUT under a
+// never-created server fails with 404 ParentResourceNotFound.
+func TestSDKAzureSQLDatabaseUnderMissingServer(t *testing.T) {
+	_, dbs := newSDKClients(t)
+	ctx := context.Background()
+
+	poller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "ghostsrv", "db1", armsql.Database{
+		Location: to.Ptr("westus2"),
+	}, nil)
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("expected an azcore.ResponseError, got %T: %v", err, err)
+	}
+
+	if respErr.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", respErr.StatusCode)
+	}
+
+	if respErr.ErrorCode != "ParentResourceNotFound" {
+		t.Fatalf("error code = %q, want ParentResourceNotFound", respErr.ErrorCode)
+	}
+}

--- a/server/azure/sql/operations.go
+++ b/server/azure/sql/operations.go
@@ -20,6 +20,7 @@ func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, r
 	cfg := rdsdriver.ClusterConfig{
 		ID:             rp.ResourceName,
 		Engine:         "SQLServer",
+		Location:       body.Location,
 		MasterUsername: stringFrom(body.Properties, func(p *armServerProps) string { return p.AdministratorLogin }),
 		MasterUserPassword: stringFrom(body.Properties, func(p *armServerProps) string {
 			return p.AdministratorLoginPassword
@@ -121,7 +122,12 @@ func (h *Handler) databases() (rdsdriver.Databases, bool) {
 }
 
 func dbCfgFromBody(body *armDatabase, rp *azurearm.ResourcePath) rdsdriver.DatabaseConfig {
-	cfg := rdsdriver.DatabaseConfig{Server: rp.ResourceName, Name: rp.SubResourceName}
+	cfg := rdsdriver.DatabaseConfig{
+		Server:   rp.ResourceName,
+		Name:     rp.SubResourceName,
+		Location: body.Location,
+		Tags:     body.Tags,
+	}
 	if body.SKU != nil {
 		cfg.SKUName = body.SKU.Name
 		cfg.SKUTier = body.SKU.Tier
@@ -151,6 +157,14 @@ func (*Handler) putDatabase(w http.ResponseWriter, r *http.Request, rp *azurearm
 
 	out, err := db.CreateDatabase(r.Context(), cfg)
 	if err != nil {
+		if cerrors.IsNotFound(err) {
+			// The only NotFound CreateDatabase raises is a missing parent server;
+			// real Azure answers 404 ParentResourceNotFound for a child under an
+			// absent parent.
+			azurearm.WriteParentNotFound(w, err)
+			return
+		}
+
 		if !cerrors.IsAlreadyExists(err) {
 			azurearm.WriteCErr(w, err)
 			return
@@ -190,6 +204,14 @@ func replaceDatabase(
 		merged.Collation = cfg.Collation
 	}
 
+	if cfg.Location != "" {
+		merged.Location = cfg.Location
+	}
+
+	if cfg.Tags != nil {
+		merged.Tags = cfg.Tags
+	}
+
 	if body.Properties != nil && body.Properties.ZoneRedundant != nil {
 		merged.ZoneRedundant = *body.Properties.ZoneRedundant
 	}
@@ -203,6 +225,8 @@ func replaceDatabase(
 		Name:          merged.Name,
 		Charset:       merged.Charset,
 		Collation:     merged.Collation,
+		Location:      merged.Location,
+		Tags:          merged.Tags,
 		SKUName:       merged.SKUName,
 		SKUTier:       merged.SKUTier,
 		ZoneRedundant: merged.ZoneRedundant,

--- a/server/azure/sql/types.go
+++ b/server/azure/sql/types.go
@@ -68,11 +68,10 @@ type armList[T any] struct {
 // toARMServer converts a portable Cluster (logical server) to ARM JSON.
 func toARMServer(cluster *rdsdriver.Cluster, subscription, resourceGroup string) armServer {
 	return armServer{
-		ID:   armServerID(subscription, resourceGroup, cluster.ID),
-		Name: cluster.ID,
-		Type: providerName + "/servers",
-		// Region is stashed in SubnetGroupName by the provider.
-		Location: cluster.SubnetGroupName,
+		ID:       armServerID(subscription, resourceGroup, cluster.ID),
+		Name:     cluster.ID,
+		Type:     providerName + "/servers",
+		Location: cluster.Location,
 		Tags:     cluster.Tags,
 		Properties: &armServerProps{
 			AdministratorLogin:       cluster.MasterUsername,
@@ -90,10 +89,12 @@ func toARMDatabase(db *rdsdriver.Database, rp *azurearm.ResourcePath) armDatabas
 	zoneRedundant := db.ZoneRedundant
 
 	return armDatabase{
-		ID:   armDatabaseID(rp.Subscription, rp.ResourceGroup, db.Server, db.Name),
-		Name: db.Name,
-		Type: providerName + "/servers/databases",
-		SKU:  &armSKU{Name: db.SKUName, Tier: db.SKUTier},
+		ID:       armDatabaseID(rp.Subscription, rp.ResourceGroup, db.Server, db.Name),
+		Name:     db.Name,
+		Type:     providerName + "/servers/databases",
+		Location: db.Location,
+		Tags:     db.Tags,
+		SKU:      &armSKU{Name: db.SKUName, Tier: db.SKUTier},
 		Properties: &armDatabaseProps{
 			Status:                      dbStatusOnline,
 			Collation:                   db.Collation,

--- a/server/wire/azurearm/azurearm.go
+++ b/server/wire/azurearm/azurearm.go
@@ -149,6 +149,13 @@ func WriteError(w http.ResponseWriter, status int, code, msg string) {
 	WriteJSON(w, status, errorEnvelope{Error: errorBody{Code: code, Message: msg}})
 }
 
+// WriteParentNotFound writes the ARM 404 ParentResourceNotFound response real
+// Azure returns when a child resource (e.g. a database under a server) is
+// created while its parent does not exist.
+func WriteParentNotFound(w http.ResponseWriter, err error) {
+	WriteError(w, http.StatusNotFound, "ParentResourceNotFound", err.Error())
+}
+
 // WriteCErr maps a CloudEmu canonical error to the matching ARM HTTP status
 // and code. Used by handlers so error mapping is consistent across services.
 func WriteCErr(w http.ResponseWriter, err error) {

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -79,6 +79,11 @@ type InstanceConfig struct {
 	OptionGroupName      string
 	ClusterID            string // empty for standalone, set for Aurora cluster members
 	AvailabilityZone     string
+	// Location is the Azure region a managed server lives in (the ARM top-level
+	// "location"). It is distinct from AvailabilityZone, which on Azure Flexible
+	// Servers carries the compute zone id ("1"/"2"/"3"). Empty for AWS/GCP, which
+	// derive region from the endpoint/self-link.
+	Location string
 	// StorageEncrypted requests encryption-at-rest on the instance's storage
 	// (AWS RDS StorageEncrypted); false for engines with no such flag.
 	StorageEncrypted bool
@@ -125,6 +130,10 @@ type Instance struct {
 	OptionGroupName      string
 	ClusterID            string
 	AvailabilityZone     string
+	// Location is the Azure region the server lives in (ARM top-level "location"),
+	// echoed on read. It is distinct from AvailabilityZone (the Azure Flexible
+	// Server compute zone id). Empty for AWS/GCP.
+	Location string
 	// The fields below echo AWS RDS DBInstance attributes on read. They default
 	// to their zero value for engines (Azure/GCP) that have no such concept.
 	// DbiResourceId is the immutable region-unique resource id (db-XXXX...).
@@ -213,7 +222,10 @@ type ClusterConfig struct {
 	Encrypted          bool
 	PubliclyAccessible bool
 	AvailabilityZone   string
-	Tags               map[string]string
+	// Location is the Azure region an Azure SQL logical server lives in (ARM
+	// top-level "location"). Empty for AWS/GCP.
+	Location string
+	Tags     map[string]string
 }
 
 // Cluster describes an Aurora-style database cluster.
@@ -253,8 +265,11 @@ type Cluster struct {
 	PubliclyAccessible bool
 	AvailabilityZone   string
 	VpcID              string
-	CreatedAt          time.Time
-	Tags               map[string]string
+	// Location is the Azure region an Azure SQL logical server lives in (ARM
+	// top-level "location"), echoed on read. Empty for AWS/GCP.
+	Location  string
+	CreatedAt time.Time
+	Tags      map[string]string
 }
 
 // SnapshotConfig configures an instance snapshot.
@@ -384,6 +399,10 @@ type DatabaseConfig struct {
 	Name      string
 	Charset   string
 	Collation string
+	// Location is the Azure region the database lives in (ARM top-level
+	// "location"); Tags are the ARM resource tags. Both round-trip on read.
+	Location string
+	Tags     map[string]string
 	// SKUName / SKUTier are the database compute SKU (e.g. "GP_Gen5_2" /
 	// "GeneralPurpose") and ZoneRedundant is the HA flag — cost inputs a
 	// discoverer reads from an Azure SQL database's sku / properties.
@@ -400,6 +419,10 @@ type Database struct {
 	Charset   string
 	Collation string
 	ARN       string
+	// Location is the Azure region the database lives in (ARM top-level
+	// "location"); Tags are the ARM resource tags. Both echoed on read.
+	Location string
+	Tags     map[string]string
 	// SKUName / SKUTier / ZoneRedundant are echoed on read for cost discovery
 	// (Azure SQL database sku.name + properties.currentSku / zoneRedundant).
 	SKUName       string


### PR DESCRIPTION
Real-user (azure-sdk-for-go over httptest) end-to-end audit of Azure SQL, PostgreSQL/MySQL Flexible Server and Managed Cassandra surfaced several wire-contract mismatches. Each fix is applied at the correct layer and matched against the official Azure REST contract.

## Findings fixed

**Location round-trip**
- `Microsoft.Sql/servers` echoed an AWS-style default region instead of the submitted `location`. The region was stashed in the `SubnetGroupName` carrier; replaced with a proper `Location` field on the relationaldb `Cluster`/`Instance`, and the wire now passes the request `location` through. (F1)
- `Microsoft.Sql/servers/databases` returned `location=nil`. Added `Location` (+ `Tags`) to the relationaldb `Database`, defaulted from the parent server, echoed on create/GET/list. (F2, F6)

**Flexible Server compute zone vs region**
- Postgres and MySQL Flexible Server returned `properties.availabilityZone` set to the region string (the zone id was dropped). `availabilityZone` ("1"/"2"/"3") is now stored and echoed separately from `location`, via the new `Instance.Location`/`AvailabilityZone` split. (F3, F4)

**Parent-not-found semantics**
- A database PUT under a never-created SQL server returned Online/200; now returns `404 ParentResourceNotFound`. (F5)
- A Cassandra datacenter under a missing cluster returned `400 InvalidParameterValue`; now returns `404 ParentResourceNotFound`. (F10)
- Added `azurearm.WriteParentNotFound` so both handlers emit the exact ARM code.

**Idempotent re-PUT applies changes**
- A second PUT of a Postgres/MySQL Flexible Server with changed storage/SKU/HA previously returned the stale record; it now applies the update (shared `modifyInputFromBody`). (F7, F8)

**Server parameters**
- Postgres `configurations` now populate `defaultValue` (Get/List) and ship a broader standard parameter set. (F9)

## Tests
- New real-SDK round-trips: SQL server/database location + tags, database-under-missing-server 404, Postgres/MySQL zone-vs-location, Flexible Server re-PUT apply.
- Provider unit tests for database location/tags, parent-not-found, and configuration defaultValue.
- Updated the two existing tests that asserted the old (incorrect) 400/InvalidArgument Cassandra behavior.

## Gates
`go build ./...`, `go test ./providers/azure/... ./server/azure/... ./services/... .` green; golangci-lint clean on changed packages (one pre-existing prealloc in an untouched file remains). No driver-interface method change, so `docs/coverage` is unchanged.