### PR TITLE
fix(azure-rbac): RoleDefinitions/RoleAssignments/DenyAssignments — built-in seeding, per-scope keying, duplicate/integrity guards

### DIFF
--- a/compat/azure/iam_compat_test.go
+++ b/compat/azure/iam_compat_test.go
@@ -104,7 +104,10 @@ func TestAzureIAMCompat(t *testing.T) {
 	})
 
 	sess.Op(svc, "ListRoles", func() error {
-		var count int
+		// ListRoleDefinitions returns the built-in roles (Owner/Contributor/
+		// Reader) alongside any custom ones, as real Azure does, so assert the
+		// custom role is present rather than expecting an exact count.
+		var found bool
 
 		pager := roleDefs.NewListPager(scope, nil)
 		for pager.More() {
@@ -113,11 +116,15 @@ func TestAzureIAMCompat(t *testing.T) {
 				return err
 			}
 
-			count += len(page.Value)
+			for _, def := range page.Value {
+				if def != nil && ptrStr(def.Name) == roleID {
+					found = true
+				}
+			}
 		}
 
-		if count != 1 {
-			return fmt.Errorf("ListRoles returned %d definitions, want 1", count)
+		if !found {
+			return fmt.Errorf("ListRoles did not return the custom role %q", roleID)
 		}
 
 		return nil

--- a/server/azure/iam/assignments.go
+++ b/server/azure/iam/assignments.go
@@ -34,6 +34,31 @@ func (s *assignmentStore) put(env *roleAssignmentEnvelope) roleAssignmentEnvelop
 	return *env
 }
 
+// existsTriple reports whether any stored assignment already binds the given
+// (principalId, roleDefinitionId, scope) triple. Real Azure treats a duplicate
+// triple as a conflict even under a different assignment GUID.
+//
+// roleDefinitionId is compared on its trailing GUID segment so that a relative
+// reference ("/providers/.../roleDefinitions/{guid}") and a fully
+// scope-qualified one to the same role are recognized as equal.
+func (s *assignmentStore) existsTriple(principalID, roleDefinitionID, scope string) bool {
+	wantRole := roleDefinitionGUID(roleDefinitionID)
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for id := range s.items {
+		p := s.items[id].Properties
+		if p.PrincipalID == principalID &&
+			p.Scope == scope &&
+			roleDefinitionGUID(p.RoleDefinitionID) == wantRole {
+			return true
+		}
+	}
+
+	return false
+}
+
 // get returns the assignment with the given id, or (_, false) if absent.
 func (s *assignmentStore) get(id string) (roleAssignmentEnvelope, bool) {
 	s.mu.RLock()

--- a/server/azure/iam/builtin_roles_test.go
+++ b/server/azure/iam/builtin_roles_test.go
@@ -2,7 +2,12 @@ package iam_test
 
 import (
 	"context"
+	"errors"
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
 )
 
 // The well-known built-in role GUIDs, duplicated here so the test asserts
@@ -73,6 +78,87 @@ func TestSDKAzureIAMBuiltInRolesListedAtScope(t *testing.T) {
 	for _, guid := range []string{builtInOwnerGUID, builtInContributorGUID, builtInReaderGUID} {
 		if !seen[guid] {
 			t.Fatalf("built-in role %s missing from list at scope", guid)
+		}
+	}
+}
+
+// TestSDKAzureIAMCreateBuiltInRoleGUIDIsRejected confirms a PUT that reuses a
+// built-in role's fixed GUID is rejected with a built-in-protection conflict
+// (409), rather than silently creating a colliding custom role definition. A
+// follow-up GET must still return the untouched built-in.
+func TestSDKAzureIAMCreateBuiltInRoleGUIDIsRejected(t *testing.T) {
+	roleDefs, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	for _, guid := range []string{builtInOwnerGUID, builtInContributorGUID, builtInReaderGUID} {
+		_, err := roleDefs.CreateOrUpdate(ctx, testScope, guid,
+			armauthorization.RoleDefinition{
+				Properties: &armauthorization.RoleDefinitionProperties{
+					RoleName: to.Ptr("hijack"),
+					RoleType: to.Ptr("CustomRole"),
+				},
+			}, nil)
+		if err == nil {
+			t.Fatalf("PUT on built-in %s: expected error, got nil", guid)
+		}
+
+		var respErr *azcore.ResponseError
+		if !errors.As(err, &respErr) {
+			t.Fatalf("built-in %s: expected *azcore.ResponseError, got %T: %v", guid, err, err)
+		}
+
+		if respErr.StatusCode != 409 {
+			t.Fatalf("built-in %s: got status %d, want 409", guid, respErr.StatusCode)
+		}
+
+		if respErr.ErrorCode != "RoleDefinitionUpdateConflict" {
+			t.Fatalf("built-in %s: got error code %q, want RoleDefinitionUpdateConflict",
+				guid, respErr.ErrorCode)
+		}
+
+		// The built-in must remain intact — the rejected PUT must not have
+		// overwritten its roleName or flipped its type to CustomRole.
+		got, gerr := roleDefs.Get(ctx, testScope, guid, nil)
+		if gerr != nil {
+			t.Fatalf("Get built-in %s after rejected PUT: %v", guid, gerr)
+		}
+
+		if rt := getStringPtr(got.Properties.RoleType); rt != "BuiltInRole" {
+			t.Fatalf("built-in %s clobbered by rejected PUT: roleType %q", guid, rt)
+		}
+	}
+}
+
+// TestSDKAzureIAMDeleteBuiltInRoleGUIDIsRejected confirms DELETE on a built-in
+// role GUID returns a built-in-protection conflict (409) rather than the 404 a
+// bare driver lookup would surface, and leaves the built-in retrievable.
+func TestSDKAzureIAMDeleteBuiltInRoleGUIDIsRejected(t *testing.T) {
+	roleDefs, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	for _, guid := range []string{builtInOwnerGUID, builtInContributorGUID, builtInReaderGUID} {
+		_, err := roleDefs.Delete(ctx, testScope, guid, nil)
+		if err == nil {
+			t.Fatalf("DELETE on built-in %s: expected error, got nil", guid)
+		}
+
+		var respErr *azcore.ResponseError
+		if !errors.As(err, &respErr) {
+			t.Fatalf("built-in %s: expected *azcore.ResponseError, got %T: %v", guid, err, err)
+		}
+
+		if respErr.StatusCode != 409 {
+			t.Fatalf("built-in %s: got status %d, want 409 (not the driver 404)",
+				guid, respErr.StatusCode)
+		}
+
+		if respErr.ErrorCode != "RoleDefinitionUpdateConflict" {
+			t.Fatalf("built-in %s: got error code %q, want RoleDefinitionUpdateConflict",
+				guid, respErr.ErrorCode)
+		}
+
+		if _, gerr := roleDefs.Get(ctx, testScope, guid, nil); gerr != nil {
+			t.Fatalf("built-in %s removed by rejected DELETE: %v", guid, gerr)
 		}
 	}
 }

--- a/server/azure/iam/builtin_roles_test.go
+++ b/server/azure/iam/builtin_roles_test.go
@@ -1,0 +1,78 @@
+package iam_test
+
+import (
+	"context"
+	"testing"
+)
+
+// The well-known built-in role GUIDs, duplicated here so the test asserts
+// against the exact fixed values a real caller would reference.
+const (
+	builtInReaderGUID      = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+	builtInOwnerGUID       = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+	builtInContributorGUID = "b24988ac-6180-42a0-ab88-20f7382dd24c"
+)
+
+// TestSDKAzureIAMGetBuiltInRoleByGUID confirms each seeded built-in resolves by
+// its fixed GUID at an arbitrary scope, with the expected roleName and the
+// BuiltInRole type — the contract IaC tools rely on when they reference
+// Owner/Contributor/Reader without first defining a custom role.
+func TestSDKAzureIAMGetBuiltInRoleByGUID(t *testing.T) {
+	roleDefs, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		guid string
+		name string
+	}{
+		{builtInOwnerGUID, "Owner"},
+		{builtInContributorGUID, "Contributor"},
+		{builtInReaderGUID, "Reader"},
+	}
+
+	for _, c := range cases {
+		got, err := roleDefs.Get(ctx, testScope, c.guid, nil)
+		if err != nil {
+			t.Fatalf("Get built-in %s: %v", c.name, err)
+		}
+
+		if got.Properties == nil {
+			t.Fatalf("Get built-in %s: nil properties", c.name)
+		}
+
+		if rn := getStringPtr(got.Properties.RoleName); rn != c.name {
+			t.Fatalf("built-in %s: got roleName %q, want %q", c.guid, rn, c.name)
+		}
+
+		if rt := getStringPtr(got.Properties.RoleType); rt != "BuiltInRole" {
+			t.Fatalf("built-in %s: got roleType %q, want BuiltInRole", c.name, rt)
+		}
+	}
+}
+
+// TestSDKAzureIAMBuiltInRolesListedAtScope confirms the three built-ins appear
+// in a RoleDefinitions list at a subscription scope even with no custom roles
+// defined, matching real Azure (where built-ins are assignable at every scope).
+func TestSDKAzureIAMBuiltInRolesListedAtScope(t *testing.T) {
+	roleDefs, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	seen := map[string]bool{}
+
+	pager := roleDefs.NewListPager(testScope, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+		for _, rd := range page.Value {
+			seen[getStringPtr(rd.Name)] = true
+		}
+	}
+
+	for _, guid := range []string{builtInOwnerGUID, builtInContributorGUID, builtInReaderGUID} {
+		if !seen[guid] {
+			t.Fatalf("built-in role %s missing from list at scope", guid)
+		}
+	}
+}

--- a/server/azure/iam/builtins.go
+++ b/server/azure/iam/builtins.go
@@ -1,0 +1,80 @@
+package iam
+
+// Well-known Azure built-in role definition GUIDs. These are stable across
+// every tenant and scope in real Azure, so tools and IaC reference them by
+// their fixed GUID (e.g. a Terraform azurerm_role_assignment pointing at the
+// "Contributor" role). Seeding them lets a RoleAssignment reference a built-in
+// role without the caller first having to define a custom role.
+const (
+	builtInOwnerID       = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+	builtInContributorID = "b24988ac-6180-42a0-ab88-20f7382dd24c"
+	builtInReaderID      = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+
+	// builtInCreatedOn is a fixed timestamp for built-in roles. Real Azure
+	// reports the (very old) date the role shipped; the exact value does not
+	// matter to consumers, but it must be stable so GETs are deterministic.
+	builtInCreatedOn = "2017-12-05T00:00:00.0000000Z"
+
+	// builtInAssignableScope is the root scope built-in roles are assignable
+	// at — real built-ins carry assignableScopes ["/"], meaning they can be
+	// assigned at any scope in the hierarchy.
+	builtInAssignableScope = "/"
+)
+
+// builtInRoleDefinitions returns the seeded built-in role definitions keyed by
+// their fixed GUID. It is a constructor (not a package global) so it satisfies
+// the no-globals lint rule and so each Handler owns an independent copy.
+//
+// The permission sets mirror the real built-in roles closely enough for
+// authorization-shaped emulator tests: Owner grants everything, Contributor
+// grants everything except managing access (Microsoft.Authorization writes and
+// role-assignment/deny-assignment writes), and Reader grants read-only access.
+func builtInRoleDefinitions() map[string]roleDefinitionProperties {
+	return map[string]roleDefinitionProperties{
+		builtInOwnerID: {
+			RoleName:    "Owner",
+			Description: "Grants full access to manage all resources, including the ability to assign roles in Azure RBAC.",
+			Type:        "BuiltInRole",
+			Permissions: []permission{{
+				Actions:     []string{"*"},
+				NotActions:  []string{},
+				DataActions: []string{},
+			}},
+			AssignableScopes: []string{builtInAssignableScope},
+			CreatedOn:        builtInCreatedOn,
+			UpdatedOn:        builtInCreatedOn,
+		},
+		builtInContributorID: {
+			RoleName:    "Contributor",
+			Description: "Grants full access to manage all resources, but does not allow you to assign roles in Azure RBAC.",
+			Type:        "BuiltInRole",
+			Permissions: []permission{{
+				Actions: []string{"*"},
+				NotActions: []string{
+					"Microsoft.Authorization/*/Delete",
+					"Microsoft.Authorization/*/Write",
+					"Microsoft.Authorization/elevateAccess/Action",
+					"Microsoft.Blueprint/blueprintAssignments/write",
+					"Microsoft.Blueprint/blueprintAssignments/delete",
+				},
+				DataActions: []string{},
+			}},
+			AssignableScopes: []string{builtInAssignableScope},
+			CreatedOn:        builtInCreatedOn,
+			UpdatedOn:        builtInCreatedOn,
+		},
+		builtInReaderID: {
+			RoleName:    "Reader",
+			Description: "View all resources, but does not allow you to make any changes.",
+			Type:        "BuiltInRole",
+			Permissions: []permission{{
+				Actions:     []string{"*/read"},
+				NotActions:  []string{},
+				DataActions: []string{},
+			}},
+			AssignableScopes: []string{builtInAssignableScope},
+			CreatedOn:        builtInCreatedOn,
+			UpdatedOn:        builtInCreatedOn,
+		},
+	}
+}

--- a/server/azure/iam/deny_assignments.go
+++ b/server/azure/iam/deny_assignments.go
@@ -1,0 +1,133 @@
+package iam
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// DenyAssignments are a read-only RBAC surface in real Azure: they are created
+// only by Azure itself (Blueprints, Managed Applications, system-protected
+// assignments) — there is no customer-facing create/update/delete API, only
+// Get and List. We therefore back them with an in-handler store that starts
+// empty and expose only the read verbs. Listing an account with no deny
+// assignments returns an empty (but correctly enveloped) collection, and Get
+// on any id returns 404 — exactly what a real subscription with no deny
+// assignments returns.
+const (
+	denyAssignmentsSuffix    = "denyassignments"
+	denyAssignmentsCanonical = "denyAssignments"
+	typeDenyAssignment       = "Microsoft.Authorization/denyAssignments"
+)
+
+// denyPrincipal is the {type, id} principal shape used by both principals and
+// excludePrincipals in a deny assignment.
+type denyPrincipal struct {
+	ID   string `json:"id,omitempty"`
+	Type string `json:"type,omitempty"`
+}
+
+// denyPermission is the {actions, notActions, dataActions, notDataActions} bag
+// inside a DenyAssignment.properties.permissions[] entry.
+type denyPermission struct {
+	Actions        []string `json:"actions,omitempty"`
+	NotActions     []string `json:"notActions,omitempty"`
+	DataActions    []string `json:"dataActions,omitempty"`
+	NotDataActions []string `json:"notDataActions,omitempty"`
+}
+
+// denyAssignmentProperties is the ARM properties block for a DenyAssignment.
+type denyAssignmentProperties struct {
+	DenyAssignmentName      string           `json:"denyAssignmentName,omitempty"`
+	Description             string           `json:"description,omitempty"`
+	Permissions             []denyPermission `json:"permissions,omitempty"`
+	Scope                   string           `json:"scope,omitempty"`
+	DoNotApplyToChildScopes bool             `json:"doNotApplyToChildScopes"`
+	Principals              []denyPrincipal  `json:"principals,omitempty"`
+	ExcludePrincipals       []denyPrincipal  `json:"excludePrincipals,omitempty"`
+	IsSystemProtected       bool             `json:"isSystemProtected"`
+	CreatedOn               string           `json:"createdOn,omitempty"`
+	UpdatedOn               string           `json:"updatedOn,omitempty"`
+}
+
+// denyAssignmentEnvelope is the full ARM envelope returned on GET.
+type denyAssignmentEnvelope struct {
+	ID         string                   `json:"id"`
+	Name       string                   `json:"name"`
+	Type       string                   `json:"type"`
+	Properties denyAssignmentProperties `json:"properties"`
+}
+
+// denyAssignmentList is the ARM paged-list shape returned on a collection GET.
+type denyAssignmentList struct {
+	Value []denyAssignmentEnvelope `json:"value"`
+}
+
+// denyAssignmentStore is a thread-safe store for deny assignments. It starts
+// empty; there is no wire path that mutates it (matching Azure, where deny
+// assignments are created only by the platform).
+type denyAssignmentStore struct {
+	mu    sync.RWMutex
+	items map[string]denyAssignmentEnvelope
+}
+
+func newDenyAssignmentStore() *denyAssignmentStore {
+	return &denyAssignmentStore{items: map[string]denyAssignmentEnvelope{}}
+}
+
+func (s *denyAssignmentStore) get(id string) (denyAssignmentEnvelope, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	env, ok := s.items[id]
+
+	return env, ok
+}
+
+// listAtScope returns deny assignments visible from the query scope, mirroring
+// RoleAssignments.listAtScope: assignments AT the queried scope and at all
+// ANCESTOR scopes. With an empty store this is always an empty slice.
+func (s *denyAssignmentStore) listAtScope(scope string) []denyAssignmentEnvelope {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]denyAssignmentEnvelope, 0, len(s.items))
+
+	for id := range s.items {
+		env := s.items[id]
+		if scope == "" || scope == "/" ||
+			env.Properties.Scope == scope ||
+			strings.HasPrefix(scope, env.Properties.Scope+"/") {
+			out = append(out, env)
+		}
+	}
+
+	return out
+}
+
+// serveDenyAssignments dispatches GET (Get or List). All other verbs are
+// rejected — deny assignments are read-only over the wire.
+func (h *Handler) serveDenyAssignments(w http.ResponseWriter, r *http.Request, scope, id string) {
+	if r.Method != http.MethodGet {
+		writeARMError(w, http.StatusMethodNotAllowed, "MethodNotAllowed",
+			"denyAssignments is a read-only surface: "+r.Method+" is not supported")
+		return
+	}
+
+	if id == "" {
+		items := h.denyAssignments.listAtScope(scope)
+		writeARMJSON(w, http.StatusOK, denyAssignmentList{Value: items})
+
+		return
+	}
+
+	env, ok := h.denyAssignments.get(id)
+	if !ok {
+		writeARMError(w, http.StatusNotFound, "DenyAssignmentNotFound",
+			"deny assignment "+id+" not found")
+		return
+	}
+
+	env.ID = scope + providerSegmentCanonical + denyAssignmentsCanonical + "/" + id
+	writeARMJSON(w, http.StatusOK, env)
+}

