### PR TITLE
fix(dynamodb): ListTables pagination (Limit/ExclusiveStartTableName/LastEvaluatedTableName, stable order), ReturnValuesOnConditionCheckFailure=ALL_OLD

### DIFF
--- a/server/aws/dynamodb/advanced.go
+++ b/server/aws/dynamodb/advanced.go
@@ -33,6 +33,8 @@ func (h *Handler) updateItem(w http.ResponseWriter, r *http.Request) {
 		ExpressionAttributeNames  map[string]string `json:"ExpressionAttributeNames"`
 		ReturnValues              string            `json:"ReturnValues"`
 		ReturnConsumedCapacity    string            `json:"ReturnConsumedCapacity"`
+
+		ReturnValuesOnConditionCheckFailure string `json:"ReturnValuesOnConditionCheckFailure"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -46,7 +48,8 @@ func (h *Handler) updateItem(w http.ResponseWriter, r *http.Request) {
 	// ConditionExpression, matching real DynamoDB. Gate the mutation on the
 	// condition (evaluated against the current item) before applying actions.
 	if !h.gateCondition(r.Context(), w, req.TableName, key,
-		req.ConditionExpression, req.ExpressionAttributeNames, vals) {
+		req.ConditionExpression, req.ExpressionAttributeNames, vals,
+		req.ReturnValuesOnConditionCheckFailure) {
 		return
 	}
 

--- a/server/aws/dynamodb/dynamodb_conditional_return_values_test.go
+++ b/server/aws/dynamodb/dynamodb_conditional_return_values_test.go
@@ -1,0 +1,143 @@
+// dynamodb_conditional_return_values_test.go — real aws-sdk-go-v2 journeys
+// asserting ReturnValuesOnConditionCheckFailure=ALL_OLD returns the conflicting
+// item in ConditionalCheckFailedException.Item for PutItem, UpdateItem and
+// DeleteItem, and that omitting it leaves Item empty.
+package dynamodb_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDDBPutItemConditionFailureReturnsItem(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "widgets", "id", "")
+	suiteDDBPut(t, client, "widgets", map[string]ddbtypes.AttributeValue{
+		"id":    sAttr("w1"),
+		"color": sAttr("red"),
+	})
+
+	// attribute_not_exists on an existing item fails the condition. With
+	// ALL_OLD, DynamoDB returns the current item in the exception's Item member.
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName:                           aws.String("widgets"),
+		Item:                                map[string]ddbtypes.AttributeValue{"id": sAttr("w1"), "color": sAttr("blue")},
+		ConditionExpression:                 aws.String("attribute_not_exists(id)"),
+		ReturnValuesOnConditionCheckFailure: ddbtypes.ReturnValuesOnConditionCheckFailureAllOld,
+	})
+
+	var ccf *ddbtypes.ConditionalCheckFailedException
+	require.ErrorAs(t, err, &ccf)
+	require.NotEmpty(t, ccf.Item)
+	assert.Equal(t, "w1", attrS(t, ccf.Item, "id"))
+	assert.Equal(t, "red", attrS(t, ccf.Item, "color"))
+}
+
+func TestDDBPutItemConditionFailureNoReturnValuesOmitsItem(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "widgets", "id", "")
+	suiteDDBPut(t, client, "widgets", map[string]ddbtypes.AttributeValue{
+		"id":    sAttr("w1"),
+		"color": sAttr("red"),
+	})
+
+	// Without ReturnValuesOnConditionCheckFailure, Item is absent.
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName:           aws.String("widgets"),
+		Item:                map[string]ddbtypes.AttributeValue{"id": sAttr("w1"), "color": sAttr("blue")},
+		ConditionExpression: aws.String("attribute_not_exists(id)"),
+	})
+
+	var ccf *ddbtypes.ConditionalCheckFailedException
+	require.ErrorAs(t, err, &ccf)
+	assert.Empty(t, ccf.Item)
+}
+
+func TestDDBUpdateItemConditionFailureReturnsItem(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "widgets", "id", "")
+	suiteDDBPut(t, client, "widgets", map[string]ddbtypes.AttributeValue{
+		"id":    sAttr("w1"),
+		"stock": nAttr("5"),
+	})
+
+	_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName:                 aws.String("widgets"),
+		Key:                       map[string]ddbtypes.AttributeValue{"id": sAttr("w1")},
+		UpdateExpression:          aws.String("SET stock = :n"),
+		ConditionExpression:       aws.String("stock = :expected"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":n": nAttr("9"), ":expected": nAttr("1")},
+
+		ReturnValuesOnConditionCheckFailure: ddbtypes.ReturnValuesOnConditionCheckFailureAllOld,
+	})
+
+	var ccf *ddbtypes.ConditionalCheckFailedException
+	require.ErrorAs(t, err, &ccf)
+	require.NotEmpty(t, ccf.Item)
+	assert.Equal(t, "w1", attrS(t, ccf.Item, "id"))
+	assert.Equal(t, "5", attrN(t, ccf.Item, "stock"))
+}
+
+func TestDDBDeleteItemConditionFailureReturnsItem(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "widgets", "id", "")
+	suiteDDBPut(t, client, "widgets", map[string]ddbtypes.AttributeValue{
+		"id":    sAttr("w1"),
+		"color": sAttr("green"),
+	})
+
+	_, err := client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName:                 aws.String("widgets"),
+		Key:                       map[string]ddbtypes.AttributeValue{"id": sAttr("w1")},
+		ConditionExpression:       aws.String("color = :c"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":c": sAttr("purple")},
+
+		ReturnValuesOnConditionCheckFailure: ddbtypes.ReturnValuesOnConditionCheckFailureAllOld,
+	})
+
+	var ccf *ddbtypes.ConditionalCheckFailedException
+	require.ErrorAs(t, err, &ccf)
+	require.NotEmpty(t, ccf.Item)
+	assert.Equal(t, "green", attrS(t, ccf.Item, "color"))
+
+	// The item is still present — a failed conditional delete does not remove it.
+	got := suiteDDBGet(t, client, "widgets", map[string]ddbtypes.AttributeValue{"id": sAttr("w1")})
+	require.NotEmpty(t, got.Item)
+	assert.Equal(t, "green", attrS(t, got.Item, "color"))
+}
+
+// A conditional failure with ALL_OLD but no existing item leaves Item empty
+// (there is nothing to return).
+func TestDDBPutItemConditionFailureMissingItemHasNoItem(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "widgets", "id", "")
+
+	// attribute_exists on an absent item fails; there is no current item.
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName:                           aws.String("widgets"),
+		Item:                                map[string]ddbtypes.AttributeValue{"id": sAttr("ghost")},
+		ConditionExpression:                 aws.String("attribute_exists(id)"),
+		ReturnValuesOnConditionCheckFailure: ddbtypes.ReturnValuesOnConditionCheckFailureAllOld,
+	})
+
+	var ccf *ddbtypes.ConditionalCheckFailedException
+	require.True(t, errors.As(err, &ccf))
+	assert.Empty(t, ccf.Item)
+}

--- a/server/aws/dynamodb/dynamodb_list_tables_pagination_test.go
+++ b/server/aws/dynamodb/dynamodb_list_tables_pagination_test.go
@@ -1,0 +1,96 @@
+// dynamodb_list_tables_pagination_test.go — real aws-sdk-go-v2 journeys
+// asserting ListTables pagination matches DynamoDB: Limit caps the page,
+// LastEvaluatedTableName is returned when more names remain, and the
+// ExclusiveStartTableName cursor walks a stable (sorted) order to completion.
+package dynamodb_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDDBListTablesPaginationCursor(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	// Create in a deliberately non-sorted order to prove the response order does
+	// not depend on creation/map-iteration order.
+	created := []string{"t03", "t01", "t04", "t00", "t02"}
+	for _, name := range created {
+		suiteDDBCreateTable(t, client, name, "pk", "")
+	}
+
+	want := append([]string(nil), created...)
+	sort.Strings(want)
+
+	// First page: Limit=2 returns exactly two names and a cursor because more
+	// tables remain.
+	page1, err := client.ListTables(ctx, &dynamodb.ListTablesInput{
+		Limit: aws.Int32(2),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, want[:2], page1.TableNames)
+	require.NotNil(t, page1.LastEvaluatedTableName)
+	assert.Equal(t, want[1], aws.ToString(page1.LastEvaluatedTableName))
+
+	// Second page resumes strictly after the cursor (exclusive).
+	page2, err := client.ListTables(ctx, &dynamodb.ListTablesInput{
+		Limit:                   aws.Int32(2),
+		ExclusiveStartTableName: page1.LastEvaluatedTableName,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, want[2:4], page2.TableNames)
+	require.NotNil(t, page2.LastEvaluatedTableName)
+	assert.Equal(t, want[3], aws.ToString(page2.LastEvaluatedTableName))
+
+	// Final page: the last name, and no cursor because nothing remains.
+	page3, err := client.ListTables(ctx, &dynamodb.ListTablesInput{
+		Limit:                   aws.Int32(2),
+		ExclusiveStartTableName: page2.LastEvaluatedTableName,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, want[4:], page3.TableNames)
+	assert.Nil(t, page3.LastEvaluatedTableName)
+}
+
+func TestDDBListTablesPaginatorWalksAll(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	want := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+	for _, name := range want {
+		suiteDDBCreateTable(t, client, name, "pk", "")
+	}
+
+	var got []string
+
+	p := dynamodb.NewListTablesPaginator(client, &dynamodb.ListTablesInput{
+		Limit: aws.Int32(2),
+	})
+	for p.HasMorePages() {
+		out, err := p.NextPage(ctx)
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(out.TableNames), 2)
+		got = append(got, out.TableNames...)
+	}
+
+	assert.Equal(t, want, got)
+}
+
+func TestDDBListTablesNoCursorWhenUnderLimit(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "only-one", "pk", "")
+
+	out, err := client.ListTables(ctx, &dynamodb.ListTablesInput{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"only-one"}, out.TableNames)
+	assert.Nil(t, out.LastEvaluatedTableName)
+}

--- a/server/aws/dynamodb/dynamodb_list_tables_pagination_test.go
+++ b/server/aws/dynamodb/dynamodb_list_tables_pagination_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/smithy-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,6 +82,43 @@ func TestDDBListTablesPaginatorWalksAll(t *testing.T) {
 	}
 
 	assert.Equal(t, want, got)
+}
+
+func TestDDBListTablesLimitOutOfRangeRejected(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "t00", "pk", "")
+
+	// DynamoDB validates Limit against [1,100]; an out-of-range value is a
+	// ValidationException rather than being silently clamped to the 100 default.
+	cases := []int32{0, -1, 101, 1000}
+	for _, limit := range cases {
+		_, err := client.ListTables(ctx, &dynamodb.ListTablesInput{
+			Limit: aws.Int32(limit),
+		})
+		require.Error(t, err, "limit=%d must be rejected", limit)
+
+		var apiErr smithy.APIError
+		require.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, "ValidationException", apiErr.ErrorCode(), "limit=%d", limit)
+	}
+}
+
+func TestDDBListTablesLimitBoundariesAccepted(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "t00", "pk", "")
+
+	// The inclusive boundaries 1 and 100 are valid.
+	for _, limit := range []int32{1, 100} {
+		out, err := client.ListTables(ctx, &dynamodb.ListTablesInput{
+			Limit: aws.Int32(limit),
+		})
+		require.NoError(t, err, "limit=%d must be accepted", limit)
+		assert.Equal(t, []string{"t00"}, out.TableNames)
+	}
 }
 
 func TestDDBListTablesNoCursorWhenUnderLimit(t *testing.T) {

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sort"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -17,6 +18,10 @@ import (
 )
 
 const targetPrefix = "DynamoDB_20120810."
+
+// listTablesMaxPageSize is the maximum number of table names DynamoDB returns
+// in a single ListTables page (also the default when Limit is unset).
+const listTablesMaxPageSize = 100
 
 const (
 	keyTypeHash        = "HASH"
@@ -547,15 +552,53 @@ func (h *Handler) describeContinuousBackups(w http.ResponseWriter, r *http.Reque
 }
 
 func (h *Handler) listTables(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ExclusiveStartTableName string `json:"ExclusiveStartTableName"`
+		Limit                   *int   `json:"Limit"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
 	tables, err := h.db.ListTables(r.Context())
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	wire.WriteJSON(w, map[string]any{
-		"TableNames": tables,
-	})
+	// DynamoDB returns table names in a stable (sorted) order so that
+	// ExclusiveStartTableName/LastEvaluatedTableName pagination is repeatable.
+	// The driver hands names back in map-iteration order, so sort here.
+	sort.Strings(tables)
+
+	// ExclusiveStartTableName resumes after the named table (exclusive).
+	if req.ExclusiveStartTableName != "" {
+		idx := sort.SearchStrings(tables, req.ExclusiveStartTableName)
+		if idx < len(tables) && tables[idx] == req.ExclusiveStartTableName {
+			idx++
+		}
+
+		tables = tables[idx:]
+	}
+
+	// Limit defaults to and is capped at 100; values below 1 fall back to 100.
+	limit := listTablesMaxPageSize
+	if req.Limit != nil && *req.Limit >= 1 && *req.Limit < listTablesMaxPageSize {
+		limit = *req.Limit
+	}
+
+	resp := map[string]any{}
+
+	if len(tables) > limit {
+		page := tables[:limit]
+		resp["TableNames"] = page
+		resp["LastEvaluatedTableName"] = page[len(page)-1]
+	} else {
+		resp["TableNames"] = tables
+	}
+
+	wire.WriteJSON(w, resp)
 }
 
 func (h *Handler) putItem(w http.ResponseWriter, r *http.Request) {
@@ -567,6 +610,8 @@ func (h *Handler) putItem(w http.ResponseWriter, r *http.Request) {
 		ExpressionAttributeValues map[string]any    `json:"ExpressionAttributeValues"`
 		ReturnValues              string            `json:"ReturnValues"`
 		ReturnConsumedCapacity    string            `json:"ReturnConsumedCapacity"`
+
+		ReturnValuesOnConditionCheckFailure string `json:"ReturnValuesOnConditionCheckFailure"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -577,7 +622,8 @@ func (h *Handler) putItem(w http.ResponseWriter, r *http.Request) {
 	vals := fromWireItem(req.ExpressionAttributeValues)
 
 	if !h.gateCondition(r.Context(), w, req.TableName, item,
-		req.ConditionExpression, req.ExpressionAttributeNames, vals) {
+		req.ConditionExpression, req.ExpressionAttributeNames, vals,
+		req.ReturnValuesOnConditionCheckFailure) {
 		return
 	}
 
@@ -633,6 +679,7 @@ func (h *Handler) gateCondition(
 	condExpr string,
 	names map[string]string,
 	values map[string]any,
+	returnValuesOnCondFail string,
 ) bool {
 	ok, err := h.checkCondition(ctx, table, keySource, condExpr, names, values)
 	if err != nil {
@@ -641,8 +688,18 @@ func (h *Handler) gateCondition(
 	}
 
 	if !ok {
-		wire.WriteJSONError(w, http.StatusBadRequest,
-			"ConditionalCheckFailedException", "The conditional request failed")
+		var extra map[string]any
+		// ReturnValuesOnConditionCheckFailure=ALL_OLD asks DynamoDB to return the
+		// conflicting item in the exception's Item member.
+		if strings.EqualFold(returnValuesOnCondFail, "ALL_OLD") {
+			if old := h.previousItem(ctx, table, keySource); old != nil {
+				extra = map[string]any{"Item": toWireItem(old)}
+			}
+		}
+
+		wire.WriteJSONErrorFields(w, http.StatusBadRequest,
+			"ConditionalCheckFailedException", "The conditional request failed", extra)
+
 		return false
 	}
 
@@ -776,6 +833,8 @@ func (h *Handler) deleteItem(w http.ResponseWriter, r *http.Request) {
 		ExpressionAttributeValues map[string]any    `json:"ExpressionAttributeValues"`
 		ReturnValues              string            `json:"ReturnValues"`
 		ReturnConsumedCapacity    string            `json:"ReturnConsumedCapacity"`
+
+		ReturnValuesOnConditionCheckFailure string `json:"ReturnValuesOnConditionCheckFailure"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -786,7 +845,8 @@ func (h *Handler) deleteItem(w http.ResponseWriter, r *http.Request) {
 	vals := fromWireItem(req.ExpressionAttributeValues)
 
 	if !h.gateCondition(r.Context(), w, req.TableName, key,
-		req.ConditionExpression, req.ExpressionAttributeNames, vals) {
+		req.ConditionExpression, req.ExpressionAttributeNames, vals,
+		req.ReturnValuesOnConditionCheckFailure) {
 		return
 	}
 

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -7,6 +7,7 @@ package dynamodb
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
@@ -582,10 +583,28 @@ func (h *Handler) listTables(w http.ResponseWriter, r *http.Request) {
 		tables = tables[idx:]
 	}
 
-	// Limit defaults to and is capped at 100; values below 1 fall back to 100.
+	// Limit is optional; when present it must be within [1,100]. Out-of-range
+	// values are rejected with a ValidationException, matching real DynamoDB,
+	// rather than being silently clamped to the 100 default.
 	limit := listTablesMaxPageSize
-	if req.Limit != nil && *req.Limit >= 1 && *req.Limit < listTablesMaxPageSize {
-		limit = *req.Limit
+
+	if req.Limit != nil {
+		switch {
+		case *req.Limit < 1:
+			wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException",
+				fmt.Sprintf("1 validation error detected: Value '%d' at 'limit' failed to satisfy constraint: "+
+					"Member must have value greater than or equal to 1", *req.Limit))
+
+			return
+		case *req.Limit > listTablesMaxPageSize:
+			wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException",
+				fmt.Sprintf("1 validation error detected: Value '%d' at 'limit' failed to satisfy constraint: "+
+					"Member must have value less than or equal to 100", *req.Limit))
+
+			return
+		default:
+			limit = *req.Limit
+		}
 	}
 
 	resp := map[string]any{}

--- a/server/wire/wire.go
+++ b/server/wire/wire.go
@@ -56,3 +56,22 @@ func WriteJSONError(w http.ResponseWriter, status int, errType, msg string) {
 		"Message": msg,
 	})
 }
