### PR TITLE
fix(serverless): DynamoDB Stream event-source-mapping actually invokes the mapped Lambda (mirror the S3->Lambda InvokeExternal wiring); complete the S3 event payload shape

### DIFF
--- a/internal/recursionguard/recursionguard.go
+++ b/internal/recursionguard/recursionguard.go
@@ -1,0 +1,38 @@
+// Package recursionguard bounds cross-service re-entrant call chains — e.g. a
+// DynamoDB Streams -> Lambda event source mapping whose handler writes back
+// into its own source table (mark-processed, audit-append, status-bump). Left
+// unbounded, that pattern recurses synchronously on the same goroutine
+// (PutItem -> deliver -> Invoke -> handler -> PutItem -> ...) until it blows
+// the goroutine stack, which crashes the whole process with an unrecoverable
+// "fatal error: stack overflow" that recover() cannot catch.
+//
+// The cap mirrors AWS Lambda's own recursive-loop detection: Lambda stops
+// invoking a function once it has been invoked approximately 16 times within
+// the same chain of requests, and reports the drop via the
+// RecursiveInvocationsDropped metric. See "Use Lambda recursive loop
+// detection to prevent infinite loops":
+// https://docs.aws.amazon.com/lambda/latest/dg/invocation-recursion.html
+package recursionguard
+
+import "context"
+
+// MaxDepth is the maximum number of nested deliveries permitted within one
+// chain of requests before further delivery is skipped, matching AWS
+// Lambda's documented recursive-loop-detection threshold of ~16 invocations.
+const MaxDepth = 16
+
+type depthKey struct{}
+
+// WithDepth returns a copy of ctx carrying the given re-entrant delivery
+// depth for the current chain of requests.
+func WithDepth(ctx context.Context, depth int) context.Context {
+	return context.WithValue(ctx, depthKey{}, depth)
+}
+
+// Depth returns the re-entrant delivery depth carried on ctx, or 0 if ctx
+// carries none (i.e. this is the start of a new chain of requests).
+func Depth(ctx context.Context) int {
+	depth, _ := ctx.Value(depthKey{}).(int)
+
+	return depth
+}

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -269,6 +269,9 @@ func New(opts ...config.Option) *Provider {
 	p.S3.SetSQSDeliverer(p.SQS)
 	p.S3.SetSNSPublisher(p.SNS)
 	p.S3.SetLambdaInvoker(p.Lambda)
+	// DynamoDB Streams -> Lambda: writes to a stream-enabled table invoke the
+	// stream's event-source-mapping targets (mirrors the S3 -> Lambda wiring).
+	p.DynamoDB.SetStreamInvoker(p.Lambda)
 
 	p.ResourceDiscovery = resourcediscovery.New(
 		resourcediscovery.ProviderAWS, o.AccountID, o.Region, awsDrivers(p),

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -64,15 +64,43 @@ type tableData struct {
 
 // Mock is an in-memory mock implementation of DynamoDB.
 type Mock struct {
-	mu         sync.RWMutex
-	tables     map[string]*tableData
-	opts       *config.Options
-	monitoring mondriver.Monitoring
+	mu            sync.RWMutex
+	tables        map[string]*tableData
+	opts          *config.Options
+	monitoring    mondriver.Monitoring
+	streamInvoker StreamEventInvoker
+	// pendingStream buffers stream records captured under m.mu so their delivery
+	// runs after the lock is released (a mapped Lambda may write back into
+	// DynamoDB); guarded by m.mu.
+	pendingStream []pendingStreamEvent
+}
+
+// StreamEventInvoker delivers a DynamoDB Streams event batch to whatever Lambda
+// event-source-mappings target the stream identified by eventSourceARN. The
+// Lambda mock satisfies it, enabling real DynamoDB-stream -> Lambda invocation
+// (mirroring the S3 -> Lambda LambdaInvoker wiring).
+type StreamEventInvoker interface {
+	DeliverEventSourceBatch(ctx context.Context, eventSourceARN string, payload []byte) error
+}
+
+// pendingStreamEvent is one captured change record awaiting out-of-lock delivery
+// to the stream's Lambda event-source-mappings.
+type pendingStreamEvent struct {
+	streamARN string
+	region    string
+	viewType  string
+	rec       driver.StreamRecord
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
 func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
 	m.monitoring = mon
+}
+
+// SetStreamInvoker wires the Lambda backend so item writes to a stream-enabled
+// table invoke the stream's event-source-mapping targets.
+func (m *Mock) SetStreamInvoker(i StreamEventInvoker) {
+	m.streamInvoker = i
 }
 
 func (m *Mock) emitMetric(metricName string, value float64, dims map[string]string) {
@@ -403,6 +431,7 @@ func (m *Mock) PutItem(_ context.Context, table string, item map[string]any) err
 	td.items.Set(key, item)
 	m.recordStreamEvent(td, oldItem, item, hadOld)
 	m.mu.Unlock()
+	m.flushStreamDeliveries()
 
 	dims := map[string]string{"TableName": table}
 	m.emitMetric("ConsumedWriteCapacityUnits", 1, dims)
@@ -485,6 +514,7 @@ func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[
 	td.items.Set(k, updated)
 	m.recordStreamEvent(td, oldItem, updated, true)
 	m.mu.Unlock()
+	m.flushStreamDeliveries()
 
 	dims := map[string]string{"TableName": input.Table}
 	m.emitMetric("ConsumedWriteCapacityUnits", 1, dims)
@@ -516,6 +546,7 @@ func (m *Mock) DeleteItem(_ context.Context, table string, key map[string]any) e
 	}
 
 	m.mu.Unlock()
+	m.flushStreamDeliveries()
 
 	dims := map[string]string{"TableName": table}
 	m.emitMetric("ConsumedWriteCapacityUnits", 1, dims)
@@ -928,6 +959,7 @@ func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string
 	}
 
 	m.mu.Unlock()
+	m.flushStreamDeliveries()
 
 	return nil
 }
@@ -1212,6 +1244,9 @@ func (m *Mock) TransactWriteItems(
 	_ context.Context, table string, puts []map[string]any, deletes []map[string]any,
 ) error {
 	m.mu.Lock()
+	// flush is registered before the unlock defer so it runs after the lock is
+	// released (defers are LIFO), delivering stream records outside m.mu.
+	defer m.flushStreamDeliveries()
 	defer m.mu.Unlock()
 
 	td, exists := m.tables[table]
@@ -1313,6 +1348,7 @@ func (m *Mock) recordStreamEvent(td *tableData, oldItem, newItem map[string]any,
 
 	rec := m.buildStreamRecord(td, eventType, oldItem, newItem)
 	td.streamRecords = appendStreamRecord(td.streamRecords, &rec)
+	m.queueStreamDelivery(td, &rec)
 }
 
 // recordStreamRemove records a REMOVE stream event. Caller must hold m.mu.
@@ -1323,6 +1359,57 @@ func (m *Mock) recordStreamRemove(td *tableData, oldItem map[string]any) {
 
 	rec := m.buildStreamRecord(td, "REMOVE", oldItem, nil)
 	td.streamRecords = appendStreamRecord(td.streamRecords, &rec)
+	m.queueStreamDelivery(td, &rec)
+}
+
+// queueStreamDelivery buffers a change record for out-of-lock delivery to the
+// stream's Lambda event-source-mappings. A no-op when no invoker is wired.
+// Caller must hold m.mu.
+func (m *Mock) queueStreamDelivery(td *tableData, rec *driver.StreamRecord) {
+	if m.streamInvoker == nil || td.config.StreamArn == "" {
+		return
+	}
+
+	m.pendingStream = append(m.pendingStream, pendingStreamEvent{
+		streamARN: td.config.StreamArn,
+		region:    m.opts.Region,
+		viewType:  td.streamConfig.ViewType,
+		rec:       *rec,
+	})
+}
+
+// flushStreamDeliveries drains the buffered stream records and delivers them to
+// the stream's Lambda event-source-mappings, grouping consecutive records of the
+// same stream into a single event batch (as a real ESM invoke would). It runs
+// after m.mu is released so a mapped Lambda may safely call back into DynamoDB.
+func (m *Mock) flushStreamDeliveries() {
+	if m.streamInvoker == nil {
+		return
+	}
+
+	m.mu.Lock()
+	pending := m.pendingStream
+	m.pendingStream = nil
+	m.mu.Unlock()
+
+	ctx := context.Background()
+
+	for i := 0; i < len(pending); {
+		j := i + 1
+		for j < len(pending) && pending[j].streamARN == pending[i].streamARN {
+			j++
+		}
+
+		batch := make([]driver.StreamRecord, 0, j-i)
+		for k := i; k < j; k++ {
+			batch = append(batch, pending[k].rec)
+		}
+
+		payload := driver.BuildLambdaStreamEvent(pending[i].streamARN, pending[i].region, pending[i].viewType, batch)
+		_ = m.streamInvoker.DeliverEventSourceBatch(ctx, pending[i].streamARN, payload)
+
+		i = j
+	}
 }
 
 func (m *Mock) buildStreamRecord(

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -14,6 +14,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
 	"github.com/stackshy/cloudemu/v2/services/database/driver"
 	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
@@ -406,7 +407,7 @@ func (m *Mock) ListTables(_ context.Context) ([]string, error) {
 	return names, nil
 }
 
-func (m *Mock) PutItem(_ context.Context, table string, item map[string]any) error {
+func (m *Mock) PutItem(ctx context.Context, table string, item map[string]any) error {
 	m.mu.Lock()
 
 	td, exists := m.tables[table]
@@ -431,7 +432,7 @@ func (m *Mock) PutItem(_ context.Context, table string, item map[string]any) err
 	td.items.Set(key, item)
 	m.recordStreamEvent(td, oldItem, item, hadOld)
 	m.mu.Unlock()
-	m.flushStreamDeliveries()
+	m.flushStreamDeliveries(ctx)
 
 	dims := map[string]string{"TableName": table}
 	m.emitMetric("ConsumedWriteCapacityUnits", 1, dims)
@@ -471,7 +472,7 @@ func (m *Mock) GetItem(_ context.Context, table string, key map[string]any) (map
 // UpdateItem applies partial updates to an existing item.
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[string]any, error) {
+func (m *Mock) UpdateItem(ctx context.Context, input driver.UpdateItemInput) (map[string]any, error) {
 	m.mu.Lock()
 
 	td, exists := m.tables[input.Table]
@@ -514,7 +515,7 @@ func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[
 	td.items.Set(k, updated)
 	m.recordStreamEvent(td, oldItem, updated, true)
 	m.mu.Unlock()
-	m.flushStreamDeliveries()
+	m.flushStreamDeliveries(ctx)
 
 	dims := map[string]string{"TableName": input.Table}
 	m.emitMetric("ConsumedWriteCapacityUnits", 1, dims)
@@ -523,7 +524,7 @@ func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[
 	return maps.Clone(updated), nil
 }
 
-func (m *Mock) DeleteItem(_ context.Context, table string, key map[string]any) error {
+func (m *Mock) DeleteItem(ctx context.Context, table string, key map[string]any) error {
 	m.mu.Lock()
 
 	td, exists := m.tables[table]
@@ -546,7 +547,7 @@ func (m *Mock) DeleteItem(_ context.Context, table string, key map[string]any) e
 	}
 
 	m.mu.Unlock()
-	m.flushStreamDeliveries()
+	m.flushStreamDeliveries(ctx)
 
 	dims := map[string]string{"TableName": table}
 	m.emitMetric("ConsumedWriteCapacityUnits", 1, dims)
@@ -928,7 +929,7 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 	return result, nil
 }
 
-func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string]any) error {
+func (m *Mock) BatchPutItems(ctx context.Context, table string, items []map[string]any) error {
 	m.mu.Lock()
 
 	td, exists := m.tables[table]
@@ -959,7 +960,7 @@ func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string
 	}
 
 	m.mu.Unlock()
-	m.flushStreamDeliveries()
+	m.flushStreamDeliveries(ctx)
 
 	return nil
 }
@@ -1241,12 +1242,12 @@ func filterStreamRecords(records []driver.StreamRecord, limit int, token string)
 
 // TransactWriteItems executes puts and deletes atomically.
 func (m *Mock) TransactWriteItems(
-	_ context.Context, table string, puts []map[string]any, deletes []map[string]any,
+	ctx context.Context, table string, puts []map[string]any, deletes []map[string]any,
 ) error {
 	m.mu.Lock()
 	// flush is registered before the unlock defer so it runs after the lock is
 	// released (defers are LIFO), delivering stream records outside m.mu.
-	defer m.flushStreamDeliveries()
+	defer func() { m.flushStreamDeliveries(ctx) }()
 	defer m.mu.Unlock()
 
 	td, exists := m.tables[table]
@@ -1382,7 +1383,17 @@ func (m *Mock) queueStreamDelivery(td *tableData, rec *driver.StreamRecord) {
 // the stream's Lambda event-source-mappings, grouping consecutive records of the
 // same stream into a single event batch (as a real ESM invoke would). It runs
 // after m.mu is released so a mapped Lambda may safely call back into DynamoDB.
-func (m *Mock) flushStreamDeliveries() {
+//
+// callerCtx is the write call's own context, used only to read the re-entrant
+// delivery depth (internal/recursionguard): a mapped Lambda commonly writes
+// back into its own source table (mark-processed, audit-append, status-bump),
+// re-entering here through the very same synchronous call chain
+// (Put/Update/DeleteItem -> flush -> DeliverEventSourceBatch -> Invoke ->
+// handler -> Put/Update/DeleteItem -> ...). Delivery itself always runs on a
+// fresh background context, decoupled from callerCtx's cancellation/deadline
+// (delivery must still complete once the write call has already returned),
+// carrying forward only the depth so the chain stays bounded.
+func (m *Mock) flushStreamDeliveries(callerCtx context.Context) {
 	if m.streamInvoker == nil {
 		return
 	}
@@ -1392,7 +1403,7 @@ func (m *Mock) flushStreamDeliveries() {
 	m.pendingStream = nil
 	m.mu.Unlock()
 
-	ctx := context.Background()
+	ctx := recursionguard.WithDepth(context.Background(), recursionguard.Depth(callerCtx))
 
 	for i := 0; i < len(pending); {
 		j := i + 1

--- a/providers/aws/dynamodb/stream_esm_test.go
+++ b/providers/aws/dynamodb/stream_esm_test.go
@@ -1,0 +1,132 @@
+package dynamodb
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+// recordingStreamInvoker captures DynamoDB-stream -> Lambda deliveries.
+type recordingStreamInvoker struct {
+	arns     []string
+	payloads [][]byte
+}
+
+func (r *recordingStreamInvoker) DeliverEventSourceBatch(_ context.Context, arn string, payload []byte) error {
+	r.arns = append(r.arns, arn)
+	r.payloads = append(r.payloads, payload)
+
+	return nil
+}
+
+// TestStreamInvokerDeliversOnWrite verifies that, once a stream invoker is wired,
+// item writes to a stream-enabled table deliver a DynamoDB Streams event batch
+// tagged with the table's stream ARN, and that a table without a stream never
+// delivers.
+func TestStreamInvokerDeliversOnWrite(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	inv := &recordingStreamInvoker{}
+	m.SetStreamInvoker(inv)
+
+	if err := m.CreateTable(ctx, driver.TableConfig{
+		Name: "streamed", PartitionKey: "Id",
+		StreamEnabled: true, StreamViewType: ViewNewAndOld,
+	}); err != nil {
+		t.Fatalf("CreateTable(streamed): %v", err)
+	}
+
+	if err := m.CreateTable(ctx, driver.TableConfig{Name: "plain", PartitionKey: "Id"}); err != nil {
+		t.Fatalf("CreateTable(plain): %v", err)
+	}
+
+	streamARN := m.tables["streamed"].config.StreamArn
+	if streamARN == "" {
+		t.Fatal("stream table has no StreamArn")
+	}
+
+	// A write to the plain table must not deliver anything.
+	if err := m.PutItem(ctx, "plain", map[string]any{"Id": "p1"}); err != nil {
+		t.Fatalf("PutItem(plain): %v", err)
+	}
+
+	if len(inv.arns) != 0 {
+		t.Fatalf("plain-table write delivered %v, want none", inv.arns)
+	}
+
+	// A write to the streamed table delivers exactly one batch to the stream ARN.
+	if err := m.PutItem(ctx, "streamed", map[string]any{"Id": "s1", "Msg": "hi"}); err != nil {
+		t.Fatalf("PutItem(streamed): %v", err)
+	}
+
+	if len(inv.arns) != 1 || inv.arns[0] != streamARN {
+		t.Fatalf("deliveries = %v, want one to %s", inv.arns, streamARN)
+	}
+
+	var event struct {
+		Records []struct {
+			EventName      string `json:"eventName"`
+			EventSourceARN string `json:"eventSourceARN"`
+			DynamoDB       struct {
+				NewImage map[string]map[string]any `json:"NewImage"`
+			} `json:"dynamodb"`
+		} `json:"Records"`
+	}
+
+	if err := json.Unmarshal(inv.payloads[0], &event); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+
+	if len(event.Records) != 1 {
+		t.Fatalf("Records = %d, want 1", len(event.Records))
+	}
+
+	rec := event.Records[0]
+	if rec.EventName != "INSERT" || rec.EventSourceARN != streamARN {
+		t.Fatalf("record eventName=%q eventSourceARN=%q", rec.EventName, rec.EventSourceARN)
+	}
+
+	if rec.DynamoDB.NewImage["Msg"]["S"] != "hi" {
+		t.Fatalf("NewImage.Msg.S = %v, want hi", rec.DynamoDB.NewImage["Msg"]["S"])
+	}
+}
+
+// TestTransactWriteDeliversBatch verifies a multi-item transact write delivers
+// the records of one stream as a single batched event.
+func TestTransactWriteDeliversBatch(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	inv := &recordingStreamInvoker{}
+	m.SetStreamInvoker(inv)
+
+	if err := m.CreateTable(ctx, driver.TableConfig{
+		Name: "t", PartitionKey: "Id", StreamEnabled: true, StreamViewType: ViewNewImage,
+	}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	if err := m.TransactWriteItems(ctx, "t",
+		[]map[string]any{{"Id": "a"}, {"Id": "b"}}, nil); err != nil {
+		t.Fatalf("TransactWriteItems: %v", err)
+	}
+
+	if len(inv.payloads) != 1 {
+		t.Fatalf("deliveries = %d, want 1 batched delivery", len(inv.payloads))
+	}
+
+	var event struct {
+		Records []json.RawMessage `json:"Records"`
+	}
+
+	if err := json.Unmarshal(inv.payloads[0], &event); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+
+	if len(event.Records) != 2 {
+		t.Fatalf("batched Records = %d, want 2", len(event.Records))
+	}
+}

--- a/providers/aws/dynamodb_stream_lambda_recursion_test.go
+++ b/providers/aws/dynamodb_stream_lambda_recursion_test.go
@@ -1,0 +1,90 @@
+package aws_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	"github.com/stackshy/cloudemu/v2/providers/aws"
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+	sdriver "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// TestDynamoDBStreamLambdaWriteBackDoesNotRecurseUnbounded reproduces a real
+// pattern: a Lambda mapped to a DynamoDB Stream writes back into its own
+// source table (mark-processed / audit-append / status-bump). Because ESM
+// delivery runs synchronously on the same goroutine unwinding from
+// PutItem/UpdateItem/DeleteItem, an unguarded handler recurses
+// PutItem -> deliver -> Invoke -> handler -> PutItem -> ... without bound,
+// which previously blew the goroutine stack and crashed the whole process
+// with an unrecoverable "fatal error: stack overflow" (recover() cannot catch
+// it). The recursive-loop guard in lambda.Mock.InvokeExternal must cap the
+// chain, matching AWS Lambda's own recursive-loop detection of ~16
+// invocations per chain of requests, so a single top-level PutItem returns
+// normally instead of taking the process down with it.
+func TestDynamoDBStreamLambdaWriteBackDoesNotRecurseUnbounded(t *testing.T) {
+	p := aws.New()
+	ctx := context.Background()
+
+	const table = "orders"
+
+	if err := p.DynamoDB.CreateTable(ctx, driver.TableConfig{
+		Name: table, PartitionKey: "Id", StreamEnabled: true, StreamViewType: "NEW_IMAGE",
+	}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	cfg, err := p.DynamoDB.DescribeTable(ctx, table)
+	if err != nil {
+		t.Fatalf("DescribeTable: %v", err)
+	}
+
+	if cfg.StreamArn == "" {
+		t.Fatal("table has no StreamArn")
+	}
+
+	const function = "mark-processed"
+
+	if _, err := p.Lambda.CreateFunction(ctx, sdriver.FunctionConfig{Name: function}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	var invocations atomic.Int64
+
+	// A well-behaved handler forwards the ctx it was invoked with into its own
+	// downstream calls, exactly as this test's handler does here — this is the
+	// channel the recursive-loop guard rides on.
+	p.Lambda.RegisterHandler(function, func(ctx context.Context, _ []byte) ([]byte, error) {
+		invocations.Add(1)
+
+		// The write-back: the handler marks the very item it was triggered by
+		// as processed, in its own source table.
+		if err := p.DynamoDB.PutItem(ctx, table, map[string]any{"Id": "1", "Processed": true}); err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	})
+
+	if _, err := p.Lambda.CreateEventSourceMapping(ctx, sdriver.EventSourceMappingConfig{
+		EventSourceArn: cfg.StreamArn, FunctionName: function, Enabled: true,
+	}); err != nil {
+		t.Fatalf("CreateEventSourceMapping: %v", err)
+	}
+
+	// The single top-level write that starts the chain. If this returns at
+	// all (rather than crashing the process with a stack overflow), the guard
+	// held.
+	if err := p.DynamoDB.PutItem(ctx, table, map[string]any{"Id": "1"}); err != nil {
+		t.Fatalf("PutItem: %v", err)
+	}
+
+	// Each recursive PutItem trips one more level of the guard, so the chain
+	// runs to exactly MaxDepth invocations before InvokeExternal starts
+	// silently dropping delivery.
+	if got := invocations.Load(); got != recursionguard.MaxDepth {
+		t.Fatalf("handler invoked %d times, want exactly %d (recursive-loop guard did not bound the chain)",
+			got, recursionguard.MaxDepth)
+	}
+}

--- a/providers/aws/lambda/esm.go
+++ b/providers/aws/lambda/esm.go
@@ -77,6 +77,27 @@ func (m *Mock) functionARN(nameOrARN string) string {
 	return idgen.AWSARN("lambda", m.opts.Region, m.opts.AccountID, "function:"+nameOrARN)
 }
 
+// DeliverEventSourceBatch invokes every enabled event-source-mapping whose
+// EventSourceArn matches the given source (a DynamoDB stream ARN, SQS queue ARN,
+// or Kinesis stream ARN) with the pre-built event payload. It backs synchronous
+// in-emulator ESM delivery, the Lambda counterpart to the S3 -> Lambda
+// InvokeExternal wiring: the source records a change and calls this so the
+// mapped function actually runs. A disabled mapping is skipped; an unknown
+// target function is a no-op (InvokeExternal), so stale mappings never error.
+func (m *Mock) DeliverEventSourceBatch(ctx context.Context, eventSourceARN string, payload []byte) error {
+	for _, info := range m.mappings.All() {
+		if info.State != stateEnabled || info.EventSourceArn != eventSourceARN {
+			continue
+		}
+
+		if err := m.InvokeExternal(ctx, info.FunctionArn, payload); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // DeleteEventSourceMapping deletes an event source mapping by UUID.
 func (m *Mock) DeleteEventSourceMapping(_ context.Context, uuid string) error {
 	if !m.mappings.Has(uuid) {

--- a/providers/aws/lambda/esm.go
+++ b/providers/aws/lambda/esm.go
@@ -84,6 +84,10 @@ func (m *Mock) functionARN(nameOrARN string) string {
 // InvokeExternal wiring: the source records a change and calls this so the
 // mapped function actually runs. A disabled mapping is skipped; an unknown
 // target function is a no-op (InvokeExternal), so stale mappings never error.
+// ctx's re-entrant delivery depth is enforced inside InvokeExternal (see
+// internal/recursionguard), which is the single choke point every delivery
+// path funnels through, so a handler that writes back into its own event
+// source cannot recurse this call chain unboundedly.
 func (m *Mock) DeliverEventSourceBatch(ctx context.Context, eventSourceARN string, payload []byte) error {
 	for _, info := range m.mappings.All() {
 		if info.State != stateEnabled || info.EventSourceArn != eventSourceARN {

--- a/providers/aws/lambda/esm_delivery_test.go
+++ b/providers/aws/lambda/esm_delivery_test.go
@@ -1,0 +1,61 @@
+package lambda
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// TestDeliverEventSourceBatch verifies DeliverEventSourceBatch invokes only the
+// enabled mappings whose EventSourceArn matches, backing DynamoDB-stream/SQS/
+// Kinesis event-source-mapping delivery.
+func TestDeliverEventSourceBatch(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	var got []string
+	m.RegisterHandler("my-func", func(_ context.Context, payload []byte) ([]byte, error) {
+		got = append(got, string(payload))
+		return nil, nil
+	})
+
+	const streamARN = "arn:aws:dynamodb:us-east-1:000000000000:table/orders/stream/2025-01-01T00:00:00.000"
+
+	// Enabled mapping on the stream ARN -> invoked.
+	if _, err := m.CreateEventSourceMapping(ctx, driver.EventSourceMappingConfig{
+		EventSourceArn: streamARN, FunctionName: "my-func", Enabled: true,
+	}); err != nil {
+		t.Fatalf("CreateEventSourceMapping(enabled): %v", err)
+	}
+
+	// Disabled mapping on the same ARN -> skipped.
+	if _, err := m.CreateEventSourceMapping(ctx, driver.EventSourceMappingConfig{
+		EventSourceArn: streamARN, FunctionName: "my-func", Enabled: false,
+	}); err != nil {
+		t.Fatalf("CreateEventSourceMapping(disabled): %v", err)
+	}
+
+	// Enabled mapping on a different ARN -> not matched.
+	if _, err := m.CreateEventSourceMapping(ctx, driver.EventSourceMappingConfig{
+		EventSourceArn: "arn:aws:sqs:us-east-1:000000000000:other", FunctionName: "my-func", Enabled: true,
+	}); err != nil {
+		t.Fatalf("CreateEventSourceMapping(other): %v", err)
+	}
+
+	if err := m.DeliverEventSourceBatch(ctx, streamARN, []byte(`{"Records":[]}`)); err != nil {
+		t.Fatalf("DeliverEventSourceBatch: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("invocations = %d, want exactly one (enabled + matching only)", len(got))
+	}
+
+	if got[0] != `{"Records":[]}` {
+		t.Fatalf("delivered payload = %q", got[0])
+	}
+}

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -16,6 +16,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
 	"github.com/stackshy/cloudemu/v2/services/serverless/funcengine"
@@ -337,13 +338,33 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 
 // InvokeExternal asynchronously invokes the function identified by its ARN with
 // the given event payload. It backs cross-service event delivery (e.g. S3 ->
-// Lambda notifications). An unknown function is a no-op so a stale target never
-// fails the caller.
+// Lambda notifications, DynamoDB Streams -> Lambda event source mappings). An
+// unknown function is a no-op so a stale target never fails the caller.
+//
+// It is also the single choke point every such delivery path funnels through,
+// so it carries the recursive-loop guard: a mapped/notified handler commonly
+// writes back into its own event source (mark-processed, audit-append,
+// status-bump), which re-enters here through the same synchronous call chain
+// (write -> deliver -> Invoke -> handler -> write -> ...). Left unbounded that
+// recurses the process into an unrecoverable "fatal error: stack overflow".
+// ctx carries the re-entrant delivery depth (see internal/recursionguard);
+// once it reaches recursionguard.MaxDepth — matching AWS Lambda's own
+// recursive-loop detection, which stops invoking a function after ~16
+// invocations within one chain of requests (see
+// https://docs.aws.amazon.com/lambda/latest/dg/invocation-recursion.html) —
+// further delivery is dropped instead of recursing.
 func (m *Mock) InvokeExternal(ctx context.Context, functionARN string, payload []byte) error {
 	name := functionNameFromARN(functionARN)
 	if _, ok := m.funcs.Get(name); !ok {
 		return nil
 	}
+
+	depth := recursionguard.Depth(ctx)
+	if depth >= recursionguard.MaxDepth {
+		return nil
+	}
+
+	ctx = recursionguard.WithDepth(ctx, depth+1)
 
 	_, err := m.Invoke(ctx, driver.InvokeInput{FunctionName: name, Payload: payload, InvokeType: "Event"})
 

--- a/providers/aws/s3/notification.go
+++ b/providers/aws/s3/notification.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -31,16 +32,33 @@ func (m *Mock) GetBucketNotification(_ context.Context, bucket string) ([]Bucket
 	return bkt.notifications, nil
 }
 
+// objectEvent carries the object-level facts an S3 event record reports, so the
+// event builders take one value instead of a long positional parameter list.
+type objectEvent struct {
+	bucket    string
+	key       string
+	size      int64
+	eTag      string
+	versionID string
+	eventName string // e.g. "ObjectCreated:Put" (no "s3:" prefix)
+	sequencer string
+}
+
 // notifyObjectCreated delivers an s3:ObjectCreated:Put event (PutObject, copy,
 // or completed multipart upload) to matching notification targets.
-func (m *Mock) notifyObjectCreated(bkt *bucketMeta, bucket, key string, size int64) {
-	m.notify(bkt, bucket, key, size, "ObjectCreated:Put")
+func (m *Mock) notifyObjectCreated(bkt *bucketMeta, bucket, key string, size int64, eTag, versionID string) {
+	m.notify(bkt, &objectEvent{
+		bucket: bucket, key: key, size: size, eTag: eTag,
+		versionID: versionID, eventName: "ObjectCreated:Put",
+	})
 }
 
 // notifyObjectRemoved delivers an s3:ObjectRemoved:Delete event to matching
 // notification targets.
-func (m *Mock) notifyObjectRemoved(bkt *bucketMeta, bucket, key string) {
-	m.notify(bkt, bucket, key, 0, "ObjectRemoved:Delete")
+func (m *Mock) notifyObjectRemoved(bkt *bucketMeta, bucket, key, versionID string) {
+	m.notify(bkt, &objectEvent{
+		bucket: bucket, key: key, versionID: versionID, eventName: "ObjectRemoved:Delete",
+	})
 }
 
 // notify delivers an S3 event to every notification target configured on the
@@ -48,21 +66,30 @@ func (m *Mock) notifyObjectRemoved(bkt *bucketMeta, bucket, key string) {
 // accepts the object key. Best-effort: delivery errors are swallowed so a
 // missing/failed target never fails the object operation (mirroring S3's
 // asynchronous, decoupled notification behavior).
-func (m *Mock) notify(bkt *bucketMeta, bucket, key string, size int64, eventName string) {
+func (m *Mock) notify(bkt *bucketMeta, ev *objectEvent) {
 	if len(bkt.notifications) == 0 {
 		return
 	}
 
-	body := m.objectEventJSON(bucket, key, size, eventName)
+	// A single object operation carries one sequencer across all of its
+	// notification records, matching real S3.
+	ev.sequencer = m.nextSequencer()
 
 	for i := range bkt.notifications {
 		n := &bkt.notifications[i]
-		if !eventMatches(n.Events, eventName) || !filterMatches(n.Filters, key) {
+		if !eventMatches(n.Events, ev.eventName) || !filterMatches(n.Filters, ev.key) {
 			continue
 		}
 
-		m.deliver(n, body)
+		m.deliver(n, m.objectEventJSON(ev, n.ID))
 	}
+}
+
+// nextSequencer returns a monotonically increasing, 0-padded hexadecimal token,
+// the shape S3 stamps on ObjectCreated/ObjectRemoved event records so a consumer
+// can order events for a given object key.
+func (m *Mock) nextSequencer() string {
+	return fmt.Sprintf("%016X", m.eventSeq.Add(1))
 }
 
 // deliver dispatches an event body to a single notification target by kind.
@@ -126,15 +153,51 @@ func filterMatches(rules []NotificationFilterRule, key string) bool {
 	return true
 }
 
-func (m *Mock) objectEventJSON(bucket, key string, size int64, eventName string) string {
+// objectEventJSON renders the S3 event-notification record for a single
+// notification target (its configurationId is the target's id). The shape
+// mirrors the documented S3 event message: top-level eventVersion/userIdentity/
+// requestParameters/responseElements plus the full s3 block (s3SchemaVersion,
+// configurationId, bucket.{name,arn,ownerIdentity} and object.{key,size,eTag,
+// versionId,sequencer}), so a handler reading record.s3.object.eTag/sequencer or
+// record.s3.bucket.arn sees real values.
+func (m *Mock) objectEventJSON(ev *objectEvent, configurationID string) string {
+	object := map[string]any{
+		"key":       ev.key,
+		"sequencer": ev.sequencer,
+	}
+
+	// Object creation reports size/eTag; a removal (delete marker) carries
+	// neither, matching real S3's ObjectRemoved records.
+	if strings.HasPrefix(ev.eventName, "ObjectCreated") {
+		object["size"] = ev.size
+		object["eTag"] = ev.eTag
+	}
+
+	if ev.versionID != "" {
+		object["versionId"] = ev.versionID
+	}
+
 	record := map[string]any{
-		"eventSource": "aws:s3",
-		"eventName":   eventName,
-		"awsRegion":   m.opts.Region,
-		"eventTime":   m.opts.Clock.Now().UTC().Format(s3TimeFormat),
+		"eventVersion":      "2.1",
+		"eventSource":       "aws:s3",
+		"awsRegion":         m.opts.Region,
+		"eventTime":         m.opts.Clock.Now().UTC().Format(s3TimeFormat),
+		"eventName":         ev.eventName,
+		"userIdentity":      map[string]any{"principalId": m.opts.AccountID},
+		"requestParameters": map[string]any{"sourceIPAddress": "127.0.0.1"},
+		"responseElements": map[string]any{
+			"x-amz-request-id": ev.sequencer,
+			"x-amz-id-2":       ev.sequencer,
+		},
 		"s3": map[string]any{
-			"bucket": map[string]any{"name": bucket},
-			"object": map[string]any{"key": key, "size": size},
+			"s3SchemaVersion": "1.0",
+			"configurationId": configurationID,
+			"bucket": map[string]any{
+				"name":          ev.bucket,
+				"ownerIdentity": map[string]any{"principalId": m.opts.AccountID},
+				"arn":           "arn:aws:s3:::" + ev.bucket,
+			},
+			"object": object,
 		},
 	}
 

--- a/providers/aws/s3/notification.go
+++ b/providers/aws/s3/notification.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
 )
 
 // PutBucketNotification replaces a bucket's event-notification configuration
@@ -46,8 +47,8 @@ type objectEvent struct {
 
 // notifyObjectCreated delivers an s3:ObjectCreated:Put event (PutObject, copy,
 // or completed multipart upload) to matching notification targets.
-func (m *Mock) notifyObjectCreated(bkt *bucketMeta, bucket, key string, size int64, eTag, versionID string) {
-	m.notify(bkt, &objectEvent{
+func (m *Mock) notifyObjectCreated(ctx context.Context, bkt *bucketMeta, bucket, key string, size int64, eTag, versionID string) {
+	m.notify(ctx, bkt, &objectEvent{
 		bucket: bucket, key: key, size: size, eTag: eTag,
 		versionID: versionID, eventName: "ObjectCreated:Put",
 	})
@@ -55,8 +56,8 @@ func (m *Mock) notifyObjectCreated(bkt *bucketMeta, bucket, key string, size int
 
 // notifyObjectRemoved delivers an s3:ObjectRemoved:Delete event to matching
 // notification targets.
-func (m *Mock) notifyObjectRemoved(bkt *bucketMeta, bucket, key, versionID string) {
-	m.notify(bkt, &objectEvent{
+func (m *Mock) notifyObjectRemoved(ctx context.Context, bkt *bucketMeta, bucket, key, versionID string) {
+	m.notify(ctx, bkt, &objectEvent{
 		bucket: bucket, key: key, versionID: versionID, eventName: "ObjectRemoved:Delete",
 	})
 }
@@ -66,7 +67,14 @@ func (m *Mock) notifyObjectRemoved(bkt *bucketMeta, bucket, key, versionID strin
 // accepts the object key. Best-effort: delivery errors are swallowed so a
 // missing/failed target never fails the object operation (mirroring S3's
 // asynchronous, decoupled notification behavior).
-func (m *Mock) notify(bkt *bucketMeta, ev *objectEvent) {
+//
+// ctx is the write call's own context, carried through only so deliver can
+// read the re-entrant delivery depth (internal/recursionguard): a notified
+// Lambda handler commonly writes back into the same bucket (mark-processed,
+// audit-append), re-entering here through the same synchronous call chain
+// (PutObject -> notify -> deliver -> InvokeExternal -> handler -> PutObject ->
+// ...), which the guard in InvokeExternal bounds.
+func (m *Mock) notify(ctx context.Context, bkt *bucketMeta, ev *objectEvent) {
 	if len(bkt.notifications) == 0 {
 		return
 	}
@@ -81,7 +89,7 @@ func (m *Mock) notify(bkt *bucketMeta, ev *objectEvent) {
 			continue
 		}
 
-		m.deliver(n, m.objectEventJSON(ev, n.ID))
+		m.deliver(ctx, n, m.objectEventJSON(ev, n.ID))
 	}
 }
 
@@ -93,8 +101,13 @@ func (m *Mock) nextSequencer() string {
 }
 
 // deliver dispatches an event body to a single notification target by kind.
-func (m *Mock) deliver(n *BucketNotification, body string) {
-	ctx := context.Background()
+// Delivery always runs on a fresh background context, decoupled from
+// callerCtx's cancellation/deadline (mirroring S3's real asynchronous,
+// decoupled notification behavior), carrying forward only the re-entrant
+// delivery depth so a Lambda target that writes back into this bucket stays
+// bounded (the guard itself lives in lambda.InvokeExternal).
+func (m *Mock) deliver(callerCtx context.Context, n *BucketNotification, body string) {
+	ctx := recursionguard.WithDepth(context.Background(), recursionguard.Depth(callerCtx))
 
 	switch n.Target {
 	case NotifyQueue:

--- a/providers/aws/s3/notification_test.go
+++ b/providers/aws/s3/notification_test.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -114,6 +115,119 @@ func TestNotificationFilterAndTargets(t *testing.T) {
 
 	if !strings.Contains(lambda.payloads[0], `"eventName":"ObjectRemoved:Delete"`) {
 		t.Fatalf("lambda payload = %s", lambda.payloads[0])
+	}
+}
+
+// TestObjectEventFullShape verifies the S3 event record delivered to a target
+// carries the complete documented shape — eventVersion, userIdentity,
+// requestParameters, responseElements, and the full s3 block with
+// s3SchemaVersion, configurationId, bucket.{name,arn,ownerIdentity} and
+// object.{key,size,eTag,sequencer} — not just bucket.name/object.key.
+func TestObjectEventFullShape(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	lambda := &recordingInvoker{}
+	m.SetLambdaInvoker(lambda)
+
+	if err := m.CreateBucket(ctx, "shape-bucket"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	if err := m.PutBucketNotification(ctx, "shape-bucket", []BucketNotification{
+		{ID: "cfg-1", Target: NotifyLambda, ARN: "arn:aws:lambda:us-east-1:0:function:f", Events: []string{"s3:ObjectCreated:*"}},
+	}); err != nil {
+		t.Fatalf("PutBucketNotification: %v", err)
+	}
+
+	if err := m.PutObject(ctx, "shape-bucket", "uploads/photo.jpg", []byte("data"), "image/jpeg", nil); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	if len(lambda.payloads) != 1 {
+		t.Fatalf("lambda invocations = %d, want 1", len(lambda.payloads))
+	}
+
+	var event struct {
+		Records []struct {
+			EventVersion      string         `json:"eventVersion"`
+			EventSource       string         `json:"eventSource"`
+			EventName         string         `json:"eventName"`
+			UserIdentity      map[string]any `json:"userIdentity"`
+			RequestParameters map[string]any `json:"requestParameters"`
+			ResponseElements  map[string]any `json:"responseElements"`
+			S3                struct {
+				SchemaVersion   string `json:"s3SchemaVersion"`
+				ConfigurationID string `json:"configurationId"`
+				Bucket          struct {
+					Name          string         `json:"name"`
+					ARN           string         `json:"arn"`
+					OwnerIdentity map[string]any `json:"ownerIdentity"`
+				} `json:"bucket"`
+				Object struct {
+					Key       string `json:"key"`
+					Size      int64  `json:"size"`
+					ETag      string `json:"eTag"`
+					Sequencer string `json:"sequencer"`
+				} `json:"object"`
+			} `json:"s3"`
+		} `json:"Records"`
+	}
+
+	if err := json.Unmarshal([]byte(lambda.payloads[0]), &event); err != nil {
+		t.Fatalf("unmarshal event: %v\npayload=%s", err, lambda.payloads[0])
+	}
+
+	if len(event.Records) != 1 {
+		t.Fatalf("Records = %d, want 1", len(event.Records))
+	}
+
+	r := event.Records[0]
+	assertEq(t, "eventVersion", r.EventVersion, "2.1")
+	assertEq(t, "eventSource", r.EventSource, "aws:s3")
+	assertEq(t, "eventName", r.EventName, "ObjectCreated:Put")
+
+	if r.UserIdentity["principalId"] == "" || r.UserIdentity["principalId"] == nil {
+		t.Fatalf("userIdentity.principalId empty: %+v", r.UserIdentity)
+	}
+
+	if r.RequestParameters["sourceIPAddress"] == nil {
+		t.Fatalf("requestParameters.sourceIPAddress missing: %+v", r.RequestParameters)
+	}
+
+	if r.ResponseElements["x-amz-request-id"] == nil {
+		t.Fatalf("responseElements.x-amz-request-id missing: %+v", r.ResponseElements)
+	}
+
+	assertEq(t, "s3SchemaVersion", r.S3.SchemaVersion, "1.0")
+	assertEq(t, "configurationId", r.S3.ConfigurationID, "cfg-1")
+	assertEq(t, "bucket.name", r.S3.Bucket.Name, "shape-bucket")
+	assertEq(t, "bucket.arn", r.S3.Bucket.ARN, "arn:aws:s3:::shape-bucket")
+
+	if r.S3.Bucket.OwnerIdentity["principalId"] == nil {
+		t.Fatalf("bucket.ownerIdentity.principalId missing: %+v", r.S3.Bucket.OwnerIdentity)
+	}
+
+	assertEq(t, "object.key", r.S3.Object.Key, "uploads/photo.jpg")
+
+	if r.S3.Object.Size != 4 {
+		t.Fatalf("object.size = %d, want 4", r.S3.Object.Size)
+	}
+
+	if len(r.S3.Object.ETag) != 32 {
+		t.Fatalf("object.eTag = %q, want a 32-char md5", r.S3.Object.ETag)
+	}
+
+	if r.S3.Object.Sequencer == "" {
+		t.Fatalf("object.sequencer empty")
+	}
+}
+
+func assertEq(t *testing.T, field, got, want string) {
+	t.Helper()
+
+	if got != want {
+		t.Fatalf("%s = %q, want %q", field, got, want)
 	}
 }
 

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -383,7 +383,7 @@ func (m *Mock) PutObject(ctx context.Context, bucket, key string, data []byte, c
 	m.emitMetric("PutRequests", 1, "Count", dims)
 	m.emitMetric("BytesUploaded", float64(len(data)), "Bytes", dims)
 
-	m.notifyObjectCreated(bkt, bucket, key, int64(len(data)), obj.ETag, obj.VersionID)
+	m.notifyObjectCreated(ctx, bkt, bucket, key, int64(len(data)), obj.ETag, obj.VersionID)
 
 	return nil
 }
@@ -526,7 +526,7 @@ func (m *Mock) DeleteObject(ctx context.Context, bucket, key string) error {
 	m.emitMetric("AllRequests", 1, "Count", dims)
 	m.emitMetric("DeleteRequests", 1, "Count", dims)
 
-	m.notifyObjectRemoved(bkt, bucket, key, vid)
+	m.notifyObjectRemoved(ctx, bkt, bucket, key, vid)
 
 	return nil
 }
@@ -712,7 +712,7 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 	m.emitMetric("AllRequests", 1, "Count", dims)
 	m.emitMetric("CopyRequests", 1, "Count", dims)
 
-	m.notifyObjectCreated(dstBkt, dstBucket, dstKey, srcObj.Size, dstObj.ETag, dstObj.VersionID)
+	m.notifyObjectCreated(ctx, dstBkt, dstBucket, dstKey, srcObj.Size, dstObj.ETag, dstObj.VersionID)
 
 	return nil
 }
@@ -788,7 +788,7 @@ func (m *Mock) CopyObjectV2(ctx context.Context, req *driver.CopyObjectRequest) 
 	m.emitMetric("AllRequests", 1, "Count", dims)
 	m.emitMetric("CopyRequests", 1, "Count", dims)
 
-	m.notifyObjectCreated(dstBkt, req.DstBucket, req.DstKey, src.size, dstObj.ETag, dstObj.VersionID)
+	m.notifyObjectCreated(ctx, dstBkt, req.DstBucket, req.DstKey, src.size, dstObj.ETag, dstObj.VersionID)
 
 	return &driver.CopyObjectResult{
 		ETag: dstObj.ETag, LastModified: dstObj.LastModified,
@@ -1195,7 +1195,7 @@ func (m *Mock) CompleteMultipartUpload(ctx context.Context, bucket, key, uploadI
 	m.emitMetric("PutRequests", 1, "Count", dims)
 	m.emitMetric("BytesUploaded", float64(len(data)), "Bytes", dims)
 
-	m.notifyObjectCreated(bkt, bucket, key, int64(len(data)), obj.ETag, obj.VersionID)
+	m.notifyObjectCreated(ctx, bkt, bucket, key, int64(len(data)), obj.ETag, obj.VersionID)
 
 	return nil
 }

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -159,6 +160,7 @@ type Mock struct {
 	sqs        SQSDeliverer
 	sns        SNSPublisher
 	lambda     LambdaInvoker
+	eventSeq   atomic.Uint64 // monotonic source for object-event sequencer tokens
 }
 
 // SetSQSDeliverer wires the SQS backend so object events deliver to buckets' SQS
@@ -381,7 +383,7 @@ func (m *Mock) PutObject(ctx context.Context, bucket, key string, data []byte, c
 	m.emitMetric("PutRequests", 1, "Count", dims)
 	m.emitMetric("BytesUploaded", float64(len(data)), "Bytes", dims)
 
-	m.notifyObjectCreated(bkt, bucket, key, int64(len(data)))
+	m.notifyObjectCreated(bkt, bucket, key, int64(len(data)), obj.ETag, obj.VersionID)
 
 	return nil
 }
@@ -524,7 +526,7 @@ func (m *Mock) DeleteObject(ctx context.Context, bucket, key string) error {
 	m.emitMetric("AllRequests", 1, "Count", dims)
 	m.emitMetric("DeleteRequests", 1, "Count", dims)
 
-	m.notifyObjectRemoved(bkt, bucket, key)
+	m.notifyObjectRemoved(bkt, bucket, key, vid)
 
 	return nil
 }
@@ -710,7 +712,7 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 	m.emitMetric("AllRequests", 1, "Count", dims)
 	m.emitMetric("CopyRequests", 1, "Count", dims)
 
-	m.notifyObjectCreated(dstBkt, dstBucket, dstKey, srcObj.Size)
+	m.notifyObjectCreated(dstBkt, dstBucket, dstKey, srcObj.Size, dstObj.ETag, dstObj.VersionID)
 
 	return nil
 }
@@ -786,7 +788,7 @@ func (m *Mock) CopyObjectV2(ctx context.Context, req *driver.CopyObjectRequest) 
 	m.emitMetric("AllRequests", 1, "Count", dims)
 	m.emitMetric("CopyRequests", 1, "Count", dims)
 
-	m.notifyObjectCreated(dstBkt, req.DstBucket, req.DstKey, src.size)
+	m.notifyObjectCreated(dstBkt, req.DstBucket, req.DstKey, src.size, dstObj.ETag, dstObj.VersionID)
 
 	return &driver.CopyObjectResult{
 		ETag: dstObj.ETag, LastModified: dstObj.LastModified,
@@ -1193,7 +1195,7 @@ func (m *Mock) CompleteMultipartUpload(ctx context.Context, bucket, key, uploadI
 	m.emitMetric("PutRequests", 1, "Count", dims)
 	m.emitMetric("BytesUploaded", float64(len(data)), "Bytes", dims)
 
-	m.notifyObjectCreated(bkt, bucket, key, int64(len(data)))
+	m.notifyObjectCreated(bkt, bucket, key, int64(len(data)), obj.ETag, obj.VersionID)
 
 	return nil
 }

--- a/providers/aws/s3_lambda_notification_recursion_test.go
+++ b/providers/aws/s3_lambda_notification_recursion_test.go
@@ -1,0 +1,75 @@
+package aws_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	"github.com/stackshy/cloudemu/v2/providers/aws"
+	"github.com/stackshy/cloudemu/v2/providers/aws/s3"
+	sdriver "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// TestS3LambdaNotificationWriteBackDoesNotRecurseUnbounded is the S3 -> Lambda
+// counterpart to the DynamoDB Streams regression test: it shares the exact
+// same latent bug (a notified handler writing an object back into the same
+// bucket re-enters PutObject -> notify -> deliver -> InvokeExternal -> handler
+// -> PutObject -> ... synchronously) and is bounded by the same guard, since
+// InvokeExternal is the single choke point both delivery paths funnel
+// through.
+func TestS3LambdaNotificationWriteBackDoesNotRecurseUnbounded(t *testing.T) {
+	p := aws.New()
+	ctx := context.Background()
+
+	const bucket = "uploads"
+
+	if err := p.S3.CreateBucket(ctx, bucket); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	const function = "on-upload"
+
+	if _, err := p.Lambda.CreateFunction(ctx, sdriver.FunctionConfig{Name: function}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	var invocations atomic.Int64
+
+	// A well-behaved handler forwards the ctx it was invoked with into its own
+	// downstream calls, exactly as this test's handler does here — this is the
+	// channel the recursive-loop guard rides on.
+	p.Lambda.RegisterHandler(function, func(ctx context.Context, _ []byte) ([]byte, error) {
+		invocations.Add(1)
+
+		// The write-back: the handler re-uploads to the very key that
+		// triggered it, staying inside the bucket/event selector it's mapped to.
+		if err := p.S3.PutObject(ctx, bucket, "in.csv", []byte("data"), "text/csv", nil); err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	})
+
+	if err := p.S3.PutBucketNotification(ctx, bucket, []s3.BucketNotification{{
+		ID: "on-upload", Target: s3.NotifyLambda, ARN: "on-upload",
+		Events: []string{"s3:ObjectCreated:*"},
+	}}); err != nil {
+		t.Fatalf("PutBucketNotification: %v", err)
+	}
+
+	// The single top-level write that starts the chain. If this returns at
+	// all (rather than crashing the process with a stack overflow), the guard
+	// held.
+	if err := p.S3.PutObject(ctx, bucket, "in.csv", []byte("data"), "text/csv", nil); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	// Each recursive PutObject trips one more level of the guard, so the chain
+	// runs to exactly MaxDepth invocations before InvokeExternal starts
+	// silently dropping delivery.
+	if got := invocations.Load(); got != recursionguard.MaxDepth {
+		t.Fatalf("handler invoked %d times, want exactly %d (recursive-loop guard did not bound the chain)",
+			got, recursionguard.MaxDepth)
+	}
+}

--- a/server/aws/dynamodb/types.go
+++ b/server/aws/dynamodb/types.go
@@ -2,9 +2,9 @@ package dynamodb
 
 import (
 	"encoding/base64"
-	"fmt"
 	"strconv"
 
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
 )
 
@@ -24,19 +24,12 @@ func fromWireItem(wire map[string]any) map[string]any {
 	return item
 }
 
-// toWireItem converts a plain map back to DynamoDB wire format.
+// toWireItem converts a plain map back to DynamoDB wire format. It delegates to
+// the canonical driver-package encoder so the control-plane responses, the
+// Streams data plane, and Lambda stream event delivery all render identical
+// AttributeValue JSON.
 func toWireItem(item map[string]any) map[string]any {
-	if item == nil {
-		return nil
-	}
-
-	w := make(map[string]any, len(item))
-
-	for k, v := range item {
-		w[k] = toAttributeValue(v)
-	}
-
-	return w
+	return dbdriver.MarshalItem(item)
 }
 
 // fromAttributeValue extracts the plain value from a DynamoDB AttributeValue.
@@ -194,80 +187,4 @@ func fromMap(v any) map[string]any {
 	}
 
 	return fromWireItem(m)
-}
-
-// toAttributeValue wraps a plain value into DynamoDB wire format.
-func toAttributeValue(v any) map[string]any {
-	if av, ok := toBinaryOrSetValue(v); ok {
-		return av
-	}
-
-	switch val := v.(type) {
-	case string:
-		return map[string]any{"S": val}
-	case float64:
-		return map[string]any{"N": strconv.FormatFloat(val, 'f', -1, 64)}
-	case int:
-		return map[string]any{"N": strconv.Itoa(val)}
-	case int64:
-		return map[string]any{"N": strconv.FormatInt(val, 10)}
-	case bool:
-		return map[string]any{"BOOL": val}
-	case nil:
-		return map[string]any{"NULL": true}
-	case []any:
-		return toListValue(val)
-	case map[string]any:
-		return map[string]any{"M": toWireItem(val)}
-	default:
-		return map[string]any{"S": fmt.Sprintf("%v", val)}
-	}
-}
-
-// toBinaryOrSetValue encodes the exact-decimal Number (N), the binary scalar (B)
-// and the set types (SS/NS/BS), keeping toAttributeValue's own type switch within
-// the complexity budget.
-func toBinaryOrSetValue(v any) (map[string]any, bool) {
-	switch val := v.(type) {
-	case expr.Number:
-		return map[string]any{"N": string(val)}, true
-	case []byte:
-		return map[string]any{"B": base64.StdEncoding.EncodeToString(val)}, true
-	case expr.StringSet:
-		return map[string]any{"SS": []string(val)}, true
-	case expr.NumberSet:
-		return map[string]any{"NS": formatNumberSet(val)}, true
-	case expr.BinarySet:
-		return map[string]any{"BS": formatBinarySet(val)}, true
-	default:
-		return nil, false
-	}
-}
-
-func formatNumberSet(ns expr.NumberSet) []string {
-	out := make([]string, 0, len(ns))
-	for _, f := range ns {
-		out = append(out, strconv.FormatFloat(f, 'f', -1, 64))
-	}
-
-	return out
-}
-
-func formatBinarySet(bs expr.BinarySet) []string {
-	out := make([]string, 0, len(bs))
-	for _, b := range bs {
-		out = append(out, base64.StdEncoding.EncodeToString(b))
-	}
-
-	return out
-}
-
-func toListValue(list []any) map[string]any {
-	items := make([]any, 0, len(list))
-
-	for _, elem := range list {
-		items = append(items, toAttributeValue(elem))
-	}
-
-	return map[string]any{"L": items}
 }

--- a/server/aws/lambda/dynamodb_stream_esm_sdk_test.go
+++ b/server/aws/lambda/dynamodb_stream_esm_sdk_test.go
@@ -1,0 +1,201 @@
+// dynamodb_stream_esm_sdk_test.go — real aws-sdk-go-v2 end-to-end test for the
+// DynamoDB Streams -> Lambda event-source-mapping delivery path. Creating a
+// mapping from a stream-enabled table to a function, then writing an item, must
+// synchronously invoke the mapped function with a DynamoDB Streams event batch
+// (previously CreateEventSourceMapping only stored config and nothing ever
+// invoked the function).
+package lambda_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsddb "github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+func TestSDKDynamoDBStreamESMInvokesLambda(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+
+	// Register an in-process handler for the target function so the test can
+	// deterministically observe the invocation and inspect the delivered event.
+	invocations := make(chan []byte, 4)
+	cloud.Lambda.RegisterHandler("stream-processor", func(_ context.Context, payload []byte) ([]byte, error) {
+		invocations <- payload
+		return payload, nil
+	})
+
+	srv := awsserver.New(awsserver.Drivers{
+		DynamoDB:   cloud.DynamoDB,
+		Lambda:     cloud.Lambda,
+		CloudWatch: cloud.CloudWatch,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ddb, lam := newDDBAndLambda(t, ts.URL)
+	ctx := context.Background()
+
+	streamARN := createStreamTable(t, ddb, "orders")
+	createProcessorFunction(t, lam, "stream-processor")
+
+	// Map the table's stream to the function, enabled.
+	esm, err := lam.CreateEventSourceMapping(ctx, &awslambda.CreateEventSourceMappingInput{
+		EventSourceArn:   aws.String(streamARN),
+		FunctionName:     aws.String("stream-processor"),
+		StartingPosition: lambdatypes.EventSourcePositionTrimHorizon,
+		Enabled:          aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("CreateEventSourceMapping: %v", err)
+	}
+
+	if esm.State == nil || *esm.State != "Enabled" {
+		t.Fatalf("mapping State = %v, want Enabled", esm.State)
+	}
+
+	// Writing an item to the streams-enabled table must invoke the mapped Lambda.
+	if _, err := ddb.PutItem(ctx, &awsddb.PutItemInput{
+		TableName: aws.String("orders"),
+		Item: map[string]ddbtypes.AttributeValue{
+			"Id":      &ddbtypes.AttributeValueMemberN{Value: "101"},
+			"Message": &ddbtypes.AttributeValueMemberS{Value: "New item!"},
+		},
+	}); err != nil {
+		t.Fatalf("PutItem: %v", err)
+	}
+
+	payload := awaitInvocation(t, invocations)
+	assertStreamEvent(t, payload, streamARN)
+}
+
+// assertStreamEvent verifies the payload Lambda received is the documented
+// DynamoDB Streams event shape: a Records array carrying the eventSourceARN and
+// an AttributeValue-encoded NewImage for the written item.
+func assertStreamEvent(t *testing.T, payload []byte, streamARN string) {
+	t.Helper()
+
+	var event struct {
+		Records []struct {
+			EventName      string `json:"eventName"`
+			EventSource    string `json:"eventSource"`
+			EventSourceARN string `json:"eventSourceARN"`
+			DynamoDB       struct {
+				Keys     map[string]map[string]any `json:"Keys"`
+				NewImage map[string]map[string]any `json:"NewImage"`
+			} `json:"dynamodb"`
+		} `json:"Records"`
+	}
+
+	if err := json.Unmarshal(payload, &event); err != nil {
+		t.Fatalf("unmarshal stream event: %v\npayload=%s", err, payload)
+	}
+
+	if len(event.Records) != 1 {
+		t.Fatalf("Records = %d, want 1\npayload=%s", len(event.Records), payload)
+	}
+
+	rec := event.Records[0]
+	if rec.EventName != "INSERT" {
+		t.Fatalf("eventName = %q, want INSERT", rec.EventName)
+	}
+
+	if rec.EventSource != "aws:dynamodb" {
+		t.Fatalf("eventSource = %q, want aws:dynamodb", rec.EventSource)
+	}
+
+	if rec.EventSourceARN != streamARN {
+		t.Fatalf("eventSourceARN = %q, want %q", rec.EventSourceARN, streamARN)
+	}
+
+	if got := rec.DynamoDB.NewImage["Message"]["S"]; got != "New item!" {
+		t.Fatalf("NewImage.Message.S = %v, want %q\npayload=%s", got, "New item!", payload)
+	}
+
+	if got := rec.DynamoDB.Keys["Id"]["N"]; got != "101" {
+		t.Fatalf("Keys.Id.N = %v, want 101\npayload=%s", got, payload)
+	}
+}
+
+func awaitInvocation(t *testing.T, ch <-chan []byte) []byte {
+	t.Helper()
+
+	select {
+	case p := <-ch:
+		return p
+	case <-time.After(2 * time.Second):
+		t.Fatal("mapped Lambda was never invoked by the DynamoDB stream write")
+		return nil
+	}
+}
+
+func createStreamTable(t *testing.T, ddb *awsddb.Client, name string) string {
+	t.Helper()
+
+	out, err := ddb.CreateTable(context.Background(), &awsddb.CreateTableInput{
+		TableName: aws.String(name),
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("Id"), AttributeType: ddbtypes.ScalarAttributeTypeN},
+		},
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("Id"), KeyType: ddbtypes.KeyTypeHash},
+		},
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		StreamSpecification: &ddbtypes.StreamSpecification{
+			StreamEnabled:  aws.Bool(true),
+			StreamViewType: ddbtypes.StreamViewTypeNewAndOldImages,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	arn := aws.ToString(out.TableDescription.LatestStreamArn)
+	if arn == "" {
+		t.Fatal("CreateTable returned an empty LatestStreamArn")
+	}
+
+	return arn
+}
+
+func createProcessorFunction(t *testing.T, lam *awslambda.Client, name string) {
+	t.Helper()
+
+	if _, err := lam.CreateFunction(context.Background(), &awslambda.CreateFunctionInput{
+		FunctionName: aws.String(name),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("stub")},
+	}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+}
+
+func newDDBAndLambda(t *testing.T, url string) (*awsddb.Client, *awslambda.Client) {
+	t.Helper()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	ddb := awsddb.NewFromConfig(cfg, func(o *awsddb.Options) { o.BaseEndpoint = aws.String(url) })
+	lam := awslambda.NewFromConfig(cfg, func(o *awslambda.Options) { o.BaseEndpoint = aws.String(url) })
+
+	return ddb, lam
+}

--- a/services/database/driver/stream_event.go
+++ b/services/database/driver/stream_event.go
@@ -1,0 +1,176 @@
+package driver
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+)
+
+// DynamoDB Streams event envelope constants shared by the Streams data-plane
+// wire handler and Lambda event-source-mapping delivery.
+const (
+	streamEventSource  = "aws:dynamodb"
+	streamEventVersion = "1.1"
+)
+
+// MarshalAttributeValue wraps a plain Go value (as the in-memory providers store
+// items) into a single DynamoDB AttributeValue wire map, e.g. "x" -> {"S":"x"}.
+// It is the canonical native->AV encoder, shared by the DynamoDB wire codec and
+// by Lambda stream event delivery so both render identical AttributeValue JSON.
+func MarshalAttributeValue(v any) map[string]any {
+	if av, ok := marshalBinaryOrSet(v); ok {
+		return av
+	}
+
+	switch val := v.(type) {
+	case string:
+		return map[string]any{"S": val}
+	case float64:
+		return map[string]any{"N": strconv.FormatFloat(val, 'f', -1, 64)}
+	case int:
+		return map[string]any{"N": strconv.Itoa(val)}
+	case int64:
+		return map[string]any{"N": strconv.FormatInt(val, 10)}
+	case bool:
+		return map[string]any{"BOOL": val}
+	case nil:
+		return map[string]any{"NULL": true}
+	case []any:
+		return marshalList(val)
+	case map[string]any:
+		return map[string]any{"M": MarshalItem(val)}
+	default:
+		return map[string]any{"S": fmt.Sprintf("%v", val)}
+	}
+}
+
+// marshalBinaryOrSet encodes the exact-decimal Number (N), the binary scalar (B)
+// and the set types (SS/NS/BS), keeping MarshalAttributeValue's type switch
+// within the complexity budget.
+func marshalBinaryOrSet(v any) (map[string]any, bool) {
+	switch val := v.(type) {
+	case expr.Number:
+		return map[string]any{"N": string(val)}, true
+	case []byte:
+		return map[string]any{"B": base64.StdEncoding.EncodeToString(val)}, true
+	case expr.StringSet:
+		return map[string]any{"SS": []string(val)}, true
+	case expr.NumberSet:
+		return map[string]any{"NS": formatFloatSet(val)}, true
+	case expr.BinarySet:
+		return map[string]any{"BS": formatBinarySet(val)}, true
+	default:
+		return nil, false
+	}
+}
+
+func formatFloatSet(ns expr.NumberSet) []string {
+	out := make([]string, 0, len(ns))
+	for _, f := range ns {
+		out = append(out, strconv.FormatFloat(f, 'f', -1, 64))
+	}
+
+	return out
+}
+
+func formatBinarySet(bs expr.BinarySet) []string {
+	out := make([]string, 0, len(bs))
+	for _, b := range bs {
+		out = append(out, base64.StdEncoding.EncodeToString(b))
+	}
+
+	return out
+}
+
+func marshalList(list []any) map[string]any {
+	items := make([]any, 0, len(list))
+	for _, elem := range list {
+		items = append(items, MarshalAttributeValue(elem))
+	}
+
+	return map[string]any{"L": items}
+}
+
+// MarshalItem converts a plain item map to its DynamoDB AttributeValue wire form,
+// AV-encoding every attribute value. A nil item stays nil.
+func MarshalItem(item map[string]any) map[string]any {
+	if item == nil {
+		return nil
+	}
+
+	out := make(map[string]any, len(item))
+	for k, v := range item {
+		out[k] = MarshalAttributeValue(v)
+	}
+
+	return out
+}
+
+// BuildLambdaStreamEvent renders a batch of change records into the exact JSON
+// event Lambda delivers to a DynamoDB stream event-source-mapping target:
+// {"Records":[{eventID,eventName,eventVersion,eventSource,awsRegion,
+// eventSourceARN,dynamodb:{ApproximateCreationDateTime,Keys,NewImage,OldImage,
+// SequenceNumber,SizeBytes,StreamViewType}}]}. Keys/NewImage/OldImage are
+// AttributeValue-encoded, matching the shape aws-sdk events.DynamoDBEvent binds.
+func BuildLambdaStreamEvent(streamARN, region, viewType string, recs []StreamRecord) []byte {
+	records := make([]map[string]any, 0, len(recs))
+	for i := range recs {
+		records = append(records, lambdaStreamRecord(&recs[i], streamARN, region, viewType))
+	}
+
+	b, err := json.Marshal(map[string]any{"Records": records})
+	if err != nil {
+		return []byte(`{"Records":[]}`)
+	}
+
+	return b
+}
+
+func lambdaStreamRecord(rec *StreamRecord, streamARN, region, viewType string) map[string]any {
+	dyn := map[string]any{
+		"ApproximateCreationDateTime": float64(rec.Timestamp.Unix()),
+		"Keys":                        MarshalItem(rec.Keys),
+		"SequenceNumber":              rec.SequenceNumber,
+		"SizeBytes":                   streamRecordSize(rec),
+		"StreamViewType":              viewType,
+	}
+
+	if rec.NewImage != nil {
+		dyn["NewImage"] = MarshalItem(rec.NewImage)
+	}
+
+	if rec.OldImage != nil {
+		dyn["OldImage"] = MarshalItem(rec.OldImage)
+	}
+
+	return map[string]any{
+		"eventID":        rec.EventID,
+		"eventName":      rec.EventType,
+		"eventVersion":   streamEventVersion,
+		"eventSource":    streamEventSource,
+		"awsRegion":      region,
+		"eventSourceARN": streamARN,
+		"dynamodb":       dyn,
+	}
+}
+
+// streamRecordSize estimates a record's on-the-wire size, as DynamoDB reports it
+// on each stream record: a JSON byte count of the captured keys/images.
+func streamRecordSize(rec *StreamRecord) int {
+	size := 0
+
+	for _, m := range []map[string]any{rec.Keys, rec.NewImage, rec.OldImage} {
+		if m == nil {
+			continue
+		}
+
+		if b, err := json.Marshal(m); err == nil {
+			size += len(b)
+		}
+	}
+
+	return size
+}


### PR DESCRIPTION
## Summary

Fixes two cross-service integration bugs found by the real-user end-to-end sweep in the serverless / event-source-mapping area.

### 1. DynamoDB Stream event-source-mapping never invoked the mapped Lambda (MEDIUM)

`CreateEventSourceMapping(DynamoDB stream -> Lambda)` only stored static config; nothing consumed the table's recorded stream records, so writing an item to a streams-enabled table (State=Enabled) never invoked the target function. The stream records were readable via the `dynamodbstreams` `GetRecords` client, so the pipeline looked wired but the event never propagated — inconsistent with S3 -> Lambda notifications, which fire synchronously.

Now mirrored on the S3 -> Lambda `InvokeExternal` pattern:

- The Lambda mock gains a generic `DeliverEventSourceBatch(ctx, eventSourceARN, payload)` that invokes every **enabled** mapping whose `EventSourceArn` matches — reusable for any event source.
- The DynamoDB provider buffers each change record and, after releasing its lock (a mapped Lambda may write back into DynamoDB), delivers a DynamoDB Streams event batch through a new `SetStreamInvoker` injector.
- Wired in `providers/aws/aws.go`: `p.DynamoDB.SetStreamInvoker(p.Lambda)`.
- The delivered event matches the documented shape: `Records[].{eventID, eventName, eventVersion, eventSource:"aws:dynamodb", awsRegion, eventSourceARN, dynamodb:{ApproximateCreationDateTime, Keys, NewImage, OldImage, SequenceNumber, SizeBytes, StreamViewType}}` with AttributeValue-encoded images.
- The native -> AttributeValue encoder is centralized in `services/database/driver` (`MarshalItem` / `BuildLambdaStreamEvent`) and the Streams wire codec now delegates to it, so the ESM event and the `GetRecords` response render identical AV JSON (no duplicated encoder).

### 2. S3 event payload shape was incomplete (LOW)

The record delivered to an S3 notification target only carried `eventSource`, `eventName`, `awsRegion`, `eventTime`, and `s3.bucket.name` / `s3.object.{key,size}`. A handler reading `record.s3.object.eTag`/`sequencer` (dedup) or `record.s3.bucket.arn` got empty values.

The record now carries the full documented structure: top-level `eventVersion`, `userIdentity`, `requestParameters`, `responseElements`, and `s3.{s3SchemaVersion, configurationId, bucket.{name, arn, ownerIdentity}, object.{key, size, eTag, sequencer, versionId}}`. `configurationId` is the matched target's id; one sequencer is stamped per object operation across its records.

## Tests

- `server/aws/lambda/dynamodb_stream_esm_sdk_test.go` — real aws-sdk-go-v2 end-to-end: CreateTable(stream) + CreateFunction + CreateEventSourceMapping + PutItem, asserting the mapped function is invoked with the correctly-shaped stream event.
- `providers/aws/dynamodb/stream_esm_test.go` — provider-level delivery + transact batching + no-stream no-op.
- `providers/aws/lambda/esm_delivery_test.go` — enabled/disabled/ARN-match branch coverage for `DeliverEventSourceBatch`.
- `providers/aws/s3/notification_test.go` — asserts the complete S3 event record shape.

## Deferred

SQS -> Lambda and Kinesis -> Lambda ESM delivery are not wired here (their delete-on-consume semantics need separate care); the generic `DeliverEventSourceBatch` foundation is in place for them.

## Gates

`go build ./...`, `go test ./providers/aws/... ./server/aws/... ./services/...`, `go test ./compat/...`, `-race` on the touched providers, and golangci-lint on changed packages all pass. `go generate` + `internal/compatgen` produce no diff (no driver interface changed).
