### PR TITLE
fix(azure-vmss): honor explicit sku.capacity:0 (scale-in-to-zero)

### DIFF
--- a/providers/azure/virtualmachines/scaleset.go
+++ b/providers/azure/virtualmachines/scaleset.go
@@ -11,16 +11,22 @@ import (
 // discoverer prices on are modeled: the SKU (VM size / tier / instance count)
 // and the per-VM profile (Spot priority, hybrid-benefit license, OS type).
 type ScaleSet struct {
-	Name        string
-	ID          string
-	Location    string
-	SKUName     string
-	SKUTier     string
-	Capacity    int
-	Priority    string // Spot / Regular
-	LicenseType string
-	OSType      string // Linux / Windows
-	Tags        map[string]string
+	Name     string
+	ID       string
+	Location string
+	SKUName  string
+	SKUTier  string
+	Capacity int
+	// CapacityZero must be set true when Capacity==0 is an explicit
+	// scale-in-to-zero request rather than an omitted field. Without it,
+	// CreateScaleSet cannot tell "capacity not specified" (default to 1)
+	// apart from "capacity explicitly 0" (honor it) — real Azure
+	// tooling sends the latter via a nullable capacity field.
+	CapacityZero bool
+	Priority     string // Spot / Regular
+	LicenseType  string
+	OSType       string // Linux / Windows
+	Tags         map[string]string
 }
 
 // CreateScaleSet stores a VMSS, defaulting the fields real Azure fills in.
@@ -46,7 +52,10 @@ func (m *Mock) CreateScaleSet(_ context.Context, s ScaleSet) (*ScaleSet, error) 
 		s.SKUTier = "Standard"
 	}
 
