### PR TITLE
fix(gcp-artifactregistry): sub-collections, repo patch/IAM, numeric format enum, extra fields, list paging

### DIFF
--- a/providers/gcp/artifactregistry/artifactregistry.go
+++ b/providers/gcp/artifactregistry/artifactregistry.go
@@ -99,11 +99,13 @@ func (m *Mock) CreateRepository(_ context.Context, cfg driver.RepositoryConfig) 
 	tags := copyTags(cfg.Tags)
 	uri := fmt.Sprintf("%s-docker.pkg.dev/%s/%s", m.opts.Region, m.opts.ProjectID, cfg.Name)
 	selfLink := idgen.GCPID(m.opts.ProjectID, "repositories", cfg.Name)
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
 
 	info := driver.Repository{
 		Name:       selfLink,
 		URI:        uri,
-		CreatedAt:  m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		CreatedAt:  now,
+		UpdatedAt:  now,
 		Tags:       tags,
 		ImageCount: 0,
 	}
@@ -145,6 +147,29 @@ func (m *Mock) GetRepository(_ context.Context, name string) (*driver.Repository
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", name)
 	}
+
+	result := rd.info
+	result.ImageCount = rd.images.Len()
+
+	return &result, nil
+}
+
+// UpdateRepository replaces a repository's tag set (used by the GCP Artifact
+// Registry wire layer to persist label/description/mode patches) and advances
+// UpdatedAt. It is a GCP-specific extension not part of the shared driver
+// interface; the wire handler reaches it via an optional interface assertion.
+func (m *Mock) UpdateRepository(_ context.Context, name string, tags map[string]string) (*driver.Repository, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.repos.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", name)
+	}
+
+	rd.info.Tags = copyTags(tags)
+	rd.info.UpdatedAt = m.opts.Clock.Now().UTC().Format(time.RFC3339)
+	m.repos.Set(name, rd)
 
 	result := rd.info
 	result.ImageCount = rd.images.Len()

--- a/server/gcp/artifactregistry/handler.go
+++ b/server/gcp/artifactregistry/handler.go
@@ -1,15 +1,24 @@
 // Package artifactregistry implements the artifactregistry.googleapis.com v1
 // REST API as a server.Handler. Real google.golang.org/api/artifactregistry/v1
-// clients pointed at this server CRUD repositories and list docker images
-// end-to-end against the shared containerregistry driver.
+// clients pointed at this server CRUD repositories, patch them, manage repo
+// IAM, and list docker images / packages / versions / tags / files end-to-end
+// against the shared containerregistry driver.
 //
 // Coverage (v1 REST):
 //
-//	POST   /v1/projects/{p}/locations/{l}/repositories?repositoryId={id}        — Create repo (async)
-//	GET    /v1/projects/{p}/locations/{l}/repositories/{id}                     — Get repo
-//	GET    /v1/projects/{p}/locations/{l}/repositories                          — List repos
-//	DELETE /v1/projects/{p}/locations/{l}/repositories/{id}                     — Delete repo (async)
-//	GET    /v1/projects/{p}/locations/{l}/repositories/{id}/dockerImages        — List docker images
+//	POST   .../repositories?repositoryId={id}              — Create repo (async)
+//	GET    .../repositories/{id}                           — Get repo
+//	GET    .../repositories                                — List repos (paged)
+//	PATCH  .../repositories/{id}                           — Update labels/description/mode
+//	DELETE .../repositories/{id}                           — Delete repo (async)
+//	GET/POST .../repositories/{id}:{get,set}IamPolicy      — Repo IAM
+//	POST   .../repositories/{id}:testIamPermissions        — Repo IAM
+//	GET    .../repositories/{id}/dockerImages             — List docker images (paged)
+//	GET    .../repositories/{id}/packages                 — List packages (paged)
+//	GET    .../repositories/{id}/packages/{pkg}           — Get package
+//	GET    .../repositories/{id}/packages/{pkg}/versions  — List versions (paged)
+//	GET    .../repositories/{id}/packages/{pkg}/tags      — List tags (paged)
+//	GET    .../repositories/{id}/files                    — List files (paged)
 //
 // The driver has no location dimension, so {l} is accepted and echoed but not
 // used to partition state.
