### PR TITLE
fix(gcp-secretmanager): version lifecycle, patch, IAM, pagination, and etag/state fields

### DIFF
--- a/docs/coverage/aws/secretsmanager.md
+++ b/docs/coverage/aws/secretsmanager.md
@@ -19,6 +19,20 @@ AWS's `secrets` service · portable interface `driver.Secrets` · [AWS index](./
 
 Discovered by type assertion; only some providers implement these.
 
+### GCPSecrets
+
+GCPSecrets is the GCP Secret Manager-specific surface kept off the shared
+
+| Operation | Description |
+| --- | --- |
+| `DestroySecretVersion` | DestroySecretVersion moves a version to DESTROYED, wipes its payload, and |
+| `DisableSecretVersion` | DisableSecretVersion moves a version to DISABLED. It fails on a DESTROYED |
+| `EnableSecretVersion` | EnableSecretVersion moves a version to ENABLED. It is idempotent on an |
+| `GetSecretIAMPolicy` | GetSecretIAMPolicy returns the secret's stored IAM policy (an empty |
+| `PatchSecret` | PatchSecret applies a partial update (labels) to a secret's metadata. |
+| `SetSecretIAMPolicy` | SetSecretIAMPolicy stores the secret's IAM policy and returns it with a |
+| `TestSecretIAMPermissions` | TestSecretIAMPermissions returns the subset of permissions the caller |
+
 ### KeyVaultCertificates
 
 KeyVaultCertificates is the Azure Key Vault-specific certificate data-plane

--- a/docs/coverage/azure/keyvault.md
+++ b/docs/coverage/azure/keyvault.md
@@ -19,6 +19,20 @@ Azure's `secrets` service · portable interface `driver.Secrets` · [Azure index
 
 Discovered by type assertion; only some providers implement these.
 
