### PR TITLE
fix(azure-tablequeue): Queue Storage message TTL, Table $select projection, TableNotFound vs EntityNotFound

### DIFF
--- a/providers/azure/servicebus/queue_storage.go
+++ b/providers/azure/servicebus/queue_storage.go
@@ -12,9 +12,6 @@ import (
 // Compile-time check that Mock implements the Azure-specific queue surface.
 var _ driver.AzureQueueStorage = (*Mock)(nil)
 
-// defaultMessageRetention is the Azure Queue Storage default message TTL.
-const defaultMessageRetention = 7 * 24 * time.Hour
-
 // maxQueueStorageMessages is the maximum number of messages Azure Queue Storage
 // returns from a single Get Messages or Peek Messages call. This differs from
 // Service Bus's receive cap, so Queue Storage clamps against its own limit.
@@ -70,13 +67,43 @@ func (m *Mock) DequeueMessages(
 	return results, nil
 }
 
-// messageExpiry returns when a message expires given the queue's retention.
-func (qd *queueData) messageExpiry(msg *sbMessage) time.Time {
-	if qd.messageRetention > 0 {
-		return msg.SentAt.Add(time.Duration(qd.messageRetention) * time.Second)
+// computeExpiry resolves a message's absolute expiration time from the
+// caller-supplied Azure Queue Storage TTL (Put Message's messagettl,
+// SendMessageInput.MessageTTLSeconds). A nil pointer means the caller didn't
+// specify a TTL (Service Bus queues never set this field, so they keep their
+// existing no-expiry behavior); a negative value is Azure's "never expire"
+// sentinel. Both map to the zero time.Time, the internal "does not expire"
+// marker isMessageExpired checks for.
+func computeExpiry(now time.Time, ttlSeconds *int) time.Time {
+	if ttlSeconds == nil || *ttlSeconds < 0 {
+		return time.Time{}
 	}
 
-	return msg.SentAt.Add(defaultMessageRetention)
+	return now.Add(time.Duration(*ttlSeconds) * time.Second)
+}
+
+// isMessageExpired reports whether msg's TTL has elapsed. A zero ExpiresAt
+// means the message never expires.
+func isMessageExpired(msg *sbMessage, now time.Time) bool {
+	return !msg.ExpiresAt.IsZero() && !msg.ExpiresAt.After(now)
+}
+
+// removeExpiredMessages drops messages whose per-message TTL has elapsed,
+// mirroring the lazy TTL reaping the Cosmos DB mock performs on read
+// (isItemExpired): an expired message is simply never surfaced to Peek
+// Messages rather than actively swept by a background job.
+func removeExpiredMessages(messages []*sbMessage, now time.Time) []*sbMessage {
+	kept := messages[:0]
+
+	for _, msg := range messages {
+		if isMessageExpired(msg, now) {
+			continue
+		}
+
+		kept = append(kept, msg)
+	}
+
+	return kept
 }
 
 // PeekMessages returns up to maxMessages visible messages without changing
@@ -92,6 +119,8 @@ func (m *Mock) PeekMessages(_ context.Context, queueURL string, maxMessages int)
 
 	limit := clampQueueStorageMessages(maxMessages)
 	now := m.opts.Clock.Now()
+
+	qd.messages = removeExpiredMessages(qd.messages, now)
 
 	out := make([]driver.AzureQueueMessage, 0, limit)
 
@@ -109,7 +138,7 @@ func (m *Mock) PeekMessages(_ context.Context, queueURL string, maxMessages int)
 			Body:         msg.Body,
 			ReceiveCount: msg.ReceiveCount,
 			InsertedAt:   msg.SentAt,
-			ExpiresAt:    qd.messageExpiry(msg),
+			ExpiresAt:    msg.ExpiresAt,
 		})
 	}
 

