### PR TITLE
fix(azure-blob): fail-closed on unknown PUT comp + SetTags/GetTags (stop blob-body corruption)

### DIFF
--- a/server/azure/blobstorage/blob_tags.go
+++ b/server/azure/blobstorage/blob_tags.go
@@ -1,0 +1,82 @@
+package blobstorage
+
+import (
+	"bytes"
+	"encoding/xml"
+	"net/http"
+	"sort"
+)
+
+// setBlobTags handles PUT /{container}/{blob}?comp=tags (Set Blob Tags). It
+// parses the <Tags> XML body and stores the tags per blob WITHOUT touching the
+// blob's content, ETag, or last-modified time (per the Azure spec). An empty
+// <TagSet> clears all tags. Returns 204 No Content on success.
+func (h *Handler) setBlobTags(w http.ResponseWriter, r *http.Request, container, blob string) {
+	if h.checkLease(w, r, container, blob) {
+		return
+	}
+
+	body, ok := readLimitedBody(w, r)
+	if !ok {
+		return
+	}
+
+	tags, err := parseTagsXML(body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidXmlDocument", "could not parse Tags body")
+		return
+	}
+
+	if err := h.bucket.PutObjectTagging(r.Context(), container, blob, tags); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// getBlobTags handles GET /{container}/{blob}?comp=tags (Get Blob Tags),
+// returning the blob's stored tags as a <Tags> XML document with 200 OK.
+func (h *Handler) getBlobTags(w http.ResponseWriter, r *http.Request, container, blob string) {
+	tags, err := h.bucket.GetObjectTagging(r.Context(), container, blob)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	out := blobTagsXML{}
+	for _, k := range keys {
+		out.TagSet = append(out.TagSet, tagXML{Key: k, Value: tags[k]})
+	}
+
+	writeXML(w, out)
+}
+
+// parseTagsXML extracts the key/value tags from a Set Blob Tags request body.
+// An empty or whitespace-only body (or an empty <TagSet>) yields an empty map,
+// which clears the blob's tags.
+func parseTagsXML(body []byte) (map[string]string, error) {
+	tags := make(map[string]string)
+
+	if len(bytes.TrimSpace(body)) == 0 {
+		return tags, nil
+	}
+
+	var doc blobTagsXML
+	if err := xml.Unmarshal(body, &doc); err != nil {
+		return nil, err
+	}
+
+	for _, t := range doc.TagSet {
+		tags[t.Key] = t.Value
+	}
+
+	return tags, nil
+}

--- a/server/azure/blobstorage/blob_tags_test.go
+++ b/server/azure/blobstorage/blob_tags_test.go
@@ -1,0 +1,158 @@
+package blobstorage_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/pageblob"
+)
+
+// TestSDKSetTagsPreservesContent proves the data-corruption bug is gone: Set
+// Blob Tags stores tags and leaves the blob body untouched (the old
+// fall-through wrote the tags XML over the blob content).
+func TestSDKSetTagsPreservesContent(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	body := []byte("original-value")
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", body, nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+
+	if _, err := bc.SetTags(ctx, map[string]string{"env": "prod", "team": "payments"}, nil); err != nil {
+		t.Fatalf("SetTags: %v", err)
+	}
+
+	if got := e.download(t, "k1"); got != string(body) {
+		t.Fatalf("blob body corrupted by SetTags: got %q, want %q", got, body)
+	}
+}
+
+// TestSDKSetAndGetTagsRoundTrip proves SetTags/GetTags round-trip the tag set.
+func TestSDKSetAndGetTagsRoundTrip(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("payload"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+
+	want := map[string]string{"env": "prod", "team": "payments"}
+	if _, err := bc.SetTags(ctx, want, nil); err != nil {
+		t.Fatalf("SetTags: %v", err)
+	}
+
+	resp, err := bc.GetTags(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetTags: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, tag := range resp.BlobTagSet {
+		if tag.Key != nil && tag.Value != nil {
+			got[*tag.Key] = *tag.Value
+		}
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("tag count = %d, want %d (%v)", len(got), len(want), got)
+	}
+
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("tag %q = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+// TestSetTagsEmptyClearsTags proves an empty tag set clears the blob's tags
+// without touching its body.
+func TestSetTagsEmptyClearsTags(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("keep-me"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	bc := e.blob(t, "/c1/k1")
+
+	if _, err := bc.SetTags(ctx, map[string]string{"env": "prod"}, nil); err != nil {
+		t.Fatalf("SetTags: %v", err)
+	}
+
+	if _, err := bc.SetTags(ctx, map[string]string{}, nil); err != nil {
+		t.Fatalf("SetTags (clear): %v", err)
+	}
+
+	resp, err := bc.GetTags(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetTags: %v", err)
+	}
+
+	if len(resp.BlobTagSet) != 0 {
+		t.Errorf("tags not cleared: %v", resp.BlobTagSet)
+	}
+
+	if got := e.download(t, "k1"); got != "keep-me" {
+		t.Errorf("blob body altered by tag clear: got %q, want keep-me", got)
+	}
+}
+
+// TestUnknownCompFailsClosed proves a blob PUT with an unrecognized comp value
+// is rejected (fail-closed) and does NOT overwrite the blob body — the
+// architectural root fix that prevents the tags/page corruption class.
+func TestUnknownCompFailsClosed(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("do-not-corrupt"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+		e.base+"/c1/k1?comp=totallybogus", bytes.NewReader([]byte("<Bogus/>")))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	req.Header.Set("x-ms-version", "2023-11-03")
+
+	resp, err := e.tr.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 400 {
+		t.Fatalf("unknown comp PUT returned %d, want a 4xx/5xx failure", resp.StatusCode)
+	}
+
+	if got := e.download(t, "k1"); got != "do-not-corrupt" {
+		t.Fatalf("unknown comp PUT corrupted the blob body: got %q, want do-not-corrupt", got)
+	}
+}
+
+// TestPageBlobFailsClosed proves page-blob create and UploadPages fail closed
+// (page-blob range semantics are not implemented) rather than silently
+// corrupting a blob via the comp fall-through.
+func TestPageBlobFailsClosed(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	pc, err := pageblob.NewClientWithNoCredential(e.base+"/c1/page1", &pageblob.ClientOptions{ClientOptions: e.clientOpts()})
+	if err != nil {
+		t.Fatalf("pageblob.NewClient: %v", err)
+	}
+
+	const pageSize = 512
+	if _, err := pc.Create(ctx, pageSize, nil); err == nil {
+		t.Fatal("page-blob Create should fail closed (page blobs unsupported), got success")
+	}
+}

--- a/server/azure/blobstorage/handler.go
+++ b/server/azure/blobstorage/handler.go
@@ -15,8 +15,9 @@
 //	HEAD   /{container}/{blob}                          — head blob
 //	DELETE /{container}/{blob}                          — delete blob
 //
-// Less-used surfaces (lifecycle, encryption, tags, versioning) are not yet
-// wired and return 501.
+// Less-used surfaces (lifecycle, encryption, versioning) are not yet wired and
+// return 501. An unrecognized or unimplemented blob-PUT comp selector fails
+// closed with an Azure error rather than falling through to a content write.
 package blobstorage
 
 import (
@@ -62,6 +63,12 @@ const (
 	compSnapshot    = "snapshot"
 	compAppendBlock = "appendblock"
 	compLease       = "lease"
+	compTags        = "tags"
+	compPage        = "page"
+
+	// blobTypePageBlob is the Azure page-blob type; cloudemu does not implement
+	// page-blob range semantics, so a page-blob create/write fails closed.
+	blobTypePageBlob = "PageBlob"
 
 	// compACL is the ?comp= value for Set/Get Container ACL
 	// (?restype=container&comp=acl).
@@ -167,6 +174,11 @@ func (h *Handler) blobOp(w http.ResponseWriter, r *http.Request, container, blob
 	case http.MethodPut:
 		h.putBlobOp(w, r, container, blob)
 	case http.MethodGet:
+		if r.URL.Query().Get("comp") == compTags {
+			h.getBlobTags(w, r, container, blob)
+			return
+		}
+
 		if ext, ok := h.bucket.(storagedriver.AzureBlobExtensions); ok && r.URL.Query().Get("comp") == compBlockList {
 			h.getBlockList(w, r, ext, container, blob)
 			return
@@ -187,10 +199,12 @@ func (h *Handler) blobOp(w http.ResponseWriter, r *http.Request, container, blob
 // metadata/properties/tier/snapshot/appendblock each mean something different
 // and must NOT be treated as a content write (doing so corrupts the blob).
 func (h *Handler) putBlobOp(w http.ResponseWriter, r *http.Request, container, blob string) {
-	comp := r.URL.Query().Get("comp")
-
-	ext, hasExt := h.bucket.(storagedriver.AzureBlobExtensions)
-	if comp != "" && hasExt && h.dispatchBlobComp(w, r, ext, container, blob, comp) {
+	// A blob PUT carrying a ?comp= selector is a distinct sub-operation, never a
+	// content write. An unrecognized or unimplemented comp MUST fail closed:
+	// falling through to Put Blob would write the sub-operation's request body
+	// over the blob's content (silent data corruption).
+	if comp := r.URL.Query().Get("comp"); comp != "" {
+		h.putBlobComp(w, r, container, blob, comp)
 		return
 	}
 
@@ -199,12 +213,44 @@ func (h *Handler) putBlobOp(w http.ResponseWriter, r *http.Request, container, b
 		return
 	}
 
-	if strings.EqualFold(r.Header.Get("x-ms-blob-type"), "AppendBlob") && hasExt {
+	blobType := r.Header.Get("X-Ms-Blob-Type")
+
+	if ext, ok := h.bucket.(storagedriver.AzureBlobExtensions); ok && strings.EqualFold(blobType, "AppendBlob") {
 		h.createAppendBlob(w, r, ext, container, blob)
 		return
 	}
 
+	// Page blobs are not implemented; fail closed rather than silently creating
+	// a block blob (which would misreport page-blob support and, on an existing
+	// blob, clobber it).
+	if strings.EqualFold(blobType, blobTypePageBlob) {
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "page blobs are not supported")
+		return
+	}
+
 	h.putBlob(w, r, container, blob)
+}
+
+// putBlobComp routes a blob PUT ?comp= sub-operation. Any comp it does not
+// implement fails closed with an Azure error so an unknown selector can never
+// fall through to a content write and corrupt the blob body.
+func (h *Handler) putBlobComp(w http.ResponseWriter, r *http.Request, container, blob, comp string) {
+	if comp == compTags {
+		h.setBlobTags(w, r, container, blob)
+		return
+	}
+
+	if ext, ok := h.bucket.(storagedriver.AzureBlobExtensions); ok && h.dispatchBlobComp(w, r, ext, container, blob, comp) {
+		return
+	}
+
+	if comp == compPage {
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "page blobs are not supported")
+		return
+	}
+
+	writeError(w, http.StatusBadRequest, "UnsupportedQueryParameter",
+		fmt.Sprintf("the query parameter comp=%s is not supported for a blob PUT", comp))
 }
 
 // dispatchBlobComp routes a PUT comp sub-operation to its handler, returning

--- a/server/azure/blobstorage/types.go
+++ b/server/azure/blobstorage/types.go
@@ -107,6 +107,18 @@ type blockXML struct {
 	Size int64  `xml:"Size"`
 }
 
+// blobTagsXML is the request body for Set Blob Tags and the response body for
+// Get Blob Tags (PUT/GET /{container}/{blob}?comp=tags).
+type blobTagsXML struct {
+	XMLName xml.Name `xml:"Tags"`
+	TagSet  []tagXML `xml:"TagSet>Tag"`
+}
+
+type tagXML struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
+}
+
 // signedIdentifiersXML is the request/response body for PUT and GET
 // /{container}?restype=container&comp=acl.
 type signedIdentifiersXML struct {


### PR DESCRIPTION
## What

Fixes a HIGH data-corruption bug class in the Azure Blob wire handler where a `PUT /{container}/{blob}?comp=<x>` with an unhandled `comp` selector fell through to `putBlob` and wrote the sub-operation's request body **over the blob's content**.

- **SetTags (`?comp=tags`) — HIGH data corruption:** had no case in the blob-PUT dispatch, so `BlobClient.SetTags` silently replaced the blob body with the tags XML. Now implemented (Set/Get Blob Tags) and the body is preserved.
- **UploadPages (`?comp=page`) — same root cause:** page-blob range writes fell through and clobbered the whole blob.

## Fix

- **Fail-closed architecture (core safety fix):** a blob `PUT` carrying a `?comp=` selector is now always treated as a sub-operation. Any unrecognized or unimplemented `comp` returns a proper Azure error (400 `UnsupportedQueryParameter`, or 501 `NotImplemented` for page) instead of falling through to a content write. This kills the entire corruption class (same class as the pre-#619 lease bug).
- **SetBlobTags / GetBlobTags implemented** (`PUT`/`GET ?comp=tags`): parse the `<Tags>` XML body, store per-blob via the existing `PutObjectTagging`/`GetObjectTagging` storage, return 204/200. Set Blob Tags leaves the blob content, ETag, and last-modified untouched (per the Azure spec); an empty `<TagSet>` clears tags. Cross-checked against the official Set/Get Blob Tags REST docs.
- **Page blobs fail closed:** page-blob create (`x-ms-blob-type: PageBlob`) and `UploadPages` (`?comp=page`) now return 501 `NotImplemented` rather than corrupting/misreporting support.

## Tests (real azblob SDK)

- SetTags leaves the blob body unchanged (corruption gone)
- SetTags/GetTags round-trip; empty tag set clears tags without touching the body
- an unknown `comp` PUT fails closed and does not overwrite the blob body
- page-blob create fails closed

## Deferrals

- **Page-blob range semantics (UploadPages) deferred** as a feature gap. It requires a new page-blob type plus create-with-content-length and 512-aligned range writes across the driver interface + provider — out of scope here. It now fails closed (501) with no corruption.
