### PR TITLE
fix(azure-acr-aks): ACR ARM management plane (registry/listCredentials/webhooks/replications), AKS cluster+nodepool lifecycle/kubeconfig

### DIFF
--- a/docs/coverage/aws/ecr.md
+++ b/docs/coverage/aws/ecr.md
@@ -32,7 +32,7 @@ AzureRegistryManager is the Azure-specific ACR management-plane surface,
 
 | Operation | Description |
 | --- | --- |
-| `CreateOrUpdateRegistry` |  |
+| `CreateOrUpdateRegistry` | CreateOrUpdateRegistry is the ARM PUT (full create-or-replace). It reports |
 | `CreateOrUpdateReplication` |  |
 | `CreateOrUpdateWebhook` |  |
 | `DeleteRegistry` |  |
@@ -47,6 +47,9 @@ AzureRegistryManager is the Azure-specific ACR management-plane surface,
 | `ListReplications` |  |
 | `ListWebhooks` |  |
 | `RegenerateRegistryCredential` |  |
+| `UpdateRegistry` | UpdateRegistry is the ARM PATCH (partial update). It merges upd onto the |
+| `UpdateReplication` |  |
+| `UpdateWebhook` |  |
 
 ### AzureRepositoryWriter
 

--- a/docs/coverage/aws/ecr.md
+++ b/docs/coverage/aws/ecr.md
@@ -22,6 +22,40 @@ AWS's `containerregistry` service · portable interface `driver.ContainerRegistr
 | `StartImageScan` | Image scanning |
 | `TagImage` |  |
 
+## Optional capabilities
+
+Discovered by type assertion; only some providers implement these.
+
+### AzureRegistryManager
+
+AzureRegistryManager is the Azure-specific ACR management-plane surface,
+
+| Operation | Description |
+| --- | --- |
+| `CreateOrUpdateRegistry` |  |
+| `CreateOrUpdateReplication` |  |
+| `CreateOrUpdateWebhook` |  |
+| `DeleteRegistry` |  |
+| `DeleteReplication` |  |
+| `DeleteWebhook` |  |
+| `GetRegistry` |  |
+| `GetReplication` |  |
+| `GetWebhook` |  |
+| `ListRegistries` |  |
+| `ListRegistryCredentials` |  |
+| `ListRegistryUsages` |  |
+| `ListReplications` |  |
+| `ListWebhooks` |  |
+| `RegenerateRegistryCredential` |  |
+
+### AzureRepositoryWriter
+
+AzureRepositoryWriter is the Azure-specific ACR data-plane surface for
+
+| Operation | Description |
+| --- | --- |
+| `DeleteTag` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/azure/acr.md
+++ b/docs/coverage/azure/acr.md
@@ -22,6 +22,40 @@ Azure's `containerregistry` service · portable interface `driver.ContainerRegis
 | `StartImageScan` | Image scanning |
 | `TagImage` |  |
 
+## Optional capabilities
+
+Discovered by type assertion; only some providers implement these.
+
+### AzureRegistryManager
+
+AzureRegistryManager is the Azure-specific ACR management-plane surface,
+
+| Operation | Description |
+| --- | --- |
+| `CreateOrUpdateRegistry` |  |
+| `CreateOrUpdateReplication` |  |
+| `CreateOrUpdateWebhook` |  |
+| `DeleteRegistry` |  |
+| `DeleteReplication` |  |
+| `DeleteWebhook` |  |
+| `GetRegistry` |  |
+| `GetReplication` |  |
+| `GetWebhook` |  |
+| `ListRegistries` |  |
+| `ListRegistryCredentials` |  |
+| `ListRegistryUsages` |  |
+| `ListReplications` |  |
+| `ListWebhooks` |  |
+| `RegenerateRegistryCredential` |  |
+
+### AzureRepositoryWriter
+
+AzureRepositoryWriter is the Azure-specific ACR data-plane surface for
+
+| Operation | Description |
+| --- | --- |
+| `DeleteTag` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/azure/acr.md
+++ b/docs/coverage/azure/acr.md
@@ -32,7 +32,7 @@ AzureRegistryManager is the Azure-specific ACR management-plane surface,
 
 | Operation | Description |
 | --- | --- |
-| `CreateOrUpdateRegistry` |  |
+| `CreateOrUpdateRegistry` | CreateOrUpdateRegistry is the ARM PUT (full create-or-replace). It reports |
 | `CreateOrUpdateReplication` |  |
 | `CreateOrUpdateWebhook` |  |
 | `DeleteRegistry` |  |
@@ -47,6 +47,9 @@ AzureRegistryManager is the Azure-specific ACR management-plane surface,
 | `ListReplications` |  |
 | `ListWebhooks` |  |
 | `RegenerateRegistryCredential` |  |
+| `UpdateRegistry` | UpdateRegistry is the ARM PATCH (partial update). It merges upd onto the |
+| `UpdateReplication` |  |
+| `UpdateWebhook` |  |
 
 ### AzureRepositoryWriter
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -2553,7 +2553,8 @@
         "doc": "AzureRegistryManager is the Azure-specific ACR management-plane surface,",
         "operations": [
           {
-            "name": "CreateOrUpdateRegistry"
+            "name": "CreateOrUpdateRegistry",
+            "doc": "CreateOrUpdateRegistry is the ARM PUT (full create-or-replace). It reports"
           },
           {
             "name": "CreateOrUpdateReplication"
@@ -2596,6 +2597,16 @@
           },
           {
             "name": "RegenerateRegistryCredential"
+          },
+          {
+            "name": "UpdateRegistry",
+            "doc": "UpdateRegistry is the ARM PATCH (partial update). It merges upd onto the"
+          },
+          {
+            "name": "UpdateReplication"
+          },
+          {
+            "name": "UpdateWebhook"
           }
         ]
       },

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -2547,6 +2547,68 @@
         "name": "TagImage"
       }
     ],
+    "optionalCapabilities": [
+      {
+        "name": "AzureRegistryManager",
+        "doc": "AzureRegistryManager is the Azure-specific ACR management-plane surface,",
+        "operations": [
+          {
+            "name": "CreateOrUpdateRegistry"
+          },
+          {
+            "name": "CreateOrUpdateReplication"
+          },
+          {
+            "name": "CreateOrUpdateWebhook"
+          },
+          {
+            "name": "DeleteRegistry"
+          },
+          {
+            "name": "DeleteReplication"
+          },
+          {
+            "name": "DeleteWebhook"
+          },
+          {
+            "name": "GetRegistry"
+          },
+          {
+            "name": "GetReplication"
+          },
+          {
+            "name": "GetWebhook"
+          },
+          {
+            "name": "ListRegistries"
+          },
+          {
+            "name": "ListRegistryCredentials"
+          },
+          {
+            "name": "ListRegistryUsages"
+          },
+          {
+            "name": "ListReplications"
+          },
+          {
+            "name": "ListWebhooks"
+          },
+          {
+            "name": "RegenerateRegistryCredential"
+          }
+        ]
+      },
+      {
+        "name": "AzureRepositoryWriter",
+        "doc": "AzureRepositoryWriter is the Azure-specific ACR data-plane surface for",
+        "operations": [
+          {
+            "name": "DeleteTag"
+          }
+        ]
+      }
+    ],
     "providers": {
       "aws": "ECR",
       "azure": "ACR",

--- a/docs/coverage/gcp/artifactregistry.md
+++ b/docs/coverage/gcp/artifactregistry.md
@@ -22,6 +22,40 @@ GCP's `containerregistry` service · portable interface `driver.ContainerRegistr
 | `StartImageScan` | Image scanning |
 | `TagImage` |  |
 
+## Optional capabilities
+
+Discovered by type assertion; only some providers implement these.
+
+### AzureRegistryManager
+
+AzureRegistryManager is the Azure-specific ACR management-plane surface,
+
+| Operation | Description |
+| --- | --- |
+| `CreateOrUpdateRegistry` |  |
+| `CreateOrUpdateReplication` |  |
+| `CreateOrUpdateWebhook` |  |
+| `DeleteRegistry` |  |
+| `DeleteReplication` |  |
+| `DeleteWebhook` |  |
+| `GetRegistry` |  |
+| `GetReplication` |  |
+| `GetWebhook` |  |
+| `ListRegistries` |  |
+| `ListRegistryCredentials` |  |
+| `ListRegistryUsages` |  |
+| `ListReplications` |  |
+| `ListWebhooks` |  |
+| `RegenerateRegistryCredential` |  |
+
+### AzureRepositoryWriter
+
+AzureRepositoryWriter is the Azure-specific ACR data-plane surface for
+
+| Operation | Description |
+| --- | --- |
+| `DeleteTag` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/gcp/artifactregistry.md
+++ b/docs/coverage/gcp/artifactregistry.md
@@ -32,7 +32,7 @@ AzureRegistryManager is the Azure-specific ACR management-plane surface,
 
 | Operation | Description |
 | --- | --- |
-| `CreateOrUpdateRegistry` |  |
+| `CreateOrUpdateRegistry` | CreateOrUpdateRegistry is the ARM PUT (full create-or-replace). It reports |
 | `CreateOrUpdateReplication` |  |
 | `CreateOrUpdateWebhook` |  |
 | `DeleteRegistry` |  |
@@ -47,6 +47,9 @@ AzureRegistryManager is the Azure-specific ACR management-plane surface,
 | `ListReplications` |  |
 | `ListWebhooks` |  |
 | `RegenerateRegistryCredential` |  |
+| `UpdateRegistry` | UpdateRegistry is the ARM PATCH (partial update). It merges upd onto the |
+| `UpdateReplication` |  |
+| `UpdateWebhook` |  |
 
 ### AzureRepositoryWriter
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.3
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3 v3.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcogni
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.8.0/go.mod h1:BElPQ/GZtrdQ2i5uDZw3OKLE1we75W0AEWyeBR1TWQA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0 h1:LkHbJbgF3YyvC53aqYGR+wWQDn2Rdp9AQdGndf9QvY4=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0/go.mod h1:QyiQdW4f4/BIfB8ZutZ2s+28RAgfa/pT+zS++ZHyM1I=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0 h1:DWlwvVV5r/Wy1561nZ3wrpI1/vDIBRY/Wd1HWaRBZWA=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0/go.mod h1:E7ltexgRDmeJ0fJWv0D/HLwY2xbDdN+uv+X2uZtOx3w=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5 v5.0.0 h1:5n7dPVqsWfVKw+ZiEKSd3Kzu7gwBkbEBkeXb8rgaE9Q=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5 v5.0.0/go.mod h1:HcZY0PHPo/7d75p99lB6lK0qYOP4vLRJUBpiehYXtLQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0 h1:xkWEcbsnJWid3rOf/S/LOHy1I55JA+4kw/f8Tnm+Onc=

--- a/internal/idgen/idgen.go
+++ b/internal/idgen/idgen.go
@@ -3,8 +3,30 @@ package idgen
 
 import (
 	"fmt"
+	"hash/fnv"
 	"sync/atomic"
 )
+
+// guidNodeMask isolates the low 48 bits used as a GUID's node field.
+const guidNodeMask = 0xffffffffffff
+
+// SyntheticGUID derives a deterministic GUID-shaped string from seed. The value
+// is synthetic (a stand-in for an Azure principal/tenant id), not a real
+// security identifier — the same seed always yields the same GUID so tests are
+// stable.
+func SyntheticGUID(seed string) string {
+	h1 := fnv.New64a()
+	_, _ = h1.Write([]byte(seed))
+	a := h1.Sum64()
+
+	h2 := fnv.New64a()
+	_, _ = h2.Write([]byte(seed + "#salt"))
+	b := h2.Sum64()
+
+	//nolint:gosec,mnd // intentional narrowing + GUID field-width shifts
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		uint32(a>>32), uint16(a>>16), uint16(a), uint16(b>>48), b&guidNodeMask)
+}
 
 //nolint:gochecknoglobals // counter must be a package-level variable for atomic operations across all ID generators
 var counter uint64

--- a/providers/azure/acr/acr.go
+++ b/providers/azure/acr/acr.go
@@ -52,6 +52,12 @@ type Mock struct {
 	repos      *memstore.Store[*repoData]
 	opts       *config.Options
 	monitoring mondriver.Monitoring
+
+	// registries holds the ARM management-plane registry resources, keyed by
+	// "{rg}/{name}". Distinct from repos (the data-plane catalog).
+	registries   *memstore.Store[*registryData]
+	webhooks     *memstore.Store[*driver.AzureWebhook]
+	replications *memstore.Store[*driver.AzureReplication]
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -84,8 +90,11 @@ func (m *Mock) emitMetric(repoName string, metrics map[string]float64) {
 // New creates a new ACR mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		repos: memstore.New[*repoData](),
-		opts:  opts,
+		repos:        memstore.New[*repoData](),
+		opts:         opts,
+		registries:   memstore.New[*registryData](),
+		webhooks:     memstore.New[*driver.AzureWebhook](),
+		replications: memstore.New[*driver.AzureReplication](),
 	}
 }
 
@@ -309,6 +318,38 @@ func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag stri
 	rd.info.ImageCount = rd.images.Len()
 
 	return nil
