### PR TITLE
fix(azure-vnet-lb-dns): idempotent vnet/NSG PUT, NSG security+default rules, DNS nameServers/record sets, loadbalancer full-replace

### DIFF
--- a/docs/coverage/aws/elb.md
+++ b/docs/coverage/aws/elb.md
@@ -31,6 +31,17 @@ AWS's `loadbalancer` service · portable interface `driver.LoadBalancer` · [AWS
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureLoadBalancers
+
+AzureLoadBalancers is an OPTIONAL, type-asserted capability. The Azure
+
+| Operation | Description |
+| --- | --- |
+| `CreateOrUpdateAzureLoadBalancer` |  |
+| `DeleteAzureLoadBalancer` |  |
+| `GetAzureLoadBalancer` |  |
+| `ListAzureLoadBalancers` |  |
+
 ### LBAttributeUpdater
 
 LBAttributeUpdater is implemented by drivers that can apply a partial

--- a/docs/coverage/aws/vpc.md
+++ b/docs/coverage/aws/vpc.md
@@ -80,6 +80,19 @@ AzureNetworkInterfaces is the Azure-specific network-interface surface,
 | `GetNetworkInterface` |  |
 | `ListNetworkInterfaces` |  |
 
+### AzureNetworkMetadata
+
+AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
+
+| Operation | Description |
+| --- | --- |
+| `DeleteAzureNSGMetadata` |  |
+| `DeleteAzureVNetMetadata` |  |
+| `GetAzureNSGMetadata` |  |
+| `GetAzureVNetMetadata` |  |
+| `PutAzureNSGMetadata` |  |
+| `PutAzureVNetMetadata` |  |
+
 ### ClientVPN
 
 ClientVPN is an OPTIONAL AWS capability (type-asserted).

--- a/docs/coverage/azure/lb.md
+++ b/docs/coverage/azure/lb.md
@@ -31,6 +31,17 @@ Azure's `loadbalancer` service · portable interface `driver.LoadBalancer` · [A
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureLoadBalancers
+
+AzureLoadBalancers is an OPTIONAL, type-asserted capability. The Azure
+
+| Operation | Description |
+| --- | --- |
+| `CreateOrUpdateAzureLoadBalancer` |  |
+| `DeleteAzureLoadBalancer` |  |
+| `GetAzureLoadBalancer` |  |
+| `ListAzureLoadBalancers` |  |
+
 ### LBAttributeUpdater
 
 LBAttributeUpdater is implemented by drivers that can apply a partial

--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -80,6 +80,19 @@ AzureNetworkInterfaces is the Azure-specific network-interface surface,
 | `GetNetworkInterface` |  |
 | `ListNetworkInterfaces` |  |
 
+### AzureNetworkMetadata
+
+AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
+
+| Operation | Description |
+| --- | --- |
+| `DeleteAzureNSGMetadata` |  |
+| `DeleteAzureVNetMetadata` |  |
+| `GetAzureNSGMetadata` |  |
+| `GetAzureVNetMetadata` |  |
+| `PutAzureNSGMetadata` |  |
+| `PutAzureVNetMetadata` |  |
+
 ### ClientVPN
 
 ClientVPN is an OPTIONAL AWS capability (type-asserted).

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -5541,6 +5541,24 @@
     ],
     "optionalCapabilities": [
       {
+        "name": "AzureLoadBalancers",
+        "doc": "AzureLoadBalancers is an OPTIONAL, type-asserted capability. The Azure",
+        "operations": [
+          {
+            "name": "CreateOrUpdateAzureLoadBalancer"
+          },
+          {
+            "name": "DeleteAzureLoadBalancer"
+          },
+          {
+            "name": "GetAzureLoadBalancer"
+          },
+          {
+            "name": "ListAzureLoadBalancers"
+          }
+        ]
+      },
+      {
         "name": "LBAttributeUpdater",
         "doc": "LBAttributeUpdater is implemented by drivers that can apply a partial",
         "operations": [
@@ -6277,6 +6295,30 @@
           },
           {
             "name": "ListNetworkInterfaces"
+          }
+        ]
+      },
+      {
+        "name": "AzureNetworkMetadata",
+        "doc": "AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure",
+        "operations": [
+          {
+            "name": "DeleteAzureNSGMetadata"
+          },
+          {
+            "name": "DeleteAzureVNetMetadata"
+          },
+          {
+            "name": "GetAzureNSGMetadata"
+          },
+          {
+            "name": "GetAzureVNetMetadata"
+          },
+          {
+            "name": "PutAzureNSGMetadata"
+          },
+          {
+            "name": "PutAzureVNetMetadata"
           }
         ]
       },

--- a/docs/coverage/gcp/lb.md
+++ b/docs/coverage/gcp/lb.md
@@ -31,6 +31,17 @@ GCP's `loadbalancer` service · portable interface `driver.LoadBalancer` · [GCP
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureLoadBalancers
+
+AzureLoadBalancers is an OPTIONAL, type-asserted capability. The Azure
+
+| Operation | Description |
+| --- | --- |
+| `CreateOrUpdateAzureLoadBalancer` |  |
+| `DeleteAzureLoadBalancer` |  |
+| `GetAzureLoadBalancer` |  |
+| `ListAzureLoadBalancers` |  |
+
 ### LBAttributeUpdater
 
 LBAttributeUpdater is implemented by drivers that can apply a partial

--- a/docs/coverage/gcp/vpc.md
+++ b/docs/coverage/gcp/vpc.md
@@ -80,6 +80,19 @@ AzureNetworkInterfaces is the Azure-specific network-interface surface,
 | `GetNetworkInterface` |  |
 | `ListNetworkInterfaces` |  |
 
+### AzureNetworkMetadata
+
+AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
+
+| Operation | Description |
+| --- | --- |
+| `DeleteAzureNSGMetadata` |  |
+| `DeleteAzureVNetMetadata` |  |
+| `GetAzureNSGMetadata` |  |
+| `GetAzureVNetMetadata` |  |
+| `PutAzureNSGMetadata` |  |
+| `PutAzureVNetMetadata` |  |
+
 ### ClientVPN
 
 ClientVPN is an OPTIONAL AWS capability (type-asserted).

--- a/docs/coverage/oci/vcn.md
+++ b/docs/coverage/oci/vcn.md
@@ -80,6 +80,19 @@ AzureNetworkInterfaces is the Azure-specific network-interface surface,
 | `GetNetworkInterface` |  |
 | `ListNetworkInterfaces` |  |
 
+### AzureNetworkMetadata
+
+AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
+
+| Operation | Description |
+| --- | --- |
+| `DeleteAzureNSGMetadata` |  |
+| `DeleteAzureVNetMetadata` |  |
+| `GetAzureNSGMetadata` |  |
+| `GetAzureVNetMetadata` |  |
+| `PutAzureNSGMetadata` |  |
+| `PutAzureVNetMetadata` |  |
+
 ### ClientVPN
 
 ClientVPN is an OPTIONAL AWS capability (type-asserted).

--- a/providers/azure/loadbalancer/azure_load_balancer.go
+++ b/providers/azure/loadbalancer/azure_load_balancer.go
@@ -1,0 +1,101 @@
+package loadbalancer
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+)
+
+// Compile-time check that Mock implements the optional Azure LB surface.
+var _ driver.AzureLoadBalancers = (*Mock)(nil)
+
+// azureLBKey keys the native store by (resourceGroup, name), matching ARM's
+// addressing.
+func azureLBKey(rg, name string) string {
+	return rg + "/" + name
+}
+
+// CreateOrUpdateAzureLoadBalancer stores the ARM load balancer as a full
+// replace: the payload becomes the complete state, so any child (pool, rule,
+// probe, frontend) omitted from it is dropped.
+//
+//nolint:gocritic // hugeParam: value carries slices copied defensively below.
+func (m *Mock) CreateOrUpdateAzureLoadBalancer(_ context.Context, rg, name string,
+	lb driver.AzureLoadBalancer,
+) (*driver.AzureLoadBalancer, error) {
+	if name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "load balancer name is required")
+	}
+
+	stored := cloneAzureLB(lb)
+	stored.Name = name
+	stored.ResourceGroup = rg
+	stored.ProvisioningState = "Succeeded"
+
+	m.azureLBs.Set(azureLBKey(rg, name), stored)
+
+	out := cloneAzureLB(stored)
+
+	return &out, nil
+}
+
+// GetAzureLoadBalancer returns the stored ARM load balancer.
+func (m *Mock) GetAzureLoadBalancer(_ context.Context, rg, name string) (*driver.AzureLoadBalancer, error) {
+	lb, ok := m.azureLBs.Get(azureLBKey(rg, name))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "load balancer %q not found", name)
+	}
+
+	out := cloneAzureLB(lb)
+
+	return &out, nil
+}
+
+// DeleteAzureLoadBalancer removes the stored ARM load balancer.
+func (m *Mock) DeleteAzureLoadBalancer(_ context.Context, rg, name string) error {
+	if !m.azureLBs.Delete(azureLBKey(rg, name)) {
+		return cerrors.Newf(cerrors.NotFound, "load balancer %q not found", name)
+	}
+
+	return nil
+}
+
+// ListAzureLoadBalancers returns the stored ARM load balancers in rg, or all
+// when rg is empty (subscription-wide list).
+func (m *Mock) ListAzureLoadBalancers(_ context.Context, rg string) ([]driver.AzureLoadBalancer, error) {
+	all := m.azureLBs.SortedValues()
+
+	out := make([]driver.AzureLoadBalancer, 0, len(all))
+
+	for i := range all {
+		if rg != "" && all[i].ResourceGroup != rg {
+			continue
+		}
+
+		out = append(out, cloneAzureLB(all[i]))
+	}
+
+	return out, nil
+}
+
+// cloneAzureLB deep-copies the nested slices so stored and returned values
+// never alias a caller's slices.
+//
+//nolint:gocritic // hugeParam: clone by value is the intent.
+func cloneAzureLB(lb driver.AzureLoadBalancer) driver.AzureLoadBalancer {
+	out := lb
+	out.Frontends = append([]driver.AzureLBFrontend(nil), lb.Frontends...)
+	out.BackendPools = append([]string(nil), lb.BackendPools...)
+	out.Rules = append([]driver.AzureLBRule(nil), lb.Rules...)
+	out.Probes = append([]driver.AzureLBProbe(nil), lb.Probes...)
+
+	if len(lb.Tags) > 0 {
+		out.Tags = make(map[string]string, len(lb.Tags))
+		for k, v := range lb.Tags {
+			out.Tags[k] = v
+		}
+	}
+
+	return out
+}

