### PR TITLE
fix(errors): EC2 DetachInternetGateway not-attached error, cross-service error message shape parity (EC2/IAM/Lambda/S3)

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -70,6 +70,25 @@ func Newf(code Code, format string, args ...any) *Error {
 	return &Error{Code: code, Message: fmt.Sprintf(format, args...)}
 }
 
+// Message returns the human-readable message of a cloudemu error, without the
+// canonical code prefix that Error() prepends. Wire handlers use this so the
+// error surfaced to an SDK carries only the human message (real AWS never
+// leaks an internal error-taxonomy name into its <Message>/message field).
+// For a nil error it returns "", and for a non-cloudemu error it falls back to
+// err.Error().
+func Message(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var e *Error
+	if errors.As(err, &e) {
+		return e.Message
+	}
+
+	return err.Error()
+}
+
 // GetCode extracts the error code from an error. Returns Internal for non-cloudemu errors
 // and OK for nil errors.
 func GetCode(err error) Code {

--- a/providers/aws/vpc/acl.go
+++ b/providers/aws/vpc/acl.go
@@ -125,7 +125,7 @@ func (m *Mock) DeleteNetworkACL(_ context.Context, id string) error {
 	// caller must move the subnet (ReplaceNetworkAclAssociation) first.
 	if m.aclHasAssociation(id) {
 		return errors.Newf(errors.FailedPrecondition,
-			"DependencyViolation: network ACL %q is associated with a subnet", id)
+			"network ACL %q is associated with a subnet", id)
 	}
 
 	m.networkACLs.Delete(id)

--- a/providers/aws/vpc/dhcp_options.go
+++ b/providers/aws/vpc/dhcp_options.go
@@ -35,7 +35,7 @@ func (m *Mock) DeleteDHCPOptions(_ context.Context, id string) error {
 	for _, v := range m.vpcs.All() {
 		if v.DhcpOptionsID == id {
 			return errors.Newf(errors.FailedPrecondition,
-				"DependencyViolation: dhcp options %q is associated with vpc %q", id, v.ID)
+				"dhcp options %q is associated with vpc %q", id, v.ID)
 		}
 	}
 

--- a/providers/aws/vpc/route_table.go
+++ b/providers/aws/vpc/route_table.go
@@ -71,7 +71,7 @@ func (m *Mock) DeleteRouteTable(_ context.Context, id string) error {
 
 	if rt.IsMain {
 		return errors.Newf(errors.FailedPrecondition,
-			"DependencyViolation: cannot delete the main route table %q of vpc %q", id, rt.VPCID)
+			"cannot delete the main route table %q of vpc %q", id, rt.VPCID)
 	}
 
 	// Real EC2 refuses to delete a route table still associated with a subnet;
@@ -79,7 +79,7 @@ func (m *Mock) DeleteRouteTable(_ context.Context, id string) error {
 	for _, a := range m.rtAssocs.All() {
 		if a.RouteTableID == id && !a.Main {
 			return errors.Newf(errors.FailedPrecondition,
-				"DependencyViolation: route table %q has a subnet association %q and cannot be deleted", id, a.ID)
+				"route table %q has a subnet association %q and cannot be deleted", id, a.ID)
 		}
 	}
 

--- a/providers/aws/vpc/traffic_mirror.go
+++ b/providers/aws/vpc/traffic_mirror.go
@@ -68,7 +68,7 @@ func (m *Mock) DeleteTrafficMirrorTarget(_ context.Context, id string) error {
 
 	if sid, inUse := m.sessionReferencingTarget(id); inUse {
 		return errors.Newf(errors.FailedPrecondition,
-			"DependencyViolation: traffic mirror session %q still references target %q", sid, id)
+			"traffic mirror session %q still references target %q", sid, id)
 	}
 
 	m.trafficMirrorTargets.Delete(id)
@@ -136,7 +136,7 @@ func (m *Mock) DeleteTrafficMirrorFilter(_ context.Context, id string) error {
 
 	if sid, inUse := m.sessionReferencingFilter(id); inUse {
 		return errors.Newf(errors.FailedPrecondition,
-			"DependencyViolation: traffic mirror session %q still references filter %q", sid, id)
+			"traffic mirror session %q still references filter %q", sid, id)
 	}
 
 	m.trafficMirrorFilters.Delete(id)

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -358,7 +358,7 @@ func (m *Mock) DeleteVPC(_ context.Context, id string) error {
 	// refuses, and a caller whose drain is broken never finds out.
 	if eni, blocked := m.attachedENIIn(id, ""); blocked {
 		return errors.Newf(errors.FailedPrecondition,
-			"DependencyViolation: network interface %q is still attached in vpc %q", eni, id)
+			"network interface %q is still attached in vpc %q", eni, id)
 	}
 
 	// Real EC2 refuses the delete while user-managed dependencies remain and
@@ -367,7 +367,7 @@ func (m *Mock) DeleteVPC(_ context.Context, id string) error {
 	// the VPC — so it is deliberately absent from the dependency scan.
 	if dep, blocked := m.vpcDependency(id); blocked {
 		return errors.Newf(errors.FailedPrecondition,
-			"DependencyViolation: the vpc %q has dependencies and cannot be deleted (%s)", id, dep)
+			"the vpc %q has dependencies and cannot be deleted (%s)", id, dep)
 	}
 
 	m.vpcs.Delete(id)
@@ -550,7 +550,7 @@ func (m *Mock) DeleteSubnet(_ context.Context, id string) error {
 	// one. Accepting the delete otherwise lets a broken drain pass unnoticed.
 	if eni, blocked := m.eniInSubnet(id); blocked {
 		return errors.Newf(errors.FailedPrecondition,
-			"DependencyViolation: network interface %q still resides in subnet %q", eni, id)
+			"network interface %q still resides in subnet %q", eni, id)
 	}
 
 	m.subnets.Delete(id)
@@ -766,7 +766,7 @@ func (m *Mock) DeleteSecurityGroup(_ context.Context, id string) error {
 	// network interface or referenced by another security group in the VPC.
 	if dep, blocked := m.securityGroupInUse(id); blocked {
 		return errors.Newf(errors.FailedPrecondition,
-			"DependencyViolation: security group %q is in use by %s", id, dep)
+			"security group %q is in use by %s", id, dep)
 	}
 
 	m.securityGroups.Delete(id)

--- a/server/aws/ec2/error_shape_test.go
+++ b/server/aws/ec2/error_shape_test.go
@@ -1,0 +1,187 @@
+package ec2_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	smithy "github.com/aws/smithy-go"
+)
+
+// leakedPrefixes are the internal cloudemu error-taxonomy names that must never
+// appear as a prefix on a wire error message. Real AWS surfaces only the human
+// sentence in <Message>.
+var leakedPrefixes = []string{ //nolint:gochecknoglobals // shared test fixture
+	"FailedPrecondition:",
+	"NotFound:",
+	"AlreadyExists:",
+	"InvalidArgument:",
+	"DependencyViolation:",
+	"PermissionDenied:",
+	"Internal:",
+}
+
+func apiMessage(t *testing.T, err error) string {
+	t.Helper()
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected an API error, got %v", err)
+	}
+
+	return apiErr.ErrorMessage()
+}
+
+func assertNoLeakedPrefix(t *testing.T, msg string) {
+	t.Helper()
+
+	for _, p := range leakedPrefixes {
+		if strings.HasPrefix(msg, p) || strings.Contains(msg, " "+p) {
+			t.Errorf("wire message %q leaks internal error-code prefix %q", msg, p)
+		}
+	}
+}
+
+// TestDetachInternetGatewayNotAttached pins that detaching an internet gateway
+// that was never attached to any VPC returns the AWS error code
+// Gateway.NotAttached (not DependencyViolation, which is delete-while-attached).
+func TestDetachInternetGatewayNotAttached(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	igw, err := c.CreateInternetGateway(ctx, &ec2.CreateInternetGatewayInput{})
+	if err != nil {
+		t.Fatalf("CreateInternetGateway: %v", err)
+	}
+
+	_, err = c.DetachInternetGateway(ctx, &ec2.DetachInternetGatewayInput{
+		InternetGatewayId: igw.InternetGateway.InternetGatewayId,
+		VpcId:             vpc.Vpc.VpcId,
+	})
+	if err == nil {
+		t.Fatal("DetachInternetGateway on an unattached gateway: want error, got nil")
+	}
+
+	if got := apiCode(t, err); got != "Gateway.NotAttached" {
+		t.Errorf("error code = %q, want Gateway.NotAttached", got)
+	}
+
+	assertNoLeakedPrefix(t, apiMessage(t, err))
+}
+
+// TestDetachInternetGatewayWrongVpc pins that detaching an attached internet
+// gateway while naming the wrong VPC also returns Gateway.NotAttached — the
+// gateway is not attached to the VPC the caller specified.
+func TestDetachInternetGatewayWrongVpc(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpcA, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc A: %v", err)
+	}
+
+	vpcB, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.1.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc B: %v", err)
+	}
+
+	igw, err := c.CreateInternetGateway(ctx, &ec2.CreateInternetGatewayInput{})
+	if err != nil {
+		t.Fatalf("CreateInternetGateway: %v", err)
+	}
+
+	if _, err := c.AttachInternetGateway(ctx, &ec2.AttachInternetGatewayInput{
+		InternetGatewayId: igw.InternetGateway.InternetGatewayId,
+		VpcId:             vpcA.Vpc.VpcId,
+	}); err != nil {
+		t.Fatalf("AttachInternetGateway: %v", err)
+	}
+
+	_, err = c.DetachInternetGateway(ctx, &ec2.DetachInternetGatewayInput{
+		InternetGatewayId: igw.InternetGateway.InternetGatewayId,
+		VpcId:             vpcB.Vpc.VpcId,
+	})
+	if err == nil {
+		t.Fatal("DetachInternetGateway naming the wrong VPC: want error, got nil")
+	}
+
+	if got := apiCode(t, err); got != "Gateway.NotAttached" {
+		t.Errorf("error code = %q, want Gateway.NotAttached", got)
+	}
+}
+
+// TestDeleteInternetGatewayWhileAttachedIsDependencyViolation guards the sibling
+// case: deleting (not detaching) an attached gateway is still DependencyViolation.
+func TestDeleteInternetGatewayWhileAttachedIsDependencyViolation(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	igw, err := c.CreateInternetGateway(ctx, &ec2.CreateInternetGatewayInput{})
+	if err != nil {
+		t.Fatalf("CreateInternetGateway: %v", err)
+	}
+
+	if _, err := c.AttachInternetGateway(ctx, &ec2.AttachInternetGatewayInput{
+		InternetGatewayId: igw.InternetGateway.InternetGatewayId,
+		VpcId:             vpc.Vpc.VpcId,
+	}); err != nil {
+		t.Fatalf("AttachInternetGateway: %v", err)
+	}
+
+	_, err = c.DeleteInternetGateway(ctx, &ec2.DeleteInternetGatewayInput{
+		InternetGatewayId: igw.InternetGateway.InternetGatewayId,
+	})
+	if err == nil {
+		t.Fatal("DeleteInternetGateway on an attached gateway: want error, got nil")
+	}
+
+	if got := apiCode(t, err); got != "DependencyViolation" {
+		t.Errorf("error code = %q, want DependencyViolation", got)
+	}
+}
+
+// TestEC2ErrorMessagesHaveNoInternalPrefix pins that EC2 wire error messages
+// carry only the human sentence — no "FailedPrecondition:" / "DependencyViolation:"
+// taxonomy prefix leaked from the internal error type.
+func TestEC2ErrorMessagesHaveNoInternalPrefix(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	// (1) DeleteVpc with a subnet dependency -> DependencyViolation, clean message.
+	vpcID, _ := mkVPCSubnet(t, c)
+
+	_, err := c.DeleteVpc(ctx, &ec2.DeleteVpcInput{VpcId: aws.String(vpcID)})
+	if err == nil {
+		t.Fatal("DeleteVpc with dependency: want error, got nil")
+	}
+
+	if got := apiCode(t, err); got != "DependencyViolation" {
+		t.Errorf("DeleteVpc code = %q, want DependencyViolation", got)
+	}
+
+	assertNoLeakedPrefix(t, apiMessage(t, err))
+
+	// (2) NotFound path -> clean message, no "NotFound:" prefix.
+	_, err = c.DeleteInternetGateway(ctx, &ec2.DeleteInternetGatewayInput{
+		InternetGatewayId: aws.String("igw-doesnotexist"),
+	})
+	if err == nil {
+		t.Fatal("DeleteInternetGateway on a missing gateway: want error, got nil")
+	}
+
+	assertNoLeakedPrefix(t, apiMessage(t, err))
+}

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -565,25 +565,27 @@ func writeErr(w http.ResponseWriter, err error) {
 // writeErrWithNotFound writes an error with caller-supplied NotFound and
 // FailedPrecondition codes so each resource type emits the right AWS error.
 func writeErrWithNotFound(w http.ResponseWriter, err error, notFoundCode, preconditionCode string) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, notFoundCode, err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, notFoundCode, msg)
 	case cerrors.IsAlreadyExists(err):
 		awsquery.WriteXMLError(w, http.StatusBadRequest,
-			"ResourceAlreadyExists", err.Error())
+			"ResourceAlreadyExists", msg)
 	case cerrors.IsInvalidArgument(err):
 		awsquery.WriteXMLError(w, http.StatusBadRequest,
-			"InvalidParameterValue", err.Error())
+			"InvalidParameterValue", msg)
 	case cerrors.IsFailedPrecondition(err):
 		awsquery.WriteXMLError(w, http.StatusBadRequest,
-			preconditionCode, err.Error())
+			preconditionCode, msg)
 	case cerrors.GetCode(err) == cerrors.Unimplemented:
 		// An unsupported optional op is a client-facing 400 InvalidAction, not a
 		// 500 — matching how the launch-template ops answer an absent capability.
 		awsquery.WriteXMLError(w, http.StatusBadRequest,
-			"InvalidAction", err.Error())
+			"InvalidAction", msg)
 	default:
 		awsquery.WriteXMLError(w, http.StatusInternalServerError,
-			"InternalError", err.Error())
+			"InternalError", msg)
 	}
 }

