### PR TITLE
fix(azure-vnet): NIC to VM cross-reference and sole ipConfiguration primary

### DIFF
--- a/features/chaos/wrappers_test.go
+++ b/features/chaos/wrappers_test.go
@@ -432,6 +432,7 @@ type computeConfigCompat = struct {
 	IamInstanceProfileARN  string
 	IamInstanceProfileName string
 	Identity               *computedriver.ManagedIdentity
+	NetworkInterfaces      []computedriver.AzureNICRef
 }
 
 // computeInstanceConfig reproduces the helper used elsewhere in the package

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -201,6 +201,7 @@ func New(opts ...config.Option) *Provider {
 		Region:             o.Region,
 	}
 	p.VirtualMachines.SetMonitoring(p.Monitor)
+	p.VirtualMachines.SetNICAttacher(p.VNet)
 	p.BlobStorage.SetMonitoring(p.Monitor)
 	p.CosmosDB.SetMonitoring(p.Monitor)
 	p.Functions.SetMonitoring(p.Monitor)

--- a/providers/azure/virtualmachines/nic_attacher.go
+++ b/providers/azure/virtualmachines/nic_attacher.go
@@ -1,0 +1,28 @@
+package virtualmachines
+
+import "context"
+
+// NICAttacher is the slice of the networking mock the VM lifecycle needs to
+// keep a network interface's properties.virtualMachine back-reference in sync
+// with the VM(s) referencing it in networkProfile.networkInterfaces. Real
+// Azure sets this back-reference when a VM attaches a NIC and clears it when
+// the VM is deleted; without a resolver wired, a NIC's GetNetworkInterface
+// never reports its owning VM. nil until wired by the provider.
+type NICAttacher interface {
+	// AttachNetworkInterface associates the NIC (resourceGroup, name) with
+	// vmID, the ARM resource id of the owning VM. It must fail when the NIC is
+	// already attached to a different VM (a NIC attaches to only one VM at a
+	// time) and succeed idempotently when it is already attached to vmID.
+	AttachNetworkInterface(ctx context.Context, resourceGroup, name, vmID string) error
+	// DetachNetworkInterface clears the NIC's back-reference, but only when it
+	// currently points at vmID; detaching a NIC that points elsewhere (or
+	// isn't attached) is a no-op.
+	DetachNetworkInterface(ctx context.Context, resourceGroup, name, vmID string) error
+}
+
+// SetNICAttacher wires the networking mock in. Without it, a VM's
+// networkProfile.networkInterfaces references are accepted but the
+// referenced NICs' properties.virtualMachine back-reference is never set.
+func (m *Mock) SetNICAttacher(a NICAttacher) {
+	m.nicAttacher = a
+}

