### PR TITLE
fix(azure-cache-databricks): redis listKeys/regenerateKey, location/tags/sku round-trip, databricks workspace props

### DIFF
--- a/docs/coverage/aws/elasticache.md
+++ b/docs/coverage/aws/elasticache.md
@@ -29,6 +29,15 @@ AWS's `cache` service · portable interface `driver.Cache` · [AWS index](./READ
 
 Discovered by type assertion; only some providers implement these.
 
+### AccessKeys
+
+AccessKeys is an OPTIONAL capability, discovered by type assertion. Azure
+
+| Operation | Description |
+| --- | --- |
+| `ListCacheKeys` | ListCacheKeys returns the cache's current primary and secondary access |
+| `RegenerateCacheKey` | RegenerateCacheKey rotates the requested key ("Primary" or "Secondary") |
+
 ### ReplicationGroups
 
 ReplicationGroups is an OPTIONAL capability, discovered by type assertion.

--- a/docs/coverage/azure/cache.md
+++ b/docs/coverage/azure/cache.md
@@ -29,6 +29,15 @@ Azure's `cache` service · portable interface `driver.Cache` · [Azure index](./
 
 Discovered by type assertion; only some providers implement these.
 
+### AccessKeys
+
+AccessKeys is an OPTIONAL capability, discovered by type assertion. Azure
+
+| Operation | Description |
+| --- | --- |
+| `ListCacheKeys` | ListCacheKeys returns the cache's current primary and secondary access |
+| `RegenerateCacheKey` | RegenerateCacheKey rotates the requested key ("Primary" or "Secondary") |
+
 ### ReplicationGroups
 
 ReplicationGroups is an OPTIONAL capability, discovered by type assertion.

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -1535,6 +1535,20 @@
     ],
     "optionalCapabilities": [
       {
+        "name": "AccessKeys",
+        "doc": "AccessKeys is an OPTIONAL capability, discovered by type assertion. Azure",
+        "operations": [
+          {
+            "name": "ListCacheKeys",
+            "doc": "ListCacheKeys returns the cache's current primary and secondary access"
+          },
+          {
+            "name": "RegenerateCacheKey",
+            "doc": "RegenerateCacheKey rotates the requested key (\"Primary\" or \"Secondary\")"
+          }
+        ]
+      },
+      {
         "name": "ReplicationGroups",
         "doc": "ReplicationGroups is an OPTIONAL capability, discovered by type assertion.",
         "operations": [

--- a/docs/coverage/gcp/memorystore.md
+++ b/docs/coverage/gcp/memorystore.md
@@ -29,6 +29,15 @@ GCP's `cache` service · portable interface `driver.Cache` · [GCP index](./READ
 
 Discovered by type assertion; only some providers implement these.
 
+### AccessKeys
+
+AccessKeys is an OPTIONAL capability, discovered by type assertion. Azure
+
+| Operation | Description |
+| --- | --- |
+| `ListCacheKeys` | ListCacheKeys returns the cache's current primary and secondary access |
+| `RegenerateCacheKey` | RegenerateCacheKey rotates the requested key ("Primary" or "Secondary") |
+
 ### ReplicationGroups
 
 ReplicationGroups is an OPTIONAL capability, discovered by type assertion.

--- a/providers/azure/cache/access_keys_test.go
+++ b/providers/azure/cache/access_keys_test.go
@@ -1,0 +1,87 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateCacheGeneratesAccessKeys(t *testing.T) {
+	m, _ := newTestMock()
+
+	info, err := m.CreateCache(context.Background(), driver.CacheConfig{Name: "c1"})
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, info.PrimaryKey)
+	assert.NotEmpty(t, info.SecondaryKey)
+	assert.NotEqual(t, info.PrimaryKey, info.SecondaryKey)
+}
+
+func TestCreateCacheStoresLocation(t *testing.T) {
+	m, _ := newTestMock()
+
+	info, err := m.CreateCache(context.Background(), driver.CacheConfig{Name: "c1", Location: "westus2"})
+	require.NoError(t, err)
+	assert.Equal(t, "westus2", info.Location)
+
+	got, err := m.GetCache(context.Background(), "c1")
+	require.NoError(t, err)
+	assert.Equal(t, "westus2", got.Location)
+}
+
+func TestListCacheKeys(t *testing.T) {
+	m, _ := newTestMock()
+	createTestCache(t, m, "c1")
+
+	primary, secondary, err := m.ListCacheKeys(context.Background(), "c1")
+	require.NoError(t, err)
+	assert.NotEmpty(t, primary)
+	assert.NotEmpty(t, secondary)
+
+	_, _, err = m.ListCacheKeys(context.Background(), "missing")
+	assert.Error(t, err)
+}
+
+func TestRegenerateCacheKeyPrimary(t *testing.T) {
+	m, _ := newTestMock()
+	createTestCache(t, m, "c1")
+
+	before, secBefore, err := m.ListCacheKeys(context.Background(), "c1")
+	require.NoError(t, err)
+
+	primary, secondary, err := m.RegenerateCacheKey(context.Background(), "c1", "Primary")
+	require.NoError(t, err)
+	assert.NotEqual(t, before, primary, "primary key must rotate")
+	assert.Equal(t, secBefore, secondary, "secondary key must be unchanged")
+}
+
+func TestRegenerateCacheKeySecondary(t *testing.T) {
+	m, _ := newTestMock()
+	createTestCache(t, m, "c1")
+
+	priBefore, secBefore, err := m.ListCacheKeys(context.Background(), "c1")
+	require.NoError(t, err)
+
+	primary, secondary, err := m.RegenerateCacheKey(context.Background(), "c1", "Secondary")
+	require.NoError(t, err)
+	assert.Equal(t, priBefore, primary, "primary key must be unchanged")
+	assert.NotEqual(t, secBefore, secondary, "secondary key must rotate")
+}
+
+func TestRegenerateCacheKeyInvalidType(t *testing.T) {
+	m, _ := newTestMock()
+	createTestCache(t, m, "c1")
+
+	_, _, err := m.RegenerateCacheKey(context.Background(), "c1", "Tertiary")
+	assert.Error(t, err)
+}
+
+func TestRegenerateCacheKeyNotFound(t *testing.T) {
+	m, _ := newTestMock()
+
+	_, _, err := m.RegenerateCacheKey(context.Background(), "missing", "Primary")
+	assert.Error(t, err)
+}

--- a/providers/azure/cache/cache.go
+++ b/providers/azure/cache/cache.go
@@ -3,6 +3,8 @@ package cache
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"maps"
 	"path"
@@ -20,8 +22,16 @@ import (
 
 const defaultRedisSSLPort = 6380
 
-// Compile-time check that Mock implements driver.Cache.
-var _ driver.Cache = (*Mock)(nil)
+// accessKeyBytes is the byte length of a generated Redis access key before
+// base64 encoding; 32 bytes encodes to the 44-character key real Azure returns.
+const accessKeyBytes = 32
+
+// Compile-time checks that Mock implements driver.Cache and the optional
+// Azure access-key capability.
+var (
+	_ driver.Cache      = (*Mock)(nil)
+	_ driver.AccessKeys = (*Mock)(nil)
+)
 
 type cacheItem struct {
 	Value     []byte
@@ -106,6 +116,7 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 	info := driver.CacheInfo{
 		Name:               cfg.Name,
 		Scope:              cfg.Scope,
+		Location:           cfg.Location,
 		NodeType:           nodeType,
 		Engine:             engine,
 		Status:             "Running",
@@ -116,6 +127,8 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 		SKUCapacity:        cfg.SKUCapacity,
 		ShardCount:         cfg.ShardCount,
 		ReplicasPerPrimary: cfg.ReplicasPerPrimary,
+		PrimaryKey:         generateAccessKey(),
+		SecondaryKey:       generateAccessKey(),
 	}
 
 	// Opt-in: back the cache with a real Redis, replacing the synthetic endpoint
@@ -228,6 +241,56 @@ func (m *Mock) UpdateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 	result := updated.info
 
 	return &result, nil
+}
+
+// ListCacheKeys returns the cache's current primary and secondary access keys.
+func (m *Mock) ListCacheKeys(_ context.Context, name string) (primary, secondary string, err error) {
+	cd, ok := m.caches.Get(name)
+	if !ok {
+		return "", "", errors.Newf(errors.NotFound, "cache %q not found", name)
+	}
+
+	return cd.info.PrimaryKey, cd.info.SecondaryKey, nil
+}
+
+// RegenerateCacheKey rotates the requested key ("Primary" or "Secondary") and
+// returns both current keys.
+func (m *Mock) RegenerateCacheKey(_ context.Context, name, keyType string) (primary, secondary string, err error) {
+	cd, ok := m.caches.Get(name)
+	if !ok {
+		return "", "", errors.Newf(errors.NotFound, "cache %q not found", name)
+	}
+
+	// Mutate a copy and swap it in, never the shared stored pointer: GetCache
+	// snapshots cd.info without a lock, so an in-place write would be a torn
+	// read under concurrency.
+	updated := *cd
+
+	switch keyType {
+	case "Secondary":
+		updated.info.SecondaryKey = generateAccessKey()
+	case "Primary":
+		updated.info.PrimaryKey = generateAccessKey()
+	default:
+		return "", "", errors.Newf(errors.InvalidArgument, "keyType %q must be Primary or Secondary", keyType)
+	}
+
+	m.caches.Set(name, &updated)
+
+	return updated.info.PrimaryKey, updated.info.SecondaryKey, nil
+}
+
+// generateAccessKey returns a fresh 44-character base64 Redis access key,
+// matching the shape of a real Azure Cache for Redis key.
+func generateAccessKey() string {
+	b := make([]byte, accessKeyBytes)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand.Read never returns an error on supported platforms; fall
+		// back to a deterministic value rather than panicking.
+		return base64.StdEncoding.EncodeToString(make([]byte, accessKeyBytes))
+	}
+
+	return base64.StdEncoding.EncodeToString(b)
 }
 
 // Set stores a value in the cache with an optional TTL.

--- a/providers/azure/databricks/arm_accessconnectors.go
+++ b/providers/azure/databricks/arm_accessconnectors.go
@@ -23,6 +23,8 @@ const emulatorTenantID = "11111111-1111-1111-1111-111111111111"
 
 // CreateOrUpdateAccessConnector creates or updates an access connector,
 // completing provisioning synchronously (store-and-echo).
+//
+//nolint:gocritic // cfg matches the driver interface signature; copied once on entry.
 func (m *Mock) CreateOrUpdateAccessConnector(
 	_ context.Context, cfg driver.AccessConnectorConfig,
 ) (*driver.AccessConnector, error) {
@@ -49,9 +51,11 @@ func (m *Mock) CreateOrUpdateAccessConnector(
 		return cloneAccessConnector(&updated), nil
 	}
 
+	sub := m.subOrDefault(cfg.Subscription)
 	ac := &driver.AccessConnector{
-		ID:                idgen.AzureID(m.opts.AccountID, cfg.ResourceGroup, providerNamespace, accessConnectorsType, cfg.Name),
+		ID:                idgen.AzureID(sub, cfg.ResourceGroup, providerNamespace, accessConnectorsType, cfg.Name),
 		Name:              cfg.Name,
+		Subscription:      sub,
 		ResourceGroup:     cfg.ResourceGroup,
 		Location:          cfg.Location,
 		Tags:              copyMap(cfg.Tags),

--- a/providers/azure/databricks/arm_network.go
+++ b/providers/azure/databricks/arm_network.go
@@ -33,9 +33,16 @@ func subKey(resourceGroup, workspace, childType, name string) string {
 	return key(resourceGroup, workspace) + "/" + childType + "/" + name
 }
 
-// subID builds the ARM ID for a workspace sub-resource.
+// subID builds the ARM ID for a workspace sub-resource. The subscription is
+// taken from the parent workspace so a child's id shares its parent's
+// subscription rather than defaulting to the emulator account.
 func (m *Mock) subID(resourceGroup, workspace, childType, name string) string {
-	return idgen.AzureID(m.opts.AccountID, resourceGroup, providerNamespace, resourceType, workspace) +
+	sub := m.opts.AccountID
+	if ws, ok := m.workspaces.Get(key(resourceGroup, workspace)); ok && ws.Subscription != "" {
+		sub = ws.Subscription
+	}
+
+	return idgen.AzureID(sub, resourceGroup, providerNamespace, resourceType, workspace) +
 		"/" + childType + "/" + name
 }
 

--- a/providers/azure/databricks/databricks.go
+++ b/providers/azure/databricks/databricks.go
@@ -81,6 +81,18 @@ func key(resourceGroup, name string) string {
 	return resourceGroup + "/" + name
 }
 
+// subOrDefault returns the request subscription, falling back to the emulator's
+// default account when a caller (e.g. the typed Go API) supplies none. ARM
+// resource IDs must reflect the subscription the request targeted, not the
+// default account.
+func (m *Mock) subOrDefault(subscription string) string {
+	if subscription != "" {
+		return subscription
+	}
+
+	return m.opts.AccountID
+}
+
 // CreateWorkspace creates a workspace, completing provisioning synchronously.
 //
 //nolint:gocritic // cfg matches the driver interface signature; copied once on entry.
@@ -113,9 +125,11 @@ func (m *Mock) CreateWorkspace(_ context.Context, cfg driver.WorkspaceConfig) (*
 	}
 
 	wsID := workspaceID(k)
+	sub := m.subOrDefault(cfg.Subscription)
 	ws := &driver.Workspace{
-		ID:                     idgen.AzureID(m.opts.AccountID, cfg.ResourceGroup, providerNamespace, resourceType, cfg.Name),
+		ID:                     idgen.AzureID(sub, cfg.ResourceGroup, providerNamespace, resourceType, cfg.Name),
 		Name:                   cfg.Name,
+		Subscription:           sub,
 		ResourceGroup:          cfg.ResourceGroup,
 		Location:               cfg.Location,
 		SKUName:                skuOrDefault(cfg.SKUName),

--- a/providers/azure/databricks/subscription_test.go
+++ b/providers/azure/databricks/subscription_test.go
@@ -1,0 +1,88 @@
+package databricks
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/databricks/driver"
+)
+
+// TestCreateWorkspaceUsesRequestSubscription verifies the workspace id is built
+// from the request subscription rather than the emulator's default account.
+func TestCreateWorkspaceUsesRequestSubscription(t *testing.T) {
+	m := newTestMock() // default account is "sub-1"
+
+	cfg := validConfig()
+	cfg.Subscription = "req-sub"
+
+	ws, err := m.CreateWorkspace(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+
+	if ws.Subscription != "req-sub" {
+		t.Errorf("subscription = %q, want req-sub", ws.Subscription)
+	}
+
+	if !strings.HasPrefix(ws.ID, "/subscriptions/req-sub/") {
+		t.Errorf("id = %q, want prefix /subscriptions/req-sub/", ws.ID)
+	}
+}
+
+// TestCreateWorkspaceFallsBackToAccount verifies that when no subscription is
+// supplied (typed Go API callers), the id falls back to the default account.
+func TestCreateWorkspaceFallsBackToAccount(t *testing.T) {
+	m := newTestMock() // default account is "sub-1"
+
+	ws, err := m.CreateWorkspace(context.Background(), validConfig())
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+
+	if !strings.HasPrefix(ws.ID, "/subscriptions/sub-1/") {
+		t.Errorf("id = %q, want prefix /subscriptions/sub-1/", ws.ID)
+	}
+}
+
+// TestAccessConnectorUsesRequestSubscription verifies the access-connector id is
+// built from the request subscription.
+func TestAccessConnectorUsesRequestSubscription(t *testing.T) {
+	m := newTestMock()
+
+	ac, err := m.CreateOrUpdateAccessConnector(context.Background(), driver.AccessConnectorConfig{
+		Name:          "conn-1",
+		Subscription:  "req-sub",
+		ResourceGroup: "rg-1",
+		Location:      "eastus",
+	})
+	if err != nil {
+		t.Fatalf("CreateOrUpdateAccessConnector: %v", err)
+	}
+
+	if !strings.HasPrefix(ac.ID, "/subscriptions/req-sub/") {
+		t.Errorf("id = %q, want prefix /subscriptions/req-sub/", ac.ID)
+	}
+}
+
+// TestWorkspaceChildInheritsSubscription verifies a workspace sub-resource id
+// inherits the parent workspace's subscription.
+func TestWorkspaceChildInheritsSubscription(t *testing.T) {
+	m := newTestMock()
+
+	cfg := validConfig()
+	cfg.Subscription = "req-sub"
+
+	if _, err := m.CreateWorkspace(context.Background(), cfg); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+
+	pec, err := m.PutPrivateEndpointConnection(context.Background(), "rg-1", "ws-1", "pec-1", "Approved", "ok")
+	if err != nil {
+		t.Fatalf("PutPrivateEndpointConnection: %v", err)
+	}
+
+	if !strings.HasPrefix(pec.ID, "/subscriptions/req-sub/") {
+		t.Errorf("child id = %q, want prefix /subscriptions/req-sub/", pec.ID)
+	}
+}

--- a/server/azure/cache/access_keys_sdk_test.go
+++ b/server/azure/cache/access_keys_sdk_test.go
@@ -1,0 +1,173 @@
+package cache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
+)
+
+// createCache is a small helper that provisions a Standard cache for the
+// access-key tests.
+func createCache(t *testing.T, client *armredis.Client, name string) {
+	t.Helper()
+
+	poller, err := client.BeginCreate(context.Background(), testRG, name, armredis.CreateParameters{
+		Location: to.Ptr("eastus"),
+		Properties: &armredis.CreateProperties{
+			SKU: &armredis.SKU{
+				Name:     to.Ptr(armredis.SKUNameStandard),
+				Family:   to.Ptr(armredis.SKUFamilyC),
+				Capacity: to.Ptr(int32(1)),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(context.Background(), nil); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+}
+
+// TestSDKAzureCacheListKeys verifies ListKeys returns both access keys — the
+// primary way a client fetches the credential needed to connect to the cache.
+func TestSDKAzureCacheListKeys(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	createCache(t, client, "keys-cache")
+
+	got, err := client.ListKeys(ctx, testRG, "keys-cache", nil)
+	if err != nil {
+		t.Fatalf("ListKeys: %v", err)
+	}
+
+	if got.PrimaryKey == nil || *got.PrimaryKey == "" {
+		t.Errorf("primaryKey = %v, want non-empty", got.PrimaryKey)
+	}
+
+	if got.SecondaryKey == nil || *got.SecondaryKey == "" {
+		t.Errorf("secondaryKey = %v, want non-empty", got.SecondaryKey)
+	}
+
+	if got.PrimaryKey != nil && got.SecondaryKey != nil && *got.PrimaryKey == *got.SecondaryKey {
+		t.Error("primary and secondary keys must differ")
+	}
+}
+
+// TestSDKAzureCacheListKeysNotFound confirms ListKeys on a missing cache is a
+// 404, not a 200 with empty keys.
+func TestSDKAzureCacheListKeysNotFound(t *testing.T) {
+	client := newRedisClient(t)
+
+	_, err := client.ListKeys(context.Background(), testRG, "missing", nil)
+	if err == nil {
+		t.Fatal("ListKeys(missing): got nil error, want 404")
+	}
+}
+
+// TestSDKAzureCacheRegenerateKey verifies RegenerateKey rotates only the
+// requested key: regenerating Primary changes the primary key while the
+// secondary is untouched, and both current keys come back in the response.
+func TestSDKAzureCacheRegenerateKey(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	createCache(t, client, "regen-cache")
+
+	before, err := client.ListKeys(ctx, testRG, "regen-cache", nil)
+	if err != nil {
+		t.Fatalf("ListKeys: %v", err)
+	}
+
+	after, err := client.RegenerateKey(ctx, testRG, "regen-cache", armredis.RegenerateKeyParameters{
+		KeyType: to.Ptr(armredis.RedisKeyTypePrimary),
+	}, nil)
+	if err != nil {
+		t.Fatalf("RegenerateKey: %v", err)
+	}
+
+	if after.PrimaryKey == nil || *after.PrimaryKey == *before.PrimaryKey {
+		t.Errorf("primary key was not rotated: before=%v after=%v", before.PrimaryKey, after.PrimaryKey)
+	}
+
+	if after.SecondaryKey == nil || *after.SecondaryKey != *before.SecondaryKey {
+		t.Errorf("secondary key changed unexpectedly: before=%v after=%v", before.SecondaryKey, after.SecondaryKey)
+	}
+
+	// A subsequent ListKeys must reflect the rotated primary.
+	relisted, err := client.ListKeys(ctx, testRG, "regen-cache", nil)
+	if err != nil {
+		t.Fatalf("ListKeys after regenerate: %v", err)
+	}
+
+	if relisted.PrimaryKey == nil || *relisted.PrimaryKey != *after.PrimaryKey {
+		t.Errorf("listKeys primary = %v, want %v", relisted.PrimaryKey, after.PrimaryKey)
+	}
+}
+
+// TestSDKAzureCacheRegenerateSecondary confirms rotating Secondary leaves the
+// primary key unchanged.
+func TestSDKAzureCacheRegenerateSecondary(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	createCache(t, client, "regen-sec")
+
+	before, err := client.ListKeys(ctx, testRG, "regen-sec", nil)
+	if err != nil {
+		t.Fatalf("ListKeys: %v", err)
+	}
+
+	after, err := client.RegenerateKey(ctx, testRG, "regen-sec", armredis.RegenerateKeyParameters{
+		KeyType: to.Ptr(armredis.RedisKeyTypeSecondary),
+	}, nil)
+	if err != nil {
+		t.Fatalf("RegenerateKey: %v", err)
+	}
+
+	if after.PrimaryKey == nil || *after.PrimaryKey != *before.PrimaryKey {
+		t.Errorf("primary key changed unexpectedly: before=%v after=%v", before.PrimaryKey, after.PrimaryKey)
+	}
+
+	if after.SecondaryKey == nil || *after.SecondaryKey == *before.SecondaryKey {
+		t.Errorf("secondary key was not rotated: before=%v after=%v", before.SecondaryKey, after.SecondaryKey)
+	}
+}
+
+// TestSDKAzureCacheCreateReturnsKeys verifies the Create response carries
+// properties.accessKeys (real Azure populates them only on create/update).
+func TestSDKAzureCacheCreateReturnsKeys(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreate(ctx, testRG, "create-keys", armredis.CreateParameters{
+		Location: to.Ptr("eastus"),
+		Properties: &armredis.CreateProperties{
+			SKU: &armredis.SKU{
+				Name:     to.Ptr(armredis.SKUNameStandard),
+				Family:   to.Ptr(armredis.SKUFamilyC),
+				Capacity: to.Ptr(int32(1)),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	if created.Properties == nil || created.Properties.AccessKeys == nil {
+		t.Fatalf("expected accessKeys on create response, got %+v", created.Properties)
+	}
+
+	if created.Properties.AccessKeys.PrimaryKey == nil || *created.Properties.AccessKeys.PrimaryKey == "" {
+		t.Errorf("create accessKeys.primaryKey = %v, want non-empty", created.Properties.AccessKeys.PrimaryKey)
+	}
+}

--- a/server/azure/cache/handler.go
+++ b/server/azure/cache/handler.go
@@ -78,6 +78,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Sub-resource actions on a named cache (listKeys, regenerateKey) are POSTs.
+	if rp.SubResource != "" {
+		h.serveAction(w, r, &rp)
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPut, http.MethodPatch:
 		// PUT is Redis.BeginCreate; PATCH is Redis.Update (partial update of a
@@ -90,6 +96,24 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.deleteCache(w, r, &rp)
 	default:
 		writeMethodNotAllowed(w)
+	}
+}
+
+// serveAction routes the POST sub-resource actions on a named cache. Real Azure
+// exposes listKeys and regenerateKey as POST-only action endpoints.
+func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	switch rp.SubResource {
+	case "listKeys":
+		h.listKeys(w, r, rp)
+	case "regenerateKey":
+		h.regenerateKey(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusNotFound, "InvalidResourceType", "unknown action "+rp.SubResource)
 	}
 }
 

--- a/server/azure/cache/operations.go
+++ b/server/azure/cache/operations.go
@@ -27,6 +27,7 @@ func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp
 	cfg := cachedriver.CacheConfig{
 		Name:     rp.ResourceName,
 		Engine:   "redis",
+		Location: body.Location,
 		NodeType: nodeTypeFromBody(&body),
 		Tags:     body.Tags,
 		Scope:    scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
@@ -39,7 +40,11 @@ func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp
 			azurearm.WriteCErr(w, uerr)
 			return
 		}
-		azurearm.WriteJSON(w, http.StatusOK, toRedisJSON(rp, info))
+
+		resp := toRedisJSON(rp, info)
+		attachAccessKeys(&resp, info)
+		azurearm.WriteJSON(w, http.StatusOK, resp)
+
 		return
 	}
 
@@ -49,7 +54,23 @@ func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusCreated, toRedisJSON(rp, info))
+	resp := toRedisJSON(rp, info)
+	attachAccessKeys(&resp, info)
+	azurearm.WriteJSON(w, http.StatusCreated, resp)
+}
+
+// attachAccessKeys adds the cache's access keys to a Create/Update response.
+// Real Azure returns properties.accessKeys only on create/update (never on
+// Get/List), so Get and List keep using the bare toRedisJSON.
+func attachAccessKeys(out *redisJSON, info *cachedriver.CacheInfo) {
+	if info.PrimaryKey == "" && info.SecondaryKey == "" {
+		return
+	}
+
+	out.Properties.AccessKeys = &accessKeysJSON{
+		PrimaryKey:   info.PrimaryKey,
+		SecondaryKey: info.SecondaryKey,
+	}
 }
 
 // skuNamePremium is the Redis SKU tier that supports clustering (shardCount /
@@ -123,7 +144,10 @@ func nodeTypeFromBody(body *redisJSON) string {
 	return sku.Name + "_" + family + strconv.Itoa(sku.Capacity)
 }
 
-// getCache handles GET on a single resource — Redis.Get.
+// getCache handles GET on a single resource — Redis.Get. The driver keys caches
+// by name alone, so the handler enforces the request's resource-group scope: a
+// cache created in one group must not resolve under a different group in the URL
+// (real ARM answers 404, since the id would contradict the request path).
 func (h *Handler) getCache(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	info, err := h.cache.GetCache(r.Context(), rp.ResourceName)
 	if err != nil {
@@ -131,7 +155,87 @@ func (h *Handler) getCache(w http.ResponseWriter, r *http.Request, rp *azurearm.
 		return
 	}
 
+	if !info.Scope.Matches(scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}) {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound",
+			"cache "+rp.ResourceName+" not found in resource group "+rp.ResourceGroup)
+		return
+	}
+
 	azurearm.WriteJSON(w, http.StatusOK, toRedisJSON(rp, info))
+}
+
+// listKeys handles POST .../redis/{name}/listKeys — Redis.ListKeys. Returns the
+// cache's primary and secondary access keys.
+func (h *Handler) listKeys(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	keys, ok := h.cache.(cachedriver.AccessKeys)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidAction", "access keys are not supported by this backend")
+		return
+	}
+
+	if !h.cacheInScope(w, r, rp) {
+		return
+	}
+
+	primary, secondary, err := keys.ListCacheKeys(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, accessKeysJSON{PrimaryKey: primary, SecondaryKey: secondary})
+}
+
+// regenerateKey handles POST .../redis/{name}/regenerateKey — Redis.RegenerateKey.
+// The body selects which key to rotate ("Primary" or "Secondary"); the response
+// carries both current keys.
+func (h *Handler) regenerateKey(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	keys, ok := h.cache.(cachedriver.AccessKeys)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidAction", "access keys are not supported by this backend")
+		return
+	}
+
+	var body regenerateKeyRequest
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	if body.KeyType != "Primary" && body.KeyType != "Secondary" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameterValue", "keyType must be Primary or Secondary")
+		return
+	}
+
+	if !h.cacheInScope(w, r, rp) {
+		return
+	}
+
+	primary, secondary, err := keys.RegenerateCacheKey(r.Context(), rp.ResourceName, body.KeyType)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, accessKeysJSON{PrimaryKey: primary, SecondaryKey: secondary})
+}
+
+// cacheInScope resolves the cache and verifies it lives in the request's
+// resource group, writing a 404 (and returning false) when it does not. Used by
+// the key sub-actions, which address a cache by name under a scoped path.
+func (h *Handler) cacheInScope(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) bool {
+	info, err := h.cache.GetCache(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return false
+	}
+
+	if !info.Scope.Matches(scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}) {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound",
+			"cache "+rp.ResourceName+" not found in resource group "+rp.ResourceGroup)
+		return false
+	}
+
+	return true
 }
 
 // deleteCache handles DELETE — Redis.BeginDelete. Returning 200 with an empty

