### PR TITLE
fix(azure-servicebus): TTL of scheduled messages counts from enqueue time, not submit

### DIFF
--- a/providers/azure/servicebus/scheduled_ttl_test.go
+++ b/providers/azure/servicebus/scheduled_ttl_test.go
@@ -1,0 +1,100 @@
+package servicebus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScheduledMessageSurvivesUntilEnqueue confirms a message scheduled for a
+// future enqueue time with a TTL shorter than the schedule delay is still
+// delivered once it becomes active (rather than being silently reaped before it
+// is ever visible). Real Azure computes expires-at-utc from the enqueued time,
+// not the submit time.
+func TestScheduledMessageSurvivesUntilEnqueue(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newTestMock()
+
+	url := createStdQueue(t, m)
+
+	// Scheduled 60s out with a 30s TTL: on real Azure the message materializes at
+	// +60s and lives until +90s. The buggy path expired it at submit+30s (+30s),
+	// before it ever became visible.
+	_, err := m.SendMessage(ctx, driver.SendMessageInput{
+		QueueURL: url, Body: "scheduled", DelaySeconds: 60, MessageTTLSeconds: ttlPtr(30),
+	})
+	require.NoError(t, err)
+
+	// Advance past the scheduled enqueue time (and past submit+TTL).
+	clk.Advance(61 * time.Second)
+
+	msgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: url, MaxMessages: 1})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1, "scheduled message must survive until its enqueue time")
+	assert.Equal(t, "scheduled", msgs[0].Body)
+
+	// TTL is measured from the scheduled enqueue time: expires-at-utc = enqueue + TTL.
+	wantExpiry := clk.Now().Add((90 - 61) * time.Second) // T0+90s
+	assert.Equal(t, wantExpiry, msgs[0].ExpiresAt, "TTL must count from the scheduled enqueue time")
+}
+
+// TestScheduledMessageExpiresAfterEnqueuePlusTTL confirms the scheduled
+// message's TTL clock runs from the enqueue time: it is gone only after
+// enqueue+TTL, not before.
+func TestScheduledMessageExpiresAfterEnqueuePlusTTL(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newTestMock()
+
+	url := createStdQueue(t, m)
+
+	_, err := m.SendMessage(ctx, driver.SendMessageInput{
+		QueueURL: url, Body: "scheduled", DelaySeconds: 60, MessageTTLSeconds: ttlPtr(30),
+	})
+	require.NoError(t, err)
+
+	// Past enqueue+TTL (T0+90s): the message has now genuinely expired.
+	clk.Advance(91 * time.Second)
+
+	msgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: url, MaxMessages: 1})
+	require.NoError(t, err)
+	assert.Empty(t, msgs, "scheduled message expires at enqueue+TTL")
+}
+
+// TestNonScheduledTTLCountsFromSubmit confirms the fix does not change a
+// non-scheduled message: with no delay, the enqueue time equals the submit time,
+// so the TTL still counts from submit.
+func TestNonScheduledTTLCountsFromSubmit(t *testing.T) {
+	ctx := context.Background()
+
+	send := func(m *Mock, url string) {
+		_, err := m.SendMessage(ctx, driver.SendMessageInput{
+			QueueURL: url, Body: "plain", MessageTTLSeconds: ttlPtr(30),
+		})
+		require.NoError(t, err)
+	}
+
+	// Present just before submit+TTL.
+	m, clk := newTestMock()
+	url := createStdQueue(t, m)
+	send(m, url)
+	clk.Advance(29 * time.Second)
+
+	msgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: url, MaxMessages: 1})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, clk.Now().Add(time.Second), msgs[0].ExpiresAt, "non-scheduled TTL counts from submit")
+
+	// Gone just after submit+TTL.
+	m2, clk2 := newTestMock()
+	url2 := createStdQueue(t, m2)
+	send(m2, url2)
+	clk2.Advance(31 * time.Second)
+
+	msgs2, err := m2.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: url2, MaxMessages: 1})
+	require.NoError(t, err)
+	assert.Empty(t, msgs2, "non-scheduled message expires at submit+TTL")
+}

--- a/providers/azure/servicebus/servicebus.go
+++ b/providers/azure/servicebus/servicebus.go
@@ -284,7 +284,13 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 	}
 
 	visibleAt := now.Add(time.Duration(delaySeconds) * time.Second)
