### PR TITLE
fix(monitoring): backfill VM launch metrics into the past so query windows include them

### DIFF
--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -272,9 +272,12 @@ func (m *Mock) emitInstanceMetrics(ctx context.Context, instanceID, launchTime s
 
 	var data []mondriver.MetricDatum
 
+	// Backfill the 5 datapoints going backward from launch time so they land in
+	// the recent past. Forward-dating would place them in the future, where a
+	// GetMetricStatistics query ending at "now" filters them out.
 	for i, metricName := range metrics {
 		for j := 0; j < 5; j++ {
-			ts := lt.Add(time.Duration(j) * time.Minute)
+			ts := lt.Add(-time.Duration(j) * time.Minute)
 			data = append(data, mondriver.MetricDatum{
 				Namespace:  "AWS/EC2",
 				MetricName: metricName,

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -185,9 +185,12 @@ func (m *Mock) emitInstanceMetrics(ctx context.Context, instanceID, launchTime s
 
 	var data []mondriver.MetricDatum
 
+	// Backfill the 5 datapoints going backward from launch time so they land in
+	// the recent past. Forward-dating would place them in the future, where a
+	// metrics query ending at "now" filters them out.
 	for i, metricName := range metrics {
 		for j := 0; j < 5; j++ {
-			ts := lt.Add(time.Duration(j) * time.Minute)
+			ts := lt.Add(-time.Duration(j) * time.Minute)
 			data = append(data, mondriver.MetricDatum{
 				Namespace:  "Microsoft.Compute/virtualMachines",
 				MetricName: metricName,

--- a/providers/gcp/compute/gce.go
+++ b/providers/gcp/compute/gce.go
@@ -141,9 +141,12 @@ func (m *Mock) emitInstanceMetrics(ctx context.Context, instanceID, launchTime s
 
 	var data []mondriver.MetricDatum
 
+	// Backfill the 5 datapoints going backward from launch time so they land in
+	// the recent past. Forward-dating would place them in the future, where a
+	// metrics query ending at "now" filters them out.
 	for i, metricName := range metrics {
 		for j := 0; j < 5; j++ {
-			ts := lt.Add(time.Duration(j) * time.Minute)
+			ts := lt.Add(-time.Duration(j) * time.Minute)
 			data = append(data, mondriver.MetricDatum{
 				Namespace:  "compute.googleapis.com",
 				MetricName: metricName,

--- a/server/aws/ec2_test.go
+++ b/server/aws/ec2_test.go
@@ -2083,7 +2083,7 @@ func TestCloudWatchMetricsFlow(t *testing.T) {
 		Statistics: []cwtypes.Statistic{cwtypes.StatisticAverage},
 	})
 	require.NoError(t, err)
-	assert.NotEmpty(t, out.Datapoints, "CPUUtilization should have datapoints after RunInstances")
+	require.NotEmpty(t, out.Datapoints, "CPUUtilization should have datapoints after RunInstances")
 	assert.Greater(t, aws.ToFloat64(out.Datapoints[0].Average), 0.0)
 }
 


### PR DESCRIPTION
## Summary

`emitInstanceMetrics` on all three providers (AWS EC2, Azure VMs, GCP GCE) dated the 5 auto-emitted launch metrics **forward** from launch time (`lt.Add(+j*minute)`). Since launch time ≈ now, four of the five datapoints landed in the **future**, where a `GetMetricStatistics` query ending at `now` filters them out — leaving one boundary-fragile datapoint that intermittently aggregated to zero.

That surfaced as a flaky CI panic in `TestCloudWatchMetricsFlow`: `assert.NotEmpty` (non-halting) fell through to `out.Datapoints[0]` → `index out of range [0] with length 0`, crashing the whole `server/aws` test binary.

## Changes
- Backfill the 5 datapoints **backward** from launch time (recent past) on all three providers, so they reliably fall inside any `[past, now]` query window.
- Harden `TestCloudWatchMetricsFlow` to `require.NotEmpty` so an empty window fails cleanly instead of panic-indexing.

## Why
Pre-existing bug, mirrored identically across AWS/Azure/GCP. Real users query historical windows ending at "now"; forward-dated backfill is never visible to them. No driver-interface change.