### PR TITLE
fix(azure-mysqlpg): resource-group scoping, MySQL Flex parameter defaults, HA-gated failover, restart body

### DIFF
--- a/docs/coverage/aws/redshift.md
+++ b/docs/coverage/aws/redshift.md
@@ -297,6 +297,14 @@ ReplicaPromotion is an OPTIONAL capability that promotes a read replica to a
 | --- | --- |
 | `PromoteReplica` |  |
 
+### ScopedDelete
+
+ScopedDelete is an OPTIONAL capability, discovered by type assertion. It lets
+
+| Operation | Description |
+| --- | --- |
+| `DeleteInstanceInScope` |  |
+
 ### SslCerts
 
 SslCerts is an OPTIONAL capability for managing client SSL certificates,

--- a/docs/coverage/azure/mysqlflex.md
+++ b/docs/coverage/azure/mysqlflex.md
@@ -297,6 +297,14 @@ ReplicaPromotion is an OPTIONAL capability that promotes a read replica to a
 | --- | --- |
 | `PromoteReplica` |  |
 
+### ScopedDelete
+
+ScopedDelete is an OPTIONAL capability, discovered by type assertion. It lets
+
+| Operation | Description |
+| --- | --- |
+| `DeleteInstanceInScope` |  |
+
 ### SslCerts
 
 SslCerts is an OPTIONAL capability for managing client SSL certificates,

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -8170,6 +8170,15 @@
         ]
       },
       {
+        "name": "ScopedDelete",
+        "doc": "ScopedDelete is an OPTIONAL capability, discovered by type assertion. It lets",
+        "operations": [
+          {
+            "name": "DeleteInstanceInScope"
+          }
+        ]
+      },
+      {
         "name": "SslCerts",
         "doc": "SslCerts is an OPTIONAL capability for managing client SSL certificates,",
         "operations": [

--- a/docs/coverage/gcp/alloydb.md
+++ b/docs/coverage/gcp/alloydb.md
@@ -297,6 +297,14 @@ ReplicaPromotion is an OPTIONAL capability that promotes a read replica to a
 | --- | --- |
 | `PromoteReplica` |  |
 
+### ScopedDelete
+
+ScopedDelete is an OPTIONAL capability, discovered by type assertion. It lets
+
+| Operation | Description |
+| --- | --- |
+| `DeleteInstanceInScope` |  |
+
 ### SslCerts
 
 SslCerts is an OPTIONAL capability for managing client SSL certificates,

--- a/providers/azure/mysqlflex/mysqlflex.go
+++ b/providers/azure/mysqlflex/mysqlflex.go
@@ -22,6 +22,7 @@ import (
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	dbengine "github.com/stackshy/cloudemu/v2/services/relationaldb/dbengine"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const (
@@ -42,7 +43,10 @@ const (
 	diskWriteOpsRunning   = 5.0
 )
 
-var _ rdsdriver.RelationalDB = (*Mock)(nil)
+var (
+	_ rdsdriver.RelationalDB = (*Mock)(nil)
+	_ rdsdriver.ScopedDelete = (*Mock)(nil)
+)
 
 // Mock is the in-memory Azure MySQL Flexible Server implementation.
 type Mock struct {
@@ -223,6 +227,7 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		StandbyAvailabilityZone: cfg.StandbyAvailabilityZone,
 		CreatedAt:               m.opts.Clock.Now().UTC(),
 		Tags:                    copyTags(cfg.Tags),
+		Scope:                   cfg.Scope,
 	}
 }
 
@@ -345,11 +350,27 @@ func (m *Mock) ModifyInstance(
 
 // DeleteInstance removes a server.
 func (m *Mock) DeleteInstance(ctx context.Context, id string) error {
+	return m.deleteInstanceScoped(ctx, id, scope.Scope{})
+}
+
+// DeleteInstanceInScope removes a server, refusing (NotFound) when it exists
+// but was created under a different subscription/resource group. Implements
+// the optional rdsdriver.ScopedDelete capability so a cross-tenant DELETE
+// through the ARM handler can never remove another scope's server.
+func (m *Mock) DeleteInstanceInScope(ctx context.Context, id string, filter scope.Scope) error {
+	return m.deleteInstanceScoped(ctx, id, filter)
+}
+
+// deleteInstanceScoped performs the get-check-delete under a single lock
+// acquisition so the scope check and the delete are atomic. A zero filter
+// matches any scope (see scope.Scope.Matches), so DeleteInstance's unscoped
+// callers are unaffected.
+func (m *Mock) deleteInstanceScoped(ctx context.Context, id string, filter scope.Scope) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	inst, ok := m.instances.Get(id)
-	if !ok {
+	if !ok || !inst.Scope.Matches(filter) {
 		return cerrors.Newf(cerrors.NotFound, "MySQL Flexible Server %q not found", id)
 	}
 

--- a/providers/azure/mysqlflex/mysqlflex_test.go
+++ b/providers/azure/mysqlflex/mysqlflex_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
 
@@ -357,7 +358,10 @@ func TestFailoverRequiresRunning(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	if _, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "srv"}); err != nil {
+	if _, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{
+		ID:                   "srv",
+		HighAvailabilityMode: rdsdriver.HAModeZoneRedundant,
+	}); err != nil {
 		t.Fatalf("CreateInstance: %v", err)
 	}
 
@@ -375,6 +379,27 @@ func TestFailoverRequiresRunning(t *testing.T) {
 
 	if err := m.FailoverInstance(ctx, "ghost"); err == nil {
 		t.Error("FailoverInstance on missing server: expected NotFound")
+	}
+}
+
+// TestFailoverRequiresHighAvailability confirms a forced failover is rejected
+// on a running server with no standby (HighAvailability Disabled/unset) —
+// there is nothing to fail over to.
+func TestFailoverRequiresHighAvailability(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "no-ha"}); err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+
+	err := m.FailoverInstance(ctx, "no-ha")
+	if err == nil {
+		t.Fatal("FailoverInstance on server without HA: expected FailedPrecondition, got nil")
+	}
+
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Errorf("FailoverInstance on server without HA: got %v, want FailedPrecondition", err)
 	}
 }
 

--- a/providers/azure/mysqlflex/subresources.go
+++ b/providers/azure/mysqlflex/subresources.go
@@ -283,10 +283,11 @@ func (m *Mock) applyConfiguration(cfg rdsdriver.ConfigurationConfig) rdsdriver.C
 	conf, ok := m.configurations.Get(key)
 	if !ok {
 		conf = rdsdriver.Configuration{
-			Server:   cfg.Server,
-			Name:     cfg.Name,
-			DataType: "String",
-			ARN:      m.childARN(cfg.Server, "configurations", cfg.Name),
+			Server:       cfg.Server,
+			Name:         cfg.Name,
+			DataType:     "String",
+			DefaultValue: knownServerParameters[cfg.Name],
+			ARN:          m.childARN(cfg.Server, "configurations", cfg.Name),
 		}
 	}
 
@@ -371,12 +372,13 @@ func (m *Mock) GetConfiguration(_ context.Context, server, name string) (*rdsdri
 // defaultConfiguration builds the system-default view of a known parameter.
 func (m *Mock) defaultConfiguration(server, name, value string) *rdsdriver.Configuration {
 	return &rdsdriver.Configuration{
-		Server:   server,
-		Name:     name,
-		Value:    value,
-		Source:   "system-default",
-		DataType: "String",
-		ARN:      m.childARN(server, "configurations", name),
+		Server:       server,
+		Name:         name,
+		Value:        value,
+		Source:       "system-default",
+		DataType:     "String",
+		DefaultValue: value,
+		ARN:          m.childARN(server, "configurations", name),
 	}
 }
 
@@ -424,7 +426,9 @@ func (m *Mock) ListConfigurations(_ context.Context, server string) ([]rdsdriver
 // ---- Failover ----
 
 // FailoverInstance triggers a server failover to its standby. The server must
-// be running; it stays available afterwards.
+// be running and have an active standby (HighAvailability enabled) — real
+// Azure rejects a forced failover on a server with no standby to fail over to.
+// It stays available afterwards.
 func (m *Mock) FailoverInstance(_ context.Context, id string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -437,6 +441,11 @@ func (m *Mock) FailoverInstance(_ context.Context, id string) error {
 	if inst.State != rdsdriver.StateAvailable {
 		return cerrors.Newf(cerrors.FailedPrecondition,
 			"MySQL Flexible Server %q is in state %q; failover requires %q", id, inst.State, rdsdriver.StateAvailable)
+	}
+
+	if !rdsdriver.HAEnabled(inst.HighAvailabilityMode) {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"MySQL Flexible Server %q has no standby to fail over to; high availability is not enabled", id)
 	}
 
 	m.emitInstanceMetrics(id, cpuMetricRunning, connectionMetricValue, diskReadOpsRunning, diskWriteOpsRunning)

--- a/providers/azure/postgresflex/postgresflex.go
+++ b/providers/azure/postgresflex/postgresflex.go
@@ -26,6 +26,7 @@ import (
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	dbengine "github.com/stackshy/cloudemu/v2/services/relationaldb/dbengine"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const (
@@ -43,7 +44,10 @@ const (
 	connRunning        = 5.0
 )
 
-var _ rdsdriver.RelationalDB = (*Mock)(nil)
+var (
+	_ rdsdriver.RelationalDB = (*Mock)(nil)
+	_ rdsdriver.ScopedDelete = (*Mock)(nil)
+)
 
 // Mock is the in-memory Azure Postgres Flex implementation.
 type Mock struct {
@@ -234,6 +238,7 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		StandbyAvailabilityZone: cfg.StandbyAvailabilityZone,
 		CreatedAt:               m.opts.Clock.Now().UTC(),
 		Tags:                    copyTags(cfg.Tags),
+		Scope:                   cfg.Scope,
 	}
 }
 
@@ -355,11 +360,27 @@ func (m *Mock) ModifyInstance(
 
 // DeleteInstance removes a flexible server.
 func (m *Mock) DeleteInstance(ctx context.Context, id string) error {
+	return m.deleteInstanceScoped(ctx, id, scope.Scope{})
+}
+
+// DeleteInstanceInScope removes a flexible server, refusing (NotFound) when it
+// exists but was created under a different subscription/resource group.
+// Implements the optional rdsdriver.ScopedDelete capability so a cross-tenant
+// DELETE through the ARM handler can never remove another scope's server.
+func (m *Mock) DeleteInstanceInScope(ctx context.Context, id string, filter scope.Scope) error {
+	return m.deleteInstanceScoped(ctx, id, filter)
+}
+
+// deleteInstanceScoped performs the get-check-delete under a single lock
+// acquisition so the scope check and the delete are atomic. A zero filter
+// matches any scope (see scope.Scope.Matches), so DeleteInstance's unscoped
+// callers are unaffected.
+func (m *Mock) deleteInstanceScoped(ctx context.Context, id string, filter scope.Scope) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	inst, ok := m.instances.Get(id)
-	if !ok {
+	if !ok || !inst.Scope.Matches(filter) {
 		return cerrors.Newf(cerrors.NotFound, "Postgres Flex server %q not found", id)
 	}
 

--- a/server/azure/mysqlflex/operations.go
+++ b/server/azure/mysqlflex/operations.go
@@ -16,6 +16,30 @@ func requestScope(rp *azurearm.ResourcePath) scope.Scope {
 	return scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}
 }
 
+// lookupInScope resolves the server named in rp and verifies it lives in the
+// request's subscription/resource group before any by-name mutation. It writes
+// the wire error and returns false when the server is missing (WriteCErr) or
+// belongs to a different scope (404 ResourceNotFound), so a caller in one
+// resource group can never update, start, stop, restart, fail over, or reach
+// the sub-resources of another group's server. A server's Scope is fixed at
+// create time, so this check-then-act needs no extra lock.
+func (h *Handler) lookupInScope(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath,
+) (*rdsdriver.Instance, bool) {
+	insts, err := h.db.DescribeInstances(r.Context(), []string{rp.ResourceName})
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return nil, false
+	}
+
+	if len(insts) == 0 || !insts[0].Scope.Matches(requestScope(rp)) {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "server "+rp.ResourceName+" not found")
+		return nil, false
+	}
+
+	return &insts[0], true
+}
+
 // ---- Server lifecycle ----
 
 // rejectInvalidHAMode writes a 400 and returns true when the body carries a
@@ -83,16 +107,44 @@ func (h *Handler) createServer(w http.ResponseWriter, r *http.Request, rp *azure
 			return
 		}
 
-		// Idempotent PUT: a create against an existing server applies the body's
-		// storage/sku/version/HA rather than returning the stale record.
-		inst, err = h.db.ModifyInstance(r.Context(), rp.ResourceName, modifyInputFromBody(&body))
-		if err != nil {
-			azurearm.WriteCErr(w, err)
+		var ok bool
+		if inst, ok = h.upsertOnNameCollision(w, r, rp, &body); !ok {
 			return
 		}
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, toARMServer(inst, rp.Subscription, rp.ResourceGroup))
+}
+
+// upsertOnNameCollision resolves a PUT whose server name is already taken.
+// Flexible Server names are globally unique (they back a public FQDN), so a
+// same-name PUT from a different resource group is a naming conflict — mutating
+// the real owner's server would be a cross-tenant write. Only an in-scope
+// collision is a legitimate idempotent PUT that applies the body's
+// storage/sku/version/HA. It writes the wire error and returns false when the
+// caller must stop.
+func (h *Handler) upsertOnNameCollision(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, body *armServer,
+) (*rdsdriver.Instance, bool) {
+	existing, err := h.db.DescribeInstances(r.Context(), []string{rp.ResourceName})
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return nil, false
+	}
+
+	if len(existing) == 0 || !existing[0].Scope.Matches(requestScope(rp)) {
+		azurearm.WriteError(w, http.StatusConflict, "Conflict",
+			"server name "+rp.ResourceName+" is already in use")
+		return nil, false
+	}
+
+	inst, err := h.db.ModifyInstance(r.Context(), rp.ResourceName, modifyInputFromBody(body))
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return nil, false
+	}
+
+	return inst, true
 }
 
 // modifyInputFromBody maps a MySQL Flex server body to the portable modify
@@ -130,6 +182,10 @@ func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azure
 		return
 	}
 
