### PR TITLE
fix(azure): model VM managed identity; RoleDefinitions List scope-and-above

### DIFF
--- a/features/chaos/wrappers_test.go
+++ b/features/chaos/wrappers_test.go
@@ -10,6 +10,7 @@ import (
 	awsdynamo "github.com/stackshy/cloudemu/v2/providers/aws/dynamodb"
 	awsec2 "github.com/stackshy/cloudemu/v2/providers/aws/ec2"
 	awss3 "github.com/stackshy/cloudemu/v2/providers/aws/s3"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
 )
@@ -430,6 +431,7 @@ type computeConfigCompat = struct {
 	ClientToken            string
 	IamInstanceProfileARN  string
 	IamInstanceProfileName string
+	Identity               *computedriver.ManagedIdentity
 }
 
 // computeInstanceConfig reproduces the helper used elsewhere in the package

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -11,6 +11,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -42,6 +43,12 @@ const (
 	ipSegmentSize  = 256
 	stateAvailable = "available"
 	stateInUse     = "in-use"
+	// identityTypeNone mirrors the ARM ResourceIdentityType "None" value: no
+	// managed identity attached.
+	identityTypeNone = "None"
+	// emulatorTenantID is the single Azure AD directory all emulated
+	// resources belong to.
+	emulatorTenantID = "11111111-1111-1111-1111-111111111111"
 )
 
 type lifecycleTransition struct {
@@ -145,6 +152,9 @@ type instanceData struct {
 	// Generalized is true once the VM has been generalized (Azure Generalize
 	// action), a precondition for capturing it into a reusable image.
 	Generalized bool
+	// Identity is the resolved managed-identity block, nil when no identity
+	// is attached.
+	Identity *driver.ManagedIdentity
 	// engineBacked is true when a real config.ComputeEngine backs this
 	// instance, so Terminate deprovisions it and console output is read from
 	// the engine rather than synthesized.
@@ -306,7 +316,60 @@ func toInstance(d *instanceData) driver.Instance {
 		Region: d.Region, ResourceGroup: d.ResourceGroup,
 		PowerState:  d.PowerState,
 		Generalized: d.Generalized,
+		Identity:    copyIdentity(d.Identity),
 	}
+}
+
+// copyIdentity deep-copies a ManagedIdentity so a caller holding the returned
+// driver.Instance cannot mutate the stored instanceData through it.
+func copyIdentity(in *driver.ManagedIdentity) *driver.ManagedIdentity {
+	if in == nil {
+		return nil
+	}
+
+	out := *in
+
+	if len(in.UserAssigned) > 0 {
+		out.UserAssigned = make(map[string]driver.UserAssignedIdentity, len(in.UserAssigned))
+		for k, v := range in.UserAssigned {
+			out.UserAssigned[k] = v
+		}
+	}
+
+	return &out
+}
+
+// resolveIdentity normalizes a caller-supplied managed identity: for a
+// system-assigned identity it synthesizes a deterministic principal/tenant
+// GUID pair (as Azure does on assignment), and for each user-assigned
+// identity it synthesizes a deterministic principal/client GUID pair, keyed
+// by the seed (the owning instance's id) so the same instance always reports
+// the same identity across GET/List. A nil or "None" identity resolves to
+// nil (no identity attached).
+func resolveIdentity(in *driver.ManagedIdentity, seed string) *driver.ManagedIdentity {
+	if in == nil || in.Type == "" || strings.EqualFold(in.Type, identityTypeNone) {
+		return nil
+	}
+
+	out := &driver.ManagedIdentity{Type: in.Type}
+
+	if strings.Contains(strings.ToLower(in.Type), "systemassigned") {
+		out.PrincipalID = idgen.SyntheticGUID("principal/vm/" + seed)
+		out.TenantID = emulatorTenantID
+	}
+
+	if len(in.UserAssigned) > 0 {
+		out.UserAssigned = make(map[string]driver.UserAssignedIdentity, len(in.UserAssigned))
+
+		for id := range in.UserAssigned {
+			out.UserAssigned[id] = driver.UserAssignedIdentity{
+				PrincipalID: idgen.SyntheticGUID("principal/uai/" + id),
+				ClientID:    idgen.SyntheticGUID("client/uai/" + id),
+			}
+		}
+	}
+
+	return out
 }
 
 // RunInstances creates and starts the specified number of virtual machine instances.
@@ -358,6 +421,8 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 			ResourceGroup: cfg.ResourceGroup,
 			PowerState:    powerStateRunning,
 		}
