### PR TITLE
fix(logs-route53): FilterLogEvents pattern/pagination, ChangeResourceRecordSets validation

### DIFF
--- a/server/aws/cloudwatchlogs/filter_scope_sdk_test.go
+++ b/server/aws/cloudwatchlogs/filter_scope_sdk_test.go
@@ -1,0 +1,135 @@
+package cloudwatchlogs_test
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cwl "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+)
+
+// seedFilterStreams creates a group with three streams (app-1, app-2, db-1),
+// each carrying one event whose message is the stream name, so a caller can tell
+// which streams a FilterLogEvents call actually searched.
+func seedFilterStreams(t *testing.T, client *cwl.Client, group string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String(group)}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	base := time.Now().UTC().Truncate(time.Millisecond)
+
+	for _, s := range []string{"app-1", "app-2", "db-1"} {
+		if _, err := client.CreateLogStream(ctx, &cwl.CreateLogStreamInput{
+			LogGroupName: aws.String(group), LogStreamName: aws.String(s),
+		}); err != nil {
+			t.Fatalf("CreateLogStream(%s): %v", s, err)
+		}
+
+		if _, err := client.PutLogEvents(ctx, &cwl.PutLogEventsInput{
+			LogGroupName: aws.String(group), LogStreamName: aws.String(s),
+			LogEvents: []cwltypes.InputLogEvent{{
+				Timestamp: aws.Int64(base.UnixMilli()),
+				Message:   aws.String(s),
+			}},
+		}); err != nil {
+			t.Fatalf("PutLogEvents(%s): %v", s, err)
+		}
+	}
+}
+
+func filteredStreams(events []cwltypes.FilteredLogEvent) []string {
+	names := make([]string, 0, len(events))
+	for i := range events {
+		names = append(names, aws.ToString(events[i].LogStreamName))
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+// TestSDKFilterLogEventsLogStreamNames guards that logStreamNames restricts the
+// result to only the listed streams, including when the list has two or more
+// entries (the single-element fast path is not the only supported case).
+func TestSDKFilterLogEventsLogStreamNames(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+	seedFilterStreams(t, client, "/scope/names")
+
+	out, err := client.FilterLogEvents(ctx, &cwl.FilterLogEventsInput{
+		LogGroupName:   aws.String("/scope/names"),
+		LogStreamNames: []string{"app-1", "app-2"},
+	})
+	if err != nil {
+		t.Fatalf("FilterLogEvents: %v", err)
+	}
+
+	got := filteredStreams(out.Events)
+	want := []string{"app-1", "app-2"}
+
+	if len(got) != len(want) {
+		t.Fatalf("FilterLogEvents streams = %v, want %v (db-1 must be excluded)", got, want)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("FilterLogEvents streams = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestSDKFilterLogEventsLogStreamNamePrefix guards that logStreamNamePrefix
+// restricts the result to streams whose name starts with the prefix.
+func TestSDKFilterLogEventsLogStreamNamePrefix(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+	seedFilterStreams(t, client, "/scope/prefix")
+
+	out, err := client.FilterLogEvents(ctx, &cwl.FilterLogEventsInput{
+		LogGroupName:        aws.String("/scope/prefix"),
+		LogStreamNamePrefix: aws.String("app-"),
+	})
+	if err != nil {
+		t.Fatalf("FilterLogEvents: %v", err)
+	}
+
+	got := filteredStreams(out.Events)
+	want := []string{"app-1", "app-2"}
+
+	if len(got) != len(want) {
+		t.Fatalf("FilterLogEvents streams = %v, want %v (db-1 must be excluded)", got, want)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("FilterLogEvents streams = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestSDKFilterLogEventsNamesAndPrefixConflict guards that specifying both
+// logStreamNames and logStreamNamePrefix is rejected as InvalidParameterException.
+func TestSDKFilterLogEventsNamesAndPrefixConflict(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+	seedFilterStreams(t, client, "/scope/conflict")
+
+	_, err := client.FilterLogEvents(ctx, &cwl.FilterLogEventsInput{
+		LogGroupName:        aws.String("/scope/conflict"),
+		LogStreamNames:      []string{"app-1"},
+		LogStreamNamePrefix: aws.String("app-"),
+	})
+
+	var invalid *cwltypes.InvalidParameterException
+	if !errors.As(err, &invalid) {
+		t.Fatalf("FilterLogEvents(names+prefix): got %v, want InvalidParameterException", err)
+	}
+}

--- a/server/aws/cloudwatchlogs/operations.go
+++ b/server/aws/cloudwatchlogs/operations.go
@@ -355,10 +355,19 @@ func (h *Handler) filterLogEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// logStreamNames and logStreamNamePrefix are mutually exclusive; supplying
+	// both is an InvalidParameterException on real AWS.
+	if len(req.LogStreamNames) > 0 && req.LogStreamNamePrefix != "" {
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException",
+			"logStreamNames and logStreamNamePrefix are mutually exclusive")
+		return
+	}
+
 	// The driver filters one stream at a time; when the caller scopes the query
-	// to a single stream, honor it, otherwise search across all streams.
+	// to exactly one stream (and no prefix), push it down. A name list or a
+	// prefix needs events from every stream, which are then scoped below.
 	stream := ""
-	if len(req.LogStreamNames) == 1 {
+	if len(req.LogStreamNames) == 1 && req.LogStreamNamePrefix == "" {
 		stream = req.LogStreamNames[0]
 	}
 
@@ -376,6 +385,11 @@ func (h *Handler) filterLogEvents(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, err)
 		return
 	}
+
+	// Restrict to the requested streams: an explicit name list (membership) or a
+	// name prefix. The single-stream fast path already scoped the driver query,
+	// so this only trims the multi-name and prefix cases.
+	events = scopeFilteredStreams(events, req.LogStreamNames, req.LogStreamNamePrefix)
 
 	limit := req.Limit
 	if limit <= 0 {
@@ -401,4 +415,39 @@ func (h *Handler) filterLogEvents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wire.WriteJSON(w, resp)
+}
+
+// scopeFilteredStreams restricts filtered events to the caller's requested
+// streams. names limits results to that exact set; prefix limits them to streams
+// whose name starts with it. With neither set (or an empty names list), events
+// pass through unchanged. names and prefix are mutually exclusive at the call
+// site, so at most one is ever active.
+func scopeFilteredStreams(
+	events []logdriver.FilteredLogEvent,
+	names []string,
+	prefix string,
+) []logdriver.FilteredLogEvent {
+	if len(names) == 0 && prefix == "" {
+		return events
+	}
+
+	allowed := make(map[string]bool, len(names))
+	for _, n := range names {
+		allowed[n] = true
+	}
+
+	scoped := make([]logdriver.FilteredLogEvent, 0, len(events))
+
+	for i := range events {
+		switch {
+		case len(names) > 0:
+			if allowed[events[i].LogStream] {
+				scoped = append(scoped, events[i])
+			}
+		case strings.HasPrefix(events[i].LogStream, prefix):
+			scoped = append(scoped, events[i])
+		}
+	}
+
+	return scoped
 }

--- a/server/aws/cloudwatchlogs/types.go
+++ b/server/aws/cloudwatchlogs/types.go
@@ -62,13 +62,14 @@ type getLogEventsRequest struct {
 }
 
 type filterLogEventsRequest struct {
-	LogGroupName   string   `json:"logGroupName"`
-	LogStreamNames []string `json:"logStreamNames"`
-	FilterPattern  string   `json:"filterPattern"`
-	StartTime      int64    `json:"startTime"`
-	EndTime        int64    `json:"endTime"`
-	Limit          int32    `json:"limit"`
-	NextToken      string   `json:"nextToken"`
+	LogGroupName        string   `json:"logGroupName"`
+	LogStreamNames      []string `json:"logStreamNames"`
+	LogStreamNamePrefix string   `json:"logStreamNamePrefix"`
+	FilterPattern       string   `json:"filterPattern"`
+	StartTime           int64    `json:"startTime"`
+	EndTime             int64    `json:"endTime"`
+	Limit               int32    `json:"limit"`
+	NextToken           string   `json:"nextToken"`
 }
 
 // --- response envelopes ---

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -217,6 +217,26 @@ func rrSetKey(name, rtype, setID string) string {
 	return strings.ToLower(name) + "|" + strings.ToUpper(rtype) + "|" + setID
 }
 
+// validateRecordSet checks a single record set's fields are self-consistent,
+// independent of the zone's current state. Real Route 53 rejects these as part
+// of change-batch validation before any change is applied.
+func validateRecordSet(rr *resourceRecordSetXML) error {
+	if rr.Name == "" || rr.Type == "" {
+		return cerrors.New(cerrors.InvalidArgument, "record set name and type are required")
+	}
+
+	// Weighted routing record sets require a non-empty SetIdentifier that
+	// distinguishes them from their siblings at the same name+type. Real Route 53
+	// rejects a weighted record set with a missing SetIdentifier as an
+	// InvalidChangeBatch (FailedPrecondition maps to that code).
+	if rr.Weight != nil && rr.SetIdentifier == "" {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"record set %q %s: SetIdentifier is required for weighted routing", rr.Name, rr.Type)
+	}
+
+	return nil
+}
+
 // validateChangeBatch checks every change would apply cleanly before any is
 // applied, so an invalid batch is rejected whole (nothing half-applied). It
 // simulates the batch against the zone's current record sets, folding in each
@@ -235,8 +255,8 @@ func (h *Handler) validateChangeBatch(r *http.Request, zoneID string, changes []
 	for i := range changes {
 		rr := &changes[i].ResourceRecordSet
 
-		if rr.Name == "" || rr.Type == "" {
-			return cerrors.New(cerrors.InvalidArgument, "record set name and type are required")
+		if err := validateRecordSet(rr); err != nil {
+			return err
 		}
 
 		key := rrSetKey(rr.Name, rr.Type, rr.SetIdentifier)

--- a/server/aws/route53/record_set_routing_test.go
+++ b/server/aws/route53/record_set_routing_test.go
@@ -2,6 +2,7 @@ package route53_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -181,6 +182,38 @@ func TestSDKRoutingPolicyRoundTrip(t *testing.T) {
 	geo := findRecordSet(t, sets, "geo.routing.com.", r53types.RRTypeA)
 	if geo.GeoLocation == nil || aws.ToString(geo.GeoLocation.CountryCode) != "IN" {
 		t.Fatalf("GeoLocation = %+v, want CountryCode IN", geo.GeoLocation)
+	}
+}
+
+// TestSDKWeightedRecordRequiresSetIdentifier pins that a CREATE of a weighted
+// routing record set (Weight set) with no SetIdentifier is rejected as
+// InvalidChangeBatch, matching real Route 53, and that the record is not stored.
+func TestSDKWeightedRecordRequiresSetIdentifier(t *testing.T) {
+	client := newRoute53Client(t)
+	zoneID := createRoutingZone(t, client, "wtd-req.com.")
+	name := "app.wtd-req.com."
+
+	_, err := client.ChangeResourceRecordSets(context.Background(), &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{
+			Changes: []r53types.Change{{
+				Action: r53types.ChangeActionCreate,
+				ResourceRecordSet: &r53types.ResourceRecordSet{
+					Name: aws.String(name), Type: r53types.RRTypeA, TTL: aws.Int64(60),
+					Weight:          aws.Int64(10),
+					ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.1")}},
+				},
+			}},
+		},
+	})
+
+	var invalid *r53types.InvalidChangeBatch
+	if !errors.As(err, &invalid) {
+		t.Fatalf("weighted CREATE without SetIdentifier: got %v, want InvalidChangeBatch", err)
+	}
+
+	if got := weightedSetIdentifiers(t, client, zoneID, name); len(got) != 0 {
+		t.Fatalf("record stored despite rejection: %v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Round-5 AWS deep-audit fixes for CloudWatch Logs FilterLogEvents stream scoping and Route 53 weighted-routing validation. All at the wire/server layer; no driver interfaces changed.

### FilterLogEvents stream scoping (finding 1 & 2)
- `logStreamNamePrefix` was silently dropped — the request type had no such field and no prefix filter was applied, so events from every stream in the group were returned. The parameter is now parsed and events are restricted to streams whose name starts with the prefix.
- `logStreamNames` was only honored when the list had exactly one element; for two or more names the query fell back to searching all streams, returning events from streams the caller excluded. Multi-element lists are now scoped by set membership.
- Specifying both `logStreamNames` and `logStreamNamePrefix` is now rejected with `InvalidParameterException` (HTTP 400), matching AWS (the two parameters are mutually exclusive).

### ChangeResourceRecordSets weighted validation (finding 3)
- A CREATE (or UPSERT) of a record set carrying `Weight` but omitting `SetIdentifier` was silently accepted. Real Route 53 rejects this weighted-routing config with `InvalidChangeBatch` (HTTP 400); the change batch is now validated up front and rejected whole (nothing stored). Per-record field checks were extracted into a `validateRecordSet` helper.

### Tests
- `filter_scope_sdk_test.go` — real aws-sdk-go-v2 tests asserting logStreamNames (multi-element) and logStreamNamePrefix each scope results to the expected streams, and that names+prefix returns InvalidParameterException.
- `record_set_routing_test.go` — asserts a weighted CREATE without SetIdentifier returns InvalidChangeBatch and stores nothing.

Gates: `go build ./...`, `go test ./providers/aws/... ./server/aws/... ./services/...`, and golangci-lint on changed packages all green (changed code clean; remaining lint flags are pre-existing debt in untouched functions).