### PR TITLE
fix(loadbalancer): route Azure LB sub-resource requests to per-child CRUD

### DIFF
--- a/docs/coverage/aws/elb.md
+++ b/docs/coverage/aws/elb.md
@@ -38,9 +38,13 @@ AzureLoadBalancers is an OPTIONAL, type-asserted capability. The Azure
 | Operation | Description |
 | --- | --- |
 | `CreateOrUpdateAzureLoadBalancer` |  |
+| `DeleteAzureLBBackendPool` | DeleteAzureLBBackendPool removes a single backend pool by name, leaving |
+| `DeleteAzureLBNatRule` | DeleteAzureLBNatRule removes a single inbound NAT rule by name, leaving |
 | `DeleteAzureLoadBalancer` |  |
 | `GetAzureLoadBalancer` |  |
 | `ListAzureLoadBalancers` |  |
+| `UpsertAzureLBBackendPool` | UpsertAzureLBBackendPool adds poolName to the load balancer's backend |
+| `UpsertAzureLBNatRule` | UpsertAzureLBNatRule creates or replaces a single inbound NAT rule by |
 
 ### LBAttributeUpdater
 

--- a/docs/coverage/azure/lb.md
+++ b/docs/coverage/azure/lb.md
@@ -38,9 +38,13 @@ AzureLoadBalancers is an OPTIONAL, type-asserted capability. The Azure
 | Operation | Description |
 | --- | --- |
 | `CreateOrUpdateAzureLoadBalancer` |  |
+| `DeleteAzureLBBackendPool` | DeleteAzureLBBackendPool removes a single backend pool by name, leaving |
+| `DeleteAzureLBNatRule` | DeleteAzureLBNatRule removes a single inbound NAT rule by name, leaving |
 | `DeleteAzureLoadBalancer` |  |
 | `GetAzureLoadBalancer` |  |
 | `ListAzureLoadBalancers` |  |
+| `UpsertAzureLBBackendPool` | UpsertAzureLBBackendPool adds poolName to the load balancer's backend |
+| `UpsertAzureLBNatRule` | UpsertAzureLBNatRule creates or replaces a single inbound NAT rule by |
 
 ### LBAttributeUpdater
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -5667,6 +5667,14 @@
             "name": "CreateOrUpdateAzureLoadBalancer"
           },
           {
+            "name": "DeleteAzureLBBackendPool",
+            "doc": "DeleteAzureLBBackendPool removes a single backend pool by name, leaving"
+          },
+          {
+            "name": "DeleteAzureLBNatRule",
+            "doc": "DeleteAzureLBNatRule removes a single inbound NAT rule by name, leaving"
+          },
+          {
             "name": "DeleteAzureLoadBalancer"
           },
           {
@@ -5674,6 +5682,14 @@
           },
           {
             "name": "ListAzureLoadBalancers"
+          },
+          {
+            "name": "UpsertAzureLBBackendPool",
+            "doc": "UpsertAzureLBBackendPool adds poolName to the load balancer's backend"
+          },
+          {
+            "name": "UpsertAzureLBNatRule",
+            "doc": "UpsertAzureLBNatRule creates or replaces a single inbound NAT rule by"
           }
         ]
       },

--- a/docs/coverage/gcp/lb.md
+++ b/docs/coverage/gcp/lb.md
@@ -38,9 +38,13 @@ AzureLoadBalancers is an OPTIONAL, type-asserted capability. The Azure
 | Operation | Description |
 | --- | --- |
 | `CreateOrUpdateAzureLoadBalancer` |  |
+| `DeleteAzureLBBackendPool` | DeleteAzureLBBackendPool removes a single backend pool by name, leaving |
+| `DeleteAzureLBNatRule` | DeleteAzureLBNatRule removes a single inbound NAT rule by name, leaving |
 | `DeleteAzureLoadBalancer` |  |
 | `GetAzureLoadBalancer` |  |
 | `ListAzureLoadBalancers` |  |
+| `UpsertAzureLBBackendPool` | UpsertAzureLBBackendPool adds poolName to the load balancer's backend |
+| `UpsertAzureLBNatRule` | UpsertAzureLBNatRule creates or replaces a single inbound NAT rule by |
 
 ### LBAttributeUpdater
 

--- a/providers/azure/loadbalancer/azure_load_balancer.go
+++ b/providers/azure/loadbalancer/azure_load_balancer.go
@@ -110,19 +110,22 @@ func (m *Mock) UpsertAzureLBBackendPool(_ context.Context, rg, name, poolName st
 		return nil, cerrors.New(cerrors.InvalidArgument, "backend address pool name is required")
 	}
 
-	key := azureLBKey(rg, name)
+	var updated driver.AzureLoadBalancer
 
-	lb, ok := m.azureLBs.Get(key)
+	ok := m.azureLBs.Update(azureLBKey(rg, name), func(lb driver.AzureLoadBalancer) driver.AzureLoadBalancer {
+		if !containsString(lb.BackendPools, poolName) {
+			lb.BackendPools = append(append([]string(nil), lb.BackendPools...), poolName)
+		}
+
+		updated = lb
+
+		return lb
+	})
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "load balancer %q not found", name)
 	}
 
-	if !containsString(lb.BackendPools, poolName) {
-		lb.BackendPools = append(append([]string(nil), lb.BackendPools...), poolName)
-		m.azureLBs.Set(key, lb)
-	}
-
-	out := cloneAzureLB(lb)
+	out := cloneAzureLB(updated)
 
 	return &out, nil
 }
@@ -130,20 +133,27 @@ func (m *Mock) UpsertAzureLBBackendPool(_ context.Context, rg, name, poolName st
 // DeleteAzureLBBackendPool removes a single backend pool by name, leaving
 // every other child untouched.
 func (m *Mock) DeleteAzureLBBackendPool(_ context.Context, rg, name, poolName string) error {
-	key := azureLBKey(rg, name)
+	poolMissing := false
 
-	lb, ok := m.azureLBs.Get(key)
+	ok := m.azureLBs.Update(azureLBKey(rg, name), func(lb driver.AzureLoadBalancer) driver.AzureLoadBalancer {
+		idx := indexOfString(lb.BackendPools, poolName)
+		if idx == -1 {
+			poolMissing = true
+
+			return lb
+		}
+
+		lb.BackendPools = removeStringAt(lb.BackendPools, idx)
+
+		return lb
+	})
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "load balancer %q not found", name)
 	}
 
-	idx := indexOfString(lb.BackendPools, poolName)
-	if idx == -1 {
+	if poolMissing {
 		return cerrors.Newf(cerrors.NotFound, "backend address pool %q not found", poolName)
 	}
-
-	lb.BackendPools = removeStringAt(lb.BackendPools, idx)
-	m.azureLBs.Set(key, lb)
 
 	return nil
 }
@@ -159,42 +169,53 @@ func (m *Mock) UpsertAzureLBNatRule(
 		return nil, cerrors.New(cerrors.InvalidArgument, "inbound NAT rule name is required")
 	}
 
-	key := azureLBKey(rg, name)
+	rule.Name = natRuleName
 
-	lb, ok := m.azureLBs.Get(key)
+	var (
+		updated driver.AzureLoadBalancer
+		valErr  error
+	)
+
+	ok := m.azureLBs.Update(azureLBKey(rg, name), func(lb driver.AzureLoadBalancer) driver.AzureLoadBalancer {
+		if rule.FrontendName != "" && !hasFrontend(lb.Frontends, rule.FrontendName) {
+			valErr = cerrors.Newf(cerrors.InvalidArgument,
+				"inbound NAT rule %q references frontend IP configuration %q that does not exist",
+				natRuleName, rule.FrontendName)
+
+			return lb
+		}
+
+		rules := append([]driver.AzureLBNatRule(nil), lb.NatRules...)
+
+		replaced := false
+
+		for i := range rules {
+			if rules[i].Name == natRuleName {
+				rules[i] = rule
+				replaced = true
+
+				break
+			}
+		}
+
+		if !replaced {
+			rules = append(rules, rule)
+		}
+
+		lb.NatRules = rules
+		updated = lb
+
+		return lb
+	})
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "load balancer %q not found", name)
 	}
 
-	if rule.FrontendName != "" && !hasFrontend(lb.Frontends, rule.FrontendName) {
-		return nil, cerrors.Newf(cerrors.InvalidArgument,
-			"inbound NAT rule %q references frontend IP configuration %q that does not exist",
-			natRuleName, rule.FrontendName)
+	if valErr != nil {
+		return nil, valErr
 	}
 
-	rule.Name = natRuleName
-
-	rules := append([]driver.AzureLBNatRule(nil), lb.NatRules...)
-
-	replaced := false
-
-	for i := range rules {
-		if rules[i].Name == natRuleName {
-			rules[i] = rule
-			replaced = true
-
-			break
-		}
-	}
-
-	if !replaced {
-		rules = append(rules, rule)
-	}
-
-	lb.NatRules = rules
-	m.azureLBs.Set(key, lb)
-
-	out := cloneAzureLB(lb)
+	out := cloneAzureLB(updated)
 
 	return &out, nil
 }
@@ -202,28 +223,35 @@ func (m *Mock) UpsertAzureLBNatRule(
 // DeleteAzureLBNatRule removes a single inbound NAT rule by name, leaving
 // every other child untouched.
 func (m *Mock) DeleteAzureLBNatRule(_ context.Context, rg, name, natRuleName string) error {
-	key := azureLBKey(rg, name)
+	ruleMissing := false
 
-	lb, ok := m.azureLBs.Get(key)
+	ok := m.azureLBs.Update(azureLBKey(rg, name), func(lb driver.AzureLoadBalancer) driver.AzureLoadBalancer {
+		idx := -1
+
+		for i := range lb.NatRules {
+			if lb.NatRules[i].Name == natRuleName {
+				idx = i
+				break
+			}
+		}
+
+		if idx == -1 {
+			ruleMissing = true
+
+			return lb
+		}
+
+		lb.NatRules = append(append([]driver.AzureLBNatRule(nil), lb.NatRules[:idx]...), lb.NatRules[idx+1:]...)
+
+		return lb
+	})
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "load balancer %q not found", name)
 	}
 
-	idx := -1
-
-	for i := range lb.NatRules {
-		if lb.NatRules[i].Name == natRuleName {
-			idx = i
-			break
-		}
-	}
-
-	if idx == -1 {
+	if ruleMissing {
 		return cerrors.Newf(cerrors.NotFound, "inbound NAT rule %q not found", natRuleName)
 	}
-
-	lb.NatRules = append(append([]driver.AzureLBNatRule(nil), lb.NatRules[:idx]...), lb.NatRules[idx+1:]...)
-	m.azureLBs.Set(key, lb)
 
 	return nil
 }