@@ -18,6 +27,7 @@ package artifactregistry
 import (
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
@@ -38,18 +48,30 @@ const minRepoCollectionParts = 5
 // Handler serves artifactregistry.googleapis.com v1 requests.
 type Handler struct {
 	registry crdriver.ContainerRegistry
+
+	// policies stores repo IAM policies set via :setIamPolicy, keyed by the
+	// repository resource name. CloudEmu does not enforce IAM; it stores the
+	// policy so setIamPolicy → getIamPolicy round-trips (Terraform's
+	// google_artifact_registry_repository_iam_* flow).
+	mu       sync.RWMutex
+	policies map[string]*iamPolicy
 }
 
 // New returns an Artifact Registry handler backed by reg.
 func New(reg crdriver.ContainerRegistry) *Handler {
-	return &Handler{registry: reg}
+	return &Handler{registry: reg, policies: make(map[string]*iamPolicy)}
 }
 
 type route struct {
 	project    string
 	location   string
 	repository string // repo id; empty for the collection
-	sub        string // "dockerImages" or ""
+	verb       string // colon action on the repository (getIamPolicy, ...)
+	sub        string // "dockerImages" | "packages" | "files" | ""
+	pkg        string // package id (when sub == packages)
+	pkgSub     string // "versions" | "tags" | ""
+	pkgSubID   string // version or tag id (when pkgSub set)
+	fileID     string // file id (when sub == files)
 	operation  string // operation id when this is an /operations/{op} path
 }
 
@@ -60,7 +82,7 @@ func parseRoute(urlPath string) (route, bool) {
 	}
 
 	parts := strings.Split(strings.TrimPrefix(urlPath, "/v1/"), "/")
-	// parts: [projects, {p}, locations, {l}, {repositories|operations}, {id}?, {sub}?]
+	// parts: [projects, {p}, locations, {l}, {repositories|operations}, ...]
 	if len(parts) < minRepoCollectionParts ||
 		parts[0] != "projects" || parts[2] != locationsSeg {
 		return route{}, false
@@ -69,7 +91,8 @@ func parseRoute(urlPath string) (route, bool) {
 	rt := route{project: parts[1], location: parts[3]}
 
 	// LRO polling: GAPIC clients (.Wait()) GET the operation returned by a
-	// create/delete. Without this route those polls 404.
+	// create/delete. The shared lro handler (registered first) owns these, but
+	// keep the route so a standalone AR handler still answers polls.
 	if parts[4] == operationsSeg {
 		if len(parts) > minRepoCollectionParts {
 			rt.operation = parts[5]
@@ -82,16 +105,62 @@ func parseRoute(urlPath string) (route, bool) {
 		return route{}, false
 	}
 
-	if len(parts) > minRepoCollectionParts {
-		rt.repository = parts[5]
-	}
-
-	const subIdx = 6
-	if len(parts) > subIdx {
-		rt.sub = parts[subIdx]
-	}
+	parseRepoTail(parts, &rt)
 
 	return rt, true
+}
+
+// parseRepoTail fills the repository, colon-verb, and sub-collection fields from
+// the path segments after "repositories".
+func parseRepoTail(parts []string, rt *route) {
+	const (
+		repoIdx = 5
+		subIdx  = 6
+		idIdx   = 7
+		pkgIdx  = 8
+	)
+
+	if len(parts) <= repoIdx {
+		return
+	}
+
+	// A colon verb (repositories/{id}:getIamPolicy) attaches to the repo id.
+	rt.repository, rt.verb = splitVerb(parts[repoIdx])
+
+	if len(parts) <= subIdx {
+		return
+	}
+
+	rt.sub = parts[subIdx]
+
+	switch rt.sub {
+	case packagesSeg:
+		if len(parts) > idIdx {
+			rt.pkg = parts[idIdx]
+		}
+
+		if len(parts) > pkgIdx {
+			rt.pkgSub = parts[pkgIdx]
+		}
+
+		const pkgIDIdx = 9
+		if len(parts) > pkgIDIdx {
+			rt.pkgSubID = parts[pkgIDIdx]
+		}
+	case filesSeg:
+		if len(parts) > idIdx {
+			rt.fileID = parts[idIdx]
+		}
+	}
+}
+
+// splitVerb separates a "resource:verb" segment into its parts.
+func splitVerb(seg string) (resource, verb string) {
+	if idx := strings.LastIndex(seg, ":"); idx >= 0 {
+		return seg[:idx], seg[idx+1:]
+	}
+
+	return seg, ""
 }
 
 // Matches claims artifactregistry v1 repository paths. Disjoint from the IAM
@@ -110,14 +179,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if rt.operation != "" {
-		// The mock completes operations synchronously, so any poll resolves to
-		// a done operation. This unblocks GAPIC .Wait() callers. Echo the exact
-		// operation name that was polled.
 		gcprest.WriteJSON(w, http.StatusOK, operationJSON{
 			Name: "projects/" + rt.project + "/locations/" + rt.location + "/operations/" + rt.operation,
 			Done: true,
 		})
 
+		return
+	}
+
+	if rt.verb != "" {
+		h.serveIAM(w, r, &rt)
 		return
 	}
 
@@ -141,25 +212,41 @@ func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rt *ro
 	}
 }
 
-// serveResource handles a single repository and its dockerImages sub-collection.
+// serveResource handles a single repository and its sub-collections.
 func (h *Handler) serveResource(w http.ResponseWriter, r *http.Request, rt *route) {
-	if rt.sub == dockerImagesSeg {
-		if r.Method == http.MethodGet {
-			h.listDockerImages(w, r, rt)
-			return
-		}
-
-		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported dockerImages operation")
-
+	if rt.sub != "" {
+		h.serveSub(w, r, rt)
 		return
 	}
 
 	switch r.Method {
 	case http.MethodGet:
 		h.getRepository(w, r, rt)
+	case http.MethodPatch:
+		h.patchRepository(w, r, rt)
 	case http.MethodDelete:
 		h.deleteRepository(w, r, rt)
 	default:
 		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported repository operation")
+	}
+}
+
+// serveSub dispatches the repository sub-collections (docker images, packages,
+// versions, tags, files). All are read-only GETs.
+func (h *Handler) serveSub(w http.ResponseWriter, r *http.Request, rt *route) {
+	if r.Method != http.MethodGet {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported "+rt.sub+" operation")
+		return
+	}
+
+	switch rt.sub {
+	case dockerImagesSeg:
+		h.listDockerImages(w, r, rt)
+	case packagesSeg:
+		h.servePackages(w, r, rt)
+	case filesSeg:
+		h.listFiles(w, r, rt)
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported sub-collection "+rt.sub)
 	}
 }

--- a/server/gcp/artifactregistry/iam.go
+++ b/server/gcp/artifactregistry/iam.go
@@ -1,0 +1,131 @@
+package artifactregistry
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+)
+
+const (
+	verbGetIamPolicy       = "getIamPolicy"
+	verbSetIamPolicy       = "setIamPolicy"
+	verbTestIamPermissions = "testIamPermissions"
+)
+
+// iamPolicy is the GCP IAM Policy resource returned by getIamPolicy /
+// setIamPolicy. Bindings are stored verbatim so a set/get round-trips.
+type iamPolicy struct {
+	Version  int             `json:"version,omitempty"`
+	Bindings []policyBinding `json:"bindings,omitempty"`
+	Etag     string          `json:"etag,omitempty"`
+}
+
+type policyBinding struct {
+	Role    string   `json:"role"`
+	Members []string `json:"members,omitempty"`
+}
+
+type setIamPolicyRequest struct {
+	Policy iamPolicy `json:"policy"`
+}
+
+type testIamPermissionsRequest struct {
+	Permissions []string `json:"permissions"`
+}
+
+type testIamPermissionsResponse struct {
+	Permissions []string `json:"permissions,omitempty"`
+}
+
+// serveIAM routes the repository IAM colon-verbs. CloudEmu does not enforce
+// IAM; it stores the policy so setIamPolicy → getIamPolicy round-trips (the
+// google_artifact_registry_repository_iam_* Terraform flow).
+func (h *Handler) serveIAM(w http.ResponseWriter, r *http.Request, rt *route) {
+	// All verbs act on an existing repository (real AR never serves IAM for a
+	// repository that does not exist).
+	if _, err := h.registry.GetRepository(r.Context(), rt.repository); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	switch rt.verb {
+	case verbGetIamPolicy:
+		h.getIamPolicy(w, r, rt)
+	case verbSetIamPolicy:
+		h.setIamPolicy(w, r, rt)
+	case verbTestIamPermissions:
+		h.testIamPermissions(w, r)
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported verb "+rt.verb)
+	}
+}
+
+func (h *Handler) getIamPolicy(w http.ResponseWriter, r *http.Request, rt *route) {
+	if r.Method != http.MethodGet {
+		gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "getIamPolicy requires GET")
+		return
+	}
+
+	key := repositoryResourceName(rt.project, rt.location, rt.repository)
+
+	h.mu.RLock()
+	pol := h.policies[key]
+	h.mu.RUnlock()
+
+	if pol == nil {
+		// An existing repo with no policy yet returns an empty versioned policy
+		// (real AR never 404s getIamPolicy on an existing resource).
+		pol = &iamPolicy{Version: 1, Etag: policyEtag(key, 0)}
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, pol)
+}
+
+func (h *Handler) setIamPolicy(w http.ResponseWriter, r *http.Request, rt *route) {
+	if r.Method != http.MethodPost {
+		gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "setIamPolicy requires POST")
+		return
+	}
+
+	var body setIamPolicyRequest
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	pol := body.Policy
+	if pol.Version == 0 {
+		pol.Version = 1
+	}
+
+	key := repositoryResourceName(rt.project, rt.location, rt.repository)
+	pol.Etag = policyEtag(key, len(pol.Bindings))
+
+	h.mu.Lock()
+	h.policies[key] = &pol
+	h.mu.Unlock()
+
+	gcprest.WriteJSON(w, http.StatusOK, &pol)
+}
+
+func (*Handler) testIamPermissions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "testIamPermissions requires POST")
+		return
+	}
+
+	var body testIamPermissionsRequest
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	// CloudEmu does not enforce IAM, so every requested permission is held: echo
+	// the request set, matching real AR's "subset held" contract for an owner.
+	gcprest.WriteJSON(w, http.StatusOK, testIamPermissionsResponse(body))
+}
+
+// policyEtag returns a stable etag for a policy state.
+func policyEtag(resource string, n int) string {
+	return base64.StdEncoding.EncodeToString([]byte(resource + ":" + strconv.Itoa(n)))
+}

