### PR TITLE
fix(keyvault): isolate secrets/keys per vault; fix rotationpolicy routing

### DIFF
--- a/docs/coverage/aws/secretsmanager.md
+++ b/docs/coverage/aws/secretsmanager.md
@@ -31,6 +31,7 @@ KeyVaultKeys is the Azure Key Vault keys data-plane surface: key lifecycle
 | `EncryptKey` |  |
 | `GetDeletedKey` |  |
 | `GetKey` |  |
+| `GetKeyRotationPolicy` |  |
 | `ImportKey` |  |
 | `ListDeletedKeys` |  |
 | `ListKeyVersions` |  |
@@ -40,6 +41,7 @@ KeyVaultKeys is the Azure Key Vault keys data-plane surface: key lifecycle
 | `SignKey` |  |
 | `UnwrapKey` |  |
 | `UpdateKey` |  |
+| `UpdateKeyRotationPolicy` |  |
 | `VerifyKey` |  |
 | `WrapKey` |  |
 

--- a/docs/coverage/azure/keyvault.md
+++ b/docs/coverage/azure/keyvault.md
@@ -31,6 +31,7 @@ KeyVaultKeys is the Azure Key Vault keys data-plane surface: key lifecycle
 | `EncryptKey` |  |
 | `GetDeletedKey` |  |
 | `GetKey` |  |
+| `GetKeyRotationPolicy` |  |
 | `ImportKey` |  |
 | `ListDeletedKeys` |  |
 | `ListKeyVersions` |  |
@@ -40,6 +41,7 @@ KeyVaultKeys is the Azure Key Vault keys data-plane surface: key lifecycle
 | `SignKey` |  |
 | `UnwrapKey` |  |
 | `UpdateKey` |  |
+| `UpdateKeyRotationPolicy` |  |
 | `VerifyKey` |  |
 | `WrapKey` |  |
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -9545,6 +9545,9 @@
             "name": "GetKey"
           },
           {
+            "name": "GetKeyRotationPolicy"
+          },
+          {
             "name": "ImportKey"
           },
           {
@@ -9570,6 +9573,9 @@
           },
           {
             "name": "UpdateKey"
+          },
+          {
+            "name": "UpdateKeyRotationPolicy"
           },
           {
             "name": "VerifyKey"

--- a/docs/coverage/gcp/secretmanager.md
+++ b/docs/coverage/gcp/secretmanager.md
@@ -31,6 +31,7 @@ KeyVaultKeys is the Azure Key Vault keys data-plane surface: key lifecycle
 | `EncryptKey` |  |
 | `GetDeletedKey` |  |
 | `GetKey` |  |
+| `GetKeyRotationPolicy` |  |
 | `ImportKey` |  |
 | `ListDeletedKeys` |  |
 | `ListKeyVersions` |  |
@@ -40,6 +41,7 @@ KeyVaultKeys is the Azure Key Vault keys data-plane surface: key lifecycle
 | `SignKey` |  |
 | `UnwrapKey` |  |
 | `UpdateKey` |  |
+| `UpdateKeyRotationPolicy` |  |
 | `VerifyKey` |  |
 | `WrapKey` |  |
 

--- a/providers/azure/keyvault/keys_azure.go
+++ b/providers/azure/keyvault/keys_azure.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
 )
 
@@ -60,6 +61,10 @@ type keyData struct {
 	versions       []keyVersion
 	deletedAt      time.Time
 	scheduledPurge time.Time
+	// rotationPolicy is nil until UpdateKeyRotationPolicy is called, at which
+	// point Key Vault starts returning it verbatim; GetKeyRotationPolicy
+	// synthesizes an empty default policy while it is nil.
+	rotationPolicy *driver.KVRotationPolicy
 	mu             sync.RWMutex
 }
 