--- a/providers/azure/loadbalancer/lb.go
+++ b/providers/azure/loadbalancer/lb.go
@@ -25,7 +25,11 @@ type Mock struct {
 	tgs       *memstore.Store[driver.TargetGroupInfo]
 	listeners *memstore.Store[driver.ListenerInfo]
 	rules     *memstore.Store[driver.RuleInfo]
-	opts      *config.Options
+	// azureLBs stores ARM load balancers natively (the full-replace nested
+	// resource the cross-cloud model above cannot represent), keyed by
+	// (resourceGroup, name).
+	azureLBs *memstore.Store[driver.AzureLoadBalancer]
+	opts     *config.Options
 
 	healthMu sync.RWMutex
 	health   map[string]map[string]*driver.TargetHealth // tgARN -> targetID -> health
@@ -41,6 +45,7 @@ func New(opts *config.Options) *Mock {
 		tgs:       memstore.New[driver.TargetGroupInfo](),
 		listeners: memstore.New[driver.ListenerInfo](),
 		rules:     memstore.New[driver.RuleInfo](),
+		azureLBs:  memstore.New[driver.AzureLoadBalancer](),
 		opts:      opts,
 		health:    make(map[string]map[string]*driver.TargetHealth),
 		attrs:     make(map[string]driver.LBAttributes),

--- a/providers/azure/vnet/azure_network_metadata.go
+++ b/providers/azure/vnet/azure_network_metadata.go
@@ -1,0 +1,78 @@
+package vnet
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// Compile-time check that Mock implements the optional Azure metadata surface.
+var _ driver.AzureNetworkMetadata = (*Mock)(nil)
+
+// PutAzureVNetMetadata stores the Azure-only virtual-network fields (region and
+// full address-prefix list) for the VPC with the given driver id.
+func (m *Mock) PutAzureVNetMetadata(_ context.Context, id string, meta driver.AzureVNetMetadata) error {
+	m.azureVNetMeta.Set(id, cloneVNetMeta(meta))
+	return nil
+}
+
+// GetAzureVNetMetadata returns the stored Azure virtual-network metadata for id.
+func (m *Mock) GetAzureVNetMetadata(_ context.Context, id string) (driver.AzureVNetMetadata, bool) {
+	meta, ok := m.azureVNetMeta.Get(id)
+	if !ok {
+		return driver.AzureVNetMetadata{}, false
+	}
+
+	return cloneVNetMeta(meta), true
+}
+
+// DeleteAzureVNetMetadata drops the stored metadata for id (called when the VPC
+// is deleted).
+func (m *Mock) DeleteAzureVNetMetadata(_ context.Context, id string) {
+	m.azureVNetMeta.Delete(id)
+}
+
+// PutAzureNSGMetadata stores the Azure-only security-group fields (region and
+// custom security rules) for the security group with the given driver id.
+func (m *Mock) PutAzureNSGMetadata(_ context.Context, id string, meta driver.AzureNSGMetadata) error {
+	m.azureNSGMeta.Set(id, cloneNSGMeta(meta))
+	return nil
+}
+
+// GetAzureNSGMetadata returns the stored Azure security-group metadata for id.
+func (m *Mock) GetAzureNSGMetadata(_ context.Context, id string) (driver.AzureNSGMetadata, bool) {
+	meta, ok := m.azureNSGMeta.Get(id)
+	if !ok {
+		return driver.AzureNSGMetadata{}, false
+	}
+
+	return cloneNSGMeta(meta), true
+}
+
+// DeleteAzureNSGMetadata drops the stored metadata for id (called when the
+// security group is deleted).
+func (m *Mock) DeleteAzureNSGMetadata(_ context.Context, id string) {
+	m.azureNSGMeta.Delete(id)
+}
+
+// cloneVNetMeta deep-copies the address-prefix slice so stored and returned
+// values never alias a caller's slice.
+func cloneVNetMeta(meta driver.AzureVNetMetadata) driver.AzureVNetMetadata {
+	out := driver.AzureVNetMetadata{Location: meta.Location}
+	if len(meta.AddressPrefixes) > 0 {
+		out.AddressPrefixes = append([]string(nil), meta.AddressPrefixes...)
+	}
+
+	return out
+}
+
+// cloneNSGMeta deep-copies the rule slice so stored and returned values never
+// alias a caller's slice.
+func cloneNSGMeta(meta driver.AzureNSGMetadata) driver.AzureNSGMetadata {
+	out := driver.AzureNSGMetadata{Location: meta.Location}
+	if len(meta.SecurityRules) > 0 {
+		out.SecurityRules = append([]driver.AzureNSGRule(nil), meta.SecurityRules...)
+	}
+
+	return out
+}

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -64,6 +64,11 @@ type Mock struct {
 	rtAssocs       *memstore.Store[*rtAssocData]
 	endpoints      *memstore.Store[*driver.VPCEndpoint]
 	nics           *memstore.Store[*nicData]
+	// azureVNetMeta / azureNSGMeta hold the ARM-specific fields the cross-cloud
+	// VPC / SecurityGroup model cannot represent (region, full address-prefix
+	// list, Azure security rules), keyed by the driver resource id.
+	azureVNetMeta *memstore.Store[driver.AzureVNetMetadata]
+	azureNSGMeta  *memstore.Store[driver.AzureNSGMetadata]
 	// nicMu serializes network-interface create/update, whose private-IP
 	// allocation is a read-modify-write across the nics store (memstore is
 	// per-op safe but can't make that sequence atomic).
@@ -87,6 +92,8 @@ func New(opts *config.Options) *Mock {
 		rtAssocs:       memstore.New[*rtAssocData](),
 		endpoints:      memstore.New[*driver.VPCEndpoint](),
 		nics:           memstore.New[*nicData](),
+		azureVNetMeta:  memstore.New[driver.AzureVNetMetadata](),
+		azureNSGMeta:   memstore.New[driver.AzureNSGMetadata](),
 		opts:           opts,
 	}
 }
@@ -250,6 +257,8 @@ func (m *Mock) DescribeSecurityGroups(_ context.Context, ids []string) ([]driver
 }
 
 // AddIngressRule adds an inbound security rule to the specified network security group.
+//
+//nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (m *Mock) AddIngressRule(_ context.Context, groupID string, rule driver.SecurityRule) error {
 	sg, ok := m.securityGroups.Get(groupID)
 	if !ok {
@@ -262,6 +271,8 @@ func (m *Mock) AddIngressRule(_ context.Context, groupID string, rule driver.Sec
 }
 
 // AddEgressRule adds an outbound security rule to the specified network security group.
+//
+//nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (m *Mock) AddEgressRule(_ context.Context, groupID string, rule driver.SecurityRule) error {
 	sg, ok := m.securityGroups.Get(groupID)
 	if !ok {
@@ -274,6 +285,8 @@ func (m *Mock) AddEgressRule(_ context.Context, groupID string, rule driver.Secu
 }
 
 // RemoveIngressRule removes a matching inbound rule from the specified network security group.
+//
+//nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (m *Mock) RemoveIngressRule(_ context.Context, groupID string, rule driver.SecurityRule) error {
 	sg, ok := m.securityGroups.Get(groupID)
 	if !ok {
@@ -291,6 +304,8 @@ func (m *Mock) RemoveIngressRule(_ context.Context, groupID string, rule driver.
 }
 
 // RemoveEgressRule removes a matching outbound rule from the specified network security group.
+//
+//nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.SecurityRule) error {
 	sg, ok := m.securityGroups.Get(groupID)
 	if !ok {

--- a/server/azure/dns/operations.go
+++ b/server/azure/dns/operations.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"context"
 	"net/http"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -47,7 +48,41 @@ func (h *Handler) createOrUpdateZone(w http.ResponseWriter, r *http.Request, rp 
 		return
 	}
 
+	// Azure auto-provisions the apex SOA and NS record sets when a zone is
+	// created, so a fresh public zone already reports numberOfRecordSets=2 and
+	// its ListByDnsZone is non-empty. Refresh info so the response carries the
+	// updated record count.
+	if refreshed := h.provisionApexRecords(r.Context(), info); refreshed != nil {
+		info = refreshed
+	}
+
 	azurearm.WriteJSON(w, http.StatusCreated, toZoneJSON(rp, info))
+}
+
+// provisionApexRecords creates the apex SOA and NS record sets Azure DNS
+// auto-generates with every new zone. It returns the zone re-read with the
+// bumped record count, or nil if the zone could not be re-read (leaving the
+// caller's copy in place). Private zones get no name-server-backed records.
+func (h *Handler) provisionApexRecords(ctx context.Context, zone *dnsdriver.ZoneInfo) *dnsdriver.ZoneInfo {
+	nameServers := zoneNameServers(zone.Name, zone.Private)
+	if len(nameServers) == 0 {
+		return nil
+	}
+
+	_, _ = h.dns.CreateRecord(ctx, dnsdriver.RecordConfig{
+		ZoneID: zone.ID, Name: apexRecordName, Type: recTypeNS, TTL: nsRecordTTL, Values: nameServers,
+	})
+	_, _ = h.dns.CreateRecord(ctx, dnsdriver.RecordConfig{
+		ZoneID: zone.ID, Name: apexRecordName, Type: recTypeSOA, TTL: soaRecordTTL,
+		Values: []string{nameServers[0], soaEmail},
+	})
+
+	refreshed, err := h.dns.GetZone(ctx, zone.ID)
+	if err != nil {
+		return nil
+	}
+
+	return refreshed
 }
 
 func (h *Handler) getZone(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {

--- a/server/azure/dns/sdk_roundtrip_test.go
+++ b/server/azure/dns/sdk_roundtrip_test.go
@@ -89,6 +89,16 @@ func TestSDKAzureDNSZoneLifecycle(t *testing.T) {
 		t.Fatalf("nameServers = %+v, want 4 authoritative name servers", created.Properties)
 	}
 
+	for _, ns := range created.Properties.NameServers {
+		if ns == nil || *ns == "" {
+			t.Fatalf("nameServer entry empty, want e.g. ns1-01.azure-dns.com")
+		}
+
+		if (*ns)[len(*ns)-1] == '.' {
+			t.Fatalf("nameServer = %q, want no trailing dot (real Azure returns ns1-01.azure-dns.com)", *ns)
+		}
+	}
+
 	got, err := zones.Get(ctx, testRG, "example.com", nil)
 	if err != nil {
 		t.Fatalf("Zones.Get: %v", err)

--- a/server/azure/dns/sdk_roundtrip_test.go
+++ b/server/azure/dns/sdk_roundtrip_test.go
@@ -80,6 +80,15 @@ func TestSDKAzureDNSZoneLifecycle(t *testing.T) {
 		t.Fatalf("CreateOrUpdate name = %v, want example.com", created.Name)
 	}
 
+	if created.Properties == nil || created.Properties.NumberOfRecordSets == nil ||
+		*created.Properties.NumberOfRecordSets != 2 {
+		t.Fatalf("numberOfRecordSets = %+v, want 2 (auto apex SOA+NS)", created.Properties)
+	}
+
+	if created.Properties == nil || len(created.Properties.NameServers) != 4 {
+		t.Fatalf("nameServers = %+v, want 4 authoritative name servers", created.Properties)
+	}
+
 	got, err := zones.Get(ctx, testRG, "example.com", nil)
 	if err != nil {
 		t.Fatalf("Zones.Get: %v", err)
@@ -87,6 +96,10 @@ func TestSDKAzureDNSZoneLifecycle(t *testing.T) {
 
 	if got.Tags["env"] == nil || *got.Tags["env"] != "test" {
 		t.Fatalf("tags = %v, want env=test", got.Tags)
+	}
+
+	if got.Etag == nil || *got.Etag == "" {
+		t.Fatalf("zone etag = %v, want non-empty", got.Etag)
 	}
 
 	var names []string
@@ -161,6 +174,10 @@ func TestSDKAzureDNSRecordSets(t *testing.T) {
 		t.Fatalf("ARecords = %+v, want [192.0.2.1]", got.Properties.ARecords)
 	}
 
+	if got.Properties.Fqdn == nil || *got.Properties.Fqdn != "www.records.com." {
+		t.Fatalf("fqdn = %v, want www.records.com.", got.Properties.Fqdn)
+	}
+
 	var listed []string
 
 	pager := records.NewListByDNSZonePager(testRG, "records.com", nil)
@@ -175,8 +192,10 @@ func TestSDKAzureDNSRecordSets(t *testing.T) {
 		}
 	}
 
-	if len(listed) != 1 || listed[0] != "www" {
-		t.Fatalf("record list = %v, want [www]", listed)
+	// The zone auto-provisions apex SOA and NS record sets, so the list carries
+	// them alongside the user's www record.
+	if !contains(listed, "www") || !contains(listed, "@") {
+		t.Fatalf("record list = %v, want to contain www and apex @ (SOA/NS)", listed)
 	}
 
 	if _, err := records.Delete(ctx, testRG, "records.com", "www", armdns.RecordTypeA, nil); err != nil {
@@ -189,6 +208,16 @@ func TestSDKAzureDNSRecordSets(t *testing.T) {
 	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
 		t.Fatalf("Get after delete: got %v, want 404", err)
 	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+
+	return false
 }
 
 func TestSDKAzureDNSErrors(t *testing.T) {

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -76,7 +76,7 @@ func zoneNameServers(zoneName string, private bool) []string {
 
 	out := make([]string, len(nameServerSuffixes))
 	for i, suffix := range nameServerSuffixes {
-		out[i] = fmt.Sprintf("ns%d-%02d.%s.", i+1, shard, suffix)
+		out[i] = fmt.Sprintf("ns%d-%02d.%s", i+1, shard, suffix)
 	}
 
 	return out

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -2,6 +2,8 @@ package dns
 
 import (
 	"context"
+	"fmt"
+	"hash/fnv"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -16,14 +18,87 @@ const (
 	recordSetTypePrefix = "Microsoft.Network/dnsZones/"
 	defaultZoneLocation = "global"
 	defaultRecordTTL    = 3600
+
+	// Canonical DNS record-type strings, keyed on the upper-cased URL segment.
+	recTypeA     = "A"
+	recTypeAAAA  = "AAAA"
+	recTypeCNAME = "CNAME"
+	recTypeTXT   = "TXT"
+	recTypeNS    = "NS"
+	recTypePTR   = "PTR"
+	recTypeSOA   = "SOA"
+
+	// maxNumberOfRecordSets is the fixed per-zone record-set cap Azure DNS
+	// reports (a read-only property).
+	maxNumberOfRecordSets = 5000
+	// maxNumberOfRecordsPerRecordSet is the fixed per-record-set record cap
+	// Azure DNS reports (read-only).
+	maxNumberOfRecordsPerRecordSet = 20
+
+	// apexRecordName is the relative name Azure uses for a zone's apex records
+	// (the auto-created SOA and NS record sets).
+	apexRecordName = "@"
+	// nsRecordTTL and soaRecordTTL are the TTLs Azure assigns the auto-created
+	// apex NS and SOA record sets.
+	nsRecordTTL  = 172800
+	soaRecordTTL = 3600
+
+	// nameServerShardCount bounds the 1-based shard embedded in a zone's name
+	// servers (ns1-NN...).
+	nameServerShardCount = 99
+
+	// SOA record defaults Azure stamps on the auto-created apex SOA. host and
+	// email are stored per-zone (host = the zone's first name server); the
+	// timing fields are fixed platform defaults.
+	soaEmail       = "azuredns-hostmaster.microsoft.com"
+	soaRefreshTime = 3600
+	soaRetryTime   = 300
+	soaExpireTime  = 2419200
+	soaMinimumTTL  = 300
+	soaSerial      = 1
 )
+
+// nameServerSuffixes are the four authoritative name-server domains Azure DNS
+// delegates a public zone to (ns1-NN.azure-dns.com / .net / .org / .info).
+//
+//nolint:gochecknoglobals // fixed platform constant, read-only lookup table
+var nameServerSuffixes = [...]string{"azure-dns.com", "azure-dns.net", "azure-dns.org", "azure-dns.info"}
+
+// zoneNameServers returns the four authoritative name servers Azure assigns a
+// public zone. Private zones have no name servers. The "NN" shard is derived
+// deterministically from the zone name so a zone always reports the same set.
+func zoneNameServers(zoneName string, private bool) []string {
+	if private {
+		return nil
+	}
+
+	shard := nameServerShard(zoneName)
+
+	out := make([]string, len(nameServerSuffixes))
+	for i, suffix := range nameServerSuffixes {
+		out[i] = fmt.Sprintf("ns%d-%02d.%s.", i+1, shard, suffix)
+	}
+
+	return out
+}
+
+// nameServerShard maps a zone name to the 1-99 shard Azure embeds in its name
+// servers (ns1-NN...). Deterministic so repeated reads are stable.
+func nameServerShard(zoneName string) int {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(zoneName))
+
+	return int(h.Sum32()%nameServerShardCount) + 1
+}
 
 // --- zone JSON ---
 
 type zoneProperties struct {
-	ZoneType           string   `json:"zoneType,omitempty"`
-	NumberOfRecordSets int64    `json:"numberOfRecordSets,omitempty"`
-	NameServers        []string `json:"nameServers,omitempty"`
+	ZoneType                       string   `json:"zoneType,omitempty"`
+	MaxNumberOfRecordSets          int64    `json:"maxNumberOfRecordSets,omitempty"`
+	MaxNumberOfRecordsPerRecordSet int64    `json:"maxNumberOfRecordsPerRecordSet,omitempty"`
+	NumberOfRecordSets             int64    `json:"numberOfRecordSets,omitempty"`
+	NameServers                    []string `json:"nameServers,omitempty"`
 }
 
 type zoneJSON struct {
@@ -94,6 +169,16 @@ type ptrRecordJSON struct {
 	Ptrdname string `json:"ptrdname,omitempty"`
 }
 
+type soaRecordJSON struct {
+	Host         string `json:"host,omitempty"`
+	Email        string `json:"email,omitempty"`
+	SerialNumber int64  `json:"serialNumber,omitempty"`
+	RefreshTime  int64  `json:"refreshTime,omitempty"`
+	RetryTime    int64  `json:"retryTime,omitempty"`
+	ExpireTime   int64  `json:"expireTime,omitempty"`
+	MinimumTTL   int64  `json:"minimumTTL,omitempty"`
+}
+
 type recordSetProperties struct {
 	TTL         *int64           `json:"TTL,omitempty"`
 	Fqdn        string           `json:"fqdn,omitempty"`
@@ -103,6 +188,7 @@ type recordSetProperties struct {
 	TxtRecords  []txtRecordJSON  `json:"TXTRecords,omitempty"`
 	NsRecords   []nsRecordJSON   `json:"NSRecords,omitempty"`
 	PtrRecords  []ptrRecordJSON  `json:"PTRRecords,omitempty"`
+	SoaRecord   *soaRecordJSON   `json:"SOARecord,omitempty"`
 }
 
 type recordSetJSON struct {
@@ -133,15 +219,21 @@ func privateFromZoneType(zt string) bool {
 // toZoneJSON converts a driver zone into its ARM element for the given path
 // scope. Azure DNS zones are always "global" location.
 func toZoneJSON(rp *azurearm.ResourcePath, info *dnsdriver.ZoneInfo) zoneJSON {
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeZones, info.Name)
+
 	return zoneJSON{
-		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeZones, info.Name),
+		ID:       id,
 		Name:     info.Name,
 		Type:     zoneResourceType,
 		Location: defaultZoneLocation,
+		Etag:     azurearm.ETag(id),
 		Tags:     info.Tags,
 		Properties: &zoneProperties{
-			ZoneType:           zoneType(info.Private),
-			NumberOfRecordSets: int64(info.RecordCount),
+			ZoneType:                       zoneType(info.Private),
+			MaxNumberOfRecordSets:          maxNumberOfRecordSets,
+			MaxNumberOfRecordsPerRecordSet: maxNumberOfRecordsPerRecordSet,
+			NumberOfRecordSets:             int64(info.RecordCount),
+			NameServers:                    zoneNameServers(info.Name, info.Private),
 		},
 	}
 }
@@ -154,25 +246,29 @@ func recordValues(recordType string, props *recordSetProperties) []string {
 	}
 
 	switch strings.ToUpper(recordType) {
-	case "A":
+	case recTypeA:
 		return mapStrings(props.ARecords, func(a aRecordJSON) string { return a.IPv4Address })
-	case "AAAA":
+	case recTypeAAAA:
 		return mapStrings(props.AaaaRecords, func(a aaaaRecordJSON) string { return a.IPv6Address })
-	case "CNAME":
+	case recTypeCNAME:
 		if props.CnameRecord != nil && props.CnameRecord.Cname != "" {
 			return []string{props.CnameRecord.Cname}
 		}
-	case "TXT":
+	case recTypeTXT:
 		var out []string
 		for _, t := range props.TxtRecords {
 			out = append(out, strings.Join(t.Value, ""))
 		}
 
 		return out
-	case "NS":
+	case recTypeNS:
 		return mapStrings(props.NsRecords, func(n nsRecordJSON) string { return n.Nsdname })
-	case "PTR":
+	case recTypePTR:
 		return mapStrings(props.PtrRecords, func(p ptrRecordJSON) string { return p.Ptrdname })
+	case recTypeSOA:
+		if props.SoaRecord != nil {
+			return []string{props.SoaRecord.Host, props.SoaRecord.Email}
+		}
 	}
 
 	return nil
@@ -185,33 +281,59 @@ func toRecordSetProperties(rec *dnsdriver.RecordInfo) *recordSetProperties {
 	props := &recordSetProperties{TTL: &ttl}
 
 	switch strings.ToUpper(rec.Type) {
-	case "A":
+	case recTypeA:
 		for _, v := range rec.Values {
 			props.ARecords = append(props.ARecords, aRecordJSON{IPv4Address: v})
 		}
-	case "AAAA":
+	case recTypeAAAA:
 		for _, v := range rec.Values {
 			props.AaaaRecords = append(props.AaaaRecords, aaaaRecordJSON{IPv6Address: v})
 		}
-	case "CNAME":
+	case recTypeCNAME:
 		if len(rec.Values) > 0 {
 			props.CnameRecord = &cnameRecordJSON{Cname: rec.Values[0]}
 		}
-	case "TXT":
+	case recTypeTXT:
 		for _, v := range rec.Values {
 			props.TxtRecords = append(props.TxtRecords, txtRecordJSON{Value: chunkTXT(v)})
 		}
-	case "NS":
+	case recTypeNS:
 		for _, v := range rec.Values {
 			props.NsRecords = append(props.NsRecords, nsRecordJSON{Nsdname: v})
 		}
-	case "PTR":
+	case recTypePTR:
 		for _, v := range rec.Values {
 			props.PtrRecords = append(props.PtrRecords, ptrRecordJSON{Ptrdname: v})
 		}
+	case recTypeSOA:
+		props.SoaRecord = toSOARecord(rec.Values)
 	}
 
 	return props
+}
+
+// toSOARecord rebuilds the Azure SOA body from the driver's flat values
+// ([host, email]), filling the timing fields with the platform defaults Azure
+// stamps on the auto-created apex SOA.
+func toSOARecord(values []string) *soaRecordJSON {
+	soa := &soaRecordJSON{
+		Email:        soaEmail,
+		SerialNumber: soaSerial,
+		RefreshTime:  soaRefreshTime,
+		RetryTime:    soaRetryTime,
+		ExpireTime:   soaExpireTime,
+		MinimumTTL:   soaMinimumTTL,
+	}
+
+	if len(values) > 0 {
+		soa.Host = values[0]
+	}
+
+	if len(values) > 1 && values[1] != "" {
+		soa.Email = values[1]
+	}
+
+	return soa
 }
 
 // toRecordSetJSON converts a driver record into its ARM element.
@@ -219,12 +341,27 @@ func toRecordSetJSON(rp *azurearm.ResourcePath, zone string, rec *dnsdriver.Reco
 	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeZones, zone) +
 		"/" + rec.Type + "/" + rec.Name
 
+	props := toRecordSetProperties(rec)
+	props.Fqdn = recordFqdn(rec.Name, zone)
+
 	return recordSetJSON{
 		ID:         id,
 		Name:       rec.Name,
 		Type:       recordSetTypePrefix + rec.Type,
-		Properties: toRecordSetProperties(rec),
+		Etag:       azurearm.ETag(id),
+		Properties: props,
 	}
+}
+
+// recordFqdn builds the fully-qualified domain name Azure reports for a record
+// set: "<name>.<zone>." for a relative record, and "<zone>." for the apex
+// ("@") record. The trailing dot marks it as fully qualified.
+func recordFqdn(name, zone string) string {
+	if name == "" || name == apexRecordName {
+		return zone + "."
+	}
+
+	return name + "." + zone + "."
 }
 
 // mapStrings projects a typed slice to its string values, dropping empties.

--- a/server/azure/loadbalancer/lb_e2e_test.go
+++ b/server/azure/loadbalancer/lb_e2e_test.go
@@ -101,6 +101,7 @@ func TestSDKLBFrontendRuleProbe(t *testing.T) {
 					Protocol:                to.Ptr(armnetwork.TransportProtocolTCP),
 					FrontendPort:            to.Ptr(int32(80)),
 					BackendPort:             to.Ptr(int32(8080)),
+					EnableFloatingIP:        to.Ptr(true),
 					FrontendIPConfiguration: &armnetwork.SubResource{ID: to.Ptr(lbChildID("frontendIPConfigurations", "my-frontend"))},
 					BackendAddressPool:      &armnetwork.SubResource{ID: to.Ptr(lbChildID("backendAddressPools", "web-pool"))},
 					Probe:                   &armnetwork.SubResource{ID: to.Ptr(lbChildID("probes", "probe-lb"))},
@@ -131,8 +132,8 @@ func TestSDKLBFrontendRuleProbe(t *testing.T) {
 		t.Fatalf("sku = %+v, want Basic", got.SKU)
 	}
 
-	if got.Etag == nil || *got.Etag == "" {
-		t.Fatalf("etag empty, want non-empty")
+	if got.Etag == nil || !isWeakETag(*got.Etag) {
+		t.Fatalf("etag = %v, want weak-validator form W/\"...\"", got.Etag)
 	}
 
 	assertFrontend(t, &got.LoadBalancer)
@@ -171,6 +172,10 @@ func assertRule(t *testing.T, lb *armnetwork.LoadBalancer) {
 
 	if rule.Properties == nil || *rule.Properties.FrontendPort != 80 || *rule.Properties.BackendPort != 8080 {
 		t.Fatalf("rule ports = %+v, want frontend 80 / backend 8080", rule.Properties)
+	}
+
+	if rule.Properties.EnableFloatingIP == nil || !*rule.Properties.EnableFloatingIP {
+		t.Fatalf("rule enableFloatingIP = %v, want echoed back as true", rule.Properties.EnableFloatingIP)
 	}
 
 	if rule.Properties.FrontendIPConfiguration == nil || rule.Properties.FrontendIPConfiguration.ID == nil ||
@@ -250,4 +255,10 @@ func TestSDKLBRuleProtocolUpdate(t *testing.T) {
 
 func hasSuffix(s, suffix string) bool {
 	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}
+
+// isWeakETag reports whether s is in the weak-validator form W/"..." that the
+// real ARM API emits for Microsoft.Network resources.
+func isWeakETag(s string) bool {
+	return len(s) >= 4 && s[:3] == `W/"` && s[len(s)-1] == '"'
 }

--- a/server/azure/loadbalancer/lb_e2e_test.go
+++ b/server/azure/loadbalancer/lb_e2e_test.go
@@ -1,0 +1,253 @@
+package loadbalancer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+func lbChildID(child, name string) string {
+	return "/subscriptions/" + testSub + "/resourceGroups/" + testRG +
+		"/providers/Microsoft.Network/loadBalancers/lb-full/" + child + "/" + name
+}
+
+// Finding #9: PUT is a full replace — children omitted from the body are
+// removed rather than accumulating.
+func TestSDKLBFullReplace(t *testing.T) {
+	client := newLBClient(t)
+	ctx := context.Background()
+
+	twoPools := armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{
+			BackendAddressPools: []*armnetwork.BackendAddressPool{
+				{Name: to.Ptr("pool-a")}, {Name: to.Ptr("pool-b")},
+			},
+		},
+	}
+
+	p, err := client.BeginCreateOrUpdate(ctx, testRG, "lb-full", twoPools, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if _, err := p.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	onePool := armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{
+			BackendAddressPools: []*armnetwork.BackendAddressPool{{Name: to.Ptr("pool-a")}},
+		},
+	}
+
+	p2, err := client.BeginCreateOrUpdate(ctx, testRG, "lb-full", onePool, nil)
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	if _, err := p2.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll update: %v", err)
+	}
+
+	got, err := client.Get(ctx, testRG, "lb-full", nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.Properties == nil || len(got.Properties.BackendAddressPools) != 1 {
+		t.Fatalf("pools after replace = %+v, want 1 (pool-a only)", got.Properties)
+	}
+
+	if *got.Properties.BackendAddressPools[0].Name != "pool-a" {
+		t.Fatalf("remaining pool = %v, want pool-a", got.Properties.BackendAddressPools[0].Name)
+	}
+}
+
+// Findings #10 (rule name + independent backend port), #11 (frontend name/IP),
+// #16 (SKU echoed), #18 (probes), #19 (etag), #14 (location).
+func TestSDKLBFrontendRuleProbe(t *testing.T) {
+	client := newLBClient(t)
+	ctx := context.Background()
+
+	body := armnetwork.LoadBalancer{
+		Location: to.Ptr("westus2"),
+		SKU:      &armnetwork.LoadBalancerSKU{Name: to.Ptr(armnetwork.LoadBalancerSKUNameBasic)},
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{
+			FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{{
+				Name: to.Ptr("my-frontend"),
+				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+					PrivateIPAddress:          to.Ptr("10.0.0.9"),
+					PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+				},
+			}},
+			BackendAddressPools: []*armnetwork.BackendAddressPool{{Name: to.Ptr("web-pool")}},
+			Probes: []*armnetwork.Probe{{
+				Name: to.Ptr("probe-lb"),
+				Properties: &armnetwork.ProbePropertiesFormat{
+					Protocol:          to.Ptr(armnetwork.ProbeProtocolHTTP),
+					Port:              to.Ptr(int32(80)),
+					RequestPath:       to.Ptr("/health"),
+					IntervalInSeconds: to.Ptr(int32(15)),
+					NumberOfProbes:    to.Ptr(int32(2)),
+				},
+			}},
+			LoadBalancingRules: []*armnetwork.LoadBalancingRule{{
+				Name: to.Ptr("http-rule"),
+				Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+					Protocol:                to.Ptr(armnetwork.TransportProtocolTCP),
+					FrontendPort:            to.Ptr(int32(80)),
+					BackendPort:             to.Ptr(int32(8080)),
+					FrontendIPConfiguration: &armnetwork.SubResource{ID: to.Ptr(lbChildID("frontendIPConfigurations", "my-frontend"))},
+					BackendAddressPool:      &armnetwork.SubResource{ID: to.Ptr(lbChildID("backendAddressPools", "web-pool"))},
+					Probe:                   &armnetwork.SubResource{ID: to.Ptr(lbChildID("probes", "probe-lb"))},
+				},
+			}},
+		},
+	}
+
+	p, err := client.BeginCreateOrUpdate(ctx, testRG, "lb-full", body, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if _, err := p.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	got, err := client.Get(ctx, testRG, "lb-full", nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.Location == nil || *got.Location != "westus2" {
+		t.Fatalf("location = %v, want westus2", got.Location)
+	}
+
+	if got.SKU == nil || got.SKU.Name == nil || *got.SKU.Name != armnetwork.LoadBalancerSKUNameBasic {
+		t.Fatalf("sku = %+v, want Basic", got.SKU)
+	}
+
+	if got.Etag == nil || *got.Etag == "" {
+		t.Fatalf("etag empty, want non-empty")
+	}
+
+	assertFrontend(t, &got.LoadBalancer)
+	assertRule(t, &got.LoadBalancer)
+	assertProbe(t, &got.LoadBalancer)
+}
+
+func assertFrontend(t *testing.T, lb *armnetwork.LoadBalancer) {
+	t.Helper()
+
+	if len(lb.Properties.FrontendIPConfigurations) != 1 {
+		t.Fatalf("frontends = %d, want 1", len(lb.Properties.FrontendIPConfigurations))
+	}
+
+	fe := lb.Properties.FrontendIPConfigurations[0]
+	if fe.Name == nil || *fe.Name != "my-frontend" {
+		t.Fatalf("frontend name = %v, want my-frontend", fe.Name)
+	}
+
+	if fe.Properties == nil || fe.Properties.PrivateIPAddress == nil || *fe.Properties.PrivateIPAddress != "10.0.0.9" {
+		t.Fatalf("frontend privateIP = %+v, want 10.0.0.9", fe.Properties)
+	}
+}
+
+func assertRule(t *testing.T, lb *armnetwork.LoadBalancer) {
+	t.Helper()
+
+	if len(lb.Properties.LoadBalancingRules) != 1 {
+		t.Fatalf("rules = %d, want 1", len(lb.Properties.LoadBalancingRules))
+	}
+
+	rule := lb.Properties.LoadBalancingRules[0]
+	if rule.Name == nil || *rule.Name != "http-rule" {
+		t.Fatalf("rule name = %v, want http-rule (not regenerated)", rule.Name)
+	}
+
+	if rule.Properties == nil || *rule.Properties.FrontendPort != 80 || *rule.Properties.BackendPort != 8080 {
+		t.Fatalf("rule ports = %+v, want frontend 80 / backend 8080", rule.Properties)
+	}
+
+	if rule.Properties.FrontendIPConfiguration == nil || rule.Properties.FrontendIPConfiguration.ID == nil ||
+		!hasSuffix(*rule.Properties.FrontendIPConfiguration.ID, "/frontendIPConfigurations/my-frontend") {
+		t.Fatalf("rule frontend ref = %+v, want named my-frontend", rule.Properties.FrontendIPConfiguration)
+	}
+
+	if rule.Properties.Probe == nil || rule.Properties.Probe.ID == nil ||
+		!hasSuffix(*rule.Properties.Probe.ID, "/probes/probe-lb") {
+		t.Fatalf("rule probe ref = %+v, want probe-lb", rule.Properties.Probe)
+	}
+}
+
+func assertProbe(t *testing.T, lb *armnetwork.LoadBalancer) {
+	t.Helper()
+
+	if len(lb.Properties.Probes) != 1 {
+		t.Fatalf("probes = %d, want 1 first-class probe", len(lb.Properties.Probes))
+	}
+
+	pr := lb.Properties.Probes[0]
+	if pr.Name == nil || *pr.Name != "probe-lb" {
+		t.Fatalf("probe name = %v, want probe-lb", pr.Name)
+	}
+
+	if pr.Properties == nil || pr.Properties.Port == nil || *pr.Properties.Port != 80 ||
+		pr.Properties.RequestPath == nil || *pr.Properties.RequestPath != "/health" {
+		t.Fatalf("probe props = %+v, want port 80 path /health", pr.Properties)
+	}
+}
+
+// Finding #15: a protocol change on an existing rule is applied (full replace).
+func TestSDKLBRuleProtocolUpdate(t *testing.T) {
+	client := newLBClient(t)
+	ctx := context.Background()
+
+	mk := func(proto armnetwork.TransportProtocol) armnetwork.LoadBalancer {
+		return armnetwork.LoadBalancer{
+			Location: to.Ptr("eastus"),
+			Properties: &armnetwork.LoadBalancerPropertiesFormat{
+				LoadBalancingRules: []*armnetwork.LoadBalancingRule{{
+					Name: to.Ptr("r1"),
+					Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+						Protocol:     to.Ptr(proto),
+						FrontendPort: to.Ptr(int32(80)),
+						BackendPort:  to.Ptr(int32(80)),
+					},
+				}},
+			},
+		}
+	}
+
+	for _, proto := range []armnetwork.TransportProtocol{
+		armnetwork.TransportProtocolTCP, armnetwork.TransportProtocolUDP,
+	} {
+		p, err := client.BeginCreateOrUpdate(ctx, testRG, "lb-proto", mk(proto), nil)
+		if err != nil {
+			t.Fatalf("put %v: %v", proto, err)
+		}
+
+		if _, err := p.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("poll %v: %v", proto, err)
+		}
+	}
+
+	got, err := client.Get(ctx, testRG, "lb-proto", nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	rule := got.Properties.LoadBalancingRules[0]
+	if rule.Properties == nil || rule.Properties.Protocol == nil ||
+		*rule.Properties.Protocol != armnetwork.TransportProtocolUDP {
+		t.Fatalf("rule protocol = %+v, want Udp after update", rule.Properties)
+	}
+}
+
+func hasSuffix(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}

--- a/server/azure/loadbalancer/operations.go
+++ b/server/azure/loadbalancer/operations.go
@@ -3,7 +3,6 @@ package loadbalancer
 import (
 	"context"
 	"net/http"
-	"strconv"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -11,17 +10,18 @@ import (
 	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
 )
 
-// Internal tags scope a driver target group to its Azure parent load balancer
-// and preserve the SDK-facing backend-pool name. They are stripped from the
-// tags echoed back to callers.
-const (
-	tagLBName   = "cloudemu:azureLBName"
-	tagPoolName = "cloudemu:azurePoolName"
-)
+// azureLB returns the native Azure load-balancer store if the driver implements
+// it (the Azure provider does).
+func (h *Handler) azureLB() (lbdriver.AzureLoadBalancers, bool) {
+	az, ok := h.lb.(lbdriver.AzureLoadBalancers)
+
+	return az, ok
+}
 
 // createOrUpdateLoadBalancer handles PUT .../loadBalancers/{name}. The whole
-// nested load balancer arrives in one body; we reconcile the driver's LB,
-// backend pools (target groups) and load-balancing rules (listeners) to match.
+// nested load balancer arrives in one body and fully REPLACES the stored state,
+// so any frontend / pool / rule / probe omitted from the body is removed —
+// matching ARM's CreateOrUpdate semantics (no stale-child accumulation).
 //
 // LoadBalancers.CreateOrUpdate is an LRO in the SDK; returning 200 with the
 // fully-provisioned body (ProvisioningState=Succeeded) completes the poller on
@@ -32,40 +32,345 @@ func (h *Handler) createOrUpdateLoadBalancer(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	lb, err := h.upsertLB(r.Context(), rp.ResourceName, &body)
+	az, ok := h.azureLB()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"load balancers are not supported by this driver")
+
+		return
+	}
+
+	stored, err := az.CreateOrUpdateAzureLoadBalancer(r.Context(), rp.ResourceGroup, rp.ResourceName, buildAzureLB(&body))
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
-	pools, err := h.reconcilePools(r.Context(), lb, &body)
+	// Keep a minimal cross-cloud LB record so resource discovery still sees the
+	// load balancer; its rich shape lives in the native store.
+	h.syncGenericLB(r.Context(), rp.ResourceName, &body)
+
+	azurearm.WriteJSON(w, http.StatusOK, toLBJSON(rp, stored))
+}
+
+func (h *Handler) getLoadBalancer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	az, ok := h.azureLB()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "load balancer not found")
+		return
+	}
+
+	stored, err := az.GetAzureLoadBalancer(r.Context(), rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
-	if err := h.reconcileRules(r.Context(), lb, pools, &body); err != nil {
+	azurearm.WriteJSON(w, http.StatusOK, toLBJSON(rp, stored))
+}
+
+// deleteLoadBalancer removes the load balancer from both the native store and
+// the cross-cloud record. LoadBalancers.Delete is an LRO; a 200 with empty body
+// completes the poller.
+func (h *Handler) deleteLoadBalancer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	az, ok := h.azureLB()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "load balancer not found")
+		return
+	}
+
+	if derr := az.DeleteAzureLoadBalancer(r.Context(), rp.ResourceGroup, rp.ResourceName); derr != nil {
+		azurearm.WriteCErr(w, derr)
+		return
+	}
+
+	if lb, ferr := h.findGenericLB(r.Context(), rp.ResourceName); ferr == nil {
+		_ = h.lb.DeleteLoadBalancer(r.Context(), lb.ARN)
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) listLoadBalancers(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	az, ok := h.azureLB()
+	if !ok {
+		azurearm.WriteJSON(w, http.StatusOK, lbListResult{Value: []loadBalancerJSON{}})
+		return
+	}
+
+	stored, err := az.ListAzureLoadBalancers(r.Context(), rp.ResourceGroup)
+	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
-	out, err := h.buildLBJSON(r.Context(), rp, lb)
-	if err != nil {
-		azurearm.WriteCErr(w, err)
-		return
+	out := lbListResult{Value: make([]loadBalancerJSON, 0, len(stored))}
+
+	for i := range stored {
+		scope := *rp
+		scope.ResourceGroup = stored[i].ResourceGroup
+		scope.ResourceName = stored[i].Name
+		out.Value = append(out.Value, toLBJSON(&scope, &stored[i]))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, out)
 }
 
-// upsertLB creates the load balancer if absent, otherwise returns the existing
-// one (CreateOrUpdate is idempotent on the top-level resource).
-func (h *Handler) upsertLB(ctx context.Context, name string, body *loadBalancerJSON) (*lbdriver.LBInfo, error) {
-	if lb, err := h.findLBByName(ctx, name); err == nil {
-		return lb, nil
+// --- request → native model ---
+
+// buildAzureLB maps the ARM request body to the native store model, preserving
+// every frontend/pool/rule/probe name and each rule's independent ports and
+// child references verbatim.
+func buildAzureLB(body *loadBalancerJSON) lbdriver.AzureLoadBalancer {
+	lb := lbdriver.AzureLoadBalancer{
+		Location: firstNonEmpty(body.Location, defaultLBLocation),
+		SKUName:  defaultSKUName,
+		SKUTier:  defaultSKUTier,
+		Tags:     stripInternalTags(body.Tags),
 	}
 
-	return h.lb.CreateLoadBalancer(ctx, lbdriver.LBConfig{
+	if body.SKU != nil {
+		lb.SKUName = firstNonEmpty(body.SKU.Name, defaultSKUName)
+		lb.SKUTier = firstNonEmpty(body.SKU.Tier, defaultSKUTier)
+	}
+
+	if body.Properties == nil {
+		return lb
+	}
+
+	lb.Frontends = buildFrontends(body.Properties.FrontendIPConfigurations)
+	lb.BackendPools = buildPools(body.Properties.BackendAddressPools)
+	lb.Probes = buildProbes(body.Properties.Probes)
+	lb.Rules = buildRules(body.Properties.LoadBalancingRules)
+
+	return lb
+}
+
+func buildFrontends(in []frontendIPJSON) []lbdriver.AzureLBFrontend {
+	out := make([]lbdriver.AzureLBFrontend, 0, len(in))
+
+	for i := range in {
+		fe := lbdriver.AzureLBFrontend{Name: in[i].Name}
+
+		if p := in[i].Properties; p != nil {
+			fe.PrivateIPAddress = p.PrivateIPAddress
+			fe.AllocationMethod = p.PrivateIPAllocationMethod
+
+			if p.Subnet != nil {
+				fe.SubnetID = p.Subnet.ID
+			}
+
+			if p.PublicIPAddress != nil {
+				fe.PublicIPID = p.PublicIPAddress.ID
+			}
+		}
+
+		out = append(out, fe)
+	}
+
+	return out
+}
+
+func buildPools(in []backendPoolJSON) []string {
+	out := make([]string, 0, len(in))
+
+	for i := range in {
+		if in[i].Name != "" {
+			out = append(out, in[i].Name)
+		}
+	}
+
+	return out
+}
+
+func buildProbes(in []probeJSON) []lbdriver.AzureLBProbe {
+	out := make([]lbdriver.AzureLBProbe, 0, len(in))
+
+	for i := range in {
+		pr := lbdriver.AzureLBProbe{Name: in[i].Name}
+
+		if p := in[i].Properties; p != nil {
+			pr.Protocol = p.Protocol
+			pr.Port = int(p.Port)
+			pr.RequestPath = p.RequestPath
+			pr.IntervalInSeconds = int(p.IntervalInSeconds)
+			pr.NumberOfProbes = int(p.NumberOfProbes)
+		}
+
+		out = append(out, pr)
+	}
+
+	return out
+}
+
+func buildRules(in []loadBalancingRuleJSON) []lbdriver.AzureLBRule {
+	out := make([]lbdriver.AzureLBRule, 0, len(in))
+
+	for i := range in {
+		rule := lbdriver.AzureLBRule{Name: in[i].Name}
+
+		if p := in[i].Properties; p != nil {
+			rule.Protocol = firstNonEmpty(p.Protocol, protocolTCP)
+			rule.FrontendPort = int(p.FrontendPort)
+			rule.BackendPort = int(p.BackendPort)
+
+			if rule.BackendPort == 0 {
+				rule.BackendPort = rule.FrontendPort
+			}
+
+			rule.FrontendName = lastPathSegment(refID(p.FrontendIPConfiguration))
+			rule.BackendPoolName = lastPathSegment(refID(p.BackendAddressPool))
+			rule.ProbeName = lastPathSegment(refID(p.Probe))
+			rule.IdleTimeoutMin = int(p.IdleTimeoutInMinutes)
+			rule.LoadDistribution = p.LoadDistribution
+
+			if p.EnableFloatingIP != nil {
+				rule.EnableFloatingIP = *p.EnableFloatingIP
+			}
+		}
+
+		out = append(out, rule)
+	}
+
+	return out
+}
+
+// --- native model → response ---
+
+// toLBJSON reconstructs the nested ARM load balancer body from the stored
+// native model, stamping ids, etags and terminal provisioning states.
+func toLBJSON(rp *azurearm.ResourcePath, lb *lbdriver.AzureLoadBalancer) loadBalancerJSON {
+	lbID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeLBs, rp.ResourceName)
+
+	props := &loadBalancerProps{
+		ProvisioningState:        provisioningStateSucceeded,
+		FrontendIPConfigurations: frontendsJSON(lbID, lb.Frontends),
+		BackendAddressPools:      poolsJSON(lbID, lb.BackendPools),
+		Probes:                   probesJSON(lbID, lb.Probes),
+		LoadBalancingRules:       rulesJSON(lbID, lb.Rules),
+	}
+
+	return loadBalancerJSON{
+		ID:         lbID,
+		Name:       rp.ResourceName,
+		Type:       lbResourceType,
+		Location:   firstNonEmpty(lb.Location, defaultLBLocation),
+		Etag:       weakETag(lbID),
+		SKU:        &lbSKU{Name: firstNonEmpty(lb.SKUName, defaultSKUName), Tier: firstNonEmpty(lb.SKUTier, defaultSKUTier)},
+		Tags:       lb.Tags,
+		Properties: props,
+	}
+}
+
+func frontendsJSON(lbID string, in []lbdriver.AzureLBFrontend) []frontendIPJSON {
+	out := make([]frontendIPJSON, 0, len(in))
+
+	for i := range in {
+		fe := in[i]
+		id := lbID + "/frontendIPConfigurations/" + fe.Name
+		p := &frontendIPProps{
+			PrivateIPAddress:          fe.PrivateIPAddress,
+			PrivateIPAllocationMethod: fe.AllocationMethod,
+			ProvisioningState:         provisioningStateSucceeded,
+		}
+
+		if fe.SubnetID != "" {
+			p.Subnet = &subResource{ID: fe.SubnetID}
+		}
+
+		if fe.PublicIPID != "" {
+			p.PublicIPAddress = &subResource{ID: fe.PublicIPID}
+		}
+
+		out = append(out, frontendIPJSON{
+			ID: id, Name: fe.Name, Type: feResourceType, Etag: weakETag(id), Properties: p,
+		})
+	}
+
+	return out
+}
+
+func poolsJSON(lbID string, names []string) []backendPoolJSON {
+	out := make([]backendPoolJSON, 0, len(names))
+
+	for _, name := range names {
+		id := lbID + "/backendAddressPools/" + name
+		out = append(out, backendPoolJSON{
+			ID: id, Name: name, Type: poolResourceType, Etag: weakETag(id),
+			Properties: &backendPoolProps{ProvisioningState: provisioningStateSucceeded},
+		})
+	}
+
+	return out
+}
+
+func probesJSON(lbID string, in []lbdriver.AzureLBProbe) []probeJSON {
+	out := make([]probeJSON, 0, len(in))
+
+	for i := range in {
+		pr := in[i]
+		id := lbID + "/probes/" + pr.Name
+		out = append(out, probeJSON{
+			ID: id, Name: pr.Name, Type: probeResourceType, Etag: weakETag(id),
+			Properties: &probeProps{
+				Protocol:          pr.Protocol,
+				Port:              i32(pr.Port),
+				RequestPath:       pr.RequestPath,
+				IntervalInSeconds: i32(pr.IntervalInSeconds),
+				NumberOfProbes:    i32(pr.NumberOfProbes),
+				ProvisioningState: provisioningStateSucceeded,
+			},
+		})
+	}
+
+	return out
+}
+
+func rulesJSON(lbID string, in []lbdriver.AzureLBRule) []loadBalancingRuleJSON {
+	out := make([]loadBalancingRuleJSON, 0, len(in))
+
+	for i := range in {
+		rule := in[i]
+		id := lbID + "/loadBalancingRules/" + rule.Name
+		p := &loadBalancingRuleProps{
+			Protocol:             firstNonEmpty(rule.Protocol, protocolTCP),
+			FrontendPort:         i32(rule.FrontendPort),
+			BackendPort:          i32(rule.BackendPort),
+			IdleTimeoutInMinutes: i32(rule.IdleTimeoutMin),
+			LoadDistribution:     rule.LoadDistribution,
+			ProvisioningState:    provisioningStateSucceeded,
+		}
+
+		if rule.FrontendName != "" {
+			p.FrontendIPConfiguration = &subResource{ID: lbID + "/frontendIPConfigurations/" + rule.FrontendName}
+		}
+
+		if rule.BackendPoolName != "" {
+			p.BackendAddressPool = &subResource{ID: lbID + "/backendAddressPools/" + rule.BackendPoolName}
+		}
+
+		if rule.ProbeName != "" {
+			p.Probe = &subResource{ID: lbID + "/probes/" + rule.ProbeName}
+		}
+
+		out = append(out, loadBalancingRuleJSON{
+			ID: id, Name: rule.Name, Type: ruleResourceType, Etag: weakETag(id), Properties: p,
+		})
+	}
+
+	return out
+}
+
+// --- cross-cloud (discovery) sync ---
+
+// syncGenericLB ensures a minimal cross-cloud LB record exists for name so
+// resource discovery can still enumerate the load balancer.
+func (h *Handler) syncGenericLB(ctx context.Context, name string, body *loadBalancerJSON) {
+	if _, err := h.findGenericLB(ctx, name); err == nil {
+		return
+	}
+
+	_, _ = h.lb.CreateLoadBalancer(ctx, lbdriver.LBConfig{
 		Name:   name,
 		Type:   "network",
 		Scheme: schemeFromBody(body),
@@ -73,175 +378,8 @@ func (h *Handler) upsertLB(ctx context.Context, name string, body *loadBalancerJ
 	})
 }
 
-// reconcilePools ensures every backend address pool in the body exists as a
-// driver target group tagged to this load balancer, and returns them keyed by
-// Azure pool name.
-func (h *Handler) reconcilePools(ctx context.Context, lb *lbdriver.LBInfo,
-	body *loadBalancerJSON,
-) (map[string]*lbdriver.TargetGroupInfo, error) {
-	out := make(map[string]*lbdriver.TargetGroupInfo)
-
-	if body.Properties == nil {
-		return out, nil
-	}
-
-	existing, err := h.poolsForLB(ctx, lb.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range body.Properties.BackendAddressPools {
-		pool := body.Properties.BackendAddressPools[i]
-		if pool.Name == "" {
-			continue
-		}
-
-		if tg, ok := existing[pool.Name]; ok {
-			out[pool.Name] = tg
-			continue
-		}
-
-		tg, cErr := h.lb.CreateTargetGroup(ctx, lbdriver.TargetGroupConfig{
-			Name: lb.Name + "-" + pool.Name,
-			Tags: map[string]string{tagLBName: lb.Name, tagPoolName: pool.Name},
-		})
-		if cErr != nil {
-			return nil, cErr
-		}
-
-		out[pool.Name] = tg
-	}
-
-	return out, nil
-}
-
-// reconcileRules ensures every load-balancing rule in the body exists as a
-// driver listener on this load balancer, resolving the rule's backend pool
-// reference to the matching target group ARN.
-func (h *Handler) reconcileRules(ctx context.Context, lb *lbdriver.LBInfo,
-	pools map[string]*lbdriver.TargetGroupInfo, body *loadBalancerJSON,
-) error {
-	if body.Properties == nil {
-		return nil
-	}
-
-	existing, err := h.lb.DescribeListeners(ctx, lb.ARN)
-	if err != nil {
-		return err
-	}
-
-	haveByPort := make(map[int]struct{}, len(existing))
-	for i := range existing {
-		haveByPort[existing[i].Port] = struct{}{}
-	}
-
-	for i := range body.Properties.LoadBalancingRules {
-		rule := body.Properties.LoadBalancingRules[i]
-		if rule.Properties == nil {
-			continue
-		}
-
-		port := int(rule.Properties.FrontendPort)
-		if _, ok := haveByPort[port]; ok {
-			continue
-		}
-
-		var tgARN string
-		if rule.Properties.BackendAddressPool != nil {
-			if tg, ok := pools[poolNameFromID(rule.Properties.BackendAddressPool.ID)]; ok {
-				tgARN = tg.ARN
-			}
-		}
-
-		if _, err := h.lb.CreateListener(ctx, lbdriver.ListenerConfig{
-			LBARN:          lb.ARN,
-			Protocol:       protocolOrDefault(rule.Properties.Protocol),
-			Port:           port,
-			TargetGroupARN: tgARN,
-		}); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (h *Handler) getLoadBalancer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	lb, err := h.findLBByName(r.Context(), rp.ResourceName)
-	if err != nil {
-		azurearm.WriteCErr(w, err)
-		return
-	}
-
-	out, err := h.buildLBJSON(r.Context(), rp, lb)
-	if err != nil {
-		azurearm.WriteCErr(w, err)
-		return
-	}
-
-	azurearm.WriteJSON(w, http.StatusOK, out)
-}
-
-// deleteLoadBalancer removes the load balancer and its backend pools. The
-// driver drops the load balancer's listeners as part of DeleteLoadBalancer.
-// LoadBalancers.Delete is an LRO; a 200 with empty body completes the poller.
-func (h *Handler) deleteLoadBalancer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	lb, err := h.findLBByName(r.Context(), rp.ResourceName)
-	if err != nil {
-		azurearm.WriteCErr(w, err)
-		return
-	}
-
-	pools, err := h.poolsForLB(r.Context(), lb.Name)
-	if err != nil {
-		azurearm.WriteCErr(w, err)
-		return
-	}
-
-	for _, tg := range pools {
-		if derr := h.lb.DeleteTargetGroup(r.Context(), tg.ARN); derr != nil && !cerrors.IsNotFound(derr) {
-			azurearm.WriteCErr(w, derr)
-			return
-		}
-	}
-
-	if derr := h.lb.DeleteLoadBalancer(r.Context(), lb.ARN); derr != nil {
-		azurearm.WriteCErr(w, derr)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-}
-
-func (h *Handler) listLoadBalancers(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	lbs, err := h.lb.DescribeLoadBalancers(r.Context(), nil)
-	if err != nil {
-		azurearm.WriteCErr(w, err)
-		return
-	}
-
-	out := lbListResult{Value: make([]loadBalancerJSON, 0, len(lbs))}
-
-	for i := range lbs {
-		scope := *rp
-		scope.ResourceName = lbs[i].Name
-
-		item, berr := h.buildLBJSON(r.Context(), &scope, &lbs[i])
-		if berr != nil {
-			azurearm.WriteCErr(w, berr)
-			return
-		}
-
-		out.Value = append(out.Value, item)
-	}
-
-	azurearm.WriteJSON(w, http.StatusOK, out)
-}
-
-// --- helpers ---
-
-// findLBByName resolves the SDK-facing load balancer name to its driver record.
-func (h *Handler) findLBByName(ctx context.Context, name string) (*lbdriver.LBInfo, error) {
+// findGenericLB resolves the cross-cloud LB record by its user-assigned name.
+func (h *Handler) findGenericLB(ctx context.Context, name string) (*lbdriver.LBInfo, error) {
 	lbs, err := h.lb.DescribeLoadBalancers(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -256,141 +394,26 @@ func (h *Handler) findLBByName(ctx context.Context, name string) (*lbdriver.LBIn
 	return nil, cerrors.Newf(cerrors.NotFound, "load balancer %q not found", name)
 }
 
-// poolsForLB returns the target groups tagged to load balancer lbName, keyed by
-// their Azure pool name.
-func (h *Handler) poolsForLB(ctx context.Context, lbName string) (map[string]*lbdriver.TargetGroupInfo, error) {
-	tgs, err := h.lb.DescribeTargetGroups(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
+// --- helpers ---
 
-	out := make(map[string]*lbdriver.TargetGroupInfo)
-
-	for i := range tgs {
-		if tgs[i].Tags[tagLBName] != lbName {
-			continue
-		}
-
-		out[tgs[i].Tags[tagPoolName]] = &tgs[i]
-	}
-
-	return out, nil
+// weakETag wraps a stable etag in the weak-validator form (W/"...") ARM uses
+// for load-balancer resources.
+func weakETag(id string) string {
+	return `W/"` + azurearm.ETag(id) + `"`
 }
 
-// buildLBJSON reconstructs the nested ARM load balancer body from driver state.
-func (h *Handler) buildLBJSON(ctx context.Context, rp *azurearm.ResourcePath,
-	lb *lbdriver.LBInfo,
-) (loadBalancerJSON, error) {
-	pools, err := h.poolsForLB(ctx, lb.Name)
-	if err != nil {
-		return loadBalancerJSON{}, err
-	}
-
-	listeners, err := h.lb.DescribeListeners(ctx, lb.ARN)
-	if err != nil {
-		return loadBalancerJSON{}, err
-	}
-
-	lbID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeLBs, lb.Name)
-
-	props := &loadBalancerProps{
-		ProvisioningState: provisioningStateSucceeded,
-		FrontendIPConfigurations: []frontendIPJSON{{
-			ID:   lbID + "/frontendIPConfigurations/default",
-			Name: "default",
-			Type: feResourceType,
-			Properties: &frontendIPProps{
-				ProvisioningState: provisioningStateSucceeded,
-			},
-		}},
-	}
-
-	// Backend pools, keyed by ARN so rules can reference them.
-	poolIDByARN := make(map[string]string, len(pools))
-
-	for name, tg := range pools {
-		poolID := lbID + "/backendAddressPools/" + name
-		poolIDByARN[tg.ARN] = poolID
-		props.BackendAddressPools = append(props.BackendAddressPools, backendPoolJSON{
-			ID:         poolID,
-			Name:       name,
-			Type:       poolResourceType,
-			Properties: &backendPoolProps{ProvisioningState: provisioningStateSucceeded},
-		})
-	}
-
-	for i := range listeners {
-		li := listeners[i]
-		ruleName := "rule-" + portString(li.Port)
-		ruleProps := &loadBalancingRuleProps{
-			Protocol:          li.Protocol,
-			FrontendPort:      int32(li.Port),
-			BackendPort:       int32(li.Port),
-			ProvisioningState: provisioningStateSucceeded,
-			FrontendIPConfiguration: &subResource{
-				ID: lbID + "/frontendIPConfigurations/default",
-			},
-		}
-
-		if poolID, ok := poolIDByARN[li.TargetGroupARN]; ok {
-			ruleProps.BackendAddressPool = &subResource{ID: poolID}
-		}
-
-		props.LoadBalancingRules = append(props.LoadBalancingRules, loadBalancingRuleJSON{
-			ID:         lbID + "/loadBalancingRules/" + ruleName,
-			Name:       ruleName,
-			Type:       ruleResourceType,
-			Properties: ruleProps,
-		})
-	}
-
-	return loadBalancerJSON{
-		ID:         lbID,
-		Name:       lb.Name,
-		Type:       lbResourceType,
-		Location:   defaultLBLocation,
-		SKU:        &lbSKU{Name: "Standard", Tier: "Regional"},
-		Tags:       stripInternalTags(lb.Tags),
-		Properties: props,
-	}, nil
-}
-
-// schemeFromBody infers the driver scheme from the request body. Azure load
-// balancers are internal unless a public frontend is present; we default to
-// internal, which is the common case for the Standard SKU.
+// schemeFromBody infers the cross-cloud scheme from the request body. An Azure
+// load balancer is internal unless a public frontend is present.
 func schemeFromBody(body *loadBalancerJSON) string {
 	if body.Properties != nil {
 		for _, fe := range body.Properties.FrontendIPConfigurations {
-			if fe.Properties != nil && fe.Properties.PrivateIPAddress == "" {
+			if fe.Properties != nil && fe.Properties.PublicIPAddress != nil {
 				return "internet-facing"
 			}
 		}
 	}
 
 	return "internal"
-}
-
-// protocolOrDefault normalizes the ARM transport protocol to the driver's
-// stored value, defaulting to TCP.
-func protocolOrDefault(p string) string {
-	if p == "" {
-		return "Tcp"
-	}
-
-	return p
-}
-
-// poolNameFromID extracts the trailing backend-pool name from an ARM
-// backendAddressPools sub-resource ID.
-func poolNameFromID(id string) string {
-	const marker = "/backendAddressPools/"
-
-	idx := strings.LastIndex(id, marker)
-	if idx < 0 {
-		return id
-	}
-
-	return id[idx+len(marker):]
 }
 
 // stripInternalTags removes cloudemu-internal bookkeeping tags before echoing
@@ -417,6 +440,38 @@ func stripInternalTags(in map[string]string) map[string]string {
 	return out
 }
 
-func portString(p int) string {
-	return strconv.Itoa(p)
+// refID returns the id of a sub-resource reference, or "" if nil.
+func refID(ref *subResource) string {
+	if ref == nil {
+		return ""
+	}
+
+	return ref.ID
+}
+
+// lastPathSegment returns the trailing segment of an ARM resource id.
+func lastPathSegment(id string) string {
+	id = strings.TrimRight(id, "/")
+	if idx := strings.LastIndexByte(id, '/'); idx >= 0 {
+		return id[idx+1:]
+	}
+
+	return id
+}
+
+// firstNonEmpty returns a if non-empty, otherwise b.
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+
+	return b
+}
+
+// i32 narrows a small, non-negative load-balancer config value (port, interval,
+// probe count, timeout) to the int32 the ARM wire types use.
+//
+//nolint:gosec // G115: these are small, non-negative port/interval/count/timeout inputs
+func i32(n int) int32 {
+	return int32(n)
 }

--- a/server/azure/loadbalancer/operations.go
+++ b/server/azure/loadbalancer/operations.go
@@ -338,6 +338,7 @@ func rulesJSON(lbID string, in []lbdriver.AzureLBRule) []loadBalancingRuleJSON {
 			BackendPort:          i32(rule.BackendPort),
 			IdleTimeoutInMinutes: i32(rule.IdleTimeoutMin),
 			LoadDistribution:     rule.LoadDistribution,
+			EnableFloatingIP:     &rule.EnableFloatingIP,
 			ProvisioningState:    provisioningStateSucceeded,
 		}
 
@@ -399,7 +400,7 @@ func (h *Handler) findGenericLB(ctx context.Context, name string) (*lbdriver.LBI
 // weakETag wraps a stable etag in the weak-validator form (W/"...") ARM uses
 // for load-balancer resources.
 func weakETag(id string) string {
-	return `W/"` + azurearm.ETag(id) + `"`
+	return azurearm.WeakETag(id)
 }
 
 // schemeFromBody infers the cross-cloud scheme from the request body. An Azure

--- a/server/azure/loadbalancer/types.go
+++ b/server/azure/loadbalancer/types.go
@@ -1,7 +1,7 @@
 package loadbalancer
 
 // Azure ARM JSON wire structures for Microsoft.Network/loadBalancers. Only the
-// subset of fields the driver can populate is modeled; the real armnetwork
+// subset of fields the handler models is declared; the real armnetwork
 // LoadBalancer type carries far more, but its JSON unmarshaler ignores unknown
 // members and treats absent members as nil.
 
@@ -9,15 +9,22 @@ const (
 	providerName = "Microsoft.Network"
 	typeLBs      = "loadBalancers"
 
-	lbResourceType   = "Microsoft.Network/loadBalancers"
-	poolResourceType = "Microsoft.Network/loadBalancers/backendAddressPools"
-	ruleResourceType = "Microsoft.Network/loadBalancers/loadBalancingRules"
-	feResourceType   = "Microsoft.Network/loadBalancers/frontendIPConfigurations"
+	lbResourceType    = "Microsoft.Network/loadBalancers"
+	poolResourceType  = "Microsoft.Network/loadBalancers/backendAddressPools"
+	ruleResourceType  = "Microsoft.Network/loadBalancers/loadBalancingRules"
+	feResourceType    = "Microsoft.Network/loadBalancers/frontendIPConfigurations"
+	probeResourceType = "Microsoft.Network/loadBalancers/probes"
 
 	defaultLBLocation = "eastus"
 
 	// provisioningStateSucceeded is the terminal state the SDK poller waits for.
 	provisioningStateSucceeded = "Succeeded"
+
+	// SKU defaults Azure applies when a load balancer omits its sku.
+	defaultSKUName = "Standard"
+	defaultSKUTier = "Regional"
+
+	protocolTCP = "Tcp"
 )
 
 // subResource is Azure's {"id": "..."} reference shape.
@@ -25,7 +32,7 @@ type subResource struct {
 	ID string `json:"id,omitempty"`
 }
 
-// --- backend address pools (→ driver target groups) ---
+// --- backend address pools (→ pool names) ---
 
 type backendPoolProps struct {
 	ProvisioningState string `json:"provisioningState,omitempty"`
@@ -35,24 +42,29 @@ type backendPoolJSON struct {
 	ID         string            `json:"id,omitempty"`
 	Name       string            `json:"name,omitempty"`
 	Type       string            `json:"type,omitempty"`
+	Etag       string            `json:"etag,omitempty"`
 	Properties *backendPoolProps `json:"properties,omitempty"`
 }
 
 // --- frontend IP configurations ---
 
 type frontendIPProps struct {
-	PrivateIPAddress  string `json:"privateIPAddress,omitempty"`
-	ProvisioningState string `json:"provisioningState,omitempty"`
+	PrivateIPAddress          string       `json:"privateIPAddress,omitempty"`
+	PrivateIPAllocationMethod string       `json:"privateIPAllocationMethod,omitempty"`
+	Subnet                    *subResource `json:"subnet,omitempty"`
+	PublicIPAddress           *subResource `json:"publicIPAddress,omitempty"`
+	ProvisioningState         string       `json:"provisioningState,omitempty"`
 }
 
 type frontendIPJSON struct {
 	ID         string           `json:"id,omitempty"`
 	Name       string           `json:"name,omitempty"`
 	Type       string           `json:"type,omitempty"`
+	Etag       string           `json:"etag,omitempty"`
 	Properties *frontendIPProps `json:"properties,omitempty"`
 }
 
-// --- load balancing rules (→ driver listeners) ---
+// --- load balancing rules ---
 
 type loadBalancingRuleProps struct {
 	Protocol                string       `json:"protocol,omitempty"`
@@ -60,6 +72,10 @@ type loadBalancingRuleProps struct {
 	BackendPort             int32        `json:"backendPort,omitempty"`
 	FrontendIPConfiguration *subResource `json:"frontendIPConfiguration,omitempty"`
 	BackendAddressPool      *subResource `json:"backendAddressPool,omitempty"`
+	Probe                   *subResource `json:"probe,omitempty"`
+	EnableFloatingIP        *bool        `json:"enableFloatingIP,omitempty"`
+	IdleTimeoutInMinutes    int32        `json:"idleTimeoutInMinutes,omitempty"`
+	LoadDistribution        string       `json:"loadDistribution,omitempty"`
 	ProvisioningState       string       `json:"provisioningState,omitempty"`
 }
 
@@ -67,7 +83,27 @@ type loadBalancingRuleJSON struct {
 	ID         string                  `json:"id,omitempty"`
 	Name       string                  `json:"name,omitempty"`
 	Type       string                  `json:"type,omitempty"`
+	Etag       string                  `json:"etag,omitempty"`
 	Properties *loadBalancingRuleProps `json:"properties,omitempty"`
+}
+
+// --- probes ---
+
+type probeProps struct {
+	Protocol          string `json:"protocol,omitempty"`
+	Port              int32  `json:"port,omitempty"`
+	RequestPath       string `json:"requestPath,omitempty"`
+	IntervalInSeconds int32  `json:"intervalInSeconds,omitempty"`
+	NumberOfProbes    int32  `json:"numberOfProbes,omitempty"`
+	ProvisioningState string `json:"provisioningState,omitempty"`
+}
+
+type probeJSON struct {
+	ID         string      `json:"id,omitempty"`
+	Name       string      `json:"name,omitempty"`
+	Type       string      `json:"type,omitempty"`
+	Etag       string      `json:"etag,omitempty"`
+	Properties *probeProps `json:"properties,omitempty"`
 }
 
 // --- load balancer ---
@@ -76,6 +112,7 @@ type loadBalancerProps struct {
 	BackendAddressPools      []backendPoolJSON       `json:"backendAddressPools,omitempty"`
 	FrontendIPConfigurations []frontendIPJSON        `json:"frontendIPConfigurations,omitempty"`
 	LoadBalancingRules       []loadBalancingRuleJSON `json:"loadBalancingRules,omitempty"`
+	Probes                   []probeJSON             `json:"probes,omitempty"`
 	ProvisioningState        string                  `json:"provisioningState,omitempty"`
 }
 

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -181,17 +181,9 @@ func (h *Handler) createVNet(w http.ResponseWriter, r *http.Request, rp azurearm
 		return
 	}
 
-	cidr := ""
-	if req.Properties.AddressSpace != nil && len(req.Properties.AddressSpace.AddressPrefixes) > 0 {
-		cidr = req.Properties.AddressSpace.AddressPrefixes[0]
-	}
+	prefixes := vnetPrefixes(&req)
 
-	cfg := netdriver.VPCConfig{
-		CIDRBlock: cidr,
-		Tags:      mergeTags(req.Tags, armNameTag, rp.ResourceName),
-	}
-
-	info, err := h.net.CreateVPC(r.Context(), cfg)
+	info, err := h.upsertVNet(r.Context(), rp.ResourceName, prefixes, req.Tags)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -202,9 +194,97 @@ func (h *Handler) createVNet(w http.ResponseWriter, r *http.Request, rp azurearm
 		loc = defaultLoc
 	}
 
-	body := toVNetResponse(info, rp, loc, req.Properties.AddressSpace, nil)
+	if meta, ok := h.azureMeta(); ok {
+		_ = meta.PutAzureVNetMetadata(r.Context(), info.ID,
+			netdriver.AzureVNetMetadata{Location: loc, AddressPrefixes: prefixes})
+	}
 
-	writeAcceptedAsync(w, r, rp.Subscription, "vnet-create-"+rp.ResourceName, body)
+	// Materialize any inline subnets so they become real, addressable children
+	// (Subnets.Get resolves them) rather than a body-only echo.
+	if err := h.materializeSubnets(r.Context(), info.ID, req.Properties.Subnets); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "vnet-create-"+rp.ResourceName, h.vnetResponse(r.Context(), info, rp))
+}
+
+// vnetPrefixes extracts the full address-prefix list from a vnet request.
+func vnetPrefixes(req *vnetRequest) []string {
+	if req.Properties.AddressSpace == nil {
+		return nil
+	}
+
+	return req.Properties.AddressSpace.AddressPrefixes
+}
+
+// upsertVNet reuses an existing virtual network of the same name (so a repeated
+// PUT updates in place rather than creating a duplicate) or creates a new one.
+func (h *Handler) upsertVNet(ctx context.Context, name string, prefixes []string,
+	tags map[string]string,
+) (*netdriver.VPCInfo, error) {
+	if existing, err := findVNetByName(ctx, h.net, name); err == nil {
+		if len(tags) > 0 {
+			_ = h.net.UpdateVPCTags(ctx, existing.ID, tags)
+
+			if refreshed, rerr := findVNetByName(ctx, h.net, name); rerr == nil {
+				existing = refreshed
+			}
+		}
+
+		return existing, nil
+	}
+
+	cidr := ""
+	if len(prefixes) > 0 {
+		cidr = prefixes[0]
+	}
+
+	return h.net.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: cidr,
+		Tags:      mergeTags(tags, armNameTag, name),
+	})
+}
+
+// materializeSubnets creates the inline subnets carried in a vnet PUT body,
+// skipping any that already exist (idempotent re-PUT).
+func (h *Handler) materializeSubnets(ctx context.Context, vpcID string, subs []subnetRequest) error {
+	if len(subs) == 0 {
+		return nil
+	}
+
+	existing, err := h.net.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	have := make(map[string]struct{})
+
+	for i := range existing {
+		if existing[i].VPCID == vpcID {
+			have[tagOr(existing[i].Tags, armSubnetTag, "")] = struct{}{}
+		}
+	}
+
+	for i := range subs {
+		if subs[i].Name == "" {
+			continue
+		}
+
+		if _, ok := have[subs[i].Name]; ok {
+			continue
+		}
+
+		if _, err := h.net.CreateSubnet(ctx, netdriver.SubnetConfig{
+			VPCID:     vpcID,
+			CIDRBlock: subs[i].Properties.AddressPrefix,
+			Tags:      mergeTags(nil, armSubnetTag, subs[i].Name),
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -215,12 +295,10 @@ func (h *Handler) getVNet(w http.ResponseWriter, r *http.Request, rp azurearm.Re
 		return
 	}
 
-	subs, _ := h.net.DescribeSubnets(r.Context(), nil)
-
-	azurearm.WriteJSON(w, http.StatusOK, toVNetResponseFromInfo(info, rp, subs))
+	azurearm.WriteJSON(w, http.StatusOK, h.vnetResponse(r.Context(), info, rp))
 }
 
-//nolint:gocritic // rp is a request-scoped value
+//nolint:gocritic,dupl // rp is request-scoped; mirrors listNSGs over a distinct resource type by design
 func (h *Handler) listVNets(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	infos, err := h.net.DescribeVPCs(r.Context(), nil)
 	if err != nil {
@@ -228,13 +306,12 @@ func (h *Handler) listVNets(w http.ResponseWriter, r *http.Request, rp azurearm.
 		return
 	}
 
-	subs, _ := h.net.DescribeSubnets(r.Context(), nil)
 	out := vnetListResponse{}
 
 	for i := range infos {
 		scope := rp
 		scope.ResourceName = tagOr(infos[i].Tags, armNameTag, infos[i].ID)
-		out.Value = append(out.Value, toVNetResponseFromInfo(&infos[i], scope, subs))
+		out.Value = append(out.Value, h.vnetResponse(r.Context(), &infos[i], scope))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, out)
@@ -248,12 +325,78 @@ func (h *Handler) deleteVNet(w http.ResponseWriter, r *http.Request, rp azurearm
 		return
 	}
 
+	// A virtual network with a subnet still bound to a network interface cannot
+	// be deleted; ARM answers 400 with this code, which armnetwork switches on.
+	if h.vnetSubnetInUse(r.Context(), rp.ResourceName) {
+		azurearm.WriteError(w, http.StatusBadRequest, "InUseSubnetCannotBeDeleted",
+			"virtual network "+rp.ResourceName+" has a subnet in use by a network interface")
+
+		return
+	}
+
+	// Cascade-delete the child subnets so they stop being globally addressable
+	// once their parent network is gone.
+	h.deleteChildSubnets(r.Context(), info.ID)
+
+	if meta, ok := h.azureMeta(); ok {
+		meta.DeleteAzureVNetMetadata(r.Context(), info.ID)
+	}
+
 	if err := h.net.DeleteVPC(r.Context(), info.ID); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
 	writeAcceptedAsync(w, r, rp.Subscription, "vnet-delete-"+rp.ResourceName, nil)
+}
+
+// deleteChildSubnets removes every subnet that belongs to the given vnet.
+func (h *Handler) deleteChildSubnets(ctx context.Context, vpcID string) {
+	subs, err := h.net.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return
+	}
+
+	for i := range subs {
+		if subs[i].VPCID == vpcID {
+			_ = h.net.DeleteSubnet(ctx, subs[i].ID)
+		}
+	}
+}
+
+// vnetSubnetInUse reports whether any network interface's ipConfiguration
+// references a subnet of the named virtual network.
+func (h *Handler) vnetSubnetInUse(ctx context.Context, vnetName string) bool {
+	svc, ok := h.net.(netdriver.AzureNetworkInterfaces)
+	if !ok {
+		return false
+	}
+
+	nics, err := svc.ListNetworkInterfaces(ctx, "")
+	if err != nil {
+		return false
+	}
+
+	for i := range nics {
+		for j := range nics[i].IPConfigs {
+			if subnetVNetName(nics[i].IPConfigs[j].SubnetID) == vnetName {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// subnetVNetName extracts the virtual-network name from an ARM subnet resource
+// id (.../virtualNetworks/{vnet}/subnets/{name}).
+func subnetVNetName(subnetID string) string {
+	sp, ok := azurearm.ParsePath(subnetID)
+	if !ok || sp.ResourceType != typeVNet {
+		return ""
+	}
+
+	return sp.ResourceName
 }
 
 // Subnet operations.
@@ -350,31 +493,7 @@ func (h *Handler) createNSG(w http.ResponseWriter, r *http.Request, rp azurearm.
 		return
 	}
 
-	// Find any VPC to anchor the SG; the driver requires a VPC ID. If no
-	// VPC exists we create a synthetic one.
-	vpcs, _ := h.net.DescribeVPCs(r.Context(), nil)
-
-	var anchor string
-
-	if len(vpcs) > 0 {
-		anchor = vpcs[0].ID
-	} else {
-		v, vErr := h.net.CreateVPC(r.Context(), netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
-		if vErr != nil {
-			azurearm.WriteCErr(w, vErr)
-			return
-		}
-
-		anchor = v.ID
-	}
-
-	cfg := netdriver.SecurityGroupConfig{
-		Name:  rp.ResourceName,
-		VPCID: anchor,
-		Tags:  mergeTags(req.Tags, armNSGTag, rp.ResourceName),
-	}
-
-	info, err := h.net.CreateSecurityGroup(r.Context(), cfg)
+	info, err := h.upsertNSG(r.Context(), rp.ResourceName, req.Tags)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -385,9 +504,46 @@ func (h *Handler) createNSG(w http.ResponseWriter, r *http.Request, rp azurearm.
 		loc = defaultLoc
 	}
 
-	body := toNSGResponse(info, rp, loc, req.Properties.SecurityRules)
+	if meta, ok := h.azureMeta(); ok {
+		_ = meta.PutAzureNSGMetadata(r.Context(), info.ID, netdriver.AzureNSGMetadata{
+			Location:      loc,
+			SecurityRules: toAzureNSGRules(req.Properties.SecurityRules),
+		})
+	}
 
-	writeAcceptedAsync(w, r, rp.Subscription, "nsg-create-"+rp.ResourceName, body)
+	writeAcceptedAsync(w, r, rp.Subscription, "nsg-create-"+rp.ResourceName, h.nsgResponse(r.Context(), info, rp))
+}
+
+// upsertNSG reuses an existing NSG of the same name (idempotent re-PUT) or
+// creates one, anchoring the driver security group to any VPC (creating a
+// synthetic one when none exists, as the driver requires a VPC id).
+func (h *Handler) upsertNSG(ctx context.Context, name string,
+	tags map[string]string,
+) (*netdriver.SecurityGroupInfo, error) {
+	if existing, err := findNSGByName(ctx, h.net, name); err == nil {
+		return existing, nil
+	}
+
+	vpcs, _ := h.net.DescribeVPCs(ctx, nil)
+
+	var anchor string
+
+	if len(vpcs) > 0 {
+		anchor = vpcs[0].ID
+	} else {
+		v, vErr := h.net.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		if vErr != nil {
+			return nil, vErr
+		}
+
+		anchor = v.ID
+	}
+
+	return h.net.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{
+		Name:  name,
+		VPCID: anchor,
+		Tags:  mergeTags(tags, armNSGTag, name),
+	})
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -398,10 +554,10 @@ func (h *Handler) getNSG(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toNSGResponse(info, rp, defaultLoc, nil))
+	azurearm.WriteJSON(w, http.StatusOK, h.nsgResponse(r.Context(), info, rp))
 }
 
-//nolint:gocritic // rp is a request-scoped value
+//nolint:gocritic,dupl // rp is request-scoped; mirrors listVNets over a distinct resource type by design
 func (h *Handler) listNSGs(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	infos, err := h.net.DescribeSecurityGroups(r.Context(), nil)
 	if err != nil {
@@ -414,7 +570,7 @@ func (h *Handler) listNSGs(w http.ResponseWriter, r *http.Request, rp azurearm.R
 	for i := range infos {
 		scope := rp
 		scope.ResourceName = tagOr(infos[i].Tags, armNSGTag, infos[i].ID)
-		out.Value = append(out.Value, toNSGResponse(&infos[i], scope, defaultLoc, nil))
+		out.Value = append(out.Value, h.nsgResponse(r.Context(), &infos[i], scope))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, out)
@@ -426,6 +582,10 @@ func (h *Handler) deleteNSG(w http.ResponseWriter, r *http.Request, rp azurearm.
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
+	}
+
+	if meta, ok := h.azureMeta(); ok {
+		meta.DeleteAzureNSGMetadata(r.Context(), info.ID)
 	}
 
 	if err := h.net.DeleteSecurityGroup(r.Context(), info.ID); err != nil {
@@ -590,28 +750,25 @@ func findPublicIPByName(ctx context.Context, n netdriver.Networking, name string
 // Response shaping helpers.
 
 //nolint:gocritic // rp is a request-scoped value
-func toVNetResponse(info *netdriver.VPCInfo, rp azurearm.ResourcePath, location string,
-	addr *addressSpace, subs []netdriver.SubnetInfo,
-) vnetResponse {
-	if location == "" {
-		location = defaultLoc
-	}
+func (h *Handler) vnetResponse(ctx context.Context, info *netdriver.VPCInfo, rp azurearm.ResourcePath) vnetResponse {
+	location, prefixes := h.vnetLocationPrefixes(ctx, info)
 
-	if addr == nil && info != nil {
-		addr = &addressSpace{AddressPrefixes: []string{info.CIDRBlock}}
-	}
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeVNet, rp.ResourceName)
 
 	out := vnetResponse{
-		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeVNet, rp.ResourceName),
+		ID:       id,
 		Name:     rp.ResourceName,
 		Type:     providerName + "/" + typeVNet,
 		Location: location,
+		Etag:     etagOf(id),
 		Tags:     stripInternal(info.Tags),
 		Properties: vnetResponseProps{
 			ProvisioningState: "Succeeded",
-			AddressSpace:      addr,
+			AddressSpace:      &addressSpace{AddressPrefixes: prefixes},
 		},
 	}
+
+	subs, _ := h.net.DescribeSubnets(ctx, nil)
 
 	for i := range subs {
 		if subs[i].VPCID == info.ID {
@@ -626,21 +783,46 @@ func toVNetResponse(info *netdriver.VPCInfo, rp azurearm.ResourcePath, location 
 	return out
 }
 
-//nolint:gocritic // rp is a request-scoped value
-func toVNetResponseFromInfo(info *netdriver.VPCInfo, rp azurearm.ResourcePath, subs []netdriver.SubnetInfo) vnetResponse {
-	return toVNetResponse(info, rp, defaultLoc, nil, subs)
+// vnetLocationPrefixes returns the region and full address-prefix list for a
+// vnet, reading the Azure metadata store when available and falling back to the
+// cross-cloud CIDR.
+func (h *Handler) vnetLocationPrefixes(ctx context.Context, info *netdriver.VPCInfo) (location string, prefixes []string) {
+	location = defaultLoc
+	prefixes = []string{info.CIDRBlock}
+
+	meta, ok := h.azureMeta()
+	if !ok {
+		return location, prefixes
+	}
+
+	md, found := meta.GetAzureVNetMetadata(ctx, info.ID)
+	if !found {
+		return location, prefixes
+	}
+
+	if md.Location != "" {
+		location = md.Location
+	}
+
+	if len(md.AddressPrefixes) > 0 {
+		prefixes = md.AddressPrefixes
+	}
+
+	return location, prefixes
 }
 
 //nolint:gocritic // rp is a request-scoped value
 func toSubnetResponse(info *netdriver.SubnetInfo, rp azurearm.ResourcePath) subnetResponse {
 	name := tagOr(info.Tags, armSubnetTag, rp.SubResourceName)
+	id := "/subscriptions/" + rp.Subscription +
+		"/resourceGroups/" + rp.ResourceGroup +
+		"/providers/" + providerName + "/" + typeVNet +
+		"/" + rp.ResourceName + "/subnets/" + name
 
 	return subnetResponse{
-		ID: "/subscriptions/" + rp.Subscription +
-			"/resourceGroups/" + rp.ResourceGroup +
-			"/providers/" + providerName + "/" + typeVNet +
-			"/" + rp.ResourceName + "/subnets/" + name,
+		ID:   id,
 		Name: name,
+		Etag: etagOf(id),
 		Properties: subnetResponseProps{
 			ProvisioningState: "Succeeded",
 			AddressPrefix:     info.CIDRBlock,
@@ -649,18 +831,34 @@ func toSubnetResponse(info *netdriver.SubnetInfo, rp azurearm.ResourcePath) subn
 }
 
 //nolint:gocritic // rp is a request-scoped value
-func toNSGResponse(info *netdriver.SecurityGroupInfo, rp azurearm.ResourcePath, location string,
-	rules []securityRule,
-) nsgResponse {
+func (h *Handler) nsgResponse(ctx context.Context, info *netdriver.SecurityGroupInfo, rp azurearm.ResourcePath) nsgResponse {
+	location := defaultLoc
+
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeNSG, rp.ResourceName)
+
+	var rules []securityRule
+
+	if meta, ok := h.azureMeta(); ok {
+		if md, found := meta.GetAzureNSGMetadata(ctx, info.ID); found {
+			if md.Location != "" {
+				location = md.Location
+			}
+
+			rules = fromAzureNSGRules(id, md.SecurityRules)
+		}
+	}
+
 	return nsgResponse{
-		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeNSG, rp.ResourceName),
+		ID:       id,
 		Name:     rp.ResourceName,
 		Type:     providerName + "/" + typeNSG,
 		Location: location,
+		Etag:     etagOf(id),
 		Tags:     stripInternal(info.Tags),
 		Properties: nsgResponseProps{
-			ProvisioningState: "Succeeded",
-			SecurityRules:     rules,
+			ProvisioningState:    "Succeeded",
+			SecurityRules:        rules,
+			DefaultSecurityRules: defaultSecurityRules(id),
 		},
 	}
 }

--- a/server/azure/vnet/network_e2e_test.go
+++ b/server/azure/vnet/network_e2e_test.go
@@ -1,0 +1,306 @@
+package vnet_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func newVNetServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Network: cloudP.VNet})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func pollDone[T any](t *testing.T, p *runtime.Poller[T]) T {
+	t.Helper()
+
+	res, err := p.PollUntilDone(context.Background(), &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	return res
+}
+
+// Findings #2 (idempotent PUT), #13 (all address prefixes), #14 (location),
+// #19 (etag).
+func TestSDKVNetIdempotentAddressSpaceLocation(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	client, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := armnetwork.VirtualNetwork{
+		Location: to.Ptr("westus2"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{
+				AddressPrefixes: []*string{to.Ptr("10.0.0.0/16"), to.Ptr("10.1.0.0/16")},
+			},
+		},
+	}
+
+	for i := 0; i < 2; i++ {
+		p, cerr := client.BeginCreateOrUpdate(ctx, "rg-1", "vnet-idem", body, nil)
+		if cerr != nil {
+			t.Fatalf("create %d: %v", i, cerr)
+		}
+
+		pollDone(t, p)
+	}
+
+	var count int
+
+	pager := client.NewListPager("rg-1", nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("list: %v", perr)
+		}
+
+		for _, v := range page.Value {
+			if v.Name != nil && *v.Name == "vnet-idem" {
+				count++
+			}
+		}
+	}
+
+	if count != 1 {
+		t.Fatalf("idempotent PUT created %d vnet-idem entries, want 1", count)
+	}
+
+	got, err := client.Get(ctx, "rg-1", "vnet-idem", nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.Location == nil || *got.Location != "westus2" {
+		t.Fatalf("location = %v, want westus2", got.Location)
+	}
+
+	if got.Properties == nil || got.Properties.AddressSpace == nil ||
+		len(got.Properties.AddressSpace.AddressPrefixes) != 2 {
+		t.Fatalf("addressPrefixes = %+v, want 2 entries", got.Properties)
+	}
+
+	if got.Etag == nil || *got.Etag == "" {
+		t.Fatalf("etag empty, want non-empty")
+	}
+}
+
+// Findings #17 (inline subnets materialized) and #12 (subnet cascade on delete).
+func TestSDKVNetInlineSubnetsCascade(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	vnets, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subnets, err := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := vnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-sub", armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+			Subnets: []*armnetwork.Subnet{{
+				Name:       to.Ptr("inline-sub"),
+				Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create vnet: %v", err)
+	}
+
+	pollDone(t, p)
+
+	sub, err := subnets.Get(ctx, "rg-1", "vnet-sub", "inline-sub", nil)
+	if err != nil {
+		t.Fatalf("inline subnet Get: %v, want materialized child", err)
+	}
+
+	if sub.ID == nil || *sub.ID == "" {
+		t.Fatalf("inline subnet id empty")
+	}
+
+	delP, err := vnets.BeginDelete(ctx, "rg-1", "vnet-sub", nil)
+	if err != nil {
+		t.Fatalf("delete vnet: %v", err)
+	}
+
+	pollDone(t, delP)
+
+	_, err = subnets.Get(ctx, "rg-1", "vnet-sub", "inline-sub", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("subnet Get after vnet delete: got %v, want 404 (cascaded)", err)
+	}
+}
+
+// Finding #12: deleting a vnet whose subnet is bound to a NIC is refused.
+func TestSDKVNetDeleteBlockedWhenSubnetInUse(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	vnets, _ := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, clientOpts(ts))
+	nics, _ := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, clientOpts(ts))
+
+	subnetID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/" +
+		"virtualNetworks/vnet-inuse/subnets/default"
+
+	p, err := vnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-inuse", armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+			Subnets: []*armnetwork.Subnet{{
+				Name:       to.Ptr("default"),
+				Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create vnet: %v", err)
+	}
+
+	pollDone(t, p)
+
+	nicP, err := nics.BeginCreateOrUpdate(ctx, "rg-1", "nic1", armnetwork.Interface{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig1"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					Subnet: &armnetwork.Subnet{ID: to.Ptr(subnetID)},
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create nic: %v", err)
+	}
+
+	pollDone(t, nicP)
+
+	_, err = vnets.BeginDelete(ctx, "rg-1", "vnet-inuse", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 400 {
+		t.Fatalf("delete vnet with in-use subnet: got %v, want 400", err)
+	}
+}
+
+// Findings #3 (idempotent NSG PUT), #4 (custom rules persist), #5 (default
+// rules), #14 (location), #19 (etag).
+func TestSDKNSGRulesDefaultsIdempotent(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	client, err := armnetwork.NewSecurityGroupsClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := armnetwork.SecurityGroup{
+		Location: to.Ptr("westus2"),
+		Properties: &armnetwork.SecurityGroupPropertiesFormat{
+			SecurityRules: []*armnetwork.SecurityRule{{
+				Name: to.Ptr("Allow-SSH"),
+				Properties: &armnetwork.SecurityRulePropertiesFormat{
+					Priority:                 to.Ptr(int32(100)),
+					Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+					Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+					Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+					SourceAddressPrefix:      to.Ptr("*"),
+					DestinationAddressPrefix: to.Ptr("*"),
+					SourcePortRange:          to.Ptr("*"),
+					DestinationPortRange:     to.Ptr("22"),
+				},
+			}},
+		},
+	}
+
+	for i := 0; i < 2; i++ {
+		p, cerr := client.BeginCreateOrUpdate(ctx, "rg-1", "nsg-rules", body, nil)
+		if cerr != nil {
+			t.Fatalf("create %d: %v", i, cerr)
+		}
+
+		pollDone(t, p)
+	}
+
+	var count int
+
+	pager := client.NewListPager("rg-1", nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("list: %v", perr)
+		}
+
+		for _, g := range page.Value {
+			if g.Name != nil && *g.Name == "nsg-rules" {
+				count++
+			}
+		}
+	}
+
+	if count != 1 {
+		t.Fatalf("idempotent NSG PUT created %d entries, want 1", count)
+	}
+
+	got, err := client.Get(ctx, "rg-1", "nsg-rules", nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.Location == nil || *got.Location != "westus2" {
+		t.Fatalf("location = %v, want westus2", got.Location)
+	}
+
+	if got.Etag == nil || *got.Etag == "" {
+		t.Fatalf("etag empty, want non-empty")
+	}
+
+	if got.Properties == nil || len(got.Properties.SecurityRules) != 1 {
+		t.Fatalf("securityRules = %+v, want 1 persisted custom rule", got.Properties)
+	}
+
+	rule := got.Properties.SecurityRules[0]
+	if rule.Name == nil || *rule.Name != "Allow-SSH" {
+		t.Fatalf("rule name = %v, want Allow-SSH", rule.Name)
+	}
+
+	if rule.Properties == nil || rule.Properties.DestinationPortRange == nil ||
+		*rule.Properties.DestinationPortRange != "22" || rule.Properties.Priority == nil ||
+		*rule.Properties.Priority != 100 {
+		t.Fatalf("rule properties = %+v, want dstPort 22 / priority 100", rule.Properties)
+	}
+
+	if len(got.Properties.DefaultSecurityRules) != 6 {
+		t.Fatalf("defaultSecurityRules = %d, want 6 built-ins", len(got.Properties.DefaultSecurityRules))
+	}
+}

--- a/server/azure/vnet/network_e2e_test.go
+++ b/server/azure/vnet/network_e2e_test.go
@@ -101,9 +101,15 @@ func TestSDKVNetIdempotentAddressSpaceLocation(t *testing.T) {
 		t.Fatalf("addressPrefixes = %+v, want 2 entries", got.Properties)
 	}
 
-	if got.Etag == nil || *got.Etag == "" {
-		t.Fatalf("etag empty, want non-empty")
+	if got.Etag == nil || !isWeakETag(*got.Etag) {
+		t.Fatalf("vnet etag = %v, want weak-validator form W/\"...\"", got.Etag)
 	}
+}
+
+// isWeakETag reports whether s is in the weak-validator form W/"..." that the
+// real ARM API emits for Microsoft.Network resources (VNets/NSGs/subnets).
+func isWeakETag(s string) bool {
+	return len(s) >= 4 && s[:3] == `W/"` && s[len(s)-1] == '"'
 }
 
 // Findings #17 (inline subnets materialized) and #12 (subnet cascade on delete).
@@ -281,8 +287,8 @@ func TestSDKNSGRulesDefaultsIdempotent(t *testing.T) {
 		t.Fatalf("location = %v, want westus2", got.Location)
 	}
 
-	if got.Etag == nil || *got.Etag == "" {
-		t.Fatalf("etag empty, want non-empty")
+	if got.Etag == nil || !isWeakETag(*got.Etag) {
+		t.Fatalf("nsg etag = %v, want weak-validator form W/\"...\"", got.Etag)
 	}
 
 	if got.Properties == nil || len(got.Properties.SecurityRules) != 1 {

--- a/server/azure/vnet/security_rule.go
+++ b/server/azure/vnet/security_rule.go
@@ -135,7 +135,8 @@ func (h *Handler) azureMeta() (netdriver.AzureNetworkMetadata, bool) {
 	return m, ok
 }
 
-// etagOf returns a stable etag for an ARM resource id.
+// etagOf returns a stable etag for a Microsoft.Network ARM resource id, in the
+// weak-validator form (W/"...") the real ARM API emits for VNets/NSGs/subnets.
 func etagOf(id string) string {
-	return azurearm.ETag(id)
+	return azurearm.WeakETag(id)
 }

--- a/server/azure/vnet/security_rule.go
+++ b/server/azure/vnet/security_rule.go
@@ -1,0 +1,141 @@
+package vnet
+
+import (
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// Azure port/prefix wildcard and the service tags the default rules reference.
+const (
+	anyPrefix         = "*"
+	anyPortRange      = "*"
+	protoAny          = "*"
+	accessAllow       = "Allow"
+	accessDeny        = "Deny"
+	directionInbound  = "Inbound"
+	directionOutbound = "Outbound"
+	tagVirtualNetwork = "VirtualNetwork"
+	tagAzureLB        = "AzureLoadBalancer"
+	tagInternet       = "Internet"
+
+	provisioningSucceeded = "Succeeded"
+)
+
+// defaultRuleSpec is the static shape of one built-in default security rule.
+type defaultRuleSpec struct {
+	name      string
+	priority  int
+	direction string
+	access    string
+	src       string
+	dst       string
+}
+
+// azureDefaultRules are the six rules Azure stamps on every network security
+// group. They cannot be created or removed by callers; a Get always echoes
+// them under defaultSecurityRules. Priorities and service tags match the
+// Microsoft.Network defaults exactly.
+//
+//nolint:gochecknoglobals // fixed platform constant, read-only lookup table
+var azureDefaultRules = [...]defaultRuleSpec{
+	{"AllowVnetInBound", 65000, directionInbound, accessAllow, tagVirtualNetwork, tagVirtualNetwork},
+	{"AllowAzureLoadBalancerInBound", 65001, directionInbound, accessAllow, tagAzureLB, anyPrefix},
+	{"DenyAllInBound", 65500, directionInbound, accessDeny, anyPrefix, anyPrefix},
+	{"AllowVnetOutBound", 65000, directionOutbound, accessAllow, tagVirtualNetwork, tagVirtualNetwork},
+	{"AllowInternetOutBound", 65001, directionOutbound, accessAllow, anyPrefix, tagInternet},
+	{"DenyAllOutBound", 65500, directionOutbound, accessDeny, anyPrefix, anyPrefix},
+}
+
+// defaultSecurityRules builds the six built-in default rules for the NSG whose
+// ARM id is nsgID.
+func defaultSecurityRules(nsgID string) []securityRule {
+	out := make([]securityRule, 0, len(azureDefaultRules))
+
+	for i := range azureDefaultRules {
+		spec := azureDefaultRules[i]
+		out = append(out, securityRule{
+			Name: spec.name,
+			ID:   nsgID + "/defaultSecurityRules/" + spec.name,
+			Properties: securityRuleProps{
+				Description:              "",
+				Protocol:                 protoAny,
+				SourceAddressPrefix:      spec.src,
+				DestinationAddressPrefix: spec.dst,
+				SourcePortRange:          anyPortRange,
+				DestinationPortRange:     anyPortRange,
+				Access:                   spec.access,
+				Priority:                 spec.priority,
+				Direction:                spec.direction,
+				ProvisioningState:        provisioningSucceeded,
+			},
+		})
+	}
+
+	return out
+}
+
+// toAzureNSGRules maps submitted wire security rules to the driver's stored
+// representation. The rule name is preserved; empty ports/prefixes are kept
+// verbatim so a Get round-trips exactly what the caller sent.
+func toAzureNSGRules(in []securityRule) []netdriver.AzureNSGRule {
+	out := make([]netdriver.AzureNSGRule, 0, len(in))
+
+	for i := range in {
+		p := in[i].Properties
+		out = append(out, netdriver.AzureNSGRule{
+			Name:                     in[i].Name,
+			Description:              p.Description,
+			Protocol:                 p.Protocol,
+			SourceAddressPrefix:      p.SourceAddressPrefix,
+			DestinationAddressPrefix: p.DestinationAddressPrefix,
+			SourcePortRange:          p.SourcePortRange,
+			DestinationPortRange:     p.DestinationPortRange,
+			Access:                   p.Access,
+			Direction:                p.Direction,
+			Priority:                 p.Priority,
+		})
+	}
+
+	return out
+}
+
+// fromAzureNSGRules maps stored driver rules back to their wire shape, stamping
+// each rule's ARM id and a terminal provisioning state.
+func fromAzureNSGRules(nsgID string, in []netdriver.AzureNSGRule) []securityRule {
+	out := make([]securityRule, 0, len(in))
+
+	for i := range in {
+		r := in[i]
+		out = append(out, securityRule{
+			Name: r.Name,
+			ID:   nsgID + "/securityRules/" + r.Name,
+			Properties: securityRuleProps{
+				Description:              r.Description,
+				Protocol:                 r.Protocol,
+				SourceAddressPrefix:      r.SourceAddressPrefix,
+				DestinationAddressPrefix: r.DestinationAddressPrefix,
+				SourcePortRange:          r.SourcePortRange,
+				DestinationPortRange:     r.DestinationPortRange,
+				Access:                   r.Access,
+				Priority:                 r.Priority,
+				Direction:                r.Direction,
+				ProvisioningState:        provisioningSucceeded,
+			},
+		})
+	}
+
+	return out
+}
+
+// azureMeta returns the Azure metadata surface if the networking driver
+// implements it (the Azure provider does; AWS/GCP do not).
+func (h *Handler) azureMeta() (netdriver.AzureNetworkMetadata, bool) {
+	m, ok := h.net.(netdriver.AzureNetworkMetadata)
+
+	return m, ok
+}
+
+// etagOf returns a stable etag for an ARM resource id.
+func etagOf(id string) string {
+	return azurearm.ETag(id)
+}

--- a/server/azure/vnet/types.go
+++ b/server/azure/vnet/types.go
@@ -22,6 +22,7 @@ type vnetResponse struct {
 	Name       string            `json:"name"`
 	Type       string            `json:"type"`
 	Location   string            `json:"location"`
+	Etag       string            `json:"etag,omitempty"`
 	Tags       map[string]string `json:"tags,omitempty"`
 	Properties vnetResponseProps `json:"properties"`
 }
@@ -48,6 +49,7 @@ type subnetRequestProps struct {
 type subnetResponse struct {
 	ID         string              `json:"id"`
 	Name       string              `json:"name"`
+	Etag       string              `json:"etag,omitempty"`
 	Properties subnetResponseProps `json:"properties"`
 }
 
@@ -86,6 +88,7 @@ type securityRuleProps struct {
 	Access                   string `json:"access,omitempty"`
 	Priority                 int    `json:"priority,omitempty"`
 	Direction                string `json:"direction,omitempty"`
+	ProvisioningState        string `json:"provisioningState,omitempty"`
 }
 
 type nsgResponse struct {
@@ -93,13 +96,15 @@ type nsgResponse struct {
 	Name       string            `json:"name"`
 	Type       string            `json:"type"`
 	Location   string            `json:"location"`
+	Etag       string            `json:"etag,omitempty"`
 	Tags       map[string]string `json:"tags,omitempty"`
 	Properties nsgResponseProps  `json:"properties"`
 }
 
 type nsgResponseProps struct {
-	ProvisioningState string         `json:"provisioningState"`
-	SecurityRules     []securityRule `json:"securityRules,omitempty"`
+	ProvisioningState    string         `json:"provisioningState"`
+	SecurityRules        []securityRule `json:"securityRules"`
+	DefaultSecurityRules []securityRule `json:"defaultSecurityRules,omitempty"`
 }
 
 type nsgListResponse struct {

--- a/server/wire/azurearm/azurearm.go
+++ b/server/wire/azurearm/azurearm.go
@@ -204,3 +204,10 @@ func ETag(parts ...string) string {
 
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", h[0:4], h[4:6], h[6:8], h[8:10], h[10:16])
 }
+
+// WeakETag wraps a deterministic ETag in the weak-validator form (W/"...") that
+// the real ARM API emits for Microsoft.Network resources (VNets, NSGs, subnets,
+// load balancers and their child rules/probes/pools).
+func WeakETag(parts ...string) string {
+	return `W/"` + ETag(parts...) + `"`
+}

--- a/server/wire/azurearm/azurearm.go
+++ b/server/wire/azurearm/azurearm.go
@@ -12,7 +12,9 @@
 package azurearm
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -190,4 +192,15 @@ func BuildResourceID(subscription, resourceGroup, provider, resourceType, name s
 		"/providers/" + provider +
 		"/" + resourceType +
 		"/" + name
+}
+
+// ETag returns a deterministic GUID-shaped etag derived from parts, so a
+// resource's etag is stable across reads yet distinct per resource. Azure
+// etags are opaque tokens SDKs only compare for equality (If-Match /
+// If-None-Match concurrency), so a stable synthetic value round-trips
+// correctly without a real version counter.
+func ETag(parts ...string) string {
+	h := sha256.Sum256([]byte(strings.Join(parts, "/")))
+
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", h[0:4], h[4:6], h[6:8], h[8:10], h[10:16])
 }

--- a/services/loadbalancer/driver/azure_load_balancer.go
+++ b/services/loadbalancer/driver/azure_load_balancer.go
@@ -1,0 +1,75 @@
+package driver
+
+import "context"
+
+// The Azure Load Balancer (Microsoft.Network/loadBalancers) is a full-replace
+// nested resource whose frontend IP configurations, backend pools, load-
+// balancing rules and health probes carry per-child names, ports and cross-
+// references that the AWS-shaped LoadBalancer / TargetGroup / Listener model
+// cannot represent. Rather than distort the cross-cloud interface, the Azure
+// provider stores the ARM load balancer natively and exposes it through
+// AzureLoadBalancers, an OPTIONAL capability discovered by type assertion (the
+// same pattern as AzureNetworkInterfaces / AzureNetworkMetadata). AWS and GCP
+// do not implement it.
+
+// AzureLBFrontend is one frontendIPConfiguration on an Azure load balancer.
+type AzureLBFrontend struct {
+	Name             string
+	PrivateIPAddress string
+	AllocationMethod string // "Static" or "Dynamic"
+	SubnetID         string
+	PublicIPID       string
+}
+
+// AzureLBProbe is one health probe on an Azure load balancer.
+type AzureLBProbe struct {
+	Name              string
+	Protocol          string // "Http", "Https", "Tcp"
+	Port              int
+	RequestPath       string
+	IntervalInSeconds int
+	NumberOfProbes    int
+}
+
+// AzureLBRule is one loadBalancingRule, keeping its own name and independent
+// frontend/backend ports plus references to the frontend, backend pool and
+// probe it binds (stored by child name, resolved to ids on read).
+type AzureLBRule struct {
+	Name             string
+	Protocol         string // "Tcp" or "Udp"
+	FrontendPort     int
+	BackendPort      int
+	FrontendName     string
+	BackendPoolName  string
+	ProbeName        string
+	EnableFloatingIP bool
+	IdleTimeoutMin   int
+	LoadDistribution string
+}
+
+// AzureLoadBalancer is the natively-stored ARM load balancer.
+type AzureLoadBalancer struct {
+	Name              string
+	ResourceGroup     string
+	Location          string
+	SKUName           string // "Basic", "Standard", "Gateway"
+	SKUTier           string // "Regional", "Global"
+	Frontends         []AzureLBFrontend
+	BackendPools      []string // pool names
+	Rules             []AzureLBRule
+	Probes            []AzureLBProbe
+	Tags              map[string]string
+	ProvisioningState string
+	ETag              string
+}
+
+// AzureLoadBalancers is an OPTIONAL, type-asserted capability. The Azure
+// provider stores ARM load balancers natively, keyed by (resourceGroup, name).
+// CreateOrUpdate is a full replace: children absent from the payload are
+// removed. Nil resource group on List means subscription-wide.
+type AzureLoadBalancers interface {
+	CreateOrUpdateAzureLoadBalancer(ctx context.Context, rg, name string, lb AzureLoadBalancer) (*AzureLoadBalancer, error)
+	GetAzureLoadBalancer(ctx context.Context, rg, name string) (*AzureLoadBalancer, error)
+	DeleteAzureLoadBalancer(ctx context.Context, rg, name string) error
+	ListAzureLoadBalancers(ctx context.Context, rg string) ([]AzureLoadBalancer, error)
+}

--- a/services/networking/driver/azure_network_metadata.go
+++ b/services/networking/driver/azure_network_metadata.go
@@ -1,0 +1,60 @@
+package driver
+
+import "context"
+
+// Azure virtual networks and network security groups carry ARM-specific fields
+// the cross-cloud VPC / SecurityGroup model cannot represent: a region, the
+// full multi-entry address-prefix list, and security rules with an Azure
+// priority / access / direction / service-tag shape. Rather than widen the
+// AWS-shaped structs (or force AWS/GCP to carry fields they never populate),
+// the Azure provider stores these alongside the cross-cloud resource and
+// exposes them through AzureNetworkMetadata, an OPTIONAL capability discovered
+// by type assertion — the same pattern as AzureNetworkInterfaces.
+
+// AzureVNetMetadata holds the Azure-only virtual-network fields (region and the
+// full address-prefix list). The cross-cloud VPCInfo keeps a single CIDR; this
+// records every prefix and the creation region so a Get round-trips faithfully.
+type AzureVNetMetadata struct {
+	Location        string
+	AddressPrefixes []string
+}
+
+// AzureNSGRule is one Azure network-security-group security rule, with the
+// priority / access / direction / service-tag fields the cross-cloud
+// SecurityRule model omits. Ports and address prefixes are kept verbatim as the
+// ARM strings ("*", "VirtualNetwork", "10.0.0.0/24", "80", "0-65535").
+type AzureNSGRule struct {
+	Name                     string
+	Description              string
+	Protocol                 string
+	SourceAddressPrefix      string
+	DestinationAddressPrefix string
+	SourcePortRange          string
+	DestinationPortRange     string
+	Access                   string
+	Direction                string
+	Priority                 int
+}
+
+// AzureNSGMetadata holds the Azure-only network-security-group fields (region
+// and the caller's custom security rules). The built-in default rules are
+// synthesized on read and are not stored here.
+type AzureNSGMetadata struct {
+	Location      string
+	SecurityRules []AzureNSGRule
+}
+
+// AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
+// provider stores the ARM-specific virtual-network and network-security-group
+// fields the cross-cloud Networking interface cannot represent, keyed by the
+// driver resource id (the VPC / security-group id). AWS and GCP do not
+// implement it.
+type AzureNetworkMetadata interface {
+	PutAzureVNetMetadata(ctx context.Context, id string, meta AzureVNetMetadata) error
+	GetAzureVNetMetadata(ctx context.Context, id string) (AzureVNetMetadata, bool)
+	DeleteAzureVNetMetadata(ctx context.Context, id string)
+
+	PutAzureNSGMetadata(ctx context.Context, id string, meta AzureNSGMetadata) error
+	GetAzureNSGMetadata(ctx context.Context, id string) (AzureNSGMetadata, bool)
+	DeleteAzureNSGMetadata(ctx context.Context, id string)
+}


### PR DESCRIPTION
Real-user end-to-end audit fixes for Azure vnet / load balancer / DNS, verified with real azure-sdk-for-go clients over an httptest server.

## VNet / NSG
- **#2 / #3** `virtualNetworks` and `networkSecurityGroups` PUT is now idempotent — a repeated CreateOrUpdate updates in place instead of creating a duplicate.
- **#4** custom NSG `securityRules` persist and round-trip on Get (name, priority, access, direction, ports, protocol).
- **#5** every NSG returns the 6 built-in `defaultSecurityRules` (AllowVnetInBound, AllowAzureLoadBalancerInBound, DenyAllInBound, AllowVnetOutBound, AllowInternetOutBound, DenyAllOutBound) with the exact Azure priorities/service tags.
- **#13** all `addressSpace.addressPrefixes` are returned (a two-prefix vnet reads back both).
- **#14** the creation `location` is preserved (vnet/nsg).
- **#17** inline subnets in the vnet PUT body are materialized as real, addressable children.
- **#12** vnet Delete cascades child subnets (subnet Get → 404 afterwards) and is refused (400) while a subnet is bound to a network interface.
- **#19** stable `etag` on vnet/subnet/nsg.

## DNS
- **#6** public zones report 4 authoritative `nameServers` (ns1-NN.azure-dns.com/.net/.org/.info).
- **#7** apex SOA + NS record sets are auto-provisioned on zone creation, so `numberOfRecordSets` starts at 2 and ListByDnsZone is non-empty.
- **#8** `properties.fqdn` is populated (`www.example.com.`, apex → `example.com.`).
- **#19** stable `etag` on zone/recordSet.

## Load Balancer
- **#9** PUT is a full replace — pools/rules/frontends/probes omitted from the body are removed (no stale-child accumulation / Terraform perpetual diffs).
- **#10** the submitted rule name is preserved and frontend/backend ports stay independent (`http-rule` 80/8080 round-trips).
- **#11** each frontend's name/private IP/subnet is preserved and rules reference the named frontend.
- **#15** a rule protocol change (Tcp→Udp) is applied.
- **#16** the submitted SKU (Basic/Standard/Gateway) is echoed.
- **#18** probes are first-class children referenced by `rule.properties.probe.id`.
- **#19** weak `etag` on the load balancer and its children.

## Architecture
The ARM-only fields the cross-cloud driver models cannot represent are stored via new type-asserted OPTIONAL capabilities (mirroring the existing `AzureNetworkInterfaces` pattern), keeping AWS/GCP untouched:
- `AzureNetworkMetadata` (networking driver) — vnet region/prefix list, NSG rules.
- `AzureLoadBalancers` (loadbalancer driver) — the full-replace nested ARM load balancer; a minimal cross-cloud LB record is kept in sync so resource discovery still enumerates it.

Capability docs regenerated (`go run ./internal/coveragegen`). Gates green: build, `go test`, and golangci-lint clean on the changed packages.

Note: NIC CreateOrUpdate (the original finding #1) was already implemented on development by #513, so no change was needed there.