### PR TITLE
fix(gcp-logging): logName-optional list, entry metadata, sinks, log-based metrics, pagination

### DIFF
--- a/docs/coverage/aws/cloudwatchlogs.md
+++ b/docs/coverage/aws/cloudwatchlogs.md
@@ -22,6 +22,27 @@ AWS's `logging` service · portable interface `driver.Logging` · [AWS index](./
 | `PutMetricFilter` |  |
 | `UpdateLogGroup` | UpdateLogGroup replaces the mutable fields (retention, tags) of an |
 
+## Optional capabilities
+
+Discovered by type assertion; only some providers implement these.
+
+### GCPLogging
+
+GCPLogging is an optional interface implemented by the GCP logging backend for
+
+| Operation | Description |
+| --- | --- |
+| `CreateLogMetric` |  |
+| `CreateSink` |  |
+| `DeleteLogMetric` |  |
+| `DeleteSink` |  |
+| `GetLogMetric` |  |
+| `GetSink` |  |
+| `ListLogMetrics` |  |
+| `ListSinks` |  |
+| `UpdateLogMetric` |  |
+| `UpdateSink` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/azure/loganalytics.md
+++ b/docs/coverage/azure/loganalytics.md
@@ -22,6 +22,27 @@ Azure's `logging` service · portable interface `driver.Logging` · [Azure index
 | `PutMetricFilter` |  |
 | `UpdateLogGroup` | UpdateLogGroup replaces the mutable fields (retention, tags) of an |
 
+## Optional capabilities
+
+Discovered by type assertion; only some providers implement these.
+
+### GCPLogging
+
+GCPLogging is an optional interface implemented by the GCP logging backend for
+
+| Operation | Description |
+| --- | --- |
+| `CreateLogMetric` |  |
+| `CreateSink` |  |
+| `DeleteLogMetric` |  |
+| `DeleteSink` |  |
+| `GetLogMetric` |  |
+| `GetSink` |  |
+| `ListLogMetrics` |  |
+| `ListSinks` |  |
+| `UpdateLogMetric` |  |
+| `UpdateSink` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -5811,6 +5811,44 @@
         "doc": "UpdateLogGroup replaces the mutable fields (retention, tags) of an"
       }
     ],
+    "optionalCapabilities": [
+      {
+        "name": "GCPLogging",
+        "doc": "GCPLogging is an optional interface implemented by the GCP logging backend for",
+        "operations": [
+          {
+            "name": "CreateLogMetric"
+          },
+          {
+            "name": "CreateSink"
+          },
+          {
+            "name": "DeleteLogMetric"
+          },
+          {
+            "name": "DeleteSink"
+          },
+          {
+            "name": "GetLogMetric"
+          },
+          {
+            "name": "GetSink"
+          },
+          {
+            "name": "ListLogMetrics"
+          },
+          {
+            "name": "ListSinks"
+          },
+          {
+            "name": "UpdateLogMetric"
+          },
+          {
+            "name": "UpdateSink"
+          }
+        ]
+      }
+    ],
     "providers": {
       "aws": "CloudWatchLogs",
       "azure": "LogAnalytics",

--- a/docs/coverage/gcp/cloudlogging.md
+++ b/docs/coverage/gcp/cloudlogging.md
@@ -22,6 +22,27 @@ GCP's `logging` service · portable interface `driver.Logging` · [GCP index](./
 | `PutMetricFilter` |  |
 | `UpdateLogGroup` | UpdateLogGroup replaces the mutable fields (retention, tags) of an |
 
+## Optional capabilities
+
+Discovered by type assertion; only some providers implement these.
+
+### GCPLogging
+
+GCPLogging is an optional interface implemented by the GCP logging backend for
+
+| Operation | Description |
+| --- | --- |
+| `CreateLogMetric` |  |
+| `CreateSink` |  |
+| `DeleteLogMetric` |  |
+| `DeleteSink` |  |
+| `GetLogMetric` |  |
+| `GetSink` |  |
+| `ListLogMetrics` |  |
+| `ListSinks` |  |
+| `UpdateLogMetric` |  |
+| `UpdateSink` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/providers/gcp/cloudlogging/cloudlogging.go
+++ b/providers/gcp/cloudlogging/cloudlogging.go
@@ -42,6 +42,12 @@ type Mock struct {
 	groups     *memstore.Store[*logGroup]
 	opts       *config.Options
 	monitoring mondriver.Monitoring
+
+	// sinks and metrics back the GCP-only resource surfaces (export sinks and
+	// log-based metrics). They are keyed by "{project}/{name}" so a single mock
+	// can hold resources for more than one project.
+	sinks   *memstore.Store[*driver.LogSink]
+	metrics *memstore.Store[*driver.LogBasedMetric]
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -69,8 +75,10 @@ func (m *Mock) emitMetric(ctx context.Context, metricName string, value float64,
 // New creates a new Cloud Logging mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		groups: memstore.New[*logGroup](),
-		opts:   opts,
+		groups:  memstore.New[*logGroup](),
+		opts:    opts,
+		sinks:   memstore.New[*driver.LogSink](),
+		metrics: memstore.New[*driver.LogBasedMetric](),
 	}
 }
 

--- a/providers/gcp/cloudlogging/gcp_resources.go
+++ b/providers/gcp/cloudlogging/gcp_resources.go
@@ -1,0 +1,212 @@
+package cloudlogging
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// Compile-time check that Mock implements the optional GCP-only surface.
+var _ driver.GCPLogging = (*Mock)(nil)
+
+// defaultSinkWriterIdentity is the service account Cloud Logging reports as the
+// writer for a sink whose caller did not request a unique one.
+const defaultSinkWriterIdentity = "serviceAccount:cloud-logs@system.gserviceaccount.com"
+
+func resourceKey(project, name string) string {
+	return project + "/" + name
+}
+
+// CreateSink stores a new export sink under project.
+func (m *Mock) CreateSink(_ context.Context, project string, sink *driver.LogSink) (*driver.LogSink, error) {
+	if sink.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "sink name is required")
+	}
+
+	if sink.Destination == "" {
+		return nil, errors.New(errors.InvalidArgument, "sink destination is required")
+	}
+
+	key := resourceKey(project, sink.Name)
+	if m.sinks.Has(key) {
+		return nil, errors.Newf(errors.AlreadyExists, "sink %q already exists", sink.Name)
+	}
+
+	now := m.opts.Clock.Now().UTC()
+
+	stored := *sink
+	stored.CreatedAt = now
+	stored.UpdatedAt = now
+
+	if stored.WriterIdentity == "" {
+		stored.WriterIdentity = defaultSinkWriterIdentity
+	}
+
+	m.sinks.Set(key, &stored)
+
+	result := stored
+
+	return &result, nil
+}
+
+// GetSink returns the sink named name under project.
+func (m *Mock) GetSink(_ context.Context, project, name string) (*driver.LogSink, error) {
+	s, ok := m.sinks.Get(resourceKey(project, name))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "sink %q not found", name)
+	}
+
+	result := *s
+
+	return &result, nil
+}
+
+// ListSinks lists all sinks under project in name order.
+func (m *Mock) ListSinks(_ context.Context, project string) ([]driver.LogSink, error) {
+	prefix := project + "/"
+
+	sinks := make([]driver.LogSink, 0)
+
+	for key, s := range m.sinks.All() {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+
+		sinks = append(sinks, *s)
+	}
+
+	sort.Slice(sinks, func(i, j int) bool { return sinks[i].Name < sinks[j].Name })
+
+	return sinks, nil
+}
+
+// UpdateSink replaces the mutable fields of an existing sink (identity and
+// createTime are preserved).
+func (m *Mock) UpdateSink(_ context.Context, project string, sink *driver.LogSink) (*driver.LogSink, error) {
+	key := resourceKey(project, sink.Name)
+
+	existing, ok := m.sinks.Get(key)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "sink %q not found", sink.Name)
+	}
+
+	updated := *existing
+	updated.Destination = sink.Destination
+	updated.Filter = sink.Filter
+	updated.Description = sink.Description
+	updated.Disabled = sink.Disabled
+	updated.IncludeChildren = sink.IncludeChildren
+	updated.UpdatedAt = m.opts.Clock.Now().UTC()
+
+	m.sinks.Set(key, &updated)
+
+	result := updated
+
+	return &result, nil
+}
+
+// DeleteSink removes the sink named name under project.
+func (m *Mock) DeleteSink(_ context.Context, project, name string) error {
+	if !m.sinks.Delete(resourceKey(project, name)) {
+		return errors.Newf(errors.NotFound, "sink %q not found", name)
+	}
+
+	return nil
+}
+
+// CreateLogMetric stores a new log-based metric under project.
+func (m *Mock) CreateLogMetric(_ context.Context, project string, metric *driver.LogBasedMetric) (*driver.LogBasedMetric, error) {
+	if metric.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "metric name is required")
+	}
+
+	if metric.Filter == "" {
+		return nil, errors.New(errors.InvalidArgument, "metric filter is required")
+	}
+
+	key := resourceKey(project, metric.Name)
+	if m.metrics.Has(key) {
+		return nil, errors.Newf(errors.AlreadyExists, "metric %q already exists", metric.Name)
+	}
+
+	now := m.opts.Clock.Now().UTC()
+
+	stored := *metric
+	stored.CreatedAt = now
+	stored.UpdatedAt = now
+
+	m.metrics.Set(key, &stored)
+
+	result := stored
+
+	return &result, nil
+}
+
+// GetLogMetric returns the metric named name under project.
+func (m *Mock) GetLogMetric(_ context.Context, project, name string) (*driver.LogBasedMetric, error) {
+	mm, ok := m.metrics.Get(resourceKey(project, name))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "metric %q not found", name)
+	}
+
+	result := *mm
+
+	return &result, nil
+}
+
+// ListLogMetrics lists all log-based metrics under project in name order.
+func (m *Mock) ListLogMetrics(_ context.Context, project string) ([]driver.LogBasedMetric, error) {
+	prefix := project + "/"
+
+	metrics := make([]driver.LogBasedMetric, 0)
+
+	for key, mm := range m.metrics.All() {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+
+		metrics = append(metrics, *mm)
+	}
+
+	sort.Slice(metrics, func(i, j int) bool { return metrics[i].Name < metrics[j].Name })
+
+	return metrics, nil
+}
+
+// UpdateLogMetric replaces the mutable fields of an existing metric (createTime
+// is preserved).
+func (m *Mock) UpdateLogMetric(_ context.Context, project string, metric *driver.LogBasedMetric) (*driver.LogBasedMetric, error) {
+	key := resourceKey(project, metric.Name)
+
+	existing, ok := m.metrics.Get(key)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "metric %q not found", metric.Name)
+	}
+
+	updated := *existing
+	updated.Description = metric.Description
+	updated.Filter = metric.Filter
+	updated.ValueExtractor = metric.ValueExtractor
+	updated.MetricKind = metric.MetricKind
+	updated.ValueType = metric.ValueType
+	updated.Unit = metric.Unit
+	updated.UpdatedAt = m.opts.Clock.Now().UTC()
+
+	m.metrics.Set(key, &updated)
+
+	result := updated
+
+	return &result, nil
+}
+
+// DeleteLogMetric removes the metric named name under project.
+func (m *Mock) DeleteLogMetric(_ context.Context, project, name string) error {
+	if !m.metrics.Delete(resourceKey(project, name)) {
+		return errors.Newf(errors.NotFound, "metric %q not found", name)
+	}
+
+	return nil
+}

