### PR TITLE
fix(gcp-memorystore): private-IP host + missing connect/network fields

### DIFF
--- a/providers/gcp/memorystore/memorystore.go
+++ b/providers/gcp/memorystore/memorystore.go
@@ -4,6 +4,7 @@ package memorystore
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"maps"
 	"path"
 	"strconv"
@@ -20,6 +21,24 @@ import (
 )
 
 const defaultRedisPort = 6379
+
+// privateHostIP derives a deterministic private IPv4 in the 10/8 block for a
+// Memorystore instance's exposed Redis endpoint. Real Memorystore hands clients
+// a private IP from the reserved /29 range (never a public hostname); the octets
+// are derived from the instance name so Get/List report a stable address. Host
+// is placed at the .3 offset of a /29 block, mirroring GCP's allocation.
+func privateHostIP(name string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(name))
+	sum := h.Sum32()
+
+	const octetMask = 0xFF
+
+	second := (sum >> 16) & octetMask
+	third := (sum >> 8) & octetMask
+
+	return fmt.Sprintf("10.%d.%d.3", second, third)
+}
 
 // Compile-time check that Mock implements driver.Cache.
 var _ driver.Cache = (*Mock)(nil)
@@ -94,7 +113,7 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 	}
 
 	selfLink := idgen.GCPID(m.opts.ProjectID, "instances", cfg.Name)
-	endpoint := fmt.Sprintf("%s.redis.%s.gcp.cloud:%d", cfg.Name, m.opts.Region, defaultRedisPort)
+	endpoint := fmt.Sprintf("%s:%d", privateHostIP(cfg.Name), defaultRedisPort)
 
 	tags := make(map[string]string, len(cfg.Tags))
 	for k, v := range cfg.Tags {

--- a/server/gcp/memorystore/endpoint_fields_sdk_test.go
+++ b/server/gcp/memorystore/endpoint_fields_sdk_test.go
@@ -1,0 +1,161 @@
+package memorystore_test
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+
+	redis "google.golang.org/api/redis/v1"
+)
+
+// TestSDKMemorystoreHostIsPrivateIP guards the AUDIT_GCP host finding: a
+// Memorystore instance must expose a private IPv4 endpoint, not a fabricated
+// AWS-style "{name}.redis.{region}.gcp.cloud" hostname.
+func TestSDKMemorystoreHostIsPrivateIP(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+		Tier:         "BASIC",
+		MemorySizeGb: 1,
+	}).InstanceId("ip-cache").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Instances.Get(instanceName("ip-cache")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if strings.Contains(got.Host, "gcp.cloud") || strings.Contains(got.Host, ".redis.") {
+		t.Fatalf("host is a fabricated hostname, want a private IP: %q", got.Host)
+	}
+
+	ip := net.ParseIP(got.Host)
+	if ip == nil || ip.To4() == nil {
+		t.Fatalf("host = %q, want a private IPv4 address", got.Host)
+	}
+
+	if !ip.IsPrivate() {
+		t.Fatalf("host = %q, want an RFC1918 private address", got.Host)
+	}
+
+	if got.Port != 6379 {
+		t.Fatalf("port = %d, want 6379", got.Port)
+	}
+}
+
+// TestSDKMemorystoreNetworkFields guards the AUDIT_GCP missing-fields finding:
+// authorizedNetwork must round-trip (normalized to the full network path) and
+// connectMode/currentLocationId/persistenceIamIdentity must be populated.
+func TestSDKMemorystoreNetworkFields(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+		Tier:              "BASIC",
+		MemorySizeGb:      1,
+		AuthorizedNetwork: "projects/demo/global/networks/my-vpc",
+		ConnectMode:       "PRIVATE_SERVICE_ACCESS",
+	}).InstanceId("net-cache").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Instances.Get(instanceName("net-cache")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.AuthorizedNetwork != "projects/demo/global/networks/my-vpc" {
+		t.Errorf("authorizedNetwork = %q, want it echoed", got.AuthorizedNetwork)
+	}
+
+	if got.ConnectMode != "PRIVATE_SERVICE_ACCESS" {
+		t.Errorf("connectMode = %q, want PRIVATE_SERVICE_ACCESS", got.ConnectMode)
+	}
+
+	if got.CurrentLocationId == "" {
+		t.Errorf("currentLocationId is empty, want a zone")
+	}
+
+	if !strings.HasPrefix(got.CurrentLocationId, testLocation+"-") {
+		t.Errorf("currentLocationId = %q, want a zone within %q", got.CurrentLocationId, testLocation)
+	}
+
+	if got.LocationId != got.CurrentLocationId {
+		t.Errorf("locationId = %q, currentLocationId = %q, want them equal for BASIC", got.LocationId, got.CurrentLocationId)
+	}
+
+	if !strings.HasPrefix(got.PersistenceIamIdentity, "serviceAccount:") {
+		t.Errorf("persistenceIamIdentity = %q, want a serviceAccount: identity", got.PersistenceIamIdentity)
+	}
+}
+
+// TestSDKMemorystoreNetworkDefaults guards the defaults real Memorystore applies
+// when connect/network fields are omitted: authorizedNetwork falls back to the
+// full "default" network path and connectMode to DIRECT_PEERING.
+func TestSDKMemorystoreNetworkDefaults(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+		Tier:         "BASIC",
+		MemorySizeGb: 1,
+	}).InstanceId("default-net").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Instances.Get(instanceName("default-net")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.AuthorizedNetwork != "projects/"+testProject+"/global/networks/default" {
+		t.Errorf("authorizedNetwork = %q, want the default network path", got.AuthorizedNetwork)
+	}
+
+	if got.ConnectMode != "DIRECT_PEERING" {
+		t.Errorf("connectMode = %q, want DIRECT_PEERING", got.ConnectMode)
+	}
+
+	// BASIC (standalone) instances have no read replica endpoint.
+	if got.ReadEndpoint != "" {
+		t.Errorf("readEndpoint = %q, want empty for BASIC tier", got.ReadEndpoint)
+	}
+}
+
+// TestSDKMemorystoreReadEndpointStandardHA guards that Standard-tier instances
+// expose a read endpoint distinct from the primary host.
+func TestSDKMemorystoreReadEndpointStandardHA(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+		Tier:         "STANDARD_HA",
+		MemorySizeGb: 5,
+	}).InstanceId("ha-cache").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Instances.Get(instanceName("ha-cache")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.ReadEndpoint == "" {
+		t.Fatalf("readEndpoint is empty, want a Standard-tier read endpoint")
+	}
+
+	if net.ParseIP(got.ReadEndpoint) == nil {
+		t.Errorf("readEndpoint = %q, want an IP address", got.ReadEndpoint)
+	}
+
+	if got.ReadEndpoint == got.Host {
+		t.Errorf("readEndpoint = %q must differ from primary host %q", got.ReadEndpoint, got.Host)
+	}
+
+	if got.ReadEndpointPort != 6379 {
+		t.Errorf("readEndpointPort = %d, want 6379", got.ReadEndpointPort)
+	}
+}

