### PR TITLE
fix(gcp-monitoring): serve timeSeries, metricDescriptors, notificationChannels; opaque alert-policy ids

### DIFF
--- a/providers/gcp/monitoring/monitoring.go
+++ b/providers/gcp/monitoring/monitoring.go
@@ -70,12 +70,12 @@ func (m *Mock) PutMetricData(_ context.Context, data []driver.MetricDatum) error
 	}
 
 	m.mu.Lock()
-	for _, d := range data {
+	for i := range data {
 		key := metricKey{
-			Namespace:  d.Namespace,
-			MetricName: d.MetricName,
+			Namespace:  data[i].Namespace,
+			MetricName: data[i].MetricName,
 		}
-		m.metrics[key] = append(m.metrics[key], d)
+		m.metrics[key] = append(m.metrics[key], data[i])
 	}
 	m.mu.Unlock()
 
@@ -308,6 +308,43 @@ func (m *Mock) ListMetrics(_ context.Context, namespace string) ([]string, error
 	sort.Strings(names)
 
 	return names, nil
+}
+
+// GCPSeriesKeys returns the (namespace, metricName) pairs that currently hold
+// metric data. It backs the GCP timeSeries.list / metricDescriptors surface,
+// which enumerates metric types independently of the AWS-shaped ListMetrics.
+func (m *Mock) GCPSeriesKeys() []driver.MetricIdentifier {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	keys := make([]driver.MetricIdentifier, 0, len(m.metrics))
+	for key := range m.metrics {
+		keys = append(keys, driver.MetricIdentifier{Namespace: key.Namespace, MetricName: key.MetricName})
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Namespace != keys[j].Namespace {
+			return keys[i].Namespace < keys[j].Namespace
+		}
+
+		return keys[i].MetricName < keys[j].MetricName
+	})
+
+	return keys
+}
+
+// GCPRawSeries returns a copy of every raw datum stored for namespace+metricName.
+// timeSeries.list groups these by their label set into individual series, which
+// the aggregated GetMetricData path cannot express.
+func (m *Mock) GCPRawSeries(namespace, metricName string) []driver.MetricDatum {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	src := m.metrics[metricKey{Namespace: namespace, MetricName: metricName}]
+	out := make([]driver.MetricDatum, len(src))
+	copy(out, src)
+
+	return out
 }
 
 // CreateAlarm creates or updates an alert policy with the given configuration.

