### PR TITLE
fix(azure-sql): cascade-delete databases/pools on server delete, wire elastic pool membership

### DIFF
--- a/providers/azure/sql/databases.go
+++ b/providers/azure/sql/databases.go
@@ -20,6 +20,9 @@ func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 		return nil, cerrors.New(cerrors.InvalidArgument, "server and database name are required")
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	// A database is a child of a logical server: real Azure returns
 	// ParentResourceNotFound (404) when the server has not been created.
 	server, ok := m.clusters.Get(cfg.Server)
@@ -30,6 +33,10 @@ func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 	key := dbKey(cfg.Server, cfg.Name)
 	if _, ok := m.databases.Get(key); ok {
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "database %q already exists on server %q", cfg.Name, cfg.Server)
+	}
+
+	if err := m.requireElasticPool(cfg.Server, cfg.ElasticPoolID); err != nil {
+		return nil, err
 	}
 
 	skuName := cfg.SKUName
@@ -53,6 +60,7 @@ func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 		SKUName:       skuName,
 		SKUTier:       skuTier,
 		ZoneRedundant: cfg.ZoneRedundant,
+		ElasticPoolID: cfg.ElasticPoolID,
 	}
 	m.databases.Set(key, db)
 
@@ -63,6 +71,9 @@ func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 
 // GetDatabase returns a logical database, or NotFound.
 func (m *Mock) GetDatabase(_ context.Context, server, name string) (*rdsdriver.Database, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	db, ok := m.databases.Get(dbKey(server, name))
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "database %q not found on server %q", name, server)
@@ -76,6 +87,9 @@ func (m *Mock) GetDatabase(_ context.Context, server, name string) (*rdsdriver.D
 
 // ListDatabases returns every logical database on a server.
 func (m *Mock) ListDatabases(_ context.Context, server string) ([]rdsdriver.Database, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	out := []rdsdriver.Database{}
 
 	vals := m.databases.SortedValues()
@@ -92,6 +106,9 @@ func (m *Mock) ListDatabases(_ context.Context, server string) ([]rdsdriver.Data
 
 // DeleteDatabase removes a logical database, or returns NotFound.
 func (m *Mock) DeleteDatabase(_ context.Context, server, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if !m.databases.Delete(dbKey(server, name)) {
 		return cerrors.Newf(cerrors.NotFound, "database %q not found on server %q", name, server)
 	}

--- a/providers/azure/sql/databases_elasticpool_test.go
+++ b/providers/azure/sql/databases_elasticpool_test.go
@@ -1,0 +1,155 @@
+package sql
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// TestCreateDatabaseValidatesElasticPoolCapability is the Databases-capability
+// counterpart of TestCreateDatabaseValidatesElasticPool (which only exercises
+// the CreateInstance/RDS-shaped path). The ARM wire server backs
+// Microsoft.Sql/servers/databases with CreateDatabase, not CreateInstance, so
+// this is the path a real armsql client actually drives.
+func TestCreateDatabaseValidatesElasticPoolCapability(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustServer(t, m, "srv")
+
+	if _, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{
+		Server: "srv", Name: "db1", ElasticPoolID: "ghost-pool",
+	}); !cerrors.IsNotFound(err) {
+		t.Fatalf("CreateDatabase with unknown elastic pool: got %v, want NotFound", err)
+	}
+
+	if _, err := m.CreateElasticPool(ctx, rdsdriver.ElasticPoolConfig{Server: "srv", Name: "pool1"}); err != nil {
+		t.Fatalf("CreateElasticPool: %v", err)
+	}
+
+	db, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{
+		Server: "srv", Name: "db1", ElasticPoolID: "pool1",
+	})
+	if err != nil {
+		t.Fatalf("CreateDatabase with valid elastic pool: %v", err)
+	}
+
+	if db.ElasticPoolID != "pool1" {
+		t.Fatalf("ElasticPoolID not persisted on create: got %q, want pool1", db.ElasticPoolID)
+	}
+
+	// Round-trips on Get and List too, not just the create response.
+	got, err := m.GetDatabase(ctx, "srv", "db1")
+	if err != nil {
+		t.Fatalf("GetDatabase: %v", err)
+	}
+
+	if got.ElasticPoolID != "pool1" {
+		t.Fatalf("ElasticPoolID not echoed on Get: got %q, want pool1", got.ElasticPoolID)
+	}
+
+	list, err := m.ListDatabases(ctx, "srv")
+	if err != nil || len(list) != 1 || list[0].ElasticPoolID != "pool1" {
+		t.Fatalf("ElasticPoolID not echoed on List: %+v, err=%v", list, err)
+	}
+}
+
+// TestDatabaseElasticPoolMembershipBlocksDelete is the Databases-capability
+// counterpart of TestElasticPoolMembershipBlocksDelete: a pool populated via
+// CreateDatabase (what the ARM wire server actually calls) must block delete
+// the same way a pool populated via the legacy CreateInstance path does.
+// Before this fix DeleteElasticPool only inspected the Instance store, so a
+// pool full of wire-created databases could be deleted while non-empty.
+func TestDatabaseElasticPoolMembershipBlocksDelete(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustServer(t, m, "srv")
+
+	if _, err := m.CreateElasticPool(ctx, rdsdriver.ElasticPoolConfig{Server: "srv", Name: "pool"}); err != nil {
+		t.Fatalf("CreateElasticPool: %v", err)
+	}
+
+	poolID := "/subscriptions/x/resourceGroups/x/providers/Microsoft.Sql/servers/srv/elasticPools/pool"
+	if _, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{
+		Server: "srv", Name: "db1", ElasticPoolID: poolID,
+	}); err != nil {
+		t.Fatalf("CreateDatabase: %v", err)
+	}
+
+	if err := m.DeleteElasticPool(ctx, "srv", "pool"); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("DeleteElasticPool on non-empty pool: got %v, want FailedPrecondition", err)
+	}
+
+	if err := m.DeleteDatabase(ctx, "srv", "db1"); err != nil {
+		t.Fatalf("DeleteDatabase: %v", err)
+	}
+
+	if err := m.DeleteElasticPool(ctx, "srv", "pool"); err != nil {
+		t.Errorf("DeleteElasticPool on empty pool: %v", err)
+	}
+}
+
+// TestCascadeDeleteServerRemovesLogicalDatabases is the Databases-capability
+// counterpart of TestCascadeDeleteServer. Real Azure: "a logical container
+// with strong lifetime semantics - delete a server and it deletes its
+// databases and elastic pools"
+// (learn.microsoft.com/azure/azure-sql/database/logical-servers). Databases
+// created through the Databases capability (what the ARM wire server uses for
+// Microsoft.Sql/servers/databases) previously survived DeleteCluster, which
+// only cleared the legacy Instance store and firewall/vnet/elasticPool/
+// failoverGroup/AAD-admin children — never m.databases.
+func TestCascadeDeleteServerRemovesLogicalDatabases(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustServer(t, m, "srv1")
+
+	if _, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv1", Name: "db1"}); err != nil {
+		t.Fatalf("CreateDatabase db1: %v", err)
+	}
+
+	if _, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv1", Name: "db2"}); err != nil {
+		t.Fatalf("CreateDatabase db2: %v", err)
+	}
+
+	if _, err := m.CreateElasticPool(ctx, rdsdriver.ElasticPoolConfig{Server: "srv1", Name: "pool1"}); err != nil {
+		t.Fatalf("CreateElasticPool: %v", err)
+	}
+
+	if err := m.DeleteCluster(ctx, "srv1"); err != nil {
+		t.Fatalf("DeleteCluster: %v", err)
+	}
+
+	list, err := m.ListDatabases(ctx, "srv1")
+	if err != nil {
+		t.Fatalf("ListDatabases after server delete: %v", err)
+	}
+
+	if len(list) != 0 {
+		t.Fatalf("databases survived server delete: %+v", list)
+	}
+
+	if _, err := m.GetDatabase(ctx, "srv1", "db1"); !cerrors.IsNotFound(err) {
+		t.Fatalf("GetDatabase after server delete: got %v, want NotFound", err)
+	}
+
+	// ListElasticPools requires the server to exist, so its NotFound here
+	// confirms the server itself is gone; GetElasticPool confirms the pool
+	// specifically didn't survive under a since-recreated server below.
+	if _, err := m.ListElasticPools(ctx, "srv1"); !cerrors.IsNotFound(err) {
+		t.Fatalf("ListElasticPools after server delete: got %v, want NotFound", err)
+	}
+
+	// Re-creating the server and a same-named database afterward must not
+	// resurrect anything from the deleted server: the store starts clean.
+	mustServer(t, m, "srv1")
+
+	db, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv1", Name: "db1"})
+	if err != nil {
+		t.Fatalf("re-CreateDatabase db1: %v", err)
+	}
+
+	if db.ElasticPoolID != "" {
+		t.Fatalf("re-created database inherited stale ElasticPoolID: %q", db.ElasticPoolID)
+	}
+}