--- a/server/gcp/artifactregistry/operations.go
+++ b/server/gcp/artifactregistry/operations.go
@@ -1,9 +1,13 @@
 package artifactregistry
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"strings"
 
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
 )
@@ -16,24 +20,9 @@ func (h *Handler) createRepository(w http.ResponseWriter, r *http.Request, rt *r
 		return
 	}
 
-	// The driver models a Docker registry and has no format/description field,
-	// so preserve the request's values in reserved tags and echo them on read.
-	tags := make(map[string]string, len(body.Labels))
-	for k, v := range body.Labels {
-		tags[k] = v
-	}
-
-	if body.Format != "" {
-		tags[formatTag] = body.Format
-	}
-
-	if body.Description != "" {
-		tags[descriptionTag] = body.Description
-	}
-
 	repo, err := h.registry.CreateRepository(r.Context(), crdriver.RepositoryConfig{
 		Name: repoID,
-		Tags: tags,
+		Tags: reservedTagsFrom(&body),
 	})
 	if err != nil {
 		gcprest.WriteCErr(w, err)
@@ -41,7 +30,39 @@ func (h *Handler) createRepository(w http.ResponseWriter, r *http.Request, rt *r
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt, repoID,
-		typedResponse(repositoryTypeURL, toRepositoryJSON(rt.project, rt.location, repo))))
+		typedResponse(repositoryTypeURL, toRepositoryJSON(rt.project, rt.location, repo, 0))))
+}
+
+// reservedTagsFrom folds the GCP-only Repository fields (format, description,
+// mode, kmsKeyName) the driver does not model into reserved tags alongside the
+// user labels, so they round-trip on read.
+// reservedFieldCount is the number of GCP-only Repository fields folded into
+// reserved tags (format, description, mode, kmsKeyName).
+const reservedFieldCount = 4
+
+func reservedTagsFrom(body *repositoryJSON) map[string]string {
+	tags := make(map[string]string, len(body.Labels)+reservedFieldCount)
+	for k, v := range body.Labels {
+		tags[k] = v
+	}
+
+	if body.Format != "" {
+		tags[formatTag] = string(body.Format)
+	}
+
+	if body.Description != "" {
+		tags[descriptionTag] = body.Description
+	}
+
+	if body.Mode != "" {
+		tags[modeTag] = body.Mode
+	}
+
+	if body.KmsKeyName != "" {
+		tags[kmsKeyTag] = body.KmsKeyName
+	}
+
+	return tags
 }
 
 // repositoryTypeURL is the protobuf Any type URL a GAPIC client expects in a
