### PR TITLE
fix(cosmos): multi-region accounts, failoverPriorityChange, container defaultTtl, unique keys, database throughput

### DIFF
--- a/server/azure/cosmosaccount/handler.go
+++ b/server/azure/cosmosaccount/handler.go
@@ -29,6 +29,7 @@ package cosmosaccount
 import (
 	"context"
 	"net/http"
+	"sort"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -144,6 +145,8 @@ func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, rp *azurea
 		// synchronously with an empty 200 so the SDK's poller terminates. Keys
 		// are deterministic per account, so there is nothing to persist.
 		w.WriteHeader(http.StatusOK)
+	case "failoverprioritychange":
+		h.failoverPriorityChange(w, r, rp)
 	default:
 		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unsupported action: "+rp.SubResource)
 	}
@@ -180,6 +183,8 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 		attrs.OfferType = body.Properties.DatabaseAccountOfferType
 		attrs.EnableFreeTier = body.Properties.EnableFreeTier
 		attrs.Capabilities = capabilityNames(body.Properties.Capabilities)
+		attrs.Locations = toAccountLocations(body.Properties.Locations)
+		attrs.EnableMultipleWriteLocations = body.Properties.EnableMultipleWriteLocations
 	}
 
 	if h.attrs != nil {
@@ -269,6 +274,16 @@ func renderAccount(subscription, name string, attrs dbdriver.AccountAttributes) 
 		location = defaultLocation
 	}
 
+	locations := attrs.Locations
+	if len(locations) == 0 {
+		// Single-region account (or one created before multi-region support):
+		// synthesize the one entry from Location so every array is still populated.
+		locations = []dbdriver.AccountLocation{{Name: location, FailoverPriority: 0}}
+	}
+
+	all := toArmLocations(name, locations)
+	writeLocs := writeLocations(name, locations, attrs.EnableMultipleWriteLocations)
+
 	return armAccount{
 		ID:       azurearm.BuildResourceID(subscription, attrs.ResourceGroup, providerName, resourceType, name),
 		Name:     name,
@@ -282,12 +297,153 @@ func renderAccount(subscription, name string, attrs dbdriver.AccountAttributes) 
 			Capabilities:             toCapabilities(attrs.Capabilities),
 			ProvisioningState:        "Succeeded",
 			DocumentEndpoint:         documentEndpoint(name),
-			Locations:                []armLocation{regionEntry(name, location)},
-			ReadLocations:            []armLocation{regionEntry(name, location)},
-			WriteLocations:           []armLocation{regionEntry(name, location)},
-			FailoverPolicies:         []armFailover{failoverEntry(name, location)},
+			Locations:                all,
+			ReadLocations:            all,
+			WriteLocations:           writeLocs,
+			FailoverPolicies:         toFailoverPolicies(name, locations),
 		},
 	}
