### PR TITLE
fix(aws-ec2): terminate detaches EBS volumes + atomic AttachVolume + attach/detach state validation

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -7126,7 +7126,7 @@ func TestVolumeLifecycleAWS(t *testing.T) {
 		t.Errorf("expected state 'in-use', got %q", vols[0].State)
 	}
 
-	if err := p.EC2.DetachVolume(ctx, vol.ID); err != nil {
+	if err := p.EC2.DetachVolume(ctx, vol.ID, "", ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/docs/coverage/aws/ec2.md
+++ b/docs/coverage/aws/ec2.md
@@ -28,7 +28,7 @@ AWS's `compute` service · portable interface `driver.Compute` · [AWS index](./
 | `DescribeSnapshots` |  |
 | `DescribeSpotRequests` |  |
 | `DescribeVolumes` |  |
-| `DetachVolume` |  |
+| `DetachVolume` | DetachVolume detaches a volume. When instanceID or device is non-empty it |
 | `ExecuteScalingPolicy` |  |
 | `GetAutoScalingGroup` |  |
 | `GetLaunchTemplate` |  |

--- a/docs/coverage/azure/virtualmachines.md
+++ b/docs/coverage/azure/virtualmachines.md
@@ -28,7 +28,7 @@ Azure's `compute` service · portable interface `driver.Compute` · [Azure index
 | `DescribeSnapshots` |  |
 | `DescribeSpotRequests` |  |
 | `DescribeVolumes` |  |
-| `DetachVolume` |  |
+| `DetachVolume` | DetachVolume detaches a volume. When instanceID or device is non-empty it |
 | `ExecuteScalingPolicy` |  |
 | `GetAutoScalingGroup` |  |
 | `GetLaunchTemplate` |  |

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -1960,7 +1960,8 @@
         "name": "DescribeVolumes"
       },
       {
-        "name": "DetachVolume"
+        "name": "DetachVolume",
+        "doc": "DetachVolume detaches a volume. When instanceID or device is non-empty it"
       },
       {
         "name": "ExecuteScalingPolicy"

--- a/docs/coverage/gcp/gce.md
+++ b/docs/coverage/gcp/gce.md
@@ -28,7 +28,7 @@ GCP's `compute` service · portable interface `driver.Compute` · [GCP index](./
 | `DescribeSnapshots` |  |
 | `DescribeSpotRequests` |  |
 | `DescribeVolumes` |  |
-| `DetachVolume` |  |
+| `DetachVolume` | DetachVolume detaches a volume. When instanceID or device is non-empty it |
 | `ExecuteScalingPolicy` |  |
 | `GetAutoScalingGroup` |  |
 | `GetLaunchTemplate` |  |

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -217,6 +217,14 @@ func (d *instanceData) terminationProtected() bool {
 	return d.disableAPITermination
 }
 
+// readState returns the instance's current lifecycle state under mu.
+func (d *instanceData) readState() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.State
+}
+
 // isEngineBacked reports whether a real compute engine backs this instance,
 // read under mu.
 func (d *instanceData) isEngineBacked() bool {
@@ -824,6 +832,10 @@ func (m *Mock) TerminateInstances(ctx context.Context, instanceIDs []string) err
 		return err
 	}
 
+	// Every attached EBS volume must be released, otherwise it stays in-use
+	// against a dead instance forever and can never be deleted (VolumeInUse).
+	m.detachTerminatedVolumes(instanceIDs)
+
 	// Tear down the real backing for any engine-backed instances. Every id is now
 	// Terminated (transitionInstances verified they exist), and a Terminated
 	// instance can't be terminated again — so this must be best-effort: continue
@@ -1285,53 +1297,127 @@ func (m *Mock) DescribeVolumes(_ context.Context, ids []string) ([]driver.Volume
 
 // AttachVolume attaches a volume to an instance.
 func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device string) error {
-	vol, ok := m.volumes.Get(volumeID)
+	// The target instance must exist and be in a state that can take an
+	// attachment. Real EC2 rejects attaching to a pending/shutting-down/
+	// terminated instance with IncorrectInstanceState — a volume can only
+	// attach to a running or stopped instance.
+	inst, ok := m.instances.Get(instanceID)
 	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "volume %q not found", volumeID)
-	}
-
-	if vol.State == stateInUse {
-		return cerrors.Newf(cerrors.FailedPrecondition,
-			"VolumeInUse: volume %q is attached to instance %q", volumeID, vol.AttachedTo)
-	}
-
-	if _, ok := m.instances.Get(instanceID); !ok {
 		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
 	}
 
