### PR TITLE
fix(azure-rm): cascade resource-group delete + scope network reads to their RG

### DIFF
--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -211,10 +211,39 @@ func New(d Drivers) http.Handler {
 	// before the permissive blob fallback so it isn't swallowed as a blob call.
 	srv.Register(tenants.New(tenantID))
 
+	// Build the per-service handlers that own resource-group-scoped resources up
+	// front so they can be handed to the resource-group cascade below and then
+	// registered at their normal positions. A resource group is a pure
+	// container, so deleting it must delete the resources created under it;
+	// each of these handlers implements ResourceGroupPurger to tear its own
+	// resources down. Other resource types are not cascaded yet.
+	var (
+		vnetHandler    *vnet.Handler
+		vmHandler      *virtualmachines.Handler
+		storageHandler *storageaccountsrv.Handler
+		rgPurgers      []resourcegroups.ResourceGroupPurger
+	)
+
+	if d.Network != nil {
+		vnetHandler = vnet.New(d.Network)
+		rgPurgers = append(rgPurgers, vnetHandler)
+	}
+
+	if d.VirtualMachines != nil {
+		vmHandler = virtualmachines.New(d.VirtualMachines, d.Network)
+		rgPurgers = append(rgPurgers, vmHandler)
+	}
+
+	if d.BlobStorage != nil {
+		storageHandler = storageaccountsrv.New(d.BlobStorage)
+		rgPurgers = append(rgPurgers, storageHandler)
+	}
+
 	// Resource groups have no driver of their own: they are containers, and the
 	// emulator tracks membership by the ids resources already carry. The
-	// discovery engine (nil-safe) lets exportTemplate enumerate that membership.
-	srv.Register(resourcegroups.New(d.ResourceDiscovery))
+	// discovery engine (nil-safe) lets exportTemplate enumerate that membership;
+	// the purgers cascade a group delete into its resources.
+	srv.Register(resourcegroups.New(d.ResourceDiscovery, rgPurgers...))
 
 	// microsoft.insights extension resources (metrics, metricDefinitions,
 	// diagnosticSettings) hang off an arbitrary resource URI, so they must claim
@@ -264,8 +293,8 @@ func New(d Drivers) http.Handler {
 		srv.Register(cosmospostgresql.New(d.CosmosPostgreSQL))
 	}
 
-	if d.Network != nil {
-		srv.Register(vnet.New(d.Network))
+	if vnetHandler != nil {
+		srv.Register(vnetHandler)
 	}
 
 	// Azure DNS shares the Microsoft.Network ARM provider with the network
@@ -396,8 +425,8 @@ func New(d Drivers) http.Handler {
 		srv.Register(azuresearchserver.NewDataPlane(d.SearchDataPlane))
 	}
 
-	if d.VirtualMachines != nil {
-		srv.Register(virtualmachines.New(d.VirtualMachines, d.Network))
+	if vmHandler != nil {
+		srv.Register(vmHandler)
 	}
 
 	// Kubernetes data-plane API. Matches /k8s/{uid}/... — disjoint from every
@@ -478,8 +507,8 @@ func New(d Drivers) http.Handler {
 	// Claims only the /providers/Microsoft.Storage/storageAccounts/ management
 	// path (which starts with /subscriptions/), disjoint from the blob
 	// data-plane fallback below, so it must register before that fallback.
-	if d.BlobStorage != nil {
-		srv.Register(storageaccountsrv.New(d.BlobStorage))
+	if storageHandler != nil {
+		srv.Register(storageHandler)
 	}
 
 	// BlobStorage handler is the data-plane fallback for non-ARM URLs. It

--- a/server/azure/resourcegroups/cascade_test.go
+++ b/server/azure/resourcegroups/cascade_test.go
@@ -1,0 +1,126 @@
+// Deep-audit regression (N1): deleting a resource group did not cascade to the
+// resources created under it. A teardown "succeeded" (the group vanished) while
+// every storage account, virtual network, etc. inside it stayed alive and
+// globally addressable — leaking resources and colliding on the next apply. A
+// resource group is a pure container, so its delete must remove the resources
+// it holds.
+
+package resourcegroups_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func armOpts(ts *httptest.Server) *arm.ClientOptions {
+	return &arm.ClientOptions{ClientOptions: azcore.ClientOptions{
+		Cloud: cloud.Configuration{Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		}},
+		Transport: ts.Client(),
+		Retry:     policy.RetryOptions{MaxRetries: -1},
+	}}
+}
+
+func statusCode(t *testing.T, err error) int {
+	t.Helper()
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("expected an azcore.ResponseError, got %v", err)
+	}
+
+	return respErr.StatusCode
+}
+
+// TestResourceGroupDeleteCascades creates a resource group with a storage
+// account and a virtual network inside it (through the real ARM wire API), then
+// deletes the group and asserts both contained resources are gone (404), not
+// merely the group.
+func TestResourceGroupDeleteCascades(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	ts := httptest.NewTLSServer(azureserver.NewFromProvider(cloudP))
+	t.Cleanup(ts.Close)
+
+	opts := armOpts(ts)
+
+	rgClient, err := armresources.NewResourceGroupsClient(subID, fakeCred{}, opts)
+	require.NoError(t, err)
+
+	storageClient, err := armstorage.NewAccountsClient(subID, fakeCred{}, opts)
+	require.NoError(t, err)
+
+	vnetClient, err := armnetwork.NewVirtualNetworksClient(subID, fakeCred{}, opts)
+	require.NoError(t, err)
+
+	const rg = "rg-cascade"
+
+	_, err = rgClient.CreateOrUpdate(ctx, rg, armresources.ResourceGroup{Location: to.Ptr("eastus")}, nil)
+	require.NoError(t, err)
+
+	// Storage account inside the group.
+	saPoller, err := storageClient.BeginCreate(ctx, rg, "sacascade", armstorage.AccountCreateParameters{
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		Location: to.Ptr("eastus"),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+	}, nil)
+	require.NoError(t, err)
+	_, err = saPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	require.NoError(t, err)
+
+	// Virtual network inside the group.
+	vnetPoller, err := vnetClient.BeginCreateOrUpdate(ctx, rg, "vnetcascade", armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+		},
+	}, nil)
+	require.NoError(t, err)
+	_, err = vnetPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	require.NoError(t, err)
+
+	// Both resources are reachable before the group delete.
+	_, err = storageClient.GetProperties(ctx, rg, "sacascade", nil)
+	require.NoError(t, err, "storage account should exist before RG delete")
+
+	_, err = vnetClient.Get(ctx, rg, "vnetcascade", nil)
+	require.NoError(t, err, "vnet should exist before RG delete")
+
+	// Delete the resource group.
+	delPoller, err := rgClient.BeginDelete(ctx, rg, nil)
+	require.NoError(t, err)
+	_, err = delPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	require.NoError(t, err)
+
+	// The contained resources must be gone, not just the group.
+	if _, gerr := storageClient.GetProperties(ctx, rg, "sacascade", nil); gerr == nil {
+		t.Fatal("storage account survived resource-group delete (no cascade)")
+	} else if code := statusCode(t, gerr); code != 404 {
+		t.Fatalf("storage account after RG delete: status %d, want 404", code)
+	}
+
+	if _, gerr := vnetClient.Get(ctx, rg, "vnetcascade", nil); gerr == nil {
+		t.Fatal("vnet survived resource-group delete (no cascade)")
+	} else if code := statusCode(t, gerr); code != 404 {
+		t.Fatalf("vnet after RG delete: status %d, want 404", code)
+	}
+}

--- a/server/azure/resourcegroups/handler.go
+++ b/server/azure/resourcegroups/handler.go
@@ -43,6 +43,17 @@ const (
 	partsOperation  = 4 // /subscriptions/{sub}/operationresults/{id}
 )
 
+// ResourceGroupPurger deletes every resource one service handler owns in a given
+// resource group. It backs the resource-group cascade delete: an RG is a pure
+// container, so deleting it must delete the resources created under it rather
+// than leaving them as globally addressable orphans. Each per-service ARM
+// handler that stores its resources resource-group-scoped (compute, networking,
+// storage today) implements it; a handler that does not is simply not passed to
+// New, so its resource type is not cascaded (a documented, extensible gap).
+type ResourceGroupPurger interface {
+	PurgeResourceGroup(ctx context.Context, subscription, resourceGroup string) error
+}
+
 // Handler serves the resource-group collection and its members.
 type Handler struct {
 	mu sync.RWMutex
@@ -57,13 +68,17 @@ type Handler struct {
 	// from. Nil disables exportTemplate's resource enumeration (it still
 	// returns a valid, empty template) — callers that don't wire discovery.
 	engine *resourcediscovery.Engine
+	// purgers cascade a resource-group delete into the resources it contains.
+	purgers []ResourceGroupPurger
 }
 
 // New returns a resource-group handler. engine is the cross-service inventory
 // engine exportTemplate enumerates a group's resources from; nil is accepted
-// (exportTemplate then reports an empty resources[]).
-func New(engine *resourcediscovery.Engine) *Handler {
-	return &Handler{groups: map[string]map[string]map[string]any{}, engine: engine}
+// (exportTemplate then reports an empty resources[]). purgers cascade a group
+// delete into the resources created under it; pass the per-service handlers
+// that own resource-group-scoped resources.
+func New(engine *resourcediscovery.Engine, purgers ...ResourceGroupPurger) *Handler {
+	return &Handler{groups: map[string]map[string]map[string]any{}, engine: engine, purgers: purgers}
 }
 
 // routeKind classifies a resource-group request path.
@@ -272,12 +287,29 @@ func (h *Handler) remove(w http.ResponseWriter, r *http.Request, sub, name strin
 		return
 	}
 
+	// Cascade: a resource group is a container, so deleting it deletes every
+	// resource created under it. Each purger tears down its own service's
+	// resources in this group; a purge failure is best-effort (the group is
+	// already gone and the ARM delete contract is a fire-and-forget 202), so it
+	// does not fail the response.
+	h.cascade(r.Context(), sub, name)
+
 	// Real ARM deletes a resource group asynchronously: 202 with a Location the
 	// SDK polls until it returns a terminal status. The delete already ran in
 	// memory, so the poll endpoint reports success immediately.
 	w.Header().Set("Location", absoluteURL(r, "/subscriptions/"+sub+"/operationresults/"+strings.ToLower(name)))
 	w.Header().Set("Retry-After", "0")
 	w.WriteHeader(http.StatusAccepted)
+}
+
+// cascade fans a resource-group delete out to every registered purger so the
+// resources created under the group are torn down with it. Best-effort: a
+// purger error is swallowed (there is no channel to report it on an async
+// fire-and-forget delete, and a partial teardown must not block the rest).
+func (h *Handler) cascade(ctx context.Context, sub, name string) {
+	for _, p := range h.purgers {
+		_ = p.PurgeResourceGroup(ctx, sub, name)
+	}
 }
 
 // exportTemplateRequest is the exportTemplate POST body: see

--- a/server/azure/storageaccount/handler.go
+++ b/server/azure/storageaccount/handler.go
@@ -264,7 +264,9 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 		return
 	}
 
-	attrs := storagedriver.AccountAttributes{Kind: body.Kind, Location: body.Location, Tags: body.Tags}
+	attrs := storagedriver.AccountAttributes{
+		Kind: body.Kind, Location: body.Location, ResourceGroup: rp.ResourceGroup, Tags: body.Tags,
+	}
 	if body.SKU != nil {
 		attrs.SKU = body.SKU.Name
 	}
@@ -322,7 +324,9 @@ func (h *Handler) update(w http.ResponseWriter, r *http.Request, rp *azurearm.Re
 		if _, err := h.attrs.UpdateBucketAttributes(r.Context(), rp.ResourceName, func(
 			cur storagedriver.AccountAttributes,
 		) storagedriver.AccountAttributes {
-			return applyAccountUpdate(cur, &body)
+			applyAccountUpdate(&cur, &body)
+
+			return cur
 		}); err != nil {
 			azurearm.WriteCErr(w, err)
 			return
@@ -342,9 +346,9 @@ func (h *Handler) update(w http.ResponseWriter, r *http.Request, rp *azurearm.Re
 	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), rp))
 }
 
