### PR TITLE
fix(azure-eventgrid): scope-bound event subscriptions

### DIFF
--- a/server/azure/eventgrid/handler.go
+++ b/server/azure/eventgrid/handler.go
@@ -22,6 +22,8 @@
 //	GET            .../topics/{t}/eventSubscriptions        — TopicEventSubscriptions.List
 //	PUT/GET/DELETE .../domains/{d}/topics/{t}               — DomainTopics CRUD
 //	GET            .../domains/{d}/topics                   — DomainTopics.ListByDomain
+//	PUT/GET/DELETE {scope}/.../eventSubscriptions/{s}      — EventSubscriptions CRUD (subscription/RG/resource scope)
+//	GET            {scope}/.../eventSubscriptions          — EventSubscriptions List (ByResource / Global{BySub,ByRG})
 package eventgrid
 
 import (
@@ -51,6 +53,11 @@ type Handler struct {
 	mu           sync.RWMutex
 	systemTopics map[string]*systemTopicRecord
 	domains      map[string]*domainRecord
+	// scopedSubs holds event subscriptions created as extension resources on a
+	// non-topic scope (subscription, resource group, or an arbitrary resource).
+	// These have no eventbus-driver topic to hang off, so — like systemTopics
+	// and domains — the wire handler owns their state. Keyed by scope+name.
+	scopedSubs map[string]*scopedSubRecord
 }
 
 // New returns an Azure Event Grid handler backed by b.
@@ -59,6 +66,7 @@ func New(b ebdriver.EventBus) *Handler {
 		bus:          b,
 		systemTopics: make(map[string]*systemTopicRecord),
 		domains:      make(map[string]*domainRecord),
+		scopedSubs:   make(map[string]*scopedSubRecord),
 	}
 }
 
