### PR TITLE
fix(lambda-ecs): DescribeTasks, DeleteEventSourceMapping/ListEventSourceMappings, Create/UpdateAlias

### DIFF
--- a/providers/aws/ecs/tasks.go
+++ b/providers/aws/ecs/tasks.go
@@ -428,6 +428,9 @@ func (m *Mock) ListTasks(_ context.Context, cluster, family, desiredStatus, serv
 // DescribeTasks resolves tasks by id or ARN; unresolved ids become failures. A
 // nonexistent cluster is rejected up front with ClusterNotFoundException,
 // matching real ECS (the implicit "default" cluster always resolves).
+// DescribeTasks is cluster-scoped: a task that resolves but belongs to a
+// different cluster than the requested one is reported as a MISSING failure,
+// never as a found task, matching real ECS and the sibling StopTask/ListTasks.
 func (m *Mock) DescribeTasks(_ context.Context, cluster string, ids []string) ([]driver.Task, []driver.Failure, error) {
 	want := resolveClusterName(cluster)
 	if !m.clusterExists(want) {
@@ -438,7 +441,7 @@ func (m *Mock) DescribeTasks(_ context.Context, cluster string, ids []string) ([
 	failures := make([]driver.Failure, 0, len(ids))
 
 	for _, id := range ids {
-		if t, ok := m.resolveTask(id); ok {
+		if t, ok := m.resolveTask(id); ok && clusterNameFromARN(t.ClusterARN) == want {
 			found = append(found, cloneTask(t))
 			continue
 		}

--- a/providers/aws/lambda/aliases.go
+++ b/providers/aws/lambda/aliases.go
@@ -63,25 +63,35 @@ func (m *Mock) UpdateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 		return nil, cerrors.Newf(cerrors.NotFound, "alias %s not found", cfg.Name)
 	}
 
+	// Compute the prospective effective FunctionVersion without touching the
+	// live alias yet. UpdateAlias is atomic in real AWS: if any validation
+	// fails the alias must be left completely unchanged.
+	effectiveVersion := ad.alias.FunctionVersion
+
 	if cfg.FunctionVersion != "" {
 		if !m.versionExists(&fd, cfg.FunctionVersion) {
 			return nil, cerrors.Newf(cerrors.NotFound, "version %s not found", cfg.FunctionVersion)
 		}
 
-		ad.alias.FunctionVersion = cfg.FunctionVersion
+		effectiveVersion = cfg.FunctionVersion
 	}
+
+	if cfg.RoutingConfig != nil {
+		// Validate the routing config against the prospective FunctionVersion,
+		// which is the effective primary target for this alias.
+		if err := m.validateRoutingConfig(&fd, effectiveVersion, cfg.RoutingConfig); err != nil {
+			return nil, err
+		}
+	}
+
+	// All validation passed — commit the changes to the live alias.
+	ad.alias.FunctionVersion = effectiveVersion
 
 	if cfg.Description != "" {
 		ad.alias.Description = cfg.Description
 	}
 
 	if cfg.RoutingConfig != nil {
-		// ad.alias.FunctionVersion already reflects any FunctionVersion update
-		// applied above, so it is the effective primary target for this alias.
-		if err := m.validateRoutingConfig(&fd, ad.alias.FunctionVersion, cfg.RoutingConfig); err != nil {
-			return nil, err
-		}
-
 		ad.alias.RoutingConfig = copyRoutingConfig(cfg.RoutingConfig)
 	}
 

--- a/providers/aws/lambda/aliases.go
+++ b/providers/aws/lambda/aliases.go
@@ -24,6 +24,10 @@ func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 		return nil, cerrors.Newf(cerrors.NotFound, "version %s not found", cfg.FunctionVersion)
 	}
 
+	if err := m.validateRoutingConfig(&fd, cfg.RoutingConfig); err != nil {
+		return nil, err
+	}
+
 	aliasARN := idgen.AWSARN(
 		"lambda", m.opts.Region, m.opts.AccountID,
 		"function:"+cfg.FunctionName+":"+cfg.Name,
@@ -72,6 +76,10 @@ func (m *Mock) UpdateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 	}
 
 	if cfg.RoutingConfig != nil {
+		if err := m.validateRoutingConfig(&fd, cfg.RoutingConfig); err != nil {
+			return nil, err
+		}
+
 		ad.alias.RoutingConfig = copyRoutingConfig(cfg.RoutingConfig)
 	}
 
@@ -142,6 +150,27 @@ func copyRoutingConfig(rc *driver.AliasRoutingConfig) *driver.AliasRoutingConfig
 	cp := *rc
 
 	return &cp
+}
+
+// validateRoutingConfig enforces the RoutingConfig.AdditionalVersionWeights
+// rules real Lambda applies: a weighted alias cannot reference $LATEST
+// (InvalidParameterValueException), and the additional version must exist
+// (ResourceNotFoundException). An absent additional version is a no-op.
+func (m *Mock) validateRoutingConfig(fd *funcData, rc *driver.AliasRoutingConfig) error {
+	if rc == nil || rc.AdditionalVersion == "" {
+		return nil
+	}
+
+	if rc.AdditionalVersion == latestVersion {
+		return cerrors.New(cerrors.InvalidArgument,
+			"Alias with weights can not be created with function version $LATEST")
+	}
+
+	if !m.versionExists(fd, rc.AdditionalVersion) {
+		return cerrors.Newf(cerrors.NotFound, "version %s not found", rc.AdditionalVersion)
+	}
+
+	return nil
 }
 
 // versionExists checks whether a version string exists for the given function.

--- a/providers/aws/lambda/aliases.go
+++ b/providers/aws/lambda/aliases.go
@@ -24,7 +24,7 @@ func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 		return nil, cerrors.Newf(cerrors.NotFound, "version %s not found", cfg.FunctionVersion)
 	}
 
-	if err := m.validateRoutingConfig(&fd, cfg.RoutingConfig); err != nil {
+	if err := m.validateRoutingConfig(&fd, cfg.FunctionVersion, cfg.RoutingConfig); err != nil {
 		return nil, err
 	}
 
@@ -76,7 +76,9 @@ func (m *Mock) UpdateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 	}
 
 	if cfg.RoutingConfig != nil {
-		if err := m.validateRoutingConfig(&fd, cfg.RoutingConfig); err != nil {
+		// ad.alias.FunctionVersion already reflects any FunctionVersion update
+		// applied above, so it is the effective primary target for this alias.
+		if err := m.validateRoutingConfig(&fd, ad.alias.FunctionVersion, cfg.RoutingConfig); err != nil {
 			return nil, err
 		}
 
@@ -153,15 +155,19 @@ func copyRoutingConfig(rc *driver.AliasRoutingConfig) *driver.AliasRoutingConfig
 }
 
 // validateRoutingConfig enforces the RoutingConfig.AdditionalVersionWeights
-// rules real Lambda applies: a weighted alias cannot reference $LATEST
-// (InvalidParameterValueException), and the additional version must exist
-// (ResourceNotFoundException). An absent additional version is a no-op.
-func (m *Mock) validateRoutingConfig(fd *funcData, rc *driver.AliasRoutingConfig) error {
+// rules real Lambda applies: neither the alias's own version nor the additional
+// version can be $LATEST (InvalidParameterValueException), and the additional
+// version must exist (ResourceNotFoundException). effectiveVersion is the alias's
+// own FunctionVersion after the operation. An absent additional version is a no-op.
+func (m *Mock) validateRoutingConfig(fd *funcData, effectiveVersion string, rc *driver.AliasRoutingConfig) error {
 	if rc == nil || rc.AdditionalVersion == "" {
 		return nil
 	}
 
-	if rc.AdditionalVersion == latestVersion {
+	// A weighted alias cannot point to $LATEST — this restriction applies to the
+	// alias's own FunctionVersion (the primary target) as well as the additional
+	// version. Both must be published.
+	if effectiveVersion == latestVersion || rc.AdditionalVersion == latestVersion {
 		return cerrors.New(cerrors.InvalidArgument,
 			"Alias with weights can not be created with function version $LATEST")
 	}

--- a/providers/aws/lambda/lambda_test.go
+++ b/providers/aws/lambda/lambda_test.go
@@ -459,6 +459,44 @@ func TestAliasWeightedRouting(t *testing.T) {
 	assertEqual(t, 0.5, updated.RoutingConfig.Weight)
 }
 
+func TestAliasWeightedRoutingRejectsLatest(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+	_, _ = m.PublishVersion(ctx, "my-func", "v1")
+
+	// A weighted alias whose own FunctionVersion is $LATEST is rejected.
+	_, err := m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName:    "my-func",
+		Name:            "bad",
+		FunctionVersion: "$LATEST",
+		RoutingConfig: &driver.AliasRoutingConfig{
+			AdditionalVersion: "1",
+			Weight:            0.1,
+		},
+	})
+	assertError(t, err, true)
+
+	// A plain alias on $LATEST is allowed; adding routing later that leaves the
+	// effective FunctionVersion at $LATEST is rejected.
+	_, err = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName:    "my-func",
+		Name:            "plain",
+		FunctionVersion: "$LATEST",
+	})
+	requireNoError(t, err)
+
+	_, err = m.UpdateAlias(ctx, driver.AliasConfig{
+		FunctionName: "my-func",
+		Name:         "plain",
+		RoutingConfig: &driver.AliasRoutingConfig{
+			AdditionalVersion: "1",
+			Weight:            0.1,
+		},
+	})
+	assertError(t, err, true)
+}
+
 func TestPublishLayerVersion(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
@@ -703,16 +741,17 @@ func TestAliasRoutingConfigDeepCopy(t *testing.T) {
 	ctx := context.Background()
 	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
 	_, _ = m.PublishVersion(ctx, "my-func", "v1")
+	_, _ = m.PublishVersion(ctx, "my-func", "v2")
 
 	rc := &driver.AliasRoutingConfig{
-		AdditionalVersion: "1",
+		AdditionalVersion: "2",
 		Weight:            0.5,
 	}
 
 	_, err := m.CreateAlias(ctx, driver.AliasConfig{
 		FunctionName:    "my-func",
 		Name:            "deep-copy",
-		FunctionVersion: "$LATEST",
+		FunctionVersion: "1",
 		RoutingConfig:   rc,
 	})
 	requireNoError(t, err)

--- a/providers/aws/lambda/lambda_test.go
+++ b/providers/aws/lambda/lambda_test.go
@@ -395,6 +395,33 @@ func TestUpdateAlias(t *testing.T) {
 		})
 		assertError(t, err, true)
 	})
+
+	t.Run("atomic: failed routing validation leaves alias unchanged", func(t *testing.T) {
+		_, _ = m.CreateAlias(ctx, driver.AliasConfig{
+			FunctionName: "my-func", Name: "atomic", FunctionVersion: "1",
+		})
+
+		// A valid FunctionVersion change combined with a RoutingConfig that fails
+		// validation ($LATEST additional version) must fail as a whole and leave
+		// the alias completely unchanged — FunctionVersion must stay "1".
+		_, err := m.UpdateAlias(ctx, driver.AliasConfig{
+			FunctionName:    "my-func",
+			Name:            "atomic",
+			FunctionVersion: "2",
+			RoutingConfig: &driver.AliasRoutingConfig{
+				AdditionalVersion: "$LATEST",
+				Weight:            0.1,
+			},
+		})
+		assertError(t, err, true)
+
+		got, err := m.GetAlias(ctx, "my-func", "atomic")
+		requireNoError(t, err)
+		assertEqual(t, "1", got.FunctionVersion)
+		if got.RoutingConfig != nil {
+			t.Fatalf("expected RoutingConfig to remain nil, got %+v", got.RoutingConfig)
+		}
+	})
 }
 
 func TestDeleteAlias(t *testing.T) {

--- a/server/aws/ecs/cluster_scoping_test.go
+++ b/server/aws/ecs/cluster_scoping_test.go
@@ -91,6 +91,69 @@ func TestSDKStopTaskClusterScoping(t *testing.T) {
 	}
 }
 
+// TestSDKDescribeTasksClusterScoping guards that DescribeTasks is cluster-scoped:
+// a task that exists but belongs to a different cluster than the one requested is
+// reported in failures with reason "MISSING", never in tasks. It must still be
+// visible from its own cluster. This mirrors StopTask/ListTasks scoping.
+func TestSDKDescribeTasksClusterScoping(t *testing.T) {
+	client, cloud := newECSServer(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"prod", "staging"} {
+		if _, err := client.CreateCluster(ctx, &awsecs.CreateClusterInput{ClusterName: aws.String(name)}); err != nil {
+			t.Fatalf("CreateCluster(%s): %v", name, err)
+		}
+	}
+
+	registerNginx(t, client, ctx)
+	cloud.ECS.SeedContainerInstance("prod", "i-scope")
+
+	run, err := client.RunTask(ctx, &awsecs.RunTaskInput{
+		Cluster:        aws.String("prod"),
+		TaskDefinition: aws.String("web"),
+	})
+	if err != nil {
+		t.Fatalf("RunTask: %v", err)
+	}
+
+	if len(run.Tasks) != 1 {
+		t.Fatalf("RunTask = %d tasks, want 1 (failures %+v)", len(run.Tasks), run.Failures)
+	}
+
+	taskARN := aws.ToString(run.Tasks[0].TaskArn)
+
+	// Described against the wrong (but existing) cluster: MISSING failure, no task.
+	wrong, err := client.DescribeTasks(ctx, &awsecs.DescribeTasksInput{
+		Cluster: aws.String("staging"),
+		Tasks:   []string{taskARN},
+	})
+	if err != nil {
+		t.Fatalf("DescribeTasks(staging): %v", err)
+	}
+
+	if len(wrong.Tasks) != 0 {
+		t.Fatalf("DescribeTasks(wrong cluster) tasks = %+v, want none", wrong.Tasks)
+	}
+
+	if len(wrong.Failures) != 1 || aws.ToString(wrong.Failures[0].Reason) != "MISSING" {
+		t.Fatalf("DescribeTasks(wrong cluster) failures = %+v, want one MISSING", wrong.Failures)
+	}
+
+	// Described against its own cluster: found, no failures.
+	right, err := client.DescribeTasks(ctx, &awsecs.DescribeTasksInput{
+		Cluster: aws.String("prod"),
+		Tasks:   []string{taskARN},
+	})
+	if err != nil {
+		t.Fatalf("DescribeTasks(prod): %v", err)
+	}
+
+	if len(right.Tasks) != 1 || len(right.Failures) != 0 {
+		t.Fatalf("DescribeTasks(prod) = %d tasks / %d failures, want 1 task / 0 failures",
+			len(right.Tasks), len(right.Failures))
+	}
+}
+
 // TestSDKListServicesMissingCluster guards that ListServices against a
 // nonexistent cluster returns ClusterNotFoundException rather than an empty
 // list, as documented in the ListServices Errors section.

--- a/server/aws/lambda/esm.go
+++ b/server/aws/lambda/esm.go
@@ -74,12 +74,24 @@ func (h *Handler) serveEventSourceMappings(w http.ResponseWriter, r *http.Reques
 	case http.MethodPut:
 		h.updateEventSourceMapping(w, r, uuid)
 	case http.MethodDelete:
+		// AWS returns 202 with the full EventSourceMappingConfiguration whose
+		// State is "Deleting" (the mapping enters a Deleting state and is not
+		// fully removed for several seconds). Snapshot it before deleting so the
+		// SDK caller can read UUID/State/FunctionArn off the response.
+		info, err := h.fn.GetEventSourceMapping(r.Context(), uuid)
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+
 		if err := h.fn.DeleteEventSourceMapping(r.Context(), uuid); err != nil {
 			writeErr(w, err)
 			return
 		}
 
-		w.WriteHeader(http.StatusNoContent)
+		body := toESMJSON(info)
+		body.State = "Deleting"
+		writeJSON(w, http.StatusAccepted, body)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
 	}
@@ -167,7 +179,11 @@ func (h *Handler) updateEventSourceMapping(w http.ResponseWriter, r *http.Reques
 }
 
 func (h *Handler) listEventSourceMappings(w http.ResponseWriter, r *http.Request) {
-	// FunctionName is an optional filter carried as a query parameter.
+	// FunctionName and EventSourceArn are optional filters carried as query
+	// parameters. FunctionName is applied by the driver; EventSourceArn narrows
+	// the result further to mappings for a single event source.
+	eventSourceArn := r.URL.Query().Get("EventSourceArn")
+
 	infos, err := h.fn.ListEventSourceMappings(r.Context(), r.URL.Query().Get("FunctionName"))
 	if err != nil {
 		writeErr(w, err)
@@ -175,7 +191,12 @@ func (h *Handler) listEventSourceMappings(w http.ResponseWriter, r *http.Request
 	}
 
 	out := make([]eventSourceMappingJSON, 0, len(infos))
+
 	for i := range infos {
+		if eventSourceArn != "" && infos[i].EventSourceArn != eventSourceArn {
+			continue
+		}
+
 		out = append(out, toESMJSON(&infos[i]))
 	}
 

--- a/server/aws/lambda/lambda_test.go
+++ b/server/aws/lambda/lambda_test.go
@@ -303,9 +303,25 @@ func TestEventSourceMappings(t *testing.T) {
 		t.Fatalf("get ESM status = %d", got.StatusCode)
 	}
 
-	// DELETE by UUID.
-	if del := doJSON(t, http.MethodDelete, esmURL+"/"+esm.UUID, ""); del.StatusCode != http.StatusNoContent {
-		t.Fatalf("delete ESM status = %d", del.StatusCode)
+	// DELETE by UUID returns 202 with the full config in a Deleting state.
+	del := doJSON(t, http.MethodDelete, esmURL+"/"+esm.UUID, "")
+	if del.StatusCode != http.StatusAccepted {
+		t.Fatalf("delete ESM status = %d, want 202", del.StatusCode)
+	}
+
+	var deleted struct {
+		UUID  string `json:"UUID"`
+		State string `json:"State"`
+	}
+
+	decode(t, del, &deleted)
+
+	if deleted.UUID != esm.UUID {
+		t.Fatalf("delete ESM UUID = %q, want %q", deleted.UUID, esm.UUID)
+	}
+
+	if deleted.State != "Deleting" {
+		t.Fatalf("delete ESM State = %q, want Deleting", deleted.State)
 	}
 }
 

--- a/server/aws/lambda/sdk_roundtrip_test.go
+++ b/server/aws/lambda/sdk_roundtrip_test.go
@@ -3,6 +3,7 @@ package lambda_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http/httptest"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
 	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/aws/smithy-go"
 	"github.com/stackshy/cloudemu/v2"
 	awsprovider "github.com/stackshy/cloudemu/v2/providers/aws"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
@@ -481,6 +483,156 @@ func TestSDKEventSourceMappingFunctionArn(t *testing.T) {
 	}
 }
 
+// TestSDKDeleteEventSourceMappingReturnsConfig covers DeleteEventSourceMapping
+// returning the full EventSourceMappingConfiguration with State "Deleting"
+// rather than an empty body, so a caller can read UUID/State off the response.
+func TestSDKDeleteEventSourceMappingReturnsConfig(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "delconsumer")
+
+	created, err := client.CreateEventSourceMapping(ctx, &awslambda.CreateEventSourceMappingInput{
+		FunctionName:   aws.String("delconsumer"),
+		EventSourceArn: aws.String("arn:aws:sqs:us-east-1:000000000000:del-queue"),
+	})
+	if err != nil {
+		t.Fatalf("CreateEventSourceMapping: %v", err)
+	}
+
+	del, err := client.DeleteEventSourceMapping(ctx, &awslambda.DeleteEventSourceMappingInput{
+		UUID: created.UUID,
+	})
+	if err != nil {
+		t.Fatalf("DeleteEventSourceMapping: %v", err)
+	}
+
+	if aws.ToString(del.UUID) != aws.ToString(created.UUID) {
+		t.Fatalf("Delete UUID = %q, want %q", aws.ToString(del.UUID), aws.ToString(created.UUID))
+	}
+	if aws.ToString(del.State) != "Deleting" {
+		t.Fatalf("Delete State = %q, want Deleting", aws.ToString(del.State))
+	}
+	if aws.ToString(del.FunctionArn) == "" {
+		t.Fatal("Delete FunctionArn empty, want the full function ARN")
+	}
+
+	// The mapping is gone afterward.
+	if _, err := client.GetEventSourceMapping(ctx, &awslambda.GetEventSourceMappingInput{
+		UUID: created.UUID,
+	}); err == nil {
+		t.Fatal("GetEventSourceMapping after delete = nil error, want ResourceNotFoundException")
+	}
+}
+
+// TestSDKListEventSourceMappingsByEventSourceArn covers the EventSourceArn query
+// filter: listing with an EventSourceArn returns only mappings for that source.
+func TestSDKListEventSourceMappingsByEventSourceArn(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "multi")
+
+	const (
+		arnA = "arn:aws:sqs:us-east-1:000000000000:queue-a"
+		arnB = "arn:aws:sqs:us-east-1:000000000000:queue-b"
+	)
+
+	for _, src := range []string{arnA, arnB} {
+		if _, err := client.CreateEventSourceMapping(ctx, &awslambda.CreateEventSourceMappingInput{
+			FunctionName:   aws.String("multi"),
+			EventSourceArn: aws.String(src),
+		}); err != nil {
+			t.Fatalf("CreateEventSourceMapping(%s): %v", src, err)
+		}
+	}
+
+	filtered, err := client.ListEventSourceMappings(ctx, &awslambda.ListEventSourceMappingsInput{
+		EventSourceArn: aws.String(arnA),
+	})
+	if err != nil {
+		t.Fatalf("ListEventSourceMappings(EventSourceArn=A): %v", err)
+	}
+
+	if len(filtered.EventSourceMappings) != 1 {
+		t.Fatalf("filtered mappings = %d, want 1", len(filtered.EventSourceMappings))
+	}
+	if aws.ToString(filtered.EventSourceMappings[0].EventSourceArn) != arnA {
+		t.Fatalf("filtered EventSourceArn = %q, want %q",
+			aws.ToString(filtered.EventSourceMappings[0].EventSourceArn), arnA)
+	}
+
+	// No filter returns both.
+	all, err := client.ListEventSourceMappings(ctx, &awslambda.ListEventSourceMappingsInput{})
+	if err != nil {
+		t.Fatalf("ListEventSourceMappings(all): %v", err)
+	}
+	if len(all.EventSourceMappings) != 2 {
+		t.Fatalf("unfiltered mappings = %d, want 2", len(all.EventSourceMappings))
+	}
+}
+
+// TestSDKCreateAliasRoutingConfigValidation covers RoutingConfig validation:
+// a weight on $LATEST is InvalidParameterValueException, a weight on a
+// nonexistent version is ResourceNotFoundException, and a weight on a real
+// published version succeeds.
+func TestSDKCreateAliasRoutingConfigValidation(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "routed")
+
+	for range 2 {
+		if _, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
+			FunctionName: aws.String("routed"),
+		}); err != nil {
+			t.Fatalf("PublishVersion: %v", err)
+		}
+	}
+
+	// $LATEST in the weights is rejected with InvalidParameterValueException.
+	_, err := client.CreateAlias(ctx, &awslambda.CreateAliasInput{
+		FunctionName:    aws.String("routed"),
+		Name:            aws.String("bad-latest"),
+		FunctionVersion: aws.String("1"),
+		RoutingConfig: &lambdatypes.AliasRoutingConfiguration{
+			AdditionalVersionWeights: map[string]float64{"$LATEST": 0.1},
+		},
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValueException" {
+		t.Fatalf("CreateAlias($LATEST weight) err = %v, want InvalidParameterValueException", err)
+	}
+
+	// A nonexistent version is ResourceNotFoundException.
+	_, err = client.CreateAlias(ctx, &awslambda.CreateAliasInput{
+		FunctionName:    aws.String("routed"),
+		Name:            aws.String("bad-missing"),
+		FunctionVersion: aws.String("1"),
+		RoutingConfig: &lambdatypes.AliasRoutingConfiguration{
+			AdditionalVersionWeights: map[string]float64{"99": 0.1},
+		},
+	})
+
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ResourceNotFoundException" {
+		t.Fatalf("CreateAlias(missing version weight) err = %v, want ResourceNotFoundException", err)
+	}
+
+	// A real version succeeds.
+	created, err := client.CreateAlias(ctx, &awslambda.CreateAliasInput{
+		FunctionName:    aws.String("routed"),
+		Name:            aws.String("good"),
+		FunctionVersion: aws.String("1"),
+		RoutingConfig: &lambdatypes.AliasRoutingConfiguration{
+			AdditionalVersionWeights: map[string]float64{"2": 0.2},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateAlias(valid weight): %v", err)
+	}
+	if created.RoutingConfig == nil || created.RoutingConfig.AdditionalVersionWeights["2"] != 0.2 {
+		t.Fatalf("RoutingConfig = %+v, want version 2 weight 0.2", created.RoutingConfig)
+	}
+}
+
 // TestSDKVersionPerVersionAttributes covers PublishVersion/ListVersionsByFunction
 // leaving per-version CodeSha256/RevisionId empty and reusing $LATEST config.
 func TestSDKVersionPerVersionAttributes(t *testing.T) {
@@ -534,10 +686,12 @@ func TestSDKAliasRevisionAndRouting(t *testing.T) {
 	ctx := context.Background()
 	createBasicFunction(t, client, "aliased")
 
-	if _, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
-		FunctionName: aws.String("aliased"),
-	}); err != nil {
-		t.Fatalf("PublishVersion: %v", err)
+	for range 2 {
+		if _, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
+			FunctionName: aws.String("aliased"),
+		}); err != nil {
+			t.Fatalf("PublishVersion: %v", err)
+		}
 	}
 
 	created, err := client.CreateAlias(ctx, &awslambda.CreateAliasInput{
@@ -557,7 +711,7 @@ func TestSDKAliasRevisionAndRouting(t *testing.T) {
 		Name:            aws.String("live"),
 		FunctionVersion: aws.String("1"),
 		RoutingConfig: &lambdatypes.AliasRoutingConfiguration{
-			AdditionalVersionWeights: map[string]float64{"$LATEST": 0.1},
+			AdditionalVersionWeights: map[string]float64{"2": 0.1},
 		},
 	})
 	if err != nil {
@@ -566,8 +720,8 @@ func TestSDKAliasRevisionAndRouting(t *testing.T) {
 	if aws.ToString(updated.RevisionId) == aws.ToString(created.RevisionId) {
 		t.Fatal("alias RevisionId unchanged after update")
 	}
-	if updated.RoutingConfig == nil || updated.RoutingConfig.AdditionalVersionWeights["$LATEST"] != 0.1 {
-		t.Fatalf("RoutingConfig = %+v, want $LATEST weight 0.1", updated.RoutingConfig)
+	if updated.RoutingConfig == nil || updated.RoutingConfig.AdditionalVersionWeights["2"] != 0.1 {
+		t.Fatalf("RoutingConfig = %+v, want version 2 weight 0.1", updated.RoutingConfig)
 	}
 }
 

--- a/server/aws/lambda/sdk_roundtrip_test.go
+++ b/server/aws/lambda/sdk_roundtrip_test.go
@@ -602,6 +602,21 @@ func TestSDKCreateAliasRoutingConfigValidation(t *testing.T) {
 		t.Fatalf("CreateAlias($LATEST weight) err = %v, want InvalidParameterValueException", err)
 	}
 
+	// The alias's own FunctionVersion cannot be $LATEST when a routing config is
+	// present — a weighted alias's primary target must be a published version.
+	_, err = client.CreateAlias(ctx, &awslambda.CreateAliasInput{
+		FunctionName:    aws.String("routed"),
+		Name:            aws.String("bad-primary-latest"),
+		FunctionVersion: aws.String("$LATEST"),
+		RoutingConfig: &lambdatypes.AliasRoutingConfiguration{
+			AdditionalVersionWeights: map[string]float64{"1": 0.1},
+		},
+	})
+
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValueException" {
+		t.Fatalf("CreateAlias($LATEST primary) err = %v, want InvalidParameterValueException", err)
+	}
+
 	// A nonexistent version is ResourceNotFoundException.
 	_, err = client.CreateAlias(ctx, &awslambda.CreateAliasInput{
 		FunctionName:    aws.String("routed"),
@@ -630,6 +645,28 @@ func TestSDKCreateAliasRoutingConfigValidation(t *testing.T) {
 	}
 	if created.RoutingConfig == nil || created.RoutingConfig.AdditionalVersionWeights["2"] != 0.2 {
 		t.Fatalf("RoutingConfig = %+v, want version 2 weight 0.2", created.RoutingConfig)
+	}
+
+	// A plain alias may point to $LATEST; adding a routing config to it later
+	// (leaving the effective FunctionVersion at $LATEST) must be rejected.
+	if _, err = client.CreateAlias(ctx, &awslambda.CreateAliasInput{
+		FunctionName:    aws.String("routed"),
+		Name:            aws.String("plain-latest"),
+		FunctionVersion: aws.String("$LATEST"),
+	}); err != nil {
+		t.Fatalf("CreateAlias(plain $LATEST): %v", err)
+	}
+
+	_, err = client.UpdateAlias(ctx, &awslambda.UpdateAliasInput{
+		FunctionName: aws.String("routed"),
+		Name:         aws.String("plain-latest"),
+		RoutingConfig: &lambdatypes.AliasRoutingConfiguration{
+			AdditionalVersionWeights: map[string]float64{"1": 0.1},
+		},
+	})
+
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValueException" {
+		t.Fatalf("UpdateAlias(routing on $LATEST) err = %v, want InvalidParameterValueException", err)
 	}
 }
 


### PR DESCRIPTION
Round-4 confirmation-audit edges for AWS Lambda and ECS. Each fix confirmed against the official AWS API reference and covered by real aws-sdk-go-v2 tests.

## Changes

**1. ecs:DescribeTasks is now cluster-scoped (MEDIUM)**
`DescribeTasks` looked tasks up globally, so a task created in cluster A was returned as a found task when described with `cluster=B` (empty failures). It now compares `clusterNameFromARN(task.ClusterARN)` against the requested cluster and reports a mismatched task in `failures` with reason `MISSING`, never in `tasks` — matching real ECS and the sibling `StopTask`/`ListTasks` scoping.

**2. lambda:DeleteEventSourceMapping returns the full config (MEDIUM)**
The handler returned HTTP 204 with an empty body, so `DeleteEventSourceMappingOutput` came back with every field empty. It now returns HTTP 202 with the full `EventSourceMappingConfiguration` (UUID, FunctionArn, ...) and `State="Deleting"`, matching AWS.

**3. lambda:CreateAlias / UpdateAlias validate RoutingConfig (MEDIUM)**
`RoutingConfig.AdditionalVersionWeights` was copied verbatim. It is now validated: a weight referencing `$LATEST` is rejected with `InvalidParameterValueException` ("Alias with weights can not be created with function version $LATEST"), and a weight referencing a nonexistent version is rejected with `ResourceNotFoundException`.

**4. lambda:ListEventSourceMappings honors EventSourceArn (LOW)**
The `EventSourceArn` query parameter was dropped, so filtering returned every mapping. The handler now narrows the result to mappings whose event source matches.

## Tests
- `TestSDKDescribeTasksClusterScoping` — wrong-cluster describe yields a MISSING failure; own-cluster describe finds it.
- `TestSDKDeleteEventSourceMappingReturnsConfig` — delete returns UUID + State=Deleting + FunctionArn; mapping is gone afterward.
- `TestSDKListEventSourceMappingsByEventSourceArn` — filter returns only the matching source; no filter returns all.
- `TestSDKCreateAliasRoutingConfigValidation` — \$LATEST → InvalidParameterValueException, missing version → ResourceNotFoundException, real version → success.
- Updated `TestEventSourceMappings` and `TestSDKAliasRevisionAndRouting` to the corrected behavior.

No driver interface changed (findings #2 and #4 fixed at the server layer, #1 and #3 at the provider layer), so `docs/coverage` needs no regeneration.