### PR TITLE
fix(gcp-pubsub): fan-out, extended sub fields, modifyAckDeadline/seek/snapshots/IAM, ordering key, publishTime, pagination

### DIFF
--- a/server/gcp/pubsub/handler.go
+++ b/server/gcp/pubsub/handler.go
@@ -1,41 +1,34 @@
 // Package pubsub implements the GCP Pub/Sub v1 REST API as a server.Handler.
-// Real google.golang.org/api/pubsub/v1 clients configured with a custom
-// endpoint hit this handler the same way they hit pubsub.googleapis.com.
+// Real google.golang.org/api/pubsub/v1 and cloud.google.com/go/pubsub clients
+// configured with a custom endpoint hit this handler the same way they hit
+// pubsub.googleapis.com.
 //
-// MVP coverage:
+// Coverage:
 //
-//	PUT    /v1/projects/{p}/topics/{name}                  — Create
-//	GET    /v1/projects/{p}/topics/{name}                  — Get
-//	GET    /v1/projects/{p}/topics                         — List
-//	DELETE /v1/projects/{p}/topics/{name}                  — Delete
-//	POST   /v1/projects/{p}/topics/{name}:publish          — Publish
-//	PUT    /v1/projects/{p}/subscriptions/{name}           — Create
-//	GET    /v1/projects/{p}/subscriptions/{name}           — Get
-//	GET    /v1/projects/{p}/subscriptions                  — List
-//	DELETE /v1/projects/{p}/subscriptions/{name}           — Delete
-//	POST   /v1/projects/{p}/subscriptions/{name}:pull      — Pull
-//	POST   /v1/projects/{p}/subscriptions/{name}:acknowledge — Ack
+//	topics       create/get/list/delete/publish, getIamPolicy/setIamPolicy/testIamPermissions,
+//	             topics.subscriptions.list, topics.snapshots.list
+//	subscriptions create/get/list/delete, pull/acknowledge/modifyAckDeadline/
+//	             modifyPushConfig/seek, getIamPolicy/setIamPolicy/testIamPermissions
+//	snapshots    create/get/list/delete
 //
-// The portable messagequeue driver pairs a topic and subscription under a
-// single queue keyed by name. SDK-compat reflects this: a subscription's
-// "topic" must point at a topic with the same trailing name. Cross-name
-// subscriptions (sub "billing-events" linked to topic "events") are not
-// modeled in the MVP.
+// Topic existence and labels are backed by the portable messagequeue driver;
+// Pub/Sub-native delivery (independent fan-out per subscription, publish-time
+// stamping, ordering keys, snapshots, seek, IAM) is modeled in this handler
+// because that behavior does not map onto the SQS-style driver.
 package pubsub
 
 import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
-	"sort"
+	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
 )
 
@@ -44,47 +37,27 @@ const (
 
 	resTopics        = "topics"
 	resSubscriptions = "subscriptions"
+	resSnapshots     = "snapshots"
+
+	verbGetIamPolicy       = "getIamPolicy"
+	verbSetIamPolicy       = "setIamPolicy"
+	verbTestIamPermissions = "testIamPermissions"
+
+	reasonNotFound         = "NOT_FOUND"
+	reasonInvalidArgument  = "INVALID_ARGUMENT"
+	reasonMethodNotAllowed = "METHOD_NOT_ALLOWED"
+	reasonAlreadyExists    = "ALREADY_EXISTS"
+	reasonInternal         = "INTERNAL"
 
 	contentTypeJSON = "application/json"
 	maxBodyBytes    = 5 << 20
 
-	// Path-segment counts used to dispatch by URL shape.
 	partsTypeOnly = 2 // /v1/projects/{p}/{type}
 	partsResource = 3 // /v1/projects/{p}/{type}/{name}
+	partsNested   = 4 // /v1/projects/{p}/{type}/{name}/{subtype}
 )
 
-// Handler serves Pub/Sub v1 REST requests against a messagequeue driver.
-//
-// The portable messagequeue driver has one queue per topic and no separate
-// subscription concept, so subscription identity + metadata (its topic,
-// ackDeadline, labels) is tracked here. Messages still live in the topic's
-// queue; a subscription resolves to that queue for pull/ack. This lets a
-// subscription carry a name distinct from its topic. (Multiple subscriptions
-// on one topic share the single underlying queue rather than each getting an
-// independent copy — a documented emulator simplification.)
-type Handler struct {
-	mq mqdriver.MessageQueue
-
-	mu   sync.RWMutex
-	subs map[string]*subMeta // keyed by subscription short-name
-}
-
-// subMeta is the per-subscription metadata the driver can't hold.
-type subMeta struct {
-	topic       string // topic short-name whose queue backs this subscription
-	ackDeadline int
-	labels      map[string]string
-}
-
-// New returns a Pub/Sub handler backed by mq.
-func New(mq mqdriver.MessageQueue) *Handler {
-	return &Handler{mq: mq, subs: make(map[string]*subMeta)}
-}
-
-// Matches accepts /v1/projects/{p}/topics[...] and /v1/projects/{p}/subscriptions[...].
-// The resource-type guard prevents this handler from claiming Cloud Functions
-// (locations/functions) or Firestore (databases) URLs that share the same
-// /v1/projects/ prefix.
+// Matches accepts /v1/projects/{p}/{topics|subscriptions|snapshots}[...].
 func (*Handler) Matches(r *http.Request) bool {
 	if !strings.HasPrefix(r.URL.Path, pathPrefix) {
 		return false
@@ -95,49 +68,41 @@ func (*Handler) Matches(r *http.Request) bool {
 		return false
 	}
 
-	// parts[1] is "topics" or "subscriptions" (possibly with :action suffix).
-	t := parts[1]
-	if i := strings.Index(t, ":"); i >= 0 {
-		t = t[:i]
-	}
+	t, _ := splitColon(parts[1])
 
-	return t == resTopics || t == resSubscriptions
+	return t == resTopics || t == resSubscriptions || t == resSnapshots
 }
 
 // ServeHTTP routes by URL shape.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	parts := splitPath(r.URL.Path)
 	if len(parts) < partsTypeOnly {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "unsupported path")
+		writeError(w, http.StatusNotFound, reasonNotFound, "unsupported path")
 		return
 	}
 
 	project := parts[0]
-	resType := parts[1]
+	bareType, typeAction := splitColon(parts[1])
 
-	// Strip ":action" from the type for the bare-collection match.
-	bareType, action := resType, ""
-	if i := strings.Index(resType, ":"); i >= 0 {
-		bareType = resType[:i]
-		action = resType[i+1:]
-	}
+	if len(parts) == partsTypeOnly {
+		if typeAction != "" {
+			writeError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "method not allowed")
+			return
+		}
 
-	if len(parts) == partsTypeOnly && action == "" {
-		// /v1/projects/{p}/{topics|subscriptions}
 		h.serveCollection(w, r, project, bareType)
+
 		return
 	}
 
-	// Resource-level: /v1/projects/{p}/{type}/{name}[:action]
-	if len(parts) < partsResource {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "missing resource name")
-		return
-	}
+	name, action := splitColon(parts[2])
 
