### PR TITLE
fix(azure-vnet): subnet validation, NSG security-rule sub-resource CRUD, subnet/NIC association, effective NSGs

### DIFF
--- a/docs/coverage/aws/vpc.md
+++ b/docs/coverage/aws/vpc.md
@@ -87,11 +87,13 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | Operation | Description |
 | --- | --- |
 | `DeleteAzureNSGMetadata` |  |
+| `DeleteAzureNSGRule` | DeleteAzureNSGRule removes a single custom security rule by name, leaving |
 | `DeleteAzureVNetMetadata` |  |
 | `GetAzureNSGMetadata` |  |
 | `GetAzureVNetMetadata` |  |
 | `PutAzureNSGMetadata` |  |
 | `PutAzureVNetMetadata` |  |
+| `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
 
 ### ClientVPN
 

--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -87,11 +87,13 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | Operation | Description |
 | --- | --- |
 | `DeleteAzureNSGMetadata` |  |
+| `DeleteAzureNSGRule` | DeleteAzureNSGRule removes a single custom security rule by name, leaving |
 | `DeleteAzureVNetMetadata` |  |
 | `GetAzureNSGMetadata` |  |
 | `GetAzureVNetMetadata` |  |
 | `PutAzureNSGMetadata` |  |
 | `PutAzureVNetMetadata` |  |
+| `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
 
 ### ClientVPN
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -6469,6 +6469,10 @@
             "name": "DeleteAzureNSGMetadata"
           },
           {
+            "name": "DeleteAzureNSGRule",
+            "doc": "DeleteAzureNSGRule removes a single custom security rule by name, leaving"
+          },
+          {
             "name": "DeleteAzureVNetMetadata"
           },
           {
@@ -6482,6 +6486,10 @@
           },
           {
             "name": "PutAzureVNetMetadata"
+          },
+          {
+            "name": "UpsertAzureNSGRule",
+            "doc": "UpsertAzureNSGRule creates or replaces a single custom security rule by"
           }
         ]
       },

--- a/docs/coverage/gcp/vpc.md
+++ b/docs/coverage/gcp/vpc.md
@@ -87,11 +87,13 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | Operation | Description |
 | --- | --- |
 | `DeleteAzureNSGMetadata` |  |
+| `DeleteAzureNSGRule` | DeleteAzureNSGRule removes a single custom security rule by name, leaving |
 | `DeleteAzureVNetMetadata` |  |
 | `GetAzureNSGMetadata` |  |
 | `GetAzureVNetMetadata` |  |
 | `PutAzureNSGMetadata` |  |
 | `PutAzureVNetMetadata` |  |
+| `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
 
 ### ClientVPN
 

--- a/docs/coverage/oci/vcn.md
+++ b/docs/coverage/oci/vcn.md
@@ -87,11 +87,13 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | Operation | Description |
 | --- | --- |
 | `DeleteAzureNSGMetadata` |  |
+| `DeleteAzureNSGRule` | DeleteAzureNSGRule removes a single custom security rule by name, leaving |
 | `DeleteAzureVNetMetadata` |  |
 | `GetAzureNSGMetadata` |  |
 | `GetAzureVNetMetadata` |  |
 | `PutAzureNSGMetadata` |  |
 | `PutAzureVNetMetadata` |  |
+| `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
 
 ### ClientVPN
 

--- a/providers/azure/vnet/azure_network_metadata.go
+++ b/providers/azure/vnet/azure_network_metadata.go
@@ -3,6 +3,7 @@ package vnet
 import (
 	"context"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
@@ -53,6 +54,80 @@ func (m *Mock) GetAzureNSGMetadata(_ context.Context, id string) (driver.AzureNS
 // security group is deleted).
 func (m *Mock) DeleteAzureNSGMetadata(_ context.Context, id string) {
 	m.azureNSGMeta.Delete(id)
+}
+
+// UpsertAzureNSGRule creates or replaces a single custom security rule by
+// name via an atomic read-modify-write on the stored metadata, leaving every
+// sibling rule untouched — the SecurityRules sub-resource CRUD's mutation.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) UpsertAzureNSGRule(_ context.Context, id string, rule driver.AzureNSGRule) (driver.AzureNSGMetadata, error) {
+	var updated driver.AzureNSGMetadata
+
+	ok := m.azureNSGMeta.Update(id, func(meta driver.AzureNSGMetadata) driver.AzureNSGMetadata {
+		rules := append([]driver.AzureNSGRule(nil), meta.SecurityRules...)
+
+		replaced := false
+
+		for i := range rules {
+			if rules[i].Name == rule.Name {
+				rules[i] = rule
+				replaced = true
+
+				break
+			}
+		}
+
+		if !replaced {
+			rules = append(rules, rule)
+		}
+
+		meta.SecurityRules = rules
+		updated = cloneNSGMeta(meta)
+
+		return meta
+	})
+	if !ok {
+		return driver.AzureNSGMetadata{}, cerrors.Newf(cerrors.NotFound, "network security group %q not found", id)
+	}
+
+	return updated, nil
+}
+
+// DeleteAzureNSGRule removes a single custom security rule by name via an
+// atomic read-modify-write, leaving every sibling rule untouched.
+func (m *Mock) DeleteAzureNSGRule(_ context.Context, id, ruleName string) error {
+	ruleMissing := false
+
+	ok := m.azureNSGMeta.Update(id, func(meta driver.AzureNSGMetadata) driver.AzureNSGMetadata {
+		idx := -1
+
+		for i := range meta.SecurityRules {
+			if meta.SecurityRules[i].Name == ruleName {
+				idx = i
+				break
+			}
+		}
+
+		if idx == -1 {
+			ruleMissing = true
+
+			return meta
+		}
+
+		meta.SecurityRules = append(append([]driver.AzureNSGRule(nil), meta.SecurityRules[:idx]...), meta.SecurityRules[idx+1:]...)
+
+		return meta
+	})
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", id)
+	}
+
+	if ruleMissing {
+		return cerrors.Newf(cerrors.NotFound, "security rule %q not found", ruleName)
+	}
+
+	return nil
 }
 
 // cloneVNetMeta deep-copies the address-prefix slice so stored and returned

--- a/providers/azure/vnet/azure_nsg_rule_test.go
+++ b/providers/azure/vnet/azure_nsg_rule_test.go
@@ -1,0 +1,139 @@
+package vnet
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createTestNSG(t *testing.T, m *Mock, vpcID string) string {
+	t.Helper()
+
+	ctx := context.Background()
+
+	info, err := m.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{Name: "nsg-1", VPCID: vpcID})
+	require.NoError(t, err)
+
+	require.NoError(t, m.PutAzureNSGMetadata(ctx, info.ID, driver.AzureNSGMetadata{Location: "eastus"}))
+
+	return info.ID
+}
+
+func TestUpsertAzureNSGRule(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpcID := createTestVPC(t, m)
+	nsgID := createTestNSG(t, m, vpcID)
+
+	meta, err := m.UpsertAzureNSGRule(ctx, nsgID, driver.AzureNSGRule{
+		Name: "Allow-SSH", Priority: 100, Direction: "Inbound", Access: "Allow", Protocol: "Tcp",
+		SourceAddressPrefix: "*", DestinationAddressPrefix: "*", SourcePortRange: "*", DestinationPortRange: "22",
+	})
+	require.NoError(t, err)
+	require.Len(t, meta.SecurityRules, 1)
+	assert.Equal(t, "Allow-SSH", meta.SecurityRules[0].Name)
+
+	// A second rule must not disturb the first.
+	meta, err = m.UpsertAzureNSGRule(ctx, nsgID, driver.AzureNSGRule{
+		Name: "Allow-HTTP", Priority: 110, Direction: "Inbound", Access: "Allow", Protocol: "Tcp",
+		DestinationPortRange: "80",
+	})
+	require.NoError(t, err)
+	require.Len(t, meta.SecurityRules, 2)
+
+	// Re-PUT of the same name replaces in place rather than appending.
+	meta, err = m.UpsertAzureNSGRule(ctx, nsgID, driver.AzureNSGRule{
+		Name: "Allow-SSH", Priority: 100, Direction: "Inbound", Access: "Deny", Protocol: "Tcp",
+		DestinationPortRange: "22",
+	})
+	require.NoError(t, err)
+	require.Len(t, meta.SecurityRules, 2)
+
+	for _, r := range meta.SecurityRules {
+		if r.Name == "Allow-SSH" {
+			assert.Equal(t, "Deny", r.Access)
+		}
+	}
+}
+
+func TestUpsertAzureNSGRuleNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.UpsertAzureNSGRule(context.Background(), "nsg-missing", driver.AzureNSGRule{Name: "r1"})
+	require.Error(t, err)
+}
+
+func TestDeleteAzureNSGRule(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpcID := createTestVPC(t, m)
+	nsgID := createTestNSG(t, m, vpcID)
+
+	_, err := m.UpsertAzureNSGRule(ctx, nsgID, driver.AzureNSGRule{Name: "r1", Priority: 100, Direction: "Inbound"})
+	require.NoError(t, err)
+	_, err = m.UpsertAzureNSGRule(ctx, nsgID, driver.AzureNSGRule{Name: "r2", Priority: 110, Direction: "Inbound"})
+	require.NoError(t, err)
+
+	require.NoError(t, m.DeleteAzureNSGRule(ctx, nsgID, "r1"))
+
+	md, found := m.GetAzureNSGMetadata(ctx, nsgID)
+	require.True(t, found)
+	require.Len(t, md.SecurityRules, 1)
+	assert.Equal(t, "r2", md.SecurityRules[0].Name)
+}
+
+func TestDeleteAzureNSGRuleNotFound(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpcID := createTestVPC(t, m)
+	nsgID := createTestNSG(t, m, vpcID)
+
+	err := m.DeleteAzureNSGRule(ctx, nsgID, "missing")
+	require.Error(t, err)
+
+	err = m.DeleteAzureNSGRule(ctx, "nsg-missing", "missing")
+	require.Error(t, err)
+}
+
+// TestUpsertAzureNSGRuleConcurrent guards the sub-resource CRUD path against
+// lost updates: N goroutines each add a distinct rule to the SAME NSG. With a
+// non-atomic Get()+Set() read-modify-write all but a handful silently vanish;
+// the store.Update path keeps every one. Run with -race.
+func TestUpsertAzureNSGRuleConcurrent(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpcID := createTestVPC(t, m)
+	nsgID := createTestNSG(t, m, vpcID)
+
+	const n = 50
+
+	var wg sync.WaitGroup
+
+	wg.Add(n)
+
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			_, upErr := m.UpsertAzureNSGRule(ctx, nsgID, driver.AzureNSGRule{
+				Name: fmt.Sprintf("rule-%d", i), Priority: 100 + i, Direction: "Inbound", Access: "Allow",
+			})
+			assert.NoError(t, upErr)
+		}(i)
+	}
+
+	wg.Wait()
+
+	md, found := m.GetAzureNSGMetadata(ctx, nsgID)
+	require.True(t, found)
+	assert.Len(t, md.SecurityRules, n, "every concurrently-added security rule must survive")
+}