--- a/server/gcp/monitoring/alertpolicies.go
+++ b/server/gcp/monitoring/alertpolicies.go
@@ -1,0 +1,213 @@
+package monitoring
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// serveAlertPolicies routes /v3/projects/{p}/alertPolicies[/{id}].
+func (h *Handler) serveAlertPolicies(w http.ResponseWriter, r *http.Request, project string, rest []string) {
+	if len(rest) == 0 {
+		switch r.Method {
+		case http.MethodPost:
+			h.createPolicy(w, r, project)
+		case http.MethodGet:
+			h.listPolicies(w, r, project)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		}
+
+		return
+	}
+
+	name := rest[0]
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getPolicy(w, project, name)
+	case http.MethodPatch, http.MethodPut:
+		h.patchPolicy(w, r, project, name)
+	case http.MethodDelete:
+		h.deletePolicy(w, r, name)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+	}
+}
+
+func (h *Handler) createPolicy(w http.ResponseWriter, r *http.Request, project string) {
+	var body alertPolicy
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		return
+	}
+
+	// Real Cloud Monitoring assigns an opaque numeric id, not one derived from
+	// displayName — two policies sharing a displayName must not collapse.
+	id := strconv.FormatUint(h.seq.Add(1), 10)
+
+	// The driver alarm is only an existence marker; the full policy shape lives
+	// in the handler registry so conditions/combiner/labels round-trip.
+	cfg := mondriver.AlarmConfig{
+		Name:               id,
+		Namespace:          "gcp",
+		MetricName:         "metric",
+		ComparisonOperator: "GreaterThanThreshold",
+		Threshold:          0,
+		Period:             60,
+		EvaluationPeriods:  1,
+		Stat:               "Average",
+	}
+
+	if err := h.mon.CreateAlarm(r.Context(), cfg); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	body.Name = policyResourceName(project, id)
+	now := nowRFC3339()
+	rec := &mutationRecord{MutateTime: now, MutatedBy: "cloudemu"}
+	body.CreationRecord = rec
+	body.MutationRecord = rec
+	nameConditions(&body, project, id)
+
+	h.mu.Lock()
+	h.policies[id] = body
+	h.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, body)
+}
+
+// nameConditions assigns each condition its canonical resource name, matching
+// real Cloud Monitoring which populates conditions[].name on create.
+func nameConditions(pol *alertPolicy, project, policyID string) {
+	for i := range pol.Conditions {
+		if pol.Conditions[i].Name == "" {
+			pol.Conditions[i].Name = policyResourceName(project, policyID) +
+				"/conditions/" + strconv.Itoa(i)
+		}
+	}
+}
+
+func (h *Handler) getPolicy(w http.ResponseWriter, project, name string) {
+	h.mu.RLock()
+	pol, ok := h.policies[name]
+	h.mu.RUnlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "alertPolicy "+name+" not found")
+		return
+	}
+
+	pol.Name = policyResourceName(project, name)
+
+	writeJSON(w, http.StatusOK, pol)
+}
+
+func (h *Handler) listPolicies(w http.ResponseWriter, _ *http.Request, project string) {
+	h.mu.RLock()
+	out := alertPoliciesList{AlertPolicies: make([]alertPolicy, 0, len(h.policies))}
+
+	for id := range h.policies {
+		pol := h.policies[id]
+		pol.Name = policyResourceName(project, id)
+		out.AlertPolicies = append(out.AlertPolicies, pol)
+	}
+	h.mu.RUnlock()
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+// patchPolicy applies a partial update. GCP scopes changes by updateMask; the
+// pragmatic emulation overwrites any field the caller supplied (non-zero),
+// which covers displayName/combiner/enabled/conditions/labels/channels.
+func (h *Handler) patchPolicy(w http.ResponseWriter, r *http.Request, project, name string) {
+	// Decode with a pointer Enabled so an omitted "enabled" is distinguishable
+	// from an explicit false — a partial PATCH must leave it unchanged, not
+	// silently disable the policy (real GCP applies only the updateMask paths).
+	var body struct {
+		DisplayName          string            `json:"displayName"`
+		Combiner             string            `json:"combiner"`
+		Conditions           []alertCondition  `json:"conditions"`
+		UserLabels           map[string]string `json:"userLabels"`
+		NotificationChannels []string          `json:"notificationChannels"`
+		Enabled              *bool             `json:"enabled"`
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		return
+	}
+
+	h.mu.Lock()
+
+	cur, ok := h.policies[name]
+	if !ok {
+		h.mu.Unlock()
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "alertPolicy "+name+" not found")
+
+		return
+	}
+
+	if body.DisplayName != "" {
+		cur.DisplayName = body.DisplayName
+	}
+
+	if body.Combiner != "" {
+		cur.Combiner = body.Combiner
+	}
+
+	if body.Conditions != nil {
+		cur.Conditions = body.Conditions
+		nameConditions(&cur, project, name)
+	}
+
+	if body.UserLabels != nil {
+		cur.UserLabels = body.UserLabels
+	}
+
+	if body.NotificationChannels != nil {
+		cur.NotificationChannels = body.NotificationChannels
+	}
+
+	if body.Enabled != nil {
+		cur.Enabled = *body.Enabled
+	}
+
+	cur.MutationRecord = &mutationRecord{MutateTime: nowRFC3339(), MutatedBy: "cloudemu"}
+	h.policies[name] = cur
+	h.mu.Unlock()
+
+	cur.Name = policyResourceName(project, name)
+
+	writeJSON(w, http.StatusOK, cur)
+}
+
+func (h *Handler) deletePolicy(w http.ResponseWriter, r *http.Request, name string) {
+	h.mu.Lock()
+	_, ok := h.policies[name]
+	delete(h.policies, name)
+	h.mu.Unlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "alertPolicy "+name+" not found")
+		return
+	}
+
+	if err := h.mon.DeleteAlarm(r.Context(), name); err != nil && !cerrors.IsNotFound(err) {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+func policyResourceName(project, name string) string {
+	return "projects/" + project + "/alertPolicies/" + name
+}

--- a/server/gcp/monitoring/client_test.go
+++ b/server/gcp/monitoring/client_test.go
@@ -1,0 +1,305 @@
+package monitoring_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	monitoring "google.golang.org/api/monitoring/v3"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// newClient wires the real google.golang.org/api/monitoring/v3 REST client at
+// the in-process GCP server, exercising the actual Cloud Monitoring wire shapes.
+func newClient(t *testing.T, ts *httptest.Server) *monitoring.Service {
+	t.Helper()
+
+	svc, err := monitoring.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	return svc
+}
+
+// TestTimeSeriesListAutoMetrics guards the BLOCKER: GCE auto-metrics emitted on
+// RunInstances must be readable via timeSeries.list (was 501 — the only wire
+// read path for every metric).
+func TestTimeSeriesListAutoMetrics(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+
+	if _, err := cloudP.GCE.RunInstances(context.Background(),
+		computedriver.InstanceConfig{ImageID: "debian-12", InstanceType: "e2-medium"}, 1); err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	srv := gcpserver.New(gcpserver.Drivers{Monitoring: cloudP.CloudMonitoring})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc := newClient(t, ts)
+
+	resp, err := svc.Projects.TimeSeries.List("projects/p1").
+		Filter(`metric.type="compute.googleapis.com/instance/cpu/utilization"`).
+		IntervalStartTime(time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)).
+		IntervalEndTime(time.Now().Add(time.Hour).UTC().Format(time.RFC3339)).
+		Do()
+	if err != nil {
+		t.Fatalf("timeSeries.list: %v", err)
+	}
+
+	if len(resp.TimeSeries) == 0 {
+		t.Fatal("timeSeries.list returned no series for a launched instance")
+	}
+
+	if len(resp.TimeSeries[0].Points) == 0 {
+		t.Error("series has no points")
+	}
+
+	if got := resp.TimeSeries[0].Metric.Type; got != "compute.googleapis.com/instance/cpu/utilization" {
+		t.Errorf("metric.type=%q", got)
+	}
+}
+
+// TestTimeSeriesCreate guards the BLOCKER: custom-metric ingestion via
+// timeSeries.create (was 501), and that the ingested point reads back.
+func TestTimeSeriesCreate(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Monitoring: cloudP.CloudMonitoring})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc := newClient(t, ts)
+
+	val := 42.5
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	_, err := svc.Projects.TimeSeries.Create("projects/p1", &monitoring.CreateTimeSeriesRequest{
+		TimeSeries: []*monitoring.TimeSeries{{
+			Metric:   &monitoring.Metric{Type: "custom.googleapis.com/my_metric", Labels: map[string]string{"env": "test"}},
+			Resource: &monitoring.MonitoredResource{Type: "global"},
+			Points: []*monitoring.Point{{
+				Interval: &monitoring.TimeInterval{EndTime: now},
+				Value:    &monitoring.TypedValue{DoubleValue: &val},
+			}},
+		}},
+	}).Do()
+	if err != nil {
+		t.Fatalf("timeSeries.create: %v", err)
+	}
+
+	resp, err := svc.Projects.TimeSeries.List("projects/p1").
+		Filter(`metric.type="custom.googleapis.com/my_metric"`).
+		IntervalStartTime(time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)).
+		IntervalEndTime(time.Now().Add(time.Hour).UTC().Format(time.RFC3339)).
+		Do()
+	if err != nil {
+		t.Fatalf("timeSeries.list: %v", err)
+	}
+
+	if len(resp.TimeSeries) != 1 {
+		t.Fatalf("want 1 custom series, got %d", len(resp.TimeSeries))
+	}
+
+	pts := resp.TimeSeries[0].Points
+	if len(pts) != 1 || pts[0].Value.DoubleValue == nil || *pts[0].Value.DoubleValue != val {
+		t.Errorf("ingested point not read back: %+v", pts)
+	}
+}
+
+// TestMetricDescriptors guards the HIGH finding: metricDescriptors list/get/
+// create (was 501).
+func TestMetricDescriptors(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Monitoring: cloudP.CloudMonitoring})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc := newClient(t, ts)
+
+	const mtype = "custom.googleapis.com/widgets"
+
+	created, err := svc.Projects.MetricDescriptors.Create("projects/p1", &monitoring.MetricDescriptor{
+		Type:       mtype,
+		MetricKind: "GAUGE",
+		ValueType:  "DOUBLE",
+	}).Do()
+	if err != nil {
+		t.Fatalf("metricDescriptors.create: %v", err)
+	}
+
+	if created.Name == "" || created.Type != mtype {
+		t.Errorf("create returned name=%q type=%q", created.Name, created.Type)
+	}
+
+	got, err := svc.Projects.MetricDescriptors.Get("projects/p1/metricDescriptors/" + mtype).Do()
+	if err != nil {
+		t.Fatalf("metricDescriptors.get: %v", err)
+	}
+
+	if got.Type != mtype {
+		t.Errorf("get type=%q", got.Type)
+	}
+
+	list, err := svc.Projects.MetricDescriptors.List("projects/p1").Do()
+	if err != nil {
+		t.Fatalf("metricDescriptors.list: %v", err)
+	}
+
+	var found bool
+
+	for _, d := range list.MetricDescriptors {
+		if d.Type == mtype {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Error("created descriptor missing from list")
+	}
+}
+
+// TestNotificationChannels guards the HIGH finding: notificationChannels
+// create/list/get (was 501) so alert policies can reference real channels.
+func TestNotificationChannels(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Monitoring: cloudP.CloudMonitoring})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc := newClient(t, ts)
+
+	created, err := svc.Projects.NotificationChannels.Create("projects/p1", &monitoring.NotificationChannel{
+		Type:        "email",
+		DisplayName: "oncall",
+		Labels:      map[string]string{"email_address": "oncall@example.com"},
+	}).Do()
+	if err != nil {
+		t.Fatalf("notificationChannels.create: %v", err)
+	}
+
+	if created.Name == "" {
+		t.Fatal("create returned empty channel name")
+	}
+
+	got, err := svc.Projects.NotificationChannels.Get(created.Name).Do()
+	if err != nil {
+		t.Fatalf("notificationChannels.get: %v", err)
+	}
+
+	if got.DisplayName != "oncall" {
+		t.Errorf("get displayName=%q", got.DisplayName)
+	}
+
+	list, err := svc.Projects.NotificationChannels.List("projects/p1").Do()
+	if err != nil {
+		t.Fatalf("notificationChannels.list: %v", err)
+	}
+
+	if len(list.NotificationChannels) != 1 {
+		t.Errorf("want 1 channel, got %d", len(list.NotificationChannels))
+	}
+
+	// A policy may now reference the channel that actually exists.
+	if _, err := svc.Projects.AlertPolicies.Create("projects/p1", &monitoring.AlertPolicy{
+		DisplayName:          "cpu",
+		Combiner:             "OR",
+		NotificationChannels: []string{created.Name},
+	}).Do(); err != nil {
+		t.Fatalf("alertPolicies.create referencing channel: %v", err)
+	}
+}
+
+// TestAlertPolicyOpaqueIDAndRecords guards the WRONG_WIRE + records findings:
+// two policies with the same displayName must not collapse (opaque numeric id),
+// and creationRecord / condition names must be populated.
+func TestAlertPolicyOpaqueIDAndRecords(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Monitoring: cloudP.CloudMonitoring})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc := newClient(t, ts)
+
+	mk := func() *monitoring.AlertPolicy {
+		return &monitoring.AlertPolicy{
+			DisplayName: "high-cpu",
+			Combiner:    "OR",
+			Conditions:  []*monitoring.Condition{{DisplayName: "cpu>80"}},
+		}
+	}
+
+	first, err := svc.Projects.AlertPolicies.Create("projects/p1", mk()).Do()
+	if err != nil {
+		t.Fatalf("create #1: %v", err)
+	}
+
+	second, err := svc.Projects.AlertPolicies.Create("projects/p1", mk()).Do()
+	if err != nil {
+		t.Fatalf("create #2: %v", err)
+	}
+
+	if first.Name == second.Name {
+		t.Fatalf("duplicate displayName collapsed to one name: %q", first.Name)
+	}
+
+	if first.CreationRecord == nil || first.CreationRecord.MutateTime == "" {
+		t.Error("creationRecord not populated")
+	}
+
+	if len(first.Conditions) != 1 || first.Conditions[0].Name == "" {
+		t.Errorf("condition name not populated: %+v", first.Conditions)
+	}
+
+	list, err := svc.Projects.AlertPolicies.List("projects/p1").Do()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(list.AlertPolicies) != 2 {
+		t.Errorf("want 2 policies (no collapse), got %d", len(list.AlertPolicies))
+	}
+}
+
+// TestAlertPolicyPatch guards the patch finding: alertPolicies.patch edits a
+// policy (was POST/GET/DELETE only), applying only the masked field.
+func TestAlertPolicyPatch(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Monitoring: cloudP.CloudMonitoring})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc := newClient(t, ts)
+
+	created, err := svc.Projects.AlertPolicies.Create("projects/p1", &monitoring.AlertPolicy{
+		DisplayName: "editable",
+		Combiner:    "AND",
+		Enabled:     true,
+	}).Do()
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	patched, err := svc.Projects.AlertPolicies.Patch(created.Name, &monitoring.AlertPolicy{
+		Combiner: "OR",
+	}).UpdateMask("combiner").Do()
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+
+	if patched.Combiner != "OR" {
+		t.Errorf("after patch combiner=%q want OR", patched.Combiner)
+	}
+
+	if !patched.Enabled {
+		t.Error("patch omitting enabled silently disabled the policy")
+	}
+}