--- a/providers/azure/servicebus/queue_storage_ttl_test.go
+++ b/providers/azure/servicebus/queue_storage_ttl_test.go
@@ -1,0 +1,75 @@
+package servicebus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ttlPtr returns a pointer to seconds, for SendMessageInput.MessageTTLSeconds.
+func ttlPtr(seconds int) *int {
+	return &seconds
+}
+
+// TestMessageTTLExpiry confirms a message sent with a short Azure Queue
+// Storage messagettl is lazily dropped from Peek/Dequeue Messages once it
+// expires, while a messagettl=-1 message survives indefinitely.
+func TestMessageTTLExpiry(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newTestMock()
+
+	url := createStdQueue(t, m)
+
+	_, err := m.SendMessage(ctx, driver.SendMessageInput{
+		QueueURL: url, Body: "expires-soon", MessageTTLSeconds: ttlPtr(5),
+	})
+	require.NoError(t, err)
+
+	_, err = m.SendMessage(ctx, driver.SendMessageInput{
+		QueueURL: url, Body: "never-expires", MessageTTLSeconds: ttlPtr(-1),
+	})
+	require.NoError(t, err)
+
+	// Before the TTL elapses, both messages are visible via Peek.
+	peeked, err := m.PeekMessages(ctx, url, 10)
+	require.NoError(t, err)
+	assert.Len(t, peeked, 2)
+
+	clk.Advance(10 * time.Second)
+
+	// After the TTL elapses, only the never-expiring message remains.
+	peeked, err = m.PeekMessages(ctx, url, 10)
+	require.NoError(t, err)
+	require.Len(t, peeked, 1)
+	assert.Equal(t, "never-expires", peeked[0].Body)
+
+	msgs, err := m.DequeueMessages(ctx, url, 10, 30)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "never-expires", msgs[0].Body)
+}
+
+// TestMessageTTLUnsetNeverExpires confirms a message sent through the generic
+// cross-cloud SendMessage path (Service Bus dataplane; MessageTTLSeconds left
+// nil) keeps its existing unlimited-retention behavior rather than picking up
+// Queue Storage's 7-day default.
+func TestMessageTTLUnsetNeverExpires(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newTestMock()
+
+	url := createStdQueue(t, m)
+
+	_, err := m.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "plain"})
+	require.NoError(t, err)
+
+	clk.Advance(365 * 24 * time.Hour) // a full year later
+
+	msgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: url, MaxMessages: 10})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "plain", msgs[0].Body)
+}

--- a/providers/azure/servicebus/servicebus.go
+++ b/providers/azure/servicebus/servicebus.go
@@ -36,6 +36,11 @@ type sbMessage struct {
 	VisibleAt       time.Time
 	SentAt          time.Time
 	ReceiveCount    int
+	// ExpiresAt is the message's absolute expiration time. The zero value
+	// means the message never expires — the default for Service Bus queues
+	// (which never set SendMessageInput.MessageTTLSeconds) and for Azure
+	// Queue Storage messages sent with messagettl=-1. See isMessageExpired.
+	ExpiresAt time.Time
 }
 
 // queueData holds the internal state of a single Service Bus queue.
@@ -265,6 +270,7 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 	}
 
 	visibleAt := now.Add(time.Duration(delaySeconds) * time.Second)
+	expiresAt := computeExpiry(now, input.MessageTTLSeconds)
 
 	msg := &sbMessage{
 		ID:              msgID,
@@ -274,6 +280,7 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		Attributes:      attrs,
 		VisibleAt:       visibleAt,
 		SentAt:          now,
+		ExpiresAt:       expiresAt,
 	}
 
 	qd.messages = append(qd.messages, msg)
@@ -304,6 +311,7 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 
 	return &driver.SendMessageOutput{
 		MessageID: msgID,
+		ExpiresAt: expiresAt,
 	}, nil
 }
 
@@ -367,7 +375,7 @@ func (m *Mock) ReceiveMessages(_ context.Context, input driver.ReceiveMessageInp
 	now := m.opts.Clock.Now()
 	results, toRemove := m.collectVisibleMessages(qd, maxMsgs, visibilityTimeout, now)
 
-	// Remove DLQ-moved messages in reverse order.
+	// Remove DLQ-moved and expired messages in reverse order.
 	for i := len(toRemove) - 1; i >= 0; i-- {
 		idx := toRemove[i]
 		qd.messages = append(qd.messages[:idx], qd.messages[idx+1:]...)
@@ -409,6 +417,14 @@ func (m *Mock) collectVisibleMessages(
 			break
 		}
 
+		// Lazily reap an expired message (Azure Queue Storage's per-message
+		// messagettl) instead of returning it, mirroring the Cosmos DB mock's
+		// on-read TTL check.
+		if isMessageExpired(msg, now) {
+			toRemove = append(toRemove, i)
+			continue
+		}
+
 		if msg.VisibleAt.After(now) {
 			continue
 		}
@@ -448,6 +464,7 @@ func buildReceivedMessage(msg *sbMessage, visibilityTimeout int, now time.Time) 
 		Attributes:    attrs,
 		GroupID:       msg.GroupID,
 		ReceiveCount:  msg.ReceiveCount,
+		ExpiresAt:     msg.ExpiresAt,
 	}
 }
 

