### PR TITLE
fix(azure-misc): Cosmos per-database isolation, EventGrid SystemTopics+Domains, NotificationHubs DebugSend/creds

### DIFF
--- a/docs/coverage/aws/sns.md
+++ b/docs/coverage/aws/sns.md
@@ -31,12 +31,15 @@ AzureNotificationHubs is the Azure-only Notification Hubs surface: namespace
 | `DeleteRegistration` |  |
 | `DeleteSASRule` |  |
 | `GetNamespaceMeta` |  |
+| `GetPnsCredentials` |  |
 | `GetRegistration` |  |
 | `GetSASRule` |  |
 | `ListRegistrations` |  |
 | `ListSASRules` |  |
 | `PutSASRule` |  |
+| `RegenerateSASKey` | RegenerateSASKey rotates the primary or secondary key of a rule (policyKey |
 | `SetNamespaceMeta` |  |
+| `SetPnsCredentials` | SetPnsCredentials stores a hub's Platform Notification Service credentials |
 
 ## Not in scope
 

--- a/docs/coverage/azure/notificationhubs.md
+++ b/docs/coverage/azure/notificationhubs.md
@@ -31,12 +31,15 @@ AzureNotificationHubs is the Azure-only Notification Hubs surface: namespace
 | `DeleteRegistration` |  |
 | `DeleteSASRule` |  |
 | `GetNamespaceMeta` |  |
+| `GetPnsCredentials` |  |
 | `GetRegistration` |  |
 | `GetSASRule` |  |
 | `ListRegistrations` |  |
 | `ListSASRules` |  |
 | `PutSASRule` |  |
+| `RegenerateSASKey` | RegenerateSASKey rotates the primary or secondary key of a rule (policyKey |
 | `SetNamespaceMeta` |  |
+| `SetPnsCredentials` | SetPnsCredentials stores a hub's Platform Notification Service credentials |
 
 ## Not in scope
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -7196,6 +7196,9 @@
             "name": "GetNamespaceMeta"
           },
           {
+            "name": "GetPnsCredentials"
+          },
+          {
             "name": "GetRegistration"
           },
           {
@@ -7211,7 +7214,15 @@
             "name": "PutSASRule"
           },
           {
+            "name": "RegenerateSASKey",
+            "doc": "RegenerateSASKey rotates the primary or secondary key of a rule (policyKey"
+          },
+          {
             "name": "SetNamespaceMeta"
+          },
+          {
+            "name": "SetPnsCredentials",
+            "doc": "SetPnsCredentials stores a hub's Platform Notification Service credentials"
           }
         ]
       }

--- a/docs/coverage/gcp/fcm.md
+++ b/docs/coverage/gcp/fcm.md
@@ -31,12 +31,15 @@ AzureNotificationHubs is the Azure-only Notification Hubs surface: namespace
 | `DeleteRegistration` |  |
 | `DeleteSASRule` |  |
 | `GetNamespaceMeta` |  |
+| `GetPnsCredentials` |  |
 | `GetRegistration` |  |
 | `GetSASRule` |  |
 | `ListRegistrations` |  |
 | `ListSASRules` |  |
 | `PutSASRule` |  |
+| `RegenerateSASKey` | RegenerateSASKey rotates the primary or secondary key of a rule (policyKey |
 | `SetNamespaceMeta` |  |
+| `SetPnsCredentials` | SetPnsCredentials stores a hub's Platform Notification Service credentials |
 
 ## Not in scope
 

--- a/providers/azure/notificationhubs/azure_extras.go
+++ b/providers/azure/notificationhubs/azure_extras.go
@@ -2,6 +2,7 @@ package notificationhubs
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"strings"
@@ -10,6 +11,9 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
 )
+
+// sasKeyBytes is the length of a freshly generated Shared Access key.
+const sasKeyBytes = 32
 
 // Compile-time check that Mock implements the Azure-only optional surface.
 var _ driver.AzureNotificationHubs = (*Mock)(nil)
@@ -123,6 +127,68 @@ func (m *Mock) DeleteSASRule(_ context.Context, resourceKey, ruleName string) er
 	}
 
 	return nil