-	name := parts[2]
-	if i := strings.Index(name, ":"); i >= 0 {
-		action = name[i+1:]
-		name = name[:i]
+	// 4-segment nested collections: topics/{t}/subscriptions|snapshots.
+	if len(parts) >= partsNested {
+		sub, _ := splitColon(parts[3])
+		h.serveNested(w, r, project, bareType, name, sub)
+
+		return
 	}
 
 	switch bareType {
@@ -145,71 +110,57 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.serveTopic(w, r, project, name, action)
 	case resSubscriptions:
 		h.serveSubscription(w, r, project, name, action)
+	case resSnapshots:
+		h.serveSnapshot(w, r, project, name, action)
 	default:
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown resource type: "+bareType)
+		writeError(w, http.StatusNotFound, reasonNotFound, "unknown resource type: "+bareType)
 	}
 }
 
 func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, project, resType string) {
 	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
-		return
-	}
-
-	queues, err := h.mq.ListQueues(r.Context(), "")
-	if err != nil {
-		writeErr(w, err)
+		writeError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "method not allowed")
 		return
 	}
 
 	switch resType {
 	case resTopics:
-		out := listTopicsResponse{Topics: make([]topic, 0, len(queues))}
-		for i := range queues {
-			out.Topics = append(out.Topics, topic{
-				Name: topicName(project, queues[i].Name),
-			})
-		}
-
-		writeJSON(w, http.StatusOK, out)
+		h.listTopics(w, r, project)
 	case resSubscriptions:
-		// List from the subscription registry (not one phantom sub per queue),
-		// so distinct sub/topic names and their ackDeadline/labels round-trip.
-		// Emit in sorted name order: Go map iteration is randomized, and the
-		// repo's list endpoints are deterministic.
-		h.mu.RLock()
-		subNames := make([]string, 0, len(h.subs))
-
-		for subName := range h.subs {
-			subNames = append(subNames, subName)
-		}
-
-		sort.Strings(subNames)
-
-		out := listSubscriptionsResponse{Subscriptions: make([]subscription, 0, len(subNames))}
-
-		for _, subName := range subNames {
-			meta := h.subs[subName]
-			out.Subscriptions = append(out.Subscriptions, subscription{
-				Name:               subscriptionName(project, subName),
-				Topic:              topicName(project, meta.topic),
-				AckDeadlineSeconds: meta.ackDeadline,
-				Labels:             meta.labels,
-			})
-		}
-		h.mu.RUnlock()
-
-		writeJSON(w, http.StatusOK, out)
+		h.listSubscriptions(w, r, project)
+	case resSnapshots:
+		h.listSnapshots(w, r, project)
 	default:
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown collection type")
+		writeError(w, http.StatusNotFound, reasonNotFound, "unknown collection type")
+	}
+}
+
+// serveNested handles topics/{t}/subscriptions and topics/{t}/snapshots list.
+func (h *Handler) serveNested(w http.ResponseWriter, r *http.Request, project, bareType, name, sub string) {
+	if bareType != resTopics || r.Method != http.MethodGet {
+		writeError(w, http.StatusNotFound, reasonNotFound, "unsupported nested path")
+		return
+	}
+
+	switch sub {
+	case resSubscriptions:
+		h.listTopicSubscriptions(w, r, project, name)
+	case resSnapshots:
+		h.listTopicSnapshots(w, project, name)
+	default:
+		writeError(w, http.StatusNotFound, reasonNotFound, "unsupported nested collection: "+sub)
 	}
 }
 
 // ---------- Topics ----------
 
 func (h *Handler) serveTopic(w http.ResponseWriter, r *http.Request, project, name, action string) {
-	if action == "publish" {
-		h.publish(w, r, project, name)
+	switch action {
+	case "publish":
+		h.publish(w, r, name)
+		return
+	case verbGetIamPolicy, verbSetIamPolicy, verbTestIamPermissions:
+		h.serveIam(w, r, resTopics, name, action)
 		return
 	}
 
@@ -219,18 +170,16 @@ func (h *Handler) serveTopic(w http.ResponseWriter, r *http.Request, project, na
 	case http.MethodGet:
 		h.getTopic(w, r, project, name)
 	case http.MethodDelete:
-		h.deleteTopic(w, r, project, name)
+		h.deleteTopic(w, r, name)
 	default:
-		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		writeError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "method not allowed")
 	}
 }
 
 func (h *Handler) createTopic(w http.ResponseWriter, r *http.Request, project, name string) {
-	// Real Pub/Sub createTopic accepts an empty body, so tolerate EOF/empty
-	// rather than 400ing on a bodyless request.
 	var body topic
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, reasonInvalidArgument, "invalid JSON: "+err.Error())
 		return
 	}
 
@@ -239,6 +188,10 @@ func (h *Handler) createTopic(w http.ResponseWriter, r *http.Request, project, n
 		writeErr(w, err)
 		return
 	}
+
+	h.mu.Lock()
+	h.topicLog(name)
+	h.mu.Unlock()
 
 	writeJSON(w, http.StatusOK, topic{
 		Name:   topicName(project, info.Name),
@@ -259,7 +212,7 @@ func (h *Handler) getTopic(w http.ResponseWriter, r *http.Request, project, name
 	})
 }
 
-func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request, _, name string) {
+func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request, name string) {
 	q, err := h.findQueueByName(r, name)
 	if err != nil {
 		writeErr(w, err)
@@ -271,12 +224,38 @@ func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request, _, name st
 		return
 	}
 
+	h.mu.Lock()
+	delete(h.topics, name)
+	h.mu.Unlock()
+
 	writeJSON(w, http.StatusOK, map[string]any{})
 }
 
-func (h *Handler) publish(w http.ResponseWriter, r *http.Request, _, name string) {
+func (h *Handler) listTopics(w http.ResponseWriter, r *http.Request, project string) {
+	queues, err := h.mq.ListQueues(r.Context(), "")
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	items := make([]topic, 0, len(queues))
+	for i := range queues {
+		items = append(items, topic{Name: topicName(project, queues[i].Name), Labels: queues[i].Tags})
+	}
+
+	page, err := pagination.PaginateSorted(items, func(a, b topic) bool { return a.Name < b.Name },
+		r.URL.Query().Get("pageToken"), pageSize(r))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, reasonInvalidArgument, "invalid pageToken")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, listTopicsResponse{Topics: page.Items, NextPageToken: page.NextPageToken})
+}
+
+func (h *Handler) publish(w http.ResponseWriter, r *http.Request, name string) {
 	if r.Method != http.MethodPost {
-		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		writeError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "method not allowed")
 		return
 	}
 
@@ -285,224 +264,25 @@ func (h *Handler) publish(w http.ResponseWriter, r *http.Request, _, name string
 		return
 	}
 
-	q, err := h.findQueueByName(r, name)
-	if err != nil {
+	if _, err := h.findQueueByName(r, name); err != nil {
 		writeErr(w, err)
 		return
 	}
 
+	publishTime := time.Now().UTC()
 	out := publishResponse{MessageIDs: make([]string, 0, len(req.Messages))}
 
 	for i := range req.Messages {
-		body, decErr := base64.StdEncoding.DecodeString(req.Messages[i].Data)
-		if decErr != nil {
-			// Tolerate unencoded payloads — some test clients send raw JSON.
-			body = []byte(req.Messages[i].Data)
-		}
-
-		send, sendErr := h.mq.SendMessage(r.Context(), mqdriver.SendMessageInput{
-			QueueURL:   q.URL,
-			Body:       string(body),
-			GroupID:    req.Messages[i].OrderingKey,
-			Attributes: req.Messages[i].Attributes,
+		id := h.appendMessage(name, &storedMessage{
+			body:        decodeData(req.Messages[i].Data),
+			attributes:  req.Messages[i].Attributes,
+			orderingKey: req.Messages[i].OrderingKey,
+			publishTime: publishTime,
 		})
-		if sendErr != nil {
-			writeErr(w, sendErr)
-			return
-		}
-
-		out.MessageIDs = append(out.MessageIDs, send.MessageID)
+		out.MessageIDs = append(out.MessageIDs, id)
 	}
 
 	writeJSON(w, http.StatusOK, out)
-}
-
-// ---------- Subscriptions ----------
-
-func (h *Handler) serveSubscription(w http.ResponseWriter, r *http.Request, project, name, action string) {
-	switch action {
-	case "pull":
-		h.pull(w, r, name)
-		return
-	case "acknowledge":
-		h.acknowledge(w, r, name)
-		return
-	}
-
-	switch r.Method {
-	case http.MethodPut:
-		h.createSubscription(w, r, project, name)
-	case http.MethodGet:
-		h.getSubscription(w, r, project, name)
-	case http.MethodDelete:
-		h.deleteSubscription(w, r, name)
-	default:
-		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
-	}
-}
-
-func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, project, name string) {
-	var body subscription
-	if !decodeJSON(w, r, &body) {
-		return
-	}
-
-	// The topic (a driver queue) must exist. Its short name may differ from
-	// the subscription name; default to the subscription name only when the
-	// caller omitted the topic (tolerant legacy path).
-	topicShort := subToTopicName(body.Topic)
-	if topicShort == "" {
-		topicShort = name
-	}
-
-	if _, err := h.findQueueByName(r, topicShort); err != nil {
-		writeErr(w, err)
-		return
-	}
-
-	ackDeadline := body.AckDeadlineSeconds
-	if ackDeadline == 0 {
-		ackDeadline = 10
-	}
-
-	h.mu.Lock()
-	h.subs[name] = &subMeta{topic: topicShort, ackDeadline: ackDeadline, labels: body.Labels}
-	h.mu.Unlock()
-
-	writeJSON(w, http.StatusOK, subscription{
-		Name:               subscriptionName(project, name),
-		Topic:              topicName(project, topicShort),
-		AckDeadlineSeconds: ackDeadline,
-		Labels:             body.Labels,
-	})
-}
-
-func (h *Handler) getSubscription(w http.ResponseWriter, _ *http.Request, project, name string) {
-	h.mu.RLock()
-	meta, ok := h.subs[name]
-	h.mu.RUnlock()
-
-	if !ok {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "subscription "+name+" not found")
-		return
-	}
-
-	writeJSON(w, http.StatusOK, subscription{
-		Name:               subscriptionName(project, name),
-		Topic:              topicName(project, meta.topic),
-		AckDeadlineSeconds: meta.ackDeadline,
-		Labels:             meta.labels,
-	})
-}
-
-func (h *Handler) deleteSubscription(w http.ResponseWriter, _ *http.Request, name string) {
-	h.mu.Lock()
-	_, ok := h.subs[name]
-	delete(h.subs, name)
-	h.mu.Unlock()
-
-	if !ok {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "subscription "+name+" not found")
-		return
-	}
-
-	// The subscription is removed from the registry; the topic's queue is left
-	// intact (real Pub/Sub deletes the subscription, not the topic).
-	writeJSON(w, http.StatusOK, map[string]any{})
-}
-
-// subscriptionQueue resolves a subscription to the queue that backs it (its
-// topic's queue). Falls back to a same-named queue for subscriptions created
-// before registration (legacy tolerance).
-func (h *Handler) subscriptionQueue(r *http.Request, name string) (*mqdriver.QueueInfo, error) {
-	h.mu.RLock()
-	meta, ok := h.subs[name]
-	h.mu.RUnlock()
-
-	target := name
-	if ok {
-		target = meta.topic
-	}
-
-	return h.findQueueByName(r, target)
-}
-
-func (h *Handler) pull(w http.ResponseWriter, r *http.Request, name string) {
-	if r.Method != http.MethodPost {
-		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
-		return
-	}
-
-	var req pullRequest
-	if !decodeJSON(w, r, &req) {
-		return
-	}
-
-	q, err := h.subscriptionQueue(r, name)
-	if err != nil {
-		writeErr(w, err)
-		return
-	}
-
-	if req.MaxMessages == 0 {
-		req.MaxMessages = 1
-	}
-
-	msgs, err := h.mq.ReceiveMessages(r.Context(), mqdriver.ReceiveMessageInput{
-		QueueURL:    q.URL,
-		MaxMessages: req.MaxMessages,
-	})
-	if err != nil {
-		writeErr(w, err)
-		return
-	}
-
-	// Real Pub/Sub always stamps a publishTime; the driver doesn't retain one,
-	// so approximate with the delivery time (clients that require a non-empty,
-	// valid RFC3339 timestamp are satisfied).
-	publishTime := time.Now().UTC().Format(time.RFC3339)
-
-	out := pullResponse{ReceivedMessages: make([]receivedMessage, 0, len(msgs))}
-	for i := range msgs {
-		out.ReceivedMessages = append(out.ReceivedMessages, receivedMessage{
-			AckID: msgs[i].ReceiptHandle,
-			Message: pubsubMessage{
-				MessageID:   msgs[i].MessageID,
-				Data:        base64.StdEncoding.EncodeToString([]byte(msgs[i].Body)),
-				Attributes:  msgs[i].Attributes,
-				PublishTime: publishTime,
-			},
-		})
-	}
-
-	writeJSON(w, http.StatusOK, out)
-}
-
-func (h *Handler) acknowledge(w http.ResponseWriter, r *http.Request, name string) {
-	if r.Method != http.MethodPost {
-		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
-		return
-	}
-
-	var req acknowledgeRequest
-	if !decodeJSON(w, r, &req) {
-		return
-	}
-
-	q, err := h.subscriptionQueue(r, name)
-	if err != nil {
-		writeErr(w, err)
-		return
-	}
-
-	for _, ack := range req.AckIDs {
-		if delErr := h.mq.DeleteMessage(r.Context(), q.URL, ack); delErr != nil {
-			writeErr(w, delErr)
-			return
-		}
-	}
-
-	writeJSON(w, http.StatusOK, map[string]any{})
 }
 
 // ---------- helpers ----------
