### PR TITLE
fix(gcp-compute): instances disks/tags/metadata/actions/zone-scope/dup-409/self-links/pagination

### DIFF
--- a/providers/gcp/compute/gce.go
+++ b/providers/gcp/compute/gce.go
@@ -443,6 +443,37 @@ func (m *Mock) RemoveInstance(ctx context.Context, instanceID string) error {
 	return nil
 }
 
+// MutateInstanceGCP applies a GCP-specific instance mutation used by the GCE
+// wire handler for setLabels/setMetadata/setTags/setMachineType/attachDisk/
+// detachDisk. Unlike ModifyInstance (which requires a stopped instance), these
+// GCP verbs apply to running VMs. set entries are merged into the tag map,
+// remove keys are deleted, and machineType replaces the instance type when
+// non-empty. GCP-specific; reached via a type assertion from the GCE handler.
+func (m *Mock) MutateInstanceGCP(instanceID string, set map[string]string, remove []string, machineType string) error {
+	inst, ok := m.instances.Get(instanceID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
+	}
+
+	if inst.Tags == nil {
+		inst.Tags = make(map[string]string)
+	}
+
+	for k, v := range set {
+		inst.Tags[k] = v
+	}
+
+	for _, k := range remove {
+		delete(inst.Tags, k)
+	}
+
+	if machineType != "" {
+		inst.InstanceType = machineType
+	}
+
+	return nil
+}
+
 func (m *Mock) DescribeInstances(
 	_ context.Context, instanceIDs []string, filters []driver.DescribeFilter, _ ...driver.DescribeInstancesOptions,
 ) ([]driver.Instance, error) {

--- a/server/gcp/compute/handler.go
+++ b/server/gcp/compute/handler.go
@@ -12,10 +12,9 @@
 //	POST   /compute/v1/projects/{p}/zones/{z}/instances/{name}/start — start
 //	POST   /compute/v1/projects/{p}/zones/{z}/instances/{name}/stop  — stop
 //	POST   /compute/v1/projects/{p}/zones/{z}/instances/{name}/reset — reset
+//	POST   /compute/v1/projects/{p}/zones/{z}/instances/{name}/{verb} — setLabels/setMetadata/setTags/setMachineType/attachDisk/detachDisk
+//	GET    /compute/v1/projects/{p}/aggregated/instances             — aggregatedList (grouped by zone)
 //	GET    /compute/v1/projects/{p}/zones/{z}/operations/{name}      — get operation (always DONE)
-//
-// Less-used surfaces (aggregated list, snapshots, disks, images) are not yet
-// wired and return 501 Not Implemented.
 package compute
 
 import (
@@ -72,28 +71,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if rp.ResourceType == resourceOperations {
-		serveOperations(w, r, rp)
+	if rp.Scope == gcprest.ScopeAggregated {
+		h.serveAggregated(w, r, rp)
 		return
 	}
 
-	if rp.ResourceType == resourceDisks {
-		h.serveDisksRoute(w, r, rp)
-		return
-	}
-
-	if rp.ResourceType == resourceSnapshots {
-		h.serveSnapshotsRoute(w, r, rp)
-		return
-	}
-
-	if rp.ResourceType == resourceImages {
-		h.serveImagesRoute(w, r, rp)
-		return
-	}
-
-	if rp.ResourceType == resourceMachineTyp {
-		serveMachineTypesRoute(w, r, rp)
+	if h.routeResource(w, r, rp) {
 		return
 	}
 
@@ -105,6 +88,42 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		h.serveInstanceCollection(w, r, rp)
 	}
+}
+
+// serveAggregated handles the /aggregated/{type} scope (currently only
+// instances, which gcloud uses when no zone is given).
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) serveAggregated(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if r.Method == http.MethodGet && rp.ResourceType == resourceInstances {
+		h.aggregatedListInstances(w, r, rp)
+		return
+	}
+
+	writeNotImplemented(w, r.Method+" "+r.URL.Path)
+}
+
+// routeResource dispatches the non-instance resource types (operations, disks,
+// snapshots, images, machineTypes), returning true when it handled the request.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) routeResource(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) bool {
+	switch rp.ResourceType {
+	case resourceOperations:
+		serveOperations(w, r, rp)
+	case resourceDisks:
+		h.serveDisksRoute(w, r, rp)
+	case resourceSnapshots:
+		h.serveSnapshotsRoute(w, r, rp)
+	case resourceImages:
+		h.serveImagesRoute(w, r, rp)
+	case resourceMachineTyp:
+		serveMachineTypesRoute(w, r, rp)
+	default:
+		return false
+	}
+
+	return true
 }
 
 //nolint:gocritic,dupl // rp is a request-scoped value; route shape is duplicate-by-design across resource types
@@ -226,6 +245,14 @@ func (h *Handler) serveInstanceAction(w http.ResponseWriter, r *http.Request, rp
 		return
 	}
 
+	h.dispatchInstanceVerb(w, r, rp)
+}
+
+// dispatchInstanceVerb routes the POST instance verbs (lifecycle + GCP-specific
+// mutations) to their handlers.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) dispatchInstanceVerb(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
 	switch strings.ToLower(rp.Action) {
 	case "start":
 		h.startInstance(w, r, rp)
@@ -233,6 +260,18 @@ func (h *Handler) serveInstanceAction(w http.ResponseWriter, r *http.Request, rp
 		h.stopInstance(w, r, rp)
 	case "reset":
 		h.resetInstance(w, r, rp)
+	case "setlabels":
+		h.setLabels(w, r, rp)
+	case "setmetadata":
+		h.setMetadata(w, r, rp)
+	case "settags":
+		h.setTags(w, r, rp)
+	case "setmachinetype":
+		h.setMachineType(w, r, rp)
+	case "attachdisk":
+		h.attachDisk(w, r, rp)
+	case "detachdisk":
+		h.detachDisk(w, r, rp)
 	default:
 		writeNotImplemented(w, "action: "+rp.Action)
 	}

--- a/server/gcp/compute/instance_actions.go
+++ b/server/gcp/compute/instance_actions.go
@@ -1,0 +1,239 @@
+package compute
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+)
+
+// defaultMaxResults is GCP's default page size for list calls.
+const defaultMaxResults = 500
+
+// setLabels handles POST .../instances/{name}/setLabels: it replaces the
+// instance's user labels (internal state tags are preserved).
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) setLabels(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	var body setLabelsRequest
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	inst, err := findInZone(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	// Remove existing user labels that the new set drops.
+	var remove []string
+
+	for k := range userLabels(inst.Tags) {
+		if _, keep := body.Labels[k]; !keep {
+			remove = append(remove, k)
+		}
+	}
+
+	h.applyMutation(w, r, rp, inst.ID, "setLabels", body.Labels, remove, "")
+}
+
+// setMetadata handles POST .../instances/{name}/setMetadata.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) setMetadata(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	var body metadataBlock
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	inst, err := findInZone(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	h.applyMutation(w, r, rp, inst.ID, "setMetadata",
+		map[string]string{keyMetadata: encodeJSON(body.Items)}, nil, "")
+}
+
+// setTags handles POST .../instances/{name}/setTags.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) setTags(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	var body tagsBlock
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	inst, err := findInZone(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	h.applyMutation(w, r, rp, inst.ID, "setTags",
+		map[string]string{keyNetTags: encodeJSON(body.Items)}, nil, "")
+}
+
+// setMachineType handles POST .../instances/{name}/setMachineType.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) setMachineType(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	var body setMachineTypeRequest
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	inst, err := findInZone(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	h.applyMutation(w, r, rp, inst.ID, "setMachineType", nil, nil, machineTypeShort(body.MachineType))
+}
+
+// attachDisk handles POST .../instances/{name}/attachDisk.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) attachDisk(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	var disk attachedDisk
+	if !gcprest.DecodeJSON(w, r, &disk) {
+		return
+	}
+
+	inst, err := findInZone(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	disks := append(decodeDisks(inst.Tags), disk)
+
+	h.applyMutation(w, r, rp, inst.ID, "attachDisk",
+		map[string]string{keyDisks: encodeJSON(disks)}, nil, "")
+}
+
+// detachDisk handles POST .../instances/{name}/detachDisk?deviceName=...
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) detachDisk(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	device := r.URL.Query().Get("deviceName")
+	if device == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "deviceName is required")
+		return
+	}
+
+	inst, err := findInZone(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	kept := make([]attachedDisk, 0)
+
+	for _, d := range decodeDisks(inst.Tags) {
+		if d.DeviceName != device {
+			kept = append(kept, d)
+		}
+	}
+
+	h.applyMutation(w, r, rp, inst.ID, "detachDisk",
+		map[string]string{keyDisks: encodeJSON(kept)}, nil, "")
+}
+
+// applyMutation runs a GCP-specific instance mutation through the mutator
+// capability and returns a DONE Operation.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) applyMutation(
+	w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath,
+	instanceID, opType string, set map[string]string, remove []string, machineType string,
+) {
+	mutator, ok := h.compute.(instanceMutator)
+	if !ok {
+		writeNotImplemented(w, "instance mutation: "+opType)
+		return
+	}
+
+	if err := mutator.MutateInstanceGCP(instanceID, set, remove, machineType); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
+		"instances", rp.ResourceName, opType)
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// parseMaxResults parses the maxResults query param, defaulting to GCP's page
+// size when absent or invalid.
+func parseMaxResults(raw string) int {
+	if raw == "" {
+		return defaultMaxResults
+	}
+
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return defaultMaxResults
+	}
+
+	return n
+}
+
+// parseFilter compiles a GCP list filter into a predicate. It supports the
+// common single-clause forms "<field> <op> <value>" where op is one of
+// "=", "!=", "eq", "ne" and field is name/status/machineType/zone. An
+// unrecognized or empty filter matches everything.
+func parseFilter(raw string) func(*instanceResponse) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return func(*instanceResponse) bool { return true }
+	}
+
+	field, op, value, ok := splitFilter(raw)
+	if !ok {
+		return func(*instanceResponse) bool { return true }
+	}
+
+	negate := op == "!=" || op == "ne"
+
+	return func(resp *instanceResponse) bool {
+		got := filterField(resp, field)
+		eq := got == value
+
+		return eq != negate
+	}
+}
+
+func splitFilter(raw string) (field, op, value string, ok bool) {
+	for _, candidate := range []string{"!=", "=", " ne ", " eq "} {
+		if idx := strings.Index(raw, candidate); idx >= 0 {
+			field = strings.TrimSpace(raw[:idx])
+			value = strings.Trim(strings.TrimSpace(raw[idx+len(candidate):]), `"'`)
+			op = strings.TrimSpace(candidate)
+
+			return field, op, value, field != ""
+		}
+	}
+
+	return "", "", "", false
+}
+
+func filterField(resp *instanceResponse, field string) string {
+	switch field {
+	case "name":
+		return resp.Name
+	case "status":
+		return resp.Status
+	case "machineType":
+		return lastSegment(resp.MachineType)
+	case "zone":
+		return lastSegment(resp.Zone)
+	default:
+		return ""
+	}
+}

