### PR TITLE
fix(aws-s3): enforce conditional writes (If-None-Match/If-Match→412) + conditional reads (304/412)

### DIFF
--- a/docs/coverage/aws/s3.md
+++ b/docs/coverage/aws/s3.md
@@ -101,6 +101,14 @@ BucketAttributes is an OPTIONAL capability, discovered by type assertion (like
 | --- | --- |
 | `BucketAttributes` |  |
 
+### ConditionalBucket
+
+ConditionalBucket is an OPTIONAL capability (discovered by type assertion like
+
+| Operation | Description |
+| --- | --- |
+| `PutObjectConditional` |  |
+
 ### GCSExtensions
 
 GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type

--- a/docs/coverage/azure/blobstorage.md
+++ b/docs/coverage/azure/blobstorage.md
@@ -101,6 +101,14 @@ BucketAttributes is an OPTIONAL capability, discovered by type assertion (like
 | --- | --- |
 | `BucketAttributes` |  |
 
+### ConditionalBucket
+
+ConditionalBucket is an OPTIONAL capability (discovered by type assertion like
+
+| Operation | Description |
+| --- | --- |
+| `PutObjectConditional` |  |
+
 ### GCSExtensions
 
 GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -10679,6 +10679,15 @@
         ]
       },
       {
+        "name": "ConditionalBucket",
+        "doc": "ConditionalBucket is an OPTIONAL capability (discovered by type assertion like",
+        "operations": [
+          {
+            "name": "PutObjectConditional"
+          }
+        ]
+      },
+      {
         "name": "GCSExtensions",
         "doc": "GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type",
         "operations": [

--- a/docs/coverage/gcp/gcs.md
+++ b/docs/coverage/gcp/gcs.md
@@ -101,6 +101,14 @@ BucketAttributes is an OPTIONAL capability, discovered by type assertion (like
 | --- | --- |
 | `BucketAttributes` |  |
 
+### ConditionalBucket
+
+ConditionalBucket is an OPTIONAL capability (discovered by type assertion like
+
+| Operation | Description |
+| --- | --- |
+| `PutObjectConditional` |  |
+
 ### GCSExtensions
 
 GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type

--- a/providers/aws/s3/conditional_test.go
+++ b/providers/aws/s3/conditional_test.go
@@ -1,0 +1,132 @@
+package s3
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// TestPutObjectConditionalIfNoneMatch verifies create-if-absent semantics: the
+// first If-None-Match:"*" write on a fresh key succeeds; a second one over the
+// now-existing key fails with FailedPrecondition and does NOT overwrite.
+func TestPutObjectConditionalIfNoneMatch(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "cb"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	pre := driver.S3PutPrecondition{IfNoneMatch: "*"}
+
+	if _, err := m.PutObjectConditional(ctx, "cb", "k", []byte("v1"), "text/plain", nil, pre); err != nil {
+		t.Fatalf("first create-if-absent: %v", err)
+	}
+
+	_, err := m.PutObjectConditional(ctx, "cb", "k", []byte("v2"), "text/plain", nil, pre)
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("second create-if-absent err = %v, want FailedPrecondition", err)
+	}
+
+	// The clobbering write must not have landed.
+	obj, err := m.GetObject(ctx, "cb", "k")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	if string(obj.Data) != "v1" {
+		t.Fatalf("body = %q, want v1 (failed condition must not overwrite)", obj.Data)
+	}
+}
+
+// TestPutObjectConditionalIfMatch verifies optimistic replace: an If-Match with
+// the current ETag succeeds; a stale ETag fails without overwriting; an If-Match
+// on a missing key fails.
+func TestPutObjectConditionalIfMatch(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "cb"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+	if err := m.PutObject(ctx, "cb", "k", []byte("v1"), "text/plain", nil); err != nil {
+		t.Fatalf("seed PutObject: %v", err)
+	}
+
+	info, err := m.HeadObject(ctx, "cb", "k")
+	if err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+
+	// Matching ETag -> success.
+	if _, err := m.PutObjectConditional(ctx, "cb", "k",
+		[]byte("v2"), "text/plain", nil, driver.S3PutPrecondition{IfMatch: info.ETag}); err != nil {
+		t.Fatalf("If-Match matching: %v", err)
+	}
+
+	// Stale ETag -> 412, no overwrite.
+	_, err = m.PutObjectConditional(ctx, "cb", "k",
+		[]byte("v3"), "text/plain", nil, driver.S3PutPrecondition{IfMatch: "0000000000000000000000000000dead"})
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("If-Match stale err = %v, want FailedPrecondition", err)
+	}
+	obj, err := m.GetObject(ctx, "cb", "k")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	if string(obj.Data) != "v2" {
+		t.Fatalf("body = %q, want v2", obj.Data)
+	}
+
+	// If-Match on a missing key -> 412.
+	_, err = m.PutObjectConditional(ctx, "cb", "missing",
+		[]byte("x"), "text/plain", nil, driver.S3PutPrecondition{IfMatch: info.ETag})
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("If-Match on missing key err = %v, want FailedPrecondition", err)
+	}
+}
+
+// TestPutObjectConditionalConcurrentCreate hammers the same fresh key with many
+// concurrent create-if-absent writers: exactly one must win, proving the guard
+// and the store are evaluated atomically (run with -race). A Get-then-Put
+// implementation would let several racing writers all observe "absent" and win.
+func TestPutObjectConditionalConcurrentCreate(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "cb"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	const writers = 32
+	var (
+		wins  atomic.Int64
+		start = make(chan struct{})
+		wg    sync.WaitGroup
+	)
+
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := m.PutObjectConditional(ctx, "cb", "race",
+				[]byte("v"), "text/plain", nil, driver.S3PutPrecondition{IfNoneMatch: "*"})
+			if err == nil {
+				wins.Add(1)
+			} else if !cerrors.IsFailedPrecondition(err) {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	if got := wins.Load(); got != 1 {
+		t.Fatalf("winners = %d, want exactly 1 (atomic create-if-absent)", got)
+	}
+}

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -355,9 +355,54 @@ func (m *Mock) PutObject(ctx context.Context, bucket, key string, data []byte, c
 		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
 	}
 
+	obj := m.newObject(key, data, contentType, metadata)
+	m.storeObject(bkt, key, obj)
+
+	return m.afterPut(ctx, bkt, bucket, key, obj, data, contentType, metadata)
+}
+
+// PutObjectConditional implements driver.ConditionalBucket: it writes the object
+// only if the If-None-Match / If-Match precondition holds, evaluating the guard
+// and the store atomically under versionsMu so concurrent create-if-absent
+// writers cannot both win. A failed precondition returns a FailedPrecondition
+// error (mapped to 412 by the wire handler) and leaves any existing object
+// untouched.
+func (m *Mock) PutObjectConditional(
+	ctx context.Context, bucket, key string, data []byte, contentType string,
+	metadata map[string]string, pre driver.S3PutPrecondition,
+) (*driver.ObjectInfo, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	obj := m.newObject(key, data, contentType, metadata)
+	if err := m.storeObjectConditional(bkt, key, obj, pre); err != nil {
+		return nil, err
+	}
+
+	if err := m.afterPut(ctx, bkt, bucket, key, obj, data, contentType, metadata); err != nil {
+		return nil, err
+	}
+
+	return &driver.ObjectInfo{
+		Key:          key,
+		Size:         obj.Size,
+		ContentType:  obj.ContentType,
+		ETag:         obj.ETag,
+		LastModified: obj.LastModified,
+		Metadata:     obj.Metadata,
+		VersionID:    obj.VersionID,
+	}, nil
+}
+
+// newObject builds a fresh current-object record from a PutObject body, copying
+// the bytes so a later caller mutation cannot alias stored data.
+func (m *Mock) newObject(key string, data []byte, contentType string, metadata map[string]string) *s3Object {
 	dataCopy := make([]byte, len(data))
 	copy(dataCopy, data)
-	obj := &s3Object{
+
+	return &s3Object{
 		Key:          key,
 		Data:         dataCopy,
 		Size:         int64(len(data)),
@@ -366,10 +411,16 @@ func (m *Mock) PutObject(ctx context.Context, bucket, key string, data []byte, c
 		LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
 		Metadata:     maps.Clone(metadata),
 	}
-	m.storeObject(bkt, key, obj)
+}
 
-	// storeObject stamps obj.VersionID, so the engine ref matches what GetObject
-	// (and GetObjectVersion for a versioned PUT) reads back.
+// afterPut runs the side effects shared by every PutObject variant: persist the
+// bytes to a configured storage engine, emit request metrics, and fire the
+// s3:ObjectCreated notification. storeObject has already stamped obj.VersionID,
+// so the engine ref matches what GetObject reads back.
+func (m *Mock) afterPut(
+	ctx context.Context, bkt *bucketMeta, bucket, key string, obj *s3Object,
+	data []byte, contentType string, metadata map[string]string,
+) error {
 	if err := m.engineStore(ctx, bucket, key, obj.VersionID, contentType, data, metadata); err != nil {
 		return err
 	}
@@ -398,14 +449,36 @@ const (
 
 func newVersionID() string { return idgen.GenerateID("") }
 
-// storeObject sets key's current object and, on a versioned bucket, records the
-// new version in history (stamping obj.VersionID). Enabled appends a fresh
-// version; Suspended overwrites the reusable "null" version; an unversioned
-// bucket keeps no history.
+// storeObject records key's current object under versionsMu (see
+// storeObjectLocked for the versioning behavior).
 func (m *Mock) storeObject(bkt *bucketMeta, key string, obj *s3Object) {
 	bkt.versionsMu.Lock()
 	defer bkt.versionsMu.Unlock()
 
+	m.storeObjectLocked(bkt, key, obj)
+}
+
+// storeObjectConditional evaluates an If-None-Match / If-Match precondition
+// against the current object and, only if it holds, stores obj — both under a
+// single versionsMu hold so the check and the write are atomic.
+func (m *Mock) storeObjectConditional(bkt *bucketMeta, key string, obj *s3Object, pre driver.S3PutPrecondition) error {
+	bkt.versionsMu.Lock()
+	defer bkt.versionsMu.Unlock()
+
+	if err := evalPutPrecondition(bkt, key, pre); err != nil {
+		return err
+	}
+
+	m.storeObjectLocked(bkt, key, obj)
+
+	return nil
+}
+
+// storeObjectLocked records key's current object; the caller must hold
+// versionsMu. On a versioned bucket it also appends/overwrites the version
+// history (stamping obj.VersionID). Enabled appends a fresh version; Suspended
+// overwrites the reusable "null" version; an unversioned bucket keeps no history.
+func (m *Mock) storeObjectLocked(bkt *bucketMeta, key string, obj *s3Object) {
 	// When an engine holds the bytes, the version record keeps only metadata +
 	// size; its bytes live in the engine under the version id (dropData).
 	dropData := m.opts.StorageEngine != nil
@@ -420,6 +493,36 @@ func (m *Mock) storeObject(bkt *bucketMeta, key string, obj *s3Object) {
 	}
 
 	bkt.objects.Set(key, obj)
+}
+
+// evalPutPrecondition reports whether a conditional PutObject may proceed. It
+// runs under versionsMu, reading the current object (a delete marker leaves no
+// current object, so the key reads as absent). If-None-Match: "*" requires the
+// object be absent; a specific ETag requires no current object with that ETag;
+// If-Match requires a current object whose ETag matches. A violated condition
+// returns FailedPrecondition (mapped to 412 PreconditionFailed at the wire).
+func evalPutPrecondition(bkt *bucketMeta, key string, pre driver.S3PutPrecondition) error {
+	cur, exists := bkt.objects.Get(key)
+
+	if pre.IfNoneMatch != "" {
+		if pre.IfNoneMatch == "*" && exists {
+			return failedPrecondition()
+		}
+
+		if pre.IfNoneMatch != "*" && exists && etagMatches(pre.IfNoneMatch, cur.ETag) {
+			return failedPrecondition()
+		}
+	}
+
+	if pre.IfMatch != "" && (!exists || !etagMatches(pre.IfMatch, cur.ETag)) {
+		return failedPrecondition()
+	}
+
+	return nil
+}
+
+func failedPrecondition() error {
+	return cerrors.New(cerrors.FailedPrecondition, "At least one of the preconditions you specified did not hold")
 }
 
 func versionFromObject(obj *s3Object, dropData bool) *s3Version {

--- a/server/aws/s3/conditional_sdk_test.go
+++ b/server/aws/s3/conditional_sdk_test.go
@@ -1,0 +1,254 @@
+package s3_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// putSimple seeds a key and returns its ETag.
+func putSimple(t *testing.T, c *awss3.Client, bucket, key, body string) string {
+	t.Helper()
+
+	out, err := c.PutObject(context.Background(), &awss3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader([]byte(body)),
+	})
+	if err != nil {
+		t.Fatalf("PutObject %s: %v", key, err)
+	}
+
+	return aws.ToString(out.ETag)
+}
+
+func mustGetBody(t *testing.T, c *awss3.Client, bucket, key string) string {
+	t.Helper()
+
+	out, err := c.GetObject(context.Background(), &awss3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatalf("GetObject %s: %v", key, err)
+	}
+	defer out.Body.Close()
+
+	data, err := io.ReadAll(out.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	return string(data)
+}
+
+// TestSDKPutObjectIfNoneMatchStar drives the real S3 conditional-write flow:
+// create-if-absent succeeds on a new key and returns 412 PreconditionFailed on an
+// existing key, without clobbering the stored object.
+func TestSDKPutObjectIfNoneMatchStar(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket, key = "cond-write", "obj"
+	mustCreateBucket(t, client, bucket)
+
+	// First create-if-absent succeeds.
+	if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket:      aws.String(bucket),
+		Key:         aws.String(key),
+		Body:        bytes.NewReader([]byte("v1")),
+		IfNoneMatch: aws.String("*"),
+	}); err != nil {
+		t.Fatalf("create-if-absent (new key): %v", err)
+	}
+
+	// Second create-if-absent over the existing key -> 412, no overwrite.
+	_, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket:      aws.String(bucket),
+		Key:         aws.String(key),
+		Body:        bytes.NewReader([]byte("v2")),
+		IfNoneMatch: aws.String("*"),
+	})
+	assertAPICode(t, err, "PreconditionFailed")
+	assertStatus(t, err, 412)
+
+	if got := mustGetBody(t, client, bucket, key); got != "v1" {
+		t.Fatalf("body = %q, want v1 (failed condition must not overwrite)", got)
+	}
+}
+
+// TestSDKPutObjectIfMatch verifies optimistic replace: a matching ETag succeeds
+// and a stale ETag returns 412 without overwriting.
+func TestSDKPutObjectIfMatch(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket, key = "cond-write-match", "obj"
+	mustCreateBucket(t, client, bucket)
+	etag := putSimple(t, client, bucket, key, "v1")
+
+	// Matching ETag -> success.
+	if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket:  aws.String(bucket),
+		Key:     aws.String(key),
+		Body:    bytes.NewReader([]byte("v2")),
+		IfMatch: aws.String(etag),
+	}); err != nil {
+		t.Fatalf("If-Match matching: %v", err)
+	}
+
+	// Stale ETag -> 412, no overwrite.
+	_, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket:  aws.String(bucket),
+		Key:     aws.String(key),
+		Body:    bytes.NewReader([]byte("v3")),
+		IfMatch: aws.String("\"0000000000000000000000000000dead\""),
+	})
+	assertAPICode(t, err, "PreconditionFailed")
+	assertStatus(t, err, 412)
+
+	if got := mustGetBody(t, client, bucket, key); got != "v2" {
+		t.Fatalf("body = %q, want v2", got)
+	}
+}
+
+// TestSDKGetObjectIfNoneMatch verifies a revalidating GET: a matching
+// If-None-Match returns 304 Not Modified, and a non-matching one serves the body.
+func TestSDKGetObjectIfNoneMatch(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket, key = "cond-read", "obj"
+	mustCreateBucket(t, client, bucket)
+	etag := putSimple(t, client, bucket, key, "hello")
+
+	// Matching ETag -> 304.
+	_, err := client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket:      aws.String(bucket),
+		Key:         aws.String(key),
+		IfNoneMatch: aws.String(etag),
+	})
+	assertStatus(t, err, 304)
+
+	// Different ETag -> 200 + body.
+	out, err := client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket:      aws.String(bucket),
+		Key:         aws.String(key),
+		IfNoneMatch: aws.String("\"0000000000000000000000000000dead\""),
+	})
+	if err != nil {
+		t.Fatalf("GetObject If-None-Match mismatch: %v", err)
+	}
+	out.Body.Close()
+}
+
+// TestSDKGetObjectIfMatch verifies a wrong If-Match returns 412.
+func TestSDKGetObjectIfMatch(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket, key = "cond-read-match", "obj"
+	mustCreateBucket(t, client, bucket)
+	etag := putSimple(t, client, bucket, key, "hello")
+
+	// Matching ETag -> 200.
+	out, err := client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket:  aws.String(bucket),
+		Key:     aws.String(key),
+		IfMatch: aws.String(etag),
+	})
+	if err != nil {
+		t.Fatalf("GetObject If-Match matching: %v", err)
+	}
+	out.Body.Close()
+
+	// Wrong ETag -> 412.
+	_, err = client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket:  aws.String(bucket),
+		Key:     aws.String(key),
+		IfMatch: aws.String("\"0000000000000000000000000000dead\""),
+	})
+	assertAPICode(t, err, "PreconditionFailed")
+	assertStatus(t, err, 412)
+}
+
+// TestSDKGetObjectIfModifiedSince verifies a future If-Modified-Since returns 304
+// (the object has not been modified since a future time).
+func TestSDKGetObjectIfModifiedSince(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket, key = "cond-read-time", "obj"
+	mustCreateBucket(t, client, bucket)
+	putSimple(t, client, bucket, key, "hello")
+
+	_, err := client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket:          aws.String(bucket),
+		Key:             aws.String(key),
+		IfModifiedSince: aws.Time(time.Now().Add(24 * time.Hour)),
+	})
+	assertStatus(t, err, 304)
+}
+
+// TestSDKGetObjectIfUnmodifiedSince verifies a past If-Unmodified-Since returns
+// 412 (the object was modified after that time).
+func TestSDKGetObjectIfUnmodifiedSince(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket, key = "cond-read-unmod", "obj"
+	mustCreateBucket(t, client, bucket)
+	putSimple(t, client, bucket, key, "hello")
+
+	_, err := client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket:            aws.String(bucket),
+		Key:               aws.String(key),
+		IfUnmodifiedSince: aws.Time(time.Now().Add(-24 * time.Hour)),
+	})
+	assertAPICode(t, err, "PreconditionFailed")
+	assertStatus(t, err, 412)
+}
+
+// TestSDKGetObjectIfMatchOverridesUnmodifiedSince pins RFC 7232 precedence: a
+// true If-Match overrides a false If-Unmodified-Since, so S3 serves 200.
+func TestSDKGetObjectIfMatchOverridesUnmodifiedSince(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket, key = "cond-read-prec", "obj"
+	mustCreateBucket(t, client, bucket)
+	etag := putSimple(t, client, bucket, key, "hello")
+
+	out, err := client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket:            aws.String(bucket),
+		Key:               aws.String(key),
+		IfMatch:           aws.String(etag),
+		IfUnmodifiedSince: aws.Time(time.Now().Add(-24 * time.Hour)),
+	})
+	if err != nil {
+		t.Fatalf("If-Match should override If-Unmodified-Since, got: %v", err)
+	}
+	out.Body.Close()
+}
+
+// TestSDKHeadObjectIfNoneMatch verifies conditional HEAD returns 304 on a match.
+func TestSDKHeadObjectIfNoneMatch(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket, key = "cond-head", "obj"
+	mustCreateBucket(t, client, bucket)
+	etag := putSimple(t, client, bucket, key, "hello")
+
+	_, err := client.HeadObject(ctx, &awss3.HeadObjectInput{
+		Bucket:      aws.String(bucket),
+		Key:         aws.String(key),
+		IfNoneMatch: aws.String(etag),
+	})
+	assertStatus(t, err, 304)
+}

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -54,6 +54,9 @@ type Handler struct {
 	// regional is set when the driver can create a bucket in a caller-specified
 	// region (CreateBucketConfiguration.LocationConstraint).
 	regional driver.RegionalBucket
+	// conditional is set when the driver can perform an atomic conditional
+	// PutObject; the handler then enforces If-None-Match/If-Match on writes.
+	conditional driver.ConditionalBucket
 }
 
 // New returns an S3 handler backed by b.
