### PR TITLE
fix(azure-systemic): idempotent DELETE-missing -> 204 sweep, DNS recordSet FQDN trailing dot, Queue Storage numofmessages validation

### DIFF
--- a/server/azure/dns/idempotent_delete_sdk_test.go
+++ b/server/azure/dns/idempotent_delete_sdk_test.go
@@ -1,0 +1,75 @@
+package dns_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
+)
+
+// TestSDKAzureDNSRecordSetFqdnNoTrailingDot asserts the record set fqdn matches
+// real Azure, which returns "<name>.<zone>" for a relative record and "<zone>"
+// for the apex — neither carrying a trailing dot (mirroring nameServers).
+func TestSDKAzureDNSRecordSetFqdnNoTrailingDot(t *testing.T) {
+	zones, records := newDNSClients(t)
+	ctx := context.Background()
+
+	const zone = "fqdn.com"
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, zone, armdns.Zone{Location: to.Ptr("global")}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	rel, err := records.CreateOrUpdate(ctx, testRG, zone, "www", armdns.RecordTypeA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL:      to.Ptr(int64(300)),
+			ARecords: []*armdns.ARecord{{IPv4Address: to.Ptr("192.0.2.1")}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.CreateOrUpdate: %v", err)
+	}
+
+	if rel.Properties == nil || rel.Properties.Fqdn == nil {
+		t.Fatalf("record set fqdn missing: %+v", rel.Properties)
+	}
+
+	if got := *rel.Properties.Fqdn; got != "www."+zone {
+		t.Fatalf("relative fqdn = %q, want %q (no trailing dot)", got, "www."+zone)
+	}
+
+	if strings.HasSuffix(*rel.Properties.Fqdn, ".") {
+		t.Fatalf("relative fqdn = %q, want no trailing dot", *rel.Properties.Fqdn)
+	}
+
+	// The apex SOA record auto-provisioned with the zone reports the bare zone
+	// name as its fqdn, again with no trailing dot.
+	soa, err := records.Get(ctx, testRG, zone, "@", armdns.RecordTypeSOA, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.Get SOA: %v", err)
+	}
+
+	if soa.Properties == nil || soa.Properties.Fqdn == nil || *soa.Properties.Fqdn != zone {
+		t.Fatalf("apex fqdn = %+v, want %q (no trailing dot)", soa.Properties, zone)
+	}
+}
+
+// TestSDKAzureDNSDeleteZoneMissingIsIdempotent asserts that deleting a DNS zone
+// that does not exist completes cleanly. Real Azure ARM DELETE is idempotent and
+// returns 204 No Content ("The DNS zone was not found"), which lets the SDK LRO
+// poller finish without a 404 error.
+func TestSDKAzureDNSDeleteZoneMissingIsIdempotent(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	poller, err := zones.BeginDelete(ctx, testRG, "never-created.com", nil)
+	if err != nil {
+		t.Fatalf("Zones.BeginDelete on missing zone: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete of missing zone should be a no-op (204), got: %v", err)
+	}
+}

--- a/server/azure/dns/operations.go
+++ b/server/azure/dns/operations.go
@@ -102,16 +102,30 @@ func (h *Handler) getZone(w http.ResponseWriter, r *http.Request, rp *azurearm.R
 }
 
 // deleteZone removes the zone. Zones.Delete is an LRO in the SDK; returning
-// 200 with an empty body completes the poller on the first response.
+// 200 with an empty body completes the poller on the first response. A missing
+// zone makes the ARM DELETE idempotent: 204 No Content ("The DNS zone was not
+// found"), not a 404 error body.
 func (h *Handler) deleteZone(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	id, err := h.resolveZoneID(r.Context(), rp)
 	if err != nil {
+		if cerrors.IsNotFound(err) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
 		azurearm.WriteCErr(w, err)
+
 		return
 	}
 
 	if derr := h.dns.DeleteZone(r.Context(), id); derr != nil {
+		if cerrors.IsNotFound(derr) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
 		azurearm.WriteCErr(w, derr)
+
 		return
 	}
 

--- a/server/azure/dns/sdk_roundtrip_test.go
+++ b/server/azure/dns/sdk_roundtrip_test.go
@@ -184,8 +184,8 @@ func TestSDKAzureDNSRecordSets(t *testing.T) {
 		t.Fatalf("ARecords = %+v, want [192.0.2.1]", got.Properties.ARecords)
 	}
 
-	if got.Properties.Fqdn == nil || *got.Properties.Fqdn != "www.records.com." {
-		t.Fatalf("fqdn = %v, want www.records.com.", got.Properties.Fqdn)
+	if got.Properties.Fqdn == nil || *got.Properties.Fqdn != "www.records.com" {
+		t.Fatalf("fqdn = %v, want www.records.com (no trailing dot)", got.Properties.Fqdn)
 	}
 
 	var listed []string

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -354,14 +354,15 @@ func toRecordSetJSON(rp *azurearm.ResourcePath, zone string, rec *dnsdriver.Reco
 }
 
 // recordFqdn builds the fully-qualified domain name Azure reports for a record
-// set: "<name>.<zone>." for a relative record, and "<zone>." for the apex
-// ("@") record. The trailing dot marks it as fully qualified.
+// set: "<name>.<zone>" for a relative record, and "<zone>" for the apex ("@")
+// record. Azure DNS returns the fqdn without a trailing dot (mirroring the
+// zone's nameServers), so none is appended.
 func recordFqdn(name, zone string) string {
 	if name == "" || name == apexRecordName {
-		return zone + "."
+		return zone
 	}
 
-	return name + "." + zone + "."
+	return name + "." + zone
 }
 
 // mapStrings projects a typed slice to its string values, dropping empties.

--- a/server/azure/loganalytics/child_resources.go
+++ b/server/azure/loganalytics/child_resources.go
@@ -169,13 +169,24 @@ func (h *Handler) getChild(w http.ResponseWriter, rp *azurearm.ResourcePath) {
 	azurearm.WriteJSON(w, http.StatusOK, h.childToJSON(rp, res))
 }
 
+// deleteChild removes a workspace child. The missing-resource status differs per
+// child type, matching the Log Analytics REST reference exactly:
+//   - tables:        204 No Content ("Resource does not exist")
+//   - dataExports:   404 Not Found (documented response, which the SDK ignores)
+//   - savedSearches: only 200 is documented; a miss falls through to a 404
+//     ErrorResponse ("Other Status Codes")
 func (h *Handler) deleteChild(w http.ResponseWriter, rp *azurearm.ResourcePath) {
-	if !h.children.delete(rp.ResourceName, rp.SubResource, rp.SubResourceName) {
-		azurearm.WriteError(w, http.StatusNotFound, "NotFound", rp.SubResource+" "+rp.SubResourceName+" not found")
+	if h.children.delete(rp.ResourceName, rp.SubResource, rp.SubResourceName) {
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	if rp.SubResource == subTables {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	azurearm.WriteError(w, http.StatusNotFound, "NotFound", rp.SubResource+" "+rp.SubResourceName+" not found")
 }
 
 func (h *Handler) listChildren(w http.ResponseWriter, rp *azurearm.ResourcePath) {

--- a/server/azure/loganalytics/idempotent_delete_test.go
+++ b/server/azure/loganalytics/idempotent_delete_test.go
@@ -1,0 +1,121 @@
+package loganalytics_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// newLogAnalyticsServer stands up a TLS server backed by a fresh Azure Log
+// Analytics driver, returning both the server (for raw child-resource requests)
+// and arm.ClientOptions pointed at it.
+func newLogAnalyticsServer(t *testing.T) (*httptest.Server, *arm.ClientOptions) {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{LogAnalytics: cloudP.LogAnalytics})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	return ts, opts
+}
+
+// TestSDKWorkspaceDeleteMissingIsIdempotent asserts that deleting a workspace
+// that does not exist completes cleanly. Real Azure ARM DELETE is idempotent and
+// returns 204 No Content ("Resource does not exist"), so the SDK LRO poller
+// finishes without a 404 error.
+func TestSDKWorkspaceDeleteMissingIsIdempotent(t *testing.T) {
+	_, opts := newLogAnalyticsServer(t)
+	ctx := context.Background()
+
+	client, err := armoperationalinsights.NewWorkspacesClient(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewWorkspacesClient: %v", err)
+	}
+
+	poller, err := client.BeginDelete(ctx, testRG, "never-created", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete on missing workspace: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete of missing workspace should be a no-op (204), got: %v", err)
+	}
+}
+
+// TestChildDeleteMissingStatusMatchesAzure asserts the per-child-type
+// missing-resource DELETE status, matching the Log Analytics REST reference:
+// tables return 204 (idempotent), while dataExports and savedSearches return
+// 404 (their references document a 404/ErrorResponse for the missing case; the
+// DataExports SDK tolerates that 404, making Delete a no-op for callers).
+func TestChildDeleteMissingStatusMatchesAzure(t *testing.T) {
+	ts, opts := newLogAnalyticsServer(t)
+	ctx := context.Background()
+
+	client, err := armoperationalinsights.NewWorkspacesClient(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewWorkspacesClient: %v", err)
+	}
+
+	createWorkspace(t, client, "ws-del", "eastus")
+
+	cases := []struct {
+		child string
+		want  int
+	}{
+		{"tables", http.StatusNoContent},
+		{"dataExports", http.StatusNotFound},
+		{"savedSearches", http.StatusNotFound},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.child, func(t *testing.T) {
+			url := fmt.Sprintf(
+				"%s/subscriptions/%s/resourceGroups/%s/providers/Microsoft.OperationalInsights/workspaces/ws-del/%s/missing?api-version=2022-10-01",
+				ts.URL, testSub, testRG, tc.child,
+			)
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+
+			resp, err := ts.Client().Do(req)
+			if err != nil {
+				t.Fatalf("Do: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.want {
+				t.Fatalf("DELETE missing %s = %d, want %d", tc.child, resp.StatusCode, tc.want)
+			}
+		})
+	}
+}

--- a/server/azure/loganalytics/operations.go
+++ b/server/azure/loganalytics/operations.go
@@ -3,6 +3,7 @@ package loganalytics
 import (
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
 	"github.com/stackshy/cloudemu/v2/services/scope"
@@ -61,10 +62,18 @@ func (h *Handler) getWorkspace(w http.ResponseWriter, r *http.Request, rp *azure
 }
 
 // deleteWorkspace removes the workspace. Workspaces.Delete is an LRO in the SDK;
-// returning 200 with an empty body completes the poller on the first response.
+// returning 200 with an empty body completes the poller on the first response. A
+// missing workspace makes the ARM DELETE idempotent: 204 No Content ("Resource
+// does not exist"), not a 404 error body.
 func (h *Handler) deleteWorkspace(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	if err := h.logs.DeleteLogGroup(r.Context(), rp.ResourceName); err != nil {
+		if cerrors.IsNotFound(err) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
 		azurearm.WriteCErr(w, err)
+
 		return
 	}
 

--- a/server/azure/queue/handler.go
+++ b/server/azure/queue/handler.go
@@ -45,6 +45,11 @@ const (
 	// timeout (7 days, in seconds).
 	maxUpdateVisibilityTimeout = 7 * 24 * 60 * 60
 
+	// minNumOfMessages / maxNumOfMessages bound the numofmessages query parameter
+	// for Get Messages and Peek Messages. Azure rejects anything outside [1, 32].
+	minNumOfMessages = 1
+	maxNumOfMessages = 32
+
 	// maxEnqueueBodyBytes caps a single enqueued message body. Azure allows up
 	// to 64 KiB; we use a generous 1 MiB cap.
 	maxEnqueueBodyBytes = 1 << 20
@@ -353,7 +358,12 @@ func (h *Handler) dequeue(w http.ResponseWriter, r *http.Request, queue string) 
 	}
 
 	q := r.URL.Query()
-	maxMsgs := atoiDefault(q.Get("numofmessages"), 1)
+
+	maxMsgs, ok := parseNumOfMessages(w, q.Get("numofmessages"))
+	if !ok {
+		return
+	}
+
 	visTimeout := atoiDefault(q.Get("visibilitytimeout"), 0)
 
 	msgs, err := h.dequeueMessages(r, url, maxMsgs, visTimeout)
@@ -410,7 +420,10 @@ func (h *Handler) peek(w http.ResponseWriter, r *http.Request, queue string) {
 		return
 	}
 
-	maxMsgs := atoiDefault(r.URL.Query().Get("numofmessages"), 1)
+	maxMsgs, ok := parseNumOfMessages(w, r.URL.Query().Get("numofmessages"))
+	if !ok {
+		return
+	}
 
 	msgs, err := svc.PeekMessages(r.Context(), url, maxMsgs)
 	if err != nil {
@@ -583,6 +596,33 @@ func parseVisibilityTimeout(w http.ResponseWriter, raw string) (int, bool) {
 	return v, true
 }
 
+// parseNumOfMessages validates the optional numofmessages parameter for Get
+// Messages and Peek Messages. An absent value defaults to 1; a present value
+// must be an integer in [1, 32]. A non-integer is a 400 InvalidQueryParameterValue
+// and an out-of-range integer is a 400 OutOfRangeQueryParameterValue carrying the
+// permissible bounds, matching real Azure Queue Storage. It writes the error and
+// returns ok=false on a bad value.
+func parseNumOfMessages(w http.ResponseWriter, raw string) (int, bool) {
+	if raw == "" {
+		return minNumOfMessages, true
+	}
+
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidQueryParameterValue",
+			"Value for one of the query parameters specified in the request URI is invalid.")
+
+		return 0, false
+	}
+
+	if n < minNumOfMessages || n > maxNumOfMessages {
+		writeQueryParameterRangeError(w, "numofmessages", raw, minNumOfMessages, maxNumOfMessages)
+		return 0, false
+	}
+
+	return n, true
+}
+
 // readMessageText reads an optional <QueueMessage><MessageText> body, returning
 // nil when the body is empty (visibility-only update).
 func readMessageText(w http.ResponseWriter, r *http.Request) (*string, error) {
@@ -633,6 +673,26 @@ func writeError(w http.ResponseWriter, status int, code, msg string) {
 	w.WriteHeader(status)
 	_, _ = w.Write([]byte(xml.Header))
 	_ = xml.NewEncoder(w).Encode(errorXML{Code: code, Message: msg})
+}
+
+// writeQueryParameterRangeError emits the Azure Queue Storage 400
+// OutOfRangeQueryParameterValue error, including the offending parameter's name
+// and value plus the permitted [min, max] bounds, as real Queue Storage does.
+func writeQueryParameterRangeError(w http.ResponseWriter, name, value string, minVal, maxVal int) {
+	const code = "OutOfRangeQueryParameterValue"
+
+	w.Header().Set("Content-Type", contentTypeXML)
+	w.Header().Set("X-Ms-Error-Code", code)
+	w.WriteHeader(http.StatusBadRequest)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(queryParamRangeErrorXML{
+		Code:                code,
+		Message:             "One of the query parameters specified in the request URI is outside the permissible range.",
+		QueryParameterName:  name,
+		QueryParameterValue: value,
+		MinimumAllowed:      strconv.Itoa(minVal),
+		MaximumAllowed:      strconv.Itoa(maxVal),
+	})
 }
 
 // writeErr maps CloudEmu canonical errors to Azure Queue HTTP errors.

--- a/server/azure/queue/numofmessages_validation_test.go
+++ b/server/azure/queue/numofmessages_validation_test.go
@@ -1,0 +1,131 @@
+package queue_test
+
+import (
+	"context"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// newQueueServer stands up a server backed by a fresh Azure Queue Storage driver
+// and pre-creates one queue, returning the server so raw requests can exercise
+// query-parameter validation the SDK clamps away client-side.
+func newQueueServer(t *testing.T, queueName string) *httptest.Server {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{QueueStorage: cloudP.QueueStorage})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	opts := &azqueue.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}},
+	}
+
+	svc, err := azqueue.NewServiceClientWithNoCredential(ts.URL+"/", opts)
+	if err != nil {
+		t.Fatalf("NewServiceClientWithNoCredential: %v", err)
+	}
+
+	if _, err := svc.CreateQueue(context.Background(), queueName, nil); err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	return ts
+}
+
+func getStatus(t *testing.T, ts *httptest.Server, url string) (int, string) {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	return resp.StatusCode, string(body)
+}
+
+// TestQueueNumOfMessagesOutOfRangeRejected covers the finding: Get/Peek Messages
+// with numofmessages outside [1,32] must be rejected with 400
+// OutOfRangeQueryParameterValue (carrying the parameter name/value and bounds),
+// not silently clamped, matching real Azure Queue Storage.
+func TestQueueNumOfMessagesOutOfRangeRejected(t *testing.T) {
+	ts := newQueueServer(t, "numq")
+	base := ts.URL + "/numq/messages"
+
+	type errBody struct {
+		XMLName             xml.Name `xml:"Error"`
+		Code                string   `xml:"Code"`
+		QueryParameterName  string   `xml:"QueryParameterName"`
+		QueryParameterValue string   `xml:"QueryParameterValue"`
+		MinimumAllowed      string   `xml:"MinimumAllowed"`
+		MaximumAllowed      string   `xml:"MaximumAllowed"`
+	}
+
+	cases := []struct {
+		name string
+		url  string
+		val  string
+	}{
+		{"dequeue-zero", base + "?numofmessages=0", "0"},
+		{"dequeue-too-many", base + "?numofmessages=33", "33"},
+		{"dequeue-negative", base + "?numofmessages=-1", "-1"},
+		{"peek-too-many", base + "?peekonly=true&numofmessages=33", "33"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, body := getStatus(t, ts, tc.url)
+			if status != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body=%s", status, body)
+			}
+
+			var e errBody
+			if err := xml.Unmarshal([]byte(body), &e); err != nil {
+				t.Fatalf("unmarshal error body: %v; body=%s", err, body)
+			}
+
+			if e.Code != "OutOfRangeQueryParameterValue" {
+				t.Fatalf("code = %q, want OutOfRangeQueryParameterValue; body=%s", e.Code, body)
+			}
+
+			if e.QueryParameterName != "numofmessages" || e.QueryParameterValue != tc.val {
+				t.Fatalf("param = %q=%q, want numofmessages=%q", e.QueryParameterName, e.QueryParameterValue, tc.val)
+			}
+
+			if e.MinimumAllowed != "1" || e.MaximumAllowed != "32" {
+				t.Fatalf("bounds = [%s,%s], want [1,32]", e.MinimumAllowed, e.MaximumAllowed)
+			}
+		})
+	}
+}
+
+// TestQueueNumOfMessagesInRangeAccepted confirms the validation does not regress
+// valid requests: an in-range value and an absent value (defaulting to 1) both
+// return 200.
+func TestQueueNumOfMessagesInRangeAccepted(t *testing.T) {
+	ts := newQueueServer(t, "okq")
+	base := ts.URL + "/okq/messages"
+
+	for _, url := range []string{base, base + "?numofmessages=1", base + "?numofmessages=32"} {
+		if status, body := getStatus(t, ts, url); status != http.StatusOK {
+			t.Fatalf("GET %s = %d, want 200; body=%s", url, status, body)
+		}
+	}
+}

--- a/server/azure/queue/types.go
+++ b/server/azure/queue/types.go
@@ -70,3 +70,17 @@ type errorXML struct {
 	Code    string   `xml:"Code"`
 	Message string   `xml:"Message"`
 }
+
+// queryParamRangeErrorXML is the Azure Storage error envelope for an
+// out-of-range query parameter. It extends the base error with the offending
+// parameter's name and value plus the permitted bounds, matching the body real
+// Queue Storage returns for OutOfRangeQueryParameterValue.
+type queryParamRangeErrorXML struct {
+	XMLName             xml.Name `xml:"Error"`
+	Code                string   `xml:"Code"`
+	Message             string   `xml:"Message"`
+	QueryParameterName  string   `xml:"QueryParameterName"`
+	QueryParameterValue string   `xml:"QueryParameterValue"`
+	MinimumAllowed      string   `xml:"MinimumAllowed"`
+	MaximumAllowed      string   `xml:"MaximumAllowed"`
+}


### PR DESCRIPTION
## Summary

Fixes three Azure wire-contract deviations found in the confirmation-minors sweep, each researched against the official Azure REST reference and matched exactly.

### Finding 1 — Idempotent DELETE-missing -> 204 (loganalytics + DNS)
Real Azure ARM DELETE is idempotent, returning 204 No Content on a missing resource rather than a 404 body. Swept the DNS and Log Analytics handlers and aligned each to its documented per-operation contract:

- `dns Zones.Delete` (deleteZone): missing zone -> 204 (was 404). Reference: *The DNS zone was not found -> 204 No Content*.
- `OperationalInsights Workspaces.Delete` (deleteWorkspace): missing workspace -> 204 (was 404). Reference: *Resource does not exist -> 204 No Content*.
- `OperationalInsights Tables` child delete: missing table -> 204 (was 404). Reference: *Resource does not exist -> 204 No Content*.
- `dataExports` and `savedSearches` child deletes intentionally keep 404: the Data Exports reference documents *404 Not Found* for the missing case (the SDK tolerates it, making Delete a caller-side no-op), and Saved Searches documents only 200, so a miss falls through to a 404 ErrorResponse.
- Monitor's diagnosticSettings / metricAlert / actionGroup / activityLogAlert deletes were already idempotent (verified, unchanged).
- Queue Storage `Delete Queue` is data-plane and legitimately returns 404 on a missing queue (verified against the Delete Queue reference) — left unchanged.

### Finding 2 — DNS recordSet FQDN trailing dot
`recordFqdn` appended a trailing dot (`<name>.<zone>.`). Real Azure returns the fqdn without a trailing dot (`<name>.<zone>`, apex `<zone>`), mirroring the zone nameServers. Dropped the dot.

### Finding 3 — Queue Storage numofmessages validation
Get/Peek Messages silently clamped `numofmessages` to [1,32]. Real Queue Storage rejects out-of-range values with 400 `OutOfRangeQueryParameterValue`, including the parameter name/value and the permitted bounds. Added wire-layer validation returning that exact error body; a non-integer value returns 400 `InvalidQueryParameterValue`. The portable-layer clamp remains as an internal safety net for non-wire callers.

## Tests
- `server/azure/dns/idempotent_delete_sdk_test.go` — armdns: recordSet fqdn has no trailing dot (relative + apex); BeginDelete on a missing zone completes cleanly (204).
- `server/azure/loganalytics/idempotent_delete_test.go` — armoperationalinsights: Workspaces.BeginDelete on a missing workspace is a no-op; per-child missing-delete status (tables 204, dataExports/savedSearches 404) via raw ARM requests.
- `server/azure/queue/numofmessages_validation_test.go` — raw Queue Storage requests: out-of-range numofmessages (0, 33, -1, peek 33) -> 400 OutOfRangeQueryParameterValue with name/value/bounds; in-range and absent values -> 200.
- Updated the existing DNS roundtrip assertion to the corrected (dot-free) fqdn.

## Gates
`go build ./...`, `go test ./providers/azure/... ./server/azure/... ./services/...` green; golangci-lint clean on the changed code (only pre-existing warnings in untouched functions remain). No driver interfaces changed, so no docs/coverage regeneration.