### PR TITLE
fix(azure-compute-tail): VM networkProfile dependency validation, Generalize/Capture, disk GetAccess SAS, sshkey Update, provisioningState Creating

### DIFF
--- a/docs/coverage/aws/ec2.md
+++ b/docs/coverage/aws/ec2.md
@@ -49,6 +49,23 @@ AWS's `compute` service · portable interface `driver.Compute` · [AWS index](./
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureDiskAccessor
+
+AzureDiskAccessor is an optional Azure-only capability for the managed-disk
+
+| Operation | Description |
+| --- | --- |
+| `GrantDiskAccess` | GrantDiskAccess issues a time-bounded SAS URI granting the requested |
+| `RevokeDiskAccess` | RevokeDiskAccess revokes any SAS access previously granted to the disk. |
+
+### AzureSSHKeyUpdater
+
+AzureSSHKeyUpdater is an optional Azure-only capability for the sshPublicKeys
+
+| Operation | Description |
+| --- | --- |
+| `UpdateKeyPair` | UpdateKeyPair updates the public key and/or tags of an existing key pair. |
+
 ### AzureVMController
 
 AzureVMController is an optional Azure-only capability supporting the ARM
@@ -56,6 +73,7 @@ AzureVMController is an optional Azure-only capability supporting the ARM
 | Operation | Description |
 | --- | --- |
 | `Deallocate` | Deallocate stops the guest and releases the allocated compute |
