### PR TITLE
feat(persist): identity-preserving snapshots for Azure + GCP core mocks (Phase 2a, refs #582)

### DIFF
--- a/persist/identity_azure_test.go
+++ b/persist/identity_azure_test.go
@@ -1,0 +1,135 @@
+package persist_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/persist"
+	"github.com/stackshy/cloudemu/v2/seed"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+// TestIdentityPreservedAcrossRestoreAzure is the Azure analogue of the AWS
+// identity guarantee: after a full Export→JSON→Restore into a FRESH Azure
+// provider, resource identifiers and id-string cross-references survive
+// unchanged. In particular a virtual machine keeps the SAME instance id and its
+// security-group reference — the thing the old driver-replay compute path could
+// not do (it minted a fresh id via RunInstances).
+func TestIdentityPreservedAcrossRestoreAzure(t *testing.T) {
+	ctx := context.Background()
+
+	src := cloudemu.NewAzure()
+
+	// Blob container + blob (with bytes).
+	if err := src.BlobStorage.CreateBucket(ctx, "app-data"); err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	if err := src.BlobStorage.PutObject(ctx, "app-data", "config.yaml", []byte("port: 8080"), "text/yaml", nil); err != nil {
+		t.Fatalf("put blob: %v", err)
+	}
+
+	// Cosmos container + item.
+	if err := src.CosmosDB.CreateTable(ctx, dbdriver.TableConfig{Name: "users", PartitionKey: "id"}); err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	if err := src.CosmosDB.PutItem(ctx, "users", map[string]any{"id": "u1", "name": "Ada"}); err != nil {
+		t.Fatalf("put item: %v", err)
+	}
+
+	// Key Vault secret.
+	if _, err := src.KeyVault.CreateSecret(ctx, secretsdriver.SecretConfig{Name: "db-password"}, []byte("s3cr3t")); err != nil {
+		t.Fatalf("create secret: %v", err)
+	}
+
+	// VM launched with a security group.
+	const sgID = "nsg-0abc123"
+
+	launched, err := src.VirtualMachines.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "ubuntu-22", InstanceType: "Standard_D2s_v3", SecurityGroups: []string{sgID},
+	}, 1)
+	if err != nil {
+		t.Fatalf("run instances: %v", err)
+	}
+	if len(launched) != 1 {
+		t.Fatalf("launched %d instances, want 1", len(launched))
+	}
+
+	wantInstanceID := launched[0].ID
+
+	tSrc := seed.Target{Storage: src.BlobStorage, Database: src.CosmosDB, Secrets: src.KeyVault, Compute: src.VirtualMachines}
+
+	snap, err := persist.ExportAll(ctx, map[string]seed.Target{"azure": tSrc}, persist.Options{IncludeAssets: true})
+	if err != nil {
+		t.Fatalf("ExportAll: %v", err)
+	}
+
+	raw, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+
+	var got persist.Snapshot
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal snapshot: %v", err)
+	}
+
+	// Restore into a completely fresh provider.
+	dst := cloudemu.NewAzure()
+	tDst := seed.Target{Storage: dst.BlobStorage, Database: dst.CosmosDB, Secrets: dst.KeyVault, Compute: dst.VirtualMachines}
+	if err := persist.RestoreAll(ctx, &got, map[string]seed.Target{"azure": tDst}); err != nil {
+		t.Fatalf("RestoreAll: %v", err)
+	}
+
+	// VM keeps its identity and its SG cross-reference.
+	insts, err := dst.VirtualMachines.DescribeInstances(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("describe restored instances: %v", err)
+	}
+	if len(insts) != 1 {
+		t.Fatalf("restored %d instances, want 1", len(insts))
+	}
+	if insts[0].ID != wantInstanceID {
+		t.Fatalf("restored instance id = %q, want SAME id %q", insts[0].ID, wantInstanceID)
+	}
+	if len(insts[0].SecurityGroups) != 1 || insts[0].SecurityGroups[0] != sgID {
+		t.Fatalf("restored SG reference = %v, want [%s]", insts[0].SecurityGroups, sgID)
+	}
+
+	// The restored instance is still a live, transitionable resource: the state
+	// machine was re-registered, so a Stop succeeds (it would fail if only the
+	// record — not the FSM state — had been restored).
+	if err := dst.VirtualMachines.StopInstances(ctx, []string{wantInstanceID}); err != nil {
+		t.Fatalf("stop restored instance: %v", err)
+	}
+
+	// Blob bytes survive.
+	obj, err := dst.BlobStorage.GetObject(ctx, "app-data", "config.yaml")
+	if err != nil {
+		t.Fatalf("get restored blob: %v", err)
+	}
+	if string(obj.Data) != "port: 8080" {
+		t.Fatalf("restored blob body = %q, want %q", obj.Data, "port: 8080")
+	}
+
+	// Cosmos item survives.
+	item, err := dst.CosmosDB.GetItem(ctx, "users", map[string]any{"id": "u1"})
+	if err != nil {
+		t.Fatalf("get restored item: %v", err)
+	}
+	if item == nil || item["name"] != "Ada" {
+		t.Fatalf("restored item = %v, want {id:u1,name:Ada}", item)
+	}
+
+	// Secret value survives.
+	sv, err := dst.KeyVault.GetSecretValue(ctx, "db-password", "")
+	if err != nil {
+		t.Fatalf("get restored secret: %v", err)
+	}
+	if string(sv.Value) != "s3cr3t" {
+		t.Fatalf("restored secret value = %q, want s3cr3t", sv.Value)
+	}
+}

