### PR TITLE
fix(azure-functions): reject App Service Plan delete while sites assigned

### DIFF
--- a/providers/azure/functions/app_service_plan.go
+++ b/providers/azure/functions/app_service_plan.go
@@ -3,8 +3,10 @@ package functions
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
 )
 
 // AppServicePlan is an Azure App Service plan (Microsoft.Web/serverfarms) — the
@@ -87,13 +89,44 @@ func (m *Mock) GetAppServicePlan(_ context.Context, subscription, resourceGroup,
 }
 
 // DeleteAppServicePlan removes one App Service plan scoped to the given
-// subscription and resource group, or NotFound.
+// subscription and resource group, or NotFound. A plan that still has a Web App
+// assigned to it (any site whose ServerFarmID targets the plan's ARM id) cannot
+// be deleted — real Azure answers 409 Conflict ("Server farm ... cannot be
+// deleted because it has web app(s) assigned to it"), so the delete is rejected
+// with FailedPrecondition (mapped to 409 by the wire layer) rather than
+// silently leaving every site pointing at a plan that no longer exists.
 func (m *Mock) DeleteAppServicePlan(_ context.Context, subscription, resourceGroup, name string) error {
-	if !m.plans.Delete(planKey(subscription, resourceGroup, name)) {
+	if _, ok := m.plans.Get(planKey(subscription, resourceGroup, name)); !ok {
 		return cerrors.Newf(cerrors.NotFound, "app service plan %s not found", name)
 	}
 
+	if site := m.planAssignedSite(subscription, resourceGroup, name); site != "" {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"Server farm %q cannot be deleted because it has web app(s) assigned to it (site %q)", name, site)
+	}
+
+	m.plans.Delete(planKey(subscription, resourceGroup, name))
+
 	return nil
+}
+
+// planAssignedSite returns the name of a site still assigned to the named plan
+// (its ServerFarmID equal to the plan's ARM id), or "" when none reference it.
+// A site's plan may live in a different resource group than the site, so every
+// site in the subscription is a candidate — the join mirrors listPlanWebApps.
+func (m *Mock) planAssignedSite(subscription, resourceGroup, name string) string {
+	planID := idgen.AzureID(subscription, resourceGroup, "Microsoft.Web", "serverfarms", name)
+
+	m.sitesMu.RLock()
+	defer m.sitesMu.RUnlock()
+
+	for _, meta := range m.sites.SortedValues() {
+		if strings.EqualFold(meta.ServerFarmID, planID) {
+			return meta.Name
+		}
+	}
+
+	return ""
 }
 
 // ListAppServicePlans returns the App Service plans in the given resource

