### PR TITLE
fix(azure-resourcegroups): resource-group + subscription lifecycle, tags, provisioningState, cross-cutting list/get scoping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch v1.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0 h1:2qsI
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0/go.mod h1:AW8VEadnhw9xox+VaVd9sP7NjzOAnaZBLRH6Tq3cJ38=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v4 v4.0.0 h1:H5ykGRBhX8CJKpB2tiRVut1DPbH7BnYKQ+orFTD7+JY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v4 v4.0.0/go.mod h1:nivJvZio5SHpEASAk8LKIueqs7zEHU+iRLKWbx3Xi10=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0 h1:pPvTJ1dY0sA35JOeFq6TsY2xj6Z85Yo23Pj4wCCvu4o=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0/go.mod h1:mLfWfj8v3jfWKsL9G4eoBoXVcsqcIUTapmdKy7uGOp0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0 h1:3jDMffAwnvs6qmOqhjNVHB29AKxs6brnzJeo65E1YwM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0/go.mod h1:0mKVz3WT8oNjBunT1zD/HPwMleQ72QClMa7Gmsm+6Kc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 h1:QM6sE5k2ZT/vI5BEe0r7mqjsUSnhVBFbOsVkEuaEfiA=

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -59,6 +59,7 @@ import (
 	storageaccountsrv "github.com/stackshy/cloudemu/v2/server/azure/storageaccount"
 	"github.com/stackshy/cloudemu/v2/server/azure/subscriptions"
 	tablesrv "github.com/stackshy/cloudemu/v2/server/azure/tablestorage"
+	"github.com/stackshy/cloudemu/v2/server/azure/tenants"
 	"github.com/stackshy/cloudemu/v2/server/azure/virtualmachines"
 	"github.com/stackshy/cloudemu/v2/server/azure/vnet"
 	azureaidriver "github.com/stackshy/cloudemu/v2/services/azureai/driver"
@@ -171,7 +172,14 @@ type Drivers struct {
 	// check on incoming queries.
 	ResourceDiscovery *resourcediscovery.Engine
 	SubscriptionID    string
+	// TenantID is the Azure AD tenant reported by the subscriptions Get/List and
+	// the global tenants list. Empty falls back to defaultTenantID.
+	TenantID string
 }
+
+// defaultTenantID is reported when Drivers.TenantID is unset, so a caller
+// verifying an account always sees a well-formed tenant GUID.
+const defaultTenantID = "11111111-1111-1111-1111-111111111111"
 
 // New returns a server that speaks the Azure ARM JSON wire protocol for every
 // non-nil driver in d. Routing is path-based on
@@ -190,9 +198,18 @@ type Drivers struct {
 func New(d Drivers) http.Handler {
 	srv := server.New()
 
-	// The subscriptions collection has no driver behind it — see the package
-	// doc for why the list is empty rather than invented.
-	srv.Register(subscriptions.New())
+	tenantID := d.TenantID
+	if tenantID == "" {
+		tenantID = defaultTenantID
+	}
+
+	// The subscriptions endpoints (list / get / locations) have no driver: the
+	// emulator serves a single estate under one subscription and echoes it back.
+	srv.Register(subscriptions.New(d.SubscriptionID, tenantID))
+
+	// The global tenants list is a non-/subscriptions ARM path; register it
+	// before the permissive blob fallback so it isn't swallowed as a blob call.
+	srv.Register(tenants.New(tenantID))
 
 	// Resource groups have no driver: they are containers, and the emulator
 	// tracks membership by the ids resources already carry.
@@ -393,6 +410,9 @@ func New(d Drivers) http.Handler {
 	// unconstrained relative to the resource handlers above.
 	if d.ResourceDiscovery != nil {
 		srv.Register(resourcegraph.New(d.ResourceDiscovery, d.SubscriptionID))
+		// Generic Microsoft.Resources listing (az resource list) at subscription
+		// and resource-group scope, backed by the same discovery engine.
+		srv.Register(resourcegraph.NewResources(d.ResourceDiscovery, d.SubscriptionID))
 	}
 
 	// IAM matches /providers/Microsoft.Authorization/role{Definitions,Assignments}

--- a/server/azure/resourcegraph/resources.go
+++ b/server/azure/resourcegraph/resources.go
@@ -1,0 +1,101 @@
+package resourcegraph
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
+)
+
+// ResourcesHandler serves the generic Microsoft.Resources listing API — the
+// `az resource list` surface — at two scopes:
+//
+//	GET /subscriptions/{sub}/resources
+//	GET /subscriptions/{sub}/resourceGroups/{rg}/resources
+//
+// Resource Graph (the Handler above) requires a KQL POST; this is the plain
+// per-subscription / per-group inventory a CLI reaches for by default. Both are
+// backed by the same discovery engine and the same row renderer, so a resource
+// shows up identically whichever surface a caller uses.
+type ResourcesHandler struct {
+	engine         *resourcediscovery.Engine
+	subscriptionID string
+}
+
+// NewResources returns a generic-resources handler backed by engine.
+// subscriptionID scopes rendered resource ids, mirroring the Resource Graph
+// handler; an empty value falls back to the engine's own account id.
+func NewResources(engine *resourcediscovery.Engine, subscriptionID string) *ResourcesHandler {
+	if subscriptionID == "" && engine != nil {
+		subscriptionID = engine.AccountID()
+	}
+
+	return &ResourcesHandler{engine: engine, subscriptionID: subscriptionID}
+}
+
+// resourcesRoute reports the resource group scope for a generic-resources path,
+// or ok=false when the path is not a generic-resources listing. An empty group
+// means the subscription-wide listing.
+func resourcesRoute(urlPath string) (group string, ok bool) {
+	parts := strings.Split(strings.Trim(urlPath, "/"), "/")
+	if len(parts) < 3 || !strings.EqualFold(parts[0], "subscriptions") {
+		return "", false
+	}
+
+	// /subscriptions/{sub}/resources
+	if len(parts) == 3 && strings.EqualFold(parts[2], "resources") {
+		return "", true
+	}
+
+	// /subscriptions/{sub}/resourceGroups/{rg}/resources
+	if len(parts) == 5 && strings.EqualFold(parts[2], "resourcegroups") &&
+		strings.EqualFold(parts[4], "resources") {
+		return parts[3], true
+	}
+
+	return "", false
+}
+
+// Matches claims a GET of the generic-resources listing at either scope.
+func (*ResourcesHandler) Matches(r *http.Request) bool {
+	if r.Method != http.MethodGet {
+		return false
+	}
+
+	_, ok := resourcesRoute(r.URL.Path)
+
+	return ok
+}
+
+func (h *ResourcesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	group, ok := resourcesRoute(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unknown resources path: "+r.URL.Path)
+		return
+	}
+
+	all, err := h.engine.ListAll(r.Context())
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	value := make([]map[string]any, 0, len(all))
+
+	for i := range all {
+		if group != "" && !strings.EqualFold(resourceGroupOrDefault(all[i].ARN), group) {
+			continue
+		}
+
+		value = append(value, resourceToWire(&all[i], h.subscriptionID))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, map[string]any{"value": value})
+}
+
+// compile-time check that ResourcesHandler satisfies the dispatch contract.
+var _ interface {
+	Matches(*http.Request) bool
+	http.Handler
+} = (*ResourcesHandler)(nil)

--- a/server/azure/resourcegraph/resources_sdk_test.go
+++ b/server/azure/resourcegraph/resources_sdk_test.go
@@ -1,0 +1,111 @@
+// Real-SDK test for the generic Microsoft.Resources listing (az resource list).
+// The live armresources Client drives both the subscription-wide and the
+// per-resource-group listing against the discovery-backed handler.
+
+package resourcegraph_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+	dbxdriver "github.com/stackshy/cloudemu/v2/services/databricks/driver"
+)
+
+func TestSDKGenericResourcesList(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	_, err := cloudP.Databricks.CreateWorkspace(ctx, dbxdriver.WorkspaceConfig{
+		Name: "ws-e2e", ResourceGroup: "rg-e2e", Location: "eastus", SKUName: "premium",
+		ManagedResourceGroupID: "/subscriptions/123456789012/resourceGroups/managed-rg",
+		Tags:                   map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	srv := azureserver.New(azureserver.Drivers{
+		Databricks:        cloudP.Databricks,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		SubscriptionID:    "123456789012",
+	})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newGenericResourcesClient(t, ts)
+
+	t.Run("list by resource group", func(t *testing.T) {
+		names := collect(ctx, t, client.NewListByResourceGroupPager("rg-e2e", nil),
+			func(p armresources.ClientListByResourceGroupResponse) []*armresources.GenericResourceExpanded {
+				return p.Value
+			})
+		assert.Contains(t, names, "ws-e2e")
+	})
+
+	t.Run("subscription-wide list", func(t *testing.T) {
+		names := collect(ctx, t, client.NewListPager(nil),
+			func(p armresources.ClientListResponse) []*armresources.GenericResourceExpanded {
+				return p.Value
+			})
+		assert.Contains(t, names, "ws-e2e")
+	})
+
+	t.Run("empty group returns nothing", func(t *testing.T) {
+		names := collect(ctx, t, client.NewListByResourceGroupPager("no-such-rg", nil),
+			func(p armresources.ClientListByResourceGroupResponse) []*armresources.GenericResourceExpanded {
+				return p.Value
+			})
+		assert.Empty(t, names)
+	})
+}
+
+// collect drains a pager, extracting resource names via value, so it works for
+// both the subscription-wide and per-group list pagers (which return distinct
+// response types).
+func collect[T any](ctx context.Context, t *testing.T, pager *runtime.Pager[T],
+	value func(T) []*armresources.GenericResourceExpanded,
+) []string {
+	t.Helper()
+
+	var names []string
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		require.NoError(t, err)
+
+		for _, r := range value(page) {
+			if r.Name != nil {
+				names = append(names, *r.Name)
+			}
+		}
+	}
+
+	return names
+}
+
+func newGenericResourcesClient(t *testing.T, ts *httptest.Server) *armresources.Client {
+	t.Helper()
+
+	opts := &arm.ClientOptions{ClientOptions: azcore.ClientOptions{
+		Cloud: cloud.Configuration{Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		}},
+		Transport: ts.Client(),
+		Retry:     policy.RetryOptions{MaxRetries: -1},
+	}}
+
+	c, err := armresources.NewClient("123456789012", fakeCred{}, opts)
+	require.NoError(t, err)
+
+	return c
+}

--- a/server/azure/resourcegroups/handler.go
+++ b/server/azure/resourcegroups/handler.go
@@ -4,10 +4,15 @@
 // Every Azure resource lives in a resource group, so a caller creates one
 // before anything else and deletes it last. Without the API the first step of
 // any provisioning run fails and nothing behind it is reachable.
+//
+// The handler models the real lifecycle a client depends on: a create returns
+// 201 (an update 200) and requires a location; lookups and updates are case-
+// insensitive on the group name; PATCH merges tags; delete is an async
+// long-running operation (202 + Location) the SDK polls; and exportTemplate
+// returns an ARM template skeleton.
 package resourcegroups
 
 import (
-	"encoding/json"
 	"net/http"
 	"strings"
 	"sync"
@@ -15,174 +20,302 @@ import (
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 )
 
+const resourceGroupType = "Microsoft.Resources/resourceGroups"
+
+// Path-segment counts for the routes this handler serves.
+const (
+	partsCollection = 3 // /subscriptions/{sub}/resourcegroups
+	partsGroup      = 4 // /subscriptions/{sub}/resourcegroups/{name}
+	partsExport     = 5 // /subscriptions/{sub}/resourcegroups/{name}/exportTemplate
+	partsOperation  = 4 // /subscriptions/{sub}/operationresults/{id}
+)
+
 // Handler serves the resource-group collection and its members.
 type Handler struct {
-	mu     sync.RWMutex
-	groups map[string]map[string]json.RawMessage // subscription -> name -> body
+	mu sync.RWMutex
+	// groups is keyed subscription -> lowercased-name -> group body. Names are
+	// stored lowercased because ARM resolves a resource group case-insensitively
+	// (create "myRG", get "MYRG"); the body keeps the original-cased name.
+	groups map[string]map[string]map[string]any
 }
 
 // New returns a resource-group handler.
 func New() *Handler {
-	return &Handler{groups: map[string]map[string]json.RawMessage{}}
+	return &Handler{groups: map[string]map[string]map[string]any{}}
 }
 
-// path splits /subscriptions/{sub}/resourcegroups[/{name}], case-insensitively
-// on the collection segment because callers spell it both ways.
-func path(urlPath string) (sub, name string, ok bool) {
+// routeKind classifies a resource-group request path.
+type routeKind int
+
+const (
+	kindNone       routeKind = iota
+	kindCollection           // /subscriptions/{sub}/resourcegroups
+	kindGroup                // /subscriptions/{sub}/resourcegroups/{name}
+	kindExport               // /subscriptions/{sub}/resourcegroups/{name}/exportTemplate
+	kindOperation            // /subscriptions/{sub}/operationresults/{id}
+)
+
+// parse classifies urlPath, case-insensitively on the collection segment
+// because callers spell "resourceGroups" and "resourcegroups" both ways.
+func parse(urlPath string) (kind routeKind, sub, name string) {
 	parts := strings.Split(strings.Trim(urlPath, "/"), "/")
-	if len(parts) < 3 || !strings.EqualFold(parts[0], "subscriptions") {
-		return "", "", false
+	if len(parts) < partsCollection || !strings.EqualFold(parts[0], "subscriptions") {
+		return kindNone, "", ""
+	}
+
+	sub = parts[1]
+
+	// Async operation-result poll for a resource-group delete.
+	if len(parts) == partsOperation && strings.EqualFold(parts[2], "operationresults") {
+		return kindOperation, sub, parts[3]
 	}
 
 	if !strings.EqualFold(parts[2], "resourcegroups") {
-		return "", "", false
+		return kindNone, "", ""
 	}
 
-	// Anything deeper belongs to a resource handler, not this one.
-	if len(parts) > 4 {
-		return "", "", false
+	switch len(parts) {
+	case partsCollection:
+		return kindCollection, sub, ""
+	case partsGroup:
+		return kindGroup, sub, parts[3]
+	case partsExport:
+		if strings.EqualFold(parts[4], "exportTemplate") {
+			return kindExport, sub, parts[3]
+		}
 	}
 
-	if len(parts) == 4 {
-		return parts[1], parts[3], true
-	}
-
-	return parts[1], "", true
+	return kindNone, "", ""
 }
 
-// Matches claims resource-group requests only. A path that continues into
-// /providers/... is a resource inside the group and belongs elsewhere.
+// Matches claims resource-group requests and the delete operation-result poll.
+// A path that continues into /providers/... is a resource inside the group (and
+// a .../resources path is the generic resources list) — both belong elsewhere.
 func (*Handler) Matches(r *http.Request) bool {
-	_, _, ok := path(r.URL.Path)
+	kind, _, _ := parse(r.URL.Path)
 
-	return ok
+	return kind != kindNone
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	sub, name, ok := path(r.URL.Path)
-	if !ok {
-		writeErr(w, http.StatusBadRequest, "InvalidPath", "malformed resource group path")
+	kind, sub, name := parse(r.URL.Path)
+
+	switch kind {
+	case kindCollection:
+		h.serveCollection(w, r, sub)
+	case kindGroup:
+		h.serveGroup(w, r, sub, name)
+	case kindExport:
+		h.serveExport(w, r, sub, name)
+	case kindOperation:
+		// The delete already ran synchronously; the poll is always terminal.
+		w.WriteHeader(http.StatusOK)
+	case kindNone:
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unknown resource-group path")
+	}
+}
+
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, sub string) {
+	if r.Method != http.MethodGet {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 		return
 	}
 
-	if name == "" {
-		if r.Method == http.MethodGet {
-			h.list(w, sub)
-			return
-		}
+	h.list(w, sub)
+}
 
-		writeErr(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
-
-		return
-	}
-
+func (h *Handler) serveGroup(w http.ResponseWriter, r *http.Request, sub, name string) {
 	switch r.Method {
 	case http.MethodPut:
 		h.put(w, r, sub, name)
+	case http.MethodPatch:
+		h.patch(w, r, sub, name)
 	case http.MethodGet, http.MethodHead:
 		h.get(w, sub, name)
 	case http.MethodDelete:
-		h.remove(w, sub, name)
+		h.remove(w, r, sub, name)
 	default:
-		writeErr(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
 }
 
 func (h *Handler) put(w http.ResponseWriter, r *http.Request, sub, name string) {
-	// Capped like every sibling ARM handler; the decode stays tolerant
-	// because a bare resource-group PUT carries no body.
-	r.Body = http.MaxBytesReader(w, r.Body, azurearm.MaxBodyBytes)
-
 	var body map[string]any
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		body = map[string]any{}
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
 	}
 
-	body["id"] = "/subscriptions/" + sub + "/resourceGroups/" + name
-	body["name"] = name
-	body["type"] = "Microsoft.Resources/resourceGroups"
+	// A resource group requires a location that cannot be changed later; real
+	// ARM rejects a create/update with no location.
+	loc, _ := body["location"].(string)
+	if strings.TrimSpace(loc) == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "LocationRequired",
+			"The location property is required for this definition.")
 
-	// A group is usable the moment it is created; there is no provisioning to
-	// wait on, and a caller that polls would never see it leave a pending state.
-	body["properties"] = map[string]any{"provisioningState": "Succeeded"}
+		return
+	}
 
-	raw, err := json.Marshal(body)
-	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "InternalError", err.Error())
+	group := map[string]any{
+		"id":         azureGroupID(sub, name),
+		"name":       name,
+		"type":       resourceGroupType,
+		"location":   loc,
+		"properties": map[string]any{"provisioningState": "Succeeded"},
+	}
+
+	if tags, ok := body["tags"]; ok {
+		group["tags"] = tags
+	}
+
+	if mb, ok := body["managedBy"].(string); ok && mb != "" {
+		group["managedBy"] = mb
+	}
+
+	status := http.StatusCreated
+	if h.store(sub, name, group) {
+		status = http.StatusOK
+	}
+
+	azurearm.WriteJSON(w, status, group)
+}
+
+func (h *Handler) patch(w http.ResponseWriter, r *http.Request, sub, name string) {
+	var body map[string]any
+	if !azurearm.DecodeJSON(w, r, &body) {
 		return
 	}
 
 	h.mu.Lock()
-	if h.groups[sub] == nil {
-		h.groups[sub] = map[string]json.RawMessage{}
-	}
+	defer h.mu.Unlock()
 
-	h.groups[sub][name] = raw
-	h.mu.Unlock()
-
-	writeJSON(w, http.StatusOK, raw)
-}
-
-func (h *Handler) get(w http.ResponseWriter, sub, name string) {
-	h.mu.RLock()
-	raw, ok := h.groups[sub][name]
-	h.mu.RUnlock()
-
+	group, ok := h.groups[sub][strings.ToLower(name)]
 	if !ok {
-		writeErr(w, http.StatusNotFound, "ResourceGroupNotFound",
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceGroupNotFound",
 			"Resource group '"+name+"' could not be found.")
 
 		return
 	}
 
-	writeJSON(w, http.StatusOK, raw)
+	// PATCH replaces the tags and managedBy fields when supplied and leaves the
+	// rest (location, provisioningState) untouched.
+	if tags, present := body["tags"]; present {
+		group["tags"] = tags
+	}
+
+	if mb, present := body["managedBy"].(string); present {
+		group["managedBy"] = mb
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, group)
+}
+
+func (h *Handler) get(w http.ResponseWriter, sub, name string) {
+	h.mu.RLock()
+	group, ok := h.groups[sub][strings.ToLower(name)]
+	h.mu.RUnlock()
+
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceGroupNotFound",
+			"Resource group '"+name+"' could not be found.")
+
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, group)
 }
 
 func (h *Handler) list(w http.ResponseWriter, sub string) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
-	value := make([]json.RawMessage, 0, len(h.groups[sub]))
-	for _, raw := range h.groups[sub] {
-		value = append(value, raw)
+	value := make([]map[string]any, 0, len(h.groups[sub]))
+	for _, group := range h.groups[sub] {
+		value = append(value, group)
 	}
 
-	writeJSON(w, http.StatusOK, mustMarshal(map[string]any{"value": value}))
+	azurearm.WriteJSON(w, http.StatusOK, map[string]any{"value": value})
 }
 
-func (h *Handler) remove(w http.ResponseWriter, sub, name string) {
+func (h *Handler) remove(w http.ResponseWriter, r *http.Request, sub, name string) {
 	h.mu.Lock()
-	_, existed := h.groups[sub][name]
-	delete(h.groups[sub], name)
+	_, existed := h.groups[sub][strings.ToLower(name)]
+	delete(h.groups[sub], strings.ToLower(name))
 	h.mu.Unlock()
 
 	// Deleting a group that is already gone is the caller's desired end state,
-	// and a teardown retry must not fail on its second pass.
+	// and a teardown retry must not fail on its second pass. There is nothing to
+	// poll, so answer synchronously.
 	if !existed {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	// Real ARM deletes a resource group asynchronously: 202 with a Location the
+	// SDK polls until it returns a terminal status. The delete already ran in
+	// memory, so the poll endpoint reports success immediately.
+	w.Header().Set("Location", absoluteURL(r, "/subscriptions/"+sub+"/operationresults/"+strings.ToLower(name)))
+	w.Header().Set("Retry-After", "0")
+	w.WriteHeader(http.StatusAccepted)
 }
 
-func mustMarshal(v any) json.RawMessage {
-	raw, err := json.Marshal(v)
-	if err != nil {
-		return json.RawMessage(`{}`)
+func (h *Handler) serveExport(w http.ResponseWriter, r *http.Request, sub, name string) {
+	if r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "POST required")
+		return
 	}
 
-	return raw
+	h.mu.RLock()
+	_, ok := h.groups[sub][strings.ToLower(name)]
+	h.mu.RUnlock()
+
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceGroupNotFound",
+			"Resource group '"+name+"' could not be found.")
+
+		return
+	}
+
+	// The emulator does not track per-group resource membership here, so the
+	// exported template is a valid, empty ARM template skeleton.
+	azurearm.WriteJSON(w, http.StatusOK, map[string]any{
+		"template": map[string]any{
+			"$schema":        "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+			"contentVersion": "1.0.0.0",
+			"parameters":     map[string]any{},
+			"variables":      map[string]any{},
+			"resources":      []any{},
+			"outputs":        map[string]any{},
+		},
+	})
 }
 
-func writeJSON(w http.ResponseWriter, status int, raw json.RawMessage) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_, _ = w.Write(raw)
+// store writes the group under a case-insensitive key and reports whether a
+// group of that name already existed (an update rather than a create).
+func (h *Handler) store(sub, name string, group map[string]any) (existed bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.groups[sub] == nil {
+		h.groups[sub] = map[string]map[string]any{}
+	}
+
+	_, existed = h.groups[sub][strings.ToLower(name)]
+	h.groups[sub][strings.ToLower(name)] = group
+
+	return existed
 }
 
-func writeErr(w http.ResponseWriter, status int, code, message string) {
-	writeJSON(w, status, mustMarshal(map[string]any{
-		"error": map[string]string{"code": code, "message": message},
-	}))
+func azureGroupID(sub, name string) string {
+	return "/subscriptions/" + sub + "/resourceGroups/" + name
+}
+
+// absoluteURL builds an absolute URL for path from the incoming request, so a
+// Location header the SDK poller follows resolves correctly.
+func absoluteURL(r *http.Request, path string) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	return scheme + "://" + r.Host + path
 }

--- a/server/azure/resourcegroups/sdk_test.go
+++ b/server/azure/resourcegroups/sdk_test.go
@@ -1,0 +1,162 @@
+// Real-SDK and wire round-trip tests for the Azure resource-group handler. The
+// live azure-sdk-for-go armresources ResourceGroupsClient drives the async
+// create/get/update/delete/export lifecycle end-to-end; raw HTTP pins the
+// status codes and validation the SDK hides (201-on-create, 400-no-location).
+
+package resourcegroups_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+const subID = "00000000-0000-0000-0000-000000000000"
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func newServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	ts := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{SubscriptionID: subID}))
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func newRGClient(t *testing.T, ts *httptest.Server) *armresources.ResourceGroupsClient {
+	t.Helper()
+
+	opts := &arm.ClientOptions{ClientOptions: azcore.ClientOptions{
+		Cloud: cloud.Configuration{Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		}},
+		Transport: ts.Client(),
+		Retry:     policy.RetryOptions{MaxRetries: -1},
+	}}
+
+	c, err := armresources.NewResourceGroupsClient(subID, fakeCred{}, opts)
+	require.NoError(t, err)
+
+	return c
+}
+
+// TestResourceGroupLifecycleSDK drives the full lifecycle with the real SDK,
+// proving the async delete LRO, case-insensitive get, PATCH tag update and
+// export all satisfy the live poller/marshalling.
+func TestResourceGroupLifecycleSDK(t *testing.T) {
+	ctx := context.Background()
+	ts := newServer(t)
+	client := newRGClient(t, ts)
+
+	created, err := client.CreateOrUpdate(ctx, "myRG", armresources.ResourceGroup{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+	}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "eastus", *created.Location)
+	assert.Equal(t, "Succeeded", *created.Properties.ProvisioningState)
+
+	// ARM resolves the group name case-insensitively.
+	got, err := client.Get(ctx, "MYRG", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "eastus", *got.Location)
+	assert.Equal(t, "prod", *got.Tags["env"])
+
+	// PATCH merges tags and returns the group.
+	updated, err := client.Update(ctx, "myrg", armresources.ResourceGroupPatchable{
+		Tags: map[string]*string{"env": to.Ptr("stage"), "team": to.Ptr("core")},
+	}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "stage", *updated.Tags["env"])
+	assert.Equal(t, "core", *updated.Tags["team"])
+
+	// exportTemplate returns a valid template skeleton via the LRO poller.
+	exp, err := client.BeginExportTemplate(ctx, "myRG", armresources.ExportTemplateRequest{
+		Resources: []*string{to.Ptr("*")},
+	}, nil)
+	require.NoError(t, err)
+	expRes, err := exp.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, expRes.Template)
+
+	// Async delete: 202 + Location the poller drives to completion.
+	poller, err := client.BeginDelete(ctx, "myRG", nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	_, err = client.Get(ctx, "myRG", nil)
+	require.Error(t, err, "group must be gone after delete")
+}
+
+// TestResourceGroupCreateReturns201 pins the create-vs-update status codes and
+// the location-required validation the SDK abstracts away.
+func TestResourceGroupCreateReturns201(t *testing.T) {
+	ts := newServer(t)
+
+	base := ts.URL + "/subscriptions/" + subID + "/resourcegroups/statusrg?api-version=2021-04-01"
+
+	// First PUT creates -> 201.
+	assert.Equal(t, http.StatusCreated, putRG(t, ts, base, `{"location":"eastus"}`))
+
+	// Second PUT updates -> 200.
+	assert.Equal(t, http.StatusOK, putRG(t, ts, base, `{"location":"eastus"}`))
+}
+
+func TestResourceGroupRequiresLocation(t *testing.T) {
+	ts := newServer(t)
+
+	base := ts.URL + "/subscriptions/" + subID + "/resourcegroups/noloc?api-version=2021-04-01"
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPut, base, strings.NewReader(`{}`))
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	var env struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(body, &env))
+	assert.Equal(t, "LocationRequired", env.Error.Code)
+}
+
+func putRG(t *testing.T, ts *httptest.Server, url, body string) int {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, url, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	return resp.StatusCode
+}

