### PR TITLE
fix(gcp-cloudrun): Services/Revisions surface + Jobs patch/IAM/executions.list/status fields

### DIFF
--- a/docs/coverage/README.md
+++ b/docs/coverage/README.md
@@ -17,7 +17,7 @@ capability the code does not implement. Machine-readable: [`coverage.json`](./co
 | `bedrockagentruntime` | [BedrockAgentRuntime](./aws/bedrockagentruntime.md) | — | — | — | 3 |
 | `bigtable` | — | — | [Bigtable](./gcp/bigtable.md) | — | 38 |
 | `cache` | [ElastiCache](./aws/elasticache.md) | [Cache](./azure/cache.md) | [Memorystore](./gcp/memorystore.md) | — | 17 |
-| `cloudrun` | — | — | [CloudRun](./gcp/cloudrun.md) | — | 6 |
+| `cloudrun` | — | — | [CloudRun](./gcp/cloudrun.md) | — | 16 |
 | `cloudtrail` | [CloudTrail](./aws/cloudtrail.md) | — | — | — | 60 |
 | `compute` | [EC2](./aws/ec2.md) | [VirtualMachines](./azure/virtualmachines.md) | [GCE](./gcp/gce.md) | — | 37 |
 | `configservice` | [Config](./aws/config.md) | — | — | — | 102 |

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -1609,8 +1609,20 @@
         "doc": "CreateJob stores a job spec. It does not run anything — RunJob does."
       },
       {
+        "name": "CreateService",
+        "doc": "CreateService stores a service spec and materializes its first Revision,"
+      },
+      {
         "name": "DeleteJob",
         "doc": "DeleteJob removes a job and stops any container workloads its executions"
+      },
+      {
+        "name": "DeleteRevision",
+        "doc": "DeleteRevision removes a single revision of a service."
+      },
+      {
+        "name": "DeleteService",
+        "doc": "DeleteService removes a service and its revisions."
       },
       {
         "name": "GetExecution",
@@ -1621,12 +1633,40 @@
         "doc": "GetJob returns a job by name. name may be the bare job id or a fully"
       },
       {
+        "name": "GetRevision",
+        "doc": "GetRevision returns a revision by name (bare revision id or a fully"
+      },
+      {
+        "name": "GetService",
+        "doc": "GetService returns a service by name (bare service id or a fully"
+      },
+      {
+        "name": "ListExecutions",
+        "doc": "ListExecutions returns every stored execution of the named job."
+      },
+      {
         "name": "ListJobs",
         "doc": "ListJobs returns every stored job."
       },
       {
+        "name": "ListRevisions",
+        "doc": "ListRevisions returns every stored revision of the named service."
+      },
+      {
+        "name": "ListServices",
+        "doc": "ListServices returns every stored service."
+      },
+      {
         "name": "RunJob",
         "doc": "RunJob creates and runs one Execution of the named job, blocking until"
+      },
+      {
+        "name": "UpdateJob",
+        "doc": "UpdateJob applies an in-place update to an existing job, bumping its"
+      },
+      {
+        "name": "UpdateService",
+        "doc": "UpdateService applies an in-place update, materializing a new Revision"
       }
     ],
     "providers": {

--- a/docs/coverage/gcp/README.md
+++ b/docs/coverage/gcp/README.md
@@ -12,7 +12,7 @@ Services cloudemu emulates for GCP, by native name. Back to the [cross-provider 
 | [CloudFunctions](./cloudfunctions.md) | `serverless` | 27 |
 | [CloudLogging](./cloudlogging.md) | `logging` | 14 |
 | [CloudMonitoring](./cloudmonitoring.md) | `monitoring` | 12 |
-| [CloudRun](./cloudrun.md) | `cloudrun` | 6 |
+| [CloudRun](./cloudrun.md) | `cloudrun` | 16 |
 | [Eventarc](./eventarc.md) | `eventbus` | 16 |
 | [FCM](./fcm.md) | `notification` | 9 |
 | [Firestore](./firestore.md) | `database` | 24 |

--- a/docs/coverage/gcp/cloudrun.md
+++ b/docs/coverage/gcp/cloudrun.md
@@ -3,16 +3,26 @@
 
 GCP's `cloudrun` service · portable interface `driver.CloudRun` · [GCP index](./README.md)
 
-## Operations (6)
+## Operations (16)
 
 | Operation | Description |
 | --- | --- |
 | `CreateJob` | CreateJob stores a job spec. It does not run anything — RunJob does. |
+| `CreateService` | CreateService stores a service spec and materializes its first Revision, |
 | `DeleteJob` | DeleteJob removes a job and stops any container workloads its executions |
+| `DeleteRevision` | DeleteRevision removes a single revision of a service. |
+| `DeleteService` | DeleteService removes a service and its revisions. |
 | `GetExecution` | GetExecution returns an execution by name (bare execution id or a fully |
 | `GetJob` | GetJob returns a job by name. name may be the bare job id or a fully |
+| `GetRevision` | GetRevision returns a revision by name (bare revision id or a fully |
+| `GetService` | GetService returns a service by name (bare service id or a fully |
+| `ListExecutions` | ListExecutions returns every stored execution of the named job. |
 | `ListJobs` | ListJobs returns every stored job. |
+| `ListRevisions` | ListRevisions returns every stored revision of the named service. |
+| `ListServices` | ListServices returns every stored service. |
 | `RunJob` | RunJob creates and runs one Execution of the named job, blocking until |
+| `UpdateJob` | UpdateJob applies an in-place update to an existing job, bumping its |
+| `UpdateService` | UpdateService applies an in-place update, materializing a new Revision |
 
 ## Not in scope
 

--- a/providers/gcp/cloudrun/cloudrun.go
+++ b/providers/gcp/cloudrun/cloudrun.go
@@ -14,8 +14,10 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -44,6 +46,8 @@ type Mock struct {
 	mu         sync.Mutex
 	jobs       *memstore.Store[*driver.Job]
 	executions *memstore.Store[*driver.Execution]
+	services   *memstore.Store[*driver.Service]
+	revisions  *memstore.Store[*driver.Revision]
 	// engineHandles maps a job id to the ContainerEngine handles its executions
 	// started. A present, non-empty entry is the engine-backed marker DeleteJob
 	// consults to tear down real containers; an absent entry means the job's
@@ -58,12 +62,16 @@ func New(opts *config.Options) *Mock {
 	return &Mock{
 		jobs:          memstore.New[*driver.Job](),
 		executions:    memstore.New[*driver.Execution](),
+		services:      memstore.New[*driver.Service](),
+		revisions:     memstore.New[*driver.Revision](),
 		engineHandles: memstore.New[[]string](),
 		opts:          opts,
 	}
 }
 
 // CreateJob stores a job spec without running it.
+//
+//nolint:gocritic // hugeParam: cfg is passed by value to satisfy the CloudRun driver interface.
 func (m *Mock) CreateJob(_ context.Context, cfg driver.JobConfig) (*driver.Job, error) {
 	name := lastSegment(cfg.Name)
 	if name == "" {
@@ -84,22 +92,103 @@ func (m *Mock) CreateJob(_ context.Context, cfg driver.JobConfig) (*driver.Job, 
 
 	now := m.opts.Clock.Now()
 	job := &driver.Job{
-		Name:        name,
-		UID:         newID(uidBytes),
-		Generation:  1,
-		CreateTime:  now,
-		UpdateTime:  now,
-		LaunchStage: launchStageGA,
-		TaskCount:   taskCount,
-		Containers:  cloneContainers(cfg.Containers),
-		Labels:      cloneMap(cfg.Labels),
-		Annotations: cloneMap(cfg.Annotations),
-		Conditions:  []driver.Condition{{Type: condReady, State: stateSucceeded, Reason: "Ready"}},
+		Name:                 name,
+		UID:                  newID(uidBytes),
+		Generation:           1,
+		ObservedGeneration:   1,
+		CreateTime:           now,
+		UpdateTime:           now,
+		LaunchStage:          launchStageGA,
+		TaskCount:            taskCount,
+		Parallelism:          cfg.Parallelism,
+		MaxRetries:           cfg.MaxRetries,
+		Timeout:              cfg.Timeout,
+		ServiceAccount:       cfg.ServiceAccount,
+		ExecutionEnvironment: cfg.ExecutionEnvironment,
+		VPCAccess:            cloneVPCAccess(cfg.VPCAccess),
+		Containers:           cloneContainers(cfg.Containers),
+		Labels:               cloneMap(cfg.Labels),
+		Annotations:          cloneMap(cfg.Annotations),
+		Conditions:           []driver.Condition{{Type: condReady, State: stateSucceeded, Reason: "Ready"}},
+		TerminalCondition:    &driver.Condition{Type: condReady, State: stateSucceeded, Reason: "Ready"},
+		Etag:                 newEtag(now, 1),
 	}
 
 	m.jobs.Set(name, job)
 
 	return cloneJob(job), nil
+}
+
+// UpdateJob applies an in-place update to an existing job, bumping its
+// generation, and returns the mutated job.
+//
+//nolint:gocritic // hugeParam: cfg is passed by value to satisfy the CloudRun driver interface.
+func (m *Mock) UpdateJob(_ context.Context, cfg driver.JobConfig) (*driver.Job, error) {
+	name := lastSegment(cfg.Name)
+	if name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "job name is required")
+	}
+
+	taskCount := cfg.TaskCount
+	if taskCount <= 0 {
+		taskCount = defaultTaskCount
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	job, ok := m.jobs.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "job %q not found", name)
+	}
+
+	now := m.opts.Clock.Now()
+	job.Generation++
+	job.ObservedGeneration = job.Generation
+	job.UpdateTime = now
+	job.TaskCount = taskCount
+	job.Parallelism = cfg.Parallelism
+	job.MaxRetries = cfg.MaxRetries
+	job.Timeout = cfg.Timeout
+	job.ServiceAccount = cfg.ServiceAccount
+	job.ExecutionEnvironment = cfg.ExecutionEnvironment
+	job.VPCAccess = cloneVPCAccess(cfg.VPCAccess)
+	job.Containers = cloneContainers(cfg.Containers)
+	job.Labels = cloneMap(cfg.Labels)
+	job.Annotations = cloneMap(cfg.Annotations)
+	job.Etag = newEtag(now, job.Generation)
+
+	m.jobs.Set(name, job)
+
+	return cloneJob(job), nil
+}
+
+// ListExecutions returns every stored execution of the named job.
+func (m *Mock) ListExecutions(_ context.Context, jobName string) ([]driver.Execution, error) {
+	id := lastSegment(jobName)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.jobs.Has(id) {
+		return nil, cerrors.Newf(cerrors.NotFound, "job %q not found", id)
+	}
+
+	return collectByParent(m.executions.SortedValues(), id,
+		func(e *driver.Execution) string { return e.JobName }, cloneExecution), nil
+}
+
+// collectByParent returns clones of every value whose parent id matches.
+func collectByParent[T any](values []*T, parent string, parentOf func(*T) string, clone func(*T) *T) []T {
+	out := make([]T, 0, len(values))
+
+	for _, v := range values {
+		if parentOf(v) == parent {
+			out = append(out, *clone(v))
+		}
+	}
+
+	return out
 }
 
 // GetJob returns a job by id or fully qualified name.
@@ -232,8 +321,42 @@ func cloneJob(j *driver.Job) *driver.Job {
 	cp.Labels = cloneMap(j.Labels)
 	cp.Annotations = cloneMap(j.Annotations)
 	cp.Conditions = append([]driver.Condition(nil), j.Conditions...)
+	cp.VPCAccess = cloneVPCAccess(j.VPCAccess)
+
+	if j.TerminalCondition != nil {
+		tc := *j.TerminalCondition
+		cp.TerminalCondition = &tc
+	}
+
+	if j.LatestCreatedExecution != nil {
+		ref := *j.LatestCreatedExecution
+		cp.LatestCreatedExecution = &ref
+	}
 
 	return &cp
+}
+
+// cloneVPCAccess deep-copies a VPC access config, or returns nil.
+func cloneVPCAccess(in *driver.VpcAccess) *driver.VpcAccess {
+	if in == nil {
+		return nil
+	}
+
+	out := &driver.VpcAccess{Connector: in.Connector, Egress: in.Egress}
+	for _, ni := range in.NetworkInterfaces {
+		out.NetworkInterfaces = append(out.NetworkInterfaces, driver.VpcNetworkInterface{
+			Network:    ni.Network,
+			Subnetwork: ni.Subnetwork,
+			Tags:       append([]string(nil), ni.Tags...),
+		})
+	}
+
+	return out
+}
+
+// newEtag returns a stable, opaque etag for a resource state.
+func newEtag(t time.Time, generation int64) string {
+	return `"` + strconv.FormatInt(t.UnixNano(), 36) + "-" + strconv.FormatInt(generation, 10) + `"`
 }
 
 func cloneExecution(e *driver.Execution) *driver.Execution {

--- a/providers/gcp/cloudrun/cloudrun.go
+++ b/providers/gcp/cloudrun/cloudrun.go
@@ -296,6 +296,7 @@ func cloneContainers(in []driver.Container) []driver.Container {
 			Command: append([]string(nil), in[i].Command...),
 			Args:    append([]string(nil), in[i].Args...),
 			Env:     cloneMap(in[i].Env),
+			Ports:   append([]int(nil), in[i].Ports...),
 		}
 	}
 

--- a/providers/gcp/cloudrun/engine.go
+++ b/providers/gcp/cloudrun/engine.go
@@ -51,6 +51,15 @@ func (m *Mock) RunJob(ctx context.Context, name string) (*driver.Execution, erro
 	m.mu.Lock()
 	exec.CompletionTime = m.opts.Clock.Now()
 	m.executions.Set(exec.Name, exec)
+
+	if job, ok := m.jobs.Get(jobName); ok {
+		job.LatestCreatedExecution = &driver.ExecutionReference{
+			Name:           exec.Name,
+			CreateTime:     exec.CreateTime,
+			CompletionTime: exec.CompletionTime,
+		}
+	}
+
 	m.mu.Unlock()
 
 	return cloneExecution(exec), nil

--- a/providers/gcp/cloudrun/services.go
+++ b/providers/gcp/cloudrun/services.go
@@ -1,0 +1,360 @@
+package cloudrun
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
+)
+
+const (
+	ingressDefault      = "INGRESS_TRAFFIC_ALL"
+	trafficTypeLatest   = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+	trafficTypeRevision = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
+	revSuffixBytes      = 2  // 4 hex chars, matching Cloud Run's revision id suffix
+	uriHashLen          = 10 // length of the uid-derived hash in the *.run.app URL
+	fullPercent         = 100
+)
+
+// CreateService stores a service spec, materializes its first revision, and
+// returns the reconciled service serving traffic at a stable URL.
+//
+//nolint:gocritic // hugeParam: cfg is passed by value to satisfy the CloudRun driver interface.
+func (m *Mock) CreateService(_ context.Context, cfg driver.ServiceConfig) (*driver.Service, error) {
+	name := lastSegment(cfg.Name)
+	if name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "service name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.services.Has(name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "service %q already exists", name)
+	}
+
+	now := m.opts.Clock.Now()
+	svc := &driver.Service{
+		Name:       name,
+		UID:        newID(uidBytes),
+		Generation: 1,
+		CreateTime: now,
+	}
+	applyServiceConfig(svc, &cfg)
+
+	rev := m.materializeRevision(svc, now)
+	reconcile(svc, rev, now, regionOrDefault(cfg.Location))
+
+	m.services.Set(name, svc)
+
+	return cloneService(svc), nil
+}
+
+// GetService returns a service by id or fully qualified name.
+func (m *Mock) GetService(_ context.Context, name string) (*driver.Service, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	svc, ok := m.services.Get(lastSegment(name))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "service %q not found", lastSegment(name))
+	}
+
+	return cloneService(svc), nil
+}
+
+// ListServices returns every stored service, sorted by id.
+func (m *Mock) ListServices(_ context.Context) ([]driver.Service, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	svcs := m.services.SortedValues()
+	out := make([]driver.Service, 0, len(svcs))
+
+	for _, s := range svcs {
+		out = append(out, *cloneService(s))
+	}
+
+	return out, nil
+}
+
+// UpdateService applies an in-place update, materializes a new revision, bumps
+// the generation, and returns the reconciled service.
+//
+//nolint:gocritic // hugeParam: cfg is passed by value to satisfy the CloudRun driver interface.
+func (m *Mock) UpdateService(_ context.Context, cfg driver.ServiceConfig) (*driver.Service, error) {
+	name := lastSegment(cfg.Name)
+	if name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "service name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	svc, ok := m.services.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "service %q not found", name)
+	}
+
+	created, uid, gen := svc.CreateTime, svc.UID, svc.Generation+1
+
+	applyServiceConfig(svc, &cfg)
+
+	svc.CreateTime, svc.UID, svc.Generation = created, uid, gen
+	now := m.opts.Clock.Now()
+	rev := m.materializeRevision(svc, now)
+	reconcile(svc, rev, now, regionOrDefault(cfg.Location))
+
+	m.services.Set(name, svc)
+
+	return cloneService(svc), nil
+}
+
+// DeleteService removes a service and all of its revisions.
+func (m *Mock) DeleteService(_ context.Context, name string) error {
+	id := lastSegment(name)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.services.Has(id) {
+		return cerrors.Newf(cerrors.NotFound, "service %q not found", id)
+	}
+
+	m.services.Delete(id)
+
+	for _, key := range m.revisions.Keys() {
+		if rev, ok := m.revisions.Get(key); ok && rev.Service == id {
+			m.revisions.Delete(key)
+		}
+	}
+
+	return nil
+}
+
+// ListRevisions returns every stored revision of the named service, sorted by id.
+func (m *Mock) ListRevisions(_ context.Context, serviceName string) ([]driver.Revision, error) {
+	id := lastSegment(serviceName)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.services.Has(id) {
+		return nil, cerrors.Newf(cerrors.NotFound, "service %q not found", id)
+	}
+
+	return collectByParent(m.revisions.SortedValues(), id,
+		func(r *driver.Revision) string { return r.Service }, cloneRevision), nil
+}
+
+// GetRevision returns a revision by id or fully qualified name.
+func (m *Mock) GetRevision(_ context.Context, name string) (*driver.Revision, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rev, ok := m.revisions.Get(lastSegment(name))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "revision %q not found", lastSegment(name))
+	}
+
+	return cloneRevision(rev), nil
+}
+
+// DeleteRevision removes a single revision of a service.
+func (m *Mock) DeleteRevision(_ context.Context, name string) error {
+	id := lastSegment(name)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.revisions.Has(id) {
+		return cerrors.Newf(cerrors.NotFound, "revision %q not found", id)
+	}
+
+	m.revisions.Delete(id)
+
+	return nil
+}
+
+// applyServiceConfig overlays cfg's mutable fields onto svc, defaulting ingress
+// and launch stage when the caller omitted them.
+func applyServiceConfig(svc *driver.Service, cfg *driver.ServiceConfig) {
+	ingress := cfg.Ingress
+	if ingress == "" {
+		ingress = ingressDefault
+	}
+
+	launchStage := cfg.LaunchStage
+	if launchStage == "" {
+		launchStage = launchStageGA
+	}
+
+	svc.Description = cfg.Description
+	svc.Ingress = ingress
+	svc.LaunchStage = launchStage
+	svc.Containers = cloneContainers(cfg.Containers)
+	svc.ServiceAccount = cfg.ServiceAccount
+	svc.Timeout = cfg.Timeout
+	svc.ExecutionEnvironment = cfg.ExecutionEnvironment
+	svc.VPCAccess = cloneVPCAccess(cfg.VPCAccess)
+	svc.Scaling = cloneScaling(cfg.Scaling)
+	svc.Traffic = cloneTraffic(cfg.Traffic)
+	svc.Labels = cloneMap(cfg.Labels)
+	svc.Annotations = cloneMap(cfg.Annotations)
+}
+
+// materializeRevision creates and stores a new revision from svc's current
+// template, named {service}-{generation:05d}-{suffix}, and returns it.
+func (m *Mock) materializeRevision(svc *driver.Service, now time.Time) *driver.Revision {
+	revName := fmt.Sprintf("%s-%05d-%s", svc.Name, svc.Generation, newID(revSuffixBytes))
+	rev := &driver.Revision{
+		Name:                 revName,
+		UID:                  newID(uidBytes),
+		Generation:           svc.Generation,
+		Service:              svc.Name,
+		CreateTime:           now,
+		UpdateTime:           now,
+		LaunchStage:          svc.LaunchStage,
+		Containers:           cloneContainers(svc.Containers),
+		ServiceAccount:       svc.ServiceAccount,
+		Timeout:              svc.Timeout,
+		ExecutionEnvironment: svc.ExecutionEnvironment,
+		VPCAccess:            cloneVPCAccess(svc.VPCAccess),
+		Scaling:              cloneScaling(svc.Scaling),
+		Conditions:           []driver.Condition{{Type: condReady, State: stateSucceeded, Reason: "Ready"}},
+		Etag:                 newEtag(now, svc.Generation),
+	}
+
+	m.revisions.Set(revName, rev)
+
+	return rev
+}
+
+// reconcile rolls the newly materialized revision up onto svc: revision
+// pointers, URL, traffic status, terminal condition, generation echoes, and
+// etag — the observed state a real reconcile would report.
+func reconcile(svc *driver.Service, rev *driver.Revision, now time.Time, region string) {
+	svc.UpdateTime = now
+	svc.ObservedGeneration = svc.Generation
+	svc.LatestCreatedRevision = rev.Name
+	svc.LatestReadyRevision = rev.Name
+	svc.Reconciling = false
+	svc.Etag = newEtag(now, svc.Generation)
+
+	if svc.URI == "" {
+		svc.URI = serviceURI(svc, region)
+	}
+
+	if len(svc.Traffic) == 0 {
+		svc.Traffic = []driver.TrafficTarget{{Type: trafficTypeLatest, Percent: fullPercent}}
+	}
+
+	svc.TrafficStatuses = trafficStatuses(svc)
+	svc.TerminalCondition = &driver.Condition{Type: condReady, State: stateSucceeded, Reason: "Ready"}
+	svc.Conditions = []driver.Condition{{Type: condReady, State: stateSucceeded, Reason: "Ready"}}
+}
+
+// regionOrDefault falls back to a canonical region when the path carried none.
+func regionOrDefault(region string) string {
+	if region == "" {
+		return "us-central1"
+	}
+
+	return region
+}
+
+// serviceURI returns the stable *.run.app URL Cloud Run assigns a service.
+func serviceURI(svc *driver.Service, region string) string {
+	hash := svc.UID
+	if len(hash) > uriHashLen {
+		hash = hash[:uriHashLen]
+	}
+
+	return fmt.Sprintf("https://%s-%s.%s.run.app", svc.Name, hash, region)
+}
+
+// trafficStatuses resolves a service's requested traffic split into observed
+// statuses, pinning LATEST targets to the latest ready revision and attaching
+// each tagged target's per-tag URL.
+func trafficStatuses(svc *driver.Service) []driver.TrafficTarget {
+	out := make([]driver.TrafficTarget, 0, len(svc.Traffic))
+
+	for _, t := range svc.Traffic {
+		st := driver.TrafficTarget{Type: t.Type, Percent: t.Percent, Tag: t.Tag}
+
+		if t.Type == trafficTypeLatest || t.Revision == "" {
+			st.Type = trafficTypeLatest
+			st.Revision = svc.LatestReadyRevision
+		} else {
+			st.Type = trafficTypeRevision
+			st.Revision = t.Revision
+		}
+
+		if t.Tag != "" {
+			st.URI = taggedURI(svc.URI, t.Tag)
+		}
+
+		out = append(out, st)
+	}
+
+	return out
+}
+
+// taggedURI derives a per-tag revision URL from a service URL.
+func taggedURI(serviceURL, tag string) string {
+	const scheme = "https://"
+	if len(serviceURL) > len(scheme) && serviceURL[:len(scheme)] == scheme {
+		return scheme + tag + "---" + serviceURL[len(scheme):]
+	}
+
+	return serviceURL
+}
+
+func cloneService(s *driver.Service) *driver.Service {
+	cp := *s
+	cp.Containers = cloneContainers(s.Containers)
+	cp.Labels = cloneMap(s.Labels)
+	cp.Annotations = cloneMap(s.Annotations)
+	cp.Conditions = append([]driver.Condition(nil), s.Conditions...)
+	cp.Traffic = cloneTraffic(s.Traffic)
+	cp.TrafficStatuses = cloneTraffic(s.TrafficStatuses)
+	cp.VPCAccess = cloneVPCAccess(s.VPCAccess)
+	cp.Scaling = cloneScaling(s.Scaling)
+
+	if s.TerminalCondition != nil {
+		tc := *s.TerminalCondition
+		cp.TerminalCondition = &tc
+	}
+
+	return &cp
+}
+
+func cloneRevision(r *driver.Revision) *driver.Revision {
+	cp := *r
+	cp.Containers = cloneContainers(r.Containers)
+	cp.Conditions = append([]driver.Condition(nil), r.Conditions...)
+	cp.VPCAccess = cloneVPCAccess(r.VPCAccess)
+	cp.Scaling = cloneScaling(r.Scaling)
+
+	return &cp
+}
+
+func cloneTraffic(in []driver.TrafficTarget) []driver.TrafficTarget {
+	if in == nil {
+		return nil
+	}
+
+	return append([]driver.TrafficTarget(nil), in...)
+}
+
+func cloneScaling(in *driver.ServiceScaling) *driver.ServiceScaling {
+	if in == nil {
+		return nil
+	}
+
+	cp := *in
+
+	return &cp
+}