+
+		inst.Identity = resolveIdentity(cfg.Identity, id)
 
 		// Back the instance with a real compute engine when one is configured.
 		// The engine runs the decoded customData as the boot script and may
@@ -490,39 +555,49 @@ func (m *Mock) Deallocate(ctx context.Context, instanceID string) error {
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) UpdateInstance(_ context.Context, instanceID string, cfg driver.InstanceConfig) error {
-	inst, ok := m.instances.Get(instanceID)
+	ok := m.instances.Update(instanceID, func(inst *instanceData) *instanceData {
+		if cfg.InstanceType != "" {
+			inst.InstanceType = cfg.InstanceType
+		}
+
+		if cfg.ImageID != "" {
+			inst.ImageID = cfg.ImageID
+		}
+
+		if cfg.SubnetID != "" {
+			inst.SubnetID = cfg.SubnetID
+		}
+
+		if cfg.OSType != "" {
+			inst.OSType = cfg.OSType
+		}
+
+		inst.Priority = cfg.Priority
+		inst.LicenseType = cfg.LicenseType
+
+		if len(cfg.Zones) > 0 {
+			inst.Zones = append([]string(nil), cfg.Zones...)
+		}
+
+		if cfg.Region != "" {
+			inst.Region = cfg.Region
+		}
+
+		inst.Tags = copyTags(cfg.Tags)
+
+		// A nil cfg.Identity means the request omitted the identity block
+		// entirely (real Azure preserves the existing identity in that case);
+		// a non-nil one (including an explicit "None") replaces it.
+		if cfg.Identity != nil {
+			inst.Identity = resolveIdentity(cfg.Identity, instanceID)
+		}
+
+		return inst
+	})
+
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
 	}
-
-	if cfg.InstanceType != "" {
-		inst.InstanceType = cfg.InstanceType
-	}
-
-	if cfg.ImageID != "" {
-		inst.ImageID = cfg.ImageID
-	}
-
-	if cfg.SubnetID != "" {
-		inst.SubnetID = cfg.SubnetID
-	}
-
-	if cfg.OSType != "" {
-		inst.OSType = cfg.OSType
-	}
-
-	inst.Priority = cfg.Priority
-	inst.LicenseType = cfg.LicenseType
-
-	if len(cfg.Zones) > 0 {
-		inst.Zones = append([]string(nil), cfg.Zones...)
-	}
-
-	if cfg.Region != "" {
-		inst.Region = cfg.Region
-	}
-
-	inst.Tags = copyTags(cfg.Tags)
 
 	return nil
 }

