### PR TITLE
fix(gcp-networking): routes API, address IP allocation, region-scoped subnets, delete-in-use, pagination, timestamps, custom-mode IPv4Range, JSON 501

### DIFF
--- a/server/gcp/compute/fallback.go
+++ b/server/gcp/compute/fallback.go
@@ -1,0 +1,29 @@
+package compute
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+)
+
+// Fallback claims any /compute/v1/ request that no real compute-space handler
+// (instances, networks, load balancing, …) matched, and answers with a proper
+// GCP JSON error envelope instead of the dispatcher's bare-text 501 with the
+// wrong Content-Type. Register it LAST among the /compute/v1 handlers so
+// first-match-wins keeps every implemented path on its real handler.
+type Fallback struct{}
+
+// NewFallback returns the compute-space catch-all handler.
+func NewFallback() *Fallback { return &Fallback{} }
+
+// Matches reports whether the request targets the compute API URL space.
+func (*Fallback) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.URL.Path, gcprest.BasePrefix)
+}
+
+// ServeHTTP writes a GCP-style JSON 501 for an unimplemented compute path.
+func (*Fallback) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	gcprest.WriteError(w, http.StatusNotImplemented, "notImplemented",
+		"not implemented: "+r.Method+" "+r.URL.Path)
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -171,6 +171,14 @@ func New(d Drivers) *server.Server {
 		srv.Register(lbsrv.New(d.LB))
 	}
 
+	// Compute-space catch-all. Registered AFTER the compute, networks and load-
+	// balancing handlers so first-match-wins keeps every implemented /compute/v1
+	// path on its real handler; this only claims the leftovers, answering with a
+	// GCP JSON error envelope instead of the dispatcher's bare-text 501.
+	if d.Compute != nil || d.Networking != nil || d.LB != nil {
+		srv.Register(compute.NewFallback())
+	}
+
 	// CloudFunctions matches /v1/projects/{p}/locations/{l}/functions paths
 	// before Firestore so the locations+functions guard wins over Firestore's
 	// /v1/projects/ prefix match.

--- a/server/gcp/vpc/addresses.go
+++ b/server/gcp/vpc/addresses.go
@@ -1,12 +1,20 @@
 package vpc
 
 import (
+	"encoding/binary"
 	"encoding/json"
+	"net"
 	"net/http"
+	"sort"
 	"sync"
 
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 )
+
+// reservedIPBase is the start of the synthetic range CloudEmu hands out for
+// reserved addresses that the caller didn't pin to a specific IP.
+const reservedIPBase = "10.128.0.0"
 
 // Addresses are reserved IP ranges. Private services access uses a global one
 // to carve out the block a managed service is peered into, so a caller
@@ -19,10 +27,29 @@ import (
 type addressStore struct {
 	mu        sync.RWMutex
 	addresses map[string]map[string]json.RawMessage // project/scope -> name -> body
+	seq       uint32                                // monotonic IP allocator
 }
 
 func newAddressStore() *addressStore {
 	return &addressStore{addresses: map[string]map[string]json.RawMessage{}}
+}
+
+// allocIP hands out the next IP from the synthetic reserved range. Real GCP
+// allocates an address at reservation time; a caller reading back status
+// RESERVED with an actual IP is what unblocks PSA/VPC-peering range setup.
+func (s *addressStore) allocIP() string {
+	s.mu.Lock()
+	s.seq++
+	n := s.seq
+	s.mu.Unlock()
+
+	base := net.ParseIP(reservedIPBase).To4()
+
+	v := binary.BigEndian.Uint32(base) + n
+	out := make(net.IP, net.IPv4len)
+	binary.BigEndian.PutUint32(out, v)
+
+	return out.String()
 }
 
 func (s *addressStore) key(project, scope string) string { return project + "/" + scope }
@@ -136,10 +163,45 @@ func (h *Handler) insertAddress(w http.ResponseWriter, r *http.Request, rp gcpre
 		return
 	}
 
-	h.addresses.put(rp.Project, scopeOf(rp), named.Name, raw)
+	h.addresses.put(rp.Project, scopeOf(rp), named.Name,
+		h.enrichAddress(raw, rp, hostOf(r), named.Name))
 
 	gcprest.WriteJSON(w, http.StatusOK, gcprest.NewDoneOperation(hostOf(r), rp.Project,
 		rp.Scope, rp.ScopeName, resourceAddresses, named.Name, "insert"))
+}
+
+// enrichAddress fills the server-assigned fields real GCP stamps on a reserved
+// address — kind, id, status=RESERVED, an allocated IP, selfLink, region and
+// creationTimestamp — while preserving everything the caller sent (purpose,
+// prefixLength, addressType, …). Without this a Get reads back all-empty.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) enrichAddress(raw json.RawMessage, rp gcprest.ResourcePath, host, name string) json.RawMessage {
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil || body == nil {
+		return raw
+	}
+
+	body["kind"] = "compute#address"
+	body["id"] = numericID(rp.Project + "/" + scopeOf(rp) + "/" + name)
+	body["status"] = "RESERVED"
+	body["selfLink"] = gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, resourceAddresses, name)
+	body["creationTimestamp"] = nowRFC3339()
+
+	if addr, ok := body["address"].(string); !ok || addr == "" {
+		body["address"] = h.addresses.allocIP()
+	}
+
+	if rp.Scope == gcprest.ScopeRegions {
+		body["region"] = host + "/compute/v1/projects/" + rp.Project + "/regions/" + rp.ScopeName
+	}
+
+	enriched, err := json.Marshal(body)
+	if err != nil {
+		return raw
+	}
+
+	return enriched
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -157,10 +219,48 @@ func (h *Handler) getAddress(w http.ResponseWriter, r *http.Request, rp gcprest.
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) listAddresses(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	gcprest.WriteJSON(w, http.StatusOK, map[string]any{
+	all := h.addresses.list(rp.Project, scopeOf(rp))
+	filter := r.URL.Query().Get("filter")
+
+	items := make([]json.RawMessage, 0, len(all))
+
+	for _, body := range all {
+		if nameMatches(filter, rawName(body)) {
+			items = append(items, body)
+		}
+	}
+
+	// Stable order for offset pagination.
+	sort.SliceStable(items, func(i, j int) bool { return rawName(items[i]) < rawName(items[j]) })
+
+	page, err := pagination.Paginate(items, r.URL.Query().Get("pageToken"),
+		maxResultsOf(r.URL.Query().Get("maxResults")))
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid pageToken")
+		return
+	}
+
+	out := map[string]any{
 		"kind":  "compute#addressList",
-		"items": h.addresses.list(rp.Project, scopeOf(rp)),
-	})
+		"items": page.Items,
+	}
+	if page.NextPageToken != "" {
+		out["nextPageToken"] = page.NextPageToken
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, out)
+}
+
+// rawName extracts the "name" field from a stored address body for filtering
+// and ordering.
+func rawName(body json.RawMessage) string {
+	var named struct {
+		Name string `json:"name"`
+	}
+
+	_ = json.Unmarshal(body, &named)
+
+	return named.Name
 }
 
 //nolint:gocritic // rp is a request-scoped value