-	// A volume can only attach to an instance in the SAME Availability Zone
-	// (real EC2 InvalidVolume.ZoneMismatch). Instances aren't placed in an
-	// explicit zone here, so they occupy the region's default zone, which is
-	// what CreateVolume also defaults to — an explicit cross-AZ volume mismatches.
-	if instZone := m.opts.Region + "a"; vol.AvailabilityZone != "" && vol.AvailabilityZone != instZone {
+	if state := inst.readState(); state != compute.StateRunning && state != compute.StateStopped {
 		return cerrors.Newf(cerrors.FailedPrecondition,
-			"ZoneMismatch: volume %q is in availability zone %q but instance %q is in %q",
-			volumeID, vol.AvailabilityZone, instanceID, instZone)
+			"IncorrectInstanceState: instance %q is in state %q; a volume can only attach to a running or stopped instance",
+			instanceID, state)
 	}
 
-	vol.State = stateInUse
-	vol.AttachedTo = instanceID
-	vol.Device = device
+	// Instances aren't placed in an explicit zone here, so they occupy the
+	// region's default zone, which is what CreateVolume also defaults to.
+	instZone := m.opts.Region + "a"
 
-	return nil
-}
+	// Atomic check-and-set: the "is this volume available?" test and the "mark
+	// it attached" write happen together under the store lock, so two concurrent
+	// attaches of the same volume have exactly one winner (the loser sees
+	// VolumeInUse). The fn returns a fresh pointer (copy-on-write) so a
+	// concurrent DescribeVolumes, which dereferences the stored pointer outside
+	// the store lock, never races with the field writes.
+	var attachErr error
 
