### PR TITLE
fix(dynamodb-rds): PutItem key/size validation, RDS Engine/DBInstanceClass validation, expression reserved-word/unused-placeholder validation

### DIFF
--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -473,6 +473,11 @@ func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[
 		return nil, err
 	}
 
+	if err := validateItemSize(updated); err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+
 	td.items.Set(k, updated)
 	m.recordStreamEvent(td, oldItem, updated, true)
 	m.mu.Unlock()

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -91,10 +91,16 @@ func New(opts *config.Options) *Mock {
 	return &Mock{tables: make(map[string]*tableData), opts: opts}
 }
 
+// maxItemSizeBytes is the 400 KB ceiling DynamoDB enforces on a single item
+// (the sum of its attribute names and values). A write exceeding it is a
+// ValidationException.
+const maxItemSizeBytes = 400 * 1024
+
 // validateItemKeys enforces the DynamoDB rule that an item written to a table
-// must carry every primary-key attribute, and that each key attribute's type
-// matches the table's AttributeDefinitions. AWS rejects a violation with a
-// ValidationException carrying the exact wording matched here.
+// must carry every primary-key attribute, that each key attribute's type
+// matches the table's AttributeDefinitions, and that no key attribute holds an
+// empty String/Binary value. AWS rejects a violation with a ValidationException
+// carrying the exact wording matched here.
 func validateItemKeys(cfg driver.TableConfig, item map[string]any) error {
 	for _, keyName := range []string{cfg.PartitionKey, cfg.SortKey} {
 		if keyName == "" {
@@ -107,8 +113,137 @@ func validateItemKeys(cfg driver.TableConfig, item map[string]any) error {
 				"One or more parameter values were invalid: Missing the key %s in the item", keyName)
 		}
 
+		if err := validateKeyNotEmpty(keyName, val); err != nil {
+			return err
+		}
+
 		if err := validateKeyType(cfg, keyName, val); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+// validateKeyNotEmpty rejects an empty-string or empty-binary value on a
+// primary-key attribute. A String/Binary attribute may be zero-length only when
+// it is NOT used as a table or index key, so a key with an empty value is the
+// AWS "cannot contain an empty string/binary value" ValidationException.
+func validateKeyNotEmpty(keyName string, val any) error {
+	switch v := val.(type) {
+	case string:
+		if v == "" {
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"One or more parameter values were invalid: "+
+					"The AttributeValue for a key attribute cannot contain an empty string value. Key: %s", keyName)
+		}
+	case []byte:
+		if len(v) == 0 {
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"One or more parameter values were invalid: "+
+					"The AttributeValue for a key attribute cannot contain an empty binary value. Key: %s", keyName)
+		}
+	}
+
+	return nil
+}
+
+// validateItemSize enforces DynamoDB's 400 KB per-item ceiling. The item size
+// is the sum of each attribute's name length (UTF-8 bytes) and value size. AWS
+// rejects an oversized write with a ValidationException.
+func validateItemSize(item map[string]any) error {
+	total := 0
+	for name, val := range item {
+		total += len(name) + valueSize(val)
+	}
+
+	if total > maxItemSizeBytes {
+		return cerrors.New(cerrors.InvalidArgument, "Item size has exceeded the maximum allowed size")
+	}
+
+	return nil
+}
+
+// elementOverhead is the nominal per-element byte charge added when sizing a
+// list, map or set, approximating DynamoDB's per-element structural cost.
+const elementOverhead = 1
+
+// numberSetElementSize is a nominal per-number byte cost used when sizing a
+// number set, whose elements are parsed floats with no retained source text.
+const numberSetElementSize = 8
+
+// valueSize approximates the on-the-wire byte size DynamoDB attributes to a
+// value, enough to enforce the 400 KB item ceiling. Scalars count their raw
+// bytes; documents recurse via collectionSize and charge a small per-element
+// overhead.
+func valueSize(val any) int {
+	switch v := val.(type) {
+	case string:
+		return len(v)
+	case expr.Number:
+		return len(string(v))
+	case []byte:
+		return len(v)
+	case bool, nil:
+		return 1
+	default:
+		return collectionSize(val)
+	}
+}
+
+// collectionSize sizes the document and set attribute types, keeping valueSize
+// within the cyclomatic-complexity budget. An unrecognized value falls back to
+// its formatted string length.
+func collectionSize(val any) int {
+	switch v := val.(type) {
+	case []any:
+		total := 0
+		for _, e := range v {
+			total += valueSize(e) + elementOverhead
+		}
+
+		return total
+	case map[string]any:
+		total := 0
+		for name, e := range v {
+			total += len(name) + valueSize(e) + elementOverhead
+		}
+
+		return total
+	case expr.StringSet:
+		total := 0
+		for _, s := range v {
+			total += len(s) + elementOverhead
+		}
+
+		return total
+	case expr.NumberSet:
+		return len(v) * (numberSetElementSize + elementOverhead)
+	case expr.BinarySet:
+		total := 0
+		for _, b := range v {
+			total += len(b) + elementOverhead
+		}
+
+		return total
+	default:
+		return len(fmt.Sprintf("%v", v))
+	}
+}
+
+// validateKeyMapNotEmpty rejects an empty-string/binary value on any key
+// attribute supplied in a Key map (UpdateItem, DeleteItem), matching the same
+// AWS rule PutItem enforces on the full item.
+func validateKeyMapNotEmpty(partitionKey, sortKey string, key map[string]any) error {
+	for _, keyName := range []string{partitionKey, sortKey} {
+		if keyName == "" {
+			continue
+		}
+
+		if val, present := key[keyName]; present {
+			if err := validateKeyNotEmpty(keyName, val); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -253,6 +388,11 @@ func (m *Mock) PutItem(_ context.Context, table string, item map[string]any) err
 		return err
 	}
 
+	if err := validateItemSize(item); err != nil {
+		m.mu.Unlock()
+		return err
+	}
+
 	key := itemKey(td.config, item)
 	oldItem, hadOld := td.items.Get(key)
 	item = maps.Clone(item)
@@ -307,6 +447,11 @@ func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[
 		return nil, cerrors.Newf(cerrors.NotFound, "table %s not found", input.Table)
 	}
 
+	if err := validateKeyMapNotEmpty(td.config.PartitionKey, td.config.SortKey, input.Key); err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+
 	k := itemKey(td.config, input.Key)
 	item, ok := td.items.Get(k)
 
@@ -346,6 +491,11 @@ func (m *Mock) DeleteItem(_ context.Context, table string, key map[string]any) e
 	if !exists {
 		m.mu.Unlock()
 		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	if err := validateKeyMapNotEmpty(td.config.PartitionKey, td.config.SortKey, key); err != nil {
+		m.mu.Unlock()
+		return err
 	}
 
 	k := itemKey(td.config, key)
@@ -748,6 +898,18 @@ func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string
 	}
 
 	for _, item := range items {
+		if err := validateItemKeys(td.config, item); err != nil {
+			m.mu.Unlock()
+			return err
+		}
+
+		if err := validateItemSize(item); err != nil {
+			m.mu.Unlock()
+			return err
+		}
+	}
+
+	for _, item := range items {
 		key := itemKey(td.config, item)
 		oldItem, hadOld := td.items.Get(key)
 		item = maps.Clone(item)
@@ -1046,6 +1208,22 @@ func (m *Mock) TransactWriteItems(
 	td, exists := m.tables[table]
 	if !exists {
 		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	for _, item := range puts {
+		if err := validateItemKeys(td.config, item); err != nil {
+			return err
+		}
+
+		if err := validateItemSize(item); err != nil {
+			return err
+		}
+	}
+
+	for _, key := range deletes {
+		if err := validateKeyMapNotEmpty(td.config.PartitionKey, td.config.SortKey, key); err != nil {
+			return err
+		}
 	}
 
 	m.applyTransactPuts(td, puts)

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -164,9 +164,13 @@ func validateItemSize(item map[string]any) error {
 	return nil
 }
 
-// elementOverhead is the nominal per-element byte charge added when sizing a
-// list, map or set, approximating DynamoDB's per-element structural cost.
+// elementOverhead is the 1 byte DynamoDB charges per List or Map element, on
+// top of the element's own value size.
 const elementOverhead = 1
+
+// documentContainerOverhead is the flat 3 bytes DynamoDB charges for any List
+// or Map attribute, regardless of its contents.
+const documentContainerOverhead = 3
 
 // numberSetElementSize is a nominal per-number byte cost used when sizing a
 // number set, whose elements are parsed floats with no retained source text.
@@ -197,14 +201,14 @@ func valueSize(val any) int {
 func collectionSize(val any) int {
 	switch v := val.(type) {
 	case []any:
-		total := 0
+		total := documentContainerOverhead
 		for _, e := range v {
 			total += valueSize(e) + elementOverhead
 		}
 
 		return total
 	case map[string]any:
-		total := 0
+		total := documentContainerOverhead
 		for name, e := range v {
 			total += len(name) + valueSize(e) + elementOverhead
 		}
@@ -213,16 +217,16 @@ func collectionSize(val any) int {
 	case expr.StringSet:
 		total := 0
 		for _, s := range v {
-			total += len(s) + elementOverhead
+			total += len(s)
 		}
 
 		return total
 	case expr.NumberSet:
-		return len(v) * (numberSetElementSize + elementOverhead)
+		return len(v) * numberSetElementSize
 	case expr.BinarySet:
 		total := 0
 		for _, b := range v {
-			total += len(b) + elementOverhead
+			total += len(b)
 		}
 
 		return total

--- a/providers/aws/dynamodb/key_size_validation_test.go
+++ b/providers/aws/dynamodb/key_size_validation_test.go
@@ -1,0 +1,125 @@
+package dynamodb
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+// createSingleKeyTable makes a table keyed only on "pk" (no sort key), so an
+// item needs just the partition key.
+func createSingleKeyTable(m *Mock, name string) {
+	_ = m.CreateTable(context.Background(), driver.TableConfig{Name: name, PartitionKey: "pk"})
+}
+
+func TestPutItemEmptyStringKeyRejected(t *testing.T) {
+	m := newTestMock()
+	createSingleKeyTable(m, "t")
+
+	err := m.PutItem(context.Background(), "t", map[string]any{"pk": ""})
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("want InvalidArgument for empty key, got %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "cannot contain an empty string value") {
+		t.Fatalf("message = %q, want empty-string-key wording", err.Error())
+	}
+}
+
+func TestPutItemEmptyBinaryKeyRejected(t *testing.T) {
+	m := newTestMock()
+	createSingleKeyTable(m, "t")
+
+	err := m.PutItem(context.Background(), "t", map[string]any{"pk": []byte{}})
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("want InvalidArgument for empty binary key, got %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "cannot contain an empty binary value") {
+		t.Fatalf("message = %q, want empty-binary-key wording", err.Error())
+	}
+}
+
+func TestPutItemOversizedRejected(t *testing.T) {
+	m := newTestMock()
+	createSingleKeyTable(m, "t")
+
+	err := m.PutItem(context.Background(), "t", map[string]any{
+		"pk":   "k1",
+		"blob": strings.Repeat("a", maxItemSizeBytes+1),
+	})
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("want InvalidArgument for oversized item, got %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "maximum allowed size") {
+		t.Fatalf("message = %q, want item-size wording", err.Error())
+	}
+}
+
+func TestBatchPutOversizedRejected(t *testing.T) {
+	m := newTestMock()
+	createSingleKeyTable(m, "t")
+
+	err := m.BatchPutItems(context.Background(), "t", []map[string]any{
+		{"pk": "ok", "small": "v"},
+		{"pk": "big", "blob": strings.Repeat("a", maxItemSizeBytes+1)},
+	})
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("want InvalidArgument for oversized batch item, got %v", err)
+	}
+
+	// The oversized batch must be rejected wholesale — the valid item must not
+	// have been written either.
+	if _, getErr := m.GetItem(context.Background(), "t", map[string]any{"pk": "ok"}); getErr == nil {
+		t.Fatal("valid item should not persist when the batch is rejected")
+	}
+}
+
+func TestDeleteItemEmptyKeyRejected(t *testing.T) {
+	m := newTestMock()
+	createSingleKeyTable(m, "t")
+
+	err := m.DeleteItem(context.Background(), "t", map[string]any{"pk": ""})
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("want InvalidArgument for empty delete key, got %v", err)
+	}
+}
+
+func TestUpdateItemEmptyKeyRejected(t *testing.T) {
+	m := newTestMock()
+	createSingleKeyTable(m, "t")
+
+	_, err := m.UpdateItem(context.Background(), driver.UpdateItemInput{
+		Table:            "t",
+		Key:              map[string]any{"pk": ""},
+		UpdateExpression: "SET v = :v",
+		ExprValues:       map[string]any{":v": "x"},
+	})
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("want InvalidArgument for empty update key, got %v", err)
+	}
+}
+
+func TestTransactWriteEmptyKeyRejected(t *testing.T) {
+	m := newTestMock()
+	createSingleKeyTable(m, "t")
+
+	err := m.TransactWriteItems(context.Background(), "t",
+		[]map[string]any{{"pk": ""}}, nil)
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("want InvalidArgument for empty transact put key, got %v", err)
+	}
+}
+
+func TestPutItemNonEmptyKeySucceeds(t *testing.T) {
+	m := newTestMock()
+	createSingleKeyTable(m, "t")
+
+	if err := m.PutItem(context.Background(), "t", map[string]any{"pk": "good"}); err != nil {
+		t.Fatalf("valid key put should succeed: %v", err)
+	}
+}

--- a/providers/aws/dynamodb/key_size_validation_test.go
+++ b/providers/aws/dynamodb/key_size_validation_test.go
@@ -104,6 +104,39 @@ func TestUpdateItemEmptyKeyRejected(t *testing.T) {
 	}
 }
 
+func TestUpdateItemOversizedRejected(t *testing.T) {
+	m := newTestMock()
+	createSingleKeyTable(m, "t")
+
+	if err := m.PutItem(context.Background(), "t", map[string]any{"pk": "k1"}); err != nil {
+		t.Fatalf("seed put should succeed: %v", err)
+	}
+
+	_, err := m.UpdateItem(context.Background(), driver.UpdateItemInput{
+		Table:            "t",
+		Key:              map[string]any{"pk": "k1"},
+		UpdateExpression: "SET blob = :b",
+		ExprValues:       map[string]any{":b": strings.Repeat("a", maxItemSizeBytes+1)},
+	})
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("want InvalidArgument for oversized update result, got %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "maximum allowed size") {
+		t.Fatalf("message = %q, want item-size wording", err.Error())
+	}
+
+	// The oversized update must not have persisted; the item stays as seeded.
+	got, getErr := m.GetItem(context.Background(), "t", map[string]any{"pk": "k1"})
+	if getErr != nil {
+		t.Fatalf("seed item should still be readable: %v", getErr)
+	}
+
+	if _, ok := got["blob"]; ok {
+		t.Fatal("oversized attribute should not have been written")
+	}
+}
+
 func TestTransactWriteEmptyKeyRejected(t *testing.T) {
 	m := newTestMock()
 	createSingleKeyTable(m, "t")

--- a/providers/aws/rds/instance_config_validation.go
+++ b/providers/aws/rds/instance_config_validation.go
@@ -1,0 +1,116 @@
+package rds
+
+import (
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// validEngines is the set of Engine values RDS accepts on CreateDBInstance,
+// mirroring the documented enum. Neptune and DocumentDB share the RDS
+// query-protocol wire in cloudemu, so their engine names are accepted here too.
+// AWS rejects any other value with InvalidParameterValue.
+var validEngines = map[string]struct{}{ //nolint:gochecknoglobals // static lookup table
+	"aurora-mysql":          {},
+	"aurora-postgresql":     {},
+	"custom-oracle-ee":      {},
+	"custom-oracle-ee-cdb":  {},
+	"custom-oracle-se2":     {},
+	"custom-oracle-se2-cdb": {},
+	"custom-sqlserver-ee":   {},
+	"custom-sqlserver-se":   {},
+	"custom-sqlserver-web":  {},
+	"custom-sqlserver-dev":  {},
+	"db2-ae":                {},
+	"db2-ce":                {},
+	"db2-se":                {},
+	"mariadb":               {},
+	"mysql":                 {},
+	"oracle-ee":             {},
+	"oracle-ee-cdb":         {},
+	"oracle-se2":            {},
+	"oracle-se2-cdb":        {},
+	"postgres":              {},
+	"sqlserver-dev-ee":      {},
+	"sqlserver-ee":          {},
+	"sqlserver-se":          {},
+	"sqlserver-ex":          {},
+	"sqlserver-web":         {},
+	engineNeptune:           {},
+	engineDocDB:             {},
+}
+
+// instanceClassFamilies is a curated set of the DB instance-class families RDS
+// offers (db.<family>.<size>). The full class enum is region- and
+// engine-dependent, so — like the engine-default parameter tables — this is a
+// representative set broad enough to accept real classes while rejecting a
+// clearly bogus family. Aurora Serverless v2 uses the db.serverless class,
+// handled separately.
+var instanceClassFamilies = map[string]struct{}{ //nolint:gochecknoglobals // static lookup table
+	"t2": {}, "t3": {}, "t4g": {},
+	"m1": {}, "m3": {}, "m4": {}, "m5": {}, "m5d": {}, "m6g": {}, "m6gd": {},
+	"m6i": {}, "m6id": {}, "m7g": {}, "m7i": {}, "m8g": {},
+	"r3": {}, "r4": {}, "r5": {}, "r5b": {}, "r5d": {}, "r6g": {}, "r6gd": {},
+	"r6i": {}, "r6id": {}, "r7g": {}, "r7i": {}, "r8g": {},
+	"x1": {}, "x1e": {}, "x2g": {}, "x2idn": {}, "x2iedn": {}, "x2iezn": {},
+	"z1d": {},
+}
+
+// instanceClassSizes is a curated set of the size suffixes RDS instance classes
+// use. Combined with instanceClassFamilies it validates the db.<family>.<size>
+// shape without hard-coding every region/engine-specific class.
+var instanceClassSizes = map[string]struct{}{ //nolint:gochecknoglobals // static lookup table
+	"micro": {}, "small": {}, "medium": {}, "large": {}, "xlarge": {},
+	"2xlarge": {}, "4xlarge": {}, "6xlarge": {}, "8xlarge": {}, "9xlarge": {},
+	"12xlarge": {}, "16xlarge": {}, "18xlarge": {}, "24xlarge": {}, "32xlarge": {},
+	"48xlarge": {}, "metal": {},
+}
+
+// validateEngine rejects an Engine value outside the accepted enum, matching
+// real RDS which fails CreateDBInstance with InvalidParameterValue.
+func validateEngine(engine string) error {
+	if _, ok := validEngines[strings.ToLower(engine)]; !ok {
+		return cerrors.Newf(cerrors.InvalidArgument, "Invalid DB engine: %s", engine)
+	}
+
+	return nil
+}
+
+// validateInstanceClass rejects a malformed or unknown DBInstanceClass. A class
+// is db.<family>.<size> (or db.serverless for Aurora Serverless v2); an empty
+// class defaults later and is not validated here. Real RDS rejects an invalid
+// class with InvalidParameterValue.
+func validateInstanceClass(class string) error {
+	if class == "" {
+		return nil
+	}
+
+	if class == "db.serverless" {
+		return nil
+	}
+
+	if instanceClassIsValid(class) {
+		return nil
+	}
+
+	return cerrors.Newf(cerrors.InvalidArgument, "Invalid DB instance class: %s", class)
+}
+
+// instanceClassIsValid reports whether class is a db.<family>.<size> string
+// whose family and size are both recognized.
+func instanceClassIsValid(class string) bool {
+	const classParts = 3
+
+	parts := strings.Split(class, ".")
+	if len(parts) != classParts || parts[0] != "db" {
+		return false
+	}
+
+	if _, ok := instanceClassFamilies[parts[1]]; !ok {
+		return false
+	}
+
+	_, ok := instanceClassSizes[parts[2]]
+
+	return ok
+}

--- a/providers/aws/rds/instance_config_validation_test.go
+++ b/providers/aws/rds/instance_config_validation_test.go
@@ -1,0 +1,69 @@
+package rds
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+func TestCreateInstanceRejectsInvalidEngine(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.CreateInstance(context.Background(), rdsdriver.InstanceConfig{
+		ID:            "db1",
+		Engine:        "not-a-real-engine",
+		InstanceClass: "db.t3.micro",
+	})
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("want InvalidArgument for bad engine, got %v", err)
+	}
+
+	// The rejected instance must not have been reserved.
+	if insts, _ := m.DescribeInstances(context.Background(), nil); len(insts) != 0 {
+		t.Fatalf("no instance should be created on a validation failure, got %d", len(insts))
+	}
+}
+
+func TestCreateInstanceRejectsInvalidClass(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.CreateInstance(context.Background(), rdsdriver.InstanceConfig{
+		ID:            "db1",
+		Engine:        "mysql",
+		InstanceClass: "db.bogus.xlarge",
+	})
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("want InvalidArgument for bad instance class, got %v", err)
+	}
+}
+
+func TestCreateInstanceAcceptsKnownEnginesAndClasses(t *testing.T) {
+	cases := []struct {
+		engine string
+		class  string
+	}{
+		{"mysql", "db.t3.micro"},
+		{"postgres", "db.r5.large"},
+		{"aurora-mysql", "db.r6g.2xlarge"},
+		{"aurora-postgresql", "db.serverless"},
+		{"mariadb", ""}, // empty class defaults later
+		{"sqlserver-ex", "db.m5.xlarge"},
+		{"docdb", "db.r5.large"},
+		{"neptune", "db.r5.large"},
+	}
+
+	for _, tc := range cases {
+		m := newTestMock()
+
+		_, err := m.CreateInstance(context.Background(), rdsdriver.InstanceConfig{
+			ID:            "db1",
+			Engine:        tc.engine,
+			InstanceClass: tc.class,
+		})
+		if err != nil {
+			t.Fatalf("engine=%q class=%q should be accepted: %v", tc.engine, tc.class, err)
+		}
+	}
+}

--- a/providers/aws/rds/instance_config_validation_test.go
+++ b/providers/aws/rds/instance_config_validation_test.go
@@ -39,6 +39,61 @@ func TestCreateInstanceRejectsInvalidClass(t *testing.T) {
 	}
 }
 
+func TestModifyInstanceRejectsInvalidClass(t *testing.T) {
+	m := newTestMock()
+
+	if _, err := m.CreateInstance(context.Background(), rdsdriver.InstanceConfig{
+		ID:            "db1",
+		Engine:        "mysql",
+		InstanceClass: "db.t3.micro",
+	}); err != nil {
+		t.Fatalf("create should succeed: %v", err)
+	}
+
+	_, err := m.ModifyInstance(context.Background(), "db1", rdsdriver.ModifyInstanceInput{
+		InstanceClass: "db.bogus.xlarge",
+	})
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("want InvalidArgument for bad instance class, got %v", err)
+	}
+
+	// The invalid class must not have been applied.
+	insts, _ := m.DescribeInstances(context.Background(), []string{"db1"})
+	if len(insts) != 1 || insts[0].InstanceClass != "db.t3.micro" {
+		t.Fatalf("class should stay db.t3.micro, got %+v", insts)
+	}
+}
+
+func TestModifyInstanceAcceptsValidAndEmptyClass(t *testing.T) {
+	m := newTestMock()
+
+	if _, err := m.CreateInstance(context.Background(), rdsdriver.InstanceConfig{
+		ID:            "db1",
+		Engine:        "mysql",
+		InstanceClass: "db.t3.micro",
+	}); err != nil {
+		t.Fatalf("create should succeed: %v", err)
+	}
+
+	// Empty class means "no change" and must not be rejected.
+	if _, err := m.ModifyInstance(context.Background(), "db1", rdsdriver.ModifyInstanceInput{
+		AllocatedStorage: 50,
+	}); err != nil {
+		t.Fatalf("empty class modify should succeed: %v", err)
+	}
+
+	out, err := m.ModifyInstance(context.Background(), "db1", rdsdriver.ModifyInstanceInput{
+		InstanceClass: "db.r5.large",
+	})
+	if err != nil {
+		t.Fatalf("valid class modify should succeed: %v", err)
+	}
+
+	if out.InstanceClass != "db.r5.large" {
+		t.Fatalf("class = %q, want db.r5.large", out.InstanceClass)
+	}
+}
+
 func TestCreateInstanceAcceptsKnownEnginesAndClasses(t *testing.T) {
 	cases := []struct {
 		engine string

--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -347,6 +347,14 @@ func (m *Mock) CreateInstance(ctx context.Context, cfg rdsdriver.InstanceConfig)
 		return nil, cerrors.New(cerrors.InvalidArgument, "Engine is required")
 	}
 
+	if err := validateEngine(cfg.Engine); err != nil {
+		return nil, err
+	}
+
+	if err := validateInstanceClass(cfg.InstanceClass); err != nil {
+		return nil, err
+	}
+
 	inst, plan, err := m.reserveInstance(cfg)
 	if err != nil {
 		return nil, err

--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -615,6 +615,12 @@ func (m *Mock) ModifyInstance(
 		return nil, cerrors.Newf(cerrors.NotFound, "DB instance %q not found", id)
 	}
 
+	// Reject an invalid DBInstanceClass before applying it, mirroring
+	// CreateInstance. An empty class leaves the current one untouched.
+	if err := validateInstanceClass(input.InstanceClass); err != nil {
+		return nil, err
+	}
+
 	// Rotate the master password on the backing engine so the new credential
 	// actually authenticates.
 	if err := m.rotateEnginePassword(ctx, &inst, input.MasterUserPassword); err != nil {

--- a/server/aws/dynamodb/dynamodb_validation_test.go
+++ b/server/aws/dynamodb/dynamodb_validation_test.go
@@ -151,6 +151,84 @@ func TestDDBBatchGetOver100(t *testing.T) {
 	assert.Equal(t, "ValidationException", apiErrorCode(t, err))
 }
 
+// TestDDBPutItemEmptyStringPartitionKey: an empty-string value on the partition
+// key is a ValidationException — a String key attribute may not be zero-length.
+func TestDDBPutItemEmptyStringPartitionKey(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "pk_empty", "id", "")
+
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String("pk_empty"),
+		Item:      map[string]ddbtypes.AttributeValue{"id": sAttr(""), "data": sAttr("x")},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+	assert.Contains(t, err.Error(), "cannot contain an empty string value")
+	assert.Contains(t, err.Error(), "Key: id")
+}
+
+// TestDDBPutItemEmptyStringSortKey: an empty-string value on the sort key is
+// rejected the same way as the partition key.
+func TestDDBPutItemEmptyStringSortKey(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "sk_empty", "id", "sk")
+
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String("sk_empty"),
+		Item:      map[string]ddbtypes.AttributeValue{"id": sAttr("a"), "sk": sAttr("")},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+	assert.Contains(t, err.Error(), "cannot contain an empty string value")
+	assert.Contains(t, err.Error(), "Key: sk")
+}
+
+// TestDDBPutItemExceedsMaxSize: an item larger than the 400 KB ceiling is a
+// ValidationException.
+func TestDDBPutItemExceedsMaxSize(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "big_item", "id", "")
+
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String("big_item"),
+		Item: map[string]ddbtypes.AttributeValue{
+			"id":   sAttr("k1"),
+			"blob": sAttr(strings.Repeat("a", 500*1024)),
+		},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+	assert.Contains(t, err.Error(), "maximum allowed size")
+}
+
+// TestDDBPutItemUnderMaxSizeSucceeds: an item comfortably under 400 KB still
+// writes, guarding against an over-eager size check.
+func TestDDBPutItemUnderMaxSizeSucceeds(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "ok_item", "id", "")
+
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String("ok_item"),
+		Item: map[string]ddbtypes.AttributeValue{
+			"id":   sAttr("k1"),
+			"blob": sAttr(strings.Repeat("a", 100*1024)),
+		},
+	})
+
+	require.NoError(t, err)
+}
+
 // TestDDBUpdateTableAddGSIWithoutAttrDef: creating a GSI via UpdateTable whose
 // key attribute is not supplied in the request AttributeDefinitions is a
 // ValidationException.