@@ -516,16 +296,29 @@ func splitPath(p string) []string {
 	return strings.Split(rest, "/")
 }
 
+// splitColon separates a "name:action" segment into its parts.
+func splitColon(s string) (name, action string) {
+	if i := strings.Index(s, ":"); i >= 0 {
+		return s[:i], s[i+1:]
+	}
+
+	return s, ""
+}
+
 func topicName(project, name string) string {
-	return fmt.Sprintf("projects/%s/topics/%s", project, name)
+	return "projects/" + project + "/topics/" + name
 }
 
 func subscriptionName(project, name string) string {
-	return fmt.Sprintf("projects/%s/subscriptions/%s", project, name)
+	return "projects/" + project + "/subscriptions/" + name
 }
 
-// subToTopicName extracts the trailing topic name from "projects/p/topics/foo".
-func subToTopicName(full string) string {
+func snapshotName(project, name string) string {
+	return "projects/" + project + "/snapshots/" + name
+}
+
+// shortName returns the trailing segment of a resource path.
+func shortName(full string) string {
 	if i := strings.LastIndex(full, "/"); i >= 0 {
 		return full[i+1:]
 	}
@@ -548,11 +341,34 @@ func (h *Handler) findQueueByName(r *http.Request, name string) (*mqdriver.Queue
 	return nil, cerrors.Newf(cerrors.NotFound, "%s not found", name)
 }
 
+func pageSize(r *http.Request) int {
+	if v := r.URL.Query().Get("pageSize"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+
+	return 0
+}
+
+func encodeData(raw string) string {
+	return base64.StdEncoding.EncodeToString([]byte(raw))
+}
+
+// decodeData tolerates unencoded payloads — some test clients send raw JSON.
+func decodeData(data string) string {
+	if b, err := base64.StdEncoding.DecodeString(data); err == nil {
+		return string(b)
+	}
+
+	return data
+}
+
 func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
 
 	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, reasonInvalidArgument, "invalid JSON: "+err.Error())
 		return false
 	}
 
@@ -578,12 +394,12 @@ func writeError(w http.ResponseWriter, status int, reason, msg string) {
 func writeErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+		writeError(w, http.StatusNotFound, reasonNotFound, err.Error())
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+		writeError(w, http.StatusConflict, reasonAlreadyExists, err.Error())
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		writeError(w, http.StatusBadRequest, reasonInvalidArgument, err.Error())
 	default:
-		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+		writeError(w, http.StatusInternalServerError, reasonInternal, err.Error())
 	}
 }

--- a/server/gcp/pubsub/iam.go
+++ b/server/gcp/pubsub/iam.go
@@ -1,0 +1,134 @@
+package pubsub
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strconv"
+)
+
+// ---------- IAM ----------
+//
+// Pub/Sub topics and subscriptions expose the standard google.iam.v1 policy
+// surface (getIamPolicy/setIamPolicy/testIamPermissions), which
+// google_pubsub_topic_iam_* / google_pubsub_subscription_iam_* Terraform
+// resources depend on. Policies are stored per-resource and round-trip verbatim.
+
+func (h *Handler) serveIam(w http.ResponseWriter, r *http.Request, resType, name, action string) {
+	switch action {
+	case verbGetIamPolicy:
+		h.getIamPolicy(w, r, resType, name)
+	case verbSetIamPolicy:
+		h.setIamPolicy(w, r, resType, name)
+	case verbTestIamPermissions:
+		testIamPermissions(w, r)
+	default:
+		writeError(w, http.StatusNotFound, reasonNotFound, "unknown IAM verb: "+action)
+	}
+}
+
+func (h *Handler) getIamPolicy(w http.ResponseWriter, r *http.Request, resType, name string) {
+	if !h.resourceExists(r, resType, name) {
+		writeError(w, http.StatusNotFound, reasonNotFound, resType+" "+name+" not found")
+		return
+	}
+
+	h.mu.RLock()
+	pol := h.loadPolicy(resType, name)
+	h.mu.RUnlock()
+
+	if pol == nil {
+		pol = &iamPolicy{Version: 1, Etag: h.nextEtag()}
+	}
+
+	writeJSON(w, http.StatusOK, pol)
+}
+
+func (h *Handler) setIamPolicy(w http.ResponseWriter, r *http.Request, resType, name string) {
+	if !h.resourceExists(r, resType, name) {
+		writeError(w, http.StatusNotFound, reasonNotFound, resType+" "+name+" not found")
+		return
+	}
+
+	var req setIamPolicyRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	pol := req.Policy
+	if pol.Version == 0 {
+		pol.Version = 1
+	}
+
+	pol.Etag = h.nextEtag()
+
+	h.mu.Lock()
+	h.storePolicy(resType, name, &pol)
+	h.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, pol)
+}
+
+func testIamPermissions(w http.ResponseWriter, r *http.Request) {
+	var req testIamPermissionsRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	// The emulator grants every requested permission (no policy enforcement on
+	// the wire), so echo the request back as the held subset.
+	writeJSON(w, http.StatusOK, testIamPermissionsResponse(req))
+}
+
+func (h *Handler) resourceExists(r *http.Request, resType, name string) bool {
+	switch resType {
+	case resTopics:
+		_, err := h.findQueueByName(r, name)
+		return err == nil
+	case resSubscriptions:
+		h.mu.RLock()
+		_, ok := h.subs[name]
+		h.mu.RUnlock()
+
+		return ok
+	case resSnapshots:
+		h.mu.RLock()
+		_, ok := h.snapshots[name]
+		h.mu.RUnlock()
+
+		return ok
+	default:
+		return false
+	}
+}
+
+// loadPolicy returns the stored policy for a resource, or nil. The caller holds h.mu.
+func (h *Handler) loadPolicy(resType, name string) *iamPolicy {
+	switch resType {
+	case resTopics:
+		if ts, ok := h.topics[name]; ok {
+			return ts.iam
+		}
+	case resSubscriptions:
+		if s, ok := h.subs[name]; ok {
+			return s.iam
+		}
+	}
+
+	return nil
+}
+
+// storePolicy persists a resource's policy. The caller holds h.mu.
+func (h *Handler) storePolicy(resType, name string, pol *iamPolicy) {
+	switch resType {
+	case resTopics:
+		h.topicLog(name).iam = pol
+	case resSubscriptions:
+		if s, ok := h.subs[name]; ok {
+			s.iam = pol
+		}
+	}
+}
+
+func (h *Handler) nextEtag() string {
+	return base64.StdEncoding.EncodeToString([]byte("etag-" + strconv.FormatUint(h.ackCounter.Add(1), 10)))
+}