-	expiresAt := computeExpiry(now, input.MessageTTLSeconds)
+	// TimeToLive is measured from when the message becomes active (its enqueue
+	// time), not from submit. For a scheduled message (ScheduledEnqueueTimeUtc in
+	// the future, carried here as a delivery delay) the effective enqueue time is
+	// visibleAt, so a message scheduled for T+delay with a TTL shorter than the
+	// delay still survives until at least T+delay and then lives for its full TTL.
+	// For a non-scheduled send visibleAt == now, so this is unchanged.
+	expiresAt := computeExpiry(visibleAt, input.MessageTTLSeconds)
 
 	msg := &sbMessage{
 		ID:              msgID,

--- a/server/azure/servicebus/dataplane_message_test.go
+++ b/server/azure/servicebus/dataplane_message_test.go
@@ -2,6 +2,7 @@ package servicebus_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -145,5 +146,42 @@ func TestDataPlaneScheduledMessageDelayed(t *testing.T) {
 	early := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/sched/messages/head", "")
 	if early.StatusCode != http.StatusNoContent {
 		t.Fatalf("receive before scheduled time = %d, want 204 (not yet enqueued)", early.StatusCode)
+	}
+}
+
+// TestDataPlaneScheduledMessageTTLFromEnqueue is the regression for silent loss
+// of a scheduled message whose TTL is shorter than the schedule delay: a message
+// scheduled for +120s with a 30s TimeToLive must still be delivered once it
+// becomes active, because expires-at-utc is enqueued-time + TTL, not submit + TTL.
+// The buggy path expired it at submit+30s, before it was ever visible.
+func TestDataPlaneScheduledMessageTTLFromEnqueue(t *testing.T) {
+	srv, clk := newClockServer(t)
+	seedNamespace(t, srv)
+
+	if r := doRequest(t, srv, http.MethodPut, queueURL("schedttl")+apiVer, `{"properties":{}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create queue = %d", r.StatusCode)
+	}
+
+	// The dataplane derives the delivery delay from ScheduledEnqueueTimeUtc via the
+	// wall clock, while TTL reaping runs on the FakeClock (both anchored at start).
+	schedule := time.Now().Add(120 * time.Second).UTC().Format(time.RFC3339)
+	broker := fmt.Sprintf(`{"ScheduledEnqueueTimeUtc":%q,"TimeToLive":30}`, schedule)
+
+	send := doRequest(t, srv, http.MethodPost, "/"+nsName+"/schedttl/messages", "future",
+		map[string]string{"BrokerProperties": broker})
+	if send.StatusCode != http.StatusCreated {
+		t.Fatalf("send = %d, want 201", send.StatusCode)
+	}
+
+	// Advance past the scheduled enqueue time (and well past submit+TTL).
+	clk.Advance(121 * time.Second)
+
+	got := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/schedttl/messages/head", "")
+	if got.StatusCode != http.StatusOK {
+		t.Fatalf("receive after enqueue = %d, want 200 (delivered, not lost to TTL)", got.StatusCode)
+	}
+
+	if body := readBody(t, got); body != "future" {
+		t.Fatalf("body = %q, want future", body)
 	}
 }


### PR DESCRIPTION
## What

A scheduled Service Bus message's TTL clock started at submit time instead of at the scheduled enqueue time. So a message scheduled for the future with a `TimeToLive` shorter than the schedule delay expired **before it ever became visible** and was silently lost.

Fix: base the message expiry on the effective enqueue time (`visibleAt`) rather than the submit time:

```go
expiresAt := computeExpiry(visibleAt, input.MessageTTLSeconds)
```

For a non-scheduled send `visibleAt == now`, so that path is unchanged.

## Why

Per the official Azure Service Bus docs (message expiration): *"The message expiration time depends on the enqueued time, not on the time at which the message is sent to Service Bus. Therefore, the expires-at-utc is still enqueued time + time-to-live."* Example from the docs: schedule +5 min, TTL 10 min → expires at +15 min.

Before this fix, a message scheduled for +60s with a 30s TTL got `ExpiresAt = submit + 30s = +30s`, which is before its +60s enqueue time, so it was reaped and never delivered (round-2 re-audit finding S1, MED, silent message loss).

## Tests

- `providers/azure/servicebus/scheduled_ttl_test.go` — scheduled message survives until its enqueue time and is delivered; its `ExpiresAt` equals enqueue+TTL; it expires only after enqueue+TTL; a non-scheduled message's TTL still counts from submit.
- `server/azure/servicebus/dataplane_message_test.go` — `TestDataPlaneScheduledMessageTTLFromEnqueue`: end-to-end reproduction over the Brokered-Messaging REST data plane with a FakeClock — a message scheduled +120s with a 30s TTL is delivered after enqueue instead of being lost.

Both new tests fail on the pre-fix code and pass after. Existing Service Bus tests (incl. the #621 DLQ/TTL/scheduled tests) stay green; `-race` clean; lint 0 new issues.