@@ -118,7 +123,7 @@ func curveFor(name string) (elliptic.Curve, error) {
 
 // CreateKey generates a new key (RSA or EC) with real key material and stores
 // it as the current version, creating a new version if the name already exists.
-func (m *Mock) CreateKey(_ context.Context, name string, params *driver.KVCreateKeyParams) (*driver.KVKey, error) {
+func (m *Mock) CreateKey(_ context.Context, vault, name string, params *driver.KVCreateKeyParams) (*driver.KVKey, error) {
 	if name == "" {
 		return nil, errors.New(errors.InvalidArgument, "key name is required")
 	}
@@ -128,7 +133,7 @@ func (m *Mock) CreateKey(_ context.Context, name string, params *driver.KVCreate
 		return nil, err
 	}
 
-	return m.storeVersion(name, v)
+	return storeVersion(m.vault(vault).keys, name, v)
 }
 
 func (m *Mock) generateVersion(params *driver.KVCreateKeyParams) (*keyVersion, error) {
@@ -214,10 +219,11 @@ func generateEC(v *keyVersion, params *driver.KVCreateKeyParams) error {
 	return nil
 }
 
-// storeVersion appends v as the current version of name, creating the key if
-// it does not yet exist. A soft-deleted name cannot be reused until recovered.
-func (m *Mock) storeVersion(name string, v *keyVersion) (*driver.KVKey, error) {
-	if kd, ok := m.keys.Get(name); ok {
+// storeVersion appends v as the current version of name in store, creating
+// the key if it does not yet exist. A soft-deleted name cannot be reused
+// until recovered.
+func storeVersion(store *memstore.Store[*keyData], name string, v *keyVersion) (*driver.KVKey, error) {
+	if kd, ok := store.Get(name); ok {
 		kd.mu.Lock()
 		defer kd.mu.Unlock()
 
@@ -236,7 +242,7 @@ func (m *Mock) storeVersion(name string, v *keyVersion) (*driver.KVKey, error) {
 	}
 
 	kd := &keyData{name: name, versions: []keyVersion{*v}}
-	m.keys.Set(name, kd)
+	store.Set(name, kd)
 
 	kv := toKVKey(name, &kd.versions[0])
 
@@ -245,7 +251,7 @@ func (m *Mock) storeVersion(name string, v *keyVersion) (*driver.KVKey, error) {
 
 // ImportKey stores a caller-supplied key. RSA and EC keys are reconstructed
 // from their JWK components; oct keys keep their raw bytes.
-func (m *Mock) ImportKey(_ context.Context, name string, params *driver.KVImportKeyParams) (*driver.KVKey, error) {
+func (m *Mock) ImportKey(_ context.Context, vault, name string, params *driver.KVImportKeyParams) (*driver.KVKey, error) {
 	if name == "" {
 		return nil, errors.New(errors.InvalidArgument, "key name is required")
 	}
@@ -280,7 +286,7 @@ func (m *Mock) ImportKey(_ context.Context, name string, params *driver.KVImport
 		v.kty = hsmVariant(v.kty)
 	}
 
-	return m.storeVersion(name, v)
+	return storeVersion(m.vault(vault).keys, name, v)
 }
 
 func importMaterial(v *keyVersion, jwk *driver.KVImportJWK) error {

--- a/providers/azure/keyvault/keys_azure_test.go
+++ b/providers/azure/keyvault/keys_azure_test.go
@@ -14,7 +14,7 @@ func TestCreateRSAKeyAndCrypto(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	key, err := m.CreateKey(ctx, "k", &driver.KVCreateKeyParams{Kty: "RSA", KeySize: 2048, Attributes: driver.KVKeyAttributes{Enabled: true}})
+	key, err := m.CreateKey(ctx, "default", "k", &driver.KVCreateKeyParams{Kty: "RSA", KeySize: 2048, Attributes: driver.KVKeyAttributes{Enabled: true}})
 	require.NoError(t, err)
 	assert.Equal(t, "RSA", key.Kty)
 	assert.NotEmpty(t, key.N)
@@ -22,10 +22,10 @@ func TestCreateRSAKeyAndCrypto(t *testing.T) {
 
 	plaintext := []byte("secret payload")
 
-	enc, err := m.EncryptKey(ctx, "k", "", driver.KVCryptoParams{Algorithm: "RSA-OAEP-256", Value: plaintext})
+	enc, err := m.EncryptKey(ctx, "default", "k", "", driver.KVCryptoParams{Algorithm: "RSA-OAEP-256", Value: plaintext})
 	require.NoError(t, err)
 
-	dec, err := m.DecryptKey(ctx, "k", "", driver.KVCryptoParams{Algorithm: "RSA-OAEP-256", Value: enc.Value})
+	dec, err := m.DecryptKey(ctx, "default", "k", "", driver.KVCryptoParams{Algorithm: "RSA-OAEP-256", Value: enc.Value})
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, dec.Value)
 }
@@ -34,15 +34,15 @@ func TestCreateECKeySignVerify(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	_, err := m.CreateKey(ctx, "ec", &driver.KVCreateKeyParams{Kty: "EC", Curve: "P-384", Attributes: driver.KVKeyAttributes{Enabled: true}})
+	_, err := m.CreateKey(ctx, "default", "ec", &driver.KVCreateKeyParams{Kty: "EC", Curve: "P-384", Attributes: driver.KVKeyAttributes{Enabled: true}})
 	require.NoError(t, err)
 
 	digest := sha256.Sum256([]byte("data"))
 
-	sig, err := m.SignKey(ctx, "ec", "", driver.KVCryptoParams{Algorithm: "ES384", Value: digest[:]})
+	sig, err := m.SignKey(ctx, "default", "ec", "", driver.KVCryptoParams{Algorithm: "ES384", Value: digest[:]})
 	require.NoError(t, err)
 
-	ok, err := m.VerifyKey(ctx, "ec", "", driver.KVCryptoParams{Algorithm: "ES384", Value: digest[:], Signature: sig.Value})
+	ok, err := m.VerifyKey(ctx, "default", "ec", "", driver.KVCryptoParams{Algorithm: "ES384", Value: digest[:], Signature: sig.Value})
 	require.NoError(t, err)
 	assert.True(t, ok)
 }
@@ -51,16 +51,16 @@ func TestCreateHSMKeyPreservesKty(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	rsa, err := m.CreateKey(ctx, "rsa-hsm",
+	rsa, err := m.CreateKey(ctx, "default", "rsa-hsm",
 		&driver.KVCreateKeyParams{Kty: "RSA-HSM", Attributes: driver.KVKeyAttributes{Enabled: true}})
 	require.NoError(t, err)
 	assert.Equal(t, "RSA-HSM", rsa.Kty)
 
-	got, err := m.GetKey(ctx, "rsa-hsm", "")
+	got, err := m.GetKey(ctx, "default", "rsa-hsm", "")
 	require.NoError(t, err)
 	assert.Equal(t, "RSA-HSM", got.Kty)
 
-	ec, err := m.CreateKey(ctx, "ec-hsm",
+	ec, err := m.CreateKey(ctx, "default", "ec-hsm",
 		&driver.KVCreateKeyParams{Kty: "EC-HSM", Curve: "P-256", Attributes: driver.KVKeyAttributes{Enabled: true}})
 	require.NoError(t, err)
 	assert.Equal(t, "EC-HSM", ec.Kty)
@@ -68,10 +68,10 @@ func TestCreateHSMKeyPreservesKty(t *testing.T) {
 	// HSM keys still perform real crypto (single-tier storage).
 	digest := sha256.Sum256([]byte("data"))
 
-	sig, err := m.SignKey(ctx, "ec-hsm", "", driver.KVCryptoParams{Algorithm: "ES256", Value: digest[:]})
+	sig, err := m.SignKey(ctx, "default", "ec-hsm", "", driver.KVCryptoParams{Algorithm: "ES256", Value: digest[:]})
 	require.NoError(t, err)
 
-	ok, err := m.VerifyKey(ctx, "ec-hsm", "", driver.KVCryptoParams{Algorithm: "ES256", Value: digest[:], Signature: sig.Value})
+	ok, err := m.VerifyKey(ctx, "default", "ec-hsm", "", driver.KVCryptoParams{Algorithm: "ES256", Value: digest[:], Signature: sig.Value})
 	require.NoError(t, err)
 	assert.True(t, ok)
 }
@@ -83,7 +83,7 @@ func TestImportKeyHSMFlagPromotesKty(t *testing.T) {
 	kek := []byte("0123456789abcdef0123456789abcdef")
 
 	// A software oct JWK imported with HSM:true must round-trip as oct-HSM.
-	imported, err := m.ImportKey(ctx, "kek", &driver.KVImportKeyParams{
+	imported, err := m.ImportKey(ctx, "default", "kek", &driver.KVImportKeyParams{
 		Key:        driver.KVImportJWK{Kty: "oct", K: kek},
 		HSM:        true,
 		Attributes: driver.KVKeyAttributes{Enabled: true},
@@ -94,7 +94,7 @@ func TestImportKeyHSMFlagPromotesKty(t *testing.T) {
 	// An explicit RSA-HSM JWK is preserved as-is without the HSM flag.
 	src := newTestMock()
 
-	_, err = src.CreateKey(ctx, "orig", &driver.KVCreateKeyParams{Kty: "RSA", Attributes: driver.KVKeyAttributes{Enabled: true}})
+	_, err = src.CreateKey(ctx, "default", "orig", &driver.KVCreateKeyParams{Kty: "RSA", Attributes: driver.KVKeyAttributes{Enabled: true}})
 	require.NoError(t, err)
 
 	kd, ok := src.keys.Get("orig")
@@ -102,7 +102,7 @@ func TestImportKeyHSMFlagPromotesKty(t *testing.T) {
 
 	priv := kd.versions[0].rsaKey
 
-	rsaHSM, err := m.ImportKey(ctx, "imp", &driver.KVImportKeyParams{
+	rsaHSM, err := m.ImportKey(ctx, "default", "imp", &driver.KVImportKeyParams{
 		Key: driver.KVImportJWK{
 			Kty: "RSA-HSM",
 			N:   priv.N.Bytes(),
@@ -120,7 +120,7 @@ func TestImportKeyHSMFlagPromotesKty(t *testing.T) {
 func TestUnsupportedCurveRejected(t *testing.T) {
 	m := newTestMock()
 
-	_, err := m.CreateKey(context.Background(), "k", &driver.KVCreateKeyParams{Kty: "EC", Curve: "P-256K"})
+	_, err := m.CreateKey(context.Background(), "default", "k", &driver.KVCreateKeyParams{Kty: "EC", Curve: "P-256K"})
 	require.Error(t, err)
 }
 
@@ -130,7 +130,7 @@ func TestImportOctKeyAESKeyWrap(t *testing.T) {
 
 	kek := []byte("0123456789abcdef0123456789abcdef") // 32-byte AES-256 KEK
 
-	_, err := m.ImportKey(ctx, "kek", &driver.KVImportKeyParams{
+	_, err := m.ImportKey(ctx, "default", "kek", &driver.KVImportKeyParams{
 		Key:        driver.KVImportJWK{Kty: "oct", K: kek, KeyOps: []string{"wrapKey", "unwrapKey"}},
 		Attributes: driver.KVKeyAttributes{Enabled: true},
 	})
@@ -138,11 +138,11 @@ func TestImportOctKeyAESKeyWrap(t *testing.T) {
 
 	cek := []byte("fedcba9876543210fedcba9876543210") // 32-byte content key
 
-	wrapped, err := m.WrapKey(ctx, "kek", "", driver.KVCryptoParams{Algorithm: "A256KW", Value: cek})
+	wrapped, err := m.WrapKey(ctx, "default", "kek", "", driver.KVCryptoParams{Algorithm: "A256KW", Value: cek})
 	require.NoError(t, err)
 	assert.NotEqual(t, cek, wrapped.Value)
 
-	unwrapped, err := m.UnwrapKey(ctx, "kek", "", driver.KVCryptoParams{Algorithm: "A256KW", Value: wrapped.Value})
+	unwrapped, err := m.UnwrapKey(ctx, "default", "kek", "", driver.KVCryptoParams{Algorithm: "A256KW", Value: wrapped.Value})
 	require.NoError(t, err)
 	assert.Equal(t, cek, unwrapped.Value)
 }
@@ -153,7 +153,7 @@ func TestAESKeyUnwrapIntegrityFailure(t *testing.T) {
 
 	kek := []byte("0123456789abcdef") // 16-byte AES-128 KEK
 
-	_, err := m.ImportKey(ctx, "kek", &driver.KVImportKeyParams{
+	_, err := m.ImportKey(ctx, "default", "kek", &driver.KVImportKeyParams{
 		Key:        driver.KVImportJWK{Kty: "oct", K: kek},
 		Attributes: driver.KVKeyAttributes{Enabled: true},
 	})
@@ -161,7 +161,7 @@ func TestAESKeyUnwrapIntegrityFailure(t *testing.T) {
 
 	corrupt := make([]byte, 40)
 
-	_, err = m.UnwrapKey(ctx, "kek", "", driver.KVCryptoParams{Algorithm: "A128KW", Value: corrupt})
+	_, err = m.UnwrapKey(ctx, "default", "kek", "", driver.KVCryptoParams{Algorithm: "A128KW", Value: corrupt})
 	require.Error(t, err)
 }
 
@@ -173,7 +173,7 @@ func TestImportRSAKeyRoundTrip(t *testing.T) {
 	// through ImportKey to confirm reconstruction is exact.
 	src := newTestMock()
 
-	_, err := src.CreateKey(ctx, "orig", &driver.KVCreateKeyParams{Kty: "RSA", Attributes: driver.KVKeyAttributes{Enabled: true}})
+	_, err := src.CreateKey(ctx, "default", "orig", &driver.KVCreateKeyParams{Kty: "RSA", Attributes: driver.KVKeyAttributes{Enabled: true}})
 	require.NoError(t, err)
 
 	kd, ok := src.keys.Get("orig")
@@ -191,15 +191,15 @@ func TestImportRSAKeyRoundTrip(t *testing.T) {
 		Q:   priv.Primes[1].Bytes(),
 	}
 
-	_, err = m.ImportKey(ctx, "imp", &driver.KVImportKeyParams{Key: jwk, Attributes: driver.KVKeyAttributes{Enabled: true}})
+	_, err = m.ImportKey(ctx, "default", "imp", &driver.KVImportKeyParams{Key: jwk, Attributes: driver.KVKeyAttributes{Enabled: true}})
 	require.NoError(t, err)
 
 	digest := sha256.Sum256([]byte("cross"))
 
-	sig, err := src.SignKey(ctx, "orig", "", driver.KVCryptoParams{Algorithm: "RS256", Value: digest[:]})
+	sig, err := src.SignKey(ctx, "default", "orig", "", driver.KVCryptoParams{Algorithm: "RS256", Value: digest[:]})
 	require.NoError(t, err)
 
-	ok2, err := m.VerifyKey(ctx, "imp", "", driver.KVCryptoParams{Algorithm: "RS256", Value: digest[:], Signature: sig.Value})
+	ok2, err := m.VerifyKey(ctx, "default", "imp", "", driver.KVCryptoParams{Algorithm: "RS256", Value: digest[:], Signature: sig.Value})
 	require.NoError(t, err)
 	assert.True(t, ok2)
 }
@@ -208,30 +208,30 @@ func TestKeySoftDeleteRecoverPurge(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	_, err := m.CreateKey(ctx, "k", &driver.KVCreateKeyParams{Kty: "RSA", Attributes: driver.KVKeyAttributes{Enabled: true}})
+	_, err := m.CreateKey(ctx, "default", "k", &driver.KVCreateKeyParams{Kty: "RSA", Attributes: driver.KVKeyAttributes{Enabled: true}})
 	require.NoError(t, err)
 
-	_, err = m.DeleteKey(ctx, "k")
+	_, err = m.DeleteKey(ctx, "default", "k")
 	require.NoError(t, err)
 
-	_, err = m.GetKey(ctx, "k", "")
+	_, err = m.GetKey(ctx, "default", "k", "")
 	require.Error(t, err)
 
-	_, err = m.GetDeletedKey(ctx, "k")
+	_, err = m.GetDeletedKey(ctx, "default", "k")
 	require.NoError(t, err)
 
-	_, err = m.RecoverDeletedKey(ctx, "k")
+	_, err = m.RecoverDeletedKey(ctx, "default", "k")
 	require.NoError(t, err)
 
-	_, err = m.GetKey(ctx, "k", "")
+	_, err = m.GetKey(ctx, "default", "k", "")
 	require.NoError(t, err)
 
-	_, err = m.DeleteKey(ctx, "k")
+	_, err = m.DeleteKey(ctx, "default", "k")
 	require.NoError(t, err)
 
-	require.NoError(t, m.PurgeDeletedKey(ctx, "k"))
+	require.NoError(t, m.PurgeDeletedKey(ctx, "default", "k"))
 
-	_, err = m.GetDeletedKey(ctx, "k")
+	_, err = m.GetDeletedKey(ctx, "default", "k")
 	require.Error(t, err)
 }
 
@@ -240,10 +240,10 @@ func TestKeyOperationNotPermitted(t *testing.T) {
 	ctx := context.Background()
 
 	// An EC key defaults to sign/verify only; encrypt must be rejected.
-	_, err := m.CreateKey(ctx, "ec", &driver.KVCreateKeyParams{Kty: "EC", Curve: "P-256", Attributes: driver.KVKeyAttributes{Enabled: true}})
+	_, err := m.CreateKey(ctx, "default", "ec", &driver.KVCreateKeyParams{Kty: "EC", Curve: "P-256", Attributes: driver.KVKeyAttributes{Enabled: true}})
 	require.NoError(t, err)
 
-	_, err = m.EncryptKey(ctx, "ec", "", driver.KVCryptoParams{Algorithm: "RSA-OAEP", Value: []byte("x")})
+	_, err = m.EncryptKey(ctx, "default", "ec", "", driver.KVCryptoParams{Algorithm: "RSA-OAEP", Value: []byte("x")})
 	require.Error(t, err)
 }
 
@@ -251,9 +251,9 @@ func TestDisabledKeyRejectsCrypto(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	_, err := m.CreateKey(ctx, "k", &driver.KVCreateKeyParams{Kty: "RSA", Attributes: driver.KVKeyAttributes{Enabled: false}})
+	_, err := m.CreateKey(ctx, "default", "k", &driver.KVCreateKeyParams{Kty: "RSA", Attributes: driver.KVKeyAttributes{Enabled: false}})
 	require.NoError(t, err)
 
-	_, err = m.EncryptKey(ctx, "k", "", driver.KVCryptoParams{Algorithm: "RSA-OAEP", Value: []byte("x")})
+	_, err = m.EncryptKey(ctx, "default", "k", "", driver.KVCryptoParams{Algorithm: "RSA-OAEP", Value: []byte("x")})
 	require.Error(t, err)
 }

--- a/providers/azure/keyvault/keys_crypto_azure.go
+++ b/providers/azure/keyvault/keys_crypto_azure.go
@@ -41,8 +41,8 @@ const (
 )
 
 // opKey resolves a live, enabled key version and checks that op is permitted.
-func (m *Mock) opKey(name, version, op string) (*keyVersion, error) {
-	kd := m.liveKey(name)
+func (m *Mock) opKey(vault, name, version, op string) (*keyVersion, error) {
+	kd := liveKey(m.vault(vault).keys, name)
 	if kd == nil {
 		return nil, errors.Newf(errors.NotFound, "key %q not found", name)
 	}
@@ -92,8 +92,8 @@ func result(v *keyVersion, out []byte) *driver.KVCryptoResult {
 }
 
 // EncryptKey encrypts a single block with the key's public part.
-func (m *Mock) EncryptKey(_ context.Context, name, version string, p driver.KVCryptoParams) (*driver.KVCryptoResult, error) {
-	v, err := m.opKey(name, version, "encrypt")
+func (m *Mock) EncryptKey(_ context.Context, vault, name, version string, p driver.KVCryptoParams) (*driver.KVCryptoResult, error) {
+	v, err := m.opKey(vault, name, version, "encrypt")
 	if err != nil {
 		return nil, err
 	}
@@ -111,8 +111,8 @@ func (m *Mock) EncryptKey(_ context.Context, name, version string, p driver.KVCr
 }
 
 // DecryptKey decrypts a single block with the key's private part.
-func (m *Mock) DecryptKey(_ context.Context, name, version string, p driver.KVCryptoParams) (*driver.KVCryptoResult, error) {
-	v, err := m.opKey(name, version, "decrypt")
+func (m *Mock) DecryptKey(_ context.Context, vault, name, version string, p driver.KVCryptoParams) (*driver.KVCryptoResult, error) {
+	v, err := m.opKey(vault, name, version, "decrypt")
 	if err != nil {
 		return nil, err
 	}
@@ -131,8 +131,8 @@ func (m *Mock) DecryptKey(_ context.Context, name, version string, p driver.KVCr
 
 // WrapKey wraps a symmetric key. RSA keys wrap with the RSA algorithms; oct
 // keys wrap with AES key wrap (RFC 3394).
-func (m *Mock) WrapKey(_ context.Context, name, version string, p driver.KVCryptoParams) (*driver.KVCryptoResult, error) {
-	v, err := m.opKey(name, version, "wrapKey")
+func (m *Mock) WrapKey(_ context.Context, vault, name, version string, p driver.KVCryptoParams) (*driver.KVCryptoResult, error) {
+	v, err := m.opKey(vault, name, version, "wrapKey")
 	if err != nil {
 		return nil, err
 	}
@@ -146,8 +146,8 @@ func (m *Mock) WrapKey(_ context.Context, name, version string, p driver.KVCrypt
 }
 
 // UnwrapKey reverses WrapKey.
-func (m *Mock) UnwrapKey(_ context.Context, name, version string, p driver.KVCryptoParams) (*driver.KVCryptoResult, error) {
-	v, err := m.opKey(name, version, "unwrapKey")
+func (m *Mock) UnwrapKey(_ context.Context, vault, name, version string, p driver.KVCryptoParams) (*driver.KVCryptoResult, error) {
+	v, err := m.opKey(vault, name, version, "unwrapKey")
 	if err != nil {
 		return nil, err
 	}
@@ -202,8 +202,8 @@ func rsaDecrypt(key *rsa.PrivateKey, alg string, ct []byte) ([]byte, error) {
 }
 
 // SignKey signs a pre-computed digest and returns the signature.
-func (m *Mock) SignKey(_ context.Context, name, version string, p driver.KVCryptoParams) (*driver.KVCryptoResult, error) {
-	v, err := m.opKey(name, version, "sign")
+func (m *Mock) SignKey(_ context.Context, vault, name, version string, p driver.KVCryptoParams) (*driver.KVCryptoResult, error) {
+	v, err := m.opKey(vault, name, version, "sign")
 	if err != nil {
 		return nil, err
 	}
@@ -217,8 +217,8 @@ func (m *Mock) SignKey(_ context.Context, name, version string, p driver.KVCrypt
 }
 
 // VerifyKey checks a signature over a digest.
-func (m *Mock) VerifyKey(_ context.Context, name, version string, p driver.KVCryptoParams) (bool, error) {
-	v, err := m.opKey(name, version, "verify")
+func (m *Mock) VerifyKey(_ context.Context, vault, name, version string, p driver.KVCryptoParams) (bool, error) {
+	v, err := m.opKey(vault, name, version, "verify")
 	if err != nil {
 		return false, err
 	}

--- a/providers/azure/keyvault/keys_store_azure.go
+++ b/providers/azure/keyvault/keys_store_azure.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
 )
 
@@ -57,9 +58,10 @@ func toKVKey(name string, v *keyVersion) driver.KVKey {
 	return kv
 }
 
-// liveKey returns the stored key if it exists and is not soft-deleted.
-func (m *Mock) liveKey(name string) *keyData {
-	kd, ok := m.keys.Get(name)
+// liveKey returns the stored key from store if it exists and is not
+// soft-deleted.
+func liveKey(store *memstore.Store[*keyData], name string) *keyData {
+	kd, ok := store.Get(name)
 	if !ok {
 		return nil
 	}
@@ -91,8 +93,8 @@ func findKeyVersion(kd *keyData, version string) *keyVersion {
 }
 
 // GetKey returns one key version. Empty version returns the current version.
-func (m *Mock) GetKey(_ context.Context, name, version string) (*driver.KVKey, error) {
-	kd := m.liveKey(name)
+func (m *Mock) GetKey(_ context.Context, vault, name, version string) (*driver.KVKey, error) {
+	kd := liveKey(m.vault(vault).keys, name)
 	if kd == nil {
 		return nil, errors.Newf(errors.NotFound, "key %q not found", name)
 	}
@@ -111,8 +113,8 @@ func (m *Mock) GetKey(_ context.Context, name, version string) (*driver.KVKey, e
 }
 
 // ListKeys returns the current version of each live key.
-func (m *Mock) ListKeys(_ context.Context) ([]driver.KVKey, error) {
-	all := m.keys.All()
+func (m *Mock) ListKeys(_ context.Context, vault string) ([]driver.KVKey, error) {
+	all := m.vault(vault).keys.All()
 
 	out := make([]driver.KVKey, 0, len(all))
 
@@ -130,8 +132,8 @@ func (m *Mock) ListKeys(_ context.Context) ([]driver.KVKey, error) {
 }
 
 // ListKeyVersions returns every version of a key.
-func (m *Mock) ListKeyVersions(_ context.Context, name string) ([]driver.KVKey, error) {
-	kd := m.liveKey(name)
+func (m *Mock) ListKeyVersions(_ context.Context, vault, name string) ([]driver.KVKey, error) {
+	kd := liveKey(m.vault(vault).keys, name)
 	if kd == nil {
 		return nil, errors.Newf(errors.NotFound, "key %q not found", name)
 	}
@@ -148,8 +150,8 @@ func (m *Mock) ListKeyVersions(_ context.Context, name string) ([]driver.KVKey, 
 }
 
 // UpdateKey patches a version's attributes, tags and key operations.
-func (m *Mock) UpdateKey(_ context.Context, name, version string, patch driver.KVKeyPatch) (*driver.KVKey, error) {
-	kd := m.liveKey(name)
+func (m *Mock) UpdateKey(_ context.Context, vault, name, version string, patch driver.KVKeyPatch) (*driver.KVKey, error) {
+	kd := liveKey(m.vault(vault).keys, name)
 	if kd == nil {
 		return nil, errors.Newf(errors.NotFound, "key %q not found", name)
 	}
@@ -193,8 +195,8 @@ func applyKeyPatch(v *keyVersion, patch driver.KVKeyPatch) {
 }
 
 // DeleteKey soft-deletes a key and returns its deleted view.
-func (m *Mock) DeleteKey(_ context.Context, name string) (*driver.KVDeletedKey, error) {
-	kd := m.liveKey(name)
+func (m *Mock) DeleteKey(_ context.Context, vault, name string) (*driver.KVDeletedKey, error) {
+	kd := liveKey(m.vault(vault).keys, name)
 	if kd == nil {
 		return nil, errors.Newf(errors.NotFound, "key %q not found", name)
 	}
@@ -228,8 +230,8 @@ func deletedKeyView(kd *keyData) *driver.KVDeletedKey {
 }
 
 // GetDeletedKey returns a soft-deleted key by name.
-func (m *Mock) GetDeletedKey(_ context.Context, name string) (*driver.KVDeletedKey, error) {
-	kd, ok := m.keys.Get(name)
+func (m *Mock) GetDeletedKey(_ context.Context, vault, name string) (*driver.KVDeletedKey, error) {
+	kd, ok := m.vault(vault).keys.Get(name)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "deleted key %q not found", name)
 	}
@@ -245,8 +247,8 @@ func (m *Mock) GetDeletedKey(_ context.Context, name string) (*driver.KVDeletedK
 }
 
 // ListDeletedKeys returns all soft-deleted keys.
-func (m *Mock) ListDeletedKeys(_ context.Context) ([]driver.KVDeletedKey, error) {
-	all := m.keys.All()
+func (m *Mock) ListDeletedKeys(_ context.Context, vault string) ([]driver.KVDeletedKey, error) {
+	all := m.vault(vault).keys.All()
 
 	out := make([]driver.KVDeletedKey, 0, len(all))
 
@@ -262,8 +264,8 @@ func (m *Mock) ListDeletedKeys(_ context.Context) ([]driver.KVDeletedKey, error)
 }
 
 // RecoverDeletedKey clears the soft-delete state of a key.
-func (m *Mock) RecoverDeletedKey(_ context.Context, name string) (*driver.KVKey, error) {
-	kd, ok := m.keys.Get(name)
+func (m *Mock) RecoverDeletedKey(_ context.Context, vault, name string) (*driver.KVKey, error) {
+	kd, ok := m.vault(vault).keys.Get(name)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "deleted key %q not found", name)
 	}
@@ -289,8 +291,10 @@ func (m *Mock) RecoverDeletedKey(_ context.Context, name string) (*driver.KVKey,
 }
 
 // PurgeDeletedKey permanently removes a soft-deleted key.
-func (m *Mock) PurgeDeletedKey(_ context.Context, name string) error {
-	kd, ok := m.keys.Get(name)
+func (m *Mock) PurgeDeletedKey(_ context.Context, vault, name string) error {
+	store := m.vault(vault).keys
+
+	kd, ok := store.Get(name)
 	if !ok {
 		return errors.Newf(errors.NotFound, "deleted key %q not found", name)
 	}
@@ -303,7 +307,58 @@ func (m *Mock) PurgeDeletedKey(_ context.Context, name string) error {
 		return errors.Newf(errors.NotFound, "deleted key %q not found", name)
 	}
 
-	m.keys.Delete(name)
+	store.Delete(name)
 
 	return nil
+}
+
+// GetKeyRotationPolicy returns name's rotation policy. A key that has never
+// had a policy set returns Key Vault's empty default (no lifetime actions, no
+// expiry) rather than an error.
+func (m *Mock) GetKeyRotationPolicy(_ context.Context, vault, name string) (*driver.KVRotationPolicy, error) {
+	kd := liveKey(m.vault(vault).keys, name)
+	if kd == nil {
+		return nil, errors.Newf(errors.NotFound, "key %q not found", name)
+	}
+
+	kd.mu.RLock()
+	defer kd.mu.RUnlock()
+
+	if kd.rotationPolicy == nil {
+		return &driver.KVRotationPolicy{}, nil
+	}
+
+	policy := *kd.rotationPolicy
+
+	return &policy, nil
+}
+
+// UpdateKeyRotationPolicy replaces name's rotation policy, preserving its
+// original Created time (Key Vault semantics: Created is set once, Updated
+// changes on every write).
+func (m *Mock) UpdateKeyRotationPolicy(
+	_ context.Context, vault, name string, policy driver.KVRotationPolicy,
+) (*driver.KVRotationPolicy, error) {
+	kd := liveKey(m.vault(vault).keys, name)
+	if kd == nil {
+		return nil, errors.Newf(errors.NotFound, "key %q not found", name)
+	}
+
+	kd.mu.Lock()
+	defer kd.mu.Unlock()
+
+	now := m.opts.Clock.Now().UTC().Unix()
+
+	created := now
+	if kd.rotationPolicy != nil {
+		created = kd.rotationPolicy.Created
+	}
+
+	policy.Created = created
+	policy.Updated = now
+	kd.rotationPolicy = &policy
+
+	stored := *kd.rotationPolicy
+
+	return &stored, nil
 }

--- a/providers/azure/keyvault/keyvault.go
+++ b/providers/azure/keyvault/keyvault.go
@@ -47,20 +47,81 @@ type secretData struct {
 	mu             sync.RWMutex
 }
 
-// Mock is an in-memory mock implementation of Azure Key Vault.
-type Mock struct {
+// vaultData is one Key Vault vault's isolated secrets/keys namespace. The
+// KeyVaultSecrets and KeyVaultKeys surfaces (server/azure/keyvault) each
+// resolve the caller's vault name to one of these before touching storage, so
+// a secret or key created in one vault is never visible through another.
+type vaultData struct {
 	secrets *memstore.Store[*secretData]
 	keys    *memstore.Store[*keyData]
-	opts    *config.Options
+}
+
+func newVaultData() *vaultData {
+	return &vaultData{
+		secrets: memstore.New[*secretData](),
+		keys:    memstore.New[*keyData](),
+	}
+}
+
+// defaultVault is the vault name that backs the shared, cross-cloud Secrets
+// driver interface (CreateSecret, GetSecret, PutSecretValue, ...), which has
+// no notion of a vault. A caller that reaches the Key Vault data-plane API
+// under this vault name (the wire layer's host-extraction fallback for a
+// request whose Host carries no recognizable vault subdomain — see
+// vaultFromRequest in server/azure/keyvault) sees the exact same secrets and
+// keys the portable API manages, preserving pre-multi-vault behavior. Any
+// other vault name gets its own fully isolated namespace.
+const defaultVault = "default"
+
+// Mock is an in-memory mock implementation of Azure Key Vault.
+type Mock struct {
+	// secrets and keys are the defaultVault's stores, kept as direct fields so
+	// the shared Secrets driver interface methods (which carry no vault name)
+	// can use them without a map lookup.
+	secrets *memstore.Store[*secretData]
+	keys    *memstore.Store[*keyData]
+	// vaults backs the Azure-specific KeyVaultSecrets/KeyVaultKeys data-plane
+	// surface, keyed by vault name, so secrets/keys are isolated per vault.
+	// vaults[defaultVault] aliases secrets/keys above.
+	vaults *memstore.Store[*vaultData]
+	opts   *config.Options
 }
 
 // New creates a new Key Vault mock with the given configuration options.
 func New(opts *config.Options) *Mock {
+	secrets := memstore.New[*secretData]()
+	keys := memstore.New[*keyData]()
+
+	vaults := memstore.New[*vaultData]()
+	vaults.Set(defaultVault, &vaultData{secrets: secrets, keys: keys})
+
 	return &Mock{
-		secrets: memstore.New[*secretData](),
-		keys:    memstore.New[*keyData](),
+		secrets: secrets,
+		keys:    keys,
+		vaults:  vaults,
 		opts:    opts,
 	}
+}
+
+// vault returns the named vault's secret/key store, creating it on first
+// touch. Key Vault vaults have no separate ARM "create vault" step in the
+// data-plane surface cloudemu emulates, so a vault springs into existence the
+// first time any secret or key name is addressed within it.
+func (m *Mock) vault(name string) *vaultData {
+	if vd, ok := m.vaults.Get(name); ok {
+		return vd
+	}
+
+	vd := newVaultData()
+	if m.vaults.SetIfAbsent(name, vd) {
+		return vd
+	}
+
+	// Lost the race to a concurrent first touch of the same vault name;
+	// use the winner's store instead of orphaning ours.
+	existing, _ := m.vaults.Get(name)
+
+	return existing
 }
 
 func copyTags(in map[string]string) map[string]string {

--- a/providers/azure/keyvault/keyvault_azure.go
+++ b/providers/azure/keyvault/keyvault_azure.go
@@ -7,8 +7,28 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
 )
+
+// liveVaultSecret returns the stored secret from store if it exists and is
+// not soft-deleted.
+func liveVaultSecret(store *memstore.Store[*secretData], name string) *secretData {
+	sd, ok := store.Get(name)
+	if !ok {
+		return nil
+	}
+
+	sd.mu.RLock()
+	deleted := !sd.deletedAt.IsZero()
+	sd.mu.RUnlock()
+
+	if deleted {
+		return nil
+	}
+
+	return sd
+}
 
 func (v *secretVersion) toKV(name string) driver.KVSecret {
 	return driver.KVSecret{
@@ -28,12 +48,14 @@ func (v *secretVersion) toKV(name string) driver.KVSecret {
 
 // SetKeyVaultSecret creates the secret on first call and appends a new version
 // on subsequent calls, carrying content type, tags and attributes.
-func (m *Mock) SetKeyVaultSecret(_ context.Context, name string, params driver.KVSetParams) (*driver.KVSecret, error) {
+func (m *Mock) SetKeyVaultSecret(_ context.Context, vault, name string, params driver.KVSetParams) (*driver.KVSecret, error) {
 	if name == "" {
 		return nil, errors.New(errors.InvalidArgument, "secret name is required")
 	}
 
-	if sd, ok := m.secrets.Get(name); ok {
+	store := m.vault(vault).secrets
+
+	if sd, ok := store.Get(name); ok {
 		sd.mu.Lock()
 		defer sd.mu.Unlock()
 
@@ -75,7 +97,7 @@ func (m *Mock) SetKeyVaultSecret(_ context.Context, name string, params driver.K
 		versions: []secretVersion{v},
 	}
 
-	m.secrets.Set(name, sd)
+	store.Set(name, sd)
 
 	kv := v.toKV(name)
 
@@ -83,8 +105,8 @@ func (m *Mock) SetKeyVaultSecret(_ context.Context, name string, params driver.K
 }
 
 // GetKeyVaultSecret returns one secret version. Empty version returns current.
-func (m *Mock) GetKeyVaultSecret(_ context.Context, name, version string) (*driver.KVSecret, error) {
-	sd := m.liveSecret(name)
+func (m *Mock) GetKeyVaultSecret(_ context.Context, vault, name, version string) (*driver.KVSecret, error) {
+	sd := liveVaultSecret(m.vault(vault).secrets, name)
 	if sd == nil {
 		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
 	}
@@ -103,8 +125,8 @@ func (m *Mock) GetKeyVaultSecret(_ context.Context, name, version string) (*driv
 }
 
 // ListKeyVaultSecrets returns the current version of each live secret.
-func (m *Mock) ListKeyVaultSecrets(_ context.Context) ([]driver.KVSecret, error) {
-	all := m.secrets.All()
+func (m *Mock) ListKeyVaultSecrets(_ context.Context, vault string) ([]driver.KVSecret, error) {
+	all := m.vault(vault).secrets.All()
 
 	out := make([]driver.KVSecret, 0, len(all))
 
@@ -124,8 +146,8 @@ func (m *Mock) ListKeyVaultSecrets(_ context.Context) ([]driver.KVSecret, error)
 }
 
 // ListKeyVaultSecretVersions returns every version of a secret (no values).
-func (m *Mock) ListKeyVaultSecretVersions(_ context.Context, name string) ([]driver.KVSecret, error) {
-	sd := m.liveSecret(name)
+func (m *Mock) ListKeyVaultSecretVersions(_ context.Context, vault, name string) ([]driver.KVSecret, error) {
+	sd := liveVaultSecret(m.vault(vault).secrets, name)
 	if sd == nil {
 		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
 	}
@@ -145,8 +167,8 @@ func (m *Mock) ListKeyVaultSecretVersions(_ context.Context, name string) ([]dri
 }
 
 // UpdateKeyVaultSecret patches a version's attributes, tags and content type.
-func (m *Mock) UpdateKeyVaultSecret(_ context.Context, name, version string, patch driver.KVPatch) (*driver.KVSecret, error) {
-	sd := m.liveSecret(name)
+func (m *Mock) UpdateKeyVaultSecret(_ context.Context, vault, name, version string, patch driver.KVPatch) (*driver.KVSecret, error) {
+	sd := liveVaultSecret(m.vault(vault).secrets, name)
 	if sd == nil {
 		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
 	}
@@ -195,8 +217,8 @@ func applyPatch(v *secretVersion, patch driver.KVPatch) {
 }
 
 // DeleteKeyVaultSecret soft-deletes a secret and returns its deleted view.
-func (m *Mock) DeleteKeyVaultSecret(_ context.Context, name string) (*driver.KVDeletedSecret, error) {
-	sd := m.liveSecret(name)
+func (m *Mock) DeleteKeyVaultSecret(_ context.Context, vault, name string) (*driver.KVDeletedSecret, error) {
+	sd := liveVaultSecret(m.vault(vault).secrets, name)
 	if sd == nil {
 		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
 	}
@@ -228,8 +250,8 @@ func deletedView(sd *secretData) *driver.KVDeletedSecret {
 }
 
 // GetDeletedKeyVaultSecret returns a soft-deleted secret by name.
-func (m *Mock) GetDeletedKeyVaultSecret(_ context.Context, name string) (*driver.KVDeletedSecret, error) {
-	sd, ok := m.secrets.Get(name)
+func (m *Mock) GetDeletedKeyVaultSecret(_ context.Context, vault, name string) (*driver.KVDeletedSecret, error) {
+	sd, ok := m.vault(vault).secrets.Get(name)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "deleted secret %q not found", name)
 	}
@@ -245,8 +267,8 @@ func (m *Mock) GetDeletedKeyVaultSecret(_ context.Context, name string) (*driver
 }
 
 // ListDeletedKeyVaultSecrets returns all soft-deleted secrets.
-func (m *Mock) ListDeletedKeyVaultSecrets(_ context.Context) ([]driver.KVDeletedSecret, error) {
-	all := m.secrets.All()
+func (m *Mock) ListDeletedKeyVaultSecrets(_ context.Context, vault string) ([]driver.KVDeletedSecret, error) {
+	all := m.vault(vault).secrets.All()
 
 	out := make([]driver.KVDeletedSecret, 0, len(all))
 
@@ -262,8 +284,8 @@ func (m *Mock) ListDeletedKeyVaultSecrets(_ context.Context) ([]driver.KVDeleted
 }
 
 // RecoverDeletedKeyVaultSecret clears the soft-delete state of a secret.
-func (m *Mock) RecoverDeletedKeyVaultSecret(_ context.Context, name string) (*driver.KVSecret, error) {
-	sd, ok := m.secrets.Get(name)
+func (m *Mock) RecoverDeletedKeyVaultSecret(_ context.Context, vault, name string) (*driver.KVSecret, error) {
+	sd, ok := m.vault(vault).secrets.Get(name)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "deleted secret %q not found", name)
 	}
@@ -289,8 +311,10 @@ func (m *Mock) RecoverDeletedKeyVaultSecret(_ context.Context, name string) (*dr
 }
 
 // PurgeDeletedKeyVaultSecret permanently removes a soft-deleted secret.
-func (m *Mock) PurgeDeletedKeyVaultSecret(_ context.Context, name string) error {
-	sd, ok := m.secrets.Get(name)
+func (m *Mock) PurgeDeletedKeyVaultSecret(_ context.Context, vault, name string) error {
+	store := m.vault(vault).secrets
+
+	sd, ok := store.Get(name)
 	if !ok {
 		return errors.Newf(errors.NotFound, "deleted secret %q not found", name)
 	}
@@ -303,7 +327,7 @@ func (m *Mock) PurgeDeletedKeyVaultSecret(_ context.Context, name string) error 
 		return errors.Newf(errors.NotFound, "deleted secret %q not found", name)
 	}
 
-	m.secrets.Delete(name)
+	store.Delete(name)
 
 	return nil
 }
@@ -328,8 +352,8 @@ type backupSnapshot struct {
 }
 
 // BackupKeyVaultSecret returns an opaque blob capturing every version.
-func (m *Mock) BackupKeyVaultSecret(_ context.Context, name string) ([]byte, error) {
-	sd := m.liveSecret(name)
+func (m *Mock) BackupKeyVaultSecret(_ context.Context, vault, name string) ([]byte, error) {
+	sd := liveVaultSecret(m.vault(vault).secrets, name)
 	if sd == nil {
 		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
 	}
@@ -352,7 +376,7 @@ func (m *Mock) BackupKeyVaultSecret(_ context.Context, name string) ([]byte, err
 }
 
 // RestoreKeyVaultSecret recreates a secret from a backup blob.
-func (m *Mock) RestoreKeyVaultSecret(_ context.Context, backup []byte) (*driver.KVSecret, error) {
+func (m *Mock) RestoreKeyVaultSecret(_ context.Context, vault string, backup []byte) (*driver.KVSecret, error) {
 	var snap backupSnapshot
 	if err := json.Unmarshal(backup, &snap); err != nil {
 		return nil, errors.New(errors.InvalidArgument, "invalid secret backup blob")
@@ -362,7 +386,9 @@ func (m *Mock) RestoreKeyVaultSecret(_ context.Context, backup []byte) (*driver.
 		return nil, errors.New(errors.InvalidArgument, "invalid secret backup blob")
 	}
 
-	if _, ok := m.secrets.Get(snap.Name); ok {
+	store := m.vault(vault).secrets
+
+	if _, ok := store.Get(snap.Name); ok {
 		return nil, errors.Newf(errors.AlreadyExists, "secret %q already exists", snap.Name)
 	}
 
@@ -387,7 +413,7 @@ func (m *Mock) RestoreKeyVaultSecret(_ context.Context, backup []byte) (*driver.
 		})
 	}
 
-	m.secrets.Set(snap.Name, sd)
+	store.Set(snap.Name, sd)
 
 	v := findVersion(sd, "")
 

--- a/providers/azure/keyvault/keyvault_azure_test.go
+++ b/providers/azure/keyvault/keyvault_azure_test.go
@@ -13,7 +13,7 @@ func TestSetKeyVaultSecretRoundTrip(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	kv, err := m.SetKeyVaultSecret(ctx, "s", driver.KVSetParams{
+	kv, err := m.SetKeyVaultSecret(ctx, "default", "s", driver.KVSetParams{
 		Value:       []byte("v"),
 		ContentType: "text/plain",
 		Tags:        map[string]string{"k": "val"},
@@ -27,7 +27,7 @@ func TestSetKeyVaultSecretRoundTrip(t *testing.T) {
 	assert.Equal(t, int64(222), kv.NotBefore)
 	assert.Equal(t, "val", kv.Tags["k"])
 
-	got, err := m.GetKeyVaultSecret(ctx, "s", "")
+	got, err := m.GetKeyVaultSecret(ctx, "default", "s", "")
 	require.NoError(t, err)
 	assert.Equal(t, "text/plain", got.ContentType)
 	assert.False(t, got.Enabled)
@@ -37,7 +37,7 @@ func TestUpdateKeyVaultSecretPartial(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	set, err := m.SetKeyVaultSecret(ctx, "s", driver.KVSetParams{
+	set, err := m.SetKeyVaultSecret(ctx, "default", "s", driver.KVSetParams{
 		Value:       []byte("v"),
 		ContentType: "text/plain",
 		Attributes:  driver.KVAttributes{Enabled: true},
@@ -45,7 +45,7 @@ func TestUpdateKeyVaultSecretPartial(t *testing.T) {
 	require.NoError(t, err)
 
 	enabled := false
-	upd, err := m.UpdateKeyVaultSecret(ctx, "s", set.Version, driver.KVPatch{Enabled: &enabled})
+	upd, err := m.UpdateKeyVaultSecret(ctx, "default", "s", set.Version, driver.KVPatch{Enabled: &enabled})
 	require.NoError(t, err)
 
 	// Content type untouched, enabled patched.
@@ -57,25 +57,25 @@ func TestKeyVaultSoftDeleteLifecycle(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	_, err := m.SetKeyVaultSecret(ctx, "s", driver.KVSetParams{Value: []byte("v"), Attributes: driver.KVAttributes{Enabled: true}})
+	_, err := m.SetKeyVaultSecret(ctx, "default", "s", driver.KVSetParams{Value: []byte("v"), Attributes: driver.KVAttributes{Enabled: true}})
 	require.NoError(t, err)
 
-	del, err := m.DeleteKeyVaultSecret(ctx, "s")
+	del, err := m.DeleteKeyVaultSecret(ctx, "default", "s")
 	require.NoError(t, err)
 	assert.NotZero(t, del.DeletedDate)
 	assert.NotZero(t, del.ScheduledPurgeDate)
 
-	_, err = m.GetKeyVaultSecret(ctx, "s", "")
+	_, err = m.GetKeyVaultSecret(ctx, "default", "s", "")
 	require.Error(t, err)
 
-	dl, err := m.ListDeletedKeyVaultSecrets(ctx)
+	dl, err := m.ListDeletedKeyVaultSecrets(ctx, "default")
 	require.NoError(t, err)
 	assert.Len(t, dl, 1)
 
-	_, err = m.RecoverDeletedKeyVaultSecret(ctx, "s")
+	_, err = m.RecoverDeletedKeyVaultSecret(ctx, "default", "s")
 	require.NoError(t, err)
 
-	_, err = m.GetKeyVaultSecret(ctx, "s", "")
+	_, err = m.GetKeyVaultSecret(ctx, "default", "s", "")
 	require.NoError(t, err)
 }
 
@@ -83,15 +83,15 @@ func TestKeyVaultPurge(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	_, err := m.SetKeyVaultSecret(ctx, "s", driver.KVSetParams{Value: []byte("v"), Attributes: driver.KVAttributes{Enabled: true}})
+	_, err := m.SetKeyVaultSecret(ctx, "default", "s", driver.KVSetParams{Value: []byte("v"), Attributes: driver.KVAttributes{Enabled: true}})
 	require.NoError(t, err)
 
-	_, err = m.DeleteKeyVaultSecret(ctx, "s")
+	_, err = m.DeleteKeyVaultSecret(ctx, "default", "s")
 	require.NoError(t, err)
 
-	require.NoError(t, m.PurgeDeletedKeyVaultSecret(ctx, "s"))
+	require.NoError(t, m.PurgeDeletedKeyVaultSecret(ctx, "default", "s"))
 
-	_, err = m.GetDeletedKeyVaultSecret(ctx, "s")
+	_, err = m.GetDeletedKeyVaultSecret(ctx, "default", "s")
 	require.Error(t, err)
 }
 
@@ -99,23 +99,23 @@ func TestKeyVaultBackupRestore(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	_, err := m.SetKeyVaultSecret(ctx, "s", driver.KVSetParams{
+	_, err := m.SetKeyVaultSecret(ctx, "default", "s", driver.KVSetParams{
 		Value:       []byte("secret"),
 		ContentType: "text/plain",
 		Attributes:  driver.KVAttributes{Enabled: true},
 	})
 	require.NoError(t, err)
 
-	blob, err := m.BackupKeyVaultSecret(ctx, "s")
+	blob, err := m.BackupKeyVaultSecret(ctx, "default", "s")
 	require.NoError(t, err)
 	require.NotEmpty(t, blob)
 
-	_, err = m.DeleteKeyVaultSecret(ctx, "s")
+	_, err = m.DeleteKeyVaultSecret(ctx, "default", "s")
 	require.NoError(t, err)
 
-	require.NoError(t, m.PurgeDeletedKeyVaultSecret(ctx, "s"))
+	require.NoError(t, m.PurgeDeletedKeyVaultSecret(ctx, "default", "s"))
 
-	restored, err := m.RestoreKeyVaultSecret(ctx, blob)
+	restored, err := m.RestoreKeyVaultSecret(ctx, "default", blob)
 	require.NoError(t, err)
 	assert.Equal(t, "secret", string(restored.Value))
 	assert.Equal(t, "text/plain", restored.ContentType)

--- a/providers/azure/keyvault/keyvault_test.go
+++ b/providers/azure/keyvault/keyvault_test.go
@@ -404,7 +404,7 @@ func TestCreateSecretRejectsSoftDeletedName(t *testing.T) {
 
 	// The soft-deleted secret is untouched and still recoverable with its
 	// original value.
-	recovered, err := m.RecoverDeletedKeyVaultSecret(context.Background(), "sd-secret")
+	recovered, err := m.RecoverDeletedKeyVaultSecret(context.Background(), "default", "sd-secret")
 	require.NoError(t, err)
 	assert.Equal(t, "v1", string(recovered.Value))
 }

--- a/providers/azure/keyvault/vault_test.go
+++ b/providers/azure/keyvault/vault_test.go
@@ -1,0 +1,81 @@
+package keyvault
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVaultLazyCreateIsRaceSafe exercises the concurrent first-touch path in
+// Mock.vault: many goroutines racing to address the same brand-new vault name
+// (each writing its own distinct secret) must all end up sharing exactly one
+// store for that vault — the SetIfAbsent/Get double-check in vault() must
+// never let two goroutines settle on two different winning stores, which
+// would silently split the vault's secrets across them. Run with -race.
+func TestVaultLazyCreateIsRaceSafe(t *testing.T) {
+	m := newTestMock()
+
+	const goroutines = 32
+
+	var wg sync.WaitGroup
+
+	wg.Add(goroutines)
+
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+
+			_, err := m.SetKeyVaultSecret(context.Background(), "race-vault", fmt.Sprintf("s-%d", i),
+				driver.KVSetParams{Value: []byte("v"), Attributes: driver.KVAttributes{Enabled: true}})
+			assert.NoError(t, err, "goroutine %d", i)
+		}(i)
+	}
+
+	wg.Wait()
+
+	all, err := m.ListKeyVaultSecrets(context.Background(), "race-vault")
+	require.NoError(t, err)
+	assert.Len(t, all, goroutines, "vault() must not split concurrent first-touches of a new vault across two different stores")
+}
+
+// TestVaultIsolation is the package-internal counterpart to the SDK-level
+// isolation regression tests in server/azure/keyvault: the same secret and
+// key name in two different vaults must not alias each other, and the
+// "default" vault must stay aliased to the shared, vault-less Secrets
+// interface for backward compatibility.
+func TestVaultIsolation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.SetKeyVaultSecret(ctx, "vault-a", "shared-name", driver.KVSetParams{
+		Value: []byte("a-value"), Attributes: driver.KVAttributes{Enabled: true},
+	})
+	require.NoError(t, err)
+
+	// vault-b must not see vault-a's secret.
+	_, err = m.GetKeyVaultSecret(ctx, "vault-b", "shared-name", "")
+	require.Error(t, err)
+
+	_, err = m.SetKeyVaultSecret(ctx, "vault-b", "shared-name", driver.KVSetParams{
+		Value: []byte("b-value"), Attributes: driver.KVAttributes{Enabled: true},
+	})
+	require.NoError(t, err)
+
+	gotA, err := m.GetKeyVaultSecret(ctx, "vault-a", "shared-name", "")
+	require.NoError(t, err)
+	assert.Equal(t, "a-value", string(gotA.Value), "vault-a must be unaffected by vault-b's SetKeyVaultSecret")
+
+	// The "default" vault is the same namespace the shared portable Secrets
+	// interface (CreateSecret/GetSecret/...) manages.
+	_, err = m.CreateSecret(ctx, driver.SecretConfig{Name: "portable-secret"}, []byte("portable-value"))
+	require.NoError(t, err)
+
+	viaKeyVault, err := m.GetKeyVaultSecret(ctx, "default", "portable-secret", "")
+	require.NoError(t, err)
+	assert.Equal(t, "portable-value", string(viaKeyVault.Value))
+}

--- a/server/azure/keyvault/handler.go
+++ b/server/azure/keyvault/handler.go
@@ -191,6 +191,40 @@ func (h *Handler) routeDeleted(w http.ResponseWriter, r *http.Request, tail stri
 	}
 }
 
+// vaultSuffixes are the DNS suffixes real Key Vault and Managed HSM data-plane
+// hosts are addressed under, across Azure public/US Gov/China clouds. The
+// vault (or HSM) name is the leading label of the host.
+//
+//nolint:gochecknoglobals // read-only lookup table, not mutable state
+var vaultSuffixes = []string{
+	".vault.azure.net",
+	".vault.azure.cn",
+	".vault.usgovcloudapi.net",
+	".managedhsm.azure.net",
+	".managedhsm.azure.cn",
+	".managedhsm.usgovcloudapi.net",
+}
+
+// vaultFromRequest extracts the vault name that scopes secret/key isolation
+// for r, so that a secret or key created in one vault is never visible
+// through another. Real Key Vault clients address a vault via its unique
+// {vault-name}.vault.azure.net (or Managed HSM equivalent) subdomain; a
+// request whose Host carries none of those suffixes (a bare host, as in a
+// test pointed directly at this server without DisableChallengeResourceVerification-style
+// vault URLs) falls back to a single "default" vault, matching this server's
+// pre-multi-vault behavior.
+func vaultFromRequest(r *http.Request) string {
+	host, _, _ := strings.Cut(r.Host, ":")
+
+	for _, suffix := range vaultSuffixes {
+		if i := strings.Index(host, suffix); i > 0 {
+			return host[:i]
+		}
+	}
+
+	return "default"
+}
+
 // bearerChallenge answers an unauthenticated request with the Key Vault bearer
 // challenge and reports whether it handled the request. Key Vault SDKs expect a
 // 401 with a WWW-Authenticate header before retrying with a token.

--- a/server/azure/keyvault/keys_crypto_operations.go
+++ b/server/azure/keyvault/keys_crypto_operations.go
@@ -11,7 +11,7 @@ import (
 // cryptoOp decodes a keyOperationRequest, runs op, and writes the result.
 func cryptoOp(
 	w http.ResponseWriter, r *http.Request, name, version string,
-	op func(name, version string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error),
+	op func(vault, name, version string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error),
 ) {
 	var req keyOperationRequest
 	if !wire.DecodeJSON(w, r, &req) {
@@ -24,7 +24,7 @@ func cryptoOp(
 		return
 	}
 
-	res, err := op(name, version, secretsdriver.KVCryptoParams{Algorithm: req.Alg, Value: value})
+	res, err := op(vaultFromRequest(r), name, version, secretsdriver.KVCryptoParams{Algorithm: req.Alg, Value: value})
 	if err != nil {
 		writeKeyErr(w, err)
 		return
@@ -37,32 +37,32 @@ func cryptoOp(
 }
 
 func (h *KeysHandler) encrypt(w http.ResponseWriter, r *http.Request, name, version string) {
-	cryptoOp(w, r, name, version, func(n, v string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error) {
-		return h.kv.EncryptKey(r.Context(), n, v, p)
+	cryptoOp(w, r, name, version, func(vault, n, v string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error) {
+		return h.kv.EncryptKey(r.Context(), vault, n, v, p)
 	})
 }
 
 func (h *KeysHandler) decrypt(w http.ResponseWriter, r *http.Request, name, version string) {
-	cryptoOp(w, r, name, version, func(n, v string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error) {
-		return h.kv.DecryptKey(r.Context(), n, v, p)
+	cryptoOp(w, r, name, version, func(vault, n, v string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error) {
+		return h.kv.DecryptKey(r.Context(), vault, n, v, p)
 	})
 }
 
 func (h *KeysHandler) wrapKey(w http.ResponseWriter, r *http.Request, name, version string) {
-	cryptoOp(w, r, name, version, func(n, v string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error) {
-		return h.kv.WrapKey(r.Context(), n, v, p)
+	cryptoOp(w, r, name, version, func(vault, n, v string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error) {
+		return h.kv.WrapKey(r.Context(), vault, n, v, p)
 	})
 }
 
 func (h *KeysHandler) unwrapKey(w http.ResponseWriter, r *http.Request, name, version string) {
-	cryptoOp(w, r, name, version, func(n, v string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error) {
-		return h.kv.UnwrapKey(r.Context(), n, v, p)
+	cryptoOp(w, r, name, version, func(vault, n, v string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error) {
+		return h.kv.UnwrapKey(r.Context(), vault, n, v, p)
 	})
 }
 
 func (h *KeysHandler) sign(w http.ResponseWriter, r *http.Request, name, version string) {
-	cryptoOp(w, r, name, version, func(n, v string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error) {
-		return h.kv.SignKey(r.Context(), n, v, p)
+	cryptoOp(w, r, name, version, func(vault, n, v string, p secretsdriver.KVCryptoParams) (*secretsdriver.KVCryptoResult, error) {
+		return h.kv.SignKey(r.Context(), vault, n, v, p)
 	})
 }
 
@@ -84,7 +84,7 @@ func (h *KeysHandler) verify(w http.ResponseWriter, r *http.Request, name, versi
 		return
 	}
 
-	ok, err := h.kv.VerifyKey(r.Context(), name, version, secretsdriver.KVCryptoParams{
+	ok, err := h.kv.VerifyKey(r.Context(), vaultFromRequest(r), name, version, secretsdriver.KVCryptoParams{
 		Algorithm: req.Alg,
 		Value:     digest,
 		Signature: sig,

--- a/server/azure/keyvault/keys_handler.go
+++ b/server/azure/keyvault/keys_handler.go
@@ -21,6 +21,8 @@
 //	POST   /keys/{name}/{version}/unwrapkey     — unwrap key
 //	POST   /keys/{name}/{version}/sign          — sign digest
 //	POST   /keys/{name}/{version}/verify        — verify signature
+//	GET    /keys/{name}/rotationpolicy          — get key rotation policy
+//	PUT    /keys/{name}/rotationpolicy          — update key rotation policy
 //	GET    /deletedkeys                         — list deleted keys
 //	GET    /deletedkeys/{name}                  — get deleted key
 //	POST   /deletedkeys/{name}/recover          — recover deleted key
@@ -39,6 +41,7 @@ const (
 	keysPrefix        = "/keys"
 	deletedKeysPrefix = "/deletedkeys"
 	createSeg         = "create"
+	rotationPolicySeg = "rotationpolicy"
 	encryptSeg        = "encrypt"
 	decryptSeg        = "decrypt"
 	wrapSeg           = "wrapkey"
@@ -129,6 +132,14 @@ func (h *KeysHandler) routeNamedKey(w http.ResponseWriter, r *http.Request, name
 		return
 	}
 
+	// rotationpolicy is not version-scoped (there is no /keys/{name}/{version}/
+	// rotationpolicy shape) and must be routed before the version/op split
+	// below, which would otherwise misread "rotationpolicy" as a version.
+	if sub == rotationPolicySeg {
+		h.routeKeyRotationPolicy(w, r, name)
+		return
+	}
+
 	// A crypto operation on the current version collapses to /keys/{name}/{op}
 	// (the SDK drops the empty version segment).
 	if isCryptoOp(sub) {
@@ -184,6 +195,18 @@ func (h *KeysHandler) routeCryptoOp(w http.ResponseWriter, r *http.Request, name
 		h.verify(w, r, name, version)
 	default:
 		writeErr(w, http.StatusNotFound, "NotFound", "unsupported Key Vault operation")
+	}
+}
+
+// routeKeyRotationPolicy dispatches GET/PUT /keys/{name}/rotationpolicy.
+func (h *KeysHandler) routeKeyRotationPolicy(w http.ResponseWriter, r *http.Request, name string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getKeyRotationPolicy(w, r, name)
+	case http.MethodPut:
+		h.updateKeyRotationPolicy(w, r, name)
+	default:
+		writeErr(w, http.StatusMethodNotAllowed, "BadRequest", "unsupported Key Vault operation")
 	}
 }
 

--- a/server/azure/keyvault/keys_operations.go
+++ b/server/azure/keyvault/keys_operations.go
@@ -35,7 +35,7 @@ func (h *KeysHandler) createKey(w http.ResponseWriter, r *http.Request, name str
 		return
 	}
 
-	key, err := h.kv.CreateKey(r.Context(), name, &secretsdriver.KVCreateKeyParams{
+	key, err := h.kv.CreateKey(r.Context(), vaultFromRequest(r), name, &secretsdriver.KVCreateKeyParams{
 		Kty:            req.Kty,
 		KeySize:        req.KeySize,
 		Curve:          req.Crv,
@@ -64,7 +64,7 @@ func (h *KeysHandler) importKey(w http.ResponseWriter, r *http.Request, name str
 		return
 	}
 
-	key, err := h.kv.ImportKey(r.Context(), name, &secretsdriver.KVImportKeyParams{
+	key, err := h.kv.ImportKey(r.Context(), vaultFromRequest(r), name, &secretsdriver.KVImportKeyParams{
 		Key:        jwk,
 		HSM:        req.HSM,
 		Tags:       req.Tags,
@@ -79,7 +79,7 @@ func (h *KeysHandler) importKey(w http.ResponseWriter, r *http.Request, name str
 }
 
 func (h *KeysHandler) getKey(w http.ResponseWriter, r *http.Request, name, version string) {
-	key, err := h.kv.GetKey(r.Context(), name, version)
+	key, err := h.kv.GetKey(r.Context(), vaultFromRequest(r), name, version)
 	if err != nil {
 		writeKeyErr(w, err)
 		return
@@ -111,7 +111,7 @@ func (h *KeysHandler) updateKey(w http.ResponseWriter, r *http.Request, name, ve
 		patch.NotBefore = a.NotBefore
 	}
 
-	key, err := h.kv.UpdateKey(r.Context(), name, version, patch)
+	key, err := h.kv.UpdateKey(r.Context(), vaultFromRequest(r), name, version, patch)
 	if err != nil {
 		writeKeyErr(w, err)
 		return
@@ -121,7 +121,7 @@ func (h *KeysHandler) updateKey(w http.ResponseWriter, r *http.Request, name, ve
 }
 
 func (h *KeysHandler) deleteKey(w http.ResponseWriter, r *http.Request, name string) {
-	deleted, err := h.kv.DeleteKey(r.Context(), name)
+	deleted, err := h.kv.DeleteKey(r.Context(), vaultFromRequest(r), name)
 	if err != nil {
 		writeKeyErr(w, err)
 		return
@@ -131,7 +131,7 @@ func (h *KeysHandler) deleteKey(w http.ResponseWriter, r *http.Request, name str
 }
 
 func (h *KeysHandler) listKeys(w http.ResponseWriter, r *http.Request) {
-	keys, err := h.kv.ListKeys(r.Context())
+	keys, err := h.kv.ListKeys(r.Context(), vaultFromRequest(r))
 	if err != nil {
 		writeKeyErr(w, err)
 		return
@@ -146,7 +146,7 @@ func (h *KeysHandler) listKeys(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *KeysHandler) listKeyVersions(w http.ResponseWriter, r *http.Request, name string) {
-	versions, err := h.kv.ListKeyVersions(r.Context(), name)
+	versions, err := h.kv.ListKeyVersions(r.Context(), vaultFromRequest(r), name)
 	if err != nil {
 		writeKeyErr(w, err)
 		return
@@ -161,7 +161,7 @@ func (h *KeysHandler) listKeyVersions(w http.ResponseWriter, r *http.Request, na
 }
 
 func (h *KeysHandler) listDeletedKeys(w http.ResponseWriter, r *http.Request) {
-	deleted, err := h.kv.ListDeletedKeys(r.Context())
+	deleted, err := h.kv.ListDeletedKeys(r.Context(), vaultFromRequest(r))
 	if err != nil {
 		writeKeyErr(w, err)
 		return
@@ -176,7 +176,7 @@ func (h *KeysHandler) listDeletedKeys(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *KeysHandler) getDeletedKey(w http.ResponseWriter, r *http.Request, name string) {
-	deleted, err := h.kv.GetDeletedKey(r.Context(), name)
+	deleted, err := h.kv.GetDeletedKey(r.Context(), vaultFromRequest(r), name)
 	if err != nil {
 		writeKeyErr(w, err)
 		return
@@ -186,7 +186,7 @@ func (h *KeysHandler) getDeletedKey(w http.ResponseWriter, r *http.Request, name
 }
 
 func (h *KeysHandler) recoverDeletedKey(w http.ResponseWriter, r *http.Request, name string) {
-	key, err := h.kv.RecoverDeletedKey(r.Context(), name)
+	key, err := h.kv.RecoverDeletedKey(r.Context(), vaultFromRequest(r), name)
 	if err != nil {
 		writeKeyErr(w, err)
 		return
@@ -196,12 +196,37 @@ func (h *KeysHandler) recoverDeletedKey(w http.ResponseWriter, r *http.Request, 
 }
 
 func (h *KeysHandler) purgeDeletedKey(w http.ResponseWriter, r *http.Request, name string) {
-	if err := h.kv.PurgeDeletedKey(r.Context(), name); err != nil {
+	if err := h.kv.PurgeDeletedKey(r.Context(), vaultFromRequest(r), name); err != nil {
 		writeKeyErr(w, err)
 		return
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *KeysHandler) getKeyRotationPolicy(w http.ResponseWriter, r *http.Request, name string) {
+	policy, err := h.kv.GetKeyRotationPolicy(r.Context(), vaultFromRequest(r), name)
+	if err != nil {
+		writeKeyErr(w, err)
+		return
+	}
+
+	writeJSON(w, toRotationPolicyJSON(r, name, policy))
+}
+
+func (h *KeysHandler) updateKeyRotationPolicy(w http.ResponseWriter, r *http.Request, name string) {
+	var req keyRotationPolicyJSON
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	policy, err := h.kv.UpdateKeyRotationPolicy(r.Context(), vaultFromRequest(r), name, fromRotationPolicyJSON(&req))
+	if err != nil {
+		writeKeyErr(w, err)
+		return
+	}
+
+	writeJSON(w, toRotationPolicyJSON(r, name, policy))
 }
 
 // decodeImportJWK decodes the base64url components of an inbound JWK.

--- a/server/azure/keyvault/keys_types.go
+++ b/server/azure/keyvault/keys_types.go
@@ -150,6 +150,87 @@ type keyVerifyResultJSON struct {
 	Value bool `json:"value"`
 }
 
+// keyRotationPolicyActionJSON is a lifetime action's action type ("Rotate" or
+// "Notify").
+type keyRotationPolicyActionJSON struct {
+	Type string `json:"type"`
+}
+
+// keyRotationPolicyTriggerJSON is a lifetime action's trigger condition,
+// exactly one of which is set: an ISO 8601 duration after key creation, or
+// before the key's expiry.
+type keyRotationPolicyTriggerJSON struct {
+	TimeAfterCreate  string `json:"timeAfterCreate,omitempty"`
+	TimeBeforeExpiry string `json:"timeBeforeExpiry,omitempty"`
+}
+
+// lifetimeActionJSON pairs a trigger with the action it fires.
+type lifetimeActionJSON struct {
+	Trigger keyRotationPolicyTriggerJSON `json:"trigger"`
+	Action  keyRotationPolicyActionJSON  `json:"action"`
+}
+
+// keyRotationPolicyAttributesJSON is the rotation policy's attributes:
+// the expiry ISO 8601 duration applied to new versions, plus the policy's own
+// created/updated timestamps (Unix epoch seconds).
+type keyRotationPolicyAttributesJSON struct {
+	ExpiryTime string `json:"expiryTime,omitempty"`
+	Created    int64  `json:"created,omitempty"`
+	Updated    int64  `json:"updated,omitempty"`
+}
+
+// keyRotationPolicyJSON is the GET/PUT .../rotationpolicy request and
+// response body.
+type keyRotationPolicyJSON struct {
+	ID              string                          `json:"id,omitempty"`
+	LifetimeActions []lifetimeActionJSON            `json:"lifetimeActions,omitempty"`
+	Attributes      keyRotationPolicyAttributesJSON `json:"attributes"`
+}
+
+// keyRotationPolicyID builds "{vault}/keys/{name}/rotationpolicy".
+func keyRotationPolicyID(r *http.Request, name string) string {
+	return vaultBaseURL(r) + keysPrefix + "/" + name + "/" + rotationPolicySeg
+}
+
+func toRotationPolicyJSON(r *http.Request, name string, p *secretsdriver.KVRotationPolicy) keyRotationPolicyJSON {
+	out := keyRotationPolicyJSON{
+		ID: keyRotationPolicyID(r, name),
+		Attributes: keyRotationPolicyAttributesJSON{
+			ExpiryTime: p.ExpiryTime,
+			Created:    p.Created,
+			Updated:    p.Updated,
+		},
+	}
+
+	for _, la := range p.LifetimeActions {
+		out.LifetimeActions = append(out.LifetimeActions, lifetimeActionJSON{
+			Trigger: keyRotationPolicyTriggerJSON{
+				TimeAfterCreate:  la.Trigger.TimeAfterCreate,
+				TimeBeforeExpiry: la.Trigger.TimeBeforeExpiry,
+			},
+			Action: keyRotationPolicyActionJSON{Type: la.Action.Type},
+		})
+	}
+
+	return out
+}
+
+func fromRotationPolicyJSON(in *keyRotationPolicyJSON) secretsdriver.KVRotationPolicy {
+	out := secretsdriver.KVRotationPolicy{ExpiryTime: in.Attributes.ExpiryTime}
+
+	for _, la := range in.LifetimeActions {
+		out.LifetimeActions = append(out.LifetimeActions, secretsdriver.KVLifetimeAction{
+			Trigger: secretsdriver.KVRotationPolicyTrigger{
+				TimeAfterCreate:  la.Trigger.TimeAfterCreate,
+				TimeBeforeExpiry: la.Trigger.TimeBeforeExpiry,
+			},
+			Action: secretsdriver.KVRotationPolicyAction{Type: la.Action.Type},
+		})
+	}
+
+	return out
+}
+
 // keyID builds "{vault}/keys/{name}[/{version}]".
 func keyID(r *http.Request, name, version string) string {
 	id := vaultBaseURL(r) + keysPrefix + "/" + name

--- a/server/azure/keyvault/multivault_test.go
+++ b/server/azure/keyvault/multivault_test.go
@@ -1,0 +1,247 @@
+package keyvault_test
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// hostRedirectTransport dials addr for every request regardless of the
+// hostname in the request URL, while still presenting that hostname over TLS
+// SNI and in the Host header. This lets a test address two distinct
+// {vault}.vault.azure.net hostnames against a single local httptest TLS
+// server, reproducing how two real Key Vault vaults are two distinct
+// hostnames that resolve to Azure's shared data-plane front door — exactly
+// the signal cloudemu's wire layer uses to scope a request to its vault.
+func hostRedirectTransport(addr string) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, network, addr)
+			},
+			//nolint:gosec // test-only: dialing a fixed local httptest server under a fake vault hostname it has no cert for
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+}
+
+func secretsClientForVault(t *testing.T, addr, vaultHost string) *azsecrets.Client {
+	t.Helper()
+
+	client, err := azsecrets.NewClient("https://"+vaultHost, fakeCred{}, &azsecrets.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: hostRedirectTransport(addr),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+		DisableChallengeResourceVerification: true,
+	})
+	if err != nil {
+		t.Fatalf("azsecrets.NewClient: %v", err)
+	}
+
+	return client
+}
+
+func keysClientForVault(t *testing.T, addr, vaultHost string) *azkeys.Client {
+	t.Helper()
+
+	client, err := azkeys.NewClient("https://"+vaultHost, fakeCred{}, &azkeys.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: hostRedirectTransport(addr),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+		DisableChallengeResourceVerification: true,
+	})
+	if err != nil {
+		t.Fatalf("azkeys.NewClient: %v", err)
+	}
+
+	return client
+}
+
+// TestSDKSecretsIsolatedPerVault reproduces the reported bug: two vaults
+// (distinguished only by their request host, as real Key Vault clients always
+// are) must not share a secrets namespace. Before the fix, vault-b silently
+// read and overwrote vault-a's "db-password" secret.
+func TestSDKSecretsIsolatedPerVault(t *testing.T) {
+	cloud := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{KeyVault: cloud.KeyVault})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	addr := ts.Listener.Addr().String()
+	ctx := context.Background()
+
+	vaultA := secretsClientForVault(t, addr, "vault-a.vault.azure.net")
+	vaultB := secretsClientForVault(t, addr, "vault-b.vault.azure.net")
+
+	if _, err := vaultA.SetSecret(ctx, "db-password", azsecrets.SetSecretParameters{Value: to.Ptr("vault-a-value")}, nil); err != nil {
+		t.Fatalf("SetSecret in vault A: %v", err)
+	}
+
+	// The same secret name must not exist in vault B yet.
+	if _, err := vaultB.GetSecret(ctx, "db-password", "", nil); err == nil {
+		t.Fatal("GetSecret in vault B unexpectedly found vault A's secret")
+	}
+
+	if _, err := vaultB.SetSecret(ctx, "db-password", azsecrets.SetSecretParameters{Value: to.Ptr("vault-b-value")}, nil); err != nil {
+		t.Fatalf("SetSecret in vault B: %v", err)
+	}
+
+	gotA, err := vaultA.GetSecret(ctx, "db-password", "", nil)
+	if err != nil {
+		t.Fatalf("GetSecret in vault A: %v", err)
+	}
+
+	if gotA.Value == nil || *gotA.Value != "vault-a-value" {
+		t.Fatalf("vault A secret value = %v, want vault-a-value (must survive vault B's SetSecret of the same name)", gotA.Value)
+	}
+
+	gotB, err := vaultB.GetSecret(ctx, "db-password", "", nil)
+	if err != nil {
+		t.Fatalf("GetSecret in vault B: %v", err)
+	}
+
+	if gotB.Value == nil || *gotB.Value != "vault-b-value" {
+		t.Fatalf("vault B secret value = %v, want vault-b-value", gotB.Value)
+	}
+
+	// Listing must also stay scoped: vault A shows exactly its own secret.
+	var namesA []string
+
+	pager := vaultA.NewListSecretPropertiesPager(nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NewListSecretPropertiesPager in vault A: %v", err)
+		}
+
+		for _, s := range page.Value {
+			namesA = append(namesA, s.ID.Name())
+		}
+	}
+
+	if len(namesA) != 1 || namesA[0] != "db-password" {
+		t.Fatalf("vault A secret list = %v, want exactly [db-password]", namesA)
+	}
+}
+
+// TestSDKKeysIsolatedPerVault is the keys-surface counterpart: the same key
+// name in two vaults must be two independent keys.
+func TestSDKKeysIsolatedPerVault(t *testing.T) {
+	cloud := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{KeyVault: cloud.KeyVault})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	addr := ts.Listener.Addr().String()
+	ctx := context.Background()
+
+	vaultA := keysClientForVault(t, addr, "vault-a.vault.azure.net")
+	vaultB := keysClientForVault(t, addr, "vault-b.vault.azure.net")
+
+	if _, err := vaultA.CreateKey(ctx, "app-key",
+		azkeys.CreateKeyParameters{Kty: to.Ptr(azkeys.KeyTypeRSA), KeySize: to.Ptr(int32(2048))}, nil); err != nil {
+		t.Fatalf("CreateKey in vault A: %v", err)
+	}
+
+	if _, err := vaultB.GetKey(ctx, "app-key", "", nil); err == nil {
+		t.Fatal("GetKey in vault B unexpectedly found vault A's key")
+	}
+
+	if _, err := vaultB.CreateKey(ctx, "app-key",
+		azkeys.CreateKeyParameters{Kty: to.Ptr(azkeys.KeyTypeEC), Curve: to.Ptr(azkeys.CurveNameP256)}, nil); err != nil {
+		t.Fatalf("CreateKey in vault B: %v", err)
+	}
+
+	gotA, err := vaultA.GetKey(ctx, "app-key", "", nil)
+	if err != nil {
+		t.Fatalf("GetKey in vault A: %v", err)
+	}
+
+	if gotA.Key == nil || gotA.Key.Kty == nil || *gotA.Key.Kty != azkeys.KeyTypeRSA {
+		t.Fatalf("vault A key kty = %v, want RSA (must be unaffected by vault B's EC CreateKey of the same name)", gotA.Key)
+	}
+
+	gotB, err := vaultB.GetKey(ctx, "app-key", "", nil)
+	if err != nil {
+		t.Fatalf("GetKey in vault B: %v", err)
+	}
+
+	if gotB.Key == nil || gotB.Key.Kty == nil || *gotB.Key.Kty != azkeys.KeyTypeEC {
+		t.Fatalf("vault B key kty = %v, want EC", gotB.Key)
+	}
+}
+
+// TestSDKKeyRotationPolicyLifecycle exercises GET/PUT .../rotationpolicy
+// through the real SDK. Before the fix this path was misrouted into GetKey's
+// version handler and answered a wrong-shaped 404 instead of the rotation
+// policy.
+func TestSDKKeyRotationPolicyLifecycle(t *testing.T) {
+	client := newKeysClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateKey(ctx, "rotating-key", azkeys.CreateKeyParameters{Kty: to.Ptr(azkeys.KeyTypeRSA)}, nil); err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	updated, err := client.UpdateKeyRotationPolicy(ctx, "rotating-key", azkeys.KeyRotationPolicy{
+		LifetimeActions: []*azkeys.LifetimeAction{
+			{
+				Trigger: &azkeys.LifetimeActionTrigger{TimeAfterCreate: to.Ptr("P90D")},
+				Action:  &azkeys.LifetimeActionType{Type: to.Ptr(azkeys.KeyRotationPolicyActionRotate)},
+			},
+		},
+		Attributes: &azkeys.KeyRotationPolicyAttributes{ExpiryTime: to.Ptr("P2Y")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("UpdateKeyRotationPolicy: %v", err)
+	}
+
+	if len(updated.LifetimeActions) != 1 ||
+		updated.LifetimeActions[0].Trigger == nil ||
+		updated.LifetimeActions[0].Trigger.TimeAfterCreate == nil ||
+		*updated.LifetimeActions[0].Trigger.TimeAfterCreate != "P90D" {
+		t.Fatalf("UpdateKeyRotationPolicy lifetimeActions = %+v, want one P90D rotate trigger", updated.LifetimeActions)
+	}
+
+	if updated.Attributes == nil || updated.Attributes.ExpiryTime == nil || *updated.Attributes.ExpiryTime != "P2Y" {
+		t.Fatalf("UpdateKeyRotationPolicy expiryTime = %v, want P2Y", updated.Attributes)
+	}
+
+	got, err := client.GetKeyRotationPolicy(ctx, "rotating-key", nil)
+	if err != nil {
+		t.Fatalf("GetKeyRotationPolicy: %v", err)
+	}
+
+	if got.Attributes == nil || got.Attributes.ExpiryTime == nil || *got.Attributes.ExpiryTime != "P2Y" {
+		t.Fatalf("GetKeyRotationPolicy expiryTime = %v, want P2Y (must round-trip what UpdateKeyRotationPolicy wrote)", got.Attributes)
+	}
+}
+
+// TestSDKKeyRotationPolicyOnMissingKeyIs404 confirms the rotationpolicy route
+// still reports a real 404 (via KeyNotFound) for a key that was never
+// created, rather than the version-shaped 404 the misrouting used to produce.
+func TestSDKKeyRotationPolicyOnMissingKeyIs404(t *testing.T) {
+	client := newKeysClient(t)
+
+	_, err := client.GetKeyRotationPolicy(context.Background(), "does-not-exist", nil)
+	if err == nil {
+		t.Fatal("GetKeyRotationPolicy on a missing key: want error, got nil")
+	}
+}

--- a/server/azure/keyvault/operations.go
+++ b/server/azure/keyvault/operations.go
@@ -47,7 +47,7 @@ func (h *Handler) setSecret(w http.ResponseWriter, r *http.Request, name string)
 		return
 	}
 
-	kv, err := h.kv.SetKeyVaultSecret(r.Context(), name, secretsdriver.KVSetParams{
+	kv, err := h.kv.SetKeyVaultSecret(r.Context(), vaultFromRequest(r), name, secretsdriver.KVSetParams{
 		Value:       []byte(req.Value),
 		ContentType: req.ContentType,
 		Tags:        req.Tags,
@@ -62,7 +62,7 @@ func (h *Handler) setSecret(w http.ResponseWriter, r *http.Request, name string)
 }
 
 func (h *Handler) getSecret(w http.ResponseWriter, r *http.Request, name, version string) {
-	kv, err := h.kv.GetKeyVaultSecret(r.Context(), name, version)
+	kv, err := h.kv.GetKeyVaultSecret(r.Context(), vaultFromRequest(r), name, version)
 	if err != nil {
 		writeCErr(w, err)
 		return
@@ -94,7 +94,7 @@ func (h *Handler) updateSecret(w http.ResponseWriter, r *http.Request, name, ver
 		patch.NotBefore = a.NotBefore
 	}
 
-	kv, err := h.kv.UpdateKeyVaultSecret(r.Context(), name, version, patch)
+	kv, err := h.kv.UpdateKeyVaultSecret(r.Context(), vaultFromRequest(r), name, version, patch)
 	if err != nil {
 		writeCErr(w, err)
 		return
@@ -104,7 +104,7 @@ func (h *Handler) updateSecret(w http.ResponseWriter, r *http.Request, name, ver
 }
 
 func (h *Handler) deleteSecret(w http.ResponseWriter, r *http.Request, name string) {
-	deleted, err := h.kv.DeleteKeyVaultSecret(r.Context(), name)
+	deleted, err := h.kv.DeleteKeyVaultSecret(r.Context(), vaultFromRequest(r), name)
 	if err != nil {
 		writeCErr(w, err)
 		return
@@ -114,7 +114,7 @@ func (h *Handler) deleteSecret(w http.ResponseWriter, r *http.Request, name stri
 }
 
 func (h *Handler) listSecrets(w http.ResponseWriter, r *http.Request) {
-	secrets, err := h.kv.ListKeyVaultSecrets(r.Context())
+	secrets, err := h.kv.ListKeyVaultSecrets(r.Context(), vaultFromRequest(r))
 	if err != nil {
 		writeCErr(w, err)
 		return
@@ -129,7 +129,7 @@ func (h *Handler) listSecrets(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) listSecretVersions(w http.ResponseWriter, r *http.Request, name string) {
-	versions, err := h.kv.ListKeyVaultSecretVersions(r.Context(), name)
+	versions, err := h.kv.ListKeyVaultSecretVersions(r.Context(), vaultFromRequest(r), name)
 	if err != nil {
 		writeCErr(w, err)
 		return
@@ -144,7 +144,7 @@ func (h *Handler) listSecretVersions(w http.ResponseWriter, r *http.Request, nam
 }
 
 func (h *Handler) backupSecret(w http.ResponseWriter, r *http.Request, name string) {
-	blob, err := h.kv.BackupKeyVaultSecret(r.Context(), name)
+	blob, err := h.kv.BackupKeyVaultSecret(r.Context(), vaultFromRequest(r), name)
 	if err != nil {
 		writeCErr(w, err)
 		return
@@ -165,7 +165,7 @@ func (h *Handler) restoreSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	kv, err := h.kv.RestoreKeyVaultSecret(r.Context(), blob)
+	kv, err := h.kv.RestoreKeyVaultSecret(r.Context(), vaultFromRequest(r), blob)
 	if err != nil {
 		writeCErr(w, err)
 		return
@@ -175,7 +175,7 @@ func (h *Handler) restoreSecret(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) listDeletedSecrets(w http.ResponseWriter, r *http.Request) {
-	deleted, err := h.kv.ListDeletedKeyVaultSecrets(r.Context())
+	deleted, err := h.kv.ListDeletedKeyVaultSecrets(r.Context(), vaultFromRequest(r))
 	if err != nil {
 		writeCErr(w, err)
 		return
@@ -190,7 +190,7 @@ func (h *Handler) listDeletedSecrets(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) getDeletedSecret(w http.ResponseWriter, r *http.Request, name string) {
-	deleted, err := h.kv.GetDeletedKeyVaultSecret(r.Context(), name)
+	deleted, err := h.kv.GetDeletedKeyVaultSecret(r.Context(), vaultFromRequest(r), name)
 	if err != nil {
 		writeCErr(w, err)
 		return
@@ -200,7 +200,7 @@ func (h *Handler) getDeletedSecret(w http.ResponseWriter, r *http.Request, name 
 }
 
 func (h *Handler) recoverDeletedSecret(w http.ResponseWriter, r *http.Request, name string) {
-	kv, err := h.kv.RecoverDeletedKeyVaultSecret(r.Context(), name)
+	kv, err := h.kv.RecoverDeletedKeyVaultSecret(r.Context(), vaultFromRequest(r), name)
 	if err != nil {
 		writeCErr(w, err)
 		return
@@ -210,7 +210,7 @@ func (h *Handler) recoverDeletedSecret(w http.ResponseWriter, r *http.Request, n
 }
 
 func (h *Handler) purgeDeletedSecret(w http.ResponseWriter, r *http.Request, name string) {
-	if err := h.kv.PurgeDeletedKeyVaultSecret(r.Context(), name); err != nil {
+	if err := h.kv.PurgeDeletedKeyVaultSecret(r.Context(), vaultFromRequest(r), name); err != nil {
 		writeCErr(w, err)
 		return
 	}

--- a/services/secrets/driver/driver.go
+++ b/services/secrets/driver/driver.go
@@ -112,17 +112,22 @@ type KVDeletedSecret struct {
 // and backup/restore. It is kept off the shared Secrets interface — a
 // type-asserted optional interface — so the AWS and GCP providers need not
 // model Key Vault semantics.
+//
+// Every method takes vault, the vault name the request is scoped to (derived
+// by the wire layer from the request host, e.g. the {vault-name} label of
+// {vault-name}.vault.azure.net). Each vault is an isolated namespace: the
+// same secret name in two different vaults refers to two different secrets.
 type KeyVaultSecrets interface {
-	SetKeyVaultSecret(ctx context.Context, name string, params KVSetParams) (*KVSecret, error)
-	GetKeyVaultSecret(ctx context.Context, name, version string) (*KVSecret, error)
-	ListKeyVaultSecrets(ctx context.Context) ([]KVSecret, error)
-	ListKeyVaultSecretVersions(ctx context.Context, name string) ([]KVSecret, error)
-	UpdateKeyVaultSecret(ctx context.Context, name, version string, patch KVPatch) (*KVSecret, error)
-	DeleteKeyVaultSecret(ctx context.Context, name string) (*KVDeletedSecret, error)
-	GetDeletedKeyVaultSecret(ctx context.Context, name string) (*KVDeletedSecret, error)
-	ListDeletedKeyVaultSecrets(ctx context.Context) ([]KVDeletedSecret, error)
-	RecoverDeletedKeyVaultSecret(ctx context.Context, name string) (*KVSecret, error)
-	PurgeDeletedKeyVaultSecret(ctx context.Context, name string) error
-	BackupKeyVaultSecret(ctx context.Context, name string) ([]byte, error)
-	RestoreKeyVaultSecret(ctx context.Context, backup []byte) (*KVSecret, error)
+	SetKeyVaultSecret(ctx context.Context, vault, name string, params KVSetParams) (*KVSecret, error)
+	GetKeyVaultSecret(ctx context.Context, vault, name, version string) (*KVSecret, error)
+	ListKeyVaultSecrets(ctx context.Context, vault string) ([]KVSecret, error)
+	ListKeyVaultSecretVersions(ctx context.Context, vault, name string) ([]KVSecret, error)
+	UpdateKeyVaultSecret(ctx context.Context, vault, name, version string, patch KVPatch) (*KVSecret, error)
+	DeleteKeyVaultSecret(ctx context.Context, vault, name string) (*KVDeletedSecret, error)
+	GetDeletedKeyVaultSecret(ctx context.Context, vault, name string) (*KVDeletedSecret, error)
+	ListDeletedKeyVaultSecrets(ctx context.Context, vault string) ([]KVDeletedSecret, error)
+	RecoverDeletedKeyVaultSecret(ctx context.Context, vault, name string) (*KVSecret, error)
+	PurgeDeletedKeyVaultSecret(ctx context.Context, vault, name string) error
+	BackupKeyVaultSecret(ctx context.Context, vault, name string) ([]byte, error)
+	RestoreKeyVaultSecret(ctx context.Context, vault string, backup []byte) (*KVSecret, error)
 }

--- a/services/secrets/driver/keys.go
+++ b/services/secrets/driver/keys.go
@@ -125,29 +125,67 @@ type KVCryptoResult struct {
 	Value   []byte
 }
 
+// KVRotationPolicyAction identifies what a key rotation policy's lifetime
+// action does: "Rotate" the key or "Notify" via Event Grid.
+type KVRotationPolicyAction struct {
+	Type string
+}
+
+// KVRotationPolicyTrigger is the condition ("time after create" or "time
+// before expiry", each an ISO 8601 duration such as "P90D") that fires a
+// lifetime action.
+type KVRotationPolicyTrigger struct {
+	TimeAfterCreate  string
+	TimeBeforeExpiry string
+}
+
+// KVLifetimeAction pairs a rotation policy trigger with the action it fires.
+type KVLifetimeAction struct {
+	Trigger KVRotationPolicyTrigger
+	Action  KVRotationPolicyAction
+}
+
+// KVRotationPolicy is a key's rotation policy: the expiry applied to new
+// versions plus the lifetime actions Key Vault performs automatically.
+// Created and Updated are Unix epoch seconds.
+type KVRotationPolicy struct {
+	ExpiryTime      string
+	LifetimeActions []KVLifetimeAction
+	Created         int64
+	Updated         int64
+}
+
 // KeyVaultKeys is the Azure Key Vault keys data-plane surface: key lifecycle
 // (create/import/get/list/update/soft-delete/recover/purge) plus the real
 // cryptographic operations (encrypt/decrypt/wrap/unwrap/sign/verify) performed
 // with the private key material held in the provider. It is kept off the shared
 // Secrets interface — a type-asserted optional interface — so the AWS and GCP
 // providers need not model Key Vault key semantics.
+//
+// Every method takes vault, the vault name the request is scoped to (derived
+// by the wire layer from the request host, e.g. the {vault-name} label of
+// {vault-name}.vault.azure.net). Each vault is an isolated namespace: the
+// same key name in two different vaults refers to two different keys.
 type KeyVaultKeys interface {
-	CreateKey(ctx context.Context, name string, params *KVCreateKeyParams) (*KVKey, error)
-	ImportKey(ctx context.Context, name string, params *KVImportKeyParams) (*KVKey, error)
-	GetKey(ctx context.Context, name, version string) (*KVKey, error)
-	ListKeys(ctx context.Context) ([]KVKey, error)
-	ListKeyVersions(ctx context.Context, name string) ([]KVKey, error)
-	UpdateKey(ctx context.Context, name, version string, patch KVKeyPatch) (*KVKey, error)
-	DeleteKey(ctx context.Context, name string) (*KVDeletedKey, error)
-	GetDeletedKey(ctx context.Context, name string) (*KVDeletedKey, error)
-	ListDeletedKeys(ctx context.Context) ([]KVDeletedKey, error)
-	RecoverDeletedKey(ctx context.Context, name string) (*KVKey, error)
-	PurgeDeletedKey(ctx context.Context, name string) error
+	CreateKey(ctx context.Context, vault, name string, params *KVCreateKeyParams) (*KVKey, error)
+	ImportKey(ctx context.Context, vault, name string, params *KVImportKeyParams) (*KVKey, error)
+	GetKey(ctx context.Context, vault, name, version string) (*KVKey, error)
+	ListKeys(ctx context.Context, vault string) ([]KVKey, error)
+	ListKeyVersions(ctx context.Context, vault, name string) ([]KVKey, error)
+	UpdateKey(ctx context.Context, vault, name, version string, patch KVKeyPatch) (*KVKey, error)
+	DeleteKey(ctx context.Context, vault, name string) (*KVDeletedKey, error)
+	GetDeletedKey(ctx context.Context, vault, name string) (*KVDeletedKey, error)
+	ListDeletedKeys(ctx context.Context, vault string) ([]KVDeletedKey, error)
+	RecoverDeletedKey(ctx context.Context, vault, name string) (*KVKey, error)
+	PurgeDeletedKey(ctx context.Context, vault, name string) error
 
-	EncryptKey(ctx context.Context, name, version string, params KVCryptoParams) (*KVCryptoResult, error)
-	DecryptKey(ctx context.Context, name, version string, params KVCryptoParams) (*KVCryptoResult, error)
-	WrapKey(ctx context.Context, name, version string, params KVCryptoParams) (*KVCryptoResult, error)
-	UnwrapKey(ctx context.Context, name, version string, params KVCryptoParams) (*KVCryptoResult, error)
-	SignKey(ctx context.Context, name, version string, params KVCryptoParams) (*KVCryptoResult, error)
-	VerifyKey(ctx context.Context, name, version string, params KVCryptoParams) (bool, error)
+	EncryptKey(ctx context.Context, vault, name, version string, params KVCryptoParams) (*KVCryptoResult, error)
+	DecryptKey(ctx context.Context, vault, name, version string, params KVCryptoParams) (*KVCryptoResult, error)
+	WrapKey(ctx context.Context, vault, name, version string, params KVCryptoParams) (*KVCryptoResult, error)
+	UnwrapKey(ctx context.Context, vault, name, version string, params KVCryptoParams) (*KVCryptoResult, error)
+	SignKey(ctx context.Context, vault, name, version string, params KVCryptoParams) (*KVCryptoResult, error)
+	VerifyKey(ctx context.Context, vault, name, version string, params KVCryptoParams) (bool, error)
+
+	GetKeyRotationPolicy(ctx context.Context, vault, name string) (*KVRotationPolicy, error)
+	UpdateKeyRotationPolicy(ctx context.Context, vault, name string, policy KVRotationPolicy) (*KVRotationPolicy, error)
 }


### PR DESCRIPTION
## Summary

- Key Vault secrets and keys had no per-vault namespace: `server/azure/keyvault` routed on path only, so every vault name aliased the same global store (vault-A's secret was readable via vault-B). `KeyVaultSecrets`/`KeyVaultKeys` now take the vault name, derived by the wire layer from the request host (the `{vault-name}` label of `{vault-name}.vault.azure.net`, and the Managed HSM / US Gov / China cloud equivalents). The provider keeps an isolated secrets/keys store per vault, created lazily on first touch (`Mock.vault`, race-safe via `SetIfAbsent`). The `"default"` vault name still aliases the shared cross-cloud `Secrets` store, so existing single-vault usage (including a client with no recognizable vault subdomain, e.g. tests pointed at a bare host) is unaffected.
- `GET`/`PUT .../keys/{name}/rotationpolicy` was misrouted into `GetKey`'s version-scoped path (`rotationpolicy` was read as a version), producing a wrong-shaped 404. Added an explicit `rotationpolicy` case in `routeNamedKey` ahead of the version/op split, plus `GetKeyRotationPolicy`/`UpdateKeyRotationPolicy` on the `KeyVaultKeys` driver and the provider (per [MS Learn](https://learn.microsoft.com/en-us/rest/api/keyvault/keys/update-key-rotation-policy/update-key-rotation-policy): `PUT/GET {vaultBaseUrl}/keys/{key-name}/rotationpolicy`, 200 response shaped `{id, lifetimeActions, attributes: {expiryTime, created, updated}}`).
- Certificates data-plane is out of scope here (tracked in #578).

## Test plan

- New regression tests against a live TLS server with the real `azsecrets`/`azkeys` SDKs (`server/azure/keyvault/multivault_test.go`): two vaults distinguished only by request host stay isolated for both secrets and keys; rotation policy round-trips through the real SDK; a missing key on `.../rotationpolicy` still 404s.
- `providers/azure/keyvault/vault_test.go`: vault isolation at the provider level, plus a `-race` test for concurrent first-touch of a new vault.
- `go build ./...`, `go vet ./...`, `go test ./...` (full suite), `go test -race` on the changed provider package, `go test ./compat/...` all green.
- `golangci-lint` clean on changed packages; `gofmt` clean.
- Regenerated `docs/coverage/` (`go run ./internal/coveragegen`) for the two new `KeyVaultKeys` methods; `docs/compat/` unchanged after `go run ./internal/compatgen`.