### PR TITLE
fix(azure-keyvault): Keys data-plane (crypto ops), Certificates data-plane, Vault ARM management plane

### DIFF
--- a/docs/coverage/aws/secretsmanager.md
+++ b/docs/coverage/aws/secretsmanager.md
@@ -19,6 +19,30 @@ AWS's `secrets` service · portable interface `driver.Secrets` · [AWS index](./
 
 Discovered by type assertion; only some providers implement these.
 
+### KeyVaultKeys
+
+KeyVaultKeys is the Azure Key Vault keys data-plane surface: key lifecycle
+
+| Operation | Description |
+| --- | --- |
+| `CreateKey` |  |
+| `DecryptKey` |  |
+| `DeleteKey` |  |
+| `EncryptKey` |  |
+| `GetDeletedKey` |  |
+| `GetKey` |  |
+| `ImportKey` |  |
+| `ListDeletedKeys` |  |
+| `ListKeyVersions` |  |
+| `ListKeys` |  |
+| `PurgeDeletedKey` |  |
+| `RecoverDeletedKey` |  |
+| `SignKey` |  |
+| `UnwrapKey` |  |
+| `UpdateKey` |  |
+| `VerifyKey` |  |
+| `WrapKey` |  |
+
 ### KeyVaultSecrets
 
 KeyVaultSecrets is the Azure Key Vault-specific secret surface: per-version

--- a/docs/coverage/azure/keyvault.md
+++ b/docs/coverage/azure/keyvault.md
@@ -19,6 +19,30 @@ Azure's `secrets` service · portable interface `driver.Secrets` · [Azure index
 
 Discovered by type assertion; only some providers implement these.
 