--- a/server/aws/dynamodb/dynamodb_validation_test.go
+++ b/server/aws/dynamodb/dynamodb_validation_test.go
@@ -229,6 +229,46 @@ func TestDDBPutItemUnderMaxSizeSucceeds(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestDDBUpdateItemExceedsMaxSize: an UpdateItem whose SET grows the item past
+// the 400 KB ceiling is a ValidationException naming the maximum allowed size.
+func TestDDBUpdateItemExceedsMaxSize(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "upd_big", "id", "")
+	suiteDDBPut(t, client, "upd_big", map[string]ddbtypes.AttributeValue{"id": sAttr("k1")})
+
+	_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName:                 aws.String("upd_big"),
+		Key:                       map[string]ddbtypes.AttributeValue{"id": sAttr("k1")},
+		UpdateExpression:          aws.String("SET blob = :b"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":b": sAttr(strings.Repeat("a", 500*1024))},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+	assert.Contains(t, err.Error(), "maximum allowed size")
+}
+
+// TestDDBUpdateItemUnderMaxSizeSucceeds: an UpdateItem whose result stays under
+// 400 KB is accepted, guarding against an over-eager post-update size check.
+func TestDDBUpdateItemUnderMaxSizeSucceeds(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "upd_ok", "id", "")
+	suiteDDBPut(t, client, "upd_ok", map[string]ddbtypes.AttributeValue{"id": sAttr("k1")})
+
+	_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName:                 aws.String("upd_ok"),
+		Key:                       map[string]ddbtypes.AttributeValue{"id": sAttr("k1")},
+		UpdateExpression:          aws.String("SET blob = :b"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":b": sAttr(strings.Repeat("a", 100*1024))},
+	})
+
+	require.NoError(t, err)
+}
+
 // TestDDBUpdateTableAddGSIWithoutAttrDef: creating a GSI via UpdateTable whose
 // key attribute is not supplied in the request AttributeDefinitions is a
 // ValidationException.

