### PR TITLE
fix(gcp-gcs): preconditions, generation, checksums, versions, patch, compose, bucket IAM/location/lifecycle

### DIFF
--- a/docs/coverage/aws/s3.md
+++ b/docs/coverage/aws/s3.md
@@ -101,6 +101,22 @@ BucketAttributes is an OPTIONAL capability, discovered by type assertion (like
 | --- | --- |
 | `BucketAttributes` |  |
 
+### GCSExtensions
+
+GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type
+
+| Operation | Description |
+| --- | --- |
+| `BucketAttrsGCS` | BucketAttrsGCS returns the bucket's GCS-specific attributes. |
+| `BucketIAMPolicy` |  |
+| `ComposeObjectGCS` | ComposeObjectGCS concatenates the source objects' bytes (in order) into |
+| `ListObjectGenerations` | ListObjectGenerations returns every generation (current + archived) of the |
+| `PutObjectGCS` | PutObjectGCS writes an object honoring pre (a failed condition returns a |
+| `SetBucketAttrsGCS` | SetBucketAttrsGCS records the bucket's location and default storage class |
+| `SetBucketIAMPolicy` | SetBucketIAMPolicy / BucketIAMPolicy persist and return the bucket's IAM |
+| `TouchBucket` | TouchBucket bumps the bucket's metageneration and updated timestamp, |
+| `UpdateObjectGCS` | UpdateObjectGCS mutates an existing object's system properties and/or |
+
 ### ObjectCopier
 
 ObjectCopier is an OPTIONAL capability (discovered by type assertion, like

--- a/docs/coverage/azure/blobstorage.md
+++ b/docs/coverage/azure/blobstorage.md
@@ -101,6 +101,22 @@ BucketAttributes is an OPTIONAL capability, discovered by type assertion (like
 | --- | --- |
 | `BucketAttributes` |  |
 
+### GCSExtensions
+
+GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type
+
+| Operation | Description |
+| --- | --- |
+| `BucketAttrsGCS` | BucketAttrsGCS returns the bucket's GCS-specific attributes. |
+| `BucketIAMPolicy` |  |
+| `ComposeObjectGCS` | ComposeObjectGCS concatenates the source objects' bytes (in order) into |
+| `ListObjectGenerations` | ListObjectGenerations returns every generation (current + archived) of the |
+| `PutObjectGCS` | PutObjectGCS writes an object honoring pre (a failed condition returns a |
+| `SetBucketAttrsGCS` | SetBucketAttrsGCS records the bucket's location and default storage class |
+| `SetBucketIAMPolicy` | SetBucketIAMPolicy / BucketIAMPolicy persist and return the bucket's IAM |
+| `TouchBucket` | TouchBucket bumps the bucket's metageneration and updated timestamp, |
+| `UpdateObjectGCS` | UpdateObjectGCS mutates an existing object's system properties and/or |
+
 ### ObjectCopier
 
 ObjectCopier is an OPTIONAL capability (discovered by type assertion, like

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -10535,6 +10535,47 @@
         ]
       },
       {
+        "name": "GCSExtensions",
+        "doc": "GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type",
+        "operations": [
+          {
+            "name": "BucketAttrsGCS",
+            "doc": "BucketAttrsGCS returns the bucket's GCS-specific attributes."
+          },
+          {
+            "name": "BucketIAMPolicy"
+          },
+          {
+            "name": "ComposeObjectGCS",
+            "doc": "ComposeObjectGCS concatenates the source objects' bytes (in order) into"
+          },
+          {
+            "name": "ListObjectGenerations",
+            "doc": "ListObjectGenerations returns every generation (current + archived) of the"
+          },
+          {
+            "name": "PutObjectGCS",
+            "doc": "PutObjectGCS writes an object honoring pre (a failed condition returns a"
+          },
+          {
+            "name": "SetBucketAttrsGCS",
+            "doc": "SetBucketAttrsGCS records the bucket's location and default storage class"
+          },
+          {
+            "name": "SetBucketIAMPolicy",
+            "doc": "SetBucketIAMPolicy / BucketIAMPolicy persist and return the bucket's IAM"
+          },
+          {
+            "name": "TouchBucket",
+            "doc": "TouchBucket bumps the bucket's metageneration and updated timestamp,"
+          },
+          {
+            "name": "UpdateObjectGCS",
+            "doc": "UpdateObjectGCS mutates an existing object's system properties and/or"
+          }
+        ]
+      },
+      {
         "name": "ObjectCopier",
         "doc": "ObjectCopier is an OPTIONAL capability (discovered by type assertion, like",
         "operations": [

--- a/docs/coverage/gcp/gcs.md
+++ b/docs/coverage/gcp/gcs.md
@@ -101,6 +101,22 @@ BucketAttributes is an OPTIONAL capability, discovered by type assertion (like
 | --- | --- |
 | `BucketAttributes` |  |
 
+### GCSExtensions
+
+GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type
+
+| Operation | Description |
+| --- | --- |
+| `BucketAttrsGCS` | BucketAttrsGCS returns the bucket's GCS-specific attributes. |
+| `BucketIAMPolicy` |  |
+| `ComposeObjectGCS` | ComposeObjectGCS concatenates the source objects' bytes (in order) into |
+| `ListObjectGenerations` | ListObjectGenerations returns every generation (current + archived) of the |
+| `PutObjectGCS` | PutObjectGCS writes an object honoring pre (a failed condition returns a |
+| `SetBucketAttrsGCS` | SetBucketAttrsGCS records the bucket's location and default storage class |
+| `SetBucketIAMPolicy` | SetBucketIAMPolicy / BucketIAMPolicy persist and return the bucket's IAM |
+| `TouchBucket` | TouchBucket bumps the bucket's metageneration and updated timestamp, |
+| `UpdateObjectGCS` | UpdateObjectGCS mutates an existing object's system properties and/or |
+
 ### ObjectCopier
 
 ObjectCopier is an OPTIONAL capability (discovered by type assertion, like

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -3,13 +3,18 @@ package gcs
 
 import (
 	"context"
+	"crypto/md5" //nolint:gosec // GCS md5Hash is a content digest, not a security primitive
 	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
 	"fmt"
+	"hash/crc32"
 	"maps"
 	"net/http"
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -30,18 +35,30 @@ const (
 	gcsHoursPerDay          = 24
 )
 
-// Compile-time check that Mock implements driver.Bucket.
-var _ driver.Bucket = (*Mock)(nil)
+// Compile-time check that Mock implements driver.Bucket and the GCS-specific
+// optional capability.
+var (
+	_ driver.Bucket        = (*Mock)(nil)
+	_ driver.GCSExtensions = (*Mock)(nil)
+)
 
 type gcsObject struct {
-	Key          string
-	Data         []byte
-	Size         int64
-	ContentType  string
-	ETag         string
-	LastModified string
-	Metadata     map[string]string
-	Tags         map[string]string
+	Key                string
+	Data               []byte
+	Size               int64
+	ContentType        string
+	ETag               string
+	LastModified       string
+	Metadata           map[string]string
+	Tags               map[string]string
+	Generation         int64
+	Metageneration     int64
+	MD5                string
+	CRC32C             string
+	CacheControl       string
+	ContentEncoding    string
+	ContentDisposition string
+	ContentLanguage    string
 }
 
 type gcsMultipartUpload struct {
@@ -67,6 +84,18 @@ type bucketMeta struct {
 	corsConfig *driver.CORSConfig
 	encryption *driver.EncryptionConfig
 	tags       map[string]string
+
+	// mu guards the GCS-specific mutable fields below (location/storageClass,
+	// metageneration/updated, iamPolicy, and the archived version history).
+	mu             sync.Mutex
+	location       string
+	storageClass   string
+	metageneration int64
+	updated        string
+	iamPolicy      []byte
+	// versions holds archived (non-current) object generations keyed by object
+	// key, oldest-first, populated on overwrite when versioning is enabled.
+	versions map[string][]*gcsObject
 }
 
 // Mock is an in-memory mock implementation of Google Cloud Storage.
@@ -74,6 +103,8 @@ type Mock struct {
 	buckets    *memstore.Store[*bucketMeta]
 	opts       *config.Options
 	monitoring mondriver.Monitoring
+	// gen is the source of unique, monotonically increasing object generations.
+	gen atomic.Int64
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -115,15 +146,55 @@ func (m *Mock) CreateBucket(_ context.Context, name string) error {
 		return cerrors.Newf(cerrors.AlreadyExists, "bucket %q already exists", name)
 	}
 
+	now := m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
+
 	m.buckets.Set(name, &bucketMeta{
-		Name:       name,
-		Region:     m.opts.Region,
-		CreatedAt:  m.opts.Clock.Now().UTC().Format(gcsTimeFormat),
-		objects:    memstore.New[*gcsObject](),
-		multiparts: memstore.New[*gcsMultipartUpload](),
+		Name:           name,
+		Region:         m.opts.Region,
+		CreatedAt:      now,
+		objects:        memstore.New[*gcsObject](),
+		multiparts:     memstore.New[*gcsMultipartUpload](),
+		metageneration: 1,
+		updated:        now,
+		versions:       make(map[string][]*gcsObject),
 	})
 
 	return nil
+}
+
+// checksums returns the base64-encoded MD5 (GCS md5Hash) and big-endian CRC32C
+// (Castagnoli, GCS crc32c) of data.
+func checksums(data []byte) (md5b64, crc32cb64 string) {
+	sum := md5.Sum(data) //nolint:gosec // GCS md5Hash is a content digest, not security
+	md5b64 = base64.StdEncoding.EncodeToString(sum[:])
+
+	crc := crc32.Checksum(data, crc32.MakeTable(crc32.Castagnoli))
+
+	var b [crc32.Size]byte
+
+	binary.BigEndian.PutUint32(b[:], crc)
+	crc32cb64 = base64.StdEncoding.EncodeToString(b[:])
+
+	return md5b64, crc32cb64
+}
+
+// toInfo projects a stored object into the driver's ObjectInfo. When cloneMeta
+// is true the metadata map is deep-copied (callers that hand the info straight
+// to an external consumer); list paths pass false and clone only the page.
+func toInfo(o *gcsObject, cloneMeta bool) driver.ObjectInfo {
+	meta := o.Metadata
+	if cloneMeta {
+		meta = maps.Clone(o.Metadata)
+	}
+
+	return driver.ObjectInfo{
+		Key: o.Key, Size: o.Size, ContentType: o.ContentType, ETag: o.ETag,
+		LastModified: o.LastModified, Metadata: meta,
+		Generation: o.Generation, Metageneration: o.Metageneration,
+		MD5: o.MD5, CRC32C: o.CRC32C,
+		CacheControl: o.CacheControl, ContentEncoding: o.ContentEncoding,
+		ContentDisposition: o.ContentDisposition, ContentLanguage: o.ContentLanguage,
+	}
 }
 
 func (m *Mock) DeleteBucket(_ context.Context, name string) error {
@@ -164,9 +235,25 @@ func (m *Mock) ListBuckets(_ context.Context) ([]driver.BucketInfo, error) {
 }
 
 func (m *Mock) PutObject(ctx context.Context, bucket, key string, data []byte, contentType string, metadata map[string]string) error {
+	_, err := m.putObject(ctx, bucket, key, data, contentType, metadata, driver.GCSPrecondition{})
+
+	return err
+}
+
+// putObject is the shared write path behind PutObject and PutObjectGCS. It
+// evaluates any preconditions, archives the current generation when versioning
+// is enabled, mints a fresh generation, and returns the stored object's info.
+func (m *Mock) putObject(
+	ctx context.Context, bucket, key string, data []byte, contentType string, metadata map[string]string, pre driver.GCSPrecondition,
+) (*driver.ObjectInfo, error) {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	current, exists := bkt.objects.Get(key)
+	if err := checkPrecondition(pre, current, exists); err != nil {
+		return nil, err
 	}
 
 	dataCopy := make([]byte, len(data))
@@ -184,27 +271,111 @@ func (m *Mock) PutObject(ctx context.Context, bucket, key string, data []byte, c
 			Bucket: bucket, Key: key, Data: dataCopy, ContentType: contentType, Metadata: metaCopy,
 		})
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		stored = nil
 	}
 
-	bkt.objects.Set(key, &gcsObject{
-		Key:          key,
-		Data:         stored,
-		Size:         int64(len(data)),
-		ContentType:  contentType,
-		ETag:         fmt.Sprintf("%x", sha256.Sum256(data)),
-		LastModified: m.opts.Clock.Now().UTC().Format(gcsTimeFormat),
-		Metadata:     metaCopy,
-	})
+	archiveVersion(bkt, key, current, exists)
+
+	md5b64, crc32cb64 := checksums(data)
+
+	obj := &gcsObject{
+		Key:            key,
+		Data:           stored,
+		Size:           int64(len(data)),
+		ContentType:    contentType,
+		ETag:           fmt.Sprintf("%x", sha256.Sum256(data)),
+		LastModified:   m.opts.Clock.Now().UTC().Format(gcsTimeFormat),
+		Metadata:       metaCopy,
+		Generation:     m.gen.Add(1),
+		Metageneration: 1,
+		MD5:            md5b64,
+		CRC32C:         crc32cb64,
+	}
+	bkt.objects.Set(key, obj)
 
 	dims := map[string]string{"bucket_name": bucket}
 	m.emitMetric(ctx, "api/request_count", 1, dims)
 	m.emitMetric(ctx, "network/received_bytes_count", float64(len(data)), dims)
 
+	info := toInfo(obj, true)
+
+	return &info, nil
+}
+
+// checkPrecondition evaluates GCS write preconditions against the object
+// currently stored under the key, returning a *driver.GCSPreconditionError when
+// a condition is not met.
+func checkPrecondition(pre driver.GCSPrecondition, current *gcsObject, exists bool) error {
+	var gen, metagen int64
+	if exists {
+		gen, metagen = current.Generation, current.Metageneration
+	}
+
+	if err := checkGenerationMatch(pre.IfGenerationMatch, gen, exists); err != nil {
+		return err
+	}
+
+	if err := checkGenerationNotMatch(pre.IfGenerationNotMatch, gen, exists); err != nil {
+		return err
+	}
+
+	return checkMetagenerationConditions(pre, metagen, exists)
+}
+
+func checkGenerationMatch(want *int64, gen int64, exists bool) error {
+	if want == nil {
+		return nil
+	}
+
+	if (*want == 0 && exists) || (*want != 0 && (!exists || gen != *want)) {
+		return &driver.GCSPreconditionError{Message: "conditionNotMet: ifGenerationMatch"}
+	}
+
 	return nil
+}
+
+func checkGenerationNotMatch(want *int64, gen int64, exists bool) error {
+	if want == nil {
+		return nil
+	}
+
+	if (*want == 0 && !exists) || (exists && gen == *want) {
+		return &driver.GCSPreconditionError{Message: "conditionNotMet: ifGenerationNotMatch"}
+	}
+
+	return nil
+}
+
+func checkMetagenerationConditions(pre driver.GCSPrecondition, metagen int64, exists bool) error {
+	if want := pre.IfMetagenerationMatch; want != nil && (!exists || metagen != *want) {
+		return &driver.GCSPreconditionError{Message: "conditionNotMet: ifMetagenerationMatch"}
+	}
+
+	if want := pre.IfMetagenerationNotMatch; want != nil && exists && metagen == *want {
+		return &driver.GCSPreconditionError{Message: "conditionNotMet: ifMetagenerationNotMatch"}
+	}
+
+	return nil
+}
+
+// archiveVersion retains the current object generation when versioning is
+// enabled, so a versions=true listing can still surface it after an overwrite.
+func archiveVersion(bkt *bucketMeta, key string, current *gcsObject, exists bool) {
+	if !exists || !bkt.versioning {
+		return
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	if bkt.versions == nil {
+		bkt.versions = make(map[string][]*gcsObject)
+	}
+
+	bkt.versions[key] = append(bkt.versions[key], current)
 }
 
 func (m *Mock) GetObject(ctx context.Context, bucket, key string) (*driver.Object, error) {
@@ -228,10 +399,7 @@ func (m *Mock) GetObject(ctx context.Context, bucket, key string) (*driver.Objec
 	m.emitMetric(ctx, "network/sent_bytes_count", float64(obj.Size), dims)
 
 	return &driver.Object{
-		Info: driver.ObjectInfo{
-			Key: obj.Key, Size: obj.Size, ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
-		},
+		Info: toInfo(obj, true),
 		Data: dataCopy,
 	}, nil
 }
@@ -288,10 +456,9 @@ func (m *Mock) HeadObject(_ context.Context, bucket, key string) (*driver.Object
 		return nil, cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bucket)
 	}
 
-	return &driver.ObjectInfo{
-		Key: obj.Key, Size: obj.Size, ContentType: obj.ContentType,
-		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
-	}, nil
+	info := toInfo(obj, true)
+
+	return &info, nil
 }
 
 func (m *Mock) ListObjects(ctx context.Context, bucket string, opts driver.ListOptions) (*driver.ListResult, error) {
@@ -327,10 +494,7 @@ func (m *Mock) ListObjects(ctx context.Context, bucket string, opts driver.ListO
 			continue
 		}
 
-		matchedObjects = append(matchedObjects, driver.ObjectInfo{
-			Key: obj.Key, Size: obj.Size, ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
-		})
+		matchedObjects = append(matchedObjects, toInfo(obj, false))
 	}
 
 	commonPrefixes := make([]string, 0, len(commonPrefixSet))
@@ -403,10 +567,16 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 		stored = nil
 	}
 
+	dstCurrent, dstExists := dstBkt.objects.Get(dstKey)
+	archiveVersion(dstBkt, dstKey, dstCurrent, dstExists)
+
 	dstBkt.objects.Set(dstKey, &gcsObject{
 		Key: dstKey, Data: stored, Size: srcObj.Size, ContentType: srcObj.ContentType,
 		ETag: srcObj.ETag, LastModified: m.opts.Clock.Now().UTC().Format(gcsTimeFormat),
-		Metadata: meta,
+		Metadata: meta, Generation: m.gen.Add(1), Metageneration: 1,
+		MD5: srcObj.MD5, CRC32C: srcObj.CRC32C,
+		CacheControl: srcObj.CacheControl, ContentEncoding: srcObj.ContentEncoding,
+		ContentDisposition: srcObj.ContentDisposition, ContentLanguage: srcObj.ContentLanguage,
 	})
 
 	dims := map[string]string{"bucket_name": dstBucket}
@@ -655,14 +825,23 @@ func (m *Mock) CompleteMultipartUpload(
 		stored = nil
 	}
 
+	md5b64, crc32cb64 := checksums(data)
+
+	current, exists := bkt.objects.Get(key)
+	archiveVersion(bkt, key, current, exists)
+
 	bkt.objects.Set(key, &gcsObject{
-		Key:          key,
-		Data:         stored,
-		Size:         int64(len(data)),
-		ContentType:  mp.contentType,
-		ETag:         fmt.Sprintf("%x", sha256.Sum256(data)),
-		LastModified: m.opts.Clock.Now().UTC().Format(gcsTimeFormat),
-		Metadata:     make(map[string]string),
+		Key:            key,
+		Data:           stored,
+		Size:           int64(len(data)),
+		ContentType:    mp.contentType,
+		ETag:           fmt.Sprintf("%x", sha256.Sum256(data)),
+		LastModified:   m.opts.Clock.Now().UTC().Format(gcsTimeFormat),
+		Metadata:       make(map[string]string),
+		Generation:     m.gen.Add(1),
+		Metageneration: 1,
+		MD5:            md5b64,
+		CRC32C:         crc32cb64,
 	})
 
 	bkt.multiparts.Delete(uploadID)
@@ -957,4 +1136,260 @@ func (m *Mock) DeleteBucketTagging(_ context.Context, bucket string) error {
 	bkt.tags = nil
 
 	return nil
+}
+
+// PutObjectGCS writes an object honoring GCS write preconditions and returns the
+// stored object's info with the newly minted generation.
+func (m *Mock) PutObjectGCS(
+	ctx context.Context, bucket, key string, data []byte, contentType string, metadata map[string]string, pre driver.GCSPrecondition,
+) (*driver.ObjectInfo, error) {
+	return m.putObject(ctx, bucket, key, data, contentType, metadata, pre)
+}
+
+// UpdateObjectGCS mutates an existing object's system properties and/or custom
+// metadata without touching its data, bumping metageneration.
+func (m *Mock) UpdateObjectGCS(
+	_ context.Context, bucket, key string, upd driver.GCSObjectUpdate,
+) (*driver.ObjectInfo, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	cur, ok := bkt.objects.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bucket)
+	}
+
+	next := *cur
+	next.Metageneration = cur.Metageneration + 1
+	next.Metadata = mergeMetadata(cur.Metadata, upd.Metadata)
+
+	applyStringUpdate(&next.ContentType, upd.ContentType)
+	applyStringUpdate(&next.CacheControl, upd.CacheControl)
+	applyStringUpdate(&next.ContentEncoding, upd.ContentEncoding)
+	applyStringUpdate(&next.ContentDisposition, upd.ContentDisposition)
+	applyStringUpdate(&next.ContentLanguage, upd.ContentLanguage)
+
+	bkt.objects.Set(key, &next)
+
+	info := toInfo(&next, true)
+
+	return &info, nil
+}
+
+func applyStringUpdate(dst, v *string) {
+	if v != nil {
+		*dst = *v
+	}
+}
+
+// mergeMetadata clones cur and applies patch: a nil-valued patch entry deletes
+// the key, a non-nil value sets it. A nil patch map leaves metadata unchanged.
+func mergeMetadata(cur map[string]string, patch map[string]*string) map[string]string {
+	out := maps.Clone(cur)
+	if out == nil {
+		out = make(map[string]string)
+	}
+
+	for k, v := range patch {
+		if v == nil {
+			delete(out, k)
+			continue
+		}
+
+		out[k] = *v
+	}
+
+	return out
+}
+
+// ComposeObjectGCS concatenates the source objects' bytes (in order) into
+// dstKey, minting a new generation for the destination.
+func (m *Mock) ComposeObjectGCS(
+	ctx context.Context, bucket, dstKey string, srcKeys []string, contentType string, metadata map[string]string,
+) (*driver.ObjectInfo, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	var composed []byte
+
+	for _, sk := range srcKeys {
+		srcObj, ok := bkt.objects.Get(sk)
+		if !ok {
+			return nil, cerrors.Newf(cerrors.NotFound, "source object %q not found in bucket %q", sk, bucket)
+		}
+
+		bytesOf, err := m.objectBytes(ctx, bucket, srcObj)
+		if err != nil {
+			return nil, err
+		}
+
+		composed = append(composed, bytesOf...)
+
+		if contentType == "" {
+			contentType = srcObj.ContentType
+		}
+	}
+
+	return m.putObject(ctx, bucket, dstKey, composed, contentType, metadata, driver.GCSPrecondition{})
+}
+
+// ListObjectGenerations returns every generation (current + archived) of the
+// objects matching opts, for a versions=true listing.
+func (m *Mock) ListObjectGenerations(_ context.Context, bucket string, opts driver.ListOptions) (*driver.ListResult, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	all := collectAllVersions(bkt)
+
+	var matched []driver.ObjectInfo
+
+	for _, o := range all {
+		if opts.Prefix != "" && !strings.HasPrefix(o.Key, opts.Prefix) {
+			continue
+		}
+
+		matched = append(matched, toInfo(o, true))
+	}
+
+	maxKeys := opts.MaxKeys
+	if maxKeys <= 0 {
+		maxKeys = gcsDefaultMaxKeys
+	}
+
+	page, err := pagination.Paginate(matched, opts.PageToken, maxKeys)
+	if err != nil {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+	}
+
+	return &driver.ListResult{
+		Objects:       page.Items,
+		NextPageToken: page.NextPageToken,
+		IsTruncated:   page.HasMore,
+	}, nil
+}
+
+// collectAllVersions returns archived-then-current generations for every key,
+// sorted by (key, generation) so a versioned listing is deterministic.
+func collectAllVersions(bkt *bucketMeta) []*gcsObject {
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	var all []*gcsObject
+
+	for _, k := range bkt.objects.Keys() {
+		if archived := bkt.versions[k]; len(archived) > 0 {
+			all = append(all, archived...)
+		}
+
+		if cur, ok := bkt.objects.Get(k); ok {
+			all = append(all, cur)
+		}
+	}
+
+	// Archived versions of keys that were fully deleted still count in GCS, but
+	// this mock drops them on delete; only live keys are surfaced here.
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].Key != all[j].Key {
+			return all[i].Key < all[j].Key
+		}
+
+		return all[i].Generation < all[j].Generation
+	})
+
+	return all
+}
+
+// SetBucketAttrsGCS records the bucket's location and default storage class;
+// empty values leave the current value unchanged.
+func (m *Mock) SetBucketAttrsGCS(_ context.Context, bucket, location, storageClass string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	if location != "" {
+		bkt.location = location
+	}
+
+	if storageClass != "" {
+		bkt.storageClass = storageClass
+	}
+
+	return nil
+}
+
+// BucketAttrsGCS returns the bucket's GCS-specific attributes.
+func (m *Mock) BucketAttrsGCS(_ context.Context, bucket string) (driver.GCSBucketMeta, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return driver.GCSBucketMeta{}, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	return driver.GCSBucketMeta{
+		Location:       bkt.location,
+		StorageClass:   bkt.storageClass,
+		Metageneration: bkt.metageneration,
+		Updated:        bkt.updated,
+	}, nil
+}
+
+// TouchBucket bumps the bucket's metageneration and updated timestamp.
+func (m *Mock) TouchBucket(_ context.Context, bucket string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	bkt.metageneration++
+	bkt.updated = m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
+
+	return nil
+}
+
+// SetBucketIAMPolicy persists the bucket's IAM policy document verbatim.
+func (m *Mock) SetBucketIAMPolicy(_ context.Context, bucket string, policyJSON []byte) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	bkt.iamPolicy = append([]byte(nil), policyJSON...)
+
+	return nil
+}
+
+// BucketIAMPolicy returns the bucket's IAM policy document, or NotFound when
+// none has been set.
+func (m *Mock) BucketIAMPolicy(_ context.Context, bucket string) ([]byte, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	if bkt.iamPolicy == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no IAM policy set for bucket %q", bucket)
+	}
+
+	return append([]byte(nil), bkt.iamPolicy...), nil
 }

--- a/providers/gcp/gcs/snapshot.go
+++ b/providers/gcp/gcs/snapshot.go
@@ -20,30 +20,43 @@ type gcsSnapshot struct {
 }
 
 type bucketSnapshot struct {
-	Name       string                     `json:"name"`
-	Region     string                     `json:"region,omitempty"`
-	CreatedAt  string                     `json:"createdAt,omitempty"`
-	Versioning bool                       `json:"versioning,omitempty"`
-	Lifecycle  *driver.LifecycleConfig    `json:"lifecycle,omitempty"`
-	Policy     *driver.BucketPolicy       `json:"policy,omitempty"`
-	CORS       *driver.CORSConfig         `json:"cors,omitempty"`
-	Encryption *driver.EncryptionConfig   `json:"encryption,omitempty"`
-	Tags       map[string]string          `json:"tags,omitempty"`
-	Objects    map[string]*objectSnapshot `json:"objects,omitempty"`
+	Name           string                     `json:"name"`
+	Region         string                     `json:"region,omitempty"`
+	CreatedAt      string                     `json:"createdAt,omitempty"`
+	Versioning     bool                       `json:"versioning,omitempty"`
+	Lifecycle      *driver.LifecycleConfig    `json:"lifecycle,omitempty"`
+	Policy         *driver.BucketPolicy       `json:"policy,omitempty"`
+	CORS           *driver.CORSConfig         `json:"cors,omitempty"`
+	Encryption     *driver.EncryptionConfig   `json:"encryption,omitempty"`
+	Tags           map[string]string          `json:"tags,omitempty"`
+	Location       string                     `json:"location,omitempty"`
+	StorageClass   string                     `json:"storageClass,omitempty"`
+	Metageneration int64                      `json:"metageneration,omitempty"`
+	Updated        string                     `json:"updated,omitempty"`
+	IAMPolicy      []byte                     `json:"iamPolicy,omitempty"`
+	Objects        map[string]*objectSnapshot `json:"objects,omitempty"`
 }
 
 // objectSnapshot mirrors gcsObject (all exported already), but Data is dropped
 // in a metadata-only (includeAssets=false) snapshot while Size is kept so the
 // metadata stays correct.
 type objectSnapshot struct {
-	Key          string            `json:"key"`
-	Data         []byte            `json:"data,omitempty"`
-	Size         int64             `json:"size"`
-	ContentType  string            `json:"contentType,omitempty"`
-	ETag         string            `json:"etag,omitempty"`
-	LastModified string            `json:"lastModified,omitempty"`
-	Metadata     map[string]string `json:"metadata,omitempty"`
-	Tags         map[string]string `json:"tags,omitempty"`
+	Key                string            `json:"key"`
+	Data               []byte            `json:"data,omitempty"`
+	Size               int64             `json:"size"`
+	ContentType        string            `json:"contentType,omitempty"`
+	ETag               string            `json:"etag,omitempty"`
+	LastModified       string            `json:"lastModified,omitempty"`
+	Metadata           map[string]string `json:"metadata,omitempty"`
+	Tags               map[string]string `json:"tags,omitempty"`
+	Generation         int64             `json:"generation,omitempty"`
+	Metageneration     int64             `json:"metageneration,omitempty"`
+	MD5                string            `json:"md5,omitempty"`
+	CRC32C             string            `json:"crc32c,omitempty"`
+	CacheControl       string            `json:"cacheControl,omitempty"`
+	ContentEncoding    string            `json:"contentEncoding,omitempty"`
+	ContentDisposition string            `json:"contentDisposition,omitempty"`
+	ContentLanguage    string            `json:"contentLanguage,omitempty"`
 }
 
 // Snapshot captures every bucket's state as JSON. When includeAssets is false
@@ -63,6 +76,8 @@ func snapshotBucket(bkt *bucketMeta, includeAssets bool) *bucketSnapshot {
 		Name: bkt.Name, Region: bkt.Region, CreatedAt: bkt.CreatedAt,
 		Versioning: bkt.versioning, Lifecycle: bkt.lifecycle, Policy: bkt.policy,
 		CORS: bkt.corsConfig, Encryption: bkt.encryption, Tags: bkt.tags,
+		Location: bkt.location, StorageClass: bkt.storageClass,
+		Metageneration: bkt.metageneration, Updated: bkt.updated, IAMPolicy: bkt.iamPolicy,
 		Objects: make(map[string]*objectSnapshot, bkt.objects.Len()),
 	}
 
@@ -71,6 +86,10 @@ func snapshotBucket(bkt *bucketMeta, includeAssets bool) *bucketSnapshot {
 			Key: obj.Key, Data: assetBytes(obj.Data, includeAssets), Size: obj.Size,
 			ContentType: obj.ContentType, ETag: obj.ETag, LastModified: obj.LastModified,
 			Metadata: obj.Metadata, Tags: obj.Tags,
+			Generation: obj.Generation, Metageneration: obj.Metageneration,
+			MD5: obj.MD5, CRC32C: obj.CRC32C, CacheControl: obj.CacheControl,
+			ContentEncoding: obj.ContentEncoding, ContentDisposition: obj.ContentDisposition,
+			ContentLanguage: obj.ContentLanguage,
 		}
 	}
 
@@ -103,6 +122,11 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 }
 
 func restoreBucket(bs *bucketSnapshot) *bucketMeta {
+	metagen := bs.Metageneration
+	if metagen == 0 {
+		metagen = 1
+	}
+
 	bkt := &bucketMeta{
 		Name: bs.Name, Region: bs.Region, CreatedAt: bs.CreatedAt,
 		objects:    memstore.New[*gcsObject](),
@@ -110,12 +134,19 @@ func restoreBucket(bs *bucketSnapshot) *bucketMeta {
 		versioning: bs.Versioning,
 		lifecycle:  bs.Lifecycle, policy: bs.Policy, corsConfig: bs.CORS,
 		encryption: bs.Encryption, tags: bs.Tags,
+		location: bs.Location, storageClass: bs.StorageClass,
+		metageneration: metagen, updated: bs.Updated, iamPolicy: bs.IAMPolicy,
+		versions: make(map[string][]*gcsObject),
 	}
 
 	for key, os := range bs.Objects {
 		bkt.objects.Set(key, &gcsObject{
 			Key: os.Key, Data: os.Data, Size: os.Size, ContentType: os.ContentType,
 			ETag: os.ETag, LastModified: os.LastModified, Metadata: os.Metadata, Tags: os.Tags,
+			Generation: os.Generation, Metageneration: os.Metageneration,
+			MD5: os.MD5, CRC32C: os.CRC32C, CacheControl: os.CacheControl,
+			ContentEncoding: os.ContentEncoding, ContentDisposition: os.ContentDisposition,
+			ContentLanguage: os.ContentLanguage,
 		})
 	}
 

--- a/server/gcp/gcs/gcs_bucket_semantics_test.go
+++ b/server/gcp/gcs/gcs_bucket_semantics_test.go
@@ -1,0 +1,137 @@
+package gcs_test
+
+import (
+	"testing"
+
+	"cloud.google.com/go/storage"
+)
+
+// TestGCSBucketLocationStorageClass proves a bucket created with a non-default
+// location/storage class reads them back (instead of a hardcoded US/STANDARD)
+// so IaC tools don't see perpetual drift.
+func TestGCSBucketLocationStorageClass(t *testing.T) {
+	ctx, client := newStorageClient(t)
+
+	bkt := client.Bucket("eu-nearline")
+	if err := bkt.Create(ctx, e2eProject, &storage.BucketAttrs{Location: "EU", StorageClass: "NEARLINE"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	a, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs: %v", err)
+	}
+
+	if a.Location != "EU" {
+		t.Errorf("Location = %q, want EU", a.Location)
+	}
+
+	if a.StorageClass != "NEARLINE" {
+		t.Errorf("StorageClass = %q, want NEARLINE", a.StorageClass)
+	}
+
+	if a.LocationType != "multi-region" {
+		t.Errorf("LocationType = %q, want multi-region", a.LocationType)
+	}
+}
+
+// TestGCSBucketLifecyclePersists proves a lifecycle rule set via Update is
+// persisted and read back, instead of being accepted-and-dropped.
+func TestGCSBucketLifecyclePersists(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "lifecycle-cfg")
+
+	lc := storage.Lifecycle{Rules: []storage.LifecycleRule{{
+		Action:    storage.LifecycleAction{Type: storage.DeleteAction},
+		Condition: storage.LifecycleCondition{AgeInDays: 30},
+	}}}
+
+	if _, err := bkt.Update(ctx, storage.BucketAttrsToUpdate{Lifecycle: &lc}); err != nil {
+		t.Fatalf("update lifecycle: %v", err)
+	}
+
+	a, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs: %v", err)
+	}
+
+	if len(a.Lifecycle.Rules) != 1 {
+		t.Fatalf("lifecycle rules = %d, want 1", len(a.Lifecycle.Rules))
+	}
+
+	rule := a.Lifecycle.Rules[0]
+	if rule.Action.Type != storage.DeleteAction {
+		t.Errorf("action = %q, want Delete", rule.Action.Type)
+	}
+
+	if rule.Condition.AgeInDays != 30 {
+		t.Errorf("age = %d, want 30", rule.Condition.AgeInDays)
+	}
+}
+
+// TestGCSBucketIAM proves bucket IAM (get/set/testPermissions) is served
+// (previously a 404), so google_storage_bucket_iam_* works.
+func TestGCSBucketIAM(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "iam-cfg")
+
+	handle := bkt.IAM()
+
+	policy, err := handle.Policy(ctx)
+	if err != nil {
+		t.Fatalf("IAM().Policy failed (was 404 before the fix): %v", err)
+	}
+
+	policy.Add("user:alice@example.com", "roles/storage.objectViewer")
+
+	if err := handle.SetPolicy(ctx, policy); err != nil {
+		t.Fatalf("SetPolicy: %v", err)
+	}
+
+	got, err := handle.Policy(ctx)
+	if err != nil {
+		t.Fatalf("Policy after set: %v", err)
+	}
+
+	if !got.HasRole("user:alice@example.com", "roles/storage.objectViewer") {
+		t.Errorf("IAM policy did not round-trip the binding: %+v", got)
+	}
+
+	perms, err := handle.TestPermissions(ctx, []string{"storage.objects.get"})
+	if err != nil {
+		t.Fatalf("TestPermissions: %v", err)
+	}
+
+	if len(perms) != 1 || perms[0] != "storage.objects.get" {
+		t.Errorf("TestPermissions = %v, want [storage.objects.get]", perms)
+	}
+}
+
+// TestGCSBucketMetageneration proves buckets carry a non-zero metageneration
+// that increases on each configuration change (was metageneration=0 before).
+func TestGCSBucketMetageneration(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "metagen")
+
+	a, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs: %v", err)
+	}
+
+	if a.MetaGeneration < 1 {
+		t.Errorf("MetaGeneration = %d, want >= 1", a.MetaGeneration)
+	}
+
+	if _, err := bkt.Update(ctx, storage.BucketAttrsToUpdate{VersioningEnabled: true}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	a2, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs after update: %v", err)
+	}
+
+	if a2.MetaGeneration <= a.MetaGeneration {
+		t.Errorf("MetaGeneration did not increase after a patch: %d -> %d", a.MetaGeneration, a2.MetaGeneration)
+	}
+}

