### PR TITLE
fix(gcp-lb): backendServices patch, healthChecks/targetPools/urlMaps CRUD, forwardingRule fields, dup-name 409

### DIFF
--- a/docs/coverage/aws/elb.md
+++ b/docs/coverage/aws/elb.md
@@ -46,6 +46,25 @@ AzureLoadBalancers is an OPTIONAL, type-asserted capability. The Azure
 | `UpsertAzureLBBackendPool` | UpsertAzureLBBackendPool adds poolName to the load balancer's backend |
 | `UpsertAzureLBNatRule` | UpsertAzureLBNatRule creates or replaces a single inbound NAT rule by |
 
+### GCPBackendServicePatcher
+
+GCPBackendServicePatcher is an OPTIONAL, type-asserted capability implemented
+
+| Operation | Description |
+| --- | --- |
+| `PatchGCPBackendService` | PatchGCPBackendService looks up the target group by its GCP name and |
+
+### GCPComputeResourceStore
+
+GCPComputeResourceStore is an OPTIONAL, type-asserted capability implemented
+
+| Operation | Description |
+| --- | --- |
+| `DeleteGCPResource` | DeleteGCPResource removes the resource, returning NotFound when absent. |
+| `GetGCPResource` | GetGCPResource returns the stored resource, or NotFound. |
+| `ListGCPResources` | ListGCPResources returns every resource in a (collection, scope) bucket. |
+| `PutGCPResource` | PutGCPResource stores res, returning AlreadyExists when a resource with |
+
 ### LBAttributeUpdater
 
 LBAttributeUpdater is implemented by drivers that can apply a partial

--- a/docs/coverage/azure/lb.md
+++ b/docs/coverage/azure/lb.md
@@ -46,6 +46,25 @@ AzureLoadBalancers is an OPTIONAL, type-asserted capability. The Azure
 | `UpsertAzureLBBackendPool` | UpsertAzureLBBackendPool adds poolName to the load balancer's backend |
 | `UpsertAzureLBNatRule` | UpsertAzureLBNatRule creates or replaces a single inbound NAT rule by |
 
+### GCPBackendServicePatcher
+
+GCPBackendServicePatcher is an OPTIONAL, type-asserted capability implemented
+
+| Operation | Description |
+| --- | --- |
+| `PatchGCPBackendService` | PatchGCPBackendService looks up the target group by its GCP name and |
+
+### GCPComputeResourceStore
+
+GCPComputeResourceStore is an OPTIONAL, type-asserted capability implemented
+
+| Operation | Description |
+| --- | --- |
+| `DeleteGCPResource` | DeleteGCPResource removes the resource, returning NotFound when absent. |
+| `GetGCPResource` | GetGCPResource returns the stored resource, or NotFound. |
+| `ListGCPResources` | ListGCPResources returns every resource in a (collection, scope) bucket. |
+| `PutGCPResource` | PutGCPResource stores res, returning AlreadyExists when a resource with |
+
 ### LBAttributeUpdater
 
 LBAttributeUpdater is implemented by drivers that can apply a partial

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -5694,6 +5694,38 @@
         ]
       },
       {
+        "name": "GCPBackendServicePatcher",
+        "doc": "GCPBackendServicePatcher is an OPTIONAL, type-asserted capability implemented",
+        "operations": [
+          {
+            "name": "PatchGCPBackendService",
+            "doc": "PatchGCPBackendService looks up the target group by its GCP name and"
+          }
+        ]
+      },
+      {
+        "name": "GCPComputeResourceStore",
+        "doc": "GCPComputeResourceStore is an OPTIONAL, type-asserted capability implemented",
+        "operations": [
+          {
+            "name": "DeleteGCPResource",
+            "doc": "DeleteGCPResource removes the resource, returning NotFound when absent."
+          },
+          {
+            "name": "GetGCPResource",
+            "doc": "GetGCPResource returns the stored resource, or NotFound."
+          },
+          {
+            "name": "ListGCPResources",
+            "doc": "ListGCPResources returns every resource in a (collection, scope) bucket."
+          },
+          {
+            "name": "PutGCPResource",
+            "doc": "PutGCPResource stores res, returning AlreadyExists when a resource with"
+          }
+        ]
+      },
+      {
         "name": "LBAttributeUpdater",
         "doc": "LBAttributeUpdater is implemented by drivers that can apply a partial",
         "operations": [

--- a/docs/coverage/gcp/lb.md
+++ b/docs/coverage/gcp/lb.md
@@ -46,6 +46,25 @@ AzureLoadBalancers is an OPTIONAL, type-asserted capability. The Azure
 | `UpsertAzureLBBackendPool` | UpsertAzureLBBackendPool adds poolName to the load balancer's backend |
 | `UpsertAzureLBNatRule` | UpsertAzureLBNatRule creates or replaces a single inbound NAT rule by |
 
+### GCPBackendServicePatcher
+
+GCPBackendServicePatcher is an OPTIONAL, type-asserted capability implemented
+
+| Operation | Description |
+| --- | --- |
+| `PatchGCPBackendService` | PatchGCPBackendService looks up the target group by its GCP name and |
+
+### GCPComputeResourceStore
+
+GCPComputeResourceStore is an OPTIONAL, type-asserted capability implemented
+
+| Operation | Description |
+| --- | --- |
+| `DeleteGCPResource` | DeleteGCPResource removes the resource, returning NotFound when absent. |
+| `GetGCPResource` | GetGCPResource returns the stored resource, or NotFound. |
+| `ListGCPResources` | ListGCPResources returns every resource in a (collection, scope) bucket. |
+| `PutGCPResource` | PutGCPResource stores res, returning AlreadyExists when a resource with |
+
 ### LBAttributeUpdater
 
 LBAttributeUpdater is implemented by drivers that can apply a partial

--- a/providers/gcp/loadbalancer/gcp_resources.go
+++ b/providers/gcp/loadbalancer/gcp_resources.go
@@ -1,0 +1,81 @@
+package loadbalancer
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+)
+
+// Compile-time checks that Mock implements the GCP-specific optional interfaces.
+var (
+	_ driver.GCPComputeResourceStore  = (*Mock)(nil)
+	_ driver.GCPBackendServicePatcher = (*Mock)(nil)
+)
+
+// gcpResourceKey builds the store key for an opaque GCP resource. The NUL
+// separator can't collide with a project/region/name segment.
+func gcpResourceKey(collection, scope, name string) string {
+	return collection + "\x00" + scope + "\x00" + name
+}
+
+// PutGCPResource stores an opaque GCP Compute Load Balancing resource, returning
+// AlreadyExists when the (collection, scope, name) triple is already taken.
+//
+//nolint:gocritic // hugeParam: interface method signature is fixed.
+func (m *Mock) PutGCPResource(_ context.Context, res driver.GCPResource) error {
+	key := gcpResourceKey(res.Collection, res.Scope, res.Name)
+	if !m.gcpResources.SetIfAbsent(key, res) {
+		return cerrors.Newf(cerrors.AlreadyExists, "%s %q already exists", res.Collection, res.Name)
+	}
+
+	return nil
+}
+
+// GetGCPResource returns the stored opaque resource or NotFound.
+func (m *Mock) GetGCPResource(_ context.Context, collection, scope, name string) (*driver.GCPResource, error) {
+	res, ok := m.gcpResources.Get(gcpResourceKey(collection, scope, name))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "%s %q not found", collection, name)
+	}
+
+	result := res
+
+	return &result, nil
+}
+
+// ListGCPResources returns every opaque resource in a (collection, scope) bucket.
+func (m *Mock) ListGCPResources(_ context.Context, collection, scope string) ([]driver.GCPResource, error) {
+	return filterToSlice(m.gcpResources, func(_ string, res driver.GCPResource) bool {
+		return res.Collection == collection && res.Scope == scope
+	}), nil
+}
+
+// DeleteGCPResource removes an opaque resource, returning NotFound when absent.
+func (m *Mock) DeleteGCPResource(_ context.Context, collection, scope, name string) error {
+	if !m.gcpResources.Delete(gcpResourceKey(collection, scope, name)) {
+		return cerrors.Newf(cerrors.NotFound, "%s %q not found", collection, name)
+	}
+
+	return nil
+}
+
+// PatchGCPBackendService applies mutate to the target group named name, holding
+// the store lock across the read-modify-write. Returns NotFound when no backend
+// service with that name exists.
+func (m *Mock) PatchGCPBackendService(_ context.Context, name string, mutate func(*driver.TargetGroupInfo)) error {
+	// CreateTargetGroup keys the store by GCPID(project, "backendServices", name),
+	// so the ARN is derivable from the name without scanning.
+	arn := idgen.GCPID(m.opts.ProjectID, "backendServices", name)
+
+	updated := m.tgs.Update(arn, func(tg driver.TargetGroupInfo) driver.TargetGroupInfo {
+		mutate(&tg)
+		return tg
+	})
+	if !updated {
+		return cerrors.Newf(cerrors.NotFound, "backend service %q not found", name)
+	}
+
+	return nil
+}