--- a/providers/azure/virtualmachines/rollback_nic_test.go
+++ b/providers/azure/virtualmachines/rollback_nic_test.go
@@ -1,0 +1,158 @@
+package virtualmachines
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/azure/vnet"
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+const rollbackNICRG = "rg-1"
+
+// newVMMockWithVNet builds a VM mock wired to a real vnet mock as its
+// NICAttacher (mirroring the provider factory's SetNICAttacher), optionally
+// backed by a compute engine, so a failed RunInstances exercises the real
+// attach/detach cross-reference path end to end.
+func newVMMockWithVNet(engine config.ComputeEngine) (*Mock, *vnet.Mock) {
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	vmOpts := []config.Option{config.WithClock(clk), config.WithAccountID("test-sub")}
+	if engine != nil {
+		vmOpts = append(vmOpts, config.WithComputeEngine(engine))
+	}
+
+	net := vnet.New(config.NewOptions(config.WithClock(clk), config.WithAccountID("test-sub")))
+	m := New(config.NewOptions(vmOpts...))
+	m.SetNICAttacher(net)
+
+	return m, net
+}
+
+// createSharedNIC provisions a single NIC used to force a mid-batch attach
+// failure (the second instance in a count=2 batch cannot attach it).
+func createSharedNIC(t *testing.T, net *vnet.Mock, name string) {
+	t.Helper()
+
+	if _, err := net.CreateOrUpdateNetworkInterface(context.Background(), rollbackNICRG, name, netdriver.AzureNICConfig{
+		Location: "eastus",
+		IPConfigs: []netdriver.AzureIPConfig{{
+			Name:             "ipconfig1",
+			PrivateIP:        "10.0.1.50",
+			AllocationMethod: "Static",
+			Primary:          true,
+		}},
+	}); err != nil {
+		t.Fatalf("create nic %q: %v", name, err)
+	}
+}
+
+// assertNICReleased asserts the NIC is no longer attached to any VM: its
+// back-reference is cleared, it can be deleted (not "in use"), and — before
+// deletion — it can be re-attached to a fresh instance.
+func assertNICReleased(ctx context.Context, t *testing.T, m *Mock, net *vnet.Mock, name string) {
+	t.Helper()
+
+	got, err := net.GetNetworkInterface(ctx, rollbackNICRG, name)
+	require.NoError(t, err)
+	assert.Empty(t, got.VirtualMachineID, "NIC must not stay attached to a rolled-back VM")
+
+	// A freed NIC re-attaches to a fresh instance...
+	reCfg := driver.InstanceConfig{
+		ImageID:           "img-123",
+		InstanceType:      "Standard_B1s",
+		ResourceGroup:     rollbackNICRG,
+		NetworkInterfaces: []driver.AzureNICRef{{ResourceGroup: rollbackNICRG, Name: name}},
+	}
+
+	insts, err := m.RunInstances(ctx, reCfg, 1)
+	require.NoError(t, err, "freed NIC must be re-attachable")
+	require.Len(t, insts, 1)
+
+	// ...and once that VM is terminated the NIC is deletable (not "in use").
+	require.NoError(t, m.TerminateInstances(ctx, []string{insts[0].ID}))
+	require.NoError(t, net.DeleteNetworkInterface(ctx, rollbackNICRG, name),
+		"a released NIC must be deletable, never stuck reporting in-use")
+}
+
+// TestRunInstancesRollbackReleasesNICsOnAttachFailure reproduces the HIGH bug:
+// a multi-count RunInstances whose later instance fails to attach a NIC must not
+// leave the earlier instance's NIC pointing at a now-deleted VM. The whole batch
+// is rolled back, so the shared NIC must be released, not orphaned.
+func TestRunInstancesRollbackReleasesNICsOnAttachFailure(t *testing.T) {
+	ctx := context.Background()
+	m, net := newVMMockWithVNet(nil)
+
+	const nicName = "nic-shared"
+	createSharedNIC(t, net, nicName)
+
+	cfg := driver.InstanceConfig{
+		ImageID:           "img-123",
+		InstanceType:      "Standard_B1s",
+		ResourceGroup:     rollbackNICRG,
+		NetworkInterfaces: []driver.AzureNICRef{{ResourceGroup: rollbackNICRG, Name: nicName}},
+	}
+
+	// count=2: instance 1 attaches nic-shared, instance 2's attach fails as
+	// designed (a NIC attaches to one VM at a time), so the batch rolls back.
+	insts, err := m.RunInstances(ctx, cfg, 2)
+	require.Error(t, err, "second instance must fail to attach the already-attached NIC")
+	assert.Nil(t, insts)
+
+	// The rolled-back instance 1 must have released nic-shared.
+	assertNICReleased(ctx, t, m, net, nicName)
+}
+
+// failOnNthProvision is a ComputeEngine that provisions successfully until the
+// nth call, which it fails — driving the pre-existing engine-provision rollback
+// path in RunInstances (distinct from the attachNICs path).
+type failOnNthProvision struct {
+	failAt int
+	calls  int
+}
+
+func (e *failOnNthProvision) Provision(
+	_ context.Context, _ config.ComputeProvisionRequest,
+) (config.ComputeProvisionResult, error) {
+	e.calls++
+	if e.calls == e.failAt {
+		return config.ComputeProvisionResult{}, errors.New("boom: provision failed")
+	}
+
+	return config.ComputeProvisionResult{IP: "10.0.0.5"}, nil
+}
+
+func (e *failOnNthProvision) ConsoleOutput(context.Context, string) ([]byte, error) { return nil, nil }
+func (e *failOnNthProvision) Deprovision(context.Context, string) error             { return nil }
+
+// TestRunInstancesRollbackReleasesNICsOnProvisionFailure covers the other
+// rollback trigger: instance 1 provisions and attaches its NIC, then instance
+// 2's compute-engine Provision fails before it ever attaches. The rollback of
+// instance 1 must still release its NIC.
+func TestRunInstancesRollbackReleasesNICsOnProvisionFailure(t *testing.T) {
+	ctx := context.Background()
+	m, net := newVMMockWithVNet(&failOnNthProvision{failAt: 2})
+
+	const nicName = "nic-engine"
+	createSharedNIC(t, net, nicName)
+
+	cfg := driver.InstanceConfig{
+		ImageID:           "img-123",
+		InstanceType:      "Standard_B1s",
+		ResourceGroup:     rollbackNICRG,
+		NetworkInterfaces: []driver.AzureNICRef{{ResourceGroup: rollbackNICRG, Name: nicName}},
+	}
+
+	insts, err := m.RunInstances(ctx, cfg, 2)
+	require.Error(t, err, "second instance's provision must fail")
+	assert.Nil(t, insts)
+
+	assertNICReleased(ctx, t, m, net, nicName)
+}

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -525,13 +525,18 @@ func (m *Mock) detachNICs(ctx context.Context, inst *instanceData) error {
 }
 
 // rollbackInstances best-effort tears down instances already provisioned earlier
