### PR TITLE
fix(gcp-cloudsql): request-project connectionName, absolute selfLinks, list filter+pagination, persisted operations

### DIFF
--- a/server/gcp/cloudsql/handler.go
+++ b/server/gcp/cloudsql/handler.go
@@ -17,7 +17,7 @@
 //	GET    /v1/projects/{p}/instances/{i}/backupRuns             — List backup runs
 //	GET    /v1/projects/{p}/instances/{i}/backupRuns/{id}        — Get backup run
 //	DELETE /v1/projects/{p}/instances/{i}/backupRuns/{id}        — Delete backup run
-//	GET    /v1/projects/{p}/operations/{op}                      — Poll operation (always DONE)
+//	GET    /v1/projects/{p}/operations/{op}                      — Poll operation (recorded record, 404 if unknown)
 //
 // All mutating endpoints return Operation envelopes with status=DONE so SDK
 // pollers terminate on the first response. Start/Stop are emulated via
@@ -32,6 +32,7 @@ package cloudsql
 import (
 	"net/http"
 	"strings"
+	"sync"
 
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
@@ -65,11 +66,40 @@ func isSubResource(seg string) bool {
 // Handler serves Cloud SQL Admin REST requests against a relationaldb driver.
 type Handler struct {
 	db rdsdriver.RelationalDB
+
+	// mu guards ops. Mutating endpoints complete inline (status=DONE) and record
+	// the resulting Operation here so a later Operations.Get returns the real
+	// CREATE/UPDATE/DELETE record — pointing at the affected resource — rather
+	// than a synthetic stand-in.
+	mu  sync.RWMutex
+	ops map[string]operation
 }
 
 // New returns a Cloud SQL handler backed by db.
 func New(db rdsdriver.RelationalDB) *Handler {
-	return &Handler{db: db}
+	return &Handler{
+		db:  db,
+		ops: make(map[string]operation),
+	}
+}
+
+// buildOp builds the DONE operation for a finished mutation and records it
+// keyed by name, so a later Operations.Get serves the same record. It returns
+// the operation for callers that embed it in a larger response (e.g.
+// sslCerts.insert).
+func (h *Handler) buildOp(project, name, opType, resourceType, target string) operation {
+	op := doneOperationWithTarget(project, name, opType, resourceType, target)
+
+	h.mu.Lock()
+	h.ops[name] = op
+	h.mu.Unlock()
+
+	return op
+}
+
+// completeOp records the mutation's operation and writes it as the LRO response.
+func (h *Handler) completeOp(w http.ResponseWriter, project, name, opType, resourceType, target string) {
+	writeJSON(w, http.StatusOK, h.buildOp(project, name, opType, resourceType, target))
 }
 
 // Matches accepts /v1/projects/{p}/{instances|operations|tiers}/... paths plus
@@ -290,7 +320,7 @@ func (h *Handler) serveBackupRunsRoute(w http.ResponseWriter, r *http.Request, p
 	}
 }
 
-func (*Handler) serveOperation(w http.ResponseWriter, r *http.Request, p *sqlPath) {
+func (h *Handler) serveOperation(w http.ResponseWriter, r *http.Request, p *sqlPath) {
 	if r.Method != http.MethodGet {
 		writeMethodNotAllowed(w)
 		return
@@ -301,7 +331,18 @@ func (*Handler) serveOperation(w http.ResponseWriter, r *http.Request, p *sqlPat
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperation(p.project, p.name, "GET", "noop"))
+	h.mu.RLock()
+	op, ok := h.ops[p.name]
+	h.mu.RUnlock()
+
+	// Real Cloud SQL returns 404 for an unknown operation rather than a
+	// synthetic DONE, so pollers surface a genuinely missing op.
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "operation not found: "+p.name)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, op)
 }
 
 func writeMethodNotAllowed(w http.ResponseWriter) {

--- a/server/gcp/cloudsql/instances_sdk_test.go
+++ b/server/gcp/cloudsql/instances_sdk_test.go
@@ -1,0 +1,200 @@
+package cloudsql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sqladmin "google.golang.org/api/sqladmin/v1"
+)
+
+const selfLinkPrefix = "https://sqladmin.googleapis.com/sql/v1beta4/projects/"
+
+// insertInstance is a small helper that creates a Postgres instance and fails
+// the test on error.
+func insertInstance(t *testing.T, svc *sqladmin.Service, project, name string) {
+	t.Helper()
+
+	if _, err := svc.Instances.Insert(project, &sqladmin.DatabaseInstance{
+		Name:            name,
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings:        &sqladmin.Settings{Tier: "db-custom-2-8192"},
+	}).Context(context.Background()).Do(); err != nil {
+		t.Fatalf("Insert %s: %v", name, err)
+	}
+}
+
+// Finding: connectionName was built from the server's configured project
+// (mock-project), ignoring the request project. Real Cloud SQL keys it on the
+// request project as {project}:{region}:{instance}.
+func TestSDKCloudSQLConnectionNameUsesRequestProject(t *testing.T) {
+	svc, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	const project = "proj"
+
+	insertInstance(t, svc, project, "pg")
+
+	got, err := svc.Instances.Get(project, "pg").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if want := "proj:us-central1:pg"; got.ConnectionName != want {
+		t.Fatalf("connectionName = %q, want %q", got.ConnectionName, want)
+	}
+
+	if strings.HasPrefix(got.ConnectionName, "mock-project:") {
+		t.Fatalf("connectionName %q still keyed on the server project", got.ConnectionName)
+	}
+}
+
+// Finding: selfLink was a relative, wrong-version path (/v1/projects/...).
+// Real Cloud SQL returns the absolute sql/v1beta4 URL, for instances and
+// databases alike.
+func TestSDKCloudSQLSelfLinkIsAbsolute(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	insertInstance(t, svc, project, "orders")
+
+	got, err := svc.Instances.Get(project, "orders").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if want := selfLinkPrefix + project + "/instances/orders"; got.SelfLink != want {
+		t.Fatalf("instance selfLink = %q, want %q", got.SelfLink, want)
+	}
+
+	if _, err := svc.Databases.Insert(project, "orders", &sqladmin.Database{
+		Name: "appdb",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Databases.Insert: %v", err)
+	}
+
+	db, err := svc.Databases.Get(project, "orders", "appdb").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Databases.Get: %v", err)
+	}
+
+	if want := selfLinkPrefix + project + "/instances/orders/databases/appdb"; db.SelfLink != want {
+		t.Fatalf("database selfLink = %q, want %q", db.SelfLink, want)
+	}
+}
+
+// Finding: instances.list ignored maxResults, pageToken and filter and never
+// returned a nextPageToken.
+func TestSDKCloudSQLListPaginationAndFilter(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"aaa1", "aaa2", "bbb1", "bbb2"} {
+		insertInstance(t, svc, project, name)
+	}
+
+	// Page 1: two items plus a continuation token.
+	page1, err := svc.Instances.List(project).MaxResults(2).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List page 1: %v", err)
+	}
+
+	if len(page1.Items) != 2 {
+		t.Fatalf("page 1 items = %d, want 2", len(page1.Items))
+	}
+
+	if page1.NextPageToken == "" {
+		t.Fatal("expected a nextPageToken on page 1")
+	}
+
+	// Page 2: the remaining two, no further token.
+	page2, err := svc.Instances.List(project).MaxResults(2).PageToken(page1.NextPageToken).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List page 2: %v", err)
+	}
+
+	if len(page2.Items) != 2 {
+		t.Fatalf("page 2 items = %d, want 2", len(page2.Items))
+	}
+
+	if page2.NextPageToken != "" {
+		t.Fatalf("page 2 nextPageToken = %q, want empty", page2.NextPageToken)
+	}
+
+	// Filter narrows to the two aaa* instances.
+	filtered, err := svc.Instances.List(project).Filter("name:aaa").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List filtered: %v", err)
+	}
+
+	if len(filtered.Items) != 2 {
+		t.Fatalf("filtered items = %d, want 2", len(filtered.Items))
+	}
+
+	for _, it := range filtered.Items {
+		if !strings.Contains(it.Name, "aaa") {
+			t.Fatalf("filter returned non-matching instance %q", it.Name)
+		}
+	}
+}
+
+// Finding: Operations.Get returned a synthetic operationType=GET with empty
+// target fields, and the insert LRO left selfLink/timestamps/user empty. Real
+// Cloud SQL persists the CREATE/UPDATE/DELETE record pointing at the affected
+// instance.
+func TestSDKCloudSQLOperationsGetReturnsRealRecord(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	op, err := svc.Instances.Insert(project, &sqladmin.DatabaseInstance{
+		Name:            "acct",
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings:        &sqladmin.Settings{Tier: "db-custom-2-8192"},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	// The inline LRO envelope carries the full record.
+	assertCreateOp(t, op)
+
+	// Operations.Get returns the same persisted record, not a synthetic GET.
+	got, err := svc.Operations.Get(project, op.Name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Operations.Get: %v", err)
+	}
+
+	assertCreateOp(t, got)
+
+	// An unknown operation is a 404, not a synthetic DONE.
+	if _, err := svc.Operations.Get(project, "no-such-op").Context(ctx).Do(); err == nil {
+		t.Fatal("expected error for unknown operation, got nil")
+	}
+}
+
+func assertCreateOp(t *testing.T, op *sqladmin.Operation) {
+	t.Helper()
+
+	if op.OperationType != "CREATE" {
+		t.Fatalf("operationType = %q, want CREATE", op.OperationType)
+	}
+
+	if op.TargetId != "acct" {
+		t.Fatalf("targetId = %q, want acct", op.TargetId)
+	}
+
+	if !strings.HasPrefix(op.SelfLink, selfLinkPrefix) {
+		t.Fatalf("operation selfLink = %q, want absolute sql/v1beta4 URL", op.SelfLink)
+	}
+
+	if !strings.HasPrefix(op.TargetLink, selfLinkPrefix) {
+		t.Fatalf("operation targetLink = %q, want absolute sql/v1beta4 URL", op.TargetLink)
+	}
+
+	if op.InsertTime == "" || op.StartTime == "" || op.EndTime == "" || op.User == "" {
+		t.Fatalf("operation missing populated fields: insert=%q start=%q end=%q user=%q",
+			op.InsertTime, op.StartTime, op.EndTime, op.User)
+	}
+}

--- a/server/gcp/cloudsql/list.go
+++ b/server/gcp/cloudsql/list.go
@@ -1,0 +1,94 @@
+package cloudsql
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
+)
+
+// paginateInstances sorts instances by name and slices out one page using the
+// offset-based pageToken and maxResults, mirroring Cloud SQL's instances.list
+// paging. An empty/zero maxResults falls back to the shared default page size.
+func paginateInstances(items []sqlInstance, pageToken, maxResults string) (pagination.Page[sqlInstance], error) {
+	limit := 0
+
+	if maxResults != "" {
+		if n, err := strconv.Atoi(maxResults); err == nil && n > 0 {
+			limit = n
+		}
+	}
+
+	return pagination.PaginateSorted(items, func(a, b sqlInstance) bool {
+		return a.Name < b.Name
+	}, pageToken, limit)
+}
+
+// filterInstances applies a Cloud SQL list filter of the form "field:value"
+// (substring/"has" match) or "field=value" (exact match). Unrecognized or
+// empty filters leave the list unchanged. Supported fields cover the common
+// instances.list predicates: name, state, region, databaseVersion,
+// backendType.
+func filterInstances(items []sqlInstance, filter string) []sqlInstance {
+	field, value, exact, ok := parseFilter(filter)
+	if !ok {
+		return items
+	}
+
+	out := make([]sqlInstance, 0, len(items))
+
+	for i := range items {
+		if instanceMatches(&items[i], field, value, exact) {
+			out = append(out, items[i])
+		}
+	}
+
+	return out
+}
+
+// parseFilter splits a "field<op>value" expression. exact is true for "=" and
+// false for ":". ok is false when the filter is empty or malformed.
+func parseFilter(filter string) (field, value string, exact, ok bool) {
+	filter = strings.TrimSpace(filter)
+	if filter == "" {
+		return "", "", false, false
+	}
+
+	if i := strings.IndexByte(filter, '='); i > 0 {
+		return strings.TrimSpace(filter[:i]), strings.TrimSpace(filter[i+1:]), true, true
+	}
+
+	if i := strings.IndexByte(filter, ':'); i > 0 {
+		return strings.TrimSpace(filter[:i]), strings.TrimSpace(filter[i+1:]), false, true
+	}
+
+	return "", "", false, false
+}
+
+// instanceMatches reports whether inst satisfies the parsed predicate. An
+// unknown field never matches, so a bogus filter yields an empty list rather
+// than silently returning everything.
+func instanceMatches(inst *sqlInstance, field, value string, exact bool) bool {
+	var got string
+
+	switch strings.ToLower(field) {
+	case "name":
+		got = inst.Name
+	case "state":
+		got = inst.State
+	case "region":
+		got = inst.Region
+	case "databaseversion":
+		got = inst.DatabaseVersion
+	case "backendtype":
+		got = inst.BackendType
+	default:
+		return false
+	}
+
+	if exact {
+		return strings.EqualFold(got, value)
+	}
+
+	return strings.Contains(strings.ToLower(got), strings.ToLower(value))
+}

--- a/server/gcp/cloudsql/operations.go
+++ b/server/gcp/cloudsql/operations.go
@@ -62,9 +62,9 @@ func (h *Handler) insertInstance(w http.ResponseWriter, r *http.Request, p *sqlP
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperationWithTarget(
+	h.completeOp(w,
 		p.project, "create-"+inst.ID, "CREATE", "instances", inst.ID,
-	))
+	)
 }
 
 func (h *Handler) listInstances(w http.ResponseWriter, r *http.Request, p *sqlPath) {
@@ -74,12 +74,25 @@ func (h *Handler) listInstances(w http.ResponseWriter, r *http.Request, p *sqlPa
 		return
 	}
 
-	out := sqlInstanceList{Kind: "sql#instancesList", Items: make([]sqlInstance, 0, len(insts))}
+	items := make([]sqlInstance, 0, len(insts))
 	for i := range insts {
-		out.Items = append(out.Items, toSQLInstance(&insts[i], p.project))
+		items = append(items, toSQLInstance(&insts[i], p.project))
 	}
 
-	writeJSON(w, http.StatusOK, out)
+	q := r.URL.Query()
+	items = filterInstances(items, q.Get("filter"))
+
+	page, err := paginateInstances(items, q.Get("pageToken"), q.Get("maxResults"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "invalid pageToken")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, sqlInstanceList{
+		Kind:          "sql#instancesList",
+		Items:         page.Items,
+		NextPageToken: page.NextPageToken,
+	})
 }
 
 func (h *Handler) getInstance(w http.ResponseWriter, r *http.Request, p *sqlPath) {
@@ -139,9 +152,9 @@ func (h *Handler) patchInstance(w http.ResponseWriter, r *http.Request, p *sqlPa
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperationWithTarget(
+	h.completeOp(w,
 		p.project, "patch-"+p.name, "UPDATE", "instances", p.name,
-	))
+	)
 }
 
 func (h *Handler) deleteInstance(w http.ResponseWriter, r *http.Request, p *sqlPath) {
@@ -150,9 +163,9 @@ func (h *Handler) deleteInstance(w http.ResponseWriter, r *http.Request, p *sqlP
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperationWithTarget(
+	h.completeOp(w,
 		p.project, "delete-"+p.name, "DELETE", "instances", p.name,
-	))
+	)
 }
 
 func (h *Handler) restartInstance(w http.ResponseWriter, r *http.Request, p *sqlPath) {
@@ -161,9 +174,9 @@ func (h *Handler) restartInstance(w http.ResponseWriter, r *http.Request, p *sql
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperationWithTarget(
+	h.completeOp(w,
 		p.project, "restart-"+p.name, "RESTART", "instances", p.name,
-	))
+	)
 }
 
 func (h *Handler) restoreInstance(w http.ResponseWriter, r *http.Request, p *sqlPath) {
@@ -186,9 +199,9 @@ func (h *Handler) restoreInstance(w http.ResponseWriter, r *http.Request, p *sql
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperationWithTarget(
+	h.completeOp(w,
 		p.project, "restore-"+p.name, "RESTORE_VOLUME", "instances", p.name,
-	))
+	)
 }
 
 func (h *Handler) insertBackupRun(w http.ResponseWriter, r *http.Request, p *sqlPath) {
@@ -200,10 +213,10 @@ func (h *Handler) insertBackupRun(w http.ResponseWriter, r *http.Request, p *sql
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperationWithTarget(
+	h.completeOp(w,
 		p.project, "create-backup-"+snap.ID, "BACKUP_VOLUME",
 		"instances/"+p.name+"/backupRuns", snap.ID,
-	))
+	)
 }
 
 func (h *Handler) listBackupRuns(w http.ResponseWriter, r *http.Request, p *sqlPath) {
@@ -244,8 +257,8 @@ func (h *Handler) deleteBackupRun(w http.ResponseWriter, r *http.Request, p *sql
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperationWithTarget(
+	h.completeOp(w,
 		p.project, "delete-backup-"+p.subName, "DELETE",
 		"instances/"+p.name+"/backupRuns", p.subName,
-	))
+	)
 }

