### PR TITLE
fix(gcp-iam): testIamPermissions/undelete/uniqueId/etag/keys/pagination

### DIFF
--- a/server/gcp/iam/handler.go
+++ b/server/gcp/iam/handler.go
@@ -46,26 +46,51 @@ const (
 	serviceAccountsSeg = "serviceAccounts"
 	rolesSeg           = "roles"
 	keysSeg            = "keys"
+
+	undeleteVerb = "undelete"
 )
 
 // Handler serves iam.googleapis.com v1 REST requests against the IAM driver.
 //
-// Service-account resource policies and the enabled/disabled bit have no place
-// in the portable IAM driver, so they're tracked here keyed by SA email.
+// Service-account resource policies, the enabled/disabled bit, policy etag
+// versions and soft-deleted resources have no place in the portable IAM
+// driver, so they're tracked here keyed by SA email / role id. The driver
+// hard-deletes, so undelete is served from these local tombstones.
 type Handler struct {
 	iam iamdriver.IAM
 
-	mu       sync.RWMutex
-	saPolicy map[string]*iamPolicy // SA email -> resource policy
-	disabled map[string]bool       // SA email -> disabled
+	mu            sync.RWMutex
+	saPolicy      map[string]*iamPolicy   // SA email -> resource policy
+	policyVersion map[string]int          // SA email -> monotonic policy etag version
+	disabled      map[string]bool         // SA email -> disabled
+	deletedSA     map[string]*deletedSA   // SA email -> soft-deleted account
+	deletedRole   map[string]*deletedRole // role id -> soft-deleted role
+}
+
+// deletedSA is a tombstone captured at delete time so undelete can restore the
+// account with the same project, metadata and disabled bit.
+type deletedSA struct {
+	project     string
+	displayName string
+	description string
+	disabled    bool
+}
+
+// deletedRole is a tombstone for a soft-deleted custom role.
+type deletedRole struct {
+	project string
+	props   roleProps
 }
 
 // New returns an IAM handler backed by drv.
 func New(drv iamdriver.IAM) *Handler {
 	return &Handler{
-		iam:      drv,
-		saPolicy: make(map[string]*iamPolicy),
-		disabled: make(map[string]bool),
+		iam:           drv,
+		saPolicy:      make(map[string]*iamPolicy),
+		policyVersion: make(map[string]int),
+		disabled:      make(map[string]bool),
+		deletedSA:     make(map[string]*deletedSA),
+		deletedRole:   make(map[string]*deletedRole),
 	}
 }
 
@@ -224,6 +249,13 @@ func (h *Handler) routeServiceAccountKeys(w http.ResponseWriter, r *http.Request
 }
 
 func (h *Handler) routeRoles(w http.ResponseWriter, r *http.Request, rt *route) {
+	// One-off ":method" calls on a specific role (undelete) are POSTs. Route
+	// them before the plain method switch, which is otherwise verb-blind.
+	if rt.verb != "" && rt.name != "" {
+		h.routeRoleVerb(w, r, rt)
+		return
+	}
+
 	switch rt.name {
 	case "":
 		switch r.Method {
@@ -248,4 +280,23 @@ func (h *Handler) routeRoles(w http.ResponseWriter, r *http.Request, rt *route) 
 				"unsupported verb on role: "+r.Method)
 		}
 	}
+}
+
+// routeRoleVerb dispatches one-off ":method" calls on a specific role. The
+// only such method is undelete, always a POST.
+func (h *Handler) routeRoleVerb(w http.ResponseWriter, r *http.Request, rt *route) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed",
+			"method "+rt.verb+" requires POST")
+
+		return
+	}
+
+	if rt.verb == undeleteVerb {
+		h.undeleteRole(w, r, rt.project, rt.name)
+
+		return
+	}
+
+	writeError(w, http.StatusNotFound, "notFound", "unknown method: "+rt.verb)
 }

--- a/server/gcp/iam/operations.go
+++ b/server/gcp/iam/operations.go
@@ -1,16 +1,30 @@
 package iam
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"io"
+	"math/big"
 	"net/http"
-	"strings"
+	"net/url"
+	"strconv"
+	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
 )
 
-const maxBodyBytes = 1 << 20
+const (
+	maxBodyBytes = 1 << 20
+
+	saUniqueIDDigits = 21 // real GCP service-account uniqueIds are 21-digit numerics
+	keyValidityYears = 10 // user-managed key default validity window
+	decimalBase      = 10 // base for the uniqueId digit-range math
+
+	defaultPageSize = 100
+	maxPageSize     = 1000
+)
 
 // --- ServiceAccounts ---
 
@@ -72,8 +86,9 @@ func (h *Handler) listServiceAccounts(w http.ResponseWriter, r *http.Request, pr
 	}
 
 	wildcard := project == "-"
-	out := listServiceAccountsResponse{Accounts: make([]serviceAccount, 0, len(users))}
+	matched := make([]serviceAccount, 0, len(users))
 
