### PR TITLE
fix(gcp-alloydb): cluster labels, createTime/updateTime, real uid + caller displayName

### DIFF
--- a/providers/gcp/alloydb/alloydb.go
+++ b/providers/gcp/alloydb/alloydb.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -70,6 +71,12 @@ type clusterExtra struct {
 	ContinuousBackup       bool
 	MaintenanceDay         string
 	PrimaryCluster         string // source cluster name, for a SECONDARY cluster
+	// DisplayName is the caller-supplied display name (empty when unset); real
+	// AlloyDB echoes only what the caller sent, never the id.
+	DisplayName string
+	// UpdatedAt is the last-modification time; zero until the first modify, in
+	// which case the cluster's CreatedAt stands in as the update time.
+	UpdatedAt time.Time
 }
 
 // instanceExtra holds AlloyDB instance attributes that don't map onto the
@@ -81,6 +88,9 @@ type instanceExtra struct {
 	AvailabilityType string
 	IPAddress        string
 	GceZone          string
+	// UpdatedAt is the last-modification time; zero until the first modify, in
+	// which case the instance's CreatedAt stands in as the update time.
+	UpdatedAt time.Time
 }
 
 // backupExtra holds AlloyDB backup attributes beyond the portable

--- a/providers/gcp/alloydb/alloydb_native.go
+++ b/providers/gcp/alloydb/alloydb_native.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
 