@@ -73,6 +76,10 @@ func New(b driver.Bucket) *Handler {
 
 	if rb, ok := b.(driver.RegionalBucket); ok {
 		h.regional = rb
+	}
+
+	if cb, ok := b.(driver.ConditionalBucket); ok {
+		h.conditional = cb
 	}
 
 	return h
@@ -596,38 +603,98 @@ func (h *Handler) putObject(w http.ResponseWriter, r *http.Request, bucket, key 
 
 	metadata := extractMetadata(r.Header)
 
-	if err := h.bucket.PutObject(r.Context(), bucket, key, data, contentType, metadata); err != nil {
-		writeErr(w, err)
+	etag, versionID, ok := h.storePut(w, r, bucket, key, data, contentType, metadata)
+	if !ok {
+		return // error response already written
+	}
+
+	// x-amz-tagging sets the object's tag set at upload time; apply it so
+	// GetObjectTagging returns it (real S3 stores it atomically with the object).
+	if !h.applyPutTagging(w, r, bucket, key) {
 		return
 	}
 
-	// x-amz-tagging sets the object's tag set at upload time. Apply it to the
-	// just-written object so GetObjectTagging returns it (real S3 stores the tag
-	// set atomically with the object).
-	if tags := parseTaggingHeader(r.Header.Get("X-Amz-Tagging")); len(tags) > 0 {
-		if err := h.bucket.PutObjectTagging(r.Context(), bucket, key, tags); err != nil {
-			writeErr(w, err)
-			return
-		}
+	w.Header().Set("ETag", fmt.Sprintf("%q", etag))
+
+	if versionID != "" {
+		w.Header().Set("X-Amz-Version-Id", versionID)
 	}
 
-	// Real S3 always returns the object's ETag on PutObject. Read it back
-	// from the driver so there is a single source of truth for the ETag
-	// algorithm; if a concurrent delete races the read-back, fall back to
-	// computing it from the body we just stored — a successful PUT must
-	// never answer 404.
-	etag := hex.EncodeToString(md5Sum(data))
+	w.WriteHeader(http.StatusOK)
+}
 
-	var versionID string
+// storePut writes the object, routing through the atomic conditional-write path
+// when an If-None-Match/If-Match header is present and the driver supports it.
+// On failure it writes the error response and returns ok=false; otherwise it
+// returns the stored object's ETag and version id.
+func (h *Handler) storePut(
+	w http.ResponseWriter, r *http.Request, bucket, key string,
+	data []byte, contentType string, metadata map[string]string,
+) (etag, versionID string, ok bool) {
+	ifNoneMatch := r.Header.Get("If-None-Match")
+	ifMatch := r.Header.Get("If-Match")
+
+	if (ifNoneMatch != "" || ifMatch != "") && h.conditional != nil {
+		return h.storePutConditional(w, r, bucket, key, data, contentType, metadata, ifNoneMatch, ifMatch)
+	}
+
+	if err := h.bucket.PutObject(r.Context(), bucket, key, data, contentType, metadata); err != nil {
+		writeErr(w, err)
+		return "", "", false
+	}
+
+	// Real S3 always returns the object's ETag. Read it back from the driver so
+	// there is a single source of truth for the ETag algorithm; if a concurrent
+	// delete races the read-back, fall back to computing it from the body we
+	// just stored — a successful PUT must never answer 404.
+	etag = hex.EncodeToString(md5Sum(data))
 	if info, err := h.bucket.HeadObject(r.Context(), bucket, key); err == nil {
 		etag = info.ETag
 		versionID = info.VersionID
 	}
-	w.Header().Set("ETag", fmt.Sprintf("%q", etag))
-	if versionID != "" {
-		w.Header().Set("X-Amz-Version-Id", versionID)
+
+	return etag, versionID, true
+}
+
+// storePutConditional performs an atomic If-None-Match/If-Match PutObject. A
+// failed precondition is answered 412 PreconditionFailed.
+func (h *Handler) storePutConditional(
+	w http.ResponseWriter, r *http.Request, bucket, key string,
+	data []byte, contentType string, metadata map[string]string, ifNoneMatch, ifMatch string,
+) (etag, versionID string, ok bool) {
+	pre := driver.S3PutPrecondition{IfNoneMatch: ifNoneMatch, IfMatch: ifMatch}
+
+	info, err := h.conditional.PutObjectConditional(r.Context(), bucket, key, data, contentType, metadata, pre)
+	if err != nil {
+		if cerrors.IsFailedPrecondition(err) {
+			writeError(w, http.StatusPreconditionFailed, "PreconditionFailed",
+				"At least one of the preconditions you specified did not hold.")
+
+			return "", "", false
+		}
+
+		writeErr(w, err)
+
+		return "", "", false
 	}
-	w.WriteHeader(http.StatusOK)
+
+	return info.ETag, info.VersionID, true
+}
+
+// applyPutTagging stores the x-amz-tagging tag set on the just-written object.
+// It returns false (after writing the error response) if the driver rejects it.
+func (h *Handler) applyPutTagging(w http.ResponseWriter, r *http.Request, bucket, key string) bool {
+	tags := parseTaggingHeader(r.Header.Get("X-Amz-Tagging"))
+	if len(tags) == 0 {
+		return true
+	}
+
+	if err := h.bucket.PutObjectTagging(r.Context(), bucket, key, tags); err != nil {
+		writeErr(w, err)
+		return false
+	}
+
+	return true
 }
 
 func (h *Handler) getObject(w http.ResponseWriter, r *http.Request, bucket, key string) {
@@ -649,6 +716,10 @@ func (h *Handler) getObject(w http.ResponseWriter, r *http.Request, bucket, key 
 			return
 		}
 		writeErr(w, err)
+		return
+	}
+
+	if handleReadConditions(w, r.Header, &obj.Info) {
 		return
 	}
 
@@ -793,8 +864,114 @@ func (h *Handler) headObject(w http.ResponseWriter, r *http.Request, bucket, key
 		return
 	}
 
+	if handleReadConditions(w, r.Header, info) {
+		return
+	}
+
 	writeObjectHeaders(w, info, info.Size)
 	w.WriteHeader(http.StatusOK)
+}
+
+// condReadOutcome classifies a GET/HEAD conditional-header evaluation.
+type condReadOutcome int
+
+const (
+	condProceed            condReadOutcome = iota // serve the object (200/206)
+	condNotModified                               // 304 Not Modified
+	condPreconditionFailed                        // 412 Precondition Failed
+)
+
+// handleReadConditions evaluates the four conditional-read headers against the
+// object and, when they are not satisfied, writes the 304 or 412 response and
+// returns true (so the caller must stop). It returns false to serve normally.
+func handleReadConditions(w http.ResponseWriter, hdr http.Header, info *driver.ObjectInfo) bool {
+	switch evalReadConditions(hdr, info.ETag, info.LastModified) {
+	case condNotModified:
+		writeNotModified(w, info)
+		return true
+	case condPreconditionFailed:
+		writeError(w, http.StatusPreconditionFailed, "PreconditionFailed",
+			"At least one of the preconditions you specified did not hold.")
+		return true
+	case condProceed:
+		return false
+	default:
+		return false
+	}
+}
+
+// evalReadConditions applies RFC 7232 §6 precedence for GET/HEAD: If-Match takes
+// precedence over If-Unmodified-Since (the match group → 412), and If-None-Match
+// takes precedence over If-Modified-Since (the modification group → 304); the
+// match group is evaluated before the modification group.
+func evalReadConditions(hdr http.Header, etag, lastModified string) condReadOutcome {
+	etag = strings.Trim(etag, `"`)
+	mod, modOK := parseObjectTime(lastModified)
+
+	if matchGroupFails(hdr, etag, mod, modOK) {
+		return condPreconditionFailed
+	}
+
+	if noneMatchGroupNotModified(hdr, etag, mod, modOK) {
+		return condNotModified
+	}
+
+	return condProceed
+}
+
+// matchGroupFails evaluates the 412 group: a present If-Match takes precedence
+// over If-Unmodified-Since, which is only considered when If-Match is absent.
+func matchGroupFails(hdr http.Header, etag string, mod time.Time, modOK bool) bool {
+	if ifMatch := hdr.Get("If-Match"); ifMatch != "" {
+		return !etagHeaderMatches(ifMatch, etag)
+	}
+
+	ifUnmodifiedSince := hdr.Get("If-Unmodified-Since")
+	if ifUnmodifiedSince == "" || !modOK {
+		return false
+	}
+
+	t, err := http.ParseTime(ifUnmodifiedSince)
+
+	return err == nil && mod.After(t)
+}
+
+// noneMatchGroupNotModified evaluates the 304 group: a present If-None-Match
+// takes precedence over If-Modified-Since, which is only considered when
+// If-None-Match is absent.
+func noneMatchGroupNotModified(hdr http.Header, etag string, mod time.Time, modOK bool) bool {
+	if ifNoneMatch := hdr.Get("If-None-Match"); ifNoneMatch != "" {
+		return etagHeaderMatches(ifNoneMatch, etag)
+	}
+
+	ifModifiedSince := hdr.Get("If-Modified-Since")
+	if ifModifiedSince == "" || !modOK {
+		return false
+	}
+
+	t, err := http.ParseTime(ifModifiedSince)
+
+	return err == nil && !mod.After(t)
+}
+
+// parseObjectTime parses a stored ObjectInfo.LastModified timestamp (RFC3339).
+func parseObjectTime(lastModified string) (time.Time, bool) {
+	t, err := time.Parse(time.RFC3339, lastModified)
+
+	return t, err == nil
+}
+
+// writeNotModified answers a satisfied If-None-Match/If-Modified-Since read with
+// 304 and the validators (ETag/Last-Modified) but no body, per RFC 7232.
+func writeNotModified(w http.ResponseWriter, info *driver.ObjectInfo) {
+	w.Header().Set("ETag", fmt.Sprintf("%q", info.ETag))
+	w.Header().Set("Last-Modified", wire.ToHTTPDate(info.LastModified))
+
+	if info.VersionID != "" {
+		w.Header().Set("X-Amz-Version-Id", info.VersionID)
+	}
+
+	w.WriteHeader(http.StatusNotModified)
 }
 
 func writeObjectHeaders(w http.ResponseWriter, info *driver.ObjectInfo, size int64) {
@@ -1176,9 +1353,15 @@ func evalCopySourceTimeConditions(hdr http.Header, lastModified string, skipUnmo
 }
 
 // copySourceETagMatches reports whether a copy-source-if-[none-]match header
-// value matches the source ETag: "*" matches any object; otherwise a
-// quote-insensitive, case-insensitive comparison.
+// value matches the source ETag.
 func copySourceETagMatches(header, etag string) bool {
+	return etagHeaderMatches(header, etag)
+}
+
+// etagHeaderMatches reports whether an If-[None-]Match header value matches the
+// object ETag: "*" matches any object; otherwise a quote-insensitive,
+// case-insensitive comparison. The caller must pass an unquoted etag.
+func etagHeaderMatches(header, etag string) bool {
 	header = strings.Trim(header, `"`)
 
 	return header == "*" || strings.EqualFold(header, etag)

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -624,6 +624,32 @@ type Bucket interface {
 	DeleteBucketTagging(ctx context.Context, bucket string) error
 }
 
+// S3PutPrecondition carries the S3 conditional-write headers (If-None-Match /
+// If-Match) sent on a plain PutObject, the guard AWS added for S3 conditional
+// writes. A zero value means an unconditional write. IfNoneMatch == "*" means
+// "the object must not already exist" (create-if-absent); a specific ETag means
+// "no current object with that ETag may exist". IfMatch == "<etag>" means "the
+// current object's ETag must match" (optimistic replace). A failed condition
+// must abort the write with a FailedPrecondition error, leaving any existing
+// object untouched, and must be evaluated atomically with the store so a
+// Get-then-Put race cannot lose an update.
+type S3PutPrecondition struct {
+	IfNoneMatch string
+	IfMatch     string
+}
+
+// ConditionalBucket is an OPTIONAL capability (discovered by type assertion like
+// VersionedBucket) letting a driver perform an atomic conditional PutObject that
+// honors the If-None-Match / If-Match request headers. The returned ObjectInfo
+// carries the stored ETag and (on a versioned bucket) the minted VersionID so
+// the wire handler can answer with them.
+type ConditionalBucket interface {
+	PutObjectConditional(
+		ctx context.Context, bucket, key string, data []byte, contentType string,
+		metadata map[string]string, pre S3PutPrecondition,
+	) (*ObjectInfo, error)
+}
+
 // GCSPrecondition carries the GCS write preconditions
 // (ifGenerationMatch/ifGenerationNotMatch/ifMetagenerationMatch/
 // ifMetagenerationNotMatch query parameters). A nil pointer means the caller


### PR DESCRIPTION
## What

Enforce S3 conditional requests on the AWS wire path, closing two HIGH bugs from the deep-e2e audit.

### F1 [HIGH] — Conditional writes on PutObject were silently ignored
`PutObject` with `If-None-Match: *` (create-if-absent) or `If-Match: <etag>` (optimistic replace) used to return 200 and overwrite the object regardless of the condition, breaking create-if-absent and optimistic-lock patterns (e.g. Terraform S3 state locking; AWS added S3 conditional writes in 2024).

Now the condition is enforced and a failed condition returns **412 PreconditionFailed** without overwriting. The check-and-set is done atomically in the provider under `versionsMu` (new optional `driver.ConditionalBucket` capability, mirroring the existing GCS `PutObjectGCS(..., precondition)` pattern) so concurrent create-if-absent writers cannot both win — no Get-then-Put lost-update race.

### F2 [HIGH] — Conditional reads on GetObject/HeadObject were ignored
`If-Match`, `If-Unmodified-Since`, `If-None-Match`, `If-Modified-Since` on GET/HEAD were ignored and always returned 200 + full body. Now they are evaluated (server-only) with RFC 7232 §6 precedence — If-Match beats If-Unmodified-Since (fail → 412), If-None-Match beats If-Modified-Since (match → 304) — returning **304 Not Modified** or **412 PreconditionFailed** as appropriate. Verified against the official AWS S3 GetObject/PutObject docs.

## Why

These are the exact guards clients rely on to prevent clobbering and to revalidate caches; ignoring them is a silent wrong-result / data-loss-adjacent bug.

## Tests

Real `aws-sdk-go-v2` reproductions: PutObject `If-None-Match:*` new-key success / existing-key 412; `If-Match` match success / stale 412 / missing-key 412; GET `If-None-Match` match 304, `If-Modified-Since` future 304, `If-Match` mismatch 412, `If-Unmodified-Since` violated 412; precedence (If-Match overrides If-Unmodified-Since); HEAD 304. Provider-level `-race` test proving exactly one concurrent create-if-absent writer wins. Existing S3 tests (incl. copy-source conditionals) remain green. Coverage docs regenerated.
