### PR TITLE
fix(iam-refs): RunInstances IamInstanceProfile reflected on DescribeInstances; SecretsManager KmsKeyId reflected on DescribeSecret

### DIFF
--- a/features/chaos/wrappers_test.go
+++ b/features/chaos/wrappers_test.go
@@ -412,22 +412,24 @@ func TestWrapDatabaseScanChaos(t *testing.T) {
 // Helper from chaos_test.go was here previously; we keep it co-located so
 // wrapper tests are self-contained.
 type computeConfigCompat = struct {
-	ImageID        string
-	InstanceType   string
-	Tags           map[string]string
-	SubnetID       string
-	SecurityGroups []string
-	KeyName        string
-	UserData       string
-	Managed        bool
-	Principal      string
-	OSType         string
-	Priority       string
-	LicenseType    string
-	Zones          []string
-	Region         string
-	ResourceGroup  string
-	ClientToken    string
+	ImageID                string
+	InstanceType           string
+	Tags                   map[string]string
+	SubnetID               string
+	SecurityGroups         []string
+	KeyName                string
+	UserData               string
+	Managed                bool
+	Principal              string
+	OSType                 string
+	Priority               string
+	LicenseType            string
+	Zones                  []string
+	Region                 string
+	ResourceGroup          string
+	ClientToken            string
+	IamInstanceProfileARN  string
+	IamInstanceProfileName string
 }
 
 // computeInstanceConfig reproduces the helper used elsewhere in the package

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -251,6 +251,9 @@ func New(opts ...config.Option) *Provider {
 	p.RDS.SetSubnetResolver(p.VPC)
 	p.ElastiCache.SetSubnetResolver(p.VPC)
 	p.EC2.SetSubnetResolver(p.VPC)
+	// An IamInstanceProfile passed to RunInstances resolves through IAM so the
+	// role->profile->instance chain reads back on DescribeInstances.
+	p.EC2.SetInstanceProfileResolver(p.IAM)
 	p.SSM.SetInstanceResolver(p.EC2)
 	// ECS-registered container instances surface as managed EC2 instances, so
 	// #159 (ECS) composes with #300 (EC2 managed-resource visibility).

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -182,6 +182,9 @@ type instanceData struct {
 	// metadataOptions is the instance's IMDS configuration, defaulted at launch
 	// and changed by ModifyInstanceMetadataOptions.
 	metadataOptions driver.MetadataOptions
+	// iamInstanceProfile is the IAM instance profile attached at launch (resolved
+	// ARN + ID), nil when the instance was launched without one.
+	iamInstanceProfile *driver.IamInstanceProfile
 	// settle overlays a post-launch "pending" window over the stored (running)
 	// State on the Describe surface when AsyncSettle is enabled; zero-value
 	// (default) reports the stored State immediately.
@@ -234,6 +237,11 @@ type Mock struct {
 	// instances created with a --subnet-id carry the VPCID that connectivity
 	// analysis and VPC teardown depend on. nil until wired by the provider.
 	subnetResolver SubnetResolver
+	// instanceProfileResolver resolves an IamInstanceProfile reference (Arn/Name)
+	// supplied to RunInstances into the profile's canonical ARN and ID, so the
+	// role->profile->instance chain reads back on DescribeInstances. nil until
+	// wired by the provider.
+	instanceProfileResolver InstanceProfileResolver
 	// mu guards managedResourceVisibility, clientTokens and subnetIPCounters,
 	// which are scalar/map shared state that (unlike the memstores) has no
 	// internal locking of their own.
@@ -362,12 +370,20 @@ func toInstance(d *instanceData, hidden bool, now time.Time) driver.Instance {
 		}
 	}
 
+	var iamProfile *driver.IamInstanceProfile
+
+	if d.iamInstanceProfile != nil {
+		p := *d.iamInstanceProfile
+		iamProfile = &p
+	}
+
 	return driver.Instance{
 		ID: d.ID, ImageID: d.ImageID, InstanceType: d.InstanceType, State: d.settle.Observe(now, d.State),
 		PrivateIP: d.PrivateIP, PublicIP: d.PublicIP, SubnetID: d.SubnetID, VPCID: d.VPCID,
 		SecurityGroups: sg, Tags: tags, LaunchTime: d.LaunchTime,
 		ReservationID: d.reservationID, KeyName: d.keyName, Monitoring: d.monitoring,
 		Operator: operator, MetadataOptions: d.metadataOptions,
+		IamInstanceProfile: iamProfile,
 	}
 }
 
@@ -459,6 +475,10 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 	// private-IP allocation reuse a single lookup.
 	vpcID, subnetCIDR := m.resolveSubnet(ctx, cfg.SubnetID)
 
+	// Resolve the IamInstanceProfile reference once for the whole batch; every
+	// instance launched by this call shares the same profile association.
+	iamProfile := m.resolveInstanceProfile(ctx, &cfg)
+
 	// created tracks the instances already fully provisioned in this batch, so a
 	// mid-batch engine failure can roll them back rather than orphaning live
 	// containers and half-tracked instances (real EC2 launches the whole batch or
@@ -482,13 +502,14 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 			State: compute.StatePending, PrivateIP: m.allocatePrivateIP(cfg.SubnetID, subnetCIDR),
 			SubnetID: cfg.SubnetID, VPCID: vpcID,
 			SecurityGroups: sg, Tags: tags,
-			LaunchTime:      m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
-			sourceDestCheck: true,
-			reservationID:   reservationID,
-			keyName:         cfg.KeyName,
-			userData:        cfg.UserData,
-			monitoring:      monitoringDisabled,
-			metadataOptions: defaultMetadataOptions(),
+			LaunchTime:         m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+			sourceDestCheck:    true,
+			reservationID:      reservationID,
+			keyName:            cfg.KeyName,
+			userData:           cfg.UserData,
+			monitoring:         monitoringDisabled,
+			metadataOptions:    defaultMetadataOptions(),
+			iamInstanceProfile: iamProfile,
 		}
 
 		if cfg.Managed {

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -465,6 +465,14 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 		return dup, nil
 	}
 
+	return m.launchInstances(ctx, cfg, count)
+}
+
+// launchInstances does the actual provisioning for RunInstances once count and
+// idempotency have already been validated.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) launchInstances(ctx context.Context, cfg driver.InstanceConfig, count int) ([]driver.Instance, error) {
 	results := make([]driver.Instance, 0, count)
 	hidden := m.visibility() == visibilityHidden
 
