### PR TITLE
fix(azure-appservice): scope site/plan get-delete to resource group; plan delete, PUT appsettings, ListWebApps

### DIFF
--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -409,7 +409,7 @@ type appServicePlanDiscovery struct{ m *functions.Mock }
 func (a appServicePlanDiscovery) DiscoverAppServicePlans(
 	ctx context.Context,
 ) ([]resourcediscovery.DiscoveredAppServicePlan, error) {
-	plans, err := a.m.ListAppServicePlans(ctx)
+	plans, err := a.m.ListAppServicePlans(ctx, "", "")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/azure/functions/app_service_plan.go
+++ b/providers/azure/functions/app_service_plan.go
@@ -11,14 +11,28 @@ import (
 // resource that carries the pricing tier an App Service or Function App bills
 // on. Only the cost-relevant SKU is modeled.
 type AppServicePlan struct {
-	Name     string
-	ID       string
-	Location string
-	SKUName  string // F1 / B1 / S1 / P1v3 / Y1 (Consumption) / EP1 (Elastic Premium)
-	SKUTier  string // Free / Basic / Standard / PremiumV3 / Dynamic / ElasticPremium
-	Kind     string // app / functionapp / linux
-	Capacity int
-	Tags     map[string]string
+	Name string
+	// Subscription and ResourceGroup scope the plan's storage key
+	// (planKey) — unlike a Web App name, an App Service plan name is only
+	// required to be unique within a resource group, so two different
+	// resource groups (even in the same subscription) can each have a plan
+	// named e.g. "default".
+	Subscription  string
+	ResourceGroup string
+	ID            string
+	Location      string
+	SKUName       string // F1 / B1 / S1 / P1v3 / Y1 (Consumption) / EP1 (Elastic Premium)
+	SKUTier       string // Free / Basic / Standard / PremiumV3 / Dynamic / ElasticPremium
+	Kind          string // app / functionapp / linux
+	Capacity      int
+	Tags          map[string]string
+}
+
+// planKey builds the composite key AppServicePlans are stored under, so a
+// plan named "default" in one resource group can never collide with (or be
+// overwritten by) a same-named plan in another resource group.
+func planKey(subscription, resourceGroup, name string) string {
+	return subscription + "/" + resourceGroup + "/" + name
 }
 
 // CreateAppServicePlan stores a plan, defaulting the fields real Azure fills in.
@@ -52,19 +66,54 @@ func (m *Mock) CreateAppServicePlan(_ context.Context, p AppServicePlan) (*AppSe
 
 	stored := p
 
-	m.plans.Set(p.Name, &stored)
+	m.plans.Set(planKey(p.Subscription, p.ResourceGroup, p.Name), &stored)
 
 	out := stored
 
 	return &out, nil
 }
 
-// ListAppServicePlans returns every stored App Service plan.
-func (m *Mock) ListAppServicePlans(_ context.Context) ([]AppServicePlan, error) {
+// GetAppServicePlan returns one App Service plan scoped to the given
+// subscription and resource group, or NotFound.
+func (m *Mock) GetAppServicePlan(_ context.Context, subscription, resourceGroup, name string) (*AppServicePlan, error) {
+	p, ok := m.plans.Get(planKey(subscription, resourceGroup, name))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "app service plan %s not found", name)
+	}
+
+	out := *p
+
+	return &out, nil
+}
+
+// DeleteAppServicePlan removes one App Service plan scoped to the given
+// subscription and resource group, or NotFound.
+func (m *Mock) DeleteAppServicePlan(_ context.Context, subscription, resourceGroup, name string) error {
+	if !m.plans.Delete(planKey(subscription, resourceGroup, name)) {
+		return cerrors.Newf(cerrors.NotFound, "app service plan %s not found", name)
+	}
+
+	return nil
+}
+
+// ListAppServicePlans returns the App Service plans in the given resource
+// group, or all plans in the subscription when resourceGroup is empty, or
+// every stored plan when subscription is also empty (the resource-discovery
+// / cost walkers, which have no ARM request scope to filter by).
+func (m *Mock) ListAppServicePlans(_ context.Context, subscription, resourceGroup string) ([]AppServicePlan, error) {
 	stored := m.plans.SortedValues()
 
 	out := make([]AppServicePlan, 0, len(stored))
+
 	for _, p := range stored {
+		if subscription != "" && p.Subscription != subscription {
+			continue
+		}
+
+		if resourceGroup != "" && p.ResourceGroup != resourceGroup {
+			continue
+		}
+
 		out = append(out, *p)
 	}
 

--- a/providers/azure/functions/app_service_plan_test.go
+++ b/providers/azure/functions/app_service_plan_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 )
 
 func TestCreateAppServicePlanDefaults(t *testing.T) {
@@ -39,7 +41,7 @@ func TestListAppServicePlansRoundTrip(t *testing.T) {
 	m := newTestMock()
 
 	t.Run("empty", func(t *testing.T) {
-		plans, err := m.ListAppServicePlans(ctx)
+		plans, err := m.ListAppServicePlans(ctx, "", "")
 		require.NoError(t, err)
 		assert.Empty(t, plans)
 	})
@@ -56,7 +58,7 @@ func TestListAppServicePlansRoundTrip(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		plans, err := m.ListAppServicePlans(ctx)
+		plans, err := m.ListAppServicePlans(ctx, "", "")
 		require.NoError(t, err)
 		require.Len(t, plans, 1)
 
@@ -69,4 +71,49 @@ func TestListAppServicePlansRoundTrip(t *testing.T) {
 		assert.Equal(t, 3, got.Capacity)
 		assert.Equal(t, "prod", got.Tags["env"])
 	})
+}
+
+// TestAppServicePlanResourceGroupIsolation covers the deep-sweep finding: two
+// resource groups (even in the same subscription) each naming a plan
+// "default" must not collide, and neither Get nor Delete nor a resource-group
+// scoped List may see the other resource group's plan.
+func TestAppServicePlanResourceGroupIsolation(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateAppServicePlan(ctx, AppServicePlan{
+		Name: "default", Subscription: "sub1", ResourceGroup: "rgA", SKUName: "B1",
+	})
+	require.NoError(t, err)
+
+	_, err = m.CreateAppServicePlan(ctx, AppServicePlan{
+		Name: "default", Subscription: "sub1", ResourceGroup: "rgB", SKUName: "P1v3",
+	})
+	require.NoError(t, err)
+
+	inA, err := m.GetAppServicePlan(ctx, "sub1", "rgA", "default")
+	require.NoError(t, err)
+	assert.Equal(t, "B1", inA.SKUName)
+
+	inB, err := m.GetAppServicePlan(ctx, "sub1", "rgB", "default")
+	require.NoError(t, err)
+	assert.Equal(t, "P1v3", inB.SKUName)
+
+	listA, err := m.ListAppServicePlans(ctx, "sub1", "rgA")
+	require.NoError(t, err)
+	require.Len(t, listA, 1)
+	assert.Equal(t, "B1", listA[0].SKUName)
+
+	// Deleting rgA's plan must not touch rgB's same-named plan.
+	require.NoError(t, m.DeleteAppServicePlan(ctx, "sub1", "rgA", "default"))
+
+	_, err = m.GetAppServicePlan(ctx, "sub1", "rgA", "default")
+	require.True(t, cerrors.IsNotFound(err))
+
+	stillThere, err := m.GetAppServicePlan(ctx, "sub1", "rgB", "default")
+	require.NoError(t, err)
+	assert.Equal(t, "P1v3", stillThere.SKUName)
+
+	// Deleting an already-gone (or never-scoped) plan is NotFound.
+	require.True(t, cerrors.IsNotFound(m.DeleteAppServicePlan(ctx, "sub1", "rgA", "default")))
 }

--- a/providers/azure/functions/site_meta.go
+++ b/providers/azure/functions/site_meta.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
 )
 
 // keyBytes is the entropy of a generated function/host key before base64.
@@ -108,24 +109,102 @@ func (m *Mock) UpsertSiteMeta(_ context.Context, in SiteMeta) (*SiteMeta, error)
 	return meta.clone(), nil
 }
 