-// DetachVolume detaches a volume from an instance.
-func (m *Mock) DetachVolume(_ context.Context, volumeID string) error {
-	vol, ok := m.volumes.Get(volumeID)
-	if !ok {
+	found := m.volumes.Update(volumeID, func(v *driver.VolumeInfo) *driver.VolumeInfo {
+		if v.State == stateInUse {
+			attachErr = cerrors.Newf(cerrors.FailedPrecondition,
+				"VolumeInUse: volume %q is attached to instance %q", volumeID, v.AttachedTo)
+
+			return v
+		}
+
+		// A volume can only attach to an instance in the SAME Availability Zone
+		// (real EC2 InvalidVolume.ZoneMismatch); an explicit cross-AZ volume mismatches.
+		if v.AvailabilityZone != "" && v.AvailabilityZone != instZone {
+			attachErr = cerrors.Newf(cerrors.FailedPrecondition,
+				"ZoneMismatch: volume %q is in availability zone %q but instance %q is in %q",
+				volumeID, v.AvailabilityZone, instanceID, instZone)
+
+			return v
+		}
+
+		cp := *v
+		cp.State = stateInUse
+		cp.AttachedTo = instanceID
+		cp.Device = device
+
+		return &cp
+	})
+	if !found {
 		return cerrors.Newf(cerrors.NotFound, "volume %q not found", volumeID)
 	}
 
-	if vol.State != "in-use" {
-		return cerrors.Newf(cerrors.FailedPrecondition, "volume %q is not attached", volumeID)
+	return attachErr
+}
+
+// DetachVolume detaches a volume from an instance. A non-empty instanceID or
+// device must match the volume's current attachment; real EC2 answers
+// InvalidAttachment.NotFound when the volume is not attached to the named
+// instance/device.
+func (m *Mock) DetachVolume(_ context.Context, volumeID, instanceID, device string) error {
+	var detachErr error
+
+	found := m.volumes.Update(volumeID, func(v *driver.VolumeInfo) *driver.VolumeInfo {
+		if v.State != stateInUse {
+			detachErr = cerrors.Newf(cerrors.FailedPrecondition, "volume %q is not attached", volumeID)
+
+			return v
+		}
+
+		if (instanceID != "" && instanceID != v.AttachedTo) || (device != "" && device != v.Device) {
+			detachErr = cerrors.Newf(cerrors.NotFound,
+				"InvalidAttachment.NotFound: volume %q is not attached to instance %q as device %q",
+				volumeID, instanceID, device)
+
+			return v
+		}
+
+		cp := *v
+		cp.State = stateAvailable
+		cp.AttachedTo = ""
+		cp.Device = ""
+
+		return &cp
+	})
+	if !found {
+		return cerrors.Newf(cerrors.NotFound, "volume %q not found", volumeID)
 	}
 
-	vol.State = stateAvailable
-	vol.AttachedTo = ""
-	vol.Device = ""
+	return detachErr
+}
 
-	return nil
+// detachTerminatedVolumes returns every EBS volume attached to a now-terminated
+// instance to the `available` state (attachment cleared). Real EC2 detaches
+// volumes with DeleteOnTermination=false back to available on terminate; user-
+// attached volumes carry that default, so all of them detach here. Each volume
+// is updated with a copy-on-write fresh pointer under the store lock so a
+// concurrent DescribeVolumes/AttachVolume never races.
+func (m *Mock) detachTerminatedVolumes(instanceIDs []string) {
+	terminated := make(map[string]bool, len(instanceIDs))
+	for _, id := range instanceIDs {
+		terminated[id] = true
+	}
+
+	for _, volID := range m.volumes.Keys() {
+		m.volumes.Update(volID, func(v *driver.VolumeInfo) *driver.VolumeInfo {
+			if v.AttachedTo == "" || !terminated[v.AttachedTo] {
+				return v
+			}
+
+			cp := *v
+			cp.State = stateAvailable
+			cp.AttachedTo = ""
+			cp.Device = ""
+
+			return &cp
+		})
+	}
 }
 
 // CreateSnapshot creates a snapshot from a volume.

--- a/providers/aws/ec2/ec2_test.go
+++ b/providers/aws/ec2/ec2_test.go
@@ -531,7 +531,7 @@ func TestDetachVolume(t *testing.T) {
 		err = m.AttachVolume(ctx, vol.ID, instances[0].ID, "/dev/sdf")
 		requireNoError(t, err)
 
-		err = m.DetachVolume(ctx, vol.ID)
+		err = m.DetachVolume(ctx, vol.ID, "", "")
 		requireNoError(t, err)
 
 		// Verify state changed back to available
@@ -548,9 +548,81 @@ func TestDetachVolume(t *testing.T) {
 		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
 		requireNoError(t, err)
 
-		err = m.DetachVolume(ctx, vol.ID)
+		err = m.DetachVolume(ctx, vol.ID, "", "")
 		assertError(t, err, true)
 	})
+}
+
+// TestAttachVolumeConcurrentSingleWinner reproduces audit #6: two concurrent
+// AttachVolume calls on the same available volume must have exactly one winner
+// (the loser sees VolumeInUse), and the field mutations must not race with a
+// concurrent DescribeVolumes reader. Run under `go test -race` to prove it.
+func TestAttachVolumeConcurrentSingleWinner(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	insts, err := m.RunInstances(ctx, defaultConfig(), 2)
+	requireNoError(t, err)
+
+	vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	requireNoError(t, err)
+
+	var (
+		mu        sync.Mutex
+		successes int
+		wg        sync.WaitGroup
+	)
+
+	// Concurrent readers race the attach writers on the shared volume struct.
+	stop := make(chan struct{})
+
+	for range 2 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_, _ = m.DescribeVolumes(ctx, []string{vol.ID})
+				}
+			}
+		}()
+	}
+
+	for _, inst := range insts {
+		wg.Add(1)
+
+		go func(instanceID string) {
+			defer wg.Done()
+
+			if attachErr := m.AttachVolume(ctx, vol.ID, instanceID, "/dev/sdf"); attachErr == nil {
+				mu.Lock()
+				successes++
+				mu.Unlock()
+			}
+		}(inst.ID)
+	}
+
+	// Let the two attach goroutines settle, then stop the readers.
+	for range 2 {
+		<-time.After(time.Millisecond)
+	}
+
+	close(stop)
+	wg.Wait()
+
+	if successes != 1 {
+		t.Fatalf("expected exactly one concurrent attach to win, got %d successes", successes)
+	}
+
+	vols, err := m.DescribeVolumes(ctx, []string{vol.ID})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(vols))
+	assertEqual(t, "in-use", vols[0].State)
 }
 
 // Snapshot Tests

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -944,7 +944,9 @@ func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device stri
 	return nil
 }
 