--- a/server/gcp/gcs/gcs_object_semantics_test.go
+++ b/server/gcp/gcs/gcs_object_semantics_test.go
@@ -1,0 +1,213 @@
+package gcs_test
+
+import (
+	"bytes"
+	"crypto/md5" //nolint:gosec // verifying the GCS md5Hash content digest, not a security primitive
+	"errors"
+	"hash/crc32"
+	"net/http"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/iterator"
+)
+
+// assertPreconditionFailed asserts err is a 412 conditionNotMet from GCS.
+func assertPreconditionFailed(t *testing.T, err error, when string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("%s: expected a 412 precondition error, got nil", when)
+	}
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		t.Fatalf("%s: expected *googleapi.Error, got %T: %v", when, err, err)
+	}
+
+	if gerr.Code != http.StatusPreconditionFailed {
+		t.Errorf("%s: got HTTP %d, want 412", when, gerr.Code)
+	}
+}
+
+// TestGCSObjectInsertPreconditions proves ifGenerationMatch is honored: a
+// create-if-absent (DoesNotExist) succeeds once but 412s over an existing
+// object, and GenerationMatch to a non-existent generation 412s — the behaviors
+// distributed locks and create-if-absent rely on.
+func TestGCSObjectInsertPreconditions(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "precond")
+
+	w := bkt.Object("k").If(storage.Conditions{DoesNotExist: true}).NewWriter(ctx)
+	if _, err := w.Write([]byte("v1")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("first create-if-absent should succeed: %v", err)
+	}
+
+	w2 := bkt.Object("k").If(storage.Conditions{DoesNotExist: true}).NewWriter(ctx)
+	_, _ = w2.Write([]byte("v2"))
+	assertPreconditionFailed(t, w2.Close(), "DoesNotExist over an existing object")
+
+	w3 := bkt.Object("k").If(storage.Conditions{GenerationMatch: 999999}).NewWriter(ctx)
+	_, _ = w3.Write([]byte("v3"))
+	assertPreconditionFailed(t, w3.Close(), "GenerationMatch:999999")
+
+	if got := readObject(t, ctx, bkt, "k"); string(got) != "v1" {
+		t.Errorf("object mutated despite failed preconditions: got %q, want v1", got)
+	}
+}
+
+// TestGCSObjectGenerationMinted proves each write mints a fresh, non-zero
+// generation instead of the old hardcoded "1", so optimistic concurrency and
+// versioning can distinguish writes.
+func TestGCSObjectGenerationMinted(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "gen")
+
+	putObject(t, ctx, bkt, "k", "text/plain", []byte("one"), nil)
+
+	a1, err := bkt.Object("k").Attrs(ctx)
+	if err != nil {
+		t.Fatalf("first Attrs: %v", err)
+	}
+
+	putObject(t, ctx, bkt, "k", "text/plain", []byte("two"), nil)
+
+	a2, err := bkt.Object("k").Attrs(ctx)
+	if err != nil {
+		t.Fatalf("second Attrs: %v", err)
+	}
+
+	if a1.Generation == 0 || a2.Generation == 0 {
+		t.Fatalf("generation must be non-zero: first=%d second=%d", a1.Generation, a2.Generation)
+	}
+
+	if a1.Generation == a2.Generation {
+		t.Errorf("overwrite kept generation %d; real GCS mints a new one", a1.Generation)
+	}
+}
+
+// TestGCSObjectChecksums proves Attrs returns both md5Hash and crc32c — the
+// crc32c the Go client uses for download integrity.
+func TestGCSObjectChecksums(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "sums")
+
+	data := []byte("hello world")
+	putObject(t, ctx, bkt, "k", "text/plain", data, nil)
+
+	a, err := bkt.Object("k").Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs: %v", err)
+	}
+
+	wantMD5 := md5.Sum(data) //nolint:gosec // content digest, not security
+	if !bytes.Equal(a.MD5, wantMD5[:]) {
+		t.Errorf("MD5 = %x, want %x", a.MD5, wantMD5)
+	}
+
+	wantCRC := crc32.Checksum(data, crc32.MakeTable(crc32.Castagnoli))
+	if a.CRC32C != wantCRC {
+		t.Errorf("CRC32C = %d, want %d", a.CRC32C, wantCRC)
+	}
+}
+
+// TestGCSObjectUpdateMetadata proves Objects: patch/update mutates contentType,
+// cacheControl, and custom metadata (previously a 405) and bumps metageneration.
+func TestGCSObjectUpdateMetadata(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "patch")
+
+	putObject(t, ctx, bkt, "k", "text/plain", []byte("v"), map[string]string{"a": "1"})
+
+	got, err := bkt.Object("k").Update(ctx, storage.ObjectAttrsToUpdate{
+		ContentType:  "application/json",
+		CacheControl: "public, max-age=60",
+		Metadata:     map[string]string{"a": "1", "b": "2"},
+	})
+	if err != nil {
+		t.Fatalf("Object.Update (patch) failed: %v", err)
+	}
+
+	if got.ContentType != "application/json" {
+		t.Errorf("ContentType = %q, want application/json", got.ContentType)
+	}
+
+	if got.CacheControl != "public, max-age=60" {
+		t.Errorf("CacheControl = %q, want public, max-age=60", got.CacheControl)
+	}
+
+	if got.Metadata["b"] != "2" {
+		t.Errorf("Metadata = %v, want b=2", got.Metadata)
+	}
+
+	if got.Metageneration < 2 {
+		t.Errorf("Metageneration = %d, want >= 2 after an update", got.Metageneration)
+	}
+}
+
+// TestGCSObjectCompose proves Objects: compose concatenates source bytes into a
+// destination (previously a 405).
+func TestGCSObjectCompose(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "compose")
+
+	putObject(t, ctx, bkt, "p1", "text/plain", []byte("foo"), nil)
+	putObject(t, ctx, bkt, "p2", "text/plain", []byte("bar"), nil)
+
+	comp := bkt.Object("combined").ComposerFrom(bkt.Object("p1"), bkt.Object("p2"))
+	comp.ContentType = "text/plain"
+
+	if _, err := comp.Run(ctx); err != nil {
+		t.Fatalf("compose failed: %v", err)
+	}
+
+	if got := readObject(t, ctx, bkt, "combined"); string(got) != "foobar" {
+		t.Errorf("composed object = %q, want foobar", got)
+	}
+}
+
+// TestGCSObjectVersionsList proves a versioning-enabled bucket retains prior
+// generations, so a Versions=true list returns every generation of a key.
+func TestGCSObjectVersionsList(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "versions")
+
+	if _, err := bkt.Update(ctx, storage.BucketAttrsToUpdate{VersioningEnabled: true}); err != nil {
+		t.Fatalf("enable versioning: %v", err)
+	}
+
+	putObject(t, ctx, bkt, "k", "text/plain", []byte("v1"), nil)
+	putObject(t, ctx, bkt, "k", "text/plain", []byte("v2"), nil)
+
+	it := bkt.Objects(ctx, &storage.Query{Versions: true})
+
+	var gens []int64
+
+	for {
+		a, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("versioned list: %v", err)
+		}
+
+		if a.Name == "k" {
+			gens = append(gens, a.Generation)
+		}
+	}
+
+	if len(gens) != 2 {
+		t.Fatalf("versioned list returned %d generations for k, want 2: %v", len(gens), gens)
+	}
+
+	if gens[0] == gens[1] {
+		t.Errorf("two retained generations share id %d", gens[0])
+	}
+}

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -21,9 +21,11 @@ package gcs
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -55,16 +57,29 @@ const (
 	pathBucket = 2
 	// pathBO is /b/{bucket}/o = 3 segments.
 	pathBO = 3
+
+	// subresIAM is the /b/{bucket}/iam sub-collection segment.
+	subresIAM = "iam"
+	// defaultLocation / defaultStorageClass are the GCS defaults a bucket reads
+	// back when none was set at create.
+	defaultLocation     = "US"
+	defaultStorageClass = "STANDARD"
 )
 
 // Handler serves GCS JSON REST requests against a storage.Bucket driver.
 type Handler struct {
 	bucket storagedriver.Bucket
+	// ext is the optional GCS-specific capability (nil when the backing driver
+	// doesn't implement it), covering preconditions, generation, compose,
+	// object patch, versioned listing, and bucket location/IAM/metageneration.
+	ext storagedriver.GCSExtensions
 }
 
 // New returns a GCS handler backed by b.
 func New(b storagedriver.Bucket) *Handler {
-	return &Handler{bucket: b}
+	ext, _ := b.(storagedriver.GCSExtensions)
+
+	return &Handler{bucket: b, ext: ext}
 }
 
 // Matches returns true for /storage/v1/, /upload/storage/v1/, and direct
