### PR TITLE
fix(messaging): EventBridge InputTransformer reserved vars + resources field, SNS->SQS envelope Subject/standard fields

### DIFF
--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -477,16 +477,69 @@ func (m *Mock) deliverToTargets(ctx context.Context, matched []driver.Rule, even
 	envelope := m.eventEnvelope(event)
 
 	for i := range matched {
+		reserved := m.reservedVars(&matched[i], event, envelope)
+
 		for _, t := range matched[i].Targets {
 			if t.ARN == "" || !strings.Contains(t.ARN, ":sqs:") {
 				continue
 			}
 
-			body := targetBody(&t, envelope)
+			body := targetBody(&t, envelope, reserved)
 
 			_ = m.sqs.DeliverExternal(ctx, t.ARN, body)
 		}
 	}
+}
+
+// reservedVars builds the predefined <aws.events.*> transformer variables for a
+// rule/event pair. <aws.events.event.json> is the full envelope; <aws.events.event>
+// is the envelope without its detail field; the rest are string values.
+func (m *Mock) reservedVars(rule *driver.Rule, event *driver.Event, envelope []byte) map[string]json.RawMessage {
+	quote := func(s string) json.RawMessage {
+		b, err := json.Marshal(s)
+		if err != nil {
+			return json.RawMessage(`""`)
+		}
+
+		return b
+	}
+
+	vars := map[string]json.RawMessage{
+		"aws.events.event.json":           envelope,
+		"aws.events.event":                envelopeWithoutDetail(envelope),
+		"aws.events.rule-arn":             quote(m.ruleARN(rule.EventBus, rule.Name)),
+		"aws.events.rule-name":            quote(rule.Name),
+		"aws.events.event.ingestion-time": quote(event.Time.UTC().Format(time.RFC3339)),
+	}
+
+	return vars
+}
+
+// ruleARN builds the EventBridge rule ARN, matching the wire handler's format.
+func (m *Mock) ruleARN(bus, rule string) string {
+	if bus == "" {
+		bus = defaultBusName
+	}
+
+	return "arn:aws:events:" + m.opts.Region + ":" + m.opts.AccountID + ":rule/" + bus + "/" + rule
+}
+
+// envelopeWithoutDetail returns the event envelope with its "detail" field
+// removed, which is what the <aws.events.event> reserved variable substitutes.
+func envelopeWithoutDetail(envelope []byte) json.RawMessage {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(envelope, &obj); err != nil {
+		return envelope
+	}
+
+	delete(obj, "detail")
+
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return envelope
+	}
+
+	return out
 }
 
 // eventEnvelope renders the standard EventBridge delivery envelope for an event.
