### PR TITLE
test(server): enforce dispatcher first-match-wins ordering invariants

### DIFF
--- a/server/aws/dispatch_ordering_test.go
+++ b/server/aws/dispatch_ordering_test.go
@@ -1,0 +1,151 @@
+package aws_test
+
+// Dispatch-ordering regression tests (Architecture Theme 2, #590).
+//
+// server.Server is a first-match-wins dispatcher: the FIRST registered handler
+// whose Matches() returns true serves the request. Correctness therefore
+// depends on a set of hand-ordered "register X before the catch-all Y"
+// invariants documented only as prose comments in server/aws/aws.go New():
+//
+//   - RDS (and the other AWS query-protocol handlers: IAM, Redshift, ELBv2,
+//     ElastiCache, SNS, STS, …) MUST register before the EC2 catch-all, whose
+//     Matches() claims every form-encoded POST.
+//   - GuardDuty, Lambda, Route 53, EFS, EKS (and the other REST handlers) MUST
+//     register before the permissive S3 REST fallback.
+//
+// These tests drive the FULL production server (built via NewFromProvider so
+// every handler is registered in the real order) with the exact ambiguous
+// request shapes where both the specific handler and the broad catch-all
+// match, and assert the more-specific handler wins by inspecting the response
+// shape. If someone reorders the registrations (e.g. alphabetizing, or moving
+// a catch-all earlier), these assertions fail instead of the routing silently
+// degrading into runtime 404s / wrong responses.
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fullAWSServer builds an httptest server over the complete AWS wire server
+// with every handler registered in the real production order.
+func fullAWSServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	srv := awsserver.NewFromProvider(cloudemu.NewAWS())
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+const formContentType = "application/x-www-form-urlencoded"
+
+func doRequest(t *testing.T, ts *httptest.Server, method, path, body string, headers map[string]string) (int, string) {
+	t.Helper()
+
+	var rdr io.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, ts.URL+path, rdr) //nolint:noctx // short-lived test request
+	require.NoError(t, err)
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	return resp.StatusCode, string(raw)
+}
+
+// TestQueryProtocolHandlersWinBeforeEC2 covers the AWS query-protocol handlers
+// that share the form-encoded-POST wire with the EC2 catch-all. Each request's
+// Action is served only by the specific handler; EC2's fall-through would
+// answer InvalidAction. The XML response root proves which handler served.
+func TestQueryProtocolHandlersWinBeforeEC2(t *testing.T) {
+	ts := fullAWSServer(t)
+
+	cases := []struct {
+		name   string
+		action string
+		// wantRoot is the XML response root the specific handler emits. The EC2
+		// catch-all never produces it (it answers InvalidAction), so its
+		// presence proves the specific handler won registration order.
+		wantRoot string
+	}{
+		{"rds_before_ec2", "DescribeDBInstances", "DescribeDBInstancesResponse"},
+		{"iam_before_ec2", "ListRoles", "ListRolesResponse"},
+		{"redshift_before_ec2", "DescribeClusters", "DescribeClustersResponse"},
+		{"elbv2_before_ec2", "DescribeLoadBalancers", "DescribeLoadBalancersResponse"},
+		{"elasticache_before_ec2", "DescribeCacheClusters", "DescribeCacheClustersResponse"},
+		{"sns_before_ec2", "ListTopics", "ListTopicsResponse"},
+		{"sts_before_ec2", "GetCallerIdentity", "GetCallerIdentityResponse"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := "Action=" + tc.action + "&Version=2015-01-01"
+			status, resp := doRequest(t, ts, http.MethodPost, "/", body,
+				map[string]string{"Content-Type": formContentType})
+
+			assert.Equalf(t, http.StatusOK, status,
+				"%s should be served by its specific handler, not the EC2 catch-all; body=%s", tc.action, resp)
+			assert.Containsf(t, resp, tc.wantRoot,
+				"expected %s response root %q (proves the specific handler won over EC2); got: %s",
+				tc.action, tc.wantRoot, resp)
+			assert.NotContainsf(t, resp, "InvalidAction",
+				"%s was answered by the EC2 catch-all (InvalidAction) — registration order is broken", tc.action)
+		})
+	}
+}
+
+// TestRESTHandlersWinBeforeS3 covers the REST handlers rooted at their own path
+// prefixes that would otherwise be swallowed by the permissive S3 REST fallback
+// (whose Matches() claims essentially every non-query, non-JSON-RPC request).
+// If S3 served these, it would treat the first path segment as a bucket name
+// and answer a NoSuchBucket / XML error rather than the service shape below.
+func TestRESTHandlersWinBeforeS3(t *testing.T) {
+	ts := fullAWSServer(t)
+
+	cases := []struct {
+		name   string
+		path   string
+		marker string // substring only the specific handler's response contains
+	}{
+		{"guardduty_before_s3", "/detector", "detectorIds"},
+		{"lambda_before_s3", "/2015-03-31/functions", "Functions"},
+		{"route53_before_s3", "/2013-04-01/hostedzone", "ListHostedZonesResponse"},
+		{"efs_before_s3", "/2015-02-01/file-systems", "FileSystems"},
+		{"eks_before_s3", "/clusters", "clusters"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, resp := doRequest(t, ts, http.MethodGet, tc.path, "", nil)
+
+			assert.Equalf(t, http.StatusOK, status,
+				"GET %s should be served by its specific handler, not the S3 catch-all; body=%s", tc.path, resp)
+			assert.Containsf(t, resp, tc.marker,
+				"expected marker %q for GET %s (proves the specific handler won over S3); got: %s",
+				tc.marker, tc.path, resp)
+			assert.NotContainsf(t, resp, "NoSuchBucket",
+				"GET %s was answered by the S3 catch-all (NoSuchBucket) — registration order is broken", tc.path)
+		})
+	}
+}