--- a/persist/identity_gcp_test.go
+++ b/persist/identity_gcp_test.go
@@ -1,0 +1,134 @@
+package persist_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/persist"
+	"github.com/stackshy/cloudemu/v2/seed"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+// TestIdentityPreservedAcrossRestoreGCP is the GCP analogue of the AWS identity
+// guarantee: after a full Export→JSON→Restore into a FRESH GCP provider,
+// resource identifiers and id-string cross-references survive unchanged. In
+// particular a GCE instance keeps the SAME instance id and its security-group
+// reference — the thing the old driver-replay compute path could not do.
+func TestIdentityPreservedAcrossRestoreGCP(t *testing.T) {
+	ctx := context.Background()
+
+	src := cloudemu.NewGCP()
+
+	// GCS bucket + object (with bytes).
+	if err := src.GCS.CreateBucket(ctx, "app-data"); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	if err := src.GCS.PutObject(ctx, "app-data", "config.yaml", []byte("port: 8080"), "text/yaml", nil); err != nil {
+		t.Fatalf("put object: %v", err)
+	}
+
+	// Firestore collection + document.
+	if err := src.Firestore.CreateTable(ctx, dbdriver.TableConfig{Name: "users", PartitionKey: "id"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if err := src.Firestore.PutItem(ctx, "users", map[string]any{"id": "u1", "name": "Ada"}); err != nil {
+		t.Fatalf("put document: %v", err)
+	}
+
+	// Secret Manager secret.
+	if _, err := src.SecretManager.CreateSecret(ctx, secretsdriver.SecretConfig{Name: "db-password"}, []byte("s3cr3t")); err != nil {
+		t.Fatalf("create secret: %v", err)
+	}
+
+	// GCE instance launched with a security group.
+	const sgID = "fw-0abc123"
+
+	launched, err := src.GCE.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "debian-12", InstanceType: "e2-medium", SecurityGroups: []string{sgID},
+	}, 1)
+	if err != nil {
+		t.Fatalf("run instances: %v", err)
+	}
+	if len(launched) != 1 {
+		t.Fatalf("launched %d instances, want 1", len(launched))
+	}
+
+	wantInstanceID := launched[0].ID
+
+	tSrc := seed.Target{Storage: src.GCS, Database: src.Firestore, Secrets: src.SecretManager, Compute: src.GCE}
+
+	snap, err := persist.ExportAll(ctx, map[string]seed.Target{"gcp": tSrc}, persist.Options{IncludeAssets: true})
+	if err != nil {
+		t.Fatalf("ExportAll: %v", err)
+	}
+
+	raw, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+
+	var got persist.Snapshot
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal snapshot: %v", err)
+	}
+
+	// Restore into a completely fresh provider.
+	dst := cloudemu.NewGCP()
+	tDst := seed.Target{Storage: dst.GCS, Database: dst.Firestore, Secrets: dst.SecretManager, Compute: dst.GCE}
+	if err := persist.RestoreAll(ctx, &got, map[string]seed.Target{"gcp": tDst}); err != nil {
+		t.Fatalf("RestoreAll: %v", err)
+	}
+
+	// GCE instance keeps its identity and its SG cross-reference.
+	insts, err := dst.GCE.DescribeInstances(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("describe restored instances: %v", err)
+	}
+	if len(insts) != 1 {
+		t.Fatalf("restored %d instances, want 1", len(insts))
+	}
+	if insts[0].ID != wantInstanceID {
+		t.Fatalf("restored instance id = %q, want SAME id %q", insts[0].ID, wantInstanceID)
+	}
+	if len(insts[0].SecurityGroups) != 1 || insts[0].SecurityGroups[0] != sgID {
+		t.Fatalf("restored SG reference = %v, want [%s]", insts[0].SecurityGroups, sgID)
+	}
+
+	// The restored instance is still a live, transitionable resource: the state
+	// machine was re-registered, so a Stop succeeds (it would fail if only the
+	// record — not the FSM state — had been restored).
+	if err := dst.GCE.StopInstances(ctx, []string{wantInstanceID}); err != nil {
+		t.Fatalf("stop restored instance: %v", err)
+	}
+
+	// GCS object bytes survive.
+	obj, err := dst.GCS.GetObject(ctx, "app-data", "config.yaml")
+	if err != nil {
+		t.Fatalf("get restored object: %v", err)
+	}
+	if string(obj.Data) != "port: 8080" {
+		t.Fatalf("restored object body = %q, want %q", obj.Data, "port: 8080")
+	}
+
+	// Firestore document survives.
+	item, err := dst.Firestore.GetItem(ctx, "users", map[string]any{"id": "u1"})
+	if err != nil {
+		t.Fatalf("get restored document: %v", err)
+	}
+	if item == nil || item["name"] != "Ada" {
+		t.Fatalf("restored document = %v, want {id:u1,name:Ada}", item)
+	}
+
+	// Secret value survives.
+	sv, err := dst.SecretManager.GetSecretValue(ctx, "db-password", "")
+	if err != nil {
+		t.Fatalf("get restored secret: %v", err)
+	}
+	if string(sv.Value) != "s3cr3t" {
+		t.Fatalf("restored secret value = %q, want s3cr3t", sv.Value)
+	}
+}

