### PR TITLE
chore(tooling): flag dead wire handlers in coveragegen; advisory same-filename CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,41 @@ jobs:
             exit 1
           fi
           echo "structure: no cloud-prefixed provider/wire directories — OK"
+      - name: same filename across layers (docs/STRUCTURE.md §3, advisory)
+        run: |
+          # STRUCTURE.md §3: a feature uses the same filename across the
+          # provider and wire layers, so one filename finds both the mock and
+          # the wire handler. Checked loosely — anywhere under server/<cloud>/,
+          # not necessarily the same <service> subdir, since a sub-surface can
+          # legitimately live under a differently-named service on each side
+          # (e.g. providers/aws/vpc/traffic_mirror.go /
+          # server/aws/ec2/traffic_mirror.go). Exempts each service's own
+          # core-CRUD file plus clone.go/tags.go — the per-directory template
+          # (§4) documents these as provider-only. Advisory: real pre-existing
+          # drift (renamed files, provider-only helpers) means this warns
+          # rather than fails a build.
+          missing=0
+          for cloud in aws azure gcp; do
+            provdir="providers/$cloud"
+            srvdir="server/$cloud"
+            [ -d "$provdir" ] || continue
+            [ -d "$srvdir" ] || continue
+            for f in $(find "$provdir" -mindepth 2 -name '*.go' ! -name '*_test.go' ! -path '*/driver/*'); do
+              base=$(basename "$f")
+              svc=$(basename "$(dirname "$f")")
+              case "$base" in
+                "$svc.go"|clone.go|tags.go) continue ;;
+              esac
+              if ! find "$srvdir" -name "$base" ! -name '*_test.go' | grep -q .; then
+                echo "structure: $f has no same-named file anywhere under $srvdir/ (docs/STRUCTURE.md §3)"
+                missing=$((missing + 1))
+              fi
+            done
+          done
+          echo "structure: $missing provider file(s) with no same-named wire-layer file"
+          if [ "$missing" -gt 0 ]; then
+            echo "::warning::$missing provider file(s) lack a same-named file under server/<cloud>/ (docs/STRUCTURE.md §3, advisory)"
+          fi
 
   format:
     name: Format

--- a/internal/coveragegen/coveragegen_test.go
+++ b/internal/coveragegen/coveragegen_test.go
@@ -162,6 +162,31 @@ func constructed(provider any) map[string]bool {
 	return out
 }
 
