### PR TITLE
fix(iam-secrets): GetAccountAuthorizationDetails inline+attached policies, IAM/Secrets/SSM list filters + pagination

### DIFF
--- a/server/aws/iam/account_authorization_details.go
+++ b/server/aws/iam/account_authorization_details.go
@@ -16,8 +16,8 @@ import (
 // GetAccountAuthorizationDetails returns a single aggregated snapshot of every
 // user, group, role, and managed policy in the account, each with its inline and
 // attached policies. It reads the same surfaces the individual list operations
-// expose, so it introduces no new provider state: what isn't modeled (user/group
-// inline policies, group-attached managed policies, RoleLastUsed,
+// expose (ListUserPolicies, ListGroupPolicies, ListAttachedGroupPolicies, etc.),
+// so it introduces no new provider state; what isn't modeled (RoleLastUsed,
 // PermissionsBoundary) is emitted empty or omitted rather than fabricated.
 
 type stringListXML struct {
@@ -268,6 +268,7 @@ func (h *Handler) buildUserDetails(ctx context.Context) []userDetailXML {
 
 		arns, _ := h.iam.ListAttachedUserPolicies(ctx, u.Name)
 		detail.AttachedManagedPolicies = attachedPoliciesFromARNs(arns)
+		detail.UserPolicyList = policyDetailListXML{Member: h.userInlinePolicies(ctx, u.Name)}
 
 		out = append(out, detail)
 	}
@@ -303,16 +304,59 @@ func (h *Handler) buildGroupDetails(ctx context.Context) []groupDetailXML {
 
 	for i := range groups {
 		g := &groups[i]
+		arns := h.groupAttachedPolicyARNs(ctx, g.Name)
 		out = append(out, groupDetailXML{
-			Path:       g.Path,
-			GroupName:  g.Name,
-			GroupID:    g.ID,
-			Arn:        g.ARN,
-			CreateDate: g.CreatedAt,
+			Path:                    g.Path,
+			GroupName:               g.Name,
+			GroupID:                 g.ID,
+			Arn:                     g.ARN,
+			CreateDate:              g.CreatedAt,
+			AttachedManagedPolicies: attachedPoliciesFromARNs(arns),
+			GroupPolicyList:         policyDetailListXML{Member: h.groupInlinePolicies(ctx, g.Name)},
 		})
 	}
 
 	return out
+}
+
+// userInlinePolicies returns a user's inline (embedded) policies as name+document
+// pairs, sorted by name. Empty when the driver does not expose inline user
+// policies. It reads the same surface ListUserPolicies/GetUserPolicy expose.
+func (h *Handler) userInlinePolicies(ctx context.Context, userName string) []policyDetailXML {
+	pm, ok := h.userPolicies()
+	if !ok {
+		return nil
+	}
+
+	return inlinePolicyDetails(ctx, userName, pm.ListUserPolicies, pm.GetUserPolicy)
+}
+
+// groupInlinePolicies returns a group's inline policies as name+document pairs,
+// sorted by name. It reads the same surface ListGroupPolicies/GetGroupPolicy
+// expose.
+func (h *Handler) groupInlinePolicies(ctx context.Context, groupName string) []policyDetailXML {
+	pm, ok := h.groupPolicies()
+	if !ok {
+		return nil
+	}
+
+	return inlinePolicyDetails(ctx, groupName, pm.ListGroupPolicies, pm.GetGroupPolicy)
+}
+
+// groupAttachedPolicyARNs returns the ARNs of the managed policies attached to a
+// group, or nil when the driver does not expose group-attached policies.
+func (h *Handler) groupAttachedPolicyARNs(ctx context.Context, groupName string) []string {
+	pm, ok := h.groupPolicies()
+	if !ok {
+		return nil
+	}
+
+	arns, err := pm.ListAttachedGroupPolicies(ctx, groupName)
+	if err != nil {
+		return nil
+	}
+
+	return arns
 }
 
 func (h *Handler) buildRoleDetails(ctx context.Context) []roleDetailXML {
@@ -364,13 +408,15 @@ func roleInstanceProfiles(role *iamdriver.RoleInfo, profiles []iamdriver.Instanc
 	return out
 }
 
-func (h *Handler) roleInlinePolicies(ctx context.Context, roleName string) []policyDetailXML {
-	pm, ok := h.rolePolicies()
-	if !ok {
-		return nil
-	}
-
-	names, err := pm.ListRolePolicies(ctx, roleName)
+// inlinePolicyDetails materializes an owner's inline policies as sorted
+// name+document pairs, using the list/get pair for whichever entity kind (role,
+// user, or group) the caller binds. A policy whose document can't be read is
+// skipped rather than emitted empty.
+func inlinePolicyDetails(ctx context.Context, owner string,
+	list func(context.Context, string) ([]string, error),
+	get func(context.Context, string, string) (string, error),
+) []policyDetailXML {
+	names, err := list(ctx, owner)
 	if err != nil {
 		return nil
 	}
@@ -380,7 +426,7 @@ func (h *Handler) roleInlinePolicies(ctx context.Context, roleName string) []pol
 	out := make([]policyDetailXML, 0, len(names))
 
 	for _, name := range names {
-		doc, err := pm.GetRolePolicy(ctx, roleName, name)
+		doc, err := get(ctx, owner, name)
 		if err != nil {
 			continue
 		}
@@ -389,6 +435,15 @@ func (h *Handler) roleInlinePolicies(ctx context.Context, roleName string) []pol
 	}
 
 	return out
+}
+
+func (h *Handler) roleInlinePolicies(ctx context.Context, roleName string) []policyDetailXML {
+	pm, ok := h.rolePolicies()
+	if !ok {
+		return nil
+	}
+
+	return inlinePolicyDetails(ctx, roleName, pm.ListRolePolicies, pm.GetRolePolicy)
 }
 
 func (h *Handler) buildPolicyDetails(ctx context.Context, filter gaadFilter) []managedPolicyDetailXML {

--- a/server/aws/iam/account_authorization_details_policies_test.go
+++ b/server/aws/iam/account_authorization_details_policies_test.go
@@ -1,0 +1,109 @@
+package iam_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// TestSDKGetAccountAuthorizationDetailsInlineAndAttached verifies GAAD reports a
+// user's inline policies (UserPolicyList), a group's inline policies
+// (GroupPolicyList), and a group's attached managed policies
+// (AttachedManagedPolicies) — the same surfaces ListUserPolicies,
+// ListGroupPolicies, and ListAttachedGroupPolicies expose individually.
+func TestSDKGetAccountAuthorizationDetailsInlineAndAttached(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("bob")}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+		UserName:       aws.String("bob"),
+		PolicyName:     aws.String("deny-billing"),
+		PolicyDocument: aws.String(samplePolicy),
+	}); err != nil {
+		t.Fatalf("PutUserPolicy: %v", err)
+	}
+
+	if _, err := client.CreateGroup(ctx, &iam.CreateGroupInput{GroupName: aws.String("finance")}); err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+
+	if _, err := client.PutGroupPolicy(ctx, &iam.PutGroupPolicyInput{
+		GroupName:      aws.String("finance"),
+		PolicyName:     aws.String("policygen"),
+		PolicyDocument: aws.String(samplePolicy),
+	}); err != nil {
+		t.Fatalf("PutGroupPolicy: %v", err)
+	}
+
+	pol, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String("admin-access"),
+		PolicyDocument: aws.String(samplePolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	arn := aws.ToString(pol.Policy.Arn)
+
+	if _, err := client.AttachGroupPolicy(ctx, &iam.AttachGroupPolicyInput{
+		GroupName: aws.String("finance"), PolicyArn: aws.String(arn),
+	}); err != nil {
+		t.Fatalf("AttachGroupPolicy: %v", err)
+	}
+
+	out, err := client.GetAccountAuthorizationDetails(ctx, &iam.GetAccountAuthorizationDetailsInput{})
+	if err != nil {
+		t.Fatalf("GetAccountAuthorizationDetails: %v", err)
+	}
+
+	user := findUserDetail(t, out.UserDetailList, "bob")
+	if len(user.UserPolicyList) != 1 || aws.ToString(user.UserPolicyList[0].PolicyName) != "deny-billing" {
+		t.Fatalf("bob UserPolicyList = %+v, want one deny-billing", user.UserPolicyList)
+	}
+
+	group := findGroupDetail(t, out.GroupDetailList, "finance")
+	if len(group.GroupPolicyList) != 1 || aws.ToString(group.GroupPolicyList[0].PolicyName) != "policygen" {
+		t.Fatalf("finance GroupPolicyList = %+v, want one policygen", group.GroupPolicyList)
+	}
+
+	if len(group.AttachedManagedPolicies) != 1 ||
+		aws.ToString(group.AttachedManagedPolicies[0].PolicyArn) != arn {
+		t.Fatalf("finance AttachedManagedPolicies = %+v, want one entry for %s",
+			group.AttachedManagedPolicies, arn)
+	}
+}
+
+func findUserDetail(t *testing.T, users []iamtypes.UserDetail, name string) iamtypes.UserDetail {
+	t.Helper()
+
+	for i := range users {
+		if aws.ToString(users[i].UserName) == name {
+			return users[i]
+		}
+	}
+
+	t.Fatalf("user %q not present in GAAD UserDetailList", name)
+
+	return iamtypes.UserDetail{}
+}
+
+func findGroupDetail(t *testing.T, groups []iamtypes.GroupDetail, name string) iamtypes.GroupDetail {
+	t.Helper()
+
+	for i := range groups {
+		if aws.ToString(groups[i].GroupName) == name {
+			return groups[i]
+		}
+	}
+
+	t.Fatalf("group %q not present in GAAD GroupDetailList", name)
+
+	return iamtypes.GroupDetail{}
+}

--- a/server/aws/iam/list_path_prefix_test.go
+++ b/server/aws/iam/list_path_prefix_test.go
@@ -1,0 +1,110 @@
+package iam_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+)
+
+// TestSDKListUsersPathPrefix verifies ListUsers honors PathPrefix, returning
+// only users whose path begins with the requested prefix.
+func TestSDKListUsersPathPrefix(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	mk := func(name, path string) {
+		if _, err := client.CreateUser(ctx, &iam.CreateUserInput{
+			UserName: aws.String(name), Path: aws.String(path),
+		}); err != nil {
+			t.Fatalf("CreateUser %s: %v", name, err)
+		}
+	}
+
+	mk("alice", "/team-a/")
+	mk("bob", "/team-a/")
+	mk("carol", "/team-b/")
+
+	out, err := client.ListUsers(ctx, &iam.ListUsersInput{PathPrefix: aws.String("/team-a/")})
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+
+	if len(out.Users) != 2 {
+		t.Fatalf("PathPrefix=/team-a/ returned %d users, want 2", len(out.Users))
+	}
+
+	for _, u := range out.Users {
+		if !strings.HasPrefix(aws.ToString(u.Path), "/team-a/") {
+			t.Fatalf("user %s path %q not under /team-a/", aws.ToString(u.UserName), aws.ToString(u.Path))
+		}
+	}
+
+	// The default (no PathPrefix) still returns every user.
+	all, err := client.ListUsers(ctx, &iam.ListUsersInput{})
+	if err != nil {
+		t.Fatalf("ListUsers all: %v", err)
+	}
+
+	if len(all.Users) != 3 {
+		t.Fatalf("ListUsers with no PathPrefix returned %d users, want 3", len(all.Users))
+	}
+}
+
+// TestSDKListRolesPathPrefix verifies ListRoles honors PathPrefix.
+func TestSDKListRolesPathPrefix(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	mk := func(name, path string) {
+		if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+			RoleName:                 aws.String(name),
+			Path:                     aws.String(path),
+			AssumeRolePolicyDocument: aws.String(trustPolicy),
+		}); err != nil {
+			t.Fatalf("CreateRole %s: %v", name, err)
+		}
+	}
+
+	mk("svc-a", "/svc/")
+	mk("svc-b", "/svc/")
+	mk("app-x", "/app/")
+
+	out, err := client.ListRoles(ctx, &iam.ListRolesInput{PathPrefix: aws.String("/svc/")})
+	if err != nil {
+		t.Fatalf("ListRoles: %v", err)
+	}
+
+	if len(out.Roles) != 2 {
+		t.Fatalf("PathPrefix=/svc/ returned %d roles, want 2", len(out.Roles))
+	}
+}
+
+// TestSDKListGroupsPathPrefix verifies ListGroups honors PathPrefix.
+func TestSDKListGroupsPathPrefix(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	mk := func(name, path string) {
+		if _, err := client.CreateGroup(ctx, &iam.CreateGroupInput{
+			GroupName: aws.String(name), Path: aws.String(path),
+		}); err != nil {
+			t.Fatalf("CreateGroup %s: %v", name, err)
+		}
+	}
+
+	mk("eng-a", "/eng/")
+	mk("eng-b", "/eng/")
+	mk("ops-a", "/ops/")
+
+	out, err := client.ListGroups(ctx, &iam.ListGroupsInput{PathPrefix: aws.String("/eng/")})
+	if err != nil {
+		t.Fatalf("ListGroups: %v", err)
+	}
+
+	if len(out.Groups) != 2 {
+		t.Fatalf("PathPrefix=/eng/ returned %d groups, want 2", len(out.Groups))
+	}
+}

