### PR TITLE
fix(gcp-lro): operation registry — real response + 404 on unknown ops

### DIFF
--- a/server/gcp/alloydb/handler.go
+++ b/server/gcp/alloydb/handler.go
@@ -32,6 +32,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/stackshy/cloudemu/v2/server/gcp/lro"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
 
@@ -60,12 +61,22 @@ const (
 // also implements the AlloyDB optional capability.
 type Handler struct {
 	db rdsdriver.RelationalDB
+
+	// ops records created operations with the shared poller so a client that
+	// polls the returned operation name gets the typed response (and unknown
+	// names 404). Nil in a standalone package server, where this handler serves
+	// its own /operations/ poll.
+	ops *lro.Registry
 }
 
 // New returns an AlloyDB handler backed by db.
 func New(db rdsdriver.RelationalDB) *Handler {
 	return &Handler{db: db}
 }
+
+// SetOperationRegistry wires the shared LRO poller so created operations are
+// resolvable (with their response) through the full server's operations host.
+func (h *Handler) SetOperationRegistry(reg *lro.Registry) { h.ops = reg }
 
 // Matches claims /v1/projects/{p}/locations/{l}/{clusters|backups|operations}
 // paths. Everything else under /v1/projects/ falls through to other GCP

--- a/server/gcp/alloydb/helpers.go
+++ b/server/gcp/alloydb/helpers.go
@@ -62,10 +62,11 @@ func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 	return true
 }
 
-// doneOperation builds a completed AlloyDB LRO envelope carrying the resource
-// as its response. AlloyDB REST callers receive a terminal operation, so no
-// polling is required.
-func (*Handler) doneOperation(p *alloyPath, verb string, response any) *alloydb.Operation {
+// doneOperation builds a completed AlloyDB LRO envelope carrying the resource as
+// its response. AlloyDB REST callers receive a terminal operation, and a client
+// that polls the returned name resolves the same done operation (with its
+// response) via the shared LRO poller in the full server.
+func (h *Handler) doneOperation(p *alloyPath, verb string, response any) *alloydb.Operation {
 	name := "projects/" + p.project + "/locations/" + p.location + "/operations/op-" + verb
 
 	op := &alloydb.Operation{Name: name, Done: true}
@@ -75,6 +76,8 @@ func (*Handler) doneOperation(p *alloyPath, verb string, response any) *alloydb.
 			op.Response = raw
 		}
 	}
+
+	h.ops.Register(name, op.Response)
 
 	return op
 }

--- a/server/gcp/artifactregistry/handler.go
+++ b/server/gcp/artifactregistry/handler.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/stackshy/cloudemu/v2/server/gcp/lro"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
 )
@@ -55,12 +56,22 @@ type Handler struct {
 	// google_artifact_registry_repository_iam_* flow).
 	mu       sync.RWMutex
 	policies map[string]*iamPolicy
+
+	// ops records created operations with the shared poller so a client that
+	// polls the returned operation name gets the typed response (and unknown
+	// names 404). Nil in a standalone package server, where this handler serves
+	// its own /operations/ poll.
+	ops *lro.Registry
 }
 
 // New returns an Artifact Registry handler backed by reg.
 func New(reg crdriver.ContainerRegistry) *Handler {
 	return &Handler{registry: reg, policies: make(map[string]*iamPolicy)}
 }