-// applyAccountUpdate merges the fields present on a PATCH body onto cur,
-// leaving every field the request omitted untouched.
-func applyAccountUpdate(cur storagedriver.AccountAttributes, body *armAccountUpdate) storagedriver.AccountAttributes {
+// applyAccountUpdate merges the fields present on a PATCH body onto cur in
+// place, leaving every field the request omitted untouched.
+func applyAccountUpdate(cur *storagedriver.AccountAttributes, body *armAccountUpdate) {
 	if body.Kind != "" {
 		cur.Kind = body.Kind
 	}
@@ -360,8 +364,6 @@ func applyAccountUpdate(cur storagedriver.AccountAttributes, body *armAccountUpd
 	if body.Properties != nil && body.Properties.AccessTier != "" {
 		cur.AccessTier = body.Properties.AccessTier
 	}
-
-	return cur
 }
 
 func (h *Handler) deleteAccount(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
@@ -371,6 +373,58 @@ func (h *Handler) deleteAccount(w http.ResponseWriter, r *http.Request, rp *azur
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+// PurgeResourceGroup deletes every storage account created under the given
+// resource group, backing the resource-group cascade delete. Accounts record
+// their group via AccountAttributes.ResourceGroup on create-or-update; a driver
+// with no attribute capability tracks no group, so nothing matches (safe). A
+// per-account delete failure is returned but does not stop the sweep; an
+// already-gone account is not an error. The subscription is unused (the
+// emulator is single-estate).
+func (h *Handler) PurgeResourceGroup(ctx context.Context, _, resourceGroup string) error {
+	if h.attrs == nil {
+		return nil
+	}
+
+	buckets, err := h.bucket.ListBuckets(ctx)
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+
+	for i := range buckets {
+		if pErr := h.purgeAccountIfInGroup(ctx, buckets[i].Name, resourceGroup); pErr != nil && firstErr == nil {
+			firstErr = pErr
+		}
+	}
+
+	return firstErr
+}
+
+// purgeAccountIfInGroup deletes one storage account when it belongs to rg, and
+// is a no-op otherwise. An account that vanished between listing and deletion is
+// not an error (the desired end state already holds).
+func (h *Handler) purgeAccountIfInGroup(ctx context.Context, name, rg string) error {
+	attrs, err := h.attrs.BucketAttributes(ctx, name)
+	if err != nil {
+		if cerrors.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	if !strings.EqualFold(attrs.ResourceGroup, rg) {
+		return nil
+	}
+
+	if err := h.bucket.DeleteBucket(ctx, name); err != nil && !cerrors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
 }
 
 func (h *Handler) bucketExists(ctx context.Context, name string) bool {

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -558,6 +558,32 @@ func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 	writeAcceptedAsync(w, r, rp.Subscription, "delete-"+rp.ResourceName)
 }
 
+// PurgeResourceGroup terminates every virtual machine created under the given
+// resource group, backing the resource-group cascade delete. Instances record
+// their group (Instance.ResourceGroup) on the ARM create path, so membership is
+// an exact match. Resource-group comparison is case-insensitive, matching ARM.
+// The subscription is unused (the emulator is single-estate).
+func (h *Handler) PurgeResourceGroup(ctx context.Context, _, resourceGroup string) error {
+	instances, err := h.compute.DescribeInstances(ctx, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	ids := make([]string, 0, len(instances))
+
+	for i := range instances {
+		if strings.EqualFold(instances[i].ResourceGroup, resourceGroup) {
+			ids = append(ids, instances[i].ID)
+		}
+	}
+
+	if len(ids) == 0 {
+		return nil
+	}
+
+	return h.compute.TerminateInstances(ctx, ids)
+}
+
 // start handles POST virtualMachines/{name}/start.
 //
 //nolint:gocritic // rp is a request-scoped value

--- a/server/azure/vnet/cross_rg_scope_test.go
+++ b/server/azure/vnet/cross_rg_scope_test.go
@@ -1,0 +1,158 @@
+// Deep-audit regression (N5): Microsoft.Network resources (virtual networks,
+// network security groups, subnets) were globally name-addressable, so a GET or
+// DELETE under the WRONG resource group returned 200 and even echoed the wrong
+// group back into the response id. A resource must be scoped to the group it was
+// created under: a read under a different group is a 404, and a same-named
+// resource in a second group is an independent object.
+
+package vnet_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func statusOf(t *testing.T, err error) int {
+	t.Helper()
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("expected an azcore.ResponseError, got %v", err)
+	}
+
+	return respErr.StatusCode
+}
+
+// TestVNetGetIsResourceGroupScoped proves a virtual network created in one
+// resource group is not readable — and not deletable — under another, and that
+// a same-named vnet in a second group is a distinct resource with its own id.
+func TestVNetGetIsResourceGroupScoped(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{Network: cloudP.VNet}))
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	client, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+		},
+	}
+
+	p, cerr := client.BeginCreateOrUpdate(ctx, "rgA", "vx", body, nil)
+	if cerr != nil {
+		t.Fatalf("create in rgA: %v", cerr)
+	}
+
+	pollDone(t, p)
+
+	// GET under the wrong resource group is a 404, not a wrong-group 200.
+	if _, gerr := client.Get(ctx, "rgB", "vx", nil); gerr == nil {
+		t.Fatal("GET vx under rgB returned success; expected 404 (cross-RG read)")
+	} else if code := statusOf(t, gerr); code != 404 {
+		t.Fatalf("GET vx under rgB: status %d, want 404", code)
+	}
+
+	// GET under the right group works and reports rgA in its id.
+	got, gerr := client.Get(ctx, "rgA", "vx", nil)
+	if gerr != nil {
+		t.Fatalf("GET vx under rgA: %v", gerr)
+	}
+
+	if got.ID == nil || !strings.Contains(strings.ToLower(*got.ID), "/resourcegroups/rga/") {
+		t.Fatalf("GET vx under rgA: id %v does not carry rgA", got.ID)
+	}
+
+	// A same-named vnet in a second group is an independent resource.
+	p2, cerr := client.BeginCreateOrUpdate(ctx, "rgB", "vx", body, nil)
+	if cerr != nil {
+		t.Fatalf("create in rgB: %v", cerr)
+	}
+
+	pollDone(t, p2)
+
+	if _, gerr := client.Get(ctx, "rgB", "vx", nil); gerr != nil {
+		t.Fatalf("GET vx under rgB after create: %v", gerr)
+	}
+
+	// An RG-scoped list returns only that group's vnet, not the same-named one
+	// from the other group.
+	var rgAvnets int
+
+	pager := client.NewListPager("rgA", nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("list rgA: %v", perr)
+		}
+
+		for _, v := range page.Value {
+			if v.Name != nil && *v.Name == "vx" {
+				rgAvnets++
+			}
+		}
+	}
+
+	if rgAvnets != 1 {
+		t.Fatalf("RG-scoped list of rgA returned %d vx entries, want 1", rgAvnets)
+	}
+
+	// DELETE under the wrong group must not remove the other group's vnet.
+	if _, derr := client.BeginDelete(ctx, "rgB", "vx", nil); derr != nil {
+		t.Fatalf("delete vx under rgB: %v", derr)
+	}
+
+	if _, gerr := client.Get(ctx, "rgA", "vx", nil); gerr != nil {
+		t.Fatalf("vx in rgA was removed by deleting vx in rgB: %v", gerr)
+	}
+}
+
+// TestNSGGetIsResourceGroupScoped proves the same resource-group scoping for
+// network security groups.
+func TestNSGGetIsResourceGroupScoped(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{Network: cloudP.VNet}))
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	client, err := armnetwork.NewSecurityGroupsClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, cerr := client.BeginCreateOrUpdate(ctx, "rgA", "nsgx", armnetwork.SecurityGroup{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if cerr != nil {
+		t.Fatalf("create nsg in rgA: %v", cerr)
+	}
+
+	pollDone(t, p)
+
+	if _, gerr := client.Get(ctx, "rgB", "nsgx", nil); gerr == nil {
+		t.Fatal("GET nsgx under rgB returned success; expected 404 (cross-RG read)")
+	} else if code := statusOf(t, gerr); code != 404 {
+		t.Fatalf("GET nsgx under rgB: status %d, want 404", code)
+	}
+
+	if _, gerr := client.Get(ctx, "rgA", "nsgx", nil); gerr != nil {
+		t.Fatalf("GET nsgx under rgA: %v", gerr)
+	}
+}

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -39,6 +39,16 @@ const (
 	armNSGTag        = "cloudemu:azureNSGName"
 	armPublicIPTag   = "cloudemu:azurePublicIP"
 	armPublicIPRGTag = "cloudemu:azurePublicIPResourceGroup"
+	// armVNetRGTag / armNSGRGTag record the resource group a virtual network or
+	// network security group was created under. The cross-cloud networking
+	// driver has a single flat namespace, so without this a resource is globally
+	// name-addressable and a GET/DELETE under the wrong resource group would
+	// resolve it and echo back that wrong group. Scoping the direct CRUD lookups
+	// by this tag makes a same-named resource in a different group a 404, the
+	// same way NAT gateways (armNATGatewayRGTag) and public IPs (armPublicIPRGTag)
+	// are already scoped.
+	armVNetRGTag = "cloudemu:azureVNetResourceGroup"
+	armNSGRGTag  = "cloudemu:azureNSGResourceGroup"
 	// armSubnetNATTag stores the full ARM resource id of the NAT gateway a
 	// subnet is associated with (set via the subnet's own natGateway
 	// property), so both the subnet response and the NAT gateway's
@@ -237,7 +247,7 @@ func (h *Handler) createVNet(w http.ResponseWriter, r *http.Request, rp azurearm
 
 	prefixes := vnetPrefixes(&req)
 
-	info, err := h.upsertVNet(r.Context(), rp.ResourceName, prefixes, req.Tags)
+	info, err := h.upsertVNet(r.Context(), rp.ResourceGroup, rp.ResourceName, prefixes, req.Tags)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -284,14 +294,14 @@ func vnetPrefixes(req *vnetRequest) []string {
 
 // upsertVNet reuses an existing virtual network of the same name (so a repeated
 // PUT updates in place rather than creating a duplicate) or creates a new one.
-func (h *Handler) upsertVNet(ctx context.Context, name string, prefixes []string,
+func (h *Handler) upsertVNet(ctx context.Context, rg, name string, prefixes []string,
 	tags map[string]string,
 ) (*netdriver.VPCInfo, error) {
-	if existing, err := findVNetByName(ctx, h.net, name); err == nil {
+	if existing, err := findVNetInGroup(ctx, h.net, rg, name); err == nil {
 		if len(tags) > 0 {
 			_ = h.net.UpdateVPCTags(ctx, existing.ID, tags)
 
-			if refreshed, rerr := findVNetByName(ctx, h.net, name); rerr == nil {
+			if refreshed, rerr := findVNetInGroup(ctx, h.net, rg, name); rerr == nil {
 				existing = refreshed
 			}
 		}
@@ -306,7 +316,7 @@ func (h *Handler) upsertVNet(ctx context.Context, name string, prefixes []string
 
 	return h.net.CreateVPC(ctx, netdriver.VPCConfig{
 		CIDRBlock: cidr,
-		Tags:      mergeTags(tags, armNameTag, name),
+		Tags:      mergeTags(mergeTags(tags, armNameTag, name), armVNetRGTag, rg),
 	})
 }
 
@@ -428,7 +438,7 @@ func (h *Handler) deleteOmittedSubnets(ctx context.Context, haveByName map[strin
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) getVNet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	info, err := findVNetByName(r.Context(), h.net, rp.ResourceName)
+	info, err := findVNetInGroup(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -448,8 +458,21 @@ func (h *Handler) listVNets(w http.ResponseWriter, r *http.Request, rp azurearm.
 	out := vnetListResponse{}
 
 	for i := range infos {
+		itemRG := tagOr(infos[i].Tags, armVNetRGTag, "")
+		// An RG-scoped list (rp.ResourceGroup set) returns only that group's
+		// networks; a subscription-scoped list (empty) returns all, each stamped
+		// with its own group so the response ids are correct.
+		if rp.ResourceGroup != "" && !strings.EqualFold(itemRG, rp.ResourceGroup) {
+			continue
+		}
+
 		scope := rp
 		scope.ResourceName = tagOr(infos[i].Tags, armNameTag, infos[i].ID)
+
+		if scope.ResourceGroup == "" {
+			scope.ResourceGroup = itemRG
+		}
+
 		out.Value = append(out.Value, h.vnetResponse(r.Context(), &infos[i], scope))
 	}
 
@@ -458,7 +481,7 @@ func (h *Handler) listVNets(w http.ResponseWriter, r *http.Request, rp azurearm.
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) deleteVNet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	info, err := findVNetByName(r.Context(), h.net, rp.ResourceName)
+	info, err := findVNetInGroup(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -487,6 +510,80 @@ func (h *Handler) deleteVNet(w http.ResponseWriter, r *http.Request, rp azurearm
 	}
 
 	writeAcceptedAsync(w, r, rp.Subscription, "vnet-delete-"+rp.ResourceName, nil)
+}
+
+// PurgeResourceGroup deletes every virtual network (with its subnets) and
+// network security group this handler owns in the given resource group. It
+// backs the resource-group cascade delete: when an RG is removed, the resources
+// created under it must go too rather than lingering as globally addressable
+// orphans. Deletion is forceful (the in-use guards that gate an individual
+// DELETE do not apply — the whole group is going away), and best-effort: a
+// single driver-level failure is returned but does not stop the remaining
+// teardown. The subscription is unused (the emulator is single-estate).
+func (h *Handler) PurgeResourceGroup(ctx context.Context, _, resourceGroup string) error {
+	firstErr := h.purgeVNets(ctx, resourceGroup)
+
+	if err := h.purgeNSGs(ctx, resourceGroup); err != nil && firstErr == nil {
+		firstErr = err
+	}
+
+	return firstErr
+}
+
+// purgeVNets deletes every virtual network (with its subnets and metadata) in
+// the resource group, returning the first delete error encountered.
+func (h *Handler) purgeVNets(ctx context.Context, resourceGroup string) error {
+	vpcs, err := h.net.DescribeVPCs(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+
+	for i := range vpcs {
+		if !strings.EqualFold(tagOr(vpcs[i].Tags, armVNetRGTag, ""), resourceGroup) {
+			continue
+		}
+
+		h.deleteChildSubnets(ctx, vpcs[i].ID)
+
+		if meta, ok := h.azureMeta(); ok {
+			meta.DeleteAzureVNetMetadata(ctx, vpcs[i].ID)
+		}
+
+		if derr := h.net.DeleteVPC(ctx, vpcs[i].ID); derr != nil && firstErr == nil {
+			firstErr = derr
+		}
+	}
+
+	return firstErr
+}
+
+// purgeNSGs deletes every network security group (with its metadata) in the
+// resource group, returning the first delete error encountered.
+func (h *Handler) purgeNSGs(ctx context.Context, resourceGroup string) error {
+	nsgs, err := h.net.DescribeSecurityGroups(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+
+	for i := range nsgs {
+		if !strings.EqualFold(tagOr(nsgs[i].Tags, armNSGRGTag, ""), resourceGroup) {
+			continue
+		}
+
+		if meta, ok := h.azureMeta(); ok {
+			meta.DeleteAzureNSGMetadata(ctx, nsgs[i].ID)
+		}
+
+		if derr := h.net.DeleteSecurityGroup(ctx, nsgs[i].ID); derr != nil && firstErr == nil {
+			firstErr = derr
+		}
+	}
+
+	return firstErr
 }
 
 // deleteChildSubnets removes every subnet that belongs to the given vnet.
@@ -542,7 +639,7 @@ func subnetVNetName(subnetID string) string {
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) createSubnet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	vnet, err := findVNetByName(r.Context(), h.net, rp.ResourceName)
+	vnet, err := findVNetInGroup(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -694,7 +791,16 @@ func findSubnetInVNet(ctx context.Context, n netdriver.Networking, vpcID, name s
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) getSubnet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	info, err := findSubnetByName(r.Context(), h.net, rp.SubResourceName)
+	// A subnet is addressed under its parent virtual network; resolve that vnet
+	// scoped to the request's resource group so a subnet is not readable under
+	// the wrong group (the parent vnet gates the child).
+	vnet, err := findVNetInGroup(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	info, err := findSubnetInVNet(r.Context(), h.net, vnet.ID, rp.SubResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -724,7 +830,13 @@ func (h *Handler) listSubnets(w http.ResponseWriter, r *http.Request, rp azurear
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) deleteSubnet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	info, err := findSubnetByName(r.Context(), h.net, rp.SubResourceName)
+	vnet, err := findVNetInGroup(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	info, err := findSubnetInVNet(r.Context(), h.net, vnet.ID, rp.SubResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -823,7 +935,7 @@ func (h *Handler) createNSG(w http.ResponseWriter, r *http.Request, rp azurearm.
 		return
 	}
 
-	info, err := h.upsertNSG(r.Context(), rp.ResourceName, req.Tags)
+	info, err := h.upsertNSG(r.Context(), rp.ResourceGroup, rp.ResourceName, req.Tags)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -847,10 +959,10 @@ func (h *Handler) createNSG(w http.ResponseWriter, r *http.Request, rp azurearm.
 // upsertNSG reuses an existing NSG of the same name (idempotent re-PUT) or
 // creates one, anchoring the driver security group to any VPC (creating a
 // synthetic one when none exists, as the driver requires a VPC id).
-func (h *Handler) upsertNSG(ctx context.Context, name string,
+func (h *Handler) upsertNSG(ctx context.Context, rg, name string,
 	tags map[string]string,
 ) (*netdriver.SecurityGroupInfo, error) {
-	if existing, err := findNSGByName(ctx, h.net, name); err == nil {
+	if existing, err := findNSGInGroup(ctx, h.net, rg, name); err == nil {
 		return existing, nil
 	}
 
@@ -872,13 +984,13 @@ func (h *Handler) upsertNSG(ctx context.Context, name string,
 	return h.net.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{
 		Name:  name,
 		VPCID: anchor,
-		Tags:  mergeTags(tags, armNSGTag, name),
+		Tags:  mergeTags(mergeTags(tags, armNSGTag, name), armNSGRGTag, rg),
 	})
 }
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) getNSG(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	info, err := findNSGByName(r.Context(), h.net, rp.ResourceName)
+	info, err := findNSGInGroup(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -898,8 +1010,20 @@ func (h *Handler) listNSGs(w http.ResponseWriter, r *http.Request, rp azurearm.R
 	out := nsgListResponse{}
 
 	for i := range infos {
+		itemRG := tagOr(infos[i].Tags, armNSGRGTag, "")
+		// An RG-scoped list returns only that group's NSGs; a subscription-scoped
+		// list returns all, each stamped with its own group.
+		if rp.ResourceGroup != "" && !strings.EqualFold(itemRG, rp.ResourceGroup) {
+			continue
+		}
+
 		scope := rp
 		scope.ResourceName = tagOr(infos[i].Tags, armNSGTag, infos[i].ID)
+
+		if scope.ResourceGroup == "" {
+			scope.ResourceGroup = itemRG
+		}
+
 		out.Value = append(out.Value, h.nsgResponse(r.Context(), &infos[i], scope))
 	}
 
@@ -908,7 +1032,7 @@ func (h *Handler) listNSGs(w http.ResponseWriter, r *http.Request, rp azurearm.R
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) deleteNSG(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
-	info, err := findNSGByName(r.Context(), h.net, rp.ResourceName)
+	info, err := findNSGInGroup(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -1090,19 +1214,56 @@ func findVNetByName(ctx context.Context, n netdriver.Networking, name string) (*
 	return nil, cerrors.Newf(cerrors.NotFound, "virtualNetwork %s not found", name)
 }
 
-func findSubnetByName(ctx context.Context, n netdriver.Networking, name string) (*netdriver.SubnetInfo, error) {
-	infos, err := n.DescribeSubnets(ctx, nil)
+// findVNetInGroup resolves a virtual network by both its ARM name and resource
+// group, so a same-named vnet in a different group is not returned. rg == ""
+// falls back to name-only (an unscoped lookup, e.g. a legacy path with no
+// group). Resource-group comparison is case-insensitive, matching ARM.
+//
+//nolint:dupl // mirrors findNSGInGroup over a distinct resource type and tag by design
+func findVNetInGroup(ctx context.Context, n netdriver.Networking, rg, name string) (*netdriver.VPCInfo, error) {
+	infos, err := n.DescribeVPCs(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	for i := range infos {
-		if tagOr(infos[i].Tags, armSubnetTag, "") == name {
-			return &infos[i], nil
+		if tagOr(infos[i].Tags, armNameTag, "") != name {
+			continue
 		}
+
+		if rg != "" && !strings.EqualFold(tagOr(infos[i].Tags, armVNetRGTag, ""), rg) {
+			continue
+		}
+
+		return &infos[i], nil
 	}
 
-	return nil, cerrors.Newf(cerrors.NotFound, "subnet %s not found", name)
+	return nil, cerrors.Newf(cerrors.NotFound, "virtualNetwork %s not found", name)
+}
+
+// findNSGInGroup resolves a network security group by both its ARM name and
+// resource group; see findVNetInGroup for the rg semantics.
+//
+//nolint:dupl // mirrors findVNetInGroup over a distinct resource type and tag by design
+func findNSGInGroup(ctx context.Context, n netdriver.Networking, rg, name string) (*netdriver.SecurityGroupInfo, error) {
+	infos, err := n.DescribeSecurityGroups(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range infos {
+		if tagOr(infos[i].Tags, armNSGTag, "") != name {
+			continue
+		}
+
+		if rg != "" && !strings.EqualFold(tagOr(infos[i].Tags, armNSGRGTag, ""), rg) {
+			continue
+		}
+
+		return &infos[i], nil
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "networkSecurityGroup %s not found", name)
 }
 
 func findNSGByName(ctx context.Context, n netdriver.Networking, name string) (*netdriver.SecurityGroupInfo, error) {

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -46,6 +46,10 @@ type AccountAttributes struct {
 	// Location is the account's region (e.g. westus2). Empty until an ARM
 	// create-or-update stamps it; the handler falls back to a default.
 	Location string
+	// ResourceGroup is the Azure resource group the account was created under.
+	// Recorded on the ARM create-or-update so a resource-group cascade delete can
+	// find the accounts it must remove; empty for non-ARM (S3/GCS) buckets.
+	ResourceGroup string
 	// Tags are the ARM resource tags submitted on create-or-update, round-tripped
 	// back on GET / list.
 	Tags map[string]string


### PR DESCRIPTION
## What & why

Deep-audit fixes for the Azure Resource Manager keystone cluster. A resource group is a pure container in ARM, and Microsoft.Network resources are addressed by (subscription, resource group, name) — the emulator honored neither, so a teardown leaked resources and a same-named resource in another group collided. This PR fixes the lifecycle/write path for both.

### N1 [BLOCKER] — RG delete now cascades
Deleting a resource group deleted only the group record; every storage account, virtual network, NSG, VM, etc. created under it stayed alive and globally addressable (a `terraform destroy` "succeeded" while leaking resources; the next `apply` collided).

Fix: a new `resourcegroups.ResourceGroupPurger` interface. Each per-service ARM handler that stores its resources RG-scoped implements `PurgeResourceGroup`; the resource-group handler fans a delete out to the registered purgers (best-effort, matching the async fire-and-forget 202 contract). Wired in `server/azure/azure.go`. Covered today: **compute** (already stored `Instance.ResourceGroup`), **networking** (vnet + its subnets + NSGs), **storage accounts**. Storage accounts now record their RG (`AccountAttributes.ResourceGroup`) on the ARM create so the cascade can find them.

### N5 [HIGH] — network resources scoped to their resource group
`virtualNetworks` / `networkSecurityGroups` lived in the driver's flat namespace, so a GET/DELETE under the **wrong** RG returned 200 and echoed the wrong RG back into the id. Cross-RG reads and same-name collisions across two teams/states corrupted state.

Fix: vnets and NSGs record their RG on create (`cloudemu:azure{VNet,NSG}ResourceGroup` internal tags, mirroring the existing NAT-gateway / public-IP RG-tag pattern). The direct GET / PUT-existing-check / DELETE, and the RG-scoped list, resolve them scoped to the request's RG (case-insensitive, matching ARM) → a read under the wrong group is a 404. Subnets are gated through their (now RG-scoped) parent vnet. Cross-resource references (peering remote vnet, NIC→subnet/NSG, effectiveNSG) stay name-only, since ARM permits cross-RG references.

## Findings fixed
- **N1** RG-delete-no-cascade (BLOCKER) — compute/networking/storage
- **N5** network cross-RG read/delete (HIGH) — vnet, NSG, subnet (via parent), + RG-scoped list

## Deferred (explicitly, per the deferral rule)
The **N2/N3/N4 Resource Graph row-correctness** cluster is NOT in this PR. Those are the read/discovery path (the shared `services/resourcediscovery` walkers, with AWS/GCP blast radius) and are cleanly separable from the write/lifecycle path fixed here:
- **N2** — ARG / generic `.../resources` / exportTemplate still report `resourceGroup: "default"` for networking & storage (compute already carries the real RG). Needs the network/storage walkers + ARN builders to emit the persisted Azure RG.
- **N3** — ARG `location` still shows the AWS default (`us-east-1`) for network/storage resources; the discovery Engine stamps `e.region` rather than each resource's Azure location.
- **N4** — ARG renders storage accounts with a malformed container-path id, drops user tags, and leaks `cloudemu:*` internal tags (the internal RG tags added here are `cloudemu:`-prefixed and already stripped from the ARM handler responses via `stripInternal`, but the ARG renderer needs the same filter).

These were deferred because the proper N2 fix is a systemic rework of the shared cross-provider discovery walkers, too wide to land cleanly alongside the lifecycle fix without risking AWS/GCP collateral. N1/N5 do not depend on it (the cascade queries each driver directly rather than via discovery ARNs).

Also not addressed (out of this PR's scope, from the same audit): N6 ARM-template deployments, N7 provider registration, N8 storage 200-vs-201, R13 Tags RP, R14 locks, R15 moveResources.

## Tests (real SDK, end-to-end)
- `TestResourceGroupDeleteCascades` — real `armresources` + `armstorage` + `armnetwork`: create RG + storage account + vnet, delete the RG, assert both contained resources return 404.
- `TestVNetGetIsResourceGroupScoped` / `TestNSGGetIsResourceGroupScoped` — cross-RG GET is 404; same-named resource in a second RG is independent; RG-scoped list returns only the group's own; deleting one group's copy leaves the other's intact.

## Gates
build ./... · vet · scoped tests (incl. `-race`) · golangci-lint (0 new) · gofmt · `go generate` (no docs/coverage drift — no driver interface method changed).