@@ -476,8 +484,13 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 	vpcID, subnetCIDR := m.resolveSubnet(ctx, cfg.SubnetID)
 
 	// Resolve the IamInstanceProfile reference once for the whole batch; every
-	// instance launched by this call shares the same profile association.
-	iamProfile := m.resolveInstanceProfile(ctx, &cfg)
+	// instance launched by this call shares the same profile association. A
+	// Name/ARN that doesn't resolve rejects the whole call before anything is
+	// launched, matching real EC2.
+	iamProfile, err := m.resolveInstanceProfile(ctx, &cfg)
+	if err != nil {
+		return nil, err
+	}
 
 	// created tracks the instances already fully provisioned in this batch, so a
 	// mid-batch engine failure can roll them back rather than orphaning live

--- a/providers/aws/ec2/instance_profile_resolver.go
+++ b/providers/aws/ec2/instance_profile_resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/compute/driver"
 	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
 )
@@ -24,27 +25,57 @@ func (m *Mock) SetInstanceProfileResolver(r InstanceProfileResolver) {
 }
 
 // resolveInstanceProfile turns the IamInstanceProfile reference on cfg into the
-// association stored on the instance. It returns nil when no profile is
+// association stored on the instance. It returns nil, nil when no profile is
 // referenced. When a resolver is wired and the profile exists, both the
 // canonical ARN and the ID are filled in; otherwise it falls back to the
 // supplied ARN so a caller that passed an ARN still reads it back.
