### PR TITLE
fix(gcp-clouddns): apex SOA/NS, nameServers, creationTime, zone patch, changes list/get, rrset filters+paging

### DIFF
--- a/server/gcp/clouddns/handler.go
+++ b/server/gcp/clouddns/handler.go
@@ -21,6 +21,7 @@ package clouddns
 import (
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
@@ -39,23 +40,31 @@ const (
 	minZonesCollectionParts = 3 // [projects, {p}, managedZones]
 	restZoneResource        = 1 // [{zone}]
 	restZoneSubCollection   = 2 // [{zone}, changes|rrsets]
+	restZoneSubResource     = 3 // [{zone}, changes, {changeId}]
 )
 
 // Handler serves dns.googleapis.com v1 requests against a dns driver.
 type Handler struct {
 	dns       dnsdriver.DNS
 	changeSeq atomic.Uint64
+
+	// changes records applied changes per driver zone id so changes.list/get can
+	// replay them. Cloud DNS keeps this change log itself; the dns driver models
+	// only the end state, so the wire layer owns it. Guarded by mu.
+	mu      sync.Mutex
+	changes map[string][]changeJSON
 }
 
 // New returns a Cloud DNS handler backed by d.
 func New(d dnsdriver.DNS) *Handler {
-	return &Handler{dns: d}
+	return &Handler{dns: d, changes: make(map[string][]changeJSON)}
 }
 
 type route struct {
-	project string
-	zone    string // managed zone name; empty for the collection
-	sub     string // "changes" or "rrsets"; empty for a bare zone
+	project  string
+	zone     string // managed zone name; empty for the collection
+	sub      string // "changes" or "rrsets"; empty for a bare zone
+	changeID string // change id; only set for [{zone}, changes, {changeId}]
 }
 
 // parseRoute extracts the components of a Cloud DNS v1 path.
@@ -81,6 +90,12 @@ func parseRoute(urlPath string) (route, bool) {
 	case restZoneSubCollection:
 		rt.zone = rest[0]
 		rt.sub = rest[1]
+
+		return rt, true
+	case restZoneSubResource:
+		rt.zone = rest[0]
+		rt.sub = rest[1]
+		rt.changeID = rest[2]
 
 		return rt, true
 	default:
@@ -138,19 +153,30 @@ func (h *Handler) serveZone(w http.ResponseWriter, r *http.Request, rt route) {
 		h.getZone(w, r, rt)
 	case http.MethodDelete:
 		h.deleteZone(w, r, rt)
+	case http.MethodPatch, http.MethodPut:
+		h.patchZone(w, r, rt)
 	default:
 		writeUnsupported(w)
 	}
 }
 
-// serveChanges dispatches /managedZones/{z}/changes requests.
+// serveChanges dispatches /managedZones/{z}/changes[/{changeId}] requests.
 func (h *Handler) serveChanges(w http.ResponseWriter, r *http.Request, rt route) {
-	if r.Method != http.MethodPost {
-		writeUnsupported(w)
-		return
-	}
+	switch {
+	case rt.changeID != "":
+		if r.Method != http.MethodGet {
+			writeUnsupported(w)
+			return
+		}
 
-	h.createChange(w, r, rt)
+		h.getChange(w, r, rt)
+	case r.Method == http.MethodPost:
+		h.createChange(w, r, rt)
+	case r.Method == http.MethodGet:
+		h.listChanges(w, r, rt)
+	default:
+		writeUnsupported(w)
+	}
 }
 
 // serveRRSets dispatches /managedZones/{z}/rrsets requests.

--- a/server/gcp/clouddns/management_api_sdk_test.go
+++ b/server/gcp/clouddns/management_api_sdk_test.go
@@ -1,0 +1,289 @@
+package clouddns_test
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	dns "google.golang.org/api/dns/v1"
+)
+
+// TestSDKApexRecordsSeeded reproduces the audit finding that a freshly created
+// managed zone had zero record sets: real Cloud DNS auto-creates SOA + NS
+// records at the apex, so rrsets.list on a new zone must return exactly those
+// two.
+func TestSDKApexRecordsSeeded(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	if _, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name:    "apex-zone",
+		DnsName: "apex.example.com.",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("ManagedZones.Create: %v", err)
+	}
+
+	rrsets, err := svc.ResourceRecordSets.List(testProject, "apex-zone").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("ResourceRecordSets.List: %v", err)
+	}
+
+	if len(rrsets.Rrsets) != 2 {
+		t.Fatalf("new zone rrsets = %d, want 2 (SOA+NS): %+v", len(rrsets.Rrsets), rrsets.Rrsets)
+	}
+
+	var soa, ns *dns.ResourceRecordSet
+	for _, r := range rrsets.Rrsets {
+		switch r.Type {
+		case "SOA":
+			soa = r
+		case "NS":
+			ns = r
+		}
+	}
+
+	if soa == nil || ns == nil {
+		t.Fatalf("apex records missing SOA or NS: %+v", rrsets.Rrsets)
+	}
+
+	if soa.Name != "apex.example.com." || ns.Name != "apex.example.com." {
+		t.Errorf("apex records not at dnsName: SOA=%q NS=%q", soa.Name, ns.Name)
+	}
+
+	if len(ns.Rrdatas) != 4 {
+		t.Errorf("apex NS rrdatas = %v, want 4 name servers", ns.Rrdatas)
+	}
+}
+
+// TestSDKZoneNameServers reproduces the finding that ManagedZone.nameServers was
+// absent: real Cloud DNS assigns 4 authoritative name servers, returned on both
+// create and get and stable across calls.
+func TestSDKZoneNameServers(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	created, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name:    "ns-zone",
+		DnsName: "ns.example.com.",
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("ManagedZones.Create: %v", err)
+	}
+
+	if len(created.NameServers) != 4 {
+		t.Fatalf("create nameServers = %v, want 4", created.NameServers)
+	}
+
+	for _, ns := range created.NameServers {
+		if !strings.HasSuffix(ns, ".googledomains.com.") {
+			t.Errorf("nameServer %q not a googledomains delegation host", ns)
+		}
+	}
+
+	got, err := svc.ManagedZones.Get(testProject, "ns-zone").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("ManagedZones.Get: %v", err)
+	}
+
+	if len(got.NameServers) != 4 {
+		t.Fatalf("get nameServers = %v, want 4", got.NameServers)
+	}
+
+	for i := range created.NameServers {
+		if got.NameServers[i] != created.NameServers[i] {
+			t.Fatalf("nameServers not stable: create=%v get=%v", created.NameServers, got.NameServers)
+		}
+	}
+}
+
+// TestSDKZoneCreationTime reproduces the finding that creationTime was never
+// set: real Cloud DNS returns it on create and get.
+func TestSDKZoneCreationTime(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	created, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name:    "ct-zone",
+		DnsName: "ct.example.com.",
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("ManagedZones.Create: %v", err)
+	}
+
+	if created.CreationTime == "" {
+		t.Fatalf("create creationTime empty, want RFC3339 timestamp")
+	}
+
+	got, err := svc.ManagedZones.Get(testProject, "ct-zone").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("ManagedZones.Get: %v", err)
+	}
+
+	if got.CreationTime != created.CreationTime {
+		t.Fatalf("get creationTime = %q, want %q", got.CreationTime, created.CreationTime)
+	}
+}
+
+// TestSDKZonePatchLabels reproduces the finding that managedZones.patch returned
+// 400: real Cloud DNS supports patching labels and description.
+func TestSDKZonePatchLabels(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	if _, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name:        "patch-zone",
+		DnsName:     "patch.example.com.",
+		Description: "before",
+		Labels:      map[string]string{"env": "dev"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("ManagedZones.Create: %v", err)
+	}
+
+	// Patch returns an Operation, not the zone.
+	if _, err := svc.ManagedZones.Patch(testProject, "patch-zone", &dns.ManagedZone{
+		Description: "after",
+		Labels:      map[string]string{"env": "prod", "team": "infra"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("ManagedZones.Patch: %v", err)
+	}
+
+	got, err := svc.ManagedZones.Get(testProject, "patch-zone").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("ManagedZones.Get: %v", err)
+	}
+
+	if got.Labels["env"] != "prod" || got.Labels["team"] != "infra" {
+		t.Errorf("labels after patch = %v, want env=prod team=infra", got.Labels)
+	}
+
+	if got.Description != "after" {
+		t.Errorf("description after patch = %q, want after", got.Description)
+	}
+
+	// The reserved fields must survive the patch.
+	if got.DnsName != "patch.example.com." {
+		t.Errorf("dnsName lost across patch: %q", got.DnsName)
+	}
+
+	if got.CreationTime == "" {
+		t.Errorf("creationTime lost across patch")
+	}
+}
+
+// TestSDKChangesListAndGet reproduces the finding that changes.list/get returned
+// 400 and omitted startTime: real Cloud DNS exposes the change log for polling.
+func TestSDKChangesListAndGet(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	if _, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name:    "chg-zone",
+		DnsName: "chg.example.com.",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("ManagedZones.Create: %v", err)
+	}
+
+	created, err := svc.Changes.Create(testProject, "chg-zone", &dns.Change{
+		Additions: []*dns.ResourceRecordSet{
+			{Name: "www.chg.example.com.", Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.5"}},
+		},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Changes.Create: %v", err)
+	}
+
+	if created.StartTime == "" {
+		t.Errorf("change startTime empty, want RFC3339 timestamp")
+	}
+
+	list, err := svc.Changes.List(testProject, "chg-zone").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Changes.List: %v", err)
+	}
+
+	if len(list.Changes) != 1 {
+		t.Fatalf("changes.list = %d, want 1: %+v", len(list.Changes), list.Changes)
+	}
+
+	if list.Changes[0].Id != created.Id {
+		t.Errorf("listed change id = %q, want %q", list.Changes[0].Id, created.Id)
+	}
+
+	got, err := svc.Changes.Get(testProject, "chg-zone", created.Id).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Changes.Get: %v", err)
+	}
+
+	if got.Id != created.Id || got.StartTime == "" || got.Status != "done" {
+		t.Errorf("changes.get = %+v, want id=%s startTime set status=done", got, created.Id)
+	}
+}
+
+// TestSDKRRSetsFilterAndPaging reproduces the finding that rrsets.list ignored
+// ?name=/?type= filters and had no pagination.
+func TestSDKRRSetsFilterAndPaging(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	if _, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name:    "filter-zone",
+		DnsName: "filter.example.com.",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("ManagedZones.Create: %v", err)
+	}
+
+	for i := range 3 {
+		name := "host" + strconv.Itoa(i) + ".filter.example.com."
+		if _, err := svc.Changes.Create(testProject, "filter-zone", &dns.Change{
+			Additions: []*dns.ResourceRecordSet{
+				{Name: name, Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1"}},
+			},
+		}).Context(ctx).Do(); err != nil {
+			t.Fatalf("Changes.Create(%s): %v", name, err)
+		}
+	}
+
+	// Filter by name: exactly the one A record.
+	byName, err := svc.ResourceRecordSets.List(testProject, "filter-zone").
+		Name("host1.filter.example.com.").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List(name filter): %v", err)
+	}
+
+	if len(byName.Rrsets) != 1 || byName.Rrsets[0].Name != "host1.filter.example.com." {
+		t.Fatalf("name filter = %+v, want single host1", byName.Rrsets)
+	}
+
+	// Filter by type NS: only the apex NS record.
+	byType, err := svc.ResourceRecordSets.List(testProject, "filter-zone").
+		Type("NS").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List(type filter): %v", err)
+	}
+
+	if len(byType.Rrsets) != 1 || byType.Rrsets[0].Type != "NS" {
+		t.Fatalf("type filter = %+v, want single NS", byType.Rrsets)
+	}
+
+	// Pagination: 5 total rrsets (SOA, NS, 3x A); a page of 2 must yield a token
+	// and .Pages must walk every record exactly once.
+	var pages, total int
+
+	if err := svc.ResourceRecordSets.List(testProject, "filter-zone").MaxResults(2).
+		Pages(ctx, func(page *dns.ResourceRecordSetsListResponse) error {
+			pages++
+			total += len(page.Rrsets)
+			return nil
+		}); err != nil {
+		t.Fatalf("List(paged): %v", err)
+	}
+
+	if total != 5 {
+		t.Errorf("paged total rrsets = %d, want 5", total)
+	}
+
+	if pages < 2 {
+		t.Errorf("paged in %d page(s), want the page size to force >1", pages)
+	}
+}