--- a/server/gcp/compute/instance_response.go
+++ b/server/gcp/compute/instance_response.go
@@ -1,0 +1,225 @@
+package compute
+
+import (
+	"strconv"
+	"strings"
+
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+// defaultCPUPlatform is the CPU platform GCP reports for a running VM.
+const defaultCPUPlatform = "Intel Broadwell"
+
+// toInstanceResponse maps a driver Instance back to GCP's REST shape, resolving
+// the GCP-specific state carried in the instance's internal tags (disks,
+// network tags, metadata, network self-link) and filling realistic defaults.
+func toInstanceResponse(inst *computedriver.Instance, project, host string) instanceResponse {
+	name := tagOr(inst.Tags, gcpNameTag, "")
+	zone := tagOr(inst.Tags, keyZone, "")
+	labels := userLabels(inst.Tags)
+	netTags := decodeNetTags(inst.Tags)
+	metaItems := decodeMetadata(inst.Tags)
+
+	resp := instanceResponse{
+		Kind:               "compute#instance",
+		ID:                 numericID(inst.ID),
+		Name:               name,
+		MachineType:        zoneLink(host, project, zone, "machineTypes", inst.InstanceType),
+		Status:             gcpStatusFor(inst.State),
+		Zone:               host + "/compute/v1/projects/" + project + "/zones/" + zone,
+		SelfLink:           zoneLink(host, project, zone, "instances", name),
+		CreationTimestamp:  inst.LaunchTime,
+		CPUPlatform:        defaultCPUPlatform,
+		DeletionProtection: false,
+		Disks:              resolveDisks(inst, host, project, zone, name),
+		NetworkInterfaces:  instanceNICs(inst, host, project, zone),
+		Labels:             labels,
+		LabelFingerprint:   labelFingerprintFor(labels),
+		Fingerprint:        fingerprint(inst.ID, inst.InstanceType, inst.State),
+		Tags: &tagsBlock{
+			Items:       netTags,
+			Fingerprint: fingerprint(strings.Join(netTags, ",")),
+		},
+		Metadata:               metadataResponse(metaItems),
+		Scheduling:             defaultScheduling(),
+		ServiceAccounts:        defaultServiceAccounts(),
+		ShieldedInstanceConfig: defaultShieldedConfig(),
+	}
+
+	if resp.Status == statusRunning {
+		resp.LastStartTimestamp = inst.LaunchTime
+	}
+
+	return resp
+}
+
+// zoneLink builds a zone-scoped self-link. Used instead of gcprest.SelfLink so
+// list/aggregatedList responses carry each instance's own zone rather than the
+// request path's scope (aggregatedList has no zone in its path).
+func zoneLink(host, project, zone, resourceType, name string) string {
+	host = strings.TrimSuffix(host, "/")
+	return host + "/compute/v1/projects/" + project + "/zones/" + zone + "/" + resourceType + "/" + name
+}
+
+// resolveDisks turns the stored inbound disk descriptors into the full GCP
+// attachedDisk read shape (resolved source self-link, diskSizeGb, type, mode).
+func resolveDisks(inst *computedriver.Instance, host, project, zone, instanceName string) []attachedDisk {
+	disks := decodeDisks(inst.Tags)
+	if len(disks) == 0 {
+		return nil
+	}
+
+	out := make([]attachedDisk, 0, len(disks))
+
+	for i := range disks {
+		d := disks[i]
+		d.Kind = "compute#attachedDisk"
+		d.Index = i
+
+		if d.DeviceName == "" {
+			d.DeviceName = deviceNameFor(d.Boot, instanceName, i)
+		}
+
+		if d.Type == "" {
+			d.Type = "PERSISTENT"
+		}
+
+		if d.Mode == "" {
+			d.Mode = "READ_WRITE"
+		}
+
+		if d.DiskSizeGb == "" {
+			d.DiskSizeGb = diskSizeFor(&d)
+		}
+
+		if d.Source == "" {
+			d.Source = zoneLink(host, project, zone, "disks", d.DeviceName)
+		}
+
+		out = append(out, d)
+	}
+
+	return out
+}
+
+func deviceNameFor(boot bool, instanceName string, index int) string {
+	if boot {
+		return instanceName
+	}
+
+	return "persistent-disk-" + strconv.Itoa(index)
+}
+
+func diskSizeFor(d *attachedDisk) string {
+	if d.InitializeParams != nil && d.InitializeParams.DiskSizeGb != "" {
+		return d.InitializeParams.DiskSizeGb
+	}
+
+	return defaultDiskSizeGb
+}
+
+// instanceNICs echoes the instance's network interface with fully-qualified
+// network and subnetwork self-links (real GCP resolves both to absolute URLs).
+func instanceNICs(inst *computedriver.Instance, host, project, zone string) []networkInterface {
+	network := qualifyNetwork(host, project, tagOr(inst.Tags, keyNetwork, ""))
+	subnet := qualifySubnetwork(host, project, zone, inst.SubnetID)
+
+	if network == "" && subnet == "" && inst.PrivateIP == "" {
+		return nil
+	}
+
+	return []networkInterface{{
+		Name:       "nic0",
+		Network:    network,
+		Subnetwork: subnet,
+		NetworkIP:  inst.PrivateIP,
+		StackType:  "IPV4_ONLY",
+	}}
+}
+
+// qualifyNetwork resolves a raw network reference to a global self-link.
+func qualifyNetwork(host, project, raw string) string {
+	if raw == "" {
+		return ""
+	}
+
+	host = strings.TrimSuffix(host, "/")
+
+	return host + "/compute/v1/projects/" + project + "/global/networks/" + lastSegment(raw)
+}
+
+// qualifySubnetwork resolves a raw subnetwork reference to a region-scoped
+// self-link, inferring the region from the zone when the raw value omits it.
+func qualifySubnetwork(host, project, zone, raw string) string {
+	if raw == "" {
+		return ""
+	}
+
+	host = strings.TrimSuffix(host, "/")
+	region, name := parseSubnetRef(raw, zone)
+
+	return host + "/compute/v1/projects/" + project + "/regions/" + region + "/subnetworks/" + name
+}
+
+// parseSubnetRef pulls the region and subnetwork name out of a raw reference of
+// the form ".../regions/{r}/subnetworks/{n}" or a bare name.
+func parseSubnetRef(raw, zone string) (region, name string) {
+	parts := strings.Split(raw, "/")
+	region = regionFromZone(zone)
+	name = parts[len(parts)-1]
+
+	for i := 0; i+1 < len(parts); i++ {
+		if parts[i] == "regions" {
+			region = parts[i+1]
+		}
+	}
+
+	return region, name
+}
+
+// regionFromZone derives the region ("us-central1") from a zone
+// ("us-central1-a") by trimming the trailing "-<letter>".
+func regionFromZone(zone string) string {
+	if i := strings.LastIndex(zone, "-"); i > 0 {
+		return zone[:i]
+	}
+
+	return zone
+}
+
+func metadataResponse(items []metadataItem) *metadataBlock {
+	joined := make([]string, 0, len(items)*kvStride)
+	for _, it := range items {
+		joined = append(joined, it.Key, it.Value)
+	}
+
+	return &metadataBlock{
+		Kind:        "compute#metadata",
+		Items:       items,
+		Fingerprint: fingerprint(joined...),
+	}
+}
+
+func defaultScheduling() *scheduling {
+	return &scheduling{
+		AutomaticRestart:  true,
+		OnHostMaintenance: "MIGRATE",
+		Preemptible:       false,
+		ProvisioningModel: "STANDARD",
+	}
+}
+
+func defaultServiceAccounts() []serviceAccount {
+	return []serviceAccount{{
+		Email:  "default",
+		Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
+	}}
+}
+
+func defaultShieldedConfig() *shieldedInstanceConfig {
+	return &shieldedInstanceConfig{
+		EnableSecureBoot:          false,
+		EnableVtpm:                true,
+		EnableIntegrityMonitoring: true,
+	}
+}

--- a/server/gcp/compute/instance_state.go
+++ b/server/gcp/compute/instance_state.go
@@ -1,0 +1,147 @@
+package compute
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"hash/fnv"
+	"sort"
+	"strings"
+)
+
+// GCP-specific instance state that the portable compute driver model does not
+// carry (disks, network tags, metadata, the network self-link, and the launch
+// zone) is round-tripped through the driver by encoding it into internal
+// entries of the instance's tag map, keyed with the "cloudemu:gcp" prefix.
+// These keys are stripped from the emitted labels.
+const (
+	keyDisks    = "cloudemu:gcp:disks"
+	keyNetTags  = "cloudemu:gcp:nettags"
+	keyMetadata = "cloudemu:gcp:metadata"
+	keyNetwork  = "cloudemu:gcp:network"
+	keyZone     = "cloudemu:gcp:zone"
+)
+
+// internalTagPrefix marks tag keys that carry CloudEmu-internal GCP state
+// rather than user labels. gcpNameTag ("cloudemu:gcpName") also matches.
+const internalTagPrefix = "cloudemu:gcp"
+
+// kvStride is the number of slice slots a flattened key/value pair occupies.
+const kvStride = 2
+
+// internalTagCap is the number of internal keys insertTags may add, used only
+// as a map preallocation hint.
+const internalTagCap = 6
+
+func isInternalTag(key string) bool {
+	return strings.HasPrefix(key, internalTagPrefix)
+}
+
+func encodeJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+
+	return string(b)
+}
+
+func decodeDisks(tags map[string]string) []attachedDisk {
+	raw := tags[keyDisks]
+	if raw == "" {
+		return nil
+	}
+
+	var disks []attachedDisk
+	if err := json.Unmarshal([]byte(raw), &disks); err != nil {
+		return nil
+	}
+
+	return disks
+}
+
+func decodeNetTags(tags map[string]string) []string {
+	raw := tags[keyNetTags]
+	if raw == "" {
+		return nil
+	}
+
+	var items []string
+	if err := json.Unmarshal([]byte(raw), &items); err != nil {
+		return nil
+	}
+
+	return items
+}
+
+func decodeMetadata(tags map[string]string) []metadataItem {
+	raw := tags[keyMetadata]
+	if raw == "" {
+		return nil
+	}
+
+	var items []metadataItem
+	if err := json.Unmarshal([]byte(raw), &items); err != nil {
+		return nil
+	}
+
+	return items
+}
+
+// fingerprint returns a stable GCP-style fingerprint (8 base64 bytes) derived
+// from parts. It changes when the underlying content changes, which is what
+// clients compare for optimistic concurrency on setLabels/setMetadata/setTags.
+func fingerprint(parts ...string) string {
+	h := fnv.New64a()
+	for _, p := range parts {
+		_, _ = h.Write([]byte(p))
+		_, _ = h.Write([]byte{0})
+	}
+
+	var buf [8]byte
+
+	binary.BigEndian.PutUint64(buf[:], h.Sum64())
+
+	return base64.StdEncoding.EncodeToString(buf[:])
+}
+
+// userLabels returns the user-visible labels: the tag map with all internal
+// CloudEmu keys removed. Keys are returned sorted-stable via the map itself.
+func userLabels(tags map[string]string) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(tags))
+
+	for k, v := range tags {
+		if isInternalTag(k) {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
+// labelFingerprintFor derives the labelFingerprint from the sorted user labels.
+func labelFingerprintFor(labels map[string]string) string {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys)*kvStride)
+	for _, k := range keys {
+		parts = append(parts, k, labels[k])
+	}
+
+	return fingerprint(parts...)
+}