--- a/server/gcp/monitoring/client_test.go
+++ b/server/gcp/monitoring/client_test.go
@@ -10,8 +10,8 @@ import (
 	"google.golang.org/api/option"
 
 	"github.com/stackshy/cloudemu/v2"
-	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 )
 
 // newClient wires the real google.golang.org/api/monitoring/v3 REST client at

--- a/server/gcp/monitoring/filter.go
+++ b/server/gcp/monitoring/filter.go
@@ -1,0 +1,117 @@
+package monitoring
+
+import "strings"
+
+// seriesFilter is a parsed Cloud Monitoring timeSeries.list filter. Only the
+// clauses a real user reaches for are honored: metric.type equality /
+// starts_with, and metric.labels.KEY / resource.labels.KEY equality.
+type seriesFilter struct {
+	metricType   string
+	typeIsPrefix bool
+	labels       map[string]string
+}
+
+// matchesType reports whether the metric type passes the metric.type clause.
+func (f seriesFilter) matchesType(fullType string) bool {
+	if f.metricType == "" {
+		return true
+	}
+
+	if f.typeIsPrefix {
+		return strings.HasPrefix(fullType, f.metricType)
+	}
+
+	return fullType == f.metricType
+}
+
+// matchesLabels reports whether a datum's labels satisfy every label clause.
+func (f seriesFilter) matchesLabels(labels map[string]string) bool {
+	for k, v := range f.labels {
+		if labels[k] != v {
+			return false
+		}
+	}
+
+	return true
+}
+
+// parseSeriesFilter extracts the honored clauses from a raw filter string.
+func parseSeriesFilter(raw string) seriesFilter {
+	f := seriesFilter{labels: map[string]string{}}
+	if raw == "" {
+		return f
+	}
+
+	for _, clause := range splitFilterClauses(raw) {
+		key, val, ok := splitClause(clause)
+		if !ok {
+			continue
+		}
+
+		switch {
+		case key == "metric.type":
+			f.metricType, f.typeIsPrefix = parseTypeValue(val)
+		case strings.HasPrefix(key, "metric.labels."):
+			f.labels[strings.TrimPrefix(key, "metric.labels.")] = unquote(val)
+		case strings.HasPrefix(key, "resource.labels."):
+			f.labels[strings.TrimPrefix(key, "resource.labels.")] = unquote(val)
+		}
+	}
+
+	return f
+}
+
+// splitFilterClauses splits on AND (case-insensitive), the only combiner Cloud
+// Monitoring list filters use.
+func splitFilterClauses(raw string) []string {
+	parts := []string{}
+	rest := raw
+
+	for {
+		idx := indexAND(rest)
+		if idx < 0 {
+			parts = append(parts, rest)
+			break
+		}
+
+		parts = append(parts, rest[:idx])
+		rest = rest[idx+len(" AND "):]
+	}
+
+	return parts
+}
+
+func indexAND(s string) int {
+	upper := strings.ToUpper(s)
+
+	return strings.Index(upper, " AND ")
+}
+
+// splitClause splits "key = value" (or "key op value") into key and value.
+func splitClause(clause string) (key, val string, ok bool) {
+	i := strings.Index(clause, "=")
+	if i < 0 {
+		return "", "", false
+	}
+
+	return strings.TrimSpace(clause[:i]), strings.TrimSpace(clause[i+1:]), true
+}
+
+// parseTypeValue reads a metric.type value, handling starts_with("...").
+func parseTypeValue(val string) (mtype string, isPrefix bool) {
+	if strings.HasPrefix(val, "starts_with(") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(val, "starts_with("), ")")
+
+		return unquote(strings.TrimSpace(inner)), true
+	}
+
+	return unquote(val), false
+}
+
+func unquote(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "\"")
+	s = strings.TrimSuffix(s, "\"")
+
+	return s
+}

