### PR TITLE
fix(gcp): bigtable/eventarc/vertexai/fcm/cloudasset fidelity

### DIFF
--- a/providers/gcp/vertexai/endpoints.go
+++ b/providers/gcp/vertexai/endpoints.go
@@ -2,6 +2,7 @@ package vertexai
 
 import (
 	"context"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/vertexai/driver"
@@ -63,8 +64,21 @@ func (m *Mock) DeployModel(_ context.Context, endpoint string, dm driver.Deploye
 		return nil, nil, errors.Newf(errors.NotFound, "endpoint %q not found", endpoint)
 	}
 
+	// The model being deployed must exist. Real Vertex AI rejects an unknown
+	// model resource with NOT_FOUND rather than deploying a dangling reference.
+	if dm.Model != "" {
+		base, _, _ := strings.Cut(dm.Model, "@")
+		if !m.models.Has(base) {
+			return nil, nil, errors.Newf(errors.NotFound, "model %q not found", dm.Model)
+		}
+	}
+
 	if dm.ID == "" {
 		dm.ID = m.newID()
+	}
+
+	if dm.CreateTime == "" {
+		dm.CreateTime = m.now()
 	}
 
 	// Deep-copy working set so the stored endpoint is never mutated in place.
@@ -138,13 +152,20 @@ func (m *Mock) Predict(_ context.Context, req driver.PredictRequest) (*driver.Pr
 		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", req.Endpoint)
 	}
 
+	// Prediction requires at least one deployed model. Real Vertex AI returns
+	// FAILED_PRECONDITION when the endpoint has none.
+	if len(ep.DeployedModels) == 0 {
+		return nil, errors.Newf(errors.FailedPrecondition,
+			"Endpoint %q does not have any deployed models", req.Endpoint)
+	}
+
 	m.emitMetric("prediction/count", float64(len(req.Instances)), map[string]string{"endpoint": req.Endpoint})
 
-	resp := &driver.PredictResponse{Predictions: append([]any{}, req.Instances...)}
-	if len(ep.DeployedModels) > 0 {
-		resp.DeployedModelID = ep.DeployedModels[0].ID
-		resp.Model = ep.DeployedModels[0].Model
-		resp.ModelDisplayName = ep.DeployedModels[0].DisplayName
+	resp := &driver.PredictResponse{
+		Predictions:      append([]any{}, req.Instances...),
+		DeployedModelID:  ep.DeployedModels[0].ID,
+		Model:            ep.DeployedModels[0].Model,
+		ModelDisplayName: ep.DeployedModels[0].DisplayName,
 	}
 
 	return resp, nil

--- a/providers/gcp/vertexai/vertexai_test.go
+++ b/providers/gcp/vertexai/vertexai_test.go
@@ -45,7 +45,10 @@ func TestEndpointDeployAndPredict(t *testing.T) {
 	_, ep, err := m.CreateEndpoint(ctx, driver.EndpointConfig{Location: "us-central1", DisplayName: "ep"})
 	require.NoError(t, err)
 
-	_, _, err = m.DeployModel(ctx, ep.Name, driver.DeployedModel{Model: "projects/proj/locations/us-central1/models/m", DisplayName: "v1"})
+	_, model, err := m.UploadModel(ctx, driver.ModelConfig{Location: "us-central1", DisplayName: "m"})
+	require.NoError(t, err)
+
+	_, _, err = m.DeployModel(ctx, ep.Name, driver.DeployedModel{Model: model.Name, DisplayName: "v1"})
 	require.NoError(t, err)
 
 	got, err := m.GetEndpoint(ctx, ep.Name)
@@ -212,10 +215,15 @@ func TestDeployModelKeepsTrafficForAllModels(t *testing.T) {
 	_, ep, err := m.CreateEndpoint(ctx, driver.EndpointConfig{Location: "us-central1", DisplayName: "ep"})
 	require.NoError(t, err)
 
-	_, _, err = m.DeployModel(ctx, ep.Name, driver.DeployedModel{ID: "A", Model: "m/A"})
+	_, modelA, err := m.UploadModel(ctx, driver.ModelConfig{Location: "us-central1", DisplayName: "A"})
+	require.NoError(t, err)
+	_, modelB, err := m.UploadModel(ctx, driver.ModelConfig{Location: "us-central1", DisplayName: "B"})
 	require.NoError(t, err)
 
-	_, after, err := m.DeployModel(ctx, ep.Name, driver.DeployedModel{ID: "B", Model: "m/B"})
+	_, _, err = m.DeployModel(ctx, ep.Name, driver.DeployedModel{ID: "A", Model: modelA.Name})
+	require.NoError(t, err)
+
+	_, after, err := m.DeployModel(ctx, ep.Name, driver.DeployedModel{ID: "B", Model: modelB.Name})
 	require.NoError(t, err)
 
 	require.Len(t, after.DeployedModels, 2)

--- a/server/gcp/cloudasset/handler.go
+++ b/server/gcp/cloudasset/handler.go
@@ -210,7 +210,7 @@ func (h *Handler) serveCustomMethod(w http.ResponseWriter, r *http.Request, scop
 
 // ----- searchAllResources -----
 
-func (h *Handler) searchAllResources(w http.ResponseWriter, r *http.Request, _ string) {
+func (h *Handler) searchAllResources(w http.ResponseWriter, r *http.Request, scope string) {
 	// Real Cloud Asset takes filter as a query param OR body field. Support
 	// both; body wins if both supplied.
 	body := readJSONBody(r)
@@ -235,15 +235,7 @@ func (h *Handler) searchAllResources(w http.ResponseWriter, r *http.Request, _ s
 		return
 	}
 
-	out := make([]map[string]any, 0, len(results))
-	for i := range results {
-		res := resourceToSearchResult(&results[i], h.projectID)
-		if !matchesAssetTypes(res["assetType"], assetTypes) {
-			continue
-		}
-
-		out = append(out, res)
-	}
+	out := h.formatSearchResults(results, scope, assetTypes)
 
 	// Offset-based pagination: pageToken carries the next start index.
 	start := decodePageToken(strParam(r, body, "pageToken"))
@@ -333,7 +325,9 @@ func (h *Handler) exportAssets(w http.ResponseWriter, r *http.Request, scope str
 		}
 	}
 
-	op := h.buildAndCacheExportOperation(scope, results)
+	outputConfig, _ := body["outputConfig"].(map[string]any)
+
+	op := h.buildAndCacheExportOperation(scope, results, outputConfig)
 	writeJSON(w, http.StatusOK, op)
 }
 
@@ -341,13 +335,15 @@ func (h *Handler) exportAssets(w http.ResponseWriter, r *http.Request, scope str
 // its name so a subsequent Operations.Get can find it. The operation is
 // scope-prefixed (projects/X/operations/cloudemu-export-...) so the path
 // matcher in ServeHTTP routes the poll back to this handler.
-func (h *Handler) buildAndCacheExportOperation(scope string, results []resourcediscovery.Resource) map[string]any {
+func (h *Handler) buildAndCacheExportOperation(
+	scope string, results []resourcediscovery.Resource, outputConfig map[string]any,
+) map[string]any {
 	if scope == "" {
 		scope = "projects/" + h.projectID
 	}
 
 	name := scope + "/operations/" + operationNamePrefix + strconv.FormatInt(time.Now().UnixNano(), 10)
-	op := completedExportOperation(name, results)
+	op := completedExportOperation(name, results, outputConfig)
 
 	h.mu.Lock()
 	h.operations[name] = op
@@ -362,10 +358,29 @@ func (h *Handler) buildAndCacheExportOperation(scope string, results []resourced
 // asset list inline so most callers (which call .Do() and check Done)
 // work without polling, AND caches the response under name so callers
 // that DO poll via Operations.Get find a matching entry.
-func completedExportOperation(name string, results []resourcediscovery.Resource) map[string]any {
+func completedExportOperation(
+	name string, results []resourcediscovery.Resource, outputConfig map[string]any,
+) map[string]any {
 	assets := make([]map[string]any, 0, len(results))
 	for i := range results {
 		assets = append(assets, resourceToAsset(&results[i]))
+	}
+
+	response := map[string]any{
+		"@type":    "type.googleapis.com/google.cloud.asset.v1.ExportAssetsResponse",
+		"readTime": time.Now().UTC().Format(time.RFC3339Nano),
+		"assets":   assets,
+	}
+
+	// Reflect the caller's requested destination instead of a fixed
+	// placeholder: real Cloud Asset echoes the outputConfig and reports the
+	// written location in outputResult.
+	if outputConfig != nil {
+		response["outputConfig"] = outputConfig
+
+		if res := exportOutputResult(outputConfig); res != nil {
+			response["outputResult"] = res
+		}
 	}
 
 	return map[string]any{
@@ -374,13 +389,34 @@ func completedExportOperation(name string, results []resourcediscovery.Resource)
 		"metadata": map[string]any{
 			"@type": "type.googleapis.com/google.cloud.asset.v1.ExportAssetsRequest",
 		},
-		"response": map[string]any{
-			"@type":           "type.googleapis.com/google.cloud.asset.v1.ExportAssetsResponse",
-			"readTime":        time.Now().UTC().Format(time.RFC3339Nano),
-			"assets":          assets,
-			"outputUriPrefix": "cloudemu://in-memory",
-		},
+		"response": response,
 	}
+}
+
+// exportOutputResult derives the ExportAssetsResponse.outputResult from the
+// requested outputConfig: a GCS destination reports the written object uri(s),
+// a BigQuery destination reports the target dataset.
+func exportOutputResult(outputConfig map[string]any) map[string]any {
+	if gcs, ok := outputConfig["gcsDestination"].(map[string]any); ok {
+		uri := strOrEmpty(gcs["uri"])
+		if uri == "" {
+			// A uriPrefix destination lands one object per asset type; report
+			// the prefix as the written location.
+			uri = strOrEmpty(gcs["uriPrefix"])
+		}
+
+		if uri != "" {
+			return map[string]any{"gcsResult": map[string]any{"uriList": []string{uri}}}
+		}
+	}
+
+	if bq, ok := outputConfig["bigqueryDestination"].(map[string]any); ok {
+		if dataset := strOrEmpty(bq["dataset"]); dataset != "" {
+			return map[string]any{"bigqueryResult": map[string]any{"dataset": dataset}}
+		}
+	}
+
+	return nil
 }
 
 // getOperation serves Operations.Get for export operations cached by an
@@ -733,13 +769,77 @@ func nowRFC() string {
 	return time.Now().UTC().Format(time.RFC3339Nano)
 }
 
+// scopeProject extracts the project id from a "projects/{p}" scope. It returns
+// "" for folder/organization scopes (or a malformed scope), signaling the
+// caller to fall back to the handler's default project.
+func scopeProject(scope string) string {
+	const prefix = "projects/"
+	if !strings.HasPrefix(scope, prefix) {
+		return ""
+	}
+
+	rest := strings.TrimPrefix(scope, prefix)
+	if rest == "" || strings.ContainsRune(rest, '/') {
+		return ""
+	}
+
+	return rest
+}
+
+// formatSearchResults rescopes each result to the queried scope's project and
+// filters by assetType. Real Cloud Asset reports asset names under the
+// requested scope, not a fixed default project.
+func (h *Handler) formatSearchResults(
+	results []resourcediscovery.Resource, scope string, assetTypes []string,
+) []map[string]any {
+	target := scopeProject(scope)
+	arnProject := h.arnProject()
+
+	displayProject := h.projectID
+	if target != "" {
+		displayProject = target
+	}
+
+	out := make([]map[string]any, 0, len(results))
+
+	for i := range results {
+		res := resourceToSearchResult(&results[i], arnProject, target, displayProject)
+		if matchesAssetTypes(res["assetType"], assetTypes) {
+			out = append(out, res)
+		}
+	}
+
+	return out
+}
+
+// arnProject is the project id embedded in the engine's GCP self-links
+// (idgen.GCPID uses the engine account id). It is the segment rescopeName must
+// rewrite; it falls back to the handler's configured project.
+func (h *Handler) arnProject() string {
+	if h.engine != nil {
+		if id := h.engine.AccountID(); id != "" {
+			return id
+		}
+	}
+
+	return h.projectID
+}
+
 // resourceToSearchResult formats one Resource for the searchAllResources
-// response. GCP uses a "name" of //service/path.
-func resourceToSearchResult(r *resourcediscovery.Resource, project string) map[string]any {
+// response. GCP uses a "name" of //service/path. When target is a non-empty
+// project distinct from the one embedded in the asset self-link (arnProject),
+// the asset name is rescoped to it so results reflect the queried scope;
+// displayProject is reported verbatim in the "project" field.
+func resourceToSearchResult(r *resourcediscovery.Resource, arnProject, target, displayProject string) map[string]any {
+	name := gcpResourceName(r)
+	if target != "" && target != arnProject {
+		name = strings.ReplaceAll(name, "projects/"+arnProject+"/", "projects/"+target+"/")
+	}
+
 	return map[string]any{
-		"name":        gcpResourceName(r),
+		"name":        name,
 		"assetType":   portableToGCPAssetType(r.Service, r.Type),
-		"project":     "projects/" + project,
+		"project":     "projects/" + displayProject,
 		"location":    r.Region,
 		"displayName": r.ID,
 		"labels":      labelsOrEmpty(r.Tags),

--- a/server/gcp/cloudasset/sdk_test.go
+++ b/server/gcp/cloudasset/sdk_test.go
@@ -228,6 +228,82 @@ func TestSDKCloudAsset(t *testing.T) {
 	})
 }
 
+// TestSDKCloudAssetScopeRespected pins the scope fix: searchAllResources reports
+// asset names and the project field under the queried scope, not a fixed
+// default project.
+func TestSDKCloudAssetScopeRespected(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewGCP()
+
+	_, _, err := cloudP.GKE.CreateCluster(ctx, &gke.CreateClusterInput{Name: "prod", Location: "us-central1"})
+	require.NoError(t, err)
+
+	// No ProjectID override: the handler's project == the engine account id, so
+	// asset self-links embed that project.
+	srv := gcpserver.New(gcpserver.Drivers{
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := cloudasset.NewService(ctx, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	engineProject := cloudP.ResourceDiscovery.AccountID()
+	require.NotEmpty(t, engineProject)
+
+	const queried = "audit-proj"
+
+	out, err := client.V1.SearchAllResources("projects/" + queried).
+		Query("assetType:container.googleapis.com/Cluster").Do()
+	require.NoError(t, err)
+	require.NotEmpty(t, out.Results)
+
+	for _, r := range out.Results {
+		assert.Equal(t, "projects/"+queried, r.Project, "project field must reflect the queried scope")
+		assert.Contains(t, r.Name, "projects/"+queried+"/", "asset name must be rescoped to the queried project")
+		assert.NotContains(t, r.Name, "projects/"+engineProject+"/",
+			"asset name must not leak the engine's default project")
+	}
+}
+
+// TestSDKCloudAssetExportOutputConfig pins the export fix: the requested
+// outputConfig is reflected in the operation response instead of a fixed
+// placeholder.
+func TestSDKCloudAssetExportOutputConfig(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewGCP()
+	const projectID = "export-proj"
+
+	require.NoError(t, cloudP.GCS.CreateBucket(ctx, "bkt"))
+
+	srv := gcpserver.New(gcpserver.Drivers{
+		Storage:           cloudP.GCS,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		ProjectID:         projectID,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := cloudasset.NewService(ctx, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	const uri = "gs://my-export-bucket/dump.json"
+
+	op, err := client.V1.ExportAssets("projects/"+projectID, &cloudasset.ExportAssetsRequest{
+		OutputConfig: &cloudasset.OutputConfig{
+			GcsDestination: &cloudasset.GcsDestination{Uri: uri},
+		},
+	}).Do()
+	require.NoError(t, err)
+	require.True(t, op.Done)
+	require.NotNil(t, op.Response)
+
+	// The response must carry the caller's destination, not "cloudemu://in-memory".
+	assert.Contains(t, string(op.Response), uri)
+	assert.NotContains(t, string(op.Response), "cloudemu://in-memory")
+}
+
 // TestSDKCloudAsset_KubernetesIndexing mirrors the Databricks/Azure precedent
 // for the GKE types added in this PR: a cluster and its node pool must be
 // retrievable through the real Cloud Asset search/list handler, and an

--- a/server/gcp/eventarc/handler.go
+++ b/server/gcp/eventarc/handler.go
@@ -34,7 +34,8 @@
 //
 //	POST   /v1/projects/{p}/locations/{l}/triggers?triggerId={id}   — Create (LRO, done inline)
 //	GET    /v1/projects/{p}/locations/{l}/triggers/{id}             — Get
-//	GET    /v1/projects/{p}/locations/{l}/triggers                  — List
+//	GET    /v1/projects/{p}/locations/{l}/triggers                  — List (paginated)
+//	PATCH  /v1/projects/{p}/locations/{l}/triggers/{id}?updateMask= — Update (LRO, done inline)
 //	DELETE /v1/projects/{p}/locations/{l}/triggers/{id}             — Delete (LRO, done inline)
 package eventarc
 
@@ -152,6 +153,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		h.getTrigger(w, r, &rt)
+	case http.MethodPatch:
+		h.patchTrigger(w, r, &rt)
 	case http.MethodDelete:
 		h.deleteTrigger(w, r, &rt)
 	default:

--- a/server/gcp/eventarc/operations.go
+++ b/server/gcp/eventarc/operations.go
@@ -3,8 +3,12 @@ package eventarc
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	"github.com/stackshy/cloudemu/v2/services/scope"
@@ -19,6 +23,13 @@ func (h *Handler) createTrigger(w http.ResponseWriter, r *http.Request, rt *rout
 
 	var body triggerJSON
 	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	// A trigger must route somewhere. Real Eventarc rejects a trigger with no
+	// destination with INVALID_ARGUMENT rather than storing a dead route.
+	if _, ok := destinationTarget(body.Destination); !ok {
+		gcprest.WriteError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "destination is required")
 		return
 	}
 
@@ -40,20 +51,26 @@ func (h *Handler) createTrigger(w http.ResponseWriter, r *http.Request, rt *rout
 		Name:         triggerID,
 		EventBus:     bus,
 		EventPattern: encodeEventPattern(body.EventFilters),
-		Description:  encodeTriggerMeta(body.ServiceAccount, body.Labels),
+		Description: encodeTriggerMeta(triggerMeta{
+			ServiceAccount: body.ServiceAccount,
+			Labels:         body.Labels,
+			UID:            idgen.GenerateID("trigger-"),
+		}),
 	}); err != nil {
 		gcprest.WriteCErr(w, err)
 		return
 	}
 
-	if target, ok := destinationTarget(body.Destination); ok {
-		if perr := h.bus.PutTargets(r.Context(), bus, triggerID, []ebdriver.Target{target}); perr != nil {
-			// Roll back the rule created above so a failed Create doesn't leave
-			// an orphaned trigger that blocks a later Create with the same id.
-			_ = h.bus.DeleteRule(r.Context(), bus, triggerID)
-			gcprest.WriteCErr(w, perr)
-			return
-		}
+	target, _ := destinationTarget(body.Destination)
+
+	if perr := h.bus.PutTargets(r.Context(), bus, triggerID, []ebdriver.Target{target}); perr != nil {
+		// Roll back the rule created above so a failed Create doesn't leave
+		// an orphaned trigger that blocks a later Create with the same id.
+		_ = h.bus.DeleteRule(r.Context(), bus, triggerID)
+
+		gcprest.WriteCErr(w, perr)
+
+		return
 	}
 
 	// Re-fetch so the response carries the stored targets/destination.
@@ -116,12 +133,42 @@ func (h *Handler) listTriggers(w http.ResponseWriter, r *http.Request, rt *route
 		return
 	}
 
-	out := make([]triggerJSON, 0, len(rules))
-	for i := range rules {
-		out = append(out, toTriggerJSON(rt.project, rt.location, &rules[i]))
+	page, perr := pagination.PaginateSorted(rules,
+		func(a, b ebdriver.Rule) bool { return a.Name < b.Name },
+		r.URL.Query().Get("pageToken"), triggerPageSize(r))
+	if perr != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid pageToken")
+		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, listTriggersResponse{Triggers: out})
+	out := make([]triggerJSON, 0, len(page.Items))
+	for i := range page.Items {
+		out = append(out, toTriggerJSON(rt.project, rt.location, &page.Items[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listTriggersResponse{
+		Triggers:      out,
+		NextPageToken: page.NextPageToken,
+	})
+}
+
+const (
+	defaultTriggerPageSize = 50
+	maxTriggerPageSize     = 1000
+)
+
+// triggerPageSize reads ?pageSize, clamping to a sane default and ceiling.
+func triggerPageSize(r *http.Request) int {
+	n, err := strconv.Atoi(r.URL.Query().Get("pageSize"))
+	if err != nil || n <= 0 {
+		return defaultTriggerPageSize
+	}
+
+	if n > maxTriggerPageSize {
+		return maxTriggerPageSize
+	}
+
+	return n
 }
 
 func (h *Handler) deleteTrigger(w http.ResponseWriter, r *http.Request, rt *route) {
@@ -131,6 +178,113 @@ func (h *Handler) deleteTrigger(w http.ResponseWriter, r *http.Request, rt *rout
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt, rt.trigger, nil))
+}
+
+// patchTrigger applies an updateTrigger call. Only the fields named in
+// ?updateMask are changed (an empty mask updates every field present in the
+// body); uid and createTime are preserved. Real Eventarc supports patching the
+// destination, event filters, service account, and labels.
+func (h *Handler) patchTrigger(w http.ResponseWriter, r *http.Request, rt *route) {
+	bus := channelName(rt.location)
+
+	existing, err := h.bus.GetRule(r.Context(), bus, rt.trigger)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	var body triggerJSON
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	mask := parseUpdateMask(r.URL.Query().Get("updateMask"))
+	cur := toTriggerJSON(rt.project, rt.location, existing)
+	meta := decodeTriggerMeta(existing.Description)
+
+	if mask.has("eventFilters") {
+		cur.EventFilters = body.EventFilters
+	}
+
+	if mask.has("serviceAccount") {
+		meta.ServiceAccount = body.ServiceAccount
+	}
+
+	if mask.has("labels") {
+		meta.Labels = body.Labels
+	}
+
+	if mask.has("destination") {
+		if _, ok := destinationTarget(body.Destination); !ok {
+			gcprest.WriteError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "destination is required")
+			return
+		}
+
+		cur.Destination = body.Destination
+	}
+
+	meta.Revision++
+
+	if perr := h.applyTriggerUpdate(r, rt, &cur, meta); perr != nil {
+		gcprest.WriteCErr(w, perr)
+		return
+	}
+
+	stored, gerr := h.bus.GetRule(r.Context(), bus, rt.trigger)
+	if gerr != nil {
+		gcprest.WriteCErr(w, gerr)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt, rt.trigger,
+		typedResponse(triggerTypeURL, toTriggerJSON(rt.project, rt.location, stored))))
+}
+
+// applyTriggerUpdate persists the mutated trigger back onto the driver rule and
+// its targets.
+func (h *Handler) applyTriggerUpdate(r *http.Request, rt *route, cur *triggerJSON, meta triggerMeta) error {
+	bus := channelName(rt.location)
+
+	if _, err := h.bus.PutRule(r.Context(), &ebdriver.RuleConfig{
+		Name:         rt.trigger,
+		EventBus:     bus,
+		EventPattern: encodeEventPattern(cur.EventFilters),
+		Description:  encodeTriggerMeta(meta),
+	}); err != nil {
+		return err
+	}
+
+	target, _ := destinationTarget(cur.Destination)
+
+	return h.bus.PutTargets(r.Context(), bus, rt.trigger, []ebdriver.Target{target})
+}
+
+// updateMask is a parsed FieldMask: an empty mask means "update every field
+// present in the body".
+type updateMask struct {
+	fields map[string]bool
+	all    bool
+}
+
+func (m updateMask) has(field string) bool {
+	return m.all || m.fields[field]
+}
+
+func parseUpdateMask(raw string) updateMask {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "*" {
+		return updateMask{all: true}
+	}
+
+	fields := map[string]bool{}
+
+	for _, f := range strings.Split(raw, ",") {
+		if f = strings.TrimSpace(f); f != "" {
+			fields[f] = true
+		}
+	}
+
+	return updateMask{fields: fields}
 }
 
 // ensureChannel creates the location's backing event bus if it does not already

--- a/server/gcp/eventarc/sdk_roundtrip_test.go
+++ b/server/gcp/eventarc/sdk_roundtrip_test.go
@@ -190,3 +190,142 @@ func TestSDKEventarcErrors(t *testing.T) {
 		t.Fatalf("duplicate Create: got %v, want 409", err)
 	}
 }
+
+// TestSDKEventarcMissingDestination: a trigger with no destination is a 400
+// INVALID_ARGUMENT, not a silently-stored dead route.
+func TestSDKEventarcMissingDestination(t *testing.T) {
+	svc := newEventarcService(t)
+	ctx := context.Background()
+
+	trigger := &eventarc.Trigger{
+		EventFilters: []*eventarc.EventFilter{{Attribute: "type", Value: "google.cloud.storage.object.v1.finalized"}},
+	}
+
+	_, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).
+		TriggerId("no-dest").Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 400 {
+		t.Fatalf("Create(no destination): got %v, want 400", err)
+	}
+}
+
+// TestSDKEventarcServerFields: create assigns a uid, etag, and an
+// auto-provisioned Pub/Sub transport topic that round-trip on Get.
+func TestSDKEventarcServerFields(t *testing.T) {
+	svc := newEventarcService(t)
+	ctx := context.Background()
+
+	trigger := &eventarc.Trigger{
+		EventFilters: []*eventarc.EventFilter{{Attribute: "type", Value: "google.cloud.storage.object.v1.finalized"}},
+		Destination:  &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "svc", Region: testLocation}},
+	}
+
+	if _, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).
+		TriggerId("fields").Context(ctx).Do(); err != nil {
+		t.Fatalf("Triggers.Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Triggers.Get(parent() + "/triggers/fields").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Triggers.Get: %v", err)
+	}
+
+	if got.Uid == "" {
+		t.Error("uid empty, want a server-assigned uid")
+	}
+
+	if got.Etag == "" {
+		t.Error("etag empty, want a server-assigned etag")
+	}
+
+	if got.Transport == nil || got.Transport.Pubsub == nil || got.Transport.Pubsub.Topic == "" {
+		t.Fatalf("transport = %+v, want an auto-provisioned pubsub topic", got.Transport)
+	}
+}
+
+// TestSDKEventarcPatch: updateTrigger changes the destination (and etag) via the
+// updateMask, previously a 404.
+func TestSDKEventarcPatch(t *testing.T) {
+	svc := newEventarcService(t)
+	ctx := context.Background()
+
+	trigger := &eventarc.Trigger{
+		EventFilters: []*eventarc.EventFilter{{Attribute: "type", Value: "google.cloud.storage.object.v1.finalized"}},
+		Destination:  &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "old", Region: testLocation}},
+	}
+
+	if _, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).
+		TriggerId("patch-me").Context(ctx).Do(); err != nil {
+		t.Fatalf("Triggers.Create: %v", err)
+	}
+
+	name := parent() + "/triggers/patch-me"
+
+	before, err := svc.Projects.Locations.Triggers.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Triggers.Get (before): %v", err)
+	}
+
+	upd := &eventarc.Trigger{
+		Destination: &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "new", Region: testLocation}},
+	}
+
+	op, err := svc.Projects.Locations.Triggers.Patch(name, upd).
+		UpdateMask("destination").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Triggers.Patch: %v", err)
+	}
+
+	if !op.Done {
+		t.Fatalf("Patch operation not done: %+v", op)
+	}
+
+	after, err := svc.Projects.Locations.Triggers.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Triggers.Get (after): %v", err)
+	}
+
+	if after.Destination == nil || after.Destination.CloudRun == nil || after.Destination.CloudRun.Service != "new" {
+		t.Fatalf("destination = %+v, want cloudRun service new", after.Destination)
+	}
+
+	if after.Etag == before.Etag {
+		t.Errorf("etag unchanged after patch: %q", after.Etag)
+	}
+}
+
+// TestSDKEventarcListPagination: pageSize splits the results and a pageToken
+// walks to the next page.
+func TestSDKEventarcListPagination(t *testing.T) {
+	svc := newEventarcService(t)
+	ctx := context.Background()
+
+	for _, id := range []string{"a", "b", "c"} {
+		tr := &eventarc.Trigger{
+			Destination: &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "s", Region: testLocation}},
+		}
+		if _, err := svc.Projects.Locations.Triggers.Create(parent(), tr).TriggerId(id).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create(%s): %v", id, err)
+		}
+	}
+
+	first, err := svc.Projects.Locations.Triggers.List(parent()).PageSize(2).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List(page 1): %v", err)
+	}
+
+	if len(first.Triggers) != 2 || first.NextPageToken == "" {
+		t.Fatalf("page 1 = %d triggers, token=%q; want 2 + a continuation token", len(first.Triggers), first.NextPageToken)
+	}
+
+	second, err := svc.Projects.Locations.Triggers.List(parent()).
+		PageSize(2).PageToken(first.NextPageToken).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List(page 2): %v", err)
+	}
+
+	if len(second.Triggers) != 1 {
+		t.Fatalf("page 2 = %d triggers, want 1", len(second.Triggers))
+	}
+}