--- a/server/aws/ec2/internet_gateway.go
+++ b/server/aws/ec2/internet_gateway.go
@@ -98,7 +98,7 @@ func (h *Handler) attachInternetGateway(w http.ResponseWriter, r *http.Request) 
 func (h *Handler) detachInternetGateway(w http.ResponseWriter, r *http.Request) {
 	if err := h.vpc.DetachInternetGateway(r.Context(),
 		r.Form.Get("InternetGatewayId"), r.Form.Get("VpcId")); err != nil {
-		writeIGWErr(w, err)
+		writeDetachIGWErr(w, err)
 		return
 	}
 
@@ -218,4 +218,12 @@ func toInternetGatewayXML(igw *netdriver.InternetGateway) internetGatewayXML {
 
 func writeIGWErr(w http.ResponseWriter, err error) {
 	writeErrWithNotFound(w, err, "InvalidInternetGatewayID.NotFound", "DependencyViolation")
+}
+
+// writeDetachIGWErr maps DetachInternetGateway errors. Detaching an internet
+// gateway that is not attached to the specified VPC is a distinct AWS error
+// code (Gateway.NotAttached), not the DependencyViolation used for delete-while-
+// attached. Both are 400 client errors.
+func writeDetachIGWErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidInternetGatewayID.NotFound", "Gateway.NotAttached")
 }

--- a/server/aws/iam/errors_sdk_test.go
+++ b/server/aws/iam/errors_sdk_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -11,10 +12,38 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	smithy "github.com/aws/smithy-go"
 
 	"github.com/stackshy/cloudemu/v2"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 )