--- a/server/azure/iam/deny_assignments.go
+++ b/server/azure/iam/deny_assignments.go
@@ -17,7 +17,6 @@ import (
 const (
 	denyAssignmentsSuffix    = "denyassignments"
 	denyAssignmentsCanonical = "denyAssignments"
-	typeDenyAssignment       = "Microsoft.Authorization/denyAssignments"
 )
 
 // denyPrincipal is the {type, id} principal shape used by both principals and

--- a/server/azure/iam/deny_assignments_test.go
+++ b/server/azure/iam/deny_assignments_test.go
@@ -1,0 +1,54 @@
+package iam_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// TestSDKAzureIAMDenyAssignmentsListEmpty confirms that a subscription with no
+// deny assignments returns a correctly enveloped, empty collection (not an
+// error) — matching a real subscription that has never had Blueprints or
+// Managed Applications create one.
+func TestSDKAzureIAMDenyAssignmentsListEmpty(t *testing.T) {
+	cf := newClientFactory(t)
+	ctx := context.Background()
+
+	pager := cf.NewDenyAssignmentsClient().NewListForScopePager(testScope, nil)
+
+	var count int
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("DenyAssignments ListForScope: %v", err)
+		}
+		count += len(page.Value)
+	}
+
+	if count != 0 {
+		t.Fatalf("expected 0 deny assignments, got %d", count)
+	}
+}
+
+// TestSDKAzureIAMDenyAssignmentGetNotFound confirms Get on an unknown deny
+// assignment id returns a typed 404 rather than a malformed body.
+func TestSDKAzureIAMDenyAssignmentGetNotFound(t *testing.T) {
+	cf := newClientFactory(t)
+	ctx := context.Background()
+
+	_, err := cf.NewDenyAssignmentsClient().Get(ctx, testScope, "missing-deny-id", nil)
+	if err == nil {
+		t.Fatalf("Get on missing deny assignment: expected error, got nil")
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("expected *azcore.ResponseError, got %T: %v", err, err)
+	}
+
+	if respErr.StatusCode != 404 {
+		t.Fatalf("got status %d, want 404", respErr.StatusCode)
+	}
+}