-// GetSiteMeta returns the site metadata, or NotFound.
-func (m *Mock) GetSiteMeta(_ context.Context, name string) (*SiteMeta, error) {
+// GetSiteMeta returns the site metadata, scoped to the given subscription and
+// resource group. Azure Web App names are globally unique, so this is a plain
+// name lookup guarded by a scope check (not a composite-keyed lookup): a site
+// that exists under a different subscription/resource group than requested is
+// NotFound here, exactly as real ARM answers a GET against the wrong
+// resourceGroups segment.
+func (m *Mock) GetSiteMeta(_ context.Context, subscription, resourceGroup, name string) (*SiteMeta, error) {
 	m.sitesMu.RLock()
 	defer m.sitesMu.RUnlock()
 
 	meta, ok := m.sites.Get(name)
-	if !ok {
+	if !ok || meta.Subscription != subscription || meta.ResourceGroup != resourceGroup {
 		return nil, cerrors.Newf(cerrors.NotFound, "site %s not found", name)
 	}
 
 	return meta.clone(), nil
 }
 
-// DeleteSiteMeta removes the site metadata. Missing sites are ignored so it can
-// trail a portable DeleteFunction without racing.
-func (m *Mock) DeleteSiteMeta(_ context.Context, name string) error {
+// DeleteSiteMeta removes the site metadata, scoped to the given subscription
+// and resource group (see GetSiteMeta). A site that exists under a different
+// scope is left untouched — a DELETE against the wrong resourceGroups segment
+// must not delete another resource group's site. A site that doesn't exist at
+// all is also left untouched (ignored) so this can trail a portable
+// DeleteFunction without racing.
+func (m *Mock) DeleteSiteMeta(_ context.Context, subscription, resourceGroup, name string) error {
 	m.sitesMu.Lock()
 	defer m.sitesMu.Unlock()
+
+	meta, ok := m.sites.Get(name)
+	if !ok || meta.Subscription != subscription || meta.ResourceGroup != resourceGroup {
+		return nil
+	}
+
+	m.sites.Delete(name)
+
+	return nil
+}
+
+// UpdateAppSettings replaces a site's app settings only, preserving every
+// other stored field. This is the ARM contract for PUT .../config/appsettings
+// ("Replaces the application settings of an app" — not the whole site), and
+// is scoped exactly like GetSiteMeta/DeleteSiteMeta.
+func (m *Mock) UpdateAppSettings(
+	_ context.Context, subscription, resourceGroup, name string, settings map[string]string,
+) (*SiteMeta, error) {
+	m.sitesMu.Lock()
+	defer m.sitesMu.Unlock()
+
+	meta, ok := m.sites.Get(name)
+	if !ok || meta.Subscription != subscription || meta.ResourceGroup != resourceGroup {
+		return nil, cerrors.Newf(cerrors.NotFound, "site %s not found", name)
+	}
+
+	meta.AppSettings = maps.Clone(settings)
+	m.sites.Set(name, meta)
+
+	return meta.clone(), nil
+}
+
+// GetFunctionScoped returns the function only when it belongs to the given
+// subscription and resource group. The underlying portable function record
+// (m.funcs, driver.Serverless) is keyed by name alone across every resource
+// group — matching real Azure's globally-unique Web App names — so scope is
+// enforced here via the site metadata before ever touching that store,
+// closing the gap where an ARM GET against the wrong resourceGroups segment
+// would otherwise return another resource group's site.
+func (m *Mock) GetFunctionScoped(ctx context.Context, subscription, resourceGroup, name string) (*driver.FunctionInfo, error) {
+	m.sitesMu.RLock()
+	meta, ok := m.sites.Get(name)
+	m.sitesMu.RUnlock()
+
+	if !ok || meta.Subscription != subscription || meta.ResourceGroup != resourceGroup {
+		return nil, cerrors.Newf(cerrors.NotFound, "site %s not found", name)
+	}
+
+	return m.GetFunction(ctx, name)
+}
+
+// DeleteFunctionScoped deletes the function and its site metadata only when
+// the site belongs to the given subscription and resource group (see
+// GetFunctionScoped). The scope check, function delete and site-metadata
+// delete run under a single sitesMu hold so a concurrent
+// UpsertSiteMeta/DeleteSiteMeta for the same name can't interleave and shift
+// which resource group "owns" the name mid-operation.
+func (m *Mock) DeleteFunctionScoped(ctx context.Context, subscription, resourceGroup, name string) error {
+	m.sitesMu.Lock()
+	defer m.sitesMu.Unlock()
+
+	meta, ok := m.sites.Get(name)
+	if !ok || meta.Subscription != subscription || meta.ResourceGroup != resourceGroup {
+		return cerrors.Newf(cerrors.NotFound, "site %s not found", name)
+	}
+
+	if err := m.DeleteFunction(ctx, name); err != nil {
+		return err
+	}
 
 	m.sites.Delete(name)
 

--- a/providers/azure/functions/site_meta_test.go
+++ b/providers/azure/functions/site_meta_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
 )
 
 func newMetaMock() *Mock {
@@ -136,5 +137,149 @@ func TestSiteFunctionsLifecycle(t *testing.T) {
 	// Operations on a missing site are NotFound.
 	if _, err := m.CreateSiteFunction(ctx, "ghost", SiteFunction{Name: "fn"}); !cerrors.IsNotFound(err) {
 		t.Fatalf("create on missing site = %v, want NotFound", err)
+	}
+}
+
+// TestGetSiteMetaScoped covers the deep-sweep BLOCKER: a site must only be
+// visible through the subscription/resource group it was created in.
+func TestGetSiteMetaScoped(t *testing.T) {
+	m := newMetaMock()
+	ctx := context.Background()
+
+	if _, err := m.UpsertSiteMeta(ctx, SiteMeta{Name: "app1", Subscription: "sub1", ResourceGroup: "rgA"}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	if _, err := m.GetSiteMeta(ctx, "sub1", "rgA", "app1"); err != nil {
+		t.Fatalf("get in owning rg: %v", err)
+	}
+
+	if _, err := m.GetSiteMeta(ctx, "sub1", "rgB", "app1"); !cerrors.IsNotFound(err) {
+		t.Fatalf("get from wrong rg = %v, want NotFound", err)
+	}
+
+	if _, err := m.GetSiteMeta(ctx, "sub2", "rgA", "app1"); !cerrors.IsNotFound(err) {
+		t.Fatalf("get from wrong subscription = %v, want NotFound", err)
+	}
+}
+
+// TestDeleteSiteMetaScoped covers the deep-sweep BLOCKER: DELETE against the
+// wrong resource group must not remove another resource group's site.
+func TestDeleteSiteMetaScoped(t *testing.T) {
+	m := newMetaMock()
+	ctx := context.Background()
+
+	if _, err := m.UpsertSiteMeta(ctx, SiteMeta{Name: "app1", Subscription: "sub1", ResourceGroup: "rgA"}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	if err := m.DeleteSiteMeta(ctx, "sub1", "rgB", "app1"); err != nil {
+		t.Fatalf("delete from wrong rg returned error: %v", err)
+	}
+
+	if _, err := m.GetSiteMeta(ctx, "sub1", "rgA", "app1"); err != nil {
+		t.Fatalf("site deleted from wrong rg's request: %v", err)
+	}
+
+	if err := m.DeleteSiteMeta(ctx, "sub1", "rgA", "app1"); err != nil {
+		t.Fatalf("delete in owning rg: %v", err)
+	}
+
+	if _, err := m.GetSiteMeta(ctx, "sub1", "rgA", "app1"); !cerrors.IsNotFound(err) {
+		t.Fatalf("get after delete = %v, want NotFound", err)
+	}
+}
+
+// TestGetFunctionScopedAndDeleteFunctionScoped covers the deep-sweep BLOCKER
+// end to end: the portable function record is only reachable/deletable
+// through the resource group its site was created in.
+func TestGetFunctionScopedAndDeleteFunctionScoped(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "app1", Runtime: "dotnet6"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if _, err := m.UpsertSiteMeta(ctx, SiteMeta{Name: "app1", Subscription: "sub1", ResourceGroup: "rgA"}); err != nil {
+		t.Fatalf("upsert site meta: %v", err)
+	}
+
+	if _, err := m.GetFunctionScoped(ctx, "sub1", "rgB", "app1"); !cerrors.IsNotFound(err) {
+		t.Fatalf("get from wrong rg = %v, want NotFound", err)
+	}
+
+	info, err := m.GetFunctionScoped(ctx, "sub1", "rgA", "app1")
+	if err != nil {
+		t.Fatalf("get from owning rg: %v", err)
+	}
+
+	if info.Name != "app1" {
+		t.Fatalf("info.Name = %q, want app1", info.Name)
+	}
+
+	if err := m.DeleteFunctionScoped(ctx, "sub1", "rgB", "app1"); !cerrors.IsNotFound(err) {
+		t.Fatalf("delete from wrong rg = %v, want NotFound", err)
+	}
+
+	// The function must still exist — a delete against the wrong resource
+	// group must not have removed it.
+	if _, err := m.GetFunctionScoped(ctx, "sub1", "rgA", "app1"); err != nil {
+		t.Fatalf("function removed by wrong-rg delete: %v", err)
+	}
+
+	if err := m.DeleteFunctionScoped(ctx, "sub1", "rgA", "app1"); err != nil {
+		t.Fatalf("delete from owning rg: %v", err)
+	}
+
+	if _, err := m.GetFunctionScoped(ctx, "sub1", "rgA", "app1"); !cerrors.IsNotFound(err) {
+		t.Fatalf("get after delete = %v, want NotFound", err)
+	}
+
+	if _, err := m.GetFunction(ctx, "app1"); !cerrors.IsNotFound(err) {
+		t.Fatalf("underlying function survived scoped delete: %v", err)
+	}
+}
+
+// TestUpdateAppSettingsScoped covers the tractable HIGH finding: PUT
+// config/appsettings must persist the settings and must not touch a
+// same-named site in a different resource group.
+func TestUpdateAppSettingsScoped(t *testing.T) {
+	m := newMetaMock()
+	ctx := context.Background()
+
+	if _, err := m.UpsertSiteMeta(ctx, SiteMeta{
+		Name: "app1", Subscription: "sub1", ResourceGroup: "rgA",
+		Location: "eastus", AppSettings: map[string]string{"FOO": "orig"},
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	updated, err := m.UpdateAppSettings(ctx, "sub1", "rgA", "app1", map[string]string{"FOO": "bar", "BAZ": "qux"})
+	if err != nil {
+		t.Fatalf("update app settings: %v", err)
+	}
+
+	if updated.AppSettings["FOO"] != "bar" || updated.AppSettings["BAZ"] != "qux" {
+		t.Fatalf("app settings not updated: %+v", updated.AppSettings)
+	}
+
+	// Every other field must survive untouched (a PUT config/appsettings
+	// replaces only the app settings, not the whole site).
+	if updated.Location != "eastus" {
+		t.Fatalf("Location changed by app-settings update: %q", updated.Location)
+	}
+
+	if _, err := m.UpdateAppSettings(ctx, "sub1", "rgB", "app1", map[string]string{"FOO": "hijacked"}); !cerrors.IsNotFound(err) {
+		t.Fatalf("update from wrong rg = %v, want NotFound", err)
+	}
+
+	unchanged, err := m.GetSiteMeta(ctx, "sub1", "rgA", "app1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if unchanged.AppSettings["FOO"] != "bar" {
+		t.Fatalf("wrong-rg update leaked through: %+v", unchanged.AppSettings)
 	}
 }

--- a/server/azure/functions/handler.go
+++ b/server/azure/functions/handler.go
@@ -62,7 +62,9 @@ const (
 // satisfies it; backends that don't model plans fall through to 501.
 type appServicePlanStore interface {
 	CreateAppServicePlan(ctx context.Context, p azfunctions.AppServicePlan) (*azfunctions.AppServicePlan, error)
-	ListAppServicePlans(ctx context.Context) ([]azfunctions.AppServicePlan, error)
+	GetAppServicePlan(ctx context.Context, subscription, resourceGroup, name string) (*azfunctions.AppServicePlan, error)
+	DeleteAppServicePlan(ctx context.Context, subscription, resourceGroup, name string) error
+	ListAppServicePlans(ctx context.Context, subscription, resourceGroup string) ([]azfunctions.AppServicePlan, error)
 }
 
 // azureFunctionApps is the Azure-only site surface the handler layers on top of
@@ -72,14 +74,30 @@ type appServicePlanStore interface {
 // portable behavior (or 501 for Azure-only sub-routes).
 type azureFunctionApps interface {
 	UpsertSiteMeta(ctx context.Context, in azfunctions.SiteMeta) (*azfunctions.SiteMeta, error)
-	GetSiteMeta(ctx context.Context, name string) (*azfunctions.SiteMeta, error)
-	DeleteSiteMeta(ctx context.Context, name string) error
+	GetSiteMeta(ctx context.Context, subscription, resourceGroup, name string) (*azfunctions.SiteMeta, error)
+	DeleteSiteMeta(ctx context.Context, subscription, resourceGroup, name string) error
 	ListSiteMeta(ctx context.Context, subscription, resourceGroup string) ([]azfunctions.SiteMeta, error)
 	CreateSiteFunction(ctx context.Context, site string, fn azfunctions.SiteFunction) (*azfunctions.SiteFunction, error)
 	GetSiteFunction(ctx context.Context, site, name string) (*azfunctions.SiteFunction, error)
 	ListSiteFunctions(ctx context.Context, site string) ([]azfunctions.SiteFunction, error)
 	DeleteSiteFunction(ctx context.Context, site, name string) error
 	FunctionKeys(ctx context.Context, site, name string) (map[string]string, error)
+	UpdateAppSettings(
+		ctx context.Context, subscription, resourceGroup, name string, settings map[string]string,
+	) (*azfunctions.SiteMeta, error)
+}
+
+// azureScopedSites optionally scopes a site's get/delete to the (subscription,
+// resourceGroup) it was created under. The underlying portable function record
+// (sdrv.Serverless) is keyed by name alone across every resource group —
+// matching real Azure's globally-unique Web App names — so without this, an
+// ARM GET/DELETE against the wrong resourceGroups segment would return or
+// remove another resource group's site. Only the Azure provider Mock
+// (*azfunctions.Mock) satisfies it; other backends fall back to the unscoped
+// sdrv.Serverless calls.
+type azureScopedSites interface {
+	GetFunctionScoped(ctx context.Context, subscription, resourceGroup, name string) (*sdrv.FunctionInfo, error)
+	DeleteFunctionScoped(ctx context.Context, subscription, resourceGroup, name string) error
 }
 
 // Handler serves ARM JSON requests for Microsoft.Web/sites and direct invoke
@@ -269,23 +287,40 @@ func (h *Handler) upsertSiteMeta(
 
 //nolint:gocritic // rp travels the dispatch chain once per request.
 func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	info, err := h.fn.GetFunction(r.Context(), rp.ResourceName)
+	info, err := h.getFunction(r.Context(), rp)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toSiteResource(rp, info, h.siteMeta(r, rp.ResourceName)))
+	azurearm.WriteJSON(w, http.StatusOK, toSiteResource(rp, info, h.siteMeta(r, rp)))
 }
 
-// siteMeta fetches the stored Azure metadata for a site, or nil when absent.
-func (h *Handler) siteMeta(r *http.Request, name string) *azfunctions.SiteMeta {
+// getFunction resolves the function for rp, scoped to its (subscription,
+// resourceGroup) when the backend supports it (see azureScopedSites) so a
+// site created in one resource group is never returned through another.
+// Backends without site-scope support fall back to the unscoped lookup.
+//
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func (h *Handler) getFunction(ctx context.Context, rp azurearm.ResourcePath) (*sdrv.FunctionInfo, error) {
+	if scoped, ok := h.fn.(azureScopedSites); ok {
+		return scoped.GetFunctionScoped(ctx, rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+	}
+
+	return h.fn.GetFunction(ctx, rp.ResourceName)
+}
+
+// siteMeta fetches the stored Azure metadata for a site scoped to rp's
+// (subscription, resourceGroup), or nil when absent or out of scope.
+//
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func (h *Handler) siteMeta(r *http.Request, rp azurearm.ResourcePath) *azfunctions.SiteMeta {
 	store, ok := h.siteStore()
 	if !ok {
 		return nil
 	}
 
-	meta, err := store.GetSiteMeta(r.Context(), name)
+	meta, err := store.GetSiteMeta(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		return nil
 	}
@@ -353,13 +388,28 @@ func (h *Handler) listFromMeta(
 
 //nolint:gocritic // rp travels the dispatch chain once per request.
 func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if scoped, ok := h.fn.(azureScopedSites); ok {
+		// DeleteFunctionScoped atomically checks the site's (subscription,
+		// resourceGroup) and removes both the function and its site metadata,
+		// so a DELETE against the wrong resourceGroups segment 404s instead
+		// of deleting another resource group's site.
+		if err := scoped.DeleteFunctionScoped(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName); err != nil {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+
+		return
+	}
+
 	if err := h.fn.DeleteFunction(r.Context(), rp.ResourceName); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
 	if store, ok := h.siteStore(); ok {
-		_ = store.DeleteSiteMeta(r.Context(), rp.ResourceName)
+		_ = store.DeleteSiteMeta(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName)
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -399,6 +449,10 @@ func (h *Handler) zipDeploy(w http.ResponseWriter, r *http.Request, rp azurearm.
 	w.WriteHeader(http.StatusOK)
 }
 
+// servePlanSitesSubResource is the SubResource value of
+// GET .../serverfarms/{name}/sites — Plans.ListWebApps.
+const servePlanSitesSubResource = "sites"
+
 // servePlan routes Microsoft.Web/serverfarms (App Service plan) requests. Only
 // backends that model plans (the Azure provider Mock) are served; others 501.
 //
@@ -421,22 +475,36 @@ func (h *Handler) servePlan(w http.ResponseWriter, r *http.Request, rp azurearm.
 		return
 	}
 
+	if strings.EqualFold(rp.SubResource, servePlanSitesSubResource) {
+		if r.Method == http.MethodGet {
+			h.listPlanWebApps(w, r, rp, store)
+		} else {
+			azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		}
+
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPut:
 		createPlan(w, r, rp, store)
 	case http.MethodGet:
 		getPlan(w, r, rp, store)
+	case http.MethodDelete:
+		deletePlan(w, r, rp, store)
 	default:
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
 }
 
 // listPlans serves the serverfarms collection GET — Plans.List /
-// ListByResourceGroup.
+// ListByResourceGroup. rp.ResourceGroup empty means the whole subscription;
+// each row's scope is built from the plan's own stored resource group so a
+// subscription-wide list never emits an empty resourceGroups segment.
 //
 //nolint:gocritic // rp travels the dispatch chain once per request.
 func listPlans(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store appServicePlanStore) {
-	plans, err := store.ListAppServicePlans(r.Context())
+	plans, err := store.ListAppServicePlans(r.Context(), rp.Subscription, rp.ResourceGroup)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -445,8 +513,9 @@ func listPlans(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
 	out := make([]serverFarmResource, 0, len(plans))
 
 	for i := range plans {
-		scope := rp
-		scope.ResourceName = plans[i].Name
+		scope := azurearm.ResourcePath{
+			Subscription: rp.Subscription, ResourceGroup: plans[i].ResourceGroup, ResourceName: plans[i].Name,
+		}
 		out = append(out, toServerFarmResource(scope, &plans[i]))
 	}
 
@@ -469,13 +538,15 @@ func createPlan(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath
 	}
 
 	plan, err := store.CreateAppServicePlan(r.Context(), azfunctions.AppServicePlan{
-		Name:     rp.ResourceName,
-		Location: req.Location,
-		SKUName:  req.SKU.Name,
-		SKUTier:  req.SKU.Tier,
-		Kind:     req.Kind,
-		Capacity: req.SKU.Capacity,
-		Tags:     req.Tags,
+		Name:          rp.ResourceName,
+		Subscription:  rp.Subscription,
+		ResourceGroup: rp.ResourceGroup,
+		Location:      req.Location,
+		SKUName:       req.SKU.Name,
+		SKUTier:       req.SKU.Tier,
+		Kind:          req.Kind,
+		Capacity:      req.SKU.Capacity,
+		Tags:          req.Tags,
 	})
 	if err != nil {
 		azurearm.WriteCErr(w, err)
@@ -485,23 +556,79 @@ func createPlan(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath
 	azurearm.WriteJSON(w, http.StatusOK, toServerFarmResource(rp, plan))
 }
 
+// deletePlan serves DELETE .../serverfarms/{name} — Plans.Delete. Real Azure
+// answers 200 or 204 on success; this mock always answers 200, matching the
+// site DELETE above.
+//
 //nolint:gocritic // rp travels the dispatch chain once per request.
-func getPlan(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store appServicePlanStore) {
-	plans, err := store.ListAppServicePlans(r.Context())
+func deletePlan(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store appServicePlanStore) {
+	if err := store.DeleteAppServicePlan(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// listPlanWebApps serves GET .../serverfarms/{name}/sites — Plans.ListWebApps.
+// It joins on the site's stored ServerFarmID (set at site create/update time
+// from properties.serverFarmId) rather than keeping a reverse index on the
+// plan, so the plan and its apps can never drift out of sync.
+//
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func (h *Handler) listPlanWebApps(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store appServicePlanStore) {
+	if _, err := store.GetAppServicePlan(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	siteStore, ok := h.siteStore()
+	if !ok {
+		azurearm.WriteJSON(w, http.StatusOK, siteListResponse{Value: []siteResource{}})
+		return
+	}
+
+	planID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, serverFarmsType, rp.ResourceName)
+
+	// A site's plan can live in a different resource group than the site
+	// itself, so every site in the subscription is a candidate — not just
+	// this resource group's.
+	metas, err := siteStore.ListSiteMeta(r.Context(), rp.Subscription, "")
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
-	for i := range plans {
-		if plans[i].Name == rp.ResourceName {
-			azurearm.WriteJSON(w, http.StatusOK, toServerFarmResource(rp, &plans[i]))
-			return
+	out := make([]siteResource, 0, len(metas))
+
+	for i := range metas {
+		if !strings.EqualFold(metas[i].ServerFarmID, planID) {
+			continue
 		}
+
+		info, gerr := h.fn.GetFunction(r.Context(), metas[i].Name)
+		if gerr != nil {
+			continue
+		}
+
+		scope := azurearm.ResourcePath{
+			Subscription: metas[i].Subscription, ResourceGroup: metas[i].ResourceGroup, ResourceName: metas[i].Name,
+		}
+		out = append(out, toSiteResource(scope, info, &metas[i]))
 	}
 
-	azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound",
-		"app service plan "+rp.ResourceName+" not found")
+	azurearm.WriteJSON(w, http.StatusOK, siteListResponse{Value: out})
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func getPlan(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store appServicePlanStore) {
+	plan, err := store.GetAppServicePlan(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toServerFarmResource(rp, plan))
 }
 
 //nolint:gocritic // rp is request-scoped.

--- a/server/azure/functions/rgscope_sdk_test.go
+++ b/server/azure/functions/rgscope_sdk_test.go
@@ -1,0 +1,247 @@
+package functions_test
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3"
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// rgNameB is a second resource group, distinct from rgName, used by the
+// cross-resource-group isolation tests below.
+const rgNameB = "test-rg-b"
+
+// TestSDKSiteGetDeleteScopedByResourceGroup covers the deep-sweep BLOCKER: a
+// site created in one resource group must be invisible (Get and Delete both
+// 404) through a different resource group, even though the site name is
+// unique in the store.
+func TestSDKSiteGetDeleteScopedByResourceGroup(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{Functions: cloudP.Functions}))
+	t.Cleanup(ts.Close)
+
+	client := newWebAppsClient(t, ts)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rgName, "sdk-scoped-site",
+		armappservice.Site{
+			Kind:     to.Ptr("functionapp"),
+			Location: to.Ptr("eastus"),
+			Properties: &armappservice.SiteProperties{
+				SiteConfig: &armappservice.SiteConfig{LinuxFxVersion: to.Ptr("Python|3.11")},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err = poller.PollUntilDone(ctx, &runtimePollerOptions); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	// A GET against the real owning resource group succeeds.
+	if _, err := client.Get(ctx, rgName, "sdk-scoped-site", nil); err != nil {
+		t.Fatalf("Get in owning rg: %v", err)
+	}
+
+	// The same site name, requested through a different resource group, must
+	// 404 — not return rgName's site.
+	if _, err := client.Get(ctx, rgNameB, "sdk-scoped-site", nil); err == nil {
+		t.Fatal("Get from wrong resource group returned nil error, want 404")
+	}
+
+	// Deleting through the wrong resource group must 404 and must not remove
+	// the site from its real resource group.
+	if _, err := client.Delete(ctx, rgNameB, "sdk-scoped-site", nil); err == nil {
+		t.Fatal("Delete from wrong resource group returned nil error, want 404")
+	}
+
+	if _, err := client.Get(ctx, rgName, "sdk-scoped-site", nil); err != nil {
+		t.Fatalf("site removed by wrong-resource-group delete: %v", err)
+	}
+
+	// Deleting through the correct resource group succeeds and the site is
+	// then gone from there too.
+	if _, err := client.Delete(ctx, rgName, "sdk-scoped-site", nil); err != nil {
+		t.Fatalf("Delete in owning rg: %v", err)
+	}
+
+	if _, err := client.Get(ctx, rgName, "sdk-scoped-site", nil); err == nil {
+		t.Fatal("post-delete Get returned nil error, want 404")
+	}
+}
+
+// TestSDKAppServicePlanDeleteAndListWebApps covers the tractable HIGH
+// findings: DELETE on an App Service plan, and Plans.ListWebApps returning
+// the apps hosted on that plan (previously misrouted to the plan Get and
+// always empty).
+func TestSDKAppServicePlanDeleteAndListWebApps(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Functions: cloudP.Functions})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	plansClient := newPlansClient(t, ts)
+	webAppsClient := newWebAppsClient(t, ts)
+	ctx := context.Background()
+
+	planPoller, err := plansClient.BeginCreateOrUpdate(ctx, rgName, "sdk-plan-2",
+		armappservice.Plan{
+			Kind:     to.Ptr("linux"),
+			Location: to.Ptr("eastus"),
+			SKU:      &armappservice.SKUDescription{Name: to.Ptr("B1"), Tier: to.Ptr("Basic")},
+		}, nil)
+	if err != nil {
+		t.Fatalf("Plans BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err = planPoller.PollUntilDone(ctx, &runtimePollerOptions); err != nil {
+		t.Fatalf("Plans PollUntilDone: %v", err)
+	}
+
+	serverFarmID := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Web/serverfarms/sdk-plan-2", subID, rgName)
+
+	sitePoller, err := webAppsClient.BeginCreateOrUpdate(ctx, rgName, "sdk-plan-site",
+		armappservice.Site{
+			Kind:     to.Ptr("app"),
+			Location: to.Ptr("eastus"),
+			Properties: &armappservice.SiteProperties{
+				ServerFarmID: to.Ptr(serverFarmID),
+				SiteConfig:   &armappservice.SiteConfig{},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("Sites BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err = sitePoller.PollUntilDone(ctx, &runtimePollerOptions); err != nil {
+		t.Fatalf("Sites PollUntilDone: %v", err)
+	}
+
+	// Plans.ListWebApps must return the app just created against this plan.
+	pager := plansClient.NewListWebAppsPager(rgName, "sdk-plan-2", nil)
+
+	var names []string
+
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("ListWebApps page: %v", perr)
+		}
+
+		for _, s := range page.Value {
+			if s.Name != nil {
+				names = append(names, *s.Name)
+			}
+		}
+	}
+
+	if len(names) != 1 || names[0] != "sdk-plan-site" {
+		t.Fatalf("ListWebApps = %v, want [sdk-plan-site]", names)
+	}
+
+	// A plan in the wrong resource group must not see this plan's apps.
+	wrongPager := plansClient.NewListWebAppsPager(rgNameB, "sdk-plan-2", nil)
+	if wrongPager.More() {
+		if _, perr := wrongPager.NextPage(ctx); perr == nil {
+			t.Fatal("ListWebApps from wrong resource group returned nil error, want 404")
+		}
+	}
+
+	// DELETE the plan.
+	if _, err := plansClient.Delete(ctx, rgName, "sdk-plan-2", nil); err != nil {
+		t.Fatalf("Plans Delete: %v", err)
+	}
+
+	if _, err := plansClient.Get(ctx, rgName, "sdk-plan-2", nil); err == nil {
+		t.Fatal("post-delete Plans Get returned nil error, want 404")
+	}
+
+	// Deleting again is a 404, not a panic or 500.
+	if _, err := plansClient.Delete(ctx, rgName, "sdk-plan-2", nil); err == nil {
+		t.Fatal("second Delete returned nil error, want 404")
+	}
+}
+
+// TestSDKUpdateApplicationSettings covers the tractable HIGH finding: PUT
+// config/appsettings must persist the settings (replacing, not merging) and
+// echo them back, and a wrong-resource-group PUT must not leak through.
+func TestSDKUpdateApplicationSettings(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{Functions: cloudP.Functions}))
+	t.Cleanup(ts.Close)
+
+	client := newWebAppsClient(t, ts)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rgName, "sdk-appsettings",
+		armappservice.Site{
+			Kind:     to.Ptr("functionapp"),
+			Location: to.Ptr("eastus"),
+			Properties: &armappservice.SiteProperties{
+				SiteConfig: &armappservice.SiteConfig{
+					AppSettings: []*armappservice.NameValuePair{
+						{Name: to.Ptr("ORIGINAL"), Value: to.Ptr("keepme")},
+					},
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err = poller.PollUntilDone(ctx, &runtimePollerOptions); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	updated, err := client.UpdateApplicationSettings(ctx, rgName, "sdk-appsettings",
+		armappservice.StringDictionary{
+			Properties: map[string]*string{
+				"NEW_SETTING": to.Ptr("value1"),
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("UpdateApplicationSettings: %v", err)
+	}
+
+	if got := updated.Properties["NEW_SETTING"]; got == nil || *got != "value1" {
+		t.Fatalf("response NEW_SETTING = %v, want value1", got)
+	}
+
+	settings, err := client.ListApplicationSettings(ctx, rgName, "sdk-appsettings", nil)
+	if err != nil {
+		t.Fatalf("ListApplicationSettings: %v", err)
+	}
+
+	if got := settings.Properties["NEW_SETTING"]; got == nil || *got != "value1" {
+		t.Fatalf("persisted NEW_SETTING = %v, want value1", got)
+	}
+
+	// PUT replaces the settings map — ORIGINAL from create time must be gone.
+	if _, ok := settings.Properties["ORIGINAL"]; ok {
+		t.Fatalf("PUT config/appsettings merged instead of replacing: %+v", settings.Properties)
+	}
+
+	// A PUT against the wrong resource group must 404 and must not touch the
+	// real site's settings.
+	if _, err := client.UpdateApplicationSettings(ctx, rgNameB, "sdk-appsettings",
+		armappservice.StringDictionary{Properties: map[string]*string{"HIJACK": to.Ptr("bad")}}, nil,
+	); err == nil {
+		t.Fatal("UpdateApplicationSettings from wrong resource group returned nil error, want 404")
+	}
+
+	after, err := client.ListApplicationSettings(ctx, rgName, "sdk-appsettings", nil)
+	if err != nil {
+		t.Fatalf("ListApplicationSettings after wrong-rg update: %v", err)
+	}
+
+	if _, leaked := after.Properties["HIJACK"]; leaked {
+		t.Fatal("wrong-resource-group UpdateApplicationSettings leaked through")
+	}
+}

--- a/server/azure/functions/sites_subroutes.go
+++ b/server/azure/functions/sites_subroutes.go
@@ -1,6 +1,8 @@
 package functions
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 
 	azfunctions "github.com/stackshy/cloudemu/v2/providers/azure/functions"
@@ -57,6 +59,8 @@ func (*Handler) serveConfig(w http.ResponseWriter, r *http.Request, rp azurearm.
 		getConfigWeb(w, r, rp, store)
 	case rp.SubResourceName == configNameAppSettings && rp.SubResourceAction == actionList && r.Method == http.MethodPost:
 		listAppSettings(w, r, rp, store)
+	case rp.SubResourceName == configNameAppSettings && rp.SubResourceAction == "" && r.Method == http.MethodPut:
+		updateAppSettings(w, r, rp, store)
 	default:
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "unsupported config route")
 	}
@@ -64,7 +68,7 @@ func (*Handler) serveConfig(w http.ResponseWriter, r *http.Request, rp azurearm.
 
 //nolint:gocritic // rp travels the dispatch chain once per request.
 func getConfigWeb(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps) {
-	meta, err := store.GetSiteMeta(r.Context(), rp.ResourceName)
+	meta, err := store.GetSiteMeta(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -83,7 +87,7 @@ func getConfigWeb(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePa
 
 //nolint:gocritic // rp travels the dispatch chain once per request.
 func listAppSettings(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps) {
-	meta, err := store.GetSiteMeta(r.Context(), rp.ResourceName)
+	meta, err := store.GetSiteMeta(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -103,6 +107,35 @@ func listAppSettings(w http.ResponseWriter, r *http.Request, rp azurearm.Resourc
 	})
 }
 
+// updateAppSettings serves PUT .../config/appsettings — WebApps_
+// UpdateApplicationSettings. Per the ARM contract, this replaces the app's
+// entire settings map (not a merge) and echoes it back in the response.
+//
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func updateAppSettings(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxControlBytes)
+
+	var req stringDictionary
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidRequestContent", err.Error())
+		return
+	}
+
+	meta, err := store.UpdateAppSettings(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName, req.Properties)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, stringDictionary{
+		ID:         siteID(rp) + "/config/appsettings",
+		Name:       configNameAppSettings,
+		Type:       configResourceType,
+		Kind:       "app",
+		Properties: nonNilMap(meta.AppSettings),
+	})
+}
+
 //nolint:gocritic // rp travels the dispatch chain once per request.
 func (*Handler) serveHostKeys(
 	w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps,
@@ -112,7 +145,7 @@ func (*Handler) serveHostKeys(
 		return
 	}
 
-	meta, err := store.GetSiteMeta(r.Context(), rp.ResourceName)
+	meta, err := store.GetSiteMeta(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -132,7 +165,7 @@ func (h *Handler) serveRestart(w http.ResponseWriter, r *http.Request, rp azurea
 		return
 	}
 
-	if _, err := h.fn.GetFunction(r.Context(), rp.ResourceName); err != nil {
+	if _, err := h.getFunction(r.Context(), rp); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}


### PR DESCRIPTION
## Summary

Fixes deep-sweep findings on Azure App Service / Functions (`Microsoft.Web/sites`, `Microsoft.Web/serverfarms`), reproduced against real `azure-sdk-for-go` `armappservice` clients.

- **BLOCKER**: single-resource site GET/DELETE ignored the request's subscription/resourceGroup — `handler.go`'s `get()`/`delete()` resolved by name only, so a site created in one resource group was readable and deletable through any other resource group (or subscription). `GetSiteMeta`/`DeleteSiteMeta` are now scoped to `(subscription, resourceGroup, name)`, and new `GetFunctionScoped`/`DeleteFunctionScoped` provider methods gate the underlying portable function record (which stays name-keyed, matching the shared `driver.Serverless` interface used by AWS/GCP too) on that scope before ever returning or removing it. The delete path runs under a single lock so a concurrent create/delete for the same name can't interleave.
- App Service plans (`serverfarms`) were keyed by name only across a flat namespace, so two resource groups with a same-named plan collided/overwrote each other. Plans are now stored under a `(subscription, resourceGroup, name)` key, with `GetAppServicePlan`/`DeleteAppServicePlan` added.
- `DELETE` on a `serverfarms` plan was `405`; added `DeleteAppServicePlan` and wired it into `servePlan`.
- `PUT config/appsettings` (`WebApps_UpdateApplicationSettings`) was `405`; it now replaces the site's app settings (per the ARM contract — a replace, not a merge) and echoes them back, scoped like the other site sub-routes.
- `GET serverfarms/{name}/sites` (`Plans.ListWebApps`) was misrouted to the plan `Get` and always returned an empty response; it now joins on each site's stored `ServerFarmID` and returns the plan's apps.

Deployment slots (`Microsoft.Web/sites/slots`) are intentionally out of scope for this change.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./providers/azure/... ./server/azure/... ./services/...`
- [x] `go test -race ./providers/azure/functions/...` and `./server/azure/functions/...`
- [x] `go test ./...` (full suite)
- [x] `go test ./compat/...`
- [x] `golangci-lint` on changed packages: 0 issues
- [x] `gofmt -l`: clean
- [x] New regression tests against the real `azure-sdk-for-go` `armappservice` client over a live TLS wire server: cross-resource-group Get/Delete isolation, plan Delete + ListWebApps, and PUT `UpdateApplicationSettings`