--- a/server/azure/iam/operations.go
+++ b/server/azure/iam/operations.go
@@ -449,9 +449,12 @@ func decodeRoleProperties(doc string) (roleDefinitionProperties, error) {
 
 // scopeMatches returns true when a stored role's scope is acceptable for a
 // query scope. Empty query returns everything (azure SDK calls this with no
-// scope for "list all in subscription"). Exact-match or ancestor prefix is
-// allowed; we err on the permissive side rather than mirror Azure's exact
-// inheritance semantics, which the SDK doesn't enforce client-side.
+// scope for "list all in subscription"). Real Azure's RoleDefinitions List
+// returns definitions "applicable at scope and above" (MS Learn:
+// rest/api/authorization/role-definitions/list) — the query scope itself or
+// one of its ancestors (management group / subscription / resource group)
+// — never a definition scoped only to a descendant resource; that requires
+// the separate atScopeAndBelow $filter, which we don't model.
 func scopeMatches(query, stored string) bool {
 	if query == "" || query == "/" {
 		return true
@@ -461,11 +464,7 @@ func scopeMatches(query, stored string) bool {
 		return true
 	}
 
-	if strings.HasPrefix(query, stored+"/") {
-		return true
-	}
-
-	return strings.HasPrefix(stored, query+"/")
+	return strings.HasPrefix(query, stored+"/")
 }
 
 func decodeJSONBody(w http.ResponseWriter, r *http.Request, v any) bool {

--- a/server/azure/iam/sdk_roundtrip_test.go
+++ b/server/azure/iam/sdk_roundtrip_test.go
@@ -227,6 +227,94 @@ func TestSDKAzureIAMRoleAssignmentLifecycle(t *testing.T) {
 	}
 }
 
+// TestSDKAzureIAMRoleDefinitionListScopeAndAbove verifies real Azure's
+// documented RoleDefinitions List semantics (MS Learn:
+// rest/api/authorization/role-definitions/list — "Get all role definitions
+// that are applicable at scope and above"): a list at a scope returns role
+// definitions scoped to that scope and its ancestors, never one scoped only
+// to a descendant resource beneath it.
+func TestSDKAzureIAMRoleDefinitionListScopeAndAbove(t *testing.T) {
+	roleDefs, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	const (
+		subRoleID = "11111111-aaaa-aaaa-aaaa-111111111111"
+		rgRoleID  = "22222222-bbbb-bbbb-bbbb-222222222222"
+		vmRoleID  = "33333333-cccc-cccc-cccc-333333333333"
+	)
+
+	rgScope := testScope + "/resourceGroups/rg1"
+	vmScope := rgScope + "/providers/Microsoft.Compute/virtualMachines/vm1"
+
+	mustCreateRole(t, roleDefs, ctx, testScope, subRoleID, "Sub Role")
+	mustCreateRole(t, roleDefs, ctx, rgScope, rgRoleID, "RG Role")
+	mustCreateRole(t, roleDefs, ctx, vmScope, vmRoleID, "VM Role")
+
+	// Listing at the subscription scope must return only the subscription-
+	// scoped role — the RG- and VM-scoped roles are descendants, not
+	// ancestors, of the subscription.
+	names := listRoleNames(t, roleDefs, testScope)
+	if !names[subRoleID] {
+		t.Fatalf("list at subscription scope missing sub-scoped role: %v", names)
+	}
+	if names[rgRoleID] || names[vmRoleID] {
+		t.Fatalf("list at subscription scope leaked a descendant-scoped role: %v", names)
+	}
+
+	// Listing at the resource-group scope must return the RG-scoped role and
+	// its subscription ancestor, but not the VM-scoped descendant.
+	names = listRoleNames(t, roleDefs, rgScope)
+	if !names[subRoleID] || !names[rgRoleID] {
+		t.Fatalf("list at RG scope missing scope-and-above roles: %v", names)
+	}
+	if names[vmRoleID] {
+		t.Fatalf("list at RG scope leaked the VM-scoped descendant role: %v", names)
+	}
+
+	// Listing at the VM scope must return all three: itself and both ancestors.
+	names = listRoleNames(t, roleDefs, vmScope)
+	if !names[subRoleID] || !names[rgRoleID] || !names[vmRoleID] {
+		t.Fatalf("list at VM scope missing scope-and-above roles: %v", names)
+	}
+}
+
+func mustCreateRole(
+	t *testing.T, roleDefs *armauthorization.RoleDefinitionsClient, ctx context.Context, scope, id, name string,
+) {
+	t.Helper()
+
+	if _, err := roleDefs.CreateOrUpdate(ctx, scope, id, armauthorization.RoleDefinition{
+		Properties: &armauthorization.RoleDefinitionProperties{
+			RoleName:         to.Ptr(name),
+			RoleType:         to.Ptr("CustomRole"),
+			AssignableScopes: []*string{to.Ptr(scope)},
+		},
+	}, nil); err != nil {
+		t.Fatalf("CreateOrUpdate role definition %s at scope %s: %v", id, scope, err)
+	}
+}
+
+func listRoleNames(t *testing.T, roleDefs *armauthorization.RoleDefinitionsClient, scope string) map[string]bool {
+	t.Helper()
+
+	ctx := context.Background()
+	pager := roleDefs.NewListPager(scope, nil)
+	out := make(map[string]bool)
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListPager.NextPage at scope %s: %v", scope, err)
+		}
+
+		for _, rd := range page.Value {
+			out[getStringPtr(rd.Name)] = true
+		}
+	}
+
+	return out
+}
+
 func getStringPtr(p *string) string {
 	if p == nil {
 		return ""

--- a/server/azure/virtualmachines/identity_test.go
+++ b/server/azure/virtualmachines/identity_test.go
@@ -1,0 +1,242 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKVMIdentitySystemAssigned verifies a real armcompute client sees a
+// system-assigned identity attached at create time: a PUT VM with
+// identity.type=SystemAssigned is accepted (already true before this fix),
+// and — the bug — a subsequent GET must actually echo it back, with a
+// synthesized principalId/tenantId, rather than losing the identity block
+// entirely.
+func TestSDKVMIdentitySystemAssigned(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSDKClient(t, ts)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "identity-vm", armcompute.VirtualMachine{
+		Location: to.Ptr("eastus"),
+		Identity: &armcompute.VirtualMachineIdentity{
+			Type: to.Ptr(armcompute.ResourceIdentityTypeSystemAssigned),
+		},
+		Properties: minimalVMProperties(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := pollUntilDone(ctx, poller)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate poll: %v", err)
+	}
+
+	assertSystemAssignedIdentity(t, "create response", created.Identity)
+
+	got, err := client.Get(ctx, "rg-1", "identity-vm", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	assertSystemAssignedIdentity(t, "GET", got.Identity)
+
+	// The identity must also be stable across a second create (idempotent PUT).
+	poller2, err := client.BeginCreateOrUpdate(ctx, "rg-1", "identity-vm", armcompute.VirtualMachine{
+		Location: to.Ptr("eastus"),
+		Identity: &armcompute.VirtualMachineIdentity{
+			Type: to.Ptr(armcompute.ResourceIdentityTypeSystemAssigned),
+		},
+		Properties: minimalVMProperties(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate (idempotent PUT): %v", err)
+	}
+
+	updated, err := pollUntilDone(ctx, poller2)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate (idempotent PUT) poll: %v", err)
+	}
+
+	if updated.Identity == nil || got.Identity == nil ||
+		*updated.Identity.PrincipalID != *got.Identity.PrincipalID {
+		t.Errorf("principalId changed across idempotent PUT: got %v, want stable %v",
+			updated.Identity, got.Identity)
+	}
+
+	// Listing at the resource group must also echo the identity.
+	pager := client.NewListPager("rg-1", nil)
+
+	var listed *armcompute.VirtualMachine
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		for _, vm := range page.Value {
+			if vm.Name != nil && *vm.Name == "identity-vm" {
+				listed = vm
+			}
+		}
+	}
+
+	if listed == nil {
+		t.Fatal("List did not return identity-vm")
+	}
+
+	assertSystemAssignedIdentity(t, "List", listed.Identity)
+}
+
+// TestSDKVMIdentityUserAssigned verifies a VM created with a user-assigned
+// identity gets the userAssignedIdentities map echoed back on GET, with a
+// synthesized principalId/clientId per entry — the identity type mixes with
+// SystemAssigned too.
+func TestSDKVMIdentityUserAssigned(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSDKClient(t, ts)
+	ctx := context.Background()
+
+	const uaiID = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.ManagedIdentity/" +
+		"userAssignedIdentities/my-identity"
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "uai-vm", armcompute.VirtualMachine{
+		Location: to.Ptr("eastus"),
+		Identity: &armcompute.VirtualMachineIdentity{
+			Type: to.Ptr(armcompute.ResourceIdentityTypeSystemAssignedUserAssigned),
+			UserAssignedIdentities: map[string]*armcompute.UserAssignedIdentitiesValue{
+				uaiID: {},
+			},
+		},
+		Properties: minimalVMProperties(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := pollUntilDone(ctx, poller); err != nil {
+		t.Fatalf("CreateOrUpdate poll: %v", err)
+	}
+
+	got, err := client.Get(ctx, "rg-1", "uai-vm", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Identity == nil {
+		t.Fatal("Get: identity is nil, want SystemAssigned,UserAssigned block")
+	}
+
+	if got.Identity.PrincipalID == nil || *got.Identity.PrincipalID == "" {
+		t.Error("Get: system-assigned principalId not synthesized")
+	}
+
+	if got.Identity.TenantID == nil || *got.Identity.TenantID == "" {
+		t.Error("Get: system-assigned tenantId not synthesized")
+	}
+
+	uai, ok := got.Identity.UserAssignedIdentities[uaiID]
+	if !ok || uai == nil {
+		t.Fatalf("Get: userAssignedIdentities missing entry %q: %v", uaiID, got.Identity.UserAssignedIdentities)
+	}
+
+	if uai.PrincipalID == nil || *uai.PrincipalID == "" {
+		t.Error("Get: user-assigned identity principalId not synthesized")
+	}
+
+	if uai.ClientID == nil || *uai.ClientID == "" {
+		t.Error("Get: user-assigned identity clientId not synthesized")
+	}
+}
+
+// TestSDKVMIdentityOmittedOnCreate verifies a VM created with no identity
+// block at all reports no identity on GET (the pre-fix baseline behavior),
+// rather than a spuriously populated one.
+func TestSDKVMIdentityOmittedOnCreate(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSDKClient(t, ts)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "no-identity-vm", armcompute.VirtualMachine{
+		Location:   to.Ptr("eastus"),
+		Properties: minimalVMProperties(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := pollUntilDone(ctx, poller); err != nil {
+		t.Fatalf("CreateOrUpdate poll: %v", err)
+	}
+
+	got, err := client.Get(ctx, "rg-1", "no-identity-vm", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Identity != nil {
+		t.Errorf("Get: identity=%+v, want nil for a VM created without one", got.Identity)
+	}
+}
+
+func assertSystemAssignedIdentity(t *testing.T, step string, id *armcompute.VirtualMachineIdentity) {
+	t.Helper()
+
+	if id == nil {
+		t.Fatalf("%s: identity is nil, want SystemAssigned block", step)
+	}
+
+	if id.Type == nil || *id.Type != armcompute.ResourceIdentityTypeSystemAssigned {
+		t.Errorf("%s: identity.type=%v, want SystemAssigned", step, id.Type)
+	}
+
+	if id.PrincipalID == nil || *id.PrincipalID == "" {
+		t.Errorf("%s: principalId not synthesized", step)
+	}
+
+	if id.TenantID == nil || *id.TenantID == "" {
+		t.Errorf("%s: tenantId not synthesized", step)
+	}
+}
+
+func minimalVMProperties() *armcompute.VirtualMachineProperties {
+	return &armcompute.VirtualMachineProperties{
+		HardwareProfile: &armcompute.HardwareProfile{
+			VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+		},
+		StorageProfile: &armcompute.StorageProfile{
+			ImageReference: &armcompute.ImageReference{
+				Publisher: to.Ptr("Canonical"),
+				Offer:     to.Ptr("UbuntuServer"),
+				SKU:       to.Ptr("22.04-LTS"),
+				Version:   to.Ptr("latest"),
+			},
+		},
+		OSProfile: &armcompute.OSProfile{
+			ComputerName:  to.Ptr("identity-vm"),
+			AdminUsername: to.Ptr("azureuser"),
+		},
+	}
+}

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -97,6 +97,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		Zones:         req.Zones,
 		Region:        req.Location,
 		ResourceGroup: rp.ResourceGroup,
+		Identity:      toDriverIdentity(req.Identity),
 	}
 
 	// ARM CreateOrUpdate is idempotent: a repeated PUT to the same {rg,name}
@@ -896,6 +897,50 @@ func decodeCustomData(s string) string {
 	return s
 }
 
+// toDriverIdentity maps an inbound ARM identity block onto the driver shape.
+// Only Type and the UserAssignedIdentities keys (the identity resource IDs to
+// attach) are meaningful on input; principalId/tenantId/clientId are
+// read-only and decoded but discarded. Returns nil when the request did not
+// include an identity block at all (the caller then leaves any existing
+// identity untouched).
+func toDriverIdentity(in *identity) *computedriver.ManagedIdentity {
+	if in == nil {
+		return nil
+	}
+
+	out := &computedriver.ManagedIdentity{Type: in.Type}
+
+	if len(in.UserAssignedIdentities) > 0 {
+		out.UserAssigned = make(map[string]computedriver.UserAssignedIdentity, len(in.UserAssignedIdentities))
+		for id := range in.UserAssignedIdentities {
+			out.UserAssigned[id] = computedriver.UserAssignedIdentity{}
+		}
+	}
+
+	return out
+}
+
+// fromDriverIdentity builds the ARM identity response block from the
+// resolved driver shape, echoing each user-assigned identity's synthesized
+// principalId/clientId. Returns nil when the instance has no identity
+// attached, so the response omits the field entirely (matching real Azure).
+func fromDriverIdentity(in *computedriver.ManagedIdentity) *identity {
+	if in == nil {
+		return nil
+	}
+
+	out := &identity{Type: in.Type, PrincipalID: in.PrincipalID, TenantID: in.TenantID}
+
+	if len(in.UserAssigned) > 0 {
+		out.UserAssignedIdentities = make(map[string]*userAssignedIdentity, len(in.UserAssigned))
+		for id, u := range in.UserAssigned {
+			out.UserAssignedIdentities[id] = &userAssignedIdentity{PrincipalID: u.PrincipalID, ClientID: u.ClientID}
+		}
+	}
+
+	return out
+}
+
 func osTypeFromStorage(s *storageProfile) string {
 	if s == nil || s.OSDisk == nil {
 		return ""
@@ -973,6 +1018,7 @@ func toVMResponse(inst *computedriver.Instance, rp azurearm.ResourcePath, req vm
 		Location: defaultIfEmpty(inst.Region, defaultIfEmpty(req.Location, "eastus")),
 		Tags:     stripInternalTags(inst.Tags),
 		Zones:    inst.Zones,
+		Identity: fromDriverIdentity(inst.Identity),
 		Properties: vmResponseProps{
 			VMID:              inst.ID,
 			ProvisioningState: provisioningState,

--- a/server/azure/virtualmachines/types.go
+++ b/server/azure/virtualmachines/types.go
@@ -4,14 +4,47 @@ package virtualmachines
 //
 // We model the minimum surface needed for SDK clients to decode responses
 // and for tests to assert wire shapes. This is not a full ARM contract: many
-// optional fields (extensions, plan, identity, etc.) are intentionally omitted.
+// optional fields (extensions, plan, etc.) are intentionally omitted.
 
 // vmRequest is the inbound shape for a PUT virtualMachines/{name} request.
 type vmRequest struct {
-	Location   string            `json:"location"`
-	Tags       map[string]string `json:"tags,omitempty"`
-	Zones      []string          `json:"zones,omitempty"`
-	Properties vmRequestProps    `json:"properties"`
+	Location string            `json:"location"`
+	Tags     map[string]string `json:"tags,omitempty"`
+	Zones    []string          `json:"zones,omitempty"`
+	// Identity is the managed-identity block, a sibling of properties at the
+	// resource root (armcompute.VirtualMachine.Identity). Omitted (nil) means
+	// the request did not touch identity; real Azure then preserves whatever
+	// identity is already attached rather than clearing it.
+	Identity   *identity      `json:"identity,omitempty"`
+	Properties vmRequestProps `json:"properties"`
+}
+
+// identity is the ARM managed-service-identity envelope
+// (armcompute.VirtualMachineIdentity): system-assigned and/or user-assigned
+// identity configuration.
+type identity struct {
+	// Type is one of "None", "SystemAssigned", "UserAssigned",
+	// "SystemAssigned,UserAssigned".
+	Type string `json:"type,omitempty"`
+	// PrincipalID/TenantID are read-only: Azure populates them once a
+	// system-assigned identity is attached. A request sends neither; we
+	// still decode them (and ignore the values) so a client that round-trips
+	// a GET response back into a PUT body doesn't fail to decode.
+	PrincipalID string `json:"principalId,omitempty"`
+	TenantID    string `json:"tenantId,omitempty"`
+	// UserAssignedIdentities is keyed by the full ARM resource ID of a
+	// Microsoft.ManagedIdentity/userAssignedIdentities resource to attach. A
+	// request sends an empty object per key; principalId/clientId are
+	// read-only, populated on the response.
+	UserAssignedIdentities map[string]*userAssignedIdentity `json:"userAssignedIdentities,omitempty"`
+}
+
+// userAssignedIdentity is one entry of identity.userAssignedIdentities: the
+// read-only principal/client id pair Azure reports for an attached
+// user-assigned identity.
+type userAssignedIdentity struct {
+	PrincipalID string `json:"principalId,omitempty"`
+	ClientID    string `json:"clientId,omitempty"`
 }
 
 type vmRequestProps struct {
@@ -102,13 +135,16 @@ type bootDiagnosticsDataResult struct {
 // response closely enough that azure-sdk-for-go's armcompute.VirtualMachine
 // JSON decoder is happy.
 type vmResponse struct {
-	ID         string            `json:"id"`
-	Name       string            `json:"name"`
-	Type       string            `json:"type"`
-	Location   string            `json:"location"`
-	Tags       map[string]string `json:"tags,omitempty"`
-	Zones      []string          `json:"zones,omitempty"`
-	Properties vmResponseProps   `json:"properties"`
+	ID       string            `json:"id"`
+	Name     string            `json:"name"`
+	Type     string            `json:"type"`
+	Location string            `json:"location"`
+	Tags     map[string]string `json:"tags,omitempty"`
+	Zones    []string          `json:"zones,omitempty"`
+	// Identity echoes the managed-identity block attached to the VM, nil when
+	// none is attached.
+	Identity   *identity       `json:"identity,omitempty"`
+	Properties vmResponseProps `json:"properties"`
 }
 
 type vmResponseProps struct {

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -42,6 +42,12 @@ type InstanceConfig struct {
 	// reference to the profile's ARN and ID. Ignored by Azure/GCP.
 	IamInstanceProfileARN  string
 	IamInstanceProfileName string
+	// Identity is the ARM managed-identity block to attach at launch (Azure
+	// VM identity.type / identity.userAssignedIdentities), when set. Only
+	// Type and UserAssigned (the caller-supplied identity resource IDs) are
+	// meaningful on input — PrincipalID/TenantID/ClientID are provider-
+	// synthesized output, ignored here. Ignored by AWS/GCP.
+	Identity *ManagedIdentity
 }
 
 // IamInstanceProfile is the IAM instance profile association reported on an EC2
@@ -49,6 +55,31 @@ type InstanceConfig struct {
 type IamInstanceProfile struct {
 	ARN string
 	ID  string
+}
+
+// ManagedIdentity models an Azure VM managed-identity block: system-assigned
+// and/or user-assigned identity configuration. Ignored by AWS/GCP.
+type ManagedIdentity struct {
+	// Type is one of "None", "SystemAssigned", "UserAssigned",
+	// "SystemAssigned,UserAssigned".
+	Type string
+	// PrincipalID/TenantID are synthesized for a system-assigned identity
+	// (empty otherwise or on input).
+	PrincipalID string
+	TenantID    string
+	// UserAssigned holds the attached user-assigned identities, keyed by
+	// their full ARM resource ID. On input, only the key (the identity to
+	// attach) matters; the provider fills in each entry's synthesized
+	// PrincipalID/ClientID for output.
+	UserAssigned map[string]UserAssignedIdentity
+}
+
+// UserAssignedIdentity is one entry of ManagedIdentity.UserAssigned: the
+// synthesized principal/client id pair Azure reports for an attached
+// user-assigned identity.
+type UserAssignedIdentity struct {
+	PrincipalID string
+	ClientID    string
 }
 
 // Instance describes a running virtual machine.
@@ -106,6 +137,9 @@ type Instance struct {
 	// IamInstanceProfile is the IAM instance profile attached to the instance
 	// (AWS), nil when none is attached.
 	IamInstanceProfile *IamInstanceProfile
+	// Identity is the resolved managed-identity block (Azure), nil when no
+	// identity is attached (identity.type "None" or unset).
+	Identity *ManagedIdentity
 }
 
 // MetadataOptions is an instance's IMDS (instance metadata service)


### PR DESCRIPTION
## Summary

- VM `identity` block (system-assigned and/or user-assigned managed identity) was completely unmodeled: a PUT with `identity.type=SystemAssigned` (or `UserAssigned` + `userAssignedIdentities`) was accepted, but GET/List never returned it. Added `Identity` to the compute driver's `InstanceConfig`/`Instance`, resolved on create and on the idempotent PUT update path (synthesizing `principalId`/`tenantId` for system-assigned, and `principalId`/`clientId` per user-assigned identity), and round-tripped through the ARM `vmRequest`/`vmResponse` wire shapes. Omitting `identity` on a subsequent PUT preserves the existing identity, matching real Azure; an explicit block (including `"None"`) replaces it.
- `RoleDefinitions.List` matched a stored role scoped at a *descendant* of the query scope, in addition to the scope and its ancestors — contradicting real Azure's documented behavior ("applicable at scope and above", MS Learn: `rest/api/authorization/role-definitions/list`). Dropped the descendant-prefix branch so a list at a resource group no longer leaks role definitions scoped only to child resources.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test` on changed packages (`services/compute`, `providers/azure/virtualmachines`, `server/azure/virtualmachines`, `server/azure/iam`, `features/chaos`)
- [x] `go test -race` on `providers/azure/virtualmachines`
- [x] `golangci-lint` on changed packages — no new issues
- [x] `gofmt -l` clean
- [x] Added real-SDK (`armcompute`/`armauthorization`) regression tests: VM identity (system-assigned, user-assigned, omitted-on-create, list, idempotent PUT stability) and RoleDefinitions list scope-and-above