### PR TITLE
fix(azure-storage): stop blobServices PUT from wiping account, add PATCH/GRS/CMK support

### DIFF
--- a/docs/coverage/aws/s3.md
+++ b/docs/coverage/aws/s3.md
@@ -47,6 +47,15 @@ AWS's `storage` service · portable interface `driver.Bucket` · [AWS index](./R
 
 Discovered by type assertion; only some providers implement these.
 
+### AccountEncryptionConfig
+
+AccountEncryptionConfig is an OPTIONAL Azure-specific capability,
+
+| Operation | Description |
+| --- | --- |
+| `AccountEncryption` |  |
+| `SetAccountEncryption` |  |
+
 ### AzureBlobExtensions
 
 AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
@@ -74,6 +83,15 @@ AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
 | `SetContainerAccessPolicy` | SetContainerAccessPolicy sets a container's public access level and |
 | `SetContainerMetadata` | SetContainerMetadata replaces a container's metadata (Set Container |
 | `StageBlock` | StageBlock buffers an uncommitted block (Put Block, ?comp=block) for a blob |
+
+### BlobServiceConfig
+
+BlobServiceConfig is an OPTIONAL Azure-specific capability, discovered by
+
+| Operation | Description |
+| --- | --- |
+| `BlobServiceProperties` |  |
+| `SetBlobServiceProperties` |  |
 
 ### BucketAttributes
 

--- a/docs/coverage/azure/blobstorage.md
+++ b/docs/coverage/azure/blobstorage.md
@@ -47,6 +47,15 @@ Azure's `storage` service · portable interface `driver.Bucket` · [Azure index]
 
 Discovered by type assertion; only some providers implement these.
 
+### AccountEncryptionConfig
+
+AccountEncryptionConfig is an OPTIONAL Azure-specific capability,
+
+| Operation | Description |
+| --- | --- |
+| `AccountEncryption` |  |
+| `SetAccountEncryption` |  |
+
 ### AzureBlobExtensions
 
 AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
@@ -74,6 +83,15 @@ AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
 | `SetContainerAccessPolicy` | SetContainerAccessPolicy sets a container's public access level and |
 | `SetContainerMetadata` | SetContainerMetadata replaces a container's metadata (Set Container |
 | `StageBlock` | StageBlock buffers an uncommitted block (Put Block, ?comp=block) for a blob |
+
+### BlobServiceConfig
+
+BlobServiceConfig is an OPTIONAL Azure-specific capability, discovered by
+
+| Operation | Description |
+| --- | --- |
+| `BlobServiceProperties` |  |
+| `SetBlobServiceProperties` |  |
 
 ### BucketAttributes
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -10344,6 +10344,18 @@
     ],
     "optionalCapabilities": [
       {
+        "name": "AccountEncryptionConfig",
+        "doc": "AccountEncryptionConfig is an OPTIONAL Azure-specific capability,",
+        "operations": [
+          {
+            "name": "AccountEncryption"
+          },
+          {
+            "name": "SetAccountEncryption"
+          }
+        ]
+      },
+      {
         "name": "AzureBlobExtensions",
         "doc": "AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,",
         "operations": [
@@ -10430,6 +10442,18 @@
           {
             "name": "StageBlock",
             "doc": "StageBlock buffers an uncommitted block (Put Block, ?comp=block) for a blob"
+          }
+        ]
+      },
+      {
+        "name": "BlobServiceConfig",
+        "doc": "BlobServiceConfig is an OPTIONAL Azure-specific capability, discovered by",
+        "operations": [
+          {
+            "name": "BlobServiceProperties"
+          },
+          {
+            "name": "SetBlobServiceProperties"
           }
         ]
       },

--- a/docs/coverage/gcp/gcs.md
+++ b/docs/coverage/gcp/gcs.md
@@ -47,6 +47,15 @@ GCP's `storage` service · portable interface `driver.Bucket` · [GCP index](./R
 
 Discovered by type assertion; only some providers implement these.
 
+### AccountEncryptionConfig
+
+AccountEncryptionConfig is an OPTIONAL Azure-specific capability,
+
+| Operation | Description |
+| --- | --- |
+| `AccountEncryption` |  |
+| `SetAccountEncryption` |  |
+
 ### AzureBlobExtensions
 
 AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
@@ -74,6 +83,15 @@ AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
 | `SetContainerAccessPolicy` | SetContainerAccessPolicy sets a container's public access level and |
 | `SetContainerMetadata` | SetContainerMetadata replaces a container's metadata (Set Container |
 | `StageBlock` | StageBlock buffers an uncommitted block (Put Block, ?comp=block) for a blob |
+
+### BlobServiceConfig
+
+BlobServiceConfig is an OPTIONAL Azure-specific capability, discovered by
+
+| Operation | Description |
+| --- | --- |
+| `BlobServiceProperties` |  |
+| `SetBlobServiceProperties` |  |
 
 ### BucketAttributes
 

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -135,14 +135,30 @@ type Mock struct {
 	// accountKeys holds the shared access keys per storage account, generated
 	// lazily on first ListStorageAccountKeys.
 	accountKeys *memstore.Store[[]driver.AccountKey]
-	opts        *config.Options
-	monitoring  mondriver.Monitoring
+	// blobServiceProps holds the account-level Blob service properties
+	// (versioning/soft-delete/change-feed/CORS) set via the blobServices/default
+	// ARM sub-resource, for the BlobServiceConfig capability.
+	blobServiceProps *memstore.Store[driver.BlobServiceProperties]
+	// accountEncryption holds the account's service-side encryption
+	// configuration (Properties.Encryption), for the AccountEncryptionConfig
+	// capability. Kept separate from bucketAttrs so that struct stays small.
+	accountEncryption *memstore.Store[driver.AccountEncryption]
+	opts              *config.Options
+	monitoring        mondriver.Monitoring
 }
 
 // Compile-time check that Mock satisfies the optional BucketAttributes
 // discovery capability, so a signature typo fails the build rather than
 // silently failing the runtime type assertion in walkStorage.
 var _ driver.BucketAttributes = (*Mock)(nil)
+
+// Compile-time check that Mock satisfies the optional BlobServiceConfig
+// capability the ARM storage-account handler reaches by type assertion.
+var _ driver.BlobServiceConfig = (*Mock)(nil)
+
+// Compile-time check that Mock satisfies the optional AccountEncryptionConfig
+// capability the ARM storage-account handler reaches by type assertion.
+var _ driver.AccountEncryptionConfig = (*Mock)(nil)
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
 func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
@@ -174,10 +190,12 @@ func (m *Mock) emitMetric(container string, metrics map[string]float64) {
 // New creates a new Azure Blob Storage mock.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		containers:  memstore.New[*containerMeta](),
-		bucketAttrs: memstore.New[driver.AccountAttributes](),
-		accountKeys: memstore.New[[]driver.AccountKey](),
-		opts:        opts,
+		containers:        memstore.New[*containerMeta](),
+		bucketAttrs:       memstore.New[driver.AccountAttributes](),
+		accountKeys:       memstore.New[[]driver.AccountKey](),
+		blobServiceProps:  memstore.New[driver.BlobServiceProperties](),
+		accountEncryption: memstore.New[driver.AccountEncryption](),
+		opts:              opts,
 	}
 }
 
@@ -209,6 +227,63 @@ func (m *Mock) BucketAttributes(_ context.Context, bucket string) (driver.Accoun
 	}
 
 	return a, nil
