### PR TITLE
fix(rds): read replicas and snapshot restores inherit source DBName/port/parameter group

### DIFF
--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -1143,6 +1143,11 @@ func (m *Mock) CreateSnapshot(_ context.Context, cfg rdsdriver.SnapshotConfig) (
 		State:            rdsdriver.SnapshotAvailable,
 		CreatedAt:        m.opts.Clock.Now().UTC(),
 		Tags:             copyTags(cfg.Tags),
+		// Captured so the snapshot is a self-contained restore point that
+		// survives the source instance being deleted.
+		MasterUsername: inst.MasterUsername,
+		DBName:         inst.DBName,
+		Port:           inst.Port,
 	}
 
 	now := m.opts.Clock.Now()
@@ -1233,26 +1238,7 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 		instanceClass = defaultInstanceClass
 	}
 
-	// Inherit the source instance's master login, DBName, and port so the
-	// restored database matches the original's shape; fall back to engine
-	// defaults when the source is gone. The password is remembered under the
-	// snapshot's source id.
-	var username, dbName string
-
-	port := input.Port
-
-	if src, ok := m.instances.Get(snap.InstanceID); ok {
-		username = src.MasterUsername
-		dbName = src.DBName
-
-		if port == 0 {
-			port = src.Port
-		}
-	}
-
-	if port == 0 {
-		port = defaultPortFor(snap.Engine)
-	}
+	username, dbName, port := m.restoreAttrsFromSnapshot(&snap, input.Port)
 
 	password := m.rootPasswords[snap.InstanceID]
 
@@ -1293,6 +1279,60 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 	out := inst
 
 	return &out, nil
+}
+
+// restoreAttrsFromSnapshot resolves the master login, DBName, and port for an
+// instance being restored from snap, preferring the snapshot's own captured
+// metadata over a live source-instance lookup. This matches real RDS: a
+// snapshot is a self-contained point-in-time image, so a restore reflects the
+// source's shape AT SNAPSHOT TIME even if the source instance has since been
+// deleted or modified. Older snapshots taken before these fields were
+// captured fall back to a live source-instance lookup, then engine defaults.
+// requestedPort is the caller-supplied Port input, which always wins when set.
+func (m *Mock) restoreAttrsFromSnapshot(snap *rdsdriver.Snapshot, requestedPort int) (username, dbName string, port int) {
+	username = snap.MasterUsername
+	dbName = snap.DBName
+	port = requestedPort
+
+	if port == 0 {
+		port = snap.Port
+	}
+
+	if username == "" || dbName == "" || port == 0 {
+		username, dbName, port = m.fallbackRestoreAttrsFromSource(snap.InstanceID, username, dbName, port)
+	}
+
+	if port == 0 {
+		port = defaultPortFor(snap.Engine)
+	}
+
+	return username, dbName, port
+}
+
+// fallbackRestoreAttrsFromSource fills in any still-missing username/dbName/port
+// from a live lookup of the snapshot's source instance, for snapshots taken
+// before that metadata was captured on the snapshot itself.
+func (m *Mock) fallbackRestoreAttrsFromSource(
+	sourceID, username, dbName string, port int,
+) (resolvedUsername, resolvedDBName string, resolvedPort int) {
+	src, ok := m.instances.Get(sourceID)
+	if !ok {
+		return username, dbName, port
+	}
+
+	if username == "" {
+		username = src.MasterUsername
+	}
+
+	if dbName == "" {
+		dbName = src.DBName
+	}
+
+	if port == 0 {
+		port = src.Port
+	}
+
+	return username, dbName, port
 }
 
 // CreateClusterSnapshot snapshots a cluster.

--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -1233,12 +1233,25 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 		instanceClass = defaultInstanceClass
 	}
 
