### PR TITLE
fix(azure-vm): attach VM storageProfile.dataDisks to real managed disks

### DIFF
--- a/server/azure/disks/handler.go
+++ b/server/azure/disks/handler.go
@@ -30,6 +30,15 @@ const (
 	sourceIDTag     = "cloudemu:sourceResourceId"
 	defaultLocation = "eastus"
 
+	// vmARMNameTag mirrors the constant in server/azure/virtualmachines so a
+	// disk's AttachedTo (a driver compute instance ID) can be resolved to the
+	// attaching VM's ARM resource ID for the disk's managedBy field.
+	vmARMNameTag = "cloudemu:azureName"
+
+	// vmResourceType is the ARM resource type of the VM a disk's managedBy
+	// field points at.
+	vmResourceType = "virtualMachines"
+
 	// createOptionEmpty is the default disk createOption (an empty disk).
 	createOptionEmpty = "Empty"
 
@@ -214,7 +223,7 @@ func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp azu
 		name := tagOr(vols[i].Tags, armNameTag, vols[i].ID)
 		scope := rp
 		scope.ResourceName = name
-		out = append(out, toDiskResponse(&vols[i], scope, ""))
+		out = append(out, h.toDiskResponse(r.Context(), &vols[i], scope, ""))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, diskListResponse{Value: out})
@@ -266,7 +275,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		location = defaultLocation
 	}
 
-	body := toDiskResponse(vol, rp, location)
+	body := h.toDiskResponse(r.Context(), vol, rp, location)
 	body.SKU = req.SKU
 
 	writeDiskAsync(w, r, rp.Subscription, "disk-create-"+rp.ResourceName, body)
@@ -345,7 +354,7 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.Resour
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toDiskResponse(vol, rp, ""))
+	azurearm.WriteJSON(w, http.StatusOK, h.toDiskResponse(r.Context(), vol, rp, ""))
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -416,7 +425,9 @@ func writeDiskAsync(w http.ResponseWriter, r *http.Request, sub, opID string, bo
 // toDiskResponse maps a driver VolumeInfo to an ARM disk JSON body.
 //
 //nolint:gocritic // rp is a request-scoped value
-func toDiskResponse(vol *computedriver.VolumeInfo, rp azurearm.ResourcePath, location string) diskResponse {
+func (h *Handler) toDiskResponse(
+	ctx context.Context, vol *computedriver.VolumeInfo, rp azurearm.ResourcePath, location string,
+) diskResponse {
 	if location == "" {
 		location = defaultLocation
 	}
@@ -436,12 +447,13 @@ func toDiskResponse(vol *computedriver.VolumeInfo, rp azurearm.ResourcePath, loc
 	}
 
 	return diskResponse{
-		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, name),
-		Name:     name,
-		Type:     providerName + "/" + resourceType,
-		Location: location,
-		SKU:      sku,
-		Tags:     stripInternalDiskTags(vol.Tags),
+		ID:        azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, name),
+		Name:      name,
+		Type:      providerName + "/" + resourceType,
+		Location:  location,
+		SKU:       sku,
+		ManagedBy: h.managedByID(ctx, rp.Subscription, vol.AttachedTo),
+		Tags:      stripInternalDiskTags(vol.Tags),
 		Properties: diskResponseProps{
 			ProvisioningState: "Succeeded",
 			DiskSizeGB:        vol.Size,
@@ -454,6 +466,29 @@ func toDiskResponse(vol *computedriver.VolumeInfo, rp azurearm.ResourcePath, loc
 			UniqueID:          diskUniqueID(vol.ID),
 		},
 	}
+}
+
+// managedByID resolves a disk's AttachedTo (a driver compute instance ID) to
+// the ARM resource ID of the VM it is attached to, for the disk's managedBy
+// field (armcompute.Disk.ManagedBy: "a relative URI containing the ID of the
+// VM that has the disk attached"). Returns "" when the disk is unattached or
+// the attaching instance can't be resolved to an ARM VM name.
+func (h *Handler) managedByID(ctx context.Context, subscription, attachedTo string) string {
+	if attachedTo == "" {
+		return ""
+	}
+
+	insts, err := h.compute.DescribeInstances(ctx, []string{attachedTo}, nil)
+	if err != nil || len(insts) == 0 {
+		return ""
+	}
+
+	name := tagOr(insts[0].Tags, vmARMNameTag, "")
+	if name == "" {
+		return ""
+	}
+
+	return azurearm.BuildResourceID(subscription, insts[0].ResourceGroup, providerName, vmResourceType, name)
 }
 
 // diskUniqueID derives a stable GUID-shaped uniqueId from the driver volume id,

--- a/server/azure/disks/types.go
+++ b/server/azure/disks/types.go
@@ -31,11 +31,15 @@ type diskSKU struct {
 }
 
 type diskResponse struct {
-	ID         string            `json:"id"`
-	Name       string            `json:"name"`
-	Type       string            `json:"type"`
-	Location   string            `json:"location"`
-	SKU        *diskSKU          `json:"sku,omitempty"`
+	ID       string   `json:"id"`
+	Name     string   `json:"name"`
+	Type     string   `json:"type"`
+	Location string   `json:"location"`
+	SKU      *diskSKU `json:"sku,omitempty"`
+	// ManagedBy is the ARM resource ID of the VM the disk is attached to
+	// (armcompute.Disk.ManagedBy is a top-level, read-only field — not under
+	// properties). Empty when the disk is unattached.
+	ManagedBy  string            `json:"managedBy,omitempty"`
 	Tags       map[string]string `json:"tags,omitempty"`
 	Properties diskResponseProps `json:"properties"`
 }

--- a/server/azure/virtualmachines/datadisk_attach_test.go
+++ b/server/azure/virtualmachines/datadisk_attach_test.go
@@ -202,6 +202,142 @@ func TestSDKVMDataDiskAttachDetach(t *testing.T) {
 	}
 }
 