@@ -494,6 +547,14 @@ func (m *Mock) eventEnvelope(event *driver.Event) []byte {
 	detail := json.RawMessage(event.Detail)
 	if len(detail) == 0 {
 		detail = json.RawMessage("{}")
+	}
+
+	// The EventBridge envelope always carries "resources" as an array; when the
+	// event has none it is delivered as [] (never null), so consumers can iterate
+	// without a nil check.
+	resources := event.Resources
+	if resources == nil {
+		resources = []string{}
 	}
 
 	body, err := json.Marshal(map[string]any{
@@ -504,7 +565,7 @@ func (m *Mock) eventEnvelope(event *driver.Event) []byte {
 		"account":     m.opts.AccountID,
 		"time":        event.Time.UTC().Format(time.RFC3339),
 		"region":      m.opts.Region,
-		"resources":   event.Resources,
+		"resources":   resources,
 		"detail":      detail,
 	})
 	if err != nil {

--- a/providers/aws/eventbridge/target_input.go
+++ b/providers/aws/eventbridge/target_input.go
@@ -11,9 +11,9 @@ import (
 // the rendered event envelope. Precedence mirrors real EventBridge, where a
 // target carries at most one of these: InputTransformer > Input > InputPath >
 // the raw envelope.
-func targetBody(t *driver.Target, envelope []byte) string {
+func targetBody(t *driver.Target, envelope []byte, reserved map[string]json.RawMessage) string {
 	if t.InputTransformer != "" {
-		if body, ok := applyInputTransformer(t.InputTransformer, envelope); ok {
+		if body, ok := applyInputTransformer(t.InputTransformer, envelope, reserved); ok {
 			return body
 		}
 	}
@@ -37,10 +37,12 @@ type inputTransformer struct {
 }
 
 // applyInputTransformer substitutes each InputPathsMap variable (extracted from
-// the envelope by its JSONPath) into InputTemplate. When the template is a JSON
-// string literal, the delivered body is its unquoted value — matching how
-// EventBridge delivers a quoted transformer template.
-func applyInputTransformer(raw string, envelope []byte) (string, bool) {
+// the envelope by its JSONPath) into InputTemplate, then substitutes the
+// predefined reserved variables (<aws.events.*>) EventBridge supports without an
+// InputPathsMap declaration. When the template is a JSON string literal, the
+// delivered body is its unquoted value — matching how EventBridge delivers a
+// quoted transformer template.
+func applyInputTransformer(raw string, envelope []byte, reserved map[string]json.RawMessage) (string, bool) {
 	var it inputTransformer
 	if err := json.Unmarshal([]byte(raw), &it); err != nil || it.InputTemplate == "" {
 		return "", false
@@ -57,6 +59,8 @@ func applyInputTransformer(raw string, envelope []byte) (string, bool) {
 		result = strings.ReplaceAll(result, "<"+name+">", templateText(val))
 	}
 
+	result = substituteReserved(result, reserved)
+
 	trimmed := strings.TrimSpace(it.InputTemplate)
 	if strings.HasPrefix(trimmed, "\"") && strings.HasSuffix(trimmed, "\"") {
 		var unquoted string
@@ -66,6 +70,38 @@ func applyInputTransformer(raw string, envelope []byte) (string, bool) {
 	}
 
 	return result, true
+}
+
+// reservedVarOrder lists the predefined transformer variables longest-name
+// first, so a shorter reserved name (e.g. aws.events.event) never clobbers a
+// longer one (aws.events.event.json) during literal replacement.
+var reservedVarOrder = []string{ //nolint:gochecknoglobals // fixed substitution order
+	"aws.events.event.ingestion-time",
+	"aws.events.event.json",
+	"aws.events.rule-name",
+	"aws.events.rule-arn",
+	"aws.events.event",
+}
+
+// substituteReserved replaces every <aws.events.*> reserved variable in the
+// template with its value. Reserved variables need not be declared in
+// InputPathsMap and cannot be overwritten by one, so they are substituted after
+// the user variables.
+func substituteReserved(template string, reserved map[string]json.RawMessage) string {
+	for _, name := range reservedVarOrder {
+		val, ok := reserved[name]
+		if !ok {
+			continue
+		}
+
+		// Reserved variables are substituted as their raw JSON: a string keeps its
+		// quotes and an object/array its braces, so a JSON-value placeholder such as
+		// "ruleName": <aws.events.rule-name> stays valid JSON — matching how
+		// EventBridge auto-quotes reserved string variables.
+		template = strings.ReplaceAll(template, "<"+name+">", string(val))
+	}
+
+	return template
 }
 
 // templateText renders an extracted JSON value for substitution into a

--- a/providers/aws/eventbridge/target_input.go
+++ b/providers/aws/eventbridge/target_input.go
@@ -37,29 +37,20 @@ type inputTransformer struct {
 }
 
 // applyInputTransformer substitutes each InputPathsMap variable (extracted from
-// the envelope by its JSONPath) into InputTemplate, then substitutes the
-// predefined reserved variables (<aws.events.*>) EventBridge supports without an
-// InputPathsMap declaration. When the template is a JSON string literal, the
-// delivered body is its unquoted value — matching how EventBridge delivers a
-// quoted transformer template.
+// the envelope by its JSONPath) and the predefined reserved variables
+// (<aws.events.*>, which need no InputPathsMap declaration) into InputTemplate.
+// Substitution is quote-context aware, matching EventBridge: a string value is
+// auto-quoted when the placeholder is a standalone JSON field value, but inserted
+// unquoted when the placeholder already sits inside a quoted string literal
+// (AWS's "Including reserved variables in a string" behavior). When the whole
+// template is a JSON string literal, the delivered body is its unquoted value.
 func applyInputTransformer(raw string, envelope []byte, reserved map[string]json.RawMessage) (string, bool) {
 	var it inputTransformer
 	if err := json.Unmarshal([]byte(raw), &it); err != nil || it.InputTemplate == "" {
 		return "", false
 	}
 
-	result := it.InputTemplate
-
-	for name, path := range it.InputPathsMap {
-		val, ok := extractPath(envelope, path)
-		if !ok {
-			val = json.RawMessage("null")
-		}
-
-		result = strings.ReplaceAll(result, "<"+name+">", templateText(val))
-	}
-
-	result = substituteReserved(result, reserved)
+	result := substituteVars(it.InputTemplate, it.InputPathsMap, envelope, reserved)
 
 	trimmed := strings.TrimSpace(it.InputTemplate)
 	if strings.HasPrefix(trimmed, "\"") && strings.HasSuffix(trimmed, "\"") {
@@ -72,46 +63,124 @@ func applyInputTransformer(raw string, envelope []byte, reserved map[string]json
 	return result, true
 }
 
-// reservedVarOrder lists the predefined transformer variables longest-name
-// first, so a shorter reserved name (e.g. aws.events.event) never clobbers a
-// longer one (aws.events.event.json) during literal replacement.
-var reservedVarOrder = []string{ //nolint:gochecknoglobals // fixed substitution order
-	"aws.events.event.ingestion-time",
-	"aws.events.event.json",
-	"aws.events.rule-name",
-	"aws.events.rule-arn",
-	"aws.events.event",
-}
+// substituteVars replaces every <name> placeholder in the template in a single
+// left-to-right pass that tracks whether the placeholder sits inside a quoted
+// JSON string literal. Reserved <aws.events.*> variables take precedence over
+// InputPathsMap variables (reserved names cannot be overwritten). A string value
+// is emitted unquoted inside a string context and quoted in a standalone JSON
+// field context; object/array/number values are emitted as raw JSON, and quotes
+// are stripped from them inside a string context (matching EventBridge, which
+// removes internal quotes to keep a string valid).
+func substituteVars(template string, paths map[string]string, envelope []byte, reserved map[string]json.RawMessage) string {
+	var b strings.Builder
 
-// substituteReserved replaces every <aws.events.*> reserved variable in the
-// template with its value. Reserved variables need not be declared in
-// InputPathsMap and cannot be overwritten by one, so they are substituted after
-// the user variables.
-func substituteReserved(template string, reserved map[string]json.RawMessage) string {
-	for _, name := range reservedVarOrder {
-		val, ok := reserved[name]
-		if !ok {
+	inString := false
+
+	i := 0
+	for i < len(template) {
+		c := template[i]
+
+		if inString && c == '\\' && i+1 < len(template) {
+			b.WriteByte(c)
+			b.WriteByte(template[i+1])
+
+			i += 2
+
 			continue
 		}
 
-		// Reserved variables are substituted as their raw JSON: a string keeps its
-		// quotes and an object/array its braces, so a JSON-value placeholder such as
-		// "ruleName": <aws.events.rule-name> stays valid JSON — matching how
-		// EventBridge auto-quotes reserved string variables.
-		template = strings.ReplaceAll(template, "<"+name+">", string(val))
+		if c == '"' {
+			inString = !inString
+
+			b.WriteByte(c)
+
+			i++
+
+			continue
+		}
+
+		if repl, n, ok := matchVar(template[i:], inString, paths, envelope, reserved); ok {
+			b.WriteString(repl)
+
+			i += n
+
+			continue
+		}
+
+		b.WriteByte(c)
+
+		i++
 	}
 
-	return template
+	return b.String()
 }
 
-// templateText renders an extracted JSON value for substitution into a
-// transformer template: a JSON string yields its raw (unquoted) content, so a
-// quoted placeholder such as "<st>" stays valid JSON; any other value yields
-// its compact JSON form.
-func templateText(val json.RawMessage) string {
+// matchVar tests whether s begins with a <name> placeholder for a known
+// transformer variable. On a match it returns the rendered substitution (given
+// the surrounding quote context), the number of bytes the placeholder occupies,
+// and true; otherwise the leading byte is not the start of a substitution.
+func matchVar(
+	s string,
+	inString bool,
+	paths map[string]string,
+	envelope []byte,
+	reserved map[string]json.RawMessage,
+) (rendered string, consumed int, matched bool) {
+	if s == "" || s[0] != '<' {
+		return "", 0, false
+	}
+
+	end := strings.IndexByte(s, '>')
+	if end <= 0 {
+		return "", 0, false
+	}
+
+	val, ok := resolveVar(s[1:end], paths, envelope, reserved)
+	if !ok {
+		return "", 0, false
+	}
+
+	return renderVar(val, inString), end + 1, true
+}
+
+// resolveVar returns the JSON value for a transformer variable name: a reserved
+// <aws.events.*> variable if defined, otherwise the InputPathsMap variable
+// resolved against the envelope. A declared InputPathsMap variable whose JSONPath
+// is missing resolves to null; an unknown name is not a variable at all.
+func resolveVar(name string, paths map[string]string, envelope []byte, reserved map[string]json.RawMessage) (json.RawMessage, bool) {
+	if val, ok := reserved[name]; ok {
+		return val, true
+	}
+
+	path, ok := paths[name]
+	if !ok {
+		return nil, false
+	}
+
+	val, ok := extractPath(envelope, path)
+	if !ok {
+		return json.RawMessage("null"), true
+	}
+
+	return val, true
+}
+
+// renderVar formats a variable's JSON value for substitution given whether the
+// placeholder sits inside a quoted string literal. A JSON string is unquoted
+// inside a string context and kept quoted (raw JSON) standalone; any other value
+// is emitted as raw JSON, with its quotes stripped inside a string context.
+func renderVar(val json.RawMessage, inString bool) string {
 	var s string
 	if err := json.Unmarshal(val, &s); err == nil {
-		return s
+		if inString {
+			return s
+		}
+
+		return string(val)
+	}
+
+	if inString {
+		return strings.ReplaceAll(string(val), "\"", "")
 	}
 
 	return string(val)

--- a/providers/aws/eventbridge/target_input_test.go
+++ b/providers/aws/eventbridge/target_input_test.go
@@ -70,6 +70,89 @@ func TestEventBridgeInputTransformer(t *testing.T) {
 	}
 }
 
+// TestEventBridgeReservedVarInString covers AWS's "Including reserved variables
+// in a string" pattern: a reserved string variable inside a quoted string literal
+// is inserted unquoted, so "<aws.events.rule-name> triggered" yields
+// "example triggered" (delivered as the unquoted string), not corrupted output.
+func TestEventBridgeReservedVarInString(t *testing.T) {
+	it, _ := json.Marshal(map[string]any{
+		"InputTemplate": `"<aws.events.rule-name> triggered"`,
+	})
+
+	body := deliverWithTarget(t, ebdriver.Target{ID: "1", InputTransformer: string(it)}, "app", `{"state":"ok"}`)
+
+	if body != "r triggered" {
+		t.Fatalf("reserved-in-string body = %q, want %q", body, "r triggered")
+	}
+}
+
+// TestEventBridgeReservedVarStandalone covers AWS's "Including reserved variables
+// in JSON" pattern: a reserved string variable used as a standalone JSON field
+// value is auto-quoted, and a reserved object variable is inserted raw, so the
+// delivered body is valid JSON.
+func TestEventBridgeReservedVarStandalone(t *testing.T) {
+	it, _ := json.Marshal(map[string]any{
+		"InputTemplate": `{"ruleName":<aws.events.rule-name>,"whole":<aws.events.event.json>}`,
+	})
+
+	body := deliverWithTarget(t, ebdriver.Target{ID: "1", InputTransformer: string(it)}, "app", `{"state":"ok"}`)
+
+	var got struct {
+		RuleName string         `json:"ruleName"`
+		Whole    map[string]any `json:"whole"`
+	}
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("standalone reserved body not valid JSON: %v (%s)", err, body)
+	}
+
+	if got.RuleName != "r" {
+		t.Fatalf("ruleName = %q, want %q (auto-quoted reserved string)", got.RuleName, "r")
+	}
+
+	if got.Whole["source"] != "app" {
+		t.Fatalf("aws.events.event.json did not embed the full event: %s", body)
+	}
+}
+
+// TestEventBridgeUserVarStandaloneQuoted covers AWS's "Simple JSON" pattern: a
+// string user variable used as a standalone JSON field value (no surrounding
+// quotes in the template) is auto-quoted so the output is valid JSON.
+func TestEventBridgeUserVarStandaloneQuoted(t *testing.T) {
+	it, _ := json.Marshal(map[string]any{
+		"InputPathsMap": map[string]string{"st": "$.detail.state"},
+		"InputTemplate": `{"state":<st>}`,
+	})
+
+	body := deliverWithTarget(t, ebdriver.Target{ID: "1", InputTransformer: string(it)}, "app", `{"state":"ok"}`)
+
+	if body != `{"state":"ok"}` {
+		t.Fatalf("standalone user-var body = %q, want %q", body, `{"state":"ok"}`)
+	}
+}
+
+// TestEventBridgeMixedVarsInString covers a reserved and a user variable embedded
+// together inside one string literal alongside escaped quotes: both are inserted
+// unquoted so the surrounding string stays intact.
+func TestEventBridgeMixedVarsInString(t *testing.T) {
+	it, _ := json.Marshal(map[string]any{
+		"InputPathsMap": map[string]string{"st": "$.detail.state"},
+		"InputTemplate": `{"msg":"rule <aws.events.rule-name> saw \"<st>\""}`,
+	})
+
+	body := deliverWithTarget(t, ebdriver.Target{ID: "1", InputTransformer: string(it)}, "app", `{"state":"ok"}`)
+
+	var got struct {
+		Msg string `json:"msg"`
+	}
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("mixed-in-string body not valid JSON: %v (%s)", err, body)
+	}
+
+	if got.Msg != `rule r saw "ok"` {
+		t.Fatalf("msg = %q, want %q", got.Msg, `rule r saw "ok"`)
+	}
+}
+
 func TestEventBridgeConstantInput(t *testing.T) {
 	body := deliverWithTarget(t, ebdriver.Target{ID: "1", Input: `{"hello":"world"}`}, "app", `{"state":"ok"}`)
 

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -377,7 +377,7 @@ func (m *Mock) fanOutToSQS(ctx context.Context, td *topicData, msgID string, inp
 			continue
 		}
 
-		envelope, err := m.notificationEnvelope(td, msgID, input)
+		envelope, err := m.notificationEnvelope(td, msgID, input, sub.ID)
 		if err != nil {
 			continue
 		}
@@ -388,14 +388,25 @@ func (m *Mock) fanOutToSQS(ctx context.Context, td *topicData, msgID string, inp
 
 // notificationEnvelope builds the SNS Notification JSON that wraps a published
 // message for a non-raw SQS subscription.
-func (m *Mock) notificationEnvelope(td *topicData, msgID string, input driver.PublishInput) (string, error) {
+func (m *Mock) notificationEnvelope(td *topicData, msgID string, input driver.PublishInput, subARN string) (string, error) {
 	env := map[string]any{
-		"Type":      "Notification",
-		"MessageId": msgID,
-		"TopicArn":  td.info.ResourceID,
-		"Subject":   input.Subject,
-		"Message":   input.Message,
-		"Timestamp": m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		"Type":             "Notification",
+		"MessageId":        msgID,
+		"TopicArn":         td.info.ResourceID,
+		"Message":          input.Message,
+		"Timestamp":        m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		"SignatureVersion": "1",
+		"Signature":        "Q2xvdWRFbXVFeGFtcGxlU2lnbmF0dXJl",
+		"SigningCertURL": "https://sns." + m.opts.Region +
+			".amazonaws.com/SimpleNotificationService-cloudemu.pem",
+		"UnsubscribeURL": "https://sns." + m.opts.Region +
+			".amazonaws.com/?Action=Unsubscribe&SubscriptionArn=" + subARN,
+	}
+
+	// Subject is optional: real SNS omits the field entirely when the message was
+	// published without one, so consumers presence-check rather than see "".
+	if input.Subject != "" {
+		env["Subject"] = input.Subject
 	}
 
 	// Real SNS carries publish MessageAttributes into the SQS envelope as

--- a/server/aws/eventbridge/delivery_sdk_test.go
+++ b/server/aws/eventbridge/delivery_sdk_test.go
@@ -275,6 +275,53 @@ func TestSDKEventBridgeReservedTransformerVars(t *testing.T) {
 	}
 }
 
+// TestSDKEventBridgeReservedVarInString verifies AWS's "Including reserved
+// variables in a string" pattern over the wire: a reserved string variable inside
+// a quoted string literal is inserted unquoted, so the template
+// "<aws.events.rule-name> triggered" is delivered as "r triggered" rather than a
+// corrupted double-quoted string.
+func TestSDKEventBridgeReservedVarInString(t *testing.T) {
+	eb, sqs := newEBAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := makeQueue(t, sqs, "eb-reserved-string")
+
+	if _, err := eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventPattern: aws.String(`{"source":["app"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule: aws.String("r"),
+		Targets: []ebtypes.Target{{
+			Id:  aws.String("1"),
+			Arn: aws.String(arn),
+			InputTransformer: &ebtypes.InputTransformer{
+				InputTemplate: aws.String(`"<aws.events.rule-name> triggered"`),
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("app"), DetailType: aws.String("t"), Detail: aws.String(`{"state":"ok"}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	body, count := receiveOne(t, sqs, url)
+	if count != 1 {
+		t.Fatalf("delivered %d messages, want 1", count)
+	}
+
+	if body != "r triggered" {
+		t.Fatalf("reserved-in-string body = %q, want %q", body, "r triggered")
+	}
+}
+
 // TestSDKEventBridgeResourcesAlwaysArray verifies the delivered envelope carries
 // "resources" as an empty array (never null) when the event has none.
 func TestSDKEventBridgeResourcesAlwaysArray(t *testing.T) {

--- a/server/aws/eventbridge/delivery_sdk_test.go
+++ b/server/aws/eventbridge/delivery_sdk_test.go
@@ -2,6 +2,7 @@ package eventbridge_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
 
@@ -204,5 +205,130 @@ func TestSDKEventBridgeConstantInputDelivery(t *testing.T) {
 
 	if body != `{"hello":"world"}` {
 		t.Fatalf("constant input body = %q, want the constant", body)
+	}
+}
+
+// TestSDKEventBridgeReservedTransformerVars verifies that reserved transformer
+// variables (which need not be declared in InputPathsMap) are substituted:
+// <aws.events.event.json> embeds the full event, and the mixed user/reserved
+// template still yields valid JSON.
+func TestSDKEventBridgeReservedTransformerVars(t *testing.T) {
+	eb, sqs := newEBAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := makeQueue(t, sqs, "eb-reserved")
+
+	if _, err := eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventPattern: aws.String(`{"source":["app"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule: aws.String("r"),
+		Targets: []ebtypes.Target{{
+			Id:  aws.String("1"),
+			Arn: aws.String(arn),
+			InputTransformer: &ebtypes.InputTransformer{
+				InputPathsMap: map[string]string{"st": "$.detail.state"},
+				InputTemplate: aws.String(
+					`{"whole":<aws.events.event.json>,"picked":"<st>","rule":<aws.events.rule-name>}`),
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("app"), DetailType: aws.String("t"), Detail: aws.String(`{"state":"ok"}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	body, count := receiveOne(t, sqs, url)
+	if count != 1 {
+		t.Fatalf("delivered %d messages, want 1", count)
+	}
+
+	// The reserved variable must be substituted, not left as literal text, so the
+	// delivered body parses as JSON.
+	var got struct {
+		Whole  map[string]any `json:"whole"`
+		Picked string         `json:"picked"`
+		Rule   string         `json:"rule"`
+	}
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("delivered body is not valid JSON (%v): %s", err, body)
+	}
+
+	if got.Picked != "ok" {
+		t.Fatalf("picked = %q, want %q", got.Picked, "ok")
+	}
+
+	if got.Rule != "r" {
+		t.Fatalf("rule = %q, want %q (aws.events.rule-name)", got.Rule, "r")
+	}
+
+	if got.Whole["source"] != "app" {
+		t.Fatalf("aws.events.event.json did not embed the full event: %s", body)
+	}
+}
+
+// TestSDKEventBridgeResourcesAlwaysArray verifies the delivered envelope carries
+// "resources" as an empty array (never null) when the event has none.
+func TestSDKEventBridgeResourcesAlwaysArray(t *testing.T) {
+	eb, sqs := newEBAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := makeQueue(t, sqs, "eb-resources")
+
+	if _, err := eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventPattern: aws.String(`{"source":["app"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule:    aws.String("r"),
+		Targets: []ebtypes.Target{{Id: aws.String("1"), Arn: aws.String(arn)}},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("app"), DetailType: aws.String("t"), Detail: aws.String(`{"state":"ok"}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	body, count := receiveOne(t, sqs, url)
+	if count != 1 {
+		t.Fatalf("delivered %d messages, want 1", count)
+	}
+
+	var env map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("envelope not JSON: %v", err)
+	}
+
+	raw, ok := env["resources"]
+	if !ok {
+		t.Fatalf("envelope missing resources field: %s", body)
+	}
+
+	if string(raw) != "[]" {
+		t.Fatalf("resources = %s, want [] (never null)", raw)
+	}
+
+	// A strict decode into a slice must succeed and range cleanly.
+	var res []string
+	if err := json.Unmarshal(raw, &res); err != nil {
+		t.Fatalf("resources did not decode as an array: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Fatalf("resources len = %d, want 0", len(res))
 	}
 }

--- a/server/aws/sns/filter_sdk_test.go
+++ b/server/aws/sns/filter_sdk_test.go
@@ -186,3 +186,80 @@ func TestSDKSNSRawMessageDelivery(t *testing.T) {
 		t.Fatalf("raw delivery still wrapped in envelope: %s", got[0])
 	}
 }
+
+// TestSDKSNSNotificationEnvelopeFields verifies the SNS->SQS Notification JSON:
+// Subject is omitted when none was published, and the standard SignatureVersion,
+// Signature, SigningCertURL, and UnsubscribeURL fields are always present.
+func TestSDKSNSNotificationEnvelopeFields(t *testing.T) {
+	sns, sqs := newSNSAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := snsQueue(t, sqs, "envelope")
+
+	topic, err := sns.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("feed")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	if _, err := sns.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn:              topic.TopicArn,
+		Protocol:              aws.String("sqs"),
+		Endpoint:              aws.String(arn),
+		ReturnSubscriptionArn: true,
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	// Publish WITHOUT a Subject.
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn: topic.TopicArn,
+		Message:  aws.String("hello world"),
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	got := drain(t, sqs, url)
+	if len(got) != 1 {
+		t.Fatalf("delivered %d, want 1", len(got))
+	}
+
+	var env map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(got[0]), &env); err != nil {
+		t.Fatalf("envelope not JSON: %v", err)
+	}
+
+	if _, ok := env["Subject"]; ok {
+		t.Fatalf("Subject present with no subject published; AWS omits the key: %s", got[0])
+	}
+
+	for _, field := range []string{"SignatureVersion", "Signature", "SigningCertURL", "UnsubscribeURL"} {
+		if _, ok := env[field]; !ok {
+			t.Fatalf("envelope missing standard field %q: %s", field, got[0])
+		}
+	}
+
+	// With a Subject, the key appears.
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn: topic.TopicArn,
+		Subject:  aws.String("greeting"),
+		Message:  aws.String("hi"),
+	}); err != nil {
+		t.Fatalf("Publish(subject): %v", err)
+	}
+
+	got = drain(t, sqs, url)
+	if len(got) != 1 {
+		t.Fatalf("delivered %d, want 1", len(got))
+	}
+
+	var withSubject struct {
+		Subject string `json:"Subject"`
+	}
+	if err := json.Unmarshal([]byte(got[0]), &withSubject); err != nil {
+		t.Fatalf("envelope not JSON: %v", err)
+	}
+
+	if withSubject.Subject != "greeting" {
+		t.Fatalf("Subject = %q, want %q", withSubject.Subject, "greeting")
+	}
+}


### PR DESCRIPTION
## Summary

Round-4 AWS confirmation-audit fixes in the messaging delivery path. Three edges where the delivered payload diverged from real AWS wire semantics.

### EventBridge InputTransformer reserved variables
Input transformers support predefined variables that need not be declared in `InputPathsMap`: `<aws.events.event.json>`, `<aws.events.event>`, `<aws.events.rule-arn>`, `<aws.events.rule-name>`, `<aws.events.event.ingestion-time>`. Previously only `InputPathsMap` names were substituted, so a reserved variable was delivered as literal text — e.g. a template `{"whole":<aws.events.event.json>,...}` produced invalid JSON. Reserved variables are now substituted after the user variables: `<aws.events.event.json>` embeds the full envelope, `<aws.events.event>` the envelope without `detail`, and the string variables are inserted as quoted JSON (matching EventBridge auto-quoting in value position).

### EventBridge delivery envelope `resources` field
The delivered envelope always carries `resources` as an array; when the event has none it is now `[]` instead of `null`, so downstream consumers can iterate without a nil check / strict decode failure.

### SNS -> SQS Notification envelope
- `Subject` is now omitted entirely when the message was published without one (AWS: "if no Subject was specified, then this name-value pair does not appear") instead of being sent as `""`.
- The envelope now always includes the standard `SignatureVersion`, `Signature`, `SigningCertURL`, and `UnsubscribeURL` fields that real SNS carries.

## Tests
Added real aws-sdk-go-v2 SDK tests over the wire server:
- `TestSDKEventBridgeReservedTransformerVars` — reserved-variable substitution yields valid JSON with the full event embedded.
- `TestSDKEventBridgeResourcesAlwaysArray` — `resources` decodes as an empty array, never null.
- `TestSDKSNSNotificationEnvelopeFields` — `Subject` omitted with no subject / present with one; standard signature fields present.