--- a/server/gcp/vpc/addresses_test.go
+++ b/server/gcp/vpc/addresses_test.go
@@ -1,0 +1,72 @@
+package vpc_test
+
+import (
+	"context"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/option"
+)
+
+// TestSDKGlobalAddressAllocatesIP covers the finding that a reserved address
+// was stored verbatim with no IP allocated — Get returned status/address/
+// selfLink/kind empty and id=0, breaking PSA/VPC_PEERING range reservation.
+func TestSDKGlobalAddressAllocatesIP(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewGlobalAddressesRESTClient(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewGlobalAddressesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertGlobalAddressRequest{
+		Project: testProject,
+		AddressResource: &computepb.Address{
+			Name:         ptrStr("psa-range"),
+			Purpose:      ptrStr("VPC_PEERING"),
+			AddressType:  ptrStr("INTERNAL"),
+			PrefixLength: ptrInt32(16),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetGlobalAddressRequest{Project: testProject, Address: "psa-range"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetStatus() != "RESERVED" {
+		t.Errorf("status=%q want RESERVED", got.GetStatus())
+	}
+
+	if got.GetAddress() == "" {
+		t.Error("address empty, want an allocated IP")
+	}
+
+	if got.GetId() == 0 {
+		t.Error("id=0, want a non-zero numeric id")
+	}
+
+	if got.GetKind() != "compute#address" || got.GetSelfLink() == "" {
+		t.Errorf("kind=%q selfLink=%q want populated", got.GetKind(), got.GetSelfLink())
+	}
+
+	// Caller-supplied fields must round-trip.
+	if got.GetPurpose() != "VPC_PEERING" || got.GetPrefixLength() != 16 {
+		t.Errorf("purpose=%q prefixLength=%d want VPC_PEERING/16", got.GetPurpose(), got.GetPrefixLength())
+	}
+}

--- a/server/gcp/vpc/handler.go
+++ b/server/gcp/vpc/handler.go
@@ -23,12 +23,18 @@ package vpc
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
+	"hash/fnv"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
@@ -39,25 +45,92 @@ const (
 	resourceFirewalls   = "firewalls"
 	resourceRouters     = "routers"
 	resourceAddresses   = "addresses"
+	resourceRoutes      = "routes"
 	netNameTag          = "cloudemu:gcpNetName"
 	subnetNameTag       = "cloudemu:gcpSubnetName"
 	subnetNetworkTag    = "cloudemu:gcpSubnetNet"
 	autoSubnetTag       = "cloudemu:gcpAutoSubnet"
+	legacyNetTag        = "cloudemu:gcpLegacyNet"
+	createdAtTag        = "cloudemu:gcpCreatedAt"
+	subnetPurposeTag    = "cloudemu:gcpSubnetPurpose"
+	subnetStackTag      = "cloudemu:gcpSubnetStack"
+	subnetPGATag        = "cloudemu:gcpSubnetPGA"
 	firewallNameTag     = "cloudemu:gcpFwName"
 	firewallSpecTag     = "cloudemu:gcpFwSpec"
 	trueValue           = "true"
+
+	defaultSubnetPurpose = "PRIVATE"
+	defaultStackType     = "IPV4_ONLY"
+	internalNetCIDR      = "10.0.0.0/16"
 )
+
+// defaultListMax is GCP's default page size when maxResults is absent.
+const defaultListMax = 500
+
+// nowRFC3339 returns the current time formatted the way GCP stamps
+// creationTimestamp on every resource.
+func nowRFC3339() string { return time.Now().UTC().Format(time.RFC3339) }
+
+// nameMatches reports whether name satisfies a GCP list filter. Only the
+// common single-clause "name (=|!=|eq|ne) value" form is supported; any other
+// filter (or none) matches everything.
+func nameMatches(filter, name string) bool {
+	filter = strings.TrimSpace(filter)
+	if filter == "" {
+		return true
+	}
+
+	for _, cand := range []string{"!=", "=", " ne ", " eq "} {
+		idx := strings.Index(filter, cand)
+		if idx < 0 {
+			continue
+		}
+
+		field := strings.TrimSpace(filter[:idx])
+		if field != "name" {
+			return true
+		}
+
+		value := strings.Trim(strings.TrimSpace(filter[idx+len(cand):]), `"'`)
+		op := strings.TrimSpace(cand)
+		negate := op == "!=" || op == "ne"
+
+		return (name == value) != negate
+	}
+
+	return true
+}
+
+// maxResultsOf parses the maxResults query param, defaulting when absent/invalid.
+func maxResultsOf(raw string) int {
+	if raw == "" {
+		return defaultListMax
+	}
+
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return defaultListMax
+	}
+
+	return n
+}
 
 // Handler serves the GCP networking REST surface.
 type Handler struct {
 	net       netdriver.Networking
 	routers   *routerStore
 	addresses *addressStore
+	routes    *routeStore
 }
 
 // New returns a networks handler.
 func New(n netdriver.Networking) *Handler {
-	return &Handler{net: n, routers: newRouterStore(), addresses: newAddressStore()}
+	return &Handler{
+		net:       n,
+		routers:   newRouterStore(),
+		addresses: newAddressStore(),
+		routes:    newRouteStore(),
+	}
 }
 
 // Matches returns true for /compute/v1/.../networks|subnetworks|firewalls URLs.
@@ -75,7 +148,8 @@ func (*Handler) Matches(r *http.Request) bool {
 	}
 
 	switch rp.ResourceType {
-	case resourceNetworks, resourceSubnetworks, resourceFirewalls, resourceRouters, resourceAddresses:
+	case resourceNetworks, resourceSubnetworks, resourceFirewalls,
+		resourceRouters, resourceAddresses, resourceRoutes:
 		return true
 	}
 
@@ -101,6 +175,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routeRouters(w, r, rp)
 	case resourceAddresses:
 		h.routeAddresses(w, r, rp)
+	case resourceRoutes:
+		h.routeRoutes(w, r, rp)
 	default:
 		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unknown resource type")
 	}
@@ -208,12 +284,18 @@ func (h *Handler) insertNetwork(w http.ResponseWriter, r *http.Request, rp gcpre
 		return
 	}
 
-	cidr := "10.0.0.0/16"
+	// A network with an explicit IPv4Range is a (deprecated) legacy network;
+	// only those carry an IPv4Range on the wire. Auto/custom-mode networks must
+	// NOT report one — the driver still needs a non-empty CIDR internally, so a
+	// placeholder is stored but hidden from the response unless legacy.
+	cidr := internalNetCIDR
+	tags := map[string]string{netNameTag: req.Name, createdAtTag: nowRFC3339()}
+
 	if req.IPv4Range != "" {
 		cidr = req.IPv4Range
+		tags[legacyNetTag] = trueValue
 	}
 
-	tags := map[string]string{netNameTag: req.Name}
 	if req.AutoCreateSubnetworks != nil && *req.AutoCreateSubnetworks {
 		tags[autoSubnetTag] = trueValue
 	}
@@ -254,19 +336,35 @@ func (h *Handler) listNetworks(w http.ResponseWriter, r *http.Request, rp gcpres
 	}
 
 	host := hostOf(r)
-	out := networkListResponse{
-		Kind:     "compute#networkList",
-		ID:       "projects/" + rp.Project + "/global/networks",
-		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "networks", ""),
-	}
+	filter := r.URL.Query().Get("filter")
+
+	items := make([]networkResponse, 0, len(infos))
 
 	for i := range infos {
 		scope := rp
 		scope.ResourceName = tagOr(infos[i].Tags, netNameTag, infos[i].ID)
-		out.Items = append(out.Items, toNetworkResponse(&infos[i], scope, host))
+
+		resp := toNetworkResponse(&infos[i], scope, host)
+		if nameMatches(filter, resp.Name) {
+			items = append(items, resp)
+		}
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, out)
+	page, err := pagination.PaginateSorted(items,
+		func(a, b networkResponse) bool { return a.Name < b.Name },
+		r.URL.Query().Get("pageToken"), maxResultsOf(r.URL.Query().Get("maxResults")))
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid pageToken")
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, networkListResponse{
+		Kind:          "compute#networkList",
+		ID:            "projects/" + rp.Project + "/global/networks",
+		Items:         page.Items,
+		NextPageToken: page.NextPageToken,
+		SelfLink:      gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "networks", ""),
+	})
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -274,6 +372,19 @@ func (h *Handler) deleteNetwork(w http.ResponseWriter, r *http.Request, rp gcpre
 	v, err := findNetByName(r.Context(), h.net, rp.ResourceName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	// Real GCP refuses to delete a network that still has subnetworks; the
+	// deletion would otherwise orphan them. Scan for live subnets on this
+	// network and reject with resourceInUseByAnotherResource.
+	if sub, scanErr := h.subnetOnNetwork(r.Context(), v.ID, rp.ResourceName); scanErr != nil {
+		gcprest.WriteCErr(w, scanErr)
+		return
+	} else if sub != "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "resourceInUseByAnotherResource",
+			"The network resource '"+rp.ResourceName+"' is already being used by '"+sub+"'")
+
 		return
 	}
 