--- a/server/azure/subscriptions/handler.go
+++ b/server/azure/subscriptions/handler.go
@@ -1,48 +1,134 @@
 // Package subscriptions implements the Azure Resource Manager subscriptions
-// list endpoint.
+// endpoints: the collection list, a single subscription Get, and the per-
+// subscription locations list.
 //
 // A caller connecting an Azure account verifies the credential by listing the
-// subscriptions it can reach and checking the target is among them. Without
-// this endpoint that check fails, so an Azure account cannot be connected at
-// all — the failure lands before any resource work begins.
+// subscriptions it can reach (or getting the target subscription directly) and
+// checking the target is among them. CLIs and IaC tools also call the locations
+// endpoint at startup to validate a region. Without these the first step of any
+// Azure workflow fails before any resource work begins.
 //
-// The list is empty: the emulator has no tenant model, so it cannot say which
-// subscriptions a credential reaches. Answering with a well-formed empty list
-// lets a caller complete the request and decide for itself, rather than
-// inventing subscriptions that do not exist.
+// The emulator serves a single estate under one subscription id and is
+// subscription-transparent: Get echoes back whichever subscription id the
+// caller scoped to (the same value the management plane echoes into resource
+// ids), and List reports the one reachable subscription. This keeps
+// "connect account X" then "create under X" consistent for every service.
 package subscriptions
 
 import (
-	"encoding/json"
 	"net/http"
 	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 )
 