-func (m *Mock) DetachVolume(_ context.Context, volumeID string) error {
+// DetachVolume detaches a managed disk. instanceID/device are accepted for
+// driver-interface parity with AWS; Azure detaches by disk id alone.
+func (m *Mock) DetachVolume(_ context.Context, volumeID, _, _ string) error {
 	vol, ok := m.volumes.Get(volumeID)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)

--- a/providers/azure/virtualmachines/vm_test.go
+++ b/providers/azure/virtualmachines/vm_test.go
@@ -1468,7 +1468,7 @@ func TestDetachVolume(t *testing.T) {
 		err = m.AttachVolume(ctx, vol.ID, instances[0].ID, "/dev/sdf")
 		require.NoError(t, err)
 
-		err = m.DetachVolume(ctx, vol.ID)
+		err = m.DetachVolume(ctx, vol.ID, "", "")
 		require.NoError(t, err)
 
 		// Verify state changed back to available
@@ -1483,7 +1483,7 @@ func TestDetachVolume(t *testing.T) {
 		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
 		require.NoError(t, err)
 
-		err = m.DetachVolume(ctx, vol.ID)
+		err = m.DetachVolume(ctx, vol.ID, "", "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not attached")
 	})

--- a/providers/gcp/compute/gce.go
+++ b/providers/gcp/compute/gce.go
@@ -666,7 +666,9 @@ func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device stri
 	return nil
 }
 
-func (m *Mock) DetachVolume(_ context.Context, volumeID string) error {
+// DetachVolume detaches a persistent disk. instanceID/device are accepted for
+// driver-interface parity with AWS; GCP detaches by disk id alone.
+func (m *Mock) DetachVolume(_ context.Context, volumeID, _, _ string) error {
 	vol, ok := m.volumes.Get(volumeID)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)

--- a/providers/gcp/compute/gce_test.go
+++ b/providers/gcp/compute/gce_test.go
@@ -1535,7 +1535,7 @@ func TestDetachVolume(t *testing.T) {
 		err = m.AttachVolume(ctx, vol.ID, instances[0].ID, "/dev/sdf")
 		require.NoError(t, err)
 
-		err = m.DetachVolume(ctx, vol.ID)
+		err = m.DetachVolume(ctx, vol.ID, "", "")
 		require.NoError(t, err)
 
 		// Verify state changed back to available
@@ -1550,7 +1550,7 @@ func TestDetachVolume(t *testing.T) {
 		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
 		require.NoError(t, err)
 
-		err = m.DetachVolume(ctx, vol.ID)
+		err = m.DetachVolume(ctx, vol.ID, "", "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not attached")
 	})

--- a/server/aws/ec2/volume.go
+++ b/server/aws/ec2/volume.go
@@ -263,6 +263,13 @@ func (h *Handler) attachVolume(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// A volume can only attach to a running/stopped instance; attaching to a
+		// terminated or pending instance is IncorrectInstanceState.
+		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "IncorrectInstanceState:") {
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "IncorrectInstanceState", err.Error())
+			return
+		}
+
 		writeVolumeErr(w, err)
 
 		return
