### PR TITLE
fix(ecs): register/deregister service tasks with ELBv2 target groups, add networkBindings

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -260,6 +260,9 @@ func New(opts ...config.Option) *Provider {
 	p.ECS.SetManagedInstanceLauncher(p.EC2)
 	// Engine-backed ECS tasks push their awslogs container output to CloudWatch Logs.
 	p.ECS.SetLogSink(p.CloudWatchLogs)
+	// A service's loadBalancers[] register/deregister RUNNING tasks with their
+	// ELBv2 target group as the scheduler converges/drains the service.
+	p.ECS.SetTargetRegistrar(p.ELB)
 	p.Redshift.SetMonitoring(p.CloudWatch)
 	p.EKS.SetMonitoring(p.CloudWatch)
 	p.SageMaker.SetMonitoring(p.CloudWatch)

--- a/providers/aws/ecs/capacity.go
+++ b/providers/aws/ecs/capacity.go
@@ -14,6 +14,14 @@ const (
 	launchExternal = "EXTERNAL"
 
 	networkModeAwsvpc = "awsvpc"
+	networkModeHost   = "host"
+
+	// ephemeralPortBase / ephemeralPortSpan bound the dynamic host-port range ECS
+	// assigns a bridge-mode container port mapping left with hostPort unset,
+	// matching the Linux ephemeral-port range (32768-65535) real ECS agents draw
+	// from.
+	ephemeralPortBase = 32768
+	ephemeralPortSpan = 65536 - ephemeralPortBase
 
 	// ecsServicePrincipal / managedLaunchTag mark a container instance's backing
 	// EC2 instance as managed by ECS (composing #159 with #300).

--- a/providers/aws/ecs/clone.go
+++ b/providers/aws/ecs/clone.go
@@ -187,13 +187,32 @@ func copyStringMap(in map[string]string) map[string]string {
 	return out
 }
 
-// cloneTask deep-copies a task's Containers, Attachments (including each
-// attachment's Details), and Tags slices.
+// cloneTask deep-copies a task's Containers (including each container's
+// NetworkBindings), Attachments (including each attachment's Details), and
+// Tags slices.
 func cloneTask(t *driver.Task) driver.Task {
 	out := *t
-	out.Containers = append([]driver.Container(nil), t.Containers...)
+	out.Containers = cloneContainers(t.Containers)
 	out.Attachments = cloneAttachments(t.Attachments)
 	out.Tags = copyTags(t.Tags)
+
+	return out
+}
+
+// cloneContainers deep-copies a slice of containers and each container's
+// NetworkBindings slice.
+func cloneContainers(in []driver.Container) []driver.Container {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]driver.Container, len(in))
+
+	for i := range in {
+		c := in[i]
+		c.NetworkBindings = append([]driver.NetworkBinding(nil), in[i].NetworkBindings...)
+		out[i] = c
+	}
 
 	return out
 }