+### KeyVaultKeys
+
+KeyVaultKeys is the Azure Key Vault keys data-plane surface: key lifecycle
+
+| Operation | Description |
+| --- | --- |
+| `CreateKey` |  |
+| `DecryptKey` |  |
+| `DeleteKey` |  |
+| `EncryptKey` |  |
+| `GetDeletedKey` |  |
+| `GetKey` |  |
+| `ImportKey` |  |
+| `ListDeletedKeys` |  |
+| `ListKeyVersions` |  |
+| `ListKeys` |  |
+| `PurgeDeletedKey` |  |
+| `RecoverDeletedKey` |  |
+| `SignKey` |  |
+| `UnwrapKey` |  |
+| `UpdateKey` |  |
+| `VerifyKey` |  |
+| `WrapKey` |  |
+
 ### KeyVaultSecrets
 
 KeyVaultSecrets is the Azure Key Vault-specific secret surface: per-version

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -9484,6 +9484,63 @@
     ],
     "optionalCapabilities": [
       {
+        "name": "KeyVaultKeys",
+        "doc": "KeyVaultKeys is the Azure Key Vault keys data-plane surface: key lifecycle",
+        "operations": [
+          {
+            "name": "CreateKey"
+          },
+          {
+            "name": "DecryptKey"
+          },
+          {
+            "name": "DeleteKey"
+          },
+          {
+            "name": "EncryptKey"
+          },
+          {
+            "name": "GetDeletedKey"
+          },
+          {
+            "name": "GetKey"
+          },
+          {
+            "name": "ImportKey"
+          },
+          {
+            "name": "ListDeletedKeys"
+          },
+          {
+            "name": "ListKeyVersions"
+          },
+          {
+            "name": "ListKeys"
+          },
+          {
+            "name": "PurgeDeletedKey"
+          },
+          {
+            "name": "RecoverDeletedKey"
+          },
+          {
+            "name": "SignKey"
+          },
+          {
+            "name": "UnwrapKey"
+          },
+          {
+            "name": "UpdateKey"
+          },
+          {
+            "name": "VerifyKey"
+          },
+          {
+            "name": "WrapKey"
+          }
+        ]
+      },
+      {
         "name": "KeyVaultSecrets",
         "doc": "KeyVaultSecrets is the Azure Key Vault-specific secret surface: per-version",
         "operations": [

--- a/docs/coverage/gcp/secretmanager.md
+++ b/docs/coverage/gcp/secretmanager.md
@@ -19,6 +19,30 @@ GCP's `secrets` service · portable interface `driver.Secrets` · [GCP index](./
 
 Discovered by type assertion; only some providers implement these.
 
+### KeyVaultKeys
+
+KeyVaultKeys is the Azure Key Vault keys data-plane surface: key lifecycle
+
+| Operation | Description |
+| --- | --- |
+| `CreateKey` |  |
+| `DecryptKey` |  |
+| `DeleteKey` |  |
+| `EncryptKey` |  |
+| `GetDeletedKey` |  |
+| `GetKey` |  |
+| `ImportKey` |  |
+| `ListDeletedKeys` |  |
+| `ListKeyVersions` |  |
+| `ListKeys` |  |
+| `PurgeDeletedKey` |  |
+| `RecoverDeletedKey` |  |
+| `SignKey` |  |
+| `UnwrapKey` |  |
+| `UpdateKey` |  |
+| `VerifyKey` |  |
+| `WrapKey` |  |
+
 ### KeyVaultSecrets
 
 KeyVaultSecrets is the Azure Key Vault-specific secret surface: per-version

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 h1:S087d
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0/go.mod h1:B4cEyXrWBmbfMDAPnpJ1di7MAt5DKP57jPEObAvZChg=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0 h1:MaKvxE6D0KkjOg6Wd9M00iqP5PR0kUxCfiezes4JweM=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0/go.mod h1:i2h9fsTFKZorh8RdV2IcSUf/Qj98GlTkrTvUbX/s8as=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0 h1:aMFOzch6ZJo4Ct9hI4A9Y2fPen5YNRTPmkSBhe5m0ZQ=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0/go.mod h1:Oct8bx+g+DXKngU7i/LzFzYt44rmLdMu4uoofIpooVo=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfgcSyHZXJI8J0IWE5MsCGlb2xp9fJiXyxWgmOFg4=

--- a/providers/azure/keyvault/keys_aeskw_azure.go
+++ b/providers/azure/keyvault/keys_aeskw_azure.go
@@ -1,0 +1,121 @@
+package keyvault
+
+import (
+	"crypto/aes"
+	"crypto/subtle"
+	"encoding/binary"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+)
+
+const (
+	// aesKWBlock is the 64-bit half-block size used by RFC 3394 AES key wrap.
+	aesKWBlock = 8
+	// aesKWRounds is the fixed number of wrapping rounds in RFC 3394.
+	aesKWRounds = 6
+
+	aes128KeyLen = 16
+	aes192KeyLen = 24
+	aes256KeyLen = 32
+
+	// minWrapBlocks is the smallest plaintext (in 64-bit blocks) RFC 3394 wraps.
+	minWrapBlocks = 2
+)
+
+// defaultIV is the RFC 3394 initial value used to detect a valid unwrap.
+var defaultIV = []byte{0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6} //nolint:gochecknoglobals // fixed RFC 3394 constant
+
+func aesKWKeyLen(alg string) (int, bool) {
+	switch alg {
+	case algA128KW:
+		return aes128KeyLen, true
+	case algA192KW:
+		return aes192KeyLen, true
+	case algA256KW:
+		return aes256KeyLen, true
+	default:
+		return 0, false
+	}
+}
+
+// aesKeyWrap implements the RFC 3394 AES Key Wrap algorithm.
+func aesKeyWrap(kek []byte, alg string, plaintext []byte) ([]byte, error) {
+	if want, ok := aesKWKeyLen(alg); !ok || len(kek) != want {
+		return nil, errors.Newf(errors.InvalidArgument, "algorithm %q does not match key length", alg)
+	}
+
+	if len(plaintext) < minWrapBlocks*aesKWBlock || len(plaintext)%aesKWBlock != 0 {
+		return nil, errors.New(errors.InvalidArgument, "AES key wrap input must be a multiple of 8 bytes and at least 16 bytes")
+	}
+
+	block, err := aes.NewCipher(kek)
+	if err != nil {
+		return nil, errors.Newf(errors.Internal, "aes cipher: %v", err)
+	}
+
+	n := len(plaintext) / aesKWBlock
+	r := make([]byte, len(plaintext))
+	copy(r, plaintext)
+
+	a := make([]byte, aesKWBlock)
+	copy(a, defaultIV)
+
+	buf := make([]byte, minWrapBlocks*aesKWBlock)
+
+	for j := 0; j < aesKWRounds; j++ {
+		for i := 1; i <= n; i++ {
+			copy(buf[:aesKWBlock], a)
+			copy(buf[aesKWBlock:], r[(i-1)*aesKWBlock:i*aesKWBlock])
+			block.Encrypt(buf, buf)
+
+			copy(a, buf[:aesKWBlock])
+			binary.BigEndian.PutUint64(a, binary.BigEndian.Uint64(a)^uint64(n*j+i))
+			copy(r[(i-1)*aesKWBlock:i*aesKWBlock], buf[aesKWBlock:])
+		}
+	}
+
+	return append(append([]byte(nil), a...), r...), nil
+}
+
+// aesKeyUnwrap reverses aesKeyWrap and verifies the RFC 3394 integrity check.
+func aesKeyUnwrap(kek []byte, alg string, ciphertext []byte) ([]byte, error) {
+	if want, ok := aesKWKeyLen(alg); !ok || len(kek) != want {
+		return nil, errors.Newf(errors.InvalidArgument, "algorithm %q does not match key length", alg)
+	}
+
+	if len(ciphertext) < (minWrapBlocks+1)*aesKWBlock || len(ciphertext)%aesKWBlock != 0 {
+		return nil, errors.New(errors.InvalidArgument, "AES key unwrap input is malformed")
+	}
+
+	block, err := aes.NewCipher(kek)
+	if err != nil {
+		return nil, errors.Newf(errors.Internal, "aes cipher: %v", err)
+	}
+
+	n := len(ciphertext)/aesKWBlock - 1
+	a := make([]byte, aesKWBlock)
+	copy(a, ciphertext[:aesKWBlock])
+
+	r := make([]byte, n*aesKWBlock)
+	copy(r, ciphertext[aesKWBlock:])
+
+	buf := make([]byte, minWrapBlocks*aesKWBlock)
+
+	for j := aesKWRounds - 1; j >= 0; j-- {
+		for i := n; i >= 1; i-- {
+			binary.BigEndian.PutUint64(a, binary.BigEndian.Uint64(a)^uint64(n*j+i)) //nolint:gosec // n, j, i are small non-negative loop counters
+			copy(buf[:aesKWBlock], a)
+			copy(buf[aesKWBlock:], r[(i-1)*aesKWBlock:i*aesKWBlock])
+			block.Decrypt(buf, buf)
+
+			copy(a, buf[:aesKWBlock])
+			copy(r[(i-1)*aesKWBlock:i*aesKWBlock], buf[aesKWBlock:])
+		}
+	}
+
+	if subtle.ConstantTimeCompare(a, defaultIV) != 1 {
+		return nil, errors.New(errors.InvalidArgument, "AES key unwrap integrity check failed")
+	}
+
+	return r, nil
+}

--- a/providers/azure/keyvault/keys_azure.go
+++ b/providers/azure/keyvault/keys_azure.go
@@ -83,6 +83,23 @@ func defaultKeyOps(kty string) []string {
 	}
 }
 
+// hsmVariant returns the HSM-protected kty for a software key type. Key Vault
+// stores software and HSM keys identically here (single tier), but the returned
+// kty must preserve the -HSM suffix the caller requested so GetKey/CreateKey
+// round-trip the requested key type instead of silently downgrading it.
+func hsmVariant(kty string) string {
+	switch kty {
+	case ktyRSA:
+		return ktyRSAHSM
+	case ktyEC:
+		return ktyECHSM
+	case ktyOct:
+		return ktyOctHSM
+	default:
+		return kty
+	}
+}
+
 func curveFor(name string) (elliptic.Curve, error) {
 	switch name {
 	case crvP256:
@@ -172,7 +189,8 @@ func generateRSA(v *keyVersion, params *driver.KVCreateKeyParams) error {
 		return errors.Newf(errors.InvalidArgument, "public exponent %d is not supported", params.PublicExponent)
 	}
 
-	v.kty = ktyRSA
+	// v.kty carries the requested kty (RSA or RSA-HSM) from generateVersion;
+	// the -HSM suffix is preserved so the returned key type is not downgraded.
 	v.rsaKey = key
 
 	return nil
@@ -189,7 +207,7 @@ func generateEC(v *keyVersion, params *driver.KVCreateKeyParams) error {
 		return errors.Newf(errors.Internal, "generate EC key: %v", err)
 	}
 
-	v.kty = ktyEC
+	// v.kty carries the requested kty (EC or EC-HSM) from generateVersion.
 	v.curve = params.Curve
 	v.ecKey = key
 
@@ -256,22 +274,24 @@ func (m *Mock) ImportKey(_ context.Context, name string, params *driver.KVImport
 		return nil, err
 	}
 
+	// An explicit hsm=true request imports the key as HSM-protected even when
+	// the JWK kty is a software type; preserve that in the returned key type.
+	if params.HSM {
+		v.kty = hsmVariant(v.kty)
+	}
+
 	return m.storeVersion(name, v)
 }
 
 func importMaterial(v *keyVersion, jwk *driver.KVImportJWK) error {
+	// v.kty keeps the JWK's requested kty (including any -HSM suffix) so the
+	// imported key type is returned as-is instead of being downgraded.
 	switch jwk.Kty {
 	case ktyRSA, ktyRSAHSM:
-		v.kty = ktyRSA
-
 		return importRSA(v, jwk)
 	case ktyEC, ktyECHSM:
-		v.kty = ktyEC
-
 		return importEC(v, jwk)
 	case ktyOct, ktyOctHSM:
-		v.kty = ktyOct
-
 		v.octKey = append([]byte(nil), jwk.K...)
 
 		return nil

--- a/providers/azure/keyvault/keys_azure.go
+++ b/providers/azure/keyvault/keys_azure.go
@@ -1,0 +1,338 @@
+package keyvault
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/hex"
+	"math/big"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+const (
+	ktyRSA    = "RSA"
+	ktyRSAHSM = "RSA-HSM"
+	ktyEC     = "EC"
+	ktyECHSM  = "EC-HSM"
+	ktyOct    = "oct"
+	ktyOctHSM = "oct-HSM"
+
+	crvP256  = "P-256"
+	crvP384  = "P-384"
+	crvP521  = "P-521"
+	crvP256K = "P-256K"
+
+	defaultRSABits     = 2048
+	defaultRSAExponent = 65537
+	rsaBits3072        = 3072
+	rsaBits4096        = 4096
+	versionBytes       = 16
+)
+
+// keyVersion is one stored key version with its Key Vault attributes and the
+// real private key material used for cryptographic operations.
+type keyVersion struct {
+	versionID string
+	kty       string
+	curve     string
+	keyOps    []string
+	rsaKey    *rsa.PrivateKey
+	ecKey     *ecdsa.PrivateKey
+	octKey    []byte
+	tags      map[string]string
+	enabled   bool
+	expires   int64
+	notBefore int64
+	created   time.Time
+	updated   time.Time
+	current   bool
+	managed   bool
+}
+
+type keyData struct {
+	name           string
+	versions       []keyVersion
+	deletedAt      time.Time
+	scheduledPurge time.Time
+	mu             sync.RWMutex
+}
+
+func hexVersion() string {
+	b := make([]byte, versionBytes)
+	_, _ = rand.Read(b)
+
+	return hex.EncodeToString(b)
+}
+
+// defaultKeyOps returns the operations Key Vault assigns when a create/import
+// request omits key_ops: all six for RSA, sign/verify for EC.
+func defaultKeyOps(kty string) []string {
+	switch kty {
+	case ktyEC, ktyECHSM:
+		return []string{"sign", "verify"}
+	case ktyOct, ktyOctHSM:
+		return []string{"encrypt", "decrypt", "wrapKey", "unwrapKey"}
+	default:
+		return []string{"encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"}
+	}
+}
+
+func curveFor(name string) (elliptic.Curve, error) {
+	switch name {
+	case crvP256:
+		return elliptic.P256(), nil
+	case crvP384:
+		return elliptic.P384(), nil
+	case crvP521:
+		return elliptic.P521(), nil
+	case crvP256K:
+		// secp256k1 is not in the Go standard library's crypto/elliptic.
+		return nil, errors.Newf(errors.InvalidArgument, "curve %q is not supported", name)
+	default:
+		return nil, errors.Newf(errors.InvalidArgument, "curve %q is not supported", name)
+	}
+}
+
+// CreateKey generates a new key (RSA or EC) with real key material and stores
+// it as the current version, creating a new version if the name already exists.
+func (m *Mock) CreateKey(_ context.Context, name string, params *driver.KVCreateKeyParams) (*driver.KVKey, error) {
+	if name == "" {
+		return nil, errors.New(errors.InvalidArgument, "key name is required")
+	}
+
+	v, err := m.generateVersion(params)
+	if err != nil {
+		return nil, err
+	}
+
+	return m.storeVersion(name, v)
+}
+
+func (m *Mock) generateVersion(params *driver.KVCreateKeyParams) (*keyVersion, error) {
+	now := m.opts.Clock.Now().UTC()
+
+	keyOps := params.KeyOps
+	if len(keyOps) == 0 {
+		keyOps = defaultKeyOps(params.Kty)
+	}
+
+	v := &keyVersion{
+		versionID: hexVersion(),
+		kty:       params.Kty,
+		keyOps:    keyOps,
+		tags:      copyTags(params.Tags),
+		enabled:   params.Attributes.Enabled,
+		expires:   params.Attributes.Expires,
+		notBefore: params.Attributes.NotBefore,
+		created:   now,
+		updated:   now,
+		current:   true,
+	}
+
+	switch params.Kty {
+	case ktyRSA, ktyRSAHSM:
+		if err := generateRSA(v, params); err != nil {
+			return nil, err
+		}
+	case ktyEC, ktyECHSM:
+		if err := generateEC(v, params); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, errors.Newf(errors.InvalidArgument, "key type %q cannot be created on this vault", params.Kty)
+	}
+
+	return v, nil
+}
+
+func generateRSA(v *keyVersion, params *driver.KVCreateKeyParams) error {
+	bits := params.KeySize
+	if bits == 0 {
+		bits = defaultRSABits
+	}
+
+	if bits != defaultRSABits && bits != rsaBits3072 && bits != rsaBits4096 {
+		return errors.Newf(errors.InvalidArgument, "invalid RSA key size %d", bits)
+	}
+
+	key, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		return errors.Newf(errors.Internal, "generate RSA key: %v", err)
+	}
+
+	if params.PublicExponent != 0 && params.PublicExponent != defaultRSAExponent {
+		// Go's crypto/rsa always uses the exponent 65537; a caller-supplied
+		// exponent that differs cannot be honored.
+		return errors.Newf(errors.InvalidArgument, "public exponent %d is not supported", params.PublicExponent)
+	}
+
+	v.kty = ktyRSA
+	v.rsaKey = key
+
+	return nil
+}
+
+func generateEC(v *keyVersion, params *driver.KVCreateKeyParams) error {
+	curve, err := curveFor(params.Curve)
+	if err != nil {
+		return err
+	}
+
+	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		return errors.Newf(errors.Internal, "generate EC key: %v", err)
+	}
+
+	v.kty = ktyEC
+	v.curve = params.Curve
+	v.ecKey = key
+
+	return nil
+}
+
+// storeVersion appends v as the current version of name, creating the key if
+// it does not yet exist. A soft-deleted name cannot be reused until recovered.
+func (m *Mock) storeVersion(name string, v *keyVersion) (*driver.KVKey, error) {
+	if kd, ok := m.keys.Get(name); ok {
+		kd.mu.Lock()
+		defer kd.mu.Unlock()
+
+		if !kd.deletedAt.IsZero() {
+			return nil, errors.Newf(errors.AlreadyExists, "key %q is in a deleted but recoverable state", name)
+		}
+
+		for i := range kd.versions {
+			kd.versions[i].current = false
+		}
+
+		kd.versions = append(kd.versions, *v)
+		kv := toKVKey(name, &kd.versions[len(kd.versions)-1])
+
+		return &kv, nil
+	}
+
+	kd := &keyData{name: name, versions: []keyVersion{*v}}
+	m.keys.Set(name, kd)
+
+	kv := toKVKey(name, &kd.versions[0])
+
+	return &kv, nil
+}
+
+// ImportKey stores a caller-supplied key. RSA and EC keys are reconstructed
+// from their JWK components; oct keys keep their raw bytes.
+func (m *Mock) ImportKey(_ context.Context, name string, params *driver.KVImportKeyParams) (*driver.KVKey, error) {
+	if name == "" {
+		return nil, errors.New(errors.InvalidArgument, "key name is required")
+	}
+
+	now := m.opts.Clock.Now().UTC()
+
+	keyOps := params.Key.KeyOps
+	if len(keyOps) == 0 {
+		keyOps = defaultKeyOps(params.Key.Kty)
+	}
+
+	v := &keyVersion{
+		versionID: hexVersion(),
+		kty:       params.Key.Kty,
+		keyOps:    keyOps,
+		tags:      copyTags(params.Tags),
+		enabled:   params.Attributes.Enabled,
+		expires:   params.Attributes.Expires,
+		notBefore: params.Attributes.NotBefore,
+		created:   now,
+		updated:   now,
+		current:   true,
+	}
+
+	if err := importMaterial(v, &params.Key); err != nil {
+		return nil, err
+	}
+
+	return m.storeVersion(name, v)
+}
+
+func importMaterial(v *keyVersion, jwk *driver.KVImportJWK) error {
+	switch jwk.Kty {
+	case ktyRSA, ktyRSAHSM:
+		v.kty = ktyRSA
+
+		return importRSA(v, jwk)
+	case ktyEC, ktyECHSM:
+		v.kty = ktyEC
+
+		return importEC(v, jwk)
+	case ktyOct, ktyOctHSM:
+		v.kty = ktyOct
+
+		v.octKey = append([]byte(nil), jwk.K...)
+
+		return nil
+	default:
+		return errors.Newf(errors.InvalidArgument, "key type %q cannot be imported", jwk.Kty)
+	}
+}
+
+func importRSA(v *keyVersion, jwk *driver.KVImportJWK) error {
+	if len(jwk.N) == 0 || len(jwk.E) == 0 || len(jwk.D) == 0 {
+		return errors.New(errors.InvalidArgument, "RSA import requires n, e and d")
+	}
+
+	key := &rsa.PrivateKey{
+		PublicKey: rsa.PublicKey{
+			N: new(big.Int).SetBytes(jwk.N),
+			E: int(new(big.Int).SetBytes(jwk.E).Int64()),
+		},
+		D: new(big.Int).SetBytes(jwk.D),
+	}
+
+	if len(jwk.P) > 0 && len(jwk.Q) > 0 {
+		key.Primes = []*big.Int{new(big.Int).SetBytes(jwk.P), new(big.Int).SetBytes(jwk.Q)}
+	}
+
+	if err := key.Validate(); err != nil {
+		return errors.Newf(errors.InvalidArgument, "invalid RSA key material: %v", err)
+	}
+
+	key.Precompute()
+	v.rsaKey = key
+
+	return nil
+}
+
+func importEC(v *keyVersion, jwk *driver.KVImportJWK) error {
+	curve, err := curveFor(jwk.Curve)
+	if err != nil {
+		return err
+	}
+
+	if len(jwk.X) == 0 || len(jwk.Y) == 0 || len(jwk.D) == 0 {
+		return errors.New(errors.InvalidArgument, "EC import requires x, y and d")
+	}
+
+	key := &ecdsa.PrivateKey{
+		PublicKey: ecdsa.PublicKey{
+			Curve: curve,
+			X:     new(big.Int).SetBytes(jwk.X),
+			Y:     new(big.Int).SetBytes(jwk.Y),
+		},
+		D: new(big.Int).SetBytes(jwk.D),
+	}
+
+	//nolint:staticcheck // IsOnCurve is the direct on-curve check for an ecdsa.PublicKey we reconstruct from JWK components
+	if !curve.IsOnCurve(key.X, key.Y) {
+		return errors.New(errors.InvalidArgument, "invalid EC key material: point is not on curve")
+	}
+
+	v.curve = jwk.Curve
+	v.ecKey = key
+
+	return nil
+}

--- a/providers/azure/keyvault/keys_azure_test.go
+++ b/providers/azure/keyvault/keys_azure_test.go
@@ -1,0 +1,189 @@
+package keyvault
+
+import (
+	"context"
+	"crypto/sha256"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateRSAKeyAndCrypto(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	key, err := m.CreateKey(ctx, "k", &driver.KVCreateKeyParams{Kty: "RSA", KeySize: 2048, Attributes: driver.KVKeyAttributes{Enabled: true}})
+	require.NoError(t, err)
+	assert.Equal(t, "RSA", key.Kty)
+	assert.NotEmpty(t, key.N)
+	assert.NotEmpty(t, key.E)
+
+	plaintext := []byte("secret payload")
+
+	enc, err := m.EncryptKey(ctx, "k", "", driver.KVCryptoParams{Algorithm: "RSA-OAEP-256", Value: plaintext})
+	require.NoError(t, err)
+
+	dec, err := m.DecryptKey(ctx, "k", "", driver.KVCryptoParams{Algorithm: "RSA-OAEP-256", Value: enc.Value})
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, dec.Value)
+}
+
+func TestCreateECKeySignVerify(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateKey(ctx, "ec", &driver.KVCreateKeyParams{Kty: "EC", Curve: "P-384", Attributes: driver.KVKeyAttributes{Enabled: true}})
+	require.NoError(t, err)
+
+	digest := sha256.Sum256([]byte("data"))
+
+	sig, err := m.SignKey(ctx, "ec", "", driver.KVCryptoParams{Algorithm: "ES384", Value: digest[:]})
+	require.NoError(t, err)
+
+	ok, err := m.VerifyKey(ctx, "ec", "", driver.KVCryptoParams{Algorithm: "ES384", Value: digest[:], Signature: sig.Value})
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestUnsupportedCurveRejected(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.CreateKey(context.Background(), "k", &driver.KVCreateKeyParams{Kty: "EC", Curve: "P-256K"})
+	require.Error(t, err)
+}
+
+func TestImportOctKeyAESKeyWrap(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	kek := []byte("0123456789abcdef0123456789abcdef") // 32-byte AES-256 KEK
+
+	_, err := m.ImportKey(ctx, "kek", &driver.KVImportKeyParams{
+		Key:        driver.KVImportJWK{Kty: "oct", K: kek, KeyOps: []string{"wrapKey", "unwrapKey"}},
+		Attributes: driver.KVKeyAttributes{Enabled: true},
+	})
+	require.NoError(t, err)
+
+	cek := []byte("fedcba9876543210fedcba9876543210") // 32-byte content key
+
+	wrapped, err := m.WrapKey(ctx, "kek", "", driver.KVCryptoParams{Algorithm: "A256KW", Value: cek})
+	require.NoError(t, err)
+	assert.NotEqual(t, cek, wrapped.Value)
+
+	unwrapped, err := m.UnwrapKey(ctx, "kek", "", driver.KVCryptoParams{Algorithm: "A256KW", Value: wrapped.Value})
+	require.NoError(t, err)
+	assert.Equal(t, cek, unwrapped.Value)
+}
+
+func TestAESKeyUnwrapIntegrityFailure(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	kek := []byte("0123456789abcdef") // 16-byte AES-128 KEK
+
+	_, err := m.ImportKey(ctx, "kek", &driver.KVImportKeyParams{
+		Key:        driver.KVImportJWK{Kty: "oct", K: kek},
+		Attributes: driver.KVKeyAttributes{Enabled: true},
+	})
+	require.NoError(t, err)
+
+	corrupt := make([]byte, 40)
+
+	_, err = m.UnwrapKey(ctx, "kek", "", driver.KVCryptoParams{Algorithm: "A128KW", Value: corrupt})
+	require.Error(t, err)
+}
+
+func TestImportRSAKeyRoundTrip(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	// Generate a key via CreateKey, then round-trip its private components back
+	// through ImportKey to confirm reconstruction is exact.
+	src := newTestMock()
+
+	_, err := src.CreateKey(ctx, "orig", &driver.KVCreateKeyParams{Kty: "RSA", Attributes: driver.KVKeyAttributes{Enabled: true}})
+	require.NoError(t, err)
+
+	kd, ok := src.keys.Get("orig")
+	require.True(t, ok)
+
+	v := &kd.versions[0]
+	priv := v.rsaKey
+
+	jwk := driver.KVImportJWK{
+		Kty: "RSA",
+		N:   priv.N.Bytes(),
+		E:   encodeExponent(priv.E),
+		D:   priv.D.Bytes(),
+		P:   priv.Primes[0].Bytes(),
+		Q:   priv.Primes[1].Bytes(),
+	}
+
+	_, err = m.ImportKey(ctx, "imp", &driver.KVImportKeyParams{Key: jwk, Attributes: driver.KVKeyAttributes{Enabled: true}})
+	require.NoError(t, err)
+
+	digest := sha256.Sum256([]byte("cross"))
+
+	sig, err := src.SignKey(ctx, "orig", "", driver.KVCryptoParams{Algorithm: "RS256", Value: digest[:]})
+	require.NoError(t, err)
+
+	ok2, err := m.VerifyKey(ctx, "imp", "", driver.KVCryptoParams{Algorithm: "RS256", Value: digest[:], Signature: sig.Value})
+	require.NoError(t, err)
+	assert.True(t, ok2)
+}
+
+func TestKeySoftDeleteRecoverPurge(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateKey(ctx, "k", &driver.KVCreateKeyParams{Kty: "RSA", Attributes: driver.KVKeyAttributes{Enabled: true}})
+	require.NoError(t, err)
+
+	_, err = m.DeleteKey(ctx, "k")
+	require.NoError(t, err)
+
+	_, err = m.GetKey(ctx, "k", "")
+	require.Error(t, err)
+
+	_, err = m.GetDeletedKey(ctx, "k")
+	require.NoError(t, err)
+
+	_, err = m.RecoverDeletedKey(ctx, "k")
+	require.NoError(t, err)
+
+	_, err = m.GetKey(ctx, "k", "")
+	require.NoError(t, err)
+
+	_, err = m.DeleteKey(ctx, "k")
+	require.NoError(t, err)
+
+	require.NoError(t, m.PurgeDeletedKey(ctx, "k"))
+
+	_, err = m.GetDeletedKey(ctx, "k")
+	require.Error(t, err)
+}
+
+func TestKeyOperationNotPermitted(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	// An EC key defaults to sign/verify only; encrypt must be rejected.
+	_, err := m.CreateKey(ctx, "ec", &driver.KVCreateKeyParams{Kty: "EC", Curve: "P-256", Attributes: driver.KVKeyAttributes{Enabled: true}})
+	require.NoError(t, err)
+
+	_, err = m.EncryptKey(ctx, "ec", "", driver.KVCryptoParams{Algorithm: "RSA-OAEP", Value: []byte("x")})
+	require.Error(t, err)
+}
+
+func TestDisabledKeyRejectsCrypto(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateKey(ctx, "k", &driver.KVCreateKeyParams{Kty: "RSA", Attributes: driver.KVKeyAttributes{Enabled: false}})
+	require.NoError(t, err)
+
+	_, err = m.EncryptKey(ctx, "k", "", driver.KVCryptoParams{Algorithm: "RSA-OAEP", Value: []byte("x")})
+	require.Error(t, err)
+}

--- a/providers/azure/keyvault/keys_azure_test.go
+++ b/providers/azure/keyvault/keys_azure_test.go
@@ -47,6 +47,76 @@ func TestCreateECKeySignVerify(t *testing.T) {
 	assert.True(t, ok)
 }
 
+func TestCreateHSMKeyPreservesKty(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	rsa, err := m.CreateKey(ctx, "rsa-hsm",
+		&driver.KVCreateKeyParams{Kty: "RSA-HSM", Attributes: driver.KVKeyAttributes{Enabled: true}})
+	require.NoError(t, err)
+	assert.Equal(t, "RSA-HSM", rsa.Kty)
+
+	got, err := m.GetKey(ctx, "rsa-hsm", "")
+	require.NoError(t, err)
+	assert.Equal(t, "RSA-HSM", got.Kty)
+
+	ec, err := m.CreateKey(ctx, "ec-hsm",
+		&driver.KVCreateKeyParams{Kty: "EC-HSM", Curve: "P-256", Attributes: driver.KVKeyAttributes{Enabled: true}})
+	require.NoError(t, err)
+	assert.Equal(t, "EC-HSM", ec.Kty)
+
+	// HSM keys still perform real crypto (single-tier storage).
+	digest := sha256.Sum256([]byte("data"))
+
+	sig, err := m.SignKey(ctx, "ec-hsm", "", driver.KVCryptoParams{Algorithm: "ES256", Value: digest[:]})
+	require.NoError(t, err)
+
+	ok, err := m.VerifyKey(ctx, "ec-hsm", "", driver.KVCryptoParams{Algorithm: "ES256", Value: digest[:], Signature: sig.Value})
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestImportKeyHSMFlagPromotesKty(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	kek := []byte("0123456789abcdef0123456789abcdef")
+
+	// A software oct JWK imported with HSM:true must round-trip as oct-HSM.
+	imported, err := m.ImportKey(ctx, "kek", &driver.KVImportKeyParams{
+		Key:        driver.KVImportJWK{Kty: "oct", K: kek},
+		HSM:        true,
+		Attributes: driver.KVKeyAttributes{Enabled: true},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "oct-HSM", imported.Kty)
+
+	// An explicit RSA-HSM JWK is preserved as-is without the HSM flag.
+	src := newTestMock()
+
+	_, err = src.CreateKey(ctx, "orig", &driver.KVCreateKeyParams{Kty: "RSA", Attributes: driver.KVKeyAttributes{Enabled: true}})
+	require.NoError(t, err)
+
+	kd, ok := src.keys.Get("orig")
+	require.True(t, ok)
+
+	priv := kd.versions[0].rsaKey
+
+	rsaHSM, err := m.ImportKey(ctx, "imp", &driver.KVImportKeyParams{
+		Key: driver.KVImportJWK{
+			Kty: "RSA-HSM",
+			N:   priv.N.Bytes(),
+			E:   encodeExponent(priv.E),
+			D:   priv.D.Bytes(),
+			P:   priv.Primes[0].Bytes(),
+			Q:   priv.Primes[1].Bytes(),
+		},
+		Attributes: driver.KVKeyAttributes{Enabled: true},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "RSA-HSM", rsaHSM.Kty)
+}
+
 func TestUnsupportedCurveRejected(t *testing.T) {
 	m := newTestMock()
 

--- a/providers/azure/keyvault/keys_crypto_azure.go
+++ b/providers/azure/keyvault/keys_crypto_azure.go
@@ -1,0 +1,335 @@
+package keyvault
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1" //nolint:gosec // RSA-OAEP (SHA-1) is a Key Vault wire algorithm we must emulate
+	"crypto/sha256"
+	_ "crypto/sha512" // registers SHA-384/512 for RSA-PSS sign/verify
+	"hash"
+	"math/big"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+const (
+	algRSAOAEP    = "RSA-OAEP"
+	algRSAOAEP256 = "RSA-OAEP-256"
+	algRSA15      = "RSA1_5"
+
+	algRS256 = "RS256"
+	algRS384 = "RS384"
+	algRS512 = "RS512"
+	algPS256 = "PS256"
+	algPS384 = "PS384"
+	algPS512 = "PS512"
+	algES256 = "ES256"
+	algES384 = "ES384"
+	algES512 = "ES512"
+
+	algA128KW = "A128KW"
+	algA192KW = "A192KW"
+	algA256KW = "A256KW"
+
+	kindRSA = "rsa"
+	kindPSS = "pss"
+	kindEC  = "ec"
+)
+
+// opKey resolves a live, enabled key version and checks that op is permitted.
+func (m *Mock) opKey(name, version, op string) (*keyVersion, error) {
+	kd := m.liveKey(name)
+	if kd == nil {
+		return nil, errors.Newf(errors.NotFound, "key %q not found", name)
+	}
+
+	kd.mu.RLock()
+	defer kd.mu.RUnlock()
+
+	v := findKeyVersion(kd, version)
+	if v == nil {
+		return nil, errors.Newf(errors.NotFound, "version %q not found for key %q", version, name)
+	}
+
+	if !v.enabled {
+		return nil, errors.Newf(errors.FailedPrecondition, "key %q is disabled", name)
+	}
+
+	if !opAllowed(v.keyOps, op) {
+		return nil, errors.Newf(errors.PermissionDenied, "operation %q is not permitted on key %q", op, name)
+	}
+
+	return v, nil
+}
+
+func opAllowed(ops []string, op string) bool {
+	for _, o := range ops {
+		if o == op {
+			return true
+		}
+	}
+
+	return false
+}
+
+func rsaOAEPHash(alg string) (hash.Hash, bool) {
+	switch alg {
+	case algRSAOAEP:
+		return sha1.New(), true //nolint:gosec // RSA-OAEP (SHA-1) is a Key Vault wire algorithm we must emulate
+	case algRSAOAEP256:
+		return sha256.New(), true
+	default:
+		return nil, false
+	}
+}
+
+func result(v *keyVersion, out []byte) *driver.KVCryptoResult {
+	return &driver.KVCryptoResult{Version: v.versionID, Value: out}
+}
+
+// EncryptKey encrypts a single block with the key's public part.
+func (m *Mock) EncryptKey(_ context.Context, name, version string, p driver.KVCryptoParams) (*driver.KVCryptoResult, error) {
+	v, err := m.opKey(name, version, "encrypt")
+	if err != nil {
+		return nil, err
+	}
+
+	if v.rsaKey == nil {
+		return nil, errors.Newf(errors.InvalidArgument, "algorithm %q requires an RSA key", p.Algorithm)
+	}
+
+	out, err := rsaEncrypt(&v.rsaKey.PublicKey, p.Algorithm, p.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	return result(v, out), nil
+}
+
+// DecryptKey decrypts a single block with the key's private part.
+func (m *Mock) DecryptKey(_ context.Context, name, version string, p driver.KVCryptoParams) (*driver.KVCryptoResult, error) {
+	v, err := m.opKey(name, version, "decrypt")
+	if err != nil {
+		return nil, err
+	}
+
+	if v.rsaKey == nil {
+		return nil, errors.Newf(errors.InvalidArgument, "algorithm %q requires an RSA key", p.Algorithm)
+	}
+
+	out, err := rsaDecrypt(v.rsaKey, p.Algorithm, p.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	return result(v, out), nil
+}
+
+// WrapKey wraps a symmetric key. RSA keys wrap with the RSA algorithms; oct
+// keys wrap with AES key wrap (RFC 3394).
+func (m *Mock) WrapKey(_ context.Context, name, version string, p driver.KVCryptoParams) (*driver.KVCryptoResult, error) {
+	v, err := m.opKey(name, version, "wrapKey")
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := wrap(v, p, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return result(v, out), nil
+}
+
+// UnwrapKey reverses WrapKey.
+func (m *Mock) UnwrapKey(_ context.Context, name, version string, p driver.KVCryptoParams) (*driver.KVCryptoResult, error) {
+	v, err := m.opKey(name, version, "unwrapKey")
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := wrap(v, p, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return result(v, out), nil
+}
+
+func wrap(v *keyVersion, p driver.KVCryptoParams, forward bool) ([]byte, error) {
+	switch {
+	case v.rsaKey != nil && forward:
+		return rsaEncrypt(&v.rsaKey.PublicKey, p.Algorithm, p.Value)
+	case v.rsaKey != nil:
+		return rsaDecrypt(v.rsaKey, p.Algorithm, p.Value)
+	case v.octKey != nil && forward:
+		return aesKeyWrap(v.octKey, p.Algorithm, p.Value)
+	case v.octKey != nil:
+		return aesKeyUnwrap(v.octKey, p.Algorithm, p.Value)
+	default:
+		return nil, errors.Newf(errors.InvalidArgument, "algorithm %q is not supported for this key type", p.Algorithm)
+	}
+}
+
+func rsaEncrypt(pub *rsa.PublicKey, alg string, msg []byte) ([]byte, error) {
+	if alg == algRSA15 {
+		return rsa.EncryptPKCS1v15(rand.Reader, pub, msg)
+	}
+
+	h, ok := rsaOAEPHash(alg)
+	if !ok {
+		return nil, errors.Newf(errors.InvalidArgument, "unsupported encryption algorithm %q", alg)
+	}
+
+	return rsa.EncryptOAEP(h, rand.Reader, pub, msg, nil)
+}
+
+func rsaDecrypt(key *rsa.PrivateKey, alg string, ct []byte) ([]byte, error) {
+	if alg == algRSA15 {
+		return rsa.DecryptPKCS1v15(rand.Reader, key, ct)
+	}
+
+	h, ok := rsaOAEPHash(alg)
+	if !ok {
+		return nil, errors.Newf(errors.InvalidArgument, "unsupported encryption algorithm %q", alg)
+	}
+
+	return rsa.DecryptOAEP(h, rand.Reader, key, ct, nil)
+}
+
+// SignKey signs a pre-computed digest and returns the signature.
+func (m *Mock) SignKey(_ context.Context, name, version string, p driver.KVCryptoParams) (*driver.KVCryptoResult, error) {
+	v, err := m.opKey(name, version, "sign")
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := sign(v, p.Algorithm, p.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	return result(v, out), nil
+}
+
+// VerifyKey checks a signature over a digest.
+func (m *Mock) VerifyKey(_ context.Context, name, version string, p driver.KVCryptoParams) (bool, error) {
+	v, err := m.opKey(name, version, "verify")
+	if err != nil {
+		return false, err
+	}
+
+	return verify(v, p.Algorithm, p.Value, p.Signature)
+}
+
+// sigHash maps a signature algorithm to its digest hash and whether it is RSA,
+// RSA-PSS or ECDSA.
+func sigHash(alg string) (crypto.Hash, string, bool) {
+	switch alg {
+	case algRS256:
+		return crypto.SHA256, kindRSA, true
+	case algPS256:
+		return crypto.SHA256, kindPSS, true
+	case algES256:
+		return crypto.SHA256, kindEC, true
+	case algRS384:
+		return crypto.SHA384, kindRSA, true
+	case algPS384:
+		return crypto.SHA384, kindPSS, true
+	case algES384:
+		return crypto.SHA384, kindEC, true
+	case algRS512:
+		return crypto.SHA512, kindRSA, true
+	case algPS512:
+		return crypto.SHA512, kindPSS, true
+	case algES512:
+		return crypto.SHA512, kindEC, true
+	default:
+		return 0, "", false
+	}
+}
+
+func sign(v *keyVersion, alg string, digest []byte) ([]byte, error) {
+	h, kind, ok := sigHash(alg)
+	if !ok {
+		return nil, errors.Newf(errors.InvalidArgument, "unsupported signature algorithm %q", alg)
+	}
+
+	switch kind {
+	case kindRSA:
+		if v.rsaKey == nil {
+			return nil, errors.Newf(errors.InvalidArgument, "algorithm %q requires an RSA key", alg)
+		}
+
+		return rsa.SignPKCS1v15(rand.Reader, v.rsaKey, h, digest)
+	case kindPSS:
+		if v.rsaKey == nil {
+			return nil, errors.Newf(errors.InvalidArgument, "algorithm %q requires an RSA key", alg)
+		}
+
+		return rsa.SignPSS(rand.Reader, v.rsaKey, h, digest, &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
+	default:
+		return ecSign(v, digest)
+	}
+}
+
+func ecSign(v *keyVersion, digest []byte) ([]byte, error) {
+	if v.ecKey == nil {
+		return nil, errors.New(errors.InvalidArgument, "ECDSA algorithm requires an EC key")
+	}
+
+	r, s, err := ecdsa.Sign(rand.Reader, v.ecKey, digest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Key Vault returns EC signatures as the raw r||s concatenation, each
+	// padded to the curve's coordinate length (IEEE P1363), not ASN.1 DER.
+	size := (v.ecKey.Curve.Params().BitSize + 7) / 8
+
+	return append(padLeft(r.Bytes(), size), padLeft(s.Bytes(), size)...), nil
+}
+
+func verify(v *keyVersion, alg string, digest, sig []byte) (bool, error) {
+	h, kind, ok := sigHash(alg)
+	if !ok {
+		return false, errors.Newf(errors.InvalidArgument, "unsupported signature algorithm %q", alg)
+	}
+
+	switch kind {
+	case kindRSA:
+		if v.rsaKey == nil {
+			return false, errors.Newf(errors.InvalidArgument, "algorithm %q requires an RSA key", alg)
+		}
+
+		return rsa.VerifyPKCS1v15(&v.rsaKey.PublicKey, h, digest, sig) == nil, nil
+	case kindPSS:
+		if v.rsaKey == nil {
+			return false, errors.Newf(errors.InvalidArgument, "algorithm %q requires an RSA key", alg)
+		}
+
+		return rsa.VerifyPSS(&v.rsaKey.PublicKey, h, digest, sig, nil) == nil, nil
+	default:
+		return ecVerify(v, digest, sig)
+	}
+}
+
+func ecVerify(v *keyVersion, digest, sig []byte) (bool, error) {
+	if v.ecKey == nil {
+		return false, errors.New(errors.InvalidArgument, "ECDSA algorithm requires an EC key")
+	}
+
+	size := (v.ecKey.Curve.Params().BitSize + 7) / 8
+	if len(sig) != 2*size {
+		return false, nil
+	}
+
+	r := new(big.Int).SetBytes(sig[:size])
+	s := new(big.Int).SetBytes(sig[size:])
+
+	return ecdsa.Verify(&v.ecKey.PublicKey, digest, r, s), nil
+}

--- a/providers/azure/keyvault/keys_store_azure.go
+++ b/providers/azure/keyvault/keys_store_azure.go
@@ -1,0 +1,309 @@
+package keyvault
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+// padLeft returns b left-padded with zeros to size bytes. Used for EC
+// coordinates, which Key Vault returns at the curve's coordinate length.
+func padLeft(b []byte, size int) []byte {
+	if len(b) >= size {
+		return b
+	}
+
+	out := make([]byte, size)
+	copy(out[size-len(b):], b)
+
+	return out
+}
+
+func encodeExponent(e int) []byte {
+	return big.NewInt(int64(e)).Bytes()
+}
+
+// toKVKey projects a stored version onto the driver's public key view. Private
+// components are never included.
+func toKVKey(name string, v *keyVersion) driver.KVKey {
+	kv := driver.KVKey{
+		Name:      name,
+		Version:   v.versionID,
+		Kty:       v.kty,
+		Curve:     v.curve,
+		KeyOps:    append([]string(nil), v.keyOps...),
+		Tags:      copyTags(v.tags),
+		Enabled:   v.enabled,
+		Expires:   v.expires,
+		NotBefore: v.notBefore,
+		Created:   v.created.Unix(),
+		Updated:   v.updated.Unix(),
+		Managed:   v.managed,
+	}
+
+	switch {
+	case v.rsaKey != nil:
+		kv.N = v.rsaKey.N.Bytes()
+		kv.E = encodeExponent(v.rsaKey.E)
+	case v.ecKey != nil:
+		size := (v.ecKey.Curve.Params().BitSize + 7) / 8
+		kv.X = padLeft(v.ecKey.X.Bytes(), size)
+		kv.Y = padLeft(v.ecKey.Y.Bytes(), size)
+	}
+
+	return kv
+}
+
+// liveKey returns the stored key if it exists and is not soft-deleted.
+func (m *Mock) liveKey(name string) *keyData {
+	kd, ok := m.keys.Get(name)
+	if !ok {
+		return nil
+	}
+
+	kd.mu.RLock()
+	deleted := !kd.deletedAt.IsZero()
+	kd.mu.RUnlock()
+
+	if deleted {
+		return nil
+	}
+
+	return kd
+}
+
+func findKeyVersion(kd *keyData, version string) *keyVersion {
+	for i := range kd.versions {
+		v := &kd.versions[i]
+		if version == "" && v.current {
+			return v
+		}
+
+		if v.versionID == version {
+			return v
+		}
+	}
+
+	return nil
+}
+
+// GetKey returns one key version. Empty version returns the current version.
+func (m *Mock) GetKey(_ context.Context, name, version string) (*driver.KVKey, error) {
+	kd := m.liveKey(name)
+	if kd == nil {
+		return nil, errors.Newf(errors.NotFound, "key %q not found", name)
+	}
+
+	kd.mu.RLock()
+	defer kd.mu.RUnlock()
+
+	v := findKeyVersion(kd, version)
+	if v == nil {
+		return nil, errors.Newf(errors.NotFound, "version %q not found for key %q", version, name)
+	}
+
+	kv := toKVKey(name, v)
+
+	return &kv, nil
+}
+
+// ListKeys returns the current version of each live key.
+func (m *Mock) ListKeys(_ context.Context) ([]driver.KVKey, error) {
+	all := m.keys.All()
+
+	out := make([]driver.KVKey, 0, len(all))
+
+	for _, kd := range all {
+		kd.mu.RLock()
+		if kd.deletedAt.IsZero() {
+			if v := findKeyVersion(kd, ""); v != nil {
+				out = append(out, toKVKey(kd.name, v))
+			}
+		}
+		kd.mu.RUnlock()
+	}
+
+	return out, nil
+}
+
+// ListKeyVersions returns every version of a key.
+func (m *Mock) ListKeyVersions(_ context.Context, name string) ([]driver.KVKey, error) {
+	kd := m.liveKey(name)
+	if kd == nil {
+		return nil, errors.Newf(errors.NotFound, "key %q not found", name)
+	}
+
+	kd.mu.RLock()
+	defer kd.mu.RUnlock()
+
+	out := make([]driver.KVKey, len(kd.versions))
+	for i := range kd.versions {
+		out[i] = toKVKey(name, &kd.versions[i])
+	}
+
+	return out, nil
+}
+
+// UpdateKey patches a version's attributes, tags and key operations.
+func (m *Mock) UpdateKey(_ context.Context, name, version string, patch driver.KVKeyPatch) (*driver.KVKey, error) {
+	kd := m.liveKey(name)
+	if kd == nil {
+		return nil, errors.Newf(errors.NotFound, "key %q not found", name)
+	}
+
+	kd.mu.Lock()
+	defer kd.mu.Unlock()
+
+	v := findKeyVersion(kd, version)
+	if v == nil {
+		return nil, errors.Newf(errors.NotFound, "version %q not found for key %q", version, name)
+	}
+
+	applyKeyPatch(v, patch)
+	v.updated = m.opts.Clock.Now().UTC()
+
+	kv := toKVKey(name, v)
+
+	return &kv, nil
+}
+
+func applyKeyPatch(v *keyVersion, patch driver.KVKeyPatch) {
+	if patch.Enabled != nil {
+		v.enabled = *patch.Enabled
+	}
+
+	if patch.Expires != nil {
+		v.expires = *patch.Expires
+	}
+
+	if patch.NotBefore != nil {
+		v.notBefore = *patch.NotBefore
+	}
+
+	if patch.SetTags {
+		v.tags = copyTags(patch.Tags)
+	}
+
+	if patch.SetKeyOps {
+		v.keyOps = append([]string(nil), patch.KeyOps...)
+	}
+}
+
+// DeleteKey soft-deletes a key and returns its deleted view.
+func (m *Mock) DeleteKey(_ context.Context, name string) (*driver.KVDeletedKey, error) {
+	kd := m.liveKey(name)
+	if kd == nil {
+		return nil, errors.Newf(errors.NotFound, "key %q not found", name)
+	}
+
+	kd.mu.Lock()
+	defer kd.mu.Unlock()
+
+	now := m.opts.Clock.Now().UTC()
+	kd.deletedAt = now
+	kd.scheduledPurge = now.AddDate(0, 0, purgeWindowDays)
+
+	return deletedKeyView(kd), nil
+}
+
+func deletedKeyView(kd *keyData) *driver.KVDeletedKey {
+	v := findKeyVersion(kd, "")
+	if v == nil && len(kd.versions) > 0 {
+		v = &kd.versions[len(kd.versions)-1]
+	}
+
+	var kv driver.KVKey
+	if v != nil {
+		kv = toKVKey(kd.name, v)
+	}
+
+	return &driver.KVDeletedKey{
+		KVKey:              kv,
+		DeletedDate:        kd.deletedAt.Unix(),
+		ScheduledPurgeDate: kd.scheduledPurge.Unix(),
+	}
+}
+
+// GetDeletedKey returns a soft-deleted key by name.
+func (m *Mock) GetDeletedKey(_ context.Context, name string) (*driver.KVDeletedKey, error) {
+	kd, ok := m.keys.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "deleted key %q not found", name)
+	}
+
+	kd.mu.RLock()
+	defer kd.mu.RUnlock()
+
+	if kd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "deleted key %q not found", name)
+	}
+
+	return deletedKeyView(kd), nil
+}
+
+// ListDeletedKeys returns all soft-deleted keys.
+func (m *Mock) ListDeletedKeys(_ context.Context) ([]driver.KVDeletedKey, error) {
+	all := m.keys.All()
+
+	out := make([]driver.KVDeletedKey, 0, len(all))
+
+	for _, kd := range all {
+		kd.mu.RLock()
+		if !kd.deletedAt.IsZero() {
+			out = append(out, *deletedKeyView(kd))
+		}
+		kd.mu.RUnlock()
+	}
+
+	return out, nil
+}
+
+// RecoverDeletedKey clears the soft-delete state of a key.
+func (m *Mock) RecoverDeletedKey(_ context.Context, name string) (*driver.KVKey, error) {
+	kd, ok := m.keys.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "deleted key %q not found", name)
+	}
+
+	kd.mu.Lock()
+	defer kd.mu.Unlock()
+
+	if kd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "deleted key %q not found", name)
+	}
+
+	kd.deletedAt = time.Time{}
+	kd.scheduledPurge = time.Time{}
+
+	v := findKeyVersion(kd, "")
+
+	var kv driver.KVKey
+	if v != nil {
+		kv = toKVKey(name, v)
+	}
+
+	return &kv, nil
+}
+
+// PurgeDeletedKey permanently removes a soft-deleted key.
+func (m *Mock) PurgeDeletedKey(_ context.Context, name string) error {
+	kd, ok := m.keys.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "deleted key %q not found", name)
+	}
+
+	kd.mu.RLock()
+	deleted := !kd.deletedAt.IsZero()
+	kd.mu.RUnlock()
+
+	if !deleted {
+		return errors.Newf(errors.NotFound, "deleted key %q not found", name)
+	}
+
+	m.keys.Delete(name)
+
+	return nil
+}

--- a/providers/azure/keyvault/keyvault.go
+++ b/providers/azure/keyvault/keyvault.go
@@ -14,10 +14,11 @@ import (
 )
 
 // Compile-time checks that Mock implements the shared Secrets driver and the
-// Azure-specific KeyVaultSecrets surface.
+// Azure-specific KeyVaultSecrets and KeyVaultKeys surfaces.
 var (
 	_ driver.Secrets         = (*Mock)(nil)
 	_ driver.KeyVaultSecrets = (*Mock)(nil)
+	_ driver.KeyVaultKeys    = (*Mock)(nil)
 )
 
 // purgeWindowDays is the soft-delete retention window Key Vault schedules
@@ -49,6 +50,7 @@ type secretData struct {
 // Mock is an in-memory mock implementation of Azure Key Vault.
 type Mock struct {
 	secrets *memstore.Store[*secretData]
+	keys    *memstore.Store[*keyData]
 	opts    *config.Options
 }
 
@@ -56,6 +58,7 @@ type Mock struct {
 func New(opts *config.Options) *Mock {
 	return &Mock{
 		secrets: memstore.New[*secretData](),
+		keys:    memstore.New[*keyData](),
 		opts:    opts,
 	}
 }

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -447,6 +447,12 @@ func New(d Drivers) http.Handler {
 	// register before the permissive BlobStorage fallback below.
 	if d.KeyVault != nil {
 		srv.Register(keyvaultsrv.New(d.KeyVault))
+		// Keys data-plane matches /keys and /deletedkeys — disjoint from the
+		// /secrets surface above and from ARM. Registered only when the backend
+		// implements the KeyVaultKeys surface.
+		if _, ok := d.KeyVault.(secretsdriver.KeyVaultKeys); ok {
+			srv.Register(keyvaultsrv.NewKeys(d.KeyVault))
+		}
 	}
 
 	// Table Storage matches the OData table surface (/Tables, /Tables('name'),

--- a/server/azure/keyvault/handler.go
+++ b/server/azure/keyvault/handler.go
@@ -72,25 +72,42 @@ func (*Handler) Matches(r *http.Request) bool {
 // ServeHTTP answers the bearer challenge for unauthenticated requests, then
 // routes on the path and method.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.Header.Get("Authorization") == "" {
-		w.Header().Set("WWW-Authenticate",
-			`Bearer authorization="https://login.microsoftonline.com/common", resource="https://vault.azure.net"`)
-		writeErr(w, http.StatusUnauthorized, "Unauthorized", "bearer token required")
+	serveDataPlane(w, r, h.kv == nil, "Key Vault secrets backend unavailable", dataPlaneRoutes{
+		deletedPrefix: deletedPrefix,
+		mainPrefix:    pathPrefix,
+		routeDeleted:  func(tail string) { h.routeDeleted(w, r, tail) },
+		routeMain:     func(tail string) { h.routeSecrets(w, r, tail) },
+	})
+}
 
+// dataPlaneRoutes describes how a Key Vault data-plane handler splits its two
+// path spaces (the live surface and its /deleted… counterpart).
+type dataPlaneRoutes struct {
+	deletedPrefix string
+	mainPrefix    string
+	routeDeleted  func(tail string)
+	routeMain     func(tail string)
+}
+
+// serveDataPlane runs the shared Key Vault data-plane preamble — bearer
+// challenge, backend-availability check, then dispatch to the deleted or main
+// path space — used by both the secrets and keys handlers.
+func serveDataPlane(w http.ResponseWriter, r *http.Request, backendUnavailable bool, unavailableMsg string, routes dataPlaneRoutes) {
+	if bearerChallenge(w, r) {
 		return
 	}
 
-	if h.kv == nil {
-		writeErr(w, http.StatusInternalServerError, "InternalServerError", "Key Vault secrets backend unavailable")
+	if backendUnavailable {
+		writeErr(w, http.StatusInternalServerError, "InternalServerError", unavailableMsg)
 		return
 	}
 
-	if r.URL.Path == deletedPrefix || strings.HasPrefix(r.URL.Path, deletedPrefix+"/") {
-		h.routeDeleted(w, r, strings.Trim(strings.TrimPrefix(r.URL.Path, deletedPrefix), "/"))
+	if r.URL.Path == routes.deletedPrefix || strings.HasPrefix(r.URL.Path, routes.deletedPrefix+"/") {
+		routes.routeDeleted(strings.Trim(strings.TrimPrefix(r.URL.Path, routes.deletedPrefix), "/"))
 		return
 	}
 
-	h.routeSecrets(w, r, strings.Trim(strings.TrimPrefix(r.URL.Path, pathPrefix), "/"))
+	routes.routeMain(strings.Trim(strings.TrimPrefix(r.URL.Path, routes.mainPrefix), "/"))
 }
 
 // routeSecrets dispatches /secrets[...] requests.
@@ -146,6 +163,8 @@ func (h *Handler) routeBareSecret(w http.ResponseWriter, r *http.Request, name s
 }
 
 // routeDeleted dispatches /deletedsecrets[...] requests.
+//
+//nolint:dupl // parallel soft-delete router for secrets vs keys; the shared shape is intentional
 func (h *Handler) routeDeleted(w http.ResponseWriter, r *http.Request, tail string) {
 	if tail == "" {
 		if r.Method == http.MethodGet {
@@ -170,6 +189,21 @@ func (h *Handler) routeDeleted(w http.ResponseWriter, r *http.Request, tail stri
 	default:
 		writeErr(w, http.StatusMethodNotAllowed, "BadRequest", "unsupported Key Vault operation")
 	}
+}
+
+// bearerChallenge answers an unauthenticated request with the Key Vault bearer
+// challenge and reports whether it handled the request. Key Vault SDKs expect a
+// 401 with a WWW-Authenticate header before retrying with a token.
+func bearerChallenge(w http.ResponseWriter, r *http.Request) bool {
+	if r.Header.Get("Authorization") != "" {
+		return false
+	}
+
+	w.Header().Set("WWW-Authenticate",
+		`Bearer authorization="https://login.microsoftonline.com/common", resource="https://vault.azure.net"`)
+	writeErr(w, http.StatusUnauthorized, "Unauthorized", "bearer token required")
+
+	return true
 }
 
 // writeErr emits a Key Vault-style error body with the given HTTP status.

--- a/server/azure/keyvault/keys_crypto_operations.go
+++ b/server/azure/keyvault/keys_crypto_operations.go
@@ -1,0 +1,98 @@
+package keyvault
+
+import (
+	"encoding/base64"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+// cryptoOp decodes a keyOperationRequest, runs op, and writes the result.
+func cryptoOp(
+	w http.ResponseWriter, r *http.Request, name, version string,
+	op func(name, version string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error),
+) {
+	var req keyOperationRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	value, err := base64.RawURLEncoding.DecodeString(req.Value)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "BadParameter", "invalid base64url value")
+		return
+	}
+
+	res, err := op(name, version, secretsdriver.KVCryptoParams{Algorithm: req.Alg, Value: value})
+	if err != nil {
+		writeKeyErr(w, err)
+		return
+	}
+
+	writeJSON(w, keyOperationResultJSON{
+		KID:   keyID(r, name, res.Version),
+		Value: base64.RawURLEncoding.EncodeToString(res.Value),
+	})
+}
+
+func (h *KeysHandler) encrypt(w http.ResponseWriter, r *http.Request, name, version string) {
+	cryptoOp(w, r, name, version, func(n, v string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error) {
+		return h.kv.EncryptKey(r.Context(), n, v, p)
+	})
+}
+
+func (h *KeysHandler) decrypt(w http.ResponseWriter, r *http.Request, name, version string) {
+	cryptoOp(w, r, name, version, func(n, v string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error) {
+		return h.kv.DecryptKey(r.Context(), n, v, p)
+	})
+}
+
+func (h *KeysHandler) wrapKey(w http.ResponseWriter, r *http.Request, name, version string) {
+	cryptoOp(w, r, name, version, func(n, v string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error) {
+		return h.kv.WrapKey(r.Context(), n, v, p)
+	})
+}
+
+func (h *KeysHandler) unwrapKey(w http.ResponseWriter, r *http.Request, name, version string) {
+	cryptoOp(w, r, name, version, func(n, v string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error) {
+		return h.kv.UnwrapKey(r.Context(), n, v, p)
+	})
+}
+
+func (h *KeysHandler) sign(w http.ResponseWriter, r *http.Request, name, version string) {
+	cryptoOp(w, r, name, version, func(n, v string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error) {
+		return h.kv.SignKey(r.Context(), n, v, p)
+	})
+}
+
+func (h *KeysHandler) verify(w http.ResponseWriter, r *http.Request, name, version string) {
+	var req verifyRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	digest, err := base64.RawURLEncoding.DecodeString(req.Digest)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "BadParameter", "invalid base64url digest")
+		return
+	}
+
+	sig, err := base64.RawURLEncoding.DecodeString(req.Value)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "BadParameter", "invalid base64url signature")
+		return
+	}
+
+	ok, err := h.kv.VerifyKey(r.Context(), name, version, secretsdriver.KVCryptoParams{
+		Algorithm: req.Alg,
+		Value:     digest,
+		Signature: sig,
+	})
+	if err != nil {
+		writeKeyErr(w, err)
+		return
+	}
+
+	writeJSON(w, keyVerifyResultJSON{Value: ok})
+}

--- a/server/azure/keyvault/keys_handler.go
+++ b/server/azure/keyvault/keys_handler.go
@@ -1,0 +1,238 @@
+// This file implements the Azure Key Vault keys data-plane API (/keys/…,
+// /deletedkeys/…) as a server.Handler. Real
+// github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys clients
+// pointed at this server create, import, read, list, update, delete, recover
+// and purge keys, and run real cryptographic operations
+// (encrypt/decrypt/wrapKey/unwrapKey/sign/verify) against the KeyVaultKeys
+// surface of the secrets driver.
+//
+// Coverage (Key Vault 7.x REST shapes):
+//
+//	POST   /keys/{name}/create                 — create key (RSA/EC)
+//	PUT    /keys/{name}                         — import key
+//	GET    /keys/{name}[/{version}]             — get current or specific version
+//	PATCH  /keys/{name}/{version}               — update version attributes
+//	GET    /keys/{name}/versions                — list versions
+//	GET    /keys                                — list keys
+//	DELETE /keys/{name}                         — soft-delete key
+//	POST   /keys/{name}/{version}/encrypt       — encrypt
+//	POST   /keys/{name}/{version}/decrypt       — decrypt
+//	POST   /keys/{name}/{version}/wrapkey       — wrap key
+//	POST   /keys/{name}/{version}/unwrapkey     — unwrap key
+//	POST   /keys/{name}/{version}/sign          — sign digest
+//	POST   /keys/{name}/{version}/verify        — verify signature
+//	GET    /deletedkeys                         — list deleted keys
+//	GET    /deletedkeys/{name}                  — get deleted key
+//	POST   /deletedkeys/{name}/recover          — recover deleted key
+//	DELETE /deletedkeys/{name}                  — purge deleted key
+package keyvault
+
+import (
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+const (
+	keysPrefix        = "/keys"
+	deletedKeysPrefix = "/deletedkeys"
+	createSeg         = "create"
+	encryptSeg        = "encrypt"
+	decryptSeg        = "decrypt"
+	wrapSeg           = "wrapkey"
+	unwrapSeg         = "unwrapkey"
+	signSeg           = "sign"
+	verifySeg         = "verify"
+)
+
+// KeysHandler serves the Key Vault keys data-plane API against a backend that
+// implements the Azure-specific KeyVaultKeys surface.
+type KeysHandler struct {
+	kv secretsdriver.KeyVaultKeys
+}
+
+// NewKeys returns a keys handler backed by s. s must implement the
+// Azure-specific KeyVaultKeys surface (the Azure provider mock does); a backend
+// that does not is served 500 on every keys data-plane call.
+func NewKeys(s secretsdriver.Secrets) *KeysHandler {
+	kv, _ := s.(secretsdriver.KeyVaultKeys)
+
+	return &KeysHandler{kv: kv}
+}
+
+// Matches claims /keys and /deletedkeys data-plane requests. Disjoint from ARM
+// (/subscriptions/…) and from the secrets surface (/secrets, /deletedsecrets).
+func (*KeysHandler) Matches(r *http.Request) bool {
+	p := r.URL.Path
+
+	return p == keysPrefix || strings.HasPrefix(p, keysPrefix+"/") ||
+		p == deletedKeysPrefix || strings.HasPrefix(p, deletedKeysPrefix+"/")
+}
+
+// ServeHTTP answers the bearer challenge for unauthenticated requests, then
+// routes on the path and method.
+func (h *KeysHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	serveDataPlane(w, r, h.kv == nil, "Key Vault keys backend unavailable", dataPlaneRoutes{
+		deletedPrefix: deletedKeysPrefix,
+		mainPrefix:    keysPrefix,
+		routeDeleted:  func(tail string) { h.routeDeleted(w, r, tail) },
+		routeMain:     func(tail string) { h.routeKeys(w, r, tail) },
+	})
+}
+
+func (h *KeysHandler) routeKeys(w http.ResponseWriter, r *http.Request, tail string) {
+	if tail == "" {
+		if r.Method == http.MethodGet {
+			h.listKeys(w, r)
+			return
+		}
+
+		writeErr(w, http.StatusMethodNotAllowed, "BadRequest", "unsupported Key Vault operation")
+
+		return
+	}
+
+	name, sub, hasSub := strings.Cut(tail, "/")
+	if !hasSub {
+		h.routeBareKey(w, r, name)
+		return
+	}
+
+	h.routeNamedKey(w, r, name, sub)
+}
+
+// routeBareKey dispatches /keys/{name} requests by method.
+func (h *KeysHandler) routeBareKey(w http.ResponseWriter, r *http.Request, name string) {
+	switch r.Method {
+	case http.MethodPut:
+		h.importKey(w, r, name)
+	case http.MethodGet:
+		h.getKey(w, r, name, "")
+	case http.MethodDelete:
+		h.deleteKey(w, r, name)
+	default:
+		writeErr(w, http.StatusMethodNotAllowed, "BadRequest", "unsupported Key Vault operation")
+	}
+}
+
+// routeNamedKey dispatches /keys/{name}/{sub}[/{op}] requests.
+func (h *KeysHandler) routeNamedKey(w http.ResponseWriter, r *http.Request, name, sub string) {
+	if sub == createSeg && r.Method == http.MethodPost {
+		h.createKey(w, r, name)
+		return
+	}
+
+	if sub == versionsSeg && r.Method == http.MethodGet {
+		h.listKeyVersions(w, r, name)
+		return
+	}
+
+	// A crypto operation on the current version collapses to /keys/{name}/{op}
+	// (the SDK drops the empty version segment).
+	if isCryptoOp(sub) {
+		h.routeCryptoOp(w, r, name, "", sub)
+		return
+	}
+
+	// Remaining shapes are version-scoped: /keys/{name}/{version}[/{op}].
+	version, op, hasOp := strings.Cut(sub, "/")
+	if hasOp {
+		h.routeCryptoOp(w, r, name, version, op)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getKey(w, r, name, version)
+	case http.MethodPatch:
+		h.updateKey(w, r, name, version)
+	default:
+		writeErr(w, http.StatusMethodNotAllowed, "BadRequest", "unsupported Key Vault operation")
+	}
+}
+
+func isCryptoOp(seg string) bool {
+	switch seg {
+	case encryptSeg, decryptSeg, wrapSeg, unwrapSeg, signSeg, verifySeg:
+		return true
+	default:
+		return false
+	}
+}
+
+// routeCryptoOp dispatches /keys/{name}/{version}/{op} crypto operations.
+func (h *KeysHandler) routeCryptoOp(w http.ResponseWriter, r *http.Request, name, version, op string) {
+	if r.Method != http.MethodPost {
+		writeErr(w, http.StatusMethodNotAllowed, "BadRequest", "unsupported Key Vault operation")
+		return
+	}
+
+	switch op {
+	case encryptSeg:
+		h.encrypt(w, r, name, version)
+	case decryptSeg:
+		h.decrypt(w, r, name, version)
+	case wrapSeg:
+		h.wrapKey(w, r, name, version)
+	case unwrapSeg:
+		h.unwrapKey(w, r, name, version)
+	case signSeg:
+		h.sign(w, r, name, version)
+	case verifySeg:
+		h.verify(w, r, name, version)
+	default:
+		writeErr(w, http.StatusNotFound, "NotFound", "unsupported Key Vault operation")
+	}
+}
+
+// routeDeleted dispatches /deletedkeys[...] requests. It mirrors the secrets
+// handler's /deletedsecrets router (get/purge/recover) against the keys backend.
+//
+//nolint:dupl // parallel soft-delete router for keys vs secrets; the shared shape is intentional
+func (h *KeysHandler) routeDeleted(w http.ResponseWriter, r *http.Request, tail string) {
+	if tail == "" {
+		if r.Method == http.MethodGet {
+			h.listDeletedKeys(w, r)
+			return
+		}
+
+		writeErr(w, http.StatusMethodNotAllowed, "BadRequest", "unsupported Key Vault operation")
+
+		return
+	}
+
+	name, sub, hasSub := strings.Cut(tail, "/")
+
+	switch {
+	case !hasSub && r.Method == http.MethodGet:
+		h.getDeletedKey(w, r, name)
+	case !hasSub && r.Method == http.MethodDelete:
+		h.purgeDeletedKey(w, r, name)
+	case sub == recoverSeg && r.Method == http.MethodPost:
+		h.recoverDeletedKey(w, r, name)
+	default:
+		writeErr(w, http.StatusMethodNotAllowed, "BadRequest", "unsupported Key Vault operation")
+	}
+}
+
+// writeKeyErr maps a canonical cloudemu error to a Key Vault key error response.
+func writeKeyErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeErr(w, http.StatusNotFound, "KeyNotFound", err.Error())
+	case cerrors.IsAlreadyExists(err) && strings.Contains(err.Error(), "deleted but recoverable"):
+		writeErrInner(w, http.StatusConflict, "Conflict", err.Error(), "ObjectIsDeletedButRecoverable")
+	case cerrors.IsAlreadyExists(err):
+		writeErr(w, http.StatusConflict, "Conflict", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeErr(w, http.StatusBadRequest, "BadParameter", err.Error())
+	case cerrors.IsPermissionDenied(err):
+		writeErr(w, http.StatusForbidden, "Forbidden", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		writeErr(w, http.StatusForbidden, "Forbidden", err.Error())
+	default:
+		writeErr(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+	}
+}

--- a/server/azure/keyvault/keys_operations.go
+++ b/server/azure/keyvault/keys_operations.go
@@ -1,0 +1,233 @@
+package keyvault
+
+import (
+	"encoding/base64"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+func keyAttrsFromRequest(a *setKeyAttributesJSON) secretsdriver.KVKeyAttributes {
+	attrs := secretsdriver.KVKeyAttributes{Enabled: true}
+	if a == nil {
+		return attrs
+	}
+
+	if a.Enabled != nil {
+		attrs.Enabled = *a.Enabled
+	}
+
+	if a.Expires != nil {
+		attrs.Expires = *a.Expires
+	}
+
+	if a.NotBefore != nil {
+		attrs.NotBefore = *a.NotBefore
+	}
+
+	return attrs
+}
+
+func (h *KeysHandler) createKey(w http.ResponseWriter, r *http.Request, name string) {
+	var req createKeyRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	key, err := h.kv.CreateKey(r.Context(), name, &secretsdriver.KVCreateKeyParams{
+		Kty:            req.Kty,
+		KeySize:        req.KeySize,
+		Curve:          req.Crv,
+		PublicExponent: req.PublicExponent,
+		KeyOps:         req.KeyOps,
+		Tags:           req.Tags,
+		Attributes:     keyAttrsFromRequest(req.KeyAttributes),
+	})
+	if err != nil {
+		writeKeyErr(w, err)
+		return
+	}
+
+	writeJSON(w, toKeyBundle(r, key))
+}
+
+func (h *KeysHandler) importKey(w http.ResponseWriter, r *http.Request, name string) {
+	var req importKeyRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	jwk, err := decodeImportJWK(&req.Key)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "BadParameter", err.Error())
+		return
+	}
+
+	key, err := h.kv.ImportKey(r.Context(), name, &secretsdriver.KVImportKeyParams{
+		Key:        jwk,
+		HSM:        req.HSM,
+		Tags:       req.Tags,
+		Attributes: keyAttrsFromRequest(req.KeyAttributes),
+	})
+	if err != nil {
+		writeKeyErr(w, err)
+		return
+	}
+
+	writeJSON(w, toKeyBundle(r, key))
+}
+
+func (h *KeysHandler) getKey(w http.ResponseWriter, r *http.Request, name, version string) {
+	key, err := h.kv.GetKey(r.Context(), name, version)
+	if err != nil {
+		writeKeyErr(w, err)
+		return
+	}
+
+	writeJSON(w, toKeyBundle(r, key))
+}
+
+func (h *KeysHandler) updateKey(w http.ResponseWriter, r *http.Request, name, version string) {
+	var req updateKeyRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	patch := secretsdriver.KVKeyPatch{}
+	if req.Tags != nil {
+		patch.Tags = req.Tags
+		patch.SetTags = true
+	}
+
+	if req.KeyOps != nil {
+		patch.KeyOps = req.KeyOps
+		patch.SetKeyOps = true
+	}
+
+	if a := req.KeyAttributes; a != nil {
+		patch.Enabled = a.Enabled
+		patch.Expires = a.Expires
+		patch.NotBefore = a.NotBefore
+	}
+
+	key, err := h.kv.UpdateKey(r.Context(), name, version, patch)
+	if err != nil {
+		writeKeyErr(w, err)
+		return
+	}
+
+	writeJSON(w, toKeyBundle(r, key))
+}
+
+func (h *KeysHandler) deleteKey(w http.ResponseWriter, r *http.Request, name string) {
+	deleted, err := h.kv.DeleteKey(r.Context(), name)
+	if err != nil {
+		writeKeyErr(w, err)
+		return
+	}
+
+	writeJSON(w, toDeletedKeyBundle(r, deleted))
+}
+
+func (h *KeysHandler) listKeys(w http.ResponseWriter, r *http.Request) {
+	keys, err := h.kv.ListKeys(r.Context())
+	if err != nil {
+		writeKeyErr(w, err)
+		return
+	}
+
+	items := make([]keyItemJSON, 0, len(keys))
+	for i := range keys {
+		items = append(items, toKeyItem(r, &keys[i]))
+	}
+
+	writeJSON(w, keyListResponseJSON{Value: items})
+}
+
+func (h *KeysHandler) listKeyVersions(w http.ResponseWriter, r *http.Request, name string) {
+	versions, err := h.kv.ListKeyVersions(r.Context(), name)
+	if err != nil {
+		writeKeyErr(w, err)
+		return
+	}
+
+	items := make([]keyItemJSON, 0, len(versions))
+	for i := range versions {
+		items = append(items, toKeyItem(r, &versions[i]))
+	}
+
+	writeJSON(w, keyListResponseJSON{Value: items})
+}
+
+func (h *KeysHandler) listDeletedKeys(w http.ResponseWriter, r *http.Request) {
+	deleted, err := h.kv.ListDeletedKeys(r.Context())
+	if err != nil {
+		writeKeyErr(w, err)
+		return
+	}
+
+	items := make([]deletedKeyItemJSON, 0, len(deleted))
+	for i := range deleted {
+		items = append(items, toDeletedKeyItem(r, &deleted[i]))
+	}
+
+	writeJSON(w, deletedKeyListResponseJSON{Value: items})
+}
+
+func (h *KeysHandler) getDeletedKey(w http.ResponseWriter, r *http.Request, name string) {
+	deleted, err := h.kv.GetDeletedKey(r.Context(), name)
+	if err != nil {
+		writeKeyErr(w, err)
+		return
+	}
+
+	writeJSON(w, toDeletedKeyBundle(r, deleted))
+}
+
+func (h *KeysHandler) recoverDeletedKey(w http.ResponseWriter, r *http.Request, name string) {
+	key, err := h.kv.RecoverDeletedKey(r.Context(), name)
+	if err != nil {
+		writeKeyErr(w, err)
+		return
+	}
+
+	writeJSON(w, toKeyBundle(r, key))
+}
+
+func (h *KeysHandler) purgeDeletedKey(w http.ResponseWriter, r *http.Request, name string) {
+	if err := h.kv.PurgeDeletedKey(r.Context(), name); err != nil {
+		writeKeyErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// decodeImportJWK decodes the base64url components of an inbound JWK.
+func decodeImportJWK(in *jsonWebKeyImport) (secretsdriver.KVImportJWK, error) {
+	out := secretsdriver.KVImportJWK{Kty: in.Kty, Curve: in.Crv, KeyOps: in.KeyOps}
+
+	fields := []struct {
+		src string
+		dst *[]byte
+	}{
+		{in.N, &out.N}, {in.E, &out.E}, {in.D, &out.D}, {in.P, &out.P}, {in.Q, &out.Q},
+		{in.DP, &out.DP}, {in.DQ, &out.DQ}, {in.QI, &out.QI}, {in.X, &out.X}, {in.Y, &out.Y}, {in.K, &out.K},
+	}
+
+	for _, f := range fields {
+		if f.src == "" {
+			continue
+		}
+
+		b, err := base64.RawURLEncoding.DecodeString(f.src)
+		if err != nil {
+			return out, err
+		}
+
+		*f.dst = b
+	}
+
+	return out, nil
+}

--- a/server/azure/keyvault/keys_types.go
+++ b/server/azure/keyvault/keys_types.go
@@ -1,0 +1,238 @@
+package keyvault
+
+import (
+	"encoding/base64"
+	"net/http"
+
+	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+// keyAttributesJSON is the Key Vault KeyAttributes shape. Timestamps are Unix
+// epoch seconds; exp and nbf are omitted when unset.
+type keyAttributesJSON struct {
+	Enabled         bool   `json:"enabled"`
+	Created         int64  `json:"created,omitempty"`
+	Updated         int64  `json:"updated,omitempty"`
+	Expires         int64  `json:"exp,omitempty"`
+	NotBefore       int64  `json:"nbf,omitempty"`
+	RecoverableDays int    `json:"recoverableDays,omitempty"`
+	RecoveryLevel   string `json:"recoveryLevel,omitempty"`
+}
+
+// jsonWebKey is the JWK carried in a KeyBundle. Byte components are base64url
+// (no padding) strings; empty components are omitted.
+type jsonWebKey struct {
+	KID    string   `json:"kid,omitempty"`
+	Kty    string   `json:"kty"`
+	KeyOps []string `json:"key_ops,omitempty"`
+	Crv    string   `json:"crv,omitempty"`
+	N      string   `json:"n,omitempty"`
+	E      string   `json:"e,omitempty"`
+	X      string   `json:"x,omitempty"`
+	Y      string   `json:"y,omitempty"`
+}
+
+// keyBundleJSON is a full Key Vault key bundle.
+type keyBundleJSON struct {
+	Key        jsonWebKey        `json:"key"`
+	Attributes keyAttributesJSON `json:"attributes"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Managed    *bool             `json:"managed,omitempty"`
+}
+
+// deletedKeyBundleJSON extends a bundle with soft-delete scheduling.
+type deletedKeyBundleJSON struct {
+	keyBundleJSON
+
+	RecoveryID         string `json:"recoveryId"`
+	DeletedDate        int64  `json:"deletedDate,omitempty"`
+	ScheduledPurgeDate int64  `json:"scheduledPurgeDate,omitempty"`
+}
+
+// keyItemJSON is a list entry: identifier, attributes and metadata, no JWK.
+type keyItemJSON struct {
+	KID        string            `json:"kid"`
+	Attributes keyAttributesJSON `json:"attributes"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Managed    *bool             `json:"managed,omitempty"`
+}
+
+// deletedKeyItemJSON is a deleted-list entry.
+type deletedKeyItemJSON struct {
+	keyItemJSON
+
+	RecoveryID         string `json:"recoveryId"`
+	DeletedDate        int64  `json:"deletedDate,omitempty"`
+	ScheduledPurgeDate int64  `json:"scheduledPurgeDate,omitempty"`
+}
+
+type keyListResponseJSON struct {
+	Value    []keyItemJSON `json:"value"`
+	NextLink *string       `json:"nextLink"`
+}
+
+type deletedKeyListResponseJSON struct {
+	Value    []deletedKeyItemJSON `json:"value"`
+	NextLink *string              `json:"nextLink"`
+}
+
+// setKeyAttributesJSON is the attributes sub-object of a create/import/update
+// request. Pointers distinguish "absent" from "zero".
+type setKeyAttributesJSON struct {
+	Enabled   *bool  `json:"enabled"`
+	Expires   *int64 `json:"exp"`
+	NotBefore *int64 `json:"nbf"`
+}
+
+type createKeyRequest struct {
+	Kty            string                `json:"kty"`
+	KeySize        int                   `json:"key_size"`
+	Crv            string                `json:"crv"`
+	PublicExponent int                   `json:"public_exponent"`
+	KeyOps         []string              `json:"key_ops"`
+	Tags           map[string]string     `json:"tags"`
+	KeyAttributes  *setKeyAttributesJSON `json:"attributes"`
+}
+
+type importKeyRequest struct {
+	Key           jsonWebKeyImport      `json:"key"`
+	HSM           bool                  `json:"Hsm"`
+	Tags          map[string]string     `json:"tags"`
+	KeyAttributes *setKeyAttributesJSON `json:"attributes"`
+}
+
+// jsonWebKeyImport is the inbound JWK for ImportKey; all byte components are
+// base64url strings.
+type jsonWebKeyImport struct {
+	Kty    string   `json:"kty"`
+	Crv    string   `json:"crv"`
+	KeyOps []string `json:"key_ops"`
+	N      string   `json:"n"`
+	E      string   `json:"e"`
+	D      string   `json:"d"`
+	P      string   `json:"p"`
+	Q      string   `json:"q"`
+	DP     string   `json:"dp"`
+	DQ     string   `json:"dq"`
+	QI     string   `json:"qi"`
+	X      string   `json:"x"`
+	Y      string   `json:"y"`
+	K      string   `json:"k"`
+}
+
+type updateKeyRequest struct {
+	KeyOps        []string              `json:"key_ops"`
+	Tags          map[string]string     `json:"tags"`
+	KeyAttributes *setKeyAttributesJSON `json:"attributes"`
+}
+
+// keyOperationRequest is the encrypt/decrypt/wrapKey/unwrapKey/sign payload.
+type keyOperationRequest struct {
+	Alg   string `json:"alg"`
+	Value string `json:"value"`
+}
+
+// verifyRequest is the verify payload.
+type verifyRequest struct {
+	Alg    string `json:"alg"`
+	Digest string `json:"digest"`
+	Value  string `json:"value"`
+}
+
+// keyOperationResultJSON is the encrypt/decrypt/wrap/unwrap/sign response.
+type keyOperationResultJSON struct {
+	KID   string `json:"kid"`
+	Value string `json:"value"`
+}
+
+// keyVerifyResultJSON is the verify response.
+type keyVerifyResultJSON struct {
+	Value bool `json:"value"`
+}
+
+// keyID builds "{vault}/keys/{name}[/{version}]".
+func keyID(r *http.Request, name, version string) string {
+	id := vaultBaseURL(r) + keysPrefix + "/" + name
+	if version != "" {
+		id += "/" + version
+	}
+
+	return id
+}
+
+func deletedKeyID(r *http.Request, name string) string {
+	return vaultBaseURL(r) + deletedKeysPrefix + "/" + name
+}
+
+func keyAttributesOf(k *secretsdriver.KVKey) keyAttributesJSON {
+	return keyAttributesJSON{
+		Enabled:         k.Enabled,
+		Created:         k.Created,
+		Updated:         k.Updated,
+		Expires:         k.Expires,
+		NotBefore:       k.NotBefore,
+		RecoverableDays: recoverableDays,
+		RecoveryLevel:   recoveryLevel,
+	}
+}
+
+func toJWK(r *http.Request, k *secretsdriver.KVKey) jsonWebKey {
+	jwk := jsonWebKey{
+		KID:    keyID(r, k.Name, k.Version),
+		Kty:    k.Kty,
+		KeyOps: k.KeyOps,
+		Crv:    k.Curve,
+	}
+
+	if len(k.N) > 0 {
+		jwk.N = base64.RawURLEncoding.EncodeToString(k.N)
+	}
+
+	if len(k.E) > 0 {
+		jwk.E = base64.RawURLEncoding.EncodeToString(k.E)
+	}
+
+	if len(k.X) > 0 {
+		jwk.X = base64.RawURLEncoding.EncodeToString(k.X)
+	}
+
+	if len(k.Y) > 0 {
+		jwk.Y = base64.RawURLEncoding.EncodeToString(k.Y)
+	}
+
+	return jwk
+}
+
+func toKeyBundle(r *http.Request, k *secretsdriver.KVKey) keyBundleJSON {
+	return keyBundleJSON{
+		Key:        toJWK(r, k),
+		Attributes: keyAttributesOf(k),
+		Tags:       k.Tags,
+	}
+}
+
+func toDeletedKeyBundle(r *http.Request, d *secretsdriver.KVDeletedKey) deletedKeyBundleJSON {
+	return deletedKeyBundleJSON{
+		keyBundleJSON:      toKeyBundle(r, &d.KVKey),
+		RecoveryID:         deletedKeyID(r, d.Name),
+		DeletedDate:        d.DeletedDate,
+		ScheduledPurgeDate: d.ScheduledPurgeDate,
+	}
+}
+
+func toKeyItem(r *http.Request, k *secretsdriver.KVKey) keyItemJSON {
+	return keyItemJSON{
+		KID:        keyID(r, k.Name, k.Version),
+		Attributes: keyAttributesOf(k),
+		Tags:       k.Tags,
+	}
+}
+
+func toDeletedKeyItem(r *http.Request, d *secretsdriver.KVDeletedKey) deletedKeyItemJSON {
+	return deletedKeyItemJSON{
+		keyItemJSON:        toKeyItem(r, &d.KVKey),
+		RecoveryID:         deletedKeyID(r, d.Name),
+		DeletedDate:        d.DeletedDate,
+		ScheduledPurgeDate: d.ScheduledPurgeDate,
+	}
+}

--- a/server/azure/keyvault/sdk_keys_roundtrip_test.go
+++ b/server/azure/keyvault/sdk_keys_roundtrip_test.go
@@ -349,3 +349,42 @@ func TestSDKKeyVaultKeysErrors(t *testing.T) {
 		t.Fatalf("got error code %q, want KeyNotFound", respErr.ErrorCode)
 	}
 }
+
+func TestSDKKeyVaultHSMKeyTypePreserved(t *testing.T) {
+	client := newKeysClient(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		kty  azkeys.KeyType
+		crv  *azkeys.CurveName
+	}{
+		{name: "rsa-hsm", kty: azkeys.KeyTypeRSAHSM},
+		{name: "ec-hsm", kty: azkeys.KeyTypeECHSM, crv: to.Ptr(azkeys.CurveNameP256)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			created, err := client.CreateKey(ctx, tc.name, azkeys.CreateKeyParameters{
+				Kty:   to.Ptr(tc.kty),
+				Curve: tc.crv,
+			}, nil)
+			if err != nil {
+				t.Fatalf("CreateKey: %v", err)
+			}
+
+			if created.Key.Kty == nil || *created.Key.Kty != tc.kty {
+				t.Fatalf("CreateKey kty = %v, want %v (must not be downgraded)", created.Key.Kty, tc.kty)
+			}
+
+			got, err := client.GetKey(ctx, tc.name, "", nil)
+			if err != nil {
+				t.Fatalf("GetKey: %v", err)
+			}
+
+			if got.Key.Kty == nil || *got.Key.Kty != tc.kty {
+				t.Fatalf("GetKey kty = %v, want %v", got.Key.Kty, tc.kty)
+			}
+		})
+	}
+}

--- a/server/azure/keyvault/sdk_keys_roundtrip_test.go
+++ b/server/azure/keyvault/sdk_keys_roundtrip_test.go
@@ -1,0 +1,351 @@
+package keyvault_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func newKeysClient(t *testing.T) *azkeys.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{KeyVault: cloud.KeyVault})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := azkeys.NewClient(ts.URL, fakeCred{}, &azkeys.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+		DisableChallengeResourceVerification: true,
+	})
+	if err != nil {
+		t.Fatalf("azkeys.NewClient: %v", err)
+	}
+
+	return client
+}
+
+func TestSDKKeyVaultCreateRSAKeyLifecycle(t *testing.T) {
+	client := newKeysClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateKey(ctx, "app-key", azkeys.CreateKeyParameters{
+		Kty:     to.Ptr(azkeys.KeyTypeRSA),
+		KeySize: to.Ptr(int32(2048)),
+		Tags:    map[string]*string{"env": to.Ptr("test")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	if created.Key == nil || created.Key.KID == nil || created.Key.KID.Name() != "app-key" {
+		t.Fatalf("CreateKey key id = %v, want name app-key", created.Key)
+	}
+
+	if created.Key.Kty == nil || *created.Key.Kty != azkeys.KeyTypeRSA {
+		t.Fatalf("CreateKey kty = %v, want RSA", created.Key.Kty)
+	}
+
+	if len(created.Key.N) == 0 || len(created.Key.E) == 0 {
+		t.Fatal("CreateKey did not return RSA public material (n, e)")
+	}
+
+	got, err := client.GetKey(ctx, "app-key", "", nil)
+	if err != nil {
+		t.Fatalf("GetKey: %v", err)
+	}
+
+	if got.Key.KID.Version() != created.Key.KID.Version() {
+		t.Fatalf("GetKey version = %s, want %s", got.Key.KID.Version(), created.Key.KID.Version())
+	}
+
+	var names []string
+
+	pager := client.NewListKeyPropertiesPager(nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListKeyProperties: %v", err)
+		}
+
+		for _, item := range page.Value {
+			names = append(names, item.KID.Name())
+		}
+	}
+
+	if len(names) != 1 || names[0] != "app-key" {
+		t.Fatalf("list = %v, want [app-key]", names)
+	}
+
+	deleted, err := client.DeleteKey(ctx, "app-key", nil)
+	if err != nil {
+		t.Fatalf("DeleteKey: %v", err)
+	}
+
+	if deleted.Key.KID.Name() != "app-key" {
+		t.Fatalf("DeleteKey id = %v", deleted.Key.KID)
+	}
+
+	if _, err := client.GetKey(ctx, "app-key", "", nil); err == nil {
+		t.Fatal("GetKey after delete: want error, got nil")
+	}
+}
+
+func TestSDKKeyVaultRSAEncryptDecrypt(t *testing.T) {
+	client := newKeysClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateKey(ctx, "enc-key", azkeys.CreateKeyParameters{
+		Kty: to.Ptr(azkeys.KeyTypeRSA),
+	}, nil); err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	plaintext := []byte("attack at dawn")
+
+	for _, alg := range []azkeys.EncryptionAlgorithm{
+		azkeys.EncryptionAlgorithmRSAOAEP,
+		azkeys.EncryptionAlgorithmRSAOAEP256,
+		azkeys.EncryptionAlgorithmRSA15,
+	} {
+		enc, err := client.Encrypt(ctx, "enc-key", "", azkeys.KeyOperationParameters{
+			Algorithm: to.Ptr(alg),
+			Value:     plaintext,
+		}, nil)
+		if err != nil {
+			t.Fatalf("Encrypt(%s): %v", alg, err)
+		}
+
+		dec, err := client.Decrypt(ctx, "enc-key", "", azkeys.KeyOperationParameters{
+			Algorithm: to.Ptr(alg),
+			Value:     enc.Result,
+		}, nil)
+		if err != nil {
+			t.Fatalf("Decrypt(%s): %v", alg, err)
+		}
+
+		if string(dec.Result) != string(plaintext) {
+			t.Fatalf("Decrypt(%s) = %q, want %q", alg, dec.Result, plaintext)
+		}
+	}
+}
+
+func TestSDKKeyVaultRSASignVerify(t *testing.T) {
+	client := newKeysClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateKey(ctx, "sign-key", azkeys.CreateKeyParameters{
+		Kty: to.Ptr(azkeys.KeyTypeRSA),
+	}, nil); err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	digest := sha256.Sum256([]byte("message to sign"))
+
+	for _, alg := range []azkeys.SignatureAlgorithm{
+		azkeys.SignatureAlgorithmRS256,
+		azkeys.SignatureAlgorithmPS256,
+	} {
+		sig, err := client.Sign(ctx, "sign-key", "", azkeys.SignParameters{
+			Algorithm: to.Ptr(alg),
+			Value:     digest[:],
+		}, nil)
+		if err != nil {
+			t.Fatalf("Sign(%s): %v", alg, err)
+		}
+
+		ver, err := client.Verify(ctx, "sign-key", "", azkeys.VerifyParameters{
+			Algorithm: to.Ptr(alg),
+			Digest:    digest[:],
+			Signature: sig.Result,
+		}, nil)
+		if err != nil {
+			t.Fatalf("Verify(%s): %v", alg, err)
+		}
+
+		if ver.Value == nil || !*ver.Value {
+			t.Fatalf("Verify(%s) = %v, want true", alg, ver.Value)
+		}
+
+		// A tampered digest must not verify.
+		bad := sha256.Sum256([]byte("different message"))
+
+		ver2, err := client.Verify(ctx, "sign-key", "", azkeys.VerifyParameters{
+			Algorithm: to.Ptr(alg),
+			Digest:    bad[:],
+			Signature: sig.Result,
+		}, nil)
+		if err != nil {
+			t.Fatalf("Verify(bad, %s): %v", alg, err)
+		}
+
+		if ver2.Value != nil && *ver2.Value {
+			t.Fatalf("Verify(%s) of tampered digest = true, want false", alg)
+		}
+	}
+}
+
+func TestSDKKeyVaultECSignVerify(t *testing.T) {
+	client := newKeysClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateKey(ctx, "ec-key", azkeys.CreateKeyParameters{
+		Kty:   to.Ptr(azkeys.KeyTypeEC),
+		Curve: to.Ptr(azkeys.CurveNameP256),
+	}, nil); err != nil {
+		t.Fatalf("CreateKey(EC): %v", err)
+	}
+
+	digest := sha256.Sum256([]byte("ec message"))
+
+	sig, err := client.Sign(ctx, "ec-key", "", azkeys.SignParameters{
+		Algorithm: to.Ptr(azkeys.SignatureAlgorithmES256),
+		Value:     digest[:],
+	}, nil)
+	if err != nil {
+		t.Fatalf("Sign(ES256): %v", err)
+	}
+
+	ver, err := client.Verify(ctx, "ec-key", "", azkeys.VerifyParameters{
+		Algorithm: to.Ptr(azkeys.SignatureAlgorithmES256),
+		Digest:    digest[:],
+		Signature: sig.Result,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Verify(ES256): %v", err)
+	}
+
+	if ver.Value == nil || !*ver.Value {
+		t.Fatalf("Verify(ES256) = %v, want true", ver.Value)
+	}
+}
+
+func TestSDKKeyVaultWrapUnwrap(t *testing.T) {
+	client := newKeysClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateKey(ctx, "wrap-key", azkeys.CreateKeyParameters{
+		Kty: to.Ptr(azkeys.KeyTypeRSA),
+	}, nil); err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	cek := []byte("0123456789abcdef0123456789abcdef") // 32-byte content key
+
+	wrapped, err := client.WrapKey(ctx, "wrap-key", "", azkeys.KeyOperationParameters{
+		Algorithm: to.Ptr(azkeys.EncryptionAlgorithmRSAOAEP256),
+		Value:     cek,
+	}, nil)
+	if err != nil {
+		t.Fatalf("WrapKey: %v", err)
+	}
+
+	unwrapped, err := client.UnwrapKey(ctx, "wrap-key", "", azkeys.KeyOperationParameters{
+		Algorithm: to.Ptr(azkeys.EncryptionAlgorithmRSAOAEP256),
+		Value:     wrapped.Result,
+	}, nil)
+	if err != nil {
+		t.Fatalf("UnwrapKey: %v", err)
+	}
+
+	if string(unwrapped.Result) != string(cek) {
+		t.Fatalf("UnwrapKey = %q, want %q", unwrapped.Result, cek)
+	}
+}
+
+func TestSDKKeyVaultVersioning(t *testing.T) {
+	client := newKeysClient(t)
+	ctx := context.Background()
+
+	first, err := client.CreateKey(ctx, "rot", azkeys.CreateKeyParameters{Kty: to.Ptr(azkeys.KeyTypeRSA)}, nil)
+	if err != nil {
+		t.Fatalf("CreateKey(v1): %v", err)
+	}
+
+	second, err := client.CreateKey(ctx, "rot", azkeys.CreateKeyParameters{Kty: to.Ptr(azkeys.KeyTypeRSA)}, nil)
+	if err != nil {
+		t.Fatalf("CreateKey(v2): %v", err)
+	}
+
+	if first.Key.KID.Version() == second.Key.KID.Version() {
+		t.Fatal("second CreateKey reused the first version id")
+	}
+
+	var versions []string
+
+	pager := client.NewListKeyPropertiesVersionsPager("rot", nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListKeyPropertiesVersions: %v", err)
+		}
+
+		for _, item := range page.Value {
+			versions = append(versions, item.KID.Version())
+		}
+	}
+
+	if len(versions) != 2 {
+		t.Fatalf("got %d versions %v, want 2", len(versions), versions)
+	}
+}
+
+func TestSDKKeyVaultDeletedKeyRecover(t *testing.T) {
+	client := newKeysClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateKey(ctx, "recov", azkeys.CreateKeyParameters{Kty: to.Ptr(azkeys.KeyTypeRSA)}, nil); err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	if _, err := client.DeleteKey(ctx, "recov", nil); err != nil {
+		t.Fatalf("DeleteKey: %v", err)
+	}
+
+	deleted, err := client.GetDeletedKey(ctx, "recov", nil)
+	if err != nil {
+		t.Fatalf("GetDeletedKey: %v", err)
+	}
+
+	if deleted.Key.KID.Name() != "recov" {
+		t.Fatalf("GetDeletedKey name = %v", deleted.Key.KID)
+	}
+
+	if _, err := client.RecoverDeletedKey(ctx, "recov", nil); err != nil {
+		t.Fatalf("RecoverDeletedKey: %v", err)
+	}
+
+	if _, err := client.GetKey(ctx, "recov", "", nil); err != nil {
+		t.Fatalf("GetKey after recover: %v", err)
+	}
+}
+
+func TestSDKKeyVaultKeysErrors(t *testing.T) {
+	client := newKeysClient(t)
+	ctx := context.Background()
+
+	_, err := client.GetKey(ctx, "missing", "", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("GetKey(missing): got %v, want 404 ResponseError", err)
+	}
+
+	if respErr.ErrorCode != "KeyNotFound" {
+		t.Fatalf("got error code %q, want KeyNotFound", respErr.ErrorCode)
+	}
+}

--- a/services/secrets/driver/keys.go
+++ b/services/secrets/driver/keys.go
@@ -1,0 +1,153 @@
+package driver
+
+import "context"
+
+// KVKeyAttributes are Azure Key Vault per-version key management attributes.
+// Expires and NotBefore are Unix epoch seconds; 0 means unset.
+type KVKeyAttributes struct {
+	Enabled   bool
+	Expires   int64
+	NotBefore int64
+}
+
+// KVCreateKeyParams is the Azure Key Vault CreateKey payload. Kty is the JSON
+// Web Key type ("RSA", "RSA-HSM", "EC", "EC-HSM", "oct"). KeySize is the RSA
+// modulus size in bits (2048/3072/4096); Curve is the EC curve name ("P-256",
+// "P-384", "P-521"). PublicExponent is optional (defaults to 65537).
+type KVCreateKeyParams struct {
+	Kty            string
+	KeySize        int
+	Curve          string
+	PublicExponent int
+	KeyOps         []string
+	Tags           map[string]string
+	Attributes     KVKeyAttributes
+}
+
+// KVImportJWK carries the raw JSON Web Key material for an ImportKey call. RSA
+// keys populate N/E and the private fields; EC keys populate Curve/X/Y/D; oct
+// keys populate K. All byte slices are the raw big-endian integer bytes (the
+// wire layer handles base64url).
+type KVImportJWK struct {
+	Kty    string
+	Curve  string
+	KeyOps []string
+
+	// RSA components.
+	N  []byte
+	E  []byte
+	D  []byte
+	P  []byte
+	Q  []byte
+	DP []byte
+	DQ []byte
+	QI []byte
+
+	// EC components.
+	X []byte
+	Y []byte
+
+	// Symmetric (oct) key material.
+	K []byte
+}
+
+// KVImportKeyParams is the Azure Key Vault ImportKey payload.
+type KVImportKeyParams struct {
+	Key        KVImportJWK
+	HSM        bool
+	Tags       map[string]string
+	Attributes KVKeyAttributes
+}
+
+// KVKeyPatch is the Azure Key Vault UpdateKey payload. Nil pointer fields are
+// left unchanged; SetTags true replaces the tag set with Tags; SetKeyOps true
+// replaces the key operations with KeyOps.
+type KVKeyPatch struct {
+	Enabled   *bool
+	Expires   *int64
+	NotBefore *int64
+	Tags      map[string]string
+	SetTags   bool
+	KeyOps    []string
+	SetKeyOps bool
+}
+
+// KVKey is one Azure Key Vault key version and its public material. RSA keys
+// carry N/E; EC keys carry Curve/X/Y. Private components are never returned.
+// Created, Updated, Expires and NotBefore are Unix epoch seconds (0 = unset).
+type KVKey struct {
+	Name    string
+	Version string
+	Kty     string
+	Curve   string
+	KeyOps  []string
+
+	// RSA public components.
+	N []byte
+	E []byte
+
+	// EC public components.
+	X []byte
+	Y []byte
+
+	Tags      map[string]string
+	Enabled   bool
+	Expires   int64
+	NotBefore int64
+	Created   int64
+	Updated   int64
+	Managed   bool
+}
+
+// KVDeletedKey is a soft-deleted Azure Key Vault key with its purge schedule.
+// DeletedDate and ScheduledPurgeDate are Unix epoch seconds.
+type KVDeletedKey struct {
+	KVKey
+
+	DeletedDate        int64
+	ScheduledPurgeDate int64
+}
+
+// KVCryptoParams carries the input for a single-block cryptographic operation.
+// Algorithm is the Key Vault algorithm identifier. Value is the payload to
+// operate on (plaintext, ciphertext, digest, or key to wrap). Signature is the
+// signature to check on a verify.
+type KVCryptoParams struct {
+	Algorithm string
+	Value     []byte
+	Signature []byte
+}
+
+// KVCryptoResult is the output of a cryptographic operation. Version identifies
+// the key version that performed it (the wire layer builds the key id from it).
+type KVCryptoResult struct {
+	Version string
+	Value   []byte
+}
+
+// KeyVaultKeys is the Azure Key Vault keys data-plane surface: key lifecycle
+// (create/import/get/list/update/soft-delete/recover/purge) plus the real
+// cryptographic operations (encrypt/decrypt/wrap/unwrap/sign/verify) performed
+// with the private key material held in the provider. It is kept off the shared
+// Secrets interface — a type-asserted optional interface — so the AWS and GCP
+// providers need not model Key Vault key semantics.
+type KeyVaultKeys interface {
+	CreateKey(ctx context.Context, name string, params *KVCreateKeyParams) (*KVKey, error)
+	ImportKey(ctx context.Context, name string, params *KVImportKeyParams) (*KVKey, error)
+	GetKey(ctx context.Context, name, version string) (*KVKey, error)
+	ListKeys(ctx context.Context) ([]KVKey, error)
+	ListKeyVersions(ctx context.Context, name string) ([]KVKey, error)
+	UpdateKey(ctx context.Context, name, version string, patch KVKeyPatch) (*KVKey, error)
+	DeleteKey(ctx context.Context, name string) (*KVDeletedKey, error)
+	GetDeletedKey(ctx context.Context, name string) (*KVDeletedKey, error)
+	ListDeletedKeys(ctx context.Context) ([]KVDeletedKey, error)
+	RecoverDeletedKey(ctx context.Context, name string) (*KVKey, error)
+	PurgeDeletedKey(ctx context.Context, name string) error
+
+	EncryptKey(ctx context.Context, name, version string, params KVCryptoParams) (*KVCryptoResult, error)
+	DecryptKey(ctx context.Context, name, version string, params KVCryptoParams) (*KVCryptoResult, error)
+	WrapKey(ctx context.Context, name, version string, params KVCryptoParams) (*KVCryptoResult, error)
+	UnwrapKey(ctx context.Context, name, version string, params KVCryptoParams) (*KVCryptoResult, error)
+	SignKey(ctx context.Context, name, version string, params KVCryptoParams) (*KVCryptoResult, error)
+	VerifyKey(ctx context.Context, name, version string, params KVCryptoParams) (bool, error)
+}


### PR DESCRIPTION
## Summary

Implements the **Azure Key Vault Keys data-plane** with real cryptography as a
type-asserted optional `KeyVaultKeys` driver surface on `services/secrets` —
mirroring the existing `KeyVaultSecrets` pattern (PR #513). Unmodified
`azkeys` SDK clients pointed at the emulator create keys, run crypto
operations, and manage the soft-delete lifecycle against an in-memory backend.

## What was built

**Keys data-plane** (`/keys`, `/deletedkeys`), verified end-to-end with the
real `github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys` client:

- **Lifecycle**: `CreateKey`/`ImportKey` (RSA + EC) with real key material
  (`crypto/rsa`, `crypto/ecdsa`), `GetKey`/`ListKeys`/versions, `UpdateKey`,
  and soft-delete / recover / purge with the 90-day purge schedule.
- **Real crypto** performed against the stored private key in the provider:
  - encrypt / decrypt — `RSA-OAEP`, `RSA-OAEP-256`, `RSA1_5`
  - sign / verify — `RS256/384/512`, `PS256/384/512`, and `ES256/384/512`
    (EC signatures returned as raw `r||s` per IEEE P1363, as Key Vault does)
  - wrapKey / unwrapKey — the RSA algorithms for asymmetric keys, plus
    **RFC 3394 AES key wrap** (`A128/192/256KW`) for imported `oct` keys
- **Wire fidelity**: the handler speaks the Key Vault 7.x JWK / base64url
  (unpadded) REST shapes — `POST /keys/{name}/create`, `PUT /keys/{name}`
  (import), version-scoped crypto ops, `KeyProperties` list items, and the
  bearer challenge. Error codes map to `KeyNotFound` (404),
  `ObjectIsDeletedButRecoverable` (409), etc.

`docs/coverage` regenerated for the new driver interface.

## Deferred (with reasons)

- **Certificates data-plane** (`/certificates`) — a large greenfield surface
  in its own right: a certificate-policy state machine, a self-signed x509
  issuance flow, and an async (LRO-style) pending-operation model. The
  `azcertificates` SDK is also not available in the build's module cache, so
  it could not be covered with real-user SDK tests to the same standard.
  Deferred rather than shipped as plausible-but-wrong stubs.
- **Vault ARM management plane** (`Microsoft.KeyVault/vaults`) — the ARM
  control plane (vault CRUD, access policies, network ACLs, soft-delete /
  purge-protection flags) is a separate greenfield surface; `armkeyvault` is
  likewise not in the module cache for SDK round-trip testing. Deferred.

Correctness over coverage: the most valuable surface (Keys data-plane) is
delivered fully and correctly; the other two are called out for follow-up
rather than half-implemented.

## Testing

- Real-user `azkeys` SDK round-trips: RSA lifecycle, encrypt/decrypt across all
  three RSA algorithms, RSA + EC sign/verify (including tamper rejection),
  wrap/unwrap, versioning, deleted-key recover, and 404 error shape.
- Provider-level tests for AES key wrap (RFC 3394), oct/RSA import round-trip,
  unsupported-curve rejection, disabled-key and not-permitted-operation guards,
  and the soft-delete/recover/purge lifecycle.
- `go build ./...`, `go test ./providers/azure/... ./server/azure/...
  ./services/...`, `-race` on the keyvault packages, and `golangci-lint` on the
  changed packages all pass clean.