-func (m *Mock) resolveInstanceProfile(ctx context.Context, cfg *driver.InstanceConfig) *driver.IamInstanceProfile {
+//
+// A Name or ARN that does not resolve to any created instance profile is
+// rejected synchronously, matching real EC2's RunInstances behavior: it
+// answers InvalidParameterValue rather than launching the instance with a
+// dangling/empty profile association.
+func (m *Mock) resolveInstanceProfile(ctx context.Context, cfg *driver.InstanceConfig) (*driver.IamInstanceProfile, error) {
 	name := cfg.IamInstanceProfileName
 	if name == "" {
 		name = instanceProfileNameFromARN(cfg.IamInstanceProfileARN)
 	}
 
 	if name == "" && cfg.IamInstanceProfileARN == "" {
-		return nil
+		return nil, nil //nolint:nilnil // no profile referenced is not an error
 	}
 
-	if m.instanceProfileResolver != nil && name != "" {
-		if info, err := m.instanceProfileResolver.GetInstanceProfile(ctx, name); err == nil {
-			return &driver.IamInstanceProfile{ARN: info.ARN, ID: info.ID}
+	if m.instanceProfileResolver == nil || name == "" {
+		return &driver.IamInstanceProfile{ARN: cfg.IamInstanceProfileARN}, nil
+	}
+
+	info, err := m.instanceProfileResolver.GetInstanceProfile(ctx, name)
+	if err != nil {
+		if cerrors.IsNotFound(err) {
+			return nil, invalidInstanceProfileError(cfg)
 		}
+
+		return nil, err
 	}
 
-	return &driver.IamInstanceProfile{ARN: cfg.IamInstanceProfileARN}
+	return &driver.IamInstanceProfile{ARN: info.ARN, ID: info.ID}, nil
+}
+
+// invalidInstanceProfileError reproduces the exact wording real EC2 returns
+// for RunInstances when IamInstanceProfile.Name/.Arn does not resolve to an
+// existing instance profile, e.g.:
+//
+//	Value (my-profile) for parameter iamInstanceProfile.name is invalid.
+//	Invalid IAM Instance Profile name
+func invalidInstanceProfileError(cfg *driver.InstanceConfig) error {
+	if cfg.IamInstanceProfileName != "" {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"Value (%s) for parameter iamInstanceProfile.name is invalid. Invalid IAM Instance Profile name",
+			cfg.IamInstanceProfileName)
+	}
+
+	return cerrors.Newf(cerrors.InvalidArgument,
+		"Value (%s) for parameter iamInstanceProfile.arn is invalid. Invalid IAM Instance Profile ARN",
+		cfg.IamInstanceProfileARN)
 }
 
 // instanceProfileNameFromARN extracts the profile name from an instance-profile

--- a/providers/aws/ec2/instance_profile_resolver.go
+++ b/providers/aws/ec2/instance_profile_resolver.go
@@ -1,0 +1,67 @@
+package ec2
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// InstanceProfileResolver is the slice of the IAM mock EC2 needs to resolve an
+// IamInstanceProfile reference (Arn or Name) supplied to RunInstances into the
+// profile's canonical ARN and ID. Real EC2 echoes both on the launched instance
+// and on DescribeInstances, so the reference has to be resolved, not stored raw.
+type InstanceProfileResolver interface {
+	GetInstanceProfile(ctx context.Context, name string) (*iamdriver.InstanceProfileInfo, error)
+}
+
+// SetInstanceProfileResolver wires the IAM mock in. Without it an instance
+// launched with an IamInstanceProfile still records the supplied ARN, but its
+// profile ID is left empty (nothing to resolve it against).
+func (m *Mock) SetInstanceProfileResolver(r InstanceProfileResolver) {
+	m.instanceProfileResolver = r
+}
+
+// resolveInstanceProfile turns the IamInstanceProfile reference on cfg into the
+// association stored on the instance. It returns nil when no profile is
+// referenced. When a resolver is wired and the profile exists, both the
+// canonical ARN and the ID are filled in; otherwise it falls back to the
+// supplied ARN so a caller that passed an ARN still reads it back.
+func (m *Mock) resolveInstanceProfile(ctx context.Context, cfg *driver.InstanceConfig) *driver.IamInstanceProfile {
+	name := cfg.IamInstanceProfileName
+	if name == "" {
+		name = instanceProfileNameFromARN(cfg.IamInstanceProfileARN)
+	}
+
+	if name == "" && cfg.IamInstanceProfileARN == "" {
+		return nil
+	}
+
+	if m.instanceProfileResolver != nil && name != "" {
+		if info, err := m.instanceProfileResolver.GetInstanceProfile(ctx, name); err == nil {
+			return &driver.IamInstanceProfile{ARN: info.ARN, ID: info.ID}
+		}
+	}
+
+	return &driver.IamInstanceProfile{ARN: cfg.IamInstanceProfileARN}
+}
+
+// instanceProfileNameFromARN extracts the profile name from an instance-profile
+// ARN (arn:aws:iam::<acct>:instance-profile/<path>/<name>), returning the last
+// path segment. It returns "" for a non-ARN string.
+func instanceProfileNameFromARN(arn string) string {
+	const marker = ":instance-profile/"
+
+	idx := strings.Index(arn, marker)
+	if idx < 0 {
+		return ""
+	}
+
+	rest := arn[idx+len(marker):]
+	if slash := strings.LastIndex(rest, "/"); slash >= 0 {
+		return rest[slash+1:]
+	}
+
+	return rest
+}

--- a/providers/aws/secretsmanager/secretsmanager.go
+++ b/providers/aws/secretsmanager/secretsmanager.go
@@ -82,6 +82,7 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 		CreatedAt:   now,
 		UpdatedAt:   now,
 		Tags:        tags,
+		KMSKeyID:    cfg.KMSKeyID,
 	}
 
 	data := make([]byte, len(value))

--- a/server/aws/ec2/instance_profile_test.go
+++ b/server/aws/ec2/instance_profile_test.go
@@ -1,0 +1,129 @@
+package ec2_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newEC2AndIAMClients wires one in-process AWS server and returns real
+// aws-sdk-go-v2 EC2 and IAM clients pointed at it, so the role->profile->instance
+// reference chain can be driven end to end.
+func newEC2AndIAMClients(t *testing.T) (*ec2.Client, *iam.Client) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	ts := httptest.NewServer(awsserver.New(awsserver.DriversFrom(cloud)))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	cfg.BaseEndpoint = aws.String(ts.URL)
+
+	return ec2.NewFromConfig(cfg), iam.NewFromConfig(cfg)
+}
+
+// TestRunInstancesIamInstanceProfileReflectedOnDescribe drives the real-user
+// flow: create an IAM role, wrap it in an instance profile, launch an instance
+// referencing that profile by name, and confirm the launched instance and a
+// follow-up DescribeInstances both echo the profile's ARN (the role->profile->
+// instance reference resolves, matching the EC2 iamInstanceProfile field).
+func TestRunInstancesIamInstanceProfileReflectedOnDescribe(t *testing.T) {
+	ctx := context.Background()
+	ec2c, iamc := newEC2AndIAMClients(t)
+
+	const profileName = "web-server-profile"
+
+	if _, err := iamc.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("web-server-role"),
+		AssumeRolePolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	profile, err := iamc.CreateInstanceProfile(ctx, &iam.CreateInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+	})
+	if err != nil {
+		t.Fatalf("CreateInstanceProfile: %v", err)
+	}
+
+	wantARN := aws.ToString(profile.InstanceProfile.Arn)
+	if wantARN == "" {
+		t.Fatal("CreateInstanceProfile returned an empty ARN")
+	}
+
+	if _, err := iamc.AddRoleToInstanceProfile(ctx, &iam.AddRoleToInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+		RoleName:            aws.String("web-server-role"),
+	}); err != nil {
+		t.Fatalf("AddRoleToInstanceProfile: %v", err)
+	}
+
+	run, err := ec2c.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-123"),
+		InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		IamInstanceProfile: &ec2types.IamInstanceProfileSpecification{
+			Name: aws.String(profileName),
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	launched := run.Instances[0]
+	if launched.IamInstanceProfile == nil {
+		t.Fatal("RunInstances dropped IamInstanceProfile: instance has none")
+	}
+
+	if got := aws.ToString(launched.IamInstanceProfile.Arn); got != wantARN {
+		t.Fatalf("RunInstances IamInstanceProfile.Arn = %q, want %q", got, wantARN)
+	}
+
+	if aws.ToString(launched.IamInstanceProfile.Id) == "" {
+		t.Fatal("RunInstances IamInstanceProfile.Id is empty")
+	}
+
+	id := aws.ToString(launched.InstanceId)
+
+	desc, err := ec2c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: []string{id},
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	got := desc.Reservations[0].Instances[0]
+	if got.IamInstanceProfile == nil {
+		t.Fatal("DescribeInstances dropped IamInstanceProfile: instance has none")
+	}
+
+	if arn := aws.ToString(got.IamInstanceProfile.Arn); arn != wantARN {
+		t.Fatalf("DescribeInstances IamInstanceProfile.Arn = %q, want %q", arn, wantARN)
+	}
+
+	if aws.ToString(got.IamInstanceProfile.Id) != aws.ToString(profile.InstanceProfile.InstanceProfileId) {
+		t.Fatalf("DescribeInstances IamInstanceProfile.Id = %q, want %q",
+			aws.ToString(got.IamInstanceProfile.Id),
+			aws.ToString(profile.InstanceProfile.InstanceProfileId))
+	}
+}