+	if _, ok := h.lookupInScope(w, r, rp); !ok {
+		return
+	}
+
 	inst, err := h.db.ModifyInstance(r.Context(), rp.ResourceName, modifyInputFromBody(&body))
 	if err != nil {
 		azurearm.WriteCErr(w, err)
@@ -145,18 +201,12 @@ func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azure
 // under a different one in the URL (real ARM answers 404, since the id would
 // contradict the request path).
 func (h *Handler) getServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	insts, err := h.db.DescribeInstances(r.Context(), []string{rp.ResourceName})
-	if err != nil {
-		azurearm.WriteCErr(w, err)
+	inst, ok := h.lookupInScope(w, r, rp)
+	if !ok {
 		return
 	}
 
-	if len(insts) == 0 || !insts[0].Scope.Matches(requestScope(rp)) {
-		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "server "+rp.ResourceName+" not found")
-		return
-	}
-
-	azurearm.WriteJSON(w, http.StatusOK, toARMServer(&insts[0], rp.Subscription, rp.ResourceGroup))
+	azurearm.WriteJSON(w, http.StatusOK, toARMServer(inst, rp.Subscription, rp.ResourceGroup))
 }
 
 // deleteServer handles DELETE — Servers.Delete. When the backend implements
@@ -209,6 +259,10 @@ func (h *Handler) listServers(w http.ResponseWriter, r *http.Request, rp *azurea
 // ---- Action sub-resources ----
 
 func (h *Handler) startServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if _, ok := h.lookupInScope(w, r, rp); !ok {
+		return
+	}
+
 	if err := h.db.StartInstance(r.Context(), rp.ResourceName); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -218,6 +272,10 @@ func (h *Handler) startServer(w http.ResponseWriter, r *http.Request, rp *azurea
 }
 
 func (h *Handler) stopServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if _, ok := h.lookupInScope(w, r, rp); !ok {
+		return
+	}
+
 	if err := h.db.StopInstance(r.Context(), rp.ResourceName); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -239,6 +297,10 @@ const restartWithFailoverEnabled = "Enabled"
 func (h *Handler) restartServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body armServerRestartParameter
 	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	if _, ok := h.lookupInScope(w, r, rp); !ok {
 		return
 	}
 

--- a/server/azure/mysqlflex/operations.go
+++ b/server/azure/mysqlflex/operations.go
@@ -6,7 +6,15 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
+
+// requestScope builds the subscription/resource-group filter a server must
+// live in to be visible under rp's path — a MySQL Flexible Server created
+// under one resource group must not resolve, list, or delete under another.
+func requestScope(rp *azurearm.ResourcePath) scope.Scope {
+	return scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}
+}
 
 // ---- Server lifecycle ----
 
