### PR TITLE
fix(azure-aci): scope container groups to (subscription, resourceGroup, name)

### DIFF
--- a/docs/coverage/azure/containerinstances.md
+++ b/docs/coverage/azure/containerinstances.md
@@ -9,9 +9,9 @@ Azure's `containerinstances` service · portable interface `driver.ContainerInst
 | --- | --- |
 | `ContainerLogs` | ContainerLogs returns the captured stdout/stderr for one container in the |
 | `CreateContainerGroup` | CreateContainerGroup creates the group, or replaces it when one of the |
-| `DeleteContainerGroup` | DeleteContainerGroup removes the group, tearing down any engine-backed |
+| `DeleteContainerGroup` | DeleteContainerGroup removes the group scoped to subscription and |
 | `ExecContainer` | ExecContainer opens an exec session on one container in the group and |
-| `GetContainerGroup` | GetContainerGroup returns the recorded group, or a NotFound error. |
+| `GetContainerGroup` | GetContainerGroup returns the recorded group scoped to subscription and |
 | `ListContainerGroups` | ListContainerGroups returns the groups visible under filter. |
 | `RestartContainerGroup` | RestartContainerGroup restarts all containers in the group. Returns NotFound |
 | `StartContainerGroup` | StartContainerGroup starts all containers in a stopped group, allocating |

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -2507,7 +2507,7 @@
       },
       {
         "name": "DeleteContainerGroup",
-        "doc": "DeleteContainerGroup removes the group, tearing down any engine-backed"
+        "doc": "DeleteContainerGroup removes the group scoped to subscription and"
       },
       {
         "name": "ExecContainer",
@@ -2515,7 +2515,7 @@
       },
       {
         "name": "GetContainerGroup",
-        "doc": "GetContainerGroup returns the recorded group, or a NotFound error."
+        "doc": "GetContainerGroup returns the recorded group scoped to subscription and"
       },
       {
         "name": "ListContainerGroups",

--- a/providers/azure/containerinstances/containerinstances.go
+++ b/providers/azure/containerinstances/containerinstances.go
@@ -74,17 +74,32 @@ func New(opts *config.Options) *Mock {
 	}
 }
 
+// groupKey builds the composite key container groups are stored under. A
+// container group's ARM identity is {subscription, resourceGroup, name} — see
+// the CreateOrUpdate URI parameters at
+// https://learn.microsoft.com/en-us/rest/api/container-instances/container-groups/create-or-update
+// (subscriptionId, resourceGroupName, and containerGroupName are all required
+// path segments) — so a group named "cg1" in one resource group must never
+// collide with (or be overwritten/leaked to) a same-named group in another
+// resource group or subscription.
+func groupKey(subscription, resourceGroup, name string) string {
+	return subscription + "/" + resourceGroup + "/" + name
+}
+
 // CreateContainerGroup creates the group, replacing any existing group of the