+
+// SetOperationRegistry wires the shared LRO poller so created operations are
+// resolvable (with their response) through the full server's operations host.
+func (h *Handler) SetOperationRegistry(reg *lro.Registry) { h.ops = reg }
 
 type route struct {
 	project    string

--- a/server/gcp/artifactregistry/operations.go
+++ b/server/gcp/artifactregistry/operations.go
@@ -29,7 +29,7 @@ func (h *Handler) createRepository(w http.ResponseWriter, r *http.Request, rt *r
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt, repoID,
+	gcprest.WriteJSON(w, http.StatusOK, h.doneOperation(rt, repoID,
 		typedResponse(repositoryTypeURL, toRepositoryJSON(rt.project, rt.location, repo, 0))))
 }
 
@@ -239,7 +239,7 @@ func (h *Handler) deleteRepository(w http.ResponseWriter, r *http.Request, rt *r
 	delete(h.policies, repositoryResourceName(rt.project, rt.location, rt.repository))
 	h.mu.Unlock()
 
-	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt, rt.repository, nil))
+	gcprest.WriteJSON(w, http.StatusOK, h.doneOperation(rt, rt.repository, nil))
 }
 
 func (h *Handler) listDockerImages(w http.ResponseWriter, r *http.Request, rt *route) {
@@ -307,10 +307,15 @@ func pageSize(r *http.Request) int {
 	return n
 }
 
-// doneOperation builds a completed long-running operation envelope.
-func doneOperation(rt *route, id string, response any) operationJSON {
+// doneOperation builds a completed long-running operation envelope and records
+// it with the shared LRO poller so a client polling the returned name resolves
+// the same done operation (with its typed response) in the full server.
+func (h *Handler) doneOperation(rt *route, id string, response any) operationJSON {
+	name := "projects/" + rt.project + "/locations/" + rt.location + "/operations/op-" + id
+	h.ops.Register(name, response)
+
 	return operationJSON{
-		Name:     "projects/" + rt.project + "/locations/" + rt.location + "/operations/op-" + id,
+		Name:     name,
 		Done:     true,
 		Response: response,
 	}

--- a/server/gcp/eventarc/handler.go
+++ b/server/gcp/eventarc/handler.go
@@ -43,6 +43,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/stackshy/cloudemu/v2/server/gcp/lro"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 )
@@ -62,12 +63,21 @@ const minTriggersCollectionParts = 5
 // eventbus driver.
 type Handler struct {
 	bus ebdriver.EventBus
+
+	// ops records created operations with the shared poller so a client that
+	// polls the returned operation name gets the typed response (and unknown
+	// names 404). Nil in a standalone package server.
+	ops *lro.Registry
 }
 
 // New returns an Eventarc handler backed by b.
 func New(b ebdriver.EventBus) *Handler {
 	return &Handler{bus: b}
 }
+
+// SetOperationRegistry wires the shared LRO poller so created operations are
+// resolvable (with their response) through the full server's operations host.
+func (h *Handler) SetOperationRegistry(reg *lro.Registry) { h.ops = reg }
 
 type route struct {
 	project   string

--- a/server/gcp/eventarc/operations.go
+++ b/server/gcp/eventarc/operations.go
@@ -80,7 +80,7 @@ func (h *Handler) createTrigger(w http.ResponseWriter, r *http.Request, rt *rout
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt, triggerID,
+	gcprest.WriteJSON(w, http.StatusOK, h.doneOperation(rt, triggerID,
 		typedResponse(triggerTypeURL, toTriggerJSON(rt.project, rt.location, stored))))
 }
 
@@ -177,7 +177,7 @@ func (h *Handler) deleteTrigger(w http.ResponseWriter, r *http.Request, rt *rout
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt, rt.trigger, nil))
+	gcprest.WriteJSON(w, http.StatusOK, h.doneOperation(rt, rt.trigger, nil))
 }
 
 // patchTrigger applies an updateTrigger call. Only the fields named in
@@ -236,7 +236,7 @@ func (h *Handler) patchTrigger(w http.ResponseWriter, r *http.Request, rt *route
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt, rt.trigger,
+	gcprest.WriteJSON(w, http.StatusOK, h.doneOperation(rt, rt.trigger,
 		typedResponse(triggerTypeURL, toTriggerJSON(rt.project, rt.location, stored))))
 }
 
@@ -306,10 +306,15 @@ func (h *Handler) ensureChannel(r *http.Request, rt *route, bus string) error {
 	return nil
 }
 
-// doneOperation builds a completed long-running operation envelope.
-func doneOperation(rt *route, id string, response any) operationJSON {
+// doneOperation builds a completed long-running operation envelope and records
+// it with the shared LRO poller so a client polling the returned name resolves
+// the same done operation (with its typed response) in the full server.
+func (h *Handler) doneOperation(rt *route, id string, response any) operationJSON {
+	name := "projects/" + rt.project + "/locations/" + rt.location + "/operations/op-" + id
+	h.ops.Register(name, response)
+
 	return operationJSON{
-		Name:     "projects/" + rt.project + "/locations/" + rt.location + "/operations/op-" + id,
+		Name:     name,
 		Done:     true,
 		Response: response,
 	}

--- a/server/gcp/fullserver_test.go
+++ b/server/gcp/fullserver_test.go
@@ -1,6 +1,7 @@
 package gcp_test
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -62,8 +63,17 @@ func TestFullServerLROOperationPolling(t *testing.T) {
 	}
 
 	if code, body := do(t, ts, http.MethodGet,
-		"/v1/projects/demo/locations/us/operations/op-r1", ""); code != http.StatusOK || !strings.Contains(body, `"done":true`) {
-		t.Fatalf("AR op poll: code=%d body=%s (want 200 done:true)", code, body)
+		"/v1/projects/demo/locations/us/operations/op-r1", ""); code != http.StatusOK ||
+		!strings.Contains(body, `"done":true`) || !strings.Contains(body, `"response"`) ||
+		!strings.Contains(body, "MAVEN") {
+		t.Fatalf("AR op poll: code=%d body=%s (want 200 done:true with the repository response)", code, body)
+	}
+
+	// An operation name that was never created is 404 NOT_FOUND, not a masked
+	// done (real GCP returns 404 for an unknown operation id).
+	if code, body := do(t, ts, http.MethodGet,
+		"/v1/projects/demo/locations/us/operations/does-not-exist-123", ""); code != http.StatusNotFound {
+		t.Fatalf("unknown op poll: code=%d body=%s (want 404)", code, body)
 	}
 
 	// eventarc.
@@ -76,14 +86,22 @@ func TestFullServerLROOperationPolling(t *testing.T) {
 		t.Fatalf("eventarc op poll: code=%d body=%s", code, body)
 	}
 
-	// gke (a legitimate location-operations owner) must still resolve.
-	do(t, ts, http.MethodPost, "/v1/projects/demo/locations/us-central1/clusters",
+	// gke owns its operations: it registers ahead of the shared poller and
+	// claims a named operation poll only for the ops its mock recorded, so its
+	// richer container.Operation shape (a `status` field, not the longrunning
+	// `done` bool) is returned. Poll the name the create actually returned.
+	_, createBody := do(t, ts, http.MethodPost, "/v1/projects/demo/locations/us-central1/clusters",
 		`{"cluster":{"name":"k1","initialNodeCount":1}}`)
 
-	// GKE's container.Operation uses a `status` field, not the longrunning
-	// `done` bool — the shared handler must satisfy both.
+	var createOp struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(createBody), &createOp); err != nil || createOp.Name == "" {
+		t.Fatalf("gke create: cannot read operation name from %s (err=%v)", createBody, err)
+	}
+
 	if code, body := do(t, ts, http.MethodGet,
-		"/v1/projects/demo/locations/us-central1/operations/operation-00000001", ""); code != http.StatusOK ||
+		"/v1/projects/demo/locations/us-central1/operations/"+createOp.Name, ""); code != http.StatusOK ||
 		!strings.Contains(body, `"status":"DONE"`) {
 		t.Fatalf("gke op poll: code=%d body=%s (want status DONE)", code, body)
 	}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -152,9 +152,11 @@ func New(d Drivers) *server.Server {
 	// service handlers so it owns every GET /v1/projects/{p}/locations/{l}/
 	// operations/{op} uniformly, instead of alloydb greedily claiming (and
 	// 404ing) operations created by artifactregistry, eventarc, memorystore,
-	// etc. All emulated ops are synchronous, so a done response is always
-	// correct.
-	srv.Register(lro.New())
+	// etc. Each service registers the operations it creates into opsReg so the
+	// poller replays their typed response and 404s an operation name that was
+	// never created (as real GCP does).
+	opsReg := lro.NewRegistry()
+	srv.Register(lro.New(opsReg))
 
 	if d.Compute != nil {
 		srv.Register(compute.New(d.Compute))
@@ -234,7 +236,9 @@ func New(d Drivers) *server.Server {
 	// the two are mutually exclusive on one server. Registered before GKE so an
 	// AlloyDB-configured server (GKE nil) works; DriversFrom leaves AlloyDB nil.
 	if d.AlloyDB != nil {
-		srv.Register(alloydbsrv.New(d.AlloyDB))
+		alloyH := alloydbsrv.New(d.AlloyDB)
+		alloyH.SetOperationRegistry(opsReg)
+		srv.Register(alloyH)
 	}
 
 	// GKE is registered ahead of the LRO poller above (see the top of New) so
@@ -270,7 +274,9 @@ func New(d Drivers) *server.Server {
 	// — disjoint from IAM (serviceAccounts|roles) and Cloud Asset. Registered
 	// among the /v1/projects/ family, before Firestore's catch-all.
 	if d.ArtifactRegistry != nil {
-		srv.Register(artifactregistry.New(d.ArtifactRegistry))
+		arH := artifactregistry.New(d.ArtifactRegistry)
+		arH.SetOperationRegistry(opsReg)
+		srv.Register(arH)
 	}
 
 	// Secret Manager matches /v1/projects/{p}/secrets[/…] — disjoint from IAM
@@ -285,7 +291,9 @@ func New(d Drivers) *server.Server {
 	// GKE, and the rest of the /v1/projects/ family. Registered before
 	// Firestore's catch-all.
 	if d.Eventarc != nil {
-		srv.Register(eventarc.New(d.Eventarc))
+		eaH := eventarc.New(d.Eventarc)
+		eaH.SetOperationRegistry(opsReg)
+		srv.Register(eaH)
 	}
 
 	// Cloud DNS matches /dns/v1/projects/{p}/managedZones[...] — a distinct
@@ -310,7 +318,9 @@ func New(d Drivers) *server.Server {
 	// registration order among them is unconstrained. Registered before
 	// Firestore's permissive /v1/projects/ prefix so its paths aren't swallowed.
 	if d.Memorystore != nil {
-		srv.Register(memorystoresrv.New(d.Memorystore))
+		msH := memorystoresrv.New(d.Memorystore)
+		msH.SetOperationRegistry(opsReg)
+		srv.Register(msH)
 	}
 
 	// FCM matches /v1/projects/{p}/messages:send — disjoint from every other

--- a/server/gcp/gke/sdk_fidelity_test.go
+++ b/server/gcp/gke/sdk_fidelity_test.go
@@ -6,10 +6,13 @@ package gke_test
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
 	"google.golang.org/api/container/v1"
+	"google.golang.org/api/googleapi"
 )
 
 const selfLinkHost = "https://container.googleapis.com/v1/"
@@ -60,22 +63,25 @@ func TestSDKGKEOperationFullShape(t *testing.T) {
 	}
 }
 
-// TestSDKGKEForeignOperationStillDone proves the store-aware Matches lets an
+// TestSDKGKEForeignOperationNotFound proves the store-aware Matches lets an
 // operation the GKE mock never recorded fall through to the shared LRO poller
-// (which reports it done) instead of GKE 404ing it.
-func TestSDKGKEForeignOperationStillDone(t *testing.T) {
+// (instead of GKE greedily claiming and 404ing it), and that the shared poller
+// now 404s an operation name no service registered — real GCP returns NOT_FOUND
+// for an unknown operation id rather than masking it as done.
+func TestSDKGKEForeignOperationNotFound(t *testing.T) {
 	svc, project := newSDKClient(t)
 	ctx := context.Background()
 	loc := "us-central1"
 
-	got, err := svc.Projects.Locations.Operations.Get(parent(project, loc) + "/operations/operation-not-gke").
+	_, err := svc.Projects.Locations.Operations.Get(parent(project, loc) + "/operations/operation-not-gke").
 		Context(ctx).Do()
-	if err != nil {
-		t.Fatalf("operations.get (foreign): %v", err)
+	if err == nil {
+		t.Fatal("operations.get (foreign): want 404, got success")
 	}
 
-	if got.Status != "DONE" {
-		t.Fatalf("foreign op status = %q, want DONE", got.Status)
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != http.StatusNotFound {
+		t.Fatalf("operations.get (foreign): want 404, got %v", err)
 	}
 }
 

--- a/server/gcp/lro/handler.go
+++ b/server/gcp/lro/handler.go
@@ -7,18 +7,24 @@
 // paths become indistinguishable by URL alone — whichever handler is registered
 // first (alloydb/gke) would greedily answer every location operation poll and
 // 404 the ones it didn't create, shadowing artifactregistry, eventarc,
-// memorystore, etc.
+// memorystore, etc. This one handler, registered ahead of the service handlers,
+// owns all location-scoped operation polls uniformly.
 //
-// Every CloudEmu mutation completes synchronously (the create/delete response
-// already carries done:true with the result inlined), so an operation poll only
-// needs to report completion. This one handler, registered ahead of the
-// service handlers, answers all location-scoped operation polls uniformly with
-// a done operation — the single "operations host" the collapsed server needs.
+// Every CloudEmu mutation completes synchronously, but a client that polls the
+// returned operation name still expects two real-GCP behaviors the handler
+// must reproduce: the completed operation carries the typed result in its
+// `response`, and an operation name that was never created is 404 NOT_FOUND (not
+// masked as "done"). To do that the handler consults a shared Registry that each
+// service populates when it creates an operation. A handler built without a
+// Registry falls back to the legacy always-done response, so standalone
+// per-service package servers (which register their own operations handler) are
+// unaffected.
 package lro
 
 import (
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 )
@@ -29,11 +35,55 @@ const (
 	operationsSeg = "operations"
 )
 
-// Handler answers GET on location-scoped operation names.
-type Handler struct{}
+// Registry records the completed operations services create, keyed by the
+// operation resource name (e.g. "projects/p/locations/l/operations/op-1"), so
+// the shared poller can replay the typed response and 404 unknown names. It is
+// safe for concurrent use: services register operations while polls read them.
+type Registry struct {
+	mu  sync.RWMutex
+	ops map[string]any
+}
 
-// New returns the shared location-operations handler.
-func New() *Handler { return &Handler{} }
+// NewRegistry returns an empty operation registry.
+func NewRegistry() *Registry {
+	return &Registry{ops: make(map[string]any)}
+}
+
+// Register records a completed operation under its resource name together with
+// the typed response a poller reads off the done operation (nil for operations
+// whose result is empty, e.g. deletes). A nil registry is a no-op, so a service
+// wired without the shared poller (a standalone package server) is unaffected.
+func (r *Registry) Register(name string, response any) {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.ops[name] = response
+}
+
+// lookup returns the recorded response for name and whether it was registered.
+func (r *Registry) lookup(name string) (response any, found bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	response, found = r.ops[name]
+
+	return response, found
+}
+
+// Handler answers GET on location-scoped operation names.
+type Handler struct {
+	reg *Registry
+}
+
+// New returns the shared location-operations handler. When reg is non-nil the
+// handler resolves only operations that were registered (404ing unknown names
+// and echoing the registered response); when reg is nil it answers every poll
+// with a bare done operation (legacy standalone behavior).
+func New(reg *Registry) *Handler { return &Handler{reg: reg} }
 
 // Matches claims GET /v1/projects/{p}/locations/{l}/operations/{op}.
 func (*Handler) Matches(r *http.Request) bool {
@@ -46,22 +96,48 @@ func (*Handler) Matches(r *http.Request) bool {
 	return ok && op != ""
 }
 
-// ServeHTTP returns a completed operation echoing the polled name.
-func (*Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+// ServeHTTP returns the polled operation as a completed google.longrunning
+// Operation, carrying the registered typed response. An operation name that was
+// never registered is 404 NOT_FOUND, matching real GCP.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	project, location, op, ok := parse(r.URL.Path)
 	if !ok {
 		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "malformed operation path")
 		return
 	}
 
-	// Return a superset that satisfies both operation schemas served here:
-	// google.longrunning.Operation reads `done` (artifactregistry, eventarc,
-	// memorystore, alloydb), while GKE's container.Operation reads `status`.
-	gcprest.WriteJSON(w, http.StatusOK, map[string]any{
-		"name":   "projects/" + project + "/locations/" + location + "/operations/" + op,
+	name := "projects/" + project + "/locations/" + location + "/operations/" + op
+
+	if h.reg == nil {
+		writeDone(w, name, nil)
+		return
+	}
+
+	response, found := h.reg.lookup(name)
+	if !found {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "operation "+name+" not found")
+		return
+	}
+
+	writeDone(w, name, response)
+}
+
+// writeDone writes a completed operation. It returns a superset that satisfies
+// both operation schemas served here: google.longrunning.Operation reads `done`
+// (artifactregistry, eventarc, memorystore, alloydb) while GKE's
+// container.Operation reads `status`.
+func writeDone(w http.ResponseWriter, name string, response any) {
+	body := map[string]any{
+		"name":   name,
 		"done":   true,
 		"status": "DONE",
-	})
+	}
+
+	if response != nil {
+		body["response"] = response
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, body)
 }
 
 // parse splits /v1/projects/{p}/locations/{l}/operations/{op}.

--- a/server/gcp/lro/handler_test.go
+++ b/server/gcp/lro/handler_test.go
@@ -1,0 +1,95 @@
+package lro_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/server/gcp/lro"
+)
+
+const opPath = "/v1/projects/p/locations/us/operations/op-1"
+
+func get(t *testing.T, h *lro.Handler, path string) (int, string) {
+	t.Helper()
+
+	r := httptest.NewRequest(http.MethodGet, path, nil)
+	if !h.Matches(r) {
+		t.Fatalf("handler does not match %s", path)
+	}
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	return w.Code, w.Body.String()
+}
+
+// TestRegisteredOperationReturnsResponse verifies a registered operation
+// resolves to done with its typed response echoed back.
+func TestRegisteredOperationReturnsResponse(t *testing.T) {
+	reg := lro.NewRegistry()
+	reg.Register("projects/p/locations/us/operations/op-1",
+		map[string]any{"name": "widget-1", "state": "READY"})
+
+	code, body := get(t, lro.New(reg), opPath)
+	if code != http.StatusOK {
+		t.Fatalf("code=%d body=%s (want 200)", code, body)
+	}
+
+	for _, want := range []string{`"done":true`, `"response"`, "widget-1", "READY"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body %s missing %q", body, want)
+		}
+	}
+}
+
+// TestUnknownOperationIs404 verifies an operation name that was never registered
+// is 404 NOT_FOUND rather than masked as done.
+func TestUnknownOperationIs404(t *testing.T) {
+	code, body := get(t, lro.New(lro.NewRegistry()), opPath)
+	if code != http.StatusNotFound {
+		t.Fatalf("code=%d body=%s (want 404)", code, body)
+	}
+
+	if strings.Contains(body, `"done":true`) {
+		t.Fatalf("unknown op should not report done: %s", body)
+	}
+}
+
+// TestNilRegistryLegacyDone verifies a handler built without a registry keeps
+// the legacy always-done behaviour used by standalone package servers.
+func TestNilRegistryLegacyDone(t *testing.T) {
+	code, body := get(t, lro.New(nil), opPath)
+	if code != http.StatusOK || !strings.Contains(body, `"done":true`) {
+		t.Fatalf("code=%d body=%s (want 200 done:true)", code, body)
+	}
+}
+
+// TestRegistryConcurrentAccess exercises concurrent registration and polling so
+// the race detector guards the registry's mutex.
+func TestRegistryConcurrentAccess(t *testing.T) {
+	reg := lro.NewRegistry()
+	h := lro.New(reg)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			reg.Register("projects/p/locations/us/operations/op-1", map[string]any{"ok": true})
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			r := httptest.NewRequest(http.MethodGet, opPath, nil)
+			h.ServeHTTP(httptest.NewRecorder(), r)
+		}()
+	}
+
+	wg.Wait()
+}

--- a/server/gcp/memorystore/handler.go
+++ b/server/gcp/memorystore/handler.go
@@ -31,6 +31,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/stackshy/cloudemu/v2/server/gcp/lro"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
 )
@@ -46,7 +47,17 @@ const (
 // Handler serves redis.googleapis.com v1 requests against a cache driver.
 type Handler struct {
 	cache cachedriver.Cache
+
+	// ops records created operations with the shared poller so a client that
+	// polls the returned operation name gets the typed response (and unknown
+	// names 404). Nil in a standalone package server, where this handler serves
+	// its own /operations/ poll.
+	ops *lro.Registry
 }
+
+// SetOperationRegistry wires the shared LRO poller so created operations are
+// resolvable (with their response) through the full server's operations host.
+func (h *Handler) SetOperationRegistry(reg *lro.Registry) { h.ops = reg }
 
 // New returns a Memorystore handler backed by c.
 func New(c cachedriver.Cache) *Handler {
@@ -158,7 +169,7 @@ func (h *Handler) serveOperation(w http.ResponseWriter, r *http.Request, rt rout
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt.project, rt.location, rt.name, nil))
+	gcprest.WriteJSON(w, http.StatusOK, h.doneOperation(rt.project, rt.location, rt.name, nil))
 }
 
 func writeUnsupported(w http.ResponseWriter) {

--- a/server/gcp/memorystore/operations.go
+++ b/server/gcp/memorystore/operations.go
@@ -44,7 +44,7 @@ func (h *Handler) createInstance(w http.ResponseWriter, r *http.Request, rt rout
 		return
 	}
 
-	op := doneOperation(rt.project, rt.location, "create-"+instanceID, raw)
+	op := h.doneOperation(rt.project, rt.location, "create-"+instanceID, raw)
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
 }
@@ -119,7 +119,7 @@ func (h *Handler) patchInstance(w http.ResponseWriter, r *http.Request, rt route
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt.project, rt.location, "update-"+rt.name, raw))
+	gcprest.WriteJSON(w, http.StatusOK, h.doneOperation(rt.project, rt.location, "update-"+rt.name, raw))
 }
 
 // deleteInstance handles DELETE .../instances/{i} — Delete. The operation
@@ -130,7 +130,7 @@ func (h *Handler) deleteInstance(w http.ResponseWriter, r *http.Request, rt rout
 		return
 	}
 
-	op := doneOperation(rt.project, rt.location, "delete-"+rt.name, json.RawMessage("{}"))
+	op := h.doneOperation(rt.project, rt.location, "delete-"+rt.name, json.RawMessage("{}"))
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
 }

--- a/server/gcp/memorystore/types.go
+++ b/server/gcp/memorystore/types.go
@@ -305,10 +305,15 @@ func stateOrReady(status string) string {
 }
 
 // doneOperation builds a completed google.longrunning.Operation for the given
-// operation id. When resp is non-nil it is embedded as the operation response.
-func doneOperation(project, location, operationID string, resp json.RawMessage) operationJSON {
+// operation id and records it with the shared LRO poller so a client polling the
+// returned name resolves the same done operation (with its response) in the full
+// server. When resp is non-nil it is embedded as the operation response.
+func (h *Handler) doneOperation(project, location, operationID string, resp json.RawMessage) operationJSON {
+	name := operationResourceName(project, location, operationID)
+	h.ops.Register(name, resp)
+
 	return operationJSON{
-		Name:     operationResourceName(project, location, operationID),
+		Name:     name,
 		Done:     true,
 		Response: resp,
 	}


### PR DESCRIPTION
## What

The shared GCP long-running-operation poller (`server/gcp/lro`) answered **any** `GET /v1/projects/{p}/locations/{l}/operations/{op}` with a synthetic `{done:true, status:DONE}` and no response body. Two consequences, both flagged in `AUDIT_GCP.md ## lro`:

- A completed operation's **typed response was missing** on poll, so a GAPIC `.Wait()` read a zero-value resource off the operation.
- An operation name that was **never created was masked as `done`** instead of returning `404 NOT_FOUND` as real GCP does.

This adds a thread-safe operation **Registry** the poller consults:

- Services **register** the operations they create (name → typed response) at creation time.
- The poller **replays** a registered operation (done + its response), and **404s** any operation name that was never registered.
- A poller built **without** a registry keeps the legacy always-done behavior, so standalone per-service package servers (which serve their own `/operations/` poll) are unaffected.

## Why

Real GCP returns the typed result in a done operation's `response`, and 404s an unknown operation id. Masking unknown ops as done hides real "not found" errors from clients and breaks `CreateXOperation.Wait()` result decoding.

## Services wired

Only the location-scoped producers whose operations are routed through the shared poller register their ops (via `SetOperationRegistry`):

- **artifactregistry**
- **eventarc**
- **alloydb**
- **memorystore**

**GKE** is unchanged: it registers ahead of the poller and owns its own operations (richer `container.Operation` shape); its `Matches` only claims ops its mock recorded, so foreign/unknown names fall through and now correctly 404.

Non-producers are unaffected (disjoint paths / own handlers): Cloud Run and Cloud Functions poll on `/v2` (and CF gen1 on `/v1/operations`), Cloud SQL on `/v1/projects/{p}/operations`, Bigtable on `/v2/operations`, Cloud Asset on `projects/{p}/operations` — none of which match the poller's 5-segment location path. Vertex AI returns done-on-arrival inline and never polls.

## Tests

- `server/gcp/lro/handler_test.go` (new): registered op → done + response; unknown op → 404; nil-registry legacy done; concurrent register/poll under `-race`.
- `server/gcp/fullserver_test.go`: AR poll now also asserts the response body is present; added an unknown-op → 404 assertion; GKE poll uses the real returned operation name.
- `server/gcp/gke/sdk_fidelity_test.go`: the foreign-operation test now asserts `404 NOT_FOUND` (the corrected behavior) instead of the old masked-done.

Gates run (scoped, `GOMAXPROCS=3 -p=3`): `go build ./...`, `go vet`, `go test ./server/gcp/...`, `go test -race` on `lro` + fullserver, `golangci-lint` on changed packages (0 issues), `gofmt`.