--- a/providers/azure/tablestorage/tablestorage.go
+++ b/providers/azure/tablestorage/tablestorage.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -107,7 +108,7 @@ func (m *Mock) DeleteTable(_ context.Context, name string) error {
 	defer m.mu.Unlock()
 
 	if _, ok := m.tables[name]; !ok {
-		return errors.Newf(errors.NotFound, "table %q not found", name)
+		return driver.ErrTableNotFound
 	}
 
 	delete(m.tables, name)
@@ -136,7 +137,7 @@ func (m *Mock) table(name string) (*tableData, error) {
 
 	td, ok := m.tables[name]
 	if !ok {
-		return nil, errors.Newf(errors.NotFound, "table %q not found", name)
+		return nil, driver.ErrTableNotFound
 	}
 
 	return td, nil
@@ -320,7 +321,9 @@ func sanitize(e driver.Entity) driver.Entity {
 
 // QueryEntities returns a page of entities matching opts, ordered by
 // (PartitionKey, RowKey), honoring the OData $filter, a partition restriction,
-// $top, and a continuation position.
+// $top, $select and a continuation position.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) QueryEntities(
 	_ context.Context, table string, opts driver.QueryOptions,
 ) (driver.QueryResult, error) {
@@ -338,7 +341,7 @@ func (m *Mock) QueryEntities(
 	ordered := td.sortedEntities()
 	td.mu.RUnlock()
 
-	return page(ordered, opts, pred), nil
+	return page(ordered, &opts, pred), nil
 }
 
 // sortedEntities returns the table's entities ordered by (PartitionKey,
@@ -361,9 +364,9 @@ func (td *tableData) sortedEntities() []*storedEntity {
 	return out
 }
 
-// page applies partition restriction, filter, continuation and $top to the
-// ordered entities, returning one result page.
-func page(ordered []*storedEntity, opts driver.QueryOptions, pred predicate) driver.QueryResult {
+// page applies partition restriction, filter, continuation, $top and $select
+// to the ordered entities, returning one result page.
+func page(ordered []*storedEntity, opts *driver.QueryOptions, pred predicate) driver.QueryResult {
 	var res driver.QueryResult
 
 	for _, se := range ordered {
@@ -389,10 +392,43 @@ func page(ordered []*storedEntity, opts driver.QueryOptions, pred predicate) dri
 			return res
 		}
 
-		res.Entities = append(res.Entities, se.render())
+		res.Entities = append(res.Entities, project(se.render(), opts.Select))
 	}
 
 	return res
+}
+
+// project restricts an entity to the property names listed in a raw
+// comma-separated $select value, always keeping the system properties
+// (PartitionKey, RowKey, Timestamp, odata.etag) the real Table service
+// returns regardless of $select. An empty select returns e unchanged.
+func project(e driver.Entity, selectRaw string) driver.Entity {
+	if strings.TrimSpace(selectRaw) == "" {
+		return e
+	}
+
+	keep := map[string]bool{
+		"PartitionKey": true,
+		"RowKey":       true,
+		timestampProp:  true,
+		etagProp:       true,
+	}
+
+	for _, name := range strings.Split(selectRaw, ",") {
+		if name = strings.TrimSpace(name); name != "" {
+			keep[name] = true
+		}
+	}
+
+	out := make(driver.Entity, len(keep))
+
+	for k, v := range e {
+		if keep[k] {
+			out[k] = v
+		}
+	}
+
+	return out
 }
 
 // afterContinuation reports whether (pk, rk) sorts at or after the continuation

--- a/server/azure/queue/handler.go
+++ b/server/azure/queue/handler.go
@@ -53,6 +53,20 @@ const (
 	// maxEnqueueBodyBytes caps a single enqueued message body. Azure allows up
 	// to 64 KiB; we use a generous 1 MiB cap.
 	maxEnqueueBodyBytes = 1 << 20
+
+	// defaultMessageTTLSeconds is the message time-to-live Put Message applies
+	// when the messagettl query parameter is omitted.
+	defaultMessageTTLSeconds = 7 * 24 * 60 * 60
+
+	// neverExpireTTL is the messagettl value meaning "the message never expires".
+	neverExpireTTL = -1
+
+	// neverExpireHorizon is how far in the future the wire response reports a
+	// message's expiration when it never expires. Azure caps a "never expire"
+	// message's DateTime at a maximal value; a century is comfortably beyond
+	// any real workload's concern while still formatting as a valid RFC1123
+	// timestamp.
+	neverExpireHorizon = 100 * 365 * 24 * time.Hour
 )
 
 // Handler serves Azure Queue Storage REST requests against a messagequeue
@@ -328,10 +342,16 @@ func (h *Handler) enqueue(w http.ResponseWriter, r *http.Request, queue string) 
 
 	visTimeout := atoiDefault(r.URL.Query().Get("visibilitytimeout"), 0)
 
+	ttlSeconds, ok := parseMessageTTL(w, r.URL.Query().Get("messagettl"))
+	if !ok {
+		return
+	}
+
 	out, err := h.mq.SendMessage(r.Context(), mqdriver.SendMessageInput{
-		QueueURL:     url,
-		Body:         req.MessageText,
-		DelaySeconds: visTimeout,
+		QueueURL:          url,
+		Body:              req.MessageText,
+		DelaySeconds:      visTimeout,
+		MessageTTLSeconds: &ttlSeconds,
 	})
 	if err != nil {
 		writeErr(w, err)
@@ -342,7 +362,7 @@ func (h *Handler) enqueue(w http.ResponseWriter, r *http.Request, queue string) 
 	resp := messagesList{Messages: []messageXML{{
 		MessageID:       out.MessageID,
 		InsertionTime:   now.Format(time.RFC1123),
-		ExpirationTime:  now.Add(7 * 24 * time.Hour).Format(time.RFC1123),
+		ExpirationTime:  displayExpiry(out.ExpiresAt).UTC().Format(time.RFC1123),
 		PopReceipt:      out.MessageID,
 		TimeNextVisible: now.Add(time.Duration(visTimeout) * time.Second).Format(time.RFC1123),
 	}}}
@@ -375,11 +395,12 @@ func (h *Handler) dequeue(w http.ResponseWriter, r *http.Request, queue string) 
 	now := time.Now().UTC()
 	out := messagesList{}
 
-	for _, m := range msgs {
+	for i := range msgs {
+		m := &msgs[i]
 		out.Messages = append(out.Messages, messageXML{
 			MessageID:       m.MessageID,
 			InsertionTime:   now.Format(time.RFC1123),
-			ExpirationTime:  now.Add(7 * 24 * time.Hour).Format(time.RFC1123),
+			ExpirationTime:  displayExpiry(m.ExpiresAt).UTC().Format(time.RFC1123),
 			PopReceipt:      m.ReceiptHandle,
 			TimeNextVisible: now.Add(time.Duration(visTimeout) * time.Second).Format(time.RFC1123),
 			DequeueCount:    int64(m.ReceiveCount),
@@ -436,7 +457,7 @@ func (h *Handler) peek(w http.ResponseWriter, r *http.Request, queue string) {
 		out.Messages = append(out.Messages, peekMessageXML{
 			MessageID:      m.MessageID,
 			InsertionTime:  m.InsertedAt.UTC().Format(time.RFC1123),
-			ExpirationTime: m.ExpiresAt.UTC().Format(time.RFC1123),
+			ExpirationTime: displayExpiry(m.ExpiresAt).UTC().Format(time.RFC1123),
 			DequeueCount:   int64(m.ReceiveCount),
 			MessageText:    m.Body,
 		})
@@ -594,6 +615,43 @@ func parseVisibilityTimeout(w http.ResponseWriter, raw string) (int, bool) {
 	}
 
 	return v, true
+}
+
+// parseMessageTTL validates the optional messagettl parameter for Put Message:
+// a positive number of seconds, or -1 meaning the message never expires. An
+// absent value returns Azure's documented default of 7 days. It writes a 400
+// and returns ok=false on a bad value.
+func parseMessageTTL(w http.ResponseWriter, raw string) (int, bool) {
+	if raw == "" {
+		return defaultMessageTTLSeconds, true
+	}
+
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidQueryParameterValue",
+			"Value for one of the query parameters specified in the request URI is invalid.")
+
+		return 0, false
+	}
+
+	if v != neverExpireTTL && v < 1 {
+		writeError(w, http.StatusBadRequest, "OutOfRangeQueryParameterValue", "messagettl is out of range")
+		return 0, false
+	}
+
+	return v, true
+}
+
+// displayExpiry returns t, or — for a message that never expires (the zero
+// time.Time internal marker) — a far-future timestamp so the wire response's
+// ExpirationTime element reads as "effectively unbounded" rather than
+// formatting the zero time as year 0001 (which would look already expired).
+func displayExpiry(t time.Time) time.Time {
+	if t.IsZero() {
+		return time.Now().UTC().Add(neverExpireHorizon)
+	}
+
+	return t
 }
 
 // parseNumOfMessages validates the optional numofmessages parameter for Get

--- a/server/azure/queue/messagettl_test.go
+++ b/server/azure/queue/messagettl_test.go
@@ -1,0 +1,144 @@
+package queue_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKQueueMessageTTL drives Put Message's messagettl query parameter
+// through the real azqueue client, confirming a short-TTL message is lazily
+// dropped from Get/Peek Messages once it expires, while a messagettl=-1
+// message survives indefinitely.
+func TestSDKQueueMessageTTL(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloudP := cloudemu.NewAzure(config.WithClock(fc))
+	srv := azureserver.New(azureserver.Drivers{QueueStorage: cloudP.QueueStorage})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	opts := &azqueue.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}},
+	}
+
+	svcClient, err := azqueue.NewServiceClientWithNoCredential(ts.URL+"/", opts)
+	if err != nil {
+		t.Fatalf("NewServiceClientWithNoCredential: %v", err)
+	}
+
+	const queueName = "ttlq"
+
+	if _, err := svcClient.CreateQueue(ctx, queueName, nil); err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	qClient, err := azqueue.NewQueueClientWithNoCredential(ts.URL+"/"+queueName, opts)
+	if err != nil {
+		t.Fatalf("NewQueueClientWithNoCredential: %v", err)
+	}
+
+	shortLived := int32(5)   // expires 5s after enqueue
+	neverExpire := int32(-1) // never expires
+
+	if _, err := qClient.EnqueueMessage(ctx, "expires-soon", &azqueue.EnqueueMessageOptions{
+		TimeToLive: &shortLived,
+	}); err != nil {
+		t.Fatalf("EnqueueMessage (short TTL): %v", err)
+	}
+
+	if _, err := qClient.EnqueueMessage(ctx, "never-expires", &azqueue.EnqueueMessageOptions{
+		TimeToLive: &neverExpire,
+	}); err != nil {
+		t.Fatalf("EnqueueMessage (never expire): %v", err)
+	}
+
+	numMsgs := int32(10)
+
+	// Before the TTL elapses, both messages are visible.
+	before, err := qClient.PeekMessages(ctx, &azqueue.PeekMessagesOptions{NumberOfMessages: &numMsgs})
+	if err != nil {
+		t.Fatalf("PeekMessages (before expiry): %v", err)
+	}
+
+	if len(before.Messages) != 2 {
+		t.Fatalf("PeekMessages before expiry: got %d messages, want 2", len(before.Messages))
+	}
+
+	// Advance well past the short-lived message's TTL.
+	fc.Advance(10 * time.Second)
+
+	afterPeek, err := qClient.PeekMessages(ctx, &azqueue.PeekMessagesOptions{NumberOfMessages: &numMsgs})
+	if err != nil {
+		t.Fatalf("PeekMessages (after expiry): %v", err)
+	}
+
+	if len(afterPeek.Messages) != 1 {
+		t.Fatalf("PeekMessages after expiry: got %d messages, want 1 (only the never-expiring one)", len(afterPeek.Messages))
+	}
+
+	if got := *afterPeek.Messages[0].MessageText; got != "never-expires" {
+		t.Errorf("surviving message text = %q, want %q", got, "never-expires")
+	}
+
+	afterDequeue, err := qClient.DequeueMessages(ctx, &azqueue.DequeueMessagesOptions{NumberOfMessages: &numMsgs})
+	if err != nil {
+		t.Fatalf("DequeueMessages (after expiry): %v", err)
+	}
+
+	if len(afterDequeue.Messages) != 1 {
+		t.Fatalf("DequeueMessages after expiry: got %d messages, want 1", len(afterDequeue.Messages))
+	}
+
+	if got := *afterDequeue.Messages[0].MessageText; got != "never-expires" {
+		t.Errorf("dequeued message text = %q, want %q", got, "never-expires")
+	}
+}
+
+// TestSDKQueueMessageTTLInvalid confirms an out-of-range messagettl (0, which
+// is neither a positive TTL nor the -1 "never expire" sentinel) is rejected
+// with a 400 rather than silently accepted.
+func TestSDKQueueMessageTTLInvalid(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{QueueStorage: cloudP.QueueStorage})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	opts := &azqueue.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}},
+	}
+
+	svcClient, err := azqueue.NewServiceClientWithNoCredential(ts.URL+"/", opts)
+	if err != nil {
+		t.Fatalf("NewServiceClientWithNoCredential: %v", err)
+	}
+
+	const queueName = "ttlbad"
+
+	if _, err := svcClient.CreateQueue(ctx, queueName, nil); err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	qClient, err := azqueue.NewQueueClientWithNoCredential(ts.URL+"/"+queueName, opts)
+	if err != nil {
+		t.Fatalf("NewQueueClientWithNoCredential: %v", err)
+	}
+
+	zero := int32(0)
+	if _, err := qClient.EnqueueMessage(ctx, "x", &azqueue.EnqueueMessageOptions{TimeToLive: &zero}); err == nil {
+		t.Fatal("EnqueueMessage with messagettl=0 succeeded, want an error")
+	}
+}