+	h.mu.RLock()
 	for i := range users {
 		u := &users[i]
 		if !wildcard && u.Path != project {
@@ -88,17 +103,40 @@ func (h *Handler) listServiceAccounts(w http.ResponseWriter, r *http.Request, pr
 		}
 
 		sa := saFromUser(u)
-		out.Accounts = append(out.Accounts,
-			toServiceAccountJSON(responseProject, u.Name, &sa))
+		sa.Disabled = h.disabled[u.Name] // reflect the disabled bit in list, like Get
+		matched = append(matched, toServiceAccountJSON(responseProject, u.Name, &sa))
 	}
+	h.mu.RUnlock()
 
-	writeJSON(w, out)
+	page, next := paginate(matched, pageSizeParam(r), decodePageToken(pageTokenParam(r)))
+
+	writeJSON(w, listServiceAccountsResponse{Accounts: page, NextPageToken: next})
 }
 
 func (h *Handler) deleteServiceAccount(w http.ResponseWriter, r *http.Request, email string) {
+	// Capture a tombstone before the hard delete so a subsequent undelete can
+	// restore the account (real GCP soft-deletes for ~30 days).
+	user, gerr := h.iam.GetUser(r.Context(), email)
+
 	if err := h.iam.DeleteUser(r.Context(), email); err != nil {
 		writeCErr(w, err)
 		return
+	}
+
+	if gerr == nil {
+		sa := saFromUser(user)
+
+		h.mu.Lock()
+		h.deletedSA[email] = &deletedSA{
+			project:     user.Path,
+			displayName: sa.DisplayName,
+			description: sa.Description,
+			disabled:    h.disabled[email],
+		}
+		delete(h.disabled, email)
+		delete(h.saPolicy, email)
+		delete(h.policyVersion, email)
+		h.mu.Unlock()
 	}
 
 	// GCP returns an empty body with 200 on successful SA delete.
@@ -220,7 +258,7 @@ func (h *Handler) listRoles(w http.ResponseWriter, r *http.Request, project stri
 		return
 	}
 
-	out := listRolesResponse{Roles: make([]role, 0, len(roles))}
+	matched := make([]role, 0, len(roles))
 
 	for i := range roles {
 		dr := &roles[i]
@@ -233,10 +271,12 @@ func (h *Handler) listRoles(w http.ResponseWriter, r *http.Request, project stri
 		// its name rather than silently dropping it from the list — the
 		// underlying entry exists and the caller should see something.
 		props, _ := decodeRoleProps(dr.AssumeRolePolicyDoc)
-		out.Roles = append(out.Roles, toRoleJSON(project, dr.Name, &props))
+		matched = append(matched, toRoleJSON(project, dr.Name, &props))
 	}
 
-	writeJSON(w, out)
+	page, next := paginate(matched, pageSizeParam(r), decodePageToken(pageTokenParam(r)))
+
+	writeJSON(w, listRolesResponse{Roles: page, NextPageToken: next})
 }
 
 func (h *Handler) deleteRole(w http.ResponseWriter, r *http.Request, project, roleID string) {
@@ -258,10 +298,49 @@ func (h *Handler) deleteRole(w http.ResponseWriter, r *http.Request, project, ro
 		return
 	}
 
+	// Tombstone the role so it can be undeleted (real GCP soft-deletes custom
+	// roles for 7 days).
+	h.mu.Lock()
+	h.deletedRole[roleID] = &deletedRole{project: project, props: props}
+	h.mu.Unlock()
+
 	// GCP marks the role as deleted in the echoed body.
 	out := toRoleJSON(project, roleID, &props)
 	out.Deleted = true
 	writeJSON(w, out)
+}
+
+// undeleteRole restores a soft-deleted custom role from its tombstone.
+func (h *Handler) undeleteRole(w http.ResponseWriter, r *http.Request, project, roleID string) {
+	h.mu.Lock()
+	tomb := h.deletedRole[roleID]
+	delete(h.deletedRole, roleID) // no-op when absent
+	h.mu.Unlock()
+
+	if tomb == nil {
+		writeError(w, http.StatusNotFound, "NOT_FOUND",
+			"role "+roleID+" was not found or is not recoverable")
+
+		return
+	}
+
+	propsJSON, err := json.Marshal(tomb.props)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL",
+			"could not encode role props: "+err.Error())
+		return
+	}
+
+	if _, err := h.iam.CreateRole(r.Context(), iamdriver.RoleConfig{
+		Name:                roleID,
+		Path:                tomb.project,
+		AssumeRolePolicyDoc: string(propsJSON),
+	}); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	writeJSON(w, toRoleJSON(project, roleID, &tomb.props))
 }
 
 // updateRole handles PATCH .../roles/{roleId}. Unlike SA Patch the role
@@ -323,7 +402,9 @@ func (h *Handler) createKey(w http.ResponseWriter, r *http.Request, project, ema
 		return
 	}
 