+}
+
+// RegenerateSASKey rotates a rule's primary or secondary key to a fresh random
+// value and persists it, so subsequent GetSASRule / ListKeys reflect the change.
+func (m *Mock) RegenerateSASKey(
+	_ context.Context, resourceKey, ruleName, policyKey string,
+) (driver.AzureSASRule, error) {
+	key := sasRuleKey(resourceKey, ruleName)
+
+	rule, ok := m.sasRules.Get(key)
+	if !ok {
+		return driver.AzureSASRule{}, errors.Newf(errors.NotFound, "authorization rule %q not found", ruleName)
+	}
+
+	fresh, err := randomKey()
+	if err != nil {
+		return driver.AzureSASRule{}, err
+	}
+
+	switch policyKey {
+	case "PrimaryKey", "":
+		rule.PrimaryKey = fresh
+	case "SecondaryKey":
+		rule.SecondaryKey = fresh
+	default:
+		return driver.AzureSASRule{}, errors.Newf(errors.InvalidArgument,
+			"policyKey must be PrimaryKey or SecondaryKey, got %q", policyKey)
+	}
+
+	m.sasRules.Set(key, rule)
+
+	return rule, nil
+}
+
+// randomKey returns a fresh base64-encoded 256-bit Shared Access key.
+func randomKey() (string, error) {
+	buf := make([]byte, sasKeyBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", errors.Newf(errors.Internal, "generate key: %v", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(buf), nil
+}
+
+// --- PNS credentials ---
+
+// SetPnsCredentials stores a hub's raw PNS credential properties JSON.
+func (m *Mock) SetPnsCredentials(_ context.Context, hubKey, credentialsJSON string) error {
+	m.pnsCreds.Set(hubKey, credentialsJSON)
+
+	return nil
+}
+
+// GetPnsCredentials returns a hub's stored PNS credential properties JSON, or
+// the empty string when none were set.
+func (m *Mock) GetPnsCredentials(_ context.Context, hubKey string) (string, error) {
+	creds, ok := m.pnsCreds.Get(hubKey)
+	if !ok {
+		return "", nil
+	}
+
+	return creds, nil
 }
 
 // --- data-plane device registrations ---

--- a/providers/azure/notificationhubs/notificationhubs.go
+++ b/providers/azure/notificationhubs/notificationhubs.go
@@ -45,6 +45,7 @@ type Mock struct {
 	nsMeta        *memstore.Store[driver.AzureNamespaceMeta]
 	sasRules      *memstore.Store[driver.AzureSASRule]
 	registrations *memstore.Store[driver.AzureRegistration]
+	pnsCreds      *memstore.Store[string]
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -82,6 +83,7 @@ func New(opts *config.Options) *Mock {
 		nsMeta:        memstore.New[driver.AzureNamespaceMeta](),
 		sasRules:      memstore.New[driver.AzureSASRule](),
 		registrations: memstore.New[driver.AzureRegistration](),
+		pnsCreds:      memstore.New[string](),
 	}
 }
 

--- a/server/azure/cosmosdb/cosmos_lifecycle_test.go
+++ b/server/azure/cosmosdb/cosmos_lifecycle_test.go
@@ -4,7 +4,7 @@
 // in an httptest TLS server.
 //
 // The Cosmos HTTP surface (server/azure/cosmos/handler.go) covers: account
-// probe, virtual databases, container create/list/read/delete, document
+// probe, per-database isolation, container create/list/read/delete, document
 // create/list/read/replace/delete, and query (SQL WHERE / ORDER BY /
 // projection / aggregates evaluated).
 // TTL and the change feed are driver-level only (no HTTP endpoint), so those
@@ -87,7 +87,7 @@ func newCosmosEnv(t *testing.T, opts ...config.Option) *cosmosEnv {
 	return &cosmosEnv{provider: cloudP, client: client}
 }
 
-// container creates database db (virtual) and container name with partition
+// container creates database db and container name with partition
 // key path "/pk" and returns its client.
 func (e *cosmosEnv) container(ctx context.Context, t *testing.T, db, name string) *azcosmos.ContainerClient {
 	t.Helper()

--- a/server/azure/cosmosdb/cosmos_lifecycle_test.go
+++ b/server/azure/cosmosdb/cosmos_lifecycle_test.go
@@ -588,6 +588,11 @@ func TestCosmosTTL(t *testing.T) {
 	cc := env.container(ctx, t, "ttldb", "sessions")
 	drv := env.provider.CosmosDB
 
+	// The container lives in the "ttldb" database, so the wire handler backs it
+	// with a database-qualified driver table (see server/azure/cosmosdb qualify).
+	// Driver-level calls, which bypass the HTTP layer, address it by that name.
+	const drvTable = "ttldb/sessions"
+
 	// Two sessions expiring 5 minutes from the fake "now" (absolute epoch
 	// seconds). Distinct pk values because item identity is pk-only.
 	expires := start.Add(5 * time.Minute).Unix()
@@ -595,11 +600,11 @@ func TestCosmosTTL(t *testing.T) {
 	createDoc(ctx, t, cc, "s2", map[string]any{"id": "s2", "pk": "s2", "user": "bob", "expiresAt": expires})
 
 	// Enable TTL at the driver level and read the config back.
-	if err := drv.UpdateTTL(ctx, "sessions", dbdriver.TTLConfig{Enabled: true, AttributeName: "expiresAt"}); err != nil {
+	if err := drv.UpdateTTL(ctx, drvTable, dbdriver.TTLConfig{Enabled: true, AttributeName: "expiresAt"}); err != nil {
 		t.Fatalf("UpdateTTL: %v", err)
 	}
 
-	ttlCfg, err := drv.DescribeTTL(ctx, "sessions")
+	ttlCfg, err := drv.DescribeTTL(ctx, drvTable)
 	if err != nil {
 		t.Fatalf("DescribeTTL: %v", err)
 	}
@@ -623,7 +628,7 @@ func TestCosmosTTL(t *testing.T) {
 	// Documented quirk: BatchGetItems does NOT check TTL, so the expired s2
 	// (never point-read since expiry) is still returned by a batch get. The key
 	// carries the full (pk, id) identity the container uses.
-	batch, err := drv.BatchGetItems(ctx, "sessions", []map[string]any{{"pk": "s2", "id": "s2"}})
+	batch, err := drv.BatchGetItems(ctx, drvTable, []map[string]any{{"pk": "s2", "id": "s2"}})
 	if err != nil {
 		t.Fatalf("BatchGetItems: %v", err)
 	}
@@ -668,12 +673,17 @@ func TestCosmosChangeFeed(t *testing.T) {
 	cc := env.container(ctx, t, "feeddb", "chats")
 	drv := env.provider.CosmosDB
 
+	// The container is in the "feeddb" database; its flat driver-table name is
+	// database-qualified (see server/azure/cosmosdb qualify), and driver-level
+	// change-feed calls, which bypass the HTTP layer, address it by that name.
+	const drvTable = "feeddb/chats"
+
 	// Feed disabled → FailedPrecondition.
-	if _, err := drv.GetStreamRecords(ctx, "chats", 0, ""); !cerrors.IsFailedPrecondition(err) {
+	if _, err := drv.GetStreamRecords(ctx, drvTable, 0, ""); !cerrors.IsFailedPrecondition(err) {
 		t.Fatalf("GetStreamRecords before enable: err=%v want FailedPrecondition", err)
 	}
 
-	if err := drv.UpdateStreamConfig(ctx, "chats", dbdriver.StreamConfig{
+	if err := drv.UpdateStreamConfig(ctx, drvTable, dbdriver.StreamConfig{
 		Enabled:  true,
 		ViewType: "NEW_AND_OLD_IMAGES",
 	}); err != nil {
@@ -693,7 +703,7 @@ func TestCosmosChangeFeed(t *testing.T) {
 		t.Fatalf("DeleteItem: %v", err)
 	}
 
-	it, err := drv.GetStreamRecords(ctx, "chats", 0, "")
+	it, err := drv.GetStreamRecords(ctx, drvTable, 0, "")
 	if err != nil {
 		t.Fatalf("GetStreamRecords: %v", err)
 	}
@@ -747,7 +757,7 @@ func TestCosmosChangeFeed(t *testing.T) {
 	}
 
 	// Token-based resumption: first page of 2, then the remainder.
-	page1, err := drv.GetStreamRecords(ctx, "chats", 2, "")
+	page1, err := drv.GetStreamRecords(ctx, drvTable, 2, "")
 	if err != nil {
 		t.Fatalf("GetStreamRecords page1: %v", err)
 	}
@@ -756,7 +766,7 @@ func TestCosmosChangeFeed(t *testing.T) {
 		t.Fatalf("page1 records=%d next=%q want 2 records, token \"2\"", len(page1.Records), page1.NextToken)
 	}
 
-	page2, err := drv.GetStreamRecords(ctx, "chats", 2, page1.NextToken)
+	page2, err := drv.GetStreamRecords(ctx, drvTable, 2, page1.NextToken)
 	if err != nil {
 		t.Fatalf("GetStreamRecords page2: %v", err)
 	}

--- a/server/azure/cosmosdb/cosmos_test.go
+++ b/server/azure/cosmosdb/cosmos_test.go
@@ -48,7 +48,7 @@ func TestSDKCosmosRoundTrip(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Create database (virtual — handler always succeeds).
+	// Create database (tracked; addressable via the {db} path segment).
 	if _, err := client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: "appdb"}, nil); err != nil {
 		t.Fatalf("CreateDatabase: %v", err)
 	}

--- a/server/azure/cosmosdb/database_isolation_test.go
+++ b/server/azure/cosmosdb/database_isolation_test.go
@@ -1,0 +1,191 @@
+// Real-user tests for Cosmos DB per-database isolation: the {db} path segment
+// is honored, so a container name is scoped to its database. Two databases can
+// hold same-named containers with independent data, a container in one database
+// is unreachable through another, and deleting a database removes only its own
+// containers.
+package cosmosdb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+// makeContainer creates database db and container name (partition key "/pk")
+// through the SDK and returns its client.
+func makeContainer(ctx context.Context, t *testing.T, env *cosmosEnv, db, name string) *azcosmos.ContainerClient {
+	t.Helper()
+
+	if _, err := env.client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: db}, nil); err != nil {
+		t.Fatalf("CreateDatabase(%s): %v", db, err)
+	}
+
+	dbClient, err := env.client.NewDatabase(db)
+	if err != nil {
+		t.Fatalf("NewDatabase(%s): %v", db, err)
+	}
+
+	props := azcosmos.ContainerProperties{
+		ID:                     name,
+		PartitionKeyDefinition: azcosmos.PartitionKeyDefinition{Paths: []string{"/pk"}},
+	}
+	if _, err := dbClient.CreateContainer(ctx, props, nil); err != nil {
+		t.Fatalf("CreateContainer(%s/%s): %v", db, name, err)
+	}
+
+	cc, err := dbClient.NewContainer(name)
+	if err != nil {
+		t.Fatalf("NewContainer(%s/%s): %v", db, name, err)
+	}
+
+	return cc
+}
+
+// TestCosmosDatabaseIsolation proves that identically named containers in
+// different databases have independent contents: a document written to
+// appdb/orders is invisible through otherdb/orders, and each holds its own data.
+func TestCosmosDatabaseIsolation(t *testing.T) {
+	ctx := context.Background()
+	env := newCosmosEnv(t)
+
+	app := makeContainer(ctx, t, env, "appdb", "orders")
+	other := makeContainer(ctx, t, env, "otherdb", "orders")
+
+	createDoc(ctx, t, app, "cust-1", map[string]any{"id": "o1", "pk": "cust-1", "who": "app"})
+	createDoc(ctx, t, other, "cust-1", map[string]any{"id": "o1", "pk": "cust-1", "who": "other"})
+
+	// Same (pk, id) in each database, but the values are independent.
+	if got := readDoc(ctx, t, app, "cust-1", "o1"); got["who"] != "app" {
+		t.Errorf("appdb/orders o1 who=%v want app", got["who"])
+	}
+
+	if got := readDoc(ctx, t, other, "cust-1", "o1"); got["who"] != "other" {
+		t.Errorf("otherdb/orders o1 who=%v want other", got["who"])
+	}
+
+	// A document that exists only in appdb is unreachable through otherdb.
+	createDoc(ctx, t, app, "cust-2", map[string]any{"id": "app-only", "pk": "cust-2"})
+
+	_, err := other.ReadItem(ctx, azcosmos.NewPartitionKeyString("cust-2"), "app-only", nil)
+	wantRespErr(t, err, 404, "cross-database read of app-only doc")
+}
+
+// TestCosmosContainerNamespacedByDatabase asserts a container created in one
+// database is not reachable as a container of another: operations through the
+// wrong database's container client 404.
+func TestCosmosContainerNamespacedByDatabase(t *testing.T) {
+	ctx := context.Background()
+	env := newCosmosEnv(t)
+
+	_ = makeContainer(ctx, t, env, "dbA", "widgets")
+
+	// dbB exists but has no "widgets" container.
+	if _, err := env.client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: "dbB"}, nil); err != nil {
+		t.Fatalf("CreateDatabase(dbB): %v", err)
+	}
+
+	dbB, err := env.client.NewDatabase("dbB")
+	if err != nil {
+		t.Fatalf("NewDatabase(dbB): %v", err)
+	}
+
+	widgetsB, err := dbB.NewContainer("widgets")
+	if err != nil {
+		t.Fatalf("NewContainer(dbB/widgets): %v", err)
+	}
+
+	// Reading dbB/widgets (which was never created) 404s even though dbA/widgets
+	// exists.
+	_, err = widgetsB.Read(ctx, nil)
+	wantRespErr(t, err, 404, "read of container in wrong database")
+
+	pk := azcosmos.NewPartitionKeyString("p1")
+
+	_, err = widgetsB.ReadItem(ctx, pk, "any", nil)
+	wantRespErr(t, err, 404, "read item in wrong database's container")
+}
+
+// TestCosmosDeleteDatabaseRemovesContainers asserts DeleteDatabase drops the
+// database's containers while leaving another database's identically named
+// container intact.
+func TestCosmosDeleteDatabaseRemovesContainers(t *testing.T) {
+	ctx := context.Background()
+	env := newCosmosEnv(t)
+
+	victim := makeContainer(ctx, t, env, "tmpdb", "events")
+	keep := makeContainer(ctx, t, env, "keepdb", "events")
+
+	createDoc(ctx, t, victim, "p", map[string]any{"id": "e1", "pk": "p", "in": "tmpdb"})
+	createDoc(ctx, t, keep, "p", map[string]any{"id": "e1", "pk": "p", "in": "keepdb"})
+
+	// Delete the whole tmpdb database.
+	tmp, err := env.client.NewDatabase("tmpdb")
+	if err != nil {
+		t.Fatalf("NewDatabase(tmpdb): %v", err)
+	}
+
+	if _, err := tmp.Delete(ctx, nil); err != nil {
+		t.Fatalf("DeleteDatabase(tmpdb): %v", err)
+	}
+
+	// Its container's documents are gone: reading through it 404s.
+	_, err = victim.ReadItem(ctx, azcosmos.NewPartitionKeyString("p"), "e1", nil)
+	wantRespErr(t, err, 404, "read from deleted database's container")
+
+	// Re-reading the database itself 404s.
+	_, err = tmp.Read(ctx, nil)
+	wantRespErr(t, err, 404, "read of deleted database")
+
+	// keepdb/events is untouched.
+	if got := readDoc(ctx, t, keep, "p", "e1"); got["in"] != "keepdb" {
+		t.Errorf("keepdb/events e1 in=%v want keepdb (unaffected by tmpdb delete)", got["in"])
+	}
+}
+
+// TestCosmosDuplicateDatabaseCreate asserts creating a database that already
+// exists is a 409 Conflict, matching real Cosmos.
+func TestCosmosDuplicateDatabaseCreate(t *testing.T) {
+	ctx := context.Background()
+	env := newCosmosEnv(t)
+
+	if _, err := env.client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: "dupdb"}, nil); err != nil {
+		t.Fatalf("first CreateDatabase: %v", err)
+	}
+
+	_, err := env.client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: "dupdb"}, nil)
+	wantRespErr(t, err, 409, "duplicate CreateDatabase")
+}
+
+// TestCosmosListDatabases asserts the databases the SDK created are the ones
+// listed back through the query pager.
+func TestCosmosListDatabases(t *testing.T) {
+	ctx := context.Background()
+	env := newCosmosEnv(t)
+
+	for _, id := range []string{"alpha", "beta", "gamma"} {
+		if _, err := env.client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: id}, nil); err != nil {
+			t.Fatalf("CreateDatabase(%s): %v", id, err)
+		}
+	}
+
+	pager := env.client.NewQueryDatabasesPager("SELECT * FROM root", nil)
+	seen := map[string]bool{}
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		for _, d := range page.Databases {
+			seen[d.ID] = true
+		}
+	}
+
+	for _, id := range []string{"alpha", "beta", "gamma"} {
+		if !seen[id] {
+			t.Errorf("database %q missing from list (got %v)", id, seen)
+		}
+	}
+}

--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -51,11 +52,40 @@ type Handler struct {
 	// concept with no generic driver method, so the wire handler tracks it.
 	offerMu sync.RWMutex
 	offers  map[string]offerState
+
+	// databases tracks the Cosmos databases that exist. The generic driver has a
+	// flat table namespace with no database grouping, so the wire handler models
+	// the database layer: it records which databases were created and qualifies
+	// every container's driver-table name by its database (see qualify), giving
+	// each database an isolated container namespace.
+	dbMu      sync.RWMutex
+	databases map[string]struct{}
 }
 
 // New returns a Cosmos handler backed by db.
 func New(db dbdriver.Database) *Handler {
-	return &Handler{db: db, offers: make(map[string]offerState)}
+	return &Handler{
+		db:        db,
+		offers:    make(map[string]offerState),
+		databases: make(map[string]struct{}),
+	}
+}
+
+// qualify maps a (database, container) pair onto the flat driver table name that
+// backs it. Cosmos container ids cannot contain '/', so "{db}/{coll}" is an
+// unambiguous, collision-free key: a container in one database is unreachable
+// through another, and deleting a database can find its containers by prefix.
+func qualify(db, coll string) string {
+	return db + "/" + coll
+}
+
+// databaseExists reports whether database db has been created.
+func (h *Handler) databaseExists(db string) bool {
+	h.dbMu.RLock()
+	_, ok := h.databases[db]
+	h.dbMu.RUnlock()
+
+	return ok
 }
 
 // Matches returns true for the Cosmos data plane URLs we serve: the account
@@ -159,46 +189,127 @@ func (*Handler) accountProperties(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, props)
 }
 