@@ -74,7 +95,8 @@ func (h *Handler) getRepository(w http.ResponseWriter, r *http.Request, rt *rout
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, toRepositoryJSON(rt.project, rt.location, repo))
+	gcprest.WriteJSON(w, http.StatusOK,
+		toRepositoryJSON(rt.project, rt.location, repo, h.repoSizeBytes(r.Context(), rt.repository)))
 }
 
 func (h *Handler) listRepositories(w http.ResponseWriter, r *http.Request, rt *route) {
@@ -84,12 +106,125 @@ func (h *Handler) listRepositories(w http.ResponseWriter, r *http.Request, rt *r
 		return
 	}
 
-	out := make([]repositoryJSON, 0, len(repos))
-	for i := range repos {
-		out = append(out, toRepositoryJSON(rt.project, rt.location, &repos[i]))
+	page, err := pagination.PaginateSorted(repos,
+		func(a, b crdriver.Repository) bool { return repoName(a.Name) < repoName(b.Name) },
+		r.URL.Query().Get("pageToken"), pageSize(r))
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid page token")
+		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, listRepositoriesResponse{Repositories: out})
+	out := make([]repositoryJSON, 0, len(page.Items))
+
+	for i := range page.Items {
+		name := repoName(page.Items[i].Name)
+		out = append(out, toRepositoryJSON(rt.project, rt.location, &page.Items[i], h.repoSizeBytes(r.Context(), name)))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK,
+		listRepositoriesResponse{Repositories: out, NextPageToken: page.NextPageToken})
+}
+
+func (h *Handler) patchRepository(w http.ResponseWriter, r *http.Request, rt *route) {
+	updater, ok := h.registry.(repositoryUpdater)
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "repository patch unsupported")
+		return
+	}
+
+	current, err := h.registry.GetRepository(r.Context(), rt.repository)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	var body repositoryJSON
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	tags := applyPatch(current.Tags, &body, updateMaskFields(r))
+
+	updated, err := updater.UpdateRepository(r.Context(), rt.repository, tags)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK,
+		toRepositoryJSON(rt.project, rt.location, updated, h.repoSizeBytes(r.Context(), rt.repository)))
+}
+
+// repositoryUpdater is the optional driver extension the GCP mock implements to
+// persist a repository patch. Providers without it get a 404 on PATCH.
+type repositoryUpdater interface {
+	UpdateRepository(ctx context.Context, name string, tags map[string]string) (*crdriver.Repository, error)
+}
+
+// applyPatch merges the patch body into the current reserved+label tag set,
+// honoring the update mask. An empty mask (or "*") updates every settable field.
+func applyPatch(current map[string]string, body *repositoryJSON, mask map[string]bool) map[string]string {
+	tags := make(map[string]string, len(current))
+	for k, v := range current {
+		tags[k] = v
+	}
+
+	all := len(mask) == 0 || mask["*"]
+
+	if all || mask["labels"] {
+		replaceLabels(tags, body.Labels)
+	}
+
+	if all || mask["description"] {
+		setOrDelete(tags, descriptionTag, body.Description)
+	}
+
+	if all || mask["kmsKeyName"] {
+		setOrDelete(tags, kmsKeyTag, body.KmsKeyName)
+	}
+
+	return tags
+}
+
+// replaceLabels swaps every non-reserved (user label) key in tags for the ones
+// in labels, leaving reserved cloudemu: keys intact.
+func replaceLabels(tags, labels map[string]string) {
+	for k := range tags {
+		if !strings.HasPrefix(k, reservedTagPrefix) {
+			delete(tags, k)
+		}
+	}
+
+	for k, v := range labels {
+		tags[k] = v
+	}
+}
+
+func setOrDelete(tags map[string]string, key, val string) {
+	if val == "" {
+		delete(tags, key)
+		return
+	}
+
+	tags[key] = val
+}
+
+// updateMaskFields parses the ?updateMask=labels,description query into a set.
+func updateMaskFields(r *http.Request) map[string]bool {
+	raw := r.URL.Query().Get("updateMask")
+	if raw == "" {
+		return nil
+	}
+
+	out := make(map[string]bool)
+
+	for _, f := range strings.Split(raw, ",") {
+		if f = strings.TrimSpace(f); f != "" {
+			out[f] = true
+		}
+	}
+
+	return out
 }
 
 func (h *Handler) deleteRepository(w http.ResponseWriter, r *http.Request, rt *route) {
@@ -99,6 +234,10 @@ func (h *Handler) deleteRepository(w http.ResponseWriter, r *http.Request, rt *r
 		gcprest.WriteCErr(w, err)
 		return
 	}
+
+	h.mu.Lock()
+	delete(h.policies, repositoryResourceName(rt.project, rt.location, rt.repository))
+	h.mu.Unlock()
 
 	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt, rt.repository, nil))
 }
@@ -110,12 +249,62 @@ func (h *Handler) listDockerImages(w http.ResponseWriter, r *http.Request, rt *r
 		return
 	}
 