--- a/providers/azure/sql/sql.go
+++ b/providers/azure/sql/sql.go
@@ -558,35 +558,31 @@ func (m *Mock) DeleteCluster(_ context.Context, id string) error {
 	return nil
 }
 
-// deleteChildren removes the firewall rules, vnet rules, elastic pools,
-// failover groups and AAD admin belonging to server id, matching Azure's
-// cascade delete on server removal. The caller already holds the write lock.
+// deleteByPrefix removes every entry of store whose key starts with prefix.
+// Keys in every child store here are "{server}/{name}", so this is the shared
+// cascade primitive deleteChildren applies to each one.
+func deleteByPrefix[V any](store *memstore.Store[V], prefix string) {
+	for key := range store.All() {
+		if strings.HasPrefix(key, prefix) {
+			store.Delete(key)
+		}
+	}
+}
+
+// deleteChildren removes the logical databases, firewall rules, vnet rules,
+// elastic pools, failover groups and AAD admin belonging to server id,
+// matching Azure's cascade delete on server removal ("a logical container
+// with strong lifetime semantics - delete a server and it deletes its
+// databases and elastic pools": learn.microsoft.com/azure/azure-sql/database/
+// logical-servers). The caller already holds the write lock.
 func (m *Mock) deleteChildren(server string) {
 	prefix := server + "/"
 
-	for key := range m.firewallRules.All() {
-		if strings.HasPrefix(key, prefix) {
-			m.firewallRules.Delete(key)
-		}
-	}
-
-	for key := range m.vnetRules.All() {
-		if strings.HasPrefix(key, prefix) {
-			m.vnetRules.Delete(key)
-		}
-	}
-
-	for key := range m.elasticPools.All() {
-		if strings.HasPrefix(key, prefix) {
-			m.elasticPools.Delete(key)
-		}
-	}
-
-	for key := range m.failoverGroups.All() {
-		if strings.HasPrefix(key, prefix) {
-			m.failoverGroups.Delete(key)
-		}
-	}
+	deleteByPrefix(m.databases, prefix)
+	deleteByPrefix(m.firewallRules, prefix)
+	deleteByPrefix(m.vnetRules, prefix)
+	deleteByPrefix(m.elasticPools, prefix)
+	deleteByPrefix(m.failoverGroups, prefix)
 
 	m.aadAdmins.Delete(server)
 }