@@ -66,6 +74,14 @@ func New(b ebdriver.EventBus) *Handler {
 // and domains. Disjoint from every other Azure ARM provider, so registration
 // order is unconstrained. Registered before the BlobStorage fallback.
 func (*Handler) Matches(r *http.Request) bool {
+	// Scope-bound event subscriptions are an extension resource that can hang
+	// off any scope (subscription, resource group, or an arbitrary resource of
+	// a different provider), so the outer provider in the path is not
+	// necessarily Microsoft.EventGrid. Claim them by the trailing marker.
+	if _, ok := parseScopedEventSubscription(r.URL.Path); ok {
+		return true
+	}
+
 	rp, ok := azurearm.ParsePath(r.URL.Path)
 	if !ok {
 		return false
@@ -85,6 +101,14 @@ func (*Handler) Matches(r *http.Request) bool {
 
 // ServeHTTP routes on the parsed path shape and method.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Scope-bound / extension-form event subscriptions are recognized ahead of
+	// the topic-oriented parse: their path carries an extra
+	// providers/Microsoft.EventGrid segment that azurearm.ParsePath cannot model.
+	if sp, ok := parseScopedEventSubscription(r.URL.Path); ok {
+		h.serveScopedEventSubscription(w, r, &sp)
+		return
+	}
+
 	rp, ok := azurearm.ParsePath(r.URL.Path)
 	if !ok {
 		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
@@ -112,6 +136,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.serveTopicResource(w, r, &rp)
+}
+
+// serveTopicResource routes a named topic and its sub-resources.
+func (h *Handler) serveTopicResource(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	switch rp.SubResource {
 	case actionListKeys:
 		if r.Method != http.MethodPost {
@@ -119,11 +148,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		h.listTopicKeys(w, r, &rp)
+		h.listTopicKeys(w, r, rp)
 	case subEventSubscriptions:
-		h.serveEventSubscription(w, r, &rp)
+		h.serveEventSubscription(w, r, rp)
 	case "":
-		h.serveTopic(w, r, &rp)
+		h.serveTopic(w, r, rp)
 	default:
 		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "unsupported Event Grid topic sub-resource")
 	}

--- a/server/azure/eventgrid/scoped_subscriptions.go
+++ b/server/azure/eventgrid/scoped_subscriptions.go
@@ -1,0 +1,256 @@
+package eventgrid
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+const (
+	// scopedSubscriptionResourceType is the ARM type of an event subscription
+	// created as an extension resource on a non-topic scope.
+	scopedSubscriptionResourceType = "Microsoft.EventGrid/eventSubscriptions"
+	segProviders                   = "providers"
+	segSubscriptions               = "subscriptions"
+)
+
+// scopedSubPath is a parsed scope-bound event subscription URL of the form
+// {scope}/providers/Microsoft.EventGrid/eventSubscriptions[/{name}], where
+// {scope} is a subscription, resource group, or an arbitrary resource id.
+type scopedSubPath struct {
+	scope         string // full ARM scope, leading slash, no trailing marker
+	name          string // subscription name; empty for a list request
+	subscription  string
+	resourceGroup string
+	topicName     string // set only when {scope} is a Microsoft.EventGrid topic
+}
+
+// scopedSubRecord is a wire-handler-owned event subscription attached to a
+// non-topic scope. It has no eventbus-driver topic to hang off, so — like
+// systemTopics and domains — the handler owns its state; the raw ARM
+// properties round-trip verbatim.
+type scopedSubRecord struct {
+	scope         string
+	name          string
+	subscription  string
+	resourceGroup string
+	properties    json.RawMessage
+}
+
+// scopedSubMarker returns the index of the "providers" segment of the trailing
+// providers/Microsoft.EventGrid/eventSubscriptions marker, or -1 when absent.
+// The scan runs back-to-front so the last (extension) marker wins even when the
+// scope itself is a Microsoft.EventGrid resource.
+func scopedSubMarker(parts []string) int {
+	for i := len(parts) - 3; i >= 0; i-- {
+		if parts[i] == segProviders && parts[i+1] == providerName && parts[i+2] == subEventSubscriptions {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// parseScopedEventSubscription recognizes a scope-bound event subscription path.
+// azurearm.ParsePath cannot model it because the nested provider segment pushes
+// the real name past the fields it tracks.
+func parseScopedEventSubscription(path string) (scopedSubPath, bool) {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+
+	i := scopedSubMarker(parts)
+	if i < 0 {
+		return scopedSubPath{}, false
+	}
+
+	scopeSegs := parts[:i]
+	if len(scopeSegs) < 2 || scopeSegs[0] != segSubscriptions {
+		return scopedSubPath{}, false
+	}
+
+	// Reject trailing action segments (getFullUrl, getDeliveryAttributes): the
+	// name, if present, is the single segment right after the marker.
+	if len(parts) > i+4 {
+		return scopedSubPath{}, false
+	}
+
+	sp := scopedSubPath{scope: "/" + strings.Join(scopeSegs, "/")}
+	if len(parts) > i+3 {
+		sp.name = parts[i+3]
+	}
+
+	parseScopeContainers(scopeSegs, &sp)
+
+	return sp, true
+}
+
+// parseScopeContainers pulls the subscription, resource group, and (when the
+// scope is an Event Grid topic) the topic name out of the scope segments.
+func parseScopeContainers(segs []string, sp *scopedSubPath) {
+	if len(segs) >= 2 && segs[0] == segSubscriptions {
+		sp.subscription = segs[1]
+	}
+
+	if len(segs) >= 4 && strings.EqualFold(segs[2], "resourceGroups") {
+		sp.resourceGroup = segs[3]
+	}
+
+	n := len(segs)
+	if n >= 4 && segs[n-4] == segProviders && segs[n-3] == providerName && segs[n-2] == typeTopics {
+		sp.topicName = segs[n-1]
+	}
+}
+
+func scopedSubKey(scope, name string) string {
+	return scope + "\x00" + name
+}
+
+// serveScopedEventSubscription handles CRUD + list for scope-bound event
+// subscriptions.
+func (h *Handler) serveScopedEventSubscription(w http.ResponseWriter, r *http.Request, sp *scopedSubPath) {
+	// A topic-scoped extension form is the same resource as the direct
+	// .../topics/{t}/eventSubscriptions/{n} form, so route it through the
+	// eventbus driver to unify with direct-form subs and share delivery.
+	if sp.topicName != "" {
+		rp := &azurearm.ResourcePath{
+			Subscription:    sp.subscription,
+			ResourceGroup:   sp.resourceGroup,
+			Provider:        providerName,
+			ResourceType:    typeTopics,
+			ResourceName:    sp.topicName,
+			SubResource:     subEventSubscriptions,
+			SubResourceName: sp.name,
+		}
+		h.serveEventSubscription(w, r, rp)
+
+		return
+	}
+
+	if sp.name == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w)
+			return
+		}
+
+		h.listScopedEventSubscriptions(w, sp)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.putScopedEventSubscription(w, r, sp)
+	case http.MethodGet:
+		h.getScopedEventSubscription(w, sp)
+	case http.MethodDelete:
+		h.deleteScopedEventSubscription(w, sp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func (h *Handler) putScopedEventSubscription(w http.ResponseWriter, r *http.Request, sp *scopedSubPath) {
+	var body struct {
+		Properties json.RawMessage `json:"properties"`
+	}
+
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	rec := &scopedSubRecord{
+		scope:         sp.scope,
+		name:          sp.name,
+		subscription:  sp.subscription,
+		resourceGroup: sp.resourceGroup,
+		properties:    body.Properties,
+	}
+
+	h.mu.Lock()
+	h.scopedSubs[scopedSubKey(sp.scope, sp.name)] = rec
+	h.mu.Unlock()
+
+	azurearm.WriteJSON(w, http.StatusCreated, toScopedSubJSON(rec))
+}
+
+func (h *Handler) getScopedEventSubscription(w http.ResponseWriter, sp *scopedSubPath) {
+	h.mu.RLock()
+	rec, ok := h.scopedSubs[scopedSubKey(sp.scope, sp.name)]
+	h.mu.RUnlock()
+
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "event subscription not found")
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toScopedSubJSON(rec))
+}
+
+// deleteScopedEventSubscription removes the subscription. Delete is idempotent:
+// a missing subscription returns 204, matching ARM (the SDK BeginDelete LRO
+// accepts 200/202/204).
+func (h *Handler) deleteScopedEventSubscription(w http.ResponseWriter, sp *scopedSubPath) {
+	key := scopedSubKey(sp.scope, sp.name)
+
+	h.mu.Lock()
+	_, ok := h.scopedSubs[key]
+	delete(h.scopedSubs, key)
+	h.mu.Unlock()
+
+	if !ok {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) listScopedEventSubscriptions(w http.ResponseWriter, sp *scopedSubPath) {
+	h.mu.RLock()
+
+	recs := make([]*scopedSubRecord, 0, len(h.scopedSubs))
+
+	for _, rec := range h.scopedSubs {
+		if scopedSubInListScope(rec, sp) {
+			recs = append(recs, rec)
+		}
+	}
+
+	h.mu.RUnlock()
+
+	sort.Slice(recs, func(i, j int) bool { return recs[i].name < recs[j].name })
+
+	out := make([]eventSubscriptionJSON, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, toScopedSubJSON(rec))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, eventSubscriptionListResult{Value: out})
+}
+
+// scopedSubInListScope reports whether rec belongs in the list requested at sp.
+// A resource-extension scope (containing a nested /providers/) matches exactly;
+// a resource-group scope matches subscription+group; a subscription scope
+// matches the subscription (ListGlobalBySubscription).
+func scopedSubInListScope(rec *scopedSubRecord, sp *scopedSubPath) bool {
+	if strings.Contains(sp.scope, "/providers/") {
+		return rec.scope == sp.scope
+	}
+
+	if sp.resourceGroup != "" {
+		return rec.subscription == sp.subscription && rec.resourceGroup == sp.resourceGroup
+	}
+
+	return rec.subscription == sp.subscription
+}
+
+func toScopedSubJSON(rec *scopedSubRecord) eventSubscriptionJSON {
+	return eventSubscriptionJSON{
+		ID:         rec.scope + "/providers/" + providerName + "/" + subEventSubscriptions + "/" + rec.name,
+		Name:       rec.name,
+		Type:       scopedSubscriptionResourceType,
+		Properties: enrichSubscriptionProperties(rec.properties, rec.scope),
+	}
+}

--- a/server/azure/eventgrid/scoped_subscriptions_sdk_test.go
+++ b/server/azure/eventgrid/scoped_subscriptions_sdk_test.go
@@ -1,0 +1,250 @@
+package eventgrid_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// newEventGridFactory builds one Event Grid backend behind a TLS server and
+// returns a client factory so multiple clients (Topics + EventSubscriptions)
+// share the same state.
+func newEventGridFactory(t *testing.T) *armeventgrid.ClientFactory {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{EventGrid: cloudP.EventGrid})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	cf, err := armeventgrid.NewClientFactory(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("armeventgrid.NewClientFactory: %v", err)
+	}
+
+	return cf
+}
+
+// webhookSubscription builds an EventSubscription with a WebHook destination
+// and a subject filter that must round-trip through GET.
+func webhookSubscription(subjectPrefix string) armeventgrid.EventSubscription {
+	return armeventgrid.EventSubscription{
+		Properties: &armeventgrid.EventSubscriptionProperties{
+			Destination: &armeventgrid.WebHookEventSubscriptionDestination{
+				EndpointType: to.Ptr(armeventgrid.EndpointTypeWebHook),
+				Properties: &armeventgrid.WebHookEventSubscriptionDestinationProperties{
+					EndpointURL: to.Ptr("https://example.test/hook"),
+				},
+			},
+			Filter: &armeventgrid.EventSubscriptionFilter{
+				SubjectBeginsWith: to.Ptr(subjectPrefix),
+			},
+		},
+	}
+}
+
+func createEventSubscription(t *testing.T, c *armeventgrid.EventSubscriptionsClient, scope, name, subjectPrefix string) {
+	t.Helper()
+	ctx := context.Background()
+
+	poller, err := c.BeginCreateOrUpdate(ctx, scope, name, webhookSubscription(subjectPrefix), nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate(%s/%s): %v", scope, name, err)
+	}
+
+	if _, err = poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("CreateOrUpdate PollUntilDone(%s/%s): %v", scope, name, err)
+	}
+}
+
+// TestSDKEventSubscriptionResourceGroupScope proves an RG-scoped event
+// subscription (the Terraform azurerm_eventgrid_event_subscription shape) is no
+// longer 501: it round-trips through create/get/list/delete.
+func TestSDKEventSubscriptionResourceGroupScope(t *testing.T) {
+	client := newEventGridFactory(t).NewEventSubscriptionsClient()
+	ctx := context.Background()
+
+	scope := "/subscriptions/" + testSub + "/resourceGroups/" + testRG
+
+	createEventSubscription(t, client, scope, "rg-sub", "/blobServices/default")
+
+	got, err := client.Get(ctx, scope, "rg-sub", nil)
+	if err != nil {
+		t.Fatalf("Get rg-scope sub: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.Filter == nil ||
+		got.Properties.Filter.SubjectBeginsWith == nil ||
+		*got.Properties.Filter.SubjectBeginsWith != "/blobServices/default" {
+		t.Fatalf("filter did not round-trip: %+v", got.Properties)
+	}
+
+	names := listGlobalByResourceGroup(t, client, testRG)
+	if len(names) != 1 || names[0] != "rg-sub" {
+		t.Fatalf("ListGlobalByResourceGroup = %v, want [rg-sub]", names)
+	}
+
+	delPoller, err := client.BeginDelete(ctx, scope, "rg-sub", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+	if _, err = delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete PollUntilDone: %v", err)
+	}
+
+	_, err = client.Get(ctx, scope, "rg-sub", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("Get after delete: got %v, want 404", err)
+	}
+}
+
+// TestSDKEventSubscriptionSubscriptionScope proves a subscription-scoped event
+// subscription round-trips and is listed by ListGlobalBySubscription.
+func TestSDKEventSubscriptionSubscriptionScope(t *testing.T) {
+	client := newEventGridFactory(t).NewEventSubscriptionsClient()
+	ctx := context.Background()
+
+	scope := "/subscriptions/" + testSub
+
+	createEventSubscription(t, client, scope, "sub-scope-sub", "/foo")
+
+	if _, err := client.Get(ctx, scope, "sub-scope-sub", nil); err != nil {
+		t.Fatalf("Get subscription-scope sub: %v", err)
+	}
+
+	var names []string
+	pager := client.NewListGlobalBySubscriptionPager(nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListGlobalBySubscription: %v", err)
+		}
+		for _, es := range page.Value {
+			names = append(names, *es.Name)
+		}
+	}
+
+	if len(names) != 1 || names[0] != "sub-scope-sub" {
+		t.Fatalf("ListGlobalBySubscription = %v, want [sub-scope-sub]", names)
+	}
+}
+
+// TestSDKEventSubscriptionResourceScope proves the resource-extension form on an
+// arbitrary (non-Event-Grid) resource works and is listed by ListByResource.
+func TestSDKEventSubscriptionResourceScope(t *testing.T) {
+	client := newEventGridFactory(t).NewEventSubscriptionsClient()
+	ctx := context.Background()
+
+	scope := "/subscriptions/" + testSub + "/resourceGroups/" + testRG +
+		"/providers/Microsoft.Storage/storageAccounts/acct1"
+
+	createEventSubscription(t, client, scope, "res-sub", "/blobServices")
+
+	if _, err := client.Get(ctx, scope, "res-sub", nil); err != nil {
+		t.Fatalf("Get resource-scope sub: %v", err)
+	}
+
+	var names []string
+	pager := client.NewListByResourcePager(testRG, "Microsoft.Storage", "storageAccounts", "acct1", nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListByResource: %v", err)
+		}
+		for _, es := range page.Value {
+			names = append(names, *es.Name)
+		}
+	}
+
+	if len(names) != 1 || names[0] != "res-sub" {
+		t.Fatalf("ListByResource = %v, want [res-sub]", names)
+	}
+}
+
+// TestSDKEventSubscriptionTopicExtensionForm proves the topic extension form
+// (.../topics/{t}/providers/Microsoft.EventGrid/eventSubscriptions/{n}) is
+// unified with the direct TopicEventSubscriptions form: a subscription created
+// via the scope-bound client is visible through the topic's own list.
+func TestSDKEventSubscriptionTopicExtensionForm(t *testing.T) {
+	cf := newEventGridFactory(t)
+	topics := cf.NewTopicsClient()
+	subs := cf.NewEventSubscriptionsClient()
+	topicSubs := cf.NewTopicEventSubscriptionsClient()
+	ctx := context.Background()
+
+	createTopic(t, topics, testRG, "orders", nil)
+
+	scope := "/subscriptions/" + testSub + "/resourceGroups/" + testRG +
+		"/providers/Microsoft.EventGrid/topics/orders"
+
+	createEventSubscription(t, subs, scope, "ext-sub", "/orders")
+
+	// Visible through the direct topic-scoped client → same underlying resource.
+	if _, err := topicSubs.Get(ctx, testRG, "orders", "ext-sub", nil); err != nil {
+		t.Fatalf("TopicEventSubscriptions.Get(ext-sub): %v", err)
+	}
+
+	var names []string
+	pager := topicSubs.NewListPager(testRG, "orders", nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("TopicEventSubscriptions.List: %v", err)
+		}
+		for _, es := range page.Value {
+			names = append(names, *es.Name)
+		}
+	}
+
+	if len(names) != 1 || names[0] != "ext-sub" {
+		t.Fatalf("topic list = %v, want [ext-sub] (extension form must unify with direct form)", names)
+	}
+}
+
+func listGlobalByResourceGroup(t *testing.T, c *armeventgrid.EventSubscriptionsClient, rg string) []string {
+	t.Helper()
+	ctx := context.Background()
+
+	var names []string
+	pager := c.NewListGlobalByResourceGroupPager(rg, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListGlobalByResourceGroup: %v", err)
+		}
+		for _, es := range page.Value {
+			names = append(names, *es.Name)
+		}
+	}
+
+	return names
+}


### PR DESCRIPTION
## What

Adds support for Azure Event Grid **scope-bound / extension-form event subscriptions** — the `Microsoft.EventGrid/eventSubscriptions` extension resource that can hang off any scope. Previously only the direct `.../topics/{t}/eventSubscriptions/{n}` form worked.

Scopes now supported for CreateOrUpdate / Get / Delete / List:

- **Subscription scope** — `/subscriptions/{s}/providers/Microsoft.EventGrid/eventSubscriptions/{n}` (+ `ListGlobalBySubscription`)
- **Resource-group scope** — `/subscriptions/{s}/resourceGroups/{rg}/providers/Microsoft.EventGrid/eventSubscriptions/{n}` (+ `ListGlobalByResourceGroup`)
- **Arbitrary-resource scope** — `.../providers/{ns}/{type}/{res}/providers/Microsoft.EventGrid/eventSubscriptions/{n}` (+ `ListByResource`)
- **Topic extension scope** — `.../providers/Microsoft.EventGrid/topics/{t}/providers/Microsoft.EventGrid/eventSubscriptions/{n}`

## Why

Terraform's `azurerm_eventgrid_event_subscription` and the legacy `armeventgrid.EventSubscriptionsClient` build the scope-bound URL `{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{name}`. Against the emulator this returned **501** at RG/subscription scope (fell through to the BlobStorage fallback) and **400** for the topic extension form, so any Terraform-managed or legacy-SDK event subscription silently failed. Fixes deep-audit finding NEW-1 / DEEP-357.

## How

- `Matches()` now claims the trailing `providers/Microsoft.EventGrid/eventSubscriptions` marker regardless of the outer provider (`azurearm.ParsePath` cannot model the extra nested `providers` segment).
- The **topic** extension form is normalized to the direct-form path and routed through the eventbus driver, so it is the same resource as a direct-form subscription and shares delivery/filter machinery.
- **Non-topic** scopes (subscription / RG / arbitrary resource) have no eventbus topic to hang off, so — mirroring the existing `systemTopics`/`domains` precedent — the wire handler owns their state in memory, keyed by scope+name. Raw ARM properties round-trip verbatim (destination/filter) for Terraform state refresh. No driver interface change; docs/coverage unaffected.

## Tests

New real-SDK reproductions (`scoped_subscriptions_sdk_test.go`) via `armeventgrid.EventSubscriptionsClient`:
- RG-scope create → GET (filter round-trips) → `ListGlobalByResourceGroup` → DELETE → GET 404
- Subscription-scope create → GET → `ListGlobalBySubscription`
- Arbitrary-resource (storage account) scope create → GET → `ListByResource`
- Topic extension form create, visible through the direct `TopicEventSubscriptions` Get + List (unification)

Existing direct-form Event Grid tests stay green.