-	out := make([]dockerImageJSON, 0, len(images))
-	for i := range images {
-		out = append(out, toDockerImageJSON(rt.project, rt.location, rt.repository, &images[i]))
+	page, ok := paginateImages(w, r, images)
+	if !ok {
+		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, listDockerImagesResponse{DockerImages: out})
+	out := make([]dockerImageJSON, 0, len(page.Items))
+	for i := range page.Items {
+		out = append(out, toDockerImageJSON(rt.project, rt.location, rt.repository, &page.Items[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK,
+		listDockerImagesResponse{DockerImages: out, NextPageToken: page.NextPageToken})
+}
+
+// paginateImages sorts images by digest and slices one page, writing a 400 and
+// returning ok=false on a bad page token. Shared by every image-backed
+// sub-collection (docker images, packages, files).
+func paginateImages(
+	w http.ResponseWriter, r *http.Request, images []crdriver.ImageDetail,
+) (pagination.Page[crdriver.ImageDetail], bool) {
+	page, err := pagination.PaginateSorted(images,
+		func(a, b crdriver.ImageDetail) bool { return a.Digest < b.Digest },
+		r.URL.Query().Get("pageToken"), pageSize(r))
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid page token")
+		return page, false
+	}
+
+	return page, true
+}
+
+// repoSizeBytes sums the image sizes in a repository. Best-effort: a missing
+// repository (concurrent delete) contributes zero.
+func (h *Handler) repoSizeBytes(ctx context.Context, repository string) int64 {
+	images, err := h.registry.ListImages(ctx, repository)
+	if err != nil {
+		return 0
+	}
+
+	var total int64
+	for i := range images {
+		total += images[i].SizeBytes
+	}
+
+	return total
+}
+
+// pageSize reads the ?pageSize query parameter (0 when absent/invalid, which the
+// pagination helper treats as its default).
+func pageSize(r *http.Request) int {
+	n, err := strconv.Atoi(r.URL.Query().Get("pageSize"))
+	if err != nil || n < 0 {
+		return 0
+	}
+
+	return n
 }
 
 // doneOperation builds a completed long-running operation envelope.

--- a/server/gcp/artifactregistry/repository_ops_test.go
+++ b/server/gcp/artifactregistry/repository_ops_test.go
@@ -1,0 +1,217 @@
+package artifactregistry_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	gapic "cloud.google.com/go/artifactregistry/apiv1"
+	"cloud.google.com/go/artifactregistry/apiv1/artifactregistrypb"
+	ar "google.golang.org/api/artifactregistry/v1"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+// TestSDKArtifactRegistryPatch guards the HIGH finding: PATCH previously 404'd
+// ("unsupported repository operation"), so Terraform label/description updates
+// failed. A patch with an update mask must now persist.
+func TestSDKArtifactRegistryPatch(t *testing.T) {
+	svc, _ := newARService(t)
+	ctx := context.Background()
+
+	name := testParent + "/repositories/patchme"
+
+	if _, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{
+		Format: "DOCKER", Labels: map[string]string{"env": "dev"},
+	}).RepositoryId("patchme").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Repositories.Patch(name, &ar.Repository{
+		Labels: map[string]string{"env": "prod", "team": "platform"}, Description: "prod repo",
+	}).UpdateMask("labels,description").Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Repositories.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Labels["env"] != "prod" || got.Labels["team"] != "platform" {
+		t.Fatalf("labels not patched: %+v", got.Labels)
+	}
+
+	if got.Description != "prod repo" {
+		t.Fatalf("description=%q want 'prod repo'", got.Description)
+	}
+}
+
+// TestSDKArtifactRegistryRepoIAM guards the HIGH finding: repo IAM colon-verbs
+// (getIamPolicy/setIamPolicy/testIamPermissions) previously 404'd. They must now
+// round-trip.
+func TestSDKArtifactRegistryRepoIAM(t *testing.T) {
+	svc, _ := newARService(t)
+	ctx := context.Background()
+
+	name := testParent + "/repositories/iam"
+
+	if _, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{Format: "DOCKER"}).
+		RepositoryId("iam").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	set, err := svc.Projects.Locations.Repositories.SetIamPolicy(name, &ar.SetIamPolicyRequest{
+		Policy: &ar.Policy{Bindings: []*ar.Binding{{
+			Role: "roles/artifactregistry.reader", Members: []string{"user:a@b.com"},
+		}}},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("SetIamPolicy: %v", err)
+	}
+
+	if len(set.Bindings) != 1 || set.Etag == "" {
+		t.Fatalf("SetIamPolicy returned %+v", set)
+	}
+
+	got, err := svc.Projects.Locations.Repositories.GetIamPolicy(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("GetIamPolicy: %v", err)
+	}
+
+	if len(got.Bindings) != 1 || got.Bindings[0].Role != "roles/artifactregistry.reader" {
+		t.Fatalf("GetIamPolicy did not round-trip: %+v", got)
+	}
+
+	perms, err := svc.Projects.Locations.Repositories.TestIamPermissions(name, &ar.TestIamPermissionsRequest{
+		Permissions: []string{"artifactregistry.repositories.get"},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("TestIamPermissions: %v", err)
+	}
+
+	if len(perms.Permissions) != 1 || perms.Permissions[0] != "artifactregistry.repositories.get" {
+		t.Fatalf("TestIamPermissions returned %+v", perms.Permissions)
+	}
+}
+
+// TestSDKArtifactRegistryRepoFields guards the finding that mode / sizeBytes /
+// kmsKeyName were absent and updateTime was always empty.
+func TestSDKArtifactRegistryRepoFields(t *testing.T) {
+	svc, reg := newARService(t)
+	ctx := context.Background()
+
+	name := testParent + "/repositories/fields"
+	kms := "projects/demo/locations/us/keyRings/kr/cryptoKeys/k"
+
+	if _, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{
+		Format: "DOCKER", Mode: "STANDARD_REPOSITORY", KmsKeyName: kms,
+	}).RepositoryId("fields").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if _, err := reg.PutImage(ctx, &crdriver.ImageManifest{
+		Repository: "fields", Tag: "v1", Digest: "sha256:abc", SizeBytes: 4096,
+	}); err != nil {
+		t.Fatalf("seed PutImage: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Repositories.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Mode != "STANDARD_REPOSITORY" {
+		t.Errorf("mode=%q want STANDARD_REPOSITORY", got.Mode)
+	}
+
+	if got.KmsKeyName != kms {
+		t.Errorf("kmsKeyName=%q want %q", got.KmsKeyName, kms)
+	}
+
+	if got.SizeBytes != 4096 {
+		t.Errorf("sizeBytes=%d want 4096", got.SizeBytes)
+	}
+
+	if got.CreateTime == "" || got.UpdateTime == "" {
+		t.Errorf("create/update time empty: create=%q update=%q", got.CreateTime, got.UpdateTime)
+	}
+}
+
+// TestSDKArtifactRegistryListPaging guards the finding that pageSize/pageToken
+// were ignored on the repositories list.
+func TestSDKArtifactRegistryListPaging(t *testing.T) {
+	svc, _ := newARService(t)
+	ctx := context.Background()
+
+	for _, id := range []string{"p1", "p2", "p3"} {
+		if _, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{Format: "DOCKER"}).
+			RepositoryId(id).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create %s: %v", id, err)
+		}
+	}
+
+	first, err := svc.Projects.Locations.Repositories.List(testParent).PageSize(2).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List page 1: %v", err)
+	}
+
+	if len(first.Repositories) != 2 || first.NextPageToken == "" {
+		t.Fatalf("page 1 got %d repos, token=%q; want 2 + token", len(first.Repositories), first.NextPageToken)
+	}
+
+	second, err := svc.Projects.Locations.Repositories.List(testParent).
+		PageSize(2).PageToken(first.NextPageToken).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List page 2: %v", err)
+	}
+
+	if len(second.Repositories) != 1 || second.NextPageToken != "" {
+		t.Fatalf("page 2 got %d repos, token=%q; want 1 + no token", len(second.Repositories), second.NextPageToken)
+	}
+}
+
+// TestGAPICCreateRepositoryFormatEnum guards the WRONG_WIRE finding: the GAPIC
+// apiv1 client serializes Format as a numeric proto enum (UseEnumNumbers), which
+// previously failed to decode into the string field ("cannot unmarshal number").
+// Create with a set Format must now succeed.
+func TestGAPICCreateRepositoryFormatEnum(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.DriversFrom(cloud))
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	client, err := gapic.NewRESTClient(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	op, err := client.CreateRepository(ctx, &artifactregistrypb.CreateRepositoryRequest{
+		Parent:       "projects/demo/locations/us",
+		RepositoryId: "enum-repo",
+		Repository:   &artifactregistrypb.Repository{Format: artifactregistrypb.Repository_DOCKER},
+	})
+	if err != nil {
+		t.Fatalf("CreateRepository (numeric Format enum): %v", err)
+	}
+
+	repo, err := op.Wait(ctx)
+	if err != nil {
+		t.Fatalf("op.Wait: %v", err)
+	}
+
+	if repo.GetFormat() != artifactregistrypb.Repository_DOCKER {
+		t.Fatalf("format=%v want DOCKER", repo.GetFormat())
+	}
+}