+| `GeneralizeInstance` | GeneralizeInstance marks an instance as generalized (Azure Generalize |
 | `PowerOff` | PowerOff stops the guest OS while keeping the VM allocated |
 | `UpdateInstance` | UpdateInstance overwrites the mutable configuration of an existing |
 

--- a/docs/coverage/azure/virtualmachines.md
+++ b/docs/coverage/azure/virtualmachines.md
@@ -49,6 +49,23 @@ Azure's `compute` service · portable interface `driver.Compute` · [Azure index
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureDiskAccessor
+
+AzureDiskAccessor is an optional Azure-only capability for the managed-disk
+
+| Operation | Description |
+| --- | --- |
+| `GrantDiskAccess` | GrantDiskAccess issues a time-bounded SAS URI granting the requested |
+| `RevokeDiskAccess` | RevokeDiskAccess revokes any SAS access previously granted to the disk. |
+
+### AzureSSHKeyUpdater
+
+AzureSSHKeyUpdater is an optional Azure-only capability for the sshPublicKeys
+
+| Operation | Description |
+| --- | --- |
+| `UpdateKeyPair` | UpdateKeyPair updates the public key and/or tags of an existing key pair. |
+
 ### AzureVMController
 
 AzureVMController is an optional Azure-only capability supporting the ARM
@@ -56,6 +73,7 @@ AzureVMController is an optional Azure-only capability supporting the ARM
 | Operation | Description |
 | --- | --- |
 | `Deallocate` | Deallocate stops the guest and releases the allocated compute |
+| `GeneralizeInstance` | GeneralizeInstance marks an instance as generalized (Azure Generalize |
 | `PowerOff` | PowerOff stops the guest OS while keeping the VM allocated |
 | `UpdateInstance` | UpdateInstance overwrites the mutable configuration of an existing |
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -1958,12 +1958,40 @@
     ],
     "optionalCapabilities": [
       {
+        "name": "AzureDiskAccessor",
+        "doc": "AzureDiskAccessor is an optional Azure-only capability for the managed-disk",
+        "operations": [
+          {
+            "name": "GrantDiskAccess",
+            "doc": "GrantDiskAccess issues a time-bounded SAS URI granting the requested"
+          },
+          {
+            "name": "RevokeDiskAccess",
+            "doc": "RevokeDiskAccess revokes any SAS access previously granted to the disk."
+          }
+        ]
+      },
+      {
+        "name": "AzureSSHKeyUpdater",
+        "doc": "AzureSSHKeyUpdater is an optional Azure-only capability for the sshPublicKeys",
+        "operations": [
+          {
+            "name": "UpdateKeyPair",
+            "doc": "UpdateKeyPair updates the public key and/or tags of an existing key pair."
+          }
+        ]
+      },
+      {
         "name": "AzureVMController",
         "doc": "AzureVMController is an optional Azure-only capability supporting the ARM",
         "operations": [
           {
             "name": "Deallocate",
             "doc": "Deallocate stops the guest and releases the allocated compute"
+          },
+          {
+            "name": "GeneralizeInstance",
+            "doc": "GeneralizeInstance marks an instance as generalized (Azure Generalize"
           },
           {
             "name": "PowerOff",

--- a/docs/coverage/gcp/gce.md
+++ b/docs/coverage/gcp/gce.md
@@ -49,6 +49,23 @@ GCP's `compute` service · portable interface `driver.Compute` · [GCP index](./
 
 Discovered by type assertion; only some providers implement these.
 
+### AzureDiskAccessor
+
+AzureDiskAccessor is an optional Azure-only capability for the managed-disk
+
+| Operation | Description |
+| --- | --- |
+| `GrantDiskAccess` | GrantDiskAccess issues a time-bounded SAS URI granting the requested |
+| `RevokeDiskAccess` | RevokeDiskAccess revokes any SAS access previously granted to the disk. |
+
+### AzureSSHKeyUpdater
+
+AzureSSHKeyUpdater is an optional Azure-only capability for the sshPublicKeys
+
+| Operation | Description |
+| --- | --- |
+| `UpdateKeyPair` | UpdateKeyPair updates the public key and/or tags of an existing key pair. |
+
 ### AzureVMController
 
 AzureVMController is an optional Azure-only capability supporting the ARM
@@ -56,6 +73,7 @@ AzureVMController is an optional Azure-only capability supporting the ARM
 | Operation | Description |
 | --- | --- |
 | `Deallocate` | Deallocate stops the guest and releases the allocated compute |
+| `GeneralizeInstance` | GeneralizeInstance marks an instance as generalized (Azure Generalize |
 | `PowerOff` | PowerOff stops the guest OS while keeping the VM allocated |
 | `UpdateInstance` | UpdateInstance overwrites the mutable configuration of an existing |
 

--- a/providers/azure/virtualmachines/longtail_test.go
+++ b/providers/azure/virtualmachines/longtail_test.go
@@ -1,0 +1,86 @@
+package virtualmachines
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneralizeInstance(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{ImageID: "img", InstanceType: "Standard_D2s_v3"}, 1)
+	require.NoError(t, err)
+
+	id := insts[0].ID
+
+	require.NoError(t, m.GeneralizeInstance(ctx, id))
+
+	got, err := m.DescribeInstances(ctx, []string{id}, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.True(t, got[0].Generalized, "instance should be generalized")
+
+	// Idempotent.
+	require.NoError(t, m.GeneralizeInstance(ctx, id))
+
+	// Missing instance.
+	assert.Error(t, m.GeneralizeInstance(ctx, "vm-missing"))
+}
+
+func TestGrantAndRevokeDiskAccess(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 64})
+	require.NoError(t, err)
+
+	sas, err := m.GrantDiskAccess(ctx, vol.ID, "Read", 300)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(sas, "https://"), "SAS should be an https URI: %s", sas)
+	assert.Contains(t, sas, "sp=r")
+	assert.Contains(t, sas, "se=")
+	assert.Contains(t, sas, "st=")
+
+	// Write access grants read+write.
+	wsas, err := m.GrantDiskAccess(ctx, vol.ID, "Write", 60)
+	require.NoError(t, err)
+	assert.Contains(t, wsas, "sp=rw")
+
+	require.NoError(t, m.RevokeDiskAccess(ctx, vol.ID))
+
+	// Missing disk.
+	_, err = m.GrantDiskAccess(ctx, "disk-missing", "Read", 300)
+	assert.Error(t, err)
+	assert.Error(t, m.RevokeDiskAccess(ctx, "disk-missing"))
+}
+
+func TestUpdateKeyPair(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateKeyPair(ctx, driver.KeyPairConfig{Name: "k1", Tags: map[string]string{"env": "test"}})
+	require.NoError(t, err)
+
+	newKey := "ssh-rsa AAAAB updated"
+	updated, err := m.UpdateKeyPair(ctx, "k1", &newKey, map[string]string{"team": "infra"})
+	require.NoError(t, err)
+	assert.Equal(t, newKey, updated.PublicKey)
+	assert.Equal(t, "infra", updated.Tags["team"])
+	_, hadEnv := updated.Tags["env"]
+	assert.False(t, hadEnv, "replaced tags should not retain env")
+
+	// Nil publicKey leaves the key material unchanged.
+	again, err := m.UpdateKeyPair(ctx, "k1", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, newKey, again.PublicKey)
+
+	// Missing key.
+	_, err = m.UpdateKeyPair(ctx, "missing", &newKey, nil)
+	assert.Error(t, err)
+}

--- a/providers/azure/virtualmachines/longtail_test.go
+++ b/providers/azure/virtualmachines/longtail_test.go
@@ -19,6 +19,12 @@ func TestGeneralizeInstance(t *testing.T) {
 
 	id := insts[0].ID
 
+	// A running VM cannot be generalized — Azure requires it to be stopped or
+	// deallocated first.
+	require.Error(t, m.GeneralizeInstance(ctx, id), "generalize should reject a running VM")
+
+	// Deallocate, then generalize succeeds.
+	require.NoError(t, m.Deallocate(ctx, id))
 	require.NoError(t, m.GeneralizeInstance(ctx, id))
 
 	got, err := m.DescribeInstances(ctx, []string{id}, nil)

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -28,10 +30,12 @@ import (
 // Compile-time checks that Mock implements driver.Compute and, when a real
 // compute engine is wired, the optional driver.ConsoleReader capability.
 var (
-	_ driver.Compute           = (*Mock)(nil)
-	_ driver.ConsoleReader     = (*Mock)(nil)
-	_ driver.AzureVMController = (*Mock)(nil)
-	_ driver.KeyPairGenerator  = (*Mock)(nil)
+	_ driver.Compute            = (*Mock)(nil)
+	_ driver.ConsoleReader      = (*Mock)(nil)
+	_ driver.AzureVMController  = (*Mock)(nil)
+	_ driver.KeyPairGenerator   = (*Mock)(nil)
+	_ driver.AzureDiskAccessor  = (*Mock)(nil)
+	_ driver.AzureSSHKeyUpdater = (*Mock)(nil)
 )
 
 const (
@@ -126,6 +130,9 @@ type instanceData struct {
 	ResourceGroup  string
 	// PowerState is the Azure power state ("running"/"stopped"/"deallocated").
 	PowerState string
+	// Generalized is true once the VM has been generalized (Azure Generalize
+	// action), a precondition for capturing it into a reusable image.
+	Generalized bool
 	// engineBacked is true when a real config.ComputeEngine backs this
 	// instance, so Terminate deprovisions it and console output is read from
 	// the engine rather than synthesized.
@@ -148,6 +155,7 @@ type Mock struct {
 	images       *memstore.Store[*driver.ImageInfo]
 	keyPairs     *memstore.Store[*driver.KeyPairInfo]
 	scaleSets    *memstore.Store[*ScaleSet]
+	diskAccess   *memstore.Store[string]
 	sm           *statemachine.Machine
 	opts         *config.Options
 	ipCounter    atomic.Int64
@@ -229,6 +237,7 @@ func New(opts *config.Options) *Mock {
 		images:       memstore.New[*driver.ImageInfo](),
 		keyPairs:     memstore.New[*driver.KeyPairInfo](),
 		scaleSets:    memstore.New[*ScaleSet](),
+		diskAccess:   memstore.New[string](),
 		sm:           statemachine.New(compute.VMTransitions()),
 		opts:         opts,
 	}
@@ -256,7 +265,8 @@ func toInstance(d *instanceData) driver.Instance {
 		OSType: d.OSType, Priority: d.Priority, LicenseType: d.LicenseType,
 		Zones:  append([]string(nil), d.Zones...),
 		Region: d.Region, ResourceGroup: d.ResourceGroup,
-		PowerState: d.PowerState,
+		PowerState:  d.PowerState,
+		Generalized: d.Generalized,
 	}
 }
 
@@ -442,6 +452,20 @@ func (m *Mock) UpdateInstance(_ context.Context, instanceID string, cfg driver.I
 	}
 
 	inst.Tags = copyTags(cfg.Tags)
+
+	return nil
+}
+
+// GeneralizeInstance marks an instance as generalized (Azure Generalize
+// action), a precondition for capturing it into a reusable image. It is
+// idempotent: generalizing an already-generalized VM succeeds.
+func (m *Mock) GeneralizeInstance(_ context.Context, instanceID string) error {
+	inst, ok := m.instances.Get(instanceID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
+	}
+
+	inst.Generalized = true
 
 	return nil
 }
@@ -698,6 +722,58 @@ func (m *Mock) DetachVolume(_ context.Context, volumeID string) error {
 	return nil
 }
 
+// GrantDiskAccess issues a time-bounded SAS URI granting the requested access
+// level to a managed disk (Azure Disks beginGetAccess). The synthesized URI
+// mirrors the shape of a real managed-disk export SAS: an md-* blob host, a
+// signed-start (st) and signed-expiry (se) window derived from durationSeconds,
+// and a signed-permission (sp) reflecting the access level.
+func (m *Mock) GrantDiskAccess(_ context.Context, volumeID, access string, durationSeconds int) (string, error) {
+	vol, ok := m.volumes.Get(volumeID)
+	if !ok {
+		return "", cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)
+	}
+
+	now := m.opts.Clock.Now().UTC()
+
+	sum := sha256.Sum256([]byte(vol.ID))
+	host := "md-" + hex.EncodeToString(sum[:6])
+	token := hex.EncodeToString(sum[6:12])
+
+	sas := fmt.Sprintf(
+		"https://%s.blob.storage.azure.net/%s/abcd?sv=2018-03-28&sr=b&si=&sig=cloudemu&st=%s&se=%s&sp=%s",
+		host, token,
+		now.Format("2006-01-02T15:04:05Z"),
+		now.Add(time.Duration(durationSeconds)*time.Second).Format("2006-01-02T15:04:05Z"),
+		sasPermission(access),
+	)
+
+	m.diskAccess.Set(volumeID, sas)
+
+	return sas, nil
+}
+
+// RevokeDiskAccess revokes any SAS access previously granted to a managed disk
+// (Azure Disks endGetAccess).
+func (m *Mock) RevokeDiskAccess(_ context.Context, volumeID string) error {
+	if _, ok := m.volumes.Get(volumeID); !ok {
+		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)
+	}
+
+	m.diskAccess.Delete(volumeID)
+
+	return nil
+}
+
+// sasPermission maps an Azure disk AccessLevel to the SAS signed-permission
+// (sp) code: Write grants read+write ("rw"), everything else read-only ("r").
+func sasPermission(access string) string {
+	if access == "Write" {
+		return "rw"
+	}
+
+	return "r"
+}
+
 func (m *Mock) CreateSnapshot(_ context.Context, cfg driver.SnapshotConfig) (*driver.SnapshotInfo, error) {
 	vol, ok := m.volumes.Get(cfg.VolumeID)
 	if !ok {
@@ -844,6 +920,30 @@ func generateRSAKeyPair() (publicKey, privateKey string, err error) {
 	}
 
 	return string(ssh.MarshalAuthorizedKey(sshPub)), string(privPEM), nil
+}
+
+// UpdateKeyPair updates the public key and/or tags of an existing key pair
+// (Azure sshPublicKeys PATCH Update). A nil publicKey leaves the key material
+// unchanged; a non-nil tags map replaces the resource's tags.
+func (m *Mock) UpdateKeyPair(_ context.Context, name string, publicKey *string, tags map[string]string) (*driver.KeyPairInfo, error) {
+	kp, ok := m.keyPairs.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "sshPublicKey %q not found", name)
+	}
+
+	if publicKey != nil {
+		kp.PublicKey = *publicKey
+	}
+
+	if tags != nil {
+		kp.Tags = copyTags(tags)
+	}
+
+	m.keyPairs.Set(name, kp)
+
+	result := *kp
+
+	return &result, nil
 }
 
 // DeleteKeyPair deletes a key pair by name.

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -457,12 +457,19 @@ func (m *Mock) UpdateInstance(_ context.Context, instanceID string, cfg driver.I
 }
 
 // GeneralizeInstance marks an instance as generalized (Azure Generalize
-// action), a precondition for capturing it into a reusable image. It is
-// idempotent: generalizing an already-generalized VM succeeds.
+// action), a precondition for capturing it into a reusable image. Real Azure
+// requires the VM to be stopped or deallocated first: generalizing a running VM
+// is rejected. It is otherwise idempotent — generalizing an already-generalized
+// (and still stopped/deallocated) VM succeeds.
 func (m *Mock) GeneralizeInstance(_ context.Context, instanceID string) error {
 	inst, ok := m.instances.Get(instanceID)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
+	}
+
+	if inst.PowerState == powerStateRunning {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"instance %q must be stopped or deallocated before it can be generalized", instanceID)
 	}
 
 	inst.Generalized = true

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -379,7 +379,7 @@ func New(d Drivers) http.Handler {
 	}
 
 	if d.VirtualMachines != nil {
-		srv.Register(virtualmachines.New(d.VirtualMachines))
+		srv.Register(virtualmachines.New(d.VirtualMachines, d.Network))
 	}
 
 	// Kubernetes data-plane API. Matches /k8s/{uid}/... — disjoint from every

--- a/server/azure/disks/grant_access_test.go
+++ b/server/azure/disks/grant_access_test.go
@@ -1,0 +1,110 @@
+package disks_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKDiskGrantAndRevokeAccess drives DisksClient.BeginGrantAccess /
+// BeginRevokeAccess (the beginGetAccess / endGetAccess actions) through a real
+// armcompute client and asserts a time-bounded SAS URI is returned and can be
+// revoked.
+func TestSDKDiskGrantAndRevokeAccess(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		Disks:           cloudP.VirtualMachines,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newDisksClient(t, ts)
+	ctx := context.Background()
+
+	createPoller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "sas-disk",
+		armcompute.Disk{
+			Location: to.Ptr("eastus"),
+			SKU:      &armcompute.DiskSKU{Name: to.Ptr(armcompute.DiskStorageAccountTypesPremiumLRS)},
+			Properties: &armcompute.DiskProperties{
+				CreationData: &armcompute.CreationData{CreateOption: to.Ptr(armcompute.DiskCreateOptionEmpty)},
+				DiskSizeGB:   to.Ptr[int32](64),
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := createPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("create poll: %v", err)
+	}
+
+	grantPoller, err := client.BeginGrantAccess(ctx, "rg-1", "sas-disk",
+		armcompute.GrantAccessData{
+			Access:            to.Ptr(armcompute.AccessLevelRead),
+			DurationInSeconds: to.Ptr[int32](300),
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginGrantAccess: %v", err)
+	}
+
+	granted, err := grantPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	if err != nil {
+		t.Fatalf("grant poll: %v", err)
+	}
+
+	if granted.AccessSAS == nil || *granted.AccessSAS == "" {
+		t.Fatal("BeginGrantAccess returned empty accessSAS")
+	}
+
+	sas := *granted.AccessSAS
+	if !strings.HasPrefix(sas, "https://") || !strings.Contains(sas, "sig=") || !strings.Contains(sas, "se=") {
+		t.Errorf("accessSAS is not a time-bounded SAS URI: %s", sas)
+	}
+
+	revokePoller, err := client.BeginRevokeAccess(ctx, "rg-1", "sas-disk", nil)
+	if err != nil {
+		t.Fatalf("BeginRevokeAccess: %v", err)
+	}
+
+	if _, err := revokePoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Errorf("revoke poll: %v", err)
+	}
+}
+
+// TestSDKDiskGrantAccessMissingDisk asserts beginGetAccess on a disk that does
+// not exist fails rather than returning a bogus SAS.
+func TestSDKDiskGrantAccessMissingDisk(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		Disks:           cloudP.VirtualMachines,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newDisksClient(t, ts)
+	ctx := context.Background()
+
+	poller, err := client.BeginGrantAccess(ctx, "rg-1", "no-such-disk",
+		armcompute.GrantAccessData{
+			Access:            to.Ptr(armcompute.AccessLevelRead),
+			DurationInSeconds: to.Ptr[int32](300),
+		}, nil)
+	if err == nil {
+		if _, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err == nil {
+			t.Fatal("expected BeginGrantAccess on a missing disk to fail")
+		}
+	}
+}

--- a/server/azure/disks/handler.go
+++ b/server/azure/disks/handler.go
@@ -36,6 +36,13 @@ const (
 	// snapshotARMNameTag mirrors the ARM-name tag the snapshots handler stamps,
 	// so a Copy source snapshot can be resolved to its driver volume.
 	snapshotARMNameTag = "cloudemu:azureSnapshotName"
+
+	// accessLevelRead is the default disk SAS access level when none is given.
+	accessLevelRead = "Read"
+
+	// defaultAccessDuration is the SAS lifetime (seconds) applied when the
+	// request omits or zeroes durationInSeconds (Azure's own default is 3600).
+	defaultAccessDuration = 3600
 )
 
 // Handler serves Microsoft.Compute/disks requests.
@@ -72,6 +79,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// SAS export/import actions are POST sub-resources on a named disk.
+	if rp.SubResource != "" {
+		h.serveAction(w, r, rp)
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPut:
 		h.createOrUpdate(w, r, rp)
@@ -83,6 +96,97 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
 			"not implemented: "+r.Method+" "+r.URL.Path)
 	}
+}
+
+// serveAction dispatches the POST SAS actions on a named disk: beginGetAccess
+// (grant a time-bounded SAS URI) and endGetAccess (revoke it).
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed",
+			"method not allowed: "+r.Method+" "+r.URL.Path)
+
+		return
+	}
+
+	switch strings.ToLower(rp.SubResource) {
+	case "begingetaccess":
+		h.beginGetAccess(w, r, rp)
+	case "endgetaccess":
+		h.endGetAccess(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"not implemented: action "+rp.SubResource)
+	}
+}
+
+// beginGetAccess handles POST .../disks/{name}/beginGetAccess. It issues a
+// time-bounded SAS URI for exporting/importing the disk's contents, returning
+// the AccessUri (accessSAS) real Azure returns.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) beginGetAccess(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	accessor, ok := h.compute.(computedriver.AzureDiskAccessor)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented", "disk access SAS not supported")
+		return
+	}
+
+	vol, err := findDiskByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	var req grantAccessData
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	access := req.Access
+	if access == "" {
+		access = accessLevelRead
+	}
+
+	duration := req.DurationInSeconds
+	if duration <= 0 {
+		duration = defaultAccessDuration
+	}
+
+	sas, err := accessor.GrantDiskAccess(r.Context(), vol.ID, access, duration)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, accessURIResponse{AccessSAS: sas})
+}
+
+// endGetAccess handles POST .../disks/{name}/endGetAccess, revoking any SAS
+// access previously granted to the disk.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) endGetAccess(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	accessor, ok := h.compute.(computedriver.AzureDiskAccessor)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented", "disk access SAS not supported")
+		return
+	}
+
+	vol, err := findDiskByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if err := accessor.RevokeDiskAccess(r.Context(), vol.ID); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
 //nolint:gocritic // rp is a request-scoped value