--- a/server/gcp/eventarc/types.go
+++ b/server/gcp/eventarc/types.go
@@ -2,7 +2,10 @@ package eventarc
 
 import (
 	"encoding/json"
+	"fmt"
+	"hash/fnv"
 
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 )
 
@@ -39,10 +42,22 @@ type triggerJSON struct {
 	EventFilters   []eventFilterJSON `json:"eventFilters,omitempty"`
 	ServiceAccount string            `json:"serviceAccount,omitempty"`
 	Destination    *destinationJSON  `json:"destination,omitempty"`
+	Transport      *transportJSON    `json:"transport,omitempty"`
 	Labels         map[string]string `json:"labels,omitempty"`
 	CreateTime     string            `json:"createTime,omitempty"`
 	UpdateTime     string            `json:"updateTime,omitempty"`
 	UID            string            `json:"uid,omitempty"`
+	Etag           string            `json:"etag,omitempty"`
+}
+
+// transportJSON is the Eventarc v1 Transport shape. Every trigger is backed by
+// an auto-provisioned Pub/Sub topic.
+type transportJSON struct {
+	Pubsub *pubsubTransportJSON `json:"pubsub,omitempty"`
+}
+
+type pubsubTransportJSON struct {
+	Topic string `json:"topic,omitempty"`
 }
 
 type listTriggersResponse struct {
@@ -156,17 +171,41 @@ func destinationSummary(dest *destinationJSON) string {
 
 // toTriggerJSON converts a driver rule into its Eventarc Trigger element.
 func toTriggerJSON(project, location string, rule *ebdriver.Rule) triggerJSON {
-	sa, labels := decodeTriggerMeta(rule.Description)
+	meta := decodeTriggerMeta(rule.Description)
 
 	return triggerJSON{
 		Name:           triggerResourceName(project, location, rule.Name),
 		EventFilters:   decodeEventPattern(rule.EventPattern),
 		Destination:    destinationFromTargets(rule.Targets),
-		ServiceAccount: sa,
-		Labels:         labels,
+		Transport:      transportFor(project, location, rule.Name),
+		ServiceAccount: meta.ServiceAccount,
+		Labels:         meta.Labels,
 		CreateTime:     rule.CreatedAt,
 		UpdateTime:     rule.CreatedAt,
+		UID:            meta.UID,
+		Etag:           computeEtag(meta.UID, meta.Revision),
 	}
+}
+
+// transportFor synthesizes the auto-provisioned Pub/Sub transport a real
+// Eventarc trigger carries.
+func transportFor(project, location, trigger string) *transportJSON {
+	topic := idgen.GCPID(project, "topics", "eventarc-"+location+"-"+trigger)
+
+	return &transportJSON{Pubsub: &pubsubTransportJSON{Topic: topic}}
+}
+
+// computeEtag derives a stable, opaque etag from the trigger's uid and its
+// revision, so it changes whenever the trigger is patched.
+func computeEtag(uid string, revision int) string {
+	if uid == "" {
+		return ""
+	}
+
+	h := fnv.New64a()
+	_, _ = fmt.Fprintf(h, "%s|%d", uid, revision)
+
+	return fmt.Sprintf("%016x", h.Sum64())
 }
 
 // triggerMeta holds the Eventarc fields the eventbus Rule can't store natively;
@@ -174,14 +213,16 @@ func toTriggerJSON(project, location string, rule *ebdriver.Rule) triggerJSON {
 type triggerMeta struct {
 	ServiceAccount string            `json:"serviceAccount,omitempty"`
 	Labels         map[string]string `json:"labels,omitempty"`
+	UID            string            `json:"uid,omitempty"`
+	Revision       int               `json:"revision,omitempty"`
 }
 
-func encodeTriggerMeta(sa string, labels map[string]string) string {
-	if sa == "" && len(labels) == 0 {
+func encodeTriggerMeta(m triggerMeta) string {
+	if m.ServiceAccount == "" && len(m.Labels) == 0 && m.UID == "" && m.Revision == 0 {
 		return ""
 	}
 
-	b, err := json.Marshal(triggerMeta{ServiceAccount: sa, Labels: labels})
+	b, err := json.Marshal(m)
 	if err != nil {
 		return ""
 	}
@@ -189,15 +230,15 @@ func encodeTriggerMeta(sa string, labels map[string]string) string {
 	return string(b)
 }
 
-func decodeTriggerMeta(s string) (serviceAccount string, labels map[string]string) {
+func decodeTriggerMeta(s string) triggerMeta {
 	if s == "" {
-		return "", nil
+		return triggerMeta{}
 	}
 
 	var m triggerMeta
 	if err := json.Unmarshal([]byte(s), &m); err != nil {
-		return "", nil
+		return triggerMeta{}
 	}
 
-	return m.ServiceAccount, m.Labels
+	return m
 }

--- a/server/gcp/fcm/operations.go
+++ b/server/gcp/fcm/operations.go
@@ -50,20 +50,7 @@ func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request, rt route) 
 		return
 	}
 
-	// FCM requires exactly one target — token, topic, or condition. Reject a
-	// message that sets more than one (real FCM returns INVALID_ARGUMENT).
-	targets := 0
-
-	for _, t := range []string{body.Message.Token, body.Message.Topic, body.Message.Condition} {
-		if t != "" {
-			targets++
-		}
-	}
-
-	if targets > 1 {
-		gcprest.WriteError(w, http.StatusBadRequest, "invalid",
-			"exactly one of token, topic, condition may be set")
-
+	if !validTarget(w, body.Message) {
 		return
 	}
 
@@ -114,6 +101,35 @@ func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request, rt route) 
 	gcprest.WriteJSON(w, http.StatusOK, messageResponse{
 		Name: "projects/" + rt.project + "/messages/" + out.MessageID,
 	})
+}
+
+// validTarget enforces FCM's "exactly one of token, topic, condition" rule.
+// On violation it writes a 400 INVALID_ARGUMENT and returns false; real FCM
+// rejects a message that names none or more than one target.
+func validTarget(w http.ResponseWriter, m *fcmMessage) bool {
+	targets := 0
+
+	for _, t := range []string{m.Token, m.Topic, m.Condition} {
+		if t != "" {
+			targets++
+		}
+	}
+
+	if targets == 0 {
+		gcprest.WriteError(w, http.StatusBadRequest, "INVALID_ARGUMENT",
+			"exactly one of token, topic, condition is required")
+
+		return false
+	}
+
+	if targets > 1 {
+		gcprest.WriteError(w, http.StatusBadRequest, "INVALID_ARGUMENT",
+			"exactly one of token, topic, condition may be set")
+
+		return false
+	}
+
+	return true
 }
 
 // ensureTopic creates the target topic if it does not already exist. Errors

--- a/server/gcp/fcm/sdk_roundtrip_test.go
+++ b/server/gcp/fcm/sdk_roundtrip_test.go
@@ -102,4 +102,14 @@ func TestSDKFCMSendErrors(t *testing.T) {
 	if !errors.As(err, &gerr) || gerr.Code != 400 {
 		t.Fatalf("Send(multi-target): got %v, want 400", err)
 	}
+
+	// A message with NO target (none of token/topic/condition) is
+	// INVALID_ARGUMENT — real FCM requires exactly one.
+	_, err = svc.Projects.Messages.Send("projects/"+testProject, &fcm.SendMessageRequest{
+		Message: &fcm.Message{Notification: &fcm.Notification{Title: "hi", Body: "there"}},
+	}).Context(ctx).Do()
+
+	if !errors.As(err, &gerr) || gerr.Code != 400 {
+		t.Fatalf("Send(no-target): got %v, want 400", err)
+	}
 }

--- a/server/gcp/vertexai/endpoints.go
+++ b/server/gcp/vertexai/endpoints.go
@@ -5,15 +5,36 @@ import (
 	"io"
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/vertexai/driver"
 )
 
+func deployedModelJSON(d *driver.DeployedModel) map[string]any {
+	out := map[string]any{
+		"id": d.ID, "model": d.Model, "displayName": d.DisplayName,
+	}
+
+	if d.CreateTime != "" {
+		out["createTime"] = d.CreateTime
+	}
+
+	// Surface dedicatedResources when the deployment supplied a machine spec or
+	// replica counts, so callers reading the endpoint see what they deployed.
+	if d.MachineType != "" || d.MinReplicaCount != 0 || d.MaxReplicaCount != 0 {
+		out["dedicatedResources"] = map[string]any{
+			"machineSpec":     map[string]any{"machineType": d.MachineType},
+			"minReplicaCount": d.MinReplicaCount,
+			"maxReplicaCount": d.MaxReplicaCount,
+		}
+	}
+
+	return out
+}
+
 func endpointJSON(e *driver.Endpoint) map[string]any {
 	dms := make([]map[string]any, 0, len(e.DeployedModels))
-	for _, d := range e.DeployedModels {
-		dms = append(dms, map[string]any{
-			"id": d.ID, "model": d.Model, "displayName": d.DisplayName,
-		})
+	for i := range e.DeployedModels {
+		dms = append(dms, deployedModelJSON(&e.DeployedModels[i]))
 	}
 
 	traffic := map[string]any{}
@@ -183,8 +204,7 @@ func (h *Handler) deployModel(w http.ResponseWriter, r *http.Request, endpoint s
 	var deployed map[string]any
 
 	if n := len(ep.DeployedModels); n > 0 {
-		d := ep.DeployedModels[n-1]
-		deployed = map[string]any{"id": d.ID, "model": d.Model, "displayName": d.DisplayName}
+		deployed = deployedModelJSON(&ep.DeployedModels[n-1])
 	}
 
 	writeResourceOp(w, op, map[string]any{"deployedModel": deployed}, "DeployModelResponse")
@@ -223,6 +243,15 @@ func (h *Handler) predict(w http.ResponseWriter, r *http.Request, endpoint strin
 		Endpoint: endpoint, Instances: req.Instances, Parameters: req.Parameters,
 	})
 	if err != nil {
+		// Real Vertex AI returns HTTP 400 FAILED_PRECONDITION when the endpoint
+		// has no deployed models; the shared codec maps FailedPrecondition to 409,
+		// so surface the 400 here to match the wire contract.
+		if cerrors.IsFailedPrecondition(err) {
+			writeError(w, http.StatusBadRequest, "FAILED_PRECONDITION", err.Error())
+
+			return
+		}
+
 		writeCErr(w, err)
 
 		return

--- a/server/gcp/vertexai/sdk_roundtrip_test.go
+++ b/server/gcp/vertexai/sdk_roundtrip_test.go
@@ -95,18 +95,89 @@ func TestEndpointDeployPredict(t *testing.T) {
 	epName := op["response"].(map[string]any)["name"].(string)
 	require.NotEmpty(t, epName)
 
-	do(t, http.MethodPost, url+"/v1/"+epName+":deployModel", map[string]any{
-		"deployedModel": map[string]any{"model": base + "/models/m", "displayName": "v1"},
+	// A model must be uploaded before it can be deployed.
+	mop := do(t, http.MethodPost, url+base+"/models:upload", map[string]any{
+		"model": map[string]any{"displayName": "m", "containerSpec": map[string]any{"imageUri": "img:latest"}},
 	})
+	modelName := mop["response"].(map[string]any)["name"].(string)
+	require.NotEmpty(t, modelName)
+
+	dep := do(t, http.MethodPost, url+"/v1/"+epName+":deployModel", map[string]any{
+		"deployedModel": map[string]any{
+			"model": modelName, "displayName": "v1",
+			"dedicatedResources": map[string]any{
+				"machineSpec":     map[string]any{"machineType": "n1-standard-4"},
+				"minReplicaCount": 2, "maxReplicaCount": 5,
+			},
+		},
+	})
+	// The deployModel response echoes the deployed model with its dedicatedResources.
+	deployed := dep["response"].(map[string]any)["deployedModel"].(map[string]any)
+	assert.NotEmpty(t, deployed["createTime"])
+	dr := deployed["dedicatedResources"].(map[string]any)
+	assert.EqualValues(t, 2, dr["minReplicaCount"])
+	assert.Equal(t, "n1-standard-4", dr["machineSpec"].(map[string]any)["machineType"])
 
 	got := do(t, http.MethodGet, url+"/v1/"+epName, nil)
-	assert.Len(t, got["deployedModels"], 1)
+	require.Len(t, got["deployedModels"], 1)
+	// Get must round-trip dedicatedResources / createTime.
+	gotDM := got["deployedModels"].([]any)[0].(map[string]any)
+	assert.NotEmpty(t, gotDM["createTime"])
+	assert.EqualValues(t, 5, gotDM["dedicatedResources"].(map[string]any)["maxReplicaCount"])
 
 	pred := do(t, http.MethodPost, url+"/v1/"+epName+":predict", map[string]any{
 		"instances": []any{map[string]any{"x": 1}},
 	})
 	assert.Len(t, pred["predictions"], 1)
 	assert.NotEmpty(t, pred["deployedModelId"])
+}
+
+// doErr issues a request expecting a non-2xx status and returns the HTTP code.
+func doErr(t *testing.T, method, url string, body any) int {
+	t.Helper()
+
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(method, url, bytes.NewReader(b))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	_, _ = io.ReadAll(resp.Body)
+
+	return resp.StatusCode
+}
+
+// TestPredictNoDeployedModels: :predict on an endpoint with no deployed models
+// is a 400 FAILED_PRECONDITION, not a 200 echo.
+func TestPredictNoDeployedModels(t *testing.T) {
+	url := newServer(t)
+
+	op := do(t, http.MethodPost, url+base+"/endpoints", map[string]any{"displayName": "ep"})
+	epName := op["response"].(map[string]any)["name"].(string)
+
+	code := doErr(t, http.MethodPost, url+"/v1/"+epName+":predict", map[string]any{
+		"instances": []any{map[string]any{"x": 1}},
+	})
+	assert.Equal(t, http.StatusBadRequest, code)
+}
+
+// TestDeployUnknownModel: deploying a model resource that was never uploaded is
+// a 404 NOT_FOUND.
+func TestDeployUnknownModel(t *testing.T) {
+	url := newServer(t)
+
+	op := do(t, http.MethodPost, url+base+"/endpoints", map[string]any{"displayName": "ep"})
+	epName := op["response"].(map[string]any)["name"].(string)
+
+	code := doErr(t, http.MethodPost, url+"/v1/"+epName+":deployModel", map[string]any{
+		"deployedModel": map[string]any{"model": base + "/models/9999999", "displayName": "v1"},
+	})
+	assert.Equal(t, http.StatusNotFound, code)
 }
 
 func TestPublishersGenerateContent(t *testing.T) {

--- a/services/vertexai/driver/endpoints.go
+++ b/services/vertexai/driver/endpoints.go
@@ -18,6 +18,7 @@ type DeployedModel struct {
 	MachineType     string
 	MinReplicaCount int
 	MaxReplicaCount int
+	CreateTime      string
 }
 
 // Endpoint serves online predictions for one or more deployed models.


### PR DESCRIPTION
Fixes real-user fidelity gaps in five small GCP services from the GCP audit. One commit per service so each can be reviewed independently. Bigtable is deferred (see below).

## fcm
- `messages:send` now rejects a message with **no** target (none of token/topic/condition) with **400 INVALID_ARGUMENT**, matching real FCM's "exactly one" rule. Previously such a message was accepted and published to a synthetic topic.

## vertexai
- `endpoints.predict` on an endpoint with **no deployed models** returns **400 FAILED_PRECONDITION** instead of echoing the input instances.
- `endpoints.deployModel` of a model resource that was **never uploaded** returns **404 NOT_FOUND** instead of silently deploying a dangling reference.
- `deployedModels` entries now round-trip `dedicatedResources` (machineSpec, min/max replica counts) and `createTime` on get/deployModel responses.

## eventarc
- `triggers.create` rejects a trigger with **no destination** (400 INVALID_ARGUMENT) rather than storing a dead route.
- `triggers.patch` implements **updateTrigger** with `updateMask` (destination / eventFilters / serviceAccount / labels); previously PATCH 404'd.
- Triggers now carry a server-assigned **uid**, an **etag** (bumps on patch), and an auto-provisioned **Pub/Sub transport** topic.
- `triggers.list` honours `pageSize`/`pageToken` and returns `nextPageToken`.

## cloudasset
- `searchAllResources` now honours the requested **scope**: asset names and the `project` field are rescoped to the queried `projects/{p}` instead of a fixed default project.
- `exportAssets` reflects the caller's **outputConfig** and reports the written destination in `outputResult` instead of the fixed `cloudemu://in-memory` placeholder.

## Deferrals
- **cloudasset.searchAllIamPolicies** — still returns `[]`. CloudEmu has no GCP resource-IAM policy store wired into the asset engine; returning fabricated bindings would be worse than an honest empty result. Needs a resource-IAM policy source wired through the discovery engine first.
- **bigtable data plane (ReadRows/MutateRow)** — deferred entirely. The Bigtable data API is `google.bigtable.v2`, which real clients (`cloud.google.com/go/bigtable`) speak over **gRPC only**; this wire server is HTTP/JSON with no gRPC transport. A REST data route would be unreachable by any real client. Implementing it needs a new gRPC/HTTP2 data-plane server + row storage, out of scope for this small-services pass. The Bigtable **Admin** surface (instances/clusters/tables/backups/appProfiles/IAM) remains fully implemented.

## Tests
Per-service reproduction tests using the real GCP clients (`google.golang.org/api/{fcm,eventarc,cloudasset}` and the vertexai REST round-trip) via `option.WithEndpoint` against the in-process GCP server. Existing tests + shared LRO polling stay green.

## Gates
`go build ./...`, `go vet`, scoped `go test -count=1`, `go test -race` on the mutated vertexai provider, and `golangci-lint` (0 issues) all green on the touched packages. `go generate ./...` produces no docs/coverage diff (only a driver struct field was added, no interface method change).
