### PR TITLE
fix(azure-servicebus): evaluate subscription filters on fan-out; honor LockDuration

### DIFF
--- a/server/azure/servicebus/dataplane.go
+++ b/server/azure/servicebus/dataplane.go
@@ -126,7 +126,7 @@ func (h *Handler) serveEntityData(w http.ResponseWriter, r *http.Request, tgt *d
 		return
 	}
 
-	subURLs, ok := h.resolveTopicSubURLs(tgt.namespace, tgt.entity)
+	targets, ok := h.resolveTopicSubURLs(tgt.namespace, tgt.entity)
 	if !ok {
 		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "entity not found: "+tgt.entity)
 		return
@@ -139,7 +139,7 @@ func (h *Handler) serveEntityData(w http.ResponseWriter, r *http.Request, tgt *d
 		return
 	}
 
-	h.dataPlaneTopicSend(w, r, subURLs)
+	h.dataPlaneTopicSend(w, r, targets)
 }
 
 // serveSubscriptionData routes a "/{topic}/subscriptions/{sub}/messages"
@@ -205,10 +205,17 @@ func (h *Handler) resolveQueueURL(namespace, queue string) (string, bool) {
 	return "", false
 }
 
-// resolveTopicSubURLs returns the backing driver URLs of every subscription on
-// a topic (the fan-out targets for a topic publish), and whether the topic
-// exists.
-func (h *Handler) resolveTopicSubURLs(namespace, topic string) ([]string, bool) {
+// topicSubTarget is one subscription fan-out target: its backing queue URL
+// plus a snapshot of its rules' filter properties, evaluated against each
+// published message to decide whether that subscription receives it.
+type topicSubTarget struct {
+	url   string
+	rules []ruleProperties
+}
+
+// resolveTopicSubURLs returns the fan-out targets of every subscription on a
+// topic, and whether the topic exists.
+func (h *Handler) resolveTopicSubURLs(namespace, topic string) ([]topicSubTarget, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
@@ -218,12 +225,20 @@ func (h *Handler) resolveTopicSubURLs(namespace, topic string) ([]string, bool) 
 			continue
 		}
 
-		urls := make([]string, 0, len(t.Subs))
+		targets := make([]topicSubTarget, 0, len(t.Subs))
+
 		for _, n := range sortedKeys(t.Subs) {
-			urls = append(urls, t.Subs[n].DriverURL)
+			sub := t.Subs[n]
+
+			rules := make([]ruleProperties, 0, len(sub.Rules))
+			for _, rn := range sortedKeys(sub.Rules) {
+				rules = append(rules, sub.Rules[rn].Props)
+			}
+
+			targets = append(targets, topicSubTarget{url: sub.DriverURL, rules: rules})
 		}
 
-		return urls, true
+		return targets, true
 	}
 
 	return nil, false
@@ -307,23 +322,36 @@ func (h *Handler) dataPlaneSend(w http.ResponseWriter, r *http.Request, url stri
 	w.WriteHeader(http.StatusCreated)
 }
 