--- a/server/azure/cache/properties_sdk_test.go
+++ b/server/azure/cache/properties_sdk_test.go
@@ -1,0 +1,93 @@
+package cache_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
+)
+
+// TestSDKAzureCacheLocationRoundTrip verifies the region supplied at create time
+// is returned on Get, rather than a hardcoded default.
+func TestSDKAzureCacheLocationRoundTrip(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreate(ctx, testRG, "loc-cache", armredis.CreateParameters{
+		Location: to.Ptr("westus2"),
+		Properties: &armredis.CreateProperties{
+			SKU: &armredis.SKU{
+				Name:     to.Ptr(armredis.SKUNameStandard),
+				Family:   to.Ptr(armredis.SKUFamilyC),
+				Capacity: to.Ptr(int32(1)),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	if created.Location == nil || *created.Location != "westus2" {
+		t.Errorf("create location = %v, want westus2", created.Location)
+	}
+
+	got, err := client.Get(ctx, testRG, "loc-cache", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Location == nil || *got.Location != "westus2" {
+		t.Errorf("get location = %v, want westus2", got.Location)
+	}
+}
+
+// TestSDKAzureCachePorts verifies both the non-SSL port (6379) and the SSL port
+// (6380) are populated on the Get response.
+func TestSDKAzureCachePorts(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	createCache(t, client, "ports-cache")
+
+	got, err := client.Get(ctx, testRG, "ports-cache", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Properties == nil {
+		t.Fatal("expected properties on response")
+	}
+
+	if got.Properties.Port == nil || *got.Properties.Port != 6379 {
+		t.Errorf("port = %v, want 6379", got.Properties.Port)
+	}
+
+	if got.Properties.SSLPort == nil || *got.Properties.SSLPort != 6380 {
+		t.Errorf("sslPort = %v, want 6380", got.Properties.SSLPort)
+	}
+}
+
+// TestSDKAzureCacheGetWrongResourceGroup confirms a cache created in one
+// resource group does not resolve under a different group in the request path —
+// real ARM answers 404 because the returned id would contradict the path.
+func TestSDKAzureCacheGetWrongResourceGroup(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	createCache(t, client, "scoped-cache")
+
+	_, err := client.Get(ctx, "rg-other", "scoped-cache", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("Get(wrong rg): got %v, want 404", err)
+	}
+}

--- a/server/azure/cache/types.go
+++ b/server/azure/cache/types.go
@@ -16,6 +16,7 @@ const (
 	// terminates the SDK's poller on the first response.
 	provisioningStateSucceeded = "Succeeded"
 	defaultRedisSSLPort        = 6380
+	defaultRedisPort           = 6379
 	defaultRedisVersion        = "6.0"
 )
 
@@ -44,6 +45,18 @@ type redisProperties struct {
 	// accepted on input (older SDKs still send it) but not emitted — the
 	// response carries the current replicasPerPrimary field.
 	ReplicasPerMaster int `json:"replicasPerMaster,omitempty"`
+
+	// AccessKeys carries the cache's access keys. Real Azure populates it only
+	// on the Create/Update response (never on Get/List), so it is set by the
+	// create-or-update handler and omitted elsewhere.
+	AccessKeys *accessKeysJSON `json:"accessKeys,omitempty"`
+}
+
+// accessKeysJSON mirrors the armredis RedisAccessKeys / AccessKeys shape
+// returned by listKeys, regenerateKey, and the create/update response.
+type accessKeysJSON struct {
+	PrimaryKey   string `json:"primaryKey,omitempty"`
+	SecondaryKey string `json:"secondaryKey,omitempty"`
 }
 
 // redisJSON mirrors the armredis ResourceInfo / CreateParameters resource.
@@ -58,6 +71,12 @@ type redisJSON struct {
 
 type redisListResult struct {
 	Value []redisJSON `json:"value"`
+}
+
+// regenerateKeyRequest is the RegenerateKey request body: keyType selects which
+// access key to rotate ("Primary" or "Secondary").
+type regenerateKeyRequest struct {
+	KeyType string `json:"keyType"`
 }
 
 // skuNameFromNodeType extracts the SKU tier (Basic/Standard/Premium) from the
@@ -111,17 +130,25 @@ func toRedisJSON(rp *azurearm.ResourcePath, info *cachedriver.CacheInfo) redisJS
 		rg = rp.ResourceGroup
 	}
 
+	// Return the region the cache was created in; fall back to the default only
+	// for records that carry no location (e.g. portable-API creations).
+	location := info.Location
+	if location == "" {
+		location = defaultLocation
+	}
+
 	return redisJSON{
 		ID:       azurearm.BuildResourceID(sub, rg, providerName, typeRedis, info.Name),
 		Name:     info.Name,
 		Type:     redisResourceType,
-		Location: defaultLocation,
+		Location: location,
 		Tags:     info.Tags,
 		Properties: &redisProperties{
 			ProvisioningState:  provisioningStateSucceeded,
 			RedisVersion:       defaultRedisVersion,
 			SKU:                skuFromInfo(info),
 			HostName:           host,
+			Port:               defaultRedisPort,
 			SSLPort:            sslPort,
 			ShardCount:         info.ShardCount,
 			ReplicasPerPrimary: info.ReplicasPerPrimary,

--- a/server/azure/databricks/arm_accessconnectors_ops.go
+++ b/server/azure/databricks/arm_accessconnectors_ops.go
@@ -44,6 +44,7 @@ func (h *Handler) createOrUpdateAccessConnector(w http.ResponseWriter, r *http.R
 
 	cfg := dbxdriver.AccessConnectorConfig{
 		Name:          rp.ResourceName,
+		Subscription:  rp.Subscription,
 		ResourceGroup: rp.ResourceGroup,
 		Location:      body.Location,
 		Tags:          body.Tags,

--- a/server/azure/databricks/operations.go
+++ b/server/azure/databricks/operations.go
@@ -15,6 +15,7 @@ func (h *Handler) createOrUpdateWorkspace(w http.ResponseWriter, r *http.Request
 
 	cfg := dbxdriver.WorkspaceConfig{
 		Name:          rp.ResourceName,
+		Subscription:  rp.Subscription,
 		ResourceGroup: rp.ResourceGroup,
 		Location:      body.Location,
 		Tags:          body.Tags,

--- a/server/azure/databricks/workspace_subscription_sdk_test.go
+++ b/server/azure/databricks/workspace_subscription_sdk_test.go
@@ -1,0 +1,87 @@
+package databricks_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks"
+)
+
+// wantSubPrefix is the ARM id prefix a resource created under testSub must
+// carry. defaultAccountPrefix is the emulator's default-account id that leaked
+// into resource ids before the subscription was threaded through.
+const (
+	wantSubPrefix        = "/subscriptions/sub-1/"
+	defaultAccountPrefix = "/subscriptions/123456789012/"
+)
+
+// TestSDKWorkspaceIDReflectsSubscription verifies the workspace resource id is
+// built from the request's subscription, not the emulator's default account.
+// A client scoping role assignments or resource locks from ws.ID would
+// otherwise target a non-existent resource.
+func TestSDKWorkspaceIDReflectsSubscription(t *testing.T) {
+	client := newWorkspacesClient(t)
+	ctx := context.Background()
+
+	ws := createWorkspace(t, client)
+
+	if ws.ID == nil || !strings.HasPrefix(*ws.ID, wantSubPrefix) {
+		t.Fatalf("create id = %v, want prefix %q", ws.ID, wantSubPrefix)
+	}
+
+	if ws.ID != nil && strings.HasPrefix(*ws.ID, defaultAccountPrefix) {
+		t.Fatalf("create id = %v leaked the default account", *ws.ID)
+	}
+
+	got, err := client.Get(ctx, testRG, testWS, nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.ID == nil || !strings.HasPrefix(*got.ID, wantSubPrefix) {
+		t.Fatalf("get id = %v, want prefix %q", got.ID, wantSubPrefix)
+	}
+}
+
+// TestSDKAccessConnectorIDReflectsSubscription verifies the access-connector id
+// is built from the request subscription as well.
+func TestSDKAccessConnectorIDReflectsSubscription(t *testing.T) {
+	client := newAccessConnectorsClient(t)
+
+	created := createAccessConnector(t, client, "conn-sub", armdatabricks.AccessConnector{
+		Location: to.Ptr("eastus"),
+	})
+
+	if created.ID == nil || !strings.HasPrefix(*created.ID, wantSubPrefix) {
+		t.Fatalf("access connector id = %v, want prefix %q", created.ID, wantSubPrefix)
+	}
+
+	if created.ID != nil && strings.HasPrefix(*created.ID, defaultAccountPrefix) {
+		t.Fatalf("access connector id = %v leaked the default account", *created.ID)
+	}
+}
+
+// TestSDKWorkspaceChildIDReflectsSubscription verifies a workspace sub-resource
+// (a private-endpoint connection here) inherits its parent's subscription in its
+// id, rather than defaulting to the emulator account.
+func TestSDKWorkspaceChildIDReflectsSubscription(t *testing.T) {
+	opts, sub := newARMOptions(t)
+	seedWorkspace(t, opts, testRG, testWS)
+
+	pecClient, err := armdatabricks.NewPrivateEndpointConnectionsClient(sub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("new PEC client: %v", err)
+	}
+
+	pec := createPEC(t, pecClient, "pec-1", armdatabricks.PrivateLinkServiceConnectionStatusApproved, "ok")
+
+	if pec.ID == nil || !strings.HasPrefix(*pec.ID, wantSubPrefix) {
+		t.Fatalf("PEC id = %v, want prefix %q", pec.ID, wantSubPrefix)
+	}
+
+	if pec.ID != nil && strings.HasPrefix(*pec.ID, defaultAccountPrefix) {
+		t.Fatalf("PEC id = %v leaked the default account", *pec.ID)
+	}
+}

--- a/services/cache/driver/driver.go
+++ b/services/cache/driver/driver.go
@@ -27,6 +27,18 @@ type CacheInfo struct {
 	Tags      map[string]string
 	Scope     scope.Scope
 
+	// Location is the geo-region the cache was created in (Azure Redis
+	// `location`, e.g. "westus2"). Empty for providers with no per-resource
+	// region concept.
+	Location string
+
+	// PrimaryKey / SecondaryKey are the Azure Redis access keys clients use to
+	// authenticate to the cache. Generated at create time by the Azure backend
+	// and rotated by RegenerateCacheKey; empty for providers that do not model
+	// access keys.
+	PrimaryKey   string
+	SecondaryKey string
+
 	// ARN and EngineVersion are populated by the AWS ElastiCache backend (other
 	// clouds leave them empty). The ARN is the tag-operation handle, so tag
 	// read/write flows depend on it being set on Describe.
@@ -59,6 +71,10 @@ type CacheConfig struct {
 	Engine        string // "redis", "memcached"
 	EngineVersion string
 	Tags          map[string]string
+
+	// Location is the geo-region the cache is created in (Azure Redis
+	// `location`). Optional and left empty by non-Azure callers.
+	Location string
 
 	// Scope records where the resource lives (Azure subscription/resource
 	// group, GCP project). Zero for AWS and unscoped portable callers.
@@ -227,4 +243,18 @@ type SnapshotFilter struct {
 type Snapshots interface {
 	CreateSnapshot(ctx context.Context, cfg SnapshotConfig) (*Snapshot, error)
 	DescribeSnapshots(ctx context.Context, filter SnapshotFilter) ([]Snapshot, error)
+}
+
+// AccessKeys is an OPTIONAL capability, discovered by type assertion. Azure
+// Cache for Redis exposes the cache's two access keys via listKeys and rotates
+// them via regenerateKey; no other cloud in this emulator models cache access
+// keys, so their drivers do not implement this interface.
+type AccessKeys interface {
+	// ListCacheKeys returns the cache's current primary and secondary access
+	// keys.
+	ListCacheKeys(ctx context.Context, name string) (primary, secondary string, err error)
+
+	// RegenerateCacheKey rotates the requested key ("Primary" or "Secondary")
+	// and returns both current keys.
+	RegenerateCacheKey(ctx context.Context, name, keyType string) (primary, secondary string, err error)
 }

--- a/services/databricks/arm_resources.go
+++ b/services/databricks/arm_resources.go
@@ -12,6 +12,8 @@ import (
 // --- Access connectors ---
 
 // CreateOrUpdateAccessConnector creates or updates an access connector.
+//
+//nolint:gocritic // cfg matches the driver interface signature; passed through once.
 func (b *Databricks) CreateOrUpdateAccessConnector(
 	ctx context.Context, cfg driver.AccessConnectorConfig,
 ) (*driver.AccessConnector, error) {

--- a/services/databricks/driver/arm_resources.go
+++ b/services/databricks/driver/arm_resources.go
@@ -35,6 +35,7 @@ type ManagedIdentity struct {
 type AccessConnector struct {
 	ID                string
 	Name              string
+	Subscription      string
 	ResourceGroup     string
 	Location          string
 	Tags              map[string]string
@@ -46,6 +47,7 @@ type AccessConnector struct {
 // AccessConnectorConfig is the createOrUpdate input for an access connector.
 type AccessConnectorConfig struct {
 	Name          string
+	Subscription  string
 	ResourceGroup string
 	Location      string
 	Tags          map[string]string

--- a/services/databricks/driver/driver.go
+++ b/services/databricks/driver/driver.go
@@ -15,6 +15,7 @@ const (
 // WorkspaceConfig describes a workspace to create.
 type WorkspaceConfig struct {
 	Name                   string
+	Subscription           string
 	ResourceGroup          string
 	Location               string
 	SKUName                string
@@ -27,6 +28,7 @@ type WorkspaceConfig struct {
 type Workspace struct {
 	ID                     string
 	Name                   string
+	Subscription           string
 	ResourceGroup          string
 	Location               string
 	SKUName                string


### PR DESCRIPTION
Fixes real-user Azure e2e gaps in Azure Cache for Redis and Azure Databricks, matching the official Azure REST contracts.

## Cache for Redis
- **listKeys (was 405)**: added `POST .../Microsoft.Cache/redis/{name}/listKeys` returning `{primaryKey, secondaryKey}` (RedisAccessKeys). This is the primary way clients fetch the credential to connect, so the "create + get connection info" flow now completes. Access keys are generated at create time (44-char base64) and also surfaced in `properties.accessKeys` on the create/update response, exactly as real Azure does (never on Get/List).
- **regenerateKey (was 405)**: added `POST .../regenerateKey` with `{keyType: Primary|Secondary}`; rotates only the requested key and returns both current keys. Invalid keyType is rejected with 400.
- **location round-trip**: the created region (e.g. `westus2`) is now stored and returned on Get instead of a hardcoded `eastus`.
- **properties.port**: the non-SSL port `6379` is now emitted alongside `sslPort` `6380`.
- **Get resource-group scope**: a cache created in one resource group no longer resolves under a different group in the request path (real ARM answers 404, since the returned id would contradict the path).

## Databricks
- **workspace resource id subscription**: the workspace id is now built from the request's subscription instead of the emulator's default account, so a client scoping role assignments / locks from `ws.ID` targets a real resource. Access connectors and workspace child sub-resources (private endpoint connections, etc.) inherit the same fix — children derive the subscription from their parent workspace. Typed Go API callers with no subscription still fall back to the default account.

## Layering
- New `driver.AccessKeys` optional capability (type-asserted, Azure-only) on the shared cache driver; `Location`/`PrimaryKey`/`SecondaryKey` added to `CacheInfo`, `Location` to `CacheConfig`. `Subscription` threaded through the Databricks workspace/access-connector configs and records.
- `docs/coverage` regenerated for the driver-interface change.

## Tests
- Real azure-sdk-for-go SDK round-trip tests: listKeys, regenerateKey (primary/secondary isolation), create-returns-keys, location round-trip, port/sslPort, wrong-RG 404, and workspace/access-connector/child resource-id subscription.
- Provider-level unit tests for key generation/rotation, location storage, and subscription id derivation.

Gates: `go build ./...`, `go test ./providers/azure/... ./server/azure/... ./services/... .`, and golangci-lint on changed packages all pass.