--- a/providers/gcp/cloudrun/services_test.go
+++ b/providers/gcp/cloudrun/services_test.go
@@ -1,0 +1,158 @@
+package cloudrun
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
+)
+
+func svcCfg() driver.ServiceConfig {
+	return driver.ServiceConfig{
+		Name:           "web",
+		Location:       "us-central1",
+		ServiceAccount: "web@demo.iam.gserviceaccount.com",
+		Timeout:        "300s",
+		Scaling:        &driver.ServiceScaling{MinInstanceCount: 1, MaxInstanceCount: 3},
+		Containers:     []driver.Container{{Image: "gcr.io/demo/web:v1", Ports: []int{8080}}},
+	}
+}
+
+func TestCreateServiceReconciles(t *testing.T) {
+	m := newMock(t, nil)
+	ctx := context.Background()
+
+	svc, err := m.CreateService(ctx, svcCfg())
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	if svc.UID == "" || svc.Generation != 1 || svc.ObservedGeneration != 1 {
+		t.Fatalf("unexpected service: %+v", svc)
+	}
+
+	if !strings.HasPrefix(svc.URI, "https://web-") || !strings.HasSuffix(svc.URI, ".us-central1.run.app") {
+		t.Fatalf("uri = %q", svc.URI)
+	}
+
+	if !strings.HasPrefix(svc.LatestReadyRevision, "web-00001-") {
+		t.Fatalf("latestReadyRevision = %q", svc.LatestReadyRevision)
+	}
+
+	if len(svc.Traffic) != 1 || svc.Traffic[0].Percent != 100 {
+		t.Fatalf("traffic = %+v", svc.Traffic)
+	}
+
+	if svc.TerminalCondition == nil || svc.TerminalCondition.State != "CONDITION_SUCCEEDED" {
+		t.Fatalf("terminalCondition = %+v", svc.TerminalCondition)
+	}
+
+	if _, err := m.CreateService(ctx, svcCfg()); !cerrors.IsAlreadyExists(err) {
+		t.Fatalf("duplicate create err = %v, want AlreadyExists", err)
+	}
+}
+
+func TestUpdateServiceMaterializesRevision(t *testing.T) {
+	m := newMock(t, nil)
+	ctx := context.Background()
+
+	if _, err := m.CreateService(ctx, svcCfg()); err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	cfg := svcCfg()
+	cfg.Containers[0].Image = "gcr.io/demo/web:v2"
+
+	svc, err := m.UpdateService(ctx, cfg)
+	if err != nil {
+		t.Fatalf("UpdateService: %v", err)
+	}
+
+	if svc.Generation != 2 || !strings.HasPrefix(svc.LatestReadyRevision, "web-00002-") {
+		t.Fatalf("after update gen=%d rev=%q", svc.Generation, svc.LatestReadyRevision)
+	}
+
+	revs, err := m.ListRevisions(ctx, "web")
+	if err != nil || len(revs) != 2 {
+		t.Fatalf("ListRevisions: got %d err=%v", len(revs), err)
+	}
+
+	if _, err := m.UpdateService(ctx, driver.ServiceConfig{Name: "ghost"}); !cerrors.IsNotFound(err) {
+		t.Fatalf("update missing err = %v, want NotFound", err)
+	}
+}
+
+func TestDeleteServiceRemovesRevisions(t *testing.T) {
+	m := newMock(t, nil)
+	ctx := context.Background()
+
+	if _, err := m.CreateService(ctx, svcCfg()); err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	if err := m.DeleteService(ctx, "web"); err != nil {
+		t.Fatalf("DeleteService: %v", err)
+	}
+
+	if _, err := m.GetService(ctx, "web"); !cerrors.IsNotFound(err) {
+		t.Fatalf("GetService after delete err = %v, want NotFound", err)
+	}
+
+	if _, err := m.ListRevisions(ctx, "web"); !cerrors.IsNotFound(err) {
+		t.Fatalf("ListRevisions after delete err = %v, want NotFound", err)
+	}
+}
+
+func TestUpdateJobBumpsGeneration(t *testing.T) {
+	m := newMock(t, nil)
+	ctx := context.Background()
+
+	if _, err := m.CreateJob(ctx, jobCfg()); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+
+	cfg := jobCfg()
+	cfg.MaxRetries = 7
+	cfg.Timeout = "600s"
+
+	job, err := m.UpdateJob(ctx, cfg)
+	if err != nil {
+		t.Fatalf("UpdateJob: %v", err)
+	}
+
+	if job.Generation != 2 || job.MaxRetries != 7 || job.Timeout != "600s" {
+		t.Fatalf("after update: gen=%d maxRetries=%d timeout=%q", job.Generation, job.MaxRetries, job.Timeout)
+	}
+
+	if _, err := m.UpdateJob(ctx, driver.JobConfig{Name: "ghost"}); !cerrors.IsNotFound(err) {
+		t.Fatalf("update missing err = %v, want NotFound", err)
+	}
+}
+
+func TestListExecutionsFiltersByJob(t *testing.T) {
+	m := newMock(t, nil)
+	ctx := context.Background()
+
+	if _, err := m.CreateJob(ctx, jobCfg()); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+
+	if _, err := m.RunJob(ctx, "batch"); err != nil {
+		t.Fatalf("RunJob: %v", err)
+	}
+
+	execs, err := m.ListExecutions(ctx, "batch")
+	if err != nil || len(execs) != 1 {
+		t.Fatalf("ListExecutions: got %d err=%v", len(execs), err)
+	}
+
+	if execs[0].JobName != "batch" {
+		t.Fatalf("execution jobName = %q", execs[0].JobName)
+	}
+
+	if _, err := m.ListExecutions(ctx, "ghost"); !cerrors.IsNotFound(err) {
+		t.Fatalf("ListExecutions missing job err = %v, want NotFound", err)
+	}
+}

