### PR TITLE
fix(dynamodb): Query/Scan Limit+FilterExpression interaction, ScannedCount, LastEvaluatedKey

### DIFF
--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -380,10 +380,14 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 		return nil, err
 	}
 
-	matched, scanned, err := m.matchQueryItems(td, pkField, skField, &input)
+	// Compile the FilterExpression up front so a malformed expression is
+	// rejected before any paging, matching AWS validation.
+	node, err := compileFilter(input.FilterExpression, input.ExprNames, input.ExprValues)
 	if err != nil {
 		return nil, err
 	}
+
+	candidates := m.keyMatchedItems(td, pkField, skField, &input)
 
 	limit := input.Limit
 	if limit <= 0 {
@@ -396,14 +400,24 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 	if input.IndexName != "" {
 		keyFields = append(keyFields, pkField, skField)
 	}
-	result, err := driver.PageOrdered(matched, pkField, skField, keyFields,
+	// Page the key-matched items FIRST — AWS reads up to Limit items and only
+	// then applies the FilterExpression. The returned page is the evaluated
+	// window, and PageOrdered's LastEvaluatedKey already points at the last
+	// evaluated item, present whenever more key-matched items remain (even if
+	// every item on this page is later filtered out).
+	result, err := driver.PageOrdered(candidates, pkField, skField, keyFields,
 		limit, input.PageToken, input.ExclusiveStartKey, input.SortDescending,
 		func(it map[string]any) string { return itemKey(td.config, it) })
 	if err != nil {
 		return nil, err
 	}
 
-	result.ScannedCount = scanned
+	// ScannedCount is the number of items evaluated for this page, before the
+	// FilterExpression is applied; the filter then trims Items and Count.
+	result.ScannedCount = len(result.Items)
+	if err = applyFilter(node, input.Filters, result); err != nil {
+		return nil, err
+	}
 
 	// A GSI query only exposes the index's projected attributes; an LSI query
 	// with no projection defaults to ALL_PROJECTED_ATTRIBUTES. When a
@@ -542,20 +556,16 @@ func projectToIndex(item map[string]any, attrs map[string]struct{}) map[string]a
 	return out
 }
 
-// matchQueryItems returns the items matching the key condition and filter, plus
-// the pre-filter scanned count (items that matched the key condition before the
-// FilterExpression), which the response surfaces as ScannedCount.
-func (m *Mock) matchQueryItems(
+// keyMatchedItems returns the live (non-expired) items whose key attributes
+// satisfy the KeyConditionExpression, in arbitrary order. The FilterExpression
+// is deliberately NOT applied here: AWS reads up to Limit of these items and
+// only then filters, so filtering happens after paging (see applyFilter).
+func (m *Mock) keyMatchedItems(
 	td *tableData, pkField, skField string, input *driver.QueryInput,
-) (matched []map[string]any, scanned int, err error) {
-	node, err := compileFilter(input.FilterExpression, input.ExprNames, input.ExprValues)
-	if err != nil {
-		return nil, 0, err
-	}
+) []map[string]any {
+	var matched []map[string]any
 
-	allItems := td.items.All()
-
-	for _, item := range allItems {
+	for _, item := range td.items.All() {
 		if m.isItemExpired(td, item) {
 			continue
 		}
@@ -564,21 +574,41 @@ func (m *Mock) matchQueryItems(
 			continue
 		}
 
-		scanned++
+		matched = append(matched, item)
+	}
 
-		// Apply the FilterExpression (post key-condition), matching real
-		// DynamoDB: Query filters the key-matched set the same way Scan does.
-		ok, ferr := passesFilter(node, input.Filters, item)
-		if ferr != nil {
-			return nil, 0, ferr
+	return matched
+}
+
+// applyFilter applies the FilterExpression (or legacy Filters) to an
+// already-paged result in place: it trims Items to those that pass and updates
+// Count. ScannedCount and LastEvaluatedKey are left untouched — AWS filters
+// after reading a page, so a fully filtered-out page still reports the items it
+// evaluated and a continuation key. A nil node with no legacy filters is a
+// no-op (Count then equals ScannedCount, as AWS documents for unfiltered
+// requests).
+func applyFilter(node expr.Node, legacy []driver.ScanFilter, result *driver.QueryResult) error {
+	if node == nil && len(legacy) == 0 {
+		return nil
+	}
+
+	kept := result.Items[:0]
+
+	for _, it := range result.Items {
+		ok, err := passesFilter(node, legacy, it)
+		if err != nil {
+			return err
 		}
 
 		if ok {
-			matched = append(matched, item)
+			kept = append(kept, it)
 		}
 	}
 
-	return matched, scanned, nil
+	result.Items = kept
+	result.Count = len(kept)
+
+	return nil
 }
 
 func matchesKeyCondition(item map[string]any, pkField, skField string, input *driver.QueryInput) bool {
@@ -620,12 +650,15 @@ func passesFilter(node expr.Node, legacy []driver.ScanFilter, item map[string]an
 	return matchesFilters(item, legacy), nil
 }
 
-// scanItems walks the table's items, skipping expired ones and (for an index
-// scan) those lacking the index partition key, returning the filter-matched set
-// and the pre-filter scanned count.
-func (m *Mock) scanItems(
-	td *tableData, node expr.Node, input *driver.ScanInput, idxPK string,
-) (matched []map[string]any, scanned int, err error) {
+// scanCandidates walks the table's items, skipping expired ones and (for an
+// index scan) those lacking the index partition key. The FilterExpression is
+// applied after paging (AWS reads up to Limit items, then filters), so it is
+// not applied here.
+func (m *Mock) scanCandidates(
+	td *tableData, idxPK string,
+) []map[string]any {
+	var matched []map[string]any
+
 	for _, item := range td.items.All() {
 		if m.isItemExpired(td, item) {
 			continue
@@ -637,19 +670,10 @@ func (m *Mock) scanItems(
 			}
 		}
 
-		scanned++
-
-		ok, ferr := passesFilter(node, input.Filters, item)
-		if ferr != nil {
-			return nil, 0, ferr
-		}
-
-		if ok {
-			matched = append(matched, item)
-		}
+		matched = append(matched, item)
 	}
 
-	return matched, scanned, nil
+	return matched
 }
 
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
@@ -678,17 +702,16 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 		}
 	}
 
-	matched, scanned, err := m.scanItems(td, node, &input, idxPK)
-	if err != nil {
-		return nil, err
-	}
+	candidates := m.scanCandidates(td, idxPK)
 
 	limit := input.Limit
 	if limit <= 0 {
 		limit = 100
 	}
 
-	result, err := driver.PageOrdered(matched,
+	// Page FIRST, then filter — AWS reads up to Limit items and applies the
+	// FilterExpression to that evaluated window (see Query for the full note).
+	result, err := driver.PageOrdered(candidates,
 		td.config.PartitionKey, td.config.SortKey,
 		[]string{td.config.PartitionKey, td.config.SortKey},
 		limit, input.PageToken, input.ExclusiveStartKey, false,
@@ -697,7 +720,10 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 		return nil, err
 	}
 
-	result.ScannedCount = scanned
+	result.ScannedCount = len(result.Items)
+	if err = applyFilter(node, input.Filters, result); err != nil {
+		return nil, err
+	}
 
 	if attrs, filtered := indexProjection(td.config, input.IndexName, input.ProjectionRequested); filtered {
 		for i, it := range result.Items {

--- a/server/aws/dynamodb/dynamodb_query_limit_filter_test.go
+++ b/server/aws/dynamodb/dynamodb_query_limit_filter_test.go
@@ -1,0 +1,176 @@
+package dynamodb_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedLimitFilterTable creates a single-partition table "lf" with 10 items
+// (sk "0".."9", attribute n = index) for the Limit+FilterExpression cases.
+func seedLimitFilterTable(t *testing.T, client *dynamodb.Client) {
+	t.Helper()
+
+	suiteDDBCreateTable(t, client, "lf", "pk", "sk")
+	for i := range 10 {
+		suiteDDBPut(t, client, "lf", map[string]ddbtypes.AttributeValue{
+			"pk": sAttr("p"),
+			"sk": sAttr(fmt.Sprintf("%d", i)),
+			"n":  nAttr(fmt.Sprintf("%d", i)),
+		})
+	}
+}
+
+// TestDDBQueryLimitFilterInteraction covers the finding: Limit is the maximum
+// number of items to EVALUATE, and the FilterExpression is applied AFTER
+// reading that page. So ScannedCount is capped at Limit, Count counts matches
+// only among those first Limit evaluated items, and LastEvaluatedKey is
+// returned whenever Limit items were evaluated and more remain — including the
+// documented case where a page returns an empty result set plus a
+// LastEvaluatedKey because every item read was filtered out.
+func TestDDBQueryLimitFilterInteraction(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+	seedLimitFilterTable(t, client)
+
+	keyCond := aws.String("pk = :p")
+
+	t.Run("no filter, Limit=3", func(t *testing.T) {
+		out, err := client.Query(ctx, &dynamodb.QueryInput{
+			TableName:                 aws.String("lf"),
+			KeyConditionExpression:    keyCond,
+			Limit:                     aws.Int32(3),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":p": sAttr("p")},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(3), out.Count)
+		assert.Equal(t, int32(3), out.ScannedCount, "Limit caps items evaluated")
+		assert.NotNil(t, out.LastEvaluatedKey, "more items remain after the page")
+	})
+
+	t.Run("filter n<2, Limit=3 keeps 2 of first 3 evaluated", func(t *testing.T) {
+		out, err := client.Query(ctx, &dynamodb.QueryInput{
+			TableName:              aws.String("lf"),
+			KeyConditionExpression: keyCond,
+			FilterExpression:       aws.String("n < :two"),
+			Limit:                  aws.Int32(3),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+				":p": sAttr("p"), ":two": nAttr("2"),
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), out.Count, "sk 0,1 match among first 3 evaluated")
+		assert.Equal(t, int32(3), out.ScannedCount, "3 items evaluated, not the full 10")
+		assert.NotNil(t, out.LastEvaluatedKey, "3 evaluated and 7 remain -> continuation")
+	})
+
+	t.Run("filter n=9 only, Limit=3 -> empty page + LastEvaluatedKey", func(t *testing.T) {
+		out, err := client.Query(ctx, &dynamodb.QueryInput{
+			TableName:              aws.String("lf"),
+			KeyConditionExpression: keyCond,
+			FilterExpression:       aws.String("n = :nine"),
+			Limit:                  aws.Int32(3),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+				":p": sAttr("p"), ":nine": nAttr("9"),
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), out.Count, "sk 9 is never reached in the first 3 evaluated")
+		assert.Equal(t, int32(3), out.ScannedCount)
+		assert.Empty(t, out.Items)
+		assert.NotNil(t, out.LastEvaluatedKey,
+			"empty page still returns a continuation key when items remain")
+	})
+}
+
+// TestDDBQueryLimitFilterPagination walks the whole table via LastEvaluatedKey
+// with a Limit smaller than the partition, asserting the emulator never skips a
+// matching item that a real Limit-bounded page would only reach on a later
+// page. Filter n is even -> matches sk 0,2,4,6,8 across the pages.
+func TestDDBQueryLimitFilterPagination(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+	seedLimitFilterTable(t, client)
+
+	var (
+		startKey   map[string]ddbtypes.AttributeValue
+		gotMatches int
+		pages      int
+		scanned    int32
+	)
+
+	for {
+		out, err := client.Query(ctx, &dynamodb.QueryInput{
+			TableName:              aws.String("lf"),
+			KeyConditionExpression: aws.String("pk = :p"),
+			FilterExpression:       aws.String("n IN (:a, :b, :c, :d, :e)"),
+			Limit:                  aws.Int32(3),
+			ExclusiveStartKey:      startKey,
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+				":p": sAttr("p"),
+				":a": nAttr("0"), ":b": nAttr("2"), ":c": nAttr("4"),
+				":d": nAttr("6"), ":e": nAttr("8"),
+			},
+		})
+		require.NoError(t, err)
+
+		gotMatches += int(out.Count)
+		scanned += out.ScannedCount
+		pages++
+		require.LessOrEqual(t, pages, 10, "paging must terminate")
+
+		if out.LastEvaluatedKey == nil {
+			break
+		}
+		startKey = out.LastEvaluatedKey
+	}
+
+	assert.Equal(t, 5, gotMatches, "all five even-n items visited across pages")
+	assert.Equal(t, int32(10), scanned, "every one of the 10 items is evaluated exactly once")
+}
+
+// TestDDBScanLimitFilterInteraction mirrors the Query case for Scan: Limit
+// bounds the number of items examined, the FilterExpression runs on that page,
+// and a fully filtered-out page still reports ScannedCount and a
+// LastEvaluatedKey.
+func TestDDBScanLimitFilterInteraction(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+	seedLimitFilterTable(t, client)
+
+	t.Run("filter n=9 only, Limit=3 -> empty page + LastEvaluatedKey", func(t *testing.T) {
+		out, err := client.Scan(ctx, &dynamodb.ScanInput{
+			TableName:        aws.String("lf"),
+			FilterExpression: aws.String("n = :nine"),
+			Limit:            aws.Int32(3),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+				":nine": nAttr("9"),
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), out.Count)
+		assert.Equal(t, int32(3), out.ScannedCount, "3 items examined before filtering")
+		assert.NotNil(t, out.LastEvaluatedKey, "empty filtered page still paginates")
+	})
+
+	t.Run("filter n<2, Limit=3", func(t *testing.T) {
+		out, err := client.Scan(ctx, &dynamodb.ScanInput{
+			TableName:        aws.String("lf"),
+			FilterExpression: aws.String("n < :two"),
+			Limit:            aws.Int32(3),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+				":two": nAttr("2"),
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), out.Count)
+		assert.Equal(t, int32(3), out.ScannedCount)
+		assert.NotNil(t, out.LastEvaluatedKey)
+	})
+}


### PR DESCRIPTION
## Summary

DynamoDB `Query` and `Scan` applied the `FilterExpression` to the entire key-matched set *before* honoring `Limit`, and reported `ScannedCount` as the full pre-filter count. That contradicts the API reference: `Limit` is "the maximum number of items to **evaluate** (not necessarily the number of matching items)" — the service reads up to `Limit` items and only *then* applies the filter.

This change pages first, then filters:

- **Key/index-matched items are paged first**, and the `FilterExpression` (or legacy `Filters`) is applied to that evaluated window afterward.
- **`ScannedCount`** is the number of items evaluated for the page, capped at `Limit` (was: full pre-filter count, ignoring `Limit`).
- **`Count`** counts matches only among the evaluated items (was: matches across the whole partition, then capped).
- **`LastEvaluatedKey`** is returned whenever a full `Limit` page was evaluated and more items remain — including the documented case where the page returns an **empty result set plus a `LastEvaluatedKey`** because every item read was filtered out. Previously the emulator could also return an item that a real `Limit`-bounded page would never reach.

Same restructuring is mirrored in `Scan` (index-scan sparse-key handling preserved). A malformed `FilterExpression` is still rejected up front.

## Behavior (repro: single partition, 10 items sk 0..9, n = index)

| Request | Before | After (matches AWS) |
|---|---|---|
| no filter, Limit=3 | Count=3 ScannedCount=10 | Count=3 ScannedCount=3 LEK present |
| filter n<2, Limit=3 | Count=2 ScannedCount=10 no LEK | Count=2 ScannedCount=3 LEK present |
| filter n=9, Limit=3 | Count=1 ScannedCount=10 no LEK | Count=0 ScannedCount=3 LEK present (empty page + continuation) |

## Tests

New `server/aws/dynamodb/dynamodb_query_limit_filter_test.go` (real aws-sdk-go-v2 client): the three cases above for `Query` and `Scan`, plus a full `LastEvaluatedKey` pagination walk asserting every item is evaluated exactly once and no matching item is skipped across pages.

Gates: `go build ./...`, `go test ./providers/aws/... ./server/aws/... ./services/...`, and golangci-lint on the changed packages all pass.