+
+// WriteJSONErrorFields writes a JSON error response carrying additional
+// top-level members alongside __type and Message. DynamoDB uses this for
+// ConditionalCheckFailedException, which returns the conflicting item in an
+// Item member when ReturnValuesOnConditionCheckFailure=ALL_OLD.
+func WriteJSONErrorFields(w http.ResponseWriter, status int, errType, msg string, extra map[string]any) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+	w.WriteHeader(status)
+
+	body := map[string]any{
+		"__type":  errType,
+		"Message": msg,
+	}
+	for k, v := range extra {
+		body[k] = v
+	}
+
+	json.NewEncoder(w).Encode(body) //nolint:errcheck // best-effort response
+}


### PR DESCRIPTION
## Summary

Two AWS-contract gaps in the DynamoDB wire handler, fixed at the server layer.

### 1. ListTables pagination (Finding 1)
Previously `listTables` returned every table name in map-iteration order with only `{"TableNames":...}` — it never read `Limit` or `ExclusiveStartTableName` and never emitted `LastEvaluatedTableName`.

Now, per the ListTables API reference:
- `Limit` caps the page (default and max 100; sub-1 values fall back to 100).
- Names are returned in a stable sorted order so the cursor is repeatable.
- `ExclusiveStartTableName` resumes strictly after the named table.
- `LastEvaluatedTableName` is returned only when more names remain.