@@ -151,22 +166,25 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case pathBucket:
 		h.bucketResource(w, r, parts[1])
 	case pathBO:
-		// /b/{bucket}/o — list objects
-		if parts[2] != "o" {
+		// /b/{bucket}/o — list objects; /b/{bucket}/iam — bucket IAM policy.
+		switch parts[2] {
+		case "o":
+			h.listObjects(w, r, parts[1])
+		case subresIAM:
+			h.bucketIAM(w, r, parts[1])
+		default:
 			writeError(w, http.StatusNotFound, "notFound", "unknown sub-collection")
-			return
 		}
-
-		h.listObjects(w, r, parts[1])
 	default:
-		// /b/{bucket}/o/{obj}[/...]
-		if parts[2] != "o" {
+		// /b/{bucket}/o/{obj}[/...] or /b/{bucket}/iam/testPermissions
+		switch {
+		case parts[2] == "o":
+			h.objectOp(w, r, parts[1], strings.Join(parts[3:], "/"))
+		case parts[2] == subresIAM && parts[3] == "testPermissions":
+			h.testIAMPermissions(w, r, parts[1])
+		default:
 			writeError(w, http.StatusNotFound, "notFound", "unknown sub-collection")
-			return
 		}
-
-		objAndRest := strings.Join(parts[3:], "/")
-		h.objectOp(w, r, parts[1], objAndRest)
 	}
 }
 
