### PR TITLE
fix(rds): DBInstance DBSubnetGroup as nested complex element (not scalar DBSubnetGroupName) so the SDK/Terraform can read it

### DIFF
--- a/server/aws/rds/advanced_restore.go
+++ b/server/aws/rds/advanced_restore.go
@@ -128,7 +128,7 @@ func (h *Handler) restoreDBInstanceToPointInTime(w http.ResponseWriter, r *http.
 
 	awsquery.WriteXMLResponse(w, restoreDBInstanceToPointInTimeResponse{
 		Xmlns:    Namespace,
-		Result:   dbInstanceResult{DBInstance: toInstanceXML(inst)},
+		Result:   dbInstanceResult{DBInstance: toInstanceXML(inst, h.resolveInstanceSubnetGroupXML(r.Context(), inst))},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/rds/instance_subnet_group_association_sdk_roundtrip_test.go
+++ b/server/aws/rds/instance_subnet_group_association_sdk_roundtrip_test.go
@@ -1,0 +1,78 @@
+package rds_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+)
+
+// A DB instance placed in a subnet group must report that association back as
+// the nested complex DBInstance.DBSubnetGroup element real RDS returns — not a
+// scalar DBSubnetGroupName the SDK has no field to bind. Terraform and the
+// aws-sdk-go-v2 rdstypes.DBInstance read db_subnet_group_name off
+// DBSubnetGroup.DBSubnetGroupName, so a nil DBSubnetGroup silently drops the
+// association the caller just set.
+func TestDBInstanceSubnetGroupAssociationRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	rdsc, ec2c := newSubnetGroupClients(t)
+	vpcID, subnetIDs := mkSubnets(t, ec2c)
+
+	if _, err := rdsc.CreateDBSubnetGroup(ctx, &awsrds.CreateDBSubnetGroupInput{
+		DBSubnetGroupName:        aws.String("app-db-subnets"),
+		DBSubnetGroupDescription: aws.String("private db subnets"),
+		SubnetIds:                subnetIDs,
+	}); err != nil {
+		t.Fatalf("CreateDBSubnetGroup: %v", err)
+	}
+
+	created, err := rdsc.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("app-db"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		Engine:               aws.String("postgres"),
+		MasterUsername:       aws.String("admin"),
+		MasterUserPassword:   aws.String("password123"),
+		AllocatedStorage:     aws.Int32(20),
+		DBSubnetGroupName:    aws.String("app-db-subnets"),
+	})
+	if err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	assertInstanceSubnetGroup(t, "CreateDBInstance", created.DBInstance.DBSubnetGroup, vpcID, len(subnetIDs))
+
+	described, err := rdsc.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String("app-db"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBInstances: %v", err)
+	}
+
+	if len(described.DBInstances) != 1 {
+		t.Fatalf("describe = %d instances, want 1", len(described.DBInstances))
+	}
+
+	assertInstanceSubnetGroup(t, "DescribeDBInstances", described.DBInstances[0].DBSubnetGroup, vpcID, len(subnetIDs))
+}
+
+func assertInstanceSubnetGroup(t *testing.T, op string, sg *rdstypes.DBSubnetGroup, vpcID string, wantSubnets int) {
+	t.Helper()
+
+	if sg == nil {
+		t.Fatalf("%s: DBInstance.DBSubnetGroup is nil — the association was dropped", op)
+	}
+
+	if got := aws.ToString(sg.DBSubnetGroupName); got != "app-db-subnets" {
+		t.Errorf("%s: DBSubnetGroupName = %q, want app-db-subnets", op, got)
+	}
+
+	if got := aws.ToString(sg.VpcId); got != vpcID {
+		t.Errorf("%s: DBSubnetGroup.VpcId = %q, want %q", op, got, vpcID)
+	}
+
+	if n := len(sg.Subnets); n != wantSubnets {
+		t.Errorf("%s: DBSubnetGroup.Subnets = %d, want %d", op, n, wantSubnets)
+	}
+}