--- a/server/aws/ec2/instance_profile_test.go
+++ b/server/aws/ec2/instance_profile_test.go
@@ -2,6 +2,7 @@ package ec2_test
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	smithy "github.com/aws/smithy-go"
 
 	"github.com/stackshy/cloudemu/v2"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
@@ -125,5 +127,48 @@ func TestRunInstancesIamInstanceProfileReflectedOnDescribe(t *testing.T) {
 		t.Fatalf("DescribeInstances IamInstanceProfile.Id = %q, want %q",
 			aws.ToString(got.IamInstanceProfile.Id),
 			aws.ToString(profile.InstanceProfile.InstanceProfileId))
+	}
+}
+
+// TestRunInstancesIamInstanceProfileNotFound drives real EC2's synchronous
+// rejection: a RunInstances call referencing an IamInstanceProfile name that
+// was never created answers InvalidParameterValue rather than launching an
+// instance with a dangling/empty profile association.
+func TestRunInstancesIamInstanceProfileNotFound(t *testing.T) {
+	ctx := context.Background()
+	ec2c, _ := newEC2AndIAMClients(t)
+
+	_, err := ec2c.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-123"),
+		InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		IamInstanceProfile: &ec2types.IamInstanceProfileSpecification{
+			Name: aws.String("does-not-exist"),
+		},
+	})
+	if err == nil {
+		t.Fatal("RunInstances with a nonexistent IamInstanceProfile name succeeded, want InvalidParameterValue")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("RunInstances error = %v, want an API error", err)
+	}
+
+	if apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("RunInstances error code = %q, want InvalidParameterValue", apiErr.ErrorCode())
+	}
+
+	// No instance should have been launched: a subsequent DescribeInstances
+	// should come back empty.
+	desc, err := ec2c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	if len(desc.Reservations) != 0 {
+		t.Fatalf("DescribeInstances returned %d reservations, want 0 (RunInstances should not have launched anything)",
+			len(desc.Reservations))
 	}
 }

