### PR TITLE
fix(ecr-ssm): ECR DeleteLifecyclePolicy, SSM SendCommand Targets

### DIFF
--- a/docs/compat/README.md
+++ b/docs/compat/README.md
@@ -80,6 +80,7 @@ Legend: ✅ verified via Go SDK · `·` supported but not yet compat-tested · `
 |---|---|---|---|
 | CreateRepository | ✅ | · | ✅ |
 | DeleteImage | ✅ | · | · |
+| DeleteLifecyclePolicy | · | · | · |
 | DeleteRepository | ✅ | ✅ | ✅ |
 | EvaluateLifecyclePolicy | · | · | · |
 | GetImage | ✅ | · | · |
@@ -93,7 +94,7 @@ Legend: ✅ verified via Go SDK · `·` supported but not yet compat-tested · `
 | StartImageScan | ✅ | · | · |
 | TagImage | · | · | · |
 
-**containerregistry verified via Go SDK:** AWS 12/14 · Azure 4/14 · GCP 5/14.
+**containerregistry verified via Go SDK:** AWS 12/15 · Azure 4/15 · GCP 5/15.
 
 ## database
 

--- a/docs/compat/compat.json
+++ b/docs/compat/compat.json
@@ -964,6 +964,22 @@
   },
   {
     "service": "containerregistry",
+    "operation": "DeleteLifecyclePolicy",
+    "providers": {
+      "aws": {
+        "native": "ECR"
+      },
+      "azure": {
+        "native": "ACR"
+      },
+      "gcp": {
+        "native": "ArtifactRegistry"
+      }
+    },
+    "status": "amber"
+  },
+  {
+    "service": "containerregistry",
     "operation": "DeleteRepository",
     "providers": {
       "aws": {

--- a/docs/coverage/README.md
+++ b/docs/coverage/README.md
@@ -22,7 +22,7 @@ capability the code does not implement. Machine-readable: [`coverage.json`](./co
 | `compute` | [EC2](./aws/ec2.md) | [VirtualMachines](./azure/virtualmachines.md) | [GCE](./gcp/gce.md) | — | 37 |
 | `configservice` | [Config](./aws/config.md) | — | — | — | 102 |
 | `containerinstances` | — | [ContainerInstances](./azure/containerinstances.md) | — | — | 9 |
-| `containerregistry` | [ECR](./aws/ecr.md) | [ACR](./azure/acr.md) | [ArtifactRegistry](./gcp/artifactregistry.md) | — | 14 |
+| `containerregistry` | [ECR](./aws/ecr.md) | [ACR](./azure/acr.md) | [ArtifactRegistry](./gcp/artifactregistry.md) | — | 15 |
 | `cosmospostgresql` | — | [CosmosPostgreSQL](./azure/cosmospostgresql.md) | — | — | 34 |
 | `database` | [DynamoDB](./aws/dynamodb.md) | [CosmosDB](./azure/cosmosdb.md) | [Firestore](./gcp/firestore.md) | — | 24 |
 | `databricks` | — | [Databricks](./azure/databricks.md) | — | — | 46 |

--- a/docs/coverage/aws/README.md
+++ b/docs/coverage/aws/README.md
@@ -15,7 +15,7 @@ Services cloudemu emulates for AWS, by native name. Back to the [cross-provider 
 | [Config](./config.md) | `configservice` | 102 |
 | [DynamoDB](./dynamodb.md) | `database` | 24 |
 | [EC2](./ec2.md) | `compute` | 37 |
-| [ECR](./ecr.md) | `containerregistry` | 14 |
+| [ECR](./ecr.md) | `containerregistry` | 15 |
 | [ECS](./ecs.md) | `ecs` | 37 |
 | [EFS](./efs.md) | `efs` | 27 |
 | [ELB](./elb.md) | `loadbalancer` | 19 |

--- a/docs/coverage/aws/ecr.md
+++ b/docs/coverage/aws/ecr.md
@@ -3,12 +3,13 @@
 
 AWS's `containerregistry` service · portable interface `driver.ContainerRegistry` · [AWS index](./README.md)
 
-## Operations (14)
+## Operations (15)
 
 | Operation | Description |
 | --- | --- |
 | `CreateRepository` | Repository management |
 | `DeleteImage` |  |
+| `DeleteLifecyclePolicy` | DeleteLifecyclePolicy removes the repository's lifecycle policy and returns |
 | `DeleteRepository` |  |
 | `EvaluateLifecyclePolicy` |  |
 | `GetImage` |  |

--- a/docs/coverage/azure/README.md
+++ b/docs/coverage/azure/README.md
@@ -5,7 +5,7 @@ Services cloudemu emulates for Azure, by native name. Back to the [cross-provide
 
 | Azure service | Portable service | Operations |
 | --- | --- | --- |
-| [ACR](./acr.md) | `containerregistry` | 14 |
+| [ACR](./acr.md) | `containerregistry` | 15 |
 | [AI](./ai.md) | `azureai` | 92 |
 | [BlobStorage](./blobstorage.md) | `storage` | 35 |
 | [Cache](./cache.md) | `cache` | 17 |

--- a/docs/coverage/azure/acr.md
+++ b/docs/coverage/azure/acr.md
@@ -3,12 +3,13 @@
 
 Azure's `containerregistry` service · portable interface `driver.ContainerRegistry` · [Azure index](./README.md)
 
-## Operations (14)
+## Operations (15)
 
 | Operation | Description |
 | --- | --- |
 | `CreateRepository` | Repository management |
 | `DeleteImage` |  |
+| `DeleteLifecyclePolicy` | DeleteLifecyclePolicy removes the repository's lifecycle policy and returns |
 | `DeleteRepository` |  |
 | `EvaluateLifecyclePolicy` |  |
 | `GetImage` |  |

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -2550,6 +2550,10 @@
         "name": "DeleteImage"
       },
       {
+        "name": "DeleteLifecyclePolicy",
+        "doc": "DeleteLifecyclePolicy removes the repository's lifecycle policy and returns"
+      },
+      {
         "name": "DeleteRepository"
       },
       {

--- a/docs/coverage/gcp/README.md
+++ b/docs/coverage/gcp/README.md
@@ -6,7 +6,7 @@ Services cloudemu emulates for GCP, by native name. Back to the [cross-provider 
 | GCP service | Portable service | Operations |
 | --- | --- | --- |
 | [AlloyDB](./alloydb.md) | `relationaldb` | 21 |
-| [ArtifactRegistry](./artifactregistry.md) | `containerregistry` | 14 |
+| [ArtifactRegistry](./artifactregistry.md) | `containerregistry` | 15 |
 | [Bigtable](./bigtable.md) | `bigtable` | 38 |
 | [CloudDNS](./clouddns.md) | `dns` | 16 |
 | [CloudFunctions](./cloudfunctions.md) | `serverless` | 27 |

--- a/docs/coverage/gcp/artifactregistry.md
+++ b/docs/coverage/gcp/artifactregistry.md
@@ -3,12 +3,13 @@
 
 GCP's `containerregistry` service · portable interface `driver.ContainerRegistry` · [GCP index](./README.md)
 
-## Operations (14)
+## Operations (15)
 
 | Operation | Description |
 | --- | --- |
 | `CreateRepository` | Repository management |
 | `DeleteImage` |  |
+| `DeleteLifecyclePolicy` | DeleteLifecyclePolicy removes the repository's lifecycle policy and returns |
 | `DeleteRepository` |  |
 | `EvaluateLifecyclePolicy` |  |
 | `GetImage` |  |

--- a/providers/aws/ecr/ecr.go
+++ b/providers/aws/ecr/ecr.go
@@ -331,6 +331,24 @@ func (m *Mock) GetLifecyclePolicy(_ context.Context, repository string) (*driver
 	return &result, nil
 }
 
+// DeleteLifecyclePolicy removes the lifecycle policy from an ECR repository and
+// returns the policy that was deleted.
+func (m *Mock) DeleteLifecyclePolicy(_ context.Context, repository string) (*driver.LifecyclePolicy, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	if rd.policy == nil {
+		return nil, errors.Newf(errors.NotFound, "no lifecycle policy for repository %q", repository)
+	}
+
+	result := copyLifecyclePolicy(*rd.policy)
+	rd.policy = nil
+
+	return &result, nil
+}
+
 // EvaluateLifecyclePolicy evaluates the lifecycle policy and returns digests to expire.
 func (m *Mock) EvaluateLifecyclePolicy(_ context.Context, repository string) ([]string, error) {
 	rd, ok := m.repos.Get(repository)

--- a/providers/aws/ssm/run_command.go
+++ b/providers/aws/ssm/run_command.go
@@ -28,24 +28,32 @@ func (m *Mock) SetInstanceResolver(r InstanceResolver) {
 // invocation is recorded as successful so a caller's send/poll loop runs to
 // completion, but the script itself is never validated — see driver.RunCommand.
 func (m *Mock) SendCommand(ctx context.Context, cfg driver.CommandConfig) (string, error) {
-	if len(cfg.InstanceIDs) == 0 {
-		return "", errors.New(errors.InvalidArgument, "at least one instance id is required")
+	// Real SSM accepts EITHER explicit InstanceIds OR tag/attribute Targets;
+	// supplying neither is a ValidationException.
+	if len(cfg.InstanceIDs) == 0 && len(cfg.Targets) == 0 {
+		return "", errors.New(errors.InvalidArgument, "either instance IDs or targets must be specified")
 	}
 
 	if cfg.DocumentName == "" {
 		return "", errors.New(errors.InvalidArgument, "DocumentName is required")
 	}
 
-	// Real SSM answers InvalidInstanceId when a target is not a managed
-	// instance, and that is the single most common Run Command failure during
-	// bring-up. Accepting any id hides it until the caller runs for real.
+	// Real SSM answers InvalidInstanceId when an explicitly listed target is not
+	// a managed instance, and that is the single most common Run Command failure
+	// during bring-up. Accepting any id hides it until the caller runs for real.
 	if err := m.checkTargets(ctx, cfg.InstanceIDs); err != nil {
 		return "", err
 	}
 
+	// Resolve tag/attribute Targets to concrete instance ids. Unlike an explicit
+	// id, a Target that matches nothing is not an error — real SSM accepts the
+	// command with a TargetCount of zero.
+	resolved := m.resolveTargets(ctx, cfg.Targets)
+	instanceIDs := dedupeStrings(append(append([]string{}, cfg.InstanceIDs...), resolved...))
+
 	commandID := idgen.GenerateID("")
 
-	for _, instanceID := range cfg.InstanceIDs {
+	for _, instanceID := range instanceIDs {
 		m.commands.Set(commandKey(commandID, instanceID), driver.CommandInvocation{
 			CommandID:    commandID,
 			InstanceID:   instanceID,
@@ -56,6 +64,64 @@ func (m *Mock) SendCommand(ctx context.Context, cfg driver.CommandConfig) (strin
 	}
 
 	return commandID, nil
+}
+
+// resolveTargets maps SSM Targets to the instance ids they select. Multiple
+// targets are AND-combined, matching real SSM. Resolution needs the compute
+// mock; without it (or on a lookup error) no ids are resolved, which still
+// yields an accepted command.
+func (m *Mock) resolveTargets(ctx context.Context, targets []driver.CommandTarget) []string {
+	if len(targets) == 0 || m.instanceResolver == nil {
+		return nil
+	}
+
+	filters := make([]computedriver.DescribeFilter, 0, len(targets))
+	for _, t := range targets {
+		filters = append(filters, computedriver.DescribeFilter{
+			Name: targetFilterName(t.Key), Values: t.Values,
+		})
+	}
+
+	found, err := m.instanceResolver.DescribeInstances(ctx, nil, filters,
+		computedriver.DescribeInstancesOptions{IncludeManagedResources: true})
+	if err != nil {
+		return nil
+	}
+
+	ids := make([]string, 0, len(found))
+	for i := range found {
+		ids = append(ids, found[i].ID)
+	}
+
+	return ids
+}
+
+// targetFilterName maps an SSM Target Key to the equivalent EC2 describe-filter
+// name. Tag keys ("tag:<name>") pass through unchanged; the "InstanceIds"
+// pseudo-key selects by instance id.
+func targetFilterName(key string) string {
+	if key == "InstanceIds" {
+		return "instance-id"
+	}
+
+	return key
+}
+
+func dedupeStrings(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+
+	for _, s := range in {
+		if seen[s] {
+			continue
+		}
+
+		seen[s] = true
+
+		out = append(out, s)
+	}
+
+	return out
 }
 
 // GetCommandInvocation returns the recorded invocation for one instance.

--- a/providers/aws/ssm/run_command.go
+++ b/providers/aws/ssm/run_command.go
@@ -2,6 +2,7 @@ package ssm
 
 import (
 	"context"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
@@ -77,8 +78,19 @@ func (m *Mock) resolveTargets(ctx context.Context, targets []driver.CommandTarge
 
 	filters := make([]computedriver.DescribeFilter, 0, len(targets))
 	for _, t := range targets {
+		name, ok := targetFilterName(t.Key)
+		if !ok {
+			// A documented Run Command target key the emulator cannot resolve
+			// (resource-groups:Name, resource-groups:ResourceTypeFilters, tag-key).
+			// Targets are AND-combined, so an unresolvable one must select nothing.
+			// Forwarding the raw key as an EC2 describe-filter name instead falls
+			// into matchesTagFilter's default branch, which matches every instance
+			// unconditionally — fanning the command out to the whole fleet.
+			return nil
+		}
+
 		filters = append(filters, computedriver.DescribeFilter{
-			Name: targetFilterName(t.Key), Values: t.Values,
+			Name: name, Values: t.Values,
 		})
 	}
 
@@ -96,15 +108,23 @@ func (m *Mock) resolveTargets(ctx context.Context, targets []driver.CommandTarge
 	return ids
 }
 
-// targetFilterName maps an SSM Target Key to the equivalent EC2 describe-filter
-// name. Tag keys ("tag:<name>") pass through unchanged; the "InstanceIds"
-// pseudo-key selects by instance id.
-func targetFilterName(key string) string {
-	if key == "InstanceIds" {
-		return "instance-id"
+// targetFilterName maps a supported SSM Target Key to the equivalent EC2
+// describe-filter name, reporting whether the key is one the emulator can
+// resolve. Only the two Run Command keys the EC2 matcher actually understands
+// are supported: the "InstanceIds" pseudo-key (selects by instance id) and
+// "tag:<name>" (passes through unchanged). Other documented keys such as
+// resource-groups:Name / resource-groups:ResourceTypeFilters, and the bare
+// "tag-key" form, are reported unsupported so the caller can decline to forward
+// them — the EC2 matcher would otherwise treat them as an unrestricted match.
+func targetFilterName(key string) (string, bool) {
+	switch {
+	case key == "InstanceIds":
+		return "instance-id", true
+	case strings.HasPrefix(key, "tag:") && len(key) > len("tag:"):
+		return key, true
+	default:
+		return "", false
 	}
-
-	return key
 }
 
 func dedupeStrings(in []string) []string {

--- a/providers/aws/ssm/run_command.go
+++ b/providers/aws/ssm/run_command.go
@@ -28,6 +28,8 @@ func (m *Mock) SetInstanceResolver(r InstanceResolver) {
 // Nothing executes: an emulated instance has no guest operating system. The
 // invocation is recorded as successful so a caller's send/poll loop runs to
 // completion, but the script itself is never validated — see driver.RunCommand.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) SendCommand(ctx context.Context, cfg driver.CommandConfig) (string, error) {
 	// Real SSM accepts EITHER explicit InstanceIds OR tag/attribute Targets;
 	// supplying neither is a ValidationException.
@@ -77,6 +79,7 @@ func (m *Mock) resolveTargets(ctx context.Context, targets []driver.CommandTarge
 	}
 
 	filters := make([]computedriver.DescribeFilter, 0, len(targets))
+
 	for _, t := range targets {
 		name, ok := targetFilterName(t.Key)
 		if !ok {

--- a/providers/azure/acr/acr.go
+++ b/providers/azure/acr/acr.go
@@ -381,6 +381,24 @@ func (m *Mock) GetLifecyclePolicy(_ context.Context, repository string) (*driver
 	return &result, nil
 }
 
+// DeleteLifecyclePolicy removes the lifecycle policy from an ACR repository and
+// returns the policy that was deleted.
+func (m *Mock) DeleteLifecyclePolicy(_ context.Context, repository string) (*driver.LifecyclePolicy, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	if rd.policy == nil {
+		return nil, errors.Newf(errors.NotFound, "no lifecycle policy for repository %q", repository)
+	}
+
+	result := copyLifecyclePolicy(*rd.policy)
+	rd.policy = nil
+
+	return &result, nil
+}
+
 // EvaluateLifecyclePolicy evaluates the lifecycle policy and returns digests to expire.
 func (m *Mock) EvaluateLifecyclePolicy(_ context.Context, repository string) ([]string, error) {
 	rd, ok := m.repos.Get(repository)

--- a/providers/gcp/artifactregistry/artifactregistry.go
+++ b/providers/gcp/artifactregistry/artifactregistry.go
@@ -332,6 +332,24 @@ func (m *Mock) GetLifecyclePolicy(_ context.Context, repository string) (*driver
 	return &result, nil
 }
 
+// DeleteLifecyclePolicy removes the cleanup policy from an Artifact Registry
+// repository and returns the policy that was deleted.
+func (m *Mock) DeleteLifecyclePolicy(_ context.Context, repository string) (*driver.LifecyclePolicy, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	if rd.policy == nil {
+		return nil, errors.Newf(errors.NotFound, "no cleanup policy for repository %q", repository)
+	}
+
+	result := copyLifecyclePolicy(*rd.policy)
+	rd.policy = nil
+
+	return &result, nil
+}
+
 // EvaluateLifecyclePolicy evaluates the cleanup policy and returns digests to expire.
 func (m *Mock) EvaluateLifecyclePolicy(_ context.Context, repository string) ([]string, error) {
 	rd, ok := m.repos.Get(repository)

--- a/server/aws/ecr/handler.go
+++ b/server/aws/ecr/handler.go
@@ -84,6 +84,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.putLifecyclePolicy(w, r)
 	case "GetLifecyclePolicy":
 		h.getLifecyclePolicy(w, r)
+	case "DeleteLifecyclePolicy":
+		h.deleteLifecyclePolicy(w, r)
 	case "StartImageScan":
 		h.startImageScan(w, r)
 	case "DescribeImageScanFindings":

--- a/server/aws/ecr/lifecycle_policy.go
+++ b/server/aws/ecr/lifecycle_policy.go
@@ -77,10 +77,32 @@ func (h *Handler) getLifecyclePolicy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	policy, err := h.registry.GetLifecyclePolicy(r.Context(), req.RepositoryName)
+	h.writeLifecyclePolicyResult(w, r, req.RepositoryName, policy, err)
+}
+
+func (h *Handler) deleteLifecyclePolicy(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		RepositoryName string `json:"repositoryName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	policy, err := h.registry.DeleteLifecyclePolicy(r.Context(), req.RepositoryName)
+	h.writeLifecyclePolicyResult(w, r, req.RepositoryName, policy, err)
+}
+
+// writeLifecyclePolicyResult renders the shared Get/DeleteLifecyclePolicy
+// response: the policy body plus the owning registryId, or the exception that
+// distinguishes a missing repository from a repository with no policy.
+func (h *Handler) writeLifecyclePolicyResult(
+	w http.ResponseWriter, r *http.Request, repositoryName string, policy *crdriver.LifecyclePolicy, err error,
+) {
 	if err != nil {
 		// A missing repository is RepositoryNotFoundException; a repository with
 		// no lifecycle policy is LifecyclePolicyNotFoundException.
-		if _, repoErr := h.registry.GetRepository(r.Context(), req.RepositoryName); repoErr != nil {
+		if _, repoErr := h.registry.GetRepository(r.Context(), repositoryName); repoErr != nil {
 			writeErr(w, repoErr)
 			return
 		}
@@ -97,13 +119,13 @@ func (h *Handler) getLifecyclePolicy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := map[string]any{
-		"repositoryName":      req.RepositoryName,
+		"repositoryName":      repositoryName,
 		"lifecyclePolicyText": text,
 	}
 
-	// The policy lookup already proved the repository exists, so echo its
-	// registryId (real ECR always returns it).
-	if repo, repoErr := h.registry.GetRepository(r.Context(), req.RepositoryName); repoErr == nil {
+	// The repository is known to exist here, so echo its registryId (real ECR
+	// always returns it).
+	if repo, repoErr := h.registry.GetRepository(r.Context(), repositoryName); repoErr == nil {
 		resp["registryId"] = repo.RegistryID
 	}
 

--- a/server/aws/ecr/lifecycle_policy_test.go
+++ b/server/aws/ecr/lifecycle_policy_test.go
@@ -2,10 +2,12 @@ package ecr_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsecr "github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 )
 
 const lifecyclePolicyDoc = `{"rules":[{"rulePriority":1,"description":"expire",` +
@@ -50,5 +52,94 @@ func TestSDKECRLifecyclePolicyRegistryID(t *testing.T) {
 
 	if aws.ToString(got.RepositoryName) != "lc-repo" {
 		t.Fatalf("GetLifecyclePolicy repositoryName = %q, want lc-repo", aws.ToString(got.RepositoryName))
+	}
+}
+
+// TestSDKECRDeleteLifecyclePolicy exercises the Terraform destroy path: a
+// lifecycle policy is put, then deleted. Delete echoes the removed policy body
+// and registryId, and a subsequent Get reports the policy is gone.
+func TestSDKECRDeleteLifecyclePolicy(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("del-lc-repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	if _, err := client.PutLifecyclePolicy(ctx, &awsecr.PutLifecyclePolicyInput{
+		RepositoryName:      aws.String("del-lc-repo"),
+		LifecyclePolicyText: aws.String(lifecyclePolicyDoc),
+	}); err != nil {
+		t.Fatalf("PutLifecyclePolicy: %v", err)
+	}
+
+	del, err := client.DeleteLifecyclePolicy(ctx, &awsecr.DeleteLifecyclePolicyInput{
+		RepositoryName: aws.String("del-lc-repo"),
+	})
+	if err != nil {
+		t.Fatalf("DeleteLifecyclePolicy: %v", err)
+	}
+
+	if aws.ToString(del.RepositoryName) != "del-lc-repo" {
+		t.Fatalf("DeleteLifecyclePolicy repositoryName = %q, want del-lc-repo", aws.ToString(del.RepositoryName))
+	}
+
+	if aws.ToString(del.RegistryId) != "123456789012" {
+		t.Fatalf("DeleteLifecyclePolicy registryId = %q, want 123456789012", aws.ToString(del.RegistryId))
+	}
+
+	if aws.ToString(del.LifecyclePolicyText) == "" {
+		t.Fatal("DeleteLifecyclePolicy returned empty lifecyclePolicyText; want the deleted policy body")
+	}
+
+	// The policy is gone: Get now reports LifecyclePolicyNotFoundException.
+	_, err = client.GetLifecyclePolicy(ctx, &awsecr.GetLifecyclePolicyInput{
+		RepositoryName: aws.String("del-lc-repo"),
+	})
+
+	var lcNotFound *ecrtypes.LifecyclePolicyNotFoundException
+	if !errors.As(err, &lcNotFound) {
+		t.Fatalf("Get after delete: want LifecyclePolicyNotFoundException, got %v", err)
+	}
+}
+
+// TestSDKECRDeleteLifecyclePolicyNoPolicy asserts a repository with no lifecycle
+// policy reports LifecyclePolicyNotFoundException on delete, not a generic
+// repository error.
+func TestSDKECRDeleteLifecyclePolicyNoPolicy(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("no-lc-repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	_, err := client.DeleteLifecyclePolicy(ctx, &awsecr.DeleteLifecyclePolicyInput{
+		RepositoryName: aws.String("no-lc-repo"),
+	})
+
+	var lcNotFound *ecrtypes.LifecyclePolicyNotFoundException
+	if !errors.As(err, &lcNotFound) {
+		t.Fatalf("delete with no policy: want LifecyclePolicyNotFoundException, got %v", err)
+	}
+}
+
+// TestSDKECRDeleteLifecyclePolicyMissingRepo asserts deleting a policy on a
+// repository that does not exist reports RepositoryNotFoundException.
+func TestSDKECRDeleteLifecyclePolicyMissingRepo(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	_, err := client.DeleteLifecyclePolicy(ctx, &awsecr.DeleteLifecyclePolicyInput{
+		RepositoryName: aws.String("ghost-repo"),
+	})
+
+	var repoNotFound *ecrtypes.RepositoryNotFoundException
+	if !errors.As(err, &repoNotFound) {
+		t.Fatalf("delete on missing repo: want RepositoryNotFoundException, got %v", err)
 	}
 }

--- a/server/aws/ssm/run_command.go
+++ b/server/aws/ssm/run_command.go
@@ -9,19 +9,26 @@ import (
 	ssmdriver "github.com/stackshy/cloudemu/v2/services/parameterstore/driver"
 )
 
+type ssmTarget struct {
+	Key    string   `json:"Key"`
+	Values []string `json:"Values"`
+}
+
 type sendCommandRequest struct {
 	InstanceIds  []string            `json:"InstanceIds"`
+	Targets      []ssmTarget         `json:"Targets"`
 	DocumentName string              `json:"DocumentName"`
 	Comment      string              `json:"Comment"`
 	Parameters   map[string][]string `json:"Parameters"`
 }
 
 type commandJSON struct {
-	CommandId    string   `json:"CommandId"`
-	DocumentName string   `json:"DocumentName"`
-	Status       string   `json:"Status"`
-	InstanceIds  []string `json:"InstanceIds"`
-	Comment      string   `json:"Comment,omitempty"`
+	CommandId    string      `json:"CommandId"`
+	DocumentName string      `json:"DocumentName"`
+	Status       string      `json:"Status"`
+	InstanceIds  []string    `json:"InstanceIds"`
+	Targets      []ssmTarget `json:"Targets,omitempty"`
+	Comment      string      `json:"Comment,omitempty"`
 }
 
 type sendCommandResponse struct {
@@ -67,6 +74,7 @@ func (h *Handler) sendCommand(w http.ResponseWriter, r *http.Request) {
 
 	commandID, err := store.SendCommand(r.Context(), ssmdriver.CommandConfig{
 		InstanceIDs:  req.InstanceIds,
+		Targets:      toDriverTargets(req.Targets),
 		DocumentName: req.DocumentName,
 		Comment:      req.Comment,
 		Parameters:   req.Parameters,
@@ -95,8 +103,23 @@ func (h *Handler) sendCommand(w http.ResponseWriter, r *http.Request) {
 		DocumentName: req.DocumentName,
 		Status:       "Pending",
 		InstanceIds:  req.InstanceIds,
+		Targets:      req.Targets,
 		Comment:      req.Comment,
 	}})
+}
+
+// toDriverTargets converts wire Targets to the driver's CommandTarget shape.
+func toDriverTargets(in []ssmTarget) []ssmdriver.CommandTarget {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]ssmdriver.CommandTarget, 0, len(in))
+	for _, t := range in {
+		out = append(out, ssmdriver.CommandTarget{Key: t.Key, Values: t.Values})
+	}
+
+	return out
 }
 
 func (h *Handler) getCommandInvocation(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/ssm/run_command.go
+++ b/server/aws/ssm/run_command.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
-
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	ssmdriver "github.com/stackshy/cloudemu/v2/services/parameterstore/driver"
 )

--- a/server/aws/ssm/runcommand_sdk_roundtrip_test.go
+++ b/server/aws/ssm/runcommand_sdk_roundtrip_test.go
@@ -10,6 +10,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	awsssm "github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 
@@ -147,7 +148,92 @@ func TestSendCommandRequiresInstances(t *testing.T) {
 		DocumentName: aws.String("AWS-RunShellScript"),
 	})
 	if err == nil {
-		t.Error("SendCommand with no instances should fail")
+		t.Error("SendCommand with no instances or targets should fail")
+	}
+}
+
+// runTaggedInstance launches one instance carrying a Name tag so a tag-based
+// SendCommand target has something to resolve to.
+func runTaggedInstance(t *testing.T, ec2c *awsec2.Client, nameTag string) string {
+	t.Helper()
+
+	out, err := ec2c.RunInstances(context.Background(), &awsec2.RunInstancesInput{
+		ImageId: aws.String("ami-test"), InstanceType: "t3.micro",
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1),
+		TagSpecifications: []ec2types.TagSpecification{{
+			ResourceType: ec2types.ResourceTypeInstance,
+			Tags:         []ec2types.Tag{{Key: aws.String("Name"), Value: aws.String(nameTag)}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	return aws.ToString(out.Instances[0].InstanceId)
+}
+
+// Real SSM accepts SendCommand with tag-based Targets and no InstanceIds — the
+// mainstream fleet-automation pattern. The command must be accepted and each
+// resolved instance must get an invocation the caller can poll.
+func TestSendCommandTagTargets(t *testing.T) {
+	ctx := context.Background()
+	c, ec2c := newRunCommandClient(t)
+
+	id := runTaggedInstance(t, ec2c, "web")
+
+	sent, err := c.SendCommand(ctx, &awsssm.SendCommandInput{
+		DocumentName: aws.String("AWS-RunShellScript"),
+		Targets: []ssmtypes.Target{{
+			Key: aws.String("tag:Name"), Values: []string{"web"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("SendCommand with tag targets: %v", err)
+	}
+
+	if sent.Command == nil || aws.ToString(sent.Command.CommandId) == "" {
+		t.Fatalf("SendCommand returned no command id: %+v", sent.Command)
+	}
+
+	// The response echoes the targets that were requested.
+	if len(sent.Command.Targets) != 1 || aws.ToString(sent.Command.Targets[0].Key) != "tag:Name" {
+		t.Fatalf("SendCommand did not echo targets: %+v", sent.Command.Targets)
+	}
+
+	// The tag resolved to the tagged instance, so its invocation exists.
+	inv, err := c.GetCommandInvocation(ctx, &awsssm.GetCommandInvocationInput{
+		CommandId:  sent.Command.CommandId,
+		InstanceId: aws.String(id),
+	})
+	if err != nil {
+		t.Fatalf("GetCommandInvocation for tag-resolved instance: %v", err)
+	}
+
+	if inv.Status != ssmtypes.CommandInvocationStatusSuccess {
+		t.Errorf("status = %q, want Success", inv.Status)
+	}
+}
+
+// A tag target that matches no instance is still an accepted command (real SSM
+// returns TargetCount 0, not an error).
+func TestSendCommandTagTargetsNoMatch(t *testing.T) {
+	ctx := context.Background()
+	c, ec2c := newRunCommandClient(t)
+
+	_ = runTaggedInstance(t, ec2c, "web")
+
+	sent, err := c.SendCommand(ctx, &awsssm.SendCommandInput{
+		DocumentName: aws.String("AWS-RunShellScript"),
+		Targets: []ssmtypes.Target{{
+			Key: aws.String("tag:Name"), Values: []string{"nonexistent"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("SendCommand with unmatched tag target should still be accepted: %v", err)
+	}
+
+	if sent.Command == nil || aws.ToString(sent.Command.CommandId) == "" {
+		t.Fatalf("SendCommand returned no command id: %+v", sent.Command)
 	}
 }
 

--- a/server/aws/ssm/runcommand_sdk_roundtrip_test.go
+++ b/server/aws/ssm/runcommand_sdk_roundtrip_test.go
@@ -237,6 +237,44 @@ func TestSendCommandTagTargetsNoMatch(t *testing.T) {
 	}
 }
 
+// A documented Run Command target key the emulator cannot resolve
+// (resource-groups:Name) must select nothing rather than fanning the command
+// out to every instance in the fleet. Before the fix the raw key was forwarded
+// as an EC2 describe-filter name, which the matcher's default branch treated as
+// an unrestricted match — so the command silently hit unrelated instances.
+func TestSendCommandUnsupportedTargetKeyMatchesNothing(t *testing.T) {
+	ctx := context.Background()
+	c, ec2c := newRunCommandClient(t)
+
+	// Two live instances that the command must NOT touch.
+	ids := runInstances(t, ec2c, 2)
+
+	sent, err := c.SendCommand(ctx, &awsssm.SendCommandInput{
+		DocumentName: aws.String("AWS-RunShellScript"),
+		Targets: []ssmtypes.Target{{
+			Key: aws.String("resource-groups:Name"), Values: []string{"my-group"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("SendCommand with resource-groups target should be accepted: %v", err)
+	}
+
+	if sent.Command == nil || aws.ToString(sent.Command.CommandId) == "" {
+		t.Fatalf("SendCommand returned no command id: %+v", sent.Command)
+	}
+
+	// No instance was resolved, so none has an invocation. A fan-out bug would
+	// register invocations for both live instances instead.
+	for _, id := range ids {
+		if _, err := c.GetCommandInvocation(ctx, &awsssm.GetCommandInvocationInput{
+			CommandId:  sent.Command.CommandId,
+			InstanceId: aws.String(id),
+		}); err == nil {
+			t.Errorf("instance %s should not have been targeted by a resource-groups command", id)
+		}
+	}
+}
+
 // Real SSM answers InvalidInstanceId for a target that is not a managed
 // instance. It is the most common Run Command failure during bring-up, so
 // accepting any id would hide it until the caller runs for real.

--- a/services/containerregistry/containerregistry.go
+++ b/services/containerregistry/containerregistry.go
@@ -243,6 +243,21 @@ func (c *ContainerRegistry) GetLifecyclePolicy(
 	return out.(*driver.LifecyclePolicy), nil
 }
 
+// DeleteLifecyclePolicy removes the lifecycle policy from a repository and
+// returns the policy that was deleted.
+func (c *ContainerRegistry) DeleteLifecyclePolicy(
+	ctx context.Context, repository string,
+) (*driver.LifecyclePolicy, error) {
+	out, err := c.do(ctx, "DeleteLifecyclePolicy", repository, func() (any, error) {
+		return c.driver.DeleteLifecyclePolicy(ctx, repository)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.LifecyclePolicy), nil
+}
+
 // EvaluateLifecyclePolicy evaluates the lifecycle policy and returns digests to expire.
 func (c *ContainerRegistry) EvaluateLifecyclePolicy(
 	ctx context.Context, repository string,

--- a/services/containerregistry/driver/driver.go
+++ b/services/containerregistry/driver/driver.go
@@ -109,6 +109,11 @@ type ContainerRegistry interface {
 	// Lifecycle policies
 	PutLifecyclePolicy(ctx context.Context, repository string, policy LifecyclePolicy) error
 	GetLifecyclePolicy(ctx context.Context, repository string) (*LifecyclePolicy, error)
+	// DeleteLifecyclePolicy removes the repository's lifecycle policy and returns
+	// the policy that was deleted. It is NotFound both when the repository does
+	// not exist and when the repository has no policy set; callers distinguish
+	// the two by re-checking GetRepository.
+	DeleteLifecyclePolicy(ctx context.Context, repository string) (*LifecyclePolicy, error)
 	EvaluateLifecyclePolicy(ctx context.Context, repository string) ([]string, error)
 
 	// Image scanning

--- a/services/parameterstore/driver/driver.go
+++ b/services/parameterstore/driver/driver.go
@@ -118,9 +118,19 @@ type CommandInvocation struct {
 	Stderr       string
 }
 
-// CommandConfig describes a Run Command send.
+// CommandTarget identifies managed nodes by a Key/Values criterion, e.g.
+// {Key: "tag:Name", Values: ["web"]}. It mirrors the SSM Target shape and is an
+// alternative to listing InstanceIDs explicitly.
+type CommandTarget struct {
+	Key    string
+	Values []string
+}
+
+// CommandConfig describes a Run Command send. Either InstanceIDs or Targets
+// (or both) must be supplied; Targets select managed nodes by tag/attribute.
 type CommandConfig struct {
 	InstanceIDs  []string
+	Targets      []CommandTarget
 	DocumentName string
 	Comment      string
 	Parameters   map[string][]string


### PR DESCRIPTION
## Summary

Two AWS behavioral gaps from a confirmation audit, fixed at the correct layer with real aws-sdk-go-v2 tests.

### ECR DeleteLifecyclePolicy (finding 1)
`DeleteLifecyclePolicy` is a real ECR operation that Terraform's `aws_ecr_lifecycle_policy` resource calls on destroy. The wire handler had no case for it, so requests fell through to `UnknownOperationException` and any IaC destroy of a lifecycle policy failed.

- Added `DeleteLifecyclePolicy(ctx, repository) (*LifecyclePolicy, error)` to the `containerregistry` driver interface (companion to the existing `Put`/`Get`/`Evaluate`), implemented in all three providers (AWS ECR, Azure ACR, GCP Artifact Registry) and forwarded by the portable wrapper.
- Added the `DeleteLifecyclePolicy` dispatch case + handler in `server/aws/ecr`. It returns the deleted `lifecyclePolicyText` and `registryId`, and distinguishes `RepositoryNotFoundException` (missing repo) from `LifecyclePolicyNotFoundException` (repo exists, no policy) — matching the real API.
- Regenerated `docs/coverage` (driver interface changed).

### SSM SendCommand Targets (finding 2)
Real SSM `SendCommand` accepts EITHER `InstanceIds` OR tag/resource Targets. The wire request only decoded `InstanceIds`, and the provider rejected any request with no instance IDs, so every tag-targeted send failed with `ValidationException`.

- Added `Targets` to the wire request/response and to the driver `CommandConfig` (new `CommandTarget{Key, Values}`).
- The provider resolves tag/attribute Targets to instances via the compute mock (AND-combined, `tag:Name` passes through, `InstanceIds` maps to `instance-id`). A Target matching nothing is still an accepted command (`TargetCount` 0), matching real SSM.
- Supplying neither `InstanceIds` nor `Targets` is now the `ValidationException`; explicit unknown instance IDs still return `InvalidInstanceId`.

## Tests
- `server/aws/ecr`: DeleteLifecyclePolicy round-trip (echoes policy + registryId; Get afterward is `LifecyclePolicyNotFoundException`), no-policy case, and missing-repo case.
- `server/aws/ssm`: tag-based `Targets` send resolves to the tagged instance and registers a pollable invocation; an unmatched tag target is still accepted.

## Gates
`go build ./...`, `go test ./providers/aws/... ./server/aws/... ./services/...`, and golangci-lint on changed packages all green (no new lint findings).