--- a/providers/azure/sql/subresources.go
+++ b/providers/azure/sql/subresources.go
@@ -45,16 +45,6 @@ const (
 
 func subKey(server, name string) string { return server + "/" + name }
 
-// elasticPoolName extracts the pool name from an elasticPoolId, which may be a
-// bare name or a full ARM resource ID ending in ".../elasticPools/{name}".
-func elasticPoolName(id string) string {
-	if i := strings.LastIndex(id, "/elasticPools/"); i >= 0 {
-		return id[i+len("/elasticPools/"):]
-	}
-
-	return id
-}
-
 // requireElasticPool returns NotFound when a non-empty elastic-pool reference
 // doesn't resolve to an existing pool on the server. Empty id is a no-op (a
 // standalone database). Callers hold the write lock.
@@ -63,7 +53,7 @@ func (m *Mock) requireElasticPool(server, poolID string) error {
 		return nil
 	}
 
-	name := elasticPoolName(poolID)
+	name := rdsdriver.ElasticPoolName(poolID)
 	if _, ok := m.elasticPools.Get(subKey(server, name)); !ok {
 		return cerrors.Newf(cerrors.NotFound, "elastic pool %q not found on server %q", name, server)
 	}

--- a/providers/azure/sql/subresources.go
+++ b/providers/azure/sql/subresources.go
@@ -356,8 +356,16 @@ func (m *Mock) ListElasticPools(_ context.Context, server string) ([]rdsdriver.E
 	return out, nil
 }
 
-// DeleteElasticPool removes an elastic pool. Like real Azure, it fails with a
-// precondition error while the pool still contains databases.
+// DeleteElasticPool removes an elastic pool. Like real Azure it refuses to
+// delete a non-empty pool (real Azure answers 400 ElasticPoolNotEmpty:
+// learn.microsoft.com/rest/api/sql/elastic-pools/delete — "Request to delete
+// an elastic pool that is not empty"; this codebase maps FailedPrecondition to
+// 409 for every driver, so the mock follows that convention here too).
+// Membership is checked against both the Databases capability (the store the
+// ARM wire server actually populates for Microsoft.Sql/servers/databases) and
+// the legacy Instance store (the RDS-shaped portable API), so a pool created
+// and populated purely over the wire is protected the same as one populated
+// via the portable API.
 func (m *Mock) DeleteElasticPool(_ context.Context, server, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -366,23 +374,40 @@ func (m *Mock) DeleteElasticPool(_ context.Context, server, name string) error {
 		return cerrors.Newf(cerrors.NotFound, "elastic pool %q not found", name)
 	}
 
-	suffix := "/elasticPools/" + name
-
-	insts := m.instances.SortedValues()
-	for i := range insts {
-		if insts[i].ClusterID != server {
-			continue
-		}
-
-		if insts[i].ElasticPoolID == name || strings.HasSuffix(insts[i].ElasticPoolID, suffix) {
-			return cerrors.Newf(cerrors.FailedPrecondition,
-				"elastic pool %q cannot be deleted while it contains databases", name)
-		}
+	if m.elasticPoolHasMembers(server, name) {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"elastic pool %q cannot be deleted while it contains databases", name)
 	}
 
 	m.elasticPools.Delete(subKey(server, name))
 
 	return nil
+}
+
+// elasticPoolHasMembers reports whether any database or instance on server
+// still references the named elastic pool. Callers hold m.mu.
+func (m *Mock) elasticPoolHasMembers(server, name string) bool {
+	suffix := "/elasticPools/" + name
+
+	inPool := func(poolID string) bool {
+		return poolID == name || strings.HasSuffix(poolID, suffix)
+	}
+
+	dbs := m.databases.SortedValues()
+	for i := range dbs {
+		if dbs[i].Server == server && inPool(dbs[i].ElasticPoolID) {
+			return true
+		}
+	}
+
+	insts := m.instances.SortedValues()
+	for i := range insts {
+		if insts[i].ClusterID == server && inPool(insts[i].ElasticPoolID) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // UpdateElasticPool applies the non-zero fields of cfg to an existing pool

--- a/server/azure/echo_properties.go
+++ b/server/azure/echo_properties.go
@@ -95,15 +95,32 @@ func echoUnmodeledProperties(next http.Handler, overlay *propertyOverlay) http.H
 
 // resourceIDFromPath reconstructs the ARM resource id from a request path so a
 // DELETE can evict the matching overlay entry (DELETE responses carry no body
-// to read the id from). Returns "" for a path that is not a single named
-// resource, in which case nothing is evicted.
+// to read the id from). Handles both a top-level resource
+// (.../{type}/{name}) and a named sub-resource one level down
+// (.../{type}/{name}/{subResource}/{subResourceName}, e.g. a SQL database
+// under its server) — the sub-resource id is built the same way the handlers
+// that create these resources build it (see server/azure/sql childID), so it
+// matches the "id" field the overlay was captured under. Returns "" for a path
+// that isn't a single named resource or named sub-resource, in which case
+// nothing is evicted — e.g. a bodiless action like .../failoverGroups/{n}/
+// failover carries a SubResourceAction and is left alone.
 func resourceIDFromPath(urlPath string) string {
 	rp, ok := azurearm.ParsePath(urlPath)
-	if !ok || rp.ResourceName == "" || rp.SubResource != "" {
+	if !ok || rp.ResourceName == "" {
 		return ""
 	}
 
-	return azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, rp.Provider, rp.ResourceType, rp.ResourceName)
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, rp.Provider, rp.ResourceType, rp.ResourceName)
+
+	if rp.SubResource == "" {
+		return id
+	}
+
+	if rp.SubResourceName == "" || rp.SubResourceAction != "" {
+		return ""
+	}
+
+	return id + "/" + rp.SubResource + "/" + rp.SubResourceName
 }
 
 // readRequestProperties returns the request body's top-level "properties"

--- a/server/azure/echo_properties_test.go
+++ b/server/azure/echo_properties_test.go
@@ -262,3 +262,71 @@ func bytesReader(t *testing.T, v map[string]any) *bytes.Reader {
 
 	return bytes.NewReader(raw)
 }
+
+// deleteOK sends a DELETE and requires a 2xx response; the overlay eviction
+// hook only fires on success, matching echoUnmodeledProperties.
+func deleteOK(t *testing.T, c *http.Client, url string) {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(resp.Body)
+		t.Fatalf("DELETE %s: status %d: %s", url, resp.StatusCode, data)
+	}
+}
+
+// TestEchoEvictsSubResourceOverlayOnDelete is the MEDIUM regression: deleting
+// a named sub-resource (a SQL database under its server) must evict its
+// overlay entry the same way deleting a top-level resource does. Before the
+// fix, resourceIDFromPath returned "" for any path with a SubResource, so
+// DELETE .../servers/{s}/databases/{d} never called overlay.evict — a
+// same-named database recreated afterward resurrected the previous
+// incarnation's unmodeled properties.
+func TestEchoEvictsSubResourceOverlayOnDelete(t *testing.T) {
+	ts, c := echoTestServer(t)
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Sql/servers/srv1"
+
+	putJSON(t, c, base+"?api-version=2021-11-01", map[string]any{"location": "eastus"})
+
+	dbURL := base + "/databases/db1?api-version=2021-11-01"
+
+	created := putJSON(t, c, dbURL, map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			// readScale is not modeled by the SQL database handler; the
+			// overlay is what makes it round-trip at all.
+			"readScale": "Enabled",
+		},
+	})
+
+	if props(t, created)["readScale"] != "Enabled" {
+		t.Fatal("unmodeled readScale was not preserved after create")
+	}
+
+	if props(t, getJSON(t, c, dbURL))["readScale"] != "Enabled" {
+		t.Fatal("unmodeled readScale not echoed on GET before delete")
+	}
+
+	deleteOK(t, c, dbURL)
+
+	// Re-create the same database name with no unmodeled properties at all.
+	recreated := putJSON(t, c, dbURL, map[string]any{"location": "eastus"})
+
+	if v, ok := props(t, recreated)["readScale"]; ok {
+		t.Fatalf("recreated database resurrected stale readScale from the deleted one: %v", v)
+	}
+
+	if v, ok := props(t, getJSON(t, c, dbURL))["readScale"]; ok {
+		t.Fatalf("GET on recreated database still carries the deleted database's readScale: %v", v)
+	}
+}

