### PR TITLE
fix(azure-tablestorage): entity-group $batch transactions, table/entity lifecycle, queue message ops

### DIFF
--- a/docs/coverage/README.md
+++ b/docs/coverage/README.md
@@ -56,7 +56,7 @@ capability the code does not implement. Machine-readable: [`coverage.json`](./co
 | `sesv2` | [SESV2](./aws/sesv2.md) | — | — | — | 113 |
 | `sfn` | [SFN](./aws/sfn.md) | — | — | — | 37 |
 | `storage` | [S3](./aws/s3.md) | [BlobStorage](./azure/blobstorage.md) | [GCS](./gcp/gcs.md) | — | 35 |
-| `tablestorage` | — | [TableStorage](./azure/tablestorage.md) | — | — | 8 |
+| `tablestorage` | — | [TableStorage](./azure/tablestorage.md) | — | — | 9 |
 | `vertexai` | — | — | [VertexAI](./gcp/vertexai.md) | — | 125 |
 | `vpclattice` | [VPCLattice](./aws/vpclattice.md) | — | — | — | 73 |
 | `wafv2` | [WAFv2](./aws/wafv2.md) | — | — | — | 39 |

--- a/docs/coverage/aws/sqs.md
+++ b/docs/coverage/aws/sqs.md
@@ -32,6 +32,7 @@ AzureQueueStorage is the Azure-specific Queue Storage data-plane surface,
 
 | Operation | Description |
 | --- | --- |
+| `DequeueMessages` | DequeueMessages retrieves up to maxMessages visible messages, hiding them |
 | `GetQueueMetadata` | GetQueueMetadata reports the approximate message count and user metadata. |
 | `PeekMessages` | PeekMessages returns up to maxMessages visible messages without altering |
 | `SetQueueMetadata` | SetQueueMetadata replaces the queue's user metadata. |

--- a/docs/coverage/aws/sqs.md
+++ b/docs/coverage/aws/sqs.md
@@ -22,6 +22,21 @@ AWS's `messagequeue` service · portable interface `driver.MessageQueue` · [AWS
 | `SendMessageBatch` | Batch operations |
 | `SetQueueAttributes` |  |
 
+## Optional capabilities
+
+Discovered by type assertion; only some providers implement these.
+
+### AzureQueueStorage
+
+AzureQueueStorage is the Azure-specific Queue Storage data-plane surface,
+
+| Operation | Description |
+| --- | --- |
+| `GetQueueMetadata` | GetQueueMetadata reports the approximate message count and user metadata. |
+| `PeekMessages` | PeekMessages returns up to maxMessages visible messages without altering |
+| `SetQueueMetadata` | SetQueueMetadata replaces the queue's user metadata. |
+| `UpdateMessage` | UpdateMessage updates a message's content (when body is non-nil) and its |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/azure/README.md
+++ b/docs/coverage/azure/README.md
@@ -26,6 +26,6 @@ Services cloudemu emulates for Azure, by native name. Back to the [cross-provide
 | [NotificationHubs](./notificationhubs.md) | `notification` | 9 |
 | [QueueStorage](./queuestorage.md) | `messagequeue` | 14 |
 | [Search](./search.md) | `azuresearch` | 53 |
-| [TableStorage](./tablestorage.md) | `tablestorage` | 8 |
+| [TableStorage](./tablestorage.md) | `tablestorage` | 9 |
 | [VNet](./vnet.md) | `networking` | 57 |
 | [VirtualMachines](./virtualmachines.md) | `compute` | 37 |

--- a/docs/coverage/azure/queuestorage.md
+++ b/docs/coverage/azure/queuestorage.md
@@ -32,6 +32,7 @@ AzureQueueStorage is the Azure-specific Queue Storage data-plane surface,
 
 | Operation | Description |
 | --- | --- |
+| `DequeueMessages` | DequeueMessages retrieves up to maxMessages visible messages, hiding them |
 | `GetQueueMetadata` | GetQueueMetadata reports the approximate message count and user metadata. |
 | `PeekMessages` | PeekMessages returns up to maxMessages visible messages without altering |
 | `SetQueueMetadata` | SetQueueMetadata replaces the queue's user metadata. |

--- a/docs/coverage/azure/queuestorage.md
+++ b/docs/coverage/azure/queuestorage.md
@@ -22,6 +22,21 @@ Azure's `messagequeue` service · portable interface `driver.MessageQueue` · [A
 | `SendMessageBatch` | Batch operations |
 | `SetQueueAttributes` |  |
 
+## Optional capabilities
+
+Discovered by type assertion; only some providers implement these.
+
+### AzureQueueStorage
+
+AzureQueueStorage is the Azure-specific Queue Storage data-plane surface,
+
+| Operation | Description |
+| --- | --- |
+| `GetQueueMetadata` | GetQueueMetadata reports the approximate message count and user metadata. |
+| `PeekMessages` | PeekMessages returns up to maxMessages visible messages without altering |
+| `SetQueueMetadata` | SetQueueMetadata replaces the queue's user metadata. |
+| `UpdateMessage` | UpdateMessage updates a message's content (when body is non-nil) and its |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/azure/tablestorage.md
+++ b/docs/coverage/azure/tablestorage.md
@@ -3,10 +3,11 @@
 
 Azure's `tablestorage` service · portable interface `driver.TableStorage` · [Azure index](./README.md)
 
-## Operations (8)
+## Operations (9)
 
 | Operation | Description |
 | --- | --- |
+| `ApplyBatch` | ApplyBatch atomically applies an entity group transaction: either every |
 | `CreateTable` |  |
 | `DeleteEntity` |  |
 | `DeleteTable` |  |

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -5941,6 +5941,30 @@
         "name": "SetQueueAttributes"
       }
     ],