@@ -315,11 +426,28 @@ func (h *Handler) insertSubnetwork(w http.ResponseWriter, r *http.Request, rp gc
 		return
 	}
 
+	tags := map[string]string{
+		subnetNameTag:    req.Name,
+		subnetNetworkTag: lastSegment(req.Network),
+		createdAtTag:     nowRFC3339(),
+	}
+	if req.Purpose != "" {
+		tags[subnetPurposeTag] = req.Purpose
+	}
+
+	if req.StackType != "" {
+		tags[subnetStackTag] = req.StackType
+	}
+
+	if req.PrivateIPGoogleAccess != nil && *req.PrivateIPGoogleAccess {
+		tags[subnetPGATag] = trueValue
+	}
+
 	cfg := netdriver.SubnetConfig{
 		VPCID:            vpcID,
 		CIDRBlock:        req.IPCIDRRange,
 		AvailabilityZone: rp.ScopeName,
-		Tags:             map[string]string{subnetNameTag: req.Name, subnetNetworkTag: lastSegment(req.Network)},
+		Tags:             tags,
 	}
 
 	if _, err := h.net.CreateSubnet(r.Context(), cfg); err != nil {
@@ -335,7 +463,7 @@ func (h *Handler) insertSubnetwork(w http.ResponseWriter, r *http.Request, rp gc
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) getSubnetwork(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	s, err := findSubnetByName(r.Context(), h.net, rp.ResourceName)
+	s, err := findSubnetByName(r.Context(), h.net, rp.ResourceName, rp.ScopeName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -353,24 +481,45 @@ func (h *Handler) listSubnetworks(w http.ResponseWriter, r *http.Request, rp gcp
 	}
 
 	host := hostOf(r)
-	out := subnetworkListResponse{
-		Kind:     "compute#subnetworkList",
-		ID:       "projects/" + rp.Project + "/regions/" + rp.ScopeName + "/subnetworks",
-		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeRegions, rp.ScopeName, "subnetworks", ""),
-	}
+	filter := r.URL.Query().Get("filter")
+
+	items := make([]subnetworkResponse, 0, len(infos))
 
 	for i := range infos {
+		// subnetworks.list is regional — only return subnets in this region.
+		if rp.ScopeName != "" && infos[i].AvailabilityZone != rp.ScopeName {
+			continue
+		}
+
 		scope := rp
 		scope.ResourceName = tagOr(infos[i].Tags, subnetNameTag, infos[i].ID)
-		out.Items = append(out.Items, toSubnetworkResponse(&infos[i], scope, host))
+
+		resp := toSubnetworkResponse(&infos[i], scope, host)
+		if nameMatches(filter, resp.Name) {
+			items = append(items, resp)
+		}
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, out)
+	page, err := pagination.PaginateSorted(items,
+		func(a, b subnetworkResponse) bool { return a.Name < b.Name },
+		r.URL.Query().Get("pageToken"), maxResultsOf(r.URL.Query().Get("maxResults")))
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid pageToken")
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, subnetworkListResponse{
+		Kind:          "compute#subnetworkList",
+		ID:            "projects/" + rp.Project + "/regions/" + rp.ScopeName + "/subnetworks",
+		Items:         page.Items,
+		NextPageToken: page.NextPageToken,
+		SelfLink:      gcprest.SelfLink(host, rp.Project, gcprest.ScopeRegions, rp.ScopeName, "subnetworks", ""),
+	})
 }
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) deleteSubnetwork(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	s, err := findSubnetByName(r.Context(), h.net, rp.ResourceName)
+	s, err := findSubnetByName(r.Context(), h.net, rp.ResourceName, rp.ScopeName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -430,7 +579,7 @@ func (h *Handler) insertFirewall(w http.ResponseWriter, r *http.Request, rp gcpr
 	// (allowed/denied/direction/priority/targetTags), so persist the rule spec
 	// verbatim in a reserved tag and reconstruct it on read. Without this a
 	// created firewall reads back with no rules.
-	tags := map[string]string{firewallNameTag: req.Name}
+	tags := map[string]string{firewallNameTag: req.Name, createdAtTag: nowRFC3339()}
 	if spec := marshalFirewallSpec(&req); spec != "" {
 		tags[firewallSpecTag] = spec
 	}
@@ -473,19 +622,35 @@ func (h *Handler) listFirewalls(w http.ResponseWriter, r *http.Request, rp gcpre
 	}
 
 	host := hostOf(r)
-	out := firewallListResponse{
-		Kind:     "compute#firewallList",
-		ID:       "projects/" + rp.Project + "/global/firewalls",
-		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "firewalls", ""),
-	}
+	filter := r.URL.Query().Get("filter")
+
+	items := make([]firewallResponse, 0, len(infos))
 
 	for i := range infos {
 		scope := rp
 		scope.ResourceName = tagOr(infos[i].Tags, firewallNameTag, infos[i].ID)
-		out.Items = append(out.Items, toFirewallResponse(&infos[i], scope, host))
+
+		resp := toFirewallResponse(&infos[i], scope, host)
+		if nameMatches(filter, resp.Name) {
+			items = append(items, resp)
+		}
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, out)
+	page, err := pagination.PaginateSorted(items,
+		func(a, b firewallResponse) bool { return a.Name < b.Name },
+		r.URL.Query().Get("pageToken"), maxResultsOf(r.URL.Query().Get("maxResults")))
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid pageToken")
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, firewallListResponse{
+		Kind:          "compute#firewallList",
+		ID:            "projects/" + rp.Project + "/global/firewalls",
+		Items:         page.Items,
+		NextPageToken: page.NextPageToken,
+		SelfLink:      gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "firewalls", ""),
+	})
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -524,19 +689,47 @@ func findNetByName(ctx context.Context, n netdriver.Networking, name string) (*n
 	return nil, cerrors.Newf(cerrors.NotFound, "network %s not found", name)
 }
 