--- a/server/gcp/pubsub/model.go
+++ b/server/gcp/pubsub/model.go
@@ -1,0 +1,203 @@
+package pubsub
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+)
+
+const defaultAckDeadlineSeconds = 10
+
+// storedMessage is one message in a topic's append-only log. Every subscription
+// on the topic reads from this shared log by index; per-subscription ack state
+// (not the message bytes) is what makes delivery independent — real Pub/Sub
+// fan-out, where each subscription gets its own copy of every message.
+type storedMessage struct {
+	id          string
+	body        string // raw (un-encoded) payload
+	attributes  map[string]string
+	orderingKey string
+	publishTime time.Time
+}
+
+// topicState holds a topic's message log and IAM policy. Topic existence and
+// labels remain owned by the messagequeue driver (the provider layer); this is
+// the Pub/Sub-native state the SQS-style driver cannot express.
+type topicState struct {
+	messages []storedMessage
+	iam      *iamPolicy
+}
+
+// lease is an outstanding (delivered, not-yet-acked) message on a subscription.
+type lease struct {
+	msgIdx   int
+	deadline time.Time
+}
+
+// subState is a subscription's full native state: its config (round-tripped
+// verbatim) plus independent delivery cursor over its topic's message log.
+type subState struct {
+	cfg        subscription
+	topic      string // topic short-name whose log backs this subscription
+	createTime time.Time
+
+	acked            map[int]bool      // message indices already acknowledged
+	outstanding      map[string]*lease // ackID -> leased message
+	deliveryAttempts map[int]int       // per-index delivery count (dead-letter surface)
+	iam              *iamPolicy
+}
+
+// snapState captures a subscription's ack cursor for later seek/replay.
+type snapState struct {
+	topic      string
+	acked      map[int]bool
+	labels     map[string]string
+	createTime time.Time
+	expireTime time.Time
+}
+
+// Handler serves Pub/Sub v1 REST requests. Topic existence + labels are backed
+// by the messagequeue driver (mq); Pub/Sub-native state (per-topic message log,
+// per-subscription delivery cursors, snapshots, IAM) lives here because those
+// semantics do not map onto the shared SQS-style driver.
+type Handler struct {
+	mq mqdriver.MessageQueue
+
+	mu        sync.RWMutex
+	topics    map[string]*topicState
+	subs      map[string]*subState
+	snapshots map[string]*snapState
+
+	ackCounter atomic.Uint64
+}
+
+// New returns a Pub/Sub handler backed by mq.
+func New(mq mqdriver.MessageQueue) *Handler {
+	return &Handler{
+		mq:        mq,
+		topics:    make(map[string]*topicState),
+		subs:      make(map[string]*subState),
+		snapshots: make(map[string]*snapState),
+	}
+}
+
+// topicLog returns the message log for a topic, creating it on first use. The
+// caller holds h.mu.
+func (h *Handler) topicLog(name string) *topicState {
+	ts, ok := h.topics[name]
+	if !ok {
+		ts = &topicState{}
+		h.topics[name] = ts
+	}
+
+	return ts
+}
+
+// appendMessage records a published message on a topic and returns its id.
+func (h *Handler) appendMessage(topicName string, msg *storedMessage) string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	ts := h.topicLog(topicName)
+	msg.id = fmt.Sprintf("%d", h.ackCounter.Add(1))
+	ts.messages = append(ts.messages, *msg)
+
+	return msg.id
+}
+
+// newSub registers a subscription that starts fresh: all messages already on
+// the topic are treated as consumed, so it only receives future publishes
+// (matching real Pub/Sub, where a new subscription has no backlog).
+func (h *Handler) newSub(name, topicShort string, cfg *subscription) {
+	acked := make(map[int]bool)
+
+	if ts, ok := h.topics[topicShort]; ok {
+		for i := range ts.messages {
+			acked[i] = true
+		}
+	}
+
+	h.subs[name] = &subState{
+		cfg:              *cfg,
+		topic:            topicShort,
+		createTime:       time.Now().UTC(),
+		acked:            acked,
+		outstanding:      make(map[string]*lease),
+		deliveryAttempts: make(map[int]int),
+	}
+}
+
+// deliver selects up to maxMessages deliverable messages for a subscription,
+// leasing each for ackDeadline. Expired leases are swept first so nacked or
+// deadline-lapsed messages redeliver. The caller holds h.mu.
+func (h *Handler) deliver(sub *subState, maxMessages int) []receivedMessage {
+	ts, ok := h.topics[sub.topic]
+	if !ok {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	sweepExpired(sub, now)
+
+	leased := make(map[int]bool, len(sub.outstanding))
+	for _, l := range sub.outstanding {
+		leased[l.msgIdx] = true
+	}
+
+	ackDeadline := sub.cfg.AckDeadlineSeconds
+	if ackDeadline <= 0 {
+		ackDeadline = defaultAckDeadlineSeconds
+	}
+
+	out := make([]receivedMessage, 0, maxMessages)
+
+	for idx := range ts.messages {
+		if len(out) >= maxMessages {
+			break
+		}
+
+		if sub.acked[idx] || leased[idx] {
+			continue
+		}
+
+		ackID := fmt.Sprintf("ack-%d", h.ackCounter.Add(1))
+		sub.outstanding[ackID] = &lease{msgIdx: idx, deadline: now.Add(time.Duration(ackDeadline) * time.Second)}
+		sub.deliveryAttempts[idx]++
+
+		attempt := 0
+		if len(sub.cfg.DeadLetterPolicy) > 0 {
+			attempt = sub.deliveryAttempts[idx]
+		}
+
+		out = append(out, buildReceived(ackID, &ts.messages[idx], attempt))
+	}
+
+	return out
+}
+
+// sweepExpired drops leases whose deadline has passed, making those messages
+// deliverable again. The caller holds h.mu.
+func sweepExpired(sub *subState, now time.Time) {
+	for id, l := range sub.outstanding {
+		if now.After(l.deadline) {
+			delete(sub.outstanding, id)
+		}
+	}
+}
+
+func buildReceived(ackID string, msg *storedMessage, deliveryAttempt int) receivedMessage {
+	return receivedMessage{
+		AckID:           ackID,
+		DeliveryAttempt: deliveryAttempt,
+		Message: pubsubMessage{
+			MessageID:   msg.id,
+			Data:        encodeData(msg.body),
+			Attributes:  msg.attributes,
+			OrderingKey: msg.orderingKey,
+			PublishTime: msg.publishTime.Format(time.RFC3339Nano),
+		},
+	}
+}

--- a/server/gcp/pubsub/sdk_admin_test.go
+++ b/server/gcp/pubsub/sdk_admin_test.go
@@ -1,0 +1,228 @@
+package pubsub_test
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+
+	pubsubv1 "google.golang.org/api/pubsub/v1"
+)
+
+// TestSDKPubSubTopicIAM guards topic IAM: getIamPolicy returns a policy with an
+// etag, setIamPolicy persists bindings, and testIamPermissions echoes the held
+// permissions.
+func TestSDKPubSubTopicIAM(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/iam")
+	const res = "projects/demo/topics/iam"
+
+	pol, err := svc.Projects.Topics.GetIamPolicy(res).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("GetIamPolicy: %v", err)
+	}
+
+	if pol.Etag == "" {
+		t.Errorf("initial policy etag empty, want non-empty")
+	}
+
+	set, err := svc.Projects.Topics.SetIamPolicy(res, &pubsubv1.SetIamPolicyRequest{
+		Policy: &pubsubv1.Policy{
+			Bindings: []*pubsubv1.Binding{{Role: "roles/pubsub.viewer", Members: []string{"user:a@b.com"}}},
+		},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("SetIamPolicy: %v", err)
+	}
+
+	if len(set.Bindings) != 1 || set.Bindings[0].Role != "roles/pubsub.viewer" {
+		t.Fatalf("SetIamPolicy bindings not persisted: %+v", set.Bindings)
+	}
+
+	got, err := svc.Projects.Topics.GetIamPolicy(res).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("GetIamPolicy after set: %v", err)
+	}
+
+	if len(got.Bindings) != 1 || got.Bindings[0].Members[0] != "user:a@b.com" {
+		t.Fatalf("policy not round-tripped: %+v", got.Bindings)
+	}
+
+	test, err := svc.Projects.Topics.TestIamPermissions(res, &pubsubv1.TestIamPermissionsRequest{
+		Permissions: []string{"pubsub.topics.publish"},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("TestIamPermissions: %v", err)
+	}
+
+	if len(test.Permissions) != 1 || test.Permissions[0] != "pubsub.topics.publish" {
+		t.Fatalf("TestIamPermissions=%v", test.Permissions)
+	}
+}
+
+// TestSDKPubSubTopicSubscriptionsList guards topics.subscriptions.list — it
+// returns the topic's subscription names, not an empty list.
+func TestSDKPubSubTopicSubscriptionsList(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/lt")
+	mustSub(t, svc, "projects/demo/subscriptions/ls1", &pubsubv1.Subscription{Topic: "projects/demo/topics/lt"})
+	mustSub(t, svc, "projects/demo/subscriptions/ls2", &pubsubv1.Subscription{Topic: "projects/demo/topics/lt"})
+
+	resp, err := svc.Projects.Topics.Subscriptions.List("projects/demo/topics/lt").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Topics.Subscriptions.List: %v", err)
+	}
+
+	if len(resp.Subscriptions) != 2 {
+		t.Fatalf("listed %d subscriptions, want 2: %v", len(resp.Subscriptions), resp.Subscriptions)
+	}
+
+	if !strings.HasSuffix(resp.Subscriptions[0], "/subscriptions/ls1") {
+		t.Errorf("subscriptions[0]=%q want .../ls1", resp.Subscriptions[0])
+	}
+}
+
+// TestSDKPubSubListPagination guards pageSize/pageToken + nextPageToken on
+// topics.list.
+func TestSDKPubSubListPagination(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	for i := range 5 {
+		mustTopic(t, svc, fmt.Sprintf("projects/demo/topics/pg%d", i))
+	}
+
+	first, err := svc.Projects.Topics.List("projects/demo").PageSize(2).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Topics.List page 1: %v", err)
+	}
+
+	if len(first.Topics) != 2 {
+		t.Fatalf("page 1 returned %d topics, want 2", len(first.Topics))
+	}
+
+	if first.NextPageToken == "" {
+		t.Fatal("page 1 nextPageToken empty, want a continuation token")
+	}
+
+	seen := len(first.Topics)
+	token := first.NextPageToken
+
+	for token != "" {
+		page, perr := svc.Projects.Topics.List("projects/demo").PageSize(2).PageToken(token).Context(ctx).Do()
+		if perr != nil {
+			t.Fatalf("Topics.List page: %v", perr)
+		}
+
+		seen += len(page.Topics)
+		token = page.NextPageToken
+	}
+
+	if seen != 5 {
+		t.Fatalf("paged through %d topics, want 5", seen)
+	}
+}
+
+// TestSDKPubSubModifyPushConfig guards subscriptions.modifyPushConfig.
+func TestSDKPubSubModifyPushConfig(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/mpc")
+	mustSub(t, svc, "projects/demo/subscriptions/mpc", &pubsubv1.Subscription{Topic: "projects/demo/topics/mpc"})
+
+	if _, err := svc.Projects.Subscriptions.ModifyPushConfig("projects/demo/subscriptions/mpc",
+		&pubsubv1.ModifyPushConfigRequest{
+			PushConfig: &pubsubv1.PushConfig{PushEndpoint: "https://example.com/hook"},
+		}).Context(ctx).Do(); err != nil {
+		t.Fatalf("ModifyPushConfig: %v", err)
+	}
+
+	got, err := svc.Projects.Subscriptions.Get("projects/demo/subscriptions/mpc").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.PushConfig == nil || got.PushConfig.PushEndpoint != "https://example.com/hook" {
+		t.Fatalf("push config not applied: %+v", got.PushConfig)
+	}
+}
+
+// TestSDKPubSubSnapshotsAndSeek guards snapshot CRUD plus seek-to-snapshot and
+// seek-to-time replay.
+func TestSDKPubSubSnapshotsAndSeek(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/sk")
+	mustSub(t, svc, "projects/demo/subscriptions/sk", &pubsubv1.Subscription{Topic: "projects/demo/topics/sk"})
+
+	// Snapshot the empty backlog, then publish + consume a message.
+	snap, err := svc.Projects.Snapshots.Create("projects/demo/snapshots/snap1",
+		&pubsubv1.CreateSnapshotRequest{Subscription: "projects/demo/subscriptions/sk"}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Snapshots.Create: %v", err)
+	}
+
+	if !strings.HasSuffix(snap.Topic, "/topics/sk") {
+		t.Errorf("snapshot topic=%q want .../topics/sk", snap.Topic)
+	}
+
+	if _, err := svc.Projects.Snapshots.Get("projects/demo/snapshots/snap1").Context(ctx).Do(); err != nil {
+		t.Fatalf("Snapshots.Get: %v", err)
+	}
+
+	list, err := svc.Projects.Snapshots.List("projects/demo").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Snapshots.List: %v", err)
+	}
+
+	if len(list.Snapshots) != 1 {
+		t.Fatalf("listed %d snapshots, want 1", len(list.Snapshots))
+	}
+
+	publish(t, svc, "projects/demo/topics/sk",
+		&pubsubv1.PubsubMessage{Data: base64.StdEncoding.EncodeToString([]byte("s"))})
+
+	first := pull(t, svc, "projects/demo/subscriptions/sk", 1)
+	if len(first.ReceivedMessages) != 1 {
+		t.Fatalf("pull got %d, want 1", len(first.ReceivedMessages))
+	}
+
+	// Ack it so it would not normally redeliver.
+	if _, err := svc.Projects.Subscriptions.Acknowledge("projects/demo/subscriptions/sk",
+		&pubsubv1.AcknowledgeRequest{AckIds: []string{first.ReceivedMessages[0].AckId}}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Acknowledge: %v", err)
+	}
+
+	// Seek to the snapshot (empty-backlog cursor): the acked message replays.
+	if _, err := svc.Projects.Subscriptions.Seek("projects/demo/subscriptions/sk",
+		&pubsubv1.SeekRequest{Snapshot: "projects/demo/snapshots/snap1"}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Seek(snapshot): %v", err)
+	}
+
+	replay := pull(t, svc, "projects/demo/subscriptions/sk", 1)
+	if len(replay.ReceivedMessages) != 1 {
+		t.Fatalf("after seek-to-snapshot, pull got %d, want 1 (replay)", len(replay.ReceivedMessages))
+	}
+
+	// Seek to a far-future time marks everything acknowledged: no replay.
+	if _, err := svc.Projects.Subscriptions.Seek("projects/demo/subscriptions/sk",
+		&pubsubv1.SeekRequest{Time: "2999-01-01T00:00:00Z"}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Seek(time): %v", err)
+	}
+
+	none := pull(t, svc, "projects/demo/subscriptions/sk", 1)
+	if len(none.ReceivedMessages) != 0 {
+		t.Fatalf("after seek-to-future-time, pull got %d, want 0", len(none.ReceivedMessages))
+	}
+
+	if _, err := svc.Projects.Snapshots.Delete("projects/demo/snapshots/snap1").Context(ctx).Do(); err != nil {
+		t.Fatalf("Snapshots.Delete: %v", err)
+	}
+}