--- a/server/azure/disks/types.go
+++ b/server/azure/disks/types.go
@@ -55,3 +55,17 @@ type diskResponseProps struct {
 type diskListResponse struct {
 	Value []diskResponse `json:"value"`
 }
+
+// grantAccessData is the request body for POST .../disks/{name}/beginGetAccess
+// (armcompute.GrantAccessData): the requested access level and the SAS lifetime.
+type grantAccessData struct {
+	Access            string `json:"access,omitempty"`
+	DurationInSeconds int    `json:"durationInSeconds,omitempty"`
+	FileFormat        string `json:"fileFormat,omitempty"`
+}
+
+// accessURIResponse is the 200 body for beginGetAccess (armcompute.AccessURI):
+// the SAS URI a client exports/imports the disk contents through.
+type accessURIResponse struct {
+	AccessSAS string `json:"accessSAS"`
+}

--- a/server/azure/echo_properties_test.go
+++ b/server/azure/echo_properties_test.go
@@ -113,7 +113,9 @@ func TestEchoUnmodeledPropertiesRoundTrip(t *testing.T) {
 		t.Errorf("create response dropped evictionPolicy: %v", cp["evictionPolicy"])
 	}
 
-	if cp["provisioningState"] != "Succeeded" {
+	// A create is a long-running op: the handler's authoritative create value
+	// is "Creating" (it settles to "Succeeded" on a later GET).
+	if cp["provisioningState"] != "Creating" {
 		t.Errorf("create response lost modeled provisioningState: %v", cp["provisioningState"])
 	}
 
@@ -150,12 +152,14 @@ func TestEchoDoesNotOverrideModeledFields(t *testing.T) {
 		"location": "eastus",
 		"properties": map[string]any{
 			"hardwareProfile":   map[string]any{"vmSize": "Standard_D2s_v5"},
-			"provisioningState": "Creating", // the handler owns this — must win
+			"provisioningState": "Succeeded", // the handler owns this — must win
 		},
 	})
 
-	if got := props(t, created)["provisioningState"]; got != "Succeeded" {
-		t.Errorf("overlay overrode modeled provisioningState: got %v, want Succeeded", got)
+	// The handler's authoritative create value ("Creating") must win over the
+	// request-supplied value rather than the overlay clobbering it.
+	if got := props(t, created)["provisioningState"]; got != "Creating" {
+		t.Errorf("overlay overrode modeled provisioningState: got %v, want Creating", got)
 	}
 }
 

--- a/server/azure/images/storageprofile_test.go
+++ b/server/azure/images/storageprofile_test.go
@@ -41,7 +41,9 @@ func putRaw(t *testing.T, ts *httptest.Server, path, body string) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
+	// A VM create returns 201 Created; disks/images return 202/200.
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK &&
+		resp.StatusCode != http.StatusCreated {
 		dump, _ := io.ReadAll(resp.Body)
 		t.Fatalf("PUT %s: status %d body=%s", path, resp.StatusCode, dump)
 	}

--- a/server/azure/sshpublickeys/handler.go
+++ b/server/azure/sshpublickeys/handler.go
@@ -61,6 +61,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPut:
 		h.createOrUpdate(w, r, rp)
+	case http.MethodPatch:
+		h.update(w, r, rp)
 	case http.MethodGet:
 		h.get(w, r, rp)
 	case http.MethodDelete:
@@ -145,6 +147,54 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 
 	// SDK is happiest with sync 200/201 for sshPublicKeys.
 	azurearm.WriteJSON(w, http.StatusOK, body)
+}
+
+// update handles PATCH .../sshPublicKeys/{name}. It updates the resource's
+// publicKey and/or tags in place (Azure SshPublicKeys Update). A publicKey
+// omitted from the body leaves the key material unchanged; a tags object
+// present in the body replaces the resource's tags.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) update(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	updater, ok := h.compute.(computedriver.AzureSSHKeyUpdater)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented", "sshPublicKeys update not supported")
+		return
+	}
+
+	existing, err := findKeyByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	var req sshKeyRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	// PATCH semantics: an omitted publicKey keeps the current key material; an
+	// omitted tags object keeps the current tags.
+	publicKey := tagOr(existing.Tags, publicKeyTag, existing.PublicKey)
+	if req.Properties.PublicKey != "" {
+		publicKey = req.Properties.PublicKey
+	}
+
+	userTags := stripInternalTags(existing.Tags)
+	if req.Tags != nil {
+		userTags = req.Tags
+	}
+
+	merged := mergeTags(userTags, rp.ResourceName, publicKey, rp.ResourceGroup)
+
+	updated, err := updater.UpdateKeyPair(r.Context(), rp.ResourceName, &publicKey, merged)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toSSHKeyResponse(updated, rp, ""))
 }
 
 //nolint:gocritic // rp is a request-scoped value