-	if s.Capacity == 0 {
+	// A zero capacity is only defaulted to 1 when it wasn't explicitly
+	// requested; an explicit "capacity":0 (scale-in-to-zero) is honored —
+	// a VMSS at capacity 0 is a valid, running-with-no-instances state.
+	if s.Capacity == 0 && !s.CapacityZero {
 		s.Capacity = 1
 	}
 

--- a/providers/azure/virtualmachines/scaleset_test.go
+++ b/providers/azure/virtualmachines/scaleset_test.go
@@ -26,6 +26,20 @@ func TestCreateScaleSetDefaults(t *testing.T) {
 	assert.Equal(t, "Linux", ss.OSType)
 }
 
+func TestCreateScaleSetExplicitZeroCapacityHonored(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	ss, err := m.CreateScaleSet(ctx, ScaleSet{Name: "vmss-zero", Capacity: 0, CapacityZero: true})
+	require.NoError(t, err)
+	assert.Equal(t, 0, ss.Capacity)
+
+	list, err := m.ListScaleSets(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, 0, list[0].Capacity)
+}
+
 func TestCreateScaleSetRequiresName(t *testing.T) {
 	ctx := context.Background()
 	m := newTestMock()

--- a/server/azure/virtualmachines/scalesets.go
+++ b/server/azure/virtualmachines/scalesets.go
@@ -78,7 +78,11 @@ func createScaleSet(w http.ResponseWriter, r *http.Request, rp azurearm.Resource
 	if req.SKU != nil {
 		set.SKUName = req.SKU.Name
 		set.SKUTier = req.SKU.Tier
-		set.Capacity = req.SKU.Capacity
+
+		if req.SKU.Capacity != nil {
+			set.Capacity = int(*req.SKU.Capacity)
+			set.CapacityZero = *req.SKU.Capacity == 0
+		}
 	}
 
 	if p := req.Properties.VirtualMachineProfile; p != nil {
@@ -147,7 +151,7 @@ func toVMSSResponse(s *providervm.ScaleSet, rp azurearm.ResourcePath) vmssRespon
 		Type:     providerName + "/" + resourceTypeScaleSets,
 		Location: defaultIfEmpty(s.Location, "eastus"),
 		Tags:     s.Tags,
-		SKU:      &vmssSKU{Name: s.SKUName, Tier: s.SKUTier, Capacity: s.Capacity},
+		SKU:      &vmssSKU{Name: s.SKUName, Tier: s.SKUTier, Capacity: capacityPtr(s.Capacity)},
 		Properties: vmssResponseProps{
 			ProvisioningState: "Succeeded",
 			VirtualMachineProfile: &vmssVMProfile{
@@ -157,4 +161,11 @@ func toVMSSResponse(s *providervm.ScaleSet, rp azurearm.ResourcePath) vmssRespon
 			},
 		},
 	}
+}
+
+// capacityPtr converts the stored capacity (always a concrete value after
+// CreateScaleSet defaulting) to the pointer form the ARM wire shape uses.
+func capacityPtr(capacity int) *int64 {
+	c := int64(capacity)
+	return &c
 }

--- a/server/azure/virtualmachines/scalesets_types.go
+++ b/server/azure/virtualmachines/scalesets_types.go
@@ -11,11 +11,15 @@ type vmssRequest struct {
 	Properties vmssRequestProps  `json:"properties"`
 }
 
-// vmssSKU is the scale-set SKU: VM size, tier, and instance count.
+// vmssSKU is the scale-set SKU: VM size, tier, and instance count. Capacity
+// is a pointer (matching the real armcompute SKU.Capacity *int64 field) so a
+// request that omits "capacity" is distinguishable from one that sends the
+// scale-in-to-zero value "capacity":0 explicitly: both would decode to the
+// same Go zero value if this were a plain int.
 type vmssSKU struct {
 	Name     string `json:"name,omitempty"`
 	Tier     string `json:"tier,omitempty"`
-	Capacity int    `json:"capacity,omitempty"`
+	Capacity *int64 `json:"capacity,omitempty"`
 }
 
 type vmssRequestProps struct {

--- a/server/azure/virtualmachines/sdk_costfields_test.go
+++ b/server/azure/virtualmachines/sdk_costfields_test.go
@@ -157,3 +157,92 @@ func TestSDKVMSSCostFields(t *testing.T) {
 		t.Errorf("virtualMachineProfile.priority=%v want Spot", vp)
 	}
 }
+
+// TestSDKVMSSScaleToZero asserts an explicit sku.capacity:0 (scale-in-to-zero,
+// a standard armcompute request real autoscale/CLI tooling issues) is honored
+// rather than silently coerced to the create-time default of 1. See
+// https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-scale-in-to-zero
+// and armcompute.SKU.Capacity, which is *int64 precisely so "capacity":0 can
+// be sent distinctly from omitting the field.
+func TestSDKVMSSScaleToZero(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := armcompute.NewVirtualMachineScaleSetsClient("sub-1", fakeCred{}, armOptions(t, ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "zero-vmss", armcompute.VirtualMachineScaleSet{
+		Location: to.Ptr("eastus"),
+		SKU: &armcompute.SKU{
+			Name:     to.Ptr("Standard_D2s_v3"),
+			Tier:     to.Ptr("Standard"),
+			Capacity: to.Ptr[int64](0),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("VMSS BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("VMSS create poll: %v", err)
+	}
+
+	got, err := client.Get(ctx, "rg-1", "zero-vmss", nil)
+	if err != nil {
+		t.Fatalf("VMSS Get: %v", err)
+	}
+
+	if got.SKU == nil || got.SKU.Capacity == nil || *got.SKU.Capacity != 0 {
+		t.Errorf("sku.capacity=%v want 0 (explicit scale-in-to-zero must be honored, not coerced to 1)", got.SKU)
+	}
+}
+
+// TestSDKVMSSCapacityDefaultsWhenOmitted asserts that omitting sku.capacity
+// entirely (as opposed to sending an explicit 0) still defaults to 1, so the
+// scale-to-zero fix does not regress the default-instance-count behavior.
+func TestSDKVMSSCapacityDefaultsWhenOmitted(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := armcompute.NewVirtualMachineScaleSetsClient("sub-1", fakeCred{}, armOptions(t, ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "default-vmss", armcompute.VirtualMachineScaleSet{
+		Location: to.Ptr("eastus"),
+		SKU: &armcompute.SKU{
+			Name: to.Ptr("Standard_D2s_v3"),
+			Tier: to.Ptr("Standard"),
+			// Capacity intentionally left nil (omitted from the wire request).
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("VMSS BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("VMSS create poll: %v", err)
+	}
+
+	got, err := client.Get(ctx, "rg-1", "default-vmss", nil)
+	if err != nil {
+		t.Fatalf("VMSS Get: %v", err)
+	}
+
+	if got.SKU == nil || got.SKU.Capacity == nil || *got.SKU.Capacity != 1 {
+		t.Errorf("sku.capacity=%v want 1 (default when omitted)", got.SKU)
+	}
+}


### PR DESCRIPTION
## Summary

`CreateScaleSet` coerced any zero capacity to 1, silently discarding scale-in-to-zero (`sku.capacity:0`), a standard request real armcompute tooling issues (see [MS Learn: scale-in to zero](https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-scale-in-to-zero)). The wire decoder also collapsed "capacity omitted" and "capacity explicitly 0" into the same Go zero value, so the provider had no way to tell them apart.

`armcompute.SKU.Capacity` is `*int64` for exactly this reason: a nil pointer omits `"capacity"` from the JSON body, while a non-nil pointer to 0 sends `"capacity":0` explicitly.

## Fix

- `server/azure/virtualmachines/scalesets_types.go`: `vmssSKU.Capacity` is now `*int64`, matching the real ARM wire shape, so decode preserves presence.
- `server/azure/virtualmachines/scalesets.go`: the handler only touches `set.Capacity` when the pointer is non-nil, and sets a new `CapacityZero` flag when the explicit value is 0.
- `providers/azure/virtualmachines/scaleset.go`: `ScaleSet` gains a `CapacityZero` bool; `CreateScaleSet` only defaults capacity to 1 when it's zero *and* not explicitly requested.

Out of scope (deferred, not implemented here): full VMSS instance orchestration (enumerable/addressable VM instances) and upgradePolicy/networkProfile enforcement.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./providers/azure/virtualmachines/... ./server/azure/virtualmachines/... ./server/azure/resourcegraph/...`
- [x] `go test -race ./providers/azure/virtualmachines/...`
- [x] `golangci-lint run` on changed packages (0 new issues)
- [x] `gofmt -l` clean
- [x] Added real-SDK regression tests (`armcompute.VirtualMachineScaleSetsClient`) for explicit `capacity:0` and for capacity omitted (still defaults to 1); verified the new `capacity:0` test fails against the old coercion logic