+
+// leakedPrefixes are the internal cloudemu error-taxonomy names that must never
+// prefix a wire error message. Real AWS surfaces only the human sentence.
+var leakedPrefixes = []string{ //nolint:gochecknoglobals // shared test fixture
+	"NotFound:",
+	"AlreadyExists:",
+	"InvalidArgument:",
+	"FailedPrecondition:",
+	"PermissionDenied:",
+	"Internal:",
+}
+
+func assertNoLeakedPrefix(t *testing.T, err error) {
+	t.Helper()
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected an API error, got %v", err)
+	}
+
+	msg := apiErr.ErrorMessage()
+	for _, p := range leakedPrefixes {
+		if strings.HasPrefix(msg, p) || strings.Contains(msg, " "+p) {
+			t.Errorf("wire message %q leaks internal error-code prefix %q", msg, p)
+		}
+	}
+}
 
 // newClient is a shared helper for error-path tests. Lives here (rather than
 // sharing newSDKClient) so the SDK-driver wiring used to assert error codes
@@ -90,6 +119,40 @@ func TestSDKIAMEntityAlreadyExistsIsTyped(t *testing.T) {
 	if !errors.As(err, &eae) {
 		t.Fatalf("expected *EntityAlreadyExistsException, got %T: %v", err, err)
 	}
+}
+
+// TestSDKIAMErrorMessagesHaveNoInternalPrefix pins that IAM wire error messages
+// carry only the human sentence — not the internal "NotFound:" / "AlreadyExists:"
+// / "FailedPrecondition:" code prefix from cerrors.Error.Error().
+func TestSDKIAMErrorMessagesHaveNoInternalPrefix(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	// NotFound.
+	_, err := client.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String("nope")})
+	if err == nil {
+		t.Fatal("GetRole on a missing role: want error, got nil")
+	}
+
+	assertNoLeakedPrefix(t, err)
+
+	// AlreadyExists.
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("dup"),
+		AssumeRolePolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
+	}); err != nil {
+		t.Fatalf("first CreateRole: %v", err)
+	}
+
+	_, err = client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("dup"),
+		AssumeRolePolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
+	})
+	if err == nil {
+		t.Fatal("duplicate CreateRole: want error, got nil")
+	}
+
+	assertNoLeakedPrefix(t, err)
 }
 
 // TestSDKIAMClaimsActionsBeforeEC2 verifies the dispatch precedence