--- a/server/azure/sshpublickeys/update_test.go
+++ b/server/azure/sshpublickeys/update_test.go
@@ -1,0 +1,123 @@
+package sshpublickeys_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func newSSHClient(t *testing.T, ts *httptest.Server) *armcompute.SSHPublicKeysClient {
+	t.Helper()
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: cloud.Configuration{
+				ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+					cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+				},
+			},
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	client, err := armcompute.NewSSHPublicKeysClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return client
+}
+
+// TestSDKSSHPublicKeyUpdate drives SSHPublicKeysClient.Update (PATCH) through a
+// real armcompute client: the public key and tags are updated in place, and a
+// subsequent Get reflects the new values (tags are replaced, not merged).
+func TestSDKSSHPublicKeyUpdate(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		SSHPublicKeys:   cloudP.VirtualMachines,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSSHClient(t, ts)
+	ctx := context.Background()
+
+	const keyA = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ a@cloudemu"
+
+	const keyB = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ b@cloudemu"
+
+	if _, err := client.Create(ctx, "rg-1", "key-upd",
+		armcompute.SSHPublicKeyResource{
+			Location:   to.Ptr("eastus"),
+			Tags:       map[string]*string{"env": to.Ptr("test")},
+			Properties: &armcompute.SSHPublicKeyResourceProperties{PublicKey: to.Ptr(keyA)},
+		}, nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	updated, err := client.Update(ctx, "rg-1", "key-upd",
+		armcompute.SSHPublicKeyUpdateResource{
+			Tags:       map[string]*string{"team": to.Ptr("infra")},
+			Properties: &armcompute.SSHPublicKeyResourceProperties{PublicKey: to.Ptr(keyB)},
+		}, nil)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if updated.Properties == nil || updated.Properties.PublicKey == nil || *updated.Properties.PublicKey != keyB {
+		t.Errorf("update publicKey=%v want %q", updated.Properties, keyB)
+	}
+
+	got, err := client.Get(ctx, "rg-1", "key-upd", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.PublicKey == nil || *got.Properties.PublicKey != keyB {
+		t.Errorf("get publicKey mismatch, want %q", keyB)
+	}
+
+	if got.Tags["team"] == nil || *got.Tags["team"] != "infra" {
+		t.Errorf("tags=%v want team=infra", got.Tags)
+	}
+
+	if _, ok := got.Tags["env"]; ok {
+		t.Errorf("PATCH should replace tags, but env survived: %v", got.Tags)
+	}
+}
+
+// TestSDKSSHPublicKeyUpdateMissing asserts PATCH on a key that does not exist
+// returns an error rather than silently creating one.
+func TestSDKSSHPublicKeyUpdateMissing(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		SSHPublicKeys:   cloudP.VirtualMachines,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSSHClient(t, ts)
+
+	if _, err := client.Update(context.Background(), "rg-1", "ghost",
+		armcompute.SSHPublicKeyUpdateResource{
+			Properties: &armcompute.SSHPublicKeyResourceProperties{PublicKey: to.Ptr("ssh-rsa X")},
+		}, nil); err == nil {
+		t.Fatal("expected Update on a missing key to fail")
+	}
+}

--- a/server/azure/virtualmachines/capture_generalize_test.go
+++ b/server/azure/virtualmachines/capture_generalize_test.go
@@ -2,10 +2,13 @@ package virtualmachines_test
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
@@ -40,6 +43,21 @@ func createSDKVM(t *testing.T, client *armcompute.VirtualMachinesClient, name st
 	}
 }
 
+// deallocateSDKVM deallocates a VM through the real SDK and polls to completion.
+func deallocateSDKVM(t *testing.T, client *armcompute.VirtualMachinesClient, name string) {
+	t.Helper()
+
+	poller, err := client.BeginDeallocate(context.Background(), "rg-1", name, nil)
+	if err != nil {
+		t.Fatalf("BeginDeallocate %s: %v", name, err)
+	}
+
+	if _, err := poller.PollUntilDone(context.Background(),
+		&runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("deallocate poll %s: %v", name, err)
+	}
+}
+
 // TestSDKGeneralizeAndCapture verifies the golden-image workflow: capturing a
 // VM before it is generalized is rejected, and after Generalize the Capture
 // action returns a VirtualMachineCaptureResult template.
@@ -64,6 +82,14 @@ func TestSDKGeneralizeAndCapture(t *testing.T) {
 		}, nil); err == nil {
 		t.Fatal("expected Capture of a non-generalized VM to fail")
 	}