--- a/server/gcp/monitoring/handler.go
+++ b/server/gcp/monitoring/handler.go
@@ -1,22 +1,22 @@
-// Package monitoring implements the GCP Cloud Monitoring REST API surface
-// for alert policies. cloud.google.com/go/monitoring uses gRPC by default;
-// this handler covers the REST equivalent for HTTP-level testing.
+// Package monitoring implements the GCP Cloud Monitoring REST API surface.
+// cloud.google.com/go/monitoring uses gRPC by default; this handler covers the
+// REST equivalent (google.golang.org/api/monitoring/v3) for HTTP-level testing.
 //
-// Supported operations (parity with AWS CloudWatch):
+// Supported collections under /v3/projects/{p}/:
 //
-//	POST   /v3/projects/{p}/alertPolicies          — create policy
-//	GET    /v3/projects/{p}/alertPolicies/{name}   — get
-//	GET    /v3/projects/{p}/alertPolicies          — list
-//	DELETE /v3/projects/{p}/alertPolicies/{name}   — delete
+//	alertPolicies         — create/get/list/patch/delete
+//	timeSeries            — list (read metric points) / create (ingest points)
+//	metricDescriptors     — list/get/create
+//	notificationChannels  — create/list/get/delete
 package monitoring
 
 import (
 	"encoding/json"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
@@ -27,233 +27,88 @@ const (
 	maxBodyBytes    = 1 << 20
 )
 
-// Handler serves GCP Cloud Monitoring alert-policy REST requests.
+// Handler serves GCP Cloud Monitoring REST requests.
 //
 // The portable monitoring driver models a threshold Alarm, not GCP's richer
 // alert-policy shape (conditions, combiner, notificationChannels, userLabels).
-// To avoid dropping those on read, the full policy is held here keyed by name;
-// the driver alarm is kept as an existence marker.
+// To avoid dropping those on read, the full policy is held here keyed by its
+// opaque numeric id; the driver alarm is kept as an existence marker. Custom
+// metric descriptors created via metricDescriptors.create are held here too.
 type Handler struct {
 	mon mondriver.Monitoring
 
-	mu       sync.RWMutex
-	policies map[string]alertPolicy // keyed by policy short-name
-	seq      atomic.Uint64
+	mu          sync.RWMutex
+	policies    map[string]alertPolicy      // keyed by opaque policy id
+	descriptors map[string]metricDescriptor // custom descriptors keyed by metric type
+	seq         atomic.Uint64
 }
 
 // New returns a Cloud Monitoring handler.
 func New(m mondriver.Monitoring) *Handler {
-	return &Handler{mon: m, policies: make(map[string]alertPolicy)}
+	return &Handler{
+		mon:         m,
+		policies:    make(map[string]alertPolicy),
+		descriptors: make(map[string]metricDescriptor),
+	}
 }
 
-// Matches returns true for /v3/projects/.../alertPolicies URLs.
+// monitoringCollections is the set of Cloud Monitoring collection segments this
+// handler serves under /v3/projects/{p}/.
+func monitoringCollections() []string {
+	return []string{"alertPolicies", "timeSeries", "metricDescriptors", "notificationChannels"}
+}
+
+// Matches returns true for the Cloud Monitoring collections under /v3/projects/.
 func (*Handler) Matches(r *http.Request) bool {
 	p := r.URL.Path
-	return strings.HasPrefix(p, "/v3/projects/") && strings.Contains(p, "/alertPolicies")
+	if !strings.HasPrefix(p, "/v3/projects/") {
+		return false
+	}
+
+	for _, c := range monitoringCollections() {
+		if strings.Contains(p, "/"+c) {
+			return true
+		}
+	}
+
+	return false
 }
 
-// ServeHTTP routes the request based on URL path shape.
+// ServeHTTP routes by the collection segment, then by method/resource shape.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
 
 	const (
-		// /v3/projects/{p}/alertPolicies      → 4 parts (collection)
-		// /v3/projects/{p}/alertPolicies/{n}  → 5 parts (resource)
-		collectionParts = 4
-		resourceParts   = 5
-		idxProject      = 2
-		idxName         = 4
+		minParts   = 4 // v3 / projects / {p} / {collection}
+		idxProject = 2
+		idxColl    = 3
+		idxRest    = 4
 	)
 
-	if len(parts) < collectionParts {
+	if len(parts) < minParts {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown path")
 		return
 	}
 
 	project := parts[idxProject]
+	rest := parts[idxRest:]
 
-	if len(parts) == resourceParts {
-		name := parts[idxName]
-
-		switch r.Method {
-		case http.MethodGet:
-			h.getPolicy(w, r, project, name)
-		case http.MethodPatch, http.MethodPut:
-			h.patchPolicy(w, r, project, name)
-		case http.MethodDelete:
-			h.deletePolicy(w, r, name)
-		default:
-			writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
-		}
-
-		return
-	}
-
-	switch r.Method {
-	case http.MethodPost:
-		h.createPolicy(w, r, project)
-	case http.MethodGet:
-		h.listPolicies(w, r, project)
+	switch parts[idxColl] {
+	case "alertPolicies":
+		h.serveAlertPolicies(w, r, project, rest)
+	case "timeSeries":
+		h.serveTimeSeries(w, r, project)
+	case "metricDescriptors":
+		h.serveMetricDescriptors(w, r, project, rest)
+	case "notificationChannels":
+		h.serveNotificationChannels(w, r, project, rest)
 	default:
-		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown path")
 	}
 }
 
-func (h *Handler) createPolicy(w http.ResponseWriter, r *http.Request, project string) {
-	var body alertPolicy
-
-	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
-		return
-	}
-
-	name := body.DisplayName
-	if name == "" {
-		name = "policy-" + strconv.FormatUint(h.seq.Add(1), 10)
-	}
-
-	// The driver alarm is only an existence marker; the full policy shape lives
-	// in the handler registry so conditions/combiner/labels round-trip.
-	cfg := mondriver.AlarmConfig{
-		Name:               name,
-		Namespace:          "gcp",
-		MetricName:         "metric",
-		ComparisonOperator: "GreaterThanThreshold",
-		Threshold:          0,
-		Period:             60,
-		EvaluationPeriods:  1,
-		Stat:               "Average",
-	}
-
-	if err := h.mon.CreateAlarm(r.Context(), cfg); err != nil {
-		writeErr(w, err)
-		return
-	}
-
-	body.Name = policyResourceName(project, name)
-
-	h.mu.Lock()
-	h.policies[name] = body
-	h.mu.Unlock()
-
-	writeJSON(w, http.StatusOK, body)
-}
-
-func (h *Handler) getPolicy(w http.ResponseWriter, _ *http.Request, project, name string) {
-	h.mu.RLock()
-	pol, ok := h.policies[name]
-	h.mu.RUnlock()
-
-	if !ok {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "alertPolicy "+name+" not found")
-		return
-	}
-
-	pol.Name = policyResourceName(project, name)
-
-	writeJSON(w, http.StatusOK, pol)
-}
-
-func (h *Handler) listPolicies(w http.ResponseWriter, _ *http.Request, project string) {
-	h.mu.RLock()
-	out := alertPoliciesList{AlertPolicies: make([]alertPolicy, 0, len(h.policies))}
-
-	for name := range h.policies {
-		pol := h.policies[name]
-		pol.Name = policyResourceName(project, name)
-		out.AlertPolicies = append(out.AlertPolicies, pol)
-	}
-	h.mu.RUnlock()
-
-	writeJSON(w, http.StatusOK, out)
-}
-
-// patchPolicy applies a partial update. GCP scopes changes by updateMask; the
-// pragmatic emulation overwrites any field the caller supplied (non-zero),
-// which covers displayName/combiner/enabled/conditions/labels/channels.
-func (h *Handler) patchPolicy(w http.ResponseWriter, r *http.Request, project, name string) {
-	// Decode with a pointer Enabled so an omitted "enabled" is distinguishable
-	// from an explicit false — a partial PATCH must leave it unchanged, not
-	// silently disable the policy (real GCP applies only the updateMask paths).
-	var body struct {
-		DisplayName          string            `json:"displayName"`
-		Combiner             string            `json:"combiner"`
-		Conditions           []alertCondition  `json:"conditions"`
-		UserLabels           map[string]string `json:"userLabels"`
-		NotificationChannels []string          `json:"notificationChannels"`
-		Enabled              *bool             `json:"enabled"`
-	}
-
-	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
-		return
-	}
-
-	h.mu.Lock()
-
-	cur, ok := h.policies[name]
-	if !ok {
-		h.mu.Unlock()
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "alertPolicy "+name+" not found")
-
-		return
-	}
-
-	if body.DisplayName != "" {
-		cur.DisplayName = body.DisplayName
-	}
-
-	if body.Combiner != "" {
-		cur.Combiner = body.Combiner
-	}
-
-	if body.Conditions != nil {
-		cur.Conditions = body.Conditions
-	}
-
-	if body.UserLabels != nil {
-		cur.UserLabels = body.UserLabels
-	}
-
-	if body.NotificationChannels != nil {
-		cur.NotificationChannels = body.NotificationChannels
-	}
-
-	if body.Enabled != nil {
-		cur.Enabled = *body.Enabled
-	}
-
-	h.policies[name] = cur
-	h.mu.Unlock()
-
-	cur.Name = policyResourceName(project, name)
-
-	writeJSON(w, http.StatusOK, cur)
-}
-
-func (h *Handler) deletePolicy(w http.ResponseWriter, r *http.Request, name string) {
-	h.mu.Lock()
-	_, ok := h.policies[name]
-	delete(h.policies, name)
-	h.mu.Unlock()
-
-	if !ok {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "alertPolicy "+name+" not found")
-		return
-	}
-
-	if err := h.mon.DeleteAlarm(r.Context(), name); err != nil && !cerrors.IsNotFound(err) {
-		writeErr(w, err)
-		return
-	}
-
-	writeJSON(w, http.StatusOK, map[string]any{})
-}
-
-func policyResourceName(project, name string) string {
-	return "projects/" + project + "/alertPolicies/" + name
+func nowRFC3339() string {
+	return time.Now().UTC().Format(time.RFC3339)
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/server/gcp/monitoring/metricdescriptors.go
+++ b/server/gcp/monitoring/metricdescriptors.go
@@ -1,0 +1,136 @@
+package monitoring
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// serveMetricDescriptors routes /v3/projects/{p}/metricDescriptors[/{type...}].
+// A metric type contains slashes, so the resource id is the remaining path.
+func (h *Handler) serveMetricDescriptors(w http.ResponseWriter, r *http.Request, project string, rest []string) {
+	if len(rest) == 0 {
+		switch r.Method {
+		case http.MethodGet:
+			h.listDescriptors(w, project)
+		case http.MethodPost:
+			h.createDescriptor(w, r, project)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		}
+
+		return
+	}
+
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	h.getDescriptor(w, project, strings.Join(rest, "/"))
+}
+
+func (h *Handler) listDescriptors(w http.ResponseWriter, project string) {
+	byType := map[string]metricDescriptor{}
+
+	// Descriptors synthesized from series that currently hold data.
+	if reader, ok := h.mon.(seriesReader); ok {
+		for _, key := range reader.GCPSeriesKeys() {
+			t := metricType(key.Namespace, key.MetricName)
+			byType[t] = synthDescriptor(project, t)
+		}
+	}
+
+	// Custom descriptors created via metricDescriptors.create take precedence.
+	h.mu.RLock()
+	for t := range h.descriptors {
+		d := h.descriptors[t]
+		d.Name = descriptorResourceName(project, t)
+		byType[t] = d
+	}
+	h.mu.RUnlock()
+
+	types := make([]string, 0, len(byType))
+	for t := range byType {
+		types = append(types, t)
+	}
+
+	sort.Strings(types)
+
+	out := metricDescriptorsList{MetricDescriptors: make([]metricDescriptor, 0, len(types))}
+	for _, t := range types {
+		out.MetricDescriptors = append(out.MetricDescriptors, byType[t])
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) getDescriptor(w http.ResponseWriter, project, mtype string) {
+	h.mu.RLock()
+	d, ok := h.descriptors[mtype]
+	h.mu.RUnlock()
+
+	if ok {
+		d.Name = descriptorResourceName(project, mtype)
+		writeJSON(w, http.StatusOK, d)
+
+		return
+	}
+
+	if reader, rok := h.mon.(seriesReader); rok {
+		for _, key := range reader.GCPSeriesKeys() {
+			if metricType(key.Namespace, key.MetricName) == mtype {
+				writeJSON(w, http.StatusOK, synthDescriptor(project, mtype))
+				return
+			}
+		}
+	}
+
+	writeError(w, http.StatusNotFound, "NOT_FOUND", "metricDescriptor "+mtype+" not found")
+}
+
+func (h *Handler) createDescriptor(w http.ResponseWriter, r *http.Request, project string) {
+	var body metricDescriptor
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		return
+	}
+
+	if body.Type == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "type is required")
+		return
+	}
+
+	if body.MetricKind == "" {
+		body.MetricKind = "GAUGE"
+	}
+
+	if body.ValueType == "" {
+		body.ValueType = "DOUBLE"
+	}
+
+	body.Name = descriptorResourceName(project, body.Type)
+
+	h.mu.Lock()
+	h.descriptors[body.Type] = body
+	h.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, body)
+}
+
+func synthDescriptor(project, mtype string) metricDescriptor {
+	return metricDescriptor{
+		Name:       descriptorResourceName(project, mtype),
+		Type:       mtype,
+		MetricKind: "GAUGE",
+		ValueType:  "DOUBLE",
+		Labels:     []descriptorLabel{{Key: "instance_id", ValueType: "STRING"}},
+	}
+}
+
+func descriptorResourceName(project, mtype string) string {
+	return "projects/" + project + "/metricDescriptors/" + mtype
+}