--- a/server/aws/rds/operations.go
+++ b/server/aws/rds/operations.go
@@ -77,7 +77,7 @@ func (h *Handler) createDBInstance(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, createDBInstanceResponse{
 		Xmlns:    Namespace,
-		Result:   dbInstanceResult{DBInstance: toInstanceXML(inst)},
+		Result:   dbInstanceResult{DBInstance: toInstanceXML(inst, h.resolveInstanceSubnetGroupXML(r.Context(), inst))},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -109,7 +109,8 @@ func (h *Handler) describeDBInstances(w http.ResponseWriter, r *http.Request) {
 
 	out := dbInstancesXML{DBInstance: make([]dbInstanceXML, 0, len(page.Items))}
 	for i := range page.Items {
-		out.DBInstance = append(out.DBInstance, toInstanceXML(&page.Items[i]))
+		out.DBInstance = append(out.DBInstance,
+			toInstanceXML(&page.Items[i], h.resolveInstanceSubnetGroupXML(r.Context(), &page.Items[i])))
 	}
 
 	awsquery.WriteXMLResponse(w, describeDBInstancesResponse{
@@ -235,7 +236,7 @@ func (h *Handler) modifyDBInstance(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, modifyDBInstanceResponse{
 		Xmlns:    Namespace,
-		Result:   dbInstanceResult{DBInstance: toInstanceXML(inst)},
+		Result:   dbInstanceResult{DBInstance: toInstanceXML(inst, h.resolveInstanceSubnetGroupXML(r.Context(), inst))},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -294,7 +295,7 @@ func (h *Handler) deleteDBInstance(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, deleteDBInstanceResponse{
 		Xmlns:    Namespace,
-		Result:   dbInstanceResult{DBInstance: toInstanceXML(&last)},
+		Result:   dbInstanceResult{DBInstance: toInstanceXML(&last, h.resolveInstanceSubnetGroupXML(r.Context(), &last))},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -316,7 +317,7 @@ func (h *Handler) startDBInstance(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, startDBInstanceResponse{
 		Xmlns:    Namespace,
-		Result:   dbInstanceResult{DBInstance: toInstanceXML(&insts[0])},
+		Result:   dbInstanceResult{DBInstance: toInstanceXML(&insts[0], h.resolveInstanceSubnetGroupXML(r.Context(), &insts[0]))},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -338,7 +339,7 @@ func (h *Handler) stopDBInstance(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, stopDBInstanceResponse{
 		Xmlns:    Namespace,
-		Result:   dbInstanceResult{DBInstance: toInstanceXML(&insts[0])},
+		Result:   dbInstanceResult{DBInstance: toInstanceXML(&insts[0], h.resolveInstanceSubnetGroupXML(r.Context(), &insts[0]))},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -360,7 +361,7 @@ func (h *Handler) rebootDBInstance(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, rebootDBInstanceResponse{
 		Xmlns:    Namespace,
-		Result:   dbInstanceResult{DBInstance: toInstanceXML(&insts[0])},
+		Result:   dbInstanceResult{DBInstance: toInstanceXML(&insts[0], h.resolveInstanceSubnetGroupXML(r.Context(), &insts[0]))},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -659,7 +660,7 @@ func (h *Handler) restoreInstanceFromSnapshot(w http.ResponseWriter, r *http.Req
 
 	awsquery.WriteXMLResponse(w, restoreDBInstanceFromDBSnapshotResponse{
 		Xmlns:    Namespace,
-		Result:   dbInstanceResult{DBInstance: toInstanceXML(inst)},
+		Result:   dbInstanceResult{DBInstance: toInstanceXML(inst, h.resolveInstanceSubnetGroupXML(r.Context(), inst))},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/rds/read_replica.go
+++ b/server/aws/rds/read_replica.go
@@ -51,7 +51,7 @@ func (h *Handler) createDBInstanceReadReplica(w http.ResponseWriter, r *http.Req
 
 	awsquery.WriteXMLResponse(w, createDBInstanceReadReplicaResponse{
 		Xmlns:    Namespace,
-		Result:   dbInstanceResult{DBInstance: toInstanceXML(inst)},
+		Result:   dbInstanceResult{DBInstance: toInstanceXML(inst, h.resolveInstanceSubnetGroupXML(r.Context(), inst))},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -71,7 +71,7 @@ func (h *Handler) promoteReadReplica(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, promoteReadReplicaResponse{
 		Xmlns:    Namespace,
-		Result:   dbInstanceResult{DBInstance: toInstanceXML(inst)},
+		Result:   dbInstanceResult{DBInstance: toInstanceXML(inst, h.resolveInstanceSubnetGroupXML(r.Context(), inst))},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/rds/subnet_group.go
+++ b/server/aws/rds/subnet_group.go
@@ -1,6 +1,7 @@
 package rds
 
 import (
+	"context"
 	"encoding/xml"
 	"net/http"
 
@@ -131,6 +132,30 @@ func (h *Handler) deleteDBSubnetGroup(w http.ResponseWriter, r *http.Request) {
 		Xmlns:    Namespace,
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
+}
+
+// resolveInstanceSubnetGroupXML resolves the DB subnet group an instance is
+// placed in to the full nested <DBSubnetGroup> wire shape RDS embeds on a
+// DBInstance. It returns nil when the instance has no subnet group, the driver
+// does not model subnet groups, or the named group no longer exists.
+func (h *Handler) resolveInstanceSubnetGroupXML(ctx context.Context, inst *rdsdriver.Instance) *dbSubnetGroupXML {
+	if inst.SubnetGroupName == "" {
+		return nil
+	}
+
+	store, ok := h.subnetGroups()
+	if !ok {
+		return nil
+	}
+
+	groups, err := store.DescribeDBSubnetGroups(ctx, []string{inst.SubnetGroupName})
+	if err != nil || len(groups) == 0 {
+		return nil
+	}
+
+	x := toSubnetGroupXML(&groups[0])
+
+	return &x
 }
 
 func toSubnetGroupXML(sg *rdsdriver.SubnetGroup) dbSubnetGroupXML {

--- a/server/aws/rds/xml.go
+++ b/server/aws/rds/xml.go
@@ -94,7 +94,7 @@ type dbInstanceXML struct {
 	PubliclyAccessible                    bool                       `xml:"PubliclyAccessible"`
 	AvailabilityZone                      string                     `xml:"AvailabilityZone,omitempty"`
 	DBClusterIdentifier                   string                     `xml:"DBClusterIdentifier,omitempty"`
-	DBSubnetGroupName                     string                     `xml:"DBSubnetGroupName,omitempty"`
+	DBSubnetGroup                         *dbSubnetGroupXML          `xml:"DBSubnetGroup,omitempty"`
 	InstanceCreateTime                    string                     `xml:"InstanceCreateTime,omitempty"`
 	DbiResourceID                         string                     `xml:"DbiResourceId,omitempty"`
 	BackupRetentionPeriod                 int                        `xml:"BackupRetentionPeriod,omitempty"`
@@ -374,8 +374,14 @@ type describeDBClusterSnapshotsResponse struct {
 }
 
 // toInstanceXML converts a driver Instance to its XML representation.
-func toInstanceXML(inst *rdsdriver.Instance) dbInstanceXML {
-	return dbInstanceXML{
+//
+// resolvedSubnetGroup, when non-nil, is the fully resolved DB subnet group the
+// instance is placed in. Real RDS reports the association as a nested complex
+// <DBSubnetGroup> element (name, description, VpcId, status, Subnets) — not a
+// scalar <DBSubnetGroupName> — so the aws-sdk-go-v2 DBInstance.DBSubnetGroup
+// field (and Terraform's db_subnet_group_name off it) has something to bind.
+func toInstanceXML(inst *rdsdriver.Instance, resolvedSubnetGroup *dbSubnetGroupXML) dbInstanceXML {
+	x := dbInstanceXML{
 		DBInstanceIdentifier: inst.ID,
 		DBInstanceArn:        inst.ARN,
 		Engine:               inst.Engine,
@@ -395,7 +401,7 @@ func toInstanceXML(inst *rdsdriver.Instance) dbInstanceXML {
 		PubliclyAccessible:                    inst.PubliclyAccessible,
 		AvailabilityZone:                      inst.AvailabilityZone,
 		DBClusterIdentifier:                   inst.ClusterID,
-		DBSubnetGroupName:                     inst.SubnetGroupName,
+		DBSubnetGroup:                         resolvedSubnetGroup,
 		InstanceCreateTime:                    inst.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
 		DbiResourceID:                         inst.DbiResourceID,
 		BackupRetentionPeriod:                 inst.BackupRetentionPeriod,
@@ -412,6 +418,8 @@ func toInstanceXML(inst *rdsdriver.Instance) dbInstanceXML {
 		ReadReplicaSourceDBInstanceIdentifier: inst.ReadReplicaSource,
 		ReadReplicaDBInstanceIdentifiers:      toReadReplicaIDsXML(inst.ReadReplicaTargets),
 	}
+
+	return x
 }
 
 func toDBParameterGroupsXML(name string) *dbParameterGroupsXML {


### PR DESCRIPTION
## Summary

A DB instance placed in a DB subnet group did not report that association back in a shape the AWS SDK can read.

The RDS `DBInstance` serializer emitted the association as a **scalar** `<DBSubnetGroupName>` element. The real RDS `DBInstance` shape has no such scalar field — it carries a nested complex `<DBSubnetGroup>` element (`DBSubnetGroupName`, `DBSubnetGroupDescription`, `VpcId`, `SubnetGroupStatus`, `Subnets[]`), which aws-sdk-go-v2 binds to `DBInstance.DBSubnetGroup`. With nothing to bind the scalar to, the SDK silently dropped it: `DescribeDBInstances[0].DBSubnetGroup == nil`, so a caller (or Terraform reading `db_subnet_group_name` off the instance) lost the association it had just set.

## What changed

- `server/aws/rds/xml.go`: replaced the scalar `DBSubnetGroupName` field on `dbInstanceXML` with a nested `DBSubnetGroup *dbSubnetGroupXML` element, matching the real DBInstance shape.
- `server/aws/rds/subnet_group.go`: added `resolveInstanceSubnetGroupXML`, which resolves the instance's subnet group from the store into the full nested element (VpcId + Subnets), reusing the existing `toSubnetGroupXML` builder. Returns nil when the instance has no group, the driver doesn't model subnet groups, or the group is gone.
- All instance serialization call sites (create/describe/modify/delete/start/stop/reboot/restore/read-replica) now pass the resolved subnet group.

## Test

Added `instance_subnet_group_association_sdk_roundtrip_test.go`: drives the real aws-sdk-go-v2 RDS + EC2 clients — create subnets, create the subnet group, create a DB instance in it, then asserts `DBInstance.DBSubnetGroup` is non-nil and carries the group name, the derived VpcId, and both subnets on both CreateDBInstance and DescribeDBInstances.