--- a/providers/azure/blobstorage/snapshot.go
+++ b/providers/azure/blobstorage/snapshot.go
@@ -1,0 +1,234 @@
+package blobstorage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// blobSnapshot is the full serialized state of the Azure Blob Storage mock:
+// every container keyed by name, plus the account-level sub-resource stores.
+// In-progress multipart uploads and uncommitted staged blocks are transient and
+// intentionally not captured.
+type blobSnapshot struct {
+	Containers        map[string]*containerSnapshot `json:"containers,omitempty"`
+	BucketAttrs       json.RawMessage               `json:"bucketAttrs,omitempty"`
+	AccountKeys       json.RawMessage               `json:"accountKeys,omitempty"`
+	BlobServiceProps  json.RawMessage               `json:"blobServiceProps,omitempty"`
+	AccountEncryption json.RawMessage               `json:"accountEncryption,omitempty"`
+}
+
+type containerSnapshot struct {
+	Name           string                         `json:"name"`
+	Region         string                         `json:"region,omitempty"`
+	CreatedAt      string                         `json:"createdAt,omitempty"`
+	Versioning     bool                           `json:"versioning,omitempty"`
+	Lifecycle      *driver.LifecycleConfig        `json:"lifecycle,omitempty"`
+	Policy         *driver.BucketPolicy           `json:"policy,omitempty"`
+	CORS           *driver.CORSConfig             `json:"cors,omitempty"`
+	Encryption     *driver.EncryptionConfig       `json:"encryption,omitempty"`
+	Tags           map[string]string              `json:"tags,omitempty"`
+	Metadata       map[string]string              `json:"metadata,omitempty"`
+	PublicAccess   string                         `json:"publicAccess,omitempty"`
+	AccessPolicies []driver.SignedIdentifier      `json:"accessPolicies,omitempty"`
+	SnapshotSeq    int                            `json:"snapshotSeq,omitempty"`
+	Objects        map[string]*blobObjectSnapshot `json:"objects,omitempty"`
+	Snapshots      map[string]*blobObjectSnapshot `json:"snapshots,omitempty"`
+}
+
+// blobObjectSnapshot mirrors blobObject, promoting its meaningful unexported
+// fields (append count and the full Lease Blob state) to exported ones so they
+// survive JSON. The mutex is deliberately excluded.
+type blobObjectSnapshot struct {
+	Key                   string             `json:"key"`
+	Data                  []byte             `json:"data,omitempty"`
+	Size                  int64              `json:"size"`
+	ContentType           string             `json:"contentType,omitempty"`
+	ETag                  string             `json:"etag,omitempty"`
+	LastModified          string             `json:"lastModified,omitempty"`
+	Metadata              map[string]string  `json:"metadata,omitempty"`
+	Tags                  map[string]string  `json:"tags,omitempty"`
+	BlobType              string             `json:"blobType,omitempty"`
+	AccessTier            string             `json:"accessTier,omitempty"`
+	ContentEncoding       string             `json:"contentEncoding,omitempty"`
+	ContentLanguage       string             `json:"contentLanguage,omitempty"`
+	ContentDisposition    string             `json:"contentDisposition,omitempty"`
+	CacheControl          string             `json:"cacheControl,omitempty"`
+	CommittedBlocks       []driver.BlockInfo `json:"committedBlocks,omitempty"`
+	AppendBlocks          int                `json:"appendBlocks,omitempty"`
+	LeaseState            string             `json:"leaseState,omitempty"`
+	LeaseID               string             `json:"leaseId,omitempty"`
+	LeaseDurationSec      int32              `json:"leaseDurationSec,omitempty"`
+	LeaseExpiresAt        time.Time          `json:"leaseExpiresAt,omitempty"`
+	LeaseBreakAt          time.Time          `json:"leaseBreakAt,omitempty"`
+	LeaseModTimeAtAcquire string             `json:"leaseModTimeAtAcquire,omitempty"`
+}
+
+// Snapshot captures every container's state as JSON. When includeAssets is false
+// the blob bytes are omitted (metadata-only).
+func (m *Mock) Snapshot(_ context.Context, includeAssets bool) (json.RawMessage, error) {
+	snap := blobSnapshot{Containers: make(map[string]*containerSnapshot, m.containers.Len())}
+
+	for name, c := range m.containers.All() {
+		snap.Containers[name] = snapshotContainer(c, includeAssets)
+	}
+
+	if err := m.snapshotAccountStores(&snap); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotAccountStores(snap *blobSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.BucketAttrs, m.bucketAttrs.Snapshot},
+		{&snap.AccountKeys, m.accountKeys.Snapshot},
+		{&snap.BlobServiceProps, m.blobServiceProps.Snapshot},
+		{&snap.AccountEncryption, m.accountEncryption.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("blobstorage: snapshot account store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+func snapshotContainer(c *containerMeta, includeAssets bool) *containerSnapshot {
+	cs := &containerSnapshot{
+		Name: c.Name, Region: c.Region, CreatedAt: c.CreatedAt,
+		Versioning: c.versioning, Lifecycle: c.lifecycle, Policy: c.policy,
+		CORS: c.corsConfig, Encryption: c.encryption, Tags: c.tags,
+		Metadata: c.metadata, PublicAccess: c.publicAccess, AccessPolicies: c.accessPolicies,
+		Objects:   make(map[string]*blobObjectSnapshot, c.objects.Len()),
+		Snapshots: make(map[string]*blobObjectSnapshot, c.snapshots.Len()),
+	}
+
+	c.mu.Lock()
+	cs.SnapshotSeq = c.snapshotSeq
+	c.mu.Unlock()
+
+	for key, obj := range c.objects.All() {
+		cs.Objects[key] = snapshotBlob(obj, includeAssets)
+	}
+
+	for key, obj := range c.snapshots.All() {
+		cs.Snapshots[key] = snapshotBlob(obj, includeAssets)
+	}
+
+	return cs
+}
+
+func snapshotBlob(obj *blobObject, includeAssets bool) *blobObjectSnapshot {
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	data := obj.Data
+	if !includeAssets {
+		data = nil
+	}
+
+	return &blobObjectSnapshot{
+		Key: obj.Key, Data: data, Size: obj.Size, ContentType: obj.ContentType,
+		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata, Tags: obj.Tags,
+		BlobType: obj.BlobType, AccessTier: obj.AccessTier, ContentEncoding: obj.ContentEncoding,
+		ContentLanguage: obj.ContentLanguage, ContentDisposition: obj.ContentDisposition,
+		CacheControl: obj.CacheControl, CommittedBlocks: obj.CommittedBlocks, AppendBlocks: obj.appendBlocks,
+		LeaseState: obj.leaseState, LeaseID: obj.leaseID, LeaseDurationSec: obj.leaseDurationSec,
+		LeaseExpiresAt: obj.leaseExpiresAt, LeaseBreakAt: obj.leaseBreakAt,
+		LeaseModTimeAtAcquire: obj.leaseModTimeAtAcquire,
+	}
+}
+
+// Restore rebuilds every container under its original name with its blobs,
+// snapshots, and configuration intact.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap blobSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("blobstorage: parse snapshot: %w", err)
+	}
+
+	for name, cs := range snap.Containers {
+		m.containers.Set(name, restoreContainer(cs))
+	}
+
+	return m.restoreAccountStores(&snap)
+}
+
+func (m *Mock) restoreAccountStores(snap *blobSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.BucketAttrs, m.bucketAttrs.LoadSnapshot},
+		{snap.AccountKeys, m.accountKeys.LoadSnapshot},
+		{snap.BlobServiceProps, m.blobServiceProps.LoadSnapshot},
+		{snap.AccountEncryption, m.accountEncryption.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("blobstorage: restore account store: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func restoreContainer(cs *containerSnapshot) *containerMeta {
+	c := &containerMeta{
+		Name: cs.Name, Region: cs.Region, CreatedAt: cs.CreatedAt,
+		objects:    memstore.New[*blobObject](),
+		multiparts: memstore.New[*blobMultipartUpload](),
+		versioning: cs.Versioning,
+		lifecycle:  cs.Lifecycle, policy: cs.Policy, corsConfig: cs.CORS,
+		encryption: cs.Encryption, tags: cs.Tags, metadata: cs.Metadata,
+		publicAccess: cs.PublicAccess, accessPolicies: cs.AccessPolicies,
+		staging:     memstore.New[*blockStaging](),
+		snapshots:   memstore.New[*blobObject](),
+		snapshotSeq: cs.SnapshotSeq,
+	}
+
+	for key, os := range cs.Objects {
+		c.objects.Set(key, restoreBlob(os))
+	}
+
+	for key, os := range cs.Snapshots {
+		c.snapshots.Set(key, restoreBlob(os))
+	}
+
+	return c
+}
+
+func restoreBlob(os *blobObjectSnapshot) *blobObject {
+	return &blobObject{
+		Key: os.Key, Data: os.Data, Size: os.Size, ContentType: os.ContentType,
+		ETag: os.ETag, LastModified: os.LastModified, Metadata: os.Metadata, Tags: os.Tags,
+		BlobType: os.BlobType, AccessTier: os.AccessTier, ContentEncoding: os.ContentEncoding,
+		ContentLanguage: os.ContentLanguage, ContentDisposition: os.ContentDisposition,
+		CacheControl: os.CacheControl, CommittedBlocks: os.CommittedBlocks, appendBlocks: os.AppendBlocks,
+		leaseState: os.LeaseState, leaseID: os.LeaseID, leaseDurationSec: os.LeaseDurationSec,
+		leaseExpiresAt: os.LeaseExpiresAt, leaseBreakAt: os.LeaseBreakAt,
+		leaseModTimeAtAcquire: os.LeaseModTimeAtAcquire,
+	}
+}

--- a/providers/azure/cosmosdb/snapshot.go
+++ b/providers/azure/cosmosdb/snapshot.go
@@ -1,0 +1,105 @@
+package cosmosdb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// cosmosSnapshot is the full serialized state of the Cosmos DB mock: every
+// container keyed by name (with its config, items, TTL/change-feed
+// configuration, feed records, sequence counter, and tags), plus the
+// Cosmos-account cost attributes seeded for the TableAttributes discovery
+// capability. Items are keyed by their internal store key so they restore under
+// the same identity.
+type cosmosSnapshot struct {
+	Tables       map[string]*tableSnapshot           `json:"tables,omitempty"`
+	AccountAttrs map[string]driver.AccountAttributes `json:"accountAttrs,omitempty"`
+}
+
+type tableSnapshot struct {
+	Config        driver.TableConfig        `json:"config"`
+	Items         map[string]map[string]any `json:"items,omitempty"`
+	TTLConfig     driver.TTLConfig          `json:"ttlConfig,omitempty"`
+	StreamConfig  driver.StreamConfig       `json:"streamConfig,omitempty"`
+	StreamRecords []driver.StreamRecord     `json:"streamRecords,omitempty"`
+	SeqCounter    int64                     `json:"seqCounter,omitempty"`
+	Tags          map[string]string         `json:"tags,omitempty"`
+}
+
+// Snapshot captures every container's full state as JSON. includeAssets is
+// unused — Cosmos items are the resource, so they are always captured.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	snap := cosmosSnapshot{Tables: make(map[string]*tableSnapshot, len(m.tables))}
+
+	for name, td := range m.tables {
+		snap.Tables[name] = &tableSnapshot{
+			Config:        td.config,
+			Items:         td.items.All(),
+			TTLConfig:     td.ttlConfig,
+			StreamConfig:  td.streamConfig,
+			StreamRecords: td.streamRecords,
+			SeqCounter:    td.seqCounter.Load(),
+			Tags:          td.tags,
+		}
+	}
+
+	if len(m.accountAttrs) > 0 {
+		snap.AccountAttrs = make(map[string]driver.AccountAttributes, len(m.accountAttrs))
+		maps.Copy(snap.AccountAttrs, m.accountAttrs)
+	}
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds every container under its original name and item keys,
+// retyping item numbers back into expr.Number so exact decimals survive the
+// round-trip.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap cosmosSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("cosmosdb: parse snapshot: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for name, ts := range snap.Tables {
+		td := &tableData{
+			config:        ts.Config,
+			items:         memstore.New[map[string]any](),
+			ttlConfig:     ts.TTLConfig,
+			streamConfig:  ts.StreamConfig,
+			streamRecords: ts.StreamRecords,
+			tags:          ts.Tags,
+		}
+		td.seqCounter.Store(ts.SeqCounter)
+
+		for key, item := range ts.Items {
+			td.items.Set(key, expr.RetypeItem(item))
+		}
+
+		m.tables[name] = td
+	}
+
+	if len(snap.AccountAttrs) > 0 {
+		if m.accountAttrs == nil {
+			m.accountAttrs = make(map[string]driver.AccountAttributes, len(snap.AccountAttrs))
+		}
+
+		maps.Copy(m.accountAttrs, snap.AccountAttrs)
+	}
+
+	return nil
+}