--- a/server/azure/tablestorage/handler.go
+++ b/server/azure/tablestorage/handler.go
@@ -250,6 +250,7 @@ func (h *Handler) queryEntities(w http.ResponseWriter, r *http.Request, table st
 	res, err := h.ts.QueryEntities(r.Context(), table, driver.QueryOptions{
 		Filter:           q.Get("$filter"),
 		Top:              atoiDefault(q.Get("$top"), 0),
+		Select:           q.Get("$select"),
 		NextPartitionKey: q.Get("NextPartitionKey"),
 		NextRowKey:       q.Get("NextRowKey"),
 	})

--- a/server/azure/tablestorage/helpers.go
+++ b/server/azure/tablestorage/helpers.go
@@ -2,6 +2,7 @@ package tablestorage
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strconv"
@@ -195,8 +196,10 @@ func writeErr(w http.ResponseWriter, err error) {
 // mapErr maps a CloudEmu canonical error to its Azure Table HTTP status + code.
 func mapErr(err error) (status int, code string) {
 	switch {
+	case errors.Is(err, driver.ErrTableNotFound):
+		return http.StatusNotFound, "TableNotFound"
 	case cerrors.IsNotFound(err):
-		return http.StatusNotFound, "ResourceNotFound"
+		return http.StatusNotFound, "EntityNotFound"
 	case cerrors.IsAlreadyExists(err):
 		return http.StatusConflict, "EntityAlreadyExists"
 	case cerrors.IsFailedPrecondition(err):

--- a/server/azure/tablestorage/sdk_roundtrip_test.go
+++ b/server/azure/tablestorage/sdk_roundtrip_test.go
@@ -117,10 +117,11 @@ func TestSDKTableRoundTrip(t *testing.T) {
 		t.Fatalf("DeleteEntity: %v", err)
 	}
 
-	// Confirm the entity is gone.
+	// Confirm the entity is gone: the table still exists, so this is
+	// EntityNotFound, not the table-missing TableNotFound.
 	if _, err := client.GetEntity(ctx, "org", "alice", nil); err == nil ||
-		!strings.Contains(err.Error(), "ResourceNotFound") {
-		t.Errorf("expected ResourceNotFound after delete, got %v", err)
+		!strings.Contains(err.Error(), "EntityNotFound") {
+		t.Errorf("expected EntityNotFound after delete, got %v", err)
 	}
 
 	// Delete table.

--- a/server/azure/tablestorage/select_errorcodes_test.go
+++ b/server/azure/tablestorage/select_errorcodes_test.go
@@ -1,0 +1,161 @@
+package tablestorage_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKTableSelectProjection drives Query Entities' $select through the
+// real aztables client, confirming only the requested properties (plus the
+// always-present system properties) come back.
+func TestSDKTableSelectProjection(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{TableStorage: cloudP.TableStorage})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	svc, err := aztables.NewServiceClientWithNoCredential(ts.URL+"/", &aztables.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}},
+	})
+	if err != nil {
+		t.Fatalf("NewServiceClientWithNoCredential: %v", err)
+	}
+
+	const tableName = "selectpeople"
+
+	if _, err := svc.CreateTable(ctx, tableName, nil); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	client := svc.NewClient(tableName)
+
+	entity := map[string]any{
+		"PartitionKey": "org",
+		"RowKey":       "bob",
+		"Email":        "bob@example.com",
+		"Age":          int64(41),
+	}
+
+	marshalled, err := json.Marshal(entity)
+	if err != nil {
+		t.Fatalf("marshal entity: %v", err)
+	}
+
+	if _, err := client.AddEntity(ctx, marshalled, nil); err != nil {
+		t.Fatalf("AddEntity: %v", err)
+	}
+
+	filter := "PartitionKey eq 'org'"
+	sel := "Email"
+
+	pager := client.NewListEntitiesPager(&aztables.ListEntitiesOptions{Filter: &filter, Select: &sel})
+
+	var props map[string]any
+
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("ListEntities: %v", perr)
+		}
+
+		for _, raw := range page.Entities {
+			if uerr := json.Unmarshal(raw, &props); uerr != nil {
+				t.Fatalf("unmarshal query entity: %v", uerr)
+			}
+		}
+	}
+
+	if props == nil {
+		t.Fatal("no entity returned")
+	}
+
+	if props["Email"] != "bob@example.com" {
+		t.Errorf("Email = %v, want bob@example.com (selected property must survive projection)", props["Email"])
+	}
+
+	if _, ok := props["Age"]; ok {
+		t.Errorf("Age present in projected entity %v, want it dropped ($select=Email only)", props)
+	}
+
+	if props["PartitionKey"] != "org" || props["RowKey"] != "bob" {
+		t.Errorf("system keys dropped by projection: pk=%v rk=%v", props["PartitionKey"], props["RowKey"])
+	}
+
+	if _, ok := props["Timestamp"]; !ok {
+		t.Errorf("Timestamp dropped by projection, want it always present: %v", props)
+	}
+}
+
+// TestSDKTableNotFoundVsEntityNotFound confirms a missing table reports the
+// real Table Storage "TableNotFound" code while a missing entity in an
+// existing table reports "EntityNotFound", rather than both collapsing to
+// the non-standard "ResourceNotFound".
+func TestSDKTableNotFoundVsEntityNotFound(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{TableStorage: cloudP.TableStorage})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	svc, err := aztables.NewServiceClientWithNoCredential(ts.URL+"/", &aztables.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}},
+	})
+	if err != nil {
+		t.Fatalf("NewServiceClientWithNoCredential: %v", err)
+	}
+
+	// A GetEntity against a table that was never created: TableNotFound.
+	missingTableClient := svc.NewClient("nosuchtable")
+
+	_, err = missingTableClient.GetEntity(ctx, "p", "r", nil)
+	if err == nil {
+		t.Fatal("GetEntity on a missing table succeeded, want an error")
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("expected an azcore ResponseError, got %T: %v", err, err)
+	}
+
+	if respErr.ErrorCode != "TableNotFound" {
+		t.Errorf("missing-table error code = %q, want TableNotFound", respErr.ErrorCode)
+	}
+
+	// A GetEntity against a real table but a row that was never inserted:
+	// EntityNotFound.
+	const tableName = "existingtable"
+
+	if _, err := svc.CreateTable(ctx, tableName, nil); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	existingTableClient := svc.NewClient(tableName)
+
+	_, err = existingTableClient.GetEntity(ctx, "p", "missing-row", nil)
+	if err == nil {
+		t.Fatal("GetEntity on a missing entity succeeded, want an error")
+	}
+
+	if !errors.As(err, &respErr) {
+		t.Fatalf("expected an azcore ResponseError, got %T: %v", err, err)
+	}
+
+	if respErr.ErrorCode != "EntityNotFound" {
+		t.Errorf("missing-entity error code = %q, want EntityNotFound", respErr.ErrorCode)
+	}
+}