-func findSubnetByName(ctx context.Context, n netdriver.Networking, name string) (*netdriver.SubnetInfo, error) {
+// findSubnetByName resolves a subnetwork by name scoped to a region. Two
+// subnetworks in different regions may share a name, so region must
+// disambiguate (real GCP scopes subnetwork get/delete by region). An empty
+// region matches on name alone.
+func findSubnetByName(ctx context.Context, n netdriver.Networking, name, region string) (*netdriver.SubnetInfo, error) {
 	infos, err := n.DescribeSubnets(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	for i := range infos {
-		if tagOr(infos[i].Tags, subnetNameTag, "") == name {
-			return &infos[i], nil
+		if tagOr(infos[i].Tags, subnetNameTag, "") != name {
+			continue
 		}
+
+		if region != "" && infos[i].AvailabilityZone != region {
+			continue
+		}
+
+		return &infos[i], nil
 	}
 
 	return nil, cerrors.Newf(cerrors.NotFound, "subnetwork %s not found", name)
+}
+
+// subnetOnNetwork returns the name of the first subnetwork attached to the
+// given network (by driver VPC ID or by the stored network-name tag), or "" if
+// none. It underpins the delete-in-use guard for networks.
+func (h *Handler) subnetOnNetwork(ctx context.Context, vpcID, netName string) (string, error) {
+	infos, err := h.net.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return "", err
+	}
+
+	for i := range infos {
+		if infos[i].VPCID == vpcID || tagOr(infos[i].Tags, subnetNetworkTag, "") == netName {
+			return tagOr(infos[i].Tags, subnetNameTag, infos[i].ID), nil
+		}
+	}
+
+	return "", nil
 }
 
 func findFirewallByName(ctx context.Context, n netdriver.Networking, name string) (*netdriver.SecurityGroupInfo, error) {
@@ -593,14 +786,23 @@ func resolveNetwork(ctx context.Context, n netdriver.Networking, ref string) (st
 func toNetworkResponse(info *netdriver.VPCInfo, rp gcprest.ResourcePath, host string) networkResponse {
 	name := tagOr(info.Tags, netNameTag, info.ID)
 
-	return networkResponse{
+	resp := networkResponse{
 		Kind:                  "compute#network",
 		ID:                    numericID(info.ID),
 		Name:                  name,
-		IPv4Range:             info.CIDRBlock,
 		AutoCreateSubnetworks: info.Tags[autoSubnetTag] == trueValue,
+		CreationTimestamp:     info.Tags[createdAtTag],
 		SelfLink:              gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "networks", name),
 	}
+
+	// IPv4Range belongs only to a legacy network; a modern auto/custom network
+	// omits it (emitting it would wrongly read as legacy and conflict with
+	// autoCreateSubnetworks).
+	if info.Tags[legacyNetTag] == trueValue {
+		resp.IPv4Range = info.CIDRBlock
+	}
+
+	return resp
 }
 
 // lastSegment returns the final path/URL segment (e.g. a network self-link or
@@ -623,12 +825,18 @@ func toSubnetworkResponse(info *netdriver.SubnetInfo, rp gcprest.ResourcePath, h
 	}
 
 	resp := subnetworkResponse{
-		Kind:        "compute#subnetwork",
-		ID:          numericID(info.ID),
-		Name:        name,
-		IPCIDRRange: info.CIDRBlock,
-		Region:      host + "/compute/v1/projects/" + rp.Project + "/regions/" + region,
-		SelfLink:    gcprest.SelfLink(host, rp.Project, gcprest.ScopeRegions, region, "subnetworks", name),
+		Kind:                  "compute#subnetwork",
+		ID:                    numericID(info.ID),
+		Name:                  name,
+		IPCIDRRange:           info.CIDRBlock,
+		Region:                host + "/compute/v1/projects/" + rp.Project + "/regions/" + region,
+		SelfLink:              gcprest.SelfLink(host, rp.Project, gcprest.ScopeRegions, region, "subnetworks", name),
+		GatewayAddress:        gatewayAddress(info.CIDRBlock),
+		Purpose:               tagOr(info.Tags, subnetPurposeTag, defaultSubnetPurpose),
+		StackType:             tagOr(info.Tags, subnetStackTag, defaultStackType),
+		PrivateIPGoogleAccess: info.Tags[subnetPGATag] == trueValue,
+		Fingerprint:           fingerprintOf(name, info.CIDRBlock),
+		CreationTimestamp:     info.Tags[createdAtTag],
 	}
 
 	// Echo the parent network self-link so clients can discover a subnet's
@@ -640,16 +848,56 @@ func toSubnetworkResponse(info *netdriver.SubnetInfo, rp gcprest.ResourcePath, h
 	return resp
 }
 
+// gatewayAddress returns the first usable host of a CIDR — GCP assigns it as
+// the subnet's default gateway. Returns "" for a malformed range.
+func gatewayAddress(cidr string) string {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return ""
+	}
+
+	base := ipNet.IP.To4()
+	if base == nil {
+		base = ipNet.IP.To16()
+		if base == nil {
+			return ""
+		}
+	}
+
+	gw := append(net.IP(nil), base...)
+	gw[len(gw)-1]++
+
+	return gw.String()
+}
+
+// fingerprintOf returns a stable, non-empty base64 fingerprint. GCP requires
+// the current fingerprint on patch/update calls, so a resource missing one
+// cannot be modified.
+func fingerprintOf(parts ...string) string {
+	h := fnv.New64a()
+	for _, p := range parts {
+		_, _ = h.Write([]byte(p))
+		_, _ = h.Write([]byte{0})
+	}
+
+	var b [8]byte
+
+	binary.BigEndian.PutUint64(b[:], h.Sum64())
+
+	return base64.StdEncoding.EncodeToString(b[:])
+}
+
 //nolint:gocritic // rp is a request-scoped value
 func toFirewallResponse(info *netdriver.SecurityGroupInfo, rp gcprest.ResourcePath, host string) firewallResponse {
 	name := tagOr(info.Tags, firewallNameTag, info.ID)
 
 	resp := firewallResponse{
-		Kind:        "compute#firewall",
-		ID:          numericID(info.ID),
-		Name:        name,
-		Description: info.Description,
-		SelfLink:    gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "firewalls", name),
+		Kind:              "compute#firewall",
+		ID:                numericID(info.ID),
+		Name:              name,
+		Description:       info.Description,
+		CreationTimestamp: info.Tags[createdAtTag],
+		SelfLink:          gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "firewalls", name),
 	}
 
 	if spec, ok := unmarshalFirewallSpec(info.Tags[firewallSpecTag]); ok {

--- a/server/gcp/vpc/networks_semantics_test.go
+++ b/server/gcp/vpc/networks_semantics_test.go
@@ -1,0 +1,227 @@
+package vpc_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/option"
+)
+
+func newNetClient(t *testing.T, url string, client *http.Client) *gcpcompute.NetworksClient {
+	t.Helper()
+
+	c, err := gcpcompute.NewNetworksRESTClient(context.Background(),
+		option.WithEndpoint(url), option.WithoutAuthentication(), option.WithHTTPClient(client))
+	if err != nil {
+		t.Fatalf("NewNetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = c.Close() })
+
+	return c
+}
+
+func mustInsertNetwork(t *testing.T, ctx context.Context, c *gcpcompute.NetworksClient, n *computepb.Network) {
+	t.Helper()
+
+	op, err := c.Insert(ctx, &computepb.InsertNetworkRequest{Project: testProject, NetworkResource: n})
+	if err != nil {
+		t.Fatalf("network Insert %s: %v", n.GetName(), err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("network Insert wait %s: %v", n.GetName(), err)
+	}
+}
+
+// TestSDKNetworkCreationTimestamp covers the finding that creationTimestamp was
+// empty on every networking resource (checked here for a network).
+func TestSDKNetworkCreationTimestamp(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+	c := newNetClient(t, ts.URL, ts.Client())
+
+	mustInsertNetwork(t, ctx, c, &computepb.Network{Name: ptrStr("ts-net")})
+
+	got, err := c.Get(ctx, &computepb.GetNetworkRequest{Project: testProject, Network: "ts-net"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetCreationTimestamp() == "" {
+		t.Error("creationTimestamp empty, want RFC3339")
+	}
+}
+
+// TestSDKCustomModeNetworkOmitsIPv4Range covers the finding that IPv4Range was
+// always defaulted to 10.0.0.0/16 and always emitted, so a custom-mode network
+// wrongly read back as legacy. A modern (auto/custom) network must omit it; a
+// legacy network (explicit IPv4Range) must retain it.
+func TestSDKCustomModeNetworkOmitsIPv4Range(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+	c := newNetClient(t, ts.URL, ts.Client())
+
+	falsePtr := func() *bool { b := false; return &b }
+
+	mustInsertNetwork(t, ctx, c, &computepb.Network{
+		Name:                  ptrStr("custom-net"),
+		AutoCreateSubnetworks: falsePtr(),
+	})
+
+	custom, err := c.Get(ctx, &computepb.GetNetworkRequest{Project: testProject, Network: "custom-net"})
+	if err != nil {
+		t.Fatalf("Get custom-net: %v", err)
+	}
+
+	if custom.GetIPv4Range() != "" {
+		t.Errorf("custom-mode IPv4Range=%q want empty", custom.GetIPv4Range())
+	}
+
+	mustInsertNetwork(t, ctx, c, &computepb.Network{
+		Name:      ptrStr("legacy-net"),
+		IPv4Range: ptrStr("192.168.0.0/16"),
+	})
+
+	legacy, err := c.Get(ctx, &computepb.GetNetworkRequest{Project: testProject, Network: "legacy-net"})
+	if err != nil {
+		t.Fatalf("Get legacy-net: %v", err)
+	}
+
+	if legacy.GetIPv4Range() != "192.168.0.0/16" {
+		t.Errorf("legacy IPv4Range=%q want 192.168.0.0/16", legacy.GetIPv4Range())
+	}
+}
+
+// TestSDKNetworkDeleteInUse covers the finding that deleting a network with a
+// live subnetwork succeeded and orphaned the subnet. It must fail until the
+// subnet is removed.
+func TestSDKNetworkDeleteInUse(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+	c := newNetClient(t, ts.URL, ts.Client())
+
+	mustInsertNetwork(t, ctx, c, &computepb.Network{
+		Name:                  ptrStr("vpc-inuse"),
+		AutoCreateSubnetworks: func() *bool { b := false; return &b }(),
+	})
+
+	subClient, err := gcpcompute.NewSubnetworksRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewSubnetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = subClient.Close() })
+
+	subOp, err := subClient.Insert(ctx, &computepb.InsertSubnetworkRequest{
+		Project: testProject,
+		Region:  "us-central1",
+		SubnetworkResource: &computepb.Subnetwork{
+			Name:        ptrStr("sub-inuse"),
+			Network:     ptrStr("projects/" + testProject + "/global/networks/vpc-inuse"),
+			IpCidrRange: ptrStr("10.5.0.0/16"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("subnet Insert: %v", err)
+	}
+
+	if err := subOp.Wait(ctx); err != nil {
+		t.Fatalf("subnet Insert wait: %v", err)
+	}
+
+	if _, err := c.Delete(ctx, &computepb.DeleteNetworkRequest{Project: testProject, Network: "vpc-inuse"}); err == nil {
+		t.Fatal("Delete of in-use network: want error, got nil")
+	}
+
+	// The subnet must still exist (delete rejected, not partially applied).
+	if _, err := subClient.Get(ctx, &computepb.GetSubnetworkRequest{
+		Project: testProject, Region: "us-central1", Subnetwork: "sub-inuse",
+	}); err != nil {
+		t.Errorf("subnet Get after rejected network delete: %v", err)
+	}
+}
+
+// TestNetworkListPagination covers the finding that maxResults/pageToken were
+// ignored and nextPageToken never set. Verified over the wire since the SDK
+// iterator transparently follows pages.
+func TestNetworkListPagination(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+	c := newNetClient(t, ts.URL, ts.Client())
+
+	for _, name := range []string{"pg-a", "pg-b", "pg-c"} {
+		mustInsertNetwork(t, ctx, c, &computepb.Network{Name: ptrStr(name)})
+	}
+
+	var page struct {
+		Items         []json.RawMessage `json:"items"`
+		NextPageToken string            `json:"nextPageToken"`
+	}
+
+	url := ts.URL + "/compute/v1/projects/" + testProject + "/global/networks?maxResults=1"
+
+	resp, err := ts.Client().Get(url)
+	if err != nil {
+		t.Fatalf("list GET: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(page.Items) != 1 {
+		t.Errorf("page items=%d want 1 (maxResults ignored)", len(page.Items))
+	}
+
+	if page.NextPageToken == "" {
+		t.Error("nextPageToken empty, want a continuation token")
+	}
+}
+
+// TestComputeUnmatchedPathReturnsJSONError covers the finding that an
+// unimplemented /compute/v1 path returned a bare-text 501 with the wrong
+// Content-Type instead of a GCP JSON error envelope.
+func TestComputeUnmatchedPathReturnsJSONError(t *testing.T) {
+	ts := newGCPNetServer(t)
+
+	url := ts.URL + "/compute/v1/projects/" + testProject + "/global/targetHttpProxies"
+
+	resp, err := ts.Client().Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotImplemented {
+		t.Errorf("status=%d want 501", resp.StatusCode)
+	}
+
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type=%q want application/json", ct)
+	}
+
+	var env struct {
+		Error struct {
+			Code    int    `json:"code"`
+			Status  string `json:"status"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+
+	if env.Error.Code != http.StatusNotImplemented || env.Error.Status == "" {
+		t.Errorf("envelope code=%d status=%q want 501/non-empty", env.Error.Code, env.Error.Status)
+	}
+}

--- a/server/gcp/vpc/routers.go
+++ b/server/gcp/vpc/routers.go
@@ -78,7 +78,7 @@ func (s *routerStore) delete(project, region, name string) bool {
 	return true
 }
 
-//nolint:gocritic,dupl // rp is a request-scoped value; CRUD route shape is duplicate-by-design across resource types
+//nolint:gocritic // rp is a request-scoped value; CRUD route shape is duplicate-by-design across resource types
 func (h *Handler) routeRouters(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
 	if rp.ResourceName == "" {
 		switch r.Method {

--- a/server/gcp/vpc/routes.go
+++ b/server/gcp/vpc/routes.go
@@ -1,0 +1,211 @@
+package vpc
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"sync"
+
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+)
+
+// Routes are custom static routes on a VPC network — the record that sends a
+// destination range to a next hop (gateway, IP, or instance). A caller
+// building a network with an internet or NAT route creates one here, so
+// without the collection the network step stops before egress works.
+//
+// Like routers and addresses, routes are held in the handler rather than the
+// networking driver: a route's next-hop shape is specific to this provider's
+// REST surface, not part of the portable subset. GCP routes are global.
+type routeStore struct {
+	mu     sync.RWMutex
+	routes map[string]map[string]json.RawMessage // project -> name -> body
+}
+
+func newRouteStore() *routeStore {
+	return &routeStore{routes: map[string]map[string]json.RawMessage{}}
+}
+
+func (s *routeStore) put(project, name string, body json.RawMessage) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.routes[project] == nil {
+		s.routes[project] = map[string]json.RawMessage{}
+	}
+
+	s.routes[project][name] = body
+}
+
+func (s *routeStore) get(project, name string) (json.RawMessage, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	b, ok := s.routes[project][name]
+
+	return b, ok
+}
+
+func (s *routeStore) list(project string) []json.RawMessage {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	byName := s.routes[project]
+	out := make([]json.RawMessage, 0, len(byName))
+
+	for _, b := range byName {
+		out = append(out, b)
+	}
+
+	return out
+}
+
+func (s *routeStore) delete(project, name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.routes[project][name]; !ok {
+		return false
+	}
+
+	delete(s.routes[project], name)
+
+	return true
+}
+
+//nolint:gocritic,dupl // rp is a request-scoped value; CRUD route shape is duplicate-by-design across resource types
+func (h *Handler) routeRoutes(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.ResourceName == "" {
+		switch r.Method {
+		case http.MethodPost:
+			h.insertRoute(w, r, rp)
+		case http.MethodGet:
+			h.listRoutes(w, r, rp)
+		default:
+			gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getRoute(w, r, rp)
+	case http.MethodDelete:
+		h.deleteRoute(w, r, rp)
+	default:
+		gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) insertRoute(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.Scope != gcprest.ScopeGlobal {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "routes are global")
+		return
+	}
+
+	var raw json.RawMessage
+	if !gcprest.DecodeJSON(w, r, &raw) {
+		return
+	}
+
+	name := rawName(raw)
+	if name == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "name is required")
+		return
+	}
+
+	if _, exists := h.routes.get(rp.Project, name); exists {
+		gcprest.WriteError(w, http.StatusConflict, "alreadyExists", "route "+name+" already exists")
+		return
+	}
+
+	h.routes.put(rp.Project, name, enrichRoute(raw, rp, hostOf(r), name))
+
+	gcprest.WriteJSON(w, http.StatusOK, gcprest.NewDoneOperation(hostOf(r), rp.Project,
+		gcprest.ScopeGlobal, "", resourceRoutes, name, "insert"))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getRoute(w http.ResponseWriter, _ *http.Request, rp gcprest.ResourcePath) {
+	body, ok := h.routes.get(rp.Project, rp.ResourceName)
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "route "+rp.ResourceName+" not found")
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, body)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listRoutes(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	all := h.routes.list(rp.Project)
+	filter := r.URL.Query().Get("filter")
+
+	items := make([]json.RawMessage, 0, len(all))
+
+	for _, body := range all {
+		if nameMatches(filter, rawName(body)) {
+			items = append(items, body)
+		}
+	}
+
+	sort.SliceStable(items, func(i, j int) bool { return rawName(items[i]) < rawName(items[j]) })
+
+	page, err := pagination.Paginate(items, r.URL.Query().Get("pageToken"),
+		maxResultsOf(r.URL.Query().Get("maxResults")))
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid pageToken")
+		return
+	}
+
+	out := map[string]any{
+		"kind":     "compute#routeList",
+		"id":       "projects/" + rp.Project + "/global/routes",
+		"items":    page.Items,
+		"selfLink": gcprest.SelfLink(hostOf(r), rp.Project, gcprest.ScopeGlobal, "", resourceRoutes, ""),
+	}
+	if page.NextPageToken != "" {
+		out["nextPageToken"] = page.NextPageToken
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteRoute(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if !h.routes.delete(rp.Project, rp.ResourceName) {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "route "+rp.ResourceName+" not found")
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, gcprest.NewDoneOperation(hostOf(r), rp.Project,
+		gcprest.ScopeGlobal, "", resourceRoutes, rp.ResourceName, "delete"))
+}
+
+// enrichRoute stamps the server-assigned fields (kind, id, selfLink,
+// creationTimestamp) onto a route while preserving the caller's routing spec
+// (network, destRange, next-hop, priority). Without them a Get reads back an
+// incomplete resource.
+//
+//nolint:gocritic // rp is a request-scoped value
+func enrichRoute(raw json.RawMessage, rp gcprest.ResourcePath, host, name string) json.RawMessage {
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil || body == nil {
+		return raw
+	}
+
+	body["kind"] = "compute#route"
+	body["id"] = numericID(rp.Project + "/routes/" + name)
+	body["selfLink"] = gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", resourceRoutes, name)
+	body["creationTimestamp"] = nowRFC3339()
+
+	enriched, err := json.Marshal(body)
+	if err != nil {
+		return raw
+	}
+
+	return enriched
+}

--- a/server/gcp/vpc/routes_test.go
+++ b/server/gcp/vpc/routes_test.go
@@ -1,0 +1,99 @@
+package vpc_test
+
+import (
+	"context"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/option"
+)
+
+// TestSDKRouteRoundTrip covers the compute-networking finding that the Routes
+// API was entirely unrouted (501). Insert/Get/List/Delete must now work.
+func TestSDKRouteRoundTrip(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewRoutesRESTClient(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewRoutesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertRouteRequest{
+		Project: testProject,
+		RouteResource: &computepb.Route{
+			Name:           ptrStr("route-1"),
+			Network:        ptrStr("projects/" + testProject + "/global/networks/default"),
+			DestRange:      ptrStr("0.0.0.0/0"),
+			NextHopGateway: ptrStr("projects/" + testProject + "/global/gateways/default-internet-gateway"),
+			Priority:       func() *uint32 { p := uint32(1000); return &p }(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetRouteRequest{Project: testProject, Route: "route-1"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetName() != "route-1" {
+		t.Errorf("name=%s want route-1", got.GetName())
+	}
+
+	if got.GetDestRange() != "0.0.0.0/0" {
+		t.Errorf("destRange=%s want 0.0.0.0/0", got.GetDestRange())
+	}
+
+	if got.GetKind() != "compute#route" || got.GetSelfLink() == "" {
+		t.Errorf("kind=%s selfLink=%s want populated", got.GetKind(), got.GetSelfLink())
+	}
+
+	if got.GetCreationTimestamp() == "" {
+		t.Error("creationTimestamp empty, want RFC3339")
+	}
+
+	it := client.List(ctx, &computepb.ListRoutesRequest{Project: testProject})
+
+	found := false
+
+	for {
+		rt, iterErr := it.Next()
+		if iterErr != nil {
+			break
+		}
+
+		if rt.GetName() == "route-1" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Error("List did not return route-1")
+	}
+
+	delOp, err := client.Delete(ctx, &computepb.DeleteRouteRequest{Project: testProject, Route: "route-1"})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Errorf("Delete wait: %v", err)
+	}
+
+	if _, err := client.Get(ctx, &computepb.GetRouteRequest{Project: testProject, Route: "route-1"}); err == nil {
+		t.Error("Get after Delete: want error, got nil")
+	}
+}

--- a/server/gcp/vpc/subnetworks_test.go
+++ b/server/gcp/vpc/subnetworks_test.go
@@ -1,0 +1,103 @@
+package vpc_test
+
+import (
+	"context"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/option"
+)
+
+// TestSDKSubnetworkRegionScoped covers the finding that subnetwork get/delete
+// ignored the region: two subnets of the same name in different regions
+// resolved to the first found (wrong CIDR / wrong region on delete).
+func TestSDKSubnetworkRegionScoped(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	netClient, err := gcpcompute.NewNetworksRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewNetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = netClient.Close() })
+
+	netOp, err := netClient.Insert(ctx, &computepb.InsertNetworkRequest{
+		Project: testProject,
+		NetworkResource: &computepb.Network{
+			Name:                  ptrStr("vpc-a"),
+			AutoCreateSubnetworks: func() *bool { b := false; return &b }(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("network Insert: %v", err)
+	}
+
+	if err := netOp.Wait(ctx); err != nil {
+		t.Fatalf("network Insert wait: %v", err)
+	}
+
+	subClient, err := gcpcompute.NewSubnetworksRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewSubnetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = subClient.Close() })
+
+	insertSubnet(t, ctx, subClient, "us-central1", "dup-sub", "10.1.0.0/16")
+	insertSubnet(t, ctx, subClient, "us-east1", "dup-sub", "10.2.0.0/16")
+
+	got, err := subClient.Get(ctx, &computepb.GetSubnetworkRequest{
+		Project: testProject, Region: "us-east1", Subnetwork: "dup-sub",
+	})
+	if err != nil {
+		t.Fatalf("Get us-east1: %v", err)
+	}
+
+	// Finding: must resolve the us-east1 subnet (10.2.0.0/16), not first-found.
+	if got.GetIpCidrRange() != "10.2.0.0/16" {
+		t.Errorf("ipCidrRange=%s want 10.2.0.0/16 (region ignored)", got.GetIpCidrRange())
+	}
+
+	// Finding: gatewayAddress/purpose/stackType/fingerprint/creationTimestamp
+	// must be populated.
+	if got.GetGatewayAddress() != "10.2.0.1" {
+		t.Errorf("gatewayAddress=%s want 10.2.0.1", got.GetGatewayAddress())
+	}
+
+	if got.GetPurpose() != "PRIVATE" || got.GetStackType() != "IPV4_ONLY" {
+		t.Errorf("purpose=%s stackType=%s want PRIVATE/IPV4_ONLY", got.GetPurpose(), got.GetStackType())
+	}
+
+	if got.GetFingerprint() == "" {
+		t.Error("fingerprint empty, want a value (needed to patch)")
+	}
+
+	if got.GetCreationTimestamp() == "" {
+		t.Error("creationTimestamp empty, want RFC3339")
+	}
+}
+
+func insertSubnet(t *testing.T, ctx context.Context, c *gcpcompute.SubnetworksClient, region, name, cidr string) {
+	t.Helper()
+
+	op, err := c.Insert(ctx, &computepb.InsertSubnetworkRequest{
+		Project: testProject,
+		Region:  region,
+		SubnetworkResource: &computepb.Subnetwork{
+			Name:        ptrStr(name),
+			Network:     ptrStr("projects/" + testProject + "/global/networks/vpc-a"),
+			IpCidrRange: ptrStr(cidr),
+		},
+	})
+	if err != nil {
+		t.Fatalf("subnet Insert %s/%s: %v", region, name, err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("subnet Insert wait %s/%s: %v", region, name, err)
+	}
+}

--- a/server/gcp/vpc/types.go
+++ b/server/gcp/vpc/types.go
@@ -19,37 +19,49 @@ type networkResponse struct {
 	IPv4Range             string `json:"IPv4Range,omitempty"`
 	AutoCreateSubnetworks bool   `json:"autoCreateSubnetworks"`
 	RoutingConfig         any    `json:"routingConfig,omitempty"`
+	CreationTimestamp     string `json:"creationTimestamp,omitempty"`
 }
 
 type networkListResponse struct {
-	Kind     string            `json:"kind"`
-	ID       string            `json:"id"`
-	Items    []networkResponse `json:"items"`
-	SelfLink string            `json:"selfLink"`
+	Kind          string            `json:"kind"`
+	ID            string            `json:"id"`
+	Items         []networkResponse `json:"items"`
+	SelfLink      string            `json:"selfLink"`
+	NextPageToken string            `json:"nextPageToken,omitempty"`
 }
 
 type subnetworkRequest struct {
-	Name        string `json:"name"`
-	Network     string `json:"network,omitempty"`
-	IPCIDRRange string `json:"ipCidrRange,omitempty"`
-	Region      string `json:"region,omitempty"`
+	Name                  string `json:"name"`
+	Network               string `json:"network,omitempty"`
+	IPCIDRRange           string `json:"ipCidrRange,omitempty"`
+	Region                string `json:"region,omitempty"`
+	Purpose               string `json:"purpose,omitempty"`
+	StackType             string `json:"stackType,omitempty"`
+	PrivateIPGoogleAccess *bool  `json:"privateIpGoogleAccess,omitempty"`
 }
 
 type subnetworkResponse struct {
-	Kind        string `json:"kind"`
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Network     string `json:"network,omitempty"`
-	IPCIDRRange string `json:"ipCidrRange,omitempty"`
-	Region      string `json:"region,omitempty"`
-	SelfLink    string `json:"selfLink"`
+	Kind                  string `json:"kind"`
+	ID                    string `json:"id"`
+	Name                  string `json:"name"`
+	Network               string `json:"network,omitempty"`
+	IPCIDRRange           string `json:"ipCidrRange,omitempty"`
+	Region                string `json:"region,omitempty"`
+	SelfLink              string `json:"selfLink"`
+	GatewayAddress        string `json:"gatewayAddress,omitempty"`
+	Purpose               string `json:"purpose,omitempty"`
+	StackType             string `json:"stackType,omitempty"`
+	PrivateIPGoogleAccess bool   `json:"privateIpGoogleAccess"`
+	Fingerprint           string `json:"fingerprint,omitempty"`
+	CreationTimestamp     string `json:"creationTimestamp,omitempty"`
 }
 
 type subnetworkListResponse struct {
-	Kind     string               `json:"kind"`
-	ID       string               `json:"id"`
-	Items    []subnetworkResponse `json:"items"`
-	SelfLink string               `json:"selfLink"`
+	Kind          string               `json:"kind"`
+	ID            string               `json:"id"`
+	Items         []subnetworkResponse `json:"items"`
+	SelfLink      string               `json:"selfLink"`
+	NextPageToken string               `json:"nextPageToken,omitempty"`
 }
 
 type firewallRequest struct {
@@ -70,23 +82,25 @@ type firewallRule struct {
 }
 
 type firewallResponse struct {
-	Kind         string         `json:"kind"`
-	ID           string         `json:"id"`
-	Name         string         `json:"name"`
-	Network      string         `json:"network,omitempty"`
-	Description  string         `json:"description,omitempty"`
-	Priority     int            `json:"priority,omitempty"`
-	Direction    string         `json:"direction,omitempty"`
-	Allowed      []firewallRule `json:"allowed,omitempty"`
-	Denied       []firewallRule `json:"denied,omitempty"`
-	SourceRanges []string       `json:"sourceRanges,omitempty"`
-	TargetTags   []string       `json:"targetTags,omitempty"`
-	SelfLink     string         `json:"selfLink"`
+	Kind              string         `json:"kind"`
+	ID                string         `json:"id"`
+	Name              string         `json:"name"`
+	Network           string         `json:"network,omitempty"`
+	Description       string         `json:"description,omitempty"`
+	Priority          int            `json:"priority,omitempty"`
+	Direction         string         `json:"direction,omitempty"`
+	Allowed           []firewallRule `json:"allowed,omitempty"`
+	Denied            []firewallRule `json:"denied,omitempty"`
+	SourceRanges      []string       `json:"sourceRanges,omitempty"`
+	TargetTags        []string       `json:"targetTags,omitempty"`
+	SelfLink          string         `json:"selfLink"`
+	CreationTimestamp string         `json:"creationTimestamp,omitempty"`
 }
 
 type firewallListResponse struct {
-	Kind     string             `json:"kind"`
-	ID       string             `json:"id"`
-	Items    []firewallResponse `json:"items"`
-	SelfLink string             `json:"selfLink"`
+	Kind          string             `json:"kind"`
+	ID            string             `json:"id"`
+	Items         []firewallResponse `json:"items"`
+	SelfLink      string             `json:"selfLink"`
+	NextPageToken string             `json:"nextPageToken,omitempty"`
 }


### PR DESCRIPTION
## What

Fixes all 9 findings in the `## compute-networking` section of AUDIT_GCP.md, at the GCP compute-networking wire layer (`server/gcp/vpc`, shared `gcprest` codec). No driver-interface changes — GCP-specific state is carried in reserved tags / handler-local stores, so AWS/Azure are untouched.

## Findings fixed

1. **[HIGH][MISSING] Routes API entirely unrouted (501)** — added the global `routes` collection (insert/get/list/delete) as a handler-local store mirroring routers/addresses; responses enriched with `kind`/`id`/`selfLink`/`creationTimestamp`, caller's routing spec (network/destRange/next-hop/priority) preserved.
2. **[HIGH][BEHAVIORAL] Addresses allocated no IP** — reserved addresses now get an allocated IP, `status=RESERVED`, `kind`, numeric `id`, `selfLink`, `region` and `creationTimestamp`; caller fields (purpose/prefixLength/addressType) round-trip. Unblocks PSA / VPC_PEERING range reservation.
3. **[HIGH][WRONG_WIRE] subnetworks.get/delete ignored region** — `findSubnetByName` is now region-scoped (a name shared across two regions resolves to the correct region's CIDR; delete hits the right one). Subnetwork list is region-scoped too.
4. **[HIGH][BEHAVIORAL] networks.delete orphaned live subnets** — delete now scans for attached subnetworks and rejects with `400 resourceInUseByAnotherResource` until they are removed.
5. **[MEDIUM][BEHAVIORAL] list params ignored** — networks/subnetworks/firewalls/addresses/routes lists honor `maxResults`/`pageToken`/`filter` (name filter) and set `nextPageToken`.
6. **[MEDIUM][MISSING] creationTimestamp empty** — networks/subnetworks/firewalls (and routes/addresses) now stamp and return an RFC3339 `creationTimestamp`.
7. **[MEDIUM][WRONG_WIRE] IPv4Range always emitted** — only a legacy network (explicit `IPv4Range`) reports one; auto/custom-mode networks omit it, so a custom network no longer reads back as legacy.
8. **[LOW][MISSING] subnetwork fields** — `gatewayAddress` (first host of the CIDR), `purpose` (default PRIVATE), `stackType` (default IPV4_ONLY), `privateIpGoogleAccess`, and a stable `fingerprint` (needed to patch) are now returned.
9. **[LOW][WRONG_WIRE] bare-text 501 for unmatched /compute/v1** — a compute-space catch-all (`compute.NewFallback`, registered after the real compute/networks/LB handlers) returns a GCP JSON error envelope with the correct Content-Type.

## Why

These are behaviors a real user hits driving the GCP Compute networking REST API with the official `cloud.google.com/go/compute` clients (Terraform `google_compute_route`/`_subnetwork`/`_address`, PSA setup, `gcloud`). Each was verified against `cloud.google.com/compute/docs/reference/rest/v1`.

## Tests

Reproduction tests use the real `cloud.google.com/go/compute/apiv1` networking clients (`Routes`, `GlobalAddresses`, `Subnetworks`, `Networks`) with `option.WithEndpoint` against the in-process GCP server, one per finding: `routes_test.go`, `addresses_test.go`, `subnetworks_test.go`, `networks_semantics_test.go` (delete-in-use, pagination, creationTimestamp, custom-mode IPv4Range, JSON 501). Existing GCP vpc tests stay green.

## Deferrals

None.