--- a/providers/gcp/loadbalancer/lb.go
+++ b/providers/gcp/loadbalancer/lb.go
@@ -27,6 +27,10 @@ type Mock struct {
 	rules     *memstore.Store[driver.RuleInfo]
 	opts      *config.Options
 
+	// gcpResources holds opaque GCP-only Compute Load Balancing resources
+	// (healthChecks, targetPools, urlMaps) keyed by "collection\x00scope\x00name".
+	gcpResources *memstore.Store[driver.GCPResource]
+
 	healthMu sync.RWMutex
 	health   map[string]map[string]*driver.TargetHealth // tgARN -> targetID -> health
 
@@ -37,13 +41,14 @@ type Mock struct {
 // New creates a new Cloud Load Balancing mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		lbs:       memstore.New[driver.LBInfo](),
-		tgs:       memstore.New[driver.TargetGroupInfo](),
-		listeners: memstore.New[driver.ListenerInfo](),
-		rules:     memstore.New[driver.RuleInfo](),
-		opts:      opts,
-		health:    make(map[string]map[string]*driver.TargetHealth),
-		attrs:     make(map[string]driver.LBAttributes),
+		lbs:          memstore.New[driver.LBInfo](),
+		tgs:          memstore.New[driver.TargetGroupInfo](),
+		listeners:    memstore.New[driver.ListenerInfo](),
+		rules:        memstore.New[driver.RuleInfo](),
+		opts:         opts,
+		gcpResources: memstore.New[driver.GCPResource](),
+		health:       make(map[string]map[string]*driver.TargetHealth),
+		attrs:        make(map[string]driver.LBAttributes),
 	}
 }
 