--- a/server/gcp/memorystore/types.go
+++ b/server/gcp/memorystore/types.go
@@ -12,6 +12,10 @@ const (
 	defaultRedisPort    = 6379
 	defaultRedisVersion = "REDIS_6_X"
 	defaultTier         = "BASIC"
+	tierStandardHA      = "STANDARD_HA"
+	defaultConnectMode  = "DIRECT_PEERING"
+	defaultNetwork      = "default"
+	defaultZoneSuffix   = "-a"
 	// stateReady is Memorystore's terminal instance state; the mock provisions
 	// synchronously so every instance reports READY.
 	stateReady = "READY"
@@ -22,18 +26,24 @@ const (
 // (projects/{p}/locations/{l}/instances/{i}); `memorySizeGb` is required by the
 // API surface so a stub default is emitted.
 type instanceJSON struct {
-	Name          string            `json:"name,omitempty"`
-	DisplayName   string            `json:"displayName,omitempty"`
-	Tier          string            `json:"tier,omitempty"`
-	MemorySizeGb  int64             `json:"memorySizeGb,omitempty"`
-	RedisVersion  string            `json:"redisVersion,omitempty"`
-	State         string            `json:"state,omitempty"`
-	Host          string            `json:"host,omitempty"`
-	Port          int64             `json:"port,omitempty"`
-	CreateTime    string            `json:"createTime,omitempty"`
-	Labels        map[string]string `json:"labels,omitempty"`
-	LocationID    string            `json:"locationId,omitempty"`
-	ReservedIPRng string            `json:"reservedIpRange,omitempty"`
+	Name              string            `json:"name,omitempty"`
+	DisplayName       string            `json:"displayName,omitempty"`
+	Tier              string            `json:"tier,omitempty"`
+	MemorySizeGb      int64             `json:"memorySizeGb,omitempty"`
+	RedisVersion      string            `json:"redisVersion,omitempty"`
+	State             string            `json:"state,omitempty"`
+	Host              string            `json:"host,omitempty"`
+	Port              int64             `json:"port,omitempty"`
+	CreateTime        string            `json:"createTime,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	LocationID        string            `json:"locationId,omitempty"`
+	CurrentLocationID string            `json:"currentLocationId,omitempty"`
+	ReservedIPRng     string            `json:"reservedIpRange,omitempty"`
+	AuthorizedNetwork string            `json:"authorizedNetwork,omitempty"`
+	ConnectMode       string            `json:"connectMode,omitempty"`
+	ReadEndpoint      string            `json:"readEndpoint,omitempty"`
+	ReadEndpointPort  int64             `json:"readEndpointPort,omitempty"`
+	PersistenceIAMID  string            `json:"persistenceIamIdentity,omitempty"`
 }
 
 // listInstancesResponse mirrors redis/v1 ListInstancesResponse.
@@ -114,29 +124,107 @@ func toInstanceJSON(project, location, instanceID string, info *cachedriver.Cach
 		redisVersion = v
 	}
 
-	return instanceJSON{
-		Name:          instanceResourceName(project, location, instanceID),
-		DisplayName:   info.Tags[displayNameTag],
-		Tier:          tier,
-		MemorySizeGb:  memSize,
-		RedisVersion:  redisVersion,
-		State:         stateOrReady(info.Status),
-		Host:          host,
-		Port:          port,
-		CreateTime:    info.CreatedAt,
-		Labels:        stripReservedTags(info.Tags),
-		LocationID:    location,
-		ReservedIPRng: info.Tags[reservedIPTag],
+	zone := zoneForLocation(location, info.Tags[locationIDTag])
+
+	inst := instanceJSON{
+		Name:              instanceResourceName(project, location, instanceID),
+		DisplayName:       info.Tags[displayNameTag],
+		Tier:              tier,
+		MemorySizeGb:      memSize,
+		RedisVersion:      redisVersion,
+		State:             stateOrReady(info.Status),
+		Host:              host,
+		Port:              port,
+		CreateTime:        info.CreatedAt,
+		Labels:            stripReservedTags(info.Tags),
+		LocationID:        zone,
+		CurrentLocationID: zone,
+		ReservedIPRng:     info.Tags[reservedIPTag],
+		AuthorizedNetwork: authorizedNetworkOrDefault(project, info.Tags[authorizedNetworkTag]),
+		ConnectMode:       connectModeOrDefault(info.Tags[connectModeTag]),
+		PersistenceIAMID:  persistenceIAMIdentity(project),
 	}
+
+	// The read endpoint is a Standard-tier-only replica endpoint; BASIC
+	// standalone instances leave it unset (matching real Memorystore).
+	if strings.EqualFold(tier, tierStandardHA) {
+		inst.ReadEndpoint = readReplicaHost(host)
+		inst.ReadEndpointPort = port
+	}
+
+	return inst
+}
+
+// zoneForLocation resolves the instance's zone. Real Memorystore reports a zone
+// (e.g. "us-central1-a") in locationId/currentLocationId, distinct from the
+// region in the resource path; a create-time override round-trips, otherwise the
+// region's first zone is used.
+func zoneForLocation(region, override string) string {
+	if override != "" {
+		return override
+	}
+
+	return region + defaultZoneSuffix
+}
+
+// authorizedNetworkOrDefault normalizes the instance's authorized VPC network to
+// the full projects/{p}/global/networks/{n} form real Memorystore returns,
+// defaulting to the "default" network when unspecified.
+func authorizedNetworkOrDefault(project, network string) string {
+	if network == "" {
+		network = defaultNetwork
+	}
+
+	if strings.Contains(network, "/") {
+		return network
+	}
+
+	return "projects/" + project + "/global/networks/" + network
+}
+
+// connectModeOrDefault defaults the connect mode to DIRECT_PEERING, as real
+// Memorystore does when the field is omitted at create time.
+func connectModeOrDefault(mode string) string {
+	if mode == "" {
+		return defaultConnectMode
+	}
+
+	return mode
+}
+
+// persistenceIAMIdentity returns the output-only service-account identity
+// Memorystore uses for RDB persistence to Cloud Storage.
+func persistenceIAMIdentity(project string) string {
+	return "serviceAccount:" + project + "@cloud-redis.iam.gserviceaccount.com"
+}
+
+// readReplicaHost derives a distinct read-endpoint IP from the primary host by
+// advancing the final octet, so a Standard-tier read endpoint differs from the
+// primary host (as real Memorystore reports).
+func readReplicaHost(host string) string {
+	i := strings.LastIndex(host, ".")
+	if i < 0 {
+		return host
+	}
+
+	n, err := strconv.Atoi(host[i+1:])
+	if err != nil {
+		return host
+	}
+
+	return host[:i+1] + strconv.Itoa(n+1)
 }
 
 // Reserved tag keys carry GCP-specific fields the cache driver can't model, so
 // they round-trip through the cache's tags.
 const (
-	memorySizeTag   = "cloudemu:gcpMemorySizeGb"
-	redisVersionTag = "cloudemu:gcpRedisVersion"
-	displayNameTag  = "cloudemu:gcpDisplayName"
-	reservedIPTag   = "cloudemu:gcpReservedIpRange"
+	memorySizeTag        = "cloudemu:gcpMemorySizeGb"
+	redisVersionTag      = "cloudemu:gcpRedisVersion"
+	displayNameTag       = "cloudemu:gcpDisplayName"
+	reservedIPTag        = "cloudemu:gcpReservedIpRange"
+	authorizedNetworkTag = "cloudemu:gcpAuthorizedNetwork"
+	connectModeTag       = "cloudemu:gcpConnectMode"
+	locationIDTag        = "cloudemu:gcpLocationId"
 )
 
 // instanceTags folds the GCP-specific request fields into the tag map, layered
@@ -166,6 +254,18 @@ func instanceTags(body *instanceJSON, existing map[string]string) map[string]str
 
 	if body.ReservedIPRng != "" {
 		out[reservedIPTag] = body.ReservedIPRng
+	}
+
+	if body.AuthorizedNetwork != "" {
+		out[authorizedNetworkTag] = body.AuthorizedNetwork
+	}
+
+	if body.ConnectMode != "" {
+		out[connectModeTag] = body.ConnectMode
+	}
+
+	if body.LocationID != "" {
+		out[locationIDTag] = body.LocationID
 	}
 
 	return out


### PR DESCRIPTION
## What

Fixes the two GCP Memorystore (Redis) findings from AUDIT_GCP.md so the
redis.googleapis.com v1 surface reports realistic connection details.

### Finding 1 — [HIGH][WRONG_WIRE] host is a fabricated AWS-style hostname
`providers/gcp/memorystore` synthesized the endpoint as
`{name}.redis.{region}.gcp.cloud`, so `Instances.Get` returned an AWS-region
token as the Redis `host`. Real Memorystore hands clients a private IPv4 from
the reserved range. The provider now emits a deterministic RFC1918 address
(`10.x.y.3:6379`, stable per instance) as the exposed endpoint.

### Finding 2 — [MEDIUM][MISSING] connect/network fields dropped or empty
The wire Instance struct had no `authorizedNetwork` field and left
`connectMode`, `currentLocationId`, `readEndpoint`, and
`persistenceIamIdentity` empty. Now:
- `authorizedNetwork` round-trips and normalizes to the full
  `projects/{p}/global/networks/{n}` form, defaulting to the `default` network.
- `connectMode` round-trips, defaulting to `DIRECT_PEERING`.
- `locationId`/`currentLocationId` report a zone (`{region}-a`, create-time
  override round-trips) instead of the region.
- `persistenceIamIdentity` is populated as a `serviceAccount:` identity.
- `readEndpoint`/`readEndpointPort` populate for `STANDARD_HA` (distinct replica
  IP) and stay empty for `BASIC`, matching real Memorystore.

## Why

Real `google.golang.org/api/redis/v1` clients read `host` to connect and these
fields to configure peering/HA; the emulator previously misreported them.

## Location / approach

- Provider (`providers/gcp/memorystore`): private-IP endpoint (finding 1).
- Wire (`server/gcp/memorystore`): new output fields, GCP-specific values
  round-tripped through cache tags (finding 2).
- No shared driver interface change, so no docs/coverage regeneration.
- Operation polling still flows through the shared `lro` handler (untouched).

## Tests

New `endpoint_fields_sdk_test.go` drives the real redis/v1 client against the
in-process GCP server, proving each repro passes; existing memorystore + LRO
tests stay green.

## Findings fixed
- memorystore.Instances host — private IP, not AWS-style hostname
- memorystore.Instances.create/get — authorizedNetwork + connectMode/readEndpoint/currentLocationId/persistenceIamIdentity

## Deferrals
None.