--- a/server/aws/restjson_prefix_collision_test.go
+++ b/server/aws/restjson_prefix_collision_test.go
@@ -1,0 +1,180 @@
+package aws_test
+
+// REST-JSON top-level path-prefix collision test (Architecture Theme 2, #590).
+//
+// Every AWS REST-JSON handler claims traffic by the first (top-level) segment
+// of the request path — either a dated API-version segment (Route 53's
+// "2013-04-01", EFS's "2015-02-01", …) or a bare resource root (GuardDuty's
+// "detector", EKS's "clusters", …). Because server.Server is first-match-wins,
+// two handlers that claim the SAME top-level segment collide: whichever
+// registers first shadows the other, silently, with no compile or test error.
+//
+// restJSONTopLevelPrefixes is the curated registry of the top-level segments
+// each REST-JSON handler owns, derived from each package's Matches(). The test
+// asserts no segment is claimed by more than one handler, EXCEPT the segments
+// in sharedTopLevelPrefixes, which are intentionally multi-claimed and
+// disambiguated by deeper matching (ARN shape, path suffix). A future handler
+// that reuses a reserved segment without declaring it shared turns a silent
+// shadow into a test failure.
+//
+// This registry must be kept in sync when a REST-JSON handler is added or its
+// claimed roots change; that upkeep is the point — it forces the collision
+// question to be answered explicitly.
+
+import (
+	"sort"
+	"testing"
+)
+
+// restJSONTopLevelPrefixes maps each AWS REST-JSON handler to the top-level
+// path segments it claims. The S3 handler is the deliberate catch-all fallback
+// and owns no reserved prefix, so it is excluded.
+//
+//nolint:gochecknoglobals // test fixture: the reserved-prefix registry under test.
+var restJSONTopLevelPrefixes = map[string][]string{
+	// Dated / versioned API-prefix handlers: the top-level segment is the
+	// version, unique per service.
+	"efs":        {"2015-02-01"},
+	"opensearch": {"2021-01-01"},
+	"route53":    {"2013-04-01"},
+	"lambda":     {"2015-03-31", "2017-03-31", "2018-10-31"},
+	"sesv2":      {"v2"},
+	"kafka":      {"v1", "api", "replication"},
+
+	// Bare-root REST handlers.
+	"eks":                 {"clusters", "tags"},
+	"bedrockagent":        {"agents", "knowledgebases", "flows", "prompts"},
+	"bedrockagentruntime": {"agents", "knowledgebases"},
+	"sagemakerruntime":    {"endpoints"},
+	"k8s":                 {"k8s"},
+	"guardduty": {
+		"detector", "admin", "invitation", "tags", "malware-scan", "malware-scans",
+		"malware-protection-plan", "object-malware-scan", "organization",
+	},
+	"bedrock": {
+		"foundation-models", "model-customization-jobs", "custom-models", "model",
+		"guardrails", "provisioned-model-throughput", "async-invoke", "inference-profiles",
+	},
+	"vpclattice": {
+		"servicenetworks", "services", "targetgroups", "servicenetworkvpcassociations",
+		"servicenetworkvpcendpointassociations", "servicenetworkserviceassociations",
+		"servicenetworkresourceassociations", "resourceconfigurations", "resourcegateways",
+		"resourceendpointassociations", "accesslogsubscriptions", "authpolicy",
+		"resourcepolicy", "domainverifications", "tags",
+	},
+	"resourceexplorer2": {
+		"CreateView", "DeleteView", "ListViews", "GetView", "Search", "ListResources",
+		"ListIndexes", "GetIndex", "CreateIndex", "GetDefaultView",
+	},
+}
+
+// sharedTopLevelPrefixes are the top-level segments intentionally claimed by
+// more than one handler and safely disambiguated by deeper matching. Each
+// entry lists the exact set of handlers permitted to share it.
+//
+//nolint:gochecknoglobals // test fixture: the documented shared-prefix allowlist.
+var sharedTopLevelPrefixes = map[string]map[string]bool{
+	// The generic /tags/{ResourceArn} REST surface is shared: each handler
+	// claims it only for ARNs it owns, so tag requests fall through to the
+	// owning service.
+	"tags": {"eks": true, "guardduty": true, "vpclattice": true},
+	// bedrock-agent-runtime shares the /agents and /knowledgebases roots with
+	// the bedrock-agent control plane, matching only the runtime suffixes; it
+	// registers first so its more-specific Matches wins.
+	"agents":         {"bedrockagent": true, "bedrockagentruntime": true},
+	"knowledgebases": {"bedrockagent": true, "bedrockagentruntime": true},
+}
+
+// TestRESTJSONPrefixesAreDisjoint asserts no top-level path segment is claimed
+// by two REST-JSON handlers unless that segment is an allowlisted shared root
+// claimed only by its documented owners.
+func TestRESTJSONPrefixesAreDisjoint(t *testing.T) {
+	// segment -> set of handlers claiming it.
+	claimants := map[string]map[string]bool{}
+
+	for handler, segs := range restJSONTopLevelPrefixes {
+		for _, seg := range segs {
+			if claimants[seg] == nil {
+				claimants[seg] = map[string]bool{}
+			}
+
+			claimants[seg][handler] = true
+		}
+	}
+
+	for _, seg := range sortedKeys(claimants) {
+		owners := claimants[seg]
+		if len(owners) < 2 {
+			continue
+		}
+
+		allowed, isShared := sharedTopLevelPrefixes[seg]
+		if !isShared {
+			t.Errorf("top-level prefix %q is claimed by multiple handlers %v but is not an allowlisted shared root; "+
+				"this is a silent routing shadow — resolve the collision or document it in sharedTopLevelPrefixes",
+				seg, sortedSet(owners))
+
+			continue
+		}
+
+		for owner := range owners {
+			if !allowed[owner] {
+				t.Errorf("handler %q claims shared prefix %q but is not in its allowlist %v; "+
+					"first-match-wins may shadow it — verify Matches() disambiguation and update the allowlist",
+					owner, seg, sortedSet(allowed))
+			}
+		}
+	}
+}
+
+// TestSharedPrefixAllowlistIsGrounded guards against stale allowlist entries:
+// every shared prefix (and each of its declared owners) must actually appear in
+// the reserved-prefix registry.
+func TestSharedPrefixAllowlistIsGrounded(t *testing.T) {
+	for seg, owners := range sharedTopLevelPrefixes {
+		for owner := range owners {
+			segs, ok := restJSONTopLevelPrefixes[owner]
+			if !ok {
+				t.Errorf("allowlist owner %q for shared prefix %q is not a registered REST-JSON handler", owner, seg)
+
+				continue
+			}
+
+			if !contains(segs, seg) {
+				t.Errorf("allowlist says handler %q shares prefix %q, but %q does not claim it in the registry", owner, seg, owner)
+			}
+		}
+	}
+}
+
+func sortedKeys(m map[string]map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+func sortedSet(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+func contains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/azure/dispatch_ordering_test.go
+++ b/server/azure/dispatch_ordering_test.go
@@ -1,0 +1,84 @@
+package azure_test
+
+// Dispatch-ordering regression tests (Architecture Theme 2, #590).
+//
+// server.Server is a first-match-wins dispatcher. In server/azure/azure.go
+// New(), the BlobStorage data-plane handler is the permissive fallback — its
+// Matches() claims every non-/subscriptions/ path — so it MUST register last.
+// Several service handlers (Cosmos DB on /dbs, Key Vault on /secrets, ACR on
+// /acr/v1/…) sit on non-/subscriptions/ paths and are therefore ambiguous with
+// the Blob fallback; each is documented as "register before the permissive
+// BlobStorage fallback".
+//
+// These tests drive the FULL production server (NewFromProvider) with those
+// ambiguous paths and assert the specific handler — not Blob — served. The
+// robust discriminator is the "X-Ms-Version" response header: the BlobStorage
+// handler sets it on every response, and the specific handlers never do. If a
+// contributor moves the Blob fallback earlier (or alphabetizes registrations),
+// Blob swallows these paths, stamps X-Ms-Version, and these tests fail.
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func fullAzureServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	srv := azureserver.NewFromProvider(cloudemu.NewAzure())
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+// TestSpecificHandlersWinBeforeBlobFallback asserts the ARM/data-plane handlers
+// on non-/subscriptions/ paths win over the permissive BlobStorage fallback.
+func TestSpecificHandlersWinBeforeBlobFallback(t *testing.T) {
+	ts := fullAzureServer(t)
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"cosmos_dbs_before_blob", "/dbs"},
+		{"keyvault_secrets_before_blob", "/secrets"},
+		{"acr_catalog_before_blob", "/acr/v1/_catalog"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, ts.URL+tc.path, nil) //nolint:noctx // short-lived test request
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+
+			resp, err := ts.Client().Do(req)
+			if err != nil {
+				t.Fatalf("GET %s: %v", tc.path, err)
+			}
+
+			defer resp.Body.Close()
+
+			_, _ = io.Copy(io.Discard, resp.Body)
+
+			// The BlobStorage fallback stamps X-Ms-Version on every response;
+			// the specific handlers never do. Its presence proves Blob wrongly
+			// swallowed the request — i.e. the registration order is broken.
+			if v := resp.Header.Get("X-Ms-Version"); v != "" {
+				t.Errorf("GET %s was served by the permissive BlobStorage fallback (X-Ms-Version=%q); "+
+					"the specific handler must register before it", tc.path, v)
+			}
+
+			// Guard against a false pass where no handler matched at all.
+			if resp.StatusCode == http.StatusNotImplemented {
+				t.Errorf("GET %s reached the no-handler-registered fallback (501); expected a specific handler", tc.path)
+			}
+		})
+	}
+}