--- a/services/messagequeue/driver/driver.go
+++ b/services/messagequeue/driver/driver.go
@@ -71,12 +71,21 @@ type SendMessageInput struct {
 	// SystemAttributes are SQS message system attributes (AWS SQS; the only
 	// supported key is AWSTraceHeader). Non-AWS providers ignore them.
 	SystemAttributes map[string]MessageAttributeValue
+	// MessageTTLSeconds is Azure Queue Storage's per-message time-to-live (Put
+	// Message's messagettl query parameter), in seconds. nil means the caller
+	// didn't specify one; a negative value means the message never expires.
+	// Ignored by non-Azure providers.
+	MessageTTLSeconds *int
 }
 
 // SendMessageOutput is the result of sending a message.
 type SendMessageOutput struct {
 	MessageID      string
 	SequenceNumber string // FIFO only
+	// ExpiresAt is the message's absolute expiration time, as resolved from
+	// MessageTTLSeconds (Azure Queue Storage). Providers that don't track
+	// per-message TTL leave it zero.
+	ExpiresAt time.Time
 }
 
 // ReceiveMessageInput configures a message receive operation.
@@ -104,6 +113,9 @@ type Message struct {
 	// Queue Storage surfaces it as DequeueCount; providers that don't track it
 	// leave it zero.
 	ReceiveCount int
+	// ExpiresAt is the message's absolute expiration time (Azure Queue Storage's
+	// per-message TTL). Providers that don't track per-message TTL leave it zero.
+	ExpiresAt time.Time
 }
 
 // BatchSendEntry represents a single message in a batch send.