-const basePath = "/subscriptions"
+const (
+	basePath = "/subscriptions"
 
-// Handler serves the subscriptions collection.
-type Handler struct{}
+	// DefaultSubscriptionID is reported when the server is configured with no
+	// subscription id. It matches the cmd/cloudemu default so a caller sees a
+	// stable, well-formed GUID.
+	DefaultSubscriptionID = "00000000-0000-0000-0000-000000000000"
 
-// New returns a subscriptions handler.
-func New() *Handler {
-	return &Handler{}
+	stateEnabled        = "Enabled"
+	authorizationSource = "RoleBased"
+
+	kindList      = "list"
+	kindGet       = "get"
+	kindLocations = "locations"
+
+	partsGet       = 2
+	partsLocations = 3
+)
+
+// Handler serves the subscriptions collection, a single subscription, and the
+// per-subscription locations list.
+type Handler struct {
+	subscriptionID string
+	tenantID       string
 }
 
-// Matches claims a GET of the subscriptions collection itself. Paths that go
-// deeper — /subscriptions/{id}/resourceGroups/... — belong to the resource
-// handlers, so only the bare collection is claimed here.
+// New returns a subscriptions handler. An empty subscriptionID falls back to
+// DefaultSubscriptionID; tenantID is echoed as the subscription's tenant.
+func New(subscriptionID, tenantID string) *Handler {
+	if subscriptionID == "" {
+		subscriptionID = DefaultSubscriptionID
+	}
+
+	return &Handler{subscriptionID: subscriptionID, tenantID: tenantID}
+}
+
+// route classifies a request path into one of the three shapes this handler
+// serves, or returns ok=false for anything deeper (which belongs to the
+// resource-group / resource handlers).
+func route(urlPath string) (kind, id string, ok bool) {
+	if strings.TrimSuffix(urlPath, "/") == basePath {
+		return kindList, "", true
+	}
+
+	parts := strings.Split(strings.Trim(urlPath, "/"), "/")
+	if len(parts) < partsGet || parts[0] != "subscriptions" {
+		return "", "", false
+	}
+
+	switch len(parts) {
+	case partsGet:
+		return kindGet, parts[1], true
+	case partsLocations:
+		if strings.EqualFold(parts[2], kindLocations) {
+			return kindLocations, parts[1], true
+		}
+	}
+
+	return "", "", false
+}
+
+// Matches claims a GET of the subscriptions collection, a single subscription,
+// or a subscription's locations list. Deeper paths
+// (/subscriptions/{id}/resourceGroups/...) belong to the resource handlers.
 func (*Handler) Matches(r *http.Request) bool {
 	if r.Method != http.MethodGet {
 		return false
 	}
 
-	return strings.TrimSuffix(r.URL.Path, "/") == basePath
+	_, _, ok := route(r.URL.Path)
+
+	return ok
 }
 
-func (*Handler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
-	value := []map[string]any{}
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	kind, id, ok := route(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unknown subscriptions path: "+r.URL.Path)
+		return
+	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(map[string]any{"value": value})
+	switch kind {
+	case kindList:
+		azurearm.WriteJSON(w, http.StatusOK, map[string]any{
+			"value": []map[string]any{h.subscription(h.subscriptionID)},
+		})
+	case kindGet:
+		azurearm.WriteJSON(w, http.StatusOK, h.subscription(id))
+	case kindLocations:
+		azurearm.WriteJSON(w, http.StatusOK, map[string]any{"value": locations(id)})
+	}
+}
+
+// subscription renders the Subscription object real ARM returns for Get/List.
+// The id is echoed so the emulator stays subscription-transparent.
+func (h *Handler) subscription(id string) map[string]any {
+	return map[string]any{
+		"id":                  basePath + "/" + id,
+		"subscriptionId":      id,
+		"displayName":         "CloudEmu Subscription",
+		"state":               stateEnabled,
+		"tenantId":            h.tenantID,
+		"authorizationSource": authorizationSource,
+		"subscriptionPolicies": map[string]any{
+			"locationPlacementId": "Public_2014-09-01",
+			"quotaId":             "Public_2014-09-01",
+			"spendingLimit":       "Off",
+		},
+	}
 }

--- a/server/azure/subscriptions/handler_test.go
+++ b/server/azure/subscriptions/handler_test.go
@@ -1,0 +1,146 @@
+// Wire tests for the Azure subscriptions endpoints. They assert the ARM JSON
+// shape a real client (az account show / az account list-locations) expects:
+// a single-subscription Get, a non-empty List, and a locations list.
+
+package subscriptions_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+const (
+	subID    = "abc12345-0000-0000-0000-000000000000"
+	tenantID = "99999999-0000-0000-0000-000000000000"
+)
+
+func newServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	ts := httptest.NewServer(azureserver.New(azureserver.Drivers{
+		SubscriptionID: subID,
+		TenantID:       tenantID,
+	}))
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func getJSON(t *testing.T, ts *httptest.Server, path string, out any) int {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+path, nil)
+	require.NoError(t, err)
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	if len(body) > 0 && out != nil {
+		require.NoError(t, json.Unmarshal(body, out), "body: %s", body)
+	}
+
+	return resp.StatusCode
+}
+
+func TestSubscriptionGet(t *testing.T) {
+	ts := newServer(t)
+
+	// A caller can ask for any subscription id; the emulator echoes it back
+	// (subscription-transparent), reporting the configured tenant.
+	var sub struct {
+		ID             string `json:"id"`
+		SubscriptionID string `json:"subscriptionId"`
+		State          string `json:"state"`
+		TenantID       string `json:"tenantId"`
+		DisplayName    string `json:"displayName"`
+	}
+
+	status := getJSON(t, ts, "/subscriptions/"+subID+"?api-version=2022-12-01", &sub)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, "/subscriptions/"+subID, sub.ID)
+	assert.Equal(t, subID, sub.SubscriptionID)
+	assert.Equal(t, "Enabled", sub.State)
+	assert.Equal(t, tenantID, sub.TenantID)
+	assert.NotEmpty(t, sub.DisplayName)
+}
+
+func TestSubscriptionList(t *testing.T) {
+	ts := newServer(t)
+
+	var out struct {
+		Value []struct {
+			SubscriptionID string `json:"subscriptionId"`
+		} `json:"value"`
+	}
+
+	status := getJSON(t, ts, "/subscriptions?api-version=2022-12-01", &out)
+	assert.Equal(t, http.StatusOK, status)
+	require.Len(t, out.Value, 1)
+	assert.Equal(t, subID, out.Value[0].SubscriptionID)
+}
+
+func TestSubscriptionListLocations(t *testing.T) {
+	ts := newServer(t)
+
+	var out struct {
+		Value []struct {
+			Name        string `json:"name"`
+			DisplayName string `json:"displayName"`
+			ID          string `json:"id"`
+			Type        string `json:"type"`
+			Metadata    struct {
+				RegionType string `json:"regionType"`
+			} `json:"metadata"`
+		} `json:"value"`
+	}
+
+	status := getJSON(t, ts, "/subscriptions/"+subID+"/locations?api-version=2022-12-01", &out)
+	assert.Equal(t, http.StatusOK, status)
+	require.NotEmpty(t, out.Value)
+
+	var found bool
+	for _, loc := range out.Value {
+		assert.Equal(t, "Region", loc.Type)
+		assert.Equal(t, "/subscriptions/"+subID+"/locations/"+loc.Name, loc.ID)
+		assert.Equal(t, "Physical", loc.Metadata.RegionType)
+
+		if loc.Name == "eastus" {
+			found = true
+
+			assert.Equal(t, "East US", loc.DisplayName)
+		}
+	}
+
+	assert.True(t, found, "eastus must be present")
+}
+
+// TestSubscriptionsDoNotShadowResourceGroups guards the routing boundary: a
+// resource-group path under a subscription must not be claimed by this handler.
+func TestSubscriptionsDoNotShadowResourceGroups(t *testing.T) {
+	ts := newServer(t)
+
+	// An unknown resource-group path under a subscription must reach the
+	// resource-group handler (404 ResourceGroupNotFound), not be echoed back as
+	// a subscription by this handler.
+	var env struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	status := getJSON(t, ts, "/subscriptions/"+subID+"/resourcegroups/rg1?api-version=2021-04-01", &env)
+	assert.Equal(t, http.StatusNotFound, status)
+	assert.Equal(t, "ResourceGroupNotFound", env.Error.Code)
+}