--- a/providers/gcp/cloudrun/services_test.go
+++ b/providers/gcp/cloudrun/services_test.go
@@ -49,6 +49,15 @@ func TestCreateServiceReconciles(t *testing.T) {
 		t.Fatalf("terminalCondition = %+v", svc.TerminalCondition)
 	}
 
+	got, err := m.GetService(ctx, "web")
+	if err != nil {
+		t.Fatalf("GetService: %v", err)
+	}
+
+	if len(got.Containers) != 1 || len(got.Containers[0].Ports) != 1 || got.Containers[0].Ports[0] != 8080 {
+		t.Fatalf("container ports lost on round-trip: %+v", got.Containers)
+	}
+
 	if _, err := m.CreateService(ctx, svcCfg()); !cerrors.IsAlreadyExists(err) {
 		t.Fatalf("duplicate create err = %v, want AlreadyExists", err)
 	}

--- a/server/gcp/cloudrun/conv.go
+++ b/server/gcp/cloudrun/conv.go
@@ -1,0 +1,257 @@
+package cloudrun
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
+)
+
+// jobConfigFromWire maps a wire Job body onto a driver.JobConfig.
+func jobConfigFromWire(name string, body *jobResource) driver.JobConfig {
+	tt := body.Template.Template
+
+	return driver.JobConfig{
+		Name:                 name,
+		TaskCount:            body.Template.TaskCount,
+		Parallelism:          body.Template.Parallelism,
+		MaxRetries:           tt.MaxRetries,
+		Timeout:              tt.Timeout,
+		ServiceAccount:       tt.ServiceAccount,
+		ExecutionEnvironment: tt.ExecutionEnvironment,
+		VPCAccess:            toDriverVPC(tt.VPCAccess),
+		Containers:           toDriverContainers(tt.Containers),
+		Labels:               body.Labels,
+		Annotations:          body.Annotations,
+	}
+}
+
+func toDriverContainers(in []container) []driver.Container {
+	out := make([]driver.Container, 0, len(in))
+	for i := range in {
+		out = append(out, driver.Container{
+			Name:    in[i].Name,
+			Image:   in[i].Image,
+			Command: in[i].Command,
+			Args:    in[i].Args,
+			Env:     envToMap(in[i].Env),
+			Ports:   toDriverPorts(in[i].Ports),
+		})
+	}
+
+	return out
+}
+
+func toDriverPorts(in []containerPort) []int {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]int, 0, len(in))
+	for _, p := range in {
+		out = append(out, p.ContainerPort)
+	}
+
+	return out
+}
+
+func toWirePorts(in []int) []containerPort {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]containerPort, 0, len(in))
+	for _, p := range in {
+		out = append(out, containerPort{ContainerPort: p})
+	}
+
+	return out
+}
+
+func envToMap(in []envVar) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+	for _, e := range in {
+		out[e.Name] = e.Value
+	}
+
+	return out
+}
+
+func envToList(in map[string]string) []envVar {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]envVar, 0, len(in))
+	for k, v := range in {
+		out = append(out, envVar{Name: k, Value: v})
+	}
+
+	return out
+}
+
+func toContainers(in []driver.Container) []container {
+	out := make([]container, 0, len(in))
+	for i := range in {
+		out = append(out, container{
+			Name:    in[i].Name,
+			Image:   in[i].Image,
+			Command: in[i].Command,
+			Args:    in[i].Args,
+			Env:     envToList(in[i].Env),
+			Ports:   toWirePorts(in[i].Ports),
+		})
+	}
+
+	return out
+}
+
+func toDriverVPC(in *vpcAccess) *driver.VpcAccess {
+	if in == nil {
+		return nil
+	}
+
+	out := &driver.VpcAccess{Connector: in.Connector, Egress: in.Egress}
+	for _, ni := range in.NetworkInterfaces {
+		out.NetworkInterfaces = append(out.NetworkInterfaces, driver.VpcNetworkInterface{
+			Network:    ni.Network,
+			Subnetwork: ni.Subnetwork,
+			Tags:       ni.Tags,
+		})
+	}
+
+	return out
+}
+
+func toWireVPC(in *driver.VpcAccess) *vpcAccess {
+	if in == nil {
+		return nil
+	}
+
+	out := &vpcAccess{Connector: in.Connector, Egress: in.Egress}
+	for _, ni := range in.NetworkInterfaces {
+		out.NetworkInterfaces = append(out.NetworkInterfaces, networkInterface{
+			Network:    ni.Network,
+			Subnetwork: ni.Subnetwork,
+			Tags:       ni.Tags,
+		})
+	}
+
+	return out
+}
+
+func toConditions(in []driver.Condition) []condition {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]condition, 0, len(in))
+	for _, c := range in {
+		out = append(out, condition{Type: c.Type, State: c.State, Message: c.Message, Reason: c.Reason})
+	}
+
+	return out
+}
+
+func toWireCondition(in *driver.Condition) *condition {
+	if in == nil {
+		return nil
+	}
+
+	return &condition{Type: in.Type, State: in.State, Message: in.Message, Reason: in.Reason}
+}
+
+func toJobResource(j *driver.Job, p *crPath) jobResource {
+	return jobResource{
+		Name:               p.jobName(j.Name),
+		UID:                j.UID,
+		Generation:         strconv.FormatInt(j.Generation, 10),
+		CreateTime:         formatTime(j.CreateTime),
+		UpdateTime:         formatTime(j.UpdateTime),
+		LaunchStage:        j.LaunchStage,
+		ExecutionCount:     j.ExecutionCount,
+		Labels:             j.Labels,
+		Annotations:        j.Annotations,
+		ObservedGeneration: strconv.FormatInt(j.ObservedGeneration, 10),
+		TerminalCondition:  toWireCondition(j.TerminalCondition),
+		Conditions:         toConditions(j.Conditions),
+		Reconciling:        j.Reconciling,
+		Etag:               j.Etag,
+		Template: execTemplate{
+			Parallelism: j.Parallelism,
+			TaskCount:   j.TaskCount,
+			Template: taskTemplate{
+				Containers:           toContainers(j.Containers),
+				MaxRetries:           j.MaxRetries,
+				Timeout:              j.Timeout,
+				ServiceAccount:       j.ServiceAccount,
+				ExecutionEnvironment: j.ExecutionEnvironment,
+				VPCAccess:            toWireVPC(j.VPCAccess),
+			},
+		},
+		LatestCreatedExecution: toWireExecRef(j.LatestCreatedExecution, p),
+	}
+}
+
+func toWireExecRef(ref *driver.ExecutionReference, p *crPath) *executionReference {
+	if ref == nil {
+		return nil
+	}
+
+	return &executionReference{
+		Name:           p.jobName(execJobID(ref.Name)) + "/executions/" + ref.Name,
+		CreateTime:     formatTime(ref.CreateTime),
+		CompletionTime: formatTime(ref.CompletionTime),
+	}
+}
+
+// execJobID recovers the job id from an execution id of the form {job}-{suffix}.
+func execJobID(execName string) string {
+	if i := lastDash(execName); i >= 0 {
+		return execName[:i]
+	}
+
+	return execName
+}
+
+func lastDash(s string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '-' {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func toExecutionResource(e *driver.Execution, p *crPath) executionResource {
+	return executionResource{
+		Name:           p.jobName(e.JobName) + "/executions/" + e.Name,
+		UID:            e.UID,
+		Generation:     strconv.FormatInt(e.Generation, 10),
+		Job:            p.jobName(e.JobName),
+		CreateTime:     formatTime(e.CreateTime),
+		StartTime:      formatTime(e.StartTime),
+		CompletionTime: formatTime(e.CompletionTime),
+		TaskCount:      e.TaskCount,
+		SucceededCount: e.SucceededCount,
+		FailedCount:    e.FailedCount,
+		RunningCount:   e.RunningCount,
+		CancelledCount: e.CancelledCount,
+		LogURI:         e.LogURI,
+		Template:       taskTemplate{Containers: toContainers(e.Containers)},
+		Conditions:     toConditions(e.Conditions),
+	}
+}
+
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+
+	return t.UTC().Format(time.RFC3339Nano)
+}

--- a/server/gcp/cloudrun/handler.go
+++ b/server/gcp/cloudrun/handler.go
@@ -270,22 +270,12 @@ func (h *Handler) getExecution(w http.ResponseWriter, r *http.Request, p *crPath
 }
 
 func (h *Handler) listExecutions(w http.ResponseWriter, r *http.Request, p *crPath) {
-	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
-		return
-	}
-
-	execs, err := h.cr.ListExecutions(r.Context(), p.name)
-	if err != nil {
-		writeErr(w, err)
-		return
-	}
-
-	items, next := pageConvert(r, execs, func(e *driver.Execution) executionResource {
-		return toExecutionResource(e, p)
-	})
-
-	writeJSON(w, http.StatusOK, listExecutionsResponse{Executions: items, NextPageToken: next})
+	listPaged(w, r,
+		func() ([]driver.Execution, error) { return h.cr.ListExecutions(r.Context(), p.name) },
+		func(e *driver.Execution) executionResource { return toExecutionResource(e, p) },
+		func(items []executionResource, next string) listExecutionsResponse {
+			return listExecutionsResponse{Executions: items, NextPageToken: next}
+		})
 }
 
 // serveOperation answers GET /v2/…/operations/{op}. Mutations are synchronous
@@ -446,6 +436,32 @@ func paginate(total int, r *http.Request) (indices []int, next string) {
 	}
 
 	return indices, next
+}
+
+// listPaged serves a GET sub-collection endpoint (revisions, executions): it
+// guards the method, fetches the driver slice, paginates + converts each element
+// to its wire shape, and writes the envelope built by wrap. list, conv, and wrap
+// are the only parts that vary between endpoints.
+func listPaged[D, W, R any](
+	w http.ResponseWriter,
+	r *http.Request,
+	list func() ([]D, error),
+	conv func(*D) W,
+	wrap func(items []W, next string) R,
+) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	ds, err := list()
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	items, next := pageConvert(r, ds, conv)
+	writeJSON(w, http.StatusOK, wrap(items, next))
 }
 
 // pageConvert selects the requested page over items and maps each element to

--- a/server/gcp/cloudrun/handler.go
+++ b/server/gcp/cloudrun/handler.go
@@ -1,19 +1,31 @@
-// Package cloudrun implements the GCP Cloud Run Admin API v2 Jobs REST surface
-// as a server.Handler. Real cloud.google.com/go/run/apiv2 clients (and the
-// gcloud CLI) configured with a custom endpoint hit this handler the same way
-// they hit run.googleapis.com.
+// Package cloudrun implements the GCP Cloud Run Admin API v2 REST surface as a
+// server.Handler. Real cloud.google.com/go/run/apiv2 clients (and the gcloud
+// CLI) configured with a custom endpoint hit this handler the same way they hit
+// run.googleapis.com.
 //
-// Scope is Jobs (run-to-completion), not Services (HTTP ingress / revisions).
+// Scope covers both surfaces: Jobs (run-to-completion) and Services (HTTP
+// ingress / revisions / traffic).
 //
 // Coverage:
 //
-//	POST   /v2/projects/{p}/locations/{l}/jobs?jobId={id}                   — Create (LRO, response=Job)
-//	GET    /v2/projects/{p}/locations/{l}/jobs/{job}                        — Get
-//	GET    /v2/projects/{p}/locations/{l}/jobs                              — List
-//	DELETE /v2/projects/{p}/locations/{l}/jobs/{job}                        — Delete (LRO)
-//	POST   /v2/projects/{p}/locations/{l}/jobs/{job}:run                    — Run   (LRO, response=Execution)
-//	GET    /v2/projects/{p}/locations/{l}/jobs/{job}/executions/{exec}      — Executions.Get
-//	GET    /v2/projects/{p}/locations/{l}/operations/{op}                   — Poll an LRO
+//	POST   /v2/projects/{p}/locations/{l}/jobs?jobId={id}                — Jobs.Create (LRO)
+//	GET    /v2/projects/{p}/locations/{l}/jobs/{job}                     — Jobs.Get
+//	GET    /v2/projects/{p}/locations/{l}/jobs                           — Jobs.List
+//	PATCH  /v2/projects/{p}/locations/{l}/jobs/{job}                     — Jobs.Patch (LRO)
+//	DELETE /v2/projects/{p}/locations/{l}/jobs/{job}                     — Jobs.Delete (LRO)
+//	POST   /v2/projects/{p}/locations/{l}/jobs/{job}:run                 — Jobs.Run (LRO)
+//	GET    /v2/projects/{p}/locations/{l}/jobs/{job}/executions          — Executions.List
+//	GET    /v2/projects/{p}/locations/{l}/jobs/{job}/executions/{exec}   — Executions.Get
+//	POST   /v2/projects/{p}/locations/{l}/jobs/{job}:{get,set}IamPolicy  — Jobs IAM
+//	POST   /v2/projects/{p}/locations/{l}/services?serviceId={id}        — Services.Create (LRO)
+//	GET    /v2/projects/{p}/locations/{l}/services/{svc}                 — Services.Get
+//	GET    /v2/projects/{p}/locations/{l}/services                       — Services.List
+//	PATCH  /v2/projects/{p}/locations/{l}/services/{svc}                 — Services.Patch (LRO)
+//	DELETE /v2/projects/{p}/locations/{l}/services/{svc}                 — Services.Delete (LRO)
+//	GET    /v2/projects/{p}/locations/{l}/services/{svc}/revisions[/{r}] — Revisions.{List,Get}
+//	DELETE /v2/projects/{p}/locations/{l}/services/{svc}/revisions/{r}   — Revisions.Delete (LRO)
+//	POST   /v2/projects/{p}/locations/{l}/services/{svc}:{get,set}IamPolicy — Services IAM
+//	GET    /v2/projects/{p}/locations/{l}/operations/{op}                — Poll an LRO
 //
 // All mutating endpoints return google.longrunning.Operation envelopes with
 // done=true so SDK pollers terminate on the first response.