-	writeJSON(w, toKeyJSON(project, email, k.AccessKeyID, k.SecretAccessKey))
+	// privateKeyData is the base64 credentials file, returned once at create.
+	keyFile := buildKeyFileData(project, email, k.AccessKeyID, k.SecretAccessKey)
+	writeJSON(w, toKeyJSON(project, email, k.AccessKeyID, keyFile, k.CreatedAt))
 }
 
 func (h *Handler) getKey(w http.ResponseWriter, r *http.Request, project, email, keyID string) {
@@ -337,7 +418,7 @@ func (h *Handler) getKey(w http.ResponseWriter, r *http.Request, project, email,
 		if keys[i].AccessKeyID == keyID {
 			// Empty private-key body on GET — GCP only returns the private
 			// material once at create time.
-			writeJSON(w, toKeyJSON(project, email, keyID, ""))
+			writeJSON(w, toKeyJSON(project, email, keyID, "", keys[i].CreatedAt))
 			return
 		}
 	}
@@ -355,7 +436,8 @@ func (h *Handler) listKeys(w http.ResponseWriter, r *http.Request, project, emai
 
 	out := listKeysResponse{Keys: make([]serviceAccountKey, 0, len(keys))}
 	for i := range keys {
-		out.Keys = append(out.Keys, toKeyJSON(project, email, keys[i].AccessKeyID, ""))
+		out.Keys = append(out.Keys,
+			toKeyJSON(project, email, keys[i].AccessKeyID, "", keys[i].CreatedAt))
 	}
 
 	writeJSON(w, out)
@@ -402,11 +484,43 @@ func toServiceAccountJSON(project, email string, sa *serviceAccount) serviceAcco
 	out.Email = email
 
 	if out.UniqueID == "" {
-		// Stable synthetic ID derived from the email so tests can match it.
-		out.UniqueID = "uid-" + strings.ReplaceAll(email, "@", "-")
+		out.UniqueID = saUniqueID(email)
 	}
 
+	// In real GCP the OAuth2 client id equals the numeric unique id, and every
+	// SA carries a (deprecated but populated) etag.
+	out.OAuth2ClientID = out.UniqueID
+	out.Etag = saEtag(email)
+
 	return out
+}
+
+// saUniqueID derives a stable 21-digit numeric unique id from the SA email,
+// matching the shape of a real GCP service-account uniqueId (and oauth2ClientId).
+func saUniqueID(email string) string {
+	sum := sha256.Sum256([]byte("uid:" + email))
+	n := new(big.Int).SetBytes(sum[:])
+
+	base := big.NewInt(decimalBase)
+	// 21-digit numbers span [10^20, 10^21); map the hash into that half-open range.
+	lo := new(big.Int).Exp(base, big.NewInt(saUniqueIDDigits-1), nil)
+	hi := new(big.Int).Exp(base, big.NewInt(saUniqueIDDigits), nil)
+	span := new(big.Int).Sub(hi, lo)
+
+	n.Mod(n, span)
+	n.Add(n, lo)
+
+	return n.String()
+}
+
+// saEtag returns a stable, populated etag for a service account resource.
+func saEtag(email string) string {
+	return base64.StdEncoding.EncodeToString([]byte("sa:" + email))
+}
+
+// roleEtag returns a stable, populated etag for a custom role resource.
+func roleEtag(project, roleID string) string {
+	return base64.StdEncoding.EncodeToString([]byte("role:" + project + "/" + roleID))
 }
 
 // toRoleJSON builds the wire envelope for a custom role. The "name" field
@@ -418,22 +532,66 @@ func toRoleJSON(project, roleID string, props *roleProps) role {
 		Description:         props.Description,
 		IncludedPermissions: props.IncludedPermissions,
 		Stage:               props.Stage,
+		Etag:                roleEtag(project, roleID),
 	}
 }
 
 // toKeyJSON builds the wire envelope for a service-account key. private is
 // only populated on create (GCP returns the private key material exactly