--- a/server/gcp/cloudlogging/entries_list_sdk_test.go
+++ b/server/gcp/cloudlogging/entries_list_sdk_test.go
@@ -1,0 +1,186 @@
+package cloudlogging_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	logging "google.golang.org/api/logging/v2"
+)
+
+// writeEntry writes a single text entry to logName at ts.
+func writeEntry(t *testing.T, svc *logging.Service, logName, text string, ts time.Time) {
+	t.Helper()
+
+	if _, err := svc.Entries.Write(&logging.WriteLogEntriesRequest{
+		LogName: logName,
+		Entries: []*logging.LogEntry{
+			{Timestamp: ts.Format(time.RFC3339Nano), TextPayload: text},
+		},
+	}).Context(context.Background()).Do(); err != nil {
+		t.Fatalf("Entries.Write: %v", err)
+	}
+}
+
+// TestSDKEntriesListWithoutLogNameFilter guards the fix for the logName-optional
+// finding: entries.list with only resourceNames (no logName= filter) must read
+// across every log in the project, not 400.
+func TestSDKEntriesListWithoutLogNameFilter(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+
+	base := time.Now().UTC().Truncate(time.Millisecond)
+	writeEntry(t, svc, "projects/"+testProject+"/logs/app-a", "from-a", base)
+	writeEntry(t, svc, "projects/"+testProject+"/logs/app-b", "from-b", base.Add(time.Second))
+
+	resp, err := svc.Entries.List(&logging.ListLogEntriesRequest{
+		ResourceNames: []string{"projects/" + testProject},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Entries.List without logName filter: %v", err)
+	}
+
+	if len(resp.Entries) != 2 {
+		t.Fatalf("read-all returned %d entries, want 2: %+v", len(resp.Entries), resp.Entries)
+	}
+
+	logs := map[string]bool{}
+	for _, e := range resp.Entries {
+		logs[e.LogName] = true
+	}
+
+	if !logs["projects/"+testProject+"/logs/app-a"] || !logs["projects/"+testProject+"/logs/app-b"] {
+		t.Fatalf("read-all did not span both logs: %v", logs)
+	}
+}
+
+// TestSDKEntriesListMetadataFields guards insertId, resource and receiveTimestamp
+// being populated on read-back.
+func TestSDKEntriesListMetadataFields(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+
+	logName := "projects/" + testProject + "/logs/meta"
+	base := time.Now().UTC().Truncate(time.Millisecond)
+
+	// An explicit resource must round-trip; the writer supplies no insertId, so
+	// the server must assign one.
+	if _, err := svc.Entries.Write(&logging.WriteLogEntriesRequest{
+		LogName: logName,
+		Resource: &logging.MonitoredResource{
+			Type:   "gce_instance",
+			Labels: map[string]string{"instance_id": "i-123", "zone": "us-central1-a"},
+		},
+		Entries: []*logging.LogEntry{
+			{Timestamp: base.Format(time.RFC3339Nano), TextPayload: "hello"},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Entries.Write: %v", err)
+	}
+
+	resp, err := svc.Entries.List(&logging.ListLogEntriesRequest{
+		ResourceNames: []string{"projects/" + testProject},
+		Filter:        `logName="` + logName + `"`,
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Entries.List: %v", err)
+	}
+
+	if len(resp.Entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(resp.Entries))
+	}
+
+	e := resp.Entries[0]
+	if e.InsertId == "" {
+		t.Error("insertId was not populated")
+	}
+
+	if e.ReceiveTimestamp == "" {
+		t.Error("receiveTimestamp was not populated")
+	}
+
+	if e.Resource == nil || e.Resource.Type != "gce_instance" {
+		t.Fatalf("resource did not round-trip: %+v", e.Resource)
+	}
+
+	if e.Resource.Labels["instance_id"] != "i-123" {
+		t.Errorf("resource labels lost: %v", e.Resource.Labels)
+	}
+}
+
+// TestSDKEntriesListDefaultResource guards that an entry written with no resource
+// still reads back the default "global" MonitoredResource.
+func TestSDKEntriesListDefaultResource(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+
+	logName := "projects/" + testProject + "/logs/no-resource"
+	writeEntry(t, svc, logName, "x", time.Now().UTC())
+
+	resp, err := svc.Entries.List(&logging.ListLogEntriesRequest{
+		ResourceNames: []string{"projects/" + testProject},
+		Filter:        `logName="` + logName + `"`,
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Entries.List: %v", err)
+	}
+
+	if len(resp.Entries) != 1 || resp.Entries[0].Resource == nil {
+		t.Fatalf("expected a default resource, got %+v", resp.Entries)
+	}
+
+	if resp.Entries[0].Resource.Type != "global" {
+		t.Errorf("default resource type = %q, want global", resp.Entries[0].Resource.Type)
+	}
+}
+
+// TestSDKEntriesListPagination guards pageSize + nextPageToken paging.
+func TestSDKEntriesListPagination(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+
+	logName := "projects/" + testProject + "/logs/paged"
+	base := time.Now().UTC().Truncate(time.Millisecond)
+	for i := range 3 {
+		writeEntry(t, svc, logName, "entry", base.Add(time.Duration(i)*time.Second))
+	}
+
+	first, err := svc.Entries.List(&logging.ListLogEntriesRequest{
+		ResourceNames: []string{"projects/" + testProject},
+		Filter:        `logName="` + logName + `"`,
+		PageSize:      1,
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Entries.List page 1: %v", err)
+	}
+
+	if len(first.Entries) != 1 {
+		t.Fatalf("page 1 returned %d entries, want 1", len(first.Entries))
+	}
+
+	if first.NextPageToken == "" {
+		t.Fatal("page 1 had no nextPageToken with more entries remaining")
+	}
+
+	// Walk all pages and confirm every entry is seen exactly once.
+	seen := len(first.Entries)
+	token := first.NextPageToken
+	for token != "" {
+		page, err := svc.Entries.List(&logging.ListLogEntriesRequest{
+			ResourceNames: []string{"projects/" + testProject},
+			Filter:        `logName="` + logName + `"`,
+			PageSize:      1,
+			PageToken:     token,
+		}).Context(ctx).Do()
+		if err != nil {
+			t.Fatalf("Entries.List page token=%q: %v", token, err)
+		}
+
+		seen += len(page.Entries)
+		token = page.NextPageToken
+	}
+
+	if seen != 3 {
+		t.Fatalf("paged through %d entries, want 3", seen)
+	}
+}

--- a/server/gcp/cloudlogging/handler.go
+++ b/server/gcp/cloudlogging/handler.go
@@ -16,13 +16,15 @@
 //	GET    /v2/projects/{p}/logs          — ListLogs        -> ListLogGroups
 //	DELETE /v2/projects/{p}/logs/{logid}  — DeleteLog       -> DeleteLogGroup
 //
+// Export sinks (projects.sinks) and log-based metrics (projects.metrics) — GCP
+// resource surfaces with no cross-provider equivalent — are served through the
+// optional driver.GCPLogging interface, which the GCP backend implements.
+//
 // The /v2/ URL space is disjoint from the /v1/projects/ family (Firestore, IAM,
 // …), /compute/v1/, and /dns/v1/, so registration order relative to them is
 // unconstrained. Registered before the GCS fallback for consistency.
 //
-// Out of scope for this slice: log buckets / sinks / metrics
-// (projects.locations.buckets, projects.sinks, projects.metrics) — a separate
-// resource surface not backed by the logging driver's group/stream model.
+// Out of scope for this slice: log buckets (projects.locations.buckets).
 package cloudlogging
 
 import (
@@ -34,11 +36,13 @@ import (
 )
 
 const (
-	basePrefix     = "/v2/"
-	entriesWrite   = "/v2/entries:write"
-	entriesList    = "/v2/entries:list"
-	logsCollection = "logs"
-	projectsSeg    = "projects"
+	basePrefix        = "/v2/"
+	entriesWrite      = "/v2/entries:write"
+	entriesList       = "/v2/entries:list"
+	logsCollection    = "logs"
+	sinksCollection   = "sinks"
+	metricsCollection = "metrics"
+	projectsSeg       = "projects"
 )
 
 // defaultStream is the implicit log stream every Cloud Logging write lands in.
@@ -66,26 +70,33 @@ func (*Handler) Matches(r *http.Request) bool {
 		return true
 	}
 
-	return logsPath(p) != ""
+	return collectionPath(p, logsCollection) != "" ||
+		collectionPath(p, sinksCollection) != "" ||
+		collectionPath(p, metricsCollection) != ""
 }
 
-// logsPath returns the tail after "/v2/projects/{p}/logs" for a logs URL, or ""
-// when p is not a logs path. A bare collection returns "/".
-func logsPath(p string) string {
+// collectionPath returns the tail after "/v2/projects/{p}/{collection}" for a
+// matching URL, or "" when p is not under that collection. A bare collection
+// returns "/".
+func collectionPath(p, collection string) string {
 	if !strings.HasPrefix(p, basePrefix) {
 		return ""
 	}
 
+	// A collection URL is projects/{p}/{collection}[/{tail}...] — at least the
+	// three leading segments must be present.
+	const collectionSegments = 3
+
 	parts := strings.Split(strings.TrimPrefix(p, basePrefix), "/")
-	if len(parts) < 3 || parts[0] != projectsSeg || parts[2] != logsCollection {
+	if len(parts) < collectionSegments || parts[0] != projectsSeg || parts[2] != collection {
 		return ""
 	}
 
-	if len(parts) == 3 {
+	if len(parts) == collectionSegments {
 		return "/"
 	}
 
-	return "/" + strings.Join(parts[3:], "/")
+	return "/" + strings.Join(parts[collectionSegments:], "/")
 }
 
 // ServeHTTP routes on the path and method.
@@ -99,15 +110,31 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tail := logsPath(r.URL.Path)
-	switch {
-	case tail == "/":
-		h.serveLogsCollection(w, r)
-	case tail != "":
-		h.serveLog(w, r, strings.TrimPrefix(tail, "/"))
-	default:
-		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unrecognized Cloud Logging path")
+	if tail := collectionPath(r.URL.Path, logsCollection); tail != "" {
+		h.routeLogs(w, r, tail)
+		return
 	}
+
+	if tail := collectionPath(r.URL.Path, sinksCollection); tail != "" {
+		h.routeSinks(w, r, tail)
+		return
+	}
+
+	if tail := collectionPath(r.URL.Path, metricsCollection); tail != "" {
+		h.routeMetrics(w, r, tail)
+		return
+	}
+
+	gcprest.WriteError(w, http.StatusNotFound, "notFound", "unrecognized Cloud Logging path")
+}
+
+func (h *Handler) routeLogs(w http.ResponseWriter, r *http.Request, tail string) {
+	if tail == "/" {
+		h.serveLogsCollection(w, r)
+		return
+	}
+
+	h.serveLog(w, r, strings.TrimPrefix(tail, "/"))
 }
 
 func (h *Handler) serveEntriesWrite(w http.ResponseWriter, r *http.Request) {

--- a/server/gcp/cloudlogging/metrics.go
+++ b/server/gcp/cloudlogging/metrics.go
@@ -1,0 +1,160 @@
+package cloudlogging
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// metricDescriptorJSON is the subset of the log-based metric's MetricDescriptor
+// the SDK reads back (kind/type/unit).
+type metricDescriptorJSON struct {
+	MetricKind string `json:"metricKind,omitempty"`
+	ValueType  string `json:"valueType,omitempty"`
+	Unit       string `json:"unit,omitempty"`
+}
+
+// logMetricJSON is the Cloud Logging LogMetric resource shape.
+type logMetricJSON struct {
+	Name             string                `json:"name,omitempty"`
+	Description      string                `json:"description,omitempty"`
+	Filter           string                `json:"filter,omitempty"`
+	ValueExtractor   string                `json:"valueExtractor,omitempty"`
+	MetricDescriptor *metricDescriptorJSON `json:"metricDescriptor,omitempty"`
+	CreateTime       string                `json:"createTime,omitempty"`
+	UpdateTime       string                `json:"updateTime,omitempty"`
+}
+
+type listMetricsResponse struct {
+	Metrics       []logMetricJSON `json:"metrics"`
+	NextPageToken string          `json:"nextPageToken,omitempty"`
+}
+
+func toMetricJSON(m *logdriver.LogBasedMetric) logMetricJSON {
+	out := logMetricJSON{
+		Name:           m.Name,
+		Description:    m.Description,
+		Filter:         m.Filter,
+		ValueExtractor: m.ValueExtractor,
+	}
+
+	if m.MetricKind != "" || m.ValueType != "" || m.Unit != "" {
+		out.MetricDescriptor = &metricDescriptorJSON{
+			MetricKind: m.MetricKind,
+			ValueType:  m.ValueType,
+			Unit:       m.Unit,
+		}
+	}
+
+	if !m.CreatedAt.IsZero() {
+		out.CreateTime = m.CreatedAt.UTC().Format(time.RFC3339Nano)
+	}
+
+	if !m.UpdatedAt.IsZero() {
+		out.UpdateTime = m.UpdatedAt.UTC().Format(time.RFC3339Nano)
+	}
+
+	return out
+}
+
+func (b *logMetricJSON) toDriver(name string) *logdriver.LogBasedMetric {
+	m := &logdriver.LogBasedMetric{
+		Name:           name,
+		Description:    b.Description,
+		Filter:         b.Filter,
+		ValueExtractor: b.ValueExtractor,
+	}
+
+	if b.MetricDescriptor != nil {
+		m.MetricKind = b.MetricDescriptor.MetricKind
+		m.ValueType = b.MetricDescriptor.ValueType
+		m.Unit = b.MetricDescriptor.Unit
+	}
+
+	return m
+}
+
+// writeMetric writes a single metric or the driver error that produced it.
+func writeMetric(w http.ResponseWriter, m *logdriver.LogBasedMetric, err error) {
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toMetricJSON(m))
+}
+
+//nolint:dupl // parallel-by-design with routeSinks; sibling REST collections, distinct types
+func (h *Handler) routeMetrics(w http.ResponseWriter, r *http.Request, tail string) {
+	gcp, ok := h.gcpBackend(w)
+	if !ok {
+		return
+	}
+
+	project := projectFromPath(r.URL.Path)
+
+	if tail == "/" {
+		switch r.Method {
+		case http.MethodPost:
+			createMetric(w, r, gcp, project)
+		case http.MethodGet:
+			listMetrics(w, r, gcp, project)
+		default:
+			writeMethodNotAllowed(w)
+		}
+
+		return
+	}
+
+	metricID := strings.TrimPrefix(tail, "/")
+
+	switch r.Method {
+	case http.MethodGet:
+		m, err := gcp.GetLogMetric(r.Context(), project, metricID)
+		writeMetric(w, m, err)
+	case http.MethodPut, http.MethodPatch:
+		updateMetric(w, r, gcp, project, metricID)
+	case http.MethodDelete:
+		deleteResource(w, gcp.DeleteLogMetric(r.Context(), project, metricID))
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func createMetric(w http.ResponseWriter, r *http.Request, gcp logdriver.GCPLogging, project string) {
+	var body logMetricJSON
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	m, err := gcp.CreateLogMetric(r.Context(), project, body.toDriver(body.Name))
+	writeMetric(w, m, err)
+}
+
+func updateMetric(w http.ResponseWriter, r *http.Request, gcp logdriver.GCPLogging, project, metricID string) {
+	var body logMetricJSON
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	m, err := gcp.UpdateLogMetric(r.Context(), project, body.toDriver(metricID))
+	writeMetric(w, m, err)
+}
+
+func listMetrics(w http.ResponseWriter, r *http.Request, gcp logdriver.GCPLogging, project string) {
+	metrics, err := gcp.ListLogMetrics(r.Context(), project)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]logMetricJSON, 0, len(metrics))
+	for i := range metrics {
+		out = append(out, toMetricJSON(&metrics[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listMetricsResponse{Metrics: out})
+}

--- a/server/gcp/cloudlogging/metrics_sdk_test.go
+++ b/server/gcp/cloudlogging/metrics_sdk_test.go
@@ -1,0 +1,75 @@
+package cloudlogging_test
+
+import (
+	"context"
+	"testing"
+
+	logging "google.golang.org/api/logging/v2"
+)
+
+// TestSDKLogMetricsLifecycle guards create/get/list/update/delete of log-based
+// metrics.
+func TestSDKLogMetricsLifecycle(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject
+	metricName := parent + "/metrics/error-count"
+
+	created, err := svc.Projects.Metrics.Create(parent, &logging.LogMetric{
+		Name:        "error-count",
+		Description: "count of error logs",
+		Filter:      `severity>=ERROR`,
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Metrics.Create: %v", err)
+	}
+
+	if created.Name != "error-count" {
+		t.Errorf("created metric name = %q, want error-count", created.Name)
+	}
+
+	got, err := svc.Projects.Metrics.Get(metricName).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Metrics.Get: %v", err)
+	}
+
+	if got.Filter != `severity>=ERROR` {
+		t.Errorf("get filter = %q", got.Filter)
+	}
+
+	list, err := svc.Projects.Metrics.List(parent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Metrics.List: %v", err)
+	}
+
+	if len(list.Metrics) != 1 || list.Metrics[0].Name != "error-count" {
+		t.Fatalf("Metrics.List = %+v, want one error-count", list.Metrics)
+	}
+
+	updated, err := svc.Projects.Metrics.Update(metricName, &logging.LogMetric{
+		Name:        "error-count",
+		Description: "updated",
+		Filter:      `severity>=WARNING`,
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Metrics.Update: %v", err)
+	}
+
+	if updated.Filter != `severity>=WARNING` {
+		t.Errorf("updated filter = %q", updated.Filter)
+	}
+
+	if _, err := svc.Projects.Metrics.Delete(metricName).Context(ctx).Do(); err != nil {
+		t.Fatalf("Metrics.Delete: %v", err)
+	}
+
+	after, err := svc.Projects.Metrics.List(parent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Metrics.List after delete: %v", err)
+	}
+
+	if len(after.Metrics) != 0 {
+		t.Fatalf("metric still present after delete: %+v", after.Metrics)
+	}
+}

--- a/server/gcp/cloudlogging/operations.go
+++ b/server/gcp/cloudlogging/operations.go
@@ -43,9 +43,24 @@ func (h *Handler) writeEntries(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// Cloud Logging assigns a server-side insertId when the writer omits one;
+		// clients dedupe on it, so it must always be present on read-back.
+		if e.InsertID == "" {
+			e.InsertID = genInsertID()
+		}
+
+		// The MonitoredResource may be set per-entry or inherited from the
+		// request level, and request-level labels are merged into every entry.
+		if e.Resource == nil {
+			e.Resource = req.Resource
+		}
+
+		e.Labels = mergeLabels(req.Labels, e.Labels)
+
 		byLog[logID] = append(byLog[logID], logdriver.LogEvent{
-			Timestamp: parseTimestamp(e.Timestamp, now),
-			Message:   encodeEntryPayload(e),
+			Timestamp:     parseTimestamp(e.Timestamp, now),
+			IngestionTime: now,
+			Message:       encodeEntryPayload(e),
 		})
 	}
 
@@ -65,6 +80,26 @@ func (h *Handler) writeEntries(w http.ResponseWriter, r *http.Request) {
 	gcprest.WriteJSON(w, http.StatusOK, struct{}{})
 }
 
+// mergeLabels overlays entry-level labels onto request-level labels (entry wins),
+// returning nil when neither side has any so the field stays omitted on read.
+func mergeLabels(base, override map[string]string) map[string]string {
+	if len(base) == 0 && len(override) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(base)+len(override))
+
+	for k, v := range base {
+		out[k] = v
+	}
+
+	for k, v := range override {
+		out[k] = v
+	}
+
+	return out
+}
+
 // ensureLog creates the log group and its default stream if they do not already
 // exist. Both AlreadyExists results are benign — a log accreting more entries.
 func (h *Handler) ensureLog(ctx context.Context, logID string) error {
@@ -79,8 +114,25 @@ func (h *Handler) ensureLog(ctx context.Context, logID string) error {
 	return nil
 }
 
-// listEntries maps ListLogEntries onto GetLogEvents. The log to read is taken
-// from the filter's `logName=` clause; the project comes from resourceNames.
+// logEntry pairs a driver event with the log id it belongs to, so entries read
+// across many logs still carry their own logName.
+type logEntry struct {
+	logID string
+	event logdriver.LogEvent
+}
+
+// allEntriesLimit fetches every stored event from a log so the wire layer can
+// sort and page across the full set (the driver's Limit truncates by insertion
+// order, which would corrupt a timestamp-ordered page).
+const allEntriesLimit = 1 << 30
+
+// defaultEntriesPageSize bounds a page when the caller sets no pageSize.
+const defaultEntriesPageSize = 1000
+
+// listEntries maps ListLogEntries onto the driver. The log to read is taken from
+// the filter's `logName=` clause; when absent, entries are read across every log
+// in the project (matching `gcloud logging read` / read-all). Results are ordered
+// by timestamp and paged via pageSize/pageToken.
 func (h *Handler) listEntries(w http.ResponseWriter, r *http.Request) {
 	var req listLogEntriesRequest
 	if !gcprest.DecodeJSON(w, r, &req) {
@@ -89,17 +141,7 @@ func (h *Handler) listEntries(w http.ResponseWriter, r *http.Request) {
 
 	project := projectFromResourceNames(req.ResourceNames)
 
-	logID := logIDFromFilter(req.Filter)
-	if logID == "" {
-		gcprest.WriteError(w, http.StatusBadRequest, "invalidArgument",
-			"a logName filter is required to list entries")
-		return
-	}
-
-	events, err := h.logs.GetLogEvents(r.Context(), &logdriver.LogQueryInput{
-		LogGroup: logID,
-		Limit:    req.PageSize,
-	})
+	entries, err := h.gatherEntries(r, project, logIDFromFilter(req.Filter))
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -110,22 +152,84 @@ func (h *Handler) listEntries(w http.ResponseWriter, r *http.Request) {
 	// driver's insertion order matches (out-of-order writes must still sort).
 	desc := strings.Contains(strings.ToLower(req.OrderBy), "desc")
 
-	sorted := make([]logdriver.LogEvent, len(events))
-	copy(sorted, events)
-	sort.SliceStable(sorted, func(i, j int) bool {
+	sort.SliceStable(entries, func(i, j int) bool {
 		if desc {
-			return sorted[i].Timestamp.After(sorted[j].Timestamp)
+			return entries[i].event.Timestamp.After(entries[j].event.Timestamp)
 		}
 
-		return sorted[i].Timestamp.Before(sorted[j].Timestamp)
+		return entries[i].event.Timestamp.Before(entries[j].event.Timestamp)
 	})
 
-	out := make([]logEntryJSON, 0, len(sorted))
-	for i := range sorted {
-		out = append(out, toLogEntryJSON(project, logID, &sorted[i]))
+	page, next := pageEntries(entries, req.PageSize, req.PageToken)
+
+	out := make([]logEntryJSON, 0, len(page))
+	for i := range page {
+		out = append(out, toLogEntryJSON(project, page[i].logID, &page[i].event))
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, listLogEntriesResponse{Entries: out})
+	gcprest.WriteJSON(w, http.StatusOK, listLogEntriesResponse{Entries: out, NextPageToken: next})
+}
+
+// gatherEntries collects the events to list. When logID is set, only that log is
+// read (a missing log is a not-found, as real Cloud Logging surfaces for a
+// single-log filter); when logID is empty, every log in the project is read.
+func (h *Handler) gatherEntries(r *http.Request, project, logID string) ([]logEntry, error) {
+	if logID != "" {
+		events, err := h.logs.GetLogEvents(r.Context(), &logdriver.LogQueryInput{LogGroup: logID, Limit: allEntriesLimit})
+		if err != nil {
+			return nil, err
+		}
+
+		return tagEntries(logID, events), nil
+	}
+
+	groups, err := h.logs.ListLogGroups(r.Context(), scope.Scope{Project: project})
+	if err != nil {
+		return nil, err
+	}
+
+	var all []logEntry
+
+	for i := range groups {
+		events, err := h.logs.GetLogEvents(r.Context(), &logdriver.LogQueryInput{LogGroup: groups[i].Name, Limit: allEntriesLimit})
+		if err != nil {
+			return nil, err
+		}
+
+		all = append(all, tagEntries(groups[i].Name, events)...)
+	}
+
+	return all, nil
+}
+
+func tagEntries(logID string, events []logdriver.LogEvent) []logEntry {
+	out := make([]logEntry, len(events))
+	for i := range events {
+		out[i] = logEntry{logID: logID, event: events[i]}
+	}
+
+	return out
+}
+
+// pageEntries returns the requested page of entries and the token for the next
+// page ("" when the page is the last).
+func pageEntries(entries []logEntry, pageSize int, pageToken string) (page []logEntry, next string) {
+	size := pageSize
+	if size <= 0 {
+		size = defaultEntriesPageSize
+	}
+
+	start := decodePageToken(pageToken)
+	if start > len(entries) {
+		start = len(entries)
+	}
+
+	end := start + size
+	if end >= len(entries) {
+		return entries[start:], ""
+	}
+
+	return entries[start:end], encodePageToken(end)
 }
 
 // listLogs maps ListLogs onto ListLogGroups, returning fully-qualified log

--- a/server/gcp/cloudlogging/sinks.go
+++ b/server/gcp/cloudlogging/sinks.go
@@ -1,0 +1,172 @@
+package cloudlogging
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// logSinkJSON is the Cloud Logging LogSink resource shape.
+type logSinkJSON struct {
+	Name            string `json:"name,omitempty"`
+	Destination     string `json:"destination,omitempty"`
+	Filter          string `json:"filter,omitempty"`
+	Description     string `json:"description,omitempty"`
+	Disabled        bool   `json:"disabled,omitempty"`
+	IncludeChildren bool   `json:"includeChildren,omitempty"`
+	WriterIdentity  string `json:"writerIdentity,omitempty"`
+	CreateTime      string `json:"createTime,omitempty"`
+	UpdateTime      string `json:"updateTime,omitempty"`
+}
+
+type listSinksResponse struct {
+	Sinks         []logSinkJSON `json:"sinks"`
+	NextPageToken string        `json:"nextPageToken,omitempty"`
+}
+
+func (b *logSinkJSON) toDriver(name string) *logdriver.LogSink {
+	return &logdriver.LogSink{
+		Name:            name,
+		Destination:     b.Destination,
+		Filter:          b.Filter,
+		Description:     b.Description,
+		Disabled:        b.Disabled,
+		IncludeChildren: b.IncludeChildren,
+		WriterIdentity:  b.WriterIdentity,
+	}
+}
+
+func toSinkJSON(s *logdriver.LogSink) logSinkJSON {
+	out := logSinkJSON{
+		Name:            s.Name,
+		Destination:     s.Destination,
+		Filter:          s.Filter,
+		Description:     s.Description,
+		Disabled:        s.Disabled,
+		IncludeChildren: s.IncludeChildren,
+		WriterIdentity:  s.WriterIdentity,
+	}
+
+	if !s.CreatedAt.IsZero() {
+		out.CreateTime = s.CreatedAt.UTC().Format(time.RFC3339Nano)
+	}
+
+	if !s.UpdatedAt.IsZero() {
+		out.UpdateTime = s.UpdatedAt.UTC().Format(time.RFC3339Nano)
+	}
+
+	return out
+}
+
+// writeSink writes a single sink or the driver error that produced it.
+func writeSink(w http.ResponseWriter, s *logdriver.LogSink, err error) {
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toSinkJSON(s))
+}
+
+// gcpBackend returns the optional GCP-only logging surface, writing a 501 and
+// returning false when the driver does not implement it.
+func (h *Handler) gcpBackend(w http.ResponseWriter) (logdriver.GCPLogging, bool) {
+	gcp, ok := h.logs.(logdriver.GCPLogging)
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotImplemented, "notImplemented",
+			"this logging backend does not support sinks or log-based metrics")
+		return nil, false
+	}
+
+	return gcp, true
+}
+
+// routeSinks and routeMetrics are deliberately parallel: sinks and log-based
+// metrics are sibling project-scoped REST collections with identical method
+// routing but distinct resource types, so merging them would obscure the wire
+// shapes rather than clarify them.
+//
+//nolint:dupl // parallel-by-design with routeMetrics; see comment above
+func (h *Handler) routeSinks(w http.ResponseWriter, r *http.Request, tail string) {
+	gcp, ok := h.gcpBackend(w)
+	if !ok {
+		return
+	}
+
+	project := projectFromPath(r.URL.Path)
+
+	if tail == "/" {
+		switch r.Method {
+		case http.MethodPost:
+			createSink(w, r, gcp, project)
+		case http.MethodGet:
+			listSinks(w, r, gcp, project)
+		default:
+			writeMethodNotAllowed(w)
+		}
+
+		return
+	}
+
+	sinkID := strings.TrimPrefix(tail, "/")
+
+	switch r.Method {
+	case http.MethodGet:
+		s, err := gcp.GetSink(r.Context(), project, sinkID)
+		writeSink(w, s, err)
+	case http.MethodPut, http.MethodPatch:
+		updateSink(w, r, gcp, project, sinkID)
+	case http.MethodDelete:
+		deleteResource(w, gcp.DeleteSink(r.Context(), project, sinkID))
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func createSink(w http.ResponseWriter, r *http.Request, gcp logdriver.GCPLogging, project string) {
+	var body logSinkJSON
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	s, err := gcp.CreateSink(r.Context(), project, body.toDriver(body.Name))
+	writeSink(w, s, err)
+}
+
+func updateSink(w http.ResponseWriter, r *http.Request, gcp logdriver.GCPLogging, project, sinkID string) {
+	var body logSinkJSON
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	s, err := gcp.UpdateSink(r.Context(), project, body.toDriver(sinkID))
+	writeSink(w, s, err)
+}
+
+func listSinks(w http.ResponseWriter, r *http.Request, gcp logdriver.GCPLogging, project string) {
+	sinks, err := gcp.ListSinks(r.Context(), project)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]logSinkJSON, 0, len(sinks))
+	for i := range sinks {
+		out = append(out, toSinkJSON(&sinks[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listSinksResponse{Sinks: out})
+}
+
+// deleteResource writes the empty success body for a delete, or the driver error.
+func deleteResource(w http.ResponseWriter, err error) {
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, struct{}{})
+}

--- a/server/gcp/cloudlogging/sinks_sdk_test.go
+++ b/server/gcp/cloudlogging/sinks_sdk_test.go
@@ -1,0 +1,90 @@
+package cloudlogging_test
+
+import (
+	"context"
+	"testing"
+
+	logging "google.golang.org/api/logging/v2"
+)
+
+// TestSDKSinksLifecycle guards create/get/list/update/delete of export sinks.
+func TestSDKSinksLifecycle(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject
+	sinkName := parent + "/sinks/my-sink"
+
+	created, err := svc.Projects.Sinks.Create(parent, &logging.LogSink{
+		Name:        "my-sink",
+		Destination: "storage.googleapis.com/my-bucket",
+		Filter:      `severity>=ERROR`,
+		Description: "errors to GCS",
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Sinks.Create: %v", err)
+	}
+
+	if created.Name != "my-sink" {
+		t.Errorf("created sink name = %q, want my-sink", created.Name)
+	}
+
+	if created.WriterIdentity == "" {
+		t.Error("created sink has no writerIdentity")
+	}
+
+	got, err := svc.Projects.Sinks.Get(sinkName).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Sinks.Get: %v", err)
+	}
+
+	if got.Destination != "storage.googleapis.com/my-bucket" {
+		t.Errorf("get destination = %q", got.Destination)
+	}
+
+	list, err := svc.Projects.Sinks.List(parent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Sinks.List: %v", err)
+	}
+
+	if len(list.Sinks) != 1 || list.Sinks[0].Name != "my-sink" {
+		t.Fatalf("Sinks.List = %+v, want one my-sink", list.Sinks)
+	}
+
+	updated, err := svc.Projects.Sinks.Update(sinkName, &logging.LogSink{
+		Name:        "my-sink",
+		Destination: "storage.googleapis.com/other-bucket",
+		Filter:      `severity>=WARNING`,
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Sinks.Update: %v", err)
+	}
+
+	if updated.Destination != "storage.googleapis.com/other-bucket" {
+		t.Errorf("updated destination = %q", updated.Destination)
+	}
+
+	if _, err := svc.Projects.Sinks.Delete(sinkName).Context(ctx).Do(); err != nil {
+		t.Fatalf("Sinks.Delete: %v", err)
+	}
+
+	after, err := svc.Projects.Sinks.List(parent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Sinks.List after delete: %v", err)
+	}
+
+	if len(after.Sinks) != 0 {
+		t.Fatalf("sink still present after delete: %+v", after.Sinks)
+	}
+}
+
+// TestSDKSinksGetMissing guards a not-found error for an unknown sink.
+func TestSDKSinksGetMissing(t *testing.T) {
+	svc := newLoggingService(t)
+
+	_, err := svc.Projects.Sinks.Get("projects/" + testProject + "/sinks/nope").
+		Context(context.Background()).Do()
+	if err == nil {
+		t.Fatal("Sinks.Get(missing): want error, got nil")
+	}
+}

--- a/server/gcp/cloudlogging/types.go
+++ b/server/gcp/cloudlogging/types.go
@@ -1,8 +1,12 @@
 package cloudlogging
 
 import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,23 +18,34 @@ import (
 // (severity, jsonPayload, labels, insertId) are JSON-enveloped into it on
 // write and reconstructed on read — see encode/decodeEntryPayload.
 type logEntryJSON struct {
-	LogName     string            `json:"logName,omitempty"`
-	Timestamp   string            `json:"timestamp,omitempty"`
-	TextPayload string            `json:"textPayload,omitempty"`
-	JSONPayload map[string]any    `json:"jsonPayload,omitempty"`
-	InsertID    string            `json:"insertId,omitempty"`
-	Severity    string            `json:"severity,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
+	LogName          string             `json:"logName,omitempty"`
+	Timestamp        string             `json:"timestamp,omitempty"`
+	ReceiveTimestamp string             `json:"receiveTimestamp,omitempty"`
+	TextPayload      string             `json:"textPayload,omitempty"`
+	JSONPayload      map[string]any     `json:"jsonPayload,omitempty"`
+	InsertID         string             `json:"insertId,omitempty"`
+	Severity         string             `json:"severity,omitempty"`
+	Labels           map[string]string  `json:"labels,omitempty"`
+	Resource         *monitoredResource `json:"resource,omitempty"`
+}
+
+// monitoredResource is the Cloud Logging MonitoredResource attached to every
+// entry (its type plus type-specific labels, e.g. gce_instance / global).
+type monitoredResource struct {
+	Type   string            `json:"type,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // entryPayload is the JSON envelope stored in the driver's message string so a
 // log entry's structured fields survive a write→read round-trip.
 type entryPayload struct {
-	Text        string            `json:"t,omitempty"`
-	JSONPayload map[string]any    `json:"j,omitempty"`
-	Severity    string            `json:"s,omitempty"`
-	InsertID    string            `json:"i,omitempty"`
-	Labels      map[string]string `json:"l,omitempty"`
+	Text           string            `json:"t,omitempty"`
+	JSONPayload    map[string]any    `json:"j,omitempty"`
+	Severity       string            `json:"s,omitempty"`
+	InsertID       string            `json:"i,omitempty"`
+	Labels         map[string]string `json:"l,omitempty"`
+	ResourceType   string            `json:"rt,omitempty"`
+	ResourceLabels map[string]string `json:"rl,omitempty"`
 }
 
 // entryPayloadPrefix marks a driver message that carries an encoded envelope.
@@ -40,17 +55,23 @@ const entryPayloadPrefix = "\x00cloudemu-log\x00"
 func encodeEntryPayload(e *logEntryJSON) string {
 	// Plain text with no structured fields stays a bare string, so logs written
 	// by other means still read back naturally.
-	if e.Severity == "" && e.InsertID == "" && len(e.JSONPayload) == 0 && len(e.Labels) == 0 {
+	if e.Severity == "" && e.InsertID == "" && len(e.JSONPayload) == 0 && len(e.Labels) == 0 && e.Resource == nil {
 		return e.TextPayload
 	}
 
-	b, err := json.Marshal(entryPayload{
+	p := entryPayload{
 		Text:        e.TextPayload,
 		JSONPayload: e.JSONPayload,
 		Severity:    e.Severity,
 		InsertID:    e.InsertID,
 		Labels:      e.Labels,
-	})
+	}
+	if e.Resource != nil {
+		p.ResourceType = e.Resource.Type
+		p.ResourceLabels = e.Resource.Labels
+	}
+
+	b, err := json.Marshal(p)
 	if err != nil {
 		return e.TextPayload
 	}
@@ -75,13 +96,19 @@ func decodeEntryPayload(msg string, out *logEntryJSON) {
 	out.Severity = p.Severity
 	out.InsertID = p.InsertID
 	out.Labels = p.Labels
+
+	if p.ResourceType != "" || len(p.ResourceLabels) > 0 {
+		out.Resource = &monitoredResource{Type: p.ResourceType, Labels: p.ResourceLabels}
+	}
 }
 
 // writeLogEntriesRequest is the entries:write body. logName/resource may be set
 // at the request level and inherited by entries that omit their own logName.
 type writeLogEntriesRequest struct {
-	LogName string         `json:"logName"`
-	Entries []logEntryJSON `json:"entries"`
+	LogName  string             `json:"logName"`
+	Resource *monitoredResource `json:"resource"`
+	Labels   map[string]string  `json:"labels"`
+	Entries  []logEntryJSON     `json:"entries"`
 }
 
 // listLogEntriesRequest is the entries:list body.
@@ -89,11 +116,13 @@ type listLogEntriesRequest struct {
 	ResourceNames []string `json:"resourceNames"`
 	Filter        string   `json:"filter"`
 	PageSize      int      `json:"pageSize"`
+	PageToken     string   `json:"pageToken"`
 	OrderBy       string   `json:"orderBy"`
 }
 
 type listLogEntriesResponse struct {
-	Entries []logEntryJSON `json:"entries"`
+	Entries       []logEntryJSON `json:"entries"`
+	NextPageToken string         `json:"nextPageToken,omitempty"`
 }
 
 type listLogsResponse struct {
@@ -215,6 +244,48 @@ func logIDFromFilter(filter string) string {
 	return logIDFromName(rest)
 }
 
+// insertIDBytes is the entropy of a generated insertId (16 bytes → 32 hex chars).
+const insertIDBytes = 16
+
+// genInsertID returns an opaque unique insertId, mirroring the server-assigned id
+// real Cloud Logging generates for entries that omit their own. Clients dedupe on
+// it, so it must be unique per entry.
+func genInsertID() string {
+	b := make([]byte, insertIDBytes)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand failure is unexpected; fall back to a time-based id so an
+		// entry is never dropped for want of an insertId.
+		return strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+
+	return hex.EncodeToString(b)
+}
+
+// encodePageToken encodes a next-entry offset into an opaque list page token.
+func encodePageToken(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}
+
+// decodePageToken recovers the offset from a page token. A malformed or empty
+// token yields offset 0 (start from the beginning).
+func decodePageToken(tok string) int {
+	if tok == "" {
+		return 0
+	}
+
+	b, err := base64.StdEncoding.DecodeString(tok)
+	if err != nil {
+		return 0
+	}
+
+	n, err := strconv.Atoi(string(b))
+	if err != nil || n < 0 {
+		return 0
+	}
+
+	return n
+}
+
 // parseTimestamp parses an RFC3339(Nano) Cloud Logging timestamp. A zero/empty
 // or unparseable value yields the current time so an entry is never dropped for
 // a bad clock.
@@ -237,6 +308,21 @@ func toLogEntryJSON(project, logID string, e *logdriver.LogEvent) logEntryJSON {
 	}
 
 	decodeEntryPayload(e.Message, &out)
+
+	// receiveTimestamp is the wall-clock ingestion time recorded at write; clients
+	// use it to distinguish event time from delivery time.
+	if !e.IngestionTime.IsZero() {
+		out.ReceiveTimestamp = e.IngestionTime.UTC().Format(time.RFC3339Nano)
+	}
+
+	// Every entry carries a MonitoredResource. Default to the "global" resource
+	// scoped to the project when the writer supplied none, mirroring real GCP.
+	if out.Resource == nil {
+		out.Resource = &monitoredResource{
+			Type:   "global",
+			Labels: map[string]string{"project_id": project},
+		}
+	}
 
 	return out
 }

--- a/services/logging/driver/gcp.go
+++ b/services/logging/driver/gcp.go
@@ -1,0 +1,54 @@
+package driver
+
+import (
+	"context"
+	"time"
+)
+
+// LogSink is a Cloud Logging export sink (logging.projects.sinks). It selects
+// entries with a filter and forwards them to a destination (a GCS bucket, BigQuery
+// dataset, or Pub/Sub topic). It has no cross-provider equivalent, so it lives on
+// the optional GCPLogging interface rather than the portable Logging interface.
+type LogSink struct {
+	Name            string
+	Destination     string
+	Filter          string
+	Description     string
+	Disabled        bool
+	WriterIdentity  string
+	IncludeChildren bool
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+// LogBasedMetric is a Cloud Logging log-based metric (logging.projects.metrics):
+// a counter/distribution metric whose value is derived from matching log entries.
+type LogBasedMetric struct {
+	Name           string
+	Description    string
+	Filter         string
+	ValueExtractor string
+	MetricKind     string
+	ValueType      string
+	Unit           string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// GCPLogging is an optional interface implemented by the GCP logging backend for
+// Cloud Logging resource surfaces (export sinks, log-based metrics) that have no
+// portable, cross-provider equivalent. The Cloud Logging wire handler type-asserts
+// for it; AWS and Azure backends do not implement it.
+type GCPLogging interface {
+	CreateSink(ctx context.Context, project string, sink *LogSink) (*LogSink, error)
+	GetSink(ctx context.Context, project, name string) (*LogSink, error)
+	ListSinks(ctx context.Context, project string) ([]LogSink, error)
+	UpdateSink(ctx context.Context, project string, sink *LogSink) (*LogSink, error)
+	DeleteSink(ctx context.Context, project, name string) error
+
+	CreateLogMetric(ctx context.Context, project string, metric *LogBasedMetric) (*LogBasedMetric, error)
+	GetLogMetric(ctx context.Context, project, name string) (*LogBasedMetric, error)
+	ListLogMetrics(ctx context.Context, project string) ([]LogBasedMetric, error)
+	UpdateLogMetric(ctx context.Context, project string, metric *LogBasedMetric) (*LogBasedMetric, error)
+	DeleteLogMetric(ctx context.Context, project, name string) error
+}


### PR DESCRIPTION
## What & why

Fixes the 5 GCP Cloud Logging findings from the audit. Each is a behavior a real `google.golang.org/api/logging/v2` client (or `gcloud logging`) hits against the wire server.

## Findings fixed

1. **[HIGH] entries.list logName now optional** — a request with only `resourceNames` (no `logName=` filter) previously returned 400. It now reads across every log in the project (matching `gcloud logging read` / read-all). A single-log `logName=` filter still surfaces not-found for a missing log, as before.
2. **[HIGH] entries.list metadata fields** — entries now return `insertId` (server-assigned when the writer omits one), `resource` (MonitoredResource, defaulting to the `global` resource for the project), and `receiveTimestamp` (ingestion time). A written resource round-trips.
3. **[HIGH] projects.sinks** — full create/get/list/update/delete for export sinks (`google_logging_project_sink`), including a server-assigned `writerIdentity`.
4. **[MEDIUM] entries.list pagination** — `pageSize` is now a page size, not a hard limit; responses carry `nextPageToken` and `pageToken` walks all pages.
5. **[MEDIUM] projects.metrics** — full CRUD for log-based metrics.

## Design

Sinks and log-based metrics have no cross-provider equivalent, so they are served through a new **optional `driver.GCPLogging` interface** (type-asserted by the wire handler) rather than widening the portable `driver.Logging` interface — AWS/Azure backends are untouched. `docs/coverage` regenerated via `go generate` (the new optional interface now shows under "Optional capabilities").

## Tests

Reproduction tests using the real `logging/v2` client against the in-process GCP server: `entries_list_sdk_test.go` (read-all, metadata, default resource, pagination), `sinks_sdk_test.go`, `metrics_sdk_test.go`. Existing logging tests stay green.

## Gates

build, vet, scoped tests, `-race` on the mutated provider, gofmt, and golangci-lint (zero new issues) all green.