-	// Inherit the source instance's master login so the restored database is
-	// reachable with the same credentials; fall back to engine defaults when the
-	// source is gone. The password is remembered under the snapshot's source id.
-	var username string
+	// Inherit the source instance's master login, DBName, and port so the
+	// restored database matches the original's shape; fall back to engine
+	// defaults when the source is gone. The password is remembered under the
+	// snapshot's source id.
+	var username, dbName string
+
+	port := input.Port
+
 	if src, ok := m.instances.Get(snap.InstanceID); ok {
 		username = src.MasterUsername
+		dbName = src.DBName
+
+		if port == 0 {
+			port = src.Port
+		}
+	}
+
+	if port == 0 {
+		port = defaultPortFor(snap.Engine)
 	}
 
 	password := m.rootPasswords[snap.InstanceID]
@@ -1252,8 +1265,9 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 		AllocatedStorage: snap.AllocatedStorage,
 		StorageType:      defaultStorageType,
 		MasterUsername:   username,
+		DBName:           dbName,
 		Endpoint:         endpointFor(input.NewInstanceID, m.opts.Region, "abcd1234"),
-		Port:             defaultPortFor(snap.Engine),
+		Port:             port,
 		State:            rdsdriver.StateAvailable,
 		CreatedAt:        m.opts.Clock.Now().UTC(),
 		Tags:             copyTags(input.Tags),

--- a/providers/aws/rds/rds_test.go
+++ b/providers/aws/rds/rds_test.go
@@ -219,6 +219,48 @@ func TestSnapshotAndRestore(t *testing.T) {
 	requireNoError(t, m.DeleteSnapshot(ctx, "snap-1"))
 }
 