@@ -280,9 +287,29 @@ func (h *Handler) attachVolume(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) detachVolume(w http.ResponseWriter, r *http.Request) {
 	volID := r.Form.Get("VolumeId")
+	instID := r.Form.Get("InstanceId")
+	device := r.Form.Get("Device")
 
-	if err := h.compute.DetachVolume(r.Context(), volID); err != nil {
+	// Capture the real attachment before detaching so the response echoes the
+	// actual instance/device the volume was detached from, not the caller's
+	// (possibly empty or wrong) request values.
+	respInst, respDev := instID, device
+
+	if vols, derr := h.compute.DescribeVolumes(r.Context(), []string{volID}); derr == nil && len(vols) == 1 {
+		respInst = vols[0].AttachedTo
+		respDev = vols[0].Device
+	}
+
+	if err := h.compute.DetachVolume(r.Context(), volID, instID, device); err != nil {
+		// The named instance/device did not match the volume's actual
+		// attachment; real EC2 answers InvalidAttachment.NotFound.
+		if cerrors.IsNotFound(err) && strings.Contains(err.Error(), "InvalidAttachment.NotFound:") {
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAttachment.NotFound", err.Error())
+			return
+		}
+
 		writeVolumeErr(w, err)
+
 		return
 	}
 
@@ -290,8 +317,8 @@ func (h *Handler) detachVolume(w http.ResponseWriter, r *http.Request) {
 		Xmlns:      awsquery.Namespace,
 		RequestID:  awsquery.RequestID,
 		VolumeID:   volID,
-		InstanceID: r.Form.Get("InstanceId"),
-		Device:     r.Form.Get("Device"),
+		InstanceID: respInst,
+		Device:     respDev,
 		Status:     "detaching",
 	})
 }

