### PR TITLE
fix(messaging): SQS SendMessageBatch duplicate/>10/empty entry validation + attribute ranges, SNS Subscribe protocol validation, CloudWatch GetMetricData expressions, EventBridge PutEvents limit

### DIFF
--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -57,6 +57,25 @@ func requiresConfirmation(protocol string) bool {
 	return ok
 }
 
+// validProtocols is the set of delivery protocols SNS Subscribe accepts. Any
+// other value is rejected with InvalidParameter, matching real SNS.
+var validProtocols = map[string]struct{}{ //nolint:gochecknoglobals // static lookup table
+	"http":        {},
+	"https":       {},
+	"email":       {},
+	"email-json":  {},
+	"sms":         {},
+	"sqs":         {},
+	"application": {},
+	"lambda":      {},
+	"firehose":    {},
+}
+
+func isValidProtocol(protocol string) bool {
+	_, ok := validProtocols[protocol]
+	return ok
+}
+
 // SQSDeliverer delivers an SNS notification into an SQS queue identified by
 // its ARN. The SQS mock satisfies this, enabling real SNS -> SQS fan-out.
 type SQSDeliverer interface {
@@ -245,6 +264,11 @@ func (m *Mock) Subscribe(_ context.Context, cfg driver.SubscriptionConfig) (*dri
 
 	if cfg.Protocol == "" {
 		return nil, errors.New(errors.InvalidArgument, "protocol is required")
+	}
+
+	if !isValidProtocol(cfg.Protocol) {
+		return nil, errors.Newf(errors.InvalidArgument,
+			"Invalid parameter: Protocol Reason: %s protocol is not supported", cfg.Protocol)
 	}
 
 	if cfg.Endpoint == "" {

--- a/server/aws/cloudwatch/metric_data_ops.go
+++ b/server/aws/cloudwatch/metric_data_ops.go
@@ -49,6 +49,7 @@ type metricDataQueryCBR struct {
 	ID         string         `cbor:"Id"`
 	Label      string         `cbor:"Label,omitempty"`
 	MetricStat *metricStatCBR `cbor:"MetricStat,omitempty"`
+	Expression string         `cbor:"Expression,omitempty"`
 	ReturnData *bool          `cbor:"ReturnData,omitempty"`
 }
 
@@ -82,51 +83,57 @@ func (h *Handler) getMetricData(w http.ResponseWriter, r *http.Request, body []b
 	start := timeOrZero(in.StartTime)
 	end := timeOrZero(in.EndTime)
 
+	eval := newMathEvaluator(r.Context(), h.monitoring, in.MetricDataQueries, start, end)
+
 	out := make([]metricDataResultCBR, 0, len(in.MetricDataQueries))
 
-	for _, q := range in.MetricDataQueries {
-		if q.MetricStat == nil {
-			continue // math-expression queries are not modeled
-		}
+	for i := range in.MetricDataQueries {
+		q := in.MetricDataQueries[i]
 
-		res, err := h.monitoring.GetMetricData(r.Context(), mondriver.GetMetricInput{
-			Namespace:  q.MetricStat.Metric.Namespace,
-			MetricName: q.MetricStat.Metric.MetricName,
-			Dimensions: toDimensionMap(q.MetricStat.Metric.Dimensions),
-			StartTime:  start,
-			EndTime:    end,
-			Period:     q.MetricStat.Period,
-			Stat:       q.MetricStat.Stat,
-		})
+		series, err := eval.resolve(q.ID)
 		if err != nil {
 			writeDriverErr(w, err)
 			return
 		}
 
-		out = append(out, buildMetricDataResult(q, res))
+		// A query with ReturnData explicitly false is an input to other queries
+		// only (e.g. a raw metric feeding a math expression) and is not emitted
+		// as a data row. When omitted, ReturnData defaults to true.
+		if q.ReturnData != nil && !*q.ReturnData {
+			continue
+		}
+
+		out = append(out, buildMetricDataResult(q, series))
 	}
 
 	writeCBORResponse(w, getMetricDataOutput{MetricDataResults: out})
 }
 
-func buildMetricDataResult(q metricDataQueryCBR, res *mondriver.MetricDataResult) metricDataResultCBR {
-	label := q.Label
-	if label == "" {
-		label = q.MetricStat.Metric.MetricName
+func buildMetricDataResult(q metricDataQueryCBR, series mathSeries) metricDataResultCBR {
+	row := metricDataResultCBR{ID: q.ID, Label: metricDataLabel(q), StatusCode: statusCodeComplete}
+
+	row.Timestamps = make([]time.Time, len(series.timestamps))
+	for i := range series.timestamps {
+		row.Timestamps[i] = series.timestamps[i].UTC()
 	}
 
-	row := metricDataResultCBR{ID: q.ID, Label: label, StatusCode: statusCodeComplete}
-
-	if res != nil {
-		row.Timestamps = make([]time.Time, len(res.Timestamps))
-		for i := range res.Timestamps {
-			row.Timestamps[i] = res.Timestamps[i].UTC()
-		}
-
-		row.Values = res.Values
-	}
+	row.Values = series.values
 
 	return row
+}
+
+// metricDataLabel resolves the response label for a query: the caller-supplied
+// Label, else the metric name for a MetricStat query, else the query Id.
+func metricDataLabel(q metricDataQueryCBR) string {
+	if q.Label != "" {
+		return q.Label
+	}
+
+	if q.MetricStat != nil {
+		return q.MetricStat.Metric.MetricName
+	}
+
+	return q.ID
 }
 
 type describeAlarmsForMetricInput struct {

--- a/server/aws/cloudwatch/metric_math.go
+++ b/server/aws/cloudwatch/metric_math.go
@@ -1,0 +1,132 @@
+package cloudwatch
+
+// This file implements the metric-math evaluation GetMetricData performs when a
+// query carries an Expression instead of a MetricStat. Expressions reference the
+// Ids of other queries and combine their series with arithmetic operators
+// (+ - * / and parentheses), evaluated element-wise, matching how CloudWatch
+// computes a metric-math row (e.g. "m1*2" or "m1/m2*100").
+
+import (
+	"context"
+	"time"
+
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// mathSeries is a resolved time series: aligned timestamps and values.
+type mathSeries struct {
+	timestamps []time.Time
+	values     []float64
+}
+
+// mathEvaluator resolves each GetMetricData query Id to its series, fetching
+// MetricStat queries from the monitoring driver and computing Expression queries
+// from the series they reference. Results are memoized so a shared input query
+// is fetched once, and an in-progress guard breaks any reference cycle.
+type mathEvaluator struct {
+	ctx        context.Context //nolint:containedctx // short-lived per-request evaluator
+	monitoring mondriver.Monitoring
+	byID       map[string]metricDataQueryCBR
+	start, end time.Time
+	memo       map[string]mathSeries
+	inProgress map[string]bool
+}
+
+func newMathEvaluator(
+	ctx context.Context, mon mondriver.Monitoring, queries []metricDataQueryCBR, start, end time.Time,
+) *mathEvaluator {
+	byID := make(map[string]metricDataQueryCBR, len(queries))
+	for i := range queries {
+		byID[queries[i].ID] = queries[i]
+	}
+
+	return &mathEvaluator{
+		ctx:        ctx,
+		monitoring: mon,
+		byID:       byID,
+		start:      start,
+		end:        end,
+		memo:       make(map[string]mathSeries, len(queries)),
+		inProgress: make(map[string]bool, len(queries)),
+	}
+}
+
+// resolve returns the series for a query Id. A driver failure while fetching a
+// MetricStat query is propagated; an unknown Id or an unparsable expression
+// resolves to an empty series rather than an error.
+func (e *mathEvaluator) resolve(id string) (mathSeries, error) {
+	if s, ok := e.memo[id]; ok {
+		return s, nil
+	}
+
+	if e.inProgress[id] {
+		return mathSeries{}, nil // reference cycle: stop recursing
+	}
+
+	q, ok := e.byID[id]
+	if !ok {
+		return mathSeries{}, nil
+	}
+
+	e.inProgress[id] = true
+	defer delete(e.inProgress, id)
+
+	series, err := e.resolveQuery(q)
+	if err != nil {
+		return mathSeries{}, err
+	}
+
+	e.memo[id] = series
+
+	return series, nil
+}
+
+func (e *mathEvaluator) resolveQuery(q metricDataQueryCBR) (mathSeries, error) {
+	switch {
+	case q.MetricStat != nil:
+		return e.resolveMetricStat(q.MetricStat)
+	case q.Expression != "":
+		return e.evalExpression(q.Expression)
+	default:
+		return mathSeries{}, nil
+	}
+}
+
+func (e *mathEvaluator) resolveMetricStat(ms *metricStatCBR) (mathSeries, error) {
+	res, err := e.monitoring.GetMetricData(e.ctx, mondriver.GetMetricInput{
+		Namespace:  ms.Metric.Namespace,
+		MetricName: ms.Metric.MetricName,
+		Dimensions: toDimensionMap(ms.Metric.Dimensions),
+		StartTime:  e.start,
+		EndTime:    e.end,
+		Period:     ms.Period,
+		Stat:       ms.Stat,
+	})
+	if err != nil {
+		return mathSeries{}, err
+	}
+
+	if res == nil {
+		return mathSeries{}, nil
+	}
+
+	return mathSeries{timestamps: res.Timestamps, values: res.Values}, nil
+}
+
+// evalExpression parses and evaluates a metric-math expression, resolving each
+// referenced query Id to its series. A parse error yields an empty series.
+func (e *mathEvaluator) evalExpression(expr string) (mathSeries, error) {
+	p := &mathParser{tokens: tokenizeMath(expr)}
+
+	val, err := p.parse()
+	if err != nil || !p.atEnd() {
+		return mathSeries{}, nil
+	}
+
+	resolved, driverErr := val.evaluate(e)
+	if driverErr != nil {
+		return mathSeries{}, driverErr
+	}
+
+	return resolved.asSeries(), nil
+}

--- a/server/aws/cloudwatch/metric_math_parser.go
+++ b/server/aws/cloudwatch/metric_math_parser.go
@@ -1,0 +1,344 @@
+package cloudwatch
+
+// A small recursive-descent parser and evaluator for the subset of CloudWatch
+// metric math GetMetricData supports here: numeric literals, references to other
+// query Ids, the binary operators + - * /, unary minus, and parentheses.
+// Expressions are evaluated element-wise across the referenced series.
+
+import (
+	"errors"
+	"strconv"
+	"time"
+)
+
+// errMathParse signals a malformed expression; the caller maps it to an empty
+// series (never surfaced to the client as an error).
+var errMathParse = errors.New("malformed metric math expression")
+
+// mathResult is either a scalar constant or a resolved time series.
+type mathResult struct {
+	isScalar bool
+	scalar   float64
+	series   mathSeries
+}
+
+// asSeries renders a result as a series. A scalar collapses to a single-point
+// series so a top-level constant expression still yields a value row.
+func (r mathResult) asSeries() mathSeries {
+	if !r.isScalar {
+		return r.series
+	}
+
+	return mathSeries{timestamps: []time.Time{{}}, values: []float64{r.scalar}}
+}
+
+// combine applies a binary operator element-wise, broadcasting a scalar operand
+// across the other operand's series.
+func combine(op byte, left, right mathResult) mathResult {
+	if left.isScalar && right.isScalar {
+		return mathResult{isScalar: true, scalar: applyOp(op, left.scalar, right.scalar)}
+	}
+
+	if left.isScalar {
+		return scalarSeries(op, left.scalar, right.series, true)
+	}
+
+	if right.isScalar {
+		return scalarSeries(op, right.scalar, left.series, false)
+	}
+
+	return seriesSeries(op, left.series, right.series)
+}
+
+func scalarSeries(op byte, scalar float64, s mathSeries, scalarLeft bool) mathResult {
+	values := make([]float64, len(s.values))
+
+	for i, v := range s.values {
+		if scalarLeft {
+			values[i] = applyOp(op, scalar, v)
+		} else {
+			values[i] = applyOp(op, v, scalar)
+		}
+	}
+
+	return mathResult{series: mathSeries{timestamps: s.timestamps, values: values}}
+}
+
+func seriesSeries(op byte, left, right mathSeries) mathResult {
+	n := len(left.values)
+	if len(right.values) < n {
+		n = len(right.values)
+	}
+
+	values := make([]float64, n)
+	for i := 0; i < n; i++ {
+		values[i] = applyOp(op, left.values[i], right.values[i])
+	}
+
+	return mathResult{series: mathSeries{timestamps: left.timestamps[:n], values: values}}
+}
+
+func applyOp(op byte, a, b float64) float64 {
+	switch op {
+	case '+':
+		return a + b
+	case '-':
+		return a - b
+	case '*':
+		return a * b
+	case '/':
+		if b == 0 {
+			return 0
+		}
+
+		return a / b
+	default:
+		return 0
+	}
+}
+
+// mathNode is a parsed expression node evaluated against the evaluator so that
+// references resolve to the series of other queries.
+type mathNode interface {
+	evaluate(e *mathEvaluator) (mathResult, error)
+}
+
+type numberNode struct{ val float64 }
+
+func (n numberNode) evaluate(*mathEvaluator) (mathResult, error) {
+	return mathResult{isScalar: true, scalar: n.val}, nil
+}
+
+type refNode struct{ id string }
+
+func (n refNode) evaluate(e *mathEvaluator) (mathResult, error) {
+	series, err := e.resolve(n.id)
+	if err != nil {
+		return mathResult{}, err
+	}
+
+	return mathResult{series: series}, nil
+}
+
+type negNode struct{ operand mathNode }
+
+func (n negNode) evaluate(e *mathEvaluator) (mathResult, error) {
+	v, err := n.operand.evaluate(e)
+	if err != nil {
+		return mathResult{}, err
+	}
+
+	return combine('-', mathResult{isScalar: true, scalar: 0}, v), nil
+}
+
+type binaryNode struct {
+	op          byte
+	left, right mathNode
+}
+
+func (n binaryNode) evaluate(e *mathEvaluator) (mathResult, error) {
+	left, err := n.left.evaluate(e)
+	if err != nil {
+		return mathResult{}, err
+	}
+
+	right, err := n.right.evaluate(e)
+	if err != nil {
+		return mathResult{}, err
+	}
+
+	return combine(n.op, left, right), nil
+}
+
+// mathToken is one lexical unit of an expression.
+type mathToken struct {
+	kind  byte // 'n' number, 'i' ident, or an operator/paren rune
+	num   float64
+	ident string
+}
+
+func tokenizeMath(expr string) []mathToken {
+	var tokens []mathToken
+
+	for i := 0; i < len(expr); {
+		c := expr[i]
+
+		switch {
+		case isSpace(c):
+			i++
+		case isOperatorOrParen(c):
+			tokens = append(tokens, mathToken{kind: c})
+			i++
+		case isNumberStart(c):
+			tok, next := lexNumber(expr, i)
+			tokens = append(tokens, tok)
+			i = next
+		case isIdentStart(c):
+			tok, next := lexIdent(expr, i)
+			tokens = append(tokens, tok)
+			i = next
+		default:
+			// Unknown character: emit a sentinel the parser rejects.
+			tokens = append(tokens, mathToken{kind: '?'})
+			i++
+		}
+	}
+
+	return tokens
+}
+
+func lexNumber(expr string, start int) (tok mathToken, next int) {
+	i := start
+	for i < len(expr) && isNumberStart(expr[i]) {
+		i++
+	}
+
+	val, err := strconv.ParseFloat(expr[start:i], 64)
+	if err != nil {
+		return mathToken{kind: '?'}, i
+	}
+
+	return mathToken{kind: 'n', num: val}, i
+}
+
+func lexIdent(expr string, start int) (tok mathToken, next int) {
+	i := start
+	for i < len(expr) && isIdentPart(expr[i]) {
+		i++
+	}
+
+	return mathToken{kind: 'i', ident: expr[start:i]}, i
+}
+
+func isSpace(c byte) bool { return c == ' ' || c == '\t' }
+func isOperatorOrParen(c byte) bool {
+	return c == '+' || c == '-' || c == '*' || c == '/' || c == '(' || c == ')'
+}
+func isDigit(c byte) bool       { return c >= '0' && c <= '9' }
+func isNumberStart(c byte) bool { return isDigit(c) || c == '.' }
+func isIdentStart(c byte) bool  { return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') }
+func isIdentPart(c byte) bool   { return isIdentStart(c) || isDigit(c) }
+
+// mathParser is a recursive-descent parser over a token slice.
+type mathParser struct {
+	tokens []mathToken
+	pos    int
+}
+
+func (p *mathParser) atEnd() bool { return p.pos >= len(p.tokens) }
+
+func (p *mathParser) peek() (mathToken, bool) {
+	if p.atEnd() {
+		return mathToken{}, false
+	}
+
+	return p.tokens[p.pos], true
+}
+
+func (p *mathParser) parse() (mathNode, error) {
+	if len(p.tokens) == 0 {
+		return nil, errMathParse
+	}
+
+	return p.parseExpr()
+}
+
+func (p *mathParser) parseExpr() (mathNode, error) {
+	node, err := p.parseTerm()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		tok, ok := p.peek()
+		if !ok || (tok.kind != '+' && tok.kind != '-') {
+			return node, nil
+		}
+
+		p.pos++
+
+		right, rerr := p.parseTerm()
+		if rerr != nil {
+			return nil, rerr
+		}
+
+		node = binaryNode{op: tok.kind, left: node, right: right}
+	}
+}
+
+func (p *mathParser) parseTerm() (mathNode, error) {
+	node, err := p.parseFactor()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		tok, ok := p.peek()
+		if !ok || (tok.kind != '*' && tok.kind != '/') {
+			return node, nil
+		}
+
+		p.pos++
+
+		right, rerr := p.parseFactor()
+		if rerr != nil {
+			return nil, rerr
+		}
+
+		node = binaryNode{op: tok.kind, left: node, right: right}
+	}
+}
+
+func (p *mathParser) parseFactor() (mathNode, error) {
+	tok, ok := p.peek()
+	if !ok {
+		return nil, errMathParse
+	}
+
+	if tok.kind == '-' {
+		p.pos++
+
+		operand, err := p.parseFactor()
+		if err != nil {
+			return nil, err
+		}
+
+		return negNode{operand: operand}, nil
+	}
+
+	return p.parsePrimary()
+}
+
+func (p *mathParser) parsePrimary() (mathNode, error) {
+	tok, ok := p.peek()
+	if !ok {
+		return nil, errMathParse
+	}
+
+	switch tok.kind {
+	case 'n':
+		p.pos++
+		return numberNode{val: tok.num}, nil
+	case 'i':
+		p.pos++
+		return refNode{id: tok.ident}, nil
+	case '(':
+		p.pos++
+
+		inner, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+
+		closing, has := p.peek()
+		if !has || closing.kind != ')' {
+			return nil, errMathParse
+		}
+
+		p.pos++
+
+		return inner, nil
+	default:
+		return nil, errMathParse
+	}
+}

--- a/server/aws/cloudwatch/metric_math_test.go
+++ b/server/aws/cloudwatch/metric_math_test.go
@@ -1,0 +1,78 @@
+package cloudwatch_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awscw "github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+)
+
+// TestSDKGetMetricDataExpression covers finding 6: a raw metric query with
+// ReturnData=false is used only as an input and is not returned, while a math
+// expression referencing it returns its computed series.
+func TestSDKGetMetricDataExpression(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	base := time.Now().UTC().Truncate(time.Minute)
+	for i, v := range []float64{10, 20, 30} {
+		if _, err := client.PutMetricData(ctx, &awscw.PutMetricDataInput{
+			Namespace: aws.String("MyApp"),
+			MetricData: []cwtypes.MetricDatum{{
+				MetricName: aws.String("Latency"),
+				Value:      aws.Float64(v),
+				Timestamp:  aws.Time(base.Add(time.Duration(i) * time.Minute)),
+			}},
+		}); err != nil {
+			t.Fatalf("PutMetricData: %v", err)
+		}
+	}
+
+	out, err := client.GetMetricData(ctx, &awscw.GetMetricDataInput{
+		StartTime: aws.Time(base.Add(-time.Minute)),
+		EndTime:   aws.Time(base.Add(10 * time.Minute)),
+		MetricDataQueries: []cwtypes.MetricDataQuery{
+			{
+				Id: aws.String("m1"),
+				MetricStat: &cwtypes.MetricStat{
+					Metric: &cwtypes.Metric{
+						Namespace:  aws.String("MyApp"),
+						MetricName: aws.String("Latency"),
+					},
+					Period: aws.Int32(60),
+					Stat:   aws.String("Sum"),
+				},
+				ReturnData: aws.Bool(false),
+			},
+			{
+				Id:         aws.String("e1"),
+				Expression: aws.String("m1*2"),
+				ReturnData: aws.Bool(true),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetMetricData: %v", err)
+	}
+
+	// Only e1 is returned; the ReturnData=false input query is dropped.
+	if len(out.MetricDataResults) != 1 {
+		t.Fatalf("results = %+v, want exactly 1 (only e1)", out.MetricDataResults)
+	}
+
+	res := out.MetricDataResults[0]
+	if aws.ToString(res.Id) != "e1" {
+		t.Fatalf("result Id = %q, want e1", aws.ToString(res.Id))
+	}
+
+	var total float64
+	for _, v := range res.Values {
+		total += v
+	}
+
+	// m1 = 10+20+30 = 60; e1 = m1*2 element-wise => 20+40+60 = 120.
+	if total != 120 {
+		t.Fatalf("summed e1 values = %v, want 120 (2*(10+20+30))", total)
+	}
+}

--- a/server/aws/eventbridge/operations.go
+++ b/server/aws/eventbridge/operations.go
@@ -9,6 +9,15 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
+// maxPutEventsEntries is the maximum number of entries EventBridge accepts in a
+// single PutEvents request.
+const maxPutEventsEntries = 10
+
+// putEventsEntryCountMessage is the ValidationException detail EventBridge
+// returns when a PutEvents request carries fewer than 1 or more than 10 entries.
+const putEventsEntryCountMessage = "1 validation error detected: Value at 'entries' failed to satisfy " +
+	"constraint: Member must have length less than or equal to 10 and greater than or equal to 1."
+
 // --- event buses ---
 
 func (h *Handler) createEventBus(w http.ResponseWriter, r *http.Request) {
@@ -281,6 +290,13 @@ func (h *Handler) listTargetsByRule(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) putEvents(w http.ResponseWriter, r *http.Request) {
 	var req putEventsRequest
 	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	// EventBridge bounds a PutEvents request to between 1 and 10 entries; an
+	// out-of-range batch is rejected wholesale with a ValidationException.
+	if n := len(req.Entries); n < 1 || n > maxPutEventsEntries {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", putEventsEntryCountMessage)
 		return
 	}
 

--- a/server/aws/eventbridge/put_events_limit_test.go
+++ b/server/aws/eventbridge/put_events_limit_test.go
@@ -1,0 +1,67 @@
+package eventbridge_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKPutEventsTooManyEntries covers finding 7: PutEvents caps a request at 10
+// entries; an 11-entry batch is rejected wholesale with a ValidationException.
+func TestSDKPutEventsTooManyEntries(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	entries := make([]ebtypes.PutEventsRequestEntry, 11)
+	for i := range entries {
+		entries[i] = ebtypes.PutEventsRequestEntry{
+			Source:     aws.String("com.example"),
+			DetailType: aws.String("test"),
+			Detail:     aws.String(fmt.Sprintf(`{"i":%d}`, i)),
+		}
+	}
+
+	_, err := client.PutEvents(ctx, &awseb.PutEventsInput{Entries: entries})
+	if err == nil {
+		t.Fatal("PutEvents with 11 entries succeeded, want ValidationException")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not a smithy.APIError: %v", err)
+	}
+
+	if apiErr.ErrorCode() != "ValidationException" {
+		t.Fatalf("error code = %q, want ValidationException", apiErr.ErrorCode())
+	}
+}
+
+// TestSDKPutEventsAtLimit guards the happy path: exactly 10 entries are accepted.
+func TestSDKPutEventsAtLimit(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	entries := make([]ebtypes.PutEventsRequestEntry, 10)
+	for i := range entries {
+		entries[i] = ebtypes.PutEventsRequestEntry{
+			Source:     aws.String("com.example"),
+			DetailType: aws.String("test"),
+			Detail:     aws.String(fmt.Sprintf(`{"i":%d}`, i)),
+		}
+	}
+
+	out, err := client.PutEvents(ctx, &awseb.PutEventsInput{Entries: entries})
+	if err != nil {
+		t.Fatalf("PutEvents with 10 entries: %v", err)
+	}
+
+	if out.FailedEntryCount != 0 || len(out.Entries) != 10 {
+		t.Fatalf("FailedEntryCount=%d entries=%d, want 0 and 10", out.FailedEntryCount, len(out.Entries))
+	}
+}

--- a/server/aws/sns/subscribe_validation_test.go
+++ b/server/aws/sns/subscribe_validation_test.go
@@ -1,0 +1,67 @@
+package sns_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestSDKSubscribeInvalidProtocol covers finding 5: Subscribe with a protocol
+// outside the supported set must reject with InvalidParameter, not create a
+// subscription.
+func TestSDKSubscribeInvalidProtocol(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	topic, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("proto-topic")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	_, err = client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn: topic.TopicArn,
+		Protocol: aws.String("carrier-pigeon"),
+		Endpoint: aws.String("nowhere"),
+	})
+	if err == nil {
+		t.Fatal("Subscribe with invalid protocol succeeded, want InvalidParameter")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not a smithy.APIError: %v", err)
+	}
+
+	if apiErr.ErrorCode() != "InvalidParameter" {
+		t.Fatalf("error code = %q, want InvalidParameter", apiErr.ErrorCode())
+	}
+}
+
+// TestSDKSubscribeValidProtocol guards the happy path: a supported protocol still
+// creates a subscription.
+func TestSDKSubscribeValidProtocol(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	topic, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("ok-topic")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	out, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn: topic.TopicArn,
+		Protocol: aws.String("email"),
+		Endpoint: aws.String("dev@example.com"),
+	})
+	if err != nil {
+		t.Fatalf("Subscribe with valid protocol: %v", err)
+	}
+
+	if aws.ToString(out.SubscriptionArn) == "" {
+		t.Fatal("Subscribe returned empty SubscriptionArn")
+	}
+}

--- a/server/aws/sqs/batch_validation_test.go
+++ b/server/aws/sqs/batch_validation_test.go
@@ -1,0 +1,165 @@
+package sqs_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+)
+
+// mustCreateQueue creates a standard queue and returns its URL.
+func mustCreateQueue(t *testing.T, client *awssqs.Client, name string) string {
+	t.Helper()
+
+	out, err := client.CreateQueue(context.Background(), &awssqs.CreateQueueInput{QueueName: aws.String(name)})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	return aws.ToString(out.QueueUrl)
+}
+
+// TestSDKSendMessageBatchDuplicateIDs covers finding 1: two entries sharing an Id
+// must reject the whole batch with BatchEntryIdsNotDistinct and enqueue nothing.
+func TestSDKSendMessageBatchDuplicateIDs(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	url := mustCreateQueue(t, client, "dup-batch")
+
+	_, err := client.SendMessageBatch(ctx, &awssqs.SendMessageBatchInput{
+		QueueUrl: aws.String(url),
+		Entries: []types.SendMessageBatchRequestEntry{
+			{Id: aws.String("a"), MessageBody: aws.String("body-a")},
+			{Id: aws.String("a"), MessageBody: aws.String("body-b")},
+		},
+	})
+	if code := apiErrorCode(t, err); code != "BatchEntryIdsNotDistinct" {
+		t.Fatalf("error code = %q, want BatchEntryIdsNotDistinct", code)
+	}
+
+	// The batch must enqueue nothing.
+	recv, err := client.ReceiveMessage(ctx, &awssqs.ReceiveMessageInput{
+		QueueUrl:            aws.String(url),
+		MaxNumberOfMessages: 10,
+	})
+	if err != nil {
+		t.Fatalf("ReceiveMessage: %v", err)
+	}
+
+	if len(recv.Messages) != 0 {
+		t.Fatalf("received %d messages, want 0 (rejected batch must enqueue nothing)", len(recv.Messages))
+	}
+}
+
+// TestSDKSendMessageBatchTooManyEntries covers finding 2: more than 10 entries
+// must reject with TooManyEntriesInBatchRequest.
+func TestSDKSendMessageBatchTooManyEntries(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	url := mustCreateQueue(t, client, "too-many")
+
+	entries := make([]types.SendMessageBatchRequestEntry, 11)
+	for i := range entries {
+		entries[i] = types.SendMessageBatchRequestEntry{
+			Id:          aws.String(fmt.Sprintf("id-%d", i)),
+			MessageBody: aws.String(fmt.Sprintf("body-%d", i)),
+		}
+	}
+
+	_, err := client.SendMessageBatch(ctx, &awssqs.SendMessageBatchInput{
+		QueueUrl: aws.String(url),
+		Entries:  entries,
+	})
+	if code := apiErrorCode(t, err); code != "TooManyEntriesInBatchRequest" {
+		t.Fatalf("error code = %q, want TooManyEntriesInBatchRequest", code)
+	}
+}
+
+// TestSDKSendMessageBatchEmpty covers finding 3: an empty batch must reject with
+// EmptyBatchRequest across all three batch operations.
+func TestSDKSendMessageBatchEmpty(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	url := mustCreateQueue(t, client, "empty-batch")
+
+	_, sendErr := client.SendMessageBatch(ctx, &awssqs.SendMessageBatchInput{
+		QueueUrl: aws.String(url),
+		Entries:  []types.SendMessageBatchRequestEntry{},
+	})
+	if code := apiErrorCode(t, sendErr); code != "EmptyBatchRequest" {
+		t.Fatalf("SendMessageBatch error code = %q, want EmptyBatchRequest", code)
+	}
+
+	_, delErr := client.DeleteMessageBatch(ctx, &awssqs.DeleteMessageBatchInput{
+		QueueUrl: aws.String(url),
+		Entries:  []types.DeleteMessageBatchRequestEntry{},
+	})
+	if code := apiErrorCode(t, delErr); code != "EmptyBatchRequest" {
+		t.Fatalf("DeleteMessageBatch error code = %q, want EmptyBatchRequest", code)
+	}
+
+	_, visErr := client.ChangeMessageVisibilityBatch(ctx, &awssqs.ChangeMessageVisibilityBatchInput{
+		QueueUrl: aws.String(url),
+		Entries:  []types.ChangeMessageVisibilityBatchRequestEntry{},
+	})
+	if code := apiErrorCode(t, visErr); code != "EmptyBatchRequest" {
+		t.Fatalf("ChangeMessageVisibilityBatch error code = %q, want EmptyBatchRequest", code)
+	}
+}
+
+// TestSDKCreateQueueAttributeOutOfRange covers finding 4: an out-of-range numeric
+// queue attribute must reject with InvalidAttributeValue at CreateQueue time.
+func TestSDKCreateQueueAttributeOutOfRange(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{
+		QueueName:  aws.String("bad-vt"),
+		Attributes: map[string]string{"VisibilityTimeout": "99999"},
+	})
+	if code := apiErrorCode(t, err); code != "InvalidAttributeValue" {
+		t.Fatalf("error code = %q, want InvalidAttributeValue", code)
+	}
+}
+
+// TestSDKSetQueueAttributesOutOfRange covers finding 4: SetQueueAttributes must
+// reject an out-of-range value with InvalidAttributeValue.
+func TestSDKSetQueueAttributesOutOfRange(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	url := mustCreateQueue(t, client, "set-attr-range")
+
+	cases := map[string]string{
+		"DelaySeconds":           "901",
+		"MessageRetentionPeriod": "30",
+		"MaximumMessageSize":     "512",
+		"VisibilityTimeout":      "99999",
+	}
+
+	for name, value := range cases {
+		_, err := client.SetQueueAttributes(ctx, &awssqs.SetQueueAttributesInput{
+			QueueUrl:   aws.String(url),
+			Attributes: map[string]string{name: value},
+		})
+		if code := apiErrorCode(t, err); code != "InvalidAttributeValue" {
+			t.Fatalf("%s=%s: error code = %q, want InvalidAttributeValue", name, value, code)
+		}
+	}
+}
+
+// TestSDKSetQueueAttributesInRange guards the happy path: valid values still apply.
+func TestSDKSetQueueAttributesInRange(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	url := mustCreateQueue(t, client, "set-attr-ok")
+
+	if _, err := client.SetQueueAttributes(ctx, &awssqs.SetQueueAttributesInput{
+		QueueUrl:   aws.String(url),
+		Attributes: map[string]string{"VisibilityTimeout": "60", "DelaySeconds": "10"},
+	}); err != nil {
+		t.Fatalf("SetQueueAttributes with valid values: %v", err)
+	}
+}

--- a/server/aws/sqs/handler.go
+++ b/server/aws/sqs/handler.go
@@ -110,6 +110,10 @@ func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !validateQueueAttributeRanges(w, req.Attributes) {
+		return
+	}
+
 	cfg := mqdriver.QueueConfig{
 		Name:                          req.QueueName,
 		FIFO:                          req.Attributes["FifoQueue"] == attrTrue || strings.HasSuffix(req.QueueName, ".fifo"),
@@ -420,6 +424,15 @@ func (h *Handler) changeMessageVisibilityBatch(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	ids := make([]string, len(req.Entries))
+	for i := range req.Entries {
+		ids[i] = req.Entries[i].ID
+	}
+
+	if !validateBatchEntryIDs(w, ids) {
+		return
+	}
+
 	successful := make([]map[string]any, 0, len(req.Entries))
 	failed := make([]map[string]any, 0)
 
@@ -486,6 +499,15 @@ func (h *Handler) sendMessageBatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ids := make([]string, len(req.Entries))
+	for i := range req.Entries {
+		ids[i] = req.Entries[i].ID
+	}
+
+	if !validateBatchEntryIDs(w, ids) {
+		return
+	}
+
 	for i := range req.Entries {
 		if reason := validateSystemAttributes(req.Entries[i].SystemAttributes); reason != "" {
 			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValue", reason)
@@ -522,30 +544,43 @@ func (h *Handler) sendMessageBatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	successful := make([]map[string]any, 0, len(res.Successful))
+	successful := buildSendBatchSuccess(res.Successful, bodyByID, attrsByID, sysAttrsByID)
 
-	for i := range res.Successful {
+	wire.WriteJSON(w, map[string]any{"Successful": successful, "Failed": batchFailed(res.Failed)})
+}
+
+// buildSendBatchSuccess shapes the successful SendMessageBatch entries, attaching
+// the body/attribute MD5 checksums real clients validate, keyed back to each
+// entry by its request Id.
+func buildSendBatchSuccess(
+	entries []mqdriver.BatchSendResultEntry,
+	bodyByID map[string]string,
+	attrsByID, sysAttrsByID map[string]map[string]mqdriver.MessageAttributeValue,
+) []map[string]any {
+	successful := make([]map[string]any, 0, len(entries))
+
+	for i := range entries {
 		entry := map[string]any{
-			"Id":               res.Successful[i].ID,
-			"MessageId":        res.Successful[i].MessageID,
-			"MD5OfMessageBody": md5OfBody(bodyByID[res.Successful[i].ID]),
+			"Id":               entries[i].ID,
+			"MessageId":        entries[i].MessageID,
+			"MD5OfMessageBody": md5OfBody(bodyByID[entries[i].ID]),
 		}
-		if md5Attrs := md5OfMessageAttributes(attrsByID[res.Successful[i].ID]); md5Attrs != "" {
+		if md5Attrs := md5OfMessageAttributes(attrsByID[entries[i].ID]); md5Attrs != "" {
 			entry["MD5OfMessageAttributes"] = md5Attrs
 		}
 
-		if md5Sys := md5OfMessageAttributes(sysAttrsByID[res.Successful[i].ID]); md5Sys != "" {
+		if md5Sys := md5OfMessageAttributes(sysAttrsByID[entries[i].ID]); md5Sys != "" {
 			entry["MD5OfMessageSystemAttributes"] = md5Sys
 		}
 
-		if res.Successful[i].SequenceNumber != "" {
-			entry["SequenceNumber"] = res.Successful[i].SequenceNumber
+		if entries[i].SequenceNumber != "" {
+			entry["SequenceNumber"] = entries[i].SequenceNumber
 		}
 
 		successful = append(successful, entry)
 	}
 
-	wire.WriteJSON(w, map[string]any{"Successful": successful, "Failed": batchFailed(res.Failed)})
+	return successful
 }
 
 func (h *Handler) deleteMessageBatch(w http.ResponseWriter, r *http.Request) {
@@ -558,6 +593,15 @@ func (h *Handler) deleteMessageBatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	ids := make([]string, len(req.Entries))
+	for i := range req.Entries {
+		ids[i] = req.Entries[i].ID
+	}
+
+	if !validateBatchEntryIDs(w, ids) {
 		return
 	}
 
@@ -1012,6 +1056,10 @@ func (h *Handler) setQueueAttributes(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if !validateQueueAttributeRanges(w, req.Attributes) {
 		return
 	}
 

--- a/server/aws/sqs/request_validation.go
+++ b/server/aws/sqs/request_validation.go
@@ -1,0 +1,97 @@
+package sqs
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+)
+
+// maxBatchEntries is the maximum number of entries SQS accepts in a single
+// SendMessageBatch/DeleteMessageBatch/ChangeMessageVisibilityBatch request.
+const maxBatchEntries = 10
+
+// SQS numeric queue-attribute ranges (inclusive), per the SQS API reference.
+const (
+	minVisibilityTimeout = 0
+	maxVisibilityTimeout = 43200
+	minDelaySeconds      = 0
+	maxDelaySeconds      = 900
+	minRetentionPeriod   = 60
+	maxRetentionPeriod   = 1209600
+	minMessageSizeBytes  = 1024
+	maxMessageSizeBytes  = 1048576
+	minWaitTimeSeconds   = 0
+	maxWaitTimeSeconds   = 20
+)
+
+// validateBatchEntryIDs enforces the structural constraints SQS applies to every
+// batch request before any entry is processed: the batch must be non-empty, hold
+// at most 10 entries, and use distinct entry Ids. It writes the matching SQS
+// error (EmptyBatchRequest / TooManyEntriesInBatchRequest / BatchEntryIdsNotDistinct)
+// and reports false when the batch is rejected, so callers enqueue nothing.
+func validateBatchEntryIDs(w http.ResponseWriter, ids []string) bool {
+	if len(ids) == 0 {
+		wire.WriteJSONError(w, http.StatusBadRequest, "EmptyBatchRequest",
+			"The batch request doesn't contain any entries.")
+
+		return false
+	}
+
+	if len(ids) > maxBatchEntries {
+		wire.WriteJSONError(w, http.StatusBadRequest, "TooManyEntriesInBatchRequest",
+			fmt.Sprintf("Maximum number of entries per request are %d. You have sent %d.", maxBatchEntries, len(ids)))
+
+		return false
+	}
+
+	seen := make(map[string]struct{}, len(ids))
+
+	for _, id := range ids {
+		if _, dup := seen[id]; dup {
+			wire.WriteJSONError(w, http.StatusBadRequest, "BatchEntryIdsNotDistinct",
+				fmt.Sprintf("Id %s repeated.", id))
+
+			return false
+		}
+
+		seen[id] = struct{}{}
+	}
+
+	return true
+}
+
+// validateQueueAttributeRanges rejects out-of-range numeric queue attributes with
+// InvalidAttributeValue (HTTP 400), matching real SQS CreateQueue/SetQueueAttributes.
+// Only the numeric attributes present in the map are checked; absent attributes
+// and non-numeric attributes are ignored here. It reports false when rejected.
+func validateQueueAttributeRanges(w http.ResponseWriter, attrs map[string]string) bool {
+	ranges := []struct {
+		name     string
+		min, max int
+	}{
+		{"VisibilityTimeout", minVisibilityTimeout, maxVisibilityTimeout},
+		{"DelaySeconds", minDelaySeconds, maxDelaySeconds},
+		{"MessageRetentionPeriod", minRetentionPeriod, maxRetentionPeriod},
+		{"MaximumMessageSize", minMessageSizeBytes, maxMessageSizeBytes},
+		{"ReceiveMessageWaitTimeSeconds", minWaitTimeSeconds, maxWaitTimeSeconds},
+	}
+
+	for _, rng := range ranges {
+		raw, ok := attrs[rng.name]
+		if !ok {
+			continue
+		}
+
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < rng.min || n > rng.max {
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidAttributeValue",
+				fmt.Sprintf("Invalid value for the parameter %s.", rng.name))
+
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
## Summary

Round-5 messaging validation-parity fixes. Each negative path now returns the exact AWS error code + HTTP 400, verified against the official API references, and covered by real aws-sdk-go-v2 tests.

### SQS SendMessageBatch entry validation (findings 1-3)
- Duplicate entry `Id`s reject the whole batch with `BatchEntryIdsNotDistinct` and enqueue nothing (previously both messages were enqueued and the SDK failed checksum validation).
- More than 10 entries reject with `TooManyEntriesInBatchRequest` (was the generic `InvalidParameterValue` with a leaked `InvalidArgument:` prefix).
- Empty batches reject with `EmptyBatchRequest`; the same guard now covers `DeleteMessageBatch` and `ChangeMessageVisibilityBatch`.

### SQS queue attribute ranges (finding 4)
- `CreateQueue`/`SetQueueAttributes` reject out-of-range numeric attributes with `InvalidAttributeValue`: VisibilityTimeout 0-43200, DelaySeconds 0-900, MessageRetentionPeriod 60-1209600, MaximumMessageSize 1024-1048576, ReceiveMessageWaitTimeSeconds 0-20.

### SNS Subscribe protocol (finding 5)
- `Subscribe` rejects protocols outside `http/https/email/email-json/sms/sqs/application/lambda/firehose` with `InvalidParameter` instead of creating a bogus subscription.

### CloudWatch GetMetricData expressions (finding 6)
- Math-expression queries are now evaluated (arithmetic over referenced query series, e.g. `m1*2`) and returned.
- Queries with `ReturnData=false` are treated as inputs only and no longer emitted as data rows; `ReturnData` defaults to true when omitted.

### EventBridge PutEvents limit (finding 7)
- Requests are bounded to 1..10 entries; an out-of-range batch is rejected wholesale with `ValidationException`.

## Layering
Batch/shape and error-code concerns live in the `server/aws/*` wire handlers; SNS protocol validation lives beside the sibling `Subscribe` checks in `providers/aws/sns`. No driver interfaces changed, so `docs/coverage` is unaffected.

## Tests
Real aws-sdk-go-v2 tests assert the exact error code for every negative case and the corrected response for the CloudWatch expression/ReturnData case, plus happy-path guards.

## Gates
`go build ./...`, `go test ./providers/aws/... ./server/aws/... ./services/...`, and golangci-lint on the changed packages all pass (new code clean).