### PR TITLE
fix(azure-eventgrid): exclude resource-scoped subs from global list operations

### DIFF
--- a/server/azure/eventgrid/scoped_subscriptions.go
+++ b/server/azure/eventgrid/scoped_subscriptions.go
@@ -231,12 +231,18 @@ func (h *Handler) listScopedEventSubscriptions(w http.ResponseWriter, sp *scoped
 }
 
 // scopedSubInListScope reports whether rec belongs in the list requested at sp.
-// A resource-extension scope (containing a nested /providers/) matches exactly;
-// a resource-group scope matches subscription+group; a subscription scope
-// matches the subscription (ListGlobalBySubscription).
+// A resource-extension scope (containing a nested /providers/) matches exactly
+// (ListByResource). The global list operations (ListGlobalBySubscription /
+// ListGlobalByResourceGroup) return only global subscription/resource-group
+// scoped subs, never regional resource-scoped ones — so those branches exclude
+// records whose own scope carries a nested resource /providers/ segment.
 func scopedSubInListScope(rec *scopedSubRecord, sp *scopedSubPath) bool {
 	if strings.Contains(sp.scope, "/providers/") {
 		return rec.scope == sp.scope
+	}
+
+	if isResourceScoped(rec.scope) {
+		return false
 	}
 
 	if sp.resourceGroup != "" {
@@ -244,6 +250,14 @@ func scopedSubInListScope(rec *scopedSubRecord, sp *scopedSubPath) bool {
 	}
 
 	return rec.subscription == sp.subscription
+}
+
+// isResourceScoped reports whether scope is a regional resource-extension scope
+// (e.g. .../providers/Microsoft.Storage/storageAccounts/acct1) rather than a
+// global subscription (/subscriptions/{s}) or resource-group
+// (/subscriptions/{s}/resourceGroups/{rg}) scope.
+func isResourceScoped(scope string) bool {
+	return strings.Contains(scope, "/providers/")
 }
 
 func toScopedSubJSON(rec *scopedSubRecord) eventSubscriptionJSON {

--- a/server/azure/eventgrid/scoped_subscriptions_sdk_test.go
+++ b/server/azure/eventgrid/scoped_subscriptions_sdk_test.go
@@ -230,6 +230,79 @@ func TestSDKEventSubscriptionTopicExtensionForm(t *testing.T) {
 	}
 }
 
+// TestSDKEventSubscriptionGlobalListsExcludeResourceScoped proves that regional
+// (resource-scoped) event subscriptions do NOT leak into the global list
+// operations. Per Azure, ListGlobalBySubscription / ListGlobalByResourceGroup
+// return only global (subscription / resource-group scoped) subscriptions; a
+// storage-account resource-scoped sub is regional and belongs to ListByResource.
+func TestSDKEventSubscriptionGlobalListsExcludeResourceScoped(t *testing.T) {
+	client := newEventGridFactory(t).NewEventSubscriptionsClient()
+
+	subScope := "/subscriptions/" + testSub
+	rgScope := subScope + "/resourceGroups/" + testRG
+	resScope := rgScope + "/providers/Microsoft.Storage/storageAccounts/acct1"
+
+	createEventSubscription(t, client, subScope, "at-sub", "/a")
+	createEventSubscription(t, client, rgScope, "at-rg", "/b")
+	createEventSubscription(t, client, resScope, "at-res", "/c")
+
+	// ListGlobalBySubscription: only the global subs (sub + RG scope).
+	subNames := listGlobalBySubscription(t, client)
+	if len(subNames) != 2 || subNames[0] != "at-rg" || subNames[1] != "at-sub" {
+		t.Fatalf("ListGlobalBySubscription = %v, want [at-rg at-sub] (no at-res)", subNames)
+	}
+
+	// ListGlobalByResourceGroup: only the RG-scope sub, not the resource-scoped.
+	rgNames := listGlobalByResourceGroup(t, client, testRG)
+	if len(rgNames) != 1 || rgNames[0] != "at-rg" {
+		t.Fatalf("ListGlobalByResourceGroup = %v, want [at-rg] (no at-res)", rgNames)
+	}
+
+	// ListByResource: exactly the resource-scoped sub.
+	resNames := listByResource(t, client, testRG, "Microsoft.Storage", "storageAccounts", "acct1")
+	if len(resNames) != 1 || resNames[0] != "at-res" {
+		t.Fatalf("ListByResource = %v, want [at-res]", resNames)
+	}
+}
+
+func listGlobalBySubscription(t *testing.T, c *armeventgrid.EventSubscriptionsClient) []string {
+	t.Helper()
+	ctx := context.Background()
+
+	var names []string
+	pager := c.NewListGlobalBySubscriptionPager(nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListGlobalBySubscription: %v", err)
+		}
+		for _, es := range page.Value {
+			names = append(names, *es.Name)
+		}
+	}
+
+	return names
+}
+
+func listByResource(t *testing.T, c *armeventgrid.EventSubscriptionsClient, rg, ns, resType, resName string) []string {
+	t.Helper()
+	ctx := context.Background()
+
+	var names []string
+	pager := c.NewListByResourcePager(rg, ns, resType, resName, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListByResource: %v", err)
+		}
+		for _, es := range page.Value {
+			names = append(names, *es.Name)
+		}
+	}
+
+	return names
+}
+
 func listGlobalByResourceGroup(t *testing.T, c *armeventgrid.EventSubscriptionsClient, rg string) []string {
 	t.Helper()
 	ctx := context.Background()


### PR DESCRIPTION
## What

Regional (resource-scoped) event subscriptions were leaking into the Event Grid **global** list operations. `scopedSubInListScope` (`server/azure/eventgrid/scoped_subscriptions.go`) now excludes records whose own scope carries a nested resource `/providers/` segment from the `ListGlobalBySubscription` and `ListGlobalByResourceGroup` branches.

Repro (3 subs under the same subscription):
- subscription scope (`/subscriptions/{s}`)
- resource-group scope (`/subscriptions/{s}/resourceGroups/{rg}`)
- storage-account resource scope (`.../providers/Microsoft.Storage/storageAccounts/acct1`)

Before: `ListGlobalByResourceGroup(rg)` returned `[at-res, at-rg]` and `ListGlobalBySubscription()` returned `[at-res, at-rg, at-sub]` — the resource-scoped sub leaked into both.
After: global lists return only the global (subscription / RG scoped) subs; the resource-scoped sub is reachable only via `ListByResource` (unchanged).

## Why

Per the official Azure Event Grid REST docs, `ListGlobalBySubscription` / `ListGlobalByResourceGroup` return only **global** event subscriptions; resource-scoped subs are **regional** and belong to `ListByResource` (there are separate `ListRegionalBy*` operations for them). The old code matched every record with the same subscription/RG because `parseScopeContainers` also sets `resourceGroup` on a resource-scoped record. A reconcile/delete loop enumerating "the RG's global subs" could otherwise touch subs it shouldn't.

## Tests

Added `TestSDKEventSubscriptionGlobalListsExcludeResourceScoped` (real `armeventgrid` SDK) asserting the three list operations return the correct disjoint sets. Existing #624 scoped-sub tests remain green.