@@ -44,6 +52,7 @@ func (h *Handler) createServer(w http.ResponseWriter, r *http.Request, rp *azure
 		Engine:   "MySQL",
 		Location: body.Location,
 		Tags:     body.Tags,
+		Scope:    requestScope(rp),
 	}
 
 	if body.SKU != nil {
@@ -130,6 +139,11 @@ func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azure
 	azurearm.WriteJSON(w, http.StatusOK, toARMServer(inst, rp.Subscription, rp.ResourceGroup))
 }
 
+// getServer handles GET on a single server — Servers.Get. The driver keys
+// servers by name alone, so the handler enforces the request's resource-group
+// scope: a server created in one subscription/resource group must not resolve
+// under a different one in the URL (real ARM answers 404, since the id would
+// contradict the request path).
 func (h *Handler) getServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	insts, err := h.db.DescribeInstances(r.Context(), []string{rp.ResourceName})
 	if err != nil {
@@ -137,7 +151,7 @@ func (h *Handler) getServer(w http.ResponseWriter, r *http.Request, rp *azurearm
 		return
 	}
 
-	if len(insts) == 0 {
+	if len(insts) == 0 || !insts[0].Scope.Matches(requestScope(rp)) {
 		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "server "+rp.ResourceName+" not found")
 		return
 	}
@@ -145,8 +159,20 @@ func (h *Handler) getServer(w http.ResponseWriter, r *http.Request, rp *azurearm
 	azurearm.WriteJSON(w, http.StatusOK, toARMServer(&insts[0], rp.Subscription, rp.ResourceGroup))
 }
 
+// deleteServer handles DELETE — Servers.Delete. When the backend implements
+// ScopedDelete (MySQL Flex always does), the scope check and the delete happen
+// atomically so a cross-tenant DELETE can never remove another resource
+// group's server; otherwise DeleteInstance runs unscoped.
 func (h *Handler) deleteServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	if err := h.db.DeleteInstance(r.Context(), rp.ResourceName); err != nil {
+	var err error
+
+	if sd, ok := h.db.(rdsdriver.ScopedDelete); ok {
+		err = sd.DeleteInstanceInScope(r.Context(), rp.ResourceName, requestScope(rp))
+	} else {
+		err = h.db.DeleteInstance(r.Context(), rp.ResourceName)
+	}
+
+	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
@@ -154,6 +180,10 @@ func (h *Handler) deleteServer(w http.ResponseWriter, r *http.Request, rp *azure
 	w.WriteHeader(http.StatusOK)
 }
 
+// listServers handles GET on the collection — Servers.ListByResourceGroup /
+// ListBySubscription. The filter carries the path's subscription and, for
+// RG-level lists, its resource group; subscription-level lists leave the
+// resource group empty so the filter spans the subscription's groups.
 func (h *Handler) listServers(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	insts, err := h.db.DescribeInstances(r.Context(), nil)
 	if err != nil {
@@ -161,8 +191,15 @@ func (h *Handler) listServers(w http.ResponseWriter, r *http.Request, rp *azurea
 		return
 	}
 
+	filter := requestScope(rp)
+
 	out := make([]armServer, 0, len(insts))
+
 	for i := range insts {
+		if !insts[i].Scope.Matches(filter) {
+			continue
+		}
+
 		out = append(out, toARMServer(&insts[i], rp.Subscription, rp.ResourceGroup))
 	}
 
@@ -189,7 +226,39 @@ func (h *Handler) stopServer(w http.ResponseWriter, r *http.Request, rp *azurear
 	h.respondWithServer(w, r, rp)
 }
 
+// restartWithFailoverEnabled is the ServerRestartParameter.restartWithFailover
+// EnableStatusEnum value that routes a restart through failover to the
+// standby instead of a plain in-place restart.
+const restartWithFailoverEnabled = "Enabled"
+
+// restartServer handles POST .../restart — Servers.BeginRestart. The request
+// body is a ServerRestartParameter: restartWithFailover=="Enabled" routes the
+// restart through FailoverInstance (so it inherits the standby precondition)
+// instead of a plain in-place reboot; maxFailoverSeconds bounds the SDK
+// poller's wait and is accepted without further effect on the synchronous mock.
 func (h *Handler) restartServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body armServerRestartParameter
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	if body.RestartWithFailover == restartWithFailoverEnabled {
+		fo, ok := h.failoverCap()
+		if !ok {
+			writeUnsupported(w, "restartWithFailover")
+			return
+		}
+
+		if err := fo.FailoverInstance(r.Context(), rp.ResourceName); err != nil {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+
+		h.respondWithServer(w, r, rp)
+
+		return
+	}
+
 	if err := h.db.RebootInstance(r.Context(), rp.ResourceName); err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/mysqlflex/scope_sdk_test.go
+++ b/server/azure/mysqlflex/scope_sdk_test.go
@@ -1,0 +1,111 @@
+package mysqlflex_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers"
+)
+
+// mustCreateServerInRG creates a bare server under the given resource group.
+func mustCreateServerInRG(t *testing.T, cf *armmysqlflexibleservers.ClientFactory, rg, name string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	poller, err := cf.NewServersClient().BeginCreate(ctx, rg, name, armmysqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate %s/%s: %v", rg, name, err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Create PollUntilDone %s/%s: %v", rg, name, err)
+	}
+}
+
+// TestSDKMySQLFlexScopedListing asserts a server created in one resource
+// group must not appear when listing a different resource group.
+func TestSDKMySQLFlexScopedListing(t *testing.T) {
+	cf := newFactory(t)
+	mustCreateServerInRG(t, cf, "rg-team-a", "srv-a1")
+	mustCreateServerInRG(t, cf, "rg-team-a", "srv-a2")
+	mustCreateServerInRG(t, cf, "rg-team-b", "srv-b1")
+
+	ctx := context.Background()
+	servers := cf.NewServersClient()
+
+	listRG := func(rg string) []string {
+		var names []string
+
+		pager := servers.NewListByResourceGroupPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+
+			for _, s := range page.Value {
+				names = append(names, *s.Name)
+			}
+		}
+
+		return names
+	}
+
+	gotA := listRG("rg-team-a")
+	if len(gotA) != 2 {
+		t.Fatalf("rg-team-a listed %v, want exactly its own 2 servers", gotA)
+	}
+
+	gotB := listRG("rg-team-b")
+	if len(gotB) != 1 || gotB[0] != "srv-b1" {
+		t.Fatalf("rg-team-b listed %v, want [srv-b1]", gotB)
+	}
+}
+
+// TestSDKMySQLFlexScopedGetNotFound asserts a server created under one
+// resource group cannot be resolved via Get under a different resource group
+// (real ARM answers 404, since the id would contradict the request path).
+func TestSDKMySQLFlexScopedGetNotFound(t *testing.T) {
+	cf := newFactory(t)
+	mustCreateServerInRG(t, cf, "rg-team-a", "srv-a1")
+
+	ctx := context.Background()
+	servers := cf.NewServersClient()
+
+	if _, err := servers.Get(ctx, "rg-team-a", "srv-a1", nil); err != nil {
+		t.Fatalf("Get in owning resource group: %v", err)
+	}
+
+	if _, err := servers.Get(ctx, "rg-team-b", "srv-a1", nil); err == nil {
+		t.Fatal("Get from a different resource group: expected NotFound, got nil")
+	}
+}
+
+// TestSDKMySQLFlexScopedDeleteNotFound asserts a DELETE issued under the
+// wrong resource group cannot remove another resource group's server —
+// the cross-tenant leak this behavior guards against.
+func TestSDKMySQLFlexScopedDeleteNotFound(t *testing.T) {
+	cf := newFactory(t)
+	mustCreateServerInRG(t, cf, "rg-team-a", "srv-a1")
+
+	ctx := context.Background()
+	servers := cf.NewServersClient()
+
+	poller, err := servers.BeginDelete(ctx, "rg-team-b", "srv-a1", nil)
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("Delete from a different resource group: expected an error, got nil")
+	}
+
+	// The server must still exist, untouched, under its real resource group.
+	if _, err := servers.Get(ctx, "rg-team-a", "srv-a1", nil); err != nil {
+		t.Fatalf("Get after cross-group delete attempt: %v", err)
+	}
+}

--- a/server/azure/mysqlflex/scope_sdk_test.go
+++ b/server/azure/mysqlflex/scope_sdk_test.go
@@ -109,3 +109,127 @@ func TestSDKMySQLFlexScopedDeleteNotFound(t *testing.T) {
 		t.Fatalf("Get after cross-group delete attempt: %v", err)
 	}
 }