--- a/server/gcp/artifactregistry/subcollections.go
+++ b/server/gcp/artifactregistry/subcollections.go
@@ -1,0 +1,183 @@
+package artifactregistry
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+// The driver models docker images by digest without a distinct image-name
+// dimension, so each image is surfaced as one AR package (id = digest) with a
+// single version (the digest) and its docker tags. This keeps the packages /
+// versions / tags / files sub-collections correctly shaped and populated from
+// real repository state instead of the previous behavior of silently returning
+// the Repository body.
+
+// servePackages dispatches the packages sub-tree: the packages collection, a
+// single package, and its versions / tags sub-collections.
+func (h *Handler) servePackages(w http.ResponseWriter, r *http.Request, rt *route) {
+	if rt.pkg == "" {
+		h.listPackages(w, r, rt)
+		return
+	}
+
+	switch rt.pkgSub {
+	case versionsSeg:
+		h.listVersions(w, r, rt)
+	case tagsSeg:
+		h.listTags(w, r, rt)
+	case "":
+		h.getPackage(w, r, rt)
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported package sub-collection "+rt.pkgSub)
+	}
+}
+
+func (h *Handler) repoImages(w http.ResponseWriter, r *http.Request, rt *route) ([]crdriver.ImageDetail, bool) {
+	images, err := h.registry.ListImages(r.Context(), rt.repository)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return nil, false
+	}
+
+	return images, true
+}
+
+func (h *Handler) listPackages(w http.ResponseWriter, r *http.Request, rt *route) {
+	out, token, ok := pagedImageList(h, w, r, rt, toPackageJSON)
+	if !ok {
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listPackagesResponse{Packages: out, NextPageToken: token})
+}
+
+// pagedImageList lists a repository's images, paginates them, and converts each
+// to T. Shared by the packages and files sub-collections; ok is false when it
+// has already written an error response.
+func pagedImageList[T any](
+	h *Handler, w http.ResponseWriter, r *http.Request, rt *route,
+	conv func(*route, *crdriver.ImageDetail) T,
+) (items []T, nextPageToken string, ok bool) {
+	images, ok := h.repoImages(w, r, rt)
+	if !ok {
+		return nil, "", false
+	}
+
+	page, ok := paginateImages(w, r, images)
+	if !ok {
+		return nil, "", false
+	}
+
+	out := make([]T, 0, len(page.Items))
+	for i := range page.Items {
+		out = append(out, conv(rt, &page.Items[i]))
+	}
+
+	return out, page.NextPageToken, true
+}
+
+func (h *Handler) getPackage(w http.ResponseWriter, r *http.Request, rt *route) {
+	img, ok := h.findImage(w, r, rt)
+	if !ok {
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toPackageJSON(rt, img))
+}
+
+func (h *Handler) listVersions(w http.ResponseWriter, r *http.Request, rt *route) {
+	img, ok := h.findImage(w, r, rt)
+	if !ok {
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listVersionsResponse{Versions: []versionJSON{toVersionJSON(rt, img)}})
+}
+
+func (h *Handler) listTags(w http.ResponseWriter, r *http.Request, rt *route) {
+	img, ok := h.findImage(w, r, rt)
+	if !ok {
+		return
+	}
+
+	out := make([]tagsJSON, 0, len(img.Tags))
+	for _, t := range img.Tags {
+		out = append(out, toTagJSON(rt, t, img.Digest))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listTagsResponse{Tags: out})
+}
+
+func (h *Handler) listFiles(w http.ResponseWriter, r *http.Request, rt *route) {
+	out, token, ok := pagedImageList(h, w, r, rt, toFileJSON)
+	if !ok {
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listFilesResponse{Files: out, NextPageToken: token})
+}
+
+// findImage resolves rt.pkg (a digest) to its image, 404ing when absent.
+func (h *Handler) findImage(w http.ResponseWriter, r *http.Request, rt *route) (*crdriver.ImageDetail, bool) {
+	images, ok := h.repoImages(w, r, rt)
+	if !ok {
+		return nil, false
+	}
+
+	for i := range images {
+		if images[i].Digest == rt.pkg {
+			return &images[i], true
+		}
+	}
+
+	gcprest.WriteError(w, http.StatusNotFound, "notFound", "package "+rt.pkg+" not found")
+
+	return nil, false
+}
+
+func packageResourceName(rt *route, pkg string) string {
+	return repositoryResourceName(rt.project, rt.location, rt.repository) + "/packages/" + pkg
+}
+
+func toPackageJSON(rt *route, d *crdriver.ImageDetail) packageJSON {
+	return packageJSON{
+		Name:        packageResourceName(rt, d.Digest),
+		DisplayName: d.Digest,
+		CreateTime:  d.PushedAt,
+		UpdateTime:  d.PushedAt,
+	}
+}
+
+func toVersionJSON(rt *route, d *crdriver.ImageDetail) versionJSON {
+	related := make([]tagsJSON, 0, len(d.Tags))
+	for _, t := range d.Tags {
+		related = append(related, toTagJSON(rt, t, d.Digest))
+	}
+
+	return versionJSON{
+		Name:        packageResourceName(rt, d.Digest) + "/versions/" + d.Digest,
+		CreateTime:  d.PushedAt,
+		UpdateTime:  d.PushedAt,
+		RelatedTags: related,
+	}
+}
+
+func toTagJSON(rt *route, tag, digest string) tagsJSON {
+	return tagsJSON{
+		Name:    packageResourceName(rt, digest) + "/tags/" + tag,
+		Version: packageResourceName(rt, digest) + "/versions/" + digest,
+	}
+}
+
+func toFileJSON(rt *route, d *crdriver.ImageDetail) fileJSON {
+	return fileJSON{
+		Name:       repositoryResourceName(rt.project, rt.location, rt.repository) + "/files/" + d.Digest,
+		SizeBytes:  strconv.FormatInt(d.SizeBytes, 10),
+		Owner:      packageResourceName(rt, d.Digest) + "/versions/" + d.Digest,
+		CreateTime: d.PushedAt,
+		UpdateTime: d.PushedAt,
+	}
+}