+
+	// Generalize before the VM is stopped/deallocated must be rejected: real
+	// Azure requires the VM to be deallocated first.
+	if _, err := client.Generalize(ctx, "rg-1", "img-vm", nil); err == nil {
+		t.Fatal("expected Generalize of a running VM to fail")
+	}
+
+	deallocateSDKVM(t, client, "img-vm")
 
 	if _, err := client.Generalize(ctx, "rg-1", "img-vm", nil); err != nil {
 		t.Fatalf("Generalize: %v", err)
@@ -90,6 +116,39 @@ func TestSDKGeneralizeAndCapture(t *testing.T) {
 
 	if len(res.Resources) == 0 {
 		t.Error("capture result missing resources template")
+	}
+}
+
+// TestSDKGeneralizeRunningVMConflict asserts Generalize on a running VM is
+// rejected with a 409 Conflict / OperationNotAllowed, matching real Azure.
+func TestSDKGeneralizeRunningVMConflict(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSDKClient(t, ts)
+	ctx := context.Background()
+
+	createSDKVM(t, client, "run-vm")
+
+	_, err := client.Generalize(ctx, "rg-1", "run-vm", nil)
+	if err == nil {
+		t.Fatal("expected Generalize of a running VM to fail")
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("expected *azcore.ResponseError, got %T: %v", err, err)
+	}
+
+	if respErr.StatusCode != http.StatusConflict {
+		t.Errorf("status = %d, want %d", respErr.StatusCode, http.StatusConflict)
+	}
+
+	if respErr.ErrorCode != "OperationNotAllowed" {
+		t.Errorf("error code = %q, want %q", respErr.ErrorCode, "OperationNotAllowed")
 	}
 }
 

--- a/server/azure/virtualmachines/capture_generalize_test.go
+++ b/server/azure/virtualmachines/capture_generalize_test.go
@@ -1,0 +1,147 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// createSDKVM provisions a VM through the real SDK and polls to completion.
+func createSDKVM(t *testing.T, client *armcompute.VirtualMachinesClient, name string) {
+	t.Helper()
+
+	poller, err := client.BeginCreateOrUpdate(context.Background(), "rg-1", name,
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				StorageProfile: &armcompute.StorageProfile{
+					OSDisk: &armcompute.OSDisk{OSType: to.Ptr(armcompute.OperatingSystemTypesLinux)},
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate %s: %v", name, err)
+	}
+
+	if _, err := poller.PollUntilDone(context.Background(),
+		&runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("create poll %s: %v", name, err)
+	}
+}
+
+// TestSDKGeneralizeAndCapture verifies the golden-image workflow: capturing a
+// VM before it is generalized is rejected, and after Generalize the Capture
+// action returns a VirtualMachineCaptureResult template.
+func TestSDKGeneralizeAndCapture(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSDKClient(t, ts)
+	ctx := context.Background()
+
+	createSDKVM(t, client, "img-vm")
+
+	// Capture before generalize must be rejected.
+	if _, err := client.BeginCapture(ctx, "rg-1", "img-vm",
+		armcompute.VirtualMachineCaptureParameters{
+			VhdPrefix:                to.Ptr("cap"),
+			DestinationContainerName: to.Ptr("vhds"),
+			OverwriteVhds:            to.Ptr(true),
+		}, nil); err == nil {
+		t.Fatal("expected Capture of a non-generalized VM to fail")
+	}
+
+	if _, err := client.Generalize(ctx, "rg-1", "img-vm", nil); err != nil {
+		t.Fatalf("Generalize: %v", err)
+	}
+
+	poller, err := client.BeginCapture(ctx, "rg-1", "img-vm",
+		armcompute.VirtualMachineCaptureParameters{
+			VhdPrefix:                to.Ptr("cap"),
+			DestinationContainerName: to.Ptr("vhds"),
+			OverwriteVhds:            to.Ptr(true),
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCapture: %v", err)
+	}
+
+	res, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	if err != nil {
+		t.Fatalf("capture poll: %v", err)
+	}
+
+	if res.ID == nil || *res.ID == "" {
+		t.Error("capture result missing id")
+	}
+
+	if len(res.Resources) == 0 {
+		t.Error("capture result missing resources template")
+	}
+}
+
+// TestSDKGeneralizeMissingVM asserts Generalize on a VM that does not exist
+// returns an error.
+func TestSDKGeneralizeMissingVM(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSDKClient(t, ts)
+
+	if _, err := client.Generalize(context.Background(), "rg-1", "ghost", nil); err == nil {
+		t.Fatal("expected Generalize of a missing VM to fail")
+	}
+}
+
+// TestSDKCreateVMMissingNICFails verifies that when a networking driver is
+// wired, creating a VM whose networkProfile references a non-existent NIC is
+// rejected rather than silently succeeding.
+func TestSDKCreateVMMissingNICFails(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		Network:         cloudP.VNet,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSDKClient(t, ts)
+	ctx := context.Background()
+
+	nicID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/networkInterfaces/nope"
+
+	_, err := client.BeginCreateOrUpdate(ctx, "rg-1", "bad-nic-vm",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				NetworkProfile: &armcompute.NetworkProfile{
+					NetworkInterfaces: []*armcompute.NetworkInterfaceReference{
+						{ID: to.Ptr(nicID)},
+					},
+				},
+			},
+		}, nil)
+	if err == nil {
+		t.Fatal("expected VM create with a missing NIC to fail")
+	}
+}

--- a/server/azure/virtualmachines/handler.go
+++ b/server/azure/virtualmachines/handler.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
 // providerName is the ARM provider this handler serves.
@@ -45,11 +46,17 @@ const resourceTypeLocations = "locations"
 // Handler serves ARM JSON requests for Microsoft.Compute/virtualMachines.
 type Handler struct {
 	compute computedriver.Compute
+	// net is the networking driver used to validate that a VM's networkProfile
+	// references an existing NIC. It is optional: a nil net (or one that does
+	// not implement AzureNetworkInterfaces) skips the existence check.
+	net netdriver.Networking
 }
 
-// New returns a virtualMachines handler backed by c.
-func New(c computedriver.Compute) *Handler {
-	return &Handler{compute: c}
+// New returns a virtualMachines handler backed by c. net is the networking
+// driver used to validate networkProfile NIC references; pass nil to disable
+// the check (e.g. when no networking driver is wired).
+func New(c computedriver.Compute, net netdriver.Networking) *Handler {
+	return &Handler{compute: c, net: net}
 }
 
 // Matches returns true for ARM URLs targeting Microsoft.Compute/virtualMachines
@@ -171,6 +178,13 @@ func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, rp azurear
 		return
 	}
 
+	h.servePostAction(w, r, rp)
+}
+
+// servePostAction dispatches the POST sub-resource actions on a named VM.
+//
+//nolint:gocritic // rp travels through the dispatch chain once per request
+func (h *Handler) servePostAction(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	switch strings.ToLower(rp.SubResource) {
 	case "start":
 		h.start(w, r, rp)
@@ -180,6 +194,10 @@ func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, rp azurear
 		h.deallocate(w, r, rp)
 	case "restart":
 		h.restart(w, r, rp)
+	case "generalize":
+		h.generalize(w, r, rp)
+	case "capture":
+		h.capture(w, r, rp)
 	case "retrievebootdiagnosticsdata":
 		h.retrieveBootDiagnosticsData(w, r, rp)
 	default:

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -9,6 +9,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
 // armNameTag is the tag key we use to round-trip the ARM resource name
@@ -58,6 +59,14 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		return
 	}
 
+	// A networkProfile must reference NICs that already exist. Real Azure
+	// rejects a VM whose networkProfile points at a missing NIC rather than
+	// silently succeeding.
+	if err := h.validateNICs(r.Context(), req.Properties.NetworkProfile); err != nil {
+		azurearm.WriteError(w, http.StatusBadRequest, "NetworkInterfaceNotFound", err.Error())
+		return
+	}
+
 	cfg := computedriver.InstanceConfig{
 		ImageID:       imageRefToID(req.Properties.StorageProfile),
 		InstanceType:  hardwareSize(req.Properties.HardwareProfile),
@@ -91,7 +100,42 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toVMResponse(&instances[0], rp, req))
+	// A create is a long-running operation: the initial response reports
+	// "Creating" (201 Created) and settles to "Succeeded" on the next poll/GET.
+	azurearm.WriteJSON(w, http.StatusCreated, toVMResponse(&instances[0], rp, req, provisioningCreating))
+}
+
+// validateNICs verifies that every NIC referenced by a networkProfile exists.
+// It is a no-op when no networking driver is wired or the driver does not
+// implement the Azure network-interface surface, so handlers configured
+// without networking keep their previous permissive behavior.
+func (h *Handler) validateNICs(ctx context.Context, np *networkProfile) error {
+	if np == nil || len(np.NetworkInterfaces) == 0 || h.net == nil {
+		return nil
+	}
+
+	svc, ok := h.net.(netdriver.AzureNetworkInterfaces)
+	if !ok {
+		return nil
+	}
+
+	for _, nic := range np.NetworkInterfaces {
+		if nic.ID == "" {
+			continue
+		}
+
+		pp, ok := azurearm.ParsePath(nic.ID)
+		if !ok || pp.ResourceName == "" {
+			return cerrors.Newf(cerrors.InvalidArgument, "malformed networkInterface id %q", nic.ID)
+		}
+
+		if _, err := svc.GetNetworkInterface(ctx, pp.ResourceGroup, pp.ResourceName); err != nil {
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"networkProfile references network interface %q which does not exist", pp.ResourceName)
+		}
+	}
+
+	return nil
 }
 
 // updateExisting applies an idempotent CreateOrUpdate to an already-provisioned