+}
+
+// toAccountLocations converts the ARM create-request locations into the
+// driver's provider-agnostic AccountLocation list. Real clients always send
+// an explicit failoverPriority per entry (see the armcosmos Location docs),
+// so no ordering inference is needed here.
+func toAccountLocations(locs []armLocation) []dbdriver.AccountLocation {
+	if len(locs) == 0 {
+		return nil
+	}
+
+	out := make([]dbdriver.AccountLocation, 0, len(locs))
+
+	for _, l := range locs {
+		if l.LocationName == "" {
+			continue
+		}
+
+		out = append(out, dbdriver.AccountLocation{
+			Name:             l.LocationName,
+			FailoverPriority: l.FailoverPriority,
+			IsZoneRedundant:  l.IsZoneRedundant,
+		})
+	}
+
+	return out
+}
+
+// sortedLocations returns locs ordered by ascending failover priority
+// (priority 0 — the write region — first), matching how Azure orders every
+// location array it returns.
+func sortedLocations(locs []dbdriver.AccountLocation) []dbdriver.AccountLocation {
+	out := make([]dbdriver.AccountLocation, len(locs))
+	copy(out, locs)
+	sort.SliceStable(out, func(i, j int) bool { return out[i].FailoverPriority < out[j].FailoverPriority })
+
+	return out
+}
+
+// toArmLocations renders every declared region as an armLocation entry,
+// ordered by failover priority — the shape shared by properties.locations
+// and properties.readLocations (every region is readable).
+func toArmLocations(name string, locs []dbdriver.AccountLocation) []armLocation {
+	sorted := sortedLocations(locs)
+	out := make([]armLocation, 0, len(sorted))
+
+	for _, l := range sorted {
+		out = append(out, armLocation{
+			ID:                name + "-" + l.Name,
+			LocationName:      l.Name,
+			DocumentEndpoint:  "https://" + name + "-" + l.Name + ".documents.azure.com:443/",
+			ProvisioningState: "Succeeded",
+			FailoverPriority:  l.FailoverPriority,
+			IsZoneRedundant:   l.IsZoneRedundant,
+		})
+	}
+
+	return out
+}
+
+// writeLocations returns the regions that accept writes: every region when
+// multi-write is enabled, otherwise only the single failoverPriority-0 region.
+func writeLocations(name string, locs []dbdriver.AccountLocation, multiWrite bool) []armLocation {
+	if multiWrite {
+		return toArmLocations(name, locs)
+	}
+
+	sorted := sortedLocations(locs)
+	if len(sorted) == 0 {
+		return nil
+	}
+
+	return toArmLocations(name, sorted[:1])
+}
+
+// toFailoverPolicies renders properties.failoverPolicies: every region,
+// ordered by failover priority.
+func toFailoverPolicies(name string, locs []dbdriver.AccountLocation) []armFailover {
+	sorted := sortedLocations(locs)
+	out := make([]armFailover, 0, len(sorted))
+
+	for _, l := range sorted {
+		out = append(out, armFailover{
+			ID:               name + "-" + l.Name,
+			LocationName:     l.Name,
+			FailoverPriority: l.FailoverPriority,
+		})
+	}
+
+	return out
+}
+
+// failoverPriorityChange reorders an account's failover priorities. Real
+// Azure runs this as a long-running operation and only accepts a 202 or 204
+// response (200 fails client-side response validation); the emulator
+// completes it synchronously with an empty 204 so the SDK's poller
+// terminates on the first response.
+func (h *Handler) failoverPriorityChange(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if h.attrs == nil {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "account attributes unavailable")
+		return
+	}
+
+	var body armFailoverPolicies
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	attrs, err := h.attrs.TableAttributes(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	reordered := make([]dbdriver.AccountLocation, 0, len(body.FailoverPolicies))
+
+	for _, fp := range body.FailoverPolicies {
+		if fp.LocationName == "" {
+			continue
+		}
+
+		loc := dbdriver.AccountLocation{Name: fp.LocationName, FailoverPriority: fp.FailoverPriority}
+
+		for _, existing := range attrs.Locations {
+			if strings.EqualFold(existing.Name, fp.LocationName) {
+				loc.IsZoneRedundant = existing.IsZoneRedundant
+				break
+			}
+		}
+
+		reordered = append(reordered, loc)
+	}
+
+	attrs.Locations = reordered
+	if len(reordered) > 0 {
+		attrs.Location = sortedLocations(reordered)[0].Name
+	}
+
+	h.attrs.SetTableAttributes(rp.ResourceName, attrs)
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func kindOrDefault(kind string) string {
@@ -324,26 +480,6 @@ func accountRegion(props *armAccountCreateProps) string {
 // documentEndpoint is the account's global connection endpoint.
 func documentEndpoint(name string) string {
 	return "https://" + name + ".documents.azure.com:443/"
-}
-
-// regionEntry builds a single-region Location record for the account's
-// read/write/location arrays.
-func regionEntry(name, location string) armLocation {
-	return armLocation{
-		ID:                name + "-" + location,
-		LocationName:      location,
-		DocumentEndpoint:  "https://" + name + "-" + location + ".documents.azure.com:443/",
-		ProvisioningState: "Succeeded",
-		FailoverPriority:  0,
-	}
-}
-
-func failoverEntry(name, location string) armFailover {
-	return armFailover{
-		ID:               name + "-" + location,
-		LocationName:     location,
-		FailoverPriority: 0,
-	}
 }
 
 func capabilityNames(caps []armCapability) []string {

--- a/server/azure/cosmosaccount/multiregion_test.go
+++ b/server/azure/cosmosaccount/multiregion_test.go
@@ -1,0 +1,153 @@
+// This file exercises two HIGH bugs in the databaseAccounts control plane:
+//   - A multi-region create (Locations with more than one entry) used to
+//     collapse to a single region, with readLocations/writeLocations/
+//     failoverPolicies left unpopulated.
+//   - POST .../failoverPriorityChange 404d instead of reordering the account's
+//     regions.
+
+package cosmosaccount_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSDKDatabaseAccountMultiRegionCreateGet asserts a two-region create
+// carries both regions through to Get: properties.locations, readLocations,
+// writeLocations (single-write, so only the priority-0 region) and
+// failoverPolicies all reflect both regions, ordered by failover priority.
+func TestSDKDatabaseAccountMultiRegionCreateGet(t *testing.T) {
+	ctx := context.Background()
+	client := newDatabaseAccountsClient(t)
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "cosmos-multi", armcosmos.DatabaseAccountCreateUpdateParameters{
+		Location: to.Ptr("westus2"),
+		Kind:     to.Ptr(armcosmos.DatabaseAccountKindGlobalDocumentDB),
+		Properties: &armcosmos.DatabaseAccountCreateUpdateProperties{
+			DatabaseAccountOfferType: to.Ptr("Standard"),
+			Locations: []*armcosmos.Location{
+				{LocationName: to.Ptr("westus2"), FailoverPriority: to.Ptr[int32](0)},
+				{LocationName: to.Ptr("eastus2"), FailoverPriority: to.Ptr[int32](1)},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	assertTwoRegionAccount(t, created.Properties, "westus2", "eastus2")
+
+	got, err := client.Get(ctx, "rg-1", "cosmos-multi", nil)
+	require.NoError(t, err)
+
+	assertTwoRegionAccount(t, got.Properties, "westus2", "eastus2")
+}
+
+// assertTwoRegionAccount checks properties.locations/readLocations carry both
+// regions ordered by priority, writeLocations carries only the priority-0
+// region (single-write default), and failoverPolicies mirrors locations.
+func assertTwoRegionAccount(t *testing.T, props *armcosmos.DatabaseAccountGetProperties, first, second string) {
+	t.Helper()
+	require.NotNil(t, props)
+
+	require.Len(t, props.Locations, 2)
+	require.NotNil(t, props.Locations[0].LocationName)
+	require.NotNil(t, props.Locations[1].LocationName)
+	assert.Equal(t, first, *props.Locations[0].LocationName)
+	assert.Equal(t, second, *props.Locations[1].LocationName)
+
+	require.Len(t, props.ReadLocations, 2)
+
+	require.Len(t, props.WriteLocations, 1)
+	require.NotNil(t, props.WriteLocations[0].LocationName)
+	assert.Equal(t, first, *props.WriteLocations[0].LocationName)
+
+	require.Len(t, props.FailoverPolicies, 2)
+	require.NotNil(t, props.FailoverPolicies[0].LocationName)
+	require.NotNil(t, props.FailoverPolicies[1].LocationName)
+	assert.Equal(t, first, *props.FailoverPolicies[0].LocationName)
+	assert.Equal(t, second, *props.FailoverPolicies[1].LocationName)
+	require.NotNil(t, props.FailoverPolicies[0].FailoverPriority)
+	assert.Equal(t, int32(0), *props.FailoverPolicies[0].FailoverPriority)
+}
+
+// TestSDKDatabaseAccountMultiWriteLocations asserts an account created with
+// EnableMultipleWriteLocations reports every region as a write location, not
+// just the priority-0 one.
+func TestSDKDatabaseAccountMultiWriteLocations(t *testing.T) {
+	ctx := context.Background()
+	client := newDatabaseAccountsClient(t)
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "cosmos-multiwrite", armcosmos.DatabaseAccountCreateUpdateParameters{
+		Location: to.Ptr("westus2"),
+		Kind:     to.Ptr(armcosmos.DatabaseAccountKindGlobalDocumentDB),
+		Properties: &armcosmos.DatabaseAccountCreateUpdateProperties{
+			DatabaseAccountOfferType:     to.Ptr("Standard"),
+			EnableMultipleWriteLocations: to.Ptr(true),
+			Locations: []*armcosmos.Location{
+				{LocationName: to.Ptr("westus2"), FailoverPriority: to.Ptr[int32](0)},
+				{LocationName: to.Ptr("eastus2"), FailoverPriority: to.Ptr[int32](1)},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	require.Len(t, created.Properties.WriteLocations, 2)
+}
+
+// TestSDKDatabaseAccountFailoverPriorityChange asserts the action reorders
+// the account's failover priorities instead of 404ing, and the new ordering
+// is visible on the next Get.
+func TestSDKDatabaseAccountFailoverPriorityChange(t *testing.T) {
+	ctx := context.Background()
+	client := newDatabaseAccountsClient(t)
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "cosmos-failover", armcosmos.DatabaseAccountCreateUpdateParameters{
+		Location: to.Ptr("eastus"),
+		Kind:     to.Ptr(armcosmos.DatabaseAccountKindGlobalDocumentDB),
+		Properties: &armcosmos.DatabaseAccountCreateUpdateProperties{
+			DatabaseAccountOfferType: to.Ptr("Standard"),
+			Locations: []*armcosmos.Location{
+				{LocationName: to.Ptr("eastus"), FailoverPriority: to.Ptr[int32](0)},
+				{LocationName: to.Ptr("westus"), FailoverPriority: to.Ptr[int32](1)},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	fpPoller, err := client.BeginFailoverPriorityChange(ctx, "rg-1", "cosmos-failover", armcosmos.FailoverPolicies{
+		FailoverPolicies: []*armcosmos.FailoverPolicy{
+			{FailoverPriority: to.Ptr[int32](0), LocationName: to.Ptr("westus")},
+			{FailoverPriority: to.Ptr[int32](1), LocationName: to.Ptr("eastus")},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = fpPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	got, err := client.Get(ctx, "rg-1", "cosmos-failover", nil)
+	require.NoError(t, err)
+
+	require.Len(t, got.Properties.FailoverPolicies, 2)
+	require.NotNil(t, got.Properties.FailoverPolicies[0].LocationName)
+	assert.Equal(t, "westus", *got.Properties.FailoverPolicies[0].LocationName)
+	require.NotNil(t, got.Properties.FailoverPolicies[1].LocationName)
+	assert.Equal(t, "eastus", *got.Properties.FailoverPolicies[1].LocationName)
+
+	// westus is now the write region.
+	require.Len(t, got.Properties.WriteLocations, 1)
+	require.NotNil(t, got.Properties.WriteLocations[0].LocationName)
+	assert.Equal(t, "westus", *got.Properties.WriteLocations[0].LocationName)
+}

--- a/server/azure/cosmosaccount/types.go
+++ b/server/azure/cosmosaccount/types.go
@@ -11,10 +11,11 @@ type armAccountCreate struct {
 }
 
 type armAccountCreateProps struct {
-	DatabaseAccountOfferType string          `json:"databaseAccountOfferType,omitempty"`
-	EnableFreeTier           bool            `json:"enableFreeTier,omitempty"`
-	Capabilities             []armCapability `json:"capabilities,omitempty"`
-	Locations                []armLocation   `json:"locations,omitempty"`
+	DatabaseAccountOfferType     string          `json:"databaseAccountOfferType,omitempty"`
+	EnableFreeTier               bool            `json:"enableFreeTier,omitempty"`
+	Capabilities                 []armCapability `json:"capabilities,omitempty"`
+	Locations                    []armLocation   `json:"locations,omitempty"`
+	EnableMultipleWriteLocations bool            `json:"enableMultipleWriteLocations,omitempty"`
 }
 
 // armCapability is the ARM capability shape ([{name}]).
@@ -98,4 +99,10 @@ type armConnectionStringsResult struct {
 // armRegenerateKey is the DatabaseAccountRegenerateKeyParameters request body.
 type armRegenerateKey struct {
 	KeyKind string `json:"keyKind"`
+}
+
+// armFailoverPolicies is the FailoverPriorityChange request body: the new
+// ordering of regions by failover priority.
+type armFailoverPolicies struct {
+	FailoverPolicies []armFailover `json:"failoverPolicies"`
 }

--- a/server/azure/cosmosdb/container_attrs.go
+++ b/server/azure/cosmosdb/container_attrs.go
@@ -1,0 +1,143 @@
+package cosmosdb
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+// containerAttrs holds the Cosmos-only container properties the generic
+// database driver has no concept of (default TTL, unique key policy),
+// mirroring how offers.go tracks provisioned throughput out-of-band. Keyed by
+// the qualified table name (see qualify), so it shares the container's
+// database-scoped namespace.
+type containerAttrs struct {
+	// defaultTTL is ContainerProperties.DefaultTimeToLive. nil means TTL is
+	// disabled for the container (the real default): item-level "ttl" values
+	// are then inert, matching real Cosmos.
+	defaultTTL *int32
+	uniqueKeys []uniqueKeyDef
+}
+
+// attrsStore tracks containerAttrs plus the per-item TTL bookkeeping needed to
+// honor it (expiry is computed at write time from the container's default and
+// any item-level "ttl" override, since the wire layer — unlike the generic
+// driver — has no absolute-timestamp TTL attribute to reuse: Cosmos TTL is
+// seconds-since-last-write, not an absolute epoch).
+type attrsStore struct {
+	mu    sync.RWMutex
+	attrs map[string]containerAttrs
+	// expiry maps an item identity (table|partitionValue|id) to its computed
+	// expiry time. An item absent here never expires.
+	expiry map[string]time.Time
+}
+
+func newAttrsStore() *attrsStore {
+	return &attrsStore{attrs: make(map[string]containerAttrs), expiry: make(map[string]time.Time)}
+}
+
+func (s *attrsStore) set(table string, ttl *int32, uk *uniqueKeyPolicy) {
+	var keys []uniqueKeyDef
+	if uk != nil {
+		keys = uk.UniqueKeys
+	}
+
+	s.mu.Lock()
+	s.attrs[table] = containerAttrs{defaultTTL: ttl, uniqueKeys: keys}
+	s.mu.Unlock()
+}
+
+func (s *attrsStore) get(table string) containerAttrs {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.attrs[table]
+}
+
+// delete removes a container's attrs and every tracked item expiry under it,
+// called when the container (or its owning database) is deleted.
+func (s *attrsStore) delete(table string) {
+	prefix := table + "|"
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.attrs, table)
+
+	for k := range s.expiry {
+		if strings.HasPrefix(k, prefix) {
+			delete(s.expiry, k)
+		}
+	}
+}
+
+// itemIdentity builds the key TTL bookkeeping is stored under: stable across
+// create/replace/read of the same document, scoped to its partition so two
+// containers (or two partitions) never collide.
+func itemIdentity(table, pkAttr string, item map[string]any, id string) string {
+	if pkAttr == "" || pkAttr == idAttr {
+		return table + "|" + id
+	}
+
+	return table + "|" + fmt.Sprintf("%v", item[pkAttr]) + "|" + id
+}
+
+// recordWrite computes and stores (or clears) an item's TTL expiry at
+// create/replace time, from the container's defaultTTL and the item's own
+// "ttl" override, matching real Cosmos precedence: an item ttl of -1 always
+// wins (never expires); a positive item ttl overrides the container default;
+// otherwise the container default applies (itself -1 meaning no auto-expiry).
+// A container with no defaultTTL declared at all ignores item-level ttl
+// entirely, since TTL is off for the container.
+func (s *attrsStore) recordWrite(table string, cfg *dbdriver.TableConfig, item map[string]any) {
+	attrs := s.get(table)
+	if attrs.defaultTTL == nil {
+		return
+	}
+
+	effective := *attrs.defaultTTL
+	if v, ok := numericValue(item["ttl"]); ok {
+		effective = int32(v)
+	}
+
+	id, _ := item[idAttr].(string)
+	key := itemIdentity(table, cfg.PartitionKey, item, id)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if effective <= 0 {
+		// -1 (or an invalid/absent effective value) never expires; clear any
+		// expiry a previous write under this identity may have recorded.
+		delete(s.expiry, key)
+		return
+	}
+
+	s.expiry[key] = time.Now().Add(time.Duration(effective) * time.Second)
+}
+
+// expired reports whether the item at (table, id, partition value) has
+// passed its recorded TTL expiry.
+func (s *attrsStore) expired(table string, cfg *dbdriver.TableConfig, item map[string]any) bool {
+	id, _ := item[idAttr].(string)
+	key := itemIdentity(table, cfg.PartitionKey, item, id)
+
+	s.mu.RLock()
+	exp, ok := s.expiry[key]
+	s.mu.RUnlock()
+
+	return ok && time.Now().After(exp)
+}
+
+// forget removes an item's TTL bookkeeping, called on delete.
+func (s *attrsStore) forget(table string, cfg *dbdriver.TableConfig, item map[string]any) {
+	id, _ := item[idAttr].(string)
+	key := itemIdentity(table, cfg.PartitionKey, item, id)
+
+	s.mu.Lock()
+	delete(s.expiry, key)
+	s.mu.Unlock()
+}

--- a/server/azure/cosmosdb/container_lock.go
+++ b/server/azure/cosmosdb/container_lock.go
@@ -1,0 +1,39 @@
+package cosmosdb
+
+import "sync"
+
+// keyedMutex hands out one mutex per string key (a Cosmos container's qualified
+// table name), created on first use. It serializes the compound check-then-write
+// operations a single container needs — a document create's
+// [documentExists + checkUniqueKeys + PutItem] must be one uninterruptible step,
+// or two concurrent creates carrying the same (partition, unique-key value) can
+// both pass the uniqueness check and both insert, violating Cosmos's 409
+// guarantee. The same per-container lock also serializes replaces, deletes and
+// TTL reaping so a lazy expiry sweep can never delete a document a concurrent
+// write just resurrected.
+type keyedMutex struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func newKeyedMutex() *keyedMutex {
+	return &keyedMutex{locks: make(map[string]*sync.Mutex)}
+}
+
+// lock acquires the mutex for key and returns its unlock func. The returned
+// func must be called (typically via defer) to release the lock.
+func (k *keyedMutex) lock(key string) func() {
+	k.mu.Lock()
+
+	m, ok := k.locks[key]
+	if !ok {
+		m = &sync.Mutex{}
+		k.locks[key] = m
+	}
+
+	k.mu.Unlock()
+
+	m.Lock()
+
+	return m.Unlock
+}

--- a/server/azure/cosmosdb/database_throughput_test.go
+++ b/server/azure/cosmosdb/database_throughput_test.go
@@ -1,0 +1,63 @@
+// This file exercises database-level shared provisioned throughput: the HIGH
+// bug where CreateDatabase with ThroughputProperties never created an offer,
+// so ReadThroughput always 404d even for a database explicitly provisioned
+// with shared RU/s.
+
+package cosmosdb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+// TestSDKDatabaseThroughput drives CreateDatabase with shared manual
+// throughput and asserts ReadThroughput round-trips it.
+func TestSDKDatabaseThroughput(t *testing.T) {
+	ctx := context.Background()
+	client := newThroughputClient(t)
+
+	manual := azcosmos.NewManualThroughputProperties(500)
+
+	if _, err := client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: "shareddb"}, &azcosmos.CreateDatabaseOptions{
+		ThroughputProperties: &manual,
+	}); err != nil {
+		t.Fatalf("CreateDatabase with throughput: %v", err)
+	}
+
+	dbClient, err := client.NewDatabase("shareddb")
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	readResp, err := dbClient.ReadThroughput(ctx, nil)
+	if err != nil {
+		t.Fatalf("ReadThroughput: %v", err)
+	}
+
+	got, ok := readResp.ThroughputProperties.ManualThroughput()
+	if !ok || got != 500 {
+		t.Errorf("database ReadThroughput manual=%d ok=%v want 500", got, ok)
+	}
+}
+
+// TestSDKDatabaseThroughputAbsent asserts a database created without shared
+// throughput has no offer, matching a container with no dedicated offer.
+func TestSDKDatabaseThroughputAbsent(t *testing.T) {
+	ctx := context.Background()
+	client := newThroughputClient(t)
+
+	if _, err := client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: "unshareddb"}, nil); err != nil {
+		t.Fatalf("CreateDatabase: %v", err)
+	}
+
+	dbClient, err := client.NewDatabase("unshareddb")
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	if _, err := dbClient.ReadThroughput(ctx, nil); err == nil {
+		t.Fatal("ReadThroughput on a database with no shared offer: expected error, got nil")
+	}
+}

--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -69,6 +69,11 @@ type Handler struct {
 	// no concept of (default TTL, unique key policy) plus the per-item TTL
 	// bookkeeping needed to enforce it. See container_attrs.go.
 	attrs *attrsStore
+
+	// writeMu serializes item mutations and TTL reaping per container. A create's
+	// uniqueness check and its insert must be one uninterruptible step (see
+	// keyedMutex), and a lazy TTL sweep must not race a concurrent write.
+	writeMu *keyedMutex
 }
 
 // New returns a Cosmos handler backed by db.
@@ -78,6 +83,7 @@ func New(db dbdriver.Database) *Handler {
 		offers:    make(map[string]offerState),
 		databases: make(map[string]struct{}),
 		attrs:     newAttrsStore(),
+		writeMu:   newKeyedMutex(),
 	}
 }
 
@@ -494,28 +500,76 @@ func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, coll st
 		return
 	}
 
+	if err := h.insertDocument(r.Context(), coll, cfg, item, isUpsert(r)); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	addSystemProps(item)
+	writeJSON(w, http.StatusCreated, item)
+}
+
+// insertDocument performs the duplicate-id check, unique-key check and PutItem
+// as one atomic step under the container's write lock, so two concurrent
+// creates carrying the same (partition, unique-key value) cannot both pass the
+// checks and both insert. On upsert the duplicate-id check is skipped (create
+// becomes create-or-replace). Conflicts are returned as AlreadyExists so the
+// wire layer maps them to a 409.
+func (h *Handler) insertDocument(
+	ctx context.Context, coll string, cfg *dbdriver.TableConfig, item map[string]any, upsert bool,
+) error {
+	unlock := h.writeMu.lock(coll)
+	defer unlock()
+
 	// A plain create (not an upsert) must fail if a document with the same
 	// (partition key, id) already exists, matching real Cosmos's 409 Conflict.
-	if !isUpsert(r) && h.documentExists(r.Context(), coll, cfg, item) {
-		writeError(w, http.StatusConflict, "Conflict",
-			"Resource with specified id or name already exists.")
-		return
+	if !upsert && h.documentExists(ctx, coll, cfg, item) {
+		return cerrors.New(cerrors.AlreadyExists, "Resource with specified id or name already exists.")
 	}
 
-	if err := h.checkUniqueKeys(r.Context(), coll, cfg, item); err != nil {
-		writeErr(w, err)
-		return
+	if err := h.checkUniqueKeys(ctx, coll, cfg, item); err != nil {
+		return err
 	}
 
-	if err := h.db.PutItem(r.Context(), coll, item); err != nil {
-		writeErr(w, err)
-		return
+	if err := h.db.PutItem(ctx, coll, item); err != nil {
+		return err
 	}
 
 	h.attrs.recordWrite(coll, cfg, item)
 
-	addSystemProps(item)
-	writeJSON(w, http.StatusCreated, item)
+	return nil
+}
+
+// replaceDocument overwrites a document and refreshes its TTL bookkeeping under
+// the container's write lock, so a concurrent TTL reap cannot delete the item
+// between the write and the expiry update.
+func (h *Handler) replaceDocument(ctx context.Context, coll string, cfg *dbdriver.TableConfig, item map[string]any) error {
+	unlock := h.writeMu.lock(coll)
+	defer unlock()
+
+	if err := h.db.PutItem(ctx, coll, item); err != nil {
+		return err
+	}
+
+	h.attrs.recordWrite(coll, cfg, item)
+
+	return nil
+}
+
+// deleteDocument removes a document and its TTL bookkeeping under the
+// container's write lock, keeping the delete and forget serialized against
+// creates, replaces and TTL reaps.
+func (h *Handler) deleteDocument(ctx context.Context, coll string, cfg *dbdriver.TableConfig, keyMap map[string]any) error {
+	unlock := h.writeMu.lock(coll)
+	defer unlock()
+
+	if err := h.db.DeleteItem(ctx, coll, keyMap); err != nil {
+		return err
+	}
+
+	h.attrs.forget(coll, cfg, keyMap)
+
+	return nil
 }
 
 // documentExists reports whether a document with item's (partition key, id)
@@ -537,17 +591,14 @@ func (h *Handler) documentExists(
 // also enforces per-item TTL, lazily reaping an expired document the same way
 // a real Cosmos TTL background sweep would already have removed it.
 func (h *Handler) readDocument(w http.ResponseWriter, r *http.Request, coll string, cfg *dbdriver.TableConfig, keyMap map[string]any) {
-	item, err := h.db.GetItem(r.Context(), coll, keyMap)
+	item, expired, err := h.pointRead(r.Context(), coll, cfg, keyMap)
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	if h.attrs.expired(coll, cfg, item) {
-		_ = h.db.DeleteItem(r.Context(), coll, keyMap)
-		h.attrs.forget(coll, cfg, item)
+	if expired {
 		writeError(w, http.StatusNotFound, "NotFound", "item not found")
-
 		return
 	}
 
@@ -555,19 +606,48 @@ func (h *Handler) readDocument(w http.ResponseWriter, r *http.Request, coll stri
 	writeJSON(w, http.StatusOK, item)
 }
 
-// dropExpired filters out items whose TTL has elapsed, matching what a real
-// Cosmos TTL background sweep would already have removed by the time a
-// List/Query request observes the container.
+// pointRead fetches a document and, when its TTL has elapsed, reaps it under the
+// container's write lock (reporting expired=true) so the read-time expiry check
+// and the delete are atomic against a concurrent create/replace.
+func (h *Handler) pointRead(
+	ctx context.Context, coll string, cfg *dbdriver.TableConfig, keyMap map[string]any,
+) (item map[string]any, expired bool, err error) {
+	unlock := h.writeMu.lock(coll)
+	defer unlock()
+
+	item, err = h.db.GetItem(ctx, coll, keyMap)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if h.attrs.expired(coll, cfg, item) {
+		h.reapExpired(ctx, coll, cfg, item)
+		return nil, true, nil
+	}
+
+	return item, false, nil
+}
+
+// dropExpired filters out items whose TTL has elapsed AND reaps them from the
+// store — deleting the document and forgetting its TTL bookkeeping — matching a
+// real Cosmos TTL background sweep, which does not merely hide expired items but
+// removes them. Reaping runs under the container's write lock so a document a
+// concurrent create/replace just wrote is never mistaken for the expired one
+// and deleted.
 func (h *Handler) dropExpired(ctx context.Context, coll string, items []map[string]any) []map[string]any {
 	cfg, err := h.db.DescribeTable(ctx, coll)
 	if err != nil || cfg == nil {
 		return items
 	}
 
+	unlock := h.writeMu.lock(coll)
+	defer unlock()
+
 	out := make([]map[string]any, 0, len(items))
 
 	for _, it := range items {
 		if h.attrs.expired(coll, cfg, it) {
+			h.reapExpired(ctx, coll, cfg, it)
 			continue
 		}
 
@@ -575,6 +655,18 @@ func (h *Handler) dropExpired(ctx context.Context, coll string, items []map[stri
 	}
 
 	return out
+}
+
+// reapExpired deletes an expired document from the store and forgets its TTL
+// bookkeeping. The caller must already hold the container's write lock.
+func (h *Handler) reapExpired(ctx context.Context, coll string, cfg *dbdriver.TableConfig, item map[string]any) {
+	key := map[string]any{idAttr: item[idAttr]}
+	if cfg.PartitionKey != "" && cfg.PartitionKey != idAttr {
+		key[cfg.PartitionKey] = item[cfg.PartitionKey]
+	}
+
+	_ = h.db.DeleteItem(ctx, coll, key)
+	h.attrs.forget(coll, cfg, item)
 }
 
 func (h *Handler) listDocuments(w http.ResponseWriter, r *http.Request, coll string) {
@@ -682,22 +774,19 @@ func (h *Handler) documentResource(w http.ResponseWriter, r *http.Request, db, c
 			item[idAttr] = id
 		}
 
-		if err := h.db.PutItem(r.Context(), coll, item); err != nil {
+		if err := h.replaceDocument(r.Context(), coll, cfg, item); err != nil {
 			writeErr(w, err)
 			return
 		}
-
-		h.attrs.recordWrite(coll, cfg, item)
 
 		addSystemProps(item)
 		writeJSON(w, http.StatusOK, item)
 	case http.MethodDelete:
-		if err := h.db.DeleteItem(r.Context(), coll, keyMap); err != nil {
+		if err := h.deleteDocument(r.Context(), coll, cfg, keyMap); err != nil {
 			writeErr(w, err)
 			return
 		}
 
-		h.attrs.forget(coll, cfg, keyMap)
 		w.WriteHeader(http.StatusNoContent)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")

--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -64,6 +64,11 @@ type Handler struct {
 	// each database an isolated container namespace.
 	dbMu      sync.RWMutex
 	databases map[string]struct{}
+
+	// attrs tracks the Cosmos-only container properties the generic driver has
+	// no concept of (default TTL, unique key policy) plus the per-item TTL
+	// bookkeeping needed to enforce it. See container_attrs.go.
+	attrs *attrsStore
 }
 
 // New returns a Cosmos handler backed by db.
@@ -72,6 +77,7 @@ func New(db dbdriver.Database) *Handler {
 		db:        db,
 		offers:    make(map[string]offerState),
 		databases: make(map[string]struct{}),
+		attrs:     newAttrsStore(),
 	}
 }
 
@@ -240,6 +246,13 @@ func (h *Handler) createDatabase(w http.ResponseWriter, r *http.Request) {
 	h.databases[body.ID] = struct{}{}
 	h.dbMu.Unlock()
 
+	// A database created with ThroughputProperties (shared, database-level
+	// provisioned throughput) gets its own offer, keyed by the same _rid
+	// makeDatabaseResource assigns it — recordOffer's containerRID(id) derives
+	// exactly that "rid-{id}" key, so ReadThroughput round-trips without a
+	// container ever having been created.
+	h.recordOffer(body.ID, r)
+
 	writeJSON(w, http.StatusCreated, makeDatabaseResource(body.ID))
 }
 
@@ -307,8 +320,10 @@ func (h *Handler) deleteDatabase(w http.ResponseWriter, r *http.Request, db stri
 		}
 
 		h.deleteOffer(t)
+		h.attrs.delete(t)
 	}
 
+	h.deleteOffer(db) // the database's own shared-throughput offer, if any
 	h.dbMu.Lock()
 	delete(h.databases, db)
 	h.dbMu.Unlock()
@@ -364,9 +379,11 @@ func (h *Handler) createContainer(w http.ResponseWriter, r *http.Request, db str
 		return
 	}
 
-	h.recordOffer(qualify(db, body.ID), r)
+	table := qualify(db, body.ID)
+	h.recordOffer(table, r)
+	h.attrs.set(table, body.DefaultTTL, body.UniqueKeyPolicy)
 
-	writeJSON(w, http.StatusCreated, makeContainerResource(db, body.ID, body.PartitionKey))
+	writeJSON(w, http.StatusCreated, makeContainerResource(db, body.ID, body.PartitionKey, body.DefaultTTL, body.UniqueKeyPolicy))
 }
 
 func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request, db string) {
@@ -398,8 +415,9 @@ func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request, db stri
 			pk = &partitionKeyDef{Paths: []string{"/" + cfg.PartitionKey}, Kind: "Hash"}
 		}
 
+		attrs := h.attrs.get(t)
 		out.DocumentCollections = append(out.DocumentCollections,
-			makeContainerResource(db, coll, pk))
+			makeContainerResource(db, coll, pk, attrs.defaultTTL, uniqueKeyPolicyFromDef(attrs.uniqueKeys)))
 	}
 
 	out.Count = len(out.DocumentCollections)
@@ -423,7 +441,8 @@ func (h *Handler) containerResource(w http.ResponseWriter, r *http.Request, db, 
 			pk = &partitionKeyDef{Paths: []string{"/" + cfg.PartitionKey}, Kind: "Hash"}
 		}
 
-		writeJSON(w, http.StatusOK, makeContainerResource(db, coll, pk))
+		attrs := h.attrs.get(table)
+		writeJSON(w, http.StatusOK, makeContainerResource(db, coll, pk, attrs.defaultTTL, uniqueKeyPolicyFromDef(attrs.uniqueKeys)))
 	case http.MethodDelete:
 		if err := h.db.DeleteTable(r.Context(), table); err != nil {
 			writeErr(w, err)
@@ -431,6 +450,7 @@ func (h *Handler) containerResource(w http.ResponseWriter, r *http.Request, db, 
 		}
 
 		h.deleteOffer(table)
+		h.attrs.delete(table)
 		w.WriteHeader(http.StatusNoContent)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
@@ -482,10 +502,17 @@ func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, coll st
 		return
 	}
 
+	if err := h.checkUniqueKeys(r.Context(), coll, cfg, item); err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	if err := h.db.PutItem(r.Context(), coll, item); err != nil {
 		writeErr(w, err)
 		return
 	}
+
+	h.attrs.recordWrite(coll, cfg, item)
 
 	addSystemProps(item)
 	writeJSON(w, http.StatusCreated, item)
@@ -504,6 +531,50 @@ func (h *Handler) documentExists(
 	_, err := h.db.GetItem(ctx, coll, key)
 
 	return err == nil
+}
+
+// readDocument serves the GET case of documentResource: a point read that
+// also enforces per-item TTL, lazily reaping an expired document the same way
+// a real Cosmos TTL background sweep would already have removed it.
+func (h *Handler) readDocument(w http.ResponseWriter, r *http.Request, coll string, cfg *dbdriver.TableConfig, keyMap map[string]any) {
+	item, err := h.db.GetItem(r.Context(), coll, keyMap)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if h.attrs.expired(coll, cfg, item) {
+		_ = h.db.DeleteItem(r.Context(), coll, keyMap)
+		h.attrs.forget(coll, cfg, item)
+		writeError(w, http.StatusNotFound, "NotFound", "item not found")
+
+		return
+	}
+
+	addSystemProps(item)
+	writeJSON(w, http.StatusOK, item)
+}
+
+// dropExpired filters out items whose TTL has elapsed, matching what a real
+// Cosmos TTL background sweep would already have removed by the time a
+// List/Query request observes the container.
+func (h *Handler) dropExpired(ctx context.Context, coll string, items []map[string]any) []map[string]any {
+	cfg, err := h.db.DescribeTable(ctx, coll)
+	if err != nil || cfg == nil {
+		return items
+	}
+
+	out := make([]map[string]any, 0, len(items))
+
+	for _, it := range items {
+		if h.attrs.expired(coll, cfg, it) {
+			continue
+		}
+
+		out = append(out, it)
+	}
+
+	return out
 }
 
 func (h *Handler) listDocuments(w http.ResponseWriter, r *http.Request, coll string) {
@@ -527,11 +598,13 @@ func (h *Handler) listDocuments(w http.ResponseWriter, r *http.Request, coll str
 		return
 	}
 
-	docs := make([]any, 0, len(result.Items))
+	items := h.dropExpired(r.Context(), coll, result.Items)
 
-	for i := range result.Items {
-		addSystemProps(result.Items[i])
-		docs = append(docs, result.Items[i])
+	docs := make([]any, 0, len(items))
+
+	for i := range items {
+		addSystemProps(items[i])
+		docs = append(docs, items[i])
 	}
 
 	if result.NextPageToken != "" {
@@ -541,7 +614,7 @@ func (h *Handler) listDocuments(w http.ResponseWriter, r *http.Request, coll str
 	writeJSON(w, http.StatusOK, documentsList{
 		RID:       "cloudemu",
 		Documents: docs,
-		Count:     result.Count,
+		Count:     len(docs),
 	})
 }
 
@@ -564,7 +637,9 @@ func (h *Handler) queryDocuments(w http.ResponseWriter, r *http.Request, coll st
 		return
 	}
 
-	matched, ferr := cosmosFilter(result.Items, stmt.Where)
+	items := h.dropExpired(r.Context(), coll, result.Items)
+
+	matched, ferr := cosmosFilter(items, stmt.Where)
 	if ferr != nil {
 		writeErr(w, ferr)
 		return
@@ -595,14 +670,7 @@ func (h *Handler) documentResource(w http.ResponseWriter, r *http.Request, db, c
 
 	switch r.Method {
 	case http.MethodGet:
-		item, err := h.db.GetItem(r.Context(), coll, keyMap)
-		if err != nil {
-			writeErr(w, err)
-			return
-		}
-
-		addSystemProps(item)
-		writeJSON(w, http.StatusOK, item)
+		h.readDocument(w, r, coll, cfg, keyMap)
 	case http.MethodPut:
 		// Replace document.
 		item, ok := decodeAnyJSON(w, r)
@@ -619,6 +687,8 @@ func (h *Handler) documentResource(w http.ResponseWriter, r *http.Request, db, c
 			return
 		}
 
+		h.attrs.recordWrite(coll, cfg, item)
+
 		addSystemProps(item)
 		writeJSON(w, http.StatusOK, item)
 	case http.MethodDelete:
@@ -627,6 +697,7 @@ func (h *Handler) documentResource(w http.ResponseWriter, r *http.Request, db, c
 			return
 		}
 
+		h.attrs.forget(coll, cfg, keyMap)
 		w.WriteHeader(http.StatusNoContent)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
@@ -720,7 +791,7 @@ func makeDatabaseResource(id string) databaseResource {
 	}
 }
 
-func makeContainerResource(db, id string, pk *partitionKeyDef) containerResource {
+func makeContainerResource(db, id string, pk *partitionKeyDef, defaultTTL *int32, uk *uniqueKeyPolicy) containerResource {
 	// The container's _rid doubles as its offer resource id: the SDK reads _rid
 	// off the container, then queries /offers by it. Qualifying by database keeps
 	// the offer key unique across databases (see recordOffer / qualify).
@@ -739,13 +810,27 @@ func makeContainerResource(db, id string, pk *partitionKeyDef) containerResource
 			TS:    time.Now().Unix(),
 			Attac: "attachments/",
 		},
-		Docs:         "docs/",
-		Sprocs:       "sprocs/",
-		Triggers:     "triggers/",
-		UDFs:         "udfs/",
-		Conflicts:    "conflicts/",
-		PartitionKey: pk,
+		Docs:            "docs/",
+		Sprocs:          "sprocs/",
+		Triggers:        "triggers/",
+		UDFs:            "udfs/",
+		Conflicts:       "conflicts/",
+		PartitionKey:    pk,
+		DefaultTTL:      defaultTTL,
+		UniqueKeyPolicy: uk,
 	}
+}
+
+// uniqueKeyPolicyFromDef re-wraps the attrsStore's flat []uniqueKeyDef back
+// into the wire uniqueKeyPolicy shape for a Read/List response; nil when the
+// container declared no unique keys, so the field is omitted rather than
+// echoed as an empty policy.
+func uniqueKeyPolicyFromDef(keys []uniqueKeyDef) *uniqueKeyPolicy {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	return &uniqueKeyPolicy{UniqueKeys: keys}
 }
 
 func addSystemProps(item map[string]any) {

--- a/server/azure/cosmosdb/ttl_test.go
+++ b/server/azure/cosmosdb/ttl_test.go
@@ -1,0 +1,178 @@
+// This file exercises Cosmos's own container-level default TTL
+// (ContainerProperties.DefaultTimeToLive), as opposed to the generic
+// driver-level TTLConfig exercised by TestCosmosTTL in cosmos_lifecycle_test.go.
+// A real Cosmos client sets defaultTtl on the container itself (no driver call
+// involved), so these tests drive container create/read and document
+// create/read entirely through the real azcosmos SDK.
+
+package cosmosdb_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+// ttlContainer creates a container with the given DefaultTimeToLive (nil
+// leaves TTL disabled) and returns its client.
+func ttlContainer(ctx context.Context, t *testing.T, e *cosmosEnv, db, name string, defaultTTL *int32) *azcosmos.ContainerClient {
+	t.Helper()
+
+	if _, err := e.client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: db}, nil); err != nil {
+		t.Fatalf("CreateDatabase(%s): %v", db, err)
+	}
+
+	dbClient, err := e.client.NewDatabase(db)
+	if err != nil {
+		t.Fatalf("NewDatabase(%s): %v", db, err)
+	}
+
+	props := azcosmos.ContainerProperties{
+		ID:                     name,
+		PartitionKeyDefinition: azcosmos.PartitionKeyDefinition{Paths: []string{"/pk"}},
+		DefaultTimeToLive:      defaultTTL,
+	}
+	if _, err := dbClient.CreateContainer(ctx, props, nil); err != nil {
+		t.Fatalf("CreateContainer(%s): %v", name, err)
+	}
+
+	cc, err := dbClient.NewContainer(name)
+	if err != nil {
+		t.Fatalf("NewContainer(%s): %v", name, err)
+	}
+
+	return cc
+}
+
+// TestSDKContainerDefaultTTLEchoed asserts a container created with
+// DefaultTimeToLive echoes it back on Read — the HIGH bug: defaultTtl was
+// silently dropped and never persisted.
+func TestSDKContainerDefaultTTLEchoed(t *testing.T) {
+	ctx := context.Background()
+	e := newCosmosEnv(t)
+	cc := ttlContainer(ctx, t, e, "ttlwiredb", "events", to.Ptr[int32](3600))
+
+	resp, err := cc.Read(ctx, nil)
+	if err != nil {
+		t.Fatalf("Read container: %v", err)
+	}
+
+	if resp.ContainerProperties == nil || resp.ContainerProperties.DefaultTimeToLive == nil {
+		t.Fatalf("Read container DefaultTimeToLive = nil, want 3600")
+	}
+
+	if got := *resp.ContainerProperties.DefaultTimeToLive; got != 3600 {
+		t.Errorf("Read container DefaultTimeToLive = %d, want 3600", got)
+	}
+}
+
+// TestSDKContainerNoDefaultTTL asserts a container created without a
+// DefaultTimeToLive reads back nil (TTL stays disabled by default).
+func TestSDKContainerNoDefaultTTL(t *testing.T) {
+	ctx := context.Background()
+	e := newCosmosEnv(t)
+	cc := ttlContainer(ctx, t, e, "nottldb", "plain", nil)
+
+	resp, err := cc.Read(ctx, nil)
+	if err != nil {
+		t.Fatalf("Read container: %v", err)
+	}
+
+	if resp.ContainerProperties != nil && resp.ContainerProperties.DefaultTimeToLive != nil {
+		t.Errorf("Read container DefaultTimeToLive = %d, want nil (disabled)", *resp.ContainerProperties.DefaultTimeToLive)
+	}
+}
+
+// TestSDKItemDefaultTTLExpires asserts a document written into a container
+// with a short DefaultTimeToLive is honored: present immediately after
+// create, gone (404) once the TTL elapses.
+func TestSDKItemDefaultTTLExpires(t *testing.T) {
+	ctx := context.Background()
+	e := newCosmosEnv(t)
+	cc := ttlContainer(ctx, t, e, "ttlexpiredb", "sessions", to.Ptr[int32](1))
+
+	doc := map[string]any{"id": "s1", "pk": "s1", "user": "alice"}
+	createDoc(ctx, t, cc, "s1", doc)
+
+	// Immediately after create the item is still there.
+	if got := readDoc(ctx, t, cc, "s1", "s1"); got["user"] != "alice" {
+		t.Errorf("pre-expiry user=%v want alice", got["user"])
+	}
+
+	time.Sleep(1200 * time.Millisecond)
+
+	_, err := cc.ReadItem(ctx, azcosmos.NewPartitionKeyString("s1"), "s1", nil)
+	wantRespErr(t, err, 404, "ReadItem after container defaultTtl elapsed")
+
+	// A query over the container filters the expired item out too.
+	pager := cc.NewQueryItemsPager("SELECT * FROM c", azcosmos.NewPartitionKeyString("s1"), nil)
+
+	live := 0
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("NextPage: %v", perr)
+		}
+
+		live += len(page.Items)
+	}
+
+	if live != 0 {
+		t.Errorf("query after expiry returned %d items, want 0", live)
+	}
+}
+
+// TestSDKItemTTLOverride asserts a per-item "ttl": -1 opts a document out of
+// the container's default expiry, matching real Cosmos precedence.
+func TestSDKItemTTLOverride(t *testing.T) {
+	ctx := context.Background()
+	e := newCosmosEnv(t)
+	cc := ttlContainer(ctx, t, e, "ttloverridedb", "sessions", to.Ptr[int32](1))
+
+	doc := map[string]any{"id": "keep", "pk": "keep", "user": "bob", "ttl": -1}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if _, err := cc.CreateItem(ctx, azcosmos.NewPartitionKeyString("keep"), b, nil); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	time.Sleep(1200 * time.Millisecond)
+
+	got := readDoc(ctx, t, cc, "keep", "keep")
+	if got["user"] != "bob" {
+		t.Errorf("item with ttl=-1 override: user=%v want bob (should not have expired)", got["user"])
+	}
+}
+
+// TestSDKItemTTLDisabledOnContainer asserts an item's own "ttl" is inert when
+// the container has no DefaultTimeToLive declared at all, matching real
+// Cosmos: TTL must first be enabled at the container.
+func TestSDKItemTTLDisabledOnContainer(t *testing.T) {
+	ctx := context.Background()
+	e := newCosmosEnv(t)
+	cc := ttlContainer(ctx, t, e, "ttldisableddb", "sessions", nil)
+
+	doc := map[string]any{"id": "s1", "pk": "s1", "user": "alice", "ttl": 1}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if _, err := cc.CreateItem(ctx, azcosmos.NewPartitionKeyString("s1"), b, nil); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	time.Sleep(1200 * time.Millisecond)
+
+	got := readDoc(ctx, t, cc, "s1", "s1")
+	if got["user"] != "alice" {
+		t.Errorf("item ttl on a TTL-disabled container: user=%v want alice (should not have expired)", got["user"])
+	}
+}

--- a/server/azure/cosmosdb/types.go
+++ b/server/azure/cosmosdb/types.go
@@ -27,14 +27,31 @@ type databasesList struct {
 
 type containerResource struct {
 	resource
-	Docs            string           `json:"_docs,omitempty"`
-	Sprocs          string           `json:"_sprocs,omitempty"`
-	Triggers        string           `json:"_triggers,omitempty"`
-	UDFs            string           `json:"_udfs,omitempty"`
-	Conflicts       string           `json:"_conflicts,omitempty"`
-	PartitionKey    *partitionKeyDef `json:"partitionKey,omitempty"`
-	IndexingPolicy  map[string]any   `json:"indexingPolicy,omitempty"`
-	UniqueKeyPolicy map[string]any   `json:"uniqueKeyPolicy,omitempty"`
+	Docs           string           `json:"_docs,omitempty"`
+	Sprocs         string           `json:"_sprocs,omitempty"`
+	Triggers       string           `json:"_triggers,omitempty"`
+	UDFs           string           `json:"_udfs,omitempty"`
+	Conflicts      string           `json:"_conflicts,omitempty"`
+	PartitionKey   *partitionKeyDef `json:"partitionKey,omitempty"`
+	IndexingPolicy map[string]any   `json:"indexingPolicy,omitempty"`
+	// DefaultTTL is ContainerProperties.DefaultTimeToLive: nil means TTL is
+	// disabled for the container (the real API's default), -1 means enabled
+	// with no automatic expiry (an item's own "ttl" can still opt in), and a
+	// positive value is the default expiry in seconds since last modified.
+	DefaultTTL      *int32           `json:"defaultTtl,omitempty"`
+	UniqueKeyPolicy *uniqueKeyPolicy `json:"uniqueKeyPolicy,omitempty"`
+}
+
+// uniqueKeyPolicy is the Cosmos UniqueKeyPolicy wire shape: a set of unique
+// key constraints, each scoped to a single partition-key value.
+type uniqueKeyPolicy struct {
+	UniqueKeys []uniqueKeyDef `json:"uniqueKeys,omitempty"`
+}
+
+// uniqueKeyDef is one compound unique-key constraint: the tuple of document
+// paths (e.g. "/email") that together must be unique within a partition.
+type uniqueKeyDef struct {
+	Paths []string `json:"paths"`
 }
 
 type partitionKeyDef struct {

--- a/server/azure/cosmosdb/unique_key.go
+++ b/server/azure/cosmosdb/unique_key.go
@@ -1,0 +1,126 @@
+package cosmosdb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+// checkUniqueKeys enforces the container's UniqueKeyPolicy against candidate,
+// a document about to be created. Real Cosmos scopes a unique key constraint
+// to a single partition-key value, so only documents sharing candidate's
+// partition are considered; a document missing one of the constraint's paths
+// never collides (real Cosmos ignores an unset property when checking
+// uniqueness, rather than treating it as a matching null).
+func (h *Handler) checkUniqueKeys(ctx context.Context, table string, cfg *dbdriver.TableConfig, candidate map[string]any) error {
+	attrs := h.attrs.get(table)
+	if len(attrs.uniqueKeys) == 0 {
+		return nil
+	}
+
+	result, err := h.db.Scan(ctx, dbdriver.ScanInput{Table: table, Limit: allResults})
+	if err != nil {
+		return err
+	}
+
+	selfID, _ := candidate[idAttr].(string)
+	candidatePK := partitionValue(cfg, candidate)
+
+	for _, uk := range attrs.uniqueKeys {
+		vals, ok := uniqueKeyTuple(candidate, uk.Paths)
+		if !ok {
+			continue
+		}
+
+		if conflictsWithinPartition(result.Items, cfg, selfID, candidatePK, vals, uk.Paths) {
+			return cerrors.New(cerrors.AlreadyExists, "unique index constraint violation")
+		}
+	}
+
+	return nil
+}
+
+func conflictsWithinPartition(
+	items []map[string]any, cfg *dbdriver.TableConfig, selfID, candidatePK string, vals []any, paths []string,
+) bool {
+	for _, other := range items {
+		if otherID, _ := other[idAttr].(string); otherID == selfID {
+			continue
+		}
+
+		if cfg.PartitionKey != "" && partitionValue(cfg, other) != candidatePK {
+			continue
+		}
+
+		otherVals, ok := uniqueKeyTuple(other, paths)
+		if ok && equalTuples(vals, otherVals) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func partitionValue(cfg *dbdriver.TableConfig, item map[string]any) string {
+	if cfg.PartitionKey == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%v", item[cfg.PartitionKey])
+}
+
+// uniqueKeyTuple resolves every path in a unique-key constraint against item,
+// returning ok=false when any path is unset (such a document never
+// participates in that constraint, matching real Cosmos).
+func uniqueKeyTuple(item map[string]any, paths []string) ([]any, bool) {
+	vals := make([]any, 0, len(paths))
+
+	for _, p := range paths {
+		v, ok := uniqueKeyValue(item, p)
+		if !ok {
+			return nil, false
+		}
+
+		vals = append(vals, v)
+	}
+
+	return vals, true
+}
+
+// uniqueKeyValue walks a Cosmos property path ("/a/b") over nested maps.
+func uniqueKeyValue(item map[string]any, path string) (any, bool) {
+	var cur any = item
+
+	for _, seg := range strings.Split(strings.TrimPrefix(path, "/"), "/") {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+
+		v, ok := m[seg]
+		if !ok {
+			return nil, false
+		}
+
+		cur = v
+	}
+
+	return cur, true
+}
+
+func equalTuples(a, b []any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if fmt.Sprintf("%v", a[i]) != fmt.Sprintf("%v", b[i]) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/server/azure/cosmosdb/unique_key_test.go
+++ b/server/azure/cosmosdb/unique_key_test.go
@@ -1,0 +1,108 @@
+// This file exercises Cosmos's UniqueKeyPolicy: the HIGH bug where a
+// container's declared unique keys were accepted at create time but never
+// persisted or enforced (GET echoed UniqueKeyPolicy as nil, and a duplicate
+// value on the declared unique key succeeded instead of 409ing).
+
+package cosmosdb_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+// uniqueKeyContainer creates a container with a UniqueKeyPolicy on /email and
+// returns its client.
+func uniqueKeyContainer(ctx context.Context, t *testing.T, e *cosmosEnv, db, name string) *azcosmos.ContainerClient {
+	t.Helper()
+
+	if _, err := e.client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: db}, nil); err != nil {
+		t.Fatalf("CreateDatabase(%s): %v", db, err)
+	}
+
+	dbClient, err := e.client.NewDatabase(db)
+	if err != nil {
+		t.Fatalf("NewDatabase(%s): %v", db, err)
+	}
+
+	props := azcosmos.ContainerProperties{
+		ID:                     name,
+		PartitionKeyDefinition: azcosmos.PartitionKeyDefinition{Paths: []string{"/pk"}},
+		UniqueKeyPolicy: &azcosmos.UniqueKeyPolicy{
+			UniqueKeys: []azcosmos.UniqueKey{{Paths: []string{"/email"}}},
+		},
+	}
+	if _, err := dbClient.CreateContainer(ctx, props, nil); err != nil {
+		t.Fatalf("CreateContainer(%s): %v", name, err)
+	}
+
+	cc, err := dbClient.NewContainer(name)
+	if err != nil {
+		t.Fatalf("NewContainer(%s): %v", name, err)
+	}
+
+	return cc
+}
+
+// TestSDKUniqueKeyPolicyEchoed asserts a container's declared UniqueKeyPolicy
+// round-trips through Read.
+func TestSDKUniqueKeyPolicyEchoed(t *testing.T) {
+	ctx := context.Background()
+	e := newCosmosEnv(t)
+	cc := uniqueKeyContainer(ctx, t, e, "ukwiredb", "users")
+
+	resp, err := cc.Read(ctx, nil)
+	if err != nil {
+		t.Fatalf("Read container: %v", err)
+	}
+
+	if resp.ContainerProperties == nil || resp.ContainerProperties.UniqueKeyPolicy == nil {
+		t.Fatalf("Read container UniqueKeyPolicy = nil, want /email unique key")
+	}
+
+	uk := resp.ContainerProperties.UniqueKeyPolicy.UniqueKeys
+	if len(uk) != 1 || len(uk[0].Paths) != 1 || uk[0].Paths[0] != "/email" {
+		t.Errorf("Read container UniqueKeyPolicy = %+v, want [{Paths:[/email]}]", uk)
+	}
+}
+
+// TestSDKUniqueKeyDuplicateRejected asserts creating a second document in the
+// same partition with the same /email value 409s, and a distinct value or a
+// different partition both succeed.
+func TestSDKUniqueKeyDuplicateRejected(t *testing.T) {
+	ctx := context.Background()
+	e := newCosmosEnv(t)
+	cc := uniqueKeyContainer(ctx, t, e, "ukenforcedb", "users")
+
+	createDoc(ctx, t, cc, "team-a", map[string]any{"id": "u1", "pk": "team-a", "email": "alice@example.com"})
+
+	// Same partition, same email, different id: real Cosmos 409s.
+	dup := map[string]any{"id": "u2", "pk": "team-a", "email": "alice@example.com"}
+	b, err := json.Marshal(dup)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	_, err = cc.CreateItem(ctx, azcosmos.NewPartitionKeyString("team-a"), b, nil)
+	wantRespErr(t, err, 409, "CreateItem duplicate unique key within partition")
+
+	// Same partition, different email: allowed.
+	createDoc(ctx, t, cc, "team-a", map[string]any{"id": "u3", "pk": "team-a", "email": "carol@example.com"})
+
+	// Different partition, same email: real Cosmos scopes the constraint to a
+	// single partition-key value, so this is also allowed.
+	createDoc(ctx, t, cc, "team-b", map[string]any{"id": "u4", "pk": "team-b", "email": "alice@example.com"})
+}
+
+// TestSDKUniqueKeyMissingFieldAllowed asserts a document that never sets the
+// declared unique-key path never collides, matching real Cosmos.
+func TestSDKUniqueKeyMissingFieldAllowed(t *testing.T) {
+	ctx := context.Background()
+	e := newCosmosEnv(t)
+	cc := uniqueKeyContainer(ctx, t, e, "ukmissingdb", "users")
+
+	createDoc(ctx, t, cc, "team-a", map[string]any{"id": "u1", "pk": "team-a"})
+	createDoc(ctx, t, cc, "team-a", map[string]any{"id": "u2", "pk": "team-a"})
+}

--- a/server/azure/cosmosdb/unique_key_test.go
+++ b/server/azure/cosmosdb/unique_key_test.go
@@ -8,8 +8,13 @@ package cosmosdb_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 )
 
@@ -105,4 +110,110 @@ func TestSDKUniqueKeyMissingFieldAllowed(t *testing.T) {
 
 	createDoc(ctx, t, cc, "team-a", map[string]any{"id": "u1", "pk": "team-a"})
 	createDoc(ctx, t, cc, "team-a", map[string]any{"id": "u2", "pk": "team-a"})
+}
+
+// TestSDKUniqueKeyConcurrentCreateSingleWinner is the regression test for the
+// check-then-act race in unique-key enforcement: checkUniqueKeys scans the
+// container and decides, then PutItem writes, with nothing held across the two.
+// Two concurrent creates carrying the same (partition, unique-key value) could
+// both pass the scan and both insert, so more than one 201 was returned instead
+// of a single winner and 409s for the rest. It fires N concurrent creates that
+// all share one (partition="team-a", email="race@example.com") and asserts
+// EXACTLY one succeeds. Filler documents widen the scan window the race lives
+// in. This is a logical (check-then-act) race, so -race does not surface it —
+// the assertion on the winner count is what fails pre-fix.
+func TestSDKUniqueKeyConcurrentCreateSingleWinner(t *testing.T) {
+	ctx := context.Background()
+	e := newCosmosEnv(t)
+
+	const (
+		dbName   = "ukracedb"
+		collName = "users"
+		fillers  = 3000
+		racers   = 50
+	)
+
+	cc := uniqueKeyContainer(ctx, t, e, dbName, collName)
+
+	// Preload filler docs straight through the shared driver (fast, in-memory).
+	// They share partition "team-a" with distinct emails, so none collide with
+	// each other or the racers — they only make checkUniqueKeys' full-table Scan
+	// walk more items, widening the check-then-write window.
+	table := dbName + "/" + collName
+
+	for i := range fillers {
+		filler := map[string]any{
+			"id":    fmt.Sprintf("filler-%d", i),
+			"pk":    "team-a",
+			"email": fmt.Sprintf("filler-%d@example.com", i),
+		}
+		if err := e.provider.CosmosDB.PutItem(ctx, table, filler); err != nil {
+			t.Fatalf("preload filler %d: %v", i, err)
+		}
+	}
+
+	var (
+		wg        sync.WaitGroup
+		successes atomic.Int32
+		conflicts atomic.Int32
+		others    atomic.Int32
+	)
+
+	start := make(chan struct{})
+
+	for i := range racers {
+		wg.Add(1)
+
+		go func(idx int) {
+			defer wg.Done()
+
+			doc := map[string]any{
+				"id":    fmt.Sprintf("racer-%d", idx),
+				"pk":    "team-a",
+				"email": "race@example.com",
+			}
+
+			b, err := json.Marshal(doc)
+			if err != nil {
+				others.Add(1)
+				return
+			}
+
+			<-start // release all goroutines together to maximize overlap
+
+			resp, cerr := cc.CreateItem(ctx, azcosmos.NewPartitionKeyString("team-a"), b, nil)
+
+			switch {
+			case cerr == nil && resp.RawResponse.StatusCode == 201:
+				successes.Add(1)
+			case isRespStatus(cerr, 409):
+				conflicts.Add(1)
+			default:
+				others.Add(1)
+			}
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	if got := successes.Load(); got != 1 {
+		t.Errorf("concurrent same-unique-key create: %d succeeded, want exactly 1", got)
+	}
+
+	if got := conflicts.Load(); got != racers-1 {
+		t.Errorf("concurrent same-unique-key create: %d got 409, want %d", got, racers-1)
+	}
+
+	if got := others.Load(); got != 0 {
+		t.Errorf("concurrent same-unique-key create: %d unexpected outcomes, want 0", got)
+	}
+}
+
+// isRespStatus reports whether err is an azcore.ResponseError with the given
+// HTTP status. Unlike wantRespErr it returns a bool, so a goroutine can classify
+// an outcome without failing the test from a non-test goroutine.
+func isRespStatus(err error, status int) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == status
 }

--- a/server/azure/cosmosdb/unique_key_test.go
+++ b/server/azure/cosmosdb/unique_key_test.go
@@ -129,8 +129,12 @@ func TestSDKUniqueKeyConcurrentCreateSingleWinner(t *testing.T) {
 	const (
 		dbName   = "ukracedb"
 		collName = "users"
-		fillers  = 3000
-		racers   = 50
+		// fillers is deliberately large: checkUniqueKeys does a full-table Scan,
+		// so a big container widens the check-then-write window enough that the
+		// pre-fix (unlocked) race reproduces on every run — a handful of fillers
+		// leaves the window too narrow to reliably catch the bug.
+		fillers = 40000
+		racers  = 50
 	)
 
 	cc := uniqueKeyContainer(ctx, t, e, dbName, collName)

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -280,6 +280,15 @@ type IndexInfo struct {
 	Status       string // "ACTIVE", "CREATING", "DELETING"
 }
 
+// AccountLocation is one region entry in a Cosmos account's declared
+// topology, mirroring the ARM `Location` shape (locationName +
+// failoverPriority + isZoneRedundant) without depending on any ARM wire type.
+type AccountLocation struct {
+	Name             string // region name, e.g. "westus2"
+	FailoverPriority int32  // 0 = write region; must be unique per account
+	IsZoneRedundant  bool
+}
+
 // AccountAttributes are the Cosmos-DB-account cost/identity attributes a real
 // Azure `documentdb/databaseaccounts` resource carries but a DynamoDB/Firestore
 // table does not. Surfaced through the optional TableAttributes capability.
@@ -288,9 +297,17 @@ type AccountAttributes struct {
 	OfferType      string            // databaseAccountOfferType (Standard)
 	EnableFreeTier bool              // free-tier flag (cost)
 	Capabilities   []string          // e.g. EnableServerless (cost)
-	Location       string            // creation region (e.g. eastus)
+	Location       string            // creation region (e.g. eastus) — first/write location
 	ResourceGroup  string            // owning resource group (for byRG listing)
 	Tags           map[string]string // user-supplied resource tags
+	// Locations is the full multi-region topology declared at create time (or
+	// last reordered by failoverPriorityChange). Locations/readLocations/
+	// writeLocations/failoverPolicies are all derived from this one list.
+	// Empty means the account is single-region, using Location above.
+	Locations []AccountLocation
+	// EnableMultipleWriteLocations mirrors the ARM property of the same name:
+	// when true every declared location accepts writes, not just priority 0.
+	EnableMultipleWriteLocations bool
 }
 
 // TableAttributes is an OPTIONAL capability, discovered by type assertion (like


### PR DESCRIPTION
## Summary

Fixes five Cosmos DB bugs found in a deep-sweep audit against the real `armcosmos` / `azcosmos` SDKs:

- **Multi-region accounts collapsed to one region.** `PUT databaseAccounts/{name}` with `Locations: [{westus2, p0}, {eastus2, p1}]` returned only one location, with `readLocations`/`writeLocations`/`failoverPolicies` left unpopulated. The full `Locations` list is now persisted on `AccountAttributes` (new `Locations []AccountLocation` field) and every array on Get/List is derived from it, ordered by failover priority. `writeLocations` reflects `EnableMultipleWriteLocations`.
- **`failoverPriorityChange` 404d.** The action is now handled: it reorders the account's failover priorities and completes synchronously with 204 (the SDK's poller only accepts 202/204, not 200).
- **Container `defaultTtl` was dropped.** `ContainerProperties.DefaultTimeToLive` is now persisted and echoed on container Read/List, and per-item TTL (container default plus an item's own `"ttl"` override) is enforced: an expired item is lazily reaped on point-read and filtered out of List/Query, matching what a real TTL background sweep would already have removed.
- **`UniqueKeyPolicy` was accepted but never enforced.** It's now persisted and echoed on Read/List, and enforced on document create: a duplicate value on the declared unique key within the same partition now gets a real 409, while a different partition or a document missing the field is unaffected.
- **Database-level shared throughput was dropped.** `CreateDatabase` with `ThroughputProperties` now creates an offer (reusing the existing `/offers` tracking), so `ReadThroughput` on the database round-trips instead of 404ing.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./server/azure/cosmosdb/... ./server/azure/cosmosaccount/... ./services/database/... ./providers/azure/cosmosdb/...`
- [x] `go test -race ./server/azure/cosmosdb/... ./server/azure/cosmosaccount/...`
- [x] `go test ./...` (full suite)
- [x] `go test ./compat/...`
- [x] `golangci-lint run` on changed packages — 0 new issues
- [x] `gofmt -l` clean
- [x] New regression tests drive the real `armcosmos`/`azcosmos` SDKs against a live TLS wire server for every fix above (multi-region create/get, `failoverPriorityChange`, container `defaultTtl` echo + expiry + item-level override, `UniqueKeyPolicy` echo + 409 enforcement, database `ReadThroughput`)