### PR TITLE
fix(gcp-cloudfunctions): gen2 v2 API, gen1 metadata/versionId, testIamPermissions, list pagination

### DIFF
--- a/server/gcp/cloudfunctions/gen1meta.go
+++ b/server/gcp/cloudfunctions/gen1meta.go
@@ -1,0 +1,208 @@
+package cloudfunctions
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"net/url"
+	"strconv"
+)
+
+// gen1Meta is the GCP-specific gen1 (v1) output-only metadata a real client
+// reads back from Get/List but that has no portable Serverless-driver field:
+// the runtime service account, ingress policy, docker registry, the current
+// build id and the monotonically increasing deploy generation (versionId).
+type gen1Meta struct {
+	serviceAccountEmail string
+	ingressSettings     string
+	dockerRegistry      string
+	buildID             string
+	versionID           int64
+}
+
+// newGen1Meta builds the initial metadata for a freshly created v1 function,
+// honoring any values the create body set and falling back to the defaults real
+// Cloud Functions assigns.
+func newGen1Meta(body *cloudFunction, project string) *gen1Meta {
+	m := &gen1Meta{
+		serviceAccountEmail: body.ServiceAccountEmail,
+		ingressSettings:     body.IngressSettings,
+		dockerRegistry:      body.DockerRegistry,
+		buildID:             newBuildID(),
+		versionID:           1,
+	}
+
+	applyGen1Defaults(m, project)
+
+	return m
+}
+
+// applyGen1Defaults fills any unset gen1 metadata field with the value real
+// Cloud Functions defaults to.
+func applyGen1Defaults(m *gen1Meta, project string) {
+	if m.serviceAccountEmail == "" {
+		m.serviceAccountEmail = gen1ServiceAccount(project)
+	}
+
+	if m.ingressSettings == "" {
+		m.ingressSettings = defaultIngress
+	}
+
+	if m.dockerRegistry == "" {
+		m.dockerRegistry = defaultDockerRegistry
+	}
+
+	if m.buildID == "" {
+		m.buildID = newBuildID()
+	}
+
+	if m.versionID == 0 {
+		m.versionID = 1
+	}
+}
+
+// putGen1Meta stores freshly created metadata under the function's canonical name.
+func (h *Handler) putGen1Meta(name string, m *gen1Meta) {
+	h.mu.Lock()
+	h.gen1Meta[name] = m
+	h.mu.Unlock()
+}
+
+// bumpGen1Meta advances the deploy generation for an updated function: versionId
+// increments, a new build id is cut, and any gen1 metadata carried in the PATCH
+// body is applied. A function whose metadata is missing (created straight through
+// the portable API) is seeded first so the bump still lands on version 2.
+func (h *Handler) bumpGen1Meta(name string, body *cloudFunction, project string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	m := h.gen1Meta[name]
+	if m == nil {
+		m = &gen1Meta{versionID: 1}
+		applyGen1Defaults(m, project)
+	}
+
+	if body.ServiceAccountEmail != "" {
+		m.serviceAccountEmail = body.ServiceAccountEmail
+	}
+
+	if body.IngressSettings != "" {
+		m.ingressSettings = body.IngressSettings
+	}
+
+	if body.DockerRegistry != "" {
+		m.dockerRegistry = body.DockerRegistry
+	}
+
+	m.versionID++
+	m.buildID = newBuildID()
+	h.gen1Meta[name] = m
+}
+
+// gen1MetaFor returns a copy of the stored metadata for name, or freshly
+// defaulted metadata (versionId 1) when none is stored — the case for a function
+// created directly through the portable API rather than the wire handler.
+func (h *Handler) gen1MetaFor(name, project string) gen1Meta {
+	h.mu.RLock()
+	m := h.gen1Meta[name]
+	h.mu.RUnlock()
+
+	if m != nil {
+		return *m
+	}
+
+	out := gen1Meta{versionID: 1}
+	applyGen1Defaults(&out, project)
+
+	return out
+}
+
+// gen1ServiceAccount is the App Engine default service account real gen1 Cloud
+// Functions runs a function as when none is specified.
+func gen1ServiceAccount(project string) string {
+	return project + "@appspot.gserviceaccount.com"
+}
+
+// gen2ServiceAccount is the Compute Engine default service account real gen2
+// Cloud Functions runs a function as when none is specified. The numeric project
+// number is unknown to the emulator, so the project id stands in.
+func gen2ServiceAccount(project string) string {
+	return project + "-compute@developer.gserviceaccount.com"
+}
+
+// newBuildID returns a random build identifier, the value real Cloud Functions
+// assigns per deploy and echoes back as buildId.
+func newBuildID() string {
+	b := make([]byte, buildIDBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "build-0"
+	}
+
+	return "build-" + hex.EncodeToString(b)
+}
+
+// pageRange is a half-open [start, end) slice of a sorted result set.
+type pageRange struct {
+	start int
+	end   int
+}
+
+// paginate resolves the pageSize/pageToken query parameters against a result set
+// of length total, returning the slice to serve and the nextPageToken to
+// advertise (empty when the page is the last). The token is the base64-encoded
+// next offset, matching the opaque-cursor contract real clients expect.
+func paginate(total int, q url.Values) (page pageRange, nextToken string) {
+	start := decodePageToken(q.Get("pageToken"))
+	if start < 0 || start > total {
+		start = 0
+	}
+
+	size := parsePageSize(q.Get("pageSize"))
+
+	end := total
+	if size > 0 && start+size < total {
+		end = start + size
+	}
+
+	var next string
+	if end < total {
+		next = encodePageToken(end)
+	}
+
+	return pageRange{start: start, end: end}, next
+}
+
+func parsePageSize(s string) int {
+	if s == "" {
+		return 0
+	}
+
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 {
+		return 0
+	}
+
+	return n
+}
+
+func encodePageToken(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}
+
+func decodePageToken(tok string) int {
+	if tok == "" {
+		return 0
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(tok)
+	if err != nil {
+		return 0
+	}
+
+	n, err := strconv.Atoi(string(raw))
+	if err != nil {
+		return 0
+	}
+
+	return n
+}

--- a/server/gcp/cloudfunctions/gen2.go
+++ b/server/gcp/cloudfunctions/gen2.go
@@ -1,0 +1,592 @@
+package cloudfunctions
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// gen2Function is the GCP Cloud Functions gen2 (v2 API) resource shape. gen2 is
+// the modern default (functions/apiv2, terraform google_cloudfunctions2_function)
+// and is an entirely different resource from v1: the code and its build are
+// described by buildConfig, the deployed Cloud Run service by serviceConfig, and
+// event-driven functions by eventTrigger. CloudEmu does not build or run gen2
+// code, so it round-trips the request and synthesizes the output-only fields real
+// GCP fills in (state ACTIVE, environment GEN_2, serviceConfig.uri, build, etc.).
+type gen2Function struct {
+	Name          string             `json:"name,omitempty"`
+	Environment   string             `json:"environment,omitempty"`
+	Description   string             `json:"description,omitempty"`
+	State         string             `json:"state,omitempty"`
+	URL           string             `json:"url,omitempty"`
+	UpdateTime    string             `json:"updateTime,omitempty"`
+	CreateTime    string             `json:"createTime,omitempty"`
+	Labels        map[string]string  `json:"labels,omitempty"`
+	BuildConfig   *gen2BuildConfig   `json:"buildConfig,omitempty"`
+	ServiceConfig *gen2ServiceConfig `json:"serviceConfig,omitempty"`
+	EventTrigger  *gen2EventTrigger  `json:"eventTrigger,omitempty"`
+
+	// revisionSeq tracks the deployed-revision generation so a patch cuts a fresh
+	// serviceConfig.revision, matching a real gen2 redeploy. Not serialized.
+	revisionSeq int `json:"-"`
+}
+
+type gen2BuildConfig struct {
+	Build                string            `json:"build,omitempty"`
+	Runtime              string            `json:"runtime,omitempty"`
+	EntryPoint           string            `json:"entryPoint,omitempty"`
+	Source               *gen2Source       `json:"source,omitempty"`
+	DockerRegistry       string            `json:"dockerRegistry,omitempty"`
+	DockerRepository     string            `json:"dockerRepository,omitempty"`
+	EnvironmentVariables map[string]string `json:"environmentVariables,omitempty"`
+}
+
+type gen2Source struct {
+	StorageSource *gen2StorageSource `json:"storageSource,omitempty"`
+}
+
+type gen2StorageSource struct {
+	Bucket     string `json:"bucket,omitempty"`
+	Object     string `json:"object,omitempty"`
+	Generation int64  `json:"generation,omitempty"`
+}
+
+type gen2ServiceConfig struct {
+	Service              string            `json:"service,omitempty"`
+	URI                  string            `json:"uri,omitempty"`
+	ServiceAccountEmail  string            `json:"serviceAccountEmail,omitempty"`
+	AvailableMemory      string            `json:"availableMemory,omitempty"`
+	AvailableCPU         string            `json:"availableCpu,omitempty"`
+	TimeoutSeconds       int               `json:"timeoutSeconds,omitempty"`
+	IngressSettings      string            `json:"ingressSettings,omitempty"`
+	EnvironmentVariables map[string]string `json:"environmentVariables,omitempty"`
+	Revision             string            `json:"revision,omitempty"`
+	MaxInstanceCount     int               `json:"maxInstanceCount,omitempty"`
+	MinInstanceCount     int               `json:"minInstanceCount,omitempty"`
+}
+
+type gen2EventTrigger struct {
+	Trigger             string `json:"trigger,omitempty"`
+	TriggerRegion       string `json:"triggerRegion,omitempty"`
+	EventType           string `json:"eventType,omitempty"`
+	PubsubTopic         string `json:"pubsubTopic,omitempty"`
+	ServiceAccountEmail string `json:"serviceAccountEmail,omitempty"`
+	RetryPolicy         string `json:"retryPolicy,omitempty"`
+}
+
+// listGen2Response is the {functions, nextPageToken} envelope of v2 list.
+type listGen2Response struct {
+	Functions     []gen2Function `json:"functions"`
+	NextPageToken string         `json:"nextPageToken,omitempty"`
+}
+
+// gen2UploadURLResponse is the body of v2 functions:generateUploadUrl.
+type gen2UploadURLResponse struct {
+	UploadURL     string             `json:"uploadUrl"`
+	StorageSource *gen2StorageSource `json:"storageSource,omitempty"`
+}
+
+// v2Path holds the parsed components of a /v2/projects/... Cloud Functions URL.
+// For an operation poll, name carries the operation id.
+type v2Path struct {
+	project     string
+	location    string
+	name        string
+	action      string
+	isOperation bool
+}
+
+func (p v2Path) fullName() string {
+	return "projects/" + p.project + "/locations/" + p.location + "/functions/" + p.name
+}
+
+// matchesV2 reports whether path is a v2 Cloud Functions URL this handler owns.
+// It claims the functions collection/resource unconditionally, but only claims
+// an operation poll whose id carries the gen2OpPrefix — Cloud Run also matches
+// /v2/projects/{p}/locations/{l}/operations/... and is registered after this
+// handler, so the prefix keeps the two disjoint.
+func matchesV2(path string) bool {
+	p, ok := parseV2Path(path)
+	if !ok {
+		return false
+	}
+
+	if p.isOperation {
+		return strings.HasPrefix(p.name, gen2OpPrefix)
+	}
+
+	return true
+}
+
+// parseV2Path extracts the components of a v2 URL:
+//
+//	/v2/projects/{p}/locations/{l}/functions
+//	/v2/projects/{p}/locations/{l}/functions/{name}
+//	/v2/projects/{p}/locations/{l}/functions/{name}:{action}
+//	/v2/projects/{p}/locations/{l}/functions:{action}
+//	/v2/projects/{p}/locations/{l}/operations/{op}
+func parseV2Path(path string) (v2Path, bool) {
+	rest := strings.TrimPrefix(path, v2PathPrefix)
+	parts := strings.Split(rest, "/")
+
+	const (
+		minParts    = 4
+		idxProject  = 0
+		idxScope    = 1
+		idxLocation = 2
+		idxType     = 3
+		idxName     = 4
+	)
+
+	if len(parts) < minParts || parts[idxScope] != locationsSeg {
+		return v2Path{}, false
+	}
+
+	out := v2Path{project: parts[idxProject], location: parts[idxLocation]}
+
+	switch parts[idxType] {
+	case operationsSeg:
+		if len(parts) <= idxName {
+			return v2Path{}, false
+		}
+
+		out.isOperation = true
+		out.name = strings.Join(parts[idxName:], "/")
+
+		return out, true
+	case functionsSeg:
+		if len(parts) > idxName {
+			nameWithAction := strings.Join(parts[idxName:], "/")
+			if base, action, ok := splitColon(nameWithAction); ok {
+				out.name, out.action = base, action
+			} else {
+				out.name = nameWithAction
+			}
+		}
+
+		return out, true
+	default:
+		if base, action, ok := splitColon(parts[idxType]); ok && base == functionsSeg {
+			out.action = action
+			return out, true
+		}
+
+		return v2Path{}, false
+	}
+}
+
+// serveV2 routes a v2 Cloud Functions request by URL shape.
+func (h *Handler) serveV2(w http.ResponseWriter, r *http.Request) {
+	p, ok := parseV2Path(r.URL.Path)
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unsupported path")
+		return
+	}
+
+	if p.isOperation {
+		h.serveV2Operation(w, r, p)
+		return
+	}
+
+	if p.action != "" {
+		h.serveV2Action(w, r, p)
+		return
+	}
+
+	if p.name != "" {
+		h.serveV2Resource(w, r, p)
+		return
+	}
+
+	h.serveV2Collection(w, r, p)
+}
+
+func (h *Handler) serveV2Action(w http.ResponseWriter, r *http.Request, p v2Path) {
+	switch p.action {
+	case actionGenerateUploadURL:
+		h.generateUploadURLV2(w, r, p)
+	case actionGetIamPolicy, actionSetIamPolicy:
+		h.serveV2IamPolicy(w, r, p)
+	case actionTestIamPermissions:
+		h.serveV2TestIamPermissions(w, r, p)
+	default:
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown method: "+p.action)
+	}
+}
+
+func (h *Handler) serveV2Resource(w http.ResponseWriter, r *http.Request, p v2Path) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getV2(w, p)
+	case http.MethodPatch:
+		h.patchV2(w, r, p)
+	case http.MethodDelete:
+		h.deleteV2(w, p)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+	}
+}
+
+func (h *Handler) serveV2Collection(w http.ResponseWriter, r *http.Request, p v2Path) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createV2(w, r, p)
+	case http.MethodGet:
+		h.listV2(w, r, p)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+	}
+}
+
+func (h *Handler) createV2(w http.ResponseWriter, r *http.Request, p v2Path) {
+	var body gen2Function
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	name := lastSegment(body.Name)
+	if name == "" {
+		name = r.URL.Query().Get("functionId")
+	}
+
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "functionId is required")
+		return
+	}
+
+	p.name = name
+	key := p.fullName()
+
+	h.mu.Lock()
+	if _, exists := h.gen2[key]; exists {
+		h.mu.Unlock()
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", "function "+name+" already exists")
+
+		return
+	}
+
+	fn := body
+	fn.revisionSeq = 1
+	computeGen2Outputs(&fn, p, true)
+	h.gen2[key] = &fn
+	h.mu.Unlock()
+
+	h.finishV2LRO(w, p, &fn)
+}
+
+func (h *Handler) getV2(w http.ResponseWriter, p v2Path) {
+	h.mu.RLock()
+	fn := h.gen2[p.fullName()]
+	h.mu.RUnlock()
+
+	if fn == nil {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "function "+p.name+" not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, fn)
+}
+
+func (h *Handler) listV2(w http.ResponseWriter, r *http.Request, p v2Path) {
+	h.mu.RLock()
+	fns := make([]gen2Function, 0, len(h.gen2))
+
+	prefix := "projects/" + p.project + "/locations/" + p.location + "/functions/"
+	for name, fn := range h.gen2 {
+		if strings.HasPrefix(name, prefix) {
+			fns = append(fns, *fn)
+		}
+	}
+	h.mu.RUnlock()
+
+	sort.Slice(fns, func(i, j int) bool { return fns[i].Name < fns[j].Name })
+
+	page, next := paginate(len(fns), r.URL.Query())
+
+	writeJSON(w, http.StatusOK, listGen2Response{
+		Functions:     fns[page.start:page.end],
+		NextPageToken: next,
+	})
+}
+
+func (h *Handler) patchV2(w http.ResponseWriter, r *http.Request, p v2Path) {
+	var body gen2Function
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	key := p.fullName()
+
+	h.mu.Lock()
+
+	fn := h.gen2[key]
+	if fn == nil {
+		h.mu.Unlock()
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "function "+p.name+" not found")
+
+		return
+	}
+
+	fn.revisionSeq++
+
+	mergeGen2(fn, &body)
+	computeGen2Outputs(fn, p, false)
+
+	updated := *fn
+
+	h.mu.Unlock()
+
+	h.finishV2LRO(w, p, &updated)
+}
+
+func (h *Handler) deleteV2(w http.ResponseWriter, p v2Path) {
+	key := p.fullName()
+
+	h.mu.Lock()
+
+	_, ok := h.gen2[key]
+	if ok {
+		delete(h.gen2, key)
+		delete(h.policies, key)
+	}
+
+	h.mu.Unlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "function "+p.name+" not found")
+		return
+	}
+
+	op := h.mintV2Operation(p, nil)
+	writeJSON(w, http.StatusOK, op)
+}
+
+// finishV2LRO stores and returns the completed create/patch operation. Real gen2
+// deploys are long-running; the emulator reconciles synchronously and returns
+// done=true with the function so a client's first poll (or the inline response)
+// already sees ACTIVE.
+func (h *Handler) finishV2LRO(w http.ResponseWriter, p v2Path, fn *gen2Function) {
+	op := h.mintV2Operation(p, resourceAsResponseV2(fn))
+	writeJSON(w, http.StatusOK, op)
+}
+
+// mintV2Operation builds a done=true operation with a gen2-prefixed name and
+// caches it so a later Operations.Get poll returns the same result.
+func (h *Handler) mintV2Operation(p v2Path, response map[string]any) operation {
+	opName := "projects/" + p.project + "/locations/" + p.location + "/operations/" + gen2OpPrefix + randomToken()
+
+	op := operation{Name: opName, Done: true, Response: response}
+
+	h.mu.Lock()
+	h.operations[opName] = op
+	h.mu.Unlock()
+
+	return op
+}
+
+func (h *Handler) serveV2Operation(w http.ResponseWriter, r *http.Request, p v2Path) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	opName := "projects/" + p.project + "/locations/" + p.location + "/operations/" + p.name
+
+	h.mu.RLock()
+	op, ok := h.operations[opName]
+	h.mu.RUnlock()
+
+	if !ok {
+		// An unknown but well-formed gen2 operation is reported complete rather
+		// than 404 so a poll after a process restart still terminates.
+		op = operation{Name: opName, Done: true}
+	}
+
+	writeJSON(w, http.StatusOK, op)
+}
+
+func (h *Handler) generateUploadURLV2(w http.ResponseWriter, r *http.Request, p v2Path) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	token, err := newUploadToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "mint upload token: "+err.Error())
+		return
+	}
+
+	// Stage a slot so a subsequent PUT to the returned URL (handled by the shared
+	// v1 uploadSource endpoint) is accepted; gen2 code is not executed, so the
+	// staged bytes are only ever consumed to satisfy the upload handshake.
+	h.uploads.stage(token, nil)
+
+	uploadURL := requestScheme(r) + "://" + r.Host + pathPrefix + p.project + "/" + locationsSeg + "/" + p.location +
+		"/" + functionsSeg + ":" + actionUploadSource + "?token=" + token
+
+	writeJSON(w, http.StatusOK, gen2UploadURLResponse{
+		UploadURL: uploadURL,
+		StorageSource: &gen2StorageSource{
+			Bucket: "gcf-v2-uploads-" + p.project,
+			Object: token + ".zip",
+		},
+	})
+}
+
+// mergeGen2 applies the non-nil fields of a patch body onto the stored function.
+func mergeGen2(dst, src *gen2Function) {
+	if src.Description != "" {
+		dst.Description = src.Description
+	}
+
+	if src.Labels != nil {
+		dst.Labels = src.Labels
+	}
+
+	if src.BuildConfig != nil {
+		dst.BuildConfig = src.BuildConfig
+	}
+
+	if src.ServiceConfig != nil {
+		mergeServiceConfig(dst, src.ServiceConfig)
+	}
+
+	if src.EventTrigger != nil {
+		dst.EventTrigger = src.EventTrigger
+	}
+}
+
+func mergeServiceConfig(dst *gen2Function, sc *gen2ServiceConfig) {
+	if dst.ServiceConfig == nil {
+		dst.ServiceConfig = &gen2ServiceConfig{}
+	}
+
+	if sc.ServiceAccountEmail != "" {
+		dst.ServiceConfig.ServiceAccountEmail = sc.ServiceAccountEmail
+	}
+
+	if sc.AvailableMemory != "" {
+		dst.ServiceConfig.AvailableMemory = sc.AvailableMemory
+	}
+
+	if sc.AvailableCPU != "" {
+		dst.ServiceConfig.AvailableCPU = sc.AvailableCPU
+	}
+
+	if sc.TimeoutSeconds != 0 {
+		dst.ServiceConfig.TimeoutSeconds = sc.TimeoutSeconds
+	}
+
+	if sc.IngressSettings != "" {
+		dst.ServiceConfig.IngressSettings = sc.IngressSettings
+	}
+
+	if sc.EnvironmentVariables != nil {
+		dst.ServiceConfig.EnvironmentVariables = sc.EnvironmentVariables
+	}
+}
+
+// computeGen2Outputs fills the output-only fields real gen2 GCP reconciles a
+// function to: identity, ACTIVE state, the Cloud Run-backed serviceConfig (uri,
+// service, revision) and buildConfig.build, plus the defaults for unset config.
+func computeGen2Outputs(fn *gen2Function, p v2Path, create bool) {
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	fn.Name = p.fullName()
+	fn.Environment = "GEN_2"
+	fn.State = "ACTIVE"
+	fn.UpdateTime = now
+
+	if create {
+		fn.CreateTime = now
+	}
+
+	if fn.BuildConfig == nil {
+		fn.BuildConfig = &gen2BuildConfig{}
+	}
+
+	if fn.BuildConfig.DockerRegistry == "" {
+		fn.BuildConfig.DockerRegistry = defaultDockerRegistry
+	}
+
+	fn.BuildConfig.Build = "projects/" + p.project + "/locations/" + p.location + "/builds/" + randomToken()
+
+	if fn.ServiceConfig == nil {
+		fn.ServiceConfig = &gen2ServiceConfig{}
+	}
+
+	applyServiceConfigDefaults(fn.ServiceConfig, p)
+
+	fn.ServiceConfig.Service = "projects/" + p.project + "/locations/" + p.location + "/services/" + p.name
+	fn.ServiceConfig.Revision = p.name + "-" + revisionSuffix(fn.revisionSeq)
+	fn.ServiceConfig.URI = gen2URI(p)
+	fn.URL = fn.ServiceConfig.URI
+}
+
+func applyServiceConfigDefaults(sc *gen2ServiceConfig, p v2Path) {
+	if sc.ServiceAccountEmail == "" {
+		sc.ServiceAccountEmail = gen2ServiceAccount(p.project)
+	}
+
+	if sc.AvailableMemory == "" {
+		sc.AvailableMemory = gen2DefaultMemory
+	}
+
+	if sc.AvailableCPU == "" {
+		sc.AvailableCPU = gen2DefaultCPU
+	}
+
+	if sc.TimeoutSeconds == 0 {
+		sc.TimeoutSeconds = gen2DefaultTimeout
+	}
+
+	if sc.IngressSettings == "" {
+		sc.IngressSettings = defaultIngress
+	}
+}
+
+func gen2URI(p v2Path) string {
+	return "https://" + p.name + "-" + randomToken() + "." + p.location + ".run.app"
+}
+
+func revisionSuffix(seq int) string {
+	return "000" + strconv.Itoa(seq) + "-" + randomToken()[:3]
+}
+
+// resourceAsResponseV2 renders a gen2 function as an LRO response payload with
+// the v2 Function type URL.
+func resourceAsResponseV2(fn *gen2Function) map[string]any {
+	b, err := json.Marshal(fn)
+	if err != nil {
+		return nil
+	}
+
+	out := map[string]any{
+		"@type": "type.googleapis.com/google.cloud.functions.v2.Function",
+	}
+
+	var fields map[string]any
+	_ = json.Unmarshal(b, &fields)
+
+	for k, v := range fields {
+		out[k] = v
+	}
+
+	return out
+}
+
+// randomToken returns a short random hex string for synthesized ids.
+func randomToken() string {
+	b := make([]byte, buildIDBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "0"
+	}
+
+	return hex.EncodeToString(b)
+}