+}
+
+// DeleteTag removes a single tag from a repository, leaving the underlying
+// manifest and any other tags on it intact. This mirrors ACR's data-plane
+// DELETE /acr/v1/{repo}/_tags/{tag}, which untags rather than deleting the
+// manifest.
+func (m *Mock) DeleteTag(_ context.Context, repository, tag string) error {
+	if tag == "" {
+		return errors.New(errors.InvalidArgument, "tag cannot be empty")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	all := rd.images.All()
+	for d, img := range all {
+		if !hasTag(img.detail.Tags, tag) {
+			continue
+		}
+
+		img.detail.Tags = removeTag(img.detail.Tags, tag)
+		rd.images.Set(d, img)
+
+		return nil
+	}
+
+	return errors.Newf(errors.NotFound, "tag %q not found in repository %q", tag, repository)
 }
 
 // PutLifecyclePolicy sets a lifecycle policy on an ACR repository.

--- a/providers/azure/acr/registry.go
+++ b/providers/azure/acr/registry.go
@@ -42,16 +42,18 @@ func subResourceKey(rg, registry, name string) string {
 	return rg + "/" + registry + "/" + name
 }
 
-// CreateOrUpdateRegistry creates or replaces an ACR registry (ARM PUT).
+// CreateOrUpdateRegistry creates or replaces an ACR registry (ARM PUT). It
+// reports whether the registry was newly created (vs. replaced) so the wire
+// layer can distinguish 201 Created from 200 OK.
 func (m *Mock) CreateOrUpdateRegistry(
 	_ context.Context, rg, name string, cfg driver.AzureRegistryConfig,
-) (*driver.AzureRegistry, error) {
+) (*driver.AzureRegistry, bool, error) {
 	if name == "" {
-		return nil, errors.New(errors.InvalidArgument, "registry name is required")
+		return nil, false, errors.New(errors.InvalidArgument, "registry name is required")
 	}
 
 	if rg == "" {
-		return nil, errors.New(errors.InvalidArgument, "resource group is required")
+		return nil, false, errors.New(errors.InvalidArgument, "resource group is required")
 	}
 
 	m.mu.Lock()
@@ -81,6 +83,47 @@ func (m *Mock) CreateOrUpdateRegistry(
 	rd.reg.ProvisioningState = registryProvisioned
 	rd.reg.Tags = copyTags(cfg.Tags)
 	applyIdentity(&rd.reg, cfg.IdentityType, rg, name)
+
+	m.registries.Set(key, rd)
+
+	out := rd.reg
+
+	return &out, !existing, nil
+}
+
+// UpdateRegistry applies a partial update to an existing ACR registry (ARM
+// PATCH). Only fields present in upd are overwritten; everything else is
+// preserved. A missing registry is a NotFound.
+func (m *Mock) UpdateRegistry(
+	_ context.Context, rg, name string, upd driver.AzureRegistryUpdate,
+) (*driver.AzureRegistry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := registryStoreKey(rg, name)
+
+	rd, ok := m.registries.Get(key)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "registry %q not found in resource group %q", name, rg)
+	}
+
+	if upd.Tags != nil {
+		rd.reg.Tags = copyTags(upd.Tags)
+	}
+
+	if upd.SKUName != nil {
+		sku := defaultIfEmpty(*upd.SKUName, defaultRegistrySKU)
+		rd.reg.SKUName = sku
+		rd.reg.SKUTier = skuTier(sku)
+	}
+
+	if upd.AdminUserEnabled != nil {
+		rd.reg.AdminUserEnabled = *upd.AdminUserEnabled
+	}
+
+	if upd.IdentityType != nil {
+		applyIdentity(&rd.reg, *upd.IdentityType, rg, name)
+	}
 
 	m.registries.Set(key, rd)
 
@@ -284,22 +327,27 @@ func fnvSalted(seed string) uint64 {
 	return h.Sum64()
 }
 
-// CreateOrUpdateWebhook creates or replaces a registry webhook.
+// CreateOrUpdateWebhook creates or replaces a registry webhook (ARM PUT). It
+// reports whether the webhook was newly created so the wire layer can return
+// 201 Created vs 200 OK.
 //
 //nolint:gocritic // cfg mirrors the driver interface's value-type config; pointer would invite caller mutation.
 func (m *Mock) CreateOrUpdateWebhook(
 	_ context.Context, rg, registry, name string, cfg driver.AzureWebhookConfig,
-) (*driver.AzureWebhook, error) {
+) (*driver.AzureWebhook, bool, error) {
 	if name == "" {
-		return nil, errors.New(errors.InvalidArgument, "webhook name is required")
+		return nil, false, errors.New(errors.InvalidArgument, "webhook name is required")
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if !m.registries.Has(registryStoreKey(rg, registry)) {
-		return nil, errors.Newf(errors.NotFound, "registry %q not found in resource group %q", registry, rg)
+		return nil, false, errors.Newf(errors.NotFound, "registry %q not found in resource group %q", registry, rg)
 	}
+
+	key := subResourceKey(rg, registry, name)
+	_, existing := m.webhooks.Get(key)
 
 	wh := &driver.AzureWebhook{
 		Name:              name,
@@ -315,7 +363,54 @@ func (m *Mock) CreateOrUpdateWebhook(
 		ProvisioningState: registryProvisioned,
 	}
 
-	m.webhooks.Set(subResourceKey(rg, registry, name), wh)
+	m.webhooks.Set(key, wh)
+
+	out := *wh
+
+	return &out, !existing, nil
+}
+
+// UpdateWebhook applies a partial update to an existing registry webhook (ARM
+// PATCH). Only fields present in upd are overwritten. A missing webhook is a
+// NotFound.
+func (m *Mock) UpdateWebhook(
+	_ context.Context, rg, registry, name string, upd driver.AzureWebhookUpdate,
+) (*driver.AzureWebhook, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := subResourceKey(rg, registry, name)
+
+	wh, ok := m.webhooks.Get(key)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "webhook %q not found on registry %q", name, registry)
+	}
+
+	if upd.Tags != nil {
+		wh.Tags = copyTags(upd.Tags)
+	}
+
+	if upd.ServiceURI != nil {
+		wh.ServiceURI = *upd.ServiceURI
+	}
+
+	if upd.Actions != nil {
+		wh.Actions = append([]string(nil), upd.Actions...)
+	}
+
+	if upd.Scope != nil {
+		wh.Scope = *upd.Scope
+	}
+
+	if upd.Status != nil {
+		wh.Status = *upd.Status
+	}
+
+	if upd.CustomHeaders != nil {
+		wh.CustomHeaders = copyTags(upd.CustomHeaders)
+	}
+
+	m.webhooks.Set(key, wh)
 
 	out := *wh
 
@@ -373,20 +468,25 @@ func (m *Mock) ListWebhooks(_ context.Context, rg, registry string) ([]driver.Az
 	return out, nil
 }
 
-// CreateOrUpdateReplication creates or replaces a geo-replication.
+// CreateOrUpdateReplication creates or replaces a geo-replication (ARM PUT). It
+// reports whether the replication was newly created so the wire layer can
+// return 201 Created vs 200 OK.
 func (m *Mock) CreateOrUpdateReplication(
 	_ context.Context, rg, registry, name string, cfg driver.AzureReplicationConfig,
-) (*driver.AzureReplication, error) {
+) (*driver.AzureReplication, bool, error) {
 	if name == "" {
-		return nil, errors.New(errors.InvalidArgument, "replication name is required")
+		return nil, false, errors.New(errors.InvalidArgument, "replication name is required")
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if !m.registries.Has(registryStoreKey(rg, registry)) {
-		return nil, errors.Newf(errors.NotFound, "registry %q not found in resource group %q", registry, rg)
+		return nil, false, errors.Newf(errors.NotFound, "registry %q not found in resource group %q", registry, rg)
 	}
+
+	key := subResourceKey(rg, registry, name)
+	_, existing := m.replications.Get(key)
 
 	rep := &driver.AzureReplication{
 		Name:                  name,
@@ -399,7 +499,38 @@ func (m *Mock) CreateOrUpdateReplication(
 		Status:                "Ready",
 	}
 
-	m.replications.Set(subResourceKey(rg, registry, name), rep)
+	m.replications.Set(key, rep)
+
+	out := *rep
+
+	return &out, !existing, nil
+}
+
+// UpdateReplication applies a partial update to an existing geo-replication
+// (ARM PATCH). Only fields present in upd are overwritten. A missing
+// replication is a NotFound.
+func (m *Mock) UpdateReplication(
+	_ context.Context, rg, registry, name string, upd driver.AzureReplicationUpdate,
+) (*driver.AzureReplication, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := subResourceKey(rg, registry, name)
+
+	rep, ok := m.replications.Get(key)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "replication %q not found on registry %q", name, registry)
+	}
+
+	if upd.Tags != nil {
+		rep.Tags = copyTags(upd.Tags)
+	}
+
+	if upd.RegionEndpointEnabled != nil {
+		rep.RegionEndpointEnabled = *upd.RegionEndpointEnabled
+	}
+
+	m.replications.Set(key, rep)
 
 	out := *rep
 

--- a/providers/azure/acr/registry.go
+++ b/providers/azure/acr/registry.go
@@ -1,0 +1,458 @@
+package acr
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+const (
+	defaultRegistrySKU  = "Standard"
+	classicSKU          = "Classic"
+	registryProvisioned = "Succeeded"
+	// emulatorTenantID is the single Azure AD directory all emulated resources
+	// belong to.
+	emulatorTenantID = "11111111-1111-1111-1111-111111111111"
+	identityNone     = "None"
+)
+
+// Compile-time checks that Mock satisfies the Azure-specific optional surfaces.
+var (
+	_ driver.AzureRegistryManager  = (*Mock)(nil)
+	_ driver.AzureRepositoryWriter = (*Mock)(nil)
+)
+
+// registryData is the stored ARM registry plus its admin credential pair.
+type registryData struct {
+	reg       driver.AzureRegistry
+	password  string
+	password2 string
+}
+
+func registryStoreKey(rg, name string) string {
+	return rg + "/" + name
+}
+
+func subResourceKey(rg, registry, name string) string {
+	return rg + "/" + registry + "/" + name
+}
+
+// CreateOrUpdateRegistry creates or replaces an ACR registry (ARM PUT).
+func (m *Mock) CreateOrUpdateRegistry(
+	_ context.Context, rg, name string, cfg driver.AzureRegistryConfig,
+) (*driver.AzureRegistry, error) {
+	if name == "" {
+		return nil, errors.New(errors.InvalidArgument, "registry name is required")
+	}
+
+	if rg == "" {
+		return nil, errors.New(errors.InvalidArgument, "resource group is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := registryStoreKey(rg, name)
+	now := m.opts.Clock.Now().UTC()
+
+	rd, existing := m.registries.Get(key)
+	if !existing {
+		rd = &registryData{
+			password:  synthCredential("password/" + rg + "/" + name),
+			password2: synthCredential("password2/" + rg + "/" + name),
+		}
+		rd.reg.CreationDate = now
+	}
+
+	sku := defaultIfEmpty(cfg.SKUName, defaultRegistrySKU)
+
+	rd.reg.Name = name
+	rd.reg.ResourceGroup = rg
+	rd.reg.Location = cfg.Location
+	rd.reg.SKUName = sku
+	rd.reg.SKUTier = skuTier(sku)
+	rd.reg.LoginServer = strings.ToLower(name) + ".azurecr.io"
+	rd.reg.AdminUserEnabled = cfg.AdminUserEnabled
+	rd.reg.ProvisioningState = registryProvisioned
+	rd.reg.Tags = copyTags(cfg.Tags)
+	applyIdentity(&rd.reg, cfg.IdentityType, rg, name)
+
+	m.registries.Set(key, rd)
+
+	out := rd.reg
+
+	return &out, nil
+}
+
+// applyIdentity echoes the submitted managed-identity block, generating a
+// deterministic principal/tenant pair for a system-assigned identity.
+func applyIdentity(reg *driver.AzureRegistry, identityType, rg, name string) {
+	reg.IdentityType = identityType
+	reg.PrincipalID = ""
+	reg.TenantID = ""
+
+	if identityType == "" || identityType == identityNone {
+		return
+	}
+
+	if strings.Contains(identityType, "SystemAssigned") {
+		reg.PrincipalID = idgen.SyntheticGUID("principal/registry/" + rg + "/" + name)
+		reg.TenantID = emulatorTenantID
+	}
+}
+
+func defaultIfEmpty(v, def string) string {
+	if v == "" {
+		return def
+	}
+
+	return v
+}
+
+func skuTier(sku string) string {
+	if sku == classicSKU {
+		return classicSKU
+	}
+
+	return sku
+}
+
+// GetRegistry returns a registry by name within a resource group.
+func (m *Mock) GetRegistry(_ context.Context, rg, name string) (*driver.AzureRegistry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.registries.Get(registryStoreKey(rg, name))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "registry %q not found in resource group %q", name, rg)
+	}
+
+	out := rd.reg
+
+	return &out, nil
+}
+
+// DeleteRegistry removes a registry and its webhooks/replications.
+func (m *Mock) DeleteRegistry(_ context.Context, rg, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.registries.Delete(registryStoreKey(rg, name)) {
+		return errors.Newf(errors.NotFound, "registry %q not found in resource group %q", name, rg)
+	}
+
+	prefix := rg + "/" + name + "/"
+	for _, k := range m.webhooks.Keys() {
+		if strings.HasPrefix(k, prefix) {
+			m.webhooks.Delete(k)
+		}
+	}
+
+	for _, k := range m.replications.Keys() {
+		if strings.HasPrefix(k, prefix) {
+			m.replications.Delete(k)
+		}
+	}
+
+	return nil
+}
+
+// ListRegistries returns registries in a resource group, or across the whole
+// subscription when rg is empty.
+func (m *Mock) ListRegistries(_ context.Context, rg string) ([]driver.AzureRegistry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	all := m.registries.All()
+	out := make([]driver.AzureRegistry, 0, len(all))
+
+	for _, rd := range all {
+		if rg != "" && rd.reg.ResourceGroup != rg {
+			continue
+		}
+
+		out = append(out, rd.reg)
+	}
+
+	return out, nil
+}
+
+// ListRegistryCredentials returns the admin username / password pair.
+func (m *Mock) ListRegistryCredentials(_ context.Context, rg, name string) (*driver.AzureRegistryCredentials, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.registries.Get(registryStoreKey(rg, name))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "registry %q not found in resource group %q", name, rg)
+	}
+
+	if !rd.reg.AdminUserEnabled {
+		return nil, errors.Newf(
+			errors.FailedPrecondition, "admin user is not enabled for registry %q", name,
+		)
+	}
+
+	return &driver.AzureRegistryCredentials{
+		Username:  name,
+		Password:  rd.password,
+		Password2: rd.password2,
+	}, nil
+}
+
+// RegenerateRegistryCredential rotates the named password (password / password2).
+func (m *Mock) RegenerateRegistryCredential(
+	_ context.Context, rg, name, passwordName string,
+) (*driver.AzureRegistryCredentials, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.registries.Get(registryStoreKey(rg, name))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "registry %q not found in resource group %q", name, rg)
+	}
+
+	seed := fmt.Sprintf("%s/%s/%d", rg, name, m.opts.Clock.Now().UnixNano())
+
+	switch passwordName {
+	case "password":
+		rd.password = synthCredential("password/regen/" + seed)
+	case "password2":
+		rd.password2 = synthCredential("password2/regen/" + seed)
+	default:
+		return nil, errors.Newf(errors.InvalidArgument, "invalid password name %q", passwordName)
+	}
+
+	m.registries.Set(registryStoreKey(rg, name), rd)
+
+	return &driver.AzureRegistryCredentials{
+		Username:  name,
+		Password:  rd.password,
+		Password2: rd.password2,
+	}, nil
+}
+
+// ListRegistryUsages returns the registry's quota usages.
+func (m *Mock) ListRegistryUsages(_ context.Context, rg, name string) ([]driver.AzureRegistryUsage, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.registries.Has(registryStoreKey(rg, name)) {
+		return nil, errors.Newf(errors.NotFound, "registry %q not found in resource group %q", name, rg)
+	}
+
+	const storageLimitBytes = 536870912000 // 500 GiB, the Standard-SKU included storage.
+
+	return []driver.AzureRegistryUsage{
+		{Name: "Size", Limit: storageLimitBytes, CurrentValue: 0, Unit: "Bytes"},
+		{Name: "Webhooks", Limit: webhookQuota, CurrentValue: int64(m.countSubResources(m.webhooks.Keys(), rg, name)), Unit: "Count"},
+	}, nil
+}
+
+const webhookQuota = 100
+
+func (*Mock) countSubResources(keys []string, rg, registry string) int {
+	prefix := rg + "/" + registry + "/"
+	n := 0
+
+	for _, k := range keys {
+		if strings.HasPrefix(k, prefix) {
+			n++
+		}
+	}
+
+	return n
+}
+
+// synthCredential derives a deterministic base64-ish password from a seed.
+func synthCredential(seed string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(seed))
+
+	return fmt.Sprintf("%016x%016x", h.Sum64(), fnvSalted(seed))
+}
+
+func fnvSalted(seed string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(seed + "#cred"))
+
+	return h.Sum64()
+}
+
+// CreateOrUpdateWebhook creates or replaces a registry webhook.
+//
+//nolint:gocritic // cfg mirrors the driver interface's value-type config; pointer would invite caller mutation.
+func (m *Mock) CreateOrUpdateWebhook(
+	_ context.Context, rg, registry, name string, cfg driver.AzureWebhookConfig,
+) (*driver.AzureWebhook, error) {
+	if name == "" {
+		return nil, errors.New(errors.InvalidArgument, "webhook name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.registries.Has(registryStoreKey(rg, registry)) {
+		return nil, errors.Newf(errors.NotFound, "registry %q not found in resource group %q", registry, rg)
+	}
+
+	wh := &driver.AzureWebhook{
+		Name:              name,
+		RegistryName:      registry,
+		ResourceGroup:     rg,
+		Location:          cfg.Location,
+		Tags:              copyTags(cfg.Tags),
+		ServiceURI:        cfg.ServiceURI,
+		Actions:           append([]string(nil), cfg.Actions...),
+		Scope:             cfg.Scope,
+		Status:            defaultIfEmpty(cfg.Status, "enabled"),
+		CustomHeaders:     copyTags(cfg.CustomHeaders),
+		ProvisioningState: registryProvisioned,
+	}
+
+	m.webhooks.Set(subResourceKey(rg, registry, name), wh)
+
+	out := *wh
+
+	return &out, nil
+}
+
+// GetWebhook returns a webhook by name.
+func (m *Mock) GetWebhook(_ context.Context, rg, registry, name string) (*driver.AzureWebhook, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	wh, ok := m.webhooks.Get(subResourceKey(rg, registry, name))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "webhook %q not found on registry %q", name, registry)
+	}
+
+	out := *wh
+
+	return &out, nil
+}
+
+// DeleteWebhook removes a webhook.
+func (m *Mock) DeleteWebhook(_ context.Context, rg, registry, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.webhooks.Delete(subResourceKey(rg, registry, name)) {
+		return errors.Newf(errors.NotFound, "webhook %q not found on registry %q", name, registry)
+	}
+
+	return nil
+}
+
+// ListWebhooks returns all webhooks on a registry.
+//
+//nolint:dupl // webhook and replication sub-resource lists are intentionally typed; sharing via generics adds noise.
+func (m *Mock) ListWebhooks(_ context.Context, rg, registry string) ([]driver.AzureWebhook, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.registries.Has(registryStoreKey(rg, registry)) {
+		return nil, errors.Newf(errors.NotFound, "registry %q not found in resource group %q", registry, rg)
+	}
+
+	prefix := rg + "/" + registry + "/"
+	all := m.webhooks.All()
+	out := make([]driver.AzureWebhook, 0)
+
+	for k, wh := range all {
+		if strings.HasPrefix(k, prefix) {
+			out = append(out, *wh)
+		}
+	}
+
+	return out, nil
+}
+
+// CreateOrUpdateReplication creates or replaces a geo-replication.
+func (m *Mock) CreateOrUpdateReplication(
+	_ context.Context, rg, registry, name string, cfg driver.AzureReplicationConfig,
+) (*driver.AzureReplication, error) {
+	if name == "" {
+		return nil, errors.New(errors.InvalidArgument, "replication name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.registries.Has(registryStoreKey(rg, registry)) {
+		return nil, errors.Newf(errors.NotFound, "registry %q not found in resource group %q", registry, rg)
+	}
+
+	rep := &driver.AzureReplication{
+		Name:                  name,
+		RegistryName:          registry,
+		ResourceGroup:         rg,
+		Location:              cfg.Location,
+		Tags:                  copyTags(cfg.Tags),
+		RegionEndpointEnabled: cfg.RegionEndpointEnabled,
+		ProvisioningState:     registryProvisioned,
+		Status:                "Ready",
+	}
+
+	m.replications.Set(subResourceKey(rg, registry, name), rep)
+
+	out := *rep
+
+	return &out, nil
+}
+
+// GetReplication returns a replication by name.
+func (m *Mock) GetReplication(_ context.Context, rg, registry, name string) (*driver.AzureReplication, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rep, ok := m.replications.Get(subResourceKey(rg, registry, name))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "replication %q not found on registry %q", name, registry)
+	}
+
+	out := *rep
+
+	return &out, nil
+}
+
+// DeleteReplication removes a replication.
+func (m *Mock) DeleteReplication(_ context.Context, rg, registry, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.replications.Delete(subResourceKey(rg, registry, name)) {
+		return errors.Newf(errors.NotFound, "replication %q not found on registry %q", name, registry)
+	}
+
+	return nil
+}
+
+// ListReplications returns all replications on a registry.
+//
+//nolint:dupl // webhook and replication sub-resource lists are intentionally typed; sharing via generics adds noise.
+func (m *Mock) ListReplications(_ context.Context, rg, registry string) ([]driver.AzureReplication, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.registries.Has(registryStoreKey(rg, registry)) {
+		return nil, errors.Newf(errors.NotFound, "registry %q not found in resource group %q", registry, rg)
+	}
+
+	prefix := rg + "/" + registry + "/"
+	all := m.replications.All()
+	out := make([]driver.AzureReplication, 0)
+
+	for k, rep := range all {
+		if strings.HasPrefix(k, prefix) {
+			out = append(out, *rep)
+		}
+	}
+
+	return out, nil
+}

--- a/providers/azure/acr/registry_test.go
+++ b/providers/azure/acr/registry_test.go
@@ -13,13 +13,14 @@ func TestCreateOrUpdateRegistry(t *testing.T) {
 	m, _ := newTestMock()
 	ctx := context.Background()
 
-	reg, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "MyReg", driver.AzureRegistryConfig{
+	reg, created, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "MyReg", driver.AzureRegistryConfig{
 		Location:         "eastus",
 		SKUName:          "Premium",
 		AdminUserEnabled: true,
 		IdentityType:     "SystemAssigned",
 	})
 	require.NoError(t, err)
+	assert.True(t, created) // first PUT reports create
 
 	assert.Equal(t, "myreg.azurecr.io", reg.LoginServer)
 	assert.Equal(t, "Premium", reg.SKUTier)
@@ -27,18 +28,51 @@ func TestCreateOrUpdateRegistry(t *testing.T) {
 	assert.NotEmpty(t, reg.PrincipalID)
 	assert.NotEmpty(t, reg.TenantID)
 
-	// Idempotent update preserves creation date.
-	updated, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "MyReg", driver.AzureRegistryConfig{Location: "westus"})
+	// A second PUT replaces (not creates) and preserves the creation date.
+	updated, created, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "MyReg", driver.AzureRegistryConfig{Location: "westus"})
 	require.NoError(t, err)
+	assert.False(t, created) // replace, not create
 	assert.Equal(t, reg.CreationDate, updated.CreationDate)
 	assert.Equal(t, "Standard", updated.SKUName) // default when SKU omitted