-// dataPlaneTopicSend fans a published message out to every subscription's
-// backing queue. A topic with no subscriptions still returns 201 (the message
-// is accepted and dropped), matching Azure.
-func (h *Handler) dataPlaneTopicSend(w http.ResponseWriter, r *http.Request, subURLs []string) {
+// dataPlaneTopicSend fans a published message out to every subscription whose
+// rules it matches (each subscription's filter-only rules are OR'd, mirroring
+// real Service Bus). A topic with no subscriptions, or with none whose rules
+// match, still returns 201 (the message is accepted and dropped), matching
+// Azure.
+//
+// DEFER: only the system properties parseBrokerProperties recognizes are
+// evaluated; arbitrary custom application-property headers are not parsed, so
+// a SqlFilter or CorrelationFilter predicate over a user-defined property
+// cannot disqualify a subscription yet.
+func (h *Handler) dataPlaneTopicSend(w http.ResponseWriter, r *http.Request, targets []topicSubTarget) {
 	if r.Method != http.MethodPost {
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "send requires POST")
 		return
 	}
+
+	props := parseBrokerProperties(r)
 
 	body, ok := readSendBody(w, r)
 	if !ok {
 		return
 	}
 
-	for _, url := range subURLs {
+	for _, tgt := range targets {
+		if !rulesMatch(tgt.rules, &props) {
+			continue
+		}
+
 		if _, err := h.mq.SendMessage(r.Context(), mqdriver.SendMessageInput{
-			QueueURL: url, Body: body,
+			QueueURL: tgt.url, Body: body,
 		}); err != nil {
 			azurearm.WriteCErr(w, err)
 			return

--- a/server/azure/servicebus/dataplane_filter_test.go
+++ b/server/azure/servicebus/dataplane_filter_test.go
@@ -1,0 +1,175 @@
+package servicebus_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func ruleURL(topic, sub, rule string) string {
+	return subURL(topic, sub) + "/rules/" + rule
+}
+
+// TestDataPlaneCorrelationFilterRoutesOnlyMatchingMessages is the regression
+// for the subscription-filter bug: a CorrelationFilter rule must stop a
+// non-matching message from reaching that subscription, while a plain
+// $Default ("1=1") subscription still receives every message.
+//
+// https://learn.microsoft.com/azure/service-bus-messaging/topic-filters
+// https://learn.microsoft.com/rest/api/servicebus/send-message-to-queue
+// (BrokerProperties header carries CorrelationId/MessageId/Label etc.)
+func TestDataPlaneCorrelationFilterRoutesOnlyMatchingMessages(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+	seedTopicSub(t, srv, "orders", "urgent-only", "everything")
+
+	// Replace "urgent-only"'s $Default rule with a CorrelationFilter that
+	// only accepts CorrelationId=urgent.
+	if r := doRequest(t, srv, http.MethodDelete, ruleURL("orders", "urgent-only", "$Default")+apiVer, ""); r.StatusCode != http.StatusOK {
+		t.Fatalf("delete $Default rule = %d", r.StatusCode)
+	}
+
+	ruleBody := `{"properties":{"filterType":"CorrelationFilter","correlationFilter":{"correlationId":"urgent"}}}`
+	if r := doRequest(t, srv, http.MethodPut, ruleURL("orders", "urgent-only", "urgent-rule")+apiVer, ruleBody); r.StatusCode != http.StatusOK {
+		t.Fatalf("create correlation rule = %d", r.StatusCode)
+	}
+
+	send := func(body, correlationID string) {
+		t.Helper()
+
+		headers := map[string]string{}
+		if correlationID != "" {
+			headers["BrokerProperties"] = `{"CorrelationId":"` + correlationID + `"}`
+		}
+
+		if r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/orders/messages", body, headers); r.StatusCode != http.StatusCreated {
+			t.Fatalf("send %q = %d, want 201", body, r.StatusCode)
+		}
+	}
+
+	send("matches", "urgent")
+	send("no-match", "routine")
+
+	// "everything" has no filter beyond $Default: both messages arrive.
+	for _, want := range []string{"matches", "no-match"} {
+		r := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/orders/subscriptions/everything/messages/head", "")
+		if r.StatusCode != http.StatusOK {
+			t.Fatalf("everything receive = %d, want 200", r.StatusCode)
+		}
+
+		if got := readBody(t, r); got != want {
+			t.Fatalf("everything body = %q, want %q", got, want)
+		}
+	}
+
+	// "urgent-only" only receives the message whose CorrelationId matched.
+	r := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/orders/subscriptions/urgent-only/messages/head", "")
+	if r.StatusCode != http.StatusOK {
+		t.Fatalf("urgent-only receive = %d, want 200", r.StatusCode)
+	}
+
+	if got := readBody(t, r); got != "matches" {
+		t.Fatalf("urgent-only body = %q, want matches", got)
+	}
+
+	empty := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/orders/subscriptions/urgent-only/messages/head", "")
+	if empty.StatusCode != http.StatusNoContent {
+		t.Fatalf("urgent-only second receive = %d, want 204 (no-match message must not have arrived)", empty.StatusCode)
+	}
+}
+
+// TestDataPlaneSQLFilterSysProperty confirms a SqlFilter expression over a
+// sys.* system property (here sys.Label) is evaluated, not just stored.
+func TestDataPlaneSQLFilterSysProperty(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+	seedTopicSub(t, srv, "events", "errors-only")
+
+	if r := doRequest(t, srv, http.MethodDelete, ruleURL("events", "errors-only", "$Default")+apiVer, ""); r.StatusCode != http.StatusOK {
+		t.Fatalf("delete $Default rule = %d", r.StatusCode)
+	}
+
+	ruleBody := `{"properties":{"filterType":"SqlFilter","sqlFilter":{"sqlExpression":"sys.Label = 'error'"}}}`
+	if r := doRequest(t, srv, http.MethodPut, ruleURL("events", "errors-only", "label-rule")+apiVer, ruleBody); r.StatusCode != http.StatusOK {
+		t.Fatalf("create sql rule = %d", r.StatusCode)
+	}
+
+	send := func(body, label string) {
+		t.Helper()
+
+		r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/events/messages", body,
+			map[string]string{"BrokerProperties": `{"Label":"` + label + `"}`})
+		if r.StatusCode != http.StatusCreated {
+			t.Fatalf("send %q = %d, want 201", body, r.StatusCode)
+		}
+	}
+
+	send("info-msg", "info")
+	send("error-msg", "error")
+
+	r := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/events/subscriptions/errors-only/messages/head", "")
+	if r.StatusCode != http.StatusOK {
+		t.Fatalf("receive = %d, want 200", r.StatusCode)
+	}
+
+	if got := readBody(t, r); got != "error-msg" {
+		t.Fatalf("body = %q, want error-msg", got)
+	}
+
+	empty := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/events/subscriptions/errors-only/messages/head", "")
+	if empty.StatusCode != http.StatusNoContent {
+		t.Fatalf("second receive = %d, want 204 (info-msg must not have matched)", empty.StatusCode)
+	}
+}
+
+// TestQueueLockDurationHonored is the regression for LockDuration being
+// cosmetic: a queue created with a 5-second LockDuration must release a
+// peek-locked message after 5 seconds, not the driver's 30-second default.
+func TestQueueLockDurationHonored(t *testing.T) {
+	clk := config.NewFakeClock(time.Now())
+	cloud := cloudemu.NewAzure(config.WithClock(clk))
+	srv := httptest.NewServer(azureserver.New(azureserver.Drivers{ServiceBus: cloud.ServiceBus}))
+	t.Cleanup(srv.Close)
+
+	seedNamespace(t, srv)
+
+	if r := doRequest(t, srv, http.MethodPut, queueURL("short-lock")+apiVer,
+		`{"properties":{"lockDuration":"PT5S"}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create queue = %d", r.StatusCode)
+	}
+
+	if r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/short-lock/messages", "m"); r.StatusCode != http.StatusCreated {
+		t.Fatalf("send = %d", r.StatusCode)
+	}
+
+	lock := doRequest(t, srv, http.MethodPost, "/"+nsName+"/short-lock/messages/head", "")
+	if lock.StatusCode != http.StatusCreated {
+		t.Fatalf("peek-lock = %d", lock.StatusCode)
+	}
+
+	_ = readBody(t, lock)
+
+	// Still within the 5s lock: the message stays invisible.
+	stillLocked := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/short-lock/messages/head", "")
+	if stillLocked.StatusCode != http.StatusNoContent {
+		t.Fatalf("receive while locked = %d, want 204", stillLocked.StatusCode)
+	}
+
+	clk.Advance(6 * time.Second)
+
+	// Past the configured 5s LockDuration (well under the driver's 30s
+	// default), the message is visible again.
+	again := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/short-lock/messages/head", "")
+	if again.StatusCode != http.StatusOK {
+		t.Fatalf("receive after LockDuration elapses = %d, want 200", again.StatusCode)
+	}
+
+	if got := readBody(t, again); got != "m" {
+		t.Fatalf("body = %q, want m", got)
+	}
+}

--- a/server/azure/servicebus/filter.go
+++ b/server/azure/servicebus/filter.go
@@ -1,0 +1,289 @@
+package servicebus
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// messageProps is the subset of a Service Bus message's well-known system
+// properties that subscription rule filters evaluate against. These are the
+// same properties CorrelationFilter matches and the sys.* identifiers a
+// SqlFilter expression can reference:
+// https://learn.microsoft.com/azure/service-bus-messaging/topic-filters
+type messageProps struct {
+	MessageID        string
+	CorrelationID    string
+	Label            string
+	To               string
+	ReplyTo          string
+	SessionID        string
+	ReplyToSessionID string
+	ContentType      string
+}
+
+// brokerProperties is the JSON shape of the BrokerProperties request header
+// the Service Bus REST "Send Message" API accepts for a brokered message's
+// system properties (custom application properties travel as separate,
+// individually-named headers instead, and are not parsed here yet -- see the
+// DEFER note on dataPlaneTopicSend).
+// https://learn.microsoft.com/rest/api/servicebus/send-message-to-queue
+type brokerProperties struct {
+	MessageID        string `json:"MessageId,omitempty"`
+	CorrelationID    string `json:"CorrelationId,omitempty"`
+	Label            string `json:"Label,omitempty"`
+	To               string `json:"To,omitempty"`
+	ReplyTo          string `json:"ReplyTo,omitempty"`
+	SessionID        string `json:"SessionId,omitempty"`
+	ReplyToSessionID string `json:"ReplyToSessionId,omitempty"`
+	ContentType      string `json:"ContentType,omitempty"`
+}
+
+// parseBrokerProperties reads the sender-supplied BrokerProperties header off
+// a data-plane send request. A missing or malformed header yields the zero
+// value, which only ever satisfies filters that impose no constraint (the
+// default "1=1" rule, an unset CorrelationFilter field).
+func parseBrokerProperties(r *http.Request) messageProps {
+	var bp brokerProperties
+
+	if h := r.Header.Get("BrokerProperties"); h != "" {
+		_ = json.Unmarshal([]byte(h), &bp)
+	}
+
+	return messageProps(bp)
+}
+
+// rulesMatch reports whether a message matches at least one of a
+// subscription's rules. Real Service Bus combines every filter-only rule with
+// OR (https://learn.microsoft.com/azure/service-bus-messaging/topic-filters);
+// rule actions that annotate/copy the message are not applied here. A
+// subscription with no rules at all (shouldn't happen -- every subscription
+// is seeded with $Default) imposes no filter.
+func rulesMatch(rules []ruleProperties, props *messageProps) bool {
+	if len(rules) == 0 {
+		return true
+	}
+
+	for _, rule := range rules {
+		if ruleMatches(&rule, props) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func ruleMatches(rule *ruleProperties, props *messageProps) bool {
+	if rule.FilterType == filterTypeCorrelation {
+		return correlationMatches(rule.CorrelationFilter, props)
+	}
+
+	return sqlMatches(rule.SQLFilter, props)
+}
+
+// correlationMatches implements CorrelationFilter matching: every field the
+// filter sets must equal the message's corresponding property (logical AND);
+// unset fields impose no constraint. String comparison is case-sensitive, per
+// the docs. User-defined Properties are not matched -- see the DEFER note.
+func correlationMatches(f *correlationFilter, p *messageProps) bool {
+	if f == nil {
+		return true
+	}
+
+	pairs := [...][2]string{
+		{f.CorrelationID, p.CorrelationID},
+		{f.MessageID, p.MessageID},
+		{f.Label, p.Label},
+		{f.To, p.To},
+		{f.ReplyTo, p.ReplyTo},
+		{f.SessionID, p.SessionID},
+		{f.ReplyToSessionID, p.ReplyToSessionID},
+		{f.ContentType, p.ContentType},
+	}
+
+	for _, pair := range pairs {
+		want, got := pair[0], pair[1]
+		if want != "" && want != got {
+			return false
+		}
+	}
+
+	return true
+}
+
+// sqlProp looks up a message's value for a sys.* SQL filter identifier,
+// case-insensitively, reporting whether the identifier is one this evaluator
+// understands.
+func sqlProp(field string, p *messageProps) (string, bool) {
+	switch {
+	case strings.EqualFold(field, "CorrelationId"):
+		return p.CorrelationID, true
+	case strings.EqualFold(field, "MessageId"):
+		return p.MessageID, true
+	case strings.EqualFold(field, "Label"):
+		return p.Label, true
+	case strings.EqualFold(field, "To"):
+		return p.To, true
+	case strings.EqualFold(field, "ReplyTo"):
+		return p.ReplyTo, true
+	case strings.EqualFold(field, "SessionId"):
+		return p.SessionID, true
+	case strings.EqualFold(field, "ReplyToSessionId"):
+		return p.ReplyToSessionID, true
+	case strings.EqualFold(field, "ContentType"):
+		return p.ContentType, true
+	default:
+		return "", false
+	}
+}
+
+// sqlMatches evaluates a SqlFilter's expression against a message. Only a
+// "basic" grammar is supported: the boolean literals real SDKs generate for
+// TrueFilter/FalseFilter (1=1, 1=0, true, false), and an AND-joined list of
+// sys.<Field> = 'value' equality predicates over the system properties
+// sqlProp recognizes. A clause outside that grammar (arithmetic, LIKE, a
+// user-defined property) can't be evaluated without the deferred
+// custom-property-header support, so it is treated as satisfied rather than
+// silently dropping messages a real broker would deliver.
+func sqlMatches(f *sqlFilter, p *messageProps) bool {
+	if f == nil {
+		return true
+	}
+
+	return evalSQLExpression(f.SQLExpression, p)
+}
+
+func evalSQLExpression(expr string, p *messageProps) bool {
+	expr = strings.TrimSpace(expr)
+
+	switch strings.ToLower(expr) {
+	case "", "1=1", "true":
+		return true
+	case "1=0", "false":
+		return false
+	}
+
+	for _, clause := range splitSQLAnd(expr) {
+		if !evalSQLClause(clause, p) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// splitSQLAnd splits a SQL filter expression on top-level "AND" keywords.
+// It does not account for AND appearing inside a quoted string literal --
+// out of scope for the "basic predicates" this evaluator supports.
+func splitSQLAnd(expr string) []string {
+	fields := strings.Fields(expr)
+
+	var (
+		clauses []string
+		cur     []string
+	)
+
+	for _, f := range fields {
+		if strings.EqualFold(f, "AND") {
+			clauses = append(clauses, strings.Join(cur, " "))
+			cur = nil
+
+			continue
+		}
+
+		cur = append(cur, f)
+	}
+
+	clauses = append(clauses, strings.Join(cur, " "))
+
+	return clauses
+}
+
+// evalSQLClause evaluates one "sys.<Field> = 'value'" equality predicate.
+// Anything else (a user property, a non-equality operator) is unsupported and
+// treated as matching -- see evalSQLExpression.
+func evalSQLClause(clause string, p *messageProps) bool {
+	field, want, ok := parseSQLEquality(clause)
+	if !ok {
+		return true
+	}
+
+	field = strings.TrimPrefix(field, "sys.")
+
+	got, known := sqlProp(field, p)
+	if !known {
+		return true
+	}
+
+	return got == want
+}
+
+// minQuotedLiteralLen is the shortest a quoted SQL string literal can be: two
+// matching quote characters around an empty string (an empty pair of quotes).
+const minQuotedLiteralLen = 2
+
+// parseSQLEquality parses a "<field> = 'value'" or "<field> = \"value\""
+// clause, reporting ok=false for anything else.
+func parseSQLEquality(clause string) (field, value string, ok bool) {
+	idx := strings.Index(clause, "=")
+	if idx < 0 {
+		return "", "", false
+	}
+
+	field = strings.TrimSpace(clause[:idx])
+
+	raw := strings.TrimSpace(clause[idx+1:])
+	if len(raw) < minQuotedLiteralLen {
+		return "", "", false
+	}
+
+	quote := raw[0]
+	if (quote != '\'' && quote != '"') || raw[len(raw)-1] != quote {
+		return "", "", false
+	}
+
+	return field, raw[1 : len(raw)-1], true
+}
+
+// defaultLockDurationSeconds is the peek-lock visibility window a queue or
+// subscription gets when its LockDuration property is absent, matching
+// Service Bus' documented PT1M default.
+const defaultLockDurationSeconds = 60
+
+// lockDurationSeconds converts an ISO-8601 duration -- the subset Service
+// Bus' LockDuration property uses, e.g. "PT30S", "PT1M", "PT1M30S" -- to
+// whole seconds, defaulting to defaultLockDurationSeconds when s is empty or
+// not in that shape.
+func lockDurationSeconds(s string) int {
+	rest, ok := strings.CutPrefix(s, "PT")
+	if !ok {
+		return defaultLockDurationSeconds
+	}
+
+	total := 0
+
+	for _, unit := range [...]struct {
+		suffix byte
+		mult   int
+	}{{'H', 3600}, {'M', 60}, {'S', 1}} {
+		idx := strings.IndexByte(rest, unit.suffix)
+		if idx < 0 {
+			continue
+		}
+
+		n, err := strconv.Atoi(rest[:idx])
+		if err != nil {
+			return defaultLockDurationSeconds
+		}
+
+		total += n * unit.mult
+		rest = rest[idx+1:]
+	}
+
+	if total <= 0 {
+		return defaultLockDurationSeconds
+	}
+
+	return total
+}

--- a/server/azure/servicebus/pubsub_sdk_test.go
+++ b/server/azure/servicebus/pubsub_sdk_test.go
@@ -137,6 +137,63 @@ func TestSDKTopicSubscriptionRule(t *testing.T) {
 	}
 }
 
+// TestSDKCorrelationFilterRule drives a CorrelationFilter rule through the
+// real armservicebus SDK, confirming the filter fields round-trip and that
+// FilterType defaults from a set CorrelationFilter when the caller omits it.
+func TestSDKCorrelationFilterRule(t *testing.T) {
+	ts := pubsubServer(t)
+	cf := newClientFactory(t, ts)
+	ctx := context.Background()
+
+	createNS(t, cf.NewNamespacesClient(), rgName, nsName, nil)
+
+	if _, err := cf.NewTopicsClient().CreateOrUpdate(ctx, rgName, nsName, "orders",
+		armservicebus.SBTopic{}, nil); err != nil {
+		t.Fatalf("topic CreateOrUpdate: %v", err)
+	}
+
+	if _, err := cf.NewSubscriptionsClient().CreateOrUpdate(ctx, rgName, nsName, "orders", "billing",
+		armservicebus.SBSubscription{}, nil); err != nil {
+		t.Fatalf("subscription CreateOrUpdate: %v", err)
+	}
+
+	rules := cf.NewRulesClient()
+
+	made, err := rules.CreateOrUpdate(ctx, rgName, nsName, "orders", "billing", "urgent", armservicebus.Rule{
+		Properties: &armservicebus.Ruleproperties{
+			CorrelationFilter: &armservicebus.CorrelationFilter{
+				CorrelationID: to.Ptr("urgent"),
+				Label:         to.Ptr("invoice"),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("rule CreateOrUpdate: %v", err)
+	}
+
+	if made.Properties == nil || made.Properties.FilterType == nil ||
+		*made.Properties.FilterType != armservicebus.FilterTypeCorrelationFilter {
+		t.Fatalf("filterType = %v, want CorrelationFilter (defaulted)", made.Properties)
+	}
+
+	cfilter := made.Properties.CorrelationFilter
+	if cfilter == nil || cfilter.CorrelationID == nil || *cfilter.CorrelationID != "urgent" ||
+		cfilter.Label == nil || *cfilter.Label != "invoice" {
+		t.Fatalf("correlationFilter = %v, want CorrelationId=urgent Label=invoice", cfilter)
+	}
+
+	got, err := rules.Get(ctx, rgName, nsName, "orders", "billing", "urgent", nil)
+	if err != nil {
+		t.Fatalf("rule Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.CorrelationFilter == nil ||
+		got.Properties.CorrelationFilter.CorrelationID == nil ||
+		*got.Properties.CorrelationFilter.CorrelationID != "urgent" {
+		t.Fatalf("rule Get correlationFilter = %v", got.Properties)
+	}
+}
+
 // TestSDKAuthorizationRulesAndKeys covers the default RootManageSharedAccessKey,
 // listKeys, a custom rule, and regenerateKeys.
 func TestSDKAuthorizationRulesAndKeys(t *testing.T) {

--- a/server/azure/servicebus/queue.go
+++ b/server/azure/servicebus/queue.go
@@ -56,10 +56,14 @@ func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request, sp sbPath,
 	}
 
 	now := time.Now().UTC()
+	lockSeconds := lockDurationSeconds(req.Properties.LockDuration)
 
 	rec, existed := ns.Queues[name]
 	if !existed {
-		info, err := h.mq.CreateQueue(r.Context(), mqdriver.QueueConfig{Name: sp.namespace + "/" + name})
+		info, err := h.mq.CreateQueue(r.Context(), mqdriver.QueueConfig{
+			Name:              sp.namespace + "/" + name,
+			VisibilityTimeout: lockSeconds,
+		})
 		if err != nil && !cerrors.IsAlreadyExists(err) {
 			h.mu.Unlock()
 			azurearm.WriteCErr(w, err)
@@ -74,6 +78,10 @@ func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request, sp sbPath,
 
 		rec = &queueRecord{Name: name, DriverURL: url, CreatedAt: now}
 		ns.Queues[name] = rec
+	} else if rec.DriverURL != "" {
+		// PUT is create-or-update: honor a LockDuration change on an existing
+		// queue's peek-lock visibility window too.
+		_ = h.mq.SetQueueAttributes(r.Context(), rec.DriverURL, map[string]int{"VisibilityTimeout": lockSeconds})
 	}
 
 	rec.Props = buildQueueProps(&req.Properties, rec.CreatedAt, now)

--- a/server/azure/servicebus/servicebus_test.go
+++ b/server/azure/servicebus/servicebus_test.go
@@ -213,7 +213,10 @@ func TestDataPlaneSendToMissingQueue(t *testing.T) {
 
 // helpers --------------------------------------------------------------------
 
-func doRequest(t *testing.T, srv *httptest.Server, method, path, body string) *http.Response {
+// doRequest issues a raw HTTP request against the test server. Trailing
+// headers maps, if any, are merged onto the request (e.g. a data-plane send's
+// BrokerProperties header).
+func doRequest(t *testing.T, srv *httptest.Server, method, path, body string, headers ...map[string]string) *http.Response {
 	t.Helper()
 
 	var rdr io.Reader
@@ -224,6 +227,12 @@ func doRequest(t *testing.T, srv *httptest.Server, method, path, body string) *h
 	req, _ := http.NewRequestWithContext(context.Background(), method, srv.URL+path, rdr)
 	if body != "" {
 		req.Header.Set("Content-Type", "application/json")
+	}
+
+	for _, hs := range headers {
+		for k, v := range hs {
+			req.Header.Set(k, v)
+		}
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/server/azure/servicebus/subscription.go
+++ b/server/azure/servicebus/subscription.go
@@ -67,10 +67,11 @@ func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, sp 
 	}
 
 	now := time.Now().UTC()
+	lockSeconds := lockDurationSeconds(req.Properties.LockDuration)
 
 	rec, existed := t.Subs[name]
 	if !existed {
-		url, err := h.createSubQueue(r, sp.namespace, topic, name)
+		url, err := h.createSubQueue(r, sp.namespace, topic, name, lockSeconds)
 		if err != nil {
 			h.mu.Unlock()
 			azurearm.WriteCErr(w, err)
@@ -81,6 +82,10 @@ func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, sp 
 		rec = &subscriptionRecord{Name: name, DriverURL: url, Rules: map[string]*ruleRecord{}, CreatedAt: now}
 		rec.Rules[defaultRuleName] = defaultRule()
 		t.Subs[name] = rec
+	} else if rec.DriverURL != "" {
+		// PUT is create-or-update: honor a LockDuration change on an existing
+		// subscription's peek-lock visibility window too.
+		_ = h.mq.SetQueueAttributes(r.Context(), rec.DriverURL, map[string]int{"VisibilityTimeout": lockSeconds})
 	}
 
 	rec.Props = buildSubProps(&req.Properties, rec.CreatedAt, now)
@@ -133,11 +138,12 @@ func (h *Handler) deleteSubscription(w http.ResponseWriter, sp sbPath, topic, na
 	w.WriteHeader(http.StatusOK)
 }
 
-// createSubQueue provisions the backing message store for a new subscription.
-func (h *Handler) createSubQueue(r *http.Request, namespace, topic, sub string) (string, error) {
+// createSubQueue provisions the backing message store for a new subscription,
+// honoring its configured LockDuration for peek-lock visibility.
+func (h *Handler) createSubQueue(r *http.Request, namespace, topic, sub string, lockSeconds int) (string, error) {
 	name := namespace + "/" + topic + "/" + segSubs + "/" + sub
 
-	info, err := h.mq.CreateQueue(r.Context(), mqdriver.QueueConfig{Name: name})
+	info, err := h.mq.CreateQueue(r.Context(), mqdriver.QueueConfig{Name: name, VisibilityTimeout: lockSeconds})
 	if err != nil && !cerrors.IsAlreadyExists(err) {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
- Subscription rules (SqlFilter, CorrelationFilter) were stored but never evaluated — every subscription received every message published to a topic regardless of its filters. `dataPlaneTopicSend` now parses the sender's `BrokerProperties` header (the REST data plane's system-property carrier: CorrelationId, MessageId, Label, To, ReplyTo, SessionId, ReplyToSessionId, ContentType) and only fans a message out to subscriptions whose rules match, combining each subscription's filter-only rules with OR as real Service Bus does.
- SqlFilter support covers the boolean literals real SDKs generate for TrueFilter/FalseFilter (`1=1`, `1=0`, `true`, `false`) plus AND-joined `sys.<Field> = 'value'` equality predicates over the system properties above.
- CorrelationFilter matches every field it sets against the message's corresponding property (logical AND), case-sensitive, per docs.
- `LockDuration` was cosmetic: queue and subscription peek-lock visibility always used the driver's 30s default regardless of the configured value. `createQueue`/`createSubscription` now convert `LockDuration` (ISO-8601, e.g. `PT30S`, `PT1M`) to seconds and pass it through to the backing queue on both create and update.

Deferred (not implemented, noted in code comments): the Renew-Lock endpoint, and full custom application-property header support (arbitrary user-defined properties beyond the well-known system properties above) — so a filter predicate over a user-defined property can't yet disqualify a subscription.

Reproduced against the documented wire behavior:
- https://learn.microsoft.com/rest/api/servicebus/send-message-to-queue (BrokerProperties header shape)
- https://learn.microsoft.com/azure/service-bus-messaging/topic-filters (SqlFilter/CorrelationFilter semantics, OR-across-rules)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./server/azure/servicebus/...`
- [x] `go test ./server/azure/servicebus/... ./providers/azure/servicebus/...`
- [x] `go test -race ./server/azure/servicebus/... ./providers/azure/servicebus/...`
- [x] `golangci-lint run ./server/azure/servicebus/... ./providers/azure/servicebus/...` — 0 new issues
- [x] `gofmt -l` clean
- [x] New regression tests: `TestDataPlaneCorrelationFilterRoutesOnlyMatchingMessages`, `TestDataPlaneSQLFilterSysProperty`, `TestQueueLockDurationHonored` (raw-HTTP wire reproduction), `TestSDKCorrelationFilterRule` (real `armservicebus` SDK round-trip)