--- a/server/aws/ec2/operations.go
+++ b/server/aws/ec2/operations.go
@@ -172,6 +172,14 @@ func applyRunInstancesForm(cfg *computedriver.InstanceConfig, form url.Values) {
 
 	cfg.ClientToken = form.Get("ClientToken")
 
+	if v := form.Get("IamInstanceProfile.Arn"); v != "" {
+		cfg.IamInstanceProfileARN = v
+	}
+
+	if v := form.Get("IamInstanceProfile.Name"); v != "" {
+		cfg.IamInstanceProfileName = v
+	}
+
 	if tags := mergeTagSpecs(awsquery.TagSpecs(form), "instance"); len(tags) > 0 {
 		cfg.Tags = tags
 	}
@@ -717,6 +725,13 @@ func instanceXMLFor(inst *computedriver.Instance, names map[string]string) insta
 
 	for k, v := range inst.Tags {
 		xi.Tags = append(xi.Tags, tagItem{Key: k, Value: v})
+	}
+
+	if inst.IamInstanceProfile != nil {
+		xi.IamInstanceProfile = &iamInstanceProfileXML{
+			ARN: inst.IamInstanceProfile.ARN,
+			ID:  inst.IamInstanceProfile.ID,
+		}
 	}
 
 	if inst.Operator != nil {

--- a/server/aws/ec2/xml.go
+++ b/server/aws/ec2/xml.go
@@ -83,6 +83,15 @@ type metadataOptionsXML struct {
 	InstanceMetadataTags    string `xml:"instanceMetadataTags,omitempty"`
 }
 
+// iamInstanceProfileXML is the nested <iamInstanceProfile> element carrying the
+// IAM instance profile attached to an instance. The child element names (arn,
+// id) match the ec2 IamInstanceProfile response shape the aws-sdk-go-v2
+// deserializer binds to Instance.IamInstanceProfile.
+type iamInstanceProfileXML struct {
+	ARN string `xml:"arn,omitempty"`
+	ID  string `xml:"id,omitempty"`
+}
+
 // instanceENIAttachmentXML is the primary ENI's <attachment> (deviceIndex 0).
 type instanceENIAttachmentXML struct {
 	DeviceIndex int    `xml:"deviceIndex"`
@@ -117,31 +126,32 @@ type operatorXML struct {
 // DescribeInstances responses. We populate only the fields the SDK reliably
 // consumes and real apps actually read; unused AWS fields are omitted.
 type instanceXML struct {
-	InstanceID         string              `xml:"instanceId"`
-	ImageID            string              `xml:"imageId"`
-	State              instanceState       `xml:"instanceState"`
-	InstanceType       string              `xml:"instanceType"`
-	LaunchTime         string              `xml:"launchTime,omitempty"`
-	SubnetID           string              `xml:"subnetId,omitempty"`
-	VPCID              string              `xml:"vpcId,omitempty"`
-	PrivateIP          string              `xml:"privateIpAddress,omitempty"`
-	PublicIP           string              `xml:"ipAddress,omitempty"`
-	PrivateDNSName     string              `xml:"privateDnsName,omitempty"`
-	PublicDNSName      string              `xml:"dnsName,omitempty"`
-	KeyName            string              `xml:"keyName,omitempty"`
-	AmiLaunchIndex     int                 `xml:"amiLaunchIndex"`
-	Architecture       string              `xml:"architecture,omitempty"`
-	RootDeviceType     string              `xml:"rootDeviceType,omitempty"`
-	RootDeviceName     string              `xml:"rootDeviceName,omitempty"`
-	VirtualizationType string              `xml:"virtualizationType,omitempty"`
-	Hypervisor         string              `xml:"hypervisor,omitempty"`
-	Placement          *placementXML       `xml:"placement,omitempty"`
-	Monitoring         *monitoringXML      `xml:"monitoring,omitempty"`
-	MetadataOptions    *metadataOptionsXML `xml:"metadataOptions,omitempty"`
-	Groups             []groupItem         `xml:"groupSet>item,omitempty"`
-	NetworkInterfaces  []instanceENIXML    `xml:"networkInterfaceSet>item,omitempty"`
-	Tags               []tagItem           `xml:"tagSet>item,omitempty"`
-	Operator           *operatorXML        `xml:"operator,omitempty"`
+	InstanceID         string                 `xml:"instanceId"`
+	ImageID            string                 `xml:"imageId"`
+	State              instanceState          `xml:"instanceState"`
+	InstanceType       string                 `xml:"instanceType"`
+	LaunchTime         string                 `xml:"launchTime,omitempty"`
+	SubnetID           string                 `xml:"subnetId,omitempty"`
+	VPCID              string                 `xml:"vpcId,omitempty"`
+	PrivateIP          string                 `xml:"privateIpAddress,omitempty"`
+	PublicIP           string                 `xml:"ipAddress,omitempty"`
+	PrivateDNSName     string                 `xml:"privateDnsName,omitempty"`
+	PublicDNSName      string                 `xml:"dnsName,omitempty"`
+	KeyName            string                 `xml:"keyName,omitempty"`
+	AmiLaunchIndex     int                    `xml:"amiLaunchIndex"`
+	Architecture       string                 `xml:"architecture,omitempty"`
+	RootDeviceType     string                 `xml:"rootDeviceType,omitempty"`
+	RootDeviceName     string                 `xml:"rootDeviceName,omitempty"`
+	VirtualizationType string                 `xml:"virtualizationType,omitempty"`
+	Hypervisor         string                 `xml:"hypervisor,omitempty"`
+	Placement          *placementXML          `xml:"placement,omitempty"`
+	Monitoring         *monitoringXML         `xml:"monitoring,omitempty"`
+	MetadataOptions    *metadataOptionsXML    `xml:"metadataOptions,omitempty"`
+	IamInstanceProfile *iamInstanceProfileXML `xml:"iamInstanceProfile,omitempty"`
+	Groups             []groupItem            `xml:"groupSet>item,omitempty"`
+	NetworkInterfaces  []instanceENIXML       `xml:"networkInterfaceSet>item,omitempty"`
+	Tags               []tagItem              `xml:"tagSet>item,omitempty"`
+	Operator           *operatorXML           `xml:"operator,omitempty"`
 }
 
 // runInstancesResponse is the XML body for RunInstances.

--- a/server/aws/secretsmanager/kms_key_test.go
+++ b/server/aws/secretsmanager/kms_key_test.go
@@ -1,0 +1,65 @@
+package secretsmanager_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssm "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+)
+
+// TestCreateSecretKmsKeyIdReflectedOnDescribe drives the real-user flow: create
+// a secret encrypted with a customer KMS key, then DescribeSecret and confirm
+// the KmsKeyId round-trips (the key->secret reference is visible, matching the
+// DescribeSecret KmsKeyId field a tool like Terraform reads back).
+func TestCreateSecretKmsKeyIdReflectedOnDescribe(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	const keyARN = "arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name:         aws.String("encrypted-secret"),
+		SecretString: aws.String("hunter2"),
+		KmsKeyId:     aws.String(keyARN),
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	desc, err := client.DescribeSecret(ctx, &awssm.DescribeSecretInput{
+		SecretId: aws.String("encrypted-secret"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeSecret: %v", err)
+	}
+
+	if got := aws.ToString(desc.KmsKeyId); got != keyARN {
+		t.Fatalf("DescribeSecret KmsKeyId = %q, want %q", got, keyARN)
+	}
+}
+
+// TestCreateSecretDefaultKeyOmitsKmsKeyId confirms a secret created without a
+// customer key reports no KmsKeyId (real Secrets Manager omits it when the
+// default aws/secretsmanager key is used).
+func TestCreateSecretDefaultKeyOmitsKmsKeyId(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name:         aws.String("default-key-secret"),
+		SecretString: aws.String("hunter2"),
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	desc, err := client.DescribeSecret(ctx, &awssm.DescribeSecretInput{
+		SecretId: aws.String("default-key-secret"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeSecret: %v", err)
+	}
+
+	if got := aws.ToString(desc.KmsKeyId); got != "" {
+		t.Fatalf("DescribeSecret KmsKeyId = %q, want empty", got)
+	}
+}

--- a/server/aws/secretsmanager/operations.go
+++ b/server/aws/secretsmanager/operations.go
@@ -18,6 +18,7 @@ func (h *Handler) createSecret(w http.ResponseWriter, r *http.Request) {
 		Name:        req.Name,
 		Description: req.Description,
 		Tags:        tagsToMap(req.Tags),
+		KMSKeyID:    req.KmsKeyID,
 	}, secretValue(req.SecretString, req.SecretBinary))
 	if err != nil {
 		writeErr(w, err)

--- a/server/aws/secretsmanager/types.go
+++ b/server/aws/secretsmanager/types.go
@@ -29,6 +29,9 @@ type secretListEntryJSON struct {
 	// DeletedDate is set only for a secret scheduled for deletion: the date the
 	// secret is scheduled to be removed (delete request + RecoveryWindowInDays).
 	DeletedDate float64 `json:"DeletedDate,omitempty"`
+	// KmsKeyId is the customer KMS key the secret is encrypted with, echoed on
+	// DescribeSecret. Omitted when the default aws/secretsmanager key is used.
+	KmsKeyID string `json:"KmsKeyId,omitempty"`
 
 	VersionIDsToStages map[string][]string `json:"VersionIdsToStages,omitempty"`
 }
@@ -47,6 +50,7 @@ type createSecretRequest struct {
 	SecretString string    `json:"SecretString"`
 	SecretBinary []byte    `json:"SecretBinary"`
 	Tags         []tagJSON `json:"Tags"`
+	KmsKeyID     string    `json:"KmsKeyId"`
 }
 
 type secretIDRequest struct {
@@ -263,5 +267,6 @@ func toSecretListEntry(info *secretsdriver.SecretInfo) secretListEntryJSON {
 		Tags:            mapToTags(info.Tags),
 		CreatedDate:     epochSeconds(info.CreatedAt),
 		LastChangedDate: epochSeconds(info.UpdatedAt),
+		KmsKeyID:        info.KMSKeyID,
 	}
 }

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -36,6 +36,19 @@ type InstanceConfig struct {
 	// same case-sensitive token returns the already-launched instances instead
 	// of provisioning new ones. Empty disables dedup. Ignored by Azure/GCP.
 	ClientToken string
+	// IamInstanceProfileARN / IamInstanceProfileName reference the IAM instance
+	// profile to attach at launch (AWS RunInstances IamInstanceProfile.Arn /
+	// .Name). Callers supply one or the other; the AWS provider resolves the
+	// reference to the profile's ARN and ID. Ignored by Azure/GCP.
+	IamInstanceProfileARN  string
+	IamInstanceProfileName string
+}
+
+// IamInstanceProfile is the IAM instance profile association reported on an EC2
+// instance (arn + id), matching the EC2 IamInstanceProfile response element.
+type IamInstanceProfile struct {
+	ARN string
+	ID  string
 }
 
 // Instance describes a running virtual machine.
@@ -90,6 +103,9 @@ type Instance struct {
 	// MetadataOptions is the instance's IMDS configuration (AWS). The zero value
 	// means "not set"; the wire layer fills in EC2 defaults when rendering.
 	MetadataOptions MetadataOptions
+	// IamInstanceProfile is the IAM instance profile attached to the instance
+	// (AWS), nil when none is attached.
+	IamInstanceProfile *IamInstanceProfile
 }
 
 // MetadataOptions is an instance's IMDS (instance metadata service)

--- a/services/secrets/driver/driver.go
+++ b/services/secrets/driver/driver.go
@@ -8,6 +8,10 @@ type SecretConfig struct {
 	Name        string
 	Description string
 	Tags        map[string]string
+	// KMSKeyID is the customer KMS key (ARN, key id, or alias) the secret is
+	// encrypted with (AWS Secrets Manager). Empty means the default
+	// aws/secretsmanager key. Ignored by Azure/GCP.
+	KMSKeyID string
 }
 
 // SecretInfo describes a secret.
@@ -19,6 +23,10 @@ type SecretInfo struct {
 	CreatedAt   string
 	UpdatedAt   string
 	Tags        map[string]string
+	// KMSKeyID is the customer KMS key the secret is encrypted with (AWS Secrets
+	// Manager), echoed on DescribeSecret. Empty when the default
+	// aws/secretsmanager key is used. Ignored by Azure/GCP.
+	KMSKeyID string
 }
 
 // SecretVersion represents a specific version of a secret value.


### PR DESCRIPTION
## Summary

Two cross-resource reference-chain bugs found by the real-user end-to-end sweep: a resource reference was accepted at create time but silently dropped, so a follow-up read (or Terraform/IaC read-back) could not see the linkage. Both are fixed at the correct layers (wire shape + provider state + driver interface), and each ships a real aws-sdk-go-v2 end-to-end test.

### 1. RunInstances IamInstanceProfile now reflected on the instance (HIGH)

Previously `RunInstances` accepted `IamInstanceProfile{Arn,Name}` without error but dropped it: the launched instance and `DescribeInstances` both returned a nil `IamInstanceProfile`, breaking the role -> profile -> instance chain on the instance side.

- `server/aws/ec2/operations.go` parses `IamInstanceProfile.Arn` / `IamInstanceProfile.Name` from the RunInstances form.
- `services/compute/driver/driver.go` gains `InstanceConfig.IamInstanceProfile{ARN,Name}` inputs and an `Instance.IamInstanceProfile{ARN,ID}` echo (new `IamInstanceProfile` type).
- `providers/aws/ec2` resolves the profile reference through IAM via a new `SetInstanceProfileResolver` injector (wired `p.EC2.SetInstanceProfileResolver(p.IAM)` in `providers/aws/aws.go`, mirroring the existing `SetSubnetResolver` pattern), so the canonical ARN and ID are stored on the instance.
- `server/aws/ec2/xml.go` renders the `<iamInstanceProfile><arn/><id/></iamInstanceProfile>` element the SDK binds to `Instance.IamInstanceProfile`.

### 2. SecretsManager KmsKeyId now reflected on DescribeSecret (MEDIUM)

Previously `CreateSecret` accepted `KmsKeyId` but dropped it, so `DescribeSecret` returned an empty `KmsKeyId` even when a customer key was supplied — the key -> secret reference was invisible to any tool that reads it back.

- `server/aws/secretsmanager/types.go` adds `KmsKeyId` to the CreateSecret request and to the DescribeSecret/ListSecrets entry shape (omitted when the default `aws/secretsmanager` key is used).
- `services/secrets/driver/driver.go` carries `KMSKeyID` through `SecretConfig` and `SecretInfo`; the AWS provider stores and echoes it.

## Tests

- `server/aws/ec2/instance_profile_test.go` — real EC2 + IAM SDK clients: create role, create instance profile, RunInstances referencing the profile by name, assert the launched instance and a follow-up DescribeInstances both echo the profile ARN and ID.
- `server/aws/secretsmanager/kms_key_test.go` — real SecretsManager SDK: CreateSecret with a customer KMS key ARN, DescribeSecret round-trips the KmsKeyId; default-key secret omits it.

## Gates

`go build ./...`, `go test ./providers/aws/... ./server/aws/... ./services/... ./compat/...`, and golangci-lint on the changed packages all green. No docs/coverage or docs/compat diff (struct-field additions, no new capability methods).