### PR TITLE
fix(azure-rm): complete RG cascade (public IP/NIC/NAT/LB) + detach disks on cascade VM delete

### DIFF
--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -221,17 +221,35 @@ func New(d Drivers) http.Handler {
 		vnetHandler    *vnet.Handler
 		vmHandler      *virtualmachines.Handler
 		storageHandler *storageaccountsrv.Handler
+		lbHandler      *lbsrv.Handler
 		rgPurgers      []resourcegroups.ResourceGroupPurger
 	)
+
+	// Virtual machines are purged before the networking resources they consume
+	// (NICs, subnets): tearing a VM down first clears its NICs' virtualMachine
+	// back-reference, so the vnet purger's NIC delete is not blocked by the
+	// attached-NIC guard.
+	if d.VirtualMachines != nil {
+		vmHandler = virtualmachines.New(d.VirtualMachines, d.Network)
+		rgPurgers = append(rgPurgers, vmHandler)
+	}
 
 	if d.Network != nil {
 		vnetHandler = vnet.New(d.Network)
 		rgPurgers = append(rgPurgers, vnetHandler)
 	}
 
-	if d.VirtualMachines != nil {
-		vmHandler = virtualmachines.New(d.VirtualMachines, d.Network)
-		rgPurgers = append(rgPurgers, vmHandler)
+	if d.LB != nil {
+		lbHandler = lbsrv.New(d.LB)
+
+		// Project a backend address pool's read-only backendIPConfigurations from
+		// the NIC side of the association, so NIC↔LB pool membership reflects on
+		// both sides. Only wired when the networking driver exposes NICs.
+		if nics, ok := d.Network.(netdriver.AzureNetworkInterfaces); ok {
+			lbHandler.SetNICResolver(nics)
+		}
+
+		rgPurgers = append(rgPurgers, lbHandler)
 	}
 
 	if d.BlobStorage != nil {
@@ -311,16 +329,7 @@ func New(d Drivers) http.Handler {
 	// type (loadBalancers vs virtualNetworks / networkSecurityGroups /
 	// locations / dnsZones), so registration order relative to them is
 	// unconstrained. Registered before the BlobStorage fallback.
-	if d.LB != nil {
-		lbHandler := lbsrv.New(d.LB)
-
-		// Project a backend address pool's read-only backendIPConfigurations from
-		// the NIC side of the association, so NIC↔LB pool membership reflects on
-		// both sides. Only wired when the networking driver exposes NICs.
-		if nics, ok := d.Network.(netdriver.AzureNetworkInterfaces); ok {
-			lbHandler.SetNICResolver(nics)
-		}
-
+	if lbHandler != nil {
 		srv.Register(lbHandler)
 	}
 

--- a/server/azure/loadbalancer/operations.go
+++ b/server/azure/loadbalancer/operations.go
@@ -97,6 +97,41 @@ func (h *Handler) deleteLoadBalancer(w http.ResponseWriter, r *http.Request, rp 
 	w.WriteHeader(http.StatusOK)
 }
 
+// PurgeResourceGroup deletes every load balancer stored under the given resource
+// group, backing the resource-group cascade delete: an RG is a pure container,
+// so removing it must remove the load balancers created under it rather than
+// leaving them as globally addressable orphans. Load balancers are stored
+// resource-group-natively (keyed by resourceGroup+name), so ListAzureLoadBalancers
+// already scopes to the group. Each delete also drops the minimal cross-cloud
+// discovery record, mirroring deleteLoadBalancer. Best-effort: a single failure
+// is returned but does not stop the remaining teardown. The subscription is
+// unused (the emulator is single-estate).
+func (h *Handler) PurgeResourceGroup(ctx context.Context, _, resourceGroup string) error {
+	az, ok := h.azureLB()
+	if !ok {
+		return nil
+	}
+
+	lbs, err := az.ListAzureLoadBalancers(ctx, resourceGroup)
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+
+	for i := range lbs {
+		if derr := az.DeleteAzureLoadBalancer(ctx, lbs[i].ResourceGroup, lbs[i].Name); derr != nil && firstErr == nil {
+			firstErr = derr
+		}
+
+		if generic, ferr := h.findGenericLB(ctx, lbs[i].Name); ferr == nil {
+			_ = h.lb.DeleteLoadBalancer(ctx, generic.ARN)
+		}
+	}
+
+	return firstErr
+}
+
 func (h *Handler) listLoadBalancers(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	az, ok := h.azureLB()
 	if !ok {

--- a/server/azure/resourcegroups/cascade_completion_test.go
+++ b/server/azure/resourcegroups/cascade_completion_test.go
@@ -1,0 +1,320 @@
+// Deep-audit round-2 regression (R1): the resource-group cascade delete was
+// incomplete. Deleting an RG tore down vnets, NSGs, VMs and storage accounts but
+// orphaned the other Microsoft.Network children — public IPs, network
+// interfaces, NAT gateways and load balancers — leaving them alive and globally
+// addressable (ghosts that block name reuse and show in subscription-wide
+// lists). Folded in with the #627 review nit: a cascade-deleted VM must also
+// clear its attached data disks' managedBy (deleteOption=Detach), the same
+// release the single-VM delete path does.
+//
+// Real Azure deletes every resource contained in a group. This test creates a
+// group holding a public IP, a NIC, a NAT gateway, a load balancer and a
+// VM-with-data-disk, deletes the group, and asserts every contained network
+// resource is gone (404) while the detached data disk survives with its
+// managedBy cleared — and that an identically-shaped resource in a DIFFERENT
+// group is untouched.
+
+package resourcegroups_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// cascadeClients bundles the ARM clients the completion test drives against one
+// full Azure server.
+type cascadeClients struct {
+	rg   *armresources.ResourceGroupsClient
+	pip  *armnetwork.PublicIPAddressesClient
+	vnet *armnetwork.VirtualNetworksClient
+	nic  *armnetwork.InterfacesClient
+	nat  *armnetwork.NatGatewaysClient
+	lb   *armnetwork.LoadBalancersClient
+	disk *armcompute.DisksClient
+	vm   *armcompute.VirtualMachinesClient
+}
+
+func newCascadeClients(t *testing.T) *cascadeClients {
+	t.Helper()
+
+	// The account id must equal the subscription the SDK clients address so the
+	// VM's stamped resource id matches the NIC-attach path (see nic_crossref).
+	cloudP := cloudemu.NewAzure(config.WithAccountID(subID))
+
+	ts := httptest.NewTLSServer(azureserver.NewFromProvider(cloudP))
+	t.Cleanup(ts.Close)
+
+	opts := armOpts(ts)
+
+	rgc, err := armresources.NewResourceGroupsClient(subID, fakeCred{}, opts)
+	require.NoError(t, err)
+
+	pipc, err := armnetwork.NewPublicIPAddressesClient(subID, fakeCred{}, opts)
+	require.NoError(t, err)
+
+	vnetc, err := armnetwork.NewVirtualNetworksClient(subID, fakeCred{}, opts)
+	require.NoError(t, err)
+
+	nicc, err := armnetwork.NewInterfacesClient(subID, fakeCred{}, opts)
+	require.NoError(t, err)
+
+	natc, err := armnetwork.NewNatGatewaysClient(subID, fakeCred{}, opts)
+	require.NoError(t, err)
+
+	lbc, err := armnetwork.NewLoadBalancersClient(subID, fakeCred{}, opts)
+	require.NoError(t, err)
+
+	diskc, err := armcompute.NewDisksClient(subID, fakeCred{}, opts)
+	require.NoError(t, err)
+
+	vmc, err := armcompute.NewVirtualMachinesClient(subID, fakeCred{}, opts)
+	require.NoError(t, err)
+
+	return &cascadeClients{rg: rgc, pip: pipc, vnet: vnetc, nic: nicc, nat: natc, lb: lbc, disk: diskc, vm: vmc}
+}
+
+// TestResourceGroupDeleteCascadesNetworkChildrenAndDetachesDisks is the
+// load-bearing regression test for finding R1 plus the #627 cascade disk-detach
+// nit.
+func TestResourceGroupDeleteCascadesNetworkChildrenAndDetachesDisks(t *testing.T) {
+	ctx := context.Background()
+	c := newCascadeClients(t)
+
+	const (
+		rg      = "rg-full"
+		otherRG = "rg-other"
+	)
+
+	require.NoError(t, createRG(ctx, c.rg, rg))
+	require.NoError(t, createRG(ctx, c.rg, otherRG))
+
+	// A public IP in a DIFFERENT resource group must survive the delete below.
+	createSDKPublicIP(ctx, t, c.pip, otherRG, "pip-other")
+
+	// Contained network resources.
+	createSDKPublicIP(ctx, t, c.pip, rg, "pip-full")
+	subnetID := createSDKVNetWithSubnet(ctx, t, c.vnet, rg, "vnet-full", "sub1")
+	nicID := createSDKNICWithPublicIP(ctx, t, c.nic, rg, "nic-full", subnetID,
+		publicIPID(rg, "pip-full"))
+	createSDKNATGateway(ctx, t, c.nat, rg, "nat-full")
+	createSDKLoadBalancer(ctx, t, c.lb, rg, "lb-full")
+
+	// A VM with an attached data disk, whose NIC is the one created above (so the
+	// cascade must tear the VM down before the NIC — and clear the disk).
+	diskID := createSDKEmptyDisk(ctx, t, c.disk, rg, "disk-full")
+	createSDKVMWithNICAndDisk(ctx, t, c.vm, rg, "vm-full", nicID, diskID)
+
+	// Sanity: the disk is attached (managedBy set) before the delete.
+	before, err := c.disk.Get(ctx, rg, "disk-full", nil)
+	require.NoError(t, err)
+	require.NotNil(t, before.ManagedBy)
+	require.NotEmpty(t, *before.ManagedBy, "disk should be attached before RG delete")
+
+	// Delete the resource group and wait for the cascade.
+	delPoller, err := c.rg.BeginDelete(ctx, rg, nil)
+	require.NoError(t, err)
+	_, err = delPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	require.NoError(t, err)
+
+	// Every contained network resource is gone (404), not merely the group.
+	assertGone(t, "public IP", func() error { _, e := c.pip.Get(ctx, rg, "pip-full", nil); return e })
+	assertGone(t, "network interface", func() error { _, e := c.nic.Get(ctx, rg, "nic-full", nil); return e })
+	assertGone(t, "NAT gateway", func() error { _, e := c.nat.Get(ctx, rg, "nat-full", nil); return e })
+	assertGone(t, "load balancer", func() error { _, e := c.lb.Get(ctx, rg, "lb-full", nil); return e })
+	assertGone(t, "virtual network", func() error { _, e := c.vnet.Get(ctx, rg, "vnet-full", nil); return e })
+
+	// The data disk survives the cascade but with its managedBy cleared and its
+	// diskState back to Unattached — the deleteOption=Detach release, now applied
+	// on the cascade path too.
+	after, err := c.disk.Get(ctx, rg, "disk-full", nil)
+	require.NoError(t, err, "data disk should survive the cascade (deleteOption=Detach)")
+
+	if after.ManagedBy != nil && *after.ManagedBy != "" {
+		t.Errorf("disk-full managedBy=%q after cascade, want cleared", *after.ManagedBy)
+	}
+
+	if after.Properties == nil || after.Properties.DiskState == nil ||
+		*after.Properties.DiskState != armcompute.DiskStateUnattached {
+		t.Errorf("disk-full diskState not Unattached after cascade")
+	}
+
+	// The resource in the OTHER group is untouched.
+	_, err = c.pip.Get(ctx, otherRG, "pip-other", nil)
+	require.NoError(t, err, "public IP in a different resource group must not be affected by the delete")
+}
+
+func createRG(ctx context.Context, client *armresources.ResourceGroupsClient, name string) error {
+	_, err := client.CreateOrUpdate(ctx, name, armresources.ResourceGroup{Location: to.Ptr("eastus")}, nil)
+
+	return err
+}
+
+func createSDKPublicIP(ctx context.Context, t *testing.T, client *armnetwork.PublicIPAddressesClient, rg, name string) {
+	t.Helper()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rg, name, armnetwork.PublicIPAddress{
+		Location: to.Ptr("eastus"),
+		SKU:      &armnetwork.PublicIPAddressSKU{Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard)},
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+		},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	require.NoError(t, err)
+}
+
+func createSDKVNetWithSubnet(
+	ctx context.Context, t *testing.T, client *armnetwork.VirtualNetworksClient, rg, name, subnet string,
+) string {
+	t.Helper()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rg, name, armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+			Subnets: []*armnetwork.Subnet{{
+				Name:       to.Ptr(subnet),
+				Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.0.0/24")},
+			}},
+		},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	require.NoError(t, err)
+
+	return "/subscriptions/" + subID + "/resourceGroups/" + rg +
+		"/providers/Microsoft.Network/virtualNetworks/" + name + "/subnets/" + subnet
+}
+
+func createSDKNICWithPublicIP(
+	ctx context.Context, t *testing.T, client *armnetwork.InterfacesClient, rg, name, subnetID, pipID string,
+) string {
+	t.Helper()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rg, name, armnetwork.Interface{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig1"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					PrivateIPAddress:          to.Ptr("10.0.0.10"),
+					PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+					Subnet:                    &armnetwork.Subnet{ID: to.Ptr(subnetID)},
+					PublicIPAddress:           &armnetwork.PublicIPAddress{ID: to.Ptr(pipID)},
+				},
+			}},
+		},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	require.NoError(t, err)
+
+	return "/subscriptions/" + subID + "/resourceGroups/" + rg +
+		"/providers/Microsoft.Network/networkInterfaces/" + name
+}
+
+func createSDKNATGateway(ctx context.Context, t *testing.T, client *armnetwork.NatGatewaysClient, rg, name string) {
+	t.Helper()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rg, name, armnetwork.NatGateway{
+		Location:   to.Ptr("eastus"),
+		SKU:        &armnetwork.NatGatewaySKU{Name: to.Ptr(armnetwork.NatGatewaySKUNameStandard)},
+		Properties: &armnetwork.NatGatewayPropertiesFormat{},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	require.NoError(t, err)
+}
+
+func createSDKLoadBalancer(ctx context.Context, t *testing.T, client *armnetwork.LoadBalancersClient, rg, name string) {
+	t.Helper()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rg, name, armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		SKU:      &armnetwork.LoadBalancerSKU{Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard)},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	require.NoError(t, err)
+}
+
+func createSDKEmptyDisk(ctx context.Context, t *testing.T, client *armcompute.DisksClient, rg, name string) string {
+	t.Helper()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rg, name, armcompute.Disk{
+		Location: to.Ptr("eastus"),
+		Properties: &armcompute.DiskProperties{
+			CreationData: &armcompute.CreationData{CreateOption: to.Ptr(armcompute.DiskCreateOptionEmpty)},
+			DiskSizeGB:   to.Ptr[int32](4),
+		},
+	}, nil)
+	require.NoError(t, err)
+	created, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	require.NoError(t, err)
+	require.NotNil(t, created.ID)
+
+	return *created.ID
+}
+
+func createSDKVMWithNICAndDisk(
+	ctx context.Context, t *testing.T, client *armcompute.VirtualMachinesClient, rg, name, nicID, diskID string,
+) {
+	t.Helper()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rg, name, armcompute.VirtualMachine{
+		Location: to.Ptr("eastus"),
+		Properties: &armcompute.VirtualMachineProperties{
+			HardwareProfile: &armcompute.HardwareProfile{
+				VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+			},
+			StorageProfile: &armcompute.StorageProfile{
+				OSDisk: &armcompute.OSDisk{OSType: to.Ptr(armcompute.OperatingSystemTypesLinux)},
+				DataDisks: []*armcompute.DataDisk{{
+					Lun:          to.Ptr[int32](0),
+					CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+					ManagedDisk:  &armcompute.ManagedDiskParameters{ID: to.Ptr(diskID)},
+				}},
+			},
+			NetworkProfile: &armcompute.NetworkProfile{
+				NetworkInterfaces: []*armcompute.NetworkInterfaceReference{{ID: to.Ptr(nicID)}},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	require.NoError(t, err)
+}
+
+func publicIPID(rg, name string) string {
+	return "/subscriptions/" + subID + "/resourceGroups/" + rg +
+		"/providers/Microsoft.Network/publicIPAddresses/" + name
+}
+
+// assertGone runs get and requires it to fail with a 404, proving the resource
+// no longer exists after the cascade.
+func assertGone(t *testing.T, kind string, get func() error) {
+	t.Helper()
+
+	err := get()
+	if err == nil {
+		t.Fatalf("%s survived resource-group delete (no cascade)", kind)
+	}
+
+	if code := statusCode(t, err); code != 404 {
+		t.Fatalf("%s after RG delete: status %d, want 404", kind, code)
+	}
+}

--- a/server/azure/resourcegroups/handler.go
+++ b/server/azure/resourcegroups/handler.go
@@ -48,8 +48,9 @@ const (
 // container, so deleting it must delete the resources created under it rather
 // than leaving them as globally addressable orphans. Each per-service ARM
 // handler that stores its resources resource-group-scoped (compute, networking,
-// storage today) implements it; a handler that does not is simply not passed to
-// New, so its resource type is not cascaded (a documented, extensible gap).
+// load balancing, storage today) implements it; a handler that does not is
+// simply not passed to New, so its resource type is not cascaded (a documented,
+// extensible gap).
 type ResourceGroupPurger interface {
 	PurgeResourceGroup(ctx context.Context, subscription, resourceGroup string) error
 }

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -613,6 +613,12 @@ func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 // their group (Instance.ResourceGroup) on the ARM create path, so membership is
 // an exact match. Resource-group comparison is case-insensitive, matching ARM.
 // The subscription is unused (the emulator is single-estate).
+//
+// Each VM's attached data disks are detached first — the same release the
+// single-VM delete() path does — so a cascade-deleted VM clears its disks'
+// managedBy/diskState (deleteOption=Detach) rather than leaving them dangling at
+// the now-deleted VM. Detach is best-effort: a single failure is recorded but
+// does not stop the remaining teardown.
 func (h *Handler) PurgeResourceGroup(ctx context.Context, _, resourceGroup string) error {
 	instances, err := h.compute.DescribeInstances(ctx, nil, nil)
 	if err != nil {
@@ -631,7 +637,19 @@ func (h *Handler) PurgeResourceGroup(ctx context.Context, _, resourceGroup strin
 		return nil
 	}
 
-	return h.compute.TerminateInstances(ctx, ids)
+	var firstErr error
+
+	for _, id := range ids {
+		if derr := h.detachAttachedVolumes(ctx, id); derr != nil && firstErr == nil {
+			firstErr = derr
+		}
+	}
+
+	if terr := h.compute.TerminateInstances(ctx, ids); terr != nil && firstErr == nil {
+		firstErr = terr
+	}
+
+	return firstErr
 }
 
 // start handles POST virtualMachines/{name}/start.

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -512,19 +512,110 @@ func (h *Handler) deleteVNet(w http.ResponseWriter, r *http.Request, rp azurearm
 	writeAcceptedAsync(w, r, rp.Subscription, "vnet-delete-"+rp.ResourceName, nil)
 }
 
-// PurgeResourceGroup deletes every virtual network (with its subnets) and
-// network security group this handler owns in the given resource group. It
-// backs the resource-group cascade delete: when an RG is removed, the resources
+// PurgeResourceGroup deletes every Microsoft.Network resource this handler owns
+// in the given resource group: network interfaces, NAT gateways, public IPs,
+// virtual networks (with their subnets) and network security groups. It backs
+// the resource-group cascade delete: when an RG is removed, the resources
 // created under it must go too rather than lingering as globally addressable
 // orphans. Deletion is forceful (the in-use guards that gate an individual
 // DELETE do not apply — the whole group is going away), and best-effort: a
 // single driver-level failure is returned but does not stop the remaining
 // teardown. The subscription is unused (the emulator is single-estate).
+//
+// Order matters for the reference chains the emulator models: NICs come first
+// (the owning VMs are purged by the compute purger before this one runs, so a
+// NIC's virtualMachine back-reference is already cleared and its DELETE
+// succeeds); NAT gateways next (deleting one frees the Elastic IP association it
+// holds); then public IPs (now unassociated, so ReleaseAddress succeeds); and
+// finally the virtual networks and NSGs.
 func (h *Handler) PurgeResourceGroup(ctx context.Context, _, resourceGroup string) error {
-	firstErr := h.purgeVNets(ctx, resourceGroup)
+	var firstErr error
 
-	if err := h.purgeNSGs(ctx, resourceGroup); err != nil && firstErr == nil {
-		firstErr = err
+	recordErr := func(err error) {
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	recordErr(h.purgeNICs(ctx, resourceGroup))
+	recordErr(h.purgeNATGateways(ctx, resourceGroup))
+	recordErr(h.purgePublicIPs(ctx, resourceGroup))
+	recordErr(h.purgeVNets(ctx, resourceGroup))
+	recordErr(h.purgeNSGs(ctx, resourceGroup))
+
+	return firstErr
+}
+
+// purgeNICs deletes every network interface in the resource group. NICs are
+// stored resource-group-natively (not tag-scoped), so the driver list already
+// filters to the group. The owning VMs are torn down by the compute purger
+// first, so each NIC's virtualMachine back-reference is cleared and the delete
+// is not blocked by the attached-NIC guard.
+func (h *Handler) purgeNICs(ctx context.Context, resourceGroup string) error {
+	svc, ok := h.net.(netdriver.AzureNetworkInterfaces)
+	if !ok {
+		return nil
+	}
+
+	nics, err := svc.ListNetworkInterfaces(ctx, resourceGroup)
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+
+	for i := range nics {
+		if derr := svc.DeleteNetworkInterface(ctx, nics[i].ResourceGroup, nics[i].Name); derr != nil && firstErr == nil {
+			firstErr = derr
+		}
+	}
+
+	return firstErr
+}
+
+// purgeNATGateways deletes every NAT gateway tagged for the resource group,
+// freeing any Elastic IP allocation each one held so the public IPs can then be
+// released.
+func (h *Handler) purgeNATGateways(ctx context.Context, resourceGroup string) error {
+	nats, err := h.net.DescribeNATGateways(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+
+	for i := range nats {
+		if !strings.EqualFold(tagOr(nats[i].Tags, armNATGatewayRGTag, ""), resourceGroup) {
+			continue
+		}
+
+		if derr := h.net.DeleteNATGateway(ctx, nats[i].ID); derr != nil && firstErr == nil {
+			firstErr = derr
+		}
+	}
+
+	return firstErr
+}
+
+// purgePublicIPs releases every public IP tagged for the resource group. NAT
+// gateways are purged first, so a public IP that backed one is no longer
+// associated and ReleaseAddress succeeds.
+func (h *Handler) purgePublicIPs(ctx context.Context, resourceGroup string) error {
+	eips, err := h.net.DescribeAddresses(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+
+	for i := range eips {
+		if !strings.EqualFold(tagOr(eips[i].Tags, armPublicIPRGTag, ""), resourceGroup) {
+			continue
+		}
+
+		if derr := h.net.ReleaseAddress(ctx, eips[i].AllocationID); derr != nil && firstErr == nil {
+			firstErr = derr
+		}
 	}
 
 	return firstErr


### PR DESCRIPTION
## What

Completes the Azure resource-group cascade delete introduced in #623 and folds in the #627 cascade disk-detach review nit.

- **vnet `PurgeResourceGroup`** now also purges **network interfaces, NAT gateways and public IPs** (RG-tag filtered, `EqualFold`), in addition to the existing vnets + NSGs. Order is chosen so freed references let each delete succeed (NICs → NAT gateways → public IPs → vnets → NSGs).
- **Load balancer handler** now implements `ResourceGroupPurger` and is registered as a purger in `server/azure/azure.go` (it was not previously cascaded at all).
- **Purger order** in `azure.go`: VMs are purged **before** networking, so a terminated VM clears its NICs' `virtualMachine` back-reference and the NIC delete is not blocked by the attached-NIC guard.
- **#627 nit**: the compute cascade purge (`PurgeResourceGroup`) now routes each VM through `detachAttachedVolumes` before terminating, so cascade-deleted VMs clear their data disks' `managedBy`/`diskState` (deleteOption=Detach) — the same release the single-VM `delete()` path already does. Previously only the single-VM path was fixed.

## Why

Deleting an RG left its public IPs, NICs, NAT gateways and load balancers alive and globally addressable (round-2 finding **R1**, MED). Because their lookups are RG-tag scoped by a tag that survives, a GET under the now-deleted RG still returned the orphan — a true ghost that blocks name reuse and shows in subscription-wide lists. Real Azure (`Microsoft.Resources` RG delete) removes every resource contained in the group. Separately, cascade-deleted VMs left their detached data disks with `managedBy` still set.

Resources in a **different** resource group are left untouched (RG-tag `EqualFold` scoping).

## Tests

New real-SDK reproduction `TestResourceGroupDeleteCascadesNetworkChildrenAndDetachesDisks` (armnetwork + armcompute + armresources against the in-process server): creates an RG holding a public IP, a NIC (referencing the public IP), a NAT gateway, a load balancer, and a VM-with-data-disk whose NIC is the created one; deletes the RG; asserts all network children are gone (GET 404) and the data disk survives with `managedBy` cleared / `diskState` Unattached — while a public IP in a different RG is untouched. Existing #623 cascade + cross-RG scope tests stay green.