--- a/server/gcp/clouddns/operations.go
+++ b/server/gcp/clouddns/operations.go
@@ -3,8 +3,10 @@ package clouddns
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
 	"github.com/stackshy/cloudemu/v2/services/scope"
@@ -16,15 +18,23 @@ func (h *Handler) createZone(w http.ResponseWriter, r *http.Request, rt route) {
 		return
 	}
 
-	tags := req.Labels
-	if req.DNSName != "" {
-		tags = make(map[string]string, len(req.Labels)+1)
-		for k, v := range req.Labels {
-			tags[k] = v
-		}
+	// The dns driver's ZoneInfo models neither dnsName, description, nor
+	// creationTime, so they round-trip through reserved tags alongside the user
+	// labels. creationTime mirrors Cloud DNS's server-assigned timestamp.
+	tags := make(map[string]string, len(req.Labels)+reservedTagCount)
+	for k, v := range req.Labels {
+		tags[k] = v
+	}
 
+	if req.DNSName != "" {
 		tags[dnsNameTag] = req.DNSName
 	}
+
+	if req.Description != "" {
+		tags[descriptionTag] = req.Description
+	}
+
+	tags[creationTimeTag] = time.Now().UTC().Format(time.RFC3339)
 
 	info, err := h.dns.CreateZone(r.Context(), dnsdriver.ZoneConfig{
 		Name:    req.Name,
@@ -37,7 +47,25 @@ func (h *Handler) createZone(w http.ResponseWriter, r *http.Request, rt route) {
 		return
 	}
 
+	h.seedApexRecords(r, info)
+
 	gcprest.WriteJSON(w, http.StatusOK, toManagedZoneJSON(info))
+}
+
+// seedApexRecords creates the SOA and NS record sets Cloud DNS auto-provisions
+// at a new zone's apex, so rrsets.list on a fresh zone returns them (2 records)
+// as real Cloud DNS does. A best-effort operation: a record that somehow
+// already exists is left as-is rather than failing zone creation.
+func (h *Handler) seedApexRecords(r *http.Request, info *dnsdriver.ZoneInfo) {
+	dnsName := info.Name
+	if v, ok := info.Tags[dnsNameTag]; ok && v != "" {
+		dnsName = v
+	}
+
+	cfgs := apexRecordConfigs(info.ID, dnsName)
+	for i := range cfgs {
+		_, _ = h.dns.CreateRecord(r.Context(), cfgs[i])
+	}
 }
 
 func (h *Handler) getZone(w http.ResponseWriter, r *http.Request, rt route) {
@@ -68,10 +96,92 @@ func (h *Handler) listZones(w http.ResponseWriter, r *http.Request, rt route) {
 		out = append(out, toManagedZoneJSON(&infos[i]))
 	}
 
+	page, next, ok := paginate(w, r, len(out))
+	if !ok {
+		return
+	}
+
 	gcprest.WriteJSON(w, http.StatusOK, managedZonesListResponse{
-		Kind:         kindManagedZonesList,
-		ManagedZones: out,
+		Kind:          kindManagedZonesList,
+		ManagedZones:  out[page.start:page.end],
+		NextPageToken: next,
 	})
+}
+
+// patchZone serves managedZones.patch/update. Cloud DNS returns an Operation
+// (not the zone) from both; the zone's mutable fields — description and labels —
+// are applied via the driver, preserving the reserved tags that carry dnsName
+// and creationTime.
+func (h *Handler) patchZone(w http.ResponseWriter, r *http.Request, rt route) {
+	var req managedZoneJSON
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	id, err := h.resolveZoneID(r.Context(), rt.project, rt.zone)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	info, err := h.dns.GetZone(r.Context(), id)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	tags := mergeZoneTags(info.Tags, &req)
+
+	if _, uerr := h.dns.UpdateZone(r.Context(), dnsdriver.ZoneConfig{
+		Name:    info.Name,
+		Private: info.Private,
+		Tags:    tags,
+		Scope:   info.Scope,
+	}); uerr != nil {
+		gcprest.WriteCErr(w, uerr)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, operationJSON{
+		Kind:      kindOperation,
+		ID:        strconv.FormatUint(h.changeSeq.Add(1), 10),
+		StartTime: time.Now().UTC().Format(time.RFC3339),
+		Status:    operationStatusDone,
+		Type:      "update",
+		User:      "cloudemu",
+	})
+}
+
+// isReservedTag reports whether k is a cloudemu-internal zone tag (dnsName,
+// creationTime, description) rather than a user label.
+func isReservedTag(k string) bool {
+	return k == dnsNameTag || k == creationTimeTag || k == descriptionTag
+}
+
+// mergeZoneTags applies a patch/update request's mutable fields onto the zone's
+// existing tags: labels replace the user label set when present, description
+// updates its reserved tag, and the dnsName/creationTime reserved tags are
+// always preserved.
+func mergeZoneTags(existing map[string]string, req *managedZoneJSON) map[string]string {
+	tags := make(map[string]string, len(existing)+len(req.Labels))
+
+	// Preserve the reserved tags; carry the old user labels forward only when the
+	// request omits labels (Cloud DNS replaces the whole label map when set).
+	for k, v := range existing {
+		if isReservedTag(k) || req.Labels == nil {
+			tags[k] = v
+		}
+	}
+
+	for k, v := range req.Labels {
+		tags[k] = v
+	}
+
+	if req.Description != "" {
+		tags[descriptionTag] = req.Description
+	}
+
+	return tags
 }
 
 func (h *Handler) deleteZone(w http.ResponseWriter, r *http.Request, rt route) {
@@ -165,13 +275,75 @@ func (h *Handler) createChange(w http.ResponseWriter, r *http.Request, rt route)
 		}
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, changeJSON{
+	change := changeJSON{
 		Kind:      kindChange,
 		ID:        strconv.FormatUint(h.changeSeq.Add(1), 10),
 		Additions: req.Additions,
 		Deletions: req.Deletions,
 		Status:    changeStatusDone,
+		StartTime: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	h.recordChange(id, &change)
+
+	gcprest.WriteJSON(w, http.StatusOK, change)
+}
+
+// recordChange appends an applied change to the zone's change log for later
+// retrieval via changes.list/get.
+func (h *Handler) recordChange(zoneID string, change *changeJSON) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.changes[zoneID] = append(h.changes[zoneID], *change)
+}
+
+// listChanges serves changes.list: the zone's applied change log, oldest first,
+// with maxResults/pageToken paging.
+func (h *Handler) listChanges(w http.ResponseWriter, r *http.Request, rt route) {
+	id, err := h.resolveZoneID(r.Context(), rt.project, rt.zone)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	h.mu.Lock()
+	all := make([]changeJSON, len(h.changes[id]))
+	copy(all, h.changes[id])
+	h.mu.Unlock()
+
+	page, next, ok := paginate(w, r, len(all))
+	if !ok {
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, changesListResponse{
+		Kind:          kindChangesList,
+		Changes:       all[page.start:page.end],
+		NextPageToken: next,
 	})
+}
+
+// getChange serves changes.get: a single applied change by its id.
+func (h *Handler) getChange(w http.ResponseWriter, r *http.Request, rt route) {
+	id, err := h.resolveZoneID(r.Context(), rt.project, rt.zone)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for _, c := range h.changes[id] {
+		if c.ID == rt.changeID {
+			gcprest.WriteJSON(w, http.StatusOK, c)
+			return
+		}
+	}
+
+	gcprest.WriteError(w, http.StatusNotFound, "notFound",
+		"change "+rt.changeID+" not found")
 }
 
 // rrsetKey identifies a record set by name+type within a zone.
@@ -192,13 +364,70 @@ func (h *Handler) listRRSets(w http.ResponseWriter, r *http.Request, rt route) {
 		return
 	}
 
+	// Cloud DNS filters rrsets.list by ?name= (exact) and ?type= before paging.
+	nameFilter := r.URL.Query().Get("name")
+	typeFilter := r.URL.Query().Get("type")
+
 	out := make([]resourceRecordSetJSON, 0, len(records))
+
 	for i := range records {
+		if nameFilter != "" && records[i].Name != nameFilter {
+			continue
+		}
+
+		if typeFilter != "" && records[i].Type != typeFilter {
+			continue
+		}
+
 		out = append(out, toRecordSetJSON(&records[i]))
 	}
 
+	page, next, ok := paginate(w, r, len(out))
+	if !ok {
+		return
+	}
+
 	gcprest.WriteJSON(w, http.StatusOK, resourceRecordSetsListResponse{
-		Kind:   kindResourceRecordSetsList,
-		Rrsets: out,
+		Kind:          kindResourceRecordSetsList,
+		Rrsets:        out[page.start:page.end],
+		NextPageToken: next,
 	})
+}
+
+// pageRange is the [start,end) slice bounds paginate resolves for a page.
+type pageRange struct {
+	start int
+	end   int
+}
+
+// paginate parses Cloud DNS's maxResults/pageToken query params against a result
+// of size total and returns the slice bounds for the requested page plus the
+// nextPageToken (empty when the page is the last). On a malformed pageToken it
+// writes a 400 and returns ok=false; callers must then stop.
+func paginate(w http.ResponseWriter, r *http.Request, total int) (pageRange, string, bool) {
+	start, err := wire.DecodeOffset(r.URL.Query().Get("pageToken"))
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid pageToken")
+		return pageRange{}, "", false
+	}
+
+	if start > total {
+		start = total
+	}
+
+	end := total
+
+	if mr := r.URL.Query().Get("maxResults"); mr != "" {
+		n, cerr := strconv.Atoi(mr)
+		if cerr == nil && n > 0 && start+n < end {
+			end = start + n
+		}
+	}
+
+	next := ""
+	if end < total {
+		next = wire.EncodeOffset(end)
+	}
+
+	return pageRange{start: start, end: end}, next, true
 }