@@ -24,6 +36,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -31,31 +44,43 @@ import (
 )
 
 const (
-	pathPrefix      = "/v2/projects/"
-	locationsSeg    = "locations"
-	jobsSeg         = "jobs"
-	executionsSeg   = "executions"
-	operationsSeg   = "operations"
-	actionRun       = "run"
-	contentTypeJSON = "application/json"
-	maxBodyBytes    = 1 << 20
-	jobTypeURL      = "type.googleapis.com/google.cloud.run.v2.Job"
-	execTypeURL     = "type.googleapis.com/google.cloud.run.v2.Execution"
+	pathPrefix         = "/v2/projects/"
+	locationsSeg       = "locations"
+	jobsSeg            = "jobs"
+	servicesSeg        = "services"
+	executionsSeg      = "executions"
+	revisionsSeg       = "revisions"
+	operationsSeg      = "operations"
+	actionRun          = "run"
+	actionGetIamPolicy = "getIamPolicy"
+	actionSetIamPolicy = "setIamPolicy"
+	actionTestIamPerms = "testIamPermissions"
+	contentTypeJSON    = "application/json"
+	maxBodyBytes       = 1 << 20
+	jobTypeURL         = "type.googleapis.com/google.cloud.run.v2.Job"
+	execTypeURL        = "type.googleapis.com/google.cloud.run.v2.Execution"
+	serviceTypeURL     = "type.googleapis.com/google.cloud.run.v2.Service"
+	defaultPageSize    = 100
 )
 
-// Handler serves Cloud Run Admin API v2 Jobs requests against a CloudRun driver.
+// Handler serves Cloud Run Admin API v2 requests against a CloudRun driver.
 type Handler struct {
 	cr driver.CloudRun
+	mu sync.RWMutex
+	// policies stores the IAM policy set via setIamPolicy, keyed by a resource's
+	// canonical name. CloudEmu does not enforce IAM; the policy is stored so a
+	// set/get (and Terraform's *_iam_member read-back) round-trips.
+	policies map[string]*iamPolicy
 }
 
-// New returns a Cloud Run Jobs handler backed by cr.
+// New returns a Cloud Run handler backed by cr.
 func New(cr driver.CloudRun) *Handler {
-	return &Handler{cr: cr}
+	return &Handler{cr: cr, policies: make(map[string]*iamPolicy)}
 }
 
-// Matches claims Cloud Run v2 job and location-operation paths:
-// /v2/projects/{p}/locations/{l}/{jobs|operations}[/...]. The locations+jobs
-// guard keeps it disjoint from Cloud Logging's /v2/projects/{p}/logs paths.
+// Matches claims Cloud Run v2 job, service and location-operation paths. The
+// locations+{jobs,services,operations} guard keeps it disjoint from Cloud
+// Logging's /v2/projects/{p}/logs paths.
 func (*Handler) Matches(r *http.Request) bool {
 	_, ok := parsePath(r.URL.Path)
 
@@ -70,24 +95,49 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	switch {
-	case p.operation != "":
+	switch p.kind {
+	case operationsSeg:
 		h.serveOperation(w, r, &p)
-	case p.action == actionRun && p.job != "":
-		h.run(w, r, &p)
-	case p.execution != "":
-		h.getExecution(w, r, &p)
-	case p.job != "":
-		h.serveJob(w, r, &p)
+	case servicesSeg:
+		h.serveServices(w, r, &p)
 	default:
-		h.serveCollection(w, r, &p)
+		h.serveJobs(w, r, &p)
 	}
 }
 
-func (h *Handler) serveJob(w http.ResponseWriter, r *http.Request, p *crPath) {
+// serveJobs routes the jobs surface.
+func (h *Handler) serveJobs(w http.ResponseWriter, r *http.Request, p *crPath) {
+	switch {
+	case p.action != "":
+		h.serveJobAction(w, r, p)
+	case p.sub == executionsSeg && p.subName != "":
+		h.getExecution(w, r, p)
+	case p.sub == executionsSeg:
+		h.listExecutions(w, r, p)
+	case p.name != "":
+		h.serveJobItem(w, r, p)
+	default:
+		h.serveJobCollection(w, r, p)
+	}
+}
+
+func (h *Handler) serveJobAction(w http.ResponseWriter, r *http.Request, p *crPath) {
+	switch p.action {
+	case actionRun:
+		h.run(w, r, p)
+	case actionGetIamPolicy, actionSetIamPolicy, actionTestIamPerms:
+		h.serveIam(w, r, p, p.jobName(p.name), h.jobExists)
+	default:
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown method: "+p.action)
+	}
+}
+
+func (h *Handler) serveJobItem(w http.ResponseWriter, r *http.Request, p *crPath) {
 	switch r.Method {
 	case http.MethodGet:
 		h.getJob(w, r, p)
+	case http.MethodPatch:
+		h.updateJob(w, r, p)
 	case http.MethodDelete:
 		h.deleteJob(w, r, p)
 	default:
@@ -95,7 +145,7 @@ func (h *Handler) serveJob(w http.ResponseWriter, r *http.Request, p *crPath) {
 	}
 }
 
-func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, p *crPath) {
+func (h *Handler) serveJobCollection(w http.ResponseWriter, r *http.Request, p *crPath) {
 	switch r.Method {
 	case http.MethodPost:
 		h.create(w, r, p)
@@ -122,30 +172,40 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request, p *crPath) {
 		return
 	}
 
-	cfg := driver.JobConfig{
-		Name:        name,
-		TaskCount:   body.Template.TaskCount,
-		Containers:  toDriverContainers(body.Template.Template.Containers),
-		Labels:      body.Labels,
-		Annotations: body.Annotations,
-	}
-
-	job, err := h.cr.CreateJob(r.Context(), cfg)
+	job, err := h.cr.CreateJob(r.Context(), jobConfigFromWire(name, &body))
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	resource := toJobResource(job, p)
 	writeJSON(w, http.StatusOK, operation{
 		Name:     opName(p, "create-"+name),
 		Done:     true,
-		Response: asResponse(resource, jobTypeURL),
+		Response: asResponse(toJobResource(job, p), jobTypeURL),
+	})
+}
+
+func (h *Handler) updateJob(w http.ResponseWriter, r *http.Request, p *crPath) {
+	var body jobResource
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	job, err := h.cr.UpdateJob(r.Context(), jobConfigFromWire(p.name, &body))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, operation{
+		Name:     opName(p, "update-"+p.name),
+		Done:     true,
+		Response: asResponse(toJobResource(job, p), jobTypeURL),
 	})
 }
 
 func (h *Handler) getJob(w http.ResponseWriter, r *http.Request, p *crPath) {
-	job, err := h.cr.GetJob(r.Context(), p.job)
+	job, err := h.cr.GetJob(r.Context(), p.name)
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -161,21 +221,18 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, p *crPath) {
 		return
 	}
 
-	out := listJobsResponse{Jobs: make([]jobResource, 0, len(jobs))}
-	for i := range jobs {
-		out.Jobs = append(out.Jobs, toJobResource(&jobs[i], p))
-	}
+	items, next := pageConvert(r, jobs, func(j *driver.Job) jobResource { return toJobResource(j, p) })
 
-	writeJSON(w, http.StatusOK, out)
+	writeJSON(w, http.StatusOK, listJobsResponse{Jobs: items, NextPageToken: next})
 }
 
 func (h *Handler) deleteJob(w http.ResponseWriter, r *http.Request, p *crPath) {
-	if err := h.cr.DeleteJob(r.Context(), p.job); err != nil {
+	if err := h.cr.DeleteJob(r.Context(), p.name); err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	writeJSON(w, http.StatusOK, operation{Name: opName(p, "delete-"+p.job), Done: true})
+	writeJSON(w, http.StatusOK, operation{Name: opName(p, "delete-"+p.name), Done: true})
 }
 
 func (h *Handler) run(w http.ResponseWriter, r *http.Request, p *crPath) {
@@ -184,17 +241,16 @@ func (h *Handler) run(w http.ResponseWriter, r *http.Request, p *crPath) {
 		return
 	}
 
-	exec, err := h.cr.RunJob(r.Context(), p.job)
+	exec, err := h.cr.RunJob(r.Context(), p.name)
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	resource := toExecutionResource(exec, p)
 	writeJSON(w, http.StatusOK, operation{
-		Name:     opName(p, "run-"+p.job),
+		Name:     opName(p, "run-"+p.name),
 		Done:     true,
-		Response: asResponse(resource, execTypeURL),
+		Response: asResponse(toExecutionResource(exec, p), execTypeURL),
 	})
 }
 
@@ -204,13 +260,32 @@ func (h *Handler) getExecution(w http.ResponseWriter, r *http.Request, p *crPath
 		return
 	}
 
-	exec, err := h.cr.GetExecution(r.Context(), p.execution)
+	exec, err := h.cr.GetExecution(r.Context(), p.subName)
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
 	writeJSON(w, http.StatusOK, toExecutionResource(exec, p))
+}
+
+func (h *Handler) listExecutions(w http.ResponseWriter, r *http.Request, p *crPath) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	execs, err := h.cr.ListExecutions(r.Context(), p.name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	items, next := pageConvert(r, execs, func(e *driver.Execution) executionResource {
+		return toExecutionResource(e, p)
+	})
+
+	writeJSON(w, http.StatusOK, listExecutionsResponse{Executions: items, NextPageToken: next})
 }
 
 // serveOperation answers GET /v2/…/operations/{op}. Mutations are synchronous
@@ -222,29 +297,24 @@ func (*Handler) serveOperation(w http.ResponseWriter, r *http.Request, p *crPath
 	}
 
 	writeJSON(w, http.StatusOK, operation{
-		Name: "projects/" + p.project + "/locations/" + p.location + "/operations/" + p.operation,
+		Name: "projects/" + p.project + "/locations/" + p.location + "/operations/" + p.name,
 		Done: true,
 	})
 }
 
 // crPath holds the parsed components of a Cloud Run v2 URL.
 type crPath struct {
-	project   string
-	location  string
-	job       string
-	execution string
-	action    string // "run"
-	operation string
+	project  string
+	location string
+	kind     string // jobs | services | operations
+	name     string // job / service / operation id
+	sub      string // executions | revisions
+	subName  string // execution / revision id
+	action   string // run | getIamPolicy | setIamPolicy | testIamPermissions
 }
 
 // parsePath extracts components from a Cloud Run v2 URL, returning ok=false for
 // any path this handler does not serve.
