### PR TITLE
fix(sns): MessageBody filter policy matches array-of-objects (S3->SNS->SQS)

### DIFF
--- a/internal/eventmatch/eventmatch.go
+++ b/internal/eventmatch/eventmatch.go
@@ -53,9 +53,29 @@ func matchPatternKey(key string, pv any, event map[string]any) bool {
 	case []any:
 		return MatchLeaf(p, ev, present)
 	case map[string]any:
-		child, ok := ev.(map[string]any)
+		return matchNestedObject(p, ev)
+	default:
+		return false
+	}
+}
 
-		return ok && MatchEvent(p, child)
+// matchNestedObject applies a nested-object pattern to an event value. It matches
+// an object directly, and matches a JSON array if the pattern matches any element
+// — mirroring MatchLeaf's array handling. This makes a nested filter policy like
+// the documented S3->SNS body filter {"Records":{"s3":{"object":{"key":[...]}}}}
+// match an S3 event whose top-level "Records" is an array of objects.
+func matchNestedObject(pattern map[string]any, ev any) bool {
+	switch child := ev.(type) {
+	case map[string]any:
+		return MatchEvent(pattern, child)
+	case []any:
+		for _, el := range child {
+			if matchNestedObject(pattern, el) {
+				return true
+			}
+		}
+
+		return false
 	default:
 		return false
 	}

--- a/internal/eventmatch/eventmatch_test.go
+++ b/internal/eventmatch/eventmatch_test.go
@@ -188,6 +188,45 @@ func TestMatchAnythingButNestedLists(t *testing.T) {
 	}
 }
 
+// TestMatchEventNestedObjectArray asserts AWS's documented S3->SNS->SQS body
+// filter: a nested-object pattern applies to each element of a JSON array at that
+// key, matching when any element satisfies the nested pattern. The message body's
+// top-level "Records" is an array of objects, as S3 event notifications produce.
+func TestMatchEventNestedObjectArray(t *testing.T) {
+	pattern := mustPattern(t, `{"Records":{"s3":{"object":{"key":[{"prefix":"obj"}]}}}}`)
+
+	event := func(key string) map[string]any {
+		return map[string]any{
+			"Records": []any{
+				map[string]any{
+					"s3": map[string]any{
+						"object": map[string]any{"key": key},
+					},
+				},
+			},
+		}
+	}
+
+	if !eventmatch.MatchEvent(pattern, event("obj1.txt")) {
+		t.Fatal("expected S3 event with matching key prefix to match")
+	}
+
+	if eventmatch.MatchEvent(pattern, event("other.txt")) {
+		t.Fatal("expected S3 event with non-matching key prefix not to match")
+	}
+
+	// An array where a later element matches must still match (any-element).
+	multi := map[string]any{
+		"Records": []any{
+			map[string]any{"s3": map[string]any{"object": map[string]any{"key": "nope.txt"}}},
+			map[string]any{"s3": map[string]any{"object": map[string]any{"key": "obj9.txt"}}},
+		},
+	}
+	if !eventmatch.MatchEvent(pattern, multi) {
+		t.Fatal("expected match when any array element satisfies the nested pattern")
+	}
+}
+
 func TestMatchEventArrayValueIntersection(t *testing.T) {
 	pattern := mustPattern(t, `{"resources":["arn:2"]}`)
 	event := map[string]any{"resources": []any{"arn:1", "arn:2"}}

--- a/providers/aws/sns/filter_policy_test.go
+++ b/providers/aws/sns/filter_policy_test.go
@@ -100,6 +100,35 @@ func TestSNSFilterPolicyOrOperator(t *testing.T) {
 	}
 }
 
+// TestSNSFilterPolicyMessageBodyRecordsArray asserts AWS's documented
+// S3->SNS->SQS body-filtering pattern: a MessageBody-scope policy whose nested
+// key ("Records") is an array of objects matches when any element satisfies the
+// nested pattern. See sns-message-filtering / S3 event notification shape.
+func TestSNSFilterPolicyMessageBodyRecordsArray(t *testing.T) {
+	attrs := map[string]string{
+		"FilterPolicyScope": "MessageBody",
+		"FilterPolicy":      `{"Records":{"s3":{"object":{"key":[{"prefix":"obj"}]}}}}`,
+	}
+
+	body := func(key string) string {
+		b, _ := json.Marshal(map[string]any{
+			"Records": []any{
+				map[string]any{"s3": map[string]any{"object": map[string]any{"key": key}}},
+			},
+		})
+
+		return string(b)
+	}
+
+	if got := snsToSQS(t, attrs, body("obj1.txt"), nil); len(got) != 1 {
+		t.Fatalf("matching S3 key prefix: delivered %d, want 1", len(got))
+	}
+
+	if got := snsToSQS(t, attrs, body("other.txt"), nil); len(got) != 0 {
+		t.Fatalf("non-matching S3 key prefix: delivered %d, want 0", len(got))
+	}
+}
+
 func TestSNSRawMessageDelivery(t *testing.T) {
 	attrs := map[string]string{"RawMessageDelivery": "true"}
 


### PR DESCRIPTION
## What

SNS `MessageBody` filter policies now match when a nested-object pattern key maps to a JSON **array of objects** in the message body. The matcher applies the nested pattern to each array element and matches if any element satisfies it.

## Why

AWS's documented S3->SNS->SQS body-filtering pattern uses a filter policy shaped like:

```json
{"Records":{"s3":{"object":{"key":[{"prefix":"uploads/"}]}}}}
```

An S3 event notification body's top-level `Records` is a JSON **array**, not an object. `internal/eventmatch` descended into nested `map[string]any` objects but not into array elements, so this policy never matched a real S3 event even when the object key satisfied the prefix — 0 messages delivered where 1 was expected. This broke AWS's own documented event pattern.

## Fix

In `matchPatternKey`, when the pattern value is a nested object but the message value at that key is a JSON array, recurse the nested pattern into each element and succeed if **any** element matches — mirroring `MatchLeaf`'s existing array precedent. Object-to-object and leaf matching are unchanged; both MessageAttributes- and MessageBody-scope policies behave as before. Pure matcher fix, no wire/provider layer change.

## Tests

- `internal/eventmatch`: unit test for the S3-event body filter against a `Records` array (matches on prefix hit, any-element match, no match on prefix miss).
- `providers/aws/sns`: end-to-end SNS->SQS test publishing an S3-event-shaped body through a MessageBody-scope subscription (delivered on match, gated on miss).