--- a/server/azure/subscriptions/locations.go
+++ b/server/azure/subscriptions/locations.go
@@ -1,0 +1,74 @@
+package subscriptions
+
+// region is one row of the static geo-location table the emulator reports for
+// the ListLocations endpoint. Real Azure returns the full public-cloud region
+// set; a representative subset is enough for a caller validating a region name
+// or enumerating placement options.
+type region struct {
+	name                string
+	displayName         string
+	regionalDisplayName string
+	geography           string
+	geographyGroup      string
+	latitude            string
+	longitude           string
+	physicalLocation    string
+	pairedRegion        string
+}
+
+// regionTable is the fixed set of geo-locations reported to callers. Values
+// mirror the real Azure public-cloud metadata so a client that inspects them
+// (geography grouping, paired region) sees plausible data.
+//
+//nolint:gochecknoglobals // static reference table
+var regionTable = []region{
+	{"eastus", "East US", "(US) East US", "United States", "US", "37.3719", "-79.8164", "Virginia", "westus"},
+	{"eastus2", "East US 2", "(US) East US 2", "United States", "US", "36.6681", "-78.3889", "Virginia", "centralus"},
+	{"westus", "West US", "(US) West US", "United States", "US", "37.783", "-122.417", "California", "eastus"},
+	{"westus2", "West US 2", "(US) West US 2", "United States", "US", "47.233", "-119.852", "Washington", "westcentralus"},
+	{"centralus", "Central US", "(US) Central US", "United States", "US", "41.5908", "-93.6208", "Iowa", "eastus2"},
+	{"northeurope", "North Europe", "(Europe) North Europe", "Europe", "EU", "53.3478", "-6.2597", "Ireland", "westeurope"},
+	{"westeurope", "West Europe", "(Europe) West Europe", "Europe", "EU", "52.3667", "4.9", "Netherlands", "northeurope"},
+	{"uksouth", "UK South", "(Europe) UK South", "United Kingdom", "UK", "50.941", "-0.799", "London", "ukwest"},
+	{"southeastasia", "Southeast Asia", "(Asia Pacific) Southeast Asia", "Asia Pacific", "APAC", "1.283", "103.833", "Singapore", "eastasia"},
+	{"eastasia", "East Asia", "(Asia Pacific) East Asia", "Asia Pacific", "APAC", "22.267", "114.188", "Hong Kong", "southeastasia"},
+	{
+		"australiaeast", "Australia East", "(Asia Pacific) Australia East", "Asia Pacific",
+		"APAC", "-33.86", "151.2094", "New South Wales", "australiasoutheast",
+	},
+	{"japaneast", "Japan East", "(Asia Pacific) Japan East", "Asia Pacific", "APAC", "35.68", "139.77", "Tokyo", "japanwest"},
+}
+
+// locations renders the geo-location list for subscription id in the ARM shape
+// (Location objects with id/name/displayName/regionalDisplayName/metadata).
+func locations(subscriptionID string) []map[string]any {
+	base := basePath + "/" + subscriptionID + "/locations/"
+	out := make([]map[string]any, 0, len(regionTable))
+
+	for i := range regionTable {
+		reg := &regionTable[i]
+		out = append(out, map[string]any{
+			"id":                  base + reg.name,
+			"name":                reg.name,
+			"type":                "Region",
+			"displayName":         reg.displayName,
+			"regionalDisplayName": reg.regionalDisplayName,
+			"subscriptionId":      subscriptionID,
+			"metadata": map[string]any{
+				"regionType":       "Physical",
+				"regionCategory":   "Recommended",
+				"geography":        reg.geography,
+				"geographyGroup":   reg.geographyGroup,
+				"longitude":        reg.longitude,
+				"latitude":         reg.latitude,
+				"physicalLocation": reg.physicalLocation,
+				"pairedRegion": []map[string]any{{
+					"name": reg.pairedRegion,
+					"id":   base + reg.pairedRegion,
+				}},
+			},
+		})
+	}
+
+	return out
+}