--- a/providers/azure/keyvault/snapshot.go
+++ b/providers/azure/keyvault/snapshot.go
@@ -1,0 +1,254 @@
+package keyvault
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// keyvaultSnapshot is the full serialized state of the Key Vault mock: every
+// vault keyed by name, each with its secrets and keys. The defaultVault's
+// stores alias the shared Secrets-driver stores (m.secrets/m.keys); Restore
+// re-populates them through m.vault(name), which preserves that aliasing.
+type keyvaultSnapshot struct {
+	Vaults map[string]*vaultSnapshot `json:"vaults,omitempty"`
+}
+
+type vaultSnapshot struct {
+	Secrets map[string]*secretDataSnapshot `json:"secrets,omitempty"`
+	Keys    map[string]*keyDataSnapshot    `json:"keys,omitempty"`
+}
+
+type secretDataSnapshot struct {
+	Info           driver.SecretInfo       `json:"info"`
+	Versions       []secretVersionSnapshot `json:"versions,omitempty"`
+	DeletedAt      time.Time               `json:"deletedAt,omitempty"`
+	ScheduledPurge time.Time               `json:"scheduledPurge,omitempty"`
+}
+
+// secretVersionSnapshot mirrors the unexported secretVersion, promoting its
+// fields so they survive JSON.
+type secretVersionSnapshot struct {
+	VersionID   string            `json:"versionId"`
+	Value       []byte            `json:"value,omitempty"`
+	ContentType string            `json:"contentType,omitempty"`
+	Tags        map[string]string `json:"tags,omitempty"`
+	Enabled     bool              `json:"enabled,omitempty"`
+	Expires     int64             `json:"expires,omitempty"`
+	NotBefore   int64             `json:"notBefore,omitempty"`
+	Created     time.Time         `json:"created,omitempty"`
+	Updated     time.Time         `json:"updated,omitempty"`
+	Current     bool              `json:"current,omitempty"`
+}
+
+type keyDataSnapshot struct {
+	Name           string                   `json:"name"`
+	Versions       []keyVersionSnapshot     `json:"versions,omitempty"`
+	DeletedAt      time.Time                `json:"deletedAt,omitempty"`
+	ScheduledPurge time.Time                `json:"scheduledPurge,omitempty"`
+	RotationPolicy *driver.KVRotationPolicy `json:"rotationPolicy,omitempty"`
+}
+
+// keyVersionSnapshot mirrors the unexported keyVersion. The real private key
+// material is serialized in a portable DER form: RSA as PKCS#1, EC as SEC1,
+// oct as raw bytes.
+type keyVersionSnapshot struct {
+	VersionID string            `json:"versionId"`
+	Kty       string            `json:"kty,omitempty"`
+	Curve     string            `json:"curve,omitempty"`
+	KeyOps    []string          `json:"keyOps,omitempty"`
+	RSAKey    []byte            `json:"rsaKey,omitempty"`
+	ECKey     []byte            `json:"ecKey,omitempty"`
+	OctKey    []byte            `json:"octKey,omitempty"`
+	Tags      map[string]string `json:"tags,omitempty"`
+	Enabled   bool              `json:"enabled,omitempty"`
+	Expires   int64             `json:"expires,omitempty"`
+	NotBefore int64             `json:"notBefore,omitempty"`
+	Created   time.Time         `json:"created,omitempty"`
+	Updated   time.Time         `json:"updated,omitempty"`
+	Current   bool              `json:"current,omitempty"`
+	Managed   bool              `json:"managed,omitempty"`
+}
+
+// Snapshot captures every vault's secrets and keys as JSON. includeAssets is
+// unused — a secret or key without its material cannot be restored usefully, so
+// it is always captured.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := keyvaultSnapshot{Vaults: make(map[string]*vaultSnapshot, m.vaults.Len())}
+
+	for name, vd := range m.vaults.All() {
+		vs := &vaultSnapshot{
+			Secrets: make(map[string]*secretDataSnapshot, vd.secrets.Len()),
+			Keys:    make(map[string]*keyDataSnapshot, vd.keys.Len()),
+		}
+
+		for sName, sd := range vd.secrets.All() {
+			vs.Secrets[sName] = snapshotSecret(sd)
+		}
+
+		for kName, kd := range vd.keys.All() {
+			ks, err := snapshotKey(kd)
+			if err != nil {
+				return nil, err
+			}
+
+			vs.Keys[kName] = ks
+		}
+
+		snap.Vaults[name] = vs
+	}
+
+	return json.Marshal(snap)
+}
+
+func snapshotSecret(sd *secretData) *secretDataSnapshot {
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	ss := &secretDataSnapshot{
+		Info: sd.info, DeletedAt: sd.deletedAt, ScheduledPurge: sd.scheduledPurge,
+	}
+
+	for i := range sd.versions {
+		v := &sd.versions[i]
+		ss.Versions = append(ss.Versions, secretVersionSnapshot{
+			VersionID: v.versionID, Value: copyBytes(v.value), ContentType: v.contentType,
+			Tags: copyTags(v.tags), Enabled: v.enabled, Expires: v.expires, NotBefore: v.notBefore,
+			Created: v.created, Updated: v.updated, Current: v.current,
+		})
+	}
+
+	return ss
+}
+
+func snapshotKey(kd *keyData) (*keyDataSnapshot, error) {
+	kd.mu.RLock()
+	defer kd.mu.RUnlock()
+
+	ks := &keyDataSnapshot{
+		Name: kd.name, DeletedAt: kd.deletedAt, ScheduledPurge: kd.scheduledPurge,
+		RotationPolicy: kd.rotationPolicy,
+	}
+
+	for i := range kd.versions {
+		v := &kd.versions[i]
+
+		kvs := keyVersionSnapshot{
+			VersionID: v.versionID, Kty: v.kty, Curve: v.curve, KeyOps: v.keyOps,
+			OctKey: copyBytes(v.octKey), Tags: copyTags(v.tags), Enabled: v.enabled,
+			Expires: v.expires, NotBefore: v.notBefore, Created: v.created, Updated: v.updated,
+			Current: v.current, Managed: v.managed,
+		}
+
+		if v.rsaKey != nil {
+			kvs.RSAKey = x509.MarshalPKCS1PrivateKey(v.rsaKey)
+		}
+
+		if v.ecKey != nil {
+			der, err := x509.MarshalECPrivateKey(v.ecKey)
+			if err != nil {
+				return nil, fmt.Errorf("keyvault: marshal EC key %q: %w", kd.name, err)
+			}
+
+			kvs.ECKey = der
+		}
+
+		ks.Versions = append(ks.Versions, kvs)
+	}
+
+	return ks, nil
+}
+
+// Restore rebuilds every vault's secrets and keys under their original names and
+// version ids. The default vault is repopulated through m.vault(defaultVault),
+// which returns the aliased shared stores so the portable Secrets driver sees
+// the restored secrets.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap keyvaultSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("keyvault: parse snapshot: %w", err)
+	}
+
+	for vaultName, vs := range snap.Vaults {
+		vd := m.vault(vaultName)
+
+		for name, ss := range vs.Secrets {
+			vd.secrets.Set(name, restoreSecret(ss))
+		}
+
+		for name, ks := range vs.Keys {
+			kd, err := restoreKey(ks)
+			if err != nil {
+				return err
+			}
+
+			vd.keys.Set(name, kd)
+		}
+	}
+
+	return nil
+}
+
+func restoreSecret(ss *secretDataSnapshot) *secretData {
+	sd := &secretData{
+		info: ss.Info, deletedAt: ss.DeletedAt, scheduledPurge: ss.ScheduledPurge,
+	}
+
+	for i := range ss.Versions {
+		v := &ss.Versions[i]
+		sd.versions = append(sd.versions, secretVersion{
+			versionID: v.VersionID, value: copyBytes(v.Value), contentType: v.ContentType,
+			tags: copyTags(v.Tags), enabled: v.Enabled, expires: v.Expires, notBefore: v.NotBefore,
+			created: v.Created, updated: v.Updated, current: v.Current,
+		})
+	}
+
+	return sd
+}
+
+func restoreKey(ks *keyDataSnapshot) (*keyData, error) {
+	kd := &keyData{
+		name: ks.Name, deletedAt: ks.DeletedAt, scheduledPurge: ks.ScheduledPurge,
+		rotationPolicy: ks.RotationPolicy,
+	}
+
+	for i := range ks.Versions {
+		v := &ks.Versions[i]
+
+		kv := keyVersion{
+			versionID: v.VersionID, kty: v.Kty, curve: v.Curve, keyOps: v.KeyOps,
+			octKey: copyBytes(v.OctKey), tags: copyTags(v.Tags), enabled: v.Enabled,
+			expires: v.Expires, notBefore: v.NotBefore, created: v.Created, updated: v.Updated,
+			current: v.Current, managed: v.Managed,
+		}
+
+		if len(v.RSAKey) > 0 {
+			key, err := x509.ParsePKCS1PrivateKey(v.RSAKey)
+			if err != nil {
+				return nil, fmt.Errorf("keyvault: parse RSA key %q: %w", ks.Name, err)
+			}
+
+			kv.rsaKey = key
+		}
+
+		if len(v.ECKey) > 0 {
+			key, err := x509.ParseECPrivateKey(v.ECKey)
+			if err != nil {
+				return nil, fmt.Errorf("keyvault: parse EC key %q: %w", ks.Name, err)
+			}
+
+			kv.ecKey = key
+		}
+
+		kd.versions = append(kd.versions, kv)
+	}
+
+	return kd, nil
+}

