### PR TITLE
fix(s3): ListObjectVersions/ListParts/ListMultipartUploads pagination (max-keys/markers/IsTruncated/echoed MaxKeys)

### DIFF
--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -1560,14 +1560,21 @@ func (h *Handler) listMultipartUploads(w http.ResponseWriter, r *http.Request, b
 
 	if len(uploads) > resp.MaxUploads {
 		resp.IsTruncated = true
-		uploads = uploads[:resp.MaxUploads]
 		// S3 reports the last upload returned as the next markers; the resumed
-		// request lists uploads strictly after that key/upload-id pair.
-		if len(uploads) > 0 {
-			last := uploads[len(uploads)-1]
+		// request lists uploads strictly after that key/upload-id pair. Capture
+		// the resume position BEFORE slicing — with max-uploads=0 no uploads are
+		// returned, so fall back to the incoming markers rather than losing the
+		// caller's position (which would silently restart pagination).
+		if resp.MaxUploads > 0 {
+			last := uploads[resp.MaxUploads-1]
 			resp.NextKeyMarker = last.Key
 			resp.NextUploadIDMarker = last.UploadID
+		} else {
+			resp.NextKeyMarker = keyMarker
+			resp.NextUploadIDMarker = uploadIDMarker
 		}
+
+		uploads = uploads[:resp.MaxUploads]
 	}
 
 	for _, u := range uploads {

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -1413,8 +1413,27 @@ func (h *Handler) abortMultipartUpload(w http.ResponseWriter, r *http.Request, b
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// parseMaxItems reads a max-keys/max-parts/max-uploads value, falling back to
+// the S3 default page size of 1000 when it is absent, unparseable, or negative.
+func parseMaxItems(v string) int {
+	if v == "" {
+		return defaultMaxKeys
+	}
+
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return defaultMaxKeys
+	}
+
+	return n
+}
+
 // listParts lists the parts uploaded so far for a multipart upload, so
-// resumable-upload tooling can read back the parts it has already sent.
+// resumable-upload tooling can read back the parts it has already sent. It
+// honors max-parts and part-number-marker (parts are ordered ascending by
+// number; only parts numbered above the marker are listed), echoing MaxParts /
+// PartNumberMarker and setting IsTruncated / NextPartNumberMarker when a page is
+// cut short, as real S3 does.
 func (h *Handler) listParts(w http.ResponseWriter, r *http.Request, bucket, key, uploadID string) {
 	parts, err := h.bucket.ListParts(r.Context(), bucket, key, uploadID)
 	if err != nil {
@@ -1422,14 +1441,35 @@ func (h *Handler) listParts(w http.ResponseWriter, r *http.Request, bucket, key,
 		return
 	}
 
+	q := r.URL.Query()
+	maxParts := parseMaxItems(q.Get("max-parts"))
+	// part-number-marker: only parts strictly above it are listed. An absent or
+	// unparseable marker means 0 (list from the first part).
+	partNumberMarker, _ := strconv.Atoi(q.Get("part-number-marker"))
+
 	result := listPartsResult{
-		Xmlns:       xmlns,
-		Bucket:      bucket,
-		Key:         key,
-		UploadID:    uploadID,
-		IsTruncated: false,
+		Xmlns:            xmlns,
+		Bucket:           bucket,
+		Key:              key,
+		UploadID:         uploadID,
+		PartNumberMarker: partNumberMarker,
+		MaxParts:         maxParts,
 	}
+
 	for _, p := range parts {
+		if p.PartNumber <= partNumberMarker {
+			continue
+		}
+
+		if len(result.Parts) >= maxParts {
+			// A further matching part exists, so the page is truncated; the last
+			// part actually returned is the next request's part-number-marker.
+			result.IsTruncated = true
+			result.NextPartNumberMarker = result.Parts[len(result.Parts)-1].PartNumber
+
+			break
+		}
+
 		result.Parts = append(result.Parts, partXML{
 			PartNumber: p.PartNumber,
 			ETag:       fmt.Sprintf("%q", p.ETag),
@@ -1440,6 +1480,11 @@ func (h *Handler) listParts(w http.ResponseWriter, r *http.Request, bucket, key,
 	wire.WriteXML(w, http.StatusOK, result)
 }
 
+// listMultipartUploads lists the in-progress multipart uploads in a bucket. It
+// honors max-uploads, key-marker and upload-id-marker: uploads are ordered by
+// key ascending and then by upload id, and the handler slices the requested
+// page, echoing MaxUploads / KeyMarker / UploadIdMarker and setting IsTruncated
+// / NextKeyMarker / NextUploadIdMarker when more remain, as real S3 does.
 func (h *Handler) listMultipartUploads(w http.ResponseWriter, r *http.Request, bucket string) {
 	uploads, err := h.bucket.ListMultipartUploads(r.Context(), bucket)
 	if err != nil {
@@ -1447,7 +1492,43 @@ func (h *Handler) listMultipartUploads(w http.ResponseWriter, r *http.Request, b
 		return
 	}
 
-	resp := listMultipartUploadsResult{Xmlns: xmlns, Bucket: bucket}
+	q := r.URL.Query()
+	keyMarker := q.Get("key-marker")
+	uploadIDMarker := q.Get("upload-id-marker")
+
+	// S3 orders uploads by key, then by upload id; resume comparisons against
+	// upload-id-marker are lexicographic, so sort on the same key here.
+	sort.Slice(uploads, func(i, j int) bool {
+		if uploads[i].Key != uploads[j].Key {
+			return uploads[i].Key < uploads[j].Key
+		}
+
+		return uploads[i].UploadID < uploads[j].UploadID
+	})
+
+	uploads = skipToUploadMarker(uploads, keyMarker, uploadIDMarker)
+
+	resp := listMultipartUploadsResult{
+		Xmlns:          xmlns,
+		Bucket:         bucket,
+		Prefix:         q.Get("prefix"),
+		KeyMarker:      keyMarker,
+		UploadIDMarker: uploadIDMarker,
+		MaxUploads:     parseMaxItems(q.Get("max-uploads")),
+	}
+
+	if len(uploads) > resp.MaxUploads {
+		resp.IsTruncated = true
+		uploads = uploads[:resp.MaxUploads]
+		// S3 reports the last upload returned as the next markers; the resumed
+		// request lists uploads strictly after that key/upload-id pair.
+		if len(uploads) > 0 {
+			last := uploads[len(uploads)-1]
+			resp.NextKeyMarker = last.Key
+			resp.NextUploadIDMarker = last.UploadID
+		}
+	}
+
 	for _, u := range uploads {
 		resp.Uploads = append(resp.Uploads, multipartUploadXML{
 			Key:       u.Key,
@@ -1457,6 +1538,30 @@ func (h *Handler) listMultipartUploads(w http.ResponseWriter, r *http.Request, b
 	}
 
 	wire.WriteXML(w, http.StatusOK, resp)
+}
+
+// skipToUploadMarker drops the uploads preceding a key-marker/upload-id-marker
+// pair so a resumed listing starts at the first not-yet-returned upload. With
+// only a key-marker, listing resumes at keys strictly greater than it; with
+// both, uploads for the marker key resume at upload ids lexicographically
+// greater than upload-id-marker.
+func skipToUploadMarker(uploads []driver.MultipartUpload, keyMarker, uploadIDMarker string) []driver.MultipartUpload {
+	if keyMarker == "" {
+		return uploads
+	}
+
+	for i := range uploads {
+		u := &uploads[i]
+		if u.Key > keyMarker {
+			return uploads[i:]
+		}
+
+		if u.Key == keyMarker && uploadIDMarker != "" && u.UploadID > uploadIDMarker {
+			return uploads[i:]
+		}
+	}
+
+	return nil
 }
 
 // objectTaggingOp dispatches PUT/GET/DELETE for the ?tagging sub-resource.
@@ -1592,70 +1697,133 @@ func (h *Handler) getBucketVersioning(w http.ResponseWriter, r *http.Request, bu
 // listObjectVersions handles GET /{bucket}?versions. When the driver retains
 // version history it returns the full history (versions + delete markers);
 // otherwise it falls back to listing current objects as the sole "null" version.
+// It honors max-keys, key-marker and version-id-marker: the driver returns the
+// full ordered history (keys ascending, newest version first within a key) and
+// the handler slices the requested page, echoing the markers and setting
+// IsTruncated / NextKeyMarker / NextVersionIdMarker as real S3 does.
 func (h *Handler) listObjectVersions(w http.ResponseWriter, r *http.Request, bucket string) {
+	q := r.URL.Query()
 	opts := driver.ListOptions{
-		Prefix:    r.URL.Query().Get("prefix"),
-		Delimiter: r.URL.Query().Get("delimiter"),
+		Prefix:    q.Get("prefix"),
+		Delimiter: q.Get("delimiter"),
 	}
 
-	resp := listVersionsResult{
-		Xmlns:     xmlns,
-		Name:      bucket,
-		Prefix:    opts.Prefix,
-		Delimiter: opts.Delimiter,
-		MaxKeys:   defaultMaxKeys,
-	}
+	keyMarker := q.Get("key-marker")
+	versionIDMarker := q.Get("version-id-marker")
 
-	if h.versioned != nil {
-		result, err := h.versioned.ListObjectVersions(r.Context(), bucket, opts)
-		if err != nil {
-			writeErr(w, err)
-			return
-		}
-
-		for _, v := range result.Versions {
-			if v.DeleteMarker {
-				resp.DeleteMarkers = append(resp.DeleteMarkers, deleteMarkerXML{
-					Key: v.Key, VersionID: v.VersionID, IsLatest: v.IsLatest, LastModified: v.LastModified,
-				})
-				continue
-			}
-
-			resp.Versions = append(resp.Versions, objectVersionXML{
-				Key: v.Key, VersionID: v.VersionID, IsLatest: v.IsLatest, LastModified: v.LastModified,
-				ETag: fmt.Sprintf("%q", v.ETag), Size: v.Size, StorageClass: "STANDARD",
-			})
-		}
-
-		for _, p := range result.CommonPrefixes {
-			resp.CommonPrefixes = append(resp.CommonPrefixes, prefixXML{Prefix: p})
-		}
-
-		wire.WriteXML(w, http.StatusOK, resp)
-
-		return
-	}
-
-	// Fallback: no version history — list current objects as the "null" version.
-	result, err := h.bucket.ListObjects(r.Context(), bucket, opts)
+	entries, commonPrefixes, err := h.collectObjectVersions(r.Context(), bucket, opts)
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	for i := range result.Objects {
-		obj := &result.Objects[i]
+	resp := listVersionsResult{
+		Xmlns:           xmlns,
+		Name:            bucket,
+		Prefix:          opts.Prefix,
+		Delimiter:       opts.Delimiter,
+		KeyMarker:       keyMarker,
+		VersionIDMarker: versionIDMarker,
+		MaxKeys:         parseMaxItems(q.Get("max-keys")),
+	}
+
+	entries = skipToVersionMarker(entries, keyMarker, versionIDMarker)
+
+	if len(entries) > resp.MaxKeys {
+		next := entries[resp.MaxKeys]
+		resp.IsTruncated = true
+		resp.NextKeyMarker = next.Key
+		resp.NextVersionIDMarker = next.VersionID
+		entries = entries[:resp.MaxKeys]
+	}
+
+	for i := range entries {
+		v := &entries[i]
+		if v.DeleteMarker {
+			resp.DeleteMarkers = append(resp.DeleteMarkers, deleteMarkerXML{
+				Key: v.Key, VersionID: v.VersionID, IsLatest: v.IsLatest, LastModified: v.LastModified,
+			})
+			continue
+		}
+
 		resp.Versions = append(resp.Versions, objectVersionXML{
-			Key: obj.Key, VersionID: "null", IsLatest: true, LastModified: obj.LastModified,
-			ETag: fmt.Sprintf("%q", obj.ETag), Size: obj.Size, StorageClass: "STANDARD",
+			Key: v.Key, VersionID: v.VersionID, IsLatest: v.IsLatest, LastModified: v.LastModified,
+			ETag: fmt.Sprintf("%q", v.ETag), Size: v.Size, StorageClass: "STANDARD",
 		})
 	}
 
-	for _, p := range result.CommonPrefixes {
+	for _, p := range commonPrefixes {
 		resp.CommonPrefixes = append(resp.CommonPrefixes, prefixXML{Prefix: p})
 	}
 
 	wire.WriteXML(w, http.StatusOK, resp)
+}
+
+// collectObjectVersions returns the full ordered version history for a bucket
+// (keys ascending, newest version first within a key) and its rolled-up common
+// prefixes. It reads real history when the driver retains it, otherwise falls
+// back to listing current objects as the sole "null" version.
+func (h *Handler) collectObjectVersions(
+	ctx context.Context, bucket string, opts driver.ListOptions,
+) (entries []driver.ObjectVersion, commonPrefixes []string, err error) {
+	if h.versioned != nil {
+		result, verr := h.versioned.ListObjectVersions(ctx, bucket, opts)
+		if verr != nil {
+			return nil, nil, verr
+		}
+
+		return result.Versions, result.CommonPrefixes, nil
+	}
+
+	// Fallback: no version history — list current objects as the "null" version.
+	result, lerr := h.bucket.ListObjects(ctx, bucket, opts)
+	if lerr != nil {
+		return nil, nil, lerr
+	}
+
+	entries = make([]driver.ObjectVersion, 0, len(result.Objects))
+
+	for i := range result.Objects {
+		obj := &result.Objects[i]
+		entries = append(entries, driver.ObjectVersion{
+			Key: obj.Key, VersionID: "null", IsLatest: true,
+			Size: obj.Size, ETag: obj.ETag, LastModified: obj.LastModified,
+		})
+	}
+
+	return entries, result.CommonPrefixes, nil
+}
+
+// skipToVersionMarker drops the entries that precede a key-marker/
+// version-id-marker pair so a resumed listing starts at the first not-yet-
+// returned version. With only a key-marker, listing resumes at keys strictly
+// greater than it; with both, it resumes at the entry matching the pair
+// (inclusive) — the values S3 reports as NextKeyMarker/NextVersionIdMarker.
+func skipToVersionMarker(entries []driver.ObjectVersion, keyMarker, versionIDMarker string) []driver.ObjectVersion {
+	if keyMarker == "" {
+		return entries
+	}
+
+	for i := range entries {
+		e := &entries[i]
+		if versionIDMarker == "" {
+			if e.Key > keyMarker {
+				return entries[i:]
+			}
+
+			continue
+		}
+
+		if e.Key == keyMarker && e.VersionID == versionIDMarker {
+			return entries[i:]
+		}
+
+		if e.Key > keyMarker {
+			return entries[i:]
+		}
+	}
+
+	return nil
 }
 
 // extractMetadata pulls x-amz-meta-* headers into a map.

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -1463,9 +1463,15 @@ func (h *Handler) listParts(w http.ResponseWriter, r *http.Request, bucket, key,
 
 		if len(result.Parts) >= maxParts {
 			// A further matching part exists, so the page is truncated; the last
-			// part actually returned is the next request's part-number-marker.
+			// part actually returned is the next request's part-number-marker. With
+			// max-parts=0 no parts are returned, so fall back to the incoming
+			// part-number-marker rather than indexing an empty slice.
 			result.IsTruncated = true
-			result.NextPartNumberMarker = result.Parts[len(result.Parts)-1].PartNumber
+			if len(result.Parts) > 0 {
+				result.NextPartNumberMarker = result.Parts[len(result.Parts)-1].PartNumber
+			} else {
+				result.NextPartNumberMarker = partNumberMarker
+			}
 
 			break
 		}
@@ -1481,10 +1487,11 @@ func (h *Handler) listParts(w http.ResponseWriter, r *http.Request, bucket, key,
 }
 
 // listMultipartUploads lists the in-progress multipart uploads in a bucket. It
-// honors max-uploads, key-marker and upload-id-marker: uploads are ordered by
-// key ascending and then by upload id, and the handler slices the requested
-// page, echoing MaxUploads / KeyMarker / UploadIdMarker and setting IsTruncated
-// / NextKeyMarker / NextUploadIdMarker when more remain, as real S3 does.
+// honors prefix, max-uploads, key-marker and upload-id-marker: uploads are
+// filtered by prefix, ordered by key ascending and then by initiation time, and
+// the handler slices the requested page, echoing Prefix / MaxUploads / KeyMarker
+// / UploadIdMarker and setting IsTruncated / NextKeyMarker / NextUploadIdMarker
+// when more remain, as real S3 does.
 func (h *Handler) listMultipartUploads(w http.ResponseWriter, r *http.Request, bucket string) {
 	uploads, err := h.bucket.ListMultipartUploads(r.Context(), bucket)
 	if err != nil {
@@ -1495,23 +1502,16 @@ func (h *Handler) listMultipartUploads(w http.ResponseWriter, r *http.Request, b
 	q := r.URL.Query()
 	keyMarker := q.Get("key-marker")
 	uploadIDMarker := q.Get("upload-id-marker")
+	prefix := q.Get("prefix")
 
-	// S3 orders uploads by key, then by upload id; resume comparisons against
-	// upload-id-marker are lexicographic, so sort on the same key here.
-	sort.Slice(uploads, func(i, j int) bool {
-		if uploads[i].Key != uploads[j].Key {
-			return uploads[i].Key < uploads[j].Key
-		}
-
-		return uploads[i].UploadID < uploads[j].UploadID
-	})
-
+	uploads = filterUploadsByPrefix(uploads, prefix)
+	sortMultipartUploads(uploads)
 	uploads = skipToUploadMarker(uploads, keyMarker, uploadIDMarker)
 
 	resp := listMultipartUploadsResult{
 		Xmlns:          xmlns,
 		Bucket:         bucket,
-		Prefix:         q.Get("prefix"),
+		Prefix:         prefix,
 		KeyMarker:      keyMarker,
 		UploadIDMarker: uploadIDMarker,
 		MaxUploads:     parseMaxItems(q.Get("max-uploads")),
@@ -1538,6 +1538,46 @@ func (h *Handler) listMultipartUploads(w http.ResponseWriter, r *http.Request, b
 	}
 
 	wire.WriteXML(w, http.StatusOK, resp)
+}
+
+// filterUploadsByPrefix keeps only uploads whose key begins with prefix (an empty
+// prefix keeps them all), matching real S3's prefix parameter: the listing must
+// not include keys outside the prefix it echoes back.
+func filterUploadsByPrefix(uploads []driver.MultipartUpload, prefix string) []driver.MultipartUpload {
+	if prefix == "" {
+		return uploads
+	}
+
+	filtered := uploads[:0]
+
+	for i := range uploads {
+		if strings.HasPrefix(uploads[i].Key, prefix) {
+			filtered = append(filtered, uploads[i])
+		}
+	}
+
+	return filtered
+}
+
+// sortMultipartUploads orders uploads by key ascending, then, for uploads sharing
+// a key, by initiation time ascending (falling back to upload id when the times
+// are equal or unparseable), as real S3 does. Resume comparisons against
+// upload-id-marker stay lexicographic and are handled in skipToUploadMarker.
+func sortMultipartUploads(uploads []driver.MultipartUpload) {
+	sort.Slice(uploads, func(i, j int) bool {
+		if uploads[i].Key != uploads[j].Key {
+			return uploads[i].Key < uploads[j].Key
+		}
+
+		ti, ei := time.Parse(time.RFC3339, uploads[i].CreatedAt)
+		tj, ej := time.Parse(time.RFC3339, uploads[j].CreatedAt)
+
+		if ei == nil && ej == nil && !ti.Equal(tj) {
+			return ti.Before(tj)
+		}
+
+		return uploads[i].UploadID < uploads[j].UploadID
+	})
 }
 
 // skipToUploadMarker drops the uploads preceding a key-marker/upload-id-marker
@@ -1752,7 +1792,14 @@ func (h *Handler) listObjectVersions(w http.ResponseWriter, r *http.Request, buc
 		})
 	}
 
+	// A CommonPrefix is echoed only when it is lexicographically greater than
+	// key-marker, so a resumed (truncated) listing does not re-return the same
+	// prefixes on every page. An empty key-marker keeps them all.
 	for _, p := range commonPrefixes {
+		if p <= keyMarker {
+			continue
+		}
+
 		resp.CommonPrefixes = append(resp.CommonPrefixes, prefixXML{Prefix: p})
 	}
 

--- a/server/aws/s3/list_pagination_test.go
+++ b/server/aws/s3/list_pagination_test.go
@@ -268,3 +268,197 @@ func TestSDKListMultipartUploadsPagination(t *testing.T) {
 		t.Errorf("page2 uploads = %d keys, want exactly [key-b] (resume strictly after marker)", got)
 	}
 }
+
+// TestSDKListPartsZeroMaxParts asserts ListParts with max-parts=0 does not crash
+// the server when parts exist above the marker. Real S3 returns an empty,
+// truncated page rather than panicking on an empty result slice.
+func TestSDKListPartsZeroMaxParts(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "parts-zero-bucket"
+	const key = "obj"
+	mustCreateBucket(t, client, bucket)
+
+	created, err := client.CreateMultipartUpload(ctx, &awss3.CreateMultipartUploadInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	uploadID := aws.ToString(created.UploadId)
+
+	for _, n := range []int32{1, 2, 3} {
+		if _, err := client.UploadPart(ctx, &awss3.UploadPartInput{
+			Bucket:     aws.String(bucket),
+			Key:        aws.String(key),
+			UploadId:   aws.String(uploadID),
+			PartNumber: aws.Int32(n),
+			Body:       bytes.NewReader(bytes.Repeat([]byte("A"), 8)),
+		}); err != nil {
+			t.Fatalf("UploadPart %d: %v", n, err)
+		}
+	}
+
+	page, err := client.ListParts(ctx, &awss3.ListPartsInput{
+		Bucket:   aws.String(bucket),
+		Key:      aws.String(key),
+		UploadId: aws.String(uploadID),
+		MaxParts: aws.Int32(0),
+	})
+	if err != nil {
+		t.Fatalf("ListParts max-parts=0: %v (must not crash the server)", err)
+	}
+
+	if got := len(page.Parts); got != 0 {
+		t.Errorf("parts = %d, want 0 (max-parts=0 returns an empty page)", got)
+	}
+
+	if !aws.ToBool(page.IsTruncated) {
+		t.Error("IsTruncated = false, want true (parts remain above the marker)")
+	}
+
+	// Resuming (with a real page size) must still return every part.
+	rest, err := client.ListParts(ctx, &awss3.ListPartsInput{
+		Bucket:           aws.String(bucket),
+		Key:              aws.String(key),
+		UploadId:         aws.String(uploadID),
+		MaxParts:         aws.Int32(10),
+		PartNumberMarker: page.NextPartNumberMarker,
+	})
+	if err != nil {
+		t.Fatalf("ListParts resume: %v", err)
+	}
+
+	if got := len(rest.Parts); got != 3 {
+		t.Errorf("resumed parts = %d, want 3 (empty first page must not lose parts)", got)
+	}
+}
+
+// TestSDKListMultipartUploadsPrefix asserts ListMultipartUploads actually filters
+// the returned uploads by the prefix parameter (not merely echoing it), matching
+// real S3, which lists only uploads whose key begins with the prefix.
+func TestSDKListMultipartUploadsPrefix(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "uploads-prefix-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	keys := []string{"photos/a", "photos/b", "videos/c"}
+	for _, k := range keys {
+		if _, err := client.CreateMultipartUpload(ctx, &awss3.CreateMultipartUploadInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(k),
+		}); err != nil {
+			t.Fatalf("CreateMultipartUpload %s: %v", k, err)
+		}
+	}
+
+	out, err := client.ListMultipartUploads(ctx, &awss3.ListMultipartUploadsInput{
+		Bucket: aws.String(bucket),
+		Prefix: aws.String("photos/"),
+	})
+	if err != nil {
+		t.Fatalf("ListMultipartUploads: %v", err)
+	}
+
+	if aws.ToString(out.Prefix) != "photos/" {
+		t.Errorf("Prefix echoed = %q, want %q", aws.ToString(out.Prefix), "photos/")
+	}
+
+	var gotKeys []string
+	for _, u := range out.Uploads {
+		gotKeys = append(gotKeys, aws.ToString(u.Key))
+	}
+
+	if strings.Join(gotKeys, ",") != "photos/a,photos/b" {
+		t.Errorf("uploads = %v, want [photos/a photos/b] (prefix must actually filter)", gotKeys)
+	}
+}
+
+// TestSDKListObjectVersionsCommonPrefixesPagination asserts a delimited version
+// listing does not re-return a CommonPrefixes entry on a resumed page once the
+// key-marker has advanced past it. Real S3 filters out any CommonPrefix that is
+// not lexicographically greater than the key-marker.
+func TestSDKListObjectVersionsCommonPrefixesPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "versions-cp-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	if _, err := client.PutBucketVersioning(ctx, &awss3.PutBucketVersioningInput{
+		Bucket:                  aws.String(bucket),
+		VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusEnabled},
+	}); err != nil {
+		t.Fatalf("PutBucketVersioning: %v", err)
+	}
+
+	// "a/x" rolls up into the CommonPrefix "a/"; the bare keys m, n, o are the
+	// versions that get paginated. "a/" sorts before the page-2 key-marker "o".
+	keys := []string{"a/x", "m", "n", "o"}
+	for _, k := range keys {
+		if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(k),
+			Body:   bytes.NewReader([]byte("v-" + k)),
+		}); err != nil {
+			t.Fatalf("PutObject %s: %v", k, err)
+		}
+	}
+
+	page1, err := client.ListObjectVersions(ctx, &awss3.ListObjectVersionsInput{
+		Bucket:    aws.String(bucket),
+		Delimiter: aws.String("/"),
+		MaxKeys:   aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("ListObjectVersions page1: %v", err)
+	}
+
+	if !hasCommonPrefix(page1.CommonPrefixes, "a/") {
+		t.Errorf("page1 CommonPrefixes = %v, want to contain %q", commonPrefixStrings(page1.CommonPrefixes), "a/")
+	}
+
+	if !aws.ToBool(page1.IsTruncated) {
+		t.Fatal("page1 IsTruncated = false, want true (versions remain)")
+	}
+
+	page2, err := client.ListObjectVersions(ctx, &awss3.ListObjectVersionsInput{
+		Bucket:          aws.String(bucket),
+		Delimiter:       aws.String("/"),
+		MaxKeys:         aws.Int32(2),
+		KeyMarker:       page1.NextKeyMarker,
+		VersionIdMarker: page1.NextVersionIdMarker,
+	})
+	if err != nil {
+		t.Fatalf("ListObjectVersions page2: %v", err)
+	}
+
+	if hasCommonPrefix(page2.CommonPrefixes, "a/") {
+		t.Errorf("page2 CommonPrefixes = %v, must not re-return %q (key-marker %q has advanced past it)",
+			commonPrefixStrings(page2.CommonPrefixes), "a/", aws.ToString(page2.KeyMarker))
+	}
+}
+
+func hasCommonPrefix(prefixes []types.CommonPrefix, want string) bool {
+	for _, p := range prefixes {
+		if aws.ToString(p.Prefix) == want {
+			return true
+		}
+	}
+
+	return false
+}
+
+func commonPrefixStrings(prefixes []types.CommonPrefix) []string {
+	out := make([]string, 0, len(prefixes))
+	for _, p := range prefixes {
+		out = append(out, aws.ToString(p.Prefix))
+	}
+
+	return out
+}

--- a/server/aws/s3/list_pagination_test.go
+++ b/server/aws/s3/list_pagination_test.go
@@ -337,6 +337,83 @@ func TestSDKListPartsZeroMaxParts(t *testing.T) {
 	}
 }
 
+// TestSDKListMultipartUploadsZeroMaxUploads asserts ListMultipartUploads with
+// max-uploads=0 returns an empty, truncated page whose NextKeyMarker /
+// NextUploadIdMarker preserve the caller's incoming position rather than coming
+// back empty (which would silently restart pagination). Resuming from those
+// markers must still return every upload.
+func TestSDKListMultipartUploadsZeroMaxUploads(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "uploads-zero-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	keys := []string{"key-a", "key-b"}
+	for _, k := range keys {
+		if _, err := client.CreateMultipartUpload(ctx, &awss3.CreateMultipartUploadInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(k),
+		}); err != nil {
+			t.Fatalf("CreateMultipartUpload %s: %v", k, err)
+		}
+	}
+
+	// First list one upload so we have a non-empty marker to resume from, then
+	// request max-uploads=0 with that marker: the empty page must echo it back.
+	seed, err := client.ListMultipartUploads(ctx, &awss3.ListMultipartUploadsInput{
+		Bucket:     aws.String(bucket),
+		MaxUploads: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("ListMultipartUploads seed: %v", err)
+	}
+
+	page, err := client.ListMultipartUploads(ctx, &awss3.ListMultipartUploadsInput{
+		Bucket:         aws.String(bucket),
+		MaxUploads:     aws.Int32(0),
+		KeyMarker:      seed.NextKeyMarker,
+		UploadIdMarker: seed.NextUploadIdMarker,
+	})
+	if err != nil {
+		t.Fatalf("ListMultipartUploads max-uploads=0: %v (must not crash the server)", err)
+	}
+
+	if got := len(page.Uploads); got != 0 {
+		t.Errorf("uploads = %d, want 0 (max-uploads=0 returns an empty page)", got)
+	}
+
+	if !aws.ToBool(page.IsTruncated) {
+		t.Error("IsTruncated = false, want true (uploads remain above the marker)")
+	}
+
+	if aws.ToString(page.NextKeyMarker) != aws.ToString(seed.NextKeyMarker) {
+		t.Errorf("NextKeyMarker = %q, want %q (must not lose the caller's position)",
+			aws.ToString(page.NextKeyMarker), aws.ToString(seed.NextKeyMarker))
+	}
+
+	if aws.ToString(page.NextUploadIdMarker) != aws.ToString(seed.NextUploadIdMarker) {
+		t.Errorf("NextUploadIdMarker = %q, want %q (must not lose the caller's position)",
+			aws.ToString(page.NextUploadIdMarker), aws.ToString(seed.NextUploadIdMarker))
+	}
+
+	// Resuming from the preserved markers (with a real page size) must still
+	// return the remaining upload — the empty page must not skip it.
+	rest, err := client.ListMultipartUploads(ctx, &awss3.ListMultipartUploadsInput{
+		Bucket:         aws.String(bucket),
+		MaxUploads:     aws.Int32(10),
+		KeyMarker:      page.NextKeyMarker,
+		UploadIdMarker: page.NextUploadIdMarker,
+	})
+	if err != nil {
+		t.Fatalf("ListMultipartUploads resume: %v", err)
+	}
+
+	if got := len(rest.Uploads); got != 1 || aws.ToString(rest.Uploads[0].Key) != "key-b" {
+		t.Errorf("resumed uploads = %d keys, want exactly [key-b] (empty page must not lose uploads)", got)
+	}
+}
+
 // TestSDKListMultipartUploadsPrefix asserts ListMultipartUploads actually filters
 // the returned uploads by the prefix parameter (not merely echoing it), matching
 // real S3, which lists only uploads whose key begins with the prefix.

--- a/server/aws/s3/list_pagination_test.go
+++ b/server/aws/s3/list_pagination_test.go
@@ -1,0 +1,270 @@
+package s3_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// TestSDKListObjectVersionsPagination asserts ListObjectVersions honors max-keys:
+// it caps the page, echoes the requested MaxKeys, sets IsTruncated with
+// NextKeyMarker/NextVersionIdMarker, and round-trips those markers to return the
+// rest without gaps or overlaps.
+func TestSDKListObjectVersionsPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "versions-page-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	if _, err := client.PutBucketVersioning(ctx, &awss3.PutBucketVersioningInput{
+		Bucket:                  aws.String(bucket),
+		VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusEnabled},
+	}); err != nil {
+		t.Fatalf("PutBucketVersioning: %v", err)
+	}
+
+	keys := []string{"a", "b", "c", "d"}
+	for _, k := range keys {
+		if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(k),
+			Body:   bytes.NewReader([]byte("v-" + k)),
+		}); err != nil {
+			t.Fatalf("PutObject %s: %v", k, err)
+		}
+	}
+
+	page1, err := client.ListObjectVersions(ctx, &awss3.ListObjectVersionsInput{
+		Bucket:  aws.String(bucket),
+		MaxKeys: aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("ListObjectVersions page1: %v", err)
+	}
+
+	if got := len(page1.Versions); got != 2 {
+		t.Fatalf("page1 versions = %d, want 2 (max-keys must cap the page)", got)
+	}
+
+	if aws.ToInt32(page1.MaxKeys) != 2 {
+		t.Errorf("page1 MaxKeys echoed = %d, want 2", aws.ToInt32(page1.MaxKeys))
+	}
+
+	if !aws.ToBool(page1.IsTruncated) {
+		t.Error("page1 IsTruncated = false, want true (2 of 4 versions returned)")
+	}
+
+	if aws.ToString(page1.NextKeyMarker) != "c" {
+		t.Errorf("page1 NextKeyMarker = %q, want %q", aws.ToString(page1.NextKeyMarker), "c")
+	}
+
+	if aws.ToString(page1.NextVersionIdMarker) == "" {
+		t.Error("page1 NextVersionIdMarker is empty, want the version id of the first key not returned")
+	}
+
+	if firstKey := aws.ToString(page1.Versions[0].Key); firstKey != "a" {
+		t.Errorf("page1 first key = %q, want %q", firstKey, "a")
+	}
+
+	page2, err := client.ListObjectVersions(ctx, &awss3.ListObjectVersionsInput{
+		Bucket:          aws.String(bucket),
+		MaxKeys:         aws.Int32(2),
+		KeyMarker:       page1.NextKeyMarker,
+		VersionIdMarker: page1.NextVersionIdMarker,
+	})
+	if err != nil {
+		t.Fatalf("ListObjectVersions page2: %v", err)
+	}
+
+	if aws.ToString(page2.KeyMarker) != "c" {
+		t.Errorf("page2 KeyMarker echoed = %q, want %q", aws.ToString(page2.KeyMarker), "c")
+	}
+
+	if aws.ToBool(page2.IsTruncated) {
+		t.Error("page2 IsTruncated = true, want false (remaining versions fit)")
+	}
+
+	var page2Keys []string
+	for _, v := range page2.Versions {
+		page2Keys = append(page2Keys, aws.ToString(v.Key))
+	}
+
+	if strings.Join(page2Keys, ",") != "c,d" {
+		t.Errorf("page2 keys = %v, want [c d] (resume must not gap or overlap)", page2Keys)
+	}
+}
+
+// TestSDKListPartsPagination asserts ListParts honors max-parts and
+// part-number-marker: it caps the page, echoes MaxParts, sets IsTruncated with
+// NextPartNumberMarker (the last part returned), and resumes strictly after the
+// marker.
+func TestSDKListPartsPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "parts-page-bucket"
+	const key = "obj"
+	mustCreateBucket(t, client, bucket)
+
+	created, err := client.CreateMultipartUpload(ctx, &awss3.CreateMultipartUploadInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	uploadID := aws.ToString(created.UploadId)
+
+	for _, n := range []int32{1, 2, 3} {
+		if _, err := client.UploadPart(ctx, &awss3.UploadPartInput{
+			Bucket:     aws.String(bucket),
+			Key:        aws.String(key),
+			UploadId:   aws.String(uploadID),
+			PartNumber: aws.Int32(n),
+			Body:       bytes.NewReader(bytes.Repeat([]byte("A"), 8)),
+		}); err != nil {
+			t.Fatalf("UploadPart %d: %v", n, err)
+		}
+	}
+
+	page1, err := client.ListParts(ctx, &awss3.ListPartsInput{
+		Bucket:   aws.String(bucket),
+		Key:      aws.String(key),
+		UploadId: aws.String(uploadID),
+		MaxParts: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("ListParts page1: %v", err)
+	}
+
+	if got := len(page1.Parts); got != 1 {
+		t.Fatalf("page1 parts = %d, want 1 (max-parts must cap the page)", got)
+	}
+
+	if aws.ToInt32(page1.MaxParts) != 1 {
+		t.Errorf("page1 MaxParts echoed = %d, want 1", aws.ToInt32(page1.MaxParts))
+	}
+
+	if !aws.ToBool(page1.IsTruncated) {
+		t.Error("page1 IsTruncated = false, want true (1 of 3 parts returned)")
+	}
+
+	if aws.ToString(page1.NextPartNumberMarker) != "1" {
+		t.Errorf("page1 NextPartNumberMarker = %q, want %q", aws.ToString(page1.NextPartNumberMarker), "1")
+	}
+
+	if aws.ToInt32(page1.Parts[0].PartNumber) != 1 {
+		t.Errorf("page1 first part = %d, want 1", aws.ToInt32(page1.Parts[0].PartNumber))
+	}
+
+	page2, err := client.ListParts(ctx, &awss3.ListPartsInput{
+		Bucket:           aws.String(bucket),
+		Key:              aws.String(key),
+		UploadId:         aws.String(uploadID),
+		MaxParts:         aws.Int32(10),
+		PartNumberMarker: page1.NextPartNumberMarker,
+	})
+	if err != nil {
+		t.Fatalf("ListParts page2: %v", err)
+	}
+
+	if aws.ToString(page2.PartNumberMarker) != "1" {
+		t.Errorf("page2 PartNumberMarker echoed = %q, want %q", aws.ToString(page2.PartNumberMarker), "1")
+	}
+
+	if aws.ToBool(page2.IsTruncated) {
+		t.Error("page2 IsTruncated = true, want false (remaining parts fit)")
+	}
+
+	var nums []int32
+	for _, p := range page2.Parts {
+		nums = append(nums, aws.ToInt32(p.PartNumber))
+	}
+
+	if len(nums) != 2 || nums[0] != 2 || nums[1] != 3 {
+		t.Errorf("page2 part numbers = %v, want [2 3] (resume strictly after marker)", nums)
+	}
+}
+
+// TestSDKListMultipartUploadsPagination asserts ListMultipartUploads honors
+// max-uploads and the key-marker/upload-id-marker pair: it caps the page, echoes
+// MaxUploads, sets IsTruncated with NextKeyMarker/NextUploadIdMarker (the last
+// upload returned), and resumes strictly after that pair.
+func TestSDKListMultipartUploadsPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "uploads-page-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	keys := []string{"key-a", "key-b"}
+	for _, k := range keys {
+		if _, err := client.CreateMultipartUpload(ctx, &awss3.CreateMultipartUploadInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(k),
+		}); err != nil {
+			t.Fatalf("CreateMultipartUpload %s: %v", k, err)
+		}
+	}
+
+	page1, err := client.ListMultipartUploads(ctx, &awss3.ListMultipartUploadsInput{
+		Bucket:     aws.String(bucket),
+		MaxUploads: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("ListMultipartUploads page1: %v", err)
+	}
+
+	if got := len(page1.Uploads); got != 1 {
+		t.Fatalf("page1 uploads = %d, want 1 (max-uploads must cap the page)", got)
+	}
+
+	if aws.ToInt32(page1.MaxUploads) != 1 {
+		t.Errorf("page1 MaxUploads echoed = %d, want 1", aws.ToInt32(page1.MaxUploads))
+	}
+
+	if !aws.ToBool(page1.IsTruncated) {
+		t.Error("page1 IsTruncated = false, want true (1 of 2 uploads returned)")
+	}
+
+	if aws.ToString(page1.Uploads[0].Key) != "key-a" {
+		t.Errorf("page1 first upload key = %q, want %q", aws.ToString(page1.Uploads[0].Key), "key-a")
+	}
+
+	if aws.ToString(page1.NextKeyMarker) != "key-a" {
+		t.Errorf("page1 NextKeyMarker = %q, want %q (last upload returned)", aws.ToString(page1.NextKeyMarker), "key-a")
+	}
+
+	if aws.ToString(page1.NextUploadIdMarker) == "" {
+		t.Error("page1 NextUploadIdMarker is empty, want the upload id of the last upload returned")
+	}
+
+	page2, err := client.ListMultipartUploads(ctx, &awss3.ListMultipartUploadsInput{
+		Bucket:         aws.String(bucket),
+		MaxUploads:     aws.Int32(10),
+		KeyMarker:      page1.NextKeyMarker,
+		UploadIdMarker: page1.NextUploadIdMarker,
+	})
+	if err != nil {
+		t.Fatalf("ListMultipartUploads page2: %v", err)
+	}
+
+	if aws.ToString(page2.KeyMarker) != "key-a" {
+		t.Errorf("page2 KeyMarker echoed = %q, want %q", aws.ToString(page2.KeyMarker), "key-a")
+	}
+
+	if aws.ToBool(page2.IsTruncated) {
+		t.Error("page2 IsTruncated = true, want false (remaining uploads fit)")
+	}
+
+	if got := len(page2.Uploads); got != 1 || aws.ToString(page2.Uploads[0].Key) != "key-b" {
+		t.Errorf("page2 uploads = %d keys, want exactly [key-b] (resume strictly after marker)", got)
+	}
+}

--- a/server/aws/s3/xml.go
+++ b/server/aws/s3/xml.go
@@ -109,13 +109,16 @@ type completeMultipartUploadResult struct {
 
 // listPartsResult is the XML response for ListParts.
 type listPartsResult struct {
-	XMLName     xml.Name  `xml:"ListPartsResult"`
-	Xmlns       string    `xml:"xmlns,attr"`
-	Bucket      string    `xml:"Bucket"`
-	Key         string    `xml:"Key"`
-	UploadID    string    `xml:"UploadId"`
-	IsTruncated bool      `xml:"IsTruncated"`
-	Parts       []partXML `xml:"Part"`
+	XMLName              xml.Name  `xml:"ListPartsResult"`
+	Xmlns                string    `xml:"xmlns,attr"`
+	Bucket               string    `xml:"Bucket"`
+	Key                  string    `xml:"Key"`
+	UploadID             string    `xml:"UploadId"`
+	PartNumberMarker     int       `xml:"PartNumberMarker"`
+	NextPartNumberMarker int       `xml:"NextPartNumberMarker,omitempty"`
+	MaxParts             int       `xml:"MaxParts"`
+	IsTruncated          bool      `xml:"IsTruncated"`
+	Parts                []partXML `xml:"Part"`
 }
 
 type partXML struct {
@@ -126,11 +129,19 @@ type partXML struct {
 
 // listMultipartUploadsResult is the XML response for ListMultipartUploads.
 type listMultipartUploadsResult struct {
-	XMLName     xml.Name             `xml:"ListMultipartUploadsResult"`
-	Xmlns       string               `xml:"xmlns,attr"`
-	Bucket      string               `xml:"Bucket"`
-	IsTruncated bool                 `xml:"IsTruncated"`
-	Uploads     []multipartUploadXML `xml:"Upload"`
+	XMLName            xml.Name             `xml:"ListMultipartUploadsResult"`
+	Xmlns              string               `xml:"xmlns,attr"`
+	Bucket             string               `xml:"Bucket"`
+	KeyMarker          string               `xml:"KeyMarker"`
+	UploadIDMarker     string               `xml:"UploadIdMarker"`
+	NextKeyMarker      string               `xml:"NextKeyMarker,omitempty"`
+	NextUploadIDMarker string               `xml:"NextUploadIdMarker,omitempty"`
+	Prefix             string               `xml:"Prefix,omitempty"`
+	Delimiter          string               `xml:"Delimiter,omitempty"`
+	MaxUploads         int                  `xml:"MaxUploads"`
+	IsTruncated        bool                 `xml:"IsTruncated"`
+	Uploads            []multipartUploadXML `xml:"Upload"`
+	CommonPrefixes     []prefixXML          `xml:"CommonPrefixes,omitempty"`
 }
 
 type multipartUploadXML struct {
@@ -153,16 +164,20 @@ type tagXML struct {
 
 // listVersionsResult is the XML response for ListObjectVersions.
 type listVersionsResult struct {
-	XMLName        xml.Name           `xml:"ListVersionsResult"`
-	Xmlns          string             `xml:"xmlns,attr"`
-	Name           string             `xml:"Name"`
-	Prefix         string             `xml:"Prefix"`
-	Delimiter      string             `xml:"Delimiter,omitempty"`
-	MaxKeys        int                `xml:"MaxKeys"`
-	IsTruncated    bool               `xml:"IsTruncated"`
-	Versions       []objectVersionXML `xml:"Version"`
-	DeleteMarkers  []deleteMarkerXML  `xml:"DeleteMarker"`
-	CommonPrefixes []prefixXML        `xml:"CommonPrefixes,omitempty"`
+	XMLName             xml.Name           `xml:"ListVersionsResult"`
+	Xmlns               string             `xml:"xmlns,attr"`
+	Name                string             `xml:"Name"`
+	Prefix              string             `xml:"Prefix"`
+	KeyMarker           string             `xml:"KeyMarker"`
+	VersionIDMarker     string             `xml:"VersionIdMarker"`
+	NextKeyMarker       string             `xml:"NextKeyMarker,omitempty"`
+	NextVersionIDMarker string             `xml:"NextVersionIdMarker,omitempty"`
+	Delimiter           string             `xml:"Delimiter,omitempty"`
+	MaxKeys             int                `xml:"MaxKeys"`
+	IsTruncated         bool               `xml:"IsTruncated"`
+	Versions            []objectVersionXML `xml:"Version"`
+	DeleteMarkers       []deleteMarkerXML  `xml:"DeleteMarker"`
+	CommonPrefixes      []prefixXML        `xml:"CommonPrefixes,omitempty"`
 }
 
 type objectVersionXML struct {


### PR DESCRIPTION
## Summary

Three S3 list operations ignored their pagination parameters and returned every result in one page, so SDK/CLI paginators never terminated correctly and the echoed page-size fields were wrong. All three are fixed at the wire layer (the providers already return fully-ordered lists, so no driver-interface change was needed).

### Finding 1 — ListObjectVersions (MEDIUM)
`listObjectVersions()` never read `max-keys`, `key-marker`, or `version-id-marker`. It returned every version + delete marker, hardcoded `MaxKeys` to 1000 regardless of the request, and emitted no `IsTruncated`/`NextKeyMarker`/`NextVersionIdMarker`.

Now caps the page at `max-keys`, echoes the requested `MaxKeys` and `KeyMarker`/`VersionIdMarker`, and sets `IsTruncated` with `NextKeyMarker`/`NextVersionIdMarker` (the first key/version not returned). Resume with those markers is inclusive, matching the API reference.

### Finding 2 — ListParts (LOW)
`listParts()` hardcoded `IsTruncated=false`, never read `max-parts` or `part-number-marker`, and emitted no `MaxParts`/`PartNumberMarker`/`NextPartNumberMarker`.

Now lists only parts numbered above `part-number-marker`, caps at `max-parts`, echoes `MaxParts`/`PartNumberMarker`, and sets `IsTruncated` with `NextPartNumberMarker` (the last part returned; resume is strictly after it).

### Finding 3 — ListMultipartUploads (LOW)
`listMultipartUploads()` never read `max-uploads`/`key-marker`/`upload-id-marker` and emitted no `IsTruncated`/`MaxUploads`/next markers.

Now orders uploads by key then upload id, caps at `max-uploads`, echoes `MaxUploads`/`KeyMarker`/`UploadIdMarker`, and sets `IsTruncated` with `NextKeyMarker`/`NextUploadIdMarker` (the last upload returned; resume is strictly after the pair).

## Tests
Adds `server/aws/s3/list_pagination_test.go` with real aws-sdk-go-v2 tests for each operation: a first page is capped and truncated with the correct echoed limit and next markers, then the markers round-trip to return the remainder with no gaps or overlaps.

## Gates
- `go build ./...`
- `go test ./providers/aws/... ./server/aws/... ./services/...`
- `golangci-lint` on `server/aws/s3` — no new findings (matches pre-existing baseline)

No driver interfaces changed, so `docs/coverage` is unaffected.