--- a/server/gcp/artifactregistry/subcollections_test.go
+++ b/server/gcp/artifactregistry/subcollections_test.go
@@ -1,0 +1,82 @@
+package artifactregistry_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	ar "google.golang.org/api/artifactregistry/v1"
+
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+// TestSDKArtifactRegistrySubCollections guards the BLOCKER finding: packages /
+// versions / tags / files list endpoints previously returned the Repository
+// body (only dockerImages was special-cased), so clients silently decoded empty
+// lists. They must now return the correctly-shaped sub-collections populated
+// from repository state.
+func TestSDKArtifactRegistrySubCollections(t *testing.T) {
+	svc, reg := newARService(t)
+	ctx := context.Background()
+
+	repo := testParent + "/repositories/sub"
+
+	if _, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{Format: "DOCKER"}).
+		RepositoryId("sub").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	seed := func(digest, tag string, size int64) {
+		if _, err := reg.PutImage(ctx, &crdriver.ImageManifest{
+			Repository: "sub", Tag: tag, Digest: digest, SizeBytes: size,
+			MediaType: "application/vnd.docker.distribution.manifest.v2+json",
+		}); err != nil {
+			t.Fatalf("seed PutImage: %v", err)
+		}
+	}
+
+	seed("sha256:aaa", "v1", 1024)
+	seed("sha256:bbb", "v2", 2048)
+
+	pkgs, err := svc.Projects.Locations.Repositories.Packages.List(repo).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Packages.List: %v", err)
+	}
+
+	if len(pkgs.Packages) != 2 {
+		t.Fatalf("got %d packages, want 2 (Repository body leaked?)", len(pkgs.Packages))
+	}
+
+	if !strings.Contains(pkgs.Packages[0].Name, "/packages/") {
+		t.Fatalf("package name not a package resource: %q", pkgs.Packages[0].Name)
+	}
+
+	pkgParent := repo + "/packages/sha256:aaa"
+
+	vers, err := svc.Projects.Locations.Repositories.Packages.Versions.List(pkgParent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Versions.List: %v", err)
+	}
+
+	if len(vers.Versions) != 1 || !strings.Contains(vers.Versions[0].Name, "/versions/sha256:aaa") {
+		t.Fatalf("Versions.List returned %+v", vers.Versions)
+	}
+
+	tags, err := svc.Projects.Locations.Repositories.Packages.Tags.List(pkgParent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Tags.List: %v", err)
+	}
+
+	if len(tags.Tags) != 1 || !strings.HasSuffix(tags.Tags[0].Name, "/tags/v1") {
+		t.Fatalf("Tags.List returned %+v", tags.Tags)
+	}
+
+	files, err := svc.Projects.Locations.Repositories.Files.List(repo).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Files.List: %v", err)
+	}
+
+	if len(files.Files) != 2 {
+		t.Fatalf("got %d files, want 2", len(files.Files))
+	}
+}

--- a/server/gcp/artifactregistry/types.go
+++ b/server/gcp/artifactregistry/types.go
@@ -1,20 +1,79 @@
 package artifactregistry
 
 import (
+	"encoding/json"
 	"strconv"
 	"strings"
 
 	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
 )
 