--- a/providers/azure/vnet/network_interface.go
+++ b/providers/azure/vnet/network_interface.go
@@ -28,17 +28,18 @@ const (
 
 // nicData is the stored Azure network interface, keyed by (resourceGroup, name).
 type nicData struct {
-	Name              string
-	ResourceGroup     string
-	Location          string
-	Tags              map[string]string
-	IPConfigs         []driver.AzureIPConfig
-	IPForwarding      bool
-	MACAddress        string
-	ResourceGUID      string
-	ProvisioningState string
-	ETag              string
-	VirtualMachineID  string
+	Name                   string
+	ResourceGroup          string
+	Location               string
+	Tags                   map[string]string
+	IPConfigs              []driver.AzureIPConfig
+	IPForwarding           bool
+	NetworkSecurityGroupID string
+	MACAddress             string
+	ResourceGUID           string
+	ProvisioningState      string
+	ETag                   string
+	VirtualMachineID       string
 }
 
 // nicKey composes the store key from the ARM addressing pair. Resource-group
@@ -74,14 +75,15 @@ func (m *Mock) CreateOrUpdateNetworkInterface(
 	}
 
 	nic := &nicData{
-		Name:              name,
-		ResourceGroup:     resourceGroup,
-		Location:          cfg.Location,
-		Tags:              copyTags(cfg.Tags),
-		IPConfigs:         ipConfigs,
-		IPForwarding:      cfg.IPForwarding,
-		ProvisioningState: "Succeeded",
-		ETag:              `W/"` + idgen.GenerateID("etag-") + `"`,
+		Name:                   name,
+		ResourceGroup:          resourceGroup,
+		Location:               cfg.Location,
+		Tags:                   copyTags(cfg.Tags),
+		IPConfigs:              ipConfigs,
+		IPForwarding:           cfg.IPForwarding,
+		NetworkSecurityGroupID: cfg.NetworkSecurityGroupID,
+		ProvisioningState:      "Succeeded",
+		ETag:                   `W/"` + idgen.GenerateID("etag-") + `"`,
 	}
 
 	if isUpdate {
@@ -272,17 +274,18 @@ func toAzureNIC(n *nicData) driver.AzureNIC {
 	copy(configs, n.IPConfigs)
 
 	return driver.AzureNIC{
-		Name:              n.Name,
-		ResourceGroup:     n.ResourceGroup,
-		Location:          n.Location,
-		Tags:              copyTags(n.Tags),
-		IPConfigs:         configs,
-		IPForwarding:      n.IPForwarding,
-		MACAddress:        n.MACAddress,
-		ResourceGUID:      n.ResourceGUID,
-		ProvisioningState: n.ProvisioningState,
-		ETag:              n.ETag,
-		VirtualMachineID:  n.VirtualMachineID,
+		Name:                   n.Name,
+		ResourceGroup:          n.ResourceGroup,
+		Location:               n.Location,
+		Tags:                   copyTags(n.Tags),
+		IPConfigs:              configs,
+		IPForwarding:           n.IPForwarding,
+		NetworkSecurityGroupID: n.NetworkSecurityGroupID,
+		MACAddress:             n.MACAddress,
+		ResourceGUID:           n.ResourceGUID,
+		ProvisioningState:      n.ProvisioningState,
+		ETag:                   n.ETag,
+		VirtualMachineID:       n.VirtualMachineID,
 	}
 }
 

--- a/server/azure/vnet/effective_nsg.go
+++ b/server/azure/vnet/effective_nsg.go
@@ -1,0 +1,185 @@
+package vnet
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// listEffectiveNSGs serves InterfacesClient.BeginListEffectiveNetworkSecurityGroups:
+// POST .../networkInterfaces/{nic}/effectiveNetworkSecurityGroups. It returns
+// one EffectiveNetworkSecurityGroup entry per NSG that actually applies to the
+// NIC — its own networkSecurityGroup association and its (primary
+// ipConfiguration's) subnet's networkSecurityGroup association — each carrying
+// that NSG's custom rules plus the six built-in defaults, matching real ARM's
+// merged view of "what traffic this NIC actually sees".
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listEffectiveNSGs(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkInterfaces,
+) {
+	nic, err := svc.GetNetworkInterface(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	nicID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeNIC, rp.ResourceName)
+
+	out := effectiveNSGListResponse{}
+
+	if nic.NetworkSecurityGroupID != "" {
+		if entry, ok := h.effectiveNSGEntry(r.Context(), nic.NetworkSecurityGroupID,
+			effectiveNSGAssociation{NetworkInterface: &armIDRef{ID: nicID}}); ok {
+			out.Value = append(out.Value, entry)
+		}
+	}
+
+	if subnetID, nsgID := h.nicSubnetNSG(r.Context(), nic); nsgID != "" {
+		if entry, ok := h.effectiveNSGEntry(r.Context(), nsgID,
+			effectiveNSGAssociation{Subnet: &armIDRef{ID: subnetID}}); ok {
+			out.Value = append(out.Value, entry)
+		}
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+// nicSubnetNSG resolves the subnet referenced by the NIC's primary (or first)
+// ipConfiguration and returns its ARM id together with the NSG ARM id tagged
+// on it (armSubnetNSGTag), or ("", "") when the NIC has no subnet reference or
+// that subnet has no associated NSG.
+func (h *Handler) nicSubnetNSG(ctx context.Context, nic *netdriver.AzureNIC) (subnetID, nsgID string) {
+	candidate := primaryIPConfigSubnetID(nic)
+	if candidate == "" {
+		return "", ""
+	}
+
+	sp, ok := azurearm.ParsePath(candidate)
+	if !ok || sp.ResourceType != typeVNet || sp.SubResource != subResSubnets {
+		return "", ""
+	}
+
+	vnet, err := findVNetByName(ctx, h.net, sp.ResourceName)
+	if err != nil {
+		return "", ""
+	}
+
+	subs, err := h.net.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return "", ""
+	}
+
+	for i := range subs {
+		if subs[i].VPCID == vnet.ID && tagOr(subs[i].Tags, armSubnetTag, "") == sp.SubResourceName {
+			return candidate, tagOr(subs[i].Tags, armSubnetNSGTag, "")
+		}
+	}
+
+	return "", ""
+}
+
+// primaryIPConfigSubnetID returns the ARM subnet id of nic's primary
+// ipConfiguration, falling back to the first ipConfiguration that carries a
+// subnet reference when none is marked primary.
+func primaryIPConfigSubnetID(nic *netdriver.AzureNIC) string {
+	var candidate string
+
+	for i := range nic.IPConfigs {
+		if nic.IPConfigs[i].SubnetID == "" {
+			continue
+		}
+
+		if nic.IPConfigs[i].Primary || candidate == "" {
+			candidate = nic.IPConfigs[i].SubnetID
+		}
+	}
+
+	return candidate
+}
+
+// effectiveNSGEntry builds one EffectiveNetworkSecurityGroup entry for the NSG
+// identified by its ARM resource id (nsgARMID), combining its custom rules
+// with the six built-in defaults. ok is false when the NSG id doesn't resolve
+// (e.g. a stale reference).
+func (h *Handler) effectiveNSGEntry(ctx context.Context, nsgARMID string, assoc effectiveNSGAssociation) (effectiveNSG, bool) {
+	nsgRP, ok := azurearm.ParsePath(nsgARMID)
+	if !ok || nsgRP.ResourceType != typeNSG {
+		return effectiveNSG{}, false
+	}
+
+	info, err := findNSGByName(ctx, h.net, nsgRP.ResourceName)
+	if err != nil {
+		return effectiveNSG{}, false
+	}
+
+	meta, hasMeta := h.azureMeta()
+
+	var rules []netdriver.AzureNSGRule
+
+	if hasMeta {
+		if md, found := meta.GetAzureNSGMetadata(ctx, info.ID); found {
+			rules = md.SecurityRules
+		}
+	}
+
+	return effectiveNSG{
+		Association:            assoc,
+		EffectiveSecurityRules: toEffectiveRules(nsgARMID, rules),
+		NetworkSecurityGroup:   armIDRef{ID: nsgARMID},
+	}, true
+}
+
+// toEffectiveRules flattens an NSG's custom rules and its six built-in
+// defaults into the effectiveSecurityRule shape, name-prefixed the way real
+// ARM does ("securityRules/{name}" / "defaultSecurityRules/{name}").
+func toEffectiveRules(nsgARMID string, custom []netdriver.AzureNSGRule) []effectiveSecurityRule {
+	out := make([]effectiveSecurityRule, 0, len(custom)+len(azureDefaultRules))
+
+	for i := range custom {
+		r := custom[i]
+		out = append(out, effectiveSecurityRule{
+			Name:                     "securityRules/" + r.Name,
+			Protocol:                 effectiveProtocol(r.Protocol),
+			SourcePortRange:          r.SourcePortRange,
+			DestinationPortRange:     r.DestinationPortRange,
+			SourceAddressPrefix:      r.SourceAddressPrefix,
+			DestinationAddressPrefix: r.DestinationAddressPrefix,
+			Access:                   r.Access,
+			Priority:                 r.Priority,
+			Direction:                r.Direction,
+		})
+	}
+
+	defaults := defaultSecurityRules(nsgARMID)
+
+	for i := range defaults {
+		spec := &defaults[i]
+		out = append(out, effectiveSecurityRule{
+			Name:                     "defaultSecurityRules/" + spec.Name,
+			Protocol:                 effectiveProtocol(spec.Properties.Protocol),
+			SourcePortRange:          spec.Properties.SourcePortRange,
+			DestinationPortRange:     spec.Properties.DestinationPortRange,
+			SourceAddressPrefix:      spec.Properties.SourceAddressPrefix,
+			DestinationAddressPrefix: spec.Properties.DestinationAddressPrefix,
+			Access:                   spec.Properties.Access,
+			Priority:                 spec.Properties.Priority,
+			Direction:                spec.Properties.Direction,
+		})
+	}
+
+	return out
+}
+
+// effectiveProtocol maps the wire security-rule protocol ("*", "Tcp", ...) to
+// the distinct EffectiveSecurityRuleProtocol vocabulary real ARM uses for this
+// endpoint, which spells the wildcard "All" rather than "*".
+func effectiveProtocol(p string) string {
+	if p == protoAny {
+		return "All"
+	}
+
+	return p
+}

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -42,8 +42,14 @@ const (
 	// property), so both the subnet response and the NAT gateway's
 	// read-only subnets list can reflect the association.
 	armSubnetNATTag = "cloudemu:azureSubnetNATGateway"
-	defaultLoc      = "eastus"
-	subResSubnets   = "subnets"
+	// armSubnetNSGTag stores the full ARM resource id of the network security
+	// group a subnet is associated with (set via the subnet's own
+	// networkSecurityGroup property), mirroring armSubnetNATTag.
+	armSubnetNSGTag     = "cloudemu:azureSubnetNSG"
+	defaultLoc          = "eastus"
+	subResSubnets       = "subnets"
+	subResSecurityRules = "securityRules"
+	subResCheckIPAvail  = "CheckIPAddressAvailability"
 )
 
 // Handler serves Microsoft.Network ARM requests against a networking driver.
@@ -119,6 +125,22 @@ func (h *Handler) routeVNet(w http.ResponseWriter, r *http.Request, rp azurearm.
 		return
 	}
 
+	// CheckIPAddressAvailability is a GET action on the vnet itself
+	// (.../virtualNetworks/{name}/CheckIPAddressAvailability?ipAddress=...),
+	// not a nested resource — route it before the plain vnet GET/PUT/DELETE
+	// switch below, or it falls through and answers with the vnet body instead
+	// of an IPAddressAvailabilityResult.
+	if strings.EqualFold(rp.SubResource, subResCheckIPAvail) {
+		if r.Method != http.MethodGet {
+			azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+			return
+		}
+
+		h.checkIPAddressAvailability(w, r, rp)
+
+		return
+	}
+
 	if rp.ResourceName == "" {
 		h.listVNets(w, r, rp)
 		return
@@ -159,6 +181,16 @@ func (h *Handler) routeSubnet(w http.ResponseWriter, r *http.Request, rp azurear
 func (h *Handler) routeNSG(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	if rp.ResourceName == "" {
 		h.listNSGs(w, r, rp)
+		return
+	}
+
+	// SecurityRule sub-resource (SecurityRulesClient / azurerm_network_security_rule):
+	// SubResource="securityRules", SubResourceName="{ruleName}". Routed before
+	// the whole-NSG method switch below so a standalone rule PUT/GET/DELETE
+	// never hits createNSG/getNSG/deleteNSG, which are scoped to rp.ResourceName
+	// (the NSG's own name, not a rule).
+	if rp.SubResource == subResSecurityRules {
+		h.routeSecurityRule(w, r, rp)
 		return
 	}
 
@@ -208,9 +240,19 @@ func (h *Handler) createVNet(w http.ResponseWriter, r *http.Request, rp azurearm
 	}
 
 	// Materialize any inline subnets so they become real, addressable children
-	// (Subnets.Get resolves them) rather than a body-only echo.
+	// (Subnets.Get resolves them) rather than a body-only echo, and make this
+	// PUT authoritative over the whole subnets collection.
 	if err := h.materializeSubnets(r.Context(), info.ID, req.Properties.Subnets); err != nil {
-		azurearm.WriteCErr(w, err)
+		// A subnet this PUT's body omits but that's still in use by a NIC: ARM
+		// answers 400 InUseSubnetCannotBeDeleted, not the generic 409 WriteCErr
+		// would emit for FailedPrecondition.
+		if cerrors.IsFailedPrecondition(err) {
+			azurearm.WriteError(w, http.StatusBadRequest, "InUseSubnetCannotBeDeleted", err.Error())
+			return
+		}
+
+		writeSubnetValidationError(w, err)
+
 		return
 	}
 
@@ -254,10 +296,24 @@ func (h *Handler) upsertVNet(ctx context.Context, name string, prefixes []string
 	})
 }
 
-// materializeSubnets creates the inline subnets carried in a vnet PUT body,
-// skipping any that already exist (idempotent re-PUT).
+// materializeSubnets makes a whole-VNet PUT authoritative over its subnets
+// collection, matching real ARM's full-replace semantics for
+// VirtualNetworksClient.BeginCreateOrUpdate: a subnet present in this PUT's
+// body but not yet stored is created; a subnet already stored but omitted
+// from this PUT's body is deleted (refused with the same in-use guard
+// deleteSubnet applies, so a body that silently drops a live subnet fails the
+// whole PUT rather than orphaning a NIC's reference).
+//
+// subs == nil (the properties.subnets key was absent from the JSON body
+// entirely, not sent as []) leaves every existing subnet untouched — Azure
+// added this exact carve-out so tag-only/address-space-only updates don't
+// need to round-trip the subnet list. See "Azure Virtual Network now supports
+// updates without subnet property" (Microsoft Community Hub). An explicit
+// empty array, by contrast, is a request to delete every subnet — nil vs.
+// non-nil is exactly what encoding/json's Unmarshal already distinguishes for
+// a JSON array field, so no extra presence-tracking is needed here.
 func (h *Handler) materializeSubnets(ctx context.Context, vpcID string, subs []subnetRequest) error {
-	if len(subs) == 0 {
+	if subs == nil {
 		return nil
 	}
 
@@ -266,28 +322,89 @@ func (h *Handler) materializeSubnets(ctx context.Context, vpcID string, subs []s
 		return err
 	}
 
-	have := make(map[string]struct{})
+	haveByName := make(map[string]netdriver.SubnetInfo, len(existing))
 
 	for i := range existing {
 		if existing[i].VPCID == vpcID {
-			have[tagOr(existing[i].Tags, armSubnetTag, "")] = struct{}{}
+			haveByName[tagOr(existing[i].Tags, armSubnetTag, "")] = existing[i]
 		}
 	}
+
+	wanted, err := h.createMissingSubnets(ctx, vpcID, subs, haveByName)
+	if err != nil {
+		return err
+	}
+
+	return h.deleteOmittedSubnets(ctx, haveByName, wanted)
+}
+
+// createMissingSubnets creates every named subnet in subs that isn't already
+// in haveByName, validating its CIDR first, and returns the set of names this
+// PUT's body wants — the input deleteOmittedSubnets needs to find what to
+// remove.
+func (h *Handler) createMissingSubnets(
+	ctx context.Context, vpcID string, subs []subnetRequest, haveByName map[string]netdriver.SubnetInfo,
+) (map[string]struct{}, error) {
+	wanted := make(map[string]struct{}, len(subs))
 
 	for i := range subs {
 		if subs[i].Name == "" {
 			continue
 		}
 
-		if _, ok := have[subs[i].Name]; ok {
+		wanted[subs[i].Name] = struct{}{}
+
+		if _, ok := haveByName[subs[i].Name]; ok {
 			continue
+		}
+
+		if verr := h.validateSubnetCIDR(ctx, vpcID, subs[i].Name, subs[i].Properties.AddressPrefix); verr != nil {
+			return nil, verr
 		}
 
 		if _, err := h.net.CreateSubnet(ctx, netdriver.SubnetConfig{
 			VPCID:     vpcID,
 			CIDRBlock: subs[i].Properties.AddressPrefix,
-			Tags:      mergeTags(nil, armSubnetTag, subs[i].Name),
+			Tags:      inlineSubnetTags(&subs[i]),
 		}); err != nil {
+			return nil, err
+		}
+	}
+
+	return wanted, nil
+}
+
+// inlineSubnetTags builds the tag set for a subnet materialized from a
+// whole-VNet PUT body, carrying over its NAT gateway / NSG references.
+func inlineSubnetTags(sub *subnetRequest) map[string]string {
+	tags := mergeTags(nil, armSubnetTag, sub.Name)
+
+	if sub.Properties.NatGateway != nil {
+		tags = mergeTags(tags, armSubnetNATTag, sub.Properties.NatGateway.ID)
+	}
+
+	if sub.Properties.NetworkSecurityGroup != nil {
+		tags = mergeTags(tags, armSubnetNSGTag, sub.Properties.NetworkSecurityGroup.ID)
+	}
+
+	return tags
+}
+
+// deleteOmittedSubnets removes every previously-existing subnet whose name
+// isn't in wanted, refusing (without deleting anything further) the first one
+// still in use by a NIC — the same guard deleteSubnet applies standalone.
+func (h *Handler) deleteOmittedSubnets(ctx context.Context, haveByName map[string]netdriver.SubnetInfo, wanted map[string]struct{}) error {
+	for name, info := range haveByName {
+		if _, ok := wanted[name]; ok {
+			continue
+		}
+
+		if h.subnetInUseByNICs(ctx, info.ID) {
+			return cerrors.Newf(cerrors.FailedPrecondition,
+				"subnet %q is in use by a network interface and cannot be deleted", name)
+		}
+
+		if err := h.net.DeleteSubnet(ctx, info.ID); err != nil {
 			return err
 		}
 	}
@@ -423,24 +540,22 @@ func (h *Handler) createSubnet(w http.ResponseWriter, r *http.Request, rp azurea
 		return
 	}
 
-	var natGatewayID string
-
-	if req.Properties.NatGateway != nil {
-		ngRP, ok := azurearm.ParsePath(req.Properties.NatGateway.ID)
-		if !ok || ngRP.ResourceType != typeNATGateway {
-			azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "malformed natGateway id")
-			return
-		}
-
-		if _, ngErr := findNATGatewayByName(r.Context(), h.net, ngRP.ResourceGroup, ngRP.ResourceName); ngErr != nil {
-			azurearm.WriteCErr(w, ngErr)
-			return
-		}
-
-		natGatewayID = req.Properties.NatGateway.ID
+	natGatewayID, ok := h.resolveSubnetNATGateway(w, r, req.Properties.NatGateway)
+	if !ok {
+		return
 	}
 
-	info, err := h.upsertSubnet(r.Context(), vnet.ID, rp.SubResourceName, req.Properties.AddressPrefix, natGatewayID)
+	nsgID, ok := h.resolveSubnetNSG(w, r, req.Properties.NetworkSecurityGroup)
+	if !ok {
+		return
+	}
+
+	if verr := h.validateSubnetCIDR(r.Context(), vnet.ID, rp.SubResourceName, req.Properties.AddressPrefix); verr != nil {
+		writeSubnetValidationError(w, verr)
+		return
+	}
+
+	info, err := h.upsertSubnet(r.Context(), vnet.ID, rp.SubResourceName, req.Properties.AddressPrefix, natGatewayID, nsgID)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -451,23 +566,81 @@ func (h *Handler) createSubnet(w http.ResponseWriter, r *http.Request, rp azurea
 	writeAcceptedAsync(w, r, rp.Subscription, "subnet-create-"+rp.SubResourceName, body)
 }
 
+// resolveSubnetNATGateway validates and resolves an optional natGateway
+// reference on a subnet PUT body, writing the appropriate error response
+// itself. ok is false when a response was already written and the caller
+// must stop.
+func (h *Handler) resolveSubnetNATGateway(w http.ResponseWriter, r *http.Request, ref *armIDRef) (id string, ok bool) {
+	if ref == nil {
+		return "", true
+	}
+
+	ngRP, parsed := azurearm.ParsePath(ref.ID)
+	if !parsed || ngRP.ResourceType != typeNATGateway {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "malformed natGateway id")
+		return "", false
+	}
+
+	if _, err := findNATGatewayByName(r.Context(), h.net, ngRP.ResourceGroup, ngRP.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return "", false
+	}
+
+	return ref.ID, true
+}
+
+// resolveSubnetNSG validates and resolves an optional networkSecurityGroup
+// reference on a subnet PUT body, writing the appropriate error response
+// itself. ok is false when a response was already written and the caller
+// must stop.
+func (h *Handler) resolveSubnetNSG(w http.ResponseWriter, r *http.Request, ref *armIDRef) (id string, ok bool) {
+	if ref == nil {
+		return "", true
+	}
+
+	nsgRP, parsed := azurearm.ParsePath(ref.ID)
+	if !parsed || nsgRP.ResourceType != typeNSG {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "malformed networkSecurityGroup id")
+		return "", false
+	}
+
+	if _, err := findNSGByName(r.Context(), h.net, nsgRP.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return "", false
+	}
+
+	return ref.ID, true
+}
+
 // upsertSubnet creates the named subnet, or — when it already exists — merges
-// in a NAT gateway reference so a subnet can be attached to a NAT gateway via
-// a second PUT (armnetwork's SubnetsClient.BeginCreateOrUpdate, the real ARM
-// mechanism: the association lives on the subnet's natGateway property, not
-// on the NAT gateway). Other subnet properties are not merged on update,
-// matching this handler's existing create-only behavior for subnets.
-func (h *Handler) upsertSubnet(ctx context.Context, vpcID, name, cidr, natGatewayID string) (*netdriver.SubnetInfo, error) {
+// in a NAT gateway and/or NSG reference so a subnet can be attached via a
+// second PUT (armnetwork's SubnetsClient.BeginCreateOrUpdate, the real ARM
+// mechanism: both associations live on the subnet's own natGateway /
+// networkSecurityGroup properties). Other subnet properties are not merged on
+// update, matching this handler's existing create-only behavior for subnets.
+func (h *Handler) upsertSubnet(ctx context.Context, vpcID, name, cidr, natGatewayID, nsgID string) (*netdriver.SubnetInfo, error) {
 	if existing, err := findSubnetInVNet(ctx, h.net, vpcID, name); err == nil {
-		if natGatewayID == "" {
+		merge := make(map[string]string)
+
+		if natGatewayID != "" {
+			merge[armSubnetNATTag] = natGatewayID
+		}
+
+		if nsgID != "" {
+			merge[armSubnetNSGTag] = nsgID
+		}
+
+		if len(merge) == 0 {
 			return existing, nil
 		}
 
-		if err := h.net.UpdateSubnetTags(ctx, existing.ID, map[string]string{armSubnetNATTag: natGatewayID}); err != nil {
+		if err := h.net.UpdateSubnetTags(ctx, existing.ID, merge); err != nil {
 			return nil, err
 		}
 
-		existing.Tags = mergeTags(existing.Tags, armSubnetNATTag, natGatewayID)
+		for k, v := range merge {
+			existing.Tags = mergeTags(existing.Tags, k, v)
+		}
 
 		return existing, nil
 	}
@@ -475,6 +648,10 @@ func (h *Handler) upsertSubnet(ctx context.Context, vpcID, name, cidr, natGatewa
 	tags := mergeTags(nil, armSubnetTag, name)
 	if natGatewayID != "" {
 		tags = mergeTags(tags, armSubnetNATTag, natGatewayID)
+	}
+
+	if nsgID != "" {
+		tags = mergeTags(tags, armSubnetNSGTag, nsgID)
 	}
 
 	return h.net.CreateSubnet(ctx, netdriver.SubnetConfig{
@@ -539,12 +716,75 @@ func (h *Handler) deleteSubnet(w http.ResponseWriter, r *http.Request, rp azurea
 		return
 	}
 
+	// A subnet still bound to a NIC ipConfiguration cannot be deleted; real
+	// ARM answers 400 InUseSubnetCannotBeDeleted (verified against the real
+	// error: https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/error-codes/publicipaddr-inusesubnet-netsecgrp-error).
+	if h.subnetInUseByNICs(r.Context(), info.ID) {
+		azurearm.WriteError(w, http.StatusBadRequest, "InUseSubnetCannotBeDeleted",
+			"subnet "+rp.SubResourceName+" is in use by a network interface and cannot be deleted")
+
+		return
+	}
+
 	if err := h.net.DeleteSubnet(r.Context(), info.ID); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
 	writeAcceptedAsync(w, r, rp.Subscription, "subnet-delete-"+rp.SubResourceName, nil)
+}
+
+// subnetInUseByNICs reports whether any network interface's ipConfiguration
+// references the subnet with the given driver id, resolving each NIC's
+// ARM subnet reference the same way subnetCIDR does.
+func (h *Handler) subnetInUseByNICs(ctx context.Context, subnetDriverID string) bool {
+	svc, ok := h.net.(netdriver.AzureNetworkInterfaces)
+	if !ok {
+		return false
+	}
+
+	nics, err := svc.ListNetworkInterfaces(ctx, "")
+	if err != nil {
+		return false
+	}
+
+	subs, err := h.net.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return false
+	}
+
+	for i := range nics {
+		for j := range nics[i].IPConfigs {
+			if resolveSubnetDriverID(ctx, h.net, subs, nics[i].IPConfigs[j].SubnetID) == subnetDriverID {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// resolveSubnetDriverID maps an ARM subnet resource id
+// (.../virtualNetworks/{vn}/subnets/{name}) to the driver's own subnet id, or
+// "" if it doesn't resolve to any known subnet.
+func resolveSubnetDriverID(ctx context.Context, n netdriver.Networking, subs []netdriver.SubnetInfo, armSubnetID string) string {
+	sp, ok := azurearm.ParsePath(armSubnetID)
+	if !ok || sp.ResourceType != typeVNet || sp.SubResource != subResSubnets {
+		return ""
+	}
+
+	vnet, err := findVNetByName(ctx, n, sp.ResourceName)
+	if err != nil {
+		return ""
+	}
+
+	for i := range subs {
+		if subs[i].VPCID == vnet.ID && tagOr(subs[i].Tags, armSubnetTag, "") == sp.SubResourceName {
+			return subs[i].ID
+		}
+	}
+
+	return ""
 }
 
 // NSG operations.
@@ -562,6 +802,13 @@ func (h *Handler) createNSG(w http.ResponseWriter, r *http.Request, rp azurearm.
 		return
 	}
 
+	rules := toAzureNSGRules(req.Properties.SecurityRules)
+
+	if verr := validateSecurityRuleBatch(rules); verr != nil {
+		azurearm.WriteCErr(w, verr)
+		return
+	}
+
 	info, err := h.upsertNSG(r.Context(), rp.ResourceName, req.Tags)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
@@ -576,7 +823,7 @@ func (h *Handler) createNSG(w http.ResponseWriter, r *http.Request, rp azurearm.
 	if meta, ok := h.azureMeta(); ok {
 		_ = meta.PutAzureNSGMetadata(r.Context(), info.ID, netdriver.AzureNSGMetadata{
 			Location:      loc,
-			SecurityRules: toAzureNSGRules(req.Properties.SecurityRules),
+			SecurityRules: rules,
 		})
 	}
 
@@ -969,6 +1216,10 @@ func toSubnetResponse(info *netdriver.SubnetInfo, rp azurearm.ResourcePath) subn
 		out.Properties.NatGateway = &armIDRef{ID: ngID}
 	}
 
+	if nsgID := tagOr(info.Tags, armSubnetNSGTag, ""); nsgID != "" {
+		out.Properties.NetworkSecurityGroup = &armIDRef{ID: nsgID}
+	}
+
 	return out
 }
 
@@ -1001,8 +1252,93 @@ func (h *Handler) nsgResponse(ctx context.Context, info *netdriver.SecurityGroup
 			ProvisioningState:    "Succeeded",
 			SecurityRules:        rules,
 			DefaultSecurityRules: defaultSecurityRules(id),
+			Subnets:              h.nsgAssociatedSubnets(ctx, id),
+			NetworkInterfaces:    h.nsgAssociatedNICs(ctx, id),
 		},
 	}
+}
+
+// nsgAssociatedSubnets scans every subnet for a networkSecurityGroup
+// reference (armSubnetNSGTag) matching nsgARMID, the read-only back-reference
+// real ARM reports on a networkSecurityGroups GET.
+func (h *Handler) nsgAssociatedSubnets(ctx context.Context, nsgARMID string) []armIDRef {
+	subs, err := h.net.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return nil
+	}
+
+	vnetNames := make(map[string]string)
+
+	var out []armIDRef
+
+	for i := range subs {
+		if !strings.EqualFold(tagOr(subs[i].Tags, armSubnetNSGTag, ""), nsgARMID) {
+			continue
+		}
+
+		vnetName, ok := vnetNames[subs[i].VPCID]
+		if !ok {
+			vnet, verr := h.net.DescribeVPCs(ctx, []string{subs[i].VPCID})
+			if verr != nil || len(vnet) == 0 {
+				continue
+			}
+
+			vnetName = tagOr(vnet[0].Tags, armNameTag, vnet[0].ID)
+			vnetNames[subs[i].VPCID] = vnetName
+		}
+
+		out = append(out, armIDRef{ID: subnetResourceID(nsgARMID, vnetName, tagOr(subs[i].Tags, armSubnetTag, ""))})
+	}
+
+	return out
+}
+
+// nsgAssociatedNICs scans every network interface for a top-level
+// networkSecurityGroup reference matching nsgARMID.
+func (h *Handler) nsgAssociatedNICs(ctx context.Context, nsgARMID string) []armIDRef {
+	svc, ok := h.net.(netdriver.AzureNetworkInterfaces)
+	if !ok {
+		return nil
+	}
+
+	nics, err := svc.ListNetworkInterfaces(ctx, "")
+	if err != nil {
+		return nil
+	}
+
+	var out []armIDRef
+
+	for i := range nics {
+		if strings.EqualFold(nics[i].NetworkSecurityGroupID, nsgARMID) {
+			out = append(out, armIDRef{ID: nicResourceID(nsgARMID, nics[i].ResourceGroup, nics[i].Name)})
+		}
+	}
+
+	return out
+}
+
+// subnetResourceID builds a subnet ARM id sharing the subscription of
+// nsgARMID (both resources live in the same ARM path shape), used only for
+// the NSG's read-only associated-subnets back-reference.
+func subnetResourceID(nsgARMID, vnetName, subnetName string) string {
+	nsgRP, ok := azurearm.ParsePath(nsgARMID)
+	if !ok {
+		return ""
+	}
+
+	return azurearm.BuildResourceID(nsgRP.Subscription, nsgRP.ResourceGroup, providerName, typeVNet, vnetName) +
+		"/subnets/" + subnetName
+}
+
+// nicResourceID builds a NIC ARM id sharing the subscription of nsgARMID,
+// used only for the NSG's read-only associated-NICs back-reference.
+func nicResourceID(nsgARMID, nicResourceGroup, nicName string) string {
+	nsgRP, ok := azurearm.ParsePath(nsgARMID)
+	if !ok {
+		return ""
+	}
+
+	return azurearm.BuildResourceID(nsgRP.Subscription, nicResourceGroup, providerName, typeNIC, nicName)
 }
 
 //nolint:gocritic // rp is a request-scoped value

--- a/server/azure/vnet/network_interface.go
+++ b/server/azure/vnet/network_interface.go
@@ -12,6 +12,10 @@ import (
 
 const typeNIC = "networkInterfaces"
 
+// subResEffectiveNSGs is the POST action segment InterfacesClient.
+// BeginListEffectiveNetworkSecurityGroups sends: .../networkInterfaces/{nic}/effectiveNetworkSecurityGroups.
+const subResEffectiveNSGs = "effectiveNetworkSecurityGroups"
+
 // ARM JSON shapes for Microsoft.Network/networkInterfaces.
 
 type nicRequest struct {
@@ -21,8 +25,9 @@ type nicRequest struct {
 }
 
 type nicRequestProps struct {
-	IPConfigurations   []nicIPConfigRequest `json:"ipConfigurations"`
-	EnableIPForwarding bool                 `json:"enableIPForwarding,omitempty"`
+	IPConfigurations     []nicIPConfigRequest `json:"ipConfigurations"`
+	EnableIPForwarding   bool                 `json:"enableIPForwarding,omitempty"`
+	NetworkSecurityGroup *armIDRef            `json:"networkSecurityGroup,omitempty"`
 }
 
 type nicIPConfigRequest struct {
@@ -53,12 +58,13 @@ type nicResponse struct {
 }
 
 type nicResponseProps struct {
-	ProvisioningState  string                `json:"provisioningState"`
-	ResourceGUID       string                `json:"resourceGuid,omitempty"`
-	MACAddress         string                `json:"macAddress,omitempty"`
-	EnableIPForwarding bool                  `json:"enableIPForwarding"`
-	IPConfigurations   []nicIPConfigResponse `json:"ipConfigurations"`
-	VirtualMachine     *armIDRef             `json:"virtualMachine,omitempty"`
+	ProvisioningState    string                `json:"provisioningState"`
+	ResourceGUID         string                `json:"resourceGuid,omitempty"`
+	MACAddress           string                `json:"macAddress,omitempty"`
+	EnableIPForwarding   bool                  `json:"enableIPForwarding"`
+	IPConfigurations     []nicIPConfigResponse `json:"ipConfigurations"`
+	NetworkSecurityGroup *armIDRef             `json:"networkSecurityGroup,omitempty"`
+	VirtualMachine       *armIDRef             `json:"virtualMachine,omitempty"`
 }
 
 type nicIPConfigResponse struct {
@@ -95,6 +101,20 @@ func (h *Handler) routeNIC(w http.ResponseWriter, r *http.Request, rp azurearm.R
 
 	if rp.ResourceName == "" {
 		h.listNICs(w, r, rp, svc)
+		return
+	}
+
+	// InterfacesClient.BeginListEffectiveNetworkSecurityGroups: a POST action
+	// on the NIC, not a nested collection — routed before the whole-NIC method
+	// switch so it never falls through to createNIC/getNIC/deleteNIC.
+	if strings.EqualFold(rp.SubResource, subResEffectiveNSGs) {
+		if r.Method != http.MethodPost {
+			azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+			return
+		}
+
+		h.listEffectiveNSGs(w, r, rp, svc)
+
 		return
 	}
 
@@ -137,11 +157,29 @@ func (h *Handler) createNIC(w http.ResponseWriter, r *http.Request, rp azurearm.
 		return
 	}
 
+	var nsgID string
+
+	if req.Properties.NetworkSecurityGroup != nil {
+		nsgRP, ok := azurearm.ParsePath(req.Properties.NetworkSecurityGroup.ID)
+		if !ok || nsgRP.ResourceType != typeNSG {
+			azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "malformed networkSecurityGroup id")
+			return
+		}
+
+		if _, nsgErr := findNSGByName(r.Context(), h.net, nsgRP.ResourceName); nsgErr != nil {
+			azurearm.WriteCErr(w, nsgErr)
+			return
+		}
+
+		nsgID = req.Properties.NetworkSecurityGroup.ID
+	}
+
 	cfg := netdriver.AzureNICConfig{
-		Location:     req.Location,
-		Tags:         req.Tags,
-		IPConfigs:    ipConfigs,
-		IPForwarding: req.Properties.EnableIPForwarding,
+		Location:               req.Location,
+		Tags:                   req.Tags,
+		IPConfigs:              ipConfigs,
+		IPForwarding:           req.Properties.EnableIPForwarding,
+		NetworkSecurityGroupID: nsgID,
 	}
 
 	nic, err := svc.CreateOrUpdateNetworkInterface(r.Context(), rp.ResourceGroup, rp.ResourceName, cfg)
@@ -377,6 +415,10 @@ func toNICResponse(nic *netdriver.AzureNIC, rp azurearm.ResourcePath) nicRespons
 		}
 
 		out.Properties.IPConfigurations = append(out.Properties.IPConfigurations, rc)
+	}
+
+	if nic.NetworkSecurityGroupID != "" {
+		out.Properties.NetworkSecurityGroup = &armIDRef{ID: nic.NetworkSecurityGroupID}
 	}
 
 	if nic.VirtualMachineID != "" {

--- a/server/azure/vnet/security_rule_regression_test.go
+++ b/server/azure/vnet/security_rule_regression_test.go
@@ -1,0 +1,491 @@
+package vnet_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// Finding (BLOCKER): individual SecurityRule sub-resource CRUD
+// (SecurityRulesClient / azurerm_network_security_rule) was not routed —
+// routeNSG never inspected rp.SubResource, so a standalone rule op hit the
+// whole-NSG handler. This verifies a standalone rule PUT mutates only the
+// addressed rule and preserves siblings, and standalone Get/List/Delete work.
+func TestSDKSecurityRuleSubResourceCRUD(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	nsgs, err := armnetwork.NewSecurityGroupsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rules, err := armnetwork.NewSecurityRulesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed the NSG with one rule via the whole-object PUT.
+	p, err := nsgs.BeginCreateOrUpdate(ctx, "rg-1", "nsg-subres", armnetwork.SecurityGroup{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.SecurityGroupPropertiesFormat{
+			SecurityRules: []*armnetwork.SecurityRule{{
+				Name: to.Ptr("seed-rule"),
+				Properties: &armnetwork.SecurityRulePropertiesFormat{
+					Priority: to.Ptr(int32(100)), Direction: to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+					Access: to.Ptr(armnetwork.SecurityRuleAccessAllow), Protocol: to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+					SourceAddressPrefix: to.Ptr("*"), DestinationAddressPrefix: to.Ptr("*"),
+					SourcePortRange: to.Ptr("*"), DestinationPortRange: to.Ptr("22"),
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create nsg: %v", err)
+	}
+
+	pollDone(t, p)
+
+	// Standalone rule PUT: add a second rule via SecurityRulesClient.
+	rp, err := rules.BeginCreateOrUpdate(ctx, "rg-1", "nsg-subres", "standalone-rule", armnetwork.SecurityRule{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Priority: to.Ptr(int32(200)), Direction: to.Ptr(armnetwork.SecurityRuleDirectionOutbound),
+			Access: to.Ptr(armnetwork.SecurityRuleAccessAllow), Protocol: to.Ptr(armnetwork.SecurityRuleProtocolUDP),
+			SourceAddressPrefix: to.Ptr("*"), DestinationAddressPrefix: to.Ptr("*"),
+			SourcePortRange: to.Ptr("*"), DestinationPortRange: to.Ptr("53"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate standalone rule: %v", err)
+	}
+
+	created := pollDone(t, rp)
+
+	if created.Name == nil || *created.Name != "standalone-rule" {
+		t.Fatalf("created rule name = %v, want standalone-rule", created.Name)
+	}
+
+	// The whole-NSG GET must show both rules — the standalone PUT must not
+	// have clobbered the seed rule.
+	got, err := nsgs.Get(ctx, "rg-1", "nsg-subres", nil)
+	if err != nil {
+		t.Fatalf("nsg Get: %v", err)
+	}
+
+	if len(got.Properties.SecurityRules) != 2 {
+		t.Fatalf("nsg securityRules after standalone PUT = %d, want 2 (seed + standalone preserved)", len(got.Properties.SecurityRules))
+	}
+
+	// Standalone Get.
+	gotRule, err := rules.Get(ctx, "rg-1", "nsg-subres", "standalone-rule", nil)
+	if err != nil {
+		t.Fatalf("rule Get: %v", err)
+	}
+
+	if gotRule.Properties == nil || gotRule.Properties.DestinationPortRange == nil ||
+		*gotRule.Properties.DestinationPortRange != "53" {
+		t.Fatalf("rule Get properties = %+v, want destinationPortRange 53", gotRule.Properties)
+	}
+
+	// Standalone List.
+	var names []string
+
+	pager := rules.NewListPager("rg-1", "nsg-subres", nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("rule list: %v", perr)
+		}
+
+		for _, r := range page.Value {
+			if r.Name != nil {
+				names = append(names, *r.Name)
+			}
+		}
+	}
+
+	if len(names) != 2 {
+		t.Fatalf("securityRules list = %v, want 2 entries", names)
+	}
+
+	// Standalone Delete must remove only the addressed rule.
+	dp, err := rules.BeginDelete(ctx, "rg-1", "nsg-subres", "standalone-rule", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete rule: %v", err)
+	}
+
+	pollDone(t, dp)
+
+	got2, err := nsgs.Get(ctx, "rg-1", "nsg-subres", nil)
+	if err != nil {
+		t.Fatalf("nsg Get after delete: %v", err)
+	}
+
+	if len(got2.Properties.SecurityRules) != 1 || got2.Properties.SecurityRules[0].Name == nil ||
+		*got2.Properties.SecurityRules[0].Name != "seed-rule" {
+		t.Fatalf("nsg securityRules after standalone delete = %+v, want only seed-rule", got2.Properties.SecurityRules)
+	}
+}
+
+// Finding: no priority validation on security rules — an out-of-range
+// priority and a duplicate priority within the same direction were both
+// silently accepted.
+func TestSDKSecurityRulePriorityValidation(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	nsgs, err := armnetwork.NewSecurityGroupsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rules, err := armnetwork.NewSecurityRulesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nsgP, err := nsgs.BeginCreateOrUpdate(ctx, "rg-1", "nsg-priority", armnetwork.SecurityGroup{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create nsg: %v", err)
+	}
+
+	pollDone(t, nsgP)
+
+	_, err = rules.BeginCreateOrUpdate(ctx, "rg-1", "nsg-priority", "too-high", armnetwork.SecurityRule{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Priority: to.Ptr(int32(5000)), Direction: to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+			Access: to.Ptr(armnetwork.SecurityRuleAccessAllow), Protocol: to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			SourceAddressPrefix: to.Ptr("*"), DestinationAddressPrefix: to.Ptr("*"),
+			SourcePortRange: to.Ptr("*"), DestinationPortRange: to.Ptr("80"),
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("priority 5000 (out of [100,4096]): want error, got nil")
+	}
+
+	if got := respStatus(t, err); got != 400 {
+		t.Fatalf("priority 5000: status = %d, want 400", got)
+	}
+
+	p1, err := rules.BeginCreateOrUpdate(ctx, "rg-1", "nsg-priority", "rule-1", armnetwork.SecurityRule{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Priority: to.Ptr(int32(100)), Direction: to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+			Access: to.Ptr(armnetwork.SecurityRuleAccessAllow), Protocol: to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			SourceAddressPrefix: to.Ptr("*"), DestinationAddressPrefix: to.Ptr("*"),
+			SourcePortRange: to.Ptr("*"), DestinationPortRange: to.Ptr("80"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create rule-1: %v", err)
+	}
+
+	pollDone(t, p1)
+
+	_, err = rules.BeginCreateOrUpdate(ctx, "rg-1", "nsg-priority", "rule-2", armnetwork.SecurityRule{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Priority: to.Ptr(int32(100)), Direction: to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+			Access: to.Ptr(armnetwork.SecurityRuleAccessDeny), Protocol: to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			SourceAddressPrefix: to.Ptr("*"), DestinationAddressPrefix: to.Ptr("*"),
+			SourcePortRange: to.Ptr("*"), DestinationPortRange: to.Ptr("81"),
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("duplicate priority+direction (rule-2 vs rule-1): want error, got nil")
+	}
+
+	if got := respStatus(t, err); got != 400 {
+		t.Fatalf("duplicate priority+direction: status = %d, want 400", got)
+	}
+
+	// The same priority in the OTHER direction is fine.
+	p3, err := rules.BeginCreateOrUpdate(ctx, "rg-1", "nsg-priority", "rule-3", armnetwork.SecurityRule{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Priority: to.Ptr(int32(100)), Direction: to.Ptr(armnetwork.SecurityRuleDirectionOutbound),
+			Access: to.Ptr(armnetwork.SecurityRuleAccessAllow), Protocol: to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			SourceAddressPrefix: to.Ptr("*"), DestinationAddressPrefix: to.Ptr("*"),
+			SourcePortRange: to.Ptr("*"), DestinationPortRange: to.Ptr("82"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("same priority, opposite direction should be accepted: %v", err)
+	}
+
+	pollDone(t, p3)
+}
+
+// Finding: a custom rule named identically to a reserved default-rule name
+// was accepted, silently shadowing the real default rule's identity.
+func TestSDKSecurityRuleReservedNameCollisionRejected(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	nsgs, err := armnetwork.NewSecurityGroupsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rules, err := armnetwork.NewSecurityRulesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nsgP, err := nsgs.BeginCreateOrUpdate(ctx, "rg-1", "nsg-reserved", armnetwork.SecurityGroup{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create nsg: %v", err)
+	}
+
+	pollDone(t, nsgP)
+
+	_, err = rules.BeginCreateOrUpdate(ctx, "rg-1", "nsg-reserved", "DenyAllInBound", armnetwork.SecurityRule{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Priority: to.Ptr(int32(150)), Direction: to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+			Access: to.Ptr(armnetwork.SecurityRuleAccessAllow), Protocol: to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			SourceAddressPrefix: to.Ptr("*"), DestinationAddressPrefix: to.Ptr("*"),
+			SourcePortRange: to.Ptr("*"), DestinationPortRange: to.Ptr("80"),
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("rule named DenyAllInBound (reserved): want error, got nil")
+	}
+
+	if got := respStatus(t, err); got != 400 {
+		t.Fatalf("reserved rule name: status = %d, want 400", got)
+	}
+}
+
+// Finding: NSG association to Subnets and NICs was unimplemented — the
+// networkSecurityGroup reference was dropped on write and never echoed, and
+// the NSG's own GET never listed the associated subnet/NIC back-references.
+func TestSDKNSGSubnetAndNICAssociation(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnets, _ := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	subnets, _ := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+	nsgs, _ := armnetwork.NewSecurityGroupsClient("sub-1", fakeCred{}, opts)
+	nics, _ := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, opts)
+
+	nsgP, err := nsgs.BeginCreateOrUpdate(ctx, "rg-1", "nsg-assoc", armnetwork.SecurityGroup{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create nsg: %v", err)
+	}
+
+	pollDone(t, nsgP)
+
+	nsgID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/networkSecurityGroups/nsg-assoc"
+
+	createTestVNet(t, ctx, vnets, "rg-1", "vnet-assoc", "10.0.0.0/16")
+
+	subP, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-assoc", "default", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix:        to.Ptr("10.0.1.0/24"),
+			NetworkSecurityGroup: &armnetwork.SecurityGroup{ID: to.Ptr(nsgID)},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create subnet with NSG: %v", err)
+	}
+
+	sub := pollDone(t, subP)
+
+	if sub.Properties == nil || sub.Properties.NetworkSecurityGroup == nil || sub.Properties.NetworkSecurityGroup.ID == nil ||
+		*sub.Properties.NetworkSecurityGroup.ID != nsgID {
+		t.Fatalf("subnet networkSecurityGroup = %+v, want %s", sub.Properties, nsgID)
+	}
+
+	subnetID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/" +
+		"virtualNetworks/vnet-assoc/subnets/default"
+
+	nicP, err := nics.BeginCreateOrUpdate(ctx, "rg-1", "nic-assoc", armnetwork.Interface{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			NetworkSecurityGroup: &armnetwork.SecurityGroup{ID: to.Ptr(nsgID)},
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig1"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					Subnet: &armnetwork.Subnet{ID: to.Ptr(subnetID)},
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create nic with NSG: %v", err)
+	}
+
+	nic := pollDone(t, nicP)
+
+	if nic.Properties == nil || nic.Properties.NetworkSecurityGroup == nil || nic.Properties.NetworkSecurityGroup.ID == nil ||
+		*nic.Properties.NetworkSecurityGroup.ID != nsgID {
+		t.Fatalf("nic networkSecurityGroup = %+v, want %s", nic.Properties, nsgID)
+	}
+
+	gotNSG, err := nsgs.Get(ctx, "rg-1", "nsg-assoc", nil)
+	if err != nil {
+		t.Fatalf("nsg Get: %v", err)
+	}
+
+	if len(gotNSG.Properties.Subnets) != 1 {
+		t.Fatalf("nsg.properties.subnets = %v, want 1 associated subnet", gotNSG.Properties.Subnets)
+	}
+
+	if len(gotNSG.Properties.NetworkInterfaces) != 1 {
+		t.Fatalf("nsg.properties.networkInterfaces = %v, want 1 associated NIC", gotNSG.Properties.NetworkInterfaces)
+	}
+}
+
+// Finding: no effective-security-rules endpoint —
+// InterfacesClient.BeginListEffectiveNetworkSecurityGroups was absent.
+func TestSDKEffectiveNetworkSecurityGroups(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnets, _ := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	subnets, _ := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+	nsgs, _ := armnetwork.NewSecurityGroupsClient("sub-1", fakeCred{}, opts)
+	nics, _ := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, opts)
+
+	nicNSGP, err := nsgs.BeginCreateOrUpdate(ctx, "rg-1", "nsg-nic-eff", armnetwork.SecurityGroup{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.SecurityGroupPropertiesFormat{
+			SecurityRules: []*armnetwork.SecurityRule{{
+				Name: to.Ptr("allow-nic"),
+				Properties: &armnetwork.SecurityRulePropertiesFormat{
+					Priority: to.Ptr(int32(100)), Direction: to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+					Access: to.Ptr(armnetwork.SecurityRuleAccessAllow), Protocol: to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+					SourceAddressPrefix: to.Ptr("*"), DestinationAddressPrefix: to.Ptr("*"),
+					SourcePortRange: to.Ptr("*"), DestinationPortRange: to.Ptr("22"),
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create nic-level nsg: %v", err)
+	}
+
+	pollDone(t, nicNSGP)
+
+	subnetNSGP, err := nsgs.BeginCreateOrUpdate(ctx, "rg-1", "nsg-subnet-eff", armnetwork.SecurityGroup{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.SecurityGroupPropertiesFormat{
+			SecurityRules: []*armnetwork.SecurityRule{{
+				Name: to.Ptr("allow-subnet"),
+				Properties: &armnetwork.SecurityRulePropertiesFormat{
+					Priority: to.Ptr(int32(100)), Direction: to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+					Access: to.Ptr(armnetwork.SecurityRuleAccessAllow), Protocol: to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+					SourceAddressPrefix: to.Ptr("*"), DestinationAddressPrefix: to.Ptr("*"),
+					SourcePortRange: to.Ptr("*"), DestinationPortRange: to.Ptr("443"),
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create subnet-level nsg: %v", err)
+	}
+
+	pollDone(t, subnetNSGP)
+
+	createTestVNet(t, ctx, vnets, "rg-1", "vnet-eff", "10.0.0.0/16")
+
+	subnetNSGID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/networkSecurityGroups/nsg-subnet-eff"
+
+	subP, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-eff", "default", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix:        to.Ptr("10.0.1.0/24"),
+			NetworkSecurityGroup: &armnetwork.SecurityGroup{ID: to.Ptr(subnetNSGID)},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create subnet: %v", err)
+	}
+
+	pollDone(t, subP)
+
+	subnetID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/" +
+		"virtualNetworks/vnet-eff/subnets/default"
+	nicNSGID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/networkSecurityGroups/nsg-nic-eff"
+
+	nicP, err := nics.BeginCreateOrUpdate(ctx, "rg-1", "nic-eff", armnetwork.Interface{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			NetworkSecurityGroup: &armnetwork.SecurityGroup{ID: to.Ptr(nicNSGID)},
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig1"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					Primary: to.Ptr(true),
+					Subnet:  &armnetwork.Subnet{ID: to.Ptr(subnetID)},
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create nic: %v", err)
+	}
+
+	pollDone(t, nicP)
+
+	effP, err := nics.BeginListEffectiveNetworkSecurityGroups(ctx, "rg-1", "nic-eff", nil)
+	if err != nil {
+		t.Fatalf("BeginListEffectiveNetworkSecurityGroups: %v", err)
+	}
+
+	eff := pollDone(t, effP)
+
+	if len(eff.Value) != 2 {
+		t.Fatalf("effective NSGs = %d, want 2 (NIC-level + subnet-level)", len(eff.Value))
+	}
+
+	var sawNICLevel, sawSubnetLevel, sawCustomRule, sawDefaultRule bool
+
+	for _, g := range eff.Value {
+		if g.NetworkSecurityGroup != nil && g.NetworkSecurityGroup.ID != nil {
+			switch *g.NetworkSecurityGroup.ID {
+			case nicNSGID:
+				sawNICLevel = true
+			case subnetNSGID:
+				sawSubnetLevel = true
+			}
+		}
+
+		for _, r := range g.EffectiveSecurityRules {
+			if r.Name == nil {
+				continue
+			}
+
+			switch *r.Name {
+			case "securityRules/allow-nic", "securityRules/allow-subnet":
+				sawCustomRule = true
+			case "defaultSecurityRules/DenyAllInBound":
+				sawDefaultRule = true
+			}
+		}
+	}
+
+	if !sawNICLevel {
+		t.Error("effective NSGs missing the NIC-level NSG entry")
+	}
+
+	if !sawSubnetLevel {
+		t.Error("effective NSGs missing the subnet-level NSG entry")
+	}
+
+	if !sawCustomRule {
+		t.Error("effective NSGs missing a custom rule")
+	}
+
+	if !sawDefaultRule {
+		t.Error("effective NSGs missing a default rule")
+	}
+}

--- a/server/azure/vnet/security_rule_subresource.go
+++ b/server/azure/vnet/security_rule_subresource.go
@@ -1,0 +1,233 @@
+package vnet
+
+import (
+	"context"
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// Real ARM accepts a security-rule priority only in this range and rejects a
+// duplicate priority within the same direction (both documented in "Azure
+// network security groups overview", learn.microsoft.com/azure/virtual-network/
+// network-security-groups-overview: "A number between 100 and 4096 ... You
+// can't create two security rules with the same priority and direction.").
+const (
+	minSecurityRulePriority = 100
+	maxSecurityRulePriority = 4096
+)
+
+// routeSecurityRule serves the SecurityRulesClient / azurerm_network_security_rule
+// sub-resource surface: PUT/GET/DELETE .../networkSecurityGroups/{nsg}/securityRules/{rule}
+// and GET .../networkSecurityGroups/{nsg}/securityRules (list). Registered
+// from routeNSG before any whole-NSG handler ever sees the request, so a
+// standalone rule op mutates only the addressed rule and preserves siblings.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) routeSecurityRule(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.SubResourceName == "" {
+		if r.Method != http.MethodGet {
+			azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+			return
+		}
+
+		h.listSecurityRules(w, r, rp)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.putSecurityRule(w, r, rp)
+	case http.MethodGet:
+		h.getSecurityRule(w, r, rp)
+	case http.MethodDelete:
+		h.deleteSecurityRule(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listSecurityRules(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := findNSGByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	nsgID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeNSG, rp.ResourceName)
+
+	rules := h.customRules(r.Context(), info.ID)
+
+	azurearm.WriteJSON(w, http.StatusOK, securityRuleListResponse{Value: fromAzureNSGRules(nsgID, rules)})
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getSecurityRule(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := findNSGByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	nsgID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeNSG, rp.ResourceName)
+
+	for _, rule := range h.customRules(r.Context(), info.ID) {
+		if rule.Name == rp.SubResourceName {
+			azurearm.WriteJSON(w, http.StatusOK, fromAzureNSGRules(nsgID, []netdriver.AzureNSGRule{rule})[0])
+			return
+		}
+	}
+
+	azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "security rule "+rp.SubResourceName+" not found")
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) putSecurityRule(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	meta, ok := h.azureMeta()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"network security groups are not supported by this networking driver")
+
+		return
+	}
+
+	info, err := findNSGByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	var body securityRule
+
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	// The URL name is authoritative, matching ARM's PUT-by-name semantics.
+	body.Name = rp.SubResourceName
+
+	rule := toAzureNSGRules([]securityRule{body})[0]
+
+	if verr := validateSecurityRule(rule, h.customRules(r.Context(), info.ID)); verr != nil {
+		azurearm.WriteCErr(w, verr)
+		return
+	}
+
+	updated, err := meta.UpsertAzureNSGRule(r.Context(), info.ID, rule)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	nsgID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeNSG, rp.ResourceName)
+
+	for _, ru := range updated.SecurityRules {
+		if ru.Name == rp.SubResourceName {
+			azurearm.WriteJSON(w, http.StatusOK, fromAzureNSGRules(nsgID, []netdriver.AzureNSGRule{ru})[0])
+			return
+		}
+	}
+
+	azurearm.WriteError(w, http.StatusInternalServerError, "InternalError", "security rule not found after create")
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteSecurityRule(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	meta, ok := h.azureMeta()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"network security groups are not supported by this networking driver")
+
+		return
+	}
+
+	info, err := findNSGByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if err := meta.DeleteAzureNSGRule(r.Context(), info.ID, rp.SubResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// customRules returns the caller-defined security rules stored for the NSG
+// with the given driver id (empty when the driver carries no Azure metadata
+// or the NSG has none yet).
+func (h *Handler) customRules(ctx context.Context, nsgDriverID string) []netdriver.AzureNSGRule {
+	meta, ok := h.azureMeta()
+	if !ok {
+		return nil
+	}
+
+	md, found := meta.GetAzureNSGMetadata(ctx, nsgDriverID)
+	if !found {
+		return nil
+	}
+
+	return md.SecurityRules
+}
+
+// validateSecurityRuleBatch applies validateSecurityRule to every rule in a
+// whole-NSG PUT body against its siblings in the same body — the
+// createNSG/whole-NSG-replace counterpart of putSecurityRule's single-rule
+// check against the already-stored rules.
+func validateSecurityRuleBatch(rules []netdriver.AzureNSGRule) error {
+	for i := range rules {
+		siblings := make([]netdriver.AzureNSGRule, 0, len(rules)-1)
+
+		for j := range rules {
+			if j != i {
+				siblings = append(siblings, rules[j])
+			}
+		}
+
+		if err := validateSecurityRule(rules[i], siblings); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateSecurityRule checks a single rule the way real ARM does before ever
+// storing it: priority in [100, 4096], no duplicate priority with another
+// rule in the same direction, and no name collision with one of the six
+// reserved default-rule names (a custom rule can never shadow a default one).
+//
+//nolint:gocritic // hugeParam: rule is a small value type passed by every caller in this file; a pointer buys nothing here.
+func validateSecurityRule(rule netdriver.AzureNSGRule, siblings []netdriver.AzureNSGRule) error {
+	if rule.Priority < minSecurityRulePriority || rule.Priority > maxSecurityRulePriority {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"priority %d is out of range: must be between %d and %d", rule.Priority, minSecurityRulePriority, maxSecurityRulePriority)
+	}
+
+	for i := range azureDefaultRules {
+		if rule.Name == azureDefaultRules[i].name {
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"security rule name %q conflicts with a reserved default security rule", rule.Name)
+		}
+	}
+
+	for i := range siblings {
+		sib := &siblings[i]
+		if sib.Name == rule.Name {
+			continue
+		}
+
+		if sib.Direction == rule.Direction && sib.Priority == rule.Priority {
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"priority %d is already used by security rule %q in the %s direction", rule.Priority, sib.Name, rule.Direction)
+		}
+	}
+
+	return nil
+}

--- a/server/azure/vnet/subnet_validate.go
+++ b/server/azure/vnet/subnet_validate.go
@@ -1,0 +1,335 @@
+package vnet
+
+import (
+	"context"
+	"net"
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// netcfgInvalidSubnetCode is the real ARM error code for both classes of
+// subnet CIDR violation this file rejects: a prefix outside the vnet's
+// address space, and a prefix overlapping a sibling subnet. Verified against
+// reports of the real error (azure-cli #10917; Azure/azure-service-operator
+// #997): the wire code is NetcfgInvalidSubnet, HTTP 400, with message
+// "Subnet '{name}' is not valid in virtual network '{vnet}'", quoted verbatim.
+const netcfgInvalidSubnetCode = "NetcfgInvalidSubnet"
+
+// validateSubnetCIDR checks a candidate subnet prefix the way real ARM does
+// before ever storing it: it must parse as a valid CIDR, fall entirely within
+// one of the vnet's address-space prefixes, and not overlap any sibling
+// subnet already in the same vnet (subnetName itself is excluded from the
+// sibling scan so a same-CIDR re-PUT of an existing subnet isn't flagged as
+// overlapping itself).
+func (h *Handler) validateSubnetCIDR(ctx context.Context, vpcID, subnetName, cidr string) error {
+	_, candidate, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return cerrors.Newf(cerrors.InvalidArgument, "invalid address prefix %q", cidr)
+	}
+
+	if !cidrWithinAny(candidate, h.vnetAddressPrefixesByID(ctx, vpcID)) {
+		return azurearmSubnetError(subnetName,
+			"subnet '"+subnetName+"' address range does not fall within the virtual network's address space")
+	}
+
+	subs, err := h.net.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	if overlapsSiblingSubnet(candidate, subs, vpcID, subnetName) {
+		return azurearmSubnetError(subnetName,
+			"subnet '"+subnetName+"' address range overlaps an existing subnet in the same virtual network")
+	}
+
+	return nil
+}
+
+// cidrWithinAny reports whether candidate falls entirely within at least one
+// of the given address-space prefix strings.
+func cidrWithinAny(candidate *net.IPNet, prefixes []string) bool {
+	for _, p := range prefixes {
+		_, parent, err := net.ParseCIDR(p)
+		if err != nil {
+			continue
+		}
+
+		if cidrWithin(candidate, parent) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// overlapsSiblingSubnet reports whether candidate overlaps any other subnet
+// already stored in the same vnet (subnetName itself is excluded so a
+// same-CIDR re-PUT of an existing subnet isn't flagged as overlapping itself).
+func overlapsSiblingSubnet(candidate *net.IPNet, subs []netdriver.SubnetInfo, vpcID, subnetName string) bool {
+	for i := range subs {
+		if subs[i].VPCID != vpcID || tagOr(subs[i].Tags, armSubnetTag, "") == subnetName {
+			continue
+		}
+
+		_, sibling, err := net.ParseCIDR(subs[i].CIDRBlock)
+		if err != nil {
+			continue
+		}
+
+		if sibling.Contains(candidate.IP) || candidate.Contains(sibling.IP) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// azurearmSubnetError is a plain error carrying the NetcfgInvalidSubnet
+// message; the server layer maps it to the wire response via
+// writeSubnetValidationError since cerrors has no ARM-code-carrying variant.
+type azurearmSubnetErr struct {
+	subnetName string
+	msg        string
+}
+
+func (e *azurearmSubnetErr) Error() string { return e.msg }
+
+func azurearmSubnetError(subnetName, msg string) error {
+	return &azurearmSubnetErr{subnetName: subnetName, msg: msg}
+}
+
+// writeSubnetValidationError renders a subnet-CIDR validation failure as the
+// real ARM 400 NetcfgInvalidSubnet, falling back to the generic canonical-error
+// mapping for anything else (so callers can pass any error from
+// validateSubnetCIDR straight through).
+func writeSubnetValidationError(w http.ResponseWriter, err error) {
+	if _, ok := err.(*azurearmSubnetErr); ok { //nolint:errorlint // sentinel-free local type, never wrapped
+		azurearm.WriteError(w, http.StatusBadRequest, netcfgInvalidSubnetCode, err.Error())
+		return
+	}
+
+	azurearm.WriteCErr(w, err)
+}
+
+// vnetAddressPrefixesByID returns the full address-space prefix list for the
+// vnet with driver id vpcID, preferring the Azure metadata store (which keeps
+// every prefix) and falling back to the cross-cloud single CIDR.
+func (h *Handler) vnetAddressPrefixesByID(ctx context.Context, vpcID string) []string {
+	if meta, ok := h.azureMeta(); ok {
+		if md, found := meta.GetAzureVNetMetadata(ctx, vpcID); found && len(md.AddressPrefixes) > 0 {
+			return md.AddressPrefixes
+		}
+	}
+
+	vpcs, err := h.net.DescribeVPCs(ctx, nil)
+	if err != nil {
+		return nil
+	}
+
+	for i := range vpcs {
+		if vpcs[i].ID == vpcID {
+			return []string{vpcs[i].CIDRBlock}
+		}
+	}
+
+	return nil
+}
+
+// cidrWithin reports whether candidate's entire address range falls inside
+// parent: same IP family, a mask at least as specific, and both the network
+// and broadcast addresses of candidate contained in parent.
+func cidrWithin(candidate, parent *net.IPNet) bool {
+	cOnes, cBits := candidate.Mask.Size()
+	pOnes, pBits := parent.Mask.Size()
+
+	if cBits != pBits {
+		return false
+	}
+
+	if cOnes < pOnes {
+		return false
+	}
+
+	return parent.Contains(candidate.IP) && parent.Contains(lastAddr(candidate))
+}
+
+// lastAddr returns the broadcast (highest) address of an IPv4 CIDR block.
+func lastAddr(n *net.IPNet) net.IP {
+	ip := n.IP.To4()
+	if ip == nil {
+		ip = n.IP
+	}
+
+	mask := n.Mask
+	last := make(net.IP, len(ip))
+
+	for i := range ip {
+		last[i] = ip[i] | ^mask[i]
+	}
+
+	return last
+}
+
+// availableIPSuggestionLimit caps the alternate addresses CheckIPAddressAvailability
+// suggests when the queried address is taken, matching the real API's sample
+// response (5 suggestions).
+const availableIPSuggestionLimit = 5
+
+// checkIPAddrReservedHosts mirrors the Azure VNet subnet-address FAQ: the
+// first four host addresses of every subnet are reserved (network address,
+// default gateway, two Azure-internal), so suggestions start past them.
+const checkIPAddrReservedHosts = 4
+
+// checkIPAddressAvailability serves VirtualNetworksClient.CheckIPAddressAvailability:
+// GET .../virtualNetworks/{name}/CheckIPAddressAvailability?ipAddress={ip}.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) checkIPAddressAvailability(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	vnet, err := findVNetByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	ipAddress := r.URL.Query().Get("ipAddress")
+
+	ip := net.ParseIP(ipAddress).To4()
+	if ip == nil {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "invalid ipAddress query parameter")
+		return
+	}
+
+	subs, err := h.net.DescribeSubnets(r.Context(), nil)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	target := containingSubnet(subs, vnet.ID, ip)
+
+	result := ipAddressAvailabilityResult{Available: true}
+
+	if target != nil {
+		used := h.usedIPsInSubnet(r.Context(), target.ID)
+
+		if used[ipAddress] {
+			result.Available = false
+			result.AvailableIPAddresses = nextFreeIPs(target.CIDRBlock, used, availableIPSuggestionLimit)
+		}
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, result)
+}
+
+// containingSubnet returns the subnet of vpcID whose CIDR block contains ip,
+// or nil when no subnet in the vnet covers it.
+func containingSubnet(subs []netdriver.SubnetInfo, vpcID string, ip net.IP) *netdriver.SubnetInfo {
+	for i := range subs {
+		if subs[i].VPCID != vpcID {
+			continue
+		}
+
+		_, cidr, err := net.ParseCIDR(subs[i].CIDRBlock)
+		if err != nil {
+			continue
+		}
+
+		if cidr.Contains(ip) {
+			return &subs[i]
+		}
+	}
+
+	return nil
+}
+
+// usedIPsInSubnet collects the private IPs already assigned to any NIC
+// ipConfiguration in the subnet identified by its driver id.
+func (h *Handler) usedIPsInSubnet(ctx context.Context, subnetDriverID string) map[string]bool {
+	used := make(map[string]bool)
+
+	svc, ok := h.net.(netdriver.AzureNetworkInterfaces)
+	if !ok {
+		return used
+	}
+
+	nics, err := svc.ListNetworkInterfaces(ctx, "")
+	if err != nil {
+		return used
+	}
+
+	subs, err := h.net.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return used
+	}
+
+	for i := range nics {
+		for j := range nics[i].IPConfigs {
+			if nics[i].IPConfigs[j].PrivateIP == "" {
+				continue
+			}
+
+			if resolveSubnetDriverID(ctx, h.net, subs, nics[i].IPConfigs[j].SubnetID) == subnetDriverID {
+				used[nics[i].IPConfigs[j].PrivateIP] = true
+			}
+		}
+	}
+
+	return used
+}
+
+// nextFreeIPs returns up to limit host addresses in cidr, starting past
+// Azure's reserved addresses, that are not present in used.
+func nextFreeIPs(cidr string, used map[string]bool, limit int) []string {
+	base, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil
+	}
+
+	baseV4 := base.To4()
+	if baseV4 == nil {
+		return nil
+	}
+
+	out := make([]string, 0, limit)
+
+	for host := checkIPAddrReservedHosts; len(out) < limit; host++ {
+		ip := addHostOffset(baseV4, host)
+		if !ipNet.Contains(ip) {
+			break
+		}
+
+		s := ip.String()
+		if !used[s] {
+			out = append(out, s)
+		}
+	}
+
+	return out
+}
+
+// addHostOffset returns base (an IPv4 network address) plus n host addresses.
+func addHostOffset(base net.IP, n int) net.IP {
+	const octetSpan = 256
+
+	v4 := base.To4()
+	out := make(net.IP, len(v4))
+	copy(out, v4)
+
+	carry := n
+	for i := len(out) - 1; i >= 0 && carry > 0; i-- {
+		sum := int(out[i]) + carry
+		out[i] = byte(sum % octetSpan) //nolint:gosec // sum % 256 is always within byte range
+		carry = sum / octetSpan
+	}
+
+	return out
+}
+
+// ipAddressAvailabilityResult is the wire shape of IPAddressAvailabilityResult.
+type ipAddressAvailabilityResult struct {
+	Available            bool     `json:"available"`
+	AvailableIPAddresses []string `json:"availableIPAddresses,omitempty"`
+}

--- a/server/azure/vnet/types.go
+++ b/server/azure/vnet/types.go
@@ -43,8 +43,9 @@ type subnetRequest struct {
 }
 
 type subnetRequestProps struct {
-	AddressPrefix string    `json:"addressPrefix,omitempty"`
-	NatGateway    *armIDRef `json:"natGateway,omitempty"`
+	AddressPrefix        string    `json:"addressPrefix,omitempty"`
+	NatGateway           *armIDRef `json:"natGateway,omitempty"`
+	NetworkSecurityGroup *armIDRef `json:"networkSecurityGroup,omitempty"`
 }
 
 type subnetResponse struct {
@@ -55,9 +56,10 @@ type subnetResponse struct {
 }
 
 type subnetResponseProps struct {
-	ProvisioningState string    `json:"provisioningState"`
-	AddressPrefix     string    `json:"addressPrefix,omitempty"`
-	NatGateway        *armIDRef `json:"natGateway,omitempty"`
+	ProvisioningState    string    `json:"provisioningState"`
+	AddressPrefix        string    `json:"addressPrefix,omitempty"`
+	NatGateway           *armIDRef `json:"natGateway,omitempty"`
+	NetworkSecurityGroup *armIDRef `json:"networkSecurityGroup,omitempty"`
 }
 
 type subnetListResponse struct {
@@ -107,6 +109,47 @@ type nsgResponseProps struct {
 	ProvisioningState    string         `json:"provisioningState"`
 	SecurityRules        []securityRule `json:"securityRules"`
 	DefaultSecurityRules []securityRule `json:"defaultSecurityRules,omitempty"`
+	// Subnets and NetworkInterfaces are the read-only back-references real ARM
+	// reports on a networkSecurityGroups GET once the NSG is associated with a
+	// subnet or NIC (server-side scans, mirroring vnetResponse's subnet scan and
+	// publicIPConfigurationRef's NIC scan).
+	Subnets           []armIDRef `json:"subnets,omitempty"`
+	NetworkInterfaces []armIDRef `json:"networkInterfaces,omitempty"`
+}
+
+// securityRuleListResponse is the collection envelope for the securityRules
+// sub-resource List operation.
+type securityRuleListResponse struct {
+	Value []securityRule `json:"value"`
+}
+
+// Effective-security-rules (InterfacesClient.BeginListEffectiveNetworkSecurityGroups).
+
+type effectiveNSGListResponse struct {
+	Value []effectiveNSG `json:"value"`
+}
+
+type effectiveNSG struct {
+	Association            effectiveNSGAssociation `json:"association"`
+	EffectiveSecurityRules []effectiveSecurityRule `json:"effectiveSecurityRules"`
+	NetworkSecurityGroup   armIDRef                `json:"networkSecurityGroup"`
+}
+
+type effectiveNSGAssociation struct {
+	NetworkInterface *armIDRef `json:"networkInterface,omitempty"`
+	Subnet           *armIDRef `json:"subnet,omitempty"`
+}
+
+type effectiveSecurityRule struct {
+	Name                     string `json:"name"`
+	Protocol                 string `json:"protocol"`
+	SourcePortRange          string `json:"sourcePortRange"`
+	DestinationPortRange     string `json:"destinationPortRange"`
+	SourceAddressPrefix      string `json:"sourceAddressPrefix"`
+	DestinationAddressPrefix string `json:"destinationAddressPrefix"`
+	Access                   string `json:"access"`
+	Priority                 int    `json:"priority"`
+	Direction                string `json:"direction"`
 }
 
 type nsgListResponse struct {

--- a/server/azure/vnet/vnet_nsg_regression_test.go
+++ b/server/azure/vnet/vnet_nsg_regression_test.go
@@ -1,0 +1,320 @@
+package vnet_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// respStatus extracts the HTTP status code from an SDK error, failing the
+// test if err isn't an *azcore.ResponseError.
+func respStatus(t *testing.T, err error) int {
+	t.Helper()
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("error is not *azcore.ResponseError: %v", err)
+	}
+
+	return respErr.StatusCode
+}
+
+// createTestVNet creates a vnet with the given address prefix and no subnets.
+func createTestVNet(t *testing.T, ctx context.Context, vnets *armnetwork.VirtualNetworksClient, rg, name, prefix string) {
+	t.Helper()
+
+	p, err := vnets.BeginCreateOrUpdate(ctx, rg, name, armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr(prefix)}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create vnet %s: %v", name, err)
+	}
+
+	pollDone(t, p)
+}
+
+// Finding: DeleteSubnet has no in-use guard — a standalone subnet delete
+// bypassed the check the whole-vnet-delete path already had.
+func TestSDKDeleteSubnetInUseBlocked(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnets, _ := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	subnets, _ := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+	nics, _ := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, opts)
+
+	createTestVNet(t, ctx, vnets, "rg-1", "vnet-subdel", "10.0.0.0/16")
+
+	subP, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-subdel", "default", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create subnet: %v", err)
+	}
+
+	pollDone(t, subP)
+
+	subnetID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/" +
+		"virtualNetworks/vnet-subdel/subnets/default"
+
+	nicP, err := nics.BeginCreateOrUpdate(ctx, "rg-1", "nic-subdel", armnetwork.Interface{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig1"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					Subnet: &armnetwork.Subnet{ID: to.Ptr(subnetID)},
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create nic: %v", err)
+	}
+
+	pollDone(t, nicP)
+
+	_, err = subnets.BeginDelete(ctx, "rg-1", "vnet-subdel", "default", nil)
+	if err == nil {
+		t.Fatal("delete subnet in use: want error, got nil")
+	}
+
+	if got := respStatus(t, err); got != 400 {
+		t.Fatalf("delete subnet in use: status = %d, want 400", got)
+	}
+}
+
+// Finding: CreateSubnet did zero CIDR validation — a prefix outside the
+// vnet's address space was silently accepted.
+func TestSDKCreateSubnetOutsideVNetAddressSpaceRejected(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnets, _ := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	subnets, _ := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+
+	createTestVNet(t, ctx, vnets, "rg-1", "vnet-oob", "10.0.0.0/16")
+
+	_, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-oob", "outside", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("11.0.0.0/24")},
+	}, nil)
+	if err == nil {
+		t.Fatal("create subnet outside vnet address space: want error, got nil")
+	}
+
+	if got := respStatus(t, err); got != 400 {
+		t.Fatalf("create subnet outside vnet address space: status = %d, want 400", got)
+	}
+}
+
+// Finding: CreateSubnet did zero CIDR validation — a prefix overlapping a
+// sibling subnet was silently accepted.
+func TestSDKCreateSubnetOverlappingSiblingRejected(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnets, _ := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	subnets, _ := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+
+	createTestVNet(t, ctx, vnets, "rg-1", "vnet-overlap", "10.0.0.0/16")
+
+	p, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-overlap", "sub-a", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create subnet sub-a: %v", err)
+	}
+
+	pollDone(t, p)
+
+	_, err = subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-overlap", "sub-b", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.128/25")},
+	}, nil)
+	if err == nil {
+		t.Fatal("create overlapping subnet: want error, got nil")
+	}
+
+	if got := respStatus(t, err); got != 400 {
+		t.Fatalf("create overlapping subnet: status = %d, want 400", got)
+	}
+}
+
+// Finding: PUT VirtualNetwork with a REDUCED subnets[] array must delete the
+// omitted previously-existing subnet (authoritative replace), matching real
+// ARM whole-VNet PUT semantics.
+func TestSDKVNetPutReducedSubnetsDeletesOmitted(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnets, _ := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	subnets, _ := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+
+	p, err := vnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-shrink", armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+			Subnets: []*armnetwork.Subnet{
+				{Name: to.Ptr("keep"), Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")}},
+				{Name: to.Ptr("drop"), Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.2.0/24")}},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create vnet: %v", err)
+	}
+
+	pollDone(t, p)
+
+	if _, err := subnets.Get(ctx, "rg-1", "vnet-shrink", "drop", nil); err != nil {
+		t.Fatalf("subnet drop should exist before the reduced PUT: %v", err)
+	}
+
+	p2, err := vnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-shrink", armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+			Subnets: []*armnetwork.Subnet{
+				{Name: to.Ptr("keep"), Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")}},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("reduced PUT: %v", err)
+	}
+
+	pollDone(t, p2)
+
+	if _, err := subnets.Get(ctx, "rg-1", "vnet-shrink", "keep", nil); err != nil {
+		t.Fatalf("subnet keep should survive the reduced PUT: %v", err)
+	}
+
+	_, err = subnets.Get(ctx, "rg-1", "vnet-shrink", "drop", nil)
+	if err == nil {
+		t.Fatal("subnet drop should be gone after the reduced PUT")
+	}
+
+	if got := respStatus(t, err); got != 404 {
+		t.Fatalf("subnet drop Get after reduced PUT: status = %d, want 404", got)
+	}
+}
+
+// Azure added an explicit carve-out ("Azure Virtual Network now supports
+// updates without subnet property"): a whole-VNet PUT whose body omits the
+// subnets property entirely (as opposed to sending an explicit empty array)
+// must leave existing subnets untouched.
+func TestSDKVNetPutOmittedSubnetsPreservesExisting(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnets, _ := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	subnets, _ := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+
+	createTestVNet(t, ctx, vnets, "rg-1", "vnet-preserve", "10.0.0.0/16")
+
+	subP, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-preserve", "standalone", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create standalone subnet: %v", err)
+	}
+
+	pollDone(t, subP)
+
+	// A tags-only PUT whose body carries no subnets property at all (the
+	// VirtualNetworkPropertiesFormat.Subnets field is left nil).
+	p, err := vnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-preserve", armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("tags-only PUT: %v", err)
+	}
+
+	pollDone(t, p)
+
+	if _, err := subnets.Get(ctx, "rg-1", "vnet-preserve", "standalone", nil); err != nil {
+		t.Fatalf("subnet standalone should survive an omitted-subnets PUT: %v", err)
+	}
+}
+
+// Finding: CheckIPAddressAvailability mis-routed into the plain VNet-GET
+// handler and returned a VNet body / zero result.
+func TestSDKCheckIPAddressAvailability(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnets, _ := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	subnets, _ := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+	nics, _ := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, opts)
+
+	createTestVNet(t, ctx, vnets, "rg-1", "vnet-checkip", "10.0.0.0/16")
+
+	subP, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-checkip", "default", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create subnet: %v", err)
+	}
+
+	pollDone(t, subP)
+
+	subnetID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/" +
+		"virtualNetworks/vnet-checkip/subnets/default"
+
+	nicP, err := nics.BeginCreateOrUpdate(ctx, "rg-1", "nic-checkip", armnetwork.Interface{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig1"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					PrivateIPAddress:          to.Ptr("10.0.1.10"),
+					PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+					Subnet:                    &armnetwork.Subnet{ID: to.Ptr(subnetID)},
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create nic: %v", err)
+	}
+
+	pollDone(t, nicP)
+
+	taken, err := vnets.CheckIPAddressAvailability(ctx, "rg-1", "vnet-checkip", "10.0.1.10", nil)
+	if err != nil {
+		t.Fatalf("CheckIPAddressAvailability(taken): %v", err)
+	}
+
+	if taken.Available == nil || *taken.Available {
+		t.Fatalf("CheckIPAddressAvailability(10.0.1.10).available = %v, want false (in use)", taken.Available)
+	}
+
+	if len(taken.AvailableIPAddresses) == 0 {
+		t.Fatal("CheckIPAddressAvailability(taken) returned no alternate addresses")
+	}
+
+	free, err := vnets.CheckIPAddressAvailability(ctx, "rg-1", "vnet-checkip", "10.0.1.20", nil)
+	if err != nil {
+		t.Fatalf("CheckIPAddressAvailability(free): %v", err)
+	}
+
+	if free.Available == nil || !*free.Available {
+		t.Fatalf("CheckIPAddressAvailability(10.0.1.20).available = %v, want true (free)", free.Available)
+	}
+}

--- a/services/networking/driver/azure_network_metadata.go
+++ b/services/networking/driver/azure_network_metadata.go
@@ -57,4 +57,14 @@ type AzureNetworkMetadata interface {
 	PutAzureNSGMetadata(ctx context.Context, id string, meta AzureNSGMetadata) error
 	GetAzureNSGMetadata(ctx context.Context, id string) (AzureNSGMetadata, bool)
 	DeleteAzureNSGMetadata(ctx context.Context, id string)
+
+	// UpsertAzureNSGRule creates or replaces a single custom security rule by
+	// name, leaving every sibling rule untouched — the atomic read-modify-write
+	// the SecurityRules sub-resource CRUD (securityRules/{ruleName}) needs.
+	// Returns NotFound when the network security group itself doesn't exist.
+	UpsertAzureNSGRule(ctx context.Context, id string, rule AzureNSGRule) (AzureNSGMetadata, error)
+	// DeleteAzureNSGRule removes a single custom security rule by name, leaving
+	// every sibling rule untouched. Returns NotFound when either the network
+	// security group or the named rule doesn't exist.
+	DeleteAzureNSGRule(ctx context.Context, id string, ruleName string) error
 }

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -387,21 +387,26 @@ type AzureNICConfig struct {
 	Tags         map[string]string
 	IPConfigs    []AzureIPConfig
 	IPForwarding bool
+	// NetworkSecurityGroupID is the ARM resource id of the NSG associated with
+	// the whole interface (properties.networkSecurityGroup) — an Azure NIC
+	// binds its NSG at this top level, not per ipConfiguration.
+	NetworkSecurityGroupID string
 }
 
 // AzureNIC is the stored/returned Azure network interface.
 type AzureNIC struct {
-	Name              string
-	ResourceGroup     string
-	Location          string
-	Tags              map[string]string
-	IPConfigs         []AzureIPConfig
-	IPForwarding      bool
-	MACAddress        string
-	ResourceGUID      string
-	ProvisioningState string
-	ETag              string
-	VirtualMachineID  string // set while attached to a VM
+	Name                   string
+	ResourceGroup          string
+	Location               string
+	Tags                   map[string]string
+	IPConfigs              []AzureIPConfig
+	IPForwarding           bool
+	NetworkSecurityGroupID string
+	MACAddress             string
+	ResourceGUID           string
+	ProvisioningState      string
+	ETag                   string
+	VirtualMachineID       string // set while attached to a VM
 }
 
 // AzureNetworkInterfaces is the Azure-specific network-interface surface,


### PR DESCRIPTION
## Summary

VNet/Subnet:
- **DeleteSubnet in-use guard**: a standalone subnet delete no longer bypasses the in-use check the whole-vnet-delete path already had — a subnet still bound to a NIC ipConfiguration is now rejected with the real 400 `InUseSubnetCannotBeDeleted`.
- **CreateSubnet CIDR validation**: the subnet prefix must now fall within one of the vnet's address-space prefixes and must not overlap a sibling subnet (400 `NetcfgInvalidSubnet`, matching the real ARM error for both cases).
- **Whole-VNet PUT is now authoritative over subnets**: a PUT with a reduced `subnets[]` array deletes the previously-existing subnets it omits (refused if one is still in use by a NIC). A PUT whose body omits the `subnets` property *entirely* leaves existing subnets untouched, matching Azure's documented "updates without subnet property" behavior — the nil-vs-empty-array distinction `encoding/json` already gives us.
- **CheckIPAddressAvailability** is now routed correctly (it previously fell through to the plain VNet GET handler) and returns a real `IPAddressAvailabilityResult` (`available` + `availableIPAddresses`).

NSG:
- **SecurityRule sub-resource CRUD**: `SecurityRulesClient` / `azurerm_network_security_rule` (PUT/GET/DELETE/List on `.../networkSecurityGroups/{nsg}/securityRules/{rule}`) is now routed to true per-rule CRUD that mutates only the addressed rule and preserves siblings, mirroring the load balancer sub-resource pattern (atomic `store.Update` RMW).
- **NSG association to subnets and NICs**: both directions now round-trip — a subnet or NIC PUT with `networkSecurityGroup` set persists and echoes the reference, and the NSG's own GET lists its associated `subnets`/`networkInterfaces` back-references.
- **Effective security rules**: added `InterfacesClient.BeginListEffectiveNetworkSecurityGroups`, returning the merged effective rule set (NIC's own NSG + its subnet's NSG, each with its custom rules plus the six built-in defaults).
- **Priority validation**: a security rule's priority must be in `[100, 4096]` and unique among rules in the same direction (400), both on a whole-NSG PUT and a standalone rule PUT.
- **Reserved name collision**: a custom rule can no longer be named identically to one of the six reserved default-rule names.

Deferred (noted, not implemented): `Microsoft.Network/routeTables` ARM handler — a separate resource type, out of scope for this PR.

## Test plan
- New real-SDK (`azure-sdk-for-go`/`armnetwork`) regression tests against a live TLS wire server cover every fix above.
- New provider-level tests (including a `-race` concurrency test) cover the atomic per-rule NSG store.Update path.
- `go build ./...`, `go vet ./...`, full `go test ./...`, and `go test ./compat/...` all green.
- `golangci-lint` clean on every changed package (zero new issues).
- `internal/coveragegen` regenerated and committed (the `AzureNetworkMetadata` optional-capability interface gained two methods).