@@ -119,7 +163,7 @@ func (h *Handler) updateExisting(
 		existing = updated
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toVMResponse(existing, rp, req))
+	azurearm.WriteJSON(w, http.StatusOK, toVMResponse(existing, rp, req, provisioningSucceeded))
 }
 
 // get handles GET virtualMachines/{name}.
@@ -132,7 +176,7 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.Resour
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toVMResponse(inst, rp, vmRequest{}))
+	azurearm.WriteJSON(w, http.StatusOK, toVMResponse(inst, rp, vmRequest{}, provisioningSucceeded))
 }
 
 // list handles GET virtualMachines. A resource-group-scoped path
@@ -157,7 +201,7 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp azurearm.Resou
 		name := tagOr(instances[i].Tags, armNameTag, instances[i].ID)
 		scope := rp
 		scope.ResourceName = name
-		out = append(out, toVMResponse(&instances[i], scope, vmRequest{}))
+		out = append(out, toVMResponse(&instances[i], scope, vmRequest{}, provisioningSucceeded))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, vmListResponse{Value: out})
@@ -258,6 +302,96 @@ func (h *Handler) powerAction(
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) restart(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	h.lifecycleAction(w, r, rp, h.compute.RebootInstances)
+}
+
+// generalize handles POST virtualMachines/{name}/generalize. It marks the VM
+// as generalized (OS-specific state removed), a precondition for capturing it
+// into a reusable image. Real Azure returns 200 OK with no body.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) generalize(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	ctrl, ok := h.compute.(computedriver.AzureVMController)
+	if !ok {
+		writeNotImplemented(w, "action: generalize")
+		return
+	}
+
+	inst, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if err := ctrl.GeneralizeInstance(r.Context(), inst.ID); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// capture handles POST virtualMachines/{name}/capture. It copies the VM's
+// virtual hard disks and returns a template (VirtualMachineCaptureResult) that
+// can recreate similar VMs. The VM must first be generalized — capturing a
+// non-generalized VM is rejected, matching real Azure.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) capture(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	var req captureRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	inst, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if !inst.Generalized {
+		azurearm.WriteError(w, http.StatusConflict, "OperationNotAllowed",
+			"the virtual machine must be generalized before it can be captured")
+
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, captureResult(inst, rp, req))
+}
+
+// captureResult builds the VirtualMachineCaptureResult template for a captured
+// VM: the ARM deployment-template envelope plus a single virtualMachines/image
+// resource describing the captured VHD.
+//
+//nolint:gocritic // rp/req are request-scoped values
+func captureResult(inst *computedriver.Instance, rp azurearm.ResourcePath, req captureRequest) captureResponse {
+	prefix := req.VhdPrefix
+	if prefix == "" {
+		prefix = "captured"
+	}
+
+	vhdURI := "https://cloudemu.blob.storage.azure.net/" +
+		req.DestinationContainerName + "/" + prefix + "-osdisk.vhd"
+
+	return captureResponse{
+		Schema:         "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+		ContentVersion: "1.0.0.0",
+		Parameters:     map[string]any{},
+		ID:             azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, rp.ResourceName),
+		Resources: []captureResource{{
+			Type:       providerName + "/images",
+			APIVersion: "2023-09-01",
+			Properties: captureResourceProps{
+				StorageProfile: captureStorageProfile{
+					OSDisk: captureOSDisk{
+						OSType: defaultIfEmpty(inst.OSType, "Linux"),
+						Name:   prefix + "-osdisk",
+						Image:  &captureVHD{URI: vhdURI},
+					},
+				},
+			},
+		}},
+	}
 }
 
 // retrieveBootDiagnosticsData handles POST virtualMachines/{name}/retrieveBootDiagnosticsData.