+// repoFormat is the Repository.format field. The GAPIC apiv1 REST client
+// serializes proto enums with UseEnumNumbers, so it sends format as a number
+// (e.g. 1 for DOCKER); the raw google.golang.org/api client sends the name.
+// UnmarshalJSON accepts either and normalizes to the string name so a create
+// with a GAPIC client no longer 400s "cannot unmarshal number into string".
+type repoFormat string
+
+// formatNames maps the artifactregistry.v1 Repository_Format enum numbers to
+// their names, matching the protobuf enum.
+//
+//nolint:gochecknoglobals // static enum lookup table, not mutable state.
+var formatNames = map[int]string{
+	0:  "FORMAT_UNSPECIFIED",
+	1:  "DOCKER",
+	2:  "MAVEN",
+	3:  "NPM",
+	5:  "APT",
+	6:  "YUM",
+	8:  "PYTHON",
+	9:  "KFP",
+	10: "GO",
+	11: "GENERIC",
+}
+
+// UnmarshalJSON accepts the format as a JSON string or a numeric enum.
+func (f *repoFormat) UnmarshalJSON(b []byte) error {
+	s := strings.TrimSpace(string(b))
+	if s == "null" || s == "" {
+		return nil
+	}
+
+	if s[0] == '"' {
+		var str string
+		if err := json.Unmarshal(b, &str); err != nil {
+			return err
+		}
+
+		*f = repoFormat(str)
+
+		return nil
+	}
+
+	var n int
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+
+	if name, ok := formatNames[n]; ok {
+		*f = repoFormat(name)
+	}
+
+	return nil
+}
+
 // repositoryJSON is the artifactregistry.googleapis.com v1 Repository shape.
 type repositoryJSON struct {
-	Name        string            `json:"name"`
-	Format      string            `json:"format,omitempty"`
-	Description string            `json:"description,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	CreateTime  string            `json:"createTime,omitempty"`
-	UpdateTime  string            `json:"updateTime,omitempty"`
+	Name         string            `json:"name"`
+	Format       repoFormat        `json:"format,omitempty"`
+	Mode         string            `json:"mode,omitempty"`
+	Description  string            `json:"description,omitempty"`
+	Labels       map[string]string `json:"labels,omitempty"`
+	KmsKeyName   string            `json:"kmsKeyName,omitempty"`
+	SizeBytes    string            `json:"sizeBytes,omitempty"`
+	SatisfiesPzs bool              `json:"satisfiesPzs,omitempty"`
+	CreateTime   string            `json:"createTime,omitempty"`
+	UpdateTime   string            `json:"updateTime,omitempty"`
 }
 
 // dockerImageJSON is the v1 DockerImage shape. imageSizeBytes is an int64
@@ -29,6 +88,37 @@ type dockerImageJSON struct {
 	UpdateTime     string   `json:"updateTime,omitempty"`
 }
 
+// packageJSON is the v1 Package shape.
+type packageJSON struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName,omitempty"`
+	CreateTime  string `json:"createTime,omitempty"`
+	UpdateTime  string `json:"updateTime,omitempty"`
+}
+
+// versionJSON is the v1 Version shape.
+type versionJSON struct {
+	Name        string     `json:"name"`
+	CreateTime  string     `json:"createTime,omitempty"`
+	UpdateTime  string     `json:"updateTime,omitempty"`
+	RelatedTags []tagsJSON `json:"relatedTags,omitempty"`
+}
+
+// tagsJSON is the v1 Tag shape.
+type tagsJSON struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
+// fileJSON is the v1 File shape.
+type fileJSON struct {
+	Name       string `json:"name"`
+	SizeBytes  string `json:"sizeBytes,omitempty"`
+	Owner      string `json:"owner,omitempty"`
+	CreateTime string `json:"createTime,omitempty"`
+	UpdateTime string `json:"updateTime,omitempty"`
+}
+
 type listRepositoriesResponse struct {
 	Repositories  []repositoryJSON `json:"repositories"`
 	NextPageToken string           `json:"nextPageToken,omitempty"`
@@ -37,6 +127,26 @@ type listRepositoriesResponse struct {
 type listDockerImagesResponse struct {
 	DockerImages  []dockerImageJSON `json:"dockerImages"`
 	NextPageToken string            `json:"nextPageToken,omitempty"`
+}
+
+type listPackagesResponse struct {
+	Packages      []packageJSON `json:"packages"`
+	NextPageToken string        `json:"nextPageToken,omitempty"`
+}
+
+type listVersionsResponse struct {
+	Versions      []versionJSON `json:"versions"`
+	NextPageToken string        `json:"nextPageToken,omitempty"`
+}
+
+type listTagsResponse struct {
+	Tags          []tagsJSON `json:"tags"`
+	NextPageToken string     `json:"nextPageToken,omitempty"`
+}
+
+type listFilesResponse struct {
+	Files         []fileJSON `json:"files"`
+	NextPageToken string     `json:"nextPageToken,omitempty"`
 }
 
 // operationJSON is a google.longrunning.Operation. Artifact Registry's create
@@ -48,9 +158,17 @@ type operationJSON struct {
 }
 
 const (
-	dockerFormat   = "DOCKER"
-	formatTag      = "cloudemu:gcpArFormat"
-	descriptionTag = "cloudemu:gcpArDescription"
+	dockerFormat      = "DOCKER"
+	standardMode      = "STANDARD_REPOSITORY"
+	formatTag         = "cloudemu:gcpArFormat"
+	descriptionTag    = "cloudemu:gcpArDescription"
+	modeTag           = "cloudemu:gcpArMode"
+	kmsKeyTag         = "cloudemu:gcpArKmsKeyName"
+	reservedTagPrefix = "cloudemu:"
+	packagesSeg       = "packages"
+	versionsSeg       = "versions"
+	tagsSeg           = "tags"
+	filesSeg          = "files"
 )
 
 func repositoryResourceName(project, location, id string) string {
@@ -72,20 +190,38 @@ func repoName(name string) string {
 	return name
 }
 
-func toRepositoryJSON(project, location string, r *crdriver.Repository) repositoryJSON {
+func toRepositoryJSON(project, location string, r *crdriver.Repository, sizeBytes int64) repositoryJSON {
 	format := dockerFormat
 	if f := r.Tags[formatTag]; f != "" {
 		format = f
 	}
 
-	return repositoryJSON{
+	mode := standardMode
+	if m := r.Tags[modeTag]; m != "" {
+		mode = m
+	}
+
+	updateTime := r.UpdatedAt
+	if updateTime == "" {
+		updateTime = r.CreatedAt
+	}
+
+	out := repositoryJSON{
 		Name:        repositoryResourceName(project, location, repoName(r.Name)),
-		Format:      format,
+		Format:      repoFormat(format),
+		Mode:        mode,
 		Description: r.Tags[descriptionTag],
 		Labels:      stripReservedTags(r.Tags),
+		KmsKeyName:  r.Tags[kmsKeyTag],
 		CreateTime:  r.CreatedAt,
-		UpdateTime:  r.CreatedAt,
+		UpdateTime:  updateTime,
 	}
+
+	if sizeBytes > 0 {
+		out.SizeBytes = strconv.FormatInt(sizeBytes, 10)
+	}
+
+	return out
 }
 
 // stripReservedTags returns user labels without cloudemu-internal keys.
@@ -97,7 +233,7 @@ func stripReservedTags(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
 
 	for k, v := range in {
-		if strings.HasPrefix(k, "cloudemu:") {
+		if strings.HasPrefix(k, reservedTagPrefix) {
 			continue
 		}
 

--- a/services/containerregistry/driver/driver.go
+++ b/services/containerregistry/driver/driver.go
@@ -7,9 +7,13 @@ import (
 
 // Repository represents a container repository.
 type Repository struct {
-	Name       string
-	URI        string
-	CreatedAt  string
+	Name      string
+	URI       string
+	CreatedAt string
+	// UpdatedAt is the last-modified timestamp. Providers that support in-place
+	// updates (GCP Artifact Registry patch) advance it; others leave it equal to
+	// CreatedAt.
+	UpdatedAt  string
 	Tags       map[string]string
 	ImageCount int
 	// Arn is the provider-native resource identifier (AWS ECR ARN). Optional


### PR DESCRIPTION
## What

Fixes all 6 GCP Artifact Registry findings from the audit. Real `google.golang.org/api/artifactregistry/v1` and GAPIC `apiv1` clients now drive repositories, their patches, repo IAM, and the packages/versions/tags/files sub-collections end-to-end against the shared container-registry driver.

## Why / findings fixed

- **[BLOCKER] packages/versions/tags/files.list returned the Repository body** — only `dockerImages` was special-cased, so clients silently decoded empty lists. These sub-collections are now routed and return correctly-shaped, populated responses. The driver models docker images by digest without a distinct image-name dimension, so each image is surfaced as one package (id = digest) with a single version and its docker tags; files are the repo blobs.
- **[HIGH][WRONG_WIRE] CreateRepository numeric Format enum** — the GAPIC apiv1 REST client serializes proto enums with `UseEnumNumbers`, sending `format` as a number, which failed to decode into the string field. `format` now unmarshals from either a JSON string or the numeric enum.
- **[HIGH] repositories.patch 404** — PATCH is now supported; labels/description/kmsKeyName update via the update mask (persisted through a GCP-only optional driver extension `UpdateRepository`).
- **[HIGH] repositories IAM colon-verbs 404** — `:getIamPolicy` / `:setIamPolicy` / `:testIamPermissions` on a repository now round-trip (policy stored in the wire handler, matching the cloudfunctions IAM pattern).
- **[LOW] missing fields** — `mode`, `sizeBytes`, `kmsKeyName` are now returned, and `updateTime` is tracked separately from `createTime` (advances on patch) via a new `Repository.UpdatedAt` driver field.
- **[LOW] list paging ignored** — `pageSize`/`pageToken` are honored on the repositories list and the sub-collection lists, with `nextPageToken` emitted.

## Notes

- The shared `ContainerRegistry` driver interface is unchanged (only a struct field was added and a GCP-mock-only optional method); `go run ./internal/coveragegen` produces no doc diff.
- Artifact Registry operations continue to poll through the shared `lro` handler (registered first); this handler's own operation route is only a standalone fallback and does not shadow it.

## Tests

Reproduction tests using the real clients against the in-process GCP server, one per finding: `subcollections_test.go` (packages/versions/tags/files) and `repository_ops_test.go` (patch, repo IAM, numeric format enum, extra fields, list paging). Existing AR + shared LRO tests remain green.