### PR TITLE
fix(blobstorage): preserve lease across authorized writes; enforce SAS permission + expiry

### DIFF
--- a/providers/azure/blobstorage/blob_extensions.go
+++ b/providers/azure/blobstorage/blob_extensions.go
@@ -104,6 +104,7 @@ func (m *Mock) CommitBlockList(
 		obj.Data = data
 	}
 
+	m.carryOverLease(ctr, blob, obj)
 	ctr.objects.Set(blob, obj)
 	ctr.staging.Delete(blob)
 
@@ -458,6 +459,37 @@ func effectiveLeaseState(obj *blobObject, now time.Time) string {
 		return leaseStateBroken
 	default:
 		return leaseStateAvailable
+	}
+}
+
+// carryOverLease copies an existing blob's lease bookkeeping onto the
+// replacement object built by an overwrite (Put Blob / Commit Block List /
+// Copy Blob), so an authorized write does not silently clear an active lease.
+// Real Azure keeps a fixed or infinite lease active across writes made with
+// the correct lease id; without this the lease evaporates after the first
+// write and any no-lease writer can then overwrite the blob.
+func (m *Mock) carryOverLease(ctr *containerMeta, key string, next *blobObject) {
+	prev, ok := ctr.objects.Get(key)
+	if !ok {
+		return
+	}
+
+	prev.mu.Lock()
+	defer prev.mu.Unlock()
+
+	next.leaseState = prev.leaseState
+	next.leaseID = prev.leaseID
+	next.leaseDurationSec = prev.leaseDurationSec
+	next.leaseExpiresAt = prev.leaseExpiresAt
+	next.leaseBreakAt = prev.leaseBreakAt
+	next.leaseModTimeAtAcquire = prev.leaseModTimeAtAcquire
+
+	// A write authorized under an active lease advances the blob's
+	// last-modified; record it as the lease's reference time so a later renew
+	// of that same lease (after it expires) still treats the blob as
+	// unmodified by anyone else.
+	if s := effectiveLeaseState(prev, m.opts.Clock.Now().UTC()); s == leaseStateLeased || s == leaseStateBreaking {
+		next.leaseModTimeAtAcquire = next.LastModified
 	}
 }
 

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -380,6 +380,7 @@ func (m *Mock) PutObject(ctx context.Context, bucket, key string, data []byte, c
 		obj.Data = dataCopy
 	}
 
+	m.carryOverLease(ctr, key, obj)
 	ctr.objects.Set(key, obj)
 
 	m.emitMetric(bucket, map[string]float64{"Transactions": 1, "Ingress": float64(size)})
@@ -610,6 +611,7 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 		dstObj.Data = dataCopy
 	}
 
+	m.carryOverLease(dstCtr, dstKey, dstObj)
 	dstCtr.objects.Set(dstKey, dstObj)
 
 	m.emitMetric(dstBucket, map[string]float64{"Transactions": 1})

--- a/server/azure/blobstorage/blob_lease_test.go
+++ b/server/azure/blobstorage/blob_lease_test.go
@@ -114,6 +114,55 @@ func TestSDKLeaseGatesWrites(t *testing.T) {
 	}
 }
 
