### PR TITLE
fix(azure-compute): PATCH dataDisk detach + clear disk managedBy on VM delete

### DIFF
--- a/server/azure/virtualmachines/datadisk_attach_test.go
+++ b/server/azure/virtualmachines/datadisk_attach_test.go
@@ -133,13 +133,20 @@ func TestSDKVMDataDiskAttachDetach(t *testing.T) {
 		t.Errorf("disk-0 diskState=%v, want Attached", diskStateOf(gotDisk1))
 	}
 
-	// PATCH (BeginUpdate) attaches disk-1 at lun 1 — the non-recreating
-	// merge-patch path — without disturbing the existing lun-0 attachment.
+	// PATCH (BeginUpdate) adds disk-1 at lun 1 via the real read-modify-write
+	// pattern: the desired dataDisks list carries BOTH lun 0 (kept) and lun 1
+	// (new). A PATCH's supplied dataDisks array is a full replace, so keeping an
+	// existing attachment means re-listing it — the same way `az vm disk attach`
+	// GETs, appends, then updates.
 	updatePoller, err := vmClient.BeginUpdate(ctx, "rg-1", "vm-disks",
 		armcompute.VirtualMachineUpdate{
 			Properties: &armcompute.VirtualMachineProperties{
 				StorageProfile: &armcompute.StorageProfile{
 					DataDisks: []*armcompute.DataDisk{{
+						Lun:          to.Ptr[int32](0),
+						CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+						ManagedDisk:  &armcompute.ManagedDiskParameters{ID: disk1.ID},
+					}, {
 						Lun:          to.Ptr[int32](1),
 						CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
 						ManagedDisk:  &armcompute.ManagedDiskParameters{ID: disk2.ID},
@@ -162,8 +169,9 @@ func TestSDKVMDataDiskAttachDetach(t *testing.T) {
 
 	assertDataDiskLUNs(t, got.Properties.StorageProfile, 0, 1)
 
-	// PATCH detaches lun 0 via toBeDetached — real Azure's Update semantics,
-	// distinct from PUT's declarative "omit to detach".
+	// PATCH detaches lun 0 via toBeDetached while keeping lun 1 — real Azure's
+	// graceful-detach shape (list all disks, mark the one to detach). lun 1 is
+	// re-listed so the full-replace PATCH keeps it attached.
 	detachPoller, err := vmClient.BeginUpdate(ctx, "rg-1", "vm-disks",
 		armcompute.VirtualMachineUpdate{
 			Properties: &armcompute.VirtualMachineProperties{
@@ -171,6 +179,10 @@ func TestSDKVMDataDiskAttachDetach(t *testing.T) {
 					DataDisks: []*armcompute.DataDisk{{
 						Lun:          to.Ptr[int32](0),
 						ToBeDetached: to.Ptr(true),
+					}, {
+						Lun:          to.Ptr[int32](1),
+						CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+						ManagedDisk:  &armcompute.ManagedDiskParameters{ID: disk2.ID},
 					}},
 				},
 			},

--- a/server/azure/virtualmachines/datadisk_lifecycle_test.go
+++ b/server/azure/virtualmachines/datadisk_lifecycle_test.go
@@ -1,0 +1,245 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+)
+
+// TestSDKVMPATCHDataDiskDetachByOmission is the regression test for the PATCH
+// (BeginUpdate) declarative-detach fix: `az vm update` / BeginUpdate remove a
+// data disk by sending the modified (shorter) storageProfile.dataDisks array.
+// A PATCH that supplies a dataDisks array must detach every disk whose LUN is
+// absent from it (a supplied empty array detaches all), clearing each disk's
+// managedBy/diskState — matching real Azure — while a PATCH that omits the
+// array entirely stays a merge-patch and leaves attachments untouched.
+func TestSDKVMPATCHDataDiskDetachByOmission(t *testing.T) {
+	vmClient, diskClient := newDataDiskTestServer(t)
+	ctx := context.Background()
+
+	createBareVM(ctx, t, vmClient, "vm-det")
+
+	diskA, err := createDataDisk(ctx, t, diskClient, "det-a")
+	if err != nil {
+		t.Fatalf("create det-a: %v", err)
+	}
+
+	diskB, err := createDataDisk(ctx, t, diskClient, "det-b")
+	if err != nil {
+		t.Fatalf("create det-b: %v", err)
+	}
+
+	// Attach both disks via PUT (lun 0 = det-a, lun 1 = det-b).
+	putDataDisks(ctx, t, vmClient, "vm-det", []*armcompute.DataDisk{
+		{Lun: to.Ptr[int32](0), CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+			ManagedDisk: &armcompute.ManagedDiskParameters{ID: diskA.ID}},
+		{Lun: to.Ptr[int32](1), CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+			ManagedDisk: &armcompute.ManagedDiskParameters{ID: diskB.ID}},
+	})
+
+	vm, err := vmClient.Get(ctx, "rg-1", "vm-det", nil)
+	if err != nil {
+		t.Fatalf("Get after attach: %v", err)
+	}
+
+	assertDataDiskLUNs(t, vm.Properties.StorageProfile, 0, 1)
+
+	// PATCH with a dataDisks list that supplies ONLY lun 1 (omitting lun 0):
+	// real Azure's full-replace-on-PATCH detaches lun 0's disk. This was the
+	// bug — the PATCH path treated the shorter array as a no-op.
+	patchDataDisks(ctx, t, vmClient, "vm-det", []*armcompute.DataDisk{
+		{Lun: to.Ptr[int32](1), CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+			ManagedDisk: &armcompute.ManagedDiskParameters{ID: diskB.ID}},
+	})
+
+	vm, err = vmClient.Get(ctx, "rg-1", "vm-det", nil)
+	if err != nil {
+		t.Fatalf("Get after PATCH omit lun0: %v", err)
+	}
+
+	// lun 0 detached; lun 1 survives.
+	assertDataDiskLUNs(t, vm.Properties.StorageProfile, 1)
+
+	assertDiskDetached(ctx, t, diskClient, "det-a")
+
+	// PATCH with an explicit EMPTY dataDisks array detaches everything that
+	// remains (lun 1). An empty non-nil array is a full replace with no disks.
+	patchDataDisks(ctx, t, vmClient, "vm-det", []*armcompute.DataDisk{})
+
+	vm, err = vmClient.Get(ctx, "rg-1", "vm-det", nil)
+	if err != nil {
+		t.Fatalf("Get after PATCH empty: %v", err)
+	}
+
+	assertDataDiskLUNs(t, vm.Properties.StorageProfile)
+
+	assertDiskDetached(ctx, t, diskClient, "det-b")
+}
+
+// TestSDKVMDeleteClearsDiskManagedBy is the regression test for the VM-delete
+// disk-lifecycle fix: deleting a VM with an attached data disk (default
+// deleteOption=Detach — the disk survives) must clear the disk's managedBy and
+// return it to Unattached, rather than leaving it dangling at the now-deleted
+// VM. A cleared disk is re-attachable to another VM.
+func TestSDKVMDeleteClearsDiskManagedBy(t *testing.T) {
+	vmClient, diskClient := newDataDiskTestServer(t)
+	ctx := context.Background()
+
+	createBareVM(ctx, t, vmClient, "vm-del")
+
+	disk, err := createDataDisk(ctx, t, diskClient, "del-disk")
+	if err != nil {
+		t.Fatalf("create del-disk: %v", err)
+	}
+
+	putDataDisks(ctx, t, vmClient, "vm-del", []*armcompute.DataDisk{
+		{Lun: to.Ptr[int32](0), CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+			ManagedDisk: &armcompute.ManagedDiskParameters{ID: disk.ID}},
+	})
+
+	// Sanity: the disk is attached before delete.
+	got, err := diskClient.Get(ctx, "rg-1", "del-disk", nil)
+	if err != nil {
+		t.Fatalf("Get del-disk before delete: %v", err)
+	}
+
+	if got.ManagedBy == nil || *got.ManagedBy == "" {
+		t.Fatalf("del-disk managedBy empty before delete, want set")
+	}
+
+	// Delete the VM.
+	delPoller, err := vmClient.BeginDelete(ctx, "rg-1", "vm-del", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete vm-del: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("Delete vm-del poll: %v", err)
+	}
+
+	// The disk survives with managedBy cleared and diskState Unattached.
+	assertDiskDetached(ctx, t, diskClient, "del-disk")
+
+	// A cleared disk is re-attachable: attach it to a fresh VM.
+	createBareVM(ctx, t, vmClient, "vm-del2")
+
+	putDataDisks(ctx, t, vmClient, "vm-del2", []*armcompute.DataDisk{
+		{Lun: to.Ptr[int32](0), CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+			ManagedDisk: &armcompute.ManagedDiskParameters{ID: disk.ID}},
+	})
+
+	vm2, err := vmClient.Get(ctx, "rg-1", "vm-del2", nil)
+	if err != nil {
+		t.Fatalf("Get vm-del2: %v", err)
+	}
+
+	assertDataDiskLUNs(t, vm2.Properties.StorageProfile, 0)
+
+	reattached, err := diskClient.Get(ctx, "rg-1", "del-disk", nil)
+	if err != nil {
+		t.Fatalf("Get del-disk after reattach: %v", err)
+	}
+
+	if reattached.ManagedBy == nil || *reattached.ManagedBy != *vm2.ID {
+		t.Errorf("del-disk managedBy=%v after reattach, want %v", derefStr(reattached.ManagedBy), *vm2.ID)
+	}
+}
+
+// createBareVM provisions a data-disk-less VM through the SDK create path.
+func createBareVM(ctx context.Context, t *testing.T, vmClient *armcompute.VirtualMachinesClient, name string) {
+	t.Helper()
+
+	poller, err := vmClient.BeginCreateOrUpdate(ctx, "rg-1", name,
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				StorageProfile: &armcompute.StorageProfile{
+					ImageReference: &armcompute.ImageReference{
+						Publisher: to.Ptr("Canonical"), Offer: to.Ptr("UbuntuServer"),
+						SKU: to.Ptr("22.04-LTS"), Version: to.Ptr("latest"),
+					},
+				},
+				OSProfile: &armcompute.OSProfile{ComputerName: to.Ptr(name), AdminUsername: to.Ptr("azureuser")},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate %s: %v", name, err)
+	}
+
+	if _, err := pollUntilDone(ctx, poller); err != nil {
+		t.Fatalf("CreateOrUpdate %s poll: %v", name, err)
+	}
+}
+
+// putDataDisks re-PUTs a VM with the given dataDisks set (declarative attach).
+func putDataDisks(
+	ctx context.Context, t *testing.T, vmClient *armcompute.VirtualMachinesClient, name string, disks []*armcompute.DataDisk,
+) {
+	t.Helper()
+
+	poller, err := vmClient.BeginCreateOrUpdate(ctx, "rg-1", name,
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				StorageProfile: &armcompute.StorageProfile{DataDisks: disks},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate %s dataDisks: %v", name, err)
+	}
+
+	if _, err := pollUntilDone(ctx, poller); err != nil {
+		t.Fatalf("CreateOrUpdate %s dataDisks poll: %v", name, err)
+	}
+}
+
+// patchDataDisks PATCHes (BeginUpdate) a VM with the given dataDisks array.
+// A non-nil (empty included) array is a full replace of the disk set.
+func patchDataDisks(
+	ctx context.Context, t *testing.T, vmClient *armcompute.VirtualMachinesClient, name string, disks []*armcompute.DataDisk,
+) {
+	t.Helper()
+
+	poller, err := vmClient.BeginUpdate(ctx, "rg-1", name,
+		armcompute.VirtualMachineUpdate{
+			Properties: &armcompute.VirtualMachineProperties{
+				StorageProfile: &armcompute.StorageProfile{DataDisks: disks},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate %s dataDisks: %v", name, err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("Update %s dataDisks poll: %v", name, err)
+	}
+}
+
+// assertDiskDetached verifies a managed disk is detached: managedBy cleared and
+// diskState back to Unattached.
+func assertDiskDetached(ctx context.Context, t *testing.T, diskClient *armcompute.DisksClient, name string) {
+	t.Helper()
+
+	got, err := diskClient.Get(ctx, "rg-1", name, nil)
+	if err != nil {
+		t.Fatalf("Get %s: %v", name, err)
+	}
+
+	if got.ManagedBy != nil && *got.ManagedBy != "" {
+		t.Errorf("%s managedBy=%v, want empty", name, *got.ManagedBy)
+	}
+
+	if got.Properties == nil || got.Properties.DiskState == nil || *got.Properties.DiskState != armcompute.DiskStateUnattached {
+		t.Errorf("%s diskState=%v, want Unattached", name, diskStateOf(got))
+	}
+}

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -231,10 +231,16 @@ func (h *Handler) update(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 		return
 	}
 
-	// Update's dataDisks is merge-patch, not declarative: a disk is only
-	// detached when its entry explicitly sets toBeDetached (real Azure's
-	// Update semantics), never by omission.
-	if err = h.applyDataDisks(r.Context(), inst.ID, dataDisksOf(req.Properties.StorageProfile), false); err != nil {
+	// A PATCH that omits storageProfile.dataDisks entirely (nil slice) leaves the
+	// attached disks untouched — true merge-patch. But a PATCH that *supplies* a
+	// dataDisks array (non-nil, empty included) is a full replace of the disk set:
+	// real Azure detaches every disk whose LUN is absent from the array (this is
+	// how `az vm update` / BeginUpdate remove a data disk). json.Unmarshal yields
+	// nil for an omitted array and a non-nil (possibly empty) slice for a present
+	// one, so presence is a sufficient declarative-vs-merge discriminator.
+	if err = h.applyDataDisks(
+		r.Context(), inst.ID, dataDisksOf(req.Properties.StorageProfile), dataDisksPresent(req.Properties.StorageProfile),
+	); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
@@ -258,14 +264,25 @@ func dataDisksOf(s *storageProfile) []dataDisk {
 	return s.DataDisks
 }
 
+// dataDisksPresent reports whether the request explicitly supplied a
+// storageProfile.dataDisks array (non-nil, empty included) — the signal that a
+// PATCH is a full replace of the data-disk set rather than a merge-patch that
+// omitted the field. It stays false when storageProfile or its dataDisks array
+// was absent, so an omitted array leaves attachments untouched.
+func dataDisksPresent(s *storageProfile) bool {
+	return s != nil && s.DataDisks != nil
+}
+
 // applyDataDisks reconciles instanceID's attached data disks against disks,
-// the request's storageProfile.dataDisks. declarative selects PUT
-// CreateOrUpdate's full-replace semantics — the array is the VM's complete
-// desired data-disk state, so any currently attached disk whose LUN is absent
-// from disks is detached — versus PATCH Update's merge-patch semantics, where
-// a disk is detached only when its own entry sets toBeDetached and entries
-// absent from the request are left untouched. Both paths attach any entry
-// whose managedDisk.id resolves to a disk not yet attached at that LUN.
+// the request's storageProfile.dataDisks. declarative selects full-replace
+// semantics — the array is the VM's complete desired data-disk state, so any
+// currently attached disk whose LUN is absent from disks is detached — versus
+// merge-patch semantics, where a disk is detached only when its own entry sets
+// toBeDetached and entries absent from the request are left untouched. PUT
+// CreateOrUpdate always uses full-replace; PATCH Update uses full-replace when
+// the request supplies a dataDisks array and merge-patch when it omits one.
+// Both modes attach any entry whose managedDisk.id resolves to a disk not yet
+// attached at that LUN.
 func (h *Handler) applyDataDisks(ctx context.Context, instanceID string, disks []dataDisk, declarative bool) error {
 	vols, err := h.compute.DescribeVolumes(ctx, nil)
 	if err != nil {
@@ -349,6 +366,30 @@ func (h *Handler) attachDataDisk(
 	}
 
 	attached[d.Lun] = volID
+
+	return nil
+}
+
+// detachAttachedVolumes detaches every volume the instance currently holds,
+// clearing each disk's managedBy/diskState (returning it to Unattached). Used on
+// VM delete so surviving managed disks (deleteOption=Detach) don't dangle at the
+// deleted VM. It reuses the driver's DetachVolume — the same call applyDataDisks
+// uses — rather than duplicating detach bookkeeping.
+func (h *Handler) detachAttachedVolumes(ctx context.Context, instanceID string) error {
+	vols, err := h.compute.DescribeVolumes(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	for i := range vols {
+		if vols[i].AttachedTo != instanceID {
+			continue
+		}
+
+		if err := h.compute.DetachVolume(ctx, vols[i].ID); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -546,6 +587,15 @@ func (h *Handler) instanceView(w http.ResponseWriter, r *http.Request, rp azurea
 func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	inst, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	// A deleted VM's attached data disks default to deleteOption=Detach: the disk
+	// survives but must be released. Detach every volume the VM held first so each
+	// disk's managedBy/diskState is cleared (returned to Unattached) rather than
+	// left dangling at the now-deleted VM, matching real Azure.
+	if err := h.detachAttachedVolumes(r.Context(), inst.ID); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}


### PR DESCRIPTION
## What

Two Azure Microsoft.Compute disk-lifecycle correctness fixes, both localized to the `server/azure/virtualmachines` handler.

1. **PATCH `VirtualMachines.Update` dataDisk detach.** `az vm update` / `armcompute.VirtualMachinesClient.BeginUpdate` remove a data disk by sending a modified (shorter/empty) `storageProfile.dataDisks` array. Previously the PATCH path treated a supplied array as merge-patch and only detached a disk whose entry set `toBeDetached`, so an omitted disk stayed attached forever (managedBy/diskState never cleared). PATCH now distinguishes an **omitted** array (nil → merge-patch, untouched) from a **supplied** array (non-nil, empty included → full replace: detach every attached disk whose LUN is absent), matching the PUT path and real Azure's read-modify-write semantics.

2. **Clear disk `managedBy` on VM delete.** Deleting a VM left each attached managed disk's `managedBy` pointing at the now-deleted VM (default `deleteOption=Detach` keeps the disk). VM delete now detaches every attached volume first, clearing each disk's `managedBy`/`diskState` (back to `Unattached`) so the disk is free and re-attachable.

Both reuse the existing driver `DetachVolume` — the same call `applyDataDisks` uses — rather than duplicating detach logic.

## Why

Verified against the official Microsoft.Compute virtualMachines Update docs: a supplied `dataDisks` array on PATCH replaces the list (omitted LUNs detach), and a deleted VM releases its detach-option disks. The emulator diverged on both, breaking `az vm update`/Terraform disk removal and leaving disks unusably "still-managed" after VM deletion.

## Tests

- New `datadisk_lifecycle_test.go` (real `armcompute/v5` SDK):
  - `TestSDKVMPATCHDataDiskDetachByOmission` — PATCH omitting a LUN detaches that disk (managedBy cleared, diskState Unattached); an explicit empty array detaches all.
  - `TestSDKVMDeleteClearsDiskManagedBy` — delete a VM with an attached disk clears managedBy/diskState and the disk re-attaches to a new VM.
- Updated `TestSDKVMDataDiskAttachDetach` to the correct read-modify-write PATCH shape (the old step encoded the now-fixed merge-patch-attach assumption).

Gates: build, vet, scoped tests, -race, golangci-lint (0 issues), gofmt — all green.