--- a/server/gcp/cloudsql/subresources.go
+++ b/server/gcp/cloudsql/subresources.go
@@ -125,14 +125,14 @@ func (h *Handler) serveDatabasesRoute(w http.ResponseWriter, r *http.Request, p 
 			return
 		}
 
-		writeJSON(w, http.StatusOK, doneOperationWithTarget(p.project, "delete-db", "DELETE_DATABASE", "instances", p.name))
+		h.completeOp(w, p.project, "delete-db", "DELETE_DATABASE", "instances", p.name)
 	default:
 		writeMethodNotAllowed(w)
 	}
 }
 
 //nolint:dupl // mirrors the sibling insert handler by design.
-func (*Handler) insertDatabase(w http.ResponseWriter, r *http.Request, p *sqlPath, db rdsdriver.Databases) {
+func (h *Handler) insertDatabase(w http.ResponseWriter, r *http.Request, p *sqlPath, db rdsdriver.Databases) {
 	var body database
 	if !decodeJSON(w, r, &body) {
 		return
@@ -146,7 +146,7 @@ func (*Handler) insertDatabase(w http.ResponseWriter, r *http.Request, p *sqlPat
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperationWithTarget(p.project, "insert-db", "CREATE_DATABASE", "instances", p.name))
+	h.completeOp(w, p.project, "insert-db", "CREATE_DATABASE", "instances", p.name)
 }
 
 func (*Handler) getDatabase(w http.ResponseWriter, r *http.Request, p *sqlPath, db rdsdriver.Databases) {
@@ -182,7 +182,7 @@ func toWireDatabase(d *rdsdriver.Database, project string) database {
 		Project:   project,
 		Charset:   d.Charset,
 		Collation: d.Collation,
-		SelfLink:  "/sql/v1beta4/projects/" + project + "/instances/" + d.Server + "/databases/" + d.Name,
+		SelfLink:  selfLinkBase + project + "/instances/" + d.Server + "/databases/" + d.Name,
 	}
 }
 
@@ -224,7 +224,7 @@ func (h *Handler) serveUsersRoute(w http.ResponseWriter, r *http.Request, p *sql
 }
 
 //nolint:dupl // mirrors the sibling insert handler by design.
-func (*Handler) insertUser(w http.ResponseWriter, r *http.Request, p *sqlPath, u rdsdriver.Users) {
+func (h *Handler) insertUser(w http.ResponseWriter, r *http.Request, p *sqlPath, u rdsdriver.Users) {
 	var body user
 	if !decodeJSON(w, r, &body) {
 		return
@@ -238,7 +238,7 @@ func (*Handler) insertUser(w http.ResponseWriter, r *http.Request, p *sqlPath, u
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperationWithTarget(p.project, "insert-user", "CREATE_USER", "instances", p.name))
+	h.completeOp(w, p.project, "insert-user", "CREATE_USER", "instances", p.name)
 }
 
 func (*Handler) getUser(w http.ResponseWriter, r *http.Request, p *sqlPath, u rdsdriver.Users) {
@@ -266,7 +266,7 @@ func (*Handler) listUsers(w http.ResponseWriter, r *http.Request, p *sqlPath, u 
 	writeJSON(w, http.StatusOK, usersList{Kind: "sql#usersList", Items: out})
 }
 
-func (*Handler) updateUser(w http.ResponseWriter, r *http.Request, p *sqlPath, u rdsdriver.Users) {
+func (h *Handler) updateUser(w http.ResponseWriter, r *http.Request, p *sqlPath, u rdsdriver.Users) {
 	var body user
 	if !decodeJSON(w, r, &body) {
 		return
@@ -282,10 +282,10 @@ func (*Handler) updateUser(w http.ResponseWriter, r *http.Request, p *sqlPath, u
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperationWithTarget(p.project, "update-user", "UPDATE_USER", "instances", p.name))
+	h.completeOp(w, p.project, "update-user", "UPDATE_USER", "instances", p.name)
 }
 
-func (*Handler) deleteUser(w http.ResponseWriter, r *http.Request, p *sqlPath, u rdsdriver.Users) {
+func (h *Handler) deleteUser(w http.ResponseWriter, r *http.Request, p *sqlPath, u rdsdriver.Users) {
 	name := r.URL.Query().Get("name")
 
 	if err := u.DeleteUser(r.Context(), p.name, name); err != nil {
@@ -293,7 +293,7 @@ func (*Handler) deleteUser(w http.ResponseWriter, r *http.Request, p *sqlPath, u
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperationWithTarget(p.project, "delete-user", "DELETE_USER", "instances", p.name))
+	h.completeOp(w, p.project, "delete-user", "DELETE_USER", "instances", p.name)
 }
 
 func toWireUser(u *rdsdriver.User, project string) user {
@@ -332,13 +332,13 @@ func (h *Handler) serveSslCertsRoute(w http.ResponseWriter, r *http.Request, p *
 			return
 		}
 
-		writeJSON(w, http.StatusOK, doneOperationWithTarget(p.project, "delete-cert", "DELETE_SSL_CERT", "instances", p.name))
+		h.completeOp(w, p.project, "delete-cert", "DELETE_SSL_CERT", "instances", p.name)
 	default:
 		writeMethodNotAllowed(w)
 	}
 }
 
-func (*Handler) insertSslCert(w http.ResponseWriter, r *http.Request, p *sqlPath, sc rdsdriver.SslCerts) {
+func (h *Handler) insertSslCert(w http.ResponseWriter, r *http.Request, p *sqlPath, sc rdsdriver.SslCerts) {
 	var body struct {
 		CommonName string `json:"commonName"`
 	}
@@ -356,7 +356,7 @@ func (*Handler) insertSslCert(w http.ResponseWriter, r *http.Request, p *sqlPath
 	writeJSON(w, http.StatusOK, sslCertInsertResponse{
 		Kind:       "sql#sslCertsInsert",
 		ClientCert: clientCert{CertInfo: toWireSslCert(out), CertPrivateKey: mockKeyPEM},
-		Operation:  doneOperationWithTarget(p.project, "insert-cert", "CREATE_SSL_CERT", "instances", p.name),
+		Operation:  h.buildOp(p.project, "insert-cert", "CREATE_SSL_CERT", "instances", p.name),
 	})
 }
 
@@ -415,8 +415,7 @@ func (h *Handler) cloneInstance(w http.ResponseWriter, r *http.Request, p *sqlPa
 		return
 	}
 
-	writeJSON(w, http.StatusOK,
-		doneOperationWithTarget(p.project, "clone", "CLONE", "instances", body.CloneContext.DestinationInstanceName))
+	h.completeOp(w, p.project, "clone", "CLONE", "instances", body.CloneContext.DestinationInstanceName)
 }
 
 func (h *Handler) failoverInstance(w http.ResponseWriter, r *http.Request, p *sqlPath) {
@@ -431,7 +430,7 @@ func (h *Handler) failoverInstance(w http.ResponseWriter, r *http.Request, p *sq
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperationWithTarget(p.project, "failover", "FAILOVER", "instances", p.name))
+	h.completeOp(w, p.project, "failover", "FAILOVER", "instances", p.name)
 }
 
 func (h *Handler) promoteReplica(w http.ResponseWriter, r *http.Request, p *sqlPath) {
@@ -446,7 +445,7 @@ func (h *Handler) promoteReplica(w http.ResponseWriter, r *http.Request, p *sqlP
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperationWithTarget(p.project, "promote", "PROMOTE_REPLICA", "instances", p.name))
+	h.completeOp(w, p.project, "promote", "PROMOTE_REPLICA", "instances", p.name)
 }
 
 // startReplica / stopReplica start and stop replication on a read replica.
@@ -458,7 +457,7 @@ func (h *Handler) startReplica(w http.ResponseWriter, r *http.Request, p *sqlPat
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperationWithTarget(p.project, "start-replica", "START_REPLICA", "instances", p.name))
+	h.completeOp(w, p.project, "start-replica", "START_REPLICA", "instances", p.name)
 }
 
 // requireReplica writes an error and returns false unless p.name is an existing
@@ -483,5 +482,5 @@ func (h *Handler) stopReplica(w http.ResponseWriter, r *http.Request, p *sqlPath
 		return
 	}
 
-	writeJSON(w, http.StatusOK, doneOperationWithTarget(p.project, "stop-replica", "STOP_REPLICA", "instances", p.name))
+	h.completeOp(w, p.project, "stop-replica", "STOP_REPLICA", "instances", p.name)
 }

--- a/server/gcp/cloudsql/types.go
+++ b/server/gcp/cloudsql/types.go
@@ -3,6 +3,7 @@ package cloudsql
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
@@ -13,6 +14,20 @@ import (
 const (
 	activationAlways = "ALWAYS"
 	activationNever  = "NEVER"
+
+	// selfLinkBase is the resource URI prefix Cloud SQL stamps on every
+	// selfLink/targetLink. Even the v1 client is answered with sql/v1beta4
+	// selfLinks — that is the version the real service returns.
+	selfLinkBase = "https://sqladmin.googleapis.com/sql/v1beta4/projects/"
+
+	// operationUser is the caller identity Cloud SQL records on an operation.
+	// The emulator enforces no auth, so a fixed service-account address stands
+	// in for the authenticated principal.
+	operationUser = "cloudemu@cloudemu.iam.gserviceaccount.com"
+
+	// rfc3339Milli is the millisecond RFC3339 layout Cloud SQL uses for its
+	// timestamp fields (createTime, insertTime, startTime, endTime).
+	rfc3339Milli = "2006-01-02T15:04:05.000Z"
 )
 
 // sqlInstance is the JSON shape Cloud SQL expects for DatabaseInstance.
@@ -49,8 +64,9 @@ type ipMapping struct {
 }
 
 type sqlInstanceList struct {
-	Kind  string        `json:"kind"`
-	Items []sqlInstance `json:"items"`
+	Kind          string        `json:"kind"`
+	Items         []sqlInstance `json:"items"`
+	NextPageToken string        `json:"nextPageToken,omitempty"`
 }
 
 type backupRun struct {
@@ -95,42 +111,47 @@ type operation struct {
 	SelfLink      string `json:"selfLink,omitempty"`
 }
 
-// doneOperation builds an LRO Operation with status=DONE and a synthetic name
-// derived from project+verb.
-func doneOperation(project, name, opType, _ string) operation {
+// doneOperationWithTarget builds a DONE operation that carries the full record
+// a real Cloud SQL operation exposes: the affected resource (targetId /
+// targetLink), the acting user, insert/start/end timestamps, and its own
+// selfLink. Mutating handlers persist the result so a later Operations.Get
+// returns this same record rather than a synthetic stand-in.
+func doneOperationWithTarget(project, name, opType, resourceType, target string) operation {
+	now := time.Now().UTC().Format(rfc3339Milli)
+
 	return operation{
 		Kind:          "sql#operation",
 		Name:          name,
 		OperationType: opType,
 		Status:        "DONE",
+		User:          operationUser,
+		InsertTime:    now,
+		StartTime:     now,
+		EndTime:       now,
+		TargetID:      target,
 		TargetProject: project,
+		TargetLink:    selfLinkBase + project + "/" + resourceType + "/" + target,
+		SelfLink:      selfLinkBase + project + "/operations/" + name,
 	}
-}
-
-// doneOperationWithTarget builds a DONE operation that also carries a
-// targetLink/targetId pointing at the affected resource.
-func doneOperationWithTarget(project, name, opType, resourceType, target string) operation {
-	op := doneOperation(project, name, opType, "")
-	op.TargetID = target
-	op.TargetLink = pathPrefix + project + "/" + resourceType + "/" + target
-
-	return op
 }
 
 // toSQLInstance converts a portable Instance to the wire shape.
 func toSQLInstance(inst *rdsdriver.Instance, project string) sqlInstance {
 	return sqlInstance{
-		Kind:               "sql#instance",
-		Name:               inst.ID,
-		Project:            project,
-		Region:             inst.AvailabilityZone,
-		DatabaseVersion:    inst.Engine,
-		State:              sqlState(inst.State),
-		BackendType:        "SECOND_GEN",
-		ConnectionName:     inst.ConnectionName,
+		Kind:            "sql#instance",
+		Name:            inst.ID,
+		Project:         project,
+		Region:          inst.AvailabilityZone,
+		DatabaseVersion: inst.Engine,
+		State:           sqlState(inst.State),
+		BackendType:     "SECOND_GEN",
+		// connectionName is keyed on the REQUEST project (from the URL), matching
+		// real Cloud SQL's {project}:{region}:{instance} — not the server's
+		// configured project, which the stored inst.ConnectionName carries.
+		ConnectionName:     project + ":" + inst.AvailabilityZone + ":" + inst.ID,
 		MasterInstanceName: inst.ReadReplicaSource,
 		ReplicaNames:       inst.ReadReplicaTargets,
-		SelfLink:           pathPrefix + project + "/instances/" + inst.ID,
+		SelfLink:           selfLinkBase + project + "/instances/" + inst.ID,
 		// PRIMARY is the public IP a client is meant to connect to. Endpoint holds
 		// the reachable host: a synthetic IP normally, or the real engine host
 		// when a database engine backs the instance.
@@ -144,7 +165,7 @@ func toSQLInstance(inst *rdsdriver.Instance, project string) sqlInstance {
 			UserLabels:       inst.Tags,
 			ActivationPolicy: activationFromState(inst.State),
 		},
-		CreateTime: inst.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
+		CreateTime: inst.CreatedAt.UTC().Format(rfc3339Milli),
 	}
 }
 
@@ -156,8 +177,8 @@ func toBackupRun(snap *rdsdriver.Snapshot) backupRun {
 		Status:     sqlBackupStatus(snap.State),
 		Type:       "ON_DEMAND",
 		Instance:   snap.InstanceID,
-		StartTime:  snap.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
-		EndTime:    snap.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
+		StartTime:  snap.CreatedAt.UTC().Format(rfc3339Milli),
+		EndTime:    snap.CreatedAt.UTC().Format(rfc3339Milli),
 		BackupKind: "SNAPSHOT",
 	}
 }


### PR DESCRIPTION
## What & why

Fixes the GCP Cloud SQL bug batch from `AUDIT_GCP.md` (`## cloudsql`). All findings were wire-shape / behavioral mismatches against the real Cloud SQL Admin API; fixes are contained to the wire layer (`server/gcp/cloudsql`) — no driver interface or provider change, so no docs/coverage regeneration was needed.

## Findings fixed

- **[MEDIUM][WRONG_WIRE] connectionName** — was built from the server's configured project (`mock-project:...`), ignoring the request project. Now keyed on the request project as `{project}:{region}:{instance}`, matching real Cloud SQL.
- **[MEDIUM][WRONG_WIRE] selfLink** — instance (and database) selfLinks were relative, wrong-version paths (`/v1/projects/...`). Now emit the absolute `https://sqladmin.googleapis.com/sql/v1beta4/projects/...` URLs the real service returns.
- **[MEDIUM][BEHAVIORAL] instances.list** — `filter`, `maxResults` and `pageToken` were ignored and no `nextPageToken` was returned. Now sorts by name, applies a `field:value`/`field=value` filter (name/state/region/databaseVersion/backendType), paginates with offset tokens, and returns `nextPageToken`.
- **[LOW][BEHAVIORAL] Operations.get** — returned a synthetic `operationType=GET` with empty target fields for any name. Mutating endpoints now persist their Operation, so `Operations.Get` returns the real CREATE/UPDATE/DELETE record pointing at the affected resource; an unknown operation is a 404.
- **[LOW][MISSING] instance insert LRO** — the returned Operation now populates `selfLink`, `insertTime`, `startTime`, `endTime`, `user`, and `targetLink`.

## Tests

Added `instances_sdk_test.go` — reproduction tests using the real `google.golang.org/api/sqladmin/v1` client against the in-process GCP server, one per finding (connectionName, absolute selfLinks for instances+databases, list pagination+filter, persisted operation record + populated LRO fields + 404 on unknown op). Existing Cloud SQL tests stay green.

## Gates

`go build ./...`, `go vet`, `go test` (+ `-race`) on `server/gcp/cloudsql`, `golangci-lint` (0 issues), and `gofmt` all clean.