--- a/server/aws/iam/handler.go
+++ b/server/aws/iam/handler.go
@@ -368,18 +368,20 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // writeErr maps canonical cloudemu errors to IAM XML error responses.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		awsquery.WriteXMLError(w, http.StatusNotFound, notFoundCode(err), err.Error())
+		awsquery.WriteXMLError(w, http.StatusNotFound, notFoundCode(err), msg)
 	case cerrors.IsAlreadyExists(err):
-		awsquery.WriteXMLError(w, http.StatusConflict, alreadyExistsCode(err), err.Error())
+		awsquery.WriteXMLError(w, http.StatusConflict, alreadyExistsCode(err), msg)
 	case cerrors.IsInvalidArgument(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidInput", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidInput", msg)
 	case cerrors.IsFailedPrecondition(err):
-		awsquery.WriteXMLError(w, http.StatusConflict, "DeleteConflict", err.Error())
+		awsquery.WriteXMLError(w, http.StatusConflict, "DeleteConflict", msg)
 	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
-		awsquery.WriteXMLError(w, http.StatusConflict, "LimitExceeded", err.Error())
+		awsquery.WriteXMLError(w, http.StatusConflict, "LimitExceeded", msg)
 	default:
-		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
+		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", msg)
 	}
 }

--- a/server/aws/lambda/error_shape_test.go
+++ b/server/aws/lambda/error_shape_test.go
@@ -1,0 +1,43 @@
+package lambda_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKLambdaErrorMessagesHaveNoInternalPrefix pins that Lambda wire error
+// messages carry only the human sentence — not the internal "NotFound:" code
+// prefix that cerrors.Error.Error() prepends.
+func TestSDKLambdaErrorMessagesHaveNoInternalPrefix(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.GetFunction(ctx, &awslambda.GetFunctionInput{
+		FunctionName: aws.String("nope"),
+	})
+	if err == nil {
+		t.Fatal("GetFunction on a missing function: want error, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected an API error, got %v", err)
+	}
+
+	if apiErr.ErrorCode() != "ResourceNotFoundException" {
+		t.Errorf("error code = %q, want ResourceNotFoundException", apiErr.ErrorCode())
+	}
+
+	msg := apiErr.ErrorMessage()
+	for _, p := range []string{"NotFound:", "AlreadyExists:", "InvalidArgument:", "FailedPrecondition:"} {
+		if strings.HasPrefix(msg, p) {
+			t.Errorf("wire message %q leaks internal error-code prefix %q", msg, p)
+		}
+	}
+}

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -1107,14 +1107,16 @@ func writeError(w http.ResponseWriter, status int, errType, msg string) {
 }
 
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", msg)
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "ResourceConflictException", err.Error())
+		writeError(w, http.StatusConflict, "ResourceConflictException", msg)
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", err.Error())
+		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", msg)
 	default:
-		writeError(w, http.StatusInternalServerError, "ServiceException", err.Error())
+		writeError(w, http.StatusInternalServerError, "ServiceException", msg)
 	}
 }

--- a/server/aws/s3/error_shape_test.go
+++ b/server/aws/s3/error_shape_test.go
@@ -1,0 +1,85 @@
+package s3_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
+)
+
+func assertS3NoLeakedPrefix(t *testing.T, err error) {
+	t.Helper()
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected an API error, got %v", err)
+	}
+
+	msg := apiErr.ErrorMessage()
+	for _, p := range []string{"NotFound:", "AlreadyExists:", "InvalidArgument:", "FailedPrecondition:"} {
+		if strings.HasPrefix(msg, p) {
+			t.Errorf("wire message %q leaks internal error-code prefix %q", msg, p)
+		}
+	}
+}
+
+// TestSDKS3ErrorMessagesHaveNoInternalPrefix pins that S3 wire error messages
+// carry only the human sentence — not the internal cerrors code prefix — across
+// NoSuchKey (missing object) and BucketNotEmpty (delete non-empty bucket).
+func TestSDKS3ErrorMessagesHaveNoInternalPrefix(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "shape-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	// NoSuchKey: GetObject on a missing key.
+	_, err := client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("missing"),
+	})
+	if err == nil {
+		t.Fatal("GetObject on a missing key: want error, got nil")
+	}
+
+	if got := s3Code(t, err); got != "NoSuchKey" {
+		t.Errorf("GetObject code = %q, want NoSuchKey", got)
+	}
+
+	assertS3NoLeakedPrefix(t, err)
+
+	// BucketNotEmpty: DeleteBucket on a bucket that still holds an object.
+	if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("k"),
+		Body:   strings.NewReader("v"),
+	}); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	_, err = client.DeleteBucket(ctx, &awss3.DeleteBucketInput{Bucket: aws.String(bucket)})
+	if err == nil {
+		t.Fatal("DeleteBucket on a non-empty bucket: want error, got nil")
+	}
+
+	if got := s3Code(t, err); got != "BucketNotEmpty" {
+		t.Errorf("DeleteBucket code = %q, want BucketNotEmpty", got)
+	}
+
+	assertS3NoLeakedPrefix(t, err)
+}
+
+func s3Code(t *testing.T, err error) string {
+	t.Helper()
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected an API error, got %v", err)
+	}
+
+	return apiErr.ErrorCode()
+}

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -897,7 +897,7 @@ func (h *Handler) deleteObjects(w http.ResponseWriter, r *http.Request, bucket s
 			return
 		case derr != nil:
 			result.Errors = append(result.Errors, deleteErrorXML{
-				Key: obj.Key, Code: "InternalError", Message: derr.Error(),
+				Key: obj.Key, Code: "InternalError", Message: cerrors.Message(derr),
 			})
 		case !req.Quiet:
 			result.Deleted = append(result.Deleted, deletedObjectXML{
@@ -1715,7 +1715,7 @@ func writeError(w http.ResponseWriter, status int, code, msg string) {
 // missing resource is the upload (NoSuchUpload), not the object key.
 func writeMultipartErr(w http.ResponseWriter, err error) {
 	if cerrors.IsNotFound(err) {
-		writeError(w, http.StatusNotFound, "NoSuchUpload", err.Error())
+		writeError(w, http.StatusNotFound, "NoSuchUpload", cerrors.Message(err))
 		return
 	}
 	writeErr(w, err)
@@ -1727,9 +1727,9 @@ func writeMultipartErr(w http.ResponseWriter, err error) {
 func writeCompleteMultipartErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "NoSuchUpload", err.Error())
+		writeError(w, http.StatusNotFound, "NoSuchUpload", cerrors.Message(err))
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "InvalidPart", err.Error())
+		writeError(w, http.StatusBadRequest, "InvalidPart", cerrors.Message(err))
 	default:
 		writeErr(w, err)
 	}
@@ -1752,23 +1752,25 @@ func bucketMissing(err error) bool {
 }
 
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
 		// Real S3 distinguishes NoSuchBucket from NoSuchKey.
 		if bucketMissing(err) {
-			writeError(w, http.StatusNotFound, "NoSuchBucket", err.Error())
+			writeError(w, http.StatusNotFound, "NoSuchBucket", msg)
 			return
 		}
-		writeError(w, http.StatusNotFound, "NoSuchKey", err.Error())
+		writeError(w, http.StatusNotFound, "NoSuchKey", msg)
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "BucketAlreadyOwnedByYou", err.Error())
+		writeError(w, http.StatusConflict, "BucketAlreadyOwnedByYou", msg)
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "InvalidArgument", err.Error())
+		writeError(w, http.StatusBadRequest, "InvalidArgument", msg)
 	case cerrors.IsFailedPrecondition(err):
 		// Deleting a non-empty bucket is a client error in real S3, not a
 		// server fault — and a 5xx would trigger SDK retry backoff.
-		writeError(w, http.StatusConflict, "BucketNotEmpty", err.Error())
+		writeError(w, http.StatusConflict, "BucketNotEmpty", msg)
 	default:
-		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
+		writeError(w, http.StatusInternalServerError, "InternalError", msg)
 	}
 }