+
+func skuName(s *armmysqlflexibleservers.Server) string {
+	if s == nil || s.SKU == nil || s.SKU.Name == nil {
+		return ""
+	}
+
+	return *s.SKU.Name
+}
+
+// TestSDKMySQLFlexScopedUpdateNotFound asserts a PATCH issued under the wrong
+// resource group cannot mutate another resource group's server (the SKU/storage
+// cross-tenant write) — it must 404 and leave the real server untouched.
+func TestSDKMySQLFlexScopedUpdateNotFound(t *testing.T) {
+	cf := newFactory(t)
+	mustCreateServerInRG(t, cf, "rg-team-a", "srv-a1")
+
+	ctx := context.Background()
+	servers := cf.NewServersClient()
+
+	before, err := servers.Get(ctx, "rg-team-a", "srv-a1", nil)
+	if err != nil {
+		t.Fatalf("Get before: %v", err)
+	}
+
+	origSKU := skuName(&before.Server)
+
+	poller, err := servers.BeginUpdate(ctx, "rg-team-b", "srv-a1", armmysqlflexibleservers.ServerForUpdate{
+		SKU: &armmysqlflexibleservers.SKU{Name: to.Ptr("Standard_D8ds_v4")},
+	}, nil)
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("Update from a different resource group: expected an error, got nil")
+	}
+
+	after, err := servers.Get(ctx, "rg-team-a", "srv-a1", nil)
+	if err != nil {
+		t.Fatalf("Get after: %v", err)
+	}
+
+	if got := skuName(&after.Server); got != origSKU {
+		t.Fatalf("cross-group update mutated the owner's SKU: %q -> %q", origSKU, got)
+	}
+}
+
+// TestSDKMySQLFlexCrossGroupCreateConflict asserts a same-name PUT from a
+// different resource group conflicts (Flex names are globally FQDN-unique)
+// rather than silently mutating the real owner's server.
+func TestSDKMySQLFlexCrossGroupCreateConflict(t *testing.T) {
+	cf := newFactory(t)
+	ctx := context.Background()
+	servers := cf.NewServersClient()
+
+	poller, err := servers.BeginCreate(ctx, "rg-team-a", "srv1", armmysqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+		SKU:      &armmysqlflexibleservers.SKU{Name: to.Ptr("Standard_B1ms")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate rg-team-a: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Create rg-team-a: %v", err)
+	}
+
+	poller2, err := servers.BeginCreate(ctx, "rg-team-b", "srv1", armmysqlflexibleservers.Server{
+		Location: to.Ptr("westus"),
+		SKU:      &armmysqlflexibleservers.SKU{Name: to.Ptr("Standard_D8ds_v4")},
+	}, nil)
+	if err == nil {
+		_, err = poller2.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("cross-group same-name create: expected a conflict, got nil")
+	}
+
+	got, err := servers.Get(ctx, "rg-team-a", "srv1", nil)
+	if err != nil {
+		t.Fatalf("Get rg-team-a after conflict: %v", err)
+	}
+
+	if name := skuName(&got.Server); name != "Standard_B1ms" {
+		t.Fatalf("cross-group create mutated the owner's SKU, got %q", name)
+	}
+
+	if _, err := servers.Get(ctx, "rg-team-b", "srv1", nil); err == nil {
+		t.Fatal("server must not exist under rg-team-b after a rejected create")
+	}
+}
+
+// TestSDKMySQLFlexScopedStartStopNotFound asserts start/stop issued under the
+// wrong resource group cannot act on another resource group's server.
+func TestSDKMySQLFlexScopedStartStopNotFound(t *testing.T) {
+	cf := newFactory(t)
+	mustCreateServerInRG(t, cf, "rg-team-a", "srv-a1")
+
+	ctx := context.Background()
+	servers := cf.NewServersClient()
+
+	stopP, err := servers.BeginStop(ctx, "rg-team-b", "srv-a1", nil)
+	if err == nil {
+		_, err = stopP.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("Stop from a different resource group: expected an error, got nil")
+	}
+
+	startP, err := servers.BeginStart(ctx, "rg-team-b", "srv-a1", nil)
+	if err == nil {
+		_, err = startP.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("Start from a different resource group: expected an error, got nil")
+	}
+
+	if _, err := servers.Get(ctx, "rg-team-a", "srv-a1", nil); err != nil {
+		t.Fatalf("Get after cross-group start/stop attempt: %v", err)
+	}
+}

--- a/server/azure/mysqlflex/sdk_roundtrip_test.go
+++ b/server/azure/mysqlflex/sdk_roundtrip_test.go
@@ -234,6 +234,54 @@ func TestSDKMySQLFlexStartStopRestart(t *testing.T) {
 	}
 }
 
