### PR TITLE
fix(azure-dns): preserve unmodeled record-type data (MX/SRV) on RecordSets List

### DIFF
--- a/server/azure/dns/sdk_roundtrip_test.go
+++ b/server/azure/dns/sdk_roundtrip_test.go
@@ -220,6 +220,111 @@ func TestSDKAzureDNSRecordSets(t *testing.T) {
 	}
 }
 
+// TestSDKAzureDNSListPreservesUnmodeledRecordTypes is the regression for the
+// HIGH finding: MX and SRV record sets are not natively modeled by the DNS
+// handler (Azure represents them as properties.MXRecords / properties.SRVRecords
+// — see RecordSet in
+// https://learn.microsoft.com/en-us/rest/api/dns/record-sets/list-by-dns-zone),
+// so cloudemu relies on the unmodeled-property overlay to round-trip their
+// data. A single RecordSets.Get on one of them worked, but
+// RecordSets.ListByDnsZone returned every record set with its MXRecords /
+// SRVRecords silently dropped. A/AAAA/CNAME/TXT are natively modeled and must
+// keep listing correctly alongside the fix.
+func TestSDKAzureDNSListPreservesUnmodeledRecordTypes(t *testing.T) {
+	zones, records := newDNSClients(t)
+	ctx := context.Background()
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, "unmodeled.com", armdns.Zone{
+		Location: to.Ptr("global"),
+	}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	if _, err := records.CreateOrUpdate(ctx, testRG, "unmodeled.com", "@", armdns.RecordTypeMX, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL: to.Ptr(int64(300)),
+			MxRecords: []*armdns.MxRecord{
+				{Exchange: to.Ptr("mail.unmodeled.com"), Preference: to.Ptr(int32(10))},
+			},
+		},
+	}, nil); err != nil {
+		t.Fatalf("RecordSets.CreateOrUpdate(MX): %v", err)
+	}
+
+	if _, err := records.CreateOrUpdate(ctx, testRG, "unmodeled.com", "_sip._tcp", armdns.RecordTypeSRV, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL: to.Ptr(int64(300)),
+			SrvRecords: []*armdns.SrvRecord{
+				{Priority: to.Ptr(int32(1)), Weight: to.Ptr(int32(5)), Port: to.Ptr(int32(5060)), Target: to.Ptr("sip.unmodeled.com")},
+			},
+		},
+	}, nil); err != nil {
+		t.Fatalf("RecordSets.CreateOrUpdate(SRV): %v", err)
+	}
+
+	if _, err := records.CreateOrUpdate(ctx, testRG, "unmodeled.com", "www", armdns.RecordTypeA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL:      to.Ptr(int64(300)),
+			ARecords: []*armdns.ARecord{{IPv4Address: to.Ptr("203.0.113.9")}},
+		},
+	}, nil); err != nil {
+		t.Fatalf("RecordSets.CreateOrUpdate(A): %v", err)
+	}
+
+	var (
+		mxSeen, srvSeen, aSeen bool
+	)
+
+	pager := records.NewListByDNSZonePager(testRG, "unmodeled.com", nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("ListByDNSZone: %v", perr)
+		}
+
+		for _, rs := range page.Value {
+			if rs.Properties == nil {
+				continue
+			}
+
+			switch {
+			case len(rs.Properties.MxRecords) > 0:
+				mxSeen = true
+
+				mx := rs.Properties.MxRecords[0]
+				if mx.Exchange == nil || *mx.Exchange != "mail.unmodeled.com" || mx.Preference == nil || *mx.Preference != 10 {
+					t.Errorf("list MX record = %+v, want exchange=mail.unmodeled.com preference=10", mx)
+				}
+			case len(rs.Properties.SrvRecords) > 0:
+				srvSeen = true
+
+				srv := rs.Properties.SrvRecords[0]
+				if srv.Target == nil || *srv.Target != "sip.unmodeled.com" || srv.Port == nil || *srv.Port != 5060 {
+					t.Errorf("list SRV record = %+v, want target=sip.unmodeled.com port=5060", srv)
+				}
+			case len(rs.Properties.ARecords) > 0:
+				aSeen = true
+
+				if *rs.Properties.ARecords[0].IPv4Address != "203.0.113.9" {
+					t.Errorf("list A record = %+v, want 203.0.113.9", rs.Properties.ARecords[0])
+				}
+			}
+		}
+	}
+
+	if !mxSeen {
+		t.Error("ListByDnsZone dropped the MX record set's MXRecords data")
+	}
+
+	if !srvSeen {
+		t.Error("ListByDnsZone dropped the SRV record set's SRVRecords data")
+	}
+
+	if !aSeen {
+		t.Error("ListByDnsZone regressed on the natively-modeled A record set")
+	}
+}
+
 func contains(haystack []string, needle string) bool {
 	for _, s := range haystack {
 		if s == needle {

--- a/server/azure/echo_properties.go
+++ b/server/azure/echo_properties.go
@@ -206,7 +206,8 @@ func writeJSONResponse(w http.ResponseWriter, status int, body []byte) {
 // rewrite merges the recorded and request-carried unmodeled properties into the
 // response and writes the result. It returns false (and writes nothing) when
 // the response is not a rewritable ARM resource object, leaving the caller to
-// flush the original bytes.
+// flush the original bytes. A collection response ({"value": [...]}) is
+// dispatched to rewriteList instead of the single-resource path below.
 func (c *captureWriter) rewrite(
 	w http.ResponseWriter, r *http.Request, reqProps map[string]any, overlay *propertyOverlay,
 ) bool {
@@ -223,6 +224,10 @@ func (c *captureWriter) rewrite(
 		return false
 	}
 
+	if values, ok := resource["value"].([]any); ok {
+		return c.rewriteList(w, resource, values, overlay)
+	}
+
 	id, ok := resource["id"].(string)
 	if !ok || id == "" {
 		return false
@@ -237,6 +242,54 @@ func (c *captureWriter) rewrite(
 	}
 
 	resource["properties"] = mergeProperties(respProps, unmodeled)
+
+	rewritten, err := json.Marshal(resource)
+	if err != nil {
+		return false
+	}
+
+	writeJSONResponse(w, c.status, rewritten)
+
+	return true
+}
+
+// rewriteList merges each list item's previously-recorded overlay entry into
+// its own properties, keyed by the item's own "id". A collection list (e.g.
+// RecordSets.ListByDnsZone) carries no request body to capture fresh
+// unmodeled properties from — list is read-only — so this only replays what
+// an earlier create/update on that same item already recorded; without it, a
+// record set with unmodeled data (e.g. an MX or SRV DNS record set, whose
+// MXRecords/SRVRecords are not natively modeled) loses that data specifically
+// on the list response while a single GET on it still returns it correctly.
+func (c *captureWriter) rewriteList(
+	w http.ResponseWriter, resource map[string]any, values []any, overlay *propertyOverlay,
+) bool {
+	changed := false
+
+	for _, v := range values {
+		item, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		id, ok := item["id"].(string)
+		if !ok || id == "" {
+			continue
+		}
+
+		unmodeled := overlay.lookup(id)
+		if len(unmodeled) == 0 {
+			continue
+		}
+
+		respProps, _ := item["properties"].(map[string]any)
+		item["properties"] = mergeProperties(respProps, unmodeled)
+		changed = true
+	}
+
+	if !changed {
+		return false
+	}
 
 	rewritten, err := json.Marshal(resource)
 	if err != nil {


### PR DESCRIPTION
## Summary

Azure DNS record sets whose data isn't natively modeled (MX, SRV, CAA, etc.) lost that data specifically on `RecordSets.ListByDnsZone` — a single `RecordSets.Get` on the same record set returned it correctly. Confirmed against the real ARM schema: [Record Sets - List By Dns Zone](https://learn.microsoft.com/en-us/rest/api/dns/record-sets/list-by-dns-zone?view=rest-dns-2018-05-01) shows `properties.MXRecords` / `properties.SRVRecords` on the exact same `RecordSet` object returned by both Get and List.

## Root cause

cloudemu preserves data for unmodeled DNS record types via a shared ARM "property overlay" middleware (`server/azure/echo_properties.go`), which remembers request properties a handler didn't natively model and merges them back into JSON responses keyed by the resource's `id`. Its rewrite path only recognized a single-resource response (a JSON object with a top-level `"id"`). A collection response (`{"value": [...]}`) has no top-level `id`, so the middleware silently skipped rewriting it — every item in a list response kept only what the handler itself modeled, dropping unmodeled fields like `MXRecords`/`SRVRecords`.

## Fix

`echo_properties.go`: when the response body is a `{"value": [...]}` collection, iterate each item, look up its own overlay entry by its own `id`, and merge it into that item's `properties` — the same merge already used for a single-resource response, just replayed per list item. Nothing changes for A/AAAA/CNAME/TXT (natively modeled, no overlay entry to merge).

This is a fix to the shared Azure ARM middleware, so it also fixes the same list-drops-unmodeled-data bug for any other Azure resource collection that relies on the overlay, not just DNS.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./server/azure/...`
- [x] `go test ./server/azure/... ./server/azure/dns/...`
- [x] `go test -race ./server/azure/...`
- [x] `golangci-lint run ./server/azure/...` — no new findings in changed files
- [x] `gofmt -l` clean
- [x] Added `TestSDKAzureDNSListPreservesUnmodeledRecordTypes` using the real `armdns` SDK: creates MX, SRV, and A record sets, lists via `RecordSetsClient.NewListByDNSZonePager`, and asserts MX/SRV data survives the list while A keeps listing correctly (no regression)