### PR TITLE
fix(azure-resourcegroups): exportTemplate enumerates the group's actual resources

### DIFF
--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -211,9 +211,10 @@ func New(d Drivers) http.Handler {
 	// before the permissive blob fallback so it isn't swallowed as a blob call.
 	srv.Register(tenants.New(tenantID))
 
-	// Resource groups have no driver: they are containers, and the emulator
-	// tracks membership by the ids resources already carry.
-	srv.Register(resourcegroups.New())
+	// Resource groups have no driver of their own: they are containers, and the
+	// emulator tracks membership by the ids resources already carry. The
+	// discovery engine (nil-safe) lets exportTemplate enumerate that membership.
+	srv.Register(resourcegroups.New(d.ResourceDiscovery))
 
 	// microsoft.insights extension resources (metrics, metricDefinitions,
 	// diagnosticSettings) hang off an arbitrary resource URI, so they must claim

--- a/server/azure/resourcegraph/handler.go
+++ b/server/azure/resourcegraph/handler.go
@@ -447,6 +447,25 @@ func portableToAzureType(service, typ string) string {
 	return strings.ToLower(key)
 }
 
+// AzureType translates an engine Resource's (Service, Type) into the ARM type
+// string a real Azure client expects (e.g. "compute"/"Instance" ->
+// "microsoft.compute/virtualmachines"). Exported so other Azure handlers that
+// render resourcediscovery.Resource rows into Azure-shaped output — e.g. the
+// resource-groups exportTemplate — use the same naming Resource Graph does,
+// rather than a second, possibly-diverging mapping.
+func AzureType(service, typ string) string {
+	return portableToAzureType(service, typ)
+}
+
+// ResourceGroupOf reports the resource group embedded in an Azure resource ID,
+// or "default" for an ID that doesn't carry one. Exported for the same reason
+// as AzureType: other Azure handlers that need "which group does this
+// resource belong to" (e.g. exportTemplate) reuse the parsing Resource Graph
+// and the generic-resources listing already rely on.
+func ResourceGroupOf(id string) string {
+	return resourceGroupOrDefault(id)
+}
+
 // Compile-time check that Handler implements the Matches+ServeHTTP pair the
 // dispatch chain expects.
 var _ interface {

--- a/server/azure/resourcegroups/export_template_test.go
+++ b/server/azure/resourcegroups/export_template_test.go
@@ -1,0 +1,100 @@
+// Regression test for exportTemplate actually enumerating a resource group's
+// members: https://learn.microsoft.com/en-us/rest/api/resources/resource-groups/export-template
+// documents a "resources" array of type/apiVersion/name/location/properties
+// entries in the returned template — before this fix the handler always
+// returned an empty array regardless of what the group held.
+
+package resourcegroups_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+// TestExportTemplateEnumeratesGroupResources drives the real armresources SDK
+// end-to-end: a VM is created directly against the provider's compute driver
+// (as the wire VM-create handler would leave it), the containing resource
+// group is created through the wire API, and exportTemplate must report the
+// VM in its resources[] rather than the empty skeleton it used to return.
+func TestExportTemplateEnumeratesGroupResources(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	inst, err := cloudP.VirtualMachines.RunInstances(ctx, computedriver.InstanceConfig{
+		ResourceGroup: "myrg",
+		InstanceType:  "Standard_D2s_v3",
+		OSType:        "Linux",
+		Region:        "eastus",
+	}, 1)
+	require.NoError(t, err)
+	require.Len(t, inst, 1)
+
+	srv := azureserver.New(azureserver.Drivers{
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		SubscriptionID:    cloudP.SubscriptionID,
+	})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	rgClient := newRGClient(t, ts)
+
+	_, err = rgClient.CreateOrUpdate(ctx, "myrg", armresources.ResourceGroup{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	require.NoError(t, err)
+
+	poller, err := rgClient.BeginExportTemplate(ctx, "myrg", armresources.ExportTemplateRequest{
+		Resources: []*string{to.Ptr("*")},
+	}, nil)
+	require.NoError(t, err)
+
+	result, err := poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	tmpl, ok := result.Template.(map[string]any)
+	require.True(t, ok, "expected template to decode as an object, got %T", result.Template)
+
+	resources, ok := tmpl["resources"].([]any)
+	require.True(t, ok, "expected resources to decode as an array, got %T", tmpl["resources"])
+	require.Len(t, resources, 1, "exportTemplate must enumerate the VM in the group")
+
+	entry, ok := resources[0].(map[string]any)
+	require.True(t, ok, "expected a resource entry object, got %T", resources[0])
+
+	assert.Equal(t, "microsoft.compute/virtualmachines", entry["type"])
+	assert.Equal(t, inst[0].ID, entry["name"])
+	assert.Equal(t, "eastus", entry["location"])
+	assert.NotEmpty(t, entry["apiVersion"])
+
+	// A group export scoped to a name that isn't the VM's own group stays
+	// empty — exportTemplate must not leak resources across groups.
+	_, err = rgClient.CreateOrUpdate(ctx, "otherrg", armresources.ResourceGroup{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	require.NoError(t, err)
+
+	otherPoller, err := rgClient.BeginExportTemplate(ctx, "otherrg", armresources.ExportTemplateRequest{
+		Resources: []*string{to.Ptr("*")},
+	}, nil)
+	require.NoError(t, err)
+
+	otherResult, err := otherPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	otherTmpl, ok := otherResult.Template.(map[string]any)
+	require.True(t, ok)
+
+	otherResources, ok := otherTmpl["resources"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, otherResources, "exportTemplate for an unrelated group must not include the VM")
+}

--- a/server/azure/resourcegroups/handler.go
+++ b/server/azure/resourcegroups/handler.go
@@ -13,12 +13,25 @@
 package resourcegroups
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"sync"
 
+	"github.com/stackshy/cloudemu/v2/server/azure/resourcegraph"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
 )
+
+// templateAPIVersion is the apiVersion stamped onto every resource entry in an
+// exported template. Real ARM resolves this per resource type from the
+// provider's registered API versions; the emulator has no such registry, so —
+// mirroring the same fixed-apiVersion approach the VM capture template already
+// uses (server/azure/virtualmachines/instances.go's captureResult) — every
+// entry gets one reasonable, recent Resource Manager API version rather than a
+// second per-type table to maintain.
+const templateAPIVersion = "2021-04-01"
 
 const resourceGroupType = "Microsoft.Resources/resourceGroups"
 
@@ -37,11 +50,20 @@ type Handler struct {
 	// stored lowercased because ARM resolves a resource group case-insensitively
 	// (create "myRG", get "MYRG"); the body keeps the original-cased name.
 	groups map[string]map[string]map[string]any
+	// engine backs exportTemplate: the emulator tracks group membership by the
+	// resource group segment already embedded in each resource's own id, so
+	// enumerating "what's in this group" means walking the same cross-service
+	// inventory Resource Graph and the generic resources listing already read
+	// from. Nil disables exportTemplate's resource enumeration (it still
+	// returns a valid, empty template) — callers that don't wire discovery.
+	engine *resourcediscovery.Engine
 }
 
-// New returns a resource-group handler.
-func New() *Handler {
-	return &Handler{groups: map[string]map[string]map[string]any{}}
+// New returns a resource-group handler. engine is the cross-service inventory
+// engine exportTemplate enumerates a group's resources from; nil is accepted
+// (exportTemplate then reports an empty resources[]).
+func New(engine *resourcediscovery.Engine) *Handler {
+	return &Handler{groups: map[string]map[string]map[string]any{}, engine: engine}
 }
 
 // routeKind classifies a resource-group request path.
@@ -258,6 +280,17 @@ func (h *Handler) remove(w http.ResponseWriter, r *http.Request, sub, name strin
 	w.WriteHeader(http.StatusAccepted)
 }
 
+// exportTemplateRequest is the exportTemplate POST body: see
+// https://learn.microsoft.com/en-us/rest/api/resources/resource-groups/export-template
+// ("ExportTemplateRequest"). Resources is an allowlist of resource IDs to
+// export, or a single "*" entry for the whole group; Options is a CSV of
+// parameterization flags this emulator does not act on (the export already
+// bakes in literal names rather than parameterizing them).
+type exportTemplateRequest struct {
+	Resources []string `json:"resources"`
+	Options   string   `json:"options"`
+}
+
 func (h *Handler) serveExport(w http.ResponseWriter, r *http.Request, sub, name string) {
 	if r.Method != http.MethodPost {
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "POST required")
@@ -275,18 +308,134 @@ func (h *Handler) serveExport(w http.ResponseWriter, r *http.Request, sub, name 
 		return
 	}
 
-	// The emulator does not track per-group resource membership here, so the
-	// exported template is a valid, empty ARM template skeleton.
+	req := decodeExportRequest(r)
+
+	resources, err := h.exportResources(r.Context(), name, req.Resources)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
 	azurearm.WriteJSON(w, http.StatusOK, map[string]any{
 		"template": map[string]any{
 			"$schema":        "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
 			"contentVersion": "1.0.0.0",
 			"parameters":     map[string]any{},
 			"variables":      map[string]any{},
-			"resources":      []any{},
+			"resources":      resources,
 			"outputs":        map[string]any{},
 		},
 	})
+}
+
+// decodeExportRequest best-effort decodes the exportTemplate POST body. Both
+// fields are optional per the ARM contract (a bare POST with no body is a
+// valid "export everything" request), so a missing or malformed body is
+// treated as no filter rather than failing the request.
+func decodeExportRequest(r *http.Request) exportTemplateRequest {
+	var req exportTemplateRequest
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&req)
+	}
+
+	return req
+}
+
+// exportResources enumerates the resources belonging to group, rendered as
+// ARM template resource entries. The emulator has no dedicated group-
+// membership store: group ownership is read off the same resource-group
+// segment already embedded in every resource's id, via the cross-service
+// discovery engine that Resource Graph and the generic resources listing
+// (GET .../resourceGroups/{rg}/resources) already read from — so exportTemplate
+// stays consistent with what those two report the group contains. A nil
+// engine (discovery not wired) yields an empty slice, matching the previous
+// always-empty behavior for callers who don't opt in to discovery.
+func (h *Handler) exportResources(ctx context.Context, group string, filter []string) ([]map[string]any, error) {
+	out := []map[string]any{}
+
+	if h.engine == nil {
+		return out, nil
+	}
+
+	all, err := h.engine.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	byID := !wantsAllResources(filter)
+
+	for i := range all {
+		res := &all[i]
+		if !strings.EqualFold(resourcegraph.ResourceGroupOf(res.ARN), group) {
+			continue
+		}
+
+		if byID && !containsFold(filter, res.ARN) {
+			continue
+		}
+
+		out = append(out, exportResourceEntry(res))
+	}
+
+	return out, nil
+}
+
+// wantsAllResources reports whether an exportTemplate request's resources
+// filter selects the whole group: no filter was supplied, or it names the "*"
+// wildcard the ARM contract documents for "export everything".
+func wantsAllResources(resources []string) bool {
+	if len(resources) == 0 {
+		return true
+	}
+
+	for _, id := range resources {
+		if id == "*" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// containsFold reports whether want is present in list, case-insensitively —
+// ARM resource IDs are case-insensitive.
+func containsFold(list []string, want string) bool {
+	for _, s := range list {
+		if strings.EqualFold(s, want) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// exportResourceEntry renders one discovered resource as an ARM template
+// resource entry: type + apiVersion + name + location + properties, the
+// fields every real exportTemplate response carries (id/subscriptionId are
+// not part of a template resource — a template is meant to be redeployable
+// under any subscription/resource group). properties defaults to an empty
+// object rather than being omitted, matching the shape of a real response.
+func exportResourceEntry(r *resourcediscovery.Resource) map[string]any {
+	entry := map[string]any{
+		"type":       resourcegraph.AzureType(r.Service, r.Type),
+		"apiVersion": templateAPIVersion,
+		"name":       r.ID,
+		"properties": map[string]any{},
+	}
+
+	if r.Region != "" {
+		entry["location"] = r.Region
+	}
+
+	if len(r.Properties) > 0 {
+		entry["properties"] = r.Properties
+	}
+
+	if len(r.Tags) > 0 {
+		entry["tags"] = r.Tags
+	}
+
+	return entry
 }
 
 // store writes the group under a case-insensitive key and reports whether a


### PR DESCRIPTION
## Summary

Azure `exportTemplate` (Resource Groups) always returned an empty `resources[]` regardless of what was actually in the group.

`serveExport` now enumerates the group's resources via the same `resourcediscovery.Engine.ListAll(...)` that Resource Graph and the generic resources listing (`GET .../resourceGroups/{rg}/resources`) already read from, filtering to the requested group and rendering each match as an ARM template resource entry (`type`, `apiVersion`, `name`, `location`, `properties`, `tags` when present).

Also honors the request's `resources` ID allowlist (`["*"]` for everything, or a specific set of resource IDs), matching the [ExportTemplate REST contract](https://learn.microsoft.com/en-us/rest/api/resources/resource-groups/export-template).

Two small helpers (`AzureType`, `ResourceGroupOf`) were exported from `resourcegraph` so the export renders the same type/group naming Resource Graph already uses, rather than a second, possibly-diverging mapping.

Deferred (separate features, not in scope): resource locks, `moveResources`, the dedicated Tags RP API.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./server/azure/resourcegroups/... ./server/azure/resourcegraph/... ./services/resourcediscovery/... ./server/azure/`
- [x] `go test -race ./server/azure/resourcegroups/... ./server/azure/resourcegraph/...`
- [x] `golangci-lint run ./server/azure/...` — 0 new issues
- [x] `gofmt -l` clean
- [x] Added a real-SDK regression test (`armresources` client) that creates a VM, creates the resource group, calls `BeginExportTemplate`, and asserts the VM shows up in `resources[]` — and that an unrelated group's export stays empty.