### PR TITLE
feat(persist): per-driver identity-preserving snapshotting (Phase 1, refs #582)

### DIFF
--- a/internal/memstore/store.go
+++ b/internal/memstore/store.go
@@ -2,6 +2,7 @@
 package memstore
 
 import (
+	"encoding/json"
 	"sort"
 	"sync"
 )
@@ -145,6 +146,32 @@ func (s *Store[V]) Filter(fn func(key string, value V) bool) map[string]V {
 	}
 
 	return result
+}
+
+// Snapshot serializes the whole store as a JSON object keyed by id
+// (map[string]V), so a restore can reinstate every value under its exact key.
+// Identity is preserved: the keys are the resource ids and round-trip unchanged.
+// V must be JSON-serializable for the dump to be lossless — a value type with
+// unexported data fields needs an exported snapshot form or custom JSON methods.
+func (s *Store[V]) Snapshot() ([]byte, error) {
+	return json.Marshal(s.All())
+}
+
+// LoadSnapshot restores a store from Snapshot's output, Set-ing each value under
+// the same key it was dumped with, so ids and any id-string cross-references
+// survive. It merges onto whatever the store already holds (a fresh store is
+// empty), leaving existing unrelated keys untouched.
+func (s *Store[V]) LoadSnapshot(data []byte) error {
+	var items map[string]V
+	if err := json.Unmarshal(data, &items); err != nil {
+		return err
+	}
+
+	for k, v := range items {
+		s.Set(k, v)
+	}
+
+	return nil
 }
 
 // SortedValues returns the values ordered by their keys. List endpoints

--- a/internal/memstore/store_snapshot_test.go
+++ b/internal/memstore/store_snapshot_test.go
@@ -1,0 +1,66 @@
+package memstore
+
+import (
+	"testing"
+)
+
+type snapValue struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+// TestStoreSnapshotRoundTrip proves a store's Snapshot/LoadSnapshot round-trip
+// preserves both keys (identity) and values.
+func TestStoreSnapshotRoundTrip(t *testing.T) {
+	src := New[snapValue]()
+	src.Set("id-1", snapValue{Name: "alpha", Count: 3})
+	src.Set("id-2", snapValue{Name: "beta", Count: 7})
+
+	data, err := src.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	dst := New[snapValue]()
+	if err := dst.LoadSnapshot(data); err != nil {
+		t.Fatalf("LoadSnapshot: %v", err)
+	}
+
+	if dst.Len() != 2 {
+		t.Fatalf("restored len = %d, want 2", dst.Len())
+	}
+
+	for _, key := range []string{"id-1", "id-2"} {
+		want, _ := src.Get(key)
+		got, ok := dst.Get(key)
+		if !ok {
+			t.Fatalf("restored store missing key %q", key)
+		}
+
+		if got != want {
+			t.Fatalf("restored[%q] = %+v, want %+v", key, got, want)
+		}
+	}
+}
+
+// TestStoreLoadSnapshotMerges verifies LoadSnapshot restores under the original
+// keys onto a store that already holds unrelated entries.
+func TestStoreLoadSnapshotMerges(t *testing.T) {
+	src := New[snapValue]()
+	src.Set("id-1", snapValue{Name: "alpha"})
+
+	data, err := src.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	dst := New[snapValue]()
+	dst.Set("id-existing", snapValue{Name: "keep"})
+	if err := dst.LoadSnapshot(data); err != nil {
+		t.Fatalf("LoadSnapshot: %v", err)
+	}
+
+	if !dst.Has("id-existing") || !dst.Has("id-1") {
+		t.Fatalf("expected both existing and restored keys, got keys %v", dst.Keys())
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -1,0 +1,27 @@
+// Package snapshot defines the optional per-driver snapshotting contract a mock
+// implements so persist can capture and restore its state identity-preservingly.
+//
+// It is a leaf package — it imports only context and encoding/json — so any mock
+// can implement Snapshottable without risking an import cycle back into persist,
+// exactly like internal/memstore. persist type-asserts each driver to this
+// interface and falls back to its bespoke path for mocks that do not implement
+// it yet.
+package snapshot
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// Snapshottable is implemented by a service mock that can serialize its entire
+// in-memory state to JSON and restore it under the same identities (resource
+// IDs, cross-reference keys), so a snapshot/restore round-trip is transparent to
+// clients — unlike a driver-level replay that mints fresh IDs.
+//
+// includeAssets selects whether large object bodies (e.g. S3 object bytes) are
+// captured; false yields a metadata-only snapshot. Restore is called on a
+// freshly built (empty) mock.
+type Snapshottable interface {
+	Snapshot(ctx context.Context, includeAssets bool) (json.RawMessage, error)
+	Restore(ctx context.Context, data json.RawMessage) error
+}

--- a/persist/dynamodb_number_persist_test.go
+++ b/persist/dynamodb_number_persist_test.go
@@ -21,7 +21,7 @@ func TestRetypeItemRestoresNumber(t *testing.T) {
 		"nested": map[string]any{"inner": map[string]any{expr.NumberJSONTag: "42"}},
 		"list":   []any{map[string]any{expr.NumberJSONTag: "7"}, "s"},
 	}
-	got := retypeItem(item)
+	got := expr.RetypeItem(item)
 	if got["big"] != expr.Number("123456789012345678901234567890") {
 		t.Fatalf("big = %#v, want exact-decimal Number", got["big"])
 	}

--- a/persist/identity_test.go
+++ b/persist/identity_test.go
@@ -1,0 +1,135 @@
+package persist_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/persist"
+	"github.com/stackshy/cloudemu/v2/seed"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+// TestIdentityPreservedAcrossRestore is the headline guarantee of the per-driver
+// snapshot: after a full Export→JSON→Restore into a FRESH provider, resource
+// identifiers and id-string cross-references survive unchanged. In particular an
+// EC2 instance keeps the SAME instance id and its security-group reference — the
+// thing the old driver-replay compute path could not do (it minted a fresh id).
+func TestIdentityPreservedAcrossRestore(t *testing.T) {
+	ctx := context.Background()
+
+	src := cloudemu.NewAWS()
+
+	// S3 bucket + object (with bytes).
+	if err := src.S3.CreateBucket(ctx, "app-data"); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	if err := src.S3.PutObject(ctx, "app-data", "config.yaml", []byte("port: 8080"), "text/yaml", nil); err != nil {
+		t.Fatalf("put object: %v", err)
+	}
+
+	// DynamoDB table + item.
+	if err := src.DynamoDB.CreateTable(ctx, dbdriver.TableConfig{Name: "users", PartitionKey: "id"}); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if err := src.DynamoDB.PutItem(ctx, "users", map[string]any{"id": "u1", "name": "Ada"}); err != nil {
+		t.Fatalf("put item: %v", err)
+	}
+
+	// Secret.
+	if _, err := src.SecretsManager.CreateSecret(ctx, secretsdriver.SecretConfig{Name: "db-password"}, []byte("s3cr3t")); err != nil {
+		t.Fatalf("create secret: %v", err)
+	}
+
+	// EC2 instance launched with a security group.
+	const sgID = "sg-0abc123"
+
+	launched, err := src.EC2.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "ami-123", InstanceType: "t3.micro", SecurityGroups: []string{sgID},
+	}, 1)
+	if err != nil {
+		t.Fatalf("run instances: %v", err)
+	}
+	if len(launched) != 1 {
+		t.Fatalf("launched %d instances, want 1", len(launched))
+	}
+
+	wantInstanceID := launched[0].ID
+
+	// Export the whole emulator to JSON bytes, exactly as the on-disk snapshot.
+	tSrc := seed.Target{Storage: src.S3, Database: src.DynamoDB, Secrets: src.SecretsManager, Compute: src.EC2}
+
+	snap, err := persist.ExportAll(ctx, map[string]seed.Target{"aws": tSrc}, persist.Options{IncludeAssets: true})
+	if err != nil {
+		t.Fatalf("ExportAll: %v", err)
+	}
+
+	raw, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+
+	var got persist.Snapshot
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal snapshot: %v", err)
+	}
+
+	// Restore into a completely fresh provider.
+	dst := cloudemu.NewAWS()
+	tDst := seed.Target{Storage: dst.S3, Database: dst.DynamoDB, Secrets: dst.SecretsManager, Compute: dst.EC2}
+	if err := persist.RestoreAll(ctx, &got, map[string]seed.Target{"aws": tDst}); err != nil {
+		t.Fatalf("RestoreAll: %v", err)
+	}
+
+	// EC2 instance keeps its identity and its SG cross-reference.
+	insts, err := dst.EC2.DescribeInstances(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("describe restored instances: %v", err)
+	}
+	if len(insts) != 1 {
+		t.Fatalf("restored %d instances, want 1", len(insts))
+	}
+	if insts[0].ID != wantInstanceID {
+		t.Fatalf("restored instance id = %q, want SAME id %q", insts[0].ID, wantInstanceID)
+	}
+	if len(insts[0].SecurityGroups) != 1 || insts[0].SecurityGroups[0] != sgID {
+		t.Fatalf("restored SG reference = %v, want [%s]", insts[0].SecurityGroups, sgID)
+	}
+
+	// The restored instance is still a live, transitionable resource: the state
+	// machine was re-registered, so a Stop succeeds (it would fail "not found" if
+	// only the record — not the FSM state — had been restored).
+	if err := dst.EC2.StopInstances(ctx, []string{wantInstanceID}); err != nil {
+		t.Fatalf("stop restored instance: %v", err)
+	}
+
+	// S3 object bytes survive.
+	obj, err := dst.S3.GetObject(ctx, "app-data", "config.yaml")
+	if err != nil {
+		t.Fatalf("get restored object: %v", err)
+	}
+	if string(obj.Data) != "port: 8080" {
+		t.Fatalf("restored object body = %q, want %q", obj.Data, "port: 8080")
+	}
+
+	// DynamoDB item survives.
+	item, err := dst.DynamoDB.GetItem(ctx, "users", map[string]any{"id": "u1"})
+	if err != nil {
+		t.Fatalf("get restored item: %v", err)
+	}
+	if item == nil || item["name"] != "Ada" {
+		t.Fatalf("restored item = %v, want {id:u1,name:Ada}", item)
+	}
+
+	// Secret value survives.
+	sv, err := dst.SecretsManager.GetSecretValue(ctx, "db-password", "")
+	if err != nil {
+		t.Fatalf("get restored secret: %v", err)
+	}
+	if string(sv.Value) != "s3cr3t" {
+		t.Fatalf("restored secret value = %q, want s3cr3t", sv.Value)
+	}
+}

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -1,12 +1,14 @@
 // Package persist snapshots cloudemu provider state to disk and restores it, so
 // emulated resources survive a stop/start of the standalone server.
 //