--- a/providers/azure/functions/app_service_plan_test.go
+++ b/providers/azure/functions/app_service_plan_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
 )
 
 func TestCreateAppServicePlanDefaults(t *testing.T) {
@@ -77,6 +78,38 @@ func TestListAppServicePlansRoundTrip(t *testing.T) {
 // resource groups (even in the same subscription) each naming a plan
 // "default" must not collide, and neither Get nor Delete nor a resource-group
 // scoped List may see the other resource group's plan.
+func TestDeleteAppServicePlanRejectedWhileSiteAssigned(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateAppServicePlan(ctx, AppServicePlan{
+		Name: "plan1", Subscription: "sub1", ResourceGroup: "rgA", SKUName: "B1",
+	})
+	require.NoError(t, err)
+
+	// A site assigned to the plan (ServerFarmID = the plan's ARM id) blocks
+	// the delete, even though the site lives in a different resource group.
+	_, err = m.UpsertSiteMeta(ctx, SiteMeta{
+		Name: "site1", Subscription: "sub1", ResourceGroup: "rgB",
+		ServerFarmID: idgen.AzureID("sub1", "rgA", "Microsoft.Web", "serverfarms", "plan1"),
+	})
+	require.NoError(t, err)
+
+	err = m.DeleteAppServicePlan(ctx, "sub1", "rgA", "plan1")
+	require.True(t, cerrors.IsFailedPrecondition(err), "want FailedPrecondition, got %v", err)
+
+	// The plan must survive the rejected delete.
+	_, err = m.GetAppServicePlan(ctx, "sub1", "rgA", "plan1")
+	require.NoError(t, err)
+
+	// Once the site is gone, the plan deletes cleanly.
+	require.NoError(t, m.DeleteSiteMeta(ctx, "sub1", "rgB", "site1"))
+	require.NoError(t, m.DeleteAppServicePlan(ctx, "sub1", "rgA", "plan1"))
+
+	_, err = m.GetAppServicePlan(ctx, "sub1", "rgA", "plan1")
+	require.True(t, cerrors.IsNotFound(err))
+}
+
 func TestAppServicePlanResourceGroupIsolation(t *testing.T) {
 	ctx := context.Background()
 	m := newTestMock()

--- a/server/azure/functions/rgscope_sdk_test.go
+++ b/server/azure/functions/rgscope_sdk_test.go
@@ -2,10 +2,13 @@ package functions_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3"
 	"github.com/stackshy/cloudemu/v2"
@@ -154,7 +157,13 @@ func TestSDKAppServicePlanDeleteAndListWebApps(t *testing.T) {
 		}
 	}
 
-	// DELETE the plan.
+	// The plan cannot be deleted while it still hosts a site (guarded, see
+	// TestSDKAppServicePlanDeleteRejectedWhileSiteAssigned) — remove the site
+	// first, then DELETE the plan.
+	if _, err := webAppsClient.Delete(ctx, rgName, "sdk-plan-site", nil); err != nil {
+		t.Fatalf("Sites Delete: %v", err)
+	}
+
 	if _, err := plansClient.Delete(ctx, rgName, "sdk-plan-2", nil); err != nil {
 		t.Fatalf("Plans Delete: %v", err)
 	}
@@ -166,6 +175,84 @@ func TestSDKAppServicePlanDeleteAndListWebApps(t *testing.T) {
 	// Deleting again is a 404, not a panic or 500.
 	if _, err := plansClient.Delete(ctx, rgName, "sdk-plan-2", nil); err == nil {
 		t.Fatal("second Delete returned nil error, want 404")
+	}
+}
+
+// TestSDKAppServicePlanDeleteRejectedWhileSiteAssigned covers the data-corruption
+// finding: deleting an App Service plan that still hosts a Web App must 409
+// Conflict (real Azure: "Server farm ... cannot be deleted because it has web
+// app(s) assigned to it"), not silently succeed and leave the site pointing at a
+// plan that no longer exists. Once the site is deleted, the plan delete succeeds.
+func TestSDKAppServicePlanDeleteRejectedWhileSiteAssigned(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{Functions: cloudP.Functions}))
+	t.Cleanup(ts.Close)
+
+	plansClient := newPlansClient(t, ts)
+	webAppsClient := newWebAppsClient(t, ts)
+	ctx := context.Background()
+
+	planPoller, err := plansClient.BeginCreateOrUpdate(ctx, rgName, "sdk-guard-plan",
+		armappservice.Plan{
+			Kind:     to.Ptr("linux"),
+			Location: to.Ptr("eastus"),
+			SKU:      &armappservice.SKUDescription{Name: to.Ptr("B1"), Tier: to.Ptr("Basic")},
+		}, nil)
+	if err != nil {
+		t.Fatalf("Plans BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err = planPoller.PollUntilDone(ctx, &runtimePollerOptions); err != nil {
+		t.Fatalf("Plans PollUntilDone: %v", err)
+	}
+
+	serverFarmID := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Web/serverfarms/sdk-guard-plan", subID, rgName)
+
+	sitePoller, err := webAppsClient.BeginCreateOrUpdate(ctx, rgName, "sdk-guard-site",
+		armappservice.Site{
+			Kind:     to.Ptr("app"),
+			Location: to.Ptr("eastus"),
+			Properties: &armappservice.SiteProperties{
+				ServerFarmID: to.Ptr(serverFarmID),
+				SiteConfig:   &armappservice.SiteConfig{},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("Sites BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err = sitePoller.PollUntilDone(ctx, &runtimePollerOptions); err != nil {
+		t.Fatalf("Sites PollUntilDone: %v", err)
+	}
+
+	// Deleting the plan while the site is still assigned must 409 Conflict.
+	_, err = plansClient.Delete(ctx, rgName, "sdk-guard-plan", nil)
+	if err == nil {
+		t.Fatal("Plans Delete with an assigned site returned nil error, want 409 Conflict")
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != http.StatusConflict {
+		t.Fatalf("Plans Delete error = %v, want 409 Conflict", err)
+	}
+
+	// The plan (and the site's reference to it) must survive the rejected delete.
+	if _, err := plansClient.Get(ctx, rgName, "sdk-guard-plan", nil); err != nil {
+		t.Fatalf("plan removed by rejected delete: %v", err)
+	}
+
+	// After the site is deleted, deleting the plan succeeds.
+	if _, err := webAppsClient.Delete(ctx, rgName, "sdk-guard-site", nil); err != nil {
+		t.Fatalf("Sites Delete: %v", err)
+	}
+
+	if _, err := plansClient.Delete(ctx, rgName, "sdk-guard-plan", nil); err != nil {
+		t.Fatalf("Plans Delete after site removed: %v", err)
+	}
+
+	if _, err := plansClient.Get(ctx, rgName, "sdk-guard-plan", nil); err == nil {
+		t.Fatal("post-delete Plans Get returned nil error, want 404")
 	}
 }
 


### PR DESCRIPTION
## What

An App Service Plan (`Microsoft.Web/serverfarms`) could be **deleted while a Web App (`Microsoft.Web/sites`) still referenced it**, with no error. The plan vanished and every site was left pointing at a `serverFarmId` that no longer existed — silent state corruption that IaC state files then disagree with.

`DeleteAppServicePlan` now rejects the delete when any site's `ServerFarmID` still targets the plan's ARM id, returning `FailedPrecondition` which the ARM wire layer maps to **409 Conflict** ("Server farm ... cannot be deleted because it has web app(s) assigned to it"). Once the assigned site is deleted, the plan deletes cleanly.

## Why

Real Azure rejects this delete with 409 Conflict (App Service Plans Delete REST API). The previous behavior (`m.plans.Delete(...)` with no reverse reference check) matched neither real Azure nor the emulator's own data-integrity guarantees, and reproduces under any teardown that races app vs plan deletion (`terraform destroy`, `az appservice plan delete`).

## Changes

- `providers/azure/functions/app_service_plan.go` — `DeleteAppServicePlan` checks plan existence, then scans sites for a matching `ServerFarmID` (new `planAssignedSite` helper, scanning the whole subscription since a site's plan may live in another resource group — mirrors the `listPlanWebApps` join). Rejects with `FailedPrecondition` (→ 409) when a site is still assigned.
- Tests:
  - `server/azure/functions/rgscope_sdk_test.go` — `TestSDKAppServicePlanDeleteRejectedWhileSiteAssigned` (real `armappservice/v3`): create plan → create web app on it → DELETE plan → 409 Conflict; delete the web app → DELETE plan succeeds. Updated `TestSDKAppServicePlanDeleteAndListWebApps` to delete the site before the plan.
  - `providers/azure/functions/app_service_plan_test.go` — provider-level guard test covering the reject + delete-after-site-removed path.