+// TestRestoreFromSnapshotAfterSourceDeleted verifies that RestoreDBInstanceFromDBSnapshot
+// restores DBName, MasterUsername, and Port from the snapshot's own captured metadata, not
+// a live lookup of the source instance. Snapshots are meant to outlive their source instance
+// (a normal, common scenario), so the source being deleted before restore must not lose or
+// default these attributes. See AWS API docs for RestoreDBInstanceFromDBSnapshot: "The target
+// database is created from the source database restore point with most of the source's
+// original configuration" and Port "Default: The same port as the original DB instance".
+func TestRestoreFromSnapshotAfterSourceDeleted(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	const nonDefaultPort = 5555
+
+	_, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{
+		ID:             "src2",
+		Engine:         "mysql",
+		MasterUsername: "appadmin",
+		DBName:         "appdb",
+		Port:           nonDefaultPort,
+	})
+	requireNoError(t, err)
+
+	_, err = m.CreateSnapshot(ctx, rdsdriver.SnapshotConfig{
+		ID:         "snap-2",
+		InstanceID: "src2",
+	})
+	requireNoError(t, err)
+
+	// Snapshots outlive their source instance; delete it before restoring.
+	requireNoError(t, m.DeleteInstance(ctx, "src2"))
+
+	restored, err := m.RestoreInstanceFromSnapshot(ctx, rdsdriver.RestoreInstanceInput{
+		NewInstanceID: "restored2",
+		SnapshotID:    "snap-2",
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "appdb", restored.DBName)
+	assertEqual(t, "appadmin", restored.MasterUsername)
+	assertEqual(t, nonDefaultPort, restored.Port)
+}
+
 func TestClusterSnapshotAndRestore(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/providers/aws/rds/read_replica.go
+++ b/providers/aws/rds/read_replica.go
@@ -19,7 +19,8 @@ func (m *Mock) sourceEngineBacked(engine string) bool {
 }
 
 // CreateDBInstanceReadReplica creates a replica reading from an existing
-// primary instance, inheriting the source's engine, version and storage.
+// primary instance, inheriting the source's engine, version, storage,
+// DBName, and DBParameterGroup unless the caller overrides them.
 //
 //nolint:gocritic // cfg matches the driver interface signature.
 func (m *Mock) CreateDBInstanceReadReplica(_ context.Context, cfg rdsdriver.ReadReplicaConfig) (*rdsdriver.Instance, error) {
@@ -53,6 +54,14 @@ func (m *Mock) CreateDBInstanceReadReplica(_ context.Context, cfg rdsdriver.Read
 		port = src.Port
 	}
 
+	// Same-Region read replicas inherit the source's DBParameterGroup and
+	// DBName unless the caller overrides the parameter group explicitly.
+	// DBName has no override parameter on CreateDBInstanceReadReplica at all.
+	dbParameterGroupName := cfg.DBParameterGroupName
+	if dbParameterGroupName == "" {
+		dbParameterGroupName = src.DBParameterGroupName
+	}
+
 	// A real read replica serves the SOURCE's data. When the source is backed by
 	// a real engine, point the replica at the source's reachable host:port so a
 	// client reading from the replica reaches the real database — provisioning a
@@ -65,22 +74,24 @@ func (m *Mock) CreateDBInstanceReadReplica(_ context.Context, cfg rdsdriver.Read
 	}
 
 	replica := rdsdriver.Instance{
-		ID:                 cfg.ID,
-		ARN:                instanceARN(m.opts.Region, m.opts.AccountID, cfg.ID),
-		Engine:             src.Engine,
-		EngineVersion:      src.EngineVersion,
-		InstanceClass:      instanceClass,
-		AllocatedStorage:   src.AllocatedStorage,
-		StorageType:        src.StorageType,
-		MasterUsername:     src.MasterUsername,
-		Endpoint:           endpoint,
-		Port:               port,
-		State:              rdsdriver.StateAvailable,
-		PubliclyAccessible: cfg.PubliclyAccessible,
-		AvailabilityZone:   cfg.AvailabilityZone,
-		CreatedAt:          m.opts.Clock.Now(),
-		Tags:               copyTags(cfg.Tags),
-		ReadReplicaSource:  cfg.SourceInstanceID,
+		ID:                   cfg.ID,
+		ARN:                  instanceARN(m.opts.Region, m.opts.AccountID, cfg.ID),
+		Engine:               src.Engine,
+		EngineVersion:        src.EngineVersion,
+		InstanceClass:        instanceClass,
+		AllocatedStorage:     src.AllocatedStorage,
+		StorageType:          src.StorageType,
+		MasterUsername:       src.MasterUsername,
+		DBName:               src.DBName,
+		Endpoint:             endpoint,
+		Port:                 port,
+		State:                rdsdriver.StateAvailable,
+		PubliclyAccessible:   cfg.PubliclyAccessible,
+		AvailabilityZone:     cfg.AvailabilityZone,
+		DBParameterGroupName: dbParameterGroupName,
+		CreatedAt:            m.opts.Clock.Now(),
+		Tags:                 copyTags(cfg.Tags),
+		ReadReplicaSource:    cfg.SourceInstanceID,
 	}
 	m.instances.Set(cfg.ID, replica)
 

--- a/server/aws/rds/operations.go
+++ b/server/aws/rds/operations.go
@@ -649,6 +649,7 @@ func (h *Handler) restoreInstanceFromSnapshot(w http.ResponseWriter, r *http.Req
 		NewInstanceID: form.Get("DBInstanceIdentifier"),
 		SnapshotID:    form.Get("DBSnapshotIdentifier"),
 		InstanceClass: form.Get("DBInstanceClass"),
+		Port:          formInt(form.Get("Port")),
 		Tags:          parseRDSTags(form),
 	}
 

--- a/server/aws/rds/read_replica.go
+++ b/server/aws/rds/read_replica.go
@@ -36,13 +36,14 @@ func (h *Handler) createDBInstanceReadReplica(w http.ResponseWriter, r *http.Req
 	}
 
 	inst, err := store.CreateDBInstanceReadReplica(r.Context(), rdsdriver.ReadReplicaConfig{
-		ID:                 r.Form.Get("DBInstanceIdentifier"),
-		SourceInstanceID:   r.Form.Get("SourceDBInstanceIdentifier"),
-		InstanceClass:      r.Form.Get("DBInstanceClass"),
-		AvailabilityZone:   r.Form.Get("AvailabilityZone"),
-		Port:               formInt(r.Form.Get("Port")),
-		PubliclyAccessible: formBool(r.Form.Get("PubliclyAccessible")),
-		Tags:               parseRDSTags(r.Form),
+		ID:                   r.Form.Get("DBInstanceIdentifier"),
+		SourceInstanceID:     r.Form.Get("SourceDBInstanceIdentifier"),
+		InstanceClass:        r.Form.Get("DBInstanceClass"),
+		AvailabilityZone:     r.Form.Get("AvailabilityZone"),
+		Port:                 formInt(r.Form.Get("Port")),
+		PubliclyAccessible:   formBool(r.Form.Get("PubliclyAccessible")),
+		DBParameterGroupName: r.Form.Get("DBParameterGroupName"),
+		Tags:                 parseRDSTags(r.Form),
 	})
 	if err != nil {
 		writeErr(w, err)

--- a/server/aws/rds/restore_replica_inherit_sdk_roundtrip_test.go
+++ b/server/aws/rds/restore_replica_inherit_sdk_roundtrip_test.go
@@ -1,0 +1,92 @@
+package rds_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+)
+
+// TestSDKRDSReadReplicaInheritsSourceAttributes guards that a read replica
+// inherits DBName and DBParameterGroupName from its source instance when the
+// caller doesn't override them, matching real RDS: "All other attributes
+// ... are inherited from the source DB instance ... except as specified."
+func TestSDKRDSReadReplicaInheritsSourceAttributes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("inherit-src"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		AllocatedStorage:     aws.Int32(20),
+		DBName:               aws.String("appdb"),
+		DBParameterGroupName: aws.String("custom-mysql-params"),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	replica, err := client.CreateDBInstanceReadReplica(ctx, &awsrds.CreateDBInstanceReadReplicaInput{
+		DBInstanceIdentifier:       aws.String("inherit-replica"),
+		SourceDBInstanceIdentifier: aws.String("inherit-src"),
+	})
+	if err != nil {
+		t.Fatalf("CreateDBInstanceReadReplica: %v", err)
+	}
+
+	if got := aws.ToString(replica.DBInstance.DBName); got != "appdb" {
+		t.Fatalf("replica DBName = %q, want appdb (inherited from source)", got)
+	}
+
+	if len(replica.DBInstance.DBParameterGroups) != 1 ||
+		aws.ToString(replica.DBInstance.DBParameterGroups[0].DBParameterGroupName) != "custom-mysql-params" {
+		t.Fatalf("replica DBParameterGroups = %v, want [custom-mysql-params] (inherited from source)",
+			replica.DBInstance.DBParameterGroups)
+	}
+}
+
+// TestSDKRDSRestoreFromSnapshotInheritsSourceAttributes guards that
+// RestoreDBInstanceFromDBSnapshot carries DBName and the source instance's
+// non-default Port onto the restored instance, matching the API docs:
+// Port "Default: The same port as the original DB instance".
+func TestSDKRDSRestoreFromSnapshotInheritsSourceAttributes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("restore-src"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		AllocatedStorage:     aws.Int32(20),
+		DBName:               aws.String("appdb"),
+		Port:                 aws.Int32(3307), // non-default MySQL port
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	if _, err := client.CreateDBSnapshot(ctx, &awsrds.CreateDBSnapshotInput{
+		DBSnapshotIdentifier: aws.String("restore-snap"),
+		DBInstanceIdentifier: aws.String("restore-src"),
+	}); err != nil {
+		t.Fatalf("CreateDBSnapshot: %v", err)
+	}
+
+	restored, err := client.RestoreDBInstanceFromDBSnapshot(ctx,
+		&awsrds.RestoreDBInstanceFromDBSnapshotInput{
+			DBInstanceIdentifier: aws.String("restored-inherit"),
+			DBSnapshotIdentifier: aws.String("restore-snap"),
+		})
+	if err != nil {
+		t.Fatalf("RestoreDBInstanceFromDBSnapshot: %v", err)
+	}
+
+	if got := aws.ToString(restored.DBInstance.DBName); got != "appdb" {
+		t.Fatalf("restored DBName = %q, want appdb (inherited from source)", got)
+	}
+
+	if restored.DBInstance.Endpoint == nil || aws.ToInt32(restored.DBInstance.Endpoint.Port) != 3307 {
+		t.Fatalf("restored Port = %v, want 3307 (inherited from source, not the engine default)",
+			restored.DBInstance.Endpoint)
+	}
+}

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -323,7 +323,11 @@ type RestoreInstanceInput struct {
 	NewInstanceID string
 	SnapshotID    string
 	InstanceClass string
-	Tags          map[string]string
+	// Port overrides the restored instance's connection port. Zero means "no
+	// override": AWS falls back to the same port as the original DB instance
+	// the snapshot was taken from, not the engine default.
+	Port int
+	Tags map[string]string
 }
 
 // RestoreClusterInput configures restoring a cluster from a snapshot.
@@ -886,7 +890,11 @@ type ReadReplicaConfig struct {
 	AvailabilityZone   string
 	Port               int
 	PubliclyAccessible bool
-	Tags               map[string]string
+	// DBParameterGroupName overrides the replica's parameter group. Empty
+	// means "no override": AWS inherits the source instance's DBParameterGroup
+	// for a same-Region replica.
+	DBParameterGroupName string
+	Tags                 map[string]string
 }
 
 // ReadReplicas is an OPTIONAL capability for creating and promoting read

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -290,6 +290,16 @@ type Snapshot struct {
 	State            string
 	CreatedAt        time.Time
 	Tags             map[string]string
+	// The fields below capture the source instance's shape at snapshot time, so a
+	// restore is a self-contained point-in-time image, matching real RDS ("the
+	// target database is created from the source database restore point with most
+	// of the source's original configuration") rather than a live lookup of a
+	// source instance that may since have been deleted. They are empty on
+	// snapshots created before this capture existed; restore falls back to a live
+	// source-instance lookup in that case.
+	MasterUsername string
+	DBName         string
+	Port           int
 }
 
 // ClusterSnapshotConfig configures a cluster snapshot.


### PR DESCRIPTION
## Summary

Real RDS documents that a read replica inherits "all other attributes ... from the source DB instance ... except as specified", and that `RestoreDBInstanceFromDBSnapshot`'s `Port` defaults to "the same port as the original DB instance". CloudEmu wasn't matching either behavior:

- `CreateDBInstanceReadReplica` dropped the source's `DBName` and `DBParameterGroupName` entirely instead of inheriting them (or honoring a `DBParameterGroupName` override).
- `RestoreDBInstanceFromDBSnapshot` dropped `DBName` (while `AllocatedStorage`/`Engine`/`MasterUsername` were already carried over), and always restored the engine's default port instead of falling back to the source instance's port when the caller doesn't specify one.

## Changes

- `services/relationaldb/driver`: add `DBParameterGroupName` to `ReadReplicaConfig` and `Port` to `RestoreInstanceInput` as optional overrides.
- `providers/aws/rds`: `CreateDBInstanceReadReplica` now inherits `DBName` and `DBParameterGroupName` from the source when not overridden; `RestoreInstanceFromSnapshot` now looks up the source instance (same pattern as `MasterUsername`) to inherit `DBName` and falls back to the source's `Port` before falling back to the engine default.
- `server/aws/rds`: wire the new `DBParameterGroupName` (read replica) and `Port` (restore) form fields through to the driver configs.

## Test plan

- Added `TestSDKRDSReadReplicaInheritsSourceAttributes` and `TestSDKRDSRestoreFromSnapshotInheritsSourceAttributes` — real `aws-sdk-go-v2` RDS client against a live `httptest` wire server, verifying both regressions are fixed (confirmed they fail against the pre-fix code).
- `go build ./...`, `go vet ./...`, `go test ./providers/... ./server/... ./services/... .`, `go test ./compat/...`, `golangci-lint run` on changed packages (no new issues), `gofmt -l` clean.
- `go run ./internal/coveragegen` and `go run ./internal/compatgen` produced no diff.