### PR TITLE
fix(azure-vnet): route virtualNetworkPeerings as its own sub-resource

### DIFF
--- a/docs/coverage/aws/vpc.md
+++ b/docs/coverage/aws/vpc.md
@@ -89,11 +89,16 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | `DeleteAzureNSGMetadata` |  |
 | `DeleteAzureNSGRule` | DeleteAzureNSGRule removes a single custom security rule by name, leaving |
 | `DeleteAzureVNetMetadata` |  |
+| `DeleteAzureVNetPeering` | DeleteAzureVNetPeering removes a single peering by name, leaving every |
 | `GetAzureNSGMetadata` |  |
 | `GetAzureVNetMetadata` |  |
+| `GetAzureVNetPeering` | GetAzureVNetPeering returns one stored peering by name. |
+| `ListAzureVNetPeerings` | ListAzureVNetPeerings returns every peering stored for a VNet, ordered by |
 | `PutAzureNSGMetadata` |  |
 | `PutAzureVNetMetadata` |  |
+| `SetAzureVNetPeeringState` | SetAzureVNetPeeringState atomically updates just the peeringState field of |
 | `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
+| `UpsertAzureVNetPeering` | UpsertAzureVNetPeering creates or replaces a single virtualNetworkPeerings |
 
 ### ClientVPN
 

--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -89,11 +89,16 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | `DeleteAzureNSGMetadata` |  |
 | `DeleteAzureNSGRule` | DeleteAzureNSGRule removes a single custom security rule by name, leaving |
 | `DeleteAzureVNetMetadata` |  |
+| `DeleteAzureVNetPeering` | DeleteAzureVNetPeering removes a single peering by name, leaving every |
 | `GetAzureNSGMetadata` |  |
 | `GetAzureVNetMetadata` |  |
+| `GetAzureVNetPeering` | GetAzureVNetPeering returns one stored peering by name. |
+| `ListAzureVNetPeerings` | ListAzureVNetPeerings returns every peering stored for a VNet, ordered by |
 | `PutAzureNSGMetadata` |  |
 | `PutAzureVNetMetadata` |  |
+| `SetAzureVNetPeeringState` | SetAzureVNetPeeringState atomically updates just the peeringState field of |
 | `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
+| `UpsertAzureVNetPeering` | UpsertAzureVNetPeering creates or replaces a single virtualNetworkPeerings |
 
 ### ClientVPN
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -6476,10 +6476,22 @@
             "name": "DeleteAzureVNetMetadata"
           },
           {
+            "name": "DeleteAzureVNetPeering",
+            "doc": "DeleteAzureVNetPeering removes a single peering by name, leaving every"
+          },
+          {
             "name": "GetAzureNSGMetadata"
           },
           {
             "name": "GetAzureVNetMetadata"
+          },
+          {
+            "name": "GetAzureVNetPeering",
+            "doc": "GetAzureVNetPeering returns one stored peering by name."
+          },
+          {
+            "name": "ListAzureVNetPeerings",
+            "doc": "ListAzureVNetPeerings returns every peering stored for a VNet, ordered by"
           },
           {
             "name": "PutAzureNSGMetadata"
@@ -6488,8 +6500,16 @@
             "name": "PutAzureVNetMetadata"
           },
           {
+            "name": "SetAzureVNetPeeringState",
+            "doc": "SetAzureVNetPeeringState atomically updates just the peeringState field of"
+          },
+          {
             "name": "UpsertAzureNSGRule",
             "doc": "UpsertAzureNSGRule creates or replaces a single custom security rule by"
+          },
+          {
+            "name": "UpsertAzureVNetPeering",
+            "doc": "UpsertAzureVNetPeering creates or replaces a single virtualNetworkPeerings"
           }
         ]
       },

--- a/docs/coverage/gcp/vpc.md
+++ b/docs/coverage/gcp/vpc.md
@@ -89,11 +89,16 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | `DeleteAzureNSGMetadata` |  |
 | `DeleteAzureNSGRule` | DeleteAzureNSGRule removes a single custom security rule by name, leaving |
 | `DeleteAzureVNetMetadata` |  |
+| `DeleteAzureVNetPeering` | DeleteAzureVNetPeering removes a single peering by name, leaving every |
 | `GetAzureNSGMetadata` |  |
 | `GetAzureVNetMetadata` |  |
+| `GetAzureVNetPeering` | GetAzureVNetPeering returns one stored peering by name. |
+| `ListAzureVNetPeerings` | ListAzureVNetPeerings returns every peering stored for a VNet, ordered by |
 | `PutAzureNSGMetadata` |  |
 | `PutAzureVNetMetadata` |  |