+// TestSDKMySQLFlexRestartWithFailover asserts BeginRestart honors the request
+// body's restartWithFailover: on an HA server it routes through failover
+// (inheriting its precondition), and on a non-HA server it is rejected rather
+// than silently performing a plain restart.
+func TestSDKMySQLFlexRestartWithFailover(t *testing.T) {
+	cf := newFactory(t)
+	mustCreateHAServer(t, cf, "ha-restart")
+
+	ctx := context.Background()
+	servers := cf.NewServersClient()
+
+	restartPoller, err := servers.BeginRestart(ctx, "rg-1", "ha-restart", armmysqlflexibleservers.ServerRestartParameter{
+		RestartWithFailover: to.Ptr(armmysqlflexibleservers.EnableStatusEnumEnabled),
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginRestart(restartWithFailover=Enabled): %v", err)
+	}
+
+	if _, err := restartPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Restart(restartWithFailover) PollUntilDone: %v", err)
+	}
+
+	got, err := servers.Get(ctx, "rg-1", "ha-restart", nil)
+	if err != nil {
+		t.Fatalf("Get after restart: %v", err)
+	}
+
+	if got.Server.Properties == nil || got.Server.Properties.State == nil ||
+		*got.Server.Properties.State != armmysqlflexibleservers.ServerStateReady {
+		t.Fatalf("expected state Ready after restart with failover, got %v", got.Server.Properties.State)
+	}
+
+	// A non-HA server has no standby: restartWithFailover=Enabled must fail
+	// rather than silently degrade into a plain restart.
+	mustCreateServer(t, cf) // creates "srv1" with no HighAvailability
+
+	noHAPoller, err := servers.BeginRestart(ctx, "rg-1", "srv1", armmysqlflexibleservers.ServerRestartParameter{
+		RestartWithFailover: to.Ptr(armmysqlflexibleservers.EnableStatusEnumEnabled),
+	}, nil)
+	if err == nil {
+		_, err = noHAPoller.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("expected restartWithFailover on a non-HA server to fail, got nil")
+	}
+}
+
 func TestSDKMySQLFlexHighAvailability(t *testing.T) {
 	servers := newSDKClient(t)
 	ctx := context.Background()

--- a/server/azure/mysqlflex/subresources.go
+++ b/server/azure/mysqlflex/subresources.go
@@ -93,6 +93,10 @@ func (h *Handler) serveDatabase(w http.ResponseWriter, r *http.Request, rp *azur
 		return
 	}
 
+	if _, ok := h.lookupInScope(w, r, rp); !ok {
+		return
+	}
+
 	if rp.SubResourceName == "" {
 		if r.Method != http.MethodGet {
 			writeMethodNotAllowed(w)
@@ -197,6 +201,10 @@ func (h *Handler) serveFirewallRule(w http.ResponseWriter, r *http.Request, rp *
 	fw, ok := h.firewallRules()
 	if !ok {
 		writeUnsupported(w, "firewallRules")
+		return
+	}
+
+	if _, ok := h.lookupInScope(w, r, rp); !ok {
 		return
 	}
 
@@ -308,6 +316,10 @@ func (h *Handler) serveConfiguration(w http.ResponseWriter, r *http.Request, rp 
 		return
 	}
 
+	if _, ok := h.lookupInScope(w, r, rp); !ok {
+		return
+	}
+
 	if rp.SubResourceName == "" {
 		if r.Method != http.MethodGet {
 			writeMethodNotAllowed(w)
@@ -389,6 +401,10 @@ func (h *Handler) batchUpdateConfigurations(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	if _, inScope := h.lookupInScope(w, r, rp); !inScope {
+		return
+	}
+
 	var body armConfigBatch
 	if !azurearm.DecodeJSON(w, r, &body) {
 		return
@@ -454,6 +470,10 @@ func toARMConfiguration(c *rdsdriver.Configuration, rp *azurearm.ResourcePath) a
 // ---- Failover ----
 
 func (h *Handler) failoverServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if _, ok := h.lookupInScope(w, r, rp); !ok {
+		return
+	}
+
 	fo, ok := h.failoverCap()
 	if !ok {
 		writeUnsupported(w, "failover")

--- a/server/azure/mysqlflex/subresources_sdk_test.go
+++ b/server/azure/mysqlflex/subresources_sdk_test.go
@@ -164,6 +164,23 @@ func TestSDKMySQLFlexConfigurations(t *testing.T) {
 		t.Fatalf("value: got %v, want 200", got.Properties)
 	}
 
+	// DefaultValue must be populated (the catalog default), not just Value —
+	// a real client relies on it to know what "reset" restores.
+	if got.Properties.DefaultValue == nil || *got.Properties.DefaultValue != "151" {
+		t.Errorf("max_connections defaultValue: got %v, want 151", got.Properties.DefaultValue)
+	}
+
+	// An untouched known parameter's Get must also carry its DefaultValue.
+	untouched, err := conf.Get(ctx, "rg-1", "srv1", "wait_timeout", nil)
+	if err != nil {
+		t.Fatalf("Get wait_timeout: %v", err)
+	}
+
+	if untouched.Properties == nil || untouched.Properties.DefaultValue == nil ||
+		*untouched.Properties.DefaultValue != "28800" {
+		t.Errorf("wait_timeout defaultValue: got %v, want 28800", untouched.Properties)
+	}
+
 	batchPoller, err := conf.BeginBatchUpdate(ctx, "rg-1", "srv1", armmysqlflexibleservers.ConfigurationListForBatchUpdate{
 		Value: []*armmysqlflexibleservers.ConfigurationForBatchUpdate{
 			{Name: to.Ptr("slow_query_log"), Properties: &armmysqlflexibleservers.ConfigurationForBatchUpdateProperties{
@@ -208,9 +225,34 @@ func TestSDKMySQLFlexConfigurations(t *testing.T) {
 	}
 }
 
+// mustCreateHAServer creates a server with ZoneRedundant HighAvailability —
+// the precondition a forced failover needs (there is a standby to fail over
+// to).
+func mustCreateHAServer(t *testing.T, cf *armmysqlflexibleservers.ClientFactory, name string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	poller, err := cf.NewServersClient().BeginCreate(ctx, "rg-1", name, armmysqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+		Properties: &armmysqlflexibleservers.ServerProperties{
+			HighAvailability: &armmysqlflexibleservers.HighAvailability{
+				Mode: to.Ptr(armmysqlflexibleservers.HighAvailabilityModeZoneRedundant),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Create PollUntilDone: %v", err)
+	}
+}
+
 func TestSDKMySQLFlexFailover(t *testing.T) {
 	cf := newFactory(t)
-	mustCreateServer(t, cf)
+	mustCreateHAServer(t, cf, "srv1")
 
 	ctx := context.Background()
 	servers := cf.NewServersClient()
@@ -232,5 +274,25 @@ func TestSDKMySQLFlexFailover(t *testing.T) {
 	if got.Server.Properties == nil || got.Server.Properties.State == nil ||
 		*got.Server.Properties.State != armmysqlflexibleservers.ServerStateReady {
 		t.Fatalf("expected Ready after failover, got %v", got.Server.Properties.State)
+	}
+}
+
+// TestSDKMySQLFlexFailoverRequiresHighAvailability asserts real Azure's
+// behavior: a forced failover on a server with HighAvailability Disabled (no
+// standby) is rejected rather than silently succeeding.
+func TestSDKMySQLFlexFailoverRequiresHighAvailability(t *testing.T) {
+	cf := newFactory(t)
+	mustCreateServer(t, cf) // no HighAvailability configured
+
+	ctx := context.Background()
+	servers := cf.NewServersClient()
+
+	poller, err := servers.BeginFailover(ctx, "rg-1", "srv1", nil)
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("expected failover on a non-HA server to fail, got nil")
 	}
 }

--- a/server/azure/mysqlflex/types.go
+++ b/server/azure/mysqlflex/types.go
@@ -51,6 +51,16 @@ type armHighAvailability struct {
 	State                   string `json:"state,omitempty"`
 }
 
+// armServerRestartParameter is the ServerRestartParameter request body for
+// POST .../restart. RestartWithFailover is the EnableStatusEnum
+// "Enabled"/"Disabled"; MaxFailoverSeconds bounds how long the SDK's poller is
+// willing to wait for that failover — the mock's failover is synchronous, so
+// it is accepted but not otherwise consulted.
+type armServerRestartParameter struct {
+	RestartWithFailover string `json:"restartWithFailover,omitempty"`
+	MaxFailoverSeconds  int    `json:"maxFailoverSeconds,omitempty"`
+}
+
 type armStorage struct {
 	StorageSizeGB int    `json:"storageSizeGB,omitempty"`
 	StorageSKU    string `json:"storageSku,omitempty"`

--- a/server/azure/postgresflex/operations.go
+++ b/server/azure/postgresflex/operations.go
@@ -6,7 +6,15 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
+
+// requestScope builds the subscription/resource-group filter a server must
+// live in to be visible under rp's path — a Postgres Flexible Server created
+// under one resource group must not resolve, list, or delete under another.
+func requestScope(rp *azurearm.ResourcePath) scope.Scope {
+	return scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}
+}
 
 // rejectInvalidHAMode writes a 400 and returns true when the body carries a
 // highAvailability.mode that is not a recognized enum value — real Azure
@@ -29,11 +37,12 @@ func rejectInvalidHAMode(w http.ResponseWriter, body *armServer) bool {
 
 // instanceFromBody decodes a Postgres Flex create/update body and converts it
 // to the portable driver shape.
-func instanceFromBody(body *armServer) rdsdriver.InstanceConfig {
+func instanceFromBody(body *armServer, rp *azurearm.ResourcePath) rdsdriver.InstanceConfig {
 	cfg := rdsdriver.InstanceConfig{
 		Engine:   "Postgres",
 		Location: body.Location,
 		Tags:     body.Tags,
+		Scope:    requestScope(rp),
 	}
 
 	if body.SKU != nil {
@@ -75,7 +84,7 @@ func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
-	cfg := instanceFromBody(&body)
+	cfg := instanceFromBody(&body, rp)
 	cfg.ID = rp.ResourceName
 
 	inst, err := h.db.CreateInstance(r.Context(), cfg)
@@ -161,6 +170,11 @@ func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azure
 	azurearm.WriteJSON(w, http.StatusOK, toARMServer(inst, rp.Subscription, rp.ResourceGroup))
 }
 
+// getServer handles GET on a single server — Servers.Get. The driver keys
+// servers by name alone, so the handler enforces the request's resource-group
+// scope: a server created in one subscription/resource group must not resolve
+// under a different one in the URL (real ARM answers 404, since the id would
+// contradict the request path).
 func (h *Handler) getServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	insts, err := h.db.DescribeInstances(r.Context(), []string{rp.ResourceName})
 	if err != nil {
@@ -168,7 +182,7 @@ func (h *Handler) getServer(w http.ResponseWriter, r *http.Request, rp *azurearm
 		return
 	}
 
-	if len(insts) == 0 {
+	if len(insts) == 0 || !insts[0].Scope.Matches(requestScope(rp)) {
 		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "server "+rp.ResourceName+" not found")
 		return
 	}
@@ -176,8 +190,20 @@ func (h *Handler) getServer(w http.ResponseWriter, r *http.Request, rp *azurearm
 	azurearm.WriteJSON(w, http.StatusOK, toARMServer(&insts[0], rp.Subscription, rp.ResourceGroup))
 }
 
+// deleteServer handles DELETE — Servers.Delete. When the backend implements
+// ScopedDelete (Postgres Flex always does), the scope check and the delete
+// happen atomically so a cross-tenant DELETE can never remove another
+// resource group's server; otherwise DeleteInstance runs unscoped.
 func (h *Handler) deleteServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	if err := h.db.DeleteInstance(r.Context(), rp.ResourceName); err != nil {
+	var err error
+
+	if sd, ok := h.db.(rdsdriver.ScopedDelete); ok {
+		err = sd.DeleteInstanceInScope(r.Context(), rp.ResourceName, requestScope(rp))
+	} else {
+		err = h.db.DeleteInstance(r.Context(), rp.ResourceName)
+	}
+
+	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
@@ -185,6 +211,10 @@ func (h *Handler) deleteServer(w http.ResponseWriter, r *http.Request, rp *azure
 	w.WriteHeader(http.StatusOK)
 }
 
+// listServers handles GET on the collection — Servers.ListByResourceGroup /
+// ListBySubscription. The filter carries the path's subscription and, for
+// RG-level lists, its resource group; subscription-level lists leave the
+// resource group empty so the filter spans the subscription's groups.
 func (h *Handler) listServers(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	insts, err := h.db.DescribeInstances(r.Context(), nil)
 	if err != nil {
@@ -192,8 +222,15 @@ func (h *Handler) listServers(w http.ResponseWriter, r *http.Request, rp *azurea
 		return
 	}
 
+	filter := requestScope(rp)
+
 	out := make([]armServer, 0, len(insts))
+
 	for i := range insts {
+		if !insts[i].Scope.Matches(filter) {
+			continue
+		}
+
 		out = append(out, toARMServer(&insts[i], rp.Subscription, rp.ResourceGroup))
 	}
 

--- a/server/azure/postgresflex/operations.go
+++ b/server/azure/postgresflex/operations.go
@@ -16,6 +16,30 @@ func requestScope(rp *azurearm.ResourcePath) scope.Scope {
 	return scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}
 }
 
+// lookupInScope resolves the server named in rp and verifies it lives in the
+// request's subscription/resource group before any by-name mutation. It writes
+// the wire error and returns false when the server is missing (WriteCErr) or
+// belongs to a different scope (404 ResourceNotFound), so a caller in one
+// resource group can never update, start, stop, restart, or reach the
+// sub-resources of another group's server. A server's Scope is fixed at create
+// time, so this check-then-act needs no extra lock.
+func (h *Handler) lookupInScope(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath,
+) (*rdsdriver.Instance, bool) {
+	insts, err := h.db.DescribeInstances(r.Context(), []string{rp.ResourceName})
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return nil, false
+	}
+
+	if len(insts) == 0 || !insts[0].Scope.Matches(requestScope(rp)) {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "server "+rp.ResourceName+" not found")
+		return nil, false
+	}
+
+	return &insts[0], true
+}
+
 // rejectInvalidHAMode writes a 400 and returns true when the body carries a
 // highAvailability.mode that is not a recognized enum value — real Azure
 // rejects a bogus mode rather than storing it.
@@ -94,16 +118,44 @@ func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, r
 			return
 		}
 
-		// Idempotent PUT: a create against an existing server applies the body's
-		// storage/sku/version/HA rather than returning the stale record.
-		inst, err = h.db.ModifyInstance(r.Context(), rp.ResourceName, modifyInputFromBody(&body))
-		if err != nil {
-			azurearm.WriteCErr(w, err)
+		var ok bool
+		if inst, ok = h.upsertOnNameCollision(w, r, rp, &body); !ok {
 			return
 		}
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, toARMServer(inst, rp.Subscription, rp.ResourceGroup))
+}
+
+// upsertOnNameCollision resolves a PUT whose server name is already taken.
+// Flexible Server names are globally unique (they back a public FQDN), so a
+// same-name PUT from a different resource group is a naming conflict — mutating
+// the real owner's server would be a cross-tenant write. Only an in-scope
+// collision is a legitimate idempotent PUT that applies the body's
+// storage/sku/version/HA. It writes the wire error and returns false when the
+// caller must stop.
+func (h *Handler) upsertOnNameCollision(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, body *armServer,
+) (*rdsdriver.Instance, bool) {
+	existing, err := h.db.DescribeInstances(r.Context(), []string{rp.ResourceName})
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return nil, false
+	}
+
+	if len(existing) == 0 || !existing[0].Scope.Matches(requestScope(rp)) {
+		azurearm.WriteError(w, http.StatusConflict, "Conflict",
+			"server name "+rp.ResourceName+" is already in use")
+		return nil, false
+	}
+
+	inst, err := h.db.ModifyInstance(r.Context(), rp.ResourceName, modifyInputFromBody(body))
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return nil, false
+	}
+
+	return inst, true
 }
 
 // modifyInputFromBody maps a Postgres Flex server body to the portable modify
@@ -161,6 +213,10 @@ func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azure
 		return
 	}
 
+	if _, ok := h.lookupInScope(w, r, rp); !ok {
+		return
+	}
+
 	inst, err := h.db.ModifyInstance(r.Context(), rp.ResourceName, modifyInputFromBody(&body))
 	if err != nil {
 		azurearm.WriteCErr(w, err)
@@ -176,18 +232,12 @@ func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azure
 // under a different one in the URL (real ARM answers 404, since the id would
 // contradict the request path).
 func (h *Handler) getServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	insts, err := h.db.DescribeInstances(r.Context(), []string{rp.ResourceName})
-	if err != nil {
-		azurearm.WriteCErr(w, err)
+	inst, ok := h.lookupInScope(w, r, rp)
+	if !ok {
 		return
 	}
 
-	if len(insts) == 0 || !insts[0].Scope.Matches(requestScope(rp)) {
-		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "server "+rp.ResourceName+" not found")
-		return
-	}
-
-	azurearm.WriteJSON(w, http.StatusOK, toARMServer(&insts[0], rp.Subscription, rp.ResourceGroup))
+	azurearm.WriteJSON(w, http.StatusOK, toARMServer(inst, rp.Subscription, rp.ResourceGroup))
 }
 
 // deleteServer handles DELETE — Servers.Delete. When the backend implements
@@ -238,6 +288,10 @@ func (h *Handler) listServers(w http.ResponseWriter, r *http.Request, rp *azurea
 }
 
 func (h *Handler) startServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if _, ok := h.lookupInScope(w, r, rp); !ok {
+		return
+	}
+
 	if err := h.db.StartInstance(r.Context(), rp.ResourceName); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -247,6 +301,10 @@ func (h *Handler) startServer(w http.ResponseWriter, r *http.Request, rp *azurea
 }
 
 func (h *Handler) stopServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if _, ok := h.lookupInScope(w, r, rp); !ok {
+		return
+	}
+
 	if err := h.db.StopInstance(r.Context(), rp.ResourceName); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -256,6 +314,10 @@ func (h *Handler) stopServer(w http.ResponseWriter, r *http.Request, rp *azurear
 }
 
 func (h *Handler) restartServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if _, ok := h.lookupInScope(w, r, rp); !ok {
+		return
+	}
+
 	if err := h.db.RebootInstance(r.Context(), rp.ResourceName); err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/postgresflex/scope_sdk_test.go
+++ b/server/azure/postgresflex/scope_sdk_test.go
@@ -1,0 +1,108 @@
+package postgresflex_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers"
+)
+
+// mustCreateServerInRG creates a bare server under the given resource group.
+func mustCreateServerInRG(t *testing.T, servers *armpostgresqlflexibleservers.ServersClient, rg, name string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	poller, err := servers.BeginCreate(ctx, rg, name, armpostgresqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate %s/%s: %v", rg, name, err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Create PollUntilDone %s/%s: %v", rg, name, err)
+	}
+}
+
+// TestSDKPostgresFlexScopedListing asserts a server created in one resource
+// group must not appear when listing a different resource group.
+func TestSDKPostgresFlexScopedListing(t *testing.T) {
+	servers := newSDKClient(t)
+	mustCreateServerInRG(t, servers, "rg-team-a", "srv-a1")
+	mustCreateServerInRG(t, servers, "rg-team-a", "srv-a2")
+	mustCreateServerInRG(t, servers, "rg-team-b", "srv-b1")
+
+	ctx := context.Background()
+
+	listRG := func(rg string) []string {
+		var names []string
+
+		pager := servers.NewListByResourceGroupPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+
+			for _, s := range page.Value {
+				names = append(names, *s.Name)
+			}
+		}
+
+		return names
+	}
+
+	gotA := listRG("rg-team-a")
+	if len(gotA) != 2 {
+		t.Fatalf("rg-team-a listed %v, want exactly its own 2 servers", gotA)
+	}
+
+	gotB := listRG("rg-team-b")
+	if len(gotB) != 1 || gotB[0] != "srv-b1" {
+		t.Fatalf("rg-team-b listed %v, want [srv-b1]", gotB)
+	}
+}
+
+// TestSDKPostgresFlexScopedGetNotFound asserts a server created under one
+// resource group cannot be resolved via Get under a different resource group
+// (real ARM answers 404, since the id would contradict the request path).
+func TestSDKPostgresFlexScopedGetNotFound(t *testing.T) {
+	servers := newSDKClient(t)
+	mustCreateServerInRG(t, servers, "rg-team-a", "srv-a1")
+
+	ctx := context.Background()
+
+	if _, err := servers.Get(ctx, "rg-team-a", "srv-a1", nil); err != nil {
+		t.Fatalf("Get in owning resource group: %v", err)
+	}
+
+	if _, err := servers.Get(ctx, "rg-team-b", "srv-a1", nil); err == nil {
+		t.Fatal("Get from a different resource group: expected NotFound, got nil")
+	}
+}
+
+// TestSDKPostgresFlexScopedDeleteNotFound asserts a DELETE issued under the
+// wrong resource group cannot remove another resource group's server — the
+// cross-tenant leak this behavior guards against.
+func TestSDKPostgresFlexScopedDeleteNotFound(t *testing.T) {
+	servers := newSDKClient(t)
+	mustCreateServerInRG(t, servers, "rg-team-a", "srv-a1")
+
+	ctx := context.Background()
+
+	poller, err := servers.BeginDelete(ctx, "rg-team-b", "srv-a1", nil)
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("Delete from a different resource group: expected an error, got nil")
+	}
+
+	// The server must still exist, untouched, under its real resource group.
+	if _, err := servers.Get(ctx, "rg-team-a", "srv-a1", nil); err != nil {
+		t.Fatalf("Get after cross-group delete attempt: %v", err)
+	}
+}

--- a/server/azure/postgresflex/scope_sdk_test.go
+++ b/server/azure/postgresflex/scope_sdk_test.go
@@ -106,3 +106,124 @@ func TestSDKPostgresFlexScopedDeleteNotFound(t *testing.T) {
 		t.Fatalf("Get after cross-group delete attempt: %v", err)
 	}
 }
+
+func skuName(s *armpostgresqlflexibleservers.Server) string {
+	if s == nil || s.SKU == nil || s.SKU.Name == nil {
+		return ""
+	}
+
+	return *s.SKU.Name
+}
+
+// TestSDKPostgresFlexScopedUpdateNotFound asserts a PATCH issued under the wrong
+// resource group cannot mutate another resource group's server (the SKU/storage
+// cross-tenant write) — it must 404 and leave the real server untouched.
+func TestSDKPostgresFlexScopedUpdateNotFound(t *testing.T) {
+	servers := newSDKClient(t)
+	mustCreateServerInRG(t, servers, "rg-team-a", "srv-a1")
+
+	ctx := context.Background()
+
+	before, err := servers.Get(ctx, "rg-team-a", "srv-a1", nil)
+	if err != nil {
+		t.Fatalf("Get before: %v", err)
+	}
+
+	origSKU := skuName(&before.Server)
+
+	poller, err := servers.BeginUpdate(ctx, "rg-team-b", "srv-a1", armpostgresqlflexibleservers.ServerForUpdate{
+		SKU: &armpostgresqlflexibleservers.SKU{Name: to.Ptr("Standard_D8s_v3")},
+	}, nil)
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("Update from a different resource group: expected an error, got nil")
+	}
+
+	after, err := servers.Get(ctx, "rg-team-a", "srv-a1", nil)
+	if err != nil {
+		t.Fatalf("Get after: %v", err)
+	}
+
+	if got := skuName(&after.Server); got != origSKU {
+		t.Fatalf("cross-group update mutated the owner's SKU: %q -> %q", origSKU, got)
+	}
+}
+
+// TestSDKPostgresFlexCrossGroupCreateConflict asserts a same-name PUT from a
+// different resource group conflicts (Flex names are globally FQDN-unique)
+// rather than silently mutating the real owner's server.
+func TestSDKPostgresFlexCrossGroupCreateConflict(t *testing.T) {
+	servers := newSDKClient(t)
+	ctx := context.Background()
+
+	poller, err := servers.BeginCreate(ctx, "rg-team-a", "srv1", armpostgresqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+		SKU:      &armpostgresqlflexibleservers.SKU{Name: to.Ptr("Standard_B1ms")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate rg-team-a: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Create rg-team-a: %v", err)
+	}
+
+	poller2, err := servers.BeginCreate(ctx, "rg-team-b", "srv1", armpostgresqlflexibleservers.Server{
+		Location: to.Ptr("westus"),
+		SKU:      &armpostgresqlflexibleservers.SKU{Name: to.Ptr("Standard_D8s_v3")},
+	}, nil)
+	if err == nil {
+		_, err = poller2.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("cross-group same-name create: expected a conflict, got nil")
+	}
+
+	got, err := servers.Get(ctx, "rg-team-a", "srv1", nil)
+	if err != nil {
+		t.Fatalf("Get rg-team-a after conflict: %v", err)
+	}
+
+	if name := skuName(&got.Server); name != "Standard_B1ms" {
+		t.Fatalf("cross-group create mutated the owner's SKU, got %q", name)
+	}
+
+	if _, err := servers.Get(ctx, "rg-team-b", "srv1", nil); err == nil {
+		t.Fatal("server must not exist under rg-team-b after a rejected create")
+	}
+}
+
+// TestSDKPostgresFlexScopedStartStopNotFound asserts start/stop issued under the
+// wrong resource group cannot act on another resource group's server.
+func TestSDKPostgresFlexScopedStartStopNotFound(t *testing.T) {
+	servers := newSDKClient(t)
+	mustCreateServerInRG(t, servers, "rg-team-a", "srv-a1")
+
+	ctx := context.Background()
+
+	stopP, err := servers.BeginStop(ctx, "rg-team-b", "srv-a1", nil)
+	if err == nil {
+		_, err = stopP.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("Stop from a different resource group: expected an error, got nil")
+	}
+
+	startP, err := servers.BeginStart(ctx, "rg-team-b", "srv-a1", nil)
+	if err == nil {
+		_, err = startP.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("Start from a different resource group: expected an error, got nil")
+	}
+
+	if _, err := servers.Get(ctx, "rg-team-a", "srv-a1", nil); err != nil {
+		t.Fatalf("Get after cross-group start/stop attempt: %v", err)
+	}
+}

--- a/server/azure/postgresflex/subresources.go
+++ b/server/azure/postgresflex/subresources.go
@@ -84,6 +84,10 @@ func (h *Handler) serveDatabase(w http.ResponseWriter, r *http.Request, rp *azur
 		return
 	}
 
+	if _, ok := h.lookupInScope(w, r, rp); !ok {
+		return
+	}
+
 	if rp.SubResourceName == "" {
 		if r.Method != http.MethodGet {
 			writeMethodNotAllowed(w)
@@ -188,6 +192,10 @@ func (h *Handler) serveFirewallRule(w http.ResponseWriter, r *http.Request, rp *
 	fw, ok := h.firewallRules()
 	if !ok {
 		writeUnsupported(w, "firewallRules")
+		return
+	}
+
+	if _, ok := h.lookupInScope(w, r, rp); !ok {
 		return
 	}
 
@@ -296,6 +304,10 @@ func (h *Handler) serveConfiguration(w http.ResponseWriter, r *http.Request, rp 
 	cf, ok := h.configurations()
 	if !ok {
 		writeUnsupported(w, "configurations")
+		return
+	}
+
+	if _, ok := h.lookupInScope(w, r, rp); !ok {
 		return
 	}
 

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"strings"
 	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Lifecycle states. Mirrors the AWS RDS terminology since RDS is the
@@ -103,6 +105,9 @@ type InstanceConfig struct {
 	// empty for a standalone primary.
 	MasterInstanceName string
 	Tags               map[string]string
+	// Scope records where the resource lives (Azure subscription/resource
+	// group). Zero for AWS/GCP and unscoped portable callers.
+	Scope scope.Scope
 }
 
 // Instance describes a managed database instance.
@@ -159,6 +164,11 @@ type Instance struct {
 	// replica identifiers reading from this instance.
 	ReadReplicaSource  string
 	ReadReplicaTargets []string
+	// Scope records where the resource lives (Azure subscription/resource
+	// group), echoed from the InstanceConfig it was created with. Zero for
+	// AWS/GCP and unscoped portable callers — Scope.Matches treats a zero
+	// Scope as visible under any filter.
+	Scope scope.Scope
 }
 
 // ModifyInstanceInput holds modifiable instance (and cluster) attributes.
@@ -530,6 +540,17 @@ type BatchConfigurations interface {
 // standby, discovered by type assertion.
 type Failover interface {
 	FailoverInstance(ctx context.Context, id string) error
+}
+
+// ScopedDelete is an OPTIONAL capability, discovered by type assertion. It lets
+// a scoped provider (Azure MySQL/Postgres Flexible Server) refuse to delete an
+// instance that does not belong to the caller's subscription/resource group —
+// a single atomic check-and-delete, avoiding the fetch-then-delete race a
+// handler-level Scope check on top of the plain DeleteInstance would leave.
+// AWS RDS and GCP Cloud SQL have no resource-group concept and do not
+// implement this interface, so their DeleteInstance is used unscoped.
+type ScopedDelete interface {
+	DeleteInstanceInScope(ctx context.Context, id string, filter scope.Scope) error
 }
 
 // VNetRuleConfig describes a virtual-network rule to create (Azure SQL).


### PR DESCRIPTION
## Summary

- **HIGH — cross-tenant leak**: MySQL/Postgres Flexible Server List/Get/Delete were keyed by server name only, ignoring subscription/resource group, so a server created in one resource group was visible and deletable through any other resource group's URL. Instances now carry a `scope.Scope` (set from the request's subscription/resource group on create); `getServer`/`listServers` filter on it, and `deleteServer` uses a new optional `rdsdriver.ScopedDelete` capability (`DeleteInstanceInScope`) so the scope check and the delete happen atomically under one lock. AWS RDS / GCP Cloud SQL are unaffected — the base `RelationalDB` interface is unchanged and they simply don't implement the new optional interface.
- **MEDIUM**: MySQL Flex's server-parameter catalog stopped populating `DefaultValue` on both the user-override and system-default paths (regressed vs Postgres Flex, which already sets it). Mirrored Postgres Flex's behavior so `Configurations.Get`/`List` always report the catalog default.
- **MEDIUM**: MySQL Flex's forced Failover (`POST .../failover`) succeeded even when the server had `HighAvailability` disabled (no standby). `FailoverInstance` now rejects with `FailedPrecondition` (409) when there is no active standby to fail over to, matching real Azure.
- **LOW**: MySQL Flex's `BeginRestart` ignored the `ServerRestartParameter` request body. `restartServer` now decodes it; `restartWithFailover=Enabled` routes the restart through `FailoverInstance` (inheriting the HA precondition above) instead of always performing a plain in-place restart; `maxFailoverSeconds` is accepted (the mock is synchronous, so there's nothing further to bound).

Regenerated `docs/coverage/` via `go generate ./...` for the new `ScopedDelete` optional interface (also picked up by the AWS RDS/Redshift and GCP AlloyDB coverage pages, which share the same driver package); reran `go run ./internal/compatgen` — no `docs/compat/` changes.

## Test plan
- [x] `go build ./...`
- [x] `go vet` on changed packages
- [x] `go test` on changed packages (provider + server/azure/{mysqlflex,postgresflex})
- [x] `go test -race` on changed provider/server packages
- [x] `golangci-lint` on changed packages — 0 issues
- [x] `gofmt -l` clean
- [x] New real-SDK regression tests: cross-resource-group List/Get/Delete (both engines), MySQL Flex failover HA precondition, MySQL Flex `restartWithFailover` body handling, `DefaultValue` round-trip