### PR TITLE
fix(azure-networking): NIC ipConfig <-> LB backend-pool membership

### DIFF
--- a/providers/azure/vnet/network_interface.go
+++ b/providers/azure/vnet/network_interface.go
@@ -326,7 +326,8 @@ func (m *Mock) usedPrivateIPs(subnetID, selfKey string) map[string]bool {
 			continue
 		}
 
-		for _, ipc := range nic.IPConfigs {
+		for i := range nic.IPConfigs {
+			ipc := &nic.IPConfigs[i]
 			if ipc.SubnetID == subnetID && ipc.PrivateIP != "" {
 				used[ipc.PrivateIP] = true
 			}
@@ -355,6 +356,12 @@ func addHost(base net.IP, n int) net.IP {
 func toAzureNIC(n *nicData) driver.AzureNIC {
 	configs := make([]driver.AzureIPConfig, len(n.IPConfigs))
 	copy(configs, n.IPConfigs)
+
+	// Deep-copy each ipConfiguration's backend-pool membership so a caller
+	// mutating the returned slice cannot reach back into stored state.
+	for i := range configs {
+		configs[i].LBBackendPoolIDs = append([]string(nil), n.IPConfigs[i].LBBackendPoolIDs...)
+	}
 
 	return driver.AzureNIC{
 		Name:                   n.Name,

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -283,7 +283,16 @@ func New(d Drivers) http.Handler {
 	// locations / dnsZones), so registration order relative to them is
 	// unconstrained. Registered before the BlobStorage fallback.
 	if d.LB != nil {
-		srv.Register(lbsrv.New(d.LB))
+		lbHandler := lbsrv.New(d.LB)
+
+		// Project a backend address pool's read-only backendIPConfigurations from
+		// the NIC side of the association, so NIC↔LB pool membership reflects on
+		// both sides. Only wired when the networking driver exposes NICs.
+		if nics, ok := d.Network.(netdriver.AzureNetworkInterfaces); ok {
+			lbHandler.SetNICResolver(nics)
+		}
+
+		srv.Register(lbHandler)
 	}
 
 	// Event Grid claims Microsoft.EventGrid/topics — a distinct ARM provider

--- a/server/azure/loadbalancer/handler.go
+++ b/server/azure/loadbalancer/handler.go
@@ -55,22 +55,78 @@
 package loadbalancer
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
 // Handler serves Microsoft.Network/loadBalancers ARM requests against a
 // loadbalancer driver.
 type Handler struct {
 	lb lbdriver.LoadBalancer
+	// nics resolves NIC ipConfigurations so a backend address pool can project
+	// its read-only backendIPConfigurations from the NIC side of the
+	// association. Optional: nil when the networking driver is absent, in which
+	// case pools report no members. Wired via SetNICResolver.
+	nics netdriver.AzureNetworkInterfaces
 }
 
 // New returns an Azure Load Balancer handler backed by lb.
 func New(lb lbdriver.LoadBalancer) *Handler {
 	return &Handler{lb: lb}
+}
+
+// SetNICResolver wires the Azure network-interface surface so a backend
+// address pool can project the ipConfigurations that reference it into its
+// read-only backendIPConfigurations. Without it, pools resolve with no members.
+func (h *Handler) SetNICResolver(nics netdriver.AzureNetworkInterfaces) {
+	h.nics = nics
+}
+
+// poolMembers builds a lookup from a backend address pool's ARM id (lower-cased,
+// since ARM ids are case-insensitive) to the ipConfiguration ARM ids that have
+// joined it, scanning every NIC's stored loadBalancerBackendAddressPools. It
+// returns nil when no NIC resolver is wired, so pools simply carry no members.
+func (h *Handler) poolMembers(ctx context.Context, subscription string) map[string][]string {
+	if h.nics == nil {
+		return nil
+	}
+
+	nics, err := h.nics.ListNetworkInterfaces(ctx, "")
+	if err != nil {
+		return nil
+	}
+
+	members := make(map[string][]string)
+
+	for i := range nics {
+		nic := &nics[i]
+
+		for j := range nic.IPConfigs {
+			cfg := &nic.IPConfigs[j]
+			ipCfgID := nicIPConfigID(subscription, nic.ResourceGroup, nic.Name, cfg.Name)
+
+			for _, poolID := range cfg.LBBackendPoolIDs {
+				key := strings.ToLower(poolID)
+				members[key] = append(members[key], ipCfgID)
+			}
+		}
+	}
+
+	return members
+}
+
+// nicIPConfigID builds the nested ARM resource id of a NIC ipConfiguration,
+// used as a backend address pool's backendIPConfigurations reference.
+func nicIPConfigID(subscription, resourceGroup, nicName, configName string) string {
+	return "/subscriptions/" + subscription +
+		"/resourceGroups/" + resourceGroup +
+		"/providers/" + providerName + "/networkInterfaces/" +
+		nicName + "/ipConfigurations/" + configName
 }
 
 // isLBsType reports whether the ARM resource type is loadBalancers,

--- a/server/azure/loadbalancer/nic_backend_pool_e2e_test.go
+++ b/server/azure/loadbalancer/nic_backend_pool_e2e_test.go
@@ -1,0 +1,292 @@
+package loadbalancer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// backendPoolARMID builds the ARM resource id of a load balancer's backend
+// address pool, the value a NIC ipConfiguration references to join the pool.
+func backendPoolARMID(lbName, pool string) string {
+	return "/subscriptions/" + testSub + "/resourceGroups/" + testRG +
+		"/providers/Microsoft.Network/loadBalancers/" + lbName + "/backendAddressPools/" + pool
+}
+
+// ipConfigARMID builds the ARM resource id of a NIC ipConfiguration, the value
+// a backend address pool projects back in its backendIPConfigurations.
+func ipConfigARMID(nicName, configName string) string {
+	return "/subscriptions/" + testSub + "/resourceGroups/" + testRG +
+		"/providers/Microsoft.Network/networkInterfaces/" + nicName + "/ipConfigurations/" + configName
+}
+
+// newInterfacesClient builds an armnetwork InterfacesClient pointed at the same
+// in-memory server as the load-balancer clients, so a NIC and a load balancer
+// created in one test share one driver instance.
+func newInterfacesClient(t *testing.T, srv lbServer) *armnetwork.InterfacesClient {
+	t.Helper()
+
+	client, err := armnetwork.NewInterfacesClient(testSub, fakeCred{}, srv.Opts)
+	if err != nil {
+		t.Fatalf("NewInterfacesClient: %v", err)
+	}
+
+	return client
+}
+
+// putNICWithPools creates or updates a NIC whose single ipConfiguration
+// references the given backend address pool ids.
+func putNICWithPools(
+	t *testing.T, nics *armnetwork.InterfacesClient, nicName, configName string, poolIDs ...string,
+) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	pools := make([]*armnetwork.BackendAddressPool, 0, len(poolIDs))
+	for _, id := range poolIDs {
+		pools = append(pools, &armnetwork.BackendAddressPool{ID: to.Ptr(id)})
+	}
+
+	poller, err := nics.BeginCreateOrUpdate(ctx, testRG, nicName, armnetwork.Interface{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr(configName),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					PrivateIPAllocationMethod:       to.Ptr(armnetwork.IPAllocationMethodDynamic),
+					LoadBalancerBackendAddressPools: pools,
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate NIC %q: %v", nicName, err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll NIC %q: %v", nicName, err)
+	}
+}
+
+// nicPoolIDs returns the backend-pool ids the NIC's first ipConfiguration
+// currently references (loadBalancerBackendAddressPools).
+func nicPoolIDs(t *testing.T, nics *armnetwork.InterfacesClient, nicName string) []string {
+	t.Helper()
+
+	got, err := nics.Get(context.Background(), testRG, nicName, nil)
+	if err != nil {
+		t.Fatalf("Get NIC %q: %v", nicName, err)
+	}
+
+	if got.Properties == nil || len(got.Properties.IPConfigurations) == 0 {
+		t.Fatalf("NIC %q has no ipConfigurations", nicName)
+	}
+
+	cfg := got.Properties.IPConfigurations[0]
+	if cfg.Properties == nil {
+		return nil
+	}
+
+	out := make([]string, 0, len(cfg.Properties.LoadBalancerBackendAddressPools))
+	for _, p := range cfg.Properties.LoadBalancerBackendAddressPools {
+		if p != nil && p.ID != nil {
+			out = append(out, *p.ID)
+		}
+	}
+
+	return out
+}
+
+// poolMemberIDs returns the ipConfiguration ids a backend pool reports as
+// members (backendIPConfigurations), read via the standalone pools client.
+func poolMemberIDs(t *testing.T, pools *armnetwork.LoadBalancerBackendAddressPoolsClient, lbName, poolName string) []string {
+	t.Helper()
+
+	got, err := pools.Get(context.Background(), testRG, lbName, poolName, nil)
+	if err != nil {
+		t.Fatalf("Get pool %q: %v", poolName, err)
+	}
+
+	if got.Properties == nil {
+		return nil
+	}
+
+	out := make([]string, 0, len(got.Properties.BackendIPConfigurations))
+	for _, ipc := range got.Properties.BackendIPConfigurations {
+		if ipc != nil && ipc.ID != nil {
+			out = append(out, *ipc.ID)
+		}
+	}
+
+	return out
+}
+
+func containsID(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestSDKNICBackendPoolMembershipReflectsBothSides proves the NIC ipConfig ↔ LB
+// backend-pool association is reflected on BOTH sides: after a NIC ipConfig
+// joins a pool, GET NIC lists the pool in loadBalancerBackendAddressPools AND
+// GET pool lists the ipConfig in backendIPConfigurations.
+func TestSDKNICBackendPoolMembershipReflectsBothSides(t *testing.T) {
+	srv := newLBServer(t)
+	ctx := context.Background()
+
+	lb, err := armnetwork.NewLoadBalancersClient(testSub, fakeCred{}, srv.Opts)
+	if err != nil {
+		t.Fatalf("NewLoadBalancersClient: %v", err)
+	}
+
+	pools, err := armnetwork.NewLoadBalancerBackendAddressPoolsClient(testSub, fakeCred{}, srv.Opts)
+	if err != nil {
+		t.Fatalf("NewLoadBalancerBackendAddressPoolsClient: %v", err)
+	}
+
+	nics := newInterfacesClient(t, srv)
+
+	const (
+		lbName   = "lb-nic"
+		poolName = "pool1"
+		nicName  = "nic1"
+		cfgName  = "ipcfg1"
+	)
+
+	poller, err := lb.BeginCreateOrUpdate(ctx, testRG, lbName, armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{
+			BackendAddressPools: []*armnetwork.BackendAddressPool{{Name: to.Ptr(poolName)}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create LB: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll LB: %v", err)
+	}
+
+	poolID := backendPoolARMID(lbName, poolName)
+	ipCfgID := ipConfigARMID(nicName, cfgName)
+
+	putNICWithPools(t, nics, nicName, cfgName, poolID)
+
+	// Forward direction: GET NIC shows the pool.
+	if got := nicPoolIDs(t, nics, nicName); !containsID(got, poolID) {
+		t.Fatalf("NIC ipConfig loadBalancerBackendAddressPools = %v, want to contain %q", got, poolID)
+	}
+
+	// Reverse direction: GET pool shows the ipConfig.
+	if got := poolMemberIDs(t, pools, lbName, poolName); !containsID(got, ipCfgID) {
+		t.Fatalf("pool backendIPConfigurations = %v, want to contain %q", got, ipCfgID)
+	}
+
+	// The whole-LB GET projects the same membership onto the nested pool.
+	lbGot, err := lb.Get(ctx, testRG, lbName, nil)
+	if err != nil {
+		t.Fatalf("Get LB: %v", err)
+	}
+
+	var found bool
+
+	for _, p := range lbGot.Properties.BackendAddressPools {
+		if p.Name == nil || *p.Name != poolName || p.Properties == nil {
+			continue
+		}
+
+		for _, ipc := range p.Properties.BackendIPConfigurations {
+			if ipc != nil && ipc.ID != nil && *ipc.ID == ipCfgID {
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		t.Fatalf("whole-LB GET pool %q did not project ipConfig %q in backendIPConfigurations", poolName, ipCfgID)
+	}
+}
+
+// TestSDKNICBackendPoolMembershipClearedBothSides proves that removing the
+// association — by re-PUTting the NIC without the pool ref, or by deleting the
+// NIC — clears it on BOTH sides.
+func TestSDKNICBackendPoolMembershipClearedBothSides(t *testing.T) {
+	srv := newLBServer(t)
+	ctx := context.Background()
+
+	lb, err := armnetwork.NewLoadBalancersClient(testSub, fakeCred{}, srv.Opts)
+	if err != nil {
+		t.Fatalf("NewLoadBalancersClient: %v", err)
+	}
+
+	pools, err := armnetwork.NewLoadBalancerBackendAddressPoolsClient(testSub, fakeCred{}, srv.Opts)
+	if err != nil {
+		t.Fatalf("NewLoadBalancerBackendAddressPoolsClient: %v", err)
+	}
+
+	nics := newInterfacesClient(t, srv)
+
+	const (
+		lbName   = "lb-nic2"
+		poolName = "pool1"
+		nicName  = "nic1"
+		cfgName  = "ipcfg1"
+	)
+
+	poller, err := lb.BeginCreateOrUpdate(ctx, testRG, lbName, armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{
+			BackendAddressPools: []*armnetwork.BackendAddressPool{{Name: to.Ptr(poolName)}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create LB: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll LB: %v", err)
+	}
+
+	poolID := backendPoolARMID(lbName, poolName)
+	ipCfgID := ipConfigARMID(nicName, cfgName)
+
+	// Associate, then disassociate by re-PUTting the NIC without the pool.
+	putNICWithPools(t, nics, nicName, cfgName, poolID)
+	putNICWithPools(t, nics, nicName, cfgName)
+
+	if got := nicPoolIDs(t, nics, nicName); len(got) != 0 {
+		t.Fatalf("after clearing, NIC loadBalancerBackendAddressPools = %v, want empty", got)
+	}
+
+	if got := poolMemberIDs(t, pools, lbName, poolName); containsID(got, ipCfgID) {
+		t.Fatalf("after clearing, pool backendIPConfigurations = %v, still contains %q", got, ipCfgID)
+	}
+
+	// Re-associate, then delete the NIC entirely; the pool must drop the member.
+	putNICWithPools(t, nics, nicName, cfgName, poolID)
+
+	if got := poolMemberIDs(t, pools, lbName, poolName); !containsID(got, ipCfgID) {
+		t.Fatalf("after re-associate, pool backendIPConfigurations = %v, want to contain %q", got, ipCfgID)
+	}
+
+	delPoller, err := nics.BeginDelete(ctx, testRG, nicName, nil)
+	if err != nil {
+		t.Fatalf("BeginDelete NIC: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll delete NIC: %v", err)
+	}
+
+	if got := poolMemberIDs(t, pools, lbName, poolName); containsID(got, ipCfgID) {
+		t.Fatalf("after NIC delete, pool backendIPConfigurations = %v, still contains %q", got, ipCfgID)
+	}
+}

--- a/server/azure/loadbalancer/operations.go
+++ b/server/azure/loadbalancer/operations.go
@@ -56,7 +56,7 @@ func (h *Handler) createOrUpdateLoadBalancer(w http.ResponseWriter, r *http.Requ
 	// load balancer; its rich shape lives in the native store.
 	h.syncGenericLB(r.Context(), rp.ResourceName, &body)
 
-	azurearm.WriteJSON(w, http.StatusOK, toLBJSON(rp, stored))
+	azurearm.WriteJSON(w, http.StatusOK, toLBJSON(rp, stored, h.poolMembers(r.Context(), rp.Subscription)))
 }
 
 func (h *Handler) getLoadBalancer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
@@ -72,7 +72,7 @@ func (h *Handler) getLoadBalancer(w http.ResponseWriter, r *http.Request, rp *az
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toLBJSON(rp, stored))
+	azurearm.WriteJSON(w, http.StatusOK, toLBJSON(rp, stored, h.poolMembers(r.Context(), rp.Subscription)))
 }
 
 // deleteLoadBalancer removes the load balancer from both the native store and
@@ -110,13 +110,15 @@ func (h *Handler) listLoadBalancers(w http.ResponseWriter, r *http.Request, rp *
 		return
 	}
 
+	members := h.poolMembers(r.Context(), rp.Subscription)
+
 	out := lbListResult{Value: make([]loadBalancerJSON, 0, len(stored))}
 
 	for i := range stored {
 		scope := *rp
 		scope.ResourceGroup = stored[i].ResourceGroup
 		scope.ResourceName = stored[i].Name
-		out.Value = append(out.Value, toLBJSON(&scope, &stored[i]))
+		out.Value = append(out.Value, toLBJSON(&scope, &stored[i], members))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, out)
@@ -326,14 +328,16 @@ func buildOutboundRules(in []outboundRuleJSON) []lbdriver.AzureLBOutboundRule {
 // --- native model → response ---
 
 // toLBJSON reconstructs the nested ARM load balancer body from the stored
-// native model, stamping ids, etags and terminal provisioning states.
-func toLBJSON(rp *azurearm.ResourcePath, lb *lbdriver.AzureLoadBalancer) loadBalancerJSON {
+// native model, stamping ids, etags and terminal provisioning states. members
+// maps a backend pool's ARM id to the ipConfigurations that joined it (nil when
+// membership projection is unavailable).
+func toLBJSON(rp *azurearm.ResourcePath, lb *lbdriver.AzureLoadBalancer, members map[string][]string) loadBalancerJSON {
 	lbID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeLBs, rp.ResourceName)
 
 	props := &loadBalancerProps{
 		ProvisioningState:        provisioningStateSucceeded,
 		FrontendIPConfigurations: frontendsJSON(lbID, lb.Frontends),
-		BackendAddressPools:      poolsJSON(lbID, lb.BackendPools),
+		BackendAddressPools:      poolsJSON(lbID, lb.BackendPools, members),
 		Probes:                   probesJSON(lbID, lb.Probes),
 		LoadBalancingRules:       rulesJSON(lbID, lb.Rules),
 		InboundNatRules:          natRulesJSON(lbID, lb.NatRules),
@@ -381,14 +385,20 @@ func frontendsJSON(lbID string, in []lbdriver.AzureLBFrontend) []frontendIPJSON 
 	return out
 }
 
-func poolsJSON(lbID string, names []string) []backendPoolJSON {
+func poolsJSON(lbID string, names []string, members map[string][]string) []backendPoolJSON {
 	out := make([]backendPoolJSON, 0, len(names))
 
 	for _, name := range names {
 		id := lbID + "/backendAddressPools/" + name
+		props := &backendPoolProps{ProvisioningState: provisioningStateSucceeded}
+
+		for _, ipCfgID := range members[strings.ToLower(id)] {
+			props.BackendIPConfigurations = append(props.BackendIPConfigurations, subResource{ID: ipCfgID})
+		}
+
 		out = append(out, backendPoolJSON{
 			ID: id, Name: name, Type: poolResourceType, Etag: weakETag(id),
-			Properties: &backendPoolProps{ProvisioningState: provisioningStateSucceeded},
+			Properties: props,
 		})
 	}
 

--- a/server/azure/loadbalancer/subresource.go
+++ b/server/azure/loadbalancer/subresource.go
@@ -107,7 +107,9 @@ func (h *Handler) listSubResource(w http.ResponseWriter, r *http.Request, rp *az
 
 	lbID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeLBs, rp.ResourceName)
 
-	azurearm.WriteJSON(w, http.StatusOK, subResourceListResult{Value: listChildren(lbID, lb, kind)})
+	members := h.poolMembers(r.Context(), rp.Subscription)
+
+	azurearm.WriteJSON(w, http.StatusOK, subResourceListResult{Value: listChildren(lbID, lb, kind, members)})
 }
 
 // getSubResource handles GET .../loadBalancers/{name}/{kind}/{childName} — the
@@ -127,7 +129,7 @@ func (h *Handler) getSubResource(w http.ResponseWriter, r *http.Request, rp *azu
 
 	lbID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeLBs, rp.ResourceName)
 
-	child, found := findChild(lbID, lb, kind, rp.SubResourceName)
+	child, found := findChild(lbID, lb, kind, rp.SubResourceName, h.poolMembers(r.Context(), rp.Subscription))
 	if !found {
 		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
 			rp.SubResource+" "+rp.SubResourceName+" not found")
@@ -161,7 +163,7 @@ func (h *Handler) putSubResource(w http.ResponseWriter, r *http.Request, rp *azu
 
 	switch kind {
 	case kindBackendAddressPools:
-		putBackendPool(w, r, rp, az, lbID)
+		h.putBackendPool(w, r, rp, az, lbID)
 	case kindInboundNatRules:
 		putNatRule(w, r, rp, az, lbID)
 	case kindUnknown, kindFrontendIPConfigurations, kindLoadBalancingRules, kindProbes, kindOutboundRules:
@@ -169,7 +171,7 @@ func (h *Handler) putSubResource(w http.ResponseWriter, r *http.Request, rp *azu
 	}
 }
 
-func putBackendPool(
+func (h *Handler) putBackendPool(
 	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, az lbdriver.AzureLoadBalancers, lbID string,
 ) {
 	var body backendPoolJSON
@@ -183,7 +185,8 @@ func putBackendPool(
 		return
 	}
 
-	child, found := findChild(lbID, lb, kindBackendAddressPools, rp.SubResourceName)
+	child, found := findChild(lbID, lb, kindBackendAddressPools, rp.SubResourceName,
+		h.poolMembers(r.Context(), rp.Subscription))
 	if !found {
 		azurearm.WriteError(w, http.StatusInternalServerError, "InternalError", "backend address pool not found after create")
 		return
@@ -211,7 +214,7 @@ func putNatRule(
 		return
 	}
 
-	child, found := findChild(lbID, lb, kindInboundNatRules, rp.SubResourceName)
+	child, found := findChild(lbID, lb, kindInboundNatRules, rp.SubResourceName, nil)
 	if !found {
 		azurearm.WriteError(w, http.StatusInternalServerError, "InternalError", "inbound NAT rule not found after create")
 		return
@@ -257,13 +260,14 @@ func (h *Handler) deleteSubResource(w http.ResponseWriter, r *http.Request, rp *
 }
 
 // listChildren builds the full JSON slice for kind from lb, for the
-// collection-list response envelope.
-func listChildren(lbID string, lb *lbdriver.AzureLoadBalancer, kind subResourceKind) any {
+// collection-list response envelope. members supplies backend-pool membership
+// (nil when unavailable).
+func listChildren(lbID string, lb *lbdriver.AzureLoadBalancer, kind subResourceKind, members map[string][]string) any {
 	switch kind {
 	case kindFrontendIPConfigurations:
 		return frontendsJSON(lbID, lb.Frontends)
 	case kindBackendAddressPools:
-		return poolsJSON(lbID, lb.BackendPools)
+		return poolsJSON(lbID, lb.BackendPools, members)
 	case kindLoadBalancingRules:
 		return rulesJSON(lbID, lb.Rules)
 	case kindProbes:
@@ -280,13 +284,16 @@ func listChildren(lbID string, lb *lbdriver.AzureLoadBalancer, kind subResourceK
 }
 
 // findChild locates the single named child of kind on lb and returns its JSON
-// representation. found is false when no child of that name exists.
-func findChild(lbID string, lb *lbdriver.AzureLoadBalancer, kind subResourceKind, name string) (any, bool) {
+// representation. found is false when no child of that name exists. members
+// supplies backend-pool membership (nil when unavailable).
+func findChild(
+	lbID string, lb *lbdriver.AzureLoadBalancer, kind subResourceKind, name string, members map[string][]string,
+) (any, bool) {
 	switch kind {
 	case kindFrontendIPConfigurations:
 		return findFrontend(lbID, lb.Frontends, name)
 	case kindBackendAddressPools:
-		return findPool(lbID, lb.BackendPools, name)
+		return findPool(lbID, lb.BackendPools, name, members)
 	case kindLoadBalancingRules:
 		return findRule(lbID, lb.Rules, name)
 	case kindProbes:
@@ -312,10 +319,10 @@ func findFrontend(lbID string, in []lbdriver.AzureLBFrontend, name string) (any,
 	return nil, false
 }
 
-func findPool(lbID string, in []string, name string) (any, bool) {
+func findPool(lbID string, in []string, name string, members map[string][]string) (any, bool) {
 	for _, p := range in {
 		if p == name {
-			return poolsJSON(lbID, []string{p})[0], true
+			return poolsJSON(lbID, []string{p}, members)[0], true
 		}
 	}
 

--- a/server/azure/loadbalancer/types.go
+++ b/server/azure/loadbalancer/types.go
@@ -47,7 +47,13 @@ type subResource struct {
 // --- backend address pools (→ pool names) ---
 
 type backendPoolProps struct {
-	ProvisioningState string `json:"provisioningState,omitempty"`
+	// BackendIPConfigurations is the read-only set of NIC ipConfiguration
+	// references that have joined this pool (BackendAddressPoolPropertiesFormat.
+	// backendIPConfigurations). It is projected on read from the NIC side of the
+	// association rather than stored on the pool, so it always agrees with each
+	// NIC's loadBalancerBackendAddressPools.
+	BackendIPConfigurations []subResource `json:"backendIPConfigurations,omitempty"`
+	ProvisioningState       string        `json:"provisioningState,omitempty"`
 }
 
 type backendPoolJSON struct {

--- a/server/azure/vnet/network_interface.go
+++ b/server/azure/vnet/network_interface.go
@@ -36,11 +36,12 @@ type nicIPConfigRequest struct {
 }
 
 type nicIPConfigRequestProps struct {
-	PrivateIPAddress          string    `json:"privateIPAddress,omitempty"`
-	PrivateIPAllocationMethod string    `json:"privateIPAllocationMethod,omitempty"`
-	Primary                   bool      `json:"primary,omitempty"`
-	Subnet                    *armIDRef `json:"subnet,omitempty"`
-	PublicIPAddress           *armIDRef `json:"publicIPAddress,omitempty"`
+	PrivateIPAddress                string     `json:"privateIPAddress,omitempty"`
+	PrivateIPAllocationMethod       string     `json:"privateIPAllocationMethod,omitempty"`
+	Primary                         bool       `json:"primary,omitempty"`
+	Subnet                          *armIDRef  `json:"subnet,omitempty"`
+	PublicIPAddress                 *armIDRef  `json:"publicIPAddress,omitempty"`
+	LoadBalancerBackendAddressPools []armIDRef `json:"loadBalancerBackendAddressPools,omitempty"`
 }
 
 type armIDRef struct {
@@ -73,12 +74,13 @@ type nicIPConfigResponse struct {
 }
 
 type nicIPConfigResponseProps struct {
-	ProvisioningState         string    `json:"provisioningState"`
-	PrivateIPAddress          string    `json:"privateIPAddress,omitempty"`
-	PrivateIPAllocationMethod string    `json:"privateIPAllocationMethod"`
-	Primary                   bool      `json:"primary"`
-	Subnet                    *armIDRef `json:"subnet,omitempty"`
-	PublicIPAddress           *armIDRef `json:"publicIPAddress,omitempty"`
+	ProvisioningState               string     `json:"provisioningState"`
+	PrivateIPAddress                string     `json:"privateIPAddress,omitempty"`
+	PrivateIPAllocationMethod       string     `json:"privateIPAllocationMethod"`
+	Primary                         bool       `json:"primary"`
+	Subnet                          *armIDRef  `json:"subnet,omitempty"`
+	PublicIPAddress                 *armIDRef  `json:"publicIPAddress,omitempty"`
+	LoadBalancerBackendAddressPools []armIDRef `json:"loadBalancerBackendAddressPools,omitempty"`
 }
 
 type nicListResponse struct {
@@ -265,6 +267,7 @@ func (h *Handler) buildIPConfigs(ctx context.Context, rg, nicName string, in []n
 			PrivateIP:        p.PrivateIPAddress,
 			AllocationMethod: p.PrivateIPAllocationMethod,
 			Primary:          p.Primary,
+			LBBackendPoolIDs: backendPoolIDs(p.LoadBalancerBackendAddressPools),
 		}
 
 		if p.Subnet != nil {
@@ -300,6 +303,30 @@ func (h *Handler) buildIPConfigs(ctx context.Context, rg, nicName string, in []n
 	}
 
 	return out, nil
+}
+
+// backendPoolIDs extracts the referenced load-balancer backend-pool ARM ids
+// from an ipConfiguration's loadBalancerBackendAddressPools, dropping empty
+// references. It returns nil when none are present so an unassociated
+// ipConfiguration carries no membership.
+func backendPoolIDs(refs []armIDRef) []string {
+	if len(refs) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(refs))
+
+	for i := range refs {
+		if refs[i].ID != "" {
+			out = append(out, refs[i].ID)
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
 }
 
 // checkPublicIPNotAttached rejects attaching armID to (rg, nicName) when it is
@@ -412,6 +439,11 @@ func toNICResponse(nic *netdriver.AzureNIC, rp azurearm.ResourcePath) nicRespons
 
 		if c.PublicIPID != "" {
 			rc.Properties.PublicIPAddress = &armIDRef{ID: c.PublicIPID}
+		}
+
+		for _, poolID := range c.LBBackendPoolIDs {
+			rc.Properties.LoadBalancerBackendAddressPools = append(
+				rc.Properties.LoadBalancerBackendAddressPools, armIDRef{ID: poolID})
 		}
 
 		out.Properties.IPConfigurations = append(out.Properties.IPConfigurations, rc)

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -379,6 +379,14 @@ type AzureIPConfig struct {
 	AllocationMethod string // "Dynamic" (default) or "Static"
 	PublicIPID       string // ARM resource id of an associated public IP, optional
 	Primary          bool
+	// LBBackendPoolIDs are the ARM resource ids of the load-balancer backend
+	// address pools this ipConfiguration has joined
+	// (properties.loadBalancerBackendAddressPools). This is the single source of
+	// truth for NIC↔LB backend-pool membership: the NIC echoes these back on
+	// GET, and a load balancer projects each backend pool's read-only
+	// backendIPConfigurations by reverse-lookup against this field, so both
+	// sides of the association resolve consistently from one stored reference.
+	LBBackendPoolIDs []string
 }
 
 // AzureNICConfig is the create-or-update payload for an Azure network interface.


### PR DESCRIPTION
## What

Fixes the Azure **NIC ipConfig ↔ Load Balancer backend-pool membership** bug (deep-audit finding NEW-1, HIGH). Associating a NIC ipConfiguration with an LB backend address pool was a two-way no-op: `GET networkInterface` never showed the pool, and `GET backendAddressPool` never showed the ipConfig — so Terraform's `azurerm_network_interface_backend_address_pool_association`, a NIC ipConfig with `loadBalancerBackendAddressPools`, and `az network nic ip-config address-pool add` all silently dropped the link (perpetual diff; pool membership impossible to reason about).

Root cause: the NIC ipConfig wire struct had no `loadBalancerBackendAddressPools` field (discarded at decode), and the LB backend pool was modeled as `[]string` pool names with no `backendIPConfigurations`.

## Why / approach (3-layer, single source of truth)

The membership is threaded through the driver model rather than blind-echoed, with one source of truth so both sides always agree:

- **Driver:** `AzureIPConfig` gains `LBBackendPoolIDs []string` — the ARM ids of the backend pools an ipConfiguration has joined.
- **NIC wire (forward):** the ipConfig request/response carry `loadBalancerBackendAddressPools`; the value is stored on and echoed from the NIC.
- **LB wire (reverse):** a backend pool projects its read-only `backendIPConfigurations` by reverse-lookup against the NIC side (via the networking driver, wired into the LB handler with `SetNICResolver`). The whole-LB GET, the pool list, and the standalone pool GET all project the same membership.

Because the pool derives its members from the NIC, clearing the NIC (re-PUT without the ref, or deleting the NIC) clears both directions with no sync/drift. When only the LB driver is configured, pools simply report no members.

ARM shapes verified against `armnetwork` (`InterfaceIPConfigurationPropertiesFormat.loadBalancerBackendAddressPools`, `BackendAddressPoolPropertiesFormat.backendIPConfigurations`). No driver interface method changed, so `docs/coverage` is unchanged.

## Tests

New real-`armnetwork` e2e tests in `server/azure/loadbalancer`:

- `TestSDKNICBackendPoolMembershipReflectsBothSides` — after a NIC ipConfig joins a pool, `GET NIC` lists the pool in `loadBalancerBackendAddressPools` **and** `GET pool` / whole-LB GET list the ipConfig in `backendIPConfigurations`.
- `TestSDKNICBackendPoolMembershipClearedBothSides` — re-PUT without the ref clears both sides, and deleting the NIC drops it from the pool.

Gates: build, vet, scoped tests (`server/azure/{networking,loadbalancer}`, `providers/azure/{networking,loadbalancer}`), `-race` on the new cross-service reads, gofmt, and golangci-lint on changed packages all green (zero new issues).