--- a/server/gcp/pubsub/sdk_delivery_test.go
+++ b/server/gcp/pubsub/sdk_delivery_test.go
@@ -1,0 +1,203 @@
+package pubsub_test
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	pubsubv1 "google.golang.org/api/pubsub/v1"
+)
+
+func mustTopic(t *testing.T, svc *pubsubv1.Service, name string) {
+	t.Helper()
+
+	if _, err := svc.Projects.Topics.Create(name, &pubsubv1.Topic{}).Context(context.Background()).Do(); err != nil {
+		t.Fatalf("Topic.Create(%s): %v", name, err)
+	}
+}
+
+func mustSub(t *testing.T, svc *pubsubv1.Service, name string, sub *pubsubv1.Subscription) {
+	t.Helper()
+
+	if _, err := svc.Projects.Subscriptions.Create(name, sub).Context(context.Background()).Do(); err != nil {
+		t.Fatalf("Subscription.Create(%s): %v", name, err)
+	}
+}
+
+func publish(t *testing.T, svc *pubsubv1.Service, topic string, msgs ...*pubsubv1.PubsubMessage) {
+	t.Helper()
+
+	if _, err := svc.Projects.Topics.Publish(topic,
+		&pubsubv1.PublishRequest{Messages: msgs}).Context(context.Background()).Do(); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+}
+
+func pull(t *testing.T, svc *pubsubv1.Service, sub string, maxMsgs int64) *pubsubv1.PullResponse {
+	t.Helper()
+
+	resp, err := svc.Projects.Subscriptions.Pull(sub,
+		&pubsubv1.PullRequest{MaxMessages: maxMsgs}).Context(context.Background()).Do()
+	if err != nil {
+		t.Fatalf("Pull(%s): %v", sub, err)
+	}
+
+	return resp
+}
+
+// TestSDKPubSubFanOut guards the BLOCKER: two subscriptions on one topic each
+// receive an independent copy of every published message.
+func TestSDKPubSubFanOut(t *testing.T) {
+	svc := newSDKService(t)
+
+	mustTopic(t, svc, "projects/demo/topics/fo")
+	mustSub(t, svc, "projects/demo/subscriptions/foa", &pubsubv1.Subscription{Topic: "projects/demo/topics/fo"})
+	mustSub(t, svc, "projects/demo/subscriptions/fob", &pubsubv1.Subscription{Topic: "projects/demo/topics/fo"})
+
+	publish(t, svc, "projects/demo/topics/fo",
+		&pubsubv1.PubsubMessage{Data: base64.StdEncoding.EncodeToString([]byte("m1"))})
+
+	a := pull(t, svc, "projects/demo/subscriptions/foa", 10)
+	b := pull(t, svc, "projects/demo/subscriptions/fob", 10)
+
+	if len(a.ReceivedMessages) != 1 {
+		t.Fatalf("foa got %d messages, want 1", len(a.ReceivedMessages))
+	}
+
+	if len(b.ReceivedMessages) != 1 {
+		t.Fatalf("fob got %d messages, want 1 (fan-out: second sub must not be starved)", len(b.ReceivedMessages))
+	}
+}
+
+// TestSDKPubSubModifyAckDeadlineRedelivery guards modifyAckDeadline: setting the
+// deadline to 0 nacks the message and it is redelivered on the next pull.
+func TestSDKPubSubModifyAckDeadlineRedelivery(t *testing.T) {
+	svc := newSDKService(t)
+
+	mustTopic(t, svc, "projects/demo/topics/mad")
+	mustSub(t, svc, "projects/demo/subscriptions/mad", &pubsubv1.Subscription{Topic: "projects/demo/topics/mad"})
+	publish(t, svc, "projects/demo/topics/mad",
+		&pubsubv1.PubsubMessage{Data: base64.StdEncoding.EncodeToString([]byte("x"))})
+
+	first := pull(t, svc, "projects/demo/subscriptions/mad", 1)
+	if len(first.ReceivedMessages) != 1 {
+		t.Fatalf("first pull got %d, want 1", len(first.ReceivedMessages))
+	}
+
+	ackID := first.ReceivedMessages[0].AckId
+	if _, err := svc.Projects.Subscriptions.ModifyAckDeadline("projects/demo/subscriptions/mad",
+		&pubsubv1.ModifyAckDeadlineRequest{AckIds: []string{ackID}, AckDeadlineSeconds: 0}).
+		Context(context.Background()).Do(); err != nil {
+		t.Fatalf("ModifyAckDeadline: %v", err)
+	}
+
+	second := pull(t, svc, "projects/demo/subscriptions/mad", 1)
+	if len(second.ReceivedMessages) != 1 {
+		t.Fatalf("after nack, redelivery pull got %d, want 1", len(second.ReceivedMessages))
+	}
+}
+
+// TestSDKPubSubExtendedSubscriptionFields guards that the extended subscription
+// config round-trips on Get instead of being silently dropped.
+func TestSDKPubSubExtendedSubscriptionFields(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/ext")
+	mustTopic(t, svc, "projects/demo/topics/ext-dlq")
+
+	want := &pubsubv1.Subscription{
+		Topic:                    "projects/demo/topics/ext",
+		AckDeadlineSeconds:       30,
+		RetainAckedMessages:      true,
+		MessageRetentionDuration: "600s",
+		EnableMessageOrdering:    true,
+		Filter:                   `attributes.type = "order"`,
+		PushConfig:               &pubsubv1.PushConfig{PushEndpoint: "https://example.com/push"},
+		ExpirationPolicy:         &pubsubv1.ExpirationPolicy{Ttl: "86400s"},
+		DeadLetterPolicy: &pubsubv1.DeadLetterPolicy{
+			DeadLetterTopic: "projects/demo/topics/ext-dlq", MaxDeliveryAttempts: 5,
+		},
+		RetryPolicy: &pubsubv1.RetryPolicy{MinimumBackoff: "10s", MaximumBackoff: "600s"},
+	}
+	mustSub(t, svc, "projects/demo/subscriptions/ext", want)
+
+	got, err := svc.Projects.Subscriptions.Get("projects/demo/subscriptions/ext").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	switch {
+	case got.PushConfig == nil || got.PushConfig.PushEndpoint != "https://example.com/push":
+		t.Errorf("pushConfig not round-tripped: %+v", got.PushConfig)
+	case !got.RetainAckedMessages:
+		t.Errorf("retainAckedMessages dropped")
+	case got.MessageRetentionDuration != "600s":
+		t.Errorf("messageRetentionDuration=%q want 600s", got.MessageRetentionDuration)
+	case !got.EnableMessageOrdering:
+		t.Errorf("enableMessageOrdering dropped")
+	case got.Filter != `attributes.type = "order"`:
+		t.Errorf("filter=%q", got.Filter)
+	case got.ExpirationPolicy == nil || got.ExpirationPolicy.Ttl != "86400s":
+		t.Errorf("expirationPolicy not round-tripped: %+v", got.ExpirationPolicy)
+	case got.DeadLetterPolicy == nil || got.DeadLetterPolicy.MaxDeliveryAttempts != 5:
+		t.Errorf("deadLetterPolicy not round-tripped: %+v", got.DeadLetterPolicy)
+	case got.RetryPolicy == nil || got.RetryPolicy.MinimumBackoff != "10s":
+		t.Errorf("retryPolicy not round-tripped: %+v", got.RetryPolicy)
+	}
+}
+
+// TestSDKPubSubDuplicateSubscription409 guards that a duplicate Create is
+// rejected rather than silently overwriting.
+func TestSDKPubSubDuplicateSubscription409(t *testing.T) {
+	svc := newSDKService(t)
+
+	mustTopic(t, svc, "projects/demo/topics/ds")
+	mustSub(t, svc, "projects/demo/subscriptions/ds",
+		&pubsubv1.Subscription{Topic: "projects/demo/topics/ds", AckDeadlineSeconds: 20})
+
+	_, err := svc.Projects.Subscriptions.Create("projects/demo/subscriptions/ds",
+		&pubsubv1.Subscription{Topic: "projects/demo/topics/ds", AckDeadlineSeconds: 99}).
+		Context(context.Background()).Do()
+	if err == nil {
+		t.Fatal("duplicate Subscription.Create returned nil error, want 409 ALREADY_EXISTS")
+	}
+}
+
+// TestSDKPubSubOrderingKeyAndPublishTime guards that the received message
+// carries the publish-time orderingKey and a publishTime stamped at publish
+// (not at pull).
+func TestSDKPubSubOrderingKeyAndPublishTime(t *testing.T) {
+	svc := newSDKService(t)
+
+	mustTopic(t, svc, "projects/demo/topics/ord")
+	mustSub(t, svc, "projects/demo/subscriptions/ord", &pubsubv1.Subscription{Topic: "projects/demo/topics/ord"})
+
+	publish(t, svc, "projects/demo/topics/ord", &pubsubv1.PubsubMessage{
+		Data:        base64.StdEncoding.EncodeToString([]byte("y")),
+		OrderingKey: "k1",
+	})
+
+	// Delay so a pull-time publishTime would be measurably later than publish.
+	time.Sleep(60 * time.Millisecond)
+
+	resp := pull(t, svc, "projects/demo/subscriptions/ord", 1)
+	if len(resp.ReceivedMessages) != 1 {
+		t.Fatalf("pull got %d, want 1", len(resp.ReceivedMessages))
+	}
+
+	msg := resp.ReceivedMessages[0].Message
+	if msg.OrderingKey != "k1" {
+		t.Errorf("orderingKey=%q want k1", msg.OrderingKey)
+	}
+
+	pt, err := time.Parse(time.RFC3339Nano, msg.PublishTime)
+	if err != nil {
+		t.Fatalf("publishTime %q not RFC3339: %v", msg.PublishTime, err)
+	}
+
+	if age := time.Since(pt); age < 40*time.Millisecond {
+		t.Errorf("publishTime age %v too small — stamped at pull, not publish", age)
+	}
+}