@@ -220,12 +238,15 @@ func (h *Handler) createBucket(w http.ResponseWriter, r *http.Request) {
 		_ = h.bucket.SetBucketVersioning(r.Context(), body.Name, true)
 	}
 
-	res := h.bucketView(r, body.Name, time.Now().UTC().Format(time.RFC3339))
-	if body.Location != "" {
-		res.Location = body.Location
+	if h.ext != nil {
+		_ = h.ext.SetBucketAttrsGCS(r.Context(), body.Name, body.Location, body.StorageClass)
 	}
 
-	writeJSON(w, http.StatusOK, res)
+	if body.Lifecycle != nil {
+		_ = h.bucket.PutLifecycleConfig(r.Context(), body.Name, toLifecycleConfig(body.Lifecycle))
+	}
+
+	writeJSON(w, http.StatusOK, h.bucketView(r, body.Name, time.Now().UTC().Format(time.RFC3339)))
 }
 
 func (h *Handler) listBuckets(w http.ResponseWriter, r *http.Request) {
@@ -237,14 +258,7 @@ func (h *Handler) listBuckets(w http.ResponseWriter, r *http.Request) {
 
 	out := bucketsListResponse{Kind: "storage#buckets"}
 	for _, b := range buckets {
-		out.Items = append(out.Items, bucketResource{
-			Kind:        "storage#bucket",
-			ID:          b.Name,
-			Name:        b.Name,
-			SelfLink:    selfLink(r, "/storage/v1/b/"+b.Name),
-			Location:    "US",
-			TimeCreated: b.CreatedAt,
-		})
+		out.Items = append(out.Items, h.bucketView(r, b.Name, b.CreatedAt))
 	}
 
 	writeJSON(w, http.StatusOK, out)
@@ -267,18 +281,26 @@ func (h *Handler) getBucket(w http.ResponseWriter, r *http.Request, name string)
 	writeError(w, http.StatusNotFound, "notFound", "bucket "+name+" not found")
 }
 
-// bucketView builds the bucket JSON with its configured versioning + labels
-// reflected (real GCS returns these; the driver stores them so a read must
-// surface them).
+// bucketView builds the bucket JSON with its configured versioning, labels,
+// location, storage class, lifecycle, IAM config, and metageneration/etag/
+// updated reflected — real GCS returns these, and the driver stores them so a
+// read must surface them instead of a hardcoded US/STANDARD default.
 func (h *Handler) bucketView(r *http.Request, name, created string) bucketResource {
+	location, storageClass, metageneration, updated := h.resolveBucketAttrs(r, name, created)
+
 	res := bucketResource{
-		Kind:         "storage#bucket",
-		ID:           name,
-		Name:         name,
-		SelfLink:     selfLink(r, "/storage/v1/b/"+name),
-		Location:     "US",
-		StorageClass: "STANDARD",
-		TimeCreated:  created,
+		Kind:             "storage#bucket",
+		ID:               name,
+		Name:             name,
+		SelfLink:         selfLink(r, "/storage/v1/b/"+name),
+		Location:         location,
+		LocationType:     locationType(location),
+		StorageClass:     storageClass,
+		Metageneration:   strconv.FormatInt(metageneration, 10),
+		Etag:             name + "/" + strconv.FormatInt(metageneration, 10),
+		TimeCreated:      created,
+		Updated:          updated,
+		IamConfiguration: &iamConfiguration{PublicAccessPrevention: "inherited"},
 	}
 
 	if enabled, err := h.bucket.GetBucketVersioning(r.Context(), name); err == nil && enabled {
@@ -289,7 +311,105 @@ func (h *Handler) bucketView(r *http.Request, name, created string) bucketResour
 		res.Labels = labels
 	}
 
+	if cfg, err := h.bucket.GetLifecycleConfig(r.Context(), name); err == nil && cfg != nil && len(cfg.Rules) > 0 {
+		res.Lifecycle = fromLifecycleConfig(cfg)
+	}
+
 	return res
+}
+
+// resolveBucketAttrs returns the bucket's location, storage class,
+// metageneration, and updated timestamp, falling back to the GCS defaults when
+// the backing driver doesn't record them.
+func (h *Handler) resolveBucketAttrs(
+	r *http.Request, name, created string,
+) (location, storageClass string, metageneration int64, updated string) {
+	location, storageClass, metageneration, updated = defaultLocation, defaultStorageClass, 1, created
+
+	if h.ext == nil {
+		return location, storageClass, metageneration, updated
+	}
+
+	attrs, err := h.ext.BucketAttrsGCS(r.Context(), name)
+	if err != nil {
+		return location, storageClass, metageneration, updated
+	}
+
+	if attrs.Location != "" {
+		location = attrs.Location
+	}
+
+	if attrs.StorageClass != "" {
+		storageClass = attrs.StorageClass
+	}
+
+	if attrs.Metageneration > 0 {
+		metageneration = attrs.Metageneration
+	}
+
+	if attrs.Updated != "" {
+		updated = attrs.Updated
+	}
+
+	return location, storageClass, metageneration, updated
+}
+
+// locationType classifies a GCS location as a multi-region or a region, which
+// real GCS reports in the locationType field.
+func locationType(location string) string {
+	switch strings.ToUpper(location) {
+	case "US", "EU", "ASIA":
+		return "multi-region"
+	default:
+		return "region"
+	}
+}
+
+// toLifecycleConfig converts the GCS lifecycle JSON into the driver's rule set.
+// Delete → object expiration; SetStorageClass → a class transition.
+func toLifecycleConfig(lc *bucketLifecycle) storagedriver.LifecycleConfig {
+	cfg := storagedriver.LifecycleConfig{Rules: make([]storagedriver.LifecycleRule, 0, len(lc.Rule))}
+
+	for i, r := range lc.Rule {
+		rule := storagedriver.LifecycleRule{
+			ID:      strconv.Itoa(i),
+			Enabled: true,
+		}
+
+		switch r.Action.Type {
+		case "Delete":
+			rule.ExpirationDays = r.Condition.Age
+		case "SetStorageClass":
+			rule.TransitionDays = r.Condition.Age
+			rule.TransitionStorageClass = r.Action.StorageClass
+		}
+
+		cfg.Rules = append(cfg.Rules, rule)
+	}
+
+	return cfg
+}
+
+// fromLifecycleConfig renders the driver's lifecycle rules back into GCS JSON.
+func fromLifecycleConfig(cfg *storagedriver.LifecycleConfig) *bucketLifecycle {
+	lc := &bucketLifecycle{Rule: make([]lifecycleRule, 0, len(cfg.Rules))}
+
+	for _, rule := range cfg.Rules {
+		switch {
+		case rule.TransitionStorageClass != "":
+			lc.Rule = append(lc.Rule, lifecycleRule{
+				Action:    lifecycleAction{Type: "SetStorageClass", StorageClass: rule.TransitionStorageClass},
+				Condition: lifecycleCondition{Age: rule.TransitionDays},
+			})
+		case rule.ExpirationDays > 0:
+			lc.Rule = append(lc.Rule, lifecycleRule{
+				Action:    lifecycleAction{Type: "Delete"},
+				Condition: lifecycleCondition{Age: rule.ExpirationDays},
+			})
+		}
+	}
+
+	return lc
 }
 
 // patchBucket applies a bucket configuration update (versioning + labels),
@@ -315,6 +435,21 @@ func (h *Handler) patchBucket(w http.ResponseWriter, r *http.Request, name strin
 		}
 	}
 
