### PR TITLE
fix(sqs-lambda): wire SQS -> Lambda event-source-mapping delivery end to end

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -1526,56 +1526,60 @@ func TestCostTrackerReset(t *testing.T) {
 	}
 }
 
-// Feature: Lambda-SQS Trigger Tests
+// Feature: Lambda-SQS Event Source Mapping Tests
 func TestLambdaSQSTrigger(t *testing.T) {
 	ctx := context.Background()
 	p := NewAWS()
 
-	// 1. Create a Lambda function
+	// 1. Create a Lambda function.
+	var triggerCount int64
 	p.Lambda.RegisterHandler("processor", func(_ context.Context, payload []byte) ([]byte, error) {
+		atomic.AddInt64(&triggerCount, 1)
 		return []byte("processed: " + string(payload)), nil
 	})
-	_, err := p.Lambda.CreateFunction(ctx, serverlessdriver.FunctionConfig{
+
+	if _, err := p.Lambda.CreateFunction(ctx, serverlessdriver.FunctionConfig{
 		Name: "processor", Runtime: "go1.x", Handler: "main",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
-	// 2. Create SQS queue
+	// 2. Create SQS queue.
 	q, err := p.SQS.CreateQueue(ctx, mqdriver.QueueConfig{Name: "trigger-queue"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// 3. Wire the trigger: SQS → Lambda
-	var triggerCount int64
-	p.SQS.SetTrigger(q.URL, func(queueURL string, msg mqdriver.Message) {
-		// Invoke lambda with the message body
-		_, invokeErr := p.Lambda.Invoke(ctx, serverlessdriver.InvokeInput{
-			FunctionName: "processor",
-			Payload:      []byte(msg.Body),
-		})
-		if invokeErr != nil {
-			t.Errorf("trigger invoke failed: %v", invokeErr)
-		}
-		atomic.AddInt64(&triggerCount, 1)
-	})
+	// 3. Wire the trigger: SQS -> Lambda, via a real event source mapping.
+	if _, err := p.Lambda.CreateEventSourceMapping(ctx, serverlessdriver.EventSourceMappingConfig{
+		EventSourceArn: q.ARN, FunctionName: "processor", Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
 
-	// 4. Send messages — Lambda should be triggered automatically
+	// 4. Send messages — Lambda should be invoked automatically.
 	for i := 0; i < 5; i++ {
-		_, err := p.SQS.SendMessage(ctx, mqdriver.SendMessageInput{
+		if _, err := p.SQS.SendMessage(ctx, mqdriver.SendMessageInput{
 			QueueURL: q.URL,
 			Body:     "message-body",
-		})
-		if err != nil {
+		}); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	// 5. Verify Lambda was triggered 5 times
-	if atomic.LoadInt64(&triggerCount) != 5 {
-		t.Errorf("expected 5 trigger invocations, got %d", triggerCount)
+	// 5. Verify Lambda was invoked 5 times, and each processed message was
+	// deleted from the queue on success.
+	if got := atomic.LoadInt64(&triggerCount); got != 5 {
+		t.Errorf("expected 5 invocations, got %d", got)
+	}
+
+	info, err := p.SQS.GetQueueInfo(ctx, q.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.ApproxMessageCount != 0 {
+		t.Errorf("expected 0 messages left in queue after successful processing, got %d", info.ApproxMessageCount)
 	}
 }
 
@@ -1583,29 +1587,51 @@ func TestLambdaSQSTriggerRemove(t *testing.T) {
 	ctx := context.Background()
 	p := NewAWS()
 
+	var triggerCount int64
+	p.Lambda.RegisterHandler("remover", func(_ context.Context, _ []byte) ([]byte, error) {
+		atomic.AddInt64(&triggerCount, 1)
+		return nil, nil
+	})
+
+	if _, err := p.Lambda.CreateFunction(ctx, serverlessdriver.FunctionConfig{
+		Name: "remover", Runtime: "go1.x", Handler: "main",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
 	q, err := p.SQS.CreateQueue(ctx, mqdriver.QueueConfig{Name: "removable-trigger"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	var triggerCount int64
-	p.SQS.SetTrigger(q.URL, func(_ string, _ mqdriver.Message) {
-		atomic.AddInt64(&triggerCount, 1)
+	mapping, err := p.Lambda.CreateEventSourceMapping(ctx, serverlessdriver.EventSourceMappingConfig{
+		EventSourceArn: q.ARN, FunctionName: "remover", Enabled: true,
 	})
-
-	// Send one message — trigger fires
-	p.SQS.SendMessage(ctx, mqdriver.SendMessageInput{QueueURL: q.URL, Body: "first"})
-	if atomic.LoadInt64(&triggerCount) != 1 {
-		t.Errorf("expected 1 trigger, got %d", triggerCount)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	// Remove trigger
-	p.SQS.RemoveTrigger(q.URL)
+	// Send one message — the mapping fires.
+	if _, err := p.SQS.SendMessage(ctx, mqdriver.SendMessageInput{QueueURL: q.URL, Body: "first"}); err != nil {
+		t.Fatal(err)
+	}
 
-	// Send another message — trigger should NOT fire
-	p.SQS.SendMessage(ctx, mqdriver.SendMessageInput{QueueURL: q.URL, Body: "second"})
-	if atomic.LoadInt64(&triggerCount) != 1 {
-		t.Errorf("expected still 1 trigger after removal, got %d", triggerCount)
+	if got := atomic.LoadInt64(&triggerCount); got != 1 {
+		t.Errorf("expected 1 invocation, got %d", got)
+	}
+
+	// Remove the mapping.
+	if err := p.Lambda.DeleteEventSourceMapping(ctx, mapping.UUID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send another message — the mapping should NOT fire.
+	if _, err := p.SQS.SendMessage(ctx, mqdriver.SendMessageInput{QueueURL: q.URL, Body: "second"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := atomic.LoadInt64(&triggerCount); got != 1 {
+		t.Errorf("expected still 1 invocation after mapping removal, got %d", got)
 	}
 }
 

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -278,6 +278,10 @@ func New(opts ...config.Option) *Provider {
 	// DynamoDB Streams -> Lambda: writes to a stream-enabled table invoke the
 	// stream's event-source-mapping targets (mirrors the S3 -> Lambda wiring).
 	p.DynamoDB.SetStreamInvoker(p.Lambda)
+	// SQS -> Lambda: a message sent to a queue invokes the queue's
+	// event-source-mapping target(s), deleting the message on success or
+	// leaving it for DLQ redrive on failure (mirrors the DynamoDB Streams wiring).
+	p.SQS.SetEventSourceInvoker(p.Lambda)
 
 	p.ResourceDiscovery = resourcediscovery.New(
 		resourcediscovery.ProviderAWS, o.AccountID, o.Region, awsDrivers(p),

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -81,7 +81,7 @@ type Mock struct {
 // Lambda mock satisfies it, enabling real DynamoDB-stream -> Lambda invocation
 // (mirroring the S3 -> Lambda LambdaInvoker wiring).
 type StreamEventInvoker interface {
-	DeliverEventSourceBatch(ctx context.Context, eventSourceARN string, payload []byte) error
+	DeliverEventSourceBatch(ctx context.Context, eventSourceARN string, payload []byte) (delivered bool, err error)
 }
 
 // pendingStreamEvent is one captured change record awaiting out-of-lock delivery
@@ -1417,7 +1417,7 @@ func (m *Mock) flushStreamDeliveries(callerCtx context.Context) {
 		}
 
 		payload := driver.BuildLambdaStreamEvent(pending[i].streamARN, pending[i].region, pending[i].viewType, batch)
-		_ = m.streamInvoker.DeliverEventSourceBatch(ctx, pending[i].streamARN, payload)
+		_, _ = m.streamInvoker.DeliverEventSourceBatch(ctx, pending[i].streamARN, payload)
 
 		i = j
 	}

--- a/providers/aws/dynamodb/stream_esm_test.go
+++ b/providers/aws/dynamodb/stream_esm_test.go
@@ -14,11 +14,11 @@ type recordingStreamInvoker struct {
 	payloads [][]byte
 }
 
-func (r *recordingStreamInvoker) DeliverEventSourceBatch(_ context.Context, arn string, payload []byte) error {
+func (r *recordingStreamInvoker) DeliverEventSourceBatch(_ context.Context, arn string, payload []byte) (bool, error) {
 	r.arns = append(r.arns, arn)
 	r.payloads = append(r.payloads, payload)
 
-	return nil
+	return true, nil
 }
 
 // TestStreamInvokerDeliversOnWrite verifies that, once a stream invoker is wired,

--- a/providers/aws/lambda/esm.go
+++ b/providers/aws/lambda/esm.go
@@ -84,22 +84,38 @@ func (m *Mock) functionARN(nameOrARN string) string {
 // InvokeExternal wiring: the source records a change and calls this so the
 // mapped function actually runs. A disabled mapping is skipped; an unknown
 // target function is a no-op (InvokeExternal), so stale mappings never error.
+// Every matching mapping is invoked regardless of an earlier one's outcome
+// (each is an independent poller against the same source in real AWS); if any
+// invocation fails, its error is returned after all mappings have run, so a
+// caller such as the SQS mock can tell success from failure (delete the
+// message vs. leave it for redrive) without silently starving other mappings.
+//
+// delivered reports whether at least one enabled mapping matched eventSourceARN
+// at all, distinct from err: a source with no ESM configured must be a true
+// no-op to its caller (e.g. SQS must not delete a message nobody consumed),
+// which a nil error alone cannot express since "no mapping" and "mapping
+// succeeded" would otherwise look identical.
+//
 // ctx's re-entrant delivery depth is enforced inside InvokeExternal (see
 // internal/recursionguard), which is the single choke point every delivery
 // path funnels through, so a handler that writes back into its own event
 // source cannot recurse this call chain unboundedly.
-func (m *Mock) DeliverEventSourceBatch(ctx context.Context, eventSourceARN string, payload []byte) error {
+func (m *Mock) DeliverEventSourceBatch(ctx context.Context, eventSourceARN string, payload []byte) (delivered bool, err error) {
+	var deliveryErr error
+
 	for _, info := range m.mappings.All() {
 		if info.State != stateEnabled || info.EventSourceArn != eventSourceARN {
 			continue
 		}
 
-		if err := m.InvokeExternal(ctx, info.FunctionArn, payload); err != nil {
-			return err
+		delivered = true
+
+		if invokeErr := m.InvokeExternal(ctx, info.FunctionArn, payload); invokeErr != nil {
+			deliveryErr = invokeErr
 		}
 	}
 
-	return nil
+	return delivered, deliveryErr
 }
 
 // DeleteEventSourceMapping deletes an event source mapping by UUID.

--- a/providers/aws/lambda/esm_delivery_test.go
+++ b/providers/aws/lambda/esm_delivery_test.go
@@ -47,8 +47,13 @@ func TestDeliverEventSourceBatch(t *testing.T) {
 		t.Fatalf("CreateEventSourceMapping(other): %v", err)
 	}
 
-	if err := m.DeliverEventSourceBatch(ctx, streamARN, []byte(`{"Records":[]}`)); err != nil {
+	delivered, err := m.DeliverEventSourceBatch(ctx, streamARN, []byte(`{"Records":[]}`))
+	if err != nil {
 		t.Fatalf("DeliverEventSourceBatch: %v", err)
+	}
+
+	if !delivered {
+		t.Fatal("delivered = false, want true (a mapping matched)")
 	}
 
 	if len(got) != 1 {
@@ -57,5 +62,16 @@ func TestDeliverEventSourceBatch(t *testing.T) {
 
 	if got[0] != `{"Records":[]}` {
 		t.Fatalf("delivered payload = %q", got[0])
+	}
+
+	// No mapping targets an unrelated ARN -> delivered reports false, distinct
+	// from a mapping that ran and succeeded.
+	delivered, err = m.DeliverEventSourceBatch(ctx, "arn:aws:sqs:us-east-1:000000000000:unmapped", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("DeliverEventSourceBatch(unmapped): %v", err)
+	}
+
+	if delivered {
+		t.Fatal("delivered = true for an ARN with no matching mapping")
 	}
 }

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -338,8 +338,14 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 
 // InvokeExternal asynchronously invokes the function identified by its ARN with
 // the given event payload. It backs cross-service event delivery (e.g. S3 ->
-// Lambda notifications, DynamoDB Streams -> Lambda event source mappings). An
-// unknown function is a no-op so a stale target never fails the caller.
+// Lambda notifications, DynamoDB Streams / SQS event source mappings). An
+// unknown function is a no-op so a stale target never fails the caller. A
+// handler that runs but raises (StatusCode 500 / a non-empty FunctionError,
+// exactly as Invoke reports it — see invoke's X-Amz-Function-Error semantics)
+// is surfaced here as a genuine error, unlike Invoke itself: callers that only
+// care whether delivery succeeded (S3, DynamoDB Streams) already discard
+// InvokeExternal's error, while a caller that must react to handler failure
+// (SQS: delete the message on success, leave it for redrive on failure) can.
 //
 // It is also the single choke point every such delivery path funnels through,
 // so it carries the recursive-loop guard: a mapped/notified handler commonly
@@ -366,9 +372,16 @@ func (m *Mock) InvokeExternal(ctx context.Context, functionARN string, payload [
 
 	ctx = recursionguard.WithDepth(ctx, depth+1)
 
-	_, err := m.Invoke(ctx, driver.InvokeInput{FunctionName: name, Payload: payload, InvokeType: "Event"})
+	out, err := m.Invoke(ctx, driver.InvokeInput{FunctionName: name, Payload: payload, InvokeType: "Event"})
+	if err != nil {
+		return err
+	}
 
-	return err
+	if out != nil && out.Error != "" {
+		return cerrors.Newf(cerrors.Internal, "function %s returned an error: %s", name, out.Error)
+	}
+
+	return nil
 }
 
 // functionNameFromARN extracts the function name from a Lambda ARN

--- a/providers/aws/sqs/event_source_mapping_test.go
+++ b/providers/aws/sqs/event_source_mapping_test.go
@@ -1,0 +1,257 @@
+package sqs
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+)
+
+// recordingESMInvoker captures SQS -> Lambda event-source-mapping deliveries,
+// mirroring providers/aws/dynamodb's recordingStreamInvoker. It always reports
+// a mapping as present (delivered=true), since these tests are about handler
+// success/failure, not mapping presence (see TestEventSourceInvokerNoMapping*
+// for that). fail, when set, makes every delivery report a handler failure
+// (as Lambda's DeliverEventSourceBatch does when the mapped function returns
+// an error), so tests can drive the DLQ redrive path.
+type recordingESMInvoker struct {
+	arns     []string
+	payloads [][]byte
+	fail     bool
+}
+
+func (r *recordingESMInvoker) DeliverEventSourceBatch(_ context.Context, arn string, payload []byte) (bool, error) {
+	r.arns = append(r.arns, arn)
+	r.payloads = append(r.payloads, payload)
+
+	if r.fail {
+		return true, errors.New(errors.Internal, "handler failed")
+	}
+
+	return true, nil
+}
+
+// TestEventSourceInvokerDeliversOnSend verifies that, once an event source
+// invoker is wired, SendMessage delivers a real SQS Lambda event (see
+// https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html) tagged with the
+// queue's ARN, and that a successfully processed message is deleted from the
+// queue exactly as a real ESM would.
+func TestEventSourceInvokerDeliversOnSend(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	inv := &recordingESMInvoker{}
+	m.SetEventSourceInvoker(inv)
+
+	q, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "esm-queue"})
+	requireNoError(t, err)
+
+	sendOut, err := m.SendMessage(ctx, driver.SendMessageInput{
+		QueueURL: q.URL,
+		Body:     "hello-lambda",
+		MessageAttributes: map[string]driver.MessageAttributeValue{
+			"myAttribute": {DataType: "String", StringValue: "myValue"},
+		},
+	})
+	requireNoError(t, err)
+
+	if len(inv.arns) != 1 || inv.arns[0] != q.ARN {
+		t.Fatalf("deliveries = %v, want exactly one to %s", inv.arns, q.ARN)
+	}
+
+	var event struct {
+		Records []struct {
+			MessageID         string            `json:"messageId"`
+			ReceiptHandle     string            `json:"receiptHandle"`
+			Body              string            `json:"body"`
+			Attributes        map[string]string `json:"attributes"`
+			MD5OfBody         string            `json:"md5OfBody"`
+			EventSource       string            `json:"eventSource"`
+			EventSourceARN    string            `json:"eventSourceARN"`
+			AWSRegion         string            `json:"awsRegion"`
+			MessageAttributes map[string]struct {
+				StringValue string `json:"stringValue"`
+				DataType    string `json:"dataType"`
+			} `json:"messageAttributes"`
+		} `json:"Records"`
+	}
+
+	requireNoError(t, json.Unmarshal(inv.payloads[0], &event))
+
+	if len(event.Records) != 1 {
+		t.Fatalf("Records = %d, want 1", len(event.Records))
+	}
+
+	rec := event.Records[0]
+
+	if rec.MessageID != sendOut.MessageID {
+		t.Fatalf("messageId = %q, want %q", rec.MessageID, sendOut.MessageID)
+	}
+
+	if rec.ReceiptHandle == "" {
+		t.Fatal("receiptHandle is empty")
+	}
+
+	if rec.Body != "hello-lambda" {
+		t.Fatalf("body = %q, want %q", rec.Body, "hello-lambda")
+	}
+
+	if rec.EventSource != "aws:sqs" || rec.EventSourceARN != q.ARN || rec.AWSRegion != "us-east-1" {
+		t.Fatalf("eventSource=%q eventSourceARN=%q awsRegion=%q", rec.EventSource, rec.EventSourceARN, rec.AWSRegion)
+	}
+
+	if rec.Attributes["ApproximateReceiveCount"] != "1" {
+		t.Fatalf("ApproximateReceiveCount = %q, want 1", rec.Attributes["ApproximateReceiveCount"])
+	}
+
+	if rec.Attributes["SentTimestamp"] == "" || rec.Attributes["SenderId"] == "" ||
+		rec.Attributes["ApproximateFirstReceiveTimestamp"] == "" {
+		t.Fatalf("attributes missing standard fields: %+v", rec.Attributes)
+	}
+
+	if rec.MessageAttributes["myAttribute"].StringValue != "myValue" ||
+		rec.MessageAttributes["myAttribute"].DataType != "String" {
+		t.Fatalf("messageAttributes = %+v", rec.MessageAttributes)
+	}
+
+	// The message was processed successfully, so it must be gone from the queue.
+	info, err := m.GetQueueInfo(ctx, q.URL)
+	requireNoError(t, err)
+	assertEqual(t, 0, info.ApproxMessageCount)
+}
+
+// TestEventSourceInvokerNoInvokerNoDelivery verifies SendMessage never delivers
+// or blocks when no event source invoker is wired (the default).
+func TestEventSourceInvokerNoInvokerNoDelivery(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	q, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "no-invoker-queue"})
+	requireNoError(t, err)
+
+	_, err = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: q.URL, Body: "hi"})
+	requireNoError(t, err)
+
+	info, err := m.GetQueueInfo(ctx, q.URL)
+	requireNoError(t, err)
+	assertEqual(t, 1, info.ApproxMessageCount)
+}
+
+// noMappingESMInvoker always reports delivered=false, as Lambda's
+// DeliverEventSourceBatch does when no enabled event-source-mapping targets
+// the given ARN.
+type noMappingESMInvoker struct{}
+
+func (noMappingESMInvoker) DeliverEventSourceBatch(_ context.Context, _ string, _ []byte) (bool, error) {
+	return false, nil
+}
+
+// TestEventSourceInvokerNoMappingLeavesMessageUntouched verifies that an
+// invoker being wired is not, by itself, enough to consume a message: when no
+// enabled event-source-mapping actually targets the queue's ARN
+// (delivered=false), SendMessage must leave ordinary queue behavior
+// completely unaffected, not silently delete every message it sends.
+func TestEventSourceInvokerNoMappingLeavesMessageUntouched(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	m.SetEventSourceInvoker(noMappingESMInvoker{})
+
+	q, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "unmapped-queue"})
+	requireNoError(t, err)
+
+	_, err = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: q.URL, Body: "hi"})
+	requireNoError(t, err)
+
+	info, err := m.GetQueueInfo(ctx, q.URL)
+	requireNoError(t, err)
+	assertEqual(t, 1, info.ApproxMessageCount)
+
+	msgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: q.URL, MaxMessages: 1})
+	requireNoError(t, err)
+
+	if len(msgs) != 1 || msgs[0].SystemAttributes["ApproximateReceiveCount"] != "1" {
+		t.Fatalf("messages = %+v, want one message with ApproximateReceiveCount=1", msgs)
+	}
+}
+
+// TestEventSourceInvokerDLQRedrive verifies that a message whose mapped Lambda
+// handler always fails is redriven to the dead-letter queue once its receive
+// count exceeds RedrivePolicy's maxReceiveCount, exercising the same DLQ
+// threshold ReceiveMessages honors (see exceedsMaxReceive / collectVisibleMessages)
+// end to end through Lambda ESM delivery.
+func TestEventSourceInvokerDLQRedrive(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	inv := &recordingESMInvoker{fail: true}
+	m.SetEventSourceInvoker(inv)
+
+	dlq, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "esm-dlq"})
+	requireNoError(t, err)
+
+	q, err := m.CreateQueue(ctx, driver.QueueConfig{
+		Name: "esm-source",
+		DeadLetterQueue: &driver.DeadLetterConfig{
+			TargetQueueURL:  dlq.URL,
+			MaxReceiveCount: 2,
+		},
+	})
+	requireNoError(t, err)
+
+	sendOut, err := m.SendMessage(ctx, driver.SendMessageInput{QueueURL: q.URL, Body: "always-fails"})
+	requireNoError(t, err)
+
+	// The failing handler should have been invoked twice (MaxReceiveCount=2)
+	// before the message was redriven to the DLQ.
+	if len(inv.arns) != 2 {
+		t.Fatalf("delivery attempts = %d, want 2", len(inv.arns))
+	}
+
+	srcInfo, err := m.GetQueueInfo(ctx, q.URL)
+	requireNoError(t, err)
+	assertEqual(t, 0, srcInfo.ApproxMessageCount)
+
+	dlqMsgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: dlq.URL, MaxMessages: 10})
+	requireNoError(t, err)
+
+	if len(dlqMsgs) != 1 {
+		t.Fatalf("DLQ messages = %d, want 1", len(dlqMsgs))
+	}
+
+	if dlqMsgs[0].MessageID != sendOut.MessageID || dlqMsgs[0].Body != "always-fails" {
+		t.Fatalf("DLQ message = %+v, want id=%s body=always-fails", dlqMsgs[0], sendOut.MessageID)
+	}
+}
+
+// TestEventSourceInvokerFailureNoDLQLeavesMessage verifies that, with no
+// RedrivePolicy configured, a single failed delivery leaves the message in
+// the source queue rather than retrying indefinitely or dropping it.
+func TestEventSourceInvokerFailureNoDLQLeavesMessage(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	inv := &recordingESMInvoker{fail: true}
+	m.SetEventSourceInvoker(inv)
+
+	q, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "no-dlq-fail-queue"})
+	requireNoError(t, err)
+
+	_, err = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: q.URL, Body: "will-fail"})
+	requireNoError(t, err)
+
+	if len(inv.arns) != 1 {
+		t.Fatalf("delivery attempts = %d, want exactly 1 (no DLQ configured)", len(inv.arns))
+	}
+
+	qd, ok := m.queues.Get(q.URL)
+	if !ok {
+		t.Fatal("queue not found")
+	}
+
+	if len(qd.messages) != 1 {
+		t.Fatalf("messages left in queue = %d, want 1", len(qd.messages))
+	}
+}

--- a/providers/aws/sqs/sqs.go
+++ b/providers/aws/sqs/sqs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
 	"github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
@@ -77,8 +78,18 @@ type queueData struct {
 	seqCounter         atomic.Uint64
 }
 
-// LambdaTrigger is a function that gets called when a message is sent to a queue.
-type LambdaTrigger func(queueURL string, message driver.Message)
+// EventSourceInvoker delivers an SQS event-source-mapping batch to whatever
+// Lambda ESM(s) target the queue identified by eventSourceARN. delivered
+// reports whether any enabled mapping actually targeted the queue at all —
+// with none configured, SendMessage must leave the message queued rather than
+// treat "nothing happened" as a processed batch. err reports a targeted
+// mapping's handler failure, so the caller can decide whether to delete the
+// message (success) or leave it for redrive (failure). The Lambda mock
+// satisfies it, enabling real SQS -> Lambda invocation (mirroring the
+// DynamoDB Streams -> Lambda StreamEventInvoker wiring).
+type EventSourceInvoker interface {
+	DeliverEventSourceBatch(ctx context.Context, eventSourceARN string, payload []byte) (delivered bool, err error)
+}
 
 // Mock is an in-memory mock implementation of the AWS SQS service.
 type Mock struct {
@@ -86,7 +97,7 @@ type Mock struct {
 	moveTasks  *memstore.Store[*moveTask]
 	opts       *config.Options
 	mu         sync.RWMutex
-	triggers   map[string]LambdaTrigger // queueURL -> trigger
+	esmInvoker EventSourceInvoker
 	monitoring mondriver.Monitoring
 }
 
@@ -112,25 +123,16 @@ func New(opts *config.Options) *Mock {
 		queues:    memstore.New[*queueData](),
 		moveTasks: memstore.New[*moveTask](),
 		opts:      opts,
-		triggers:  make(map[string]LambdaTrigger),
 	}
 }
 
-// SetTrigger registers a Lambda trigger for a queue. When a message is sent to the
-// queue, the trigger function is called automatically.
-func (m *Mock) SetTrigger(queueURL string, fn LambdaTrigger) {
+// SetEventSourceInvoker wires the Lambda backend so a message sent to a queue
+// invokes the queue's Lambda event-source-mapping target(s).
+func (m *Mock) SetEventSourceInvoker(i EventSourceInvoker) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.triggers[queueURL] = fn
-}
-
-// RemoveTrigger removes a Lambda trigger from a queue.
-func (m *Mock) RemoveTrigger(queueURL string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	delete(m.triggers, queueURL)
+	m.esmInvoker = i
 }
 
 // DeliverExternal enqueues body into the queue identified by ARN. It is used
@@ -377,16 +379,16 @@ func (m *Mock) ListQueues(_ context.Context, prefix string) ([]driver.QueueInfo,
 // SendMessage sends a message to the specified SQS queue.
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*driver.SendMessageOutput, error) {
+func (m *Mock) SendMessage(ctx context.Context, input driver.SendMessageInput) (*driver.SendMessageOutput, error) {
 	qd, ok := m.queues.Get(input.QueueURL)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "queue %q not found", input.QueueURL)
 	}
 
 	qd.mu.Lock()
-	defer qd.mu.Unlock()
 
 	if qd.maxMessageSize > 0 && len(input.Body) > qd.maxMessageSize {
+		qd.mu.Unlock()
 		return nil, errors.Newf(errors.InvalidArgument,
 			"One or more parameters are invalid. Reason: Message must be shorter than %d bytes.", qd.maxMessageSize)
 	}
@@ -394,6 +396,7 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 	input.DeduplicationID = effectiveDedupID(qd, &input)
 
 	if err := validateFIFORequirements(qd, &input); err != nil {
+		qd.mu.Unlock()
 		return nil, err
 	}
 
@@ -401,6 +404,7 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 
 	// FIFO deduplication: check if same DeduplicationID was sent within 5-min window.
 	if existingID, found := findDuplicate(qd, &input, now); found {
+		qd.mu.Unlock()
 		return &driver.SendMessageOutput{MessageID: existingID}, nil
 	}
 
@@ -414,31 +418,179 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		qd.deduplicationIndex[input.DeduplicationID] = now
 	}
 
-	// Fire Lambda trigger if registered.
-	m.mu.RLock()
-	trigger := m.triggers[input.QueueURL]
-	m.mu.RUnlock()
-
-	if trigger != nil {
-		triggerMsg := driver.Message{
-			MessageID:         msgID,
-			Body:              input.Body,
-			Attributes:        msg.Attributes,
-			MessageAttributes: msg.MessageAttributes,
-			GroupID:           input.GroupID,
-		}
-
-		trigger(input.QueueURL, triggerMsg)
-	}
-
 	dims := map[string]string{"QueueName": qd.info.Name}
+	qd.mu.Unlock()
+
 	m.emitMetric("NumberOfMessagesSent", 1, "Count", dims)
 	m.emitMetric("SentMessageSize", float64(len(input.Body)), "Bytes", dims)
+
+	// Deliver to any Lambda event-source-mapping targeting this queue. Runs
+	// outside qd.mu so a handler that calls back into SQS (SendMessage,
+	// ReceiveMessage, DeleteMessage against this or another queue) never
+	// deadlocks on it.
+	m.deliverToESM(ctx, qd, msg)
 
 	return &driver.SendMessageOutput{
 		MessageID:      msgID,
 		SequenceNumber: seqNum,
 	}, nil
+}
+
+// deliverToESM synchronously delivers a newly sent message to the Lambda
+// event-source-mapping(s) targeting this queue, mirroring real SQS ESM
+// polling collapsed into the SendMessage call since the emulator has no
+// background poller. Each pass builds a trial "received" view of the message
+// (a fresh ReceiptHandle, ReceiveCount+1) without touching the stored message
+// yet, and only commits that receive once DeliverEventSourceBatch reports
+// delivered=true — i.e. a mapping actually exists for this queue's ARN. A
+// queue with no ESM configured at all must therefore leave the message
+// completely untouched, rather than have "nothing happened" misread as a
+// processed batch.
+//
+// Once a mapping has genuinely consumed the message: on success it is
+// deleted, matching "When your function successfully processes a batch,
+// Lambda deletes its messages from the queue"
+// (https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html). On failure it
+// is left in the queue (invisible until the visibility timeout, as in real
+// SQS) unless a RedrivePolicy is configured, in which case delivery retries
+// in a synchronous loop until it either succeeds or exceedsMaxReceive is
+// reached, at which point the same DLQ-redrive threshold ReceiveMessages
+// honors (see collectVisibleMessages) moves the message to the dead-letter
+// queue. A no-op when no invoker is wired.
+//
+// callerCtx is SendMessage's own context, used only to read the re-entrant
+// delivery depth (internal/recursionguard): a mapped handler commonly
+// re-sends to the very queue that triggered it, re-entering here through the
+// same synchronous call chain (SendMessage -> deliver -> Invoke -> handler ->
+// SendMessage -> ...). Delivery itself always runs on a fresh background
+// context, decoupled from callerCtx's cancellation/deadline (delivery must
+// still complete once the SendMessage call has already returned), carrying
+// forward only the depth so the chain stays bounded.
+func (m *Mock) deliverToESM(callerCtx context.Context, qd *queueData, msg *sqsMessage) {
+	if m.esmInvoker == nil {
+		return
+	}
+
+	ctx := recursionguard.WithDepth(context.Background(), recursionguard.Depth(callerCtx))
+
+	for {
+		qd.mu.Lock()
+
+		if !containsMessage(qd, msg) {
+			qd.mu.Unlock()
+			return
+		}
+
+		trialCount := msg.ReceiveCount + 1
+
+		// A receive that would cross MaxReceiveCount is redirected to the DLQ
+		// without ever invoking Lambda for it, mirroring collectVisibleMessages
+		// (the receive that crosses the threshold never reaches the consumer
+		// there either). This can only fire once at least one earlier attempt
+		// in this same call has already been delivered: ReceiveCount starts at
+		// 0 for a freshly sent message, so its first attempt (trialCount=1)
+		// can never exceed a MaxReceiveCount >= 1.
+		if qd.dlqConfig != nil && qd.dlqConfig.MaxReceiveCount > 0 && trialCount > qd.dlqConfig.MaxReceiveCount {
+			msg.ReceiveCount = trialCount
+			removeQueuedMessage(qd, msg)
+			dlqURL, sourceURL := qd.dlqConfig.TargetQueueURL, qd.info.URL
+			qd.mu.Unlock()
+			m.moveToDLQ(dlqURL, sourceURL, msg)
+
+			return
+		}
+
+		trial := *msg
+		trial.ReceiveCount = trialCount
+		received := buildReceivedMessage(&trial, qd.visibilityTimeout, m.opts.Clock.Now())
+		arn := qd.info.ARN
+		region := m.opts.Region
+		qd.mu.Unlock()
+
+		payload := driver.BuildLambdaSQSEvent(arn, region, []driver.Message{received})
+
+		delivered, deliverErr := m.esmInvoker.DeliverEventSourceBatch(ctx, arn, payload)
+		if !delivered {
+			// No event-source-mapping targets this queue: the send is unaffected.
+			return
+		}
+
+		if m.commitESMReceive(qd, msg, &trial, deliverErr) {
+			return
+		}
+	}
+}
+
+// commitESMReceive applies a trial receive (built by deliverToESM once a
+// mapping is known to have actually consumed the message) onto the real
+// stored message, then resolves the outcome: delete on success, DLQ-redrive
+// once exceedsMaxReceive, leave in place with no DLQ configured, or signal
+// the caller to retry. It reports whether deliverToESM's loop should stop.
+func (m *Mock) commitESMReceive(qd *queueData, msg, trial *sqsMessage, deliverErr error) (done bool) {
+	qd.mu.Lock()
+
+	if !containsMessage(qd, msg) {
+		qd.mu.Unlock()
+		return true
+	}
+
+	msg.ReceiveCount = trial.ReceiveCount
+	msg.ReceiptHandle = trial.ReceiptHandle
+	msg.VisibleAt = trial.VisibleAt
+	msg.FirstReceivedAt = trial.FirstReceivedAt
+
+	if deliverErr == nil {
+		removeQueuedMessage(qd, msg)
+		qd.mu.Unlock()
+		m.emitMetric("NumberOfMessagesDeleted", 1, "Count", map[string]string{"QueueName": qd.info.Name})
+
+		return true
+	}
+
+	// deliverToESM's upfront check already redirects a receive that would
+	// cross the threshold before ever invoking Lambda for it; this only fires
+	// if a concurrent SetQueueAttributesRaw shrank MaxReceiveCount between
+	// that check and this commit.
+	if exceedsMaxReceive(qd, msg) {
+		removeQueuedMessage(qd, msg)
+		dlqURL, sourceURL := qd.dlqConfig.TargetQueueURL, qd.info.URL
+		qd.mu.Unlock()
+		m.moveToDLQ(dlqURL, sourceURL, msg)
+
+		return true
+	}
+
+	hasDLQ := qd.dlqConfig != nil
+	qd.mu.Unlock()
+
+	// No DLQ configured: one delivery attempt only. The message stays in the
+	// queue, invisible until the visibility timeout just set expires, exactly
+	// as an unconfigured real SQS/Lambda ESM leaves a failed batch for the
+	// next poll. A DLQ that hasn't hit its threshold yet retries immediately.
+	return !hasDLQ
+}
+
+// containsMessage reports whether the given message pointer is still queued.
+// Caller must hold qd.mu.
+func containsMessage(qd *queueData, target *sqsMessage) bool {
+	for _, msg := range qd.messages {
+		if msg == target {
+			return true
+		}
+	}
+
+	return false
+}
+
+// removeQueuedMessage removes the given message pointer from the queue's
+// backlog, if still present. Caller must hold qd.mu.
+func removeQueuedMessage(qd *queueData, target *sqsMessage) {
+	for i, msg := range qd.messages {
+		if msg == target {
+			qd.messages = append(qd.messages[:i], qd.messages[i+1:]...)
+			return
+		}
+	}
 }
 
 // effectiveDedupID returns the deduplication ID to use, deriving it from the
@@ -640,7 +792,7 @@ func (m *Mock) collectVisibleMessages(
 		msg.ReceiveCount++
 
 		// Check if message exceeded max receive count - move to DLQ.
-		if qd.dlqConfig != nil && qd.dlqConfig.MaxReceiveCount > 0 && msg.ReceiveCount > qd.dlqConfig.MaxReceiveCount {
+		if exceedsMaxReceive(qd, msg) {
 			m.moveToDLQ(qd.dlqConfig.TargetQueueURL, qd.info.URL, msg)
 
 			toRemove = append(toRemove, i)
@@ -702,6 +854,14 @@ func buildReceivedMessage(msg *sqsMessage, visibilityTimeout int, now time.Time)
 		SequenceNumber:    msg.SequenceNumber,
 		GroupID:           msg.GroupID,
 	}
+}
+
+// exceedsMaxReceive reports whether msg's receive count has now exceeded the
+// queue's configured DLQ MaxReceiveCount. Shared by ReceiveMessages (see
+// collectVisibleMessages) and Lambda event-source-mapping delivery (see
+// deliverToESM) so both polling paths honor the same redrive threshold.
+func exceedsMaxReceive(qd *queueData, msg *sqsMessage) bool {
+	return qd.dlqConfig != nil && qd.dlqConfig.MaxReceiveCount > 0 && msg.ReceiveCount > qd.dlqConfig.MaxReceiveCount
 }
 
 // moveToDLQ moves a message to the dead-letter queue, recording the source

--- a/providers/aws/sqs/sqs_test.go
+++ b/providers/aws/sqs/sqs_test.go
@@ -609,30 +609,6 @@ func createSQSQueue(m *Mock, name string) *driver.QueueInfo {
 	return info
 }
 
-func TestLambdaTrigger(t *testing.T) {
-	m, _ := newTestMock()
-	ctx := context.Background()
-	q := createStdQueue(m, "trigger-queue")
-
-	var triggered bool
-	var triggeredBody string
-
-	m.SetTrigger(q.URL, func(queueURL string, msg driver.Message) {
-		triggered = true
-		triggeredBody = msg.Body
-	})
-
-	_, _ = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: q.URL, Body: "trigger-test"})
-
-	assertEqual(t, true, triggered)
-	assertEqual(t, "trigger-test", triggeredBody)
-
-	m.RemoveTrigger(q.URL)
-	triggered = false
-	_, _ = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: q.URL, Body: "no-trigger"})
-	assertEqual(t, false, triggered)
-}
-
 func TestReceiveMessagesWithOptionsMetrics(t *testing.T) {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))

--- a/server/aws/lambda/sqs_esm_sdk_test.go
+++ b/server/aws/lambda/sqs_esm_sdk_test.go
@@ -1,0 +1,304 @@
+// sqs_esm_sdk_test.go — real aws-sdk-go-v2 end-to-end test for the SQS ->
+// Lambda event-source-mapping delivery path. Creating a mapping from a queue
+// to a function, then sending a message, must synchronously invoke the mapped
+// function with a real SQS event batch and delete the message on success
+// (previously CreateEventSourceMapping only stored config and nothing ever
+// invoked the function, nor deleted the message, leaving the DLQ redrive path
+// unreachable). Mirrors dynamodb_stream_esm_sdk_test.go for the SQS source.
+package lambda_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// TestSDKSQSESMInvokesLambdaAndDeletesMessage verifies that sending a message
+// to a queue with an enabled event-source-mapping synchronously invokes the
+// mapped Lambda with the documented SQS event shape, and deletes the message
+// from the queue once the handler succeeds.
+func TestSDKSQSESMInvokesLambdaAndDeletesMessage(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+
+	invocations := make(chan []byte, 4)
+	cloud.Lambda.RegisterHandler("sqs-processor", func(_ context.Context, payload []byte) ([]byte, error) {
+		invocations <- payload
+		return payload, nil
+	})
+
+	srv := awsserver.New(awsserver.Drivers{
+		SQS:        cloud.SQS,
+		Lambda:     cloud.Lambda,
+		CloudWatch: cloud.CloudWatch,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	sqsClient, lam := newSQSAndLambda(t, ts.URL)
+	ctx := context.Background()
+
+	queueURL, queueARN := createQueue(t, sqsClient, "orders-queue")
+	createProcessorFunction(t, lam, "sqs-processor")
+
+	esm, err := lam.CreateEventSourceMapping(ctx, &awslambda.CreateEventSourceMappingInput{
+		EventSourceArn: aws.String(queueARN),
+		FunctionName:   aws.String("sqs-processor"),
+		Enabled:        aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("CreateEventSourceMapping: %v", err)
+	}
+
+	if esm.State == nil || *esm.State != "Enabled" {
+		t.Fatalf("mapping State = %v, want Enabled", esm.State)
+	}
+
+	// Sending a message must invoke the mapped Lambda.
+	if _, err := sqsClient.SendMessage(ctx, &awssqs.SendMessageInput{
+		QueueUrl:    aws.String(queueURL),
+		MessageBody: aws.String("New order!"),
+		MessageAttributes: map[string]sqstypes.MessageAttributeValue{
+			"orderType": {DataType: aws.String("String"), StringValue: aws.String("standard")},
+		},
+	}); err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+
+	payload := awaitInvocation(t, invocations)
+	assertSQSEvent(t, payload, queueARN)
+
+	// The handler succeeded, so the message must have been deleted -- a
+	// receive against the (now empty) queue finds nothing.
+	rcv, err := sqsClient.ReceiveMessage(ctx, &awssqs.ReceiveMessageInput{
+		QueueUrl:            aws.String(queueURL),
+		MaxNumberOfMessages: 10,
+	})
+	if err != nil {
+		t.Fatalf("ReceiveMessage: %v", err)
+	}
+
+	if len(rcv.Messages) != 0 {
+		t.Fatalf("queue has %d messages after successful processing, want 0", len(rcv.Messages))
+	}
+}
+
+// TestSDKSQSESMFailureRedrivesToDLQ verifies that a message whose mapped
+// Lambda handler always fails is redriven to the RedrivePolicy's dead-letter
+// queue once its receive count exceeds MaxReceiveCount, exercising the
+// existing DLQ-redrive logic end to end through Lambda ESM delivery.
+func TestSDKSQSESMFailureRedrivesToDLQ(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+
+	var invocationCount int
+	invoked := make(chan struct{}, 8)
+	cloud.Lambda.RegisterHandler("always-fails", func(_ context.Context, _ []byte) ([]byte, error) {
+		invocationCount++
+		invoked <- struct{}{}
+		return nil, fmt.Errorf("processing failed")
+	})
+
+	srv := awsserver.New(awsserver.Drivers{
+		SQS:        cloud.SQS,
+		Lambda:     cloud.Lambda,
+		CloudWatch: cloud.CloudWatch,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	sqsClient, lam := newSQSAndLambda(t, ts.URL)
+	ctx := context.Background()
+
+	dlqURL, dlqARN := createQueue(t, sqsClient, "poison-dlq")
+	mainURL, mainARN := createQueue(t, sqsClient, "poison-main")
+
+	redrive := fmt.Sprintf(`{"deadLetterTargetArn":%q,"maxReceiveCount":2}`, dlqARN)
+	if _, err := sqsClient.SetQueueAttributes(ctx, &awssqs.SetQueueAttributesInput{
+		QueueUrl:   aws.String(mainURL),
+		Attributes: map[string]string{"RedrivePolicy": redrive},
+	}); err != nil {
+		t.Fatalf("SetQueueAttributes: %v", err)
+	}
+
+	createProcessorFunction(t, lam, "always-fails")
+
+	if _, err := lam.CreateEventSourceMapping(ctx, &awslambda.CreateEventSourceMappingInput{
+		EventSourceArn: aws.String(mainARN),
+		FunctionName:   aws.String("always-fails"),
+		Enabled:        aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("CreateEventSourceMapping: %v", err)
+	}
+
+	if _, err := sqsClient.SendMessage(ctx, &awssqs.SendMessageInput{
+		QueueUrl:    aws.String(mainURL),
+		MessageBody: aws.String("poison"),
+	}); err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-invoked:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("handler was invoked %d times, want 2", i)
+		}
+	}
+
+	if invocationCount != 2 {
+		t.Fatalf("invocationCount = %d, want exactly 2 (MaxReceiveCount)", invocationCount)
+	}
+
+	// The main queue must now be empty...
+	mainRcv, err := sqsClient.ReceiveMessage(ctx, &awssqs.ReceiveMessageInput{
+		QueueUrl:            aws.String(mainURL),
+		MaxNumberOfMessages: 10,
+	})
+	if err != nil {
+		t.Fatalf("ReceiveMessage(main): %v", err)
+	}
+
+	if len(mainRcv.Messages) != 0 {
+		t.Fatalf("main queue has %d messages after redrive, want 0", len(mainRcv.Messages))
+	}
+
+	// ...and the DLQ must hold exactly the redriven message.
+	dlqRcv, err := sqsClient.ReceiveMessage(ctx, &awssqs.ReceiveMessageInput{
+		QueueUrl:            aws.String(dlqURL),
+		MaxNumberOfMessages: 10,
+	})
+	if err != nil {
+		t.Fatalf("ReceiveMessage(dlq): %v", err)
+	}
+
+	if len(dlqRcv.Messages) != 1 {
+		t.Fatalf("DLQ has %d messages, want 1", len(dlqRcv.Messages))
+	}
+
+	if aws.ToString(dlqRcv.Messages[0].Body) != "poison" {
+		t.Errorf("DLQ body = %q, want poison", aws.ToString(dlqRcv.Messages[0].Body))
+	}
+}
+
+// assertSQSEvent verifies the payload Lambda received is the documented SQS
+// event shape: https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html.
+func assertSQSEvent(t *testing.T, payload []byte, queueARN string) {
+	t.Helper()
+
+	var event struct {
+		Records []struct {
+			MessageID         string            `json:"messageId"`
+			ReceiptHandle     string            `json:"receiptHandle"`
+			Body              string            `json:"body"`
+			Attributes        map[string]string `json:"attributes"`
+			MessageAttributes map[string]struct {
+				StringValue string `json:"stringValue"`
+				DataType    string `json:"dataType"`
+			} `json:"messageAttributes"`
+			MD5OfBody      string `json:"md5OfBody"`
+			EventSource    string `json:"eventSource"`
+			EventSourceARN string `json:"eventSourceARN"`
+			AWSRegion      string `json:"awsRegion"`
+		} `json:"Records"`
+	}
+
+	if err := json.Unmarshal(payload, &event); err != nil {
+		t.Fatalf("unmarshal SQS event: %v\npayload=%s", err, payload)
+	}
+
+	if len(event.Records) != 1 {
+		t.Fatalf("Records = %d, want 1\npayload=%s", len(event.Records), payload)
+	}
+
+	rec := event.Records[0]
+
+	if rec.Body != "New order!" {
+		t.Fatalf("body = %q, want %q", rec.Body, "New order!")
+	}
+
+	if rec.ReceiptHandle == "" || rec.MessageID == "" || rec.MD5OfBody == "" {
+		t.Fatalf("record missing messageId/receiptHandle/md5OfBody: %+v", rec)
+	}
+
+	if rec.EventSource != "aws:sqs" {
+		t.Fatalf("eventSource = %q, want aws:sqs", rec.EventSource)
+	}
+
+	if rec.EventSourceARN != queueARN {
+		t.Fatalf("eventSourceARN = %q, want %q", rec.EventSourceARN, queueARN)
+	}
+
+	if rec.AWSRegion == "" {
+		t.Fatal("awsRegion is empty")
+	}
+
+	if rec.Attributes["ApproximateReceiveCount"] != "1" {
+		t.Fatalf("ApproximateReceiveCount = %q, want 1", rec.Attributes["ApproximateReceiveCount"])
+	}
+
+	if rec.Attributes["SentTimestamp"] == "" || rec.Attributes["SenderId"] == "" ||
+		rec.Attributes["ApproximateFirstReceiveTimestamp"] == "" {
+		t.Fatalf("attributes missing standard fields: %+v", rec.Attributes)
+	}
+
+	if rec.MessageAttributes["orderType"].StringValue != "standard" ||
+		rec.MessageAttributes["orderType"].DataType != "String" {
+		t.Fatalf("messageAttributes = %+v", rec.MessageAttributes)
+	}
+}
+
+// createQueue creates a standard SQS queue and returns its URL and ARN.
+func createQueue(t *testing.T, client *awssqs.Client, name string) (queueURL, queueARN string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	out, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String(name)})
+	if err != nil {
+		t.Fatalf("CreateQueue(%s): %v", name, err)
+	}
+
+	attrs, err := client.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       out.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameQueueArn},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes(%s): %v", name, err)
+	}
+
+	arn := attrs.Attributes["QueueArn"]
+	if arn == "" {
+		t.Fatalf("GetQueueAttributes(%s) returned an empty QueueArn", name)
+	}
+
+	return aws.ToString(out.QueueUrl), arn
+}
+
+func newSQSAndLambda(t *testing.T, url string) (*awssqs.Client, *awslambda.Client) {
+	t.Helper()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	sqsClient := awssqs.NewFromConfig(cfg, func(o *awssqs.Options) { o.BaseEndpoint = aws.String(url) })
+	lam := awslambda.NewFromConfig(cfg, func(o *awslambda.Options) { o.BaseEndpoint = aws.String(url) })
+
+	return sqsClient, lam
+}

--- a/services/messagequeue/driver/sqs_event.go
+++ b/services/messagequeue/driver/sqs_event.go
@@ -1,0 +1,79 @@
+package driver
+
+import (
+	"crypto/md5" //nolint:gosec // SQS MD5 checksums are a wire-protocol field, not a security use.
+	"encoding/hex"
+	"encoding/json"
+)
+
+// sqsEventSource is the eventSource value Lambda stamps on every record
+// delivered from an SQS event-source-mapping.
+const sqsEventSource = "aws:sqs"
+
+// BuildLambdaSQSEvent renders a batch of received messages into the exact JSON
+// event Lambda delivers to an SQS event-source-mapping target:
+// {"Records":[{messageId,receiptHandle,body,attributes,messageAttributes,
+// md5OfBody,eventSource:"aws:sqs",eventSourceARN,awsRegion}]}. attributes
+// carries the SQS system attributes exactly as Message.SystemAttributes
+// already holds them (ApproximateReceiveCount, SentTimestamp, SenderId,
+// ApproximateFirstReceiveTimestamp, and for FIFO queues SequenceNumber,
+// MessageGroupId, MessageDeduplicationId).
+// See https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html.
+func BuildLambdaSQSEvent(eventSourceARN, region string, msgs []Message) []byte {
+	records := make([]map[string]any, 0, len(msgs))
+	for i := range msgs {
+		records = append(records, lambdaSQSRecord(&msgs[i], eventSourceARN, region))
+	}
+
+	b, err := json.Marshal(map[string]any{"Records": records})
+	if err != nil {
+		return []byte(`{"Records":[]}`)
+	}
+
+	return b
+}
+
+func lambdaSQSRecord(msg *Message, eventSourceARN, region string) map[string]any {
+	return map[string]any{
+		"messageId":         msg.MessageID,
+		"receiptHandle":     msg.ReceiptHandle,
+		"body":              msg.Body,
+		"attributes":        msg.SystemAttributes,
+		"messageAttributes": lambdaMessageAttributes(msg.MessageAttributes),
+		"md5OfBody":         md5OfBody(msg.Body),
+		"eventSource":       sqsEventSource,
+		"eventSourceARN":    eventSourceARN,
+		"awsRegion":         region,
+	}
+}
+
+// lambdaMessageAttributes renders typed SQS message attributes into the shape
+// Lambda's SQS event binds them as: stringValue/binaryValue plus the always-
+// present (if empty) stringListValues/binaryListValues arrays and dataType.
+func lambdaMessageAttributes(attrs map[string]MessageAttributeValue) map[string]any {
+	out := make(map[string]any, len(attrs))
+
+	for k, v := range attrs {
+		rec := map[string]any{
+			"stringValue":      v.StringValue,
+			"stringListValues": []string{},
+			"binaryListValues": [][]byte{},
+			"dataType":         v.DataType,
+		}
+
+		if len(v.BinaryValue) > 0 {
+			rec["binaryValue"] = v.BinaryValue
+		}
+
+		out[k] = rec
+	}
+
+	return out
+}
+
+// md5OfBody returns the hex MD5 checksum of a message body, matching the
+// md5OfBody field SQS/Lambda report for a message.
+func md5OfBody(body string) string {
+	sum := md5.Sum([]byte(body)) //nolint:gosec // SQS MD5 checksum, not a security use.
+	return hex.EncodeToString(sum[:])
+}


### PR DESCRIPTION
## Summary

`CreateEventSourceMapping(EventSourceArn=<queue ARN>, ...)` succeeded and reported `State=Enabled`, but `SendMessage` never actually invoked the mapped Lambda and never deleted the message — the SQS -> Lambda ESM was a pure DB record. This also made the existing DLQ redrive logic in `sqs.go` unreachable for an SQS event source, since a message could never accumulate failed Lambda deliveries.

`providers/aws/sqs/sqs.go` had an internal `triggers` map populated only by a test-only `SetTrigger(queueURL, fn)`, never wired from `aws.go` or from `server/aws/lambda/esm.go`'s `CreateEventSourceMapping` — unlike the DynamoDB Streams (`SetStreamInvoker`) and S3 (`SetLambdaInvoker`) wiring, which already deliver to Lambda for real.

## What changed

- **`providers/aws/sqs/sqs.go`**: `SendMessage` now delivers a real SQS event to any enabled Lambda event-source-mapping targeting the queue's ARN, mirroring the documented shape (`Records[].{messageId,receiptHandle,body,attributes,messageAttributes,md5OfBody,eventSource:"aws:sqs",eventSourceARN,awsRegion}` — see [AWS docs](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html)). On handler success the message is deleted; on failure it's left for redrive, retrying synchronously until it either succeeds or `ReceiveCount` exceeds `RedrivePolicy.maxReceiveCount`, at which point the **existing** DLQ-redrive logic (shared with `ReceiveMessages` via a new `exceedsMaxReceive` helper) moves it to the DLQ. Removed the unused, test-only `SetTrigger`/`RemoveTrigger`/`LambdaTrigger` machinery in favor of the real `CreateEventSourceMapping` flow.
- **`providers/aws/aws.go`**: wires `p.SQS.SetEventSourceInvoker(p.Lambda)`, mirroring the existing `p.DynamoDB.SetStreamInvoker(p.Lambda)` pattern.
- **`providers/aws/lambda/esm.go`**: `DeliverEventSourceBatch` now also reports `delivered bool` — whether any enabled mapping actually matched the ARN — distinct from a nil error, since SQS must not treat "no mapping configured" as a successfully processed batch. It also no longer stops at the first failing mapping; every matching mapping is invoked, with the last error returned.
- **`providers/aws/lambda/lambda.go`**: `InvokeExternal` now surfaces a handler's raised error (`StatusCode 500` / non-empty `FunctionError`) as a genuine Go error, instead of always returning nil for a ran-but-failed invocation. Existing callers (S3 notifications, DynamoDB Streams) already discard this error, so behavior there is unchanged; SQS is the first caller that needs to distinguish success from failure.
- **`providers/aws/dynamodb/dynamodb.go`**: updated `StreamEventInvoker`'s signature to match (discarding the new `delivered` return, unchanged behavior).
- **`services/messagequeue/driver/sqs_event.go`** (new): `BuildLambdaSQSEvent`, the portable event-payload builder, mirroring `services/database/driver/stream_event.go`'s `BuildLambdaStreamEvent` precedent.

## Tests

- `providers/aws/sqs/event_source_mapping_test.go` (new, unit-level): delivery with the correct event shape + message deleted on success; no invoker wired is a no-op; an invoker wired but no matching mapping leaves the message completely untouched; failing handler + `maxReceiveCount=2` lands the message in the DLQ after exactly 2 deliveries; a failure with no DLQ configured leaves the message in the queue after exactly 1 attempt.
- `server/aws/lambda/sqs_esm_sdk_test.go` (new, real `aws-sdk-go-v2` client against a live `httptest` wire server, mirroring `dynamodb_stream_esm_sdk_test.go`): end-to-end SendMessage -> Lambda invocation with the documented event shape + message deletion; end-to-end failing handler -> DLQ redrive after `maxReceiveCount` deliveries.
- `cloudemu_test.go`: `TestLambdaSQSTrigger`/`TestLambdaSQSTriggerRemove` rewritten against the real `CreateEventSourceMapping`/`DeleteEventSourceMapping` flow instead of the removed manual trigger API.
- `providers/aws/lambda/esm_delivery_test.go`: extended to assert `delivered` distinguishes a matched mapping from an unmapped ARN.

DynamoDB/Kinesis sources stay out of scope (already wired); this addresses the SQS source only.