-// in a RunInstances batch that then failed: each engine-backed instance is
-// deprovisioned (so no live container remains) and every instance is dropped from
-// the store and the state machine (so no half-tracked state remains).
+// in a RunInstances batch that then failed: every NIC the instance attached at
+// launch is detached (so no NIC keeps a virtualMachine back-reference to a VM
+// that's about to vanish, which would strand it as permanently "in use"), each
+// engine-backed instance is deprovisioned (so no live container remains) and
+// every instance is dropped from the store and the state machine (so no
+// half-tracked state remains).
 func (m *Mock) rollbackInstances(ctx context.Context, created []*instanceData) {
 	engine := m.opts.ComputeEngine
 
 	for _, inst := range created {
+		_ = m.detachNICs(ctx, inst)
+
 		if inst.engineBacked {
 			di := driver.Instance{ID: inst.ID}
 			_ = computeengine.Deprovision(ctx, engine, &di)

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -159,6 +159,11 @@ type instanceData struct {
 	// instance, so Terminate deprovisions it and console output is read from
 	// the engine rather than synthesized.
 	engineBacked bool
+	// NICRefs are the network interfaces this instance was attached to at
+	// launch (networkProfile.networkInterfaces), so Terminate knows which NICs
+	// to detach (clearing their properties.virtualMachine back-reference).
+	// Empty when no NICAttacher is wired or the VM referenced no NICs.
+	NICRefs []driver.AzureNICRef
 }
 
 type asgData struct {
@@ -185,6 +190,12 @@ type Mock struct {
 	snapCounter  atomic.Int64
 	imgCounter   atomic.Int64
 	monitoring   mondriver.Monitoring
+	// nicAttacher keeps a network interface's virtualMachine back-reference in
+	// sync with the VM lifecycle (attach on create, detach on terminate). nil
+	// until wired by the provider factory, in which case NIC attachment is
+	// silently skipped (matching the pre-wiring behavior of every other
+	// optional cross-service hook in this package).
+	nicAttacher NICAttacher
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -439,6 +450,12 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 			inst.engineBacked = true
 		}
 
+		if err := m.attachNICs(ctx, inst, cfg.NetworkInterfaces); err != nil {
+			m.rollbackInstances(ctx, created)
+
+			return nil, err
+		}
+
 		m.instances.Set(id, inst)
 		m.sm.SetState(id, compute.StatePending)
 		_ = m.sm.Transition(id, compute.StateRunning)
@@ -449,6 +466,62 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 	}
 
 	return results, nil
+}
+
+// attachNICs attaches each of refs to inst, setting the NIC's
+// properties.virtualMachine back-reference to inst's ARM resource id, and
+// records what was attached on inst.NICRefs so a later Terminate knows what
+// to detach. It is a no-op when no NICAttacher is wired. A failure partway
+// through (e.g. a NIC already attached to a different VM) rolls back the NICs
+// already attached during this call before returning the error, so a failed
+// RunInstances never leaves a NIC dangling on a VM that was never created.
+func (m *Mock) attachNICs(ctx context.Context, inst *instanceData, refs []driver.AzureNICRef) error {
+	if m.nicAttacher == nil || len(refs) == 0 {
+		return nil
+	}
+
+	vmID := m.armResourceID(inst)
+	attached := make([]driver.AzureNICRef, 0, len(refs))
+
+	for _, ref := range refs {
+		if err := m.nicAttacher.AttachNetworkInterface(ctx, ref.ResourceGroup, ref.Name, vmID); err != nil {
+			for _, done := range attached {
+				_ = m.nicAttacher.DetachNetworkInterface(ctx, done.ResourceGroup, done.Name, vmID)
+			}
+
+			return err
+		}
+
+		attached = append(attached, ref)
+	}
+
+	inst.NICRefs = attached
+
+	return nil
+}
+
+// detachNICs clears the virtualMachine back-reference of every NIC inst was
+// attached to at launch, best-effort: every ref is attempted and failures are
+// aggregated rather than stopping partway, so a Terminate always releases
+// every NIC it can. It is a no-op when no NICAttacher is wired.
+func (m *Mock) detachNICs(ctx context.Context, inst *instanceData) error {
+	if m.nicAttacher == nil || len(inst.NICRefs) == 0 {
+		return nil
+	}
+
+	vmID := m.armResourceID(inst)
+
+	var errs []error
+
+	for _, ref := range inst.NICRefs {
+		if err := m.nicAttacher.DetachNetworkInterface(ctx, ref.ResourceGroup, ref.Name, vmID); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	inst.NICRefs = nil
+
+	return errors.Join(errs...)
 }
 
 // rollbackInstances best-effort tears down instances already provisioned earlier
@@ -645,7 +718,15 @@ func (m *Mock) TerminateInstances(ctx context.Context, instanceIDs []string) err
 
 	for _, id := range instanceIDs {
 		inst, ok := m.instances.Get(id)
-		if !ok || !inst.engineBacked {
+		if !ok {
+			continue
+		}
+
+		if err := m.detachNICs(ctx, inst); err != nil {
+			errs = append(errs, err)
+		}
+
+		if !inst.engineBacked {
 			continue
 		}
 

--- a/providers/azure/vnet/network_interface.go
+++ b/providers/azure/vnet/network_interface.go
@@ -141,6 +141,51 @@ func (m *Mock) DeleteNetworkInterface(_ context.Context, resourceGroup, name str
 	return nil
 }
 
+// AttachNetworkInterface associates the NIC identified by (resourceGroup,
+// name) with vmID, the ARM resource id of the owning VM — the driver-layer
+// hook the VM lifecycle uses to keep properties.virtualMachine in sync with
+// networkProfile.networkInterfaces. Matching real Azure, a NIC attaches to
+// only one VM at a time: attaching it to a second, different VM is rejected.
+// Re-attaching the same vmID is idempotent, matching ARM's idempotent PUT.
+func (m *Mock) AttachNetworkInterface(_ context.Context, resourceGroup, name, vmID string) error {
+	m.nicMu.Lock()
+	defer m.nicMu.Unlock()
+
+	nic, ok := m.nics.Get(nicKey(resourceGroup, name))
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "network interface %q not found in resource group %q", name, resourceGroup)
+	}
+
+	if nic.VirtualMachineID != "" && nic.VirtualMachineID != vmID {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"network interface %q is already attached to %q", name, nic.VirtualMachineID)
+	}
+
+	nic.VirtualMachineID = vmID
+
+	return nil
+}
+
+// DetachNetworkInterface clears the NIC's virtualMachine back-reference, but
+// only when it currently points at vmID. Detaching a NIC that is unattached,
+// already deleted, or attached to a different VM is a no-op — a stale or
+// duplicate detach must not disturb a real, current attachment.
+func (m *Mock) DetachNetworkInterface(_ context.Context, resourceGroup, name, vmID string) error {
+	m.nicMu.Lock()
+	defer m.nicMu.Unlock()
+
+	nic, ok := m.nics.Get(nicKey(resourceGroup, name))
+	if !ok {
+		return nil
+	}
+
+	if nic.VirtualMachineID == vmID {
+		nic.VirtualMachineID = ""
+	}
+
+	return nil
+}
+
 // ListNetworkInterfaces returns NICs in a resource group, or all when
 // resourceGroup is empty (subscription-wide list).
 func (m *Mock) ListNetworkInterfaces(_ context.Context, resourceGroup string) ([]driver.AzureNIC, error) {
@@ -203,7 +248,45 @@ func (m *Mock) resolveIPConfigs(configs []driver.AzureIPConfig, selfKey string) 
 		out = append(out, cfg)
 	}
 
+	if err := enforcePrimary(out); err != nil {
+		return nil, err
+	}
+
 	return out, nil
+}
+
+// enforcePrimary applies Azure's primary-ipConfiguration invariant to configs
+// in place. A NIC with a single ipConfiguration always has it as primary,
+// regardless of what the caller submitted — real Azure forces this rather
+// than erroring or leaving it non-primary ("Each network interface is
+// assigned one primary IP configuration": Microsoft Learn, Configure IP
+// addresses for an Azure network interface). With more than one
+// ipConfiguration, exactly one must already be marked primary ("A network
+// interface can't have more than one Primary IP configuration": same
+// source).
+func enforcePrimary(configs []driver.AzureIPConfig) error {
+	if len(configs) == 1 {
+		configs[0].Primary = true
+
+		return nil
+	}
+
+	count := 0
+
+	for i := range configs {
+		if configs[i].Primary {
+			count++
+		}
+	}
+
+	switch count {
+	case 1:
+		return nil
+	case 0:
+		return cerrors.New(cerrors.InvalidArgument, "one ipConfiguration must be marked primary")
+	default:
+		return cerrors.New(cerrors.InvalidArgument, "a network interface can have only one primary ipConfiguration")
+	}
 }
 
 // allocatePrivateIP returns the lowest free host in cidr (starting past Azure's

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -79,30 +79,32 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 	// A networkProfile must reference NICs that already exist. Real Azure
 	// rejects a VM whose networkProfile points at a missing NIC rather than
 	// silently succeeding.
-	if err := h.validateNICs(r.Context(), req.Properties.NetworkProfile); err != nil {
+	nicRefs, err := h.validateNICs(r.Context(), req.Properties.NetworkProfile)
+	if err != nil {
 		azurearm.WriteError(w, http.StatusBadRequest, "NetworkInterfaceNotFound", err.Error())
 		return
 	}
 
 	cfg := computedriver.InstanceConfig{
-		ImageID:       imageRefToID(req.Properties.StorageProfile),
-		InstanceType:  hardwareSize(req.Properties.HardwareProfile),
-		SubnetID:      firstNicID(req.Properties.NetworkProfile),
-		KeyName:       computerName(req.Properties.OSProfile),
-		UserData:      decodeCustomData(customData(req.Properties.OSProfile)),
-		Tags:          mergeTags(req.Tags, rp.ResourceName),
-		Priority:      req.Properties.Priority,
-		LicenseType:   req.Properties.LicenseType,
-		OSType:        osTypeFromStorage(req.Properties.StorageProfile),
-		Zones:         req.Zones,
-		Region:        req.Location,
-		ResourceGroup: rp.ResourceGroup,
-		Identity:      toDriverIdentity(req.Identity),
+		ImageID:           imageRefToID(req.Properties.StorageProfile),
+		InstanceType:      hardwareSize(req.Properties.HardwareProfile),
+		SubnetID:          firstNicID(req.Properties.NetworkProfile),
+		KeyName:           computerName(req.Properties.OSProfile),
+		UserData:          decodeCustomData(customData(req.Properties.OSProfile)),
+		Tags:              mergeTags(req.Tags, rp.ResourceName),
+		Priority:          req.Properties.Priority,
+		LicenseType:       req.Properties.LicenseType,
+		OSType:            osTypeFromStorage(req.Properties.StorageProfile),
+		Zones:             req.Zones,
+		Region:            req.Location,
+		ResourceGroup:     rp.ResourceGroup,
+		Identity:          toDriverIdentity(req.Identity),
+		NetworkInterfaces: nicRefs,
 	}
 
 	// ARM CreateOrUpdate is idempotent: a repeated PUT to the same {rg,name}
 	// updates the VM in place rather than provisioning a duplicate.
-	if existing, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName); err == nil {
+	if existing, findErr := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName); findErr == nil {
 		h.updateExisting(w, r, rp, req, existing, cfg)
 		return
 	}
@@ -131,19 +133,24 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 	azurearm.WriteJSON(w, http.StatusCreated, h.buildVMResponse(r.Context(), &instances[0], rp, req, provisioningCreating))
 }
 
