### PR TITLE
fix(servicebus): dead-lettering, system properties, TTL and scheduled messages in the data plane

### DIFF
--- a/providers/azure/servicebus/dead_letter_test.go
+++ b/providers/azure/servicebus/dead_letter_test.go
@@ -1,0 +1,103 @@
+package servicebus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeadLetterMissingStorePreservesMessage guards the latent data-loss bug:
+// when a message exceeds maxReceiveCount but its dead-letter store is absent, it
+// must stay on the main queue rather than being silently dropped.
+func TestDeadLetterMissingStorePreservesMessage(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newTestMock()
+
+	mainInfo, err := m.CreateQueue(ctx, driver.QueueConfig{
+		Name: "guarded",
+		DeadLetterQueue: &driver.DeadLetterConfig{
+			TargetQueueURL:  "https://missing.example/nope",
+			MaxReceiveCount: 1,
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: mainInfo.URL, Body: "keep-me"})
+	require.NoError(t, err)
+
+	msgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: mainInfo.URL, MaxMessages: 1, VisibilityTimeout: 1})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	clk.Advance(2 * time.Second)
+
+	// Second receive would exceed maxReceiveCount, but the DLQ store is missing.
+	msgs, err = m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: mainInfo.URL, MaxMessages: 1})
+	require.NoError(t, err)
+	assert.Empty(t, msgs)
+
+	// The message is preserved rather than lost.
+	info, err := m.GetQueueInfo(ctx, mainInfo.URL)
+	require.NoError(t, err)
+	assert.Equal(t, 1, info.ApproxMessageCount)
+}
+
+// TestSendPreservesSystemProperties confirms brokered-message system properties
+// survive a send/receive round-trip through the driver.
+func TestSendPreservesSystemProperties(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	url := createStdQueue(t, m)
+
+	_, err := m.SendMessage(ctx, driver.SendMessageInput{
+		QueueURL:         url,
+		Body:             "b",
+		SystemProperties: map[string]string{"MessageId": "m-9", "Label": "L"},
+	})
+	require.NoError(t, err)
+
+	msgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: url, MaxMessages: 1})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "m-9", msgs[0].SystemProperties["MessageId"])
+	assert.Equal(t, "L", msgs[0].SystemProperties["Label"])
+}
+
+// TestDeadLetterOnExpiration confirms an expired message is routed to the DLQ
+// (not dropped) when deadLetteringOnMessageExpiration is enabled.
+func TestDeadLetterOnExpiration(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newTestMock()
+
+	dlqInfo, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "expiry-dlq"})
+	require.NoError(t, err)
+
+	mainInfo, err := m.CreateQueue(ctx, driver.QueueConfig{
+		Name:                   "expiry-main",
+		DeadLetterQueue:        &driver.DeadLetterConfig{TargetQueueURL: dlqInfo.URL, MaxReceiveCount: 10},
+		DeadLetterOnExpiration: true,
+	})
+	require.NoError(t, err)
+
+	_, err = m.SendMessage(ctx, driver.SendMessageInput{
+		QueueURL: mainInfo.URL, Body: "expiring", MessageTTLSeconds: ttlPtr(5),
+	})
+	require.NoError(t, err)
+
+	clk.Advance(6 * time.Second)
+
+	// The reaping receive on the main queue routes the expired message to the DLQ.
+	msgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: mainInfo.URL, MaxMessages: 1})
+	require.NoError(t, err)
+	assert.Empty(t, msgs)
+
+	dlqMsgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: dlqInfo.URL, MaxMessages: 1})
+	require.NoError(t, err)
+	require.Len(t, dlqMsgs, 1)
+	assert.Equal(t, "expiring", dlqMsgs[0].Body)
+}

--- a/providers/azure/servicebus/servicebus.go
+++ b/providers/azure/servicebus/servicebus.go
@@ -32,10 +32,13 @@ type sbMessage struct {
 	GroupID         string
 	DeduplicationID string
 	Attributes      map[string]string
-	ReceiptHandle   string
-	VisibleAt       time.Time
-	SentAt          time.Time
-	ReceiveCount    int
+	// SystemProps carries Azure Service Bus brokered-message system properties
+	// (MessageId, CorrelationId, Label, SessionId, ...) preserved from the send.
+	SystemProps   map[string]string
+	ReceiptHandle string
+	VisibleAt     time.Time
+	SentAt        time.Time
+	ReceiveCount  int
 	// ExpiresAt is the message's absolute expiration time. The zero value
 	// means the message never expires — the default for Service Bus queues
 	// (which never set SendMessageInput.MessageTTLSeconds) and for Azure
@@ -57,7 +60,10 @@ type queueData struct {
 	lastModifiedAt     time.Time
 	deduplicationIndex map[string]time.Time
 	dlqConfig          *driver.DeadLetterConfig
-	metadata           map[string]string
+	// deadLetterOnExpiration routes an expired message to the dead-letter queue
+	// instead of dropping it (Service Bus deadLetteringOnMessageExpiration).
+	deadLetterOnExpiration bool
+	metadata               map[string]string
 }
 
 // FunctionTrigger is a function that gets called when a message is sent to a queue.
@@ -125,6 +131,8 @@ func (m *Mock) RemoveTrigger(queueURL string) {
 }
 
 // CreateQueue creates a new Service Bus queue.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.QueueInfo, error) {
 	if cfg.Name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "queue name is required")
@@ -163,17 +171,18 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 	now := m.opts.Clock.Now()
 
 	qd := &queueData{
-		info:               info,
-		messages:           make([]*sbMessage, 0),
-		delaySeconds:       cfg.DelaySeconds,
-		visibilityTimeout:  visibilityTimeout,
-		maxMessageSize:     cfg.MaxMessageSize,
-		messageRetention:   cfg.MessageRetention,
-		createdAt:          now,
-		lastModifiedAt:     now,
-		deduplicationIndex: make(map[string]time.Time),
-		dlqConfig:          cfg.DeadLetterQueue,
-		metadata:           make(map[string]string),
+		info:                   info,
+		messages:               make([]*sbMessage, 0),
+		delaySeconds:           cfg.DelaySeconds,
+		visibilityTimeout:      visibilityTimeout,
+		maxMessageSize:         cfg.MaxMessageSize,
+		messageRetention:       cfg.MessageRetention,
+		createdAt:              now,
+		lastModifiedAt:         now,
+		deduplicationIndex:     make(map[string]time.Time),
+		dlqConfig:              cfg.DeadLetterQueue,
+		deadLetterOnExpiration: cfg.DeadLetterOnExpiration,
+		metadata:               make(map[string]string),
 	}
 
 	m.queues.Set(url, qd)
@@ -264,6 +273,11 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		attrs[k] = v
 	}
 