+| `SetAzureVNetPeeringState` | SetAzureVNetPeeringState atomically updates just the peeringState field of |
 | `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
+| `UpsertAzureVNetPeering` | UpsertAzureVNetPeering creates or replaces a single virtualNetworkPeerings |
 
 ### ClientVPN
 

--- a/docs/coverage/oci/vcn.md
+++ b/docs/coverage/oci/vcn.md
@@ -89,11 +89,16 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | `DeleteAzureNSGMetadata` |  |
 | `DeleteAzureNSGRule` | DeleteAzureNSGRule removes a single custom security rule by name, leaving |
 | `DeleteAzureVNetMetadata` |  |
+| `DeleteAzureVNetPeering` | DeleteAzureVNetPeering removes a single peering by name, leaving every |
 | `GetAzureNSGMetadata` |  |
 | `GetAzureVNetMetadata` |  |
+| `GetAzureVNetPeering` | GetAzureVNetPeering returns one stored peering by name. |
+| `ListAzureVNetPeerings` | ListAzureVNetPeerings returns every peering stored for a VNet, ordered by |
 | `PutAzureNSGMetadata` |  |
 | `PutAzureVNetMetadata` |  |
+| `SetAzureVNetPeeringState` | SetAzureVNetPeeringState atomically updates just the peeringState field of |
 | `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
+| `UpsertAzureVNetPeering` | UpsertAzureVNetPeering creates or replaces a single virtualNetworkPeerings |
 
 ### ClientVPN
 