-// once); GET / LIST pass an empty string.
-func toKeyJSON(project, email, keyID, private string) serviceAccountKey {
+// once); GET / LIST pass an empty string. createdAt (RFC3339) drives the
+// validity window; a zero value means "now".
+func toKeyJSON(project, email, keyID, private, createdAt string) serviceAccountKey {
+	validAfter := createdAt
+	if validAfter == "" {
+		validAfter = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	validBefore := validAfter
+	if t, err := time.Parse(time.RFC3339, validAfter); err == nil {
+		validBefore = t.AddDate(keyValidityYears, 0, 0).UTC().Format(time.RFC3339)
+	}
+
 	return serviceAccountKey{
 		Name: "projects/" + project + "/serviceAccounts/" + email +
 			"/keys/" + keyID,
-		PrivateKeyType: "TYPE_GOOGLE_CREDENTIALS_FILE",
-		KeyAlgorithm:   "KEY_ALG_RSA_2048",
-		PrivateKeyData: private,
-		KeyOrigin:      "GOOGLE_PROVIDED",
-		KeyType:        "USER_MANAGED",
+		PrivateKeyType:  "TYPE_GOOGLE_CREDENTIALS_FILE",
+		KeyAlgorithm:    "KEY_ALG_RSA_2048",
+		PrivateKeyData:  private,
+		ValidAfterTime:  validAfter,
+		ValidBeforeTime: validBefore,
+		KeyOrigin:       "GOOGLE_PROVIDED",
+		KeyType:         "USER_MANAGED",
 	}
+}
+
+// buildKeyFileData returns the base64-encoded service-account credentials file
+// (JSON) that real GCP hands back exactly once, at key-create time. The private
+// key material is a synthetic placeholder — cloudemu never mints real RSA keys —
+// but the envelope is the standard google-credentials shape clients parse.
+func buildKeyFileData(project, email, keyID, secret string) string {
+	// Synthetic PEM body — cloudemu never mints real RSA keys.
+	pemBody := base64.StdEncoding.EncodeToString([]byte("cloudemu:" + secret))
+	pem := "-----BEGIN PRIVATE KEY-----\n" + pemBody + "\n-----END PRIVATE KEY-----\n"
+
+	keyFile := map[string]string{ //nolint:gosec // synthetic key file, no real credentials
+		"type":                        "service_account",
+		"project_id":                  project,
+		"private_key_id":              keyID,
+		"private_key":                 pem,
+		"client_email":                email,
+		"client_id":                   saUniqueID(email),
+		"auth_uri":                    "https://accounts.google.com/o/oauth2/auth",
+		"token_uri":                   "https://oauth2.googleapis.com/token",
+		"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+		"client_x509_cert_url":        "https://www.googleapis.com/robot/v1/metadata/x509/" + url.PathEscape(email),
+	}
+
+	raw, err := json.Marshal(keyFile)
+	if err != nil {
+		return ""
+	}
+
+	return base64.StdEncoding.EncodeToString(raw)
 }
 
 func decodeRoleProps(doc string) (roleProps, error) {
@@ -484,6 +642,64 @@ func drainBody(r *http.Request) error {
 	_, err := io.Copy(io.Discard, r.Body)
 
 	return err
+}
+
+// --- pagination ---
+
+// paginate returns the slice window starting at offset (capped to pageSize)
+// and the opaque nextPageToken for the following window, or "" when exhausted.
+func paginate[T any](items []T, pageSize, offset int) (page []T, nextToken string) {
+	if offset < 0 || offset >= len(items) {
+		return []T{}, ""
+	}
+
+	end := offset + pageSize
+	if end >= len(items) {
+		return items[offset:], ""
+	}
+
+	return items[offset:end], encodePageToken(end)
+}
+
+// pageSizeParam reads ?pageSize, clamping to a sane default/max.
+func pageSizeParam(r *http.Request) int {
+	n, err := strconv.Atoi(r.URL.Query().Get("pageSize"))
+	if err != nil || n <= 0 {
+		return defaultPageSize
+	}
+
+	if n > maxPageSize {
+		return maxPageSize
+	}
+
+	return n
+}
+
+func pageTokenParam(r *http.Request) string {
+	return r.URL.Query().Get("pageToken")
+}
+
+// encodePageToken/decodePageToken carry a slice offset as an opaque base64 token.
+func encodePageToken(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}
+
+func decodePageToken(tok string) int {
+	if tok == "" {
+		return 0
+	}
+
+	b, err := base64.StdEncoding.DecodeString(tok)
+	if err != nil {
+		return 0
+	}
+
+	n, err := strconv.Atoi(string(b))
+	if err != nil || n < 0 {
+		return 0
+	}
+
+	return n
 }
 
 // writeCErr maps canonical cloudemu errors to GCP JSON error envelopes.

--- a/server/gcp/iam/sdk_iam_compat_test.go
+++ b/server/gcp/iam/sdk_iam_compat_test.go
@@ -1,0 +1,406 @@
+package iam_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	iamv1 "google.golang.org/api/iam/v1"
+)
+
+// createSA is a small helper: creates an SA and returns its email.
+func createSA(t *testing.T, svc *iamv1.Service, accountID string) string {
+	t.Helper()
+
+	parent := "projects/" + testProject
+
+	sa, err := svc.Projects.ServiceAccounts.Create(parent, &iamv1.CreateServiceAccountRequest{
+		AccountId: accountID,
+	}).Context(context.Background()).Do()
+	if err != nil {
+		t.Fatalf("Create %s: %v", accountID, err)
+	}
+
+	return sa.Email
+}
+
+// TestSDKGCPIAMTestIamPermissions guards the HIGH finding: TestIamPermissions
+// on an SA must return the held subset of requested permissions, not 404.
+func TestSDKGCPIAMTestIamPermissions(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	email := createSA(t, svc, "perm-sa")
+	resource := "projects/" + testProject + "/serviceAccounts/" + email
+
+	resp, err := svc.Projects.ServiceAccounts.TestIamPermissions(resource,
+		&iamv1.TestIamPermissionsRequest{
+			Permissions: []string{"iam.serviceAccounts.actAs", "iam.serviceAccounts.get"},
+		}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("TestIamPermissions: %v", err)
+	}
+
+	// With no restricting policy the resource owner holds every requested perm.
+	if len(resp.Permissions) != 2 {
+		t.Fatalf("got %d held permissions, want 2: %v", len(resp.Permissions), resp.Permissions)
+	}
+}
+
+// TestSDKGCPIAMTestIamPermissionsSubset checks that a bound custom role narrows
+// the held set to exactly that role's includedPermissions.
+func TestSDKGCPIAMTestIamPermissionsSubset(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject
+
+	if _, err := svc.Projects.Roles.Create(parent, &iamv1.CreateRoleRequest{
+		RoleId: "actAsOnly",
+		Role: &iamv1.Role{
+			Title:               "Act As Only",
+			IncludedPermissions: []string{"iam.serviceAccounts.actAs"},
+			Stage:               "GA",
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Create role: %v", err)
+	}
+
+	email := createSA(t, svc, "subset-sa")
+	resource := "projects/" + testProject + "/serviceAccounts/" + email
+
+	if _, err := svc.Projects.ServiceAccounts.SetIamPolicy(resource, &iamv1.SetIamPolicyRequest{
+		Policy: &iamv1.Policy{
+			Bindings: []*iamv1.Binding{{
+				Role:    parent + "/roles/actAsOnly",
+				Members: []string{"user:alice@example.com"},
+			}},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("SetIamPolicy: %v", err)
+	}
+
+	resp, err := svc.Projects.ServiceAccounts.TestIamPermissions(resource,
+		&iamv1.TestIamPermissionsRequest{
+			Permissions: []string{"iam.serviceAccounts.actAs", "iam.serviceAccounts.delete"},
+		}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("TestIamPermissions: %v", err)
+	}
+
+	if len(resp.Permissions) != 1 || resp.Permissions[0] != "iam.serviceAccounts.actAs" {
+		t.Fatalf("expected only actAs held, got %v", resp.Permissions)
+	}
+}
+
+// TestSDKGCPIAMServiceAccountUndelete guards the MEDIUM finding: a recently
+// deleted SA can be restored via Undelete.
+func TestSDKGCPIAMServiceAccountUndelete(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	email := createSA(t, svc, "restore-me")
+	name := "projects/-/serviceAccounts/" + email
+
+	if _, err := svc.Projects.ServiceAccounts.Delete(name).Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	resp, err := svc.Projects.ServiceAccounts.Undelete(name,
+		&iamv1.UndeleteServiceAccountRequest{}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Undelete: %v", err)
+	}
+
+	if resp.RestoredAccount == nil || resp.RestoredAccount.Email != email {
+		t.Fatalf("Undelete did not return restored account: %+v", resp.RestoredAccount)
+	}
+
+	// The account is queryable again after restore.
+	if _, err := svc.Projects.ServiceAccounts.Get(name).Context(ctx).Do(); err != nil {
+		t.Fatalf("Get after Undelete: %v", err)
+	}
+}
+
+// TestSDKGCPIAMRoleUndelete guards the MEDIUM finding: Roles.Undelete restores
+// a deleted custom role (routeRoles previously ignored the verb → 405).
+func TestSDKGCPIAMRoleUndelete(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject
+	name := parent + "/roles/undeleteMe"
+
+	if _, err := svc.Projects.Roles.Create(parent, &iamv1.CreateRoleRequest{
+		RoleId: "undeleteMe",
+		Role: &iamv1.Role{
+			Title:               "Undelete Me",
+			IncludedPermissions: []string{"compute.instances.get"},
+			Stage:               "GA",
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Create role: %v", err)
+	}
+
+	if _, err := svc.Projects.Roles.Delete(name).Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete role: %v", err)
+	}
+
+	restored, err := svc.Projects.Roles.Undelete(name, &iamv1.UndeleteRoleRequest{}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Undelete role: %v", err)
+	}
+
+	if restored.Name != name {
+		t.Fatalf("restored role name %q, want %q", restored.Name, name)
+	}
+
+	got, err := svc.Projects.Roles.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after Undelete: %v", err)
+	}
+
+	if len(got.IncludedPermissions) != 1 {
+		t.Fatalf("restored role lost permissions: %v", got.IncludedPermissions)
+	}
+}
+
+var uniqueIDRe = regexp.MustCompile(`^[1-9][0-9]{20}$`)
+
+// TestSDKGCPIAMServiceAccountIdentity guards the MEDIUM finding: uniqueId is a
+// stable 21-digit numeric, oauth2ClientId equals it, and etag is populated.
+func TestSDKGCPIAMServiceAccountIdentity(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	created := func() *iamv1.ServiceAccount {
+		sa, err := svc.Projects.ServiceAccounts.Create("projects/"+testProject,
+			&iamv1.CreateServiceAccountRequest{AccountId: "identity-sa"}).Context(ctx).Do()
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+
+		return sa
+	}()
+
+	if !uniqueIDRe.MatchString(created.UniqueId) {
+		t.Fatalf("uniqueId %q is not a 21-digit numeric", created.UniqueId)
+	}
+
+	if created.Oauth2ClientId != created.UniqueId {
+		t.Fatalf("oauth2ClientId %q != uniqueId %q", created.Oauth2ClientId, created.UniqueId)
+	}
+
+	if created.Etag == "" {
+		t.Fatal("etag is empty, want populated")
+	}
+
+	// uniqueId is stable across Get.
+	got, err := svc.Projects.ServiceAccounts.Get(
+		"projects/-/serviceAccounts/" + created.Email).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.UniqueId != created.UniqueId {
+		t.Fatalf("uniqueId not stable: create=%q get=%q", created.UniqueId, got.UniqueId)
+	}
+}
+
+// TestSDKGCPIAMListReflectsDisabled guards the MEDIUM finding: List must
+// reflect the disabled bit, not just Get.
+func TestSDKGCPIAMListReflectsDisabled(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	email := createSA(t, svc, "toggle-sa")
+	resource := "projects/" + testProject + "/serviceAccounts/" + email
+
+	if _, err := svc.Projects.ServiceAccounts.Disable(resource,
+		&iamv1.DisableServiceAccountRequest{}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+
+	list, err := svc.Projects.ServiceAccounts.List("projects/" + testProject).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	var found *iamv1.ServiceAccount
+
+	for _, sa := range list.Accounts {
+		if sa.Email == email {
+			found = sa
+			break
+		}
+	}
+
+	if found == nil {
+		t.Fatalf("SA %s missing from list", email)
+	}
+
+	if !found.Disabled {
+		t.Fatal("List did not reflect disabled=true")
+	}
+}
+
+// TestSDKGCPIAMKeyFileAndValidity guards the MEDIUM finding: Keys.Create returns
+// a base64 credentials file (parseable service_account JSON) and populated
+// validAfterTime/validBeforeTime.
+func TestSDKGCPIAMKeyFileAndValidity(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	email := createSA(t, svc, "key-file-sa")
+	resource := "projects/-/serviceAccounts/" + email
+
+	key, err := svc.Projects.ServiceAccounts.Keys.Create(resource,
+		&iamv1.CreateServiceAccountKeyRequest{}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Keys.Create: %v", err)
+	}
+
+	if key.ValidAfterTime == "" || key.ValidBeforeTime == "" {
+		t.Fatalf("validity window empty: after=%q before=%q", key.ValidAfterTime, key.ValidBeforeTime)
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(key.PrivateKeyData)
+	if err != nil {
+		t.Fatalf("privateKeyData is not base64: %v", err)
+	}
+
+	var keyFile map[string]any
+	if err := json.Unmarshal(raw, &keyFile); err != nil {
+		t.Fatalf("privateKeyData is not a JSON credentials file: %v", err)
+	}
+
+	if keyFile["type"] != "service_account" {
+		t.Fatalf("key file type = %v, want service_account", keyFile["type"])
+	}
+
+	if keyFile["client_email"] != email {
+		t.Fatalf("key file client_email = %v, want %s", keyFile["client_email"], email)
+	}
+
+	if _, ok := keyFile["private_key"]; !ok {
+		t.Fatal("key file missing private_key field")
+	}
+}
+
+// TestSDKGCPIAMSetIamPolicyEtagConcurrency guards the LOW finding: a stale etag
+// on setIamPolicy is rejected with 409 ABORTED (optimistic concurrency).
+func TestSDKGCPIAMSetIamPolicyEtagConcurrency(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	email := createSA(t, svc, "etag-sa")
+	resource := "projects/" + testProject + "/serviceAccounts/" + email
+
+	first, err := svc.Projects.ServiceAccounts.SetIamPolicy(resource, &iamv1.SetIamPolicyRequest{
+		Policy: &iamv1.Policy{
+			Bindings: []*iamv1.Binding{{Role: "roles/iam.serviceAccountUser", Members: []string{"user:a@x.com"}}},
+		},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("SetIamPolicy #1: %v", err)
+	}
+
+	if first.Etag == "" {
+		t.Fatal("first policy returned empty etag")
+	}
+
+	// A write carrying the fresh etag succeeds and advances the etag.
+	second, err := svc.Projects.ServiceAccounts.SetIamPolicy(resource, &iamv1.SetIamPolicyRequest{
+		Policy: &iamv1.Policy{
+			Etag:     first.Etag,
+			Bindings: []*iamv1.Binding{{Role: "roles/viewer", Members: []string{"user:b@x.com"}}},
+		},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("SetIamPolicy #2 (fresh etag): %v", err)
+	}
+
+	if second.Etag == first.Etag {
+		t.Fatal("etag did not advance after a successful write")
+	}
+
+	// Replaying the now-stale first etag must be rejected with 409 ABORTED.
+	_, err = svc.Projects.ServiceAccounts.SetIamPolicy(resource, &iamv1.SetIamPolicyRequest{
+		Policy: &iamv1.Policy{
+			Etag:     first.Etag,
+			Bindings: []*iamv1.Binding{{Role: "roles/editor", Members: []string{"user:c@x.com"}}},
+		},
+	}).Context(ctx).Do()
+	if err == nil {
+		t.Fatal("stale-etag SetIamPolicy: expected error, got nil")
+	}
+
+	var apiErr *googleapi.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *googleapi.Error, got %T: %v", err, err)
+	}
+
+	if apiErr.Code != 409 {
+		t.Fatalf("stale-etag: got HTTP %d, want 409", apiErr.Code)
+	}
+}
+
+// TestSDKGCPIAMListPagination guards the LOW finding: List honors
+// pageSize/pageToken and returns nextPageToken, and roles carry an etag.
+func TestSDKGCPIAMListPagination(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	for _, id := range []string{"page-a", "page-b", "page-c"} {
+		createSA(t, svc, id)
+	}
+
+	first, err := svc.Projects.ServiceAccounts.List("projects/" + testProject).
+		PageSize(2).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List page 1: %v", err)
+	}
+
+	if len(first.Accounts) != 2 {
+		t.Fatalf("page 1 returned %d accounts, want 2", len(first.Accounts))
+	}
+
+	if first.NextPageToken == "" {
+		t.Fatal("page 1 missing nextPageToken")
+	}
+
+	second, err := svc.Projects.ServiceAccounts.List("projects/" + testProject).
+		PageSize(2).PageToken(first.NextPageToken).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List page 2: %v", err)
+	}
+
+	if len(second.Accounts) != 1 {
+		t.Fatalf("page 2 returned %d accounts, want 1", len(second.Accounts))
+	}
+
+	if second.NextPageToken != "" {
+		t.Fatal("page 2 should be the last page (empty nextPageToken)")
+	}
+
+	// Roles carry a populated etag.
+	if _, err := svc.Projects.Roles.Create("projects/"+testProject, &iamv1.CreateRoleRequest{
+		RoleId: "etag-role",
+		Role:   &iamv1.Role{Title: "Etag Role", Stage: "GA"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Create role: %v", err)
+	}
+
+	got, err := svc.Projects.Roles.Get("projects/" + testProject + "/roles/etag-role").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get role: %v", err)
+	}
+
+	if got.Etag == "" {
+		t.Fatal("role etag is empty, want populated")
+	}
+}

--- a/server/gcp/iam/verbs.go
+++ b/server/gcp/iam/verbs.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
+
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
 )
 
 // iamPolicy is the GCP IAM Policy resource returned by getIamPolicy /
@@ -32,17 +35,33 @@ func (h *Handler) routeSAVerb(w http.ResponseWriter, r *http.Request, rt *route)
 		return
 	}
 
-	// Confirm the SA exists (all these verbs act on an existing account).
-	if _, err := h.iam.GetUser(r.Context(), rt.name); err != nil {
-		writeCErr(w, err)
+	// undelete acts on a tombstone, not a live account, so it must not go
+	// through the existence check below (the SA is gone from the driver).
+	if rt.verb == undeleteVerb {
+		h.undeleteServiceAccount(w, r, rt.project, rt.name)
+
 		return
 	}
 
+	// Confirm the SA exists (all remaining verbs act on an existing account).
+	if _, err := h.iam.GetUser(r.Context(), rt.name); err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	h.dispatchSAVerb(w, r, rt)
+}
+
+// dispatchSAVerb routes the ":method" calls that act on an existing SA.
+func (h *Handler) dispatchSAVerb(w http.ResponseWriter, r *http.Request, rt *route) {
 	switch rt.verb {
 	case "getIamPolicy":
 		h.getSAIamPolicy(w, rt.name)
 	case "setIamPolicy":
 		h.setSAIamPolicy(w, r, rt.name)
+	case "testIamPermissions":
+		h.testSAIamPermissions(w, r, rt.name)
 	case "signBlob":
 		h.signBlob(w, r, rt.name)
 	case "signJwt":
@@ -56,6 +75,144 @@ func (h *Handler) routeSAVerb(w http.ResponseWriter, r *http.Request, rt *route)
 	default:
 		writeError(w, http.StatusNotFound, "notFound", "unknown method: "+rt.verb)
 	}
+}
+
+// testSAIamPermissions returns the subset of the requested permissions the
+// caller holds. The emulator has no request-principal identity, so it grants
+// exactly the permissions named in the SA's bound roles' includedPermissions
+// (custom roles) plus any granted directly in the SA resource policy bindings.
+// With no matching policy every requested permission is held — real GCP grants
+// what the caller actually has; here the "caller" is the resource owner.
+func (h *Handler) testSAIamPermissions(w http.ResponseWriter, r *http.Request, email string) {
+	var body struct {
+		Permissions []string `json:"permissions"`
+	}
+
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	held := h.heldPermissions(r, email)
+
+	out := struct {
+		Permissions []string `json:"permissions,omitempty"`
+	}{Permissions: make([]string, 0, len(body.Permissions))}
+
+	for _, p := range body.Permissions {
+		if held == nil || held[p] {
+			out.Permissions = append(out.Permissions, p)
+		}
+	}
+
+	if len(out.Permissions) == 0 {
+		out.Permissions = nil
+	}
+
+	writeJSON(w, &out)
+}
+
+// heldPermissions returns the set of permissions granted on the SA. A nil map
+// means "grant everything requested" (no policy has been set, so the resource
+// owner implicitly holds all permissions). A non-nil map is the explicit
+// allow-set drawn from the SA's policy bindings' custom-role permissions.
+func (h *Handler) heldPermissions(r *http.Request, email string) map[string]bool {
+	h.mu.RLock()
+	pol := h.saPolicy[email]
+	h.mu.RUnlock()
+
+	if pol == nil || len(pol.Bindings) == 0 {
+		return nil
+	}
+
+	held := make(map[string]bool)
+
+	for i := range pol.Bindings {
+		roleName := pol.Bindings[i].Role
+		// Custom roles are "projects/{p}/roles/{id}" — resolve their perms.
+		id := roleName[strings.LastIndex(roleName, "/")+1:]
+
+		dr, err := h.iam.GetRole(r.Context(), id)
+		if err != nil {
+			continue
+		}
+
+		props, perr := decodeRoleProps(dr.AssumeRolePolicyDoc)
+		if perr != nil {
+			continue
+		}
+
+		for _, p := range props.IncludedPermissions {
+			held[p] = true
+		}
+	}
+
+	return held
+}
+
+// undeleteServiceAccount restores a recently-deleted SA from its tombstone.
+// The name segment may be the SA email or its 21-digit uniqueId, matching the
+// two resource-name forms real GCP accepts.
+func (h *Handler) undeleteServiceAccount(w http.ResponseWriter, r *http.Request, project, name string) {
+	h.mu.Lock()
+
+	email, tomb := h.takeTombstone(name)
+	if tomb == nil {
+		h.mu.Unlock()
+		writeError(w, http.StatusNotFound, "NOT_FOUND",
+			"service account "+name+" was not found or is not recoverable")
+
+		return
+	}
+
+	if tomb.disabled {
+		h.disabled[email] = true
+	}
+
+	h.mu.Unlock()
+
+	restoreProject := project
+	if restoreProject == "-" {
+		restoreProject = tomb.project
+	}
+
+	if _, err := h.iam.CreateUser(r.Context(), iamdriver.UserConfig{
+		Name: email,
+		Path: tomb.project,
+		Tags: map[string]string{
+			"displayName": tomb.displayName,
+			"description": tomb.description,
+		},
+	}); err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	sa := serviceAccount{DisplayName: tomb.displayName, Description: tomb.description, Disabled: tomb.disabled}
+	restored := toServiceAccountJSON(restoreProject, email, &sa)
+
+	writeJSON(w, map[string]any{"restoredAccount": &restored})
+}
+
+// takeTombstone finds and removes the tombstone for name, which may be the SA
+// email or its 21-digit uniqueId (the two resource-name forms real GCP accepts).
+// The caller must hold h.mu.
+func (h *Handler) takeTombstone(name string) (string, *deletedSA) {
+	if tomb := h.deletedSA[name]; tomb != nil {
+		delete(h.deletedSA, name)
+
+		return name, tomb
+	}
+
+	for email, tomb := range h.deletedSA {
+		if saUniqueID(email) == name {
+			delete(h.deletedSA, email)
+
+			return email, tomb
+		}
+	}
+
+	return "", nil
 }
 
 func (h *Handler) getSAIamPolicy(w http.ResponseWriter, email string) {
@@ -72,6 +229,11 @@ func (h *Handler) getSAIamPolicy(w http.ResponseWriter, email string) {
 	writeJSON(w, pol)
 }
 
+// setSAIamPolicy enforces optimistic concurrency. If a policy already exists,
+// the request's policy.etag must match the stored etag or the write is
+// rejected with 409 ABORTED — mirroring real GCP's read-modify-write contract.
+// Each accepted write bumps a per-SA version so successive states get distinct
+// etags (the old base64(email+bindingCount) scheme collided across states).
 func (h *Handler) setSAIamPolicy(w http.ResponseWriter, r *http.Request, email string) {
 	var body struct {
 		Policy iamPolicy `json:"policy"`
@@ -81,15 +243,26 @@ func (h *Handler) setSAIamPolicy(w http.ResponseWriter, r *http.Request, email s
 		return
 	}
 
+	h.mu.Lock()
+
+	if cur := h.saPolicy[email]; cur != nil && body.Policy.Etag != cur.Etag {
+		h.mu.Unlock()
+		writeError(w, http.StatusConflict, "ABORTED",
+			"there were concurrent policy changes; please retry the whole "+
+				"read-modify-write with the new etag")
+
+		return
+	}
+
 	pol := body.Policy
 	if pol.Version == 0 {
 		pol.Version = 1
 	}
 
-	pol.Etag = etagFor(email, len(pol.Bindings))
-
-	h.mu.Lock()
+	h.policyVersion[email]++
+	pol.Etag = etagFor(email, h.policyVersion[email])
 	h.saPolicy[email] = &pol
+
 	h.mu.Unlock()
 
 	writeJSON(w, &pol)


### PR DESCRIPTION
## What

Wire-layer fixes for the GCP IAM (`iam.googleapis.com` v1) audit batch. All eight findings are handled in `server/gcp/iam/` — no driver-interface or provider changes, so `docs/coverage` is unaffected.

## Why

Real `google.golang.org/api/iam/v1` clients hit missing methods (404/405) and behavioral gaps (empty/synthetic identity fields, unenforced etag concurrency, no pagination) that diverge from real GCP.

## Findings fixed

1. **[HIGH]** `ServiceAccounts.testIamPermissions` — `routeSAVerb` had no case → 404. Now returns the held subset of requested permissions (all when no restricting policy; narrowed to a bound custom role's `includedPermissions` when one is set).
2. **[MED]** `ServiceAccounts.undelete` — restores a recently-deleted SA from a tombstone captured at delete time (accepts email or 21-digit uniqueId in the resource name).
3. **[MED]** `Roles.undelete` — `routeRoles` was verb-blind (405); now dispatches the `undelete` verb and restores the soft-deleted custom role.
4. **[MED]** `ServiceAccounts.get/create` — return a stable 21-digit numeric `uniqueId`, matching `oauth2ClientId`, and a populated `etag` (were `uid-…` / empty).
5. **[MED]** `ServiceAccounts.list` — reflects the `disabled` bit (previously only `get` overlaid it).
6. **[MED]** `ServiceAccountKeys.create` — `privateKeyData` is now a base64 `service_account` credentials file (was 15 raw secret bytes); `validAfterTime`/`validBeforeTime` populated.
7. **[LOW]** `ServiceAccounts.setIamPolicy` — enforces optimistic concurrency: request `policy.etag` is compared to the stored etag, stale writes get `409 ABORTED`; each accepted write bumps a per-SA version so successive states get distinct etags (the old `base64(email+bindingCount)` scheme collided).
8. **[LOW]** `Roles.get/list` & `ServiceAccounts.list` — roles carry a populated `etag`; both lists honor `pageSize`/`pageToken` and return `nextPageToken`.

## Tests

Added `server/gcp/iam/sdk_iam_compat_test.go` — nine reproduction tests driving a real `iamv1` client (via `option.WithEndpoint`) against the in-process GCP server, one per finding (plus a custom-role subset check for testIamPermissions and a fresh-then-stale etag flow). Existing GCP IAM tests stay green.

## Deferrals

None.
