### PR TITLE
fix(s3): x-amz-tagging header on PutObject/CopyObject/CreateMultipartUpload, bucket notification configuration (Put/Get + QueueConfiguration filter + event delivery)

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -264,8 +264,11 @@ func New(opts ...config.Option) *Provider {
 	p.SNS.SetSQSDeliverer(p.SQS)
 	// EventBridge -> SQS: matched rules deliver events to SQS targets.
 	p.EventBridge.SetSQSDeliverer(p.SQS)
-	// S3 -> SQS: object-create events deliver to bucket notification targets.
+	// S3 event notifications deliver to their configured targets: SQS queues,
+	// SNS topics, and Lambda functions.
 	p.S3.SetSQSDeliverer(p.SQS)
+	p.S3.SetSNSPublisher(p.SNS)
+	p.S3.SetLambdaInvoker(p.Lambda)
 
 	p.ResourceDiscovery = resourcediscovery.New(
 		resourcediscovery.ProviderAWS, o.AccountID, o.Region, awsDrivers(p),

--- a/providers/aws/lambda/invoke_external_test.go
+++ b/providers/aws/lambda/invoke_external_test.go
@@ -46,7 +46,7 @@ func TestFunctionNameFromARN(t *testing.T) {
 		"arn:aws:lambda:us-east-1:0:function:fn":       "fn",
 		"arn:aws:lambda:us-east-1:0:function:fn:PROD":  "fn",
 		"arn:aws:lambda:us-east-1:0:function:fn:$LATE": "fn",
-		"fn":                                           "fn",
+		"fn": "fn",
 	}
 	for in, want := range cases {
 		if got := functionNameFromARN(in); got != want {

--- a/providers/aws/lambda/invoke_external_test.go
+++ b/providers/aws/lambda/invoke_external_test.go
@@ -1,0 +1,56 @@
+package lambda
+
+import (
+	"context"
+	"testing"
+)
+
+// TestInvokeExternalByARN verifies InvokeExternal resolves a function by ARN
+// (including a version qualifier) and invokes it with the event payload, and
+// that an unknown ARN is a no-op (backing S3 -> Lambda notifications).
+func TestInvokeExternalByARN(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	var got string
+	m.RegisterHandler("my-func", func(_ context.Context, payload []byte) ([]byte, error) {
+		got = string(payload)
+		return []byte("ok"), nil
+	})
+
+	// Unknown ARN: no error, handler not invoked.
+	if err := m.InvokeExternal(ctx, "arn:aws:lambda:us-east-1:0:function:absent", []byte("x")); err != nil {
+		t.Fatalf("InvokeExternal unknown: %v", err)
+	}
+
+	if got != "" {
+		t.Fatalf("handler ran for unknown ARN: %q", got)
+	}
+
+	arn := "arn:aws:lambda:us-east-1:000000000000:function:my-func:PROD"
+	if err := m.InvokeExternal(ctx, arn, []byte(`{"event":"s3"}`)); err != nil {
+		t.Fatalf("InvokeExternal: %v", err)
+	}
+
+	if got != `{"event":"s3"}` {
+		t.Fatalf("handler payload = %q, want the S3 event", got)
+	}
+}
+
+func TestFunctionNameFromARN(t *testing.T) {
+	cases := map[string]string{
+		"arn:aws:lambda:us-east-1:0:function:fn":       "fn",
+		"arn:aws:lambda:us-east-1:0:function:fn:PROD":  "fn",
+		"arn:aws:lambda:us-east-1:0:function:fn:$LATE": "fn",
+		"fn":                                           "fn",
+	}
+	for in, want := range cases {
+		if got := functionNameFromARN(in); got != want {
+			t.Fatalf("functionNameFromARN(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"maps"
+	"strings"
 	"sync"
 	"time"
 
@@ -332,6 +333,40 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 	m.emitMetric(ctx, "ConcurrentExecutions", 1, dims)
 
 	return &driver.InvokeOutput{StatusCode: 200, Payload: payload}, nil
+}
+
+// InvokeExternal asynchronously invokes the function identified by its ARN with
+// the given event payload. It backs cross-service event delivery (e.g. S3 ->
+// Lambda notifications). An unknown function is a no-op so a stale target never
+// fails the caller.
+func (m *Mock) InvokeExternal(ctx context.Context, functionARN string, payload []byte) error {
+	name := functionNameFromARN(functionARN)
+	if _, ok := m.funcs.Get(name); !ok {
+		return nil
+	}
+
+	_, err := m.Invoke(ctx, driver.InvokeInput{FunctionName: name, Payload: payload, InvokeType: "Event"})
+
+	return err
+}
+
+// functionNameFromARN extracts the function name from a Lambda ARN
+// (arn:aws:lambda:region:account:function:name[:qualifier]); a bare name is
+// returned unchanged.
+func functionNameFromARN(arn string) string {
+	const marker = ":function:"
+
+	i := strings.Index(arn, marker)
+	if i < 0 {
+		return arn
+	}
+
+	name := arn[i+len(marker):]
+	if j := strings.IndexByte(name, ':'); j >= 0 { // strip a version/alias qualifier
+		name = name[:j]
+	}
+
+	return name
 }
 
 // invokeEngine runs a function whose code was deployed to the configured

--- a/providers/aws/s3/notification.go
+++ b/providers/aws/s3/notification.go
@@ -8,8 +8,9 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 )
 
-// PutBucketNotification replaces a bucket's SQS notification configuration.
-func (m *Mock) PutBucketNotification(_ context.Context, bucket string, configs []QueueNotification) error {
+// PutBucketNotification replaces a bucket's event-notification configuration
+// (SQS queue, SNS topic, and Lambda function targets).
+func (m *Mock) PutBucketNotification(_ context.Context, bucket string, configs []BucketNotification) error {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
@@ -20,8 +21,8 @@ func (m *Mock) PutBucketNotification(_ context.Context, bucket string, configs [
 	return nil
 }
 
-// GetBucketNotification returns a bucket's SQS notification configuration.
-func (m *Mock) GetBucketNotification(_ context.Context, bucket string) ([]QueueNotification, error) {
+// GetBucketNotification returns a bucket's event-notification configuration.
+func (m *Mock) GetBucketNotification(_ context.Context, bucket string) ([]BucketNotification, error) {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
@@ -31,23 +32,24 @@ func (m *Mock) GetBucketNotification(_ context.Context, bucket string) ([]QueueN
 }
 
 // notifyObjectCreated delivers an s3:ObjectCreated:Put event (PutObject, copy,
-// or completed multipart upload) to matching SQS targets.
+// or completed multipart upload) to matching notification targets.
 func (m *Mock) notifyObjectCreated(bkt *bucketMeta, bucket, key string, size int64) {
 	m.notify(bkt, bucket, key, size, "ObjectCreated:Put")
 }
 
-// notifyObjectRemoved delivers an s3:ObjectRemoved:Delete event to matching SQS
-// targets.
+// notifyObjectRemoved delivers an s3:ObjectRemoved:Delete event to matching
+// notification targets.
 func (m *Mock) notifyObjectRemoved(bkt *bucketMeta, bucket, key string) {
 	m.notify(bkt, bucket, key, 0, "ObjectRemoved:Delete")
 }
 
-// notify delivers an S3 event to every SQS target configured on the bucket
-// whose event filter matches. Best-effort: delivery errors are swallowed so a
-// missing/failed queue never fails the object operation (mirroring S3's
+// notify delivers an S3 event to every notification target configured on the
+// bucket whose event selector matches and whose S3Key filter (prefix/suffix)
+// accepts the object key. Best-effort: delivery errors are swallowed so a
+// missing/failed target never fails the object operation (mirroring S3's
 // asynchronous, decoupled notification behavior).
 func (m *Mock) notify(bkt *bucketMeta, bucket, key string, size int64, eventName string) {
-	if m.sqs == nil || len(bkt.notifications) == 0 {
+	if len(bkt.notifications) == 0 {
 		return
 	}
 
@@ -55,11 +57,31 @@ func (m *Mock) notify(bkt *bucketMeta, bucket, key string, size int64, eventName
 
 	for i := range bkt.notifications {
 		n := &bkt.notifications[i]
-		if !eventMatches(n.Events, eventName) {
+		if !eventMatches(n.Events, eventName) || !filterMatches(n.Filters, key) {
 			continue
 		}
 
-		_ = m.sqs.DeliverExternal(context.Background(), n.QueueARN, body)
+		m.deliver(n, body)
+	}
+}
+
+// deliver dispatches an event body to a single notification target by kind.
+func (m *Mock) deliver(n *BucketNotification, body string) {
+	ctx := context.Background()
+
+	switch n.Target {
+	case NotifyQueue:
+		if m.sqs != nil {
+			_ = m.sqs.DeliverExternal(ctx, n.ARN, body)
+		}
+	case NotifyTopic:
+		if m.sns != nil {
+			_ = m.sns.PublishExternal(ctx, n.ARN, body)
+		}
+	case NotifyLambda:
+		if m.lambda != nil {
+			_ = m.lambda.InvokeExternal(ctx, n.ARN, []byte(body))
+		}
 	}
 }
 
@@ -82,6 +104,26 @@ func eventMatches(selectors []string, eventName string) bool {
 	}
 
 	return false
+}
+
+// filterMatches reports whether an object key satisfies every S3Key filter rule.
+// S3 ANDs a prefix and a suffix rule, so a key must match all rules; no rules
+// means the target receives every matching event.
+func filterMatches(rules []NotificationFilterRule, key string) bool {
+	for i := range rules {
+		switch strings.ToLower(rules[i].Name) {
+		case "prefix":
+			if !strings.HasPrefix(key, rules[i].Value) {
+				return false
+			}
+		case "suffix":
+			if !strings.HasSuffix(key, rules[i].Value) {
+				return false
+			}
+		}
+	}
+
+	return true
 }
 
 func (m *Mock) objectEventJSON(bucket, key string, size int64, eventName string) string {

--- a/providers/aws/s3/notification_test.go
+++ b/providers/aws/s3/notification_test.go
@@ -1,0 +1,159 @@
+package s3
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// recordingPublisher captures S3 -> SNS deliveries.
+type recordingPublisher struct {
+	arns   []string
+	bodies []string
+}
+
+func (p *recordingPublisher) PublishExternal(_ context.Context, topicARN, message string) error {
+	p.arns = append(p.arns, topicARN)
+	p.bodies = append(p.bodies, message)
+
+	return nil
+}
+
+// recordingInvoker captures S3 -> Lambda deliveries.
+type recordingInvoker struct {
+	arns     []string
+	payloads []string
+}
+
+func (i *recordingInvoker) InvokeExternal(_ context.Context, functionARN string, payload []byte) error {
+	i.arns = append(i.arns, functionARN)
+	i.payloads = append(i.payloads, string(payload))
+
+	return nil
+}
+
+// TestNotificationFilterAndTargets verifies that S3 event delivery honors the
+// S3Key prefix/suffix filter (no over-delivery) and dispatches to SQS, SNS, and
+// Lambda targets by kind and event selector.
+func TestNotificationFilterAndTargets(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	sqs := &recordingDeliverer{}
+	sns := &recordingPublisher{}
+	lambda := &recordingInvoker{}
+	m.SetSQSDeliverer(sqs)
+	m.SetSNSPublisher(sns)
+	m.SetLambdaInvoker(lambda)
+
+	if err := m.CreateBucket(ctx, "nb"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	const (
+		queueARN  = "arn:aws:sqs:us-east-1:000000000000:s3events"
+		topicARN  = "arn:aws:sns:us-east-1:000000000000:s3topic"
+		lambdaARN = "arn:aws:lambda:us-east-1:000000000000:function:s3fn"
+	)
+
+	if err := m.PutBucketNotification(ctx, "nb", []BucketNotification{
+		{
+			Target: NotifyQueue, ARN: queueARN, Events: []string{"s3:ObjectCreated:*"},
+			Filters: []NotificationFilterRule{
+				{Name: "prefix", Value: "images/"},
+				{Name: "suffix", Value: ".jpg"},
+			},
+		},
+		{Target: NotifyTopic, ARN: topicARN, Events: []string{"s3:ObjectCreated:*"}},
+		{Target: NotifyLambda, ARN: lambdaARN, Events: []string{"s3:ObjectRemoved:*"}},
+	}); err != nil {
+		t.Fatalf("PutBucketNotification: %v", err)
+	}
+
+	// A matching key: reaches the filtered queue and the (unfiltered) topic, not
+	// the lambda (event mismatch).
+	if err := m.PutObject(ctx, "nb", "images/a.jpg", []byte("x"), "image/jpeg", nil); err != nil {
+		t.Fatalf("PutObject match: %v", err)
+	}
+
+	if len(sqs.arns) != 1 || sqs.arns[0] != queueARN {
+		t.Fatalf("queue deliveries = %v, want one to %s", sqs.arns, queueARN)
+	}
+
+	if len(sns.arns) != 1 || sns.arns[0] != topicARN {
+		t.Fatalf("topic deliveries = %v, want one to %s", sns.arns, topicARN)
+	}
+
+	if len(lambda.arns) != 0 {
+		t.Fatalf("lambda deliveries = %v, want none on create", lambda.arns)
+	}
+
+	// A key failing the filter (wrong prefix and suffix): the queue must NOT
+	// receive it (regression: events were delivered for every key), but the
+	// unfiltered topic still does.
+	if err := m.PutObject(ctx, "nb", "docs/b.txt", []byte("y"), "text/plain", nil); err != nil {
+		t.Fatalf("PutObject non-match: %v", err)
+	}
+
+	if len(sqs.arns) != 1 {
+		t.Fatalf("queue over-delivered to a filtered-out key: %v", sqs.arns)
+	}
+
+	if len(sns.arns) != 2 {
+		t.Fatalf("topic deliveries = %v, want two", sns.arns)
+	}
+
+	// Removing an object fires the lambda target (ObjectRemoved:*).
+	if err := m.DeleteObject(ctx, "nb", "images/a.jpg"); err != nil {
+		t.Fatalf("DeleteObject: %v", err)
+	}
+
+	if len(lambda.arns) != 1 || lambda.arns[0] != lambdaARN {
+		t.Fatalf("lambda deliveries = %v, want one to %s", lambda.arns, lambdaARN)
+	}
+
+	if !strings.Contains(lambda.payloads[0], `"eventName":"ObjectRemoved:Delete"`) {
+		t.Fatalf("lambda payload = %s", lambda.payloads[0])
+	}
+}
+
+// TestNotificationConfigRoundTrip verifies Put/Get preserves every target kind
+// and its filter rules.
+func TestNotificationConfigRoundTrip(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "rb"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	want := []BucketNotification{
+		{
+			ID: "q", Target: NotifyQueue, ARN: "arn:aws:sqs:us-east-1:0:q", Events: []string{"s3:ObjectCreated:Put"},
+			Filters: []NotificationFilterRule{{Name: "prefix", Value: "in/"}},
+		},
+		{ID: "t", Target: NotifyTopic, ARN: "arn:aws:sns:us-east-1:0:t", Events: []string{"s3:ObjectCreated:*"}},
+		{ID: "l", Target: NotifyLambda, ARN: "arn:aws:lambda:us-east-1:0:function:f", Events: []string{"s3:ObjectRemoved:*"}},
+	}
+
+	if err := m.PutBucketNotification(ctx, "rb", want); err != nil {
+		t.Fatalf("PutBucketNotification: %v", err)
+	}
+
+	got, err := m.GetBucketNotification(ctx, "rb")
+	if err != nil {
+		t.Fatalf("GetBucketNotification: %v", err)
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("got %d configs, want 3", len(got))
+	}
+
+	if got[0].Target != NotifyQueue || len(got[0].Filters) != 1 || got[0].Filters[0].Value != "in/" {
+		t.Fatalf("queue config not round-tripped: %+v", got[0])
+	}
+
+	if got[1].Target != NotifyTopic || got[2].Target != NotifyLambda {
+		t.Fatalf("topic/lambda configs not round-tripped: %+v", got)
+	}
+}

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -73,6 +73,9 @@ type multipartUpload struct {
 	id          string
 	key         string
 	contentType string
+	// tags is the create-time object tag set (S3 x-amz-tagging on
+	// CreateMultipartUpload), applied to the object when the upload completes.
+	tags map[string]string
 	// mu guards parts: the SDK uploader sends parts concurrently (UploadPart
 	// writes) while ListParts/CompleteMultipartUpload read them.
 	mu        sync.Mutex
@@ -97,7 +100,7 @@ type bucketMeta struct {
 	corsConfig    *driver.CORSConfig
 	encryption    *driver.EncryptionConfig
 	tags          map[string]string
-	notifications []QueueNotification
+	notifications []BucketNotification
 	// rawConfigs holds opaque configuration sub-resource documents (policy, cors,
 	// encryption, lifecycle, website, …) exactly as written, so the wire handler
 	// can echo them back byte-for-byte. Guarded by rawConfigMu.
@@ -105,12 +108,29 @@ type bucketMeta struct {
 	rawConfigs  map[string][]byte
 }
 
-// QueueNotification is one S3 bucket-notification target: an SQS queue that
-// receives events whose names match one of Events (e.g. "s3:ObjectCreated:*").
-type QueueNotification struct {
-	ID       string
-	QueueARN string
-	Events   []string
+// Notification target kinds for a bucket-notification configuration.
+const (
+	NotifyQueue  = "queue"
+	NotifyTopic  = "topic"
+	NotifyLambda = "lambda"
+)
+
+// NotificationFilterRule is one S3Key name-filter rule of a bucket notification:
+// Name is "prefix" or "suffix", Value the object-key fragment to match.
+type NotificationFilterRule struct {
+	Name  string
+	Value string
+}
+
+// BucketNotification is one S3 bucket-notification target: an SQS queue, SNS
+// topic, or Lambda function that receives events whose names match one of Events
+// and whose object key satisfies every S3Key filter rule.
+type BucketNotification struct {
+	ID      string
+	Target  string // NotifyQueue / NotifyTopic / NotifyLambda
+	ARN     string
+	Events  []string
+	Filters []NotificationFilterRule
 }
 
 // SQSDeliverer delivers an S3 event notification into an SQS queue by ARN. The
@@ -119,18 +139,44 @@ type SQSDeliverer interface {
 	DeliverExternal(ctx context.Context, queueARN, body string) error
 }
 
+// SNSPublisher publishes an S3 event notification to an SNS topic by ARN. The
+// SNS mock satisfies this, enabling real S3 -> SNS event delivery.
+type SNSPublisher interface {
+	PublishExternal(ctx context.Context, topicARN, message string) error
+}
+
+// LambdaInvoker asynchronously invokes a Lambda function by ARN with an S3 event
+// payload. The Lambda mock satisfies this, enabling real S3 -> Lambda delivery.
+type LambdaInvoker interface {
+	InvokeExternal(ctx context.Context, functionARN string, payload []byte) error
+}
+
 // Mock is an in-memory mock implementation of the AWS S3 service.
 type Mock struct {
 	buckets    *memstore.Store[*bucketMeta]
 	opts       *config.Options
 	monitoring mondriver.Monitoring
 	sqs        SQSDeliverer
+	sns        SNSPublisher
+	lambda     LambdaInvoker
 }
 
-// SetSQSDeliverer wires the SQS backend so object-create events deliver to
-// buckets' SQS notification targets.
+// SetSQSDeliverer wires the SQS backend so object events deliver to buckets' SQS
+// notification targets.
 func (m *Mock) SetSQSDeliverer(d SQSDeliverer) {
 	m.sqs = d
+}
+
+// SetSNSPublisher wires the SNS backend so object events deliver to buckets' SNS
+// topic notification targets.
+func (m *Mock) SetSNSPublisher(p SNSPublisher) {
+	m.sns = p
+}
+
+// SetLambdaInvoker wires the Lambda backend so object events invoke buckets'
+// Lambda function notification targets.
+func (m *Mock) SetLambdaInvoker(i LambdaInvoker) {
+	m.lambda = i
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -646,7 +692,7 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 	dstObj := &s3Object{
 		Key: dstKey, Data: dataCopy, Size: srcObj.Size, ContentType: srcObj.ContentType,
 		ETag: srcObj.ETag, LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
-		Metadata: meta,
+		Metadata: meta, Tags: maps.Clone(srcObj.Tags),
 	}
 	m.storeObject(dstBkt, dstKey, dstObj)
 
@@ -677,6 +723,7 @@ type copySrcSnapshot struct {
 	etag         string
 	lastModified string
 	metadata     map[string]string
+	tags         map[string]string
 	versionID    string
 }
 
@@ -713,10 +760,17 @@ func (m *Mock) CopyObjectV2(ctx context.Context, req *driver.CopyObjectRequest) 
 	dataCopy := make([]byte, len(src.data))
 	copy(dataCopy, src.data)
 
+	// COPY tagging directive (the default) inherits the source object's tags;
+	// REPLACE takes the request's x-amz-tagging tag set instead.
+	tags := src.tags
+	if req.ReplaceTags {
+		tags = req.Tags
+	}
+
 	dstObj := &s3Object{
 		Key: req.DstKey, Data: dataCopy, Size: src.size, ContentType: contentType,
 		ETag: src.etag, LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
-		Metadata: maps.Clone(metadata),
+		Metadata: maps.Clone(metadata), Tags: maps.Clone(tags),
 	}
 	m.storeObject(dstBkt, req.DstKey, dstObj)
 
@@ -765,7 +819,7 @@ func (m *Mock) resolveCopySource(ctx context.Context, src driver.CopySource, ver
 
 	return &copySrcSnapshot{
 		data: data, size: srcObj.Size, contentType: srcObj.ContentType, etag: srcObj.ETag,
-		lastModified: srcObj.LastModified, metadata: srcObj.Metadata, versionID: srcObj.VersionID,
+		lastModified: srcObj.LastModified, metadata: srcObj.Metadata, tags: srcObj.Tags, versionID: srcObj.VersionID,
 	}, nil
 }
 
@@ -979,7 +1033,15 @@ func objectExpired(obj *s3Object, cfg *driver.LifecycleConfig, now time.Time) bo
 	return false
 }
 
-func (m *Mock) CreateMultipartUpload(_ context.Context, bucket, key, contentType string) (*driver.MultipartUpload, error) {
+func (m *Mock) CreateMultipartUpload(ctx context.Context, bucket, key, contentType string) (*driver.MultipartUpload, error) {
+	return m.CreateMultipartUploadWithTagging(ctx, bucket, key, contentType, nil)
+}
+
+// CreateMultipartUploadWithTagging begins a multipart upload carrying the
+// create-time x-amz-tagging tag set, applied to the object on completion.
+func (m *Mock) CreateMultipartUploadWithTagging(
+	_ context.Context, bucket, key, contentType string, tags map[string]string,
+) (*driver.MultipartUpload, error) {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
@@ -992,6 +1054,7 @@ func (m *Mock) CreateMultipartUpload(_ context.Context, bucket, key, contentType
 		id:          uploadID,
 		key:         key,
 		contentType: contentType,
+		tags:        maps.Clone(tags),
 		parts:       make(map[int][]byte),
 		createdAt:   now,
 	})
@@ -1109,6 +1172,7 @@ func (m *Mock) CompleteMultipartUpload(ctx context.Context, bucket, key, uploadI
 		ETag:         multipartETag(ordered),
 		LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
 		Metadata:     make(map[string]string),
+		Tags:         maps.Clone(mp.tags),
 	}
 	m.storeObject(bkt, key, obj)
 

--- a/providers/aws/s3/s3_test.go
+++ b/providers/aws/s3/s3_test.go
@@ -46,9 +46,9 @@ func TestBucketNotificationDelivery(t *testing.T) {
 		t.Fatalf("CreateBucket: %v", err)
 	}
 
-	if err := m.PutBucketNotification(ctx, "nb", []QueueNotification{
-		{QueueARN: "arn:aws:sqs:us-east-1:000000000000:s3events", Events: []string{"s3:ObjectCreated:*"}},
-		{QueueARN: "arn:aws:sqs:us-east-1:000000000000:deletes", Events: []string{"s3:ObjectRemoved:*"}},
+	if err := m.PutBucketNotification(ctx, "nb", []BucketNotification{
+		{Target: NotifyQueue, ARN: "arn:aws:sqs:us-east-1:000000000000:s3events", Events: []string{"s3:ObjectCreated:*"}},
+		{Target: NotifyQueue, ARN: "arn:aws:sqs:us-east-1:000000000000:deletes", Events: []string{"s3:ObjectRemoved:*"}},
 	}); err != nil {
 		t.Fatalf("PutBucketNotification: %v", err)
 	}

--- a/providers/aws/sns/delivery_test.go
+++ b/providers/aws/sns/delivery_test.go
@@ -75,3 +75,49 @@ func TestSNSToSQSDelivery(t *testing.T) {
 		t.Fatalf("unexpected MessageAttributes: %+v", attrs)
 	}
 }
+
+// TestPublishExternalByARN verifies PublishExternal resolves a topic by ARN and
+// fans a raw message out to its SQS subscriptions (backing S3 -> SNS delivery),
+// and that an unknown topic ARN is a no-op.
+func TestPublishExternalByARN(t *testing.T) {
+	ctx := context.Background()
+	opts := config.NewOptions()
+
+	sqs := sqsprovider.New(opts)
+	sns := snsprovider.New(opts)
+	sns.SetSQSDeliverer(sqs)
+
+	q, err := sqs.CreateQueue(ctx, mqdriver.QueueConfig{Name: "inbox"})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	topic, err := sns.CreateTopic(ctx, sndriver.TopicConfig{Name: "s3-topic"})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	if _, err := sns.Subscribe(ctx, sndriver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "sqs", Endpoint: q.ARN, Attributes: map[string]string{"RawMessageDelivery": "true"},
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	// Unknown topic ARN: no error, nothing delivered.
+	if err := sns.PublishExternal(ctx, "arn:aws:sns:us-east-1:000000000000:missing", "x"); err != nil {
+		t.Fatalf("PublishExternal unknown: %v", err)
+	}
+
+	if err := sns.PublishExternal(ctx, topic.ResourceID, `{"event":"s3"}`); err != nil {
+		t.Fatalf("PublishExternal: %v", err)
+	}
+
+	msgs, err := sqs.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: q.URL, MaxMessages: 10})
+	if err != nil {
+		t.Fatalf("ReceiveMessages: %v", err)
+	}
+
+	if len(msgs) != 1 || msgs[0].Body != `{"event":"s3"}` {
+		t.Fatalf("expected the raw S3 event delivered once, got %d: %+v", len(msgs), msgs)
+	}
+}

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"maps"
+	"strings"
 	"sync"
 	"time"
 
@@ -373,6 +374,31 @@ func (m *Mock) Publish(ctx context.Context, input driver.PublishInput) (*driver.
 	m.emitMetric("PublishSize", float64(len(input.Message)), "Bytes", dims)
 
 	return &driver.PublishOutput{MessageID: msgID}, nil
+}
+
+// PublishExternal publishes a raw message to the topic identified by its ARN,
+// fanning it out to the topic's subscriptions. It backs cross-service event
+// delivery (e.g. S3 -> SNS notifications). An unknown topic is a no-op so a
+// stale target never fails the caller.
+func (m *Mock) PublishExternal(ctx context.Context, topicARN, message string) error {
+	name := arnResource(topicARN)
+	if _, ok := m.topics.Get(name); !ok {
+		return nil
+	}
+
+	_, err := m.Publish(ctx, driver.PublishInput{TopicID: name, Message: message})
+
+	return err
+}
+
+// arnResource returns the resource segment (after the last colon) of an ARN,
+// e.g. the topic name of arn:aws:sns:us-east-1:000000000000:my-topic.
+func arnResource(arn string) string {
+	if i := strings.LastIndexByte(arn, ':'); i >= 0 {
+		return arn[i+1:]
+	}
+
+	return arn
 }
 
 // fanOutToSQS delivers a published message to every SQS-protocol subscription

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -601,6 +601,16 @@ func (h *Handler) putObject(w http.ResponseWriter, r *http.Request, bucket, key 
 		return
 	}
 
+	// x-amz-tagging sets the object's tag set at upload time. Apply it to the
+	// just-written object so GetObjectTagging returns it (real S3 stores the tag
+	// set atomically with the object).
+	if tags := parseTaggingHeader(r.Header.Get("X-Amz-Tagging")); len(tags) > 0 {
+		if err := h.bucket.PutObjectTagging(r.Context(), bucket, key, tags); err != nil {
+			writeErr(w, err)
+			return
+		}
+	}
+
 	// Real S3 always returns the object's ETag on PutObject. Read it back
 	// from the driver so there is a single source of truth for the ETag
 	// algorithm; if a concurrent delete races the read-back, fall back to
@@ -1029,6 +1039,13 @@ func buildCopyRequest(
 		req.ContentType = r.Header.Get("Content-Type")
 	}
 
+	// x-amz-tagging-directive: REPLACE takes the destination tag set from the
+	// x-amz-tagging header; the default COPY inherits the source object's tags.
+	if strings.EqualFold(r.Header.Get("X-Amz-Tagging-Directive"), "REPLACE") {
+		req.ReplaceTags = true
+		req.Tags = parseTaggingHeader(r.Header.Get("X-Amz-Tagging"))
+	}
+
 	applyCopyConditions(req, r.Header)
 
 	return req
@@ -1318,13 +1335,23 @@ func (h *Handler) multipartUploadOp(w http.ResponseWriter, r *http.Request, buck
 	}
 }
 
+// multipartTagger is the AWS-specific capability to carry the create-time
+// x-amz-tagging tag set on a multipart upload (applied to the object on
+// completion). Type-asserted like bucketNotifier; drivers without it ignore
+// create-time multipart tags.
+type multipartTagger interface {
+	CreateMultipartUploadWithTagging(
+		ctx context.Context, bucket, key, contentType string, tags map[string]string,
+	) (*driver.MultipartUpload, error)
+}
+
 func (h *Handler) createMultipartUpload(w http.ResponseWriter, r *http.Request, bucket, key string) {
 	contentType := r.Header.Get("Content-Type")
 	if contentType == "" {
 		contentType = "application/octet-stream"
 	}
 
-	mp, err := h.bucket.CreateMultipartUpload(r.Context(), bucket, key, contentType)
+	mp, err := h.beginMultipartUpload(r, bucket, key, contentType)
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -1336,6 +1363,20 @@ func (h *Handler) createMultipartUpload(w http.ResponseWriter, r *http.Request, 
 		Key:      key,
 		UploadID: mp.UploadID,
 	})
+}
+
+// beginMultipartUpload starts an upload, threading the x-amz-tagging tag set
+// through to a driver that supports create-time multipart tags and falling back
+// to the plain CreateMultipartUpload otherwise.
+func (h *Handler) beginMultipartUpload(r *http.Request, bucket, key, contentType string) (*driver.MultipartUpload, error) {
+	tags := parseTaggingHeader(r.Header.Get("X-Amz-Tagging"))
+	if len(tags) > 0 {
+		if tagger, ok := h.bucket.(multipartTagger); ok {
+			return tagger.CreateMultipartUploadWithTagging(r.Context(), bucket, key, contentType, tags)
+		}
+	}
+
+	return h.bucket.CreateMultipartUpload(r.Context(), bucket, key, contentType)
 }
 
 func (h *Handler) uploadPart(w http.ResponseWriter, r *http.Request, bucket, key, uploadID string) {
@@ -1675,6 +1716,33 @@ func extractMetadata(h http.Header) map[string]string {
 	}
 
 	return meta
+}
+
+// parseTaggingHeader decodes an x-amz-tagging header ("k1=v1&k2=v2",
+// URL-query-encoded) into a tag map. An empty or unparseable header yields nil.
+func parseTaggingHeader(header string) map[string]string {
+	if header == "" {
+		return nil
+	}
+
+	values, err := url.ParseQuery(header)
+	if err != nil {
+		return nil
+	}
+
+	tags := make(map[string]string, len(values))
+
+	for k, v := range values {
+		if len(v) > 0 {
+			tags[k] = v[0]
+		}
+	}
+
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return tags
 }
 
 // writeDeleteMarker answers a version-addressed GET/HEAD of a delete marker

--- a/server/aws/s3/notification.go
+++ b/server/aws/s3/notification.go
@@ -13,25 +13,63 @@ import (
 // of the portable Bucket driver (Azure Blob / GCS notify differently), so the
 // handler type-asserts for it.
 type bucketNotifier interface {
-	PutBucketNotification(ctx context.Context, bucket string, configs []s3provider.QueueNotification) error
-	GetBucketNotification(ctx context.Context, bucket string) ([]s3provider.QueueNotification, error)
+	PutBucketNotification(ctx context.Context, bucket string, configs []s3provider.BucketNotification) error
+	GetBucketNotification(ctx context.Context, bucket string) ([]s3provider.BucketNotification, error)
 }
 
+// filterRuleXML is one S3Key name-filter rule (<Name>prefix|suffix</Name>).
+type filterRuleXML struct {
+	Name  string `xml:"Name"`
+	Value string `xml:"Value"`
+}
+
+type s3KeyFilterXML struct {
+	FilterRules []filterRuleXML `xml:"FilterRule"`
+}
+
+// notificationFilterXML is the <Filter><S3Key>… key-name filter shared by all
+// three destination kinds.
+type notificationFilterXML struct {
+	S3Key s3KeyFilterXML `xml:"S3Key"`
+}
+
+// queueConfigurationXML targets an SQS queue (<Queue> = queue ARN).
 type queueConfigurationXML struct {
-	ID     string   `xml:"Id,omitempty"`
-	Queue  string   `xml:"Queue"`
-	Events []string `xml:"Event"`
+	ID     string                 `xml:"Id,omitempty"`
+	Queue  string                 `xml:"Queue"`
+	Events []string               `xml:"Event"`
+	Filter *notificationFilterXML `xml:"Filter,omitempty"`
+}
+
+// topicConfigurationXML targets an SNS topic (<Topic> = topic ARN).
+type topicConfigurationXML struct {
+	ID     string                 `xml:"Id,omitempty"`
+	Topic  string                 `xml:"Topic"`
+	Events []string               `xml:"Event"`
+	Filter *notificationFilterXML `xml:"Filter,omitempty"`
+}
+
+// lambdaConfigurationXML targets a Lambda function. Its wire element is
+// <CloudFunctionConfiguration> with the ARN in <CloudFunction> — the names the
+// AWS SDKs marshal LambdaFunctionConfiguration to.
+type lambdaConfigurationXML struct {
+	ID            string                 `xml:"Id,omitempty"`
+	CloudFunction string                 `xml:"CloudFunction"`
+	Events        []string               `xml:"Event"`
+	Filter        *notificationFilterXML `xml:"Filter,omitempty"`
 }
 
 type notificationConfigurationXML struct {
-	XMLName             xml.Name                `xml:"NotificationConfiguration"`
-	Xmlns               string                  `xml:"xmlns,attr,omitempty"`
-	QueueConfigurations []queueConfigurationXML `xml:"QueueConfiguration"`
+	XMLName              xml.Name                 `xml:"NotificationConfiguration"`
+	Xmlns                string                   `xml:"xmlns,attr,omitempty"`
+	QueueConfigurations  []queueConfigurationXML  `xml:"QueueConfiguration"`
+	TopicConfigurations  []topicConfigurationXML  `xml:"TopicConfiguration"`
+	LambdaConfigurations []lambdaConfigurationXML `xml:"CloudFunctionConfiguration"`
 }
 
 // bucketNotificationOp dispatches PUT/GET for the bucket ?notification
 // sub-resource. Without this a PUT ?notification fell through to CreateBucket
-// (BucketAlreadyOwnedByYou), and S3 -> SQS event pipelines could not be wired.
+// (BucketAlreadyOwnedByYou), and S3 event pipelines could not be wired.
 func (h *Handler) bucketNotificationOp(w http.ResponseWriter, r *http.Request, bucket string) {
 	notifier, ok := h.bucket.(bucketNotifier)
 	if !ok {
@@ -41,41 +79,107 @@ func (h *Handler) bucketNotificationOp(w http.ResponseWriter, r *http.Request, b
 
 	switch r.Method {
 	case http.MethodPut:
-		var body notificationConfigurationXML
-		if err := xml.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeError(w, http.StatusBadRequest, "MalformedXML", "could not parse request body")
-			return
-		}
-
-		configs := make([]s3provider.QueueNotification, 0, len(body.QueueConfigurations))
-		for _, qc := range body.QueueConfigurations {
-			configs = append(configs, s3provider.QueueNotification{
-				ID: qc.ID, QueueARN: qc.Queue, Events: qc.Events,
-			})
-		}
-
-		if err := notifier.PutBucketNotification(r.Context(), bucket, configs); err != nil {
-			writeErr(w, err)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
+		h.putBucketNotification(w, r, bucket, notifier)
 	case http.MethodGet:
-		configs, err := notifier.GetBucketNotification(r.Context(), bucket)
-		if err != nil {
-			writeErr(w, err)
-			return
-		}
-
-		resp := notificationConfigurationXML{Xmlns: xmlns}
-		for _, c := range configs {
-			resp.QueueConfigurations = append(resp.QueueConfigurations, queueConfigurationXML{
-				ID: c.ID, Queue: c.QueueARN, Events: c.Events,
-			})
-		}
-
-		wire.WriteXML(w, http.StatusOK, resp)
+		h.getBucketNotification(w, r, bucket, notifier)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
+}
+
+func (*Handler) putBucketNotification(w http.ResponseWriter, r *http.Request, bucket string, notifier bucketNotifier) {
+	var body notificationConfigurationXML
+	if err := xml.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "MalformedXML", "could not parse request body")
+		return
+	}
+
+	configs := make([]s3provider.BucketNotification, 0,
+		len(body.QueueConfigurations)+len(body.TopicConfigurations)+len(body.LambdaConfigurations))
+
+	for _, qc := range body.QueueConfigurations {
+		configs = append(configs, s3provider.BucketNotification{
+			ID: qc.ID, Target: s3provider.NotifyQueue, ARN: qc.Queue, Events: qc.Events, Filters: filtersFromXML(qc.Filter),
+		})
+	}
+
+	for _, tc := range body.TopicConfigurations {
+		configs = append(configs, s3provider.BucketNotification{
+			ID: tc.ID, Target: s3provider.NotifyTopic, ARN: tc.Topic, Events: tc.Events, Filters: filtersFromXML(tc.Filter),
+		})
+	}
+
+	for _, lc := range body.LambdaConfigurations {
+		configs = append(configs, s3provider.BucketNotification{
+			ID: lc.ID, Target: s3provider.NotifyLambda, ARN: lc.CloudFunction, Events: lc.Events, Filters: filtersFromXML(lc.Filter),
+		})
+	}
+
+	if err := notifier.PutBucketNotification(r.Context(), bucket, configs); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (*Handler) getBucketNotification(w http.ResponseWriter, r *http.Request, bucket string, notifier bucketNotifier) {
+	configs, err := notifier.GetBucketNotification(r.Context(), bucket)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	resp := notificationConfigurationXML{Xmlns: xmlns}
+
+	for i := range configs {
+		c := &configs[i]
+
+		switch c.Target {
+		case s3provider.NotifyTopic:
+			resp.TopicConfigurations = append(resp.TopicConfigurations, topicConfigurationXML{
+				ID: c.ID, Topic: c.ARN, Events: c.Events, Filter: filtersToXML(c.Filters),
+			})
+		case s3provider.NotifyLambda:
+			resp.LambdaConfigurations = append(resp.LambdaConfigurations, lambdaConfigurationXML{
+				ID: c.ID, CloudFunction: c.ARN, Events: c.Events, Filter: filtersToXML(c.Filters),
+			})
+		default:
+			resp.QueueConfigurations = append(resp.QueueConfigurations, queueConfigurationXML{
+				ID: c.ID, Queue: c.ARN, Events: c.Events, Filter: filtersToXML(c.Filters),
+			})
+		}
+	}
+
+	wire.WriteXML(w, http.StatusOK, resp)
+}
+
+// filtersFromXML flattens an optional <Filter><S3Key> element into the provider
+// filter-rule list.
+func filtersFromXML(f *notificationFilterXML) []s3provider.NotificationFilterRule {
+	if f == nil || len(f.S3Key.FilterRules) == 0 {
+		return nil
+	}
+
+	rules := make([]s3provider.NotificationFilterRule, 0, len(f.S3Key.FilterRules))
+	for _, r := range f.S3Key.FilterRules {
+		rules = append(rules, s3provider.NotificationFilterRule{Name: r.Name, Value: r.Value})
+	}
+
+	return rules
+}
+
+// filtersToXML rebuilds the <Filter><S3Key> element from provider filter rules,
+// returning nil (so the element is omitted) when there are none.
+func filtersToXML(rules []s3provider.NotificationFilterRule) *notificationFilterXML {
+	if len(rules) == 0 {
+		return nil
+	}
+
+	out := &notificationFilterXML{}
+	for _, r := range rules {
+		out.S3Key.FilterRules = append(out.S3Key.FilterRules, filterRuleXML{Name: r.Name, Value: r.Value})
+	}
+
+	return out
 }

--- a/server/aws/s3/notification_config_sdk_test.go
+++ b/server/aws/s3/notification_config_sdk_test.go
@@ -1,0 +1,90 @@
+// notification_config_sdk_test.go — real aws-sdk-go-v2 tests for bucket event
+// notification configuration. Queue (SQS), Topic (SNS), and Lambda function
+// destinations, plus an S3Key prefix/suffix filter, must round-trip through
+// PutBucketNotificationConfiguration / GetBucketNotificationConfiguration
+// (previously Topic/Lambda configs and filters were silently dropped).
+package s3_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestS3BucketNotificationConfigRoundTrip(t *testing.T) {
+	client := newSuiteS3Client(t)
+	ctx := context.Background()
+
+	const bucket = "notif-roundtrip"
+	suiteCreateBucket(t, client, bucket)
+
+	const (
+		queueARN  = "arn:aws:sqs:us-east-1:000000000000:s3-events"
+		topicARN  = "arn:aws:sns:us-east-1:000000000000:s3-topic"
+		lambdaARN = "arn:aws:lambda:us-east-1:000000000000:function:s3-fn"
+	)
+
+	_, err := client.PutBucketNotificationConfiguration(ctx, &s3.PutBucketNotificationConfigurationInput{
+		Bucket: aws.String(bucket),
+		NotificationConfiguration: &types.NotificationConfiguration{
+			QueueConfigurations: []types.QueueConfiguration{{
+				Id:       aws.String("q1"),
+				QueueArn: aws.String(queueARN),
+				Events:   []types.Event{types.EventS3ObjectCreatedPut},
+				Filter: &types.NotificationConfigurationFilter{
+					Key: &types.S3KeyFilter{FilterRules: []types.FilterRule{
+						{Name: types.FilterRuleNamePrefix, Value: aws.String("images/")},
+						{Name: types.FilterRuleNameSuffix, Value: aws.String(".jpg")},
+					}},
+				},
+			}},
+			TopicConfigurations: []types.TopicConfiguration{{
+				Id:       aws.String("t1"),
+				TopicArn: aws.String(topicARN),
+				Events:   []types.Event{types.EventS3ObjectCreated},
+			}},
+			LambdaFunctionConfigurations: []types.LambdaFunctionConfiguration{{
+				Id:                aws.String("l1"),
+				LambdaFunctionArn: aws.String(lambdaARN),
+				Events:            []types.Event{types.EventS3ObjectRemoved},
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	got, err := client.GetBucketNotificationConfiguration(ctx, &s3.GetBucketNotificationConfigurationInput{
+		Bucket: aws.String(bucket),
+	})
+	require.NoError(t, err)
+
+	// Queue configuration with its S3Key filter.
+	require.Len(t, got.QueueConfigurations, 1)
+	q := got.QueueConfigurations[0]
+	assert.Equal(t, "q1", aws.ToString(q.Id))
+	assert.Equal(t, queueARN, aws.ToString(q.QueueArn))
+	assert.Equal(t, []types.Event{types.EventS3ObjectCreatedPut}, q.Events)
+	require.NotNil(t, q.Filter)
+	require.NotNil(t, q.Filter.Key)
+	require.Len(t, q.Filter.Key.FilterRules, 2)
+	assert.Equal(t, types.FilterRuleNamePrefix, q.Filter.Key.FilterRules[0].Name)
+	assert.Equal(t, "images/", aws.ToString(q.Filter.Key.FilterRules[0].Value))
+	assert.Equal(t, types.FilterRuleNameSuffix, q.Filter.Key.FilterRules[1].Name)
+	assert.Equal(t, ".jpg", aws.ToString(q.Filter.Key.FilterRules[1].Value))
+
+	// Topic (SNS) configuration — previously dropped.
+	require.Len(t, got.TopicConfigurations, 1)
+	assert.Equal(t, "t1", aws.ToString(got.TopicConfigurations[0].Id))
+	assert.Equal(t, topicARN, aws.ToString(got.TopicConfigurations[0].TopicArn))
+	assert.Equal(t, []types.Event{types.EventS3ObjectCreated}, got.TopicConfigurations[0].Events)
+
+	// Lambda function configuration — previously dropped.
+	require.Len(t, got.LambdaFunctionConfigurations, 1)
+	assert.Equal(t, "l1", aws.ToString(got.LambdaFunctionConfigurations[0].Id))
+	assert.Equal(t, lambdaARN, aws.ToString(got.LambdaFunctionConfigurations[0].LambdaFunctionArn))
+	assert.Equal(t, []types.Event{types.EventS3ObjectRemoved}, got.LambdaFunctionConfigurations[0].Events)
+}

--- a/server/aws/s3/object_tagging_sdk_test.go
+++ b/server/aws/s3/object_tagging_sdk_test.go
@@ -1,0 +1,125 @@
+// object_tagging_sdk_test.go — real aws-sdk-go-v2 tests for the create-time
+// x-amz-tagging header on PutObject, CopyObject, and CreateMultipartUpload. The
+// tag-set supplied at write time must be retrievable via GetObjectTagging.
+package s3_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tagMap flattens a GetObjectTagging TagSet into a comparable map.
+func tagMap(set []types.Tag) map[string]string {
+	out := make(map[string]string, len(set))
+	for _, t := range set {
+		out[aws.ToString(t.Key)] = aws.ToString(t.Value)
+	}
+
+	return out
+}
+
+func getObjectTags(t *testing.T, client *s3.Client, bucket, key string) map[string]string {
+	t.Helper()
+
+	out, err := client.GetObjectTagging(context.Background(), &s3.GetObjectTaggingInput{
+		Bucket: aws.String(bucket), Key: aws.String(key),
+	})
+	require.NoError(t, err)
+
+	return tagMap(out.TagSet)
+}
+
+// TestS3PutObjectTaggingHeader verifies the x-amz-tagging request header on
+// PutObject sets the object's tag-set at upload time (previously silently
+// dropped, leaving GetObjectTagging empty).
+func TestS3PutObjectTaggingHeader(t *testing.T) {
+	client := newSuiteS3Client(t)
+	ctx := context.Background()
+
+	const bucket = "tagging-put"
+	suiteCreateBucket(t, client, bucket)
+
+	_, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:  aws.String(bucket),
+		Key:     aws.String("obj.txt"),
+		Body:    bytes.NewReader([]byte("hi")),
+		Tagging: aws.String("env=prod&team=payments"),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{"env": "prod", "team": "payments"},
+		getObjectTags(t, client, bucket, "obj.txt"))
+}
+
+// TestS3CopyObjectTaggingReplace verifies x-amz-tagging-directive: REPLACE takes
+// the destination tag-set from the request's x-amz-tagging header instead of the
+// source object's tags.
+func TestS3CopyObjectTaggingReplace(t *testing.T) {
+	client := newSuiteS3Client(t)
+	ctx := context.Background()
+
+	const bucket = "tagging-copy"
+	suiteCreateBucket(t, client, bucket)
+
+	_, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:  aws.String(bucket),
+		Key:     aws.String("src.txt"),
+		Body:    bytes.NewReader([]byte("body")),
+		Tagging: aws.String("origin=src"),
+	})
+	require.NoError(t, err)
+
+	_, err = client.CopyObject(ctx, &s3.CopyObjectInput{
+		Bucket:           aws.String(bucket),
+		Key:              aws.String("dst.txt"),
+		CopySource:       aws.String(bucket + "/src.txt"),
+		TaggingDirective: types.TaggingDirectiveReplace,
+		Tagging:          aws.String("origin=dst&stage=copied"),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{"origin": "dst", "stage": "copied"},
+		getObjectTags(t, client, bucket, "dst.txt"), "REPLACE takes the request tag-set")
+}
+
+// TestS3CreateMultipartUploadTaggingHeader verifies the x-amz-tagging header on
+// CreateMultipartUpload carries through to the completed object's tag-set.
+func TestS3CreateMultipartUploadTaggingHeader(t *testing.T) {
+	client := newSuiteS3Client(t)
+	ctx := context.Background()
+
+	const bucket = "tagging-mpu"
+	suiteCreateBucket(t, client, bucket)
+
+	create, err := client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
+		Bucket:  aws.String(bucket),
+		Key:     aws.String("big.bin"),
+		Tagging: aws.String("kind=archive"),
+	})
+	require.NoError(t, err)
+
+	part := make([]byte, 5<<20) // one 5 MiB part
+	up, err := client.UploadPart(ctx, &s3.UploadPartInput{
+		Bucket: aws.String(bucket), Key: aws.String("big.bin"),
+		UploadId: create.UploadId, PartNumber: aws.Int32(1), Body: bytes.NewReader(part),
+	})
+	require.NoError(t, err)
+
+	_, err = client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+		Bucket: aws.String(bucket), Key: aws.String("big.bin"), UploadId: create.UploadId,
+		MultipartUpload: &types.CompletedMultipartUpload{
+			Parts: []types.CompletedPart{{ETag: up.ETag, PartNumber: aws.Int32(1)}},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{"kind": "archive"},
+		getObjectTags(t, client, bucket, "big.bin"))
+}

--- a/server/aws/s3/s3_lifecycle_test.go
+++ b/server/aws/s3/s3_lifecycle_test.go
@@ -617,8 +617,9 @@ func TestS3MetadataContentTypeRoundTrip(t *testing.T) {
 }
 
 // TestS3CopyObjectSemantics verifies the survey-documented copy
-// behavior end-to-end: ETag and metadata are preserved, tags are NOT copied,
-// and copying from a missing source key fails with NoSuchKey.
+// behavior end-to-end: ETag and metadata are preserved, the source tag-set is
+// copied under the default COPY tagging directive, and copying from a missing
+// source key fails with NoSuchKey.
 func TestS3CopyObjectSemantics(t *testing.T) {
 	client := newSuiteS3Client(t)
 	ctx := context.Background()
@@ -661,11 +662,15 @@ func TestS3CopyObjectSemantics(t *testing.T) {
 	assert.Equal(t, "text/plain", aws.ToString(get.ContentType), "copy preserves content type")
 	assert.Equal(t, map[string]string{"origin": "src"}, get.Metadata, "copy preserves metadata")
 
+	// The default tagging directive is COPY: the destination inherits the source
+	// object's tag-set.
 	dstTags, err := client.GetObjectTagging(ctx, &s3.GetObjectTaggingInput{
 		Bucket: aws.String(dstBucket), Key: aws.String("dst.txt"),
 	})
 	require.NoError(t, err)
-	assert.Empty(t, dstTags.TagSet, "tags must NOT be copied")
+	require.Len(t, dstTags.TagSet, 1, "source tag-set must be copied under the default COPY directive")
+	assert.Equal(t, "classified", aws.ToString(dstTags.TagSet[0].Key))
+	assert.Equal(t, "yes", aws.ToString(dstTags.TagSet[0].Value))
 
 	// Copy from a missing source key fails.
 	_, err = client.CopyObject(ctx, &s3.CopyObjectInput{

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -280,6 +280,12 @@ type CopyObjectRequest struct {
 	ReplaceMetadata bool
 	Metadata        map[string]string
 	ContentType     string
+	// Tags is the destination object's tag set, applied only when ReplaceTags is
+	// true (x-amz-tagging with x-amz-tagging-directive: REPLACE). With ReplaceTags
+	// false (the default COPY tagging directive) the destination inherits the
+	// source object's tags.
+	Tags        map[string]string
+	ReplaceTags bool
 	// Copy-source preconditions; a zero value means the header was absent. A
 	// failed precondition must abort the copy with a FailedPrecondition error.
 	IfMatch           string


### PR DESCRIPTION
## Summary

Fixes three real behavioral gaps in the S3 wire emulator, all confirmed against the official S3 API reference and verified with real aws-sdk-go-v2 tests.

### 1. `x-amz-tagging` header dropped on object writes (HIGH)
The object-write path silently discarded the `x-amz-tagging` request header, so an object uploaded with tags returned success but `GetObjectTagging` came back empty.

- `PutObject` now applies the header tag-set to the just-written object.
- `CreateMultipartUpload` carries the create-time tag-set through to the object on `CompleteMultipartUpload` (new AWS-only `CreateMultipartUploadWithTagging`, type-asserted like the other optional S3 surfaces).
- `CopyObject` honors `x-amz-tagging-directive`: the default `COPY` inherits the source object's tags; `REPLACE` takes the request's `x-amz-tagging` tag-set. (`CopyObjectRequest` gained `Tags`/`ReplaceTags`.)

The prior end-to-end copy test asserted "tags must NOT be copied", which contradicts the documented default (`TaggingDirective` defaults to `COPY`); updated to assert the correct behavior.

### 2. Topic (SNS) and Lambda notification configs silently dropped (HIGH)
`PutBucketNotificationConfiguration` decoded only `QueueConfiguration`; `TopicConfiguration` and `CloudFunctionConfiguration` elements were discarded, the call returned 200, and the subsequent GET returned nothing (acknowledged-then-lost). The wire XML and the provider notification model now carry all three destination kinds, so SNS and Lambda targets round-trip.

### 3. `QueueConfiguration` S3Key filter dropped + over-delivery (HIGH)
The `<Filter><S3Key>` prefix/suffix rules were neither persisted nor enforced, so every object key triggered the notification. Filters now round-trip through Put/Get and gate delivery (prefix AND suffix must match). Events dispatch to the configured target by kind — SQS (`DeliverExternal`), SNS (new `PublishExternal`, resolves topic by ARN and fans out to subscriptions), and Lambda (new `InvokeExternal`, resolves the function by ARN and invokes with the S3 event payload). Wired in the AWS provider factory.

## Tests
- Real aws-sdk-go-v2: PutObject / CopyObject(REPLACE) / multipart create-time tagging; notification config round-trip for Queue+Topic+Lambda with an S3Key prefix/suffix filter.
- Provider-level: filter-honoring multi-target delivery (no over-delivery), Put/Get round-trip, SNS `PublishExternal` and Lambda `InvokeExternal` ARN resolution.

## Contract references
- PutBucketNotificationConfiguration: `<Queue>`/`<Topic>`/`<CloudFunction>` element names and `<Filter><S3Key><FilterRule><Name>prefix|suffix</Name>` confirmed against the API reference and the aws-sdk-go-v2 serializer (LambdaFunctionConfiguration serializes as `CloudFunctionConfiguration`/`CloudFunction` on the wire).
- CopyObject: `x-amz-tagging-directive` default `COPY`.

## Gates
`go build ./...`, `go test ./providers/aws/... ./server/aws/... ./services/...`, and root integration tests pass; golangci-lint clean on changed code. `docs/coverage` unchanged (no driver interface method set changed).