--- a/server/aws/iam/operations.go
+++ b/server/aws/iam/operations.go
@@ -162,6 +162,8 @@ func (h *Handler) listUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	users = filterByPathPrefix(users, r.Form.Get("PathPrefix"), func(u *iamdriver.UserInfo) string { return u.Path })
+
 	sort.Slice(users, func(i, j int) bool { return users[i].Name < users[j].Name })
 
 	start, end, marker, truncated := pageWindow(len(users), r.Form)
@@ -262,6 +264,8 @@ func (h *Handler) listRoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	roles = filterByPathPrefix(roles, r.Form.Get("PathPrefix"), func(role *iamdriver.RoleInfo) string { return role.Path })
+
 	sort.Slice(roles, func(i, j int) bool { return roles[i].Name < roles[j].Name })
 
 	start, end, marker, truncated := pageWindow(len(roles), r.Form)
@@ -357,6 +361,25 @@ func (h *Handler) listPolicies(w http.ResponseWriter, r *http.Request) {
 		Result:   listPoliciesResult{Policies: out, IsTruncated: truncated, Marker: marker},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
+}
+
+// filterByPathPrefix returns only the entities whose path begins with prefix,
+// implementing the PathPrefix request parameter shared by ListUsers, ListRoles,
+// and ListGroups. An empty prefix (the default) returns everything unchanged.
+func filterByPathPrefix[T any](items []T, prefix string, path func(*T) string) []T {
+	if prefix == "" {
+		return items
+	}
+
+	out := items[:0]
+
+	for i := range items {
+		if strings.HasPrefix(path(&items[i]), prefix) {
+			out = append(out, items[i])
+		}
+	}
+
+	return out
 }
 
 // awsManagedPolicyPrefix is the ARN prefix AWS-published (managed) policies