-// State can't be serialized generically (Go has no pickle; the in-memory value
-// types hold mutexes, funcs, and nested stores that no reflection codec can
-// round-trip). Instead Export/Restore read and write through the same
-// provider-agnostic driver interfaces the seed package uses — so one snapshot
-// format spans AWS, Azure, and GCP, and the on-disk file is human-readable and
-// diffable JSON rather than an opaque binary blob.
+// A mock that implements internal/snapshot.Snapshottable serializes its own
+// full state (identity-preserving: resource ids and id-string cross-references
+// survive), captured under ProviderState.Services keyed by service name. For a
+// mock that does not implement it yet, Export/Restore fall back to the bespoke
+// path that reads and writes through the same provider-agnostic driver
+// interfaces the seed package uses — so one snapshot format still spans AWS,
+// Azure, and GCP as more services migrate. Either way the on-disk file is
+// human-readable, diffable JSON rather than an opaque binary blob.
 package persist
 
 import (
@@ -17,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
 	"github.com/stackshy/cloudemu/v2/seed"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
@@ -25,20 +28,30 @@ import (
 	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
 )
 
-// SchemaVersion is the on-disk snapshot format version. Bump it on a
-// backward-incompatible change to the JSON shape.
-const SchemaVersion = 1
+// SchemaVersion is the on-disk snapshot format version. Bumped to 2 for the
+// per-driver identity-preserving layout (a migrated service's mock serializes
+// its own state under ProviderState.Services); a v1 snapshot is rejected on
+// load. Snapshots are a dev-only convenience, so a clean break is acceptable.
+const SchemaVersion = 2
 
 const (
 	defaultContentType = "application/octet-stream"
 
 	dirPerm = 0o755
+
+	// Service names keying ProviderState.Services for the generic (per-driver
+	// Snapshottable) path.
+	svcStorage  = "storage"
+	svcDatabase = "database"
+	svcSecrets  = "secrets"
+	svcCompute  = "compute"
 )
 
 // Sentinel errors so callers (and err113) get static, wrappable failures.
 var (
-	errNoDriver = errors.New("snapshot names a resource kind with no driver in the target")
-	errSchema   = errors.New("unsupported snapshot schema version")
+	errNoDriver        = errors.New("snapshot names a resource kind with no driver in the target")
+	errSchema          = errors.New("unsupported snapshot schema version")
+	errNotSnapshotable = errors.New("snapshot carries per-driver state for a service whose target driver is not snapshottable")
 )
 
 // Snapshot is a multi-cloud, point-in-time capture of provider state, written
@@ -59,12 +72,17 @@ type Meta struct {
 	Providers       []string `json:"providers,omitempty"`
 }
 
-// ProviderState is a single provider's persisted resources.
+// ProviderState is a single provider's persisted resources. Services holds the
+// per-driver identity-preserving snapshots (keyed by service name) for mocks
+// that implement snapshot.Snapshottable; the remaining fields hold the bespoke
+// fallback capture for mocks not yet migrated. For any given service exactly one
+// representation is populated.
 type ProviderState struct {
-	Buckets   []Bucket   `json:"buckets,omitempty"`
-	Tables    []Table    `json:"tables,omitempty"`
-	Secrets   []Secret   `json:"secrets,omitempty"`
-	Instances []Instance `json:"instances,omitempty"`
+	Services  map[string]json.RawMessage `json:"services,omitempty"`
+	Buckets   []Bucket                   `json:"buckets,omitempty"`
+	Tables    []Table                    `json:"tables,omitempty"`
+	Secrets   []Secret                   `json:"secrets,omitempty"`
+	Instances []Instance                 `json:"instances,omitempty"`
 }
 
 // Bucket is an object-storage bucket and its objects.
@@ -154,48 +172,114 @@ func RestoreAll(ctx context.Context, snap *Snapshot, targets map[string]seed.Tar
 	return nil
 }
 
-// Export reads a provider's current state through its drivers. A nil driver for
-// a kind simply contributes nothing (that kind isn't persisted).
+// Export captures a provider's current state. For each service whose mock
+// implements snapshot.Snapshottable, its identity-preserving self-snapshot is
+// stored under ProviderState.Services; every other service falls back to the
+// bespoke driver-replay capture. A nil driver for a kind contributes nothing.
 func Export(ctx context.Context, t seed.Target, opts Options) (ProviderState, error) {
-	buckets, err := exportBuckets(ctx, t.Storage, opts.IncludeAssets)
-	if err != nil {
+	ps := ProviderState{Services: map[string]json.RawMessage{}}
+
+	if err := exportKind(ctx, &ps, svcStorage, t.Storage, opts.IncludeAssets, func() error {
+		buckets, err := exportBuckets(ctx, t.Storage, opts.IncludeAssets)
+		ps.Buckets = buckets
+		return err
+	}); err != nil {
 		return ProviderState{}, err
 	}
 
-	tables, err := exportTables(ctx, t.Database)
-	if err != nil {
+	if err := exportKind(ctx, &ps, svcDatabase, t.Database, opts.IncludeAssets, func() error {
+		tables, err := exportTables(ctx, t.Database)
+		ps.Tables = tables
+		return err
+	}); err != nil {
 		return ProviderState{}, err
 	}
 
-	secrets, err := exportSecrets(ctx, t.Secrets)
-	if err != nil {
+	if err := exportKind(ctx, &ps, svcSecrets, t.Secrets, opts.IncludeAssets, func() error {
+		secrets, err := exportSecrets(ctx, t.Secrets)
+		ps.Secrets = secrets
+		return err
+	}); err != nil {
 		return ProviderState{}, err
 	}
 
-	instances, err := exportInstances(ctx, t.Compute)
-	if err != nil {
+	if err := exportKind(ctx, &ps, svcCompute, t.Compute, opts.IncludeAssets, func() error {
+		instances, err := exportInstances(ctx, t.Compute)
+		ps.Instances = instances
+		return err
+	}); err != nil {
 		return ProviderState{}, err
 	}
 
-	return ProviderState{Buckets: buckets, Tables: tables, Secrets: secrets, Instances: instances}, nil
+	if len(ps.Services) == 0 {
+		ps.Services = nil
+	}
+
+	return ps, nil
 }
 
-// Restore writes a provider state back through its drivers, into what should be
-// a freshly-built (empty) provider.
+// exportKind stores d's self-snapshot under name when d implements
+// Snapshottable; otherwise it runs the bespoke fallback capture.
+func exportKind[D any](ctx context.Context, ps *ProviderState, name string, d D, includeAssets bool, bespoke func() error) error {
+	if s, ok := any(d).(snapshot.Snapshottable); ok {
+		raw, err := s.Snapshot(ctx, includeAssets)
+		if err != nil {
+			return fmt.Errorf("snapshot %s: %w", name, err)
+		}
+
+		ps.Services[name] = raw
+
+		return nil
+	}
+
+	return bespoke()
+}
+
+// Restore writes a provider state back into what should be a freshly-built
+// (empty) provider. A service captured under Services is restored through its
+// mock's Snapshottable.Restore; otherwise the bespoke driver-replay path runs.
 func Restore(ctx context.Context, t seed.Target, ps *ProviderState) error {
-	if err := restoreBuckets(ctx, t.Storage, ps.Buckets); err != nil {
+	if err := restoreKind(ctx, ps, svcStorage, t.Storage, func() error {
+		return restoreBuckets(ctx, t.Storage, ps.Buckets)
+	}); err != nil {
 		return err
 	}
 
-	if err := restoreTables(ctx, t.Database, ps.Tables); err != nil {
+	if err := restoreKind(ctx, ps, svcDatabase, t.Database, func() error {
+		return restoreTables(ctx, t.Database, ps.Tables)
+	}); err != nil {
 		return err
 	}
 
-	if err := restoreSecrets(ctx, t.Secrets, ps.Secrets); err != nil {
+	if err := restoreKind(ctx, ps, svcSecrets, t.Secrets, func() error {
+		return restoreSecrets(ctx, t.Secrets, ps.Secrets)
+	}); err != nil {
 		return err
 	}
 
-	return restoreInstances(ctx, t.Compute, ps.Instances)
+	return restoreKind(ctx, ps, svcCompute, t.Compute, func() error {
+		return restoreInstances(ctx, t.Compute, ps.Instances)
+	})
+}
+
+// restoreKind restores name's per-driver snapshot through d's Snapshottable when
+// the snapshot carries one; otherwise it runs the bespoke fallback restore.
+func restoreKind[D any](ctx context.Context, ps *ProviderState, name string, d D, bespoke func() error) error {
+	raw, ok := ps.Services[name]
+	if !ok {
+		return bespoke()
+	}
+
+	s, ok := any(d).(snapshot.Snapshottable)
+	if !ok {
+		return fmt.Errorf("%w: %s", errNotSnapshotable, name)
+	}
+
+	if err := s.Restore(ctx, raw); err != nil {
+		return fmt.Errorf("restore %s: %w", name, err)
+	}
+
+	return nil
 }
 
 func exportBuckets(ctx context.Context, d storagedriver.Bucket, includeAssets bool) ([]Bucket, error) {
@@ -418,49 +502,13 @@ func restoreTables(ctx context.Context, d dbdriver.Database, tables []Table) err
 		}
 
 		for i, item := range tb.Items {
-			if err := d.PutItem(ctx, tb.Name, retypeItem(item)); err != nil {
+			if err := d.PutItem(ctx, tb.Name, expr.RetypeItem(item)); err != nil {
 				return fmt.Errorf("restore table %q item %d: %w", tb.Name, i, err)
 			}
 		}
 	}
 
 	return nil
-}
-
-// retypeItem restores DynamoDB Number attributes that a JSON round-trip left as
-// the self-describing {"$ddbN":"25"} object back into expr.Number, recursing
-// through nested maps and lists so exact-decimal numbers survive persist.
-func retypeItem(item map[string]any) map[string]any {
-	out := make(map[string]any, len(item))
-	for k, v := range item {
-		out[k] = retypeValue(v)
-	}
-
-	return out
-}
-
-func retypeValue(v any) any {
-	switch t := v.(type) {
-	case map[string]any:
-		if len(t) == 1 {
-			if n, ok := t[expr.NumberJSONTag]; ok {
-				if s, isStr := n.(string); isStr {
-					return expr.Number(s)
-				}
-			}
-		}
-
-		return retypeItem(t)
-	case []any:
-		out := make([]any, len(t))
-		for i := range t {
-			out[i] = retypeValue(t[i])
-		}
-
-		return out
-	default:
-		return v
-	}
 }
 
 func restoreSecrets(ctx context.Context, d secretsdriver.Secrets, secrets []Secret) error {

--- a/persist/persist_test.go
+++ b/persist/persist_test.go
@@ -164,7 +164,10 @@ func dataOf(o *storagedriver.Object) []byte {
 
 // TestExportMetadataOnlyOmitsBodies verifies the default (metadata-only) export
 // records object keys/metadata but drops the bytes, and that IncludeAssets keeps
-// them — the flag that keeps the snapshot file KB-sized by default.
+// them — the flag that keeps the snapshot file KB-sized by default. With the AWS
+// S3 mock now snapshotting itself, the guarantee is asserted through a restore:
+// metadata-only keeps the object but empties its bytes, while IncludeAssets
+// keeps them.
 func TestExportMetadataOnlyOmitsBodies(t *testing.T) {
 	ctx := context.Background()
 
@@ -176,23 +179,50 @@ func TestExportMetadataOnlyOmitsBodies(t *testing.T) {
 		t.Fatalf("seed source: %v", err)
 	}
 
+	// Metadata-only: the object is restored (still listed) but its bytes are gone.
 	meta, err := persist.Export(ctx, tSrc, persist.Options{IncludeAssets: false})
 	if err != nil {
 		t.Fatalf("export metadata-only: %v", err)
 	}
-	if len(meta.Buckets) != 1 || len(meta.Buckets[0].Objects) != 1 {
-		t.Fatalf("metadata-only dropped bucket/object metadata: %+v", meta)
-	}
-	if len(meta.Buckets[0].Objects[0].Body) != 0 {
-		t.Fatalf("metadata-only kept body: %q", meta.Buckets[0].Objects[0].Body)
+
+	metaDst := cloudemu.NewAWS()
+	if err := persist.Restore(ctx, seed.Target{Storage: metaDst.S3}, &meta); err != nil {
+		t.Fatalf("restore metadata-only: %v", err)
 	}
 
+	head, err := metaDst.S3.HeadObject(ctx, "b", "k")
+	if err != nil {
+		t.Fatalf("metadata-only dropped object metadata: %v", err)
+	}
+	if head.Key != "k" {
+		t.Fatalf("restored object key = %q, want k", head.Key)
+	}
+
+	mo, err := metaDst.S3.GetObject(ctx, "b", "k")
+	if err != nil {
+		t.Fatalf("get metadata-only object: %v", err)
+	}
+	if len(mo.Data) != 0 {
+		t.Fatalf("metadata-only kept body: %q", mo.Data)
+	}
+
+	// IncludeAssets: the bytes survive.
 	full, err := persist.Export(ctx, tSrc, persist.Options{IncludeAssets: true})
 	if err != nil {
 		t.Fatalf("export with assets: %v", err)
 	}
-	if string(full.Buckets[0].Objects[0].Body) != "secret-bytes" {
-		t.Fatalf("asset export dropped body: %q", full.Buckets[0].Objects[0].Body)
+
+	fullDst := cloudemu.NewAWS()
+	if err := persist.Restore(ctx, seed.Target{Storage: fullDst.S3}, &full); err != nil {
+		t.Fatalf("restore with assets: %v", err)
+	}
+
+	fo, err := fullDst.S3.GetObject(ctx, "b", "k")
+	if err != nil {
+		t.Fatalf("get asset object: %v", err)
+	}
+	if string(fo.Data) != "secret-bytes" {
+		t.Fatalf("asset export dropped body: %q", fo.Data)
 	}
 }
 

--- a/providers/aws/dynamodb/snapshot.go
+++ b/providers/aws/dynamodb/snapshot.go
@@ -1,0 +1,91 @@
+package dynamodb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// dynamoSnapshot is the full serialized state of the DynamoDB mock: every table
+// keyed by name, each with its config (including secondary indexes), items,
+// TTL/stream configuration, stream records, sequence counter, tags, and PITR
+// flag. Items are keyed by their internal store key so they restore under the
+// same identity.
+type dynamoSnapshot struct {
+	Tables map[string]*tableSnapshot `json:"tables,omitempty"`
+}
+
+type tableSnapshot struct {
+	Config        driver.TableConfig        `json:"config"`
+	Items         map[string]map[string]any `json:"items,omitempty"`
+	TTLConfig     driver.TTLConfig          `json:"ttlConfig,omitempty"`
+	StreamConfig  driver.StreamConfig       `json:"streamConfig,omitempty"`
+	StreamRecords []driver.StreamRecord     `json:"streamRecords,omitempty"`
+	SeqCounter    int64                     `json:"seqCounter,omitempty"`
+	Tags          map[string]string         `json:"tags,omitempty"`
+	PITREnabled   bool                      `json:"pitrEnabled,omitempty"`
+}
+
+// Snapshot captures every table's full state as JSON. includeAssets is unused —
+// DynamoDB items are the resource, so they are always captured.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	snap := dynamoSnapshot{Tables: make(map[string]*tableSnapshot, len(m.tables))}
+
+	for name, td := range m.tables {
+		snap.Tables[name] = &tableSnapshot{
+			Config:        td.config,
+			Items:         td.items.All(),
+			TTLConfig:     td.ttlConfig,
+			StreamConfig:  td.streamConfig,
+			StreamRecords: td.streamRecords,
+			SeqCounter:    td.seqCounter.Load(),
+			Tags:          td.tags,
+			PITREnabled:   td.pitrEnabled,
+		}
+	}
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds every table under its original name and item keys, retyping
+// item numbers back into expr.Number so exact decimals survive the round-trip.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap dynamoSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("dynamodb: parse snapshot: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for name, ts := range snap.Tables {
+		td := &tableData{
+			config:        ts.Config,
+			items:         memstore.New[map[string]any](),
+			ttlConfig:     ts.TTLConfig,
+			streamConfig:  ts.StreamConfig,
+			streamRecords: ts.StreamRecords,
+			tags:          ts.Tags,
+			pitrEnabled:   ts.PITREnabled,
+		}
+		td.seqCounter.Store(ts.SeqCounter)
+
+		for key, item := range ts.Items {
+			td.items.Set(key, expr.RetypeItem(item))
+		}
+
+		m.tables[name] = td
+	}
+
+	return nil
+}

--- a/providers/aws/ec2/snapshot.go
+++ b/providers/aws/ec2/snapshot.go
@@ -1,0 +1,293 @@
+package ec2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// ec2Snapshot is the full serialized state of the EC2 mock. Instances carry an
+// exported form (the stored instanceData has unexported fields and a mutex that
+// json.Marshal cannot see); the driver-typed stores round-trip through the
+// generic memstore helper. In-flight settle overlays and the sync primitives are
+// intentionally not serialized — a restored instance reports its stored state
+// immediately.
+type ec2Snapshot struct {
+	Instances         map[string]*instanceSnapshot `json:"instances,omitempty"`
+	Volumes           json.RawMessage              `json:"volumes,omitempty"`
+	Snapshots         json.RawMessage              `json:"snapshots,omitempty"`
+	Images            json.RawMessage              `json:"images,omitempty"`
+	KeyPairs          json.RawMessage              `json:"keyPairs,omitempty"`
+	SpotRequests      json.RawMessage              `json:"spotRequests,omitempty"`
+	Templates         json.RawMessage              `json:"templates,omitempty"`
+	TemplateVersions  json.RawMessage              `json:"templateVersions,omitempty"`
+	PlacementGroups   json.RawMessage              `json:"placementGroups,omitempty"`
+	ASGs              map[string]*asgSnapshot      `json:"asgs,omitempty"`
+	ManagedVisibility string                       `json:"managedVisibility,omitempty"`
+	ClientTokens      map[string][]string          `json:"clientTokens,omitempty"`
+	SubnetIPCounters  map[string]int               `json:"subnetIpCounters,omitempty"`
+	Counters          countersSnapshot             `json:"counters"`
+}
+
+type countersSnapshot struct {
+	IP   int64 `json:"ip,omitempty"`
+	Vol  int64 `json:"vol,omitempty"`
+	Snap int64 `json:"snap,omitempty"`
+	AMI  int64 `json:"ami,omitempty"`
+	Key  int64 `json:"key,omitempty"`
+	PG   int64 `json:"pg,omitempty"`
+}
+
+// instanceSnapshot mirrors instanceData, promoting its meaningful unexported
+// fields to exported ones so they survive JSON. The mutex and the transient
+// settle window are deliberately excluded.
+type instanceSnapshot struct {
+	ID                    string                     `json:"id"`
+	ImageID               string                     `json:"imageId,omitempty"`
+	InstanceType          string                     `json:"instanceType,omitempty"`
+	State                 string                     `json:"state,omitempty"`
+	PrivateIP             string                     `json:"privateIp,omitempty"`
+	PublicIP              string                     `json:"publicIp,omitempty"`
+	SubnetID              string                     `json:"subnetId,omitempty"`
+	VPCID                 string                     `json:"vpcId,omitempty"`
+	SecurityGroups        []string                   `json:"securityGroups,omitempty"`
+	Tags                  map[string]string          `json:"tags,omitempty"`
+	LaunchTime            string                     `json:"launchTime,omitempty"`
+	Operator              *operatorData              `json:"operator,omitempty"`
+	EngineBacked          bool                       `json:"engineBacked,omitempty"`
+	DisableAPITermination bool                       `json:"disableApiTermination,omitempty"`
+	SourceDestCheck       bool                       `json:"sourceDestCheck,omitempty"`
+	UserData              string                     `json:"userData,omitempty"`
+	EBSOptimized          bool                       `json:"ebsOptimized,omitempty"`
+	ReservationID         string                     `json:"reservationId,omitempty"`
+	KeyName               string                     `json:"keyName,omitempty"`
+	Monitoring            string                     `json:"monitoring,omitempty"`
+	MetadataOptions       driver.MetadataOptions     `json:"metadataOptions,omitempty"`
+	IamInstanceProfile    *driver.IamInstanceProfile `json:"iamInstanceProfile,omitempty"`
+}
+
+type asgSnapshot struct {
+	Config   driver.AutoScalingGroup `json:"config"`
+	Policies json.RawMessage         `json:"policies,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// EC2 holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := ec2Snapshot{Instances: m.snapshotInstances()}
+
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	asgs, err := m.snapshotASGs()
+	if err != nil {
+		return nil, err
+	}
+
+	snap.ASGs = asgs
+
+	m.mu.RLock()
+	snap.ManagedVisibility = m.managedResourceVisibility
+	snap.ClientTokens = m.clientTokens
+	snap.SubnetIPCounters = m.subnetIPCounters
+	m.mu.RUnlock()
+
+	snap.Counters = countersSnapshot{
+		IP: m.ipCounter.Load(), Vol: m.volCounter.Load(), Snap: m.snapCounter.Load(),
+		AMI: m.amiCounter.Load(), Key: m.keyCounter.Load(), PG: m.pgCounter.Load(),
+	}
+
+	return json.Marshal(snap)
+}
+
+// snapshotInstances promotes each stored instanceData to its exported snapshot
+// form.
+//
+//nolint:dupl // inverse field map of restoreInstances; mirrored lists are inherent.
+func (m *Mock) snapshotInstances() map[string]*instanceSnapshot {
+	out := make(map[string]*instanceSnapshot, m.instances.Len())
+
+	for id, d := range m.instances.All() {
+		d.mu.Lock()
+		out[id] = &instanceSnapshot{
+			ID: d.ID, ImageID: d.ImageID, InstanceType: d.InstanceType, State: d.State,
+			PrivateIP: d.PrivateIP, PublicIP: d.PublicIP, SubnetID: d.SubnetID, VPCID: d.VPCID,
+			SecurityGroups: d.SecurityGroups, Tags: d.Tags, LaunchTime: d.LaunchTime, Operator: d.Operator,
+			EngineBacked: d.engineBacked, DisableAPITermination: d.disableAPITermination,
+			SourceDestCheck: d.sourceDestCheck, UserData: d.userData, EBSOptimized: d.ebsOptimized,
+			ReservationID: d.reservationID, KeyName: d.keyName, Monitoring: d.monitoring,
+			MetadataOptions: d.metadataOptions, IamInstanceProfile: d.iamInstanceProfile,
+		}
+		d.mu.Unlock()
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotStores(snap *ec2Snapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Volumes, m.volumes.Snapshot},
+		{&snap.Snapshots, m.snapshots.Snapshot},
+		{&snap.Images, m.images.Snapshot},
+		{&snap.KeyPairs, m.keyPairs.Snapshot},
+		{&snap.SpotRequests, m.spotRequests.Snapshot},
+		{&snap.Templates, m.templates.Snapshot},
+		{&snap.TemplateVersions, m.templateVersions.Snapshot},
+		{&snap.PlacementGroups, m.placementGroups.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("ec2: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+func (m *Mock) snapshotASGs() (map[string]*asgSnapshot, error) {
+	if m.asgs.Len() == 0 {
+		return nil, nil
+	}
+
+	out := make(map[string]*asgSnapshot, m.asgs.Len())
+
+	for name, a := range m.asgs.All() {
+		pol, err := a.policies.Snapshot()
+		if err != nil {
+			return nil, fmt.Errorf("ec2: snapshot asg policies: %w", err)
+		}
+
+		out[name] = &asgSnapshot{Config: a.config, Policies: pol}
+	}
+
+	return out, nil
+}
+
+// Restore rebuilds the mock's state under the original identities: instance ids
+// (and their id-string cross-references, e.g. security groups) are preserved,
+// and each restored instance is re-registered with the state machine.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap ec2Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("ec2: parse snapshot: %w", err)
+	}
+
+	m.restoreInstances(snap.Instances)
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	if err := m.restoreASGs(snap.ASGs); err != nil {
+		return err
+	}
+
+	m.restoreScalarState(&snap)
+
+	c := snap.Counters
+	m.ipCounter.Store(c.IP)
+	m.volCounter.Store(c.Vol)
+	m.snapCounter.Store(c.Snap)
+	m.amiCounter.Store(c.AMI)
+	m.keyCounter.Store(c.Key)
+	m.pgCounter.Store(c.PG)
+
+	return nil
+}
+
+// restoreScalarState reinstates the mu-guarded scalar/map fields from the
+// snapshot, leaving unset ones at their New() defaults.
+func (m *Mock) restoreScalarState(snap *ec2Snapshot) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if snap.ManagedVisibility != "" {
+		m.managedResourceVisibility = snap.ManagedVisibility
+	}
+
+	if snap.ClientTokens != nil {
+		m.clientTokens = snap.ClientTokens
+	}
+
+	if snap.SubnetIPCounters != nil {
+		m.subnetIPCounters = snap.SubnetIPCounters
+	}
+}
+
+// restoreInstances reinstates each instance under its original id and
+// re-registers it with the state machine.
+//
+//nolint:dupl // inverse field map of snapshotInstances; mirrored lists are inherent.
+func (m *Mock) restoreInstances(instances map[string]*instanceSnapshot) {
+	for id, s := range instances {
+		m.instances.Set(id, &instanceData{
+			ID: s.ID, ImageID: s.ImageID, InstanceType: s.InstanceType, State: s.State,
+			PrivateIP: s.PrivateIP, PublicIP: s.PublicIP, SubnetID: s.SubnetID, VPCID: s.VPCID,
+			SecurityGroups: s.SecurityGroups, Tags: s.Tags, LaunchTime: s.LaunchTime, Operator: s.Operator,
+			engineBacked: s.EngineBacked, disableAPITermination: s.DisableAPITermination,
+			sourceDestCheck: s.SourceDestCheck, userData: s.UserData, ebsOptimized: s.EBSOptimized,
+			reservationID: s.ReservationID, keyName: s.KeyName, monitoring: s.Monitoring,
+			metadataOptions: s.MetadataOptions, iamInstanceProfile: s.IamInstanceProfile,
+		})
+		// Re-register with the state machine so lifecycle transitions
+		// (Start/Stop/Terminate) validate against the restored state.
+		m.sm.SetState(id, s.State)
+	}
+}
+
+func (m *Mock) restoreStores(snap *ec2Snapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Volumes, m.volumes.LoadSnapshot},
+		{snap.Snapshots, m.snapshots.LoadSnapshot},
+		{snap.Images, m.images.LoadSnapshot},
+		{snap.KeyPairs, m.keyPairs.LoadSnapshot},
+		{snap.SpotRequests, m.spotRequests.LoadSnapshot},
+		{snap.Templates, m.templates.LoadSnapshot},
+		{snap.TemplateVersions, m.templateVersions.LoadSnapshot},
+		{snap.PlacementGroups, m.placementGroups.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("ec2: restore store: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (m *Mock) restoreASGs(asgs map[string]*asgSnapshot) error {
+	for name, a := range asgs {
+		ad := &asgData{config: a.Config, policies: memstore.New[driver.ScalingPolicy]()}
+		if len(a.Policies) > 0 {
+			if err := ad.policies.LoadSnapshot(a.Policies); err != nil {
+				return fmt.Errorf("ec2: restore asg policies: %w", err)
+			}
+		}
+
+		m.asgs.Set(name, ad)
+	}
+
+	return nil
+}

--- a/providers/aws/s3/snapshot.go
+++ b/providers/aws/s3/snapshot.go
@@ -1,0 +1,220 @@
+package s3
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// s3Snapshot is the full serialized state of the S3 mock: every bucket keyed by
+// name, plus the object-event sequence counter. In-progress multipart uploads
+// are transient and intentionally not captured.
+type s3Snapshot struct {
+	Buckets  map[string]*bucketSnapshot `json:"buckets,omitempty"`
+	EventSeq uint64                     `json:"eventSeq,omitempty"`
+}
+
+// bucketSnapshot captures a bucket's metadata, configuration sub-resources,
+// current objects, and full version history. Object keys and version ids are
+// preserved so a restore is transparent to clients.
+type bucketSnapshot struct {
+	Name          string                        `json:"name"`
+	Region        string                        `json:"region,omitempty"`
+	CreatedAt     string                        `json:"createdAt,omitempty"`
+	VersionStatus string                        `json:"versionStatus,omitempty"`
+	Tags          map[string]string             `json:"tags,omitempty"`
+	Lifecycle     *driver.LifecycleConfig       `json:"lifecycle,omitempty"`
+	Policy        *driver.BucketPolicy          `json:"policy,omitempty"`
+	CORS          *driver.CORSConfig            `json:"cors,omitempty"`
+	Encryption    *driver.EncryptionConfig      `json:"encryption,omitempty"`
+	Notifications []BucketNotification          `json:"notifications,omitempty"`
+	RawConfigs    map[string][]byte             `json:"rawConfigs,omitempty"`
+	Objects       map[string]*objectSnapshot    `json:"objects,omitempty"`
+	Versions      map[string][]*versionSnapshot `json:"versions,omitempty"`
+}
+
+// objectSnapshot is a current object. Data is omitted in a metadata-only
+// (includeAssets=false) snapshot; Size is kept independently so metadata stays
+// correct.
+type objectSnapshot struct {
+	Key          string            `json:"key"`
+	Data         []byte            `json:"data,omitempty"`
+	Size         int64             `json:"size"`
+	ContentType  string            `json:"contentType,omitempty"`
+	ETag         string            `json:"etag,omitempty"`
+	LastModified string            `json:"lastModified,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+	Tags         map[string]string `json:"tags,omitempty"`
+	VersionID    string            `json:"versionId,omitempty"`
+}
+
+// versionSnapshot is one entry in a key's version history (a stored version or a
+// delete marker). Its fields mirror the unexported s3Version, since json.Marshal
+// cannot see that type's unexported data.
+type versionSnapshot struct {
+	VersionID    string            `json:"versionId"`
+	Data         []byte            `json:"data,omitempty"`
+	Size         int64             `json:"size"`
+	ContentType  string            `json:"contentType,omitempty"`
+	ETag         string            `json:"etag,omitempty"`
+	LastModified string            `json:"lastModified,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+	DeleteMarker bool              `json:"deleteMarker,omitempty"`
+}
+
+// Snapshot captures every bucket's state as JSON. When includeAssets is false
+// the object and version bytes are omitted (metadata-only), mirroring the
+// persist default that keeps snapshot files small.
+func (m *Mock) Snapshot(_ context.Context, includeAssets bool) (json.RawMessage, error) {
+	snap := s3Snapshot{
+		Buckets:  make(map[string]*bucketSnapshot, m.buckets.Len()),
+		EventSeq: m.eventSeq.Load(),
+	}
+
+	for name, bkt := range m.buckets.All() {
+		snap.Buckets[name] = snapshotBucket(bkt, includeAssets)
+	}
+
+	return json.Marshal(snap)
+}
+
+func snapshotBucket(bkt *bucketMeta, includeAssets bool) *bucketSnapshot {
+	bs := &bucketSnapshot{
+		Name: bkt.Name, Region: bkt.Region, CreatedAt: bkt.CreatedAt,
+		Tags: bkt.tags, Lifecycle: bkt.lifecycle, Policy: bkt.policy,
+		CORS: bkt.corsConfig, Encryption: bkt.encryption, Notifications: bkt.notifications,
+		Objects: make(map[string]*objectSnapshot, bkt.objects.Len()),
+	}
+
+	for key, obj := range bkt.objects.All() {
+		bs.Objects[key] = &objectSnapshot{
+			Key: obj.Key, Data: assetBytes(obj.Data, includeAssets), Size: obj.Size,
+			ContentType: obj.ContentType, ETag: obj.ETag, LastModified: obj.LastModified,
+			Metadata: obj.Metadata, Tags: obj.Tags, VersionID: obj.VersionID,
+		}
+	}
+
+	snapshotBucketVersions(bkt, bs, includeAssets)
+	snapshotBucketRawConfigs(bkt, bs)
+
+	return bs
+}
+
+func snapshotBucketVersions(bkt *bucketMeta, bs *bucketSnapshot, includeAssets bool) {
+	bkt.versionsMu.Lock()
+	defer bkt.versionsMu.Unlock()
+
+	bs.VersionStatus = bkt.versionStatus
+
+	if len(bkt.versions) == 0 {
+		return
+	}
+
+	bs.Versions = make(map[string][]*versionSnapshot, len(bkt.versions))
+
+	for key, chain := range bkt.versions {
+		out := make([]*versionSnapshot, 0, len(chain))
+
+		for _, v := range chain {
+			out = append(out, &versionSnapshot{
+				VersionID: v.versionID, Data: assetBytes(v.data, includeAssets), Size: v.size,
+				ContentType: v.contentType, ETag: v.etag, LastModified: v.lastModified,
+				Metadata: v.metadata, DeleteMarker: v.deleteMarker,
+			})
+		}
+
+		bs.Versions[key] = out
+	}
+}
+
+func snapshotBucketRawConfigs(bkt *bucketMeta, bs *bucketSnapshot) {
+	bkt.rawConfigMu.Lock()
+	defer bkt.rawConfigMu.Unlock()
+
+	if len(bkt.rawConfigs) == 0 {
+		return
+	}
+
+	bs.RawConfigs = make(map[string][]byte, len(bkt.rawConfigs))
+	for k, v := range bkt.rawConfigs {
+		bs.RawConfigs[k] = v
+	}
+}
+
+// assetBytes returns data only when assets are included, so metadata-only
+// snapshots omit object/version bodies.
+func assetBytes(data []byte, includeAssets bool) []byte {
+	if !includeAssets {
+		return nil
+	}
+
+	return data
+}
+
+// Restore rebuilds every bucket under its original name with its objects,
+// version history, and configuration intact.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap s3Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("s3: parse snapshot: %w", err)
+	}
+
+	m.eventSeq.Store(snap.EventSeq)
+
+	for name, bs := range snap.Buckets {
+		m.buckets.Set(name, restoreBucket(bs))
+	}
+
+	return nil
+}
+
+func restoreBucket(bs *bucketSnapshot) *bucketMeta {
+	bkt := &bucketMeta{
+		Name: bs.Name, Region: bs.Region, CreatedAt: bs.CreatedAt,
+		objects:       memstore.New[*s3Object](),
+		multiparts:    memstore.New[*multipartUpload](),
+		versionStatus: bs.VersionStatus,
+		lifecycle:     bs.Lifecycle, policy: bs.Policy, corsConfig: bs.CORS,
+		encryption: bs.Encryption, tags: bs.Tags, notifications: bs.Notifications,
+		rawConfigs: bs.RawConfigs,
+	}
+
+	for key, os := range bs.Objects {
+		bkt.objects.Set(key, &s3Object{
+			Key: os.Key, Data: os.Data, Size: os.Size, ContentType: os.ContentType,
+			ETag: os.ETag, LastModified: os.LastModified, Metadata: os.Metadata,
+			Tags: os.Tags, VersionID: os.VersionID,
+		})
+	}
+
+	restoreBucketVersions(bkt, bs)
+
+	return bkt
+}
+
+func restoreBucketVersions(bkt *bucketMeta, bs *bucketSnapshot) {
+	if len(bs.Versions) == 0 {
+		return
+	}
+
+	bkt.versions = make(map[string][]*s3Version, len(bs.Versions))
+
+	for key, chain := range bs.Versions {
+		out := make([]*s3Version, 0, len(chain))
+
+		for _, v := range chain {
+			out = append(out, &s3Version{
+				versionID: v.VersionID, data: v.Data, size: v.Size, contentType: v.ContentType,
+				etag: v.ETag, lastModified: v.LastModified, metadata: v.Metadata, deleteMarker: v.DeleteMarker,
+			})
+		}
+
+		bkt.versions[key] = out
+	}
+}

--- a/providers/aws/secretsmanager/snapshot.go
+++ b/providers/aws/secretsmanager/snapshot.go
@@ -1,0 +1,67 @@
+package secretsmanager
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// secretsSnapshot is the full serialized state of the Secrets Manager mock:
+// every secret keyed by name, each with its metadata, version history, and
+// soft-delete state, so identifiers (ARN, version ids) restore unchanged.
+type secretsSnapshot struct {
+	Secrets map[string]*secretSnapshot `json:"secrets,omitempty"`
+}
+
+type secretSnapshot struct {
+	Info           driver.SecretInfo      `json:"info"`
+	Versions       []driver.SecretVersion `json:"versions,omitempty"`
+	DeletedAt      time.Time              `json:"deletedAt,omitempty"`
+	RecoveryWindow int                    `json:"recoveryWindow,omitempty"`
+}
+
+// Snapshot captures every secret's full state as JSON. includeAssets is unused —
+// a secret without its value cannot be restored usefully, so values are always
+// captured.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := secretsSnapshot{Secrets: make(map[string]*secretSnapshot)}
+
+	for name, sd := range m.secrets.All() {
+		sd.mu.RLock()
+		snap.Secrets[name] = &secretSnapshot{
+			Info:           sd.info,
+			Versions:       sd.versions,
+			DeletedAt:      sd.deletedAt,
+			RecoveryWindow: sd.recoveryWindow,
+		}
+		sd.mu.RUnlock()
+	}
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds every secret under its original name with its metadata and
+// version history intact.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap secretsSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("secretsmanager: parse snapshot: %w", err)
+	}
+
+	for name, ss := range snap.Secrets {
+		m.secrets.Set(name, &secretData{
+			info:           ss.Info,
+			versions:       ss.Versions,
+			deletedAt:      ss.DeletedAt,
+			recoveryWindow: ss.RecoveryWindow,
+		})
+	}
+
+	return nil
+}

--- a/services/database/driver/expr/retype.go
+++ b/services/database/driver/expr/retype.go
@@ -1,0 +1,44 @@
+package expr
+
+// RetypeItem walks a decoded item and reconstructs every DynamoDB Number (N)
+// attribute that a generic map[string]any JSON round-trip left as the
+// self-describing {"$ddbN":"25"} object back into a Number, recursing through
+// nested maps and lists. A bare JSON number decodes into any as float64, which
+// would silently drop exact-decimal precision; Number's marshaled tag form
+// survives the round-trip and this rebuilds it. Both the persist snapshot path
+// and per-driver snapshots use it so item numbers restore losslessly.
+func RetypeItem(item map[string]any) map[string]any {
+	out := make(map[string]any, len(item))
+	for k, v := range item {
+		out[k] = RetypeValue(v)
+	}
+
+	return out
+}
+
+// RetypeValue reconstructs a single decoded value, recursing through maps and
+// lists. A one-key map carrying NumberJSONTag becomes a Number; everything else
+// is returned structurally unchanged.
+func RetypeValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		if len(t) == 1 {
+			if n, ok := t[NumberJSONTag]; ok {
+				if s, isStr := n.(string); isStr {
+					return Number(s)
+				}
+			}
+		}
+
+		return RetypeItem(t)
+	case []any:
+		out := make([]any, len(t))
+		for i := range t {
+			out[i] = RetypeValue(t[i])
+		}
+
+		return out
+	default:
+		return v
+	}
+}

--- a/services/database/driver/expr/retype_test.go
+++ b/services/database/driver/expr/retype_test.go
@@ -1,0 +1,37 @@
+package expr
+
+import (
+	"testing"
+)
+
+// TestRetypeItemReconstructsNumbers pins that RetypeItem rebuilds every tagged
+// Number, recursing through nested maps and lists, and leaves other values
+// unchanged.
+func TestRetypeItemReconstructsNumbers(t *testing.T) {
+	item := map[string]any{
+		"pk":     "k1",
+		"big":    map[string]any{NumberJSONTag: "123456789012345678901234567890"},
+		"nested": map[string]any{"inner": map[string]any{NumberJSONTag: "42"}},
+		"list":   []any{map[string]any{NumberJSONTag: "7"}, "s"},
+	}
+
+	got := RetypeItem(item)
+
+	if got["pk"] != "k1" {
+		t.Fatalf("pk = %#v, want unchanged string", got["pk"])
+	}
+
+	if got["big"] != Number("123456789012345678901234567890") {
+		t.Fatalf("big = %#v, want exact-decimal Number", got["big"])
+	}
+
+	m, ok := got["nested"].(map[string]any)
+	if !ok || m["inner"] != Number("42") {
+		t.Fatalf("nested number not retyped: %#v", got["nested"])
+	}
+
+	l, ok := got["list"].([]any)
+	if !ok || l[0] != Number("7") || l[1] != "s" {
+		t.Fatalf("list number not retyped: %#v", got["list"])
+	}
+}


### PR DESCRIPTION
## What

Phase 1 of #582 — evolves `persist/` from its 4-kind bespoke design toward **per-driver, identity-preserving snapshotting**.

A mock that implements the new optional `internal/snapshot.Snapshottable` interface serializes its **entire** in-memory state and restores it under the **same identities** (resource ids, and id-string cross-references between resources). `persist` type-asserts each service driver to this interface and calls it; for any service whose mock does not implement it yet, it **falls back to the existing bespoke `exportX`/`restoreX` path**, so Azure/GCP and un-migrated services keep working unchanged.

### Delivered

- **`internal/snapshot`** — leaf interface (`Snapshot`/`Restore`, only `context` + `encoding/json`), so any mock can implement it without an import cycle.
- **`internal/memstore`** — generic `Store.Snapshot()` / `Store.LoadSnapshot()` helpers that dump/restore `map[string]V` **under the same keys** (identity-preserving), with a round-trip test.
- **`services/database/driver/expr`** — public `RetypeItem`/`RetypeValue` (item-number reconstruction lifted out of `persist`, now shared, no duplication).
- **AWS 4 mocks implement `Snapshottable`**: `s3` (storage), `dynamodb` (database), `secretsmanager` (secrets), `ec2` (compute). Each dumps **all** its state — every `memstore.Store` plus non-store state (atomic id/IP counters, client-token & subnet-IP maps, managed-visibility, ASG policies, S3 version history, bucket config sub-resources). Value types with **unexported data** are round-tripped via exported snapshot structs; `sync.Mutex`/`func`/transient settle fields are never serialized. `includeAssets=false` omits S3 object bytes (metadata-only), mirroring the current default. EC2 re-registers restored instances with the state machine so lifecycle transitions still validate.
- **`persist/`** — generic export/restore producing `map[serviceName]json.RawMessage` under `ProviderState.Services`, with bespoke fallback. `SchemaVersion` bumped to **2**; a v1 snapshot is rejected on load (snapshots are dev-only — clean break). The generic path enumerates services via the existing `seed.Target`, so **no provider packages are imported into `persist`** and **no call-site changes** were needed in `cmd/cloudemu/serve.go` or the admin snapshot endpoint.

## Why

The old compute path recreated instances via `RunInstances` on restore, minting **fresh** instance ids and dropping cross-references. The headline win here: **instance ids and references survive**. New test `TestIdentityPreservedAcrossRestore` creates an S3 bucket+object, a DynamoDB table+item, a secret, and an EC2 instance launched with a security group; exports to bytes; restores into a **fresh** `NewAWS()`; and asserts the EC2 instance has the **same** instance id, its SG reference resolves, the instance is still transitionable (state machine re-registered), and the object bytes / item / secret round-trip.

## Remaining #582 work (Phase 2)

Roll `Snapshottable` out to Azure/GCP and the remaining ~16 services, then retire the bespoke fallback path.

## Gates

`go build ./...`, `go vet`, scoped `go test` (incl. the identity test), `-race` on `persist`/`memstore` and the four AWS provider packages, `golangci-lint` (zero new issues), and `gofmt` — all green.