--- a/server/gcp/compute/instances.go
+++ b/server/gcp/compute/instances.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 )
@@ -17,6 +18,13 @@ const gcpNameTag = "cloudemu:gcpName"
 
 // statusTerminated is GCP Compute's status for stopped/terminated instances.
 const statusTerminated = "TERMINATED"
+
+// statusRunning is GCP Compute's status for a running instance.
+const statusRunning = "RUNNING"
+
+// defaultDiskSizeGb is the boot-disk size GCP reports when the caller did not
+// request one.
+const defaultDiskSizeGb = "10"
 
 // insertInstance handles POST .../instances. Maps the GCP body to an
 // InstanceConfig, runs RunInstances(count=1), returns a DONE Operation
@@ -40,11 +48,19 @@ func (h *Handler) insertInstance(w http.ResponseWriter, r *http.Request, rp gcpr
 		return
 	}
 
+	// Real GCP rejects a duplicate name in the same zone with 409 alreadyExists.
+	if existing, err := findInZone(r.Context(), h.compute, req.Name, rp.ScopeName); err == nil && existing != nil {
+		gcprest.WriteError(w, http.StatusConflict, "alreadyExists",
+			"The resource 'projects/"+rp.Project+"/zones/"+rp.ScopeName+"/instances/"+req.Name+"' already exists")
+
+		return
+	}
+
 	cfg := computedriver.InstanceConfig{
 		ImageID:      bootImage(req.Disks),
 		InstanceType: machineTypeShort(req.MachineType),
 		SubnetID:     firstSubnet(req.NetworkInterfaces),
-		Tags:         mergeTags(req.Labels, req.Name),
+		Tags:         insertTags(&req, rp.ScopeName),
 		UserData:     startupScript(req.Metadata),
 	}
 
@@ -69,17 +85,17 @@ func (h *Handler) insertInstance(w http.ResponseWriter, r *http.Request, rp gcpr
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) getInstance(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	inst, err := findByName(r.Context(), h.compute, rp.ResourceName)
+	inst, err := findInZone(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, toInstanceResponse(inst, rp, hostFromRequest(r)))
+	gcprest.WriteJSON(w, http.StatusOK, toInstanceResponse(inst, rp.Project, hostFromRequest(r)))
 }
 
