### PR TITLE
fix(lambda): Invoke resolves version/alias qualifiers and ARNs

### DIFF
--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -290,6 +290,11 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", input.FunctionName)
 	}
 
+	executedVersion, err := m.resolveQualifier(&fd, input.Qualifier)
+	if err != nil {
+		return nil, err
+	}
+
 	dims := map[string]string{"FunctionName": input.FunctionName}
 
 	h := fd.handler
@@ -300,7 +305,7 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 	}
 
 	if h == nil && fd.engineBacked {
-		return m.invokeEngine(ctx, input, dims)
+		return m.invokeEngine(ctx, input, dims, executedVersion)
 	}
 
 	if h == nil {
@@ -318,7 +323,7 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 			payload = []byte("{}")
 		}
 
-		return &driver.InvokeOutput{StatusCode: 200, Payload: payload}, nil
+		return &driver.InvokeOutput{StatusCode: 200, Payload: payload, ExecutedVersion: executedVersion}, nil
 	}
 
 	payload, err := h(ctx, input.Payload)
@@ -326,14 +331,37 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 		m.emitMetric(ctx, "Invocations", 1, dims)
 		m.emitMetric(ctx, "Errors", 1, dims)
 
-		return &driver.InvokeOutput{StatusCode: 500, Error: err.Error()}, nil
+		return &driver.InvokeOutput{StatusCode: 500, Error: err.Error(), ExecutedVersion: executedVersion}, nil
 	}
 
 	m.emitMetric(ctx, "Invocations", 1, dims)
 	m.emitMetric(ctx, "Duration", 1.0, dims)
 	m.emitMetric(ctx, "ConcurrentExecutions", 1, dims)
 
-	return &driver.InvokeOutput{StatusCode: 200, Payload: payload}, nil
+	return &driver.InvokeOutput{StatusCode: 200, Payload: payload, ExecutedVersion: executedVersion}, nil
+}
+
+// resolveQualifier resolves an Invoke Qualifier (empty, "$LATEST", a numeric
+// published version, or an alias name) to the concrete version that should be
+// reported as ExecutedVersion, matching real Lambda's alias-resolution
+// semantics: an alias resolves one hop to its target FunctionVersion (aliases
+// can't point to other aliases); a version qualifier must name a version that
+// was actually published. An unknown qualifier is a ResourceNotFoundException,
+// the same error AWS returns for an alias or version that doesn't exist.
+func (m *Mock) resolveQualifier(fd *funcData, qualifier string) (string, error) {
+	if qualifier == "" || qualifier == latestVersion {
+		return latestVersion, nil
+	}
+
+	if ad, ok := fd.aliases.Get(qualifier); ok {
+		return ad.alias.FunctionVersion, nil
+	}
+
+	if m.versionExists(fd, qualifier) {
+		return qualifier, nil
+	}
+
+	return "", cerrors.Newf(cerrors.NotFound, "function version/alias not found for %s", qualifier)
 }
 
 // InvokeExternal asynchronously invokes the function identified by its ARN with