@@ -729,6 +752,8 @@ func (h *Handler) listGroups(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, err)
 		return
 	}
+
+	groups = filterByPathPrefix(groups, r.Form.Get("PathPrefix"), func(g *iamdriver.GroupInfo) string { return g.Path })
 
 	sort.Slice(groups, func(i, j int) bool { return groups[i].Name < groups[j].Name })
 

--- a/server/aws/secretsmanager/helpers.go
+++ b/server/aws/secretsmanager/helpers.go
@@ -72,8 +72,10 @@ func decodePageToken(token string) (int, error) {
 
 // matchesSecretFilters reports whether a secret satisfies every ListSecrets
 // filter (filters are AND'd, values within a filter OR'd). Supported keys are
-// name, description, tag-key, tag-value, and all — matching is substring-based
-// as the real service does.
+// name, description, tag-key, tag-value, and all. Matching mirrors the real
+// service: name/tag-key/tag-value are case-sensitive prefix matches, description
+// is a case-insensitive prefix match, and all tokenizes the value into words and
+// searches every attribute case-insensitively.
 func matchesSecretFilters(info *secretsdriver.SecretInfo, filters []secretFilter) bool {
 	for i := range filters {
 		if !matchesSecretFilter(info, &filters[i]) {
@@ -90,7 +92,7 @@ func matchesSecretFilter(info *secretsdriver.SecretInfo, f *secretFilter) bool {
 	}
 
 	for _, v := range f.Values {
-		if secretFieldContains(info, f.Key, v) {
+		if secretFieldMatches(info, f.Key, v) {
 			return true
 		}
 	}
@@ -98,37 +100,69 @@ func matchesSecretFilter(info *secretsdriver.SecretInfo, f *secretFilter) bool {
 	return false
 }
 
-func secretFieldContains(info *secretsdriver.SecretInfo, key, value string) bool {
+func secretFieldMatches(info *secretsdriver.SecretInfo, key, value string) bool {
 	switch key {
 	case "name":
-		return strings.Contains(info.Name, value)
+		return strings.HasPrefix(info.Name, value)
 	case "description":
-		return strings.Contains(info.Description, value)
+		return hasPrefixFold(info.Description, value)
 	case "tag-key":
-		return anyTagContains(info.Tags, value, true)
+		return anyTagHasPrefix(info.Tags, value, true)
 	case "tag-value":
-		return anyTagContains(info.Tags, value, false)
+		return anyTagHasPrefix(info.Tags, value, false)
 	case "all":
-		return secretFieldContains(info, "name", value) ||
-			secretFieldContains(info, "description", value) ||
-			secretFieldContains(info, "tag-key", value) ||
-			secretFieldContains(info, "tag-value", value)
+		return matchesAllWords(info, value)
 	default:
 		// Unsupported key: do not exclude on it.
 		return true
 	}
 }
 
-// anyTagContains reports whether any tag key (matchKey=true) or value contains
-// the substring.
-func anyTagContains(tags map[string]string, value string, matchKey bool) bool {
+// hasPrefixFold reports whether s begins with prefix, ignoring case.
+func hasPrefixFold(s, prefix string) bool {
+	return strings.HasPrefix(strings.ToLower(s), strings.ToLower(prefix))
+}
+
+// anyTagHasPrefix reports whether any tag key (matchKey=true) or value begins
+// with value (case-sensitive prefix, as the real service does).
+func anyTagHasPrefix(tags map[string]string, value string, matchKey bool) bool {
 	for k, v := range tags {
 		field := v
 		if matchKey {
 			field = k
 		}
 
-		if strings.Contains(field, value) {
+		if strings.HasPrefix(field, value) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchesAllWords implements the 'all' filter key: the value is split into
+// words and the secret matches only when every word appears (case-insensitive
+// substring) in the name, description, or any tag key/value.
+func matchesAllWords(info *secretsdriver.SecretInfo, value string) bool {
+	words := strings.Fields(value)
+	for _, w := range words {
+		if !anyAttrContainsFold(info, w) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func anyAttrContainsFold(info *secretsdriver.SecretInfo, word string) bool {
+	lw := strings.ToLower(word)
+	if strings.Contains(strings.ToLower(info.Name), lw) ||
+		strings.Contains(strings.ToLower(info.Description), lw) {
+		return true
+	}
+
+	for k, v := range info.Tags {
+		if strings.Contains(strings.ToLower(k), lw) || strings.Contains(strings.ToLower(v), lw) {
 			return true
 		}
 	}

--- a/server/aws/secretsmanager/list_secrets_filter_test.go
+++ b/server/aws/secretsmanager/list_secrets_filter_test.go
@@ -1,0 +1,154 @@
+package secretsmanager_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssm "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+)
+
+func secretNames(secrets []smtypes.SecretListEntry) []string {
+	out := make([]string, 0, len(secrets))
+	for i := range secrets {
+		out = append(out, aws.ToString(secrets[i].Name))
+	}
+
+	return out
+}
+
+// TestSDKListSecretsNameFilterPrefix verifies the name filter is a case-sensitive
+// PREFIX match, not a substring match. "prod/db/password" must NOT be returned
+// for name="db" even though it contains "db".
+func TestSDKListSecretsNameFilterPrefix(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"prod/db/password", "db-config"} {
+		if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+			Name: aws.String(name), SecretString: aws.String("x"),
+		}); err != nil {
+			t.Fatalf("CreateSecret %s: %v", name, err)
+		}
+	}
+
+	out, err := client.ListSecrets(ctx, &awssm.ListSecretsInput{
+		Filters: []smtypes.Filter{{
+			Key:    smtypes.FilterNameStringTypeName,
+			Values: []string{"db"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+
+	got := secretNames(out.SecretList)
+	if len(got) != 1 || got[0] != "db-config" {
+		t.Fatalf("name filter 'db' returned %v, want only [db-config] (prefix, not substring)", got)
+	}
+}
+
+// TestSDKListSecretsDescriptionFilterCaseInsensitivePrefix verifies the
+// description filter is a case-INSENSITIVE prefix match.
+func TestSDKListSecretsDescriptionFilterCaseInsensitivePrefix(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("api-key"), Description: aws.String("Production API token"),
+		SecretString: aws.String("x"),
+	}); err != nil {
+		t.Fatalf("CreateSecret api-key: %v", err)
+	}
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("db-key"), Description: aws.String("Staging database"),
+		SecretString: aws.String("x"),
+	}); err != nil {
+		t.Fatalf("CreateSecret db-key: %v", err)
+	}
+
+	// Lowercase "prod" must prefix-match "Production ..." case-insensitively.
+	out, err := client.ListSecrets(ctx, &awssm.ListSecretsInput{
+		Filters: []smtypes.Filter{{
+			Key:    smtypes.FilterNameStringTypeDescription,
+			Values: []string{"prod"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+
+	got := secretNames(out.SecretList)
+	if len(got) != 1 || got[0] != "api-key" {
+		t.Fatalf("description filter 'prod' returned %v, want only [api-key]", got)
+	}
+
+	// "database" is not a prefix of either description, so nothing matches.
+	none, err := client.ListSecrets(ctx, &awssm.ListSecretsInput{
+		Filters: []smtypes.Filter{{
+			Key:    smtypes.FilterNameStringTypeDescription,
+			Values: []string{"database"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ListSecrets database: %v", err)
+	}
+
+	if n := len(none.SecretList); n != 0 {
+		t.Fatalf("description filter 'database' returned %d secrets, want 0 (not a prefix)",
+			n)
+	}
+}
+
+// TestSDKListSecretsTagKeyFilterPrefix verifies the tag-key filter is a prefix
+// match against tag keys.
+func TestSDKListSecretsTagKeyFilterPrefix(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("tagged"), SecretString: aws.String("x"),
+		Tags: []smtypes.Tag{{Key: aws.String("environment"), Value: aws.String("prod")}},
+	}); err != nil {
+		t.Fatalf("CreateSecret tagged: %v", err)
+	}
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("untagged"), SecretString: aws.String("x"),
+	}); err != nil {
+		t.Fatalf("CreateSecret untagged: %v", err)
+	}
+
+	// "env" is a prefix of the key "environment".
+	out, err := client.ListSecrets(ctx, &awssm.ListSecretsInput{
+		Filters: []smtypes.Filter{{
+			Key:    smtypes.FilterNameStringTypeTagKey,
+			Values: []string{"env"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+
+	got := secretNames(out.SecretList)
+	if len(got) != 1 || got[0] != "tagged" {
+		t.Fatalf("tag-key filter 'env' returned %v, want only [tagged]", got)
+	}
+
+	// "vironment" is a substring but NOT a prefix, so it must not match.
+	none, err := client.ListSecrets(ctx, &awssm.ListSecretsInput{
+		Filters: []smtypes.Filter{{
+			Key:    smtypes.FilterNameStringTypeTagKey,
+			Values: []string{"vironment"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ListSecrets vironment: %v", err)
+	}
+
+	if n := len(none.SecretList); n != 0 {
+		t.Fatalf("tag-key filter 'vironment' returned %d secrets, want 0 (not a prefix)", n)
+	}
+}

--- a/server/aws/ssm/max_results_validation_test.go
+++ b/server/aws/ssm/max_results_validation_test.go
@@ -1,0 +1,81 @@
+package ssm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsssm "github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKGetParametersByPathMaxResultsOverCeiling verifies MaxResults above the
+// validated ceiling (10 for GetParametersByPath) is rejected with a
+// ValidationException rather than being silently clamped down.
+func TestSDKGetParametersByPathMaxResultsOverCeiling(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := context.Background()
+
+	if _, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name: aws.String("/app/db/host"), Value: aws.String("h"), Type: ssmtypes.ParameterTypeString,
+	}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	_, err := client.GetParametersByPath(ctx, &awsssm.GetParametersByPathInput{
+		Path:       aws.String("/app/"),
+		Recursive:  aws.Bool(true),
+		MaxResults: aws.Int32(50),
+	})
+	if err == nil {
+		t.Fatal("GetParametersByPath MaxResults=50 succeeded, want ValidationException")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ValidationException" {
+		t.Fatalf("got error %v, want ValidationException", err)
+	}
+
+	// The ceiling itself (10) is accepted.
+	if _, err := client.GetParametersByPath(ctx, &awsssm.GetParametersByPathInput{
+		Path:       aws.String("/app/"),
+		Recursive:  aws.Bool(true),
+		MaxResults: aws.Int32(10),
+	}); err != nil {
+		t.Fatalf("GetParametersByPath MaxResults=10: %v", err)
+	}
+}
+
+// TestSDKDescribeParametersMaxResultsOverCeiling verifies DescribeParameters
+// rejects MaxResults above its ceiling (50).
+func TestSDKDescribeParametersMaxResultsOverCeiling(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := context.Background()
+
+	if _, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name: aws.String("/d/one"), Value: aws.String("v"), Type: ssmtypes.ParameterTypeString,
+	}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	_, err := client.DescribeParameters(ctx, &awsssm.DescribeParametersInput{
+		MaxResults: aws.Int32(51),
+	})
+	if err == nil {
+		t.Fatal("DescribeParameters MaxResults=51 succeeded, want ValidationException")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ValidationException" {
+		t.Fatalf("got error %v, want ValidationException", err)
+	}
+
+	// The ceiling itself (50) is accepted.
+	if _, err := client.DescribeParameters(ctx, &awsssm.DescribeParametersInput{
+		MaxResults: aws.Int32(50),
+	}); err != nil {
+		t.Fatalf("DescribeParameters MaxResults=50: %v", err)
+	}
+}

--- a/server/aws/ssm/paginate.go
+++ b/server/aws/ssm/paginate.go
@@ -29,7 +29,13 @@ func pageWindow(token string, maxResults int32, defaultMax, total int) (start, e
 	}
 
 	limit := int(maxResults)
-	if limit <= 0 || limit > defaultMax {
+	if limit > defaultMax {
+		return 0, 0, "", cerrors.Newf(cerrors.InvalidArgument,
+			"1 validation error detected: Value '%d' at 'maxResults' failed to satisfy constraint: "+
+				"Member must have value less than or equal to %d", maxResults, defaultMax)
+	}
+
+	if limit <= 0 {
 		limit = defaultMax
 	}
 


### PR DESCRIPTION
## Summary

Round-4 confirmation-audit fixes for AWS IAM, Secrets Manager, and SSM — adjacent edges earlier rounds missed. Each is verified against the official AWS API reference. No driver interfaces changed.

## Findings fixed

### 1. [HIGH] iam:GetAccountAuthorizationDetails under-reported permissions
GAAD emitted `UserDetail.UserPolicyList`, `GroupDetail.GroupPolicyList`, and `GroupDetail.AttachedManagedPolicies` as empty even though the data is modeled and the individual List ops (`ListUserPolicies`, `ListGroupPolicies`, `ListAttachedGroupPolicies`) return it. Security-audit tooling (Prowler/ScoutSuite/policy diffing) got an incomplete snapshot. Now populated from the same surfaces. The three near-identical inline-policy builders are collapsed into one generic helper.

### 2. [MEDIUM] iam:ListUsers/ListRoles/ListGroups ignored PathPrefix
The `PathPrefix` request parameter was never read, so every entity was returned regardless of prefix (`ListPolicies` already honored it). Added a shared `filterByPathPrefix` applied to all three list handlers.

### 3. [MEDIUM] secretsmanager:ListSecrets filters used substring, not prefix
`name`/`tag-key`/`tag-value` are case-sensitive **prefix** matches, `description` is a case-insensitive prefix match, and `all` tokenizes the value and searches all attributes case-insensitively. The code used case-sensitive `strings.Contains`, so `name=db` wrongly matched `prod/db/password`. Replaced with the correct per-key semantics.

### 4. [LOW] ssm MaxResults over ceiling was silently clamped
`GetParametersByPath` (1–10) and `DescribeParameters`/`GetParameterHistory` (1–50) now reject an over-range `MaxResults` with a `ValidationException` instead of clamping down to the ceiling.

## Tests
Added real aws-sdk-go-v2 tests asserting each corrected behavior: GAAD inline/attached user+group policies, IAM list PathPrefix filtering, ListSecrets prefix semantics (name/description/tag-key, including substring-not-prefix negatives), and SSM MaxResults ValidationException with ceiling-value acceptance.

## Gates
`go build ./...`, `go test ./providers/aws/... ./server/aws/... ./services/...`, and golangci-lint on the touched packages all green.