+}
+
+func TestUpdateRegistryPartialMerge(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, created, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "MyReg", driver.AzureRegistryConfig{
+		Location:         "eastus",
+		SKUName:          "Premium",
+		AdminUserEnabled: true,
+		IdentityType:     "SystemAssigned",
+		Tags:             map[string]string{"team": "core"},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	// PATCH only adminUserEnabled: SKU, location, identity and tags must survive.
+	disabled := false
+	updated, err := m.UpdateRegistry(ctx, "rg-1", "MyReg", driver.AzureRegistryUpdate{
+		AdminUserEnabled: &disabled,
+	})
+	require.NoError(t, err)
+
+	assert.False(t, updated.AdminUserEnabled)
+	assert.Equal(t, "Premium", updated.SKUName)      // untouched
+	assert.Equal(t, "eastus", updated.Location)      // untouched
+	assert.Equal(t, "SystemAssigned", updated.IdentityType)
+	assert.Equal(t, "core", updated.Tags["team"])    // untouched
+
+	// PATCH on a missing registry is a NotFound.
+	_, err = m.UpdateRegistry(ctx, "rg-1", "ghost", driver.AzureRegistryUpdate{AdminUserEnabled: &disabled})
+	require.Error(t, err)
 }
 
 func TestListRegistryCredentialsRequiresAdmin(t *testing.T) {
 	m, _ := newTestMock()
 	ctx := context.Background()
 
-	_, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "noadmin", driver.AzureRegistryConfig{})
+	_, _, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "noadmin", driver.AzureRegistryConfig{})
 	require.NoError(t, err)
 
 	// Admin user disabled: listing credentials is a failed precondition.
@@ -54,7 +88,7 @@ func TestRegenerateRegistryCredential(t *testing.T) {
 	m, _ := newTestMock()
 	ctx := context.Background()
 
-	_, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "reg", driver.AzureRegistryConfig{AdminUserEnabled: true})
+	_, _, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "reg", driver.AzureRegistryConfig{AdminUserEnabled: true})
 	require.NoError(t, err)
 
 	before, err := m.ListRegistryCredentials(ctx, "rg-1", "reg")

--- a/providers/azure/acr/registry_test.go
+++ b/providers/azure/acr/registry_test.go
@@ -1,0 +1,93 @@
+package acr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateOrUpdateRegistry(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	reg, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "MyReg", driver.AzureRegistryConfig{
+		Location:         "eastus",
+		SKUName:          "Premium",
+		AdminUserEnabled: true,
+		IdentityType:     "SystemAssigned",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "myreg.azurecr.io", reg.LoginServer)
+	assert.Equal(t, "Premium", reg.SKUTier)
+	assert.True(t, reg.AdminUserEnabled)
+	assert.NotEmpty(t, reg.PrincipalID)
+	assert.NotEmpty(t, reg.TenantID)
+
+	// Idempotent update preserves creation date.
+	updated, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "MyReg", driver.AzureRegistryConfig{Location: "westus"})
+	require.NoError(t, err)
+	assert.Equal(t, reg.CreationDate, updated.CreationDate)
+	assert.Equal(t, "Standard", updated.SKUName) // default when SKU omitted
+}
+
+func TestListRegistryCredentialsRequiresAdmin(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "noadmin", driver.AzureRegistryConfig{})
+	require.NoError(t, err)
+
+	// Admin user disabled: listing credentials is a failed precondition.
+	_, err = m.ListRegistryCredentials(ctx, "rg-1", "noadmin")
+	require.Error(t, err)
+
+	// Unknown registry is a not-found.
+	_, err = m.ListRegistryCredentials(ctx, "rg-1", "ghost")
+	require.Error(t, err)
+}
+
+func TestRegenerateRegistryCredential(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "reg", driver.AzureRegistryConfig{AdminUserEnabled: true})
+	require.NoError(t, err)
+
+	before, err := m.ListRegistryCredentials(ctx, "rg-1", "reg")
+	require.NoError(t, err)
+
+	after, err := m.RegenerateRegistryCredential(ctx, "rg-1", "reg", "password")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, before.Password, after.Password)
+	assert.Equal(t, before.Password2, after.Password2)
+
+	_, err = m.RegenerateRegistryCredential(ctx, "rg-1", "reg", "bogus")
+	require.Error(t, err)
+}
+
+func TestDeleteTagKeepsManifest(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "app")
+	detail := pushTestImage(t, m, "app", "v1")
+
+	require.NoError(t, m.TagImage(ctx, "app", detail.Digest, "v2"))
+	require.NoError(t, m.DeleteTag(ctx, "app", "v1"))
+
+	// The manifest survives, reachable by its remaining tag and by digest.
+	img, err := m.GetImage(ctx, "app", "v2")
+	require.NoError(t, err)
+	assert.Equal(t, detail.Digest, img.Digest)
+
+	_, err = m.GetImage(ctx, "app", "v1")
+	require.Error(t, err)
+
+	// Deleting an unknown tag is a not-found.
+	require.Error(t, m.DeleteTag(ctx, "app", "ghost"))
+}