--- a/server/gcp/clouddns/sdk_roundtrip_test.go
+++ b/server/gcp/clouddns/sdk_roundtrip_test.go
@@ -137,11 +137,14 @@ func TestSDKCloudDNSRecordChanges(t *testing.T) {
 		t.Fatalf("ResourceRecordSets.List: %v", err)
 	}
 
-	if len(rrsets.Rrsets) != 1 {
-		t.Fatalf("got %d rrsets, want 1: %+v", len(rrsets.Rrsets), rrsets.Rrsets)
+	// The zone also carries the auto-created apex SOA + NS records, so filter to
+	// the user-added record set before asserting.
+	user := userRrsets(rrsets.Rrsets)
+	if len(user) != 1 {
+		t.Fatalf("got %d user rrsets, want 1: %+v", len(user), user)
 	}
 
-	got := rrsets.Rrsets[0]
+	got := user[0]
 	if got.Name != "www.records.com." || got.Type != "A" || got.Ttl != 300 {
 		t.Fatalf("rrset = %+v, want www.records.com. A 300", got)
 	}
@@ -162,9 +165,22 @@ func TestSDKCloudDNSRecordChanges(t *testing.T) {
 		t.Fatalf("ResourceRecordSets.List after delete: %v", err)
 	}
 
-	if len(after.Rrsets) != 0 {
-		t.Fatalf("got %d rrsets after delete, want 0: %+v", len(after.Rrsets), after.Rrsets)
+	if got := userRrsets(after.Rrsets); len(got) != 0 {
+		t.Fatalf("got %d user rrsets after delete, want 0: %+v", len(got), got)
 	}
+}
+
+// userRrsets drops the apex SOA and NS record sets Cloud DNS auto-creates so a
+// test can assert on just the record sets it added.
+func userRrsets(in []*dns.ResourceRecordSet) []*dns.ResourceRecordSet {
+	out := make([]*dns.ResourceRecordSet, 0, len(in))
+	for _, r := range in {
+		if r.Type == "SOA" || r.Type == "NS" {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
 }
 
 // TestSDKCloudDNSUpdateRecord guards the #321 fix: the canonical record update
@@ -214,8 +230,9 @@ func TestSDKCloudDNSUpdateRecord(t *testing.T) {
 		t.Fatalf("List: %v", err)
 	}
 
-	if len(rrsets.Rrsets) != 1 || rrsets.Rrsets[0].Ttl != 600 || rrsets.Rrsets[0].Rrdatas[0] != "192.0.2.2" {
-		t.Fatalf("after update rrsets=%+v want single 600/192.0.2.2", rrsets.Rrsets)
+	user := userRrsets(rrsets.Rrsets)
+	if len(user) != 1 || user[0].Ttl != 600 || user[0].Rrdatas[0] != "192.0.2.2" {
+		t.Fatalf("after update rrsets=%+v want single 600/192.0.2.2", user)
 	}
 }
 

--- a/server/gcp/clouddns/types.go
+++ b/server/gcp/clouddns/types.go
@@ -11,9 +11,18 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
-// dnsNameTag stores a zone's DNS suffix (dnsName), which the dns driver does
-// not model, so it round-trips through the zone's tags.
-const dnsNameTag = "cloudemu:gcpDnsName"
+// Reserved tag keys the dns driver's ZoneInfo does not model, so they
+// round-trip through the zone's tags: the DNS suffix (dnsName), the
+// human-readable description, and the RFC3339 creation time.
+const (
+	dnsNameTag      = "cloudemu:gcpDnsName"
+	descriptionTag  = "cloudemu:gcpDescription"
+	creationTimeTag = "cloudemu:gcpCreationTime"
+)
+
+// reservedTagCount is the number of reserved tags above, used to size the tag
+// map created at zone creation.
+const reservedTagCount = 3
 
 // Kind values Cloud DNS stamps on its resources; the SDK tolerates them being
 // absent but real responses carry them, so we mirror the wire faithfully.
@@ -23,11 +32,17 @@ const (
 	kindResourceRecordSet      = "dns#resourceRecordSet"
 	kindResourceRecordSetsList = "dns#resourceRecordSetsListResponse"
 	kindChange                 = "dns#change"
+	kindChangesList            = "dns#changesListResponse"
+	kindOperation              = "dns#operation"
 )
 
 // changeStatusDone is the terminal state Cloud DNS reports once a change has
 // propagated; our mock applies changes synchronously so every change is done.
 const changeStatusDone = "done"
+
+// operationStatusDone is the terminal state a managed-zone Operation reports;
+// zone mutations apply synchronously so every operation is immediately done.
+const operationStatusDone = "done"
 
 // managedZoneJSON is the Cloud DNS ManagedZone resource. The SDK unmarshals
 // `id` as a uint64 (via a `,string` tag), so it must serialize as a numeric
@@ -41,11 +56,13 @@ type managedZoneJSON struct {
 	Visibility   string            `json:"visibility,omitempty"`
 	Labels       map[string]string `json:"labels,omitempty"`
 	CreationTime string            `json:"creationTime,omitempty"`
+	NameServers  []string          `json:"nameServers,omitempty"`
 }
 
 type managedZonesListResponse struct {
-	Kind         string            `json:"kind"`
-	ManagedZones []managedZoneJSON `json:"managedZones"`
+	Kind          string            `json:"kind"`
+	ManagedZones  []managedZoneJSON `json:"managedZones"`
+	NextPageToken string            `json:"nextPageToken,omitempty"`
 }
 
 // resourceRecordSetJSON is the Cloud DNS ResourceRecordSet resource.
@@ -58,8 +75,28 @@ type resourceRecordSetJSON struct {
 }
 
 type resourceRecordSetsListResponse struct {
-	Kind   string                  `json:"kind"`
-	Rrsets []resourceRecordSetJSON `json:"rrsets"`
+	Kind          string                  `json:"kind"`
+	Rrsets        []resourceRecordSetJSON `json:"rrsets"`
+	NextPageToken string                  `json:"nextPageToken,omitempty"`
+}
+
+// changesListResponse is the Cloud DNS changes.list response.
+type changesListResponse struct {
+	Kind          string       `json:"kind"`
+	Changes       []changeJSON `json:"changes"`
+	NextPageToken string       `json:"nextPageToken,omitempty"`
+}
+
+// operationJSON is the Cloud DNS Operation resource, returned by
+// managedZones.patch and managedZones.update. Zone mutations apply
+// synchronously, so the operation is reported done immediately.
+type operationJSON struct {
+	Kind      string `json:"kind"`
+	ID        string `json:"id,omitempty"`
+	StartTime string `json:"startTime,omitempty"`
+	Status    string `json:"status,omitempty"`
+	Type      string `json:"type,omitempty"`
+	User      string `json:"user,omitempty"`
 }
 
 // changeJSON is the Cloud DNS Change resource: a batch of record additions and
@@ -106,13 +143,41 @@ func toManagedZoneJSON(info *dnsdriver.ZoneInfo) managedZoneJSON {
 	}
 
 	return managedZoneJSON{
-		Kind:       kindManagedZone,
-		Name:       info.Name,
-		ID:         numericID(info.ID),
-		Visibility: visibilityFor(info.Private),
-		Labels:     stripReservedTags(info.Tags),
-		DNSName:    dnsName,
+		Kind:         kindManagedZone,
+		Name:         info.Name,
+		ID:           numericID(info.ID),
+		Visibility:   visibilityFor(info.Private),
+		Labels:       stripReservedTags(info.Tags),
+		DNSName:      dnsName,
+		Description:  info.Tags[descriptionTag],
+		CreationTime: info.Tags[creationTimeTag],
+		NameServers:  nameServersFor(info.ID),
 	}
+}
+
+// nsLetterCount is the number of ns-cloud-<letter> pools Cloud DNS draws from.
+const nsLetterCount = 5
+
+// nameServersPerZone is the number of authoritative name servers Cloud DNS
+// assigns to every managed zone.
+const nameServersPerZone = 4
+
+// nameServersFor returns the four authoritative name servers Cloud DNS assigns
+// to a zone, e.g. ns-cloud-e1.googledomains.com. … ns-cloud-e4.googledomains.com.
+// Real Cloud DNS picks one of five letter pools (a–e) per zone; we derive it
+// deterministically from the zone id so a given zone always reports the same
+// delegation NS set on every create/get and in its apex NS record.
+func nameServersFor(zoneID string) []string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(zoneID))
+	letter := rune('a' + int(h.Sum32()%nsLetterCount))
+
+	ns := make([]string, 0, nameServersPerZone)
+	for i := 1; i <= nameServersPerZone; i++ {
+		ns = append(ns, "ns-cloud-"+string(letter)+strconv.Itoa(i)+".googledomains.com.")
+	}
+
+	return ns
 }
 
 // stripReservedTags returns the user labels with cloudemu-internal keys removed.