--- a/server/aws/ec2_test.go
+++ b/server/aws/ec2_test.go
@@ -1596,6 +1596,132 @@ func TestEC2VolumeAttachDetach(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestEC2TerminateDetachesAttachedVolume reproduces the HIGH data-loss bug
+// (audit #1): terminating an instance must release its attached EBS volumes
+// back to `available` so they can be deleted, instead of stranding them
+// in-use against a dead instance forever.
+func TestEC2TerminateDetachesAttachedVolume(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId: aws.String("ami-term-vol"), InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1),
+	})
+	require.NoError(t, err)
+	instID := aws.ToString(run.Instances[0].InstanceId)
+
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"), Size: aws.Int32(20),
+	})
+	require.NoError(t, err)
+	volID := aws.ToString(vol.VolumeId)
+
+	_, err = client.AttachVolume(ctx, &ec2.AttachVolumeInput{
+		VolumeId: aws.String(volID), InstanceId: aws.String(instID), Device: aws.String("/dev/sdf"),
+	})
+	require.NoError(t, err)
+
+	_, err = client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+		InstanceIds: []string{instID},
+	})
+	require.NoError(t, err)
+
+	desc, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{VolumeIds: []string{volID}})
+	require.NoError(t, err)
+	require.Len(t, desc.Volumes, 1)
+	assert.Equal(t, ec2types.VolumeStateAvailable, desc.Volumes[0].State,
+		"terminating the instance must detach the volume back to available")
+	assert.Empty(t, desc.Volumes[0].Attachments, "detached volume must report no attachments")
+
+	// The freed volume must now be deletable (was stuck VolumeInUse forever).
+	_, err = client.DeleteVolume(ctx, &ec2.DeleteVolumeInput{VolumeId: aws.String(volID)})
+	require.NoError(t, err, "detached volume must be deletable after terminate")
+}
+
+// TestEC2AttachVolumeToTerminatedInstanceRejected reproduces audit #2: a volume
+// can only attach to a running or stopped instance; attaching to a terminated
+// instance is IncorrectInstanceState, not a silent success.
+func TestEC2AttachVolumeToTerminatedInstanceRejected(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId: aws.String("ami-term"), InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1),
+	})
+	require.NoError(t, err)
+	instID := aws.ToString(run.Instances[0].InstanceId)
+
+	_, err = client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{InstanceIds: []string{instID}})
+	require.NoError(t, err)
+
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"), Size: aws.Int32(10),
+	})
+	require.NoError(t, err)
+
+	_, err = client.AttachVolume(ctx, &ec2.AttachVolumeInput{
+		VolumeId: vol.VolumeId, InstanceId: aws.String(instID), Device: aws.String("/dev/sdf"),
+	})
+	require.Error(t, err)
+
+	var apiErr smithy.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, "IncorrectInstanceState", apiErr.ErrorCode())
+}
+
+// TestEC2DetachVolumeWrongInstanceRejected reproduces audit #3: detaching a
+// volume while naming an instance it is not attached to must fail with
+// InvalidAttachment.NotFound rather than silently detaching.
+func TestEC2DetachVolumeWrongInstanceRejected(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId: aws.String("ami-detach"), InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1),
+	})
+	require.NoError(t, err)
+	instID := aws.ToString(run.Instances[0].InstanceId)
+
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"), Size: aws.Int32(10),
+	})
+	require.NoError(t, err)
+	volID := aws.ToString(vol.VolumeId)
+
+	_, err = client.AttachVolume(ctx, &ec2.AttachVolumeInput{
+		VolumeId: aws.String(volID), InstanceId: aws.String(instID), Device: aws.String("/dev/sdf"),
+	})
+	require.NoError(t, err)
+
+	_, err = client.DetachVolume(ctx, &ec2.DetachVolumeInput{
+		VolumeId: aws.String(volID), InstanceId: aws.String("i-someotherinstance"),
+	})
+	require.Error(t, err)
+
+	var apiErr smithy.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, "InvalidAttachment.NotFound", apiErr.ErrorCode())
+
+	// The mismatched detach must not have altered the real attachment.
+	desc, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{VolumeIds: []string{volID}})
+	require.NoError(t, err)
+	require.Len(t, desc.Volumes, 1)
+	assert.Equal(t, ec2types.VolumeStateInUse, desc.Volumes[0].State)
+	require.Len(t, desc.Volumes[0].Attachments, 1)
+	assert.Equal(t, instID, aws.ToString(desc.Volumes[0].Attachments[0].InstanceId))
+
+	// A correctly-targeted detach still succeeds and echoes the real attachment.
+	detach, err := client.DetachVolume(ctx, &ec2.DetachVolumeInput{
+		VolumeId: aws.String(volID), InstanceId: aws.String(instID), Device: aws.String("/dev/sdf"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, instID, aws.ToString(detach.InstanceId))
+	assert.Equal(t, "/dev/sdf", aws.ToString(detach.Device))
+}
+
 func TestEC2DeleteVolumeUnknownReturnsError(t *testing.T) {
 	client := newEC2Client(t)
 	ctx := context.Background()

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -321,7 +321,7 @@ func (h *Handler) applyDataDisk(
 			return nil
 		}
 
-		if err := h.compute.DetachVolume(ctx, volID); err != nil {
+		if err := h.compute.DetachVolume(ctx, volID, "", ""); err != nil {
 			return err
 		}
 
@@ -356,7 +356,7 @@ func (h *Handler) attachDataDisk(
 	}
 
 	if prevVolID, ok := attached[d.Lun]; ok && prevVolID != volID {
-		if err := h.compute.DetachVolume(ctx, prevVolID); err != nil {
+		if err := h.compute.DetachVolume(ctx, prevVolID, "", ""); err != nil {
 			return err
 		}
 	}
@@ -386,7 +386,7 @@ func (h *Handler) detachAttachedVolumes(ctx context.Context, instanceID string) 
 			continue
 		}
 
-		if err := h.compute.DetachVolume(ctx, vols[i].ID); err != nil {
+		if err := h.compute.DetachVolume(ctx, vols[i].ID, "", ""); err != nil {
 			return err
 		}
 	}
@@ -402,7 +402,7 @@ func detachUnlistedDisks(ctx context.Context, c computedriver.Compute, attached 
 			continue
 		}
 
-		if err := c.DetachVolume(ctx, volID); err != nil {
+		if err := c.DetachVolume(ctx, volID, "", ""); err != nil {
 			return err
 		}
 	}

--- a/services/compute/compute.go
+++ b/services/compute/compute.go
@@ -398,9 +398,13 @@ func (c *Compute) AttachVolume(ctx context.Context, volumeID, instanceID, device
 	return err
 }
 
-// DetachVolume detaches a volume.
-func (c *Compute) DetachVolume(ctx context.Context, volumeID string) error {
-	_, err := c.do(ctx, "DetachVolume", volumeID, func() (any, error) { return nil, c.driver.DetachVolume(ctx, volumeID) })
+// DetachVolume detaches a volume. A non-empty instanceID or device must match
+// the volume's current attachment.
+func (c *Compute) DetachVolume(ctx context.Context, volumeID, instanceID, device string) error {
+	_, err := c.do(ctx, "DetachVolume", volumeID, func() (any, error) {
+		return nil, c.driver.DetachVolume(ctx, volumeID, instanceID, device)
+	})
+
 	return err
 }
 

--- a/services/compute/compute_test.go
+++ b/services/compute/compute_test.go
@@ -839,7 +839,7 @@ func (mc *mockCompute) AttachVolume(_ context.Context, volumeID, instanceID, dev
 	return nil
 }
 
-func (mc *mockCompute) DetachVolume(_ context.Context, volumeID string) error {
+func (mc *mockCompute) DetachVolume(_ context.Context, volumeID, _, _ string) error {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 
@@ -1074,7 +1074,7 @@ func TestDetachVolumePortable(t *testing.T) {
 	err = c.AttachVolume(ctx, vol.ID, instances[0].ID, "/dev/sdf")
 	require.NoError(t, err)
 
-	err = c.DetachVolume(ctx, vol.ID)
+	err = c.DetachVolume(ctx, vol.ID, "", "")
 	require.NoError(t, err)
 
 	// Verify state
@@ -1090,7 +1090,7 @@ func TestDetachVolumePortableError(t *testing.T) {
 	vol, err := c.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
 	require.NoError(t, err)
 
-	err = c.DetachVolume(ctx, vol.ID)
+	err = c.DetachVolume(ctx, vol.ID, "", "")
 	require.Error(t, err)
 }
 

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -596,7 +596,10 @@ type Compute interface {
 	DeleteVolume(ctx context.Context, id string) error
 	DescribeVolumes(ctx context.Context, ids []string) ([]VolumeInfo, error)
 	AttachVolume(ctx context.Context, volumeID, instanceID, device string) error
-	DetachVolume(ctx context.Context, volumeID string) error
+	// DetachVolume detaches a volume. When instanceID or device is non-empty it
+	// must match the volume's current attachment (real EC2 answers
+	// InvalidAttachment.NotFound on a mismatch); empty values detach by volume.
+	DetachVolume(ctx context.Context, volumeID, instanceID, device string) error
 
 	// Snapshots
 	CreateSnapshot(ctx context.Context, config SnapshotConfig) (*SnapshotInfo, error)


### PR DESCRIPTION
## What

Fixes a cohesive cluster of AWS EC2/EBS attach-lifecycle bugs found by the deep-e2e audit, including a HIGH data-loss bug and a proven data race.

- **#1 [HIGH data-loss]** `TerminateInstances` now releases every attached EBS volume back to `available` (attachment cleared). Previously a terminated instance stranded its volume `in-use` forever, and the volume could never be deleted (`DeleteVolume` -> `VolumeInUse`). User-attached volumes carry `DeleteOnTermination=false`, so they detach rather than delete.
- **#6 [MED concurrency, -race-proven]** `AttachVolume` is now an atomic check-and-set via `memstore.Update` with copy-on-write (returns a fresh pointer). Two concurrent attaches of the same volume now have exactly one winner; the loser gets `VolumeInUse`. The old check-then-set on the stored pointer both double-attached one volume to two instances and raced with concurrent `DescribeVolumes` reads.
- **#2 [MED]** `AttachVolume` to a terminated/non-running instance is rejected with `IncorrectInstanceState` (was a silent success). A volume can only attach to a running or stopped instance.
- **#3 [MED]** `DetachVolume` validates the supplied `InstanceId`/`Device` against the actual attachment; a mismatch returns `InvalidAttachment.NotFound` (was a silent detach). The wire response now echoes the real attachment, not the caller's request values.

## Why

These match real EC2 semantics for TerminateInstances / AttachVolume / DetachVolume and the EBS volume lifecycle (verified against the AWS EC2 API error reference). The terminate bug orphaned volumes permanently; the attach race could corrupt volume ownership under concurrency.

## Notes

`DetachVolume` gains `instanceID`/`device` params on the shared compute driver. AWS validates them; Azure/GCP accept and ignore them (they detach by disk id), preserving existing behavior.

## Tests

Real `aws-sdk-go-v2` EC2 reproductions in `server/aws/ec2_test.go`:
- terminate an instance with an attached volume -> volume becomes `available` and is deletable
- AttachVolume to a terminated instance -> `IncorrectInstanceState`
- DetachVolume with the wrong InstanceId -> `InvalidAttachment.NotFound` (and a correctly-targeted detach still succeeds)

Plus a `-race` provider test (`providers/aws/ec2/ec2_test.go`): concurrent AttachVolume of one volume to two instances with concurrent DescribeVolumes readers -> exactly one winner, no data race.