--- a/server/azure/sql/cascade_elasticpool_sdk_test.go
+++ b/server/azure/sql/cascade_elasticpool_sdk_test.go
@@ -176,3 +176,99 @@ func TestSDKAzureSQLDatabaseElasticPoolMembership(t *testing.T) {
 		t.Fatalf("pool delete PollUntilDone: %v", err)
 	}
 }
+
+// TestSDKAzureSQLDatabaseUpdateBadElasticPoolPreservesDatabase is the HIGH
+// regression: a PUT against an EXISTING database that references an
+// elasticPoolId which doesn't resolve must fail the request without deleting
+// the database. replaceDatabase upserts by deleting the stored record and
+// re-creating it merged with the request body — before the fix, the delete
+// ran first, so a bad pool reference on the re-create half permanently lost a
+// database that already existed.
+func TestSDKAzureSQLDatabaseUpdateBadElasticPoolPreservesDatabase(t *testing.T) {
+	cf := newFactory(t)
+	ctx := context.Background()
+	mustCreateSQLServer(t, cf)
+
+	dbs := cf.NewDatabasesClient()
+
+	createPoller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "keepme", armsql.Database{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("create PollUntilDone: %v", err)
+	}
+
+	// PUT again, attaching a pool that was never created on this server.
+	badPoller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "keepme", armsql.Database{
+		Location:   to.Ptr("eastus"),
+		Properties: &armsql.DatabaseProperties{ElasticPoolID: to.Ptr("ghost-pool")},
+	}, nil)
+	if err == nil {
+		_, err = badPoller.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("update with nonexistent elasticPoolId: expected error")
+	}
+
+	// The database must still exist — the rejected update must have no
+	// side effect, not have deleted it out from under the failed request.
+	got, err := dbs.Get(ctx, "rg-1", "srv1", "keepme", nil)
+	if err != nil {
+		t.Fatalf("Get after rejected update: expected database to survive, got error: %v", err)
+	}
+
+	if got.Database.Properties != nil && got.Database.Properties.ElasticPoolID != nil {
+		t.Errorf("surviving database carries the rejected elasticPoolId: %+v", got.Database.Properties)
+	}
+}
+
+// TestSDKAzureSQLDatabaseCreateBadElasticPoolNotParentNotFound is the MEDIUM
+// regression: creating a brand-new database on an EXISTING server with an
+// elasticPoolId that doesn't resolve must not be reported as
+// ParentResourceNotFound — that code means the parent SERVER is missing, and
+// here the server exists. Real Azure answers 400 TargetElasticPoolDoesNotExist
+// (learn.microsoft.com/rest/api/sql/databases/create-or-update).
+func TestSDKAzureSQLDatabaseCreateBadElasticPoolNotParentNotFound(t *testing.T) {
+	cf := newFactory(t)
+	ctx := context.Background()
+	mustCreateSQLServer(t, cf)
+
+	dbs := cf.NewDatabasesClient()
+
+	poller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "newdb", armsql.Database{
+		Location:   to.Ptr("eastus"),
+		Properties: &armsql.DatabaseProperties{ElasticPoolID: to.Ptr("ghost-pool")},
+	}, nil)
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	var re *azcore.ResponseError
+	if !errors.As(err, &re) {
+		t.Fatalf("create with nonexistent elasticPoolId: expected azcore.ResponseError, got %T: %v", err, err)
+	}
+
+	if re.ErrorCode == "ParentResourceNotFound" {
+		t.Errorf("error code = %q: the server exists, this must not be reported as a missing parent", re.ErrorCode)
+	}
+
+	if re.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", re.StatusCode)
+	}
+
+	if re.ErrorCode != "TargetElasticPoolDoesNotExist" {
+		t.Errorf("error code = %q, want TargetElasticPoolDoesNotExist", re.ErrorCode)
+	}
+
+	// The database must not have been created either.
+	if _, err := dbs.Get(ctx, "rg-1", "srv1", "newdb", nil); err == nil {
+		t.Error("Get newdb after failed create: expected NotFound")
+	} else if got := statusOf(t, err); got != http.StatusNotFound {
+		t.Errorf("Get newdb after failed create: status %d, want 404", got)
+	}
+}