+}
+
+// UpdateBucketAttributes atomically applies fn to a container's stored
+// attributes (Azure storage-account PATCH — AccountsClient.Update), seeding
+// the real-Azure baseline (Standard_LRS/StorageV2/Hot) first if none was set
+// yet. Routed through memstore's Update rather than a Get-then-Set pair so a
+// concurrent PATCH/create never loses an update.
+func (m *Mock) UpdateBucketAttributes(
+	_ context.Context, name string, fn func(driver.AccountAttributes) driver.AccountAttributes,
+) (driver.AccountAttributes, error) {
+	m.bucketAttrs.SetIfAbsent(name, driver.AccountAttributes{SKU: "Standard_LRS", Kind: "StorageV2", AccessTier: "Hot"})
+
+	var updated driver.AccountAttributes
+
+	m.bucketAttrs.Update(name, func(v driver.AccountAttributes) driver.AccountAttributes {
+		updated = fn(v)
+		return updated
+	})
+
+	return updated, nil
+}
+
+// SetBlobServiceProperties implements the storage BlobServiceConfig optional
+// capability (…/blobServices/default PUT), replacing any previously stored
+// properties for the account wholesale — matching real Azure's Set Blob
+// Service Properties, which takes a complete properties document each call.
+func (m *Mock) SetBlobServiceProperties(_ context.Context, account string, props driver.BlobServiceProperties) error {
+	m.blobServiceProps.Set(account, props)
+
+	return nil
+}
+
+// BlobServiceProperties implements the storage BlobServiceConfig optional
+// capability (…/blobServices/default GET), returning the zero value (all
+// features disabled) for an account that never had properties set — matching
+// real Azure's defaults for a freshly created account.
+func (m *Mock) BlobServiceProperties(_ context.Context, account string) (driver.BlobServiceProperties, error) {
+	props, _ := m.blobServiceProps.Get(account)
+
+	return props, nil
+}
+
+// SetAccountEncryption implements the storage AccountEncryptionConfig
+// optional capability, storing the account's requested encryption
+// configuration so it round-trips on a later GET instead of always reporting
+// the platform-managed default.
+func (m *Mock) SetAccountEncryption(account string, enc driver.AccountEncryption) {
+	m.accountEncryption.Set(account, enc)
+}
+
+// AccountEncryption implements the storage AccountEncryptionConfig optional
+// capability, returning the zero value (platform-managed default) for an
+// account that never requested customer-managed-key encryption.
+func (m *Mock) AccountEncryption(_ context.Context, account string) (driver.AccountEncryption, error) {
+	enc, _ := m.accountEncryption.Get(account)
+
+	return enc, nil
 }
 
 // CreateBucket creates a new blob container.

--- a/providers/azure/blobstorage/bucketattrs_update_test.go
+++ b/providers/azure/blobstorage/bucketattrs_update_test.go
@@ -1,0 +1,165 @@
+package blobstorage
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateBucketAttributes_SeedsDefaultsWhenAbsent verifies a PATCH-style
+// update on a never-created account starts from the real-Azure baseline
+// (Standard_LRS/StorageV2/Hot), matching BucketAttributes' own default.
+func TestUpdateBucketAttributes_SeedsDefaultsWhenAbsent(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	updated, err := m.UpdateBucketAttributes(ctx, "never-seeded", func(a driver.AccountAttributes) driver.AccountAttributes {
+		a.AccessTier = "Cool"
+		return a
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "Standard_LRS", updated.SKU)
+	assert.Equal(t, "StorageV2", updated.Kind)
+	assert.Equal(t, "Cool", updated.AccessTier)
+}
+
+// TestUpdateBucketAttributes_PreservesUntouchedFields verifies a partial
+// update via fn only changes what fn changes, leaving every other seeded
+// field intact — the non-destructive PATCH semantics the ARM handler relies
+// on.
+func TestUpdateBucketAttributes_PreservesUntouchedFields(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	m.SetBucketAttributes("acct1", driver.AccountAttributes{
+		SKU: "Premium_LRS", Kind: "BlockBlobStorage", AccessTier: "Hot",
+		Location: "westus2", Tags: map[string]string{"env": "prod"},
+	})
+
+	updated, err := m.UpdateBucketAttributes(ctx, "acct1", func(a driver.AccountAttributes) driver.AccountAttributes {
+		a.AccessTier = "Cool"
+		return a
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "Cool", updated.AccessTier)
+	assert.Equal(t, "Premium_LRS", updated.SKU)
+	assert.Equal(t, "BlockBlobStorage", updated.Kind)
+	assert.Equal(t, "westus2", updated.Location)
+	assert.Equal(t, map[string]string{"env": "prod"}, updated.Tags)
+
+	// The store itself, not just the returned value, reflects the update.
+	stored, err := m.BucketAttributes(ctx, "acct1")
+	require.NoError(t, err)
+	assert.Equal(t, "Cool", stored.AccessTier)
+}
+
+// TestUpdateBucketAttributes_ConcurrentNoLostUpdates drives many concurrent
+// updates through UpdateBucketAttributes and asserts every one of them is
+// reflected in the end state — proving the atomic Update-based
+// read-modify-write doesn't lose writes the way a Get-then-Set pair would
+// under concurrent access.
+func TestUpdateBucketAttributes_ConcurrentNoLostUpdates(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	const n = 100
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			_, err := m.UpdateBucketAttributes(ctx, "acct-concurrent", func(a driver.AccountAttributes) driver.AccountAttributes {
+				if a.Tags == nil {
+					a.Tags = map[string]string{}
+				}
+
+				a.Tags[keyFor(i)] = "set"
+
+				return a
+			})
+			assert.NoError(t, err)
+		}(i)
+	}
+
+	wg.Wait()
+
+	final, err := m.BucketAttributes(ctx, "acct-concurrent")
+	require.NoError(t, err)
+	assert.Len(t, final.Tags, n, "every concurrent update must be reflected — none lost")
+}
+
+func keyFor(i int) string {
+	return "k" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+}
+
+// TestBlobServiceProperties_DefaultsToZeroValue verifies an account that
+// never had blob service properties set reports all-disabled defaults,
+// matching a freshly created real Azure account.
+func TestBlobServiceProperties_DefaultsToZeroValue(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	props, err := m.BlobServiceProperties(ctx, "never-seeded")
+	require.NoError(t, err)
+
+	assert.False(t, props.IsVersioningEnabled)
+	assert.False(t, props.ChangeFeedEnabled)
+	assert.False(t, props.DeleteRetentionEnabled)
+	assert.Empty(t, props.CORS)
+}
+
+// TestBlobServiceProperties_RoundTrip verifies a full Set survives an
+// independent Get.
+func TestBlobServiceProperties_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	want := driver.BlobServiceProperties{
+		IsVersioningEnabled:     true,
+		ChangeFeedEnabled:       true,
+		ChangeFeedRetentionDays: 30,
+		DeleteRetentionEnabled:  true,
+		DeleteRetentionDays:     7,
+		CORS: []driver.CORSRule{{
+			AllowedOrigins: []string{"*"}, AllowedMethods: []string{"GET"}, MaxAgeSeconds: 3600,
+		}},
+	}
+
+	require.NoError(t, m.SetBlobServiceProperties(ctx, "acct1", want))
+
+	got, err := m.BlobServiceProperties(ctx, "acct1")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+// TestBlobServiceProperties_SetIsFullReplace verifies a second Set call
+// wholesale replaces the first — Azure's Set Blob Service Properties takes a
+// complete document each call, not a merge patch.
+func TestBlobServiceProperties_SetIsFullReplace(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.SetBlobServiceProperties(ctx, "acct1", driver.BlobServiceProperties{
+		IsVersioningEnabled: true, DeleteRetentionEnabled: true, DeleteRetentionDays: 7,
+	}))
+	require.NoError(t, m.SetBlobServiceProperties(ctx, "acct1", driver.BlobServiceProperties{
+		ChangeFeedEnabled: true,
+	}))
+
+	got, err := m.BlobServiceProperties(ctx, "acct1")
+	require.NoError(t, err)
+
+	assert.False(t, got.IsVersioningEnabled, "second Set must clear fields it omits")
+	assert.False(t, got.DeleteRetentionEnabled)
+	assert.True(t, got.ChangeFeedEnabled)
+}