-// listInstances handles GET .../instances. Returns all driver instances; the
-// mock isn't project/zone scoped.
+// listInstances handles GET .../instances. Scopes to the requested zone and
+// applies the filter / maxResults / pageToken query parameters.
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) listInstances(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
@@ -90,19 +106,66 @@ func (h *Handler) listInstances(w http.ResponseWriter, r *http.Request, rp gcpre
 	}
 
 	host := hostFromRequest(r)
+	pred := parseFilter(r.URL.Query().Get("filter"))
+
 	out := make([]instanceResponse, 0, len(instances))
 
 	for i := range instances {
-		scope := rp
-		scope.ResourceName = tagOr(instances[i].Tags, gcpNameTag, instances[i].ID)
-		out = append(out, toInstanceResponse(&instances[i], scope, host))
+		if !instanceInZone(&instances[i], rp.ScopeName) {
+			continue
+		}
+
+		resp := toInstanceResponse(&instances[i], rp.Project, host)
+		if pred(&resp) {
+			out = append(out, resp)
+		}
+	}
+
+	page, err := pagination.PaginateSorted(out,
+		func(a, b instanceResponse) bool { return a.Name < b.Name },
+		r.URL.Query().Get("pageToken"), parseMaxResults(r.URL.Query().Get("maxResults")))
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid pageToken")
+		return
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, instanceListResponse{
-		Kind:     "compute#instanceList",
-		ID:       "projects/" + rp.Project + "/zones/" + rp.ScopeName + "/instances",
-		Items:    out,
-		SelfLink: gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, "instances", ""),
+		Kind:          "compute#instanceList",
+		ID:            "projects/" + rp.Project + "/zones/" + rp.ScopeName + "/instances",
+		Items:         page.Items,
+		NextPageToken: page.NextPageToken,
+		SelfLink:      gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, "instances", ""),
+	})
+}
+
+// aggregatedListInstances handles GET .../aggregated/instances: every instance
+// grouped by its "zones/{zone}" scope, the shape gcloud uses when no zone is
+// given.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) aggregatedListInstances(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	instances, err := h.compute.DescribeInstances(r.Context(), nil, nil)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	host := hostFromRequest(r)
+	items := make(map[string]instancesScopedList)
+
+	for i := range instances {
+		resp := toInstanceResponse(&instances[i], rp.Project, host)
+		scope := "zones/" + tagOr(instances[i].Tags, keyZone, "unknown")
+		bucket := items[scope]
+		bucket.Instances = append(bucket.Instances, resp)
+		items[scope] = bucket
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, aggregatedListResponse{
+		Kind:     "compute#instanceAggregatedList",
+		ID:       "projects/" + rp.Project + "/aggregated/instances",
+		Items:    items,
+		SelfLink: host + "/compute/v1/projects/" + rp.Project + "/aggregated/instances",
 	})
 }
 