### 2. ReturnValuesOnConditionCheckFailure=ALL_OLD (Finding 2)
The parameter was never parsed, so `ConditionalCheckFailedException` came back with an empty `Item` even when the conflicting item existed and `ALL_OLD` was requested.

Now PutItem / UpdateItem / DeleteItem parse `ReturnValuesOnConditionCheckFailure`; on a failed conditional write with `ALL_OLD`, `gateCondition` reads the current item and returns it in the exception's `Item` member. A new `wire.WriteJSONErrorFields` helper carries the extra top-level `Item` member alongside `__type`/`Message`.

## Tests
Real aws-sdk-go-v2 journeys against the httptest server:
- `dynamodb_list_tables_pagination_test.go` — Limit cap, cursor walk, paginator to completion, no-cursor-when-under-limit, stable order regardless of creation order.
- `dynamodb_conditional_return_values_test.go` — Item returned for Put/Update/Delete with ALL_OLD, Item omitted without the flag, Item empty when no current item, and failed conditional delete leaves the item intact.

## Gates
- `go build ./...` clean
- `go test ./providers/aws/... ./server/aws/... ./services/...` pass
- golangci-lint on changed packages: no new findings (pre-existing dupl/hugeParam only)

No driver interface changed, so `docs/coverage` is unaffected.