+// TestNoDeadWireHandlers guards against a service the provider factory fully
+// implements (driver + a populated Provider field, i.e. Service.Providers is
+// set) but that server/<cloud>/<cloud>.go never wires up: a Drivers field
+// backing it is either absent or declared-but-unread in New(). Such a service
+// is reachable through the Go library and the in-process SDK-compat server,
+// but never through the standalone wire-protocol server for that cloud — a
+// silent capability gap.
+func TestNoDeadWireHandlers(t *testing.T) {
+	services := loadServices(t)
+
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("repoRoot: %v", err)
+	}
+
+	warnings, err := checkRegistrations(root, sortedServices(services))
+	if err != nil {
+		t.Fatalf("checkRegistrations: %v", err)
+	}
+
+	for _, w := range warnings {
+		t.Error(w)
+	}
+}
+
 // TestFullyImplementedProvidersHaveServices makes sure the constructed-field
 // gate did not over-filter AWS/Azure/GCP down to nothing.
 func TestFullyImplementedProvidersHaveServices(t *testing.T) {

--- a/internal/coveragegen/main.go
+++ b/internal/coveragegen/main.go
@@ -78,6 +78,15 @@ func run() error {
 
 	fmt.Printf("coveragegen: wrote coverage for %d services\n", len(ordered))
 
+	warnings, checkErr := checkRegistrations(root, ordered)
+	if checkErr != nil {
+		return checkErr
+	}
+
+	for _, w := range warnings {
+		fmt.Fprintln(os.Stderr, w)
+	}
+
 	return nil
 }
 

--- a/internal/coveragegen/providers.go
+++ b/internal/coveragegen/providers.go
@@ -159,11 +159,20 @@ type structField struct {
 // a pointer to another package's type (`*pkg.Mock`), carrying the field name and
 // that package's local alias.
 func providerFields(file *ast.File) []structField {
+	return structFields(file, providerStructName)
+}
+
+// structFields returns the named fields of the top-level struct type typeName
+// whose type is a package-selector expression (`pkg.Type` or `*pkg.Type`),
+// carrying the field name and that package's local alias. Shared by
+// providerFields (typeName "Provider") and the registration cross-check
+// (typeName "Drivers").
+func structFields(file *ast.File, typeName string) []structField {
 	var out []structField
 
 	ast.Inspect(file, func(n ast.Node) bool {
 		ts, ok := n.(*ast.TypeSpec)
-		if !ok || ts.Name.Name != providerStructName {
+		if !ok || ts.Name.Name != typeName {
 			return true
 		}
 

--- a/internal/coveragegen/registration.go
+++ b/internal/coveragegen/registration.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+)
+
+// driversStructName is the driver-bundle struct every server/<cloud>/<cloud>.go
+// declares and passes to New.
+const driversStructName = "Drivers"
+
+// checkRegistrations cross-references, for every provider, the services its
+// Provider factory actually implements (Service.Providers, populated by
+// attachProviders) against the driver-typed fields server/<cloud>/<cloud>.go's
+// Drivers struct declares AND reads inside New() — i.e. actually wires to a
+// registered handler.
+//
+// A service with a driver interface and a populated provider field but no
+// such field is a dead/absent wire handler: the backend implements the
+// service in full, but no protocol on that cloud's wire server can ever reach
+// it. This never fails the generator run; it returns human-readable warnings
+// for the caller to surface.
+func checkRegistrations(root string, services []*Service) ([]string, error) {
+	var warnings []string
+
+	for _, prov := range providerOrder {
+		registered, err := registeredServices(root, prov)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, svc := range services {
+			native := svc.Providers[prov]
+			if native == "" {
+				continue
+			}
+
+			if !registered[svc.Name] {
+				warnings = append(warnings, fmt.Sprintf(
+					"coveragegen: %s implements service %q (as %s.%s) but server/%s/%s.go registers no wire handler for it",
+					prov, svc.Name, prov, native, prov, prov))
+			}
+		}
+	}
+
+	return warnings, nil
+}
+
+// registeredServices returns the services a provider's wire server actually
+// registers a handler for: the set of services backing a Drivers struct field
+// that New() reads from its Drivers parameter.
+func registeredServices(root, prov string) (map[string]bool, error) {
+	factory := filepath.Join(root, "server", prov, prov+".go")
+
+	fset := token.NewFileSet()
+
+	file, err := parser.ParseFile(fset, factory, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	aliases := importAliases(file)
+	used := usedDriversFields(file)
+
+	out := map[string]bool{}
+
+	for _, field := range structFields(file, driversStructName) {
+		if !used[field.name] {
+			continue
+		}
+
+		pkgPath, ok := aliases[field.pkgAlias]
+		if !ok {
+			continue
+		}
+
+		if svcName, ok := driverServiceName(pkgPath); ok {
+			out[svcName] = true
+		}
+	}
+
+	return out, nil
+}
+
+// usedDriversFields returns the field names referenced as `<param>.Field`
+// anywhere in New's body, where <param> is New's by-value Drivers parameter.
+// A field only declared on Drivers but never read in New backs no handler.
+func usedDriversFields(file *ast.File) map[string]bool {
+	out := map[string]bool{}
+
+	fn := findFunc(file, "New")
+	if fn == nil || fn.Body == nil {
+		return out
+	}
+
+	param := driversParamName(fn)
+	if param == "" {
+		return out
+	}
+
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		if id, isIdent := sel.X.(*ast.Ident); isIdent && id.Name == param {
+			out[sel.Sel.Name] = true
+		}
+
+		return true
+	})
+
+	return out
+}
+
+// findFunc returns the top-level, non-method function declaration named
+// name, or nil.
+func findFunc(file *ast.File, name string) *ast.FuncDecl {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Recv == nil && fn.Name.Name == name {
+			return fn
+		}
+	}
+
+	return nil
+}
+
+// driversParamName returns the name of fn's by-value `Drivers` parameter, or
+// "" if it has none.
+func driversParamName(fn *ast.FuncDecl) string {
+	if fn.Type.Params == nil {
+		return ""
+	}
+
+	for _, field := range fn.Type.Params.List {
+		id, ok := field.Type.(*ast.Ident)
+		if !ok || id.Name != driversStructName || len(field.Names) == 0 {
+			continue
+		}
+
+		return field.Names[0].Name
+	}
+
+	return ""
+}


### PR DESCRIPTION
## Summary

Architecture Theme 2, steps 3-4 (#590) — tooling only, no behavior change.

**coveragegen (step 3):** cross-references each service discovered under `services/<x>/driver` against the `Drivers` struct in `server/<cloud>/<cloud>.go`. For every service a provider factory fully implements (`Service.Providers[cloud]` set, i.e. driver + a populated `Provider` field), it checks whether `New()` actually reads a corresponding `Drivers` field. A service with an implementation but no reachable wire handler is flagged as a warning (printed by `go run ./internal/coveragegen`, and asserted empty by a new `TestNoDeadWireHandlers`). Currently zero findings on the real tree.

**CI Structure job (step 4):** adds a second, advisory step implementing STRUCTURE.md §3 (same filename across layers): for each `providers/<cloud>/<svc>/<feature>.go`, checks that a same-named file exists somewhere under `server/<cloud>/` (loosely — not necessarily the same `<svc>` subdir, since a sub-surface can legitimately live under a different service name on each side, e.g. `providers/aws/vpc/traffic_mirror.go` / `server/aws/ec2/traffic_mirror.go`). Exempts each service's own core-CRUD file plus `clone.go`/`tags.go` per the §4 per-directory template. Real pre-existing drift (184 files) means this is `::warning::`-only, not blocking.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/coveragegen/...` (new `TestNoDeadWireHandlers` passes, 0 findings)
- [x] `golangci-lint run ./internal/coveragegen/...` — 0 issues
- [x] `gofmt -l` clean
- [x] `go run ./internal/coveragegen` regenerates `docs/coverage/` with no diff
- [x] Extracted and ran both Structure-job shell steps locally against the repo tree; both exit 0 (second step logs 184 advisory warnings, no failure)