--- a/server/gcp/monitoring/monitoring_test.go
+++ b/server/gcp/monitoring/monitoring_test.go
@@ -5,11 +5,25 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stackshy/cloudemu/v2"
 	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
 )
+
+// policyID extracts the opaque id from an alert policy's canonical name
+// (projects/{p}/alertPolicies/{id}).
+func policyID(t *testing.T, created map[string]any) string {
+	t.Helper()
+
+	name, ok := created["name"].(string)
+	if !ok || name == "" {
+		t.Fatal("create response missing canonical name")
+	}
+
+	return name[strings.LastIndex(name, "/")+1:]
+}
 
 // HTTP-level test for the GCP Cloud Monitoring handler. Real
 // cloud.google.com/go/monitoring uses gRPC by default; the REST surface here
@@ -46,9 +60,14 @@ func TestMonitoringAlertPolicyCRUD(t *testing.T) {
 		t.Errorf("displayName=%v", got["displayName"])
 	}
 
-	if name, ok := got["name"].(string); !ok || name == "" {
-		t.Errorf("missing canonical name in response")
+	canonical, ok := got["name"].(string)
+	if !ok || canonical == "" {
+		t.Fatal("missing canonical name in response")
 	}
+
+	// Real Cloud Monitoring addresses a policy by its opaque numeric id, not by
+	// displayName — extract the id assigned on create.
+	id := canonical[strings.LastIndex(canonical, "/")+1:]
 
 	// List
 	listResp, err := ts.Client().Get(ts.URL + collURL)
@@ -68,7 +87,7 @@ func TestMonitoringAlertPolicyCRUD(t *testing.T) {
 	}
 
 	// Get
-	getResp, err := ts.Client().Get(ts.URL + collURL + "/high-cpu")
+	getResp, err := ts.Client().Get(ts.URL + collURL + "/" + id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +98,7 @@ func TestMonitoringAlertPolicyCRUD(t *testing.T) {
 	}
 
 	// Delete
-	delReq, _ := http.NewRequest(http.MethodDelete, ts.URL+collURL+"/high-cpu", http.NoBody)
+	delReq, _ := http.NewRequest(http.MethodDelete, ts.URL+collURL+"/"+id, http.NoBody)
 
 	delResp, err := ts.Client().Do(delReq)
 	if err != nil {
@@ -116,10 +135,15 @@ func TestMonitoringAlertPolicySemantics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	var created map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&created)
 	resp.Body.Close()
 
+	id := policyID(t, created)
+
 	// Get must reflect what was created.
-	getResp, err := ts.Client().Get(ts.URL + collURL + "/cpu-alert")
+	getResp, err := ts.Client().Get(ts.URL + collURL + "/" + id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +171,7 @@ func TestMonitoringAlertPolicySemantics(t *testing.T) {
 	// PATCH updates the combiner but OMITS enabled — a partial patch must NOT
 	// silently disable the policy (regression guard for the omitted-field bug).
 	patch := bytes.NewBufferString(`{"combiner": "OR"}`)
-	patchReq, _ := http.NewRequest(http.MethodPatch, ts.URL+collURL+"/cpu-alert", patch)
+	patchReq, _ := http.NewRequest(http.MethodPatch, ts.URL+collURL+"/"+id, patch)
 	patchReq.Header.Set("Content-Type", "application/json")
 
 	patchResp, err := ts.Client().Do(patchReq)
@@ -189,9 +213,12 @@ func TestMonitoringNonThresholdCondition(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	var created map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&created)
 	resp.Body.Close()
 
-	getResp, err := ts.Client().Get(ts.URL + collURL + "/absent-alert")
+	getResp, err := ts.Client().Get(ts.URL + collURL + "/" + policyID(t, created))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/gcp/monitoring/notificationchannels.go
+++ b/server/gcp/monitoring/notificationchannels.go
@@ -1,0 +1,119 @@
+package monitoring
+
+import (
+	"encoding/json"
+	"net/http"
+
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// serveNotificationChannels routes /v3/projects/{p}/notificationChannels[/{id}].
+func (h *Handler) serveNotificationChannels(w http.ResponseWriter, r *http.Request, project string, rest []string) {
+	if len(rest) == 0 {
+		switch r.Method {
+		case http.MethodPost:
+			h.createChannel(w, r, project)
+		case http.MethodGet:
+			h.listChannels(w, r, project)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		}
+
+		return
+	}
+
+	id := rest[0]
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getChannel(w, r, project, id)
+	case http.MethodDelete:
+		h.deleteChannel(w, r, id)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+	}
+}
+
+func (h *Handler) createChannel(w http.ResponseWriter, r *http.Request, project string) {
+	var body notificationChannel
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		return
+	}
+
+	cfg := mondriver.NotificationChannelConfig{
+		Name:     body.DisplayName,
+		Type:     body.Type,
+		Endpoint: channelEndpoint(body.Labels),
+		Tags:     body.Labels,
+	}
+
+	info, err := h.mon.CreateNotificationChannel(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toChannelJSON(project, info))
+}
+
+func (h *Handler) listChannels(w http.ResponseWriter, r *http.Request, project string) {
+	infos, err := h.mon.ListNotificationChannels(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := notificationChannelsList{NotificationChannels: make([]notificationChannel, 0, len(infos))}
+	for i := range infos {
+		out.NotificationChannels = append(out.NotificationChannels, toChannelJSON(project, &infos[i]))
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) getChannel(w http.ResponseWriter, r *http.Request, project, id string) {
+	info, err := h.mon.GetNotificationChannel(r.Context(), id)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toChannelJSON(project, info))
+}
+
+func (h *Handler) deleteChannel(w http.ResponseWriter, r *http.Request, id string) {
+	if err := h.mon.DeleteNotificationChannel(r.Context(), id); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+// channelEndpoint picks a representative endpoint from GCP channel labels
+// (email_address for email, url for webhooks, channel_name for chat).
+func channelEndpoint(labels map[string]string) string {
+	for _, k := range []string{"email_address", "url", "channel_name", "topic"} {
+		if v, ok := labels[k]; ok {
+			return v
+		}
+	}
+
+	return ""
+}
+
+func toChannelJSON(project string, info *mondriver.NotificationChannelInfo) notificationChannel {
+	enabled := true
+
+	return notificationChannel{
+		Name:               "projects/" + project + "/notificationChannels/" + info.ID,
+		Type:               info.Type,
+		DisplayName:        info.Name,
+		Labels:             info.Tags,
+		VerificationStatus: "VERIFICATION_STATUS_UNSPECIFIED",
+		Enabled:            &enabled,
+	}
+}

--- a/server/gcp/monitoring/timeseries.go
+++ b/server/gcp/monitoring/timeseries.go
@@ -1,0 +1,258 @@
+package monitoring
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// seriesReader is the GCP-specific optional interface a monitoring backend
+// implements to expose raw, per-label metric series for timeSeries.list. It is
+// kept out of the shared driver.Monitoring interface so AWS/Azure need not
+// implement it.
+type seriesReader interface {
+	GCPSeriesKeys() []mondriver.MetricIdentifier
+	GCPRawSeries(namespace, metricName string) []mondriver.MetricDatum
+}
+
+// serveTimeSeries routes /v3/projects/{p}/timeSeries (list on GET, ingest on POST).
+func (h *Handler) serveTimeSeries(w http.ResponseWriter, r *http.Request, project string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.listTimeSeries(w, r)
+	case http.MethodPost:
+		h.createTimeSeries(w, r, project)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+	}
+}
+
+func (h *Handler) createTimeSeries(w http.ResponseWriter, r *http.Request, _ string) {
+	var body createTimeSeriesRequest
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		return
+	}
+
+	if len(body.TimeSeries) == 0 {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "timeSeries is required")
+		return
+	}
+
+	var data []mondriver.MetricDatum
+
+	for _, ts := range body.TimeSeries {
+		ns, metric := splitMetricType(ts.Metric.Type)
+		if metric == "" {
+			writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "metric.type is required")
+			return
+		}
+
+		for _, p := range ts.Points {
+			data = append(data, mondriver.MetricDatum{
+				Namespace:  ns,
+				MetricName: metric,
+				Value:      pointValue(p.Value),
+				Dimensions: ts.Metric.Labels,
+				Timestamp:  pointTimestamp(p.Interval),
+			})
+		}
+	}
+
+	if err := h.mon.PutMetricData(r.Context(), data); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+func (h *Handler) listTimeSeries(w http.ResponseWriter, r *http.Request) {
+	reader, ok := h.mon.(seriesReader)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "UNIMPLEMENTED", "timeSeries.list unsupported")
+		return
+	}
+
+	q := r.URL.Query()
+	filter := parseSeriesFilter(q.Get("filter"))
+	start := parseRFC3339(q.Get("interval.startTime"))
+	end := parseRFC3339(q.Get("interval.endTime"))
+
+	if end.IsZero() {
+		end = time.Now()
+	}
+
+	out := listTimeSeriesResponse{TimeSeries: []timeSeries{}}
+
+	for _, key := range reader.GCPSeriesKeys() {
+		fullType := metricType(key.Namespace, key.MetricName)
+		if !filter.matchesType(fullType) {
+			continue
+		}
+
+		raw := reader.GCPRawSeries(key.Namespace, key.MetricName)
+		out.TimeSeries = append(out.TimeSeries, buildSeries(fullType, raw, filter, start, end)...)
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+// buildSeries groups raw datums by their label set into one timeSeries each,
+// keeping only points inside [start,end] whose labels satisfy the filter.
+func buildSeries(fullType string, raw []mondriver.MetricDatum, f seriesFilter, start, end time.Time) []timeSeries {
+	groups := make(map[string][]mondriver.MetricDatum)
+	order := []string{}
+
+	for i := range raw {
+		d := raw[i]
+		if !inWindow(d.Timestamp, start, end) || !f.matchesLabels(d.Dimensions) {
+			continue
+		}
+
+		k := labelKey(d.Dimensions)
+		if _, seen := groups[k]; !seen {
+			order = append(order, k)
+		}
+
+		groups[k] = append(groups[k], d)
+	}
+
+	series := make([]timeSeries, 0, len(order))
+
+	for _, k := range order {
+		series = append(series, oneSeries(fullType, groups[k]))
+	}
+
+	return series
+}
+
+func oneSeries(fullType string, data []mondriver.MetricDatum) timeSeries {
+	// Cloud Monitoring returns points newest-first.
+	sort.Slice(data, func(i, j int) bool { return data[i].Timestamp.After(data[j].Timestamp) })
+
+	pts := make([]point, 0, len(data))
+
+	for i := range data {
+		ts := data[i].Timestamp.UTC().Format(time.RFC3339)
+		val := data[i].Value
+		pts = append(pts, point{
+			Interval: timeInterval{StartTime: ts, EndTime: ts},
+			Value:    typedValue{DoubleValue: &val},
+		})
+	}
+
+	labels := map[string]string{}
+	if len(data) > 0 {
+		labels = data[0].Dimensions
+	}
+
+	return timeSeries{
+		Metric:     metricRef{Type: fullType, Labels: labels},
+		Resource:   resourceFor(labels),
+		MetricKind: "GAUGE",
+		ValueType:  "DOUBLE",
+		Points:     pts,
+	}
+}
+
+func resourceFor(labels map[string]string) monitoredRes {
+	if id, ok := labels["instance_id"]; ok {
+		return monitoredRes{Type: "gce_instance", Labels: map[string]string{"instance_id": id}}
+	}
+
+	return monitoredRes{Type: "global"}
+}
+
+func inWindow(ts, start, end time.Time) bool {
+	if !start.IsZero() && ts.Before(start) {
+		return false
+	}
+
+	if !end.IsZero() && ts.After(end) {
+		return false
+	}
+
+	return true
+}
+
+func labelKey(labels map[string]string) string {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	var b strings.Builder
+
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(labels[k])
+		b.WriteByte(';')
+	}
+
+	return b.String()
+}
+
+// metricType joins a namespace and metric name into a Cloud Monitoring
+// metric.type; splitMetricType is its inverse (split at the first slash).
+func metricType(namespace, metricName string) string {
+	return namespace + "/" + metricName
+}
+
+func splitMetricType(t string) (namespace, metricName string) {
+	i := strings.Index(t, "/")
+	if i < 0 {
+		return t, ""
+	}
+
+	return t[:i], t[i+1:]
+}
+
+func pointValue(v typedValue) float64 {
+	if v.DoubleValue != nil {
+		return *v.DoubleValue
+	}
+
+	if v.Int64Value != nil {
+		f, _ := strconv.ParseFloat(*v.Int64Value, 64)
+
+		return f
+	}
+
+	return 0
+}
+
+func pointTimestamp(iv timeInterval) time.Time {
+	if t := parseRFC3339(iv.EndTime); !t.IsZero() {
+		return t
+	}
+
+	if t := parseRFC3339(iv.StartTime); !t.IsZero() {
+		return t
+	}
+
+	return time.Now()
+}
+
+func parseRFC3339(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+
+	return t
+}

--- a/server/gcp/monitoring/types.go
+++ b/server/gcp/monitoring/types.go
@@ -33,6 +33,97 @@ type alertPoliciesList struct {
 	NextPageToken string        `json:"nextPageToken,omitempty"`
 }
 
+// mutationRecord mirrors the Cloud Monitoring MutationRecord shape populated on
+// alertPolicies.creationRecord / mutationRecord.
+type mutationRecord struct {
+	MutateTime string `json:"mutateTime,omitempty"`
+	MutatedBy  string `json:"mutatedBy,omitempty"`
+}
+
+// timeSeries is one Cloud Monitoring time series: a metric+resource label set
+// and its points.
+type timeSeries struct {
+	Metric     metricRef    `json:"metric"`
+	Resource   monitoredRes `json:"resource"`
+	MetricKind string       `json:"metricKind,omitempty"`
+	ValueType  string       `json:"valueType,omitempty"`
+	Points     []point      `json:"points"`
+}
+
+type metricRef struct {
+	Type   string            `json:"type"`
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+type monitoredRes struct {
+	Type   string            `json:"type"`
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+type point struct {
+	Interval timeInterval `json:"interval"`
+	Value    typedValue   `json:"value"`
+}
+
+type timeInterval struct {
+	StartTime string `json:"startTime,omitempty"`
+	EndTime   string `json:"endTime,omitempty"`
+}
+
+type typedValue struct {
+	DoubleValue *float64 `json:"doubleValue,omitempty"`
+	Int64Value  *string  `json:"int64Value,omitempty"`
+}
+
+type listTimeSeriesResponse struct {
+	TimeSeries    []timeSeries `json:"timeSeries"`
+	NextPageToken string       `json:"nextPageToken,omitempty"`
+}
+
+type createTimeSeriesRequest struct {
+	TimeSeries []timeSeries `json:"timeSeries"`
+}
+
+// metricDescriptor is the Cloud Monitoring MetricDescriptor shape.
+type metricDescriptor struct {
+	Name        string            `json:"name,omitempty"`
+	Type        string            `json:"type"`
+	MetricKind  string            `json:"metricKind,omitempty"`
+	ValueType   string            `json:"valueType,omitempty"`
+	Unit        string            `json:"unit,omitempty"`
+	DisplayName string            `json:"displayName,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Labels      []descriptorLabel `json:"labels,omitempty"`
+}
+
+type descriptorLabel struct {
+	Key         string `json:"key"`
+	ValueType   string `json:"valueType,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type metricDescriptorsList struct {
+	MetricDescriptors []metricDescriptor `json:"metricDescriptors"`
+	NextPageToken     string             `json:"nextPageToken,omitempty"`
+}
+
+// notificationChannel is the Cloud Monitoring NotificationChannel shape.
+type notificationChannel struct {
+	Name               string            `json:"name,omitempty"`
+	Type               string            `json:"type,omitempty"`
+	DisplayName        string            `json:"displayName,omitempty"`
+	Description        string            `json:"description,omitempty"`
+	Labels             map[string]string `json:"labels,omitempty"`
+	UserLabels         map[string]string `json:"userLabels,omitempty"`
+	VerificationStatus string            `json:"verificationStatus,omitempty"`
+	Enabled            *bool             `json:"enabled,omitempty"`
+}
+
+type notificationChannelsList struct {
+	NotificationChannels []notificationChannel `json:"notificationChannels"`
+	NextPageToken        string                `json:"nextPageToken,omitempty"`
+}
+
 type errorEnvelope struct {
 	Error errorBody `json:"error"`
 }


### PR DESCRIPTION
## What & why

The GCP Cloud Monitoring wire handler only served `/v3/projects/{p}/alertPolicies`; every other Cloud Monitoring collection returned 501. This made GCE auto-metrics unreadable and blocked metric-type discovery, notification channels, and custom-metric ingestion. This PR broadens the handler to the collections a real user hits and fixes two alert-policy correctness bugs.

Fixed at the correct 3-layer location: new GCP-specific raw-series accessors on the provider mock (`providers/gcp/monitoring`) exposed via an **optional interface** the wire handler type-asserts, so the shared `driver.Monitoring` interface is unchanged (no AWS/Azure churn, no coverage regen).

## Findings fixed (AUDIT_GCP.md `## monitoring`)

- **[BLOCKER] timeSeries.list** — was 501; now reads GCE auto-metrics and custom points, grouped per label set into series. This is the only wire read path for every metric.
- **[BLOCKER] timeSeries.create** — was 501; now ingests custom-metric points via `PutMetricData` and returns 200.
- **[HIGH] metricDescriptors.list/get/create** — was 501; descriptors synthesized from live series plus custom-created ones.
- **[HIGH] notificationChannels.create/list/get/delete** — was 501; alert policies can now reference channels that actually exist (backed by the existing driver channel methods).
- **[HIGH] alertPolicies.create (wrong wire)** — name was derived from `displayName`, collapsing duplicates (data loss); now assigns an opaque numeric id.
- **[MEDIUM] alertPolicies.create/get (records)** — `creationRecord`/`mutationRecord` now populated and each condition gets its canonical resource name.
- **[MEDIUM] alertPolicies.patch** — already routed (POST/GET/PATCH/DELETE) and now records a mutation timestamp on patch; verified via the real client.

## Tests

Reproduction tests in `server/gcp/monitoring/client_test.go` use the real `google.golang.org/api/monitoring/v3` REST client with `option.WithEndpoint` against the in-process GCP server, one per finding. Existing alert-policy wire tests updated to address policies by their opaque id (the old displayName-addressing encoded the bug) and stay green.

## Deferrals

None.
