### PR TITLE
fix(azure-cosmos): account delete fully tears down namespace + prunes accountAttrs

### DIFF
--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -195,6 +195,29 @@ func (m *Mock) DeleteTable(_ context.Context, name string) error {
 	return nil
 }
 
+// PurgeAccount fully tears down a Cosmos databaseAccount's driver footprint: the
+// account's own table, every data-plane container table in its namespace (the
+// tables whose name is prefixed "{account}/"), and the account's discovery
+// attributes (accountAttrs). A plain DeleteTable removes only the single named
+// table, which left the deleted account visible in AccountTables and its
+// container tables live; PurgeAccount is the account-delete teardown that makes
+// a deleted account stop listing and a same-name recreate start from an empty
+// namespace.
+func (m *Mock) PurgeAccount(account string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.tables, account)
+	delete(m.accountAttrs, account)
+
+	prefix := account + "/"
+	for name := range m.tables {
+		if strings.HasPrefix(name, prefix) {
+			delete(m.tables, name)
+		}
+	}
+}
+
 // DescribeTable returns the configuration of a container (table).
 func (m *Mock) DescribeTable(_ context.Context, name string) (*driver.TableConfig, error) {
 	m.mu.RLock()

--- a/providers/azure/cosmosdb/purge_account_test.go
+++ b/providers/azure/cosmosdb/purge_account_test.go
@@ -1,0 +1,63 @@
+package cosmosdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPurgeAccount verifies the account-delete teardown drops the account's own
+// table, its discovery attributes and every data-plane container table in its
+// namespace, while leaving another account's namespace and attributes intact.
+func TestPurgeAccount(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	// acct1: the account table, its attributes and one container table.
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "acct1"}))
+	m.SetTableAttributes("acct1", driver.AccountAttributes{Kind: "GlobalDocumentDB"})
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "acct1/db1/coll1", PartitionKey: "pk"}))
+
+	// acct2: an independent account that must survive acct1's purge.
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "acct2"}))
+	m.SetTableAttributes("acct2", driver.AccountAttributes{Kind: "MongoDB"})
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "acct2/db1/coll1", PartitionKey: "pk"}))
+
+	m.PurgeAccount("acct1")
+
+	// acct1 is gone: not listed as an account, its own table and its container
+	// table no longer describe.
+	assert.NotContains(t, m.AccountTables(), "acct1", "purged account must not linger in AccountTables")
+
+	_, err := m.DescribeTable(ctx, "acct1")
+	require.Error(t, err, "purged account's own table must be gone")
+
+	_, err = m.DescribeTable(ctx, "acct1/db1/coll1")
+	require.Error(t, err, "purged account's container table must be gone")
+
+	// acct2 is untouched.
+	assert.Contains(t, m.AccountTables(), "acct2", "the other account must survive the purge")
+
+	_, err = m.DescribeTable(ctx, "acct2/db1/coll1")
+	require.NoError(t, err, "the other account's container table must survive")
+}
+
+// TestPurgeAccountUnknown verifies purging an account that was never created is a
+// no-op that leaves existing state intact.
+func TestPurgeAccountUnknown(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "acct1"}))
+	m.SetTableAttributes("acct1", driver.AccountAttributes{Kind: "GlobalDocumentDB"})
+
+	m.PurgeAccount("does-not-exist")
+
+	assert.Contains(t, m.AccountTables(), "acct1")
+
+	_, err := m.DescribeTable(ctx, "acct1")
+	require.NoError(t, err)
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -275,12 +275,15 @@ func New(d Drivers) http.Handler {
 	// Cosmos DB matches on /dbs/* paths — register before the catch-all
 	// blob handler.
 	if d.CosmosDB != nil {
-		srv.Register(cosmosdb.New(d.CosmosDB))
+		cosmosDataPlane := cosmosdb.New(d.CosmosDB)
+		srv.Register(cosmosDataPlane)
 		// Cosmos-account ARM control plane (Microsoft.DocumentDB/databaseAccounts).
 		// Claims only the /providers/Microsoft.DocumentDB/databaseAccounts/
 		// management path — disjoint from the /dbs data plane above and from
-		// managedcassandra (cassandraClusters), so order is unconstrained.
-		srv.Register(cosmosaccount.New(d.CosmosDB))
+		// managedcassandra (cassandraClusters), so order is unconstrained. Account
+		// DELETE is delegated to the data-plane handler so the account is torn
+		// down fully (tables, attributes and data-plane bookkeeping).
+		srv.Register(cosmosaccount.New(d.CosmosDB, cosmosDataPlane))
 	}
 
 	// Managed Cassandra matches ARM Microsoft.DocumentDB/cassandraClusters paths

--- a/server/azure/cosmosaccount/account_delete_test.go
+++ b/server/azure/cosmosaccount/account_delete_test.go
@@ -1,0 +1,141 @@
+// Real-user end-to-end test for account deletion (round-2 finding C1): deleting a
+// Cosmos databaseAccount must be a FULL teardown, not a shallow one. Driving the
+// live armcosmos control plane and the azcosmos data plane against one emulator,
+// it proves that after BeginDelete:
+//   - the deleted account is gone from List (no ghost) and GET 404s;
+//   - recreating a same-named account starts CLEAN — none of the previous
+//     incarnation's databases/containers/items survive;
+//   - a DIFFERENT account's databases/containers/items are untouched.
+package cosmosaccount_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// listAccountNames returns the set of databaseAccount names the subscription
+// List pager reports, used to assert presence/absence of an account.
+func listAccountNames(ctx context.Context, t *testing.T, stack *cosmosStack) map[string]bool {
+	t.Helper()
+
+	names := map[string]bool{}
+	pager := stack.arm.NewListPager(nil)
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		require.NoError(t, err)
+
+		for _, acc := range page.Value {
+			require.NotNil(t, acc.Name)
+			names[*acc.Name] = true
+		}
+	}
+
+	return names
+}
+
+// databaseIDs returns the ids of the databases the data-plane client can see.
+func databaseIDs(ctx context.Context, t *testing.T, client *azcosmos.Client) []string {
+	t.Helper()
+
+	var ids []string
+	pager := client.NewQueryDatabasesPager("SELECT * FROM root", nil)
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		require.NoError(t, err)
+
+		for _, db := range page.Databases {
+			ids = append(ids, db.ID)
+		}
+	}
+
+	return ids
+}
+
+// putUser writes {id, pk, who} into a users container and reads it back to
+// confirm the write landed.
+func putUser(ctx context.Context, t *testing.T, cc *azcosmos.ContainerClient, id, pk, who string) {
+	t.Helper()
+
+	doc, err := json.Marshal(map[string]any{"id": id, "pk": pk, "who": who})
+	require.NoError(t, err)
+
+	_, err = cc.CreateItem(ctx, azcosmos.NewPartitionKeyString(pk), doc, nil)
+	require.NoError(t, err)
+}
+
+// TestSDKCosmosAccountDeleteTearsDownNamespace is the C1 reproduction: an account
+// delete fully tears down the account (no List ghost, clean same-name recreate)
+// while leaving other accounts untouched.
+func TestSDKCosmosAccountDeleteTearsDownNamespace(t *testing.T) {
+	ctx := context.Background()
+	stack := newCosmosStack(t)
+
+	// Two accounts, each with its own appdb/users and one item.
+	epDel := stack.createAccountEndpoint(t, "rg-del", "acct-del")
+	epKeep := stack.createAccountEndpoint(t, "rg-keep", "acct-keep")
+
+	clientDel := stack.dataClient(t, epDel)
+	usersDel := makeUsersContainer(ctx, t, clientDel)
+	putUser(ctx, t, usersDel, "u1", "team-a", "before-delete")
+
+	clientKeep := stack.dataClient(t, epKeep)
+	usersKeep := makeUsersContainer(ctx, t, clientKeep)
+	putUser(ctx, t, usersKeep, "k1", "team-k", "keeper")
+
+	// Delete acct-del through the real armcosmos LRO.
+	poller, err := stack.arm.BeginDelete(ctx, "rg-del", "acct-del", nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	// No ghost: List no longer returns acct-del, but still returns acct-keep.
+	names := listAccountNames(ctx, t, stack)
+	assert.False(t, names["acct-del"], "deleted account must not linger in List (ghost)")
+	assert.True(t, names["acct-keep"], "the other account must survive the delete")
+
+	// GET on the deleted account 404s.
+	_, err = stack.arm.Get(ctx, "rg-del", "acct-del", nil)
+	wantStatus(t, err, 404, "GET on deleted account")
+
+	// Recreate a same-named account: it must start from an empty namespace.
+	epDel2 := stack.createAccountEndpoint(t, "rg-del", "acct-del")
+	clientDel2 := stack.dataClient(t, epDel2)
+
+	assert.Empty(t, databaseIDs(ctx, t, clientDel2),
+		"a same-name recreate must inherit no stale databases")
+
+	dbDel2, err := clientDel2.NewDatabase("appdb")
+	require.NoError(t, err)
+
+	usersDel2, err := dbDel2.NewContainer("users")
+	require.NoError(t, err)
+
+	_, err = usersDel2.Read(ctx, nil)
+	wantStatus(t, err, 404, "recreated account reading the previous incarnation's container")
+
+	_, err = usersDel2.ReadItem(ctx, azcosmos.NewPartitionKeyString("team-a"), "u1", nil)
+	wantStatus(t, err, 404, "recreated account reading the previous incarnation's item")
+
+	// The recreated account is visible again; the keeper is still present.
+	names = listAccountNames(ctx, t, stack)
+	assert.True(t, names["acct-del"], "recreated account must appear in List")
+	assert.True(t, names["acct-keep"], "the other account must still be listed")
+
+	// The other account's data is entirely untouched by the delete + recreate.
+	assert.Equal(t, []string{"appdb"}, databaseIDs(ctx, t, clientKeep),
+		"the other account keeps its database")
+
+	readK, err := usersKeep.ReadItem(ctx, azcosmos.NewPartitionKeyString("team-k"), "k1", nil)
+	require.NoError(t, err, "the other account's item must survive")
+
+	var gotK map[string]any
+	require.NoError(t, json.Unmarshal(readK.Value, &gotK))
+	assert.Equal(t, "keeper", gotK["who"], "the other account's item is unchanged")
+}

--- a/server/azure/cosmosaccount/handler.go
+++ b/server/azure/cosmosaccount/handler.go
@@ -54,16 +54,30 @@ type attrBackend interface {
 	AccountTables() []string
 }
 
+// AccountPurger tears down a deleted account's full footprint in one step: its
+// driver tables (the account's own table plus every container table in its
+// namespace), its discovery attributes, and the cosmos data-plane handler's
+// in-memory database/offer/attrs bookkeeping. The account control plane
+// delegates DELETE to it so a deleted account leaves no ghost in List and a
+// same-name recreate starts from an empty namespace. The cosmos data-plane
+// handler implements it.
+type AccountPurger interface {
+	PurgeAccount(ctx context.Context, account string)
+}
+
 // Handler serves Microsoft.DocumentDB/databaseAccounts ARM requests against a
 // database driver.
 type Handler struct {
-	db    dbdriver.Database
-	attrs attrBackend // nil when the driver doesn't expose account attributes
+	db     dbdriver.Database
+	attrs  attrBackend   // nil when the driver doesn't expose account attributes
+	purger AccountPurger // tears down an account's data-plane footprint on delete
 }
 
-// New returns a Cosmos-account handler backed by db.
-func New(db dbdriver.Database) *Handler {
-	h := &Handler{db: db}
+// New returns a Cosmos-account handler backed by db. purger is the cosmos
+// data-plane handler, to which account DELETE is delegated so an account is torn
+// down fully (tables, attributes and data-plane bookkeeping), not shallowly.
+func New(db dbdriver.Database, purger AccountPurger) *Handler {
+	h := &Handler{db: db, purger: purger}
 	if a, ok := db.(attrBackend); ok {
 		h.attrs = a
 	}
@@ -249,12 +263,28 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp *azurearm.Reso
 }
 
 func (h *Handler) deleteAccount(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	// A shallow DeleteTable(account) would leave the account visible in List (its
+	// discovery attributes linger) and its databases/containers live for a
+	// same-name recreate to inherit. Delegate to the data-plane purger, which
+	// drops the account's tables, attributes and data-plane bookkeeping in one
+	// idempotent step.
+	//
+	// Delete is a long-running op in real Azure; complete it synchronously with
+	// an empty 204 so the SDK's poller terminates (armcosmos BeginDelete accepts
+	// only 202/204 — a 200 fails its client-side response validation).
+	if h.purger != nil {
+		h.purger.PurgeAccount(r.Context(), rp.ResourceName)
+		w.WriteHeader(http.StatusNoContent)
+
+		return
+	}
+
 	if err := h.db.DeleteTable(r.Context(), rp.ResourceName); err != nil && !cerrors.IsNotFound(err) {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // toARMAccount renders the ARM databaseAccounts wire shape, reading the stored

--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -468,6 +468,62 @@ func (h *Handler) deleteDatabase(w http.ResponseWriter, r *http.Request, account
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// accountPurger is the optional driver capability that tears down a Cosmos
+// databaseAccount's driver footprint (its own table, every "{account}/…"
+// container table, and its discovery attributes) in one step. The Azure cosmos
+// provider implements it; DynamoDB/Firestore don't.
+type accountPurger interface {
+	PurgeAccount(account string)
+}
+
+// PurgeAccount removes every trace of a Cosmos databaseAccount: the data-plane
+// wire state this handler tracks (the account's databases set, their
+// shared-throughput offers, and every container's offer + TTL/attrs
+// bookkeeping) and, via the driver, the account's own table, its container
+// tables and its discovery attributes. The account control plane calls this on
+// DELETE so a deleted account stops listing (no ghost) and a same-name recreate
+// starts from an empty namespace. It is idempotent — purging an unknown account
+// is a no-op.
+func (h *Handler) PurgeAccount(ctx context.Context, account string) {
+	// Reap the offer + TTL/attrs bookkeeping for every container table in the
+	// account's namespace before the driver drops the tables underneath us.
+	prefix := nsPrefix(account)
+
+	if tables, err := h.db.ListTables(ctx); err == nil {
+		for _, t := range tables {
+			if strings.HasPrefix(t, prefix) {
+				h.deleteOffer(t)
+				h.attrs.delete(t)
+			}
+		}
+	}
+
+	// Drop the account's databases and each one's shared-throughput offer.
+	h.dbMu.Lock()
+	dbKeys := make([]string, 0)
+
+	for key := range h.databases {
+		if _, ok := accountDBName(key, account); ok {
+			dbKeys = append(dbKeys, key)
+			delete(h.databases, key)
+		}
+	}
+	h.dbMu.Unlock()
+
+	for _, key := range dbKeys {
+		h.deleteOffer(key)
+	}
+
+	// Tear down the driver namespace in one step: the account's own table, its
+	// "{account}/…" container tables, and its discovery attributes.
+	if p, ok := h.db.(accountPurger); ok {
+		p.PurgeAccount(account)
+		return
+	}
+
+	_ = h.db.DeleteTable(ctx, account)
+}
+
 func (h *Handler) containerCollection(w http.ResponseWriter, r *http.Request, account, db string) {
 	switch r.Method {
 	case http.MethodPost:


### PR DESCRIPTION
## What

Deleting a Cosmos `databaseAccount` was a **shallow** teardown. The ARM delete path called `DeleteTable(account)`, which dropped only the account's own driver table — it never pruned `accountAttrs`, the account's container tables, or the data-plane handler's in-memory bookkeeping.

Consequences (round-2 re-audit finding C1, MED):
- the deleted account **still appeared in `List`** (a ghost — while `GET` 404'd, an inconsistency real clients trip over);
- its data-plane namespace stayed live (`isAccount` still true);
- recreating a **same-named** account (CI teardown+setup, `terraform destroy`+`apply`) **inherited the previous incarnation's databases/containers/items** — a stale-data leak across lifecycles, especially after the per-account isolation work in #620.

## Why / Fix

Tear the account down fully, across all three layers:

- **Driver** (`providers/azure/cosmosdb`): new `PurgeAccount(account)` drops the account's own table, its `accountAttrs` entry, and every `{account}/…` container table (only that account's prefix — other accounts' namespaces are untouched).
- **Data-plane wire handler** (`server/azure/cosmosdb`): new `PurgeAccount(ctx, account)` prunes its own `databases` set, shared-throughput offers, and container TTL/attrs bookkeeping for the account, then delegates to the driver purge.
- **ARM control plane** (`server/azure/cosmosaccount`): `deleteAccount` delegates to the data-plane purger and returns **204** — the real `armcosmos` `BeginDelete` poller accepts only 202/204 (a 200 fails its client-side validation), so account delete now works via the real SDK.

After delete the account is gone from `List` (no ghost), `GET` 404s, its data plane stops serving, and a same-name recreate starts from an empty namespace.

## Tests

- Real `armcosmos` v3 + `azcosmos` end-to-end: create account → db/container/item → `BeginDelete` → account NOT in `List`, `GET` 404 → recreate same name → its database/container list is EMPTY (no stale data) → a different account's data is untouched.
- Provider-level `PurgeAccount` unit tests (namespace teardown + other-account isolation + unknown-account no-op).
- Existing cosmos tests (incl. #620 isolation + indexingPolicy round-trip) stay green.