--- a/providers/azure/virtualmachines/snapshot.go
+++ b/providers/azure/virtualmachines/snapshot.go
@@ -1,0 +1,250 @@
+package virtualmachines
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// vmSnapshot is the full serialized state of the Azure VM mock. Instances carry
+// an exported form (the stored instanceData has an unexported engineBacked
+// flag); the driver-typed stores round-trip through the generic memstore
+// helper. The state machine is rebuilt from each restored instance's stored
+// state. The nicAttacher hook is a live cross-service wiring, not state, and is
+// re-attached by the provider factory rather than serialized.
+type vmSnapshot struct {
+	Instances    map[string]*instanceSnapshot `json:"instances,omitempty"`
+	SpotRequests json.RawMessage              `json:"spotRequests,omitempty"`
+	Templates    json.RawMessage              `json:"templates,omitempty"`
+	Volumes      json.RawMessage              `json:"volumes,omitempty"`
+	Snapshots    json.RawMessage              `json:"snapshots,omitempty"`
+	Images       json.RawMessage              `json:"images,omitempty"`
+	KeyPairs     json.RawMessage              `json:"keyPairs,omitempty"`
+	ScaleSets    json.RawMessage              `json:"scaleSets,omitempty"`
+	DiskAccess   json.RawMessage              `json:"diskAccess,omitempty"`
+	ASGs         map[string]*asgSnapshot      `json:"asgs,omitempty"`
+	Counters     countersSnapshot             `json:"counters"`
+}
+
+type countersSnapshot struct {
+	IP   int64 `json:"ip,omitempty"`
+	Vol  int64 `json:"vol,omitempty"`
+	Snap int64 `json:"snap,omitempty"`
+	Img  int64 `json:"img,omitempty"`
+}
+
+// instanceSnapshot mirrors instanceData, promoting its one unexported field
+// (engineBacked) to an exported one so it survives JSON.
+type instanceSnapshot struct {
+	ID             string                  `json:"id"`
+	ImageID        string                  `json:"imageId,omitempty"`
+	InstanceType   string                  `json:"instanceType,omitempty"`
+	State          string                  `json:"state,omitempty"`
+	PrivateIP      string                  `json:"privateIp,omitempty"`
+	PublicIP       string                  `json:"publicIp,omitempty"`
+	SubnetID       string                  `json:"subnetId,omitempty"`
+	VPCID          string                  `json:"vpcId,omitempty"`
+	SecurityGroups []string                `json:"securityGroups,omitempty"`
+	Tags           map[string]string       `json:"tags,omitempty"`
+	LaunchTime     string                  `json:"launchTime,omitempty"`
+	OSType         string                  `json:"osType,omitempty"`
+	Priority       string                  `json:"priority,omitempty"`
+	LicenseType    string                  `json:"licenseType,omitempty"`
+	Zones          []string                `json:"zones,omitempty"`
+	Region         string                  `json:"region,omitempty"`
+	ResourceGroup  string                  `json:"resourceGroup,omitempty"`
+	PowerState     string                  `json:"powerState,omitempty"`
+	Generalized    bool                    `json:"generalized,omitempty"`
+	Identity       *driver.ManagedIdentity `json:"identity,omitempty"`
+	EngineBacked   bool                    `json:"engineBacked,omitempty"`
+	NICRefs        []driver.AzureNICRef    `json:"nicRefs,omitempty"`
+}
+
+type asgSnapshot struct {
+	Config   driver.AutoScalingGroup `json:"config"`
+	Policies json.RawMessage         `json:"policies,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// the VM service holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := vmSnapshot{Instances: m.snapshotInstances()}
+
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	asgs, err := m.snapshotASGs()
+	if err != nil {
+		return nil, err
+	}
+
+	snap.ASGs = asgs
+	snap.Counters = countersSnapshot{
+		IP: m.ipCounter.Load(), Vol: m.volCounter.Load(),
+		Snap: m.snapCounter.Load(), Img: m.imgCounter.Load(),
+	}
+
+	return json.Marshal(snap)
+}
+
+//nolint:dupl // inverse field map of restoreInstances; mirrored lists are inherent.
+func (m *Mock) snapshotInstances() map[string]*instanceSnapshot {
+	out := make(map[string]*instanceSnapshot, m.instances.Len())
+
+	for id, d := range m.instances.All() {
+		out[id] = &instanceSnapshot{
+			ID: d.ID, ImageID: d.ImageID, InstanceType: d.InstanceType, State: d.State,
+			PrivateIP: d.PrivateIP, PublicIP: d.PublicIP, SubnetID: d.SubnetID, VPCID: d.VPCID,
+			SecurityGroups: d.SecurityGroups, Tags: d.Tags, LaunchTime: d.LaunchTime,
+			OSType: d.OSType, Priority: d.Priority, LicenseType: d.LicenseType, Zones: d.Zones,
+			Region: d.Region, ResourceGroup: d.ResourceGroup, PowerState: d.PowerState,
+			Generalized: d.Generalized, Identity: d.Identity, EngineBacked: d.engineBacked,
+			NICRefs: d.NICRefs,
+		}
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotStores(snap *vmSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.SpotRequests, m.spotRequests.Snapshot},
+		{&snap.Templates, m.templates.Snapshot},
+		{&snap.Volumes, m.volumes.Snapshot},
+		{&snap.Snapshots, m.snapshots.Snapshot},
+		{&snap.Images, m.images.Snapshot},
+		{&snap.KeyPairs, m.keyPairs.Snapshot},
+		{&snap.ScaleSets, m.scaleSets.Snapshot},
+		{&snap.DiskAccess, m.diskAccess.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("virtualmachines: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+func (m *Mock) snapshotASGs() (map[string]*asgSnapshot, error) {
+	if m.asgs.Len() == 0 {
+		return nil, nil
+	}
+
+	out := make(map[string]*asgSnapshot, m.asgs.Len())
+
+	for name, a := range m.asgs.All() {
+		pol, err := a.policies.Snapshot()
+		if err != nil {
+			return nil, fmt.Errorf("virtualmachines: snapshot asg policies: %w", err)
+		}
+
+		out[name] = &asgSnapshot{Config: a.config, Policies: pol}
+	}
+
+	return out, nil
+}
+
+// Restore rebuilds the mock's state under the original identities: instance ids
+// (and their id-string cross-references, e.g. security groups) are preserved,
+// and each restored instance is re-registered with the state machine at its
+// stored state.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap vmSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("virtualmachines: parse snapshot: %w", err)
+	}
+
+	m.restoreInstances(snap.Instances)
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	if err := m.restoreASGs(snap.ASGs); err != nil {
+		return err
+	}
+
+	c := snap.Counters
+	m.ipCounter.Store(c.IP)
+	m.volCounter.Store(c.Vol)
+	m.snapCounter.Store(c.Snap)
+	m.imgCounter.Store(c.Img)
+
+	return nil
+}
+
+//nolint:dupl // inverse field map of snapshotInstances; mirrored lists are inherent.
+func (m *Mock) restoreInstances(instances map[string]*instanceSnapshot) {
+	for id, s := range instances {
+		m.instances.Set(id, &instanceData{
+			ID: s.ID, ImageID: s.ImageID, InstanceType: s.InstanceType, State: s.State,
+			PrivateIP: s.PrivateIP, PublicIP: s.PublicIP, SubnetID: s.SubnetID, VPCID: s.VPCID,
+			SecurityGroups: s.SecurityGroups, Tags: s.Tags, LaunchTime: s.LaunchTime,
+			OSType: s.OSType, Priority: s.Priority, LicenseType: s.LicenseType, Zones: s.Zones,
+			Region: s.Region, ResourceGroup: s.ResourceGroup, PowerState: s.PowerState,
+			Generalized: s.Generalized, Identity: s.Identity, engineBacked: s.EngineBacked,
+			NICRefs: s.NICRefs,
+		})
+		// Re-register with the state machine so lifecycle transitions
+		// (Start/Stop/Terminate) validate against the restored state.
+		m.sm.SetState(id, s.State)
+	}
+}
+
+func (m *Mock) restoreStores(snap *vmSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.SpotRequests, m.spotRequests.LoadSnapshot},
+		{snap.Templates, m.templates.LoadSnapshot},
+		{snap.Volumes, m.volumes.LoadSnapshot},
+		{snap.Snapshots, m.snapshots.LoadSnapshot},
+		{snap.Images, m.images.LoadSnapshot},
+		{snap.KeyPairs, m.keyPairs.LoadSnapshot},
+		{snap.ScaleSets, m.scaleSets.LoadSnapshot},
+		{snap.DiskAccess, m.diskAccess.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("virtualmachines: restore store: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (m *Mock) restoreASGs(asgs map[string]*asgSnapshot) error {
+	for name, a := range asgs {
+		ad := &asgData{config: a.Config, policies: memstore.New[driver.ScalingPolicy]()}
+		if len(a.Policies) > 0 {
+			if err := ad.policies.LoadSnapshot(a.Policies); err != nil {
+				return fmt.Errorf("virtualmachines: restore asg policies: %w", err)
+			}
+		}
+
+		m.asgs.Set(name, ad)
+	}
+
+	return nil
+}

--- a/providers/gcp/compute/snapshot.go
+++ b/providers/gcp/compute/snapshot.go
@@ -1,0 +1,224 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// gceSnapshot is the full serialized state of the GCE mock. Instances carry an
+// exported form (the stored instanceData has an unexported engineBacked flag);
+// the driver-typed stores round-trip through the generic memstore helper. The
+// state machine is rebuilt from each restored instance's stored state.
+type gceSnapshot struct {
+	Instances    map[string]*instanceSnapshot `json:"instances,omitempty"`
+	SpotRequests json.RawMessage              `json:"spotRequests,omitempty"`
+	Templates    json.RawMessage              `json:"templates,omitempty"`
+	Volumes      json.RawMessage              `json:"volumes,omitempty"`
+	Snapshots    json.RawMessage              `json:"snapshots,omitempty"`
+	Images       json.RawMessage              `json:"images,omitempty"`
+	KeyPairs     json.RawMessage              `json:"keyPairs,omitempty"`
+	ASGs         map[string]*asgSnapshot      `json:"asgs,omitempty"`
+	Counters     countersSnapshot             `json:"counters"`
+}
+
+type countersSnapshot struct {
+	IP   int64 `json:"ip,omitempty"`
+	Vol  int64 `json:"vol,omitempty"`
+	Snap int64 `json:"snap,omitempty"`
+	Img  int64 `json:"img,omitempty"`
+}
+
+// instanceSnapshot mirrors instanceData, promoting its one unexported field
+// (engineBacked) to an exported one so it survives JSON.
+type instanceSnapshot struct {
+	ID             string            `json:"id"`
+	ImageID        string            `json:"imageId,omitempty"`
+	InstanceType   string            `json:"instanceType,omitempty"`
+	State          string            `json:"state,omitempty"`
+	PrivateIP      string            `json:"privateIp,omitempty"`
+	PublicIP       string            `json:"publicIp,omitempty"`
+	SubnetID       string            `json:"subnetId,omitempty"`
+	VPCID          string            `json:"vpcId,omitempty"`
+	SecurityGroups []string          `json:"securityGroups,omitempty"`
+	Tags           map[string]string `json:"tags,omitempty"`
+	LaunchTime     string            `json:"launchTime,omitempty"`
+	EngineBacked   bool              `json:"engineBacked,omitempty"`
+}
+
+type asgSnapshot struct {
+	Config   driver.AutoScalingGroup `json:"config"`
+	Policies json.RawMessage         `json:"policies,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// GCE holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := gceSnapshot{Instances: m.snapshotInstances()}
+
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	asgs, err := m.snapshotASGs()
+	if err != nil {
+		return nil, err
+	}
+
+	snap.ASGs = asgs
+	snap.Counters = countersSnapshot{
+		IP: m.ipCounter.Load(), Vol: m.volCounter.Load(),
+		Snap: m.snapCounter.Load(), Img: m.imgCounter.Load(),
+	}
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotInstances() map[string]*instanceSnapshot {
+	out := make(map[string]*instanceSnapshot, m.instances.Len())
+
+	for id, d := range m.instances.All() {
+		out[id] = &instanceSnapshot{
+			ID: d.ID, ImageID: d.ImageID, InstanceType: d.InstanceType, State: d.State,
+			PrivateIP: d.PrivateIP, PublicIP: d.PublicIP, SubnetID: d.SubnetID, VPCID: d.VPCID,
+			SecurityGroups: d.SecurityGroups, Tags: d.Tags, LaunchTime: d.LaunchTime,
+			EngineBacked: d.engineBacked,
+		}
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotStores(snap *gceSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.SpotRequests, m.spotRequests.Snapshot},
+		{&snap.Templates, m.templates.Snapshot},
+		{&snap.Volumes, m.volumes.Snapshot},
+		{&snap.Snapshots, m.snapshots.Snapshot},
+		{&snap.Images, m.images.Snapshot},
+		{&snap.KeyPairs, m.keyPairs.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("gce: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+func (m *Mock) snapshotASGs() (map[string]*asgSnapshot, error) {
+	if m.asgs.Len() == 0 {
+		return nil, nil
+	}
+
+	out := make(map[string]*asgSnapshot, m.asgs.Len())
+
+	for name, a := range m.asgs.All() {
+		pol, err := a.policies.Snapshot()
+		if err != nil {
+			return nil, fmt.Errorf("gce: snapshot asg policies: %w", err)
+		}
+
+		out[name] = &asgSnapshot{Config: a.config, Policies: pol}
+	}
+
+	return out, nil
+}
+
+// Restore rebuilds the mock's state under the original identities: instance ids
+// (and their id-string cross-references, e.g. security groups) are preserved,
+// and each restored instance is re-registered with the state machine at its
+// stored state.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap gceSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("gce: parse snapshot: %w", err)
+	}
+
+	m.restoreInstances(snap.Instances)
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	if err := m.restoreASGs(snap.ASGs); err != nil {
+		return err
+	}
+
+	c := snap.Counters
+	m.ipCounter.Store(c.IP)
+	m.volCounter.Store(c.Vol)
+	m.snapCounter.Store(c.Snap)
+	m.imgCounter.Store(c.Img)
+
+	return nil
+}
+
+func (m *Mock) restoreInstances(instances map[string]*instanceSnapshot) {
+	for id, s := range instances {
+		m.instances.Set(id, &instanceData{
+			ID: s.ID, ImageID: s.ImageID, InstanceType: s.InstanceType, State: s.State,
+			PrivateIP: s.PrivateIP, PublicIP: s.PublicIP, SubnetID: s.SubnetID, VPCID: s.VPCID,
+			SecurityGroups: s.SecurityGroups, Tags: s.Tags, LaunchTime: s.LaunchTime,
+			engineBacked: s.EngineBacked,
+		})
+		// Re-register with the state machine so lifecycle transitions
+		// (Start/Stop/Terminate) validate against the restored state.
+		m.sm.SetState(id, s.State)
+	}
+}
+
+func (m *Mock) restoreStores(snap *gceSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.SpotRequests, m.spotRequests.LoadSnapshot},
+		{snap.Templates, m.templates.LoadSnapshot},
+		{snap.Volumes, m.volumes.LoadSnapshot},
+		{snap.Snapshots, m.snapshots.LoadSnapshot},
+		{snap.Images, m.images.LoadSnapshot},
+		{snap.KeyPairs, m.keyPairs.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("gce: restore store: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (m *Mock) restoreASGs(asgs map[string]*asgSnapshot) error {
+	for name, a := range asgs {
+		ad := &asgData{config: a.Config, policies: memstore.New[driver.ScalingPolicy]()}
+		if len(a.Policies) > 0 {
+			if err := ad.policies.LoadSnapshot(a.Policies); err != nil {
+				return fmt.Errorf("gce: restore asg policies: %w", err)
+			}
+		}
+
+		m.asgs.Set(name, ad)
+	}
+
+	return nil
+}

--- a/providers/gcp/firestore/snapshot.go
+++ b/providers/gcp/firestore/snapshot.go
@@ -1,0 +1,89 @@
+package firestore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// firestoreSnapshot is the full serialized state of the Firestore mock: every
+// collection keyed by name, each with its config (including composite indexes),
+// documents, TTL/listener configuration, snapshot records, sequence counter,
+// and labels. Documents are keyed by their internal store key so they restore
+// under the same identity.
+type firestoreSnapshot struct {
+	Collections map[string]*collectionSnapshot `json:"collections,omitempty"`
+}
+
+type collectionSnapshot struct {
+	Config        driver.TableConfig        `json:"config"`
+	Items         map[string]map[string]any `json:"items,omitempty"`
+	TTLConfig     driver.TTLConfig          `json:"ttlConfig,omitempty"`
+	StreamConfig  driver.StreamConfig       `json:"streamConfig,omitempty"`
+	StreamRecords []driver.StreamRecord     `json:"streamRecords,omitempty"`
+	SeqCounter    int64                     `json:"seqCounter,omitempty"`
+	Labels        map[string]string         `json:"labels,omitempty"`
+}
+
+// Snapshot captures every collection's full state as JSON. includeAssets is
+// unused — Firestore documents are the resource, so they are always captured.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	snap := firestoreSnapshot{Collections: make(map[string]*collectionSnapshot, len(m.collections))}
+
+	for name, cd := range m.collections {
+		snap.Collections[name] = &collectionSnapshot{
+			Config:        cd.config,
+			Items:         cd.items.All(),
+			TTLConfig:     cd.ttlConfig,
+			StreamConfig:  cd.streamConfig,
+			StreamRecords: cd.streamRecords,
+			SeqCounter:    cd.seqCounter.Load(),
+			Labels:        cd.labels,
+		}
+	}
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds every collection under its original name and document keys,
+// retyping document numbers back into expr.Number so exact decimals survive the
+// round-trip.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap firestoreSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("firestore: parse snapshot: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for name, cs := range snap.Collections {
+		cd := &collectionData{
+			config:        cs.Config,
+			items:         memstore.New[map[string]any](),
+			ttlConfig:     cs.TTLConfig,
+			streamConfig:  cs.StreamConfig,
+			streamRecords: cs.StreamRecords,
+			labels:        cs.Labels,
+		}
+		cd.seqCounter.Store(cs.SeqCounter)
+
+		for key, item := range cs.Items {
+			cd.items.Set(key, expr.RetypeItem(item))
+		}
+
+		m.collections[name] = cd
+	}
+
+	return nil
+}

--- a/providers/gcp/gcs/snapshot.go
+++ b/providers/gcp/gcs/snapshot.go
@@ -1,0 +1,123 @@
+package gcs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// gcsSnapshot is the full serialized state of the GCS mock: every bucket keyed
+// by name with its metadata, configuration sub-resources, and current objects.
+// In-progress multipart uploads are transient and intentionally not captured.
+type gcsSnapshot struct {
+	Buckets map[string]*bucketSnapshot `json:"buckets,omitempty"`
+}
+
+type bucketSnapshot struct {
+	Name       string                     `json:"name"`
+	Region     string                     `json:"region,omitempty"`
+	CreatedAt  string                     `json:"createdAt,omitempty"`
+	Versioning bool                       `json:"versioning,omitempty"`
+	Lifecycle  *driver.LifecycleConfig    `json:"lifecycle,omitempty"`
+	Policy     *driver.BucketPolicy       `json:"policy,omitempty"`
+	CORS       *driver.CORSConfig         `json:"cors,omitempty"`
+	Encryption *driver.EncryptionConfig   `json:"encryption,omitempty"`
+	Tags       map[string]string          `json:"tags,omitempty"`
+	Objects    map[string]*objectSnapshot `json:"objects,omitempty"`
+}
+
+// objectSnapshot mirrors gcsObject (all exported already), but Data is dropped
+// in a metadata-only (includeAssets=false) snapshot while Size is kept so the
+// metadata stays correct.
+type objectSnapshot struct {
+	Key          string            `json:"key"`
+	Data         []byte            `json:"data,omitempty"`
+	Size         int64             `json:"size"`
+	ContentType  string            `json:"contentType,omitempty"`
+	ETag         string            `json:"etag,omitempty"`
+	LastModified string            `json:"lastModified,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+	Tags         map[string]string `json:"tags,omitempty"`
+}
+
+// Snapshot captures every bucket's state as JSON. When includeAssets is false
+// the object bytes are omitted (metadata-only).
+func (m *Mock) Snapshot(_ context.Context, includeAssets bool) (json.RawMessage, error) {
+	snap := gcsSnapshot{Buckets: make(map[string]*bucketSnapshot, m.buckets.Len())}
+
+	for name, bkt := range m.buckets.All() {
+		snap.Buckets[name] = snapshotBucket(bkt, includeAssets)
+	}
+
+	return json.Marshal(snap)
+}
+
+func snapshotBucket(bkt *bucketMeta, includeAssets bool) *bucketSnapshot {
+	bs := &bucketSnapshot{
+		Name: bkt.Name, Region: bkt.Region, CreatedAt: bkt.CreatedAt,
+		Versioning: bkt.versioning, Lifecycle: bkt.lifecycle, Policy: bkt.policy,
+		CORS: bkt.corsConfig, Encryption: bkt.encryption, Tags: bkt.tags,
+		Objects: make(map[string]*objectSnapshot, bkt.objects.Len()),
+	}
+
+	for key, obj := range bkt.objects.All() {
+		bs.Objects[key] = &objectSnapshot{
+			Key: obj.Key, Data: assetBytes(obj.Data, includeAssets), Size: obj.Size,
+			ContentType: obj.ContentType, ETag: obj.ETag, LastModified: obj.LastModified,
+			Metadata: obj.Metadata, Tags: obj.Tags,
+		}
+	}
+
+	return bs
+}
+
+// assetBytes returns data only when assets are included, so metadata-only
+// snapshots omit object bodies.
+func assetBytes(data []byte, includeAssets bool) []byte {
+	if !includeAssets {
+		return nil
+	}
+
+	return data
+}
+
+// Restore rebuilds every bucket under its original name with its objects and
+// configuration intact.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap gcsSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("gcs: parse snapshot: %w", err)
+	}
+
+	for name, bs := range snap.Buckets {
+		m.buckets.Set(name, restoreBucket(bs))
+	}
+
+	return nil
+}
+
+func restoreBucket(bs *bucketSnapshot) *bucketMeta {
+	bkt := &bucketMeta{
+		Name: bs.Name, Region: bs.Region, CreatedAt: bs.CreatedAt,
+		objects:    memstore.New[*gcsObject](),
+		multiparts: memstore.New[*gcsMultipartUpload](),
+		versioning: bs.Versioning,
+		lifecycle:  bs.Lifecycle, policy: bs.Policy, corsConfig: bs.CORS,
+		encryption: bs.Encryption, tags: bs.Tags,
+	}
+
+	for key, os := range bs.Objects {
+		bkt.objects.Set(key, &gcsObject{
+			Key: os.Key, Data: os.Data, Size: os.Size, ContentType: os.ContentType,
+			ETag: os.ETag, LastModified: os.LastModified, Metadata: os.Metadata, Tags: os.Tags,
+		})
+	}
+
+	return bkt
+}

--- a/providers/gcp/secretmanager/snapshot.go
+++ b/providers/gcp/secretmanager/snapshot.go
@@ -1,0 +1,64 @@
+package secretmanager
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// secretsSnapshot is the full serialized state of the GCP Secret Manager mock:
+// every secret keyed by name, each with its metadata, version history, and
+// soft-delete state, so identifiers (self-link, version ids) restore unchanged.
+type secretsSnapshot struct {
+	Secrets map[string]*secretSnapshot `json:"secrets,omitempty"`
+}
+
+type secretSnapshot struct {
+	Info      driver.SecretInfo      `json:"info"`
+	Versions  []driver.SecretVersion `json:"versions,omitempty"`
+	DeletedAt time.Time              `json:"deletedAt,omitempty"`
+}
+
+// Snapshot captures every secret's full state as JSON. includeAssets is unused —
+// a secret without its value cannot be restored usefully, so values are always
+// captured.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := secretsSnapshot{Secrets: make(map[string]*secretSnapshot)}
+
+	for name, sd := range m.secrets.All() {
+		sd.mu.RLock()
+		snap.Secrets[name] = &secretSnapshot{
+			Info:      sd.info,
+			Versions:  sd.versions,
+			DeletedAt: sd.deletedAt,
+		}
+		sd.mu.RUnlock()
+	}
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds every secret under its original name with its metadata and
+// version history intact.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap secretsSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("secretmanager: parse snapshot: %w", err)
+	}
+
+	for name, ss := range snap.Secrets {
+		m.secrets.Set(name, &secretData{
+			info:      ss.Info,
+			versions:  ss.Versions,
+			deletedAt: ss.DeletedAt,
+		})
+	}
+
+	return nil
+}


### PR DESCRIPTION
## What

Phase 2a of #582 (persist evolution). Implements identity-preserving `internal/snapshot.Snapshottable` (`Snapshot`/`Restore`) on the Azure and GCP mocks for the four service kinds persist already orchestrates — Storage, Database, Secrets, Compute — mirroring the four AWS mocks merged in Phase 1 (#616).

Eight new `snapshot.go` files:

- **Azure**: `blobstorage` (storage), `cosmosdb` (database), `keyvault` (secrets), `virtualmachines` (compute)
- **GCP**: `gcs` (storage), `firestore` (database), `secretmanager` (secrets), `compute`/GCE (compute)

Each dumps the mock's full state: every `memstore.Store` (via the `Store.Snapshot`/`LoadSnapshot` helpers) plus non-store state (atomic ID/IP/sequence counters, cross-ref maps, per-container/table sequence counters, Cosmos account attributes). Value types with unexported data fields are promoted to exported snapshot structs so `json.Marshal` doesn't silently drop them:

- **VM / GCE instanceData**: `engineBacked` (plus Azure's `PowerState`/`Generalized`/`Identity`/`NICRefs`, all already exported).
- **blobstorage blobObject**: the full Lease Blob state (`leaseState`/`leaseID`/`leaseDurationSec`/`leaseExpiresAt`/`leaseBreakAt`/`leaseModTimeAtAcquire`) and `appendBlocks`; container snapshots and `snapshotSeq` captured too.
- **keyvault**: multi-vault (secrets + keys per vault); `secretVersion` and `keyVersion` unexported fields promoted, with RSA/EC private-key material serialized as PKCS#1 / SEC1 DER and oct keys as raw bytes. The default vault is restored through `m.vault(defaultVault)` so it stays aliased to the shared Secrets-driver stores.

Sync primitives, transient multipart/staging state, and settle overlays are intentionally not serialized.

**Compute identity preservation** (the point of the phase): Azure VM and GCE previously minted fresh instance IDs on restore via the driver-replay `RunInstances` path. Now restored instances keep their stored ID and ID-string cross-references (security groups), and each is re-registered with the state machine at its **stored** state (copying `ec2/snapshot.go`), so a restored stopped instance stays stopped and remains transitionable.

## Why

Completes identity preservation across all three clouds' four core kinds. The existing generic persist orchestration type-asserts each driver to `Snapshottable`, so it picks these up automatically — `persist/persist.go` is unchanged. `cmd/cloudemu/serve.go` already builds the Azure/GCP `seed.Target`s from the raw `*Mock` types, so the assertion hits.

## Tests

`persist/identity_azure_test.go` and `persist/identity_gcp_test.go` mirror the AWS `identity_test.go`: create a resource of each of the 4 kinds + a compute instance with a security-group cross-ref, `ExportAll` → JSON → `RestoreAll` into a fresh `NewAzure()`/`NewGCP()`, then assert the compute instance keeps the SAME ID, its SG cross-ref resolves, it's transitionable (Stop succeeds), and the storage/database/secret payloads survive.

## Follow-up

Phase 2b = replace the `seed.Target` enumeration so persist reaches the remaining services beyond these four core kinds.