+### GCPSecrets
+
+GCPSecrets is the GCP Secret Manager-specific surface kept off the shared
+
+| Operation | Description |
+| --- | --- |
+| `DestroySecretVersion` | DestroySecretVersion moves a version to DESTROYED, wipes its payload, and |
+| `DisableSecretVersion` | DisableSecretVersion moves a version to DISABLED. It fails on a DESTROYED |
+| `EnableSecretVersion` | EnableSecretVersion moves a version to ENABLED. It is idempotent on an |
+| `GetSecretIAMPolicy` | GetSecretIAMPolicy returns the secret's stored IAM policy (an empty |
+| `PatchSecret` | PatchSecret applies a partial update (labels) to a secret's metadata. |
+| `SetSecretIAMPolicy` | SetSecretIAMPolicy stores the secret's IAM policy and returns it with a |
+| `TestSecretIAMPermissions` | TestSecretIAMPermissions returns the subset of permissions the caller |
+
 ### KeyVaultCertificates
 
 KeyVaultCertificates is the Azure Key Vault-specific certificate data-plane

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -9552,6 +9552,40 @@
     ],
     "optionalCapabilities": [
       {
+        "name": "GCPSecrets",
+        "doc": "GCPSecrets is the GCP Secret Manager-specific surface kept off the shared",
+        "operations": [
+          {
+            "name": "DestroySecretVersion",
+            "doc": "DestroySecretVersion moves a version to DESTROYED, wipes its payload, and"
+          },
+          {
+            "name": "DisableSecretVersion",
+            "doc": "DisableSecretVersion moves a version to DISABLED. It fails on a DESTROYED"
+          },
+          {
+            "name": "EnableSecretVersion",
+            "doc": "EnableSecretVersion moves a version to ENABLED. It is idempotent on an"
+          },
+          {
+            "name": "GetSecretIAMPolicy",
+            "doc": "GetSecretIAMPolicy returns the secret's stored IAM policy (an empty"
+          },
+          {
+            "name": "PatchSecret",
+            "doc": "PatchSecret applies a partial update (labels) to a secret's metadata."
+          },
+          {
+            "name": "SetSecretIAMPolicy",
+            "doc": "SetSecretIAMPolicy stores the secret's IAM policy and returns it with a"
+          },
+          {
+            "name": "TestSecretIAMPermissions",
+            "doc": "TestSecretIAMPermissions returns the subset of permissions the caller"
+          }
+        ]
+      },
+      {
         "name": "KeyVaultCertificates",
         "doc": "KeyVaultCertificates is the Azure Key Vault-specific certificate data-plane",
         "operations": [

--- a/docs/coverage/gcp/secretmanager.md
+++ b/docs/coverage/gcp/secretmanager.md
@@ -19,6 +19,20 @@ GCP's `secrets` service · portable interface `driver.Secrets` · [GCP index](./
 
 Discovered by type assertion; only some providers implement these.
 
+### GCPSecrets
+
+GCPSecrets is the GCP Secret Manager-specific surface kept off the shared
+
+| Operation | Description |
+| --- | --- |
+| `DestroySecretVersion` | DestroySecretVersion moves a version to DESTROYED, wipes its payload, and |
+| `DisableSecretVersion` | DisableSecretVersion moves a version to DISABLED. It fails on a DESTROYED |
+| `EnableSecretVersion` | EnableSecretVersion moves a version to ENABLED. It is idempotent on an |
+| `GetSecretIAMPolicy` | GetSecretIAMPolicy returns the secret's stored IAM policy (an empty |
+| `PatchSecret` | PatchSecret applies a partial update (labels) to a secret's metadata. |
+| `SetSecretIAMPolicy` | SetSecretIAMPolicy stores the secret's IAM policy and returns it with a |
+| `TestSecretIAMPermissions` | TestSecretIAMPermissions returns the subset of permissions the caller |
+
 ### KeyVaultCertificates
 
 KeyVaultCertificates is the Azure Key Vault-specific certificate data-plane

--- a/providers/gcp/secretmanager/iam.go
+++ b/providers/gcp/secretmanager/iam.go
@@ -1,0 +1,92 @@
+package secretmanager
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+// GetSecretIAMPolicy returns the secret's stored IAM policy. An existing secret
+// with no policy yet returns an empty, versioned policy (real GCP never 404s
+// getIamPolicy on an existing resource).
+func (m *Mock) GetSecretIAMPolicy(_ context.Context, name string) (*driver.GCPIAMPolicy, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
+
+	if sd.iam == nil {
+		return &driver.GCPIAMPolicy{Version: 1, Etag: newEtag()}, nil
+	}
+
+	return clonePolicy(sd.iam), nil
+}
+
+// SetSecretIAMPolicy stores the secret's IAM policy and returns it with a
+// refreshed etag.
+func (m *Mock) SetSecretIAMPolicy(_ context.Context, name string, policy driver.GCPIAMPolicy) (*driver.GCPIAMPolicy, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
+
+	stored := clonePolicy(&policy)
+	if stored.Version == 0 {
+		stored.Version = 1
+	}
+
+	stored.Etag = newEtag()
+	sd.iam = stored
+
+	return clonePolicy(stored), nil
+}
+
+// TestSecretIAMPermissions echoes back the requested permissions — CloudEmu
+// does not enforce IAM, so every requested permission is reported as granted.
+func (m *Mock) TestSecretIAMPermissions(_ context.Context, name string, permissions []string) ([]string, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
+
+	granted := make([]string, len(permissions))
+	copy(granted, permissions)
+
+	return granted, nil
+}
+
+// clonePolicy deep-copies an IAM policy so stored and returned values don't
+// share backing slices.
+func clonePolicy(p *driver.GCPIAMPolicy) *driver.GCPIAMPolicy {
+	out := &driver.GCPIAMPolicy{Version: p.Version, Etag: p.Etag}
+
+	for _, b := range p.Bindings {
+		members := make([]string, len(b.Members))
+		copy(members, b.Members)
+		out.Bindings = append(out.Bindings, driver.GCPIAMBinding{Role: b.Role, Members: members})
+	}
+
+	return out
+}

--- a/providers/gcp/secretmanager/lifecycle.go
+++ b/providers/gcp/secretmanager/lifecycle.go
@@ -1,0 +1,137 @@
+package secretmanager
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+// Compile-time check that Mock implements the GCP-specific optional surface.
+var _ driver.GCPSecrets = (*Mock)(nil)
+
+// findVersion returns a pointer to the stored version with the given id.
+// Caller must hold sd.mu.
+func findVersion(sd *secretData, versionID string) (*driver.SecretVersion, bool) {
+	for i := range sd.versions {
+		v := &sd.versions[i]
+		if versionID == "" && v.Current {
+			return v, true
+		}
+
+		if v.VersionID == versionID {
+			return v, true
+		}
+	}
+
+	return nil, false
+}
+
+// mutateVersion loads a live secret, locates a version, and applies fn to it
+// under the secret's write lock. It centralizes the not-found/deleted checks
+// shared by enable/disable/destroy.
+func (m *Mock) mutateVersion(name, versionID string,
+	fn func(v *driver.SecretVersion) error,
+) (*driver.SecretVersion, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
+
+	v, ok := findVersion(sd, versionID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "version %q not found for secret %q", versionID, name)
+	}
+
+	if err := fn(v); err != nil {
+		return nil, err
+	}
+
+	result := *v
+	result.Value = nil // lifecycle responses carry metadata only
+
+	return &result, nil
+}
+
+// EnableSecretVersion moves a version to ENABLED.
+func (m *Mock) EnableSecretVersion(_ context.Context, name, versionID string) (*driver.SecretVersion, error) {
+	return m.mutateVersion(name, versionID, func(v *driver.SecretVersion) error {
+		if v.State == driver.VersionDestroyed {
+			return errors.Newf(errors.FailedPrecondition, "version %q is destroyed", versionID)
+		}
+
+		v.State = driver.VersionEnabled
+		v.Etag = newEtag()
+
+		return nil
+	})
+}
+
+// DisableSecretVersion moves a version to DISABLED.
+func (m *Mock) DisableSecretVersion(_ context.Context, name, versionID string) (*driver.SecretVersion, error) {
+	return m.mutateVersion(name, versionID, func(v *driver.SecretVersion) error {
+		if v.State == driver.VersionDestroyed {
+			return errors.Newf(errors.FailedPrecondition, "version %q is destroyed", versionID)
+		}
+
+		v.State = driver.VersionDisabled
+		v.Etag = newEtag()
+
+		return nil
+	})
+}
+
+// DestroySecretVersion moves a version to DESTROYED, wiping its payload.
+func (m *Mock) DestroySecretVersion(_ context.Context, name, versionID string) (*driver.SecretVersion, error) {
+	return m.mutateVersion(name, versionID, func(v *driver.SecretVersion) error {
+		if v.State == driver.VersionDestroyed {
+			return errors.Newf(errors.FailedPrecondition, "version %q is already destroyed", versionID)
+		}
+
+		v.State = driver.VersionDestroyed
+		v.Value = nil
+		v.DestroyTime = m.opts.Clock.Now().UTC().Format(time.RFC3339)
+		v.Etag = newEtag()
+
+		return nil
+	})
+}
+
+// PatchSecret applies a partial update to a secret's metadata.
+func (m *Mock) PatchSecret(_ context.Context, name string, patch driver.GCPSecretPatch) (*driver.SecretInfo, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
+
+	if patch.SetLabels {
+		labels := make(map[string]string, len(patch.Labels))
+		for k, v := range patch.Labels {
+			labels[k] = v
+		}
+
+		sd.info.Tags = labels
+	}
+
+	sd.info.UpdatedAt = m.opts.Clock.Now().UTC().Format(time.RFC3339)
+	sd.info.Etag = newEtag()
+
+	result := sd.info
+
+	return &result, nil
+}

--- a/providers/gcp/secretmanager/secretmanager.go
+++ b/providers/gcp/secretmanager/secretmanager.go
@@ -3,6 +3,7 @@ package secretmanager
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"time"
 
@@ -17,10 +18,17 @@ import (
 var _ driver.Secrets = (*Mock)(nil)
 
 type secretData struct {
-	info      driver.SecretInfo
-	versions  []driver.SecretVersion
-	deletedAt time.Time
-	mu        sync.RWMutex
+	info       driver.SecretInfo
+	versions   []driver.SecretVersion
+	verCounter int                  // monotonic version-number allocator (GCP numbers versions 1,2,3…)
+	iam        *driver.GCPIAMPolicy // stored IAM policy; nil until first set
+	deletedAt  time.Time
+	mu         sync.RWMutex
+}
+
+// newEtag returns a fresh opaque optimistic-concurrency tag.
+func newEtag() string {
+	return idgen.GenerateID("etag-")
 }
 
 // Mock is an in-memory mock implementation of GCP Secret Manager.
@@ -63,6 +71,7 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 		CreatedAt:   now,
 		UpdatedAt:   now,
 		Tags:        tags,
+		Etag:        newEtag(),
 	}
 
 	sd := &secretData{info: info}
@@ -75,11 +84,14 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 		data := make([]byte, len(value))
 		copy(data, value)
 
+		sd.verCounter++
 		sd.versions = []driver.SecretVersion{{
-			VersionID: idgen.GenerateID("ver-"),
+			VersionID: strconv.Itoa(sd.verCounter),
 			Value:     data,
 			CreatedAt: now,
 			Current:   true,
+			State:     driver.VersionEnabled,
+			Etag:      newEtag(),
 		}}
 	}
 
@@ -168,12 +180,14 @@ func (m *Mock) PutSecretValue(_ context.Context, name string, value []byte) (*dr
 	data := make([]byte, len(value))
 	copy(data, value)
 
-	versionID := idgen.GenerateID("ver-")
+	sd.verCounter++
 	version := driver.SecretVersion{
-		VersionID: versionID,
+		VersionID: strconv.Itoa(sd.verCounter),
 		Value:     data,
 		CreatedAt: now,
 		Current:   true,
+		State:     driver.VersionEnabled,
+		Etag:      newEtag(),
 	}
 
 	sd.versions = append(sd.versions, version)
@@ -239,10 +253,14 @@ func (m *Mock) ListSecretVersions(_ context.Context, name string) ([]driver.Secr
 
 	versions := make([]driver.SecretVersion, len(sd.versions))
 	for i, v := range sd.versions {
+		// Project metadata only — the payload is omitted from list results.
 		versions[i] = driver.SecretVersion{
-			VersionID: v.VersionID,
-			CreatedAt: v.CreatedAt,
-			Current:   v.Current,
+			VersionID:   v.VersionID,
+			CreatedAt:   v.CreatedAt,
+			Current:     v.Current,
+			State:       v.State,
+			DestroyTime: v.DestroyTime,
+			Etag:        v.Etag,
 		}
 	}
 

--- a/providers/gcp/secretmanager/snapshot.go
+++ b/providers/gcp/secretmanager/snapshot.go
@@ -20,9 +20,11 @@ type secretsSnapshot struct {
 }
 
 type secretSnapshot struct {
-	Info      driver.SecretInfo      `json:"info"`
-	Versions  []driver.SecretVersion `json:"versions,omitempty"`
-	DeletedAt time.Time              `json:"deletedAt,omitempty"`
+	Info       driver.SecretInfo      `json:"info"`
+	Versions   []driver.SecretVersion `json:"versions,omitempty"`
+	VerCounter int                    `json:"verCounter,omitempty"`
+	IAM        *driver.GCPIAMPolicy   `json:"iam,omitempty"`
+	DeletedAt  time.Time              `json:"deletedAt,omitempty"`
 }
 
 // Snapshot captures every secret's full state as JSON. includeAssets is unused —
@@ -34,9 +36,11 @@ func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
 	for name, sd := range m.secrets.All() {
 		sd.mu.RLock()
 		snap.Secrets[name] = &secretSnapshot{
-			Info:      sd.info,
-			Versions:  sd.versions,
-			DeletedAt: sd.deletedAt,
+			Info:       sd.info,
+			Versions:   sd.versions,
+			VerCounter: sd.verCounter,
+			IAM:        sd.iam,
+			DeletedAt:  sd.deletedAt,
 		}
 		sd.mu.RUnlock()
 	}
@@ -54,9 +58,11 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 
 	for name, ss := range snap.Secrets {
 		m.secrets.Set(name, &secretData{
-			info:      ss.Info,
-			versions:  ss.Versions,
-			deletedAt: ss.DeletedAt,
+			info:       ss.Info,
+			versions:   ss.Versions,
+			verCounter: ss.VerCounter,
+			iam:        ss.IAM,
+			deletedAt:  ss.DeletedAt,
 		})
 	}
 

--- a/server/gcp/secretmanager/handler.go
+++ b/server/gcp/secretmanager/handler.go
@@ -5,16 +5,24 @@
 //
 // Coverage (v1 REST):
 //
-//	POST   /v1/projects/{p}/secrets?secretId={id}              — Create secret
-//	GET    /v1/projects/{p}/secrets/{id}                       — Get secret
-//	GET    /v1/projects/{p}/secrets                            — List secrets
-//	DELETE /v1/projects/{p}/secrets/{id}                       — Delete secret
-//	POST   /v1/projects/{p}/secrets/{id}:addVersion            — Add version
-//	GET    /v1/projects/{p}/secrets/{id}/versions              — List versions
-//	GET    /v1/projects/{p}/secrets/{id}/versions/{v}          — Get version
-//	GET    /v1/projects/{p}/secrets/{id}/versions/{v}:access   — Access payload
+//	POST   /v1/projects/{p}/secrets?secretId={id}                 — Create secret
+//	GET    /v1/projects/{p}/secrets/{id}                          — Get secret
+//	PATCH  /v1/projects/{p}/secrets/{id}?updateMask=labels        — Patch secret
+//	GET    /v1/projects/{p}/secrets                               — List secrets (paged)
+//	DELETE /v1/projects/{p}/secrets/{id}                          — Delete secret
+//	POST   /v1/projects/{p}/secrets/{id}:addVersion               — Add version
+//	GET    /v1/projects/{p}/secrets/{id}:getIamPolicy             — Get IAM policy
+//	POST   /v1/projects/{p}/secrets/{id}:setIamPolicy             — Set IAM policy
+//	POST   /v1/projects/{p}/secrets/{id}:testIamPermissions       — Test IAM perms
+//	GET    /v1/projects/{p}/secrets/{id}/versions                 — List versions (paged)
+//	GET    /v1/projects/{p}/secrets/{id}/versions/{v}             — Get version
+//	GET    /v1/projects/{p}/secrets/{id}/versions/{v}:access      — Access payload
+//	POST   /v1/projects/{p}/secrets/{id}/versions/{v}:enable      — Enable version
+//	POST   /v1/projects/{p}/secrets/{id}/versions/{v}:disable     — Disable version
+//	POST   /v1/projects/{p}/secrets/{id}/versions/{v}:destroy     — Destroy version
 //
-// "latest" is accepted as a version alias, matching real Secret Manager. The
+// Versions are numbered by monotonic integer (1, 2, 3…) and addressable by that
+// id; "latest" is accepted as a version alias, matching real Secret Manager. The
 // driver seeds an initial (empty) version on create, so a freshly created
 // secret carries one more version than the addVersion calls made against it.
 package secretmanager
@@ -34,6 +42,13 @@ const (
 
 	verbAddVersion = "addVersion"
 	verbAccess     = "access"
+	verbDestroy    = "destroy"
+	verbDisable    = "disable"
+	verbEnable     = "enable"
+
+	verbGetIam  = "getIamPolicy"
+	verbSetIam  = "setIamPolicy"
+	verbTestIam = "testIamPermissions"
 
 	latestAlias = "latest"
 )
@@ -49,11 +64,20 @@ const (
 // Handler serves secretmanager.googleapis.com v1 requests.
 type Handler struct {
 	secrets secretsdriver.Secrets
+	// gcp is the GCP-specific surface (version lifecycle, patch, IAM). It is
+	// present whenever the backing driver implements driver.GCPSecrets (the GCP
+	// mock always does); nil-checked so a non-GCP driver degrades to 501.
+	gcp secretsdriver.GCPSecrets
 }
 
 // New returns a Secret Manager handler backed by s.
 func New(s secretsdriver.Secrets) *Handler {
-	return &Handler{secrets: s}
+	h := &Handler{secrets: s}
+	if g, ok := s.(secretsdriver.GCPSecrets); ok {
+		h.gcp = g
+	}
+
+	return h
 }
 
 type route struct {
@@ -144,13 +168,34 @@ func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rt rou
 // serveSecret dispatches /secrets/{id} resource requests, including the
 // :addVersion custom method.
 func (h *Handler) serveSecret(w http.ResponseWriter, r *http.Request, rt route) {
-	switch {
-	case rt.verb == verbAddVersion && r.Method == http.MethodPost:
-		h.addVersion(w, r, rt)
-	case rt.verb == "" && r.Method == http.MethodGet:
+	if rt.verb != "" {
+		h.serveSecretVerb(w, r, rt)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
 		h.getSecret(w, r, rt)
-	case rt.verb == "" && r.Method == http.MethodDelete:
+	case http.MethodPatch:
+		h.patchSecret(w, r, rt)
+	case http.MethodDelete:
 		h.deleteSecret(w, r, rt)
+	default:
+		writeUnsupported(w)
+	}
+}
+
+// serveSecretVerb dispatches the custom :verb methods on a secret resource.
+func (h *Handler) serveSecretVerb(w http.ResponseWriter, r *http.Request, rt route) {
+	switch rt.verb {
+	case verbAddVersion:
+		postOnly(w, r, func() { h.addVersion(w, r, rt) })
+	case verbSetIam:
+		postOnly(w, r, func() { h.setIamPolicy(w, r, rt) })
+	case verbTestIam:
+		postOnly(w, r, func() { h.testIamPermissions(w, r, rt) })
+	case verbGetIam:
+		getOnly(w, r, func() { h.getIamPolicy(w, r, rt) })
 	default:
 		writeUnsupported(w)
 	}
@@ -160,12 +205,22 @@ func (h *Handler) serveSecret(w http.ResponseWriter, r *http.Request, rt route) 
 // the :access custom method.
 func (h *Handler) serveVersions(w http.ResponseWriter, r *http.Request, rt route) {
 	switch {
-	case rt.listVer && r.Method == http.MethodGet:
-		h.listVersions(w, r, rt)
-	case rt.verb == verbAccess && r.Method == http.MethodGet:
-		h.accessVersion(w, r, rt)
-	case rt.verb == "" && r.Method == http.MethodGet:
-		h.getVersion(w, r, rt)
+	case rt.listVer:
+		getOnly(w, r, func() { h.listVersions(w, r, rt) })
+	case rt.verb != "":
+		h.serveVersionVerb(w, r, rt)
+	default:
+		getOnly(w, r, func() { h.getVersion(w, r, rt) })
+	}
+}
+
+// serveVersionVerb dispatches the custom :verb methods on a version resource.
+func (h *Handler) serveVersionVerb(w http.ResponseWriter, r *http.Request, rt route) {
+	switch rt.verb {
+	case verbAccess:
+		getOnly(w, r, func() { h.accessVersion(w, r, rt) })
+	case verbDestroy, verbDisable, verbEnable:
+		postOnly(w, r, func() { h.mutateVersion(w, r, rt, rt.verb) })
 	default:
 		writeUnsupported(w)
 	}
@@ -173,4 +228,24 @@ func (h *Handler) serveVersions(w http.ResponseWriter, r *http.Request, rt route
 
 func writeUnsupported(w http.ResponseWriter) {
 	gcprest.WriteError(w, http.StatusBadRequest, "badRequest", "unsupported Secret Manager operation")
+}
+
+// getOnly runs fn for GET requests, else replies 400 unsupported.
+func getOnly(w http.ResponseWriter, r *http.Request, fn func()) {
+	if r.Method == http.MethodGet {
+		fn()
+		return
+	}
+
+	writeUnsupported(w)
+}
+
+// postOnly runs fn for POST requests, else replies 400 unsupported.
+func postOnly(w http.ResponseWriter, r *http.Request, fn func()) {
+	if r.Method == http.MethodPost {
+		fn()
+		return
+	}
+
+	writeUnsupported(w)
 }

--- a/server/gcp/secretmanager/iam.go
+++ b/server/gcp/secretmanager/iam.go
@@ -1,0 +1,67 @@
+package secretmanager
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+)
+
+// getIamPolicy serves secrets/{id}:getIamPolicy. CloudEmu does not enforce IAM;
+// it stores the policy so Terraform's google_secret_manager_secret_iam_* round-
+// trips (setIamPolicy followed by a getIamPolicy read).
+func (h *Handler) getIamPolicy(w http.ResponseWriter, r *http.Request, rt route) {
+	if h.gcp == nil {
+		writeUnsupported(w)
+		return
+	}
+
+	pol, err := h.gcp.GetSecretIAMPolicy(r.Context(), rt.secret)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toPolicyJSON(pol))
+}
+
+// setIamPolicy serves secrets/{id}:setIamPolicy.
+func (h *Handler) setIamPolicy(w http.ResponseWriter, r *http.Request, rt route) {
+	if h.gcp == nil {
+		writeUnsupported(w)
+		return
+	}
+
+	var req setIamPolicyRequest
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	pol, err := h.gcp.SetSecretIAMPolicy(r.Context(), rt.secret, fromPolicyJSON(req.Policy))
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toPolicyJSON(pol))
+}
+
+// testIamPermissions serves secrets/{id}:testIamPermissions.
+func (h *Handler) testIamPermissions(w http.ResponseWriter, r *http.Request, rt route) {
+	if h.gcp == nil {
+		writeUnsupported(w)
+		return
+	}
+
+	var req testIamPermissionsRequest
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	granted, err := h.gcp.TestSecretIAMPermissions(r.Context(), rt.secret, req.Permissions)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, testIamPermissionsResponse{Permissions: granted})
+}

--- a/server/gcp/secretmanager/lifecycle_sdk_test.go
+++ b/server/gcp/secretmanager/lifecycle_sdk_test.go
@@ -1,0 +1,311 @@
+package secretmanager_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	sm "google.golang.org/api/secretmanager/v1"
+)
+
+// mustCreateSecret creates an empty (GCP-style) secret container.
+func mustCreateSecret(t *testing.T, svc *sm.Service, id string) string {
+	t.Helper()
+
+	if _, err := svc.Projects.Secrets.Create(testParent, &sm.Secret{
+		Replication: &sm.Replication{Automatic: &sm.Automatic{}},
+	}).SecretId(id).Context(context.Background()).Do(); err != nil {
+		t.Fatalf("Create(%s): %v", id, err)
+	}
+
+	return testParent + "/secrets/" + id
+}
+
+// TestSDKVersionIntegerNaming proves versions are numbered 1,2,3… and are
+// addressable by their integer id (audit: AddSecretVersion version naming).
+func TestSDKVersionIntegerNaming(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+	name := mustCreateSecret(t, svc, "int-named")
+
+	v1, err := svc.Projects.Secrets.AddVersion(name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode("one")},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("AddVersion: %v", err)
+	}
+
+	if !strings.HasSuffix(v1.Name, "/versions/1") {
+		t.Fatalf("v1 name = %q, want .../versions/1", v1.Name)
+	}
+
+	// Address the version by its integer id.
+	got, err := svc.Projects.Secrets.Versions.Access(name + "/versions/1").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Access(versions/1): %v", err)
+	}
+
+	if got.Payload.Data != encode("one") {
+		t.Fatalf("payload = %q, want %q", got.Payload.Data, encode("one"))
+	}
+
+	v2, err := svc.Projects.Secrets.AddVersion(name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode("two")},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("AddVersion(2): %v", err)
+	}
+
+	if !strings.HasSuffix(v2.Name, "/versions/2") {
+		t.Fatalf("v2 name = %q, want .../versions/2", v2.Name)
+	}
+}
+
+// TestSDKVersionLifecycle proves disable/enable/destroy transition state and
+// gate :access (audit: destroy, disable/enable, per-version state).
+func TestSDKVersionLifecycle(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+	name := mustCreateSecret(t, svc, "lifecycle")
+
+	v1, err := svc.Projects.Secrets.AddVersion(name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode("secret")},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("AddVersion: %v", err)
+	}
+
+	// Disable → state DISABLED, access blocked with FAILED_PRECONDITION (400).
+	dis, err := svc.Projects.Secrets.Versions.Disable(v1.Name, &sm.DisableSecretVersionRequest{}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+
+	if dis.State != "DISABLED" {
+		t.Fatalf("state after Disable = %q, want DISABLED", dis.State)
+	}
+
+	_, err = svc.Projects.Secrets.Versions.Access(v1.Name).Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 400 {
+		t.Fatalf("Access(disabled): got %v, want 400 FAILED_PRECONDITION", err)
+	}
+
+	// Get still reports metadata for a disabled version.
+	meta, err := svc.Projects.Secrets.Versions.Get(v1.Name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get(disabled): %v", err)
+	}
+
+	if meta.State != "DISABLED" {
+		t.Fatalf("Get state = %q, want DISABLED", meta.State)
+	}
+
+	// Enable → access works again.
+	en, err := svc.Projects.Secrets.Versions.Enable(v1.Name, &sm.EnableSecretVersionRequest{}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+
+	if en.State != "ENABLED" {
+		t.Fatalf("state after Enable = %q, want ENABLED", en.State)
+	}
+
+	if _, err := svc.Projects.Secrets.Versions.Access(v1.Name).Context(ctx).Do(); err != nil {
+		t.Fatalf("Access after Enable: %v", err)
+	}
+
+	// Destroy → state DESTROYED, destroyTime stamped, payload gone, access fails.
+	des, err := svc.Projects.Secrets.Versions.Destroy(v1.Name, &sm.DestroySecretVersionRequest{}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+
+	if des.State != "DESTROYED" {
+		t.Fatalf("state after Destroy = %q, want DESTROYED", des.State)
+	}
+
+	if des.DestroyTime == "" {
+		t.Fatal("DestroyTime empty after Destroy, want a timestamp")
+	}
+
+	_, err = svc.Projects.Secrets.Versions.Access(v1.Name).Context(ctx).Do()
+	if !errors.As(err, &gerr) || gerr.Code != 400 {
+		t.Fatalf("Access(destroyed): got %v, want 400 FAILED_PRECONDITION", err)
+	}
+}
+
+// TestSDKSecretPatch proves secrets.patch updates labels (audit: Secrets.patch).
+func TestSDKSecretPatch(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+	name := mustCreateSecret(t, svc, "patch-me")
+
+	updated, err := svc.Projects.Secrets.Patch(name, &sm.Secret{
+		Labels: map[string]string{"team": "platform", "env": "prod"},
+	}).UpdateMask("labels").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	if updated.Labels["team"] != "platform" || updated.Labels["env"] != "prod" {
+		t.Fatalf("labels = %v, want team=platform env=prod", updated.Labels)
+	}
+
+	got, err := svc.Projects.Secrets.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Labels["team"] != "platform" {
+		t.Fatalf("persisted labels = %v, want team=platform", got.Labels)
+	}
+}
+
+// TestSDKSecretIAM proves getIamPolicy/setIamPolicy/testIamPermissions round-
+// trip (audit: Secrets IAM).
+func TestSDKSecretIAM(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+	name := mustCreateSecret(t, svc, "iam-me")
+
+	// getIamPolicy on an existing secret with no policy returns an empty policy.
+	empty, err := svc.Projects.Secrets.GetIamPolicy(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("GetIamPolicy(empty): %v", err)
+	}
+
+	if len(empty.Bindings) != 0 {
+		t.Fatalf("empty policy has %d bindings, want 0", len(empty.Bindings))
+	}
+
+	set, err := svc.Projects.Secrets.SetIamPolicy(name, &sm.SetIamPolicyRequest{
+		Policy: &sm.Policy{
+			Bindings: []*sm.Binding{{
+				Role:    "roles/secretmanager.secretAccessor",
+				Members: []string{"user:alice@example.com"},
+			}},
+		},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("SetIamPolicy: %v", err)
+	}
+
+	if len(set.Bindings) != 1 || set.Bindings[0].Members[0] != "user:alice@example.com" {
+		t.Fatalf("set policy = %+v, want alice binding", set.Bindings)
+	}
+
+	got, err := svc.Projects.Secrets.GetIamPolicy(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("GetIamPolicy: %v", err)
+	}
+
+	if len(got.Bindings) != 1 || got.Bindings[0].Role != "roles/secretmanager.secretAccessor" {
+		t.Fatalf("round-tripped policy = %+v, want accessor binding", got.Bindings)
+	}
+
+	tip, err := svc.Projects.Secrets.TestIamPermissions(name, &sm.TestIamPermissionsRequest{
+		Permissions: []string{"secretmanager.versions.access"},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("TestIamPermissions: %v", err)
+	}
+
+	if len(tip.Permissions) != 1 || tip.Permissions[0] != "secretmanager.versions.access" {
+		t.Fatalf("granted = %v, want the requested permission", tip.Permissions)
+	}
+}
+
+// TestSDKSecretListPagination proves pageSize/pageToken page the secrets list
+// (audit: Secrets.list pagination).
+func TestSDKSecretListPagination(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+
+	const total = 6
+	for i := 0; i < total; i++ {
+		mustCreateSecret(t, svc, fmt.Sprintf("paged-%d", i))
+	}
+
+	first, err := svc.Projects.Secrets.List(testParent).PageSize(2).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List(page 1): %v", err)
+	}
+
+	if len(first.Secrets) != 2 {
+		t.Fatalf("page 1 = %d secrets, want 2", len(first.Secrets))
+	}
+
+	if first.NextPageToken == "" {
+		t.Fatal("page 1 NextPageToken empty, want a continuation token")
+	}
+
+	// Walk every page and count the distinct secrets returned.
+	seen := map[string]bool{}
+	token := ""
+
+	for {
+		page, err := svc.Projects.Secrets.List(testParent).PageSize(2).PageToken(token).Context(ctx).Do()
+		if err != nil {
+			t.Fatalf("List(page token=%q): %v", token, err)
+		}
+
+		if len(page.Secrets) > 2 {
+			t.Fatalf("page returned %d secrets, want <= pageSize 2", len(page.Secrets))
+		}
+
+		for _, s := range page.Secrets {
+			seen[s.Name] = true
+		}
+
+		if page.NextPageToken == "" {
+			break
+		}
+
+		token = page.NextPageToken
+	}
+
+	if len(seen) != total {
+		t.Fatalf("paged through %d distinct secrets, want %d", len(seen), total)
+	}
+}
+
+// TestSDKVersionFields proves versions carry etag and replicationStatus, and a
+// live version has no destroyTime (audit: Secret/SecretVersion fields).
+func TestSDKVersionFields(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+	name := mustCreateSecret(t, svc, "fields")
+
+	v1, err := svc.Projects.Secrets.AddVersion(name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode("x")},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("AddVersion: %v", err)
+	}
+
+	if v1.Etag == "" {
+		t.Fatal("version Etag empty, want an opaque tag")
+	}
+
+	if v1.ReplicationStatus == nil || v1.ReplicationStatus.Automatic == nil {
+		t.Fatalf("replicationStatus = %+v, want automatic", v1.ReplicationStatus)
+	}
+
+	if v1.DestroyTime != "" {
+		t.Fatalf("DestroyTime = %q on a live version, want empty", v1.DestroyTime)
+	}
+
+	sec, err := svc.Projects.Secrets.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get secret: %v", err)
+	}
+
+	if sec.Etag == "" {
+		t.Fatal("secret Etag empty, want an opaque tag")
+	}
+}

--- a/server/gcp/secretmanager/operations.go
+++ b/server/gcp/secretmanager/operations.go
@@ -2,10 +2,66 @@ package secretmanager
 
 import (
 	"net/http"
+	"strconv"
+	"strings"
 
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
 )
+
+// maskContains reports whether a field-update mask names the given field. An
+// empty mask is treated as "update everything present in the body".
+func maskContains(mask, field string) bool {
+	if strings.TrimSpace(mask) == "" {
+		return true
+	}
+
+	for _, f := range strings.Split(mask, ",") {
+		if strings.TrimSpace(f) == field {
+			return true
+		}
+	}
+
+	return false
+}
+
+const (
+	defaultPageSize = 100
+	maxPageSize     = 25000
+)
+
+// pageSize reads ?pageSize, clamping to a sane default and ceiling.
+func pageSize(r *http.Request) int {
+	n, err := strconv.Atoi(r.URL.Query().Get("pageSize"))
+	if err != nil || n <= 0 {
+		return defaultPageSize
+	}
+
+	if n > maxPageSize {
+		return maxPageSize
+	}
+
+	return n
+}
+
+// pageToken reads the opaque ?pageToken continuation cursor.
+func pageToken(r *http.Request) string {
+	return r.URL.Query().Get("pageToken")
+}
+
+// versionLess orders two numeric version ids ascending; non-numeric ids fall
+// back to string order.
+func versionLess(a, b string) bool {
+	ai, aerr := strconv.Atoi(a)
+	bi, berr := strconv.Atoi(b)
+
+	if aerr == nil && berr == nil {
+		return ai < bi
+	}
+
+	return a < b
+}
 
 func (h *Handler) createSecret(w http.ResponseWriter, r *http.Request, rt route) {
 	var req createSecretRequest
@@ -44,12 +100,26 @@ func (h *Handler) listSecrets(w http.ResponseWriter, r *http.Request, rt route) 
 		return
 	}
 
-	out := make([]secretJSON, 0, len(infos))
-	for i := range infos {
-		out = append(out, toSecretJSON(rt.project, &infos[i]))
+	// Stable order by secret name so offset page tokens stay meaningful across
+	// calls (ListSecrets iterates a map, which is unordered).
+	page, err := pagination.PaginateSorted(infos,
+		func(a, b secretsdriver.SecretInfo) bool { return a.Name < b.Name },
+		pageToken(r), pageSize(r))
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid pageToken")
+		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, listSecretsResponse{Secrets: out, TotalSize: len(out)})
+	out := make([]secretJSON, 0, len(page.Items))
+	for i := range page.Items {
+		out = append(out, toSecretJSON(rt.project, &page.Items[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listSecretsResponse{
+		Secrets:       out,
+		TotalSize:     len(infos),
+		NextPageToken: page.NextPageToken,
+	})
 }
 
 func (h *Handler) deleteSecret(w http.ResponseWriter, r *http.Request, rt route) {
@@ -84,12 +154,84 @@ func (h *Handler) listVersions(w http.ResponseWriter, r *http.Request, rt route)
 		return
 	}
 
-	out := make([]versionResourceJSON, 0, len(versions))
-	for i := range versions {
-		out = append(out, toVersionJSON(rt.project, rt.secret, &versions[i]))
+	// Real GCP lists versions newest-first (descending version number).
+	page, err := pagination.PaginateSorted(versions,
+		func(a, b secretsdriver.SecretVersion) bool { return versionLess(b.VersionID, a.VersionID) },
+		pageToken(r), pageSize(r))
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid pageToken")
+		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, listVersionsResponse{Versions: out, TotalSize: len(out)})
+	out := make([]versionResourceJSON, 0, len(page.Items))
+	for i := range page.Items {
+		out = append(out, toVersionJSON(rt.project, rt.secret, &page.Items[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listVersionsResponse{
+		Versions:      out,
+		TotalSize:     len(versions),
+		NextPageToken: page.NextPageToken,
+	})
+}
+
+func (h *Handler) patchSecret(w http.ResponseWriter, r *http.Request, rt route) {
+	if h.gcp == nil {
+		writeUnsupported(w)
+		return
+	}
+
+	var req patchSecretRequest
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	// The update mask names the fields to change; only labels are modeled.
+	patch := secretsdriver.GCPSecretPatch{}
+	if maskContains(r.URL.Query().Get("updateMask"), "labels") {
+		patch.Labels = req.Labels
+		patch.SetLabels = true
+	}
+
+	info, err := h.gcp.PatchSecret(r.Context(), rt.secret, patch)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toSecretJSON(rt.project, info))
+}
+
+// mutateVersion applies an enable/disable/destroy lifecycle verb to a version.
+func (h *Handler) mutateVersion(w http.ResponseWriter, r *http.Request, rt route, verb string) {
+	if h.gcp == nil {
+		writeUnsupported(w)
+		return
+	}
+
+	var (
+		ver *secretsdriver.SecretVersion
+		err error
+	)
+
+	switch verb {
+	case verbEnable:
+		ver, err = h.gcp.EnableSecretVersion(r.Context(), rt.secret, driverVersion(rt.version))
+	case verbDisable:
+		ver, err = h.gcp.DisableSecretVersion(r.Context(), rt.secret, driverVersion(rt.version))
+	case verbDestroy:
+		ver, err = h.gcp.DestroySecretVersion(r.Context(), rt.secret, driverVersion(rt.version))
+	default:
+		writeUnsupported(w)
+		return
+	}
+
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toVersionJSON(rt.project, rt.secret, ver))
 }
 
 func (h *Handler) getVersion(w http.ResponseWriter, r *http.Request, rt route) {
@@ -106,6 +248,14 @@ func (h *Handler) accessVersion(w http.ResponseWriter, r *http.Request, rt route
 	ver, err := h.secrets.GetSecretValue(r.Context(), rt.secret, driverVersion(rt.version))
 	if err != nil {
 		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	// A version's payload can only be accessed in the ENABLED state; disabled
+	// and destroyed versions fail with FAILED_PRECONDITION, matching real GCP.
+	if ver.State != "" && ver.State != secretsdriver.VersionEnabled {
+		gcprest.WriteError(w, http.StatusBadRequest, "failedPrecondition",
+			"cannot access version "+ver.VersionID+" in state "+ver.State)
 		return
 	}
 

--- a/server/gcp/secretmanager/types.go
+++ b/server/gcp/secretmanager/types.go
@@ -4,13 +4,14 @@ import (
 	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
 )
 
-// stateEnabled is the lifecycle state reported for every version — the mock
-// models neither disabled nor destroyed versions.
-const stateEnabled = "ENABLED"
-
 type automaticJSON struct{}
 
 type replicationJSON struct {
+	Automatic *automaticJSON `json:"automatic,omitempty"`
+}
+
+// replicationStatusJSON mirrors the automatic replication shape on a version.
+type replicationStatusJSON struct {
 	Automatic *automaticJSON `json:"automatic,omitempty"`
 }
 
@@ -19,12 +20,16 @@ type secretJSON struct {
 	Replication replicationJSON   `json:"replication"`
 	CreateTime  string            `json:"createTime,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`
+	Etag        string            `json:"etag,omitempty"`
 }
 
 type versionResourceJSON struct {
-	Name       string `json:"name"`
-	CreateTime string `json:"createTime,omitempty"`
-	State      string `json:"state"`
+	Name              string                 `json:"name"`
+	CreateTime        string                 `json:"createTime,omitempty"`
+	DestroyTime       string                 `json:"destroyTime,omitempty"`
+	State             string                 `json:"state"`
+	ReplicationStatus *replicationStatusJSON `json:"replicationStatus,omitempty"`
+	Etag              string                 `json:"etag,omitempty"`
 }
 
 // payloadJSON carries the secret bytes; encoding/json renders []byte as the
@@ -34,6 +39,11 @@ type payloadJSON struct {
 }
 
 type createSecretRequest struct {
+	Labels map[string]string `json:"labels"`
+}
+
+// patchSecretRequest is the body of secrets.patch; only labels are modeled.
+type patchSecretRequest struct {
 	Labels map[string]string `json:"labels"`
 }
 
@@ -47,13 +57,40 @@ type accessResponse struct {
 }
 
 type listSecretsResponse struct {
-	Secrets   []secretJSON `json:"secrets"`
-	TotalSize int          `json:"totalSize"`
+	Secrets       []secretJSON `json:"secrets"`
+	TotalSize     int          `json:"totalSize"`
+	NextPageToken string       `json:"nextPageToken,omitempty"`
 }
 
 type listVersionsResponse struct {
-	Versions  []versionResourceJSON `json:"versions"`
-	TotalSize int                   `json:"totalSize"`
+	Versions      []versionResourceJSON `json:"versions"`
+	TotalSize     int                   `json:"totalSize"`
+	NextPageToken string                `json:"nextPageToken,omitempty"`
+}
+
+// iamPolicyJSON is the GCP IAM Policy resource returned by getIamPolicy /
+// setIamPolicy.
+type iamPolicyJSON struct {
+	Version  int              `json:"version,omitempty"`
+	Bindings []iamBindingJSON `json:"bindings,omitempty"`
+	Etag     string           `json:"etag,omitempty"`
+}
+
+type iamBindingJSON struct {
+	Role    string   `json:"role"`
+	Members []string `json:"members,omitempty"`
+}
+
+type setIamPolicyRequest struct {
+	Policy iamPolicyJSON `json:"policy"`
+}
+
+type testIamPermissionsRequest struct {
+	Permissions []string `json:"permissions"`
+}
+
+type testIamPermissionsResponse struct {
+	Permissions []string `json:"permissions,omitempty"`
 }
 
 // secretName builds the canonical "projects/{p}/secrets/{id}" resource name,
@@ -82,13 +119,40 @@ func toSecretJSON(project string, info *secretsdriver.SecretInfo) secretJSON {
 		Replication: replicationJSON{Automatic: &automaticJSON{}},
 		CreateTime:  info.CreatedAt,
 		Labels:      info.Tags,
+		Etag:        info.Etag,
 	}
 }
 
 func toVersionJSON(project, id string, ver *secretsdriver.SecretVersion) versionResourceJSON {
-	return versionResourceJSON{
-		Name:       versionName(project, id, ver.VersionID),
-		CreateTime: ver.CreatedAt,
-		State:      stateEnabled,
+	state := ver.State
+	if state == "" {
+		state = secretsdriver.VersionEnabled
 	}
+
+	return versionResourceJSON{
+		Name:              versionName(project, id, ver.VersionID),
+		CreateTime:        ver.CreatedAt,
+		DestroyTime:       ver.DestroyTime,
+		State:             state,
+		ReplicationStatus: &replicationStatusJSON{Automatic: &automaticJSON{}},
+		Etag:              ver.Etag,
+	}
+}
+
+func toPolicyJSON(pol *secretsdriver.GCPIAMPolicy) iamPolicyJSON {
+	out := iamPolicyJSON{Version: pol.Version, Etag: pol.Etag}
+	for _, b := range pol.Bindings {
+		out.Bindings = append(out.Bindings, iamBindingJSON{Role: b.Role, Members: b.Members})
+	}
+
+	return out
+}
+
+func fromPolicyJSON(pol iamPolicyJSON) secretsdriver.GCPIAMPolicy {
+	out := secretsdriver.GCPIAMPolicy{Version: pol.Version, Etag: pol.Etag}
+	for _, b := range pol.Bindings {
+		out.Bindings = append(out.Bindings, secretsdriver.GCPIAMBinding{Role: b.Role, Members: b.Members})
+	}
+
+	return out
 }

--- a/services/secrets/driver/driver.go
+++ b/services/secrets/driver/driver.go
@@ -27,6 +27,9 @@ type SecretInfo struct {
 	// Manager), echoed on DescribeSecret. Empty when the default
 	// aws/secretsmanager key is used. Ignored by Azure/GCP.
 	KMSKeyID string
+	// Etag is an opaque optimistic-concurrency tag (GCP Secret Manager), echoed
+	// on the secret resource. Empty for providers that don't model it.
+	Etag string
 }
 
 // SecretVersion represents a specific version of a secret value.
@@ -39,6 +42,16 @@ type SecretVersion struct {
 	// SecretString), so a reader returns it in the SecretBinary field. AWS Secrets
 	// Manager keeps these mutually exclusive; other providers leave it false.
 	Binary bool
+	// State is the lifecycle state of the version (GCP Secret Manager):
+	// "ENABLED", "DISABLED", or "DESTROYED". Empty for providers that don't
+	// model per-version state.
+	State string
+	// DestroyTime is the RFC3339 time the version was destroyed (GCP Secret
+	// Manager); empty unless State is "DESTROYED".
+	DestroyTime string
+	// Etag is an opaque optimistic-concurrency tag (GCP Secret Manager), echoed
+	// on the version resource. Empty for providers that don't model it.
+	Etag string
 }
 
 // Secrets is the interface that secret management provider implementations must satisfy.
@@ -51,6 +64,61 @@ type Secrets interface {
 	PutSecretValue(ctx context.Context, name string, value []byte) (*SecretVersion, error)
 	GetSecretValue(ctx context.Context, name string, versionID string) (*SecretVersion, error)
 	ListSecretVersions(ctx context.Context, name string) ([]SecretVersion, error)
+}
+
+// Version lifecycle states reported by GCP Secret Manager.
+const (
+	VersionEnabled   = "ENABLED"
+	VersionDisabled  = "DISABLED"
+	VersionDestroyed = "DESTROYED"
+)
+
+// GCPSecretPatch is the GCP Secret Manager secrets.patch payload. Only the
+// fields named in the update mask are applied; SetLabels true replaces the
+// label set with Labels (including clearing it when Labels is empty).
+type GCPSecretPatch struct {
+	Labels    map[string]string
+	SetLabels bool
+}
+
+// GCPIAMBinding binds an IAM role to a set of members.
+type GCPIAMBinding struct {
+	Role    string
+	Members []string
+}
+
+// GCPIAMPolicy is a GCP IAM policy as served by getIamPolicy/setIamPolicy.
+type GCPIAMPolicy struct {
+	Version  int
+	Bindings []GCPIAMBinding
+	Etag     string
+}
+
+// GCPSecrets is the GCP Secret Manager-specific surface kept off the shared
+// Secrets interface — a type-asserted optional interface — so the AWS and Azure
+// providers need not model version lifecycle, secret patch, or IAM semantics.
+type GCPSecrets interface {
+	// EnableSecretVersion moves a version to ENABLED. It is idempotent on an
+	// already-enabled version and fails on a DESTROYED one.
+	EnableSecretVersion(ctx context.Context, name, versionID string) (*SecretVersion, error)
+	// DisableSecretVersion moves a version to DISABLED. It fails on a DESTROYED
+	// version.
+	DisableSecretVersion(ctx context.Context, name, versionID string) (*SecretVersion, error)
+	// DestroySecretVersion moves a version to DESTROYED, wipes its payload, and
+	// stamps its destroyTime. It fails on an already-DESTROYED version.
+	DestroySecretVersion(ctx context.Context, name, versionID string) (*SecretVersion, error)
+	// PatchSecret applies a partial update (labels) to a secret's metadata.
+	PatchSecret(ctx context.Context, name string, patch GCPSecretPatch) (*SecretInfo, error)
+	// GetSecretIAMPolicy returns the secret's stored IAM policy (an empty
+	// versioned policy when none has been set).
+	GetSecretIAMPolicy(ctx context.Context, name string) (*GCPIAMPolicy, error)
+	// SetSecretIAMPolicy stores the secret's IAM policy and returns it with a
+	// refreshed etag.
+	SetSecretIAMPolicy(ctx context.Context, name string, policy GCPIAMPolicy) (*GCPIAMPolicy, error)
+	// TestSecretIAMPermissions returns the subset of permissions the caller
+	// holds. CloudEmu does not enforce IAM, so all requested permissions are
+	// reported as granted.
+	TestSecretIAMPermissions(ctx context.Context, name string, permissions []string) ([]string, error)
 }
 
 // KVAttributes are Azure Key Vault per-version secret management attributes.


### PR DESCRIPTION
## What

Fixes the entire GCP **Secret Manager** batch from \`AUDIT_GCP.md\` (\`## secretmanager\`). Real \`google.golang.org/api/secretmanager/v1\` clients pointed at the in-process GCP server now drive the full secret + version lifecycle end-to-end.

GCP-specific operations are added through a type-asserted optional interface (\`driver.GCPSecrets\`) so AWS/Azure secret backends are untouched; only new struct fields (\`Etag\`, \`State\`, \`DestroyTime\`) land on the shared driver types (defaults are zero for other providers).

## Findings fixed

- **[BLOCKER] SecretVersions.destroy** — \`:destroy\` now routed; wipes the payload, sets \`state=DESTROYED\` + \`destroyTime\`. \`:access\` on a destroyed version fails FAILED_PRECONDITION.
- **[HIGH] SecretVersions.disable/enable** — \`:disable\`/\`:enable\` routed; toggle ENABLED/DISABLED. \`:access\` on a disabled version returns FAILED_PRECONDITION (HTTP 400).
- **[HIGH] AddSecretVersion version naming** — versions are numbered by monotonic integer (\`1, 2, 3…\`) and addressable by that id (\`.../versions/1\`), not an internal random counter.
- **[HIGH] SecretVersion.state** — real per-version state reported (ENABLED/DISABLED/DESTROYED) with \`destroyTime\`, replacing the hardcoded ENABLED.
- **[HIGH] Secrets.patch** — \`PATCH\` with \`updateMask=labels\` updates the secret's labels and round-trips.
- **[HIGH] Secrets IAM** — \`:getIamPolicy\` / \`:setIamPolicy\` / \`:testIamPermissions\` served and round-trip (policy stored per secret).
- **[MEDIUM] Secrets/Versions.list pagination** — \`pageSize\`/\`pageToken\` honored with \`nextPageToken\`; secrets paged over a stable name ordering, versions newest-first.
- **[MEDIUM] Secret/SecretVersion fields** — \`etag\` on both, plus \`replicationStatus\` and \`destroyTime\` on versions.

## Layering

- Driver (\`services/secrets/driver\`): new optional \`GCPSecrets\` interface + \`Etag\`/\`State\`/\`DestroyTime\` fields.
- Provider (\`providers/gcp/secretmanager\`): integer version numbering, lifecycle/patch/IAM implementations, snapshot round-trip of the new state.
- Wire (\`server/gcp/secretmanager\`): routing for the new verbs/methods, pagination, and the GCP REST JSON shapes.

## Tests

New \`server/gcp/secretmanager/lifecycle_sdk_test.go\` drives the real \`secretmanager/v1\` SDK against the in-process server, one reproduction per finding (integer naming, lifecycle+access gating, patch, IAM, pagination, fields). Existing secretmanager tests stay green.

## Docs

\`docs/coverage\` regenerated (\`go generate ./...\`) for the new \`GCPSecrets\` capability.

## Deferrals

None.