-//
-//	/v2/projects/{p}/locations/{l}/jobs
-//	/v2/projects/{p}/locations/{l}/jobs/{job}
-//	/v2/projects/{p}/locations/{l}/jobs/{job}:run
-//	/v2/projects/{p}/locations/{l}/jobs/{job}/executions/{exec}
-//	/v2/projects/{p}/locations/{l}/operations/{op}
 func parsePath(path string) (crPath, bool) {
 	if !strings.HasPrefix(path, pathPrefix) {
 		return crPath{}, false
@@ -253,9 +323,9 @@ func parsePath(path string) (crPath, bool) {
 	parts := strings.Split(strings.TrimPrefix(path, pathPrefix), "/")
 
 	const (
-		minParts = 4 // {project}/locations/{location}/{type}
+		minParts = 4 // {project}/locations/{location}/{kind}
 		idxScope = 1
-		idxType  = 3
+		idxKind  = 3
 		idxName  = 4
 	)
 
@@ -263,19 +333,19 @@ func parsePath(path string) (crPath, bool) {
 		return crPath{}, false
 	}
 
-	p := crPath{project: parts[0], location: parts[2]}
+	p := crPath{project: parts[0], location: parts[2], kind: parts[idxKind]}
 
-	switch parts[idxType] {
+	switch p.kind {
 	case operationsSeg:
 		if len(parts) <= idxName || parts[idxName] == "" {
 			return crPath{}, false
 		}
 
-		p.operation = parts[idxName]
+		p.name = parts[idxName]
 
 		return p, true
-	case jobsSeg:
-		parseJobTail(parts, idxName, &p)
+	case jobsSeg, servicesSeg:
+		parseTail(parts, idxName, &p)
 
 		return p, true
 	default:
@@ -283,28 +353,33 @@ func parsePath(path string) (crPath, bool) {
 	}
 }
 
-// parseJobTail reads the job / :run / executions segments after ".../jobs".
-func parseJobTail(parts []string, idxName int, p *crPath) {
+// parseTail reads the {name}[:action] and sub-collection segments after
+// .../{jobs|services}.
+func parseTail(parts []string, idxName int, p *crPath) {
 	if len(parts) <= idxName {
 		return // collection
 	}
 
 	if base, action, ok := splitColon(parts[idxName]); ok {
-		p.job = base
+		p.name = base
 		p.action = action
 
 		return
 	}
 
-	p.job = parts[idxName]
+	p.name = parts[idxName]
 
 	const (
-		idxExecType = 5
-		idxExecName = 6
+		idxSub     = 5
+		idxSubName = 6
 	)
 
-	if len(parts) > idxExecName && parts[idxExecType] == executionsSeg {
-		p.execution = parts[idxExecName]
+	if len(parts) > idxSub {
+		p.sub = parts[idxSub]
+	}
+
+	if len(parts) > idxSubName {
+		p.subName = parts[idxSubName]
 	}
 }
 
@@ -329,125 +404,61 @@ func (p *crPath) jobName(id string) string {
 	return "projects/" + p.project + "/locations/" + p.location + "/jobs/" + id
 }
 
+func (p *crPath) serviceName(id string) string {
+	return "projects/" + p.project + "/locations/" + p.location + "/services/" + id
+}
+
 func opName(p *crPath, suffix string) string {
 	return "projects/" + p.project + "/locations/" + p.location + "/operations/" +
 		suffix + "-" + strconv.FormatInt(time.Now().UnixNano(), 10)
 }
 
-func toDriverContainers(in []container) []driver.Container {
-	out := make([]driver.Container, 0, len(in))
-	for i := range in {
-		out = append(out, driver.Container{
-			Name:    in[i].Name,
-			Image:   in[i].Image,
-			Command: in[i].Command,
-			Args:    in[i].Args,
-			Env:     envToMap(in[i].Env),
-		})
+// paginate resolves pageSize / pageToken query params into the indices of the
+// requested page over a total-length slice, plus the next page token (empty on
+// the last page). Tokens are 1-based start offsets rendered as decimal strings.
+func paginate(total int, r *http.Request) (indices []int, next string) {
+	size := defaultPageSize
+	if v, err := strconv.Atoi(r.URL.Query().Get("pageSize")); err == nil && v > 0 {
+		size = v
 	}
 
-	return out
+	start := 0
+	if v, err := strconv.Atoi(r.URL.Query().Get("pageToken")); err == nil && v > 0 {
+		start = v
+	}
+
+	if start > total {
+		start = total
+	}
+
+	end := start + size
+	if end > total {
+		end = total
+	}
+
+	indices = make([]int, 0, end-start)
+	for i := start; i < end; i++ {
+		indices = append(indices, i)
+	}
+
+	if end < total {
+		next = strconv.Itoa(end)
+	}
+
+	return indices, next
 }
 
-func envToMap(in []envVar) map[string]string {
-	if len(in) == 0 {
-		return nil
+// pageConvert selects the requested page over items and maps each element to
+// its wire shape, returning the converted page and the next page token.
+func pageConvert[S, W any](r *http.Request, items []S, conv func(*S) W) (page []W, next string) {
+	idx, next := paginate(len(items), r)
+
+	page = make([]W, 0, len(idx))
+	for _, i := range idx {
+		page = append(page, conv(&items[i]))
 	}
 
-	out := make(map[string]string, len(in))
-	for _, e := range in {
-		out[e.Name] = e.Value
-	}
-
-	return out
-}
-
-func envToList(in map[string]string) []envVar {
-	if len(in) == 0 {
-		return nil
-	}
-
-	out := make([]envVar, 0, len(in))
-	for k, v := range in {
-		out = append(out, envVar{Name: k, Value: v})
-	}
-
-	return out
-}
-
-func toContainers(in []driver.Container) []container {
-	out := make([]container, 0, len(in))
-	for i := range in {
-		out = append(out, container{
-			Name:    in[i].Name,
-			Image:   in[i].Image,
-			Command: in[i].Command,
-			Args:    in[i].Args,
-			Env:     envToList(in[i].Env),
-		})
-	}
-
-	return out
-}
-
-func toConditions(in []driver.Condition) []condition {
-	if len(in) == 0 {
-		return nil
-	}
-
-	out := make([]condition, 0, len(in))
-	for _, c := range in {
-		out = append(out, condition{Type: c.Type, State: c.State, Message: c.Message, Reason: c.Reason})
-	}
-
-	return out
-}
-
-func toJobResource(j *driver.Job, p *crPath) jobResource {
-	return jobResource{
-		Name:           p.jobName(j.Name),
-		UID:            j.UID,
-		Generation:     strconv.FormatInt(j.Generation, 10),
-		CreateTime:     formatTime(j.CreateTime),
-		UpdateTime:     formatTime(j.UpdateTime),
-		LaunchStage:    j.LaunchStage,
-		ExecutionCount: j.ExecutionCount,
-		Labels:         j.Labels,
-		Annotations:    j.Annotations,
-		Template: execTemplate{
-			TaskCount: j.TaskCount,
-			Template:  taskTemplate{Containers: toContainers(j.Containers)},
-		},
-		Conditions: toConditions(j.Conditions),
-	}
-}
-
-func toExecutionResource(e *driver.Execution, p *crPath) executionResource {
-	return executionResource{
-		Name:           p.jobName(e.JobName) + "/executions/" + e.Name,
-		UID:            e.UID,
-		Generation:     strconv.FormatInt(e.Generation, 10),
-		Job:            p.jobName(e.JobName),
-		CreateTime:     formatTime(e.CreateTime),
-		StartTime:      formatTime(e.StartTime),
-		CompletionTime: formatTime(e.CompletionTime),
-		TaskCount:      e.TaskCount,
-		SucceededCount: e.SucceededCount,
-		FailedCount:    e.FailedCount,
-		RunningCount:   e.RunningCount,
-		CancelledCount: e.CancelledCount,
-		LogURI:         e.LogURI,
-		Template:       taskTemplate{Containers: toContainers(e.Containers)},
-		Conditions:     toConditions(e.Conditions),
-	}
-}
-
-func formatTime(t time.Time) string {
-	if t.IsZero() {
-		return ""
-	}
-
-	return t.UTC().Format(time.RFC3339Nano)
+	return page, next
 }
 
 // asResponse marshals a wire resource into the {@type, ...fields} map an LRO

--- a/server/gcp/cloudrun/iam.go
+++ b/server/gcp/cloudrun/iam.go
@@ -1,0 +1,124 @@
+package cloudrun
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strconv"
+)
+
+// iamPolicy is the GCP IAM Policy resource returned by getIamPolicy /
+// setIamPolicy. Bindings are stored verbatim so a set/get round-trips.
+type iamPolicy struct {
+	Version  int             `json:"version,omitempty"`
+	Bindings []policyBinding `json:"bindings,omitempty"`
+	Etag     string          `json:"etag,omitempty"`
+}
+
+type policyBinding struct {
+	Role    string   `json:"role"`
+	Members []string `json:"members,omitempty"`
+}
+
+// setIamPolicyRequest is the body of {resource}:setIamPolicy.
+type setIamPolicyRequest struct {
+	Policy iamPolicy `json:"policy"`
+}
+
+// testIamPermissionsRequest is the body of {resource}:testIamPermissions.
+type testIamPermissionsRequest struct {
+	Permissions []string `json:"permissions"`
+}
+
+// existsFn reports whether the IAM target resource exists (returning the
+// driver's NotFound error otherwise), so IAM verbs 404 like real GCP.
+type existsFn func(r *http.Request, name string) error
+
+// serveIam routes the IAM verbs (getIamPolicy / setIamPolicy /
+// testIamPermissions) for a job or service. CloudEmu does not enforce IAM; the
+// policy is stored so a set/get (and Terraform's *_iam_member read-back)
+// round-trips. key is the resource's canonical name used both to 404 and to
+// index the stored policy.
+func (h *Handler) serveIam(w http.ResponseWriter, r *http.Request, p *crPath, key string, exists existsFn) {
+	if err := exists(r, p.name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	switch p.action {
+	case actionGetIamPolicy:
+		if r.Method != http.MethodGet && r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "getIamPolicy requires GET or POST")
+			return
+		}
+
+		h.getIamPolicy(w, key)
+	case actionSetIamPolicy:
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "setIamPolicy requires POST")
+			return
+		}
+
+		h.setIamPolicy(w, r, key)
+	case actionTestIamPerms:
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "testIamPermissions requires POST")
+			return
+		}
+
+		testIamPermissions(w, r)
+	default:
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown method: "+p.action)
+	}
+}
+
+func (h *Handler) getIamPolicy(w http.ResponseWriter, key string) {
+	h.mu.RLock()
+	pol := h.policies[key]
+	h.mu.RUnlock()
+
+	if pol == nil {
+		// An existing resource with no policy yet returns an empty, versioned
+		// policy (real GCP never 404s getIamPolicy on an existing resource).
+		pol = &iamPolicy{Version: 1, Etag: policyEtag(key, 0)}
+	}
+
+	writeJSON(w, http.StatusOK, pol)
+}
+
+func (h *Handler) setIamPolicy(w http.ResponseWriter, r *http.Request, key string) {
+	var body setIamPolicyRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	pol := body.Policy
+	if pol.Version == 0 {
+		pol.Version = 1
+	}
+
+	pol.Etag = policyEtag(key, len(pol.Bindings))
+
+	h.mu.Lock()
+	h.policies[key] = &pol
+	h.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, &pol)
+}
+
+// testIamPermissions echoes back the requested permissions as held. CloudEmu
+// does not enforce IAM, so the caller is treated as fully authorized — the
+// subset returned is the full set requested, matching what a permitted
+// principal sees on real GCP.
+func testIamPermissions(w http.ResponseWriter, r *http.Request) {
+	var body testIamPermissionsRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"permissions": body.Permissions})
+}
+
+// policyEtag returns a stable etag for a policy state.
+func policyEtag(resource string, n int) string {
+	return base64.StdEncoding.EncodeToString([]byte(resource + ":" + strconv.Itoa(n)))
+}

--- a/server/gcp/cloudrun/jobs_sdk_test.go
+++ b/server/gcp/cloudrun/jobs_sdk_test.go
@@ -1,0 +1,310 @@
+package cloudrun_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	run "google.golang.org/api/run/v2"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+const parent = "projects/" + project + "/locations/" + location
+
+// newRun boots an in-process GCP server backed by the real cloudemu Cloud Run
+// driver and returns a run/v2 SDK client pointed at it.
+func newRun(t *testing.T, eng config.ContainerEngine) *run.Service {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP(config.WithContainerEngine(eng))
+	ts := httptest.NewServer(gcpserver.New(gcpserver.Drivers{CloudRun: cloud.CloudRun}))
+	t.Cleanup(ts.Close)
+
+	svc, err := run.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("run.NewService: %v", err)
+	}
+
+	return svc
+}
+
+func sdkJob() *run.GoogleCloudRunV2Job {
+	return &run.GoogleCloudRunV2Job{
+		Template: &run.GoogleCloudRunV2ExecutionTemplate{
+			TaskCount:   2,
+			Parallelism: 1,
+			Template: &run.GoogleCloudRunV2TaskTemplate{
+				MaxRetries:           3,
+				Timeout:              "600s",
+				ServiceAccount:       "runner@demo-project.iam.gserviceaccount.com",
+				ExecutionEnvironment: "EXECUTION_ENVIRONMENT_GEN2",
+				VpcAccess: &run.GoogleCloudRunV2VpcAccess{
+					Connector: "projects/demo-project/locations/us-central1/connectors/c1",
+					Egress:    "ALL_TRAFFIC",
+				},
+				Containers: []*run.GoogleCloudRunV2Container{{Image: "busybox"}},
+			},
+		},
+	}
+}
+
+// TestSDKJobTemplateFieldsRoundTrip covers the [MEDIUM] finding: create with
+// maxRetries/serviceAccount/timeout/parallelism/executionEnvironment/vpcAccess
+// then Get must round-trip them.
+func TestSDKJobTemplateFieldsRoundTrip(t *testing.T) {
+	svc := newRun(t, nil)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Jobs.Create(parent, sdkJob()).JobId("batch").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Jobs.Get(parent + "/jobs/batch").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	tt := got.Template.Template
+	if tt.MaxRetries != 3 {
+		t.Errorf("maxRetries = %d, want 3", tt.MaxRetries)
+	}
+
+	if tt.Timeout != "600s" {
+		t.Errorf("timeout = %q, want 600s", tt.Timeout)
+	}
+
+	if tt.ServiceAccount != "runner@demo-project.iam.gserviceaccount.com" {
+		t.Errorf("serviceAccount = %q", tt.ServiceAccount)
+	}
+
+	if tt.ExecutionEnvironment != "EXECUTION_ENVIRONMENT_GEN2" {
+		t.Errorf("executionEnvironment = %q", tt.ExecutionEnvironment)
+	}
+
+	if got.Template.Parallelism != 1 {
+		t.Errorf("parallelism = %d, want 1", got.Template.Parallelism)
+	}
+
+	if tt.VpcAccess == nil || tt.VpcAccess.Connector == "" || tt.VpcAccess.Egress != "ALL_TRAFFIC" {
+		t.Errorf("vpcAccess = %+v", tt.VpcAccess)
+	}
+}
+
+// TestSDKJobGetStatusFields covers the [MEDIUM] finding: Get returns
+// terminalCondition/etag/observedGeneration/reconciling and, after a run,
+// latestCreatedExecution.
+func TestSDKJobGetStatusFields(t *testing.T) {
+	eng := &fakeEngine{statuses: []config.ContainerStatus{{State: "exited", ExitCode: 0}}}
+	svc := newRun(t, eng)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Jobs.Create(parent, sdkJob()).JobId("batch").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Jobs.Run(parent+"/jobs/batch", &run.GoogleCloudRunV2RunJobRequest{}).
+		Context(ctx).Do(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Jobs.Get(parent + "/jobs/batch").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.TerminalCondition == nil || got.TerminalCondition.Type != "Ready" {
+		t.Errorf("terminalCondition = %+v, want type Ready", got.TerminalCondition)
+	}
+
+	if got.Etag == "" {
+		t.Error("etag is empty")
+	}
+
+	if got.ObservedGeneration != 1 {
+		t.Errorf("observedGeneration = %d, want 1", got.ObservedGeneration)
+	}
+
+	if got.LatestCreatedExecution == nil || !strings.Contains(got.LatestCreatedExecution.Name, "/executions/batch-") {
+		t.Errorf("latestCreatedExecution = %+v", got.LatestCreatedExecution)
+	}
+}
+
+// TestSDKJobPatch covers the [HIGH] finding: Jobs.Patch returns an LRO with the
+// mutated job rather than 405.
+func TestSDKJobPatch(t *testing.T) {
+	svc := newRun(t, nil)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Jobs.Create(parent, sdkJob()).JobId("batch").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	patched := sdkJob()
+	patched.Template.TaskCount = 5
+	patched.Template.Template.MaxRetries = 7
+
+	op, err := svc.Projects.Locations.Jobs.Patch(parent+"/jobs/batch", patched).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	if !op.Done {
+		t.Fatal("patch operation not done")
+	}
+
+	got, err := svc.Projects.Locations.Jobs.Get(parent + "/jobs/batch").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Template.TaskCount != 5 || got.Template.Template.MaxRetries != 7 {
+		t.Errorf("after patch taskCount=%d maxRetries=%d, want 5/7",
+			got.Template.TaskCount, got.Template.Template.MaxRetries)
+	}
+
+	if got.Generation != 2 {
+		t.Errorf("generation = %d, want 2 after patch", got.Generation)
+	}
+}
+
+// TestSDKJobIam covers the [HIGH] finding: getIamPolicy/setIamPolicy round-trip
+// and testIamPermissions returns the held subset.
+func TestSDKJobIam(t *testing.T) {
+	svc := newRun(t, nil)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Jobs.Create(parent, sdkJob()).JobId("batch").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	resource := parent + "/jobs/batch"
+
+	set := &run.GoogleIamV1SetIamPolicyRequest{Policy: &run.GoogleIamV1Policy{
+		Bindings: []*run.GoogleIamV1Binding{{
+			Role:    "roles/run.invoker",
+			Members: []string{"user:dev@example.com"},
+		}},
+	}}
+	if _, err := svc.Projects.Locations.Jobs.SetIamPolicy(resource, set).Context(ctx).Do(); err != nil {
+		t.Fatalf("SetIamPolicy: %v", err)
+	}
+
+	pol, err := svc.Projects.Locations.Jobs.GetIamPolicy(resource).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("GetIamPolicy: %v", err)
+	}
+
+	if len(pol.Bindings) != 1 || pol.Bindings[0].Role != "roles/run.invoker" {
+		t.Fatalf("policy bindings = %+v", pol.Bindings)
+	}
+
+	test := &run.GoogleIamV1TestIamPermissionsRequest{Permissions: []string{"run.jobs.run", "run.jobs.get"}}
+
+	res, err := svc.Projects.Locations.Jobs.TestIamPermissions(resource, test).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("TestIamPermissions: %v", err)
+	}
+
+	if len(res.Permissions) != 2 {
+		t.Errorf("held permissions = %v, want 2", res.Permissions)
+	}
+}
+
+// TestSDKJobExecutionsList covers the [HIGH] finding: the executions collection
+// returns {executions,...}, not the Job.
+func TestSDKJobExecutionsList(t *testing.T) {
+	eng := &fakeEngine{statuses: []config.ContainerStatus{{State: "exited", ExitCode: 0}}}
+	svc := newRun(t, eng)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Jobs.Create(parent, sdkJob()).JobId("batch").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	for range 2 {
+		if _, err := svc.Projects.Locations.Jobs.Run(parent+"/jobs/batch", &run.GoogleCloudRunV2RunJobRequest{}).
+			Context(ctx).Do(); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	}
+
+	list, err := svc.Projects.Locations.Jobs.Executions.List(parent + "/jobs/batch").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Executions.List: %v", err)
+	}
+
+	if len(list.Executions) != 2 {
+		t.Fatalf("executions = %d, want 2", len(list.Executions))
+	}
+
+	if !strings.Contains(list.Executions[0].Name, "/jobs/batch/executions/") {
+		t.Errorf("execution name = %q", list.Executions[0].Name)
+	}
+}
+
+// TestSDKJobsListPagination covers the [LOW] finding: pageSize/pageToken paginate.
+func TestSDKJobsListPagination(t *testing.T) {
+	svc := newRun(t, nil)
+	ctx := context.Background()
+
+	for _, id := range []string{"a", "b"} {
+		if _, err := svc.Projects.Locations.Jobs.Create(parent, sdkJob()).JobId(id).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create %s: %v", id, err)
+		}
+	}
+
+	page1, err := svc.Projects.Locations.Jobs.List(parent).PageSize(1).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List page1: %v", err)
+	}
+
+	if len(page1.Jobs) != 1 || page1.NextPageToken == "" {
+		t.Fatalf("page1 jobs=%d token=%q, want 1 job + token", len(page1.Jobs), page1.NextPageToken)
+	}
+
+	page2, err := svc.Projects.Locations.Jobs.List(parent).PageSize(1).PageToken(page1.NextPageToken).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List page2: %v", err)
+	}
+
+	if len(page2.Jobs) != 1 || page2.NextPageToken != "" {
+		t.Fatalf("page2 jobs=%d token=%q, want 1 job + no token", len(page2.Jobs), page2.NextPageToken)
+	}
+}
+
+// TestSDKJobRunSucceededCount covers the [LOW] finding: a completed synthetic
+// (no-engine) execution reports succeededCount == taskCount, distinguishing
+// success from failure.
+func TestSDKJobRunSucceededCount(t *testing.T) {
+	svc := newRun(t, nil)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Jobs.Create(parent, sdkJob()).JobId("batch").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	op, err := svc.Projects.Locations.Jobs.Run(parent+"/jobs/batch", &run.GoogleCloudRunV2RunJobRequest{}).
+		Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var exec run.GoogleCloudRunV2Execution
+	decodeOpResponse(t, op, &exec)
+
+	if exec.SucceededCount != 2 {
+		t.Fatalf("succeededCount = %d, want 2 (taskCount)", exec.SucceededCount)
+	}
+
+	if exec.FailedCount != 0 || exec.CompletionTime == "" {
+		t.Fatalf("failedCount=%d completionTime=%q, want 0 + set", exec.FailedCount, exec.CompletionTime)
+	}
+}