@@ -128,6 +129,7 @@ func (m *Mock) CreateAlloyDBCluster(
 		AutomatedBackupEnabled: cfg.AutomatedBackupEnabled,
 		ContinuousBackup:       cfg.ContinuousBackup,
 		MaintenanceDay:         cfg.MaintenanceDay,
+		DisplayName:            cfg.DisplayName,
 	}
 
 	if cfg.InitialUser != "" {
@@ -208,6 +210,7 @@ func (m *Mock) PromoteCluster(_ context.Context, id string) (*rdsdriver.Cluster,
 
 	extra.ClusterType = clusterTypePrimary
 	extra.PrimaryCluster = ""
+	extra.UpdatedAt = m.opts.Clock.Now().UTC()
 	m.clusterExtra[id] = extra
 
 	out := cloneCluster(cluster)
@@ -336,11 +339,19 @@ func (m *Mock) AlloyDBClusterInfo(_ context.Context, id string) (*rdsdriver.Allo
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if !m.clusters.Has(id) {
+	c, ok := m.clusters.Get(id)
+	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "AlloyDB cluster %q not found", id)
 	}
 
 	e := m.clusterExtra[id]
+
+	// A cluster not yet modified reports its creation time as the update time,
+	// matching real AlloyDB where updateTime == createTime on a fresh resource.
+	updated := e.UpdatedAt
+	if updated.IsZero() {
+		updated = c.CreatedAt
+	}
 
 	return &rdsdriver.AlloyDBClusterInfo{
 		ClusterType:            e.ClusterType,
@@ -350,6 +361,10 @@ func (m *Mock) AlloyDBClusterInfo(_ context.Context, id string) (*rdsdriver.Allo
 		ContinuousBackup:       e.ContinuousBackup,
 		MaintenanceDay:         e.MaintenanceDay,
 		PrimaryCluster:         e.PrimaryCluster,
+		UID:                    idgen.SyntheticGUID(c.ARN),
+		DisplayName:            e.DisplayName,
+		CreateTime:             c.CreatedAt,
+		UpdateTime:             updated,
 	}, nil
 }
 
@@ -361,11 +376,18 @@ func (m *Mock) AlloyDBInstanceInfo(
 	defer m.mu.RUnlock()
 
 	key := instanceKey(clusterID, instanceID)
-	if !m.instances.Has(key) {
+
+	inst, ok := m.instances.Get(key)
+	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "AlloyDB instance %q not found in cluster %q", instanceID, clusterID)
 	}
 
 	e := m.instanceExtra[key]
+
+	updated := e.UpdatedAt
+	if updated.IsZero() {
+		updated = inst.CreatedAt
+	}
 
 	return &rdsdriver.AlloyDBInstanceInfo{
 		InstanceType:     e.InstanceType,
@@ -374,5 +396,7 @@ func (m *Mock) AlloyDBInstanceInfo(
 		AvailabilityType: e.AvailabilityType,
 		IPAddress:        e.IPAddress,
 		GceZone:          e.GceZone,
+		CreateTime:       inst.CreatedAt,
+		UpdateTime:       updated,
 	}, nil
 }

--- a/providers/gcp/alloydb/clusters.go
+++ b/providers/gcp/alloydb/clusters.go
@@ -129,6 +129,10 @@ func (m *Mock) ModifyCluster(
 		c.Tags = copyTags(input.Tags)
 	}
 
+	extra := m.clusterExtra[id]
+	extra.UpdatedAt = m.opts.Clock.Now().UTC()
+	m.clusterExtra[id] = extra
+
 	m.clusters.Set(id, c)
 
 	out := cloneCluster(c)
@@ -163,11 +167,14 @@ func (m *Mock) DeleteCluster(ctx context.Context, id string) error {
 // ghost primary (the replica-linkage class from #303). The caller holds the
 // write lock.
 func (m *Mock) detachSecondaries(primaryID string) {
-	for cid, extra := range m.clusterExtra {
-		if extra.PrimaryCluster == primaryID {
-			extra.PrimaryCluster = ""
-			m.clusterExtra[cid] = extra
+	for cid := range m.clusterExtra {
+		extra := m.clusterExtra[cid]
+		if extra.PrimaryCluster != primaryID {
+			continue
 		}
+
+		extra.PrimaryCluster = ""
+		m.clusterExtra[cid] = extra
 	}
 }
 

--- a/providers/gcp/alloydb/instances.go
+++ b/providers/gcp/alloydb/instances.go
@@ -189,6 +189,10 @@ func (m *Mock) ModifyInstance(
 		inst.Tags = copyTags(input.Tags)
 	}
 
+	extra := m.instanceExtra[key]
+	extra.UpdatedAt = m.opts.Clock.Now().UTC()
+	m.instanceExtra[key] = extra
+
 	m.instances.Set(key, inst)
 
 	out := cloneInstance(inst)

--- a/server/gcp/alloydb/clusters.go
+++ b/server/gcp/alloydb/clusters.go
@@ -44,6 +44,7 @@ func (h *Handler) createCluster(w http.ResponseWriter, r *http.Request, p *alloy
 
 	cfg := rdsdriver.AlloyDBClusterConfig{
 		ID:              r.URL.Query().Get("clusterId"),
+		DisplayName:     body.DisplayName,
 		DatabaseVersion: body.DatabaseVersion,
 		Network:         body.Network,
 		Tags:            body.Labels,

--- a/server/gcp/alloydb/helpers.go
+++ b/server/gcp/alloydb/helpers.go
@@ -3,6 +3,7 @@ package alloydb
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	alloydb "google.golang.org/api/alloydb/v1"
 
@@ -96,12 +97,15 @@ func (h *Handler) usersCap() (rdsdriver.Users, bool) {
 func (*Handler) toWireCluster(c *rdsdriver.Cluster, info *rdsdriver.AlloyDBClusterInfo) *alloydb.Cluster {
 	out := &alloydb.Cluster{
 		Name:            c.ARN,
-		DisplayName:     c.ID,
+		DisplayName:     info.DisplayName,
 		DatabaseVersion: info.DatabaseVersion,
 		Network:         info.Network,
 		ClusterType:     info.ClusterType,
 		State:           alloyDBState(c.State),
-		Uid:             c.ID,
+		Uid:             info.UID,
+		Labels:          c.Tags,
+		CreateTime:      formatTime(info.CreateTime),
+		UpdateTime:      formatTime(info.UpdateTime),
 		ContinuousBackupConfig: &alloydb.ContinuousBackupConfig{
 			Enabled: info.ContinuousBackup,
 		},
@@ -117,6 +121,16 @@ func (*Handler) toWireCluster(c *rdsdriver.Cluster, info *rdsdriver.AlloyDBClust
 	return out
 }
 
+// formatTime renders t as an RFC3339Nano timestamp, matching AlloyDB's
+// output-only createTime/updateTime; a zero time renders as the empty string.
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
 func (*Handler) toWireInstance(inst *rdsdriver.Instance, info *rdsdriver.AlloyDBInstanceInfo) *alloydb.Instance {
 	return &alloydb.Instance{
 		Name:             inst.ARN,
@@ -127,6 +141,8 @@ func (*Handler) toWireInstance(inst *rdsdriver.Instance, info *rdsdriver.AlloyDB
 		GceZone:          info.GceZone,
 		State:            alloyDBState(inst.State),
 		Uid:              inst.ID,
+		CreateTime:       formatTime(info.CreateTime),
+		UpdateTime:       formatTime(info.UpdateTime),
 		MachineConfig:    &alloydb.MachineConfig{CpuCount: int64(info.CPUCount)},
 	}
 }

--- a/server/gcp/alloydb/sdk_roundtrip_test.go
+++ b/server/gcp/alloydb/sdk_roundtrip_test.go
@@ -336,6 +336,83 @@ func TestSDKAlloyDBUserPatchAndGuards(t *testing.T) {
 	assertStatus(t, err, 400)
 }
 
+// TestSDKAlloyDBClusterMetadata pins the three metadata findings: labels
+// round-trip, createTime/updateTime are populated, and uid/displayName are the
+// server-assigned UID and the caller's display name (never the cluster id).
+func TestSDKAlloyDBClusterMetadata(t *testing.T) {
+	svc := newSDKClient(t)
+	ctx := context.Background()
+
+	// Cluster WITH labels and a display name.
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(), &alloydb.Cluster{
+		DatabaseVersion: "POSTGRES_15",
+		DisplayName:     "Orders Prod",
+		Labels:          map[string]string{"env": "prod", "team": "payments"},
+	}).ClusterId("c1").Context(ctx).Do(); err != nil {
+		t.Fatalf("Clusters.Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.Get(parent() + "/clusters/c1").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Clusters.Get: %v", err)
+	}
+
+	// Finding 1: labels round-trip.
+	if got.Labels["env"] != "prod" || got.Labels["team"] != "payments" {
+		t.Errorf("labels: got %v, want env=prod team=payments", got.Labels)
+	}
+
+	// Finding 2: createTime/updateTime populated.
+	if got.CreateTime == "" || got.UpdateTime == "" {
+		t.Errorf("timestamps: createTime=%q updateTime=%q, want both set", got.CreateTime, got.UpdateTime)
+	}
+
+	// Finding 3: uid is a server UID (not the id) and displayName is echoed.
+	if got.Uid == "" || got.Uid == "c1" {
+		t.Errorf("uid: got %q, want a server-assigned UID distinct from the id", got.Uid)
+	}
+
+	if got.DisplayName != "Orders Prod" {
+		t.Errorf("displayName: got %q, want %q", got.DisplayName, "Orders Prod")
+	}
+
+	// Cluster WITHOUT a display name must not fabricate one from the id.
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(), &alloydb.Cluster{DatabaseVersion: "POSTGRES_15"}).
+		ClusterId("c2").Context(ctx).Do(); err != nil {
+		t.Fatalf("Clusters.Create c2: %v", err)
+	}
+
+	got2, err := svc.Projects.Locations.Clusters.Get(parent() + "/clusters/c2").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Clusters.Get c2: %v", err)
+	}
+
+	if got2.DisplayName != "" {
+		t.Errorf("displayName without a caller value: got %q, want empty", got2.DisplayName)
+	}
+
+	if got2.Uid == got.Uid {
+		t.Errorf("uid: c1 and c2 share uid %q, want distinct", got2.Uid)
+	}
+
+	// Instance createTime/updateTime are populated too (finding 2, instances).
+	if _, err := svc.Projects.Locations.Clusters.Instances.Create(parent()+"/clusters/c1", &alloydb.Instance{
+		InstanceType:  "PRIMARY",
+		MachineConfig: &alloydb.MachineConfig{CpuCount: 2},
+	}).InstanceId("i1").Context(ctx).Do(); err != nil {
+		t.Fatalf("Instances.Create: %v", err)
+	}
+
+	inst, err := svc.Projects.Locations.Clusters.Instances.Get(parent() + "/clusters/c1/instances/i1").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Instances.Get: %v", err)
+	}
+
+	if inst.CreateTime == "" || inst.UpdateTime == "" {
+		t.Errorf("instance timestamps: createTime=%q updateTime=%q, want both set", inst.CreateTime, inst.UpdateTime)
+	}
+}
+
 func TestAlloyDBRawGetPromoteRejected(t *testing.T) {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 	opts := config.NewOptions(config.WithClock(fc), config.WithRegion(testLocation), config.WithProjectID(testProject))

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -1262,6 +1262,7 @@ type Tagging interface {
 // AlloyDBClusterConfig carries AlloyDB-specific cluster-create fields.
 type AlloyDBClusterConfig struct {
 	ID                     string
+	DisplayName            string // user-settable; echoed only when the caller sets it
 	DatabaseVersion        string // "POSTGRES_15", …
 	Network                string
 	InitialUser            string
@@ -1300,6 +1301,14 @@ type AlloyDBClusterInfo struct {
 	ContinuousBackup       bool
 	MaintenanceDay         string
 	PrimaryCluster         string // set for a SECONDARY cluster
+	// UID is the server-generated system UID (distinct from the resource id).
+	UID string
+	// DisplayName is the caller-supplied display name, empty when unset.
+	DisplayName string
+	// CreateTime / UpdateTime are the cluster's creation and last-modification
+	// timestamps.
+	CreateTime time.Time
+	UpdateTime time.Time
 }
 
 // AlloyDBInstanceInfo is the AlloyDB-native view of an instance's extra
@@ -1311,6 +1320,10 @@ type AlloyDBInstanceInfo struct {
 	AvailabilityType string
 	IPAddress        string
 	GceZone          string
+	// CreateTime / UpdateTime are the instance's creation and last-modification
+	// timestamps.
+	CreateTime time.Time
+	UpdateTime time.Time
 }
 
 // AlloyDB is an OPTIONAL capability for AlloyDB-specific cluster/instance


### PR DESCRIPTION
## Summary

Fixes the three AlloyDB metadata findings from the GCP audit. All three are wire-output-shape fixes in an AlloyDB-only server; routing is untouched, so GKE (which shares the `/v1/projects/{p}/locations/{l}/clusters` path and is guarded by the panic invariant + `DriversFrom` leaving AlloyDB nil) is unaffected.

- **Labels dropped (HIGH):** `toWireCluster` never emitted `labels`, causing perpetual Terraform drift. Now round-tripped from the cluster's stored tags (create/get/list).
- **createTime/updateTime empty (MEDIUM):** clusters and instances now report RFC3339 `createTime`/`updateTime`. `updateTime` bumps on cluster patch/promote and instance patch; a freshly created resource reports `updateTime == createTime`, matching real AlloyDB.
- **uid/displayName wrong (LOW):** `uid` is now a stable server-generated GUID (`idgen.SyntheticGUID` seeded on the resource name) instead of the cluster id; `displayName` echoes only the caller-supplied value instead of being forced to the id.

## Notes

- New AlloyDB-native fields flow through `AlloyDBClusterInfo`/`AlloyDBInstanceInfo` and `AlloyDBClusterConfig` (added `DisplayName`), so the portable and SDK-compat layers stay in sync.
- GKE + shared LRO tests remain green.

## Tests

Added `TestSDKAlloyDBClusterMetadata` (real `google.golang.org/api/alloydb/v1` client) asserting label round-trip, populated timestamps for clusters and instances, a server UID distinct from the id (and distinct across clusters), and that displayName is empty when the caller sends none.