+	if body.Lifecycle != nil {
+		if err := h.bucket.PutLifecycleConfig(r.Context(), name, toLifecycleConfig(body.Lifecycle)); err != nil {
+			writeErr(w, err)
+			return
+		}
+	}
+
+	if h.ext != nil {
+		if body.StorageClass != "" {
+			_ = h.ext.SetBucketAttrsGCS(r.Context(), name, "", body.StorageClass)
+		}
+
+		_ = h.ext.TouchBucket(r.Context(), name)
+	}
+
 	writeJSON(w, http.StatusOK, h.bucketView(r, name, ""))
 }
 
@@ -325,6 +460,106 @@ func (h *Handler) deleteBucket(w http.ResponseWriter, r *http.Request, name stri
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// bucketIAM serves /b/{bucket}/iam — GET returns the bucket's IAM policy (a
+// default empty policy when none was set), PUT/POST replaces it.
+func (h *Handler) bucketIAM(w http.ResponseWriter, r *http.Request, name string) {
+	if !h.bucketExists(r, name) {
+		writeError(w, http.StatusNotFound, "notFound", "bucket "+name+" not found")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getBucketIAM(w, r, name)
+	case http.MethodPut, http.MethodPost:
+		h.setBucketIAM(w, r, name)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+	}
+}
+
+func (h *Handler) getBucketIAM(w http.ResponseWriter, r *http.Request, name string) {
+	if h.ext != nil {
+		if raw, err := h.ext.BucketIAMPolicy(r.Context(), name); err == nil {
+			writeRawJSON(w, raw)
+			return
+		}
+	}
+
+	writeJSON(w, http.StatusOK, defaultIAMPolicy(name))
+}
+
+func (h *Handler) setBucketIAM(w http.ResponseWriter, r *http.Request, name string) {
+	raw, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxPutBodyBytes))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid", "could not read body")
+		return
+	}
+
+	// Validate it is a JSON policy before storing.
+	var policy iamPolicyResource
+	if uErr := json.Unmarshal(raw, &policy); uErr != nil {
+		writeError(w, http.StatusBadRequest, "invalid", uErr.Error())
+		return
+	}
+
+	if h.ext != nil {
+		if sErr := h.ext.SetBucketIAMPolicy(r.Context(), name, raw); sErr != nil {
+			writeErr(w, sErr)
+			return
+		}
+	}
+
+	writeRawJSON(w, raw)
+}
+
+// testIAMPermissions serves /b/{bucket}/iam/testPermissions — the mock grants
+// every requested permission back.
+func (h *Handler) testIAMPermissions(w http.ResponseWriter, r *http.Request, name string) {
+	if !h.bucketExists(r, name) {
+		writeError(w, http.StatusNotFound, "notFound", "bucket "+name+" not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, testPermissionsResponse{
+		Kind:        "storage#testIamPermissionsResponse",
+		Permissions: r.URL.Query()["permissions"],
+	})
+}
+
+func (h *Handler) bucketExists(r *http.Request, name string) bool {
+	buckets, err := h.bucket.ListBuckets(r.Context())
+	if err != nil {
+		return false
+	}
+
+	for _, b := range buckets {
+		if b.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func defaultIAMPolicy(bucket string) iamPolicyResource {
+	return iamPolicyResource{
+		Kind:       "storage#policy",
+		ResourceID: "projects/_/buckets/" + bucket,
+		Version:    1,
+		Bindings:   []iamPolicyBind{},
+		Etag:       "CAE=",
+	}
+}
+
+func writeRawJSON(w http.ResponseWriter, raw []byte) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(http.StatusOK)
+	// raw is an IAM policy document validated as JSON before storage and served
+	// as application/json, not HTML — no XSS surface.
+	_, _ = w.Write(raw) //nolint:gosec // validated JSON policy, served as application/json
 }
 
 // upload handles POST /upload/storage/v1/b/{bucket}/o?uploadType=media&name={obj}.
@@ -354,6 +589,70 @@ func (h *Handler) upload(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// parsePrecondition extracts the GCS write preconditions from the request query
+// (ifGenerationMatch/ifGenerationNotMatch/ifMetagenerationMatch/
+// ifMetagenerationNotMatch). Each is a nil pointer when absent.
+func parsePrecondition(q url.Values) storagedriver.GCSPrecondition {
+	return storagedriver.GCSPrecondition{
+		IfGenerationMatch:        parseInt64Ptr(q.Get("ifGenerationMatch")),
+		IfGenerationNotMatch:     parseInt64Ptr(q.Get("ifGenerationNotMatch")),
+		IfMetagenerationMatch:    parseInt64Ptr(q.Get("ifMetagenerationMatch")),
+		IfMetagenerationNotMatch: parseInt64Ptr(q.Get("ifMetagenerationNotMatch")),
+	}
+}
+
+func parseInt64Ptr(s string) *int64 {
+	if s == "" {
+		return nil
+	}
+
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return nil
+	}
+
+	return &n
+}
+
+// storeObject writes an object through the preconditioned GCS path when the
+// backing driver supports it (returning a 412 on a failed precondition), else
+// falls back to the plain Bucket.PutObject.
+func (h *Handler) storeObject(
+	w http.ResponseWriter, r *http.Request, bucket, name, contentType string, data []byte, metadata map[string]string,
+) {
+	if h.ext != nil {
+		info, err := h.ext.PutObjectGCS(r.Context(), bucket, name, data, contentType, metadata, parsePrecondition(r.URL.Query()))
+		if err != nil {
+			var preErr *storagedriver.GCSPreconditionError
+			if errors.As(err, &preErr) {
+				writeError(w, http.StatusPreconditionFailed, "conditionNotMet", preErr.Error())
+				return
+			}
+
+			writeErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, http.StatusOK, toObjectResource(info, bucket, r))
+
+		return
+	}
+
+	if putErr := h.bucket.PutObject(r.Context(), bucket, name, data, contentType, metadata); putErr != nil {
+		writeErr(w, putErr)
+		return
+	}
+
+	info, err := h.bucket.HeadObject(r.Context(), bucket, name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toObjectResource(info, bucket, r))
+}
+
 func (h *Handler) uploadMedia(w http.ResponseWriter, r *http.Request, bucket, name string) {
 	if name == "" {
 		writeError(w, http.StatusBadRequest, "invalid", "name query parameter required")
@@ -373,18 +672,7 @@ func (h *Handler) uploadMedia(w http.ResponseWriter, r *http.Request, bucket, na
 		contentType = contentTypeBinary
 	}
 
-	if putErr := h.bucket.PutObject(r.Context(), bucket, name, data, contentType, nil); putErr != nil {
-		writeErr(w, putErr)
-		return
-	}
-
-	info, err := h.bucket.HeadObject(r.Context(), bucket, name)
-	if err != nil {
-		writeErr(w, err)
-		return
-	}
-
-	writeJSON(w, http.StatusOK, toObjectResource(info, bucket, r))
+	h.storeObject(w, r, bucket, name, contentType, data, nil)
 }
 
 // uploadMultipart parses a multipart/related body where the first part is a
@@ -421,18 +709,7 @@ func (h *Handler) uploadMultipart(w http.ResponseWriter, r *http.Request, bucket
 		payloadCT = contentTypeBinary
 	}
 
-	if putErr := h.bucket.PutObject(r.Context(), bucket, meta.Name, payload, payloadCT, meta.Metadata); putErr != nil {
-		writeErr(w, putErr)
-		return
-	}
-
-	info, err := h.bucket.HeadObject(r.Context(), bucket, meta.Name)
-	if err != nil {
-		writeErr(w, err)
-		return
-	}
-
-	writeJSON(w, http.StatusOK, toObjectResource(info, bucket, r))
+	h.storeObject(w, r, bucket, meta.Name, payloadCT, payload, meta.Metadata)
 }
 
 func (h *Handler) listObjects(w http.ResponseWriter, r *http.Request, bucket string) {
@@ -458,7 +735,14 @@ func (h *Handler) listObjects(w http.ResponseWriter, r *http.Request, bucket str
 		PageToken: q.Get("pageToken"),
 	}
 
-	result, err := h.bucket.ListObjects(r.Context(), bucket, opts)
+	// versions=true lists every generation (current + archived), not just the
+	// live objects — real GCS retains prior generations on a versioned bucket.
+	listFn := h.bucket.ListObjects
+	if q.Get("versions") == "true" && h.ext != nil {
+		listFn = h.ext.ListObjectGenerations
+	}
+
+	result, err := listFn(r.Context(), bucket, opts)
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -478,14 +762,21 @@ func (h *Handler) listObjects(w http.ResponseWriter, r *http.Request, bucket str
 }
 
 func (h *Handler) objectOp(w http.ResponseWriter, r *http.Request, bucket, objAndRest string) {
-	// Detect rewriteTo / copyTo sub-resources, e.g. "k1/rewriteTo/b/dstb/o/dstk"
+	// Detect rewriteTo / copyTo / compose sub-resources, e.g.
+	// "k1/rewriteTo/b/dstb/o/dstk" or "dst/compose".
 	parts := strings.Split(objAndRest, "/")
 
 	for i, p := range parts {
-		if p == "rewriteTo" || p == "copyTo" {
-			obj := strings.Join(parts[:i], "/")
-			h.copyObject(w, r, bucket, obj, parts[i+1:])
+		if i == 0 {
+			continue // the object key itself is never a sub-resource verb
+		}
 
+		switch p {
+		case "rewriteTo", "copyTo":
+			h.copyObject(w, r, bucket, strings.Join(parts[:i], "/"), parts[i+1:])
+			return
+		case "compose":
+			h.composeObject(w, r, bucket, strings.Join(parts[:i], "/"))
 			return
 		}
 	}
@@ -498,11 +789,87 @@ func (h *Handler) objectOp(w http.ResponseWriter, r *http.Request, bucket, objAn
 		}
 
 		h.getObjectMetadata(w, r, bucket, objAndRest)
+	case http.MethodPatch, http.MethodPut:
+		h.updateObject(w, r, bucket, objAndRest)
 	case http.MethodDelete:
 		h.deleteObject(w, r, bucket, objAndRest)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
 	}
+}
+
+// updateObject handles PATCH/PUT /b/{bucket}/o/{obj} — an Objects: patch/update
+// that mutates system properties and/or custom metadata without touching data.
+func (h *Handler) updateObject(w http.ResponseWriter, r *http.Request, bucket, key string) {
+	if h.ext == nil {
+		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "object update not supported")
+		return
+	}
+
+	var body objectPatchBody
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	info, err := h.ext.UpdateObjectGCS(r.Context(), bucket, key, storagedriver.GCSObjectUpdate{
+		ContentType:        body.ContentType,
+		CacheControl:       body.CacheControl,
+		ContentEncoding:    body.ContentEncoding,
+		ContentDisposition: body.ContentDisposition,
+		ContentLanguage:    body.ContentLanguage,
+		Metadata:           body.Metadata,
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toObjectResource(info, bucket, r))
+}
+
+// composeObject handles POST /b/{bucket}/o/{dst}/compose — concatenating the
+// named source objects' bytes into the destination.
+func (h *Handler) composeObject(w http.ResponseWriter, r *http.Request, bucket, dstKey string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+		return
+	}
+
+	if h.ext == nil {
+		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "compose not supported")
+		return
+	}
+
+	var body composeRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	srcKeys := make([]string, 0, len(body.SourceObjects))
+	for _, s := range body.SourceObjects {
+		srcKeys = append(srcKeys, s.Name)
+	}
+
+	contentType := ""
+	if body.Destination != nil {
+		contentType = body.Destination.ContentType
+	}
+
+	info, err := h.ext.ComposeObjectGCS(r.Context(), bucket, dstKey, srcKeys, contentType, destinationMetadata(body.Destination))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toObjectResource(info, bucket, r))
+}
+
+func destinationMetadata(dst *objectResource) map[string]string {
+	if dst == nil {
+		return nil
+	}
+
+	return dst.Metadata
 }
 
 func (h *Handler) getObjectMetadata(w http.ResponseWriter, r *http.Request, bucket, key string) {
@@ -611,22 +978,40 @@ func (h *Handler) copyObject(w http.ResponseWriter, r *http.Request, srcBucket, 
 }
 
 func toObjectResource(info *storagedriver.ObjectInfo, bucket string, r *http.Request) objectResource {
+	generation := info.Generation
+	if generation == 0 {
+		generation = 1
+	}
+
+	metageneration := info.Metageneration
+	if metageneration == 0 {
+		metageneration = 1
+	}
+
+	genStr := strconv.FormatInt(generation, 10)
+
 	return objectResource{
-		Kind:           "storage#object",
-		ID:             bucket + "/" + info.Key + "/1",
-		Name:           info.Key,
-		Bucket:         bucket,
-		Generation:     "1",
-		Metageneration: "1",
-		ContentType:    info.ContentType,
-		Size:           strconv.FormatInt(info.Size, 10),
-		ETag:           info.ETag,
-		StorageClass:   "STANDARD",
-		TimeCreated:    info.LastModified,
-		Updated:        info.LastModified,
-		Metadata:       info.Metadata,
-		SelfLink:       selfLink(r, "/storage/v1/b/"+bucket+"/o/"+info.Key),
-		MediaLink:      selfLink(r, "/storage/v1/b/"+bucket+"/o/"+info.Key+"?alt=media"),
+		Kind:               "storage#object",
+		ID:                 bucket + "/" + info.Key + "/" + genStr,
+		Name:               info.Key,
+		Bucket:             bucket,
+		Generation:         genStr,
+		Metageneration:     strconv.FormatInt(metageneration, 10),
+		ContentType:        info.ContentType,
+		Size:               strconv.FormatInt(info.Size, 10),
+		MD5Hash:            info.MD5,
+		CRC32C:             info.CRC32C,
+		ETag:               info.ETag,
+		StorageClass:       "STANDARD",
+		CacheControl:       info.CacheControl,
+		ContentEncoding:    info.ContentEncoding,
+		ContentDisposition: info.ContentDisposition,
+		ContentLanguage:    info.ContentLanguage,
+		TimeCreated:        info.LastModified,
+		Updated:            info.LastModified,
+		Metadata:           info.Metadata,
+		SelfLink:           selfLink(r, "/storage/v1/b/"+bucket+"/o/"+info.Key),
+		MediaLink:          selfLink(r, "/storage/v1/b/"+bucket+"/o/"+info.Key+"?alt=media"),
 	}
 }
 

--- a/server/gcp/gcs/types.go
+++ b/server/gcp/gcs/types.go
@@ -4,18 +4,51 @@ package gcs
 // Names map directly to the wire format the SDK expects.
 
 type bucketResource struct {
-	Kind         string            `json:"kind"`
-	ID           string            `json:"id"`
-	Name         string            `json:"name"`
-	SelfLink     string            `json:"selfLink,omitempty"`
-	Location     string            `json:"location,omitempty"`
-	StorageClass string            `json:"storageClass,omitempty"`
-	Versioning   *bucketVersioning `json:"versioning,omitempty"`
-	Labels       map[string]string `json:"labels,omitempty"`
-	TimeCreated  string            `json:"timeCreated,omitempty"`
+	Kind             string            `json:"kind"`
+	ID               string            `json:"id"`
+	Name             string            `json:"name"`
+	SelfLink         string            `json:"selfLink,omitempty"`
+	Location         string            `json:"location,omitempty"`
+	LocationType     string            `json:"locationType,omitempty"`
+	StorageClass     string            `json:"storageClass,omitempty"`
+	Versioning       *bucketVersioning `json:"versioning,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	Lifecycle        *bucketLifecycle  `json:"lifecycle,omitempty"`
+	IamConfiguration *iamConfiguration `json:"iamConfiguration,omitempty"`
+	Metageneration   string            `json:"metageneration,omitempty"`
+	Etag             string            `json:"etag,omitempty"`
+	TimeCreated      string            `json:"timeCreated,omitempty"`
+	Updated          string            `json:"updated,omitempty"`
 }
 
 type bucketVersioning struct {
+	Enabled bool `json:"enabled"`
+}
+
+type bucketLifecycle struct {
+	Rule []lifecycleRule `json:"rule"`
+}
+
+type lifecycleRule struct {
+	Action    lifecycleAction    `json:"action"`
+	Condition lifecycleCondition `json:"condition"`
+}
+
+type lifecycleAction struct {
+	Type         string `json:"type"`
+	StorageClass string `json:"storageClass,omitempty"`
+}
+
+type lifecycleCondition struct {
+	Age int `json:"age,omitempty"`
+}
+
+type iamConfiguration struct {
+	UniformBucketLevelAccess *uniformBucketLevelAccess `json:"uniformBucketLevelAccess,omitempty"`
+	PublicAccessPrevention   string                    `json:"publicAccessPrevention,omitempty"`
+}
+
+type uniformBucketLevelAccess struct {
 	Enabled bool `json:"enabled"`
 }
 
@@ -25,22 +58,27 @@ type bucketsListResponse struct {
 }
 
 type objectResource struct {
-	Kind           string            `json:"kind"`
-	ID             string            `json:"id"`
-	Name           string            `json:"name"`
-	Bucket         string            `json:"bucket"`
-	Generation     string            `json:"generation"`
-	Metageneration string            `json:"metageneration"`
-	ContentType    string            `json:"contentType,omitempty"`
-	Size           string            `json:"size"`
-	MD5Hash        string            `json:"md5Hash,omitempty"`
-	ETag           string            `json:"etag,omitempty"`
-	StorageClass   string            `json:"storageClass,omitempty"`
-	TimeCreated    string            `json:"timeCreated,omitempty"`
-	Updated        string            `json:"updated,omitempty"`
-	Metadata       map[string]string `json:"metadata,omitempty"`
-	SelfLink       string            `json:"selfLink,omitempty"`
-	MediaLink      string            `json:"mediaLink,omitempty"`
+	Kind               string            `json:"kind"`
+	ID                 string            `json:"id"`
+	Name               string            `json:"name"`
+	Bucket             string            `json:"bucket"`
+	Generation         string            `json:"generation"`
+	Metageneration     string            `json:"metageneration"`
+	ContentType        string            `json:"contentType,omitempty"`
+	Size               string            `json:"size"`
+	MD5Hash            string            `json:"md5Hash,omitempty"`
+	CRC32C             string            `json:"crc32c,omitempty"`
+	ETag               string            `json:"etag,omitempty"`
+	StorageClass       string            `json:"storageClass,omitempty"`
+	CacheControl       string            `json:"cacheControl,omitempty"`
+	ContentEncoding    string            `json:"contentEncoding,omitempty"`
+	ContentDisposition string            `json:"contentDisposition,omitempty"`
+	ContentLanguage    string            `json:"contentLanguage,omitempty"`
+	TimeCreated        string            `json:"timeCreated,omitempty"`
+	Updated            string            `json:"updated,omitempty"`
+	Metadata           map[string]string `json:"metadata,omitempty"`
+	SelfLink           string            `json:"selfLink,omitempty"`
+	MediaLink          string            `json:"mediaLink,omitempty"`
 }
 
 type objectsListResponse struct {
@@ -48,6 +86,49 @@ type objectsListResponse struct {
 	Items         []objectResource `json:"items"`
 	Prefixes      []string         `json:"prefixes,omitempty"`
 	NextPageToken string           `json:"nextPageToken,omitempty"`
+}
+
+// objectPatchBody is the Objects: patch/update request. Pointer fields let the
+// handler tell "field absent" from "field set to empty"; metadata values are
+// pointers so a null entry deletes that custom-metadata key (GCS merge patch).
+type objectPatchBody struct {
+	ContentType        *string            `json:"contentType"`
+	CacheControl       *string            `json:"cacheControl"`
+	ContentEncoding    *string            `json:"contentEncoding"`
+	ContentDisposition *string            `json:"contentDisposition"`
+	ContentLanguage    *string            `json:"contentLanguage"`
+	Metadata           map[string]*string `json:"metadata"`
+}
+
+// composeRequest is the Objects: compose request body.
+type composeRequest struct {
+	SourceObjects []composeSource `json:"sourceObjects"`
+	Destination   *objectResource `json:"destination,omitempty"`
+}
+
+type composeSource struct {
+	Name       string `json:"name"`
+	Generation int64  `json:"generation,omitempty"`
+}
+
+// iamPolicyResource is the storage#policy document (Buckets: get/setIamPolicy).
+type iamPolicyResource struct {
+	Kind       string          `json:"kind"`
+	ResourceID string          `json:"resourceId"`
+	Version    int             `json:"version"`
+	Bindings   []iamPolicyBind `json:"bindings"`
+	Etag       string          `json:"etag"`
+}
+
+type iamPolicyBind struct {
+	Role    string   `json:"role"`
+	Members []string `json:"members"`
+}
+
+// testPermissionsResponse is the Buckets: testIamPermissions response.
+type testPermissionsResponse struct {
+	Kind        string   `json:"kind"`
+	Permissions []string `json:"permissions"`
 }
 
 type errorEnvelope struct {

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -301,6 +301,27 @@ type ObjectInfo struct {
 	// AccessTier is the Azure blob access tier (Hot/Cool/Cold/Archive), set by
 	// Set Blob Tier. Empty when unset; non-Azure providers leave it empty.
 	AccessTier string
+	// Generation is the GCS object generation — a unique, monotonically
+	// increasing id minted on every write of the object's data. Zero for
+	// providers that don't model generations (S3/Azure).
+	Generation int64
+	// Metageneration is the GCS object metageneration — starts at 1 for each
+	// generation and increments on each metadata-only update. Zero for
+	// non-GCS providers.
+	Metageneration int64
+	// MD5 is the base64-encoded MD5 digest of the object bytes (GCS md5Hash).
+	// Empty for providers that don't compute it.
+	MD5 string
+	// CRC32C is the base64-encoded big-endian CRC32C (Castagnoli) of the object
+	// bytes (GCS crc32c). Empty for providers that don't compute it.
+	CRC32C string
+	// CacheControl / ContentEncoding / ContentDisposition / ContentLanguage are
+	// GCS/S3 system object properties, settable via an object metadata update.
+	// Empty when unset.
+	CacheControl       string
+	ContentEncoding    string
+	ContentDisposition string
+	ContentLanguage    string
 }
 
 // Object is an object with its data.
@@ -601,4 +622,95 @@ type Bucket interface {
 	PutBucketTagging(ctx context.Context, bucket string, tags map[string]string) error
 	GetBucketTagging(ctx context.Context, bucket string) (map[string]string, error)
 	DeleteBucketTagging(ctx context.Context, bucket string) error
+}
+
+// GCSPrecondition carries the GCS write preconditions
+// (ifGenerationMatch/ifGenerationNotMatch/ifMetagenerationMatch/
+// ifMetagenerationNotMatch query parameters). A nil pointer means the caller
+// did not send that precondition. ifGenerationMatch == 0 means "the object must
+// not already exist" (create-if-absent).
+type GCSPrecondition struct {
+	IfGenerationMatch        *int64
+	IfGenerationNotMatch     *int64
+	IfMetagenerationMatch    *int64
+	IfMetagenerationNotMatch *int64
+}
+
+// GCSPreconditionError signals a failed GCS write precondition. Real GCS answers
+// with 412 Precondition Failed and reason "conditionNotMet", which does NOT map
+// to the canonical FailedPrecondition→409 the storage wire layer uses elsewhere,
+// so providers return this typed error and the GCS handler matches it with
+// errors.As to emit the exact 412 response.
+type GCSPreconditionError struct {
+	Message string
+}
+
+func (e *GCSPreconditionError) Error() string {
+	if e.Message == "" {
+		return "conditionNotMet"
+	}
+
+	return e.Message
+}
+
+// GCSObjectUpdate carries the mutable properties an Objects: patch/update sets.
+// A nil pointer field leaves that property unchanged; a nil Metadata map leaves
+// custom metadata unchanged, while a non-nil map is merged (a nil value deletes
+// that key).
+type GCSObjectUpdate struct {
+	ContentType        *string
+	CacheControl       *string
+	ContentEncoding    *string
+	ContentDisposition *string
+	ContentLanguage    *string
+	Metadata           map[string]*string
+}
+
+// GCSBucketMeta are the GCS-specific bucket attributes the shared BucketInfo
+// doesn't carry: multi-region/region location, default storage class, and the
+// metageneration/updated pair that back etag/ifMetagenerationMatch concurrency.
+type GCSBucketMeta struct {
+	Location       string
+	StorageClass   string
+	Metageneration int64
+	Updated        string
+}
+
+// GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type
+// assertion (like VersionedBucket). It persists GCS bucket/object behaviors the
+// shared Bucket interface can't express: preconditioned writes with generation
+// minting, object metadata patch, server-side compose, versioned (all-
+// generation) listing, and bucket location/storageClass/IAM + metageneration.
+// S3/Azure don't implement it and keep their own semantics.
+type GCSExtensions interface {
+	// PutObjectGCS writes an object honoring pre (a failed condition returns a
+	// *GCSPreconditionError) and returns the stored object's info with the newly
+	// minted generation.
+	PutObjectGCS(
+		ctx context.Context, bucket, key string, data []byte, contentType string, metadata map[string]string, pre GCSPrecondition,
+	) (*ObjectInfo, error)
+	// UpdateObjectGCS mutates an existing object's system properties and/or
+	// custom metadata without touching its data, bumping metageneration.
+	UpdateObjectGCS(ctx context.Context, bucket, key string, upd GCSObjectUpdate) (*ObjectInfo, error)
+	// ComposeObjectGCS concatenates the source objects' bytes (in order) into
+	// dstKey, minting a new generation for the destination.
+	ComposeObjectGCS(
+		ctx context.Context, bucket, dstKey string, srcKeys []string, contentType string, metadata map[string]string,
+	) (*ObjectInfo, error)
+	// ListObjectGenerations returns every generation (current + archived) of the
+	// objects matching opts, for a versions=true listing.
+	ListObjectGenerations(ctx context.Context, bucket string, opts ListOptions) (*ListResult, error)
+
+	// SetBucketAttrsGCS records the bucket's location and default storage class
+	// (empty values leave the current value unchanged).
+	SetBucketAttrsGCS(ctx context.Context, bucket, location, storageClass string) error
+	// BucketAttrsGCS returns the bucket's GCS-specific attributes.
+	BucketAttrsGCS(ctx context.Context, bucket string) (GCSBucketMeta, error)
+	// TouchBucket bumps the bucket's metageneration and updated timestamp,
+	// called after any bucket configuration change.
+	TouchBucket(ctx context.Context, bucket string) error
+	// SetBucketIAMPolicy / BucketIAMPolicy persist and return the bucket's IAM
+	// policy document verbatim (Buckets: setIamPolicy / getIamPolicy).
+	SetBucketIAMPolicy(ctx context.Context, bucket string, policyJSON []byte) error
+	BucketIAMPolicy(ctx context.Context, bucket string) ([]byte, error)
 }


### PR DESCRIPTION
## What

Fixes the GCS JSON API behaviors an unmodified `cloud.google.com/go/storage` client hits, from the AUDIT_GCP.md `## gcs` batch. All GCS-specific state lives behind a new optional `driver.GCSExtensions` capability discovered by type assertion, so the shared `Bucket` interface and the AWS S3 / Azure Blob providers are untouched.

## Why

The GCS handler previously ignored write preconditions, hardcoded object generation/metageneration to `"1"`, returned no checksums, dropped versioned listings, 405'd object patch/compose, 404'd bucket IAM, dropped lifecycle rules on patch, and reported a fixed US/STANDARD location. These break create-if-absent, distributed locks, optimistic concurrency, versioning, download integrity, `google_storage_bucket_iam_*`, and cause perpetual Terraform drift.

## Findings fixed (all 10 in the `## gcs` section)

- objects.insert preconditions — honor `ifGenerationMatch`/`ifGenerationNotMatch`/`ifMetagenerationMatch`/`ifMetagenerationNotMatch`; failed condition → 412 `conditionNotMet` (create-if-absent + locks work).
- objects.insert generation — mint a unique, monotonically increasing generation per write; per-generation metageneration.
- objects.Attrs checksums — return `md5Hash` and `crc32c`.
- objects.list `versions=true` — retain prior generations on a versioning-enabled bucket and list them.
- objects.patch/update — mutate contentType/cacheControl/content-encoding/disposition/language/metadata, bump metageneration (was 405).
- objects.compose — concatenate source bytes into the destination (was 405).
- buckets IAM — `/b/{bucket}/iam` get/set/testPermissions (was 404).
- buckets.patch lifecycle — persist lifecycle rules and round-trip them on read.
- buckets.get location/storageClass — round-trip the create-time values instead of hardcoded US/STANDARD.
- buckets.get metageneration/etag/updated/locationType/iamConfiguration — returned.

## 3-layer placement

- `services/storage/driver`: additive `ObjectInfo` fields + new optional `GCSExtensions` interface, `GCSPrecondition`, `GCSPreconditionError`, `GCSObjectUpdate`, `GCSBucketMeta`.
- `providers/gcp/gcs`: implementation + snapshot round-trip of the new fields.
- `server/gcp/gcs`: wire routing (`/iam`, compose, PATCH/PUT), preconditions → 412, versioned listing, richer bucket/object JSON.

## Tests

Real-SDK reproduction tests (in-process GCP server via `option.WithEndpoint`) proving each finding: `gcs_object_semantics_test.go`, `gcs_bucket_semantics_test.go`. Existing GCS tests stay green.

## Docs

Regenerated `docs/coverage` (`go generate ./...`) — `GCSExtensions` now listed as an optional storage capability.

## Deferrals

None.