--- a/providers/azure/aks/aks.go
+++ b/providers/azure/aks/aks.go
@@ -12,6 +12,7 @@ package aks
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -31,6 +32,12 @@ const (
 	defaultNodeCount     = 3
 	defaultVMSize        = "Standard_DS2_v2"
 	defaultOSDiskGB      = 128
+	defaultMaxPods       = 110
+	defaultOSDiskType    = "Managed"
+	defaultPoolType      = "VirtualMachineScaleSets"
+	defaultNodeImage     = "AKSUbuntu-2204gen2containerd-202401.09.0"
+	poolPowerRunning     = "Running"
+	emulatorTenantID     = "11111111-1111-1111-1111-111111111111"
 	cpuMetricRunning     = 0.35
 	memMetricRunning     = 0.50
 	podMetricRunning     = 12.0
@@ -53,6 +60,16 @@ type ManagedCluster struct {
 	Tags           map[string]string
 	AgentPoolNames []string
 
+	// EnableRBAC mirrors properties.enableRBAC; defaults to true, the AKS
+	// default when a create omits it.
+	EnableRBAC bool
+	// Identity echoes the managed-identity block. IdentityType is
+	// "SystemAssigned" / "UserAssigned" / "None"/""; PrincipalID and TenantID
+	// are populated for a system-assigned identity.
+	IdentityType string
+	PrincipalID  string
+	TenantID     string
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
@@ -74,6 +91,14 @@ type AgentPool struct {
 	ScaleSetPriority string
 	NodeLabels       map[string]string
 	NodeTaints       []string
+	// MaxPods, OSDiskType, Type, PowerState and NodeImageVersion are the
+	// computed pool fields the real API always returns; the emulator synthesizes
+	// standard defaults when a create omits them.
+	MaxPods          int32
+	OSDiskType       string
+	Type             string
+	PowerState       string
+	NodeImageVersion string
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
@@ -237,6 +262,12 @@ type ClusterInput struct {
 	// Tier is the cluster SKU tier (Free / Standard / Premium); defaults to Free.
 	Tier string
 	Tags map[string]string
+	// IdentityType echoes the managed-identity block: "SystemAssigned",
+	// "UserAssigned", "None" or "".
+	IdentityType string
+	// EnableRBAC mirrors properties.enableRBAC. Nil means "not submitted", which
+	// the mock resolves to the AKS default (true).
+	EnableRBAC *bool
 	// AgentPools may be nil for an empty cluster; otherwise these are the
 	// pools shipped inline at create time (system pool typically).
 	AgentPools []AgentPoolInput
@@ -254,6 +285,9 @@ type AgentPoolInput struct {
 	ScaleSetPriority string
 	NodeLabels       map[string]string
 	NodeTaints       []string
+	// MaxPods is the submitted max-pods-per-node; 0 means "not submitted" and
+	// the mock applies the standard default.
+	MaxPods int32
 }
 
 // CreateOrUpdateCluster creates a new managed cluster or updates an existing
@@ -293,10 +327,12 @@ func (m *Mock) CreateOrUpdateCluster(_ context.Context, input ClusterInput) (*Ma
 	cluster.PowerState = "Running"
 	cluster.Tier = defaultIfEmpty(input.Tier, "Free")
 	cluster.Tags = copyTags(input.Tags)
+	cluster.EnableRBAC = input.EnableRBAC == nil || *input.EnableRBAC
+	applyClusterIdentity(&cluster, input.IdentityType)
 	cluster.UpdatedAt = now
 
 	// Inline pools — replace what we have for this cluster.
-	cluster.AgentPoolNames = m.replaceInlinePools(input, now)
+	cluster.AgentPoolNames = m.replaceInlinePools(input, cluster.KubernetesVersion, now)
 
 	// Wave 2: if a Kubernetes data-plane server is wired and this is a fresh
 	// cluster, register a ClusterState and remember the UID so Kubeconfig can
@@ -319,11 +355,30 @@ func (m *Mock) CreateOrUpdateCluster(_ context.Context, input ClusterInput) (*Ma
 	return &out, nil
 }
 
+// applyClusterIdentity echoes the submitted managed-identity block, generating
+// a deterministic principal/tenant pair for a system-assigned identity.
+func applyClusterIdentity(cluster *ManagedCluster, identityType string) {
+	cluster.IdentityType = identityType
+	cluster.PrincipalID = ""
+	cluster.TenantID = ""
+
+	if identityType == "" || identityType == "None" {
+		return
+	}
+
+	if strings.Contains(identityType, "SystemAssigned") {
+		cluster.PrincipalID = idgen.SyntheticGUID(
+			"principal/cluster/" + cluster.ResourceGroup + "/" + cluster.Name)
+		cluster.TenantID = emulatorTenantID
+	}
+}
+
 // replaceInlinePools wipes any pre-existing pools for the cluster and re-adds
-// each input pool. Caller must hold m.mu (write).
+// each input pool. Caller must hold m.mu (write). clusterVersion is inherited
+// by inline pools that omit their own orchestratorVersion.
 //
 //nolint:gocritic // input is a value-type mirror of the public CreateOrUpdate body.
-func (m *Mock) replaceInlinePools(input ClusterInput, now time.Time) []string {
+func (m *Mock) replaceInlinePools(input ClusterInput, clusterVersion string, now time.Time) []string {
 	// Drop existing pools for this cluster.
 	prefix := input.ResourceGroup + "/" + input.Name + "/"
 
@@ -337,7 +392,7 @@ func (m *Mock) replaceInlinePools(input ClusterInput, now time.Time) []string {
 
 	//nolint:gocritic // pool is a value mirror of the SDK input; copy is intentional.
 	for _, pool := range input.AgentPools {
-		ap := buildAgentPool(input.ResourceGroup, input.Name, pool, now)
+		ap := buildAgentPool(input.ResourceGroup, input.Name, clusterVersion, pool, now)
 		m.pools.Set(poolKey(input.ResourceGroup, input.Name, pool.Name), ap)
 		names = append(names, pool.Name)
 	}
@@ -346,7 +401,7 @@ func (m *Mock) replaceInlinePools(input ClusterInput, now time.Time) []string {
 }
 
 //nolint:gocritic // in is a value mirror of the SDK AgentPool body; pointer would invite caller mutation.
-func buildAgentPool(rg, cluster string, in AgentPoolInput, now time.Time) AgentPool {
+func buildAgentPool(rg, cluster, clusterVersion string, in AgentPoolInput, now time.Time) AgentPool {
 	count := in.Count
 	if count <= 0 {
 		count = defaultNodeCount
@@ -355,6 +410,11 @@ func buildAgentPool(rg, cluster string, in AgentPoolInput, now time.Time) AgentP
 	disk := in.OSDiskSizeGB
 	if disk <= 0 {
 		disk = defaultOSDiskGB
+	}
+
+	maxPods := in.MaxPods
+	if maxPods <= 0 {
+		maxPods = defaultMaxPods
 	}
 
 	return AgentPool{
@@ -366,11 +426,16 @@ func buildAgentPool(rg, cluster string, in AgentPoolInput, now time.Time) AgentP
 		OSDiskSizeGB:      disk,
 		OSType:            defaultIfEmpty(in.OSType, "Linux"),
 		Mode:              defaultIfEmpty(in.Mode, "User"),
-		OrchestratorVer:   defaultIfEmpty(in.OrchestratorVer, defaultK8sVersion),
+		OrchestratorVer:   defaultIfEmpty(in.OrchestratorVer, defaultIfEmpty(clusterVersion, defaultK8sVersion)),
 		ProvisioningState: "Succeeded",
 		ScaleSetPriority:  defaultIfEmpty(in.ScaleSetPriority, "Regular"),
 		NodeLabels:        copyLabels(in.NodeLabels),
 		NodeTaints:        copyTaints(in.NodeTaints),
+		MaxPods:           maxPods,
+		OSDiskType:        defaultOSDiskType,
+		Type:              defaultPoolType,
+		PowerState:        poolPowerRunning,
+		NodeImageVersion:  defaultNodeImage,
 		CreatedAt:         now,
 		UpdatedAt:         now,
 	}
@@ -535,12 +600,14 @@ func (m *Mock) CreateOrUpdateAgentPool(
 	defer m.mu.Unlock()
 
 	cKey := clusterKey(rg, cluster)
-	if !m.clusters.Has(cKey) {
+
+	clusterRec, ok := m.clusters.Get(cKey)
+	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "managed cluster %q not found in resource group %q", cluster, rg)
 	}
 
 	now := m.opts.Clock.Now().UTC()
-	pool := buildAgentPool(rg, cluster, in, now)
+	pool := buildAgentPool(rg, cluster, clusterRec.KubernetesVersion, in, now)
 
 	if existing, ok := m.pools.Get(poolKey(rg, cluster, in.Name)); ok {
 		pool.CreatedAt = existing.CreatedAt

--- a/server/azure/acr/arm_partial_update_test.go
+++ b/server/azure/acr/arm_partial_update_test.go
@@ -111,6 +111,69 @@ func TestARMRegistryPutStatusAndPatchMerge(t *testing.T) {
 	}
 }
 
+// TestARMRegistryPatchPropertiesPreservesAdminUser reproduces the partial-merge
+// blocker: a PATCH whose properties body touches only another field (here
+// publicNetworkAccess) must not silently reset a previously-set adminUserEnabled.
+func TestARMRegistryPatchPropertiesPreservesAdminUser(t *testing.T) {
+	ts, client := rawARMServer(t)
+
+	regURL := ts.URL + "/subscriptions/sub-1/resourceGroups/rg-1" +
+		"/providers/Microsoft.ContainerRegistry/registries/netreg" + acrAPIVersion
+
+	code, _ := armDo(t, client, http.MethodPut, regURL,
+		`{"location":"eastus","sku":{"name":"Premium"},"properties":{"adminUserEnabled":true}}`)
+	if code != http.StatusCreated {
+		t.Fatalf("PUT: got %d, want 201", code)
+	}
+
+	// PATCH a properties block that only sets publicNetworkAccess (a field absent
+	// from our decode shape); adminUserEnabled is omitted and must survive.
+	code, _ = armDo(t, client, http.MethodPatch, regURL,
+		`{"properties":{"publicNetworkAccess":"Disabled"}}`)
+	if code != http.StatusOK {
+		t.Fatalf("PATCH: got %d, want 200", code)
+	}
+
+	_, body := armDo(t, client, http.MethodGet, regURL, "")
+
+	props, _ := body["properties"].(map[string]any)
+	if props == nil || props["adminUserEnabled"] != true {
+		t.Fatalf("PATCH reset adminUserEnabled: %v", body["properties"])
+	}
+}
+
+// TestARMDeleteMissingIsIdempotent204 asserts ARM DELETE is idempotent: deleting
+// a never-created registry/webhook/replication is a successful no-op returning
+// 204, matching the ACR swagger ("does not exist in the subscription").
+func TestARMDeleteMissingIsIdempotent204(t *testing.T) {
+	ts, client := rawARMServer(t)
+
+	base := ts.URL + "/subscriptions/sub-1/resourceGroups/rg-1" +
+		"/providers/Microsoft.ContainerRegistry/registries"
+
+	code, _ := armDo(t, client, http.MethodDelete, base+"/ghost"+acrAPIVersion, "")
+	if code != http.StatusNoContent {
+		t.Fatalf("DELETE missing registry: got %d, want 204", code)
+	}
+
+	// Create a parent registry so the webhook/replication paths resolve.
+	code, _ = armDo(t, client, http.MethodPut, base+"/idemreg"+acrAPIVersion,
+		`{"location":"eastus","sku":{"name":"Premium"}}`)
+	if code != http.StatusCreated {
+		t.Fatalf("registry PUT: got %d, want 201", code)
+	}
+
+	code, _ = armDo(t, client, http.MethodDelete, base+"/idemreg/webhooks/ghost"+acrAPIVersion, "")
+	if code != http.StatusNoContent {
+		t.Fatalf("DELETE missing webhook: got %d, want 204", code)
+	}
+
+	code, _ = armDo(t, client, http.MethodDelete, base+"/idemreg/replications/ghost"+acrAPIVersion, "")
+	if code != http.StatusNoContent {
+		t.Fatalf("DELETE missing replication: got %d, want 204", code)
+	}
+}
+
 func TestARMRegistryPatchMissingIs404(t *testing.T) {
 	ts, client := rawARMServer(t)
 

--- a/server/azure/acr/arm_partial_update_test.go
+++ b/server/azure/acr/arm_partial_update_test.go
@@ -1,0 +1,212 @@
+package acr_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+const acrAPIVersion = "?api-version=2023-07-01"
+
+// rawARMServer returns an httptest TLS server serving the ACR ARM plane plus a
+// client wired to trust it, for tests that need to inspect raw status codes and
+// bodies (the azure-sdk poller hides the create vs. replace status code).
+func rawARMServer(t *testing.T) (*httptest.Server, *http.Client) {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{ACR: cloudP.ACR})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts, ts.Client()
+}
+
+func armDo(t *testing.T, client *http.Client, method, url, body string) (int, map[string]any) {
+	t.Helper()
+
+	var reader io.Reader
+	if body != "" {
+		reader = bytes.NewBufferString(body)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), method, url, reader)
+	if err != nil {
+		t.Fatalf("NewRequest %s %s: %v", method, url, err)
+	}
+
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+
+	var decoded map[string]any
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &decoded)
+	}
+
+	return resp.StatusCode, decoded
+}
+
+func TestARMRegistryPutStatusAndPatchMerge(t *testing.T) {
+	ts, client := rawARMServer(t)
+
+	regURL := ts.URL + "/subscriptions/sub-1/resourceGroups/rg-1" +
+		"/providers/Microsoft.ContainerRegistry/registries/myreg" + acrAPIVersion
+
+	// First PUT creates: 201 Created.
+	code, _ := armDo(t, client, http.MethodPut, regURL,
+		`{"location":"eastus","sku":{"name":"Premium"},"properties":{"adminUserEnabled":true},"tags":{"team":"core"}}`)
+	if code != http.StatusCreated {
+		t.Fatalf("first PUT: got %d, want 201", code)
+	}
+
+	// Second PUT replaces the existing registry: 200 OK.
+	code, _ = armDo(t, client, http.MethodPut, regURL,
+		`{"location":"eastus","sku":{"name":"Premium"},"properties":{"adminUserEnabled":true}}`)
+	if code != http.StatusOK {
+		t.Fatalf("second PUT: got %d, want 200", code)
+	}
+
+	// PATCH only the tags: SKU, location and adminUserEnabled must survive.
+	code, _ = armDo(t, client, http.MethodPatch, regURL, `{"tags":{"env":"prod"}}`)
+	if code != http.StatusOK {
+		t.Fatalf("PATCH: got %d, want 200", code)
+	}
+
+	_, body := armDo(t, client, http.MethodGet, regURL, "")
+
+	sku, _ := body["sku"].(map[string]any)
+	if sku == nil || sku["name"] != "Premium" {
+		t.Fatalf("PATCH clobbered sku: %v", body["sku"])
+	}
+
+	props, _ := body["properties"].(map[string]any)
+	if props == nil || props["adminUserEnabled"] != true {
+		t.Fatalf("PATCH clobbered adminUserEnabled: %v", body["properties"])
+	}
+
+	if props["loginServer"] != "myreg.azurecr.io" {
+		t.Fatalf("PATCH clobbered loginServer: %v", props["loginServer"])
+	}
+
+	tags, _ := body["tags"].(map[string]any)
+	if tags == nil || tags["env"] != "prod" {
+		t.Fatalf("PATCH did not apply tags: %v", body["tags"])
+	}
+}
+
+func TestARMRegistryPatchMissingIs404(t *testing.T) {
+	ts, client := rawARMServer(t)
+
+	url := ts.URL + "/subscriptions/sub-1/resourceGroups/rg-1" +
+		"/providers/Microsoft.ContainerRegistry/registries/ghost" + acrAPIVersion
+
+	code, _ := armDo(t, client, http.MethodPatch, url, `{"tags":{"env":"prod"}}`)
+	if code != http.StatusNotFound {
+		t.Fatalf("PATCH missing registry: got %d, want 404", code)
+	}
+}
+
+func TestARMWebhookPutStatusAndPatchMerge(t *testing.T) {
+	ts, client := rawARMServer(t)
+
+	base := ts.URL + "/subscriptions/sub-1/resourceGroups/rg-1" +
+		"/providers/Microsoft.ContainerRegistry/registries/hookreg"
+
+	code, _ := armDo(t, client, http.MethodPut, base+acrAPIVersion,
+		`{"location":"eastus","sku":{"name":"Standard"}}`)
+	if code != http.StatusCreated {
+		t.Fatalf("registry PUT: got %d, want 201", code)
+	}
+
+	whURL := base + "/webhooks/wh1" + acrAPIVersion
+
+	// First PUT creates the webhook: 201.
+	code, _ = armDo(t, client, http.MethodPut, whURL,
+		`{"location":"eastus","properties":{"serviceUri":"https://example.com/hook","actions":["push"],"status":"enabled"}}`)
+	if code != http.StatusCreated {
+		t.Fatalf("webhook PUT: got %d, want 201", code)
+	}
+
+	// PATCH only status: actions must survive.
+	code, _ = armDo(t, client, http.MethodPatch, whURL, `{"properties":{"status":"disabled"}}`)
+	if code != http.StatusOK {
+		t.Fatalf("webhook PATCH: got %d, want 200", code)
+	}
+
+	_, body := armDo(t, client, http.MethodGet, whURL, "")
+
+	props, _ := body["properties"].(map[string]any)
+	if props == nil {
+		t.Fatalf("webhook GET missing properties: %v", body)
+	}
+
+	if props["status"] != "disabled" {
+		t.Fatalf("webhook PATCH did not apply status: %v", props["status"])
+	}
+
+	actions, _ := props["actions"].([]any)
+	if len(actions) != 1 || actions[0] != "push" {
+		t.Fatalf("webhook PATCH clobbered actions: %v", props["actions"])
+	}
+}
+
+func TestARMReplicationPutStatusAndPatchMerge(t *testing.T) {
+	ts, client := rawARMServer(t)
+
+	base := ts.URL + "/subscriptions/sub-1/resourceGroups/rg-1" +
+		"/providers/Microsoft.ContainerRegistry/registries/repreg"
+
+	code, _ := armDo(t, client, http.MethodPut, base+acrAPIVersion,
+		`{"location":"eastus","sku":{"name":"Premium"}}`)
+	if code != http.StatusCreated {
+		t.Fatalf("registry PUT: got %d, want 201", code)
+	}
+
+	repURL := base + "/replications/westus" + acrAPIVersion
+
+	// First PUT creates the replication with regionEndpointEnabled=false: 201.
+	code, _ = armDo(t, client, http.MethodPut, repURL,
+		`{"location":"westus","properties":{"regionEndpointEnabled":false}}`)
+	if code != http.StatusCreated {
+		t.Fatalf("replication PUT: got %d, want 201", code)
+	}
+
+	// PATCH only tags: regionEndpointEnabled must survive (not reset to zero).
+	code, _ = armDo(t, client, http.MethodPatch, repURL, `{"tags":{"env":"prod"}}`)
+	if code != http.StatusOK {
+		t.Fatalf("replication PATCH: got %d, want 200", code)
+	}
+
+	_, body := armDo(t, client, http.MethodGet, repURL, "")
+
+	props, _ := body["properties"].(map[string]any)
+	if props == nil {
+		t.Fatalf("replication GET missing properties: %v", body)
+	}
+
+	if props["regionEndpointEnabled"] != false {
+		t.Fatalf("replication PATCH clobbered regionEndpointEnabled: %v", props["regionEndpointEnabled"])
+	}
+
+	tags, _ := body["tags"].(map[string]any)
+	if tags == nil || tags["env"] != "prod" {
+		t.Fatalf("replication PATCH did not apply tags: %v", body["tags"])
+	}
+}

--- a/server/azure/acr/arm_registry_roundtrip_test.go
+++ b/server/azure/acr/arm_registry_roundtrip_test.go
@@ -142,6 +142,77 @@ func TestSDKACRRegistryLifecycle(t *testing.T) {
 	}
 }
 
+// TestSDKACRRegistryUpdatePreservesAdminUser drives the real armcontainerregistry
+// SDK: a BeginUpdate that sets only publicNetworkAccess must preserve the
+// adminUserEnabled=true established at create time.
+func TestSDKACRRegistryUpdatePreservesAdminUser(t *testing.T) {
+	cf := newACRARMFactory(t)
+	client := cf.NewRegistriesClient()
+	ctx := context.Background()
+
+	createRegistry(t, client, "rg-1", "netreg")
+
+	poller, err := client.BeginUpdate(ctx, "rg-1", "netreg", armcontainerregistry.RegistryUpdateParameters{
+		Properties: &armcontainerregistry.RegistryPropertiesUpdateParameters{
+			PublicNetworkAccess: to.Ptr(armcontainerregistry.PublicNetworkAccessDisabled),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Update PollUntilDone: %v", err)
+	}
+
+	got, err := client.Get(ctx, "rg-1", "netreg", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.AdminUserEnabled == nil || !*got.Properties.AdminUserEnabled {
+		t.Fatalf("PATCH reset adminUserEnabled; want true, got %v", got.Properties.AdminUserEnabled)
+	}
+}
+
+// TestSDKACRDeleteMissingIsIdempotent drives the real SDK: deleting a
+// never-created registry/webhook/replication completes without error (204).
+func TestSDKACRDeleteMissingIsIdempotent(t *testing.T) {
+	cf := newACRARMFactory(t)
+	ctx := context.Background()
+
+	regClient := cf.NewRegistriesClient()
+
+	delPoller, err := regClient.BeginDelete(ctx, "rg-1", "ghost", nil)
+	if err != nil {
+		t.Fatalf("registry BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("registry delete of missing resource: %v", err)
+	}
+
+	createRegistry(t, regClient, "rg-1", "idemreg")
+
+	whPoller, err := cf.NewWebhooksClient().BeginDelete(ctx, "rg-1", "idemreg", "ghost", nil)
+	if err != nil {
+		t.Fatalf("webhook BeginDelete: %v", err)
+	}
+
+	if _, err := whPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("webhook delete of missing resource: %v", err)
+	}
+
+	repPoller, err := cf.NewReplicationsClient().BeginDelete(ctx, "rg-1", "idemreg", "ghost", nil)
+	if err != nil {
+		t.Fatalf("replication BeginDelete: %v", err)
+	}
+
+	if _, err := repPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("replication delete of missing resource: %v", err)
+	}
+}
+
 func TestSDKACRRegistryCredentials(t *testing.T) {
 	cf := newACRARMFactory(t)
 	client := cf.NewRegistriesClient()

--- a/server/azure/acr/arm_registry_roundtrip_test.go
+++ b/server/azure/acr/arm_registry_roundtrip_test.go
@@ -1,0 +1,268 @@
+package acr_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func newACRARMFactory(t *testing.T) *armcontainerregistry.ClientFactory {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{ACR: cloudP.ACR})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	cf, err := armcontainerregistry.NewClientFactory("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewClientFactory: %v", err)
+	}
+
+	return cf
+}
+
+func createRegistry(t *testing.T, client *armcontainerregistry.RegistriesClient, rg, name string) armcontainerregistry.Registry {
+	t.Helper()
+
+	poller, err := client.BeginCreate(context.Background(), rg, name, armcontainerregistry.Registry{
+		Location: to.Ptr("eastus"),
+		SKU:      &armcontainerregistry.SKU{Name: to.Ptr(armcontainerregistry.SKUNameStandard)},
+		Identity: &armcontainerregistry.IdentityProperties{
+			Type: to.Ptr(armcontainerregistry.ResourceIdentityTypeSystemAssigned),
+		},
+		Properties: &armcontainerregistry.RegistryProperties{AdminUserEnabled: to.Ptr(true)},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	resp, err := poller.PollUntilDone(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Create PollUntilDone: %v", err)
+	}
+
+	return resp.Registry
+}
+
+func TestSDKACRRegistryLifecycle(t *testing.T) {
+	cf := newACRARMFactory(t)
+	client := cf.NewRegistriesClient()
+	ctx := context.Background()
+
+	reg := createRegistry(t, client, "rg-1", "myreg")
+
+	if reg.Properties == nil || reg.Properties.LoginServer == nil || *reg.Properties.LoginServer != "myreg.azurecr.io" {
+		t.Fatalf("got loginServer %v, want myreg.azurecr.io", reg.Properties)
+	}
+
+	if reg.Properties.AdminUserEnabled == nil || !*reg.Properties.AdminUserEnabled {
+		t.Fatal("expected adminUserEnabled true")
+	}
+
+	if reg.Identity == nil || reg.Identity.PrincipalID == nil || *reg.Identity.PrincipalID == "" {
+		t.Fatal("expected system-assigned identity with principalId")
+	}
+
+	if reg.Identity.TenantID == nil || *reg.Identity.TenantID == "" {
+		t.Fatal("expected identity tenantId")
+	}
+
+	got, err := client.Get(ctx, "rg-1", "myreg", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if *got.SKU.Tier != armcontainerregistry.SKUTierStandard {
+		t.Fatalf("got tier %v, want Standard", *got.SKU.Tier)
+	}
+
+	// List within resource group.
+	rgPager := client.NewListByResourceGroupPager("rg-1", nil)
+
+	rgPage, err := rgPager.NextPage(ctx)
+	if err != nil {
+		t.Fatalf("ListByResourceGroup: %v", err)
+	}
+
+	if len(rgPage.Value) != 1 {
+		t.Fatalf("got %d registries in rg, want 1", len(rgPage.Value))
+	}
+
+	// Subscription-wide list.
+	subPager := client.NewListPager(nil)
+
+	subPage, err := subPager.NextPage(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(subPage.Value) != 1 {
+		t.Fatalf("got %d registries in subscription, want 1", len(subPage.Value))
+	}
+
+	// Delete.
+	delPoller, err := client.BeginDelete(ctx, "rg-1", "myreg", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete PollUntilDone: %v", err)
+	}
+
+	if _, err := client.Get(ctx, "rg-1", "myreg", nil); err == nil {
+		t.Fatal("expected NotFound after delete")
+	}
+}
+
+func TestSDKACRRegistryCredentials(t *testing.T) {
+	cf := newACRARMFactory(t)
+	client := cf.NewRegistriesClient()
+	ctx := context.Background()
+
+	createRegistry(t, client, "rg-1", "credreg")
+
+	creds, err := client.ListCredentials(ctx, "rg-1", "credreg", nil)
+	if err != nil {
+		t.Fatalf("ListCredentials: %v", err)
+	}
+
+	if creds.Username == nil || *creds.Username != "credreg" {
+		t.Fatalf("got username %v, want credreg", creds.Username)
+	}
+
+	if len(creds.Passwords) != 2 {
+		t.Fatalf("got %d passwords, want 2", len(creds.Passwords))
+	}
+
+	firstPassword := *creds.Passwords[0].Value
+
+	regen, err := client.RegenerateCredential(ctx, "rg-1", "credreg", armcontainerregistry.RegenerateCredentialParameters{
+		Name: to.Ptr(armcontainerregistry.PasswordNamePassword),
+	}, nil)
+	if err != nil {
+		t.Fatalf("RegenerateCredential: %v", err)
+	}
+
+	if *regen.Passwords[0].Value == firstPassword {
+		t.Fatal("expected password to change after regenerate")
+	}
+
+	// Usages.
+	usages, err := client.ListUsages(ctx, "rg-1", "credreg", nil)
+	if err != nil {
+		t.Fatalf("ListUsages: %v", err)
+	}
+
+	if len(usages.Value) == 0 {
+		t.Fatal("expected non-empty usages")
+	}
+}
+
+func TestSDKACRWebhookAndReplication(t *testing.T) {
+	cf := newACRARMFactory(t)
+	regClient := cf.NewRegistriesClient()
+	ctx := context.Background()
+
+	createRegistry(t, regClient, "rg-1", "hookreg")
+
+	whClient := cf.NewWebhooksClient()
+
+	whPoller, err := whClient.BeginCreate(ctx, "rg-1", "hookreg", "wh1", armcontainerregistry.WebhookCreateParameters{
+		Location: to.Ptr("eastus"),
+		Properties: &armcontainerregistry.WebhookPropertiesCreateParameters{
+			ServiceURI: to.Ptr("https://example.com/hook"),
+			Actions:    []*armcontainerregistry.WebhookAction{to.Ptr(armcontainerregistry.WebhookActionPush)},
+			Status:     to.Ptr(armcontainerregistry.WebhookStatusEnabled),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Webhook BeginCreate: %v", err)
+	}
+
+	whResp, err := whPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("Webhook PollUntilDone: %v", err)
+	}
+
+	if whResp.Name == nil || *whResp.Name != "wh1" {
+		t.Fatalf("got webhook name %v, want wh1", whResp.Name)
+	}
+
+	if _, err := whClient.Get(ctx, "rg-1", "hookreg", "wh1", nil); err != nil {
+		t.Fatalf("Webhook Get: %v", err)
+	}
+
+	whPage, err := whClient.NewListPager("rg-1", "hookreg", nil).NextPage(ctx)
+	if err != nil {
+		t.Fatalf("Webhook List: %v", err)
+	}
+
+	if len(whPage.Value) != 1 {
+		t.Fatalf("got %d webhooks, want 1", len(whPage.Value))
+	}
+
+	whDel, err := whClient.BeginDelete(ctx, "rg-1", "hookreg", "wh1", nil)
+	if err != nil {
+		t.Fatalf("Webhook BeginDelete: %v", err)
+	}
+
+	if _, err := whDel.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Webhook delete poll: %v", err)
+	}
+
+	// Replication.
+	repClient := cf.NewReplicationsClient()
+
+	repPoller, err := repClient.BeginCreate(ctx, "rg-1", "hookreg", "westus", armcontainerregistry.Replication{
+		Location: to.Ptr("westus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("Replication BeginCreate: %v", err)
+	}
+
+	repResp, err := repPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("Replication PollUntilDone: %v", err)
+	}
+
+	if repResp.Name == nil || *repResp.Name != "westus" {
+		t.Fatalf("got replication name %v, want westus", repResp.Name)
+	}
+
+	repPage, err := repClient.NewListPager("rg-1", "hookreg", nil).NextPage(ctx)
+	if err != nil {
+		t.Fatalf("Replication List: %v", err)
+	}
+
+	if len(repPage.Value) != 1 {
+		t.Fatalf("got %d replications, want 1", len(repPage.Value))
+	}
+}

--- a/server/azure/acr/dataplane_tags_test.go
+++ b/server/azure/acr/dataplane_tags_test.go
@@ -1,0 +1,119 @@
+package acr_test
+
+import (
+	"context"
+	"testing"
+
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+func TestSDKACRDeleteTag(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	seedImage(t, reg, "app", "v1")
+	seedImage(t, reg, "app", "v2")
+
+	if _, err := client.DeleteTag(ctx, "app", "v1", nil); err != nil {
+		t.Fatalf("DeleteTag: %v", err)
+	}
+
+	var tags []string
+
+	pager := client.NewListTagsPager("app", nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListTags: %v", err)
+		}
+
+		for _, tag := range page.Tags {
+			tags = append(tags, *tag.Name)
+		}
+	}
+
+	if contains(tags, "v1") {
+		t.Fatalf("tag v1 should be gone, tags=%v", tags)
+	}
+
+	if !contains(tags, "v2") {
+		t.Fatalf("tag v2 should survive, tags=%v", tags)
+	}
+}
+
+func TestSDKACRGetTagProperties(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	seedImage(t, reg, "app", "v1")
+
+	props, err := client.GetTagProperties(ctx, "app", "v1", nil)
+	if err != nil {
+		t.Fatalf("GetTagProperties: %v", err)
+	}
+
+	if props.Tag == nil || props.Tag.Name == nil || *props.Tag.Name != "v1" {
+		t.Fatalf("got tag %v, want v1", props.Tag)
+	}
+
+	if props.Tag.Digest == nil || *props.Tag.Digest == "" {
+		t.Fatal("expected tag digest populated")
+	}
+
+	if props.Tag.ChangeableAttributes == nil || props.Tag.ChangeableAttributes.CanDelete == nil ||
+		!*props.Tag.ChangeableAttributes.CanDelete {
+		t.Fatal("expected changeable attributes with deleteEnabled true")
+	}
+
+	if _, err := client.GetTagProperties(ctx, "app", "ghost", nil); err == nil {
+		t.Fatal("expected error for unknown tag")
+	}
+}
+
+func TestSDKACRListAndGetManifests(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	seedImage(t, reg, "app", "v1")
+
+	var digest string
+
+	pager := client.NewListManifestsPager("app", nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListManifests: %v", err)
+		}
+
+		for _, m := range page.Manifests.Attributes {
+			if m.Digest != nil {
+				digest = *m.Digest
+			}
+		}
+	}
+
+	if digest == "" {
+		t.Fatal("expected at least one manifest with a digest")
+	}
+
+	got, err := client.GetManifestProperties(ctx, "app", digest, nil)
+	if err != nil {
+		t.Fatalf("GetManifestProperties: %v", err)
+	}
+
+	if got.Manifest == nil || got.Manifest.Digest == nil || *got.Manifest.Digest != digest {
+		t.Fatalf("got manifest digest %v, want %s", got.Manifest, digest)
+	}
+}

--- a/server/azure/acr/handler.go
+++ b/server/azure/acr/handler.go
@@ -31,8 +31,8 @@ const pathPrefix = "/acr/v1/"
 
 const (
 	catalogSeg   = "_catalog"
-	tagsSuffix   = "/_tags"
-	manifestsSeg = "/_manifests"
+	tagsSeg      = "_tags"
+	manifestsSeg = "_manifests"
 )
 
 // Handler serves the ACR data-plane catalog API against a ContainerRegistry
@@ -56,22 +56,92 @@ func (*Handler) Matches(r *http.Request) bool {
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	tail := strings.TrimPrefix(r.URL.Path, pathPrefix)
 
-	switch {
-	case tail == catalogSeg && r.Method == http.MethodGet:
-		h.listRepositories(w, r)
-	case strings.Contains(tail, manifestsSeg):
-		// Manifest operations are out of scope; answer explicitly rather than
-		// letting the path masquerade as a (missing) repository.
-		writeErr(w, http.StatusNotImplemented, "UNSUPPORTED", "manifest operations are not supported")
-	case strings.HasSuffix(tail, tagsSuffix) && r.Method == http.MethodGet:
-		h.listTags(w, r, strings.TrimSuffix(tail, tagsSuffix))
-	case r.Method == http.MethodGet:
-		h.getRepositoryProperties(w, r, tail)
-	case r.Method == http.MethodDelete:
-		h.deleteRepository(w, r, tail)
+	if tail == catalogSeg {
+		if r.Method == http.MethodGet {
+			h.listRepositories(w, r)
+			return
+		}
+
+		writeErr(w, http.StatusMethodNotAllowed, "UNSUPPORTED", "unsupported ACR operation")
+
+		return
+	}
+
+	repo, resource, reference := parseACRPath(tail)
+
+	switch resource {
+	case tagsSeg:
+		h.serveTags(w, r, repo, reference)
+	case manifestsSeg:
+		h.serveManifests(w, r, repo, reference)
+	default:
+		h.serveRepository(w, r, repo)
+	}
+}
+
+// parseACRPath splits an ACR data-plane tail into the repository name, the
+// resource kind ("_tags" / "_manifests" / ""), and the trailing reference. The
+// repository name may be hierarchical (e.g. "team/app"), so the split hinges on
+// the "_tags" / "_manifests" marker segment rather than the first slash.
+func parseACRPath(tail string) (repo, resource, reference string) {
+	for _, marker := range []string{tagsSeg, manifestsSeg} {
+		if idx := strings.Index(tail, "/"+marker+"/"); idx >= 0 {
+			return tail[:idx], marker, tail[idx+len(marker)+2:]
+		}
+
+		if strings.HasSuffix(tail, "/"+marker) {
+			return strings.TrimSuffix(tail, "/"+marker), marker, ""
+		}
+	}
+
+	return tail, "", ""
+}
+
+func (h *Handler) serveRepository(w http.ResponseWriter, r *http.Request, repo string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getRepositoryProperties(w, r, repo)
+	case http.MethodDelete:
+		h.deleteRepository(w, r, repo)
 	default:
 		writeErr(w, http.StatusMethodNotAllowed, "UNSUPPORTED", "unsupported ACR operation")
 	}
+}
+
+func (h *Handler) serveTags(w http.ResponseWriter, r *http.Request, repo, tag string) {
+	if tag == "" {
+		if r.Method == http.MethodGet {
+			h.listTags(w, r, repo)
+			return
+		}
+
+		writeErr(w, http.StatusMethodNotAllowed, "UNSUPPORTED", "unsupported ACR operation")
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getTagProperties(w, r, repo, tag)
+	case http.MethodDelete:
+		h.deleteTag(w, r, repo, tag)
+	default:
+		writeErr(w, http.StatusMethodNotAllowed, "UNSUPPORTED", "unsupported ACR operation")
+	}
+}
+
+func (h *Handler) serveManifests(w http.ResponseWriter, r *http.Request, repo, digest string) {
+	if r.Method != http.MethodGet {
+		writeErr(w, http.StatusMethodNotAllowed, "UNSUPPORTED", "unsupported ACR operation")
+		return
+	}
+
+	if digest == "" {
+		h.listManifests(w, r, repo)
+		return
+	}
+
+	h.getManifestProperties(w, r, repo, digest)
 }
 
 // writeErr emits an ACR-style error body with the given HTTP status.

--- a/server/azure/acr/operations.go
+++ b/server/azure/acr/operations.go
@@ -3,6 +3,8 @@ package acr
 import (
 	"encoding/json"
 	"net/http"
+
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
 )
 
 func (h *Handler) listRepositories(w http.ResponseWriter, r *http.Request) {
@@ -68,6 +70,89 @@ func (h *Handler) deleteRepository(w http.ResponseWriter, r *http.Request, repo 
 	writeJSON(w, http.StatusAccepted, deleteRepositoryResponse{
 		ManifestsDeleted: []string{},
 		TagsDeleted:      []string{},
+	})
+}
+
+// findTag locates the image carrying tag in repo and returns it, or ok=false.
+func findTag(images []crdriver.ImageDetail, tag string) (crdriver.ImageDetail, bool) {
+	for i := range images {
+		for _, t := range images[i].Tags {
+			if t == tag {
+				return images[i], true
+			}
+		}
+	}
+
+	return crdriver.ImageDetail{}, false
+}
+
+func (h *Handler) getTagProperties(w http.ResponseWriter, r *http.Request, repo, tag string) {
+	images, err := h.registry.ListImages(r.Context(), repo)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	img, ok := findTag(images, tag)
+	if !ok {
+		writeErr(w, http.StatusNotFound, "TAG_UNKNOWN", "tag "+tag+" not found in repository "+repo)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, tagProperties{
+		Registry:  registryLoginServer,
+		ImageName: repo,
+		Tag: tagAttributes{
+			Name:                 tag,
+			Digest:               img.Digest,
+			CreatedTime:          img.PushedAt,
+			LastUpdateTime:       img.PushedAt,
+			ChangeableAttributes: allEnabled(),
+		},
+	})
+}
+
+func (h *Handler) deleteTag(w http.ResponseWriter, r *http.Request, repo, tag string) {
+	writer, ok := h.registry.(crdriver.AzureRepositoryWriter)
+	if !ok {
+		writeErr(w, http.StatusNotImplemented, "UNSUPPORTED", "tag deletion is not supported by this registry driver")
+		return
+	}
+
+	if err := writer.DeleteTag(r.Context(), repo, tag); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	// ACR answers DELETE _tags/{tag} with 202 Accepted and an empty body.
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *Handler) listManifests(w http.ResponseWriter, r *http.Request, repo string) {
+	images, err := h.registry.ListImages(r.Context(), repo)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, manifestList{
+		Registry:  registryLoginServer,
+		ImageName: repo,
+		Manifests: toManifestAttributes(images),
+	})
+}
+
+func (h *Handler) getManifestProperties(w http.ResponseWriter, r *http.Request, repo, digest string) {
+	img, err := h.registry.GetImage(r.Context(), repo, digest)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, manifestProperties{
+		Registry:  registryLoginServer,
+		ImageName: repo,
+		Manifest:  toManifestAttribute(img),
 	})
 }
 

--- a/server/azure/acr/registry.go
+++ b/server/azure/acr/registry.go
@@ -86,8 +86,10 @@ func (h *ARMHandler) serveRegistryCollection(w http.ResponseWriter, r *http.Requ
 
 func (h *ARMHandler) serveRegistry(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	switch r.Method {
-	case http.MethodPut, http.MethodPatch:
+	case http.MethodPut:
 		h.createOrUpdateRegistry(w, r, rp)
+	case http.MethodPatch:
+		h.updateRegistry(w, r, rp)
 	case http.MethodGet:
 		h.getRegistry(w, r, rp)
 	case http.MethodDelete:
@@ -97,6 +99,8 @@ func (h *ARMHandler) serveRegistry(w http.ResponseWriter, r *http.Request, rp *a
 	}
 }
 
+// createOrUpdateRegistry handles the ARM PUT (full create-or-replace): every
+// attribute is taken from the request body, replacing the stored registry.
 func (h *ARMHandler) createOrUpdateRegistry(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body armRegistry
 	if !azurearm.DecodeJSON(w, r, &body) {
@@ -120,7 +124,45 @@ func (h *ARMHandler) createOrUpdateRegistry(w http.ResponseWriter, r *http.Reque
 		cfg.AdminUserEnabled = body.Properties.AdminUserEnabled
 	}
 
-	reg, err := h.mgr.CreateOrUpdateRegistry(r.Context(), rp.ResourceGroup, rp.ResourceName, cfg)
+	reg, created, err := h.mgr.CreateOrUpdateRegistry(r.Context(), rp.ResourceGroup, rp.ResourceName, cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, createdStatus(created), toARMRegistry(reg, rp.Subscription))
+}
+
+// updateRegistry handles the ARM PATCH (partial update): only attributes
+// present in the request body are overwritten; the rest are preserved.
+func (h *ARMHandler) updateRegistry(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body armRegistry
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	var upd crdriver.AzureRegistryUpdate
+
+	if body.Tags != nil {
+		upd.Tags = fromPtrTags(body.Tags)
+	}
+
+	if body.SKU != nil {
+		sku := body.SKU.Name
+		upd.SKUName = &sku
+	}
+
+	if body.Identity != nil {
+		id := body.Identity.Type
+		upd.IdentityType = &id
+	}
+
+	if body.Properties != nil {
+		admin := body.Properties.AdminUserEnabled
+		upd.AdminUserEnabled = &admin
+	}
+
+	reg, err := h.mgr.UpdateRegistry(r.Context(), rp.ResourceGroup, rp.ResourceName, upd)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -220,4 +262,14 @@ func (h *ARMHandler) getListUsages(w http.ResponseWriter, r *http.Request, rp *a
 
 func armMethodNotAllowed(w http.ResponseWriter) {
 	azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+}
+
+// createdStatus maps an ARM PUT create-or-replace outcome to its status code:
+// 201 Created on first create, 200 OK on replace.
+func createdStatus(created bool) int {
+	if created {
+		return http.StatusCreated
+	}
+
+	return http.StatusOK
 }

--- a/server/azure/acr/registry.go
+++ b/server/azure/acr/registry.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
 )
@@ -136,7 +137,7 @@ func (h *ARMHandler) createOrUpdateRegistry(w http.ResponseWriter, r *http.Reque
 // updateRegistry handles the ARM PATCH (partial update): only attributes
 // present in the request body are overwritten; the rest are preserved.
 func (h *ARMHandler) updateRegistry(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	var body armRegistry
+	var body armRegistryUpdateParameters
 	if !azurearm.DecodeJSON(w, r, &body) {
 		return
 	}
@@ -157,9 +158,8 @@ func (h *ARMHandler) updateRegistry(w http.ResponseWriter, r *http.Request, rp *
 		upd.IdentityType = &id
 	}
 
-	if body.Properties != nil {
-		admin := body.Properties.AdminUserEnabled
-		upd.AdminUserEnabled = &admin
+	if body.Properties != nil && body.Properties.AdminUserEnabled != nil {
+		upd.AdminUserEnabled = body.Properties.AdminUserEnabled
 	}
 
 	reg, err := h.mgr.UpdateRegistry(r.Context(), rp.ResourceGroup, rp.ResourceName, upd)
@@ -182,12 +182,22 @@ func (h *ARMHandler) getRegistry(w http.ResponseWriter, r *http.Request, rp *azu
 }
 
 func (h *ARMHandler) deleteRegistry(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	if err := h.mgr.DeleteRegistry(r.Context(), rp.ResourceGroup, rp.ResourceName); err != nil {
-		azurearm.WriteCErr(w, err)
-		return
-	}
+	writeDeleteStatus(w, h.mgr.DeleteRegistry(r.Context(), rp.ResourceGroup, rp.ResourceName))
+}
 
-	w.WriteHeader(http.StatusOK)
+// writeDeleteStatus renders an idempotent ARM DELETE result: 200 OK when the
+// resource existed and was removed, 204 No Content when it was already absent.
+// ARM DELETE is idempotent — the ACR swagger documents 204 "does not exist in
+// the subscription" for a missing registry/webhook/replication.
+func writeDeleteStatus(w http.ResponseWriter, err error) {
+	switch {
+	case err == nil:
+		w.WriteHeader(http.StatusOK)
+	case cerrors.IsNotFound(err):
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		azurearm.WriteCErr(w, err)
+	}
 }
 
 func (h *ARMHandler) postListCredentials(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {

--- a/server/azure/acr/registry.go
+++ b/server/azure/acr/registry.go
@@ -1,0 +1,223 @@
+package acr
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+// ARMHandler serves the Microsoft.ContainerRegistry ARM management plane
+// (registries, admin credentials, usages, webhooks, geo-replications) against
+// an AzureRegistryManager. It is registered alongside the /acr/v1 data-plane
+// Handler; the two match disjoint path prefixes.
+type ARMHandler struct {
+	mgr crdriver.AzureRegistryManager
+}
+
+// NewARM returns an ARM handler backed by mgr.
+func NewARM(mgr crdriver.AzureRegistryManager) *ARMHandler {
+	return &ARMHandler{mgr: mgr}
+}
+
+// Matches claims ARM Microsoft.ContainerRegistry/registries paths.
+func (*ARMHandler) Matches(r *http.Request) bool {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	return strings.EqualFold(rp.Provider, armProviderName) &&
+		strings.EqualFold(rp.ResourceType, resourceTypeRegistries)
+}
+
+// ServeHTTP routes on path shape and method.
+func (h *ARMHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	if rp.ResourceName == "" {
+		h.serveRegistryCollection(w, r, &rp)
+		return
+	}
+
+	switch {
+	case rp.SubResource == "":
+		h.serveRegistry(w, r, &rp)
+	case strings.EqualFold(rp.SubResource, "listCredentials"):
+		h.postListCredentials(w, r, &rp)
+	case strings.EqualFold(rp.SubResource, "regenerateCredential"):
+		h.postRegenerateCredential(w, r, &rp)
+	case strings.EqualFold(rp.SubResource, "listUsages"):
+		h.getListUsages(w, r, &rp)
+	case strings.EqualFold(rp.SubResource, "webhooks"):
+		h.serveWebhook(w, r, &rp)
+	case strings.EqualFold(rp.SubResource, "replications"):
+		h.serveReplication(w, r, &rp)
+	default:
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"ACR sub-resource not implemented: "+rp.SubResource)
+	}
+}
+
+func (h *ARMHandler) serveRegistryCollection(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		armMethodNotAllowed(w)
+		return
+	}
+
+	regs, err := h.mgr.ListRegistries(r.Context(), rp.ResourceGroup)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]armRegistry, 0, len(regs))
+	for i := range regs {
+		out = append(out, toARMRegistry(&regs[i], rp.Subscription))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armRegistryList[armRegistry]{Value: out})
+}
+
+func (h *ARMHandler) serveRegistry(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	switch r.Method {
+	case http.MethodPut, http.MethodPatch:
+		h.createOrUpdateRegistry(w, r, rp)
+	case http.MethodGet:
+		h.getRegistry(w, r, rp)
+	case http.MethodDelete:
+		h.deleteRegistry(w, r, rp)
+	default:
+		armMethodNotAllowed(w)
+	}
+}
+
+func (h *ARMHandler) createOrUpdateRegistry(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body armRegistry
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	cfg := crdriver.AzureRegistryConfig{
+		Location: body.Location,
+		Tags:     fromPtrTags(body.Tags),
+	}
+
+	if body.SKU != nil {
+		cfg.SKUName = body.SKU.Name
+	}
+
+	if body.Identity != nil {
+		cfg.IdentityType = body.Identity.Type
+	}
+
+	if body.Properties != nil {
+		cfg.AdminUserEnabled = body.Properties.AdminUserEnabled
+	}
+
+	reg, err := h.mgr.CreateOrUpdateRegistry(r.Context(), rp.ResourceGroup, rp.ResourceName, cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMRegistry(reg, rp.Subscription))
+}
+
+func (h *ARMHandler) getRegistry(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	reg, err := h.mgr.GetRegistry(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMRegistry(reg, rp.Subscription))
+}
+
+func (h *ARMHandler) deleteRegistry(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if err := h.mgr.DeleteRegistry(r.Context(), rp.ResourceGroup, rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *ARMHandler) postListCredentials(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodPost {
+		armMethodNotAllowed(w)
+		return
+	}
+
+	creds, err := h.mgr.ListRegistryCredentials(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toCredentialsResult(creds))
+}
+
+func (h *ARMHandler) postRegenerateCredential(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodPost {
+		armMethodNotAllowed(w)
+		return
+	}
+
+	var body armRegenerateCredentialParameters
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	creds, err := h.mgr.RegenerateRegistryCredential(r.Context(), rp.ResourceGroup, rp.ResourceName, body.Name)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toCredentialsResult(creds))
+}
+
+func toCredentialsResult(creds *crdriver.AzureRegistryCredentials) armRegistryListCredentialsResult {
+	return armRegistryListCredentialsResult{
+		Username: creds.Username,
+		Passwords: []armRegistryPassword{
+			{Name: "password", Value: creds.Password},
+			{Name: "password2", Value: creds.Password2},
+		},
+	}
+}
+
+func (h *ARMHandler) getListUsages(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		armMethodNotAllowed(w)
+		return
+	}
+
+	usages, err := h.mgr.ListRegistryUsages(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]armRegistryUsage, 0, len(usages))
+	for i := range usages {
+		out = append(out, armRegistryUsage{
+			Name:         usages[i].Name,
+			Limit:        usages[i].Limit,
+			CurrentValue: usages[i].CurrentValue,
+			Unit:         usages[i].Unit,
+		})
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armRegistryUsageListResult{Value: out})
+}
+
+func armMethodNotAllowed(w http.ResponseWriter) {
+	azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+}

--- a/server/azure/acr/registry_types.go
+++ b/server/azure/acr/registry_types.go
@@ -45,6 +45,22 @@ type armRegistryProperties struct {
 	AdminUserEnabled  bool   `json:"adminUserEnabled"`
 }
 
+// armRegistryUpdateParameters mirrors armcontainerregistry.RegistryUpdateParameters
+// for ARM PATCH decoding. Every field is a pointer so an absent field is
+// distinguishable from a zero value and left untouched during the partial merge;
+// modeling AdminUserEnabled as a bare bool would silently reset it to false on
+// any PATCH that only touches another property.
+type armRegistryUpdateParameters struct {
+	Tags       map[string]*string      `json:"tags,omitempty"`
+	SKU        *armRegistrySKU         `json:"sku,omitempty"`
+	Identity   *armRegistryIdentity    `json:"identity,omitempty"`
+	Properties *armRegistryUpdateProps `json:"properties,omitempty"`
+}
+
+type armRegistryUpdateProps struct {
+	AdminUserEnabled *bool `json:"adminUserEnabled,omitempty"`
+}
+
 // armRegistryListCredentialsResult mirrors RegistryListCredentialsResult.
 type armRegistryListCredentialsResult struct {
 	Username  string                `json:"username,omitempty"`

--- a/server/azure/acr/registry_types.go
+++ b/server/azure/acr/registry_types.go
@@ -1,0 +1,218 @@
+package acr
+
+import (
+	"time"
+
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+// ARM resource type identifiers for the Microsoft.ContainerRegistry provider.
+const (
+	armProviderName        = "Microsoft.ContainerRegistry"
+	resourceTypeRegistries = "registries"
+	registryTypeFull       = "Microsoft.ContainerRegistry/registries"
+	webhookTypeFull        = "Microsoft.ContainerRegistry/registries/webhooks"
+	replicationTypeFull    = "Microsoft.ContainerRegistry/registries/replications"
+)
+
+// armRegistry mirrors armcontainerregistry.Registry.
+type armRegistry struct {
+	ID         string                 `json:"id,omitempty"`
+	Name       string                 `json:"name,omitempty"`
+	Type       string                 `json:"type,omitempty"`
+	Location   string                 `json:"location,omitempty"`
+	Tags       map[string]*string     `json:"tags,omitempty"`
+	SKU        *armRegistrySKU        `json:"sku,omitempty"`
+	Identity   *armRegistryIdentity   `json:"identity,omitempty"`
+	Properties *armRegistryProperties `json:"properties,omitempty"`
+}
+
+type armRegistrySKU struct {
+	Name string `json:"name,omitempty"`
+	Tier string `json:"tier,omitempty"`
+}
+
+type armRegistryIdentity struct {
+	Type        string `json:"type,omitempty"`
+	PrincipalID string `json:"principalId,omitempty"`
+	TenantID    string `json:"tenantId,omitempty"`
+}
+
+type armRegistryProperties struct {
+	LoginServer       string `json:"loginServer,omitempty"`
+	CreationDate      string `json:"creationDate,omitempty"`
+	ProvisioningState string `json:"provisioningState,omitempty"`
+	AdminUserEnabled  bool   `json:"adminUserEnabled"`
+}
+
+// armRegistryListCredentialsResult mirrors RegistryListCredentialsResult.
+type armRegistryListCredentialsResult struct {
+	Username  string                `json:"username,omitempty"`
+	Passwords []armRegistryPassword `json:"passwords,omitempty"`
+}
+
+type armRegistryPassword struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+// armRegenerateCredentialParameters mirrors RegenerateCredentialParameters.
+type armRegenerateCredentialParameters struct {
+	Name string `json:"name,omitempty"`
+}
+
+// armRegistryUsageListResult mirrors RegistryUsageListResult.
+type armRegistryUsageListResult struct {
+	Value []armRegistryUsage `json:"value"`
+}
+
+type armRegistryUsage struct {
+	Name         string `json:"name,omitempty"`
+	Limit        int64  `json:"limit"`
+	CurrentValue int64  `json:"currentValue"`
+	Unit         string `json:"unit,omitempty"`
+}
+
+// armWebhook mirrors armcontainerregistry.Webhook. Properties on create carry
+// serviceUri and customHeaders (WebhookPropertiesCreateParameters); the GET
+// response omits them (WebhookProperties), so serviceUri/customHeaders are
+// decode-only and left off the response shape.
+type armWebhook struct {
+	ID         string             `json:"id,omitempty"`
+	Name       string             `json:"name,omitempty"`
+	Type       string             `json:"type,omitempty"`
+	Location   string             `json:"location,omitempty"`
+	Tags       map[string]*string `json:"tags,omitempty"`
+	Properties *armWebhookProps   `json:"properties,omitempty"`
+}
+
+type armWebhookProps struct {
+	ServiceURI        string             `json:"serviceUri,omitempty"`
+	Actions           []string           `json:"actions,omitempty"`
+	Scope             string             `json:"scope,omitempty"`
+	Status            string             `json:"status,omitempty"`
+	CustomHeaders     map[string]*string `json:"customHeaders,omitempty"`
+	ProvisioningState string             `json:"provisioningState,omitempty"`
+}
+
+// armReplication mirrors armcontainerregistry.Replication.
+type armReplication struct {
+	ID         string               `json:"id,omitempty"`
+	Name       string               `json:"name,omitempty"`
+	Type       string               `json:"type,omitempty"`
+	Location   string               `json:"location,omitempty"`
+	Tags       map[string]*string   `json:"tags,omitempty"`
+	Properties *armReplicationProps `json:"properties,omitempty"`
+}
+
+type armReplicationProps struct {
+	RegionEndpointEnabled bool                  `json:"regionEndpointEnabled"`
+	ProvisioningState     string                `json:"provisioningState,omitempty"`
+	Status                *armReplicationStatus `json:"status,omitempty"`
+}
+
+type armReplicationStatus struct {
+	DisplayStatus string `json:"displayStatus,omitempty"`
+}
+
+// armRegistryList is the ARM list envelope for registries.
+type armRegistryList[T any] struct {
+	Value    []T    `json:"value"`
+	NextLink string `json:"nextLink,omitempty"`
+}
+
+func toARMRegistry(reg *crdriver.AzureRegistry, subscription string) armRegistry {
+	out := armRegistry{
+		ID:       registryResourceID(subscription, reg.ResourceGroup, reg.Name),
+		Name:     reg.Name,
+		Type:     registryTypeFull,
+		Location: reg.Location,
+		Tags:     toPtrTags(reg.Tags),
+		SKU:      &armRegistrySKU{Name: reg.SKUName, Tier: reg.SKUTier},
+		Properties: &armRegistryProperties{
+			LoginServer:       reg.LoginServer,
+			CreationDate:      reg.CreationDate.UTC().Format(time.RFC3339),
+			ProvisioningState: reg.ProvisioningState,
+			AdminUserEnabled:  reg.AdminUserEnabled,
+		},
+	}
+
+	if reg.IdentityType != "" && reg.IdentityType != "None" {
+		out.Identity = &armRegistryIdentity{
+			Type:        reg.IdentityType,
+			PrincipalID: reg.PrincipalID,
+			TenantID:    reg.TenantID,
+		}
+	}
+
+	return out
+}
+
+func toARMWebhook(wh *crdriver.AzureWebhook, subscription string) armWebhook {
+	return armWebhook{
+		ID:       registryResourceID(subscription, wh.ResourceGroup, wh.RegistryName) + "/webhooks/" + wh.Name,
+		Name:     wh.Name,
+		Type:     webhookTypeFull,
+		Location: wh.Location,
+		Tags:     toPtrTags(wh.Tags),
+		Properties: &armWebhookProps{
+			Actions:           wh.Actions,
+			Scope:             wh.Scope,
+			Status:            wh.Status,
+			ProvisioningState: wh.ProvisioningState,
+		},
+	}
+}
+
+func toARMReplication(rep *crdriver.AzureReplication, subscription string) armReplication {
+	return armReplication{
+		ID:       registryResourceID(subscription, rep.ResourceGroup, rep.RegistryName) + "/replications/" + rep.Name,
+		Name:     rep.Name,
+		Type:     replicationTypeFull,
+		Location: rep.Location,
+		Tags:     toPtrTags(rep.Tags),
+		Properties: &armReplicationProps{
+			RegionEndpointEnabled: rep.RegionEndpointEnabled,
+			ProvisioningState:     rep.ProvisioningState,
+			Status:                &armReplicationStatus{DisplayStatus: rep.Status},
+		},
+	}
+}
+
+func registryResourceID(subscription, rg, name string) string {
+	return "/subscriptions/" + subscription +
+		"/resourceGroups/" + rg +
+		"/providers/" + armProviderName +
+		"/registries/" + name
+}
+
+func toPtrTags(in map[string]string) map[string]*string {
+	if in == nil {
+		return nil
+	}
+
+	out := make(map[string]*string, len(in))
+
+	for k, v := range in {
+		val := v
+		out[k] = &val
+	}
+
+	return out
+}
+
+func fromPtrTags(in map[string]*string) map[string]string {
+	if in == nil {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+
+	for k, v := range in {
+		if v != nil {
+			out[k] = *v
+		}
+	}
+
+	return out
+}

--- a/server/azure/acr/replication.go
+++ b/server/azure/acr/replication.go
@@ -101,12 +101,7 @@ func (h *ARMHandler) getReplication(w http.ResponseWriter, r *http.Request, rp *
 }
 
 func (h *ARMHandler) deleteReplication(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	if err := h.mgr.DeleteReplication(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName); err != nil {
-		azurearm.WriteCErr(w, err)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
+	writeDeleteStatus(w, h.mgr.DeleteReplication(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName))
 }
 
 //nolint:dupl // webhook and replication sub-resource lists are intentionally typed; sharing via generics adds noise.

--- a/server/azure/acr/replication.go
+++ b/server/azure/acr/replication.go
@@ -1,0 +1,95 @@
+package acr
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+// serveReplication routes .../registries/{registry}/replications[/{name}].
+//
+//nolint:dupl // webhook and replication sub-resource routers are intentionally typed; sharing via generics adds noise.
+func (h *ARMHandler) serveReplication(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if rp.SubResourceName == "" {
+		if r.Method != http.MethodGet {
+			armMethodNotAllowed(w)
+			return
+		}
+
+		h.listReplications(w, r, rp)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut, http.MethodPatch:
+		h.createOrUpdateReplication(w, r, rp)
+	case http.MethodGet:
+		h.getReplication(w, r, rp)
+	case http.MethodDelete:
+		h.deleteReplication(w, r, rp)
+	default:
+		armMethodNotAllowed(w)
+	}
+}
+
+func (h *ARMHandler) createOrUpdateReplication(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body armReplication
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	cfg := crdriver.AzureReplicationConfig{
+		Location:              body.Location,
+		Tags:                  fromPtrTags(body.Tags),
+		RegionEndpointEnabled: true,
+	}
+
+	if body.Properties != nil {
+		cfg.RegionEndpointEnabled = body.Properties.RegionEndpointEnabled
+	}
+
+	rep, err := h.mgr.CreateOrUpdateReplication(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName, cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMReplication(rep, rp.Subscription))
+}
+
+func (h *ARMHandler) getReplication(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	rep, err := h.mgr.GetReplication(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMReplication(rep, rp.Subscription))
+}
+
+func (h *ARMHandler) deleteReplication(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if err := h.mgr.DeleteReplication(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+//nolint:dupl // webhook and replication sub-resource lists are intentionally typed; sharing via generics adds noise.
+func (h *ARMHandler) listReplications(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	reps, err := h.mgr.ListReplications(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]armReplication, 0, len(reps))
+	for i := range reps {
+		out = append(out, toARMReplication(&reps[i], rp.Subscription))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armRegistryList[armReplication]{Value: out})
+}

--- a/server/azure/acr/replication.go
+++ b/server/azure/acr/replication.go
@@ -23,8 +23,10 @@ func (h *ARMHandler) serveReplication(w http.ResponseWriter, r *http.Request, rp
 	}
 
 	switch r.Method {
-	case http.MethodPut, http.MethodPatch:
+	case http.MethodPut:
 		h.createOrUpdateReplication(w, r, rp)
+	case http.MethodPatch:
+		h.updateReplication(w, r, rp)
 	case http.MethodGet:
 		h.getReplication(w, r, rp)
 	case http.MethodDelete:
@@ -34,6 +36,7 @@ func (h *ARMHandler) serveReplication(w http.ResponseWriter, r *http.Request, rp
 	}
 }
 
+// createOrUpdateReplication handles the ARM PUT (full create-or-replace).
 func (h *ARMHandler) createOrUpdateReplication(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body armReplication
 	if !azurearm.DecodeJSON(w, r, &body) {
@@ -50,7 +53,35 @@ func (h *ARMHandler) createOrUpdateReplication(w http.ResponseWriter, r *http.Re
 		cfg.RegionEndpointEnabled = body.Properties.RegionEndpointEnabled
 	}
 
-	rep, err := h.mgr.CreateOrUpdateReplication(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName, cfg)
+	rep, created, err := h.mgr.CreateOrUpdateReplication(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName, cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, createdStatus(created), toARMReplication(rep, rp.Subscription))
+}
+
+// updateReplication handles the ARM PATCH (partial update): only properties
+// present in the request body are overwritten; the rest are preserved.
+func (h *ARMHandler) updateReplication(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body armReplication
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	var upd crdriver.AzureReplicationUpdate
+
+	if body.Tags != nil {
+		upd.Tags = fromPtrTags(body.Tags)
+	}
+
+	if body.Properties != nil {
+		enabled := body.Properties.RegionEndpointEnabled
+		upd.RegionEndpointEnabled = &enabled
+	}
+
+	rep, err := h.mgr.UpdateReplication(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName, upd)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/acr/types.go
+++ b/server/azure/acr/types.go
@@ -61,6 +61,64 @@ type deleteRepositoryResponse struct {
 	TagsDeleted      []string `json:"tagsDeleted"`
 }
 
+// tagProperties is the GET /acr/v1/{name}/_tags/{tag} body.
+type tagProperties struct {
+	Registry  string        `json:"registry"`
+	ImageName string        `json:"imageName"`
+	Tag       tagAttributes `json:"tag"`
+}
+
+// manifestAttributes is one entry in the _manifests list.
+type manifestAttributes struct {
+	Digest               string               `json:"digest"`
+	CreatedTime          string               `json:"createdTime,omitempty"`
+	LastUpdateTime       string               `json:"lastUpdateTime,omitempty"`
+	MediaType            string               `json:"mediaType,omitempty"`
+	ImageSize            int64                `json:"imageSize"`
+	Tags                 []string             `json:"tags"`
+	ChangeableAttributes changeableAttributes `json:"changeableAttributes"`
+}
+
+// manifestList is the GET /acr/v1/{name}/_manifests body.
+type manifestList struct {
+	Registry  string               `json:"registry"`
+	ImageName string               `json:"imageName"`
+	Manifests []manifestAttributes `json:"manifests"`
+}
+
+// manifestProperties is the GET /acr/v1/{name}/_manifests/{digest} body.
+type manifestProperties struct {
+	Registry  string             `json:"registry"`
+	ImageName string             `json:"imageName"`
+	Manifest  manifestAttributes `json:"manifest"`
+}
+
+func toManifestAttribute(img *crdriver.ImageDetail) manifestAttributes {
+	tags := img.Tags
+	if tags == nil {
+		tags = []string{}
+	}
+
+	return manifestAttributes{
+		Digest:               img.Digest,
+		CreatedTime:          img.PushedAt,
+		LastUpdateTime:       img.PushedAt,
+		MediaType:            img.MediaType,
+		ImageSize:            img.SizeBytes,
+		Tags:                 tags,
+		ChangeableAttributes: allEnabled(),
+	}
+}
+
+func toManifestAttributes(images []crdriver.ImageDetail) []manifestAttributes {
+	out := make([]manifestAttributes, 0, len(images))
+	for i := range images {
+		out = append(out, toManifestAttribute(&images[i]))
+	}
+
+	return out
+}
+
 // registriesMarker precedes the repository name in the Azure resource ID the
 // driver stores (…/Microsoft.ContainerRegistry/registries/{name}).
 const registriesMarker = "/registries/"

--- a/server/azure/acr/webhook.go
+++ b/server/azure/acr/webhook.go
@@ -1,0 +1,98 @@
+package acr
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+// serveWebhook routes .../registries/{registry}/webhooks[/{name}].
+//
+//nolint:dupl // webhook and replication sub-resource routers are intentionally typed; sharing via generics adds noise.
+func (h *ARMHandler) serveWebhook(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if rp.SubResourceName == "" {
+		if r.Method != http.MethodGet {
+			armMethodNotAllowed(w)
+			return
+		}
+
+		h.listWebhooks(w, r, rp)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut, http.MethodPatch:
+		h.createOrUpdateWebhook(w, r, rp)
+	case http.MethodGet:
+		h.getWebhook(w, r, rp)
+	case http.MethodDelete:
+		h.deleteWebhook(w, r, rp)
+	default:
+		armMethodNotAllowed(w)
+	}
+}
+
+func (h *ARMHandler) createOrUpdateWebhook(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body armWebhook
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	cfg := crdriver.AzureWebhookConfig{
+		Location: body.Location,
+		Tags:     fromPtrTags(body.Tags),
+	}
+
+	if body.Properties != nil {
+		cfg.ServiceURI = body.Properties.ServiceURI
+		cfg.Actions = body.Properties.Actions
+		cfg.Scope = body.Properties.Scope
+		cfg.Status = body.Properties.Status
+		cfg.CustomHeaders = fromPtrTags(body.Properties.CustomHeaders)
+	}
+
+	wh, err := h.mgr.CreateOrUpdateWebhook(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName, cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMWebhook(wh, rp.Subscription))
+}
+
+func (h *ARMHandler) getWebhook(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	wh, err := h.mgr.GetWebhook(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMWebhook(wh, rp.Subscription))
+}
+
+func (h *ARMHandler) deleteWebhook(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if err := h.mgr.DeleteWebhook(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+//nolint:dupl // webhook and replication sub-resource lists are intentionally typed; sharing via generics adds noise.
+func (h *ARMHandler) listWebhooks(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	whs, err := h.mgr.ListWebhooks(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]armWebhook, 0, len(whs))
+	for i := range whs {
+		out = append(out, toARMWebhook(&whs[i], rp.Subscription))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armRegistryList[armWebhook]{Value: out})
+}

--- a/server/azure/acr/webhook.go
+++ b/server/azure/acr/webhook.go
@@ -132,12 +132,7 @@ func (h *ARMHandler) getWebhook(w http.ResponseWriter, r *http.Request, rp *azur
 }
 
 func (h *ARMHandler) deleteWebhook(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	if err := h.mgr.DeleteWebhook(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName); err != nil {
-		azurearm.WriteCErr(w, err)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
+	writeDeleteStatus(w, h.mgr.DeleteWebhook(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName))
 }
 
 //nolint:dupl // webhook and replication sub-resource lists are intentionally typed; sharing via generics adds noise.

--- a/server/azure/acr/webhook.go
+++ b/server/azure/acr/webhook.go
@@ -23,8 +23,10 @@ func (h *ARMHandler) serveWebhook(w http.ResponseWriter, r *http.Request, rp *az
 	}
 
 	switch r.Method {
-	case http.MethodPut, http.MethodPatch:
+	case http.MethodPut:
 		h.createOrUpdateWebhook(w, r, rp)
+	case http.MethodPatch:
+		h.updateWebhook(w, r, rp)
 	case http.MethodGet:
 		h.getWebhook(w, r, rp)
 	case http.MethodDelete:
@@ -34,6 +36,7 @@ func (h *ARMHandler) serveWebhook(w http.ResponseWriter, r *http.Request, rp *az
 	}
 }
 
+// createOrUpdateWebhook handles the ARM PUT (full create-or-replace).
 func (h *ARMHandler) createOrUpdateWebhook(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body armWebhook
 	if !azurearm.DecodeJSON(w, r, &body) {
@@ -53,13 +56,69 @@ func (h *ARMHandler) createOrUpdateWebhook(w http.ResponseWriter, r *http.Reques
 		cfg.CustomHeaders = fromPtrTags(body.Properties.CustomHeaders)
 	}
 
-	wh, err := h.mgr.CreateOrUpdateWebhook(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName, cfg)
+	wh, created, err := h.mgr.CreateOrUpdateWebhook(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName, cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, createdStatus(created), toARMWebhook(wh, rp.Subscription))
+}
+
+// updateWebhook handles the ARM PATCH (partial update): only properties present
+// in the request body are overwritten; the rest are preserved.
+func (h *ARMHandler) updateWebhook(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body armWebhook
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	upd := crdriver.AzureWebhookUpdate{}
+
+	if body.Tags != nil {
+		upd.Tags = fromPtrTags(body.Tags)
+	}
+
+	applyWebhookProps(body.Properties, &upd)
+
+	wh, err := h.mgr.UpdateWebhook(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName, upd)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, toARMWebhook(wh, rp.Subscription))
+}
+
+// applyWebhookProps copies the properties present in a PATCH body onto upd,
+// leaving absent fields nil so the provider preserves the stored values.
+func applyWebhookProps(p *armWebhookProps, upd *crdriver.AzureWebhookUpdate) {
+	if p == nil {
+		return
+	}
+
+	if p.ServiceURI != "" {
+		uri := p.ServiceURI
+		upd.ServiceURI = &uri
+	}
+
+	if p.Actions != nil {
+		upd.Actions = p.Actions
+	}
+
+	if p.Scope != "" {
+		scope := p.Scope
+		upd.Scope = &scope
+	}
+
+	if p.Status != "" {
+		status := p.Status
+		upd.Status = &status
+	}
+
+	if p.CustomHeaders != nil {
+		upd.CustomHeaders = fromPtrTags(p.CustomHeaders)
+	}
 }
 
 func (h *ARMHandler) getWebhook(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {

--- a/server/azure/aks/operations.go
+++ b/server/azure/aks/operations.go
@@ -3,6 +3,7 @@ package aks
 import (
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/providers/azure/aks"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 )
@@ -100,12 +101,19 @@ func (h *Handler) updateClusterTags(w http.ResponseWriter, r *http.Request, rp *
 }
 
 func (h *Handler) deleteCluster(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	if err := h.be.DeleteCluster(r.Context(), rp.ResourceGroup, rp.ResourceName); err != nil {
+	writeIdempotentDelete(w, h.be.DeleteCluster(r.Context(), rp.ResourceGroup, rp.ResourceName))
+}
+
+// writeIdempotentDelete renders an ARM DELETE result. ARM DELETE is idempotent:
+// a missing resource is a successful no-op, so a NotFound error is treated the
+// same as a successful delete. 204 keeps the SDK LRO poller terminal (the AKS
+// swagger documents 202/204 for DELETE).
+func writeIdempotentDelete(w http.ResponseWriter, err error) {
+	if err != nil && !cerrors.IsNotFound(err) {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
-	// SDK accepts 202/204 on DELETE; 204 keeps the LRO poller terminal.
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -178,13 +186,7 @@ func (h *Handler) getAgentPool(w http.ResponseWriter, r *http.Request, rp *azure
 }
 
 func (h *Handler) deleteAgentPool(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	if err := h.be.DeleteAgentPool(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName); err != nil {
-		azurearm.WriteCErr(w, err)
-		return
-	}
-
-	// SDK requires 202/204 on agent-pool DELETE.
-	w.WriteHeader(http.StatusNoContent)
+	writeIdempotentDelete(w, h.be.DeleteAgentPool(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName))
 }
 
 //nolint:dupl // sub-resource lists are intentionally typed; sharing via generics adds noise.

--- a/server/azure/aks/operations.go
+++ b/server/azure/aks/operations.go
@@ -39,10 +39,15 @@ func buildClusterInput(body *armManagedCluster, rp *azurearm.ResourcePath) aks.C
 		in.Tier = body.SKU.Tier
 	}
 
+	if body.Identity != nil {
+		in.IdentityType = body.Identity.Type
+	}
+
 	if body.Properties != nil {
 		in.KubernetesVersion = body.Properties.KubernetesVersion
 		in.DNSPrefix = body.Properties.DNSPrefix
 		in.NodeResourceGroup = body.Properties.NodeResourceGroup
+		in.EnableRBAC = body.Properties.EnableRBAC
 
 		for i := range body.Properties.AgentPoolProfiles {
 			p := &body.Properties.AgentPoolProfiles[i]
@@ -57,6 +62,7 @@ func buildClusterInput(body *armManagedCluster, rp *azurearm.ResourcePath) aks.C
 				ScaleSetPriority: p.ScaleSetPriority,
 				NodeLabels:       fromPtrTags(p.NodeLabels),
 				NodeTaints:       p.NodeTaints,
+				MaxPods:          p.MaxPods,
 			})
 		}
 	}
@@ -149,6 +155,7 @@ func (h *Handler) createOrUpdateAgentPool(w http.ResponseWriter, r *http.Request
 		in.ScaleSetPriority = body.Properties.ScaleSetPriority
 		in.NodeLabels = fromPtrTags(body.Properties.NodeLabels)
 		in.NodeTaints = body.Properties.NodeTaints
+		in.MaxPods = body.Properties.MaxPods
 	}
 
 	pool, err := h.be.CreateOrUpdateAgentPool(r.Context(), rp.ResourceGroup, rp.ResourceName, in)

--- a/server/azure/aks/sdk_properties_test.go
+++ b/server/azure/aks/sdk_properties_test.go
@@ -1,0 +1,98 @@
+package aks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
+)
+
+func TestSDKAKSClusterIdentityAndDefaults(t *testing.T) {
+	clusters, _, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	poller, err := clusters.BeginCreateOrUpdate(ctx, "rg-1", "k8s-1", armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+		Identity: &armcontainerservice.ManagedClusterIdentity{
+			Type: to.Ptr(armcontainerservice.ResourceIdentityTypeSystemAssigned),
+		},
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			KubernetesVersion: to.Ptr("1.30.2"),
+			AgentPoolProfiles: []*armcontainerservice.ManagedClusterAgentPoolProfile{
+				{
+					Name:    to.Ptr("system"),
+					Count:   to.Ptr[int32](1),
+					VMSize:  to.Ptr("Standard_DS2_v2"),
+					Mode:    to.Ptr(armcontainerservice.AgentPoolModeSystem),
+					MaxPods: to.Ptr[int32](110),
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	resp, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	props := resp.ManagedCluster.Properties
+	if props == nil {
+		t.Fatal("nil properties")
+	}
+
+	// F3: system-assigned identity echoed with principal/tenant.
+	if resp.Identity == nil || resp.Identity.PrincipalID == nil || *resp.Identity.PrincipalID == "" {
+		t.Fatal("expected identity principalId")
+	}
+
+	if resp.Identity.TenantID == nil || *resp.Identity.TenantID == "" {
+		t.Fatal("expected identity tenantId")
+	}
+
+	// F6: defaults synthesized server-side.
+	if props.EnableRBAC == nil || !*props.EnableRBAC {
+		t.Fatal("expected enableRBAC true default")
+	}
+
+	if props.CurrentKubernetesVersion == nil || *props.CurrentKubernetesVersion != "1.30.2" {
+		t.Fatalf("got currentKubernetesVersion %v, want 1.30.2", props.CurrentKubernetesVersion)
+	}
+
+	if props.NetworkProfile == nil || props.NetworkProfile.NetworkPlugin == nil {
+		t.Fatal("expected networkProfile with networkPlugin default")
+	}
+
+	// F7 + F8 + F12: pool completeness, submitted maxPods preserved, version inherited.
+	if len(props.AgentPoolProfiles) != 1 {
+		t.Fatalf("got %d pools, want 1", len(props.AgentPoolProfiles))
+	}
+
+	pool := props.AgentPoolProfiles[0]
+	if pool.MaxPods == nil || *pool.MaxPods != 110 {
+		t.Fatalf("got maxPods %v, want 110", pool.MaxPods)
+	}
+
+	if pool.Type == nil || *pool.Type != armcontainerservice.AgentPoolTypeVirtualMachineScaleSets {
+		t.Fatalf("got pool type %v, want VirtualMachineScaleSets", pool.Type)
+	}
+
+	if pool.OSDiskType == nil || *pool.OSDiskType == "" {
+		t.Fatal("expected osDiskType populated")
+	}
+
+	if pool.PowerState == nil || pool.PowerState.Code == nil {
+		t.Fatal("expected pool powerState populated")
+	}
+
+	if pool.NodeImageVersion == nil || *pool.NodeImageVersion == "" {
+		t.Fatal("expected nodeImageVersion populated")
+	}
+
+	if pool.OrchestratorVersion == nil || *pool.OrchestratorVersion != "1.30.2" {
+		t.Fatalf("got pool orchestratorVersion %v, want inherited 1.30.2", pool.OrchestratorVersion)
+	}
+}

--- a/server/azure/aks/sdk_roundtrip_test.go
+++ b/server/azure/aks/sdk_roundtrip_test.go
@@ -305,6 +305,44 @@ func TestSDKAKSMaintenanceConfigLifecycle(t *testing.T) {
 	}
 }
 
+// TestSDKAKSDeleteMissingIsIdempotent asserts ARM DELETE is idempotent: deleting
+// a never-created managed cluster or agent pool completes without error (204),
+// matching the AKS swagger (DELETE documents 202/204).
+func TestSDKAKSDeleteMissingIsIdempotent(t *testing.T) {
+	clusters, pools, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	delPoller, err := clusters.BeginDelete(ctx, "rg-1", "ghost", nil)
+	if err != nil {
+		t.Fatalf("cluster BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("cluster delete of missing resource: %v", err)
+	}
+
+	// Create a cluster so the agent-pool path resolves, then delete a missing pool.
+	cPoller, err := clusters.BeginCreateOrUpdate(ctx, "rg-1", "k8s-1", armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("Cluster BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := cPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Cluster PollUntilDone: %v", err)
+	}
+
+	poolPoller, err := pools.BeginDelete(ctx, "rg-1", "k8s-1", "ghost", nil)
+	if err != nil {
+		t.Fatalf("pool BeginDelete: %v", err)
+	}
+
+	if _, err := poolPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("pool delete of missing resource: %v", err)
+	}
+}
+
 func TestSDKAKSListClusterAdminCredential(t *testing.T) {
 	clusters, _, _ := newSDKClients(t)
 	ctx := context.Background()

--- a/server/azure/aks/types.go
+++ b/server/azure/aks/types.go
@@ -23,7 +23,15 @@ type armManagedCluster struct {
 	Location   string                       `json:"location,omitempty"`
 	Tags       map[string]*string           `json:"tags,omitempty"`
 	SKU        *armManagedClusterSKU        `json:"sku,omitempty"`
+	Identity   *armManagedClusterIdentity   `json:"identity,omitempty"`
 	Properties *armManagedClusterProperties `json:"properties,omitempty"`
+}
+
+// armManagedClusterIdentity mirrors armcontainerservice.ManagedClusterIdentity.
+type armManagedClusterIdentity struct {
+	Type        string `json:"type,omitempty"`
+	PrincipalID string `json:"principalId,omitempty"`
+	TenantID    string `json:"tenantId,omitempty"`
 }
 
 // armManagedClusterSKU mirrors armcontainerservice.ManagedClusterSKU. The tier
@@ -34,18 +42,31 @@ type armManagedClusterSKU struct {
 }
 
 type armManagedClusterProperties struct {
-	ProvisioningState string                `json:"provisioningState,omitempty"`
-	KubernetesVersion string                `json:"kubernetesVersion,omitempty"`
-	DNSPrefix         string                `json:"dnsPrefix,omitempty"`
-	Fqdn              string                `json:"fqdn,omitempty"`
-	NodeResourceGroup string                `json:"nodeResourceGroup,omitempty"`
-	AgentPoolProfiles []armAgentPoolProfile `json:"agentPoolProfiles,omitempty"`
-	PowerState        *armPowerState        `json:"powerState,omitempty"`
-	EnableRBAC        *bool                 `json:"enableRBAC,omitempty"`
+	ProvisioningState        string                `json:"provisioningState,omitempty"`
+	KubernetesVersion        string                `json:"kubernetesVersion,omitempty"`
+	CurrentKubernetesVersion string                `json:"currentKubernetesVersion,omitempty"`
+	DNSPrefix                string                `json:"dnsPrefix,omitempty"`
+	Fqdn                     string                `json:"fqdn,omitempty"`
+	NodeResourceGroup        string                `json:"nodeResourceGroup,omitempty"`
+	AgentPoolProfiles        []armAgentPoolProfile `json:"agentPoolProfiles,omitempty"`
+	PowerState               *armPowerState        `json:"powerState,omitempty"`
+	EnableRBAC               *bool                 `json:"enableRBAC,omitempty"`
+	NetworkProfile           *armNetworkProfile    `json:"networkProfile,omitempty"`
 }
 
 type armPowerState struct {
 	Code string `json:"code,omitempty"`
+}
+
+// armNetworkProfile mirrors the subset of
+// armcontainerservice.NetworkProfile the emulator synthesizes as defaults.
+type armNetworkProfile struct {
+	NetworkPlugin   string `json:"networkPlugin,omitempty"`
+	LoadBalancerSKU string `json:"loadBalancerSku,omitempty"`
+	ServiceCidr     string `json:"serviceCidr,omitempty"`
+	DNSServiceIP    string `json:"dnsServiceIP,omitempty"`
+	PodCidr         string `json:"podCidr,omitempty"`
+	OutboundType    string `json:"outboundType,omitempty"`
 }
 
 type armAgentPoolProfile struct {
@@ -60,6 +81,11 @@ type armAgentPoolProfile struct {
 	NodeLabels        map[string]*string `json:"nodeLabels,omitempty"`
 	NodeTaints        []string           `json:"nodeTaints,omitempty"`
 	ProvisioningState string             `json:"provisioningState,omitempty"`
+	MaxPods           int32              `json:"maxPods,omitempty"`
+	OSDiskType        string             `json:"osDiskType,omitempty"`
+	Type              string             `json:"type,omitempty"`
+	PowerState        *armPowerState     `json:"powerState,omitempty"`
+	NodeImageVersion  string             `json:"nodeImageVersion,omitempty"`
 }
 
 // armAgentPool is the standalone (sub-resource) shape used by the
@@ -83,6 +109,11 @@ type armAgentPoolProperties struct {
 	NodeLabels        map[string]*string `json:"nodeLabels,omitempty"`
 	NodeTaints        []string           `json:"nodeTaints,omitempty"`
 	ProvisioningState string             `json:"provisioningState,omitempty"`
+	MaxPods           int32              `json:"maxPods,omitempty"`
+	OSDiskType        string             `json:"osDiskType,omitempty"`
+	Type              string             `json:"type,omitempty"`
+	PowerState        *armPowerState     `json:"powerState,omitempty"`
+	NodeImageVersion  string             `json:"nodeImageVersion,omitempty"`
 }
 
 // armMaintenanceConfig is the wire shape for the maintenanceConfigurations
@@ -120,7 +151,8 @@ type armList[T any] struct {
 // shape returned by the SDK. Pools are listed inline under
 // properties.agentPoolProfiles for parity with the real API.
 func toARMCluster(c *aks.ManagedCluster, pools []aks.AgentPool, subscription string) armManagedCluster {
-	return armManagedCluster{
+	enableRBAC := c.EnableRBAC
+	out := armManagedCluster{
 		ID:       aks.ClusterResourceID(subscription, c.ResourceGroup, c.Name),
 		Name:     c.Name,
 		Type:     resourceTypeManagedClusterFull,
@@ -128,14 +160,40 @@ func toARMCluster(c *aks.ManagedCluster, pools []aks.AgentPool, subscription str
 		Tags:     toPtrTags(c.Tags),
 		SKU:      &armManagedClusterSKU{Name: "Base", Tier: c.Tier},
 		Properties: &armManagedClusterProperties{
-			ProvisioningState: c.ProvisioningState,
-			KubernetesVersion: c.KubernetesVersion,
-			DNSPrefix:         c.DNSPrefix,
-			Fqdn:              c.FQDN,
-			NodeResourceGroup: c.NodeResourceGroup,
-			AgentPoolProfiles: toAgentPoolProfiles(pools),
-			PowerState:        &armPowerState{Code: c.PowerState},
+			ProvisioningState:        c.ProvisioningState,
+			KubernetesVersion:        c.KubernetesVersion,
+			CurrentKubernetesVersion: c.KubernetesVersion,
+			DNSPrefix:                c.DNSPrefix,
+			Fqdn:                     c.FQDN,
+			NodeResourceGroup:        c.NodeResourceGroup,
+			AgentPoolProfiles:        toAgentPoolProfiles(pools),
+			PowerState:               &armPowerState{Code: c.PowerState},
+			EnableRBAC:               &enableRBAC,
+			NetworkProfile:           defaultNetworkProfile(),
 		},
+	}
+
+	if c.IdentityType != "" && c.IdentityType != "None" {
+		out.Identity = &armManagedClusterIdentity{
+			Type:        c.IdentityType,
+			PrincipalID: c.PrincipalID,
+			TenantID:    c.TenantID,
+		}
+	}
+
+	return out
+}
+
+// defaultNetworkProfile returns the standard AKS network-profile defaults the
+// real service synthesizes when a create omits networkProfile.
+func defaultNetworkProfile() *armNetworkProfile {
+	return &armNetworkProfile{
+		NetworkPlugin:   "kubenet",
+		LoadBalancerSKU: "standard",
+		ServiceCidr:     "10.0.0.0/16",
+		DNSServiceIP:    "10.0.0.10",
+		PodCidr:         "10.244.0.0/16",
+		OutboundType:    "loadBalancer",
 	}
 }
 
@@ -158,6 +216,11 @@ func toAgentPoolProfiles(pools []aks.AgentPool) []armAgentPoolProfile {
 			NodeLabels:        toPtrTags(pools[i].NodeLabels),
 			NodeTaints:        pools[i].NodeTaints,
 			ProvisioningState: pools[i].ProvisioningState,
+			MaxPods:           pools[i].MaxPods,
+			OSDiskType:        pools[i].OSDiskType,
+			Type:              pools[i].Type,
+			PowerState:        &armPowerState{Code: pools[i].PowerState},
+			NodeImageVersion:  pools[i].NodeImageVersion,
 		})
 	}
 
@@ -182,6 +245,11 @@ func toARMAgentPool(p *aks.AgentPool, subscription string) armAgentPool {
 			NodeLabels:        toPtrTags(p.NodeLabels),
 			NodeTaints:        p.NodeTaints,
 			ProvisioningState: p.ProvisioningState,
+			MaxPods:           p.MaxPods,
+			OSDiskType:        p.OSDiskType,
+			Type:              p.Type,
+			PowerState:        &armPowerState{Code: p.PowerState},
+			NodeImageVersion:  p.NodeImageVersion,
 		},
 	}
 }

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -398,6 +398,13 @@ func New(d Drivers) http.Handler {
 	// must register before the permissive BlobStorage fallback below.
 	if d.ACR != nil {
 		srv.Register(acr.New(d.ACR))
+
+		// ACR ARM management plane (Microsoft.ContainerRegistry/registries) is
+		// an Azure-specific optional capability; register it when the driver
+		// implements the manager surface.
+		if mgr, ok := d.ACR.(crdriver.AzureRegistryManager); ok {
+			srv.Register(acr.NewARM(mgr))
+		}
 	}
 
 	// Azure Container Instances claims a unique ARM provider

--- a/services/containerregistry/driver/azure.go
+++ b/services/containerregistry/driver/azure.go
@@ -14,7 +14,8 @@ import (
 // AzureRegistryManager; the wire handler reaches it by type assertion,
 // mirroring the AzureNetworkInterfaces pattern in the networking driver.
 
-// AzureRegistryConfig is the create-or-update payload for an ACR registry.
+// AzureRegistryConfig is the full create-or-replace payload for an ACR registry
+// (ARM PUT).
 type AzureRegistryConfig struct {
 	Location         string
 	Tags             map[string]string
@@ -24,6 +25,17 @@ type AzureRegistryConfig struct {
 	// block: "SystemAssigned", "UserAssigned", "SystemAssigned, UserAssigned"
 	// or "None"/"" for no identity.
 	IdentityType string
+}
+
+// AzureRegistryUpdate is the partial-update payload for an ACR registry (ARM
+// PATCH, RegistryUpdateParameters). Every field is optional: a nil pointer (or
+// nil Tags map) leaves the corresponding attribute untouched on the existing
+// registry.
+type AzureRegistryUpdate struct {
+	Tags             map[string]string // nil = unchanged; non-nil replaces the tag set
+	SKUName          *string
+	AdminUserEnabled *bool
+	IdentityType     *string
 }
 
 // AzureRegistry is a stored/returned ACR registry resource.
@@ -62,7 +74,8 @@ type AzureRegistryUsage struct {
 	Unit         string
 }
 
-// AzureWebhookConfig is the create-or-update payload for a registry webhook.
+// AzureWebhookConfig is the full create-or-replace payload for a registry
+// webhook (ARM PUT).
 type AzureWebhookConfig struct {
 	Location      string
 	Tags          map[string]string
@@ -71,6 +84,18 @@ type AzureWebhookConfig struct {
 	Scope         string
 	Status        string // "enabled" / "disabled"
 	CustomHeaders map[string]string
+}
+
+// AzureWebhookUpdate is the partial-update payload for a registry webhook (ARM
+// PATCH, WebhookUpdateParameters). Every field is optional: a nil pointer (or
+// nil slice/map) leaves the corresponding attribute untouched.
+type AzureWebhookUpdate struct {
+	Tags          map[string]string // nil = unchanged
+	ServiceURI    *string
+	Actions       []string // nil = unchanged
+	Scope         *string
+	Status        *string
+	CustomHeaders map[string]string // nil = unchanged
 }
 
 // AzureWebhook is a stored/returned registry webhook resource.
@@ -88,11 +113,20 @@ type AzureWebhook struct {
 	ProvisioningState string
 }
 
-// AzureReplicationConfig is the create-or-update payload for a geo-replication.
+// AzureReplicationConfig is the full create-or-replace payload for a
+// geo-replication (ARM PUT).
 type AzureReplicationConfig struct {
 	Location              string
 	Tags                  map[string]string
 	RegionEndpointEnabled bool
+}
+
+// AzureReplicationUpdate is the partial-update payload for a geo-replication
+// (ARM PATCH, ReplicationUpdateParameters). Every field is optional: a nil
+// pointer (or nil Tags map) leaves the corresponding attribute untouched.
+type AzureReplicationUpdate struct {
+	Tags                  map[string]string // nil = unchanged
+	RegionEndpointEnabled *bool
 }
 
 // AzureReplication is a stored/returned geo-replication resource.
@@ -111,7 +145,15 @@ type AzureReplication struct {
 // keyed by (resourceGroup, name) to match ARM addressing and give idempotent
 // createOrUpdate. An empty resource group on a list means subscription-wide.
 type AzureRegistryManager interface {
-	CreateOrUpdateRegistry(ctx context.Context, rg, name string, cfg AzureRegistryConfig) (*AzureRegistry, error)
+	// CreateOrUpdateRegistry is the ARM PUT (full create-or-replace). It reports
+	// whether the registry was newly created so the wire layer can return 201
+	// Created on first create and 200 OK on replace.
+	CreateOrUpdateRegistry(
+		ctx context.Context, rg, name string, cfg AzureRegistryConfig,
+	) (reg *AzureRegistry, created bool, err error)
+	// UpdateRegistry is the ARM PATCH (partial update). It merges upd onto the
+	// existing registry, returning NotFound when the registry does not exist.
+	UpdateRegistry(ctx context.Context, rg, name string, upd AzureRegistryUpdate) (*AzureRegistry, error)
 	GetRegistry(ctx context.Context, rg, name string) (*AzureRegistry, error)
 	DeleteRegistry(ctx context.Context, rg, name string) error
 	ListRegistries(ctx context.Context, rg string) ([]AzureRegistry, error)
@@ -120,13 +162,19 @@ type AzureRegistryManager interface {
 	RegenerateRegistryCredential(ctx context.Context, rg, name, passwordName string) (*AzureRegistryCredentials, error)
 	ListRegistryUsages(ctx context.Context, rg, name string) ([]AzureRegistryUsage, error)
 
-	CreateOrUpdateWebhook(ctx context.Context, rg, registry, name string, cfg AzureWebhookConfig) (*AzureWebhook, error)
+	CreateOrUpdateWebhook(
+		ctx context.Context, rg, registry, name string, cfg AzureWebhookConfig,
+	) (wh *AzureWebhook, created bool, err error)
+	UpdateWebhook(ctx context.Context, rg, registry, name string, upd AzureWebhookUpdate) (*AzureWebhook, error)
 	GetWebhook(ctx context.Context, rg, registry, name string) (*AzureWebhook, error)
 	DeleteWebhook(ctx context.Context, rg, registry, name string) error
 	ListWebhooks(ctx context.Context, rg, registry string) ([]AzureWebhook, error)
 
 	CreateOrUpdateReplication(
 		ctx context.Context, rg, registry, name string, cfg AzureReplicationConfig,
+	) (rep *AzureReplication, created bool, err error)
+	UpdateReplication(
+		ctx context.Context, rg, registry, name string, upd AzureReplicationUpdate,
 	) (*AzureReplication, error)
 	GetReplication(ctx context.Context, rg, registry, name string) (*AzureReplication, error)
 	DeleteReplication(ctx context.Context, rg, registry, name string) error

--- a/services/containerregistry/driver/azure.go
+++ b/services/containerregistry/driver/azure.go
@@ -1,0 +1,142 @@
+package driver
+
+import (
+	"context"
+	"time"
+)
+
+// The Azure Container Registry ARM management plane
+// (Microsoft.ContainerRegistry/registries) is an Azure-specific optional
+// capability kept out of the cross-cloud ContainerRegistry interface: a
+// registry is an ARM resource with a SKU, an admin credential pair, quota
+// usages, webhooks and geo-replications that the AWS ECR / GCP Artifact
+// Registry models do not share. A provider exposes it by implementing
+// AzureRegistryManager; the wire handler reaches it by type assertion,
+// mirroring the AzureNetworkInterfaces pattern in the networking driver.
+
+// AzureRegistryConfig is the create-or-update payload for an ACR registry.
+type AzureRegistryConfig struct {
+	Location         string
+	Tags             map[string]string
+	SKUName          string // Basic / Standard / Premium (defaults to Standard)
+	AdminUserEnabled bool
+	// IdentityType is the managed-identity type submitted in the ARM identity
+	// block: "SystemAssigned", "UserAssigned", "SystemAssigned, UserAssigned"
+	// or "None"/"" for no identity.
+	IdentityType string
+}
+
+// AzureRegistry is a stored/returned ACR registry resource.
+type AzureRegistry struct {
+	Name              string
+	ResourceGroup     string
+	Location          string
+	SKUName           string
+	SKUTier           string
+	LoginServer       string
+	AdminUserEnabled  bool
+	ProvisioningState string
+	CreationDate      time.Time
+	Tags              map[string]string
+	// IdentityType and the principal/tenant IDs echo the managed identity block.
+	// PrincipalID/TenantID are populated only when a system-assigned identity is
+	// requested.
+	IdentityType string
+	PrincipalID  string
+	TenantID     string
+}
+
+// AzureRegistryCredentials is the admin username / password pair returned by
+// listCredentials and regenerateCredential.
+type AzureRegistryCredentials struct {
+	Username  string
+	Password  string
+	Password2 string
+}
+
+// AzureRegistryUsage is one quota-usage entry returned by listUsages.
+type AzureRegistryUsage struct {
+	Name         string
+	Limit        int64
+	CurrentValue int64
+	Unit         string
+}
+
+// AzureWebhookConfig is the create-or-update payload for a registry webhook.
+type AzureWebhookConfig struct {
+	Location      string
+	Tags          map[string]string
+	ServiceURI    string
+	Actions       []string
+	Scope         string
+	Status        string // "enabled" / "disabled"
+	CustomHeaders map[string]string
+}
+
+// AzureWebhook is a stored/returned registry webhook resource.
+type AzureWebhook struct {
+	Name              string
+	RegistryName      string
+	ResourceGroup     string
+	Location          string
+	Tags              map[string]string
+	ServiceURI        string
+	Actions           []string
+	Scope             string
+	Status            string
+	CustomHeaders     map[string]string
+	ProvisioningState string
+}
+
+// AzureReplicationConfig is the create-or-update payload for a geo-replication.
+type AzureReplicationConfig struct {
+	Location              string
+	Tags                  map[string]string
+	RegionEndpointEnabled bool
+}
+
+// AzureReplication is a stored/returned geo-replication resource.
+type AzureReplication struct {
+	Name                  string
+	RegistryName          string
+	ResourceGroup         string
+	Location              string
+	Tags                  map[string]string
+	RegionEndpointEnabled bool
+	ProvisioningState     string
+	Status                string
+}
+
+// AzureRegistryManager is the Azure-specific ACR management-plane surface,
+// keyed by (resourceGroup, name) to match ARM addressing and give idempotent
+// createOrUpdate. An empty resource group on a list means subscription-wide.
+type AzureRegistryManager interface {
+	CreateOrUpdateRegistry(ctx context.Context, rg, name string, cfg AzureRegistryConfig) (*AzureRegistry, error)
+	GetRegistry(ctx context.Context, rg, name string) (*AzureRegistry, error)
+	DeleteRegistry(ctx context.Context, rg, name string) error
+	ListRegistries(ctx context.Context, rg string) ([]AzureRegistry, error)
+
+	ListRegistryCredentials(ctx context.Context, rg, name string) (*AzureRegistryCredentials, error)
+	RegenerateRegistryCredential(ctx context.Context, rg, name, passwordName string) (*AzureRegistryCredentials, error)
+	ListRegistryUsages(ctx context.Context, rg, name string) ([]AzureRegistryUsage, error)
+
+	CreateOrUpdateWebhook(ctx context.Context, rg, registry, name string, cfg AzureWebhookConfig) (*AzureWebhook, error)
+	GetWebhook(ctx context.Context, rg, registry, name string) (*AzureWebhook, error)
+	DeleteWebhook(ctx context.Context, rg, registry, name string) error
+	ListWebhooks(ctx context.Context, rg, registry string) ([]AzureWebhook, error)
+
+	CreateOrUpdateReplication(
+		ctx context.Context, rg, registry, name string, cfg AzureReplicationConfig,
+	) (*AzureReplication, error)
+	GetReplication(ctx context.Context, rg, registry, name string) (*AzureReplication, error)
+	DeleteReplication(ctx context.Context, rg, registry, name string) error
+	ListReplications(ctx context.Context, rg, registry string) ([]AzureReplication, error)
+}
+
+// AzureRepositoryWriter is the Azure-specific ACR data-plane surface for
+// mutating a single tag or repository. DeleteTag removes one tag while leaving
+// the underlying manifest and any other tags intact (unlike DeleteImage, which
+// removes the whole manifest). The wire handler reaches it by type assertion.
+type AzureRepositoryWriter interface {
+	DeleteTag(ctx context.Context, repository, tag string) error
+}


### PR DESCRIPTION
## Summary

Closes gaps found in an end-to-end audit of Azure ACR and AKS against real azure-sdk-for-go clients. All changes are validated with real SDK round-trip tests over an httptest server.

### ACR — ARM management plane (was entirely 501)

A user could not create a registry before push/pull because `Microsoft.ContainerRegistry/registries` had no ARM handler (only the `/acr/v1` data-plane catalog existed). Added a full management plane behind an Azure-only optional driver interface (`AzureRegistryManager`, type-asserted — never forced onto AWS/GCP):

- Registries: `BeginCreate` / `Get` / `List` (subscription + resource group) / `BeginDelete` — returns `loginServer` (`{name}.azurecr.io`), `sku.tier`, `creationDate`, `provisioningState`, and echoes the managed-identity block with generated `principalId`/`tenantId`. (finding 1, and per-registry loginServer, finding 11, in the ARM plane)
- `listCredentials` / `regenerateCredential` (password/password2) / `listUsages`. (finding 1)
- Webhooks and geo-replications CRUD. (finding 1)

### ACR — data-plane tag/manifest routing

- `DELETE /acr/v1/{repo}/_tags/{tag}` was routed to repository delete (silent no-op). It now untags without removing the manifest or other tags. (finding 2)
- `GET /acr/v1/{repo}/_tags/{tag}` returned 404; now returns tag attributes. (finding 4)
- `_manifests` list and `GetManifestProperties` were rejected 501; now served. (finding 5)

Routing now splits on the `_tags` / `_manifests` marker so hierarchical repo names (`team/app`) survive.

### AKS — response fidelity

- Managed-identity block was never returned; now echoed with generated `principalId`/`tenantId` for a system-assigned identity. (finding 3)
- `enableRBAC`, `currentKubernetesVersion` and `networkProfile` defaults synthesized server-side. (finding 6)
- Agent-pool profiles now include `maxPods`, `osDiskType`, `type=VirtualMachineScaleSets`, `powerState`, `nodeImageVersion`. (finding 7)
- A submitted inline-pool `maxPods` is preserved. (finding 8)
- Inline pools inherit the cluster `kubernetesVersion` instead of the package default. (finding 12)

### Deferred

- **kubeconfig data-plane wiring (finding 9):** the mechanism already exists and is tested (`SetK8sAPI` + `sdk_dataplane_test.go`); enabling it by default is a shared cross-provider serve-layer decision (the same `kubernetes.APIServer` handle backs EKS/GKE), out of scope for an ACR/AKS-only change.
- **UpdateTag/UpdateRepositoryProperties PATCH (finding 10):** requires persisting per-tag/per-repo writeable-attribute state; the read paths already report the default all-enabled attributes that a fresh repository carries.

### Testing

- `go build ./...`, `go test ./...` green.
- `golangci-lint` clean on all changed packages.
- New real-SDK round-trip tests: `armcontainerregistry` (registry lifecycle, credentials, usages, webhooks, replications), `azcontainerregistry` (DeleteTag, GetTagProperties, manifests), `armcontainerservice/v6` (identity + defaults + pool fields), plus provider unit tests.
- Regenerated `docs/coverage`.