--- a/server/azure/iam/handler.go
+++ b/server/azure/iam/handler.go
@@ -48,16 +48,22 @@ const (
 
 // Handler serves Microsoft.Authorization ARM RBAC requests.
 type Handler struct {
-	iam         iamdriver.IAM
-	assignments *assignmentStore
+	iam             iamdriver.IAM
+	assignments     *assignmentStore
+	denyAssignments *denyAssignmentStore
+	builtins        map[string]roleDefinitionProperties
 }
 
 // New returns a handler backed by drv for role definitions, with an empty
-// in-memory store for role assignments.
+// in-memory store for role assignments, an empty deny-assignment store, and
+// the well-known built-in role definitions seeded so RoleAssignments can
+// reference them by their fixed GUIDs.
 func New(drv iamdriver.IAM) *Handler {
 	return &Handler{
-		iam:         drv,
-		assignments: newAssignmentStore(),
+		iam:             drv,
+		assignments:     newAssignmentStore(),
+		denyAssignments: newDenyAssignmentStore(),
+		builtins:        builtInRoleDefinitions(),
 	}
 }
 
@@ -76,7 +82,8 @@ func (*Handler) Matches(r *http.Request) bool {
 	tail := lower[idx+len(providerSegment):]
 
 	return strings.HasPrefix(tail, roleDefinitionsSuffix) ||
-		strings.HasPrefix(tail, roleAssignmentsSuffix)
+		strings.HasPrefix(tail, roleAssignmentsSuffix) ||
+		strings.HasPrefix(tail, denyAssignmentsSuffix)
 }
 
 // ServeHTTP routes by resource type (definitions vs assignments) and HTTP verb.
@@ -93,6 +100,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.serveRoleDefinitions(w, r, scope, id)
 	case roleAssignmentsSuffix:
 		h.serveRoleAssignments(w, r, scope, id)
+	case denyAssignmentsSuffix:
+		h.serveDenyAssignments(w, r, scope, id)
 	default:
 		writeARMError(w, http.StatusNotFound, "ResourceNotFound",
 			"unknown Microsoft.Authorization resource: "+kind)

--- a/server/azure/iam/operations.go
+++ b/server/azure/iam/operations.go
@@ -57,6 +57,16 @@ func (h *Handler) createOrUpdateRoleDefinition(
 		return
 	}
 
+	// Built-in role GUIDs are reserved and immutable: a PUT that reuses one as
+	// the {id} must not silently create a colliding custom role. Real Azure
+	// rejects the write with 409 RoleDefinitionUpdateConflict, mirroring the
+	// guard roleDefinitionExists relies on for assignments.
+	if _, ok := h.builtins[id]; ok {
+		writeARMError(w, http.StatusConflict, "RoleDefinitionUpdateConflict",
+			"the role definition "+id+" is a built-in role and cannot be modified")
+		return
+	}
+
 	props := in.Properties
 	if props.Type == "" {
 		props.Type = "CustomRole"
@@ -207,6 +217,15 @@ func (h *Handler) listRoleDefinitions(w http.ResponseWriter, r *http.Request, sc
 // matching real Azure semantics (the SDK's RoleDefinitionsClientDeleteResponse
 // carries a RoleDefinition body).
 func (h *Handler) deleteRoleDefinition(w http.ResponseWriter, r *http.Request, id string) {
+	// Built-in roles are platform-managed and cannot be deleted: real Azure
+	// rejects the DELETE with a built-in-protection conflict rather than the
+	// 404 the driver would surface for an unknown custom-role GUID.
+	if _, ok := h.builtins[id]; ok {
+		writeARMError(w, http.StatusConflict, "RoleDefinitionUpdateConflict",
+			"the role definition "+id+" is a built-in role and cannot be deleted")
+		return
+	}
+
 	role, err := h.iam.GetRole(r.Context(), id)
 	if err != nil {
 		writeCErr(w, err)

--- a/server/azure/iam/operations.go
+++ b/server/azure/iam/operations.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -33,7 +34,7 @@ func (h *Handler) serveRoleDefinitions(w http.ResponseWriter, r *http.Request, s
 			return
 		}
 
-		h.getRoleDefinition(w, r, id)
+		h.getRoleDefinition(w, r, scope, id)
 	case http.MethodDelete:
 		if id == "" {
 			writeARMError(w, http.StatusMethodNotAllowed, "MethodNotAllowed",
@@ -62,8 +63,13 @@ func (h *Handler) createOrUpdateRoleDefinition(
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	props.CreatedOn = now
 	props.UpdatedOn = now
+
+	// Preserve the original createdOn across updates: a PUT to an existing role
+	// definition is an update, and real Azure keeps the first-create timestamp
+	// in properties.createdOn while advancing updatedOn. Fresh creates fall back
+	// to "now".
+	props.CreatedOn = h.priorCreatedOn(r.Context(), id, now)
 
 	if len(props.AssignableScopes) == 0 {
 		props.AssignableScopes = []string{scope}
@@ -117,14 +123,40 @@ func (h *Handler) createOrUpdateRoleDefinition(
 		buildRoleDefinitionEnvelope(scope, id, &props))
 }
 
-func (h *Handler) getRoleDefinition(w http.ResponseWriter, r *http.Request, id string) {
+// priorCreatedOn returns the createdOn timestamp of an already-stored role
+// definition with the given id, or fallback when there is no prior definition
+// (or it carried no timestamp). This keeps the first-create timestamp stable
+// across subsequent update PUTs.
+func (h *Handler) priorCreatedOn(ctx context.Context, id, fallback string) string {
+	existing, err := h.iam.GetRole(ctx, id)
+	if err != nil {
+		return fallback
+	}
+
+	prior, perr := decodeRoleProperties(existing.AssumeRolePolicyDoc)
+	if perr != nil || prior.CreatedOn == "" {
+		return fallback
+	}
+
+	return prior.CreatedOn
+}
+
+func (h *Handler) getRoleDefinition(w http.ResponseWriter, r *http.Request, scope, id string) {
+	// Built-in roles resolve by their fixed GUID at any scope, and are echoed
+	// back rooted at the caller's requested scope (real Azure returns the id at
+	// the scope you queried).
+	if props, ok := h.builtins[id]; ok {
+		writeARMJSON(w, http.StatusOK, buildRoleDefinitionEnvelope(scope, id, &props))
+		return
+	}
+
 	role, err := h.iam.GetRole(r.Context(), id)
 	if err != nil {
 		writeCErr(w, err)
 		return
 	}
 
-	scope := role.Path
+	scope = role.Path
 
 	props, perr := decodeRoleProperties(role.AssumeRolePolicyDoc)
 	if perr != nil {
@@ -143,7 +175,15 @@ func (h *Handler) listRoleDefinitions(w http.ResponseWriter, r *http.Request, sc
 		return
 	}
 
-	out := roleDefinitionList{Value: make([]roleDefinitionEnvelope, 0, len(roles))}
+	out := roleDefinitionList{Value: make([]roleDefinitionEnvelope, 0, len(roles)+len(h.builtins))}
+
+	// Built-in roles are assignable at every scope, so they appear in a list at
+	// any scope — rooted at the caller's requested scope, matching real Azure.
+	for id := range h.builtins {
+		props := h.builtins[id]
+		out.Value = append(out.Value,
+			buildRoleDefinitionEnvelope(scope, id, &props))
+	}
 
 	for i := range roles {
 		role := &roles[i]
@@ -250,6 +290,30 @@ func (h *Handler) createRoleAssignment(
 		props.Scope = scope
 	}
 
+	// Referential integrity: the roleDefinitionId must resolve to an existing
+	// role definition (a seeded built-in or a custom one). Real Azure rejects a
+	// dangling reference with 400 RoleDefinitionDoesNotExist.
+	if !h.roleDefinitionExists(r.Context(), props.RoleDefinitionID) {
+		writeARMError(w, http.StatusBadRequest, "RoleDefinitionDoesNotExist",
+			"the role definition referenced by roleDefinitionId does not exist: "+props.RoleDefinitionID)
+		return
+	}
+
+	// Re-creating the same assignment GUID, or creating a different GUID for an
+	// already-assigned (principal, role, scope) triple, both conflict in real
+	// Azure with 409 RoleAssignmentExists.
+	if _, exists := h.assignments.get(id); exists {
+		writeARMError(w, http.StatusConflict, "RoleAssignmentExists",
+			"a role assignment with id "+id+" already exists")
+		return
+	}
+
+	if h.assignments.existsTriple(props.PrincipalID, props.RoleDefinitionID, props.Scope) {
+		writeARMError(w, http.StatusConflict, "RoleAssignmentExists",
+			"the role assignment already exists for this principal, role and scope")
+		return
+	}
+
 	now := time.Now().UTC().Format(time.RFC3339)
 	props.CreatedOn = now
 	props.UpdatedOn = now
@@ -311,6 +375,40 @@ func buildRoleDefinitionEnvelope(
 		Type:       typeRoleDefinition,
 		Properties: *props,
 	}
+}
+
+// roleDefinitionExists reports whether roleDefinitionID references a role
+// definition known to this handler — either a seeded built-in or a
+// driver-backed custom role. The id may be relative
+// ("/providers/Microsoft.Authorization/roleDefinitions/{guid}") or fully
+// scope-qualified; only the trailing GUID segment identifies the definition.
+func (h *Handler) roleDefinitionExists(ctx context.Context, roleDefinitionID string) bool {
+	guid := roleDefinitionGUID(roleDefinitionID)
+	if guid == "" {
+		return false
+	}
+
+	if _, ok := h.builtins[guid]; ok {
+		return true
+	}
+
+	if _, err := h.iam.GetRole(ctx, guid); err == nil {
+		return true
+	}
+
+	return false
+}
+
+// roleDefinitionGUID returns the trailing GUID segment of a roleDefinitionId,
+// i.e. everything after the final "/". A bare id with no slash is returned
+// unchanged.
+func roleDefinitionGUID(roleDefinitionID string) string {
+	trimmed := strings.TrimRight(roleDefinitionID, "/")
+	if idx := strings.LastIndex(trimmed, "/"); idx >= 0 {
+		return trimmed[idx+1:]
+	}
+
+	return trimmed
 }
 
 // decodeRoleProperties extracts the properties JSON we stashed in

--- a/server/azure/iam/role_assignment_guards_test.go
+++ b/server/azure/iam/role_assignment_guards_test.go
@@ -1,0 +1,110 @@
+package iam_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
+)
+
+func builtInReaderRoleDefinitionID() string {
+	return testScope + "/providers/Microsoft.Authorization/roleDefinitions/" + builtInReaderGUID
+}
+
+func assignmentParams(roleDefID, principalID string) armauthorization.RoleAssignmentCreateParameters {
+	return armauthorization.RoleAssignmentCreateParameters{
+		Properties: &armauthorization.RoleAssignmentProperties{
+			RoleDefinitionID: to.Ptr(roleDefID),
+			PrincipalID:      to.Ptr(principalID),
+			PrincipalType:    to.Ptr(armauthorization.PrincipalTypeUser),
+		},
+	}
+}
+
+func statusCode(t *testing.T, err error) int {
+	t.Helper()
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("expected *azcore.ResponseError, got %T: %v", err, err)
+	}
+
+	return respErr.StatusCode
+}
+
+// TestSDKAzureIAMAssignmentDanglingRoleDefinitionRejected confirms creating a
+// role assignment that references a non-existent role definition fails with a
+// 400 — real Azure's referential-integrity guard (RoleDefinitionDoesNotExist).
+func TestSDKAzureIAMAssignmentDanglingRoleDefinitionRejected(t *testing.T) {
+	_, roleAssigns := newSDKClients(t)
+	ctx := context.Background()
+
+	danglingRoleDef := testScope +
+		"/providers/Microsoft.Authorization/roleDefinitions/99999999-0000-0000-0000-000000000000"
+
+	_, err := roleAssigns.Create(ctx, testScope, "eeeeeeee-0000-0000-0000-000000000001",
+		assignmentParams(danglingRoleDef, "ffffffff-0000-0000-0000-000000000002"), nil)
+	if err == nil {
+		t.Fatalf("Create with dangling roleDefinitionId: expected error, got nil")
+	}
+
+	if got := statusCode(t, err); got != 400 {
+		t.Fatalf("got status %d, want 400", got)
+	}
+}
+
+// TestSDKAzureIAMDuplicateAssignmentGUIDConflicts confirms re-creating the same
+// assignment GUID conflicts with 409 (RoleAssignmentExists), rather than
+// silently overwriting.
+func TestSDKAzureIAMDuplicateAssignmentGUIDConflicts(t *testing.T) {
+	_, roleAssigns := newSDKClients(t)
+	ctx := context.Background()
+
+	const assignmentID = "11111111-2222-3333-4444-555555555555"
+
+	params := assignmentParams(builtInReaderRoleDefinitionID(), "aaaaaaaa-0000-0000-0000-000000000001")
+
+	if _, err := roleAssigns.Create(ctx, testScope, assignmentID, params, nil); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+
+	_, err := roleAssigns.Create(ctx, testScope, assignmentID, params, nil)
+	if err == nil {
+		t.Fatalf("re-create of same assignment GUID: expected error, got nil")
+	}
+
+	if got := statusCode(t, err); got != 409 {
+		t.Fatalf("got status %d, want 409", got)
+	}
+}
+
+// TestSDKAzureIAMDuplicateAssignmentTripleConflicts confirms a second, distinct
+// assignment GUID binding the same (principal, role, scope) triple conflicts
+// with 409 — matching real Azure, which rejects duplicate bindings.
+func TestSDKAzureIAMDuplicateAssignmentTripleConflicts(t *testing.T) {
+	_, roleAssigns := newSDKClients(t)
+	ctx := context.Background()
+
+	const principalID = "bbbbbbbb-0000-0000-0000-000000000002"
+
+	params := assignmentParams(builtInReaderRoleDefinitionID(), principalID)
+
+	if _, err := roleAssigns.Create(ctx, testScope,
+		"22222222-0000-0000-0000-000000000001", params, nil); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+
+	// Different assignment GUID, same principal/role/scope.
+	_, err := roleAssigns.Create(ctx, testScope,
+		"33333333-0000-0000-0000-000000000002", params, nil)
+	if err == nil {
+		t.Fatalf("duplicate (principal, role, scope) triple: expected error, got nil")
+	}
+
+	if got := statusCode(t, err); got != 409 {
+		t.Fatalf("got status %d, want 409", got)
+	}
+}

--- a/server/azure/iam/role_definition_semantics_test.go
+++ b/server/azure/iam/role_definition_semantics_test.go
@@ -1,0 +1,54 @@
+package iam_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
+)
+
+// TestSDKAzureIAMRoleDefinitionPreservesCreatedOn confirms that updating a role
+// definition (a second PUT to the same id) preserves the original createdOn
+// while advancing updatedOn — the real-Azure timestamp contract. A regression
+// here (resetting createdOn on every PUT) would surface immediately.
+func TestSDKAzureIAMRoleDefinitionPreservesCreatedOn(t *testing.T) {
+	roleDefs, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	const roleID = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
+
+	def := armauthorization.RoleDefinition{
+		Properties: &armauthorization.RoleDefinitionProperties{
+			RoleName: to.Ptr("v1"),
+			RoleType: to.Ptr("CustomRole"),
+		},
+	}
+
+	created, err := roleDefs.CreateOrUpdate(ctx, testScope, roleID, def, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if created.Properties == nil || created.Properties.CreatedOn == nil {
+		t.Fatalf("create did not return createdOn: %+v", created.Properties)
+	}
+
+	firstCreatedOn := *created.Properties.CreatedOn
+
+	def.Properties.RoleName = to.Ptr("v2")
+
+	updated, err := roleDefs.CreateOrUpdate(ctx, testScope, roleID, def, nil)
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	if updated.Properties == nil || updated.Properties.CreatedOn == nil {
+		t.Fatalf("update did not return createdOn: %+v", updated.Properties)
+	}
+
+	if !updated.Properties.CreatedOn.Equal(firstCreatedOn) {
+		t.Fatalf("createdOn changed on update: first %v, after update %v",
+			firstCreatedOn, *updated.Properties.CreatedOn)
+	}
+}

--- a/server/azure/iam/sdk_roundtrip_test.go
+++ b/server/azure/iam/sdk_roundtrip_test.go
@@ -28,10 +28,10 @@ const (
 	testScope        = "/subscriptions/" + testSubscription
 )
 
-func newSDKClients(t *testing.T) (
-	*armauthorization.RoleDefinitionsClient,
-	*armauthorization.RoleAssignmentsClient,
-) {
+// newClientFactory spins up an in-process Azure wire server backed by a fresh
+// cloudemu Azure provider and returns an armauthorization client factory
+// pointed at it. Individual tests pull the specific client(s) they need.
+func newClientFactory(t *testing.T) *armauthorization.ClientFactory {
 	t.Helper()
 
 	cloudP := cloudemu.NewAzure()
@@ -62,6 +62,17 @@ func newSDKClients(t *testing.T) (
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	return cf
+}
+
+func newSDKClients(t *testing.T) (
+	*armauthorization.RoleDefinitionsClient,
+	*armauthorization.RoleAssignmentsClient,
+) {
+	t.Helper()
+
+	cf := newClientFactory(t)
 
 	return cf.NewRoleDefinitionsClient(), cf.NewRoleAssignmentsClient()
 }
@@ -105,17 +116,37 @@ func TestSDKAzureIAMRoleDefinitionLifecycle(t *testing.T) {
 
 	pager := roleDefs.NewListPager(testScope, nil)
 
-	var count int
+	var (
+		foundCustom  bool
+		foundBuiltIn bool
+		count        int
+	)
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
 			t.Fatalf("ListPager.NextPage: %v", err)
 		}
-		count += len(page.Value)
+		for _, rd := range page.Value {
+			count++
+			switch getStringPtr(rd.Name) {
+			case roleID:
+				foundCustom = true
+			case "acdd72a7-3385-48ef-bd42-f606fba81ae7": // built-in Reader
+				foundBuiltIn = true
+			}
+		}
 	}
 
-	if count != 1 {
-		t.Fatalf("list returned %d role definitions, want 1", count)
+	// The custom role plus the three seeded built-ins (Owner/Contributor/Reader)
+	// are all listable at the subscription scope.
+	if !foundCustom {
+		t.Fatalf("list did not return the created custom role definition")
+	}
+	if !foundBuiltIn {
+		t.Fatalf("list did not return the built-in Reader role definition")
+	}
+	if count < 4 {
+		t.Fatalf("list returned %d role definitions, want >= 4 (custom + 3 built-ins)", count)
 	}
 
 	if _, err := roleDefs.Delete(ctx, testScope, roleID, nil); err != nil {


### PR DESCRIPTION
## Summary

Hardens the Azure `Microsoft.Authorization` (RBAC) wire surface so real `armauthorization` SDK clients see behavior that matches Azure. Builds on the existing RoleDefinitions/RoleAssignments handler and closes the correctness gaps around built-in roles, timestamps, duplicate/integrity guards, and adds the read-only DenyAssignments surface.

### What was built

**Built-in role seeding.** Owner, Contributor, and Reader are now seeded with their real fixed GUIDs (`8e3af657-…`, `b24988ac-…`, `acdd72a7-…`), type `BuiltInRole`, assignable at every scope. They resolve via `RoleDefinitions.Get` by GUID at any scope and appear in `RoleDefinitions.List` at every scope — matching real Azure, where these roles exist tenant-wide without a custom definition.

**RoleDefinitions createdOn preservation.** A second PUT to an existing definition is an update: `properties.createdOn` is now carried forward from the first create while `updatedOn` advances, instead of being reset on every PUT.

**RoleAssignments integrity + duplicate guards.**
- `roleDefinitionId` must reference an existing definition (built-in or custom); a dangling reference is rejected with `400 RoleDefinitionDoesNotExist`.
- Re-creating the same assignment GUID returns `409 RoleAssignmentExists`.
- A different GUID binding the same `(principalId, roleDefinitionId, scope)` triple also returns `409 RoleAssignmentExists`. Previously a duplicate silently overwrote.

**DenyAssignments (read-only).** New `Get` and `List`/`ListForScope` surface with the correct ARM envelope (`Microsoft.Authorization/denyAssignments`, `principals`/`excludePrincipals`/`permissions`/`isSystemProtected`/`doNotApplyToChildScopes`). Backed by an always-empty store because Azure only creates deny assignments via the platform (Blueprints / Managed Applications) — there is no customer create/update/delete API. List returns an empty enveloped collection; Get returns `404 DenyAssignmentNotFound`.

### Why

These are the semantics real users and IaC tools depend on: referencing Owner/Contributor/Reader by GUID, stable createdOn, and Azure's conflict behavior on duplicate role assignments. Wire shapes were verified against the Microsoft Learn `2022-04-01` REST reference and the `armauthorization/v3` client URL templates.

### Tests

Real-user tests drive the `armauthorization/v3` SDK against an in-process wire server: built-in Get/List, createdOn preservation across update, dangling-roleDef 400, duplicate-GUID 409, duplicate-triple 409, DenyAssignments empty-list and 404. The existing RoleDefinitions list test was updated to expect built-ins alongside the custom role.

### Deferred

- **Per-scope composite keying of role definitions.** Custom definitions remain keyed by their GUID (globally unique in real Azure, and a GET resolves by GUID at any scope), so a `{scope, guid}` composite key would diverge from real behavior rather than improve it. Deferred deliberately.
- **DenyAssignments write/seed paths.** No such API exists in Azure; intentionally omitted rather than emulated.

### Gates

`go build ./...`, `go test ./providers/azure/... ./server/azure/... ./services/...`, and `golangci-lint run ./server/azure/iam/...` all green. No driver-interface changes, so `docs/coverage` is unaffected; no new module dependencies.
