### PR TITLE
test(azure-cosmos): lock prefix-safety on account purge + empty-account guard

### DIFF
--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -204,6 +204,13 @@ func (m *Mock) DeleteTable(_ context.Context, name string) error {
 // a deleted account stop listing and a same-name recreate start from an empty
 // namespace.
 func (m *Mock) PurgeAccount(account string) {
+	// Guard against an empty account: prefix "" makes HasPrefix always true, so an
+	// empty account would match and delete every table (a match-all data-loss
+	// footgun). Purging the empty/default account is a no-op.
+	if account == "" {
+		return
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/providers/azure/cosmosdb/purge_account_test.go
+++ b/providers/azure/cosmosdb/purge_account_test.go
@@ -45,6 +45,72 @@ func TestPurgeAccount(t *testing.T) {
 	require.NoError(t, err, "the other account's container table must survive")
 }
 
+// TestPurgeAccountPrefixSubset locks the foo-vs-foobar prefix-safety guarantee:
+// purging "foo" must not touch "foobar", whose name merely starts with "foo".
+// The purge matches on the "{account}/" separator, so "foobar/…" tables never
+// fall inside "foo"'s namespace. A bare HasPrefix(name, "foo") would wrongly
+// reap foobar's data — this test is the CI guard against that regression class.
+func TestPurgeAccountPrefixSubset(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	// foo: account table + attributes + a container holding one item.
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "foo"}))
+	m.SetTableAttributes("foo", driver.AccountAttributes{Kind: "GlobalDocumentDB"})
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "foo/db1/coll1", PartitionKey: "pk"}))
+	require.NoError(t, m.PutItem(ctx, "foo/db1/coll1", map[string]any{"pk": "a", "v": "foo-item"}))
+
+	// foobar: a distinct account whose name has "foo" as a prefix; it must survive.
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "foobar"}))
+	m.SetTableAttributes("foobar", driver.AccountAttributes{Kind: "MongoDB"})
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "foobar/db1/coll1", PartitionKey: "pk"}))
+	require.NoError(t, m.PutItem(ctx, "foobar/db1/coll1", map[string]any{"pk": "a", "v": "foobar-item"}))
+
+	m.PurgeAccount("foo")
+
+	// foo and its data are gone.
+	assert.NotContains(t, m.AccountTables(), "foo", "purged account must not linger")
+
+	_, err := m.DescribeTable(ctx, "foo")
+	require.Error(t, err, "purged account's own table must be gone")
+
+	_, err = m.DescribeTable(ctx, "foo/db1/coll1")
+	require.Error(t, err, "purged account's container table must be gone")
+
+	// foobar survives untouched — table, attributes and its item.
+	assert.Contains(t, m.AccountTables(), "foobar", "prefix-sharing account must survive")
+
+	_, err = m.DescribeTable(ctx, "foobar/db1/coll1")
+	require.NoError(t, err, "prefix-sharing account's container table must survive")
+
+	item, err := m.GetItem(ctx, "foobar/db1/coll1", map[string]any{"pk": "a"})
+	require.NoError(t, err, "prefix-sharing account's item must survive")
+	assert.Equal(t, "foobar-item", item["v"])
+}
+
+// TestPurgeAccountEmpty verifies the empty-account guard: purging "" is a no-op
+// and never reaps unrelated tables. nsPrefix("")=="" makes HasPrefix(t,"")
+// always true, so without the guard an empty account would match and delete
+// every table — a latent match-all data-loss footgun.
+func TestPurgeAccountEmpty(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "acct1"}))
+	m.SetTableAttributes("acct1", driver.AccountAttributes{Kind: "GlobalDocumentDB"})
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "acct1/db1/coll1", PartitionKey: "pk"}))
+
+	m.PurgeAccount("")
+
+	assert.Contains(t, m.AccountTables(), "acct1", "empty-account purge must not drop real accounts")
+
+	_, err := m.DescribeTable(ctx, "acct1")
+	require.NoError(t, err, "empty-account purge must not drop unrelated tables")
+
+	_, err = m.DescribeTable(ctx, "acct1/db1/coll1")
+	require.NoError(t, err, "empty-account purge must not drop unrelated container tables")
+}
+
 // TestPurgeAccountUnknown verifies purging an account that was never created is a
 // no-op that leaves existing state intact.
 func TestPurgeAccountUnknown(t *testing.T) {

--- a/server/azure/cosmosaccount/account_delete_test.go
+++ b/server/azure/cosmosaccount/account_delete_test.go
@@ -139,3 +139,52 @@ func TestSDKCosmosAccountDeleteTearsDownNamespace(t *testing.T) {
 	require.NoError(t, json.Unmarshal(readK.Value, &gotK))
 	assert.Equal(t, "keeper", gotK["who"], "the other account's item is unchanged")
 }
+
+// TestSDKCosmosAccountDeletePrefixSubset locks the foo-vs-foobar prefix-safety
+// guarantee end-to-end: deleting account "foo" must not touch account "foobar",
+// whose name merely starts with "foo". The teardown matches on the "{account}/"
+// separator, so "foobar/…" tables never fall inside "foo"'s namespace. A bare
+// HasPrefix(name, "foo") would wrongly reap foobar's data — this is the wire-level
+// CI guard against that regression class.
+func TestSDKCosmosAccountDeletePrefixSubset(t *testing.T) {
+	ctx := context.Background()
+	stack := newCosmosStack(t)
+
+	// foo and foobar: distinct accounts whose names share the "foo" prefix. Each
+	// gets its own appdb/users and one item.
+	epFoo := stack.createAccountEndpoint(t, "rg-foo", "foo")
+	epFoobar := stack.createAccountEndpoint(t, "rg-foobar", "foobar")
+
+	clientFoo := stack.dataClient(t, epFoo)
+	usersFoo := makeUsersContainer(ctx, t, clientFoo)
+	putUser(ctx, t, usersFoo, "f1", "team-foo", "foo-data")
+
+	clientFoobar := stack.dataClient(t, epFoobar)
+	usersFoobar := makeUsersContainer(ctx, t, clientFoobar)
+	putUser(ctx, t, usersFoobar, "b1", "team-bar", "foobar-data")
+
+	// Delete only "foo".
+	poller, err := stack.arm.BeginDelete(ctx, "rg-foo", "foo", nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	// foo is gone: no List ghost, GET 404s.
+	names := listAccountNames(ctx, t, stack)
+	assert.False(t, names["foo"], "deleted account must not linger in List (ghost)")
+	assert.True(t, names["foobar"], "prefix-sharing account must survive the delete")
+
+	_, err = stack.arm.Get(ctx, "rg-foo", "foo", nil)
+	wantStatus(t, err, 404, "GET on deleted account")
+
+	// foobar is entirely untouched: its database, container and item all survive.
+	assert.Equal(t, []string{"appdb"}, databaseIDs(ctx, t, clientFoobar),
+		"prefix-sharing account keeps its database")
+
+	readBar, err := usersFoobar.ReadItem(ctx, azcosmos.NewPartitionKeyString("team-bar"), "b1", nil)
+	require.NoError(t, err, "prefix-sharing account's item must survive")
+
+	var gotBar map[string]any
+	require.NoError(t, json.Unmarshal(readBar.Value, &gotBar))
+	assert.Equal(t, "foobar-data", gotBar["who"], "prefix-sharing account's item is unchanged")
+}

--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -485,6 +485,14 @@ type accountPurger interface {
 // starts from an empty namespace. It is idempotent — purging an unknown account
 // is a no-op.
 func (h *Handler) PurgeAccount(ctx context.Context, account string) {
+	// Guard against an empty account: nsPrefix("")=="" makes HasPrefix always
+	// true, so an empty account would match and reap every container's
+	// bookkeeping (and, via the driver, every table) — a match-all data-loss
+	// footgun. Purging the empty/default account is a no-op.
+	if account == "" {
+		return
+	}
+
 	// Reap the offer + TTL/attrs bookkeeping for every container table in the
 	// account's namespace before the driver drops the tables underneath us.
 	prefix := nsPrefix(account)


### PR DESCRIPTION
## What

Hardening follow-up to #630 (Cosmos account-delete full-namespace purge). Adds tests that lock the correctness guarantees into CI, plus a defensive empty-account guard.

- **Prefix-subset regression tests** (foo vs foobar): create accounts `foo` and `foobar`, each with a database + container + item; purge/delete `foo`; assert `foo` and its data are gone while `foobar` and ITS data survive intact.
  - Driver level: `TestPurgeAccountPrefixSubset` in `providers/azure/cosmosdb/purge_account_test.go`.
  - Wire/real-SDK level: `TestSDKCosmosAccountDeletePrefixSubset` in `server/azure/cosmosaccount/account_delete_test.go` (drives armcosmos + azcosmos end-to-end).
- **Empty-account guard**: `Handler.PurgeAccount` (server) and driver `PurgeAccount` return early (no-op) when `account == ""`, with `TestPurgeAccountEmpty` covering it.

## Why

The existing purge tests only used disjoint names (acct1/acct2), so the exact foo-vs-foobar prefix-subset regression class wasn't guarded. `nsPrefix("")==""` makes `HasPrefix(t, "")` always true, so an empty account would match and delete ALL tables — a latent match-all data-loss footgun (unreachable today, but now hardened).

Verified the new foo/foobar test FAILS when the purge is temporarily changed to a bare `HasPrefix(name, account)` without the `/` separator, and passes after reverting — proving it catches the regression class. No other behavior changed.