-// same name (ARM PUT is create-or-update). When an engine is wired the
-// containers run for real and their observed state is reflected back.
+// same name within the same subscription/resource group (ARM PUT is
+// create-or-update). When an engine is wired the containers run for real and
+// their observed state is reflected back.
 //
 //nolint:gocritic // cfg is the by-value config defined by the driver interface.
 func (m *Mock) CreateContainerGroup(ctx context.Context, cfg driver.ContainerGroupConfig) (*driver.ContainerGroup, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	key := groupKey(cfg.Scope.Subscription, cfg.Scope.ResourceGroup, cfg.Name)
+
 	// Replacing an existing group tears down its prior engine workload first.
-	if prev, ok := m.groups.Get(cfg.Name); ok {
+	if prev, ok := m.groups.Get(key); ok {
 		m.stopWorkload(ctx, prev)
 	}
 
@@ -106,7 +121,7 @@ func (m *Mock) CreateContainerGroup(ctx context.Context, cfg driver.ContainerGro
 		return nil, err
 	}
 
-	m.groups.Set(cfg.Name, data)
+	m.groups.Set(key, data)
 
 	out := data.group
 
@@ -173,9 +188,10 @@ func (m *Mock) restartOnFailure(
 	return handle, statuses, nil
 }
 
-// GetContainerGroup returns the recorded group.
-func (m *Mock) GetContainerGroup(_ context.Context, name string) (*driver.ContainerGroup, error) {
-	data, ok := m.groups.Get(name)
+// GetContainerGroup returns the recorded group scoped to subscription and
+// resourceGroup.
+func (m *Mock) GetContainerGroup(_ context.Context, subscription, resourceGroup, name string) (*driver.ContainerGroup, error) {
+	data, ok := m.groups.Get(groupKey(subscription, resourceGroup, name))
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "container group %q not found", name)
 	}
@@ -185,28 +201,33 @@ func (m *Mock) GetContainerGroup(_ context.Context, name string) (*driver.Contai
 	return &out, nil
 }
 
-// DeleteContainerGroup removes the group, tearing down any engine workload.
-func (m *Mock) DeleteContainerGroup(ctx context.Context, name string) error {
+// DeleteContainerGroup removes the group scoped to subscription and
+// resourceGroup, tearing down any engine workload.
+func (m *Mock) DeleteContainerGroup(ctx context.Context, subscription, resourceGroup, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	data, ok := m.groups.Get(name)
+	key := groupKey(subscription, resourceGroup, name)
+
+	data, ok := m.groups.Get(key)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "container group %q not found", name)
 	}
 
 	m.stopWorkload(ctx, data)
-	m.groups.Delete(name)
+	m.groups.Delete(key)
 
 	return nil
 }
 
-// ListContainerGroups returns the groups visible under filter.
+// ListContainerGroups returns the groups visible under filter: a zero filter
+// lists every group in the store (subscription-wide when only Subscription is
+// set, matching the ARM ListByResourceGroup/List distinction).
 func (m *Mock) ListContainerGroups(_ context.Context, filter scope.Scope) ([]driver.ContainerGroup, error) {
-	all := m.groups.All()
-	out := make([]driver.ContainerGroup, 0, len(all))
+	stored := m.groups.SortedValues()
+	out := make([]driver.ContainerGroup, 0, len(stored))
 
-	for _, data := range all {
+	for _, data := range stored {
 		if data.group.Scope.Matches(filter) {
 			out = append(out, data.group)
 		}
@@ -215,10 +236,11 @@ func (m *Mock) ListContainerGroups(_ context.Context, filter scope.Scope) ([]dri
 	return out, nil
 }
 
-// ContainerLogs returns the engine-captured output for one container. It is
-// empty for a group that never ran on an engine.
-func (m *Mock) ContainerLogs(ctx context.Context, group, container string, tail int) (string, error) {
-	data, ok := m.groups.Get(group)
+// ContainerLogs returns the engine-captured output for one container in the
+// group scoped to subscription and resourceGroup. It is empty for a group
+// that never ran on an engine.
+func (m *Mock) ContainerLogs(ctx context.Context, subscription, resourceGroup, group, container string, tail int) (string, error) {
+	data, ok := m.groups.Get(groupKey(subscription, resourceGroup, group))
 	if !ok {
 		return "", cerrors.Newf(cerrors.NotFound, "container group %q not found", group)
 	}

--- a/providers/azure/containerinstances/containerinstances_test.go
+++ b/providers/azure/containerinstances/containerinstances_test.go
@@ -50,6 +50,11 @@ func (e *recordingEngine) Stop(_ context.Context, handle string) error {
 	return nil
 }
 
+const (
+	testSub = "sub1"
+	testRG  = "rg1"
+)
+
 func sampleConfig() driver.ContainerGroupConfig {
 	return driver.ContainerGroupConfig{
 		Name:          "cg1",
@@ -64,7 +69,7 @@ func sampleConfig() driver.ContainerGroupConfig {
 			MemoryInGB: 1.5,
 			Env:        []driver.EnvVar{{Name: "FOO", Value: "bar"}},
 		}},
-		Scope: scope.Scope{Subscription: "sub1", ResourceGroup: "rg1"},
+		Scope: scope.Scope{Subscription: testSub, ResourceGroup: testRG},
 	}
 }
 
@@ -238,7 +243,7 @@ func TestGetSurfacesEngineState(t *testing.T) {
 		t.Fatalf("Always restart policy should run detached")
 	}
 
-	got, err := m.GetContainerGroup(context.Background(), "cg1")
+	got, err := m.GetContainerGroup(context.Background(), testSub, testRG, "cg1")
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
@@ -268,7 +273,7 @@ func TestContainerLogsReturnEngineOutput(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 
-	out, err := m.ContainerLogs(context.Background(), "cg1", "app", 10)
+	out, err := m.ContainerLogs(context.Background(), testSub, testRG, "cg1", "app", 10)
 	if err != nil {
 		t.Fatalf("logs: %v", err)
 	}
@@ -293,7 +298,7 @@ func TestDeleteStopsEngineWorkload(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 
-	if err := m.DeleteContainerGroup(context.Background(), "cg1"); err != nil {
+	if err := m.DeleteContainerGroup(context.Background(), testSub, testRG, "cg1"); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 
@@ -301,7 +306,7 @@ func TestDeleteStopsEngineWorkload(t *testing.T) {
 		t.Fatalf("engine workload not stopped: %v", eng.stopped)
 	}
 
-	if _, err := m.GetContainerGroup(context.Background(), "cg1"); !cerrors.IsNotFound(err) {
+	if _, err := m.GetContainerGroup(context.Background(), testSub, testRG, "cg1"); !cerrors.IsNotFound(err) {
 		t.Fatalf("group should be gone after delete, got %v", err)
 	}
 }
@@ -325,7 +330,7 @@ func TestNilEngineStaysSynthetic(t *testing.T) {
 	}
 
 	// Logs are empty and no engine call is made for a synthetic group.
-	out, err := m.ContainerLogs(context.Background(), "cg1", "app", 0)
+	out, err := m.ContainerLogs(context.Background(), testSub, testRG, "cg1", "app", 0)
 	if err != nil {
 		t.Fatalf("logs: %v", err)
 	}
@@ -358,5 +363,57 @@ func TestListFiltersByScope(t *testing.T) {
 
 	if len(otherRG) != 0 {
 		t.Fatalf("expected 0 groups in other rg, got %d", len(otherRG))
+	}
+}
+
+// TestSameNameGroupsIsolatedAcrossResourceGroups is a regression test for the
+// cross-RG collision bug: a container group's ARM identity is
+// {subscription, resourceGroup, name}, so a same-named group in a different
+// resource group (or subscription) must not alias, leak into, or be deleted by
+// operations on the other.
+func TestSameNameGroupsIsolatedAcrossResourceGroups(t *testing.T) {
+	m := New(config.NewOptions())
+	ctx := context.Background()
+
+	cfg1 := sampleConfig()
+	cfg1.Location = "eastus"
+
+	cfg2 := sampleConfig()
+	cfg2.Location = "westus2"
+	cfg2.Scope = scope.Scope{Subscription: testSub, ResourceGroup: "rg2"}
+
+	if _, err := m.CreateContainerGroup(ctx, cfg1); err != nil {
+		t.Fatalf("create rg1: %v", err)
+	}
+
+	if _, err := m.CreateContainerGroup(ctx, cfg2); err != nil {
+		t.Fatalf("create rg2: %v", err)
+	}
+
+	g1, err := m.GetContainerGroup(ctx, testSub, testRG, "cg1")
+	if err != nil {
+		t.Fatalf("get rg1: %v", err)
+	}
+
+	g2, err := m.GetContainerGroup(ctx, testSub, "rg2", "cg1")
+	if err != nil {
+		t.Fatalf("get rg2: %v", err)
+	}
+
+	if g1.Location != "eastus" || g2.Location != "westus2" {
+		t.Fatalf("groups aliased across resource groups: rg1=%q rg2=%q", g1.Location, g2.Location)
+	}
+
+	// Deleting the rg1 group must not remove the same-named rg2 group.
+	if err := m.DeleteContainerGroup(ctx, testSub, testRG, "cg1"); err != nil {
+		t.Fatalf("delete rg1: %v", err)
+	}
+
+	if _, err := m.GetContainerGroup(ctx, testSub, testRG, "cg1"); !cerrors.IsNotFound(err) {
+		t.Fatalf("rg1 group should be gone, got %v", err)
+	}
+
+	if _, err := m.GetContainerGroup(ctx, testSub, "rg2", "cg1"); err != nil {
+		t.Fatalf("rg2 group should still exist after rg1 delete: %v", err)
 	}
 }

--- a/providers/azure/containerinstances/lifecycle.go
+++ b/providers/azure/containerinstances/lifecycle.go
@@ -77,87 +77,99 @@ func synthPublicIP(seed string) string {
 }
 
 // StartContainerGroup restarts the group's workload and returns it to Running.
-func (m *Mock) StartContainerGroup(ctx context.Context, name string) error {
+func (m *Mock) StartContainerGroup(ctx context.Context, subscription, resourceGroup, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	data, ok := m.groups.Get(name)
-	if !ok {
+	key := groupKey(subscription, resourceGroup, name)
+
+	if !m.groups.Has(key) {
 		return cerrors.Newf(cerrors.NotFound, "container group %q not found", name)
 	}
 
-	return m.runGroup(ctx, data)
+	return m.runGroup(ctx, key)
 }
 
 // StopContainerGroup tears down the workload and marks the group Stopped.
-func (m *Mock) StopContainerGroup(ctx context.Context, name string) error {
+func (m *Mock) StopContainerGroup(ctx context.Context, subscription, resourceGroup, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	data, ok := m.groups.Get(name)
+	key := groupKey(subscription, resourceGroup, name)
+
+	data, ok := m.groups.Get(key)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "container group %q not found", name)
 	}
 
 	m.stopWorkload(ctx, data)
-	data.engineBacked = false
-	data.handle = ""
-	data.group.State = groupStateStopped
 
-	for i := range data.group.Containers {
-		data.group.Containers[i].Current = driver.ContainerState{State: containerStateTerminated}
-	}
+	m.groups.Update(key, func(d *groupData) *groupData {
+		d.engineBacked = false
+		d.handle = ""
+		d.group.State = groupStateStopped
 
-	m.groups.Set(name, data)
+		for i := range d.group.Containers {
+			d.group.Containers[i].Current = driver.ContainerState{State: containerStateTerminated}
+		}
+
+		return d
+	})
 
 	return nil
 }
 
 // RestartContainerGroup tears the workload down and runs it again.
-func (m *Mock) RestartContainerGroup(ctx context.Context, name string) error {
+func (m *Mock) RestartContainerGroup(ctx context.Context, subscription, resourceGroup, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	data, ok := m.groups.Get(name)
+	key := groupKey(subscription, resourceGroup, name)
+
+	data, ok := m.groups.Get(key)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "container group %q not found", name)
 	}
 
 	m.stopWorkload(ctx, data)
 
-	return m.runGroup(ctx, data)
+	return m.runGroup(ctx, key)
 }
 
-// runGroup resets the group to a fresh Running state and re-runs it on the
-// engine (a no-op when none is configured), reflecting the observed state back.
-func (m *Mock) runGroup(ctx context.Context, data *groupData) error {
-	cfg := driver.ContainerGroupConfig{
-		Name:          data.group.Name,
-		RestartPolicy: data.group.RestartPolicy,
-		Containers:    configsFromInstances(data.group.Containers),
-	}
+// runGroup resets the group at key to a fresh Running state and re-runs it on
+// the engine (a no-op when none is configured), reflecting the observed state
+// back.
+func (m *Mock) runGroup(ctx context.Context, key string) error {
+	var runErr error
 
-	data.group.State = groupStateRunning
-	data.group.Containers = synthContainers(cfg.Containers)
-	data.engineBacked = false
-	data.handle = ""
+	m.groups.Update(key, func(data *groupData) *groupData {
+		cfg := driver.ContainerGroupConfig{
+			Name:          data.group.Name,
+			RestartPolicy: data.group.RestartPolicy,
+			Containers:    configsFromInstances(data.group.Containers),
+			Scope:         data.group.Scope,
+		}
 
-	if err := m.backWithEngine(ctx, &cfg, data); err != nil {
-		return err
-	}
+		data.group.State = groupStateRunning
+		data.group.Containers = synthContainers(cfg.Containers)
+		data.engineBacked = false
+		data.handle = ""
 
-	m.groups.Set(cfg.Name, data)
+		runErr = m.backWithEngine(ctx, &cfg, data)
 
-	return nil
+		return data
+	})
+
+	return runErr
 }
 
 // ExecContainer opens an exec session on one container. When the group is
 // engine-backed the command runs for real on the engine before the session
 // descriptor is returned.
 func (m *Mock) ExecContainer(
-	ctx context.Context, group, container string, command []string,
+	ctx context.Context, subscription, resourceGroup, group, container string, command []string,
 ) (*driver.ExecSession, error) {
-	data, ok := m.groups.Get(group)
+	data, ok := m.groups.Get(groupKey(subscription, resourceGroup, group))
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "container group %q not found", group)
 	}

--- a/providers/azure/containerinstances/lifecycle_test.go
+++ b/providers/azure/containerinstances/lifecycle_test.go
@@ -70,33 +70,33 @@ func TestStopStartRestartStateTransitions(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 
-	if err := m.StopContainerGroup(ctx, "cg1"); err != nil {
+	if err := m.StopContainerGroup(ctx, testSub, testRG, "cg1"); err != nil {
 		t.Fatalf("stop: %v", err)
 	}
 
-	g, _ := m.GetContainerGroup(ctx, "cg1")
+	g, _ := m.GetContainerGroup(ctx, testSub, testRG, "cg1")
 	if g.State != groupStateStopped || g.Containers[0].Current.State != containerStateTerminated {
 		t.Fatalf("after stop: group=%q container=%q", g.State, g.Containers[0].Current.State)
 	}
 
-	if err := m.StartContainerGroup(ctx, "cg1"); err != nil {
+	if err := m.StartContainerGroup(ctx, testSub, testRG, "cg1"); err != nil {
 		t.Fatalf("start: %v", err)
 	}
 
-	g, _ = m.GetContainerGroup(ctx, "cg1")
+	g, _ = m.GetContainerGroup(ctx, testSub, testRG, "cg1")
 	if g.State != groupStateRunning {
 		t.Fatalf("after start: group state = %q, want Running", g.State)
 	}
 
-	if err := m.RestartContainerGroup(ctx, "cg1"); err != nil {
+	if err := m.RestartContainerGroup(ctx, testSub, testRG, "cg1"); err != nil {
 		t.Fatalf("restart: %v", err)
 	}
 
 	// Missing group → NotFound for each verb.
 	for _, err := range []error{
-		m.StopContainerGroup(ctx, "ghost"),
-		m.StartContainerGroup(ctx, "ghost"),
-		m.RestartContainerGroup(ctx, "ghost"),
+		m.StopContainerGroup(ctx, testSub, testRG, "ghost"),
+		m.StartContainerGroup(ctx, testSub, testRG, "ghost"),
+		m.RestartContainerGroup(ctx, testSub, testRG, "ghost"),
 	} {
 		if !cerrors.IsNotFound(err) {
 			t.Fatalf("lifecycle on missing group = %v, want NotFound", err)
@@ -113,7 +113,7 @@ func TestExecValidatesAndDrivesEngine(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 
-	session, err := m.ExecContainer(ctx, "cg1", "app", []string{"ls", "-la"})
+	session, err := m.ExecContainer(ctx, testSub, testRG, "cg1", "app", []string{"ls", "-la"})
 	if err != nil {
 		t.Fatalf("exec: %v", err)
 	}
@@ -127,12 +127,12 @@ func TestExecValidatesAndDrivesEngine(t *testing.T) {
 	}
 
 	// Unknown container → NotFound.
-	if _, err := m.ExecContainer(ctx, "cg1", "ghost", []string{"ls"}); !cerrors.IsNotFound(err) {
+	if _, err := m.ExecContainer(ctx, testSub, testRG, "cg1", "ghost", []string{"ls"}); !cerrors.IsNotFound(err) {
 		t.Fatalf("exec on missing container = %v, want NotFound", err)
 	}
 
 	// Unknown group → NotFound.
-	if _, err := m.ExecContainer(ctx, "ghost", "app", []string{"ls"}); !cerrors.IsNotFound(err) {
+	if _, err := m.ExecContainer(ctx, testSub, testRG, "ghost", "app", []string{"ls"}); !cerrors.IsNotFound(err) {
 		t.Fatalf("exec on missing group = %v, want NotFound", err)
 	}
 }

--- a/server/azure/containerinstances/handler_test.go
+++ b/server/azure/containerinstances/handler_test.go
@@ -54,7 +54,11 @@ func (e *recordingEngine) Stop(_ context.Context, handle string) error {
 }
 
 func groupURL(name string) string {
-	return "/subscriptions/" + subID + "/resourceGroups/" + rgName +
+	return groupURLInRG(rgName, name)
+}
+
+func groupURLInRG(rg, name string) string {
+	return "/subscriptions/" + subID + "/resourceGroups/" + rg +
 		"/providers/Microsoft.ContainerInstance/containerGroups/" + name
 }
 
@@ -136,6 +140,42 @@ func TestContainerGroupLifecycleDrivesEngine(t *testing.T) {
 
 	// 5. GET after delete → 404.
 	doReq(t, srv.URL, http.MethodGet, groupURL("cg1")+apiVer, nil, http.StatusNotFound)
+}
+
+// TestContainerGroupsIsolatedAcrossResourceGroups is a regression test for the
+// cross-RG collision fix: a container group's ARM identity is
+// {subscriptionId, resourceGroupName, containerGroupName} — see
+// https://learn.microsoft.com/en-us/rest/api/container-instances/container-groups/create-or-update
+// — so two resource groups can each hold a same-named group without one
+// aliasing or leaking into the other.
+func TestContainerGroupsIsolatedAcrossResourceGroups(t *testing.T) {
+	const otherRG = "other-rg"
+
+	cloud := cloudemu.NewAzure()
+	srv := httptest.NewServer(azureserver.New(azureserver.DriversFrom(cloud)))
+	t.Cleanup(srv.Close)
+
+	// Same group name ("shared") created in two different resource groups.
+	doReq(t, srv.URL, http.MethodPut, groupURLInRG(rgName, "shared")+apiVer,
+		strings.NewReader(createBody), http.StatusCreated)
+	doReq(t, srv.URL, http.MethodPut, groupURLInRG(otherRG, "shared")+apiVer,
+		strings.NewReader(strings.Replace(createBody, `"location": "eastus"`, `"location": "westus2"`, 1)),
+		http.StatusCreated)
+
+	// GET in each RG returns that RG's own group, not the other's.
+	inFirst := decodeGroup(t, doReq(t, srv.URL, http.MethodGet, groupURLInRG(rgName, "shared")+apiVer, nil, http.StatusOK))
+	inOther := decodeGroup(t, doReq(t, srv.URL, http.MethodGet, groupURLInRG(otherRG, "shared")+apiVer, nil, http.StatusOK))
+
+	if inFirst.Properties.Containers[0].Properties.Image == "" || inOther.Properties.Containers[0].Properties.Image == "" {
+		t.Fatalf("expected both groups populated, got %+v / %+v", inFirst, inOther)
+	}
+
+	// Deleting the group in one RG must not remove (or affect) the same-named
+	// group in the other RG.
+	doReq(t, srv.URL, http.MethodDelete, groupURLInRG(rgName, "shared")+apiVer, nil, http.StatusOK)
+
+	doReq(t, srv.URL, http.MethodGet, groupURLInRG(rgName, "shared")+apiVer, nil, http.StatusNotFound)
+	doReq(t, srv.URL, http.MethodGet, groupURLInRG(otherRG, "shared")+apiVer, nil, http.StatusOK)
 }
 
 func TestNilEngineStaysSynthetic(t *testing.T) {

--- a/server/azure/containerinstances/operations.go
+++ b/server/azure/containerinstances/operations.go
@@ -19,7 +19,7 @@ func (h *Handler) createOrUpdateGroup(w http.ResponseWriter, r *http.Request, rp
 		return
 	}
 
-	_, getErr := h.aci.GetContainerGroup(r.Context(), rp.ResourceName)
+	_, getErr := h.aci.GetContainerGroup(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName)
 	existed := getErr == nil
 
 	group, err := h.aci.CreateContainerGroup(r.Context(), toConfig(rp, &body))
@@ -44,11 +44,11 @@ func (h *Handler) lifecycleGroup(w http.ResponseWriter, r *http.Request, rp *azu
 
 	switch rp.SubResource {
 	case subActionStart:
-		err = h.aci.StartContainerGroup(r.Context(), rp.ResourceName)
+		err = h.aci.StartContainerGroup(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName)
 	case subActionStop:
-		err = h.aci.StopContainerGroup(r.Context(), rp.ResourceName)
+		err = h.aci.StopContainerGroup(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName)
 	case subActionRestart:
-		err = h.aci.RestartContainerGroup(r.Context(), rp.ResourceName)
+		err = h.aci.RestartContainerGroup(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName)
 	}
 
 	if err != nil {
@@ -74,7 +74,8 @@ func (h *Handler) execContainer(w http.ResponseWriter, r *http.Request, rp *azur
 		return
 	}
 
-	session, err := h.aci.ExecContainer(r.Context(), rp.ResourceName, rp.SubResourceName, strings.Fields(req.Command))
+	session, err := h.aci.ExecContainer(
+		r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName, rp.SubResourceName, strings.Fields(req.Command))
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 
@@ -89,7 +90,7 @@ func (h *Handler) execContainer(w http.ResponseWriter, r *http.Request, rp *azur
 
 // getGroup handles GET on a single resource — ContainerGroups.Get.
 func (h *Handler) getGroup(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	group, err := h.aci.GetContainerGroup(r.Context(), rp.ResourceName)
+	group, err := h.aci.GetContainerGroup(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 
@@ -102,14 +103,14 @@ func (h *Handler) getGroup(w http.ResponseWriter, r *http.Request, rp *azurearm.
 // deleteGroup handles DELETE — ContainerGroups.BeginDelete. Returning 200 with
 // the deleted resource body completes the SDK's poller on the first response.
 func (h *Handler) deleteGroup(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	group, err := h.aci.GetContainerGroup(r.Context(), rp.ResourceName)
+	group, err := h.aci.GetContainerGroup(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 
 		return
 	}
 
-	if derr := h.aci.DeleteContainerGroup(r.Context(), rp.ResourceName); derr != nil {
+	if derr := h.aci.DeleteContainerGroup(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName); derr != nil {
 		azurearm.WriteCErr(w, derr)
 
 		return
@@ -148,7 +149,8 @@ func (h *Handler) containerLogs(w http.ResponseWriter, r *http.Request, rp *azur
 		return
 	}
 
-	content, err := h.aci.ContainerLogs(r.Context(), rp.ResourceName, rp.SubResourceName, tailParam(r))
+	content, err := h.aci.ContainerLogs(
+		r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName, rp.SubResourceName, tailParam(r))
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 

--- a/services/containerinstances/driver/driver.go
+++ b/services/containerinstances/driver/driver.go
@@ -115,37 +115,41 @@ type ContainerInstances interface {
 	// the returned state reflects the engine's observed states/exit codes.
 	CreateContainerGroup(ctx context.Context, cfg ContainerGroupConfig) (*ContainerGroup, error)
 
-	// GetContainerGroup returns the recorded group, or a NotFound error.
-	GetContainerGroup(ctx context.Context, name string) (*ContainerGroup, error)
+	// GetContainerGroup returns the recorded group scoped to subscription and
+	// resourceGroup, or a NotFound error. A container group's ARM identity is
+	// {subscription, resourceGroup, name} — the same name in a different
+	// resource group (or subscription) is a different resource.
+	GetContainerGroup(ctx context.Context, subscription, resourceGroup, name string) (*ContainerGroup, error)
 
-	// DeleteContainerGroup removes the group, tearing down any engine-backed
-	// workload first. Returns NotFound when the group does not exist.
-	DeleteContainerGroup(ctx context.Context, name string) error
+	// DeleteContainerGroup removes the group scoped to subscription and
+	// resourceGroup, tearing down any engine-backed workload first. Returns
+	// NotFound when the group does not exist.
+	DeleteContainerGroup(ctx context.Context, subscription, resourceGroup, name string) error
 
 	// ListContainerGroups returns the groups visible under filter.
 	ListContainerGroups(ctx context.Context, filter scope.Scope) ([]ContainerGroup, error)
 
 	// StartContainerGroup starts all containers in a stopped group, allocating
 	// compute again. Returns NotFound when the group does not exist.
-	StartContainerGroup(ctx context.Context, name string) error
+	StartContainerGroup(ctx context.Context, subscription, resourceGroup, name string) error
 
 	// StopContainerGroup stops all containers in the group and deallocates
 	// compute, tearing down any engine-backed workload. Returns NotFound when the
 	// group does not exist.
-	StopContainerGroup(ctx context.Context, name string) error
+	StopContainerGroup(ctx context.Context, subscription, resourceGroup, name string) error
 
 	// RestartContainerGroup restarts all containers in the group. Returns NotFound
 	// when the group does not exist.
-	RestartContainerGroup(ctx context.Context, name string) error
+	RestartContainerGroup(ctx context.Context, subscription, resourceGroup, name string) error
 
 	// ExecContainer opens an exec session on one container in the group and
 	// returns its websocket URI and password. When the group is engine-backed the
 	// command is run for real on the engine. Returns NotFound when the group or
 	// container does not exist.
-	ExecContainer(ctx context.Context, group, container string, command []string) (*ExecSession, error)
+	ExecContainer(ctx context.Context, subscription, resourceGroup, group, container string, command []string) (*ExecSession, error)
 
 	// ContainerLogs returns the captured stdout/stderr for one container in the
 	// group. A non-positive tail returns the full log. It is empty for a group
 	// that is not engine-backed.
-	ContainerLogs(ctx context.Context, group, container string, tail int) (string, error)
+	ContainerLogs(ctx context.Context, subscription, resourceGroup, group, container string, tail int) (string, error)
 }


### PR DESCRIPTION
## Summary

Azure Container Instances container groups were keyed globally in the store by name alone (`providers/azure/containerinstances/containerinstances.go`), so a group named e.g. `cg1` in one resource group aliased — and could be overwritten or deleted by — a same-named group in a different resource group or subscription.

Real ACI's `ContainerGroups.CreateOrUpdate` identifies a resource by `{subscriptionId, resourceGroupName, containerGroupName}` — all three are required path segments ([MS Learn](https://learn.microsoft.com/en-us/rest/api/container-instances/container-groups/create-or-update?view=rest-container-instances-2023-05-01)).

## Changes

- Store key is now the composite `subscription/resourceGroup/name` (`groupKey`), matching the convention used elsewhere in the codebase (e.g. `providers/azure/functions/app_service_plan.go`, `providers/azure/aks/aks.go`).
- `driver.ContainerInstances`: `GetContainerGroup`, `DeleteContainerGroup`, `StartContainerGroup`, `StopContainerGroup`, `RestartContainerGroup`, `ExecContainer`, and `ContainerLogs` now take `subscription, resourceGroup` alongside `name`. `ListContainerGroups` is unchanged (already scope-filtered) and now iterates `SortedValues()` for deterministic order.
- The wire handler (`server/azure/containerinstances/operations.go`) threads `rp.Subscription`/`rp.ResourceGroup` from the parsed ARM path through to the driver calls.
- `StopContainerGroup`/`runGroup` (used by Start/Restart) now use `store.Update` for their read-modify-write instead of `Get` + direct pointer mutation + `Set`.
- Regenerated `docs/coverage/` via `go generate` (driver doc comments changed).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./providers/azure/containerinstances/... ./server/azure/containerinstances/... ./services/containerinstances/...`
- [x] `go test -race ./providers/azure/containerinstances/... ./server/azure/containerinstances/...`
- [x] `golangci-lint run ./providers/azure/containerinstances/... ./server/azure/containerinstances/... ./services/containerinstances/...` — 0 issues
- [x] `gofmt -l` clean
- [x] New regression test `TestContainerGroupsIsolatedAcrossResourceGroups` (wire-level, real ARM request/response shapes) and `TestSameNameGroupsIsolatedAcrossResourceGroups` (provider-level): two resource groups each hold a group named `cg1`/`shared`; deleting one leaves the other untouched.