--- a/server/gcp/cloudfunctions/gen2.go
+++ b/server/gcp/cloudfunctions/gen2.go
@@ -274,14 +274,15 @@ func (h *Handler) createV2(w http.ResponseWriter, r *http.Request, p v2Path) {
 	fn.revisionSeq = 1
 	computeGen2Outputs(&fn, p, true)
 	h.gen2[key] = &fn
+	resp := cloneGen2(&fn)
 	h.mu.Unlock()
 
-	h.finishV2LRO(w, p, &fn)
+	h.finishV2LRO(w, p, resp)
 }
 
 func (h *Handler) getV2(w http.ResponseWriter, p v2Path) {
 	h.mu.RLock()
-	fn := h.gen2[p.fullName()]
+	fn := cloneGen2(h.gen2[p.fullName()])
 	h.mu.RUnlock()
 
 	if fn == nil {
@@ -299,7 +300,7 @@ func (h *Handler) listV2(w http.ResponseWriter, r *http.Request, p v2Path) {
 	prefix := "projects/" + p.project + "/locations/" + p.location + "/functions/"
 	for name, fn := range h.gen2 {
 		if strings.HasPrefix(name, prefix) {
-			fns = append(fns, *fn)
+			fns = append(fns, *cloneGen2(fn))
 		}
 	}
 	h.mu.RUnlock()
@@ -337,11 +338,11 @@ func (h *Handler) patchV2(w http.ResponseWriter, r *http.Request, p v2Path) {
 	mergeGen2(fn, &body)
 	computeGen2Outputs(fn, p, false)
 
-	updated := *fn
+	updated := cloneGen2(fn)
 
 	h.mu.Unlock()
 
-	h.finishV2LRO(w, p, &updated)
+	h.finishV2LRO(w, p, updated)
 }
 
 func (h *Handler) deleteV2(w http.ResponseWriter, p v2Path) {
@@ -575,6 +576,66 @@ func resourceAsResponseV2(fn *gen2Function) map[string]any {
 	_ = json.Unmarshal(b, &fields)
 
 	for k, v := range fields {
+		out[k] = v
+	}
+
+	return out
+}
+
+// cloneGen2 returns a deep copy of fn: the nested BuildConfig/ServiceConfig/
+// EventTrigger structs and every map are cloned, so the copy shares no mutable
+// state with the stored function. Readers clone under the lock and then marshal
+// the copy after releasing it, so a concurrent patchV2 (which mutates the stored
+// serviceConfig in place and reassigns nested pointers) can never be observed
+// mid-write. A shallow struct copy is not enough — it still aliases the nested
+// pointers and maps.
+func cloneGen2(fn *gen2Function) *gen2Function {
+	if fn == nil {
+		return nil
+	}
+
+	out := *fn
+	out.Labels = cloneStringMap(fn.Labels)
+
+	if fn.BuildConfig != nil {
+		bc := *fn.BuildConfig
+		bc.EnvironmentVariables = cloneStringMap(fn.BuildConfig.EnvironmentVariables)
+
+		if fn.BuildConfig.Source != nil {
+			src := *fn.BuildConfig.Source
+
+			if fn.BuildConfig.Source.StorageSource != nil {
+				ss := *fn.BuildConfig.Source.StorageSource
+				src.StorageSource = &ss
+			}
+
+			bc.Source = &src
+		}
+
+		out.BuildConfig = &bc
+	}
+
+	if fn.ServiceConfig != nil {
+		sc := *fn.ServiceConfig
+		sc.EnvironmentVariables = cloneStringMap(fn.ServiceConfig.EnvironmentVariables)
+		out.ServiceConfig = &sc
+	}
+
+	if fn.EventTrigger != nil {
+		et := *fn.EventTrigger
+		out.EventTrigger = &et
+	}
+
+	return &out
+}
+
+func cloneStringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+
+	out := make(map[string]string, len(m))
+	for k, v := range m {
 		out[k] = v
 	}
 

--- a/server/gcp/cloudfunctions/gen2_concurrency_test.go
+++ b/server/gcp/cloudfunctions/gen2_concurrency_test.go
@@ -1,0 +1,89 @@
+package cloudfunctions_test
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+
+	cloudfunctions2 "google.golang.org/api/cloudfunctions/v2"
+)
+
+// TestSDKGen2ConcurrentGetPatch drives Get and Patch against the SAME gen2
+// function from many goroutines at once. patchV2 mutates the stored
+// serviceConfig in place and reassigns nested pointers under the write lock; a
+// reader that marshals the stored object (or a shallow copy of it) after
+// releasing the lock aliases those pointers and races the writer. This test
+// fails under -race on the pre-fix code (read at getV2->writeJSON vs write at
+// mergeServiceConfig) and passes once readers deep-copy under the lock.
+func TestSDKGen2ConcurrentGetPatch(t *testing.T) {
+	svc := newGCPV2Service(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+	name := parent + "/functions/g2"
+
+	if _, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions2.Function{
+		BuildConfig: &cloudfunctions2.BuildConfig{
+			Runtime:    "go121",
+			EntryPoint: "Hello",
+			Source: &cloudfunctions2.Source{
+				StorageSource: &cloudfunctions2.StorageSource{Bucket: "b", Object: "o.zip"},
+			},
+			EnvironmentVariables: map[string]string{"K": "V"},
+		},
+		ServiceConfig: &cloudfunctions2.ServiceConfig{
+			AvailableMemory:      "256M",
+			EnvironmentVariables: map[string]string{"FOO": "bar"},
+		},
+	}).FunctionId("g2").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	const iterations = 40
+
+	var wg sync.WaitGroup
+
+	// Writers: patch serviceConfig in place repeatedly.
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < iterations; i++ {
+			_, err := svc.Projects.Locations.Functions.Patch(name, &cloudfunctions2.Function{
+				ServiceConfig: &cloudfunctions2.ServiceConfig{
+					AvailableMemory:      strconv.Itoa(i) + "M",
+					EnvironmentVariables: map[string]string{"FOO": strconv.Itoa(i)},
+				},
+			}).UpdateMask("serviceConfig").Context(ctx).Do()
+			if err != nil {
+				t.Errorf("Patch: %v", err)
+				return
+			}
+		}
+	}()
+
+	// Readers: concurrent Get and List on the same function while it is patched.
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for i := 0; i < iterations; i++ {
+				if _, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do(); err != nil {
+					t.Errorf("Get: %v", err)
+					return
+				}
+
+				if _, err := svc.Projects.Locations.Functions.List(parent).Context(ctx).Do(); err != nil {
+					t.Errorf("List: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/server/gcp/cloudfunctions/gen2_sdk_test.go
+++ b/server/gcp/cloudfunctions/gen2_sdk_test.go
@@ -1,0 +1,179 @@
+package cloudfunctions_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	cloudfunctions2 "google.golang.org/api/cloudfunctions/v2"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+func newGCPV2Service(t *testing.T) *cloudfunctions2.Service {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{CloudFunctions: cloud.CloudFunctions})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := cloudfunctions2.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("NewService (v2): %v", err)
+	}
+
+	return svc
+}
+
+// TestSDKGen2CreateGetListDelete reproduces the gen2 (v2 API) blocker: the modern
+// functions/apiv2 + google_cloudfunctions2_function surface must work — create
+// reconciles to ACTIVE with a Cloud Run-backed serviceConfig.uri, and get/list/
+// delete round-trip.
+func TestSDKGen2CreateGetListDelete(t *testing.T) {
+	svc := newGCPV2Service(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+
+	op, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions2.Function{
+		Environment: "GEN_2",
+		BuildConfig: &cloudfunctions2.BuildConfig{
+			Runtime:    "go121",
+			EntryPoint: "Hello",
+			Source: &cloudfunctions2.Source{
+				StorageSource: &cloudfunctions2.StorageSource{Bucket: "b", Object: "o.zip"},
+			},
+		},
+		ServiceConfig: &cloudfunctions2.ServiceConfig{
+			AvailableMemory: "512M",
+			TimeoutSeconds:  120,
+		},
+	}).FunctionId("g2").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create (gen2): %v", err)
+	}
+
+	if !op.Done {
+		t.Fatal("Create operation not done")
+	}
+
+	name := parent + "/functions/g2"
+
+	got, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get (gen2): %v", err)
+	}
+
+	if got.State != "ACTIVE" {
+		t.Fatalf("State = %q, want ACTIVE", got.State)
+	}
+
+	if got.Environment != "GEN_2" {
+		t.Fatalf("Environment = %q, want GEN_2", got.Environment)
+	}
+
+	if got.ServiceConfig == nil || got.ServiceConfig.Uri == "" {
+		t.Fatalf("serviceConfig.uri missing: %+v", got.ServiceConfig)
+	}
+
+	// Client-set config must survive the round-trip.
+	if got.ServiceConfig.AvailableMemory != "512M" {
+		t.Fatalf("availableMemory = %q, want 512M", got.ServiceConfig.AvailableMemory)
+	}
+
+	if got.ServiceConfig.TimeoutSeconds != 120 {
+		t.Fatalf("timeoutSeconds = %d, want 120", got.ServiceConfig.TimeoutSeconds)
+	}
+
+	if got.BuildConfig == nil || got.BuildConfig.Runtime != "go121" {
+		t.Fatalf("buildConfig.runtime missing: %+v", got.BuildConfig)
+	}
+
+	// Output-only defaults must be populated.
+	if got.ServiceConfig.ServiceAccountEmail == "" || got.ServiceConfig.IngressSettings == "" {
+		t.Fatalf("serviceConfig defaults empty: %+v", got.ServiceConfig)
+	}
+
+	if !strings.HasSuffix(got.Name, "/functions/g2") {
+		t.Fatalf("Name = %q, want suffix /functions/g2", got.Name)
+	}
+
+	listResp, err := svc.Projects.Locations.Functions.List(parent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List (gen2): %v", err)
+	}
+
+	if len(listResp.Functions) != 1 {
+		t.Fatalf("listed %d gen2 functions, want 1", len(listResp.Functions))
+	}
+
+	delOp, err := svc.Projects.Locations.Functions.Delete(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Delete (gen2): %v", err)
+	}
+
+	if !delOp.Done {
+		t.Fatal("Delete operation not done")
+	}
+
+	if _, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do(); err == nil {
+		t.Fatal("post-delete Get returned nil error, want NotFound")
+	}
+}
+
+// TestSDKGen2Patch confirms a gen2 update merges config and stays ACTIVE.
+func TestSDKGen2Patch(t *testing.T) {
+	svc := newGCPV2Service(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+	name := parent + "/functions/g2"
+
+	if _, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions2.Function{
+		BuildConfig: &cloudfunctions2.BuildConfig{Runtime: "go121", EntryPoint: "Hello"},
+	}).FunctionId("g2").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	op, err := svc.Projects.Locations.Functions.Patch(name, &cloudfunctions2.Function{
+		ServiceConfig: &cloudfunctions2.ServiceConfig{AvailableMemory: "1024M"},
+	}).UpdateMask("serviceConfig.availableMemory").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	if !op.Done {
+		t.Fatal("Patch operation not done")
+	}
+
+	got, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if got.ServiceConfig.AvailableMemory != "1024M" {
+		t.Fatalf("availableMemory = %q, want 1024M", got.ServiceConfig.AvailableMemory)
+	}
+
+	if got.State != "ACTIVE" {
+		t.Fatalf("State = %q, want ACTIVE", got.State)
+	}
+}
+
+// TestSDKGen2GetMissing confirms a missing gen2 function 404s.
+func TestSDKGen2GetMissing(t *testing.T) {
+	svc := newGCPV2Service(t)
+
+	name := "projects/demo/locations/us-central1/functions/ghost"
+	if _, err := svc.Projects.Locations.Functions.Get(name).Context(context.Background()).Do(); err == nil {
+		t.Fatal("Get on missing gen2 function returned nil error, want NotFound")
+	}
+}

--- a/server/gcp/cloudfunctions/handler.go
+++ b/server/gcp/cloudfunctions/handler.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -36,8 +37,10 @@ import (
 
 const (
 	pathPrefix      = "/v1/projects/"
+	v2PathPrefix    = "/v2/projects/"
 	functionsSeg    = "functions"
 	locationsSeg    = "locations"
+	operationsSeg   = "operations"
 	contentTypeJSON = "application/json"
 	maxBodyBytes    = 5 << 20
 	// maxUploadBytes bounds a source-zip PUT; real gen1 caps uploads at 100 MiB.
@@ -57,6 +60,22 @@ const (
 	// actionGetIamPolicy / actionSetIamPolicy are the IAM invoker-policy verbs.
 	actionGetIamPolicy = "getIamPolicy"
 	actionSetIamPolicy = "setIamPolicy"
+	// actionTestIamPermissions returns the caller's held permission subset.
+	actionTestIamPermissions = "testIamPermissions"
+	// gen2OpPrefix namespaces the v2 (gen2) long-running-operation ids this
+	// handler mints so its operation polls stay disjoint from Cloud Run's, which
+	// also matches /v2/projects/{p}/locations/{l}/operations/... paths.
+	gen2OpPrefix = "cf2-"
+	// gen1 defaults populated onto a v1 function's output-only metadata.
+	defaultIngress        = "ALLOW_ALL"
+	defaultDockerRegistry = "ARTIFACT_REGISTRY"
+	// gen2ServiceAccountSuffix / gen1ServiceAccountSuffix are the default runtime
+	// service accounts real GCP assigns (compute default SA for gen2, App Engine
+	// default SA for gen1).
+	gen2DefaultMemory  = "256M"
+	gen2DefaultCPU     = "0.1666"
+	gen2DefaultTimeout = 60
+	buildIDBytes       = 8
 )
 
 // ObjectStore is the slice of the in-process GCS backend the handler needs to
@@ -77,13 +96,26 @@ type Handler struct {
 	// in-process GCS backend. Nil when no GCS backend is wired; an archive deploy
 	// then fails loudly rather than silently falling back to the echo stub.
 	objects ObjectStore
-	// mu guards policies.
+	// mu guards policies, gen1Meta, gen2 and operations.
 	mu sync.RWMutex
 	// policies stores the IAM policy set via setIamPolicy, keyed by the function's
 	// canonical resource name. CloudEmu does not enforce IAM; the policy is stored
 	// verbatim so Terraform's setIamPolicy → getIamPolicy round-trips (the standard
 	// way to grant roles/cloudfunctions.invoker to allUsers for a public function).
 	policies map[string]*iamPolicy
+	// gen1Meta holds the GCP-specific gen1 (v1) output-only metadata that has no
+	// portable Serverless-driver equivalent — serviceAccountEmail, ingressSettings,
+	// dockerRegistry, buildId and the monotonically increasing versionId. Keyed by
+	// the function's canonical resource name; populated on create and bumped on
+	// update so a real client's Get reflects the deploy generation.
+	gen1Meta map[string]*gen1Meta
+	// gen2 holds gen2 (v2 API) functions, which are an entirely different resource
+	// shape (buildConfig/serviceConfig/eventTrigger, Cloud Run-backed) with no
+	// portable-driver representation. Keyed by canonical resource name.
+	gen2 map[string]*gen2Function
+	// operations caches completed v2 LROs so a client that polls the returned
+	// operation name (Terraform, apiv2 .Wait) sees the same done=true response.
+	operations map[string]operation
 }
 
 // Option configures a Handler.
@@ -97,7 +129,14 @@ func WithObjectStore(s ObjectStore) Option {
 
 // New returns a Cloud Functions handler backed by fn.
 func New(fn sdrv.Serverless, opts ...Option) *Handler {
-	h := &Handler{fn: fn, uploads: newUploadStaging(), policies: make(map[string]*iamPolicy)}
+	h := &Handler{
+		fn:         fn,
+		uploads:    newUploadStaging(),
+		policies:   make(map[string]*iamPolicy),
+		gen1Meta:   make(map[string]*gen1Meta),
+		gen2:       make(map[string]*gen2Function),
+		operations: make(map[string]operation),
+	}
 	for _, opt := range opts {
 		opt(h)
 	}
@@ -112,6 +151,10 @@ func New(fn sdrv.Serverless, opts ...Option) *Handler {
 func (*Handler) Matches(r *http.Request) bool {
 	if strings.HasPrefix(r.URL.Path, "/v1/operations/") {
 		return true
+	}
+
+	if strings.HasPrefix(r.URL.Path, v2PathPrefix) {
+		return matchesV2(r.URL.Path)
 	}
 
 	if !strings.HasPrefix(r.URL.Path, pathPrefix) {
@@ -147,6 +190,11 @@ func (*Handler) Matches(r *http.Request) bool {
 
 // ServeHTTP routes requests by URL shape.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, v2PathPrefix) {
+		h.serveV2(w, r)
+		return
+	}
+
 	if strings.HasPrefix(r.URL.Path, "/v1/operations/") {
 		h.serveOperation(w, r)
 		return
@@ -187,6 +235,12 @@ func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, p function
 		}
 
 		h.serveIamPolicy(w, r, p)
+	case actionTestIamPermissions:
+		if p.name == "" {
+			return false
+		}
+
+		h.serveTestIamPermissions(w, r, p)
 	case actionGenerateUploadURL:
 		h.generateUploadURL(w, r, p)
 	case actionUploadSource:
@@ -243,15 +297,19 @@ func (h *Handler) generateUploadURL(w http.ResponseWriter, r *http.Request, p fu
 	// upload against an unknown token is rejected.
 	h.uploads.stage(token, nil)
 
-	scheme := "http"
-	if r.TLS != nil {
-		scheme = "https"
-	}
-
-	uploadURL := scheme + "://" + r.Host + pathPrefix + p.project + "/" + locationsSeg + "/" + p.location +
+	uploadURL := requestScheme(r) + "://" + r.Host + pathPrefix + p.project + "/" + locationsSeg + "/" + p.location +
 		"/" + functionsSeg + ":" + actionUploadSource + "?token=" + token
 
 	writeJSON(w, http.StatusOK, map[string]string{"uploadUrl": uploadURL})
+}
+
+// requestScheme returns the URL scheme the request arrived on.
+func requestScheme(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
+	}
+
+	return "http"
 }
 
 // uploadSource accepts the PUT of a source zip to a generated upload URL and
@@ -458,7 +516,11 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request, p functionPath)
 		return
 	}
 
-	resource := toCloudFunction(info, p)
+	scope := p
+	scope.name = name
+	h.putGen1Meta(scope.fullName(), newGen1Meta(&body, p.project))
+
+	resource := h.toCloudFunction(info, p)
 
 	writeJSON(w, http.StatusOK, operation{
 		Name:     "operations/create-" + name + "-" + strconv.FormatInt(time.Now().UnixNano(), 10),
@@ -474,7 +536,7 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, p functionPath) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, toCloudFunction(info, p))
+	writeJSON(w, http.StatusOK, h.toCloudFunction(info, p))
 }
 
 func (h *Handler) list(w http.ResponseWriter, r *http.Request, p functionPath) {
@@ -484,9 +546,19 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, p functionPath) {
 		return
 	}
 
-	out := listFunctionsResponse{Functions: make([]cloudFunction, 0, len(infos))}
-	for i := range infos {
-		out.Functions = append(out.Functions, toCloudFunction(&infos[i], p))
+	// Sort by name so pagination over the base64 offset token is stable across
+	// calls (the provider store iterates a map in unspecified order).
+	sort.Slice(infos, func(i, j int) bool { return infos[i].Name < infos[j].Name })
+
+	page, next := paginate(len(infos), r.URL.Query())
+
+	out := listFunctionsResponse{
+		Functions:     make([]cloudFunction, 0, page.end-page.start),
+		NextPageToken: next,
+	}
+
+	for i := page.start; i < page.end; i++ {
+		out.Functions = append(out.Functions, h.toCloudFunction(&infos[i], p))
 	}
 
 	writeJSON(w, http.StatusOK, out)
@@ -524,7 +596,11 @@ func (h *Handler) update(w http.ResponseWriter, r *http.Request, p functionPath)
 		return
 	}
 
-	resource := toCloudFunction(info, p)
+	// A deploy bumps versionId and cuts a fresh build, matching real Cloud
+	// Functions, and applies any changed gen1 metadata carried in the PATCH body.
+	h.bumpGen1Meta(p.fullName(), &body, p.project)
+
+	resource := h.toCloudFunction(info, p)
 	writeJSON(w, http.StatusOK, operation{
 		Name:     "operations/update-" + p.name,
 		Done:     true,
@@ -537,6 +613,13 @@ func (h *Handler) delete(w http.ResponseWriter, r *http.Request, p functionPath)
 		writeErr(w, err)
 		return
 	}
+
+	key := p.fullName()
+
+	h.mu.Lock()
+	delete(h.gen1Meta, key)
+	delete(h.policies, key)
+	h.mu.Unlock()
 
 	writeJSON(w, http.StatusOK, operation{
 		Name: "operations/delete-" + p.name,
@@ -673,20 +756,26 @@ func parseTimeoutSeconds(t string) int {
 	return n
 }
 
-func toCloudFunction(info *sdrv.FunctionInfo, p functionPath) cloudFunction {
+func (h *Handler) toCloudFunction(info *sdrv.FunctionInfo, p functionPath) cloudFunction {
 	scope := p
 	scope.name = info.Name
 
+	meta := h.gen1MetaFor(scope.fullName(), p.project)
+
 	cf := cloudFunction{
-		Name:            scope.fullName(),
-		Status:          "ACTIVE",
-		Runtime:         info.Runtime,
-		EntryPoint:      info.Handler,
-		AvailableMemory: info.Memory,
-		Labels:          info.Tags,
-		EnvVariables:    info.Environment,
-		UpdateTime:      info.LastModified,
-		VersionID:       "1",
+		Name:                scope.fullName(),
+		Status:              "ACTIVE",
+		Runtime:             info.Runtime,
+		EntryPoint:          info.Handler,
+		AvailableMemory:     info.Memory,
+		Labels:              info.Tags,
+		EnvVariables:        info.Environment,
+		UpdateTime:          info.LastModified,
+		VersionID:           strconv.FormatInt(meta.versionID, 10),
+		ServiceAccountEmail: meta.serviceAccountEmail,
+		IngressSettings:     meta.ingressSettings,
+		DockerRegistry:      meta.dockerRegistry,
+		BuildID:             meta.buildID,
 		// Real Cloud Functions always advertises the HTTPS trigger URL; clients
 		// read it to invoke the function.
 		HTTPSTrigger: &httpsTrigger{

--- a/server/gcp/cloudfunctions/iam.go
+++ b/server/gcp/cloudfunctions/iam.go
@@ -57,22 +57,31 @@ func (h *Handler) serveIamPolicy(w http.ResponseWriter, r *http.Request, p funct
 }
 
 func (h *Handler) getIamPolicy(w http.ResponseWriter, p functionPath) {
-	key := p.fullName()
+	h.writeIamPolicy(w, p.fullName())
+}
 
+func (h *Handler) setIamPolicy(w http.ResponseWriter, r *http.Request, p functionPath) {
+	h.storeIamPolicy(w, r, p.fullName())
+}
+
+// writeIamPolicy returns the policy stored under key, or an empty versioned
+// policy when none is set (real GCP never 404s getIamPolicy on an existing
+// resource). Shared by the v1 and v2 handlers.
+func (h *Handler) writeIamPolicy(w http.ResponseWriter, key string) {
 	h.mu.RLock()
 	pol := h.policies[key]
 	h.mu.RUnlock()
 
 	if pol == nil {
-		// An existing function with no policy yet returns an empty, versioned
-		// policy (real GCP never 404s getIamPolicy on an existing resource).
 		pol = &iamPolicy{Version: 1, Etag: policyEtag(key, 0)}
 	}
 
 	writeJSON(w, http.StatusOK, pol)
 }
 
-func (h *Handler) setIamPolicy(w http.ResponseWriter, r *http.Request, p functionPath) {
+// storeIamPolicy persists the policy from the request body under key and echoes
+// it back. Shared by the v1 and v2 handlers.
+func (h *Handler) storeIamPolicy(w http.ResponseWriter, r *http.Request, key string) {
 	var body setIamPolicyRequest
 	if !decodeJSON(w, r, &body) {
 		return
@@ -83,7 +92,6 @@ func (h *Handler) setIamPolicy(w http.ResponseWriter, r *http.Request, p functio
 		pol.Version = 1
 	}
 
-	key := p.fullName()
 	pol.Etag = policyEtag(key, len(pol.Bindings))
 
 	h.mu.Lock()
@@ -96,4 +104,88 @@ func (h *Handler) setIamPolicy(w http.ResponseWriter, r *http.Request, p functio
 // policyEtag returns a stable etag for a policy state.
 func policyEtag(resource string, n int) string {
 	return base64.StdEncoding.EncodeToString([]byte(resource + ":" + strconv.Itoa(n)))
+}
+
+// serveTestIamPermissions answers functions/{name}:testIamPermissions (v1). Real
+// GCP returns the subset of the requested permissions the caller holds; CloudEmu
+// does not enforce IAM (any credential is an owner), so it echoes back the full
+// requested set — the answer callers use to gate optional UI, and which
+// Terraform's data.google_iam_policy tooling round-trips.
+func (h *Handler) serveTestIamPermissions(w http.ResponseWriter, r *http.Request, p functionPath) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "testIamPermissions requires POST")
+		return
+	}
+
+	if _, err := h.fn.GetFunction(r.Context(), p.name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	var body testIamPermissionsRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	writeJSON(w, http.StatusOK, testIamPermissionsResponse(body))
+}
+
+// gen2Exists reports whether a gen2 function is stored under key.
+func (h *Handler) gen2Exists(key string) bool {
+	h.mu.RLock()
+	_, ok := h.gen2[key]
+	h.mu.RUnlock()
+
+	return ok
+}
+
+// serveV2IamPolicy handles :getIamPolicy / :setIamPolicy on a gen2 function,
+// sharing the same verbatim-policy store as v1 (CloudEmu does not enforce IAM;
+// the policy round-trips so terraform google_cloudfunctions2_function_iam_member
+// works).
+func (h *Handler) serveV2IamPolicy(w http.ResponseWriter, r *http.Request, p v2Path) {
+	key := p.fullName()
+	if !h.gen2Exists(key) {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "function "+p.name+" not found")
+		return
+	}
+
+	switch p.action {
+	case actionGetIamPolicy:
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "getIamPolicy requires GET")
+			return
+		}
+
+		h.writeIamPolicy(w, key)
+	case actionSetIamPolicy:
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "setIamPolicy requires POST")
+			return
+		}
+
+		h.storeIamPolicy(w, r, key)
+	default:
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown method: "+p.action)
+	}
+}
+
+// serveV2TestIamPermissions echoes the requested permissions for a gen2 function.
+func (h *Handler) serveV2TestIamPermissions(w http.ResponseWriter, r *http.Request, p v2Path) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "testIamPermissions requires POST")
+		return
+	}
+
+	if !h.gen2Exists(p.fullName()) {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "function "+p.name+" not found")
+		return
+	}
+
+	var body testIamPermissionsRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	writeJSON(w, http.StatusOK, testIamPermissionsResponse(body))
 }

--- a/server/gcp/cloudfunctions/metadata_sdk_test.go
+++ b/server/gcp/cloudfunctions/metadata_sdk_test.go
@@ -1,0 +1,187 @@
+package cloudfunctions_test
+
+import (
+	"context"
+	"testing"
+
+	cloudfunctions "google.golang.org/api/cloudfunctions/v1"
+)
+
+// TestSDKGen1MetadataFields reproduces the missing-fields finding: Get after
+// Create must return non-empty serviceAccountEmail/ingressSettings/dockerRegistry/
+// buildId, and versionId must be 1 at create and bump on update.
+func TestSDKGen1MetadataFields(t *testing.T) {
+	svc := newGCPSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+	name := parent + "/functions/meta"
+
+	if _, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions.CloudFunction{
+		Name:    name,
+		Runtime: "go121",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.ServiceAccountEmail == "" {
+		t.Fatal("serviceAccountEmail empty, want a default")
+	}
+
+	if got.IngressSettings == "" {
+		t.Fatal("ingressSettings empty, want ALLOW_ALL")
+	}
+
+	if got.DockerRegistry == "" {
+		t.Fatal("dockerRegistry empty, want ARTIFACT_REGISTRY")
+	}
+
+	if got.BuildId == "" {
+		t.Fatal("buildId empty, want a generated id")
+	}
+
+	if got.VersionId != 1 {
+		t.Fatalf("versionId = %d at create, want 1", got.VersionId)
+	}
+
+	firstBuild := got.BuildId
+
+	// A deploy (PATCH) bumps the versionId and cuts a fresh build.
+	if _, err := svc.Projects.Locations.Functions.Patch(name, &cloudfunctions.CloudFunction{
+		Name:              name,
+		AvailableMemoryMb: 256,
+	}).UpdateMask("availableMemoryMb").Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got2, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if got2.VersionId != 2 {
+		t.Fatalf("versionId = %d after patch, want 2", got2.VersionId)
+	}
+
+	if got2.BuildId == firstBuild {
+		t.Fatalf("buildId unchanged after patch: %q", got2.BuildId)
+	}
+}
+
+// TestSDKGen1MetadataHonorsBody confirms client-supplied ingress/serviceAccount/
+// dockerRegistry survive the round-trip instead of being overwritten by defaults.
+func TestSDKGen1MetadataHonorsBody(t *testing.T) {
+	svc := newGCPSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+	name := parent + "/functions/custom"
+
+	if _, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions.CloudFunction{
+		Name:                name,
+		Runtime:             "go121",
+		IngressSettings:     "ALLOW_INTERNAL_ONLY",
+		ServiceAccountEmail: "svc@demo.iam.gserviceaccount.com",
+		DockerRegistry:      "CONTAINER_REGISTRY",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.IngressSettings != "ALLOW_INTERNAL_ONLY" {
+		t.Fatalf("ingressSettings = %q, want ALLOW_INTERNAL_ONLY", got.IngressSettings)
+	}
+
+	if got.ServiceAccountEmail != "svc@demo.iam.gserviceaccount.com" {
+		t.Fatalf("serviceAccountEmail = %q, want the supplied value", got.ServiceAccountEmail)
+	}
+
+	if got.DockerRegistry != "CONTAINER_REGISTRY" {
+		t.Fatalf("dockerRegistry = %q, want CONTAINER_REGISTRY", got.DockerRegistry)
+	}
+}
+
+// TestSDKCloudFunctionsTestIamPermissions reproduces the missing testIamPermissions
+// verb: real GCP returns the held permission subset; CloudEmu (no IAM enforcement)
+// echoes the requested set rather than 405.
+func TestSDKCloudFunctionsTestIamPermissions(t *testing.T) {
+	svc := newGCPSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+	name := parent + "/functions/hello"
+
+	if _, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions.CloudFunction{
+		Name:    name,
+		Runtime: "go121",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	want := []string{"cloudfunctions.functions.invoke", "cloudfunctions.functions.get"}
+
+	resp, err := svc.Projects.Locations.Functions.TestIamPermissions(name,
+		&cloudfunctions.TestIamPermissionsRequest{Permissions: want}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("TestIamPermissions: %v", err)
+	}
+
+	if len(resp.Permissions) != len(want) {
+		t.Fatalf("permissions = %v, want %v", resp.Permissions, want)
+	}
+}
+
+// TestSDKCloudFunctionsListPagination reproduces the ignored-pagination finding:
+// with two functions, PageSize(1) must return one function plus a nextPageToken,
+// and the token must fetch the second.
+func TestSDKCloudFunctionsListPagination(t *testing.T) {
+	svc := newGCPSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+
+	for _, id := range []string{"fn-a", "fn-b"} {
+		if _, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions.CloudFunction{
+			Name:    parent + "/functions/" + id,
+			Runtime: "go121",
+		}).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create %s: %v", id, err)
+		}
+	}
+
+	page1, err := svc.Projects.Locations.Functions.List(parent).PageSize(1).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List page 1: %v", err)
+	}
+
+	if len(page1.Functions) != 1 {
+		t.Fatalf("page 1 returned %d functions, want 1", len(page1.Functions))
+	}
+
+	if page1.NextPageToken == "" {
+		t.Fatal("page 1 has no nextPageToken, want one")
+	}
+
+	page2, err := svc.Projects.Locations.Functions.List(parent).
+		PageSize(1).PageToken(page1.NextPageToken).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List page 2: %v", err)
+	}
+
+	if len(page2.Functions) != 1 {
+		t.Fatalf("page 2 returned %d functions, want 1", len(page2.Functions))
+	}
+
+	if page1.Functions[0].Name == page2.Functions[0].Name {
+		t.Fatalf("page 1 and 2 returned the same function %q", page1.Functions[0].Name)
+	}
+}

--- a/server/gcp/cloudfunctions/sdk_roundtrip_test.go
+++ b/server/gcp/cloudfunctions/sdk_roundtrip_test.go
@@ -6,10 +6,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stackshy/cloudemu/v2"
-	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
 	"google.golang.org/api/cloudfunctions/v1"
 	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
 )
 
 func newGCPSDKService(t *testing.T) *cloudfunctions.Service {

--- a/server/gcp/cloudfunctions/types.go
+++ b/server/gcp/cloudfunctions/types.go
@@ -3,20 +3,24 @@ package cloudfunctions
 // cloudFunction is the v1 GCP Cloud Functions resource shape returned by
 // Get / Create / Update.
 type cloudFunction struct {
-	Name             string            `json:"name"`
-	Description      string            `json:"description,omitempty"`
-	SourceArchiveURL string            `json:"sourceArchiveUrl,omitempty"`
-	SourceUploadURL  string            `json:"sourceUploadUrl,omitempty"`
-	HTTPSTrigger     *httpsTrigger     `json:"httpsTrigger,omitempty"`
-	Status           string            `json:"status"`
-	EntryPoint       string            `json:"entryPoint,omitempty"`
-	Runtime          string            `json:"runtime,omitempty"`
-	Timeout          string            `json:"timeout,omitempty"`
-	AvailableMemory  int               `json:"availableMemoryMb,omitempty"`
-	Labels           map[string]string `json:"labels,omitempty"`
-	EnvVariables     map[string]string `json:"environmentVariables,omitempty"`
-	UpdateTime       string            `json:"updateTime,omitempty"`
-	VersionID        string            `json:"versionId,omitempty"`
+	Name                string            `json:"name"`
+	Description         string            `json:"description,omitempty"`
+	SourceArchiveURL    string            `json:"sourceArchiveUrl,omitempty"`
+	SourceUploadURL     string            `json:"sourceUploadUrl,omitempty"`
+	HTTPSTrigger        *httpsTrigger     `json:"httpsTrigger,omitempty"`
+	Status              string            `json:"status"`
+	EntryPoint          string            `json:"entryPoint,omitempty"`
+	Runtime             string            `json:"runtime,omitempty"`
+	Timeout             string            `json:"timeout,omitempty"`
+	AvailableMemory     int               `json:"availableMemoryMb,omitempty"`
+	Labels              map[string]string `json:"labels,omitempty"`
+	EnvVariables        map[string]string `json:"environmentVariables,omitempty"`
+	UpdateTime          string            `json:"updateTime,omitempty"`
+	VersionID           string            `json:"versionId,omitempty"`
+	ServiceAccountEmail string            `json:"serviceAccountEmail,omitempty"`
+	IngressSettings     string            `json:"ingressSettings,omitempty"`
+	DockerRegistry      string            `json:"dockerRegistry,omitempty"`
+	BuildID             string            `json:"buildId,omitempty"`
 }
 
 type httpsTrigger struct {
@@ -26,7 +30,20 @@ type httpsTrigger struct {
 // listFunctionsResponse is the {functions: [...]} envelope returned by
 // projects.locations.functions.list.
 type listFunctionsResponse struct {
-	Functions []cloudFunction `json:"functions"`
+	Functions     []cloudFunction `json:"functions"`
+	NextPageToken string          `json:"nextPageToken,omitempty"`
+}
+
+// testIamPermissionsRequest / testIamPermissionsResponse are the bodies of
+// functions/{name}:testIamPermissions. Real GCP returns the subset of the
+// requested permissions the caller holds; CloudEmu does not enforce IAM (any
+// credential is treated as an owner) so it echoes back the full requested set.
+type testIamPermissionsRequest struct {
+	Permissions []string `json:"permissions,omitempty"`
+}
+
+type testIamPermissionsResponse struct {
+	Permissions []string `json:"permissions,omitempty"`
 }
 
 // operation is the google.longrunning.Operation envelope used by mutating


### PR DESCRIPTION
## What

Fixes the GCP Cloud Functions bug batch from `AUDIT_GCP.md` (`## cloudfunctions`). All at the wire layer (`server/gcp/cloudfunctions`); no shared-driver or provider churn, so no `docs/coverage` regeneration.

### Findings fixed

- **[BLOCKER] gen2 (v2 API)** — the `/v2/...` surface previously 501'd (only gen1 `/v1/` was registered), breaking `functions/apiv2` and `google_cloudfunctions2_function`. Implemented v2 `create/get/list/delete/patch` (each mutation returns an LRO that reconciles synchronously to `state: ACTIVE` with a Cloud Run-backed `serviceConfig.uri`), plus `generateUploadUrl` and the IAM verbs. gen2 functions round-trip `buildConfig`/`serviceConfig`/`eventTrigger` and synthesize the output-only fields real GCP fills in. (Note: v2 has no `functions.call` — gen2 is invoked via the Cloud Run URL — so `call` is intentionally not added to v2.)
- **[MEDIUM] gen1 missing fields + versionId** — `serviceAccountEmail`/`ingressSettings`/`dockerRegistry`/`buildId` were empty and `versionId` was hardcoded `"1"`. Now populated with real defaults (honoring create-body values), and `versionId` increments with a fresh `buildId` on every deploy (PATCH).
- **[MEDIUM] testIamPermissions** — was 405. Added `:testIamPermissions` for v1 and v2; CloudEmu does not enforce IAM (any credential is an owner) so it echoes back the requested permission set, the answer callers use to gate optional UI.
- **[LOW] list pagination** — `pageSize`/`pageToken` were ignored. Now honored via a stable name-sorted base64 offset cursor returning `nextPageToken`; applied to both v1 and v2 list.

## Why

These are behaviors a real user hits immediately: gen2 is the modern default and was entirely unusable; missing metadata and a frozen `versionId` break drift detection; `testIamPermissions` and pagination are standard client/Terraform flows.

## Notes

- gen2 LRO operation polls are namespaced with a `cf2-` id prefix so they stay disjoint from the Cloud Run handler, which also matches `/v2/projects/{p}/locations/{l}/operations/...` (Cloud Functions is registered first).
- GCP-specific state (gen1 metadata, gen2 functions) lives in the wire handler, mirroring the existing IAM-policy store — no portable-driver representation exists for these and gen2 code is not executed.

## Tests

New reproduction tests using the real `google.golang.org/api/cloudfunctions/v1` and `/v2` clients against the in-process GCP server:
- `gen2_sdk_test.go` — gen2 create/get/list/delete, patch, missing-get 404.
- `metadata_sdk_test.go` — gen1 metadata population + versionId bump, body-honoring, testIamPermissions, list pagination.

Existing GCP Cloud Functions tests remain green.

## Deferrals

None.