+	sysProps := make(map[string]string, len(input.SystemProperties))
+	for k, v := range input.SystemProperties {
+		sysProps[k] = v
+	}
+
 	delaySeconds := input.DelaySeconds
 	if delaySeconds == 0 {
 		delaySeconds = qd.delaySeconds
@@ -278,6 +292,7 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		GroupID:         input.GroupID,
 		DeduplicationID: input.DeduplicationID,
 		Attributes:      attrs,
+		SystemProps:     sysProps,
 		VisibleAt:       visibleAt,
 		SentAt:          now,
 		ExpiresAt:       expiresAt,
@@ -417,10 +432,7 @@ func (m *Mock) collectVisibleMessages(
 			break
 		}
 
-		// Lazily reap an expired message (Azure Queue Storage's per-message
-		// messagettl) instead of returning it, mirroring the Cosmos DB mock's
-		// on-read TTL check.
-		if isMessageExpired(msg, now) {
+		if m.reapExpired(qd, msg, now) {
 			toRemove = append(toRemove, i)
 			continue
 		}
@@ -431,11 +443,10 @@ func (m *Mock) collectVisibleMessages(
 
 		msg.ReceiveCount++
 
-		// Check if message exceeded max receive count -- move to DLQ.
-		if qd.dlqConfig != nil && qd.dlqConfig.MaxReceiveCount > 0 && msg.ReceiveCount > qd.dlqConfig.MaxReceiveCount {
-			m.moveToDLQ(qd.dlqConfig.TargetQueueURL, msg)
-
-			toRemove = append(toRemove, i)
+		if exceeded, moved := m.deadLetterExhausted(qd, msg); exceeded {
+			if moved {
+				toRemove = append(toRemove, i)
+			}
 
 			continue
 		}
@@ -444,6 +455,35 @@ func (m *Mock) collectVisibleMessages(
 	}
 
 	return results, toRemove
+}
+
+// reapExpired handles an expired message (Azure Queue Storage's per-message
+// messagettl / Service Bus defaultMessageTimeToLive), mirroring the Cosmos DB
+// mock's on-read TTL check: it routes the message to the DLQ when
+// dead-lettering-on-expiration is enabled and reports whether it was reaped so
+// the caller drops it.
+func (m *Mock) reapExpired(qd *queueData, msg *sbMessage, now time.Time) bool {
+	if !isMessageExpired(msg, now) {
+		return false
+	}
+
+	if qd.deadLetterOnExpiration && qd.dlqConfig != nil {
+		m.moveToDLQ(qd.dlqConfig.TargetQueueURL, msg)
+	}
+
+	return true
+}
+
+// deadLetterExhausted reports whether msg has exhausted its delivery attempts,
+// and whether it was successfully moved to the DLQ. Only when moved may the
+// caller drop it from the main queue -- a missing DLQ store must not silently
+// lose the message.
+func (m *Mock) deadLetterExhausted(qd *queueData, msg *sbMessage) (exceeded, moved bool) {
+	if qd.dlqConfig == nil || qd.dlqConfig.MaxReceiveCount <= 0 || msg.ReceiveCount <= qd.dlqConfig.MaxReceiveCount {
+		return false, false
+	}
+
+	return true, m.moveToDLQ(qd.dlqConfig.TargetQueueURL, msg)
 }
 
 func buildReceivedMessage(msg *sbMessage, visibilityTimeout int, now time.Time) driver.Message {
@@ -457,37 +497,50 @@ func buildReceivedMessage(msg *sbMessage, visibilityTimeout int, now time.Time) 
 		attrs[k] = v
 	}
 
+	sysProps := make(map[string]string, len(msg.SystemProps))
+	for k, v := range msg.SystemProps {
+		sysProps[k] = v
+	}
+
 	return driver.Message{
-		MessageID:     msg.ID,
-		ReceiptHandle: receiptHandle,
-		Body:          msg.Body,
-		Attributes:    attrs,
-		GroupID:       msg.GroupID,
-		ReceiveCount:  msg.ReceiveCount,
-		ExpiresAt:     msg.ExpiresAt,
+		MessageID:        msg.ID,
+		ReceiptHandle:    receiptHandle,
+		Body:             msg.Body,
+		Attributes:       attrs,
+		SystemProperties: sysProps,
+		GroupID:          msg.GroupID,
+		ReceiveCount:     msg.ReceiveCount,
+		ExpiresAt:        msg.ExpiresAt,
 	}
 }
 
-// moveToDLQ moves a message to the dead-letter queue.
-func (m *Mock) moveToDLQ(dlqURL string, msg *sbMessage) {
+// moveToDLQ copies a message into the dead-letter queue, reporting whether the
+// move succeeded. A missing DLQ store yields false so the caller can keep the
+// message on the main queue rather than dropping (and losing) it. Dead-lettered
+// messages do not carry the source TTL (ExpiresAt stays zero), matching Service
+// Bus, where the DLQ has its own retention.
+func (m *Mock) moveToDLQ(dlqURL string, msg *sbMessage) bool {
 	dlq, ok := m.queues.Get(dlqURL)
 	if !ok {
-		return
+		return false
 	}
+
+	now := m.opts.Clock.Now()
 
 	dlq.mu.Lock()
 	defer dlq.mu.Unlock()
 
-	dlqMsg := &sbMessage{
-		ID:         msg.ID,
-		Body:       msg.Body,
-		GroupID:    msg.GroupID,
-		Attributes: msg.Attributes,
-		VisibleAt:  m.opts.Clock.Now(),
-		SentAt:     m.opts.Clock.Now(),
-	}
+	dlq.messages = append(dlq.messages, &sbMessage{
+		ID:          msg.ID,
+		Body:        msg.Body,
+		GroupID:     msg.GroupID,
+		Attributes:  msg.Attributes,
+		SystemProps: msg.SystemProps,
+		VisibleAt:   now,
+		SentAt:      now,
+	})
 
-	dlq.messages = append(dlq.messages, dlqMsg)
+	return true
 }
 
 // DeleteMessage deletes (completes) a message from the specified queue using its receipt handle (lock token).

--- a/server/azure/servicebus/dataplane.go
+++ b/server/azure/servicebus/dataplane.go
@@ -2,9 +2,11 @@ package servicebus
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
@@ -18,7 +20,14 @@ const (
 	// subPathTail is the segment count of ".../subscriptions/{name}/messages",
 	// counted from the message segment back to the "subscriptions" keyword.
 	subPathTail = 2
+	// dlqSuffix is the reserved sub-queue segment addressing an entity's
+	// dead-letter queue (received from <entity>/$DeadLetterQueue/messages).
+	dlqSuffix = "$DeadLetterQueue"
 )
+
+// isDLQSegment reports whether seg is the dead-letter sub-queue address suffix,
+// matched case-insensitively ($DeadLetterQueue / $deadletterqueue).
+func isDLQSegment(seg string) bool { return strings.EqualFold(seg, dlqSuffix) }
 
 // isDataPlanePath reports whether p is a raw-HTTP Service Bus data-plane URL
 // (contains a /messages segment) rather than an ARM control-plane path.
@@ -36,18 +45,25 @@ type dataPlaneTarget struct {
 	namespace string
 	entity    string
 	sub       string   // subscription name; "" for a queue or a topic send
+	dlq       bool     // .../$DeadLetterQueue/messages addressing
 	head      bool     // .../messages/head
 	lock      []string // [messageId, lockToken] for .../messages/{id}/{token}
 }
 
 // messagesBase returns the "/messages" URL prefix for building the Location
-// header of a peek-locked message, honoring topic-subscription addressing.
+// header of a peek-locked message, honoring topic-subscription and dead-letter
+// sub-queue addressing.
 func (t *dataPlaneTarget) messagesBase() string {
+	base := "/" + t.namespace + "/" + t.entity
 	if t.sub != "" {
-		return "/" + t.namespace + "/" + t.entity + "/" + segSubs + "/" + t.sub + "/" + segMessages
+		base += "/" + segSubs + "/" + t.sub
 	}
 
-	return "/" + t.namespace + "/" + t.entity + "/" + segMessages
+	if t.dlq {
+		base += "/" + dlqSuffix
+	}
+
+	return base + "/" + segMessages
 }
 
 func parseDataPlanePath(p string) (dataPlaneTarget, bool) {
@@ -84,20 +100,41 @@ func parseDataPlanePath(p string) (dataPlaneTarget, bool) {
 // parseEntityScope resolves namespace/entity/subscription from the segments
 // that precede the /messages segment at index mi. A ".../{topic}/subscriptions/
 // {sub}/messages" shape addresses a topic subscription; anything else is a flat
-// queue (or a topic send).
+// queue (or a topic send). A trailing "$DeadLetterQueue" segment before
+// /messages is stripped into the dlq flag, leaving the entity address behind it.
 func parseEntityScope(segs []string, mi int) dataPlaneTarget {
-	if mi > subPathTail && strings.EqualFold(segs[mi-subPathTail], segSubs) {
-		return dataPlaneTarget{
-			namespace: segs[mi-subPathTail-2],
-			entity:    segs[mi-subPathTail-1],
-			sub:       segs[mi-1],
+	// end is the virtual /messages index once a $DeadLetterQueue suffix, if any,
+	// is peeled off the entity address.
+	end := mi
+
+	dlq := mi >= 1 && isDLQSegment(segs[mi-1])
+	if dlq {
+		end = mi - 1
+	}
+
+	// A bare "$DeadLetterQueue/messages" leaves no entity segment; report it as
+	// empty so serveDataPlane rejects the path.
+	if end < 1 {
+		return dataPlaneTarget{dlq: dlq}
+	}
+
+	var tgt dataPlaneTarget
+
+	switch {
+	case end > subPathTail && strings.EqualFold(segs[end-subPathTail], segSubs):
+		tgt = dataPlaneTarget{
+			namespace: segs[end-subPathTail-2],
+			entity:    segs[end-subPathTail-1],
+			sub:       segs[end-1],
+		}
+	default:
+		tgt = dataPlaneTarget{entity: segs[end-1]}
+		if end >= lockTokenParts {
+			tgt.namespace = segs[end-lockTokenParts]
 		}
 	}
 
-	tgt := dataPlaneTarget{entity: segs[mi-1]}
-	if mi >= lockTokenParts {
-		tgt.namespace = segs[mi-lockTokenParts]
-	}
+	tgt.dlq = dlq
 
 	return tgt
 }
@@ -121,8 +158,8 @@ func (h *Handler) serveDataPlane(w http.ResponseWriter, r *http.Request) {
 // queue when it exists as one; otherwise a topic (send fans out to every
 // subscription). Receiving directly from a topic is not permitted.
 func (h *Handler) serveEntityData(w http.ResponseWriter, r *http.Request, tgt *dataPlaneTarget) {
-	if url, ok := h.resolveQueueURL(tgt.namespace, tgt.entity); ok {
-		h.routeQueueOps(w, r, url, tgt)
+	if cfg, ok := h.resolveQueue(tgt.namespace, tgt.entity); ok {
+		h.routeQueueOps(w, r, &cfg, tgt)
 		return
 	}
 
@@ -143,35 +180,66 @@ func (h *Handler) serveEntityData(w http.ResponseWriter, r *http.Request, tgt *d
 }
 
 // serveSubscriptionData routes a "/{topic}/subscriptions/{sub}/messages"
-// request. Only receive/peek-lock/complete/abandon are valid; sending is done
-// against the parent topic.
+// request. Only receive/peek-lock/complete/abandon/renew-lock (and the same on
+// the $DeadLetterQueue sub-queue) are valid; sending is done against the parent
+// topic.
 func (h *Handler) serveSubscriptionData(w http.ResponseWriter, r *http.Request, tgt *dataPlaneTarget) {
-	url, ok := h.resolveSubURL(tgt.namespace, tgt.entity, tgt.sub)
+	cfg, ok := h.resolveSubscription(tgt.namespace, tgt.entity, tgt.sub)
 	if !ok {
 		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "subscription not found: "+tgt.sub)
 		return
 	}
 
+	if tgt.dlq {
+		h.serveDeadLetter(w, r, cfg.dlqURL, cfg.lockSecs, tgt)
+		return
+	}
+
 	switch {
 	case len(tgt.lock) == lockTokenParts:
-		h.serveLockedMessage(w, r, url, tgt.lock[1])
+		h.serveLockedMessage(w, r, cfg.url, tgt.lock[1], cfg.lockSecs)
 	case tgt.head:
-		h.serveHead(w, r, url, tgt)
+		h.serveHead(w, r, cfg.url, tgt)
 	default:
 		azurearm.WriteError(w, http.StatusBadRequest, "InvalidOperation",
 			"cannot send to a subscription; send to the parent topic")
 	}
 }
 
-// routeQueueOps dispatches the queue send/receive/complete/abandon verbs.
-func (h *Handler) routeQueueOps(w http.ResponseWriter, r *http.Request, url string, tgt *dataPlaneTarget) {
+// routeQueueOps dispatches the queue send/receive/complete/abandon/renew-lock
+// verbs, routing $DeadLetterQueue-addressed requests to the DLQ store.
+func (h *Handler) routeQueueOps(w http.ResponseWriter, r *http.Request, cfg *queueDataPlane, tgt *dataPlaneTarget) {
+	if tgt.dlq {
+		h.serveDeadLetter(w, r, cfg.dlqURL, cfg.lockSecs, tgt)
+		return
+	}
+
 	switch {
 	case len(tgt.lock) == lockTokenParts:
-		h.serveLockedMessage(w, r, url, tgt.lock[1])
+		h.serveLockedMessage(w, r, cfg.url, tgt.lock[1], cfg.lockSecs)
 	case tgt.head:
-		h.serveHead(w, r, url, tgt)
+		h.serveHead(w, r, cfg.url, tgt)
 	default:
-		h.dataPlaneSend(w, r, url)
+		h.dataPlaneSend(w, r, cfg.url, cfg.ttlSecs)
+	}
+}
+
+// serveDeadLetter handles receive/complete/abandon/renew-lock against an
+// entity's dead-letter sub-queue. Sending to the DLQ is rejected.
+func (h *Handler) serveDeadLetter(w http.ResponseWriter, r *http.Request, dlqURL string, lockSecs int, tgt *dataPlaneTarget) {
+	if dlqURL == "" {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "dead-letter queue not found")
+		return
+	}
+
+	switch {
+	case len(tgt.lock) == lockTokenParts:
+		h.serveLockedMessage(w, r, dlqURL, tgt.lock[1], lockSecs)
+	case tgt.head:
+		h.serveHead(w, r, dlqURL, tgt)
+	default:
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidOperation",
+			"cannot send to the dead-letter sub-queue")
 	}
 }
 
@@ -191,26 +259,76 @@ func (h *Handler) dataNamespaces(namespace string) []*namespaceState {
 	return h.namespaces.SortedValues()
 }
 
-// resolveQueueURL finds the driver URL for a namespace/queue pair.
-func (h *Handler) resolveQueueURL(namespace, queue string) (string, bool) {
+// queueDataPlane is a queue's resolved data-plane configuration: its backing
+// store URL, its paired dead-letter store URL, the default message TTL applied
+// to sends, and the peek-lock duration used for locks/renew-lock.
+type queueDataPlane struct {
+	url      string
+	dlqURL   string
+	ttlSecs  int
+	lockSecs int
+}
+
+// resolveQueue resolves a namespace/queue pair's data-plane configuration.
+func (h *Handler) resolveQueue(namespace, queue string) (queueDataPlane, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
 	for _, ns := range h.dataNamespaces(namespace) {
 		if rec, ok := ns.Queues[queue]; ok {
-			return rec.DriverURL, true
+			return queueDataPlane{
+				url:      rec.DriverURL,
+				dlqURL:   rec.DLQURL,
+				ttlSecs:  ttlSecondsFromISO(rec.Props.DefaultMessageTimeToLive),
+				lockSecs: lockDurationSeconds(rec.Props.LockDuration),
+			}, true
 		}
 	}
 
-	return "", false
+	return queueDataPlane{}, false
 }
 
-// topicSubTarget is one subscription fan-out target: its backing queue URL
-// plus a snapshot of its rules' filter properties, evaluated against each
-// published message to decide whether that subscription receives it.
+// subDataPlane is a subscription's resolved data-plane configuration.
+type subDataPlane struct {
+	url      string
+	dlqURL   string
+	lockSecs int
+}
+
+// resolveSubscription resolves a topic subscription's data-plane configuration.
+func (h *Handler) resolveSubscription(namespace, topic, sub string) (subDataPlane, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	for _, ns := range h.dataNamespaces(namespace) {
+		t, ok := ns.Topics[topic]
+		if !ok {
+			continue
+		}
+
+		s, ok := t.Subs[sub]
+		if !ok {
+			return subDataPlane{}, false
+		}
+
+		return subDataPlane{
+			url:      s.DriverURL,
+			dlqURL:   s.DLQURL,
+			lockSecs: lockDurationSeconds(s.Props.LockDuration),
+		}, true
+	}
+
+	return subDataPlane{}, false
+}
+
+// topicSubTarget is one subscription fan-out target: its backing queue URL, its
+// default message TTL, plus a snapshot of its rules' filter properties,
+// evaluated against each published message to decide whether that subscription
+// receives it.
 type topicSubTarget struct {
-	url   string
-	rules []ruleProperties
+	url     string
+	ttlSecs int
+	rules   []ruleProperties
 }
 
 // resolveTopicSubURLs returns the fan-out targets of every subscription on a
@@ -235,34 +353,17 @@ func (h *Handler) resolveTopicSubURLs(namespace, topic string) ([]topicSubTarget
 				rules = append(rules, sub.Rules[rn].Props)
 			}
 
-			targets = append(targets, topicSubTarget{url: sub.DriverURL, rules: rules})
+			targets = append(targets, topicSubTarget{
+				url:     sub.DriverURL,
+				ttlSecs: ttlSecondsFromISO(sub.Props.DefaultMessageTimeToLive),
+				rules:   rules,
+			})
 		}
 
 		return targets, true
 	}
 
 	return nil, false
-}
-
-// resolveSubURL finds the backing driver URL of a topic subscription.
-func (h *Handler) resolveSubURL(namespace, topic, sub string) (string, bool) {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-
-	for _, ns := range h.dataNamespaces(namespace) {
-		t, ok := ns.Topics[topic]
-		if !ok {
-			continue
-		}
-
-		if s, ok := t.Subs[sub]; ok {
-			return s.DriverURL, true
-		}
-
-		return "", false
-	}
-
-	return "", false
 }
 
 func (h *Handler) serveHead(w http.ResponseWriter, r *http.Request, url string, tgt *dataPlaneTarget) {
@@ -277,9 +378,10 @@ func (h *Handler) serveHead(w http.ResponseWriter, r *http.Request, url string, 
 	}
 }
 
-// serveLockedMessage handles complete (DELETE) and abandon (PUT) on a locked
-// message addressed by .../messages/{messageId}/{lockToken}.
-func (h *Handler) serveLockedMessage(w http.ResponseWriter, r *http.Request, url, lockToken string) {
+// serveLockedMessage handles complete (DELETE), abandon (PUT) and renew-lock
+// (POST) on a locked message addressed by .../messages/{messageId}/{lockToken}.
+// Renew re-arms the visibility window by the entity's configured lock duration.
+func (h *Handler) serveLockedMessage(w http.ResponseWriter, r *http.Request, url, lockToken string, lockSecs int) {
 	switch r.Method {
 	case http.MethodDelete:
 		if err := h.mq.DeleteMessage(r.Context(), url, lockToken); err != nil {
@@ -295,13 +397,20 @@ func (h *Handler) serveLockedMessage(w http.ResponseWriter, r *http.Request, url
 		}
 
 		w.WriteHeader(http.StatusOK)
+	case http.MethodPost:
+		if err := h.mq.ChangeVisibility(r.Context(), url, lockToken, lockSecs); err != nil {
+			writeLockError(w, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
 	default:
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed",
-			"locked message accepts DELETE (complete) or PUT (abandon)")
+			"locked message accepts DELETE (complete), PUT (abandon) or POST (renew-lock)")
 	}
 }
 
-func (h *Handler) dataPlaneSend(w http.ResponseWriter, r *http.Request, url string) {
+func (h *Handler) dataPlaneSend(w http.ResponseWriter, r *http.Request, url string, ttlSecs int) {
 	if r.Method != http.MethodPost {
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "send requires POST")
 		return
@@ -312,9 +421,9 @@ func (h *Handler) dataPlaneSend(w http.ResponseWriter, r *http.Request, url stri
 		return
 	}
 
-	if _, err := h.mq.SendMessage(r.Context(), mqdriver.SendMessageInput{
-		QueueURL: url, Body: body,
-	}); err != nil {
+	bp := parseWireBrokerProps(r)
+
+	if _, err := h.mq.SendMessage(r.Context(), bp.sendInput(url, body, ttlSecs)); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
@@ -326,19 +435,21 @@ func (h *Handler) dataPlaneSend(w http.ResponseWriter, r *http.Request, url stri
 // rules it matches (each subscription's filter-only rules are OR'd, mirroring
 // real Service Bus). A topic with no subscriptions, or with none whose rules
 // match, still returns 201 (the message is accepted and dropped), matching
-// Azure.
+// Azure. Each matching subscription persists the sender's system properties and
+// applies its own default message TTL.
 //
-// DEFER: only the system properties parseBrokerProperties recognizes are
-// evaluated; arbitrary custom application-property headers are not parsed, so
-// a SqlFilter or CorrelationFilter predicate over a user-defined property
-// cannot disqualify a subscription yet.
+// DEFER: only the well-known system properties are evaluated in filters;
+// arbitrary custom application-property headers are not parsed, so a SqlFilter
+// or CorrelationFilter predicate over a user-defined property cannot disqualify
+// a subscription yet.
 func (h *Handler) dataPlaneTopicSend(w http.ResponseWriter, r *http.Request, targets []topicSubTarget) {
 	if r.Method != http.MethodPost {
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "send requires POST")
 		return
 	}
 
-	props := parseBrokerProperties(r)
+	bp := parseWireBrokerProps(r)
+	filter := bp.filterProps()
 
 	body, ok := readSendBody(w, r)
 	if !ok {
@@ -346,19 +457,119 @@ func (h *Handler) dataPlaneTopicSend(w http.ResponseWriter, r *http.Request, tar
 	}
 
 	for _, tgt := range targets {
-		if !rulesMatch(tgt.rules, &props) {
+		if !rulesMatch(tgt.rules, &filter) {
 			continue
 		}
 
-		if _, err := h.mq.SendMessage(r.Context(), mqdriver.SendMessageInput{
-			QueueURL: tgt.url, Body: body,
-		}); err != nil {
+		if _, err := h.mq.SendMessage(r.Context(), bp.sendInput(tgt.url, body, tgt.ttlSecs)); err != nil {
 			azurearm.WriteCErr(w, err)
 			return
 		}
 	}
 
 	w.WriteHeader(http.StatusCreated)
+}
+
+// wireBrokerProps is the sender-supplied BrokerProperties header of the Service
+// Bus REST "Send Message" API: brokered-message system properties plus the
+// TimeToLive and ScheduledEnqueueTimeUtc that control expiry and scheduling.
+// https://learn.microsoft.com/rest/api/servicebus/send-message-to-queue
+type wireBrokerProps struct {
+	MessageID               string  `json:"MessageId,omitempty"`
+	CorrelationID           string  `json:"CorrelationId,omitempty"`
+	SessionID               string  `json:"SessionId,omitempty"`
+	Label                   string  `json:"Label,omitempty"`
+	ReplyTo                 string  `json:"ReplyTo,omitempty"`
+	To                      string  `json:"To,omitempty"`
+	ReplyToSessionID        string  `json:"ReplyToSessionId,omitempty"`
+	ContentType             string  `json:"ContentType,omitempty"`
+	TimeToLive              float64 `json:"TimeToLive,omitempty"`
+	ScheduledEnqueueTimeUtc string  `json:"ScheduledEnqueueTimeUtc,omitempty"`
+}
+
+// parseWireBrokerProps reads the sender-supplied BrokerProperties header off a
+// data-plane send request. A missing or malformed header yields the zero value.
+func parseWireBrokerProps(r *http.Request) wireBrokerProps {
+	var bp wireBrokerProps
+
+	if h := r.Header.Get("BrokerProperties"); h != "" {
+		_ = json.Unmarshal([]byte(h), &bp)
+	}
+
+	return bp
+}
+
+// filterProps projects the well-known system properties a subscription rule
+// filter evaluates against.
+func (b *wireBrokerProps) filterProps() messageProps {
+	return messageProps{
+		MessageID:        b.MessageID,
+		CorrelationID:    b.CorrelationID,
+		Label:            b.Label,
+		To:               b.To,
+		ReplyTo:          b.ReplyTo,
+		SessionID:        b.SessionID,
+		ReplyToSessionID: b.ReplyToSessionID,
+		ContentType:      b.ContentType,
+	}
+}
+
+// systemProperties returns the non-empty brokered-message system properties to
+// persist and echo back to the receiver, or nil when none were supplied.
+func (b *wireBrokerProps) systemProperties() map[string]string {
+	m := map[string]string{}
+
+	for k, v := range map[string]string{
+		"MessageId":        b.MessageID,
+		"CorrelationId":    b.CorrelationID,
+		"SessionId":        b.SessionID,
+		"Label":            b.Label,
+		"ReplyTo":          b.ReplyTo,
+		"To":               b.To,
+		"ReplyToSessionId": b.ReplyToSessionID,
+		"ContentType":      b.ContentType,
+	} {
+		if v != "" {
+			m[k] = v
+		}
+	}
+
+	if len(m) == 0 {
+		return nil
+	}
+
+	return m
+}
+
+// sendInput builds the driver send input for a message: it persists the
+// sender's system properties, resolves the effective TTL (a per-message
+// TimeToLive overrides the entity default), and converts ScheduledEnqueueTimeUtc
+// into a delivery delay.
+func (b *wireBrokerProps) sendInput(url, body string, defaultTTLSecs int) mqdriver.SendMessageInput {
+	in := mqdriver.SendMessageInput{
+		QueueURL:         url,
+		Body:             body,
+		SystemProperties: b.systemProperties(),
+	}
+
+	ttl := defaultTTLSecs
+	if b.TimeToLive > 0 {
+		ttl = int(b.TimeToLive)
+	}
+
+	if ttl > 0 {
+		in.MessageTTLSeconds = &ttl
+	}
+
+	if b.ScheduledEnqueueTimeUtc != "" {
+		if t, err := time.Parse(time.RFC3339, b.ScheduledEnqueueTimeUtc); err == nil {
+			if delay := int(time.Until(t).Seconds()); delay > 0 {
+				in.DelaySeconds = delay
+			}
+		}
+	}
+
+	return in
 }
 
 // readSendBody reads a size-capped request body, writing an error on failure.
@@ -409,14 +620,36 @@ func (h *Handler) dataPlanePeekLock(w http.ResponseWriter, r *http.Request, url 
 	msg := msgs[0]
 	base := tgt.messagesBase()
 	w.Header().Set("Location", base+"/"+msg.MessageID+"/"+msg.ReceiptHandle)
-	w.Header().Set("BrokerProperties",
-		`{"MessageId":"`+msg.MessageID+`","LockToken":"`+msg.ReceiptHandle+`"}`)
+	w.Header().Set("BrokerProperties", brokerPropertiesHeader(&msg, msg.ReceiptHandle))
 	writeMessage(w, &msg, http.StatusCreated)
+}
+
+// brokerPropertiesHeader builds the BrokerProperties response header from a
+// received message: the sender's preserved system properties, the effective
+// MessageId (the sender's when supplied, else the server id), and the LockToken
+// for a peek-locked message.
+func brokerPropertiesHeader(msg *mqdriver.Message, lockToken string) string {
+	props := make(map[string]string, len(msg.SystemProperties)+lockTokenParts)
+	for k, v := range msg.SystemProperties {
+		props[k] = v
+	}
+
+	if props["MessageId"] == "" {
+		props["MessageId"] = msg.MessageID
+	}
+
+	if lockToken != "" {
+		props["LockToken"] = lockToken
+	}
+
+	b, _ := json.Marshal(props)
+
+	return string(b)
 }
 
 func writeMessage(w http.ResponseWriter, msg *mqdriver.Message, status int) {
 	if h := w.Header().Get("BrokerProperties"); h == "" {
-		w.Header().Set("BrokerProperties", `{"MessageId":"`+msg.MessageID+`"}`)
+		w.Header().Set("BrokerProperties", brokerPropertiesHeader(msg, ""))
 	}
 
 	w.Header().Set("Content-Type", "application/octet-stream")

--- a/server/azure/servicebus/dataplane_dlq_test.go
+++ b/server/azure/servicebus/dataplane_dlq_test.go
@@ -1,0 +1,178 @@
+package servicebus_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDataPlaneDeadLettersAfterMaxDeliveryCount is the regression for
+// non-functional dead-lettering: a message abandoned past maxDeliveryCount must
+// move to the dead-letter queue (draining the main queue) and be readable from
+// the $DeadLetterQueue sub-queue endpoint, preserving its system properties.
+func TestDataPlaneDeadLettersAfterMaxDeliveryCount(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+
+	// maxDeliveryCount=2: delivered twice, dead-lettered on the 3rd attempt.
+	if r := doRequest(t, srv, http.MethodPut, queueURL("poison")+apiVer,
+		`{"properties":{"maxDeliveryCount":2}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create queue = %d", r.StatusCode)
+	}
+
+	if r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/poison/messages", "boom",
+		map[string]string{"BrokerProperties": `{"MessageId":"m-poison"}`}); r.StatusCode != http.StatusCreated {
+		t.Fatalf("send = %d", r.StatusCode)
+	}
+
+	// Two peek-lock + abandon cycles keep the message on the main queue.
+	for i := 0; i < 2; i++ {
+		lock := doRequest(t, srv, http.MethodPost, "/"+nsName+"/poison/messages/head", "")
+		if lock.StatusCode != http.StatusCreated {
+			t.Fatalf("peek-lock %d = %d, want 201", i, lock.StatusCode)
+		}
+
+		_ = readBody(t, lock)
+
+		loc := lock.Header.Get("Location")
+		if r := doRequest(t, srv, http.MethodPut, loc, ""); r.StatusCode != http.StatusOK {
+			t.Fatalf("abandon %d = %d", i, r.StatusCode)
+		}
+	}
+
+	// The 3rd delivery attempt exceeds maxDeliveryCount: the message is
+	// dead-lettered, so the main queue drains empty.
+	third := doRequest(t, srv, http.MethodPost, "/"+nsName+"/poison/messages/head", "")
+	if third.StatusCode != http.StatusNoContent {
+		t.Fatalf("3rd receive = %d, want 204 (message dead-lettered)", third.StatusCode)
+	}
+
+	// The poison message is now readable from the DLQ endpoint, with its
+	// system properties intact.
+	dlq := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/poison/$DeadLetterQueue/messages/head", "")
+	if dlq.StatusCode != http.StatusOK {
+		t.Fatalf("DLQ receive = %d, want 200", dlq.StatusCode)
+	}
+
+	if got := readBody(t, dlq); got != "boom" {
+		t.Fatalf("DLQ body = %q, want boom", got)
+	}
+
+	if props := brokerHeader(t, dlq); props["MessageId"] != "m-poison" {
+		t.Fatalf("DLQ MessageId = %q, want m-poison", props["MessageId"])
+	}
+}
+
+// TestDataPlaneTTLExpiryDeadLetters confirms that with
+// deadLetteringOnMessageExpiration enabled, an expired message is routed to the
+// dead-letter queue rather than silently dropped.
+func TestDataPlaneTTLExpiryDeadLetters(t *testing.T) {
+	srv, clk := newClockServer(t)
+	seedNamespace(t, srv)
+
+	if r := doRequest(t, srv, http.MethodPut, queueURL("ttldlq")+apiVer,
+		`{"properties":{"defaultMessageTimeToLive":"PT5S","deadLetteringOnMessageExpiration":true}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create queue = %d", r.StatusCode)
+	}
+
+	if r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/ttldlq/messages", "expiring"); r.StatusCode != http.StatusCreated {
+		t.Fatalf("send = %d", r.StatusCode)
+	}
+
+	clk.Advance(6 * time.Second)
+
+	// A receive on the main queue lazily reaps the expired message into the DLQ.
+	main := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/ttldlq/messages/head", "")
+	if main.StatusCode != http.StatusNoContent {
+		t.Fatalf("main receive after TTL = %d, want 204", main.StatusCode)
+	}
+
+	dlq := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/ttldlq/$DeadLetterQueue/messages/head", "")
+	if dlq.StatusCode != http.StatusOK {
+		t.Fatalf("DLQ receive = %d, want 200 (expired message dead-lettered)", dlq.StatusCode)
+	}
+
+	if got := readBody(t, dlq); got != "expiring" {
+		t.Fatalf("DLQ body = %q, want expiring", got)
+	}
+}
+
+// TestDataPlaneSubscriptionDeadLetter confirms a topic subscription also
+// dead-letters poison messages onto its own $DeadLetterQueue endpoint.
+func TestDataPlaneSubscriptionDeadLetter(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+
+	if r := doRequest(t, srv, http.MethodPut, topicURL("orders")+apiVer, `{"properties":{}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create topic = %d", r.StatusCode)
+	}
+
+	if r := doRequest(t, srv, http.MethodPut, subURL("orders", "billing")+apiVer,
+		`{"properties":{"maxDeliveryCount":1}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create subscription = %d", r.StatusCode)
+	}
+
+	if r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/orders/messages", "inv-1"); r.StatusCode != http.StatusCreated {
+		t.Fatalf("publish = %d", r.StatusCode)
+	}
+
+	// maxDeliveryCount=1: one delivery, then dead-lettered on the 2nd attempt.
+	lock := doRequest(t, srv, http.MethodPost, "/"+nsName+"/orders/subscriptions/billing/messages/head", "")
+	if lock.StatusCode != http.StatusCreated {
+		t.Fatalf("peek-lock = %d", lock.StatusCode)
+	}
+
+	_ = readBody(t, lock)
+
+	if r := doRequest(t, srv, http.MethodPut, lock.Header.Get("Location"), ""); r.StatusCode != http.StatusOK {
+		t.Fatalf("abandon = %d", r.StatusCode)
+	}
+
+	second := doRequest(t, srv, http.MethodPost, "/"+nsName+"/orders/subscriptions/billing/messages/head", "")
+	if second.StatusCode != http.StatusNoContent {
+		t.Fatalf("2nd receive = %d, want 204 (dead-lettered)", second.StatusCode)
+	}
+
+	dlq := doRequest(t, srv, http.MethodDelete,
+		"/"+nsName+"/orders/subscriptions/billing/$DeadLetterQueue/messages/head", "")
+	if dlq.StatusCode != http.StatusOK {
+		t.Fatalf("subscription DLQ receive = %d, want 200", dlq.StatusCode)
+	}
+
+	if got := readBody(t, dlq); got != "inv-1" {
+		t.Fatalf("subscription DLQ body = %q, want inv-1", got)
+	}
+}
+
+// TestDataPlaneRenewLock is the regression for the unimplemented renew-lock
+// verb: a POST on a locked message must extend its lock (200), not return 405.
+func TestDataPlaneRenewLock(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+
+	if r := doRequest(t, srv, http.MethodPut, queueURL("renew")+apiVer, `{"properties":{}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create queue = %d", r.StatusCode)
+	}
+
+	if r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/renew/messages", "m"); r.StatusCode != http.StatusCreated {
+		t.Fatalf("send = %d", r.StatusCode)
+	}
+
+	lock := doRequest(t, srv, http.MethodPost, "/"+nsName+"/renew/messages/head", "")
+	if lock.StatusCode != http.StatusCreated {
+		t.Fatalf("peek-lock = %d", lock.StatusCode)
+	}
+
+	_ = readBody(t, lock)
+
+	loc := lock.Header.Get("Location")
+	if !strings.Contains(loc, "/renew/messages/") {
+		t.Fatalf("Location = %q, want locked-message path", loc)
+	}
+
+	renew := doRequest(t, srv, http.MethodPost, loc, "")
+	if renew.StatusCode != http.StatusOK {
+		t.Fatalf("renew-lock = %d, want 200", renew.StatusCode)
+	}
+}

--- a/server/azure/servicebus/dataplane_message_test.go
+++ b/server/azure/servicebus/dataplane_message_test.go
@@ -1,0 +1,149 @@
+package servicebus_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// newClockServer starts a Service Bus test server backed by a FakeClock so
+// time-dependent data-plane behavior (TTL, scheduling) can be driven
+// deterministically without sleeping.
+func newClockServer(t *testing.T) (*httptest.Server, *config.FakeClock) {
+	t.Helper()
+
+	clk := config.NewFakeClock(time.Now())
+	cloud := cloudemu.NewAzure(config.WithClock(clk))
+	srv := httptest.NewServer(azureserver.New(azureserver.Drivers{ServiceBus: cloud.ServiceBus}))
+	t.Cleanup(srv.Close)
+
+	return srv, clk
+}
+
+// brokerHeader parses the BrokerProperties response header into a map.
+func brokerHeader(t *testing.T, resp *http.Response) map[string]string {
+	t.Helper()
+
+	raw := resp.Header.Get("BrokerProperties")
+	if raw == "" {
+		t.Fatal("response missing BrokerProperties header")
+	}
+
+	var props map[string]string
+	if err := json.Unmarshal([]byte(raw), &props); err != nil {
+		t.Fatalf("decode BrokerProperties %q: %v", raw, err)
+	}
+
+	return props
+}
+
+// TestDataPlaneSystemPropertiesRoundTrip is the regression for dropped brokered
+// system properties: a sender's MessageId/CorrelationId/Label must be preserved
+// and echoed on receive, and the sender's MessageId must not be overwritten by
+// the server-assigned id.
+func TestDataPlaneSystemPropertiesRoundTrip(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+
+	if r := doRequest(t, srv, http.MethodPut, queueURL("props")+apiVer, `{"properties":{}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create queue = %d", r.StatusCode)
+	}
+
+	send := doRequest(t, srv, http.MethodPost, "/"+nsName+"/props/messages", "payload",
+		map[string]string{"BrokerProperties": `{"MessageId":"m-1","CorrelationId":"cid-1","Label":"lbl"}`})
+	if send.StatusCode != http.StatusCreated {
+		t.Fatalf("send = %d, want 201", send.StatusCode)
+	}
+
+	lock := doRequest(t, srv, http.MethodPost, "/"+nsName+"/props/messages/head", "")
+	if lock.StatusCode != http.StatusCreated {
+		t.Fatalf("peek-lock = %d, want 201", lock.StatusCode)
+	}
+
+	_ = readBody(t, lock)
+
+	props := brokerHeader(t, lock)
+	if props["MessageId"] != "m-1" {
+		t.Fatalf("MessageId = %q, want sender's m-1 (not the server id)", props["MessageId"])
+	}
+
+	if props["CorrelationId"] != "cid-1" {
+		t.Fatalf("CorrelationId = %q, want cid-1", props["CorrelationId"])
+	}
+
+	if props["Label"] != "lbl" {
+		t.Fatalf("Label = %q, want lbl", props["Label"])
+	}
+
+	if props["LockToken"] == "" {
+		t.Fatal("peek-lock BrokerProperties missing LockToken")
+	}
+}
+
+// TestDataPlaneMessageTTLExpires is the regression for cosmetic TTL: a queue's
+// defaultMessageTimeToLive must actually expire messages so an elapsed message
+// is not delivered, while the queue itself keeps working for fresh messages.
+func TestDataPlaneMessageTTLExpires(t *testing.T) {
+	srv, clk := newClockServer(t)
+	seedNamespace(t, srv)
+
+	if r := doRequest(t, srv, http.MethodPut, queueURL("ttl")+apiVer,
+		`{"properties":{"defaultMessageTimeToLive":"PT5S"}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create queue = %d", r.StatusCode)
+	}
+
+	if r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/ttl/messages", "temp"); r.StatusCode != http.StatusCreated {
+		t.Fatalf("send = %d", r.StatusCode)
+	}
+
+	clk.Advance(6 * time.Second)
+
+	expired := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/ttl/messages/head", "")
+	if expired.StatusCode != http.StatusNoContent {
+		t.Fatalf("receive after TTL = %d, want 204 (message expired)", expired.StatusCode)
+	}
+
+	// A fresh message on the same queue is still deliverable, proving the 204
+	// was expiry rather than a broken queue.
+	if r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/ttl/messages", "fresh"); r.StatusCode != http.StatusCreated {
+		t.Fatalf("second send = %d", r.StatusCode)
+	}
+
+	fresh := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/ttl/messages/head", "")
+	if fresh.StatusCode != http.StatusOK {
+		t.Fatalf("fresh receive = %d, want 200", fresh.StatusCode)
+	}
+
+	if got := readBody(t, fresh); got != "fresh" {
+		t.Fatalf("fresh body = %q, want fresh", got)
+	}
+}
+
+// TestDataPlaneScheduledMessageDelayed is the regression for ignored
+// ScheduledEnqueueTimeUtc: a message scheduled for a future enqueue time must
+// not be delivered immediately.
+func TestDataPlaneScheduledMessageDelayed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+
+	if r := doRequest(t, srv, http.MethodPut, queueURL("sched")+apiVer, `{"properties":{}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create queue = %d", r.StatusCode)
+	}
+
+	send := doRequest(t, srv, http.MethodPost, "/"+nsName+"/sched/messages", "future",
+		map[string]string{"BrokerProperties": `{"ScheduledEnqueueTimeUtc":"2099-01-01T00:00:00Z"}`})
+	if send.StatusCode != http.StatusCreated {
+		t.Fatalf("send = %d, want 201", send.StatusCode)
+	}
+
+	early := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/sched/messages/head", "")
+	if early.StatusCode != http.StatusNoContent {
+		t.Fatalf("receive before scheduled time = %d, want 204 (not yet enqueued)", early.StatusCode)
+	}
+}

--- a/server/azure/servicebus/filter.go
+++ b/server/azure/servicebus/filter.go
@@ -1,8 +1,6 @@
 package servicebus
 
 import (
-	"encoding/json"
-	"net/http"
 	"strconv"
 	"strings"
 )
@@ -21,37 +19,6 @@ type messageProps struct {
 	SessionID        string
 	ReplyToSessionID string
 	ContentType      string
-}
-
-// brokerProperties is the JSON shape of the BrokerProperties request header
-// the Service Bus REST "Send Message" API accepts for a brokered message's
-// system properties (custom application properties travel as separate,
-// individually-named headers instead, and are not parsed here yet -- see the
-// DEFER note on dataPlaneTopicSend).
-// https://learn.microsoft.com/rest/api/servicebus/send-message-to-queue
-type brokerProperties struct {
-	MessageID        string `json:"MessageId,omitempty"`
-	CorrelationID    string `json:"CorrelationId,omitempty"`
-	Label            string `json:"Label,omitempty"`
-	To               string `json:"To,omitempty"`
-	ReplyTo          string `json:"ReplyTo,omitempty"`
-	SessionID        string `json:"SessionId,omitempty"`
-	ReplyToSessionID string `json:"ReplyToSessionId,omitempty"`
-	ContentType      string `json:"ContentType,omitempty"`
-}
-
-// parseBrokerProperties reads the sender-supplied BrokerProperties header off
-// a data-plane send request. A missing or malformed header yields the zero
-// value, which only ever satisfies filters that impose no constraint (the
-// default "1=1" rule, an unset CorrelationFilter field).
-func parseBrokerProperties(r *http.Request) messageProps {
-	var bp brokerProperties
-
-	if h := r.Header.Get("BrokerProperties"); h != "" {
-		_ = json.Unmarshal([]byte(h), &bp)
-	}
-
-	return messageProps(bp)
 }
 
 // rulesMatch reports whether a message matches at least one of a
@@ -286,4 +253,91 @@ func lockDurationSeconds(s string) int {
 	}
 
 	return total
+}
+
+// secondsPerDay is the whole-seconds length of the ISO-8601 date component "D".
+const secondsPerDay = 86400
+
+// ttlSecondsFromISO converts a DefaultMessageTimeToLive ISO-8601 duration
+// (e.g. "PT5S", "PT1M", "P1DT2H") to whole seconds, returning 0 for "no TTL":
+// an empty value, the effectively-unlimited maxTimeToLive sentinel, or anything
+// it cannot cleanly parse (fractional seconds, weeks/months/years). Only the
+// day/hour/minute/second subset Service Bus emits is supported.
+func ttlSecondsFromISO(s string) int {
+	if s == "" || s == maxTimeToLive {
+		return 0
+	}
+
+	rest, ok := strings.CutPrefix(s, "P")
+	if !ok {
+		return 0
+	}
+
+	datePart, timePart := rest, ""
+	if i := strings.IndexByte(rest, 'T'); i >= 0 {
+		datePart, timePart = rest[:i], rest[i+1:]
+	}
+
+	days, ok := scanDurationField(datePart, 'D')
+	if !ok {
+		return 0
+	}
+
+	secs, ok := scanTimeComponents(timePart)
+	if !ok {
+		return 0
+	}
+
+	total := days*secondsPerDay + secs
+	if total <= 0 {
+		return 0
+	}
+
+	return total
+}
+
+// scanTimeComponents sums the H/M/S components of an ISO-8601 duration's time
+// part, reporting ok=false if any leftover text remains (an unsupported unit).
+func scanTimeComponents(timePart string) (int, bool) {
+	total := 0
+
+	for _, unit := range [...]struct {
+		suffix byte
+		mult   int
+	}{{'H', 3600}, {'M', 60}, {'S', 1}} {
+		idx := strings.IndexByte(timePart, unit.suffix)
+		if idx < 0 {
+			continue
+		}
+
+		n, err := strconv.Atoi(timePart[:idx])
+		if err != nil {
+			return 0, false
+		}
+
+		total += n * unit.mult
+		timePart = timePart[idx+1:]
+	}
+
+	if timePart != "" {
+		return 0, false
+	}
+
+	return total, true
+}
+
+// scanDurationField reads the integer preceding suffix in part, returning (0,
+// true) when the suffix is absent and (0, false) when the number won't parse.
+func scanDurationField(part string, suffix byte) (int, bool) {
+	idx := strings.IndexByte(part, suffix)
+	if idx < 0 {
+		return 0, true
+	}
+
+	n, err := strconv.Atoi(part[:idx])
+	if err != nil {
+		return 0, false
+	}
+
+	return n, true
 }

--- a/server/azure/servicebus/namespace.go
+++ b/server/azure/servicebus/namespace.go
@@ -137,15 +137,16 @@ func (h *Handler) deleteNamespace(w http.ResponseWriter, sp sbPath) {
 		return
 	}
 
-	// Cascade: drop the message store for every child queue and subscription.
+	// Cascade: drop the message store (and paired dead-letter store) for every
+	// child queue and subscription.
 	urls := make([]string, 0, len(ns.Queues))
 	for _, q := range ns.Queues {
-		urls = append(urls, q.DriverURL)
+		urls = append(urls, q.DriverURL, q.DLQURL)
 	}
 
 	for _, t := range ns.Topics {
 		for _, s := range t.Subs {
-			urls = append(urls, s.DriverURL)
+			urls = append(urls, s.DriverURL, s.DLQURL)
 		}
 	}
 

--- a/server/azure/servicebus/queue.go
+++ b/server/azure/servicebus/queue.go
@@ -60,9 +60,22 @@ func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request, sp sbPath,
 
 	rec, existed := ns.Queues[name]
 	if !existed {
+		dlqURL, err := h.provisionDLQ(r, sp.namespace+"/"+name)
+		if err != nil {
+			h.mu.Unlock()
+			azurearm.WriteCErr(w, err)
+
+			return
+		}
+
 		info, err := h.mq.CreateQueue(r.Context(), mqdriver.QueueConfig{
 			Name:              sp.namespace + "/" + name,
 			VisibilityTimeout: lockSeconds,
+			DeadLetterQueue: &mqdriver.DeadLetterConfig{
+				TargetQueueURL:  dlqURL,
+				MaxReceiveCount: effectiveMaxDeliveryCount(&req.Properties),
+			},
+			DeadLetterOnExpiration: req.Properties.DeadLetteringOnExpiration,
 		})
 		if err != nil && !cerrors.IsAlreadyExists(err) {
 			h.mu.Unlock()
@@ -76,7 +89,7 @@ func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request, sp sbPath,
 			url = info.URL
 		}
 
-		rec = &queueRecord{Name: name, DriverURL: url, CreatedAt: now}
+		rec = &queueRecord{Name: name, DriverURL: url, DLQURL: dlqURL, CreatedAt: now}
 		ns.Queues[name] = rec
 	} else if rec.DriverURL != "" {
 		// PUT is create-or-update: honor a LockDuration change on an existing
@@ -149,6 +162,7 @@ func (h *Handler) deleteQueue(w http.ResponseWriter, sp sbPath, name string) {
 	}
 
 	url := rec.DriverURL
+	dlqURL := rec.DLQURL
 
 	delete(ns.Queues, name)
 	h.mu.Unlock()
@@ -157,7 +171,35 @@ func (h *Handler) deleteQueue(w http.ResponseWriter, sp sbPath, name string) {
 		_ = h.mq.DeleteQueue(context.Background(), url)
 	}
 
+	h.deleteBackingQueue(dlqURL)
+
 	w.WriteHeader(http.StatusOK)
+}
+
+// provisionDLQ creates the backing store for an entity's $DeadLetterQueue
+// sub-queue and returns its driver URL. The DLQ store carries no onward
+// dead-lettering of its own. Callers hold h.mu.
+func (h *Handler) provisionDLQ(r *http.Request, entityName string) (string, error) {
+	info, err := h.mq.CreateQueue(r.Context(), mqdriver.QueueConfig{Name: entityName + "/" + dlqSuffix})
+	if err != nil && !cerrors.IsAlreadyExists(err) {
+		return "", err
+	}
+
+	if info != nil {
+		return info.URL, nil
+	}
+
+	return "", nil
+}
+
+// effectiveMaxDeliveryCount is the delivery-attempt ceiling after which a
+// message dead-letters, defaulting to Service Bus' documented 10.
+func effectiveMaxDeliveryCount(p *queueProperties) int {
+	if p.MaxDeliveryCount > 0 {
+		return int(p.MaxDeliveryCount)
+	}
+
+	return defaultMaxDeliveryCount
 }
 
 // buildQueueProps synthesizes the server-computed fields and defaults a real

--- a/server/azure/servicebus/state.go
+++ b/server/azure/servicebus/state.go
@@ -72,6 +72,8 @@ type namespaceState struct {
 type queueRecord struct {
 	Name      string
 	DriverURL string
+	// DLQURL is the backing store of this queue's $DeadLetterQueue sub-queue.
+	DLQURL    string
 	Props     queueProperties
 	CreatedAt time.Time
 	UpdatedAt time.Time
@@ -88,6 +90,8 @@ type topicRecord struct {
 type subscriptionRecord struct {
 	Name      string
 	DriverURL string
+	// DLQURL is the backing store of this subscription's $DeadLetterQueue.
+	DLQURL    string
 	Props     subscriptionProperties
 	Rules     map[string]*ruleRecord
 	CreatedAt time.Time

--- a/server/azure/servicebus/subscription.go
+++ b/server/azure/servicebus/subscription.go
@@ -71,7 +71,7 @@ func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, sp 
 
 	rec, existed := t.Subs[name]
 	if !existed {
-		url, err := h.createSubQueue(r, sp.namespace, topic, name, lockSeconds)
+		url, dlqURL, err := h.createSubQueue(r, sp.namespace, topic, name, lockSeconds, &req.Properties)
 		if err != nil {
 			h.mu.Unlock()
 			azurearm.WriteCErr(w, err)
@@ -79,7 +79,7 @@ func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, sp 
 			return
 		}
 
-		rec = &subscriptionRecord{Name: name, DriverURL: url, Rules: map[string]*ruleRecord{}, CreatedAt: now}
+		rec = &subscriptionRecord{Name: name, DriverURL: url, DLQURL: dlqURL, Rules: map[string]*ruleRecord{}, CreatedAt: now}
 		rec.Rules[defaultRuleName] = defaultRule()
 		t.Subs[name] = rec
 	} else if rec.DriverURL != "" {
@@ -130,29 +130,58 @@ func (h *Handler) deleteSubscription(w http.ResponseWriter, sp sbPath, topic, na
 	}
 
 	url := rec.DriverURL
+	dlqURL := rec.DLQURL
 
 	delete(t.Subs, name)
 	h.mu.Unlock()
 
 	h.deleteBackingQueue(url)
+	h.deleteBackingQueue(dlqURL)
 	w.WriteHeader(http.StatusOK)
 }
 
-// createSubQueue provisions the backing message store for a new subscription,
-// honoring its configured LockDuration for peek-lock visibility.
-func (h *Handler) createSubQueue(r *http.Request, namespace, topic, sub string, lockSeconds int) (string, error) {
+// createSubQueue provisions the backing message store for a new subscription
+// plus its paired $DeadLetterQueue, honoring the subscription's LockDuration,
+// MaxDeliveryCount and deadLetteringOnMessageExpiration. It returns the primary
+// and dead-letter store URLs.
+func (h *Handler) createSubQueue(
+	r *http.Request, namespace, topic, sub string, lockSeconds int, props *subscriptionProperties,
+) (url, dlqURL string, err error) {
 	name := namespace + "/" + topic + "/" + segSubs + "/" + sub
 
-	info, err := h.mq.CreateQueue(r.Context(), mqdriver.QueueConfig{Name: name, VisibilityTimeout: lockSeconds})
+	dlqURL, err = h.provisionDLQ(r, name)
+	if err != nil {
+		return "", "", err
+	}
+
+	info, err := h.mq.CreateQueue(r.Context(), mqdriver.QueueConfig{
+		Name:              name,
+		VisibilityTimeout: lockSeconds,
+		DeadLetterQueue: &mqdriver.DeadLetterConfig{
+			TargetQueueURL:  dlqURL,
+			MaxReceiveCount: effectiveSubMaxDeliveryCount(props),
+		},
+		DeadLetterOnExpiration: props.DeadLetteringOnExpiration,
+	})
 	if err != nil && !cerrors.IsAlreadyExists(err) {
-		return "", err
+		return "", "", err
 	}
 
 	if info != nil {
-		return info.URL, nil
+		return info.URL, dlqURL, nil
 	}
 
-	return "", nil
+	return "", dlqURL, nil
+}
+
+// effectiveSubMaxDeliveryCount mirrors effectiveMaxDeliveryCount for a
+// subscription's MaxDeliveryCount.
+func effectiveSubMaxDeliveryCount(p *subscriptionProperties) int {
+	if p.MaxDeliveryCount > 0 {
+		return int(p.MaxDeliveryCount)
+	}
+
+	return defaultMaxDeliveryCount
 }
 
 // lookupTopic returns the topic record; caller must hold h.mu.

--- a/server/azure/servicebus/topic.go
+++ b/server/azure/servicebus/topic.go
@@ -142,10 +142,11 @@ func (h *Handler) deleteTopic(w http.ResponseWriter, sp sbPath, name string) {
 		return
 	}
 
-	// Cascade: drop the backing message store of every subscription.
+	// Cascade: drop the backing message store of every subscription plus its
+	// paired dead-letter store.
 	urls := make([]string, 0, len(t.Subs))
 	for _, s := range t.Subs {
-		urls = append(urls, s.DriverURL)
+		urls = append(urls, s.DriverURL, s.DLQURL)
 	}
 
 	delete(ns.Topics, name)

--- a/services/messagequeue/driver/driver.go
+++ b/services/messagequeue/driver/driver.go
@@ -19,6 +19,11 @@ type QueueConfig struct {
 	MessageRetention  int // seconds
 	Tags              map[string]string
 	DeadLetterQueue   *DeadLetterConfig
+	// DeadLetterOnExpiration moves a message to the dead-letter queue when its
+	// TTL elapses instead of silently dropping it (Azure Service Bus'
+	// deadLetteringOnMessageExpiration). Requires DeadLetterQueue to be set;
+	// ignored by non-Azure providers.
+	DeadLetterOnExpiration bool
 
 	// AWS SQS extras (ignored by non-AWS providers).
 	ReceiveMessageWaitTimeSeconds int
@@ -76,6 +81,11 @@ type SendMessageInput struct {
 	// didn't specify one; a negative value means the message never expires.
 	// Ignored by non-Azure providers.
 	MessageTTLSeconds *int
+	// SystemProperties carries Azure Service Bus brokered-message system
+	// properties (MessageId, CorrelationId, SessionId, Label, ReplyTo, To,
+	// ReplyToSessionId, ContentType) so they survive a send/receive round-trip.
+	// Ignored by non-Azure providers.
+	SystemProperties map[string]string
 }
 
 // SendMessageOutput is the result of sending a message.
@@ -116,6 +126,9 @@ type Message struct {
 	// ExpiresAt is the message's absolute expiration time (Azure Queue Storage's
 	// per-message TTL). Providers that don't track per-message TTL leave it zero.
 	ExpiresAt time.Time
+	// SystemProperties carries Azure Service Bus brokered-message system
+	// properties preserved from the send (see SendMessageInput.SystemProperties).
+	SystemProperties map[string]string
 }
 
 // BatchSendEntry represents a single message in a batch send.


### PR DESCRIPTION
## What

Fixes the Azure Service Bus data-plane correctness bugs found by the deep end-to-end audit. The ARM control plane round-tripped these settings but the REST data plane ignored them, so the canonical reliability patterns (DLQ, correlation, TTL, scheduling) silently broke.

### Fixed findings
- **NEW-1 (BLOCKER) — dead-lettering unwired.** Each queue and subscription now provisions a paired `$DeadLetterQueue` backing store; `createQueue`/`createSubQueue` set `QueueConfig.DeadLetterQueue` with `MaxReceiveCount = maxDeliveryCount`. The data-plane router recognizes the `$DeadLetterQueue` address suffix (queue and subscription forms), so the DLQ is readable from `<entity>/$DeadLetterQueue/messages`. Also fixes the latent data-loss bug: `moveToDLQ` now reports success and the message is dropped from the main queue only once it is safely stored in the DLQ.
- **NEW-3 (HIGH) — system properties dropped.** Caller `MessageId`/`CorrelationId`/`Label`/`SessionId`/`ReplyTo`/`To`/`ReplyToSessionId`/`ContentType` are parsed on send, persisted on the message, and echoed back in the receive `BrokerProperties` header. The sender's `MessageId` is no longer overwritten by the server id.
- **NEW-5 (HIGH) — TTL cosmetic.** Queue/subscription `defaultMessageTimeToLive` and per-message `TimeToLive` are honored; expired messages are not delivered, and dead-letter on expiry when `deadLetteringOnMessageExpiration` is set.
- **NEW-6 (HIGH) — scheduled messages.** `ScheduledEnqueueTimeUtc` delays delivery until that time instead of delivering immediately.
- **NEW-2 (MEDIUM) — renew-lock 405.** `POST` on a locked message re-arms the visibility window by the entity's lock duration.

### 3-layer touch points
- Wire (`server/azure/servicebus`): DLQ provisioning + routing, BrokerProperties parse/echo, TTL/scheduled/renew wiring, ISO-8601 duration parsing, cascade cleanup of DLQ stores.
- Driver (`providers/azure/servicebus`): `SystemProps` on messages, `deadLetterOnExpiration`, guarded `moveToDLQ`, expiry→DLQ.
- Portable interface (`services/messagequeue/driver`): Azure-specific `SystemProperties` (send/receive) and `DeadLetterOnExpiration` (queue config) fields, ignored by non-Azure providers.

## Tests
- `dataplane_dlq_test.go`: dead-letters after maxDeliveryCount and is readable on the DLQ endpoint (queue + subscription), TTL-expiry dead-lettering, renew-lock returns 200.
- `dataplane_message_test.go`: system-property round-trip, expired-TTL message not delivered, scheduled message not delivered before its time.
- `dead_letter_test.go` (driver): missing-DLQ-store data-loss guard, system-property preservation, dead-letter-on-expiration.

## Deferred (remaining Service Bus work)
- **NEW-7** sessions (`requiresSession`) — no session-scoped receive / FIFO / state.
- **NEW-4** custom application-property filters — custom props not parsed off the wire.
- **NEW-8** duplicate detection (`requiresDuplicateDetection`) keyed on MessageId.
- AMQP data plane (`azservicebus` SDK), **NEW-9** LRO namespace create/delete, **NEW-10** resolvable `nextLink` pagination.

## Gates
`go build ./...`, `go vet`, scoped `go test` (server + provider), `go test -race` (provider), `golangci-lint` (0 issues), `gofmt` — all green.
