### PR TITLE
fix(azure-vnet): public IP delete/RG isolation/double-attach, NAT gateway ARM support

### DIFF
--- a/providers/aws/vpc/elastic_ip.go
+++ b/providers/aws/vpc/elastic_ip.go
@@ -19,6 +19,8 @@ type eipData struct {
 }
 
 // AllocateAddress allocates a new elastic IP address.
+//
+//nolint:gocritic // hugeParam: cfg is passed by value to satisfy the Networking driver interface.
 func (m *Mock) AllocateAddress(
 	_ context.Context, cfg driver.ElasticIPConfig,
 ) (*driver.ElasticIP, error) {

--- a/providers/azure/vnet/elastic_ip.go
+++ b/providers/azure/vnet/elastic_ip.go
@@ -9,16 +9,28 @@ import (
 )
 
 type eipData struct {
-	AllocationID     string
-	PublicIP         string
-	AssociationID    string
-	InstanceID       string
-	Tags             map[string]string
-	SKU              string
-	AllocationMethod string
+	AllocationID       string
+	PublicIP           string
+	AssociationID      string
+	InstanceID         string
+	Tags               map[string]string
+	SKU                string
+	AllocationMethod   string
+	Zones              []string
+	IdleTimeoutMinutes int
+	DNSDomainNameLabel string
+	DNSFQDN            string
 }
 
+// defaultFQDNRegion is the region segment used to build a mock DNS FQDN for a
+// public IP's domainNameLabel. Real Azure computes this from the resource's
+// actual location plus a per-cloud hash segment; a fixed region keeps the mock
+// deterministic without threading location through ElasticIPConfig.
+const defaultFQDNRegion = "eastus"
+
 // AllocateAddress allocates a new public IP address.
+//
+//nolint:gocritic // hugeParam: cfg is passed by value to satisfy the Networking driver interface.
 func (m *Mock) AllocateAddress(
 	_ context.Context, cfg driver.ElasticIPConfig,
 ) (*driver.ElasticIP, error) {
@@ -37,12 +49,20 @@ func (m *Mock) AllocateAddress(
 	}
 
 	eip := &eipData{
-		AllocationID:     allocID,
-		PublicIP:         mockPublicIP(allocID),
-		Tags:             copyTags(cfg.Tags),
-		SKU:              sku,
-		AllocationMethod: allocMethod,
+		AllocationID:       allocID,
+		PublicIP:           mockPublicIP(allocID),
+		Tags:               copyTags(cfg.Tags),
+		SKU:                sku,
+		AllocationMethod:   allocMethod,
+		Zones:              append([]string(nil), cfg.Zones...),
+		IdleTimeoutMinutes: cfg.IdleTimeoutMinutes,
+		DNSDomainNameLabel: cfg.DNSDomainNameLabel,
 	}
+
+	if cfg.DNSDomainNameLabel != "" {
+		eip.DNSFQDN = cfg.DNSDomainNameLabel + "." + defaultFQDNRegion + ".cloudapp.azure.com"
+	}
+
 	m.eips.Set(allocID, eip)
 
 	info := toEIPInfo(eip)
@@ -129,12 +149,16 @@ func (m *Mock) DisassociateAddress(
 
 func toEIPInfo(eip *eipData) driver.ElasticIP {
 	return driver.ElasticIP{
-		AllocationID:     eip.AllocationID,
-		PublicIP:         eip.PublicIP,
-		AssociationID:    eip.AssociationID,
-		InstanceID:       eip.InstanceID,
-		Tags:             copyTags(eip.Tags),
-		SKU:              eip.SKU,
-		AllocationMethod: eip.AllocationMethod,
+		AllocationID:       eip.AllocationID,
+		PublicIP:           eip.PublicIP,
+		AssociationID:      eip.AssociationID,
+		InstanceID:         eip.InstanceID,
+		Tags:               copyTags(eip.Tags),
+		SKU:                eip.SKU,
+		AllocationMethod:   eip.AllocationMethod,
+		Zones:              append([]string(nil), eip.Zones...),
+		IdleTimeoutMinutes: eip.IdleTimeoutMinutes,
+		DNSDomainNameLabel: eip.DNSDomainNameLabel,
+		DNSFQDN:            eip.DNSFQDN,
 	}
 }

--- a/providers/azure/vnet/nat_gateway.go
+++ b/providers/azure/vnet/nat_gateway.go
@@ -21,29 +21,52 @@ type natGatewayData struct {
 	State     string
 	CreatedAt string
 	Tags      map[string]string
+	// AllocationID is the Elastic IP allocation bound to this NAT gateway, set
+	// when the caller passes NATGatewayConfig.AllocationID. Unlike AWS, an
+	// Azure NAT gateway is not bound to a subnet at creation time (subnets
+	// attach to it afterwards via their own natGateway reference), so SubnetID
+	// stays empty for the Azure wire handler's normal flow.
+	AllocationID string
 }
 
-// CreateNATGateway creates a NAT gateway in the specified subnet.
+// CreateNATGateway creates a NAT gateway, optionally binding it to a subnet
+// (AWS-style, if a caller passes one) and/or a public IP allocation (Azure's
+// natGateways.properties.publicIpAddresses). Binding an already-associated
+// allocation is rejected, matching a public IP that can only serve one
+// resource at a time.
 func (m *Mock) CreateNATGateway(_ context.Context, cfg driver.NATGatewayConfig) (*driver.NATGateway, error) {
-	if cfg.SubnetID == "" {
-		return nil, cerrors.New(cerrors.InvalidArgument, "subnet ID is required")
-	}
+	var vpcID string
 
-	subnet, ok := m.subnets.Get(cfg.SubnetID)
-	if !ok {
-		return nil, cerrors.Newf(cerrors.NotFound, "subnet %q not found", cfg.SubnetID)
+	if cfg.SubnetID != "" {
+		subnet, ok := m.subnets.Get(cfg.SubnetID)
+		if !ok {
+			return nil, cerrors.Newf(cerrors.NotFound, "subnet %q not found", cfg.SubnetID)
+		}
+
+		vpcID = subnet.VPCID
 	}
 
 	id := idgen.GenerateID("natgw-")
+
 	nat := &natGatewayData{
 		ID:        id,
 		SubnetID:  cfg.SubnetID,
-		VPCID:     subnet.VPCID,
-		PublicIP:  mockPublicIP(id),
+		VPCID:     vpcID,
 		State:     NATStateAvailable,
 		CreatedAt: m.opts.Clock.Now().Format(timeFormat),
 		Tags:      copyTags(cfg.Tags),
 	}
+
+	if cfg.AllocationID != "" {
+		publicIP, err := m.bindNATGatewayAllocation(cfg.AllocationID)
+		if err != nil {
+			return nil, err
+		}
+
+		nat.AllocationID = cfg.AllocationID
+		nat.PublicIP = publicIP
+	}
+
 	m.natGateways.Set(id, nat)
 
 	info := toNATGatewayInfo(nat)
@@ -51,10 +74,55 @@ func (m *Mock) CreateNATGateway(_ context.Context, cfg driver.NATGatewayConfig) 
 	return &info, nil
 }
 
-// DeleteNATGateway deletes the NAT gateway with the given ID.
+// bindNATGatewayAllocation atomically marks the given Elastic IP allocation as
+// associated (rejecting one already in use) and returns its address, so the
+// check-and-set can't race a concurrent AssociateAddress/CreateNATGateway call.
+func (m *Mock) bindNATGatewayAllocation(allocationID string) (string, error) {
+	var (
+		conflict error
+		address  string
+	)
+
+	found := m.eips.Update(allocationID, func(e *eipData) *eipData {
+		if e.AssociationID != "" {
+			conflict = cerrors.Newf(cerrors.FailedPrecondition,
+				"public IP %q is already associated", allocationID)
+
+			return e
+		}
+
+		e.AssociationID = idgen.GenerateID("natgwassoc-")
+		address = e.PublicIP
+
+		return e
+	})
+
+	if !found {
+		return "", cerrors.Newf(cerrors.NotFound, "public IP %q not found", allocationID)
+	}
+
+	if conflict != nil {
+		return "", conflict
+	}
+
+	return address, nil
+}
+
+// DeleteNATGateway deletes the NAT gateway with the given ID, freeing any
+// bound Elastic IP allocation so it can be released or reused.
 func (m *Mock) DeleteNATGateway(_ context.Context, id string) error {
-	if !m.natGateways.Delete(id) {
+	nat, ok := m.natGateways.Get(id)
+	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "NAT gateway %q not found", id)
+	}
+
+	m.natGateways.Delete(id)
+
+	if nat.AllocationID != "" {
+		m.eips.Update(nat.AllocationID, func(e *eipData) *eipData {
+			e.AssociationID = ""
+			return e
+		})
 	}
 
 	return nil
@@ -67,12 +135,13 @@ func (m *Mock) DescribeNATGateways(_ context.Context, ids []string) ([]driver.NA
 
 func toNATGatewayInfo(n *natGatewayData) driver.NATGateway {
 	return driver.NATGateway{
-		ID:        n.ID,
-		SubnetID:  n.SubnetID,
-		VPCID:     n.VPCID,
-		PublicIP:  n.PublicIP,
-		State:     n.State,
-		CreatedAt: n.CreatedAt,
-		Tags:      copyTags(n.Tags),
+		ID:           n.ID,
+		SubnetID:     n.SubnetID,
+		VPCID:        n.VPCID,
+		PublicIP:     n.PublicIP,
+		State:        n.State,
+		CreatedAt:    n.CreatedAt,
+		Tags:         copyTags(n.Tags),
+		AllocationID: n.AllocationID,
 	}
 }

--- a/providers/azure/vnet/vnet_test.go
+++ b/providers/azure/vnet/vnet_test.go
@@ -478,12 +478,19 @@ func TestAcceptPeeringConnection(t *testing.T) {
 	})
 }
 
+// TestCreateNATGateway covers Azure's actual creation semantics: unlike AWS, a
+// NAT gateway is not bound to a subnet at creation time (subnets attach to it
+// afterwards via their own natGateway reference), so an empty config succeeds.
+// A supplied AllocationID must resolve to a real, unassociated public IP.
 func TestCreateNATGateway(t *testing.T) {
 	ctx := context.Background()
 	m := newTestMock()
 	vpcID := createTestVPC(t, m)
 
 	subnet, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpcID, CIDRBlock: "10.0.1.0/24"})
+	require.NoError(t, err)
+
+	eip, err := m.AllocateAddress(ctx, driver.ElasticIPConfig{})
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -493,17 +500,21 @@ func TestCreateNATGateway(t *testing.T) {
 		errMsg  string
 	}{
 		{
-			name: "success",
-			cfg:  driver.NATGatewayConfig{SubnetID: subnet.ID, Tags: map[string]string{"env": "test"}},
+			name: "no subnet or public IP",
+			cfg:  driver.NATGatewayConfig{Tags: map[string]string{"env": "test"}},
 		},
 		{
-			name:    "empty subnet",
-			cfg:     driver.NATGatewayConfig{},
-			wantErr: true, errMsg: "subnet ID is required",
+			name: "bound to subnet and public IP",
+			cfg:  driver.NATGatewayConfig{SubnetID: subnet.ID, AllocationID: eip.AllocationID},
 		},
 		{
 			name:    "subnet not found",
 			cfg:     driver.NATGatewayConfig{SubnetID: "subnet-missing"},
+			wantErr: true, errMsg: "not found",
+		},
+		{
+			name:    "allocation not found",
+			cfg:     driver.NATGatewayConfig{AllocationID: "eip-missing"},
 			wantErr: true, errMsg: "not found",
 		},
 	}
@@ -519,13 +530,58 @@ func TestCreateNATGateway(t *testing.T) {
 			default:
 				require.NoError(t, err)
 				assert.NotEmpty(t, nat.ID)
-				assert.Equal(t, subnet.ID, nat.SubnetID)
-				assert.Equal(t, vpcID, nat.VPCID)
+				assert.Equal(t, tt.cfg.SubnetID, nat.SubnetID)
 				assert.Equal(t, "available", nat.State)
-				assert.NotEmpty(t, nat.PublicIP)
+
+				if tt.cfg.AllocationID != "" {
+					assert.Equal(t, tt.cfg.AllocationID, nat.AllocationID)
+					assert.NotEmpty(t, nat.PublicIP)
+				} else {
+					assert.Empty(t, nat.PublicIP)
+				}
 			}
 		})
 	}