--- a/server/azure/tenants/handler.go
+++ b/server/azure/tenants/handler.go
@@ -1,0 +1,51 @@
+// Package tenants implements the Azure Resource Manager tenants list endpoint
+// (GET /tenants).
+//
+// The tenants list is a global (non-subscription-scoped) management endpoint a
+// caller hits when connecting an account — it is one of the first calls the
+// Azure CLI and SDKs make to discover the directory a credential belongs to.
+// Because the path does not start with /subscriptions/, it would otherwise fall
+// through to the permissive blob-storage data-plane fallback and come back as a
+// blob XML error; this handler claims it and answers with the ARM JSON shape.
+package tenants
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+const basePath = "/tenants"
+
+// Handler serves the global tenants list.
+type Handler struct {
+	tenantID string
+}
+
+// New returns a tenants handler that reports the single directory the emulator
+// serves, identified by tenantID.
+func New(tenantID string) *Handler {
+	return &Handler{tenantID: tenantID}
+}
+
+// Matches claims a GET of the /tenants collection. The path carries no deeper
+// segments in the real API, so only the bare collection is claimed.
+func (*Handler) Matches(r *http.Request) bool {
+	return r.Method == http.MethodGet && strings.TrimSuffix(r.URL.Path, "/") == basePath
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	azurearm.WriteJSON(w, http.StatusOK, map[string]any{
+		"value": []map[string]any{{
+			"id":             basePath + "/" + h.tenantID,
+			"tenantId":       h.tenantID,
+			"tenantCategory": "Home",
+			"displayName":    "CloudEmu Directory",
+			"countryCode":    "US",
+			"defaultDomain":  "cloudemu.onmicrosoft.com",
+			"domains":        []string{"cloudemu.onmicrosoft.com"},
+			"tenantType":     "AAD",
+		}},
+	})
+}

