### PR TITLE
fix(gcp-gke): full operation shape, absolute selfLinks, real endpoint, cluster fields, serverConfig

### DIFF
--- a/providers/gcp/gke/gke.go
+++ b/providers/gcp/gke/gke.go
@@ -4,13 +4,15 @@
 // Operations they emit) plus a live Kubernetes data plane. When a shared
 // kubernetes.APIServer is wired in, GetCluster's Endpoint + masterAuth CA point
 // at a real in-memory apiserver so `gcloud container clusters get-credentials`
-// yields a working kubeconfig. Without one, GetCluster falls back to a sentinel
-// Endpoint (https://GKE-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local) so kubeconfig
+// yields a working kubeconfig. Without one, GetCluster reports a deterministic
+// control-plane IP (matching real GKE's bare-IP `endpoint` field) so kubeconfig
 // rendering still works syntactically.
 package gke
 
 import (
 	"context"
+	"fmt"
+	"hash/fnv"
 	"sync"
 	"time"
 
@@ -22,10 +24,8 @@ import (
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
 
-// Stub values used in Cluster responses until the Kubernetes data-plane
-// arrives in Wave 2.
+// Default versions reported by clusters/node pools and getServerConfig.
 const (
-	StubEndpoint    = "GKE-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local"
 	StubMasterVer   = "1.30.0-gke.0"
 	stubNodeVersion = "1.30.0-gke.0"
 )
@@ -36,6 +36,20 @@ const (
 	defaultNodeCount   = 1
 	defaultMachineType = "e2-medium"
 	defaultDiskSizeGB  = 100
+
+	// defaultServicesCIDR mirrors GKE's default Kubernetes Services IP range.
+	defaultServicesCIDR = "34.118.224.0/20"
+	// defaultClusterCIDR is the default pod IP range for the cluster.
+	defaultClusterCIDR = "10.0.0.0/14"
+	// defaultNodeIPv4CIDRSize is the per-node pod CIDR block size (/24).
+	defaultNodeIPv4CIDRSize = 24
+
+	// controlPlaneIPFirstOctet anchors synthesized control-plane IPs in a
+	// public-looking /8, matching real GKE's public endpoint shape.
+	controlPlaneIPFirstOctet = 35
+	octetMod                 = 253
+	octetShift8              = 8
+	octetShift16             = 16
 )
 
 // Cluster is the in-memory representation of a GKE cluster. The shape mirrors
@@ -43,6 +57,7 @@ const (
 // these to the wire shape google.golang.org/api/container/v1.Cluster expects.
 type Cluster struct {
 	Name              string
+	ID                string
 	Location          string
 	Description       string
 	Network           string
@@ -50,6 +65,8 @@ type Cluster struct {
 	InitialNodeCount  int64
 	NodeIPv4CIDRSize  int64
 	ClusterIPv4CIDR   string
+	ServicesIPv4CIDR  string
+	ControlPlaneIP    string
 	LoggingService    string
 	MonitoringService string
 	LegacyAbacEnabled bool
@@ -147,14 +164,16 @@ func (m *Mock) SetK8sAPI(api *kubernetes.APIServer) {
 // Endpoint returns the data-plane URL clients should target for a given
 // cluster. If a Kubernetes APIServer is wired and the cluster has a
 // registered UID, returns "<base>/k8s/<uid>" — the in-memory data plane.
-// Otherwise returns "https://" + StubEndpoint so the Wave-1 sentinel surface
-// stays intact.
+// Otherwise returns the cluster's synthesized control-plane IP (a bare IPv4
+// address, matching real GKE's `endpoint` field) so a kubeconfig renders to a
+// well-formed, non-sentinel host.
 func (m *Mock) Endpoint(location, name string) string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	key := clusterKey(location, name)
+
 	if m.k8sAPI != nil {
-		key := clusterKey(location, name)
 		if uid, ok := m.k8sUIDs[key]; ok {
 			if base := m.k8sAPI.BaseURL(); base != "" {
 				return base + "/k8s/" + uid
@@ -162,7 +181,28 @@ func (m *Mock) Endpoint(location, name string) string {
 		}
 	}
 
-	return "https://" + StubEndpoint
+	if c, ok := m.clusters.Get(key); ok && c.ControlPlaneIP != "" {
+		return c.ControlPlaneIP
+	}
+
+	return controlPlaneIP(location, name)
+}
+
+// controlPlaneIP synthesizes a deterministic, public-looking IPv4 address for a
+// cluster's control-plane endpoint. Real GKE returns such an IP in the Cluster
+// `endpoint` field; the emulator has no real control-plane host without a wired
+// data plane, so a stable per-cluster IP stands in.
+func controlPlaneIP(location, name string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(location + "/" + name))
+	sum := h.Sum32()
+
+	return fmt.Sprintf("%d.%d.%d.%d",
+		controlPlaneIPFirstOctet,
+		(sum>>octetShift16)%octetMod+1,
+		(sum>>octetShift8)%octetMod+1,
+		sum%octetMod+1,
+	)
 }
 
 // emitClusterMetrics pushes container.googleapis.com metrics for a cluster.
@@ -252,13 +292,16 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 
 	cluster := Cluster{
 		Name:              input.Name,
+		ID:                idgen.SyntheticGUID(key),
 		Location:          input.Location,
 		Description:       input.Description,
 		Network:           defaultIfEmpty(input.Network, "default"),
 		Subnetwork:        defaultIfEmpty(input.Subnetwork, "default"),
 		InitialNodeCount:  input.InitialNodeCount,
-		NodeIPv4CIDRSize:  24,
-		ClusterIPv4CIDR:   "10.0.0.0/14",
+		NodeIPv4CIDRSize:  defaultNodeIPv4CIDRSize,
+		ClusterIPv4CIDR:   defaultClusterCIDR,
+		ServicesIPv4CIDR:  defaultServicesCIDR,
+		ControlPlaneIP:    controlPlaneIP(input.Location, input.Name),
 		LoggingService:    defaultIfEmpty(input.LoggingService, "logging.googleapis.com/kubernetes"),
 		MonitoringService: defaultIfEmpty(input.MonitoringService, "monitoring.googleapis.com/kubernetes"),
 		ResourceLabels:    copyLabels(input.ResourceLabels),
@@ -719,6 +762,17 @@ func (m *Mock) GetOperation(_ context.Context, _, name string) (*Operation, erro
 	out := op
 
 	return &out, nil
+}
+
+// HasOperation reports whether an operation with the given name was recorded by
+// this GKE mock. The handler uses it to claim only its own operation polls,
+// letting foreign location operations (artifactregistry, eventarc, …) fall
+// through to the shared LRO handler.
+func (m *Mock) HasOperation(name string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.operations.Has(name)
 }
 
 // ListOperations returns all operations in a location ("-" for all).

--- a/providers/gcp/gke/gke_k8s_test.go
+++ b/providers/gcp/gke/gke_k8s_test.go
@@ -62,7 +62,7 @@ func TestEndpoint_RealURLWhenWired(t *testing.T) {
 	}
 }
 
-func TestEndpoint_NoAPIKeepsSentinel(t *testing.T) {
+func TestEndpoint_NoAPIReturnsControlPlaneIP(t *testing.T) {
 	m := newTestMock()
 
 	if _, _, err := m.CreateCluster(context.Background(), &CreateClusterInput{
@@ -74,16 +74,14 @@ func TestEndpoint_NoAPIKeepsSentinel(t *testing.T) {
 	}
 
 	got := m.Endpoint("us-central1", "c1")
-	if !strings.Contains(got, "GKE-DATAPLANE-NOT-IMPLEMENTED") {
-		t.Fatalf("expected sentinel when no APIServer wired, got: %q", got)
-	}
+	assertControlPlaneIP(t, got)
 }
 
-func TestEndpoint_APIWithoutBaseURLKeepsSentinel(t *testing.T) {
+func TestEndpoint_APIWithoutBaseURLReturnsControlPlaneIP(t *testing.T) {
 	m := newTestMock()
 
 	api := kubernetes.NewAPIServer()
-	// Intentionally no SetBaseURL — Endpoint should fall back.
+	// Intentionally no SetBaseURL — Endpoint should fall back to the IP.
 	m.SetK8sAPI(api)
 
 	if _, _, err := m.CreateCluster(context.Background(), &CreateClusterInput{
@@ -95,23 +93,37 @@ func TestEndpoint_APIWithoutBaseURLKeepsSentinel(t *testing.T) {
 	}
 
 	got := m.Endpoint("us-central1", "c1")
-	if !strings.Contains(got, "GKE-DATAPLANE-NOT-IMPLEMENTED") {
-		t.Fatalf("expected sentinel when APIServer has no base URL, got: %q", got)
-	}
+	assertControlPlaneIP(t, got)
 }
 
-func TestEndpoint_UnknownClusterFallsBackToSentinel(t *testing.T) {
+func TestEndpoint_UnknownClusterFallsBackToControlPlaneIP(t *testing.T) {
 	m := newTestMock()
 
 	api := kubernetes.NewAPIServer()
 	api.SetBaseURL("http://127.0.0.1:8080")
 	m.SetK8sAPI(api)
 
-	// Cluster never created — Endpoint should still return the sentinel
-	// rather than a half-built URL.
+	// Cluster never created — Endpoint should return a synthesized IP rather
+	// than a half-built /k8s/ URL.
 	got := m.Endpoint("us-central1", "ghost")
-	if !strings.Contains(got, "GKE-DATAPLANE-NOT-IMPLEMENTED") {
-		t.Fatalf("expected sentinel for unknown cluster, got: %q", got)
+	assertControlPlaneIP(t, got)
+}
+
+// assertControlPlaneIP fails unless got is a non-sentinel, dotted IPv4 host
+// (not a /k8s/ data-plane URL).
+func assertControlPlaneIP(t *testing.T, got string) {
+	t.Helper()
+
+	if strings.Contains(got, "NOT-IMPLEMENTED") {
+		t.Fatalf("endpoint still the sentinel: %q", got)
+	}
+
+	if strings.Contains(got, "/k8s/") {
+		t.Fatalf("endpoint should be a bare IP, got data-plane URL: %q", got)
+	}
+
+	if strings.Count(got, ".") != 3 {
+		t.Fatalf("endpoint = %q, want a dotted IPv4 address", got)
 	}
 }
 

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -139,11 +139,21 @@ func New(d Drivers) *server.Server {
 
 	srv := server.New()
 
-	// Shared location-operations poller. Registered FIRST so it owns every
-	// GET /v1/projects/{p}/locations/{l}/operations/{op} uniformly, instead of
-	// alloydb/gke greedily claiming (and 404ing) operations created by
-	// artifactregistry, eventarc, memorystore, etc. All emulated ops are
-	// synchronous, so a done response is always correct.
+	// GKE registers ahead of the shared LRO poller because it answers a richer
+	// operation shape (operationType/targetLink/selfLink/zone/timestamps) for
+	// its OWN operations. Its Matches claims a named operation poll only when
+	// the op was recorded by the GKE mock, so foreign location operations still
+	// fall through to lro below — no shadowing.
+	if d.GKE != nil {
+		srv.Register(gke.New(d.GKE))
+	}
+
+	// Shared location-operations poller. Registered ahead of the remaining
+	// service handlers so it owns every GET /v1/projects/{p}/locations/{l}/
+	// operations/{op} uniformly, instead of alloydb greedily claiming (and
+	// 404ing) operations created by artifactregistry, eventarc, memorystore,
+	// etc. All emulated ops are synchronous, so a done response is always
+	// correct.
 	srv.Register(lro.New())
 
 	if d.Compute != nil {
@@ -227,11 +237,8 @@ func New(d Drivers) *server.Server {
 		srv.Register(alloydbsrv.New(d.AlloyDB))
 	}
 
-	// GKE matches /v1/projects/{p}/locations/{l}/{clusters|operations}/...;
-	// same /v1/projects/ space as Firestore, so register first.
-	if d.GKE != nil {
-		srv.Register(gke.New(d.GKE))
-	}
+	// GKE is registered ahead of the LRO poller above (see the top of New) so
+	// its richer operation shape wins for its own operations.
 
 	// Vertex AI matches /v1/projects/{p}/locations/{l}/{models|endpoints|datasets|
 	// customJobs|batchPredictionJobs}/... and /v1/publishers/...:generateContent.

--- a/server/gcp/gke/handler.go
+++ b/server/gcp/gke/handler.go
@@ -54,10 +54,11 @@ const (
 	contentTypeJSON = "application/json"
 	maxBodyBytes    = 1 << 20
 
-	resourceClusters   = "clusters"
-	resourceNodePools  = "nodePools"
-	resourceOperations = "operations"
-	locationsSeg       = "locations"
+	resourceClusters     = "clusters"
+	resourceNodePools    = "nodePools"
+	resourceOperations   = "operations"
+	resourceServerConfig = "serverConfig"
+	locationsSeg         = "locations"
 
 	// actionResX values tag the resource an action applies to.
 	actionResCluster    = "cluster"
@@ -76,35 +77,37 @@ func New(m *gke.Mock) *Handler {
 	return &Handler{gke: m}
 }
 
-// Matches accepts /v1/projects/{p}/locations/{l}/{clusters|operations}/...
-// paths. Anything else (functions, instances, databases) belongs to a
-// different handler and falls through.
-func (*Handler) Matches(r *http.Request) bool {
+// Matches accepts /v1/projects/{p}/locations/{l}/{clusters|operations|
+// serverConfig}/... paths. Anything else (functions, instances, databases)
+// belongs to a different handler and falls through.
+//
+// For a named operation poll it claims ONLY operations this GKE mock recorded,
+// so the shared LRO handler still answers foreign location operations
+// (artifactregistry, eventarc, memorystore, …). This lets the handler register
+// ahead of the LRO poller and return GKE's richer operation shape for its own
+// ops without shadowing everyone else's.
+func (h *Handler) Matches(r *http.Request) bool {
 	if !strings.HasPrefix(r.URL.Path, pathPrefix) {
 		return false
 	}
 
-	parts := strings.Split(strings.TrimPrefix(r.URL.Path, pathPrefix), "/")
-
-	const (
-		idxScope    = 1 // "locations"
-		idxResource = 3 // "clusters" | "operations"
-	)
-
-	if len(parts) <= idxResource {
+	p, ok := parsePath(r.URL.Path)
+	if !ok {
 		return false
 	}
 
-	if parts[idxScope] != locationsSeg {
+	switch p.resource {
+	case resourceClusters, resourceServerConfig:
+		return true
+	case resourceOperations:
+		if p.name != "" && p.action == "" {
+			return h.gke.HasOperation(p.name)
+		}
+
+		return true
+	default:
 		return false
 	}
-
-	res := parts[idxResource]
-	if i := strings.Index(res, ":"); i >= 0 {
-		res = res[:i]
-	}
-
-	return res == resourceClusters || res == resourceOperations
 }
 
 // gkePath holds the parsed components of a GKE URL.
@@ -222,9 +225,23 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.serveClusters(w, r, &p)
 	case resourceOperations:
 		h.serveOperations(w, r, &p)
+	case resourceServerConfig:
+		h.serveServerConfig(w, r)
 	default:
 		writeError(w, http.StatusNotFound, "NOT_FOUND", "unsupported resource: "+p.resource)
 	}
+}
+
+// serveServerConfig answers GET /v1/projects/{p}/locations/{l}/serverConfig
+// with the default/valid cluster and node versions, so `gcloud container
+// get-server-config` and SDK version validation succeed.
+func (*Handler) serveServerConfig(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, defaultServerConfig())
 }
 
 func (h *Handler) serveClusters(w http.ResponseWriter, r *http.Request, p *gkePath) {

--- a/server/gcp/gke/sdk_fidelity_test.go
+++ b/server/gcp/gke/sdk_fidelity_test.go
@@ -1,0 +1,207 @@
+// Reproduction tests for the AUDIT_GCP.md `## gke` findings: full operation
+// shape, absolute selfLinks, a non-sentinel control-plane endpoint, populated
+// cluster identity/network fields, and getServerConfig.
+
+package gke_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/container/v1"
+)
+
+const selfLinkHost = "https://container.googleapis.com/v1/"
+
+// TestSDKGKEOperationFullShape proves operations.get returns GKE's richer
+// operation (operationType/targetLink/selfLink/zone/timestamps), not just the
+// {name,done,status} the shared LRO poller used to shadow it with.
+func TestSDKGKEOperationFullShape(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	op, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "prod"},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Operations.Get(parent(project, loc) + "/operations/" + op.Name).
+		Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("operations.get: %v", err)
+	}
+
+	if got.OperationType != "CREATE_CLUSTER" {
+		t.Fatalf("operationType = %q, want CREATE_CLUSTER", got.OperationType)
+	}
+
+	if got.Status != "DONE" {
+		t.Fatalf("status = %q, want DONE", got.Status)
+	}
+
+	if got.Zone != loc {
+		t.Fatalf("zone = %q, want %q", got.Zone, loc)
+	}
+
+	if got.StartTime == "" || got.EndTime == "" {
+		t.Fatalf("startTime/endTime empty: %q / %q", got.StartTime, got.EndTime)
+	}
+
+	if !strings.HasPrefix(got.SelfLink, selfLinkHost) {
+		t.Fatalf("selfLink = %q, want %s prefix", got.SelfLink, selfLinkHost)
+	}
+
+	if !strings.HasPrefix(got.TargetLink, selfLinkHost) || !strings.Contains(got.TargetLink, "/clusters/prod") {
+		t.Fatalf("targetLink = %q, want absolute URL ending /clusters/prod", got.TargetLink)
+	}
+}
+
+// TestSDKGKEForeignOperationStillDone proves the store-aware Matches lets an
+// operation the GKE mock never recorded fall through to the shared LRO poller
+// (which reports it done) instead of GKE 404ing it.
+func TestSDKGKEForeignOperationStillDone(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	got, err := svc.Projects.Locations.Operations.Get(parent(project, loc) + "/operations/operation-not-gke").
+		Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("operations.get (foreign): %v", err)
+	}
+
+	if got.Status != "DONE" {
+		t.Fatalf("foreign op status = %q, want DONE", got.Status)
+	}
+}
+
+// TestSDKGKEAbsoluteSelfLinks proves cluster and node-pool selfLinks are full
+// https://container.googleapis.com/... URLs, not bare project paths.
+func TestSDKGKEAbsoluteSelfLinks(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "links"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.Get(clusterName(project, loc, "links")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	wantCluster := selfLinkHost + "projects/" + project + "/locations/" + loc + "/clusters/links"
+	if got.SelfLink != wantCluster {
+		t.Fatalf("cluster selfLink = %q, want %q", got.SelfLink, wantCluster)
+	}
+
+	if len(got.NodePools) == 0 {
+		t.Fatal("expected a default node pool")
+	}
+
+	if !strings.HasPrefix(got.NodePools[0].SelfLink, selfLinkHost) {
+		t.Fatalf("nodePool selfLink = %q, want %s prefix", got.NodePools[0].SelfLink, selfLinkHost)
+	}
+}
+
+// TestSDKGKEEndpointNotSentinel proves a fresh cluster reports a non-sentinel,
+// IPv4-shaped control-plane endpoint (not GKE-DATAPLANE-NOT-IMPLEMENTED).
+func TestSDKGKEEndpointNotSentinel(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "reachable"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.Get(clusterName(project, loc, "reachable")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if strings.Contains(got.Endpoint, "NOT-IMPLEMENTED") {
+		t.Fatalf("endpoint still the sentinel: %q", got.Endpoint)
+	}
+
+	if strings.Count(got.Endpoint, ".") != 3 {
+		t.Fatalf("endpoint = %q, want a dotted IPv4 address", got.Endpoint)
+	}
+}
+
+// TestSDKGKEClusterIdentityFields proves id/zone/servicesIpv4Cidr/
+// clusterIpv4Cidr/nodeIpv4CidrSize/currentNodeCount are populated.
+func TestSDKGKEClusterIdentityFields(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "fields", InitialNodeCount: 3},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.Get(clusterName(project, loc, "fields")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.Id == "" {
+		t.Fatal("cluster id empty")
+	}
+
+	if got.Zone != loc {
+		t.Fatalf("zone = %q, want %q", got.Zone, loc)
+	}
+
+	if got.ServicesIpv4Cidr == "" {
+		t.Fatal("servicesIpv4Cidr empty")
+	}
+
+	if got.ClusterIpv4Cidr == "" {
+		t.Fatal("clusterIpv4Cidr empty")
+	}
+
+	if got.NodeIpv4CidrSize == 0 {
+		t.Fatal("nodeIpv4CidrSize zero")
+	}
+
+	if got.CurrentNodeCount == 0 {
+		t.Fatal("currentNodeCount zero")
+	}
+}
+
+// TestSDKGKEGetServerConfig proves getServerConfig returns valid/default
+// versions instead of the old 501.
+func TestSDKGKEGetServerConfig(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	cfg, err := svc.Projects.Locations.GetServerConfig(parent(project, loc)).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("getServerConfig: %v", err)
+	}
+
+	if cfg.DefaultClusterVersion == "" {
+		t.Fatal("defaultClusterVersion empty")
+	}
+
+	if len(cfg.ValidMasterVersions) == 0 {
+		t.Fatal("validMasterVersions empty")
+	}
+
+	if len(cfg.ValidNodeVersions) == 0 {
+		t.Fatal("validNodeVersions empty")
+	}
+}

--- a/server/gcp/gke/sdk_roundtrip_test.go
+++ b/server/gcp/gke/sdk_roundtrip_test.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/api/option"
 
 	"github.com/stackshy/cloudemu/v2"
-	gkeprov "github.com/stackshy/cloudemu/v2/providers/gcp/gke"
 	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
 )
 
@@ -80,8 +79,8 @@ func TestSDKGKECreateGetList(t *testing.T) {
 		t.Fatalf("got status %q, want RUNNING", got.Status)
 	}
 
-	if !strings.Contains(got.Endpoint, gkeprov.StubEndpoint) {
-		t.Fatalf("expected Wave-2 stub endpoint, got %q", got.Endpoint)
+	if got.Endpoint == "" || strings.Contains(got.Endpoint, "NOT-IMPLEMENTED") {
+		t.Fatalf("expected a non-sentinel control-plane endpoint, got %q", got.Endpoint)
 	}
 
 	if got.MasterAuth == nil || got.MasterAuth.ClusterCaCertificate == "" {

--- a/server/gcp/gke/types.go
+++ b/server/gcp/gke/types.go
@@ -14,17 +14,21 @@ import (
 // values via the standard json package.
 type gkeCluster struct {
 	Name              string            `json:"name,omitempty"`
+	ID                string            `json:"id,omitempty"`
 	Description       string            `json:"description,omitempty"`
 	Location          string            `json:"location,omitempty"`
+	Zone              string            `json:"zone,omitempty"`
 	Network           string            `json:"network,omitempty"`
 	Subnetwork        string            `json:"subnetwork,omitempty"`
 	InitialNodeCount  int64             `json:"initialNodeCount,omitempty"`
+	CurrentNodeCount  int64             `json:"currentNodeCount,omitempty"`
 	LoggingService    string            `json:"loggingService,omitempty"`
 	MonitoringService string            `json:"monitoringService,omitempty"`
 	ResourceLabels    map[string]string `json:"resourceLabels,omitempty"`
 	NodePools         []gkeNodePool     `json:"nodePools,omitempty"`
 	NodeIpv4CIDRSize  int64             `json:"nodeIpv4CidrSize,omitempty"`
 	ClusterIpv4Cidr   string            `json:"clusterIpv4Cidr,omitempty"`
+	ServicesIpv4Cidr  string            `json:"servicesIpv4Cidr,omitempty"`
 	Endpoint          string            `json:"endpoint,omitempty"`
 	MasterAuth        *gkeMasterAuth    `json:"masterAuth,omitempty"`
 	Status            string            `json:"status,omitempty"`
@@ -165,29 +169,52 @@ type gkeOperation struct {
 	OperationType string `json:"operationType,omitempty"`
 	Status        string `json:"status,omitempty"`
 	Location      string `json:"location,omitempty"`
+	Zone          string `json:"zone,omitempty"`
 	TargetLink    string `json:"targetLink,omitempty"`
 	StartTime     string `json:"startTime,omitempty"`
 	EndTime       string `json:"endTime,omitempty"`
 	SelfLink      string `json:"selfLink,omitempty"`
 }
 
+// gkeServerConfig mirrors container/v1.ServerConfig for getServerConfig.
+type gkeServerConfig struct {
+	DefaultClusterVersion string   `json:"defaultClusterVersion,omitempty"`
+	ValidMasterVersions   []string `json:"validMasterVersions,omitempty"`
+	ValidNodeVersions     []string `json:"validNodeVersions,omitempty"`
+	DefaultImageType      string   `json:"defaultImageType,omitempty"`
+	ValidImageTypes       []string `json:"validImageTypes,omitempty"`
+}
+
+// selfLinkBase is the container-API host+version prefix real GKE stamps onto
+// every selfLink/targetLink it returns.
+const selfLinkBase = "https://container.googleapis.com/v1/"
+
 // toClusterResource converts a provider Cluster into the wire shape. The
 // endpoint argument is what the Mock reported via Endpoint(location, name) —
-// either the in-memory K8s data-plane URL when Wave 2 is wired, or the
-// "https://GKE-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local" sentinel.
+// either the in-memory K8s data-plane URL when a data plane is wired, or the
+// cluster's synthesized control-plane IP.
 func toClusterResource(c *gke.Cluster, project, endpoint string, pools []gke.NodePool) gkeCluster {
+	var currentNodes int64
+	for i := range pools {
+		currentNodes += pools[i].NodeCount
+	}
+
 	out := gkeCluster{
 		Name:              c.Name,
+		ID:                c.ID,
 		Description:       c.Description,
 		Location:          c.Location,
+		Zone:              c.Location,
 		Network:           c.Network,
 		Subnetwork:        c.Subnetwork,
 		InitialNodeCount:  c.InitialNodeCount,
+		CurrentNodeCount:  currentNodes,
 		LoggingService:    c.LoggingService,
 		MonitoringService: c.MonitoringService,
 		ResourceLabels:    c.ResourceLabels,
 		NodeIpv4CIDRSize:  c.NodeIPv4CIDRSize,
 		ClusterIpv4Cidr:   c.ClusterIPv4CIDR,
+		ServicesIpv4Cidr:  c.ServicesIPv4CIDR,
 		Endpoint:          endpoint,
 		MasterAuth: &gkeMasterAuth{
 			Username: c.MasterUsername,
@@ -199,7 +226,7 @@ func toClusterResource(c *gke.Cluster, project, endpoint string, pools []gke.Nod
 		Status:           c.Status,
 		CurrentMasterVer: versionOr(c.MasterVersion),
 		CurrentNodeVer:   versionOr(c.NodeVersion),
-		SelfLink:         "projects/" + project + "/locations/" + c.Location + "/clusters/" + c.Name,
+		SelfLink:         selfLinkBase + "projects/" + project + "/locations/" + c.Location + "/clusters/" + c.Name,
 		CreateTime:       c.CreatedAt.Format("2006-01-02T15:04:05.000Z"),
 	}
 
@@ -234,7 +261,7 @@ func toNodePoolResource(np *gke.NodePool, project string) gkeNodePool {
 			AutoRepair:  np.AutoRepair,
 		},
 		Status: np.Status,
-		SelfLink: "projects/" + project + "/locations/" + np.Location +
+		SelfLink: selfLinkBase + "projects/" + project + "/locations/" + np.Location +
 			"/clusters/" + np.ClusterName + "/nodePools/" + np.Name,
 	}
 
@@ -255,10 +282,26 @@ func toOperationResource(op *gke.Operation, project string) gkeOperation {
 		OperationType: op.OperationType,
 		Status:        op.Status,
 		Location:      op.Location,
-		TargetLink:    op.TargetLink,
+		Zone:          op.Location,
+		TargetLink:    selfLinkBase + op.TargetLink,
 		StartTime:     op.StartTime.Format("2006-01-02T15:04:05.000Z"),
 		EndTime:       op.EndTime.Format("2006-01-02T15:04:05.000Z"),
-		SelfLink:      "projects/" + project + "/locations/" + op.Location + "/operations/" + op.Name,
+		SelfLink:      selfLinkBase + "projects/" + project + "/locations/" + op.Location + "/operations/" + op.Name,
+	}
+}
+
+// defaultServerConfig returns the versions getServerConfig advertises. They are
+// centered on the emulator's default GKE version so create/upgrade validation
+// against these lists succeeds.
+func defaultServerConfig() gkeServerConfig {
+	versions := []string{gke.StubMasterVer, "1.29.0-gke.0", "1.28.0-gke.0"}
+
+	return gkeServerConfig{
+		DefaultClusterVersion: gke.StubMasterVer,
+		ValidMasterVersions:   versions,
+		ValidNodeVersions:     versions,
+		DefaultImageType:      "COS_CONTAINERD",
+		ValidImageTypes:       []string{"COS_CONTAINERD", "UBUNTU_CONTAINERD"},
 	}
 }
 


### PR DESCRIPTION
## What & why

Fixes the 5 GKE (Kubernetes Engine / Container API) findings from the GCP audit. These are behaviors a real `google.golang.org/api/container/v1` user hits when driving clusters, node pools, operations, and version discovery.

## Findings fixed

- **[HIGH] operations.get shadowed** — the shared `lro.Handler` was registered ahead of GKE and answered every location-operation poll with only `{name,done,status}`, stripping GKE's richer shape. GKE now registers ahead of the LRO poller and its `Matches` claims a named operation poll **only when the op is in the GKE store**, so foreign location operations (artifactregistry, eventarc, memorystore, …) still fall through to `lro` — no shadowing. `operations.get` now returns `operationType`/`targetLink`/`selfLink`/`zone`/`startTime`/`endTime`.
- **[HIGH] relative selfLinks** — cluster, node-pool, and operation `selfLink` (plus operation `targetLink`) are now absolute `https://container.googleapis.com/v1/...` URLs.
- **[MEDIUM] sentinel endpoint** — a fresh cluster reported `https://GKE-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local`. It now reports a deterministic, dotted-IPv4 control-plane IP (matching real GKE's bare-IP `endpoint` field); when the in-memory Kubernetes data plane is wired, the reachable `/k8s/<uid>` URL still wins.
- **[MEDIUM] empty cluster fields** — `id`, `zone`, `servicesIpv4Cidr`, and `currentNodeCount` are now populated (`clusterIpv4Cidr`/`nodeIpv4CidrSize` were already set).
- **[LOW] getServerConfig 501** — `GET .../locations/{l}/serverConfig` now returns default/valid cluster and node versions so `gcloud container get-server-config` and SDK version validation succeed.

## Tests

New `server/gcp/gke/sdk_fidelity_test.go` drives the real `container/v1` client against the in-process GCP server and proves each finding's repro passes, plus a foreign-operation test proving the LRO fall-through still works. Existing GKE server/provider tests updated for the non-sentinel endpoint and kept green.

## Notes

No shared driver interface changed — GKE uses a concrete provider mock, so no `docs/coverage` regeneration was needed.