+}
+
+// TestCreateNATGatewayAllocationAlreadyAssociated guards the atomic
+// check-and-set in bindNATGatewayAllocation: a public IP already bound to one
+// NAT gateway cannot be bound to a second.
+func TestCreateNATGatewayAllocationAlreadyAssociated(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	eip, err := m.AllocateAddress(ctx, driver.ElasticIPConfig{})
+	require.NoError(t, err)
+
+	_, err = m.CreateNATGateway(ctx, driver.NATGatewayConfig{AllocationID: eip.AllocationID})
+	require.NoError(t, err)
+
+	_, err = m.CreateNATGateway(ctx, driver.NATGatewayConfig{AllocationID: eip.AllocationID})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already associated")
+}
+
+// TestDeleteNATGatewayReleasesAllocation guards the DeleteNATGateway fix: the
+// bound public IP must be releasable again once the NAT gateway is gone.
+func TestDeleteNATGatewayReleasesAllocation(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	eip, err := m.AllocateAddress(ctx, driver.ElasticIPConfig{})
+	require.NoError(t, err)
+
+	nat, err := m.CreateNATGateway(ctx, driver.NATGatewayConfig{AllocationID: eip.AllocationID})
+	require.NoError(t, err)
+
+	// The allocation is in use: release must be refused.
+	err = m.ReleaseAddress(ctx, eip.AllocationID)
+	require.Error(t, err)
+
+	require.NoError(t, m.DeleteNATGateway(ctx, nat.ID))
+
+	// Freed by the delete: release now succeeds.
+	require.NoError(t, m.ReleaseAddress(ctx, eip.AllocationID))
 }
 
 func TestCreateFlowLog(t *testing.T) {

--- a/providers/gcp/vpc/elastic_ip.go
+++ b/providers/gcp/vpc/elastic_ip.go
@@ -17,6 +17,8 @@ type eipData struct {
 }
 
 // AllocateAddress reserves a new external IP address.
+//
+//nolint:gocritic // hugeParam: cfg is passed by value to satisfy the Networking driver interface.
 func (m *Mock) AllocateAddress(
 	_ context.Context, cfg driver.ElasticIPConfig,
 ) (*driver.ElasticIP, error) {

--- a/providers/oci/vcn/public_ip.go
+++ b/providers/oci/vcn/public_ip.go
@@ -28,6 +28,8 @@ type publicIPData struct {
 
 // AllocateAddress reserves a public IP. cfg.AllocationMethod carries OCI's
 // lifetime, defaulting to RESERVED.
+//
+//nolint:gocritic // hugeParam: cfg is passed by value to satisfy the Networking driver interface.
 func (m *Mock) AllocateAddress(_ context.Context, cfg driver.ElasticIPConfig) (*driver.ElasticIP, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -27,17 +27,23 @@ import (
 )
 
 const (
-	providerName   = "Microsoft.Network"
-	typeVNet       = "virtualNetworks"
-	typeNSG        = "networkSecurityGroups"
-	typePublicIP   = "publicIPAddresses"
-	typeLocations  = "locations"
-	armNameTag     = "cloudemu:azureNetName"
-	armSubnetTag   = "cloudemu:azureSubnet"
-	armNSGTag      = "cloudemu:azureNSGName"
-	armPublicIPTag = "cloudemu:azurePublicIP"
-	defaultLoc     = "eastus"
-	subResSubnets  = "subnets"
+	providerName     = "Microsoft.Network"
+	typeVNet         = "virtualNetworks"
+	typeNSG          = "networkSecurityGroups"
+	typePublicIP     = "publicIPAddresses"
+	typeLocations    = "locations"
+	armNameTag       = "cloudemu:azureNetName"
+	armSubnetTag     = "cloudemu:azureSubnet"
+	armNSGTag        = "cloudemu:azureNSGName"
+	armPublicIPTag   = "cloudemu:azurePublicIP"
+	armPublicIPRGTag = "cloudemu:azurePublicIPResourceGroup"
+	// armSubnetNATTag stores the full ARM resource id of the NAT gateway a
+	// subnet is associated with (set via the subnet's own natGateway
+	// property), so both the subnet response and the NAT gateway's
+	// read-only subnets list can reflect the association.
+	armSubnetNATTag = "cloudemu:azureSubnetNATGateway"
+	defaultLoc      = "eastus"
+	subResSubnets   = "subnets"
 )
 
 // Handler serves Microsoft.Network ARM requests against a networking driver.
@@ -64,7 +70,7 @@ func (*Handler) Matches(r *http.Request) bool {
 	}
 
 	switch rp.ResourceType {
-	case typeVNet, typeNSG, typePublicIP, typeNIC, typeLocations:
+	case typeVNet, typeNSG, typePublicIP, typeNIC, typeNATGateway, typeLocations:
 		return true
 	}
 
@@ -97,6 +103,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routePublicIP(w, r, rp)
 	case typeNIC:
 		h.routeNIC(w, r, rp)
+	case typeNATGateway:
+		h.routeNATGateway(w, r, rp)
 	default:
 		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
 			"unsupported resource type: "+rp.ResourceType)
@@ -415,13 +423,24 @@ func (h *Handler) createSubnet(w http.ResponseWriter, r *http.Request, rp azurea
 		return
 	}
 
-	cfg := netdriver.SubnetConfig{
-		VPCID:     vnet.ID,
-		CIDRBlock: req.Properties.AddressPrefix,
-		Tags:      mergeTags(nil, armSubnetTag, rp.SubResourceName),
+	var natGatewayID string
+
+	if req.Properties.NatGateway != nil {
+		ngRP, ok := azurearm.ParsePath(req.Properties.NatGateway.ID)
+		if !ok || ngRP.ResourceType != typeNATGateway {
+			azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "malformed natGateway id")
+			return
+		}
+
+		if _, ngErr := findNATGatewayByName(r.Context(), h.net, ngRP.ResourceGroup, ngRP.ResourceName); ngErr != nil {
+			azurearm.WriteCErr(w, ngErr)
+			return
+		}
+
+		natGatewayID = req.Properties.NatGateway.ID
 	}
 
-	info, err := h.net.CreateSubnet(r.Context(), cfg)
+	info, err := h.upsertSubnet(r.Context(), vnet.ID, rp.SubResourceName, req.Properties.AddressPrefix, natGatewayID)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -430,6 +449,56 @@ func (h *Handler) createSubnet(w http.ResponseWriter, r *http.Request, rp azurea
 	body := toSubnetResponse(info, rp)
 
 	writeAcceptedAsync(w, r, rp.Subscription, "subnet-create-"+rp.SubResourceName, body)
+}
+
+// upsertSubnet creates the named subnet, or — when it already exists — merges
+// in a NAT gateway reference so a subnet can be attached to a NAT gateway via
+// a second PUT (armnetwork's SubnetsClient.BeginCreateOrUpdate, the real ARM
+// mechanism: the association lives on the subnet's natGateway property, not
+// on the NAT gateway). Other subnet properties are not merged on update,
+// matching this handler's existing create-only behavior for subnets.
+func (h *Handler) upsertSubnet(ctx context.Context, vpcID, name, cidr, natGatewayID string) (*netdriver.SubnetInfo, error) {
+	if existing, err := findSubnetInVNet(ctx, h.net, vpcID, name); err == nil {
+		if natGatewayID == "" {
+			return existing, nil
+		}
+
+		if err := h.net.UpdateSubnetTags(ctx, existing.ID, map[string]string{armSubnetNATTag: natGatewayID}); err != nil {
+			return nil, err
+		}
+
+		existing.Tags = mergeTags(existing.Tags, armSubnetNATTag, natGatewayID)
+
+		return existing, nil
+	}
+
+	tags := mergeTags(nil, armSubnetTag, name)
+	if natGatewayID != "" {
+		tags = mergeTags(tags, armSubnetNATTag, natGatewayID)
+	}
+
+	return h.net.CreateSubnet(ctx, netdriver.SubnetConfig{
+		VPCID:     vpcID,
+		CIDRBlock: cidr,
+		Tags:      tags,
+	})
+}
+
+// findSubnetInVNet resolves a subnet by (vnet, name) — subnet names are only
+// unique within a vnet — mirroring subnetCIDR's scoped lookup.
+func findSubnetInVNet(ctx context.Context, n netdriver.Networking, vpcID, name string) (*netdriver.SubnetInfo, error) {
+	subs, err := n.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range subs {
+		if subs[i].VPCID == vpcID && tagOr(subs[i].Tags, armSubnetTag, "") == name {
+			return &subs[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "subnet %s not found", name)
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -610,6 +679,8 @@ func (h *Handler) routePublicIP(w http.ResponseWriter, r *http.Request, rp azure
 		h.createPublicIP(w, r, rp)
 	case http.MethodGet:
 		h.getPublicIP(w, r, rp)
+	case http.MethodDelete:
+		h.deletePublicIP(w, r, rp)
 	default:
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
@@ -633,10 +704,19 @@ func (h *Handler) createPublicIP(w http.ResponseWriter, r *http.Request, rp azur
 		sku = req.SKU.Name
 	}
 
+	tags := mergeTags(req.Tags, armPublicIPTag, rp.ResourceName)
+	tags = mergeTags(tags, armPublicIPRGTag, rp.ResourceGroup)
+
 	cfg := netdriver.ElasticIPConfig{
-		SKU:              sku,
-		AllocationMethod: req.Properties.PublicIPAllocationMethod,
-		Tags:             mergeTags(req.Tags, armPublicIPTag, rp.ResourceName),
+		SKU:                sku,
+		AllocationMethod:   req.Properties.PublicIPAllocationMethod,
+		Tags:               tags,
+		Zones:              req.Zones,
+		IdleTimeoutMinutes: req.Properties.IdleTimeoutInMinutes,
+	}
+
+	if req.Properties.DNSSettings != nil {
+		cfg.DNSDomainNameLabel = req.Properties.DNSSettings.DomainNameLabel
 	}
 
 	info, err := h.net.AllocateAddress(r.Context(), cfg)
@@ -650,23 +730,65 @@ func (h *Handler) createPublicIP(w http.ResponseWriter, r *http.Request, rp azur
 		loc = defaultLoc
 	}
 
-	body := toPublicIPResponse(info, rp, loc)
+	body := h.toPublicIPResponse(r.Context(), info, rp, loc)
 
 	writeAcceptedAsync(w, r, rp.Subscription, "publicip-create-"+rp.ResourceName, body)
 }
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) getPublicIP(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	info, err := findPublicIPByName(r.Context(), h.net, rp.ResourceName)
+	info, err := findPublicIPByName(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toPublicIPResponse(info, rp, defaultLoc))
+	azurearm.WriteJSON(w, http.StatusOK, h.toPublicIPResponse(r.Context(), info, rp, defaultLoc))
 }
 
 //nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deletePublicIP(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := findPublicIPByName(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	// A NIC's ipConfiguration reference doesn't go through
+	// AssociateAddress/eip.AssociationID (that's reserved for AWS-style
+	// instance/NAT-gateway attachment), so it needs its own in-use check here
+	// — the same scan the ipConfiguration back-reference already does.
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typePublicIP, rp.ResourceName)
+
+	if h.publicIPConfigurationRef(r.Context(), rp.Subscription, id) != nil {
+		azurearm.WriteError(w, http.StatusBadRequest, "PublicIPAddressCannotBeDeleted",
+			"public IP "+rp.ResourceName+" is still referenced by a network interface ipConfiguration")
+
+		return
+	}
+
+	if err := h.net.ReleaseAddress(r.Context(), info.AllocationID); err != nil {
+		// A public IP still bound to a NIC/NAT gateway: ARM answers 400 with
+		// this specific code, not the generic 409 WriteCErr would emit.
+		if cerrors.IsFailedPrecondition(err) {
+			azurearm.WriteError(w, http.StatusBadRequest, "PublicIPAddressCannotBeDeleted", err.Error())
+			return
+		}
+
+		azurearm.WriteCErr(w, err)
+
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "publicip-delete-"+rp.ResourceName, nil)
+}
+
+// listPublicIPs lists public IPs in rp's resource group, or every public IP in
+// the subscription when the request path carries no resource group (ARM
+// supports both .../resourceGroups/{rg}/.../publicIPAddresses and the
+// subscription-wide .../providers/Microsoft.Network/publicIPAddresses).
+//
+//nolint:gocritic,dupl // rp is request-scoped; mirrors listNATGateways over a distinct resource type by design
 func (h *Handler) listPublicIPs(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	infos, err := h.net.DescribeAddresses(r.Context(), nil)
 	if err != nil {
@@ -677,9 +799,14 @@ func (h *Handler) listPublicIPs(w http.ResponseWriter, r *http.Request, rp azure
 	out := publicIPListResponse{}
 
 	for i := range infos {
+		if rp.ResourceGroup != "" && tagOr(infos[i].Tags, armPublicIPRGTag, "") != rp.ResourceGroup {
+			continue
+		}
+
 		scope := rp
+		scope.ResourceGroup = tagOr(infos[i].Tags, armPublicIPRGTag, rp.ResourceGroup)
 		scope.ResourceName = tagOr(infos[i].Tags, armPublicIPTag, infos[i].AllocationID)
-		out.Value = append(out.Value, toPublicIPResponse(&infos[i], scope, defaultLoc))
+		out.Value = append(out.Value, h.toPublicIPResponse(r.Context(), &infos[i], scope, defaultLoc))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, out)
@@ -732,16 +859,25 @@ func findNSGByName(ctx context.Context, n netdriver.Networking, name string) (*n
 	return nil, cerrors.Newf(cerrors.NotFound, "networkSecurityGroup %s not found", name)
 }
 
-func findPublicIPByName(ctx context.Context, n netdriver.Networking, name string) (*netdriver.ElasticIP, error) {
+// findPublicIPByName matches by both the ARM name tag and, when rg is
+// non-empty, the resource-group tag — a public IP in a different resource
+// group with the same name must not match (see armPublicIPRGTag).
+func findPublicIPByName(ctx context.Context, n netdriver.Networking, rg, name string) (*netdriver.ElasticIP, error) {
 	infos, err := n.DescribeAddresses(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	for i := range infos {
-		if tagOr(infos[i].Tags, armPublicIPTag, "") == name {
-			return &infos[i], nil
+		if tagOr(infos[i].Tags, armPublicIPTag, "") != name {
+			continue
 		}
+
+		if rg != "" && tagOr(infos[i].Tags, armPublicIPRGTag, "") != rg {
+			continue
+		}
+
+		return &infos[i], nil
 	}
 
 	return nil, cerrors.Newf(cerrors.NotFound, "publicIPAddress %s not found", name)
@@ -819,7 +955,7 @@ func toSubnetResponse(info *netdriver.SubnetInfo, rp azurearm.ResourcePath) subn
 		"/providers/" + providerName + "/" + typeVNet +
 		"/" + rp.ResourceName + "/subnets/" + name
 
-	return subnetResponse{
+	out := subnetResponse{
 		ID:   id,
 		Name: name,
 		Etag: etagOf(id),
@@ -828,6 +964,12 @@ func toSubnetResponse(info *netdriver.SubnetInfo, rp azurearm.ResourcePath) subn
 			AddressPrefix:     info.CIDRBlock,
 		},
 	}
+
+	if ngID := tagOr(info.Tags, armSubnetNATTag, ""); ngID != "" {
+		out.Properties.NatGateway = &armIDRef{ID: ngID}
+	}
+
+	return out
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -864,21 +1006,27 @@ func (h *Handler) nsgResponse(ctx context.Context, info *netdriver.SecurityGroup
 }
 
 //nolint:gocritic // rp is a request-scoped value
-func toPublicIPResponse(info *netdriver.ElasticIP, rp azurearm.ResourcePath, location string) publicIPResponse {
+func (h *Handler) toPublicIPResponse(
+	ctx context.Context, info *netdriver.ElasticIP, rp azurearm.ResourcePath, location string,
+) publicIPResponse {
 	if location == "" {
 		location = defaultLoc
 	}
 
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typePublicIP, rp.ResourceName)
+
 	out := publicIPResponse{
-		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typePublicIP, rp.ResourceName),
+		ID:       id,
 		Name:     rp.ResourceName,
 		Type:     providerName + "/" + typePublicIP,
 		Location: location,
 		Tags:     stripInternal(info.Tags),
+		Zones:    info.Zones,
 		Properties: publicIPRespProps{
 			ProvisioningState:        "Succeeded",
 			PublicIPAllocationMethod: info.AllocationMethod,
 			IPAddress:                info.PublicIP,
+			IdleTimeoutInMinutes:     info.IdleTimeoutMinutes,
 		},
 	}
 
@@ -886,7 +1034,42 @@ func toPublicIPResponse(info *netdriver.ElasticIP, rp azurearm.ResourcePath, loc
 		out.SKU = &publicIPSKU{Name: info.SKU}
 	}
 
+	if info.DNSDomainNameLabel != "" {
+		out.Properties.DNSSettings = &publicIPDNSSettings{
+			DomainNameLabel: info.DNSDomainNameLabel,
+			FQDN:            info.DNSFQDN,
+		}
+	}
+
+	out.Properties.IPConfiguration = h.publicIPConfigurationRef(ctx, rp.Subscription, id)
+
 	return out
+}
+
+// publicIPConfigurationRef scans network interfaces for an ipConfiguration
+// referencing the public IP with the given ARM id, matching the back-reference
+// a real publicIPAddresses GET reports once a NIC attaches the address (mirrors
+// vnetResponse's subnet-by-VPCID scan and vnetSubnetInUse's NIC scan).
+func (h *Handler) publicIPConfigurationRef(ctx context.Context, sub, publicIPARMID string) *armIDRef {
+	svc, ok := h.net.(netdriver.AzureNetworkInterfaces)
+	if !ok {
+		return nil
+	}
+
+	nics, err := svc.ListNetworkInterfaces(ctx, "")
+	if err != nil {
+		return nil
+	}
+
+	for i := range nics {
+		for j := range nics[i].IPConfigs {
+			if strings.EqualFold(nics[i].IPConfigs[j].PublicIPID, publicIPARMID) {
+				return &armIDRef{ID: ipConfigResourceID(sub, nics[i].ResourceGroup, nics[i].Name, nics[i].IPConfigs[j].Name)}
+			}
+		}
+	}
+
+	return nil
 }
 
 // writeAcceptedAsync replies for create/delete operations. armnetwork's

--- a/server/azure/vnet/nat_gateway.go
+++ b/server/azure/vnet/nat_gateway.go
@@ -1,0 +1,345 @@
+package vnet
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+const (
+	typeNATGateway   = "natGateways"
+	armNATGatewayTag = "cloudemu:azureNatGatewayName"
+	// armNATGatewayRGTag scopes NAT gateway lookups to the resource group they
+	// were created in, the same isolation fix applied to public IPs.
+	armNATGatewayRGTag = "cloudemu:azureNatGatewayResourceGroup"
+)
+
+// ARM JSON shapes for Microsoft.Network/natGateways.
+
+type natGatewayRequest struct {
+	Location   string                 `json:"location"`
+	Tags       map[string]string      `json:"tags,omitempty"`
+	SKU        *natGatewaySKU         `json:"sku,omitempty"`
+	Zones      []string               `json:"zones,omitempty"`
+	Properties natGatewayRequestProps `json:"properties"`
+}
+
+type natGatewaySKU struct {
+	Name string `json:"name,omitempty"`
+}
+
+type natGatewayRequestProps struct {
+	IdleTimeoutInMinutes int        `json:"idleTimeoutInMinutes,omitempty"`
+	PublicIPAddresses    []armIDRef `json:"publicIpAddresses,omitempty"`
+}
+
+type natGatewayResponse struct {
+	ID         string                  `json:"id"`
+	Name       string                  `json:"name"`
+	Type       string                  `json:"type"`
+	Location   string                  `json:"location"`
+	Tags       map[string]string       `json:"tags,omitempty"`
+	SKU        *natGatewaySKU          `json:"sku,omitempty"`
+	Zones      []string                `json:"zones,omitempty"`
+	Etag       string                  `json:"etag,omitempty"`
+	Properties natGatewayResponseProps `json:"properties"`
+}
+
+type natGatewayResponseProps struct {
+	ProvisioningState    string     `json:"provisioningState"`
+	IdleTimeoutInMinutes int        `json:"idleTimeoutInMinutes,omitempty"`
+	PublicIPAddresses    []armIDRef `json:"publicIpAddresses,omitempty"`
+	// Subnets is read-only in real ARM: a subnet attaches to a NAT gateway by
+	// setting its own natGateway property, not the other way around. It is
+	// populated here by scanning subnets for that back-reference.
+	Subnets []armIDRef `json:"subnets,omitempty"`
+}
+
+type natGatewayListResponse struct {
+	Value []natGatewayResponse `json:"value"`
+}
+
+// routeNATGateway dispatches Microsoft.Network/natGateways requests.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) routeNATGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.ResourceName == "" {
+		h.listNATGateways(w, r, rp)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createNATGateway(w, r, rp)
+	case http.MethodGet:
+		h.getNATGateway(w, r, rp)
+	case http.MethodDelete:
+		h.deleteNATGateway(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) createNATGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	var req natGatewayRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	tags := mergeTags(req.Tags, armNATGatewayTag, rp.ResourceName)
+	tags = mergeTags(tags, armNATGatewayRGTag, rp.ResourceGroup)
+
+	cfg := netdriver.NATGatewayConfig{
+		Tags:             tags,
+		ConnectivityType: "public",
+	}
+
+	allocationID, err := h.resolveNATGatewayAllocation(r.Context(), req.Properties.PublicIPAddresses)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	cfg.AllocationID = allocationID
+
+	info, err := h.upsertNATGateway(r.Context(), rp.ResourceGroup, rp.ResourceName, cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	loc := req.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	body := h.natGatewayResponse(r.Context(), info, rp, loc)
+
+	// SKU / zones / idleTimeoutInMinutes aren't part of the cross-cloud NAT
+	// gateway model, so they don't survive a later GET; echo what the caller
+	// just submitted on the create response, matching real ARM's create-time
+	// body while keeping the driver AWS/Azure/GCP-portable.
+	if req.SKU != nil {
+		body.SKU = req.SKU
+	}
+
+	if len(req.Zones) > 0 {
+		body.Zones = req.Zones
+	}
+
+	if req.Properties.IdleTimeoutInMinutes > 0 {
+		body.Properties.IdleTimeoutInMinutes = req.Properties.IdleTimeoutInMinutes
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "natgw-create-"+rp.ResourceName, body)
+}
+
+// resolveNATGatewayAllocation resolves the first entry of a natGateways PUT
+// body's properties.publicIpAddresses to the driver Elastic IP allocation id
+// CreateNATGateway expects. Real Azure supports multiple public IPs per NAT
+// gateway; this mock binds only the first, matching the cross-cloud driver
+// model's single AllocationID.
+func (h *Handler) resolveNATGatewayAllocation(ctx context.Context, publicIPAddresses []armIDRef) (string, error) {
+	if len(publicIPAddresses) == 0 {
+		return "", nil
+	}
+
+	pipID := publicIPAddresses[0].ID
+
+	pipRP, ok := azurearm.ParsePath(pipID)
+	if !ok || pipRP.ResourceType != typePublicIP {
+		return "", cerrors.Newf(cerrors.InvalidArgument, "malformed publicIpAddresses[0].id %q", pipID)
+	}
+
+	pip, err := findPublicIPByName(ctx, h.net, pipRP.ResourceGroup, pipRP.ResourceName)
+	if err != nil {
+		return "", err
+	}
+
+	return pip.AllocationID, nil
+}
+
+// upsertNATGateway reuses an existing NAT gateway of the same name (idempotent
+// re-PUT) or creates one.
+func (h *Handler) upsertNATGateway(ctx context.Context, rg, name string, cfg netdriver.NATGatewayConfig) (*netdriver.NATGateway, error) {
+	if existing, err := findNATGatewayByName(ctx, h.net, rg, name); err == nil {
+		return existing, nil
+	}
+
+	return h.net.CreateNATGateway(ctx, cfg)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getNATGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := findNATGatewayByName(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, h.natGatewayResponse(r.Context(), info, rp, defaultLoc))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteNATGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := findNATGatewayByName(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.net.DeleteNATGateway(r.Context(), info.ID); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "natgw-delete-"+rp.ResourceName, nil)
+}
+
+//nolint:gocritic,dupl // rp is request-scoped; mirrors listPublicIPs over a distinct resource type by design
+func (h *Handler) listNATGateways(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	infos, err := h.net.DescribeNATGateways(r.Context(), nil)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := natGatewayListResponse{}
+
+	for i := range infos {
+		if rp.ResourceGroup != "" && tagOr(infos[i].Tags, armNATGatewayRGTag, "") != rp.ResourceGroup {
+			continue
+		}
+
+		scope := rp
+		scope.ResourceGroup = tagOr(infos[i].Tags, armNATGatewayRGTag, rp.ResourceGroup)
+		scope.ResourceName = tagOr(infos[i].Tags, armNATGatewayTag, infos[i].ID)
+		out.Value = append(out.Value, h.natGatewayResponse(r.Context(), &infos[i], scope, defaultLoc))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+// findNATGatewayByName matches by both the ARM name tag and, when rg is
+// non-empty, the resource-group tag (see armNATGatewayRGTag).
+func findNATGatewayByName(ctx context.Context, n netdriver.Networking, rg, name string) (*netdriver.NATGateway, error) {
+	infos, err := n.DescribeNATGateways(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range infos {
+		if tagOr(infos[i].Tags, armNATGatewayTag, "") != name {
+			continue
+		}
+
+		if rg != "" && tagOr(infos[i].Tags, armNATGatewayRGTag, "") != rg {
+			continue
+		}
+
+		return &infos[i], nil
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "natGateway %s not found", name)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) natGatewayResponse(
+	ctx context.Context, info *netdriver.NATGateway, rp azurearm.ResourcePath, location string,
+) natGatewayResponse {
+	if location == "" {
+		location = defaultLoc
+	}
+
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeNATGateway, rp.ResourceName)
+
+	return natGatewayResponse{
+		ID:       id,
+		Name:     rp.ResourceName,
+		Type:     providerName + "/" + typeNATGateway,
+		Location: location,
+		Tags:     stripInternal(info.Tags),
+		Properties: natGatewayResponseProps{
+			ProvisioningState: "Succeeded",
+			PublicIPAddresses: h.natGatewayPublicIPRefs(ctx, rp, info.AllocationID),
+			Subnets:           h.natGatewaySubnetRefs(ctx, rp, id),
+		},
+	}
+}
+
+// natGatewayPublicIPRefs resolves the NAT gateway's bound Elastic IP
+// allocation (if any) back to its own ARM resource id.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) natGatewayPublicIPRefs(ctx context.Context, rp azurearm.ResourcePath, allocationID string) []armIDRef {
+	if allocationID == "" {
+		return nil
+	}
+
+	eips, err := h.net.DescribeAddresses(ctx, []string{allocationID})
+	if err != nil || len(eips) == 0 {
+		return nil
+	}
+
+	pipName := tagOr(eips[0].Tags, armPublicIPTag, "")
+	if pipName == "" {
+		return nil
+	}
+
+	pipRG := tagOr(eips[0].Tags, armPublicIPRGTag, rp.ResourceGroup)
+	id := azurearm.BuildResourceID(rp.Subscription, pipRG, providerName, typePublicIP, pipName)
+
+	return []armIDRef{{ID: id}}
+}
+
+// natGatewaySubnetRefs scans subnets for the ones associated with this NAT
+// gateway (their armSubnetNATTag matches natGatewayARMID), building each
+// subnet's nested ARM resource id.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) natGatewaySubnetRefs(ctx context.Context, rp azurearm.ResourcePath, natGatewayARMID string) []armIDRef {
+	subs, err := h.net.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return nil
+	}
+
+	vpcs, err := h.net.DescribeVPCs(ctx, nil)
+	if err != nil {
+		return nil
+	}
+
+	vpcNames := make(map[string]string, len(vpcs))
+	for i := range vpcs {
+		vpcNames[vpcs[i].ID] = tagOr(vpcs[i].Tags, armNameTag, vpcs[i].ID)
+	}
+
+	var out []armIDRef
+
+	for i := range subs {
+		if !strings.EqualFold(tagOr(subs[i].Tags, armSubnetNATTag, ""), natGatewayARMID) {
+			continue
+		}
+
+		vnetName := vpcNames[subs[i].VPCID]
+		subnetName := tagOr(subs[i].Tags, armSubnetTag, subs[i].ID)
+		id := "/subscriptions/" + rp.Subscription +
+			"/resourceGroups/" + rp.ResourceGroup +
+			"/providers/" + providerName + "/" + typeVNet +
+			"/" + vnetName + "/subnets/" + subnetName
+
+		out = append(out, armIDRef{ID: id})
+	}
+
+	return out
+}

--- a/server/azure/vnet/nat_gateway_test.go
+++ b/server/azure/vnet/nat_gateway_test.go
@@ -1,0 +1,265 @@
+package vnet_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// TestSDKNATGatewayRoundTrip guards the Microsoft.Network/natGateways wire
+// handler: every op used to 501. This drives the real armnetwork
+// NatGatewaysClient through create (bound to a public IP), get, subnet
+// association (via the subnet's own natGateway property, the real ARM
+// mechanism), and delete — checking both the subnets and publicIpAddresses
+// back-references round-trip.
+func TestSDKNATGatewayRoundTrip(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	pips, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pp, err := pips.BeginCreateOrUpdate(ctx, "rg-1", "pip-nat", armnetwork.PublicIPAddress{
+		Location: to.Ptr("eastus"),
+		SKU:      &armnetwork.PublicIPAddressSKU{Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard)},
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create pip: %v", err)
+	}
+
+	pollDone(t, pp)
+
+	pipID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/publicIPAddresses/pip-nat"
+
+	natClient, err := armnetwork.NewNatGatewaysClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	np, err := natClient.BeginCreateOrUpdate(ctx, "rg-1", "natgw-1", armnetwork.NatGateway{
+		Location: to.Ptr("eastus"),
+		SKU:      &armnetwork.NatGatewaySKU{Name: to.Ptr(armnetwork.NatGatewaySKUNameStandard)},
+		Properties: &armnetwork.NatGatewayPropertiesFormat{
+			IdleTimeoutInMinutes: to.Ptr(int32(10)),
+			PublicIPAddresses:    []*armnetwork.SubResource{{ID: to.Ptr(pipID)}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created := pollDone(t, np)
+
+	if created.Name == nil || *created.Name != "natgw-1" {
+		t.Fatalf("name=%v want natgw-1", created.Name)
+	}
+
+	if created.Properties == nil || len(created.Properties.PublicIPAddresses) != 1 ||
+		created.Properties.PublicIPAddresses[0].ID == nil || *created.Properties.PublicIPAddresses[0].ID != pipID {
+		t.Errorf("publicIpAddresses=%v want [%s]", created.Properties, pipID)
+	}
+
+	// GET round-trips the public IP association.
+	got, err := natClient.Get(ctx, "rg-1", "natgw-1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Properties == nil || len(got.Properties.PublicIPAddresses) != 1 {
+		t.Fatalf("Get publicIpAddresses=%v want 1 entry", got.Properties)
+	}
+
+	// Attach a subnet the real ARM way: PUT the subnet with its natGateway
+	// property set, not the NAT gateway itself.
+	vnets, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vp, err := vnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-nat", armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create vnet: %v", err)
+	}
+
+	pollDone(t, vp)
+
+	subnets, err := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sp, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-nat", "subnet-1", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create subnet: %v", err)
+	}
+
+	pollDone(t, sp)
+
+	natGatewayID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/natGateways/natgw-1"
+
+	sp2, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-nat", "subnet-1", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: to.Ptr("10.0.1.0/24"),
+			NatGateway:    &armnetwork.SubResource{ID: to.Ptr(natGatewayID)},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("associate subnet to natgw: %v", err)
+	}
+
+	associated := pollDone(t, sp2)
+
+	if associated.Properties == nil || associated.Properties.NatGateway == nil ||
+		associated.Properties.NatGateway.ID == nil || *associated.Properties.NatGateway.ID != natGatewayID {
+		t.Errorf("subnet natGateway=%v want %s", associated.Properties, natGatewayID)
+	}
+
+	// The NAT gateway's own GET must now report the subnet back-reference.
+	got, err = natClient.Get(ctx, "rg-1", "natgw-1", nil)
+	if err != nil {
+		t.Fatalf("Get after subnet association: %v", err)
+	}
+
+	subnetID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/" +
+		"virtualNetworks/vnet-nat/subnets/subnet-1"
+
+	if got.Properties == nil || len(got.Properties.Subnets) != 1 ||
+		got.Properties.Subnets[0].ID == nil || *got.Properties.Subnets[0].ID != subnetID {
+		t.Errorf("natgw subnets=%v want [%s]", got.Properties, subnetID)
+	}
+
+	// Delete frees the bound public IP.
+	dp, err := natClient.BeginDelete(ctx, "rg-1", "natgw-1", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+
+	pollDone(t, dp)
+
+	if _, err = natClient.Get(ctx, "rg-1", "natgw-1", nil); err == nil {
+		t.Error("Get after delete succeeded, want NotFound")
+	}
+
+	dpip, err := pips.BeginDelete(ctx, "rg-1", "pip-nat", nil)
+	if err != nil {
+		t.Fatalf("delete freed public IP: %v", err)
+	}
+
+	pollDone(t, dpip)
+}
+
+// TestSDKNATGatewayPublicIPAlreadyBound guards the atomic association check: a
+// public IP already bound to one NAT gateway is rejected on a second.
+func TestSDKNATGatewayPublicIPAlreadyBound(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	pips, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pp, err := pips.BeginCreateOrUpdate(ctx, "rg-1", "pip-shared-nat", armnetwork.PublicIPAddress{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create pip: %v", err)
+	}
+
+	pollDone(t, pp)
+
+	pipID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/publicIPAddresses/pip-shared-nat"
+
+	natClient, err := armnetwork.NewNatGatewaysClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := armnetwork.NatGateway{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.NatGatewayPropertiesFormat{
+			PublicIPAddresses: []*armnetwork.SubResource{{ID: to.Ptr(pipID)}},
+		},
+	}
+
+	np, err := natClient.BeginCreateOrUpdate(ctx, "rg-1", "natgw-first", body, nil)
+	if err != nil {
+		t.Fatalf("first natgw create: %v", err)
+	}
+
+	pollDone(t, np)
+
+	_, err = natClient.BeginCreateOrUpdate(ctx, "rg-1", "natgw-second", body, nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("second natgw bound to the same public IP: got %v, want an ARM error", err)
+	}
+}
+
+// TestSDKNATGatewayResourceGroupIsolation guards the same RG-isolation fix
+// applied to NAT gateways: two resource groups may each have a NAT gateway
+// named identically, and a resource-group-scoped List must only see its own.
+func TestSDKNATGatewayResourceGroupIsolation(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	natClient, err := armnetwork.NewNatGatewaysClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, rg := range []string{"rg-a", "rg-b"} {
+		np, cErr := natClient.BeginCreateOrUpdate(ctx, rg, "natgw-shared", armnetwork.NatGateway{
+			Location: to.Ptr("eastus"),
+		}, nil)
+		if cErr != nil {
+			t.Fatalf("create in %s: %v", rg, cErr)
+		}
+
+		pollDone(t, np)
+	}
+
+	if _, err = natClient.Get(ctx, "rg-a", "natgw-shared", nil); err != nil {
+		t.Fatalf("get rg-a: %v", err)
+	}
+
+	if _, err = natClient.Get(ctx, "rg-b", "natgw-shared", nil); err != nil {
+		t.Fatalf("get rg-b: %v", err)
+	}
+
+	count := 0
+
+	pager := natClient.NewListPager("rg-a", nil)
+	for pager.More() {
+		page, pErr := pager.NextPage(ctx)
+		if pErr != nil {
+			t.Fatalf("list rg-a: %v", pErr)
+		}
+
+		count += len(page.Value)
+	}
+
+	if count != 1 {
+		t.Errorf("List(rg-a) returned %d NAT gateways, want 1 (rg-b's must not leak in)", count)
+	}
+}

--- a/server/azure/vnet/network_interface.go
+++ b/server/azure/vnet/network_interface.go
@@ -125,9 +125,15 @@ func (h *Handler) createNIC(w http.ResponseWriter, r *http.Request, rp azurearm.
 		return
 	}
 
-	ipConfigs, err := h.buildIPConfigs(r.Context(), req.Properties.IPConfigurations)
+	ipConfigs, err := h.buildIPConfigs(r.Context(), rp.ResourceGroup, rp.ResourceName, req.Properties.IPConfigurations, svc)
 	if err != nil {
+		if cerrors.IsFailedPrecondition(err) {
+			azurearm.WriteError(w, http.StatusBadRequest, "PublicIPAddressCannotBeAssignedToMultipleIpConfigs", err.Error())
+			return
+		}
+
 		azurearm.WriteCErr(w, err)
+
 		return
 	}
 
@@ -205,8 +211,12 @@ func (*Handler) listNICs(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 
 // buildIPConfigs maps the wire ipConfigurations to driver configs, resolving
 // each referenced subnet to its address prefix so the mock can allocate a
-// dynamic private IP from the right range.
-func (h *Handler) buildIPConfigs(ctx context.Context, in []nicIPConfigRequest) ([]netdriver.AzureIPConfig, error) {
+// dynamic private IP from the right range. rg/nicName identify the NIC being
+// created or updated, so a re-PUT of the same NIC doesn't conflict with its
+// own existing public IP reference.
+func (h *Handler) buildIPConfigs(ctx context.Context, rg, nicName string, in []nicIPConfigRequest,
+	svc netdriver.AzureNetworkInterfaces,
+) ([]netdriver.AzureIPConfig, error) {
 	out := make([]netdriver.AzureIPConfig, 0, len(in))
 
 	for i := range in {
@@ -231,10 +241,18 @@ func (h *Handler) buildIPConfigs(ctx context.Context, in []nicIPConfigRequest) (
 		}
 
 		if p.PublicIPAddress != nil {
-			pipName := lastSegment(p.PublicIPAddress.ID)
-			if _, err := findPublicIPByName(ctx, h.net, pipName); err != nil {
+			pipRP, ok := azurearm.ParsePath(p.PublicIPAddress.ID)
+			if !ok || pipRP.ResourceType != typePublicIP {
+				return nil, cerrors.Newf(cerrors.InvalidArgument, "malformed public IP id %q", p.PublicIPAddress.ID)
+			}
+
+			if _, err := findPublicIPByName(ctx, h.net, pipRP.ResourceGroup, pipRP.ResourceName); err != nil {
 				return nil, cerrors.Newf(cerrors.InvalidArgument,
-					"ipConfiguration references public IP %q which does not exist", pipName)
+					"ipConfiguration references public IP %q which does not exist", pipRP.ResourceName)
+			}
+
+			if err := checkPublicIPNotAttached(ctx, svc, p.PublicIPAddress.ID, rg, nicName); err != nil {
+				return nil, err
 			}
 
 			cfg.PublicIPID = p.PublicIPAddress.ID
@@ -244,6 +262,33 @@ func (h *Handler) buildIPConfigs(ctx context.Context, in []nicIPConfigRequest) (
 	}
 
 	return out, nil
+}
+
+// checkPublicIPNotAttached rejects attaching armID to (rg, nicName) when it is
+// already referenced by a DIFFERENT network interface's ipConfiguration — a
+// static public IP can only be bound to one NIC at a time in real Azure
+// (PublicIPAddressCannotBeAssignedToMultipleIpConfigs). A re-PUT of the same
+// NIC that keeps its own existing reference is not a conflict.
+func checkPublicIPNotAttached(ctx context.Context, svc netdriver.AzureNetworkInterfaces, armID, rg, nicName string) error {
+	nics, err := svc.ListNetworkInterfaces(ctx, "")
+	if err != nil {
+		return err
+	}
+
+	for i := range nics {
+		if strings.EqualFold(nics[i].ResourceGroup, rg) && nics[i].Name == nicName {
+			continue
+		}
+
+		for j := range nics[i].IPConfigs {
+			if strings.EqualFold(nics[i].IPConfigs[j].PublicIPID, armID) {
+				return cerrors.Newf(cerrors.FailedPrecondition,
+					"public IP %q is already associated with network interface %q", armID, nics[i].Name)
+			}
+		}
+	}
+
+	return nil
 }
 
 // subnetCIDR resolves the address prefix of the subnet named by an ARM subnet
@@ -278,14 +323,13 @@ func (h *Handler) subnetCIDR(ctx context.Context, subnetID string) (string, erro
 		"ipConfiguration references subnet %q which does not exist in vnet %q", sp.SubResourceName, sp.ResourceName)
 }
 
-func lastSegment(id string) string {
-	id = strings.TrimRight(id, "/")
-
-	if i := strings.LastIndexByte(id, '/'); i >= 0 {
-		return id[i+1:]
-	}
-
-	return id
+// ipConfigResourceID builds the nested ARM resource id of one NIC
+// ipConfiguration, used as the publicIPAddresses.ipConfiguration back-reference.
+func ipConfigResourceID(sub, rg, nicName, configName string) string {
+	return "/subscriptions/" + sub +
+		"/resourceGroups/" + rg +
+		"/providers/" + providerName + "/" + typeNIC +
+		"/" + nicName + "/ipConfigurations/" + configName
 }
 
 //nolint:gocritic // rp is a request-scoped value

--- a/server/azure/vnet/network_interface_test.go
+++ b/server/azure/vnet/network_interface_test.go
@@ -2,10 +2,12 @@ package vnet_test
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
@@ -296,6 +298,91 @@ func TestSDKNetworkInterfaceUnknownSubnet(t *testing.T) {
 	}, nil)
 	if err == nil {
 		t.Fatal("NIC create against a missing subnet succeeded, want error")
+	}
+}
+
+// TestSDKNetworkInterfacePublicIPDoubleAttachRejected guards buildIPConfigs'
+// association check: the same static public IP cannot be attached to two
+// different NICs at once. A re-PUT of the SAME NIC keeping its own reference
+// must still succeed (not a false-positive conflict with itself).
+func TestSDKNetworkInterfacePublicIPDoubleAttachRejected(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Network: cloudP.VNet})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	opts := clientOpts(ts)
+	poll := &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}
+
+	pips, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pp, err := pips.BeginCreateOrUpdate(ctx, "rg-1", "pip-double", armnetwork.PublicIPAddress{
+		Location: to.Ptr("eastus"),
+		SKU:      &armnetwork.PublicIPAddressSKU{Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard)},
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create pip: %v", err)
+	}
+
+	if _, err = pp.PollUntilDone(ctx, poll); err != nil {
+		t.Fatalf("pip poll: %v", err)
+	}
+
+	pipID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/publicIPAddresses/pip-double"
+
+	nicClient, err := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nicBody := func() armnetwork.Interface {
+		return armnetwork.Interface{
+			Location: to.Ptr("eastus"),
+			Properties: &armnetwork.InterfacePropertiesFormat{
+				IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+					Name: to.Ptr("ipconfig1"),
+					Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+						PublicIPAddress: &armnetwork.PublicIPAddress{ID: to.Ptr(pipID)},
+					},
+				}},
+			},
+		}
+	}
+
+	np1, err := nicClient.BeginCreateOrUpdate(ctx, "rg-1", "nic-first", nicBody(), nil)
+	if err != nil {
+		t.Fatalf("first nic create: %v", err)
+	}
+
+	if _, err = np1.PollUntilDone(ctx, poll); err != nil {
+		t.Fatalf("first nic poll: %v", err)
+	}
+
+	// A second, different NIC referencing the same public IP must be rejected.
+	_, err = nicClient.BeginCreateOrUpdate(ctx, "rg-1", "nic-second", nicBody(), nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 400 {
+		t.Fatalf("second nic double-attach: got %v, want 400", err)
+	}
+
+	// Re-PUTting the FIRST nic with the same reference is not a conflict with
+	// itself.
+	np1b, err := nicClient.BeginCreateOrUpdate(ctx, "rg-1", "nic-first", nicBody(), nil)
+	if err != nil {
+		t.Fatalf("first nic re-PUT: %v", err)
+	}
+
+	if _, err = np1b.PollUntilDone(ctx, poll); err != nil {
+		t.Fatalf("first nic re-PUT poll: %v", err)
 	}
 }
 

--- a/server/azure/vnet/public_ip_test.go
+++ b/server/azure/vnet/public_ip_test.go
@@ -1,0 +1,290 @@
+package vnet_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// TestSDKPublicIPDelete guards the fix for publicIPAddresses having no DELETE
+// handler (every teardown 405'd). A public IP with no association deletes
+// cleanly and a subsequent Get reports NotFound.
+func TestSDKPublicIPDelete(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	pips, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := pips.BeginCreateOrUpdate(ctx, "rg-1", "pip-del", armnetwork.PublicIPAddress{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	pollDone(t, p)
+
+	dp, err := pips.BeginDelete(ctx, "rg-1", "pip-del", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+
+	pollDone(t, dp)
+
+	if _, err = pips.Get(ctx, "rg-1", "pip-del", nil); err == nil {
+		t.Error("Get after delete succeeded, want NotFound")
+	}
+}
+
+// TestSDKPublicIPDeleteBlockedWhileAttached guards ReleaseAddress's existing
+// in-use precondition now being reachable through the DELETE handler: a public
+// IP still attached to a NIC's ipConfiguration cannot be deleted until the NIC
+// releases it.
+func TestSDKPublicIPDeleteBlockedWhileAttached(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	pips, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := pips.BeginCreateOrUpdate(ctx, "rg-1", "pip-attached", armnetwork.PublicIPAddress{
+		Location: to.Ptr("eastus"),
+		SKU:      &armnetwork.PublicIPAddressSKU{Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard)},
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create pip: %v", err)
+	}
+
+	pollDone(t, p)
+
+	pipID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/publicIPAddresses/pip-attached"
+
+	nics, err := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	np, err := nics.BeginCreateOrUpdate(ctx, "rg-1", "nic-attached", armnetwork.Interface{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig1"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					PublicIPAddress: &armnetwork.PublicIPAddress{ID: to.Ptr(pipID)},
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create nic: %v", err)
+	}
+
+	pollDone(t, np)
+
+	_, err = pips.BeginDelete(ctx, "rg-1", "pip-attached", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 400 {
+		t.Fatalf("delete attached public IP: got %v, want 400", err)
+	}
+}
+
+// TestSDKPublicIPResourceGroupIsolation guards the RG-scoping fix: two public
+// IPs sharing a name but living in different resource groups must not
+// collide, and a resource-group-scoped List must only return its own.
+func TestSDKPublicIPResourceGroupIsolation(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	pips, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, rg := range []string{"rg-a", "rg-b"} {
+		p, cErr := pips.BeginCreateOrUpdate(ctx, rg, "pip-shared", armnetwork.PublicIPAddress{
+			Location: to.Ptr("eastus"),
+		}, nil)
+		if cErr != nil {
+			t.Fatalf("create in %s: %v", rg, cErr)
+		}
+
+		pollDone(t, p)
+	}
+
+	// Each resource group's own Get succeeds and returns a distinct address.
+	gotA, err := pips.Get(ctx, "rg-a", "pip-shared", nil)
+	if err != nil {
+		t.Fatalf("get rg-a: %v", err)
+	}
+
+	gotB, err := pips.Get(ctx, "rg-b", "pip-shared", nil)
+	if err != nil {
+		t.Fatalf("get rg-b: %v", err)
+	}
+
+	if gotA.Properties == nil || gotB.Properties == nil ||
+		gotA.Properties.IPAddress == nil || gotB.Properties.IPAddress == nil {
+		t.Fatal("missing ipAddress on one of the two public IPs")
+	}
+
+	if *gotA.Properties.IPAddress != *gotB.Properties.IPAddress {
+		// Not required to differ, but if they don't the ids below still prove isolation.
+		t.Logf("rg-a=%s rg-b=%s (distinct addresses, expected)", *gotA.Properties.IPAddress, *gotB.Properties.IPAddress)
+	}
+
+	// A resource-group-scoped list of rg-a must not see rg-b's public IP.
+	count := 0
+
+	pager := pips.NewListPager("rg-a", nil)
+	for pager.More() {
+		page, pErr := pager.NextPage(ctx)
+		if pErr != nil {
+			t.Fatalf("list rg-a: %v", pErr)
+		}
+
+		count += len(page.Value)
+	}
+
+	if count != 1 {
+		t.Errorf("List(rg-a) returned %d public IPs, want 1 (rg-b's must not leak in)", count)
+	}
+}
+
+// TestSDKPublicIPFieldsRoundTrip guards zones/dnsSettings/idleTimeoutInMinutes
+// no longer being silently dropped.
+func TestSDKPublicIPFieldsRoundTrip(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	pips, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := pips.BeginCreateOrUpdate(ctx, "rg-1", "pip-fields", armnetwork.PublicIPAddress{
+		Location: to.Ptr("eastus"),
+		Zones:    []*string{to.Ptr("1"), to.Ptr("2")},
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+			IdleTimeoutInMinutes: to.Ptr(int32(15)),
+			DNSSettings: &armnetwork.PublicIPAddressDNSSettings{
+				DomainNameLabel: to.Ptr("cloudemu-test"),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	pollDone(t, p)
+
+	got, err := pips.Get(ctx, "rg-1", "pip-fields", nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if len(got.Zones) != 2 || *got.Zones[0] != "1" || *got.Zones[1] != "2" {
+		t.Errorf("zones=%v want [1 2]", got.Zones)
+	}
+
+	if got.Properties == nil || got.Properties.IdleTimeoutInMinutes == nil || *got.Properties.IdleTimeoutInMinutes != 15 {
+		t.Errorf("idleTimeoutInMinutes=%v want 15", got.Properties)
+	}
+
+	if got.Properties == nil || got.Properties.DNSSettings == nil ||
+		got.Properties.DNSSettings.DomainNameLabel == nil || *got.Properties.DNSSettings.DomainNameLabel != "cloudemu-test" {
+		t.Errorf("dnsSettings.domainNameLabel missing, want cloudemu-test")
+	}
+
+	if got.Properties == nil || got.Properties.DNSSettings == nil ||
+		got.Properties.DNSSettings.Fqdn == nil || *got.Properties.DNSSettings.Fqdn == "" {
+		t.Error("dnsSettings.fqdn empty, want derived FQDN")
+	}
+}
+
+// TestSDKPublicIPIPConfigurationBackref guards the missing ipConfiguration
+// back-reference: once a NIC attaches a public IP, a Get on that address must
+// report the NIC's ipConfiguration id.
+func TestSDKPublicIPIPConfigurationBackref(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	pips, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := pips.BeginCreateOrUpdate(ctx, "rg-1", "pip-backref", armnetwork.PublicIPAddress{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create pip: %v", err)
+	}
+
+	pollDone(t, p)
+
+	// Before attachment: no back-reference.
+	got, err := pips.Get(ctx, "rg-1", "pip-backref", nil)
+	if err != nil {
+		t.Fatalf("get before attach: %v", err)
+	}
+
+	if got.Properties != nil && got.Properties.IPConfiguration != nil {
+		t.Error("ipConfiguration set before any NIC attached it")
+	}
+
+	pipID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/publicIPAddresses/pip-backref"
+
+	nics, err := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	np, err := nics.BeginCreateOrUpdate(ctx, "rg-1", "nic-backref", armnetwork.Interface{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig1"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					PublicIPAddress: &armnetwork.PublicIPAddress{ID: to.Ptr(pipID)},
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create nic: %v", err)
+	}
+
+	pollDone(t, np)
+
+	got, err = pips.Get(ctx, "rg-1", "pip-backref", nil)
+	if err != nil {
+		t.Fatalf("get after attach: %v", err)
+	}
+
+	wantIPConfig := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/" +
+		"networkInterfaces/nic-backref/ipConfigurations/ipconfig1"
+
+	if got.Properties == nil || got.Properties.IPConfiguration == nil || got.Properties.IPConfiguration.ID == nil {
+		t.Fatal("ipConfiguration backref missing after NIC attach")
+	}
+
+	if *got.Properties.IPConfiguration.ID != wantIPConfig {
+		t.Errorf("ipConfiguration.id=%q want %q", *got.Properties.IPConfiguration.ID, wantIPConfig)
+	}
+}

--- a/server/azure/vnet/types.go
+++ b/server/azure/vnet/types.go
@@ -43,7 +43,8 @@ type subnetRequest struct {
 }
 
 type subnetRequestProps struct {
-	AddressPrefix string `json:"addressPrefix,omitempty"`
+	AddressPrefix string    `json:"addressPrefix,omitempty"`
+	NatGateway    *armIDRef `json:"natGateway,omitempty"`
 }
 
 type subnetResponse struct {
@@ -54,8 +55,9 @@ type subnetResponse struct {
 }
 
 type subnetResponseProps struct {
-	ProvisioningState string `json:"provisioningState"`
-	AddressPrefix     string `json:"addressPrefix,omitempty"`
+	ProvisioningState string    `json:"provisioningState"`
+	AddressPrefix     string    `json:"addressPrefix,omitempty"`
+	NatGateway        *armIDRef `json:"natGateway,omitempty"`
 }
 
 type subnetListResponse struct {
@@ -115,6 +117,7 @@ type publicIPRequest struct {
 	Location   string            `json:"location"`
 	Tags       map[string]string `json:"tags,omitempty"`
 	SKU        *publicIPSKU      `json:"sku,omitempty"`
+	Zones      []string          `json:"zones,omitempty"`
 	Properties publicIPReqProps  `json:"properties"`
 }
 
@@ -123,7 +126,13 @@ type publicIPSKU struct {
 }
 
 type publicIPReqProps struct {
-	PublicIPAllocationMethod string `json:"publicIPAllocationMethod,omitempty"`
+	PublicIPAllocationMethod string                  `json:"publicIPAllocationMethod,omitempty"`
+	IdleTimeoutInMinutes     int                     `json:"idleTimeoutInMinutes,omitempty"`
+	DNSSettings              *publicIPDNSSettingsReq `json:"dnsSettings,omitempty"`
+}
+
+type publicIPDNSSettingsReq struct {
+	DomainNameLabel string `json:"domainNameLabel,omitempty"`
 }
 
 type publicIPResponse struct {
@@ -133,13 +142,24 @@ type publicIPResponse struct {
 	Location   string            `json:"location"`
 	Tags       map[string]string `json:"tags,omitempty"`
 	SKU        *publicIPSKU      `json:"sku,omitempty"`
+	Zones      []string          `json:"zones,omitempty"`
 	Properties publicIPRespProps `json:"properties"`
 }
 
 type publicIPRespProps struct {
-	ProvisioningState        string `json:"provisioningState"`
-	PublicIPAllocationMethod string `json:"publicIPAllocationMethod,omitempty"`
-	IPAddress                string `json:"ipAddress,omitempty"`
+	ProvisioningState        string               `json:"provisioningState"`
+	PublicIPAllocationMethod string               `json:"publicIPAllocationMethod,omitempty"`
+	IPAddress                string               `json:"ipAddress,omitempty"`
+	IdleTimeoutInMinutes     int                  `json:"idleTimeoutInMinutes,omitempty"`
+	DNSSettings              *publicIPDNSSettings `json:"dnsSettings,omitempty"`
+	// IPConfiguration is the back-reference to the NIC ipConfiguration a real
+	// publicIPAddresses GET reports once a NIC attaches the address.
+	IPConfiguration *armIDRef `json:"ipConfiguration,omitempty"`
+}
+
+type publicIPDNSSettings struct {
+	DomainNameLabel string `json:"domainNameLabel,omitempty"`
+	FQDN            string `json:"fqdn,omitempty"`
 }
 
 type publicIPListResponse struct {

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -278,6 +278,12 @@ type ElasticIPConfig struct {
 	// Dynamic) are cost/behavior inputs a discoverer reads; optional.
 	SKU              string
 	AllocationMethod string
+	// Zones, IdleTimeoutMinutes and DNSDomainNameLabel are Azure public-IP-only
+	// fields (availability zones, TCP idle timeout, DNS label) the AWS-shaped
+	// fields above cannot represent; empty/zero for AWS and GCP.
+	Zones              []string
+	IdleTimeoutMinutes int
+	DNSDomainNameLabel string
 }
 
 // ElasticIP represents an elastic IP address.
@@ -297,6 +303,13 @@ type ElasticIP struct {
 	SKU string
 	// AllocationMethod is Static/Dynamic (Azure publicIPAllocationMethod).
 	AllocationMethod string
+	// Zones, IdleTimeoutMinutes, DNSDomainNameLabel and DNSFQDN round-trip the
+	// Azure-only public-IP fields set in ElasticIPConfig; DNSFQDN is derived by
+	// the provider from DNSDomainNameLabel. Empty/zero for AWS and GCP.
+	Zones              []string
+	IdleTimeoutMinutes int
+	DNSDomainNameLabel string
+	DNSFQDN            string
 }
 
 // AssociateAddressInput carries the target of an AssociateAddress call. Exactly

--- a/services/networking/networking.go
+++ b/services/networking/networking.go
@@ -519,6 +519,8 @@ func (n *Networking) DetachInternetGateway(
 }
 
 // AllocateAddress allocates a new elastic IP address.
+//
+//nolint:gocritic // hugeParam: cfg is passed by value to satisfy the Networking driver interface.
 func (n *Networking) AllocateAddress(
 	ctx context.Context, cfg driver.ElasticIPConfig,
 ) (*driver.ElasticIP, error) {


### PR DESCRIPTION
## What

Fixes deep-sweep findings on Azure `publicIPAddresses` and adds the missing `Microsoft.Network/natGateways` wire handler.

**publicIPAddresses (`server/azure/vnet/`)**
- No DELETE handler — `routePublicIP` only switched PUT/GET, so teardown 405'd. Added, resolving the allocation and calling `ReleaseAddress`; blocks with `PublicIPAddressCannotBeDeleted` (400) while a NIC ipConfiguration or NAT gateway still references the address.
- List/Get were not resource-group scoped — every RG saw every subscription's public IPs. Public IPs are now tagged with their owning RG (`cloudemu:azurePublicIPResourceGroup`, mirroring the existing ARM-name-tag pattern) and list/get filter by it.
- The same static public IP could be attached to two different NICs at once — `buildIPConfigs` only checked the IP existed, never its association state. Rejects a second NIC referencing an already-attached public IP with `PublicIPAddressCannotBeAssignedToMultipleIpConfigs` (400); a re-PUT of the *same* NIC is not a false-positive conflict.
- `zones`, `dnsSettings` (`domainNameLabel`/`fqdn`) and `idleTimeoutInMinutes` were silently dropped — round-tripped through `ElasticIPConfig`/`ElasticIP`.
- The public IP never reported its `ipConfiguration` back-reference after a NIC attach — added by scanning NICs for a matching `PublicIPID`, mirroring the existing subnet-by-VPC-id scan `vnetResponse` already does.

**Microsoft.Network/natGateways (new: `server/azure/vnet/nat_gateway.go`)**
- Every op previously 501'd (no handler registered). Added full CRUD (PUT/GET/DELETE/List), wrapping the existing Azure NAT gateway provider CRUD (`providers/azure/vnet/nat_gateway.go`, which already existed but only supported the AWS-shaped mandatory-subnet-at-creation model).
- Subnet association is modeled the real ARM way: a subnet attaches to a NAT gateway by setting its own `natGateway` property (`SubnetsClient.BeginCreateOrUpdate`), not via a field on the NAT gateway itself — the NAT gateway's own GET reports the association by scanning subnets, matching how real ARM's `properties.subnets` field is read-only/computed.
- Public IP association uses the driver's existing `AllocationID` field (already present from AWS's NAT gateway model) with an atomic check-and-set (`store.Update`) so binding a public IP already in use by another NAT gateway is rejected, and deleting the NAT gateway frees the allocation again.
- Azure NAT gateways aren't bound to a subnet at creation (unlike AWS), so the provider's mandatory-subnet check was relaxed for that path.

**Deferred (not in this PR)**: `publicIPPrefixes` (`Microsoft.Network/publicIPPrefixes`) — needs its own driver/provider/handler, out of scope for this bug wave.

## Why

Reproduced against the real `azure-sdk-for-go` (`armnetwork` v1.1.0) via a live TLS wire server — every fix has a regression test driving the actual SDK client through create/get/list/delete against `cloudemu`.

## Test plan
- `go build ./...`, `go vet ./...`
- `go test ./providers/azure/... ./server/azure/... ./services/... ./compat/...`
- `go test -race ./providers/azure/vnet/...`
- Full `go test ./...`
- `golangci-lint` clean on all changed packages (including `providers/aws/vpc`, `providers/gcp/vpc`, `providers/oci/vcn`, which share the widened `ElasticIPConfig`/`ElasticIP` struct)
- New SDK-driven tests: `server/azure/vnet/nat_gateway_test.go`, `server/azure/vnet/public_ip_test.go`, plus an addition to `network_interface_test.go` for the double-attach guard