### PR TITLE
fix(cloudwatch): alarm state transition fires SNS AlarmAction (delivered to subscribers); Logs PutMetricFilter creates the custom metric that PutLogEvents increments

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -260,6 +260,9 @@ func New(opts ...config.Option) *Provider {
 	p.Redshift.SetMonitoring(p.CloudWatch)
 	p.EKS.SetMonitoring(p.CloudWatch)
 	p.SageMaker.SetMonitoring(p.CloudWatch)
+	// CloudWatch alarm -> SNS: an alarm state transition fires its configured
+	// SNS-topic actions, fanning a notification out to the topic's subscribers.
+	p.CloudWatch.SetSNSPublisher(p.SNS)
 	// SNS -> SQS fan-out: publishes deliver to SQS-protocol subscriptions.
 	p.SNS.SetSQSDeliverer(p.SQS)
 	// EventBridge -> SQS: matched rules deliver events to SQS targets.

--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -3,6 +3,7 @@ package cloudwatch
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -19,6 +20,26 @@ import (
 // Compile-time check that Mock implements driver.Monitoring.
 var _ driver.Monitoring = (*Mock)(nil)
 
+// snsTopicARNPrefix identifies an alarm action that targets an SNS topic. Only
+// these actions are delivered to a notification publisher; other action ARNs
+// (Auto Scaling, EC2, etc.) are recorded but not fired.
+const snsTopicARNPrefix = "arn:aws:sns:"
+
+// Alarm states, matching the CloudWatch StateValue enum.
+const (
+	stateAlarm            = "ALARM"
+	stateOK               = "OK"
+	stateInsufficientData = "INSUFFICIENT_DATA"
+)
+
+// ActionPublisher publishes an alarm-state-change notification to an SNS topic
+// by ARN. It is satisfied by the SNS backend's PublishExternal, mirroring the
+// S3 -> SNS notification wiring, so an alarm transition fans a message out to
+// the topic's subscribers.
+type ActionPublisher interface {
+	PublishExternal(ctx context.Context, topicARN, message string) error
+}
+
 // metricKey uniquely identifies a metric series by namespace, name, and dimensions.
 type metricKey struct {
 	Namespace  string
@@ -33,6 +54,14 @@ type Mock struct {
 	channels *memstore.Store[*driver.NotificationChannelInfo]
 	history  []driver.AlarmHistoryEntry
 	opts     *config.Options
+	sns      ActionPublisher
+}
+
+// SetSNSPublisher wires the SNS backend so an alarm state transition delivers
+// its configured actions (AlarmActions / OKActions / InsufficientDataActions)
+// to the SNS topics they name. Nil (the default) leaves actions un-fired.
+func (m *Mock) SetSNSPublisher(p ActionPublisher) {
+	m.sns = p
 }
 
 type alarmData struct {
@@ -150,21 +179,23 @@ func (m *Mock) evaluateSingleAlarm(alarm *alarmData, namespace, metricName strin
 
 	var newState, reason string
 	if evaluateComparison(stat, alarm.ComparisonOperator, alarm.Threshold) {
-		newState = "ALARM"
+		newState = stateAlarm
 		reason = "Threshold crossed"
 	} else {
-		newState = "OK"
+		newState = stateOK
 		reason = "Threshold not crossed"
 	}
 
-	if alarm.State != newState {
+	oldState := alarm.State
+
+	if oldState != newState {
 		m.mu.Lock()
 		m.history = append(m.history, driver.AlarmHistoryEntry{
 			AlarmName: alarm.Name,
 			Timestamp: now,
-			OldState:  alarm.State,
+			OldState:  oldState,
 			NewState:  newState,
-			Reason:    fmt.Sprintf("Transition from %s to %s: %s", alarm.State, newState, reason),
+			Reason:    fmt.Sprintf("Transition from %s to %s: %s", oldState, newState, reason),
 		})
 		m.mu.Unlock()
 
@@ -173,6 +204,77 @@ func (m *Mock) evaluateSingleAlarm(alarm *alarmData, namespace, metricName strin
 
 	alarm.State = newState
 	alarm.StateReason = reason
+
+	// An alarm invokes its actions only when it changes state — matching real
+	// CloudWatch, which never re-fires actions while the state is steady.
+	if oldState != newState {
+		m.fireAlarmActions(alarm, oldState, newState, now)
+	}
+}
+
+// fireAlarmActions delivers an alarm's state-change actions. Only SNS-topic
+// action ARNs are published (via the wired publisher); the notification carries
+// the alarm's new state so subscribers can react. It is a no-op when no
+// publisher is wired or the alarm has actions disabled.
+func (m *Mock) fireAlarmActions(a *alarmData, oldState, newState string, now time.Time) {
+	if m.sns == nil || !a.ActionsEnabled {
+		return
+	}
+
+	var actions []string
+
+	switch newState {
+	case stateAlarm:
+		actions = a.AlarmActions
+	case stateOK:
+		actions = a.OKActions
+	case stateInsufficientData:
+		actions = a.InsufficientDataActions
+	}
+
+	if len(actions) == 0 {
+		return
+	}
+
+	message := m.alarmNotification(a, oldState, newState, now)
+
+	for _, arn := range actions {
+		if strings.HasPrefix(arn, snsTopicARNPrefix) {
+			_ = m.sns.PublishExternal(context.Background(), arn, message)
+		}
+	}
+}
+
+// alarmNotification renders the JSON body CloudWatch publishes to an SNS topic
+// on a state change. It mirrors the real notification's key fields so a
+// subscriber (e.g. an SQS queue) receives a recognizable alarm payload.
+func (m *Mock) alarmNotification(a *alarmData, oldState, newState string, now time.Time) string {
+	payload := map[string]any{
+		"AlarmName":        a.Name,
+		"AlarmDescription": a.AlarmDescription,
+		"AWSAccountId":     m.opts.AccountID,
+		"Region":           m.opts.Region,
+		"NewStateValue":    newState,
+		"NewStateReason":   a.StateReason,
+		"OldStateValue":    oldState,
+		"StateChangeTime":  now.UTC().Format(time.RFC3339),
+		"Trigger": map[string]any{
+			"MetricName":         a.MetricName,
+			"Namespace":          a.Namespace,
+			"Statistic":          a.Stat,
+			"ComparisonOperator": a.ComparisonOperator,
+			"Threshold":          a.Threshold,
+			"Period":             a.Period,
+			"EvaluationPeriods":  a.EvaluationPeriods,
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+
+	return string(body)
 }
 
 func (m *Mock) collectFilteredDatums(
@@ -438,7 +540,7 @@ func (m *Mock) CreateAlarm(_ context.Context, cfg driver.AlarmConfig) error {
 	// When PutMetricAlarm updates an existing alarm, its state is left unchanged and
 	// tags supplied in this operation are ignored (real AWS API_PutMetricAlarm semantics).
 	// The rest of the configuration is completely overwritten.
-	state := "INSUFFICIENT_DATA"
+	state := stateInsufficientData
 	stateReason := ""
 	stateUpdated := m.opts.Clock.Now()
 

--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -216,6 +216,14 @@ func (m *Mock) evaluateSingleAlarm(alarm *alarmData, namespace, metricName strin
 // action ARNs are published (via the wired publisher); the notification carries
 // the alarm's new state so subscribers can react. It is a no-op when no
 // publisher is wired or the alarm has actions disabled.
+//
+// The stateInsufficientData branch below is wired for completeness (and to
+// keep the switch exhaustive over the alarm state enum) but is currently
+// unreachable: evaluateSingleAlarm only ever assigns stateAlarm or stateOK,
+// since alarm evaluation here is event-driven off incoming PutMetricData
+// calls. Real CloudWatch instead transitions an alarm to INSUFFICIENT_DATA
+// on a background timer when expected datapoints stop arriving — a
+// timer-driven behavior this mock does not simulate.
 func (m *Mock) fireAlarmActions(a *alarmData, oldState, newState string, now time.Time) {
 	if m.sns == nil || !a.ActionsEnabled {
 		return

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -3,8 +3,8 @@ package cloudwatchlogs
 
 import (
 	"context"
-	"github.com/stackshy/cloudemu/v2/services/scope"
 	"maps"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -15,6 +15,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/logging/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const (
@@ -270,7 +271,66 @@ func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, eve
 	m.emitMetric("IncomingLogEvents", float64(len(events)), "Count", dims)
 	m.emitMetric("IncomingBytes", float64(totalBytes), "Bytes", dims)
 
+	m.evaluateMetricFilters(g, events)
+
 	return nil
+}
+
+// evaluateMetricFilters turns matching log events into CloudWatch metric data.
+// For each metric filter on the group, every event whose message matches the
+// filter pattern contributes the filter's metric value; the total is published
+// to the filter's configured namespace/metric, mirroring how CloudWatch Logs
+// extracts custom metrics from ingested events.
+func (m *Mock) evaluateMetricFilters(g *logGroup, events []driver.LogEvent) {
+	if m.monitoring == nil {
+		return
+	}
+
+	for _, mf := range g.metricFilters.All() {
+		var (
+			matched int
+			total   float64
+		)
+
+		for i := range events {
+			if mf.FilterPattern == "" || strings.Contains(events[i].Message, mf.FilterPattern) {
+				matched++
+				total += metricFilterValue(mf.MetricValue)
+			}
+		}
+
+		if matched == 0 {
+			continue
+		}
+
+		namespace := mf.MetricNamespace
+		if namespace == "" {
+			namespace = "LogMetrics"
+		}
+
+		_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{{
+			Namespace:  namespace,
+			MetricName: mf.MetricName,
+			Value:      total,
+			Timestamp:  m.opts.Clock.Now(),
+		}})
+	}
+}
+
+// metricFilterValue resolves a metric filter's metricValue to the number each
+// matching event contributes. A literal number is used directly; anything else
+// (an empty value, or a "$field" token this emulator does not extract) counts
+// as 1 per matching event, which is the common "count occurrences" filter.
+func metricFilterValue(raw string) float64 {
+	if raw == "" {
+		return 1
+	}
+
+	if v, err := strconv.ParseFloat(raw, 64); err == nil {
+		return v
+	}
+
+	return 1
 }
 
 // GetLogEvents retrieves log events matching the query.

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -281,6 +281,13 @@ func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, eve
 // filter pattern contributes the filter's metric value; the total is published
 // to the filter's configured namespace/metric, mirroring how CloudWatch Logs
 // extracts custom metrics from ingested events.
+//
+// Pattern matching only supports plain-substring "count occurrences of a
+// term" matching (strings.Contains). Real CloudWatch Logs filter pattern
+// syntax — quoted phrases, JSON-field patterns (e.g. { $.level = "ERROR" }),
+// ?OR-style alternation, and -exclusion terms — is not parsed, so a more
+// elaborate real filter pattern will not behave like real CloudWatch Logs
+// here.
 func (m *Mock) evaluateMetricFilters(g *logGroup, events []driver.LogEvent) {
 	if m.monitoring == nil {
 		return

--- a/server/aws/cloudwatch_actions_sdk_test.go
+++ b/server/aws/cloudwatch_actions_sdk_test.go
@@ -1,0 +1,206 @@
+package aws_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	cwl "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// sdkConfig builds an aws.Config pointed at ts with static test credentials.
+func sdkConfig(t *testing.T, url string) aws.Config {
+	t.Helper()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	require.NoError(t, err)
+
+	cfg.BaseEndpoint = aws.String(url)
+
+	return cfg
+}
+
+// TestE2ECloudWatchAlarmActionFiresSNSToSQS is the real-user integration for the
+// alarm-action delivery finding: a metric alarm with an SNS AlarmAction must
+// publish to the topic on its OK->ALARM transition, and — with an sqs-protocol
+// subscription — the notification must land in the subscribed queue.
+func TestE2ECloudWatchAlarmActionFiresSNSToSQS(t *testing.T) {
+	provider := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{
+		CloudWatch: provider.CloudWatch,
+		SNS:        provider.SNS,
+		SQS:        provider.SQS,
+	})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	cfg := sdkConfig(t, ts.URL)
+	ctx := context.Background()
+
+	cw := cloudwatch.NewFromConfig(cfg)
+	snsClient := sns.NewFromConfig(cfg)
+	sqsClient := sqs.NewFromConfig(cfg)
+
+	topic, err := snsClient.CreateTopic(ctx, &sns.CreateTopicInput{Name: aws.String("alarm-topic")})
+	require.NoError(t, err)
+	topicARN := aws.ToString(topic.TopicArn)
+
+	queue, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{QueueName: aws.String("alarm-queue")})
+	require.NoError(t, err)
+	queueURL := aws.ToString(queue.QueueUrl)
+
+	attrs, err := sqsClient.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+		QueueUrl:       queue.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameQueueArn},
+	})
+	require.NoError(t, err)
+	queueARN := attrs.Attributes[string(sqstypes.QueueAttributeNameQueueArn)]
+	require.NotEmpty(t, queueARN)
+
+	_, err = snsClient.Subscribe(ctx, &sns.SubscribeInput{
+		TopicArn: aws.String(topicARN),
+		Protocol: aws.String("sqs"),
+		Endpoint: aws.String(queueARN),
+	})
+	require.NoError(t, err)
+
+	_, err = cw.PutMetricAlarm(ctx, &cloudwatch.PutMetricAlarmInput{
+		AlarmName:          aws.String("app-errors"),
+		Namespace:          aws.String("Custom/App"),
+		MetricName:         aws.String("AppErrors"),
+		ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+		Threshold:          aws.Float64(10),
+		EvaluationPeriods:  aws.Int32(1),
+		Period:             aws.Int32(60),
+		Statistic:          cwtypes.StatisticSum,
+		AlarmActions:       []string{topicARN},
+	})
+	require.NoError(t, err)
+
+	// A breaching datapoint drives the alarm INSUFFICIENT_DATA -> ALARM, which
+	// must fire the AlarmAction.
+	_, err = cw.PutMetricData(ctx, &cloudwatch.PutMetricDataInput{
+		Namespace: aws.String("Custom/App"),
+		MetricData: []cwtypes.MetricDatum{{
+			MetricName: aws.String("AppErrors"),
+			Value:      aws.Float64(99),
+		}},
+	})
+	require.NoError(t, err)
+
+	// The alarm must be in ALARM (sanity), and the SNS notification must have
+	// been delivered to the subscribed SQS queue.
+	desc, err := cw.DescribeAlarms(ctx, &cloudwatch.DescribeAlarmsInput{AlarmNames: []string{"app-errors"}})
+	require.NoError(t, err)
+	require.Len(t, desc.MetricAlarms, 1)
+	assert.Equal(t, cwtypes.StateValueAlarm, desc.MetricAlarms[0].StateValue)
+
+	msgs, err := sqsClient.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+		QueueUrl:            aws.String(queueURL),
+		MaxNumberOfMessages: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, msgs.Messages, 1, "alarm AlarmAction should deliver one SNS notification to the queue")
+	assert.Contains(t, aws.ToString(msgs.Messages[0].Body), "app-errors")
+}
+
+// TestE2ECloudWatchLogsMetricFilterIncrementsMetric is the real-user integration
+// for the metric-filter finding: PutMetricFilter must be accepted at the wire
+// layer, and log events matching the pattern (published via PutLogEvents) must
+// increment the configured custom metric.
+func TestE2ECloudWatchLogsMetricFilterIncrementsMetric(t *testing.T) {
+	provider := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{
+		CloudWatchLogs: provider.CloudWatchLogs,
+		CloudWatch:     provider.CloudWatch,
+	})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	cfg := sdkConfig(t, ts.URL)
+	ctx := context.Background()
+
+	logs := cwl.NewFromConfig(cfg)
+	cw := cloudwatch.NewFromConfig(cfg)
+
+	const (
+		group  = "/app/api"
+		stream = "instance-1"
+	)
+
+	_, err := logs.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String(group)})
+	require.NoError(t, err)
+
+	_, err = logs.CreateLogStream(ctx, &cwl.CreateLogStreamInput{
+		LogGroupName:  aws.String(group),
+		LogStreamName: aws.String(stream),
+	})
+	require.NoError(t, err)
+
+	_, err = logs.PutMetricFilter(ctx, &cwl.PutMetricFilterInput{
+		LogGroupName:  aws.String(group),
+		FilterName:    aws.String("errors"),
+		FilterPattern: aws.String("ERROR"),
+		MetricTransformations: []cwltypes.MetricTransformation{{
+			MetricName:      aws.String("ErrorCount"),
+			MetricNamespace: aws.String("MyApp/Errors"),
+			MetricValue:     aws.String("1"),
+		}},
+	})
+	require.NoError(t, err)
+
+	descMF, err := logs.DescribeMetricFilters(ctx, &cwl.DescribeMetricFiltersInput{
+		LogGroupName: aws.String(group),
+	})
+	require.NoError(t, err)
+	require.Len(t, descMF.MetricFilters, 1)
+	assert.Equal(t, "errors", aws.ToString(descMF.MetricFilters[0].FilterName))
+	require.Len(t, descMF.MetricFilters[0].MetricTransformations, 1)
+	assert.Equal(t, "ErrorCount", aws.ToString(descMF.MetricFilters[0].MetricTransformations[0].MetricName))
+
+	nowMillis := time.Now().UnixMilli()
+	_, err = logs.PutLogEvents(ctx, &cwl.PutLogEventsInput{
+		LogGroupName:  aws.String(group),
+		LogStreamName: aws.String(stream),
+		LogEvents: []cwltypes.InputLogEvent{
+			{Timestamp: aws.Int64(nowMillis), Message: aws.String("INFO started")},
+			{Timestamp: aws.Int64(nowMillis + 1), Message: aws.String("ERROR db timeout")},
+			{Timestamp: aws.Int64(nowMillis + 2), Message: aws.String("ERROR retry failed")},
+		},
+	})
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	stats, err := cw.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
+		Namespace:  aws.String("MyApp/Errors"),
+		MetricName: aws.String("ErrorCount"),
+		StartTime:  aws.Time(now.Add(-1 * time.Hour)),
+		EndTime:    aws.Time(now.Add(1 * time.Hour)),
+		Period:     aws.Int32(60),
+		Statistics: []cwtypes.Statistic{cwtypes.StatisticSum},
+	})
+	require.NoError(t, err)
+	require.Len(t, stats.Datapoints, 1, "the two ERROR lines should publish one datapoint to MyApp/Errors ErrorCount")
+	require.NotNil(t, stats.Datapoints[0].Sum)
+	assert.InDelta(t, 2.0, *stats.Datapoints[0].Sum, 0.001)
+}

--- a/server/aws/cloudwatchlogs/handler.go
+++ b/server/aws/cloudwatchlogs/handler.go
@@ -14,6 +14,7 @@
 //	CreateLogGroup      DescribeLogGroups   DeleteLogGroup
 //	CreateLogStream     DescribeLogStreams  DeleteLogStream
 //	PutLogEvents        GetLogEvents        FilterLogEvents
+//	PutMetricFilter     DescribeMetricFilters DeleteMetricFilter
 package cloudwatchlogs
 
 import (
@@ -47,7 +48,10 @@ func (*Handler) Matches(r *http.Request) bool {
 	return strings.HasPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
 }
 
-// ServeHTTP dispatches CloudWatch Logs operations based on X-Amz-Target.
+// ServeHTTP dispatches CloudWatch Logs operations based on X-Amz-Target. Core
+// log-group / log-stream / log-event operations are handled here; retention,
+// metric-filter, and tagging operations route through dispatchManagement to
+// keep either switch within the complexity budget.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
 
@@ -70,8 +74,23 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.getLogEvents(w, r)
 	case "FilterLogEvents":
 		h.filterLogEvents(w, r)
+	default:
+		h.dispatchManagement(w, r, op)
+	}
+}
+
+// dispatchManagement handles the retention, metric-filter, and tagging
+// operations, and reports the unknown-operation error for anything unmatched.
+func (h *Handler) dispatchManagement(w http.ResponseWriter, r *http.Request, op string) {
+	switch op {
 	case "PutRetentionPolicy":
 		h.putRetentionPolicy(w, r)
+	case "PutMetricFilter":
+		h.putMetricFilter(w, r)
+	case "DescribeMetricFilters":
+		h.describeMetricFilters(w, r)
+	case "DeleteMetricFilter":
+		h.deleteMetricFilter(w, r)
 	case "TagResource", "TagLogGroup":
 		h.tagLogGroup(w, r)
 	case "UntagResource", "UntagLogGroup":

--- a/server/aws/cloudwatchlogs/metric_filters.go
+++ b/server/aws/cloudwatchlogs/metric_filters.go
@@ -1,0 +1,143 @@
+package cloudwatchlogs
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// metricTransformationJSON is one MetricTransformation, the object that binds a
+// matched log event to an emitted CloudWatch metric. AWS fixes the enclosing
+// array to exactly one element, so this maps 1:1 onto the flat driver config.
+type metricTransformationJSON struct {
+	MetricName      string            `json:"metricName"`
+	MetricNamespace string            `json:"metricNamespace"`
+	MetricValue     string            `json:"metricValue"`
+	DefaultValue    *float64          `json:"defaultValue,omitempty"`
+	Dimensions      map[string]string `json:"dimensions,omitempty"`
+	Unit            string            `json:"unit,omitempty"`
+}
+
+type putMetricFilterRequest struct {
+	LogGroupName          string                     `json:"logGroupName"`
+	FilterName            string                     `json:"filterName"`
+	FilterPattern         string                     `json:"filterPattern"`
+	MetricTransformations []metricTransformationJSON `json:"metricTransformations"`
+}
+
+type describeMetricFiltersRequest struct {
+	LogGroupName     string `json:"logGroupName"`
+	FilterNamePrefix string `json:"filterNamePrefix"`
+	MetricName       string `json:"metricName"`
+	MetricNamespace  string `json:"metricNamespace"`
+	Limit            int32  `json:"limit"`
+	NextToken        string `json:"nextToken"`
+}
+
+type deleteMetricFilterRequest struct {
+	LogGroupName string `json:"logGroupName"`
+	FilterName   string `json:"filterName"`
+}
+
+// metricFilterJSON is a DescribeMetricFilters response element.
+type metricFilterJSON struct {
+	FilterName            string                     `json:"filterName"`
+	FilterPattern         string                     `json:"filterPattern"`
+	LogGroupName          string                     `json:"logGroupName"`
+	CreationTime          int64                      `json:"creationTime"`
+	MetricTransformations []metricTransformationJSON `json:"metricTransformations"`
+}
+
+type describeMetricFiltersResponse struct {
+	MetricFilters []metricFilterJSON `json:"metricFilters"`
+	NextToken     string             `json:"nextToken,omitempty"`
+}
+
+// putMetricFilter creates or updates a metric filter (Logs_20140328.PutMetricFilter).
+// The metricTransformations array is fixed at one element by AWS, so the first
+// transformation supplies the metric this filter emits to. A successful call
+// returns an empty body.
+func (h *Handler) putMetricFilter(w http.ResponseWriter, r *http.Request) {
+	var req putMetricFilterRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if len(req.MetricTransformations) == 0 {
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException",
+			"metricTransformations is required and must contain exactly one item")
+		return
+	}
+
+	mt := req.MetricTransformations[0]
+
+	if err := h.logs.PutMetricFilter(r.Context(), &logdriver.MetricFilterConfig{
+		Name:            req.FilterName,
+		LogGroup:        req.LogGroupName,
+		FilterPattern:   req.FilterPattern,
+		MetricName:      mt.MetricName,
+		MetricNamespace: mt.MetricNamespace,
+		MetricValue:     mt.MetricValue,
+	}); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, struct{}{})
+}
+
+// describeMetricFilters lists a log group's metric filters, ASCII-sorted by
+// filter name and optionally narrowed by filterNamePrefix.
+func (h *Handler) describeMetricFilters(w http.ResponseWriter, r *http.Request) {
+	var req describeMetricFiltersRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	filters, err := h.logs.DescribeMetricFilters(r.Context(), req.LogGroupName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]metricFilterJSON, 0, len(filters))
+
+	for i := range filters {
+		mf := &filters[i]
+		if req.FilterNamePrefix != "" && !strings.HasPrefix(mf.Name, req.FilterNamePrefix) {
+			continue
+		}
+
+		out = append(out, metricFilterJSON{
+			FilterName:    mf.Name,
+			FilterPattern: mf.FilterPattern,
+			LogGroupName:  mf.LogGroup,
+			CreationTime:  epochMillis(mf.CreatedAt),
+			MetricTransformations: []metricTransformationJSON{{
+				MetricName:      mf.MetricName,
+				MetricNamespace: mf.MetricNamespace,
+				MetricValue:     mf.MetricValue,
+			}},
+		})
+	}
+
+	wire.WriteJSON(w, describeMetricFiltersResponse{MetricFilters: out})
+}
+
+// deleteMetricFilter removes a metric filter from a log group. A successful
+// call returns an empty body.
+func (h *Handler) deleteMetricFilter(w http.ResponseWriter, r *http.Request) {
+	var req deleteMetricFilterRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.logs.DeleteMetricFilter(r.Context(), req.LogGroupName, req.FilterName); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, struct{}{})
+}


### PR DESCRIPTION
## Summary

Two cross-service integration gaps found by the real-user end-to-end sweep, both fixed at the correct layer by mirroring the existing S3 -> SNS/Lambda notification wiring.

### 1. CloudWatch alarm action -> SNS -> SQS (HIGH)
A metric alarm with an SNS `AlarmAction` transitioned to ALARM but never fired the action, so a subscribed SQS queue received nothing. Alarm actions were stored but `evaluateSingleAlarm` only updated state/history.

- `providers/aws/cloudwatch`: added an `ActionPublisher` injector (`SetSNSPublisher`) and `fireAlarmActions`. On a state transition (and only on a change, matching real CloudWatch), the alarm now publishes a JSON notification to each SNS-topic action ARN for the new state (AlarmActions/OKActions/InsufficientDataActions), honoring `ActionsEnabled`.
- `providers/aws/aws.go`: wired `p.CloudWatch.SetSNSPublisher(p.SNS)`, so the publish fans out to the topic's sqs-protocol subscriptions via the existing SNS -> SQS path.

### 2. CloudWatch Logs metric filters (HIGH)
`PutMetricFilter` failed at the wire layer (`UnknownOperationException`), so IaC/SDK users could not create metric filters; even stored filters never affected any metric.

- `server/aws/cloudwatchlogs`: added `PutMetricFilter`, `DescribeMetricFilters`, `DeleteMetricFilter` wire operations (request/response shapes match the AWS JSON 1.1 `metricTransformations` contract; the fixed single-element array maps onto the flat driver config). ServeHTTP dispatch split to keep complexity in budget.
- `providers/aws/cloudwatchlogs`: `PutLogEvents` now evaluates stored metric filters against each incoming event and publishes matches to the filter's configured namespace/metric, so e.g. `MyApp/Errors ErrorCount` increments as matching lines arrive.

## Tests
Added real aws-sdk-go-v2 end-to-end tests in `server/aws/cloudwatch_actions_sdk_test.go`:
- `TestE2ECloudWatchAlarmActionFiresSNSToSQS`: create topic + queue, subscribe (sqs), alarm with SNS AlarmAction, breaching PutMetricData -> ReceiveMessage returns exactly one notification.
- `TestE2ECloudWatchLogsMetricFilterIncrementsMetric`: PutMetricFilter + DescribeMetricFilters round-trip, PutLogEvents with matching lines -> GetMetricStatistics Sum equals the match count.

## Gates
`go build ./...`, `go vet`, `go test ./providers/aws/... ./server/aws/... ./services/... ./compat/...` all pass; golangci-lint clean on changed code; no docs/coverage or docs/compat diff (no driver interface changed).