### PR TITLE
fix(eventgrid): deliver PutEvents to WebHook subscribers, apply filters, isolate MatchedRules, persist InputSchema, add DomainTopics CRUD

### DIFF
--- a/internal/recursionguard/recursionguard.go
+++ b/internal/recursionguard/recursionguard.go
@@ -21,6 +21,15 @@ import "context"
 // Lambda's documented recursive-loop-detection threshold of ~16 invocations.
 const MaxDepth = 16
 
+// DepthHeader carries the re-entrant delivery depth across a delivery hop that
+// crosses an HTTP boundary. In-process chains ride the goroutine's ctx, but a
+// hop like Event Grid WebHook delivery is a fresh outbound HTTP request whose
+// response re-enters the emulator through a separate handler goroutine, so the
+// ctx depth can't ride along. The sender stamps the incremented depth on this
+// header; the re-entered publish handler seeds ctx from it via WithDepth so the
+// chain keeps counting toward MaxDepth instead of resetting to zero each hop.
+const DepthHeader = "X-Cloudemu-Delivery-Depth"
+
 type depthKey struct{}
 
 // WithDepth returns a copy of ctx carrying the given re-entrant delivery

--- a/providers/azure/eventgrid/delivery.go
+++ b/providers/azure/eventgrid/delivery.go
@@ -1,0 +1,151 @@
+package eventgrid
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+)
+
+// endpointTypeWebHook is the only ARM EventSubscriptionDestination.endpointType
+// this mock actually delivers to (see deliverToTargets). ServiceBusQueue,
+// ServiceBusTopic, EventHub, AzureFunction, StorageQueue, and HybridConnection
+// destinations are parsed and round-trip on the subscription resource (the raw
+// ARM properties JSON is echoed verbatim regardless of type) but are not
+// delivered to: EventHub has no peer mock in this codebase, and wiring
+// ServiceBus/Functions delivery is left as a follow-up (see PR notes).
+const endpointTypeWebHook = "WebHook"
+
+// webhookDeliveryTimeout bounds how long PutEvents waits for a single WebHook
+// destination to respond. Real Event Grid waits up to 30s before queuing a
+// retry; this mock uses a shorter bound so a dead test endpoint can't hang a
+// publish call indefinitely.
+const webhookDeliveryTimeout = 10 * time.Second
+
+// subscriptionDestination is the parsed form of an ARM
+// EventSubscriptionDestination (properties.destination on an event
+// subscription) — the polymorphic "endpointType" + nested "properties" union
+// ARM emits. Azure-only, so it stays local to this provider package rather
+// than the shared eventbus driver.
+type subscriptionDestination struct {
+	EndpointType string
+	EndpointURL  string // WebHook
+	ResourceID   string // ServiceBusQueue/Topic, EventHub, AzureFunction, StorageQueue, HybridConnection
+}
+
+// parseSubscriptionDestination extracts the "destination" object from a raw
+// ARM EventSubscription properties JSON blob.
+func parseSubscriptionDestination(rawProperties string) subscriptionDestination {
+	if rawProperties == "" {
+		return subscriptionDestination{}
+	}
+
+	var body struct {
+		Destination struct {
+			EndpointType string `json:"endpointType"`
+			Properties   struct {
+				EndpointURL string `json:"endpointUrl"`
+				ResourceID  string `json:"resourceId"`
+			} `json:"properties"`
+		} `json:"destination"`
+	}
+
+	if err := json.Unmarshal([]byte(rawProperties), &body); err != nil {
+		return subscriptionDestination{}
+	}
+
+	return subscriptionDestination{
+		EndpointType: body.Destination.EndpointType,
+		EndpointURL:  body.Destination.Properties.EndpointURL,
+		ResourceID:   body.Destination.Properties.ResourceID,
+	}
+}
+
+// deliveryEvent is the Event Grid schema payload POSTed to a WebHook
+// destination. Real Event Grid defaults to unbatched delivery — one event per
+// request, carried as a single-element array — which this mirrors.
+type deliveryEvent struct {
+	ID              string          `json:"id"`
+	Topic           string          `json:"topic"`
+	Subject         string          `json:"subject"`
+	EventType       string          `json:"eventType"`
+	EventTime       string          `json:"eventTime"`
+	Data            json.RawMessage `json:"data"`
+	DataVersion     string          `json:"dataVersion"`
+	MetadataVersion string          `json:"metadataVersion"`
+}
+
+// deliverToTargets POSTs event to every matched subscription's WebHook
+// destination. Delivery is synchronous (mirroring how AWS EventBridge's
+// deliverToTargets runs in-line in this codebase) but decoupled from the
+// caller's context so a client that cancels its publish request doesn't abort
+// in-flight deliveries. ServiceBusQueue/Topic, EventHub, and AzureFunction
+// destinations are parsed and round-trip on the subscription resource, but
+// are not delivered to: EventHub has no peer mock in this codebase, and
+// wiring ServiceBus/Functions delivery is left as a follow-up (see PR notes).
+func (m *Mock) deliverToTargets(matched []*ruleData, event *driver.Event, topicARN string) {
+	if len(matched) == 0 {
+		return
+	}
+
+	payload := deliveryEvent{
+		ID:          event.ID,
+		Topic:       topicARN,
+		Subject:     event.Subject,
+		EventType:   event.DetailType,
+		EventTime:   event.Time.UTC().Format(time.RFC3339Nano),
+		Data:        eventDataOrEmpty(event.Detail),
+		DataVersion: "1.0",
+	}
+
+	body, err := json.Marshal([]deliveryEvent{payload})
+	if err != nil {
+		return
+	}
+
+	for _, rd := range matched {
+		if rd.dest.EndpointType != endpointTypeWebHook || rd.dest.EndpointURL == "" {
+			continue
+		}
+
+		m.postWebhook(rd.dest.EndpointURL, body)
+	}
+}
+
+// postWebhook delivers one rendered batch to a WebHook endpoint, matching the
+// headers real Event Grid sends. Errors (unreachable endpoint, non-2xx
+// status) are swallowed: this mock does not model Event Grid's retry/dead-
+// letter pipeline, so a failed delivery is simply dropped, same as
+// EventBridge's dispatchTarget in this codebase.
+func (m *Mock) postWebhook(url string, body []byte) {
+	ctx, cancel := context.WithTimeout(context.Background(), webhookDeliveryTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Aeg-Event-Type", "Notification")
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+}
+
+func eventDataOrEmpty(detail string) json.RawMessage {
+	if detail == "" {
+		return json.RawMessage("{}")
+	}
+
+	return json.RawMessage(detail)
+}

--- a/providers/azure/eventgrid/delivery.go
+++ b/providers/azure/eventgrid/delivery.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 )
 
