### PR TITLE
fix(compute): make VM power actions idempotent on their settled state

### DIFF
--- a/providers/azure/virtualmachines/powerstate_test.go
+++ b/providers/azure/virtualmachines/powerstate_test.go
@@ -46,6 +46,120 @@ func TestDeallocateReleasesCompute(t *testing.T) {
 	assert.Equal(t, "deallocated", got[0].PowerState)
 }
 
+// TestStartInstancesIdempotentOnRunning covers the systemic VM-lifecycle-
+// idempotency bug: real Azure's BeginStart returns 200/202 (no
+// state-conflict error) when the VM is already running (MS Learn:
+// rest/api/compute/virtual-machines/start only documents 200/202).
+func TestStartInstancesIdempotentOnRunning(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{InstanceType: "Standard_B1s"}, 1)
+	require.NoError(t, err)
+
+	id := insts[0].ID
+
+	require.NoError(t, m.StartInstances(ctx, []string{id}))
+	require.NoError(t, m.StartInstances(ctx, []string{id}), "repeat Start on an already-running VM must be a no-op success, not 409")
+
+	got, err := m.DescribeInstances(ctx, []string{id}, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, compute.StateRunning, got[0].State)
+	assert.Equal(t, "running", got[0].PowerState)
+}
+
+// TestPowerOffIdempotentOnStopped mirrors TestStartInstancesIdempotentOnRunning
+// for BeginPowerOff (MS Learn: rest/api/compute/virtual-machines/power-off
+// only documents 200/202, no precondition error).
+func TestPowerOffIdempotentOnStopped(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{InstanceType: "Standard_B1s"}, 1)
+	require.NoError(t, err)
+
+	id := insts[0].ID
+
+	require.NoError(t, m.PowerOff(ctx, id))
+	require.NoError(t, m.PowerOff(ctx, id), "repeat PowerOff on an already-stopped VM must be a no-op success, not 409")
+
+	got, err := m.DescribeInstances(ctx, []string{id}, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, compute.StateStopped, got[0].State)
+	assert.Equal(t, "stopped", got[0].PowerState)
+}
+
+// TestDeallocateIdempotentOnDeallocated mirrors the above for BeginDeallocate
+// (MS Learn: rest/api/compute/virtual-machines/deallocate only documents
+// 200/202, no precondition error).
+func TestDeallocateIdempotentOnDeallocated(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{InstanceType: "Standard_B1s"}, 1)
+	require.NoError(t, err)
+
+	id := insts[0].ID
+
+	require.NoError(t, m.Deallocate(ctx, id))
+	require.NoError(t, m.Deallocate(ctx, id), "repeat Deallocate on an already-deallocated VM must be a no-op success, not 409")
+
+	got, err := m.DescribeInstances(ctx, []string{id}, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, compute.StateStopped, got[0].State)
+	assert.Equal(t, "deallocated", got[0].PowerState)
+}
+
+// TestDeallocateAfterPowerOffReleasesCompute checks the cross-action case:
+// the lifecycle FSM settles both PowerOff and Deallocate at the same
+// compute.StateStopped, so calling Deallocate on a VM already PowerOff'd
+// must not hit the (illegal) same-state FSM edge, and must still perform
+// its real effect of releasing the allocated compute.
+func TestDeallocateAfterPowerOffReleasesCompute(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{InstanceType: "Standard_B1s"}, 1)
+	require.NoError(t, err)
+
+	id := insts[0].ID
+
+	require.NoError(t, m.PowerOff(ctx, id))
+	require.NoError(t, m.Deallocate(ctx, id))
+
+	got, err := m.DescribeInstances(ctx, []string{id}, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, compute.StateStopped, got[0].State)
+	assert.Equal(t, "deallocated", got[0].PowerState)
+}
+
+// TestPowerOffAfterDeallocateStaysDeallocated is the reverse of the above:
+// PowerOff on an already-deallocated VM has nothing further to release, so
+// it must succeed as a no-op that leaves the VM deallocated rather than
+// reporting it as merely stopped.
+func TestPowerOffAfterDeallocateStaysDeallocated(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{InstanceType: "Standard_B1s"}, 1)
+	require.NoError(t, err)
+
+	id := insts[0].ID
+
+	require.NoError(t, m.Deallocate(ctx, id))
+	require.NoError(t, m.PowerOff(ctx, id))
+
+	got, err := m.DescribeInstances(ctx, []string{id}, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, compute.StateStopped, got[0].State)
+	assert.Equal(t, "deallocated", got[0].PowerState)
+}
+
 func TestUpdateInstanceInPlace(t *testing.T) {
 	ctx := context.Background()
 	m := newTestMock()

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -52,6 +52,14 @@ type lifecycleTransition struct {
 	// powerState is the Azure power state the instance settles into after the
 	// transition ("running"/"stopped"/"deallocated"). Empty leaves it unchanged.
 	powerState string
+	// idempotentPowerStates are the Azure PowerState values the instance may
+	// already be in for which this action is a true no-op. Real Azure
+	// documents Start/PowerOff/Deallocate as always succeeding (200/202) —
+	// no state-conflict error is documented for calling them on a VM already
+	// at (or past) the target power level (MS Learn: rest/api/compute/
+	// virtual-machines/start, .../deallocate). Nil for actions (Reboot,
+	// Terminate) that are not idempotent on the settled state.
+	idempotentPowerStates []string
 }
 
 var (
@@ -59,32 +67,36 @@ var (
 	zeroMetricValues    = []float64{0.0, 0.0, 0.0, 0.0, 0.0}          //nolint:gochecknoglobals // package-level test fixtures
 
 	startTransition = lifecycleTransition{ //nolint:gochecknoglobals // package-level config
-		intermediateState: compute.StatePending,
-		finalState:        compute.StateRunning,
-		metricValues:      runningMetricValues,
-		errVerb:           "start",
-		powerState:        powerStateRunning,
+		intermediateState:     compute.StatePending,
+		finalState:            compute.StateRunning,
+		metricValues:          runningMetricValues,
+		errVerb:               "start",
+		powerState:            powerStateRunning,
+		idempotentPowerStates: []string{powerStateRunning},
 	}
 	stopTransition = lifecycleTransition{ //nolint:gochecknoglobals // package-level config
-		intermediateState: compute.StateStopping,
-		finalState:        compute.StateStopped,
-		metricValues:      zeroMetricValues,
-		errVerb:           "stop",
-		powerState:        powerStateDeallocated,
+		intermediateState:     compute.StateStopping,
+		finalState:            compute.StateStopped,
+		metricValues:          zeroMetricValues,
+		errVerb:               "stop",
+		powerState:            powerStateDeallocated,
+		idempotentPowerStates: []string{powerStateDeallocated},
 	}
 	powerOffTransition = lifecycleTransition{ //nolint:gochecknoglobals // package-level config
-		intermediateState: compute.StateStopping,
-		finalState:        compute.StateStopped,
-		metricValues:      zeroMetricValues,
-		errVerb:           "power off",
-		powerState:        powerStateStopped,
+		intermediateState:     compute.StateStopping,
+		finalState:            compute.StateStopped,
+		metricValues:          zeroMetricValues,
+		errVerb:               "power off",
+		powerState:            powerStateStopped,
+		idempotentPowerStates: []string{powerStateStopped, powerStateDeallocated},
 	}
 	deallocateTransition = lifecycleTransition{ //nolint:gochecknoglobals // package-level config
-		intermediateState: compute.StateStopping,
-		finalState:        compute.StateStopped,
-		metricValues:      zeroMetricValues,
-		errVerb:           "deallocate",
-		powerState:        powerStateDeallocated,
+		intermediateState:     compute.StateStopping,
+		finalState:            compute.StateStopped,
+		metricValues:          zeroMetricValues,
+		errVerb:               "deallocate",
+		powerState:            powerStateDeallocated,
+		idempotentPowerStates: []string{powerStateDeallocated},
 	}
 	rebootTransition = lifecycleTransition{ //nolint:gochecknoglobals // package-level config
 		intermediateState: compute.StateRestarting,
@@ -399,6 +411,21 @@ func (m *Mock) transitionInstances(ctx context.Context, instanceIDs []string, t 
 			return cerrors.Newf(cerrors.NotFound, "instance %q not found", id)
 		}
 
+		// The lifecycle state machine is already settled at this action's
+		// target state (e.g. Start on an already-running VM, or PowerOff
+		// after Deallocate — both settle at compute.StateStopped). Walking
+		// the FSM again would hit an illegal same-state edge, but real Azure
+		// treats the action as idempotent, so short-circuit instead of
+		// erroring.
+		if inst.State == t.finalState && isIdempotentPowerState(t) {
+			if !isIdempotent(inst.PowerState, t.idempotentPowerStates) && t.powerState != "" {
+				inst.PowerState = t.powerState
+				m.emitLifecycleMetrics(ctx, inst, t.metricValues)
+			}
+
+			continue
+		}
+
 		if err := m.sm.Transition(id, t.intermediateState); err != nil {
 			return cerrors.Newf(cerrors.FailedPrecondition, "cannot %s instance %q: %v", t.errVerb, id, err)
 		}
@@ -415,6 +442,23 @@ func (m *Mock) transitionInstances(ctx context.Context, instanceIDs []string, t 
 	}
 
 	return nil
+}
+
+// isIdempotentPowerState reports whether t is one of the power actions
+// (Start/Stop/PowerOff/Deallocate) that Azure documents as idempotent on the
+// settled state, as opposed to Reboot/Terminate which always act.
+func isIdempotentPowerState(t *lifecycleTransition) bool {
+	return len(t.idempotentPowerStates) > 0
+}
+
+func isIdempotent(state string, idempotentStates []string) bool {
+	for _, s := range idempotentStates {
+		if state == s {
+			return true
+		}
+	}
+
+	return false
 }
 
 // StartInstances starts the specified stopped virtual machine instances.

--- a/providers/azure/virtualmachines/vm_test.go
+++ b/providers/azure/virtualmachines/vm_test.go
@@ -137,7 +137,9 @@ func TestStartInstances(t *testing.T) {
 	}{
 		{name: "success", ids: []string{id}},
 		{name: "not found", ids: []string{"vm-missing"}, wantErr: true, errMsg: "not found"},
-		{name: "already running", ids: []string{id}, wantErr: true, errMsg: "cannot start"},
+		// Real Azure returns 200/202 (no state-conflict error) when Start is
+		// called on an already-running VM.
+		{name: "idempotent on already running", ids: []string{id}},
 	}
 
 	for _, tt := range tests {
@@ -175,7 +177,9 @@ func TestStopInstances(t *testing.T) {
 	}{
 		{name: "success", ids: []string{id}},
 		{name: "not found", ids: []string{"vm-missing"}, wantErr: true, errMsg: "not found"},
-		{name: "already stopped", ids: []string{id}, wantErr: true, errMsg: "cannot stop"},
+		// Real Azure returns 200/202 (no state-conflict error) when Stop is
+		// called on an already-stopped VM.
+		{name: "idempotent on already stopped", ids: []string{id}},
 	}
 
 	for _, tt := range tests {

--- a/providers/gcp/compute/gce.go
+++ b/providers/gcp/compute/gce.go
@@ -37,6 +37,12 @@ type lifecycleTransition struct {
 	finalState        string
 	metricValues      []float64
 	errVerb           string
+	// idempotentStates are states where the operation is a no-op rather than
+	// an error. Real GCE documents instances.start/instances.stop as
+	// returning a completed zone operation (no error) when the instance is
+	// already at the requested power state, rather than an invalid-state
+	// error.
+	idempotentStates []string
 }
 
 var (
@@ -48,12 +54,14 @@ var (
 		finalState:        compute.StateRunning,
 		metricValues:      runningMetricValues,
 		errVerb:           "start",
+		idempotentStates:  []string{compute.StateRunning, compute.StatePending},
 	}
 	stopTransition = lifecycleTransition{ //nolint:gochecknoglobals // package-level config
 		intermediateState: compute.StateStopping,
 		finalState:        compute.StateStopped,
 		metricValues:      zeroMetricValues,
 		errVerb:           "stop",
+		idempotentStates:  []string{compute.StateStopped, compute.StateStopping},
 	}
 	rebootTransition = lifecycleTransition{ //nolint:gochecknoglobals // package-level config
 		intermediateState: compute.StateRestarting,
@@ -309,11 +317,18 @@ func (m *Mock) rollbackInstances(ctx context.Context, created []*instanceData) {
 	}
 }
 
-func (m *Mock) transitionInstances(ctx context.Context, instanceIDs []string, t lifecycleTransition) error {
+func (m *Mock) transitionInstances(ctx context.Context, instanceIDs []string, t *lifecycleTransition) error {
 	for _, id := range instanceIDs {
 		inst, ok := m.instances.Get(id)
 		if !ok {
 			return cerrors.Newf(cerrors.NotFound, "instance %q not found", id)
+		}
+
+		// Real GCE documents start/stop as idempotent on the target state.
+		// Skip the state machine and return success without changing state
+		// when we're already there.
+		if isIdempotent(inst.State, t.idempotentStates) {
+			continue
 		}
 
 		if err := m.sm.Transition(id, t.intermediateState); err != nil {
@@ -330,20 +345,30 @@ func (m *Mock) transitionInstances(ctx context.Context, instanceIDs []string, t 
 	return nil
 }
 
+func isIdempotent(state string, idempotentStates []string) bool {
+	for _, s := range idempotentStates {
+		if state == s {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (m *Mock) StartInstances(ctx context.Context, instanceIDs []string) error {
-	return m.transitionInstances(ctx, instanceIDs, startTransition)
+	return m.transitionInstances(ctx, instanceIDs, &startTransition)
 }
 
 func (m *Mock) StopInstances(ctx context.Context, instanceIDs []string) error {
-	return m.transitionInstances(ctx, instanceIDs, stopTransition)
+	return m.transitionInstances(ctx, instanceIDs, &stopTransition)
 }
 
 func (m *Mock) RebootInstances(ctx context.Context, instanceIDs []string) error {
-	return m.transitionInstances(ctx, instanceIDs, rebootTransition)
+	return m.transitionInstances(ctx, instanceIDs, &rebootTransition)
 }
 
 func (m *Mock) TerminateInstances(ctx context.Context, instanceIDs []string) error {
-	if err := m.transitionInstances(ctx, instanceIDs, terminateTransition); err != nil {
+	if err := m.transitionInstances(ctx, instanceIDs, &terminateTransition); err != nil {
 		return err
 	}
 

--- a/providers/gcp/compute/gce_test.go
+++ b/providers/gcp/compute/gce_test.go
@@ -191,7 +191,9 @@ func TestStartInstances(t *testing.T) {
 	}{
 		{name: "success", ids: []string{id}},
 		{name: "not found", ids: []string{"nonexistent"}, wantErr: true, errSubstr: "not found"},
-		{name: "already running", ids: []string{id}, wantErr: true, errSubstr: "cannot start"},
+		// Real GCE returns a completed zone operation (no error) when
+		// instances.start is called on an already-running instance.
+		{name: "idempotent on already running", ids: []string{id}},
 	}
 
 	for _, tt := range tests {
@@ -227,7 +229,9 @@ func TestStopInstances(t *testing.T) {
 	}{
 		{name: "success", ids: []string{id}},
 		{name: "not found", ids: []string{"nonexistent"}, wantErr: true, errSubstr: "not found"},
-		{name: "already stopped", ids: []string{id}, wantErr: true, errSubstr: "cannot stop"},
+		// Real GCE returns a completed zone operation (no error) when
+		// instances.stop is called on an already-stopped instance.
+		{name: "idempotent on already stopped", ids: []string{id}},
 	}
 
 	for _, tt := range tests {

--- a/server/azure/virtualmachines/lifecycle_e2e_test.go
+++ b/server/azure/virtualmachines/lifecycle_e2e_test.go
@@ -209,6 +209,44 @@ func TestVMInstanceView(t *testing.T) {
 	}
 }
 
+// TestVMLifecycleIdempotent verifies repeating the same power action over the
+// wire — exactly what Terraform/az cli commonly re-issues — succeeds
+// idempotently (200/202) instead of the 409 real Azure never documents for
+// Start/PowerOff/Deallocate (MS Learn: rest/api/compute/virtual-machines/
+// start, .../power-off, .../deallocate list only 200/202 as responses).
+func TestVMLifecycleIdempotent(t *testing.T) {
+	ts := newAzureTestServer(t)
+	_ = putVM(t, ts, "vm-idem-power")
+
+	if code := postAction(t, ts, "vm-idem-power", "start"); code != http.StatusAccepted {
+		t.Fatalf("start status=%d want 202", code)
+	}
+
+	if code := postAction(t, ts, "vm-idem-power", "start"); code != http.StatusAccepted {
+		t.Fatalf("repeat start on already-running VM status=%d want 202 (idempotent), not a state-conflict error", code)
+	}
+
+	if code := postAction(t, ts, "vm-idem-power", "powerOff"); code != http.StatusAccepted {
+		t.Fatalf("powerOff status=%d want 202", code)
+	}
+
+	if code := postAction(t, ts, "vm-idem-power", "powerOff"); code != http.StatusAccepted {
+		t.Fatalf("repeat powerOff on already-stopped VM status=%d want 202 (idempotent), not a state-conflict error", code)
+	}
+
+	if code := postAction(t, ts, "vm-idem-power", "deallocate"); code != http.StatusAccepted {
+		t.Fatalf("deallocate status=%d want 202", code)
+	}
+
+	if code := postAction(t, ts, "vm-idem-power", "deallocate"); code != http.StatusAccepted {
+		t.Fatalf("repeat deallocate on already-deallocated VM status=%d want 202 (idempotent), not a state-conflict error", code)
+	}
+
+	if got := powerStateCode(t, getVM(t, ts, "vm-idem-power")); got != "deallocated" {
+		t.Errorf("after idempotent deallocate powerState=%q want deallocated", got)
+	}
+}
+
 // TestVMPowerOffVsDeallocate verifies PowerOff reports PowerState/stopped (the
 // VM stays allocated) while Deallocate reports PowerState/deallocated.
 func TestVMPowerOffVsDeallocate(t *testing.T) {


### PR DESCRIPTION
## Summary

Repeating the same power action on a VM — exactly what Terraform/az cli/aws cli commonly re-issue — returned 409 instead of the idempotent success real clouds document:

- Azure `BeginStart` on an already-running VM -> 409 (`transition from running to pending not allowed`)
- Azure `BeginPowerOff` on an already-stopped VM -> 409
- Azure `BeginDeallocate` on an already-deallocated VM -> 409

Root cause: `services/compute/states.go` `VMTransitions()` is a forward-only FSM shared by AWS/Azure/GCP, so calling a power action whose target state the instance has already settled into re-walks an illegal same-state edge.

MS Learn documents Start/PowerOff/Deallocate as only ever returning 200/202 — no state-conflict error is documented for any current power state:
- https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/start
- https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/deallocate

## Fix

Added a no-op short-circuit in each provider's `transitionInstances` wrapper (before the FSM `Transition` call) rather than adding self-edges to the shared FSM, keeping the blast radius to the three provider packages:

- **Azure** (`providers/azure/virtualmachines/vm.go`): when the FSM is already settled at the action's target lifecycle state, skip the illegal edge. Because PowerOff and Deallocate both settle at `StateStopped` but differ by Azure `PowerState` (`stopped` vs `deallocated`), the check is PowerState-aware: PowerOff after Deallocate stays deallocated (true no-op), Deallocate after PowerOff still releases compute (applies the real PowerState change without touching the FSM).
- **GCP** (`providers/gcp/compute/gce.go`): mirrors the `idempotentStates` pattern AWS EC2 already uses (`fix(ec2): make StartInstances/StopInstances idempotent on target state`) — GCE also documents start/stop on an already-matching-state instance as a no-op success.
- **AWS EC2** was already fixed; verified its existing idempotency behavior and tests still pass unchanged.

`services/compute/states.go` (the shared FSM) is untouched — Reboot/Terminate keep their existing strict-state behavior on all three clouds.

## Tests

- New Azure regression tests: repeat Start/PowerOff/Deallocate -> idempotent success, including the PowerOff<->Deallocate cross-action cases.
- New GCP regression tests: repeat StartInstances/StopInstances -> idempotent success (existing tests asserting a 409 there were updated to reflect real GCE behavior).
- New wire-level (real HTTP, ARM protocol) regression test exercising repeated start/powerOff/deallocate through the actual server handler.
- Existing AWS EC2 idempotency tests, and existing EC2/GCE lifecycle + metric-emission tests across all three providers, still pass unchanged.