--- a/providers/azure/vnet/azure_vnet_peering.go
+++ b/providers/azure/vnet/azure_vnet_peering.go
@@ -1,0 +1,137 @@
+package vnet
+
+import (
+	"context"
+	"sort"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// UpsertAzureVNetPeering creates or replaces a single virtualNetworkPeerings
+// sub-resource by name via an atomic read-modify-write on the stored slice,
+// leaving every sibling peering on the same VNet untouched.
+//
+//nolint:gocritic // hugeParam: peering is a small value type; interface method signature cannot be changed.
+func (m *Mock) UpsertAzureVNetPeering(_ context.Context, vnetID string, peering driver.AzureVNetPeering) (driver.AzureVNetPeering, error) {
+	if !m.vpcs.Has(vnetID) {
+		return driver.AzureVNetPeering{}, cerrors.Newf(cerrors.NotFound, "virtual network %q not found", vnetID)
+	}
+
+	// Ensure the key exists so the Update below always finds it — a VNet's
+	// first peering has nothing to read-modify-write yet.
+	m.azureVNetPeerings.SetIfAbsent(vnetID, nil)
+
+	m.azureVNetPeerings.Update(vnetID, func(peerings []driver.AzureVNetPeering) []driver.AzureVNetPeering {
+		out := append([]driver.AzureVNetPeering(nil), peerings...)
+
+		for i := range out {
+			if out[i].Name == peering.Name {
+				out[i] = peering
+				return out
+			}
+		}
+
+		return append(out, peering)
+	})
+
+	return peering, nil
+}
+
+// GetAzureVNetPeering returns one stored peering by name.
+func (m *Mock) GetAzureVNetPeering(_ context.Context, vnetID, peeringName string) (driver.AzureVNetPeering, bool) {
+	peerings, ok := m.azureVNetPeerings.Get(vnetID)
+	if !ok {
+		return driver.AzureVNetPeering{}, false
+	}
+
+	for _, p := range peerings {
+		if p.Name == peeringName {
+			return p, true
+		}
+	}
+
+	return driver.AzureVNetPeering{}, false
+}
+
+// ListAzureVNetPeerings returns every peering stored for a VNet, ordered by
+// name — map iteration order is random and real ARM returns a deterministic
+// list ordering.
+func (m *Mock) ListAzureVNetPeerings(_ context.Context, vnetID string) []driver.AzureVNetPeering {
+	peerings, ok := m.azureVNetPeerings.Get(vnetID)
+	if !ok {
+		return nil
+	}
+
+	out := append([]driver.AzureVNetPeering(nil), peerings...)
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+
+	return out
+}
+
+// DeleteAzureVNetPeering removes a single peering by name via an atomic
+// read-modify-write, leaving every sibling peering untouched.
+func (m *Mock) DeleteAzureVNetPeering(_ context.Context, vnetID, peeringName string) error {
+	if !m.vpcs.Has(vnetID) {
+		return cerrors.Newf(cerrors.NotFound, "virtual network %q not found", vnetID)
+	}
+
+	missing := false
+
+	ok := m.azureVNetPeerings.Update(vnetID, func(peerings []driver.AzureVNetPeering) []driver.AzureVNetPeering {
+		idx := -1
+
+		for i := range peerings {
+			if peerings[i].Name == peeringName {
+				idx = i
+				break
+			}
+		}
+
+		if idx == -1 {
+			missing = true
+			return peerings
+		}
+
+		return append(append([]driver.AzureVNetPeering(nil), peerings[:idx]...), peerings[idx+1:]...)
+	})
+
+	if !ok || missing {
+		return cerrors.Newf(cerrors.NotFound, "virtual network peering %q not found", peeringName)
+	}
+
+	return nil
+}
+
+// SetAzureVNetPeeringState atomically updates just the peeringState field of
+// one stored peering via a read-modify-write, used to sync the reciprocal
+// side of a two-way peering without clobbering its other properties.
+func (m *Mock) SetAzureVNetPeeringState(_ context.Context, vnetID, peeringName, state string) error {
+	if !m.vpcs.Has(vnetID) {
+		return cerrors.Newf(cerrors.NotFound, "virtual network %q not found", vnetID)
+	}
+
+	missing := false
+
+	ok := m.azureVNetPeerings.Update(vnetID, func(peerings []driver.AzureVNetPeering) []driver.AzureVNetPeering {
+		out := append([]driver.AzureVNetPeering(nil), peerings...)
+
+		for i := range out {
+			if out[i].Name == peeringName {
+				out[i].PeeringState = state
+				return out
+			}
+		}
+
+		missing = true
+
+		return out
+	})
+
+	if !ok || missing {
+		return cerrors.Newf(cerrors.NotFound, "virtual network peering %q not found", peeringName)
+	}
+
+	return nil
+}

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -69,6 +69,12 @@ type Mock struct {
 	// list, Azure security rules), keyed by the driver resource id.
 	azureVNetMeta *memstore.Store[driver.AzureVNetMetadata]
 	azureNSGMeta  *memstore.Store[driver.AzureNSGMetadata]
+	// azureVNetPeerings holds the ARM-specific virtualNetworkPeerings
+	// sub-resources for each VNet, keyed by the VNet's driver id, separately
+	// from azureVNetMeta so a whole-VNet PUT's PutAzureVNetMetadata (which
+	// replaces the vnet's metadata wholesale) never clobbers peerings created
+	// through the dedicated peerings sub-resource CRUD.
+	azureVNetPeerings *memstore.Store[[]driver.AzureVNetPeering]
 	// nicMu serializes network-interface create/update, whose private-IP
 	// allocation is a read-modify-write across the nics store (memstore is
 	// per-op safe but can't make that sequence atomic).
@@ -79,22 +85,23 @@ type Mock struct {
 // New creates a new Azure Virtual Network mock.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		vpcs:           memstore.New[*vpcData](),
-		subnets:        memstore.New[*subnetData](),
-		securityGroups: memstore.New[*sgData](),
-		peerings:       memstore.New[*peeringData](),
-		natGateways:    memstore.New[*natGatewayData](),
-		flowLogs:       memstore.New[*flowLogData](),
-		routeTables:    memstore.New[*routeTableData](),
-		networkACLs:    memstore.New[*networkACLData](),
-		igws:           memstore.New[*igwData](),
-		eips:           memstore.New[*eipData](),
-		rtAssocs:       memstore.New[*rtAssocData](),
-		endpoints:      memstore.New[*driver.VPCEndpoint](),
-		nics:           memstore.New[*nicData](),
-		azureVNetMeta:  memstore.New[driver.AzureVNetMetadata](),
-		azureNSGMeta:   memstore.New[driver.AzureNSGMetadata](),
-		opts:           opts,
+		vpcs:              memstore.New[*vpcData](),
+		subnets:           memstore.New[*subnetData](),
+		securityGroups:    memstore.New[*sgData](),
+		peerings:          memstore.New[*peeringData](),
+		natGateways:       memstore.New[*natGatewayData](),
+		flowLogs:          memstore.New[*flowLogData](),
+		routeTables:       memstore.New[*routeTableData](),
+		networkACLs:       memstore.New[*networkACLData](),
+		igws:              memstore.New[*igwData](),
+		eips:              memstore.New[*eipData](),
+		rtAssocs:          memstore.New[*rtAssocData](),
+		endpoints:         memstore.New[*driver.VPCEndpoint](),
+		nics:              memstore.New[*nicData](),
+		azureVNetMeta:     memstore.New[driver.AzureVNetMetadata](),
+		azureNSGMeta:      memstore.New[driver.AzureNSGMetadata](),
+		azureVNetPeerings: memstore.New[[]driver.AzureVNetPeering](),
+		opts:              opts,
 	}
 }
 

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -14,6 +14,8 @@
 //	GET .../networkSecurityGroups                        — list NSGs
 //	PUT/GET/DELETE  .../networkInterfaces/{name}         — NIC CRUD
 //	GET .../networkInterfaces                            — list NICs
+//	PUT/GET/DELETE  .../virtualNetworks/{vn}/virtualNetworkPeerings/{n} — peering CRUD
+//	GET .../virtualNetworks/{vn}/virtualNetworkPeerings  — list peerings
 package vnet
 
 import (
@@ -49,6 +51,7 @@ const (
 	defaultLoc          = "eastus"
 	subResSubnets       = "subnets"
 	subResSecurityRules = "securityRules"
+	subResVNetPeerings  = "virtualNetworkPeerings"
 	subResCheckIPAvail  = "CheckIPAddressAvailability"
 )
 
@@ -122,6 +125,17 @@ func (h *Handler) routeVNet(w http.ResponseWriter, r *http.Request, rp azurearm.
 	// Subnet sub-resource: SubResource="subnets", SubResourceName="{name}".
 	if rp.SubResource == subResSubnets {
 		h.routeSubnet(w, r, rp)
+		return
+	}
+
+	// VirtualNetworkPeerings sub-resource (VirtualNetworkPeeringsClient):
+	// SubResource="virtualNetworkPeerings", SubResourceName="{peeringName}".
+	// Routed before the whole-VNet method switch below — BLOCKER fix: without
+	// this, a peering PUT/GET/DELETE fell through to createVNet/getVNet/deleteVNet
+	// keyed on rp.ResourceName (the parent VNet's own name), so a peering DELETE
+	// deleted the entire virtual network instead of just the peering.
+	if rp.SubResource == subResVNetPeerings {
+		h.routeVNetPeering(w, r, rp)
 		return
 	}
 

--- a/server/azure/vnet/security_rule_subresource.go
+++ b/server/azure/vnet/security_rule_subresource.go
@@ -25,7 +25,7 @@ const (
 // from routeNSG before any whole-NSG handler ever sees the request, so a
 // standalone rule op mutates only the addressed rule and preserves siblings.
 //
-//nolint:gocritic // rp is a request-scoped value
+//nolint:gocritic,dupl // rp is request-scoped; mirrors routeVNetPeering over a distinct sub-resource by design
 func (h *Handler) routeSecurityRule(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	if rp.SubResourceName == "" {
 		if r.Method != http.MethodGet {

--- a/server/azure/vnet/types.go
+++ b/server/azure/vnet/types.go
@@ -208,3 +208,39 @@ type publicIPDNSSettings struct {
 type publicIPListResponse struct {
 	Value []publicIPResponse `json:"value"`
 }
+
+// VirtualNetworkPeerings sub-resource (VirtualNetworkPeeringsClient).
+
+type vnetPeeringRequest struct {
+	Properties vnetPeeringRequestProps `json:"properties"`
+}
+
+type vnetPeeringRequestProps struct {
+	RemoteVirtualNetwork      *armIDRef `json:"remoteVirtualNetwork,omitempty"`
+	AllowVirtualNetworkAccess *bool     `json:"allowVirtualNetworkAccess,omitempty"`
+	AllowForwardedTraffic     *bool     `json:"allowForwardedTraffic,omitempty"`
+	AllowGatewayTransit       *bool     `json:"allowGatewayTransit,omitempty"`
+	UseRemoteGateways         *bool     `json:"useRemoteGateways,omitempty"`
+}
+
+type vnetPeeringResponse struct {
+	ID         string                   `json:"id"`
+	Name       string                   `json:"name"`
+	Etag       string                   `json:"etag,omitempty"`
+	Properties vnetPeeringResponseProps `json:"properties"`
+}
+
+type vnetPeeringResponseProps struct {
+	ProvisioningState         string        `json:"provisioningState"`
+	PeeringState              string        `json:"peeringState"`
+	RemoteVirtualNetwork      *armIDRef     `json:"remoteVirtualNetwork,omitempty"`
+	RemoteAddressSpace        *addressSpace `json:"remoteAddressSpace,omitempty"`
+	AllowVirtualNetworkAccess bool          `json:"allowVirtualNetworkAccess"`
+	AllowForwardedTraffic     bool          `json:"allowForwardedTraffic"`
+	AllowGatewayTransit       bool          `json:"allowGatewayTransit"`
+	UseRemoteGateways         bool          `json:"useRemoteGateways"`
+}
+
+type vnetPeeringListResponse struct {
+	Value []vnetPeeringResponse `json:"value"`
+}

--- a/server/azure/vnet/vnet_peering_regression_test.go
+++ b/server/azure/vnet/vnet_peering_regression_test.go
@@ -1,0 +1,209 @@
+package vnet_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// Finding (BLOCKER): VirtualNetworkPeerings PUT/GET/DELETE were not routed as
+// a sub-resource — routeVNet never inspected rp.SubResource for
+// "virtualNetworkPeerings", so a standalone peering op hit the whole-VNet
+// handler keyed on the parent VNet's own name. A peering DELETE therefore
+// deleted the entire virtual network. This verifies a standalone peering
+// PUT/GET/List/DELETE mutate only the addressed peering and preserve the
+// parent VNet (and its sibling peerings).
+func TestSDKVNetPeeringSubResourceCRUD(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnets, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	peerings, err := armnetwork.NewVirtualNetworkPeeringsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createTestVNet(t, ctx, vnets, "rg-1", "vnet-a", "10.0.0.0/16")
+	createTestVNet(t, ctx, vnets, "rg-1", "vnet-b", "10.1.0.0/16")
+
+	remoteID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/virtualNetworks/vnet-b"
+
+	p, err := peerings.BeginCreateOrUpdate(ctx, "rg-1", "vnet-a", "a-to-b", armnetwork.VirtualNetworkPeering{
+		Properties: &armnetwork.VirtualNetworkPeeringPropertiesFormat{
+			RemoteVirtualNetwork:  &armnetwork.SubResource{ID: to.Ptr(remoteID)},
+			AllowForwardedTraffic: to.Ptr(true),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate peering: %v", err)
+	}
+
+	created := pollDone(t, p)
+
+	if created.Name == nil || *created.Name != "a-to-b" {
+		t.Fatalf("created peering name = %v, want a-to-b", created.Name)
+	}
+
+	// Only one side exists so far: real ARM reports Initiated, not Connected,
+	// until the reciprocal peering on vnet-b also exists.
+	if created.Properties == nil || created.Properties.PeeringState == nil ||
+		*created.Properties.PeeringState != armnetwork.VirtualNetworkPeeringStateInitiated {
+		t.Fatalf("one-sided peering state = %v, want Initiated", created.Properties.PeeringState)
+	}
+
+	// The parent VNet must still exist and be untouched by the peering PUT —
+	// this is the BLOCKER regression: a peering op must never alias the VNet.
+	gotVNet, err := vnets.Get(ctx, "rg-1", "vnet-a", nil)
+	if err != nil {
+		t.Fatalf("vnet-a Get after peering create: %v", err)
+	}
+
+	if gotVNet.Properties == nil || gotVNet.Properties.AddressSpace == nil ||
+		len(gotVNet.Properties.AddressSpace.AddressPrefixes) != 1 ||
+		*gotVNet.Properties.AddressSpace.AddressPrefixes[0] != "10.0.0.0/16" {
+		t.Fatalf("vnet-a survived peering create with wrong address space: %+v", gotVNet.Properties)
+	}
+
+	// Standalone Get.
+	gotPeering, err := peerings.Get(ctx, "rg-1", "vnet-a", "a-to-b", nil)
+	if err != nil {
+		t.Fatalf("peering Get: %v", err)
+	}
+
+	if gotPeering.Properties == nil || gotPeering.Properties.RemoteVirtualNetwork == nil ||
+		gotPeering.Properties.RemoteVirtualNetwork.ID == nil || *gotPeering.Properties.RemoteVirtualNetwork.ID != remoteID {
+		t.Fatalf("peering remoteVirtualNetwork = %+v, want %s", gotPeering.Properties, remoteID)
+	}
+
+	if gotPeering.Properties.AllowForwardedTraffic == nil || !*gotPeering.Properties.AllowForwardedTraffic {
+		t.Fatal("peering allowForwardedTraffic did not round-trip")
+	}
+
+	// The reciprocal peering on vnet-b: once it exists, both sides connect.
+	p2, err := peerings.BeginCreateOrUpdate(ctx, "rg-1", "vnet-b", "b-to-a", armnetwork.VirtualNetworkPeering{
+		Properties: &armnetwork.VirtualNetworkPeeringPropertiesFormat{
+			RemoteVirtualNetwork: &armnetwork.SubResource{
+				ID: to.Ptr("/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/virtualNetworks/vnet-a"),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate reciprocal peering: %v", err)
+	}
+
+	reciprocal := pollDone(t, p2)
+
+	if reciprocal.Properties == nil || reciprocal.Properties.PeeringState == nil ||
+		*reciprocal.Properties.PeeringState != armnetwork.VirtualNetworkPeeringStateConnected {
+		t.Fatalf("reciprocal peering state = %v, want Connected", reciprocal.Properties.PeeringState)
+	}
+
+	// The original side must now report Connected too.
+	aSide, err := peerings.Get(ctx, "rg-1", "vnet-a", "a-to-b", nil)
+	if err != nil {
+		t.Fatalf("peering Get after reciprocal: %v", err)
+	}
+
+	if aSide.Properties == nil || aSide.Properties.PeeringState == nil ||
+		*aSide.Properties.PeeringState != armnetwork.VirtualNetworkPeeringStateConnected {
+		t.Fatalf("original side peering state after reciprocal = %v, want Connected", aSide.Properties.PeeringState)
+	}
+
+	// Standalone List on vnet-a must show only its own peering.
+	var names []string
+
+	pager := peerings.NewListPager("rg-1", "vnet-a", nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("peering list: %v", perr)
+		}
+
+		for _, pr := range page.Value {
+			if pr.Name != nil {
+				names = append(names, *pr.Name)
+			}
+		}
+	}
+
+	if len(names) != 1 || names[0] != "a-to-b" {
+		t.Fatalf("vnet-a peerings list = %v, want [a-to-b]", names)
+	}
+
+	// Standalone Delete must remove only the addressed peering and leave the
+	// parent VNet (and the other VNet's peering) intact.
+	dp, err := peerings.BeginDelete(ctx, "rg-1", "vnet-a", "a-to-b", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete peering: %v", err)
+	}
+
+	pollDone(t, dp)
+
+	if _, err := vnets.Get(ctx, "rg-1", "vnet-a", nil); err != nil {
+		t.Fatalf("vnet-a must survive its peering's delete: %v", err)
+	}
+
+	_, getErr := peerings.Get(ctx, "rg-1", "vnet-a", "a-to-b", nil)
+	if getErr == nil {
+		t.Fatal("deleted peering a-to-b should be gone")
+	}
+
+	if got := respStatus(t, getErr); got != 404 {
+		t.Fatalf("deleted peering Get: status = %d, want 404", got)
+	}
+
+	if _, err := peerings.Get(ctx, "rg-1", "vnet-b", "b-to-a", nil); err != nil {
+		t.Fatalf("sibling peering on vnet-b must survive vnet-a's peering delete: %v", err)
+	}
+}
+
+// Finding: a peering pointing at a nonexistent remote VNet was silently
+// accepted instead of resolving to a 404, and a self-peering was accepted
+// instead of being rejected.
+func TestSDKVNetPeeringValidation(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnets, _ := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	peerings, _ := armnetwork.NewVirtualNetworkPeeringsClient("sub-1", fakeCred{}, opts)
+
+	createTestVNet(t, ctx, vnets, "rg-1", "vnet-solo", "10.2.0.0/16")
+
+	_, err := peerings.BeginCreateOrUpdate(ctx, "rg-1", "vnet-solo", "to-nowhere", armnetwork.VirtualNetworkPeering{
+		Properties: &armnetwork.VirtualNetworkPeeringPropertiesFormat{
+			RemoteVirtualNetwork: &armnetwork.SubResource{
+				ID: to.Ptr("/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/virtualNetworks/does-not-exist"),
+			},
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("peering to nonexistent remote VNet: want error, got nil")
+	}
+
+	if got := respStatus(t, err); got != 404 {
+		t.Fatalf("peering to nonexistent remote VNet: status = %d, want 404", got)
+	}
+
+	selfID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/virtualNetworks/vnet-solo"
+
+	_, err = peerings.BeginCreateOrUpdate(ctx, "rg-1", "vnet-solo", "to-self", armnetwork.VirtualNetworkPeering{
+		Properties: &armnetwork.VirtualNetworkPeeringPropertiesFormat{
+			RemoteVirtualNetwork: &armnetwork.SubResource{ID: to.Ptr(selfID)},
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("self-peering: want error, got nil")
+	}
+
+	if got := respStatus(t, err); got != 400 {
+		t.Fatalf("self-peering: status = %d, want 400", got)
+	}
+}

--- a/server/azure/vnet/vnet_peering_subresource.go
+++ b/server/azure/vnet/vnet_peering_subresource.go
@@ -1,0 +1,256 @@
+package vnet
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// routeVNetPeering serves the VirtualNetworkPeeringsClient sub-resource
+// surface: PUT/GET/DELETE .../virtualNetworks/{vn}/virtualNetworkPeerings/{n}
+// and GET .../virtualNetworks/{vn}/virtualNetworkPeerings (list). Registered
+// from routeVNet before any whole-VNet handler ever sees the request, so a
+// standalone peering op mutates only the addressed peering and preserves the
+// VNet (and every sibling peering on it).
+//
+//nolint:gocritic,dupl // rp is request-scoped; mirrors routeSecurityRule over a distinct sub-resource by design
+func (h *Handler) routeVNetPeering(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.SubResourceName == "" {
+		if r.Method != http.MethodGet {
+			azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+			return
+		}
+
+		h.listVNetPeerings(w, r, rp)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.putVNetPeering(w, r, rp)
+	case http.MethodGet:
+		h.getVNetPeering(w, r, rp)
+	case http.MethodDelete:
+		h.deleteVNetPeering(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listVNetPeerings(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	meta, ok := h.azureMeta()
+	if !ok {
+		azurearm.WriteJSON(w, http.StatusOK, vnetPeeringListResponse{})
+		return
+	}
+
+	vnet, err := findVNetByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := vnetPeeringListResponse{}
+
+	for _, p := range meta.ListAzureVNetPeerings(r.Context(), vnet.ID) {
+		out.Value = append(out.Value, toVNetPeeringResponse(p, rp))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getVNetPeering(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	meta, ok := h.azureMeta()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"virtual network peerings are not supported by this networking driver")
+
+		return
+	}
+
+	vnet, err := findVNetByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	p, found := meta.GetAzureVNetPeering(r.Context(), vnet.ID, rp.SubResourceName)
+	if !found {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound",
+			"virtual network peering "+rp.SubResourceName+" not found")
+
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toVNetPeeringResponse(p, rp))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) putVNetPeering(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	meta, ok := h.azureMeta()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"virtual network peerings are not supported by this networking driver")
+
+		return
+	}
+
+	vnet, err := findVNetByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	var body vnetPeeringRequest
+
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	remoteVNet, remoteARMID, ok := h.resolvePeeringRemote(w, r, body.Properties.RemoteVirtualNetwork)
+	if !ok {
+		return
+	}
+
+	if remoteVNet.ID == vnet.ID {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "a virtual network cannot peer with itself")
+		return
+	}
+
+	localID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeVNet, rp.ResourceName)
+
+	_, remoteAddrPrefixes := h.vnetLocationPrefixes(r.Context(), remoteVNet)
+
+	peering := netdriver.AzureVNetPeering{
+		Name:                      rp.SubResourceName,
+		RemoteVirtualNetworkID:    remoteARMID,
+		RemoteAddressSpace:        remoteAddrPrefixes,
+		AllowVirtualNetworkAccess: boolOr(body.Properties.AllowVirtualNetworkAccess, true),
+		AllowForwardedTraffic:     boolOr(body.Properties.AllowForwardedTraffic, false),
+		AllowGatewayTransit:       boolOr(body.Properties.AllowGatewayTransit, false),
+		UseRemoteGateways:         boolOr(body.Properties.UseRemoteGateways, false),
+		PeeringState:              netdriver.AzurePeeringStateInitiated,
+	}
+
+	// A peering stays Initiated until its reciprocal peering (one on the
+	// remote VNet pointing back at this one) also exists, at which point real
+	// ARM reports both sides Connected — see the peeringState citation on
+	// AzureVNetPeering in services/networking/driver/azure_network_metadata.go.
+	if reciprocal := findReciprocalPeering(r.Context(), meta, remoteVNet.ID, localID); reciprocal != "" {
+		peering.PeeringState = netdriver.AzurePeeringStateConnected
+
+		_ = meta.SetAzureVNetPeeringState(r.Context(), remoteVNet.ID, reciprocal, netdriver.AzurePeeringStateConnected)
+	}
+
+	updated, err := meta.UpsertAzureVNetPeering(r.Context(), vnet.ID, peering)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "peering-create-"+rp.SubResourceName, toVNetPeeringResponse(updated, rp))
+}
+
+// resolvePeeringRemote validates and resolves a PUT body's required
+// remoteVirtualNetwork reference, writing the appropriate error response
+// itself. ok is false when a response was already written and the caller
+// must stop. armID is the reference's own ARM id, echoed back verbatim on the
+// stored peering (it may name a different subscription/resource group than
+// the local one).
+func (h *Handler) resolvePeeringRemote(
+	w http.ResponseWriter, r *http.Request, ref *armIDRef,
+) (remote *netdriver.VPCInfo, armID string, ok bool) {
+	if ref == nil || ref.ID == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "remoteVirtualNetwork is required")
+		return nil, "", false
+	}
+
+	remoteRP, parsed := azurearm.ParsePath(ref.ID)
+	if !parsed || remoteRP.ResourceType != typeVNet {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "malformed remoteVirtualNetwork id")
+		return nil, "", false
+	}
+
+	vnet, err := findVNetByName(r.Context(), h.net, remoteRP.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return nil, "", false
+	}
+
+	return vnet, ref.ID, true
+}
+
+// findReciprocalPeering scans every peering stored on the remote VNet for one
+// whose own remoteVirtualNetwork reference points back at localVNetARMID —
+// the other half of a two-way peering.
+func findReciprocalPeering(ctx context.Context, meta netdriver.AzureNetworkMetadata, remoteVNetID, localVNetARMID string) string {
+	for _, p := range meta.ListAzureVNetPeerings(ctx, remoteVNetID) {
+		if strings.EqualFold(p.RemoteVirtualNetworkID, localVNetARMID) {
+			return p.Name
+		}
+	}
+
+	return ""
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteVNetPeering(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	meta, ok := h.azureMeta()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"virtual network peerings are not supported by this networking driver")
+
+		return
+	}
+
+	vnet, err := findVNetByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if err := meta.DeleteAzureVNetPeering(r.Context(), vnet.ID, rp.SubResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "peering-delete-"+rp.SubResourceName, nil)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toVNetPeeringResponse(p netdriver.AzureVNetPeering, rp azurearm.ResourcePath) vnetPeeringResponse {
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeVNet, rp.ResourceName) +
+		"/virtualNetworkPeerings/" + p.Name
+
+	return vnetPeeringResponse{
+		ID:   id,
+		Name: p.Name,
+		Etag: etagOf(id),
+		Properties: vnetPeeringResponseProps{
+			ProvisioningState:         provisioningSucceeded,
+			PeeringState:              p.PeeringState,
+			RemoteVirtualNetwork:      &armIDRef{ID: p.RemoteVirtualNetworkID},
+			RemoteAddressSpace:        &addressSpace{AddressPrefixes: p.RemoteAddressSpace},
+			AllowVirtualNetworkAccess: p.AllowVirtualNetworkAccess,
+			AllowForwardedTraffic:     p.AllowForwardedTraffic,
+			AllowGatewayTransit:       p.AllowGatewayTransit,
+			UseRemoteGateways:         p.UseRemoteGateways,
+		},
+	}
+}
+
+// boolOr returns *v, or def when v is nil (the request body omitted the
+// field entirely).
+func boolOr(v *bool, def bool) bool {
+	if v == nil {
+		return def
+	}
+
+	return *v
+}

--- a/services/networking/driver/azure_network_metadata.go
+++ b/services/networking/driver/azure_network_metadata.go
@@ -44,6 +44,35 @@ type AzureNSGMetadata struct {
 	SecurityRules []AzureNSGRule
 }
 
+// Azure virtual-network peering states, matching Microsoft.Network's
+// VirtualNetworkPeeringState. A peering reports Initiated until its
+// reciprocal peering (a peering on the remote VNet pointing back at this
+// one) also exists, at which point both report Connected. See "Virtual
+// network peering" (learn.microsoft.com/azure/virtual-network/
+// virtual-network-peering-overview) and the VirtualNetworkPeeringPropertiesFormat
+// REST shape (learn.microsoft.com/rest/api/virtualnetwork/virtual-network-peerings/create-or-update).
+const (
+	AzurePeeringStateInitiated    = "Initiated"
+	AzurePeeringStateConnected    = "Connected"
+	AzurePeeringStateDisconnected = "Disconnected"
+)
+
+// AzureVNetPeering is one Azure virtualNetworkPeerings sub-resource: a
+// one-sided link from its parent virtual network to a remote one. Unlike the
+// cross-cloud PeeringConnection (a single symmetric object linking two VPCs),
+// ARM models each direction of a VNet peering as its own resource, addressed
+// by (parent VNet, peering name) and carrying its own traffic/gateway flags.
+type AzureVNetPeering struct {
+	Name                      string
+	RemoteVirtualNetworkID    string
+	RemoteAddressSpace        []string
+	AllowVirtualNetworkAccess bool
+	AllowForwardedTraffic     bool
+	AllowGatewayTransit       bool
+	UseRemoteGateways         bool
+	PeeringState              string
+}
+
 // AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 // provider stores the ARM-specific virtual-network and network-security-group
 // fields the cross-cloud Networking interface cannot represent, keyed by the
@@ -67,4 +96,26 @@ type AzureNetworkMetadata interface {
 	// every sibling rule untouched. Returns NotFound when either the network
 	// security group or the named rule doesn't exist.
 	DeleteAzureNSGRule(ctx context.Context, id string, ruleName string) error
+
+	// UpsertAzureVNetPeering creates or replaces a single virtualNetworkPeerings
+	// sub-resource by name on the VNet with the given driver id, leaving every
+	// sibling peering untouched — the atomic read-modify-write the peerings
+	// sub-resource CRUD needs. Returns NotFound when the virtual network itself
+	// doesn't exist.
+	UpsertAzureVNetPeering(ctx context.Context, vnetID string, peering AzureVNetPeering) (AzureVNetPeering, error)
+	// GetAzureVNetPeering returns one stored peering by name.
+	GetAzureVNetPeering(ctx context.Context, vnetID, peeringName string) (AzureVNetPeering, bool)
+	// ListAzureVNetPeerings returns every peering stored for a VNet, ordered by
+	// name.
+	ListAzureVNetPeerings(ctx context.Context, vnetID string) []AzureVNetPeering
+	// DeleteAzureVNetPeering removes a single peering by name, leaving every
+	// sibling peering untouched. Returns NotFound when either the virtual
+	// network or the named peering doesn't exist.
+	DeleteAzureVNetPeering(ctx context.Context, vnetID, peeringName string) error
+	// SetAzureVNetPeeringState atomically updates just the peeringState field of
+	// one stored peering, used to sync the reciprocal side of a two-way peering
+	// once it also exists, without touching that peering's other properties.
+	// Returns NotFound when either the virtual network or the named peering
+	// doesn't exist.
+	SetAzureVNetPeeringState(ctx context.Context, vnetID, peeringName, state string) error
 }


### PR DESCRIPTION
## Summary

**BLOCKER:** `VirtualNetworkPeerings` PUT/GET/DELETE were not routed as a sub-resource — `routeVNet` never inspected `rp.SubResource` for `virtualNetworkPeerings`, so a standalone peering operation fell through to the whole-VNet handler keyed on the parent VNet's own name. A peering DELETE therefore deleted the entire virtual network. `routeVNet` now dispatches `.../virtualNetworks/{vn}/virtualNetworkPeerings/{n}` to a dedicated peering CRUD, mirroring the `securityRules` sub-resource pattern already in place for NSGs.

**HIGH:** wired an Azure-shaped peering model in the optional `AzureNetworkMetadata` capability (`services/networking/driver/azure_network_metadata.go`) — `remoteVirtualNetwork` reference, `allowForwardedTraffic`/`allowGatewayTransit`/`useRemoteGateways`, and `peeringState` — stored per-VNet in `providers/azure/vnet` via `store.Update` read-modify-write, separately from the existing VNet metadata store so a whole-VNet PUT never clobbers peerings. `peeringState` reports `Connected` once a reciprocal peering exists on the remote VNet (mirroring real ARM's two-sided peering sync) and `Initiated` otherwise. Verified request/response shape against MS Learn (`VirtualNetworkPeeringPropertiesFormat`, `PUT .../virtualNetworkPeerings/{name}`).

**DEFERRED:** Virtual Network Gateways / Local Network Gateways / Gateway Connections — separate feature package, out of scope here.

## Test plan
- [x] `TestSDKVNetPeeringSubResourceCRUD` — real `armnetwork.VirtualNetworkPeeringsClient` PUT/GET/List/DELETE; confirms the parent VNet and sibling peerings survive a peering create/delete, and confirms `peeringState` transitions Initiated → Connected once the reciprocal peering exists
- [x] `TestSDKVNetPeeringValidation` — peering to a nonexistent remote VNet (404) and self-peering (400)
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./server/azure/vnet/... ./providers/azure/vnet/... ./services/networking/... ./server/azure/... ./providers/azure/...`
- [x] `go test -race ./providers/azure/vnet/...`
- [x] `golangci-lint` clean on changed packages (0 new issues)
- [x] `gofmt -l` clean
- [x] `internal/coveragegen` + `internal/compatgen` regenerated (driver interface changed), `docs/compat` diff is empty