--- a/server/azure/tenants/handler_test.go
+++ b/server/azure/tenants/handler_test.go
@@ -1,0 +1,54 @@
+// Wire test for the global tenants list. It pins that GET /tenants returns the
+// ARM JSON shape (not the blob-storage XML fallback that used to answer any
+// non-/subscriptions path), which is what an account-connect flow expects.
+
+package tenants_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+const tenantID = "77777777-0000-0000-0000-000000000000"
+
+func TestTenantsList(t *testing.T) {
+	ts := httptest.NewServer(azureserver.New(azureserver.Drivers{TenantID: tenantID}))
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		ts.URL+"/tenants?api-version=2022-12-01", nil)
+	require.NoError(t, err)
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var out struct {
+		Value []struct {
+			ID             string `json:"id"`
+			TenantID       string `json:"tenantId"`
+			TenantCategory string `json:"tenantCategory"`
+		} `json:"value"`
+	}
+	require.NoError(t, json.Unmarshal(body, &out), "body: %s", body)
+
+	require.Len(t, out.Value, 1)
+	assert.Equal(t, tenantID, out.Value[0].TenantID)
+	assert.Equal(t, "/tenants/"+tenantID, out.Value[0].ID)
+	assert.Equal(t, "Home", out.Value[0].TenantCategory)
+}