--- a/server/azure/sql/cascade_elasticpool_sdk_test.go
+++ b/server/azure/sql/cascade_elasticpool_sdk_test.go
@@ -1,0 +1,178 @@
+package sql_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
+)
+
+// TestSDKAzureSQLServerDeleteCascadesDatabases is the BLOCKER regression: real
+// Azure documents the logical server as "a logical container with strong
+// lifetime semantics - delete a server and it deletes its databases and
+// elastic pools" (learn.microsoft.com/azure/azure-sql/database/logical-servers).
+// Before the fix, DeleteCluster left every database created via the
+// Databases capability (what a real armsql.DatabasesClient drives) orphaned in
+// the store, so it kept answering Get/List after the parent server was gone.
+func TestSDKAzureSQLServerDeleteCascadesDatabases(t *testing.T) {
+	cf := newFactory(t)
+	ctx := context.Background()
+	mustCreateSQLServer(t, cf)
+
+	dbs := cf.NewDatabasesClient()
+
+	for _, name := range []string{"db1", "db2"} {
+		poller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", name, armsql.Database{
+			Location: to.Ptr("eastus"),
+		}, nil)
+		if err != nil {
+			t.Fatalf("BeginCreateOrUpdate %s: %v", name, err)
+		}
+
+		if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("PollUntilDone %s: %v", name, err)
+		}
+	}
+
+	page, err := dbs.NewListByServerPager("rg-1", "srv1", nil).NextPage(ctx)
+	if err != nil {
+		t.Fatalf("List before delete: %v", err)
+	}
+
+	if len(page.Value) != 2 {
+		t.Fatalf("got %d databases before server delete, want 2", len(page.Value))
+	}
+
+	delPoller, err := cf.NewServersClient().BeginDelete(ctx, "rg-1", "srv1", nil)
+	if err != nil {
+		t.Fatalf("server BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("server delete PollUntilDone: %v", err)
+	}
+
+	// Each database must be gone too, not just unreachable via the deleted
+	// server's listing.
+	for _, name := range []string{"db1", "db2"} {
+		if _, err := dbs.Get(ctx, "rg-1", "srv1", name, nil); err == nil {
+			t.Errorf("Get %s after server delete: expected NotFound", name)
+		} else if got := statusOf(t, err); got != http.StatusNotFound {
+			t.Errorf("Get %s after server delete: status %d, want 404", name, got)
+		}
+	}
+
+	// Re-creating the server and a same-named database must start clean, not
+	// resurrect the deleted database's record.
+	mustCreateSQLServer(t, cf)
+
+	rePoller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "db1", armsql.Database{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("re-create db1 BeginCreateOrUpdate: %v", err)
+	}
+
+	reResp, err := rePoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("re-create db1 PollUntilDone: %v", err)
+	}
+
+	if reResp.Database.Properties == nil || reResp.Database.Properties.ElasticPoolID != nil {
+		t.Errorf("re-created db1 carries a stale elasticPoolId: %+v", reResp.Database.Properties)
+	}
+}
+
+// TestSDKAzureSQLDatabaseElasticPoolMembership is the HIGH regression: setting
+// databaseProperties.elasticPoolId through the Databases API must actually
+// bind the database to the pool (persisted + echoed on read), and the pool
+// must then refuse deletion while that database is still a member — matching
+// real Azure's ElasticPoolNotEmpty error
+// (learn.microsoft.com/rest/api/sql/elastic-pools/delete: "Request to delete
+// an elastic pool that is not empty").
+func TestSDKAzureSQLDatabaseElasticPoolMembership(t *testing.T) {
+	cf := newFactory(t)
+	ctx := context.Background()
+	mustCreateSQLServer(t, cf)
+
+	ep := cf.NewElasticPoolsClient()
+
+	epPoller, err := ep.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "pool1", armsql.ElasticPool{
+		Location: to.Ptr("eastus"),
+		SKU:      &armsql.SKU{Name: to.Ptr("StandardPool"), Tier: to.Ptr("Standard")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("pool BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := epPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("pool PollUntilDone: %v", err)
+	}
+
+	dbs := cf.NewDatabasesClient()
+
+	dbPoller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "pooleddb", armsql.Database{
+		Location:   to.Ptr("eastus"),
+		Properties: &armsql.DatabaseProperties{ElasticPoolID: to.Ptr("pool1")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("db BeginCreateOrUpdate: %v", err)
+	}
+
+	dbResp, err := dbPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("db PollUntilDone: %v", err)
+	}
+
+	if dbResp.Database.Properties == nil || dbResp.Database.Properties.ElasticPoolID == nil ||
+		*dbResp.Database.Properties.ElasticPoolID != "pool1" {
+		t.Fatalf("elasticPoolId not echoed on create: %+v", dbResp.Database.Properties)
+	}
+
+	got, err := dbs.Get(ctx, "rg-1", "srv1", "pooleddb", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Database.Properties == nil || got.Database.Properties.ElasticPoolID == nil ||
+		*got.Database.Properties.ElasticPoolID != "pool1" {
+		t.Fatalf("elasticPoolId not persisted: %+v", got.Database.Properties)
+	}
+
+	// A pool with a member database refuses deletion.
+	if _, err := ep.BeginDelete(ctx, "rg-1", "srv1", "pool1", nil); err == nil {
+		t.Error("delete non-empty pool: expected error")
+	} else {
+		var re *azcore.ResponseError
+		if !errors.As(err, &re) {
+			t.Fatalf("expected azcore.ResponseError, got %T: %v", err, err)
+		}
+
+		if re.StatusCode != http.StatusConflict {
+			t.Errorf("delete non-empty pool: status %d, want 409", re.StatusCode)
+		}
+	}
+
+	// Once the member database is gone, the pool deletes cleanly.
+	delDBPoller, err := dbs.BeginDelete(ctx, "rg-1", "srv1", "pooleddb", nil)
+	if err != nil {
+		t.Fatalf("db BeginDelete: %v", err)
+	}
+
+	if _, err := delDBPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("db delete PollUntilDone: %v", err)
+	}
+
+	delPoolPoller, err := ep.BeginDelete(ctx, "rg-1", "srv1", "pool1", nil)
+	if err != nil {
+		t.Fatalf("pool BeginDelete after db removed: %v", err)
+	}
+
+	if _, err := delPoolPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("pool delete PollUntilDone: %v", err)
+	}
+}

--- a/server/azure/sql/operations.go
+++ b/server/azure/sql/operations.go
@@ -135,6 +135,8 @@ func dbCfgFromBody(body *armDatabase, rp *azurearm.ResourcePath) rdsdriver.Datab
 
 	if body.Properties != nil {
 		cfg.Collation = body.Properties.Collation
+		cfg.ElasticPoolID = body.Properties.ElasticPoolID
+
 		if body.Properties.ZoneRedundant != nil {
 			cfg.ZoneRedundant = *body.Properties.ZoneRedundant
 		}
@@ -180,18 +182,13 @@ func (*Handler) putDatabase(w http.ResponseWriter, r *http.Request, rp *azurearm
 	azurearm.WriteJSON(w, http.StatusOK, toARMDatabase(out, rp))
 }
 
-// replaceDatabase merges the request body over the stored database and
-// re-creates it, so a PUT/PATCH against an existing database changes sku/tier/
-// HA while leaving omitted fields intact.
-func replaceDatabase(
-	ctx context.Context, db rdsdriver.Databases, body *armDatabase, cfg *rdsdriver.DatabaseConfig,
-) (*rdsdriver.Database, error) {
-	existing, err := db.GetDatabase(ctx, cfg.Server, cfg.Name)
-	if err != nil {
-		return nil, err
-	}
-
+// mergeDatabaseFields overlays the non-empty fields of cfg (and body's
+// pointer-only properties) onto existing, leaving fields the request omitted
+// untouched. Split out of replaceDatabase to keep that function's
+// cyclomatic complexity down — this is pure field merging, no I/O.
+func mergeDatabaseFields(existing *rdsdriver.Database, body *armDatabase, cfg *rdsdriver.DatabaseConfig) rdsdriver.Database {
 	merged := *existing
+
 	if cfg.SKUName != "" {
 		merged.SKUName = cfg.SKUName
 	}
@@ -212,9 +209,29 @@ func replaceDatabase(
 		merged.Tags = cfg.Tags
 	}
 
+	if cfg.ElasticPoolID != "" {
+		merged.ElasticPoolID = cfg.ElasticPoolID
+	}
+
 	if body.Properties != nil && body.Properties.ZoneRedundant != nil {
 		merged.ZoneRedundant = *body.Properties.ZoneRedundant
 	}
+
+	return merged
+}
+
+// replaceDatabase merges the request body over the stored database and
+// re-creates it, so a PUT/PATCH against an existing database changes sku/tier/
+// HA while leaving omitted fields intact.
+func replaceDatabase(
+	ctx context.Context, db rdsdriver.Databases, body *armDatabase, cfg *rdsdriver.DatabaseConfig,
+) (*rdsdriver.Database, error) {
+	existing, err := db.GetDatabase(ctx, cfg.Server, cfg.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := mergeDatabaseFields(existing, body, cfg)
 
 	if err := db.DeleteDatabase(ctx, cfg.Server, cfg.Name); err != nil {
 		return nil, err
@@ -230,6 +247,7 @@ func replaceDatabase(
 		SKUName:       merged.SKUName,
 		SKUTier:       merged.SKUTier,
 		ZoneRedundant: merged.ZoneRedundant,
+		ElasticPoolID: merged.ElasticPoolID,
 	})
 }
 

--- a/server/azure/sql/operations.go
+++ b/server/azure/sql/operations.go
@@ -149,7 +149,7 @@ func dbCfgFromBody(body *armDatabase, rp *azurearm.ResourcePath) rdsdriver.Datab
 // absent, otherwise apply the body's sku/tier/zoneRedundant to the existing
 // record. The Databases capability has no update verb, so an upsert merges the
 // body over the stored fields and re-creates.
-func (*Handler) putDatabase(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db rdsdriver.Databases) {
+func (h *Handler) putDatabase(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db rdsdriver.Databases) {
 	var body armDatabase
 	if !azurearm.DecodeJSON(w, r, &body) {
 		return
@@ -158,28 +158,54 @@ func (*Handler) putDatabase(w http.ResponseWriter, r *http.Request, rp *azurearm
 	cfg := dbCfgFromBody(&body, rp)
 
 	out, err := db.CreateDatabase(r.Context(), cfg)
-	if err != nil {
-		if cerrors.IsNotFound(err) {
-			// The only NotFound CreateDatabase raises is a missing parent server;
-			// real Azure answers 404 ParentResourceNotFound for a child under an
-			// absent parent.
-			azurearm.WriteParentNotFound(w, err)
-			return
-		}
-
-		if !cerrors.IsAlreadyExists(err) {
-			azurearm.WriteCErr(w, err)
-			return
-		}
-
-		out, err = replaceDatabase(r.Context(), db, &body, &cfg)
-		if err != nil {
-			azurearm.WriteCErr(w, err)
-			return
-		}
+	if err == nil {
+		azurearm.WriteJSON(w, http.StatusOK, toARMDatabase(out, rp))
+		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toARMDatabase(out, rp))
+	if cerrors.IsNotFound(err) {
+		// CreateDatabase raises NotFound for two distinct causes: a missing
+		// parent server, or (once the server exists) an elasticPoolId that
+		// doesn't resolve to a pool on it. Disambiguate by server existence.
+		h.writeDatabaseNotFound(r.Context(), w, rp.ResourceName, err)
+		return
+	}
+
+	if !cerrors.IsAlreadyExists(err) {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out, err = replaceDatabase(r.Context(), db, &body, &cfg)
+	if err == nil {
+		azurearm.WriteJSON(w, http.StatusOK, toARMDatabase(out, rp))
+		return
+	}
+
+	if cerrors.IsNotFound(err) {
+		// Same disambiguation as above: replaceDatabase's own elastic-pool
+		// pre-check also raises NotFound.
+		h.writeDatabaseNotFound(r.Context(), w, rp.ResourceName, err)
+		return
+	}
+
+	azurearm.WriteCErr(w, err)
+}
+
+// writeDatabaseNotFound distinguishes the two NotFound causes a database
+// create/replace can raise: a missing parent server (real Azure answers 404
+// ParentResourceNotFound for a child under an absent parent) vs an existing
+// server whose referenced elastic pool doesn't exist (real Azure answers 400
+// TargetElasticPoolDoesNotExist — see
+// https://learn.microsoft.com/en-us/rest/api/sql/databases/create-or-update).
+func (h *Handler) writeDatabaseNotFound(ctx context.Context, w http.ResponseWriter, server string, err error) {
+	clusters, dErr := h.db.DescribeClusters(ctx, []string{server})
+	if dErr != nil || len(clusters) == 0 {
+		azurearm.WriteParentNotFound(w, err)
+		return
+	}
+
+	azurearm.WriteError(w, http.StatusBadRequest, "TargetElasticPoolDoesNotExist", err.Error())
 }
 
 // mergeDatabaseFields overlays the non-empty fields of cfg (and body's
@@ -223,6 +249,12 @@ func mergeDatabaseFields(existing *rdsdriver.Database, body *armDatabase, cfg *r
 // replaceDatabase merges the request body over the stored database and
 // re-creates it, so a PUT/PATCH against an existing database changes sku/tier/
 // HA while leaving omitted fields intact.
+//
+// The merged elasticPoolId is validated before DeleteDatabase runs: a request
+// that references a nonexistent pool must fail the update with no side
+// effect, not delete the database out from under a bad request (CreateDatabase
+// re-validates the pool too, but only after the delete below would already
+// have happened).
 func replaceDatabase(
 	ctx context.Context, db rdsdriver.Databases, body *armDatabase, cfg *rdsdriver.DatabaseConfig,
 ) (*rdsdriver.Database, error) {
@@ -232,6 +264,10 @@ func replaceDatabase(
 	}
 
 	merged := mergeDatabaseFields(existing, body, cfg)
+
+	if err := requireElasticPool(ctx, db, cfg.Server, merged.ElasticPoolID); err != nil {
+		return nil, err
+	}
 
 	if err := db.DeleteDatabase(ctx, cfg.Server, cfg.Name); err != nil {
 		return nil, err
@@ -249,6 +285,26 @@ func replaceDatabase(
 		ZoneRedundant: merged.ZoneRedundant,
 		ElasticPoolID: merged.ElasticPoolID,
 	})
+}
+
+// requireElasticPool returns NotFound when a non-empty elastic-pool reference
+// doesn't resolve to an existing pool on the server. Empty id is a no-op (a
+// standalone database). Mirrors the provider-level check CreateDatabase
+// applies, so replaceDatabase can fail before mutating anything instead of
+// only after CreateDatabase re-validates on the re-create half of the upsert.
+func requireElasticPool(ctx context.Context, db rdsdriver.Databases, server, poolID string) error {
+	if poolID == "" {
+		return nil
+	}
+
+	pools, ok := db.(rdsdriver.ElasticPools)
+	if !ok {
+		return nil
+	}
+
+	_, err := pools.GetElasticPool(ctx, server, rdsdriver.ElasticPoolName(poolID))
+
+	return err
 }
 
 func (*Handler) getDatabase(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db rdsdriver.Databases) {

--- a/server/azure/sql/types.go
+++ b/server/azure/sql/types.go
@@ -102,6 +102,7 @@ func toARMDatabase(db *rdsdriver.Database, rp *azurearm.ResourcePath) armDatabas
 			CurrentServiceObjectiveName: db.SKUName,
 			CurrentSKU:                  &armSKU{Name: db.SKUName, Tier: db.SKUTier},
 			ZoneRedundant:               &zoneRedundant,
+			ElasticPoolID:               db.ElasticPoolID,
 		},
 	}
 }

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -7,6 +7,7 @@ package driver
 
 import (
 	"context"
+	"strings"
 	"time"
 )
 
@@ -590,6 +591,20 @@ type ElasticPools interface {
 	GetElasticPool(ctx context.Context, server, name string) (*ElasticPool, error)
 	ListElasticPools(ctx context.Context, server string) ([]ElasticPool, error)
 	DeleteElasticPool(ctx context.Context, server, name string) error
+}
+
+// ElasticPoolName extracts the pool name from an elasticPoolId, which may be
+// a bare name or a full ARM resource ID ending in ".../elasticPools/{name}".
+// Shared by the provider (which owns the pool store) and the wire server
+// (which must validate a pool reference before mutating a database), so the
+// two never parse the id differently.
+func ElasticPoolName(id string) string {
+	const marker = "/elasticPools/"
+	if i := strings.LastIndex(id, marker); i >= 0 {
+		return id[i+len(marker):]
+	}
+
+	return id
 }
 
 // FailoverGroupConfig describes a failover group to create (Azure SQL).

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -423,6 +423,10 @@ type DatabaseConfig struct {
 	SKUName       string
 	SKUTier       string
 	ZoneRedundant bool
+	// ElasticPoolID is the Azure SQL elastic pool this database belongs to (a
+	// bare pool name or a full ARM resource ID); empty for a standalone
+	// database. Set via properties.elasticPoolId on the ARM request body.
+	ElasticPoolID string
 }
 
 // Database is a logical database hosted by a managed server (Azure MySQL /
@@ -442,6 +446,9 @@ type Database struct {
 	SKUName       string
 	SKUTier       string
 	ZoneRedundant bool
+	// ElasticPoolID echoes the elastic pool this database belongs to on read
+	// (properties.elasticPoolId); empty for a standalone database.
+	ElasticPoolID string
 }
 
 // Databases is an OPTIONAL capability for managing the logical databases inside


### PR DESCRIPTION
## Summary

Azure SQL fixes, verified against real Azure semantics (Microsoft Learn cited inline):

- **BLOCKER** — deleting a SQL logical server did not cascade-delete its databases. `DeleteCluster`/`deleteChildren` only cleared the legacy Instance-shaped store; the `Databases` capability store (what the ARM wire server actually populates for `Microsoft.Sql/servers/databases`, and the only path a real `armsql` client drives) was never touched, so databases and elastic pools survived server deletion. Real Azure: "a logical container with strong lifetime semantics - delete a server and it deletes its databases and elastic pools" ([learn.microsoft.com/azure/azure-sql/database/logical-servers](https://learn.microsoft.com/en-us/azure/azure-sql/database/logical-servers?view=azuresql)).
- **HIGH** — elastic pool membership set via the Databases API was cosmetic. `properties.elasticPoolId` was parsed and then discarded; the pool-membership guard on `DeleteElasticPool` only inspected the legacy Instance store, which the wire layer never populates for databases. Added `ElasticPoolID` to `services/relationaldb/driver`'s `DatabaseConfig`/`Database`, threaded it through create/get/list and the ARM JSON layer, validated it against an existing pool on create, and extended the delete guard to check both the `Databases` and Instance stores (409, matching this codebase's `FailedPrecondition` convention — real Azure documents `400 ElasticPoolNotEmpty`: [learn.microsoft.com/rest/api/sql/elastic-pools/delete](https://learn.microsoft.com/en-us/rest/api/sql/elastic-pools/delete)).
- **MEDIUM** — deleting a database sub-resource didn't evict its unmodeled-property overlay. `resourceIDFromPath` (`server/azure/echo_properties.go`) only built an eviction id for top-level resources, so `DELETE .../servers/{s}/databases/{d}` never evicted the overlay entry; a same-named recreate resurrected the previous incarnation's stale properties. Generalized to also evict named sub-resources.
- **DEFERRED** — Transparent Data Encryption (separate feature, wire-routing depth change).

Also fixed a pre-existing gap while touching `CreateDatabase`/`GetDatabase`/`ListDatabases`/`DeleteDatabase`: they held no lock at all, so the new elastic-pool-membership check-then-write is now atomic under `m.mu`, consistent with the rest of the package.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./providers/azure/... ./server/azure/... ./services/...`
- [x] `go test -race ./providers/azure/sql/... ./server/azure/ ./server/azure/sql/...`
- [x] `go test ./...` (full suite)
- [x] `go test ./compat/...`
- [x] `golangci-lint` on changed packages — zero new issues
- [x] `gofmt -l` clean
- [x] `go run ./internal/coveragegen` — no diff (driver method set unchanged, only struct fields added)
- [x] New `armsql`-vs-live-TLS-server regression tests: server-delete cascades databases (and a same-named recreate doesn't inherit stale state), elastic pool membership round-trips and blocks non-empty delete with 409
- [x] New provider-level unit tests for the same behaviors plus the property-overlay eviction regression