### PR TITLE
fix(gcp-disks): sourceImage/sourceDisk reflection, dup-name 409, resize, aggregatedList, users[], creationTimestamp

### DIFF
--- a/providers/gcp/compute/gce.go
+++ b/providers/gcp/compute/gce.go
@@ -629,6 +629,22 @@ func (m *Mock) DescribeVolumes(_ context.Context, ids []string) ([]driver.Volume
 	return describeResources(m.volumes, ids), nil
 }
 
+// ResizeVolumeGCP grows the disk to sizeGb (a no-op when already that large).
+// GCP forbids shrinking, so the wire handler rejects smaller sizes before this
+// is reached. GCP-specific; reached via a type assertion from the GCE handler.
+func (m *Mock) ResizeVolumeGCP(volumeID string, sizeGb int) error {
+	vol, ok := m.volumes.Get(volumeID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)
+	}
+
+	if sizeGb > vol.Size {
+		vol.Size = sizeGb
+	}
+
+	return nil
+}
+
 func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device string) error {
 	vol, ok := m.volumes.Get(volumeID)
 	if !ok {

--- a/server/gcp/compute/disks.go
+++ b/server/gcp/compute/disks.go
@@ -15,6 +15,10 @@ import (
 // the underlying compute driver, since the driver indexes by its own ID.
 const gcpDiskNameTag = "cloudemu:gcpDiskName"
 
+// gcpDiskSourceImageTag round-trips the sourceImage URL the caller created the
+// disk from, so a read echoes it (real GCP retains sourceImage/sourceImageId).
+const gcpDiskSourceImageTag = "cloudemu:gcpDiskSourceImage"
+
 // diskRequest mirrors the subset of GCP compute#disk we accept on insert.
 type diskRequest struct {
 	Name        string            `json:"name"`
@@ -35,6 +39,9 @@ type diskResponse struct {
 	Status            string            `json:"status"`
 	Zone              string            `json:"zone"`
 	SelfLink          string            `json:"selfLink"`
+	SourceImage       string            `json:"sourceImage,omitempty"`
+	SourceImageID     string            `json:"sourceImageId,omitempty"`
+	Users             []string          `json:"users,omitempty"`
 	Labels            map[string]string `json:"labels,omitempty"`
 	CreationTimestamp string            `json:"creationTimestamp,omitempty"`
 }
@@ -64,11 +71,15 @@ func (h *Handler) insertDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 		return
 	}
 
+	if _, err := findDiskByName(r.Context(), h.compute, req.Name); conflictIfExists(w, err, "disk "+req.Name+" already exists") {
+		return
+	}
+
 	cfg := computedriver.VolumeConfig{
 		Size:             pickSize(req.SizeGb, req.SizeGbInt),
 		VolumeType:       lastSegment(req.Type),
 		AvailabilityZone: rp.ScopeName,
-		Tags:             mergeDiskTags(req.Labels, req.Name),
+		Tags:             mergeDiskTags(req.Labels, req.Name, req.SourceImage),
 	}
 
 	_, err := h.compute.CreateVolume(r.Context(), cfg)
@@ -91,7 +102,10 @@ func (h *Handler) getDisk(w http.ResponseWriter, r *http.Request, rp gcprest.Res
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, toDiskResponse(vol, rp, hostFromRequest(r)))
+	host := hostFromRequest(r)
+	users := h.diskUsersByName(r.Context(), host, rp.Project)
+
+	gcprest.WriteJSON(w, http.StatusOK, toDiskResponse(vol, rp, host, users[rp.ResourceName]))
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -103,12 +117,14 @@ func (h *Handler) listDisks(w http.ResponseWriter, r *http.Request, rp gcprest.R
 	}
 
 	host := hostFromRequest(r)
+	users := h.diskUsersByName(r.Context(), host, rp.Project)
 	out := make([]diskResponse, 0, len(vols))
 
 	for i := range vols {
 		scope := rp
-		scope.ResourceName = tagOr(vols[i].Tags, gcpDiskNameTag, vols[i].ID)
-		out = append(out, toDiskResponse(&vols[i], scope, host))
+		name := tagOr(vols[i].Tags, gcpDiskNameTag, vols[i].ID)
+		scope.ResourceName = name
+		out = append(out, toDiskResponse(&vols[i], scope, host, users[name]))
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, diskListResponse{
@@ -138,6 +154,106 @@ func (h *Handler) deleteDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 	gcprest.WriteJSON(w, http.StatusOK, op)
 }
 
+// diskResizeRequest is the compute#disksResizeRequest body (sizeGb arrives as a
+// JSON string from the protobuf clients).
+type diskResizeRequest struct {
+	SizeGb    int `json:"sizeGb,string,omitempty"`
+	SizeGbInt int `json:"-"`
+}
+
+// volumeResizer is the GCP-local grow-a-disk capability the GCE Mock implements;
+// reached via a type assertion so the shared compute driver stays unchanged.
+type volumeResizer interface {
+	ResizeVolumeGCP(volumeID string, sizeGb int) error
+}
+
+// resizeDisk handles POST .../disks/{name}/resize, growing the disk to the
+// requested size and returning a DONE Operation (GCP forbids shrinking).
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) resizeDisk(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	var req diskResizeRequest
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	vol, err := findDiskByName(r.Context(), h.compute, rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	newSize := pickSize(req.SizeGb, req.SizeGbInt)
+	if newSize < vol.Size {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "disk size cannot be reduced")
+		return
+	}
+
+	resizer, ok := h.compute.(volumeResizer)
+	if !ok {
+		writeNotImplemented(w, "disk resize")
+		return
+	}
+
+	if err := resizer.ResizeVolumeGCP(vol.ID, newSize); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
+		"disks", rp.ResourceName, "resize")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// disksScopedList is one zone's bucket in an aggregated disk list.
+type disksScopedList struct {
+	Disks   []diskResponse     `json:"disks,omitempty"`
+	Warning *scopedListWarning `json:"warning,omitempty"`
+}
+
+type diskAggregatedListResponse struct {
+	Kind     string                     `json:"kind"`
+	ID       string                     `json:"id"`
+	Items    map[string]disksScopedList `json:"items"`
+	SelfLink string                     `json:"selfLink"`
+}
+
+// aggregatedListDisks handles GET /aggregated/disks, returning every disk
+// grouped by its "zones/{zone}" scope.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) aggregatedListDisks(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	vols, err := h.compute.DescribeVolumes(r.Context(), nil)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	host := hostFromRequest(r)
+	users := h.diskUsersByName(r.Context(), host, rp.Project)
+	items := make(map[string]disksScopedList)
+
+	for i := range vols {
+		zone := vols[i].AvailabilityZone
+		name := tagOr(vols[i].Tags, gcpDiskNameTag, vols[i].ID)
+		scope := gcprest.ResourcePath{
+			Project: rp.Project, Scope: gcprest.ScopeZones, ScopeName: zone, ResourceName: name,
+		}
+		key := "zones/" + zone
+		bucket := items[key]
+		bucket.Disks = append(bucket.Disks, toDiskResponse(&vols[i], scope, host, users[name]))
+		items[key] = bucket
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, diskAggregatedListResponse{
+		Kind:     "compute#diskAggregatedList",
+		ID:       "projects/" + rp.Project + "/aggregated/disks",
+		Items:    items,
+		SelfLink: strings.TrimSuffix(host, "/") + "/compute/v1/projects/" + rp.Project + "/aggregated/disks",
+	})
+}
+
 func findDiskByName(ctx context.Context, c computedriver.Compute, name string) (*computedriver.VolumeInfo, error) {
 	vols, err := c.DescribeVolumes(ctx, nil)
 	if err != nil {
@@ -157,23 +273,61 @@ func findDiskByName(ctx context.Context, c computedriver.Compute, name string) (
 // model the GCP-specific CREATING / FAILED / DELETING transitions.
 const diskStatusReady = "READY"
 
-// toDiskResponse maps a driver VolumeInfo to GCP REST disk JSON.
+// toDiskResponse maps a driver VolumeInfo to GCP REST disk JSON. users is the
+// list of instance self-links the disk is attached to (empty when detached).
 //
 //nolint:gocritic // rp is a request-scoped value
-func toDiskResponse(vol *computedriver.VolumeInfo, rp gcprest.ResourcePath, host string) diskResponse {
+func toDiskResponse(vol *computedriver.VolumeInfo, rp gcprest.ResourcePath, host string, users []string) diskResponse {
 	name := tagOr(vol.Tags, gcpDiskNameTag, rp.ResourceName)
+	sourceImage := vol.Tags[gcpDiskSourceImageTag]
 
-	return diskResponse{
-		Kind:     "compute#disk",
-		ID:       numericID(vol.ID),
-		Name:     name,
-		SizeGb:   strconv.Itoa(vol.Size),
-		Type:     gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, "diskTypes", defaultDiskType(vol.VolumeType)),
-		Status:   diskStatusReady,
-		Zone:     host + "/compute/v1/projects/" + rp.Project + "/zones/" + rp.ScopeName,
-		SelfLink: gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, "disks", name),
-		Labels:   stripInternalDiskTags(vol.Tags),
+	resp := diskResponse{
+		Kind:              "compute#disk",
+		ID:                numericID(vol.ID),
+		Name:              name,
+		SizeGb:            strconv.Itoa(vol.Size),
+		Type:              gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, "diskTypes", defaultDiskType(vol.VolumeType)),
+		Status:            diskStatusReady,
+		Zone:              host + "/compute/v1/projects/" + rp.Project + "/zones/" + rp.ScopeName,
+		SelfLink:          gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, "disks", name),
+		SourceImage:       sourceImage,
+		Users:             users,
+		Labels:            userLabels(vol.Tags),
+		CreationTimestamp: vol.CreatedAt,
 	}
+
+	if sourceImage != "" {
+		resp.SourceImageID = numericID(sourceImage)
+	}
+
+	return resp
+}
+
+// diskUsersByName scans instances and maps each disk name to the self-links of
+// the instances it is attached to, so a disk read reflects its users[] (kept
+// consistent with the instance-side disks[] populated by attachDisk).
+func (h *Handler) diskUsersByName(ctx context.Context, host, project string) map[string][]string {
+	instances, err := h.compute.DescribeInstances(ctx, nil, nil)
+	if err != nil {
+		return nil
+	}
+
+	out := make(map[string][]string)
+
+	for i := range instances {
+		instName := tagOr(instances[i].Tags, gcpNameTag, "")
+		zone := tagOr(instances[i].Tags, keyZone, "")
+		link := gcprest.SelfLink(host, project, gcprest.ScopeZones, zone, "instances", instName)
+
+		attached := decodeDisks(instances[i].Tags)
+		for j := range attached {
+			if dn := lastSegment(attached[j].Source); dn != "" {
+				out[dn] = append(out[dn], link)
+			}
+		}
+	}
+
+	return out
 }
 
 func defaultDiskType(vt string) string {
@@ -184,8 +338,8 @@ func defaultDiskType(vt string) string {
 	return vt
 }
 
-func mergeDiskTags(in map[string]string, name string) map[string]string {
-	out := make(map[string]string, len(in)+1)
+func mergeDiskTags(in map[string]string, name, sourceImage string) map[string]string {
+	out := make(map[string]string, len(in)+internalTagCap)
 
 	for k, v := range in {
 		out[k] = v
@@ -193,29 +347,27 @@ func mergeDiskTags(in map[string]string, name string) map[string]string {
 
 	out[gcpDiskNameTag] = name
 
+	if sourceImage != "" {
+		out[gcpDiskSourceImageTag] = sourceImage
+	}
+
 	return out
 }
 
-func stripInternalDiskTags(in map[string]string) map[string]string {
-	if len(in) == 0 {
-		return nil
+// conflictIfExists writes a 409 alreadyExists (or the underlying error) and
+// returns true when a name-existence probe found the resource or errored; it
+// returns false, letting the caller proceed, only when findErr is NotFound.
+func conflictIfExists(w http.ResponseWriter, findErr error, msg string) bool {
+	switch {
+	case findErr == nil:
+		gcprest.WriteError(w, http.StatusConflict, "alreadyExists", msg)
+		return true
+	case !cerrors.IsNotFound(findErr):
+		gcprest.WriteCErr(w, findErr)
+		return true
+	default:
+		return false
 	}
-
-	out := make(map[string]string, len(in))
-
-	for k, v := range in {
-		if k == gcpDiskNameTag {
-			continue
-		}
-
-		out[k] = v
-	}
-
-	if len(out) == 0 {
-		return nil
-	}
-
-	return out
 }
 
 // pickSize chooses sizeGb from the alternate fields the SDK might use.

--- a/server/gcp/compute/disks_sdk_test.go
+++ b/server/gcp/compute/disks_sdk_test.go
@@ -114,3 +114,234 @@ func TestSDKDiskRoundTrip(t *testing.T) {
 }
 
 func ptrInt64(v int64) *int64 { return &v }
+
+// newGCPServer builds an in-process GCP server backed by a fresh GCP cloud.
+func newGCPServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Compute: cloudP.GCE})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func insertDisk(t *testing.T, c *gcpcompute.DisksClient, disk *computepb.Disk) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	op, err := c.Insert(ctx, &computepb.InsertDiskRequest{
+		Project: testProject, Zone: testZone, DiskResource: disk,
+	})
+	if err != nil {
+		t.Fatalf("disk Insert: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("disk Insert wait: %v", err)
+	}
+}
+
+// TestSDKDiskSourceImageReflected proves disks.get echoes sourceImage and a
+// derived sourceImageId (previously dropped).
+func TestSDKDiskSourceImageReflected(t *testing.T) {
+	ts := newGCPServer(t)
+	client := newDisksSDKClient(t, ts)
+	ctx := context.Background()
+
+	const srcImage = "projects/debian-cloud/global/images/family/debian-12"
+
+	insertDisk(t, client, &computepb.Disk{
+		Name:        ptrStr("img-disk"),
+		SizeGb:      ptrInt64(20),
+		SourceImage: ptrStr(srcImage),
+	})
+
+	got, err := client.Get(ctx, &computepb.GetDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "img-disk",
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetSourceImage() != srcImage {
+		t.Errorf("sourceImage=%q want %q", got.GetSourceImage(), srcImage)
+	}
+
+	if got.GetSourceImageId() == "" {
+		t.Error("sourceImageId is empty")
+	}
+}
+
+// TestSDKDiskDuplicateNameConflict proves a duplicate-name insert is rejected
+// (409) rather than silently creating a second disk.
+func TestSDKDiskDuplicateNameConflict(t *testing.T) {
+	ts := newGCPServer(t)
+	client := newDisksSDKClient(t, ts)
+	ctx := context.Background()
+
+	insertDisk(t, client, &computepb.Disk{Name: ptrStr("dup"), SizeGb: ptrInt64(10)})
+
+	if _, err := client.Insert(ctx, &computepb.InsertDiskRequest{
+		Project: testProject, Zone: testZone,
+		DiskResource: &computepb.Disk{Name: ptrStr("dup"), SizeGb: ptrInt64(10)},
+	}); err == nil {
+		t.Fatal("duplicate Insert succeeded, want conflict")
+	}
+
+	it := client.List(ctx, &computepb.ListDisksRequest{Project: testProject, Zone: testZone})
+
+	count := 0
+	for {
+		if _, err := it.Next(); err != nil {
+			break
+		}
+
+		count++
+	}
+
+	if count != 1 {
+		t.Errorf("disk count=%d want 1", count)
+	}
+}
+
+// TestSDKDiskCreationTimestamp proves disks.get returns a creationTimestamp.
+func TestSDKDiskCreationTimestamp(t *testing.T) {
+	ts := newGCPServer(t)
+	client := newDisksSDKClient(t, ts)
+	ctx := context.Background()
+
+	insertDisk(t, client, &computepb.Disk{Name: ptrStr("ts-disk"), SizeGb: ptrInt64(10)})
+
+	got, err := client.Get(ctx, &computepb.GetDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "ts-disk",
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetCreationTimestamp() == "" {
+		t.Error("creationTimestamp is empty")
+	}
+}
+
+// TestSDKDiskResize proves disks.resize grows the disk (previously 501).
+func TestSDKDiskResize(t *testing.T) {
+	ts := newGCPServer(t)
+	client := newDisksSDKClient(t, ts)
+	ctx := context.Background()
+
+	insertDisk(t, client, &computepb.Disk{Name: ptrStr("grow"), SizeGb: ptrInt64(32)})
+
+	op, err := client.Resize(ctx, &computepb.ResizeDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "grow",
+		DisksResizeRequestResource: &computepb.DisksResizeRequest{SizeGb: ptrInt64(50)},
+	})
+	if err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("Resize wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "grow",
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetSizeGb() != 50 {
+		t.Errorf("sizeGb=%d want 50", got.GetSizeGb())
+	}
+}
+
+// TestSDKDiskAggregatedList proves aggregatedList returns disks grouped by zone
+// (previously 501).
+func TestSDKDiskAggregatedList(t *testing.T) {
+	ts := newGCPServer(t)
+	client := newDisksSDKClient(t, ts)
+	ctx := context.Background()
+
+	insertDisk(t, client, &computepb.Disk{Name: ptrStr("agg-disk"), SizeGb: ptrInt64(10)})
+
+	it := client.AggregatedList(ctx, &computepb.AggregatedListDisksRequest{Project: testProject})
+
+	found := false
+	for {
+		pair, err := it.Next()
+		if err != nil {
+			break
+		}
+
+		for _, d := range pair.Value.GetDisks() {
+			if d.GetName() == "agg-disk" {
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		t.Error("AggregatedList did not return agg-disk")
+	}
+}
+
+// TestSDKDiskUsersReflectAttachment proves a disk attached to an instance shows
+// the instance in users[], consistent with the instance-side disks[].
+func TestSDKDiskUsersReflectAttachment(t *testing.T) {
+	ts := newGCPServer(t)
+	disks := newDisksSDKClient(t, ts)
+	instances := newSDKInstancesClient(t, ts)
+	ctx := context.Background()
+
+	insertDisk(t, disks, &computepb.Disk{Name: ptrStr("shared-disk"), SizeGb: ptrInt64(10)})
+
+	insOp, err := instances.Insert(ctx, &computepb.InsertInstanceRequest{
+		Project: testProject, Zone: testZone,
+		InstanceResource: &computepb.Instance{
+			Name:        ptrStr("holder-vm"),
+			MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+			NetworkInterfaces: []*computepb.NetworkInterface{
+				{Network: ptrStr("global/networks/default")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("instance Insert: %v", err)
+	}
+
+	if err := insOp.Wait(ctx); err != nil {
+		t.Fatalf("instance Insert wait: %v", err)
+	}
+
+	diskURL := "projects/" + testProject + "/zones/" + testZone + "/disks/shared-disk"
+
+	attachOp, err := instances.AttachDisk(ctx, &computepb.AttachDiskInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "holder-vm",
+		AttachedDiskResource: &computepb.AttachedDisk{
+			Source: ptrStr(diskURL), DeviceName: ptrStr("data"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("AttachDisk: %v", err)
+	}
+
+	if err := attachOp.Wait(ctx); err != nil {
+		t.Fatalf("AttachDisk wait: %v", err)
+	}
+
+	got, err := disks.Get(ctx, &computepb.GetDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "shared-disk",
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	users := got.GetUsers()
+	if len(users) != 1 || !strings.HasSuffix(users[0], "/instances/holder-vm") {
+		t.Errorf("users=%v want one link ending /instances/holder-vm", users)
+	}
+}

--- a/server/gcp/compute/handler.go
+++ b/server/gcp/compute/handler.go
@@ -95,9 +95,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) serveAggregated(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	if r.Method == http.MethodGet && rp.ResourceType == resourceInstances {
-		h.aggregatedListInstances(w, r, rp)
-		return
+	if r.Method == http.MethodGet {
+		switch rp.ResourceType {
+		case resourceInstances:
+			h.aggregatedListInstances(w, r, rp)
+			return
+		case resourceDisks:
+			h.aggregatedListDisks(w, r, rp)
+			return
+		}
 	}
 
 	writeNotImplemented(w, r.Method+" "+r.URL.Path)
@@ -176,7 +182,7 @@ func (h *Handler) serveImagesRoute(w http.ResponseWriter, r *http.Request, rp gc
 	}
 }
 
-//nolint:gocritic,dupl // rp is a request-scoped value; route shape is duplicate-by-design across resource types
+//nolint:gocritic // rp is a request-scoped value
 func (h *Handler) serveDisksRoute(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
 	if rp.ResourceName == "" {
 		switch r.Method {
@@ -188,6 +194,11 @@ func (h *Handler) serveDisksRoute(w http.ResponseWriter, r *http.Request, rp gcp
 			writeNotImplemented(w, r.Method+" "+r.URL.Path)
 		}
 
+		return
+	}
+
+	if r.Method == http.MethodPost && strings.EqualFold(rp.Action, "resize") {
+		h.resizeDisk(w, r, rp)
 		return
 	}
 

--- a/server/gcp/compute/images.go
+++ b/server/gcp/compute/images.go
@@ -3,6 +3,7 @@ package compute
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -13,20 +14,37 @@ import (
 // gcpImageNameTag is the tag we round-trip the image name through.
 const gcpImageNameTag = "cloudemu:gcpImageName"
 
+// Internal tags round-tripping the GCP-specific image fields the portable
+// compute driver model does not carry, so a read reflects them.
+const (
+	gcpImageSourceDiskTag     = "cloudemu:gcpImageSourceDisk"
+	gcpImageSourceSnapshotTag = "cloudemu:gcpImageSourceSnapshot"
+	gcpImageFamilyTag         = "cloudemu:gcpImageFamily"
+	gcpImageDiskSizeGbTag     = "cloudemu:gcpImageDiskSizeGb"
+)
+
 type imageRequest struct {
 	Name           string            `json:"name"`
 	SourceDisk     string            `json:"sourceDisk,omitempty"`
 	SourceSnapshot string            `json:"sourceSnapshot,omitempty"`
+	Family         string            `json:"family,omitempty"`
+	DiskSizeGb     int               `json:"diskSizeGb,string,omitempty"`
 	Labels         map[string]string `json:"labels,omitempty"`
 }
 
 type imageResponse struct {
-	Kind     string            `json:"kind"`
-	ID       string            `json:"id"`
-	Name     string            `json:"name"`
-	Status   string            `json:"status"`
-	SelfLink string            `json:"selfLink"`
-	Labels   map[string]string `json:"labels,omitempty"`
+	Kind              string            `json:"kind"`
+	ID                string            `json:"id"`
+	Name              string            `json:"name"`
+	Status            string            `json:"status"`
+	SelfLink          string            `json:"selfLink"`
+	SourceDisk        string            `json:"sourceDisk,omitempty"`
+	SourceDiskID      string            `json:"sourceDiskId,omitempty"`
+	SourceSnapshot    string            `json:"sourceSnapshot,omitempty"`
+	Family            string            `json:"family,omitempty"`
+	DiskSizeGb        string            `json:"diskSizeGb,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	CreationTimestamp string            `json:"creationTimestamp,omitempty"`
 }
 
 type imageListResponse struct {
@@ -54,6 +72,10 @@ func (h *Handler) insertImage(w http.ResponseWriter, r *http.Request, rp gcprest
 		return
 	}
 
+	if _, err := findImageByName(r.Context(), h.compute, req.Name); conflictIfExists(w, err, "image "+req.Name+" already exists") {
+		return
+	}
+
 	// GCP images are created from a disk, snapshot, or import — never from a
 	// source instance (that is EC2's model). Pass an empty InstanceID so the
 	// driver takes the source-based path; record the source in the description
@@ -61,7 +83,7 @@ func (h *Handler) insertImage(w http.ResponseWriter, r *http.Request, rp gcprest
 	cfg := computedriver.ImageConfig{
 		Name:        req.Name,
 		Description: imageSourceDescription(&req),
-		Tags:        mergeImageTags(req.Labels, req.Name),
+		Tags:        h.mergeImageTags(r.Context(), req.Labels, &req),
 	}
 
 	if _, err := h.compute.CreateImage(r.Context(), cfg); err != nil {
@@ -166,47 +188,74 @@ func findImageByName(ctx context.Context, c computedriver.Compute, name string) 
 //nolint:gocritic // rp is a request-scoped value
 func toImageResponse(img *computedriver.ImageInfo, rp gcprest.ResourcePath, host string) imageResponse {
 	name := tagOr(img.Tags, gcpImageNameTag, img.Name)
+	sourceDisk := img.Tags[gcpImageSourceDiskTag]
 
-	return imageResponse{
-		Kind:     "compute#image",
-		ID:       numericID(img.ID),
-		Name:     name,
-		Status:   "READY",
-		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "images", name),
-		Labels:   stripInternalImageTags(img.Tags),
+	resp := imageResponse{
+		Kind:              "compute#image",
+		ID:                numericID(img.ID),
+		Name:              name,
+		Status:            "READY",
+		SelfLink:          gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "images", name),
+		SourceDisk:        sourceDisk,
+		SourceSnapshot:    img.Tags[gcpImageSourceSnapshotTag],
+		Family:            img.Tags[gcpImageFamilyTag],
+		DiskSizeGb:        img.Tags[gcpImageDiskSizeGbTag],
+		Labels:            userLabels(img.Tags),
+		CreationTimestamp: img.CreatedAt,
 	}
+
+	if sourceDisk != "" {
+		resp.SourceDiskID = numericID(sourceDisk)
+	}
+
+	return resp
 }
 
-func mergeImageTags(in map[string]string, name string) map[string]string {
-	out := make(map[string]string, len(in)+1)
+// mergeImageTags builds the image's tag map: user labels plus the internal tags
+// round-tripping the GCP name and source fields (sourceDisk/sourceSnapshot/
+// family/diskSizeGb). diskSizeGb is resolved from the source disk when the
+// request does not carry it, mirroring real GCP.
+func (h *Handler) mergeImageTags(ctx context.Context, in map[string]string, req *imageRequest) map[string]string {
+	out := make(map[string]string, len(in)+internalTagCap)
 
 	for k, v := range in {
 		out[k] = v
 	}
 
-	out[gcpImageNameTag] = name
+	out[gcpImageNameTag] = req.Name
+
+	putIfSet(out, gcpImageSourceDiskTag, req.SourceDisk)
+	putIfSet(out, gcpImageSourceSnapshotTag, req.SourceSnapshot)
+	putIfSet(out, gcpImageFamilyTag, req.Family)
+
+	if size := h.imageDiskSizeGb(ctx, req); size != "" {
+		out[gcpImageDiskSizeGbTag] = size
+	}
 
 	return out
 }
 
-func stripInternalImageTags(in map[string]string) map[string]string {
-	if len(in) == 0 {
-		return nil
+// imageDiskSizeGb returns the image's diskSizeGb as a string: the request value
+// when given, otherwise the size of the source disk it is built from.
+func (h *Handler) imageDiskSizeGb(ctx context.Context, req *imageRequest) string {
+	if req.DiskSizeGb > 0 {
+		return strconv.Itoa(req.DiskSizeGb)
 	}
 
-	out := make(map[string]string, len(in))
-
-	for k, v := range in {
-		if k == gcpImageNameTag {
-			continue
-		}
-
-		out[k] = v
+	if req.SourceDisk == "" {
+		return ""
 	}
 
-	if len(out) == 0 {
-		return nil
+	if vol, err := findDiskByName(ctx, h.compute, lastSegment(req.SourceDisk)); err == nil {
+		return strconv.Itoa(vol.Size)
 	}
 
-	return out
+	return ""
+}
+
+// putIfSet inserts key=val into m only when val is non-empty.
+func putIfSet(m map[string]string, key, val string) {
+	if val != "" {
+		m[key] = val
+	}
 }

--- a/server/gcp/compute/images_sdk_test.go
+++ b/server/gcp/compute/images_sdk_test.go
@@ -33,6 +33,82 @@ func newImagesSDKClient(t *testing.T, ts *httptest.Server) *gcpcompute.ImagesCli
 	return client
 }
 
+// TestSDKImageSourceDiskFields proves images.get reflects sourceDisk, family,
+// and diskSizeGb (resolved from the source disk) plus a creationTimestamp —
+// all previously dropped.
+func TestSDKImageSourceDiskFields(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Compute: cloudP.GCE})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	disksClient, err := gcpcompute.NewDisksRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewDisksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = disksClient.Close() })
+
+	diskOp, err := disksClient.Insert(ctx, &computepb.InsertDiskRequest{
+		Project: testProject, Zone: testZone,
+		DiskResource: &computepb.Disk{Name: ptrStr("imgsrc"), SizeGb: ptrInt64(40)},
+	})
+	if err != nil {
+		t.Fatalf("disk Insert: %v", err)
+	}
+
+	if err := diskOp.Wait(ctx); err != nil {
+		t.Fatalf("disk wait: %v", err)
+	}
+
+	const wantSourceDisk = "projects/" + testProject + "/zones/" + testZone + "/disks/imgsrc"
+
+	imgClient := newImagesSDKClient(t, ts)
+
+	imgOp, err := imgClient.Insert(ctx, &computepb.InsertImageRequest{
+		Project: testProject,
+		ImageResource: &computepb.Image{
+			Name:       ptrStr("img-from-disk"),
+			SourceDisk: ptrStr(wantSourceDisk),
+			Family:     ptrStr("my-family"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("image Insert: %v", err)
+	}
+
+	if err := imgOp.Wait(ctx); err != nil {
+		t.Fatalf("image wait: %v", err)
+	}
+
+	got, err := imgClient.Get(ctx, &computepb.GetImageRequest{
+		Project: testProject, Image: "img-from-disk",
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetSourceDisk() != wantSourceDisk {
+		t.Errorf("sourceDisk=%q want %q", got.GetSourceDisk(), wantSourceDisk)
+	}
+
+	if got.GetFamily() != "my-family" {
+		t.Errorf("family=%q want my-family", got.GetFamily())
+	}
+
+	if got.GetDiskSizeGb() != 40 {
+		t.Errorf("diskSizeGb=%d want 40", got.GetDiskSizeGb())
+	}
+
+	if got.GetCreationTimestamp() == "" {
+		t.Error("creationTimestamp is empty")
+	}
+}
+
 func TestSDKImageRoundTripGCP(t *testing.T) {
 	cloudP := cloudemu.NewGCP()
 	srv := gcpserver.New(gcpserver.Drivers{Compute: cloudP.GCE})

--- a/server/gcp/compute/snapshots.go
+++ b/server/gcp/compute/snapshots.go
@@ -14,6 +14,11 @@ import (
 // gcpSnapshotNameTag is the tag we round-trip the snapshot name through.
 const gcpSnapshotNameTag = "cloudemu:gcpSnapshotName"
 
+// gcpSnapshotSourceDiskTag round-trips the caller's sourceDisk URL so a read
+// echoes it verbatim (real GCP returns the source disk the caller passed,
+// not our driver-internal disk id).
+const gcpSnapshotSourceDiskTag = "cloudemu:gcpSnapshotSourceDisk"
+
 // snapshotRequest mirrors the subset of compute#snapshot we accept.
 type snapshotRequest struct {
 	Name       string            `json:"name"`
@@ -22,14 +27,16 @@ type snapshotRequest struct {
 }
 
 type snapshotResponse struct {
-	Kind       string            `json:"kind"`
-	ID         string            `json:"id"`
-	Name       string            `json:"name"`
-	SourceDisk string            `json:"sourceDisk,omitempty"`
-	DiskSizeGb string            `json:"diskSizeGb"`
-	Status     string            `json:"status"`
-	SelfLink   string            `json:"selfLink"`
-	Labels     map[string]string `json:"labels,omitempty"`
+	Kind              string            `json:"kind"`
+	ID                string            `json:"id"`
+	Name              string            `json:"name"`
+	SourceDisk        string            `json:"sourceDisk,omitempty"`
+	SourceDiskID      string            `json:"sourceDiskId,omitempty"`
+	DiskSizeGb        string            `json:"diskSizeGb"`
+	Status            string            `json:"status"`
+	SelfLink          string            `json:"selfLink"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	CreationTimestamp string            `json:"creationTimestamp,omitempty"`
 }
 
 type snapshotListResponse struct {
@@ -57,6 +64,10 @@ func (h *Handler) insertSnapshot(w http.ResponseWriter, r *http.Request, rp gcpr
 		return
 	}
 
+	if _, err := findSnapshotByName(r.Context(), h.compute, req.Name); conflictIfExists(w, err, "snapshot "+req.Name+" already exists") {
+		return
+	}
+
 	driverDiskID, err := h.resolveSourceDiskID(r.Context(), req.SourceDisk)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
@@ -66,7 +77,7 @@ func (h *Handler) insertSnapshot(w http.ResponseWriter, r *http.Request, rp gcpr
 	cfg := computedriver.SnapshotConfig{
 		VolumeID:    driverDiskID,
 		Description: req.Name,
-		Tags:        mergeSnapshotTags(req.Labels, req.Name),
+		Tags:        mergeSnapshotTags(req.Labels, req.Name, req.SourceDisk),
 	}
 
 	if _, err := h.compute.CreateSnapshot(r.Context(), cfg); err != nil {
@@ -185,20 +196,31 @@ func (h *Handler) resolveSourceDiskID(ctx context.Context, sourceDisk string) (s
 func toSnapshotResponse(snap *computedriver.SnapshotInfo, rp gcprest.ResourcePath, host string) snapshotResponse {
 	name := tagOr(snap.Tags, gcpSnapshotNameTag, rp.ResourceName)
 
-	return snapshotResponse{
-		Kind:       "compute#snapshot",
-		ID:         numericID(snap.ID),
-		Name:       name,
-		SourceDisk: snap.VolumeID,
-		DiskSizeGb: strconv.Itoa(snap.Size),
-		Status:     "READY",
-		SelfLink:   gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "snapshots", name),
-		Labels:     stripInternalSnapshotTags(snap.Tags),
+	// Echo the caller's sourceDisk URL when recorded; fall back to the
+	// driver-internal disk id for snapshots created directly on the driver.
+	sourceDisk := tagOr(snap.Tags, gcpSnapshotSourceDiskTag, snap.VolumeID)
+
+	resp := snapshotResponse{
+		Kind:              "compute#snapshot",
+		ID:                numericID(snap.ID),
+		Name:              name,
+		SourceDisk:        sourceDisk,
+		DiskSizeGb:        strconv.Itoa(snap.Size),
+		Status:            "READY",
+		SelfLink:          gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "snapshots", name),
+		Labels:            userLabels(snap.Tags),
+		CreationTimestamp: snap.CreatedAt,
 	}
+
+	if snap.VolumeID != "" {
+		resp.SourceDiskID = numericID(snap.VolumeID)
+	}
+
+	return resp
 }
 
-func mergeSnapshotTags(in map[string]string, name string) map[string]string {
-	out := make(map[string]string, len(in)+1)
+func mergeSnapshotTags(in map[string]string, name, sourceDisk string) map[string]string {
+	out := make(map[string]string, len(in)+internalTagCap)
 
 	for k, v := range in {
 		out[k] = v
@@ -206,26 +228,8 @@ func mergeSnapshotTags(in map[string]string, name string) map[string]string {
 
 	out[gcpSnapshotNameTag] = name
 
-	return out
-}
-
-func stripInternalSnapshotTags(in map[string]string) map[string]string {
-	if len(in) == 0 {
-		return nil
-	}
-
-	out := make(map[string]string, len(in))
-
-	for k, v := range in {
-		if k == gcpSnapshotNameTag {
-			continue
-		}
-
-		out[k] = v
-	}
-
-	if len(out) == 0 {
-		return nil
+	if sourceDisk != "" {
+		out[gcpSnapshotSourceDiskTag] = sourceDisk
 	}
 
 	return out

--- a/server/gcp/compute/snapshots_sdk_test.go
+++ b/server/gcp/compute/snapshots_sdk_test.go
@@ -51,6 +51,65 @@ func newDisksSDKClientForSnap(t *testing.T, ts *httptest.Server) *gcpcompute.Dis
 	return client
 }
 
+// TestSDKSnapshotSourceDiskEcho proves snapshots.get echoes the caller's
+// sourceDisk URL verbatim (previously a fabricated driver self-link) and
+// returns a creationTimestamp.
+func TestSDKSnapshotSourceDiskEcho(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Compute: cloudP.GCE})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	disksClient := newDisksSDKClientForSnap(t, ts)
+
+	diskOp, err := disksClient.Insert(ctx, &computepb.InsertDiskRequest{
+		Project: testProject, Zone: testZone,
+		DiskResource: &computepb.Disk{Name: ptrStr("snapsrc"), SizeGb: ptrInt64(64)},
+	})
+	if err != nil {
+		t.Fatalf("disk Insert: %v", err)
+	}
+
+	if err := diskOp.Wait(ctx); err != nil {
+		t.Fatalf("disk wait: %v", err)
+	}
+
+	const wantSource = "projects/" + testProject + "/zones/" + testZone + "/disks/snapsrc"
+
+	snapsClient := newSnapshotsSDKClient(t, ts)
+
+	snapOp, err := snapsClient.Insert(ctx, &computepb.InsertSnapshotRequest{
+		Project: testProject,
+		SnapshotResource: &computepb.Snapshot{
+			Name: ptrStr("snap-src-echo"), SourceDisk: ptrStr(wantSource),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := snapOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := snapsClient.Get(ctx, &computepb.GetSnapshotRequest{
+		Project: testProject, Snapshot: "snap-src-echo",
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetSourceDisk() != wantSource {
+		t.Errorf("sourceDisk=%q want %q", got.GetSourceDisk(), wantSource)
+	}
+
+	if got.GetCreationTimestamp() == "" {
+		t.Error("creationTimestamp is empty")
+	}
+}
+
 func TestSDKSnapshotRoundTripGCP(t *testing.T) {
 	cloudP := cloudemu.NewGCP()
 	srv := gcpserver.New(gcpserver.Drivers{Compute: cloudP.GCE})


### PR DESCRIPTION
## What & why

Fixes the GCP compute **disks** bug batch from the audit — persistent-disk behaviors real users hit against the emulated Compute REST API (disks/images/snapshots). All fixes live at the wire layer plus one GCP-local provider method; no shared driver interface changed.

## Findings fixed

- **[HIGH] snapshots.get sourceDisk** — now echoes the caller's `sourceDisk` URL verbatim (round-tripped via an internal tag) instead of the fabricated driver self-link; also returns `sourceDiskId`.
- **[HIGH] duplicate-name insert → 409** — `disks`, `images`, `snapshots` insert now probe for an existing name and return `alreadyExists` (409) instead of silently creating a second resource over the ID-keyed store.
- **[MEDIUM] images.get sourceDisk/family/diskSizeGb** — reflected on read (`diskSizeGb` resolved from the source disk when the request omits it); also `sourceDiskId`/`sourceSnapshot`.
- **[MEDIUM] disks.get sourceImage/sourceImageId** — reflected on read.
- **[MEDIUM] disks.aggregatedList** — implemented (`GET /aggregated/disks`), grouping disks by `zones/{zone}` scope instead of 501.
- **[MEDIUM] creationTimestamp** — populated on disk/image/snapshot reads from the driver's stored creation time.
- **[LOW] disks.resize** — implemented (`POST /disks/{name}/resize`); grows the disk and returns a DONE Operation (shrink rejected, mirroring GCP). Backed by a GCP-local `ResizeVolumeGCP` provider method reached via an optional interface.

Also, consistent with the instance-side `disks[]` from the attachDisk work: a disk attached to an instance now reports that instance in its `users[]`.

## Tests

Reproduction tests using the real `cloud.google.com/go/compute` clients against the in-process GCP server: disk sourceImage reflection, duplicate-name conflict, creationTimestamp, resize, aggregatedList, users[] attachment; snapshot sourceDisk echo; image sourceDisk/family/diskSizeGb. Existing GCP disk/snapshot/image round-trip tests stay green.

## Deferrals

- The `backendServices`/`forwardingRules` portions of the duplicate-name and `creationTimestamp` findings belong to the compute load-balancer resources and are left to the compute-LB batch to avoid overlap.