@@ -394,11 +422,15 @@ func functionNameFromARN(arn string) string {
 // FunctionEngine and records the same metrics as a real handler invocation. A
 // handler that raised is reported via out.Error (HTTP stays 200), matching real
 // Lambda's X-Amz-Function-Error semantics.
-func (m *Mock) invokeEngine(ctx context.Context, input driver.InvokeInput, dims map[string]string) (*driver.InvokeOutput, error) {
+func (m *Mock) invokeEngine(
+	ctx context.Context, input driver.InvokeInput, dims map[string]string, executedVersion string,
+) (*driver.InvokeOutput, error) {
 	out, err := funcengine.Invoke(ctx, m.opts.FunctionEngine, input.FunctionName, input.Payload)
 	if err != nil {
 		return nil, cerrors.Newf(cerrors.Internal, "invoke function %s: %v", input.FunctionName, err)
 	}
+
+	out.ExecutedVersion = executedVersion
 
 	m.emitMetric(ctx, "Invocations", 1, dims)
 

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -331,6 +331,29 @@ func functionNameFromARN(arn string) string {
 	return arn
 }
 
+// splitFunctionNameQualifier extracts the bare function name and an optional
+// version/alias qualifier from an Invoke FunctionName path segment. Per the
+// Lambda Invoke API's FunctionName pattern, a version or alias can be
+// appended with ":<qualifier>" to any accepted form: a bare name
+// ("my-fn:PROD"), a full ARN ("arn:aws:lambda:region:account:function:my-fn:PROD"),
+// or a partial ARN ("account:function:my-fn:PROD"). Everything through the
+// "function:" marker (if present) is the function name; a colon after that is
+// the qualifier boundary.
+func splitFunctionNameQualifier(raw string) (name, qualifier string) {
+	const marker = ":function:"
+
+	rest := raw
+	if i := strings.LastIndex(raw, marker); i >= 0 {
+		rest = raw[i+len(marker):]
+	}
+
+	if j := strings.IndexByte(rest, ':'); j >= 0 {
+		return rest[:j], rest[j+1:]
+	}
+
+	return rest, ""
+}
+
 // servePolicy handles POST (AddPermission) and GET (GetPolicy) on
 // .../{name}/policy.
 func (h *Handler) servePolicy(w http.ResponseWriter, r *http.Request, name string) {
@@ -851,13 +874,22 @@ func (h *Handler) invoke(w http.ResponseWriter, r *http.Request, name string) {
 		return
 	}
 
+	// FunctionName may carry its own ":<qualifier>" suffix (bare name, full ARN,
+	// or partial ARN all accept one — see the Invoke API's FunctionName pattern);
+	// the Qualifier query parameter is the other place AWS accepts one and, when
+	// both are present, wins.
+	functionName, qualifier := splitFunctionNameQualifier(name)
+	if q := r.URL.Query().Get("Qualifier"); q != "" {
+		qualifier = q
+	}
+
 	invokeType := r.Header.Get("X-Amz-Invocation-Type")
 
 	// A DryRun invocation validates the request without executing the function:
 	// confirm the function exists, then return 204 No Content (real Lambda runs
 	// nothing and returns no payload).
 	if invokeType == invocationTypeDryRun {
-		if _, err = h.fn.GetFunction(r.Context(), name); err != nil {
+		if _, err = h.fn.GetFunction(r.Context(), functionName); err != nil {
 			writeErr(w, err)
 			return
 		}
@@ -868,9 +900,10 @@ func (h *Handler) invoke(w http.ResponseWriter, r *http.Request, name string) {
 	}
 
 	out, err := h.fn.Invoke(r.Context(), sdrv.InvokeInput{
-		FunctionName: name,
+		FunctionName: functionName,
 		Payload:      payload,
 		InvokeType:   invokeType,
+		Qualifier:    qualifier,
 	})
 	if err != nil {
 		writeErr(w, err)
@@ -885,11 +918,18 @@ func (h *Handler) invoke(w http.ResponseWriter, r *http.Request, name string) {
 	}
 
 	w.Header().Set("Content-Type", contentTypeJSON)
+
 	// A synchronous (RequestResponse) invocation always reports the version that
-	// ran via X-Amz-Executed-Version. The emulator invokes the unqualified
-	// function, so the executed version is $LATEST. The SDK reads this into
-	// InvokeOutput.ExecutedVersion.
-	w.Header().Set("X-Amz-Executed-Version", latestVersion)
+	// ran via X-Amz-Executed-Version, which the SDK reads into
+	// InvokeOutput.ExecutedVersion: the alias's target version when Qualifier
+	// named an alias, the qualifier itself when it named a version, or $LATEST
+	// for an unqualified invoke.
+	executedVersion := out.ExecutedVersion
+	if executedVersion == "" {
+		executedVersion = latestVersion
+	}
+
+	w.Header().Set("X-Amz-Executed-Version", executedVersion)
 
 	if out.Error != "" {
 		// Lambda surfaces handler errors via the X-Amz-Function-Error header

--- a/server/aws/lambda/response_fields_test.go
+++ b/server/aws/lambda/response_fields_test.go
@@ -43,6 +43,84 @@ func TestSDKInvokeExecutedVersion(t *testing.T) {
 	}
 }
 
+// TestSDKInvokeAliasQualifier covers Invoke resolving a published alias to
+// its target version, both by full alias ARN and by FunctionName+Qualifier:
+// before the fix, invoking by alias ARN 404'd (FunctionName was never
+// stripped of its ARN/qualifier suffix before lookup) and invoking by
+// name+Qualifier silently ran $LATEST instead of the aliased version.
+func TestSDKInvokeAliasQualifier(t *testing.T) {
+	client, cloud := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("versioned-fn"),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+	}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	cloud.Lambda.RegisterHandler("versioned-fn", func(_ context.Context, payload []byte) ([]byte, error) {
+		return payload, nil
+	})
+
+	pub, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
+		FunctionName: aws.String("versioned-fn"),
+	})
+	if err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+
+	alias, err := client.CreateAlias(ctx, &awslambda.CreateAliasInput{
+		FunctionName:    aws.String("versioned-fn"),
+		Name:            aws.String("live"),
+		FunctionVersion: aws.String(aws.ToString(pub.Version)),
+	})
+	if err != nil {
+		t.Fatalf("CreateAlias: %v", err)
+	}
+
+	// (a) Invoke by full alias ARN must succeed (not 404) and report the
+	// alias's target version.
+	byARN, err := client.Invoke(ctx, &awslambda.InvokeInput{
+		FunctionName: alias.AliasArn,
+		Payload:      []byte(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("Invoke(aliasArn): %v", err)
+	}
+	if aws.ToString(byARN.ExecutedVersion) != "1" {
+		t.Fatalf("Invoke(aliasArn) ExecutedVersion = %q, want 1", aws.ToString(byARN.ExecutedVersion))
+	}
+
+	// (b) Invoke by name + Qualifier must resolve the same alias.
+	byQualifier, err := client.Invoke(ctx, &awslambda.InvokeInput{
+		FunctionName: aws.String("versioned-fn"),
+		Qualifier:    aws.String("live"),
+		Payload:      []byte(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("Invoke(name+Qualifier): %v", err)
+	}
+	if aws.ToString(byQualifier.ExecutedVersion) != "1" {
+		t.Fatalf("Invoke(name+Qualifier) ExecutedVersion = %q, want 1", aws.ToString(byQualifier.ExecutedVersion))
+	}
+
+	// An unqualified invoke still reports $LATEST.
+	unqualified, err := client.Invoke(ctx, &awslambda.InvokeInput{
+		FunctionName: aws.String("versioned-fn"),
+		Payload:      []byte(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("Invoke(unqualified): %v", err)
+	}
+	if aws.ToString(unqualified.ExecutedVersion) != "$LATEST" {
+		t.Fatalf("Invoke(unqualified) ExecutedVersion = %q, want $LATEST", aws.ToString(unqualified.ExecutedVersion))
+	}
+}
+
 // TestSDKGetFunctionConcurrency covers GetFunction surfacing the top-level
 // Concurrency object once reserved concurrency has been set: before the fix the
 // GetFunction response never carried Concurrency even after PutFunctionConcurrency.

--- a/services/serverless/driver/driver.go
+++ b/services/serverless/driver/driver.go
@@ -201,6 +201,10 @@ type InvokeInput struct {
 	FunctionName string
 	Payload      []byte
 	InvokeType   string // "RequestResponse" or "Event"
+	// Qualifier selects a published version (a numeric version string) or
+	// alias to invoke instead of the mutable $LATEST code. Empty invokes
+	// $LATEST, matching the AWS Lambda Invoke Qualifier parameter.
+	Qualifier string
 }
 
 // InvokeOutput is the result of a function invocation.
@@ -208,6 +212,11 @@ type InvokeOutput struct {
 	StatusCode int
 	Payload    []byte
 	Error      string
+	// ExecutedVersion is the version that actually ran: the alias's target
+	// version when Qualifier names an alias, the Qualifier itself when it
+	// names a version, or "$LATEST" for an unqualified invoke. Mirrors the
+	// AWS Lambda Invoke ExecutedVersion response field.
+	ExecutedVersion string
 }
 
 // HandlerFunc is a function handler that processes invocations.


### PR DESCRIPTION
## Summary

Lambda `Invoke` ignored version/alias qualifiers entirely. Invoking by a full alias ARN (`.../function:my-fn:live`) returned `ResourceNotFoundException`, and invoking by `FunctionName` + `Qualifier=live` succeeded but always reported `ExecutedVersion=$LATEST` instead of the version the alias actually points to.

## Changes

- `services/serverless/driver`: `InvokeInput` gains a `Qualifier` field; `InvokeOutput` gains `ExecutedVersion`.
- `providers/aws/lambda`: `Invoke` resolves the qualifier — an alias name resolves one hop to its target `FunctionVersion`, a numeric version is verified against published versions, an unknown qualifier returns `ResourceNotFoundException` — and reports the resolved version via `ExecutedVersion` on every return path (stub echo, registered handler, engine-backed).
- `server/aws/lambda/handler.go`: the Invoke wire handler now parses a `:<qualifier>` suffix off `FunctionName` (bare name, full ARN, or partial ARN all accept one, per the Invoke API's `FunctionName` pattern) and the `Qualifier` query parameter (which wins if both are present), and reports the resolved version via `X-Amz-Executed-Version`.

## Test plan

- Added `TestSDKInvokeAliasQualifier` (`server/aws/lambda/response_fields_test.go`), driving a real `aws-sdk-go-v2` Lambda client against a live `httptest` wire server: publishes a version, creates an alias, then invokes by full alias ARN and by `FunctionName`+`Qualifier`, asserting both succeed and report `ExecutedVersion="1"`, and that an unqualified invoke still reports `$LATEST`.
- `go build ./...`, `go vet ./...`, `go test ./providers/... ./server/... ./services/... .`, `go test ./compat/...` all green.
- `golangci-lint run` on changed packages: zero new issues.
- No `docs/coverage` or `docs/compat` diff (no interface method signature changed).