### PR TITLE
fix(azure-monitor): MetricAlerts persistence+tags, action groups, diagnostic settings, loganalytics workspace/query, resourcegraph

### DIFF
--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -198,6 +198,14 @@ func New(d Drivers) http.Handler {
 	// tracks membership by the ids resources already carry.
 	srv.Register(resourcegroups.New())
 
+	// microsoft.insights extension resources (metrics, metricDefinitions,
+	// diagnosticSettings) hang off an arbitrary resource URI, so they must claim
+	// those paths before the underlying resource's own handler. Registered first.
+	if d.Monitor != nil {
+		srv.Register(monitor.NewMetricsHandler(d.Monitor))
+		srv.Register(monitor.NewDiagnosticSettingsHandler())
+	}
+
 	// Register more-specific compute resource handlers first so their
 	// resourceType match wins over virtualMachines (which also accepts the
 	// locations sub-path used for async-operation polling).

--- a/server/azure/loganalytics/child_resources.go
+++ b/server/azure/loganalytics/child_resources.go
@@ -1,0 +1,220 @@
+package loganalytics
+
+import (
+	"net/http"
+	"sort"
+	"sync"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+// childResource is a stored workspace child (savedSearch / table / dataExport).
+// The properties are echoed verbatim; only the ARM envelope (id/name/type/etag)
+// is synthesized, so a client's CreateOrUpdate round-trips through Get/List.
+type childResource struct {
+	Name       string
+	Etag       string
+	Properties map[string]any
+}
+
+// childStore holds workspace child resources keyed by workspace, kind and name.
+type childStore struct {
+	mu sync.RWMutex
+	m  map[string]map[string]map[string]*childResource // workspace -> kind -> name
+}
+
+func newChildStore() *childStore {
+	return &childStore{m: make(map[string]map[string]map[string]*childResource)}
+}
+
+func (s *childStore) set(workspace, kind string, res *childResource) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	byKind := s.m[workspace]
+	if byKind == nil {
+		byKind = make(map[string]map[string]*childResource)
+		s.m[workspace] = byKind
+	}
+
+	byName := byKind[kind]
+	if byName == nil {
+		byName = make(map[string]*childResource)
+		byKind[kind] = byName
+	}
+
+	byName[res.Name] = res
+}
+
+func (s *childStore) get(workspace, kind, name string) (*childResource, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	res, ok := s.m[workspace][kind][name]
+
+	return res, ok
+}
+
+func (s *childStore) delete(workspace, kind, name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	byName := s.m[workspace][kind]
+	if _, ok := byName[name]; !ok {
+		return false
+	}
+
+	delete(byName, name)
+
+	return true
+}
+
+// list returns the children of a workspace/kind sorted by name for a stable
+// paging order.
+func (s *childStore) list(workspace, kind string) []*childResource {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	byName := s.m[workspace][kind]
+	out := make([]*childResource, 0, len(byName))
+
+	for _, res := range byName {
+		out = append(out, res)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+
+	return out
+}
+
+func (s *childStore) deleteWorkspace(workspace string) {
+	s.mu.Lock()
+	delete(s.m, workspace)
+	s.mu.Unlock()
+}
+
+// childRequest is the inbound CreateOrUpdate body for a workspace child.
+type childRequest struct {
+	Etag       string         `json:"etag,omitempty"`
+	Properties map[string]any `json:"properties"`
+}
+
+// childJSON is the ARM child-resource envelope.
+type childJSON struct {
+	ID         string         `json:"id"`
+	Name       string         `json:"name"`
+	Type       string         `json:"type"`
+	Etag       string         `json:"etag,omitempty"`
+	Properties map[string]any `json:"properties,omitempty"`
+}
+
+// childListResult is the paged list envelope for a workspace child collection.
+type childListResult struct {
+	Value []childJSON `json:"value"`
+}
+
+// serveChild routes CRUD for a workspace child collection (savedSearches /
+// tables / dataExports). A missing workspace name segment lists the collection.
+func (h *Handler) serveChild(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if _, err := h.logs.GetLogGroup(r.Context(), rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if rp.SubResourceName == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w)
+			return
+		}
+
+		h.listChildren(w, rp)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.putChild(w, r, rp)
+	case http.MethodGet:
+		h.getChild(w, rp)
+	case http.MethodDelete:
+		h.deleteChild(w, rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func (h *Handler) putChild(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var req childRequest
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	res := &childResource{Name: rp.SubResourceName, Etag: req.Etag, Properties: req.Properties}
+	if rp.SubResource == subTables {
+		res.Properties = withProvisioningState(res.Properties)
+	}
+
+	h.children.set(rp.ResourceName, rp.SubResource, res)
+	azurearm.WriteJSON(w, http.StatusOK, h.childToJSON(rp, res))
+}
+
+func (h *Handler) getChild(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	res, ok := h.children.get(rp.ResourceName, rp.SubResource, rp.SubResourceName)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", rp.SubResource+" "+rp.SubResourceName+" not found")
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, h.childToJSON(rp, res))
+}
+
+func (h *Handler) deleteChild(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	if !h.children.delete(rp.ResourceName, rp.SubResource, rp.SubResourceName) {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", rp.SubResource+" "+rp.SubResourceName+" not found")
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) listChildren(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	items := h.children.list(rp.ResourceName, rp.SubResource)
+	out := childListResult{Value: make([]childJSON, 0, len(items))}
+
+	for _, res := range items {
+		out.Value = append(out.Value, h.childToJSON(rp, res))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+// childToJSON renders a stored child as its ARM envelope. The id nests the child
+// under the workspace ARM id; the type is the parent/child dotted form real ARM
+// returns.
+func (*Handler) childToJSON(rp *azurearm.ResourcePath, res *childResource) childJSON {
+	wsID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeWorkspaces, rp.ResourceName)
+
+	return childJSON{
+		ID:         wsID + "/" + rp.SubResource + "/" + res.Name,
+		Name:       res.Name,
+		Type:       providerName + "/" + typeWorkspaces + "/" + rp.SubResource,
+		Etag:       res.Etag,
+		Properties: res.Properties,
+	}
+}
+
+// withProvisioningState ensures a table's echoed properties carry a terminal
+// provisioningState so the TablesClient LRO poller completes on the first
+// response.
+func withProvisioningState(props map[string]any) map[string]any {
+	if props == nil {
+		props = map[string]any{}
+	}
+
+	if _, ok := props["provisioningState"]; !ok {
+		props["provisioningState"] = provisioningSucceeded
+	}
+
+	return props
+}

--- a/server/azure/loganalytics/handler.go
+++ b/server/azure/loganalytics/handler.go
@@ -7,11 +7,11 @@
 //
 // The workspace lifecycle (CreateOrUpdate / Get / List / Delete) maps onto the
 // logging driver's log-group lifecycle: a workspace is a log group. The
-// retention-in-days and tags carry across; ARM read-only fields
-// (provisioningState, customerId, sku) are synthesized. The data-plane
-// log-query API (api.loganalytics.io "query" / ingestion) is a separate wire
-// surface and is out of scope for this slice — see the package README note in
-// the roundtrip test.
+// retention-in-days and tags carry across the driver; the Azure-only ARM fields
+// (provisioningState, customerId, sku, location) live in the wire handler's
+// per-workspace metadata. Workspace child resources (savedSearches, tables,
+// dataExports) and the sharedKeys action are served from the handler's own
+// in-memory stores — they have no portable equivalent.
 //
 // Microsoft.OperationalInsights is a distinct ARM provider name from every
 // other Azure handler (compute, network, DNS, sql, …), so registration order is
@@ -24,6 +24,11 @@
 //	DELETE .../workspaces/{w}                                — Workspaces.BeginDelete (LRO, completes inline)
 //	GET    .../providers/Microsoft.OperationalInsights/workspaces — Workspaces.NewListPager (subscription scope)
 //	GET    .../resourceGroups/{rg}/…/workspaces             — Workspaces.NewListByResourceGroupPager
+//	PUT/GET/DELETE .../workspaces/{w}/savedSearches/{id}     — SavedSearchesClient
+//	GET    .../workspaces/{w}/savedSearches                  — SavedSearchesClient.ListByWorkspace
+//	PUT/GET/DELETE .../workspaces/{w}/tables/{name}          — TablesClient
+//	PUT/GET/DELETE .../workspaces/{w}/dataExports/{name}     — DataExportsClient
+//	POST   .../workspaces/{w}/sharedKeys                     — SharedKeysClient.GetSharedKeys
 package loganalytics
 
 import (
@@ -39,17 +44,24 @@ const (
 	// typeWorkspaces is the ARM resource type. The subscription-scoped list path
 	// may serialize it lowercase, so matching is case-insensitive.
 	typeWorkspaces = "workspaces"
+
+	subSavedSearches = "savedSearches"
+	subTables        = "tables"
+	subDataExports   = "dataExports"
+	subSharedKeys    = "sharedKeys"
 )
 
 // Handler serves Microsoft.OperationalInsights/workspaces ARM requests against
 // a logging driver.
 type Handler struct {
-	logs logdriver.Logging
+	logs     logdriver.Logging
+	meta     *metaStore
+	children *childStore
 }
 
 // New returns an Azure Log Analytics handler backed by l.
 func New(l logdriver.Logging) *Handler {
-	return &Handler{logs: l}
+	return &Handler{logs: l, meta: newMetaStore(), children: newChildStore()}
 }
 
 // isWorkspacesType reports whether the ARM resource type is workspaces,
@@ -84,6 +96,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A child resource or action verb hangs off the workspace.
+	if rp.SubResource != "" {
+		h.serveSubResource(w, r, &rp)
+		return
+	}
+
 	h.serveWorkspace(w, r, &rp)
 }
 
@@ -106,6 +124,20 @@ func (h *Handler) serveWorkspace(w http.ResponseWriter, r *http.Request, rp *azu
 		h.deleteWorkspace(w, r, rp)
 	default:
 		writeMethodNotAllowed(w)
+	}
+}
+
+// serveSubResource routes the workspace child resources and the sharedKeys
+// action verb. An unknown sub-resource is a 404 rather than the old bug where
+// every child was misrouted to createOrUpdateWorkspace and echoed the workspace.
+func (h *Handler) serveSubResource(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	switch rp.SubResource {
+	case subSharedKeys:
+		h.getSharedKeys(w, r, rp)
+	case subSavedSearches, subTables, subDataExports:
+		h.serveChild(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unknown workspace sub-resource: "+rp.SubResource)
 	}
 }
 

--- a/server/azure/loganalytics/operations.go
+++ b/server/azure/loganalytics/operations.go
@@ -1,17 +1,18 @@
 package loganalytics
 
 import (
-	"github.com/stackshy/cloudemu/v2/services/scope"
 	"net/http"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // createOrUpdateWorkspace maps Workspaces.CreateOrUpdate onto the logging
 // driver: create when absent, otherwise apply the request's mutable fields
 // (retention, tags) via UpdateLogGroup — ARM PUT semantics, so the caller's
-// changes are never silently discarded.
+// changes are never silently discarded. The Azure-only fields (location, sku)
+// and the assigned customerId GUID are tracked in the wire handler's metadata.
 func (h *Handler) createOrUpdateWorkspace(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var req workspaceRequest
 	if !azurearm.DecodeJSON(w, r, &req) {
@@ -31,7 +32,10 @@ func (h *Handler) createOrUpdateWorkspace(w http.ResponseWriter, r *http.Request
 			azurearm.WriteCErr(w, uerr)
 			return
 		}
-		azurearm.WriteJSON(w, http.StatusOK, toWorkspaceJSON(rp, info, req.Location))
+
+		meta := h.meta.upsert(rp.ResourceName, info.ResourceID, req.Location, req.skuName())
+		azurearm.WriteJSON(w, http.StatusOK, toWorkspaceJSON(info, meta))
+
 		return
 	}
 
@@ -41,7 +45,8 @@ func (h *Handler) createOrUpdateWorkspace(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusCreated, toWorkspaceJSON(rp, info, req.Location))
+	meta := h.meta.upsert(rp.ResourceName, info.ResourceID, req.Location, req.skuName())
+	azurearm.WriteJSON(w, http.StatusCreated, toWorkspaceJSON(info, meta))
 }
 
 func (h *Handler) getWorkspace(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
@@ -51,7 +56,8 @@ func (h *Handler) getWorkspace(w http.ResponseWriter, r *http.Request, rp *azure
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toWorkspaceJSON(rp, info, ""))
+	meta := h.meta.get(rp.ResourceName, info.ResourceID)
+	azurearm.WriteJSON(w, http.StatusOK, toWorkspaceJSON(info, meta))
 }
 
 // deleteWorkspace removes the workspace. Workspaces.Delete is an LRO in the SDK;
@@ -61,6 +67,9 @@ func (h *Handler) deleteWorkspace(w http.ResponseWriter, r *http.Request, rp *az
 		azurearm.WriteCErr(w, err)
 		return
 	}
+
+	h.meta.delete(rp.ResourceName)
+	h.children.deleteWorkspace(rp.ResourceName)
 
 	w.WriteHeader(http.StatusOK)
 }
@@ -74,8 +83,10 @@ func (h *Handler) listWorkspaces(w http.ResponseWriter, r *http.Request, rp *azu
 	}
 
 	out := make([]workspaceJSON, 0, len(infos))
+
 	for i := range infos {
-		out = append(out, toWorkspaceJSON(rp, &infos[i], ""))
+		meta := h.meta.get(infos[i].Name, infos[i].ResourceID)
+		out = append(out, toWorkspaceJSON(&infos[i], meta))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, workspaceListResult{Value: out})

--- a/server/azure/loganalytics/sdk_subresources_test.go
+++ b/server/azure/loganalytics/sdk_subresources_test.go
@@ -1,0 +1,208 @@
+package loganalytics_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// newTestOptions stands up a server backed by a fresh Azure Log Analytics driver
+// and returns arm.ClientOptions pointed at it, so any armoperationalinsights
+// client can be built against the same estate.
+func newTestOptions(t *testing.T) *arm.ClientOptions {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{LogAnalytics: cloudP.LogAnalytics})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+
+	return &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+}
+
+func createWorkspace(t *testing.T, client *armoperationalinsights.WorkspacesClient, name, location string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, testRG, name, armoperationalinsights.Workspace{
+		Location: to.Ptr(location),
+		Properties: &armoperationalinsights.WorkspaceProperties{
+			SKU: &armoperationalinsights.WorkspaceSKU{Name: to.Ptr(armoperationalinsights.WorkspaceSKUNameEnumPerGB2018)},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate(%s): %v", name, err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("PollUntilDone(%s): %v", name, err)
+	}
+}
+
+// TestSDKWorkspaceLocationSKUCustomerID covers findings 4 (location echoed on
+// Get), 8 (customerId is a real GUID, not the ARM id) and 11 (SKU defaulting).
+func TestSDKWorkspaceLocationSKUCustomerID(t *testing.T) {
+	opts := newTestOptions(t)
+	ctx := context.Background()
+
+	client, err := armoperationalinsights.NewWorkspacesClient(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewWorkspacesClient: %v", err)
+	}
+
+	createWorkspace(t, client, "ws-meta", "eastus2")
+
+	got, err := client.Get(ctx, testRG, "ws-meta", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Location == nil || *got.Location != "eastus2" {
+		t.Fatalf("location = %v, want eastus2", got.Location)
+	}
+
+	if got.Properties == nil || got.Properties.SKU == nil || got.Properties.SKU.Name == nil ||
+		string(*got.Properties.SKU.Name) != "PerGB2018" {
+		t.Fatalf("sku = %+v, want PerGB2018", got.Properties)
+	}
+
+	cid := ""
+	if got.Properties.CustomerID != nil {
+		cid = *got.Properties.CustomerID
+	}
+
+	if len(cid) != 36 || strings.Count(cid, "-") != 4 {
+		t.Fatalf("customerId = %q, want a GUID", cid)
+	}
+
+	if got.ID != nil && cid == *got.ID {
+		t.Fatalf("customerId must differ from the ARM id")
+	}
+}
+
+// TestSDKSavedSearchLifecycle covers finding 5: workspace child resources are
+// stored and served, not misrouted to the workspace body.
+func TestSDKSavedSearchLifecycle(t *testing.T) {
+	opts := newTestOptions(t)
+	ctx := context.Background()
+
+	wsClient, err := armoperationalinsights.NewWorkspacesClient(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewWorkspacesClient: %v", err)
+	}
+
+	createWorkspace(t, wsClient, "ws-ss", "eastus")
+
+	ssClient, err := armoperationalinsights.NewSavedSearchesClient(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewSavedSearchesClient: %v", err)
+	}
+
+	created, err := ssClient.CreateOrUpdate(ctx, testRG, "ws-ss", "search-1", armoperationalinsights.SavedSearch{
+		Properties: &armoperationalinsights.SavedSearchProperties{
+			Category:    to.Ptr("cat"),
+			DisplayName: to.Ptr("My search"),
+			Query:       to.Ptr("Heartbeat | take 10"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "search-1" {
+		t.Fatalf("saved search name = %v, want search-1", created.Name)
+	}
+
+	if created.Type == nil || !strings.Contains(*created.Type, "savedSearches") {
+		t.Fatalf("saved search type = %v, want savedSearches", created.Type)
+	}
+
+	got, err := ssClient.Get(ctx, testRG, "ws-ss", "search-1", nil)
+	if err != nil {
+		t.Fatalf("Get saved search: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.Query == nil || *got.Properties.Query != "Heartbeat | take 10" {
+		t.Fatalf("query = %+v, want round-tripped", got.Properties)
+	}
+
+	list, err := ssClient.ListByWorkspace(ctx, testRG, "ws-ss", nil)
+	if err != nil {
+		t.Fatalf("ListByWorkspace: %v", err)
+	}
+
+	if len(list.Value) != 1 || list.Value[0].Name == nil || *list.Value[0].Name != "search-1" {
+		t.Fatalf("list = %+v, want [search-1]", list.Value)
+	}
+}
+
+// TestSDKSharedKeys covers finding 6: GetSharedKeys returns stable ingestion
+// keys instead of 405.
+func TestSDKSharedKeys(t *testing.T) {
+	opts := newTestOptions(t)
+	ctx := context.Background()
+
+	wsClient, err := armoperationalinsights.NewWorkspacesClient(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewWorkspacesClient: %v", err)
+	}
+
+	createWorkspace(t, wsClient, "ws-keys", "eastus")
+
+	skClient, err := armoperationalinsights.NewSharedKeysClient(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewSharedKeysClient: %v", err)
+	}
+
+	keys, err := skClient.GetSharedKeys(ctx, testRG, "ws-keys", nil)
+	if err != nil {
+		t.Fatalf("GetSharedKeys: %v", err)
+	}
+
+	if keys.PrimarySharedKey == nil || *keys.PrimarySharedKey == "" {
+		t.Fatalf("primary shared key missing")
+	}
+
+	if keys.SecondarySharedKey == nil || *keys.SecondarySharedKey == "" {
+		t.Fatalf("secondary shared key missing")
+	}
+
+	if *keys.PrimarySharedKey == *keys.SecondarySharedKey {
+		t.Fatalf("primary and secondary keys must differ")
+	}
+
+	again, err := skClient.GetSharedKeys(ctx, testRG, "ws-keys", nil)
+	if err != nil {
+		t.Fatalf("GetSharedKeys (repeat): %v", err)
+	}
+
+	if *again.PrimarySharedKey != *keys.PrimarySharedKey {
+		t.Fatalf("shared key not stable across calls")
+	}
+}

--- a/server/azure/loganalytics/shared_keys.go
+++ b/server/azure/loganalytics/shared_keys.go
@@ -1,0 +1,47 @@
+package loganalytics
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+// sharedKeysJSON is the SharedKeysClient.GetSharedKeys response shape.
+type sharedKeysJSON struct {
+	PrimarySharedKey   string `json:"primarySharedKey"`
+	SecondarySharedKey string `json:"secondarySharedKey"`
+}
+
+// getSharedKeys serves POST .../workspaces/{w}/sharedKeys. Real Log Analytics
+// returns the two base64 ingestion keys a client uses to POST logs. The keys
+// are derived deterministically from the workspace so repeat calls are stable
+// (until a regenerate, which the emulator does not model).
+func (h *Handler) getSharedKeys(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	info, err := h.logs.GetLogGroup(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, sharedKeysJSON{
+		PrimarySharedKey:   sharedKey(info.ResourceID + "#primary"),
+		SecondarySharedKey: sharedKey(info.ResourceID + "#secondary"),
+	})
+}
+
+// sharedKey derives a stable, base64-encoded 512-bit shared key from a seed,
+// matching the shape (88-char base64 of 64 bytes) real Log Analytics keys have.
+func sharedKey(seed string) string {
+	a := sha256.Sum256([]byte(seed))
+	b := sha256.Sum256(a[:])
+	key := append(a[:], b[:]...)
+
+	return base64.StdEncoding.EncodeToString(key)
+}

--- a/server/azure/loganalytics/types.go
+++ b/server/azure/loganalytics/types.go
@@ -1,7 +1,6 @@
 package loganalytics
 
 import (
-	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
 )
 
@@ -10,14 +9,25 @@ import (
 // response without a follow-up poll.
 const provisioningSucceeded = "Succeeded"
 
+// defaultSKUName is the SKU real Log Analytics defaults a workspace to when the
+// caller omits one (the current commitment-tier-less pricing SKU).
+const defaultSKUName = "PerGB2018"
+
+// workspaceSKU is the ARM Workspace SKU sub-object (properties.sku).
+type workspaceSKU struct {
+	Name string `json:"name"`
+}
+
 // workspaceProperties is the subset of Log Analytics workspace properties we
-// model. RetentionInDays round-trips through the driver; provisioningState is
-// synthesized so the SDK's LRO poller sees a terminal state.
+// model. RetentionInDays round-trips through the driver; provisioningState,
+// customerId and sku are Azure-only ARM fields tracked in the wire handler's
+// per-workspace metadata.
 type workspaceProperties struct {
-	ProvisioningState string `json:"provisioningState,omitempty"`
-	RetentionInDays   *int32 `json:"retentionInDays,omitempty"`
-	CustomerID        string `json:"customerId,omitempty"`
-	CreatedDate       string `json:"createdDate,omitempty"`
+	ProvisioningState string        `json:"provisioningState,omitempty"`
+	RetentionInDays   *int32        `json:"retentionInDays,omitempty"`
+	CustomerID        string        `json:"customerId,omitempty"`
+	SKU               *workspaceSKU `json:"sku,omitempty"`
+	CreatedDate       string        `json:"createdDate,omitempty"`
 }
 
 // workspaceJSON is the ARM Workspace resource envelope.
@@ -40,7 +50,8 @@ type workspaceRequest struct {
 	Location   string            `json:"location"`
 	Tags       map[string]string `json:"tags"`
 	Properties *struct {
-		RetentionInDays *int32 `json:"retentionInDays"`
+		RetentionInDays *int32        `json:"retentionInDays"`
+		SKU             *workspaceSKU `json:"sku"`
 	} `json:"properties"`
 }
 
@@ -54,22 +65,31 @@ func (req *workspaceRequest) retentionDays() int {
 	return int(*req.Properties.RetentionInDays)
 }
 
-// toWorkspaceJSON renders a driver log group as an ARM workspace. location is
-// echoed from the request on create; on read paths it is empty (the driver does
-// not persist location), which the SDK tolerates.
-func toWorkspaceJSON(rp *azurearm.ResourcePath, info *logdriver.LogGroupInfo, location string) workspaceJSON {
+// skuName returns the requested SKU name, or "" when unset.
+func (req *workspaceRequest) skuName() string {
+	if req.Properties == nil || req.Properties.SKU == nil {
+		return ""
+	}
+
+	return req.Properties.SKU.Name
+}
+
+// toWorkspaceJSON renders a driver log group as an ARM workspace, folding in the
+// Azure-only ARM fields (location, customerId GUID, sku) held in meta.
+func toWorkspaceJSON(info *logdriver.LogGroupInfo, meta *workspaceMeta) workspaceJSON {
 	retention := int32(info.RetentionDays) //nolint:gosec // retention days is a small positive value
 
 	return workspaceJSON{
 		ID:       info.ResourceID,
 		Name:     info.Name,
 		Type:     providerName + "/" + typeWorkspaces,
-		Location: location,
+		Location: meta.Location,
 		Tags:     info.Tags,
 		Properties: workspaceProperties{
 			ProvisioningState: provisioningSucceeded,
 			RetentionInDays:   &retention,
-			CustomerID:        info.ResourceID,
+			CustomerID:        meta.CustomerID,
+			SKU:               &workspaceSKU{Name: meta.SKU},
 			CreatedDate:       info.CreatedAt,
 		},
 	}

--- a/server/azure/loganalytics/workspace_meta.go
+++ b/server/azure/loganalytics/workspace_meta.go
@@ -1,0 +1,91 @@
+package loganalytics
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+)
+
+// workspaceMeta holds the Azure-only ARM attributes of a workspace that have no
+// portable log-group equivalent: the geo location supplied on create, the
+// workspace GUID (customerId) Azure assigns, and the pricing SKU. The logging
+// driver owns retention, tags, createdAt and identity; this metadata is the
+// wire layer's own so the shared driver stays cloud-neutral.
+type workspaceMeta struct {
+	Location   string
+	CustomerID string
+	SKU        string
+}
+
+// metaStore is a concurrency-safe map of workspace name to its ARM metadata.
+type metaStore struct {
+	mu sync.RWMutex
+	m  map[string]*workspaceMeta
+}
+
+func newMetaStore() *metaStore {
+	return &metaStore{m: make(map[string]*workspaceMeta)}
+}
+
+// upsert records the metadata for a workspace on create/update. The customerId
+// GUID is assigned once (on first create) and preserved across updates so a
+// client that re-reads the workspace always sees the same workspace ID.
+func (s *metaStore) upsert(name, resourceID, location, sku string) *workspaceMeta {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	meta := s.m[name]
+	if meta == nil {
+		meta = &workspaceMeta{CustomerID: workspaceGUID(resourceID)}
+		s.m[name] = meta
+	}
+
+	if location != "" {
+		meta.Location = location
+	}
+
+	if sku != "" {
+		meta.SKU = sku
+	} else if meta.SKU == "" {
+		meta.SKU = defaultSKUName
+	}
+
+	clone := *meta
+
+	return &clone
+}
+
+// get returns the metadata for a workspace, synthesizing defaults for one that
+// was created out-of-band (e.g. via the portable logging API) and therefore has
+// no wire-layer record: a deterministic customerId, the default SKU, and no
+// location (which real ARM tolerates on read).
+func (s *metaStore) get(name, resourceID string) *workspaceMeta {
+	s.mu.RLock()
+	meta := s.m[name]
+	s.mu.RUnlock()
+
+	if meta != nil {
+		clone := *meta
+
+		return &clone
+	}
+
+	return &workspaceMeta{CustomerID: workspaceGUID(resourceID), SKU: defaultSKUName}
+}
+
+func (s *metaStore) delete(name string) {
+	s.mu.Lock()
+	delete(s.m, name)
+	s.mu.Unlock()
+}
+
+// workspaceGUID derives a stable RFC-4122-shaped GUID from the workspace's ARM
+// resource ID. Real Log Analytics assigns a random workspace ID; deriving it
+// from the (unique) resource ID makes it stable across reads without any extra
+// stored state, which is what a client keying on customerId needs.
+func workspaceGUID(seed string) string {
+	sum := sha256.Sum256([]byte(seed))
+	h := hex.EncodeToString(sum[:])
+
+	return h[0:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+}

--- a/server/azure/monitor/diagnostic_settings.go
+++ b/server/azure/monitor/diagnostic_settings.go
@@ -129,8 +129,10 @@ func (h *DiagnosticSettingsHandler) delete(w http.ResponseWriter, uri, name stri
 
 	h.mu.Unlock()
 
+	// Azure DELETE is idempotent: a missing diagnosticSetting returns 204 No
+	// Content, not a 404 error body.
 	if !ok {
-		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "diagnosticSetting "+name+" not found")
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/server/azure/monitor/diagnostic_settings.go
+++ b/server/azure/monitor/diagnostic_settings.go
@@ -1,0 +1,167 @@
+package monitor
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+const diagSuffix = "/providers/microsoft.insights/diagnosticsettings"
+
+// diagType is the ARM type returned for a diagnostic setting.
+const diagType = "Microsoft.Insights/diagnosticSettings"
+
+// DiagnosticSettingsHandler serves microsoft.insights/diagnosticSettings, an
+// extension resource that hangs off any resource URI (a VM, a workspace, a
+// storage account). It has no portable equivalent, so it is stored in the
+// handler's own map keyed by the target resource URI and setting name.
+type DiagnosticSettingsHandler struct {
+	mu sync.RWMutex
+	m  map[string]map[string]map[string]any // resourceUri -> name -> properties
+}
+
+// NewDiagnosticSettingsHandler returns an empty diagnostic-settings handler.
+func NewDiagnosticSettingsHandler() *DiagnosticSettingsHandler {
+	return &DiagnosticSettingsHandler{m: make(map[string]map[string]map[string]any)}
+}
+
+// Matches claims any path whose (lowercased) form carries the
+// /providers/microsoft.insights/diagnosticSettings segment.
+func (*DiagnosticSettingsHandler) Matches(r *http.Request) bool {
+	return strings.Contains(strings.ToLower(r.URL.Path), diagSuffix)
+}
+
+// split returns the target resource URI and the (possibly empty) setting name.
+func splitDiagPath(path string) (uri, name string) {
+	i := strings.Index(strings.ToLower(path), diagSuffix)
+	if i < 0 {
+		return strings.Trim(path, "/"), ""
+	}
+
+	uri = strings.Trim(path[:i], "/")
+	name = strings.Trim(path[i+len(diagSuffix):], "/")
+
+	return uri, name
+}
+
+func (h *DiagnosticSettingsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	uri, name := splitDiagPath(r.URL.Path)
+
+	if name == "" {
+		if r.Method != http.MethodGet {
+			azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+			return
+		}
+
+		h.list(w, uri)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.put(w, r, uri, name)
+	case http.MethodGet:
+		h.get(w, uri, name)
+	case http.MethodDelete:
+		h.delete(w, uri, name)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+// diagRequest is the inbound body; only properties are meaningful.
+type diagRequest struct {
+	Properties map[string]any `json:"properties"`
+}
+
+func (h *DiagnosticSettingsHandler) put(w http.ResponseWriter, r *http.Request, uri, name string) {
+	var req diagRequest
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	props := req.Properties
+	if props == nil {
+		props = map[string]any{}
+	}
+
+	h.mu.Lock()
+
+	byName := h.m[uri]
+	if byName == nil {
+		byName = make(map[string]map[string]any)
+		h.m[uri] = byName
+	}
+
+	byName[name] = props
+
+	h.mu.Unlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, diagJSON(uri, name, props))
+}
+
+func (h *DiagnosticSettingsHandler) get(w http.ResponseWriter, uri, name string) {
+	h.mu.RLock()
+	props, ok := h.m[uri][name]
+	h.mu.RUnlock()
+
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "diagnosticSetting "+name+" not found")
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, diagJSON(uri, name, props))
+}
+
+func (h *DiagnosticSettingsHandler) delete(w http.ResponseWriter, uri, name string) {
+	h.mu.Lock()
+
+	byName := h.m[uri]
+
+	_, ok := byName[name]
+	if ok {
+		delete(byName, name)
+	}
+
+	h.mu.Unlock()
+
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "diagnosticSetting "+name+" not found")
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *DiagnosticSettingsHandler) list(w http.ResponseWriter, uri string) {
+	h.mu.RLock()
+	byName := h.m[uri]
+
+	names := make([]string, 0, len(byName))
+	for name := range byName {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	value := make([]map[string]any, 0, len(byName))
+	for _, name := range names {
+		value = append(value, diagJSON(uri, name, byName[name]))
+	}
+	h.mu.RUnlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, map[string]any{"value": value})
+}
+
+func diagJSON(uri, name string, props map[string]any) map[string]any {
+	return map[string]any{
+		"id":         uri + "/providers/microsoft.insights/diagnosticSettings/" + name,
+		"name":       name,
+		"type":       diagType,
+		"properties": props,
+	}
+}

--- a/server/azure/monitor/handler.go
+++ b/server/azure/monitor/handler.go
@@ -163,8 +163,10 @@ func (h *Handler) list(w http.ResponseWriter, rp *azurearm.ResourcePath, kind st
 }
 
 func (h *Handler) delete(w http.ResponseWriter, rp *azurearm.ResourcePath, kind string) {
+	// Azure DELETE is idempotent: a missing metricAlert/actionGroup/activityLogAlert
+	// returns 204 No Content ("resource does not exist"), not a 404 error body.
 	if !h.store.delete(kind, rp.ResourceName) {
-		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", kind+" "+rp.ResourceName+" not found")
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/server/azure/monitor/handler.go
+++ b/server/azure/monitor/handler.go
@@ -1,13 +1,16 @@
-// Package monitor implements the Azure microsoft.insights metric-alerts
-// resource against a CloudEmu monitoring driver. Real armmonitor clients
-// hit this handler the same way they hit management.azure.com.
+// Package monitor implements the Azure microsoft.insights ARM resources
+// (metricAlerts, actionGroups, activityLogAlerts) and the microsoft.insights
+// data-plane (metrics, metricDefinitions) plus diagnosticSettings against a
+// CloudEmu monitoring driver. Real armmonitor clients hit these handlers the
+// same way they hit management.azure.com.
 package monitor
 
 import (
 	"context"
 	"net/http"
+	"sort"
+	"strings"
 
-	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
@@ -15,28 +18,56 @@ import (
 const (
 	providerName    = "microsoft.insights"
 	typeAlerts      = "metricAlerts"
-	armNameTag      = "cloudemu:azureAlertName"
+	typeActionGroup = "actionGroups"
+	typeActivityLog = "activityLogAlerts"
 	defaultLocation = "global"
 )
 
-// Handler serves microsoft.insights ARM resources.
+// Handler serves the microsoft.insights ARM resource types: metricAlerts,
+// actionGroups and activityLogAlerts. Each is stored in full so reads round-trip
+// the caller's definition; metricAlerts additionally register the named metric
+// with the driver so the alarm evaluates.
 type Handler struct {
-	mon mondriver.Monitoring
+	mon   mondriver.Monitoring
+	store *resourceStore
 }
 
 // New returns a monitor handler.
 func New(m mondriver.Monitoring) *Handler {
-	return &Handler{mon: m}
+	return &Handler{mon: m, store: newResourceStore()}
 }
 
-// Matches returns true for ARM URLs targeting microsoft.insights/metricAlerts.
+// armType returns the ARM "type" string for a stored resource type.
+func armType(resourceType string) string {
+	return "Microsoft.Insights/" + resourceType
+}
+
+// canonicalType maps an incoming (case-insensitive) resource type to the stored
+// kind, or "" when this handler does not serve it.
+func canonicalType(resourceType string) string {
+	switch strings.ToLower(resourceType) {
+	case strings.ToLower(typeAlerts):
+		return typeAlerts
+	case strings.ToLower(typeActionGroup):
+		return typeActionGroup
+	case strings.ToLower(typeActivityLog):
+		return typeActivityLog
+	default:
+		return ""
+	}
+}
+
+// Matches returns true for ARM URLs targeting a microsoft.insights resource type
+// this handler serves. The provider name is matched case-insensitively because
+// real armmonitor clients emit "Microsoft.Insights" while other tooling emits
+// the lowercase form.
 func (*Handler) Matches(r *http.Request) bool {
 	rp, ok := azurearm.ParsePath(r.URL.Path)
 	if !ok {
 		return false
 	}
 
-	return rp.Provider == providerName && rp.ResourceType == typeAlerts
+	return strings.EqualFold(rp.Provider, providerName) && canonicalType(rp.ResourceType) != ""
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -46,132 +77,100 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	kind := canonicalType(rp.ResourceType)
+	if kind == "" {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unknown resource type")
+		return
+	}
+
 	if rp.ResourceName == "" {
-		h.list(w, r, rp)
+		h.list(w, &rp, kind)
 		return
 	}
 
 	switch r.Method {
 	case http.MethodPut:
-		h.createOrUpdate(w, r, rp)
+		h.createOrUpdate(w, r, &rp, kind)
 	case http.MethodGet:
-		h.get(w, r, rp)
+		h.get(w, &rp, kind)
 	case http.MethodDelete:
-		h.delete(w, r, rp)
+		h.delete(w, &rp, kind)
 	default:
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
 }
 
-//nolint:gocritic // rp is a request-scoped value
-func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, kind string) {
 	if rp.ResourceGroup == "" {
 		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
 		return
 	}
 
-	var req alertRequest
-
+	var req resourceRequest
 	if !azurearm.DecodeJSON(w, r, &req) {
 		return
 	}
 
-	cfg := mondriver.AlarmConfig{
-		Name:               rp.ResourceName,
-		Namespace:          "azure",
-		MetricName:         "metric",
-		ComparisonOperator: "GreaterThanThreshold",
-		Threshold:          0,
-		Period:             60,
-		EvaluationPeriods:  1,
-		Stat:               "Average",
+	res := &armResource{Location: req.Location, Tags: req.Tags, Properties: req.Properties}
+	if kind == typeAlerts {
+		res.Properties = withProvisioningState(res.Properties)
+
+		if err := h.registerAlarm(r, rp.ResourceName, req.Properties); err != nil {
+			azurearm.WriteCErr(w, err)
+			return
+		}
 	}
 
-	if err := h.mon.CreateAlarm(r.Context(), cfg); err != nil {
-		azurearm.WriteCErr(w, err)
-		return
+	existed := h.store.set(kind, rp.ResourceName, res)
+
+	status := http.StatusCreated
+	if existed {
+		status = http.StatusOK
 	}
 
-	loc := req.Location
-	if loc == "" {
-		loc = defaultLocation
-	}
-
-	azurearm.WriteJSON(w, http.StatusCreated, toAlertResponse(rp, loc, req))
+	azurearm.WriteJSON(w, status, toResourceJSON(rp, kind, res))
 }
 
-//nolint:gocritic // rp is a request-scoped value
-func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	if err := alarmExists(r.Context(), h.mon, rp.ResourceName); err != nil {
-		azurearm.WriteCErr(w, err)
+func (h *Handler) get(w http.ResponseWriter, rp *azurearm.ResourcePath, kind string) {
+	res, ok := h.store.get(kind, rp.ResourceName)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", kind+" "+rp.ResourceName+" not found")
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toAlertResponse(rp, defaultLocation, alertRequest{}))
+	azurearm.WriteJSON(w, http.StatusOK, toResourceJSON(rp, kind, res))
 }
 
-//nolint:gocritic // rp is a request-scoped value
-func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	alarms, err := h.mon.DescribeAlarms(r.Context(), nil)
-	if err != nil {
-		azurearm.WriteCErr(w, err)
-		return
+func (h *Handler) list(w http.ResponseWriter, rp *azurearm.ResourcePath, kind string) {
+	all := h.store.all(kind)
+
+	names := make([]string, 0, len(all))
+	for name := range all {
+		names = append(names, name)
 	}
 
-	out := alertListResponse{}
+	sort.Strings(names)
 
-	for i := range alarms {
-		scope := rp
-		scope.ResourceName = alarms[i].Name
-		out.Value = append(out.Value, toAlertResponse(scope, defaultLocation, alertRequest{}))
+	out := resourceListResponse{Value: make([]resourceResponse, 0, len(names))}
+
+	for _, name := range names {
+		scoped := *rp
+		scoped.ResourceName = name
+		out.Value = append(out.Value, toResourceJSON(&scoped, kind, all[name]))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, out)
 }
 
-//nolint:gocritic // rp is a request-scoped value
-func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	if err := alarmExists(r.Context(), h.mon, rp.ResourceName); err != nil {
-		azurearm.WriteCErr(w, err)
+func (h *Handler) delete(w http.ResponseWriter, rp *azurearm.ResourcePath, kind string) {
+	if !h.store.delete(kind, rp.ResourceName) {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", kind+" "+rp.ResourceName+" not found")
 		return
 	}
 
-	if err := h.mon.DeleteAlarm(r.Context(), rp.ResourceName); err != nil {
-		azurearm.WriteCErr(w, err)
-		return
+	if kind == typeAlerts {
+		_ = h.mon.DeleteAlarm(context.Background(), rp.ResourceName)
 	}
 
 	w.WriteHeader(http.StatusOK)
-}
-
-// alarmExists returns nil if an alarm with the given name exists in the
-// driver, NotFound otherwise. Callers only need presence/absence.
-func alarmExists(ctx context.Context, m mondriver.Monitoring, name string) error {
-	alarms, err := m.DescribeAlarms(ctx, nil)
-	if err != nil {
-		return err
-	}
-
-	for i := range alarms {
-		if alarms[i].Name == name {
-			return nil
-		}
-	}
-
-	return cerrors.Newf(cerrors.NotFound, "metricAlert %s not found", name)
-}
-
-//nolint:gocritic // rp is a request-scoped value
-func toAlertResponse(rp azurearm.ResourcePath, location string, req alertRequest) alertResponse {
-	return alertResponse{
-		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeAlerts, rp.ResourceName),
-		Name:     rp.ResourceName,
-		Type:     providerName + "/" + typeAlerts,
-		Location: location,
-		Tags:     req.Tags,
-		Properties: alertResponseProps{
-			alertRequestProps: req.Properties,
-			ProvisioningState: "Succeeded",
-		},
-	}
 }

--- a/server/azure/monitor/metric_alerts.go
+++ b/server/azure/monitor/metric_alerts.go
@@ -1,0 +1,185 @@
+package monitor
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+const (
+	defaultWindowSeconds = 300
+	opGreaterThan        = "GreaterThanThreshold"
+)
+
+// registerAlarm bridges an Azure metric-alert definition onto the monitoring
+// driver so the named metric is actually evaluated. It reads the first static
+// threshold criterion from properties.criteria.allOf and maps the ARM operator /
+// timeAggregation / windowSize onto the driver's AlarmConfig. A definition with
+// no usable criterion is stored (echoed on read) but not evaluated.
+func (h *Handler) registerAlarm(r *http.Request, name string, props map[string]any) error {
+	c, ok := firstCriterion(props)
+	if !ok {
+		return nil
+	}
+
+	cfg := mondriver.AlarmConfig{
+		Name:               name,
+		Namespace:          c.metricNamespace,
+		MetricName:         c.metricName,
+		ComparisonOperator: mapOperator(c.operator),
+		Threshold:          c.threshold,
+		Period:             windowSeconds(props),
+		EvaluationPeriods:  1,
+		Stat:               mapAggregation(c.timeAggregation),
+	}
+
+	return h.mon.CreateAlarm(r.Context(), cfg)
+}
+
+// criterion is one parsed static-threshold metric criterion.
+type criterion struct {
+	metricName      string
+	metricNamespace string
+	operator        string
+	threshold       float64
+	timeAggregation string
+}
+
+// firstCriterion extracts the first entry of properties.criteria.allOf.
+func firstCriterion(props map[string]any) (criterion, bool) {
+	criteria, ok := props["criteria"].(map[string]any)
+	if !ok {
+		return criterion{}, false
+	}
+
+	allOf, ok := criteria["allOf"].([]any)
+	if !ok || len(allOf) == 0 {
+		return criterion{}, false
+	}
+
+	item, ok := allOf[0].(map[string]any)
+	if !ok {
+		return criterion{}, false
+	}
+
+	name, ok := item["metricName"].(string)
+	if !ok || name == "" {
+		return criterion{}, false
+	}
+
+	return criterion{
+		metricName:      name,
+		metricNamespace: stringField(item, "metricNamespace"),
+		operator:        stringField(item, "operator"),
+		threshold:       floatField(item["threshold"]),
+		timeAggregation: stringField(item, "timeAggregation"),
+	}, true
+}
+
+func stringField(m map[string]any, key string) string {
+	s, _ := m[key].(string)
+
+	return s
+}
+
+// floatField coerces a JSON number (float64) or numeric string to float64.
+func floatField(v any) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case string:
+		f, _ := strconv.ParseFloat(n, 64)
+
+		return f
+	default:
+		return 0
+	}
+}
+
+// mapOperator maps an Azure metric-alert operator to a driver comparison
+// operator. An unrecognized operator falls back to GreaterThanThreshold.
+func mapOperator(op string) string {
+	switch op {
+	case "GreaterThanOrEqual":
+		return "GreaterThanOrEqualToThreshold"
+	case "LessThan":
+		return "LessThanThreshold"
+	case "LessThanOrEqual":
+		return "LessThanOrEqualToThreshold"
+	default: // "GreaterThan" and any unrecognized operator
+		return opGreaterThan
+	}
+}
+
+// mapAggregation maps an Azure timeAggregation to a driver statistic.
+func mapAggregation(agg string) string {
+	switch agg {
+	case "Total":
+		return "Sum"
+	case "Count":
+		return "SampleCount"
+	case "Minimum", "Maximum":
+		return agg
+	default:
+		return "Average"
+	}
+}
+
+// windowSeconds reads properties.windowSize (an ISO-8601 duration) as seconds,
+// defaulting to five minutes when absent or unparseable.
+func windowSeconds(props map[string]any) int {
+	iso, ok := props["windowSize"].(string)
+	if !ok {
+		return defaultWindowSeconds
+	}
+
+	if secs := parseISODuration(iso); secs > 0 {
+		return secs
+	}
+
+	return defaultWindowSeconds
+}
+
+// parseISODuration parses the minute/hour/day subset of ISO-8601 durations that
+// metric-alert windows use (PT1M, PT5M, PT1H, PT6H, P1D). Returns 0 when the
+// string is not one of those shapes.
+func parseISODuration(s string) int {
+	const (
+		secsPerMinute = 60
+		secsPerHour   = 3600
+		secsPerDay    = 86400
+	)
+
+	if num, ok := durationNumber(s, "PT", "M"); ok {
+		return num * secsPerMinute
+	}
+
+	if num, ok := durationNumber(s, "PT", "H"); ok {
+		return num * secsPerHour
+	}
+
+	if num, ok := durationNumber(s, "P", "D"); ok {
+		return num * secsPerDay
+	}
+
+	return 0
+}
+
+// durationNumber pulls the integer between prefix and suffix (e.g. "5" from
+// "PT5M"), reporting ok=false when the string does not have that shape.
+func durationNumber(s, prefix, suffix string) (int, bool) {
+	if !strings.HasPrefix(s, prefix) || !strings.HasSuffix(s, suffix) {
+		return 0, false
+	}
+
+	mid := strings.TrimSuffix(strings.TrimPrefix(s, prefix), suffix)
+
+	n, err := strconv.Atoi(mid)
+	if err != nil {
+		return 0, false
+	}
+
+	return n, true
+}

--- a/server/azure/monitor/metrics.go
+++ b/server/azure/monitor/metrics.go
@@ -1,0 +1,135 @@
+package monitor
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+const (
+	metricsSuffix     = "/providers/microsoft.insights/metrics"
+	metricDefsSuffix  = "/providers/microsoft.insights/metricdefinitions"
+	defaultRegion     = "eastus"
+	defaultIntervalS  = 60
+	defaultIntervalPT = "PT1M"
+)
+
+// MetricsHandler serves the microsoft.insights data plane
+// (Microsoft.Insights/metrics and metricDefinitions) — an extension resource
+// hanging off any resource URI. It reads the timeseries the compute/storage
+// mocks pushed into the monitoring driver.
+type MetricsHandler struct {
+	mon mondriver.Monitoring
+}
+
+// NewMetricsHandler returns a metrics data-plane handler backed by m.
+func NewMetricsHandler(m mondriver.Monitoring) *MetricsHandler {
+	return &MetricsHandler{mon: m}
+}
+
+// Matches claims GETs on {resourceUri}/providers/microsoft.insights/metrics and
+// .../metricDefinitions. The match is on the lowercased path suffix, so it wins
+// over the underlying resource's own handler regardless of which provider the
+// resource belongs to.
+func (*MetricsHandler) Matches(r *http.Request) bool {
+	p := strings.ToLower(r.URL.Path)
+
+	return strings.HasSuffix(p, metricsSuffix) || strings.HasSuffix(p, metricDefsSuffix)
+}
+
+func (h *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "GET required")
+		return
+	}
+
+	p := strings.ToLower(r.URL.Path)
+
+	switch {
+	case strings.HasSuffix(p, metricDefsSuffix):
+		h.listDefinitions(w, r)
+	case strings.HasSuffix(p, metricsSuffix):
+		h.listMetrics(w, r)
+	default:
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unknown metrics path")
+	}
+}
+
+// resourceURI returns the ARM resource id the metrics hang off (the path with
+// the trailing /providers/microsoft.insights/<leaf> removed).
+func resourceURI(path, suffix string) string {
+	idx := strings.Index(strings.ToLower(path), suffix)
+	if idx < 0 {
+		return strings.TrimPrefix(path, "/")
+	}
+
+	return strings.Trim(path[:idx], "/")
+}
+
+// namespaceFor derives the metric namespace: the explicit metricnamespace query
+// wins, otherwise it is the provider/type of the resource URI (e.g.
+// "Microsoft.Compute/virtualMachines"), which is exactly the namespace the
+// compute mock stores its datapoints under.
+func namespaceFor(r *http.Request, uri string) string {
+	if ns := r.URL.Query().Get("metricnamespace"); ns != "" {
+		return ns
+	}
+
+	return namespaceFromURI(uri)
+}
+
+func namespaceFromURI(uri string) string {
+	const key = "/providers/"
+
+	i := strings.LastIndex(strings.ToLower(uri), key)
+	if i < 0 {
+		return ""
+	}
+
+	const providerTypePair = 2
+
+	parts := strings.Split(strings.Trim(uri[i+len(key):], "/"), "/")
+	if len(parts) < providerTypePair {
+		return ""
+	}
+
+	return parts[0] + "/" + parts[1]
+}
+
+func (h *MetricsHandler) listMetrics(w http.ResponseWriter, r *http.Request) {
+	uri := resourceURI(r.URL.Path, metricsSuffix)
+	namespace := namespaceFor(r, uri)
+	aggs := aggregations(r.URL.Query().Get("aggregation"))
+	names := splitCSV(r.URL.Query().Get("metricnames"))
+
+	value := make([]map[string]any, 0, len(names))
+	for _, name := range names {
+		value = append(value, h.metricEntry(r.Context(), uri, namespace, name, aggs))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, map[string]any{
+		"timespan":       r.URL.Query().Get("timespan"),
+		"interval":       defaultIntervalPT,
+		"value":          value,
+		"namespace":      namespace,
+		"resourceregion": defaultRegion,
+	})
+}
+
+// metricEntry builds one Metric object with a single timeseries whose datapoints
+// carry each requested aggregation.
+func (h *MetricsHandler) metricEntry(ctx context.Context, uri, namespace, name string, aggs []string) map[string]any {
+	data := h.timeseriesData(ctx, namespace, name, aggs)
+
+	return map[string]any{
+		"id":         uri + metricsSuffix + "/" + name,
+		"type":       "Microsoft.Insights/metrics",
+		"name":       localizable(name),
+		"unit":       "Count",
+		"timeseries": []map[string]any{{"metadatavalues": []any{}, "data": data}},
+		"errorCode":  "Success",
+	}
+}

--- a/server/azure/monitor/metrics_data.go
+++ b/server/azure/monitor/metrics_data.go
@@ -1,0 +1,169 @@
+package monitor
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// wideWindowYears bounds the query window generously so every stored datapoint
+// (backfilled around a VM's launch time under a fake clock) is captured.
+const wideWindowYears = 50
+
+// aggregationKey pairs an Azure aggregation name with the driver statistic and
+// the JSON field it renders as.
+type aggregationKey struct {
+	azure string // "average", "minimum", "maximum", "total", "count"
+	stat  string // driver Stat
+	field string // JSON field in a MetricValue
+}
+
+//nolint:gochecknoglobals // static lookup table
+var aggregationTable = map[string]aggregationKey{
+	"average": {azure: "average", stat: "Average", field: "average"},
+	"minimum": {azure: "minimum", stat: "Minimum", field: "minimum"},
+	"maximum": {azure: "maximum", stat: "Maximum", field: "maximum"},
+	"total":   {azure: "total", stat: "Sum", field: "total"},
+	"count":   {azure: "count", stat: "SampleCount", field: "count"},
+}
+
+// aggregations parses the comma-separated aggregation query, defaulting to
+// average when none is supplied.
+func aggregations(raw string) []string {
+	names := splitCSV(strings.ToLower(raw))
+	if len(names) == 0 {
+		return []string{"average"}
+	}
+
+	out := make([]string, 0, len(names))
+
+	for _, n := range names {
+		if _, ok := aggregationTable[n]; ok {
+			out = append(out, n)
+		}
+	}
+
+	if len(out) == 0 {
+		return []string{"average"}
+	}
+
+	return out
+}
+
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+
+	return out
+}
+
+func localizable(v string) map[string]string {
+	return map[string]string{"value": v, "localizedValue": v}
+}
+
+// timeseriesData builds the datapoint array for one metric, one row per bucket
+// timestamp, carrying every requested aggregation. Buckets are keyed by
+// timestamp so multiple aggregation queries align.
+func (h *MetricsHandler) timeseriesData(ctx context.Context, namespace, name string, aggs []string) []map[string]any {
+	start := time.Unix(0, 0)
+	end := time.Now().AddDate(wideWindowYears, 0, 0)
+
+	order := []time.Time{}
+	rows := map[time.Time]map[string]any{}
+
+	for _, agg := range aggs {
+		key := aggregationTable[agg]
+		res, err := h.mon.GetMetricData(ctx, mondriver.GetMetricInput{
+			Namespace:  namespace,
+			MetricName: name,
+			StartTime:  start,
+			EndTime:    end,
+			Period:     defaultIntervalS,
+			Stat:       key.stat,
+		})
+
+		if err != nil || res == nil {
+			continue
+		}
+
+		for i, ts := range res.Timestamps {
+			row, ok := rows[ts]
+			if !ok {
+				row = map[string]any{"timeStamp": ts.UTC().Format(time.RFC3339)}
+				rows[ts] = row
+
+				order = append(order, ts)
+			}
+
+			row[key.field] = res.Values[i]
+		}
+	}
+
+	return orderedRows(order, rows)
+}
+
+func orderedRows(order []time.Time, rows map[time.Time]map[string]any) []map[string]any {
+	sortTimes(order)
+
+	out := make([]map[string]any, 0, len(order))
+	for _, ts := range order {
+		out = append(out, rows[ts])
+	}
+
+	return out
+}
+
+func sortTimes(ts []time.Time) {
+	for i := 1; i < len(ts); i++ {
+		for j := i; j > 0 && ts[j].Before(ts[j-1]); j-- {
+			ts[j], ts[j-1] = ts[j-1], ts[j]
+		}
+	}
+}
+
+// listDefinitions serves metricDefinitions: one definition per metric name the
+// driver knows in the resource's namespace.
+func (h *MetricsHandler) listDefinitions(w http.ResponseWriter, r *http.Request) {
+	uri := resourceURI(r.URL.Path, metricDefsSuffix)
+	namespace := namespaceFor(r, uri)
+
+	names, err := h.mon.ListMetrics(r.Context(), namespace)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	value := make([]map[string]any, 0, len(names))
+	for _, name := range names {
+		value = append(value, definitionEntry(uri, namespace, name))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, map[string]any{"value": value})
+}
+
+func definitionEntry(uri, namespace, name string) map[string]any {
+	return map[string]any{
+		"id":                        uri + metricDefsSuffix + "/" + name,
+		"resourceId":                uri,
+		"namespace":                 namespace,
+		"name":                      localizable(name),
+		"unit":                      "Count",
+		"primaryAggregationType":    "Average",
+		"supportedAggregationTypes": []string{"Average", "Minimum", "Maximum", "Total", "Count"},
+		"metricAvailabilities":      []map[string]any{{"timeGrain": defaultIntervalPT, "retention": "P93D"}},
+	}
+}

--- a/server/azure/monitor/metrics_test.go
+++ b/server/azure/monitor/metrics_test.go
@@ -1,0 +1,138 @@
+package monitor_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+const vmURI = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/vm1"
+
+// TestMetricsDataPlane covers finding 3: Microsoft.Insights/metrics serves the
+// timeseries the compute mock pushed, instead of 501.
+func TestMetricsDataPlane(t *testing.T) {
+	ts, cloudP := newMonitorServer(t)
+	ctx := context.Background()
+
+	if _, err := cloudP.VirtualMachines.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "img-1", InstanceType: "Standard_B1s", Region: "eastus",
+	}, 1); err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	url := vmURI + "/providers/microsoft.insights/metrics?metricnames=Percentage%20CPU&aggregation=average&api-version=2023-10-01"
+
+	code, got := doJSON(t, ts, http.MethodGet, url, "")
+	if code != http.StatusOK {
+		t.Fatalf("GET metrics status = %d, want 200", code)
+	}
+
+	value, _ := got["value"].([]any)
+	if len(value) != 1 {
+		t.Fatalf("value len = %d, want 1", len(value))
+	}
+
+	metric, _ := value[0].(map[string]any)
+	name, _ := metric["name"].(map[string]any)
+	if name["value"] != "Percentage CPU" {
+		t.Fatalf("metric name = %v, want Percentage CPU", name["value"])
+	}
+
+	series, _ := metric["timeseries"].([]any)
+	if len(series) == 0 {
+		t.Fatalf("timeseries empty")
+	}
+
+	data, _ := series[0].(map[string]any)["data"].([]any)
+	if len(data) == 0 {
+		t.Fatalf("no datapoints returned")
+	}
+
+	first, _ := data[0].(map[string]any)
+	if first["average"].(float64) != 25 {
+		t.Fatalf("average = %v, want 25", first["average"])
+	}
+}
+
+// TestMetricDefinitions covers finding 3: metricDefinitions lists the metrics
+// the driver knows for the resource's namespace.
+func TestMetricDefinitions(t *testing.T) {
+	ts, cloudP := newMonitorServer(t)
+	ctx := context.Background()
+
+	if _, err := cloudP.VirtualMachines.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "img-1", InstanceType: "Standard_B1s", Region: "eastus",
+	}, 1); err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	url := vmURI + "/providers/microsoft.insights/metricDefinitions?api-version=2023-10-01"
+
+	code, got := doJSON(t, ts, http.MethodGet, url, "")
+	if code != http.StatusOK {
+		t.Fatalf("GET metricDefinitions status = %d, want 200", code)
+	}
+
+	value, _ := got["value"].([]any)
+
+	found := false
+	for _, v := range value {
+		def, _ := v.(map[string]any)
+		name, _ := def["name"].(map[string]any)
+		if name["value"] == "Percentage CPU" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatalf("Percentage CPU not in metricDefinitions: %+v", value)
+	}
+}
+
+// TestDiagnosticSettings covers finding 2: diagnosticSettings CRUD on an
+// arbitrary resource URI, routing logs to a workspace.
+func TestDiagnosticSettings(t *testing.T) {
+	ts, _ := newMonitorServer(t)
+
+	url := vmURI + "/providers/microsoft.insights/diagnosticSettings/mysetting?api-version=2021-05-01-preview"
+
+	body := `{"properties":{
+		"workspaceId":"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.OperationalInsights/workspaces/ws1",
+		"logs":[{"categoryGroup":"allLogs","enabled":true}]}}`
+
+	if code, _ := doJSON(t, ts, http.MethodPut, url, body); code != http.StatusOK {
+		t.Fatalf("PUT diagnosticSettings status = %d, want 200", code)
+	}
+
+	code, got := doJSON(t, ts, http.MethodGet, url, "")
+	if code != http.StatusOK {
+		t.Fatalf("GET status = %d, want 200", code)
+	}
+
+	if got["type"] != "Microsoft.Insights/diagnosticSettings" {
+		t.Errorf("type = %v", got["type"])
+	}
+
+	props, _ := got["properties"].(map[string]any)
+	if wid, _ := props["workspaceId"].(string); !strings.Contains(wid, "ws1") {
+		t.Errorf("workspaceId dropped: %+v", props)
+	}
+
+	listURL := vmURI + "/providers/microsoft.insights/diagnosticSettings?api-version=2021-05-01-preview"
+
+	_, listed := doJSON(t, ts, http.MethodGet, listURL, "")
+	if v, _ := listed["value"].([]any); len(v) != 1 {
+		t.Errorf("list len = %d, want 1", len(v))
+	}
+
+	if code, _ := doJSON(t, ts, http.MethodDelete, url, ""); code != http.StatusOK {
+		t.Errorf("DELETE status = %d, want 200", code)
+	}
+
+	if code, _ := doJSON(t, ts, http.MethodGet, url, ""); code != http.StatusNotFound {
+		t.Errorf("GET after delete = %d, want 404", code)
+	}
+}

--- a/server/azure/monitor/metrics_test.go
+++ b/server/azure/monitor/metrics_test.go
@@ -136,3 +136,16 @@ func TestDiagnosticSettings(t *testing.T) {
 		t.Errorf("GET after delete = %d, want 404", code)
 	}
 }
+
+// TestDiagnosticSettingsDeleteMissingIsNoContent asserts DELETE on a
+// diagnosticSetting that does not exist returns 204 No Content (idempotent),
+// matching the Azure Monitor REST contract, not a 404 error body.
+func TestDiagnosticSettingsDeleteMissingIsNoContent(t *testing.T) {
+	ts, _ := newMonitorServer(t)
+
+	url := vmURI + "/providers/microsoft.insights/diagnosticSettings/never?api-version=2021-05-01-preview"
+
+	if code, body := doJSON(t, ts, http.MethodDelete, url, ""); code != http.StatusNoContent {
+		t.Errorf("DELETE missing status = %d, want 204; body = %v", code, body)
+	}
+}

--- a/server/azure/monitor/resources_test.go
+++ b/server/azure/monitor/resources_test.go
@@ -1,0 +1,251 @@
+package monitor_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureprovider "github.com/stackshy/cloudemu/v2/providers/azure"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+const apiVer = "?api-version=2018-03-01"
+
+func newMonitorServer(t *testing.T) (*httptest.Server, *azureprovider.Provider) {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		Monitor:         cloudP.Monitor,
+		VirtualMachines: cloudP.VirtualMachines,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts, cloudP
+}
+
+func doJSON(t *testing.T, ts *httptest.Server, method, url string, body string) (int, map[string]any) {
+	t.Helper()
+
+	var rdr io.Reader = http.NoBody
+	if body != "" {
+		rdr = bytes.NewBufferString(body)
+	}
+
+	req, _ := http.NewRequest(method, ts.URL+url, rdr)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+
+	out := map[string]any{}
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &out)
+	}
+
+	return resp.StatusCode, out
+}
+
+// TestMetricAlertPersistence covers finding 1: the full alert definition is
+// persisted and echoed on Get, not reduced to provisioningState.
+func TestMetricAlertPersistence(t *testing.T) {
+	ts, _ := newMonitorServer(t)
+
+	const url = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Insights/metricAlerts/cpu-alert" + apiVer
+
+	body := `{
+		"location": "global",
+		"tags": {"team": "sre"},
+		"properties": {
+			"description": "High CPU",
+			"severity": 2,
+			"enabled": true,
+			"scopes": ["/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/vm1"],
+			"evaluationFrequency": "PT1M",
+			"windowSize": "PT5M",
+			"criteria": {
+				"odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+				"allOf": [{
+					"name": "cpu",
+					"metricName": "Percentage CPU",
+					"metricNamespace": "Microsoft.Compute/virtualMachines",
+					"operator": "GreaterThan",
+					"threshold": 80,
+					"timeAggregation": "Average"
+				}]
+			}
+		}
+	}`
+
+	if code, _ := doJSON(t, ts, http.MethodPut, url, body); code != http.StatusCreated {
+		t.Fatalf("PUT status = %d, want 201", code)
+	}
+
+	code, got := doJSON(t, ts, http.MethodGet, url, "")
+	if code != http.StatusOK {
+		t.Fatalf("GET status = %d, want 200", code)
+	}
+
+	props, _ := got["properties"].(map[string]any)
+	if props["description"] != "High CPU" {
+		t.Errorf("description = %v, want High CPU", props["description"])
+	}
+
+	if props["severity"].(float64) != 2 {
+		t.Errorf("severity = %v, want 2", props["severity"])
+	}
+
+	if props["windowSize"] != "PT5M" {
+		t.Errorf("windowSize = %v, want PT5M", props["windowSize"])
+	}
+
+	if props["scopes"] == nil || props["criteria"] == nil {
+		t.Errorf("scopes/criteria dropped: %+v", props)
+	}
+
+	if tags, _ := got["tags"].(map[string]any); tags["team"] != "sre" {
+		t.Errorf("tags dropped: %+v", got["tags"])
+	}
+}
+
+// TestMetricAlertEvaluatesMetric covers finding 1: the named metric is actually
+// evaluated. A VM pushes Percentage CPU=25; an alert with threshold 20 (>) must
+// go to ALARM.
+func TestMetricAlertEvaluatesMetric(t *testing.T) {
+	ts, cloudP := newMonitorServer(t)
+	ctx := context.Background()
+
+	const url = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Insights/metricAlerts/cpu-hot" + apiVer
+
+	body := `{
+		"location": "global",
+		"properties": {
+			"windowSize": "PT5M",
+			"criteria": {"allOf": [{
+				"metricName": "Percentage CPU",
+				"metricNamespace": "Microsoft.Compute/virtualMachines",
+				"operator": "GreaterThan",
+				"threshold": 20,
+				"timeAggregation": "Average"
+			}]}
+		}
+	}`
+
+	if code, _ := doJSON(t, ts, http.MethodPut, url, body); code != http.StatusCreated {
+		t.Fatalf("PUT status = %d, want 201", code)
+	}
+
+	// The VM pushes Percentage CPU=25 datapoints, which drives the just-created
+	// alarm's evaluation over its metric.
+	if _, err := cloudP.VirtualMachines.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "img-1", InstanceType: "Standard_B1s", Region: "eastus",
+	}, 1); err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	alarms, err := cloudP.Monitor.DescribeAlarms(ctx, []string{"cpu-hot"})
+	if err != nil {
+		t.Fatalf("DescribeAlarms: %v", err)
+	}
+
+	if len(alarms) != 1 {
+		t.Fatalf("alarms = %d, want 1 (metric not registered with driver)", len(alarms))
+	}
+
+	if alarms[0].State != "ALARM" {
+		t.Fatalf("alarm state = %q, want ALARM (metric not evaluated)", alarms[0].State)
+	}
+}
+
+// TestMetricAlertListEmptyIsArray covers finding 10: an empty list is
+// {"value":[]}, never {"value":null}.
+func TestMetricAlertListEmptyIsArray(t *testing.T) {
+	ts, _ := newMonitorServer(t)
+
+	const url = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Insights/metricAlerts" + apiVer
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+url, http.NoBody)
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(raw), `"value":[]`) {
+		t.Fatalf("empty list body = %s, want value:[]", raw)
+	}
+}
+
+func TestActionGroupCRUD(t *testing.T) {
+	ts, _ := newMonitorServer(t)
+
+	const url = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Insights/actionGroups/ag1" + apiVer
+
+	body := `{"location":"Global","properties":{"groupShortName":"sample","enabled":true,
+		"emailReceivers":[{"name":"oncall","emailAddress":"a@b.com"}]}}`
+
+	if code, _ := doJSON(t, ts, http.MethodPut, url, body); code != http.StatusCreated {
+		t.Fatalf("PUT status = %d, want 201", code)
+	}
+
+	code, got := doJSON(t, ts, http.MethodGet, url, "")
+	if code != http.StatusOK {
+		t.Fatalf("GET status = %d, want 200", code)
+	}
+
+	props, _ := got["properties"].(map[string]any)
+	if props["groupShortName"] != "sample" {
+		t.Errorf("groupShortName = %v, want sample", props["groupShortName"])
+	}
+
+	if props["emailReceivers"] == nil {
+		t.Errorf("emailReceivers dropped")
+	}
+
+	if code, _ := doJSON(t, ts, http.MethodDelete, url, ""); code != http.StatusOK {
+		t.Errorf("DELETE status = %d, want 200", code)
+	}
+
+	if code, _ := doJSON(t, ts, http.MethodGet, url, ""); code != http.StatusNotFound {
+		t.Errorf("GET after delete = %d, want 404", code)
+	}
+}
+
+func TestActivityLogAlertCRUD(t *testing.T) {
+	ts, _ := newMonitorServer(t)
+
+	const url = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Insights/activityLogAlerts/ala1" + apiVer
+
+	body := `{"location":"Global","properties":{"enabled":true,
+		"scopes":["/subscriptions/sub-1"],
+		"condition":{"allOf":[{"field":"category","equals":"Administrative"}]}}}`
+
+	if code, _ := doJSON(t, ts, http.MethodPut, url, body); code != http.StatusCreated {
+		t.Fatalf("PUT status = %d, want 201", code)
+	}
+
+	code, got := doJSON(t, ts, http.MethodGet, url, "")
+	if code != http.StatusOK {
+		t.Fatalf("GET status = %d, want 200", code)
+	}
+
+	if props, _ := got["properties"].(map[string]any); props["condition"] == nil {
+		t.Errorf("condition dropped: %+v", got["properties"])
+	}
+}

--- a/server/azure/monitor/resources_test.go
+++ b/server/azure/monitor/resources_test.go
@@ -249,3 +249,18 @@ func TestActivityLogAlertCRUD(t *testing.T) {
 		t.Errorf("condition dropped: %+v", got["properties"])
 	}
 }
+
+// TestInsightsDeleteMissingIsNoContent asserts DELETE on a metricAlert,
+// actionGroup or activityLogAlert that does not exist returns 204 No Content
+// (idempotent), matching the Azure Monitor REST contract, not a 404.
+func TestInsightsDeleteMissingIsNoContent(t *testing.T) {
+	ts, _ := newMonitorServer(t)
+
+	for _, typ := range []string{"metricAlerts", "actionGroups", "activityLogAlerts"} {
+		url := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Insights/" + typ + "/nope" + apiVer
+
+		if code, body := doJSON(t, ts, http.MethodDelete, url, ""); code != http.StatusNoContent {
+			t.Errorf("DELETE missing %s = %d, want 204; body = %v", typ, code, body)
+		}
+	}
+}

--- a/server/azure/monitor/store.go
+++ b/server/azure/monitor/store.go
@@ -1,0 +1,82 @@
+package monitor
+
+import "sync"
+
+// armResource is a stored microsoft.insights ARM resource (metric alert, action
+// group, activity-log alert). The full request body is retained — location,
+// tags and the entire properties object — so a GET/LIST echoes back exactly
+// what the caller PUT, instead of a hardcoded stub. This is the fix for the
+// drift where every stored property was dropped and only provisioningState came
+// back.
+type armResource struct {
+	Location   string
+	Tags       map[string]string
+	Properties map[string]any
+}
+
+// resourceStore is a concurrency-safe map of resource-type to name to resource.
+type resourceStore struct {
+	mu sync.RWMutex
+	m  map[string]map[string]*armResource
+}
+
+func newResourceStore() *resourceStore {
+	return &resourceStore{m: make(map[string]map[string]*armResource)}
+}
+
+// set stores res under the (kind, name) key and reports whether an entry already
+// existed (so the caller can answer 200 vs 201).
+func (s *resourceStore) set(kind, name string, res *armResource) (existed bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	byName := s.m[kind]
+	if byName == nil {
+		byName = make(map[string]*armResource)
+		s.m[kind] = byName
+	}
+
+	_, existed = byName[name]
+	byName[name] = res
+
+	return existed
+}
+
+func (s *resourceStore) get(kind, name string) (*armResource, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	res, ok := s.m[kind][name]
+
+	return res, ok
+}
+
+func (s *resourceStore) delete(kind, name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	byName := s.m[kind]
+	if _, ok := byName[name]; !ok {
+		return false
+	}
+
+	delete(byName, name)
+
+	return true
+}
+
+// names returns the stored resource names for a kind, in the map's iteration
+// order. Callers that need determinism sort the result.
+func (s *resourceStore) all(kind string) map[string]*armResource {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	src := s.m[kind]
+	out := make(map[string]*armResource, len(src))
+
+	for k, v := range src {
+		out[k] = v
+	}
+
+	return out
+}

--- a/server/azure/monitor/types.go
+++ b/server/azure/monitor/types.go
@@ -1,39 +1,65 @@
 package monitor
 
-// ARM JSON shapes for microsoft.insights metric alerts.
+import "github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 
-type alertRequest struct {
+// resourceRequest is the inbound CreateOrUpdate body shared by every
+// microsoft.insights ARM resource type. The whole properties object is captured
+// as-is so it round-trips untouched.
+type resourceRequest struct {
 	Location   string            `json:"location"`
 	Tags       map[string]string `json:"tags,omitempty"`
-	Properties alertRequestProps `json:"properties"`
+	Properties map[string]any    `json:"properties"`
 }
 
-type alertRequestProps struct {
-	Description    string           `json:"description,omitempty"`
-	Severity       int              `json:"severity,omitempty"`
-	Enabled        bool             `json:"enabled,omitempty"`
-	Scopes         []string         `json:"scopes,omitempty"`
-	EvaluationFreq string           `json:"evaluationFrequency,omitempty"`
-	WindowSize     string           `json:"windowSize,omitempty"`
-	Criteria       map[string]any   `json:"criteria,omitempty"`
-	AutoMitigate   bool             `json:"autoMitigate,omitempty"`
-	Actions        []map[string]any `json:"actions,omitempty"`
+// resourceResponse is the ARM resource envelope.
+type resourceResponse struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties map[string]any    `json:"properties"`
 }
 
-type alertResponse struct {
-	ID         string             `json:"id"`
-	Name       string             `json:"name"`
-	Type       string             `json:"type"`
-	Location   string             `json:"location"`
-	Tags       map[string]string  `json:"tags,omitempty"`
-	Properties alertResponseProps `json:"properties"`
+// resourceListResponse is the ARM list envelope. Value is always a non-nil slice
+// so an empty list serializes as {"value":[]} rather than {"value":null}.
+type resourceListResponse struct {
+	Value []resourceResponse `json:"value"`
 }
 
-type alertResponseProps struct {
-	alertRequestProps
-	ProvisioningState string `json:"provisioningState"`
+// toResourceJSON renders a stored resource under the request's path scope.
+func toResourceJSON(rp *azurearm.ResourcePath, kind string, res *armResource) resourceResponse {
+	location := res.Location
+	if location == "" {
+		location = defaultLocation
+	}
+
+	props := res.Properties
+	if props == nil {
+		props = map[string]any{}
+	}
+
+	return resourceResponse{
+		ID:         azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, kind, rp.ResourceName),
+		Name:       rp.ResourceName,
+		Type:       armType(kind),
+		Location:   location,
+		Tags:       res.Tags,
+		Properties: props,
+	}
 }
 
-type alertListResponse struct {
-	Value []alertResponse `json:"value"`
+// withProvisioningState injects a terminal provisioningState into a metric
+// alert's properties (real metricAlerts carry provisioningState=Succeeded), so a
+// state-refresh read sees a settled resource.
+func withProvisioningState(props map[string]any) map[string]any {
+	if props == nil {
+		props = map[string]any{}
+	}
+
+	if _, ok := props["provisioningState"]; !ok {
+		props["provisioningState"] = "Succeeded"
+	}
+
+	return props
 }

--- a/server/azure/resourcegraph/handler.go
+++ b/server/azure/resourcegraph/handler.go
@@ -1,7 +1,9 @@
 package resourcegraph
 
 import (
+	"encoding/base64"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
@@ -68,8 +70,9 @@ type queryRequest struct {
 	Subscriptions []string `json:"subscriptions"`
 	Query         string   `json:"query"`
 	Options       struct {
-		Top  int `json:"$top"`
-		Skip int `json:"$skip"`
+		Top       int    `json:"$top"`
+		Skip      int    `json:"$skip"`
+		SkipToken string `json:"$skipToken"`
 	} `json:"options"`
 }
 
@@ -107,20 +110,31 @@ func (h *Handler) queryResources(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	results = applyLimit(results, parsed.Limit, req.Options.Top, req.Options.Skip)
+	// The KQL `| limit N` caps the matching set; $top/$skip/$skipToken page over
+	// it. totalRecords is the size of that matching set (not the page), so a
+	// paged client can see how many rows exist beyond the current page.
+	matched := applyKQLLimit(results, parsed.Limit)
+	skip := effectiveSkip(req.Options.Skip, req.Options.SkipToken)
+	page := pageResults(matched, req.Options.Top, skip)
 
-	data := make([]map[string]any, 0, len(results))
-	for i := range results {
-		data = append(data, resourceToWire(&results[i], subscription))
+	data := make([]map[string]any, 0, len(page))
+	for i := range page {
+		data = append(data, resourceToWire(&page[i], subscription))
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, map[string]any{
-		"totalRecords":    len(data),
+	resp := map[string]any{
+		"totalRecords":    len(matched),
 		"count":           len(data),
 		"data":            data,
 		"facets":          []any{},
 		"resultTruncated": "false",
-	})
+	}
+
+	if next := skip + len(page); next < len(matched) {
+		resp["$skipToken"] = encodeSkipToken(next)
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, resp)
 }
 
 // queryResourcesHistory returns the current inventory as a single point-in-time
@@ -182,28 +196,67 @@ func emptyResponse() map[string]any {
 	}
 }
 
-// applyLimit applies the caller-specified $top/$skip and any `| limit N` /
-// `| take N` from the KQL. The smaller of the two limits wins; $skip is
-// applied before slicing.
-func applyLimit(results []resourcediscovery.Resource, kqlLimit, top, skip int) []resourcediscovery.Resource {
-	if skip > 0 {
-		if skip >= len(results) {
-			return nil
-		}
-
-		results = results[skip:]
-	}
-
-	limit := top
-	if kqlLimit > 0 && (limit == 0 || kqlLimit < limit) {
-		limit = kqlLimit
-	}
-
-	if limit > 0 && limit < len(results) {
-		results = results[:limit]
+// applyKQLLimit caps the result set to the `| limit N` / `| take N` from the KQL
+// query. This is the query's own row cap, distinct from the $top paging control,
+// so it defines the total record count a client pages over.
+func applyKQLLimit(results []resourcediscovery.Resource, kqlLimit int) []resourcediscovery.Resource {
+	if kqlLimit > 0 && kqlLimit < len(results) {
+		return results[:kqlLimit]
 	}
 
 	return results
+}
+
+// pageResults returns the $top/$skip page of the matching set. skip past the end
+// yields an empty page; a top of 0 means no page cap.
+func pageResults(matched []resourcediscovery.Resource, top, skip int) []resourcediscovery.Resource {
+	if skip >= len(matched) {
+		return nil
+	}
+
+	page := matched[skip:]
+
+	if top > 0 && top < len(page) {
+		page = page[:top]
+	}
+
+	return page
+}
+
+// effectiveSkip resolves the paging offset: a $skipToken (an opaque continuation
+// cursor this handler issued) wins over a raw $skip.
+func effectiveSkip(skip int, token string) int {
+	if token != "" {
+		if n, ok := decodeSkipToken(token); ok {
+			return n
+		}
+	}
+
+	if skip > 0 {
+		return skip
+	}
+
+	return 0
+}
+
+// encodeSkipToken / decodeSkipToken wrap the next-page offset in an opaque
+// base64 cursor, matching how real Resource Graph returns $skipToken.
+func encodeSkipToken(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}
+
+func decodeSkipToken(token string) (int, bool) {
+	raw, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return 0, false
+	}
+
+	n, err := strconv.Atoi(string(raw))
+	if err != nil || n < 0 {
+		return 0, false
+	}
+
+	return n, true
 }
 
 // resourceToWire formats one Resource into the Azure Resource Graph row shape.

--- a/server/azure/resourcegraph/pagination_test.go
+++ b/server/azure/resourcegraph/pagination_test.go
@@ -1,0 +1,71 @@
+// Real-SDK pagination round-trip: verifies totalRecords reflects the full
+// result set and that $skipToken pages through the remainder (finding 9).
+
+package resourcegraph_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func TestSDKResourceGraph_Pagination(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	for _, name := range []string{"b1", "b2", "b3", "b4", "b5"} {
+		require.NoError(t, cloudP.BlobStorage.CreateBucket(ctx, name))
+	}
+
+	srv := azureserver.New(azureserver.Drivers{
+		BlobStorage:       cloudP.BlobStorage,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		SubscriptionID:    "123456789012",
+	})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newResourceGraphClient(t, ts)
+
+	first, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+		Query:   to.Ptr("Resources | where type == 'microsoft.storage/storageaccounts'"),
+		Options: &armresourcegraph.QueryRequestOptions{Top: to.Ptr(int32(2))},
+	}, nil)
+	require.NoError(t, err)
+
+	page1 := first.Data.([]any)
+	assert.Len(t, page1, 2, "page holds $top rows")
+
+	require.NotNil(t, first.TotalRecords)
+	assert.Equal(t, int64(5), *first.TotalRecords, "totalRecords is the full set, not the page")
+
+	require.NotNil(t, first.SkipToken, "a truncated result must return a $skipToken")
+
+	// Page through the remainder with the returned skip token.
+	seen := len(page1)
+	token := first.SkipToken
+
+	for token != nil {
+		next, nerr := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type == 'microsoft.storage/storageaccounts'"),
+			Options: &armresourcegraph.QueryRequestOptions{
+				Top:       to.Ptr(int32(2)),
+				SkipToken: token,
+			},
+		}, nil)
+		require.NoError(t, nerr)
+
+		seen += len(next.Data.([]any))
+		token = next.SkipToken
+	}
+
+	assert.Equal(t, 5, seen, "skipToken paging reaches every row exactly once")
+}


### PR DESCRIPTION
## Summary

Fixes a batch of Azure Monitor / Log Analytics / Resource Graph e2e bugs found by a real-user SDK sweep. No driver interface changed (Azure-only ARM state lives in the wire handlers), so no shared-driver ripple to AWS/GCP and no docs/coverage regeneration.

## Azure Monitor (`server/azure/monitor`)

- **MetricAlerts persistence (BLOCKER, finding 1):** the handler no longer builds a hardcoded `AlarmConfig` and drops every stored property. The full alert definition (description/severity/enabled/scopes/windowSize/criteria/tags) is persisted and echoed on Get/List, and the named metric is registered with the monitoring driver (criteria → operator/threshold/timeAggregation/windowSize) so the alarm actually evaluates.
- **ActionGroups + ActivityLogAlerts (HIGH, finding 2):** full CRUD, previously 501.
- **Metrics data plane (HIGH, finding 3):** `Microsoft.Insights/metrics` and `metricDefinitions` now serve the timeseries the compute mock pushes (e.g. `Percentage CPU`), previously 501. Extension-resource paths are claimed before the underlying resource's handler.
- **DiagnosticSettings (HIGH, finding 2):** CRUD on any resource URI, routing logs to a workspace.
- **Empty MetricAlerts list (LOW, finding 10):** `{"value":[]}` instead of `{"value":null}`.

## Log Analytics (`server/azure/loganalytics`)

- **Workspace location (HIGH, finding 4):** persisted and returned on Get (was nil).
- **Sub-resource routing (HIGH, finding 5):** SavedSearches/Tables/DataExports are stored and served from their own store instead of being misrouted to the workspace body.
- **SharedKeys (MEDIUM, finding 6):** `GetSharedKeys` returns stable primary/secondary ingestion keys (was 405).
- **customerId (MEDIUM, finding 8):** a real, stable GUID derived from the workspace id (was the full ARM id).
- **SKU default (LOW, finding 11):** `PerGB2018` synthesized when omitted.

## Resource Graph (`server/azure/resourcegraph`)

- **Pagination (MEDIUM, finding 9):** `totalRecords` now reflects the full matching set (not the page), and a `$skipToken` is returned and honored so a client can page the remainder.

## Deferred

- **Data-plane KQL log query (MEDIUM, finding 7):** a real KQL engine over ingested log tables is genuinely large greenfield (distinct from the resource-graph KQL parser); deferred rather than stubbed.

## Tests

Real-SDK round-trips (`armoperationalinsights` WorkspacesClient/SavedSearchesClient/SharedKeysClient, `armresourcegraph`) plus raw-HTTP wire assertions for the Monitor ARM + data-plane surfaces, including a VM→metrics→alarm evaluation path. Gates: `go build ./...`, `go test ./server/azure/... ./providers/azure/...`, and `golangci-lint` on changed packages all green.