-// validateNICs verifies that every NIC referenced by a networkProfile exists.
-// It is a no-op when no networking driver is wired or the driver does not
-// implement the Azure network-interface surface, so handlers configured
-// without networking keep their previous permissive behavior.
-func (h *Handler) validateNICs(ctx context.Context, np *networkProfile) error {
+// validateNICs verifies that every NIC referenced by a networkProfile exists,
+// and resolves each reference down to the (resourceGroup, name) pair the
+// driver layer needs to attach the NIC to the VM being created (setting its
+// properties.virtualMachine back-reference). It returns (nil, nil) when no
+// networking driver is wired or the driver does not implement the Azure
+// network-interface surface, so handlers configured without networking keep
+// their previous permissive behavior.
+func (h *Handler) validateNICs(ctx context.Context, np *networkProfile) ([]computedriver.AzureNICRef, error) {
 	if np == nil || len(np.NetworkInterfaces) == 0 || h.net == nil {
-		return nil
+		return nil, nil
 	}
 
 	svc, ok := h.net.(netdriver.AzureNetworkInterfaces)
 	if !ok {
-		return nil
+		return nil, nil
 	}
+
+	refs := make([]computedriver.AzureNICRef, 0, len(np.NetworkInterfaces))
 
 	for _, nic := range np.NetworkInterfaces {
 		if nic.ID == "" {
@@ -152,16 +159,18 @@ func (h *Handler) validateNICs(ctx context.Context, np *networkProfile) error {
 
 		pp, ok := azurearm.ParsePath(nic.ID)
 		if !ok || pp.ResourceName == "" {
-			return cerrors.Newf(cerrors.InvalidArgument, "malformed networkInterface id %q", nic.ID)
+			return nil, cerrors.Newf(cerrors.InvalidArgument, "malformed networkInterface id %q", nic.ID)
 		}
 
 		if _, err := svc.GetNetworkInterface(ctx, pp.ResourceGroup, pp.ResourceName); err != nil {
-			return cerrors.Newf(cerrors.InvalidArgument,
+			return nil, cerrors.Newf(cerrors.InvalidArgument,
 				"networkProfile references network interface %q which does not exist", pp.ResourceName)
 		}
+
+		refs = append(refs, computedriver.AzureNICRef{ResourceGroup: pp.ResourceGroup, Name: pp.ResourceName})
 	}
 
-	return nil
+	return refs, nil
 }
 
 // updateExisting applies an idempotent CreateOrUpdate to an already-provisioned

--- a/server/azure/virtualmachines/nic_crossref_test.go
+++ b/server/azure/virtualmachines/nic_crossref_test.go
@@ -1,0 +1,168 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// createSDKNIC provisions a network interface with a single static
+// ipConfiguration through the real armnetwork SDK and polls to completion,
+// returning its ARM resource id.
+func createSDKNIC(t *testing.T, nicClient *armnetwork.InterfacesClient, name, privateIP string) string {
+	t.Helper()
+
+	poller, err := nicClient.BeginCreateOrUpdate(context.Background(), "rg-1", name, armnetwork.Interface{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig1"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					PrivateIPAddress:          to.Ptr(privateIP),
+					PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("nic BeginCreateOrUpdate %s: %v", name, err)
+	}
+
+	if _, err := poller.PollUntilDone(context.Background(),
+		&runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("nic poll %s: %v", name, err)
+	}
+
+	return "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/networkInterfaces/" + name
+}
+
+// createSDKVMWithNIC provisions a VM referencing nicID in its networkProfile
+// through the real armcompute SDK and polls to completion, returning the
+// created VM's ARM resource id.
+func createSDKVMWithNIC(
+	t *testing.T, client *armcompute.VirtualMachinesClient, name, nicID string,
+) (string, error) {
+	t.Helper()
+
+	poller, err := client.BeginCreateOrUpdate(context.Background(), "rg-1", name,
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				StorageProfile: &armcompute.StorageProfile{
+					OSDisk: &armcompute.OSDisk{OSType: to.Ptr(armcompute.OperatingSystemTypesLinux)},
+				},
+				NetworkProfile: &armcompute.NetworkProfile{
+					NetworkInterfaces: []*armcompute.NetworkInterfaceReference{{ID: to.Ptr(nicID)}},
+				},
+			},
+		}, nil)
+	if err != nil {
+		return "", err
+	}
+
+	created, err := poller.PollUntilDone(context.Background(),
+		&runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	if err != nil {
+		return "", err
+	}
+
+	if created.ID == nil {
+		t.Fatalf("create %s: response has no id", name)
+	}
+
+	return *created.ID, nil
+}
+
+// TestSDKCreateVMSetsNICBackReference is the load-bearing regression test for
+// the NIC<->VM cross-reference: creating a VM whose networkProfile references
+// a NIC must set that NIC's properties.virtualMachine.id, a second VM cannot
+// attach an already-attached NIC, and deleting the owning VM clears the
+// back-reference again (real Azure's InUseNetworkInterfaceCannotBeDeleted /
+// attach semantics — see MS Learn "Add or remove network interfaces": a NIC
+// belongs to exactly one VM at a time).
+func TestSDKCreateVMSetsNICBackReference(t *testing.T) {
+	// AccountID matches the "sub-1" subscription the SDK clients below address,
+	// mirroring a correctly-configured deployment (cloudemu serve
+	// --azure-subscription); the driver stamps VM resource ids from this
+	// account id, and they must equal the subscription callers see in the URL.
+	cloudP := cloudemu.NewAzure(config.WithAccountID("sub-1"))
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		Network:         cloudP.VNet,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	nicClient, err := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nicID := createSDKNIC(t, nicClient, "nic-vm-1", "10.0.1.50")
+
+	vmClient := newSDKClient(t, ts)
+
+	vmID, err := createSDKVMWithNIC(t, vmClient, "vm-1", nicID)
+	if err != nil {
+		t.Fatalf("create vm-1: %v", err)
+	}
+
+	// GET NIC must now report the owning VM.
+	got, err := nicClient.Get(ctx, "rg-1", "nic-vm-1", nil)
+	if err != nil {
+		t.Fatalf("nic Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.VirtualMachine == nil || got.Properties.VirtualMachine.ID == nil {
+		t.Fatal("nic properties.virtualMachine not set after VM create")
+	}
+
+	if *got.Properties.VirtualMachine.ID != vmID {
+		t.Errorf("nic virtualMachine.id=%q want %q", *got.Properties.VirtualMachine.ID, vmID)
+	}
+
+	// A second VM cannot attach the same, already-attached NIC.
+	if _, err := createSDKVMWithNIC(t, vmClient, "vm-2", nicID); err == nil {
+		t.Fatal("expected creating a second VM with an already-attached NIC to fail")
+	}
+
+	// Deleting the owning VM must clear the NIC's back-reference.
+	delPoller, err := vmClient.BeginDelete(ctx, "rg-1", "vm-1", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete vm-1: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("delete poll vm-1: %v", err)
+	}
+
+	afterDelete, err := nicClient.Get(ctx, "rg-1", "nic-vm-1", nil)
+	if err != nil {
+		t.Fatalf("nic Get after delete: %v", err)
+	}
+
+	if afterDelete.Properties != nil && afterDelete.Properties.VirtualMachine != nil {
+		t.Errorf("nic virtualMachine ref=%v, want cleared after owning VM delete", afterDelete.Properties.VirtualMachine)
+	}
+
+	// The NIC is now unattached and can be attached to a fresh VM.
+	if _, err := createSDKVMWithNIC(t, vmClient, "vm-3", nicID); err != nil {
+		t.Errorf("re-attach freed nic to vm-3: %v", err)
+	}
+}

--- a/server/azure/vnet/network_interface_test.go
+++ b/server/azure/vnet/network_interface_test.go
@@ -386,7 +386,78 @@ func TestSDKNetworkInterfacePublicIPDoubleAttachRejected(t *testing.T) {
 	}
 }
 
+// TestSDKNetworkInterfaceSoleIPConfigForcedPrimary verifies that a NIC's one
+// and only ipConfiguration is always reported primary, even when the request
+// submitted it as non-primary — real Azure forces this rather than leaving it
+// non-primary or erroring (Microsoft Learn, "Configure IP addresses for an
+// Azure network interface": "Each network interface is assigned one primary
+// IP configuration").
+func TestSDKNetworkInterfaceSoleIPConfigForcedPrimary(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Network: cloudP.VNet})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	opts := clientOpts(ts)
+	poll := &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}
+
+	nicClient, err := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	np, err := nicClient.BeginCreateOrUpdate(ctx, "rg-1", "nic-sole", armnetwork.Interface{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig1"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					PrivateIPAddress:          to.Ptr("10.0.1.50"),
+					PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+					Primary:                   to.Ptr(false),
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("nic BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := np.PollUntilDone(ctx, poll)
+	if err != nil {
+		t.Fatalf("nic poll: %v", err)
+	}
+
+	if !isPrimary(created.Properties) {
+		t.Error("sole ipConfiguration primary=false, want Azure to force it true")
+	}
+
+	got, err := nicClient.Get(ctx, "rg-1", "nic-sole", nil)
+	if err != nil {
+		t.Fatalf("nic Get: %v", err)
+	}
+
+	if !isPrimary(got.Interface.Properties) {
+		t.Error("GET sole ipConfiguration primary=false, want true")
+	}
+}
+
 // Helpers to read nested NIC response fields without repeating nil checks.
+
+func isPrimary(p *armnetwork.InterfacePropertiesFormat) bool {
+	if p == nil || len(p.IPConfigurations) == 0 {
+		return false
+	}
+
+	ipc := p.IPConfigurations[0]
+	if ipc.Properties == nil || ipc.Properties.Primary == nil {
+		return false
+	}
+
+	return *ipc.Properties.Primary
+}
 
 func provisioningState(p *armnetwork.InterfacePropertiesFormat) string {
 	if p == nil || p.ProvisioningState == nil {

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -48,6 +48,21 @@ type InstanceConfig struct {
 	// meaningful on input — PrincipalID/TenantID/ClientID are provider-
 	// synthesized output, ignored here. Ignored by AWS/GCP.
 	Identity *ManagedIdentity
+	// NetworkInterfaces are the NICs referenced by the VM's
+	// networkProfile.networkInterfaces (Azure), resolved from each entry's ARM
+	// resource id down to the (resourceGroup, name) pair the networking mock
+	// is keyed by. The provider attaches each one to the launched instance,
+	// setting the NIC's properties.virtualMachine back-reference. Ignored by
+	// AWS/GCP.
+	NetworkInterfaces []AzureNICRef
+}
+
+// AzureNICRef identifies a Network Interface (Microsoft.Network/networkInterfaces)
+// by its (resourceGroup, name) pair, as resolved from the ARM resource id
+// referenced in networkProfile.networkInterfaces. Azure-only.
+type AzureNICRef struct {
+	ResourceGroup string
+	Name          string
 }
 
 // IamInstanceProfile is the IAM instance profile association reported on an EC2


### PR DESCRIPTION
## Summary

Two Azure Network Interface bugs, reproduced with real `armnetwork` + `armcompute` clients against the wire server.

1. **NIC<->VM cross-reference was one-directional (blocker).** Creating a VM whose `networkProfile.networkInterfaces` referenced a NIC by ARM id never set the NIC's `properties.virtualMachine` back-reference, so `GetNetworkInterface` never reported the owning VM — and `DeleteNetworkInterface`'s attached-NIC guard was dead code, since nothing ever populated `VirtualMachineID`.

   Fixed with a `NICAttacher` hook (`providers/azure/virtualmachines` -> `providers/azure/vnet`), wired through the provider factory the same way `SubnetResolver`/`InstanceProfileResolver` are (no cross-provider import). VM create attaches every referenced NIC (rejecting an attach to a NIC already attached to a *different* VM — the reverse safety check is now live); VM delete detaches them.

2. **A NIC's sole `ipConfiguration` wasn't forced primary.** Real Azure always reports the single ipConfiguration as primary regardless of what was submitted ("Each network interface is assigned one primary IP configuration" — [MS Learn](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/virtual-network-network-interface-addresses)). `resolveIPConfigs` now forces `primary=true` when there's exactly one ipConfiguration, and validates exactly one primary is marked when there's more than one ("A network interface can't have more than one Primary IP configuration" — same source).

Deferred (per scope): Application Security Groups, and the `effectiveRouteTable`/`effectiveNSG` NIC sub-resource actions.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./providers/azure/vnet/... ./providers/azure/virtualmachines/... ./server/azure/virtualmachines/... ./server/azure/vnet/... ./services/compute/... ./providers/azure/... ./features/chaos/...`
- [x] `go test -race ./providers/azure/vnet/... ./providers/azure/virtualmachines/...`
- [x] `golangci-lint run` on changed packages (0 new issues)
- [x] `gofmt -l` clean
- [x] New real-SDK regression tests: `TestSDKCreateVMSetsNICBackReference` (attach on create, reject double-attach, detach on delete, re-attach after free) and `TestSDKNetworkInterfaceSoleIPConfigForcedPrimary`