--- a/server/gcp/cloudrun/services.go
+++ b/server/gcp/cloudrun/services.go
@@ -1,0 +1,422 @@
+package cloudrun
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
+)
+
+// serviceResource is the google.cloud.run.v2.Service wire shape (the subset
+// CloudEmu models) returned by Get and inlined in create/patch Operation
+// responses.
+type serviceResource struct {
+	Name                  string                `json:"name"`
+	Description           string                `json:"description,omitempty"`
+	UID                   string                `json:"uid,omitempty"`
+	Generation            string                `json:"generation,omitempty"`
+	Labels                map[string]string     `json:"labels,omitempty"`
+	Annotations           map[string]string     `json:"annotations,omitempty"`
+	CreateTime            string                `json:"createTime,omitempty"`
+	UpdateTime            string                `json:"updateTime,omitempty"`
+	Ingress               string                `json:"ingress,omitempty"`
+	LaunchStage           string                `json:"launchStage,omitempty"`
+	Template              revisionTemplate      `json:"template"`
+	Traffic               []trafficTarget       `json:"traffic,omitempty"`
+	ObservedGeneration    string                `json:"observedGeneration,omitempty"`
+	TerminalCondition     *condition            `json:"terminalCondition,omitempty"`
+	Conditions            []condition           `json:"conditions,omitempty"`
+	LatestReadyRevision   string                `json:"latestReadyRevision,omitempty"`
+	LatestCreatedRevision string                `json:"latestCreatedRevision,omitempty"`
+	TrafficStatuses       []trafficTargetStatus `json:"trafficStatuses,omitempty"`
+	URI                   string                `json:"uri,omitempty"`
+	Reconciling           bool                  `json:"reconciling,omitempty"`
+	Etag                  string                `json:"etag,omitempty"`
+}
+
+// revisionTemplate is Service.template — the spec each new revision is cut from.
+type revisionTemplate struct {
+	Revision             string            `json:"revision,omitempty"`
+	Labels               map[string]string `json:"labels,omitempty"`
+	Annotations          map[string]string `json:"annotations,omitempty"`
+	Scaling              *revisionScaling  `json:"scaling,omitempty"`
+	VPCAccess            *vpcAccess        `json:"vpcAccess,omitempty"`
+	Timeout              string            `json:"timeout,omitempty"`
+	ServiceAccount       string            `json:"serviceAccount,omitempty"`
+	Containers           []container       `json:"containers,omitempty"`
+	ExecutionEnvironment string            `json:"executionEnvironment,omitempty"`
+}
+
+type revisionScaling struct {
+	MinInstanceCount int `json:"minInstanceCount,omitempty"`
+	MaxInstanceCount int `json:"maxInstanceCount,omitempty"`
+}
+
+type trafficTarget struct {
+	Type     string `json:"type,omitempty"`
+	Revision string `json:"revision,omitempty"`
+	Percent  int    `json:"percent,omitempty"`
+	Tag      string `json:"tag,omitempty"`
+}
+
+type trafficTargetStatus struct {
+	Type     string `json:"type,omitempty"`
+	Revision string `json:"revision,omitempty"`
+	Percent  int    `json:"percent,omitempty"`
+	Tag      string `json:"tag,omitempty"`
+	URI      string `json:"uri,omitempty"`
+}
+
+// revisionResource is the google.cloud.run.v2.Revision wire shape returned by
+// revisions.get / revisions.list.
+type revisionResource struct {
+	Name                 string           `json:"name"`
+	UID                  string           `json:"uid,omitempty"`
+	Generation           string           `json:"generation,omitempty"`
+	Service              string           `json:"service,omitempty"`
+	CreateTime           string           `json:"createTime,omitempty"`
+	UpdateTime           string           `json:"updateTime,omitempty"`
+	LaunchStage          string           `json:"launchStage,omitempty"`
+	Scaling              *revisionScaling `json:"scaling,omitempty"`
+	VPCAccess            *vpcAccess       `json:"vpcAccess,omitempty"`
+	Timeout              string           `json:"timeout,omitempty"`
+	ServiceAccount       string           `json:"serviceAccount,omitempty"`
+	Containers           []container      `json:"containers,omitempty"`
+	ExecutionEnvironment string           `json:"executionEnvironment,omitempty"`
+	Conditions           []condition      `json:"conditions,omitempty"`
+	Etag                 string           `json:"etag,omitempty"`
+}
+
+type listServicesResponse struct {
+	Services      []serviceResource `json:"services"`
+	NextPageToken string            `json:"nextPageToken,omitempty"`
+}
+
+type listRevisionsResponse struct {
+	Revisions     []revisionResource `json:"revisions"`
+	NextPageToken string             `json:"nextPageToken,omitempty"`
+}
+
+// serveServices routes the services surface.
+func (h *Handler) serveServices(w http.ResponseWriter, r *http.Request, p *crPath) {
+	switch {
+	case p.action != "":
+		h.serveIam(w, r, p, p.serviceName(p.name), h.serviceExists)
+	case p.sub == revisionsSeg && p.subName != "":
+		h.serveRevisionItem(w, r, p)
+	case p.sub == revisionsSeg:
+		h.listRevisions(w, r, p)
+	case p.name != "":
+		h.serveServiceItem(w, r, p)
+	default:
+		h.serveServiceCollection(w, r, p)
+	}
+}
+
+func (h *Handler) serveServiceCollection(w http.ResponseWriter, r *http.Request, p *crPath) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createService(w, r, p)
+	case http.MethodGet:
+		h.listServices(w, r, p)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+	}
+}
+
+func (h *Handler) serveServiceItem(w http.ResponseWriter, r *http.Request, p *crPath) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getService(w, r, p)
+	case http.MethodPatch:
+		h.updateService(w, r, p)
+	case http.MethodDelete:
+		h.deleteService(w, r, p)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+	}
+}
+
+func (h *Handler) serveRevisionItem(w http.ResponseWriter, r *http.Request, p *crPath) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getRevision(w, r, p)
+	case http.MethodDelete:
+		h.deleteRevision(w, r, p)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+	}
+}
+
+func (h *Handler) createService(w http.ResponseWriter, r *http.Request, p *crPath) {
+	var body serviceResource
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	name := r.URL.Query().Get("serviceId")
+	if name == "" {
+		name = lastSegment(body.Name)
+	}
+
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "serviceId is required")
+		return
+	}
+
+	svc, err := h.cr.CreateService(r.Context(), serviceConfigFromWire(name, p.location, &body))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, operation{
+		Name:     opName(p, "create-"+name),
+		Done:     true,
+		Response: asResponse(toServiceResource(svc, p), serviceTypeURL),
+	})
+}
+
+func (h *Handler) updateService(w http.ResponseWriter, r *http.Request, p *crPath) {
+	var body serviceResource
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	svc, err := h.cr.UpdateService(r.Context(), serviceConfigFromWire(p.name, p.location, &body))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, operation{
+		Name:     opName(p, "update-"+p.name),
+		Done:     true,
+		Response: asResponse(toServiceResource(svc, p), serviceTypeURL),
+	})
+}
+
+func (h *Handler) getService(w http.ResponseWriter, r *http.Request, p *crPath) {
+	svc, err := h.cr.GetService(r.Context(), p.name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toServiceResource(svc, p))
+}
+
+func (h *Handler) listServices(w http.ResponseWriter, r *http.Request, p *crPath) {
+	svcs, err := h.cr.ListServices(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	items, next := pageConvert(r, svcs, func(s *driver.Service) serviceResource {
+		return toServiceResource(s, p)
+	})
+
+	writeJSON(w, http.StatusOK, listServicesResponse{Services: items, NextPageToken: next})
+}
+
+func (h *Handler) deleteService(w http.ResponseWriter, r *http.Request, p *crPath) {
+	if err := h.cr.DeleteService(r.Context(), p.name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, operation{Name: opName(p, "delete-"+p.name), Done: true})
+}
+
+func (h *Handler) listRevisions(w http.ResponseWriter, r *http.Request, p *crPath) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	revs, err := h.cr.ListRevisions(r.Context(), p.name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	items, next := pageConvert(r, revs, func(rev *driver.Revision) revisionResource {
+		return toRevisionResource(rev, p)
+	})
+
+	writeJSON(w, http.StatusOK, listRevisionsResponse{Revisions: items, NextPageToken: next})
+}
+
+func (h *Handler) getRevision(w http.ResponseWriter, r *http.Request, p *crPath) {
+	rev, err := h.cr.GetRevision(r.Context(), p.subName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toRevisionResource(rev, p))
+}
+
+func (h *Handler) deleteRevision(w http.ResponseWriter, r *http.Request, p *crPath) {
+	if err := h.cr.DeleteRevision(r.Context(), p.subName); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, operation{Name: opName(p, "delete-rev-"+p.subName), Done: true})
+}
+
+// serviceConfigFromWire maps a wire Service body onto a driver.ServiceConfig.
+func serviceConfigFromWire(name, location string, body *serviceResource) driver.ServiceConfig {
+	t := body.Template
+
+	return driver.ServiceConfig{
+		Name:                 name,
+		Location:             location,
+		Description:          body.Description,
+		Ingress:              body.Ingress,
+		LaunchStage:          body.LaunchStage,
+		Containers:           toDriverContainers(t.Containers),
+		ServiceAccount:       t.ServiceAccount,
+		Timeout:              t.Timeout,
+		ExecutionEnvironment: t.ExecutionEnvironment,
+		VPCAccess:            toDriverVPC(t.VPCAccess),
+		Scaling:              toDriverScaling(t.Scaling),
+		Traffic:              toDriverTraffic(body.Traffic),
+		Labels:               body.Labels,
+		Annotations:          body.Annotations,
+	}
+}
+
+func toDriverScaling(in *revisionScaling) *driver.ServiceScaling {
+	if in == nil {
+		return nil
+	}
+
+	return &driver.ServiceScaling{MinInstanceCount: in.MinInstanceCount, MaxInstanceCount: in.MaxInstanceCount}
+}
+
+func toWireScaling(in *driver.ServiceScaling) *revisionScaling {
+	if in == nil {
+		return nil
+	}
+
+	return &revisionScaling{MinInstanceCount: in.MinInstanceCount, MaxInstanceCount: in.MaxInstanceCount}
+}
+
+func toDriverTraffic(in []trafficTarget) []driver.TrafficTarget {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]driver.TrafficTarget, 0, len(in))
+	for _, t := range in {
+		out = append(out, driver.TrafficTarget{Type: t.Type, Revision: t.Revision, Percent: t.Percent, Tag: t.Tag})
+	}
+
+	return out
+}
+
+func toWireTraffic(in []driver.TrafficTarget) []trafficTarget {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]trafficTarget, 0, len(in))
+	for _, t := range in {
+		out = append(out, trafficTarget{Type: t.Type, Revision: t.Revision, Percent: t.Percent, Tag: t.Tag})
+	}
+
+	return out
+}
+
+func toWireTrafficStatuses(in []driver.TrafficTarget) []trafficTargetStatus {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]trafficTargetStatus, 0, len(in))
+	for _, t := range in {
+		out = append(out, trafficTargetStatus{
+			Type: t.Type, Revision: t.Revision, Percent: t.Percent, Tag: t.Tag, URI: t.URI,
+		})
+	}
+
+	return out
+}
+
+func toServiceResource(s *driver.Service, p *crPath) serviceResource {
+	return serviceResource{
+		Name:                  p.serviceName(s.Name),
+		Description:           s.Description,
+		UID:                   s.UID,
+		Generation:            strconv.FormatInt(s.Generation, 10),
+		Labels:                s.Labels,
+		Annotations:           s.Annotations,
+		CreateTime:            formatTime(s.CreateTime),
+		UpdateTime:            formatTime(s.UpdateTime),
+		Ingress:               s.Ingress,
+		LaunchStage:           s.LaunchStage,
+		Traffic:               toWireTraffic(s.Traffic),
+		ObservedGeneration:    strconv.FormatInt(s.ObservedGeneration, 10),
+		TerminalCondition:     toWireCondition(s.TerminalCondition),
+		Conditions:            toConditions(s.Conditions),
+		LatestReadyRevision:   revName(p, s.Name, s.LatestReadyRevision),
+		LatestCreatedRevision: revName(p, s.Name, s.LatestCreatedRevision),
+		TrafficStatuses:       toWireTrafficStatuses(s.TrafficStatuses),
+		URI:                   s.URI,
+		Reconciling:           s.Reconciling,
+		Etag:                  s.Etag,
+		Template: revisionTemplate{
+			Scaling:              toWireScaling(s.Scaling),
+			VPCAccess:            toWireVPC(s.VPCAccess),
+			Timeout:              s.Timeout,
+			ServiceAccount:       s.ServiceAccount,
+			Containers:           toContainers(s.Containers),
+			ExecutionEnvironment: s.ExecutionEnvironment,
+		},
+	}
+}
+
+func toRevisionResource(r *driver.Revision, p *crPath) revisionResource {
+	return revisionResource{
+		Name:                 revName(p, r.Service, r.Name),
+		UID:                  r.UID,
+		Generation:           strconv.FormatInt(r.Generation, 10),
+		Service:              p.serviceName(r.Service),
+		CreateTime:           formatTime(r.CreateTime),
+		UpdateTime:           formatTime(r.UpdateTime),
+		LaunchStage:          r.LaunchStage,
+		Scaling:              toWireScaling(r.Scaling),
+		VPCAccess:            toWireVPC(r.VPCAccess),
+		Timeout:              r.Timeout,
+		ServiceAccount:       r.ServiceAccount,
+		Containers:           toContainers(r.Containers),
+		ExecutionEnvironment: r.ExecutionEnvironment,
+		Conditions:           toConditions(r.Conditions),
+		Etag:                 r.Etag,
+	}
+}
+
+// revName composes the fully qualified revision resource name, tolerating an
+// empty revision id (returns empty so the field is omitted).
+func revName(p *crPath, service, revision string) string {
+	if revision == "" {
+		return ""
+	}
+
+	return p.serviceName(service) + "/revisions/" + revision
+}
+
+func (h *Handler) serviceExists(r *http.Request, name string) error {
+	_, err := h.cr.GetService(r.Context(), name)
+
+	return err
+}
+
+func (h *Handler) jobExists(r *http.Request, name string) error {
+	_, err := h.cr.GetJob(r.Context(), name)
+
+	return err
+}

