### PR TITLE
chore(ec2): per-entity locking for instanceData + document concurrency idiom (#587)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,6 +113,19 @@ p.GCE.SetMonitoring(p.CloudMonitoring)     // GCP
 
 The source tree mirrors the layers — `services/<svc>/` (portable API + `driver/`), `providers/<cloud>/<service>/` (mocks), `server/<cloud>/<service>/` (wire handlers) — plus the `contrib/*` sibling modules. See [STRUCTURE.md](STRUCTURE.md) for the full layout, naming rules, and where new code goes.
 
+## Concurrency & thread safety
+
+Mocks are hit concurrently — the wire server serves requests on many goroutines, and SDK/CLI callers fan out. `internal/memstore.Store[V]` makes only the **map operations** (`Get`/`Set`/`Delete`/`All`/…) atomic. When a store holds pointers (`Store[*fooData]`), the pointed-to struct has **no** synchronization of its own: two goroutines mutating the same entity's fields, or one mutating while another reads, is a data race.
+
+So the rule for any entity that is stored as a pointer and mutated after it is first put in the store:
+
+- **Give the stored struct its own `sync.Mutex` (or `RWMutex`) and hold it around every read and write of its mutable fields.** The exemplar is `providers/aws/sqs.queueData.mu`; `providers/aws/ec2.instanceData.mu` follows the same pattern (it also keeps the readable `State` field in lockstep, under the lock, with the authoritative `statemachine.Machine` transition). Initialize an entity fully **before** `Set`-ing it into the store, so a concurrent reader can never observe a half-written struct.
+- **Or** apply the change through `memstore.Store.Update(key, fn)`, which performs the read-modify-write while holding the store lock.
+
+Never do `v, _ := store.Get(k); mutate(v); store.Set(k, v)` as a way to "update" shared state. Beyond the field-level race, `Get`-then-`Set` is a **lost-update** race: two callers read the same value, each mutates its copy, and the second `Set` silently clobbers the first. This is a logical check-then-act race that the `-race` detector does **not** catch (no conflicting memory access on the same address), so it will not show up in CI — use `Update` or a per-entity lock instead.
+
+An advisory `go test -race ./...` job runs in CI while the per-entity locking is rolled out mock by mock (see #587).
+
 ## Fourth provider: OCI (in progress)
 
 OCI (`providers/oci/`) follows the same three-layer shape: a `memstore`-backed mock per service implementing the shared driver, plus a `server/oci/<service>/` handler. Its foundation is in place (identity options, OCID generation in `internal/idgen/ocid.go`, `services/scope` compartment scoping, the `server/wire/ocirest` format, and the `server/oci/workrequest` async envelope); services land one PR at a time — see [oci-conventions.md](oci-conventions.md).

--- a/providers/aws/ec2/concurrency_test.go
+++ b/providers/aws/ec2/concurrency_test.go
@@ -1,0 +1,65 @@
+package ec2
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+// TestConcurrentInstanceLifecycleRaceFree hammers a single instance with
+// concurrent Start/Stop/Reboot/Describe/CreateTags/GetInstanceAttribute calls.
+// Every one of these paths reads or mutates fields on the shared *instanceData,
+// so without per-entity synchronization the -race detector flags a data race on
+// State, Tags or settle. It must run clean under `go test -race`.
+func TestConcurrentInstanceLifecycleRaceFree(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{ImageID: "ami-123", InstanceType: "t2.micro"}, 1)
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	id := insts[0].ID
+	ids := []string{id}
+
+	const workers = 8
+
+	const iterations = 40
+
+	var wg sync.WaitGroup
+
+	run := func(fn func()) {
+		defer wg.Done()
+
+		for i := 0; i < iterations; i++ {
+			fn()
+		}
+	}
+
+	wg.Add(6 * workers)
+
+	for w := 0; w < workers; w++ {
+		go run(func() { _ = m.StartInstances(ctx, ids) })
+		go run(func() { _ = m.StopInstances(ctx, ids) })
+		go run(func() { _ = m.RebootInstances(ctx, ids) })
+		go run(func() { _, _ = m.DescribeInstances(ctx, ids, nil) })
+		go run(func() { _ = m.TagResource(ctx, id, map[string]string{"k": "v"}) })
+		go run(func() { _, _ = m.GetInstanceAttribute(ctx, id, attrMonitoring) })
+	}
+
+	wg.Wait()
+
+	// The instance must still be describable and in a valid terminal state after
+	// the storm, proving the locking preserved a consistent view.
+	out, err := m.DescribeInstances(ctx, ids, nil)
+	if err != nil {
+		t.Fatalf("DescribeInstances after storm: %v", err)
+	}
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(out))
+	}
+}

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -141,9 +141,21 @@ var (
 )
 
 type instanceData struct {
-	ID             string
-	ImageID        string
-	InstanceType   string
+	// mu guards every field below that is mutated after the instance is first
+	// published to m.instances (State, settle, Tags, InstanceType,
+	// SecurityGroups, VPCID and the ModifyInstanceAttribute-backed flags). Any
+	// path that reads or writes those fields on a stored instance MUST hold mu
+	// for the duration — memstore only makes the map lookup atomic, not the
+	// pointed-to struct (see docs/architecture.md, "Concurrency & thread
+	// safety"). The exemplar is providers/aws/sqs.queueData.mu.
+	mu           sync.Mutex
+	ID           string
+	ImageID      string
+	InstanceType string
+	// State is the readable instance state. The authoritative transition
+	// validator is m.sm (internal/statemachine, itself locked); State is the
+	// synchronized mirror rendered by Describe, and is only ever written under
+	// mu in lockstep with an m.sm transition.
 	State          string
 	PrivateIP      string
 	PublicIP       string
@@ -195,6 +207,32 @@ type instanceData struct {
 type operatorData struct {
 	Managed   bool
 	Principal string
+}
+
+// terminationProtected reports the DisableApiTermination flag under mu.
+func (d *instanceData) terminationProtected() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.disableAPITermination
+}
+
+// isEngineBacked reports whether a real compute engine backs this instance,
+// read under mu.
+func (d *instanceData) isEngineBacked() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.engineBacked
+}
+
+// clearEngineBacked drops the engine-backed flag under mu, after the backing
+// has been deprovisioned.
+func (d *instanceData) clearEngineBacked() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.engineBacked = false
 }
 
 type asgData struct {
@@ -355,6 +393,9 @@ func (m *Mock) nextIP() string {
 // account-level managed-resource-visibility ("hidden") resolved once by the
 // caller, so this never touches m.mu (avoiding nested read locks).
 func toInstance(d *instanceData, hidden bool, now time.Time) driver.Instance {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	sg := make([]string, len(d.SecurityGroups))
 	copy(sg, d.SecurityGroups)
 
@@ -415,6 +456,9 @@ func (m *Mock) ModifyInstanceMetadataOptions(
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
 	}
+
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
 
 	opts := inst.metadataOptions
 	if opts.State == "" {
@@ -547,12 +591,14 @@ func (m *Mock) launchInstances(ctx context.Context, cfg driver.InstanceConfig, c
 			inst.engineBacked = true
 		}
 
-		m.instances.Set(id, inst)
 		m.sm.SetState(id, compute.StatePending)
 		_ = m.sm.Transition(id, compute.StateRunning)
 		inst.State = compute.StateRunning
 		inst.settle = settle.Pending(compute.StatePending, m.opts.Clock.Now(),
 			m.opts.SettleDuration(settle.DefaultInstanceSettle))
+		// Publish only after the instance is fully initialized so a concurrent
+		// Describe can never observe a half-written State/settle.
+		m.instances.Set(id, inst)
 		results = append(results, toInstance(inst, hidden, m.opts.Clock.Now()))
 		created = append(created, inst)
 
@@ -696,32 +742,50 @@ func (m *Mock) transitionInstances(ctx context.Context, instanceIDs []string, t 
 			return cerrors.Newf(cerrors.NotFound, "instance %q not found", id)
 		}
 
-		// Real AWS EC2 documents Start/Stop as idempotent on the target
-		// state. Skip the state machine and return success without changing
-		// state when we're already there.
-		if isIdempotent(inst.State, t.idempotentStates) {
-			continue
+		changed, err := m.transitionOne(inst, id, t)
+		if err != nil {
+			return err
 		}
-
-		if err := m.sm.Transition(id, t.intermediateState); err != nil {
-			return cerrors.Newf(cerrors.FailedPrecondition, "cannot %s instance %q: %v", t.errVerb, id, err)
-		}
-
-		inst.State = t.intermediateState
-		_ = m.sm.Transition(id, t.finalState)
-		inst.State = t.finalState
-		// A lifecycle transition supersedes any post-launch settle window, so the
-		// instance reports its new terminal state rather than a stale "pending".
-		inst.settle = settle.Window{}
 
 		// Managed instances are hidden from Describe; keep them out of metrics
-		// too so a hidden instance isn't observable via CloudWatch.
-		if !isManaged(inst) {
+		// too so a hidden instance isn't observable via CloudWatch. Emitted
+		// outside inst.mu so a metrics callback can't deadlock against it.
+		if changed && !isManaged(inst) {
 			m.emitLifecycleMetrics(ctx, id, t.metricValues)
 		}
 	}
 
 	return nil
+}
+
+// transitionOne applies one lifecycle transition to inst under its own lock,
+// keeping inst.State in lockstep with the m.sm transition. It reports whether
+// the state actually changed (false when the request was idempotent).
+//
+//nolint:gocritic // t is a small read-only config; copying once per call is fine.
+func (m *Mock) transitionOne(inst *instanceData, id string, t lifecycleTransition) (bool, error) {
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+
+	// Real AWS EC2 documents Start/Stop as idempotent on the target state. Skip
+	// the state machine and return success without changing state when we're
+	// already there.
+	if isIdempotent(inst.State, t.idempotentStates) {
+		return false, nil
+	}
+
+	if err := m.sm.Transition(id, t.intermediateState); err != nil {
+		return false, cerrors.Newf(cerrors.FailedPrecondition, "cannot %s instance %q: %v", t.errVerb, id, err)
+	}
+
+	inst.State = t.intermediateState
+	_ = m.sm.Transition(id, t.finalState)
+	inst.State = t.finalState
+	// A lifecycle transition supersedes any post-launch settle window, so the
+	// instance reports its new terminal state rather than a stale "pending".
+	inst.settle = settle.Window{}
+
+	return true, nil
 }
 
 func isIdempotent(state string, idempotentStates []string) bool {
@@ -750,7 +814,7 @@ func (m *Mock) TerminateInstances(ctx context.Context, instanceIDs []string) err
 	// Termination protection: real EC2 rejects the whole call with
 	// OperationNotPermitted if any target has DisableApiTermination set.
 	for _, id := range instanceIDs {
-		if inst, ok := m.instances.Get(id); ok && inst.disableAPITermination {
+		if inst, ok := m.instances.Get(id); ok && inst.terminationProtected() {
 			return cerrors.Newf(cerrors.PermissionDenied,
 				"instance %q may not be terminated: termination protection is enabled", id)
 		}
@@ -772,18 +836,20 @@ func (m *Mock) TerminateInstances(ctx context.Context, instanceIDs []string) err
 
 	for _, id := range instanceIDs {
 		inst, ok := m.instances.Get(id)
-		if !ok || !inst.engineBacked {
+		if !ok || !inst.isEngineBacked() {
 			continue
 		}
 
 		di := driver.Instance{ID: inst.ID}
+		// Deprovision is a potentially blocking engine call, so it runs outside
+		// inst.mu; only the flag flip is taken under the lock.
 		if err := computeengine.Deprovision(ctx, engine, &di); err != nil {
 			errs = append(errs, err)
 
 			continue
 		}
 
-		inst.engineBacked = false
+		inst.clearEngineBacked()
 		m.instances.Set(id, inst)
 	}
 
@@ -799,7 +865,7 @@ func (m *Mock) GetConsoleOutput(ctx context.Context, instanceID string) ([]byte,
 		return nil, cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
 	}
 
-	if !inst.engineBacked {
+	if !inst.isEngineBacked() {
 		return nil, nil
 	}
 
@@ -892,6 +958,11 @@ func (m *Mock) visibility() string {
 }
 
 func matchesFilters(inst *instanceData, filters []driver.DescribeFilter, now time.Time) bool {
+	// Filters read mutable fields (State, settle, InstanceType, Tags), so match
+	// under the instance's own lock to stay consistent with concurrent writers.
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+
 	for _, f := range filters {
 		if !matchesSingleFilter(inst, f, now) {
 			return false
@@ -945,6 +1016,9 @@ func (m *Mock) ModifyInstance(_ context.Context, instanceID string, input driver
 		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
 	}
 
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+
 	if inst.State != compute.StateStopped {
 		return cerrors.Newf(cerrors.FailedPrecondition, "instance %q must be stopped to modify", instanceID)
 	}
@@ -954,6 +1028,10 @@ func (m *Mock) ModifyInstance(_ context.Context, instanceID string, input driver
 	}
 
 	if input.Tags != nil {
+		if inst.Tags == nil {
+			inst.Tags = map[string]string{}
+		}
+
 		for k, v := range input.Tags {
 			inst.Tags[k] = v
 		}
@@ -984,6 +1062,9 @@ func (m *Mock) SetInstanceAttribute(_ context.Context, instanceID, name, value s
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
 	}
+
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
 
 	switch name {
 	case attrDisableAPITermination:
@@ -1022,7 +1103,10 @@ func (m *Mock) SetInstanceSecurityGroups(_ context.Context, instanceID string, g
 
 	sg := make([]string, len(groupIDs))
 	copy(sg, groupIDs)
+
+	inst.mu.Lock()
 	inst.SecurityGroups = sg
+	inst.mu.Unlock()
 
 	return nil
 }
@@ -1034,6 +1118,9 @@ func (m *Mock) GetInstanceAttribute(_ context.Context, instanceID, name string) 
 	if !ok {
 		return "", cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
 	}
+
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
 
 	switch name {
 	case attrDisableAPITermination:
@@ -1061,7 +1148,9 @@ func (m *Mock) SetInstanceVPC(instanceID, vpcID string) error {
 		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
 	}
 
+	inst.mu.Lock()
 	inst.VPCID = vpcID
+	inst.mu.Unlock()
 
 	return nil
 }

--- a/providers/aws/ec2/tags.go
+++ b/providers/aws/ec2/tags.go
@@ -7,18 +7,12 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 )
 
-// tagsOf resolves an EC2 resource ID (by prefix) to its mutable tag map.
-// Returns false when the ID is unknown or the resource does not exist.
+// tagsOf resolves a non-instance EC2 resource ID (by prefix) to its mutable tag
+// map. Returns false when the ID is unknown or the resource does not exist.
+// Instances are handled separately by mutateInstanceTags because their tag map
+// is guarded by the per-instance instanceData.mu, not m.mu.
 func (m *Mock) tagsOf(id string) (map[string]string, bool) {
 	switch {
-	case strings.HasPrefix(id, "i-"):
-		if d, ok := m.instances.Get(id); ok {
-			if d.Tags == nil {
-				d.Tags = map[string]string{}
-			}
-
-			return d.Tags, true
-		}
 	case strings.HasPrefix(id, "vol-"):
 		if d, ok := m.volumes.Get(id); ok {
 			if d.Tags == nil {
@@ -48,10 +42,45 @@ func (m *Mock) tagsOf(id string) (map[string]string, bool) {
 	return nil, false
 }
 
+// mutateInstanceTags runs fn against an instance's tag map under that instance's
+// own lock, so CreateTags/DeleteTags never race a concurrent DescribeInstances
+// read of the same map. Returns false when the instance does not exist.
+func (m *Mock) mutateInstanceTags(id string, fn func(map[string]string)) bool {
+	inst, ok := m.instances.Get(id)
+	if !ok {
+		return false
+	}
+
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+
+	if inst.Tags == nil {
+		inst.Tags = map[string]string{}
+	}
+
+	fn(inst.Tags)
+
+	return true
+}
+
 // TagResource applies tags to an EC2 instance, volume, snapshot, or image by
 // ID. This backs the EC2 CreateTags API for compute resources (VPC-family IDs
 // are handled by the networking provider). Returns NotFound for an unknown ID.
 func (m *Mock) TagResource(_ context.Context, id string, tags map[string]string) error {
+	apply := func(dst map[string]string) {
+		for k, v := range tags {
+			dst[k] = v
+		}
+	}
+
+	if strings.HasPrefix(id, "i-") {
+		if !m.mutateInstanceTags(id, apply) {
+			return cerrors.Newf(cerrors.NotFound, "resource %q not found", id)
+		}
+
+		return nil
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -60,9 +89,7 @@ func (m *Mock) TagResource(_ context.Context, id string, tags map[string]string)
 		return cerrors.Newf(cerrors.NotFound, "resource %q not found", id)
 	}
 
-	for k, v := range tags {
-		dst[k] = v
-	}
+	apply(dst)
 
 	return nil
 }
@@ -70,6 +97,28 @@ func (m *Mock) TagResource(_ context.Context, id string, tags map[string]string)
 // UntagResource removes tags by key from an EC2 resource. An empty key list
 // clears all tags, matching EC2 DeleteTags semantics.
 func (m *Mock) UntagResource(_ context.Context, id string, keys []string) error {
+	remove := func(dst map[string]string) {
+		if len(keys) == 0 {
+			for k := range dst {
+				delete(dst, k)
+			}
+
+			return
+		}
+
+		for _, k := range keys {
+			delete(dst, k)
+		}
+	}
+
+	if strings.HasPrefix(id, "i-") {
+		if !m.mutateInstanceTags(id, remove) {
+			return cerrors.Newf(cerrors.NotFound, "resource %q not found", id)
+		}
+
+		return nil
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -78,17 +127,7 @@ func (m *Mock) UntagResource(_ context.Context, id string, keys []string) error 
 		return cerrors.Newf(cerrors.NotFound, "resource %q not found", id)
 	}
 
-	if len(keys) == 0 {
-		for k := range dst {
-			delete(dst, k)
-		}
-
-		return nil
-	}
-
-	for _, k := range keys {
-		delete(dst, k)
-	}
+	remove(dst)
 
 	return nil
 }

--- a/providers/aws/ec2/template.go
+++ b/providers/aws/ec2/template.go
@@ -378,6 +378,9 @@ func (m *Mock) GetLaunchTemplateData(_ context.Context, instanceID string) (*dri
 		return nil, cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
 	}
 
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+
 	sg := make([]string, len(inst.SecurityGroups))
 	copy(sg, inst.SecurityGroups)
 


### PR DESCRIPTION
## Summary

Architecture Theme 1 (concurrency safety, #587), step 2 + step 3.

`internal/memstore.Store[V]` makes only the map operation atomic; a `Store[*T]`
hands out a shared pointer whose fields have no synchronization of their own.
EC2's `instanceData` was mutated in place (lifecycle `State`, `settle`, `Tags`,
attribute flags) with no per-entity lock, so concurrent `Start`/`Stop` and
`DescribeInstances`/`CreateTags` on the same instance race — confirmed by the
advisory `-race` job.

## What changed

- **Document the idiom** — new "Concurrency & thread safety" section in
  `docs/architecture.md`: a pointer entity stored in a memstore and mutated
  after creation must carry its own `sync.Mutex` (exemplar
  `providers/aws/sqs.queueData.mu`), or use `memstore.Store.Update` for
  read-modify-write; never `Get()`-then-`Set()` (a lost-update race the `-race`
  detector cannot catch).

- **Fix EC2 concurrency** — add `instanceData.mu` guarding every mutable field.
  All lifecycle/attribute/tag reads and writes now hold it (render, filter
  match, transitions, `Modify*`, `Set/GetInstanceAttribute`, tag mutations,
  launch-template read). Lifecycle transitions extracted into `transitionOne`,
  which keeps the readable `State` field in lockstep with the (already-locked)
  `statemachine.Machine` under the entity lock — collapsing the previously
  unsynchronized duplicate state. Instances are now published to the store only
  after full initialization, closing a publish-then-mutate window.

- **Regression test** — `TestConcurrentInstanceLifecycleRaceFree` hammers one
  instance with concurrent Start/Stop/Reboot/Describe/CreateTags/GetAttribute;
  it flagged data races before the fix and is race-clean after.

Behavior is unchanged — this is a safety fix, not a behavior change.

## Gates

- `go build ./...`, `go vet ./...` clean
- `go test ./providers/aws/ec2/... ./server/aws/ec2/...` pass
- `go test -race ./providers/aws/ec2/...` race-clean (incl. the new test)
- `gofmt` clean; `golangci-lint` no new issues (one pre-existing `prealloc` in
  untouched `describeCandidates`)

## Out of scope (remaining #587 work)

Step 4 — rolling the per-entity locking pattern out across the other provider
mocks and flipping the advisory `-race` CI job to blocking.