@@ -83,14 +85,22 @@ type deliveryEvent struct {
 // destination. Delivery is synchronous (mirroring how AWS EventBridge's
 // deliverToTargets runs in-line in this codebase) but decoupled from the
 // caller's context so a client that cancels its publish request doesn't abort
-// in-flight deliveries. ServiceBusQueue/Topic, EventHub, and AzureFunction
-// destinations are parsed and round-trip on the subscription resource, but
-// are not delivered to: EventHub has no peer mock in this codebase, and
-// wiring ServiceBus/Functions delivery is left as a follow-up (see PR notes).
-func (m *Mock) deliverToTargets(matched []*ruleData, event *driver.Event, topicARN string) {
+// in-flight deliveries. The caller ctx's re-entrant delivery depth is carried
+// forward so a self-referential WebHook chain (a subscription endpointUrl that
+// points back at this emulator's publish endpoint) stays bounded — the cap is
+// enforced in postWebhook, mirroring lambda.InvokeExternal. ServiceBusQueue/
+// Topic, EventHub, and AzureFunction destinations are parsed and round-trip on
+// the subscription resource, but are not delivered to: EventHub has no peer
+// mock in this codebase, and wiring ServiceBus/Functions delivery is left as a
+// follow-up (see PR notes).
+func (m *Mock) deliverToTargets(ctx context.Context, matched []*ruleData, event *driver.Event, topicARN string) {
 	if len(matched) == 0 {
 		return
 	}
+
+	// Decouple delivery from the caller's cancellation/deadline while carrying
+	// the re-entrant delivery depth forward onto a background-rooted context.
+	dctx := recursionguard.WithDepth(context.Background(), recursionguard.Depth(ctx))
 
 	payload := deliveryEvent{
 		ID:          event.ID,
@@ -112,7 +122,7 @@ func (m *Mock) deliverToTargets(matched []*ruleData, event *driver.Event, topicA
 			continue
 		}
 
-		m.postWebhook(rd.dest.EndpointURL, body)
+		m.postWebhook(dctx, rd.dest.EndpointURL, body)
 	}
 }
 
@@ -121,17 +131,32 @@ func (m *Mock) deliverToTargets(matched []*ruleData, event *driver.Event, topicA
 // status) are swallowed: this mock does not model Event Grid's retry/dead-
 // letter pipeline, so a failed delivery is simply dropped, same as
 // EventBridge's dispatchTarget in this codebase.
-func (m *Mock) postWebhook(url string, body []byte) {
-	ctx, cancel := context.WithTimeout(context.Background(), webhookDeliveryTimeout)
+//
+// ctx carries the re-entrant delivery depth (see internal/recursionguard). A
+// subscription's endpointUrl is arbitrary ARM input and can point back at this
+// emulator's own publish endpoint; because delivery is synchronous, an
+// unbounded self-referential chain would tie up one blocked goroutine per
+// level. Once the depth reaches recursionguard.MaxDepth — mirroring
+// lambda.InvokeExternal — the delivery is dropped instead of recursing further.
+func (m *Mock) postWebhook(ctx context.Context, url string, body []byte) {
+	depth := recursionguard.Depth(ctx)
+	if depth >= recursionguard.MaxDepth {
+		return
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, webhookDeliveryTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return
 	}
 
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	req.Header.Set("Aeg-Event-Type", "Notification")
+	// Carry the incremented depth across the webhook round-trip so a publish
+	// endpoint that re-enters PutEvents keeps counting toward the cap.
+	req.Header.Set(recursionguard.DepthHeader, strconv.Itoa(depth+1))
 
 	resp, err := m.httpClient.Do(req)
 	if err != nil {

--- a/providers/azure/eventgrid/delivery_test.go
+++ b/providers/azure/eventgrid/delivery_test.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -134,6 +137,60 @@ func TestPutEventsDeliveryHonorsFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Empty(t, receiver.events(), "non-matching subject must not be delivered")
+}
+
+// TestPutEventsWebHookRecursionBounded locks the HIGH fix: a WebHook
+// subscription whose endpoint re-publishes to the same topic is a
+// self-referential loop. Delivery is synchronous, so without a cap each level
+// ties up a blocked goroutine forever. The re-entrant depth guard (carried
+// across the webhook round-trip via recursionguard.DepthHeader) must bound the
+// chain to at most MaxDepth deliveries and let the process unwind.
+func TestPutEventsWebHookRecursionBounded(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "loop")
+
+	var deliveries atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deliveries.Add(1)
+
+		// Seed the depth from the header exactly as the real PublishHandler
+		// does, then re-publish to the same topic to close the loop.
+		reCtx := context.Background()
+		if d, err := strconv.Atoi(r.Header.Get(recursionguard.DepthHeader)); err == nil && d > 0 {
+			reCtx = recursionguard.WithDepth(reCtx, d)
+		}
+
+		_, _ = m.PutEvents(reCtx, []driver.Event{{
+			EventBus:   "loop",
+			DetailType: "Loop.Tick",
+			Subject:    "loop/1",
+		}})
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := m.PutRule(ctx, &driver.RuleConfig{
+		Name:        "sub-loop",
+		EventBus:    "loop",
+		Description: destinationJSON(srv.URL),
+	})
+	require.NoError(t, err)
+
+	_, err = m.PutEvents(ctx, []driver.Event{{
+		EventBus:   "loop",
+		DetailType: "Loop.Start",
+		Subject:    "loop/0",
+	}})
+	require.NoError(t, err)
+
+	got := deliveries.Load()
+	assert.Positive(t, got, "the webhook must be delivered to at least once")
+	assert.LessOrEqual(t, got, int32(recursionguard.MaxDepth),
+		"the self-referential webhook chain must be bounded by the depth cap")
 }
 
 // TestMatchedRulesScopedToOwnTopic locks the isolation fix: a subscription on

--- a/providers/azure/eventgrid/delivery_test.go
+++ b/providers/azure/eventgrid/delivery_test.go
@@ -1,0 +1,159 @@
+package eventgrid
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// webhookReceiver is a tiny live HTTP server standing in for a subscriber's
+// WebHook endpoint, recording every delivered batch.
+type webhookReceiver struct {
+	*httptest.Server
+
+	mu    sync.Mutex
+	calls [][]deliveryEvent
+}
+
+func newWebhookReceiver(t *testing.T) *webhookReceiver {
+	t.Helper()
+
+	wh := &webhookReceiver{}
+	wh.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var batch []deliveryEvent
+		if err := json.NewDecoder(r.Body).Decode(&batch); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		wh.mu.Lock()
+		wh.calls = append(wh.calls, batch)
+		wh.mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(wh.Close)
+
+	return wh
+}
+
+func (wh *webhookReceiver) events() []deliveryEvent {
+	wh.mu.Lock()
+	defer wh.mu.Unlock()
+
+	var out []deliveryEvent
+	for _, batch := range wh.calls {
+		out = append(out, batch...)
+	}
+
+	return out
+}
+
+func destinationJSON(endpointURL string) string {
+	b, _ := json.Marshal(map[string]any{
+		"destination": map[string]any{
+			"endpointType": endpointTypeWebHook,
+			"properties":   map[string]any{"endpointUrl": endpointURL},
+		},
+	})
+
+	return string(b)
+}
+
+// TestPutEventsDeliversToWebHook is the BLOCKER regression: PutEvents must
+// actually reach a subscription's WebHook destination, not just record the
+// event in history.
+func TestPutEventsDeliversToWebHook(t *testing.T) {
+	receiver := newWebhookReceiver(t)
+
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "orders")
+
+	_, err := m.PutRule(ctx, &driver.RuleConfig{
+		Name:        "sub1",
+		EventBus:    "orders",
+		Description: destinationJSON(receiver.URL),
+	})
+	require.NoError(t, err)
+
+	_, err = m.PutEvents(ctx, []driver.Event{{
+		EventBus:   "orders",
+		DetailType: "Order.Created",
+		Detail:     `{"total":42}`,
+		Subject:    "orders/1",
+	}})
+	require.NoError(t, err)
+
+	got := receiver.events()
+	require.Len(t, got, 1)
+	assert.Equal(t, "Order.Created", got[0].EventType)
+	assert.Equal(t, "orders/1", got[0].Subject)
+	assert.JSONEq(t, `{"total":42}`, string(got[0].Data))
+}
+
+// TestPutEventsDeliveryHonorsFilter locks the MEDIUM fix: a subscription
+// filter that doesn't match the event must suppress delivery, not just
+// suppress the MatchedRules count.
+func TestPutEventsDeliveryHonorsFilter(t *testing.T) {
+	receiver := newWebhookReceiver(t)
+
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "orders")
+
+	props, _ := json.Marshal(map[string]any{
+		"destination": map[string]any{
+			"endpointType": endpointTypeWebHook,
+			"properties":   map[string]any{"endpointUrl": receiver.URL},
+		},
+		"filter": map[string]any{"subjectBeginsWith": "orders/"},
+	})
+
+	_, err := m.PutRule(ctx, &driver.RuleConfig{
+		Name:        "sub1",
+		EventBus:    "orders",
+		Description: string(props),
+	})
+	require.NoError(t, err)
+
+	_, err = m.PutEvents(ctx, []driver.Event{{
+		EventBus:   "orders",
+		DetailType: "Invoice.Created",
+		Subject:    "invoices/1",
+	}})
+	require.NoError(t, err)
+
+	assert.Empty(t, receiver.events(), "non-matching subject must not be delivered")
+}
+
+// TestMatchedRulesScopedToOwnTopic locks the isolation fix: a subscription on
+// one topic must never match an event published to a different topic.
+func TestMatchedRulesScopedToOwnTopic(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "topic-a")
+	createTestTopic(t, m, "topic-b")
+
+	_, err := m.PutRule(ctx, &driver.RuleConfig{Name: "rule-a", EventBus: "topic-a"})
+	require.NoError(t, err)
+
+	event := &driver.Event{
+		Source:     "svc",
+		DetailType: "Thing",
+		EventBus:   "topic-b",
+	}
+
+	matched := m.MatchedRules(event)
+	assert.Empty(t, matched, "a rule on topic-a must not match an event published to topic-b")
+}

--- a/providers/azure/eventgrid/eventgrid.go
+++ b/providers/azure/eventgrid/eventgrid.go
@@ -405,7 +405,7 @@ func (m *Mock) ListTargets(_ context.Context, eventBus, ruleName string) ([]driv
 }
 
 // PutEvents publishes events to Event Grid topics.
-func (m *Mock) PutEvents(_ context.Context, events []driver.Event) (*driver.PublishResult, error) {
+func (m *Mock) PutEvents(ctx context.Context, events []driver.Event) (*driver.PublishResult, error) {
 	result := &driver.PublishResult{
 		EventIDs: make([]string, 0, len(events)),
 	}
@@ -435,7 +435,7 @@ func (m *Mock) PutEvents(_ context.Context, events []driver.Event) (*driver.Publ
 		m.storeEvent(bd, &events[i])
 
 		matched := m.matchedRuleData(bd, &events[i])
-		m.deliverToTargets(matched, &events[i], bd.info.ARN)
+		m.deliverToTargets(ctx, matched, &events[i], bd.info.ARN)
 
 		m.emitMetric(busName, map[string]float64{
 			"PublishedEvents": 1, "MatchedEvents": float64(len(matched)),

--- a/providers/azure/eventgrid/eventgrid.go
+++ b/providers/azure/eventgrid/eventgrid.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"net/http"
 	"sync"
 	"time"
 
@@ -25,6 +26,9 @@ const (
 	activeTopicState = "ACTIVE"
 	resourceProvider = "Microsoft.EventGrid"
 	resourceType     = "topics"
+	// defaultInputSchema is the event schema a topic accepts when the caller
+	// doesn't specify one, matching real Event Grid's default.
+	defaultInputSchema = "EventGridSchema"
 )
 
 // Compile-time check that Mock implements driver.EventBus.
@@ -33,6 +37,12 @@ var _ driver.EventBus = (*Mock)(nil)
 type ruleData struct {
 	rule    driver.Rule
 	targets *memstore.Store[driver.Target]
+	// filter and dest are parsed from rule.Description (the raw ARM
+	// EventSubscription properties JSON) — Event Grid's subscription filter
+	// and destination shapes have no equivalent in the portable eventbus
+	// driver, so PutRule derives them here for PutEvents to apply/deliver to.
+	filter subscriptionFilter
+	dest   subscriptionDestination
 }
 
 type busData struct {
@@ -47,6 +57,7 @@ type Mock struct {
 	buses      *memstore.Store[*busData]
 	opts       *config.Options
 	monitoring mondriver.Monitoring
+	httpClient *http.Client
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -79,8 +90,9 @@ func (m *Mock) emitMetric(topicName string, metrics map[string]float64) {
 // New creates a new Event Grid mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		buses: memstore.New[*busData](),
-		opts:  opts,
+		buses:      memstore.New[*busData](),
+		opts:       opts,
+		httpClient: &http.Client{Timeout: webhookDeliveryTimeout},
 	}
 }
 
@@ -111,14 +123,20 @@ func (m *Mock) CreateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 		tags[k] = v
 	}
 
+	inputSchema := cfg.InputSchema
+	if inputSchema == "" {
+		inputSchema = defaultInputSchema
+	}
+
 	info := driver.EventBusInfo{
-		Name:      cfg.Name,
-		Scope:     cfg.Scope,
-		ARN:       topicID,
-		State:     activeTopicState,
-		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
-		Tags:      tags,
-		Region:    cfg.Region,
+		Name:        cfg.Name,
+		Scope:       cfg.Scope,
+		ARN:         topicID,
+		State:       activeTopicState,
+		CreatedAt:   m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:        tags,
+		Region:      cfg.Region,
+		InputSchema: inputSchema,
 	}
 
 	bd := &busData{
@@ -209,6 +227,8 @@ func (m *Mock) PutRule(_ context.Context, cfg *driver.RuleConfig) (*driver.Rule,
 	rd := &ruleData{
 		rule:    rule,
 		targets: memstore.New[driver.Target](),
+		filter:  parseSubscriptionFilter(cfg.Description),
+		dest:    parseSubscriptionDestination(cfg.Description),
 	}
 
 	for _, t := range rule.Targets {
@@ -414,9 +434,11 @@ func (m *Mock) PutEvents(_ context.Context, events []driver.Event) (*driver.Publ
 
 		m.storeEvent(bd, &events[i])
 
-		matchedCount := len(m.MatchedRules(&events[i]))
+		matched := m.matchedRuleData(bd, &events[i])
+		m.deliverToTargets(matched, &events[i], bd.info.ARN)
+
 		m.emitMetric(busName, map[string]float64{
-			"PublishedEvents": 1, "MatchedEvents": float64(matchedCount),
+			"PublishedEvents": 1, "MatchedEvents": float64(len(matched)),
 		})
 
 		result.SuccessCount++
@@ -545,22 +567,45 @@ func (m *Mock) UpdateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 	return &result, nil
 }
 
-// MatchedRules returns all subscriptions that match the given event (exported for testing).
+// MatchedRules returns the subscriptions on the event's own topic that match
+// it (exported for testing). Scoped to event.EventBus so a rule on one topic
+// never counts as matched for an event published to a different topic.
 func (m *Mock) MatchedRules(event *driver.Event) []driver.Rule {
-	var matched []driver.Rule
+	bd, ok := m.buses.Get(event.EventBus)
+	if !ok {
+		return nil
+	}
 
-	all := m.buses.All()
-	for _, bd := range all {
-		rules := bd.rules.All()
-		for _, rd := range rules {
-			if rd.rule.State != defaultRuleState {
-				continue
-			}
+	rds := m.matchedRuleData(bd, event)
 
-			if matchesPattern(event, rd.rule.EventPattern) {
-				matched = append(matched, rd.rule)
-			}
+	matched := make([]driver.Rule, 0, len(rds))
+	for _, rd := range rds {
+		matched = append(matched, rd.rule)
+	}
+
+	return matched
+}
+
+// matchedRuleData returns the enabled subscriptions on bd (the event's own
+// topic) whose event pattern and Event Grid filter (subject prefix/suffix,
+// included event types, advanced filters) both match event.
+func (*Mock) matchedRuleData(bd *busData, event *driver.Event) []*ruleData {
+	var matched []*ruleData
+
+	for _, rd := range bd.rules.All() {
+		if rd.rule.State != defaultRuleState {
+			continue
 		}
+
+		if !matchesPattern(event, rd.rule.EventPattern) {
+			continue
+		}
+
+		if !rd.filter.matches(event) {
+			continue
+		}
+
+		matched = append(matched, rd)
 	}
 
 	return matched

--- a/providers/azure/eventgrid/filter.go
+++ b/providers/azure/eventgrid/filter.go
@@ -201,7 +201,11 @@ func matchAdvancedFilter(af *advancedFilter, event *driver.Event, data map[strin
 	}
 
 	if !found {
-		return false
+		// Per Event Grid's filtering semantics, a missing key evaluates as
+		// MATCHED only for the two negative-membership operators (the field
+		// genuinely can't be in the excluded set); every other operator is
+		// NOT-matched on a missing key. See Microsoft Learn "Event Filtering".
+		return af.OperatorType == opStringNotIn || af.OperatorType == opNumberNotIn
 	}
 
 	switch {

--- a/providers/azure/eventgrid/filter.go
+++ b/providers/azure/eventgrid/filter.go
@@ -1,0 +1,333 @@
+package eventgrid
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+)
+
+// Event Grid advanced filter operator types (ARM's AdvancedFilterOperatorType
+// enum). Only the operators that make sense against the mock's untyped JSON
+// "data" body are implemented; the rest fall through matchAdvancedFilter's
+// default case and never reject an event (matching real Event Grid's design
+// where filter evaluation only narrows delivery, never errors the publish).
+const (
+	opStringIn            = "StringIn"
+	opStringNotIn         = "StringNotIn"
+	opStringBeginsWith    = "StringBeginsWith"
+	opStringNotBeginsWith = "StringNotBeginsWith"
+	opStringEndsWith      = "StringEndsWith"
+	opStringNotEndsWith   = "StringNotEndsWith"
+	opStringContains      = "StringContains"
+	opStringNotContains   = "StringNotContains"
+	opNumberIn            = "NumberIn"
+	opNumberNotIn         = "NumberNotIn"
+	opNumberGreaterThan   = "NumberGreaterThan"
+	opNumberGreaterOrEq   = "NumberGreaterThanOrEquals"
+	opNumberLessThan      = "NumberLessThan"
+	opNumberLessOrEq      = "NumberLessThanOrEquals"
+	opBoolEquals          = "BoolEquals"
+	opIsNullOrUndefined   = "IsNullOrUndefined"
+	opIsNotNull           = "IsNotNull"
+)
+
+// advancedFilter is one entry of an ARM EventSubscriptionFilter.advancedFilters
+// array (AdvancedFilterOperatorType discriminated union, flattened: the
+// operators carry either a scalar Value or a Values array, never both).
+type advancedFilter struct {
+	OperatorType string          `json:"operatorType"`
+	Key          string          `json:"key"`
+	Value        json.RawMessage `json:"value,omitempty"`
+	Values       json.RawMessage `json:"values,omitempty"`
+}
+
+// subscriptionFilter is the parsed form of an ARM EventSubscriptionFilter
+// (properties.filter on an event subscription). It is the Azure-only
+// counterpart to the generic driver.Rule.EventPattern content filter AWS
+// EventBridge uses — Event Grid's filter shape (subject prefix/suffix,
+// included event types, advanced per-field operators) has no equivalent in
+// the portable eventbus driver, so it stays local to this provider package.
+type subscriptionFilter struct {
+	SubjectBeginsWith      string
+	SubjectEndsWith        string
+	IsSubjectCaseSensitive bool
+	IncludedEventTypes     []string
+	AdvancedFilters        []advancedFilter
+}
+
+// parseSubscriptionFilter extracts the "filter" object from a raw ARM
+// EventSubscription properties JSON blob. An absent or unparsable filter
+// yields the zero value, which matches every event (ARM's default when no
+// filter is configured).
+func parseSubscriptionFilter(rawProperties string) subscriptionFilter {
+	if rawProperties == "" {
+		return subscriptionFilter{}
+	}
+
+	var body struct {
+		Filter struct {
+			SubjectBeginsWith      string           `json:"subjectBeginsWith"`
+			SubjectEndsWith        string           `json:"subjectEndsWith"`
+			IsSubjectCaseSensitive bool             `json:"isSubjectCaseSensitive"`
+			IncludedEventTypes     []string         `json:"includedEventTypes"`
+			AdvancedFilters        []advancedFilter `json:"advancedFilters"`
+		} `json:"filter"`
+	}
+
+	if err := json.Unmarshal([]byte(rawProperties), &body); err != nil {
+		return subscriptionFilter{}
+	}
+
+	return subscriptionFilter{
+		SubjectBeginsWith:      body.Filter.SubjectBeginsWith,
+		SubjectEndsWith:        body.Filter.SubjectEndsWith,
+		IsSubjectCaseSensitive: body.Filter.IsSubjectCaseSensitive,
+		IncludedEventTypes:     body.Filter.IncludedEventTypes,
+		AdvancedFilters:        body.Filter.AdvancedFilters,
+	}
+}
+
+// matches reports whether event satisfies every configured filter criterion.
+// All criteria are ANDed together, matching real Event Grid subscription
+// filtering.
+func (f *subscriptionFilter) matches(event *driver.Event) bool {
+	if !f.subjectMatches(event.Subject) {
+		return false
+	}
+
+	if len(f.IncludedEventTypes) > 0 && !stringInSlice(event.DetailType, f.IncludedEventTypes) {
+		return false
+	}
+
+	data := parseEventData(event.Detail)
+	for i := range f.AdvancedFilters {
+		if !matchAdvancedFilter(&f.AdvancedFilters[i], event, data) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (f *subscriptionFilter) subjectMatches(subject string) bool {
+	s, begins, ends := subject, f.SubjectBeginsWith, f.SubjectEndsWith
+	if !f.IsSubjectCaseSensitive {
+		s, begins, ends = strings.ToLower(s), strings.ToLower(begins), strings.ToLower(ends)
+	}
+
+	if begins != "" && !strings.HasPrefix(s, begins) {
+		return false
+	}
+
+	if ends != "" && !strings.HasSuffix(s, ends) {
+		return false
+	}
+
+	return true
+}
+
+func stringInSlice(v string, list []string) bool {
+	for _, item := range list {
+		if item == v {
+			return true
+		}
+	}
+
+	return false
+}
+
+// parseEventData unmarshals the event's JSON detail body for advanced-filter
+// field lookups. An empty or unparsable body yields an empty object so a
+// filter referencing "data.*" simply finds nothing rather than panicking.
+func parseEventData(detail string) map[string]any {
+	if detail == "" {
+		return map[string]any{}
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(detail), &m); err != nil {
+		return map[string]any{}
+	}
+
+	return m
+}
+
+// filterField resolves an advanced filter's "key" against the event. "subject"
+// and "eventType" address the envelope directly; a "data."-prefixed (or bare)
+// key walks the parsed event data body by dotted path, matching how Event Grid
+// addresses fields inside the event payload.
+func filterField(key string, event *driver.Event, data map[string]any) (any, bool) {
+	switch key {
+	case "subject":
+		return event.Subject, true
+	case "eventType":
+		return event.DetailType, true
+	case "id":
+		return event.ID, true
+	}
+
+	path := strings.TrimPrefix(key, "data.")
+
+	var cur any = data
+	for _, seg := range strings.Split(path, ".") {
+		obj, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+
+		cur, ok = obj[seg]
+		if !ok {
+			return nil, false
+		}
+	}
+
+	return cur, true
+}
+
+// matchAdvancedFilter evaluates one advanced filter operator against the
+// resolved field value. Split by operator category (string/number/bool) to
+// keep each switch small; an unrecognized/unsupported operator never blocks
+// delivery on a filter this mock doesn't model.
+func matchAdvancedFilter(af *advancedFilter, event *driver.Event, data map[string]any) bool {
+	val, found := filterField(af.Key, event, data)
+
+	switch af.OperatorType {
+	case opIsNullOrUndefined:
+		return !found || val == nil
+	case opIsNotNull:
+		return found && val != nil
+	}
+
+	if !found {
+		return false
+	}
+
+	switch {
+	case strings.HasPrefix(af.OperatorType, "String"):
+		return matchStringFilter(af, val)
+	case strings.HasPrefix(af.OperatorType, "Number"):
+		return matchNumberFilter(af, val)
+	case af.OperatorType == opBoolEquals:
+		var want bool
+		_ = json.Unmarshal(af.Value, &want)
+
+		return asBool(val) == want
+	default:
+		return true
+	}
+}
+
+func matchStringFilter(af *advancedFilter, val any) bool {
+	s := asString(val)
+
+	switch af.OperatorType {
+	case opStringIn:
+		return stringInSlice(s, decodeStrings(af.Values))
+	case opStringNotIn:
+		return !stringInSlice(s, decodeStrings(af.Values))
+	case opStringBeginsWith:
+		return anyPrefixSuffix(s, decodeStrings(af.Values), strings.HasPrefix)
+	case opStringNotBeginsWith:
+		return !anyPrefixSuffix(s, decodeStrings(af.Values), strings.HasPrefix)
+	case opStringEndsWith:
+		return anyPrefixSuffix(s, decodeStrings(af.Values), strings.HasSuffix)
+	case opStringNotEndsWith:
+		return !anyPrefixSuffix(s, decodeStrings(af.Values), strings.HasSuffix)
+	case opStringContains:
+		return anyPrefixSuffix(s, decodeStrings(af.Values), strings.Contains)
+	case opStringNotContains:
+		return !anyPrefixSuffix(s, decodeStrings(af.Values), strings.Contains)
+	default:
+		return true
+	}
+}
+
+func matchNumberFilter(af *advancedFilter, val any) bool {
+	n := asNumber(val)
+
+	switch af.OperatorType {
+	case opNumberIn:
+		return numberInSlice(val, decodeNumbers(af.Values))
+	case opNumberNotIn:
+		return !numberInSlice(val, decodeNumbers(af.Values))
+	case opNumberGreaterThan:
+		return n > decodeNumber(af.Value)
+	case opNumberGreaterOrEq:
+		return n >= decodeNumber(af.Value)
+	case opNumberLessThan:
+		return n < decodeNumber(af.Value)
+	case opNumberLessOrEq:
+		return n <= decodeNumber(af.Value)
+	default:
+		return true
+	}
+}
+
+func anyPrefixSuffix(v string, prefixes []string, cmp func(s, prefix string) bool) bool {
+	for _, p := range prefixes {
+		if cmp(v, p) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func numberInSlice(v any, list []float64) bool {
+	n := asNumber(v)
+	for _, item := range list {
+		if item == n {
+			return true
+		}
+	}
+
+	return false
+}
+
+func asString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+
+	return ""
+}
+
+func asNumber(v any) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case string:
+		f, _ := strconv.ParseFloat(n, 64)
+		return f
+	default:
+		return 0
+	}
+}
+
+func asBool(v any) bool {
+	b, _ := v.(bool)
+	return b
+}
+
+func decodeStrings(raw json.RawMessage) []string {
+	var out []string
+	_ = json.Unmarshal(raw, &out)
+
+	return out
+}
+
+func decodeNumbers(raw json.RawMessage) []float64 {
+	var out []float64
+	_ = json.Unmarshal(raw, &out)
+
+	return out
+}
+
+func decodeNumber(raw json.RawMessage) float64 {
+	var f float64
+	_ = json.Unmarshal(raw, &f)
+
+	return f
+}

--- a/providers/azure/eventgrid/filter_test.go
+++ b/providers/azure/eventgrid/filter_test.go
@@ -104,6 +104,44 @@ func TestSubscriptionFilterMatches(t *testing.T) {
 			want:  false,
 		},
 		{
+			// Per Event Grid semantics, a missing key MATCHES the negative-
+			// membership operators (the field can't be in the excluded set).
+			name: "advancedFilter StringNotIn matches when key is absent",
+			rawProps: `{"filter":{"advancedFilters":[
+				{"operatorType":"StringNotIn","key":"data.missing","values":["a","b"]}]}}`,
+			event: driver.Event{Detail: `{"total":250}`},
+			want:  true,
+		},
+		{
+			name: "advancedFilter NumberNotIn matches when key is absent",
+			rawProps: `{"filter":{"advancedFilters":[
+				{"operatorType":"NumberNotIn","key":"data.missing","values":[1,2]}]}}`,
+			event: driver.Event{Detail: `{"total":250}`},
+			want:  true,
+		},
+		{
+			// The positive-membership counterparts stay NOT-matched on a missing key.
+			name: "advancedFilter StringIn rejects when key is absent",
+			rawProps: `{"filter":{"advancedFilters":[
+				{"operatorType":"StringIn","key":"data.missing","values":["a","b"]}]}}`,
+			event: driver.Event{Detail: `{"total":250}`},
+			want:  false,
+		},
+		{
+			name: "advancedFilter NumberIn rejects when key is absent",
+			rawProps: `{"filter":{"advancedFilters":[
+				{"operatorType":"NumberIn","key":"data.missing","values":[1,2]}]}}`,
+			event: driver.Event{Detail: `{"total":250}`},
+			want:  false,
+		},
+		{
+			name: "advancedFilter StringNotIn rejects when present value is excluded",
+			rawProps: `{"filter":{"advancedFilters":[
+				{"operatorType":"StringNotIn","key":"data.color","values":["red","blue"]}]}}`,
+			event: driver.Event{Detail: `{"color":"red"}`},
+			want:  false,
+		},
+		{
 			name: "advancedFilter on subject field",
 			rawProps: `{"filter":{"advancedFilters":[
 				{"operatorType":"StringBeginsWith","key":"subject","values":["orders/"]}]}}`,

--- a/providers/azure/eventgrid/filter_test.go
+++ b/providers/azure/eventgrid/filter_test.go
@@ -1,0 +1,156 @@
+package eventgrid
+
+import (
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubscriptionFilterMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawProps string
+		event    driver.Event
+		want     bool
+	}{
+		{
+			name:     "no filter matches everything",
+			rawProps: "",
+			event:    driver.Event{Subject: "anything"},
+			want:     true,
+		},
+		{
+			name:     "subjectBeginsWith matches",
+			rawProps: `{"filter":{"subjectBeginsWith":"orders/"}}`,
+			event:    driver.Event{Subject: "orders/123"},
+			want:     true,
+		},
+		{
+			name:     "subjectBeginsWith rejects other prefix",
+			rawProps: `{"filter":{"subjectBeginsWith":"orders/"}}`,
+			event:    driver.Event{Subject: "invoices/123"},
+			want:     false,
+		},
+		{
+			name:     "subjectEndsWith matches",
+			rawProps: `{"filter":{"subjectEndsWith":".jpg"}}`,
+			event:    driver.Event{Subject: "container/photo.jpg"},
+			want:     true,
+		},
+		{
+			name:     "subjectEndsWith rejects other suffix",
+			rawProps: `{"filter":{"subjectEndsWith":".jpg"}}`,
+			event:    driver.Event{Subject: "container/photo.png"},
+			want:     false,
+		},
+		{
+			name:     "case sensitivity off (default) ignores case",
+			rawProps: `{"filter":{"subjectBeginsWith":"ORDERS/"}}`,
+			event:    driver.Event{Subject: "orders/123"},
+			want:     true,
+		},
+		{
+			name:     "case sensitivity on enforces case",
+			rawProps: `{"filter":{"subjectBeginsWith":"ORDERS/","isSubjectCaseSensitive":true}}`,
+			event:    driver.Event{Subject: "orders/123"},
+			want:     false,
+		},
+		{
+			name:     "includedEventTypes matches",
+			rawProps: `{"filter":{"includedEventTypes":["Order.Created","Order.Cancelled"]}}`,
+			event:    driver.Event{DetailType: "Order.Created"},
+			want:     true,
+		},
+		{
+			name:     "includedEventTypes rejects unlisted type",
+			rawProps: `{"filter":{"includedEventTypes":["Order.Cancelled"]}}`,
+			event:    driver.Event{DetailType: "Order.Created"},
+			want:     false,
+		},
+		{
+			name: "advancedFilter StringIn on data field matches",
+			rawProps: `{"filter":{"advancedFilters":[
+				{"operatorType":"StringIn","key":"data.color","values":["red","blue"]}]}}`,
+			event: driver.Event{Detail: `{"color":"blue"}`},
+			want:  true,
+		},
+		{
+			name: "advancedFilter StringIn on data field rejects",
+			rawProps: `{"filter":{"advancedFilters":[
+				{"operatorType":"StringIn","key":"data.color","values":["red","blue"]}]}}`,
+			event: driver.Event{Detail: `{"color":"green"}`},
+			want:  false,
+		},
+		{
+			name: "advancedFilter NumberGreaterThan matches",
+			rawProps: `{"filter":{"advancedFilters":[
+				{"operatorType":"NumberGreaterThan","key":"data.total","value":100}]}}`,
+			event: driver.Event{Detail: `{"total":250}`},
+			want:  true,
+		},
+		{
+			name: "advancedFilter NumberGreaterThan rejects",
+			rawProps: `{"filter":{"advancedFilters":[
+				{"operatorType":"NumberGreaterThan","key":"data.total","value":500}]}}`,
+			event: driver.Event{Detail: `{"total":250}`},
+			want:  false,
+		},
+		{
+			name: "advancedFilter IsNotNull rejects missing field",
+			rawProps: `{"filter":{"advancedFilters":[
+				{"operatorType":"IsNotNull","key":"data.missing"}]}}`,
+			event: driver.Event{Detail: `{"total":250}`},
+			want:  false,
+		},
+		{
+			name: "advancedFilter on subject field",
+			rawProps: `{"filter":{"advancedFilters":[
+				{"operatorType":"StringBeginsWith","key":"subject","values":["orders/"]}]}}`,
+			event: driver.Event{Subject: "orders/1"},
+			want:  true,
+		},
+		{
+			name: "multiple criteria are ANDed",
+			rawProps: `{"filter":{"subjectBeginsWith":"orders/","includedEventTypes":["Order.Created"],
+				"advancedFilters":[{"operatorType":"NumberGreaterThan","key":"data.total","value":100}]}}`,
+			event: driver.Event{Subject: "orders/1", DetailType: "Order.Created", Detail: `{"total":250}`},
+			want:  true,
+		},
+		{
+			name: "multiple criteria: one mismatch fails the AND",
+			rawProps: `{"filter":{"subjectBeginsWith":"orders/","includedEventTypes":["Order.Created"],
+				"advancedFilters":[{"operatorType":"NumberGreaterThan","key":"data.total","value":1000}]}}`,
+			event: driver.Event{Subject: "orders/1", DetailType: "Order.Created", Detail: `{"total":250}`},
+			want:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := parseSubscriptionFilter(tc.rawProps)
+			assert.Equal(t, tc.want, f.matches(&tc.event))
+		})
+	}
+}
+
+func TestParseSubscriptionDestination(t *testing.T) {
+	d := parseSubscriptionDestination(
+		`{"destination":{"endpointType":"WebHook","properties":{"endpointUrl":"https://example.com/hook"}}}`)
+
+	assert.Equal(t, endpointTypeWebHook, d.EndpointType)
+	assert.Equal(t, "https://example.com/hook", d.EndpointURL)
+}
+
+func TestParseSubscriptionDestinationServiceBus(t *testing.T) {
+	d := parseSubscriptionDestination(`{"destination":{"endpointType":"ServiceBusQueue","properties":{
+		"resourceId":"/subscriptions/s/resourceGroups/rg/providers/Microsoft.ServiceBus/namespaces/ns/queues/q"}}}`)
+
+	assert.Equal(t, "ServiceBusQueue", d.EndpointType)
+	assert.Equal(t, "/subscriptions/s/resourceGroups/rg/providers/Microsoft.ServiceBus/namespaces/ns/queues/q", d.ResourceID)
+}
+
+func TestParseSubscriptionDestinationEmpty(t *testing.T) {
+	d := parseSubscriptionDestination("")
+	assert.Equal(t, subscriptionDestination{}, d)
+}

--- a/server/azure/eventgrid/delivery_sdk_test.go
+++ b/server/azure/eventgrid/delivery_sdk_test.go
@@ -1,0 +1,191 @@
+package eventgrid_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+)
+
+// liveWebhookReceiver is a real HTTP server standing in for a subscriber's
+// endpoint, recording every event batch Event Grid delivers to it.
+type liveWebhookReceiver struct {
+	*httptest.Server
+
+	mu    sync.Mutex
+	batch [][]map[string]any
+}
+
+func newLiveWebhookReceiver(t *testing.T) *liveWebhookReceiver {
+	t.Helper()
+
+	wh := &liveWebhookReceiver{}
+	wh.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var events []map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&events); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		wh.mu.Lock()
+		wh.batch = append(wh.batch, events)
+		wh.mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(wh.Close)
+
+	return wh
+}
+
+func (wh *liveWebhookReceiver) all() []map[string]any {
+	wh.mu.Lock()
+	defer wh.mu.Unlock()
+
+	var out []map[string]any
+	for _, b := range wh.batch {
+		out = append(out, b...)
+	}
+
+	return out
+}
+
+// TestSDKPublishDeliversToWebHookSubscriber is the end-to-end BLOCKER
+// regression: a real armeventgrid client creates a topic and a WebHook event
+// subscription against the live TLS wire server, publishes to the topic's
+// data-plane endpoint with the real SDK's publish client, and a genuine HTTP
+// server standing in for the subscriber must receive the event.
+func TestSDKPublishDeliversToWebHookSubscriber(t *testing.T) {
+	cf, ts := newEGFactory(t)
+	ctx := context.Background()
+
+	topics := cf.NewTopicsClient()
+	mkTopicLoc(t, topics, "orders", "eastus")
+
+	receiver := newLiveWebhookReceiver(t)
+
+	subs := cf.NewTopicEventSubscriptionsClient()
+	poller, err := subs.BeginCreateOrUpdate(ctx, testRG, "orders", "sub1", armeventgrid.EventSubscription{
+		Properties: &armeventgrid.EventSubscriptionProperties{
+			Destination: &armeventgrid.WebHookEventSubscriptionDestination{
+				EndpointType: to.Ptr(armeventgrid.EndpointTypeWebHook),
+				Properties: &armeventgrid.WebHookEventSubscriptionDestinationProperties{
+					EndpointURL: to.Ptr(receiver.URL),
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("subscription BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("subscription PollUntilDone: %v", err)
+	}
+
+	// Publish over the data-plane endpoint, exactly like a real publisher —
+	// no cloudemu-internal shortcut.
+	body := `[{"id":"e1","subject":"orders/1","eventType":"Order.Created",` +
+		`"eventTime":"2024-01-02T03:04:05Z","data":{"total":42},"dataVersion":"1.0"}]`
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/api/events", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("new publish request: %v", err)
+	}
+
+	req.Host = "orders.eastus-1.eventgrid.azure.net"
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // test cleanup
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("publish status = %d, want 200", resp.StatusCode)
+	}
+
+	got := receiver.all()
+	if len(got) != 1 {
+		t.Fatalf("webhook received %d events, want 1: %+v", len(got), got)
+	}
+
+	if got[0]["eventType"] != "Order.Created" {
+		t.Fatalf("eventType = %v, want Order.Created", got[0]["eventType"])
+	}
+
+	if got[0]["subject"] != "orders/1" {
+		t.Fatalf("subject = %v, want orders/1", got[0]["subject"])
+	}
+}
+
+// TestSDKPublishFilteredSubjectNotDelivered locks the MEDIUM filter-
+// application fix end-to-end: a subscription with subjectBeginsWith must not
+// receive an event whose subject doesn't match.
+func TestSDKPublishFilteredSubjectNotDelivered(t *testing.T) {
+	cf, ts := newEGFactory(t)
+	ctx := context.Background()
+
+	topics := cf.NewTopicsClient()
+	mkTopicLoc(t, topics, "orders", "eastus")
+
+	receiver := newLiveWebhookReceiver(t)
+
+	subs := cf.NewTopicEventSubscriptionsClient()
+	poller, err := subs.BeginCreateOrUpdate(ctx, testRG, "orders", "sub1", armeventgrid.EventSubscription{
+		Properties: &armeventgrid.EventSubscriptionProperties{
+			Destination: &armeventgrid.WebHookEventSubscriptionDestination{
+				EndpointType: to.Ptr(armeventgrid.EndpointTypeWebHook),
+				Properties: &armeventgrid.WebHookEventSubscriptionDestinationProperties{
+					EndpointURL: to.Ptr(receiver.URL),
+				},
+			},
+			Filter: &armeventgrid.EventSubscriptionFilter{
+				SubjectBeginsWith: to.Ptr("orders/"),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("subscription BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("subscription PollUntilDone: %v", err)
+	}
+
+	body := `[{"id":"e1","subject":"invoices/1","eventType":"Invoice.Created",` +
+		`"eventTime":"2024-01-02T03:04:05Z","data":{},"dataVersion":"1.0"}]`
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/api/events", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("new publish request: %v", err)
+	}
+
+	req.Host = "orders.eastus-1.eventgrid.azure.net"
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // test cleanup
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("publish status = %d, want 200", resp.StatusCode)
+	}
+
+	// Give any (incorrect) delivery a moment to land before asserting none did.
+	time.Sleep(50 * time.Millisecond)
+
+	if got := receiver.all(); len(got) != 0 {
+		t.Fatalf("webhook received %d events, want 0 (subject doesn't match filter): %+v", len(got), got)
+	}
+}

--- a/server/azure/eventgrid/domain_topics.go
+++ b/server/azure/eventgrid/domain_topics.go
@@ -1,0 +1,162 @@
+package eventgrid
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+const (
+	domainTopicResourceType      = "Microsoft.EventGrid/domains/topics"
+	domainTopicProvisioningState = "Succeeded"
+)
+
+// domainTopicJSON is the ARM DomainTopic resource shape
+// (armeventgrid.DomainTopic): id/name/type plus a provisioningState-only
+// properties object — a domain topic carries no other configurable state.
+type domainTopicJSON struct {
+	ID         string                 `json:"id,omitempty"`
+	Name       string                 `json:"name"`
+	Type       string                 `json:"type"`
+	Properties *domainTopicProperties `json:"properties,omitempty"`
+}
+
+type domainTopicProperties struct {
+	ProvisioningState string `json:"provisioningState,omitempty"`
+}
+
+type domainTopicListResult struct {
+	Value []domainTopicJSON `json:"value"`
+}
+
+func domainTopicID(rp *azurearm.ResourcePath) string {
+	return domainID(rp) + "/" + typeTopics + "/" + rp.SubResourceName
+}
+
+func domainTopicJSONFor(rp *azurearm.ResourcePath) domainTopicJSON {
+	return domainTopicJSON{
+		ID:         domainTopicID(rp),
+		Name:       rp.SubResourceName,
+		Type:       domainTopicResourceType,
+		Properties: &domainTopicProperties{ProvisioningState: domainTopicProvisioningState},
+	}
+}
+
+// serveDomainTopics routes .../domains/{domain}/topics[/{topicName}].
+func (h *Handler) serveDomainTopics(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if rp.SubResourceName == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w)
+			return
+		}
+
+		h.listDomainTopics(w, rp)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdateDomainTopic(w, rp)
+	case http.MethodGet:
+		h.getDomainTopic(w, rp)
+	case http.MethodDelete:
+		h.deleteDomainTopic(w, rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+// createOrUpdateDomainTopic requires the parent domain to already exist —
+// real Event Grid answers ParentResourceNotFound (404) for a domain topic
+// created under an absent domain.
+func (h *Handler) createOrUpdateDomainTopic(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.Lock()
+
+	rec := h.domains[key]
+	if rec == nil {
+		h.mu.Unlock()
+		azurearm.WriteError(w, http.StatusNotFound, "ParentResourceNotFound",
+			"domain "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	rec.topics[rp.SubResourceName] = struct{}{}
+	h.mu.Unlock()
+
+	// 201 with a terminal provisioningState completes the SDK's LRO poller on
+	// the first response.
+	azurearm.WriteJSON(w, http.StatusCreated, domainTopicJSONFor(rp))
+}
+
+func (h *Handler) getDomainTopic(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	rec := h.domains[key]
+	if rec == nil {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "domain "+rp.ResourceName+" not found")
+		return
+	}
+
+	if _, found := rec.topics[rp.SubResourceName]; !found {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "domain topic not found")
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, domainTopicJSONFor(rp))
+}
+
+// deleteDomainTopic is idempotent, matching real ARM delete semantics: a
+// delete of an already-missing domain topic (or one under a missing domain)
+// still completes 200.
+func (h *Handler) deleteDomainTopic(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.Lock()
+
+	if rec := h.domains[key]; rec != nil {
+		delete(rec.topics, rp.SubResourceName)
+	}
+
+	h.mu.Unlock()
+
+	// The SDK's BeginDelete LRO completes on a 200 first response.
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) listDomainTopics(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	rec := h.domains[key]
+	if rec == nil {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "domain "+rp.ResourceName+" not found")
+		return
+	}
+
+	names := make([]string, 0, len(rec.topics))
+	for name := range rec.topics {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	out := make([]domainTopicJSON, 0, len(names))
+
+	for _, name := range names {
+		scoped := *rp
+		scoped.SubResourceName = name
+		out = append(out, domainTopicJSONFor(&scoped))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, domainTopicListResult{Value: out})
+}

--- a/server/azure/eventgrid/domain_topics_sdk_test.go
+++ b/server/azure/eventgrid/domain_topics_sdk_test.go
@@ -1,0 +1,105 @@
+package eventgrid_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+)
+
+// TestSDKDomainTopicsLifecycle is the HIGH regression: DomainTopicsClient
+// CRUD against a real domain must work end to end (create, get, list,
+// delete) instead of 400ing.
+func TestSDKDomainTopicsLifecycle(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	ctx := context.Background()
+
+	domains := cf.NewDomainsClient()
+	domainPoller, err := domains.BeginCreateOrUpdate(ctx, testRG, "shop-domain", armeventgrid.Domain{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("Domains.BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := domainPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Domains PollUntilDone: %v", err)
+	}
+
+	domainTopics := cf.NewDomainTopicsClient()
+
+	topicPoller, err := domainTopics.BeginCreateOrUpdate(ctx, testRG, "shop-domain", "orders", nil)
+	if err != nil {
+		t.Fatalf("DomainTopics.BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := topicPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("DomainTopics PollUntilDone: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "orders" {
+		t.Fatalf("created name = %v, want orders", created.Name)
+	}
+
+	got, err := domainTopics.Get(ctx, testRG, "shop-domain", "orders", nil)
+	if err != nil {
+		t.Fatalf("DomainTopics.Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.ProvisioningState == nil ||
+		*got.Properties.ProvisioningState != armeventgrid.DomainTopicProvisioningStateSucceeded {
+		t.Fatalf("provisioningState = %v, want Succeeded", got.Properties)
+	}
+
+	var names []string
+
+	pager := domainTopics.NewListByDomainPager(testRG, "shop-domain", nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("ListByDomain: %v", perr)
+		}
+
+		for _, dt := range page.Value {
+			names = append(names, *dt.Name)
+		}
+	}
+
+	if len(names) != 1 || names[0] != "orders" {
+		t.Fatalf("list = %v, want [orders]", names)
+	}
+
+	delPoller, err := domainTopics.BeginDelete(ctx, testRG, "shop-domain", "orders", nil)
+	if err != nil {
+		t.Fatalf("DomainTopics.BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("DomainTopics delete PollUntilDone: %v", err)
+	}
+
+	if _, err := domainTopics.Get(ctx, testRG, "shop-domain", "orders", nil); err == nil {
+		t.Fatal("Get after delete: expected error, got nil")
+	}
+}
+
+// TestSDKDomainTopicOnMissingDomain locks the ParentResourceNotFound
+// semantics: a domain topic created under a nonexistent domain must fail,
+// not silently succeed.
+func TestSDKDomainTopicOnMissingDomain(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	ctx := context.Background()
+
+	domainTopics := cf.NewDomainTopicsClient()
+
+	_, err := domainTopics.BeginCreateOrUpdate(ctx, testRG, "no-such-domain", "orders", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("BeginCreateOrUpdate on missing domain: got %v, want 404", err)
+	}
+}

--- a/server/azure/eventgrid/domains.go
+++ b/server/azure/eventgrid/domains.go
@@ -31,6 +31,12 @@ type domainRecord struct {
 	tags     map[string]string
 	key1     string
 	key2     string
+	// topics holds the DomainTopics sub-resources created under this domain.
+	// A domain topic carries no state of its own beyond existing (real Event
+	// Grid domain topics are typically auto-created on first publish and
+	// exist only to route to per-topic subscriptions), so presence in this
+	// set is all CRUD needs to track.
+	topics map[string]struct{}
 }
 
 type domainJSON struct {
@@ -115,6 +121,11 @@ func (h *Handler) serveDomains(w http.ResponseWriter, r *http.Request, rp *azure
 		h.listDomainKeys(w, r, rp)
 	case subActionRegenerateKey:
 		h.regenerateDomainKey(w, r, rp)
+	case typeTopics:
+		// domains/{domain}/topics[/{topicName}] — DomainTopics, a distinct
+		// sub-resource from the top-level Microsoft.EventGrid/topics
+		// collection sharing the same "topics" path segment.
+		h.serveDomainTopics(w, r, rp)
 	default:
 		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "unsupported domain sub-resource")
 	}
@@ -151,11 +162,12 @@ func (h *Handler) createOrUpdateDomain(w http.ResponseWriter, r *http.Request, r
 	rec := h.domains[key]
 	if rec == nil {
 		rec = &domainRecord{
-			name: rp.ResourceName,
-			sub:  rp.Subscription,
-			rg:   rp.ResourceGroup,
-			key1: domainKey(rp.ResourceName, "key1", 0),
-			key2: domainKey(rp.ResourceName, "key2", 0),
+			name:   rp.ResourceName,
+			sub:    rp.Subscription,
+			rg:     rp.ResourceGroup,
+			key1:   domainKey(rp.ResourceName, "key1", 0),
+			key2:   domainKey(rp.ResourceName, "key2", 0),
+			topics: make(map[string]struct{}),
 		}
 		h.domains[key] = rec
 	}

--- a/server/azure/eventgrid/handler.go
+++ b/server/azure/eventgrid/handler.go
@@ -20,6 +20,8 @@
 //	POST           .../topics/{t}/listKeys                  — Topics.ListSharedAccessKeys
 //	PUT/GET/DELETE .../topics/{t}/eventSubscriptions/{s}    — TopicEventSubscriptions CRUD
 //	GET            .../topics/{t}/eventSubscriptions        — TopicEventSubscriptions.List
+//	PUT/GET/DELETE .../domains/{d}/topics/{t}               — DomainTopics CRUD
+//	GET            .../domains/{d}/topics                   — DomainTopics.ListByDomain
 package eventgrid
 
 import (

--- a/server/azure/eventgrid/input_schema_sdk_test.go
+++ b/server/azure/eventgrid/input_schema_sdk_test.go
@@ -1,0 +1,73 @@
+package eventgrid_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+)
+
+// TestSDKTopicInputSchemaRoundTrips locks the HIGH fix: a topic created with
+// a non-default InputSchema must echo that schema back, not the hardcoded
+// EventGridSchema default.
+func TestSDKTopicInputSchemaRoundTrips(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	topics := cf.NewTopicsClient()
+	ctx := context.Background()
+
+	poller, err := topics.BeginCreateOrUpdate(ctx, testRG, "custom-schema-topic", armeventgrid.Topic{
+		Location: to.Ptr("eastus"),
+		Properties: &armeventgrid.TopicProperties{
+			InputSchema: to.Ptr(armeventgrid.InputSchemaCloudEventSchemaV10),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	if created.Properties == nil || created.Properties.InputSchema == nil ||
+		*created.Properties.InputSchema != armeventgrid.InputSchemaCloudEventSchemaV10 {
+		t.Fatalf("create response inputSchema = %v, want CloudEventSchemaV1_0", created.Properties)
+	}
+
+	got, err := topics.Get(ctx, testRG, "custom-schema-topic", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.InputSchema == nil ||
+		*got.Properties.InputSchema != armeventgrid.InputSchemaCloudEventSchemaV10 {
+		t.Fatalf("Get inputSchema = %v, want CloudEventSchemaV1_0", got.Properties)
+	}
+}
+
+// TestSDKTopicInputSchemaDefaultsToEventGridSchema covers the unset case: a
+// topic created without an explicit InputSchema still gets the real default.
+func TestSDKTopicInputSchemaDefaultsToEventGridSchema(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	topics := cf.NewTopicsClient()
+	ctx := context.Background()
+
+	poller, err := topics.BeginCreateOrUpdate(ctx, testRG, "default-schema-topic", armeventgrid.Topic{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	if created.Properties == nil || created.Properties.InputSchema == nil ||
+		*created.Properties.InputSchema != armeventgrid.InputSchemaEventGridSchema {
+		t.Fatalf("inputSchema = %v, want EventGridSchema default", created.Properties)
+	}
+}

--- a/server/azure/eventgrid/operations.go
+++ b/server/azure/eventgrid/operations.go
@@ -19,10 +19,11 @@ func (h *Handler) createOrUpdateTopic(w http.ResponseWriter, r *http.Request, rp
 	}
 
 	cfg := ebdriver.EventBusConfig{
-		Name:   rp.ResourceName,
-		Tags:   tagsFromPtr(body.Tags),
-		Scope:  scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
-		Region: body.Location,
+		Name:        rp.ResourceName,
+		Tags:        tagsFromPtr(body.Tags),
+		Scope:       scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
+		Region:      body.Location,
+		InputSchema: inputSchemaFromBody(&body),
 	}
 
 	if _, err := h.bus.GetEventBus(r.Context(), rp.ResourceName); err == nil {
@@ -46,6 +47,19 @@ func (h *Handler) createOrUpdateTopic(w http.ResponseWriter, r *http.Request, rp
 	// 201 Created with a terminal provisioningState completes the SDK's LRO
 	// poller on the first response.
 	azurearm.WriteJSON(w, http.StatusCreated, toTopicJSON(rp, info))
+}
+
+// inputSchemaFromBody reads the caller's requested InputSchema off a Topics
+// CreateOrUpdate request body. CreateEventBus falls back to the real default
+// (EventGridSchema) when this is empty; UpdateEventBus never sets it, so an
+// update request's value is intentionally ignored — Event Grid does not allow
+// changing a topic's input schema after creation.
+func inputSchemaFromBody(body *topicJSON) string {
+	if body.Properties == nil {
+		return ""
+	}
+
+	return body.Properties.InputSchema
 }
 
 func (h *Handler) getTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {

--- a/server/azure/eventgrid/publish.go
+++ b/server/azure/eventgrid/publish.go
@@ -91,6 +91,7 @@ func (h *PublishHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Detail:     string(events[i].Data),
 			Time:       parseEventTime(events[i].EventTime),
 			EventBus:   topic,
+			Subject:    events[i].Subject,
 		})
 	}
 

--- a/server/azure/eventgrid/publish.go
+++ b/server/azure/eventgrid/publish.go
@@ -1,11 +1,14 @@
 package eventgrid
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 )
@@ -72,7 +75,9 @@ func (h *PublishHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := h.bus.GetEventBus(r.Context(), topic); err != nil {
+	ctx := withDeliveryDepth(r)
+
+	if _, err := h.bus.GetEventBus(ctx, topic); err != nil {
 		azurearm.WriteError(w, http.StatusNotFound, "TopicNotFound", "topic "+topic+" not found")
 		return
 	}
@@ -95,12 +100,26 @@ func (h *PublishHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	if _, err := h.bus.PutEvents(r.Context(), drvEvents); err != nil {
+	if _, err := h.bus.PutEvents(ctx, drvEvents); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+// withDeliveryDepth seeds the request context with the re-entrant delivery
+// depth carried on recursionguard.DepthHeader. A WebHook subscription whose
+// endpointUrl points back here re-enters this handler over HTTP, where the
+// in-process depth can't ride the goroutine; reading it off the header keeps a
+// self-referential publish->deliver->publish chain counting toward the cap.
+func withDeliveryDepth(r *http.Request) context.Context {
+	ctx := r.Context()
+	if d, err := strconv.Atoi(r.Header.Get(recursionguard.DepthHeader)); err == nil && d > 0 {
+		ctx = recursionguard.WithDepth(ctx, d)
+	}
+
+	return ctx
 }
 
 func parseEventTime(s string) time.Time {

--- a/server/azure/eventgrid/types.go
+++ b/server/azure/eventgrid/types.go
@@ -75,6 +75,11 @@ func toTopicJSON(rp *azurearm.ResourcePath, info *ebdriver.EventBusInfo) topicJS
 	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeTopics, info.Name)
 	loc := topicLocation(info)
 
+	inputSchema := info.InputSchema
+	if inputSchema == "" {
+		inputSchema = defaultInputSchema
+	}
+
 	return topicJSON{
 		ID:       id,
 		Name:     info.Name,
@@ -84,7 +89,7 @@ func toTopicJSON(rp *azurearm.ResourcePath, info *ebdriver.EventBusInfo) topicJS
 		Properties: &topicProperties{
 			ProvisioningState:   provisioningSucceeded,
 			Endpoint:            topicEndpoint(info.Name, loc),
-			InputSchema:         defaultInputSchema,
+			InputSchema:         inputSchema,
 			PublicNetworkAccess: defaultPublicNetworkAccess,
 			MetricResourceID:    id,
 		},

--- a/services/eventbus/driver/driver.go
+++ b/services/eventbus/driver/driver.go
@@ -19,6 +19,10 @@ type EventBusInfo struct {
 	// Region is the geographic location the resource was created in (Azure
 	// location, GCP region). Empty for AWS and unscoped portable callers.
 	Region string
+	// InputSchema records the event schema a topic accepts (Azure Event
+	// Grid: "EventGridSchema", "CustomEventSchema", "CloudEventSchemaV1_0").
+	// Empty for AWS and GCP.
+	InputSchema string
 }
 
 // EventBusConfig configures a new event bus.
@@ -32,6 +36,10 @@ type EventBusConfig struct {
 	// Region is the geographic location the resource is created in (Azure
 	// location, GCP region). Empty for AWS and unscoped portable callers.
 	Region string
+	// InputSchema records the event schema a topic accepts (Azure Event
+	// Grid: "EventGridSchema", "CustomEventSchema", "CloudEventSchemaV1_0").
+	// Empty for AWS and GCP, and for an Azure caller accepting the default.
+	InputSchema string
 }
 
 // Rule defines an event routing rule with filtering.
@@ -81,6 +89,10 @@ type Event struct {
 	Time       time.Time
 	EventBus   string
 	Resources  []string
+	// Subject is the event subject path (Azure Event Grid's resource-path
+	// concept, e.g. "/blobServices/default/containers/x"). Empty for AWS
+	// and GCP.
+	Subject string
 }
 
 // PublishResult is the result of publishing events.


### PR DESCRIPTION
## Summary

Fixes several Azure Event Grid deep-sweep findings, reproduced against real `azure-sdk-for-go` `armeventgrid` clients and a live webhook receiver:

- **BLOCKER**: `PutEvents` never delivered to any subscriber destination. `Mock` now POSTs matched events to a subscription's WebHook destination (parsed from the ARM `properties` blob), mirroring the AWS EventBridge `deliverToTargets` cross-service pattern already in this codebase. ServiceBus/EventHub/Functions destinations still parse and round-trip on the subscription resource, but are not delivered to yet — EventHub has no peer mock in this codebase, and wiring ServiceBus/Functions delivery is left as a follow-up.
- **HIGH**: Topic `InputSchema` (`CloudEventSchemaV1_0` / `CustomEventSchema`) was accepted but discarded — `createOrUpdateTopic` and `toTopicJSON` hardcoded the `EventGridSchema` default. Now persisted on the driver's `EventBusInfo`/`EventBusConfig` and echoed back; unset requests still default to `EventGridSchema`, and an update request's schema is intentionally ignored (Event Grid doesn't allow changing it after creation).
- **HIGH**: Event Grid domains had no `domains/{domain}/topics` sub-resource. Added `DomainTopics` CRUD (create/get/list/delete), 404ing `ParentResourceNotFound` when the parent domain doesn't exist, matching the existing `domains`/`systemTopics` wire-handler-owned-state pattern in this package.
- **MEDIUM**: ARM subscription filters (`subjectBeginsWith`/`subjectEndsWith`/`includedEventTypes`/`advancedFilters`) were stored only as a raw JSON blob and never applied. They're now parsed into a structured `subscriptionFilter` and applied on delivery, so only matching events reach a subscriber.
- **MEDIUM**: `MatchedRules` leaked matches across unrelated topics — it iterated every topic's rules instead of scoping to the event's own topic. Both `MatchedRules` and the new internal `matchedRuleData` now scope to `event.EventBus`.

## Deferred (not implemented, per findings note)

- Generic scope-bound `eventSubscriptions` on a resourceGroup/subscription scope (separate routing surface) — explicitly out of scope for this PR.
- ServiceBus/EventHub/Functions destination delivery — destinations parse and round-trip, but only WebHook is actually delivered to in this PR.

## What changed

- `services/eventbus/driver/driver.go`: added `Subject` to `Event` and `InputSchema` to `EventBusConfig`/`EventBusInfo` (Azure-only fields, following the existing `Region` precedent; empty/no-op for AWS and GCP).
- `providers/azure/eventgrid/filter.go` (new): parses and applies ARM `EventSubscriptionFilter` (subject prefix/suffix, included event types, advanced filters — String*/Number*/Bool/IsNull operators).
- `providers/azure/eventgrid/delivery.go` (new): parses ARM `EventSubscriptionDestination` and delivers to WebHook endpoints over real HTTP.
- `providers/azure/eventgrid/eventgrid.go`: wires filter/destination parsing into `PutRule`, delivery + isolation fix into `PutEvents`/`MatchedRules`, and `InputSchema` into `CreateEventBus`.
- `server/azure/eventgrid/domain_topics.go` (new): `DomainTopics` CRUD wire handlers.
- `server/azure/eventgrid/{operations,types}.go`: wire the topic `InputSchema` request/response field through.
- `server/azure/eventgrid/publish.go`: carry the publisher's `subject` field through to the driver event (previously dropped).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./providers/azure/eventgrid/... ./server/azure/eventgrid/... ./services/... .` — all green
- [x] `go test -race ./providers/azure/eventgrid/...` and `./server/azure/eventgrid/...` — race-clean
- [x] One full `go test ./...` — all 291 packages pass
- [x] `go test ./compat/...` — green
- [x] `golangci-lint` on changed packages — zero new issues (diffed against the pre-change baseline; all remaining findings are pre-existing)
- [x] `gofmt -l` — clean
- [x] New regression tests use the real `armeventgrid` SDK against a live TLS wire server, plus a live `httptest` webhook receiver for the delivery path (`TestSDKPublishDeliversToWebHookSubscriber`, `TestSDKPublishFilteredSubjectNotDelivered`, `TestSDKDomainTopicsLifecycle`, `TestSDKTopicInputSchemaRoundTrips`)