### PR TITLE
fix(eventbridge): PutEvents delivers to Lambda/SNS/Step Functions targets, not only SQS

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -271,8 +271,14 @@ func New(opts ...config.Option) *Provider {
 	p.CloudWatch.SetSNSPublisher(p.SNS)
 	// SNS -> SQS fan-out: publishes deliver to SQS-protocol subscriptions.
 	p.SNS.SetSQSDeliverer(p.SQS)
-	// EventBridge -> SQS: matched rules deliver events to SQS targets.
+	// EventBridge -> targets: matched rules deliver events to their first-class
+	// target types — SQS queues, Lambda functions (ASYNC), SNS topics, and Step
+	// Functions state machines (ASYNC). Lambda reuses the shared InvokeExternal
+	// choke point so its recursion guard bounds re-entrant event loops.
 	p.EventBridge.SetSQSDeliverer(p.SQS)
+	p.EventBridge.SetLambdaInvoker(p.Lambda)
+	p.EventBridge.SetSNSPublisher(p.SNS)
+	p.EventBridge.SetStepFunctionsStarter(p.SFN)
 	// S3 event notifications deliver to their configured targets: SQS queues,
 	// SNS topics, and Lambda functions.
 	p.S3.SetSQSDeliverer(p.SQS)

--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/eventmatch"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/scope"
@@ -48,12 +49,36 @@ type SQSDeliverer interface {
 	DeliverExternal(ctx context.Context, queueARN, body string) error
 }
 
+// LambdaInvoker asynchronously invokes a Lambda function target by ARN with the
+// event envelope. The Lambda mock satisfies this, enabling EventBridge -> Lambda
+// (ASYNC) delivery.
+type LambdaInvoker interface {
+	InvokeExternal(ctx context.Context, functionARN string, payload []byte) error
+}
+
+// SNSPublisher publishes the event envelope to an SNS topic target by ARN. The
+// SNS mock satisfies this, enabling EventBridge -> SNS delivery.
+type SNSPublisher interface {
+	PublishExternal(ctx context.Context, topicARN, message string) error
+}
+
+// StepFunctionsStarter starts a Step Functions state-machine execution for a
+// state-machine target by ARN, passing the event envelope as the execution
+// input. The Step Functions mock satisfies this, enabling EventBridge -> Step
+// Functions (ASYNC) delivery.
+type StepFunctionsStarter interface {
+	StartExternal(ctx context.Context, stateMachineARN, input string) error
+}
+
 // Mock is an in-memory mock implementation of AWS EventBridge.
 type Mock struct {
 	buses      *memstore.Store[*busData]
 	opts       *config.Options
 	monitoring mondriver.Monitoring
 	sqs        SQSDeliverer
+	lambda     LambdaInvoker
+	sns        SNSPublisher
+	sfn        StepFunctionsStarter
 	tagsByARN  tagStore
 }
 
@@ -65,6 +90,22 @@ func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
 // SetSQSDeliverer wires the SQS backend so PutEvents delivers to SQS targets.
 func (m *Mock) SetSQSDeliverer(d SQSDeliverer) {
 	m.sqs = d
+}
+
+// SetLambdaInvoker wires the Lambda backend so PutEvents invokes Lambda targets.
+func (m *Mock) SetLambdaInvoker(i LambdaInvoker) {
+	m.lambda = i
+}
+
+// SetSNSPublisher wires the SNS backend so PutEvents publishes to SNS targets.
+func (m *Mock) SetSNSPublisher(p SNSPublisher) {
+	m.sns = p
+}
+
+// SetStepFunctionsStarter wires the Step Functions backend so PutEvents starts
+// state-machine targets.
+func (m *Mock) SetStepFunctionsStarter(s StepFunctionsStarter) {
+	m.sfn = s
 }
 
 func (m *Mock) emitMetric(metricName string, value float64, dims map[string]string) {
@@ -464,15 +505,19 @@ func (m *Mock) PutEvents(ctx context.Context, events []driver.Event) (*driver.Pu
 	return result, nil
 }
 
-// deliverToTargets delivers an event to the SQS targets of matched rules. The
-// body delivered to each target is the event envelope by default, but is
+// deliverToTargets delivers an event to the targets of matched rules, dispatched
+// by the target ARN's service: SQS queue, Lambda function (ASYNC), SNS topic, and
+// Step Functions state machine (ASYNC) are all first-class EventBridge targets.
+// The body delivered to each target is the event envelope by default, but is
 // replaced by the target's Input (constant), InputPath (selected subtree), or
 // InputTransformer (templated) when one is configured — matching how real
 // EventBridge shapes each target's payload independently.
 func (m *Mock) deliverToTargets(ctx context.Context, matched []driver.Rule, event *driver.Event) {
-	if m.sqs == nil {
-		return
-	}
+	// Decouple delivery from the caller's cancellation/deadline (real EventBridge
+	// delivery is asynchronous) while carrying forward the re-entrant delivery
+	// depth so a Lambda target that re-publishes an event stays bounded (the guard
+	// lives in lambda.InvokeExternal).
+	dctx := recursionguard.WithDepth(context.Background(), recursionguard.Depth(ctx))
 
 	envelope := m.eventEnvelope(event)
 
@@ -480,13 +525,35 @@ func (m *Mock) deliverToTargets(ctx context.Context, matched []driver.Rule, even
 		reserved := m.reservedVars(&matched[i], event, envelope)
 
 		for _, t := range matched[i].Targets {
-			if t.ARN == "" || !strings.Contains(t.ARN, ":sqs:") {
+			if t.ARN == "" {
 				continue
 			}
 
-			body := targetBody(&t, envelope, reserved)
+			m.dispatchTarget(dctx, t.ARN, targetBody(&t, envelope, reserved))
+		}
+	}
+}
 
-			_ = m.sqs.DeliverExternal(ctx, t.ARN, body)
+// dispatchTarget routes a rendered payload to a single target by the service in
+// its ARN. Unknown/unsupported target services are silently ignored (matching
+// EventBridge accepting the target but this emulator not modeling that sink).
+func (m *Mock) dispatchTarget(ctx context.Context, arn, body string) {
+	switch {
+	case strings.Contains(arn, ":sqs:"):
+		if m.sqs != nil {
+			_ = m.sqs.DeliverExternal(ctx, arn, body)
+		}
+	case strings.Contains(arn, ":lambda:"):
+		if m.lambda != nil {
+			_ = m.lambda.InvokeExternal(ctx, arn, []byte(body))
+		}
+	case strings.Contains(arn, ":sns:"):
+		if m.sns != nil {
+			_ = m.sns.PublishExternal(ctx, arn, body)
+		}
+	case strings.Contains(arn, ":states:"):
+		if m.sfn != nil {
+			_ = m.sfn.StartExternal(ctx, arn, body)
 		}
 	}
 }

--- a/providers/aws/sfn/executions.go
+++ b/providers/aws/sfn/executions.go
@@ -131,6 +131,24 @@ func (m *Mock) StartExecution(_ context.Context, in driver.StartExecutionInput) 
 	return m.runExecution(in, true)
 }
 
+// StartExternal starts a state-machine execution on behalf of a cross-service
+// event source (e.g. an EventBridge rule whose target is this state machine).
+// It is the SFN counterpart to the SQS/SNS/Lambda external-delivery choke
+// points: an unknown state machine is a no-op so a stale target never fails the
+// caller. The event envelope is passed through as the execution input.
+func (m *Mock) StartExternal(ctx context.Context, stateMachineARN, input string) error {
+	if _, err := m.getSM(stateMachineARN); err != nil {
+		return nil
+	}
+
+	_, err := m.StartExecution(ctx, driver.StartExecutionInput{
+		StateMachineArn: stateMachineARN,
+		Input:           input,
+	})
+
+	return err
+}
+
 func (m *Mock) StartSyncExecution(_ context.Context, in driver.StartExecutionInput) (*driver.Execution, error) {
 	return m.runExecution(in, false)
 }

--- a/server/aws/eventbridge/target_dispatch_sdk_test.go
+++ b/server/aws/eventbridge/target_dispatch_sdk_test.go
@@ -1,0 +1,186 @@
+// target_dispatch_sdk_test.go — real aws-sdk-go-v2 end-to-end test for
+// EventBridge target dispatch by ARN service. A matching PutEvents must reach
+// every first-class target type, not only SQS: a Lambda function target is
+// invoked (ASYNC) and an SNS topic target is published (fanning out to its
+// SQS-protocol subscription). Previously deliverToTargets hard-coded a single
+// SQS-only branch, so Lambda/SNS/Step Functions targets were accepted by
+// PutTargets but silently never delivered.
+package eventbridge_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+type ebTargetClients struct {
+	eb  *awseb.Client
+	sqs *awssqs.Client
+	sns *awssns.Client
+	lam *awslambda.Client
+}
+
+// newEBTargets wires one wire server serving EventBridge, SQS, SNS and Lambda
+// from a single cloud (so cross-service target delivery is exercised for real),
+// registering a Lambda handler that reports each invocation on the returned
+// channel.
+func newEBTargets(t *testing.T, funcName string) (ebTargetClients, <-chan []byte) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+
+	invocations := make(chan []byte, 4)
+	cloud.Lambda.RegisterHandler(funcName, func(_ context.Context, payload []byte) ([]byte, error) {
+		invocations <- payload
+
+		return payload, nil
+	})
+
+	srv := awsserver.New(awsserver.Drivers{
+		EventBridge: cloud.EventBridge,
+		SQS:         cloud.SQS,
+		SNS:         cloud.SNS,
+		Lambda:      cloud.Lambda,
+		CloudWatch:  cloud.CloudWatch,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return ebTargetClients{
+		eb:  awseb.NewFromConfig(cfg, func(o *awseb.Options) { o.BaseEndpoint = aws.String(ts.URL) }),
+		sqs: awssqs.NewFromConfig(cfg, func(o *awssqs.Options) { o.BaseEndpoint = aws.String(ts.URL) }),
+		sns: awssns.NewFromConfig(cfg, func(o *awssns.Options) { o.BaseEndpoint = aws.String(ts.URL) }),
+		lam: awslambda.NewFromConfig(cfg, func(o *awslambda.Options) { o.BaseEndpoint = aws.String(ts.URL) }),
+	}, invocations
+}
+
+// snsTopicToQueue creates an SNS topic subscribed (raw delivery) to a fresh SQS
+// queue and returns the topic ARN plus the queue URL, so an SNS publish is
+// observable as a plain message on the queue.
+func snsTopicToQueue(t *testing.T, c ebTargetClients, topicName, queueName string) (topicARN, queueURL string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	queueURL, queueARN := makeQueue(t, c.sqs, queueName)
+
+	topic, err := c.sns.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String(topicName)})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	if _, err := c.sns.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn:              topic.TopicArn,
+		Protocol:              aws.String("sqs"),
+		Endpoint:              aws.String(queueARN),
+		ReturnSubscriptionArn: true,
+		Attributes:            map[string]string{"RawMessageDelivery": "true"},
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	return aws.ToString(topic.TopicArn), queueURL
+}
+
+func createLambda(t *testing.T, lam *awslambda.Client, name string) string {
+	t.Helper()
+
+	out, err := lam.CreateFunction(context.Background(), &awslambda.CreateFunctionInput{
+		FunctionName: aws.String(name),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("stub")},
+	})
+	if err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	return aws.ToString(out.FunctionArn)
+}
+
+// TestSDKEventBridgeDeliversToLambdaAndSNS verifies that a single rule with a
+// Lambda target and an SNS-topic target delivers a matching event to BOTH: the
+// Lambda handler is invoked and SNS fans the event out to its SQS subscription.
+// A non-matching event fires neither.
+func TestSDKEventBridgeDeliversToLambdaAndSNS(t *testing.T) {
+	c, invocations := newEBTargets(t, "eb-fn")
+	ctx := context.Background()
+
+	fnARN := createLambda(t, c.lam, "eb-fn")
+	topicARN, queueURL := snsTopicToQueue(t, c, "eb-topic", "eb-sns-queue")
+
+	if _, err := c.eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventPattern: aws.String(`{"source":["my.app"],"detail":{"state":["running"]}}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := c.eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule: aws.String("r"),
+		Targets: []ebtypes.Target{
+			{Id: aws.String("lambda"), Arn: aws.String(fnARN)},
+			{Id: aws.String("sns"), Arn: aws.String(topicARN)},
+		},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	// A non-matching event must fire neither target.
+	if _, err := c.eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("my.app"), DetailType: aws.String("t"), Detail: aws.String(`{"state":"stopped"}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents(stopped): %v", err)
+	}
+
+	if _, count := receiveOne(t, c.sqs, queueURL); count != 0 {
+		t.Fatalf("non-matching event delivered %d SNS messages, want 0", count)
+	}
+
+	select {
+	case p := <-invocations:
+		t.Fatalf("non-matching event invoked Lambda: %s", p)
+	default:
+	}
+
+	// A matching event must reach both the Lambda target and the SNS target.
+	if _, err := c.eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("my.app"), DetailType: aws.String("t"), Detail: aws.String(`{"state":"running"}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents(running): %v", err)
+	}
+
+	select {
+	case <-invocations:
+	case <-time.After(2 * time.Second):
+		t.Fatal("matching event did not invoke the Lambda target")
+	}
+
+	if _, count := receiveOne(t, c.sqs, queueURL); count != 1 {
+		t.Fatalf("SNS target fan-out delivered %d messages, want 1", count)
+	}
+}


### PR DESCRIPTION
## What

EventBridge `PutTargets` accepts Lambda, SNS, and Step Functions target ARNs (and every non-SQS type), but `PutEvents` only ever delivered to SQS targets — the rule looked fully wired, `FailedEntryCount` was 0, yet Lambda/SNS/SFN targets never fired.

Root cause: `providers/aws/eventbridge/eventbridge.go` `deliverToTargets` hard-coded a single SQS-only branch and skipped every other ARN.

## Changes

- `deliverToTargets` now dispatches by the target ARN's service (`:sqs:`, `:lambda:`, `:sns:`, `:states:`):
  - **SQS** — deliver to the queue (existing behavior)
  - **Lambda** — invoke the function ASYNC via the shared `InvokeExternal` choke point, so the recursion guard bounds re-entrant event loops
  - **SNS** — publish to the topic (fans out to its subscriptions)
  - **Step Functions** — start a state-machine execution
- Delivery runs on a decoupled background context that carries forward the re-entrant delivery depth (mirrors the S3 notification path).
- `providers/aws/sfn/executions.go`: added `StartExternal`, the SFN counterpart to the SQS/SNS/Lambda external-delivery choke points (unknown state machine is a no-op).
- `providers/aws/aws.go`: wired `SetLambdaInvoker(p.Lambda)`, `SetSNSPublisher(p.SNS)`, `SetStepFunctionsStarter(p.SFN)` alongside the existing `SetSQSDeliverer`. EventBridge defines local interfaces; aws.go passes the concrete mocks (no import cycle). Nothing forced on Azure/GCP.
- The correct EventBridge event envelope (including Input/InputPath/InputTransformer shaping) is delivered to each target type — the existing SQS body-builder is reused for all.

## Why

Matches real EventBridge: Lambda function (ASYNC), Step Functions state machine (ASYNC), Amazon SNS topic, and Amazon SQS queue are all first-class event-bus targets. A matching event asynchronously invokes/starts them.

## Test

`server/aws/eventbridge/target_dispatch_sdk_test.go` — real aws-sdk-go-v2 clients against a live httptest wire server: a rule with a Lambda target AND an SNS-topic target (SNS subscribed to an SQS queue). A matching `PutEvents` invokes the Lambda handler AND fans out via SNS to the SQS queue; a non-matching event fires neither.