--- a/providers/azure/loadbalancer/azure_load_balancer.go
+++ b/providers/azure/loadbalancer/azure_load_balancer.go
@@ -89,6 +89,9 @@ func cloneAzureLB(lb driver.AzureLoadBalancer) driver.AzureLoadBalancer {
 	out.BackendPools = append([]string(nil), lb.BackendPools...)
 	out.Rules = append([]driver.AzureLBRule(nil), lb.Rules...)
 	out.Probes = append([]driver.AzureLBProbe(nil), lb.Probes...)
+	out.NatRules = append([]driver.AzureLBNatRule(nil), lb.NatRules...)
+	out.NatPools = append([]driver.AzureLBNatPool(nil), lb.NatPools...)
+	out.OutboundRules = append([]driver.AzureLBOutboundRule(nil), lb.OutboundRules...)
 
 	if len(lb.Tags) > 0 {
 		out.Tags = make(map[string]string, len(lb.Tags))
@@ -96,6 +99,167 @@ func cloneAzureLB(lb driver.AzureLoadBalancer) driver.AzureLoadBalancer {
 			out.Tags[k] = v
 		}
 	}
+
+	return out
+}
+
+// UpsertAzureLBBackendPool adds poolName to the load balancer's backend pools
+// if absent, leaving every other child untouched.
+func (m *Mock) UpsertAzureLBBackendPool(_ context.Context, rg, name, poolName string) (*driver.AzureLoadBalancer, error) {
+	if poolName == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "backend address pool name is required")
+	}
+
+	key := azureLBKey(rg, name)
+
+	lb, ok := m.azureLBs.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "load balancer %q not found", name)
+	}
+
+	if !containsString(lb.BackendPools, poolName) {
+		lb.BackendPools = append(append([]string(nil), lb.BackendPools...), poolName)
+		m.azureLBs.Set(key, lb)
+	}
+
+	out := cloneAzureLB(lb)
+
+	return &out, nil
+}
+
+// DeleteAzureLBBackendPool removes a single backend pool by name, leaving
+// every other child untouched.
+func (m *Mock) DeleteAzureLBBackendPool(_ context.Context, rg, name, poolName string) error {
+	key := azureLBKey(rg, name)
+
+	lb, ok := m.azureLBs.Get(key)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "load balancer %q not found", name)
+	}
+
+	idx := indexOfString(lb.BackendPools, poolName)
+	if idx == -1 {
+		return cerrors.Newf(cerrors.NotFound, "backend address pool %q not found", poolName)
+	}
+
+	lb.BackendPools = removeStringAt(lb.BackendPools, idx)
+	m.azureLBs.Set(key, lb)
+
+	return nil
+}
+
+// UpsertAzureLBNatRule creates or replaces a single inbound NAT rule by name,
+// leaving every other child untouched.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) UpsertAzureLBNatRule(
+	_ context.Context, rg, name, natRuleName string, rule driver.AzureLBNatRule,
+) (*driver.AzureLoadBalancer, error) {
+	if natRuleName == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "inbound NAT rule name is required")
+	}
+
+	key := azureLBKey(rg, name)
+
+	lb, ok := m.azureLBs.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "load balancer %q not found", name)
+	}
+
+	if rule.FrontendName != "" && !hasFrontend(lb.Frontends, rule.FrontendName) {
+		return nil, cerrors.Newf(cerrors.InvalidArgument,
+			"inbound NAT rule %q references frontend IP configuration %q that does not exist",
+			natRuleName, rule.FrontendName)
+	}
+
+	rule.Name = natRuleName
+
+	rules := append([]driver.AzureLBNatRule(nil), lb.NatRules...)
+
+	replaced := false
+
+	for i := range rules {
+		if rules[i].Name == natRuleName {
+			rules[i] = rule
+			replaced = true
+
+			break
+		}
+	}
+
+	if !replaced {
+		rules = append(rules, rule)
+	}
+
+	lb.NatRules = rules
+	m.azureLBs.Set(key, lb)
+
+	out := cloneAzureLB(lb)
+
+	return &out, nil
+}
+
+// DeleteAzureLBNatRule removes a single inbound NAT rule by name, leaving
+// every other child untouched.
+func (m *Mock) DeleteAzureLBNatRule(_ context.Context, rg, name, natRuleName string) error {
+	key := azureLBKey(rg, name)
+
+	lb, ok := m.azureLBs.Get(key)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "load balancer %q not found", name)
+	}
+
+	idx := -1
+
+	for i := range lb.NatRules {
+		if lb.NatRules[i].Name == natRuleName {
+			idx = i
+			break
+		}
+	}
+
+	if idx == -1 {
+		return cerrors.Newf(cerrors.NotFound, "inbound NAT rule %q not found", natRuleName)
+	}
+
+	lb.NatRules = append(append([]driver.AzureLBNatRule(nil), lb.NatRules[:idx]...), lb.NatRules[idx+1:]...)
+	m.azureLBs.Set(key, lb)
+
+	return nil
+}
+
+// hasFrontend reports whether name matches a frontend IP configuration in in.
+func hasFrontend(in []driver.AzureLBFrontend, name string) bool {
+	for i := range in {
+		if in[i].Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// containsString reports whether s is present in in.
+func containsString(in []string, s string) bool {
+	return indexOfString(in, s) != -1
+}
+
+// indexOfString returns the index of s in in, or -1 if absent.
+func indexOfString(in []string, s string) int {
+	for i, v := range in {
+		if v == s {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// removeStringAt returns a copy of in with the element at idx removed.
+func removeStringAt(in []string, idx int) []string {
+	out := make([]string, 0, len(in)-1)
+	out = append(out, in[:idx]...)
+	out = append(out, in[idx+1:]...)
 
 	return out
 }

--- a/providers/azure/loadbalancer/lb_test.go
+++ b/providers/azure/loadbalancer/lb_test.go
@@ -2,6 +2,8 @@ package loadbalancer
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -580,4 +582,83 @@ func TestDeleteLBCascadesListeners(t *testing.T) {
 	listeners, err := m.DescribeListeners(ctx, newLBARN)
 	require.NoError(t, err)
 	assert.Empty(t, listeners)
+}
+
+// TestUpsertAzureLBBackendPoolConcurrent guards the sub-resource CRUD path
+// against lost updates: N goroutines each add a distinct pool to the SAME load
+// balancer. With a non-atomic Get()+Set() read-modify-write all but a handful
+// silently vanish; the store.Update path keeps every one. Run with -race.
+func TestUpsertAzureLBBackendPoolConcurrent(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	const rg, name = "rg1", "lb-concurrent-pools"
+
+	_, err := m.CreateOrUpdateAzureLoadBalancer(ctx, rg, name, driver.AzureLoadBalancer{
+		Location: "eastus", SKUName: "Standard",
+	})
+	require.NoError(t, err)
+
+	const n = 50
+
+	var wg sync.WaitGroup
+
+	wg.Add(n)
+
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			_, upErr := m.UpsertAzureLBBackendPool(ctx, rg, name, fmt.Sprintf("pool-%d", i))
+			assert.NoError(t, upErr)
+		}(i)
+	}
+
+	wg.Wait()
+
+	lb, err := m.GetAzureLoadBalancer(ctx, rg, name)
+	require.NoError(t, err)
+	assert.Len(t, lb.BackendPools, n, "every concurrently-added backend pool must survive")
+}
+
+// TestUpsertAzureLBNatRuleConcurrent is the NAT-rule twin of the backend-pool
+// concurrency guard above.
+func TestUpsertAzureLBNatRuleConcurrent(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	const rg, name, frontend = "rg1", "lb-concurrent-nat", "fe1"
+
+	_, err := m.CreateOrUpdateAzureLoadBalancer(ctx, rg, name, driver.AzureLoadBalancer{
+		Location:  "eastus",
+		SKUName:   "Standard",
+		Frontends: []driver.AzureLBFrontend{{Name: frontend, PrivateIPAddress: "10.0.0.4"}},
+	})
+	require.NoError(t, err)
+
+	const n = 50
+
+	var wg sync.WaitGroup
+
+	wg.Add(n)
+
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			_, upErr := m.UpsertAzureLBNatRule(ctx, rg, name, fmt.Sprintf("nat-%d", i), driver.AzureLBNatRule{
+				Protocol:     "Tcp",
+				FrontendPort: 1000 + i,
+				BackendPort:  22,
+				FrontendName: frontend,
+			})
+			assert.NoError(t, upErr)
+		}(i)
+	}
+
+	wg.Wait()
+
+	lb, err := m.GetAzureLoadBalancer(ctx, rg, name)
+	require.NoError(t, err)
+	assert.Len(t, lb.NatRules, n, "every concurrently-added inbound NAT rule must survive")
 }

--- a/server/azure/loadbalancer/handler.go
+++ b/server/azure/loadbalancer/handler.go
@@ -34,6 +34,24 @@
 //	DELETE .../loadBalancers/{name}            — LoadBalancers.BeginDelete (LRO, sync-200)
 //	GET    .../resourceGroups/{rg}/…/loadBalancers    — LoadBalancers.List (RG scope)
 //	GET    .../subscriptions/{s}/…/loadBalancers      — LoadBalancers.ListAll (sub scope)
+//
+// Sub-resource requests (a URL with a segment past the load balancer name)
+// route through serveSubResource (subresource.go) to true per-child CRUD
+// instead of ever reaching the whole-LB handlers above, matching the real ARM
+// operation surface per child kind:
+//
+//	GET                     .../backendAddressPools[/{name}]      — Get/List
+//	PUT/DELETE              .../backendAddressPools/{name}        — BeginCreateOrUpdate/BeginDelete (LRO, sync-200)
+//	GET                     .../inboundNatRules[/{name}]          — Get/List
+//	PUT/DELETE              .../inboundNatRules/{name}            — BeginCreateOrUpdate/BeginDelete (LRO, sync-200)
+//	GET                     .../probes[/{name}]                   — Get/List only (405 on PUT/DELETE)
+//	GET                     .../loadBalancingRules[/{name}]       — Get/List only (405 on PUT/DELETE)
+//	GET                     .../outboundRules[/{name}]            — Get/List only (405 on PUT/DELETE)
+//	GET                     .../frontendIPConfigurations[/{name}] — Get/List only (405 on PUT/DELETE)
+//
+// inboundNatPools has no standalone ARM operation group at all — it is
+// reflected only as a nested array inside the whole load balancer body, so a
+// request addressing it standalone 404s.
 package loadbalancer
 
 import (
@@ -92,6 +110,18 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		h.listLoadBalancers(w, r, &rp)
 
+		return
+	}
+
+	// A sub-resource segment (backendAddressPools, probes, loadBalancingRules,
+	// inboundNatRules, inboundNatPools, outboundRules, frontendIPConfigurations)
+	// addresses one child of the load balancer, not the load balancer itself —
+	// route it to per-child CRUD before any whole-LB handler ever sees the
+	// request. Falling through here would let a standalone child PUT/GET/DELETE
+	// be misparsed as a whole-LB request scoped to rp.ResourceName, silently
+	// wiping or deleting every other child.
+	if rp.SubResource != "" {
+		h.serveSubResource(w, r, &rp)
 		return
 	}
 

--- a/server/azure/loadbalancer/lb_subresource_test.go
+++ b/server/azure/loadbalancer/lb_subresource_test.go
@@ -1,0 +1,589 @@
+package loadbalancer_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// lbSubClients bundles every load-balancer sub-resource client used below,
+// all pointed at the same in-memory server as the whole-LB client so a test
+// can drive both against one shared driver instance. srv carries the raw
+// endpoint/HTTPClient for sub-resources (probes, loadBalancingRules) whose
+// real armnetwork client has no PUT/DELETE method to call at all.
+type lbSubClients struct {
+	srv   lbServer
+	lb    *armnetwork.LoadBalancersClient
+	pools *armnetwork.LoadBalancerBackendAddressPoolsClient
+	nat   *armnetwork.InboundNatRulesClient
+	rules *armnetwork.LoadBalancerLoadBalancingRulesClient
+	probe *armnetwork.LoadBalancerProbesClient
+}
+
+func newLBSubClients(t *testing.T) lbSubClients {
+	t.Helper()
+
+	srv := newLBServer(t)
+	opts := srv.Opts
+
+	lb, err := armnetwork.NewLoadBalancersClient(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewLoadBalancersClient: %v", err)
+	}
+
+	pools, err := armnetwork.NewLoadBalancerBackendAddressPoolsClient(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewLoadBalancerBackendAddressPoolsClient: %v", err)
+	}
+
+	nat, err := armnetwork.NewInboundNatRulesClient(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewInboundNatRulesClient: %v", err)
+	}
+
+	rules, err := armnetwork.NewLoadBalancerLoadBalancingRulesClient(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewLoadBalancerLoadBalancingRulesClient: %v", err)
+	}
+
+	probe, err := armnetwork.NewLoadBalancerProbesClient(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewLoadBalancerProbesClient: %v", err)
+	}
+
+	return lbSubClients{srv: srv, lb: lb, pools: pools, nat: nat, rules: rules, probe: probe}
+}
+
+// rawRequest issues method against a load-balancer sub-resource path directly
+// (bypassing the SDK, which has no client call for a standalone
+// PUT/DELETE on a Get/List-only sub-resource such as probes or
+// loadBalancingRules) and returns the response status code.
+func (c lbSubClients) rawRequest(t *testing.T, method, lbName, child, name string) int {
+	t.Helper()
+
+	url := c.srv.Endpoint + "/subscriptions/" + testSub + "/resourceGroups/" + testRG +
+		"/providers/Microsoft.Network/loadBalancers/" + lbName + "/" + child + "/" + name +
+		"?api-version=2023-09-01"
+
+	req, err := http.NewRequestWithContext(context.Background(), method, url, http.NoBody)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext: %v", err)
+	}
+
+	resp, err := c.srv.HTTPClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+
+	return resp.StatusCode
+}
+
+// seedTwoPoolLB creates lbName with two named backend pools, a probe and a
+// frontend so a standalone child PUT/GET/DELETE has siblings whose survival
+// each test can assert on.
+func seedTwoPoolLB(t *testing.T, lb *armnetwork.LoadBalancersClient, lbName string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	poller, err := lb.BeginCreateOrUpdate(ctx, testRG, lbName, armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{
+			FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{{
+				Name: to.Ptr("fe-1"),
+			}},
+			BackendAddressPools: []*armnetwork.BackendAddressPool{
+				{Name: to.Ptr("pool-a")},
+				{Name: to.Ptr("pool-b")},
+			},
+			Probes: []*armnetwork.Probe{{
+				Name: to.Ptr("probe-1"),
+				Properties: &armnetwork.ProbePropertiesFormat{
+					Protocol: to.Ptr(armnetwork.ProbeProtocolTCP),
+					Port:     to.Ptr(int32(80)),
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("seed BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("seed poll: %v", err)
+	}
+}
+
+func respStatus(t *testing.T, err error) int {
+	t.Helper()
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("error %v is not an *azcore.ResponseError", err)
+	}
+
+	return respErr.StatusCode
+}
+
+// BLOCKER: a standalone child DELETE must remove only the addressed child,
+// not cascade-delete the parent load balancer or any sibling.
+func TestSDKLBBackendPoolDeleteIsScopedToChild(t *testing.T) {
+	c := newLBSubClients(t)
+	ctx := context.Background()
+	const lbName = "lb-pool-delete"
+
+	seedTwoPoolLB(t, c.lb, lbName)
+
+	poller, err := c.pools.BeginDelete(ctx, testRG, lbName, "pool-a", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete pool-a: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll delete pool-a: %v", err)
+	}
+
+	// The parent load balancer must still exist.
+	got, err := c.lb.Get(ctx, testRG, lbName, nil)
+	if err != nil {
+		t.Fatalf("Get after child delete: %v, want the parent load balancer to survive", err)
+	}
+
+	if got.Properties == nil || len(got.Properties.BackendAddressPools) != 1 {
+		t.Fatalf("pools after deleting pool-a = %+v, want exactly [pool-b]", got.Properties)
+	}
+
+	if *got.Properties.BackendAddressPools[0].Name != "pool-b" {
+		t.Fatalf("remaining pool = %v, want pool-b", *got.Properties.BackendAddressPools[0].Name)
+	}
+
+	// The sibling probe seeded alongside the pools must also survive.
+	if len(got.Properties.Probes) != 1 || *got.Properties.Probes[0].Name != "probe-1" {
+		t.Fatalf("probes after deleting pool-a = %+v, want probe-1 untouched", got.Properties.Probes)
+	}
+}
+
+// BLOCKER: a standalone child PUT must add/update only the addressed child,
+// not wipe every other child of the parent load balancer.
+func TestSDKLBBackendPoolPutPreservesSiblings(t *testing.T) {
+	c := newLBSubClients(t)
+	ctx := context.Background()
+	const lbName = "lb-pool-put"
+
+	seedTwoPoolLB(t, c.lb, lbName)
+
+	poller, err := c.pools.BeginCreateOrUpdate(ctx, testRG, lbName, "pool-c", armnetwork.BackendAddressPool{}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate pool-c: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("poll create pool-c: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "pool-c" {
+		t.Fatalf("created pool name = %v, want pool-c (not the parent LB's name)", created.Name)
+	}
+
+	got, err := c.lb.Get(ctx, testRG, lbName, nil)
+	if err != nil {
+		t.Fatalf("Get after child put: %v", err)
+	}
+
+	var names []string
+	for _, p := range got.Properties.BackendAddressPools {
+		names = append(names, *p.Name)
+	}
+
+	if len(names) != 3 {
+		t.Fatalf("pools after standalone put = %v, want 3 (pool-a, pool-b, pool-c all present)", names)
+	}
+
+	if len(got.Properties.Probes) != 1 || *got.Properties.Probes[0].Name != "probe-1" {
+		t.Fatalf("probes after standalone pool put = %+v, want probe-1 untouched", got.Properties.Probes)
+	}
+
+	if len(got.Properties.FrontendIPConfigurations) != 1 {
+		t.Fatalf("frontends after standalone pool put = %+v, want fe-1 untouched", got.Properties.FrontendIPConfigurations)
+	}
+}
+
+// HIGH: standalone GET on the Get/List-only sub-resource kinds (probes,
+// loadBalancingRules) must also return the addressed child, not the whole
+// parent LoadBalancer object under a wrong .Name — same routing root cause,
+// exercised on the two kinds with no standalone PUT/DELETE.
+func TestSDKLBProbeAndRuleGetReturnChildNotParent(t *testing.T) {
+	c := newLBSubClients(t)
+	ctx := context.Background()
+	const lbName = "lb-getchild"
+
+	poller, err := c.lb.BeginCreateOrUpdate(ctx, testRG, lbName, armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{
+			BackendAddressPools: []*armnetwork.BackendAddressPool{{Name: to.Ptr("pool-a")}},
+			Probes: []*armnetwork.Probe{{
+				Name: to.Ptr("probe-x"),
+				Properties: &armnetwork.ProbePropertiesFormat{
+					Protocol: to.Ptr(armnetwork.ProbeProtocolTCP),
+					Port:     to.Ptr(int32(80)),
+				},
+			}},
+			LoadBalancingRules: []*armnetwork.LoadBalancingRule{{
+				Name: to.Ptr("rule-x"),
+				Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+					Protocol:           to.Ptr(armnetwork.TransportProtocolTCP),
+					FrontendPort:       to.Ptr(int32(80)),
+					BackendPort:        to.Ptr(int32(80)),
+					BackendAddressPool: &armnetwork.SubResource{ID: to.Ptr(lbChildID2(lbName, "backendAddressPools", "pool-a"))},
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	gotProbe, err := c.probe.Get(ctx, testRG, lbName, "probe-x", nil)
+	if err != nil {
+		t.Fatalf("Get probe-x: %v", err)
+	}
+
+	if gotProbe.Name == nil || *gotProbe.Name != "probe-x" {
+		t.Fatalf("standalone probe Get .Name = %v, want probe-x (not the parent load balancer's name %q)", gotProbe.Name, lbName)
+	}
+
+	gotRule, err := c.rules.Get(ctx, testRG, lbName, "rule-x", nil)
+	if err != nil {
+		t.Fatalf("Get rule-x: %v", err)
+	}
+
+	if gotRule.Name == nil || *gotRule.Name != "rule-x" {
+		t.Fatalf("standalone rule Get .Name = %v, want rule-x (not the parent load balancer's name %q)", gotRule.Name, lbName)
+	}
+}
+
+// HIGH: a standalone child GET must return the addressed child, not the whole
+// parent LoadBalancer object under a wrong .Name.
+func TestSDKLBBackendPoolGetReturnsChildNotParent(t *testing.T) {
+	c := newLBSubClients(t)
+	ctx := context.Background()
+	const lbName = "lb-pool-get"
+
+	seedTwoPoolLB(t, c.lb, lbName)
+
+	got, err := c.pools.Get(ctx, testRG, lbName, "pool-a", nil)
+	if err != nil {
+		t.Fatalf("Get pool-a: %v", err)
+	}
+
+	if got.Name == nil || *got.Name != "pool-a" {
+		t.Fatalf("standalone pool Get .Name = %v, want pool-a (not the parent load balancer's name %q)", got.Name, lbName)
+	}
+}
+
+// Same routing fix, exercised on inboundNatRules (also full standalone CRUD
+// in real ARM).
+func TestSDKLBNatRuleCRUDIsScopedToChild(t *testing.T) {
+	c := newLBSubClients(t)
+	ctx := context.Background()
+	const lbName = "lb-nat"
+
+	seedTwoPoolLB(t, c.lb, lbName)
+
+	putPoller, err := c.nat.BeginCreateOrUpdate(ctx, testRG, lbName, "nat-1", armnetwork.InboundNatRule{
+		Properties: &armnetwork.InboundNatRulePropertiesFormat{
+			Protocol:     to.Ptr(armnetwork.TransportProtocolTCP),
+			FrontendPort: to.Ptr(int32(3389)),
+			BackendPort:  to.Ptr(int32(3389)),
+			FrontendIPConfiguration: &armnetwork.SubResource{
+				ID: to.Ptr(lbChildID2(lbName, "frontendIPConfigurations", "fe-1")),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate nat-1: %v", err)
+	}
+
+	created, err := putPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("poll create nat-1: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "nat-1" {
+		t.Fatalf("created NAT rule name = %v, want nat-1", created.Name)
+	}
+
+	if created.Properties == nil || created.Properties.FrontendPort == nil || *created.Properties.FrontendPort != 3389 {
+		t.Fatalf("created NAT rule properties = %+v, want frontendPort 3389", created.Properties)
+	}
+
+	// The whole-LB body must reflect the standalone-created NAT rule, and
+	// every child seeded before it must still be present.
+	got, err := c.lb.Get(ctx, testRG, lbName, nil)
+	if err != nil {
+		t.Fatalf("Get after NAT rule put: %v", err)
+	}
+
+	if len(got.Properties.InboundNatRules) != 1 || *got.Properties.InboundNatRules[0].Name != "nat-1" {
+		t.Fatalf("NAT rules on parent = %+v, want [nat-1]", got.Properties.InboundNatRules)
+	}
+
+	if len(got.Properties.BackendAddressPools) != 2 {
+		t.Fatalf("backend pools after NAT rule put = %+v, want pool-a and pool-b untouched", got.Properties.BackendAddressPools)
+	}
+
+	// Standalone GET returns the child, not the parent.
+	gotRule, err := c.nat.Get(ctx, testRG, lbName, "nat-1", nil)
+	if err != nil {
+		t.Fatalf("Get nat-1: %v", err)
+	}
+
+	if gotRule.Name == nil || *gotRule.Name != "nat-1" {
+		t.Fatalf("standalone NAT rule Get .Name = %v, want nat-1", gotRule.Name)
+	}
+
+	// Standalone DELETE removes only the NAT rule.
+	delPoller, err := c.nat.BeginDelete(ctx, testRG, lbName, "nat-1", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete nat-1: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll delete nat-1: %v", err)
+	}
+
+	afterDelete, err := c.lb.Get(ctx, testRG, lbName, nil)
+	if err != nil {
+		t.Fatalf("Get after NAT rule delete: %v, want the parent load balancer to survive", err)
+	}
+
+	if len(afterDelete.Properties.InboundNatRules) != 0 {
+		t.Fatalf("NAT rules after delete = %+v, want none", afterDelete.Properties.InboundNatRules)
+	}
+
+	if len(afterDelete.Properties.BackendAddressPools) != 2 {
+		t.Fatalf("backend pools after NAT rule delete = %+v, want pool-a and pool-b untouched", afterDelete.Properties.BackendAddressPools)
+	}
+}
+
+// MEDIUM: a NAT rule referencing a nonexistent frontend IP configuration is
+// rejected with 400, not silently accepted.
+func TestSDKLBNatRuleDanglingFrontendRefRejected(t *testing.T) {
+	c := newLBSubClients(t)
+	ctx := context.Background()
+	const lbName = "lb-nat-badref"
+
+	seedTwoPoolLB(t, c.lb, lbName)
+
+	_, err := c.nat.BeginCreateOrUpdate(ctx, testRG, lbName, "nat-bad", armnetwork.InboundNatRule{
+		Properties: &armnetwork.InboundNatRulePropertiesFormat{
+			Protocol:     to.Ptr(armnetwork.TransportProtocolTCP),
+			FrontendPort: to.Ptr(int32(3389)),
+			BackendPort:  to.Ptr(int32(3389)),
+			FrontendIPConfiguration: &armnetwork.SubResource{
+				ID: to.Ptr(lbChildID2(lbName, "frontendIPConfigurations", "does-not-exist")),
+			},
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("BeginCreateOrUpdate with dangling frontend ref: want error, got nil")
+	}
+
+	if status := respStatus(t, err); status != 400 {
+		t.Fatalf("dangling frontend ref status = %d, want 400", status)
+	}
+}
+
+// probes and loadBalancingRules have no standalone create/delete in real ARM
+// (Get/List only) — a raw PUT/DELETE against those sub-resource paths must
+// not fall through to the whole-LB handlers (which would wipe/delete the
+// parent); it must be rejected outright, and the parent and every sibling
+// must survive the attempt.
+func TestLBProbeStandalonePutDeleteRejected(t *testing.T) {
+	c := newLBSubClients(t)
+	ctx := context.Background()
+	const lbName = "lb-probe-405"
+
+	seedTwoPoolLB(t, c.lb, lbName)
+
+	if status := c.rawRequest(t, http.MethodPut, lbName, "probes", "probe-1"); status != http.StatusMethodNotAllowed {
+		t.Fatalf("standalone PUT probes/probe-1 status = %d, want 405", status)
+	}
+
+	if status := c.rawRequest(t, http.MethodDelete, lbName, "probes", "probe-1"); status != http.StatusMethodNotAllowed {
+		t.Fatalf("standalone DELETE probes/probe-1 status = %d, want 405", status)
+	}
+
+	if status := c.rawRequest(t, http.MethodDelete, lbName, "loadBalancingRules", "no-such-rule"); status != http.StatusMethodNotAllowed {
+		t.Fatalf("standalone DELETE loadBalancingRules/no-such-rule status = %d, want 405", status)
+	}
+
+	// The parent load balancer and every sibling seeded alongside probe-1
+	// must have survived both rejected requests untouched.
+	got, err := c.lb.Get(ctx, testRG, lbName, nil)
+	if err != nil {
+		t.Fatalf("Get parent after rejected standalone probe requests: %v, want the parent to still exist", err)
+	}
+
+	if len(got.Properties.Probes) != 1 || *got.Properties.Probes[0].Name != "probe-1" {
+		t.Fatalf("probes after rejected standalone requests = %+v, want probe-1 untouched", got.Properties.Probes)
+	}
+
+	if len(got.Properties.BackendAddressPools) != 2 {
+		t.Fatalf("backend pools after rejected standalone probe requests = %+v, want pool-a and pool-b untouched",
+			got.Properties.BackendAddressPools)
+	}
+}
+
+// HIGH: loadBalancingRules.disableOutboundSnat must round-trip, not be
+// dropped on Get.
+func TestSDKLBRuleDisableOutboundSnatRoundTrips(t *testing.T) {
+	c := newLBSubClients(t)
+	ctx := context.Background()
+	const lbName = "lb-snat"
+
+	poller, err := c.lb.BeginCreateOrUpdate(ctx, testRG, lbName, armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{
+			BackendAddressPools: []*armnetwork.BackendAddressPool{{Name: to.Ptr("pool-a")}},
+			LoadBalancingRules: []*armnetwork.LoadBalancingRule{{
+				Name: to.Ptr("rule-1"),
+				Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+					Protocol:            to.Ptr(armnetwork.TransportProtocolTCP),
+					FrontendPort:        to.Ptr(int32(80)),
+					BackendPort:         to.Ptr(int32(80)),
+					DisableOutboundSnat: to.Ptr(true),
+					BackendAddressPool:  &armnetwork.SubResource{ID: to.Ptr(lbChildID2(lbName, "backendAddressPools", "pool-a"))},
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	got, err := c.lb.Get(ctx, testRG, lbName, nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if len(got.Properties.LoadBalancingRules) != 1 {
+		t.Fatalf("rules = %d, want 1", len(got.Properties.LoadBalancingRules))
+	}
+
+	rule := got.Properties.LoadBalancingRules[0]
+	if rule.Properties == nil || rule.Properties.DisableOutboundSnat == nil || !*rule.Properties.DisableOutboundSnat {
+		t.Fatalf("disableOutboundSnat = %v, want true (dropped on Get)", rule.Properties)
+	}
+}
+
+// MEDIUM: a loadBalancingRule referencing a nonexistent backendAddressPool in
+// the same whole-LB PUT is rejected with 400.
+func TestSDKLBRuleDanglingPoolRefRejected(t *testing.T) {
+	c := newLBSubClients(t)
+	ctx := context.Background()
+	const lbName = "lb-rule-badref"
+
+	_, err := c.lb.BeginCreateOrUpdate(ctx, testRG, lbName, armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{
+			LoadBalancingRules: []*armnetwork.LoadBalancingRule{{
+				Name: to.Ptr("rule-1"),
+				Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+					Protocol:           to.Ptr(armnetwork.TransportProtocolTCP),
+					FrontendPort:       to.Ptr(int32(80)),
+					BackendPort:        to.Ptr(int32(80)),
+					BackendAddressPool: &armnetwork.SubResource{ID: to.Ptr(lbChildID2(lbName, "backendAddressPools", "no-such-pool"))},
+				},
+			}},
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("BeginCreateOrUpdate with dangling pool ref: want error, got nil")
+	}
+
+	if status := respStatus(t, err); status != 400 {
+		t.Fatalf("dangling pool ref status = %d, want 400", status)
+	}
+}
+
+// MEDIUM: a loadBalancingRule referencing a nonexistent probe in the same
+// whole-LB PUT is rejected with 400.
+func TestSDKLBRuleDanglingProbeRefRejected(t *testing.T) {
+	c := newLBSubClients(t)
+	ctx := context.Background()
+	const lbName = "lb-rule-badprobe"
+
+	_, err := c.lb.BeginCreateOrUpdate(ctx, testRG, lbName, armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{
+			BackendAddressPools: []*armnetwork.BackendAddressPool{{Name: to.Ptr("pool-a")}},
+			LoadBalancingRules: []*armnetwork.LoadBalancingRule{{
+				Name: to.Ptr("rule-1"),
+				Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+					Protocol:           to.Ptr(armnetwork.TransportProtocolTCP),
+					FrontendPort:       to.Ptr(int32(80)),
+					BackendPort:        to.Ptr(int32(80)),
+					BackendAddressPool: &armnetwork.SubResource{ID: to.Ptr(lbChildID2(lbName, "backendAddressPools", "pool-a"))},
+					Probe:              &armnetwork.SubResource{ID: to.Ptr(lbChildID2(lbName, "probes", "no-such-probe"))},
+				},
+			}},
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("BeginCreateOrUpdate with dangling probe ref: want error, got nil")
+	}
+
+	if status := respStatus(t, err); status != 400 {
+		t.Fatalf("dangling probe ref status = %d, want 400", status)
+	}
+}
+
+// LOW: duplicate child names within one whole-LB PUT body are rejected, not
+// silently accepted.
+func TestSDKLBDuplicatePoolNameRejected(t *testing.T) {
+	c := newLBSubClients(t)
+	ctx := context.Background()
+	const lbName = "lb-dup-pool"
+
+	_, err := c.lb.BeginCreateOrUpdate(ctx, testRG, lbName, armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{
+			BackendAddressPools: []*armnetwork.BackendAddressPool{
+				{Name: to.Ptr("dup-pool")},
+				{Name: to.Ptr("dup-pool")},
+			},
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("BeginCreateOrUpdate with duplicate pool names: want error, got nil")
+	}
+
+	if status := respStatus(t, err); status != 400 {
+		t.Fatalf("duplicate pool name status = %d, want 400", status)
+	}
+}
+
+// lbChildID2 builds a child resource id under lbName (distinct helper name
+// from lb_e2e_test.go's lbChildID, which hardcodes "lb-full").
+func lbChildID2(lbName, child, name string) string {
+	return "/subscriptions/" + testSub + "/resourceGroups/" + testRG +
+		"/providers/Microsoft.Network/loadBalancers/" + lbName + "/" + child + "/" + name
+}

--- a/server/azure/loadbalancer/operations.go
+++ b/server/azure/loadbalancer/operations.go
@@ -40,7 +40,13 @@ func (h *Handler) createOrUpdateLoadBalancer(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	stored, err := az.CreateOrUpdateAzureLoadBalancer(r.Context(), rp.ResourceGroup, rp.ResourceName, buildAzureLB(&body))
+	azLB := buildAzureLB(&body)
+	if verr := validateAzureLB(&azLB); verr != nil {
+		azurearm.WriteCErr(w, verr)
+		return
+	}
+
+	stored, err := az.CreateOrUpdateAzureLoadBalancer(r.Context(), rp.ResourceGroup, rp.ResourceName, azLB)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -142,6 +148,9 @@ func buildAzureLB(body *loadBalancerJSON) lbdriver.AzureLoadBalancer {
 	lb.BackendPools = buildPools(body.Properties.BackendAddressPools)
 	lb.Probes = buildProbes(body.Properties.Probes)
 	lb.Rules = buildRules(body.Properties.LoadBalancingRules)
+	lb.NatRules = buildNatRules(body.Properties.InboundNatRules)
+	lb.NatPools = buildNatPools(body.Properties.InboundNatPools)
+	lb.OutboundRules = buildOutboundRules(body.Properties.OutboundRules)
 
 	return lb
 }
@@ -227,6 +236,85 @@ func buildRules(in []loadBalancingRuleJSON) []lbdriver.AzureLBRule {
 			if p.EnableFloatingIP != nil {
 				rule.EnableFloatingIP = *p.EnableFloatingIP
 			}
+
+			if p.DisableOutboundSnat != nil {
+				rule.DisableOutboundSnat = *p.DisableOutboundSnat
+			}
+		}
+
+		out = append(out, rule)
+	}
+
+	return out
+}
+
+func buildNatRules(in []inboundNatRuleJSON) []lbdriver.AzureLBNatRule {
+	out := make([]lbdriver.AzureLBNatRule, 0, len(in))
+
+	for i := range in {
+		rule := lbdriver.AzureLBNatRule{Name: in[i].Name}
+
+		if p := in[i].Properties; p != nil {
+			rule.Protocol = firstNonEmpty(p.Protocol, protocolTCP)
+			rule.FrontendPort = int(p.FrontendPort)
+			rule.BackendPort = int(p.BackendPort)
+
+			if rule.BackendPort == 0 {
+				rule.BackendPort = rule.FrontendPort
+			}
+
+			rule.FrontendName = lastPathSegment(refID(p.FrontendIPConfiguration))
+			rule.IdleTimeoutMin = int(p.IdleTimeoutInMinutes)
+
+			if p.EnableFloatingIP != nil {
+				rule.EnableFloatingIP = *p.EnableFloatingIP
+			}
+		}
+
+		out = append(out, rule)
+	}
+
+	return out
+}
+
+func buildNatPools(in []inboundNatPoolJSON) []lbdriver.AzureLBNatPool {
+	out := make([]lbdriver.AzureLBNatPool, 0, len(in))
+
+	for i := range in {
+		pool := lbdriver.AzureLBNatPool{Name: in[i].Name}
+
+		if p := in[i].Properties; p != nil {
+			pool.Protocol = firstNonEmpty(p.Protocol, protocolTCP)
+			pool.FrontendPortRangeStart = int(p.FrontendPortRangeStart)
+			pool.FrontendPortRangeEnd = int(p.FrontendPortRangeEnd)
+			pool.BackendPort = int(p.BackendPort)
+			pool.FrontendName = lastPathSegment(refID(p.FrontendIPConfiguration))
+		}
+
+		out = append(out, pool)
+	}
+
+	return out
+}
+
+func buildOutboundRules(in []outboundRuleJSON) []lbdriver.AzureLBOutboundRule {
+	out := make([]lbdriver.AzureLBOutboundRule, 0, len(in))
+
+	for i := range in {
+		rule := lbdriver.AzureLBOutboundRule{Name: in[i].Name}
+
+		if p := in[i].Properties; p != nil {
+			rule.Protocol = firstNonEmpty(p.Protocol, protocolTCP)
+			rule.BackendPoolName = lastPathSegment(refID(p.BackendAddressPool))
+			rule.AllocatedOutboundPorts = int(p.AllocatedOutboundPorts)
+			rule.IdleTimeoutMin = int(p.IdleTimeoutInMinutes)
+
+			for j := range p.FrontendIPConfigurations {
+				fe := lastPathSegment(p.FrontendIPConfigurations[j].ID)
+				if fe != "" {
+					rule.FrontendNames = append(rule.FrontendNames, fe)
+				}
+			}
 		}
 
 		out = append(out, rule)
@@ -248,6 +336,9 @@ func toLBJSON(rp *azurearm.ResourcePath, lb *lbdriver.AzureLoadBalancer) loadBal
 		BackendAddressPools:      poolsJSON(lbID, lb.BackendPools),
 		Probes:                   probesJSON(lbID, lb.Probes),
 		LoadBalancingRules:       rulesJSON(lbID, lb.Rules),
+		InboundNatRules:          natRulesJSON(lbID, lb.NatRules),
+		InboundNatPools:          natPoolsJSON(lbID, lb.NatPools),
+		OutboundRules:            outboundRulesJSON(lbID, lb.OutboundRules),
 	}
 
 	return loadBalancerJSON{
@@ -339,6 +430,7 @@ func rulesJSON(lbID string, in []lbdriver.AzureLBRule) []loadBalancingRuleJSON {
 			IdleTimeoutInMinutes: i32(rule.IdleTimeoutMin),
 			LoadDistribution:     rule.LoadDistribution,
 			EnableFloatingIP:     &rule.EnableFloatingIP,
+			DisableOutboundSnat:  &rule.DisableOutboundSnat,
 			ProvisioningState:    provisioningStateSucceeded,
 		}
 
@@ -356,6 +448,89 @@ func rulesJSON(lbID string, in []lbdriver.AzureLBRule) []loadBalancingRuleJSON {
 
 		out = append(out, loadBalancingRuleJSON{
 			ID: id, Name: rule.Name, Type: ruleResourceType, Etag: weakETag(id), Properties: p,
+		})
+	}
+
+	return out
+}
+
+func natRulesJSON(lbID string, in []lbdriver.AzureLBNatRule) []inboundNatRuleJSON {
+	out := make([]inboundNatRuleJSON, 0, len(in))
+
+	for i := range in {
+		rule := in[i]
+		id := lbID + "/inboundNatRules/" + rule.Name
+		p := &inboundNatRuleProps{
+			Protocol:             firstNonEmpty(rule.Protocol, protocolTCP),
+			FrontendPort:         i32(rule.FrontendPort),
+			BackendPort:          i32(rule.BackendPort),
+			IdleTimeoutInMinutes: i32(rule.IdleTimeoutMin),
+			EnableFloatingIP:     &rule.EnableFloatingIP,
+			ProvisioningState:    provisioningStateSucceeded,
+		}
+
+		if rule.FrontendName != "" {
+			p.FrontendIPConfiguration = &subResource{ID: lbID + "/frontendIPConfigurations/" + rule.FrontendName}
+		}
+
+		out = append(out, inboundNatRuleJSON{
+			ID: id, Name: rule.Name, Type: natRuleResourceType, Etag: weakETag(id), Properties: p,
+		})
+	}
+
+	return out
+}
+
+func natPoolsJSON(lbID string, in []lbdriver.AzureLBNatPool) []inboundNatPoolJSON {
+	out := make([]inboundNatPoolJSON, 0, len(in))
+
+	for i := range in {
+		pool := in[i]
+		id := lbID + "/inboundNatPools/" + pool.Name
+		p := &inboundNatPoolProps{
+			Protocol:               firstNonEmpty(pool.Protocol, protocolTCP),
+			FrontendPortRangeStart: i32(pool.FrontendPortRangeStart),
+			FrontendPortRangeEnd:   i32(pool.FrontendPortRangeEnd),
+			BackendPort:            i32(pool.BackendPort),
+			ProvisioningState:      provisioningStateSucceeded,
+		}
+
+		if pool.FrontendName != "" {
+			p.FrontendIPConfiguration = &subResource{ID: lbID + "/frontendIPConfigurations/" + pool.FrontendName}
+		}
+
+		out = append(out, inboundNatPoolJSON{
+			ID: id, Name: pool.Name, Type: natPoolResourceType, Etag: weakETag(id), Properties: p,
+		})
+	}
+
+	return out
+}
+
+func outboundRulesJSON(lbID string, in []lbdriver.AzureLBOutboundRule) []outboundRuleJSON {
+	out := make([]outboundRuleJSON, 0, len(in))
+
+	for i := range in {
+		rule := in[i]
+		id := lbID + "/outboundRules/" + rule.Name
+		p := &outboundRuleProps{
+			Protocol:               firstNonEmpty(rule.Protocol, protocolTCP),
+			AllocatedOutboundPorts: i32(rule.AllocatedOutboundPorts),
+			IdleTimeoutInMinutes:   i32(rule.IdleTimeoutMin),
+			ProvisioningState:      provisioningStateSucceeded,
+		}
+
+		if rule.BackendPoolName != "" {
+			p.BackendAddressPool = &subResource{ID: lbID + "/backendAddressPools/" + rule.BackendPoolName}
+		}
+
+		for _, fe := range rule.FrontendNames {
+			p.FrontendIPConfigurations = append(p.FrontendIPConfigurations,
+				subResource{ID: lbID + "/frontendIPConfigurations/" + fe})
+		}
+
+		out = append(out, outboundRuleJSON{
+			ID: id, Name: rule.Name, Type: outboundRuleResourceType, Etag: weakETag(id), Properties: p,
 		})
 	}
 

--- a/server/azure/loadbalancer/sdk_roundtrip_test.go
+++ b/server/azure/loadbalancer/sdk_roundtrip_test.go
@@ -3,6 +3,7 @@ package loadbalancer_test
 import (
 	"context"
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -29,7 +30,19 @@ func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcor
 	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
 }
 
-func newLBClient(t *testing.T) *armnetwork.LoadBalancersClient {
+// lbServer bundles the emulator's TLS wire server endpoint with the
+// arm.ClientOptions every armnetwork client in a test shares, so a whole-LB
+// client and any sub-resource client (backend pools, NAT rules, probes, ...)
+// address the same in-memory driver instance. Endpoint/HTTPClient let a test
+// issue a raw HTTP request for a method the real armnetwork SDK has no client
+// call for (e.g. a standalone PUT on a Get/List-only sub-resource).
+type lbServer struct {
+	Endpoint   string
+	HTTPClient *http.Client
+	Opts       *arm.ClientOptions
+}
+
+func newLBServer(t *testing.T) lbServer {
 	t.Helper()
 
 	cloudP := cloudemu.NewAzure()
@@ -54,15 +67,31 @@ func newLBClient(t *testing.T) *armnetwork.LoadBalancersClient {
 		},
 	}
 
-	opts := &arm.ClientOptions{
-		ClientOptions: azcore.ClientOptions{
-			Cloud:     myCloud,
-			Transport: ts.Client(),
-			Retry:     policy.RetryOptions{MaxRetries: -1},
+	return lbServer{
+		Endpoint:   ts.URL,
+		HTTPClient: ts.Client(),
+		Opts: &arm.ClientOptions{
+			ClientOptions: azcore.ClientOptions{
+				Cloud:     myCloud,
+				Transport: ts.Client(),
+				Retry:     policy.RetryOptions{MaxRetries: -1},
+			},
 		},
 	}
+}
 
-	client, err := armnetwork.NewLoadBalancersClient(testSub, fakeCred{}, opts)
+// newLBServerOpts is the arm.ClientOptions-only convenience wrapper for tests
+// that don't need raw HTTP access.
+func newLBServerOpts(t *testing.T) *arm.ClientOptions {
+	t.Helper()
+
+	return newLBServer(t).Opts
+}
+
+func newLBClient(t *testing.T) *armnetwork.LoadBalancersClient {
+	t.Helper()
+
+	client, err := armnetwork.NewLoadBalancersClient(testSub, fakeCred{}, newLBServerOpts(t))
 	if err != nil {
 		t.Fatalf("armnetwork.NewLoadBalancersClient: %v", err)
 	}

--- a/server/azure/loadbalancer/subresource.go
+++ b/server/azure/loadbalancer/subresource.go
@@ -1,0 +1,363 @@
+package loadbalancer
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+)
+
+// subResourceKind identifies which nested collection an ARM sub-resource path
+// segment addresses. Real ARM exposes each kind with a different operation
+// surface (see kindOps below); routing must dispatch on the kind before any
+// whole-LB handler ever sees the request, or a standalone child PUT/GET/DELETE
+// gets misparsed as a whole-LB request scoped to the load balancer's own name.
+type subResourceKind int
+
+const (
+	kindUnknown subResourceKind = iota
+	kindFrontendIPConfigurations
+	kindBackendAddressPools
+	kindLoadBalancingRules
+	kindProbes
+	kindInboundNatRules
+	kindOutboundRules
+)
+
+// parseSubResourceKind maps the ARM URL segment to the kind it addresses.
+// inboundNatPools is deliberately absent: real ARM has no standalone
+// inboundNatPools operation group at all (Get/List/CreateOrUpdate/Delete) —
+// it is reflected only as a nested array inside the whole load balancer body.
+func parseSubResourceKind(segment string) subResourceKind {
+	switch segment {
+	case subResourceFrontendIPConfigurations:
+		return kindFrontendIPConfigurations
+	case subResourceBackendAddressPools:
+		return kindBackendAddressPools
+	case subResourceLoadBalancingRules:
+		return kindLoadBalancingRules
+	case subResourceProbes:
+		return kindProbes
+	case subResourceInboundNatRules:
+		return kindInboundNatRules
+	case subResourceOutboundRules:
+		return kindOutboundRules
+	default:
+		return kindUnknown
+	}
+}
+
+// standaloneCRUD reports whether kind has a real standalone
+// CreateOrUpdate/Delete ARM operation group (backendAddressPools and
+// inboundNatRules), as opposed to a kind that is Get/List-only in real ARM
+// (probes, loadBalancingRules, outboundRules, frontendIPConfigurations) and
+// can only be mutated through the whole-LB CreateOrUpdate.
+func standaloneCRUD(kind subResourceKind) bool {
+	return kind == kindBackendAddressPools || kind == kindInboundNatRules
+}
+
+// serveSubResource routes a request addressing one load-balancer sub-resource
+// collection or child. Registered before any whole-LB handler runs.
+func (h *Handler) serveSubResource(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	kind := parseSubResourceKind(rp.SubResource)
+	if kind == kindUnknown {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"unknown load balancer sub-resource "+rp.SubResource)
+
+		return
+	}
+
+	if rp.SubResourceName == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w)
+			return
+		}
+
+		h.listSubResource(w, r, rp, kind)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getSubResource(w, r, rp, kind)
+	case http.MethodPut:
+		h.putSubResource(w, r, rp, kind)
+	case http.MethodDelete:
+		h.deleteSubResource(w, r, rp, kind)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+// listSubResource handles GET .../loadBalancers/{name}/{kind} — every child of
+// kind on the load balancer.
+func (h *Handler) listSubResource(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, kind subResourceKind) {
+	az, ok := h.azureLB()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "load balancer not found")
+		return
+	}
+
+	lb, err := az.GetAzureLoadBalancer(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	lbID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeLBs, rp.ResourceName)
+
+	azurearm.WriteJSON(w, http.StatusOK, subResourceListResult{Value: listChildren(lbID, lb, kind)})
+}
+
+// getSubResource handles GET .../loadBalancers/{name}/{kind}/{childName} — the
+// one addressed child, not the parent load balancer.
+func (h *Handler) getSubResource(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, kind subResourceKind) {
+	az, ok := h.azureLB()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "load balancer not found")
+		return
+	}
+
+	lb, err := az.GetAzureLoadBalancer(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	lbID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeLBs, rp.ResourceName)
+
+	child, found := findChild(lbID, lb, kind, rp.SubResourceName)
+	if !found {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			rp.SubResource+" "+rp.SubResourceName+" not found")
+
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, child)
+}
+
+// putSubResource handles PUT .../loadBalancers/{name}/{kind}/{childName} — the
+// real standalone create/update ARM exposes only for backendAddressPools and
+// inboundNatRules. It mutates only the addressed child, leaving every sibling
+// untouched; every other kind has no standalone PUT in real ARM (400/405
+// there, matching the SDK surface — see standaloneCRUD).
+func (h *Handler) putSubResource(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, kind subResourceKind) {
+	if !standaloneCRUD(kind) {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	az, ok := h.azureLB()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"load balancers are not supported by this driver")
+
+		return
+	}
+
+	lbID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeLBs, rp.ResourceName)
+
+	switch kind {
+	case kindBackendAddressPools:
+		putBackendPool(w, r, rp, az, lbID)
+	case kindInboundNatRules:
+		putNatRule(w, r, rp, az, lbID)
+	case kindUnknown, kindFrontendIPConfigurations, kindLoadBalancingRules, kindProbes, kindOutboundRules:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func putBackendPool(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, az lbdriver.AzureLoadBalancers, lbID string,
+) {
+	var body backendPoolJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	lb, err := az.UpsertAzureLBBackendPool(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	child, found := findChild(lbID, lb, kindBackendAddressPools, rp.SubResourceName)
+	if !found {
+		azurearm.WriteError(w, http.StatusInternalServerError, "InternalError", "backend address pool not found after create")
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, child)
+}
+
+func putNatRule(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, az lbdriver.AzureLoadBalancers, lbID string,
+) {
+	var body inboundNatRuleJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	// The URL name is authoritative, matching ARM's PUT-by-name semantics; a
+	// body name (if the caller sent one) is ignored.
+	rule := buildNatRules([]inboundNatRuleJSON{body})[0]
+	rule.Name = rp.SubResourceName
+
+	lb, err := az.UpsertAzureLBNatRule(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName, rule)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	child, found := findChild(lbID, lb, kindInboundNatRules, rp.SubResourceName)
+	if !found {
+		azurearm.WriteError(w, http.StatusInternalServerError, "InternalError", "inbound NAT rule not found after create")
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, child)
+}
+
+// deleteSubResource handles DELETE .../loadBalancers/{name}/{kind}/{childName}
+// — the real standalone delete ARM exposes only for backendAddressPools and
+// inboundNatRules. It removes only the addressed child, leaving every sibling
+// (and the parent load balancer itself) untouched.
+func (h *Handler) deleteSubResource(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, kind subResourceKind) {
+	if !standaloneCRUD(kind) {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	az, ok := h.azureLB()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "load balancer not found")
+		return
+	}
+
+	var err error
+
+	switch kind {
+	case kindBackendAddressPools:
+		err = az.DeleteAzureLBBackendPool(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	case kindInboundNatRules:
+		err = az.DeleteAzureLBNatRule(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	case kindUnknown, kindFrontendIPConfigurations, kindLoadBalancingRules, kindProbes, kindOutboundRules:
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// listChildren builds the full JSON slice for kind from lb, for the
+// collection-list response envelope.
+func listChildren(lbID string, lb *lbdriver.AzureLoadBalancer, kind subResourceKind) any {
+	switch kind {
+	case kindFrontendIPConfigurations:
+		return frontendsJSON(lbID, lb.Frontends)
+	case kindBackendAddressPools:
+		return poolsJSON(lbID, lb.BackendPools)
+	case kindLoadBalancingRules:
+		return rulesJSON(lbID, lb.Rules)
+	case kindProbes:
+		return probesJSON(lbID, lb.Probes)
+	case kindInboundNatRules:
+		return natRulesJSON(lbID, lb.NatRules)
+	case kindOutboundRules:
+		return outboundRulesJSON(lbID, lb.OutboundRules)
+	case kindUnknown:
+		return []struct{}{}
+	}
+
+	return []struct{}{}
+}
+
+// findChild locates the single named child of kind on lb and returns its JSON
+// representation. found is false when no child of that name exists.
+func findChild(lbID string, lb *lbdriver.AzureLoadBalancer, kind subResourceKind, name string) (any, bool) {
+	switch kind {
+	case kindFrontendIPConfigurations:
+		return findFrontend(lbID, lb.Frontends, name)
+	case kindBackendAddressPools:
+		return findPool(lbID, lb.BackendPools, name)
+	case kindLoadBalancingRules:
+		return findRule(lbID, lb.Rules, name)
+	case kindProbes:
+		return findProbe(lbID, lb.Probes, name)
+	case kindInboundNatRules:
+		return findNatRule(lbID, lb.NatRules, name)
+	case kindOutboundRules:
+		return findOutboundRule(lbID, lb.OutboundRules, name)
+	case kindUnknown:
+		return nil, false
+	}
+
+	return nil, false
+}
+
+func findFrontend(lbID string, in []lbdriver.AzureLBFrontend, name string) (any, bool) {
+	for i := range in {
+		if in[i].Name == name {
+			return frontendsJSON(lbID, []lbdriver.AzureLBFrontend{in[i]})[0], true
+		}
+	}
+
+	return nil, false
+}
+
+func findPool(lbID string, in []string, name string) (any, bool) {
+	for _, p := range in {
+		if p == name {
+			return poolsJSON(lbID, []string{p})[0], true
+		}
+	}
+
+	return nil, false
+}
+
+func findRule(lbID string, in []lbdriver.AzureLBRule, name string) (any, bool) {
+	for i := range in {
+		if in[i].Name == name {
+			return rulesJSON(lbID, []lbdriver.AzureLBRule{in[i]})[0], true
+		}
+	}
+
+	return nil, false
+}
+
+func findProbe(lbID string, in []lbdriver.AzureLBProbe, name string) (any, bool) {
+	for i := range in {
+		if in[i].Name == name {
+			return probesJSON(lbID, []lbdriver.AzureLBProbe{in[i]})[0], true
+		}
+	}
+
+	return nil, false
+}
+
+func findNatRule(lbID string, in []lbdriver.AzureLBNatRule, name string) (any, bool) {
+	for i := range in {
+		if in[i].Name == name {
+			return natRulesJSON(lbID, []lbdriver.AzureLBNatRule{in[i]})[0], true
+		}
+	}
+
+	return nil, false
+}
+
+func findOutboundRule(lbID string, in []lbdriver.AzureLBOutboundRule, name string) (any, bool) {
+	for i := range in {
+		if in[i].Name == name {
+			return outboundRulesJSON(lbID, []lbdriver.AzureLBOutboundRule{in[i]})[0], true
+		}
+	}
+
+	return nil, false
+}

--- a/server/azure/loadbalancer/types.go
+++ b/server/azure/loadbalancer/types.go
@@ -9,11 +9,23 @@ const (
 	providerName = "Microsoft.Network"
 	typeLBs      = "loadBalancers"
 
-	lbResourceType    = "Microsoft.Network/loadBalancers"
-	poolResourceType  = "Microsoft.Network/loadBalancers/backendAddressPools"
-	ruleResourceType  = "Microsoft.Network/loadBalancers/loadBalancingRules"
-	feResourceType    = "Microsoft.Network/loadBalancers/frontendIPConfigurations"
-	probeResourceType = "Microsoft.Network/loadBalancers/probes"
+	lbResourceType           = "Microsoft.Network/loadBalancers"
+	poolResourceType         = "Microsoft.Network/loadBalancers/backendAddressPools"
+	ruleResourceType         = "Microsoft.Network/loadBalancers/loadBalancingRules"
+	feResourceType           = "Microsoft.Network/loadBalancers/frontendIPConfigurations"
+	probeResourceType        = "Microsoft.Network/loadBalancers/probes"
+	natRuleResourceType      = "Microsoft.Network/loadBalancers/inboundNatRules"
+	natPoolResourceType      = "Microsoft.Network/loadBalancers/inboundNatPools"
+	outboundRuleResourceType = "Microsoft.Network/loadBalancers/outboundRules"
+
+	// sub-resource path segments, as they appear in the ARM URL.
+	subResourceFrontendIPConfigurations = "frontendIPConfigurations"
+	subResourceBackendAddressPools      = "backendAddressPools"
+	subResourceLoadBalancingRules       = "loadBalancingRules"
+	subResourceProbes                   = "probes"
+	subResourceInboundNatRules          = "inboundNatRules"
+	subResourceInboundNatPools          = "inboundNatPools"
+	subResourceOutboundRules            = "outboundRules"
 
 	defaultLBLocation = "eastus"
 
@@ -74,6 +86,7 @@ type loadBalancingRuleProps struct {
 	BackendAddressPool      *subResource `json:"backendAddressPool,omitempty"`
 	Probe                   *subResource `json:"probe,omitempty"`
 	EnableFloatingIP        *bool        `json:"enableFloatingIP,omitempty"`
+	DisableOutboundSnat     *bool        `json:"disableOutboundSnat,omitempty"`
 	IdleTimeoutInMinutes    int32        `json:"idleTimeoutInMinutes,omitempty"`
 	LoadDistribution        string       `json:"loadDistribution,omitempty"`
 	ProvisioningState       string       `json:"provisioningState,omitempty"`
@@ -106,6 +119,64 @@ type probeJSON struct {
 	Properties *probeProps `json:"properties,omitempty"`
 }
 
+// --- inbound NAT rules ---
+
+type inboundNatRuleProps struct {
+	Protocol                string       `json:"protocol,omitempty"`
+	FrontendPort            int32        `json:"frontendPort,omitempty"`
+	BackendPort             int32        `json:"backendPort,omitempty"`
+	FrontendIPConfiguration *subResource `json:"frontendIPConfiguration,omitempty"`
+	EnableFloatingIP        *bool        `json:"enableFloatingIP,omitempty"`
+	IdleTimeoutInMinutes    int32        `json:"idleTimeoutInMinutes,omitempty"`
+	ProvisioningState       string       `json:"provisioningState,omitempty"`
+}
+
+type inboundNatRuleJSON struct {
+	ID         string               `json:"id,omitempty"`
+	Name       string               `json:"name,omitempty"`
+	Type       string               `json:"type,omitempty"`
+	Etag       string               `json:"etag,omitempty"`
+	Properties *inboundNatRuleProps `json:"properties,omitempty"`
+}
+
+// --- inbound NAT pools ---
+
+type inboundNatPoolProps struct {
+	Protocol                string       `json:"protocol,omitempty"`
+	FrontendPortRangeStart  int32        `json:"frontendPortRangeStart,omitempty"`
+	FrontendPortRangeEnd    int32        `json:"frontendPortRangeEnd,omitempty"`
+	BackendPort             int32        `json:"backendPort,omitempty"`
+	FrontendIPConfiguration *subResource `json:"frontendIPConfiguration,omitempty"`
+	ProvisioningState       string       `json:"provisioningState,omitempty"`
+}
+
+type inboundNatPoolJSON struct {
+	ID         string               `json:"id,omitempty"`
+	Name       string               `json:"name,omitempty"`
+	Type       string               `json:"type,omitempty"`
+	Etag       string               `json:"etag,omitempty"`
+	Properties *inboundNatPoolProps `json:"properties,omitempty"`
+}
+
+// --- outbound rules ---
+
+type outboundRuleProps struct {
+	Protocol                 string        `json:"protocol,omitempty"`
+	BackendAddressPool       *subResource  `json:"backendAddressPool,omitempty"`
+	FrontendIPConfigurations []subResource `json:"frontendIPConfigurations,omitempty"`
+	AllocatedOutboundPorts   int32         `json:"allocatedOutboundPorts,omitempty"`
+	IdleTimeoutInMinutes     int32         `json:"idleTimeoutInMinutes,omitempty"`
+	ProvisioningState        string        `json:"provisioningState,omitempty"`
+}
+
+type outboundRuleJSON struct {
+	ID         string             `json:"id,omitempty"`
+	Name       string             `json:"name,omitempty"`
+	Type       string             `json:"type,omitempty"`
+	Etag       string             `json:"etag,omitempty"`
+	Properties *outboundRuleProps `json:"properties,omitempty"`
+}
+
 // --- load balancer ---
 
 type loadBalancerProps struct {
@@ -113,6 +184,9 @@ type loadBalancerProps struct {
 	FrontendIPConfigurations []frontendIPJSON        `json:"frontendIPConfigurations,omitempty"`
 	LoadBalancingRules       []loadBalancingRuleJSON `json:"loadBalancingRules,omitempty"`
 	Probes                   []probeJSON             `json:"probes,omitempty"`
+	InboundNatRules          []inboundNatRuleJSON    `json:"inboundNatRules,omitempty"`
+	InboundNatPools          []inboundNatPoolJSON    `json:"inboundNatPools,omitempty"`
+	OutboundRules            []outboundRuleJSON      `json:"outboundRules,omitempty"`
 	ProvisioningState        string                  `json:"provisioningState,omitempty"`
 }
 
@@ -134,4 +208,12 @@ type loadBalancerJSON struct {
 
 type lbListResult struct {
 	Value []loadBalancerJSON `json:"value"`
+}
+
+// subResourceListResult is the ARM list envelope shared by every load
+// balancer sub-resource collection (backendAddressPools, probes,
+// loadBalancingRules, inboundNatRules, inboundNatPools, outboundRules,
+// frontendIPConfigurations).
+type subResourceListResult struct {
+	Value any `json:"value"`
 }

--- a/server/azure/loadbalancer/validate.go
+++ b/server/azure/loadbalancer/validate.go
@@ -1,0 +1,243 @@
+package loadbalancer
+
+import (
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+)
+
+// validateAzureLB checks a whole-LB PUT body for two classes of error real
+// ARM rejects with 400 before ever storing the load balancer:
+//
+//   - duplicate names within one child collection (two backend pools named
+//     "pool-a" in the same PUT), and
+//   - a rule/pool/NAT-rule referencing a frontend, backend pool or probe that
+//     is not present anywhere in the same body.
+//
+// Cross-references are resolved only against siblings in the same PUT body —
+// a full-replace PUT that drops a pool while a rule still points at it is
+// exactly the dangling-reference case this rejects.
+func validateAzureLB(lb *lbdriver.AzureLoadBalancer) error {
+	if err := checkUnique("frontend IP configuration", frontendNames(lb.Frontends)); err != nil {
+		return err
+	}
+
+	if err := checkUnique("backend address pool", lb.BackendPools); err != nil {
+		return err
+	}
+
+	if err := checkUnique("probe", probeNames(lb.Probes)); err != nil {
+		return err
+	}
+
+	if err := checkUnique("load balancing rule", ruleNames(lb.Rules)); err != nil {
+		return err
+	}
+
+	if err := checkUnique("inbound NAT rule", natRuleNames(lb.NatRules)); err != nil {
+		return err
+	}
+
+	if err := checkUnique("inbound NAT pool", natPoolNames(lb.NatPools)); err != nil {
+		return err
+	}
+
+	if err := checkUnique("outbound rule", outboundRuleNames(lb.OutboundRules)); err != nil {
+		return err
+	}
+
+	return validateAzureLBRefs(lb)
+}
+
+// refSets is the set of sibling names a whole-LB PUT body's children may
+// reference, resolved once and reused across every collection.
+type refSets struct {
+	frontends map[string]struct{}
+	pools     map[string]struct{}
+	probes    map[string]struct{}
+}
+
+// validateAzureLBRefs checks that every frontend/backend-pool/probe reference
+// on a rule, NAT rule, NAT pool or outbound rule resolves to a sibling
+// present in the same load balancer.
+func validateAzureLBRefs(lb *lbdriver.AzureLoadBalancer) error {
+	refs := refSets{
+		frontends: toSet(frontendNames(lb.Frontends)),
+		pools:     toSet(lb.BackendPools),
+		probes:    toSet(probeNames(lb.Probes)),
+	}
+
+	if err := validateRuleRefs(lb.Rules, refs); err != nil {
+		return err
+	}
+
+	if err := validateNatRuleRefs(lb.NatRules, refs); err != nil {
+		return err
+	}
+
+	if err := validateNatPoolRefs(lb.NatPools, refs); err != nil {
+		return err
+	}
+
+	return validateOutboundRuleRefs(lb.OutboundRules, refs)
+}
+
+func validateRuleRefs(rules []lbdriver.AzureLBRule, refs refSets) error {
+	for i := range rules {
+		r := &rules[i]
+		if err := requireRef("load balancing rule", r.Name, "frontend IP configuration", r.FrontendName, refs.frontends); err != nil {
+			return err
+		}
+
+		if err := requireRef("load balancing rule", r.Name, "backend address pool", r.BackendPoolName, refs.pools); err != nil {
+			return err
+		}
+
+		if err := requireRef("load balancing rule", r.Name, "probe", r.ProbeName, refs.probes); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateNatRuleRefs(rules []lbdriver.AzureLBNatRule, refs refSets) error {
+	for i := range rules {
+		nr := &rules[i]
+		if err := requireRef("inbound NAT rule", nr.Name, "frontend IP configuration", nr.FrontendName, refs.frontends); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateNatPoolRefs(pools []lbdriver.AzureLBNatPool, refs refSets) error {
+	for i := range pools {
+		np := &pools[i]
+		if err := requireRef("inbound NAT pool", np.Name, "frontend IP configuration", np.FrontendName, refs.frontends); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateOutboundRuleRefs(rules []lbdriver.AzureLBOutboundRule, refs refSets) error {
+	for i := range rules {
+		or := &rules[i]
+		if err := requireRef("outbound rule", or.Name, "backend address pool", or.BackendPoolName, refs.pools); err != nil {
+			return err
+		}
+
+		for _, fe := range or.FrontendNames {
+			if err := requireRef("outbound rule", or.Name, "frontend IP configuration", fe, refs.frontends); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// requireRef returns an InvalidArgument error when ref is set but absent from
+// available. An empty ref means the field was omitted and is not checked.
+func requireRef(childKind, childName, refKind, ref string, available map[string]struct{}) error {
+	if ref == "" {
+		return nil
+	}
+
+	if _, ok := available[ref]; ok {
+		return nil
+	}
+
+	return cerrors.Newf(cerrors.InvalidArgument,
+		"%s %q references %s %q that does not exist on this load balancer", childKind, childName, refKind, ref)
+}
+
+// checkUnique returns a Conflict error if any name in names appears more than
+// once. Empty names are ignored — an unnamed child is rejected by the wire
+// decoder elsewhere, not here.
+func checkUnique(childKind string, names []string) error {
+	seen := make(map[string]struct{}, len(names))
+
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+
+		if _, dup := seen[name]; dup {
+			return cerrors.Newf(cerrors.InvalidArgument, "duplicate %s name %q in request", childKind, name)
+		}
+
+		seen[name] = struct{}{}
+	}
+
+	return nil
+}
+
+// toSet converts names to a lookup set, skipping empty entries.
+func toSet(names []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(names))
+
+	for _, name := range names {
+		if name != "" {
+			out[name] = struct{}{}
+		}
+	}
+
+	return out
+}
+
+func frontendNames(in []lbdriver.AzureLBFrontend) []string {
+	out := make([]string, len(in))
+	for i := range in {
+		out[i] = in[i].Name
+	}
+
+	return out
+}
+
+func probeNames(in []lbdriver.AzureLBProbe) []string {
+	out := make([]string, len(in))
+	for i := range in {
+		out[i] = in[i].Name
+	}
+
+	return out
+}
+
+func ruleNames(in []lbdriver.AzureLBRule) []string {
+	out := make([]string, len(in))
+	for i := range in {
+		out[i] = in[i].Name
+	}
+
+	return out
+}
+
+func natRuleNames(in []lbdriver.AzureLBNatRule) []string {
+	out := make([]string, len(in))
+	for i := range in {
+		out[i] = in[i].Name
+	}
+
+	return out
+}
+
+func natPoolNames(in []lbdriver.AzureLBNatPool) []string {
+	out := make([]string, len(in))
+	for i := range in {
+		out[i] = in[i].Name
+	}
+
+	return out
+}
+
+func outboundRuleNames(in []lbdriver.AzureLBOutboundRule) []string {
+	out := make([]string, len(in))
+	for i := range in {
+		out[i] = in[i].Name
+	}
+
+	return out
+}

--- a/services/loadbalancer/driver/azure_load_balancer.go
+++ b/services/loadbalancer/driver/azure_load_balancer.go
@@ -35,16 +35,58 @@ type AzureLBProbe struct {
 // frontend/backend ports plus references to the frontend, backend pool and
 // probe it binds (stored by child name, resolved to ids on read).
 type AzureLBRule struct {
+	Name                string
+	Protocol            string // "Tcp" or "Udp"
+	FrontendPort        int
+	BackendPort         int
+	FrontendName        string
+	BackendPoolName     string
+	ProbeName           string
+	EnableFloatingIP    bool
+	DisableOutboundSnat bool
+	IdleTimeoutMin      int
+	LoadDistribution    string
+}
+
+// AzureLBNatRule is one inboundNatRule: a load balancer sub-resource that
+// forwards a single frontend port to a single backend port on one instance.
+// Unlike AzureLBRule/AzureLBProbe, InboundNatRules is a real ARM operation
+// group with its own standalone CreateOrUpdate/Delete/Get/List, so it is
+// mutated independently rather than only through the whole-LB PUT.
+type AzureLBNatRule struct {
 	Name             string
 	Protocol         string // "Tcp" or "Udp"
 	FrontendPort     int
 	BackendPort      int
 	FrontendName     string
-	BackendPoolName  string
-	ProbeName        string
 	EnableFloatingIP bool
 	IdleTimeoutMin   int
-	LoadDistribution string
+}
+
+// AzureLBNatPool is one inboundNatPool: a frontend port-range mapping used by
+// VM Scale Set NAT (e.g. one RDP/SSH port per instance). ARM exposes it only
+// nested inside the load balancer's properties; there is no standalone
+// inboundNatPools operation group.
+type AzureLBNatPool struct {
+	Name                   string
+	Protocol               string // "Tcp" or "Udp"
+	FrontendPortRangeStart int
+	FrontendPortRangeEnd   int
+	BackendPort            int
+	FrontendName           string
+}
+
+// AzureLBOutboundRule is one outboundRule: explicit SNAT configuration for a
+// backend pool through one or more frontend IPs. ARM exposes it only nested
+// inside the load balancer's properties; there is no standalone outboundRules
+// operation group.
+type AzureLBOutboundRule struct {
+	Name                   string
+	Protocol               string // "Tcp", "Udp", or "All"
+	BackendPoolName        string
+	FrontendNames          []string
+	AllocatedOutboundPorts int
+	IdleTimeoutMin         int
 }
 
 // AzureLoadBalancer is the natively-stored ARM load balancer.
@@ -58,6 +100,9 @@ type AzureLoadBalancer struct {
 	BackendPools      []string // pool names
 	Rules             []AzureLBRule
 	Probes            []AzureLBProbe
+	NatRules          []AzureLBNatRule
+	NatPools          []AzureLBNatPool
+	OutboundRules     []AzureLBOutboundRule
 	Tags              map[string]string
 	ProvisioningState string
 	ETag              string
@@ -67,9 +112,39 @@ type AzureLoadBalancer struct {
 // provider stores ARM load balancers natively, keyed by (resourceGroup, name).
 // CreateOrUpdate is a full replace: children absent from the payload are
 // removed. Nil resource group on List means subscription-wide.
+//
+// backendAddressPools and inboundNatRules also have real standalone ARM
+// operation groups (BeginCreateOrUpdate / BeginDelete addressing one named
+// child), so the Upsert/Delete methods below let the wire handler mutate a
+// single child in place without touching its siblings — the whole-LB
+// CreateOrUpdate above would wipe every other child, and DeleteAzureLoadBalancer
+// would remove the entire parent. probes, loadBalancingRules,
+// frontendIPConfigurations, inboundNatPools and outboundRules have no
+// standalone create/delete in real ARM (Get/List only), so they are mutated
+// exclusively through CreateOrUpdateAzureLoadBalancer.
 type AzureLoadBalancers interface {
 	CreateOrUpdateAzureLoadBalancer(ctx context.Context, rg, name string, lb AzureLoadBalancer) (*AzureLoadBalancer, error)
 	GetAzureLoadBalancer(ctx context.Context, rg, name string) (*AzureLoadBalancer, error)
 	DeleteAzureLoadBalancer(ctx context.Context, rg, name string) error
 	ListAzureLoadBalancers(ctx context.Context, rg string) ([]AzureLoadBalancer, error)
+
+	// UpsertAzureLBBackendPool adds poolName to the load balancer's backend
+	// pools if absent, leaving every other frontend/pool/rule/probe/NAT rule
+	// untouched. Returns NotFound if the parent load balancer does not exist.
+	UpsertAzureLBBackendPool(ctx context.Context, rg, name, poolName string) (*AzureLoadBalancer, error)
+	// DeleteAzureLBBackendPool removes a single backend pool by name, leaving
+	// every other child untouched. Returns NotFound if the parent load
+	// balancer or the pool itself does not exist.
+	DeleteAzureLBBackendPool(ctx context.Context, rg, name, poolName string) error
+
+	// UpsertAzureLBNatRule creates or replaces a single inbound NAT rule by
+	// name, leaving every other child untouched. Returns InvalidArgument if
+	// the rule references a frontend IP configuration that does not exist on
+	// the load balancer, and NotFound if the parent load balancer does not
+	// exist.
+	UpsertAzureLBNatRule(ctx context.Context, rg, name, natRuleName string, rule AzureLBNatRule) (*AzureLoadBalancer, error)
+	// DeleteAzureLBNatRule removes a single inbound NAT rule by name, leaving
+	// every other child untouched. Returns NotFound if the parent load
+	// balancer or the rule itself does not exist.
+	DeleteAzureLBNatRule(ctx context.Context, rg, name, natRuleName string) error
 }


### PR DESCRIPTION
## What

Azure Load Balancer sub-resource requests (backendAddressPools, probes, loadBalancingRules, inboundNatRules, ...) were routed purely on the load balancer's own name — the sub-resource path segment was never checked, so every standalone child request fell through to the whole-LB handlers.

- **Standalone child DELETE** (e.g. `LoadBalancerBackendAddressPoolsClient.BeginDelete`) deleted the entire parent load balancer.
- **Standalone child PUT** (e.g. `azurerm_lb_backend_address_pool`) decoded the child body as an almost-empty whole-LB body and replaced the parent, silently wiping every other child.
- **Standalone child GET** returned the whole parent `LoadBalancer` object under the wrong `.Name`.

## Fix

- `server/azure/loadbalancer/handler.go` now routes on `rp.SubResource` before any whole-LB handler runs (`subresource.go`).
- `backendAddressPools` and `inboundNatRules` get true standalone CRUD — the only two sub-resource kinds with a real standalone `CreateOrUpdate`/`Delete` operation group in ARM (confirmed against the Microsoft Learn REST reference and the `armnetwork` v1.1.0 SDK). Each mutates only the addressed child via new `Upsert`/`DeleteAzureLB{BackendPool,NatRule}` provider methods, leaving every sibling untouched.
- `probes`, `loadBalancingRules`, `outboundRules`, `frontendIPConfigurations` get standalone `Get`/`List` only (matching real ARM), and now return 405 on a standalone PUT/DELETE instead of falling through and corrupting the parent.
- Added `AzureLBNatRule` / `AzureLBNatPool` / `AzureLBOutboundRule` types (`inboundNatRules`/`inboundNatPools`/`outboundRules` were previously unmodeled) with id/type/etag/provisioningState and cross-refs, wired into the whole-LB body.
- Added `DisableOutboundSnat` to `AzureLBRule` — it was accepted on PUT but dropped on Get.
- Added cross-reference validation: a `loadBalancingRule`/NAT rule/NAT pool/outbound rule referencing a frontend, backend pool or probe absent from the same PUT body now gets a 400 instead of silently succeeding.
- Added per-collection duplicate-name validation on whole-LB PUT.

`services/loadbalancer/driver` changed, so `docs/coverage` was regenerated via `go generate`.

## Test plan

New `server/azure/loadbalancer/lb_subresource_test.go` drives the real `azure-sdk-for-go` `armnetwork` sub-resource clients (`LoadBalancerBackendAddressPoolsClient`, `InboundNatRulesClient`, `LoadBalancerProbesClient`, `LoadBalancerLoadBalancingRulesClient`) against a live TLS wire server, proving:
- standalone pool/NAT-rule DELETE removes only that child, parent and siblings survive
- standalone pool/NAT-rule PUT adds/updates only that child, siblings survive
- standalone GET on every sub-resource kind returns the child, not the parent
- standalone PUT/DELETE on probes/loadBalancingRules is rejected (405), parent untouched
- `disableOutboundSnat` round-trips
- dangling frontend/pool/probe refs are rejected (400)
- duplicate child names in one PUT body are rejected (400)

All fixes were verified to actually catch the regression by temporarily reverting the routing change and confirming the new tests fail against the old behavior, then restoring it.

```
GOMAXPROCS=3 go build ./...
GOMAXPROCS=3 go vet ./...
GOMAXPROCS=3 go test -p=3 ./providers/azure/... ./server/azure/... ./services/... ./compat/... -count=1
GOMAXPROCS=3 go test -p=3 ./... -count=1
golangci-lint run (changed packages): 0 issues
gofmt -l (changed files): empty
```