### PR TITLE
fix(cosmosdb): per-account isolation, resolvable documentEndpoint, indexingPolicy round-trip

### DIFF
--- a/server/azure/cosmos_blob_dispatch_test.go
+++ b/server/azure/cosmos_blob_dispatch_test.go
@@ -1,0 +1,280 @@
+// Regression tests for the Cosmos-vs-Blob dispatch boundary on the shared
+// standalone listener, where NewFromProvider mounts the Cosmos SQL data plane
+// AND the permissive BlobStorage fallback on one server.
+//
+// The Cosmos data plane peels an optional leading /{account} path segment, but
+// it must peel ONLY when that segment names a registered databaseAccount.
+// Otherwise a blob path whose first segment happens to be a virtual-directory
+// prefix like "dbs/" or "offers/" would be stolen by Cosmos (routed to a
+// data-plane collection that answers PUT with 405) instead of served by Blob.
+// These tests drive the fully-assembled server and prove Blob keeps those paths
+// while real Cosmos accounts stay reachable and isolated.
+package azure_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// dispatchKey is a dummy base64 master key; the data-plane handler ignores auth.
+const dispatchKey = "dGVzdC1rZXk=" // base64("test-key")
+
+// sharedStack is the fully-assembled Azure server (blob + cosmos data plane +
+// cosmos ARM control plane, all coexisting on one TLS listener), with an
+// armcosmos client bound to it.
+type sharedStack struct {
+	arm *armcosmos.DatabaseAccountsClient
+	ts  *httptest.Server
+}
+
+func newSharedStack(t *testing.T) *sharedStack {
+	t.Helper()
+
+	srv := azureserver.NewFromProvider(cloudemu.NewAzure())
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+
+	armc, err := armcosmos.NewDatabaseAccountsClient("sub-1", fakeCred{}, &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewDatabaseAccountsClient: %v", err)
+	}
+
+	return &sharedStack{arm: armc, ts: ts}
+}
+
+// createAccountEndpoint provisions an account via ARM and returns the
+// documentEndpoint the control plane hands back.
+func (s *sharedStack) createAccountEndpoint(t *testing.T, rg, name string) string {
+	t.Helper()
+
+	poller, err := s.arm.BeginCreateOrUpdate(context.Background(), rg, name, armcosmos.DatabaseAccountCreateUpdateParameters{
+		Location: to.Ptr("eastus"),
+		Kind:     to.Ptr(armcosmos.DatabaseAccountKindGlobalDocumentDB),
+		Properties: &armcosmos.DatabaseAccountCreateUpdateProperties{
+			DatabaseAccountOfferType: to.Ptr("Standard"),
+			Locations: []*armcosmos.Location{
+				{LocationName: to.Ptr("eastus"), FailoverPriority: to.Ptr[int32](0)},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate(%s): %v", name, err)
+	}
+
+	created, err := poller.PollUntilDone(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("PollUntilDone(%s): %v", name, err)
+	}
+
+	if created.Properties == nil || created.Properties.DocumentEndpoint == nil {
+		t.Fatalf("account %s: missing documentEndpoint", name)
+	}
+
+	return *created.Properties.DocumentEndpoint
+}
+
+// dataClient builds an azcosmos client from an ARM-returned endpoint, over the
+// emulator's TLS transport.
+func (s *sharedStack) dataClient(t *testing.T, endpoint string) *azcosmos.Client {
+	t.Helper()
+
+	cred, err := azcosmos.NewKeyCredential(dispatchKey)
+	if err != nil {
+		t.Fatalf("NewKeyCredential: %v", err)
+	}
+
+	client, err := azcosmos.NewClientWithKey(endpoint, cred, &azcosmos.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: s.ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewClientWithKey: %v", err)
+	}
+
+	return client
+}
+
+// TestCosmosDoesNotStealBlobPaths proves that with blob and cosmos coexisting
+// and NO account named after the leading segment, a blob path whose first
+// segment is a "dbs"/"offers" virtual-directory prefix is served by the Blob
+// handler — not stolen by the Cosmos data plane (which would answer PUT with a
+// 405). The Blob handler stamps X-Ms-Version on every response; the Cosmos
+// handler never does, so that header proves Blob served the request.
+func TestCosmosDoesNotStealBlobPaths(t *testing.T) {
+	stack := newSharedStack(t)
+
+	for _, path := range []string{"/mycontainer/dbs", "/mycontainer/offers"} {
+		t.Run(path, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, stack.ts.URL+path, http.NoBody)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+
+			resp, err := stack.ts.Client().Do(req)
+			if err != nil {
+				t.Fatalf("PUT %s: %v", path, err)
+			}
+
+			defer resp.Body.Close()
+
+			_, _ = io.Copy(io.Discard, resp.Body)
+
+			if resp.Header.Get("X-Ms-Version") == "" {
+				t.Errorf("PUT %s: no X-Ms-Version header — the Cosmos data plane stole this blob path "+
+					"instead of letting the Blob fallback serve it (status %d)", path, resp.StatusCode)
+			}
+
+			if resp.StatusCode == http.StatusMethodNotAllowed {
+				t.Errorf("PUT %s: got 405 — routed to the Cosmos data plane, not Blob", path)
+			}
+		})
+	}
+}
+
+// TestCosmosAccountCRUDStillIsolated proves the fix did not regress the real
+// per-account flow on the shared listener: an ARM-created account's endpoint
+// resolves back to the emulator, its CRUD works, and a second account cannot see
+// the first account's data.
+func TestCosmosAccountCRUDStillIsolated(t *testing.T) {
+	ctx := context.Background()
+	stack := newSharedStack(t)
+
+	endpointA := stack.createAccountEndpoint(t, "rg-a", "acct-a")
+	endpointB := stack.createAccountEndpoint(t, "rg-b", "acct-b")
+
+	if endpointA == endpointB {
+		t.Fatalf("accounts must get distinct endpoints, both %q", endpointA)
+	}
+
+	clientA := stack.dataClient(t, endpointA)
+	clientB := stack.dataClient(t, endpointB)
+
+	usersA := makeAccountContainer(ctx, t, clientA)
+
+	docA, _ := json.Marshal(map[string]any{"id": "u1", "pk": "team-a", "who": "account-a"})
+	if _, err := usersA.CreateItem(ctx, azcosmos.NewPartitionKeyString("team-a"), docA, nil); err != nil {
+		t.Fatalf("account A CreateItem: %v", err)
+	}
+
+	readA, err := usersA.ReadItem(ctx, azcosmos.NewPartitionKeyString("team-a"), "u1", nil)
+	if err != nil {
+		t.Fatalf("account A ReadItem (endpoint must resolve back to the emulator): %v", err)
+	}
+
+	var gotA map[string]any
+	if err := json.Unmarshal(readA.Value, &gotA); err != nil {
+		t.Fatalf("unmarshal A: %v", err)
+	}
+
+	if gotA["who"] != "account-a" {
+		t.Errorf("account A doc who=%v want account-a", gotA["who"])
+	}
+
+	// Account B sees none of account A's appdb/users.
+	dbB, err := clientB.NewDatabase("appdb")
+	if err != nil {
+		t.Fatalf("account B NewDatabase: %v", err)
+	}
+
+	usersB, err := dbB.NewContainer("users")
+	if err != nil {
+		t.Fatalf("account B NewContainer: %v", err)
+	}
+
+	if _, err := usersB.ReadItem(ctx, azcosmos.NewPartitionKeyString("team-a"), "u1", nil); err == nil {
+		t.Errorf("account B read account A's item: want error, got nil (accounts not isolated)")
+	}
+}
+
+// TestCosmosAccountNamedDbsReachable is the bonus case: an account named
+// literally "dbs" (a valid Cosmos account name) is reachable through its
+// ARM-returned endpoint, because splitAccount peels the leading segment when it
+// names a registered account even if that name collides with the "dbs"
+// data-plane keyword.
+func TestCosmosAccountNamedDbsReachable(t *testing.T) {
+	ctx := context.Background()
+	stack := newSharedStack(t)
+
+	endpoint := stack.createAccountEndpoint(t, "rg-dbs", "dbs")
+	client := stack.dataClient(t, endpoint)
+
+	users := makeAccountContainer(ctx, t, client)
+
+	doc, _ := json.Marshal(map[string]any{"id": "u1", "pk": "team-a", "who": "in-dbs-account"})
+	if _, err := users.CreateItem(ctx, azcosmos.NewPartitionKeyString("team-a"), doc, nil); err != nil {
+		t.Fatalf(`account "dbs" CreateItem: %v`, err)
+	}
+
+	read, err := users.ReadItem(ctx, azcosmos.NewPartitionKeyString("team-a"), "u1", nil)
+	if err != nil {
+		t.Fatalf(`account "dbs" ReadItem: %v`, err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(read.Value, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got["who"] != "in-dbs-account" {
+		t.Errorf(`account "dbs" doc who=%v want in-dbs-account`, got["who"])
+	}
+}
+
+// makeAccountContainer creates database "appdb" / container "users" (pk "/pk")
+// through client and returns the container client.
+func makeAccountContainer(ctx context.Context, t *testing.T, client *azcosmos.Client) *azcosmos.ContainerClient {
+	t.Helper()
+
+	if _, err := client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: "appdb"}, nil); err != nil {
+		t.Fatalf("CreateDatabase(appdb): %v", err)
+	}
+
+	db, err := client.NewDatabase("appdb")
+	if err != nil {
+		t.Fatalf("NewDatabase(appdb): %v", err)
+	}
+
+	if _, err := db.CreateContainer(ctx, azcosmos.ContainerProperties{
+		ID:                     "users",
+		PartitionKeyDefinition: azcosmos.PartitionKeyDefinition{Paths: []string{"/pk"}},
+	}, nil); err != nil {
+		t.Fatalf("CreateContainer(users): %v", err)
+	}
+
+	cc, err := db.NewContainer("users")
+	if err != nil {
+		t.Fatalf("NewContainer(users): %v", err)
+	}
+
+	return cc
+}

--- a/server/azure/cosmosaccount/account_isolation_test.go
+++ b/server/azure/cosmosaccount/account_isolation_test.go
@@ -1,0 +1,269 @@
+// Real-user end-to-end tests for the ARM control plane wired to the Cosmos SQL
+// data plane: the canonical flow is armcosmos creates an account and returns
+// properties.documentEndpoint, which the azcosmos data-plane client then
+// connects to. These tests drive both live SDKs against one emulator and prove:
+//   - the ARM-returned documentEndpoint resolves back to the emulator (N3), so a
+//     client built purely from it reaches its own account's data;
+//   - two accounts are isolated (N2): a database/container in account A is not
+//     visible from account B, and each holds independent data;
+//   - a container's indexingPolicy round-trips on read (N1).
+package cosmosaccount_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// dataPlaneKey is a dummy base64 master key; the data-plane handler ignores auth.
+const dataPlaneKey = "dGVzdC1rZXk=" // base64("test-key")
+
+// cosmosStack is one emulator serving both the ARM control plane
+// (databaseAccounts) and the Cosmos SQL data plane, with an armcosmos client
+// bound to it. Data-plane clients are built per account from the endpoint ARM
+// returns, over the same TLS test transport.
+type cosmosStack struct {
+	arm *armcosmos.DatabaseAccountsClient
+	ts  *httptest.Server
+}
+
+func newCosmosStack(t *testing.T) *cosmosStack {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{CosmosDB: cloudP.CosmosDB})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	armc, err := armcosmos.NewDatabaseAccountsClient("sub-1", fakeCred{}, opts)
+	require.NoError(t, err)
+
+	return &cosmosStack{arm: armc, ts: ts}
+}
+
+// createAccountEndpoint provisions an account via ARM and returns the
+// documentEndpoint the control plane hands back — exactly what a real user feeds
+// to azcosmos.NewClientWithKey.
+func (s *cosmosStack) createAccountEndpoint(t *testing.T, rg, name string) string {
+	t.Helper()
+
+	poller, err := s.arm.BeginCreateOrUpdate(context.Background(), rg, name, armcosmos.DatabaseAccountCreateUpdateParameters{
+		Location: to.Ptr("eastus"),
+		Kind:     to.Ptr(armcosmos.DatabaseAccountKindGlobalDocumentDB),
+		Properties: &armcosmos.DatabaseAccountCreateUpdateProperties{
+			DatabaseAccountOfferType: to.Ptr("Standard"),
+			Locations: []*armcosmos.Location{
+				{LocationName: to.Ptr("eastus"), FailoverPriority: to.Ptr[int32](0)},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	created, err := poller.PollUntilDone(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, created.Properties)
+	require.NotNil(t, created.Properties.DocumentEndpoint)
+
+	return *created.Properties.DocumentEndpoint
+}
+
+// dataClient builds an azcosmos client from an ARM-returned endpoint, over the
+// emulator's TLS transport.
+func (s *cosmosStack) dataClient(t *testing.T, endpoint string) *azcosmos.Client {
+	t.Helper()
+
+	cred, err := azcosmos.NewKeyCredential(dataPlaneKey)
+	require.NoError(t, err)
+
+	client, err := azcosmos.NewClientWithKey(endpoint, cred, &azcosmos.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: s.ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	})
+	require.NoError(t, err)
+
+	return client
+}
+
+// wantStatus asserts err is an azcore.ResponseError with the given HTTP status.
+func wantStatus(t *testing.T, err error, status int, op string) {
+	t.Helper()
+
+	require.Error(t, err, op)
+
+	var respErr *azcore.ResponseError
+	require.True(t, errors.As(err, &respErr), "%s: want *azcore.ResponseError, got %T: %v", op, err, err)
+	assert.Equal(t, status, respErr.StatusCode, "%s", op)
+}
+
+// makeUsersContainer creates database "appdb" / container "users" (pk /pk)
+// through client and returns the container client.
+func makeUsersContainer(ctx context.Context, t *testing.T, client *azcosmos.Client) *azcosmos.ContainerClient {
+	t.Helper()
+
+	_, err := client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: "appdb"}, nil)
+	require.NoError(t, err)
+
+	db, err := client.NewDatabase("appdb")
+	require.NoError(t, err)
+
+	_, err = db.CreateContainer(ctx, azcosmos.ContainerProperties{
+		ID:                     "users",
+		PartitionKeyDefinition: azcosmos.PartitionKeyDefinition{Paths: []string{"/pk"}},
+	}, nil)
+	require.NoError(t, err)
+
+	cc, err := db.NewContainer("users")
+	require.NoError(t, err)
+
+	return cc
+}
+
+// TestSDKCosmosAccountEndpointResolvesAndIsolates covers N3 (the ARM
+// documentEndpoint resolves back to the emulator) and N2 (two accounts are
+// isolated): the whole flow runs across two accounts built solely from their
+// ARM-returned endpoints.
+func TestSDKCosmosAccountEndpointResolvesAndIsolates(t *testing.T) {
+	ctx := context.Background()
+	stack := newCosmosStack(t)
+
+	endpointA := stack.createAccountEndpoint(t, "rg-a", "acct-a")
+	endpointB := stack.createAccountEndpoint(t, "rg-b", "acct-b")
+	require.NotEqual(t, endpointA, endpointB, "each account must get a distinct endpoint")
+
+	clientA := stack.dataClient(t, endpointA)
+	clientB := stack.dataClient(t, endpointB)
+
+	// N3: a client built purely from account A's ARM endpoint reaches the
+	// emulator and can create and read back its own data.
+	usersA := makeUsersContainer(ctx, t, clientA)
+
+	docA, err := json.Marshal(map[string]any{"id": "u1", "pk": "team-a", "who": "account-a"})
+	require.NoError(t, err)
+	_, err = usersA.CreateItem(ctx, azcosmos.NewPartitionKeyString("team-a"), docA, nil)
+	require.NoError(t, err)
+
+	readA, err := usersA.ReadItem(ctx, azcosmos.NewPartitionKeyString("team-a"), "u1", nil)
+	require.NoError(t, err, "endpoint from ARM must resolve back to the emulator")
+
+	var gotA map[string]any
+	require.NoError(t, json.Unmarshal(readA.Value, &gotA))
+	assert.Equal(t, "account-a", gotA["who"])
+
+	// N2: account B sees NONE of account A's appdb/users — the database and
+	// container are absent in account B's namespace.
+	dbB, err := clientB.NewDatabase("appdb")
+	require.NoError(t, err)
+
+	usersB, err := dbB.NewContainer("users")
+	require.NoError(t, err)
+
+	_, err = usersB.Read(ctx, nil)
+	wantStatus(t, err, 404, "account B reading account A's container")
+
+	_, err = usersB.ReadItem(ctx, azcosmos.NewPartitionKeyString("team-a"), "u1", nil)
+	wantStatus(t, err, 404, "account B reading account A's item")
+
+	// Account B can create its OWN appdb/users with independent contents.
+	_, err = clientB.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: "appdb"}, nil)
+	require.NoError(t, err)
+	_, err = dbB.CreateContainer(ctx, azcosmos.ContainerProperties{
+		ID:                     "users",
+		PartitionKeyDefinition: azcosmos.PartitionKeyDefinition{Paths: []string{"/pk"}},
+	}, nil)
+	require.NoError(t, err)
+
+	docB, err := json.Marshal(map[string]any{"id": "u1", "pk": "team-a", "who": "account-b"})
+	require.NoError(t, err)
+	_, err = usersB.CreateItem(ctx, azcosmos.NewPartitionKeyString("team-a"), docB, nil)
+	require.NoError(t, err)
+
+	readB, err := usersB.ReadItem(ctx, azcosmos.NewPartitionKeyString("team-a"), "u1", nil)
+	require.NoError(t, err)
+
+	var gotB map[string]any
+	require.NoError(t, json.Unmarshal(readB.Value, &gotB))
+	assert.Equal(t, "account-b", gotB["who"], "account B's item is independent of account A's")
+
+	// Account A's item is untouched by account B's identically keyed write.
+	readA2, err := usersA.ReadItem(ctx, azcosmos.NewPartitionKeyString("team-a"), "u1", nil)
+	require.NoError(t, err)
+
+	var gotA2 map[string]any
+	require.NoError(t, json.Unmarshal(readA2.Value, &gotA2))
+	assert.Equal(t, "account-a", gotA2["who"], "account A's data must survive account B's write")
+}
+
+// TestSDKCosmosIndexingPolicyRoundTrip covers N1: a container's indexingPolicy
+// (mode + included/excluded paths) is returned intact on a container read.
+func TestSDKCosmosIndexingPolicyRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	stack := newCosmosStack(t)
+
+	endpoint := stack.createAccountEndpoint(t, "rg-1", "idx-acct")
+	client := stack.dataClient(t, endpoint)
+
+	_, err := client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: "db"}, nil)
+	require.NoError(t, err)
+
+	db, err := client.NewDatabase("db")
+	require.NoError(t, err)
+
+	_, err = db.CreateContainer(ctx, azcosmos.ContainerProperties{
+		ID:                     "c1",
+		PartitionKeyDefinition: azcosmos.PartitionKeyDefinition{Paths: []string{"/pk"}},
+		IndexingPolicy: &azcosmos.IndexingPolicy{
+			Automatic:     true,
+			IndexingMode:  azcosmos.IndexingModeConsistent,
+			IncludedPaths: []azcosmos.IncludedPath{{Path: "/*"}},
+			ExcludedPaths: []azcosmos.ExcludedPath{{Path: "/secret/?"}},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	cc, err := db.NewContainer("c1")
+	require.NoError(t, err)
+
+	resp, err := cc.Read(ctx, nil)
+	require.NoError(t, err)
+
+	ip := resp.ContainerProperties.IndexingPolicy
+	require.NotNil(t, ip, "indexingPolicy must round-trip on a container read")
+	assert.Equal(t, azcosmos.IndexingModeConsistent, ip.IndexingMode)
+	require.Len(t, ip.IncludedPaths, 1)
+	assert.Equal(t, "/*", ip.IncludedPaths[0].Path)
+	require.Len(t, ip.ExcludedPaths, 1)
+	assert.Equal(t, "/secret/?", ip.ExcludedPaths[0].Path)
+}

--- a/server/azure/cosmosaccount/handler.go
+++ b/server/azure/cosmosaccount/handler.go
@@ -135,7 +135,7 @@ func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, rp *azurea
 	case "readonlykeys":
 		azurearm.WriteJSON(w, http.StatusOK, readOnlyKeysResult(rp.ResourceName))
 	case "listconnectionstrings":
-		azurearm.WriteJSON(w, http.StatusOK, connectionStringsResult(rp.ResourceName))
+		azurearm.WriteJSON(w, http.StatusOK, connectionStringsResult(requestBaseURL(r), rp.ResourceName))
 	case "regeneratekey":
 		var body armRegenerateKey
 		if !azurearm.DecodeJSON(w, r, &body) {
@@ -150,6 +150,19 @@ func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, rp *azurea
 	default:
 		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unsupported action: "+rp.SubResource)
 	}
+}
+
+// requestBaseURL reconstructs the scheme://host the client reached this handler
+// on, so the account's documentEndpoint (and per-region and connection-string
+// endpoints) point back at the live emulator rather than a public-DNS
+// *.documents.azure.com host that never resolves to it.
+func requestBaseURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	return scheme + "://" + r.Host
 }
 
 func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