--- a/server/azure/storageaccount/account_replication_encryption_test.go
+++ b/server/azure/storageaccount/account_replication_encryption_test.go
@@ -1,0 +1,209 @@
+// Real-SDK round-trip tests: the live azure-sdk-for-go armstorage
+// AccountsClient proves (1) a GRS/RA-GRS/GZRS/RA-GZRS account reports a
+// secondary location/status/endpoints, an LRS account does not, and (2) a
+// customer-managed-key (Microsoft.Keyvault) encryption request is echoed
+// back consistently instead of always reporting the platform-managed
+// default.
+
+package storageaccount_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSDKAccountLRSHasNoSecondaryRegion proves a plain LRS account (the
+// default) reports no secondary location/status/endpoints — those fields
+// only apply to geo-redundant SKUs.
+func TestSDKAccountLRSHasNoSecondaryRegion(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acctlrs", armstorage.AccountCreateParameters{
+		Location: to.Ptr("eastus"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	got, err := client.GetProperties(ctx, "rg-1", "acctlrs", nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, got.Properties)
+	assert.Nil(t, got.Properties.SecondaryLocation)
+	assert.Nil(t, got.Properties.StatusOfSecondary)
+	assert.Nil(t, got.Properties.SecondaryEndpoints)
+}
+
+// TestSDKAccountGRSHasSecondaryRegion proves a GRS account reports its
+// secondary location and status, but — lacking read access — no secondary
+// endpoints.
+func TestSDKAccountGRSHasSecondaryRegion(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acctgrs", armstorage.AccountCreateParameters{
+		Location: to.Ptr("eastus"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardGRS)},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	got, err := client.GetProperties(ctx, "rg-1", "acctgrs", nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, got.Properties)
+	require.NotNil(t, got.Properties.SecondaryLocation)
+	assert.Equal(t, "westus", *got.Properties.SecondaryLocation)
+	require.NotNil(t, got.Properties.StatusOfSecondary)
+	assert.Equal(t, armstorage.AccountStatusAvailable, *got.Properties.StatusOfSecondary)
+	assert.Nil(t, got.Properties.SecondaryEndpoints, "plain GRS has no read-access secondary endpoints")
+}
+
+// TestSDKAccountRAGRSHasSecondaryEndpoints proves an RA-GRS account
+// additionally reports readable secondary endpoints, at the real "-secondary"
+// hostname convention.
+func TestSDKAccountRAGRSHasSecondaryEndpoints(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acctragrs", armstorage.AccountCreateParameters{
+		Location: to.Ptr("westeurope"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardRAGRS)},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	got, err := client.GetProperties(ctx, "rg-1", "acctragrs", nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, got.Properties)
+	require.NotNil(t, got.Properties.SecondaryLocation)
+	assert.Equal(t, "northeurope", *got.Properties.SecondaryLocation)
+	require.NotNil(t, got.Properties.SecondaryEndpoints)
+	require.NotNil(t, got.Properties.SecondaryEndpoints.Blob)
+	assert.Contains(t, *got.Properties.SecondaryEndpoints.Blob, "acctragrs-secondary.blob.core.windows.net")
+}
+
+// TestSDKAccountCMKEncryptionEchoed proves a customer-managed-key encryption
+// request survives create and an independent GET, instead of always
+// reporting the Microsoft.Storage platform default.
+func TestSDKAccountCMKEncryptionEchoed(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acctcmk", armstorage.AccountCreateParameters{
+		Location: to.Ptr("eastus"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+		Properties: &armstorage.AccountPropertiesCreateParameters{
+			Encryption: &armstorage.Encryption{
+				KeySource: to.Ptr(armstorage.KeySourceMicrosoftKeyvault),
+				KeyVaultProperties: &armstorage.KeyVaultProperties{
+					KeyVaultURI: to.Ptr("https://myvault.vault.azure.net"),
+					KeyName:     to.Ptr("mykey"),
+					KeyVersion:  to.Ptr("v1"),
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+	assertCMKEncryption(t, created.Properties)
+
+	got, err := client.GetProperties(ctx, "rg-1", "acctcmk", nil)
+	require.NoError(t, err)
+	assertCMKEncryption(t, got.Properties)
+}
+
+func assertCMKEncryption(t *testing.T, props *armstorage.AccountProperties) {
+	t.Helper()
+
+	require.NotNil(t, props)
+	require.NotNil(t, props.Encryption)
+	require.NotNil(t, props.Encryption.KeySource)
+	assert.Equal(t, armstorage.KeySourceMicrosoftKeyvault, *props.Encryption.KeySource)
+	require.NotNil(t, props.Encryption.KeyVaultProperties)
+	require.NotNil(t, props.Encryption.KeyVaultProperties.KeyVaultURI)
+	assert.Equal(t, "https://myvault.vault.azure.net", *props.Encryption.KeyVaultProperties.KeyVaultURI)
+	require.NotNil(t, props.Encryption.KeyVaultProperties.KeyName)
+	assert.Equal(t, "mykey", *props.Encryption.KeyVaultProperties.KeyName)
+}
+
+// TestSDKAccountDefaultEncryptionUnchanged proves an account created without
+// an encryption request still reports the platform-managed default — the CMK
+// fix must not regress the common case.
+func TestSDKAccountDefaultEncryptionUnchanged(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acctdefaultenc", armstorage.AccountCreateParameters{
+		Location: to.Ptr("eastus"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	got, err := client.GetProperties(ctx, "rg-1", "acctdefaultenc", nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, got.Properties)
+	require.NotNil(t, got.Properties.Encryption)
+	require.NotNil(t, got.Properties.Encryption.KeySource)
+	assert.Equal(t, armstorage.KeySourceMicrosoftStorage, *got.Properties.Encryption.KeySource)
+	assert.Nil(t, got.Properties.Encryption.KeyVaultProperties)
+}
+
+// TestSDKAccountUpdatePreservesEncryptionWhenOmitted proves a PATCH that
+// doesn't submit an encryption block leaves a previously configured
+// customer-managed key untouched — encryption lives in its own store
+// precisely so an unrelated PATCH (e.g. only changing tags) can't blindly
+// reset it.
+func TestSDKAccountUpdatePreservesEncryptionWhenOmitted(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acctcmkpatch", armstorage.AccountCreateParameters{
+		Location: to.Ptr("eastus"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+		Properties: &armstorage.AccountPropertiesCreateParameters{
+			Encryption: &armstorage.Encryption{
+				KeySource: to.Ptr(armstorage.KeySourceMicrosoftKeyvault),
+				KeyVaultProperties: &armstorage.KeyVaultProperties{
+					KeyVaultURI: to.Ptr("https://myvault.vault.azure.net"),
+					KeyName:     to.Ptr("mykey"),
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	_, err = client.Update(ctx, "rg-1", "acctcmkpatch", armstorage.AccountUpdateParameters{
+		Tags: map[string]*string{"env": to.Ptr("prod")},
+	}, nil)
+	require.NoError(t, err)
+
+	got, err := client.GetProperties(ctx, "rg-1", "acctcmkpatch", nil)
+	require.NoError(t, err)
+	assertCMKEncryption(t, got.Properties)
+	require.NotNil(t, got.Tags["env"])
+	assert.Equal(t, "prod", *got.Tags["env"])
+}

--- a/server/azure/storageaccount/account_update_test.go
+++ b/server/azure/storageaccount/account_update_test.go
@@ -1,0 +1,103 @@
+// Real-SDK round-trip test: the live azure-sdk-for-go armstorage
+// AccountsClient.Update (PATCH) drives the in-memory handler end-to-end,
+// proving a partial update changes only the submitted fields and leaves
+// everything else on the account untouched.
+
+package storageaccount_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSDKAccountUpdatePartial proves PATCH (previously a 405) applies a
+// non-destructive partial update: only the accessTier submitted in this call
+// changes, while the SKU/kind/location/tags from the original create survive.
+func TestSDKAccountUpdatePartial(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acctpatch", armstorage.AccountCreateParameters{
+		Location: to.Ptr("westus2"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+		Properties: &armstorage.AccountPropertiesCreateParameters{
+			AccessTier: to.Ptr(armstorage.AccessTierHot),
+		},
+		Tags: map[string]*string{"env": to.Ptr("prod")},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	updated, err := client.Update(ctx, "rg-1", "acctpatch", armstorage.AccountUpdateParameters{
+		Properties: &armstorage.AccountPropertiesUpdateParameters{
+			AccessTier: to.Ptr(armstorage.AccessTierCool),
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, updated.Properties)
+	require.NotNil(t, updated.Properties.AccessTier)
+	assert.Equal(t, armstorage.AccessTierCool, *updated.Properties.AccessTier)
+
+	// Everything the PATCH omitted must survive unchanged.
+	require.NotNil(t, updated.SKU)
+	assert.Equal(t, armstorage.SKUNameStandardLRS, *updated.SKU.Name)
+	require.NotNil(t, updated.Kind)
+	assert.Equal(t, armstorage.KindStorageV2, *updated.Kind)
+	require.NotNil(t, updated.Location)
+	assert.Equal(t, "westus2", *updated.Location)
+	require.NotNil(t, updated.Tags["env"])
+	assert.Equal(t, "prod", *updated.Tags["env"])
+
+	// ... and an independent GET agrees.
+	got, err := client.GetProperties(ctx, "rg-1", "acctpatch", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.Properties)
+	require.NotNil(t, got.Properties.AccessTier)
+	assert.Equal(t, armstorage.AccessTierCool, *got.Properties.AccessTier)
+	require.NotNil(t, got.SKU)
+	assert.Equal(t, armstorage.SKUNameStandardLRS, *got.SKU.Name)
+}
+
+// TestSDKAccountUpdateSKU proves PATCH can also change the SKU (a redundancy
+// upgrade, e.g. LRS -> GRS) while leaving accessTier/tags untouched.
+func TestSDKAccountUpdateSKU(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acctpatch2", armstorage.AccountCreateParameters{
+		Location: to.Ptr("eastus"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	updated, err := client.Update(ctx, "rg-1", "acctpatch2", armstorage.AccountUpdateParameters{
+		SKU: &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardGRS)},
+	}, nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, updated.SKU)
+	assert.Equal(t, armstorage.SKUNameStandardGRS, *updated.SKU.Name)
+}
+
+// TestSDKAccountUpdateMissing proves PATCH 404s on a nonexistent account,
+// matching create/get/delete.
+func TestSDKAccountUpdateMissing(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	_, err := client.Update(ctx, "rg-1", "nope", armstorage.AccountUpdateParameters{
+		Tags: map[string]*string{"env": to.Ptr("prod")},
+	}, nil)
+	require.Error(t, err)
+}

--- a/server/azure/storageaccount/blob_service_properties.go
+++ b/server/azure/storageaccount/blob_service_properties.go
@@ -1,0 +1,165 @@
+package storageaccount
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// serveBlobService serves the storage-account Blob service properties
+// sub-resource: GET/PUT …/storageAccounts/{name}/blobServices/default
+// (BlobServicesClient GetServiceProperties/SetServiceProperties). This is a
+// distinct account-level resource from the storage account itself — a PUT
+// here persists+echoes only the blob service properties and never touches
+// the account's SKU/kind/tags/encryption.
+func (h *Handler) serveBlobService(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodGet && r.Method != http.MethodPut {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	if h.blobSvc == nil {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented", "blob service properties not supported")
+		return
+	}
+
+	if !h.bucketExists(r.Context(), rp.ResourceName) {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound",
+			"storage account "+rp.ResourceName+" not found")
+		return
+	}
+
+	if r.Method == http.MethodPut {
+		var body armBlobServiceProperties
+		if !azurearm.DecodeJSON(w, r, &body) {
+			return
+		}
+
+		if err := h.blobSvc.SetBlobServiceProperties(r.Context(), rp.ResourceName, fromARMBlobServiceProperties(&body)); err != nil {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, h.toARMBlobServiceProperties(r.Context(), rp))
+}
+
+// toARMBlobServiceProperties reads the stored blob service properties back
+// through the driver and renders the ARM wire shape.
+func (h *Handler) toARMBlobServiceProperties(ctx context.Context, rp *azurearm.ResourcePath) armBlobServiceProperties {
+	props, _ := h.blobSvc.BlobServiceProperties(ctx, rp.ResourceName)
+
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, rp.ResourceName) +
+		"/blobServices/default"
+
+	return armBlobServiceProperties{
+		ID:         id,
+		Name:       "default",
+		Type:       providerName + "/" + resourceType + "/blobServices",
+		Properties: toARMBlobServicePropertiesProps(&props),
+	}
+}
+
+func toARMBlobServicePropertiesProps(props *storagedriver.BlobServiceProperties) *armBlobServicePropertiesProps {
+	versioning := props.IsVersioningEnabled
+	changeFeedEnabled := props.ChangeFeedEnabled
+	deleteRetentionEnabled := props.DeleteRetentionEnabled
+
+	out := &armBlobServicePropertiesProps{
+		IsVersioningEnabled:   &versioning,
+		ChangeFeed:            &armChangeFeed{Enabled: &changeFeedEnabled},
+		DeleteRetentionPolicy: &armDeleteRetention{Enabled: &deleteRetentionEnabled},
+		Cors:                  &armCorsRules{},
+	}
+
+	if props.ChangeFeedRetentionDays > 0 {
+		days := props.ChangeFeedRetentionDays
+		out.ChangeFeed.RetentionInDays = &days
+	}
+
+	if props.DeleteRetentionDays > 0 {
+		days := props.DeleteRetentionDays
+		out.DeleteRetentionPolicy.Days = &days
+	}
+
+	for _, rule := range props.CORS {
+		out.Cors.CorsRules = append(out.Cors.CorsRules, armCorsRule{
+			AllowedOrigins:  rule.AllowedOrigins,
+			AllowedMethods:  rule.AllowedMethods,
+			AllowedHeaders:  rule.AllowedHeaders,
+			ExposedHeaders:  rule.ExposeHeaders,
+			MaxAgeInSeconds: rule.MaxAgeSeconds,
+		})
+	}
+
+	return out
+}
+
+// fromARMBlobServiceProperties maps a PUT request body to the driver's
+// BlobServiceProperties. A missing element in the request clears the
+// corresponding setting (Azure's Set Blob Service Properties takes a
+// complete document each call, not a merge patch).
+func fromARMBlobServiceProperties(body *armBlobServiceProperties) storagedriver.BlobServiceProperties {
+	var props storagedriver.BlobServiceProperties
+	if body.Properties == nil {
+		return props
+	}
+
+	p := body.Properties
+
+	if p.IsVersioningEnabled != nil {
+		props.IsVersioningEnabled = *p.IsVersioningEnabled
+	}
+
+	applyARMChangeFeed(&props, p.ChangeFeed)
+	applyARMDeleteRetention(&props, p.DeleteRetentionPolicy)
+	applyARMCors(&props, p.Cors)
+
+	return props
+}
+
+func applyARMChangeFeed(props *storagedriver.BlobServiceProperties, cf *armChangeFeed) {
+	if cf == nil {
+		return
+	}
+
+	if cf.Enabled != nil {
+		props.ChangeFeedEnabled = *cf.Enabled
+	}
+
+	if cf.RetentionInDays != nil {
+		props.ChangeFeedRetentionDays = *cf.RetentionInDays
+	}
+}
+
+func applyARMDeleteRetention(props *storagedriver.BlobServiceProperties, dr *armDeleteRetention) {
+	if dr == nil {
+		return
+	}
+
+	if dr.Enabled != nil {
+		props.DeleteRetentionEnabled = *dr.Enabled
+	}
+
+	if dr.Days != nil {
+		props.DeleteRetentionDays = *dr.Days
+	}
+}
+
+func applyARMCors(props *storagedriver.BlobServiceProperties, cors *armCorsRules) {
+	if cors == nil {
+		return
+	}
+
+	for _, rule := range cors.CorsRules {
+		props.CORS = append(props.CORS, storagedriver.CORSRule{
+			AllowedOrigins: rule.AllowedOrigins,
+			AllowedMethods: rule.AllowedMethods,
+			AllowedHeaders: rule.AllowedHeaders,
+			ExposeHeaders:  rule.ExposedHeaders,
+			MaxAgeSeconds:  rule.MaxAgeInSeconds,
+		})
+	}
+}

--- a/server/azure/storageaccount/blob_service_properties_test.go
+++ b/server/azure/storageaccount/blob_service_properties_test.go
@@ -1,0 +1,189 @@
+// Real-SDK round-trip tests: the live azure-sdk-for-go armstorage
+// BlobServicesClient drives the in-memory handler end-to-end, proving the
+// blobServices/default sub-resource is a distinct resource from the storage
+// account itself (it must never fall through to the account create/update
+// handler and wipe the account's SKU/properties), and that Set/Get Blob
+// Service Properties round-trips versioning, change feed, soft delete, and
+// CORS.
+
+package storageaccount_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureprovider "github.com/stackshy/cloudemu/v2/providers/azure"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func newBlobServicesClient(t *testing.T, cloudP *azureprovider.Provider) *armstorage.BlobServicesClient {
+	t.Helper()
+
+	srv := azureserver.New(azureserver.Drivers{BlobStorage: cloudP.BlobStorage})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {
+				Endpoint: ts.URL,
+				Audience: "https://management.azure.com",
+			},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	client, err := armstorage.NewBlobServicesClient("sub-1", fakeCred{}, opts)
+	require.NoError(t, err)
+
+	return client
+}
+
+// TestSDKSetServicePropertiesDoesNotWipeAccount is the regression test for the
+// blocker bug: a PUT to blobServices/default (BlobServicesClient.
+// SetServiceProperties — the call the SDK/CLI use to enable blob versioning,
+// soft delete, CORS, or the change feed) was misrouted into the account
+// create/update handler and silently reset the account's SKU/kind/tags to
+// their zero-value defaults.
+func TestSDKSetServicePropertiesDoesNotWipeAccount(t *testing.T) {
+	ctx := context.Background()
+	// newAccountsClient/newBlobServicesClient each spin up their own TLS
+	// server; share the same underlying blob-storage provider so both point at
+	// the same account state.
+	cloudP := cloudemu.NewAzure()
+	accounts := newAccountsClientFor(t, cloudP)
+	blobServices := newBlobServicesClient(t, cloudP)
+
+	poller, err := accounts.BeginCreate(ctx, "rg-1", "acctblob", armstorage.AccountCreateParameters{
+		Location: to.Ptr("eastus"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNamePremiumLRS)},
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	_, err = blobServices.SetServiceProperties(ctx, "rg-1", "acctblob", armstorage.BlobServiceProperties{
+		BlobServiceProperties: &armstorage.BlobServicePropertiesProperties{
+			IsVersioningEnabled: to.Ptr(true),
+			ChangeFeed:          &armstorage.ChangeFeed{Enabled: to.Ptr(true)},
+			DeleteRetentionPolicy: &armstorage.DeleteRetentionPolicy{
+				Enabled: to.Ptr(true), Days: to.Ptr[int32](14),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	got, err := accounts.GetProperties(ctx, "rg-1", "acctblob", nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, got.SKU, "SetServiceProperties must not wipe the account's SKU")
+	assert.Equal(t, armstorage.SKUNamePremiumLRS, *got.SKU.Name)
+	require.NotNil(t, got.Kind)
+	assert.Equal(t, armstorage.KindStorageV2, *got.Kind)
+	require.NotNil(t, got.Tags["env"])
+	assert.Equal(t, "prod", *got.Tags["env"])
+}
+
+// TestSDKBlobServicePropertiesRoundTrip proves versioning/change-feed/soft-delete/
+// CORS submitted via SetServiceProperties survive an independent
+// GetServiceProperties call.
+func TestSDKBlobServicePropertiesRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+	accounts := newAccountsClientFor(t, cloudP)
+	blobServices := newBlobServicesClient(t, cloudP)
+
+	poller, err := accounts.BeginCreate(ctx, "rg-1", "acctblob2", armstorage.AccountCreateParameters{
+		Location: to.Ptr("eastus"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	set, err := blobServices.SetServiceProperties(ctx, "rg-1", "acctblob2", armstorage.BlobServiceProperties{
+		BlobServiceProperties: &armstorage.BlobServicePropertiesProperties{
+			IsVersioningEnabled: to.Ptr(true),
+			ChangeFeed:          &armstorage.ChangeFeed{Enabled: to.Ptr(true), RetentionInDays: to.Ptr[int32](30)},
+			DeleteRetentionPolicy: &armstorage.DeleteRetentionPolicy{
+				Enabled: to.Ptr(true), Days: to.Ptr[int32](7),
+			},
+			Cors: &armstorage.CorsRules{
+				CorsRules: []*armstorage.CorsRule{{
+					AllowedOrigins:  []*string{to.Ptr("*")},
+					AllowedMethods:  []*armstorage.CorsRuleAllowedMethodsItem{to.Ptr(armstorage.CorsRuleAllowedMethodsItemGET)},
+					AllowedHeaders:  []*string{to.Ptr("*")},
+					ExposedHeaders:  []*string{to.Ptr("*")},
+					MaxAgeInSeconds: to.Ptr[int32](3600),
+				}},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	assertBlobServiceProps(t, set.BlobServiceProperties)
+
+	got, err := blobServices.GetServiceProperties(ctx, "rg-1", "acctblob2", nil)
+	require.NoError(t, err)
+	assertBlobServiceProps(t, got.BlobServiceProperties)
+	assert.Contains(t, *got.ID, "/blobServices/default")
+}
+
+func assertBlobServiceProps(t *testing.T, props armstorage.BlobServiceProperties) {
+	t.Helper()
+
+	require.NotNil(t, props.BlobServiceProperties)
+	p := props.BlobServiceProperties
+
+	require.NotNil(t, p.IsVersioningEnabled)
+	assert.True(t, *p.IsVersioningEnabled)
+
+	require.NotNil(t, p.ChangeFeed)
+	require.NotNil(t, p.ChangeFeed.Enabled)
+	assert.True(t, *p.ChangeFeed.Enabled)
+	require.NotNil(t, p.ChangeFeed.RetentionInDays)
+	assert.EqualValues(t, 30, *p.ChangeFeed.RetentionInDays)
+
+	require.NotNil(t, p.DeleteRetentionPolicy)
+	require.NotNil(t, p.DeleteRetentionPolicy.Enabled)
+	assert.True(t, *p.DeleteRetentionPolicy.Enabled)
+	require.NotNil(t, p.DeleteRetentionPolicy.Days)
+	assert.EqualValues(t, 7, *p.DeleteRetentionPolicy.Days)
+
+	require.NotNil(t, p.Cors)
+	require.Len(t, p.Cors.CorsRules, 1)
+	assert.Equal(t, []*string{to.Ptr("*")}, p.Cors.CorsRules[0].AllowedOrigins)
+}
+
+// TestSDKGetServicePropertiesMissingAccount proves the sub-resource 404s like
+// real Azure when the parent storage account doesn't exist.
+func TestSDKGetServicePropertiesMissingAccount(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+	blobServices := newBlobServicesClient(t, cloudP)
+
+	_, err := blobServices.GetServiceProperties(ctx, "rg-1", "nope", nil)
+	require.Error(t, err)
+}

--- a/server/azure/storageaccount/handler.go
+++ b/server/azure/storageaccount/handler.go
@@ -13,7 +13,10 @@
 //
 //	PUT    .../providers/Microsoft.Storage/storageAccounts/{name} — create/update
 //	GET    .../providers/Microsoft.Storage/storageAccounts/{name} — get
+//	PATCH  .../providers/Microsoft.Storage/storageAccounts/{name} — partial update
 //	DELETE .../providers/Microsoft.Storage/storageAccounts/{name} — delete
+//	GET/PUT .../storageAccounts/{name}/blobServices/default — blob service properties
+//	                                       (versioning/soft-delete/change-feed/CORS)
 //
 // Create is a long-running operation in real Azure; the emulator completes it
 // synchronously by returning 200 with the resource body inline so the SDK's LRO
@@ -45,14 +48,21 @@ const (
 type attrBackend interface {
 	SetBucketAttributes(name string, attrs storagedriver.AccountAttributes)
 	BucketAttributes(ctx context.Context, bucket string) (storagedriver.AccountAttributes, error)
+	// UpdateBucketAttributes atomically applies fn to the stored attributes,
+	// backing the PATCH (AccountsClient.Update) partial-update handler.
+	UpdateBucketAttributes(
+		ctx context.Context, bucket string, fn func(storagedriver.AccountAttributes) storagedriver.AccountAttributes,
+	) (storagedriver.AccountAttributes, error)
 }
 
 // Handler serves Microsoft.Storage/storageAccounts ARM requests against a
 // storage bucket driver.
 type Handler struct {
-	bucket storagedriver.Bucket
-	attrs  attrBackend                      // nil when the driver doesn't expose account attributes
-	keys   storagedriver.StorageAccountKeys // nil when the driver doesn't expose access keys
+	bucket     storagedriver.Bucket
+	attrs      attrBackend                           // nil when the driver doesn't expose account attributes
+	keys       storagedriver.StorageAccountKeys      // nil when the driver doesn't expose access keys
+	blobSvc    storagedriver.BlobServiceConfig       // nil when the driver doesn't expose blob service properties
+	encryption storagedriver.AccountEncryptionConfig // nil when the driver doesn't expose account encryption
 }
 
 // New returns a storage-account handler backed by b.
@@ -64,6 +74,14 @@ func New(b storagedriver.Bucket) *Handler {
 
 	if k, ok := b.(storagedriver.StorageAccountKeys); ok {
 		h.keys = k
+	}
+
+	if bs, ok := b.(storagedriver.BlobServiceConfig); ok {
+		h.blobSvc = bs
+	}
+
+	if e, ok := b.(storagedriver.AccountEncryptionConfig); ok {
+		h.encryption = e
 	}
 
 	return h
@@ -99,6 +117,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// GET/PUT .../storageAccounts/{name}/blobServices/default —
+	// BlobServicesClient GetServiceProperties/SetServiceProperties. This is a
+	// distinct sub-resource from the account itself: it must never fall through
+	// to createOrUpdate, which would silently wipe the account's SKU/properties
+	// on every "enable versioning" call.
+	if strings.EqualFold(rp.SubResource, "blobServices") {
+		h.serveBlobService(w, r, &rp)
+		return
+	}
+
 	// POST .../storageAccounts/{name}/{action} — key management (listKeys,
 	// regenerateKey). These carry a sub-resource action segment.
 	if r.Method == http.MethodPost && rp.SubResource != "" {
@@ -111,6 +139,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.createOrUpdate(w, r, &rp)
 	case http.MethodGet:
 		h.get(w, r, &rp)
+	case http.MethodPatch:
+		h.update(w, r, &rp)
 	case http.MethodDelete:
 		h.deleteAccount(w, r, &rp)
 	default:
@@ -239,12 +269,22 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 		attrs.SKU = body.SKU.Name
 	}
 
+	var encryption storagedriver.AccountEncryption
+
 	if body.Properties != nil {
 		attrs.AccessTier = body.Properties.AccessTier
+		encryption = fromARMEncryptionReq(body.Properties.Encryption)
 	}
 
 	if h.attrs != nil {
 		h.attrs.SetBucketAttributes(name, attrs)
+	}
+
+	// Full-replace like the rest of the account attributes above: a create-or-
+	// update body with no encryption block resets to the platform-managed
+	// default, matching how SKU/kind/tags behave on this same call.
+	if h.encryption != nil {
+		h.encryption.SetAccountEncryption(name, encryption)
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), rp))
@@ -258,6 +298,70 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp *azurearm.Resou
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), rp))
+}
+
+// update serves PATCH …/storageAccounts/{name} (AccountsClient.Update),
+// applying a non-destructive partial update: only the fields present in the
+// request body (tags/sku/kind/accessTier/encryption) change, everything else
+// on the account is preserved. The mutation runs through attrBackend's atomic
+// UpdateBucketAttributes rather than a read-then-write pair, so a concurrent
+// PATCH never loses an update.
+func (h *Handler) update(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if !h.bucketExists(r.Context(), rp.ResourceName) {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound",
+			"storage account "+rp.ResourceName+" not found")
+		return
+	}
+
+	var body armAccountUpdate
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	if h.attrs != nil {
+		if _, err := h.attrs.UpdateBucketAttributes(r.Context(), rp.ResourceName, func(
+			cur storagedriver.AccountAttributes,
+		) storagedriver.AccountAttributes {
+			return applyAccountUpdate(cur, &body)
+		}); err != nil {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+	}
+
+	// Encryption lives in its own store (see AccountEncryptionConfig), so only
+	// touch it when the PATCH actually submitted an encryption block —
+	// otherwise a PATCH that only changes, say, tags would blindly reset any
+	// previously configured customer-managed key.
+	if h.encryption != nil && body.Properties != nil && body.Properties.Encryption != nil {
+		if enc := fromARMEncryptionReq(body.Properties.Encryption); enc.KeySource != "" {
+			h.encryption.SetAccountEncryption(rp.ResourceName, enc)
+		}
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), rp))
+}
+
+// applyAccountUpdate merges the fields present on a PATCH body onto cur,
+// leaving every field the request omitted untouched.
+func applyAccountUpdate(cur storagedriver.AccountAttributes, body *armAccountUpdate) storagedriver.AccountAttributes {
+	if body.Kind != "" {
+		cur.Kind = body.Kind
+	}
+
+	if body.SKU != nil && body.SKU.Name != "" {
+		cur.SKU = body.SKU.Name
+	}
+
+	if body.Tags != nil {
+		cur.Tags = body.Tags
+	}
+
+	if body.Properties != nil && body.Properties.AccessTier != "" {
+		cur.AccessTier = body.Properties.AccessTier
+	}
+
+	return cur
 }
 
 func (h *Handler) deleteAccount(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
@@ -300,23 +404,46 @@ func (h *Handler) toARMAccount(ctx context.Context, rp *azurearm.ResourcePath) a
 		location = defaultLocation
 	}
 
+	var encryption storagedriver.AccountEncryption
+	if h.encryption != nil {
+		if e, err := h.encryption.AccountEncryption(ctx, rp.ResourceName); err == nil {
+			encryption = e
+		}
+	}
+
+	props := &armAccountProps{
+		AccessTier:        attrs.AccessTier,
+		ProvisioningState: "Succeeded",
+		PrimaryLocation:   location,
+		StatusOfPrimary:   "available",
+		CreationTime:      h.accountCreatedAt(ctx, rp.ResourceName),
+		PrimaryEndpoints:  accountEndpoints(rp.ResourceName),
+		Encryption:        armEncryptionFor(encryption),
+	}
+
+	// GRS/RA-GRS/GZRS/RA-GZRS replicate to a documented paired region;
+	// secondaryEndpoints is only readable (and thus only reported) on the
+	// read-access (RA-*) variants — matching real Azure.
+	if skuIsGeoRedundant(attrs.SKU) {
+		if secondary := secondaryLocationFor(location); secondary != "" {
+			props.SecondaryLocation = secondary
+			props.StatusOfSecondary = "available"
+
+			if skuIsReadAccessGeoRedundant(attrs.SKU) {
+				props.SecondaryEndpoints = secondaryAccountEndpoints(rp.ResourceName)
+			}
+		}
+	}
+
 	return armAccount{
-		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, rp.ResourceName),
-		Name:     rp.ResourceName,
-		Type:     providerName + "/" + resourceType,
-		Location: location,
-		Kind:     attrs.Kind,
-		Tags:     attrs.Tags,
-		SKU:      &armSKU{Name: attrs.SKU, Tier: skuTier(attrs.SKU)},
-		Properties: &armAccountProps{
-			AccessTier:        attrs.AccessTier,
-			ProvisioningState: "Succeeded",
-			PrimaryLocation:   location,
-			StatusOfPrimary:   "available",
-			CreationTime:      h.accountCreatedAt(ctx, rp.ResourceName),
-			PrimaryEndpoints:  accountEndpoints(rp.ResourceName),
-			Encryption:        defaultEncryption(),
-		},
+		ID:         azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, rp.ResourceName),
+		Name:       rp.ResourceName,
+		Type:       providerName + "/" + resourceType,
+		Location:   location,
+		Kind:       attrs.Kind,
+		Tags:       attrs.Tags,
+		SKU:        &armSKU{Name: attrs.SKU, Tier: skuTier(attrs.SKU)},
+		Properties: props,
 	}
 }
 
@@ -330,8 +457,113 @@ func accountEndpoints(account string) *armEndpoints {
 	}
 }
 
+// secondaryAccountEndpoints builds the secondaryEndpoints service URLs a
+// read-access geo-redundant (RA-GRS/RA-GZRS) account reports: the real Azure
+// convention appends "-secondary" to the account name on the same domains.
+func secondaryAccountEndpoints(account string) *armEndpoints {
+	secondary := account + "-secondary"
+
+	return &armEndpoints{
+		Blob:  "https://" + secondary + ".blob.core.windows.net/",
+		Queue: "https://" + secondary + ".queue.core.windows.net/",
+		Table: "https://" + secondary + ".table.core.windows.net/",
+		File:  "https://" + secondary + ".file.core.windows.net/",
+	}
+}
+
+// skuIsGeoRedundant reports whether sku replicates to a secondary region
+// (Standard_GRS, Standard_RAGRS, Standard_GZRS, Standard_RAGZRS).
+func skuIsGeoRedundant(sku string) bool {
+	return strings.Contains(sku, "GRS") || strings.Contains(sku, "GZRS")
+}
+
+// skuIsReadAccessGeoRedundant reports whether sku additionally exposes its
+// secondary region for reads (the RA-GRS/RA-GZRS variants).
+func skuIsReadAccessGeoRedundant(sku string) bool {
+	return strings.Contains(sku, "RAGRS") || strings.Contains(sku, "RAGZRS")
+}
+
+// secondaryLocationFor returns the documented geo-replication partner region
+// for a primary location, or "" for a region with no listed pair. See
+// https://learn.microsoft.com/en-us/azure/reliability/regions-paired
+func secondaryLocationFor(location string) string {
+	pairs := map[string]string{
+		"eastus": "westus", "westus": "eastus",
+		"eastus2": "centralus", "centralus": "eastus2",
+		"westus2": "westcentralus", "westcentralus": "westus2",
+		"westus3":        "eastus",
+		"northcentralus": "southcentralus", "southcentralus": "northcentralus",
+		"canadacentral": "canadaeast", "canadaeast": "canadacentral",
+		"brazilsouth":        "southcentralus",
+		"northeurope":        "westeurope",
+		"westeurope":         "northeurope",
+		"uksouth":            "ukwest",
+		"ukwest":             "uksouth",
+		"germanywestcentral": "germanynorth",
+		"switzerlandnorth":   "switzerlandwest",
+		"swedencentral":      "swedensouth",
+		"norwayeast":         "norwaywest",
+		"japaneast":          "japanwest", "japanwest": "japaneast",
+		"koreacentral": "koreasouth", "koreasouth": "koreacentral",
+		"australiaeast": "australiasoutheast", "australiasoutheast": "australiaeast",
+		"centralindia": "southindia", "southindia": "centralindia",
+		"westindia":        "southindia",
+		"eastasia":         "southeastasia",
+		"southeastasia":    "eastasia",
+		"uaenorth":         "uaecentral",
+		"southafricanorth": "southafricawest",
+	}
+
+	return pairs[strings.ToLower(strings.ReplaceAll(location, " ", ""))]
+}
+
+// armEncryptionFor renders the account encryption response block: the
+// always-on platform-managed default (Microsoft.Storage), or, when the
+// account was created/updated with a customer-managed key, the
+// Microsoft.Keyvault key source and its key-vault properties — echoed back
+// exactly as requested instead of always reporting the platform default.
+func armEncryptionFor(enc storagedriver.AccountEncryption) *armEncryption {
+	if enc.KeySource != "Microsoft.Keyvault" {
+		return defaultEncryption()
+	}
+
+	svc := &armEncryptionService{Enabled: true, KeyType: "Account"}
+	e := &armEncryption{
+		KeySource: "Microsoft.Keyvault",
+		Services:  &armEncryptionServices{Blob: svc, File: svc},
+	}
+
+	if enc.KeyVaultURI != "" || enc.KeyName != "" || enc.KeyVersion != "" {
+		e.KeyVaultProperties = &armKeyVaultProperties{
+			KeyVaultURI: enc.KeyVaultURI,
+			KeyName:     enc.KeyName,
+			KeyVersion:  enc.KeyVersion,
+		}
+	}
+
+	return e
+}
+
+// fromARMEncryptionReq maps a create/update request's encryption block to the
+// driver's AccountEncryption. A nil or keySource-less request yields the zero
+// value, which armEncryptionFor renders as the platform-managed default.
+func fromARMEncryptionReq(req *armEncryptionReq) storagedriver.AccountEncryption {
+	if req == nil || req.KeySource == "" {
+		return storagedriver.AccountEncryption{}
+	}
+
+	enc := storagedriver.AccountEncryption{KeySource: req.KeySource}
+	if req.KeyVaultProperties != nil {
+		enc.KeyVaultURI = req.KeyVaultProperties.KeyVaultURI
+		enc.KeyName = req.KeyVaultProperties.KeyName
+		enc.KeyVersion = req.KeyVaultProperties.KeyVersion
+	}
+
+	return enc
+}
+
 // defaultEncryption returns the always-on service-side encryption block real
-// Azure storage accounts report.
+// Azure storage accounts report when no customer-managed key is configured.
 func defaultEncryption() *armEncryption {
 	svc := &armEncryptionService{Enabled: true, KeyType: "Account"}
 

--- a/server/azure/storageaccount/sdk_test.go
+++ b/server/azure/storageaccount/sdk_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stackshy/cloudemu/v2"
+	azureprovider "github.com/stackshy/cloudemu/v2/providers/azure"
 	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
 )
 
@@ -33,7 +34,16 @@ func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcor
 func newAccountsClient(t *testing.T) *armstorage.AccountsClient {
 	t.Helper()
 
-	cloudP := cloudemu.NewAzure()
+	return newAccountsClientFor(t, cloudemu.NewAzure())
+}
+
+// newAccountsClientFor builds an AccountsClient against a caller-supplied
+// provider, so a test can share one cloudemu.Azure (and its blob-storage
+// state) across an AccountsClient and a BlobServicesClient on independent TLS
+// servers/connections.
+func newAccountsClientFor(t *testing.T, cloudP *azureprovider.Provider) *armstorage.AccountsClient {
+	t.Helper()
+
 	srv := azureserver.New(azureserver.Drivers{BlobStorage: cloudP.BlobStorage})
 
 	ts := httptest.NewTLSServer(srv)

--- a/server/azure/storageaccount/types.go
+++ b/server/azure/storageaccount/types.go
@@ -4,15 +4,43 @@ package storageaccount
 // emulator reads. armstorage's AccountCreateParameters marshals to these JSON
 // field names.
 type armAccountCreate struct {
-	Location   string                 `json:"location,omitempty"`
-	Kind       string                 `json:"kind,omitempty"`
-	Tags       map[string]string      `json:"tags,omitempty"`
-	SKU        *armSKU                `json:"sku,omitempty"`
-	Properties *armAccountCreateProps `json:"properties,omitempty"`
+	Location   string              `json:"location,omitempty"`
+	Kind       string              `json:"kind,omitempty"`
+	Tags       map[string]string   `json:"tags,omitempty"`
+	SKU        *armSKU             `json:"sku,omitempty"`
+	Properties *armAccountPropsReq `json:"properties,omitempty"`
 }
 
-type armAccountCreateProps struct {
-	AccessTier string `json:"accessTier,omitempty"`
+// armAccountUpdate is the subset of the ARM storage-account PATCH body the
+// emulator reads. armstorage's AccountUpdateParameters marshals to these same
+// JSON field names (minus location, which a PATCH cannot change).
+type armAccountUpdate struct {
+	Kind       string              `json:"kind,omitempty"`
+	Tags       map[string]string   `json:"tags,omitempty"`
+	SKU        *armSKU             `json:"sku,omitempty"`
+	Properties *armAccountPropsReq `json:"properties,omitempty"`
+}
+
+// armAccountPropsReq is the settable subset of properties on a create or
+// update request body — shared because AccountPropertiesCreateParameters and
+// AccountPropertiesUpdateParameters marshal accessTier/encryption identically.
+type armAccountPropsReq struct {
+	AccessTier string            `json:"accessTier,omitempty"`
+	Encryption *armEncryptionReq `json:"encryption,omitempty"`
+}
+
+// armEncryptionReq is the request-side encryption block: keySource selects
+// Microsoft.Storage (platform-managed, the default) or Microsoft.Keyvault
+// (customer-managed key), in which case keyvaultproperties identifies the key.
+type armEncryptionReq struct {
+	KeySource          string               `json:"keySource,omitempty"`
+	KeyVaultProperties *armKeyVaultPropsReq `json:"keyvaultproperties,omitempty"`
+}
+
+type armKeyVaultPropsReq struct {
+	KeyVaultURI string `json:"keyvaulturi,omitempty"`
+	KeyName     string `json:"keyname,omitempty"`
+	KeyVersion  string `json:"keyversion,omitempty"`
 }
 
 // armSKU is the ARM sku shape (sku.name / sku.tier).
@@ -39,13 +67,19 @@ type armAccountList struct {
 }
 
 type armAccountProps struct {
-	AccessTier        string         `json:"accessTier,omitempty"`
-	ProvisioningState string         `json:"provisioningState,omitempty"`
-	PrimaryEndpoints  *armEndpoints  `json:"primaryEndpoints,omitempty"`
-	PrimaryLocation   string         `json:"primaryLocation,omitempty"`
-	StatusOfPrimary   string         `json:"statusOfPrimary,omitempty"`
-	CreationTime      string         `json:"creationTime,omitempty"`
-	Encryption        *armEncryption `json:"encryption,omitempty"`
+	AccessTier        string        `json:"accessTier,omitempty"`
+	ProvisioningState string        `json:"provisioningState,omitempty"`
+	PrimaryEndpoints  *armEndpoints `json:"primaryEndpoints,omitempty"`
+	PrimaryLocation   string        `json:"primaryLocation,omitempty"`
+	StatusOfPrimary   string        `json:"statusOfPrimary,omitempty"`
+	// SecondaryLocation/StatusOfSecondary are populated for GRS/RA-GRS/GZRS/
+	// RA-GZRS SKUs; SecondaryEndpoints only for the read-access (RA-*) variants
+	// — matching real Azure (see armstorage AccountProperties doc comments).
+	SecondaryLocation  string         `json:"secondaryLocation,omitempty"`
+	StatusOfSecondary  string         `json:"statusOfSecondary,omitempty"`
+	SecondaryEndpoints *armEndpoints  `json:"secondaryEndpoints,omitempty"`
+	CreationTime       string         `json:"creationTime,omitempty"`
+	Encryption         *armEncryption `json:"encryption,omitempty"`
 }
 
 // armEndpoints is the primaryEndpoints object (blob/queue/table/file service
@@ -57,11 +91,22 @@ type armEndpoints struct {
 	File  string `json:"file,omitempty"`
 }
 
-// armEncryption is the account encryption block: service-side encryption is
-// always on for Azure storage, keyed by Microsoft.Storage.
+// armEncryption is the account encryption response block: service-side
+// encryption is always on for Azure storage, keyed by either the
+// Microsoft.Storage platform default or a Microsoft.Keyvault customer-managed
+// key (in which case KeyVaultProperties identifies it).
 type armEncryption struct {
-	Services  *armEncryptionServices `json:"services,omitempty"`
-	KeySource string                 `json:"keySource,omitempty"`
+	Services           *armEncryptionServices `json:"services,omitempty"`
+	KeySource          string                 `json:"keySource,omitempty"`
+	KeyVaultProperties *armKeyVaultProperties `json:"keyvaultproperties,omitempty"`
+}
+
+// armKeyVaultProperties identifies the customer-managed key on a
+// Microsoft.Keyvault-encrypted account.
+type armKeyVaultProperties struct {
+	KeyVaultURI string `json:"keyvaulturi,omitempty"`
+	KeyName     string `json:"keyname,omitempty"`
+	KeyVersion  string `json:"keyversion,omitempty"`
 }
 
 type armEncryptionServices struct {
@@ -90,4 +135,43 @@ type armKey struct {
 // armRegenerateKey is the regenerateKey request body.
 type armRegenerateKey struct {
 	KeyName string `json:"keyName"`
+}
+
+// armBlobServiceProperties is the ARM wire shape for the storage-account Blob
+// service properties sub-resource (…/blobServices/default), returned by both
+// BlobServicesClient.SetServiceProperties and .GetServiceProperties.
+type armBlobServiceProperties struct {
+	ID         string                         `json:"id,omitempty"`
+	Name       string                         `json:"name,omitempty"`
+	Type       string                         `json:"type,omitempty"`
+	Properties *armBlobServicePropertiesProps `json:"properties,omitempty"`
+}
+
+type armBlobServicePropertiesProps struct {
+	IsVersioningEnabled   *bool               `json:"isVersioningEnabled,omitempty"`
+	ChangeFeed            *armChangeFeed      `json:"changeFeed,omitempty"`
+	DeleteRetentionPolicy *armDeleteRetention `json:"deleteRetentionPolicy,omitempty"`
+	Cors                  *armCorsRules       `json:"cors,omitempty"`
+}
+
+type armChangeFeed struct {
+	Enabled         *bool `json:"enabled,omitempty"`
+	RetentionInDays *int  `json:"retentionInDays,omitempty"`
+}
+
+type armDeleteRetention struct {
+	Enabled *bool `json:"enabled,omitempty"`
+	Days    *int  `json:"days,omitempty"`
+}
+
+type armCorsRules struct {
+	CorsRules []armCorsRule `json:"corsRules,omitempty"`
+}
+
+type armCorsRule struct {
+	AllowedOrigins  []string `json:"allowedOrigins,omitempty"`
+	AllowedMethods  []string `json:"allowedMethods,omitempty"`
+	AllowedHeaders  []string `json:"allowedHeaders,omitempty"`
+	ExposedHeaders  []string `json:"exposedHeaders,omitempty"`
+	MaxAgeInSeconds int      `json:"maxAgeInSeconds,omitempty"`
 }

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -51,6 +51,56 @@ type AccountAttributes struct {
 	Tags map[string]string
 }
 
+// AccountEncryption is the storage-account encryption configuration requested
+// on create/update (ARM Properties.Encryption): KeySource is
+// "Microsoft.Storage" (platform-managed, the default) or "Microsoft.Keyvault"
+// (customer-managed key), in which case KeyVaultURI/KeyName/KeyVersion
+// identify the CMK. A zero value means unset, which the handler renders as
+// the platform-managed default. Kept separate from AccountAttributes (rather
+// than a field on it) so that struct stays small enough to pass by value.
+type AccountEncryption struct {
+	KeySource   string
+	KeyVaultURI string
+	KeyName     string
+	KeyVersion  string
+}
+
+// AccountEncryptionConfig is an OPTIONAL Azure-specific capability,
+// discovered by type assertion (like BucketAttributes), that persists and
+// echoes back an account's service-side encryption configuration
+// (Properties.Encryption on create/update), so a customer-managed-key request
+// doesn't silently downgrade to the platform-managed default on the next GET.
+type AccountEncryptionConfig interface {
+	SetAccountEncryption(account string, enc AccountEncryption)
+	AccountEncryption(ctx context.Context, account string) (AccountEncryption, error)
+}
+
+// BlobServiceProperties are the storage-account-level Blob service settings
+// configured via Set/Get Blob Service Properties
+// (…/storageAccounts/{account}/blobServices/default): versioning, soft
+// delete, change feed, and CORS. Real Azure applies these once per storage
+// account, not per container — distinct from the per-bucket CORS/versioning
+// surface on the Bucket interface that S3/GCS also implement.
+type BlobServiceProperties struct {
+	IsVersioningEnabled bool
+	ChangeFeedEnabled   bool
+	// ChangeFeedRetentionDays is 0 for infinite retention (unset).
+	ChangeFeedRetentionDays int
+	DeleteRetentionEnabled  bool
+	// DeleteRetentionDays is 0 when unset.
+	DeleteRetentionDays int
+	CORS                []CORSRule
+}
+
+// BlobServiceConfig is an OPTIONAL Azure-specific capability, discovered by
+// type assertion (like BucketAttributes), that persists and echoes back the
+// account-level Blob service properties sub-resource. S3/GCS have no
+// equivalent and don't implement it.
+type BlobServiceConfig interface {
+	SetBlobServiceProperties(ctx context.Context, account string, props BlobServiceProperties) error
+	BlobServiceProperties(ctx context.Context, account string) (BlobServiceProperties, error)
+}
+
 // AccountKey is one access key of an Azure storage account (Microsoft.Storage
 // ListKeys / RegenerateKey). Value is a base64-encoded secret.
 type AccountKey struct {


### PR DESCRIPTION
## What

Fixes four Azure Storage Account ARM control-plane bugs found in a deep-sweep audit against the real `azure-sdk-for-go` `armstorage` client:

- **Blocker**: `BlobServicesClient.SetServiceProperties` (PUT `.../storageAccounts/{name}/blobServices/default` — the call used to enable blob versioning, soft delete, CORS, or the change feed) was misrouted into the account create/update handler, silently wiping the account's SKU/kind/tags on every call. `blobServices/default` is now routed to a dedicated sub-resource handler (GET+PUT) that persists and echoes the blob service properties without ever touching the account.
- **High**: `AccountsClient.Update` (PATCH) returned 405. It's now handled with a non-destructive partial update — only the submitted fields (tags/sku/kind/accessTier/encryption) change, routed through an atomic `memstore.Update` so a concurrent PATCH can't lose a write.
- **Medium**: GRS/RA-GRS/GZRS/RA-GZRS accounts never reported `secondaryLocation`/`statusOfSecondary`/`secondaryEndpoints`. These are now derived from a documented Azure paired-region table; `secondaryEndpoints` is reported only for the read-access (RA-*) SKUs, matching real Azure.
- **Medium**: A customer-managed-key (`Microsoft.Keyvault`) encryption request was ignored — `createOrUpdate` always hardcoded the `Microsoft.Storage` default in the response. The requested `keySource`/`keyVaultProperties` is now stored and echoed back consistently on GET.

## Why

These are all real bugs a normal SDK/CLI user would hit immediately: enabling blob versioning on a storage account is one of the most common Terraform/Bicep operations, and it was destroying the account's other settings. PATCH is the standard way to update a storage account and was completely broken. GRS/CMK are common production configurations whose responses didn't match what real Azure returns.

## How

- `services/storage/driver`: added `BlobServiceProperties`/`BlobServiceConfig` and `AccountEncryption`/`AccountEncryptionConfig` as optional Azure-specific capabilities (discovered by type assertion, same pattern as `BucketAttributes`), plus `UpdateBucketAttributes` for atomic partial updates.
- `providers/azure/blobstorage`: implements the new capabilities with their own `memstore.Store`s, each keyed by account name.
- `server/azure/storageaccount`: routes `blobServices/default` to a new handler file, adds the PATCH case, and derives secondary-region/CMK fields on GET.
- Regenerated `docs/coverage/` via `internal/coveragegen` for the new driver capabilities; ran `internal/compatgen` (exit 0, no docs/compat drift).

## Testing

New regression tests drive the in-memory handler with the real `azure-sdk-for-go` `armstorage` client against a live TLS server (`BlobServicesClient`, `AccountsClient.Update`, GRS/CMK round-trips), plus provider-level unit tests including a concurrency test proving no lost updates under `UpdateBucketAttributes`.

All gates green: `go build`, `go vet`, full `go test ./...` (0 failures), `-race` on the changed provider package, `golangci-lint` (0 new issues), `gofmt` clean, `compat/...` suite green.