--- a/server/gcp/cloudrun/services.go
+++ b/server/gcp/cloudrun/services.go
@@ -230,22 +230,12 @@ func (h *Handler) deleteService(w http.ResponseWriter, r *http.Request, p *crPat
 }
 
 func (h *Handler) listRevisions(w http.ResponseWriter, r *http.Request, p *crPath) {
-	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
-		return
-	}
-
-	revs, err := h.cr.ListRevisions(r.Context(), p.name)
-	if err != nil {
-		writeErr(w, err)
-		return
-	}
-
-	items, next := pageConvert(r, revs, func(rev *driver.Revision) revisionResource {
-		return toRevisionResource(rev, p)
-	})
-
-	writeJSON(w, http.StatusOK, listRevisionsResponse{Revisions: items, NextPageToken: next})
+	listPaged(w, r,
+		func() ([]driver.Revision, error) { return h.cr.ListRevisions(r.Context(), p.name) },
+		func(rev *driver.Revision) revisionResource { return toRevisionResource(rev, p) },
+		func(items []revisionResource, next string) listRevisionsResponse {
+			return listRevisionsResponse{Revisions: items, NextPageToken: next}
+		})
 }
 
 func (h *Handler) getRevision(w http.ResponseWriter, r *http.Request, p *crPath) {

--- a/server/gcp/cloudrun/services_sdk_test.go
+++ b/server/gcp/cloudrun/services_sdk_test.go
@@ -1,0 +1,279 @@
+package cloudrun_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	run "google.golang.org/api/run/v2"
+)
+
+// decodeOpResponse unmarshals an LRO's inlined response payload into v.
+func decodeOpResponse(t *testing.T, op *run.GoogleLongrunningOperation, v any) {
+	t.Helper()
+
+	if !op.Done {
+		t.Fatalf("operation %q not done", op.Name)
+	}
+
+	if len(op.Response) == 0 {
+		t.Fatalf("operation %q has no response payload", op.Name)
+	}
+
+	if err := json.Unmarshal(op.Response, v); err != nil {
+		t.Fatalf("decode op response: %v", err)
+	}
+}
+
+func sdkService() *run.GoogleCloudRunV2Service {
+	return &run.GoogleCloudRunV2Service{
+		Description: "web frontend",
+		Ingress:     "INGRESS_TRAFFIC_ALL",
+		Template: &run.GoogleCloudRunV2RevisionTemplate{
+			ServiceAccount: "web@demo-project.iam.gserviceaccount.com",
+			Timeout:        "300s",
+			Scaling:        &run.GoogleCloudRunV2RevisionScaling{MinInstanceCount: 1, MaxInstanceCount: 5},
+			Containers: []*run.GoogleCloudRunV2Container{{
+				Image: "gcr.io/demo/web:v1",
+				Ports: []*run.GoogleCloudRunV2ContainerPort{{ContainerPort: 8080}},
+			}},
+		},
+	}
+}
+
+// TestSDKServiceCreateGetListDelete covers the [BLOCKER] finding: the Services
+// surface exists — create reconciles to a URL + ready revision + traffic, and
+// Get/List/Delete work.
+func TestSDKServiceCreateGetListDelete(t *testing.T) {
+	svc := newRun(t, nil)
+	ctx := context.Background()
+
+	op, err := svc.Projects.Locations.Services.Create(parent, sdkService()).ServiceId("web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Services.Create: %v", err)
+	}
+
+	var created run.GoogleCloudRunV2Service
+	decodeOpResponse(t, op, &created)
+
+	if created.Uri == "" || !strings.HasPrefix(created.Uri, "https://web-") {
+		t.Errorf("uri = %q, want https://web-…run.app", created.Uri)
+	}
+
+	got, err := svc.Projects.Locations.Services.Get(parent + "/services/web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Services.Get: %v", err)
+	}
+
+	if got.Uri == "" {
+		t.Error("get: uri empty")
+	}
+
+	if !strings.Contains(got.LatestReadyRevision, "/services/web/revisions/web-00001-") {
+		t.Errorf("latestReadyRevision = %q", got.LatestReadyRevision)
+	}
+
+	if got.LatestCreatedRevision != got.LatestReadyRevision {
+		t.Errorf("latestCreated=%q latestReady=%q, want equal", got.LatestCreatedRevision, got.LatestReadyRevision)
+	}
+
+	if got.TerminalCondition == nil || got.TerminalCondition.Type != "Ready" ||
+		got.TerminalCondition.State != "CONDITION_SUCCEEDED" {
+		t.Errorf("terminalCondition = %+v", got.TerminalCondition)
+	}
+
+	if len(got.Traffic) != 1 || got.Traffic[0].Percent != 100 {
+		t.Errorf("traffic = %+v, want 100%% latest", got.Traffic)
+	}
+
+	if len(got.TrafficStatuses) != 1 || got.TrafficStatuses[0].Revision == "" {
+		t.Errorf("trafficStatuses = %+v", got.TrafficStatuses)
+	}
+
+	if got.Template.ServiceAccount != "web@demo-project.iam.gserviceaccount.com" || got.Template.Timeout != "300s" {
+		t.Errorf("template round-trip lost fields: %+v", got.Template)
+	}
+
+	list, err := svc.Projects.Locations.Services.List(parent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Services.List: %v", err)
+	}
+
+	if len(list.Services) != 1 {
+		t.Fatalf("list services = %d, want 1", len(list.Services))
+	}
+
+	delOp, err := svc.Projects.Locations.Services.Delete(parent + "/services/web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Services.Delete: %v", err)
+	}
+
+	if !delOp.Done {
+		t.Fatal("delete op not done")
+	}
+
+	if _, err := svc.Projects.Locations.Services.Get(parent + "/services/web").Context(ctx).Do(); err == nil {
+		t.Fatal("get after delete: want error")
+	}
+}
+
+// TestSDKServicePatchCreatesRevision covers the [BLOCKER] finding's patch verb:
+// updating a service materializes a new revision and bumps generation.
+func TestSDKServicePatchCreatesRevision(t *testing.T) {
+	svc := newRun(t, nil)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Services.Create(parent, sdkService()).
+		ServiceId("web").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	updated := sdkService()
+	updated.Template.Containers[0].Image = "gcr.io/demo/web:v2"
+
+	op, err := svc.Projects.Locations.Services.Patch(parent+"/services/web", updated).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	if !op.Done {
+		t.Fatal("patch op not done")
+	}
+
+	got, err := svc.Projects.Locations.Services.Get(parent + "/services/web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Generation != 2 {
+		t.Errorf("generation = %d, want 2", got.Generation)
+	}
+
+	if !strings.Contains(got.LatestReadyRevision, "/revisions/web-00002-") {
+		t.Errorf("latestReadyRevision = %q, want web-00002-…", got.LatestReadyRevision)
+	}
+
+	if got.Template.Containers[0].Image != "gcr.io/demo/web:v2" {
+		t.Errorf("image = %q, want v2", got.Template.Containers[0].Image)
+	}
+}
+
+// TestSDKServiceRevisions covers the [BLOCKER] finding's revisions surface:
+// list/get/delete of the revisions a service materializes.
+func TestSDKServiceRevisions(t *testing.T) {
+	svc := newRun(t, nil)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Services.Create(parent, sdkService()).
+		ServiceId("web").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	updated := sdkService()
+	updated.Template.Containers[0].Image = "gcr.io/demo/web:v2"
+	if _, err := svc.Projects.Locations.Services.Patch(parent+"/services/web", updated).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	list, err := svc.Projects.Locations.Services.Revisions.List(parent + "/services/web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Revisions.List: %v", err)
+	}
+
+	if len(list.Revisions) != 2 {
+		t.Fatalf("revisions = %d, want 2", len(list.Revisions))
+	}
+
+	first := list.Revisions[0].Name
+
+	rev, err := svc.Projects.Locations.Services.Revisions.Get(first).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Revisions.Get: %v", err)
+	}
+
+	if rev.Service == "" || !strings.HasSuffix(rev.Service, "/services/web") {
+		t.Errorf("revision.service = %q", rev.Service)
+	}
+
+	delOp, err := svc.Projects.Locations.Services.Revisions.Delete(first).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Revisions.Delete: %v", err)
+	}
+
+	if !delOp.Done {
+		t.Fatal("revision delete op not done")
+	}
+
+	after, err := svc.Projects.Locations.Services.Revisions.List(parent + "/services/web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Revisions.List after delete: %v", err)
+	}
+
+	if len(after.Revisions) != 1 {
+		t.Fatalf("revisions after delete = %d, want 1", len(after.Revisions))
+	}
+}
+
+// TestSDKServiceIam covers the service IAM surface (getIamPolicy/setIamPolicy).
+func TestSDKServiceIam(t *testing.T) {
+	svc := newRun(t, nil)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Services.Create(parent, sdkService()).
+		ServiceId("web").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	resource := parent + "/services/web"
+	set := &run.GoogleIamV1SetIamPolicyRequest{Policy: &run.GoogleIamV1Policy{
+		Bindings: []*run.GoogleIamV1Binding{{
+			Role:    "roles/run.invoker",
+			Members: []string{"allUsers"},
+		}},
+	}}
+	if _, err := svc.Projects.Locations.Services.SetIamPolicy(resource, set).Context(ctx).Do(); err != nil {
+		t.Fatalf("SetIamPolicy: %v", err)
+	}
+
+	pol, err := svc.Projects.Locations.Services.GetIamPolicy(resource).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("GetIamPolicy: %v", err)
+	}
+
+	if len(pol.Bindings) != 1 || pol.Bindings[0].Members[0] != "allUsers" {
+		t.Fatalf("policy = %+v", pol.Bindings)
+	}
+}
+
+// TestSDKServicesListPagination covers pageSize/pageToken over the services list.
+func TestSDKServicesListPagination(t *testing.T) {
+	svc := newRun(t, nil)
+	ctx := context.Background()
+
+	for _, id := range []string{"a", "b"} {
+		if _, err := svc.Projects.Locations.Services.Create(parent, sdkService()).
+			ServiceId(id).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create %s: %v", id, err)
+		}
+	}
+
+	page1, err := svc.Projects.Locations.Services.List(parent).PageSize(1).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List page1: %v", err)
+	}
+
+	if len(page1.Services) != 1 || page1.NextPageToken == "" {
+		t.Fatalf("page1 services=%d token=%q", len(page1.Services), page1.NextPageToken)
+	}
+
+	page2, err := svc.Projects.Locations.Services.List(parent).
+		PageSize(1).PageToken(page1.NextPageToken).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List page2: %v", err)
+	}
+
+	if len(page2.Services) != 1 || page2.NextPageToken != "" {
+		t.Fatalf("page2 services=%d token=%q", len(page2.Services), page2.NextPageToken)
+	}
+}

--- a/server/gcp/cloudrun/services_sdk_test.go
+++ b/server/gcp/cloudrun/services_sdk_test.go
@@ -95,6 +95,11 @@ func TestSDKServiceCreateGetListDelete(t *testing.T) {
 		t.Errorf("template round-trip lost fields: %+v", got.Template)
 	}
 