--- a/server/aws/rds/create_instance_validation_sdk_roundtrip_test.go
+++ b/server/aws/rds/create_instance_validation_sdk_roundtrip_test.go
@@ -67,6 +67,73 @@ func TestSDKRDSCreateInstanceInvalidClass(t *testing.T) {
 	}
 }
 
+// TestSDKRDSModifyInstanceInvalidClass: ModifyDBInstance with an unknown
+// DBInstanceClass is rejected with InvalidParameterValue, parity with the
+// Create-side validation.
+func TestSDKRDSModifyInstanceInvalidClass(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("mod-bad-class"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		MasterUsername:       aws.String("admin"),
+		MasterUserPassword:   aws.String("supersecret"),
+		AllocatedStorage:     aws.Int32(20),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance should succeed: %v", err)
+	}
+
+	_, err := client.ModifyDBInstance(ctx, &awsrds.ModifyDBInstanceInput{
+		DBInstanceIdentifier: aws.String("mod-bad-class"),
+		DBInstanceClass:      aws.String("db.bogus.xlarge"),
+	})
+	if err == nil {
+		t.Fatal("ModifyDBInstance with an invalid instance class should fail")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not a smithy APIError: %v", err)
+	}
+
+	if apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("ErrorCode = %q, want InvalidParameterValue", apiErr.ErrorCode())
+	}
+}
+
+// TestSDKRDSModifyInstanceValidClass: ModifyDBInstance to a valid
+// DBInstanceClass succeeds and is reported back, guarding against an
+// over-strict validator on the modify path.
+func TestSDKRDSModifyInstanceValidClass(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("mod-good-class"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		MasterUsername:       aws.String("admin"),
+		MasterUserPassword:   aws.String("supersecret"),
+		AllocatedStorage:     aws.Int32(20),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance should succeed: %v", err)
+	}
+
+	out, err := client.ModifyDBInstance(ctx, &awsrds.ModifyDBInstanceInput{
+		DBInstanceIdentifier: aws.String("mod-good-class"),
+		DBInstanceClass:      aws.String("db.r5.large"),
+	})
+	if err != nil {
+		t.Fatalf("ModifyDBInstance with a valid instance class should succeed: %v", err)
+	}
+
+	if aws.ToString(out.DBInstance.DBInstanceClass) != "db.r5.large" {
+		t.Fatalf("DBInstanceClass = %q, want db.r5.large", aws.ToString(out.DBInstance.DBInstanceClass))
+	}
+}
+
 // TestSDKRDSCreateInstanceValidEngineAndClass: a valid engine + class still
 // succeeds, guarding against an over-strict validator.
 func TestSDKRDSCreateInstanceValidEngineAndClass(t *testing.T) {

--- a/server/aws/rds/create_instance_validation_sdk_roundtrip_test.go
+++ b/server/aws/rds/create_instance_validation_sdk_roundtrip_test.go
@@ -1,0 +1,87 @@
+package rds_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestSDKRDSCreateInstanceInvalidEngine: CreateDBInstance with an engine outside
+// the accepted enum is rejected with InvalidParameterValue, matching real RDS —
+// so a typo'd engine fails against cloudemu exactly as it would in production.
+func TestSDKRDSCreateInstanceInvalidEngine(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("bad-engine"),
+		Engine:               aws.String("not-a-real-engine"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		MasterUsername:       aws.String("admin"),
+		MasterUserPassword:   aws.String("supersecret"),
+		AllocatedStorage:     aws.Int32(20),
+	})
+	if err == nil {
+		t.Fatal("CreateDBInstance with an invalid engine should fail")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not a smithy APIError: %v", err)
+	}
+
+	if apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("ErrorCode = %q, want InvalidParameterValue", apiErr.ErrorCode())
+	}
+}
+
+// TestSDKRDSCreateInstanceInvalidClass: CreateDBInstance with an unknown
+// DBInstanceClass is rejected with InvalidParameterValue.
+func TestSDKRDSCreateInstanceInvalidClass(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("bad-class"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.bogus.xlarge"),
+		MasterUsername:       aws.String("admin"),
+		MasterUserPassword:   aws.String("supersecret"),
+		AllocatedStorage:     aws.Int32(20),
+	})
+	if err == nil {
+		t.Fatal("CreateDBInstance with an invalid instance class should fail")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not a smithy APIError: %v", err)
+	}
+
+	if apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("ErrorCode = %q, want InvalidParameterValue", apiErr.ErrorCode())
+	}
+}
+
+// TestSDKRDSCreateInstanceValidEngineAndClass: a valid engine + class still
+// succeeds, guarding against an over-strict validator.
+func TestSDKRDSCreateInstanceValidEngineAndClass(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("good-db"),
+		Engine:               aws.String("postgres"),
+		DBInstanceClass:      aws.String("db.r5.large"),
+		MasterUsername:       aws.String("admin"),
+		MasterUserPassword:   aws.String("supersecret"),
+		AllocatedStorage:     aws.Int32(20),
+	})
+	if err != nil {
+		t.Fatalf("CreateDBInstance with a valid engine/class should succeed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

ROUND-5 deep-audit validation-parity fixes for DynamoDB and RDS. Each negative case now rejects with the exact AWS error code + HTTP 400, so code that passes against cloudemu behaves the same against production.

### DynamoDB PutItem — empty primary-key value (finding 1)
Real DynamoDB rejects an empty String/Binary value on a partition or sort key with `ValidationException` ("The AttributeValue for a key attribute cannot contain an empty string value. Key: <name>"). cloudemu silently stored the item under an empty key. Now rejected in the provider (`validateKeyNotEmpty`), applied across PutItem, BatchWriteItem, TransactWriteItems, and the UpdateItem/DeleteItem key maps.

### DynamoDB PutItem — 400 KB item size (finding 2)
Real DynamoDB rejects an item over 400 KB with `ValidationException` ("Item size has exceeded the maximum allowed size"). cloudemu accepted a ~500 KB item. Now enforced via `validateItemSize` (sum of attribute name + value bytes) on PutItem, BatchWriteItem and TransactWriteItems.

### RDS CreateDBInstance — Engine / DBInstanceClass (finding 3)
Real RDS validates `Engine` against a fixed enum and `DBInstanceClass` against the `db.<family>.<size>` shape, rejecting an unknown value with `InvalidParameterValue`. cloudemu created the instance for `Engine="not-a-real-engine"` and `DBInstanceClass="db.bogus.xlarge"`. Now validated in `CreateInstance` (`validateEngine` / `validateInstanceClass`); Neptune/DocDB engine names — which share the RDS wire in cloudemu — remain accepted, and Aurora Serverless v2's `db.serverless` is allowed.

### Deferred — expression reserved-word / unused-placeholder validation (finding 4, LOW)
Not included. The expression engine (`services/database/driver/expr`) is shared by DynamoDB, Azure Cosmos DB and GCP Firestore, and `expr.ParseUpdate` is called by all three — DynamoDB's reserved-word lexicon and unused-placeholder rules cannot be added to the shared parser without changing Cosmos/Firestore semantics. A correct implementation also needs per-operation reference tracking across the multiple expressions that share one attribute map, UpdateExpression clause-keyword awareness (SET/ADD/REMOVE/DELETE), and coordinated correction of existing DynamoDB grammar tests that intentionally use reserved words as bare identifiers (e.g. `status`, `total`, `missing`, `temp`). It is best done as an isolated DynamoDB-specific change.

## Tests
Real aws-sdk-go-v2 round-trips assert the exact error code for each negative case plus happy-path guards:
- `server/aws/dynamodb/dynamodb_validation_test.go` — empty partition/sort key, oversized item, under-limit success.
- `server/aws/rds/create_instance_validation_sdk_roundtrip_test.go` — invalid engine, invalid class, valid engine+class success.
- Provider unit tests: `providers/aws/dynamodb/key_size_validation_test.go`, `providers/aws/rds/instance_config_validation_test.go`.

## Gates
`go build ./...`, `go test ./providers/aws/... ./server/aws/... ./services/...`, and golangci-lint on changed packages all green (new code clean; remaining lint hits are pre-existing in untouched code).