--- a/server/gcp/pubsub/snapshot.go
+++ b/server/gcp/pubsub/snapshot.go
@@ -1,0 +1,214 @@
+package pubsub
+
+import (
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
+)
+
+const snapshotTTL = 7 * 24 * time.Hour
+
+// ---------- Snapshots ----------
+
+func (h *Handler) serveSnapshot(w http.ResponseWriter, r *http.Request, project, name, _ string) {
+	switch r.Method {
+	case http.MethodPut:
+		h.createSnapshot(w, r, project, name)
+	case http.MethodGet:
+		h.getSnapshot(w, project, name)
+	case http.MethodDelete:
+		h.deleteSnapshot(w, name)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *Handler) createSnapshot(w http.ResponseWriter, r *http.Request, project, name string) {
+	var body createSnapshotRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	subShort := shortName(body.Subscription)
+
+	h.mu.Lock()
+
+	sub, ok := h.subs[subShort]
+	if !ok {
+		h.mu.Unlock()
+		writeError(w, http.StatusNotFound, reasonNotFound, "subscription "+subShort+" not found")
+
+		return
+	}
+
+	if _, exists := h.snapshots[name]; exists {
+		h.mu.Unlock()
+		writeError(w, http.StatusConflict, reasonAlreadyExists, "snapshot "+name+" already exists")
+
+		return
+	}
+
+	snap := &snapState{
+		topic:      sub.topic,
+		acked:      copyIntSet(sub.acked),
+		labels:     body.Labels,
+		createTime: time.Now().UTC(),
+		expireTime: time.Now().UTC().Add(snapshotTTL),
+	}
+	h.snapshots[name] = snap
+	h.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, snapshotJSON(project, name, snap))
+}
+
+func (h *Handler) getSnapshot(w http.ResponseWriter, project, name string) {
+	h.mu.RLock()
+	snap, ok := h.snapshots[name]
+	h.mu.RUnlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, reasonNotFound, "snapshot "+name+" not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, snapshotJSON(project, name, snap))
+}
+
+func (h *Handler) deleteSnapshot(w http.ResponseWriter, name string) {
+	h.mu.Lock()
+	_, ok := h.snapshots[name]
+	delete(h.snapshots, name)
+	h.mu.Unlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, reasonNotFound, "snapshot "+name+" not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+func (h *Handler) listSnapshots(w http.ResponseWriter, r *http.Request, project string) {
+	h.mu.RLock()
+	items := make([]snapshot, 0, len(h.snapshots))
+
+	for snapName, snap := range h.snapshots {
+		items = append(items, snapshotJSON(project, snapName, snap))
+	}
+	h.mu.RUnlock()
+
+	page, err := pagination.PaginateSorted(items, func(a, b snapshot) bool { return a.Name < b.Name },
+		r.URL.Query().Get("pageToken"), pageSize(r))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, reasonInvalidArgument, "invalid pageToken")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, listSnapshotsResponse{Snapshots: page.Items, NextPageToken: page.NextPageToken})
+}
+
+func (h *Handler) listTopicSnapshots(w http.ResponseWriter, project, topicShort string) {
+	h.mu.RLock()
+	names := make([]string, 0)
+
+	for snapName, snap := range h.snapshots {
+		if snap.topic == topicShort {
+			names = append(names, snapshotName(project, snapName))
+		}
+	}
+	h.mu.RUnlock()
+
+	sort.Strings(names)
+	writeJSON(w, http.StatusOK, listTopicSubscriptionsResponse{Subscriptions: names})
+}
+
+// seek rewinds a subscription's ack cursor to a snapshot or a timestamp.
+func (h *Handler) seek(w http.ResponseWriter, r *http.Request, name string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	var req seekRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	status, reason, msg := h.applySeek(name, req)
+	if status != http.StatusOK {
+		writeError(w, status, reason, msg)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+// applySeek mutates the subscription's ack cursor and reports the HTTP outcome.
+func (h *Handler) applySeek(name string, req seekRequest) (status int, reason, msg string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	sub, ok := h.subs[name]
+	if !ok {
+		return http.StatusNotFound, reasonNotFound, "subscription " + name + " not found"
+	}
+
+	switch {
+	case req.Snapshot != "":
+		snap, sok := h.snapshots[shortName(req.Snapshot)]
+		if !sok {
+			return http.StatusNotFound, reasonNotFound, "snapshot not found"
+		}
+
+		sub.acked = copyIntSet(snap.acked)
+	case req.Time != "":
+		t, err := time.Parse(time.RFC3339Nano, req.Time)
+		if err != nil {
+			return http.StatusBadRequest, reasonInvalidArgument, "invalid time: " + err.Error()
+		}
+
+		sub.acked = h.ackedBefore(sub.topic, t)
+	default:
+		return http.StatusBadRequest, reasonInvalidArgument, "seek requires time or snapshot"
+	}
+
+	sub.outstanding = make(map[string]*lease)
+
+	return http.StatusOK, "", ""
+}
+
+// ackedBefore returns the set of message indices published before t (marked
+// acknowledged after a time-based seek). The caller holds h.mu.
+func (h *Handler) ackedBefore(topicShort string, t time.Time) map[int]bool {
+	acked := make(map[int]bool)
+
+	if ts, ok := h.topics[topicShort]; ok {
+		for i := range ts.messages {
+			if ts.messages[i].publishTime.Before(t) {
+				acked[i] = true
+			}
+		}
+	}
+
+	return acked
+}
+
+func snapshotJSON(project, name string, snap *snapState) snapshot {
+	return snapshot{
+		Name:       snapshotName(project, name),
+		Topic:      topicName(project, snap.topic),
+		ExpireTime: snap.expireTime.Format(time.RFC3339Nano),
+		Labels:     snap.labels,
+	}
+}
+
+func copyIntSet(src map[int]bool) map[int]bool {
+	dst := make(map[int]bool, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+
+	return dst
+}

--- a/server/gcp/pubsub/subscription.go
+++ b/server/gcp/pubsub/subscription.go
@@ -1,0 +1,315 @@
+package pubsub
+
+import (
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
+)
+
+// ---------- Subscriptions ----------
+
+func (h *Handler) serveSubscription(w http.ResponseWriter, r *http.Request, project, name, action string) {
+	switch action {
+	case "pull":
+		h.pull(w, r, name)
+		return
+	case "acknowledge":
+		h.acknowledge(w, r, name)
+		return
+	case "modifyAckDeadline":
+		h.modifyAckDeadline(w, r, name)
+		return
+	case "modifyPushConfig":
+		h.modifyPushConfig(w, r, name)
+		return
+	case "seek":
+		h.seek(w, r, name)
+		return
+	case verbGetIamPolicy, verbSetIamPolicy, verbTestIamPermissions:
+		h.serveIam(w, r, resSubscriptions, name, action)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createSubscription(w, r, project, name)
+	case http.MethodGet:
+		h.getSubscription(w, project, name)
+	case http.MethodDelete:
+		h.deleteSubscription(w, name)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, project, name string) {
+	var body subscription
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	topicShort := shortName(body.Topic)
+	if topicShort == "" {
+		topicShort = name
+	}
+
+	if _, err := h.findQueueByName(r, topicShort); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if body.AckDeadlineSeconds == 0 {
+		body.AckDeadlineSeconds = defaultAckDeadlineSeconds
+	}
+
+	cfg := body
+	cfg.Name = subscriptionName(project, name)
+	cfg.Topic = topicName(project, topicShort)
+
+	h.mu.Lock()
+	if _, exists := h.subs[name]; exists {
+		h.mu.Unlock()
+		writeError(w, http.StatusConflict, reasonAlreadyExists, "subscription "+name+" already exists")
+
+		return
+	}
+
+	h.newSub(name, topicShort, &cfg)
+	h.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, cfg)
+}
+
+func (h *Handler) getSubscription(w http.ResponseWriter, _, name string) {
+	h.mu.RLock()
+	var cfg subscription
+
+	meta, ok := h.subs[name]
+	if ok {
+		cfg = meta.cfg
+	}
+	h.mu.RUnlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, reasonNotFound, "subscription "+name+" not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, cfg)
+}
+
+func (h *Handler) deleteSubscription(w http.ResponseWriter, name string) {
+	h.mu.Lock()
+	_, ok := h.subs[name]
+	delete(h.subs, name)
+	h.mu.Unlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, reasonNotFound, "subscription "+name+" not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+func (h *Handler) listSubscriptions(w http.ResponseWriter, r *http.Request, _ string) {
+	h.mu.RLock()
+	items := make([]subscription, 0, len(h.subs))
+
+	for _, meta := range h.subs {
+		items = append(items, meta.cfg)
+	}
+	h.mu.RUnlock()
+
+	page, err := pagination.PaginateSorted(items, func(a, b subscription) bool { return a.Name < b.Name },
+		r.URL.Query().Get("pageToken"), pageSize(r))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, reasonInvalidArgument, "invalid pageToken")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, listSubscriptionsResponse{Subscriptions: page.Items, NextPageToken: page.NextPageToken})
+}
+
+func (h *Handler) listTopicSubscriptions(w http.ResponseWriter, r *http.Request, project, topicShort string) {
+	h.mu.RLock()
+	names := make([]string, 0)
+
+	for subName, meta := range h.subs {
+		if meta.topic == topicShort {
+			names = append(names, subscriptionName(project, subName))
+		}
+	}
+	h.mu.RUnlock()
+
+	sort.Strings(names)
+	page, err := pagination.Paginate(names, r.URL.Query().Get("pageToken"), pageSize(r))
+
+	if err != nil {
+		writeError(w, http.StatusBadRequest, reasonInvalidArgument, "invalid pageToken")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, listTopicSubscriptionsResponse{Subscriptions: page.Items, NextPageToken: page.NextPageToken})
+}
+
+func (h *Handler) pull(w http.ResponseWriter, r *http.Request, name string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	var req pullRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.MaxMessages <= 0 {
+		req.MaxMessages = 1
+	}
+
+	h.mu.Lock()
+
+	sub, err := h.resolveSubForPull(r, name)
+	if err != nil {
+		h.mu.Unlock()
+		writeErr(w, err)
+
+		return
+	}
+
+	msgs := h.deliver(sub, req.MaxMessages)
+	h.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, pullResponse{ReceivedMessages: msgs})
+}
+
+// resolveSubForPull returns the named subscription, lazily materializing an
+// implicit one when a same-named topic exists (legacy topic==subscription
+// tolerance). The implicit subscription reads the topic log from the start. The
+// caller holds h.mu.
+func (h *Handler) resolveSubForPull(r *http.Request, name string) (*subState, error) {
+	if sub, ok := h.subs[name]; ok {
+		return sub, nil
+	}
+
+	if _, err := h.findQueueByName(r, name); err != nil {
+		return nil, err
+	}
+
+	sub := &subState{
+		cfg:              subscription{AckDeadlineSeconds: defaultAckDeadlineSeconds},
+		topic:            name,
+		createTime:       time.Now().UTC(),
+		acked:            make(map[int]bool),
+		outstanding:      make(map[string]*lease),
+		deliveryAttempts: make(map[int]int),
+	}
+	h.subs[name] = sub
+
+	return sub, nil
+}
+
+func (h *Handler) acknowledge(w http.ResponseWriter, r *http.Request, name string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	var req acknowledgeRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	h.mu.Lock()
+	sub, ok := h.subs[name]
+
+	if ok {
+		for _, ack := range req.AckIDs {
+			if l, has := sub.outstanding[ack]; has {
+				sub.acked[l.msgIdx] = true
+				delete(sub.outstanding, ack)
+			}
+		}
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, reasonNotFound, "subscription "+name+" not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+func (h *Handler) modifyAckDeadline(w http.ResponseWriter, r *http.Request, name string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	var req modifyAckDeadlineRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	h.mu.Lock()
+	sub, ok := h.subs[name]
+
+	if ok {
+		deadline := time.Now().UTC().Add(time.Duration(req.AckDeadlineSeconds) * time.Second)
+
+		for _, ack := range req.AckIDs {
+			l, has := sub.outstanding[ack]
+			if !has {
+				continue
+			}
+
+			// ackDeadlineSeconds == 0 nacks the message: drop the lease so the
+			// next pull redelivers it immediately.
+			if req.AckDeadlineSeconds <= 0 {
+				delete(sub.outstanding, ack)
+				continue
+			}
+
+			l.deadline = deadline
+		}
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, reasonNotFound, "subscription "+name+" not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+func (h *Handler) modifyPushConfig(w http.ResponseWriter, r *http.Request, name string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	var req modifyPushConfigRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	h.mu.Lock()
+	sub, ok := h.subs[name]
+
+	if ok {
+		sub.cfg.PushConfig = req.PushConfig
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, reasonNotFound, "subscription "+name+" not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{})
+}

--- a/server/gcp/pubsub/types.go
+++ b/server/gcp/pubsub/types.go
@@ -1,25 +1,47 @@
 package pubsub
 
+import "encoding/json"
+
 // topic is the GCP Pub/Sub Topic resource shape.
 type topic struct {
 	Name   string            `json:"name"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 
-// subscription is the GCP Pub/Sub Subscription resource shape.
+// subscription is the GCP Pub/Sub Subscription resource shape. Extended fields
+// (pushConfig/retryPolicy/deadLetterPolicy/expirationPolicy) are kept as raw
+// JSON so they round-trip verbatim without modeling every nested member.
 type subscription struct {
-	Name               string            `json:"name"`
-	Topic              string            `json:"topic"`
-	AckDeadlineSeconds int               `json:"ackDeadlineSeconds,omitempty"`
-	Labels             map[string]string `json:"labels,omitempty"`
+	Name                     string            `json:"name"`
+	Topic                    string            `json:"topic"`
+	PushConfig               json.RawMessage   `json:"pushConfig,omitempty"`
+	AckDeadlineSeconds       int               `json:"ackDeadlineSeconds,omitempty"`
+	RetainAckedMessages      bool              `json:"retainAckedMessages,omitempty"`
+	MessageRetentionDuration string            `json:"messageRetentionDuration,omitempty"`
+	Labels                   map[string]string `json:"labels,omitempty"`
+	EnableMessageOrdering    bool              `json:"enableMessageOrdering,omitempty"`
+	ExpirationPolicy         json.RawMessage   `json:"expirationPolicy,omitempty"`
+	Filter                   string            `json:"filter,omitempty"`
+	DeadLetterPolicy         json.RawMessage   `json:"deadLetterPolicy,omitempty"`
+	RetryPolicy              json.RawMessage   `json:"retryPolicy,omitempty"`
+	Detached                 bool              `json:"detached,omitempty"`
 }
 
 type listTopicsResponse struct {
-	Topics []topic `json:"topics"`
+	Topics        []topic `json:"topics"`
+	NextPageToken string  `json:"nextPageToken,omitempty"`
 }
 
 type listSubscriptionsResponse struct {
 	Subscriptions []subscription `json:"subscriptions"`
+	NextPageToken string         `json:"nextPageToken,omitempty"`
+}
+
+// listTopicSubscriptionsResponse is topics.subscriptions.list — a list of
+// subscription resource names (strings), not full Subscription objects.
+type listTopicSubscriptionsResponse struct {
+	Subscriptions []string `json:"subscriptions"`
+	NextPageToken string   `json:"nextPageToken,omitempty"`
 }
 
 // publishRequest is POST topics/{name}:publish.
@@ -50,11 +72,73 @@ type pullResponse struct {
 }
 
 type receivedMessage struct {
-	AckID   string        `json:"ackId"`
-	Message pubsubMessage `json:"message"`
+	AckID           string        `json:"ackId"`
+	Message         pubsubMessage `json:"message"`
+	DeliveryAttempt int           `json:"deliveryAttempt,omitempty"`
 }
 
 // acknowledgeRequest is POST subscriptions/{name}:acknowledge.
 type acknowledgeRequest struct {
 	AckIDs []string `json:"ackIds"`
+}
+
+// modifyAckDeadlineRequest is POST subscriptions/{name}:modifyAckDeadline.
+type modifyAckDeadlineRequest struct {
+	AckIDs             []string `json:"ackIds"`
+	AckDeadlineSeconds int      `json:"ackDeadlineSeconds"`
+}
+
+// modifyPushConfigRequest is POST subscriptions/{name}:modifyPushConfig.
+type modifyPushConfigRequest struct {
+	PushConfig json.RawMessage `json:"pushConfig"`
+}
+
+// seekRequest is POST subscriptions/{name}:seek.
+type seekRequest struct {
+	Time     string `json:"time,omitempty"`
+	Snapshot string `json:"snapshot,omitempty"`
+}
+
+// snapshot is the GCP Pub/Sub Snapshot resource shape.
+type snapshot struct {
+	Name       string            `json:"name"`
+	Topic      string            `json:"topic"`
+	ExpireTime string            `json:"expireTime,omitempty"`
+	Labels     map[string]string `json:"labels,omitempty"`
+}
+
+// createSnapshotRequest is PUT snapshots/{name}.
+type createSnapshotRequest struct {
+	Subscription string            `json:"subscription"`
+	Labels       map[string]string `json:"labels,omitempty"`
+}
+
+type listSnapshotsResponse struct {
+	Snapshots     []snapshot `json:"snapshots"`
+	NextPageToken string     `json:"nextPageToken,omitempty"`
+}
+
+// iamPolicy is the shared google.iam.v1.Policy shape.
+type iamPolicy struct {
+	Version  int          `json:"version,omitempty"`
+	Bindings []iamBinding `json:"bindings,omitempty"`
+	Etag     string       `json:"etag,omitempty"`
+}
+
+type iamBinding struct {
+	Role      string          `json:"role"`
+	Members   []string        `json:"members"`
+	Condition json.RawMessage `json:"condition,omitempty"`
+}
+
+type setIamPolicyRequest struct {
+	Policy iamPolicy `json:"policy"`
+}
+
+type testIamPermissionsRequest struct {
+	Permissions []string `json:"permissions"`
+}
+
+type testIamPermissionsResponse struct {
+	Permissions []string `json:"permissions,omitempty"`
 }


### PR DESCRIPTION
## What & why

Reworks the GCP Pub/Sub wire handler (`server/gcp/pubsub`) so it models Pub/Sub-native delivery instead of delegating message storage to the SQS-style `messagequeue` driver. Each topic now keeps an append-only message log and each subscription an independent ack cursor, which is what real Pub/Sub fan-out, snapshots and seek require. Topic existence and labels are still backed by the driver.

All 12 findings from the AUDIT_GCP `## pubsub` section are fixed; each has a reproduction test driven by the real `google.golang.org/api/pubsub/v1` SDK against the in-process GCP server (the REST client matching our REST wire protocol — the gRPC `cloud.google.com/go/pubsub` client cannot target an HTTP handler).

## Findings fixed

- **[BLOCKER] subscriptions.pull fan-out** — two subscriptions on one topic each receive an independent copy of every message (was: first consumer drained a shared queue).
- **[HIGH] subscriptions.create/get extended fields** — `pushConfig`/`retainAckedMessages`/`messageRetentionDuration`/`enableMessageOrdering`/`filter`/`expirationPolicy`/`deadLetterPolicy`/`retryPolicy` now round-trip.
- **[HIGH] subscriptions.modifyAckDeadline** — routed; `ackDeadlineSeconds=0` nacks and the message redelivers.
- **[HIGH] topics IAM** — `getIamPolicy`/`setIamPolicy`/`testIamPermissions` served (was 405/mis-routed); subscription IAM added too.
- **[MEDIUM] topics.subscriptions.list** — the 4-segment path lists the topic's subscription names (was mis-routed to getTopic → empty).
- **[MEDIUM] subscriptions.create duplicate** — duplicate name now 409 (was silent overwrite).
- **[MEDIUM] snapshots.create/list/get/delete** — implemented.
- **[MEDIUM] subscriptions.seek** — seek to timestamp or snapshot.
- **[MEDIUM] subscriptions.modifyPushConfig** — implemented.
- **[MEDIUM] topics/subscriptions.list pagination** — `pageSize`/`pageToken` + `nextPageToken` honored.
- **[LOW] pull orderingKey** — populated on the received message.
- **[LOW] pull publishTime** — stamped at publish, not at pull.

## Notes

- Changes are confined to `server/gcp/pubsub`. No shared driver interface changed, so `docs/coverage` needs no regeneration.
- The legacy topic==subscription pull tolerance is preserved (an implicit subscription materializes on pull against a same-named topic) so existing tests stay green.
- Deferrals: none.