+	if len(got.Template.Containers) != 1 || len(got.Template.Containers[0].Ports) != 1 ||
+		got.Template.Containers[0].Ports[0].ContainerPort != 8080 {
+		t.Errorf("container ports lost on round-trip: %+v", got.Template.Containers)
+	}
+
 	list, err := svc.Projects.Locations.Services.List(parent).Context(ctx).Do()
 	if err != nil {
 		t.Fatalf("Services.List: %v", err)

--- a/server/gcp/cloudrun/types.go
+++ b/server/gcp/cloudrun/types.go
@@ -3,36 +3,53 @@ package cloudrun
 // jobResource is the google.cloud.run.v2.Job wire shape (the subset CloudEmu
 // models) returned by Get and inlined in create's Operation response.
 type jobResource struct {
-	Name           string            `json:"name"`
-	UID            string            `json:"uid,omitempty"`
-	Generation     string            `json:"generation,omitempty"`
-	CreateTime     string            `json:"createTime,omitempty"`
-	UpdateTime     string            `json:"updateTime,omitempty"`
-	LaunchStage    string            `json:"launchStage,omitempty"`
-	ExecutionCount int               `json:"executionCount,omitempty"`
-	Labels         map[string]string `json:"labels,omitempty"`
-	Annotations    map[string]string `json:"annotations,omitempty"`
-	Template       execTemplate      `json:"template"`
-	Conditions     []condition       `json:"conditions,omitempty"`
+	Name                   string              `json:"name"`
+	UID                    string              `json:"uid,omitempty"`
+	Generation             string              `json:"generation,omitempty"`
+	CreateTime             string              `json:"createTime,omitempty"`
+	UpdateTime             string              `json:"updateTime,omitempty"`
+	LaunchStage            string              `json:"launchStage,omitempty"`
+	ExecutionCount         int                 `json:"executionCount,omitempty"`
+	Labels                 map[string]string   `json:"labels,omitempty"`
+	Annotations            map[string]string   `json:"annotations,omitempty"`
+	Template               execTemplate        `json:"template"`
+	ObservedGeneration     string              `json:"observedGeneration,omitempty"`
+	TerminalCondition      *condition          `json:"terminalCondition,omitempty"`
+	Conditions             []condition         `json:"conditions,omitempty"`
+	LatestCreatedExecution *executionReference `json:"latestCreatedExecution,omitempty"`
+	Reconciling            bool                `json:"reconciling,omitempty"`
+	Etag                   string              `json:"etag,omitempty"`
 }
 
 // execTemplate is Job.template — an ExecutionTemplate wrapping a TaskTemplate.
 type execTemplate struct {
-	TaskCount int          `json:"taskCount,omitempty"`
-	Template  taskTemplate `json:"template"`
+	Parallelism int          `json:"parallelism,omitempty"`
+	TaskCount   int          `json:"taskCount,omitempty"`
+	Template    taskTemplate `json:"template"`
 }
 
-// taskTemplate is the per-task container spec.
+// taskTemplate is the per-task container spec plus its execution settings.
 type taskTemplate struct {
-	Containers []container `json:"containers,omitempty"`
+	Containers           []container `json:"containers,omitempty"`
+	MaxRetries           int         `json:"maxRetries,omitempty"`
+	Timeout              string      `json:"timeout,omitempty"`
+	ServiceAccount       string      `json:"serviceAccount,omitempty"`
+	ExecutionEnvironment string      `json:"executionEnvironment,omitempty"`
+	VPCAccess            *vpcAccess  `json:"vpcAccess,omitempty"`
 }
 
 type container struct {
-	Name    string   `json:"name,omitempty"`
-	Image   string   `json:"image"`
-	Command []string `json:"command,omitempty"`
-	Args    []string `json:"args,omitempty"`
-	Env     []envVar `json:"env,omitempty"`
+	Name    string          `json:"name,omitempty"`
+	Image   string          `json:"image"`
+	Command []string        `json:"command,omitempty"`
+	Args    []string        `json:"args,omitempty"`
+	Env     []envVar        `json:"env,omitempty"`
+	Ports   []containerPort `json:"ports,omitempty"`
+}
+
+type containerPort struct {
+	Name          string `json:"name,omitempty"`
+	ContainerPort int    `json:"containerPort,omitempty"`
 }
 
 type envVar struct {
@@ -40,11 +57,30 @@ type envVar struct {
 	Value string `json:"value,omitempty"`
 }
 
+type vpcAccess struct {
+	Connector         string             `json:"connector,omitempty"`
+	Egress            string             `json:"egress,omitempty"`
+	NetworkInterfaces []networkInterface `json:"networkInterfaces,omitempty"`
+}
+
+type networkInterface struct {
+	Network    string   `json:"network,omitempty"`
+	Subnetwork string   `json:"subnetwork,omitempty"`
+	Tags       []string `json:"tags,omitempty"`
+}
+
 type condition struct {
 	Type    string `json:"type,omitempty"`
 	State   string `json:"state,omitempty"`
 	Message string `json:"message,omitempty"`
 	Reason  string `json:"reason,omitempty"`
+}
+
+// executionReference is Job.latestCreatedExecution.
+type executionReference struct {
+	Name           string `json:"name,omitempty"`
+	CreateTime     string `json:"createTime,omitempty"`
+	CompletionTime string `json:"completionTime,omitempty"`
 }
 
 // executionResource is the google.cloud.run.v2.Execution wire shape inlined in
@@ -69,7 +105,15 @@ type executionResource struct {
 
 // listJobsResponse is the {jobs: [...]} envelope from jobs.list.
 type listJobsResponse struct {
-	Jobs []jobResource `json:"jobs"`
+	Jobs          []jobResource `json:"jobs"`
+	NextPageToken string        `json:"nextPageToken,omitempty"`
+}
+
+// listExecutionsResponse is the {executions: [...]} envelope from
+// jobs.executions.list.
+type listExecutionsResponse struct {
+	Executions    []executionResource `json:"executions"`
+	NextPageToken string              `json:"nextPageToken,omitempty"`
 }
 
 // operation is the google.longrunning.Operation envelope every mutating

--- a/services/cloudrun/driver/driver.go
+++ b/services/cloudrun/driver/driver.go
@@ -1,13 +1,14 @@
 // Package driver defines the minimal interface an in-memory GCP Cloud Run
-// (Jobs) backend must implement. Cloud Run is GCP-only, so there is a single
-// provider implementation (providers/gcp/cloudrun) rather than the usual
-// three; the interface still lives here so the wire handler
-// (server/gcp/cloudrun) depends on an abstraction rather than the concrete
-// mock.
+// backend must implement. Cloud Run is GCP-only, so there is a single provider
+// implementation (providers/gcp/cloudrun) rather than the usual three; the
+// interface still lives here so the wire handler (server/gcp/cloudrun) depends
+// on an abstraction rather than the concrete mock.
 //
-// Scope is Jobs — run-to-completion workloads — not Services (HTTP ingress /
-// revisions). A Job stores a container template; running it creates an
-// Execution whose tasks run the template's containers to completion.
+// Scope covers both Cloud Run surfaces: Jobs (run-to-completion workloads —
+// a Job stores a container template; running it creates an Execution whose
+// tasks run the template's containers to completion) and Services (HTTP
+// ingress workloads — a Service stores a revision template; creating or
+// updating it materializes a Revision and serves traffic at a stable URL).
 package driver
 
 import (
@@ -15,7 +16,7 @@ import (
 	"time"
 )
 
-// CloudRun is the control-plane surface for Cloud Run Jobs.
+// CloudRun is the control-plane surface for Cloud Run Jobs and Services.
 type CloudRun interface {
 	// CreateJob stores a job spec. It does not run anything — RunJob does.
 	CreateJob(ctx context.Context, cfg JobConfig) (*Job, error)
@@ -26,6 +27,10 @@ type CloudRun interface {
 
 	// ListJobs returns every stored job.
 	ListJobs(ctx context.Context) ([]Job, error)
+
+	// UpdateJob applies an in-place update to an existing job, bumping its
+	// generation, and returns the mutated job.
+	UpdateJob(ctx context.Context, cfg JobConfig) (*Job, error)
 
 	// DeleteJob removes a job and stops any container workloads its executions
 	// started on a configured ContainerEngine.
@@ -38,42 +43,112 @@ type CloudRun interface {
 	// GetExecution returns an execution by name (bare execution id or a fully
 	// qualified …/executions/{id} resource name).
 	GetExecution(ctx context.Context, name string) (*Execution, error)
+
+	// ListExecutions returns every stored execution of the named job.
+	ListExecutions(ctx context.Context, jobName string) ([]Execution, error)
+
+	// CreateService stores a service spec and materializes its first Revision,
+	// returning the reconciled service serving traffic at a stable URL.
+	CreateService(ctx context.Context, cfg ServiceConfig) (*Service, error)
+
+	// GetService returns a service by name (bare service id or a fully
+	// qualified projects/…/services/{id} resource name).
+	GetService(ctx context.Context, name string) (*Service, error)
+
+	// ListServices returns every stored service.
+	ListServices(ctx context.Context) ([]Service, error)
+
+	// UpdateService applies an in-place update, materializing a new Revision
+	// and bumping the service generation, and returns the reconciled service.
+	UpdateService(ctx context.Context, cfg ServiceConfig) (*Service, error)
+
+	// DeleteService removes a service and its revisions.
+	DeleteService(ctx context.Context, name string) error
+
+	// ListRevisions returns every stored revision of the named service.
+	ListRevisions(ctx context.Context, serviceName string) ([]Revision, error)
+
+	// GetRevision returns a revision by name (bare revision id or a fully
+	// qualified …/revisions/{id} resource name).
+	GetRevision(ctx context.Context, name string) (*Revision, error)
+
+	// DeleteRevision removes a single revision of a service.
+	DeleteRevision(ctx context.Context, name string) error
 }
 
-// JobConfig is the input to CreateJob — the subset of the Cloud Run Job
-// template CloudEmu models.
+// JobConfig is the input to CreateJob / UpdateJob — the subset of the Cloud Run
+// Job template CloudEmu models.
 type JobConfig struct {
-	Name        string
-	Containers  []Container
-	TaskCount   int // tasks per execution; defaults to 1 when non-positive
-	Labels      map[string]string
-	Annotations map[string]string
+	Name                 string
+	Containers           []Container
+	TaskCount            int // tasks per execution; defaults to 1 when non-positive
+	Parallelism          int
+	MaxRetries           int
+	Timeout              string // task timeout as a duration string, e.g. "600s"
+	ServiceAccount       string
+	ExecutionEnvironment string // EXECUTION_ENVIRONMENT_GEN1 / _GEN2
+	VPCAccess            *VpcAccess
+	Labels               map[string]string
+	Annotations          map[string]string
 }
 
-// Container is one container in a job's task template.
+// Container is one container in a job or service task template.
 type Container struct {
 	Name    string
 	Image   string
 	Command []string          // entrypoint override
 	Args    []string          // arguments to the entrypoint
 	Env     map[string]string // environment variables
+	Ports   []int             // container ports (services)
+}
+
+// VpcAccess is the VPC connectivity configuration of a job or service template.
+type VpcAccess struct {
+	Connector         string
+	Egress            string // ALL_TRAFFIC / PRIVATE_RANGES_ONLY
+	NetworkInterfaces []VpcNetworkInterface
+}
+
+// VpcNetworkInterface is one direct-VPC network interface.
+type VpcNetworkInterface struct {
+	Network    string
+	Subnetwork string
+	Tags       []string
 }
 
 // Job is a stored Cloud Run job. Name is the bare job id; the wire handler
 // composes the fully qualified resource name from the request path.
 type Job struct {
+	Name                   string
+	UID                    string
+	Generation             int64
+	ObservedGeneration     int64
+	CreateTime             time.Time
+	UpdateTime             time.Time
+	LaunchStage            string
+	ExecutionCount         int
+	TaskCount              int
+	Parallelism            int
+	MaxRetries             int
+	Timeout                string
+	ServiceAccount         string
+	ExecutionEnvironment   string
+	VPCAccess              *VpcAccess
+	Containers             []Container
+	Labels                 map[string]string
+	Annotations            map[string]string
+	Conditions             []Condition
+	TerminalCondition      *Condition
+	LatestCreatedExecution *ExecutionReference
+	Etag                   string
+	Reconciling            bool
+}
+
+// ExecutionReference is the LatestCreatedExecution summary carried on a Job.
+type ExecutionReference struct {
 	Name           string
-	UID            string
-	Generation     int64
 	CreateTime     time.Time
-	UpdateTime     time.Time
-	LaunchStage    string
-	ExecutionCount int
-	TaskCount      int
-	Containers     []Container
-	Labels         map[string]string
-	Annotations    map[string]string
-	Conditions     []Condition
+	CompletionTime time.Time
 }
 
 // Execution is one run-to-completion run of a job. Its counts reflect the
@@ -120,4 +195,89 @@ type Condition struct {
 	State   string // "CONDITION_SUCCEEDED", "CONDITION_FAILED", "CONDITION_PENDING"
 	Message string
 	Reason  string
+}
+
+// ServiceConfig is the input to CreateService / UpdateService — the subset of
+// the Cloud Run Service the emulator models.
+type ServiceConfig struct {
+	Name                 string
+	Location             string // GCP region from the request path, used for the *.run.app URL
+	Description          string
+	Ingress              string // INGRESS_TRAFFIC_ALL / _INTERNAL_ONLY / _INTERNAL_LOAD_BALANCER
+	LaunchStage          string
+	Containers           []Container
+	ServiceAccount       string
+	Timeout              string
+	ExecutionEnvironment string
+	VPCAccess            *VpcAccess
+	Scaling              *ServiceScaling
+	Traffic              []TrafficTarget
+	Labels               map[string]string
+	Annotations          map[string]string
+}
+
+// ServiceScaling is a service's revision-template scaling bounds.
+type ServiceScaling struct {
+	MinInstanceCount int
+	MaxInstanceCount int
+}
+
+// TrafficTarget assigns a percentage (or a latest pointer) of ingress traffic
+// to a revision, optionally under a named tag.
+type TrafficTarget struct {
+	Type     string // TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST / _REVISION
+	Revision string
+	Percent  int
+	Tag      string
+	URI      string // populated on the observed traffic status
+}
+
+// Service is a stored Cloud Run service serving HTTP ingress. Name is the bare
+// service id; the wire handler composes the fully qualified resource name.
+type Service struct {
+	Name                  string
+	UID                   string
+	Generation            int64
+	ObservedGeneration    int64
+	CreateTime            time.Time
+	UpdateTime            time.Time
+	LaunchStage           string
+	Description           string
+	Ingress               string
+	Containers            []Container
+	ServiceAccount        string
+	Timeout               string
+	ExecutionEnvironment  string
+	VPCAccess             *VpcAccess
+	Scaling               *ServiceScaling
+	Traffic               []TrafficTarget
+	TrafficStatuses       []TrafficTarget
+	URI                   string
+	LatestReadyRevision   string
+	LatestCreatedRevision string
+	Labels                map[string]string
+	Annotations           map[string]string
+	Conditions            []Condition
+	TerminalCondition     *Condition
+	Etag                  string
+	Reconciling           bool
+}
+
+// Revision is one immutable revision materialized from a service's template.
+type Revision struct {
+	Name                 string
+	UID                  string
+	Generation           int64
+	Service              string
+	CreateTime           time.Time
+	UpdateTime           time.Time
+	LaunchStage          string
+	Containers           []Container
+	ServiceAccount       string
+	Timeout              string
+	ExecutionEnvironment string
+	VPCAccess            *VpcAccess
+	Scaling              *ServiceScaling
+	Conditions           []Condition
+	Etag                 string
 }


### PR DESCRIPTION
## What

Closes the `## cloudrun` findings from the GCP audit. The Cloud Run Admin API v2 handler was Jobs-only; this adds the primary **Services** surface and fills the Jobs gaps a real `run/apiv2` (`google.golang.org/api/run/v2`) user or `google_cloud_run_v2_*` Terraform user hits.

### Services (BLOCKER — was 501, handler was Jobs-only)
- `services.create/get/list/patch/delete` — create reconciles to an Operation carrying the Service with a stable `*.run.app` `uri`, `latestReadyRevision`/`latestCreatedRevision`, default 100% LATEST `traffic` + resolved `trafficStatuses`, `terminalCondition` (Ready/CONDITION_SUCCEEDED) and `conditions`; patch materializes a new revision and bumps generation.
- `services/{svc}/revisions` list/get/delete — every create/patch materializes a `{service}-000NN-{suffix}` revision.
- Services IAM: `:getIamPolicy`/`:setIamPolicy`/`:testIamPermissions`.

### Jobs
- `jobs.patch` (HIGH) — was 405; now returns an LRO with the mutated Job.
- Jobs IAM (HIGH) — `:getIamPolicy` was mis-routed to getJob and `:setIamPolicy` was 405; now stored/round-tripped, plus `:testIamPermissions`.
- `jobs.executions.list` (HIGH) — the bare collection returned the Job; now returns `{executions,nextPageToken}`.
- Template fields (MEDIUM) — `maxRetries`/`serviceAccount`/`timeout`/`parallelism`/`executionEnvironment`/`vpcAccess` now round-trip on create/get.
- Job status fields (MEDIUM) — `terminalCondition`/`etag`/`observedGeneration`/`reconciling`/`latestCreatedExecution` now populated.
- `jobs.list` (LOW) — honors `pageSize`/`pageToken`.
- `jobs.run`/`executions.get` (LOW) — a completed execution reports `succeededCount == taskCount` (distinguishable from failure); covered by a regression test.

## Why

The Services surface is the primary Cloud Run workload type (HTTP ingress); every `run/apiv2 ServicesClient` and `google_cloud_run_v2_service` user was dead on arrival. The Jobs gaps caused 405s, IAM mis-routing, and perpetual Terraform drift.

## Where (3-layer)

- Driver `services/cloudrun/driver` gained Services/Revisions methods + `UpdateJob`/`ListExecutions` and the extra config/status fields. Cloud Run is GCP-only (single provider impl), so the interface was extended directly; `docs/coverage` regenerated via `go generate`.
- Provider `providers/gcp/cloudrun` implements the new methods in-memory.
- Wire `server/gcp/cloudrun` generalizes path routing (jobs/services/operations, sub-collections, IAM verbs) and adds the Service/Revision/IAM codecs. IAM policies are held in the handler (not enforced), mirroring the cloudfunctions pattern.

## Tests

New reproduction tests drive the real `google.golang.org/api/run/v2` client against the in-process GCP server (`server/gcp/cloudrun/{jobs,services}_sdk_test.go`) proving each finding's repro now passes, plus provider-level tests (`providers/gcp/cloudrun/services_test.go`). Existing Cloud Run tests stay green.

## Findings fixed

All `## cloudrun` findings (services.* BLOCKER; jobs.patch, jobs IAM, executions.list HIGH; template fields, job status fields MEDIUM; list pagination, succeededCount LOW).

## Deferrals

None.