+// TestSDKLeasedWritePreservesLease is the regression test for the lease-destroyed-
+// on-write blocker: an authorized write (with the correct lease id) used to
+// rebuild the blob object and drop its lease fields, leaving the blob unleased.
+// After the fix the lease survives the write — Renew still works and a
+// subsequent no-lease write is still rejected.
+func TestSDKLeasedWritePreservesLease(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("v1"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+
+	lc, err := lease.NewBlobClient(bc, nil)
+	if err != nil {
+		t.Fatalf("lease.NewBlobClient: %v", err)
+	}
+
+	if _, err := lc.AcquireLease(ctx, -1, nil); err != nil {
+		t.Fatalf("AcquireLease: %v", err)
+	}
+
+	// Authorized write with the correct lease id.
+	bb := e.blockBlob(t, "/c1/k1")
+	rightCond := &blockblob.UploadOptions{
+		AccessConditions: &blob.AccessConditions{LeaseAccessConditions: &blob.LeaseAccessConditions{LeaseID: lc.LeaseID()}},
+	}
+	if _, err := bb.Upload(ctx, streaming.NopCloser(bytes.NewReader([]byte("v2"))), rightCond); err != nil {
+		t.Fatalf("Upload with correct lease id: %v", err)
+	}
+
+	// The lease must still be present after the write: Renew succeeds.
+	if _, err := lc.RenewLease(ctx, nil); err != nil {
+		t.Fatalf("RenewLease after authorized write: %v (lease was destroyed by the write)", err)
+	}
+
+	// And the blob is still protected: a no-lease write is rejected.
+	_, err = e.svc.UploadBuffer(ctx, "c1", "k1", []byte("no-lease-overwrite"), nil)
+	if !bloberror.HasCode(err, bloberror.LeaseIDMissing) {
+		t.Fatalf("no-lease write after authorized write: err = %v, want LeaseIdMissing (blob left unleased)", err)
+	}
+
+	if got := e.download(t, "k1"); got != "v2" {
+		t.Errorf("blob content = %q, want v2 (rejected no-lease write must not overwrite)", got)
+	}
+}
+
 // TestSDKLeaseAcquireAlreadyPresentConflicts checks that acquiring a lease
 // against an already-leased blob with a different (or no) proposed id fails
 // with LeaseAlreadyPresent, per the Lease Blob acquire-outcome table.

--- a/server/azure/blobstorage/handler.go
+++ b/server/azure/blobstorage/handler.go
@@ -96,6 +96,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("X-Ms-Version", xmsVersion)
 
+	if enforceSAS(w, r, blob) {
+		return
+	}
+
 	switch {
 	case container == "" && q.Get("comp") == compList:
 		h.listContainers(w, r)

--- a/server/azure/blobstorage/sas.go
+++ b/server/azure/blobstorage/sas.go
@@ -1,0 +1,135 @@
+package blobstorage
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+// SAS (service shared-access-signature) query parameter names. See
+// https://learn.microsoft.com/en-us/rest/api/storageservices/create-service-sas.
+const (
+	sasSig    = "sig" // signature — its presence marks a SAS-authenticated request.
+	sasPerm   = "sp"  // signed permissions (r/w/d/l/a/c/…).
+	sasExpiry = "se"  // signed expiry time.
+	sasStart  = "st"  // signed start time (optional).
+)
+
+// Azure SAS permission characters relevant to blob data-plane ops.
+const (
+	sasPermRead   = "r"
+	sasPermAdd    = "a"
+	sasPermCreate = "c"
+	sasPermWrite  = "w"
+	sasPermDelete = "d"
+	sasPermList   = "l"
+)
+
+// enforceSAS applies SAS permission + validity-window scoping to a request that
+// carries a SAS signature (a `sig` query param). cloudemu does not verify the
+// SAS signature cryptographically — the whole wire layer accepts any
+// credentials — but it honors the permission set (sp) and the validity window
+// (st/se) so SAS-based least-privilege access control is testable: a read-only
+// SAS can't delete or overwrite, and an expired SAS is rejected. It writes the
+// Azure error and returns true when the request must be rejected.
+func enforceSAS(w http.ResponseWriter, r *http.Request, blob string) bool {
+	q := r.URL.Query()
+	if q.Get(sasSig) == "" {
+		return false // not a SAS-authenticated request; nothing to enforce.
+	}
+
+	now := time.Now().UTC()
+
+	if st := q.Get(sasStart); st != "" {
+		if t, ok := parseSASTime(st); ok && now.Before(t) {
+			writeError(w, http.StatusForbidden, "AuthenticationFailed",
+				"Server failed to authenticate the request: the SAS start time (st) is in the future.")
+			return true
+		}
+	}
+
+	if se := q.Get(sasExpiry); se != "" {
+		if t, ok := parseSASTime(se); ok && !now.Before(t) {
+			writeError(w, http.StatusForbidden, "AuthenticationFailed",
+				"Server failed to authenticate the request: the SAS expiry time (se) is in the past.")
+			return true
+		}
+	}
+
+	if allowed := sasPermissionsFor(r, blob); len(allowed) > 0 && !hasAnySASPermission(q.Get(sasPerm), allowed) {
+		writeError(w, http.StatusForbidden, "AuthorizationPermissionMismatch",
+			"This request is not authorized to perform this operation using this permission.")
+		return true
+	}
+
+	return false
+}
+
+// sasPermissionsFor returns the SAS permission characters that would authorize
+// the request, any one of which is sufficient. An empty result means the op is
+// not permission-gated by a service SAS here (e.g. account/container-level
+// management), and is left to run.
+func sasPermissionsFor(r *http.Request, blob string) []string {
+	comp := r.URL.Query().Get("comp")
+
+	switch r.Method {
+	case http.MethodGet, http.MethodHead:
+		if comp == compList {
+			return []string{sasPermList}
+		}
+
+		if blob == "" {
+			return nil // container property reads are not gated here.
+		}
+
+		return []string{sasPermRead}
+	case http.MethodDelete:
+		if blob == "" {
+			return nil // container delete is account/management-level.
+		}
+
+		return []string{sasPermDelete}
+	case http.MethodPut:
+		if blob == "" {
+			return nil // container create/config is account/management-level.
+		}
+
+		if comp == compAppendBlock {
+			return []string{sasPermAdd, sasPermWrite}
+		}
+
+		return []string{sasPermWrite, sasPermCreate}
+	default:
+		return nil
+	}
+}
+
+// hasAnySASPermission reports whether the signed-permission string sp grants at
+// least one of the acceptable permission characters.
+func hasAnySASPermission(sp string, allowed []string) bool {
+	for _, p := range allowed {
+		if strings.Contains(sp, p) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// parseSASTime parses an Azure SAS st/se timestamp, which may carry date-only,
+// second, or sub-second precision. It reports ok=false for an unparseable value
+// so a malformed time is treated leniently (not enforced) rather than blocking.
+func parseSASTime(v string) (t time.Time, ok bool) {
+	for _, layout := range []string{
+		"2006-01-02T15:04:05.0000000Z07:00",
+		time.RFC3339,
+		"2006-01-02T15:04Z07:00",
+		time.DateOnly,
+	} {
+		if parsed, err := time.Parse(layout, v); err == nil {
+			return parsed.UTC(), true
+		}
+	}
+
+	return time.Time{}, false
+}

--- a/server/azure/blobstorage/sas_test.go
+++ b/server/azure/blobstorage/sas_test.go
@@ -1,0 +1,131 @@
+package blobstorage_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// sasQuery builds a service-SAS query string with the given permissions and
+// expiry. The signature is a placeholder: cloudemu does not verify SAS
+// signatures cryptographically (the wire layer accepts any credentials), it
+// only enforces the permission set and validity window.
+func sasQuery(perms string, expiry time.Time) string {
+	return "sv=2023-11-03&sr=b&sp=" + perms +
+		"&se=" + expiry.UTC().Format("2006-01-02T15:04:05Z") +
+		"&sig=placeholder-signature"
+}
+
+// doSAS issues a raw HTTP request through the test transport (bypassing the
+// azblob client, which would require a real credential to mint a SAS).
+func doSAS(t *testing.T, e *blobEnv, method, url, body string) *http.Response {
+	t.Helper()
+
+	var rdr io.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), method, url, rdr)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	if method == http.MethodPut {
+		req.Header.Set("x-ms-blob-type", "BlockBlob")
+	}
+
+	resp, err := e.tr.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+
+	return resp
+}
+
+// TestSDKReadOnlySASCannotDeleteOrOverwrite checks that a read-only SAS
+// (sp=r) authorizes a read but is rejected (403 AuthorizationPermissionMismatch)
+// for delete and overwrite — the whole point of least-privilege SAS scoping.
+func TestSDKReadOnlySASCannotDeleteOrOverwrite(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("v1"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	readSAS := e.base + "/c1/k1?" + sasQuery("r", time.Now().Add(time.Hour))
+
+	// Read is allowed.
+	resp := doSAS(t, e, http.MethodGet, readSAS, "")
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("read-only SAS GET status = %d, want 200 (code=%s)", resp.StatusCode, resp.Header.Get("X-Ms-Error-Code"))
+	}
+	_ = resp.Body.Close()
+
+	// Delete is rejected.
+	resp = doSAS(t, e, http.MethodDelete, readSAS, "")
+	if resp.StatusCode != http.StatusForbidden || resp.Header.Get("X-Ms-Error-Code") != "AuthorizationPermissionMismatch" {
+		t.Errorf("read-only SAS DELETE = %d/%s, want 403/AuthorizationPermissionMismatch",
+			resp.StatusCode, resp.Header.Get("X-Ms-Error-Code"))
+	}
+	_ = resp.Body.Close()
+
+	// Overwrite is rejected.
+	resp = doSAS(t, e, http.MethodPut, readSAS, "hacked")
+	if resp.StatusCode != http.StatusForbidden || resp.Header.Get("X-Ms-Error-Code") != "AuthorizationPermissionMismatch" {
+		t.Errorf("read-only SAS PUT = %d/%s, want 403/AuthorizationPermissionMismatch",
+			resp.StatusCode, resp.Header.Get("X-Ms-Error-Code"))
+	}
+	_ = resp.Body.Close()
+
+	// The blob must be untouched by the rejected mutations.
+	if got := e.download(t, "k1"); got != "v1" {
+		t.Errorf("blob content = %q, want v1 (rejected SAS write must not overwrite)", got)
+	}
+}
+
+// TestSDKExpiredSASRejected checks that a SAS whose expiry (se) is in the past
+// is rejected with 403 AuthenticationFailed even for a read.
+func TestSDKExpiredSASRejected(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("v1"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	expiredSAS := e.base + "/c1/k1?" + sasQuery("r", time.Now().Add(-time.Hour))
+
+	resp := doSAS(t, e, http.MethodGet, expiredSAS, "")
+	defer resp.Body.Close() //nolint:errcheck // test cleanup
+
+	if resp.StatusCode != http.StatusForbidden || resp.Header.Get("X-Ms-Error-Code") != "AuthenticationFailed" {
+		t.Errorf("expired SAS GET = %d/%s, want 403/AuthenticationFailed",
+			resp.StatusCode, resp.Header.Get("X-Ms-Error-Code"))
+	}
+}
+
+// TestSDKReadWriteSASAllowsDelete checks the permission grant works in the
+// affirmative direction too: a SAS with delete permission (sp=rd) is allowed
+// to delete.
+func TestSDKReadWriteSASAllowsDelete(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("v1"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	rdSAS := e.base + "/c1/k1?" + sasQuery("rd", time.Now().Add(time.Hour))
+
+	resp := doSAS(t, e, http.MethodDelete, rdSAS, "")
+	defer resp.Body.Close() //nolint:errcheck // test cleanup
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Errorf("sp=rd SAS DELETE status = %d, want 202 (code=%s)", resp.StatusCode, resp.Header.Get("X-Ms-Error-Code"))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two HIGH Azure Blob Storage correctness bugs found by the deep end-to-end audit.

### NEW-2 (HIGH, concurrency/data-integrity): lease destroyed on write
An authorized write rebuilt a fresh `blobObject` and dropped all lease fields
(`leaseState`/`leaseID`/`leaseDurationSec`/`leaseExpiresAt`/…). After one write
made with the correct lease id, the blob was silently unleased — a subsequent
`RenewLease` failed `409 LeaseNotPresentWithLeaseOperation`, and any no-lease
writer could immediately overwrite it, defeating exclusive-writer / leader-election.

Fix (provider layer, `providers/azure/blobstorage`): a new `carryOverLease`
helper copies the existing blob's lease bookkeeping onto the replacement object.
Wired into all three overwrite paths that pass through a leased blob:
`PutObject`, `CommitBlockList`, and `CopyObject` (each is lease-gated at the wire
layer via `checkLease` before the write). The wire layer still correctly
requires the lease id for the write itself.

### NEW-1 / #288 (HIGH, security): SAS not enforced
SAS permissions and expiry were never enforced — a read-only SAS (`sp=r`) could
DELETE/overwrite and an expired SAS still read, so SAS-based access control was
untestable against the emulator.

Fix (wire/auth layer, `server/azure/blobstorage/sas.go`): a SAS gate parses the
SAS query and, when a `sig` is present, enforces the validity window (`st`/`se`)
and the permission set (`sp`) against the requested operation
(r→GET/HEAD, w/c→PUT, d→DELETE, a→append, l→list), returning
`403 AuthorizationPermissionMismatch` / `AuthenticationFailed`. Cryptographic
signature verification stays lenient, consistent with the wire layer accepting
any credentials project-wide; permission + expiry scoping is honored so SAS
behavior is testable.

### Deferred
NEW-3 (LOW): GET/DELETE on a blob in a missing container reports `BlobNotFound`
instead of `ContainerNotFound`. Deferred — a correct fix requires the provider
to return a typed error for the missing-container case across GetObject/
DeleteObject/HeadObject, which changes error semantics for portable-layer
consumers (not a trivial adjacent change).

## Tests
Real `azblob`-SDK / wire-harness reproductions:
- `TestSDKLeasedWritePreservesLease` — authorized write keeps the lease active (Renew still works; a later no-lease write is still rejected `LeaseIdMissing`).
- `TestSDKReadOnlySASCannotDeleteOrOverwrite` — `sp=r` reads but is 403'd on DELETE/PUT; blob untouched.
- `TestSDKExpiredSASRejected` — expired `se` → 403 AuthenticationFailed.
- `TestSDKReadWriteSASAllowsDelete` — `sp=rd` DELETE succeeds (positive grant).

## Gates
build · vet · scoped tests · `-race` (provider) · gofmt · golangci-lint (changed pkgs, zero new issues).