@@ -478,10 +612,19 @@ func tagOr(m map[string]string, key, fallback string) string {
 	return fallback
 }
 
+// ARM provisioningState values a VM settles through. A create returns
+// "Creating"; a subsequent GET/poll reports "Succeeded".
+const (
+	provisioningCreating  = "Creating"
+	provisioningSucceeded = "Succeeded"
+)
+
 // toVMResponse maps a driver Instance back onto the ARM JSON shape.
+// provisioningState is the properties.provisioningState to report ("Creating"
+// on the initial create response, "Succeeded" thereafter).
 //
 //nolint:gocritic // rp/req are value types passed once per response build
-func toVMResponse(inst *computedriver.Instance, rp azurearm.ResourcePath, req vmRequest) vmResponse {
+func toVMResponse(inst *computedriver.Instance, rp azurearm.ResourcePath, req vmRequest, provisioningState string) vmResponse {
 	name := tagOr(inst.Tags, armNameTag, rp.ResourceName)
 
 	return vmResponse{
@@ -496,18 +639,28 @@ func toVMResponse(inst *computedriver.Instance, rp azurearm.ResourcePath, req vm
 		Zones:    inst.Zones,
 		Properties: vmResponseProps{
 			VMID:              inst.ID,
-			ProvisioningState: "Succeeded",
+			ProvisioningState: provisioningState,
 			HardwareProfile:   &hardwareProfile{VMSize: inst.InstanceType},
 			StorageProfile:    osDiskProfile(inst.OSType),
 			Priority:          inst.Priority,
 			LicenseType:       inst.LicenseType,
 			InstanceView: &instanceView{
 				Statuses: []instanceViewStatus{
-					{Code: "ProvisioningState/succeeded", Level: "Info", DisplayStatus: "Provisioning succeeded"},
+					provisioningStatus(provisioningState),
 					{Code: "PowerState/" + powerCode(inst), Level: "Info", DisplayStatus: powerDisplay(inst)},
 				},
 			},
 		},
+	}
+}
+
+// provisioningStatus renders the instanceView ProvisioningState status line for
+// the given provisioningState.
+func provisioningStatus(state string) instanceViewStatus {
+	return instanceViewStatus{
+		Code:          "ProvisioningState/" + strings.ToLower(state),
+		Level:         "Info",
+		DisplayStatus: "Provisioning " + strings.ToLower(state),
 	}
 }
 

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -42,6 +42,12 @@ const (
 	stateTerminated = "terminated"
 )
 
+// ARM PowerState codes (the suffix after "PowerState/") a VM may report.
+const (
+	powerCodeStopped     = "stopped"
+	powerCodeDeallocated = "deallocated"
+)
+
 // createOrUpdate handles PUT virtualMachines/{name}. Maps the ARM JSON body
 // onto an InstanceConfig, calls RunInstances(count=1), and replies with an
 // ARM-shaped vmResponse.
@@ -319,6 +325,16 @@ func (h *Handler) generalize(w http.ResponseWriter, r *http.Request, rp azurearm
 	inst, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	// Real Azure requires the VM to be stopped or deallocated before it can be
+	// generalized; generalizing a running (or otherwise not-stopped) VM is
+	// rejected with OperationNotAllowed / 409 Conflict.
+	if power := powerCode(inst); power != powerCodeStopped && power != powerCodeDeallocated {
+		azurearm.WriteError(w, http.StatusConflict, "OperationNotAllowed",
+			"the virtual machine must be stopped or deallocated before it can be generalized")
+
 		return
 	}
 
@@ -727,7 +743,7 @@ func powerStateFor(state string) string {
 	case statePending:
 		return "starting"
 	case stateStopped:
-		return "deallocated"
+		return powerCodeDeallocated
 	case stateStopping:
 		return "deallocating"
 	case stateTerminated:

--- a/server/azure/virtualmachines/types.go
+++ b/server/azure/virtualmachines/types.go
@@ -135,3 +135,45 @@ type diskInstanceView struct {
 type vmListResponse struct {
 	Value []vmResponse `json:"value"`
 }
+
+// captureRequest is the body for POST virtualMachines/{name}/capture
+// (armcompute.VirtualMachineCaptureParameters).
+type captureRequest struct {
+	VhdPrefix                string `json:"vhdPrefix"`
+	DestinationContainerName string `json:"destinationContainerName"`
+	OverwriteVhds            bool   `json:"overwriteVhds"`
+}
+
+// captureResponse is the VirtualMachineCaptureResult: an ARM deployment-template
+// envelope whose resources recreate similar VMs from the captured disks.
+type captureResponse struct {
+	Schema         string            `json:"$schema"`
+	ContentVersion string            `json:"contentVersion"`
+	Parameters     map[string]any    `json:"parameters"`
+	Resources      []captureResource `json:"resources"`
+	ID             string            `json:"id"`
+}
+
+type captureResource struct {
+	Type       string               `json:"type"`
+	APIVersion string               `json:"apiVersion"`
+	Properties captureResourceProps `json:"properties"`
+}
+
+type captureResourceProps struct {
+	StorageProfile captureStorageProfile `json:"storageProfile"`
+}
+
+type captureStorageProfile struct {
+	OSDisk captureOSDisk `json:"osDisk"`
+}
+
+type captureOSDisk struct {
+	OSType string      `json:"osType"`
+	Name   string      `json:"name"`
+	Image  *captureVHD `json:"image,omitempty"`
+}
+
+type captureVHD struct {
+	URI string `json:"uri"`
+}

--- a/server/azure/virtualmachines/virtualmachines_test.go
+++ b/server/azure/virtualmachines/virtualmachines_test.go
@@ -60,7 +60,9 @@ func putVM(t *testing.T, ts *httptest.Server, name string) map[string]any {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	// A create returns 201 Created (provisioningState "Creating"); an idempotent
+	// re-PUT that updates in place returns 200 OK. Both are valid.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		dump, _ := io.ReadAll(resp.Body)
 		t.Fatalf("PUT %s: status %d, body=%s", name, resp.StatusCode, dump)
 	}
@@ -91,12 +93,21 @@ func TestVMCreateOrUpdate(t *testing.T) {
 	}
 
 	props, _ := got["properties"].(map[string]any)
-	if props["provisioningState"] != "Succeeded" {
-		t.Errorf("provisioningState=%v", props["provisioningState"])
+	// A create is a long-running op: the initial response reports "Creating".
+	if props["provisioningState"] != "Creating" {
+		t.Errorf("provisioningState=%v want Creating", props["provisioningState"])
 	}
 
 	if props["vmId"] == "" || props["vmId"] == nil {
 		t.Error("expected non-empty vmId (driver instance ID)")
+	}
+
+	// A subsequent GET reports the settled "Succeeded" state.
+	gotGet := getVM(t, ts, "vm-1")
+	getProps, _ := gotGet["properties"].(map[string]any)
+
+	if getProps["provisioningState"] != "Succeeded" {
+		t.Errorf("GET provisioningState=%v want Succeeded", getProps["provisioningState"])
 	}
 }
 

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -79,6 +79,11 @@ type Instance struct {
 	// PowerOff'd VM (stopped, still allocated) from a Deallocated one, a
 	// distinction the lifecycle State field cannot carry. Empty for AWS/GCP.
 	PowerState string
+	// Generalized is true once the VM has been generalized (Azure Generalize
+	// action): its OS-specific state has been removed so it can be captured
+	// into a reusable image. Empty/false for AWS/GCP and for un-generalized
+	// Azure VMs.
+	Generalized bool
 	// Operator carries service-provider managed-resource metadata. It is nil
 	// for ordinary (unmanaged) instances.
 	Operator *OperatorInfo
@@ -570,6 +575,35 @@ type AzureVMController interface {
 	// instance in place (preserving its ID and launch time), for idempotent
 	// ARM CreateOrUpdate.
 	UpdateInstance(ctx context.Context, instanceID string, cfg InstanceConfig) error
+	// GeneralizeInstance marks an instance as generalized (Azure Generalize
+	// action), a precondition for capturing it into a reusable image. It is
+	// idempotent: generalizing an already-generalized VM succeeds.
+	GeneralizeInstance(ctx context.Context, instanceID string) error
+}
+
+// AzureDiskAccessor is an optional Azure-only capability for the managed-disk
+// beginGetAccess / endGetAccess actions (DisksClient.BeginGrantAccess /
+// BeginRevokeAccess): a time-bounded SAS URI is issued for exporting or
+// importing the disk's contents, and later revoked. Only the Azure VM mock
+// implements it; the wire handler type-asserts for it, so AWS/GCP are
+// unaffected.
+type AzureDiskAccessor interface {
+	// GrantDiskAccess issues a time-bounded SAS URI granting the requested
+	// access level ("Read"/"Write") to the disk for durationSeconds.
+	GrantDiskAccess(ctx context.Context, volumeID, access string, durationSeconds int) (string, error)
+	// RevokeDiskAccess revokes any SAS access previously granted to the disk.
+	RevokeDiskAccess(ctx context.Context, volumeID string) error
+}
+
+// AzureSSHKeyUpdater is an optional Azure-only capability for the sshPublicKeys
+// PATCH Update operation, which updates a key resource's public key and/or tags
+// in place. Only the Azure VM mock implements it; the wire handler type-asserts
+// for it, so AWS/GCP are unaffected.
+type AzureSSHKeyUpdater interface {
+	// UpdateKeyPair updates the public key and/or tags of an existing key pair.
+	// A nil publicKey / tags leaves that field unchanged; a non-nil tags map
+	// replaces the resource's tags.
+	UpdateKeyPair(ctx context.Context, name string, publicKey *string, tags map[string]string) (*KeyPairInfo, error)
 }
 
 // KeyPairGenerator is an optional Azure-only capability for the ARM


### PR DESCRIPTION
Fixes a set of Azure compute long-tail gaps found in the real-user e2e audit. All behaviors verified against the official Azure REST reference and driven by real azure-sdk-for-go clients.

## Changes (mapped to findings)

- **VM networkProfile dependency validation** — `CreateOrUpdate` referencing a non-existent NIC previously succeeded with `Succeeded`. The handler now validates each `networkProfile.networkInterfaces[].id` against the networking driver (wired via the server) and rejects a missing NIC with `NetworkInterfaceNotFound` (400). The check is a no-op when no networking driver is wired, so existing NIC-less flows are unaffected.

- **VM Generalize / Capture** — both were `501`. Added the `generalize` action (marks the VM generalized) and the `capture` action (returns a `VirtualMachineCaptureResult` template). Capturing a VM that has not been generalized is now rejected (`OperationNotAllowed`), gating the golden-image workflow on generalize.

- **Disk BeginGetAccess / EndGetAccess** — were `501`. Added `beginGetAccess` (returns an `AccessUri` with a time-bounded `accessSAS`) and `endGetAccess` (revokes it).

- **sshPublicKeys Update** — `PATCH .../sshPublicKeys/{name}` was `501`. Added it: updates `properties.publicKey` and/or `tags` in place (PATCH replaces the tags collection).

- **VM provisioningState Creating** — the first create hardcoded `Succeeded`. A create now returns `201 Created` with `provisioningState: Creating`, settling to `Succeeded` on the next GET/poll. The SDK long-running-operation poller resolves cleanly.

## Layering

- New Azure-only, type-asserted driver capabilities on `services/compute/driver`: `AzureDiskAccessor`, `AzureSSHKeyUpdater`, and `AzureVMController.GeneralizeInstance`, plus `Instance.Generalized`. AWS/GCP are unaffected. `docs/coverage` regenerated.

## Tests

- Real `azure-sdk-for-go` (armcompute) tests: disk grant/revoke SAS, sshPublicKeys Update, VM generalize+capture (incl. capture-before-generalize rejection), and VM-create-with-missing-NIC rejection.
- Provider-level tests for `GeneralizeInstance`, `GrantDiskAccess`/`RevokeDiskAccess`, and `UpdateKeyPair`.
- Updated existing create-path tests to reflect the `Creating`→`Succeeded` transition and the 201 status.