@@ -191,7 +204,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 		h.attrs.SetTableAttributes(name, attrs)
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), rp))
+	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), requestBaseURL(r), rp))
 }
 
 func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
@@ -200,7 +213,7 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp *azurearm.Resou
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), rp))
+	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), requestBaseURL(r), rp))
 }
 
 // list serves the collection paths: GET .../databaseAccounts (subscription) and
@@ -229,7 +242,7 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp *azurearm.Reso
 			continue
 		}
 
-		out.Value = append(out.Value, renderAccount(rp.Subscription, name, attrs))
+		out.Value = append(out.Value, renderAccount(rp.Subscription, requestBaseURL(r), name, attrs))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, out)
@@ -247,7 +260,7 @@ func (h *Handler) deleteAccount(w http.ResponseWriter, r *http.Request, rp *azur
 // toARMAccount renders the ARM databaseAccounts wire shape, reading the stored
 // attributes (kind / offer type / free tier / capabilities / location / tags)
 // back through the driver.
-func (h *Handler) toARMAccount(ctx context.Context, rp *azurearm.ResourcePath) armAccount {
+func (h *Handler) toARMAccount(ctx context.Context, base string, rp *azurearm.ResourcePath) armAccount {
 	attrs := dbdriver.AccountAttributes{Kind: "GlobalDocumentDB", OfferType: "Standard"}
 	if h.attrs != nil {
 		if a, err := h.attrs.TableAttributes(ctx, rp.ResourceName); err == nil {
@@ -261,14 +274,15 @@ func (h *Handler) toARMAccount(ctx context.Context, rp *azurearm.ResourcePath) a
 		attrs.ResourceGroup = rp.ResourceGroup
 	}
 
-	return renderAccount(rp.Subscription, rp.ResourceName, attrs)
+	return renderAccount(rp.Subscription, base, rp.ResourceName, attrs)
 }
 
 // renderAccount builds the ARM account body from stored attributes. Used by
-// get/create (path-derived subscription) and by list.
+// get/create (path-derived subscription) and by list. base is the emulator's
+// scheme://host, so every endpoint it emits resolves back to the emulator.
 //
 //nolint:gocritic // attrs mirrors the driver value type.
-func renderAccount(subscription, name string, attrs dbdriver.AccountAttributes) armAccount {
+func renderAccount(subscription, base, name string, attrs dbdriver.AccountAttributes) armAccount {
 	location := attrs.Location
 	if location == "" {
 		location = defaultLocation
@@ -281,8 +295,8 @@ func renderAccount(subscription, name string, attrs dbdriver.AccountAttributes) 
 		locations = []dbdriver.AccountLocation{{Name: location, FailoverPriority: 0}}
 	}
 
-	all := toArmLocations(name, locations)
-	writeLocs := writeLocations(name, locations, attrs.EnableMultipleWriteLocations)
+	all := toArmLocations(base, name, locations)
+	writeLocs := writeLocations(base, name, locations, attrs.EnableMultipleWriteLocations)
 
 	return armAccount{
 		ID:       azurearm.BuildResourceID(subscription, attrs.ResourceGroup, providerName, resourceType, name),
@@ -296,7 +310,7 @@ func renderAccount(subscription, name string, attrs dbdriver.AccountAttributes) 
 			EnableFreeTier:           attrs.EnableFreeTier,
 			Capabilities:             toCapabilities(attrs.Capabilities),
 			ProvisioningState:        "Succeeded",
-			DocumentEndpoint:         documentEndpoint(name),
+			DocumentEndpoint:         documentEndpoint(base, name),
 			Locations:                all,
 			ReadLocations:            all,
 			WriteLocations:           writeLocs,
@@ -344,8 +358,11 @@ func sortedLocations(locs []dbdriver.AccountLocation) []dbdriver.AccountLocation
 
 // toArmLocations renders every declared region as an armLocation entry,
 // ordered by failover priority — the shape shared by properties.locations
-// and properties.readLocations (every region is readable).
-func toArmLocations(name string, locs []dbdriver.AccountLocation) []armLocation {
+// and properties.readLocations (every region is readable). Every region's
+// endpoint points at the same emulator host (which serves all regions), so the
+// per-region DocumentEndpoint resolves rather than pointing at a public-DNS
+// *.documents.azure.com host.
+func toArmLocations(base, name string, locs []dbdriver.AccountLocation) []armLocation {
 	sorted := sortedLocations(locs)
 	out := make([]armLocation, 0, len(sorted))
 
@@ -353,7 +370,7 @@ func toArmLocations(name string, locs []dbdriver.AccountLocation) []armLocation 
 		out = append(out, armLocation{
 			ID:                name + "-" + l.Name,
 			LocationName:      l.Name,
-			DocumentEndpoint:  "https://" + name + "-" + l.Name + ".documents.azure.com:443/",
+			DocumentEndpoint:  documentEndpoint(base, name),
 			ProvisioningState: "Succeeded",
 			FailoverPriority:  l.FailoverPriority,
 			IsZoneRedundant:   l.IsZoneRedundant,
@@ -365,9 +382,9 @@ func toArmLocations(name string, locs []dbdriver.AccountLocation) []armLocation 
 
 // writeLocations returns the regions that accept writes: every region when
 // multi-write is enabled, otherwise only the single failoverPriority-0 region.
-func writeLocations(name string, locs []dbdriver.AccountLocation, multiWrite bool) []armLocation {
+func writeLocations(base, name string, locs []dbdriver.AccountLocation, multiWrite bool) []armLocation {
 	if multiWrite {
-		return toArmLocations(name, locs)
+		return toArmLocations(base, name, locs)
 	}
 
 	sorted := sortedLocations(locs)
@@ -375,7 +392,7 @@ func writeLocations(name string, locs []dbdriver.AccountLocation, multiWrite boo
 		return nil
 	}
 
-	return toArmLocations(name, sorted[:1])
+	return toArmLocations(base, name, sorted[:1])
 }
 
 // toFailoverPolicies renders properties.failoverPolicies: every region,
@@ -477,9 +494,14 @@ func accountRegion(props *armAccountCreateProps) string {
 	return ""
 }
 
-// documentEndpoint is the account's global connection endpoint.
-func documentEndpoint(name string) string {
-	return "https://" + name + ".documents.azure.com:443/"
+// documentEndpoint is the account's global connection endpoint. It is derived
+// from the emulator's base URL (scheme://host) with the account name as a path
+// segment, so a client that connects to the returned endpoint reaches the
+// emulator and the data plane resolves the account from that /{account} prefix
+// (see the cosmosdb data-plane splitAccount). Real Azure returns
+// https://{name}.documents.azure.com:443/, which never resolves to the emulator.
+func documentEndpoint(base, name string) string {
+	return base + "/" + name + "/"
 }
 
 func capabilityNames(caps []armCapability) []string {

--- a/server/azure/cosmosaccount/keys.go
+++ b/server/azure/cosmosaccount/keys.go
@@ -42,11 +42,13 @@ func readOnlyKeysResult(name string) armReadOnlyKeysResult {
 }
 
 // connectionStringsResult builds the four SQL-API connection strings, one per
-// key kind, matching the DatabaseAccountListConnectionStringsResult shape.
-func connectionStringsResult(name string) armConnectionStringsResult {
+// key kind, matching the DatabaseAccountListConnectionStringsResult shape. base
+// is the emulator's scheme://host, so the embedded AccountEndpoint resolves back
+// to the emulator (see documentEndpoint).
+func connectionStringsResult(base, name string) armConnectionStringsResult {
 	entry := func(desc, key, kind string) armConnectionString {
 		return armConnectionString{
-			ConnectionString: "AccountEndpoint=" + documentEndpoint(name) + ";AccountKey=" + key + ";",
+			ConnectionString: "AccountEndpoint=" + documentEndpoint(base, name) + ";AccountKey=" + key + ";",
 			Description:      desc,
 			KeyKind:          kind,
 			Type:             "Sql",

--- a/server/azure/cosmosaccount/sdk_test.go
+++ b/server/azure/cosmosaccount/sdk_test.go
@@ -33,6 +33,17 @@ func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcor
 func newDatabaseAccountsClient(t *testing.T) *armcosmos.DatabaseAccountsClient {
 	t.Helper()
 
+	client, _ := newDatabaseAccountsClientURL(t)
+
+	return client
+}
+
+// newDatabaseAccountsClientURL is newDatabaseAccountsClient but also returns the
+// emulator's base URL, so endpoint assertions can compare against the live host
+// the handler now derives documentEndpoint from.
+func newDatabaseAccountsClientURL(t *testing.T) (*armcosmos.DatabaseAccountsClient, string) {
+	t.Helper()
+
 	cloudP := cloudemu.NewAzure()
 	srv := azureserver.New(azureserver.Drivers{CosmosDB: cloudP.CosmosDB})
 
@@ -60,7 +71,7 @@ func newDatabaseAccountsClient(t *testing.T) *armcosmos.DatabaseAccountsClient {
 	client, err := armcosmos.NewDatabaseAccountsClient("sub-1", fakeCred{}, opts)
 	require.NoError(t, err)
 
-	return client
+	return client, ts.URL
 }
 
 func TestSDKDatabaseAccountCreateGet(t *testing.T) {
@@ -150,7 +161,7 @@ func createAccount(t *testing.T, client *armcosmos.DatabaseAccountsClient, rg, n
 // location arrays a real account exposes.
 func TestSDKDatabaseAccountGetEndpointAndTags(t *testing.T) {
 	ctx := context.Background()
-	client := newDatabaseAccountsClient(t)
+	client, baseURL := newDatabaseAccountsClientURL(t)
 	createAccount(t, client, "rg-1", "cosmos-ep", "westeurope")
 
 	got, err := client.Get(ctx, "rg-1", "cosmos-ep", nil)
@@ -164,7 +175,9 @@ func TestSDKDatabaseAccountGetEndpointAndTags(t *testing.T) {
 
 	require.NotNil(t, got.Properties)
 	require.NotNil(t, got.Properties.DocumentEndpoint)
-	assert.Equal(t, "https://cosmos-ep.documents.azure.com:443/", *got.Properties.DocumentEndpoint)
+	// The endpoint now resolves back to the emulator (host-derived) and carries
+	// the account as a path segment, so a client using it reaches this account.
+	assert.Equal(t, baseURL+"/cosmos-ep/", *got.Properties.DocumentEndpoint)
 
 	require.Len(t, got.Properties.WriteLocations, 1)
 	require.NotNil(t, got.Properties.WriteLocations[0].LocationName)
@@ -202,7 +215,7 @@ func TestSDKDatabaseAccountListKeys(t *testing.T) {
 // TestSDKDatabaseAccountListConnectionStrings drives ListConnectionStrings.
 func TestSDKDatabaseAccountListConnectionStrings(t *testing.T) {
 	ctx := context.Background()
-	client := newDatabaseAccountsClient(t)
+	client, baseURL := newDatabaseAccountsClientURL(t)
 	createAccount(t, client, "rg-1", "cosmos-conn", "eastus")
 
 	res, err := client.ListConnectionStrings(ctx, "rg-1", "cosmos-conn", nil)
@@ -211,7 +224,7 @@ func TestSDKDatabaseAccountListConnectionStrings(t *testing.T) {
 	require.NotEmpty(t, res.ConnectionStrings)
 	first := res.ConnectionStrings[0]
 	require.NotNil(t, first.ConnectionString)
-	assert.Contains(t, *first.ConnectionString, "AccountEndpoint=https://cosmos-conn.documents.azure.com:443/")
+	assert.Contains(t, *first.ConnectionString, "AccountEndpoint="+baseURL+"/cosmos-conn/")
 	require.NotNil(t, first.KeyKind)
 	assert.Equal(t, armcosmos.KindPrimary, *first.KeyKind)
 	require.NotNil(t, first.Type)

--- a/server/azure/cosmosdb/container_attrs.go
+++ b/server/azure/cosmosdb/container_attrs.go
@@ -20,6 +20,10 @@ type containerAttrs struct {
 	// are then inert, matching real Cosmos.
 	defaultTTL *int32
 	uniqueKeys []uniqueKeyDef
+	// indexingPolicy is ContainerProperties.IndexingPolicy, kept verbatim so it
+	// round-trips on a container read/list (the generic driver has no indexing
+	// concept, same as TTL and unique keys). nil when none was declared.
+	indexingPolicy map[string]any
 }
 
 // attrsStore tracks containerAttrs plus the per-item TTL bookkeeping needed to
@@ -39,14 +43,14 @@ func newAttrsStore() *attrsStore {
 	return &attrsStore{attrs: make(map[string]containerAttrs), expiry: make(map[string]time.Time)}
 }
 
-func (s *attrsStore) set(table string, ttl *int32, uk *uniqueKeyPolicy) {
+func (s *attrsStore) set(table string, ttl *int32, uk *uniqueKeyPolicy, indexing map[string]any) {
 	var keys []uniqueKeyDef
 	if uk != nil {
 		keys = uk.UniqueKeys
 	}
 
 	s.mu.Lock()
-	s.attrs[table] = containerAttrs{defaultTTL: ttl, uniqueKeys: keys}
+	s.attrs[table] = containerAttrs{defaultTTL: ttl, uniqueKeys: keys, indexingPolicy: indexing}
 	s.mu.Unlock()
 }
 

--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -138,7 +138,15 @@ func (h *Handler) databaseExists(account, db string) bool {
 // account, keeping single-account and official-emulator usage working. The
 // returned rest is the remaining path with the account segment removed ("/" for
 // a bare account probe).
-func splitAccount(p string) (account, rest string) {
+//
+// The leading segment is peeled as an account ONLY when it names a Cosmos
+// databaseAccount actually registered through the shared ARM control plane
+// (isAccount). Any other first segment — "dbs"/"offers" of the default account,
+// or a blob container/virtual-directory prefix when blob and cosmos share one
+// listener — is left unpeeled so Matches declines it and the request falls
+// through to the blob handler. This keeps an account literally named "dbs" or
+// "offers" reachable while never stealing a blob path.
+func (h *Handler) splitAccount(p string) (account, rest string) {
 	trimmed := strings.Trim(p, "/")
 	if trimmed == "" {
 		return "", "/"
@@ -149,9 +157,7 @@ func splitAccount(p string) (account, rest string) {
 		first = trimmed[:i]
 	}
 
-	// A leading "dbs" or "offers" is a data-plane resource of the default
-	// account, not an account name.
-	if first == "dbs" || first == "offers" {
+	if !h.isAccount(first) {
 		return "", p
 	}
 
@@ -163,11 +169,41 @@ func splitAccount(p string) (account, rest string) {
 	return first, rest
 }
 
+// accountLister is the optional capability the shared database driver exposes to
+// enumerate the Cosmos databaseAccounts registered through the ARM control
+// plane (providers/azure/cosmosdb implements it; DynamoDB/Firestore don't).
+type accountLister interface {
+	AccountTables() []string
+}
+
+// isAccount reports whether name is a registered Cosmos databaseAccount. The
+// data-plane handler shares the very driver the account control plane writes to,
+// so it can distinguish a real account prefix from an unrelated leading segment
+// (a blob container, a default-account "dbs"/"offers") and only peel the former.
+func (h *Handler) isAccount(name string) bool {
+	if name == "" {
+		return false
+	}
+
+	lister, ok := h.db.(accountLister)
+	if !ok {
+		return false
+	}
+
+	for _, a := range lister.AccountTables() {
+		if a == name {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Matches returns true for the Cosmos data plane URLs we serve: the account
 // root probe (GET / or GET /{account}), the /dbs/... resource tree, and the
 // /offers throughput resource — each optionally under a /{account} prefix.
-func (*Handler) Matches(r *http.Request) bool {
-	account, rest := splitAccount(r.URL.Path)
+func (h *Handler) Matches(r *http.Request) bool {
+	account, rest := h.splitAccount(r.URL.Path)
 
 	// A bare "/{account}" carrying a query string is more likely a blob
 	// container/root operation than a Cosmos account probe (which carries none),
@@ -183,7 +219,7 @@ func (*Handler) Matches(r *http.Request) bool {
 // ServeHTTP routes the request based on URL path shape, after peeling off the
 // optional /{account} prefix that scopes the data plane to one account.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	account, rest := splitAccount(r.URL.Path)
+	account, rest := h.splitAccount(r.URL.Path)
 
 	if rest == "/" {
 		h.accountProperties(w, r)

--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -57,11 +57,12 @@ type Handler struct {
 	offerMu sync.RWMutex
 	offers  map[string]offerState
 
-	// databases tracks the Cosmos databases that exist. The generic driver has a
-	// flat table namespace with no database grouping, so the wire handler models
-	// the database layer: it records which databases were created and qualifies
-	// every container's driver-table name by its database (see qualify), giving
-	// each database an isolated container namespace.
+	// databases tracks the Cosmos databases that exist, keyed by their
+	// account-qualified identity (see dbNS). The generic driver has a flat table
+	// namespace with no account or database grouping, so the wire handler models
+	// both layers: it records which databases were created and qualifies every
+	// container's driver-table name by its account and database (see qualify),
+	// giving each account an isolated database/container namespace.
 	dbMu      sync.RWMutex
 	databases map[string]struct{}
 
@@ -87,66 +88,134 @@ func New(db dbdriver.Database) *Handler {
 	}
 }
 
-// qualify maps a (database, container) pair onto the flat driver table name that
-// backs it. Cosmos container ids cannot contain '/', so "{db}/{coll}" is an
-// unambiguous, collision-free key: a container in one database is unreachable
-// through another, and deleting a database can find its containers by prefix.
-func qualify(db, coll string) string {
-	return db + "/" + coll
+// nsPrefix returns the driver-table namespace prefix for an account. The
+// default account (empty name — the legacy single-account and official-emulator
+// "https://host:port/" usage) has no prefix, so its tables keep the historical
+// "{db}/{coll}" names; a named account (addressed via the
+// {account}.documents.azure.com host, modeled here as a leading /{account} path
+// segment) prefixes every table with "{account}/", giving each ARM-created
+// account an isolated namespace.
+func nsPrefix(account string) string {
+	if account == "" {
+		return ""
+	}
+
+	return account + "/"
 }
 
-// databaseExists reports whether database db has been created.
-func (h *Handler) databaseExists(db string) bool {
+// qualify maps an (account, database, container) triple onto the flat driver
+// table name that backs it. Account names and Cosmos ids cannot contain '/', so
+// "{account}/{db}/{coll}" is an unambiguous, collision-free key: a container is
+// reachable only through its own account and database, and an account's or
+// database's tables can be found by prefix.
+func qualify(account, db, coll string) string {
+	return nsPrefix(account) + db + "/" + coll
+}
+
+// dbNS is the account-qualified database identity: the databases-set key, the
+// database's shared-throughput offer key, and the prefix under which
+// deleteDatabase reaps the database's container tables.
+func dbNS(account, db string) string {
+	return nsPrefix(account) + db
+}
+
+// databaseExists reports whether database db has been created in account.
+func (h *Handler) databaseExists(account, db string) bool {
 	h.dbMu.RLock()
-	_, ok := h.databases[db]
+	_, ok := h.databases[dbNS(account, db)]
 	h.dbMu.RUnlock()
 
 	return ok
 }
 
-// Matches returns true for the Cosmos data plane URLs we serve: the account
-// root probe (GET /), the /dbs/... resource tree, and the /offers throughput
-// resource.
-func (*Handler) Matches(r *http.Request) bool {
-	p := r.URL.Path
+// splitAccount separates an optional leading /{account} segment from the Cosmos
+// resource path. The real azcosmos SDK derives the account from the
+// {account}.documents.azure.com host; the emulator collapses every account onto
+// one listener, so the ARM control plane hands clients a documentEndpoint whose
+// path carries the account ("https://host/{account}/"), and the SDK preserves
+// that prefix on every data-plane request (on failover it swaps only the Host).
+// A request with no such prefix ("/dbs/...", "/offers", "/") targets the default
+// account, keeping single-account and official-emulator usage working. The
+// returned rest is the remaining path with the account segment removed ("/" for
+// a bare account probe).
+func splitAccount(p string) (account, rest string) {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return "", "/"
+	}
 
-	return p == "/" || p == "/dbs" || strings.HasPrefix(p, "/dbs/") ||
-		p == offersPath || strings.HasPrefix(p, offersPathPrefix)
+	first := trimmed
+	if i := strings.IndexByte(trimmed, '/'); i >= 0 {
+		first = trimmed[:i]
+	}
+
+	// A leading "dbs" or "offers" is a data-plane resource of the default
+	// account, not an account name.
+	if first == "dbs" || first == "offers" {
+		return "", p
+	}
+
+	rest = strings.TrimPrefix(p, "/"+first)
+	if rest == "" {
+		rest = "/"
+	}
+
+	return first, rest
 }
 
-// ServeHTTP routes the request based on URL path shape.
+// Matches returns true for the Cosmos data plane URLs we serve: the account
+// root probe (GET / or GET /{account}), the /dbs/... resource tree, and the
+// /offers throughput resource — each optionally under a /{account} prefix.
+func (*Handler) Matches(r *http.Request) bool {
+	account, rest := splitAccount(r.URL.Path)
+
+	// A bare "/{account}" carrying a query string is more likely a blob
+	// container/root operation than a Cosmos account probe (which carries none),
+	// so decline it and let the blob handler, registered after this one, serve it.
+	if account != "" && rest == "/" && r.URL.RawQuery != "" {
+		return false
+	}
+
+	return rest == "/" || rest == "/dbs" || strings.HasPrefix(rest, "/dbs/") ||
+		rest == offersPath || strings.HasPrefix(rest, offersPathPrefix)
+}
+
+// ServeHTTP routes the request based on URL path shape, after peeling off the
+// optional /{account} prefix that scopes the data plane to one account.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path == "/" {
+	account, rest := splitAccount(r.URL.Path)
+
+	if rest == "/" {
 		h.accountProperties(w, r)
 		return
 	}
 
-	if r.URL.Path == offersPath || strings.HasPrefix(r.URL.Path, offersPathPrefix) {
-		h.serveOffers(w, r)
+	if rest == offersPath || strings.HasPrefix(rest, offersPathPrefix) {
+		h.serveOffers(w, r, rest)
 		return
 	}
 
-	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	parts := strings.Split(strings.Trim(rest, "/"), "/")
 
 	switch len(parts) {
 	case 1:
 		// /dbs
-		h.databaseCollection(w, r)
+		h.databaseCollection(w, r, account)
 	case pathDBOnly:
 		// /dbs/{db}
-		h.databaseResource(w, r, parts[1])
+		h.databaseResource(w, r, account, parts[1])
 	case pathColls:
 		// /dbs/{db}/colls
-		h.containerCollection(w, r, parts[1])
+		h.containerCollection(w, r, account, parts[1])
 	case pathContainerOrDocsCol:
 		// /dbs/{db}/colls/{coll}
-		h.containerResource(w, r, parts[1], parts[3])
+		h.containerResource(w, r, account, parts[1], parts[3])
 	case pathDocsCol:
 		// /dbs/{db}/colls/{coll}/docs
-		h.documentCollection(w, r, parts[1], parts[3])
+		h.documentCollection(w, r, account, parts[1], parts[3])
 	case pathDocResource:
 		// /dbs/{db}/colls/{coll}/docs/{id}
-		h.documentResource(w, r, parts[1], parts[3], parts[5])
+		h.documentResource(w, r, account, parts[1], parts[3], parts[5])
 	default:
 		writeError(w, http.StatusNotFound, "NotFound", "unsupported Cosmos path")
 	}
@@ -205,7 +274,7 @@ func (*Handler) accountProperties(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, props)
 }
 
-func (h *Handler) databaseCollection(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) databaseCollection(w http.ResponseWriter, r *http.Request, account string) {
 	switch r.Method {
 	case http.MethodPost:
 		// Cosmos overloads POST /dbs: a create (JSON body with an id) or, when the
@@ -213,20 +282,20 @@ func (h *Handler) databaseCollection(w http.ResponseWriter, r *http.Request) {
 		// query body but ignore its predicate — we list all databases.
 		if isQuery(r) {
 			_, _ = decodeQueryBody(w, r)
-			h.writeDatabaseList(w)
+			h.writeDatabaseList(w, account)
 
 			return
 		}
 
-		h.createDatabase(w, r)
+		h.createDatabase(w, r, account)
 	case http.MethodGet:
-		h.writeDatabaseList(w)
+		h.writeDatabaseList(w, account)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
 }
 
-func (h *Handler) createDatabase(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) createDatabase(w http.ResponseWriter, r *http.Request, account string) {
 	var body struct {
 		ID string `json:"id"`
 	}
@@ -240,8 +309,10 @@ func (h *Handler) createDatabase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	key := dbNS(account, body.ID)
+
 	h.dbMu.Lock()
-	if _, exists := h.databases[body.ID]; exists {
+	if _, exists := h.databases[key]; exists {
 		h.dbMu.Unlock()
 		writeError(w, http.StatusConflict, "Conflict",
 			"Database with specified id already exists.")
@@ -249,25 +320,32 @@ func (h *Handler) createDatabase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.databases[body.ID] = struct{}{}
+	h.databases[key] = struct{}{}
 	h.dbMu.Unlock()
 
 	// A database created with ThroughputProperties (shared, database-level
 	// provisioned throughput) gets its own offer, keyed by the same _rid
-	// makeDatabaseResource assigns it — recordOffer's containerRID(id) derives
-	// exactly that "rid-{id}" key, so ReadThroughput round-trips without a
-	// container ever having been created.
-	h.recordOffer(body.ID, r)
+	// makeDatabaseResource assigns it — recordOffer's containerRID(dbNS) derives
+	// exactly that "rid-{account-qualified-db}" key, so ReadThroughput round-trips
+	// without a container ever having been created.
+	h.recordOffer(key, r)
 
-	writeJSON(w, http.StatusCreated, makeDatabaseResource(body.ID))
+	writeJSON(w, http.StatusCreated, makeDatabaseResource(account, body.ID))
 }
 
-func (h *Handler) writeDatabaseList(w http.ResponseWriter) {
+func (h *Handler) writeDatabaseList(w http.ResponseWriter, account string) {
 	h.dbMu.RLock()
 	names := make([]string, 0, len(h.databases))
 
-	for name := range h.databases {
-		names = append(names, name)
+	for key := range h.databases {
+		// Only list databases in this account's namespace. The default account's
+		// keys ("{db}") must not leak into a named account and vice versa.
+		id, ok := accountDBName(key, account)
+		if !ok {
+			continue
+		}
+
+		names = append(names, id)
 	}
 
 	h.dbMu.RUnlock()
@@ -275,34 +353,50 @@ func (h *Handler) writeDatabaseList(w http.ResponseWriter) {
 
 	list := databasesList{RID: "cloudemu", Databases: make([]databaseResource, 0, len(names))}
 	for _, name := range names {
-		list.Databases = append(list.Databases, makeDatabaseResource(name))
+		list.Databases = append(list.Databases, makeDatabaseResource(account, name))
 	}
 
 	list.Count = len(list.Databases)
 	writeJSON(w, http.StatusOK, list)
 }
 
-func (h *Handler) databaseResource(w http.ResponseWriter, r *http.Request, db string) {
+// accountDBName reports whether databases-set key belongs to account and, if so,
+// returns the bare database id. A named account owns keys "{account}/{db}"; the
+// default account owns keys "{db}" that carry no further '/'.
+func accountDBName(key, account string) (string, bool) {
+	if account == "" {
+		if strings.ContainsRune(key, '/') {
+			return "", false
+		}
+
+		return key, true
+	}
+
+	return strings.CutPrefix(key, account+"/")
+}
+
+func (h *Handler) databaseResource(w http.ResponseWriter, r *http.Request, account, db string) {
 	switch r.Method {
 	case http.MethodGet:
-		if !h.databaseExists(db) {
+		if !h.databaseExists(account, db) {
 			writeError(w, http.StatusNotFound, "NotFound", "database not found")
 			return
 		}
 
-		writeJSON(w, http.StatusOK, makeDatabaseResource(db))
+		writeJSON(w, http.StatusOK, makeDatabaseResource(account, db))
 	case http.MethodDelete:
-		h.deleteDatabase(w, r, db)
+		h.deleteDatabase(w, r, account, db)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
 }
 
 // deleteDatabase removes a database and every container inside it. Because the
-// driver namespace is flat and keyed by qualify(db, coll), the database's
-// containers are exactly the tables whose name starts with "{db}/".
-func (h *Handler) deleteDatabase(w http.ResponseWriter, r *http.Request, db string) {
-	if !h.databaseExists(db) {
+// driver namespace is flat and keyed by qualify(account, db, coll), the
+// database's containers are exactly the tables whose name starts with the
+// account-qualified "{ns}/" prefix.
+func (h *Handler) deleteDatabase(w http.ResponseWriter, r *http.Request, account, db string) {
+	if !h.databaseExists(account, db) {
 		writeError(w, http.StatusNotFound, "NotFound", "database not found")
 		return
 	}
@@ -313,7 +407,8 @@ func (h *Handler) deleteDatabase(w http.ResponseWriter, r *http.Request, db stri
 		return
 	}
 
-	prefix := db + "/"
+	ns := dbNS(account, db)
+	prefix := ns + "/"
 
 	for _, t := range tables {
 		if !strings.HasPrefix(t, prefix) {
@@ -329,27 +424,27 @@ func (h *Handler) deleteDatabase(w http.ResponseWriter, r *http.Request, db stri
 		h.attrs.delete(t)
 	}
 
-	h.deleteOffer(db) // the database's own shared-throughput offer, if any
+	h.deleteOffer(ns) // the database's own shared-throughput offer, if any
 	h.dbMu.Lock()
-	delete(h.databases, db)
+	delete(h.databases, ns)
 	h.dbMu.Unlock()
 
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *Handler) containerCollection(w http.ResponseWriter, r *http.Request, db string) {
+func (h *Handler) containerCollection(w http.ResponseWriter, r *http.Request, account, db string) {
 	switch r.Method {
 	case http.MethodPost:
-		h.createContainer(w, r, db)
+		h.createContainer(w, r, account, db)
 	case http.MethodGet:
-		h.listContainers(w, r, db)
+		h.listContainers(w, r, account, db)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
 }
 
-func (h *Handler) createContainer(w http.ResponseWriter, r *http.Request, db string) {
-	if !h.databaseExists(db) {
+func (h *Handler) createContainer(w http.ResponseWriter, r *http.Request, account, db string) {
+	if !h.databaseExists(account, db) {
 		writeError(w, http.StatusNotFound, "NotFound", "database not found")
 		return
 	}
@@ -368,7 +463,7 @@ func (h *Handler) createContainer(w http.ResponseWriter, r *http.Request, db str
 	pkAttr := partitionKeyAttribute(body.PartitionKey)
 
 	cfg := dbdriver.TableConfig{
-		Name:         qualify(db, body.ID),
+		Name:         qualify(account, db, body.ID),
 		PartitionKey: pkAttr,
 	}
 
@@ -385,15 +480,16 @@ func (h *Handler) createContainer(w http.ResponseWriter, r *http.Request, db str
 		return
 	}
 
-	table := qualify(db, body.ID)
+	table := qualify(account, db, body.ID)
 	h.recordOffer(table, r)
-	h.attrs.set(table, body.DefaultTTL, body.UniqueKeyPolicy)
+	h.attrs.set(table, body.DefaultTTL, body.UniqueKeyPolicy, body.IndexingPolicy)
 
-	writeJSON(w, http.StatusCreated, makeContainerResource(db, body.ID, body.PartitionKey, body.DefaultTTL, body.UniqueKeyPolicy))
+	writeJSON(w, http.StatusCreated,
+		makeContainerResource(account, db, body.ID, body.PartitionKey, body.DefaultTTL, body.UniqueKeyPolicy, body.IndexingPolicy))
 }
 
-func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request, db string) {
-	if !h.databaseExists(db) {
+func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request, account, db string) {
+	if !h.databaseExists(account, db) {
 		writeError(w, http.StatusNotFound, "NotFound", "database not found")
 		return
 	}
@@ -405,7 +501,7 @@ func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request, db stri
 	}
 
 	out := containersList{RID: "cloudemu"}
-	prefix := db + "/"
+	prefix := dbNS(account, db) + "/"
 
 	for _, t := range tables {
 		if !strings.HasPrefix(t, prefix) {
@@ -423,7 +519,8 @@ func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request, db stri
 
 		attrs := h.attrs.get(t)
 		out.DocumentCollections = append(out.DocumentCollections,
-			makeContainerResource(db, coll, pk, attrs.defaultTTL, uniqueKeyPolicyFromDef(attrs.uniqueKeys)))
+			makeContainerResource(account, db, coll, pk, attrs.defaultTTL,
+				uniqueKeyPolicyFromDef(attrs.uniqueKeys), attrs.indexingPolicy))
 	}
 
 	out.Count = len(out.DocumentCollections)
@@ -431,8 +528,8 @@ func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request, db stri
 	writeJSON(w, http.StatusOK, out)
 }
 
-func (h *Handler) containerResource(w http.ResponseWriter, r *http.Request, db, coll string) {
-	table := qualify(db, coll)
+func (h *Handler) containerResource(w http.ResponseWriter, r *http.Request, account, db, coll string) {
+	table := qualify(account, db, coll)
 
 	switch r.Method {
 	case http.MethodGet:
@@ -448,7 +545,9 @@ func (h *Handler) containerResource(w http.ResponseWriter, r *http.Request, db, 
 		}
 
 		attrs := h.attrs.get(table)
-		writeJSON(w, http.StatusOK, makeContainerResource(db, coll, pk, attrs.defaultTTL, uniqueKeyPolicyFromDef(attrs.uniqueKeys)))
+		writeJSON(w, http.StatusOK,
+			makeContainerResource(account, db, coll, pk, attrs.defaultTTL,
+				uniqueKeyPolicyFromDef(attrs.uniqueKeys), attrs.indexingPolicy))
 	case http.MethodDelete:
 		if err := h.db.DeleteTable(r.Context(), table); err != nil {
 			writeErr(w, err)
@@ -463,8 +562,8 @@ func (h *Handler) containerResource(w http.ResponseWriter, r *http.Request, db, 
 	}
 }
 
-func (h *Handler) documentCollection(w http.ResponseWriter, r *http.Request, db, coll string) {
-	table := qualify(db, coll)
+func (h *Handler) documentCollection(w http.ResponseWriter, r *http.Request, account, db, coll string) {
+	table := qualify(account, db, coll)
 
 	switch r.Method {
 	case http.MethodPost:
@@ -748,8 +847,8 @@ func (h *Handler) queryDocuments(w http.ResponseWriter, r *http.Request, coll st
 	writeJSON(w, http.StatusOK, documentsList{RID: "cloudemu", Documents: page, Count: len(page)})
 }
 
-func (h *Handler) documentResource(w http.ResponseWriter, r *http.Request, db, coll, id string) {
-	coll = qualify(db, coll)
+func (h *Handler) documentResource(w http.ResponseWriter, r *http.Request, account, db, coll, id string) {
+	coll = qualify(account, db, coll)
 
 	cfg, derr := h.db.DescribeTable(r.Context(), coll)
 	if derr != nil {
@@ -863,8 +962,12 @@ func defaultPartitionKey() *partitionKeyDef {
 	return &partitionKeyDef{Paths: []string{"/id"}, Kind: "Hash"}
 }
 
-func makeDatabaseResource(id string) databaseResource {
-	rid := "rid-" + id
+func makeDatabaseResource(account, id string) databaseResource {
+	// The _rid doubles as the database's offer resource id (see createDatabase /
+	// containerRID). Qualifying by account keeps it unique across accounts so a
+	// shared-throughput offer never collides between two accounts' same-named
+	// databases; the displayed id stays the bare database name.
+	rid := "rid-" + dbNS(account, id)
 
 	return databaseResource{
 		resource: resource{
@@ -880,11 +983,13 @@ func makeDatabaseResource(id string) databaseResource {
 	}
 }
 
-func makeContainerResource(db, id string, pk *partitionKeyDef, defaultTTL *int32, uk *uniqueKeyPolicy) containerResource {
+func makeContainerResource(
+	account, db, id string, pk *partitionKeyDef, defaultTTL *int32, uk *uniqueKeyPolicy, indexing map[string]any,
+) containerResource {
 	// The container's _rid doubles as its offer resource id: the SDK reads _rid
-	// off the container, then queries /offers by it. Qualifying by database keeps
-	// the offer key unique across databases (see recordOffer / qualify).
-	rid := containerRID(qualify(db, id))
+	// off the container, then queries /offers by it. Qualifying by account and
+	// database keeps the offer key unique across both (see recordOffer / qualify).
+	rid := containerRID(qualify(account, db, id))
 
 	if pk == nil {
 		pk = defaultPartitionKey()
@@ -905,6 +1010,7 @@ func makeContainerResource(db, id string, pk *partitionKeyDef, defaultTTL *int32
 		UDFs:            "udfs/",
 		Conflicts:       "conflicts/",
 		PartitionKey:    pk,
+		IndexingPolicy:  indexing,
 		DefaultTTL:      defaultTTL,
 		UniqueKeyPolicy: uk,
 	}

--- a/server/azure/cosmosdb/offers.go
+++ b/server/azure/cosmosdb/offers.go
@@ -68,9 +68,11 @@ func parseOfferHeaders(r *http.Request) (offerState, bool) {
 
 // serveOffers routes the /offers throughput resource: POST /offers is the
 // offer query the SDK fires to locate a container's offer; GET/PUT /offers/{id}
-// read and replace it.
-func (h *Handler) serveOffers(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path == offersPath {
+// read and replace it. path is the request path with any /{account} prefix
+// already peeled off; the offer id itself encodes the account (see
+// containerRID / qualify), so offers need no separate account dimension.
+func (h *Handler) serveOffers(w http.ResponseWriter, r *http.Request, path string) {
+	if path == offersPath {
 		if r.Method != http.MethodPost {
 			writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 			return
@@ -81,7 +83,7 @@ func (h *Handler) serveOffers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rid := strings.TrimPrefix(r.URL.Path, offersPathPrefix)
+	rid := strings.TrimPrefix(path, offersPathPrefix)
 
 	switch r.Method {
 	case http.MethodGet:


### PR DESCRIPTION
## What

Fixes three Cosmos DB correctness findings from the Azure deep audit, all in the wire layer (data-plane account routing + control-plane endpoint derivation). No driver/provider change — the generic database driver already keys tables by opaque name.

### N2 (HIGH, systemic) — no per-account isolation
Two ARM `databaseAccounts` shared one flat database/container namespace, so a client "connected to account B" could read account A's `appdb/users`. The data plane now peels an optional leading `/{account}` path segment (`splitAccount`) and prefixes every driver-table name, databases-set key, and offer key with the account (`qualify`/`dbNS`/`nsPrefix`). Each ARM account gets an isolated namespace.

The default (empty) account keeps the historical `"{db}/{coll}"` table names, so existing single-account and official-emulator (`https://host:port/`) usage — including the driver-level TTL/change-feed tests that address tables by `"db/coll"` — is unchanged.

### N3 (HIGH) — documentEndpoint didn't resolve
ARM returned a synthetic `https://{name}.documents.azure.com:443/` that never routed to the emulator, breaking the canonical create-account-then-connect flow. `documentEndpoint` (plus the per-region endpoints and the connection-string `AccountEndpoint`) is now derived from the request host with the account as a path segment (`https://{host}/{account}/`), so a client built from the returned endpoint reaches its own account. The azcosmos SDK preserves that path prefix on every request and swaps only the host on failover, so isolation holds end-to-end.

### N1 (MED) — indexingPolicy dropped
The data-plane container `indexingPolicy` was decoded off the wire and discarded (nil on read, though TTL + uniqueKeyPolicy round-tripped). It is now tracked in `container_attrs` alongside TTL/unique-keys and round-trips on container read/list.

## Why
Multi-account emulation silently cross-contaminated tenants, and the standard Terraform/armcosmos → `documentEndpoint` → azcosmos flow could not reach the account it just created.

## Tests
Real `armcosmos/v3` + `azcosmos` reproductions:
- `TestSDKCosmosAccountEndpointResolvesAndIsolates` — two accounts built solely from their ARM endpoints; account A's container/item are 404 from account B, each holds independent data, and A survives B's identically-keyed write (covers N2 + N3).
- `TestSDKCosmosIndexingPolicyRoundTrip` — indexingPolicy (mode + included/excluded paths) returns intact on container read (N1).
- Updated the two existing endpoint assertions to the new host-derived form.

## Deferred
- N4 (LOW): `consistencyPolicy` is echoed via the generic overlay but not modeled/enforced. Left as-is to keep this PR cohesive.