### PR TITLE
fix(blobstorage): implement Blob Lease, fix ListBlobs/CopyBlob/DeleteBlob/SetTier/GetBlockList, add Container ACL

### DIFF
--- a/docs/coverage/aws/s3.md
+++ b/docs/coverage/aws/s3.md
@@ -53,15 +53,25 @@ AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
 
 | Operation | Description |
 | --- | --- |
+| `AcquireLease` | AcquireLease acquires a lease on a blob (Lease Blob, ?comp=lease, |
 | `AppendBlock` | AppendBlock appends a block to the end of an append blob (Append Block, |
+| `BreakLease` | BreakLease breaks the blob's current lease. breakPeriod is nil when the |
+| `ChangeLease` | ChangeLease changes the blob's lease ID. |
+| `CheckBlobLease` | CheckBlobLease validates a write/delete request's x-ms-lease-id header |
 | `CommitBlockList` | CommitBlockList assembles a block blob (Put Block List, ?comp=blocklist) |
+| `ContainerAccessPolicy` | ContainerAccessPolicy returns a container's public access level and |
 | `ContainerMetadata` | ContainerMetadata returns a container's metadata (Get Container Properties / |
 | `CreateAppendBlob` | CreateAppendBlob creates an empty append blob (Put Blob with |
 | `CreateBlobSnapshot` | CreateBlobSnapshot captures an immutable snapshot (Snapshot Blob, |
+| `DeleteBlobSnapshots` | DeleteBlobSnapshots applies the Azure delete-snapshots directive |
 | `GetBlobSnapshot` | GetBlobSnapshot reads a previously captured snapshot (GET ?snapshot=…). |
+| `GetBlockList` | GetBlockList returns the blob's committed and uncommitted blocks (Get |
+| `ReleaseLease` | ReleaseLease releases the blob's current lease. |
+| `RenewLease` | RenewLease renews the blob's current lease. |
 | `SetBlobMetadata` | SetBlobMetadata replaces only a blob's metadata (Set Blob Metadata, |
 | `SetBlobProperties` | SetBlobProperties replaces only a blob's system properties (Set Blob |
 | `SetBlobTier` | SetBlobTier sets a blob's access tier (Set Blob Tier, ?comp=tier), |
+| `SetContainerAccessPolicy` | SetContainerAccessPolicy sets a container's public access level and |
 | `SetContainerMetadata` | SetContainerMetadata replaces a container's metadata (Set Container |
 | `StageBlock` | StageBlock buffers an uncommitted block (Put Block, ?comp=block) for a blob |
 

--- a/docs/coverage/azure/blobstorage.md
+++ b/docs/coverage/azure/blobstorage.md
@@ -53,15 +53,25 @@ AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
 
 | Operation | Description |
 | --- | --- |
+| `AcquireLease` | AcquireLease acquires a lease on a blob (Lease Blob, ?comp=lease, |
 | `AppendBlock` | AppendBlock appends a block to the end of an append blob (Append Block, |
+| `BreakLease` | BreakLease breaks the blob's current lease. breakPeriod is nil when the |
+| `ChangeLease` | ChangeLease changes the blob's lease ID. |
+| `CheckBlobLease` | CheckBlobLease validates a write/delete request's x-ms-lease-id header |
 | `CommitBlockList` | CommitBlockList assembles a block blob (Put Block List, ?comp=blocklist) |
+| `ContainerAccessPolicy` | ContainerAccessPolicy returns a container's public access level and |
 | `ContainerMetadata` | ContainerMetadata returns a container's metadata (Get Container Properties / |
 | `CreateAppendBlob` | CreateAppendBlob creates an empty append blob (Put Blob with |
 | `CreateBlobSnapshot` | CreateBlobSnapshot captures an immutable snapshot (Snapshot Blob, |
+| `DeleteBlobSnapshots` | DeleteBlobSnapshots applies the Azure delete-snapshots directive |
 | `GetBlobSnapshot` | GetBlobSnapshot reads a previously captured snapshot (GET ?snapshot=…). |
+| `GetBlockList` | GetBlockList returns the blob's committed and uncommitted blocks (Get |
+| `ReleaseLease` | ReleaseLease releases the blob's current lease. |
+| `RenewLease` | RenewLease renews the blob's current lease. |
 | `SetBlobMetadata` | SetBlobMetadata replaces only a blob's metadata (Set Blob Metadata, |
 | `SetBlobProperties` | SetBlobProperties replaces only a blob's system properties (Set Blob |
 | `SetBlobTier` | SetBlobTier sets a blob's access tier (Set Blob Tier, ?comp=tier), |
+| `SetContainerAccessPolicy` | SetContainerAccessPolicy sets a container's public access level and |
 | `SetContainerMetadata` | SetContainerMetadata replaces a container's metadata (Set Container |
 | `StageBlock` | StageBlock buffers an uncommitted block (Put Block, ?comp=block) for a blob |
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -10324,12 +10324,32 @@
         "doc": "AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,",
         "operations": [
           {
+            "name": "AcquireLease",
+            "doc": "AcquireLease acquires a lease on a blob (Lease Blob, ?comp=lease,"
+          },
+          {
             "name": "AppendBlock",
             "doc": "AppendBlock appends a block to the end of an append blob (Append Block,"
           },
           {
+            "name": "BreakLease",
+            "doc": "BreakLease breaks the blob's current lease. breakPeriod is nil when the"
+          },
+          {
+            "name": "ChangeLease",
+            "doc": "ChangeLease changes the blob's lease ID."
+          },
+          {
+            "name": "CheckBlobLease",
+            "doc": "CheckBlobLease validates a write/delete request's x-ms-lease-id header"
+          },
+          {
             "name": "CommitBlockList",
             "doc": "CommitBlockList assembles a block blob (Put Block List, ?comp=blocklist)"
+          },
+          {
+            "name": "ContainerAccessPolicy",
+            "doc": "ContainerAccessPolicy returns a container's public access level and"
           },
           {
             "name": "ContainerMetadata",
@@ -10344,8 +10364,24 @@
             "doc": "CreateBlobSnapshot captures an immutable snapshot (Snapshot Blob,"
           },
           {
+            "name": "DeleteBlobSnapshots",
+            "doc": "DeleteBlobSnapshots applies the Azure delete-snapshots directive"
+          },
+          {
             "name": "GetBlobSnapshot",
             "doc": "GetBlobSnapshot reads a previously captured snapshot (GET ?snapshot=…)."
+          },
+          {
+            "name": "GetBlockList",
+            "doc": "GetBlockList returns the blob's committed and uncommitted blocks (Get"
+          },
+          {
+            "name": "ReleaseLease",
+            "doc": "ReleaseLease releases the blob's current lease."
+          },
+          {
+            "name": "RenewLease",
+            "doc": "RenewLease renews the blob's current lease."
           },
           {
             "name": "SetBlobMetadata",
@@ -10358,6 +10394,10 @@
           {
             "name": "SetBlobTier",
             "doc": "SetBlobTier sets a blob's access tier (Set Blob Tier, ?comp=tier),"
+          },
+          {
+            "name": "SetContainerAccessPolicy",
+            "doc": "SetContainerAccessPolicy sets a container's public access level and"
           },
           {
             "name": "SetContainerMetadata",

--- a/docs/coverage/gcp/gcs.md
+++ b/docs/coverage/gcp/gcs.md
@@ -53,15 +53,25 @@ AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
 
 | Operation | Description |
 | --- | --- |
+| `AcquireLease` | AcquireLease acquires a lease on a blob (Lease Blob, ?comp=lease, |
 | `AppendBlock` | AppendBlock appends a block to the end of an append blob (Append Block, |
+| `BreakLease` | BreakLease breaks the blob's current lease. breakPeriod is nil when the |
+| `ChangeLease` | ChangeLease changes the blob's lease ID. |
+| `CheckBlobLease` | CheckBlobLease validates a write/delete request's x-ms-lease-id header |
 | `CommitBlockList` | CommitBlockList assembles a block blob (Put Block List, ?comp=blocklist) |
+| `ContainerAccessPolicy` | ContainerAccessPolicy returns a container's public access level and |
 | `ContainerMetadata` | ContainerMetadata returns a container's metadata (Get Container Properties / |
 | `CreateAppendBlob` | CreateAppendBlob creates an empty append blob (Put Blob with |
 | `CreateBlobSnapshot` | CreateBlobSnapshot captures an immutable snapshot (Snapshot Blob, |
+| `DeleteBlobSnapshots` | DeleteBlobSnapshots applies the Azure delete-snapshots directive |
 | `GetBlobSnapshot` | GetBlobSnapshot reads a previously captured snapshot (GET ?snapshot=…). |
+| `GetBlockList` | GetBlockList returns the blob's committed and uncommitted blocks (Get |
+| `ReleaseLease` | ReleaseLease releases the blob's current lease. |
+| `RenewLease` | RenewLease renews the blob's current lease. |
 | `SetBlobMetadata` | SetBlobMetadata replaces only a blob's metadata (Set Blob Metadata, |
 | `SetBlobProperties` | SetBlobProperties replaces only a blob's system properties (Set Blob |
 | `SetBlobTier` | SetBlobTier sets a blob's access tier (Set Blob Tier, ?comp=tier), |
+| `SetContainerAccessPolicy` | SetContainerAccessPolicy sets a container's public access level and |
 | `SetContainerMetadata` | SetContainerMetadata replaces a container's metadata (Set Container |
 | `StageBlock` | StageBlock buffers an uncommitted block (Put Block, ?comp=block) for a blob |
 

--- a/providers/azure/blobstorage/blob_extensions.go
+++ b/providers/azure/blobstorage/blob_extensions.go
@@ -5,10 +5,14 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"maps"
+	"net/http"
 	"sort"
+	"strings"
+	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/services/storage/driver"
 	"github.com/stackshy/cloudemu/v2/services/storage/storageengine"
 )
@@ -18,6 +22,23 @@ const (
 	blobTypeAppend = "AppendBlob"
 	snapshotFormat = "2006-01-02T15:04:05."
 	octetStream    = "application/octet-stream"
+
+	accessTierHot     = "Hot"
+	accessTierCool    = "Cool"
+	accessTierCold    = "Cold"
+	accessTierArchive = "Archive"
+
+	// Lease Blob states. See
+	// https://learn.microsoft.com/en-us/rest/api/storageservices/lease-blob.
+	leaseStateAvailable = ""
+	leaseStateLeased    = "leased"
+	leaseStateBreaking  = "breaking"
+	leaseStateBroken    = "broken"
+	leaseStateExpired   = "expired"
+
+	leaseDurationInfinite int32 = -1
+	leaseDurationMinSec   int32 = 15
+	leaseDurationMaxSec   int32 = 60
 )
 
 // Compile-time check that Mock satisfies the optional AzureBlobExtensions
@@ -56,7 +77,7 @@ func (m *Mock) CommitBlockList(
 		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
 	}
 
-	data, err := assembleStagedBlocks(ctr, blob, blockIDs)
+	data, blocks, err := assembleStagedBlocks(ctr, blob, blockIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -69,6 +90,7 @@ func (m *Mock) CommitBlockList(
 		Key: blob, Size: int64(len(data)), ContentType: contentType,
 		LastModified: m.opts.Clock.Now().UTC().Format(blobTimeFormat),
 		Metadata:     maps.Clone(metadata), BlobType: blobTypeBlock,
+		CommittedBlocks: blocks,
 	}
 	obj.ETag = fmt.Sprintf("%x", sha256.Sum256(data))
 
@@ -92,11 +114,12 @@ func (m *Mock) CommitBlockList(
 	return &info, nil
 }
 
-// assembleStagedBlocks concatenates the named staged blocks in order.
-func assembleStagedBlocks(ctr *containerMeta, blob string, blockIDs []string) ([]byte, error) {
+// assembleStagedBlocks concatenates the named staged blocks in order and
+// records each block's id/size for Get Block List.
+func assembleStagedBlocks(ctr *containerMeta, blob string, blockIDs []string) ([]byte, []driver.BlockInfo, error) {
 	stg, ok := ctr.staging.Get(blob)
 	if !ok {
-		return nil, cerrors.Newf(cerrors.InvalidArgument, "no staged blocks for blob %q", blob)
+		return nil, nil, cerrors.Newf(cerrors.InvalidArgument, "no staged blocks for blob %q", blob)
 	}
 
 	stg.mu.Lock()
@@ -104,16 +127,19 @@ func assembleStagedBlocks(ctr *containerMeta, blob string, blockIDs []string) ([
 
 	var data []byte
 
+	blocks := make([]driver.BlockInfo, 0, len(blockIDs))
+
 	for _, id := range blockIDs {
 		block, ok := stg.blocks[id]
 		if !ok {
-			return nil, cerrors.Newf(cerrors.InvalidArgument, "block %q not staged for blob %q", id, blob)
+			return nil, nil, cerrors.Newf(cerrors.InvalidArgument, "block %q not staged for blob %q", id, blob)
 		}
 
 		data = append(data, block...)
+		blocks = append(blocks, driver.BlockInfo{Name: id, Size: int64(len(block))})
 	}
 
-	return data, nil
+	return data, blocks, nil
 }
 
 // SetBlobMetadata replaces only a blob's metadata, preserving its content.
@@ -159,17 +185,45 @@ func (m *Mock) SetBlobProperties(_ context.Context, container, blob string, prop
 }
 
 // SetBlobTier sets a blob's access tier, preserving its content and ETag.
-func (m *Mock) SetBlobTier(_ context.Context, container, blob, tier string) error {
+// Valid tiers for a block blob are Hot/Cool/Cold/Archive; anything else is
+// rejected. Moving a blob out of Archive returns 202 (rehydration pending)
+// rather than 200, matching real Azure's status-code table.
+// https://learn.microsoft.com/en-us/rest/api/storageservices/set-blob-tier
+func (m *Mock) SetBlobTier(_ context.Context, container, blob, tier string) (int, error) {
+	if !validAccessTier(tier) {
+		return 0, cerrors.Newf(cerrors.InvalidArgument,
+			"invalid x-ms-access-tier %q: must be one of Hot, Cool, Cold, Archive", tier)
+	}
+
 	obj, err := m.getBlobObject(container, blob)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	obj.mu.Lock()
-	obj.AccessTier = tier
-	obj.mu.Unlock()
+	defer obj.mu.Unlock()
 
-	return nil
+	status := http.StatusOK
+	if obj.AccessTier == accessTierArchive && tier != accessTierArchive {
+		status = http.StatusAccepted
+	}
+
+	obj.AccessTier = tier
+
+	return status, nil
+}
+
+// validAccessTier reports whether tier is one of the four block-blob access
+// tiers cloudemu supports (Hot/Cool/Cold/Archive). Real Azure also accepts
+// premium page-blob tiers (P4..P60) and the Smart preview tier; cloudemu's
+// in-memory blobs are block blobs only, so those are rejected here.
+func validAccessTier(tier string) bool {
+	switch tier {
+	case accessTierHot, accessTierCool, accessTierCold, accessTierArchive:
+		return true
+	default:
+		return false
+	}
 }
 
 // CreateBlobSnapshot captures an immutable snapshot of a blob. Snapshots are
@@ -346,4 +400,429 @@ func computeBlobETag(obj *blobObject) string {
 	}
 
 	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// GetBlockList returns the blob's committed blocks (from the most recent Put
+// Block List commit) and its currently staged, uncommitted blocks.
+func (m *Mock) GetBlockList(_ context.Context, container, blob string) (committed, uncommitted []driver.BlockInfo, err error) {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return nil, nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+	}
+
+	obj, objOk := ctr.objects.Get(blob)
+	stg, stgOk := ctr.staging.Get(blob)
+
+	if !objOk && !stgOk {
+		return nil, nil, cerrors.Newf(cerrors.NotFound, "blob %q not found in container %q", blob, container)
+	}
+
+	if objOk && obj.BlobType == blobTypeBlock {
+		committed = append(committed, obj.CommittedBlocks...)
+	}
+
+	if stgOk {
+		stg.mu.Lock()
+		for id, data := range stg.blocks {
+			uncommitted = append(uncommitted, driver.BlockInfo{Name: id, Size: int64(len(data))})
+		}
+		stg.mu.Unlock()
+
+		// Real Azure returns the uncommitted list in alphabetical order.
+		sort.Slice(uncommitted, func(i, j int) bool { return uncommitted[i].Name < uncommitted[j].Name })
+	}
+
+	return committed, uncommitted, nil
+}
+
+// effectiveLeaseState computes a blob's current lease state, lazily applying
+// the leased->expired and breaking->broken transitions that real Azure ties
+// to elapsed time rather than to an explicit call. Pure: callers persist any
+// resulting transition themselves when they need to (lease-management calls
+// do; read-only checks don't need to).
+func effectiveLeaseState(obj *blobObject, now time.Time) string {
+	switch obj.leaseState {
+	case leaseStateLeased:
+		if !obj.leaseExpiresAt.IsZero() && !now.Before(obj.leaseExpiresAt) {
+			return leaseStateExpired
+		}
+
+		return leaseStateLeased
+	case leaseStateBreaking:
+		if !obj.leaseBreakAt.IsZero() && !now.Before(obj.leaseBreakAt) {
+			return leaseStateBroken
+		}
+
+		return leaseStateBreaking
+	case leaseStateBroken:
+		return leaseStateBroken
+	default:
+		return leaseStateAvailable
+	}
+}
+
+// resetLease clears a blob's lease state entirely (Available, no lease id).
+func resetLease(obj *blobObject) {
+	obj.leaseState = leaseStateAvailable
+	obj.leaseID = ""
+	obj.leaseDurationSec = 0
+	obj.leaseExpiresAt = time.Time{}
+	obj.leaseBreakAt = time.Time{}
+	obj.leaseModTimeAtAcquire = ""
+}
+
+// grantLease puts a blob into the Leased state under leaseID for
+// durationSeconds, starting from now.
+func grantLease(obj *blobObject, now time.Time, leaseID string, durationSeconds int32) {
+	obj.leaseState = leaseStateLeased
+	obj.leaseID = leaseID
+	obj.leaseDurationSec = durationSeconds
+
+	if durationSeconds == leaseDurationInfinite {
+		obj.leaseExpiresAt = time.Time{}
+	} else {
+		obj.leaseExpiresAt = now.Add(time.Duration(durationSeconds) * time.Second)
+	}
+
+	obj.leaseBreakAt = time.Time{}
+	obj.leaseModTimeAtAcquire = obj.LastModified
+}
+
+// leaseManagementError builds the 409 Conflict cloudemu returns for a
+// lease-management call (acquire/renew/change/release/break) that cannot
+// proceed given the blob's current lease state.
+func leaseManagementError(code, msg string) error {
+	return &driver.BlobOpError{Status: http.StatusConflict, Code: code, Message: msg}
+}
+
+// AcquireLease acquires a lease on a blob. See
+// https://learn.microsoft.com/en-us/rest/api/storageservices/lease-blob for
+// the full acquire-outcome table this follows.
+func (m *Mock) AcquireLease(
+	_ context.Context, container, blob string, durationSeconds int32, proposedLeaseID string,
+) (*driver.BlobLeaseResult, error) {
+	if durationSeconds != leaseDurationInfinite &&
+		(durationSeconds < leaseDurationMinSec || durationSeconds > leaseDurationMaxSec) {
+		return nil, cerrors.Newf(cerrors.InvalidArgument,
+			"x-ms-lease-duration must be -1 or between %d and %d seconds", leaseDurationMinSec, leaseDurationMaxSec)
+	}
+
+	obj, err := m.getBlobObject(container, blob)
+	if err != nil {
+		return nil, err
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	now := m.opts.Clock.Now().UTC()
+	state := effectiveLeaseState(obj, now)
+
+	switch state {
+	case leaseStateBreaking:
+		return nil, leaseManagementError("LeaseAlreadyPresent", "there is already a lease present")
+	case leaseStateLeased:
+		if proposedLeaseID == "" || proposedLeaseID != obj.leaseID {
+			return nil, leaseManagementError("LeaseAlreadyPresent", "there is already a lease present")
+		}
+	}
+
+	leaseID := proposedLeaseID
+	if leaseID == "" {
+		leaseID = idgen.SyntheticGUID(idgen.GenerateID("lease-"))
+	}
+
+	grantLease(obj, now, leaseID, durationSeconds)
+
+	return &driver.BlobLeaseResult{LeaseID: leaseID, ETag: obj.ETag, LastModified: obj.LastModified}, nil
+}
+
+// RenewLease renews the blob's current lease, resetting its duration clock.
+func (m *Mock) RenewLease(_ context.Context, container, blob, leaseID string) (*driver.BlobLeaseResult, error) {
+	obj, err := m.getBlobObject(container, blob)
+	if err != nil {
+		return nil, err
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	now := m.opts.Clock.Now().UTC()
+	state := effectiveLeaseState(obj, now)
+
+	if state == leaseStateAvailable || state == leaseStateBroken || state == leaseStateBreaking {
+		return nil, leaseManagementError("LeaseNotPresentWithLeaseOperation", "there is currently no lease on the blob")
+	}
+
+	if leaseID == "" || leaseID != obj.leaseID {
+		return nil, leaseManagementError("LeaseIdMismatchWithLeaseOperation",
+			"the lease id specified did not match the lease id for the blob")
+	}
+
+	// A lease that has merely expired (not released) can still be renewed with
+	// its old id, but only if the blob hasn't changed since — otherwise someone
+	// else has taken and released the blob in between.
+	if state == leaseStateExpired && obj.leaseModTimeAtAcquire != obj.LastModified {
+		return nil, leaseManagementError("LeaseIdMismatchWithLeaseOperation",
+			"the blob has been modified since the lease was last active")
+	}
+
+	grantLease(obj, now, obj.leaseID, obj.leaseDurationSec)
+
+	return &driver.BlobLeaseResult{LeaseID: obj.leaseID, ETag: obj.ETag, LastModified: obj.LastModified}, nil
+}
+
+// ChangeLease changes the blob's lease id from leaseID to proposedLeaseID.
+func (m *Mock) ChangeLease(
+	_ context.Context, container, blob, leaseID, proposedLeaseID string,
+) (*driver.BlobLeaseResult, error) {
+	if proposedLeaseID == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "x-ms-proposed-lease-id is required for change")
+	}
+
+	obj, err := m.getBlobObject(container, blob)
+	if err != nil {
+		return nil, err
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	now := m.opts.Clock.Now().UTC()
+	state := effectiveLeaseState(obj, now)
+
+	if state != leaseStateLeased || leaseID == "" || leaseID != obj.leaseID {
+		return nil, leaseManagementError("LeaseIdMismatchWithLeaseOperation",
+			"the lease id specified did not match the lease id for the blob")
+	}
+
+	obj.leaseID = proposedLeaseID
+
+	return &driver.BlobLeaseResult{LeaseID: proposedLeaseID, ETag: obj.ETag, LastModified: obj.LastModified}, nil
+}
+
+// ReleaseLease releases the blob's current lease, making it immediately
+// available for a new Acquire.
+func (m *Mock) ReleaseLease(_ context.Context, container, blob, leaseID string) (*driver.BlobLeaseResult, error) {
+	obj, err := m.getBlobObject(container, blob)
+	if err != nil {
+		return nil, err
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	now := m.opts.Clock.Now().UTC()
+	state := effectiveLeaseState(obj, now)
+
+	if state == leaseStateAvailable || leaseID == "" || leaseID != obj.leaseID {
+		return nil, leaseManagementError("LeaseIdMismatchWithLeaseOperation",
+			"the lease id specified did not match the lease id for the blob")
+	}
+
+	etag, lastModified := obj.ETag, obj.LastModified
+	resetLease(obj)
+
+	return &driver.BlobLeaseResult{ETag: etag, LastModified: lastModified}, nil
+}
+
+// BreakLease breaks the blob's current lease. When breakPeriod is nil, a
+// fixed-duration lease breaks after its remaining time and an infinite lease
+// breaks immediately; when set, it caps (but for an already-breaking lease,
+// can only shorten) the wait.
+func (m *Mock) BreakLease(_ context.Context, container, blob string, breakPeriod *int32) (int32, error) {
+	obj, err := m.getBlobObject(container, blob)
+	if err != nil {
+		return 0, err
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	now := m.opts.Clock.Now().UTC()
+	state := effectiveLeaseState(obj, now)
+
+	switch state {
+	case leaseStateAvailable:
+		return 0, leaseManagementError("LeaseNotPresentWithLeaseOperation", "there is currently no lease on the blob")
+	case leaseStateBroken:
+		return 0, nil // idempotent: breaking an already-broken lease succeeds as a no-op.
+	case leaseStateExpired:
+		obj.leaseState = leaseStateBroken
+		obj.leaseBreakAt = time.Time{}
+
+		return 0, nil
+	}
+
+	breakAfter := computeBreakAfter(obj, now, breakPeriod)
+	if state == leaseStateBreaking {
+		if remaining := obj.leaseBreakAt.Sub(now); remaining > 0 && breakAfter > remaining {
+			breakAfter = remaining
+		}
+	}
+
+	if breakAfter <= 0 {
+		obj.leaseState = leaseStateBroken
+		obj.leaseBreakAt = time.Time{}
+
+		return 0, nil
+	}
+
+	obj.leaseState = leaseStateBreaking
+	obj.leaseBreakAt = now.Add(breakAfter)
+
+	return int32(breakAfter.Seconds()), nil
+}
+
+// computeBreakAfter resolves how long from now a Leased/Breaking lease should
+// take to break, applying the break-period cap described in the Lease Blob
+// remarks: a break period only shortens a fixed-duration lease's remaining
+// time, never lengthens it, and an infinite lease with no period breaks
+// immediately.
+func computeBreakAfter(obj *blobObject, now time.Time, breakPeriod *int32) time.Duration {
+	var remaining time.Duration
+	if obj.leaseDurationSec != leaseDurationInfinite && !obj.leaseExpiresAt.IsZero() {
+		if remaining = obj.leaseExpiresAt.Sub(now); remaining < 0 {
+			remaining = 0
+		}
+	}
+
+	if breakPeriod == nil {
+		return remaining // infinite lease: 0 (immediate); fixed lease: its remaining time.
+	}
+
+	candidate := time.Duration(*breakPeriod) * time.Second
+
+	if obj.leaseDurationSec != leaseDurationInfinite && candidate > remaining {
+		return remaining
+	}
+
+	return candidate
+}
+
+// writeLeaseError builds the write-gating error a blob operation that
+// requires a lease id returns. Real Azure always answers 412 here (see the
+// Delete Blob / Put Blob docs), unlike the 409s lease-management calls use.
+// https://learn.microsoft.com/en-us/rest/api/storageservices/delete-blob
+func writeLeaseError(code, msg string) error {
+	return &driver.BlobOpError{Status: http.StatusPreconditionFailed, Code: code, Message: msg}
+}
+
+// CheckBlobLease validates a write/delete request's x-ms-lease-id header
+// against any active lease on the blob.
+func (m *Mock) CheckBlobLease(_ context.Context, container, blob, headerLeaseID string) error {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return nil // let the caller's own existence check surface NotFound.
+	}
+
+	obj, ok := ctr.objects.Get(blob)
+	if !ok {
+		return nil
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	state := effectiveLeaseState(obj, m.opts.Clock.Now().UTC())
+
+	switch state {
+	case leaseStateLeased, leaseStateBreaking:
+		if headerLeaseID == "" {
+			return writeLeaseError("LeaseIdMissing", "there is currently a lease on the blob and no lease id was specified")
+		}
+
+		if headerLeaseID != obj.leaseID {
+			return writeLeaseError("LeaseIdMismatchWithBlobOperation",
+				"the lease id specified did not match the lease id for the blob")
+		}
+
+		return nil
+	default: // Available, Broken, Expired: any lease id supplied here is stale/invalid.
+		if headerLeaseID != "" {
+			return writeLeaseError("LeaseNotPresentWithBlobOperation", "there is currently no lease on the blob")
+		}
+
+		return nil
+	}
+}
+
+// DeleteBlobSnapshots applies the Azure delete-snapshots directive ahead of a
+// Delete Blob. See
+// https://learn.microsoft.com/en-us/rest/api/storageservices/delete-blob.
+func (m *Mock) DeleteBlobSnapshots(_ context.Context, container, blob, mode string) (bool, error) {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return false, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+	}
+
+	prefix := snapshotKey(blob, "")
+
+	var snapKeys []string
+
+	for _, k := range ctr.snapshots.Keys() {
+		if strings.HasPrefix(k, prefix) {
+			snapKeys = append(snapKeys, k)
+		}
+	}
+
+	switch mode {
+	case "":
+		if len(snapKeys) > 0 {
+			return false, &driver.BlobOpError{
+				Status: http.StatusConflict, Code: "SnapshotsPresent",
+				Message: "the specified blob has snapshots and no x-ms-delete-snapshots header was specified",
+			}
+		}
+
+		return true, nil
+	case "only":
+		for _, k := range snapKeys {
+			ctr.snapshots.Delete(k)
+		}
+
+		return false, nil
+	case "include":
+		for _, k := range snapKeys {
+			ctr.snapshots.Delete(k)
+		}
+
+		return true, nil
+	default:
+		return false, cerrors.Newf(cerrors.InvalidArgument, "invalid x-ms-delete-snapshots value %q", mode)
+	}
+}
+
+// SetContainerAccessPolicy sets a container's public access level and stored
+// access policies.
+func (m *Mock) SetContainerAccessPolicy(
+	_ context.Context, container, publicAccess string, policies []driver.SignedIdentifier,
+) error {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+	}
+
+	ctr.mu.Lock()
+	defer ctr.mu.Unlock()
+
+	ctr.publicAccess = publicAccess
+
+	ctr.accessPolicies = append([]driver.SignedIdentifier(nil), policies...)
+
+	return nil
+}
+
+// ContainerAccessPolicy returns a container's public access level and stored
+// access policies.
+func (m *Mock) ContainerAccessPolicy(_ context.Context, container string) (string, []driver.SignedIdentifier, error) {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return "", nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+	}
+
+	ctr.mu.Lock()
+	defer ctr.mu.Unlock()
+
+	return ctr.publicAccess, append([]driver.SignedIdentifier(nil), ctr.accessPolicies...), nil
 }

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -52,12 +52,29 @@ type blobObject struct {
 	ContentLanguage    string
 	ContentDisposition string
 	CacheControl       string
+	// CommittedBlocks records the block id/size pairs assembled by the most
+	// recent Put Block List commit, in commit order, for Get Block List.
+	CommittedBlocks []driver.BlockInfo
 	// mu guards the in-place mutations of the new Azure ops (append, metadata /
-	// property / tier updates). Whole-object replacements via the container store
-	// don't need it.
+	// property / tier updates, leases). Whole-object replacements via the
+	// container store don't need it.
 	mu sync.Mutex
 	// appendBlocks counts committed Append Block operations (append blobs only).
 	appendBlocks int
+
+	// Lease Blob state. leaseState is one of leaseStateAvailable (""),
+	// leaseStateLeased, leaseStateBreaking, or leaseStateBroken; a "leased" or
+	// "breaking" state additionally transitions to expired/broken lazily (see
+	// effectiveLeaseState) once its deadline passes, without a background timer.
+	leaseState       string
+	leaseID          string
+	leaseDurationSec int32
+	leaseExpiresAt   time.Time
+	leaseBreakAt     time.Time
+	// leaseModTimeAtAcquire is the blob's LastModified at the last successful
+	// Acquire/Renew, used to detect "blob modified since lease" on a Renew of
+	// an expired-but-unreleased lease.
+	leaseModTimeAtAcquire string
 }
 
 type blobMultipartUpload struct {
@@ -85,6 +102,12 @@ type containerMeta struct {
 	tags       map[string]string
 	// metadata is the container's x-ms-meta-* metadata (Set Container Metadata).
 	metadata map[string]string
+	// publicAccess is the container's public access level (Set/Get Container
+	// ACL), empty for private (the Azure default).
+	publicAccess string
+	// accessPolicies are the container's stored access policies (Set/Get
+	// Container ACL).
+	accessPolicies []driver.SignedIdentifier
 	// staging holds uncommitted blocks (Put Block) keyed by blob name.
 	staging *memstore.Store[*blockStaging]
 	// snapshots holds immutable blob snapshots keyed by snapshotKey(blob, id).
@@ -301,6 +324,18 @@ func (m *Mock) GetObject(ctx context.Context, bucket, key string) (*driver.Objec
 		return nil, cerrors.Newf(cerrors.NotFound, "blob %q not found in container %q", key, bucket)
 	}
 
+	// Get Blob doesn't support reading blob content while the blob's tier is
+	// Archive: the data has been moved to offline storage and must first be
+	// rehydrated by Set Blob Tier to an online tier. Get Blob Properties/Head/
+	// List Blobs still succeed and report the Archive tier.
+	// https://learn.microsoft.com/en-us/rest/api/storageservices/set-blob-tier
+	if obj.AccessTier == accessTierArchive {
+		return nil, &driver.BlobOpError{
+			Status: http.StatusConflict, Code: "BlobArchived",
+			Message: "This operation is not permitted on an archived blob.",
+		}
+	}
+
 	data, err := m.loadObjectData(ctx, bucket, obj)
 	if err != nil {
 		return nil, err
@@ -483,7 +518,9 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 	dstObj := &blobObject{
 		Key: dstKey, Size: srcObj.Size, ContentType: srcObj.ContentType,
 		ETag: srcObj.ETag, LastModified: m.opts.Clock.Now().UTC().Format(blobTimeFormat),
-		Metadata: meta,
+		Metadata: meta, BlobType: srcObj.BlobType, AccessTier: srcObj.AccessTier,
+		ContentEncoding: srcObj.ContentEncoding, ContentLanguage: srcObj.ContentLanguage,
+		ContentDisposition: srcObj.ContentDisposition, CacheControl: srcObj.CacheControl,
 	}
 
 	if m.opts.StorageEngine != nil {

--- a/server/azure/blobstorage/blob_extensions.go
+++ b/server/azure/blobstorage/blob_extensions.go
@@ -17,7 +17,11 @@ import (
 type blobExt = storagedriver.AzureBlobExtensions
 
 // stageBlock handles PUT /{container}/{blob}?comp=block&blockid=….
-func (*Handler) stageBlock(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+func (h *Handler) stageBlock(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	if h.checkLease(w, r, container, blob) {
+		return
+	}
+
 	blockID := r.URL.Query().Get("blockid")
 	if blockID == "" {
 		writeError(w, http.StatusBadRequest, "InvalidQueryParameterValue", "missing blockid")
@@ -39,7 +43,11 @@ func (*Handler) stageBlock(w http.ResponseWriter, r *http.Request, ext blobExt, 
 }
 
 // commitBlockList handles PUT /{container}/{blob}?comp=blocklist.
-func (*Handler) commitBlockList(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+func (h *Handler) commitBlockList(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	if h.checkLease(w, r, container, blob) {
+		return
+	}
+
 	body, ok := readLimitedBody(w, r)
 	if !ok {
 		return
@@ -61,7 +69,11 @@ func (*Handler) commitBlockList(w http.ResponseWriter, r *http.Request, ext blob
 }
 
 // setBlobMetadata handles PUT /{container}/{blob}?comp=metadata.
-func (*Handler) setBlobMetadata(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+func (h *Handler) setBlobMetadata(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	if h.checkLease(w, r, container, blob) {
+		return
+	}
+
 	info, err := ext.SetBlobMetadata(r.Context(), container, blob, extractMetadata(r.Header))
 	if err != nil {
 		writeErr(w, err)
@@ -72,7 +84,11 @@ func (*Handler) setBlobMetadata(w http.ResponseWriter, r *http.Request, ext blob
 }
 
 // setBlobProperties handles PUT /{container}/{blob}?comp=properties.
-func (*Handler) setBlobProperties(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+func (h *Handler) setBlobProperties(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	if h.checkLease(w, r, container, blob) {
+		return
+	}
+
 	props := &storagedriver.BlobProperties{
 		ContentType:        r.Header.Get("x-ms-blob-content-type"),
 		ContentEncoding:    r.Header.Get("x-ms-blob-content-encoding"),
@@ -98,12 +114,13 @@ func (*Handler) setBlobTier(w http.ResponseWriter, r *http.Request, ext blobExt,
 		return
 	}
 
-	if err := ext.SetBlobTier(r.Context(), container, blob, tier); err != nil {
+	status, err := ext.SetBlobTier(r.Context(), container, blob, tier)
+	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(status)
 }
 
 // snapshotBlob handles PUT /{container}/{blob}?comp=snapshot.
@@ -119,7 +136,11 @@ func (*Handler) snapshotBlob(w http.ResponseWriter, r *http.Request, ext blobExt
 }
 
 // createAppendBlob handles PUT /{container}/{blob} with x-ms-blob-type: AppendBlob.
-func (*Handler) createAppendBlob(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+func (h *Handler) createAppendBlob(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	if h.checkLease(w, r, container, blob) {
+		return
+	}
+
 	info, err := ext.CreateAppendBlob(r.Context(), container, blob, blobContentType(r), extractMetadata(r.Header))
 	if err != nil {
 		writeErr(w, err)
@@ -131,7 +152,11 @@ func (*Handler) createAppendBlob(w http.ResponseWriter, r *http.Request, ext blo
 }
 
 // appendBlock handles PUT /{container}/{blob}?comp=appendblock.
-func (*Handler) appendBlock(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+func (h *Handler) appendBlock(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	if h.checkLease(w, r, container, blob) {
+		return
+	}
+
 	data, ok := readLimitedBody(w, r)
 	if !ok {
 		return

--- a/server/azure/blobstorage/blob_lease.go
+++ b/server/azure/blobstorage/blob_lease.go
@@ -1,0 +1,255 @@
+package blobstorage
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// x-ms-lease-action values dispatched by leaseBlob.
+const (
+	leaseActionAcquire = "acquire"
+	leaseActionRenew   = "renew"
+	leaseActionChange  = "change"
+	leaseActionRelease = "release"
+	leaseActionBreak   = "break"
+)
+
+// checkLease validates the request's x-ms-lease-id header against any active
+// lease on the blob (Put Blob, Delete Blob, Put Block, Put Block List, Set
+// Blob Metadata/Properties, Append Block, and Copy Blob's destination all
+// require a matching lease id while a blob is leased). It returns true,
+// having already written the Azure lease error, when the request must be
+// rejected. It's a no-op when the driver doesn't implement leases.
+func (h *Handler) checkLease(w http.ResponseWriter, r *http.Request, container, blob string) bool {
+	ext, ok := h.bucket.(storagedriver.AzureBlobExtensions)
+	if !ok {
+		return false
+	}
+
+	if err := ext.CheckBlobLease(r.Context(), container, blob, r.Header.Get("X-Ms-Lease-Id")); err != nil {
+		writeErr(w, err)
+		return true
+	}
+
+	return false
+}
+
+// leaseBlob handles PUT /{container}/{blob}?comp=lease, dispatching on
+// x-ms-lease-action. See
+// https://learn.microsoft.com/en-us/rest/api/storageservices/lease-blob.
+func (h *Handler) leaseBlob(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	switch strings.ToLower(r.Header.Get("X-Ms-Lease-Action")) {
+	case leaseActionAcquire:
+		h.acquireLease(w, r, ext, container, blob)
+	case leaseActionRenew:
+		h.renewLease(w, r, ext, container, blob)
+	case leaseActionChange:
+		h.changeLease(w, r, ext, container, blob)
+	case leaseActionRelease:
+		h.releaseLease(w, r, ext, container, blob)
+	case leaseActionBreak:
+		h.breakLease(w, r, ext, container, blob)
+	default:
+		writeError(w, http.StatusBadRequest, "InvalidHeaderValue", "missing or invalid x-ms-lease-action")
+	}
+}
+
+func (*Handler) acquireLease(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	durationHeader := r.Header.Get("X-Ms-Lease-Duration")
+	if durationHeader == "" {
+		writeError(w, http.StatusBadRequest, "MissingRequiredHeader", "x-ms-lease-duration is required for acquire")
+		return
+	}
+
+	n, err := strconv.ParseInt(durationHeader, 10, 32)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidHeaderValue", "invalid x-ms-lease-duration")
+		return
+	}
+
+	result, err := ext.AcquireLease(r.Context(), container, blob, int32(n), r.Header.Get("X-Ms-Proposed-Lease-Id"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeLeaseResult(w, result, http.StatusCreated)
+}
+
+func (*Handler) renewLease(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	result, err := ext.RenewLease(r.Context(), container, blob, r.Header.Get("X-Ms-Lease-Id"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeLeaseResult(w, result, http.StatusOK)
+}
+
+func (*Handler) changeLease(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	result, err := ext.ChangeLease(r.Context(), container, blob,
+		r.Header.Get("X-Ms-Lease-Id"), r.Header.Get("X-Ms-Proposed-Lease-Id"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeLeaseResult(w, result, http.StatusOK)
+}
+
+func (*Handler) releaseLease(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	result, err := ext.ReleaseLease(r.Context(), container, blob, r.Header.Get("X-Ms-Lease-Id"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeLeaseResult(w, result, http.StatusOK)
+}
+
+func (*Handler) breakLease(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	var period *int32
+
+	if v := r.Header.Get("X-Ms-Lease-Break-Period"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 32)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "InvalidHeaderValue", "invalid x-ms-lease-break-period")
+			return
+		}
+
+		p := int32(n)
+		period = &p
+	}
+
+	leaseTime, err := ext.BreakLease(r.Context(), container, blob, period)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.Header().Set("X-Ms-Lease-Time", strconv.FormatInt(int64(leaseTime), 10))
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// writeLeaseResult writes a successful Lease Blob acquire/renew/change/release
+// response.
+func writeLeaseResult(w http.ResponseWriter, result *storagedriver.BlobLeaseResult, status int) {
+	if result != nil {
+		if result.LeaseID != "" {
+			w.Header().Set("X-Ms-Lease-Id", result.LeaseID)
+		}
+
+		if result.ETag != "" {
+			w.Header().Set("ETag", fmt.Sprintf("%q", result.ETag))
+		}
+
+		if result.LastModified != "" {
+			w.Header().Set("Last-Modified", httpDate(result.LastModified))
+		}
+	}
+
+	w.WriteHeader(status)
+}
+
+// getBlockList handles GET /{container}/{blob}?comp=blocklist.
+func (*Handler) getBlockList(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	committed, uncommitted, err := ext.GetBlockList(r.Context(), container, blob)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := blockListResult{}
+	for _, b := range committed {
+		out.CommittedBlocks = append(out.CommittedBlocks, blockXML{Name: b.Name, Size: b.Size})
+	}
+
+	for _, b := range uncommitted {
+		out.UncommittedBlocks = append(out.UncommittedBlocks, blockXML{Name: b.Name, Size: b.Size})
+	}
+
+	writeXML(w, out)
+}
+
+// setContainerACL handles PUT /{container}?restype=container&comp=acl (Set
+// Container ACL).
+func (h *Handler) setContainerACL(w http.ResponseWriter, r *http.Request, container string) {
+	ext, ok := h.bucket.(blobExt)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "container ACL not supported")
+		return
+	}
+
+	body, ok := readLimitedBody(w, r)
+	if !ok {
+		return
+	}
+
+	var identifiers []storagedriver.SignedIdentifier
+
+	if len(bytes.TrimSpace(body)) > 0 {
+		var wrapper signedIdentifiersXML
+		if err := xml.Unmarshal(body, &wrapper); err != nil {
+			writeError(w, http.StatusBadRequest, "InvalidXmlDocument", "could not parse SignedIdentifiers body")
+			return
+		}
+
+		for _, id := range wrapper.Identifiers {
+			identifiers = append(identifiers, storagedriver.SignedIdentifier{
+				ID: id.ID, Start: id.AccessPolicy.Start, Expiry: id.AccessPolicy.Expiry, Permission: id.AccessPolicy.Permission,
+			})
+		}
+	}
+
+	publicAccess := r.Header.Get("X-Ms-Blob-Public-Access")
+
+	if err := ext.SetContainerAccessPolicy(r.Context(), container, publicAccess, identifiers); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	created, _ := h.containerCreatedAt(r, container)
+	w.Header().Set("ETag", containerETag(container, created))
+	w.Header().Set("Last-Modified", httpDate(created))
+	w.WriteHeader(http.StatusOK)
+}
+
+// getContainerACL handles GET /{container}?restype=container&comp=acl (Get
+// Container ACL).
+func (h *Handler) getContainerACL(w http.ResponseWriter, r *http.Request, container string) {
+	ext, ok := h.bucket.(blobExt)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "container ACL not supported")
+		return
+	}
+
+	publicAccess, identifiers, err := ext.ContainerAccessPolicy(r.Context(), container)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if publicAccess != "" {
+		w.Header().Set("X-Ms-Blob-Public-Access", publicAccess)
+	}
+
+	created, _ := h.containerCreatedAt(r, container)
+	w.Header().Set("ETag", containerETag(container, created))
+	w.Header().Set("Last-Modified", httpDate(created))
+
+	out := signedIdentifiersXML{}
+	for _, id := range identifiers {
+		out.Identifiers = append(out.Identifiers, signedIdentifierXML{
+			ID:           id.ID,
+			AccessPolicy: accessPolicyXML{Start: id.Start, Expiry: id.Expiry, Permission: id.Permission},
+		})
+	}
+
+	writeXML(w, out)
+}

--- a/server/azure/blobstorage/blob_lease_test.go
+++ b/server/azure/blobstorage/blob_lease_test.go
@@ -1,0 +1,522 @@
+package blobstorage_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/lease"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
+)
+
+// TestSDKAcquireLeaseDoesNotCorruptContent is the regression test for the
+// data-loss blocker: AcquireLease used to fall through the comp= switch into
+// the plain Put Blob path (no comp=lease case existed) and zero the blob.
+func TestSDKAcquireLeaseDoesNotCorruptContent(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	body := []byte("do not lose me")
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", body, nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+
+	leaseClient, err := lease.NewBlobClient(bc, nil)
+	if err != nil {
+		t.Fatalf("lease.NewBlobClient: %v", err)
+	}
+
+	acq, err := leaseClient.AcquireLease(ctx, -1, nil)
+	if err != nil {
+		t.Fatalf("AcquireLease: %v", err)
+	}
+
+	if acq.LeaseID == nil || *acq.LeaseID == "" {
+		t.Fatal("AcquireLease returned no x-ms-lease-id")
+	}
+
+	if got := e.download(t, "k1"); got != string(body) {
+		t.Fatalf("blob content after AcquireLease = %q, want %q (data corrupted by lease)", got, body)
+	}
+
+	props, err := bc.GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties: %v", err)
+	}
+
+	if props.ContentLength == nil || *props.ContentLength != int64(len(body)) {
+		t.Errorf("Content-Length after AcquireLease = %v, want %d", props.ContentLength, len(body))
+	}
+}
+
+// TestSDKLeaseGatesWrites drives the full write-gating table for a leased
+// blob: no lease id, the wrong lease id, and the correct lease id.
+func TestSDKLeaseGatesWrites(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("v1"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+
+	leaseClient, err := lease.NewBlobClient(bc, nil)
+	if err != nil {
+		t.Fatalf("lease.NewBlobClient: %v", err)
+	}
+
+	if _, err := leaseClient.AcquireLease(ctx, 15, nil); err != nil {
+		t.Fatalf("AcquireLease: %v", err)
+	}
+
+	bb := e.blockBlob(t, "/c1/k1")
+
+	// No lease id: 412 LeaseIdMissing.
+	_, err = bb.Upload(ctx, streaming.NopCloser(bytes.NewReader([]byte("no-id"))), nil)
+	if !bloberror.HasCode(err, bloberror.LeaseIDMissing) {
+		t.Errorf("Upload with no lease id: err = %v, want LeaseIdMissing", err)
+	}
+
+	// Wrong lease id: 412 LeaseIdMismatchWithBlobOperation.
+	wrongCond := &blockblob.UploadOptions{
+		AccessConditions: &blob.AccessConditions{LeaseAccessConditions: &blob.LeaseAccessConditions{LeaseID: to.Ptr("not-the-lease")}},
+	}
+	_, err = bb.Upload(ctx, streaming.NopCloser(bytes.NewReader([]byte("wrong-id"))), wrongCond)
+	if !bloberror.HasCode(err, bloberror.LeaseIDMismatchWithBlobOperation) {
+		t.Errorf("Upload with wrong lease id: err = %v, want LeaseIdMismatchWithBlobOperation", err)
+	}
+
+	if got := e.download(t, "k1"); got != "v1" {
+		t.Fatalf("blob overwritten by a rejected write: %q", got)
+	}
+
+	// Correct lease id: succeeds.
+	rightCond := &blockblob.UploadOptions{
+		AccessConditions: &blob.AccessConditions{LeaseAccessConditions: &blob.LeaseAccessConditions{LeaseID: leaseClient.LeaseID()}},
+	}
+	if _, err := bb.Upload(ctx, streaming.NopCloser(bytes.NewReader([]byte("v2"))), rightCond); err != nil {
+		t.Fatalf("Upload with correct lease id: %v", err)
+	}
+
+	if got := e.download(t, "k1"); got != "v2" {
+		t.Errorf("blob content = %q, want v2", got)
+	}
+}
+
+// TestSDKLeaseAcquireAlreadyPresentConflicts checks that acquiring a lease
+// against an already-leased blob with a different (or no) proposed id fails
+// with LeaseAlreadyPresent, per the Lease Blob acquire-outcome table.
+func TestSDKLeaseAcquireAlreadyPresentConflicts(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("v1"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+
+	first, err := lease.NewBlobClient(bc, nil)
+	if err != nil {
+		t.Fatalf("lease.NewBlobClient: %v", err)
+	}
+
+	if _, err := first.AcquireLease(ctx, -1, nil); err != nil {
+		t.Fatalf("first AcquireLease: %v", err)
+	}
+
+	second, err := lease.NewBlobClient(bc, nil)
+	if err != nil {
+		t.Fatalf("lease.NewBlobClient: %v", err)
+	}
+
+	_, err = second.AcquireLease(ctx, -1, nil)
+	if !bloberror.HasCode(err, bloberror.LeaseAlreadyPresent) {
+		t.Errorf("second AcquireLease: err = %v, want LeaseAlreadyPresent", err)
+	}
+}
+
+// TestSDKLeaseRenewChangeRelease exercises the renew/change/release lease
+// management calls, and confirms a released blob accepts an unleased write
+// again.
+func TestSDKLeaseRenewChangeRelease(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("v1"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+
+	lc, err := lease.NewBlobClient(bc, nil)
+	if err != nil {
+		t.Fatalf("lease.NewBlobClient: %v", err)
+	}
+
+	if _, err := lc.AcquireLease(ctx, 15, nil); err != nil {
+		t.Fatalf("AcquireLease: %v", err)
+	}
+
+	if _, err := lc.RenewLease(ctx, nil); err != nil {
+		t.Fatalf("RenewLease: %v", err)
+	}
+
+	if _, err := lc.ChangeLease(ctx, "22222222-2222-2222-2222-222222222222", nil); err != nil {
+		t.Fatalf("ChangeLease: %v", err)
+	}
+
+	if got := lc.LeaseID(); got == nil || *got != "22222222-2222-2222-2222-222222222222" {
+		t.Errorf("LeaseID after ChangeLease = %v, want the new id", got)
+	}
+
+	if _, err := lc.ReleaseLease(ctx, nil); err != nil {
+		t.Fatalf("ReleaseLease: %v", err)
+	}
+
+	// The blob is unleased again: a plain write with no lease id succeeds.
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("v2"), nil); err != nil {
+		t.Fatalf("UploadBuffer after release: %v", err)
+	}
+
+	if got := e.download(t, "k1"); got != "v2" {
+		t.Errorf("blob content after release = %q, want v2", got)
+	}
+}
+
+// TestSDKLeaseBreak checks Break Lease returns an x-ms-lease-time and that a
+// write with the (still known) lease id succeeds while breaking.
+func TestSDKLeaseBreak(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("v1"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+
+	lc, err := lease.NewBlobClient(bc, nil)
+	if err != nil {
+		t.Fatalf("lease.NewBlobClient: %v", err)
+	}
+
+	if _, err := lc.AcquireLease(ctx, -1, nil); err != nil {
+		t.Fatalf("AcquireLease: %v", err)
+	}
+
+	brk, err := lc.BreakLease(ctx, &lease.BlobBreakOptions{BreakPeriod: to.Ptr(int32(30))})
+	if err != nil {
+		t.Fatalf("BreakLease: %v", err)
+	}
+
+	if brk.LeaseTime == nil {
+		t.Fatal("BreakLease returned no x-ms-lease-time")
+	}
+
+	rightCond := &blockblob.UploadOptions{
+		AccessConditions: &blob.AccessConditions{LeaseAccessConditions: &blob.LeaseAccessConditions{LeaseID: lc.LeaseID()}},
+	}
+	bb := e.blockBlob(t, "/c1/k1")
+
+	if _, err := bb.Upload(ctx, streaming.NopCloser(bytes.NewReader([]byte("v2"))), rightCond); err != nil {
+		t.Fatalf("Upload while breaking with correct lease id: %v", err)
+	}
+}
+
+// TestSDKGetBlockList checks Get Block List returns uncommitted blocks after
+// Stage Block and, once committed, the committed block list — the previous
+// misroute 404'd because comp=blocklist GET fell through to a plain blob
+// download before any commit had happened.
+func TestSDKGetBlockList(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	bb := e.blockBlob(t, "/c1/k1")
+
+	blockID := base64.StdEncoding.EncodeToString([]byte("block-a"))
+	if _, err := bb.StageBlock(ctx, blockID, streaming.NopCloser(bytes.NewReader([]byte("hello"))), nil); err != nil {
+		t.Fatalf("StageBlock: %v", err)
+	}
+
+	uncommitted, err := bb.GetBlockList(ctx, blockblob.BlockListTypeAll, nil)
+	if err != nil {
+		t.Fatalf("GetBlockList (before commit): %v", err)
+	}
+
+	if len(uncommitted.UncommittedBlocks) != 1 {
+		t.Fatalf("uncommitted blocks = %d, want 1", len(uncommitted.UncommittedBlocks))
+	}
+
+	if len(uncommitted.CommittedBlocks) != 0 {
+		t.Fatalf("committed blocks before commit = %d, want 0", len(uncommitted.CommittedBlocks))
+	}
+
+	if _, err := bb.CommitBlockList(ctx, []string{blockID}, nil); err != nil {
+		t.Fatalf("CommitBlockList: %v", err)
+	}
+
+	committed, err := bb.GetBlockList(ctx, blockblob.BlockListTypeCommitted, nil)
+	if err != nil {
+		t.Fatalf("GetBlockList (after commit): %v", err)
+	}
+
+	if len(committed.CommittedBlocks) != 1 {
+		t.Fatalf("committed blocks = %d, want 1", len(committed.CommittedBlocks))
+	}
+
+	if committed.CommittedBlocks[0].Size == nil || *committed.CommittedBlocks[0].Size != int64(len("hello")) {
+		t.Errorf("committed block size = %v, want %d", committed.CommittedBlocks[0].Size, len("hello"))
+	}
+}
+
+// TestSDKListBlobsIncludesMetadataAndAccessTier checks that List Blobs with
+// Include{Metadata:true} returns the blob's metadata, and that AccessTier is
+// always reported once set (List Blobs doesn't gate it behind Include).
+func TestSDKListBlobsIncludesMetadataAndAccessTier(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	uploadOpts := &azblob.UploadBufferOptions{Metadata: map[string]*string{"team": to.Ptr("platform")}}
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("v1"), uploadOpts); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+	if _, err := bc.SetTier(ctx, blob.AccessTierCool, nil); err != nil {
+		t.Fatalf("SetTier: %v", err)
+	}
+
+	cc, err := container.NewClientWithNoCredential(e.base+"/c1", &container.ClientOptions{ClientOptions: e.clientOpts()})
+	if err != nil {
+		t.Fatalf("container.NewClient: %v", err)
+	}
+
+	pager := cc.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
+		Include: container.ListBlobsInclude{Metadata: true},
+	})
+
+	page, err := pager.NextPage(ctx)
+	if err != nil {
+		t.Fatalf("NextPage: %v", err)
+	}
+
+	if len(page.Segment.BlobItems) != 1 {
+		t.Fatalf("blobs listed = %d, want 1", len(page.Segment.BlobItems))
+	}
+
+	item := page.Segment.BlobItems[0]
+
+	// Unlike Set Metadata's HTTP-header round trip (canonicalized to "Team" by
+	// Go's http.Header), List Blobs' metadata comes from an XML element name,
+	// which isn't canonicalized — it keeps the lowercase name the driver
+	// stores it under.
+	if item.Metadata["team"] == nil || *item.Metadata["team"] != "platform" {
+		t.Errorf("listed metadata = %v, want team=platform", item.Metadata)
+	}
+
+	if item.Properties.AccessTier == nil || *item.Properties.AccessTier != "Cool" {
+		t.Errorf("listed access tier = %v, want Cool", item.Properties.AccessTier)
+	}
+}
+
+// TestSDKCopyBlobPreservesBlobTypeAndTier checks that a server-side copy
+// carries the source's BlobType and AccessTier to the destination, rather
+// than dropping back to the BlockBlob/no-tier defaults.
+func TestSDKCopyBlobPreservesBlobTypeAndTier(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "src", []byte("copy me"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	srcClient := e.blob(t, "/c1/src")
+	if _, err := srcClient.SetTier(ctx, blob.AccessTierCool, nil); err != nil {
+		t.Fatalf("SetTier: %v", err)
+	}
+
+	dstClient := e.blob(t, "/c1/dst")
+	if _, err := dstClient.StartCopyFromURL(ctx, e.base+"/c1/src", nil); err != nil {
+		t.Fatalf("StartCopyFromURL: %v", err)
+	}
+
+	props, err := dstClient.GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties: %v", err)
+	}
+
+	if props.BlobType == nil || *props.BlobType != blob.BlobTypeBlockBlob {
+		t.Errorf("copied blob type = %v, want BlockBlob", props.BlobType)
+	}
+
+	if props.AccessTier == nil || *props.AccessTier != "Cool" {
+		t.Errorf("copied access tier = %v, want Cool", props.AccessTier)
+	}
+}
+
+// TestSDKDeleteBlobWithSnapshotsConflict checks Delete Blob 409s with
+// SnapshotsPresent when the blob has snapshots and no x-ms-delete-snapshots
+// header is set, and succeeds once "include" is specified.
+func TestSDKDeleteBlobWithSnapshotsConflict(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("v1"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+	if _, err := bc.CreateSnapshot(ctx, nil); err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	_, err := e.svc.DeleteBlob(ctx, "c1", "k1", nil)
+	if !bloberror.HasCode(err, bloberror.SnapshotsPresent) {
+		t.Errorf("DeleteBlob with snapshots and no directive: err = %v, want SnapshotsPresent", err)
+	}
+
+	_, err = e.svc.DeleteBlob(ctx, "c1", "k1", &blob.DeleteOptions{
+		DeleteSnapshots: to.Ptr(blob.DeleteSnapshotsOptionTypeInclude),
+	})
+	if err != nil {
+		t.Fatalf("DeleteBlob with delete-snapshots=include: %v", err)
+	}
+}
+
+// TestSDKArchiveTierBlocksDownload checks that a blob tiered to Archive
+// rejects Download until it's moved back to an online tier, while Get
+// Properties keeps working and reports the tier.
+func TestSDKArchiveTierBlocksDownload(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("cold storage"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+	if _, err := bc.SetTier(ctx, blob.AccessTierArchive, nil); err != nil {
+		t.Fatalf("SetTier(Archive): %v", err)
+	}
+
+	props, err := bc.GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties on archived blob: %v", err)
+	}
+
+	if props.AccessTier == nil || *props.AccessTier != "Archive" {
+		t.Errorf("access tier = %v, want Archive", props.AccessTier)
+	}
+
+	_, err = e.svc.DownloadStream(ctx, "c1", "k1", nil)
+	if !bloberror.HasCode(err, bloberror.BlobArchived) {
+		t.Errorf("DownloadStream on archived blob: err = %v, want BlobArchived", err)
+	}
+
+	// Rehydrating out of Archive makes it readable again.
+	if _, err := bc.SetTier(ctx, blob.AccessTierHot, nil); err != nil {
+		t.Fatalf("SetTier(Hot): %v", err)
+	}
+
+	if got := e.download(t, "k1"); got != "cold storage" {
+		t.Errorf("content after rehydrate = %q, want %q", got, "cold storage")
+	}
+}
+
+// TestSDKSetTierRejectsInvalidValue checks Set Blob Tier rejects a tier
+// outside Hot/Cool/Cold/Archive.
+func TestSDKSetTierRejectsInvalidValue(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("v1"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+	if _, err := bc.SetTier(ctx, blob.AccessTier("NotATier"), nil); err == nil {
+		t.Fatal("SetTier with an invalid tier value succeeded, want an error")
+	}
+}
+
+// TestSDKContainerListPagination checks GET /?comp=list honors maxresults and
+// marker instead of always returning every container in one page.
+func TestSDKContainerListPagination(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	// c1 already exists (created by newBlobEnv); add two more.
+	for _, name := range []string{"c2", "c3"} {
+		if _, err := e.svc.CreateContainer(ctx, name, nil); err != nil {
+			t.Fatalf("CreateContainer %s: %v", name, err)
+		}
+	}
+
+	pager := e.svc.NewListContainersPager(&service.ListContainersOptions{MaxResults: to.Ptr(int32(2))})
+
+	page, err := pager.NextPage(ctx)
+	if err != nil {
+		t.Fatalf("NextPage: %v", err)
+	}
+
+	if len(page.ContainerItems) != 2 {
+		t.Fatalf("first page = %d containers, want 2 (maxresults not honored)", len(page.ContainerItems))
+	}
+
+	if page.NextMarker == nil || *page.NextMarker == "" {
+		t.Fatal("first page returned no NextMarker despite more containers remaining")
+	}
+
+	if !pager.More() {
+		t.Fatal("pager.More() = false, want true (a second page remains)")
+	}
+
+	page2, err := pager.NextPage(ctx)
+	if err != nil {
+		t.Fatalf("NextPage (2nd): %v", err)
+	}
+
+	if len(page2.ContainerItems) != 1 {
+		t.Fatalf("second page = %d containers, want 1", len(page2.ContainerItems))
+	}
+}
+
+// TestSDKContainerACLRoundTrip checks Set/Get Container ACL: previously PUT
+// ?comp=acl fell through to CreateContainer and 409'd on the already-existing
+// container.
+func TestSDKContainerACLRoundTrip(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	cc, err := container.NewClientWithNoCredential(e.base+"/c1", &container.ClientOptions{ClientOptions: e.clientOpts()})
+	if err != nil {
+		t.Fatalf("container.NewClient: %v", err)
+	}
+
+	if _, err := cc.SetAccessPolicy(ctx, &container.SetAccessPolicyOptions{
+		Access: to.Ptr(container.PublicAccessTypeContainer),
+	}); err != nil {
+		t.Fatalf("SetAccessPolicy: %v", err)
+	}
+
+	got, err := cc.GetAccessPolicy(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetAccessPolicy: %v", err)
+	}
+
+	if got.BlobPublicAccess == nil || *got.BlobPublicAccess != container.PublicAccessTypeContainer {
+		t.Errorf("public access = %v, want %q", got.BlobPublicAccess, container.PublicAccessTypeContainer)
+	}
+}

--- a/server/azure/blobstorage/handler.go
+++ b/server/azure/blobstorage/handler.go
@@ -15,13 +15,14 @@
 //	HEAD   /{container}/{blob}                          — head blob
 //	DELETE /{container}/{blob}                          — delete blob
 //
-// Less-used surfaces (lifecycle, encryption, tags, access policies, leases,
-// snapshots, versioning) are not yet wired and return 501.
+// Less-used surfaces (lifecycle, encryption, tags, versioning) are not yet
+// wired and return 501.
 package blobstorage
 
 import (
 	"crypto/sha256"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -32,6 +33,7 @@ import (
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
 )
 
@@ -59,6 +61,11 @@ const (
 	compTier        = "tier"
 	compSnapshot    = "snapshot"
 	compAppendBlock = "appendblock"
+	compLease       = "lease"
+
+	// compACL is the ?comp= value for Set/Get Container ACL
+	// (?restype=container&comp=acl).
+	compACL = "acl"
 )
 
 // Handler serves Azure Blob Storage REST requests against a storage.Bucket
@@ -127,21 +134,25 @@ func parseBlobPath(path string) (container, blob string) {
 func (h *Handler) containerOp(w http.ResponseWriter, r *http.Request, container string, q url.Values) {
 	switch r.Method {
 	case http.MethodPut:
-		if q.Get("comp") == compMetadata {
+		switch q.Get("comp") {
+		case compMetadata:
 			h.setContainerMetadata(w, r, container)
-			return
+		case compACL:
+			h.setContainerACL(w, r, container)
+		default:
+			h.createContainer(w, r, container)
 		}
-
-		h.createContainer(w, r, container)
 	case http.MethodDelete:
 		h.deleteContainer(w, r, container)
 	case http.MethodGet, http.MethodHead:
-		if q.Get("comp") == compList {
+		switch q.Get("comp") {
+		case compList:
 			h.listBlobs(w, r, container, q)
-			return
+		case compACL:
+			h.getContainerACL(w, r, container)
+		default:
+			h.getContainerProperties(w, r, container)
 		}
-
-		h.getContainerProperties(w, r, container)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
@@ -152,6 +163,11 @@ func (h *Handler) blobOp(w http.ResponseWriter, r *http.Request, container, blob
 	case http.MethodPut:
 		h.putBlobOp(w, r, container, blob)
 	case http.MethodGet:
+		if ext, ok := h.bucket.(storagedriver.AzureBlobExtensions); ok && r.URL.Query().Get("comp") == compBlockList {
+			h.getBlockList(w, r, ext, container, blob)
+			return
+		}
+
 		h.getBlob(w, r, container, blob)
 	case http.MethodHead:
 		h.headBlob(w, r, container, blob)
@@ -207,6 +223,8 @@ func (h *Handler) dispatchBlobComp(
 		h.snapshotBlob(w, r, ext, container, blob)
 	case compAppendBlock:
 		h.appendBlock(w, r, ext, container, blob)
+	case compLease:
+		h.leaseBlob(w, r, ext, container, blob)
 	default:
 		return false
 	}
@@ -221,8 +239,24 @@ func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := listContainersResult{}
-	for _, b := range buckets {
+	q := r.URL.Query()
+	maxResults := parseMaxResults(q)
+
+	page, err := pagination.Paginate(buckets, q.Get("marker"), maxResults)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "OutOfRangeInput", "invalid marker")
+		return
+	}
+
+	out := listContainersResult{
+		Marker:     q.Get("marker"),
+		MaxResults: maxResults,
+		NextMarker: page.NextPageToken,
+	}
+
+	for i := range page.Items {
+		b := &page.Items[i]
+
 		out.Containers.Containers = append(out.Containers.Containers, containerXML{
 			Name: b.Name,
 			Properties: containerPropsXML{
@@ -232,7 +266,7 @@ func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	writeXML(w, http.StatusOK, out)
+	writeXML(w, out)
 }
 
 func (h *Handler) createContainer(w http.ResponseWriter, r *http.Request, container string) {
@@ -335,13 +369,7 @@ func (h *Handler) getContainerProperties(w http.ResponseWriter, r *http.Request,
 }
 
 func (h *Handler) listBlobs(w http.ResponseWriter, r *http.Request, container string, q url.Values) {
-	maxResults := defaultMaxResults
-
-	if v := q.Get("maxresults"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			maxResults = n
-		}
-	}
+	maxResults := parseMaxResults(q)
 
 	opts := storagedriver.ListOptions{
 		Prefix:    q.Get("prefix"),
@@ -364,6 +392,8 @@ func (h *Handler) listBlobs(w http.ResponseWriter, r *http.Request, container st
 		NextMarker:    result.NextPageToken,
 	}
 
+	includeMetadata := includesOption(q.Get("include"), "metadata")
+
 	for i := range result.Objects {
 		obj := &result.Objects[i]
 
@@ -372,7 +402,7 @@ func (h *Handler) listBlobs(w http.ResponseWriter, r *http.Request, container st
 			blobType = blobTypeBlockBlob
 		}
 
-		out.Blobs.Blobs = append(out.Blobs.Blobs, blobXML{
+		bx := blobXML{
 			Name: obj.Key,
 			Properties: blobPropsXML{
 				LastModified:  httpDate(obj.LastModified),
@@ -380,20 +410,59 @@ func (h *Handler) listBlobs(w http.ResponseWriter, r *http.Request, container st
 				ContentLength: obj.Size,
 				ContentType:   obj.ContentType,
 				BlobType:      blobType,
+				AccessTier:    obj.AccessTier,
 			},
-		})
+		}
+
+		if includeMetadata && len(obj.Metadata) > 0 {
+			bx.Metadata = &metadataXML{Items: obj.Metadata}
+		}
+
+		out.Blobs.Blobs = append(out.Blobs.Blobs, bx)
 	}
 
 	for _, p := range result.CommonPrefixes {
 		out.Blobs.BlobPrefixes = append(out.Blobs.BlobPrefixes, blobPrefixXML{Name: p})
 	}
 
-	writeXML(w, http.StatusOK, out)
+	writeXML(w, out)
 }
 
 const defaultMaxResults = 5000
 
+// parseMaxResults reads ?maxresults= off q, falling back to defaultMaxResults
+// when it's absent, non-numeric, or not positive.
+func parseMaxResults(q url.Values) int {
+	v := q.Get("maxresults")
+	if v == "" {
+		return defaultMaxResults
+	}
+
+	n, convErr := strconv.Atoi(v)
+	if convErr != nil || n <= 0 {
+		return defaultMaxResults
+	}
+
+	return n
+}
+
+// includesOption reports whether the comma-separated ?include= value (e.g.
+// "metadata,tags") contains want.
+func includesOption(include, want string) bool {
+	for _, part := range strings.Split(include, ",") {
+		if strings.EqualFold(strings.TrimSpace(part), want) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (h *Handler) putBlob(w http.ResponseWriter, r *http.Request, container, blob string) {
+	if h.checkLease(w, r, container, blob) {
+		return
+	}
+
 	if h.conditionFailed(w, r, container, blob) {
 		return
 	}
@@ -579,15 +648,39 @@ func writeBlobHeaders(w http.ResponseWriter, info *storagedriver.ObjectInfo, siz
 }
 
 func (h *Handler) deleteBlob(w http.ResponseWriter, r *http.Request, container, blob string) {
-	if err := h.bucket.DeleteObject(r.Context(), container, blob); err != nil {
-		writeErr(w, err)
+	if h.checkLease(w, r, container, blob) {
 		return
+	}
+
+	deleteBase := true
+
+	if ext, ok := h.bucket.(storagedriver.AzureBlobExtensions); ok {
+		var err error
+
+		deleteBase, err = ext.DeleteBlobSnapshots(r.Context(), container, blob, r.Header.Get("X-Ms-Delete-Snapshots"))
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+	}
+
+	if deleteBase {
+		if err := h.bucket.DeleteObject(r.Context(), container, blob); err != nil {
+			writeErr(w, err)
+			return
+		}
 	}
 
 	w.WriteHeader(http.StatusAccepted)
 }
 
 func (h *Handler) copyBlob(w http.ResponseWriter, r *http.Request, container, blob string) {
+	// Copy Blob requires the destination's lease id (if it has an active
+	// lease); the source blob needs none.
+	if h.checkLease(w, r, container, blob) {
+		return
+	}
+
 	src := r.Header.Get("X-Ms-Copy-Source")
 	srcBucket, srcKey := extractCopySource(src)
 
@@ -648,9 +741,12 @@ func httpDate(s string) string {
 	return time.Now().UTC().Format(http.TimeFormat)
 }
 
-func writeXML(w http.ResponseWriter, status int, v any) {
+// writeXML writes an XML response body. Every wire operation that returns an
+// XML document (list/get) does so with 200 OK on success — a write that needs
+// a different success status (201/202) sets headers and writes its own body.
+func writeXML(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", contentTypeXML)
-	w.WriteHeader(status)
+	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(xml.Header))
 	_ = xml.NewEncoder(w).Encode(v)
 }
@@ -665,6 +761,12 @@ func writeError(w http.ResponseWriter, status int, code, msg string) {
 
 // writeErr maps CloudEmu canonical errors to Azure Blob HTTP errors.
 func writeErr(w http.ResponseWriter, err error) {
+	var opErr *storagedriver.BlobOpError
+	if errors.As(err, &opErr) {
+		writeError(w, opErr.Status, opErr.Code, opErr.Message)
+		return
+	}
+
 	switch {
 	case cerrors.IsNotFound(err):
 		writeError(w, http.StatusNotFound, "BlobNotFound", err.Error())

--- a/server/azure/blobstorage/types.go
+++ b/server/azure/blobstorage/types.go
@@ -59,6 +59,7 @@ type blobPropsXML struct {
 	ContentLength int64  `xml:"Content-Length"`
 	ContentType   string `xml:"Content-Type"`
 	BlobType      string `xml:"BlobType"`
+	AccessTier    string `xml:"AccessTier,omitempty"`
 }
 
 type blobPrefixXML struct {
@@ -92,4 +93,34 @@ type errorXML struct {
 	XMLName xml.Name `xml:"Error"`
 	Code    string   `xml:"Code"`
 	Message string   `xml:"Message"`
+}
+
+// blockListResult is the body for GET /{container}/{blob}?comp=blocklist.
+type blockListResult struct {
+	XMLName           xml.Name   `xml:"BlockList"`
+	CommittedBlocks   []blockXML `xml:"CommittedBlocks>Block"`
+	UncommittedBlocks []blockXML `xml:"UncommittedBlocks>Block"`
+}
+
+type blockXML struct {
+	Name string `xml:"Name"`
+	Size int64  `xml:"Size"`
+}
+
+// signedIdentifiersXML is the request/response body for PUT and GET
+// /{container}?restype=container&comp=acl.
+type signedIdentifiersXML struct {
+	XMLName     xml.Name              `xml:"SignedIdentifiers"`
+	Identifiers []signedIdentifierXML `xml:"SignedIdentifier"`
+}
+
+type signedIdentifierXML struct {
+	ID           string          `xml:"Id"`
+	AccessPolicy accessPolicyXML `xml:"AccessPolicy"`
+}
+
+type accessPolicyXML struct {
+	Start      string `xml:"Start,omitempty"`
+	Expiry     string `xml:"Expiry,omitempty"`
+	Permission string `xml:"Permission,omitempty"`
 }

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -3,6 +3,7 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -84,6 +85,46 @@ type BlobProperties struct {
 	CacheControl       string
 }
 
+// BlobOpError reports an Azure Blob operation failure that carries an exact
+// HTTP status and x-ms-error-code the wire layer must echo verbatim. Several
+// blob operations (Lease Blob, Delete Blob with snapshots present, Get Blob on
+// an archived blob) don't fit the canonical cerrors taxonomy: the same
+// underlying condition maps to different statuses depending on the operation
+// (e.g. a lease mismatch is 412 for a blob write but 409 for a lease-management
+// call), so those providers return this directly instead of a cerrors code.
+type BlobOpError struct {
+	Status  int // HTTP status code, e.g. 409, 412
+	Code    string
+	Message string
+}
+
+func (e *BlobOpError) Error() string { return fmt.Sprintf("%s: %s", e.Code, e.Message) }
+
+// BlockInfo describes one block in a block blob's committed or uncommitted
+// block list (Put Block List / Get Block List).
+type BlockInfo struct {
+	Name string
+	Size int64
+}
+
+// BlobLeaseResult is the outcome of a successful Lease Blob acquire, renew, or
+// change operation.
+type BlobLeaseResult struct {
+	LeaseID      string
+	ETag         string
+	LastModified string
+}
+
+// SignedIdentifier is one stored access policy entry on a container (Set/Get
+// Container ACL, ?restype=container&comp=acl). Start/Expiry are RFC3339
+// timestamps, empty when unset.
+type SignedIdentifier struct {
+	ID         string
+	Start      string
+	Expiry     string
+	Permission string
+}
+
 // AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
 // discovered by type assertion. It covers operations with no AWS/GCS equivalent
 // (block staging + commit, metadata/properties/tier updates, snapshots, append
@@ -106,8 +147,11 @@ type AzureBlobExtensions interface {
 	// Properties, ?comp=properties), preserving its content.
 	SetBlobProperties(ctx context.Context, container, blob string, props *BlobProperties) (*ObjectInfo, error)
 	// SetBlobTier sets a blob's access tier (Set Blob Tier, ?comp=tier),
-	// preserving its content and ETag.
-	SetBlobTier(ctx context.Context, container, blob, tier string) error
+	// preserving its content and ETag. tier must be one of Hot/Cool/Cold/
+	// Archive; any other value is an InvalidArgument error. statusCode is 200
+	// when the new tier takes effect immediately or 202 when a blob is
+	// rehydrating out of Archive.
+	SetBlobTier(ctx context.Context, container, blob, tier string) (statusCode int, err error)
 
 	// CreateBlobSnapshot captures an immutable snapshot (Snapshot Blob,
 	// ?comp=snapshot) of a blob, preserving the base blob, and returns the
@@ -132,6 +176,47 @@ type AzureBlobExtensions interface {
 	// ContainerMetadata returns a container's metadata (Get Container Properties /
 	// Get Container Metadata).
 	ContainerMetadata(ctx context.Context, container string) (map[string]string, error)
+
+	// GetBlockList returns the blob's committed and uncommitted blocks (Get
+	// Block List, GET ?comp=blocklist).
+	GetBlockList(ctx context.Context, container, blob string) (committed, uncommitted []BlockInfo, err error)
+
+	// AcquireLease acquires a lease on a blob (Lease Blob, ?comp=lease,
+	// x-ms-lease-action: acquire). durationSeconds is -1 for an infinite lease
+	// or 15-60 for a fixed duration; proposedLeaseID may be empty to let the
+	// provider generate one.
+	AcquireLease(ctx context.Context, container, blob string, durationSeconds int32, proposedLeaseID string) (*BlobLeaseResult, error)
+	// RenewLease renews the blob's current lease.
+	RenewLease(ctx context.Context, container, blob, leaseID string) (*BlobLeaseResult, error)
+	// ChangeLease changes the blob's lease ID.
+	ChangeLease(ctx context.Context, container, blob, leaseID, proposedLeaseID string) (*BlobLeaseResult, error)
+	// ReleaseLease releases the blob's current lease.
+	ReleaseLease(ctx context.Context, container, blob, leaseID string) (*BlobLeaseResult, error)
+	// BreakLease breaks the blob's current lease. breakPeriod is nil when the
+	// caller omitted x-ms-lease-break-period. Returns the seconds remaining
+	// until a new lease may be acquired.
+	BreakLease(ctx context.Context, container, blob string, breakPeriod *int32) (leaseTimeSeconds int32, err error)
+	// CheckBlobLease validates a write/delete request's x-ms-lease-id header
+	// against any active lease on the blob, returning a *BlobOpError when the
+	// request must be rejected. A blob with no active lease and no header
+	// always passes (nil), as does a blob that doesn't exist yet.
+	CheckBlobLease(ctx context.Context, container, blob, headerLeaseID string) error
+
+	// DeleteBlobSnapshots applies the Azure delete-snapshots directive
+	// (x-ms-delete-snapshots: "" | "include" | "only") ahead of a Delete Blob.
+	// mode "" with existing snapshots fails with SnapshotsPresent (409); modes
+	// "include"/"only" delete the blob's snapshots. deleteBaseBlob reports
+	// whether the caller must still delete the base blob itself via
+	// Bucket.DeleteObject (false only for mode "only").
+	DeleteBlobSnapshots(ctx context.Context, container, blob, mode string) (deleteBaseBlob bool, err error)
+
+	// SetContainerAccessPolicy sets a container's public access level and
+	// stored access policies (Set Container ACL,
+	// ?restype=container&comp=acl).
+	SetContainerAccessPolicy(ctx context.Context, container, publicAccess string, policies []SignedIdentifier) error
+	// ContainerAccessPolicy returns a container's public access level and
+	// stored access policies (Get Container ACL).
+	ContainerAccessPolicy(ctx context.Context, container string) (publicAccess string, policies []SignedIdentifier, err error)
 }
 
 // BucketAttributes is an OPTIONAL capability, discovered by type assertion (like


### PR DESCRIPTION
## What

Azure Blob Storage deep-sweep fixes:

**BLOCKER (data loss).** `AcquireLease` had no `comp=lease` route: `dispatchBlobComp`'s switch fell through into the append-blob/copy/plain-Put path, silently overwriting the blob's content with an empty body. Implements a real Lease Blob operation (acquire/renew/change/release/break) as a no-content-touching op, gating writes/deletes on an active lease per the real Azure outcome table (missing lease id -> 412 `LeaseIdMissing`; wrong id -> 412 `LeaseIdMismatchWithBlobOperation`; already-leased acquire -> 409 `LeaseAlreadyPresent`), matching https://learn.microsoft.com/en-us/rest/api/storageservices/lease-blob and the per-operation Delete Blob / Put Blob docs for the write-gating status codes.

**HIGH.** `ListBlobs` never returned `Metadata` or `AccessTier` even with `Include{Metadata:true}` — now emits both (`AccessTier` unconditionally once set, `Metadata` when `include=metadata` is requested), per https://learn.microsoft.com/en-us/rest/api/storageservices/list-blobs.

**HIGH.** `CopyBlob` dropped `BlobType`/`AccessTier`/other system props on the destination — `CopyObject` now carries them from the source.

**MEDIUM.** `DeleteBlob` on a blob with snapshots succeeded unconditionally instead of 409 `SnapshotsPresent` when `x-ms-delete-snapshots` is absent; `include`/`only` now work per https://learn.microsoft.com/en-us/rest/api/storageservices/delete-blob.

**MEDIUM.** `SetTier(Archive)` left the blob immediately downloadable — `GetObject` now rejects reads of an archived blob with 409 `BlobArchived` until it's tiered back to an online tier.

**MEDIUM.** `SetBlobTier` accepted any string — now validates against Hot/Cool/Cold/Archive.

**MEDIUM.** `GET ?comp=blocklist` was misrouted to a plain blob download (404 after `StageBlock` before `CommitBlockList`) — now routes to a real Get Block List returning committed/uncommitted blocks, per https://learn.microsoft.com/en-us/rest/api/storageservices/get-block-list.

**LOW.** Container listing (`GET /?comp=list`) ignored `maxresults`/`marker` — now paginates.

**FEATURE.** Set/Get Container ACL (`?comp=acl`) previously fell through to `CreateContainer` and 409'd on the already-existing container — implemented (public access level + stored access policies).

## Why

These were found in an Azure Blob Storage deep-sweep audit driving the real `azure-sdk-for-go` client against the wire server. The lease finding is a correctness blocker: any caller that acquires a lease before writing loses the blob's prior content.

## Architecture

Fixed in the 3-layer place: extended `services/storage/driver.AzureBlobExtensions` (Azure-only optional capability, no AWS/GCS impact) with lease/block-list/snapshot-delete/container-ACL methods and a `BlobOpError` type for the handful of ops whose status/code don't fit the canonical `cerrors` taxonomy; implemented in `providers/azure/blobstorage`; wired in `server/azure/blobstorage` (new `blob_lease.go` for lease + block-list + ACL routes, plus targeted changes in `handler.go`/`blob_extensions.go`/`types.go`).

`docs/coverage/` regenerated via `go generate` (coveragegen + compatgen); `docs/coverage/aws/s3.md` and `gcp/gcs.md` also picked up the new `AzureBlobExtensions` interface entries since that doc section documents the whole `services/storage/driver` package shared across providers — not new AWS/GCP behavior.

## Testing

New `server/azure/blobstorage/blob_lease_test.go` drives the real `azure-sdk-for-go` `azblob`/`lease`/`container` clients against a live `httptest` wire server for every fix above, including the lease data-loss regression test. All existing tests pass; `docs/compat` regenerated clean (compatgen exit 0).