@@ -136,6 +201,22 @@ func stripReservedTags(in map[string]string) map[string]string {
 	}
 
 	return out
+}
+
+// apexTTL is the TTL Cloud DNS gives the auto-created apex SOA and NS records.
+const apexTTL = 21600
+
+// apexRecordConfigs returns the SOA and NS record sets Cloud DNS auto-creates at
+// a new zone's apex (dnsName). The NS record advertises the zone's delegation
+// name servers; the SOA names the first of them as primary.
+func apexRecordConfigs(zoneID, dnsName string) []dnsdriver.RecordConfig {
+	ns := nameServersFor(zoneID)
+	soa := ns[0] + " cloud-dns-hostmaster.google.com. 1 21600 3600 259200 300"
+
+	return []dnsdriver.RecordConfig{
+		{ZoneID: zoneID, Name: dnsName, Type: "NS", TTL: apexTTL, Values: ns},
+		{ZoneID: zoneID, Name: dnsName, Type: "SOA", TTL: apexTTL, Values: []string{soa}},
+	}
 }
 
 func toRecordSetJSON(rec *dnsdriver.RecordInfo) resourceRecordSetJSON {


### PR DESCRIPTION
## What & why

Fixes the Cloud DNS (`dns.googleapis.com` v1) finding batch from the GCP audit. Each was a real-user behavior gap surfaced by pointing the official `google.golang.org/api/dns/v1` client at the in-process GCP server. All fixes live in the GCP wire handler (`server/gcp/clouddns`); no shared driver interface changed, so AWS/Azure are untouched and no docs regeneration was needed.

## Findings fixed

- **[HIGH] managedZones.create → rrsets.list (apex records):** a new zone now auto-provisions the apex `SOA` + `NS` record sets, so `rrsets.list` on a fresh zone returns 2 (was 0), matching real Cloud DNS.
- **[HIGH] nameServers:** `ManagedZone.nameServers` is now populated with 4 stable authoritative name servers (`ns-cloud-<a–e>{1..4}.googledomains.com.`), derived deterministically per zone and returned on create and get; the apex NS record advertises the same set.
- **[MEDIUM] managedZones.patch/update:** `PATCH`/`PUT` are now served (were 400). They apply description/labels via the driver, preserve the reserved dnsName/creationTime, and return a `dns#operation` (as real Cloud DNS does, not the zone).
- **[MEDIUM] changes.list/get:** `GET .../changes` and `GET .../changes/{id}` now work (were 400). The handler keeps a per-zone change log; `startTime` is now populated on every change so callers can poll to `done`.
- **[MEDIUM] creationTime:** zones now carry an RFC3339 `creationTime`, returned on create and get.
- **[LOW] list pagination + rrset filters:** `managedZones.list` and `rrsets.list` honor `maxResults`/`pageToken` and emit `nextPageToken`; `rrsets.list` honors `?name=`/`?type=` filters.

## Tests

New real-SDK reproduction tests in `management_api_sdk_test.go` (one per finding), plus updated existing `sdk_roundtrip_test.go` assertions to account for the two auto-created apex records. All `server/gcp/clouddns` tests pass, including `-race`.

## Deferrals

None.