+// TestSDKVMDataDiskAttach_ReplaceAtSameLUN is the regression test for the
+// LUN-replacement fix: PUTting a VM whose dataDisks references a different
+// managed disk at a LUN that already has one attached must detach the old
+// disk (clearing its managedBy) before attaching the new one, rather than
+// leaving both disks mapped to the same LUN.
+func TestSDKVMDataDiskAttach_ReplaceAtSameLUN(t *testing.T) {
+	vmClient, diskClient := newDataDiskTestServer(t)
+	ctx := context.Background()
+
+	vmPoller, err := vmClient.BeginCreateOrUpdate(ctx, "rg-1", "vm-relun",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				StorageProfile: &armcompute.StorageProfile{
+					ImageReference: &armcompute.ImageReference{
+						Publisher: to.Ptr("Canonical"), Offer: to.Ptr("UbuntuServer"),
+						SKU: to.Ptr("22.04-LTS"), Version: to.Ptr("latest"),
+					},
+				},
+				OSProfile: &armcompute.OSProfile{ComputerName: to.Ptr("vm-relun"), AdminUsername: to.Ptr("azureuser")},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate VM: %v", err)
+	}
+
+	if _, err := pollUntilDone(ctx, vmPoller); err != nil {
+		t.Fatalf("CreateOrUpdate VM poll: %v", err)
+	}
+
+	diskA, err := createDataDisk(ctx, t, diskClient, "disk-a")
+	if err != nil {
+		t.Fatalf("create disk-a: %v", err)
+	}
+
+	diskB, err := createDataDisk(ctx, t, diskClient, "disk-b")
+	if err != nil {
+		t.Fatalf("create disk-b: %v", err)
+	}
+
+	// Attach disk A at lun 0.
+	attachPoller, err := vmClient.BeginCreateOrUpdate(ctx, "rg-1", "vm-relun",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				StorageProfile: &armcompute.StorageProfile{
+					DataDisks: []*armcompute.DataDisk{{
+						Lun:          to.Ptr[int32](0),
+						CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+						ManagedDisk:  &armcompute.ManagedDiskParameters{ID: diskA.ID},
+					}},
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate attach disk-a: %v", err)
+	}
+
+	if _, err := pollUntilDone(ctx, attachPoller); err != nil {
+		t.Fatalf("CreateOrUpdate attach disk-a poll: %v", err)
+	}
+
+	// Re-declaring lun 0 with disk B must detach disk A first — not leave
+	// both disks mapped to lun 0.
+	replacePoller, err := vmClient.BeginCreateOrUpdate(ctx, "rg-1", "vm-relun",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				StorageProfile: &armcompute.StorageProfile{
+					DataDisks: []*armcompute.DataDisk{{
+						Lun:          to.Ptr[int32](0),
+						CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+						ManagedDisk:  &armcompute.ManagedDiskParameters{ID: diskB.ID},
+					}},
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate replace lun0 with disk-b: %v", err)
+	}
+
+	got, err := pollUntilDone(ctx, replacePoller)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate replace lun0 poll: %v", err)
+	}
+
+	// Exactly one disk at lun 0.
+	assertDataDiskLUNs(t, got.Properties.StorageProfile, 0)
+
+	if len(got.Properties.StorageProfile.DataDisks) != 1 {
+		t.Fatalf("dataDisks=%d entries, want exactly 1", len(got.Properties.StorageProfile.DataDisks))
+	}
+
+	gotLunDisk := got.Properties.StorageProfile.DataDisks[0]
+	if gotLunDisk.ManagedDisk == nil || gotLunDisk.ManagedDisk.ID == nil || *gotLunDisk.ManagedDisk.ID != *diskB.ID {
+		t.Errorf("lun 0 managedDisk.id=%v, want disk-b %v", gotLunDisk.ManagedDisk, *diskB.ID)
+	}
+
+	// Disk A must be detached: managedBy cleared, diskState back to Unattached.
+	gotDiskA, err := diskClient.Get(ctx, "rg-1", "disk-a", nil)
+	if err != nil {
+		t.Fatalf("Get disk-a: %v", err)
+	}
+
+	if gotDiskA.ManagedBy != nil && *gotDiskA.ManagedBy != "" {
+		t.Errorf("disk-a managedBy=%v after replacement, want empty", *gotDiskA.ManagedBy)
+	}
+
+	if gotDiskA.Properties == nil || gotDiskA.Properties.DiskState == nil || *gotDiskA.Properties.DiskState != armcompute.DiskStateUnattached {
+		t.Errorf("disk-a diskState=%v, want Unattached", diskStateOf(gotDiskA))
+	}
+
+	// Disk B must be attached at lun 0.
+	gotDiskB, err := diskClient.Get(ctx, "rg-1", "disk-b", nil)
+	if err != nil {
+		t.Fatalf("Get disk-b: %v", err)
+	}
+
+	if gotDiskB.ManagedBy == nil || *gotDiskB.ManagedBy != *got.ID {
+		t.Errorf("disk-b managedBy=%v, want %v", derefStr(gotDiskB.ManagedBy), *got.ID)
+	}
+
+	if gotDiskB.Properties == nil || gotDiskB.Properties.DiskState == nil || *gotDiskB.Properties.DiskState != armcompute.DiskStateAttached {
+		t.Errorf("disk-b diskState=%v, want Attached", diskStateOf(gotDiskB))
+	}
+}
+
 func createDataDisk(ctx context.Context, t *testing.T, diskClient *armcompute.DisksClient, name string) (armcompute.Disk, error) {
 	t.Helper()
 

--- a/server/azure/virtualmachines/datadisk_attach_test.go
+++ b/server/azure/virtualmachines/datadisk_attach_test.go
@@ -1,0 +1,272 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// newDataDiskTestServer wires a TLS server backed by a single Azure compute
+// mock, exposing both virtualMachines and disks — a real deployment where
+// the same VM handles attaches managed disks created through the disks API.
+func newDataDiskTestServer(t *testing.T) (*armcompute.VirtualMachinesClient, *armcompute.DisksClient) {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		Disks:           cloudP.VirtualMachines,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	vmClient := newSDKClient(t, ts)
+
+	diskClient, err := armcompute.NewDisksClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return vmClient, diskClient
+}
+
+// TestSDKVMDataDiskAttachDetach is the load-bearing regression test for the
+// VM managed-disk attach fix: a real azure-sdk-for-go client creates a VM and
+// two managed disks, attaches them through both the declarative PUT
+// CreateOrUpdate path and the merge-patch PATCH Update path, and verifies the
+// attachment is real — reflected on GET (storageProfile.dataDisks) and on the
+// disk resource itself (managedBy) — then detaches one via PATCH toBeDetached.
+func TestSDKVMDataDiskAttachDetach(t *testing.T) {
+	vmClient, diskClient := newDataDiskTestServer(t)
+	ctx := context.Background()
+
+	vmPoller, err := vmClient.BeginCreateOrUpdate(ctx, "rg-1", "vm-disks",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				StorageProfile: &armcompute.StorageProfile{
+					ImageReference: &armcompute.ImageReference{
+						Publisher: to.Ptr("Canonical"), Offer: to.Ptr("UbuntuServer"),
+						SKU: to.Ptr("22.04-LTS"), Version: to.Ptr("latest"),
+					},
+				},
+				OSProfile: &armcompute.OSProfile{ComputerName: to.Ptr("vm-disks"), AdminUsername: to.Ptr("azureuser")},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate VM: %v", err)
+	}
+
+	if _, err := pollUntilDone(ctx, vmPoller); err != nil {
+		t.Fatalf("CreateOrUpdate VM poll: %v", err)
+	}
+
+	disk1, err := createDataDisk(ctx, t, diskClient, "disk-0")
+	if err != nil {
+		t.Fatalf("create disk-0: %v", err)
+	}
+
+	disk2, err := createDataDisk(ctx, t, diskClient, "disk-1")
+	if err != nil {
+		t.Fatalf("create disk-1: %v", err)
+	}
+
+	// PUT the VM again with dataDisks referencing disk-0: the standard
+	// declarative attach path. The blocker was that this was a no-op.
+	attachPoller, err := vmClient.BeginCreateOrUpdate(ctx, "rg-1", "vm-disks",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				StorageProfile: &armcompute.StorageProfile{
+					DataDisks: []*armcompute.DataDisk{{
+						Lun:          to.Ptr[int32](0),
+						CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+						ManagedDisk:  &armcompute.ManagedDiskParameters{ID: disk1.ID},
+					}},
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate attach: %v", err)
+	}
+
+	attached, err := pollUntilDone(ctx, attachPoller)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate attach poll: %v", err)
+	}
+
+	assertDataDiskLUNs(t, attached.Properties.StorageProfile, 0)
+
+	// GET must reflect the real attachment (not just echo the request).
+	got, err := vmClient.Get(ctx, "rg-1", "vm-disks", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	assertDataDiskLUNs(t, got.Properties.StorageProfile, 0)
+
+	// The disk's own managedBy must now point at the VM.
+	gotDisk1, err := diskClient.Get(ctx, "rg-1", "disk-0", nil)
+	if err != nil {
+		t.Fatalf("Get disk-0: %v", err)
+	}
+
+	if gotDisk1.ManagedBy == nil || *gotDisk1.ManagedBy != *got.ID {
+		t.Errorf("disk-0 managedBy=%v, want %v", derefStr(gotDisk1.ManagedBy), *got.ID)
+	}
+
+	if gotDisk1.Properties == nil || gotDisk1.Properties.DiskState == nil || *gotDisk1.Properties.DiskState != armcompute.DiskStateAttached {
+		t.Errorf("disk-0 diskState=%v, want Attached", diskStateOf(gotDisk1))
+	}
+
+	// PATCH (BeginUpdate) attaches disk-1 at lun 1 — the non-recreating
+	// merge-patch path — without disturbing the existing lun-0 attachment.
+	updatePoller, err := vmClient.BeginUpdate(ctx, "rg-1", "vm-disks",
+		armcompute.VirtualMachineUpdate{
+			Properties: &armcompute.VirtualMachineProperties{
+				StorageProfile: &armcompute.StorageProfile{
+					DataDisks: []*armcompute.DataDisk{{
+						Lun:          to.Ptr[int32](1),
+						CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+						ManagedDisk:  &armcompute.ManagedDiskParameters{ID: disk2.ID},
+					}},
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate attach lun1: %v", err)
+	}
+
+	if _, err := updatePoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("Update attach lun1 poll: %v", err)
+	}
+
+	got, err = vmClient.Get(ctx, "rg-1", "vm-disks", nil)
+	if err != nil {
+		t.Fatalf("Get after PATCH attach: %v", err)
+	}
+
+	assertDataDiskLUNs(t, got.Properties.StorageProfile, 0, 1)
+
+	// PATCH detaches lun 0 via toBeDetached — real Azure's Update semantics,
+	// distinct from PUT's declarative "omit to detach".
+	detachPoller, err := vmClient.BeginUpdate(ctx, "rg-1", "vm-disks",
+		armcompute.VirtualMachineUpdate{
+			Properties: &armcompute.VirtualMachineProperties{
+				StorageProfile: &armcompute.StorageProfile{
+					DataDisks: []*armcompute.DataDisk{{
+						Lun:          to.Ptr[int32](0),
+						ToBeDetached: to.Ptr(true),
+					}},
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate detach lun0: %v", err)
+	}
+
+	if _, err := detachPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("Update detach lun0 poll: %v", err)
+	}
+
+	got, err = vmClient.Get(ctx, "rg-1", "vm-disks", nil)
+	if err != nil {
+		t.Fatalf("Get after PATCH detach: %v", err)
+	}
+
+	// lun 0 detached; lun 1 (attached via PATCH, untouched by this PATCH)
+	// must survive — proving Update is merge-patch, not declarative.
+	assertDataDiskLUNs(t, got.Properties.StorageProfile, 1)
+
+	gotDisk1, err = diskClient.Get(ctx, "rg-1", "disk-0", nil)
+	if err != nil {
+		t.Fatalf("Get disk-0 after detach: %v", err)
+	}
+
+	if gotDisk1.ManagedBy != nil && *gotDisk1.ManagedBy != "" {
+		t.Errorf("disk-0 managedBy=%v after detach, want empty", *gotDisk1.ManagedBy)
+	}
+}
+
+func createDataDisk(ctx context.Context, t *testing.T, diskClient *armcompute.DisksClient, name string) (armcompute.Disk, error) {
+	t.Helper()
+
+	poller, err := diskClient.BeginCreateOrUpdate(ctx, "rg-1", name, armcompute.Disk{
+		Location: to.Ptr("eastus"),
+		SKU:      &armcompute.DiskSKU{Name: to.Ptr(armcompute.DiskStorageAccountTypesPremiumLRS)},
+		Properties: &armcompute.DiskProperties{
+			CreationData: &armcompute.CreationData{CreateOption: to.Ptr(armcompute.DiskCreateOptionEmpty)},
+			DiskSizeGB:   to.Ptr[int32](32),
+		},
+	}, nil)
+	if err != nil {
+		return armcompute.Disk{}, err
+	}
+
+	resp, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	if err != nil {
+		return armcompute.Disk{}, err
+	}
+
+	return resp.Disk, nil
+}
+
+func assertDataDiskLUNs(t *testing.T, sp *armcompute.StorageProfile, wantLUNs ...int32) {
+	t.Helper()
+
+	if sp == nil {
+		if len(wantLUNs) > 0 {
+			t.Fatalf("storageProfile is nil, want dataDisks at luns %v", wantLUNs)
+		}
+
+		return
+	}
+
+	got := make(map[int32]bool, len(sp.DataDisks))
+
+	for _, d := range sp.DataDisks {
+		if d.Lun != nil {
+			got[*d.Lun] = true
+		}
+	}
+
+	if len(got) != len(wantLUNs) {
+		t.Fatalf("dataDisks luns=%v, want %v", got, wantLUNs)
+	}
+
+	for _, lun := range wantLUNs {
+		if !got[lun] {
+			t.Errorf("dataDisks missing lun %d, got %v", lun, got)
+		}
+	}
+}
+
+func diskStateOf(d armcompute.DisksClientGetResponse) string {
+	if d.Properties == nil || d.Properties.DiskState == nil {
+		return "<nil>"
+	}
+
+	return string(*d.Properties.DiskState)
+}
+
+func derefStr(s *string) string {
+	if s == nil {
+		return "<nil>"
+	}
+
+	return *s
+}

--- a/server/azure/virtualmachines/handler.go
+++ b/server/azure/virtualmachines/handler.go
@@ -6,6 +6,7 @@
 // Supported operations (instance lifecycle parity with AWS EC2):
 //
 //	PUT    .../virtualMachines/{name}        — CreateOrUpdate
+//	PATCH  .../virtualMachines/{name}        — Update (merge-patch; dataDisks attach/detach)
 //	GET    .../virtualMachines/{name}        — Get
 //	GET    .../virtualMachines               — List in resource group
 //	GET    .../providers/.../virtualMachines — List in subscription
@@ -133,6 +134,8 @@ func (h *Handler) serveResource(w http.ResponseWriter, r *http.Request, rp azure
 	switch r.Method {
 	case http.MethodPut:
 		h.createOrUpdate(w, r, rp)
+	case http.MethodPatch:
+		h.update(w, r, rp)
 	case http.MethodGet:
 		h.get(w, r, rp)
 	case http.MethodDelete:

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -294,9 +294,31 @@ func (h *Handler) applyDataDisk(
 			return nil
 		}
 
-		return h.compute.DetachVolume(ctx, volID)
+		if err := h.compute.DetachVolume(ctx, volID); err != nil {
+			return err
+		}
+
+		delete(attached, d.Lun)
+
+		return nil
 	}
 
+	return h.attachDataDisk(ctx, instanceID, d, vols, attached)
+}
+
+// attachDataDisk attaches the managed disk resolveAttachDiskID resolves d to.
+// Real Azure's dataDisks are keyed by lun: re-declaring a lun with a
+// different managedDisk.id implicitly detaches whatever disk currently
+// occupies it (clearing that disk's managedBy/diskState) before attaching the
+// new one, rather than mapping two disks onto one lun. When attached[d.Lun]
+// already holds a different volume, we detach it first and update the attached
+// bookkeeping so the rest of this reconciliation pass (and detachUnlistedDisks)
+// sees the new occupant, not the stale one. A no-op when the resolved disk is
+// already attached at d.Lun, or when d falls into one of resolveAttachDiskID's
+// DEFERRED createOption cases and resolves to "".
+func (h *Handler) attachDataDisk(
+	ctx context.Context, instanceID string, d *dataDisk, vols []computedriver.VolumeInfo, attached map[int]string,
+) error {
 	volID, err := resolveAttachDiskID(d, vols)
 	if err != nil {
 		return err
@@ -306,7 +328,19 @@ func (h *Handler) applyDataDisk(
 		return nil
 	}
 
-	return h.compute.AttachVolume(ctx, volID, instanceID, strconv.Itoa(d.Lun))
+	if prevVolID, ok := attached[d.Lun]; ok && prevVolID != volID {
+		if err := h.compute.DetachVolume(ctx, prevVolID); err != nil {
+			return err
+		}
+	}
+
+	if err := h.compute.AttachVolume(ctx, volID, instanceID, strconv.Itoa(d.Lun)); err != nil {
+		return err
+	}
+
+	attached[d.Lun] = volID
+
+	return nil
 }
 
 // detachUnlistedDisks detaches every attached disk whose LUN is absent from

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -15,6 +17,15 @@ import (
 // armNameTag is the tag key we use to round-trip the ARM resource name
 // through the driver, since the driver indexes by its own ID.
 const armNameTag = "cloudemu:azureName"
+
+// diskARMNameTag and diskRGTag mirror the constants in server/azure/disks so
+// a storageProfile.dataDisks managedDisk.id can be resolved to its driver
+// volume, and an attached volume's driver Device (the LUN we pass to
+// AttachVolume) can be echoed back on GET/LIST/CreateOrUpdate/Update.
+const (
+	diskARMNameTag = "cloudemu:azureDiskName"
+	diskRGTag      = "cloudemu:azureRG"
+)
 
 // URL schemes for building absolute self-referential URLs (async operation
 // status, boot-diagnostics serial log) against the incoming request.
@@ -106,9 +117,17 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		return
 	}
 
+	// storageProfile.dataDisks is the VM's complete desired data-disk state on
+	// PUT (real Azure's full-replace semantics): attach every referenced
+	// managed disk not yet attached.
+	if err := h.applyDataDisks(r.Context(), instances[0].ID, dataDisksOf(req.Properties.StorageProfile), true); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
 	// A create is a long-running operation: the initial response reports
 	// "Creating" (201 Created) and settles to "Succeeded" on the next poll/GET.
-	azurearm.WriteJSON(w, http.StatusCreated, toVMResponse(&instances[0], rp, req, provisioningCreating))
+	azurearm.WriteJSON(w, http.StatusCreated, h.buildVMResponse(r.Context(), &instances[0], rp, req, provisioningCreating))
 }
 
 // validateNICs verifies that every NIC referenced by a networkProfile exists.
@@ -169,7 +188,255 @@ func (h *Handler) updateExisting(
 		existing = updated
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toVMResponse(existing, rp, req, provisioningSucceeded))
+	// storageProfile.dataDisks is the VM's complete desired data-disk state on
+	// PUT: attach newly-referenced managed disks and detach any previously
+	// attached disk whose LUN is no longer present in the request.
+	if err := h.applyDataDisks(r.Context(), existing.ID, dataDisksOf(req.Properties.StorageProfile), true); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, h.buildVMResponse(r.Context(), existing, rp, req, provisioningSucceeded))
+}
+
+// update handles PATCH virtualMachines/{name} — ARM's BeginUpdate. Unlike PUT,
+// Update is a merge-patch: only the sections present in the body are applied,
+// and everything else is left untouched. We scope this to the operation's
+// primary real-world use — storageProfile.dataDisks attach/detach, the
+// standard non-recreating disk-attach path — rather than routing through
+// UpdateInstance (whose cfg-replace semantics assume PUT's full-body shape and
+// would blank tags/priority/licenseType a partial PATCH body omits).
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) update(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	var req vmRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	inst, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	// Update's dataDisks is merge-patch, not declarative: a disk is only
+	// detached when its entry explicitly sets toBeDetached (real Azure's
+	// Update semantics), never by omission.
+	if err = h.applyDataDisks(r.Context(), inst.ID, dataDisksOf(req.Properties.StorageProfile), false); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	updated, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, h.buildVMResponse(r.Context(), updated, rp, req, provisioningSucceeded))
+}
+
+// dataDisksOf safely reads storageProfile.dataDisks, tolerating a request
+// whose storageProfile was omitted entirely.
+func dataDisksOf(s *storageProfile) []dataDisk {
+	if s == nil {
+		return nil
+	}
+
+	return s.DataDisks
+}
+
+// applyDataDisks reconciles instanceID's attached data disks against disks,
+// the request's storageProfile.dataDisks. declarative selects PUT
+// CreateOrUpdate's full-replace semantics — the array is the VM's complete
+// desired data-disk state, so any currently attached disk whose LUN is absent
+// from disks is detached — versus PATCH Update's merge-patch semantics, where
+// a disk is detached only when its own entry sets toBeDetached and entries
+// absent from the request are left untouched. Both paths attach any entry
+// whose managedDisk.id resolves to a disk not yet attached at that LUN.
+func (h *Handler) applyDataDisks(ctx context.Context, instanceID string, disks []dataDisk, declarative bool) error {
+	vols, err := h.compute.DescribeVolumes(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	attached := attachedDisksByLUN(vols, instanceID)
+	seen := make(map[int]bool, len(disks))
+
+	for i := range disks {
+		seen[disks[i].Lun] = true
+
+		if err := h.applyDataDisk(ctx, instanceID, &disks[i], vols, attached); err != nil {
+			return err
+		}
+	}
+
+	if !declarative {
+		return nil
+	}
+
+	return detachUnlistedDisks(ctx, h.compute, attached, seen)
+}
+
+// applyDataDisk applies one storageProfile.dataDisks entry: detaches the disk
+// currently attached at d.Lun when d.ToBeDetached is set, otherwise attaches
+// the managed disk resolveAttachDiskID resolves d to — a no-op when that disk
+// is already attached at d.Lun, or when d falls into one of
+// resolveAttachDiskID's DEFERRED createOption cases and resolves to "".
+func (h *Handler) applyDataDisk(
+	ctx context.Context, instanceID string, d *dataDisk, vols []computedriver.VolumeInfo, attached map[int]string,
+) error {
+	if d.ToBeDetached {
+		volID, ok := attached[d.Lun]
+		if !ok {
+			return nil
+		}
+
+		return h.compute.DetachVolume(ctx, volID)
+	}
+
+	volID, err := resolveAttachDiskID(d, vols)
+	if err != nil {
+		return err
+	}
+
+	if volID == "" || attached[d.Lun] == volID {
+		return nil
+	}
+
+	return h.compute.AttachVolume(ctx, volID, instanceID, strconv.Itoa(d.Lun))
+}
+
+// detachUnlistedDisks detaches every attached disk whose LUN is absent from
+// seen — the declarative-PUT half of applyDataDisks' reconciliation.
+func detachUnlistedDisks(ctx context.Context, c computedriver.Compute, attached map[int]string, seen map[int]bool) error {
+	for lun, volID := range attached {
+		if seen[lun] {
+			continue
+		}
+
+		if err := c.DetachVolume(ctx, volID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// attachedDisksByLUN indexes the volumes currently attached to instanceID by
+// the LUN AttachVolume was called with (recovered from the driver's Device
+// field), for reconciling against a request's desired dataDisks.
+func attachedDisksByLUN(vols []computedriver.VolumeInfo, instanceID string) map[int]string {
+	byLUN := make(map[int]string)
+
+	for i := range vols {
+		if vols[i].AttachedTo != instanceID {
+			continue
+		}
+
+		if lun, ok := parseLUN(vols[i].Device); ok {
+			byLUN[lun] = vols[i].ID
+		}
+	}
+
+	return byLUN
+}
+
+// parseLUN recovers the integer LUN AttachVolume was called with from a
+// volume's driver Device field (applyDataDisks passes strconv.Itoa(lun) as
+// the device on attach). A non-numeric Device reports false so the volume is
+// excluded from LUN-keyed reconciliation.
+func parseLUN(device string) (int, bool) {
+	lun, err := strconv.Atoi(device)
+	if err != nil {
+		return 0, false
+	}
+
+	return lun, true
+}
+
+// resolveAttachDiskID resolves the volume ID a dataDisk entry's managedDisk.id
+// references. Only createOption "Attach" references an existing managed disk;
+// Empty/FromImage/Copy/Restore implicitly provision a brand-new disk from the
+// VM's storageProfile, which cloudemu does not yet create (DEFERRED — create
+// the managed disk first via PUT .../disks/{name}, then reference it here with
+// createOption "Attach"). Such entries resolve to "" and are silently skipped
+// rather than erroring, so a request that also sets an unsupported implicit
+// disk alongside a supported Attach entry still succeeds for the latter.
+func resolveAttachDiskID(d *dataDisk, vols []computedriver.VolumeInfo) (string, error) {
+	if !strings.EqualFold(d.CreateOption, "Attach") {
+		return "", nil
+	}
+
+	if d.ManagedDisk == nil || d.ManagedDisk.ID == "" {
+		return "", cerrors.Newf(cerrors.InvalidArgument,
+			"dataDisk lun %d: createOption Attach requires managedDisk.id", d.Lun)
+	}
+
+	pp, ok := azurearm.ParsePath(d.ManagedDisk.ID)
+	if !ok || pp.ResourceName == "" {
+		return "", cerrors.Newf(cerrors.InvalidArgument, "malformed managed disk id %q", d.ManagedDisk.ID)
+	}
+
+	for i := range vols {
+		if tagOr(vols[i].Tags, diskARMNameTag, "") != pp.ResourceName {
+			continue
+		}
+
+		if pp.ResourceGroup != "" && tagOr(vols[i].Tags, diskRGTag, "") != pp.ResourceGroup {
+			continue
+		}
+
+		return vols[i].ID, nil
+	}
+
+	return "", cerrors.Newf(cerrors.NotFound, "managed disk %q not found", pp.ResourceName)
+}
+
+// attachedDataDisks builds the storageProfile.dataDisks response entries for
+// every managed disk currently attached to instanceID, so GET/LIST/
+// CreateOrUpdate/Update responses reflect real attachment state regardless of
+// what a particular request body asked for.
+//
+//nolint:gocritic // rp is a request-scoped value; pointer chain isn't worth the noise
+func (h *Handler) attachedDataDisks(ctx context.Context, rp azurearm.ResourcePath, instanceID string) []dataDisk {
+	vols, err := h.compute.DescribeVolumes(ctx, nil)
+	if err != nil {
+		return nil
+	}
+
+	out := make([]dataDisk, 0, len(vols))
+
+	for i := range vols {
+		if vols[i].AttachedTo != instanceID {
+			continue
+		}
+
+		lun, ok := parseLUN(vols[i].Device)
+		if !ok {
+			continue
+		}
+
+		name := tagOr(vols[i].Tags, diskARMNameTag, vols[i].ID)
+		diskRG := tagOr(vols[i].Tags, diskRGTag, rp.ResourceGroup)
+
+		out = append(out, dataDisk{
+			Lun:          lun,
+			Name:         name,
+			CreateOption: "Attach",
+			DiskSizeGB:   vols[i].Size,
+			ManagedDisk: &managedDiskParameters{
+				ID:                 azurearm.BuildResourceID(rp.Subscription, diskRG, providerName, "disks", name),
+				StorageAccountType: vols[i].VolumeType,
+			},
+		})
+	}
+
+	sort.Slice(out, func(a, b int) bool { return out[a].Lun < out[b].Lun })
+
+	return out
 }
 
 // get handles GET virtualMachines/{name}.
@@ -182,7 +449,7 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.Resour
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toVMResponse(inst, rp, vmRequest{}, provisioningSucceeded))
+	azurearm.WriteJSON(w, http.StatusOK, h.buildVMResponse(r.Context(), inst, rp, vmRequest{}, provisioningSucceeded))
 }
 
 // list handles GET virtualMachines. A resource-group-scoped path
@@ -207,7 +474,7 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp azurearm.Resou
 		name := tagOr(instances[i].Tags, armNameTag, instances[i].ID)
 		scope := rp
 		scope.ResourceName = name
-		out = append(out, toVMResponse(&instances[i], scope, vmRequest{}, provisioningSucceeded))
+		out = append(out, h.buildVMResponse(r.Context(), &instances[i], scope, vmRequest{}, provisioningSucceeded))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, vmListResponse{Value: out})
@@ -615,11 +882,7 @@ func mergeTags(in map[string]string, armName string) map[string]string {
 	return out
 }
 
-// tagOr returns the tag value for key, or fallback when absent. The key
-// parameter is kept for signature parity with the sibling azure compute
-// handlers even though this package only reads the ARM-name tag.
-//
-//nolint:unparam // uniform tag-helper signature across azure compute handlers
+// tagOr returns the tag value for key, or fallback when absent.
 func tagOr(m map[string]string, key, fallback string) string {
 	if v, ok := m[key]; ok {
 		return v
@@ -634,6 +897,29 @@ const (
 	provisioningCreating  = "Creating"
 	provisioningSucceeded = "Succeeded"
 )
+
+// buildVMResponse builds the ARM vmResponse for inst, augmenting
+// storageProfile.dataDisks with the disks actually attached to it (via
+// attachedDataDisks) so every response reflects real attachment state —
+// including a disk attached by an earlier request, not just the one that
+// produced this particular response.
+//
+//nolint:gocritic // rp/req are value types passed once per response build
+func (h *Handler) buildVMResponse(
+	ctx context.Context, inst *computedriver.Instance, rp azurearm.ResourcePath, req vmRequest, provisioningState string,
+) vmResponse {
+	resp := toVMResponse(inst, rp, req, provisioningState)
+
+	if disks := h.attachedDataDisks(ctx, rp, inst.ID); len(disks) > 0 {
+		if resp.Properties.StorageProfile == nil {
+			resp.Properties.StorageProfile = &storageProfile{}
+		}
+
+		resp.Properties.StorageProfile.DataDisks = disks
+	}
+
+	return resp
+}
 
 // toVMResponse maps a driver Instance back onto the ARM JSON shape.
 // provisioningState is the properties.provisioningState to report ("Creating"

--- a/server/azure/virtualmachines/sdk_roundtrip_test.go
+++ b/server/azure/virtualmachines/sdk_roundtrip_test.go
@@ -26,11 +26,11 @@ func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcor
 	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
 }
 
-// newSDKClient builds an azure-sdk-for-go armcompute VirtualMachinesClient
-// configured to talk to the given httptest server.
-func newSDKClient(t *testing.T, ts *httptest.Server) *armcompute.VirtualMachinesClient {
-	t.Helper()
-
+// sdkClientOptions builds the arm.ClientOptions shared by every armcompute
+// client in these tests: point Cloud.ResourceManager at the httptest server
+// and disable retries so a test failure is visible immediately rather than
+// masked by the SDK's retry loop.
+func sdkClientOptions(ts *httptest.Server) *arm.ClientOptions {
 	myCloud := cloud.Configuration{
 		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
 		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
@@ -41,17 +41,21 @@ func newSDKClient(t *testing.T, ts *httptest.Server) *armcompute.VirtualMachines
 		},
 	}
 
-	opts := &arm.ClientOptions{
+	return &arm.ClientOptions{
 		ClientOptions: azcore.ClientOptions{
 			Cloud:     myCloud,
 			Transport: ts.Client(),
-			// SDK wants TLS by default; we're on http httptest. Disable retries
-			// so test failures are visible immediately rather than masked.
-			Retry: policy.RetryOptions{MaxRetries: -1},
+			Retry:     policy.RetryOptions{MaxRetries: -1},
 		},
 	}
+}
 
-	client, err := armcompute.NewVirtualMachinesClient("sub-1", fakeCred{}, opts)
+// newSDKClient builds an azure-sdk-for-go armcompute VirtualMachinesClient
+// configured to talk to the given httptest server.
+func newSDKClient(t *testing.T, ts *httptest.Server) *armcompute.VirtualMachinesClient {
+	t.Helper()
+
+	client, err := armcompute.NewVirtualMachinesClient("sub-1", fakeCred{}, sdkClientOptions(ts))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/azure/virtualmachines/types.go
+++ b/server/azure/virtualmachines/types.go
@@ -32,11 +32,34 @@ type hardwareProfile struct {
 type storageProfile struct {
 	ImageReference *imageReference `json:"imageReference,omitempty"`
 	OSDisk         *osDisk         `json:"osDisk,omitempty"`
+	DataDisks      []dataDisk      `json:"dataDisks,omitempty"`
 }
 
 // osDisk carries the OS-disk shape; we only model osType, a cost input.
 type osDisk struct {
 	OSType string `json:"osType,omitempty"`
+}
+
+// dataDisk mirrors armcompute.DataDisk: one entry of storageProfile.dataDisks,
+// either declaring a managed disk to attach (createOption "Attach" +
+// managedDisk.id) or, on the PATCH Update path, marking an already-attached
+// disk for detachment (toBeDetached).
+type dataDisk struct {
+	Lun          int                    `json:"lun"`
+	Name         string                 `json:"name,omitempty"`
+	CreateOption string                 `json:"createOption,omitempty"`
+	DiskSizeGB   int                    `json:"diskSizeGB,omitempty"`
+	Caching      string                 `json:"caching,omitempty"`
+	ManagedDisk  *managedDiskParameters `json:"managedDisk,omitempty"`
+	ToBeDetached bool                   `json:"toBeDetached,omitempty"`
+	DetachOption string                 `json:"detachOption,omitempty"`
+}
+
+// managedDiskParameters references an existing Microsoft.Compute/disks
+// resource a dataDisk entry attaches.
+type managedDiskParameters struct {
+	ID                 string `json:"id,omitempty"`
+	StorageAccountType string `json:"storageAccountType,omitempty"`
 }
 
 type imageReference struct {

--- a/server/azure/virtualmachines/virtualmachines_test.go
+++ b/server/azure/virtualmachines/virtualmachines_test.go
@@ -266,7 +266,9 @@ func TestVMLifecycleActions(t *testing.T) {
 func TestVMUnsupportedMethod(t *testing.T) {
 	ts := newAzureTestServer(t)
 
-	req, _ := http.NewRequest(http.MethodPatch, ts.URL+armBasePath("x")+apiVersion, http.NoBody)
+	// PATCH is now a supported operation (Update); POST directly on a named
+	// VM resource (no sub-resource action) remains unsupported.
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+armBasePath("x")+apiVersion, http.NoBody)
 
 	resp, err := ts.Client().Do(req)
 	if err != nil {


### PR DESCRIPTION
## Summary

- `PUT virtualMachines/{name}` (CreateOrUpdate) accepted `storageProfile.dataDisks` but never called the compute driver's `AttachVolume`/`DetachVolume` — a subsequent `GET` never reflected the attachment and the disk's `managedBy` stayed empty. It now reconciles the VM's attached disks against the request's `dataDisks` array declaratively: attach every referenced managed disk not yet attached, detach any currently-attached disk whose LUN is no longer listed (matching real Azure's full-replace PUT semantics).
- `PATCH virtualMachines/{name}` (BeginUpdate) was unimplemented (501) — added as the standard, non-recreating disk-attach path. Unlike PUT, Update is a merge-patch: a disk is only detached when its own entry sets `toBeDetached` (real Azure's semantics), never by omission, and entries absent from the request are left untouched.
- `GET`/`LIST` (and the CreateOrUpdate/Update responses) now echo `storageProfile.dataDisks` from the disks actually attached to the VM, not just what a particular request asked for.
- `Microsoft.Compute/disks` GET/LIST/CreateOrUpdate responses now populate `managedBy` with the ARM resource ID of the attaching VM once a disk is attached.
- Only `createOption: "Attach"` (referencing an existing managed disk via `managedDisk.id`) is handled. Implicit disk creation from the VM body (`Empty`/`FromImage`/`Copy`/`Restore` without an existing `managedDisk.id`) is out of scope for this fix and is silently skipped rather than erroring.

Verified request/response shapes against the ARM REST docs (Virtual Machines - Update, Virtual Machines - CreateOrUpdate) and the `armcompute.Disk`/`DataDisk` SDK types.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite)
- [x] `go test -race` on the changed provider/server packages
- [x] `go test ./compat/...`
- [x] `golangci-lint run` on changed packages — 0 issues
- [x] `gofmt -l` clean
- [x] New regression test (`TestSDKVMDataDiskAttachDetach`) drives a real `azure-sdk-for-go` `armcompute` client against a live TLS server: creates a VM and two managed disks, attaches one via PUT and one via PATCH, verifies GET reflects both attachments and the disk's `managedBy`, then detaches one via PATCH `toBeDetached` and verifies the other survives (proving Update is merge-patch, not declarative)