-const defaultDBName = "cloudemu"
-
-func (*Handler) databaseCollection(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) databaseCollection(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPost:
-		var body struct {
-			ID string `json:"id"`
-		}
+		// Cosmos overloads POST /dbs: a create (JSON body with an id) or, when the
+		// isquery flag is set, a query the SDK's database pager fires. Drain the
+		// query body but ignore its predicate — we list all databases.
+		if isQuery(r) {
+			_, _ = decodeQueryBody(w, r)
+			h.writeDatabaseList(w)
 
-		if !decodeJSON(w, r, &body) {
 			return
 		}
 
-		// We pretend any database creation succeeds. Items live under tables;
-		// the Cosmos database layer is virtual.
-		writeJSON(w, http.StatusCreated, makeDatabaseResource(body.ID))
+		h.createDatabase(w, r)
 	case http.MethodGet:
-		writeJSON(w, http.StatusOK, databasesList{
-			RID: "cloudemu",
-			Databases: []databaseResource{
-				makeDatabaseResource(defaultDBName),
-			},
-			Count: 1,
-		})
+		h.writeDatabaseList(w)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
 }
 
-func (*Handler) databaseResource(w http.ResponseWriter, r *http.Request, db string) {
+func (h *Handler) createDatabase(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ID string `json:"id"`
+	}
+
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	if body.ID == "" {
+		writeError(w, http.StatusBadRequest, "BadRequest", "database id required")
+		return
+	}
+
+	h.dbMu.Lock()
+	if _, exists := h.databases[body.ID]; exists {
+		h.dbMu.Unlock()
+		writeError(w, http.StatusConflict, "Conflict",
+			"Database with specified id already exists.")
+
+		return
+	}
+
+	h.databases[body.ID] = struct{}{}
+	h.dbMu.Unlock()
+
+	writeJSON(w, http.StatusCreated, makeDatabaseResource(body.ID))
+}
+
+func (h *Handler) writeDatabaseList(w http.ResponseWriter) {
+	h.dbMu.RLock()
+	names := make([]string, 0, len(h.databases))
+
+	for name := range h.databases {
+		names = append(names, name)
+	}
+
+	h.dbMu.RUnlock()
+	sort.Strings(names)
+
+	list := databasesList{RID: "cloudemu", Databases: make([]databaseResource, 0, len(names))}
+	for _, name := range names {
+		list.Databases = append(list.Databases, makeDatabaseResource(name))
+	}
+
+	list.Count = len(list.Databases)
+	writeJSON(w, http.StatusOK, list)
+}
+
+func (h *Handler) databaseResource(w http.ResponseWriter, r *http.Request, db string) {
 	switch r.Method {
 	case http.MethodGet:
+		if !h.databaseExists(db) {
+			writeError(w, http.StatusNotFound, "NotFound", "database not found")
+			return
+		}
+
 		writeJSON(w, http.StatusOK, makeDatabaseResource(db))
 	case http.MethodDelete:
-		// No-op; the virtual database can't actually be deleted because
-		// tables underneath still belong to the driver.
-		w.WriteHeader(http.StatusNoContent)
+		h.deleteDatabase(w, r, db)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
+}
+
+// deleteDatabase removes a database and every container inside it. Because the
+// driver namespace is flat and keyed by qualify(db, coll), the database's
+// containers are exactly the tables whose name starts with "{db}/".
+func (h *Handler) deleteDatabase(w http.ResponseWriter, r *http.Request, db string) {
+	if !h.databaseExists(db) {
+		writeError(w, http.StatusNotFound, "NotFound", "database not found")
+		return
+	}
+
+	tables, err := h.db.ListTables(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	prefix := db + "/"
+
+	for _, t := range tables {
+		if !strings.HasPrefix(t, prefix) {
+			continue
+		}
+
+		if derr := h.db.DeleteTable(r.Context(), t); derr != nil {
+			writeErr(w, derr)
+			return
+		}
+
+		h.deleteOffer(t)
+	}
+
+	h.dbMu.Lock()
+	delete(h.databases, db)
+	h.dbMu.Unlock()
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) containerCollection(w http.ResponseWriter, r *http.Request, db string) {
@@ -213,6 +324,11 @@ func (h *Handler) containerCollection(w http.ResponseWriter, r *http.Request, db
 }
 
 func (h *Handler) createContainer(w http.ResponseWriter, r *http.Request, db string) {
+	if !h.databaseExists(db) {
+		writeError(w, http.StatusNotFound, "NotFound", "database not found")
+		return
+	}
+
 	var body containerResource
 
 	if !decodeJSON(w, r, &body) {
@@ -227,7 +343,7 @@ func (h *Handler) createContainer(w http.ResponseWriter, r *http.Request, db str
 	pkAttr := partitionKeyAttribute(body.PartitionKey)
 
 	cfg := dbdriver.TableConfig{
-		Name:         body.ID,
+		Name:         qualify(db, body.ID),
 		PartitionKey: pkAttr,
 	}
 
@@ -244,12 +360,17 @@ func (h *Handler) createContainer(w http.ResponseWriter, r *http.Request, db str
 		return
 	}
 
-	h.recordOffer(body.ID, r)
+	h.recordOffer(qualify(db, body.ID), r)
 
 	writeJSON(w, http.StatusCreated, makeContainerResource(db, body.ID, body.PartitionKey))
 }
 
 func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request, db string) {
+	if !h.databaseExists(db) {
+		writeError(w, http.StatusNotFound, "NotFound", "database not found")
+		return
+	}
+
 	tables, err := h.db.ListTables(r.Context())
 	if err != nil {
 		writeErr(w, err)
@@ -257,8 +378,15 @@ func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request, db stri
 	}
 
 	out := containersList{RID: "cloudemu"}
+	prefix := db + "/"
 
 	for _, t := range tables {
+		if !strings.HasPrefix(t, prefix) {
+			continue
+		}
+
+		coll := strings.TrimPrefix(t, prefix)
+
 		cfg, derr := h.db.DescribeTable(r.Context(), t)
 		pk := defaultPartitionKey()
 
@@ -267,7 +395,7 @@ func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request, db stri
 		}
 
 		out.DocumentCollections = append(out.DocumentCollections,
-			makeContainerResource(db, t, pk))
+			makeContainerResource(db, coll, pk))
 	}
 
 	out.Count = len(out.DocumentCollections)
@@ -276,9 +404,11 @@ func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request, db stri
 }
 
 func (h *Handler) containerResource(w http.ResponseWriter, r *http.Request, db, coll string) {
+	table := qualify(db, coll)
+
 	switch r.Method {
 	case http.MethodGet:
-		cfg, err := h.db.DescribeTable(r.Context(), coll)
+		cfg, err := h.db.DescribeTable(r.Context(), table)
 		if err != nil {
 			writeErr(w, err)
 			return
@@ -291,12 +421,12 @@ func (h *Handler) containerResource(w http.ResponseWriter, r *http.Request, db, 
 
 		writeJSON(w, http.StatusOK, makeContainerResource(db, coll, pk))
 	case http.MethodDelete:
-		if err := h.db.DeleteTable(r.Context(), coll); err != nil {
+		if err := h.db.DeleteTable(r.Context(), table); err != nil {
 			writeErr(w, err)
 			return
 		}
 
-		h.deleteOffer(coll)
+		h.deleteOffer(table)
 		w.WriteHeader(http.StatusNoContent)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
@@ -304,24 +434,26 @@ func (h *Handler) containerResource(w http.ResponseWriter, r *http.Request, db, 
 }
 
 func (h *Handler) documentCollection(w http.ResponseWriter, r *http.Request, db, coll string) {
+	table := qualify(db, coll)
+
 	switch r.Method {
 	case http.MethodPost:
 		// Cosmos overloads POST /docs for both create and query depending on
 		// the x-ms-documentdb-isquery header.
 		if isQuery(r) {
-			h.queryDocuments(w, r, coll)
+			h.queryDocuments(w, r, table)
 			return
 		}
 
-		h.createDocument(w, r, db, coll)
+		h.createDocument(w, r, table)
 	case http.MethodGet:
-		h.listDocuments(w, r, coll)
+		h.listDocuments(w, r, table)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
 }
 
-func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, _, coll string) {
+func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, coll string) {
 	item, ok := decodeAnyJSON(w, r)
 	if !ok {
 		return
@@ -374,6 +506,7 @@ func (h *Handler) listDocuments(w http.ResponseWriter, r *http.Request, coll str
 	// Same paging contract as the query path: x-ms-max-item-count is the
 	// page size, x-ms-continuation round-trips the driver page token.
 	limit := 100
+
 	if v := r.Header.Get("X-Ms-Max-Item-Count"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			limit = n
@@ -444,7 +577,9 @@ func (h *Handler) queryDocuments(w http.ResponseWriter, r *http.Request, coll st
 	writeJSON(w, http.StatusOK, documentsList{RID: "cloudemu", Documents: page, Count: len(page)})
 }
 
-func (h *Handler) documentResource(w http.ResponseWriter, r *http.Request, _, coll, id string) {
+func (h *Handler) documentResource(w http.ResponseWriter, r *http.Request, db, coll, id string) {
+	coll = qualify(db, coll)
+
 	cfg, derr := h.db.DescribeTable(r.Context(), coll)
 	if derr != nil {
 		writeErr(w, derr)
@@ -581,8 +716,11 @@ func makeDatabaseResource(id string) databaseResource {
 	}
 }
 
-func makeContainerResource(_, id string, pk *partitionKeyDef) containerResource {
-	rid := "rid-" + id
+func makeContainerResource(db, id string, pk *partitionKeyDef) containerResource {
+	// The container's _rid doubles as its offer resource id: the SDK reads _rid
+	// off the container, then queries /offers by it. Qualifying by database keeps
+	// the offer key unique across databases (see recordOffer / qualify).
+	rid := containerRID(qualify(db, id))
 
 	if pk == nil {
 		pk = defaultPartitionKey()

--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -11,9 +11,13 @@
 //	            GET .../docs, GET .../docs/{id}
 //	            PUT .../docs/{id}, DELETE .../docs/{id}
 //
-// The driver doesn't model Cosmos's database-level grouping, so we expose a
-// single virtual database "cloudemu" that always exists and contains every
-// driver table as a container.
+// The generic driver has a flat table namespace with no database-level
+// grouping, so the handler models the database layer itself: it tracks which
+// databases were created (listable and individually addressable via the {db}
+// path segment) and qualifies every container's driver-table name by its
+// database, giving each database an isolated container namespace. A container
+// in one database is therefore unreachable through another, and deleting a
+// database removes the containers it owns.
 package cosmosdb
 
 import (

--- a/server/azure/eventgrid/domains.go
+++ b/server/azure/eventgrid/domains.go
@@ -1,0 +1,289 @@
+package eventgrid
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+const (
+	domainResourceType        = "Microsoft.EventGrid/domains"
+	domainProvisioningState   = "Succeeded"
+	domainDefaultInputSchema  = "EventGridSchema"
+	domainDefaultNetworkAcces = "Enabled"
+	subActionListKeys         = "listKeys"
+	subActionRegenerateKey    = "regenerateKey"
+)
+
+// domainRecord is the wire-handler-owned state for one Event Grid domain. A
+// domain groups topics under a single publishing endpoint and owns two shared
+// access keys that RegenerateKey rotates; none of that maps onto the generic
+// eventbus driver, so the wire handler holds it (mirroring the Cosmos /offers
+// precedent).
+type domainRecord struct {
+	name     string
+	location string
+	sub      string
+	rg       string
+	tags     map[string]string
+	key1     string
+	key2     string
+}
+
+type domainJSON struct {
+	ID         string             `json:"id,omitempty"`
+	Name       string             `json:"name"`
+	Type       string             `json:"type"`
+	Location   string             `json:"location"`
+	Tags       map[string]*string `json:"tags,omitempty"`
+	Properties *domainProperties  `json:"properties,omitempty"`
+}
+
+type domainProperties struct {
+	Endpoint            string `json:"endpoint,omitempty"`
+	MetricResourceID    string `json:"metricResourceId,omitempty"`
+	ProvisioningState   string `json:"provisioningState,omitempty"`
+	InputSchema         string `json:"inputSchema,omitempty"`
+	PublicNetworkAccess string `json:"publicNetworkAccess,omitempty"`
+}
+
+type domainListResult struct {
+	Value []domainJSON `json:"value"`
+}
+
+// domainSharedAccessKeys is the ListSharedAccessKeys / RegenerateKey response
+// (armeventgrid.DomainSharedAccessKeys).
+type domainSharedAccessKeys struct {
+	Key1 string `json:"key1"`
+	Key2 string `json:"key2"`
+}
+
+type domainRegenerateKeyRequest struct {
+	KeyName string `json:"keyName"`
+}
+
+// domainKey derives a deterministic shared access key. gen bumps on each
+// regeneration so a rotated key differs from its predecessor.
+func domainKey(name, which string, gen int) string {
+	sum := sha256.Sum256([]byte("eventgrid-domain\x00" + name + "\x00" + which + "\x00" + strconv.Itoa(gen)))
+	return base64.StdEncoding.EncodeToString(sum[:])
+}
+
+func domainID(rp *azurearm.ResourcePath) string {
+	return azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeDomains, rp.ResourceName)
+}
+
+func (rec *domainRecord) toJSON(rp *azurearm.ResourcePath) domainJSON {
+	id := domainID(rp)
+
+	return domainJSON{
+		ID:       id,
+		Name:     rec.name,
+		Type:     domainResourceType,
+		Location: rec.location,
+		Tags:     tagsToPtr(rec.tags),
+		Properties: &domainProperties{
+			Endpoint:            topicEndpoint(rec.name, rec.location),
+			MetricResourceID:    id,
+			ProvisioningState:   domainProvisioningState,
+			InputSchema:         domainDefaultInputSchema,
+			PublicNetworkAccess: domainDefaultNetworkAcces,
+		},
+	}
+}
+
+// serveDomains routes .../domains[/{name}[/{listKeys|regenerateKey}]].
+func (h *Handler) serveDomains(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if rp.ResourceName == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w)
+			return
+		}
+
+		h.listDomains(w, rp)
+
+		return
+	}
+
+	switch rp.SubResource {
+	case "":
+		h.serveDomainResource(w, r, rp)
+	case subActionListKeys:
+		h.listDomainKeys(w, r, rp)
+	case subActionRegenerateKey:
+		h.regenerateDomainKey(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "unsupported domain sub-resource")
+	}
+}
+
+func (h *Handler) serveDomainResource(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdateDomain(w, r, rp)
+	case http.MethodGet:
+		h.getDomain(w, rp)
+	case http.MethodDelete:
+		h.deleteDomain(w, rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createOrUpdateDomain(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body domainJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	loc := body.Location
+	if loc == "" {
+		loc = defaultSystemTopicLocation
+	}
+
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.Lock()
+
+	rec := h.domains[key]
+	if rec == nil {
+		rec = &domainRecord{
+			name: rp.ResourceName,
+			sub:  rp.Subscription,
+			rg:   rp.ResourceGroup,
+			key1: domainKey(rp.ResourceName, "key1", 0),
+			key2: domainKey(rp.ResourceName, "key2", 0),
+		}
+		h.domains[key] = rec
+	}
+
+	rec.location = loc
+	rec.tags = tagsFromPtr(body.Tags)
+
+	out := rec.toJSON(rp)
+	h.mu.Unlock()
+
+	// Domains.CreateOrUpdate accepts only 201; the terminal provisioningState
+	// completes the SDK's LRO poller on the first response.
+	azurearm.WriteJSON(w, http.StatusCreated, out)
+}
+
+func (h *Handler) getDomain(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.RLock()
+	rec := h.domains[key]
+
+	if rec == nil {
+		h.mu.RUnlock()
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "domain not found")
+
+		return
+	}
+
+	out := rec.toJSON(rp)
+	h.mu.RUnlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) deleteDomain(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.Lock()
+	_, found := h.domains[key]
+	delete(h.domains, key)
+	h.mu.Unlock()
+
+	if !found {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) listDomains(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	h.mu.RLock()
+	recs := recordsInScope(h.domains, rp.Subscription, rp.ResourceGroup)
+	out := scopedList(recs, rp, (*domainRecord).toJSON)
+	h.mu.RUnlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, domainListResult{Value: out})
+}
+
+func (h *Handler) listDomainKeys(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.RLock()
+	rec := h.domains[key]
+
+	if rec == nil {
+		h.mu.RUnlock()
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "domain not found")
+
+		return
+	}
+
+	keys := domainSharedAccessKeys{Key1: rec.key1, Key2: rec.key2}
+	h.mu.RUnlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, keys)
+}
+
+func (h *Handler) regenerateDomainKey(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	var body domainRegenerateKeyRequest
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.Lock()
+
+	rec := h.domains[key]
+	if rec == nil {
+		h.mu.Unlock()
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "domain not found")
+
+		return
+	}
+
+	switch body.KeyName {
+	case "key1":
+		rec.key1 = domainKey(rec.name, "key1", nextKeyGen(rec.key1))
+	case "key2":
+		rec.key2 = domainKey(rec.name, "key2", nextKeyGen(rec.key2))
+	default:
+		h.mu.Unlock()
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "keyName must be key1 or key2")
+
+		return
+	}
+
+	keys := domainSharedAccessKeys{Key1: rec.key1, Key2: rec.key2}
+	h.mu.Unlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, keys)
+}
+
+// nextKeyGen produces a fresh generation counter for a rotated key. The prior
+// key's bytes seed it so consecutive regenerations keep yielding new values.
+func nextKeyGen(prev string) int {
+	sum := sha256.Sum256([]byte(prev))
+	// Fold a few bytes into a positive int; the exact value only needs to change.
+	return int(sum[0])<<16 | int(sum[1])<<8 | int(sum[2]) | 1
+}

--- a/server/azure/eventgrid/domains_sdk_test.go
+++ b/server/azure/eventgrid/domains_sdk_test.go
@@ -1,0 +1,120 @@
+package eventgrid_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+)
+
+// TestSDKDomainLifecycle drives the DomainsClient: CreateOrUpdate → Get →
+// ListSharedAccessKeys → RegenerateKey (key rotates) → list → Delete.
+func TestSDKDomainLifecycle(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	dc := cf.NewDomainsClient()
+	ctx := context.Background()
+
+	poller, err := dc.BeginCreateOrUpdate(ctx, testRG, "events-domain", armeventgrid.Domain{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"team": to.Ptr("data")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Domains.BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("Domains create PollUntilDone: %v", err)
+	}
+
+	if created.Properties == nil || created.Properties.Endpoint == nil || *created.Properties.Endpoint == "" {
+		t.Fatalf("domain endpoint missing: %+v", created.Properties)
+	}
+
+	got, err := dc.Get(ctx, testRG, "events-domain", nil)
+	if err != nil {
+		t.Fatalf("Domains.Get: %v", err)
+	}
+
+	if got.Tags["team"] == nil || *got.Tags["team"] != "data" {
+		t.Fatalf("tags round-trip failed: %+v", got.Tags)
+	}
+
+	// Keys are present and stable across reads.
+	keys1, err := dc.ListSharedAccessKeys(ctx, testRG, "events-domain", nil)
+	if err != nil {
+		t.Fatalf("ListSharedAccessKeys: %v", err)
+	}
+
+	if keys1.Key1 == nil || keys1.Key2 == nil || *keys1.Key1 == "" || *keys1.Key2 == "" {
+		t.Fatalf("shared access keys empty: %+v", keys1)
+	}
+
+	keys1b, err := dc.ListSharedAccessKeys(ctx, testRG, "events-domain", nil)
+	if err != nil {
+		t.Fatalf("ListSharedAccessKeys second: %v", err)
+	}
+
+	if *keys1b.Key1 != *keys1.Key1 {
+		t.Fatalf("key1 changed between reads: %q vs %q", *keys1b.Key1, *keys1.Key1)
+	}
+
+	// Regenerate key1: it must change, key2 must not.
+	regen, err := dc.RegenerateKey(ctx, testRG, "events-domain", armeventgrid.DomainRegenerateKeyRequest{
+		KeyName: to.Ptr("key1"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("RegenerateKey: %v", err)
+	}
+
+	if *regen.Key1 == *keys1.Key1 {
+		t.Fatalf("key1 did not change after regenerate: %q", *regen.Key1)
+	}
+
+	if *regen.Key2 != *keys1.Key2 {
+		t.Fatalf("key2 changed on key1 regenerate: %q vs %q", *regen.Key2, *keys1.Key2)
+	}
+
+	// List by subscription includes the domain.
+	var names []string
+
+	pager := dc.NewListBySubscriptionPager(nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("ListBySubscription: %v", perr)
+		}
+
+		for _, d := range page.Value {
+			names = append(names, *d.Name)
+		}
+	}
+
+	if len(names) != 1 || names[0] != "events-domain" {
+		t.Fatalf("ListBySubscription = %v, want [events-domain]", names)
+	}
+
+	delPoller, err := dc.BeginDelete(ctx, testRG, "events-domain", nil)
+	if err != nil {
+		t.Fatalf("Domains.BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Domains delete PollUntilDone: %v", err)
+	}
+
+	if _, err := dc.Get(ctx, testRG, "events-domain", nil); err == nil {
+		t.Fatal("Get after delete: expected error, got nil")
+	}
+}
+
+// TestSDKDomainGetMissing asserts a Get on an absent domain 404s.
+func TestSDKDomainGetMissing(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	dc := cf.NewDomainsClient()
+
+	if _, err := dc.Get(context.Background(), testRG, "ghost", nil); err == nil {
+		t.Fatal("Get missing domain: expected error, got nil")
+	}
+}

--- a/server/azure/eventgrid/handler.go
+++ b/server/azure/eventgrid/handler.go
@@ -24,37 +24,61 @@ package eventgrid
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 )
 
 const (
-	providerName = "Microsoft.EventGrid"
-	typeTopics   = "topics"
+	providerName     = "Microsoft.EventGrid"
+	typeTopics       = "topics"
+	typeSystemTopics = "systemTopics"
+	typeDomains      = "domains"
 )
 
-// Handler serves Microsoft.EventGrid/topics ARM requests against an eventbus
-// driver.
+// Handler serves Microsoft.EventGrid ARM requests. Topics (and their event
+// subscriptions) are backed by the eventbus driver. System topics and domains
+// are Event-Grid-only ARM resources with no generic driver equivalent (a system
+// topic wraps an external Azure event source; a domain groups topics and holds
+// its own access keys), so — mirroring the Cosmos /offers precedent in this
+// codebase — the wire handler owns their state in memory.
 type Handler struct {
 	bus ebdriver.EventBus
+
+	mu           sync.RWMutex
+	systemTopics map[string]*systemTopicRecord
+	domains      map[string]*domainRecord
 }
 
 // New returns an Azure Event Grid handler backed by b.
 func New(b ebdriver.EventBus) *Handler {
-	return &Handler{bus: b}
+	return &Handler{
+		bus:          b,
+		systemTopics: make(map[string]*systemTopicRecord),
+		domains:      make(map[string]*domainRecord),
+	}
 }
 
-// Matches claims ARM URLs targeting Microsoft.EventGrid/topics. Disjoint from
-// every other Azure ARM provider, so registration order is unconstrained.
-// Registered before the BlobStorage fallback.
+// Matches claims ARM URLs targeting Microsoft.EventGrid topics, systemTopics,
+// and domains. Disjoint from every other Azure ARM provider, so registration
+// order is unconstrained. Registered before the BlobStorage fallback.
 func (*Handler) Matches(r *http.Request) bool {
 	rp, ok := azurearm.ParsePath(r.URL.Path)
 	if !ok {
 		return false
 	}
 
-	return rp.Provider == providerName && rp.ResourceType == typeTopics
+	if rp.Provider != providerName {
+		return false
+	}
+
+	switch rp.ResourceType {
+	case typeTopics, typeSystemTopics, typeDomains:
+		return true
+	default:
+		return false
+	}
 }
 
 // ServeHTTP routes on the parsed path shape and method.
@@ -62,6 +86,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rp, ok := azurearm.ParsePath(r.URL.Path)
 	if !ok {
 		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	switch rp.ResourceType {
+	case typeSystemTopics:
+		h.serveSystemTopics(w, r, &rp)
+		return
+	case typeDomains:
+		h.serveDomains(w, r, &rp)
 		return
 	}
 

--- a/server/azure/eventgrid/resource_scope.go
+++ b/server/azure/eventgrid/resource_scope.go
@@ -1,0 +1,63 @@
+package eventgrid
+
+import (
+	"sort"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+// scopedRecord is a wire-handler-owned resource that knows its ARM scope, so a
+// list operation can filter a store by subscription (and optionally resource
+// group) and order the results deterministically.
+type scopedRecord interface {
+	scopeKey() (sub, rg, name string)
+}
+
+func (rec *systemTopicRecord) scopeKey() (sub, rg, name string) { return rec.sub, rec.rg, rec.name }
+func (rec *domainRecord) scopeKey() (sub, rg, name string)      { return rec.sub, rec.rg, rec.name }
+
+// scopedList converts each record to its ARM element, giving conv a ResourcePath
+// re-scoped to that record's own resource group and name so ids and elements are
+// built for the right resource even in a subscription-wide list.
+func scopedList[T scopedRecord, J any](recs []T, rp *azurearm.ResourcePath, conv func(T, *azurearm.ResourcePath) J) []J {
+	out := make([]J, 0, len(recs))
+
+	for _, rec := range recs {
+		_, rg, name := rec.scopeKey()
+		scoped := *rp
+		scoped.ResourceGroup = rg
+		scoped.ResourceName = name
+		out = append(out, conv(rec, &scoped))
+	}
+
+	return out
+}
+
+// recordsInScope returns the records in m that belong to subscription sub,
+// filtered to resource group rg when rg is non-empty (an RG-scoped list), sorted
+// by name.
+func recordsInScope[T scopedRecord](m map[string]T, sub, rg string) []T {
+	out := make([]T, 0, len(m))
+
+	for _, rec := range m {
+		recSub, recRG, _ := rec.scopeKey()
+		if recSub != sub {
+			continue
+		}
+
+		if rg != "" && recRG != rg {
+			continue
+		}
+
+		out = append(out, rec)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		_, _, ni := out[i].scopeKey()
+		_, _, nj := out[j].scopeKey()
+
+		return ni < nj
+	})
+
+	return out
+}

--- a/server/azure/eventgrid/system_topic_subscriptions.go
+++ b/server/azure/eventgrid/system_topic_subscriptions.go
@@ -1,0 +1,150 @@
+package eventgrid
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+// serveSystemTopicSubscription routes
+// .../systemTopics/{t}/eventSubscriptions[/{name}].
+func (h *Handler) serveSystemTopicSubscription(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if rp.SubResourceName == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w)
+			return
+		}
+
+		h.listSystemTopicSubscriptions(w, rp)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdateSystemTopicSubscription(w, r, rp)
+	case http.MethodGet:
+		h.getSystemTopicSubscription(w, rp)
+	case http.MethodDelete:
+		h.deleteSystemTopicSubscription(w, rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+// systemTopicSubscriptionJSON builds the ARM EventSubscription element for a
+// subscription stored under a system topic, stamping the read-only topic id and
+// provisioning state onto the round-tripped properties.
+func systemTopicSubscriptionJSON(rp *azurearm.ResourcePath, props json.RawMessage) eventSubscriptionJSON {
+	id := systemTopicID(rp) + "/" + subEventSubscriptions + "/" + rp.SubResourceName
+
+	return eventSubscriptionJSON{
+		ID:         id,
+		Name:       rp.SubResourceName,
+		Type:       systemTopicSubscriptionType,
+		Properties: enrichSubscriptionProperties(props, systemTopicID(rp)),
+	}
+}
+
+func (h *Handler) createOrUpdateSystemTopicSubscription(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body struct {
+		Properties json.RawMessage `json:"properties"`
+	}
+
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.Lock()
+
+	rec := h.systemTopics[key]
+	if rec == nil {
+		h.mu.Unlock()
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "system topic not found")
+
+		return
+	}
+
+	rec.subscriptions[rp.SubResourceName] = body.Properties
+	out := systemTopicSubscriptionJSON(rp, body.Properties)
+	h.mu.Unlock()
+
+	azurearm.WriteJSON(w, http.StatusCreated, out)
+}
+
+func (h *Handler) getSystemTopicSubscription(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.RLock()
+
+	rec := h.systemTopics[key]
+	if rec == nil {
+		h.mu.RUnlock()
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "system topic not found")
+
+		return
+	}
+
+	props, found := rec.subscriptions[rp.SubResourceName]
+	h.mu.RUnlock()
+
+	if !found {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "event subscription not found")
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, systemTopicSubscriptionJSON(rp, props))
+}
+
+func (h *Handler) deleteSystemTopicSubscription(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.Lock()
+
+	if rec := h.systemTopics[key]; rec != nil {
+		delete(rec.subscriptions, rp.SubResourceName)
+	}
+
+	h.mu.Unlock()
+
+	// The SDK's BeginDelete LRO completes on a 200 first response.
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) listSystemTopicSubscriptions(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.RLock()
+
+	rec := h.systemTopics[key]
+	if rec == nil {
+		h.mu.RUnlock()
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "system topic not found")
+
+		return
+	}
+
+	names := make([]string, 0, len(rec.subscriptions))
+	for name := range rec.subscriptions {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	out := make([]eventSubscriptionJSON, 0, len(names))
+
+	for _, name := range names {
+		props := rec.subscriptions[name]
+		scoped := *rp
+		scoped.SubResourceName = name
+		out = append(out, systemTopicSubscriptionJSON(&scoped, props))
+	}
+
+	h.mu.RUnlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, eventSubscriptionListResult{Value: out})
+}

--- a/server/azure/eventgrid/system_topics.go
+++ b/server/azure/eventgrid/system_topics.go
@@ -1,0 +1,203 @@
+package eventgrid
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+const (
+	systemTopicResourceType         = "Microsoft.EventGrid/systemTopics"
+	systemTopicSubscriptionType     = "Microsoft.EventGrid/systemTopics/eventSubscriptions"
+	defaultSystemTopicLocation      = "global"
+	systemTopicProvisioningState    = "Succeeded"
+	systemTopicSubProvisioningState = "Succeeded"
+)
+
+// systemTopicRecord is the wire-handler-owned state for one system topic. A
+// system topic represents an Azure resource (the source) that emits events into
+// Event Grid; the emulator models the management surface (CRUD + its event
+// subscriptions) rather than the external source itself.
+type systemTopicRecord struct {
+	name          string
+	location      string
+	source        string
+	topicType     string
+	sub           string
+	rg            string
+	tags          map[string]string
+	subscriptions map[string]json.RawMessage
+}
+
+// systemTopicJSON is the ARM SystemTopic resource shape (armeventgrid.SystemTopic).
+type systemTopicJSON struct {
+	ID         string                 `json:"id,omitempty"`
+	Name       string                 `json:"name"`
+	Type       string                 `json:"type"`
+	Location   string                 `json:"location"`
+	Tags       map[string]*string     `json:"tags,omitempty"`
+	Properties *systemTopicProperties `json:"properties,omitempty"`
+}
+
+type systemTopicProperties struct {
+	Source            string `json:"source,omitempty"`
+	TopicType         string `json:"topicType,omitempty"`
+	MetricResourceID  string `json:"metricResourceId,omitempty"`
+	ProvisioningState string `json:"provisioningState,omitempty"`
+}
+
+type systemTopicListResult struct {
+	Value []systemTopicJSON `json:"value"`
+}
+
+// storeKey scopes a resource record by subscription + resource group + name so
+// same-named resources in different groups do not collide.
+func storeKey(sub, rg, name string) string {
+	return sub + "|" + rg + "|" + name
+}
+
+func systemTopicID(rp *azurearm.ResourcePath) string {
+	return azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeSystemTopics, rp.ResourceName)
+}
+
+func (rec *systemTopicRecord) toJSON(rp *azurearm.ResourcePath) systemTopicJSON {
+	id := systemTopicID(rp)
+
+	return systemTopicJSON{
+		ID:       id,
+		Name:     rec.name,
+		Type:     systemTopicResourceType,
+		Location: rec.location,
+		Tags:     tagsToPtr(rec.tags),
+		Properties: &systemTopicProperties{
+			Source:            rec.source,
+			TopicType:         rec.topicType,
+			MetricResourceID:  id,
+			ProvisioningState: systemTopicProvisioningState,
+		},
+	}
+}
+
+// serveSystemTopics routes .../systemTopics[/{name}[/eventSubscriptions[/{sub}]]].
+func (h *Handler) serveSystemTopics(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if rp.ResourceName == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w)
+			return
+		}
+
+		h.listSystemTopics(w, rp)
+
+		return
+	}
+
+	switch rp.SubResource {
+	case "":
+		h.serveSystemTopicResource(w, r, rp)
+	case subEventSubscriptions:
+		h.serveSystemTopicSubscription(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "unsupported system topic sub-resource")
+	}
+}
+
+func (h *Handler) serveSystemTopicResource(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdateSystemTopic(w, r, rp)
+	case http.MethodGet:
+		h.getSystemTopic(w, rp)
+	case http.MethodDelete:
+		h.deleteSystemTopic(w, rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createOrUpdateSystemTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body systemTopicJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	loc := body.Location
+	if loc == "" {
+		loc = defaultSystemTopicLocation
+	}
+
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.Lock()
+
+	rec := h.systemTopics[key]
+	if rec == nil {
+		rec = &systemTopicRecord{
+			name:          rp.ResourceName,
+			sub:           rp.Subscription,
+			rg:            rp.ResourceGroup,
+			subscriptions: make(map[string]json.RawMessage),
+		}
+		h.systemTopics[key] = rec
+	}
+
+	rec.location = loc
+	rec.tags = tagsFromPtr(body.Tags)
+
+	if body.Properties != nil {
+		rec.source = body.Properties.Source
+		rec.topicType = body.Properties.TopicType
+	}
+
+	out := rec.toJSON(rp)
+	h.mu.Unlock()
+
+	// 201 with a terminal provisioningState completes the SDK's LRO poller on
+	// the first response.
+	azurearm.WriteJSON(w, http.StatusCreated, out)
+}
+
+func (h *Handler) getSystemTopic(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.RLock()
+	rec := h.systemTopics[key]
+
+	if rec == nil {
+		h.mu.RUnlock()
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "system topic not found")
+
+		return
+	}
+
+	out := rec.toJSON(rp)
+	h.mu.RUnlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) deleteSystemTopic(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.Lock()
+	_, found := h.systemTopics[key]
+	delete(h.systemTopics, key)
+	h.mu.Unlock()
+
+	if !found {
+		// ARM delete is idempotent: a delete of a missing resource completes 204.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) listSystemTopics(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	h.mu.RLock()
+	recs := recordsInScope(h.systemTopics, rp.Subscription, rp.ResourceGroup)
+	out := scopedList(recs, rp, (*systemTopicRecord).toJSON)
+	h.mu.RUnlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, systemTopicListResult{Value: out})
+}

--- a/server/azure/eventgrid/system_topics_sdk_test.go
+++ b/server/azure/eventgrid/system_topics_sdk_test.go
@@ -1,0 +1,229 @@
+// Real-user tests for the Event Grid system-topic and domain ARM surfaces,
+// driving the official armeventgrid SDK clients against the CloudEmu Azure
+// server mounted in an httptest TLS server.
+package eventgrid_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+)
+
+// TestSDKSystemTopicLifecycle walks CreateOrUpdate → Get → list (by RG and by
+// subscription) → Delete through the SystemTopicsClient.
+func TestSDKSystemTopicLifecycle(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	st := cf.NewSystemTopicsClient()
+	ctx := context.Background()
+
+	const source = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Storage/storageAccounts/acct"
+
+	poller, err := st.BeginCreateOrUpdate(ctx, testRG, "storage-events", armeventgrid.SystemTopic{
+		Location: to.Ptr("global"),
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+		Properties: &armeventgrid.SystemTopicProperties{
+			Source:    to.Ptr(source),
+			TopicType: to.Ptr("Microsoft.Storage.StorageAccounts"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("SystemTopics.BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("SystemTopics create PollUntilDone: %v", err)
+	}
+
+	if created.Properties == nil || created.Properties.Source == nil || *created.Properties.Source != source {
+		t.Fatalf("created source round-trip failed: %+v", created.Properties)
+	}
+
+	if created.Properties.ProvisioningState == nil || *created.Properties.ProvisioningState != armeventgrid.ResourceProvisioningStateSucceeded {
+		t.Fatalf("provisioningState = %v, want Succeeded", created.Properties.ProvisioningState)
+	}
+
+	got, err := st.Get(ctx, testRG, "storage-events", nil)
+	if err != nil {
+		t.Fatalf("SystemTopics.Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.TopicType == nil ||
+		*got.Properties.TopicType != "Microsoft.Storage.StorageAccounts" {
+		t.Fatalf("topicType round-trip failed: %+v", got.Properties)
+	}
+
+	if got.Tags["env"] == nil || *got.Tags["env"] != "test" {
+		t.Fatalf("tags round-trip failed: %+v", got.Tags)
+	}
+
+	// List by resource group.
+	var byRG []string
+
+	rgPager := st.NewListByResourceGroupPager(testRG, nil)
+	for rgPager.More() {
+		page, perr := rgPager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("ListByResourceGroup: %v", perr)
+		}
+
+		for _, s := range page.Value {
+			byRG = append(byRG, *s.Name)
+		}
+	}
+
+	if len(byRG) != 1 || byRG[0] != "storage-events" {
+		t.Fatalf("ListByResourceGroup = %v, want [storage-events]", byRG)
+	}
+
+	// List by subscription.
+	var bySub []string
+
+	subPager := st.NewListBySubscriptionPager(nil)
+	for subPager.More() {
+		page, perr := subPager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("ListBySubscription: %v", perr)
+		}
+
+		for _, s := range page.Value {
+			bySub = append(bySub, *s.Name)
+		}
+	}
+
+	if len(bySub) != 1 || bySub[0] != "storage-events" {
+		t.Fatalf("ListBySubscription = %v, want [storage-events]", bySub)
+	}
+
+	delPoller, err := st.BeginDelete(ctx, testRG, "storage-events", nil)
+	if err != nil {
+		t.Fatalf("SystemTopics.BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("SystemTopics delete PollUntilDone: %v", err)
+	}
+
+	if _, err := st.Get(ctx, testRG, "storage-events", nil); err == nil {
+		t.Fatal("Get after delete: expected error, got nil")
+	}
+}
+
+// TestSDKSystemTopicEventSubscription drives the SystemTopicEventSubscriptions
+// client: create a subscription with a webhook destination and filter, read it
+// back, list it, then delete it.
+func TestSDKSystemTopicEventSubscription(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	st := cf.NewSystemTopicsClient()
+	subs := cf.NewSystemTopicEventSubscriptionsClient()
+	ctx := context.Background()
+
+	mkSystemTopic(ctx, t, st, "storage-events")
+
+	sub := armeventgrid.EventSubscription{
+		Properties: &armeventgrid.EventSubscriptionProperties{
+			Destination: &armeventgrid.WebHookEventSubscriptionDestination{
+				EndpointType: to.Ptr(armeventgrid.EndpointTypeWebHook),
+				Properties: &armeventgrid.WebHookEventSubscriptionDestinationProperties{
+					EndpointURL: to.Ptr("https://example.com/hook"),
+				},
+			},
+			Filter: &armeventgrid.EventSubscriptionFilter{
+				SubjectBeginsWith: to.Ptr("blobs/"),
+			},
+		},
+	}
+
+	poller, err := subs.BeginCreateOrUpdate(ctx, testRG, "storage-events", "to-fn", sub, nil)
+	if err != nil {
+		t.Fatalf("subscription BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("subscription PollUntilDone: %v", err)
+	}
+
+	got, err := subs.Get(ctx, testRG, "storage-events", "to-fn", nil)
+	if err != nil {
+		t.Fatalf("subscription Get: %v", err)
+	}
+
+	dest, ok := got.Properties.Destination.(*armeventgrid.WebHookEventSubscriptionDestination)
+	if !ok {
+		t.Fatalf("destination type = %T, want WebHook", got.Properties.Destination)
+	}
+
+	if dest.Properties == nil || dest.Properties.EndpointURL == nil ||
+		*dest.Properties.EndpointURL != "https://example.com/hook" {
+		t.Fatalf("endpointUrl round-trip failed: %+v", dest.Properties)
+	}
+
+	if got.Properties.Filter == nil || got.Properties.Filter.SubjectBeginsWith == nil ||
+		*got.Properties.Filter.SubjectBeginsWith != "blobs/" {
+		t.Fatalf("filter round-trip failed: %+v", got.Properties.Filter)
+	}
+
+	var names []string
+
+	pager := subs.NewListBySystemTopicPager(testRG, "storage-events", nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("list: %v", perr)
+		}
+
+		for _, s := range page.Value {
+			names = append(names, *s.Name)
+		}
+	}
+
+	if len(names) != 1 || names[0] != "to-fn" {
+		t.Fatalf("list = %v, want [to-fn]", names)
+	}
+
+	delPoller, err := subs.BeginDelete(ctx, testRG, "storage-events", "to-fn", nil)
+	if err != nil {
+		t.Fatalf("subscription BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("subscription delete PollUntilDone: %v", err)
+	}
+}
+
+// TestSDKSystemTopicEventSubscriptionOnMissingTopic asserts a subscription
+// create against a system topic that does not exist 404s.
+func TestSDKSystemTopicEventSubscriptionOnMissingTopic(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	subs := cf.NewSystemTopicEventSubscriptionsClient()
+	ctx := context.Background()
+
+	_, err := subs.BeginCreateOrUpdate(ctx, testRG, "no-such-topic", "s1", armeventgrid.EventSubscription{
+		Properties: &armeventgrid.EventSubscriptionProperties{},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected 404 creating subscription on missing system topic, got nil")
+	}
+}
+
+// mkSystemTopic creates a system topic and waits for the LRO to complete.
+func mkSystemTopic(ctx context.Context, t *testing.T, st *armeventgrid.SystemTopicsClient, name string) {
+	t.Helper()
+
+	poller, err := st.BeginCreateOrUpdate(ctx, testRG, name, armeventgrid.SystemTopic{
+		Location: to.Ptr("global"),
+		Properties: &armeventgrid.SystemTopicProperties{
+			Source:    to.Ptr("/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Storage/storageAccounts/acct"),
+			TopicType: to.Ptr("Microsoft.Storage.StorageAccounts"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("mkSystemTopic BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("mkSystemTopic PollUntilDone: %v", err)
+	}
+}

--- a/server/azure/notificationhubs/debug_send.go
+++ b/server/azure/notificationhubs/debug_send.go
@@ -1,0 +1,82 @@
+package notificationhubs
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+// debugSendResponse is the NotificationHubs.DebugSend result
+// (armnotificationhubs.DebugSendResponse). properties.success / .failure are the
+// device outcome counts; properties.results itemizes each targeted registration.
+type debugSendResponse struct {
+	Location   string            `json:"location,omitempty"`
+	Properties *debugSendResult  `json:"properties,omitempty"`
+	Tags       map[string]string `json:"tags,omitempty"`
+}
+
+type debugSendResult struct {
+	Success float64          `json:"success"`
+	Failure float64          `json:"failure"`
+	Results []debugSendEntry `json:"results"`
+}
+
+type debugSendEntry struct {
+	ApplicationPlatformID string `json:"applicationPlatformId,omitempty"`
+	PnsHandle             string `json:"pnsHandle,omitempty"`
+	RegistrationID        string `json:"registrationId,omitempty"`
+	Outcome               string `json:"outcome"`
+}
+
+// debugSend serves NotificationHubs.DebugSend: it targets the hub's device
+// registrations with a test notification and reports the per-device outcome. The
+// emulator has no live PNS, so every current registration is a Success; a hub
+// with no registrations reports zero success and zero failure.
+func (h *Handler) debugSend(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, hub string) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	// The debug payload is advisory in the emulator; drain it so the connection
+	// is reusable, but the outcome depends only on the registered devices.
+	_, _ = io.Copy(io.Discard, r.Body)
+
+	az, ok := h.requireAz(w)
+	if !ok {
+		return
+	}
+
+	key := hubKey(rp.ResourceName, hub)
+	if _, err := h.notif.GetTopic(r.Context(), key); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	regs, err := az.ListRegistrations(r.Context(), key)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	results := make([]debugSendEntry, 0, len(regs))
+	for i := range regs {
+		results = append(results, debugSendEntry{
+			ApplicationPlatformID: regs[i].Platform,
+			PnsHandle:             regs[i].Handle,
+			RegistrationID:        regs[i].RegistrationID,
+			Outcome:               "Success",
+		})
+	}
+
+	// DebugSend answers 201 Created.
+	azurearm.WriteJSON(w, http.StatusCreated, debugSendResponse{
+		Location: defaultLocation,
+		Properties: &debugSendResult{
+			Success: float64(len(results)),
+			Failure: 0,
+			Results: results,
+		},
+	})
+}

--- a/server/azure/notificationhubs/debug_send_pns_regenerate_sdk_test.go
+++ b/server/azure/notificationhubs/debug_send_pns_regenerate_sdk_test.go
@@ -1,0 +1,221 @@
+// Real-user tests for the Notification Hubs DebugSend, GetPnsCredentials and
+// RegenerateKeys operations, driving the official armnotificationhubs SDK
+// clients against the CloudEmu Azure server mounted in an httptest TLS server.
+package notificationhubs_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/notificationhubs/armnotificationhubs"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureprovider "github.com/stackshy/cloudemu/v2/providers/azure"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+)
+
+// newExtrasEnv returns a client factory plus the provider backing it, so a test
+// can seed data-plane device registrations directly on the driver.
+func newExtrasEnv(t *testing.T) (*armnotificationhubs.ClientFactory, *azureprovider.Provider) {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{NotificationHubs: cloudP.NotificationHubs})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+
+	opts := &arm.ClientOptions{ClientOptions: azcore.ClientOptions{
+		Cloud:     myCloud,
+		Transport: ts.Client(),
+		Retry:     policy.RetryOptions{MaxRetries: -1},
+	}}
+
+	cf, err := armnotificationhubs.NewClientFactory(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewClientFactory: %v", err)
+	}
+
+	return cf, cloudP
+}
+
+// mkNamespaceHub creates namespace ns and hub under it through the SDK.
+func mkNamespaceHub(ctx context.Context, t *testing.T, cf *armnotificationhubs.ClientFactory, ns, hub string) {
+	t.Helper()
+
+	if _, err := cf.NewNamespacesClient().CreateOrUpdate(ctx, testRG, ns,
+		armnotificationhubs.NamespaceCreateOrUpdateParameters{Location: to.Ptr("eastus")}, nil); err != nil {
+		t.Fatalf("namespace create: %v", err)
+	}
+
+	if _, err := cf.NewClient().CreateOrUpdate(ctx, testRG, ns, hub,
+		armnotificationhubs.NotificationHubCreateOrUpdateParameters{Location: to.Ptr("eastus")}, nil); err != nil {
+		t.Fatalf("hub create: %v", err)
+	}
+}
+
+// TestSDKDebugSend seeds two device registrations, then asserts DebugSend
+// reports both as successful targets and an empty hub reports zero.
+func TestSDKDebugSend(t *testing.T) {
+	ctx := context.Background()
+	cf, provider := newExtrasEnv(t)
+	mkNamespaceHub(ctx, t, cf, "my-ns", "hub1")
+
+	// An empty hub: zero success, zero failure.
+	empty, err := cf.NewClient().DebugSend(ctx, testRG, "my-ns", "hub1", nil)
+	if err != nil {
+		t.Fatalf("DebugSend (empty): %v", err)
+	}
+
+	if empty.Properties == nil || empty.Properties.Success == nil || *empty.Properties.Success != 0 {
+		t.Fatalf("empty DebugSend success = %v, want 0", empty.Properties)
+	}
+
+	// Seed two registrations on the data plane (driver key is "{ns}/{hub}").
+	const hubKey = "my-ns/hub1"
+
+	for _, id := range []string{"reg-a", "reg-b"} {
+		if _, err := provider.NotificationHubs.CreateRegistration(ctx, hubKey, notifdriver.AzureRegistration{
+			RegistrationID: id,
+			Platform:       "gcm",
+			Handle:         "token-" + id,
+		}); err != nil {
+			t.Fatalf("seed registration %s: %v", id, err)
+		}
+	}
+
+	got, err := cf.NewClient().DebugSend(ctx, testRG, "my-ns", "hub1", nil)
+	if err != nil {
+		t.Fatalf("DebugSend: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.Success == nil || *got.Properties.Success != 2 {
+		t.Fatalf("DebugSend success = %v, want 2", got.Properties)
+	}
+
+	if got.Properties.Failure == nil || *got.Properties.Failure != 0 {
+		t.Fatalf("DebugSend failure = %v, want 0", got.Properties.Failure)
+	}
+
+	// DebugSend on a missing hub 404s.
+	if _, err := cf.NewClient().DebugSend(ctx, testRG, "my-ns", "ghost", nil); err == nil {
+		t.Fatal("DebugSend on missing hub: expected error, got nil")
+	}
+}
+
+// TestSDKGetPnsCredentials creates a hub carrying a GCM credential and asserts
+// GetPnsCredentials echoes it back, while a hub without credentials reports none.
+func TestSDKGetPnsCredentials(t *testing.T) {
+	ctx := context.Background()
+	cf, _ := newExtrasEnv(t)
+
+	if _, err := cf.NewNamespacesClient().CreateOrUpdate(ctx, testRG, "my-ns",
+		armnotificationhubs.NamespaceCreateOrUpdateParameters{Location: to.Ptr("eastus")}, nil); err != nil {
+		t.Fatalf("namespace create: %v", err)
+	}
+
+	// Create a hub with a GCM (FCM legacy) credential.
+	if _, err := cf.NewClient().CreateOrUpdate(ctx, testRG, "my-ns", "hub1",
+		armnotificationhubs.NotificationHubCreateOrUpdateParameters{
+			Location: to.Ptr("eastus"),
+			Properties: &armnotificationhubs.NotificationHubProperties{
+				GCMCredential: &armnotificationhubs.GCMCredential{
+					Properties: &armnotificationhubs.GCMCredentialProperties{
+						GoogleAPIKey: to.Ptr("AIzaSy-test-key"),
+					},
+				},
+			},
+		}, nil); err != nil {
+		t.Fatalf("hub create with credential: %v", err)
+	}
+
+	creds, err := cf.NewClient().GetPnsCredentials(ctx, testRG, "my-ns", "hub1", nil)
+	if err != nil {
+		t.Fatalf("GetPnsCredentials: %v", err)
+	}
+
+	if creds.Properties == nil || creds.Properties.GCMCredential == nil ||
+		creds.Properties.GCMCredential.Properties == nil ||
+		creds.Properties.GCMCredential.Properties.GoogleAPIKey == nil ||
+		*creds.Properties.GCMCredential.Properties.GoogleAPIKey != "AIzaSy-test-key" {
+		t.Fatalf("GcmCredential round-trip failed: %+v", creds.Properties)
+	}
+
+	// A hub created without credentials reports an empty (but valid) set.
+	if _, err := cf.NewClient().CreateOrUpdate(ctx, testRG, "my-ns", "bare",
+		armnotificationhubs.NotificationHubCreateOrUpdateParameters{Location: to.Ptr("eastus")}, nil); err != nil {
+		t.Fatalf("bare hub create: %v", err)
+	}
+
+	bare, err := cf.NewClient().GetPnsCredentials(ctx, testRG, "my-ns", "bare", nil)
+	if err != nil {
+		t.Fatalf("GetPnsCredentials (bare): %v", err)
+	}
+
+	if bare.Properties != nil && bare.Properties.GCMCredential != nil {
+		t.Fatalf("bare hub reported a GCM credential: %+v", bare.Properties)
+	}
+}
+
+// TestSDKRegenerateKeys rotates a hub authorization rule's primary key and
+// asserts the change is visible and durable (a subsequent ListKeys reflects it).
+func TestSDKRegenerateKeys(t *testing.T) {
+	ctx := context.Background()
+	cf, _ := newExtrasEnv(t)
+	mkNamespaceHub(ctx, t, cf, "my-ns", "hub1")
+
+	hubs := cf.NewClient()
+
+	if _, err := hubs.CreateOrUpdateAuthorizationRule(ctx, testRG, "my-ns", "hub1", "sender",
+		armnotificationhubs.SharedAccessAuthorizationRuleCreateOrUpdateParameters{
+			Properties: &armnotificationhubs.SharedAccessAuthorizationRuleProperties{
+				Rights: []*armnotificationhubs.AccessRights{to.Ptr(armnotificationhubs.AccessRightsSend)},
+			},
+		}, nil); err != nil {
+		t.Fatalf("hub CreateOrUpdateAuthorizationRule: %v", err)
+	}
+
+	before, err := hubs.ListKeys(ctx, testRG, "my-ns", "hub1", "sender", nil)
+	if err != nil {
+		t.Fatalf("ListKeys before: %v", err)
+	}
+
+	regen, err := hubs.RegenerateKeys(ctx, testRG, "my-ns", "hub1", "sender",
+		armnotificationhubs.PolicykeyResource{PolicyKey: to.Ptr("PrimaryKey")}, nil)
+	if err != nil {
+		t.Fatalf("RegenerateKeys: %v", err)
+	}
+
+	if regen.PrimaryKey == nil || before.PrimaryKey == nil || *regen.PrimaryKey == *before.PrimaryKey {
+		t.Fatalf("primary key did not change: before=%v after=%v", before.PrimaryKey, regen.PrimaryKey)
+	}
+
+	if regen.SecondaryKey == nil || before.SecondaryKey == nil || *regen.SecondaryKey != *before.SecondaryKey {
+		t.Fatalf("secondary key changed on PrimaryKey regenerate: before=%v after=%v",
+			before.SecondaryKey, regen.SecondaryKey)
+	}
+
+	// The rotation is durable: ListKeys now returns the regenerated primary.
+	after, err := hubs.ListKeys(ctx, testRG, "my-ns", "hub1", "sender", nil)
+	if err != nil {
+		t.Fatalf("ListKeys after: %v", err)
+	}
+
+	if after.PrimaryKey == nil || *after.PrimaryKey != *regen.PrimaryKey {
+		t.Fatalf("ListKeys after regenerate = %v, want rotated primary %v", after.PrimaryKey, regen.PrimaryKey)
+	}
+}

--- a/server/azure/notificationhubs/handler.go
+++ b/server/azure/notificationhubs/handler.go
@@ -40,6 +40,15 @@ const (
 	subHubs        = "notificationHubs"
 )
 
+// Trailing-segment counts for the hub sub-resource tree, named so the routing
+// table reads without bare magic numbers (mirrors the segment-count constants
+// in the Cosmos handler).
+const (
+	segHubOneSub   = 4 // .../notificationHubs/{hub}/{debugsend|pnsCredentials|AuthorizationRules}
+	segHubTwoSub   = 5 // .../notificationHubs/{hub}/AuthorizationRules/{rule}
+	segHubThreeSub = 6 // .../AuthorizationRules/{rule}/{listKeys|regenerateKeys}
+)
+
 // Handler serves Microsoft.NotificationHubs ARM requests against a notification
 // driver.
 type Handler struct {
@@ -109,6 +118,8 @@ func (h *Handler) route(w http.ResponseWriter, r *http.Request, rp *azurearm.Res
 		h.serveNamespaceAuthRule(w, r, rp, seg[2])
 	case len(seg) == 4 && eq(seg[1], subAuthorizationRules) && eq(seg[3], actionListKeys):
 		h.namespaceAuthRuleKeys(w, r, rp, seg[2])
+	case len(seg) == 4 && eq(seg[1], subAuthorizationRules) && eq(seg[3], actionRegenerateKeys):
+		h.namespaceAuthRuleRegenerate(w, r, rp, seg[2])
 	case len(seg) == 2 && eq(seg[1], subNotificationHubs):
 		h.serveHubCollection(w, r, rp)
 	case len(seg) == 3 && eq(seg[1], subNotificationHubs):
@@ -120,17 +131,35 @@ func (h *Handler) route(w http.ResponseWriter, r *http.Request, rp *azurearm.Res
 	}
 }
 
-// routeHubSub dispatches hub sub-resources: AuthorizationRules and listKeys.
+// routeHubSub dispatches hub sub-resources: debugsend, pnsCredentials and the
+// AuthorizationRules tree (delegated to routeHubAuthRule).
 func (h *Handler) routeHubSub(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, seg []string) {
 	hub := seg[2]
 
 	switch {
-	case len(seg) == 4 && eq(seg[3], subAuthorizationRules):
+	case len(seg) == segHubOneSub && eq(seg[3], subDebugSend):
+		h.debugSend(w, r, rp, hub)
+	case len(seg) == segHubOneSub && eq(seg[3], subPnsCredentials):
+		h.getPnsCredentials(w, r, rp, hub)
+	case eq(seg[3], subAuthorizationRules):
+		h.routeHubAuthRule(w, r, rp, hub, seg)
+	default:
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "unsupported Notification Hubs path")
+	}
+}
+
+// routeHubAuthRule dispatches the .../notificationHubs/{hub}/AuthorizationRules
+// tree: list, per-rule CRUD, listKeys and regenerateKeys.
+func (h *Handler) routeHubAuthRule(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, hub string, seg []string) {
+	switch {
+	case len(seg) == segHubOneSub:
 		h.listHubAuthRules(w, r, rp, hub)
-	case len(seg) == 5 && eq(seg[3], subAuthorizationRules):
+	case len(seg) == segHubTwoSub:
 		h.serveHubAuthRule(w, r, rp, hub, seg[4])
-	case len(seg) == 6 && eq(seg[3], subAuthorizationRules) && eq(seg[5], actionListKeys):
+	case len(seg) == segHubThreeSub && eq(seg[5], actionListKeys):
 		h.hubAuthRuleKeys(w, r, rp, hub, seg[4])
+	case len(seg) == segHubThreeSub && eq(seg[5], actionRegenerateKeys):
+		h.hubAuthRuleRegenerate(w, r, rp, hub, seg[4])
 	default:
 		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "unsupported Notification Hubs path")
 	}

--- a/server/azure/notificationhubs/operations.go
+++ b/server/azure/notificationhubs/operations.go
@@ -161,21 +161,18 @@ func (h *Handler) listNamespaces(w http.ResponseWriter, r *http.Request, rp *azu
 // --- notification hubs ---
 
 func (h *Handler) createOrUpdateHub(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	var body putBody
+	// Decode with the properties block kept raw so PNS credentials (whose shape
+	// is platform-specific) round-trip verbatim for GetPnsCredentials.
+	var body hubPutBody
 	if !azurearm.DecodeJSON(w, r, &body) {
 		return
 	}
 
 	key := hubKey(rp.ResourceName, rp.SubResourceName)
 
-	ttl := ""
-	if body.Properties != nil {
-		ttl = body.Properties.RegistrationTTL
-	}
-
 	cfg := notifdriver.TopicConfig{
 		Name:        key,
-		DisplayName: ttl,
+		DisplayName: body.registrationTTL(),
 		Tags:        body.Tags,
 		Scope:       rpScope(rp),
 		Region:      body.Location,
@@ -187,7 +184,10 @@ func (h *Handler) createOrUpdateHub(w http.ResponseWriter, r *http.Request, rp *
 			azurearm.WriteCErr(w, uerr)
 			return
 		}
+
+		h.storePnsCredentials(r, key, body.Properties)
 		azurearm.WriteJSON(w, http.StatusOK, toHubJSON(rp, rp.ResourceName, rp.SubResourceName, info))
+
 		return
 	}
 
@@ -197,6 +197,7 @@ func (h *Handler) createOrUpdateHub(w http.ResponseWriter, r *http.Request, rp *
 		return
 	}
 
+	h.storePnsCredentials(r, key, body.Properties)
 	azurearm.WriteJSON(w, http.StatusCreated, toHubJSON(rp, rp.ResourceName, rp.SubResourceName, info))
 }
 

--- a/server/azure/notificationhubs/pns_credentials.go
+++ b/server/azure/notificationhubs/pns_credentials.go
@@ -1,0 +1,132 @@
+package notificationhubs
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+const pnsCredentialsType = "Microsoft.NotificationHubs/namespaces/notificationHubs/pnsCredentials"
+
+// pnsCredentialKeys are the platform credential fields Notification Hubs carries
+// in a hub's properties and echoes from GetPnsCredentials.
+var pnsCredentialKeys = []string{ //nolint:gochecknoglobals // static lookup table
+	"admCredential",
+	"apnsCredential",
+	"baiduCredential",
+	"gcmCredential",
+	"mpnsCredential",
+	"wnsCredential",
+}
+
+// hubPutBody decodes a hub CreateOrUpdate request, keeping the properties block
+// raw so platform-specific PNS credentials survive verbatim.
+type hubPutBody struct {
+	Location   string            `json:"location,omitempty"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties json.RawMessage   `json:"properties,omitempty"`
+}
+
+// registrationTTL extracts the registrationTtl from the raw properties block.
+func (b *hubPutBody) registrationTTL() string {
+	if len(b.Properties) == 0 {
+		return ""
+	}
+
+	var props struct {
+		RegistrationTTL string `json:"registrationTtl"`
+	}
+
+	_ = json.Unmarshal(b.Properties, &props)
+
+	return props.RegistrationTTL
+}
+
+// pnsCredentialsResource is the GetPnsCredentials response
+// (armnotificationhubs.PnsCredentialsResource). Properties carries only the
+// platform credential objects, each in its original wire shape.
+type pnsCredentialsResource struct {
+	ID         string                     `json:"id,omitempty"`
+	Name       string                     `json:"name,omitempty"`
+	Type       string                     `json:"type,omitempty"`
+	Location   string                     `json:"location,omitempty"`
+	Properties map[string]json.RawMessage `json:"properties"`
+}
+
+// storePnsCredentials persists the credential-bearing properties supplied at hub
+// create/update. It stores nothing when the driver lacks the Azure capability or
+// the request carried no credentials, so a hub without credentials reports none.
+func (h *Handler) storePnsCredentials(r *http.Request, hubKey string, rawProps json.RawMessage) {
+	az, ok := h.az()
+	if !ok || len(rawProps) == 0 {
+		return
+	}
+
+	if len(extractPnsCredentials(rawProps)) == 0 {
+		return
+	}
+
+	_ = az.SetPnsCredentials(r.Context(), hubKey, string(rawProps))
+}
+
+// extractPnsCredentials returns the platform credential fields present in a raw
+// properties block, keyed by their wire name.
+func extractPnsCredentials(rawProps json.RawMessage) map[string]json.RawMessage {
+	out := map[string]json.RawMessage{}
+	if len(rawProps) == 0 {
+		return out
+	}
+
+	var props map[string]json.RawMessage
+	if err := json.Unmarshal(rawProps, &props); err != nil {
+		return out
+	}
+
+	for _, k := range pnsCredentialKeys {
+		if v, present := props[k]; present {
+			out[k] = v
+		}
+	}
+
+	return out
+}
+
+// getPnsCredentials serves NotificationHubs.GetPnsCredentials, echoing the PNS
+// credentials captured when the hub was created or updated.
+func (h *Handler) getPnsCredentials(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, hub string) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	az, ok := h.requireAz(w)
+	if !ok {
+		return
+	}
+
+	key := hubKey(rp.ResourceName, hub)
+
+	info, err := h.notif.GetTopic(r.Context(), key)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	stored, err := az.GetPnsCredentials(r.Context(), key)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeNamespaces, rp.ResourceName) +
+		"/" + subHubs + "/" + hub + "/pnsCredentials"
+
+	azurearm.WriteJSON(w, http.StatusOK, pnsCredentialsResource{
+		ID:         id,
+		Name:       hub,
+		Type:       pnsCredentialsType,
+		Location:   nsLocation(info),
+		Properties: extractPnsCredentials(json.RawMessage(stored)),
+	})
+}

--- a/server/azure/notificationhubs/regenerate_keys.go
+++ b/server/azure/notificationhubs/regenerate_keys.go
@@ -1,0 +1,95 @@
+package notificationhubs
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+)
+
+// policyKeyBody is the RegenerateKeys request (armnotificationhubs.PolicykeyResource).
+type policyKeyBody struct {
+	PolicyKey string `json:"policyKey,omitempty"`
+}
+
+// namespaceAuthRuleRegenerate serves NamespacesClient.RegenerateKeys.
+func (h *Handler) namespaceAuthRuleRegenerate(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, ruleName string,
+) {
+	az, ok := h.requireAz(w)
+	if !ok {
+		return
+	}
+
+	if _, err := h.notif.GetTopic(r.Context(), rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	h.regenerateKeys(w, r, az, rp.ResourceName, ruleName, rp.ResourceName)
+}
+
+// hubAuthRuleRegenerate serves NotificationHubsClient.RegenerateKeys.
+func (h *Handler) hubAuthRuleRegenerate(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, hub, ruleName string,
+) {
+	az, ok := h.requireAz(w)
+	if !ok {
+		return
+	}
+
+	key := hubKey(rp.ResourceName, hub)
+	if _, err := h.notif.GetTopic(r.Context(), key); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	h.regenerateKeys(w, r, az, key, ruleName, rp.ResourceName)
+}
+
+// regenerateKeys rotates the requested key of a rule and writes the resulting
+// ResourceListKeys. A recognized default rule is materialized on demand so its
+// keys can be rotated even when it was never explicitly created, matching how
+// ListKeys treats defaults.
+func (*Handler) regenerateKeys(
+	w http.ResponseWriter, r *http.Request, az notifdriver.AzureNotificationHubs,
+	resourceKey, ruleName, namespace string,
+) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	var body policyKeyBody
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	if _, err := az.GetSASRule(r.Context(), resourceKey, ruleName); err != nil {
+		rights, isDefault := defaultRuleRights[ruleName]
+		if !isDefault {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+
+		if _, perr := az.PutSASRule(r.Context(), resourceKey, ruleName,
+			notifdriver.AzureSASRule{Rights: rights}); perr != nil {
+			azurearm.WriteCErr(w, perr)
+			return
+		}
+	}
+
+	rule, err := az.RegenerateSASKey(r.Context(), resourceKey, ruleName, body.PolicyKey)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, resourceListKeys{
+		KeyName:                   ruleName,
+		PrimaryKey:                rule.PrimaryKey,
+		SecondaryKey:              rule.SecondaryKey,
+		PrimaryConnectionString:   sasConnectionString(namespace, ruleName, rule.PrimaryKey),
+		SecondaryConnectionString: sasConnectionString(namespace, ruleName, rule.SecondaryKey),
+	})
+}

--- a/server/azure/notificationhubs/types.go
+++ b/server/azure/notificationhubs/types.go
@@ -17,6 +17,9 @@ const (
 	subAuthorizationRules = "AuthorizationRules"
 	subNotificationHubs   = "notificationHubs"
 	actionListKeys        = "listKeys"
+	actionRegenerateKeys  = "regenerateKeys"
+	subDebugSend          = "debugsend"
+	subPnsCredentials     = "pnsCredentials"
 	typeCheckNSAvail      = "checkNamespaceAvailability"
 
 	namespaceTypeValue = "NotificationHub"

--- a/services/notification/driver/driver.go
+++ b/services/notification/driver/driver.go
@@ -147,9 +147,20 @@ type AzureNotificationHubs interface {
 	GetSASRule(ctx context.Context, resourceKey, ruleName string) (AzureSASRule, error)
 	ListSASRules(ctx context.Context, resourceKey string) (map[string]AzureSASRule, error)
 	DeleteSASRule(ctx context.Context, resourceKey, ruleName string) error
+	// RegenerateSASKey rotates the primary or secondary key of a rule (policyKey
+	// is "PrimaryKey" or "SecondaryKey"), returning the rule with the new key.
+	// The change is durable: later GetSASRule/ListKeys observe the rotated value.
+	RegenerateSASKey(ctx context.Context, resourceKey, ruleName, policyKey string) (AzureSASRule, error)
 
 	CreateRegistration(ctx context.Context, hubKey string, reg AzureRegistration) (AzureRegistration, error)
 	GetRegistration(ctx context.Context, hubKey, registrationID string) (AzureRegistration, error)
 	ListRegistrations(ctx context.Context, hubKey string) ([]AzureRegistration, error)
 	DeleteRegistration(ctx context.Context, hubKey, registrationID string) error
+
+	// SetPnsCredentials stores a hub's Platform Notification Service credentials
+	// as the raw properties JSON supplied at hub create/update time; GetPnsCredentials
+	// returns it (empty when none were set). Opaque like AzureRegistration.Body so
+	// every platform's credential shape round-trips without the driver modeling it.
+	SetPnsCredentials(ctx context.Context, hubKey, credentialsJSON string) error
+	GetPnsCredentials(ctx context.Context, hubKey string) (string, error)
 }


### PR DESCRIPTION
## Summary

Implements three previously-deferred Azure greenfield surfaces, each verified with the real azure-sdk-for-go clients against the CloudEmu Azure wire server.

### 1. Cosmos DB per-database isolation (data-integrity fix)
Previously the `{db}` path segment was ignored: every container lived in one global namespace and `DeleteDatabase` was a no-op. Now container and offer keys are qualified by database (`{db}/{coll}`):
- A container in `appdb` is unreachable through `otherdb`; same-named containers in different databases hold independent data.
- Databases are tracked, listable (`NewQueryDatabasesPager`), 409 on duplicate create, 404 on read of an absent database.
- `DeleteDatabase` removes exactly its own containers (and their offers), leaving other databases untouched.
- Container `_rid` is qualified so the SDK's `/offers` throughput lookup still resolves.
- The driver-level TTL/change-feed tests (which bypass HTTP) now address the database-qualified driver table name.

### 2. EventGrid SystemTopics + Domains (new ARM resource types)
- `Microsoft.EventGrid/systemTopics`: CreateOrUpdate / Get / Delete / ListBySubscription / ListByResourceGroup, plus their event subscriptions (CreateOrUpdate / Get / Delete / List).
- `Microsoft.EventGrid/domains`: CreateOrUpdate / Get / Delete / ListBySubscription / ListByResourceGroup / ListSharedAccessKeys / RegenerateKey (real key rotation).

Both are Event-Grid-only ARM resources with no generic driver equivalent, so — mirroring the existing Cosmos `/offers` precedent — the wire handler owns their state. No driver-interface change.

### 3. NotificationHubs DebugSend / GetPnsCredentials / RegenerateKeys
- `DebugSend`: reports device outcome counts (success/failure) and itemizes each targeted registration; an empty hub reports zero.
- `GetPnsCredentials`: PNS credentials supplied at hub create/update round-trip verbatim per platform; a hub without credentials reports none.
- `RegenerateKeys` (hub- and namespace-level): rotates a rule's primary/secondary key to a fresh crypto-random value; the change is durable, so subsequent `ListKeys` reflects it.

This adds three methods to the Azure-only `AzureNotificationHubs` optional driver interface (`RegenerateSASKey`, `SetPnsCredentials`, `GetPnsCredentials`) implemented by the Azure provider via type assertion; `docs/coverage` regenerated accordingly.

## Deferred
- **EventGrid domain topics and domain-topic event subscriptions** — their ARM paths (`/domains/{d}/topics/{t}/eventSubscriptions/{s}`) are three sub-levels deep, beyond what the shared `azurearm.ParsePath` models today. Deferred rather than shipped as a path parser hack; the domain resource itself and its keys are complete.

## Testing
- `go build ./...`, `go vet`, and `go test ./providers/azure/... ./server/azure/... ./services/...` all green.
- New real-SDK tests: Cosmos database isolation/namespacing/delete/list; EventGrid system topics + subscriptions + domains + key regeneration; NotificationHubs DebugSend + PNS credentials + RegenerateKeys.
- golangci-lint clean on all changed/new code.