### PR DESCRIPTION
## Summary
Fixes real-user gaps in the Azure resource-group and subscription lifecycle uncovered during the AWS/Azure e2e audit. Every change is at the wire-handler layer (`server/azure/*`); no driver interfaces changed. Contracts verified against the official Azure REST reference.

## Changes (mapped to findings)
- **[HIGH] subscriptions Get** — `GET /subscriptions/{id}` now returns the ARM Subscription object (id, subscriptionId, displayName, state=Enabled, tenantId, subscriptionPolicies, authorizationSource) instead of a 501 plain-text body. Subscription-transparent: echoes the requested id.
- **[HIGH] global tenants routing** — new `GET /tenants` handler returns the ARM tenant list, so account-connect no longer falls through to the blob-storage XML `InvalidUri` fallback.
- **[MEDIUM] generic resources list** — `GET .../resourceGroups/{rg}/resources` and `GET /subscriptions/{sub}/resources` (`az resource list`) served from the discovery engine, reusing the Resource Graph row renderer.
- **[MEDIUM] subscriptions ListLocations** — `.../{id}/locations` returns a representative Azure region set with the real metadata shape (geography, paired region, lat/long).
- **[MEDIUM] subscriptions List** — returns the one reachable subscription instead of an empty list.
- **[MEDIUM] resource-group case-insensitivity** — create `myrg`, get/patch `MYRG` now resolves (ARM is case-insensitive).
- **[MEDIUM] CreateOrUpdate** — returns 201 on create / 200 on update and rejects a body with no `location` (400 LocationRequired); stores tags + managedBy.
- **[MEDIUM] resource-group Update** — `PATCH .../resourceGroups/{name}` merges tags/managedBy and returns the group.
- **[LOW] resource-group Delete** — async long-running operation: 202 + `Location` header the SDK poller drives to completion.
- **[LOW] exportTemplate** — `POST .../exportTemplate` returns a valid ARM template skeleton.
- **[LOW] cross-cutting 201-on-create** — fixed for resourcegroups (via CreateOrUpdate above).

## Deferred
- **Unknown ARM route → JSON envelope** (LOW) — turning the dispatcher's 501 fallback into an ARM JSON error is a global cross-service contract change with existing 501 assertions in other services' tests (virtualmachines, databricks); out of scope for this service PR.
- **201-on-create for search/ai/databricks** (LOW) — those handlers are owned by other services; only the resourcegroups occurrence is fixed here.

## Tests
Real azure-sdk-for-go round-trips (`armresources` ResourceGroupsClient + generic Client) drive the async create/get/update/delete/export lifecycle and the per-group / subscription-wide resource listing end-to-end; wire tests pin the status codes and validation the SDK hides (201-on-create, 400-no-location) plus the subscriptions/tenants/locations ARM JSON shapes.

Gates: `go build ./...`, `go test ./providers/azure/... ./server/azure/... ./services/... .`, and golangci-lint on changed packages all green.