--- a/server/gcp/loadbalancer/backendservices_sdk_test.go
+++ b/server/gcp/loadbalancer/backendservices_sdk_test.go
@@ -1,0 +1,175 @@
+package loadbalancer_test
+
+import (
+	"context"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/option"
+)
+
+func ptrI32(v int32) *int32 { return &v }
+
+// TestSDKGCPBackendServicePatch reproduces the [BLOCKER] finding that
+// compute.backendServices.patch returned 405 (no update path), leaving the
+// resource read-only after create.
+func TestSDKGCPBackendServicePatch(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewBackendServicesRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertBackendServiceRequest{
+		Project: testProject,
+		BackendServiceResource: &computepb.BackendService{
+			Name:                ptrStr("web-bs"),
+			Protocol:            ptrStr("HTTP"),
+			TimeoutSec:          ptrI32(30),
+			LoadBalancingScheme: ptrStr("EXTERNAL_MANAGED"),
+			SessionAffinity:     ptrStr("NONE"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	// Patch must succeed (previously 405) and mutate the resource.
+	patchOp, err := client.Patch(ctx, &computepb.PatchBackendServiceRequest{
+		Project:        testProject,
+		BackendService: "web-bs",
+		BackendServiceResource: &computepb.BackendService{
+			TimeoutSec:      ptrI32(45),
+			SessionAffinity: ptrStr("CLIENT_IP"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	if err := patchOp.Wait(ctx); err != nil {
+		t.Fatalf("Patch wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetBackendServiceRequest{Project: testProject, BackendService: "web-bs"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetTimeoutSec() != 45 {
+		t.Errorf("timeoutSec = %d, want 45 (patch not applied)", got.GetTimeoutSec())
+	}
+
+	if got.GetSessionAffinity() != "CLIENT_IP" {
+		t.Errorf("sessionAffinity = %q, want CLIENT_IP", got.GetSessionAffinity())
+	}
+
+	// Protocol was not in the patch body, so it must be preserved.
+	if got.GetProtocol() != "HTTP" {
+		t.Errorf("protocol = %q, want HTTP (patch clobbered an omitted field)", got.GetProtocol())
+	}
+}
+
+// TestSDKGCPBackendServiceFields reproduces the [HIGH] finding that
+// loadBalancingScheme/timeoutSec/sessionAffinity/fingerprint/creationTimestamp
+// were all dropped on get.
+func TestSDKGCPBackendServiceFields(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewBackendServicesRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	op, err := client.Insert(ctx, &computepb.InsertBackendServiceRequest{
+		Project: testProject,
+		BackendServiceResource: &computepb.BackendService{
+			Name:                ptrStr("full-bs"),
+			Protocol:            ptrStr("HTTP"),
+			LoadBalancingScheme: ptrStr("INTERNAL_MANAGED"),
+			SessionAffinity:     ptrStr("CLIENT_IP"),
+			TimeoutSec:          ptrI32(25),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetBackendServiceRequest{Project: testProject, BackendService: "full-bs"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetLoadBalancingScheme() != "INTERNAL_MANAGED" {
+		t.Errorf("loadBalancingScheme = %q, want INTERNAL_MANAGED", got.GetLoadBalancingScheme())
+	}
+
+	if got.GetSessionAffinity() != "CLIENT_IP" {
+		t.Errorf("sessionAffinity = %q, want CLIENT_IP", got.GetSessionAffinity())
+	}
+
+	if got.GetTimeoutSec() != 25 {
+		t.Errorf("timeoutSec = %d, want 25", got.GetTimeoutSec())
+	}
+
+	if got.GetFingerprint() == "" {
+		t.Error("fingerprint empty; blocks all future patches")
+	}
+
+	if got.GetCreationTimestamp() == "" {
+		t.Error("creationTimestamp empty")
+	}
+}
+
+// TestSDKGCPBackendServiceDuplicate reproduces the #643-deferred portion: a
+// duplicate-name insert must fail with 409 alreadyExists, not silently succeed.
+func TestSDKGCPBackendServiceDuplicate(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewBackendServicesRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	insert := func() error {
+		op, err := client.Insert(ctx, &computepb.InsertBackendServiceRequest{
+			Project:                testProject,
+			BackendServiceResource: &computepb.BackendService{Name: ptrStr("dup-bs"), Protocol: ptrStr("TCP")},
+		})
+		if err != nil {
+			return err
+		}
+
+		return op.Wait(ctx)
+	}
+
+	if err := insert(); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+
+	if err := insert(); err == nil {
+		t.Fatal("second insert of duplicate name: want error, got nil")
+	}
+}

--- a/server/gcp/loadbalancer/forwardingrules_sdk_test.go
+++ b/server/gcp/loadbalancer/forwardingrules_sdk_test.go
@@ -1,0 +1,110 @@
+package loadbalancer_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/option"
+)
+
+func newForwardingRulesClient(t *testing.T, url string, httpc option.ClientOption) *gcpcompute.GlobalForwardingRulesClient {
+	t.Helper()
+
+	client, err := gcpcompute.NewGlobalForwardingRulesRESTClient(context.Background(),
+		option.WithEndpoint(url), option.WithoutAuthentication(), httpc)
+	if err != nil {
+		t.Fatalf("NewGlobalForwardingRulesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+// TestSDKGCPForwardingRuleNoBackendFields reproduces three findings on
+// forwardingRules.get when the rule has no linked backend service:
+//   - [HIGH] portRange lost;
+//   - [MEDIUM] IPAddress returned as a hostname, not an IPv4/IPv6 string;
+//   - [MEDIUM] loadBalancingScheme collapsed EXTERNAL_MANAGED → EXTERNAL.
+//
+// It also covers the #643-deferred creationTimestamp.
+func TestSDKGCPForwardingRuleNoBackendFields(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	client := newForwardingRulesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+
+	op, err := client.Insert(ctx, &computepb.InsertGlobalForwardingRuleRequest{
+		Project: testProject,
+		ForwardingRuleResource: &computepb.ForwardingRule{
+			Name:                ptrStr("edge-fr"),
+			IPProtocol:          ptrStr("TCP"),
+			PortRange:           ptrStr("443"),
+			LoadBalancingScheme: ptrStr("EXTERNAL_MANAGED"),
+			// No backendService: exercises the field-round-trip path.
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetGlobalForwardingRuleRequest{Project: testProject, ForwardingRule: "edge-fr"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetPortRange() != "443" {
+		t.Errorf("portRange = %q, want 443 (lost without a backend service)", got.GetPortRange())
+	}
+
+	if got.GetLoadBalancingScheme() != "EXTERNAL_MANAGED" {
+		t.Errorf("loadBalancingScheme = %q, want EXTERNAL_MANAGED (collapsed)", got.GetLoadBalancingScheme())
+	}
+
+	if ip := net.ParseIP(got.GetIPAddress()); ip == nil {
+		t.Errorf("IPAddress = %q, want a parseable IP, not a hostname", got.GetIPAddress())
+	}
+
+	if got.GetCreationTimestamp() == "" {
+		t.Error("creationTimestamp empty")
+	}
+}
+
+// TestSDKGCPForwardingRuleDuplicate reproduces the #643-deferred portion: a
+// duplicate-name insert must fail with 409, not silently succeed.
+func TestSDKGCPForwardingRuleDuplicate(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	client := newForwardingRulesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+
+	insert := func() error {
+		op, err := client.Insert(ctx, &computepb.InsertGlobalForwardingRuleRequest{
+			Project: testProject,
+			ForwardingRuleResource: &computepb.ForwardingRule{
+				Name:      ptrStr("dup-fr"),
+				PortRange: ptrStr("80"),
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		return op.Wait(ctx)
+	}
+
+	if err := insert(); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+
+	if err := insert(); err == nil {
+		t.Fatal("duplicate forwarding rule insert: want error, got nil")
+	}
+}

--- a/server/gcp/loadbalancer/handler.go
+++ b/server/gcp/loadbalancer/handler.go
@@ -72,7 +72,8 @@ func (*Handler) Matches(r *http.Request) bool {
 	}
 
 	switch rp.ResourceType {
-	case resourceBackendServices, resourceForwardingRules:
+	case resourceBackendServices, resourceForwardingRules,
+		resourceHealthChecks, resourceTargetPools, resourceURLMaps:
 		return true
 	}
 
@@ -92,12 +93,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routeBackendServices(w, r, rp)
 	case resourceForwardingRules:
 		h.routeForwardingRules(w, r, rp)
+	case resourceHealthChecks, resourceTargetPools, resourceURLMaps:
+		h.routeGCPResource(w, r, rp)
 	default:
 		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unknown resource type")
 	}
 }
 
-//nolint:gocritic,dupl // rp is a request-scoped value; CRUD route shape is duplicate-by-design across resource types
+//nolint:gocritic // rp is a request-scoped value
 func (h *Handler) routeBackendServices(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
 	if rp.ResourceName == "" {
 		switch r.Method {
@@ -115,6 +118,8 @@ func (h *Handler) routeBackendServices(w http.ResponseWriter, r *http.Request, r
 	switch r.Method {
 	case http.MethodGet:
 		h.getBackendService(w, r, rp)
+	case http.MethodPatch, http.MethodPut:
+		h.patchBackendService(w, r, rp)
 	case http.MethodDelete:
 		h.deleteBackendService(w, r, rp)
 	default:

--- a/server/gcp/loadbalancer/healthchecks_sdk_test.go
+++ b/server/gcp/loadbalancer/healthchecks_sdk_test.go
@@ -1,0 +1,120 @@
+package loadbalancer_test
+
+import (
+	"context"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+// TestSDKGCPHealthCheckRoundTrip reproduces the [BLOCKER] finding that the
+// healthChecks collection was entirely unrouted (501), so no L4/L7 LB could be
+// provisioned. Insert/Get/List/Delete must now round-trip.
+func TestSDKGCPHealthCheckRoundTrip(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewHealthChecksRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewHealthChecksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	op, err := client.Insert(ctx, &computepb.InsertHealthCheckRequest{
+		Project: testProject,
+		HealthCheckResource: &computepb.HealthCheck{
+			Name: ptrStr("hc1"),
+			Type: ptrStr("HTTP"),
+			HttpHealthCheck: &computepb.HTTPHealthCheck{
+				Port:        ptrI32(80),
+				RequestPath: ptrStr("/healthz"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetHealthCheckRequest{Project: testProject, HealthCheck: "hc1"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetName() != "hc1" {
+		t.Fatalf("name = %q, want hc1", got.GetName())
+	}
+
+	if got.GetType() != "HTTP" {
+		t.Errorf("type = %q, want HTTP", got.GetType())
+	}
+
+	if got.GetHttpHealthCheck().GetRequestPath() != "/healthz" {
+		t.Errorf("requestPath = %q, want /healthz", got.GetHttpHealthCheck().GetRequestPath())
+	}
+
+	if got.GetHttpHealthCheck().GetPort() != 80 {
+		t.Errorf("port = %d, want 80", got.GetHttpHealthCheck().GetPort())
+	}
+
+	if got.GetCreationTimestamp() == "" {
+		t.Error("creationTimestamp empty")
+	}
+
+	// List.
+	var names []string
+
+	it := client.List(ctx, &computepb.ListHealthChecksRequest{Project: testProject})
+
+	for {
+		hc, iErr := it.Next()
+		if iErr == iterator.Done {
+			break
+		}
+
+		if iErr != nil {
+			t.Fatalf("List: %v", iErr)
+		}
+
+		names = append(names, hc.GetName())
+	}
+
+	if len(names) != 1 || names[0] != "hc1" {
+		t.Fatalf("list = %v, want [hc1]", names)
+	}
+
+	// Duplicate insert → 409.
+	dupOp, err := client.Insert(ctx, &computepb.InsertHealthCheckRequest{
+		Project:             testProject,
+		HealthCheckResource: &computepb.HealthCheck{Name: ptrStr("hc1"), Type: ptrStr("TCP")},
+	})
+	if err == nil {
+		err = dupOp.Wait(ctx)
+	}
+
+	if err == nil {
+		t.Error("duplicate healthCheck insert: want error, got nil")
+	}
+
+	// Delete then Get → not found.
+	delOp, err := client.Delete(ctx, &computepb.DeleteHealthCheckRequest{Project: testProject, HealthCheck: "hc1"})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Fatalf("Delete wait: %v", err)
+	}
+
+	if _, err := client.Get(ctx, &computepb.GetHealthCheckRequest{Project: testProject, HealthCheck: "hc1"}); err == nil {
+		t.Fatal("Get after delete: want error, got nil")
+	}
+}

--- a/server/gcp/loadbalancer/operations.go
+++ b/server/gcp/loadbalancer/operations.go
@@ -2,9 +2,12 @@ package loadbalancer
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/binary"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
@@ -26,13 +29,20 @@ func (h *Handler) insertBackendService(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
+	if _, err := h.findTGByName(r.Context(), req.Name); conflictIfExists(w, err, "backend service "+req.Name+" already exists") {
+		return
+	}
+
+	tags := backendServiceTags(&req)
+	tags[bsCreationTag] = time.Now().UTC().Format(time.RFC3339)
+
 	if _, err := h.lb.CreateTargetGroup(r.Context(), lbdriver.TargetGroupConfig{
 		Name:     req.Name,
 		Protocol: req.Protocol,
 		Port:     req.Port,
 		// The driver TargetGroup can't hold these GCP fields, so round-trip them
 		// through tags rather than dropping them on read.
-		Tags: backendServiceTags(&req),
+		Tags: tags,
 	}); err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -40,6 +50,50 @@ func (h *Handler) insertBackendService(w http.ResponseWriter, r *http.Request, r
 
 	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
 		resourceBackendServices, req.Name, "insert")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// patchBackendService applies compute.backendServices.patch/update: it merges
+// the request's non-empty fields onto the existing backend service and returns
+// a DONE Operation. Without it, Terraform's google_compute_backend_service —
+// which patches on every change — leaves the resource read-only after create.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) patchBackendService(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	patcher, ok := h.lb.(lbdriver.GCPBackendServicePatcher)
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotImplemented, "notImplemented", "load balancer driver cannot patch backend services")
+		return
+	}
+
+	var req backendServiceRequest
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	err := patcher.PatchGCPBackendService(r.Context(), rp.ResourceName, func(tg *lbdriver.TargetGroupInfo) {
+		if req.Protocol != "" {
+			tg.Protocol = req.Protocol
+		}
+
+		if req.Port != 0 {
+			tg.Port = req.Port
+		}
+
+		if tg.Tags == nil {
+			tg.Tags = map[string]string{}
+		}
+
+		mergeBackendServiceTags(tg.Tags, &req)
+	})
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+		resourceBackendServices, rp.ResourceName, "patch")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
 }
@@ -77,7 +131,7 @@ func (h *Handler) listBackendServices(w http.ResponseWriter, r *http.Request, rp
 	gcprest.WriteJSON(w, http.StatusOK, out)
 }
 
-//nolint:gocritic // rp is a request-scoped value
+//nolint:gocritic,dupl // rp is a request-scoped value; CRUD delete shape is duplicate-by-design across resource types
 func (h *Handler) deleteBackendService(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
 	tg, err := h.findTGByName(r.Context(), rp.ResourceName)
 	if err != nil {
@@ -111,10 +165,17 @@ func (h *Handler) insertForwardingRule(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
+	if _, err := h.findLBByName(r.Context(), req.Name); conflictIfExists(w, err, "forwarding rule "+req.Name+" already exists") {
+		return
+	}
+
 	lb, err := h.lb.CreateLoadBalancer(r.Context(), lbdriver.LBConfig{
 		Name:   req.Name,
 		Type:   "network",
 		Scheme: schemeFromRule(&req),
+		// Round-trip the GCP forwarding-rule fields the driver LB can't model
+		// (exact scheme, portRange, IPProtocol, IPAddress, …) through tags.
+		Tags: forwardingRuleTags(&req),
 	})
 	if err != nil {
 		gcprest.WriteCErr(w, err)
@@ -131,6 +192,7 @@ func (h *Handler) insertForwardingRule(w http.ResponseWriter, r *http.Request, r
 			gcprest.WriteCErr(w, ferr)
 			return
 		}
+
 		if _, lerr := h.lb.CreateListener(r.Context(), lbdriver.ListenerConfig{
 			LBARN:          lb.ARN,
 			Protocol:       req.IPProtocol,
@@ -181,7 +243,7 @@ func (h *Handler) listForwardingRules(w http.ResponseWriter, r *http.Request, rp
 	gcprest.WriteJSON(w, http.StatusOK, out)
 }
 
-//nolint:gocritic // rp is a request-scoped value
+//nolint:gocritic,dupl // rp is a request-scoped value; CRUD delete shape is duplicate-by-design across resource types
 func (h *Handler) deleteForwardingRule(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
 	lb, err := h.findLBByName(r.Context(), rp.ResourceName)
 	if err != nil {
@@ -245,6 +307,18 @@ func toBackendServiceResponse(tg *lbdriver.TargetGroupInfo, rp gcprest.ResourceP
 
 	resp.Description = tg.Tags[bsDescriptionTag]
 	resp.PortName = tg.Tags[bsPortNameTag]
+	resp.LoadBalancingScheme = tg.Tags[bsSchemeTag]
+	resp.SessionAffinity = tg.Tags[bsSessionAffinityTag]
+	resp.CreationTimestamp = tg.Tags[bsCreationTag]
+	// A non-empty fingerprint is required for every future patch; real GCP always
+	// returns one, so derive a stable value from the resource name.
+	resp.Fingerprint = fingerprintOf(tg.Name)
+
+	if ts := tg.Tags[bsTimeoutSecTag]; ts != "" {
+		if n, err := strconv.Atoi(ts); err == nil {
+			resp.TimeoutSec = n
+		}
+	}
 
 	if hc := tg.Tags[bsHealthChecksTag]; hc != "" {
 		resp.HealthChecks = strings.Split(hc, ",")
@@ -256,16 +330,27 @@ func toBackendServiceResponse(tg *lbdriver.TargetGroupInfo, rp gcprest.ResourceP
 // Reserved tag keys carry the GCP backend-service fields the driver's target
 // group can't model.
 const (
-	bsDescriptionTag  = "cloudemu:gcpBsDescription"
-	bsPortNameTag     = "cloudemu:gcpBsPortName"
-	bsHealthChecksTag = "cloudemu:gcpBsHealthChecks"
+	bsDescriptionTag     = "cloudemu:gcpBsDescription"
+	bsPortNameTag        = "cloudemu:gcpBsPortName"
+	bsHealthChecksTag    = "cloudemu:gcpBsHealthChecks"
+	bsSchemeTag          = "cloudemu:gcpBsScheme"
+	bsSessionAffinityTag = "cloudemu:gcpBsSessionAffinity"
+	bsTimeoutSecTag      = "cloudemu:gcpBsTimeoutSec"
+	bsCreationTag        = "cloudemu:gcpBsCreationTimestamp"
 )
 
-// backendServiceTags folds the GCP-specific backend-service fields into a tag
-// map so they round-trip through the driver.
+// backendServiceTags folds the GCP-specific backend-service fields into a fresh
+// tag map so they round-trip through the driver.
 func backendServiceTags(req *backendServiceRequest) map[string]string {
 	tags := map[string]string{}
+	mergeBackendServiceTags(tags, req)
 
+	return tags
+}
+
+// mergeBackendServiceTags sets a tag for each non-empty field of req, leaving
+// tags for omitted fields untouched (patch-merge semantics).
+func mergeBackendServiceTags(tags map[string]string, req *backendServiceRequest) {
 	if req.Description != "" {
 		tags[bsDescriptionTag] = req.Description
 	}
@@ -278,7 +363,17 @@ func backendServiceTags(req *backendServiceRequest) map[string]string {
 		tags[bsHealthChecksTag] = strings.Join(req.HealthChecks, ",")
 	}
 
-	return tags
+	if req.LoadBalancingScheme != "" {
+		tags[bsSchemeTag] = req.LoadBalancingScheme
+	}
+
+	if req.SessionAffinity != "" {
+		tags[bsSessionAffinityTag] = req.SessionAffinity
+	}
+
+	if req.TimeoutSec != 0 {
+		tags[bsTimeoutSecTag] = strconv.Itoa(req.TimeoutSec)
+	}
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -289,13 +384,17 @@ func (h *Handler) toForwardingRuleResponse(ctx context.Context, lb *lbdriver.LBI
 		Kind:                "compute#forwardingRule",
 		ID:                  numericID(lb.ID),
 		Name:                lb.Name,
-		IPAddress:           lb.DNSName,
-		IPProtocol:          "TCP",
-		LoadBalancingScheme: schemeToGCP(lb.Scheme),
+		IPAddress:           forwardingRuleIP(lb),
+		IPProtocol:          tagOrDefault(lb.Tags, frProtocolTag, "TCP"),
+		PortRange:           lb.Tags[frPortRangeTag],
+		Description:         lb.Tags[frDescriptionTag],
+		LoadBalancingScheme: forwardingRuleScheme(lb),
+		CreationTimestamp:   lb.Tags[frCreationTag],
 		SelfLink:            gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", resourceForwardingRules, lb.Name),
 	}
 
-	// Reflect the backing backend service, if a listener links one.
+	// A linked listener (a rule referencing a backend service) supersedes the
+	// round-tripped protocol/portRange and adds the backendService self-link.
 	if listeners, err := h.lb.DescribeListeners(ctx, lb.ARN); err == nil && len(listeners) > 0 {
 		out.IPProtocol = protocolOrDefault(listeners[0].Protocol)
 		out.PortRange = strconv.Itoa(listeners[0].Port)
@@ -357,10 +456,13 @@ func firstPort(portRange string) int {
 	return n
 }
 
+// driverSchemeInternal is the driver-side scheme value for internal LBs.
+const driverSchemeInternal = "internal"
+
 // schemeFromRule maps a GCP loadBalancingScheme to the driver scheme.
 func schemeFromRule(req *forwardingRuleRequest) string {
 	if strings.EqualFold(req.LoadBalancingScheme, "INTERNAL") {
-		return "internal"
+		return driverSchemeInternal
 	}
 
 	return "internet-facing"
@@ -368,7 +470,7 @@ func schemeFromRule(req *forwardingRuleRequest) string {
 
 // schemeToGCP maps the driver scheme back to a GCP loadBalancingScheme.
 func schemeToGCP(scheme string) string {
-	if scheme == "internal" {
+	if scheme == driverSchemeInternal {
 		return "INTERNAL"
 	}
 
@@ -384,20 +486,134 @@ func protocolOrDefault(p string) string {
 	return p
 }
 
-// numericID returns a stable uint64-shaped string derived from a driver ID.
-// GCP wire IDs are uint64 and proto JSON unmarshalling rejects anything else.
-func numericID(driverID string) string {
+// fnvHash is a 64-bit FNV-1a hash used to derive stable synthetic identity
+// (numeric IDs, fingerprints, IP addresses) from a resource's name/ID.
+func fnvHash(s string) uint64 {
 	const fnvOffset uint64 = 14695981039346656037
 
 	const fnvPrime uint64 = 1099511628211
 
 	h := fnvOffset
-	for i := 0; i < len(driverID); i++ {
-		h ^= uint64(driverID[i])
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
 		h *= fnvPrime
 	}
 
-	return strconv.FormatUint(h, 10)
+	return h
+}
+
+// numericID returns a stable uint64-shaped string derived from a driver ID.
+// GCP wire IDs are uint64 and proto JSON unmarshalling rejects anything else.
+func numericID(driverID string) string {
+	return strconv.FormatUint(fnvHash(driverID), 10)
+}
+
+// fingerprintOf returns a stable base64 fingerprint for a resource. GCP returns
+// a fingerprint on every resource and requires it on patch; a stable value is
+// enough for a read-modify-write client since the mock does not enforce it.
+func fingerprintOf(name string) string {
+	var b [8]byte
+
+	binary.BigEndian.PutUint64(b[:], fnvHash("fp:"+name))
+
+	return base64.StdEncoding.EncodeToString(b[:])
+}
+
+// Reserved tag keys carry the GCP forwarding-rule fields the driver's load
+// balancer can't model.
+const (
+	frPortRangeTag   = "cloudemu:gcpFrPortRange"
+	frProtocolTag    = "cloudemu:gcpFrIPProtocol"
+	frSchemeTag      = "cloudemu:gcpFrScheme"
+	frIPAddressTag   = "cloudemu:gcpFrIPAddress"
+	frDescriptionTag = "cloudemu:gcpFrDescription"
+	frCreationTag    = "cloudemu:gcpFrCreationTimestamp"
+)
+
+// forwardingRuleTags folds the GCP-specific forwarding-rule fields into a tag
+// map so they round-trip through the driver's LB record.
+func forwardingRuleTags(req *forwardingRuleRequest) map[string]string {
+	tags := map[string]string{
+		frCreationTag: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	if req.PortRange != "" {
+		tags[frPortRangeTag] = req.PortRange
+	}
+
+	if req.IPProtocol != "" {
+		tags[frProtocolTag] = req.IPProtocol
+	}
+
+	if req.LoadBalancingScheme != "" {
+		tags[frSchemeTag] = req.LoadBalancingScheme
+	}
+
+	if req.IPAddress != "" {
+		tags[frIPAddressTag] = req.IPAddress
+	}
+
+	if req.Description != "" {
+		tags[frDescriptionTag] = req.Description
+	}
+
+	return tags
+}
+
+// forwardingRuleIP returns the rule's IP address: the client-supplied one when
+// present, otherwise a stable synthetic IPv4 (real GCP returns an IP, never a
+// hostname).
+func forwardingRuleIP(lb *lbdriver.LBInfo) string {
+	if ip := lb.Tags[frIPAddressTag]; ip != "" {
+		return ip
+	}
+
+	// Derive a deterministic public-looking IPv4 from the LB identity.
+	h := fnvHash("ip:" + lb.ID + lb.Name)
+
+	const octetMod = 254
+
+	o2 := byte(h%octetMod) + 1
+	o3 := byte((h>>8)%octetMod) + 1
+	o4 := byte((h>>16)%octetMod) + 1
+
+	return "34." + strconv.Itoa(int(o2)) + "." + strconv.Itoa(int(o3)) + "." + strconv.Itoa(int(o4))
+}
+
+// forwardingRuleScheme returns the exact GCP loadBalancingScheme, preferring the
+// round-tripped value (EXTERNAL_MANAGED / INTERNAL_MANAGED / …) over the driver
+// scheme's lossy EXTERNAL/INTERNAL collapse.
+func forwardingRuleScheme(lb *lbdriver.LBInfo) string {
+	if s := lb.Tags[frSchemeTag]; s != "" {
+		return s
+	}
+
+	return schemeToGCP(lb.Scheme)
+}
+
+// tagOrDefault returns tags[key], or def when absent/empty.
+func tagOrDefault(tags map[string]string, key, def string) string {
+	if v := tags[key]; v != "" {
+		return v
+	}
+
+	return def
+}
+
+// conflictIfExists writes a 409 alreadyExists (or the underlying error) and
+// returns true when a name-existence probe found the resource or errored; it
+// returns false, letting the caller proceed, only when findErr is NotFound.
+func conflictIfExists(w http.ResponseWriter, findErr error, msg string) bool {
+	switch {
+	case findErr == nil:
+		gcprest.WriteError(w, http.StatusConflict, "alreadyExists", msg)
+		return true
+	case !cerrors.IsNotFound(findErr):
+		gcprest.WriteCErr(w, findErr)
+		return true
+	default:
+		return false
+	}
 }
 
 func hostOf(r *http.Request) string {

--- a/server/gcp/loadbalancer/resources.go
+++ b/server/gcp/loadbalancer/resources.go
@@ -1,0 +1,216 @@
+package loadbalancer
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+)
+
+// GCP Compute Load Balancing resources that the portable LoadBalancer model
+// can't express — healthChecks and urlMaps (global) and targetPools (regional).
+// They are stored verbatim through the GCPComputeResourceStore optional
+// capability and re-emitted with server-injected identity so every field the
+// client sent round-trips (create → read/list → delete), which is all Terraform
+// and the compute SDK need to provision an L4/L7 load balancer.
+const (
+	resourceHealthChecks = "healthChecks"
+	resourceTargetPools  = "targetPools"
+	resourceURLMaps      = "urlMaps"
+)
+
+// resourceKind maps a collection to its compute#… item kind.
+//
+//nolint:gochecknoglobals // immutable lookup table, not mutable state
+var resourceKind = map[string]string{
+	resourceHealthChecks: "compute#healthCheck",
+	resourceTargetPools:  "compute#targetPool",
+	resourceURLMaps:      "compute#urlMap",
+}
+
+// gcpStore returns the store capability, or false when the backing driver does
+// not implement it (non-GCP driver wired in by mistake).
+func (h *Handler) gcpStore() (lbdriver.GCPComputeResourceStore, bool) {
+	s, ok := h.lb.(lbdriver.GCPComputeResourceStore)
+
+	return s, ok
+}
+
+// scopeKeyOf collapses a parsed path's scope to the store scope key: "global"
+// for global resources, the region name for regional ones.
+//
+//nolint:gocritic // rp is a request-scoped value
+func scopeKeyOf(rp gcprest.ResourcePath) string {
+	if rp.Scope == gcprest.ScopeGlobal {
+		return gcprest.ScopeGlobal
+	}
+
+	return rp.ScopeName
+}
+
+//nolint:gocritic,dupl // rp is a request-scoped value; CRUD route shape is duplicate-by-design across resource types
+func (h *Handler) routeGCPResource(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.ResourceName == "" {
+		switch r.Method {
+		case http.MethodPost:
+			h.insertGCPResource(w, r, rp)
+		case http.MethodGet:
+			h.listGCPResource(w, r, rp)
+		default:
+			gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getGCPResource(w, r, rp)
+	case http.MethodDelete:
+		h.deleteGCPResource(w, r, rp)
+	default:
+		gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) insertGCPResource(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	store, ok := h.gcpStore()
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotImplemented, "notImplemented", "load balancer driver has no GCP resource store")
+		return
+	}
+
+	var body map[string]any
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	name, _ := body["name"].(string)
+	if name == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "name required")
+		return
+	}
+
+	res := lbdriver.GCPResource{
+		Collection:        rp.ResourceType,
+		Scope:             scopeKeyOf(rp),
+		Name:              name,
+		ID:                numericID(rp.ResourceType + "/" + name),
+		CreationTimestamp: time.Now().UTC().Format(time.RFC3339),
+		Body:              body,
+	}
+
+	if err := store.PutGCPResource(r.Context(), res); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName, rp.ResourceType, name, "insert")
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getGCPResource(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	store, ok := h.gcpStore()
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotImplemented, "notImplemented", "load balancer driver has no GCP resource store")
+		return
+	}
+
+	res, err := store.GetGCPResource(r.Context(), rp.ResourceType, scopeKeyOf(rp), rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, gcpResourceJSON(res, rp, hostOf(r)))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listGCPResource(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	store, ok := h.gcpStore()
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotImplemented, "notImplemented", "load balancer driver has no GCP resource store")
+		return
+	}
+
+	items, err := store.ListGCPResources(r.Context(), rp.ResourceType, scopeKeyOf(rp))
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	host := hostOf(r)
+	out := make([]map[string]any, 0, len(items))
+
+	for i := range items {
+		scope := rp
+		scope.ResourceName = items[i].Name
+		out = append(out, gcpResourceJSON(&items[i], scope, host))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, map[string]any{
+		"kind":     resourceKind[rp.ResourceType] + "List",
+		"id":       "projects/" + rp.Project + "/" + listScopeSegment(rp) + "/" + rp.ResourceType,
+		"items":    out,
+		"selfLink": gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, rp.ResourceType, ""),
+	})
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteGCPResource(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	store, ok := h.gcpStore()
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotImplemented, "notImplemented", "load balancer driver has no GCP resource store")
+		return
+	}
+
+	if err := store.DeleteGCPResource(r.Context(), rp.ResourceType, scopeKeyOf(rp), rp.ResourceName); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName, rp.ResourceType, rp.ResourceName, "delete")
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// gcpResourceJSON re-emits a stored resource: the verbatim body with server
+// identity (kind/id/selfLink/creationTimestamp) layered on top.
+//
+//nolint:gocritic // rp is a request-scoped value
+func gcpResourceJSON(res *lbdriver.GCPResource, rp gcprest.ResourcePath, host string) map[string]any {
+	out := make(map[string]any, len(res.Body)+internalFieldCount)
+	for k, v := range res.Body {
+		out[k] = v
+	}
+
+	out["kind"] = resourceKind[res.Collection]
+	out["id"] = res.ID
+	out["name"] = res.Name
+	out["creationTimestamp"] = res.CreationTimestamp
+	out["selfLink"] = gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, res.Collection, res.Name)
+
+	if rp.Scope == gcprest.ScopeRegions {
+		out["region"] = host + "/compute/v1/projects/" + rp.Project + "/regions/" + rp.ScopeName
+	}
+
+	return out
+}
+
+// internalFieldCount is the number of server-injected members gcpResourceJSON
+// adds on top of the stored body (kind, id, name, creationTimestamp, selfLink,
+// region).
+const internalFieldCount = 6
+
+// listScopeSegment renders the scope path segment used in a list envelope's id.
+//
+//nolint:gocritic // rp is a request-scoped value
+func listScopeSegment(rp gcprest.ResourcePath) string {
+	if rp.Scope == gcprest.ScopeGlobal {
+		return gcprest.ScopeGlobal
+	}
+
+	return gcprest.ScopeRegions + "/" + rp.ScopeName
+}

--- a/server/gcp/loadbalancer/targetpools_sdk_test.go
+++ b/server/gcp/loadbalancer/targetpools_sdk_test.go
@@ -1,0 +1,98 @@
+package loadbalancer_test
+
+import (
+	"context"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+const testRegion = "us-central1"
+
+// TestSDKGCPTargetPoolRoundTrip reproduces the [HIGH] finding that the
+// (regional) targetPools collection was unrouted (501), breaking the classic
+// network LB / google_compute_target_pool. Insert/Get/List/Delete must
+// round-trip under the region scope.
+func TestSDKGCPTargetPoolRoundTrip(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewTargetPoolsRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewTargetPoolsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	op, err := client.Insert(ctx, &computepb.InsertTargetPoolRequest{
+		Project: testProject,
+		Region:  testRegion,
+		TargetPoolResource: &computepb.TargetPool{
+			Name:            ptrStr("tp1"),
+			SessionAffinity: ptrStr("CLIENT_IP"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetTargetPoolRequest{Project: testProject, Region: testRegion, TargetPool: "tp1"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetName() != "tp1" {
+		t.Fatalf("name = %q, want tp1", got.GetName())
+	}
+
+	if got.GetSessionAffinity() != "CLIENT_IP" {
+		t.Errorf("sessionAffinity = %q, want CLIENT_IP", got.GetSessionAffinity())
+	}
+
+	if got.GetRegion() == "" {
+		t.Error("region self-link empty on a regional resource")
+	}
+
+	var names []string
+
+	it := client.List(ctx, &computepb.ListTargetPoolsRequest{Project: testProject, Region: testRegion})
+
+	for {
+		tp, iErr := it.Next()
+		if iErr == iterator.Done {
+			break
+		}
+
+		if iErr != nil {
+			t.Fatalf("List: %v", iErr)
+		}
+
+		names = append(names, tp.GetName())
+	}
+
+	if len(names) != 1 || names[0] != "tp1" {
+		t.Fatalf("list = %v, want [tp1]", names)
+	}
+
+	delOp, err := client.Delete(ctx, &computepb.DeleteTargetPoolRequest{Project: testProject, Region: testRegion, TargetPool: "tp1"})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Fatalf("Delete wait: %v", err)
+	}
+
+	if _, err := client.Get(ctx,
+		&computepb.GetTargetPoolRequest{Project: testProject, Region: testRegion, TargetPool: "tp1"}); err == nil {
+		t.Fatal("Get after delete: want error, got nil")
+	}
+}

--- a/server/gcp/loadbalancer/types.go
+++ b/server/gcp/loadbalancer/types.go
@@ -7,24 +7,32 @@ package loadbalancer
 // --- backend services (→ driver target groups) ---
 
 type backendServiceRequest struct {
-	Name         string   `json:"name"`
-	Description  string   `json:"description,omitempty"`
-	Protocol     string   `json:"protocol,omitempty"`
-	Port         int      `json:"port,omitempty"`
-	PortName     string   `json:"portName,omitempty"`
-	HealthChecks []string `json:"healthChecks,omitempty"`
+	Name                string   `json:"name"`
+	Description         string   `json:"description,omitempty"`
+	Protocol            string   `json:"protocol,omitempty"`
+	Port                int      `json:"port,omitempty"`
+	PortName            string   `json:"portName,omitempty"`
+	HealthChecks        []string `json:"healthChecks,omitempty"`
+	LoadBalancingScheme string   `json:"loadBalancingScheme,omitempty"`
+	SessionAffinity     string   `json:"sessionAffinity,omitempty"`
+	TimeoutSec          int      `json:"timeoutSec,omitempty"`
 }
 
 type backendServiceResponse struct {
-	Kind         string   `json:"kind"`
-	ID           string   `json:"id"`
-	Name         string   `json:"name"`
-	Description  string   `json:"description,omitempty"`
-	Protocol     string   `json:"protocol,omitempty"`
-	Port         int      `json:"port,omitempty"`
-	PortName     string   `json:"portName,omitempty"`
-	HealthChecks []string `json:"healthChecks,omitempty"`
-	SelfLink     string   `json:"selfLink"`
+	Kind                string   `json:"kind"`
+	ID                  string   `json:"id"`
+	Name                string   `json:"name"`
+	Description         string   `json:"description,omitempty"`
+	Protocol            string   `json:"protocol,omitempty"`
+	Port                int      `json:"port,omitempty"`
+	PortName            string   `json:"portName,omitempty"`
+	HealthChecks        []string `json:"healthChecks,omitempty"`
+	LoadBalancingScheme string   `json:"loadBalancingScheme,omitempty"`
+	SessionAffinity     string   `json:"sessionAffinity,omitempty"`
+	TimeoutSec          int      `json:"timeoutSec,omitempty"`
+	Fingerprint         string   `json:"fingerprint,omitempty"`
+	CreationTimestamp   string   `json:"creationTimestamp,omitempty"`
+	SelfLink            string   `json:"selfLink"`
 }
 
 type backendServiceListResponse struct {
@@ -39,6 +47,7 @@ type backendServiceListResponse struct {
 type forwardingRuleRequest struct {
 	Name                string `json:"name"`
 	Description         string `json:"description,omitempty"`
+	IPAddress           string `json:"IPAddress,omitempty"`
 	IPProtocol          string `json:"IPProtocol,omitempty"`
 	PortRange           string `json:"portRange,omitempty"`
 	Target              string `json:"target,omitempty"`
@@ -57,6 +66,7 @@ type forwardingRuleResponse struct {
 	Target              string `json:"target,omitempty"`
 	BackendService      string `json:"backendService,omitempty"`
 	LoadBalancingScheme string `json:"loadBalancingScheme,omitempty"`
+	CreationTimestamp   string `json:"creationTimestamp,omitempty"`
 	SelfLink            string `json:"selfLink"`
 }
 

--- a/server/gcp/loadbalancer/urlmaps_sdk_test.go
+++ b/server/gcp/loadbalancer/urlmaps_sdk_test.go
@@ -1,0 +1,95 @@
+package loadbalancer_test
+
+import (
+	"context"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+// TestSDKGCPURLMapRoundTrip reproduces the [HIGH] finding that the urlMaps
+// collection was unrouted (501), breaking every external HTTP(S) LB /
+// google_compute_url_map. Insert/Get/List/Delete must round-trip.
+func TestSDKGCPURLMapRoundTrip(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewUrlMapsRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewUrlMapsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	defaultSvc := "projects/" + testProject + "/global/backendServices/web-bs"
+
+	op, err := client.Insert(ctx, &computepb.InsertUrlMapRequest{
+		Project: testProject,
+		UrlMapResource: &computepb.UrlMap{
+			Name:           ptrStr("web-map"),
+			DefaultService: ptrStr(defaultSvc),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetUrlMapRequest{Project: testProject, UrlMap: "web-map"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetName() != "web-map" {
+		t.Fatalf("name = %q, want web-map", got.GetName())
+	}
+
+	if got.GetDefaultService() != defaultSvc {
+		t.Errorf("defaultService = %q, want %q", got.GetDefaultService(), defaultSvc)
+	}
+
+	if got.GetSelfLink() == "" {
+		t.Error("selfLink empty")
+	}
+
+	var names []string
+
+	it := client.List(ctx, &computepb.ListUrlMapsRequest{Project: testProject})
+
+	for {
+		um, iErr := it.Next()
+		if iErr == iterator.Done {
+			break
+		}
+
+		if iErr != nil {
+			t.Fatalf("List: %v", iErr)
+		}
+
+		names = append(names, um.GetName())
+	}
+
+	if len(names) != 1 || names[0] != "web-map" {
+		t.Fatalf("list = %v, want [web-map]", names)
+	}
+
+	delOp, err := client.Delete(ctx, &computepb.DeleteUrlMapRequest{Project: testProject, UrlMap: "web-map"})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Fatalf("Delete wait: %v", err)
+	}
+
+	if _, err := client.Get(ctx, &computepb.GetUrlMapRequest{Project: testProject, UrlMap: "web-map"}); err == nil {
+		t.Fatal("Get after delete: want error, got nil")
+	}
+}

--- a/services/loadbalancer/driver/gcp.go
+++ b/services/loadbalancer/driver/gcp.go
@@ -1,0 +1,46 @@
+package driver
+
+import "context"
+
+// GCPResource is an opaque GCP global/regional Compute Load Balancing resource
+// (healthChecks, targetPools, urlMaps) that the portable LoadBalancer model
+// can't express. The GCP wire handler stores the decoded insert/patch body
+// verbatim and re-emits it, so every field the client sent round-trips exactly.
+// Server-injected identity (ID, CreationTimestamp) lives alongside the body.
+type GCPResource struct {
+	Collection        string         // "healthChecks", "targetPools", "urlMaps"
+	Scope             string         // "global" or a region name
+	Name              string         // user-assigned resource name (key)
+	ID                string         // numeric string, GCP wire ID
+	CreationTimestamp string         // RFC3339
+	Body              map[string]any // decoded insert body
+}
+
+// GCPComputeResourceStore is an OPTIONAL, type-asserted capability implemented
+// only by the GCP load-balancer provider. It persists opaque GCP Compute Load
+// Balancing resources (healthChecks, targetPools, urlMaps) that have no
+// cross-provider driver model, keyed by (collection, scope, name). Non-GCP
+// providers do not implement it.
+type GCPComputeResourceStore interface {
+	// PutGCPResource stores res, returning AlreadyExists when a resource with
+	// the same (collection, scope, name) already exists.
+	PutGCPResource(ctx context.Context, res GCPResource) error
+	// GetGCPResource returns the stored resource, or NotFound.
+	GetGCPResource(ctx context.Context, collection, scope, name string) (*GCPResource, error)
+	// ListGCPResources returns every resource in a (collection, scope) bucket.
+	ListGCPResources(ctx context.Context, collection, scope string) ([]GCPResource, error)
+	// DeleteGCPResource removes the resource, returning NotFound when absent.
+	DeleteGCPResource(ctx context.Context, collection, scope, name string) error
+}
+
+// GCPBackendServicePatcher is an OPTIONAL, type-asserted capability implemented
+// only by the GCP load-balancer provider. It applies an in-place mutation to a
+// backend-service-backed target group (GCP compute.backendServices.patch),
+// holding the store lock across the read-modify-write so overlapping patches
+// don't lose updates. Non-GCP providers do not implement it.
+type GCPBackendServicePatcher interface {
+	// PatchGCPBackendService looks up the target group by its GCP name and
+	// applies mutate to it in place, returning NotFound when no such backend
+	// service exists.
+	PatchGCPBackendService(ctx context.Context, name string, mutate func(*TargetGroupInfo)) error
+}


### PR DESCRIPTION
## What & why

Fixes the GCP Compute Load Balancing (`compute-loadbalancer`) bug batch from `AUDIT_GCP.md`. The GCP wire server left three LB collections entirely unrouted (501) and dropped most fields on the two it did serve, so `google_compute_backend_service`, `google_compute_url_map`, `google_compute_target_pool`, health checks and L4/L7 forwarding rules could not be provisioned end-to-end.

All fixes land at the correct layer: opaque GCP-only resources and backend-service patch use new **type-asserted optional driver interfaces** (`GCPComputeResourceStore`, `GCPBackendServicePatcher`) implemented only by the GCP provider — the shared `LoadBalancer` interface is unchanged. New LB resource handlers register **before** the compute-space `NewFallback` (#640), so their real handlers win first-match-wins.

## Findings fixed (8/8)

- **[BLOCKER] backendServices.patch/update** — was 405; now merges non-empty fields onto the target group and returns a DONE Operation.
- **[BLOCKER] healthChecks CRUD** — was 501; full insert/get/list/delete (global).
- **[HIGH] targetPools CRUD** — was 501; full insert/get/list/delete (regional scope).
- **[HIGH] urlMaps CRUD** — was 501; full insert/get/list/delete (global).
- **[HIGH] backendServices.get missing fields** — now emits `loadBalancingScheme`/`timeoutSec`/`sessionAffinity`/`fingerprint`/`creationTimestamp`.
- **[HIGH] forwardingRules.get portRange** — retained even when the rule has no backend service.
- **[MEDIUM] forwardingRules.get IPAddress** — now a real IPv4, not a hostname.
- **[MEDIUM] forwardingRules.get loadBalancingScheme** — exact `EXTERNAL_MANAGED`/`INTERNAL_MANAGED`/… round-trip (no longer collapsed to EXTERNAL/INTERNAL).

## PR #643-deferred LB portions

- Duplicate-name insert on `backendServices` and `forwardingRules` now returns **409 alreadyExists** (was silent success).
- `creationTimestamp` populated on both.

## Implementation notes

- healthChecks/targetPools/urlMaps have no cross-provider model, so they are stored verbatim (decoded body) through `GCPComputeResourceStore` and re-emitted with server-injected identity (`id`/`kind`/`selfLink`/`creationTimestamp`) — every field the client sent round-trips. State lives in the provider mock (memstore), not the handler.
- backendServices/forwardingRules GCP-only fields continue to round-trip through the driver's tag map.

## Tests

Reproduction tests use the real `cloud.google.com/go/compute/apiv1` GAPIC clients against the in-process GCP server (existing harness): `backendservices_sdk_test.go`, `forwardingrules_sdk_test.go`, `healthchecks_sdk_test.go`, `targetpools_sdk_test.go`, `urlmaps_sdk_test.go`. Existing LB tests and the #640 dispatch-ordering/fallback tests stay green.

## Deferrals

None — all 8 findings plus the #643 LB portions are in this PR.

## Gates

`go build ./...`, `go vet`, scoped `go test -count=1` (server/gcp/loadbalancer, providers/gcp/loadbalancer, services/loadbalancer, server/gcp, server/gcp/compute), `go test -race` on the mutated provider, `golangci-lint` on changed packages (0 issues), `gofmt -l` clean, `go generate ./...` (docs/coverage regenerated).
