### PR TITLE
fix(gcp-firestore): nested field-path update (dotted updateMask) no longer silently dropped

### DIFF
--- a/server/gcp/firestore/firestore_fieldpath_test.go
+++ b/server/gcp/firestore/firestore_fieldpath_test.go
@@ -1,0 +1,187 @@
+// Nested field-path updateMask behavior, driven by the real
+// cloud.google.com/go/firestore SDK (REST client) against the emulator's GCP
+// HTTP server. A dotted field path (e.g. "profile.age") addresses a nested
+// field; before the fix the emulator treated it as a flat top-level key, so the
+// nested write was silently dropped (data loss). These tests assert real
+// Firestore semantics: the nested leaf is written, siblings are preserved, and a
+// masked nested path absent from the write deletes only that leaf.
+package firestore_test
+
+import (
+	"testing"
+
+	gcpfirestore "cloud.google.com/go/firestore"
+)
+
+// nestedMap pulls out a nested map[string]any field from a snapshot payload.
+func nestedMap(t *testing.T, data map[string]any, key string) map[string]any {
+	t.Helper()
+
+	m, ok := data[key].(map[string]any)
+	if !ok {
+		t.Fatalf("field %q is not a nested map: %#v", key, data[key])
+	}
+
+	return m
+}
+
+// TestDatabaseNestedFieldPathUpdate asserts that Update with a dotted field
+// path writes the nested leaf, leaves sibling nested fields untouched, and that
+// updating one nested key does not disturb another top-level nested map.
+func TestDatabaseNestedFieldPathUpdate(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "people")
+
+	doc := client.Collection("people").Doc("u1")
+
+	if _, err := doc.Set(ctx, map[string]any{
+		"name": "root",
+		"profile": map[string]any{
+			"age":  int64(30),
+			"name": "alice",
+		},
+		"settings": map[string]any{
+			"theme": "dark",
+		},
+	}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	// Dotted field path addresses profile.age (the data-loss repro).
+	if _, err := doc.Update(ctx, []gcpfirestore.Update{{Path: "profile.age", Value: int64(31)}}); err != nil {
+		t.Fatalf("Update nested: %v", err)
+	}
+
+	snap, err := doc.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	data := snap.Data()
+
+	profile := nestedMap(t, data, "profile")
+	if profile["age"] != int64(31) {
+		t.Errorf("profile.age=%v want 31 (nested write was dropped)", profile["age"])
+	}
+
+	// Sibling nested field untouched.
+	if profile["name"] != "alice" {
+		t.Errorf("profile.name=%v want alice (sibling nested field must survive)", profile["name"])
+	}
+
+	// Untouched top-level nested map preserved.
+	settings := nestedMap(t, data, "settings")
+	if settings["theme"] != "dark" {
+		t.Errorf("settings.theme=%v want dark (unmasked field must survive)", settings["theme"])
+	}
+
+	// Top-level field preserved.
+	if data["name"] != "root" {
+		t.Errorf("name=%v want root", data["name"])
+	}
+}
+
+// TestDatabaseNestedFieldPathCreatesIntermediate asserts a dotted path writes
+// through into a newly created nested map when the intermediate is absent.
+func TestDatabaseNestedFieldPathCreatesIntermediate(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "people")
+
+	doc := client.Collection("people").Doc("u2")
+
+	if _, err := doc.Set(ctx, map[string]any{"name": "root"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	// address.city addresses a nested leaf under a not-yet-existing map.
+	if _, err := doc.Update(ctx, []gcpfirestore.Update{
+		{Path: "address.city", Value: "Berlin"},
+	}); err != nil {
+		t.Fatalf("Update nested (new intermediate): %v", err)
+	}
+
+	snap, err := doc.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	data := snap.Data()
+
+	addr := nestedMap(t, data, "address")
+	if addr["city"] != "Berlin" {
+		t.Errorf("address.city=%v want Berlin (intermediate map must be created)", addr["city"])
+	}
+
+	if data["name"] != "root" {
+		t.Errorf("name=%v want root", data["name"])
+	}
+}
+
+// TestDatabaseNestedFieldPathDelete asserts that deleting a nested field via a
+// dotted path removes only that leaf and preserves its siblings.
+func TestDatabaseNestedFieldPathDelete(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "people")
+
+	doc := client.Collection("people").Doc("u3")
+
+	if _, err := doc.Set(ctx, map[string]any{
+		"profile": map[string]any{
+			"age":  int64(30),
+			"name": "alice",
+		},
+	}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	// Delete just profile.age; the mask carries "profile.age" but the write
+	// omits the value, which must delete only that nested leaf.
+	if _, err := doc.Update(ctx, []gcpfirestore.Update{
+		{Path: "profile.age", Value: gcpfirestore.Delete},
+	}); err != nil {
+		t.Fatalf("Update (nested delete): %v", err)
+	}
+
+	snap, err := doc.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	profile := nestedMap(t, snap.Data(), "profile")
+
+	if _, present := profile["age"]; present {
+		t.Errorf("profile.age still present after nested delete: %#v", profile)
+	}
+
+	if profile["name"] != "alice" {
+		t.Errorf("profile.name=%v want alice (sibling must survive nested delete)", profile["name"])
+	}
+}
+
+// TestDatabaseTopLevelUpdateStillWorks guards the pre-existing #639 behavior:
+// a single-segment masked update writes the field and preserves unmasked ones.
+func TestDatabaseTopLevelUpdateStillWorks(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "people")
+
+	doc := client.Collection("people").Doc("u4")
+
+	if _, err := doc.Set(ctx, map[string]any{"keep": "original", "change": "old"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	if _, err := doc.Update(ctx, []gcpfirestore.Update{{Path: "change", Value: "new"}}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	snap, err := doc.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	data := snap.Data()
+
+	if data["change"] != "new" {
+		t.Errorf("change=%v want new", data["change"])
+	}
+
+	if data["keep"] != "original" {
+		t.Errorf("keep=%v want original (unmasked top-level field must survive)", data["keep"])
+	}
+}

--- a/server/gcp/firestore/handler.go
+++ b/server/gcp/firestore/handler.go
@@ -323,6 +323,13 @@ func checkPrecondition(w http.ResponseWriter, pc *precondition, exists bool, nam
 // mergeMasked builds the merged item for a masked update: it starts from the
 // stored document (preserving unmasked fields and the reserved keys), then for
 // each masked path writes the new value or deletes it when absent from body.
+//
+// A dotted field path (e.g. "profile.age") addresses a NESTED field: the path
+// is split into segments, intermediate maps are descended (created as needed),
+// and the leaf is set or deleted. This matches real Firestore's updateMask
+// semantics — a masked nested path present in the body is written, and a masked
+// nested path absent from the body deletes just that nested leaf while sibling
+// fields are left untouched.
 func mergeMasked(existing, body map[string]any, id string, paths []string) map[string]any {
 	merged := map[string]any{fieldID: id}
 	for k, v := range existing {
@@ -330,14 +337,116 @@ func mergeMasked(existing, body map[string]any, id string, paths []string) map[s
 	}
 
 	for _, path := range paths {
-		if v, ok := body[path]; ok {
-			merged[path] = v
+		segs := splitFieldPath(path)
+		if v, ok := getNestedPath(body, segs); ok {
+			setNestedPath(merged, segs, v)
 		} else {
-			delete(merged, path)
+			deleteNestedPath(merged, segs)
 		}
 	}
 
 	return merged
+}
+
+// splitFieldPath splits a Firestore field-path string on its unescaped '.'
+// separators. A segment wrapped in backticks may contain '.' literally; the
+// backticks are stripped. Examples: "a.b" → ["a","b"]; "`a.b`.c" → ["a.b","c"].
+// (Backslash-escaped backticks inside a quoted segment are not handled; the
+// common unescaped and backtick-quoted cases are.)
+func splitFieldPath(path string) []string {
+	var (
+		segs   []string
+		b      strings.Builder
+		inTick bool
+	)
+
+	for _, r := range path {
+		switch {
+		case r == '`':
+			inTick = !inTick
+		case r == '.' && !inTick:
+			segs = append(segs, b.String())
+			b.Reset()
+		default:
+			b.WriteRune(r)
+		}
+	}
+
+	return append(segs, b.String())
+}
+
+// getNestedPath returns the value at segs within m (descending nested maps),
+// reporting whether the full path was present.
+func getNestedPath(m map[string]any, segs []string) (any, bool) {
+	var cur any = m
+
+	for _, s := range segs {
+		cm, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+
+		v, ok := cm[s]
+		if !ok {
+			return nil, false
+		}
+
+		cur = v
+	}
+
+	return cur, true
+}
+
+// setNestedPath sets val at the segmented path within m, cloning maps along the
+// descent so the stored (shared) document is never mutated in place. Missing or
+// non-map intermediate values are replaced by a fresh map, matching Firestore's
+// behavior of overwriting a scalar when a nested path is written through it.
+func setNestedPath(m map[string]any, segs []string, val any) {
+	if len(segs) == 1 {
+		m[segs[0]] = val
+		return
+	}
+
+	child := cloneStringMap(m[segs[0]])
+	m[segs[0]] = child
+	setNestedPath(child, segs[1:], val)
+}
+
+// deleteNestedPath removes the leaf at the segmented path within m, cloning
+// maps along the descent so the stored document is not mutated in place. A path
+// whose intermediates are absent is a no-op.
+func deleteNestedPath(m map[string]any, segs []string) {
+	if len(segs) == 1 {
+		delete(m, segs[0])
+		return
+	}
+
+	existing, ok := m[segs[0]].(map[string]any)
+	if !ok {
+		return
+	}
+
+	child := cloneStringMap(existing)
+	m[segs[0]] = child
+	deleteNestedPath(child, segs[1:])
+}
+
+// cloneStringMap returns a shallow copy of v when it is a map[string]any, or a
+// fresh empty map otherwise. Cloning the immediate level is enough: descent
+// re-clones each deeper level it walks into, so a stored map is never aliased
+// and mutated.
+func cloneStringMap(v any) map[string]any {
+	src, ok := v.(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+
+	dst := make(map[string]any, len(src))
+	for k, val := range src {
+		dst[k] = val
+	}
+
+	return dst
 }
 
 // batchGet handles POST .../documents:batchGet — the batched-read endpoint.
@@ -871,7 +980,9 @@ func parseOrderBy(orderBy string) []sortKey {
 }
 
 // applyFieldMask trims a document's fields to the requested mask paths. An
-// empty mask leaves the document unchanged (all fields returned).
+// empty mask leaves the document unchanged (all fields returned). A dotted mask
+// path (e.g. "profile.age") projects the nested leaf, rebuilding the enclosing
+// mapValues so sibling nested fields are excluded.
 func applyFieldMask(doc *document, mask []string) {
 	if len(mask) == 0 || doc.Fields == nil {
 		return
@@ -880,12 +991,38 @@ func applyFieldMask(doc *document, mask []string) {
 	kept := make(map[string]value, len(mask))
 
 	for _, path := range mask {
-		if v, ok := doc.Fields[path]; ok {
-			kept[path] = v
-		}
+		projectFieldPath(doc.Fields, kept, splitFieldPath(path))
 	}
 
 	doc.Fields = kept
+}
+
+// projectFieldPath copies the value at segs from src into dst, materializing
+// nested mapValues along the way. A missing path is skipped.
+func projectFieldPath(src, dst map[string]value, segs []string) {
+	head := segs[0]
+
+	sv, ok := src[head]
+	if !ok {
+		return
+	}
+
+	if len(segs) == 1 {
+		dst[head] = sv
+		return
+	}
+
+	if sv.MapValue == nil {
+		return
+	}
+
+	node, exists := dst[head]
+	if !exists || node.MapValue == nil {
+		node = value{MapValue: &mapValue{Fields: make(map[string]value)}}
+		dst[head] = node
+	}
+
+	projectFieldPath(sv.MapValue.Fields, node.MapValue.Fields, segs[1:])
 }
 
 // atoiOr parses s as an int, returning def when s is empty or invalid.


### PR DESCRIPTION
## What

A dotted `updateMask` field path (e.g. `profile.age`) in a Firestore write now
correctly addresses a **nested** field. Previously the handler treated the whole
dotted string as a flat top-level map key, so the nested write was **silently
dropped with no error** — a real-user data-loss bug.

**Data-loss repro (real `cloud.google.com/go/firestore` SDK):**

```go
docRef.Set(ctx, map[string]any{"profile": map[string]any{"age": 30, "name": "alice"}})
docRef.Update(ctx, []firestore.Update{{Path: "profile.age", Value: 31}})
snap, _ := docRef.Get(ctx)
// before: profile.age == 30  (the update vanished, no error)
// after:  profile.age == 31
```

## Why

The SDK sends `fieldPaths: ["profile.age"]` alongside a nested body
`fields:{profile:{mapValue:{fields:{age:...}}}}`. The handler looked up
`item["profile.age"]`, which does not exist (the item key is `profile`), fell
into the mask delete branch (a no-op), and never applied the nested value. This
was the residue of the round-1 top-level-only updateMask fix (#639).

## Fix

Server wire-handler only (no driver/provider change):

- `mergeMasked` (used by `:commit` and PATCH `updateDocument`) now splits dotted
  field paths, descends/creates intermediate maps, and sets or deletes the leaf.
  A masked nested path absent from the write deletes just that nested field;
  siblings are preserved. Maps are cloned along the descent so the stored
  document is never mutated in place.
- `applyFieldMask` (the `listDocuments` mask projection) projects nested paths,
  rebuilding the enclosing `mapValue`s so sibling nested fields are excluded.
- Backtick-quoted path segments are honored, so a key literally containing a dot
  can still be addressed (`` `a.b`.c ``). Backslash-escaped backticks inside a
  quoted segment are deferred (uncommon).

Top-level masked updates and full-document sets are unchanged.

## Tests

New real-SDK reproductions (`firestore_fieldpath_test.go`): nested `profile.age`
update now sets the value (was dropped) and Get returns it; sibling nested field
and untouched top-level nested map preserved; a dotted path creates a missing
intermediate map; `firestore.Delete` on a nested path removes only that leaf;
top-level update still works. Verified these fail on the pre-fix handler and pass
after. Existing #639 firestore tests remain green (build/vet/test/-race/lint/gci
all clean; `go generate` produces no coverage diff).