### PR DESCRIPTION
## Summary

Two AWS behavioral-parity fixes surfaced by the round-6 confirmation audit.

### 1. EC2 DetachInternetGateway (IGW not attached to the given VPC) — MEDIUM

Detaching an internet gateway that is not attached to the specified VPC now returns the AWS error code **`Gateway.NotAttached`** (per the EC2 API error reference), instead of the previously-emitted `DependencyViolation`. This also covers the wrong-VPC case (gateway attached to VPC A, detach names VPC B).

The sibling case — **deleting** an attached internet gateway — is unchanged and still correctly returns `DependencyViolation`.

Implemented with a detach-specific error writer (`writeDetachIGWErr`) that maps the driver's `FailedPrecondition` to `Gateway.NotAttached`; the shared `writeIGWErr` keeps `DependencyViolation` for delete.

### 2. Error message shape parity across EC2 / IAM / Lambda / S3 — LOW

Wire `<Message>`/`message` fields leaked the internal Go error-taxonomy name — SDKs saw `"FailedPrecondition: ..."`, `"NotFound: ..."`, `"AlreadyExists: ..."`. Real AWS surfaces only the human sentence.

- Added `errors.Message(err)` which returns the unwrapped `.Message` (no code prefix), falling back to `err.Error()` for non-cloudemu errors.
- EC2, IAM, Lambda, and S3 error writers now emit `errors.Message(err)` instead of `err.Error()`.
- Removed the redundant `DependencyViolation: ` prefix baked into the VPC driver messages (the wire code already carries it), which had produced doubled `"FailedPrecondition: DependencyViolation: ..."` messages on DeleteVpc/DeleteSubnet/etc.

### Tests

Real `aws-sdk-go-v2` tests assert the corrected behavior:
- `server/aws/ec2/error_shape_test.go` — Detach not-attached and wrong-VPC → `Gateway.NotAttached`; delete-while-attached → `DependencyViolation`; DeleteVpc dependency + NotFound messages carry no leaked prefix.
- `server/aws/iam/errors_sdk_test.go` — NotFound / AlreadyExists messages carry no prefix.
- `server/aws/lambda/error_shape_test.go` — ResourceNotFoundException message carries no prefix.
- `server/aws/s3/error_shape_test.go` — NoSuchKey and BucketNotEmpty messages carry no prefix.

### Gates

- `go build ./...` clean
- `go test ./providers/aws/... ./server/aws/... ./services/...` green
- `golangci-lint` clean on changed packages

No driver interface changed, so `docs/coverage` is unaffected.