+    "optionalCapabilities": [
+      {
+        "name": "AzureQueueStorage",
+        "doc": "AzureQueueStorage is the Azure-specific Queue Storage data-plane surface,",
+        "operations": [
+          {
+            "name": "GetQueueMetadata",
+            "doc": "GetQueueMetadata reports the approximate message count and user metadata."
+          },
+          {
+            "name": "PeekMessages",
+            "doc": "PeekMessages returns up to maxMessages visible messages without altering"
+          },
+          {
+            "name": "SetQueueMetadata",
+            "doc": "SetQueueMetadata replaces the queue's user metadata."
+          },
+          {
+            "name": "UpdateMessage",
+            "doc": "UpdateMessage updates a message's content (when body is non-nil) and its"
+          }
+        ]
+      }
+    ],
     "providers": {
       "aws": "SQS",
       "azure": "QueueStorage",
@@ -10325,6 +10349,10 @@
     "service": "tablestorage",
     "interface": "TableStorage",
     "operations": [
+      {
+        "name": "ApplyBatch",
+        "doc": "ApplyBatch atomically applies an entity group transaction: either every"
+      },
       {
         "name": "CreateTable"
       },

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -5947,6 +5947,10 @@
         "doc": "AzureQueueStorage is the Azure-specific Queue Storage data-plane surface,",
         "operations": [
           {
+            "name": "DequeueMessages",
+            "doc": "DequeueMessages retrieves up to maxMessages visible messages, hiding them"
+          },
+          {
             "name": "GetQueueMetadata",
             "doc": "GetQueueMetadata reports the approximate message count and user metadata."
           },

--- a/docs/coverage/gcp/pubsub.md
+++ b/docs/coverage/gcp/pubsub.md
@@ -32,6 +32,7 @@ AzureQueueStorage is the Azure-specific Queue Storage data-plane surface,
 
 | Operation | Description |
 | --- | --- |
+| `DequeueMessages` | DequeueMessages retrieves up to maxMessages visible messages, hiding them |
 | `GetQueueMetadata` | GetQueueMetadata reports the approximate message count and user metadata. |
 | `PeekMessages` | PeekMessages returns up to maxMessages visible messages without altering |
 | `SetQueueMetadata` | SetQueueMetadata replaces the queue's user metadata. |

--- a/docs/coverage/gcp/pubsub.md
+++ b/docs/coverage/gcp/pubsub.md
@@ -22,6 +22,21 @@ GCP's `messagequeue` service · portable interface `driver.MessageQueue` · [GCP
 | `SendMessageBatch` | Batch operations |
 | `SetQueueAttributes` |  |
 
+## Optional capabilities
+
+Discovered by type assertion; only some providers implement these.
+
+### AzureQueueStorage
+
+AzureQueueStorage is the Azure-specific Queue Storage data-plane surface,
+
+| Operation | Description |
+| --- | --- |
+| `GetQueueMetadata` | GetQueueMetadata reports the approximate message count and user metadata. |
+| `PeekMessages` | PeekMessages returns up to maxMessages visible messages without altering |
+| `SetQueueMetadata` | SetQueueMetadata replaces the queue's user metadata. |
+| `UpdateMessage` | UpdateMessage updates a message's content (when body is non-nil) and its |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/providers/azure/servicebus/queue_storage.go
+++ b/providers/azure/servicebus/queue_storage.go
@@ -1,0 +1,149 @@
+package servicebus
+
+import (
+	"context"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+)
+
+// Compile-time check that Mock implements the Azure-specific queue surface.
+var _ driver.AzureQueueStorage = (*Mock)(nil)
+
+// defaultMessageRetention is the Azure Queue Storage default message TTL.
+const defaultMessageRetention = 7 * 24 * time.Hour
+
+// messageExpiry returns when a message expires given the queue's retention.
+func (qd *queueData) messageExpiry(msg *sbMessage) time.Time {
+	if qd.messageRetention > 0 {
+		return msg.SentAt.Add(time.Duration(qd.messageRetention) * time.Second)
+	}
+
+	return msg.SentAt.Add(defaultMessageRetention)
+}
+
+// PeekMessages returns up to maxMessages visible messages without changing
+// their visibility or issuing pop receipts (Azure Peek Messages).
+func (m *Mock) PeekMessages(_ context.Context, queueURL string, maxMessages int) ([]driver.AzureQueueMessage, error) {
+	qd, ok := m.queues.Get(queueURL)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "queue %q not found", queueURL)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	limit := clampMaxMessages(maxMessages)
+	now := m.opts.Clock.Now()
+
+	out := make([]driver.AzureQueueMessage, 0, limit)
+
+	for _, msg := range qd.messages {
+		if len(out) >= limit {
+			break
+		}
+
+		if msg.VisibleAt.After(now) {
+			continue
+		}
+
+		out = append(out, driver.AzureQueueMessage{
+			MessageID:    msg.ID,
+			Body:         msg.Body,
+			ReceiveCount: msg.ReceiveCount,
+			InsertedAt:   msg.SentAt,
+			ExpiresAt:    qd.messageExpiry(msg),
+		})
+	}
+
+	return out, nil
+}
+
+// UpdateMessage updates a dequeued message's content and visibility, returning a
+// fresh pop receipt (Azure Update Message). The supplied pop receipt must match
+// the message's current receipt.
+func (m *Mock) UpdateMessage(
+	_ context.Context, queueURL, messageID, popReceipt string, visibilityTimeout int, body *string,
+) (driver.AzureUpdateMessageResult, error) {
+	qd, ok := m.queues.Get(queueURL)
+	if !ok {
+		return driver.AzureUpdateMessageResult{}, cerrors.Newf(cerrors.NotFound, "queue %q not found", queueURL)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	for _, msg := range qd.messages {
+		if msg.ID != messageID || msg.ReceiptHandle != popReceipt {
+			continue
+		}
+
+		now := m.opts.Clock.Now()
+
+		if body != nil {
+			msg.Body = *body
+		}
+
+		msg.VisibleAt = now.Add(time.Duration(visibilityTimeout) * time.Second)
+		msg.ReceiptHandle = idgen.GenerateID("sb-lock-")
+
+		return driver.AzureUpdateMessageResult{
+			PopReceipt:      msg.ReceiptHandle,
+			TimeNextVisible: msg.VisibleAt,
+		}, nil
+	}
+
+	return driver.AzureUpdateMessageResult{}, cerrors.Newf(
+		cerrors.NotFound, "message %q with the specified pop receipt was not found", messageID,
+	)
+}
+
+// GetQueueMetadata reports the approximate visible-message count and the queue's
+// user metadata (Azure Get Queue Metadata).
+func (m *Mock) GetQueueMetadata(_ context.Context, queueURL string) (driver.AzureQueueMetadata, error) {
+	qd, ok := m.queues.Get(queueURL)
+	if !ok {
+		return driver.AzureQueueMetadata{}, cerrors.Newf(cerrors.NotFound, "queue %q not found", queueURL)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	now := m.opts.Clock.Now()
+	count := 0
+
+	for _, msg := range qd.messages {
+		if !msg.VisibleAt.After(now) {
+			count++
+		}
+	}
+
+	meta := make(map[string]string, len(qd.metadata))
+	for k, v := range qd.metadata {
+		meta[k] = v
+	}
+
+	return driver.AzureQueueMetadata{ApproximateMessageCount: count, Metadata: meta}, nil
+}
+
+// SetQueueMetadata replaces the queue's user metadata (Azure Set Queue Metadata).
+func (m *Mock) SetQueueMetadata(_ context.Context, queueURL string, metadata map[string]string) error {
+	qd, ok := m.queues.Get(queueURL)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "queue %q not found", queueURL)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	meta := make(map[string]string, len(metadata))
+	for k, v := range metadata {
+		meta[k] = v
+	}
+
+	qd.metadata = meta
+
+	return nil
+}

--- a/providers/azure/servicebus/queue_storage.go
+++ b/providers/azure/servicebus/queue_storage.go
@@ -15,6 +15,61 @@ var _ driver.AzureQueueStorage = (*Mock)(nil)
 // defaultMessageRetention is the Azure Queue Storage default message TTL.
 const defaultMessageRetention = 7 * 24 * time.Hour
 
+// maxQueueStorageMessages is the maximum number of messages Azure Queue Storage
+// returns from a single Get Messages or Peek Messages call. This differs from
+// Service Bus's receive cap, so Queue Storage clamps against its own limit.
+const maxQueueStorageMessages = 32
+
+// clampQueueStorageMessages bounds a requested message count to Azure Queue
+// Storage's [1, 32] range, defaulting to 1 when unset or non-positive.
+func clampQueueStorageMessages(maxMessages int) int {
+	if maxMessages <= 0 {
+		return 1
+	}
+
+	if maxMessages > maxQueueStorageMessages {
+		return maxQueueStorageMessages
+	}
+
+	return maxMessages
+}
+
+// DequeueMessages retrieves up to maxMessages visible messages, hiding each for
+// visibilityTimeout seconds and issuing a fresh pop receipt (Azure Get Messages).
+func (m *Mock) DequeueMessages(
+	_ context.Context, queueURL string, maxMessages, visibilityTimeout int,
+) ([]driver.Message, error) {
+	qd, ok := m.queues.Get(queueURL)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "queue %q not found", queueURL)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	maxMsgs := clampQueueStorageMessages(maxMessages)
+
+	visTimeout := visibilityTimeout
+	if visTimeout == 0 {
+		visTimeout = qd.visibilityTimeout
+	}
+
+	now := m.opts.Clock.Now()
+	results, toRemove := m.collectVisibleMessages(qd, maxMsgs, visTimeout, now)
+
+	removeByIndices(qd, toRemove)
+
+	if results == nil {
+		results = []driver.Message{}
+	}
+
+	m.emitMetric(qd.info.Name, map[string]float64{
+		"OutgoingMessages": float64(len(results)), "ActiveMessages": float64(len(qd.messages)),
+	})
+
+	return results, nil
+}
+
 // messageExpiry returns when a message expires given the queue's retention.
 func (qd *queueData) messageExpiry(msg *sbMessage) time.Time {
 	if qd.messageRetention > 0 {
@@ -35,7 +90,7 @@ func (m *Mock) PeekMessages(_ context.Context, queueURL string, maxMessages int)
 	qd.mu.Lock()
 	defer qd.mu.Unlock()
 
-	limit := clampMaxMessages(maxMessages)
+	limit := clampQueueStorageMessages(maxMessages)
 	now := m.opts.Clock.Now()
 
 	out := make([]driver.AzureQueueMessage, 0, limit)
@@ -111,14 +166,10 @@ func (m *Mock) GetQueueMetadata(_ context.Context, queueURL string) (driver.Azur
 	qd.mu.Lock()
 	defer qd.mu.Unlock()
 
-	now := m.opts.Clock.Now()
-	count := 0
-
-	for _, msg := range qd.messages {
-		if !msg.VisibleAt.After(now) {
-			count++
-		}
-	}
+	// x-ms-approximate-messages-count reflects the total messages in the queue,
+	// counting both visible and invisible (in-flight) messages; it ignores
+	// message visibility. See Get Queue Metadata (Azure Queue Storage) docs.
+	count := len(qd.messages)
 
 	meta := make(map[string]string, len(qd.metadata))
 	for k, v := range qd.metadata {

--- a/providers/azure/servicebus/servicebus.go
+++ b/providers/azure/servicebus/servicebus.go
@@ -52,6 +52,7 @@ type queueData struct {
 	lastModifiedAt     time.Time
 	deduplicationIndex map[string]time.Time
 	dlqConfig          *driver.DeadLetterConfig
+	metadata           map[string]string
 }
 
 // FunctionTrigger is a function that gets called when a message is sent to a queue.
@@ -167,6 +168,7 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		lastModifiedAt:     now,
 		deduplicationIndex: make(map[string]time.Time),
 		dlqConfig:          cfg.DeadLetterQueue,
+		metadata:           make(map[string]string),
 	}
 
 	m.queues.Set(url, qd)
@@ -445,6 +447,7 @@ func buildReceivedMessage(msg *sbMessage, visibilityTimeout int, now time.Time) 
 		Body:          msg.Body,
 		Attributes:    attrs,
 		GroupID:       msg.GroupID,
+		ReceiveCount:  msg.ReceiveCount,
 	}
 }
 

--- a/providers/azure/tablestorage/filter.go
+++ b/providers/azure/tablestorage/filter.go
@@ -1,0 +1,561 @@
+package tablestorage
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	driver "github.com/stackshy/cloudemu/v2/services/tablestorage/driver"
+)
+
+// predicate evaluates an OData $filter against a rendered entity.
+type predicate func(driver.Entity) bool
+
+// parseFilter compiles an OData $filter expression into a predicate. It supports
+// the comparison operators eq/ne/gt/ge/lt/le, the logical operators and/or/not,
+// parentheses, and string, numeric, boolean, datetime and guid literals. An
+// empty filter compiles to a nil predicate (match everything). A malformed
+// filter returns an InvalidArgument error so the handler answers 400.
+func parseFilter(filter string) (predicate, error) {
+	filter = strings.TrimSpace(filter)
+	if filter == "" {
+		return nil, nil
+	}
+
+	toks, err := tokenize(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &parser{toks: toks}
+
+	pred, err := p.parseOr()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.pos != len(p.toks) {
+		return nil, errFilter("unexpected trailing tokens in $filter")
+	}
+
+	return pred, nil
+}
+
+func errFilter(msg string) error {
+	return errors.New(errors.InvalidArgument, msg)
+}
+
+// token kinds.
+type tokKind int
+
+const (
+	tokIdent tokKind = iota // property name or operator keyword
+	tokString
+	tokNumber
+	tokBool
+	tokDateTime
+	tokGUID
+	tokLParen
+	tokRParen
+)
+
+type token struct {
+	kind tokKind
+	text string
+	num  float64
+	b    bool
+	t    time.Time
+}
+
+//nolint:gocyclo,cyclop // a flat lexer switch is clearer than fragmenting it.
+func tokenize(s string) ([]token, error) {
+	var toks []token
+
+	i := 0
+	for i < len(s) {
+		c := s[i]
+
+		switch {
+		case c == ' ' || c == '\t':
+			i++
+		case c == '(':
+			toks = append(toks, token{kind: tokLParen})
+			i++
+		case c == ')':
+			toks = append(toks, token{kind: tokRParen})
+			i++
+		case c == '\'':
+			str, next, err := readString(s, i)
+			if err != nil {
+				return nil, err
+			}
+
+			toks = append(toks, token{kind: tokString, text: str})
+			i = next
+		case c == '-' || c == '+' || (c >= '0' && c <= '9'):
+			tok, next, err := readNumber(s, i)
+			if err != nil {
+				return nil, err
+			}
+
+			toks = append(toks, tok)
+			i = next
+		case isIdentStart(c):
+			tok, next, err := readIdentOrTyped(s, i)
+			if err != nil {
+				return nil, err
+			}
+
+			toks = append(toks, tok)
+			i = next
+		default:
+			return nil, errFilter("unexpected character in $filter")
+		}
+	}
+
+	return toks, nil
+}
+
+func readString(s string, i int) (str string, next int, err error) {
+	// i points at the opening quote.
+	var b strings.Builder
+
+	j := i + 1
+	for j < len(s) {
+		if s[j] == '\'' {
+			if j+1 < len(s) && s[j+1] == '\'' { // escaped quote
+				b.WriteByte('\'')
+
+				j += 2
+
+				continue
+			}
+
+			return b.String(), j + 1, nil
+		}
+
+		b.WriteByte(s[j])
+
+		j++
+	}
+
+	return "", 0, errFilter("unterminated string literal in $filter")
+}
+
+func readNumber(s string, i int) (token, int, error) {
+	j := i
+	if s[j] == '-' || s[j] == '+' {
+		j++
+	}
+
+	for j < len(s) && isNumberByte(s[j]) {
+		j++
+	}
+
+	// A trailing type suffix (L for Int64, etc.) is tolerated and ignored.
+	for j < len(s) && isNumberSuffix(s[j]) {
+		j++
+	}
+
+	raw := strings.TrimRight(s[i:j], "LlfFdD")
+
+	n, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return token{}, 0, errFilter("invalid numeric literal in $filter")
+	}
+
+	return token{kind: tokNumber, num: n}, j, nil
+}
+
+func isNumberByte(c byte) bool {
+	return c == '.' || (c >= '0' && c <= '9') || c == 'e' || c == 'E'
+}
+
+func isNumberSuffix(c byte) bool {
+	return c == 'L' || c == 'l' || c == 'f' || c == 'F' || c == 'd' || c == 'D'
+}
+
+func isIdentStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isIdentPart(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9')
+}
+
+// readIdentOrTyped reads a bare identifier/keyword or a typed literal such as
+// datetime'…', guid'…', X'…' (binary), or a bare true/false boolean.
+func readIdentOrTyped(s string, i int) (token, int, error) {
+	j := i
+	for j < len(s) && isIdentPart(s[j]) {
+		j++
+	}
+
+	word := s[i:j]
+
+	// Typed literal: identifier immediately followed by a quoted value.
+	if j < len(s) && s[j] == '\'' {
+		val, next, err := readString(s, j)
+		if err != nil {
+			return token{}, 0, err
+		}
+
+		return typedLiteral(word, val, next)
+	}
+
+	switch strings.ToLower(word) {
+	case "true":
+		return token{kind: tokBool, b: true}, j, nil
+	case "false":
+		return token{kind: tokBool, b: false}, j, nil
+	}
+
+	return token{kind: tokIdent, text: word}, j, nil
+}
+
+func typedLiteral(prefix, val string, next int) (token, int, error) {
+	switch strings.ToLower(prefix) {
+	case "datetime":
+		t, err := time.Parse(time.RFC3339Nano, val)
+		if err != nil {
+			return token{}, 0, errFilter("invalid datetime literal in $filter")
+		}
+
+		return token{kind: tokDateTime, t: t}, next, nil
+	case "guid":
+		return token{kind: tokGUID, text: val}, next, nil
+	case "x", "binary":
+		return token{kind: tokString, text: val}, next, nil
+	default:
+		return token{}, 0, errFilter("unknown typed literal in $filter")
+	}
+}
+
+// parser is a recursive-descent parser over the token stream.
+type parser struct {
+	toks []token
+	pos  int
+}
+
+func (p *parser) peek() (token, bool) {
+	if p.pos >= len(p.toks) {
+		return token{}, false
+	}
+
+	return p.toks[p.pos], true
+}
+
+// isKeyword reports whether the current token is the ident keyword kw.
+func (p *parser) isKeyword(kw string) bool {
+	t, ok := p.peek()
+	return ok && t.kind == tokIdent && strings.EqualFold(t.text, kw)
+}
+
+func (p *parser) parseOr() (predicate, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.isKeyword("or") {
+		p.pos++
+
+		right, rerr := p.parseAnd()
+		if rerr != nil {
+			return nil, rerr
+		}
+
+		l, r := left, right
+		left = func(e driver.Entity) bool { return l(e) || r(e) }
+	}
+
+	return left, nil
+}
+
+func (p *parser) parseAnd() (predicate, error) {
+	left, err := p.parseUnary()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.isKeyword("and") {
+		p.pos++
+
+		right, rerr := p.parseUnary()
+		if rerr != nil {
+			return nil, rerr
+		}
+
+		l, r := left, right
+		left = func(e driver.Entity) bool { return l(e) && r(e) }
+	}
+
+	return left, nil
+}
+
+func (p *parser) parseUnary() (predicate, error) {
+	if p.isKeyword("not") {
+		p.pos++
+
+		inner, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+
+		return func(e driver.Entity) bool { return !inner(e) }, nil
+	}
+
+	return p.parsePrimary()
+}
+
+func (p *parser) parsePrimary() (predicate, error) {
+	t, ok := p.peek()
+	if !ok {
+		return nil, errFilter("unexpected end of $filter")
+	}
+
+	if t.kind == tokLParen {
+		p.pos++
+
+		inner, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+
+		if cur, ok := p.peek(); !ok || cur.kind != tokRParen {
+			return nil, errFilter("missing closing parenthesis in $filter")
+		}
+
+		p.pos++
+
+		return inner, nil
+	}
+
+	return p.parseComparison()
+}
+
+// comparison operators.
+var comparisonOps = map[string]bool{ //nolint:gochecknoglobals // immutable operator set.
+	"eq": true, "ne": true, "gt": true, "ge": true, "lt": true, "le": true,
+}
+
+func (p *parser) parseComparison() (predicate, error) {
+	left, err := p.parseOperand()
+	if err != nil {
+		return nil, err
+	}
+
+	opTok, ok := p.peek()
+	if !ok || opTok.kind != tokIdent || !comparisonOps[strings.ToLower(opTok.text)] {
+		return nil, errFilter("expected a comparison operator in $filter")
+	}
+
+	op := strings.ToLower(opTok.text)
+	p.pos++
+
+	right, err := p.parseOperand()
+	if err != nil {
+		return nil, err
+	}
+
+	return func(e driver.Entity) bool {
+		return compareOp(op, left(e), right(e))
+	}, nil
+}
+
+// operand resolves to a value against an entity: a literal ignores the entity,
+// an identifier looks up the property.
+type operand func(driver.Entity) any
+
+func (p *parser) parseOperand() (operand, error) {
+	t, ok := p.peek()
+	if !ok {
+		return nil, errFilter("expected an operand in $filter")
+	}
+
+	p.pos++
+
+	switch t.kind {
+	case tokString, tokGUID:
+		v := t.text
+		return func(driver.Entity) any { return v }, nil
+	case tokNumber:
+		v := t.num
+		return func(driver.Entity) any { return v }, nil
+	case tokBool:
+		v := t.b
+		return func(driver.Entity) any { return v }, nil
+	case tokDateTime:
+		v := t.t
+		return func(driver.Entity) any { return v }, nil
+	case tokIdent:
+		name := t.text
+		return func(e driver.Entity) any { return e[name] }, nil
+	case tokLParen, tokRParen:
+		return nil, errFilter("unexpected parenthesis where an operand was expected in $filter")
+	}
+
+	return nil, errFilter("unexpected token where an operand was expected in $filter")
+}
+
+// compareOp evaluates one comparison.
+func compareOp(op string, left, right any) bool {
+	cmp, ok := compareValues(left, right)
+
+	// "ne" is the only operator that is true for incomparable operands.
+	if op == "ne" {
+		return !ok || cmp != 0
+	}
+
+	if !ok {
+		return false
+	}
+
+	switch op {
+	case "eq":
+		return cmp == 0
+	case "gt":
+		return cmp > 0
+	case "ge":
+		return cmp >= 0
+	case "lt":
+		return cmp < 0
+	case "le":
+		return cmp <= 0
+	default:
+		return false
+	}
+}
+
+// compareValues returns -1/0/1 comparing a and b, and ok=false when they are
+// not meaningfully comparable.
+func compareValues(a, b any) (int, bool) {
+	if a == nil || b == nil {
+		return 0, a == nil && b == nil
+	}
+
+	if c, ok := cmpAsNumbers(a, b); ok {
+		return c, true
+	}
+
+	if c, ok := cmpAsTimes(a, b); ok {
+		return c, true
+	}
+
+	if c, ok := cmpAsBools(a, b); ok {
+		return c, true
+	}
+
+	return cmpAsStrings(a, b)
+}
+
+func cmpAsNumbers(a, b any) (int, bool) {
+	an, aok := toFloat(a)
+	bn, bok := toFloat(b)
+
+	if aok && bok {
+		return cmpFloat(an, bn), true
+	}
+
+	return 0, false
+}
+
+func cmpAsTimes(a, b any) (int, bool) {
+	at, aok := toTime(a)
+	bt, bok := toTime(b)
+
+	if aok && bok {
+		return cmpTime(at, bt), true
+	}
+
+	return 0, false
+}
+
+func cmpAsBools(a, b any) (int, bool) {
+	ab, aok := a.(bool)
+	bb, bok := b.(bool)
+
+	if aok && bok {
+		return cmpBool(ab, bb), true
+	}
+
+	return 0, false
+}
+
+func cmpAsStrings(a, b any) (int, bool) {
+	as, aok := a.(string)
+	bs, bok := b.(string)
+
+	if aok && bok {
+		return strings.Compare(as, bs), true
+	}
+
+	return 0, false
+}
+
+func toFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+func toTime(v any) (time.Time, bool) {
+	switch t := v.(type) {
+	case time.Time:
+		return t, true
+	case string:
+		parsed, err := time.Parse(time.RFC3339Nano, t)
+		if err != nil {
+			return time.Time{}, false
+		}
+
+		return parsed, true
+	default:
+		return time.Time{}, false
+	}
+}
+
+func cmpFloat(a, b float64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func cmpTime(a, b time.Time) int {
+	switch {
+	case a.Before(b):
+		return -1
+	case a.After(b):
+		return 1
+	default:
+		return 0
+	}
+}
+
+func cmpBool(a, b bool) int {
+	switch {
+	case a == b:
+		return 0
+	case !a:
+		return -1
+	default:
+		return 1
+	}
+}

--- a/providers/azure/tablestorage/tablestorage.go
+++ b/providers/azure/tablestorage/tablestorage.go
@@ -4,8 +4,10 @@ package tablestorage
 
 import (
 	"context"
-	"strings"
+	"fmt"
+	"sort"
 	"sync"
+	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/errors"
@@ -15,10 +17,27 @@ import (
 // Compile-time check that Mock implements driver.TableStorage.
 var _ driver.TableStorage = (*Mock)(nil)
 
+// timestampProp and etagProp are the reserved system properties Table Storage
+// injects on read. They are never persisted from a caller-supplied entity.
+const (
+	timestampProp = "Timestamp"
+	etagProp      = "odata.etag"
+
+	// numSystemProps is how many system properties render adds (Timestamp, etag).
+	numSystemProps = 2
+)
+
+// storedEntity is one row plus its server-maintained system properties.
+type storedEntity struct {
+	props     driver.Entity
+	timestamp time.Time
+	etag      string
+}
+
 // tableData holds one table's entities, keyed by "partitionKey\x00rowKey".
 type tableData struct {
 	mu       sync.RWMutex
-	entities map[string]driver.Entity
+	entities map[string]*storedEntity
 }
 
 // Mock is an in-memory Table Storage backend.
@@ -26,6 +45,9 @@ type Mock struct {
 	mu     sync.RWMutex
 	tables map[string]*tableData
 	opts   *config.Options
+
+	tsMu   sync.Mutex
+	lastTS time.Time
 }
 
 // New creates a new Table Storage mock.
@@ -38,6 +60,27 @@ func New(opts *config.Options) *Mock {
 
 func entityKey(partitionKey, rowKey string) string {
 	return partitionKey + "\x00" + rowKey
+}
+
+// nextTimestamp returns a strictly increasing timestamp so every mutation
+// produces a fresh, stable ETag even when the configured clock does not
+// advance between calls (e.g. FakeClock in tests).
+func (m *Mock) nextTimestamp() time.Time {
+	m.tsMu.Lock()
+	defer m.tsMu.Unlock()
+
+	now := m.opts.Clock.Now().UTC()
+	if !now.After(m.lastTS) {
+		now = m.lastTS.Add(time.Nanosecond)
+	}
+
+	m.lastTS = now
+
+	return now
+}
+
+func makeETag(ts time.Time) string {
+	return fmt.Sprintf("W/\"datetime'%s'\"", ts.Format(time.RFC3339Nano))
 }
 
 // CreateTable creates a new empty table.
@@ -53,7 +96,7 @@ func (m *Mock) CreateTable(_ context.Context, name string) error {
 		return errors.Newf(errors.AlreadyExists, "table %q already exists", name)
 	}
 
-	m.tables[name] = &tableData{entities: make(map[string]driver.Entity)}
+	m.tables[name] = &tableData{entities: make(map[string]*storedEntity)}
 
 	return nil
 }
@@ -82,6 +125,8 @@ func (m *Mock) ListTables(_ context.Context) ([]string, error) {
 		names = append(names, name)
 	}
 
+	sort.Strings(names)
+
 	return names, nil
 }
 
@@ -99,30 +144,40 @@ func (m *Mock) table(name string) (*tableData, error) {
 
 // InsertEntity adds a new entity. It fails if an entity with the same
 // PartitionKey/RowKey already exists.
-func (m *Mock) InsertEntity(_ context.Context, table, partitionKey, rowKey string, entity driver.Entity) error {
+func (m *Mock) InsertEntity(
+	_ context.Context, table, partitionKey, rowKey string, entity driver.Entity,
+) (string, error) {
 	if partitionKey == "" || rowKey == "" {
-		return errors.New(errors.InvalidArgument, "PartitionKey and RowKey are required")
+		return "", errors.New(errors.InvalidArgument, "PartitionKey and RowKey are required")
 	}
 
 	td, err := m.table(table)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	td.mu.Lock()
 	defer td.mu.Unlock()
 
-	key := entityKey(partitionKey, rowKey)
-	if _, ok := td.entities[key]; ok {
-		return errors.Newf(errors.AlreadyExists, "entity (%q,%q) already exists", partitionKey, rowKey)
-	}
-
-	td.entities[key] = cloneEntity(entity)
-
-	return nil
+	return m.insertLocked(td, partitionKey, rowKey, entity)
 }
 
-// GetEntity returns the entity addressed by partitionKey/rowKey.
+// insertLocked inserts one entity; td.mu must be held.
+func (m *Mock) insertLocked(td *tableData, partitionKey, rowKey string, entity driver.Entity) (string, error) {
+	key := entityKey(partitionKey, rowKey)
+	if _, ok := td.entities[key]; ok {
+		return "", errors.Newf(errors.AlreadyExists, "entity (%q,%q) already exists", partitionKey, rowKey)
+	}
+
+	ts := m.nextTimestamp()
+	se := &storedEntity{props: sanitize(entity), timestamp: ts, etag: makeETag(ts)}
+	td.entities[key] = se
+
+	return se.etag, nil
+}
+
+// GetEntity returns the entity addressed by partitionKey/rowKey, including its
+// system Timestamp and odata.etag properties.
 func (m *Mock) GetEntity(_ context.Context, table, partitionKey, rowKey string) (driver.Entity, error) {
 	td, err := m.table(table)
 	if err != nil {
@@ -132,18 +187,63 @@ func (m *Mock) GetEntity(_ context.Context, table, partitionKey, rowKey string) 
 	td.mu.RLock()
 	defer td.mu.RUnlock()
 
-	ent, ok := td.entities[entityKey(partitionKey, rowKey)]
+	se, ok := td.entities[entityKey(partitionKey, rowKey)]
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "entity (%q,%q) not found", partitionKey, rowKey)
 	}
 
-	return cloneEntity(ent), nil
+	return se.render(), nil
 }
 
-// UpdateEntity merges or replaces an existing entity.
+// UpdateEntity merges or replaces an existing entity, honoring the If-Match
+// precondition (empty or "*" is unconditional; a specific ETag must match).
 func (m *Mock) UpdateEntity(
-	_ context.Context, table, partitionKey, rowKey string, entity driver.Entity, mode driver.UpdateMode,
-) error {
+	_ context.Context, table, partitionKey, rowKey string, entity driver.Entity, mode driver.UpdateMode, ifMatch string,
+) (string, error) {
+	td, err := m.table(table)
+	if err != nil {
+		return "", err
+	}
+
+	td.mu.Lock()
+	defer td.mu.Unlock()
+
+	return m.updateLocked(td, partitionKey, rowKey, entity, mode, ifMatch)
+}
+
+// updateLocked updates one existing entity; td.mu must be held.
+func (m *Mock) updateLocked(
+	td *tableData, partitionKey, rowKey string, entity driver.Entity, mode driver.UpdateMode, ifMatch string,
+) (string, error) {
+	key := entityKey(partitionKey, rowKey)
+
+	existing, ok := td.entities[key]
+	if !ok {
+		return "", errors.Newf(errors.NotFound, "entity (%q,%q) not found", partitionKey, rowKey)
+	}
+
+	if err := checkIfMatch(existing.etag, ifMatch); err != nil {
+		return "", err
+	}
+
+	ts := m.nextTimestamp()
+
+	if mode == driver.UpdateModeReplace {
+		existing.props = sanitize(entity)
+	} else {
+		for k, v := range sanitize(entity) {
+			existing.props[k] = v
+		}
+	}
+
+	existing.timestamp = ts
+	existing.etag = makeETag(ts)
+
+	return existing.etag, nil
+}
+
+// DeleteEntity removes an entity, honoring the If-Match precondition.
+func (m *Mock) DeleteEntity(_ context.Context, table, partitionKey, rowKey, ifMatch string) error {
 	td, err := m.table(table)
 	if err != nil {
 		return err
@@ -152,6 +252,11 @@ func (m *Mock) UpdateEntity(
 	td.mu.Lock()
 	defer td.mu.Unlock()
 
+	return deleteLocked(td, partitionKey, rowKey, ifMatch)
+}
+
+// deleteLocked deletes one entity; td.mu must be held.
+func deleteLocked(td *tableData, partitionKey, rowKey, ifMatch string) error {
 	key := entityKey(partitionKey, rowKey)
 
 	existing, ok := td.entities[key]
@@ -159,34 +264,8 @@ func (m *Mock) UpdateEntity(
 		return errors.Newf(errors.NotFound, "entity (%q,%q) not found", partitionKey, rowKey)
 	}
 
-	if mode == driver.UpdateModeReplace {
-		td.entities[key] = cloneEntity(entity)
-		return nil
-	}
-
-	merged := cloneEntity(existing)
-	for k, v := range entity {
-		merged[k] = v
-	}
-
-	td.entities[key] = merged
-
-	return nil
-}
-
-// DeleteEntity removes an entity.
-func (m *Mock) DeleteEntity(_ context.Context, table, partitionKey, rowKey string) error {
-	td, err := m.table(table)
-	if err != nil {
+	if err := checkIfMatch(existing.etag, ifMatch); err != nil {
 		return err
-	}
-
-	td.mu.Lock()
-	defer td.mu.Unlock()
-
-	key := entityKey(partitionKey, rowKey)
-	if _, ok := td.entities[key]; !ok {
-		return errors.Newf(errors.NotFound, "entity (%q,%q) not found", partitionKey, rowKey)
 	}
 
 	delete(td.entities, key)
@@ -194,165 +273,210 @@ func (m *Mock) DeleteEntity(_ context.Context, table, partitionKey, rowKey strin
 	return nil
 }
 
-// QueryEntities returns entities matching the given options. Filtering
-// supports a partition-key restriction plus a best-effort OData $filter parse
-// (see matchesFilter); unrecognized filters match everything.
-func (m *Mock) QueryEntities(_ context.Context, table string, opts driver.QueryOptions) ([]driver.Entity, error) {
-	td, err := m.table(table)
-	if err != nil {
-		return nil, err
+// checkIfMatch enforces an If-Match precondition. An empty or "*" value matches
+// unconditionally; any other value must equal the current ETag or the operation
+// fails with 412 UpdateConditionNotSatisfied.
+func checkIfMatch(currentETag, ifMatch string) error {
+	if ifMatch == "" || ifMatch == driver.MatchAny {
+		return nil
 	}
 
-	conds, err := parseFilter(opts.Filter)
-	if err != nil {
-		return nil, err
+	if ifMatch != currentETag {
+		return errors.New(errors.FailedPrecondition, "the update condition specified in the request was not satisfied")
 	}
 
-	td.mu.RLock()
-	defer td.mu.RUnlock()
-
-	results := make([]driver.Entity, 0, len(td.entities))
-
-	for _, ent := range td.entities {
-		if opts.PartitionKey != "" && asString(ent["PartitionKey"]) != opts.PartitionKey {
-			continue
-		}
-
-		if !matchesConds(ent, conds) {
-			continue
-		}
-
-		results = append(results, cloneEntity(ent))
-	}
-
-	return results, nil
+	return nil
 }
 
-func cloneEntity(e driver.Entity) driver.Entity {
-	out := make(driver.Entity, len(e))
-	for k, v := range e {
+// render returns a caller-owned copy of the entity with system properties.
+func (se *storedEntity) render() driver.Entity {
+	out := make(driver.Entity, len(se.props)+numSystemProps)
+	for k, v := range se.props {
 		out[k] = v
+	}
+
+	out[timestampProp] = se.timestamp.Format(time.RFC3339Nano)
+	out[etagProp] = se.etag
+
+	return out
+}
+
+// sanitize copies caller properties, dropping reserved system keys so they can
+// never be spoofed into the store.
+func sanitize(e driver.Entity) driver.Entity {
+	out := make(driver.Entity, len(e))
+
+	for k, v := range e {
+		switch k {
+		case timestampProp, etagProp, "odata.metadata", "odata.editLink", "odata.id", "odata.type":
+			continue
+		default:
+			out[k] = v
+		}
 	}
 
 	return out
 }
 
-// eqCond is a single "property eq value" equality condition.
-type eqCond struct {
-	prop string
-	val  string
+// QueryEntities returns a page of entities matching opts, ordered by
+// (PartitionKey, RowKey), honoring the OData $filter, a partition restriction,
+// $top, and a continuation position.
+func (m *Mock) QueryEntities(
+	_ context.Context, table string, opts driver.QueryOptions,
+) (driver.QueryResult, error) {
+	td, err := m.table(table)
+	if err != nil {
+		return driver.QueryResult{}, err
+	}
+
+	pred, err := parseFilter(opts.Filter)
+	if err != nil {
+		return driver.QueryResult{}, err
+	}
+
+	td.mu.RLock()
+	ordered := td.sortedEntities()
+	td.mu.RUnlock()
+
+	return page(ordered, opts, pred), nil
 }
 
-// errUnsupportedFilter marks an OData $filter cloudemu can't evaluate. Rather
-// than silently matching everything (a data-correctness hazard — a client that
-// asked for a subset would get the whole table), QueryEntities surfaces it so
-// the handler returns 400 InvalidInput.
-var errUnsupportedFilter = errors.New(errors.InvalidArgument,
-	"unsupported $filter: only \"Prop eq 'value'\" clauses joined by \"and\" are supported")
-
-// parseFilter extracts equality conditions from an OData $filter of the form
-// "Prop eq 'val' and Prop2 eq 'val2'". Only eq clauses joined by "and" are
-// supported; any other operator (ne/gt/ge/lt/le/or, grouping, functions) —
-// or a value literal containing " and "/" or " — returns errUnsupportedFilter
-// rather than degrading to match-all.
-func parseFilter(filter string) ([]eqCond, error) {
-	filter = strings.TrimSpace(filter)
-	if filter == "" {
-		return nil, nil
+// sortedEntities returns the table's entities ordered by (PartitionKey,
+// RowKey). td.mu must be held.
+func (td *tableData) sortedEntities() []*storedEntity {
+	out := make([]*storedEntity, 0, len(td.entities))
+	for _, se := range td.entities {
+		out = append(out, se)
 	}
 
-	if hasUnsupportedFilterToken(filter) {
-		return nil, errUnsupportedFilter
-	}
-
-	var conds []eqCond
-
-	for _, clause := range strings.Split(filter, " and ") {
-		prop, val, ok := parseEqClause(clause)
-		if !ok {
-			return nil, errUnsupportedFilter
+	sort.Slice(out, func(i, j int) bool {
+		pi, pj := asString(out[i].props["PartitionKey"]), asString(out[j].props["PartitionKey"])
+		if pi != pj {
+			return pi < pj
 		}
 
-		conds = append(conds, eqCond{prop: prop, val: val})
-	}
+		return asString(out[i].props["RowKey"]) < asString(out[j].props["RowKey"])
+	})
 
-	return conds, nil
+	return out
 }
 
-// hasUnsupportedFilterToken reports whether the filter uses an operator or
-// construct beyond eq/and. Tokens are matched space-delimited so they don't
-// trip on substrings inside identifiers or quoted values (e.g. "coordinator").
-func hasUnsupportedFilterToken(filter string) bool {
-	padded := " " + strings.ToLower(filter) + " "
-	for _, tok := range []string{" or ", " ne ", " gt ", " ge ", " lt ", " le ", " not ", " and and "} {
-		if strings.Contains(padded, tok) {
-			return true
+// page applies partition restriction, filter, continuation and $top to the
+// ordered entities, returning one result page.
+func page(ordered []*storedEntity, opts driver.QueryOptions, pred predicate) driver.QueryResult {
+	var res driver.QueryResult
+
+	for _, se := range ordered {
+		pk := asString(se.props["PartitionKey"])
+		rk := asString(se.props["RowKey"])
+
+		if opts.PartitionKey != "" && pk != opts.PartitionKey {
+			continue
 		}
-	}
 
-	return strings.ContainsAny(filter, "()")
-}
-
-// parseEqClause parses one "Prop eq 'value'" clause. The value may be a quoted
-// string literal (which can contain spaces) or a bare token; a leftover quote
-// or a non-eq operator makes it unsupported. Runs of whitespace between the
-// property, operator, and value are tolerated.
-func parseEqClause(clause string) (prop, val string, ok bool) {
-	// property = first token; then the operator; then the (possibly quoted,
-	// space-containing) value is whatever remains. Splitting token-by-token
-	// with TrimSpace tolerates extra spaces that a fixed SplitN would not.
-	prop, rest, found := cutToken(strings.TrimSpace(clause))
-	if !found {
-		return "", "", false
-	}
-
-	op, raw, found := cutToken(rest)
-	if !found || !strings.EqualFold(op, "eq") {
-		return "", "", false
-	}
-
-	if strings.ContainsAny(prop, "'()") {
-		return "", "", false
-	}
-
-	// A quoted literal must be well-formed: a lone or unbalanced quote means we
-	// split through a value (e.g. it contained " and ") — reject it.
-	if strings.HasPrefix(raw, "'") && !(len(raw) >= 2 && strings.HasSuffix(raw, "'")) {
-		return "", "", false
-	}
-
-	return prop, unquote(raw), true
-}
-
-// cutToken splits the first whitespace-delimited token off s, returning it and
-// the trimmed remainder. found is false when s has no token or no remainder.
-func cutToken(s string) (token, rest string, found bool) {
-	i := strings.IndexByte(s, ' ')
-	if i < 0 {
-		return "", "", false
-	}
-
-	return s[:i], strings.TrimSpace(s[i+1:]), true
-}
-
-func matchesConds(ent driver.Entity, conds []eqCond) bool {
-	for _, c := range conds {
-		if asString(ent[c.prop]) != c.val {
-			return false
+		if !afterContinuation(pk, rk, opts.NextPartitionKey, opts.NextRowKey) {
+			continue
 		}
+
+		if pred != nil && !pred(se.render()) {
+			continue
+		}
+
+		if opts.Top > 0 && len(res.Entities) == opts.Top {
+			res.NextPartitionKey = pk
+			res.NextRowKey = rk
+
+			return res
+		}
+
+		res.Entities = append(res.Entities, se.render())
 	}
 
-	return true
+	return res
 }
 
-// unquote strips surrounding single quotes from an OData string literal.
-func unquote(s string) string {
-	s = strings.TrimSpace(s)
-	if len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\'' {
-		return s[1 : len(s)-1]
+// afterContinuation reports whether (pk, rk) sorts at or after the continuation
+// position. An empty continuation admits everything.
+func afterContinuation(pk, rk, nextPK, nextRK string) bool {
+	if nextPK == "" && nextRK == "" {
+		return true
 	}
 
-	return s
+	if pk != nextPK {
+		return pk > nextPK
+	}
+
+	return rk >= nextRK
+}
+
+// ApplyBatch atomically applies an entity group transaction.
+func (m *Mock) ApplyBatch(_ context.Context, table string, ops []driver.BatchOp) ([]driver.BatchResult, error) {
+	td, err := m.table(table)
+	if err != nil {
+		return nil, err
+	}
+
+	td.mu.Lock()
+	defer td.mu.Unlock()
+
+	// Snapshot for rollback: shallow-copy the map and deep-copy touched rows.
+	snapshot := make(map[string]*storedEntity, len(td.entities))
+	for k, v := range td.entities {
+		snapshot[k] = v.clone()
+	}
+
+	results := make([]driver.BatchResult, len(ops))
+
+	for i := range ops {
+		etag, opErr := m.applyOp(td, &ops[i])
+		if opErr != nil {
+			td.entities = snapshot
+
+			return nil, &driver.BatchError{Index: i, Err: opErr}
+		}
+
+		results[i] = driver.BatchResult{ETag: etag}
+	}
+
+	return results, nil
+}
+
+// applyOp applies a single batch op; td.mu must be held.
+func (m *Mock) applyOp(td *tableData, op *driver.BatchOp) (string, error) {
+	switch op.Type {
+	case driver.BatchInsert:
+		return m.insertLocked(td, op.PartitionKey, op.RowKey, op.Entity)
+	case driver.BatchUpsertReplace:
+		return m.upsertLocked(td, op, driver.UpdateModeReplace)
+	case driver.BatchUpsertMerge:
+		return m.upsertLocked(td, op, driver.UpdateModeMerge)
+	case driver.BatchUpdateReplace:
+		return m.updateLocked(td, op.PartitionKey, op.RowKey, op.Entity, driver.UpdateModeReplace, op.IfMatch)
+	case driver.BatchUpdateMerge:
+		return m.updateLocked(td, op.PartitionKey, op.RowKey, op.Entity, driver.UpdateModeMerge, op.IfMatch)
+	case driver.BatchDelete:
+		return "", deleteLocked(td, op.PartitionKey, op.RowKey, op.IfMatch)
+	default:
+		return "", errors.New(errors.InvalidArgument, "unsupported batch operation")
+	}
+}
+
+// upsertLocked inserts the entity if absent, otherwise updates it; td.mu held.
+func (m *Mock) upsertLocked(td *tableData, op *driver.BatchOp, mode driver.UpdateMode) (string, error) {
+	if _, ok := td.entities[entityKey(op.PartitionKey, op.RowKey)]; !ok {
+		return m.insertLocked(td, op.PartitionKey, op.RowKey, op.Entity)
+	}
+
+	return m.updateLocked(td, op.PartitionKey, op.RowKey, op.Entity, mode, "")
+}
+
+func (se *storedEntity) clone() *storedEntity {
+	props := make(driver.Entity, len(se.props))
+	for k, v := range se.props {
+		props[k] = v
+	}
+
+	return &storedEntity{props: props, timestamp: se.timestamp, etag: se.etag}
 }
 
 func asString(v any) string {

--- a/providers/azure/tablestorage/tablestorage_test.go
+++ b/providers/azure/tablestorage/tablestorage_test.go
@@ -1,0 +1,173 @@
+package tablestorage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	driver "github.com/stackshy/cloudemu/v2/services/tablestorage/driver"
+)
+
+func newMock(t *testing.T) *Mock {
+	t.Helper()
+
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	return New(config.NewOptions(config.WithClock(clk), config.WithAccountID("acct")))
+}
+
+func seed(t *testing.T, m *Mock, table, pk, rk string, extra driver.Entity) {
+	t.Helper()
+
+	e := driver.Entity{"PartitionKey": pk, "RowKey": rk}
+	for k, v := range extra {
+		e[k] = v
+	}
+
+	if _, err := m.InsertEntity(context.Background(), table, pk, rk, e); err != nil {
+		t.Fatalf("InsertEntity %s/%s: %v", pk, rk, err)
+	}
+}
+
+func queryRowKeys(t *testing.T, m *Mock, table, filter string) []string {
+	t.Helper()
+
+	res, err := m.QueryEntities(context.Background(), table, driver.QueryOptions{Filter: filter})
+	if err != nil {
+		t.Fatalf("QueryEntities %q: %v", filter, err)
+	}
+
+	rks := make([]string, 0, len(res.Entities))
+	for _, e := range res.Entities {
+		rks = append(rks, e["RowKey"].(string))
+	}
+
+	return rks
+}
+
+func TestFilterGrammar(t *testing.T) {
+	m := newMock(t)
+	if err := m.CreateTable(context.Background(), "t"); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	seed(t, m, "t", "p", "a", driver.Entity{"Age": 30.0, "Active": true, "Created": "2020-06-01T00:00:00Z"})
+	seed(t, m, "t", "p", "b", driver.Entity{"Age": 20.0, "Active": false, "Created": "2019-01-01T00:00:00Z"})
+	seed(t, m, "t", "p", "c", driver.Entity{"Age": 25.0, "Active": true, "Created": "2021-01-01T00:00:00Z"})
+
+	cases := []struct {
+		filter string
+		want   []string
+	}{
+		{"Age gt 25", []string{"a"}},
+		{"Age ge 25 and Active eq true", []string{"a", "c"}},
+		{"Active eq false", []string{"b"}},
+		{"not (Age eq 25)", []string{"a", "b"}},
+		{"Age lt 25 or Age gt 25", []string{"a", "b"}},
+		{"Created gt datetime'2020-01-01T00:00:00Z'", []string{"a", "c"}},
+		{"RowKey ge 'b'", []string{"b", "c"}},
+	}
+
+	for _, tc := range cases {
+		got := queryRowKeys(t, m, "t", tc.filter)
+		if !sameSet(got, tc.want) {
+			t.Errorf("filter %q = %v, want %v", tc.filter, got, tc.want)
+		}
+	}
+}
+
+func TestFilterMalformedRejected(t *testing.T) {
+	m := newMock(t)
+	_ = m.CreateTable(context.Background(), "t")
+
+	for _, bad := range []string{"Age gt", "Age foo 3", "(Age eq 1", "eq 3"} {
+		if _, err := m.QueryEntities(context.Background(), "t", driver.QueryOptions{Filter: bad}); err == nil {
+			t.Errorf("filter %q accepted, want InvalidArgument", bad)
+		} else if !cerrors.IsInvalidArgument(err) {
+			t.Errorf("filter %q error = %v, want InvalidArgument", bad, err)
+		}
+	}
+}
+
+func TestConditionalUpdateIfMatch(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+	_ = m.CreateTable(ctx, "t")
+	seed(t, m, "t", "p", "r", driver.Entity{"V": 1.0})
+
+	ent, err := m.GetEntity(ctx, "t", "p", "r")
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+
+	etag := ent["odata.etag"].(string)
+
+	// Stale/incorrect ETag → FailedPrecondition.
+	_, err = m.UpdateEntity(ctx, "t", "p", "r", driver.Entity{"V": 2.0}, driver.UpdateModeReplace, "W/\"stale\"")
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("stale If-Match error = %v, want FailedPrecondition", err)
+	}
+
+	// Correct ETag → succeeds and rotates the ETag.
+	newETag, err := m.UpdateEntity(ctx, "t", "p", "r", driver.Entity{"V": 2.0}, driver.UpdateModeReplace, etag)
+	if err != nil {
+		t.Fatalf("conditional update with current ETag: %v", err)
+	}
+
+	if newETag == etag {
+		t.Error("ETag did not change after update")
+	}
+}
+
+func TestApplyBatchAtomicRollback(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+	_ = m.CreateTable(ctx, "t")
+	seed(t, m, "t", "p", "dup", nil)
+
+	ops := []driver.BatchOp{
+		{Type: driver.BatchInsert, PartitionKey: "p", RowKey: "fresh", Entity: driver.Entity{"PartitionKey": "p", "RowKey": "fresh"}},
+		{Type: driver.BatchInsert, PartitionKey: "p", RowKey: "dup", Entity: driver.Entity{"PartitionKey": "p", "RowKey": "dup"}},
+	}
+
+	_, err := m.ApplyBatch(ctx, "t", ops)
+	if err == nil {
+		t.Fatal("ApplyBatch with a conflicting insert succeeded, want an error")
+	}
+
+	var batchErr *driver.BatchError
+	if !errors.As(err, &batchErr) || batchErr.Index != 1 {
+		t.Fatalf("ApplyBatch error = %v, want BatchError at index 1", err)
+	}
+
+	// The first insert must have been rolled back.
+	if _, err := m.GetEntity(ctx, "t", "p", "fresh"); !cerrors.IsNotFound(err) {
+		t.Errorf("entity 'fresh' present after rollback (err=%v), want NotFound", err)
+	}
+}
+
+func sameSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	seen := make(map[string]int, len(a))
+	for _, s := range a {
+		seen[s]++
+	}
+
+	for _, s := range b {
+		seen[s]--
+	}
+
+	for _, n := range seen {
+		if n != 0 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/server/azure/queue/handler.go
+++ b/server/azure/queue/handler.go
@@ -38,7 +38,12 @@ const (
 	// xmsVersion is the Queue Storage service version we report.
 	xmsVersion = "2018-03-28"
 
-	compList = "list"
+	compList     = "list"
+	compMetadata = "metadata"
+
+	// maxUpdateVisibilityTimeout is the Azure ceiling for a message's visibility
+	// timeout (7 days, in seconds).
+	maxUpdateVisibilityTimeout = 7 * 24 * 60 * 60
 
 	// maxEnqueueBodyBytes caps a single enqueued message body. Azure allows up
 	// to 64 KiB; we use a generous 1 MiB cap.
@@ -105,6 +110,10 @@ func (*Handler) Matches(r *http.Request) bool {
 		switch r.Method {
 		case http.MethodPut, http.MethodDelete:
 			return q.Get("restype") == ""
+		case http.MethodGet, http.MethodHead:
+			// GET|HEAD /{queue}?comp=metadata — queue properties. Blob container
+			// metadata carries restype=container, so this is unambiguous.
+			return q.Get("comp") == compMetadata && q.Get("restype") == ""
 		}
 	}
 
@@ -159,6 +168,11 @@ func parseQueuePath(path string) (queue, sub, msgID string) {
 }
 
 func (h *Handler) queueOp(w http.ResponseWriter, r *http.Request, queue string) {
+	if r.URL.Query().Get("comp") == compMetadata {
+		h.metadataOp(w, r, queue)
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPut:
 		h.createQueue(w, r, queue)
@@ -167,6 +181,55 @@ func (h *Handler) queueOp(w http.ResponseWriter, r *http.Request, queue string) 
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
+}
+
+// metadataOp handles GET|PUT /{queue}?comp=metadata (queue properties + metadata).
+func (h *Handler) metadataOp(w http.ResponseWriter, r *http.Request, queue string) {
+	svc, ok := h.mq.(mqdriver.AzureQueueStorage)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "queue metadata is not supported by this queue driver")
+		return
+	}
+
+	url, err := h.resolveQueueURL(r, queue)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet, http.MethodHead:
+		getQueueMetadata(w, r, svc, url)
+	case http.MethodPut:
+		setQueueMetadata(w, r, svc, url)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+func getQueueMetadata(w http.ResponseWriter, r *http.Request, svc mqdriver.AzureQueueStorage, url string) {
+	meta, err := svc.GetQueueMetadata(r.Context(), url)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.Header().Set("x-ms-approximate-messages-count", strconv.Itoa(meta.ApproximateMessageCount))
+
+	for k, v := range meta.Metadata {
+		w.Header().Set("x-ms-meta-"+k, v)
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func setQueueMetadata(w http.ResponseWriter, r *http.Request, svc mqdriver.AzureQueueStorage, url string) {
+	if err := svc.SetQueueMetadata(r.Context(), url, metadataFromHeaders(r.Header)); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request, queue string) {
@@ -225,6 +288,11 @@ func (h *Handler) messagesOp(w http.ResponseWriter, r *http.Request, queue strin
 	case http.MethodPost:
 		h.enqueue(w, r, queue)
 	case http.MethodGet:
+		if r.URL.Query().Get("peekonly") == "true" {
+			h.peek(w, r, queue)
+			return
+		}
+
 		h.dequeue(w, r, queue)
 	case http.MethodDelete:
 		// DELETE /{queue}/messages with no id = clear queue.
@@ -308,8 +376,45 @@ func (h *Handler) dequeue(w http.ResponseWriter, r *http.Request, queue string) 
 			ExpirationTime:  now.Add(7 * 24 * time.Hour).Format(time.RFC1123),
 			PopReceipt:      m.ReceiptHandle,
 			TimeNextVisible: now.Add(time.Duration(visTimeout) * time.Second).Format(time.RFC1123),
-			DequeueCount:    1,
+			DequeueCount:    int64(m.ReceiveCount),
 			MessageText:     m.Body,
+		})
+	}
+
+	writeXML(w, http.StatusOK, out)
+}
+
+// peek handles GET /{queue}/messages?peekonly=true — a non-destructive read
+// that leaves message visibility unchanged and issues no pop receipts.
+func (h *Handler) peek(w http.ResponseWriter, r *http.Request, queue string) {
+	svc, ok := h.mq.(mqdriver.AzureQueueStorage)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "peek is not supported by this queue driver")
+		return
+	}
+
+	url, err := h.resolveQueueURL(r, queue)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	maxMsgs := atoiDefault(r.URL.Query().Get("numofmessages"), 1)
+
+	msgs, err := svc.PeekMessages(r.Context(), url, maxMsgs)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := peekMessagesList{}
+	for _, m := range msgs {
+		out.Messages = append(out.Messages, peekMessageXML{
+			MessageID:      m.MessageID,
+			InsertionTime:  m.InsertedAt.UTC().Format(time.RFC1123),
+			ExpirationTime: m.ExpiresAt.UTC().Format(time.RFC1123),
+			DequeueCount:   int64(m.ReceiveCount),
+			MessageText:    m.Body,
 		})
 	}
 
@@ -331,13 +436,20 @@ func (h *Handler) clearQueue(w http.ResponseWriter, r *http.Request, queue strin
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// messageIDOp handles DELETE /{queue}/messages/{messageid}?popreceipt=….
-func (h *Handler) messageIDOp(w http.ResponseWriter, r *http.Request, queue, _ string) {
-	if r.Method != http.MethodDelete {
+// messageIDOp handles DELETE and PUT on /{queue}/messages/{messageid}.
+func (h *Handler) messageIDOp(w http.ResponseWriter, r *http.Request, queue, msgID string) {
+	switch r.Method {
+	case http.MethodDelete:
+		h.deleteMessage(w, r, queue)
+	case http.MethodPut:
+		h.updateMessage(w, r, queue, msgID)
+	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
-		return
 	}
+}
 
+// deleteMessage handles DELETE /{queue}/messages/{messageid}?popreceipt=….
+func (h *Handler) deleteMessage(w http.ResponseWriter, r *http.Request, queue string) {
 	url, err := h.resolveQueueURL(r, queue)
 	if err != nil {
 		writeErr(w, err)
@@ -355,6 +467,60 @@ func (h *Handler) messageIDOp(w http.ResponseWriter, r *http.Request, queue, _ s
 		return
 	}
 
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// updateMessage handles PUT /{queue}/messages/{id}?popreceipt=…&visibilitytimeout=….
+// It renews visibility and optionally replaces the message body, returning a new
+// pop receipt in x-ms-popreceipt (Azure Update Message).
+func (h *Handler) updateMessage(w http.ResponseWriter, r *http.Request, queue, msgID string) {
+	svc, ok := h.mq.(mqdriver.AzureQueueStorage)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "update message is not supported by this queue driver")
+		return
+	}
+
+	url, err := h.resolveQueueURL(r, queue)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	q := r.URL.Query()
+
+	popReceipt := q.Get("popreceipt")
+	if popReceipt == "" {
+		writeError(w, http.StatusBadRequest, "InvalidQueryParameterValue", "popreceipt is required")
+		return
+	}
+
+	visTimeout, ok := parseVisibilityTimeout(w, q.Get("visibilitytimeout"))
+	if !ok {
+		return
+	}
+
+	body, err := readMessageText(w, r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidXmlDocument", "malformed request body")
+		return
+	}
+
+	res, err := svc.UpdateMessage(r.Context(), url, msgID, popReceipt, visTimeout, body)
+	if err != nil {
+		// The queue was already resolved, so a NotFound here means the message
+		// or its pop receipt did not match.
+		if cerrors.IsNotFound(err) {
+			writeError(w, http.StatusNotFound, "MessageNotFound", err.Error())
+			return
+		}
+
+		writeErr(w, err)
+
+		return
+	}
+
+	w.Header().Set("x-ms-popreceipt", res.PopReceipt)
+	w.Header().Set("x-ms-time-next-visible", res.TimeNextVisible.UTC().Format(time.RFC1123))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -386,6 +552,61 @@ func atoiDefault(s string, def int) int {
 	}
 
 	return def
+}
+
+// parseVisibilityTimeout validates the required visibilitytimeout parameter for
+// Update Message: a non-negative integer no larger than 7 days. It writes a 400
+// and returns ok=false on a bad value.
+func parseVisibilityTimeout(w http.ResponseWriter, raw string) (int, bool) {
+	if raw == "" {
+		writeError(w, http.StatusBadRequest, "InvalidQueryParameterValue", "visibilitytimeout is required")
+		return 0, false
+	}
+
+	v, err := strconv.Atoi(raw)
+	if err != nil || v < 0 || v > maxUpdateVisibilityTimeout {
+		writeError(w, http.StatusBadRequest, "OutOfRangeQueryParameterValue", "visibilitytimeout is out of range")
+		return 0, false
+	}
+
+	return v, true
+}
+
+// readMessageText reads an optional <QueueMessage><MessageText> body, returning
+// nil when the body is empty (visibility-only update).
+func readMessageText(w http.ResponseWriter, r *http.Request) (*string, error) {
+	data, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxEnqueueBodyBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.TrimSpace(string(data)) == "" {
+		return nil, nil
+	}
+
+	var req enqueueRequest
+	if err := xml.Unmarshal(data, &req); err != nil {
+		return nil, err
+	}
+
+	return &req.MessageText, nil
+}
+
+// metadataFromHeaders collects x-ms-meta-{name} request headers into a map.
+func metadataFromHeaders(h http.Header) map[string]string {
+	const prefix = "X-Ms-Meta-"
+
+	out := make(map[string]string)
+
+	for k, vals := range h {
+		if len(vals) == 0 || !strings.HasPrefix(k, prefix) {
+			continue
+		}
+
+		out[strings.TrimPrefix(k, prefix)] = vals[0]
+	}
+
+	return out
 }
 
 func writeXML(w http.ResponseWriter, status int, v any) {

--- a/server/azure/queue/handler.go
+++ b/server/azure/queue/handler.go
@@ -356,11 +356,7 @@ func (h *Handler) dequeue(w http.ResponseWriter, r *http.Request, queue string) 
 	maxMsgs := atoiDefault(q.Get("numofmessages"), 1)
 	visTimeout := atoiDefault(q.Get("visibilitytimeout"), 0)
 
-	msgs, err := h.mq.ReceiveMessages(r.Context(), mqdriver.ReceiveMessageInput{
-		QueueURL:          url,
-		MaxMessages:       maxMsgs,
-		VisibilityTimeout: visTimeout,
-	})
+	msgs, err := h.dequeueMessages(r, url, maxMsgs, visTimeout)
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -382,6 +378,21 @@ func (h *Handler) dequeue(w http.ResponseWriter, r *http.Request, queue string) 
 	}
 
 	writeXML(w, http.StatusOK, out)
+}
+
+// dequeueMessages retrieves messages using the Azure Queue Storage surface when
+// the driver exposes it (respecting the 32-message max), falling back to the
+// cross-cloud receive path otherwise.
+func (h *Handler) dequeueMessages(r *http.Request, url string, maxMsgs, visTimeout int) ([]mqdriver.Message, error) {
+	if svc, ok := h.mq.(mqdriver.AzureQueueStorage); ok {
+		return svc.DequeueMessages(r.Context(), url, maxMsgs, visTimeout)
+	}
+
+	return h.mq.ReceiveMessages(r.Context(), mqdriver.ReceiveMessageInput{
+		QueueURL:          url,
+		MaxMessages:       maxMsgs,
+		VisibilityTimeout: visTimeout,
+	})
 }
 
 // peek handles GET /{queue}/messages?peekonly=true — a non-destructive read

--- a/server/azure/queue/message_ops_test.go
+++ b/server/azure/queue/message_ops_test.go
@@ -159,6 +159,84 @@ func TestQueueGetPropertiesAndSetMetadata(t *testing.T) {
 	}
 }
 
+// TestQueueDequeueUpTo32 covers the Azure Queue Storage max-messages limit: a
+// single Get Messages call may return up to 32 messages, not Service Bus's 10.
+func TestQueueDequeueUpTo32(t *testing.T) {
+	ctx := context.Background()
+	qc := newQueueClient(t, "maxq")
+
+	const want = 12
+	for range [want]int{} {
+		if _, err := qc.EnqueueMessage(ctx, "m", nil); err != nil {
+			t.Fatalf("EnqueueMessage: %v", err)
+		}
+	}
+
+	deq, err := qc.DequeueMessages(ctx, &azqueue.DequeueMessagesOptions{
+		NumberOfMessages: to.Ptr(int32(want)),
+	})
+	if err != nil {
+		t.Fatalf("DequeueMessages: %v", err)
+	}
+
+	if len(deq.Messages) != want {
+		t.Fatalf("dequeued %d messages, want %d (Azure allows up to 32 per call)", len(deq.Messages), want)
+	}
+}
+
+// TestQueuePeekUpTo32 covers the same 32-message limit on the Peek Messages path.
+func TestQueuePeekUpTo32(t *testing.T) {
+	ctx := context.Background()
+	qc := newQueueClient(t, "peekmaxq")
+
+	const want = 12
+	for range [want]int{} {
+		if _, err := qc.EnqueueMessage(ctx, "m", nil); err != nil {
+			t.Fatalf("EnqueueMessage: %v", err)
+		}
+	}
+
+	peek, err := qc.PeekMessages(ctx, &azqueue.PeekMessagesOptions{
+		NumberOfMessages: to.Ptr(int32(want)),
+	})
+	if err != nil {
+		t.Fatalf("PeekMessages: %v", err)
+	}
+
+	if len(peek.Messages) != want {
+		t.Fatalf("peeked %d messages, want %d (Azure allows up to 32 per call)", len(peek.Messages), want)
+	}
+}
+
+// TestQueueMetadataCountsInFlight covers the x-ms-approximate-messages-count
+// semantics: the count reflects total messages in the queue, including ones that
+// are invisible because they are mid-flight (dequeued but not yet deleted).
+func TestQueueMetadataCountsInFlight(t *testing.T) {
+	ctx := context.Background()
+	qc := newQueueClient(t, "inflightq")
+
+	for range [2]int{} {
+		if _, err := qc.EnqueueMessage(ctx, "m", nil); err != nil {
+			t.Fatalf("EnqueueMessage: %v", err)
+		}
+	}
+
+	// Dequeue one message; it becomes invisible for the visibility timeout but
+	// remains in the queue until deleted.
+	if _, err := qc.DequeueMessage(ctx, nil); err != nil {
+		t.Fatalf("DequeueMessage: %v", err)
+	}
+
+	props, err := qc.GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties: %v", err)
+	}
+
+	if props.ApproximateMessagesCount == nil || *props.ApproximateMessagesCount != 2 {
+		t.Errorf("ApproximateMessagesCount = %v, want 2 (both visible and in-flight)", props.ApproximateMessagesCount)
+	}
+}
+
 // TestQueueDequeueCountIncrements covers finding #9: DequeueCount reflects the
 // real number of receives, not a hardcoded 1.
 func TestQueueDequeueCountIncrements(t *testing.T) {

--- a/server/azure/queue/message_ops_test.go
+++ b/server/azure/queue/message_ops_test.go
@@ -1,0 +1,201 @@
+package queue_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func newQueueClient(t *testing.T, name string) *azqueue.QueueClient {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{QueueStorage: cloudP.QueueStorage})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	opts := &azqueue.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}},
+	}
+
+	svc, err := azqueue.NewServiceClientWithNoCredential(ts.URL+"/", opts)
+	if err != nil {
+		t.Fatalf("NewServiceClientWithNoCredential: %v", err)
+	}
+
+	if _, err := svc.CreateQueue(context.Background(), name, nil); err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	qc, err := azqueue.NewQueueClientWithNoCredential(ts.URL+"/"+name, opts)
+	if err != nil {
+		t.Fatalf("NewQueueClientWithNoCredential: %v", err)
+	}
+
+	return qc
+}
+
+// TestQueuePeekIsNonDestructive covers finding #4: a peek leaves the message on
+// the queue so a later dequeue still returns it.
+func TestQueuePeekIsNonDestructive(t *testing.T) {
+	ctx := context.Background()
+	qc := newQueueClient(t, "peekq")
+
+	if _, err := qc.EnqueueMessage(ctx, "payload", nil); err != nil {
+		t.Fatalf("EnqueueMessage: %v", err)
+	}
+
+	peek, err := qc.PeekMessage(ctx, nil)
+	if err != nil {
+		t.Fatalf("PeekMessage: %v", err)
+	}
+
+	if len(peek.Messages) != 1 || peek.Messages[0].MessageText == nil || *peek.Messages[0].MessageText != "payload" {
+		t.Fatalf("peek = %+v, want the payload", peek.Messages)
+	}
+
+	// The peek must not have hidden the message.
+	deq, err := qc.DequeueMessage(ctx, nil)
+	if err != nil {
+		t.Fatalf("DequeueMessage: %v", err)
+	}
+
+	if len(deq.Messages) != 1 {
+		t.Fatalf("dequeue after peek returned %d messages, want 1", len(deq.Messages))
+	}
+}
+
+// TestQueueUpdateMessage covers finding #5: Update Message renews visibility,
+// replaces the body, and returns a fresh pop receipt.
+func TestQueueUpdateMessage(t *testing.T) {
+	ctx := context.Background()
+	qc := newQueueClient(t, "updq")
+
+	if _, err := qc.EnqueueMessage(ctx, "original", nil); err != nil {
+		t.Fatalf("EnqueueMessage: %v", err)
+	}
+
+	deq, err := qc.DequeueMessage(ctx, nil)
+	if err != nil {
+		t.Fatalf("DequeueMessage: %v", err)
+	}
+
+	msg := deq.Messages[0]
+
+	upd, err := qc.UpdateMessage(ctx, *msg.MessageID, *msg.PopReceipt, "updated",
+		&azqueue.UpdateMessageOptions{VisibilityTimeout: to.Ptr(int32(0))})
+	if err != nil {
+		t.Fatalf("UpdateMessage: %v", err)
+	}
+
+	if upd.PopReceipt == nil || *upd.PopReceipt == *msg.PopReceipt {
+		t.Errorf("UpdateMessage did not return a fresh pop receipt: %+v", upd.PopReceipt)
+	}
+
+	peek, err := qc.PeekMessage(ctx, nil)
+	if err != nil {
+		t.Fatalf("PeekMessage: %v", err)
+	}
+
+	if len(peek.Messages) != 1 || peek.Messages[0].MessageText == nil || *peek.Messages[0].MessageText != "updated" {
+		t.Fatalf("peek after update = %+v, want body 'updated'", peek.Messages)
+	}
+}
+
+// TestQueueUpdateMessageBadReceipt: an unknown pop receipt is a 404 MessageNotFound.
+func TestQueueUpdateMessageBadReceipt(t *testing.T) {
+	ctx := context.Background()
+	qc := newQueueClient(t, "updbad")
+
+	enq, err := qc.EnqueueMessage(ctx, "x", nil)
+	if err != nil {
+		t.Fatalf("EnqueueMessage: %v", err)
+	}
+
+	_, err = qc.UpdateMessage(ctx, *enq.Messages[0].MessageID, "not-a-real-receipt", "y", nil)
+	if err == nil {
+		t.Fatal("UpdateMessage with a bogus pop receipt succeeded, want an error")
+	}
+}
+
+// TestQueueGetPropertiesAndSetMetadata covers finding #6: queue metadata and the
+// approximate message count are served.
+func TestQueueGetPropertiesAndSetMetadata(t *testing.T) {
+	ctx := context.Background()
+	qc := newQueueClient(t, "metaq")
+
+	// HTTP header canonicalization title-cases metadata keys on the wire, so we
+	// use an already-canonical key to keep the round-trip deterministic.
+	if _, err := qc.SetMetadata(ctx, &azqueue.SetMetadataOptions{
+		Metadata: map[string]*string{"Team": to.Ptr("payments")},
+	}); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+
+	for range [2]int{} {
+		if _, err := qc.EnqueueMessage(ctx, "m", nil); err != nil {
+			t.Fatalf("EnqueueMessage: %v", err)
+		}
+	}
+
+	props, err := qc.GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties: %v", err)
+	}
+
+	if props.ApproximateMessagesCount == nil || *props.ApproximateMessagesCount != 2 {
+		t.Errorf("ApproximateMessagesCount = %v, want 2", props.ApproximateMessagesCount)
+	}
+
+	if v, ok := props.Metadata["Team"]; !ok || v == nil || *v != "payments" {
+		t.Errorf("metadata Team = %v, want payments", props.Metadata["Team"])
+	}
+}
+
+// TestQueueDequeueCountIncrements covers finding #9: DequeueCount reflects the
+// real number of receives, not a hardcoded 1.
+func TestQueueDequeueCountIncrements(t *testing.T) {
+	ctx := context.Background()
+	qc := newQueueClient(t, "dcq")
+
+	if _, err := qc.EnqueueMessage(ctx, "m", nil); err != nil {
+		t.Fatalf("EnqueueMessage: %v", err)
+	}
+
+	first, err := qc.DequeueMessage(ctx, nil)
+	if err != nil {
+		t.Fatalf("first DequeueMessage: %v", err)
+	}
+
+	if c := first.Messages[0].DequeueCount; c == nil || *c != 1 {
+		t.Fatalf("first dequeue count = %v, want 1", c)
+	}
+
+	msg := first.Messages[0]
+
+	// Make the message visible again without incrementing its dequeue count.
+	if _, err := qc.UpdateMessage(ctx, *msg.MessageID, *msg.PopReceipt, "m",
+		&azqueue.UpdateMessageOptions{VisibilityTimeout: to.Ptr(int32(0))}); err != nil {
+		t.Fatalf("UpdateMessage: %v", err)
+	}
+
+	second, err := qc.DequeueMessage(ctx, nil)
+	if err != nil {
+		t.Fatalf("second DequeueMessage: %v", err)
+	}
+
+	if len(second.Messages) != 1 {
+		t.Fatalf("second dequeue returned %d messages, want 1", len(second.Messages))
+	}
+
+	if c := second.Messages[0].DequeueCount; c == nil || *c != 2 {
+		t.Fatalf("second dequeue count = %v, want 2", c)
+	}
+}

--- a/server/azure/queue/types.go
+++ b/server/azure/queue/types.go
@@ -30,6 +30,22 @@ type messageXML struct {
 	MessageText     string `xml:"MessageText,omitempty"`
 }
 
+// peekMessagesList is the QueueMessagesList body returned by Peek Messages. It
+// omits PopReceipt and TimeNextVisible (a peek is non-destructive) and always
+// renders DequeueCount, matching the real service.
+type peekMessagesList struct {
+	XMLName  xml.Name         `xml:"QueueMessagesList"`
+	Messages []peekMessageXML `xml:"QueueMessage"`
+}
+
+type peekMessageXML struct {
+	MessageID      string `xml:"MessageId"`
+	InsertionTime  string `xml:"InsertionTime"`
+	ExpirationTime string `xml:"ExpirationTime"`
+	DequeueCount   int64  `xml:"DequeueCount"`
+	MessageText    string `xml:"MessageText"`
+}
+
 // listQueuesResult is the EnumerationResults body for GET /?comp=list.
 type listQueuesResult struct {
 	XMLName    xml.Name   `xml:"EnumerationResults"`

--- a/server/azure/tablestorage/batch.go
+++ b/server/azure/tablestorage/batch.go
@@ -1,0 +1,378 @@
+package tablestorage
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	driver "github.com/stackshy/cloudemu/v2/services/tablestorage/driver"
+)
+
+// maxBatchBytes caps a whole entity-group-transaction payload (Azure allows 4 MiB).
+const maxBatchBytes = 4 << 20
+
+// maxBatchOps is the Table service limit of operations per change set.
+const maxBatchOps = 100
+
+// methodMerge is the OData MERGE verb used by change-set merge operations.
+const methodMerge = "MERGE"
+
+func batchErr(msg string) error {
+	return cerrors.New(cerrors.InvalidArgument, msg)
+}
+
+// batch handles POST /$batch — an OData entity group transaction. It parses the
+// multipart/mixed batch + change set, applies the operations atomically, and
+// returns the multipart/mixed batch response the aztables client expects.
+func (h *Handler) batch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	ops, table, err := parseBatch(w, r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidInput", err.Error())
+		return
+	}
+
+	if len(ops) == 0 {
+		writeError(w, http.StatusBadRequest, "InvalidInput", "empty change set")
+		return
+	}
+
+	if len(ops) > maxBatchOps {
+		writeError(w, http.StatusBadRequest, "InvalidInput", "change set exceeds 100 operations")
+		return
+	}
+
+	results, applyErr := h.ts.ApplyBatch(r.Context(), table, ops)
+	if applyErr != nil {
+		writeBatchFailure(w, applyErr)
+		return
+	}
+
+	writeBatchSuccess(w, ops, results)
+}
+
+// parseBatch decodes the multipart batch body into an ordered op list and the
+// (single) target table name.
+func parseBatch(w http.ResponseWriter, r *http.Request) ([]driver.BatchOp, string, error) {
+	changeset, err := changesetReader(w, r)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var (
+		ops   []driver.BatchOp
+		table string
+	)
+
+	for {
+		part, perr := changeset.NextPart()
+		if errors.Is(perr, io.EOF) {
+			break
+		}
+
+		if perr != nil {
+			return nil, "", fmt.Errorf("malformed change set: %w", perr)
+		}
+
+		raw, rerr := io.ReadAll(part)
+		if rerr != nil {
+			return nil, "", rerr
+		}
+
+		op, opTable, oerr := parseInnerRequest(raw)
+		if oerr != nil {
+			return nil, "", oerr
+		}
+
+		if table == "" {
+			table = opTable
+		}
+
+		ops = append(ops, op)
+	}
+
+	return ops, table, nil
+}
+
+// changesetReader unwraps the outer batch part and returns a reader over the
+// inner change set's operations.
+func changesetReader(w http.ResponseWriter, r *http.Request) (*multipart.Reader, error) {
+	boundary, err := boundaryOf(r.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, err
+	}
+
+	body := http.MaxBytesReader(w, r.Body, maxBatchBytes)
+	outer := multipart.NewReader(body, boundary)
+
+	part, err := outer.NextPart()
+	if err != nil {
+		return nil, fmt.Errorf("empty batch: %w", err)
+	}
+
+	inner, err := boundaryOf(part.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, err
+	}
+
+	return multipart.NewReader(part, inner), nil
+}
+
+func boundaryOf(contentType string) (string, error) {
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return "", fmt.Errorf("invalid multipart content type: %w", err)
+	}
+
+	boundary, ok := params["boundary"]
+	if !ok || boundary == "" {
+		return "", batchErr("missing multipart boundary")
+	}
+
+	return boundary, nil
+}
+
+// parseInnerRequest turns one application/http change-set part into a BatchOp.
+// The multipart reader has already stripped the part's MIME headers, so raw is
+// the embedded HTTP request ("POST … HTTP/1.1\r\n<headers>\r\n\r\n<body>").
+func parseInnerRequest(raw []byte) (driver.BatchOp, string, error) {
+	req, err := http.ReadRequest(bufio.NewReader(bytes.NewReader(raw)))
+	if err != nil {
+		return driver.BatchOp{}, "", fmt.Errorf("malformed inner request: %w", err)
+	}
+
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		return driver.BatchOp{}, "", err
+	}
+
+	path := strings.TrimPrefix(req.URL.Path, "/")
+
+	if !strings.ContainsRune(path, '(') {
+		return insertOp(path, bodyBytes)
+	}
+
+	table, predicate, ok := splitEntityPath(path)
+	if !ok {
+		return driver.BatchOp{}, "", batchErr("malformed entity path in change set")
+	}
+
+	pk, rk, ok := parseKeyPredicate(predicate)
+	if !ok {
+		return driver.BatchOp{}, "", batchErr("malformed key predicate in change set")
+	}
+
+	op, err := entityOpFromRequest(req, pk, rk, bodyBytes)
+	if err != nil {
+		return driver.BatchOp{}, "", err
+	}
+
+	return op, table, nil
+}
+
+// insertOp builds an insert op from a bare "POST /{table}" change-set request.
+func insertOp(table string, body []byte) (driver.BatchOp, string, error) {
+	ent, err := decodeEntity(body)
+	if err != nil {
+		return driver.BatchOp{}, "", err
+	}
+
+	return driver.BatchOp{
+		Type:         driver.BatchInsert,
+		PartitionKey: asString(ent["PartitionKey"]),
+		RowKey:       asString(ent["RowKey"]),
+		Entity:       ent,
+	}, table, nil
+}
+
+// entityOpFromRequest maps a keyed change-set request (PUT/MERGE/PATCH/DELETE)
+// to a BatchOp, distinguishing upsert (no If-Match) from update (If-Match set).
+func entityOpFromRequest(req *http.Request, pk, rk string, body []byte) (driver.BatchOp, error) {
+	ifMatch := req.Header.Get("If-Match")
+
+	op := driver.BatchOp{PartitionKey: pk, RowKey: rk, IfMatch: ifMatch}
+
+	if req.Method == http.MethodDelete {
+		op.Type = driver.BatchDelete
+		return op, nil
+	}
+
+	ent, err := decodeEntity(body)
+	if err != nil {
+		return driver.BatchOp{}, err
+	}
+
+	op.Entity = ent
+
+	switch req.Method {
+	case http.MethodPut:
+		op.Type = pick(ifMatch, driver.BatchUpdateReplace, driver.BatchUpsertReplace)
+	case http.MethodPatch, methodMerge:
+		op.Type = pick(ifMatch, driver.BatchUpdateMerge, driver.BatchUpsertMerge)
+	default:
+		return driver.BatchOp{}, cerrors.Newf(cerrors.InvalidArgument, "unsupported change-set method %q", req.Method)
+	}
+
+	return op, nil
+}
+
+// pick returns whenSet when an If-Match precondition is present, else whenUnset.
+func pick(ifMatch string, whenSet, whenUnset driver.BatchOpType) driver.BatchOpType {
+	if ifMatch != "" {
+		return whenSet
+	}
+
+	return whenUnset
+}
+
+func decodeEntity(body []byte) (driver.Entity, error) {
+	var ent driver.Entity
+	if err := json.Unmarshal(body, &ent); err != nil {
+		return nil, fmt.Errorf("malformed entity in change set: %w", err)
+	}
+
+	return ent, nil
+}
+
+// changeSet is a rendered change-set multipart document plus its boundary.
+type changeSet struct {
+	body     []byte
+	boundary string
+}
+
+// writeBatchSuccess emits a 202 batch response whose single change set reports
+// each op's outcome (204 No Content, with the new ETag for writes).
+func writeBatchSuccess(w http.ResponseWriter, ops []driver.BatchOp, results []driver.BatchResult) {
+	cs := buildChangeset(func(cw *multipart.Writer) {
+		for i := range ops {
+			writeOpPart(cw, opSuccessResponse(i, ops[i], results[i]))
+		}
+	})
+
+	writeBatchEnvelope(w, cs)
+}
+
+// writeBatchFailure emits a 202 batch response whose change set carries the
+// single failed op as a 4xx sub-response (atomic: nothing was applied).
+func writeBatchFailure(w http.ResponseWriter, err error) {
+	idx := 0
+
+	var be *driver.BatchError
+	if errors.As(err, &be) {
+		idx = be.Index
+	}
+
+	status, code := mapErr(err)
+
+	cs := buildChangeset(func(cw *multipart.Writer) {
+		writeOpPart(cw, opErrorResponse(idx, status, code, err.Error()))
+	})
+
+	writeBatchEnvelope(w, cs)
+}
+
+// buildChangeset renders a change-set multipart document via fn.
+func buildChangeset(fn func(*multipart.Writer)) changeSet {
+	var buf bytes.Buffer
+
+	cw := multipart.NewWriter(&buf)
+	fn(cw)
+	_ = cw.Close()
+
+	return changeSet{body: buf.Bytes(), boundary: cw.Boundary()}
+}
+
+// writeOpPart writes one application/http sub-response into the change set.
+func writeOpPart(cw *multipart.Writer, payload string) {
+	hdr := textproto.MIMEHeader{
+		"Content-Type":              {"application/http"},
+		"Content-Transfer-Encoding": {"binary"},
+	}
+
+	part, err := cw.CreatePart(hdr)
+	if err != nil {
+		return
+	}
+
+	_, _ = io.WriteString(part, payload)
+}
+
+// writeBatchEnvelope wraps the change set in the outer batch multipart body and
+// writes the 202 response.
+func writeBatchEnvelope(w http.ResponseWriter, cs changeSet) {
+	var buf bytes.Buffer
+
+	bw := multipart.NewWriter(&buf)
+
+	part, err := bw.CreatePart(textproto.MIMEHeader{
+		"Content-Type": {"multipart/mixed; boundary=" + cs.boundary},
+	})
+	if err == nil {
+		_, _ = part.Write(cs.body)
+	}
+
+	_ = bw.Close()
+
+	w.Header().Set("Content-Type", "multipart/mixed; boundary="+bw.Boundary())
+	w.WriteHeader(http.StatusAccepted)
+	_, _ = w.Write(buf.Bytes())
+}
+
+// opSuccessResponse renders the embedded HTTP response for a successful op.
+func opSuccessResponse(idx int, op driver.BatchOp, res driver.BatchResult) string {
+	var b strings.Builder
+
+	b.WriteString("HTTP/1.1 204 No Content\r\n")
+	fmt.Fprintf(&b, "Content-ID: %d\r\n", idx+1)
+	b.WriteString("X-Content-Type-Options: nosniff\r\n")
+	b.WriteString("Cache-Control: no-cache\r\n")
+	b.WriteString("DataServiceVersion: 3.0;\r\n")
+
+	if op.Type != driver.BatchDelete && res.ETag != "" {
+		fmt.Fprintf(&b, "ETag: %s\r\n", res.ETag)
+	}
+
+	b.WriteString("\r\n")
+
+	return b.String()
+}
+
+// opErrorResponse renders the embedded HTTP response for the failed op. The
+// error message is prefixed with the op index, as the real service does.
+func opErrorResponse(idx, status int, code, msg string) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "HTTP/1.1 %d %s\r\n", status, http.StatusText(status))
+	fmt.Fprintf(&b, "Content-ID: %d\r\n", idx+1)
+	b.WriteString("X-Content-Type-Options: nosniff\r\n")
+	b.WriteString("Content-Type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8\r\n")
+	b.WriteString("\r\n")
+
+	body := map[string]any{
+		"odata.error": map[string]any{
+			"code": code,
+			"message": map[string]any{
+				"lang":  "en-US",
+				"value": fmt.Sprintf("%d:%s", idx, msg),
+			},
+		},
+	}
+
+	encoded, _ := json.Marshal(body)
+	b.Write(encoded)
+
+	return b.String()
+}

--- a/server/azure/tablestorage/batch.go
+++ b/server/azure/tablestorage/batch.go
@@ -55,6 +55,11 @@ func (h *Handler) batch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if code, msg, ok := validateBatchPartitions(ops); !ok {
+		writeError(w, http.StatusBadRequest, code, msg)
+		return
+	}
+
 	results, applyErr := h.ts.ApplyBatch(r.Context(), table, ops)
 	if applyErr != nil {
 		writeBatchFailure(w, applyErr)
@@ -62,6 +67,32 @@ func (h *Handler) batch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeBatchSuccess(w, ops, results)
+}
+
+// validateBatchPartitions enforces Azure's entity-group-transaction rules: every
+// operation must target the same PartitionKey, and an entity — identified by its
+// (PartitionKey, RowKey) — may appear at most once. It returns the Azure error
+// code and message when a rule is violated. ops must be non-empty.
+func validateBatchPartitions(ops []driver.BatchOp) (code, msg string, ok bool) {
+	partition := ops[0].PartitionKey
+	seen := make(map[string]struct{}, len(ops))
+
+	for _, op := range ops {
+		if op.PartitionKey != partition {
+			return "CommandsInBatchActOnDifferentPartitions",
+				"all commands in a batch transaction must operate on the same partition key", false
+		}
+
+		key := op.PartitionKey + "\x00" + op.RowKey
+		if _, dup := seen[key]; dup {
+			return "InvalidDuplicateRow",
+				"an entity can appear only once in a batch transaction", false
+		}
+
+		seen[key] = struct{}{}
+	}
+
+	return "", "", true
 }
 
 // parseBatch decodes the multipart batch body into an ordered op list and the

--- a/server/azure/tablestorage/batch_test.go
+++ b/server/azure/tablestorage/batch_test.go
@@ -1,8 +1,15 @@
 package tablestorage_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
@@ -94,5 +101,115 @@ func TestSubmitTransactionRollsBack(t *testing.T) {
 	// Because the batch failed atomically, the first insert must NOT have landed.
 	if _, err := client.GetEntity(ctx, "p", "fresh", nil); err == nil {
 		t.Error("entity 'fresh' exists after a rolled-back batch, want it absent")
+	}
+}
+
+// buildRawBatch renders a raw multipart/mixed $batch body with one change set of
+// insert operations, bypassing the aztables client-side partition-key check so
+// the server's own validation can be exercised.
+func buildRawBatch(t *testing.T, table string, entities [][]byte) (contentType string, body []byte) {
+	t.Helper()
+
+	var changeset bytes.Buffer
+
+	cw := multipart.NewWriter(&changeset)
+
+	for _, ent := range entities {
+		part, err := cw.CreatePart(textproto.MIMEHeader{
+			"Content-Type":              {"application/http"},
+			"Content-Transfer-Encoding": {"binary"},
+		})
+		if err != nil {
+			t.Fatalf("create change-set part: %v", err)
+		}
+
+		var inner bytes.Buffer
+
+		fmt.Fprintf(&inner, "POST /%s HTTP/1.1\r\n", table)
+		inner.WriteString("Content-Type: application/json\r\n")
+		fmt.Fprintf(&inner, "Content-Length: %d\r\n\r\n", len(ent))
+		inner.Write(ent)
+
+		if _, err := part.Write(inner.Bytes()); err != nil {
+			t.Fatalf("write inner request: %v", err)
+		}
+	}
+
+	_ = cw.Close()
+
+	var batch bytes.Buffer
+
+	bw := multipart.NewWriter(&batch)
+
+	part, err := bw.CreatePart(textproto.MIMEHeader{
+		"Content-Type": {"multipart/mixed; boundary=" + cw.Boundary()},
+	})
+	if err != nil {
+		t.Fatalf("create batch part: %v", err)
+	}
+
+	if _, err := part.Write(changeset.Bytes()); err != nil {
+		t.Fatalf("write change set: %v", err)
+	}
+
+	_ = bw.Close()
+
+	return "multipart/mixed; boundary=" + bw.Boundary(), batch.Bytes()
+}
+
+// postRawBatch submits a raw $batch body and returns the response body text.
+func postRawBatch(t *testing.T, ts, contentType string, body []byte) string {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodPost, ts+"/$batch", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new batch request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do batch request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read batch response: %v", err)
+	}
+
+	return string(out)
+}
+
+// TestBatchMixedPartitionKeysRejected covers the entity-group-transaction rule
+// that all operations must share one PartitionKey; a mixed batch is rejected.
+func TestBatchMixedPartitionKeysRejected(t *testing.T) {
+	_, ts := newTableClient(t, "mixpk")
+
+	contentType, body := buildRawBatch(t, "mixpk", [][]byte{
+		marshalEntity(t, "p", "a", nil),
+		marshalEntity(t, "q", "b", nil),
+	})
+
+	got := postRawBatch(t, ts.URL, contentType, body)
+	if !strings.Contains(got, "CommandsInBatchActOnDifferentPartitions") {
+		t.Fatalf("mixed-partition batch response = %q, want CommandsInBatchActOnDifferentPartitions", got)
+	}
+}
+
+// TestBatchDuplicateEntityRejected covers the rule that an entity may appear only
+// once in a transaction; a duplicate (PartitionKey, RowKey) is rejected.
+func TestBatchDuplicateEntityRejected(t *testing.T) {
+	_, ts := newTableClient(t, "dupent")
+
+	contentType, body := buildRawBatch(t, "dupent", [][]byte{
+		marshalEntity(t, "p", "a", nil),
+		marshalEntity(t, "p", "a", nil),
+	})
+
+	got := postRawBatch(t, ts.URL, contentType, body)
+	if !strings.Contains(got, "InvalidDuplicateRow") {
+		t.Fatalf("duplicate-entity batch response = %q, want InvalidDuplicateRow", got)
 	}
 }

--- a/server/azure/tablestorage/batch_test.go
+++ b/server/azure/tablestorage/batch_test.go
@@ -1,0 +1,98 @@
+package tablestorage_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
+)
+
+func marshalEntity(t *testing.T, pk, rk string, extra map[string]any) []byte {
+	t.Helper()
+
+	e := map[string]any{"PartitionKey": pk, "RowKey": rk}
+	for k, v := range extra {
+		e[k] = v
+	}
+
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal entity: %v", err)
+	}
+
+	return b
+}
+
+// TestSubmitTransactionApplies covers finding #1: an entity group transaction
+// ($batch) inserts and merges entities atomically and the changes are visible.
+func TestSubmitTransactionApplies(t *testing.T) {
+	ctx := context.Background()
+	client, _ := newTableClient(t, "txn")
+
+	// Seed an entity we will merge in the transaction.
+	if _, err := client.AddEntity(ctx, marshalEntity(t, "p", "existing", map[string]any{"V": 1}), nil); err != nil {
+		t.Fatalf("seed AddEntity: %v", err)
+	}
+
+	actions := []aztables.TransactionAction{
+		{ActionType: aztables.TransactionTypeAdd, Entity: marshalEntity(t, "p", "a", map[string]any{"V": 10})},
+		{ActionType: aztables.TransactionTypeAdd, Entity: marshalEntity(t, "p", "b", map[string]any{"V": 20})},
+		{
+			ActionType: aztables.TransactionTypeUpdateMerge,
+			Entity:     marshalEntity(t, "p", "existing", map[string]any{"W": 2}),
+		},
+	}
+
+	if _, err := client.SubmitTransaction(ctx, actions, nil); err != nil {
+		t.Fatalf("SubmitTransaction: %v", err)
+	}
+
+	// The two inserts landed.
+	for _, rk := range []string{"a", "b"} {
+		if _, err := client.GetEntity(ctx, "p", rk, nil); err != nil {
+			t.Errorf("GetEntity %q after batch: %v", rk, err)
+		}
+	}
+
+	// The merge added W while keeping V.
+	got, err := client.GetEntity(ctx, "p", "existing", nil)
+	if err != nil {
+		t.Fatalf("GetEntity existing: %v", err)
+	}
+
+	var props map[string]any
+	if err := json.Unmarshal(got.Value, &props); err != nil {
+		t.Fatalf("unmarshal existing: %v", err)
+	}
+
+	if props["V"] == nil || props["W"] == nil {
+		t.Errorf("merged entity = %v, want both V and W present", props)
+	}
+}
+
+// TestSubmitTransactionRollsBack covers finding #1's atomicity: a failing op
+// (insert of an already-existing row) rolls the whole change set back.
+func TestSubmitTransactionRollsBack(t *testing.T) {
+	ctx := context.Background()
+	client, _ := newTableClient(t, "txnrb")
+
+	if _, err := client.AddEntity(ctx, marshalEntity(t, "p", "dup", nil), nil); err != nil {
+		t.Fatalf("seed AddEntity: %v", err)
+	}
+
+	actions := []aztables.TransactionAction{
+		{ActionType: aztables.TransactionTypeAdd, Entity: marshalEntity(t, "p", "fresh", nil)},
+		// This insert conflicts with the seeded row and must fail the batch.
+		{ActionType: aztables.TransactionTypeAdd, Entity: marshalEntity(t, "p", "dup", nil)},
+	}
+
+	if _, err := client.SubmitTransaction(ctx, actions, nil); err == nil {
+		t.Fatal("SubmitTransaction with a conflicting insert succeeded, want an error")
+	}
+
+	// Because the batch failed atomically, the first insert must NOT have landed.
+	if _, err := client.GetEntity(ctx, "p", "fresh", nil); err == nil {
+		t.Error("entity 'fresh' exists after a rolled-back batch, want it absent")
+	}
+}

--- a/server/azure/tablestorage/fidelity_test.go
+++ b/server/azure/tablestorage/fidelity_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 
@@ -109,18 +110,66 @@ func TestQueryFilterActuallyFilters(t *testing.T) {
 	}
 }
 
-// TestQueryUnsupportedFilterRejected covers #266: an unsupported operator must
-// return 400 InvalidInput, not silently match everything.
-func TestQueryUnsupportedFilterRejected(t *testing.T) {
+// TestQueryRangeAndLogicalFilters covers the full OData grammar: comparison
+// operators (gt/ge/lt/le/ne), logical or/and/not, and parentheses.
+func TestQueryRangeAndLogicalFilters(t *testing.T) {
 	client, _ := newTableClient(t, "flt2")
-	addEntity(t, client, "org", "alice", map[string]any{"Age": int64(30)})
-	addEntity(t, client, "org", "bob", map[string]any{"Age": int64(20)})
+	addEntity(t, client, "org", "alice", map[string]any{"Age": 30})
+	addEntity(t, client, "org", "bob", map[string]any{"Age": 20})
+	addEntity(t, client, "org", "carol", map[string]any{"Age": 25})
 
-	if _, err := listRowKeys(t, client, "Age gt 25"); err == nil {
-		t.Fatal("unsupported $filter 'Age gt 25' returned no error (degraded to match-all)")
+	sorted := func(rks []string) []string { sort.Strings(rks); return rks }
+
+	cases := []struct {
+		filter string
+		want   []string
+	}{
+		{"Age gt 25", []string{"alice"}},
+		{"Age ge 25", []string{"alice", "carol"}},
+		{"Age lt 25", []string{"bob"}},
+		{"Age ne 25", []string{"alice", "bob"}},
+		{"Age gt 20 and Age lt 30", []string{"carol"}},
+		{"Age lt 25 or Age gt 25", []string{"alice", "bob"}},
+		{"not (Age eq 25)", []string{"alice", "bob"}},
+	}
+
+	for _, tc := range cases {
+		rks, err := listRowKeys(t, client, tc.filter)
+		if err != nil {
+			t.Fatalf("filter %q: %v", tc.filter, err)
+		}
+
+		if got := sorted(rks); !equalStrings(got, tc.want) {
+			t.Errorf("filter %q = %v, want %v", tc.filter, got, tc.want)
+		}
+	}
+}
+
+// TestQueryMalformedFilterRejected: a syntactically broken $filter is a 400,
+// not a silent match-all.
+func TestQueryMalformedFilterRejected(t *testing.T) {
+	client, _ := newTableClient(t, "flt3")
+	addEntity(t, client, "org", "alice", map[string]any{"Age": 30})
+
+	if _, err := listRowKeys(t, client, "Age gt"); err == nil {
+		t.Fatal("malformed $filter 'Age gt' returned no error")
 	} else if !strings.Contains(err.Error(), "InvalidInput") {
 		t.Fatalf("error = %v, want InvalidInput (400)", err)
 	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
 }
 
 // TestGetEntitySingleKeyPredicateRejected covers #266: a key predicate that

--- a/server/azure/tablestorage/handler.go
+++ b/server/azure/tablestorage/handler.go
@@ -14,10 +14,11 @@
 //	MERGE|PATCH /{table}(PartitionKey='p',RowKey='r')     — merge entity
 //	DELETE /{table}(PartitionKey='p',RowKey='r')          — delete entity
 //	GET    /{table}()?$filter=…                           — query entities
+//	POST   /$batch                                        — entity group transaction
 //
-// Access policies and transactional batches are out of scope. Upsert (a PUT or
-// MERGE with no If-Match header against a missing row) is supported as an
-// insert-or-replace/merge, matching aztables UpsertEntity.
+// Access policies are out of scope. Upsert (a PUT or MERGE with no If-Match
+// header against a missing row) is supported as an insert-or-replace/merge,
+// matching aztables UpsertEntity.
 package tablestorage
 
 import (
@@ -39,6 +40,12 @@ const (
 
 	// maxBodyBytes caps request bodies (entities / table-create payloads).
 	maxBodyBytes = 1 << 20
+
+	// etagProp is the system property carrying an entity's ETag on read.
+	etagProp = "odata.etag"
+
+	// pathBatch is the entity-group-transaction endpoint path segment.
+	pathBatch = "$batch"
 )
 
 // Handler serves Azure Table Storage REST requests against a TableStorage
@@ -73,6 +80,11 @@ func (*Handler) Matches(r *http.Request) bool {
 	}
 
 	path := strings.TrimPrefix(r.URL.Path, "/")
+
+	// /$batch — entity group transactions.
+	if path == pathBatch {
+		return true
+	}
 
 	// /Tables and /Tables('name').
 	if path == "Tables" || strings.HasPrefix(path, "Tables(") {
@@ -109,6 +121,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/")
 
 	switch {
+	case path == pathBatch:
+		h.batch(w, r)
 	case path == "Tables":
 		h.tablesCollectionOp(w, r)
 	case strings.HasPrefix(path, "Tables("):
@@ -216,7 +230,7 @@ func (h *Handler) entityOp(w http.ResponseWriter, r *http.Request, path string) 
 		h.getEntity(w, r, table, pk, rk)
 	case http.MethodPut:
 		h.updateEntity(w, r, table, pk, rk, driver.UpdateModeReplace)
-	case http.MethodPatch, "MERGE":
+	case http.MethodPatch, methodMerge:
 		h.updateEntity(w, r, table, pk, rk, driver.UpdateModeMerge)
 	case http.MethodDelete:
 		h.deleteEntity(w, r, table, pk, rk)
@@ -231,17 +245,29 @@ func (h *Handler) queryEntities(w http.ResponseWriter, r *http.Request, table st
 		return
 	}
 
-	entities, err := h.ts.QueryEntities(r.Context(), table, driver.QueryOptions{
-		Filter: r.URL.Query().Get("$filter"),
+	q := r.URL.Query()
+
+	res, err := h.ts.QueryEntities(r.Context(), table, driver.QueryOptions{
+		Filter:           q.Get("$filter"),
+		Top:              atoiDefault(q.Get("$top"), 0),
+		NextPartitionKey: q.Get("NextPartitionKey"),
+		NextRowKey:       q.Get("NextRowKey"),
 	})
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	value := make([]map[string]any, 0, len(entities))
-	for _, e := range entities {
+	value := make([]map[string]any, 0, len(res.Entities))
+	for _, e := range res.Entities {
 		value = append(value, entityToJSON(e))
+	}
+
+	// Continuation tokens travel as response headers, mirroring the real
+	// service; aztables' pager reads them to fetch the next page.
+	if res.NextPartitionKey != "" || res.NextRowKey != "" {
+		w.Header().Set("X-Ms-Continuation-Nextpartitionkey", res.NextPartitionKey)
+		w.Header().Set("X-Ms-Continuation-Nextrowkey", res.NextRowKey)
 	}
 
 	resp := map[string]any{
@@ -262,7 +288,10 @@ func (h *Handler) getEntity(w http.ResponseWriter, r *http.Request, table, pk, r
 	out := entityToJSON(ent)
 	out["odata.metadata"] = fmt.Sprintf("%s://%s/$metadata#%s/@Element", scheme(r), r.Host, table)
 
-	w.Header().Set("ETag", entityETag())
+	if etag := asString(ent[etagProp]); etag != "" {
+		w.Header().Set("ETag", etag)
+	}
+
 	writeJSON(w, http.StatusOK, out)
 }
 
@@ -276,7 +305,8 @@ func (h *Handler) insertEntity(w http.ResponseWriter, r *http.Request, table str
 	pk := asString(ent["PartitionKey"])
 	rk := asString(ent["RowKey"])
 
-	if err := h.ts.InsertEntity(r.Context(), table, pk, rk, driver.Entity(ent)); err != nil {
+	etag, err := h.ts.InsertEntity(r.Context(), table, pk, rk, driver.Entity(ent))
+	if err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -284,8 +314,9 @@ func (h *Handler) insertEntity(w http.ResponseWriter, r *http.Request, table str
 	// Default (no Prefer header): return-content — echo the entity with 201.
 	out := entityToJSON(ent)
 	out["odata.metadata"] = fmt.Sprintf("%s://%s/$metadata#%s/@Element", scheme(r), r.Host, table)
+	out[etagProp] = etag
 
-	w.Header().Set("ETag", entityETag())
+	w.Header().Set("ETag", etag)
 
 	if strings.EqualFold(r.Header.Get("Prefer"), "return-no-content") {
 		w.Header().Set("Preference-Applied", "return-no-content")
@@ -311,32 +342,37 @@ func (h *Handler) updateEntity(
 	ent["PartitionKey"] = pk
 	ent["RowKey"] = rk
 
-	if err := h.ts.UpdateEntity(r.Context(), table, pk, rk, driver.Entity(ent), mode); err != nil {
+	ifMatch := r.Header.Get("If-Match")
+
+	etag, err := h.ts.UpdateEntity(r.Context(), table, pk, rk, driver.Entity(ent), mode, ifMatch)
+	if err != nil {
 		// aztables UpdateEntity sends an If-Match header; UpsertEntity does not.
 		// With no If-Match, a PUT/MERGE against a missing row is an insert
 		// (insert-or-replace/merge), so create it instead of returning 404.
-		if cerrors.IsNotFound(err) && r.Header.Get("If-Match") == "" {
-			if ierr := h.ts.InsertEntity(r.Context(), table, pk, rk, driver.Entity(ent)); ierr != nil {
+		if cerrors.IsNotFound(err) && ifMatch == "" {
+			ietag, ierr := h.ts.InsertEntity(r.Context(), table, pk, rk, driver.Entity(ent))
+			if ierr != nil {
 				writeErr(w, ierr)
 				return
 			}
 
-			w.Header().Set("ETag", entityETag())
+			w.Header().Set("ETag", ietag)
 			w.WriteHeader(http.StatusNoContent)
 
 			return
 		}
 
 		writeErr(w, err)
+
 		return
 	}
 
-	w.Header().Set("ETag", entityETag())
+	w.Header().Set("ETag", etag)
 	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) deleteEntity(w http.ResponseWriter, r *http.Request, table, pk, rk string) {
-	if err := h.ts.DeleteEntity(r.Context(), table, pk, rk); err != nil {
+	if err := h.ts.DeleteEntity(r.Context(), table, pk, rk, r.Header.Get("If-Match")); err != nil {
 		writeErr(w, err)
 		return
 	}

--- a/server/azure/tablestorage/helpers.go
+++ b/server/azure/tablestorage/helpers.go
@@ -2,11 +2,10 @@ package tablestorage
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
-	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	driver "github.com/stackshy/cloudemu/v2/services/tablestorage/driver"
@@ -123,8 +122,17 @@ func entityToJSON(e driver.Entity) map[string]any {
 	return out
 }
 
-func entityETag() string {
-	return fmt.Sprintf("W/\"datetime'%s'\"", time.Now().UTC().Format(time.RFC3339Nano))
+// atoiDefault parses s as an int, returning def when s is empty or invalid.
+func atoiDefault(s string, def int) int {
+	if s == "" {
+		return def
+	}
+
+	if n, err := strconv.Atoi(s); err == nil {
+		return n
+	}
+
+	return def
 }
 
 func scheme(r *http.Request) string {
@@ -180,14 +188,22 @@ func writeError(w http.ResponseWriter, status int, code, msg string) {
 
 // writeErr maps CloudEmu canonical errors to Azure Table HTTP errors.
 func writeErr(w http.ResponseWriter, err error) {
+	status, code := mapErr(err)
+	writeError(w, status, code, err.Error())
+}
+
+// mapErr maps a CloudEmu canonical error to its Azure Table HTTP status + code.
+func mapErr(err error) (status int, code string) {
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "ResourceNotFound", err.Error())
+		return http.StatusNotFound, "ResourceNotFound"
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "EntityAlreadyExists", err.Error())
+		return http.StatusConflict, "EntityAlreadyExists"
+	case cerrors.IsFailedPrecondition(err):
+		return http.StatusPreconditionFailed, "UpdateConditionNotSatisfied"
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "InvalidInput", err.Error())
+		return http.StatusBadRequest, "InvalidInput"
 	default:
-		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
+		return http.StatusInternalServerError, "InternalError"
 	}
 }

--- a/server/azure/tablestorage/lifecycle_test.go
+++ b/server/azure/tablestorage/lifecycle_test.go
@@ -1,0 +1,139 @@
+package tablestorage_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
+)
+
+// TestGetEntitySystemProperties covers finding #3: a fetched entity carries the
+// system Timestamp and odata.etag properties, and the ETag response header.
+func TestGetEntitySystemProperties(t *testing.T) {
+	ctx := context.Background()
+	client, _ := newTableClient(t, "sysprops")
+	addEntity(t, client, "p", "r", map[string]any{"X": 1})
+
+	got, err := client.GetEntity(ctx, "p", "r", nil)
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+
+	if got.ETag == "" {
+		t.Error("GetEntity response has no ETag header")
+	}
+
+	var props map[string]any
+	if err := json.Unmarshal(got.Value, &props); err != nil {
+		t.Fatalf("unmarshal entity: %v", err)
+	}
+
+	if props["Timestamp"] == nil {
+		t.Error("entity body missing Timestamp system property")
+	}
+
+	if props["odata.etag"] == nil {
+		t.Error("entity body missing odata.etag system property")
+	}
+}
+
+// TestETagStableAndConditionalUpdate covers finding #8: the ETag is stable
+// across unmodified reads, and a stale If-Match update is rejected with 412.
+func TestETagStableAndConditionalUpdate(t *testing.T) {
+	ctx := context.Background()
+	client, _ := newTableClient(t, "etag")
+	addEntity(t, client, "p", "r", map[string]any{"V": 1})
+
+	first, err := client.GetEntity(ctx, "p", "r", nil)
+	if err != nil {
+		t.Fatalf("first GetEntity: %v", err)
+	}
+
+	second, err := client.GetEntity(ctx, "p", "r", nil)
+	if err != nil {
+		t.Fatalf("second GetEntity: %v", err)
+	}
+
+	if first.ETag != second.ETag {
+		t.Fatalf("ETag not stable: %q vs %q", first.ETag, second.ETag)
+	}
+
+	original := first.ETag
+
+	// A conditional replace with the current ETag succeeds and rotates the ETag.
+	body := marshalEntity(t, "p", "r", map[string]any{"V": 2})
+
+	if _, err := client.UpdateEntity(ctx, body, &aztables.UpdateEntityOptions{
+		IfMatch:    to.Ptr(original),
+		UpdateMode: aztables.UpdateModeReplace,
+	}); err != nil {
+		t.Fatalf("conditional UpdateEntity with current ETag: %v", err)
+	}
+
+	// A second replace with the now-stale original ETag must fail with 412.
+	_, err = client.UpdateEntity(ctx, body, &aztables.UpdateEntityOptions{
+		IfMatch:    to.Ptr(original),
+		UpdateMode: aztables.UpdateModeReplace,
+	})
+	if err == nil {
+		t.Fatal("stale conditional update succeeded, want 412 UpdateConditionNotSatisfied")
+	}
+
+	if !strings.Contains(err.Error(), "UpdateConditionNotSatisfied") {
+		t.Errorf("stale update error = %v, want UpdateConditionNotSatisfied", err)
+	}
+}
+
+// TestQueryTopPagination covers finding #7: $top caps the page and a
+// continuation token lets the pager walk the whole result set exactly once.
+func TestQueryTopPagination(t *testing.T) {
+	ctx := context.Background()
+	client, _ := newTableClient(t, "paging")
+
+	for _, rk := range []string{"a", "b", "c"} {
+		addEntity(t, client, "p", rk, nil)
+	}
+
+	pager := client.NewListEntitiesPager(&aztables.ListEntitiesOptions{Top: to.Ptr(int32(1))})
+
+	pages := 0
+	seen := map[string]bool{}
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		pages++
+
+		if len(page.Entities) > 1 {
+			t.Fatalf("page %d returned %d entities, want at most 1 (Top=1)", pages, len(page.Entities))
+		}
+
+		for _, raw := range page.Entities {
+			var e map[string]any
+			if err := json.Unmarshal(raw, &e); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+
+			rk, _ := e["RowKey"].(string)
+			if seen[rk] {
+				t.Fatalf("row %q returned twice across pages", rk)
+			}
+
+			seen[rk] = true
+		}
+	}
+
+	if len(seen) != 3 {
+		t.Fatalf("paged rows = %v, want a,b,c", seen)
+	}
+
+	if pages < 3 {
+		t.Fatalf("walked %d pages for 3 rows with Top=1, want >= 3 (no continuation?)", pages)
+	}
+}

--- a/services/messagequeue/driver/driver.go
+++ b/services/messagequeue/driver/driver.go
@@ -93,6 +93,10 @@ type Message struct {
 	SystemAttributes map[string]string
 	// SequenceNumber is set for FIFO messages.
 	SequenceNumber string
+	// ReceiveCount is the number of times this message has been received. Azure
+	// Queue Storage surfaces it as DequeueCount; providers that don't track it
+	// leave it zero.
+	ReceiveCount int
 }
 
 // BatchSendEntry represents a single message in a batch send.
@@ -180,6 +184,51 @@ type MessageMoveTask struct {
 	ApproxMessagesToMove         int64
 	FailureReason                string
 	StartedAt                    time.Time
+}
+
+// AzureQueueMessage is a message returned by the Azure-specific Peek surface. It
+// is a non-destructive read: no pop receipt is issued and visibility is
+// unchanged.
+type AzureQueueMessage struct {
+	MessageID    string
+	Body         string
+	ReceiveCount int
+	InsertedAt   time.Time
+	ExpiresAt    time.Time
+}
+
+// AzureUpdateMessageResult is the outcome of an Azure Update Message call: a
+// fresh pop receipt and the time the message will next become visible.
+type AzureUpdateMessageResult struct {
+	PopReceipt      string
+	TimeNextVisible time.Time
+}
+
+// AzureQueueMetadata carries the queue properties Get Queue Metadata reports.
+type AzureQueueMetadata struct {
+	ApproximateMessageCount int
+	Metadata                map[string]string
+}
+
+// AzureQueueStorage is the Azure-specific Queue Storage data-plane surface,
+// kept off the cross-cloud MessageQueue interface (Peek, message content/
+// visibility Update, and queue metadata are Azure Queue Storage concepts a
+// provider opts into). The wire handler reaches it by type assertion, mirroring
+// the AWS-specific message-move surface on the SQS side.
+type AzureQueueStorage interface {
+	// PeekMessages returns up to maxMessages visible messages without altering
+	// their visibility or issuing pop receipts.
+	PeekMessages(ctx context.Context, queueURL string, maxMessages int) ([]AzureQueueMessage, error)
+	// UpdateMessage updates a message's content (when body is non-nil) and its
+	// visibility timeout, returning a new pop receipt. The supplied popReceipt
+	// must match the message's current receipt.
+	UpdateMessage(
+		ctx context.Context, queueURL, messageID, popReceipt string, visibilityTimeout int, body *string,
+	) (AzureUpdateMessageResult, error)
+	// GetQueueMetadata reports the approximate message count and user metadata.
+	GetQueueMetadata(ctx context.Context, queueURL string) (AzureQueueMetadata, error)
+	// SetQueueMetadata replaces the queue's user metadata.
+	SetQueueMetadata(ctx context.Context, queueURL string, metadata map[string]string) error
 }
 
 // MessageQueue is the interface that message queue provider implementations must satisfy.

--- a/services/messagequeue/driver/driver.go
+++ b/services/messagequeue/driver/driver.go
@@ -227,6 +227,11 @@ type AzureQueueMetadata struct {
 // provider opts into). The wire handler reaches it by type assertion, mirroring
 // the AWS-specific message-move surface on the SQS side.
 type AzureQueueStorage interface {
+	// DequeueMessages retrieves up to maxMessages visible messages, hiding them
+	// for visibilityTimeout seconds and issuing a pop receipt per message. It
+	// respects Azure Queue Storage's max of 32 messages per call (distinct from
+	// Service Bus's receive cap).
+	DequeueMessages(ctx context.Context, queueURL string, maxMessages, visibilityTimeout int) ([]Message, error)
 	// PeekMessages returns up to maxMessages visible messages without altering
 	// their visibility or issuing pop receipts.
 	PeekMessages(ctx context.Context, queueURL string, maxMessages int) ([]AzureQueueMessage, error)

--- a/services/tablestorage/driver/driver.go
+++ b/services/tablestorage/driver/driver.go
@@ -24,17 +24,71 @@ const (
 
 // Entity is a single Table Storage row: a flat map of property name to value.
 // PartitionKey and RowKey are stored as ordinary properties (keys
-// "PartitionKey" and "RowKey") so callers get them back verbatim.
+// "PartitionKey" and "RowKey") so callers get them back verbatim. On read, the
+// backend also injects the system properties "Timestamp" (Edm.DateTime string)
+// and "odata.etag" so responses match the real service.
 type Entity map[string]any
+
+// MatchAny is the wildcard If-Match value that matches any current ETag, making
+// a conditional operation unconditional (mirrors HTTP If-Match: *).
+const MatchAny = "*"
 
 // QueryOptions filters a QueryEntities call.
 type QueryOptions struct {
 	// PartitionKey, when non-empty, restricts results to a single partition.
 	PartitionKey string
-	// Filter is an OData $filter expression. Only a small, common subset is
-	// supported (PartitionKey/RowKey/property eq comparisons joined by "and");
-	// an unsupported filter is ignored rather than rejected.
+	// Filter is an OData $filter expression. The full comparison/logical
+	// grammar (eq/ne/gt/ge/lt/le joined by and/or/not with parentheses over
+	// string, numeric, boolean, datetime and guid literals) is supported.
 	Filter string
+	// Top caps the number of entities returned in this page (0 = no cap).
+	Top int
+	// NextPartitionKey/NextRowKey are the continuation position from a prior
+	// page; results resume strictly after this (PartitionKey, RowKey).
+	NextPartitionKey string
+	NextRowKey       string
+}
+
+// QueryResult is a single page of a QueryEntities call. NextPartitionKey and
+// NextRowKey are set when more entities remain; both empty means the last page.
+type QueryResult struct {
+	Entities         []Entity
+	NextPartitionKey string
+	NextRowKey       string
+}
+
+// BatchOpType is the operation an entity-group-transaction sub-request performs.
+type BatchOpType int
+
+const (
+	// BatchInsert inserts a new entity; fails if it already exists.
+	BatchInsert BatchOpType = iota
+	// BatchUpsertReplace inserts or fully replaces an entity (no If-Match).
+	BatchUpsertReplace
+	// BatchUpsertMerge inserts or merges an entity (no If-Match).
+	BatchUpsertMerge
+	// BatchUpdateReplace replaces an existing entity; honors If-Match.
+	BatchUpdateReplace
+	// BatchUpdateMerge merges into an existing entity; honors If-Match.
+	BatchUpdateMerge
+	// BatchDelete deletes an existing entity; honors If-Match.
+	BatchDelete
+)
+
+// BatchOp is one sub-operation of an entity group transaction. All ops in a
+// transaction share a PartitionKey.
+type BatchOp struct {
+	Type         BatchOpType
+	PartitionKey string
+	RowKey       string
+	Entity       Entity
+	IfMatch      string
+}
+
+// BatchResult is the per-op outcome of a successful ApplyBatch, carrying the
+// resulting ETag (empty for delete).
+type BatchResult struct {
+	ETag string
 }
 
 // TableStorage is the interface a Table Storage backend implements.
@@ -43,9 +97,34 @@ type TableStorage interface {
 	DeleteTable(ctx context.Context, name string) error
 	ListTables(ctx context.Context) ([]string, error)
 
-	InsertEntity(ctx context.Context, table, partitionKey, rowKey string, entity Entity) error
+	InsertEntity(ctx context.Context, table, partitionKey, rowKey string, entity Entity) (etag string, err error)
 	GetEntity(ctx context.Context, table, partitionKey, rowKey string) (Entity, error)
-	UpdateEntity(ctx context.Context, table, partitionKey, rowKey string, entity Entity, mode UpdateMode) error
-	DeleteEntity(ctx context.Context, table, partitionKey, rowKey string) error
-	QueryEntities(ctx context.Context, table string, opts QueryOptions) ([]Entity, error)
+	UpdateEntity(
+		ctx context.Context, table, partitionKey, rowKey string, entity Entity, mode UpdateMode, ifMatch string,
+	) (etag string, err error)
+	DeleteEntity(ctx context.Context, table, partitionKey, rowKey, ifMatch string) error
+	QueryEntities(ctx context.Context, table string, opts QueryOptions) (QueryResult, error)
+
+	// ApplyBatch atomically applies an entity group transaction: either every
+	// op succeeds or none is applied. On failure it returns a BatchError naming
+	// the failed op's index.
+	ApplyBatch(ctx context.Context, table string, ops []BatchOp) ([]BatchResult, error)
+}
+
+// BatchError reports which op in an entity group transaction failed. The Table
+// service echoes the zero-based index at the front of the error message and
+// rolls the whole change set back.
+type BatchError struct {
+	Index int
+	Err   error
+}
+
+// Error implements error.
+func (e *BatchError) Error() string {
+	return e.Err.Error()
+}
+
+// Unwrap exposes the underlying cause so cerrors classification still works.
+func (e *BatchError) Unwrap() error {
+	return e.Err
 }


### PR DESCRIPTION
## Summary

Fixes a batch of Azure Table Storage and Queue Storage data-plane gaps found in the real-user e2e audit, matched against the official Azure REST API reference. All behaviors are exercised with the real `aztables` / `azqueue` SDK clients over an httptest server.

## Table Storage

- **Entity group transactions (`POST /$batch`)** — previously 501. Now parses the multipart/mixed batch + change set, applies the operations atomically (all-or-nothing with rollback on failure), and returns the multipart batch response the `aztables` `SubmitTransaction` client expects. *(Finding 1, BLOCKER)*
- **Full OData `$filter` grammar** — previously only `Prop eq 'value'` + `and`. Now supports `eq/ne/gt/ge/lt/le`, `and/or/not`, parentheses, and string/numeric/boolean/datetime/guid literals, so range scans work. Malformed filters still 400 rather than degrade to match-all. *(Finding 2, HIGH)*
- **System properties on read** — `GetEntity` now returns `Timestamp` and `odata.etag` in the body plus the `ETag` header. *(Finding 3, HIGH)*
- **Stable ETag + conditional updates** — ETag is now stored per entity (stable across unmodified reads) and `If-Match` is validated, returning `412 UpdateConditionNotSatisfied` on a stale ETag. *(Finding 8, MEDIUM)*
- **`$top` + continuation** — queries honor `$top`, order by `(PartitionKey, RowKey)`, and emit `x-ms-continuation-*` tokens so the pager walks the full set. *(Finding 7, MEDIUM)*

## Queue Storage

- **Peek (`?peekonly=true`)** — now a non-destructive read; the message stays dequeueable and no pop receipt is issued. *(Finding 4, HIGH)*
- **Update Message (`PUT /{queue}/messages/{id}`)** — previously 405. Renews visibility, optionally replaces the body, and returns a fresh pop receipt in `x-ms-popreceipt`. *(Finding 5, HIGH)*
- **Get/Set queue metadata (`?comp=metadata`)** — previously 501. Serves `x-ms-approximate-messages-count` and `x-ms-meta-*`. *(Finding 6, HIGH)*
- **DequeueCount** — reflects the real receive count instead of a hardcoded `1`, enabling poison-message detection. *(Finding 9, MEDIUM)*

## Architecture notes

- Azure-only queue ops (Peek / Update / metadata) live on a **type-asserted optional interface** `AzureQueueStorage` in `services/messagequeue/driver` — no methods are forced onto the AWS/GCP providers that share `MessageQueue`.
- The `TableStorage` driver (Azure-only, single implementer) is extended with `ApplyBatch` and ETag-aware CRUD signatures.
- Capability docs regenerated via `go run ./internal/coveragegen`.

## Tests

Real-SDK e2e coverage for every finding (`aztables.SubmitTransaction`, range/logical filters, system properties, ETag/If-Match 412, `$top` pagination; `azqueue` peek/update/metadata/dequeue-count) plus provider unit tests for the filter parser, conditional update, and atomic batch rollback.