--- a/services/tablestorage/driver/driver.go
+++ b/services/tablestorage/driver/driver.go
@@ -7,7 +7,11 @@
 // Table data-plane REST API (aztables) exercises, nothing more.
 package driver
 
-import "context"
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
 
 // UpdateMode selects how UpdateEntity combines the supplied properties with an
 // existing entity.
@@ -43,6 +47,12 @@ type QueryOptions struct {
 	Filter string
 	// Top caps the number of entities returned in this page (0 = no cap).
 	Top int
+	// Select is a raw comma-separated $select property-name list restricting
+	// which properties each returned entity carries. Empty means no
+	// projection: every stored property is returned. PartitionKey, RowKey,
+	// Timestamp and odata.etag are always included regardless of Select,
+	// matching the real Table service.
+	Select string
 	// NextPartitionKey/NextRowKey are the continuation position from a prior
 	// page; results resume strictly after this (PartitionKey, RowKey).
 	NextPartitionKey string
@@ -90,6 +100,14 @@ type BatchOp struct {
 type BatchResult struct {
 	ETag string
 }
+
+// ErrTableNotFound is returned by TableStorage methods when the referenced
+// table itself does not exist. It is still a cerrors.NotFound error (so
+// cerrors.IsNotFound(err) keeps classifying it correctly), but wire handlers
+// can errors.Is(err, ErrTableNotFound) to tell it apart from a missing entity
+// inside an existing table (also cerrors.NotFound) and report the real Table
+// Storage "TableNotFound" error code instead of the generic "EntityNotFound".
+var ErrTableNotFound = cerrors.New(cerrors.NotFound, "the table specified does not exist")
 
 // TableStorage is the interface a Table Storage backend implements.
 type TableStorage interface {


### PR DESCRIPTION
## What

- **Queue Storage (HIGH):** `POST /{queue}/messages` parsed only `visibilitytimeout`; `messagettl` was silently ignored, so messages never expired. `messagettl` (seconds, `-1` = never expire) is now parsed and threaded through a new `SendMessageInput.MessageTTLSeconds` / `Message.ExpiresAt` / `SendMessageOutput.ExpiresAt` on the messagequeue driver. The Azure provider computes each message's absolute expiry at send time and lazily drops expired messages on Get/Peek Messages, mirroring the Cosmos DB mock's on-read TTL reaping. Service Bus queues never set this field, so their existing unlimited-retention behavior is unaffected, and the AWS SQS path is untouched.

- **Table Storage (MEDIUM):** `queryEntities` read only `$filter`/`$top`/`NextPartitionKey`/`NextRowKey`; `$select` was ignored and every property was always returned. `driver.QueryOptions` gained a `Select` field, and the provider now projects each returned entity down to the requested properties plus the system properties (`PartitionKey`, `RowKey`, `Timestamp`, `odata.etag`) the real service always includes regardless of `$select`.

- **Table Storage (MEDIUM):** every 404 — both a missing table and a missing entity — was reported as the non-standard `ResourceNotFound` code. The provider now returns a distinguishable `driver.ErrTableNotFound` sentinel for a missing table (still `cerrors.NotFound`-classified so existing `IsNotFound` checks keep working); the wire handler's `mapErr` maps it to the real `TableNotFound` code, while a missing entity in an existing table maps to `EntityNotFound`.

## Why

All three diverge from real Azure Table/Queue Storage behavior (confirmed against the MS Learn REST docs for Put Message and Table/Queue error codes), breaking real `azure-sdk-for-go` (`aztables`/`azqueue`) clients that rely on message expiry, entity projection, or the standard error-code taxonomy.

## Testing

New regression tests drive the real `azure-sdk-for-go` `aztables`/`azqueue` clients against a live wire server (`server/azure/queue/messagettl_test.go`, `server/azure/tablestorage/select_errorcodes_test.go`), plus provider-level coverage with a `FakeClock` for deterministic TTL expiry (`providers/azure/servicebus/queue_storage_ttl_test.go`). An existing test asserting the old `ResourceNotFound` code was updated to `EntityNotFound`.

- `go build ./...`, `go vet ./...`, `go test ./...` (full suite) all pass
- `go test -race` clean on the changed provider packages
- `golangci-lint` on changed packages: zero new findings
- `go run ./internal/coveragegen` / `./internal/compatgen`: no diff (no driver *method* signatures changed, only struct fields)