### PR TITLE
fix(ecs): CreateService/DescribeServices taskDefinition reference wire shape

### DIFF
--- a/providers/aws/ecs/services.go
+++ b/providers/aws/ecs/services.go
@@ -83,6 +83,12 @@ func (m *Mock) CreateService(ctx context.Context, in driver.CreateServiceInput) 
 		return nil, err
 	}
 
+	// Real ECS normalizes the service's taskDefinition to the full ARN regardless
+	// of how the caller referenced it (bare family or family:revision), so echo the
+	// resolved ARN rather than the caller's short form. This is what lets Terraform
+	// diff-suppress family:revision against the ARN AWS always returns.
+	in.TaskDefinition = td.ARN
+
 	// A DAEMON service runs exactly one task per container instance, so AWS
 	// rejects a caller-supplied desiredCount rather than overriding it.
 	if in.SchedulingStrategy == schedDaemon && in.DesiredCount > 0 {
@@ -357,15 +363,24 @@ func (m *Mock) UpdateService(ctx context.Context, in driver.UpdateServiceInput) 
 // unset) task definition is a no-op. A deregistered (INACTIVE) definition can't
 // back a new deployment, same as CreateService/RunTask, so it is rejected.
 func (m *Mock) applyTaskDefChange(updated, svc *driver.Service, in *driver.UpdateServiceInput) (bool, error) {
-	if in.TaskDefinition == "" || in.TaskDefinition == svc.TaskDefinition {
+	if in.TaskDefinition == "" {
 		return false, nil
 	}
 
-	if _, err := m.resolveLaunchableTaskDef(in.TaskDefinition); err != nil {
+	td, err := m.resolveLaunchableTaskDef(in.TaskDefinition)
+	if err != nil {
 		return false, err
 	}
 
-	updated.TaskDefinition = in.TaskDefinition
+	// The stored taskDefinition is always the full ARN, so compare the resolved ARN
+	// (not the caller's possibly-short reference) to detect a real change. A caller
+	// re-supplying the same revision as "family:revision" must remain a no-op.
+	if td.ARN == svc.TaskDefinition {
+		return false, nil
+	}
+
+	// Normalize to the full task-definition ARN, matching real ECS (and CreateService).
+	updated.TaskDefinition = td.ARN
 
 	return true, nil
 }

--- a/server/aws/ecs/service_taskdefinition_arn_test.go
+++ b/server/aws/ecs/service_taskdefinition_arn_test.go
@@ -1,0 +1,102 @@
+package ecs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
+
+	provecs "github.com/stackshy/cloudemu/v2/providers/aws/ecs"
+)
+
+// TestSDKServiceTaskDefinitionNormalizedToARN drives the real Terraform-style flow:
+// register a task definition (capturing the full ARN AWS returns), then create a
+// service referencing it by the bare family. Real ECS normalizes the service's
+// taskDefinition (and each deployment's taskDefinition) to the full ARN regardless
+// of how the caller referenced it, which is why aws_ecs_service must diff-suppress
+// family:revision against the ARN. CreateService, DescribeServices, and
+// UpdateService must all echo that ARN.
+func TestSDKServiceTaskDefinitionNormalizedToARN(t *testing.T) {
+	client, cloud := newECSServer(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsecs.CreateClusterInput{ClusterName: aws.String("prod")}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	cloud.ECS.SeedContainerInstance("prod", "i-svc", provecs.WithCapacity(8192, 16384))
+
+	td := registerNginx(t, client, ctx)
+	wantARN := aws.ToString(td.TaskDefinitionArn)
+
+	// Create the service by bare family — AWS still echoes the full ARN.
+	created, err := client.CreateService(ctx, &awsecs.CreateServiceInput{
+		Cluster:        aws.String("prod"),
+		ServiceName:    aws.String("web-svc"),
+		TaskDefinition: aws.String("web"),
+		DesiredCount:   aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	if got := aws.ToString(created.Service.TaskDefinition); got != wantARN {
+		t.Fatalf("CreateService taskDefinition = %q, want full ARN %q", got, wantARN)
+	}
+
+	if len(created.Service.Deployments) != 1 {
+		t.Fatalf("CreateService deployments = %d, want 1", len(created.Service.Deployments))
+	}
+
+	if got := aws.ToString(created.Service.Deployments[0].TaskDefinition); got != wantARN {
+		t.Fatalf("CreateService deployment taskDefinition = %q, want full ARN %q", got, wantARN)
+	}
+
+	// DescribeServices echoes the same ARN.
+	desc, err := client.DescribeServices(ctx, &awsecs.DescribeServicesInput{
+		Cluster: aws.String("prod"), Services: []string{"web-svc"},
+	})
+	if err != nil {
+		t.Fatalf("DescribeServices: %v", err)
+	}
+
+	if len(desc.Services) != 1 {
+		t.Fatalf("DescribeServices returned %d services, want 1", len(desc.Services))
+	}
+
+	if got := aws.ToString(desc.Services[0].TaskDefinition); got != wantARN {
+		t.Fatalf("DescribeServices taskDefinition = %q, want full ARN %q", got, wantARN)
+	}
+
+	// Register a second revision and update the service by family:revision short
+	// form; the returned service (and its new deployment) must carry the full ARN.
+	reg2, err := client.RegisterTaskDefinition(ctx, &awsecs.RegisterTaskDefinitionInput{
+		Family:               td.Family,
+		ContainerDefinitions: td.ContainerDefinitions,
+	})
+	if err != nil {
+		t.Fatalf("RegisterTaskDefinition rev2: %v", err)
+	}
+
+	want2 := aws.ToString(reg2.TaskDefinition.TaskDefinitionArn)
+
+	updated, err := client.UpdateService(ctx, &awsecs.UpdateServiceInput{
+		Cluster:        aws.String("prod"),
+		Service:        aws.String("web-svc"),
+		TaskDefinition: aws.String("web:2"),
+	})
+	if err != nil {
+		t.Fatalf("UpdateService: %v", err)
+	}
+
+	if got := aws.ToString(updated.Service.TaskDefinition); got != want2 {
+		t.Fatalf("UpdateService taskDefinition = %q, want full ARN %q", got, want2)
+	}
+
+	if len(updated.Service.Deployments) != 1 ||
+		aws.ToString(updated.Service.Deployments[0].TaskDefinition) != want2 {
+		t.Fatalf("UpdateService deployment taskDefinition = %+v, want full ARN %q",
+			updated.Service.Deployments, want2)
+	}
+}


### PR DESCRIPTION
## Summary

Real AWS normalizes a Service object's `taskDefinition` (and each `deployments[].taskDefinition`) to the **full task-definition ARN**, regardless of whether the caller referenced it by bare family or `family:revision`. This is why Terraform's `aws_ecs_service` must diff-suppress `family:revision` against the ARN AWS always echoes.

CloudEmu previously stored and echoed `in.TaskDefinition` verbatim, so `CreateService` with `TaskDefinition="web"` returned `service.taskDefinition="web"` (and the deployment likewise) — a mismatch against the ARN a caller gets back from `RegisterTaskDefinition`. `RunTask` was already correct (it uses the resolved `td.ARN`); only the Service/Deployment objects diverged.

## What changed

- `providers/aws/ecs/services.go`
  - **CreateService**: after resolving the launchable task definition, normalize `in.TaskDefinition` to `td.ARN` before building the service. The deployment copies `svc.TaskDefinition`, so it inherits the ARN transitively.
  - **UpdateService (applyTaskDefChange)**: resolve the incoming reference and store `td.ARN`. The change-detection guard now compares the resolved ARN against the stored ARN, so re-supplying the same revision as a short form remains a no-op (no spurious redeployment) even though the stored value is a full ARN.

## Test

- `server/aws/ecs/service_taskdefinition_arn_test.go` — real aws-sdk-go-v2 end-to-end: registers a task definition (capturing the ARN), creates a service by bare family and asserts `service.taskDefinition` and `deployments[0].taskDefinition` equal the full ARN, re-asserts via DescribeServices, then updates by `family:revision` and asserts the returned service and its new deployment carry the full ARN.

Gates: `go build ./...`, `go test ./providers/aws/... ./server/aws/... ./services/... ./compat/...`, and golangci-lint on changed packages all green. No driver interface changed.