@@ -110,7 +173,7 @@ func (h *Handler) listInstances(w http.ResponseWriter, r *http.Request, rp gcpre
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) deleteInstance(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	inst, err := findByName(r.Context(), h.compute, rp.ResourceName)
+	inst, err := findInZone(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -163,7 +226,7 @@ func (h *Handler) action(
 	w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath, opType string,
 	op func(ctx context.Context, ids []string) error,
 ) {
-	inst, err := findByName(r.Context(), h.compute, rp.ResourceName)
+	inst, err := findInZone(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -180,14 +243,11 @@ func (h *Handler) action(
 	gcprest.WriteJSON(w, http.StatusOK, doneOp)
 }
 
-// getSerialPortOutput handles GET .../instances/{name}/serialPort. It mirrors
-// instances.getSerialPortOutput: the instance's serial console output (the boot
-// script's captured output when a real compute engine backs the instance) is
-// returned in the "contents" field of a compute#serialPortOutput resource.
+// getSerialPortOutput handles GET .../instances/{name}/serialPort.
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) getSerialPortOutput(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	inst, err := findByName(r.Context(), h.compute, rp.ResourceName)
+	inst, err := findInZone(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -221,8 +281,16 @@ type instanceRemover interface {
 	RemoveInstance(ctx context.Context, instanceID string) error
 }
 
-// startupScript extracts the GCE boot script from instance metadata. GCE
-// carries it as the metadata item keyed "startup-script"; empty when absent.
+// instanceMutator is a GCP-local capability the GCE Mock implements: it mutates
+// an already-running instance (setLabels/setMetadata/setTags/setMachineType/
+// attachDisk/detachDisk all apply to running VMs, unlike ModifyInstance which
+// requires a stopped instance). set entries are merged into the tag map,
+// remove keys are deleted, and machineType is set when non-empty.
+type instanceMutator interface {
+	MutateInstanceGCP(instanceID string, set map[string]string, remove []string, machineType string) error
+}
+
+// startupScript extracts the GCE boot script from instance metadata.
 func startupScript(md metadataBlock) string {
 	for _, item := range md.Items {
 		if item.Key == "startup-script" {
@@ -233,15 +301,55 @@ func startupScript(md metadataBlock) string {
 	return ""
 }
 
-// findByName looks up an instance by its GCP-tagged name.
-func findByName(ctx context.Context, c computedriver.Compute, name string) (*computedriver.Instance, error) {
+// insertTags builds the driver tag map from the GCP insert body: the user
+// labels, plus the internal keys that round-trip GCP-specific state (name,
+// disks, network tags, metadata, network self-link, launch zone).
+func insertTags(req *instanceRequest, zone string) map[string]string {
+	out := make(map[string]string, len(req.Labels)+internalTagCap)
+
+	for k, v := range req.Labels {
+		out[k] = v
+	}
+
+	out[gcpNameTag] = req.Name
+	out[keyZone] = zone
+
+	if len(req.Disks) > 0 {
+		out[keyDisks] = encodeJSON(req.Disks)
+	}
+
+	if len(req.Tags.Items) > 0 {
+		out[keyNetTags] = encodeJSON(req.Tags.Items)
+	}
+
+	if len(req.Metadata.Items) > 0 {
+		out[keyMetadata] = encodeJSON(req.Metadata.Items)
+	}
+
+	if net := firstNetwork(req.NetworkInterfaces); net != "" {
+		out[keyNetwork] = net
+	}
+
+	return out
+}
+
+// findInZone looks up an instance by GCP name, scoped to zone. An instance with
+// no recorded zone (created directly through the driver) matches any zone so
+// non-wire callers stay visible.
+func findInZone(
+	ctx context.Context, c computedriver.Compute, name, zone string,
+) (*computedriver.Instance, error) {
 	instances, err := c.DescribeInstances(ctx, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	for i := range instances {
-		if tagOr(instances[i].Tags, gcpNameTag, "") == name {
+		if tagOr(instances[i].Tags, gcpNameTag, "") != name {
+			continue
+		}
+
+		if instanceInZone(&instances[i], zone) {
 			return &instances[i], nil
 		}
 	}
@@ -249,12 +357,19 @@ func findByName(ctx context.Context, c computedriver.Compute, name string) (*com
 	return nil, cerrors.Newf(cerrors.NotFound, "instance %s not found", name)
 }
 
+// instanceInZone reports whether inst belongs to zone. An instance with no
+// recorded zone matches any zone (defensive for driver-created instances).
+func instanceInZone(inst *computedriver.Instance, zone string) bool {
+	stored := tagOr(inst.Tags, keyZone, "")
+	return zone == "" || stored == "" || stored == zone
+}
+
 // Helpers that map between GCP REST shapes and the driver model.
 
 func bootImage(disks []attachedDisk) string {
-	for _, d := range disks {
-		if d.Boot && d.InitializeParams != nil {
-			return d.InitializeParams.SourceImage
+	for i := range disks {
+		if disks[i].Boot && disks[i].InitializeParams != nil {
+			return disks[i].InitializeParams.SourceImage
 		}
 	}
 
@@ -285,16 +400,14 @@ func firstSubnet(nics []networkInterface) string {
 	return ""
 }
 
-func mergeTags(in map[string]string, gcpName string) map[string]string {
-	out := make(map[string]string, len(in)+1)
-
-	for k, v := range in {
-		out[k] = v
+func firstNetwork(nics []networkInterface) string {
+	for _, n := range nics {
+		if n.Network != "" {
+			return n.Network
+		}
 	}
 
-	out[gcpNameTag] = gcpName
-
-	return out
+	return ""
 }
 
 func tagOr(m map[string]string, key, fallback string) string {
@@ -303,44 +416,6 @@ func tagOr(m map[string]string, key, fallback string) string {
 	}
 
 	return fallback
-}
-
-// toInstanceResponse maps a driver Instance back to GCP's REST shape. The
-// ID field is uint64-shaped because GCP's protobuf JSON unmarshaller rejects
-// non-numeric strings — we hash the driver ID into a stable numeric value.
-//
-//nolint:gocritic // rp is a request-scoped value passed once per response build
-func toInstanceResponse(inst *computedriver.Instance, rp gcprest.ResourcePath, host string) instanceResponse {
-	name := tagOr(inst.Tags, gcpNameTag, rp.ResourceName)
-
-	return instanceResponse{
-		Kind:              "compute#instance",
-		ID:                numericID(inst.ID),
-		Name:              name,
-		MachineType:       gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, "machineTypes", inst.InstanceType),
-		Status:            gcpStatusFor(inst.State),
-		Zone:              host + "/compute/v1/projects/" + rp.Project + "/zones/" + rp.ScopeName,
-		SelfLink:          gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, "instances", name),
-		NetworkInterfaces: instanceNICs(inst),
-		Labels:            stripInternalTags(inst.Tags),
-	}
-}
-
-// instanceNICs echoes back the network interface the instance was created
-// with. The driver stores the subnetwork the client set plus the private IP it
-// assigned; a read must return them (real GCP always reports a NIC), otherwise
-// a client that sets a subnet reads back an empty interface list.
-func instanceNICs(inst *computedriver.Instance) []networkInterface {
-	if inst.SubnetID == "" && inst.PrivateIP == "" && inst.VPCID == "" {
-		return nil
-	}
-
-	return []networkInterface{{
-		Name:       "nic0",
-		Network:    inst.VPCID,
-		Subnetwork: inst.SubnetID,
-		NetworkIP:  inst.PrivateIP,
-	}}
 }
 
 // numericID returns a stable uint64-shaped string derived from a driver
@@ -360,35 +435,11 @@ func numericID(driverID string) string {
 	return strconv.FormatUint(h, 10)
 }
 
-func stripInternalTags(in map[string]string) map[string]string {
-	if len(in) == 0 {
-		return nil
-	}
-
-	out := make(map[string]string, len(in))
-
-	for k, v := range in {
-		if k == gcpNameTag {
-			continue
-		}
-
-		out[k] = v
-	}
-
-	if len(out) == 0 {
-		return nil
-	}
-
-	return out
-}
-
 // gcpStatusFor maps driver states to GCP Compute Engine instance status.
-// GCP's documented values: PROVISIONING, STAGING, RUNNING, STOPPING,
-// STOPPED, SUSPENDING, SUSPENDED, REPAIRING, TERMINATED.
 func gcpStatusFor(state string) string {
 	switch state {
 	case "running":
-		return "RUNNING"
+		return statusRunning
 	case "pending":
 		return "PROVISIONING"
 	case "stopping":

--- a/server/gcp/compute/instances_sdk_test.go
+++ b/server/gcp/compute/instances_sdk_test.go
@@ -1,0 +1,526 @@
+package compute_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+const altZone = "europe-west1-b"
+
+// newInstancesEnv spins up a GCP wire server backed by a fresh GCE mock and a
+// real cloud.google.com/go InstancesClient pointed at it.
+func newInstancesEnv(t *testing.T) (*gcpcompute.InstancesClient, *httptest.Server, context.Context) {
+	t.Helper()
+
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Compute: cloudP.GCE})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return newSDKInstancesClient(t, ts), ts, context.Background()
+}
+
+func mustInsert(t *testing.T, client *gcpcompute.InstancesClient, zone string, inst *computepb.Instance) {
+	t.Helper()
+
+	op, err := client.Insert(context.Background(), &computepb.InsertInstanceRequest{
+		Project: testProject, Zone: zone, InstanceResource: inst,
+	})
+	if err != nil {
+		t.Fatalf("Insert %s: %v", inst.GetName(), err)
+	}
+
+	if err := op.Wait(context.Background()); err != nil {
+		t.Fatalf("Insert %s wait: %v", inst.GetName(), err)
+	}
+}
+
+func mustGet(t *testing.T, client *gcpcompute.InstancesClient, zone, name string) *computepb.Instance {
+	t.Helper()
+
+	got, err := client.Get(context.Background(), &computepb.GetInstanceRequest{
+		Project: testProject, Zone: zone, Instance: name,
+	})
+	if err != nil {
+		t.Fatalf("Get %s: %v", name, err)
+	}
+
+	return got
+}
+
+// TestSDKGCEInstanceDisksRoundTrip covers finding #1: attached disks[] must be
+// echoed with the boot disk (deviceName/source/boot/diskSizeGb/type).
+func TestSDKGCEInstanceDisksRoundTrip(t *testing.T) {
+	client, _, _ := newInstancesEnv(t)
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name:        ptrStr("disk-vm"),
+		MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+		Disks: []*computepb.AttachedDisk{{
+			Boot:       ptrBool(true),
+			AutoDelete: ptrBool(true),
+			InitializeParams: &computepb.AttachedDiskInitializeParams{
+				SourceImage: ptrStr("projects/debian-cloud/global/images/family/debian-12"),
+				DiskSizeGb:  ptrInt64(50),
+			},
+		}},
+	})
+
+	got := mustGet(t, client, testZone, "disk-vm")
+
+	disks := got.GetDisks()
+	if len(disks) != 1 {
+		t.Fatalf("disks=%d want 1", len(disks))
+	}
+
+	if !disks[0].GetBoot() {
+		t.Error("boot disk not marked boot=true")
+	}
+
+	if disks[0].GetDiskSizeGb() != 50 {
+		t.Errorf("diskSizeGb=%d want 50", disks[0].GetDiskSizeGb())
+	}
+
+	if !strings.HasSuffix(disks[0].GetSource(), "/disks/disk-vm") {
+		t.Errorf("source=%q want .../disks/disk-vm", disks[0].GetSource())
+	}
+
+	if disks[0].GetType() != "PERSISTENT" {
+		t.Errorf("type=%q want PERSISTENT", disks[0].GetType())
+	}
+}
+
+// TestSDKGCEInstanceTagsAndMetadataRoundTrip covers findings #2 and #3: network
+// tags and metadata (incl. startup-script) must round-trip with fingerprints.
+func TestSDKGCEInstanceTagsAndMetadataRoundTrip(t *testing.T) {
+	client, _, _ := newInstancesEnv(t)
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name:        ptrStr("meta-vm"),
+		MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+		Tags:        &computepb.Tags{Items: []string{"http-server", "https-server"}},
+		Metadata: &computepb.Metadata{Items: []*computepb.Items{
+			{Key: ptrStr("startup-script"), Value: ptrStr("#!/bin/bash\necho hi")},
+		}},
+	})
+
+	got := mustGet(t, client, testZone, "meta-vm")
+
+	if items := got.GetTags().GetItems(); len(items) != 2 || items[0] != "http-server" {
+		t.Errorf("tags.items=%v want [http-server https-server]", items)
+	}
+
+	if got.GetTags().GetFingerprint() == "" {
+		t.Error("tags.fingerprint empty")
+	}
+
+	md := got.GetMetadata().GetItems()
+	if len(md) != 1 || md[0].GetKey() != "startup-script" {
+		t.Fatalf("metadata.items=%v want [startup-script]", md)
+	}
+
+	if !strings.Contains(md[0].GetValue(), "echo hi") {
+		t.Errorf("startup-script value=%q", md[0].GetValue())
+	}
+
+	if got.GetMetadata().GetFingerprint() == "" {
+		t.Error("metadata.fingerprint empty")
+	}
+}
+
+// TestSDKGCEInstanceUpdateVerbs covers finding #4: setLabels/setMetadata/
+// setTags/setMachineType return a DONE Operation and mutate the instance.
+func TestSDKGCEInstanceUpdateVerbs(t *testing.T) {
+	client, _, ctx := newInstancesEnv(t)
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name:        ptrStr("upd-vm"),
+		MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+	})
+
+	labelOp, err := client.SetLabels(ctx, &computepb.SetLabelsInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "upd-vm",
+		InstancesSetLabelsRequestResource: &computepb.InstancesSetLabelsRequest{
+			Labels: map[string]string{"env": "prod"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SetLabels: %v", err)
+	}
+
+	if err := labelOp.Wait(ctx); err != nil {
+		t.Fatalf("SetLabels wait: %v", err)
+	}
+
+	mtOp, err := client.SetMachineType(ctx, &computepb.SetMachineTypeInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "upd-vm",
+		InstancesSetMachineTypeRequestResource: &computepb.InstancesSetMachineTypeRequest{
+			MachineType: ptrStr("zones/" + testZone + "/machineTypes/n2-standard-4"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("SetMachineType: %v", err)
+	}
+
+	if err := mtOp.Wait(ctx); err != nil {
+		t.Fatalf("SetMachineType wait: %v", err)
+	}
+
+	tagsOp, err := client.SetTags(ctx, &computepb.SetTagsInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "upd-vm",
+		TagsResource: &computepb.Tags{Items: []string{"web"}},
+	})
+	if err != nil {
+		t.Fatalf("SetTags: %v", err)
+	}
+
+	if err := tagsOp.Wait(ctx); err != nil {
+		t.Fatalf("SetTags wait: %v", err)
+	}
+
+	got := mustGet(t, client, testZone, "upd-vm")
+
+	if got.GetLabels()["env"] != "prod" {
+		t.Errorf("labels=%v want env=prod", got.GetLabels())
+	}
+
+	if !strings.HasSuffix(got.GetMachineType(), "/machineTypes/n2-standard-4") {
+		t.Errorf("machineType=%q want n2-standard-4", got.GetMachineType())
+	}
+
+	if items := got.GetTags().GetItems(); len(items) != 1 || items[0] != "web" {
+		t.Errorf("tags=%v want [web]", items)
+	}
+}
+
+// TestSDKGCEInstanceSetMetadata covers the setMetadata verb from finding #4.
+func TestSDKGCEInstanceSetMetadata(t *testing.T) {
+	client, _, ctx := newInstancesEnv(t)
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name:        ptrStr("sm-vm"),
+		MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+	})
+
+	op, err := client.SetMetadata(ctx, &computepb.SetMetadataInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "sm-vm",
+		MetadataResource: &computepb.Metadata{Items: []*computepb.Items{
+			{Key: ptrStr("foo"), Value: ptrStr("bar")},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("SetMetadata wait: %v", err)
+	}
+
+	got := mustGet(t, client, testZone, "sm-vm")
+
+	md := got.GetMetadata().GetItems()
+	if len(md) != 1 || md[0].GetKey() != "foo" || md[0].GetValue() != "bar" {
+		t.Errorf("metadata=%v want foo=bar", md)
+	}
+}
+
+// TestSDKGCEInstanceAttachDetachDisk covers finding #5.
+func TestSDKGCEInstanceAttachDetachDisk(t *testing.T) {
+	client, _, ctx := newInstancesEnv(t)
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name:        ptrStr("ad-vm"),
+		MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+	})
+
+	attachOp, err := client.AttachDisk(ctx, &computepb.AttachDiskInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "ad-vm",
+		AttachedDiskResource: &computepb.AttachedDisk{
+			DeviceName: ptrStr("data"),
+			Source:     ptrStr("zones/" + testZone + "/disks/data-disk"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("AttachDisk: %v", err)
+	}
+
+	if err := attachOp.Wait(ctx); err != nil {
+		t.Fatalf("AttachDisk wait: %v", err)
+	}
+
+	if !hasDevice(mustGet(t, client, testZone, "ad-vm").GetDisks(), "data") {
+		t.Fatal("attached disk 'data' not in disks[]")
+	}
+
+	detachOp, err := client.DetachDisk(ctx, &computepb.DetachDiskInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "ad-vm", DeviceName: "data",
+	})
+	if err != nil {
+		t.Fatalf("DetachDisk: %v", err)
+	}
+
+	if err := detachOp.Wait(ctx); err != nil {
+		t.Fatalf("DetachDisk wait: %v", err)
+	}
+
+	if hasDevice(mustGet(t, client, testZone, "ad-vm").GetDisks(), "data") {
+		t.Error("detached disk 'data' still present")
+	}
+}
+
+func hasDevice(disks []*computepb.AttachedDisk, device string) bool {
+	for _, d := range disks {
+		if d.GetDeviceName() == device {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestSDKGCEInstanceListZoneScoped covers finding #6: List(zone) returns only
+// that zone's instances.
+func TestSDKGCEInstanceListZoneScoped(t *testing.T) {
+	client, _, ctx := newInstancesEnv(t)
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name: ptrStr("za"), MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+	})
+	mustInsert(t, client, altZone, &computepb.Instance{
+		Name: ptrStr("zb"), MachineType: ptrStr("zones/" + altZone + "/machineTypes/n1-standard-1"),
+	})
+
+	names := listNames(t, client.List(ctx, &computepb.ListInstancesRequest{Project: testProject, Zone: testZone}))
+	if len(names) != 1 || names[0] != "za" {
+		t.Errorf("list %s = %v want [za]", testZone, names)
+	}
+}
+
+// TestSDKGCEInstanceDuplicateInsertConflict covers finding #7: a duplicate name
+// in the same zone must fail with 409 alreadyExists.
+func TestSDKGCEInstanceDuplicateInsertConflict(t *testing.T) {
+	client, _, ctx := newInstancesEnv(t)
+
+	inst := &computepb.Instance{
+		Name: ptrStr("dup"), MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+	}
+	mustInsert(t, client, testZone, inst)
+
+	_, err := client.Insert(ctx, &computepb.InsertInstanceRequest{
+		Project: testProject, Zone: testZone, InstanceResource: inst,
+	})
+	if err == nil {
+		t.Fatal("duplicate insert succeeded, want 409 alreadyExists")
+	}
+
+	if !strings.Contains(err.Error(), "alreadyExists") && !strings.Contains(err.Error(), "409") {
+		t.Errorf("err=%v want alreadyExists/409", err)
+	}
+}
+
+// TestSDKGCEInstanceNetworkSelfLinks covers finding #8: networkInterfaces echo
+// fully-qualified network + subnetwork self-links.
+func TestSDKGCEInstanceNetworkSelfLinks(t *testing.T) {
+	client, _, _ := newInstancesEnv(t)
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name:        ptrStr("net-vm"),
+		MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+		NetworkInterfaces: []*computepb.NetworkInterface{{
+			Network:    ptrStr("global/networks/default"),
+			Subnetwork: ptrStr("regions/us-central1/subnetworks/my-subnet"),
+		}},
+	})
+
+	nics := mustGet(t, client, testZone, "net-vm").GetNetworkInterfaces()
+	if len(nics) == 0 {
+		t.Fatal("no networkInterfaces")
+	}
+
+	if !strings.HasSuffix(nics[0].GetNetwork(), "/global/networks/default") {
+		t.Errorf("network=%q want fully-qualified .../global/networks/default", nics[0].GetNetwork())
+	}
+
+	if !strings.HasSuffix(nics[0].GetSubnetwork(), "/regions/us-central1/subnetworks/my-subnet") {
+		t.Errorf("subnetwork=%q want .../regions/us-central1/subnetworks/my-subnet", nics[0].GetSubnetwork())
+	}
+}
+
+// TestSDKGCEInstanceTimestampAndFingerprints covers findings #9 and #11.
+func TestSDKGCEInstanceTimestampAndFingerprints(t *testing.T) {
+	client, _, _ := newInstancesEnv(t)
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name:        ptrStr("ts-vm"),
+		MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+	})
+
+	got := mustGet(t, client, testZone, "ts-vm")
+
+	if got.GetCreationTimestamp() == "" {
+		t.Error("creationTimestamp empty")
+	}
+
+	if got.GetLabelFingerprint() == "" {
+		t.Error("labelFingerprint empty")
+	}
+
+	if got.GetFingerprint() == "" {
+		t.Error("fingerprint empty")
+	}
+}
+
+// TestSDKGCEInstanceDefaults covers finding #13: realistic defaults.
+func TestSDKGCEInstanceDefaults(t *testing.T) {
+	client, _, _ := newInstancesEnv(t)
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name:        ptrStr("def-vm"),
+		MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+	})
+
+	got := mustGet(t, client, testZone, "def-vm")
+
+	if got.GetCpuPlatform() == "" {
+		t.Error("cpuPlatform empty")
+	}
+
+	if got.GetScheduling() == nil {
+		t.Error("scheduling nil")
+	}
+
+	if len(got.GetServiceAccounts()) == 0 {
+		t.Error("serviceAccounts empty")
+	}
+
+	if got.GetShieldedInstanceConfig() == nil {
+		t.Error("shieldedInstanceConfig nil")
+	}
+}
+
+// TestSDKGCEInstanceAggregatedList covers finding #12: aggregatedList groups
+// instances by their zone scope.
+func TestSDKGCEInstanceAggregatedList(t *testing.T) {
+	client, _, ctx := newInstancesEnv(t)
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name: ptrStr("agg-a"), MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+	})
+	mustInsert(t, client, altZone, &computepb.Instance{
+		Name: ptrStr("agg-b"), MachineType: ptrStr("zones/" + altZone + "/machineTypes/n1-standard-1"),
+	})
+
+	it := client.AggregatedList(ctx, &computepb.AggregatedListInstancesRequest{Project: testProject})
+
+	byScope := map[string][]string{}
+
+	for {
+		pair, err := it.Next()
+		if err != nil {
+			break
+		}
+
+		for _, inst := range pair.Value.GetInstances() {
+			byScope[pair.Key] = append(byScope[pair.Key], inst.GetName())
+		}
+	}
+
+	if got := byScope["zones/"+testZone]; len(got) != 1 || got[0] != "agg-a" {
+		t.Errorf("scope %s = %v want [agg-a]", testZone, got)
+	}
+
+	if got := byScope["zones/"+altZone]; len(got) != 1 || got[0] != "agg-b" {
+		t.Errorf("scope %s = %v want [agg-b]", altZone, got)
+	}
+}
+
+// TestGCEInstanceListFilterAndPagination covers finding #10: the filter and
+// pagination query params are honored (SDK for filter, raw HTTP for the
+// nextPageToken/maxResults contract the SDK iterator hides).
+func TestGCEInstanceListFilterAndPagination(t *testing.T) {
+	client, ts, ctx := newInstancesEnv(t)
+
+	for _, n := range []string{"f1", "f2", "f3"} {
+		mustInsert(t, client, testZone, &computepb.Instance{
+			Name: ptrStr(n), MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+		})
+	}
+
+	// Filter: a non-matching name must return zero instances (not all).
+	miss := listNames(t, client.List(ctx, &computepb.ListInstancesRequest{
+		Project: testProject, Zone: testZone, Filter: ptrStr("name = nonexistent-xyz"),
+	}))
+	if len(miss) != 0 {
+		t.Errorf("filter miss returned %v, want none", miss)
+	}
+
+	hit := listNames(t, client.List(ctx, &computepb.ListInstancesRequest{
+		Project: testProject, Zone: testZone, Filter: ptrStr("name = f2"),
+	}))
+	if len(hit) != 1 || hit[0] != "f2" {
+		t.Errorf("filter name=f2 returned %v, want [f2]", hit)
+	}
+
+	// Pagination: maxResults=1 must return one item plus a nextPageToken.
+	page := rawList(t, ts, "/instances?maxResults=1")
+	if len(page.Items) != 1 {
+		t.Errorf("maxResults=1 returned %d items", len(page.Items))
+	}
+
+	if page.NextPageToken == "" {
+		t.Error("nextPageToken empty with more pages remaining")
+	}
+}
+
+func listNames(t *testing.T, it *gcpcompute.InstanceIterator) []string {
+	t.Helper()
+
+	var names []string
+
+	for {
+		inst, err := it.Next()
+		if err != nil {
+			break
+		}
+
+		names = append(names, inst.GetName())
+	}
+
+	return names
+}
+
+type rawInstanceList struct {
+	Items         []map[string]any `json:"items"`
+	NextPageToken string           `json:"nextPageToken"`
+}
+
+func rawList(t *testing.T, ts *httptest.Server, suffix string) rawInstanceList {
+	t.Helper()
+
+	resp, err := ts.Client().Get(ts.URL + zonesPath(suffix))
+	if err != nil {
+		t.Fatalf("raw list: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("raw list status=%d", resp.StatusCode)
+	}
+
+	var out rawInstanceList
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	return out
+}

--- a/server/gcp/compute/types.go
+++ b/server/gcp/compute/types.go
@@ -2,10 +2,8 @@ package compute
 
 // GCP REST JSON shapes for compute#instance.
 //
-// Modeled on the public schema (https://cloud.google.com/compute/docs/reference/rest/v1/instances)
-// with only the fields we need today. Optional fields like serviceAccounts,
-// scheduling, metadata, etc. are intentionally omitted — extending is purely
-// additive when needed.
+// Modeled on the public schema (https://cloud.google.com/compute/docs/reference/rest/v1/instances).
+// Fields are the subset CloudEmu round-trips; extending is purely additive.
 
 // instanceRequest is the inbound shape for POST .../instances (Insert).
 type instanceRequest struct {
@@ -22,7 +20,9 @@ type instanceRequest struct {
 // metadata item with key "startup-script"
 // (https://cloud.google.com/compute/docs/instances/startup-scripts/linux).
 type metadataBlock struct {
-	Items []metadataItem `json:"items,omitempty"`
+	Kind        string         `json:"kind,omitempty"`
+	Items       []metadataItem `json:"items,omitempty"`
+	Fingerprint string         `json:"fingerprint,omitempty"`
 }
 
 type metadataItem struct {
@@ -30,15 +30,27 @@ type metadataItem struct {
 	Value string `json:"value"`
 }
 
+// attachedDisk models compute#attachedDisk on both the request (client sets
+// boot/autoDelete/deviceName/initializeParams) and the response (we echo the
+// resolved source self-link, diskSizeGb, type, mode).
 type attachedDisk struct {
+	Kind             string                `json:"kind,omitempty"`
 	Boot             bool                  `json:"boot,omitempty"`
 	AutoDelete       bool                  `json:"autoDelete,omitempty"`
+	DeviceName       string                `json:"deviceName,omitempty"`
+	Index            int                   `json:"index,omitempty"`
+	Source           string                `json:"source,omitempty"`
+	DiskSizeGb       string                `json:"diskSizeGb,omitempty"`
+	Type             string                `json:"type,omitempty"`
+	Mode             string                `json:"mode,omitempty"`
+	Interface        string                `json:"interface,omitempty"`
 	InitializeParams *diskInitializeParams `json:"initializeParams,omitempty"`
 }
 
 type diskInitializeParams struct {
 	SourceImage string `json:"sourceImage,omitempty"`
 	DiskType    string `json:"diskType,omitempty"`
+	DiskSizeGb  string `json:"diskSizeGb,omitempty"`
 }
 
 type networkInterface struct {
@@ -46,32 +58,98 @@ type networkInterface struct {
 	Network    string `json:"network,omitempty"`
 	Subnetwork string `json:"subnetwork,omitempty"`
 	NetworkIP  string `json:"networkIP,omitempty"`
+	StackType  string `json:"stackType,omitempty"`
 }
 
 type tagsBlock struct {
-	Items []string `json:"items,omitempty"`
+	Items       []string `json:"items,omitempty"`
+	Fingerprint string   `json:"fingerprint,omitempty"`
+}
+
+// scheduling models compute#scheduling (a realistic default block).
+type scheduling struct {
+	AutomaticRestart  bool   `json:"automaticRestart"`
+	OnHostMaintenance string `json:"onHostMaintenance,omitempty"`
+	Preemptible       bool   `json:"preemptible"`
+	ProvisioningModel string `json:"provisioningModel,omitempty"`
+}
+
+// serviceAccount models compute#serviceAccount.
+type serviceAccount struct {
+	Email  string   `json:"email"`
+	Scopes []string `json:"scopes,omitempty"`
+}
+
+// shieldedInstanceConfig models compute#shieldedInstanceConfig.
+type shieldedInstanceConfig struct {
+	EnableSecureBoot          bool `json:"enableSecureBoot"`
+	EnableVtpm                bool `json:"enableVtpm"`
+	EnableIntegrityMonitoring bool `json:"enableIntegrityMonitoring"`
 }
 
 // instanceResponse is the outbound shape for GET single, GET list element.
 type instanceResponse struct {
-	Kind              string             `json:"kind"`
-	ID                string             `json:"id"`
-	Name              string             `json:"name"`
-	MachineType       string             `json:"machineType"`
-	Status            string             `json:"status"`
-	Zone              string             `json:"zone"`
-	SelfLink          string             `json:"selfLink"`
-	NetworkInterfaces []networkInterface `json:"networkInterfaces,omitempty"`
-	Labels            map[string]string  `json:"labels,omitempty"`
-	CreationTimestamp string             `json:"creationTimestamp,omitempty"`
+	Kind                   string                  `json:"kind"`
+	ID                     string                  `json:"id"`
+	Name                   string                  `json:"name"`
+	MachineType            string                  `json:"machineType"`
+	Status                 string                  `json:"status"`
+	Zone                   string                  `json:"zone"`
+	SelfLink               string                  `json:"selfLink"`
+	CreationTimestamp      string                  `json:"creationTimestamp,omitempty"`
+	CPUPlatform            string                  `json:"cpuPlatform,omitempty"`
+	LastStartTimestamp     string                  `json:"lastStartTimestamp,omitempty"`
+	DeletionProtection     bool                    `json:"deletionProtection"`
+	Disks                  []attachedDisk          `json:"disks,omitempty"`
+	NetworkInterfaces      []networkInterface      `json:"networkInterfaces,omitempty"`
+	Labels                 map[string]string       `json:"labels,omitempty"`
+	LabelFingerprint       string                  `json:"labelFingerprint,omitempty"`
+	Fingerprint            string                  `json:"fingerprint,omitempty"`
+	Tags                   *tagsBlock              `json:"tags,omitempty"`
+	Metadata               *metadataBlock          `json:"metadata,omitempty"`
+	Scheduling             *scheduling             `json:"scheduling,omitempty"`
+	ServiceAccounts        []serviceAccount        `json:"serviceAccounts,omitempty"`
+	ShieldedInstanceConfig *shieldedInstanceConfig `json:"shieldedInstanceConfig,omitempty"`
 }
 
 // instanceListResponse is the outbound shape for GET .../instances.
 type instanceListResponse struct {
-	Kind     string             `json:"kind"`
-	ID       string             `json:"id"`
-	Items    []instanceResponse `json:"items"`
-	SelfLink string             `json:"selfLink"`
+	Kind          string             `json:"kind"`
+	ID            string             `json:"id"`
+	Items         []instanceResponse `json:"items"`
+	NextPageToken string             `json:"nextPageToken,omitempty"`
+	SelfLink      string             `json:"selfLink"`
+}
+
+// instancesScopedList is one scope's bucket in an aggregated list.
+type instancesScopedList struct {
+	Instances []instanceResponse `json:"instances,omitempty"`
+	Warning   *scopedListWarning `json:"warning,omitempty"`
+}
+
+type scopedListWarning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// aggregatedListResponse is the outbound shape for GET .../aggregated/instances.
+type aggregatedListResponse struct {
+	Kind          string                         `json:"kind"`
+	ID            string                         `json:"id"`
+	Items         map[string]instancesScopedList `json:"items"`
+	NextPageToken string                         `json:"nextPageToken,omitempty"`
+	SelfLink      string                         `json:"selfLink"`
+}
+
+// setLabelsRequest is the body of instances.setLabels.
+type setLabelsRequest struct {
+	Labels           map[string]string `json:"labels"`
+	LabelFingerprint string            `json:"labelFingerprint,omitempty"`
+}
+
+// setMachineTypeRequest is the body of instances.setMachineType.
+type setMachineTypeRequest struct {
+	MachineType string `json:"machineType"`
 }
 
 // serialPortOutput is the outbound shape for

--- a/server/gcp/loadbalancer/handler.go
+++ b/server/gcp/loadbalancer/handler.go
@@ -64,6 +64,13 @@ func (*Handler) Matches(r *http.Request) bool {
 		return false
 	}
 
+	// Aggregated-scope requests (aggregatedList) are not implemented for these
+	// load-balancer resources; leave them unmatched so the dispatcher's default
+	// applies rather than mis-serving them as a scoped list.
+	if rp.Scope == gcprest.ScopeAggregated {
+		return false
+	}
+
 	switch rp.ResourceType {
 	case resourceBackendServices, resourceForwardingRules:
 		return true

--- a/server/gcp/vpc/handler.go
+++ b/server/gcp/vpc/handler.go
@@ -67,6 +67,13 @@ func (*Handler) Matches(r *http.Request) bool {
 		return false
 	}
 
+	// Aggregated-scope requests (aggregatedList) are not implemented for these
+	// networking resources; leave them unmatched so the dispatcher's default
+	// applies rather than mis-serving them as a scoped list.
+	if rp.Scope == gcprest.ScopeAggregated {
+		return false
+	}
+
 	switch rp.ResourceType {
 	case resourceNetworks, resourceSubnetworks, resourceFirewalls, resourceRouters, resourceAddresses:
 		return true

--- a/server/wire/gcprest/gcprest.go
+++ b/server/wire/gcprest/gcprest.go
@@ -35,9 +35,10 @@ const BasePrefix = "/compute/v1/"
 
 // Scope values used in GCP REST URL paths.
 const (
-	ScopeZones   = "zones"
-	ScopeRegions = "regions"
-	ScopeGlobal  = "global"
+	ScopeZones      = "zones"
+	ScopeRegions    = "regions"
+	ScopeGlobal     = "global"
+	ScopeAggregated = "aggregated"
 )
 
 // scopePairLen is the number of path segments consumed by a scope/{name} pair
@@ -99,6 +100,10 @@ func parseScope(parts []string, i int, rp *ResourcePath) (int, bool) {
 		return i + scopePairLen, true
 	case ScopeGlobal:
 		rp.Scope = ScopeGlobal
+
+		return i + 1, true
+	case ScopeAggregated:
+		rp.Scope = ScopeAggregated
 
 		return i + 1, true
 	default:


### PR DESCRIPTION
## What & why

The GCP Compute Engine `instances` wire surface dropped almost all instance
detail on read and returned 501 for every update verb, breaking Terraform
round-trips and any VM-update flow. This fixes the full `compute.instances`
bug batch from AUDIT_GCP.md `## compute`.

GCP-specific instance state the portable compute driver model does not carry
(attached `disks[]`, network `tags`, `metadata` incl. `startup-script`, the
network self-link, and the launch zone) is round-tripped through the driver by
encoding it into internal `cloudemu:gcp*` tag entries, then rebuilt into the
real REST read shape. No change to the shared `services/compute/driver`
interface — GCP-specific mutation uses an optional-interface method
(`MutateInstanceGCP`) on the GCE mock, mirroring the existing `RemoveInstance`
pattern — so AWS/Azure are untouched and no docs regen is needed.

`gcprest.ParsePath` now recognizes the `/aggregated/{type}` scope; the GCP vpc
and loadbalancer handlers are guarded to stay unmatched on that scope so their
behavior is unchanged (aggregatedList remains unimplemented there).

## Findings fixed (13/13)

- HIGH get — echo `disks[]` with boot disk (`deviceName/source/boot/autoDelete/diskSizeGb/type`)
- HIGH insert/get — round-trip network `tags.items` + `tags.fingerprint`
- HIGH insert/get — round-trip `metadata.items` (incl. startup-script) + `metadata.fingerprint`
- HIGH — implement `setMetadata`/`setLabels`/`setTags`/`setMachineType` (mutate + DONE Operation) instead of 501
- HIGH — implement `attachDisk`/`detachDisk` (reflected in `disks[]`) instead of 501
- HIGH list — zone-scoped to the requested zone
- HIGH insert — duplicate name in same zone → 409 `alreadyExists`
- HIGH get networkInterfaces — fully-qualified `network` + `subnetwork` self-links
- HIGH get — `creationTimestamp` (RFC3339) from LaunchTime
- MED list — `filter` + `maxResults`/`pageToken` pagination, `nextPageToken` set
- MED get — `labelFingerprint` + `fingerprint` populated
- MED aggregatedList — instances grouped by `zones/{zone}` scope instead of 501
- LOW get — realistic `cpuPlatform`/`scheduling`/`serviceAccounts`/`shieldedInstanceConfig`/`deletionProtection`/`lastStartTimestamp` defaults

## Deferrals

None — all 13 findings fixed.

## Tests

`server/gcp/compute/instances_sdk_test.go` drives the real
`cloud.google.com/go/compute/apiv1` InstancesClient against the in-process GCP
server, one test per finding (disks, tags/metadata, update verbs, attach/detach,
zone-scoped list, duplicate 409, network self-links, timestamp/fingerprints,
defaults, aggregatedList, filter + pagination). Existing GCP compute tests stay
green.