--- a/providers/aws/ecs/ecs.go
+++ b/providers/aws/ecs/ecs.go
@@ -6,6 +6,7 @@ package ecs
 import (
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -50,6 +51,12 @@ type Mock struct {
 	engineHandles *memstore.Store[string]
 
 	logs logdriver.Logging // optional: awslogs surfacing target (CloudWatch Logs)
+
+	registrar TargetRegistrar // optional: ELBv2 target group the service scheduler registers RUNNING tasks with
+
+	// portCounter draws successive dynamic host ports for bridge-mode container
+	// port mappings that leave hostPort unset.
+	portCounter atomic.Uint32
 }
 
 // ManagedInstanceLauncher provisions the managed EC2 instance that backs an ECS
@@ -94,6 +101,15 @@ func (m *Mock) SetLogSink(l logdriver.Logging) {
 
 func (m *Mock) now() string {
 	return m.opts.Clock.Now().UTC().Format(time.RFC3339)
+}
+
+// nextEphemeralPort returns the next synthetic dynamic host port for a
+// bridge-mode container port mapping that left hostPort unset, drawn from the
+// ephemeral range real ECS agents assign from.
+func (m *Mock) nextEphemeralPort() int {
+	n := m.portCounter.Add(1)
+
+	return ephemeralPortBase + int(n%ephemeralPortSpan)
 }
 
 func (m *Mock) arn(resource string) string {

--- a/providers/aws/ecs/services.go
+++ b/providers/aws/ecs/services.go
@@ -234,6 +234,8 @@ func (m *Mock) converge(
 
 		if task.LastStatus == statusRunning {
 			running++
+
+			m.registerTaskTargets(ctx, svc, td, task)
 		} else {
 			pending++
 		}
@@ -271,6 +273,7 @@ func (m *Mock) drainService(ctx context.Context, svc *driver.Service) {
 			continue
 		}
 
+		m.deregisterTaskTargets(ctx, svc, t)
 		_, _ = m.StopTask(ctx, cluster, t.ARN, serviceStoppedReason)
 	}
 }

--- a/providers/aws/ecs/target_registration.go
+++ b/providers/aws/ecs/target_registration.go
@@ -1,0 +1,141 @@
+package ecs
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/services/ecs/driver"
+	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+)
+
+// TargetRegistrar is the local interface the ECS mock consumes to register and
+// deregister a service's RUNNING tasks against the ELBv2 target groups
+// configured on its loadBalancers[]. The AWS provider factory wires the
+// concrete ELBv2 mock in, mirroring the ManagedInstanceLauncher shape.
+type TargetRegistrar interface {
+	RegisterTargets(ctx context.Context, targetGroupARN string, targets []lbdriver.Target) error
+	DeregisterTargets(ctx context.Context, targetGroupARN string, targets []lbdriver.Target) error
+}
+
+// SetTargetRegistrar wires the ELBv2 mock a service's loadBalancers[] register
+// running tasks against. Safe to leave unset — services with loadBalancers
+// then converge without ever touching a target group.
+func (m *Mock) SetTargetRegistrar(r TargetRegistrar) {
+	m.registrar = r
+}
+
+// registerTaskTargets registers a just-launched RUNNING task against every
+// target group configured on the service's loadBalancers[], matching each
+// entry's containerName/containerPort to where the task actually landed.
+func (m *Mock) registerTaskTargets(ctx context.Context, svc *driver.Service, td *driver.TaskDefinition, task *driver.Task) {
+	if m.registrar == nil || len(svc.LoadBalancers) == 0 {
+		return
+	}
+
+	for i := range svc.LoadBalancers {
+		lb := &svc.LoadBalancers[i]
+
+		target, ok := m.resolveTarget(td, task, lb.ContainerName, lb.ContainerPort)
+		if !ok {
+			continue
+		}
+
+		_ = m.registrar.RegisterTargets(ctx, lb.TargetGroupARN, []lbdriver.Target{target})
+	}
+}
+
+// deregisterTaskTargets removes a task the service scheduler is about to stop
+// from every target group configured on the service's loadBalancers[].
+func (m *Mock) deregisterTaskTargets(ctx context.Context, svc *driver.Service, task *driver.Task) {
+	if m.registrar == nil || len(svc.LoadBalancers) == 0 {
+		return
+	}
+
+	td, ok := m.resolveTaskDef(task.TaskDefinitionARN)
+	if !ok {
+		return
+	}
+
+	for i := range svc.LoadBalancers {
+		lb := &svc.LoadBalancers[i]
+
+		target, ok := m.resolveTarget(td, task, lb.ContainerName, lb.ContainerPort)
+		if !ok {
+			continue
+		}
+
+		_ = m.registrar.DeregisterTargets(ctx, lb.TargetGroupARN, []lbdriver.Target{target})
+	}
+}
+
+// resolveTarget computes the target ELBv2 registers for one loadBalancers[]
+// entry, matching real ECS service-load-balancing semantics: an awsvpc task
+// (Fargate, or EC2 with awsvpc trunking) is addressed directly at its ENI
+// private IP and the container port; a bridge/host EC2 task is addressed at
+// its container instance's EC2 id and the host port the container port was
+// bound to. false is returned when the task carries no resolvable placement
+// yet (e.g. PENDING with no reserved capacity).
+func (m *Mock) resolveTarget(
+	td *driver.TaskDefinition, task *driver.Task, containerName string, containerPort int,
+) (lbdriver.Target, bool) {
+	if td.NetworkMode == networkModeAwsvpc {
+		ip := eniPrivateIP(task.Attachments)
+		if ip == "" {
+			return lbdriver.Target{}, false
+		}
+
+		return lbdriver.Target{ID: ip, Port: containerPort}, true
+	}
+
+	if task.ContainerInstanceARN == "" {
+		return lbdriver.Target{}, false
+	}
+
+	ci, ok := m.instances.Get(task.ContainerInstanceARN)
+	if !ok || ci.EC2InstanceID == "" {
+		return lbdriver.Target{}, false
+	}
+
+	hostPort := hostPortFor(task.Containers, containerName, containerPort)
+	if hostPort == 0 {
+		return lbdriver.Target{}, false
+	}
+
+	return lbdriver.Target{ID: ci.EC2InstanceID, Port: hostPort}, true
+}
+
+// eniPrivateIP extracts the privateIPv4Address detail from a task's
+// ElasticNetworkInterface attachment, or "" when none is present.
+func eniPrivateIP(attachments []driver.Attachment) string {
+	for i := range attachments {
+		if attachments[i].Type != "ElasticNetworkInterface" {
+			continue
+		}
+
+		for _, kv := range attachments[i].Details {
+			if kv.Name == "privateIPv4Address" {
+				return kv.Value
+			}
+		}
+	}
+
+	return ""
+}
+
+// hostPortFor looks up the host port bound to a container's containerPort from
+// the task's resolved network bindings, or 0 when none was bound (the named
+// container is not in the task, or that port was never mapped).
+func hostPortFor(containers []driver.Container, containerName string, containerPort int) int {
+	for i := range containers {
+		if containers[i].Name != containerName {
+			continue
+		}
+
+		for _, nb := range containers[i].NetworkBindings {
+			if nb.ContainerPort == containerPort {
+				return nb.HostPort
+			}
+		}
+	}
+
+	return 0
+}

--- a/providers/aws/ecs/tasks.go
+++ b/providers/aws/ecs/tasks.go
@@ -206,7 +206,7 @@ func (m *Mock) launchTask(ctx context.Context, spec *taskSpec, pendingOnShortfal
 		Group:             spec.group,
 		StartedBy:         spec.startedBy,
 		CreatedAt:         m.now(),
-		Containers:        containersFor(spec.td),
+		Containers:        m.containersFor(spec.td),
 		Tags:              copyTags(spec.tags),
 	}
 
@@ -241,10 +241,16 @@ func (m *Mock) launchTask(ctx context.Context, spec *taskSpec, pendingOnShortfal
 	return &clone, nil
 }
 
-// markContainers sets every container's last status.
+// markContainers sets every container's last status. A container marked
+// PENDING (EC2 capacity shortfall) never actually reserved a host port, so its
+// speculative network bindings are cleared rather than reporting a phantom one.
 func markContainers(task *driver.Task, status string) {
 	for i := range task.Containers {
 		task.Containers[i].LastStatus = status
+
+		if status == statusPending {
+			task.Containers[i].NetworkBindings = nil
+		}
 	}
 }
 
@@ -319,12 +325,63 @@ func (m *Mock) placeOnInstance(
 	return failure
 }
 
-func containersFor(td *driver.TaskDefinition) []driver.Container {
+// containersFor builds the RUNNING containers for a newly launched task,
+// resolving each container's bridge/host network bindings (awsvpc/Fargate
+// tasks carry none — traffic reaches the container directly through its ENI).
+func (m *Mock) containersFor(td *driver.TaskDefinition) []driver.Container {
 	out := make([]driver.Container, 0, len(td.ContainerDefinitions))
 
 	for i := range td.ContainerDefinitions {
 		cd := &td.ContainerDefinitions[i]
-		out = append(out, driver.Container{Name: cd.Name, Image: cd.Image, LastStatus: statusRunning})
+		out = append(out, driver.Container{
+			Name:            cd.Name,
+			Image:           cd.Image,
+			LastStatus:      statusRunning,
+			NetworkBindings: m.networkBindingsFor(td.NetworkMode, cd.PortMappings),
+		})
+	}
+
+	return out
+}
+
+// defaultProtocol is the ECS network-binding protocol assumed when a port
+// mapping leaves Protocol unset, matching the AWS default.
+const defaultProtocol = "tcp"
+
+// networkBindingsFor resolves the host IP/port ECS binds for each container
+// port mapping under the task's network mode. Host mode always binds the host
+// port to the same value as the container port; bridge mode uses the caller's
+// explicit hostPort or, when left 0, a dynamically assigned one. awsvpc mode
+// (Fargate or EC2 trunking) carries no bindings — the container's ENI IP is
+// addressed directly.
+func (m *Mock) networkBindingsFor(networkMode string, mappings []driver.PortMapping) []driver.NetworkBinding {
+	if networkMode == networkModeAwsvpc || len(mappings) == 0 {
+		return nil
+	}
+
+	out := make([]driver.NetworkBinding, 0, len(mappings))
+
+	for _, pm := range mappings {
+		hostPort := pm.HostPort
+
+		switch {
+		case networkMode == networkModeHost:
+			hostPort = pm.ContainerPort
+		case hostPort == 0:
+			hostPort = m.nextEphemeralPort()
+		}
+
+		protocol := pm.Protocol
+		if protocol == "" {
+			protocol = defaultProtocol
+		}
+
+		out = append(out, driver.NetworkBinding{
+			BindIP:        "0.0.0.0",
+			ContainerPort: pm.ContainerPort,
+			HostPort:      hostPort,
+			Protocol:      protocol,
+		})
 	}
 
 	return out

--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -28,6 +28,21 @@ var (
 // defaultIdleTimeoutSec is the default idle timeout for load balancers in seconds.
 const defaultIdleTimeoutSec = 60
 
+// targetKey is the identity of a registered target within a target group.
+// AWS lets the same instance ID or IP be registered multiple times with
+// different port overrides (RegisterTargets docs, "Register targets by
+// instance ID using port overrides": the same instance ID is registered
+// twice with Port=80 and Port=766, and both remain distinct targets) — so
+// the health store must key on (ID, Port), not ID alone.
+type targetKey struct {
+	id   string
+	port int
+}
+
+func keyFor(t driver.Target) targetKey {
+	return targetKey{id: t.ID, port: t.Port}
+}
+
 // Mock is an in-memory mock implementation of the AWS ELB service.
 type Mock struct {
 	lbs       *memstore.Store[driver.LBInfo]
@@ -37,7 +52,7 @@ type Mock struct {
 	opts      *config.Options
 
 	healthMu sync.RWMutex
-	health   map[string]map[string]*driver.TargetHealth // tgARN -> targetID -> health
+	health   map[string]map[targetKey]*driver.TargetHealth // tgARN -> (id,port) -> health
 
 	attrsMu sync.RWMutex
 	attrs   map[string]driver.LBAttributes // lbARN -> attributes
@@ -54,7 +69,7 @@ func New(opts *config.Options) *Mock {
 		listeners: memstore.New[driver.ListenerInfo](),
 		rules:     memstore.New[driver.RuleInfo](),
 		opts:      opts,
-		health:    make(map[string]map[string]*driver.TargetHealth),
+		health:    make(map[string]map[targetKey]*driver.TargetHealth),
 		attrs:     make(map[string]driver.LBAttributes),
 		tgAttrs:   make(map[string]map[string]string),
 	}
@@ -235,7 +250,7 @@ func (m *Mock) CreateTargetGroup(_ context.Context, cfg driver.TargetGroupConfig
 
 	// Initialize health map for this target group.
 	m.healthMu.Lock()
-	m.health[arn] = make(map[string]*driver.TargetHealth)
+	m.health[arn] = make(map[targetKey]*driver.TargetHealth)
 	m.healthMu.Unlock()
 
 	result := tg
@@ -896,12 +911,12 @@ func (m *Mock) RegisterTargets(_ context.Context, targetGroupARN string, targets
 
 	tgHealth, ok := m.health[targetGroupARN]
 	if !ok {
-		tgHealth = make(map[string]*driver.TargetHealth)
+		tgHealth = make(map[targetKey]*driver.TargetHealth)
 		m.health[targetGroupARN] = tgHealth
 	}
 
 	for _, t := range targets {
-		tgHealth[t.ID] = &driver.TargetHealth{
+		tgHealth[keyFor(t)] = &driver.TargetHealth{
 			Target: driver.Target{
 				ID:   t.ID,
 				Port: t.Port,
@@ -930,10 +945,53 @@ func (m *Mock) DeregisterTargets(_ context.Context, targetGroupARN string, targe
 	}
 
 	for _, t := range targets {
-		delete(tgHealth, t.ID)
+		key := keyFor(t)
+		if _, ok := tgHealth[key]; ok {
+			delete(tgHealth, key)
+			continue
+		}
+
+		// No exact (ID, Port) match. Per the DeregisterTargets docs, a port
+		// is only required when the target was registered with a port
+		// override; a caller that omits Port (t.Port == 0, the common case —
+		// RegisterTargets docs Example 1 registers and deregisters by ID
+		// alone) still identifies a target unambiguously as long as that ID
+		// is registered under exactly one port. Deregistering an unknown
+		// target is a no-op ("If the specified target does not exist, the
+		// action returns successfully").
+		if t.Port == 0 {
+			deleteSolePortMatch(tgHealth, t.ID)
+		}
 	}
 
 	return nil
+}
+
+// deleteSolePortMatch removes the single entry registered under id, when
+// exactly one exists. Two or more entries for the same id (different port
+// overrides) are left untouched — disambiguating them requires the caller to
+// specify the port, matching real ELBv2 semantics.
+func deleteSolePortMatch(tgHealth map[targetKey]*driver.TargetHealth, id string) {
+	var match targetKey
+
+	count := 0
+
+	for k := range tgHealth {
+		if k.id != id {
+			continue
+		}
+
+		match = k
+		count++
+
+		if count > 1 {
+			return
+		}
+	}
+
+	if count == 1 {
+		delete(tgHealth, match)
+	}
 }
 
 // DescribeTargetHealth returns the health status of all targets in a target
@@ -984,13 +1042,24 @@ func (m *Mock) SetTargetHealth(_ context.Context, targetGroupARN, targetID, stat
 		return errors.Newf(errors.NotFound, "no targets registered in target group %q", targetGroupARN)
 	}
 
-	th, ok := tgHealth[targetID]
-	if !ok {
-		return errors.Newf(errors.NotFound, "target %q not found in target group %q", targetID, targetGroupARN)
+	// targetID alone is ambiguous when the same ID is registered under
+	// multiple ports (see targetKey); set every port registered for it,
+	// matching the common case of a single port per ID.
+	found := false
+
+	for k, th := range tgHealth {
+		if k.id != targetID {
+			continue
+		}
+
+		th.State = state
+		th.Reason = ""
+		found = true
 	}
 
-	th.State = state
-	th.Reason = ""
+	if !found {
+		return errors.Newf(errors.NotFound, "target %q not found in target group %q", targetID, targetGroupARN)
+	}
 
 	return nil
 }

--- a/providers/aws/elbv2/elb_test.go
+++ b/providers/aws/elbv2/elb_test.go
@@ -277,12 +277,37 @@ func TestDeregisterTargets(t *testing.T) {
 	tg := createTestTG(m)
 	_ = m.RegisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-1", Port: 80}, {ID: "i-2", Port: 80}})
 
-	t.Run("success", func(t *testing.T) {
-		err := m.DeregisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-1"}})
+	t.Run("success by exact (id, port)", func(t *testing.T) {
+		err := m.DeregisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-1", Port: 80}})
 		requireNoError(t, err)
 
 		health, _ := m.DescribeTargetHealth(ctx, tg.ARN)
 		assertEqual(t, 1, len(health))
+	})
+
+	t.Run("success by id alone when unambiguous", func(t *testing.T) {
+		// A caller that omits Port (the common case — RegisterTargets docs
+		// Example 1 registers and deregisters by ID alone) can still
+		// deregister as long as that ID has exactly one registered port.
+		err := m.DeregisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-2"}})
+		requireNoError(t, err)
+
+		health, _ := m.DescribeTargetHealth(ctx, tg.ARN)
+		assertEqual(t, 0, len(health))
+	})
+
+	t.Run("id alone is a no-op when ambiguous across ports", func(t *testing.T) {
+		// DeregisterTargets docs: "If you specified a port override when you
+		// registered a target, you must specify both the target ID and the
+		// port when you deregister it." Two ports for the same ID must not
+		// be collapsed by an unqualified ID.
+		_ = m.RegisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-3", Port: 80}, {ID: "i-3", Port: 766}})
+
+		err := m.DeregisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-3"}})
+		requireNoError(t, err)
+
+		health, _ := m.DescribeTargetHealth(ctx, tg.ARN)
+		assertEqual(t, 2, len(health))
 	})
 
 	t.Run("TG not found", func(t *testing.T) {
@@ -333,6 +358,46 @@ func TestSetTargetHealth(t *testing.T) {
 		err := m.SetTargetHealth(ctx, "arn:nope", "i-1", "healthy")
 		assertError(t, err, true)
 	})
+}
+
+// TestRegisterTargetsSamePortOverride is the regression case for the
+// target-health store overwriting a same-instance registration: AWS lets one
+// instance ID be registered multiple times under different port overrides
+// (RegisterTargets docs, "Register targets by instance ID using port
+// overrides": the same instance is registered as Port=80 and Port=766 in one
+// call), and both must coexist and be independently deregisterable.
+func TestRegisterTargetsSamePortOverride(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	tg := createTestTG(m)
+
+	err := m.RegisterTargets(ctx, tg.ARN, []driver.Target{
+		{ID: "i-shared", Port: 80},
+		{ID: "i-shared", Port: 766},
+	})
+	requireNoError(t, err)
+
+	health, err := m.DescribeTargetHealth(ctx, tg.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 2, len(health))
+
+	ports := map[int]bool{}
+	for _, th := range health {
+		assertEqual(t, "i-shared", th.Target.ID)
+		ports[th.Target.Port] = true
+	}
+
+	assertEqual(t, true, ports[80])
+	assertEqual(t, true, ports[766])
+
+	// Deregistering one port must leave the other target registered.
+	err = m.DeregisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-shared", Port: 80}})
+	requireNoError(t, err)
+
+	health, err = m.DescribeTargetHealth(ctx, tg.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(health))
+	assertEqual(t, 766, health[0].Target.Port)
 }
 
 func TestCreateRule(t *testing.T) {

--- a/server/aws/ecs/target_registration_test.go
+++ b/server/aws/ecs/target_registration_test.go
@@ -1,0 +1,214 @@
+package ecs_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsprovider "github.com/stackshy/cloudemu/v2/providers/aws"
+	provecs "github.com/stackshy/cloudemu/v2/providers/aws/ecs"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newECSAndELBServer wires both the ECS and ELBv2 wire handlers to the same
+// cloud provider on one httptest server, so the cross-service target
+// registration wired in providers/aws.New (ECS.SetTargetRegistrar(ELB)) is
+// exercised end-to-end, exactly as it is in a real `cloudemu serve` process.
+func newECSAndELBServer(t *testing.T) (*awsecs.Client, *elb.Client, *awsprovider.Provider) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{ECS: cloud.ECS, ELB: cloud.ELB})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	ecsClient := awsecs.NewFromConfig(cfg, func(o *awsecs.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+	elbClient := elb.NewFromConfig(cfg, func(o *elb.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+
+	return ecsClient, elbClient, cloud
+}
+
+// TestSDKServiceRegistersTargetsWithELBv2 drives a real bridge-mode ECS
+// service through the live wire server end-to-end: CreateTargetGroup ->
+// CreateService(desiredCount=2, loadBalancers=[...]) must register both
+// RUNNING tasks with the target group (DescribeTargetHealth shows 2 targets),
+// DescribeTasks must report the dynamically assigned host port as a
+// networkBinding, and scaling the service to 0 must deregister the targets.
+func TestSDKServiceRegistersTargetsWithELBv2(t *testing.T) {
+	ecsClient, elbClient, cloud := newECSAndELBServer(t)
+	ctx := context.Background()
+
+	if _, err := ecsClient.CreateCluster(ctx, &awsecs.CreateClusterInput{ClusterName: aws.String("prod")}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	// Bridge mode (the EC2 default) with a dynamic host port (hostPort unset),
+	// so registration must resolve the ECS-assigned port, not a caller-supplied one.
+	if _, err := ecsClient.RegisterTaskDefinition(ctx, &awsecs.RegisterTaskDefinitionInput{
+		Family: aws.String("web"),
+		ContainerDefinitions: []ecstypes.ContainerDefinition{{
+			Name:      aws.String("nginx"),
+			Image:     aws.String("nginx:latest"),
+			Cpu:       128,
+			Memory:    aws.Int32(256),
+			Essential: aws.Bool(true),
+			PortMappings: []ecstypes.PortMapping{{
+				ContainerPort: aws.Int32(80),
+			}},
+		}},
+	}); err != nil {
+		t.Fatalf("RegisterTaskDefinition: %v", err)
+	}
+
+	// Seed two instances, each with capacity for exactly one task, so the
+	// service's first-fit placement spreads the two tasks across both instances
+	// (rather than stacking them on one) and registration must be keyed per task.
+	cloud.ECS.SeedContainerInstance("prod", "i-web1", provecs.WithCapacity(128, 256))
+	cloud.ECS.SeedContainerInstance("prod", "i-web2", provecs.WithCapacity(128, 256))
+
+	tg, err := elbClient.CreateTargetGroup(ctx, &elb.CreateTargetGroupInput{
+		Name:       aws.String("web-tg"),
+		Protocol:   elbtypes.ProtocolEnumHttp,
+		Port:       aws.Int32(80),
+		VpcId:      aws.String("vpc-123"),
+		TargetType: elbtypes.TargetTypeEnumInstance,
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	tgARN := aws.ToString(tg.TargetGroups[0].TargetGroupArn)
+
+	svc, err := ecsClient.CreateService(ctx, &awsecs.CreateServiceInput{
+		Cluster:        aws.String("prod"),
+		ServiceName:    aws.String("web-svc"),
+		TaskDefinition: aws.String("web"),
+		DesiredCount:   aws.Int32(2),
+		LoadBalancers: []ecstypes.LoadBalancer{{
+			TargetGroupArn: aws.String(tgARN),
+			ContainerName:  aws.String("nginx"),
+			ContainerPort:  aws.Int32(80),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	if svc.Service.RunningCount != 2 {
+		t.Fatalf("CreateService runningCount = %d, want 2", svc.Service.RunningCount)
+	}
+
+	// The HIGH-severity regression: DescribeTargetHealth must show both
+	// converged tasks registered, not the empty set the bug reported.
+	health, err := elbClient.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{TargetGroupArn: aws.String(tgARN)})
+	if err != nil {
+		t.Fatalf("DescribeTargetHealth: %v", err)
+	}
+
+	if len(health.TargetHealthDescriptions) != 2 {
+		t.Fatalf("DescribeTargetHealth registered = %d, want 2: %+v", len(health.TargetHealthDescriptions), health.TargetHealthDescriptions)
+	}
+
+	registeredIDs := map[string]bool{}
+
+	for _, th := range health.TargetHealthDescriptions {
+		id := aws.ToString(th.Target.Id)
+		registeredIDs[id] = true
+
+		if id != "i-web1" && id != "i-web2" {
+			t.Fatalf("registered target id = %q, want i-web1 or i-web2", id)
+		}
+
+		port := aws.ToInt32(th.Target.Port)
+		if port < 32768 || port > 65535 {
+			t.Fatalf("registered target port = %d, want a dynamic ephemeral port", port)
+		}
+	}
+
+	if len(registeredIDs) != 2 {
+		t.Fatalf("registered target ids = %v, want both container instances distinctly registered", registeredIDs)
+	}
+
+	// The MEDIUM-severity regression: DescribeTasks must report the same
+	// dynamically assigned host port as a networkBinding.
+	listTasks, err := ecsClient.ListTasks(ctx, &awsecs.ListTasksInput{
+		Cluster: aws.String("prod"), ServiceName: aws.String("web-svc"),
+	})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+
+	if len(listTasks.TaskArns) != 2 {
+		t.Fatalf("ListTasks = %d arns, want 2", len(listTasks.TaskArns))
+	}
+
+	descTasks, err := ecsClient.DescribeTasks(ctx, &awsecs.DescribeTasksInput{
+		Cluster: aws.String("prod"), Tasks: listTasks.TaskArns,
+	})
+	if err != nil {
+		t.Fatalf("DescribeTasks: %v", err)
+	}
+
+	for _, task := range descTasks.Tasks {
+		if len(task.Containers) != 1 {
+			t.Fatalf("task containers = %d, want 1: %+v", len(task.Containers), task.Containers)
+		}
+
+		bindings := task.Containers[0].NetworkBindings
+		if len(bindings) != 1 {
+			t.Fatalf("task networkBindings = %d, want 1: %+v", len(bindings), bindings)
+		}
+
+		nb := bindings[0]
+		if aws.ToInt32(nb.ContainerPort) != 80 {
+			t.Fatalf("networkBinding containerPort = %d, want 80", aws.ToInt32(nb.ContainerPort))
+		}
+
+		if aws.ToInt32(nb.HostPort) < 32768 || aws.ToInt32(nb.HostPort) > 65535 {
+			t.Fatalf("networkBinding hostPort = %d, want a dynamic ephemeral port", aws.ToInt32(nb.HostPort))
+		}
+
+		if aws.ToString(nb.BindIP) != "0.0.0.0" {
+			t.Fatalf("networkBinding bindIP = %q, want 0.0.0.0", aws.ToString(nb.BindIP))
+		}
+
+		if nb.Protocol != ecstypes.TransportProtocolTcp {
+			t.Fatalf("networkBinding protocol = %q, want tcp", nb.Protocol)
+		}
+	}
+
+	// Scaling the service to 0 must drain its tasks and deregister them.
+	if _, err := ecsClient.UpdateService(ctx, &awsecs.UpdateServiceInput{
+		Cluster: aws.String("prod"), Service: aws.String("web-svc"), DesiredCount: aws.Int32(0),
+	}); err != nil {
+		t.Fatalf("UpdateService scale to 0: %v", err)
+	}
+
+	healthAfter, err := elbClient.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{TargetGroupArn: aws.String(tgARN)})
+	if err != nil {
+		t.Fatalf("DescribeTargetHealth after scale to 0: %v", err)
+	}
+
+	if len(healthAfter.TargetHealthDescriptions) != 0 {
+		t.Fatalf("DescribeTargetHealth after scale to 0 = %d, want 0: %+v",
+			len(healthAfter.TargetHealthDescriptions), healthAfter.TargetHealthDescriptions)
+	}
+}

--- a/server/aws/ecs/target_registration_test.go
+++ b/server/aws/ecs/target_registration_test.go
@@ -212,3 +212,126 @@ func TestSDKServiceRegistersTargetsWithELBv2(t *testing.T) {
 			len(healthAfter.TargetHealthDescriptions), healthAfter.TargetHealthDescriptions)
 	}
 }
+
+// TestSDKServiceRegistersBothTasksOnSameInstance is the regression case for
+// the target-health store overwriting a second registration: when two of a
+// service's bridge-mode tasks land on the SAME container instance, ELBv2
+// registers that one instance ID twice with two different dynamic host
+// ports (exactly the "port override" pattern documented in the RegisterTargets
+// API reference's "Register targets by instance ID using port overrides"
+// example, which registers i-80c8dd94 as Port=80 and Port=766 in the same
+// call). DescribeTargetHealth must report both entries, keyed by (id, port),
+// not have the second registration overwrite the first because they share an
+// instance ID.
+func TestSDKServiceRegistersBothTasksOnSameInstance(t *testing.T) {
+	ecsClient, elbClient, cloud := newECSAndELBServer(t)
+	ctx := context.Background()
+
+	if _, err := ecsClient.CreateCluster(ctx, &awsecs.CreateClusterInput{ClusterName: aws.String("prod")}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := ecsClient.RegisterTaskDefinition(ctx, &awsecs.RegisterTaskDefinitionInput{
+		Family: aws.String("web"),
+		ContainerDefinitions: []ecstypes.ContainerDefinition{{
+			Name:      aws.String("nginx"),
+			Image:     aws.String("nginx:latest"),
+			Cpu:       128,
+			Memory:    aws.Int32(256),
+			Essential: aws.Bool(true),
+			PortMappings: []ecstypes.PortMapping{{
+				ContainerPort: aws.Int32(80),
+			}},
+		}},
+	}); err != nil {
+		t.Fatalf("RegisterTaskDefinition: %v", err)
+	}
+
+	// A single instance sized for exactly two tasks, so both of the
+	// service's desired tasks are placed on it and register against ELBv2
+	// under the same instance ID with two distinct dynamic host ports.
+	cloud.ECS.SeedContainerInstance("prod", "i-web1", provecs.WithCapacity(256, 512))
+
+	tg, err := elbClient.CreateTargetGroup(ctx, &elb.CreateTargetGroupInput{
+		Name:       aws.String("web-tg"),
+		Protocol:   elbtypes.ProtocolEnumHttp,
+		Port:       aws.Int32(80),
+		VpcId:      aws.String("vpc-123"),
+		TargetType: elbtypes.TargetTypeEnumInstance,
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	tgARN := aws.ToString(tg.TargetGroups[0].TargetGroupArn)
+
+	svc, err := ecsClient.CreateService(ctx, &awsecs.CreateServiceInput{
+		Cluster:        aws.String("prod"),
+		ServiceName:    aws.String("web-svc"),
+		TaskDefinition: aws.String("web"),
+		DesiredCount:   aws.Int32(2),
+		LoadBalancers: []ecstypes.LoadBalancer{{
+			TargetGroupArn: aws.String(tgARN),
+			ContainerName:  aws.String("nginx"),
+			ContainerPort:  aws.Int32(80),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	if svc.Service.RunningCount != 2 {
+		t.Fatalf("CreateService runningCount = %d, want 2", svc.Service.RunningCount)
+	}
+
+	health, err := elbClient.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{TargetGroupArn: aws.String(tgARN)})
+	if err != nil {
+		t.Fatalf("DescribeTargetHealth: %v", err)
+	}
+
+	// The regression: without the (id, port) composite key, the second
+	// RegisterTargets for i-web1 overwrites the first and only one target
+	// survives.
+	if len(health.TargetHealthDescriptions) != 2 {
+		t.Fatalf("DescribeTargetHealth registered = %d, want 2 (same instance, two ports): %+v",
+			len(health.TargetHealthDescriptions), health.TargetHealthDescriptions)
+	}
+
+	ports := map[int32]bool{}
+
+	for _, th := range health.TargetHealthDescriptions {
+		id := aws.ToString(th.Target.Id)
+		if id != "i-web1" {
+			t.Fatalf("registered target id = %q, want i-web1 (both tasks on the same instance)", id)
+		}
+
+		port := aws.ToInt32(th.Target.Port)
+		if port < 32768 || port > 65535 {
+			t.Fatalf("registered target port = %d, want a dynamic ephemeral port", port)
+		}
+
+		ports[port] = true
+	}
+
+	if len(ports) != 2 {
+		t.Fatalf("registered target ports = %v, want two distinct host ports on the shared instance", ports)
+	}
+
+	// Scaling to 0 must deregister both (id, port) entries, not leave one
+	// behind because deregistration also collapsed on instance ID alone.
+	if _, err := ecsClient.UpdateService(ctx, &awsecs.UpdateServiceInput{
+		Cluster: aws.String("prod"), Service: aws.String("web-svc"), DesiredCount: aws.Int32(0),
+	}); err != nil {
+		t.Fatalf("UpdateService scale to 0: %v", err)
+	}
+
+	healthAfter, err := elbClient.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{TargetGroupArn: aws.String(tgARN)})
+	if err != nil {
+		t.Fatalf("DescribeTargetHealth after scale to 0: %v", err)
+	}
+
+	if len(healthAfter.TargetHealthDescriptions) != 0 {
+		t.Fatalf("DescribeTargetHealth after scale to 0 = %d, want 0: %+v",
+			len(healthAfter.TargetHealthDescriptions), healthAfter.TargetHealthDescriptions)
+	}
+}

--- a/server/aws/ecs/types.go
+++ b/server/aws/ecs/types.go
@@ -201,15 +201,25 @@ type wireTaskDef struct {
 // containerStatusStopped is the ECS lastStatus of a finished container.
 const containerStatusStopped = "STOPPED"
 
+// wireNetworkBinding mirrors the ECS NetworkBinding shape: the host IP/port a
+// bridge- or host-mode container port mapping was bound to.
+type wireNetworkBinding struct {
+	BindIP        string `json:"bindIP,omitempty"`
+	ContainerPort int    `json:"containerPort,omitempty"`
+	HostPort      int    `json:"hostPort,omitempty"`
+	Protocol      string `json:"protocol,omitempty"`
+}
+
 type wireContainer struct {
 	Name       string `json:"name,omitempty"`
 	Image      string `json:"image,omitempty"`
 	LastStatus string `json:"lastStatus,omitempty"`
 	// ExitCode is a pointer so a real exit 0 on a STOPPED container serializes
 	// (real ECS reports it), while a running container omits it entirely.
-	ExitCode  *int   `json:"exitCode,omitempty"`
-	Reason    string `json:"reason,omitempty"`
-	RuntimeID string `json:"runtimeId,omitempty"`
+	ExitCode        *int                 `json:"exitCode,omitempty"`
+	Reason          string               `json:"reason,omitempty"`
+	RuntimeID       string               `json:"runtimeId,omitempty"`
+	NetworkBindings []wireNetworkBinding `json:"networkBindings,omitempty"`
 }
 
 // wireAttachment mirrors the ECS Attachment shape (type/status/details), where
@@ -1181,6 +1191,23 @@ func taskDefToWire(t *driver.TaskDefinition) wireTaskDef {
 	}
 }
 
+// fromNetworkBindings converts a container's resolved bridge/host port
+// bindings to the wire shape.
+func fromNetworkBindings(in []driver.NetworkBinding) []wireNetworkBinding {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]wireNetworkBinding, 0, len(in))
+	for _, nb := range in {
+		out = append(out, wireNetworkBinding{
+			BindIP: nb.BindIP, ContainerPort: nb.ContainerPort, HostPort: nb.HostPort, Protocol: nb.Protocol,
+		})
+	}
+
+	return out
+}
+
 func taskToWire(t *driver.Task) wireTask {
 	containers := make([]wireContainer, 0, len(t.Containers))
 
@@ -1189,6 +1216,7 @@ func taskToWire(t *driver.Task) wireTask {
 		wc := wireContainer{
 			Name: c.Name, Image: c.Image, LastStatus: c.LastStatus,
 			Reason: c.Reason, RuntimeID: c.RuntimeID,
+			NetworkBindings: fromNetworkBindings(c.NetworkBindings),
 		}
 		// Surface the exit code only once the container has stopped, so a genuine
 		// exit 0 is reported while a running container has none.

--- a/services/ecs/driver/driver.go
+++ b/services/ecs/driver/driver.go
@@ -263,16 +263,28 @@ type TaskDefinition struct {
 	Tags                    []Tag
 }
 
+// NetworkBinding is a container port mapping resolved at task launch: the
+// host IP/port bound to a container port. It is populated only for bridge and
+// host network mode; an awsvpc/Fargate task carries no port bindings since
+// traffic reaches the container directly through its ENI address.
+type NetworkBinding struct {
+	BindIP        string
+	ContainerPort int
+	HostPort      int
+	Protocol      string
+}
+
 // Container is a running container within a task. ExitCode, Reason, and
 // RuntimeID are populated only when the task is backed by a real
 // config.ContainerEngine; they stay zero for the default synthetic tasks.
 type Container struct {
-	Name       string
-	Image      string
-	LastStatus string
-	ExitCode   int
-	Reason     string
-	RuntimeID  string
+	Name            string
+	Image           string
+	LastStatus      string
+	ExitCode        int
+	Reason          string
+	RuntimeID       string
+	NetworkBindings []NetworkBinding
 }
 
 // Attachment is a resource attached to a task, such as the elastic network
@@ -352,8 +364,10 @@ type ServiceEvent struct {
 }
 
 // LoadBalancer associates a service's container/port with an Elastic Load
-// Balancing target group. It is accepted and echoed but not wired to real
-// target registration or health checks.
+// Balancing target group. The service scheduler registers each RUNNING task it
+// places against TargetGroupARN (when a TargetRegistrar is wired) and
+// deregisters it when the task stops or the service scales down; health-check
+// evaluation itself is the target group's own concern.
 type LoadBalancer struct {
 	TargetGroupARN   string
 	LoadBalancerName string


### PR DESCRIPTION
## Summary

- **HIGH**: An ECS service created with `loadBalancers=[{targetGroupArn, containerName, containerPort}]` converged `runningCount` but never registered any task with the ELBv2 target group — `DescribeTargetHealth` always reported zero targets. `providers/aws/ecs` had no reference to ELBv2 at all.
- **MEDIUM**: `DescribeTasks` always returned an empty `containers[].networkBindings`; the field/type was entirely absent from the ECS driver.

## What changed

- Added a local `TargetRegistrar` interface to the ECS mock (mirrors the existing `SetMonitoring`/`ManagedInstanceLauncher` cross-service wiring pattern) and wired it in `providers/aws/aws.go` via `p.ECS.SetTargetRegistrar(p.ELB)`.
- The service scheduler now registers each RUNNING task against every configured target group as it converges, and deregisters it as tasks stop or the service scales down:
  - **awsvpc** (Fargate, or EC2 with awsvpc): registers the task's ENI private IP + `containerPort`.
  - **bridge/host**: registers the container instance's EC2 id + the resolved host port.
- Added `driver.NetworkBinding{BindIP, ContainerPort, HostPort, Protocol}` to the ECS driver's `Container` type, populated at task launch for bridge/host network mode (dynamic ephemeral host port when `hostPort` is left unset; `hostPort == containerPort` for host mode), and mapped it on the wire in `server/aws/ecs` (`containers[].networkBindings` in `DescribeTasks`).
- `go run ./internal/coveragegen` and `go run ./internal/compatgen` were run; neither produced a diff.

## Test plan

- New `server/aws/ecs/target_registration_test.go` drives the real `aws-sdk-go-v2` ECS + ELBv2 clients against a live `httptest` wire server: `CreateTargetGroup` -> `CreateService(desiredCount=2, loadBalancers=...)` -> `DescribeTargetHealth` shows 2 registered targets with dynamic host ports, `DescribeTasks` shows `networkBindings` for the bridge-mode port mapping, then scaling to 0 deregisters both targets.
- `go build ./...`, `go vet ./...`, `go test ./providers/... ./server/... ./services/... .`, `go test ./compat/...`, `golangci-lint run` on changed packages, `gofmt -l` — all clean.