--- a/server/gcp/dispatch_ordering_test.go
+++ b/server/gcp/dispatch_ordering_test.go
@@ -1,0 +1,94 @@
+package gcp_test
+
+// Dispatch-ordering regression tests (Architecture Theme 2, #590).
+//
+// server.Server is a first-match-wins dispatcher. In server/gcp/gcp.go New(),
+// the Firestore handler is a catch-all: its Matches() claims every path under
+// /v1/projects/. Handlers that live in that same URL space but own a distinct
+// resource-type segment (Cloud Functions .../functions, Pub/Sub .../topics,
+// IAM .../serviceAccounts, Secret Manager .../secrets, …) are each documented
+// as "register before Firestore's catch-all" so first-match-wins keeps them on
+// the correct package.
+//
+// These tests drive the FULL production server (NewFromProvider) with those
+// ambiguous /v1/projects/ paths and assert the specific handler served (HTTP
+// 200 plus the service's list marker). If Firestore caught them it would fail
+// to parse the path and answer 404 NOT_FOUND — so moving Firestore earlier (or
+// alphabetizing registrations) makes these tests fail.
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+func fullGCPServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	srv := gcpserver.NewFromProvider(cloudemu.NewGCP())
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+// TestSpecificHandlersWinBeforeFirestore asserts the /v1/projects/ handlers with
+// a distinct resource-type segment win over the Firestore catch-all.
+func TestSpecificHandlersWinBeforeFirestore(t *testing.T) {
+	ts := fullGCPServer(t)
+
+	cases := []struct {
+		name   string
+		path   string
+		marker string // substring only the specific handler's 200 response contains
+	}{
+		{"pubsub_topics_before_firestore", "/v1/projects/demo/topics", "topics"},
+		{"cloudfunctions_before_firestore", "/v1/projects/demo/locations/us-central1/functions", "functions"},
+		{"iam_serviceaccounts_before_firestore", "/v1/projects/demo/serviceAccounts", "accounts"},
+		{"secretmanager_before_firestore", "/v1/projects/demo/secrets", "secrets"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, ts.URL+tc.path, nil) //nolint:noctx // short-lived test request
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+
+			resp, err := ts.Client().Do(req)
+			if err != nil {
+				t.Fatalf("GET %s: %v", tc.path, err)
+			}
+
+			defer resp.Body.Close()
+
+			raw, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+
+			body := string(raw)
+
+			// Firestore's catch-all cannot parse these paths and answers
+			// 404 NOT_FOUND; a 200 proves the specific handler served.
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("GET %s = %d (want 200); the specific handler must register before Firestore's catch-all. body=%s",
+					tc.path, resp.StatusCode, body)
+			}
+
+			if !strings.Contains(body, tc.marker) {
+				t.Errorf("GET %s response missing marker %q (proves the specific handler, not Firestore, served); body=%s",
+					tc.path, tc.marker, body)
+			}
+
+			if strings.Contains(body, "NOT_FOUND") {
+				t.Errorf("GET %s was answered by the Firestore catch-all (NOT_FOUND) — registration order is broken", tc.path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Converts the wire dispatcher's hand-ordered "register X before the catch-all Y" registration invariants — previously documented only as prose comments in `server/{aws,azure,gcp}/*.go` `New()` — into executable regression tests. Test/tooling only; no dispatcher or handler-registration behavior changes.

- **`server/aws/dispatch_ordering_test.go`** — drives the full production server and asserts the specific handler (not the broad catch-all) serves each known-ambiguous request shape:
  - Query-protocol handlers win over the EC2 catch-all: RDS, IAM, Redshift, ELBv2, ElastiCache, SNS, STS (`Action=` form POST → each handler's `<{Action}Response>` XML root proves it served; EC2's fall-through would answer `InvalidAction`).
  - REST handlers win over the permissive S3 REST fallback: GuardDuty (`/detector`), Lambda (`/2015-03-31/functions`), Route 53 (`/2013-04-01/hostedzone`), EFS (`/2015-02-01/file-systems`), EKS (`/clusters`) — a service-shape marker vs S3's `NoSuchBucket`.
- **`server/azure/dispatch_ordering_test.go`** — Cosmos DB (`/dbs`), Key Vault (`/secrets`), ACR (`/acr/v1/_catalog`) win over the permissive BlobStorage fallback. Discriminator: BlobStorage stamps `X-Ms-Version` on every response; the specific handlers never do.
- **`server/gcp/dispatch_ordering_test.go`** — Pub/Sub (`/topics`), Cloud Functions (`/functions`), IAM (`/serviceAccounts`), Secret Manager (`/secrets`) win over the Firestore `/v1/projects/` catch-all (200 + service marker vs Firestore's `NOT_FOUND`).
- **`server/aws/restjson_prefix_collision_test.go`** — a curated registry of the top-level path segment each AWS REST-JSON handler owns, asserting no two handlers claim the same segment except a documented allowlist of intentionally-shared roots (`tags`, `agents`, `knowledgebases`). Makes a future accidental prefix collision a test failure instead of a silent shadow.

## Why

The dispatcher is first-match-wins; correctness depends on ~15+ ordering invariants that no test enforced. A contributor reordering registrations (e.g. alphabetizing) would silently break routing into runtime 404s / wrong responses. These tests fail loudly on any such reorder — verified by temporarily moving each catch-all's `Register` call ahead of the specific handlers and confirming the ordering tests go red.

Remaining #590 items (out of scope here): STEP 3 (coveragegen wire-registration cross-check) and STEP 4 (Structure CI filename check).

Refs #590