### PR TITLE
fix(aws-sts): AssumeRole evaluates the trust policy (deny->AccessDenied) + ListEntitiesForPolicy + instance-profile LimitExceeded

### DIFF
--- a/providers/aws/iam/entities.go
+++ b/providers/aws/iam/entities.go
@@ -1,0 +1,76 @@
+package iam
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// ListEntitiesForPolicy returns the users, groups, and roles the managed policy
+// with the given ARN is attached to (IAM ListEntitiesForPolicy). It reverse-
+// scans the managed-policy attachment maps and resolves each principal's
+// Name/Id/Path from its store. The wire layer applies the EntityFilter,
+// PathPrefix, and pagination filters. AWS-only; not part of the portable driver.
+func (m *Mock) ListEntitiesForPolicy(_ context.Context, policyARN string) (driver.PolicyEntities, error) {
+	if !m.policies.Has(policyARN) {
+		return driver.PolicyEntities{}, errors.Newf(errors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return driver.PolicyEntities{
+		Users:  m.attachedUsersLocked(policyARN),
+		Groups: m.attachedGroupsLocked(policyARN),
+		Roles:  m.attachedRolesLocked(policyARN),
+	}, nil
+}
+
+// attachedUsersLocked returns the users the policy ARN is attached to. Caller
+// must hold m.mu.
+func (m *Mock) attachedUsersLocked(policyARN string) []driver.PolicyEntity {
+	var out []driver.PolicyEntity
+
+	for name, arns := range m.userPolicies {
+		if arns[policyARN] {
+			if u, ok := m.users.Get(name); ok {
+				out = append(out, driver.PolicyEntity{Name: u.Name, ID: u.ID, Path: u.Path})
+			}
+		}
+	}
+
+	return out
+}
+
+// attachedGroupsLocked returns the groups the policy ARN is attached to. Caller
+// must hold m.mu.
+func (m *Mock) attachedGroupsLocked(policyARN string) []driver.PolicyEntity {
+	var out []driver.PolicyEntity
+
+	for name, arns := range m.groupPolicies {
+		if arns[policyARN] {
+			if g, ok := m.groups.Get(name); ok {
+				out = append(out, driver.PolicyEntity{Name: g.Name, ID: g.ID, Path: g.Path})
+			}
+		}
+	}
+
+	return out
+}
+
+// attachedRolesLocked returns the roles the policy ARN is attached to. Caller
+// must hold m.mu.
+func (m *Mock) attachedRolesLocked(policyARN string) []driver.PolicyEntity {
+	var out []driver.PolicyEntity
+
+	for name, arns := range m.rolePolicies {
+		if arns[policyARN] {
+			if r, ok := m.roles.Get(name); ok {
+				out = append(out, driver.PolicyEntity{Name: r.Name, ID: r.ID, Path: r.Path})
+			}
+		}
+	}
+
+	return out
+}

--- a/providers/aws/iam/iam.go
+++ b/providers/aws/iam/iam.go
@@ -1318,9 +1318,12 @@ func (m *Mock) AddRoleToInstanceProfile(
 	}
 
 	if p.RoleName != "" {
+		// An instance profile can contain only one role and this quota cannot be
+		// increased, so a second (different) role is a limit breach, not a
+		// duplicate. Real IAM returns LimitExceeded here.
 		return errors.Newf(
-			errors.AlreadyExists,
-			"instance profile %q already has role %q",
+			errors.ResourceExhausted,
+			"instance profile %q already has role %q; an instance profile can contain only one role",
 			profileName, p.RoleName,
 		)
 	}

--- a/providers/aws/iam/trust_policy.go
+++ b/providers/aws/iam/trust_policy.go
@@ -1,0 +1,108 @@
+package iam
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+)
+
+// assumeRoleAction is the action a trust policy must allow for a principal to
+// assume the role.
+const assumeRoleAction = "sts:AssumeRole"
+
+// trustPolicyDoc mirrors policyDoc but carries the Principal field a role trust
+// policy uses in place of Resource. The identity-policy evaluatePolicy engine
+// matches on Action+Resource, so trust evaluation reuses its Action matching
+// (matchesAction) but resolves the trusted party through Principal here.
+type trustPolicyDoc struct {
+	Statement []trustStatement `json:"Statement"`
+}
+
+type trustStatement struct {
+	Effect    string `json:"Effect"`
+	Action    any    `json:"Action"`
+	Principal any    `json:"Principal"`
+}
+
+// EvaluateAssumeRoleTrust reports whether callerPrincipal may assume the role
+// named roleName under the role's trust policy (STS AssumeRole). roleExists is
+// false when the role does not exist; the caller maps both a missing role and a
+// disallowing trust policy to AccessDenied. An explicit Deny overrides any
+// Allow. AWS-only; not part of the portable IAM driver.
+func (m *Mock) EvaluateAssumeRoleTrust(_ context.Context, roleName, callerPrincipal string) (roleExists, allowed bool) {
+	r, ok := m.roles.Get(roleName)
+	if !ok {
+		return false, false
+	}
+
+	allow, deny := evaluateTrustPolicy(r.AssumeRolePolicyDoc, callerPrincipal)
+
+	return true, allow && !deny
+}
+
+// evaluateTrustPolicy evaluates a role trust document for sts:AssumeRole against
+// callerPrincipal, returning whether any statement allows and whether any
+// statement denies. A malformed document allows nothing.
+func evaluateTrustPolicy(doc, callerPrincipal string) (allow, deny bool) {
+	var pd trustPolicyDoc
+	if err := json.Unmarshal([]byte(doc), &pd); err != nil {
+		return false, false
+	}
+
+	for _, stmt := range pd.Statement {
+		if !matchesAction(toStringSlice(stmt.Action), assumeRoleAction) {
+			continue
+		}
+
+		if !trustPrincipalMatches(stmt.Principal, callerPrincipal) {
+			continue
+		}
+
+		if strings.EqualFold(stmt.Effect, "Deny") {
+			deny = true
+		} else if strings.EqualFold(stmt.Effect, "Allow") {
+			allow = true
+		}
+	}
+
+	return allow, deny
+}
+
+// trustPrincipalMatches reports whether the caller matches a statement's
+// Principal. Principal may be the string "*", or an object keyed by principal
+// type ("AWS", "Service", "Federated") whose values are a string or a list.
+// Since cloudemu does not verify SigV4, the caller is the account-root identity
+// derived in the STS handler; an entry matches when it is "*", the account root
+// ARN, or a wildcard match of the caller.
+func trustPrincipalMatches(principal any, caller string) bool {
+	switch p := principal.(type) {
+	case string:
+		return principalEntryMatches(p, caller)
+	case map[string]any:
+		for _, v := range p {
+			for _, entry := range toStringSlice(v) {
+				if principalEntryMatches(entry, caller) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// principalEntryMatches matches a single principal entry against the caller.
+func principalEntryMatches(entry, caller string) bool {
+	if entry == "*" {
+		return true
+	}
+
+	if entry == caller {
+		return true
+	}
+
+	// A trust policy that names the account root trusts every principal in that
+	// account; the caller is the account root, so an exact match already covers
+	// it. Fall back to wildcard matching for patterns like "arn:...:role/*".
+	return wildcardMatch(entry, caller)
+}

--- a/providers/aws/iam/trust_policy_test.go
+++ b/providers/aws/iam/trust_policy_test.go
@@ -1,0 +1,135 @@
+package iam
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+const rootCaller = "arn:aws:iam::123456789012:root"
+
+func TestEvaluateAssumeRoleTrustAllow(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateRole(ctx, driver.RoleConfig{
+		Name: "allowrole",
+		AssumeRolePolicyDoc: `{"Statement":[{"Effect":"Allow",` +
+			`"Principal":{"AWS":"` + rootCaller + `"},"Action":"sts:AssumeRole"}]}`,
+	})
+	requireNoError(t, err)
+
+	exists, allowed := m.EvaluateAssumeRoleTrust(ctx, "allowrole", rootCaller)
+	assertEqual(t, true, exists)
+	assertEqual(t, true, allowed)
+}
+
+func TestEvaluateAssumeRoleTrustDeny(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateRole(ctx, driver.RoleConfig{
+		Name: "denyrole",
+		AssumeRolePolicyDoc: `{"Statement":[{"Effect":"Deny",` +
+			`"Principal":"*","Action":"sts:AssumeRole"}]}`,
+	})
+	requireNoError(t, err)
+
+	exists, allowed := m.EvaluateAssumeRoleTrust(ctx, "denyrole", rootCaller)
+	assertEqual(t, true, exists)
+	assertEqual(t, false, allowed)
+}
+
+func TestEvaluateAssumeRoleTrustDenyOverridesAllow(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateRole(ctx, driver.RoleConfig{
+		Name: "mixedrole",
+		AssumeRolePolicyDoc: `{"Statement":[` +
+			`{"Effect":"Allow","Principal":"*","Action":"sts:AssumeRole"},` +
+			`{"Effect":"Deny","Principal":"*","Action":"sts:AssumeRole"}]}`,
+	})
+	requireNoError(t, err)
+
+	_, allowed := m.EvaluateAssumeRoleTrust(ctx, "mixedrole", rootCaller)
+	assertEqual(t, false, allowed)
+}
+
+func TestEvaluateAssumeRoleTrustMissingRole(t *testing.T) {
+	m := newTestMock()
+
+	exists, allowed := m.EvaluateAssumeRoleTrust(context.Background(), "ghost", rootCaller)
+	assertEqual(t, false, exists)
+	assertEqual(t, false, allowed)
+}
+
+func TestEvaluateAssumeRoleTrustWrongPrincipalImplicitDeny(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	// Trust only a specific unrelated service principal; the account-root caller
+	// is not named, so assumption is an implicit deny.
+	_, err := m.CreateRole(ctx, driver.RoleConfig{
+		Name: "servicerole",
+		AssumeRolePolicyDoc: `{"Statement":[{"Effect":"Allow",` +
+			`"Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}`,
+	})
+	requireNoError(t, err)
+
+	_, allowed := m.EvaluateAssumeRoleTrust(ctx, "servicerole", rootCaller)
+	assertEqual(t, false, allowed)
+}
+
+func TestAddRoleToInstanceProfileSecondRoleLimitExceeded(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateInstanceProfile(ctx, driver.InstanceProfileConfig{Name: "ip1"})
+	requireNoError(t, err)
+
+	for _, name := range []string{"r1", "r2"} {
+		_, err = m.CreateRole(ctx, driver.RoleConfig{Name: name, AssumeRolePolicyDoc: "{}"})
+		requireNoError(t, err)
+	}
+
+	requireNoError(t, m.AddRoleToInstanceProfile(ctx, "ip1", "r1"))
+
+	// A second, different role exceeds the one-role-per-profile quota.
+	err = m.AddRoleToInstanceProfile(ctx, "ip1", "r2")
+	assertEqual(t, cerrors.ResourceExhausted, cerrors.GetCode(err))
+}
+
+func TestListEntitiesForPolicyReverseLookup(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	pol, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "shared", PolicyDocument: "{}"})
+	requireNoError(t, err)
+
+	_, err = m.CreateUser(ctx, driver.UserConfig{Name: "u1"})
+	requireNoError(t, err)
+	_, err = m.CreateRole(ctx, driver.RoleConfig{Name: "r1", AssumeRolePolicyDoc: "{}"})
+	requireNoError(t, err)
+
+	requireNoError(t, m.AttachUserPolicy(ctx, "u1", pol.ARN))
+	requireNoError(t, m.AttachRolePolicy(ctx, "r1", pol.ARN))
+
+	ents, err := m.ListEntitiesForPolicy(ctx, pol.ARN)
+	requireNoError(t, err)
+
+	assertEqual(t, 1, len(ents.Users))
+	assertEqual(t, "u1", ents.Users[0].Name)
+	assertEqual(t, 1, len(ents.Roles))
+	assertEqual(t, "r1", ents.Roles[0].Name)
+	assertEqual(t, 0, len(ents.Groups))
+}
+
+func TestListEntitiesForPolicyMissingPolicy(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.ListEntitiesForPolicy(context.Background(), "arn:aws:iam::123456789012:policy/ghost")
+	assertEqual(t, cerrors.NotFound, cerrors.GetCode(err))
+}

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -545,7 +545,10 @@ func New(d Drivers) *server.Server {
 	// ElastiCache, SNS, and EC2, so no shadowing occurs. It has no driver, so
 	// it's gated on the STS bool. Registered before the EC2 catch-all.
 	if d.STS {
-		srv.Register(stssrv.New(d.AccountID, d.Region))
+		// Pass the IAM driver so AssumeRole can enforce the target role's trust
+		// policy and existence. d.IAM may be nil (standalone STS-only), in which
+		// case AssumeRole stays permissive.
+		srv.Register(stssrv.New(d.AccountID, d.Region, d.IAM))
 	}
 
 	if d.EC2 != nil || d.VPC != nil {

--- a/server/aws/iam/handler.go
+++ b/server/aws/iam/handler.go
@@ -58,6 +58,7 @@ var iamActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup
 	"DetachRolePolicy":               {},
 	"ListAttachedUserPolicies":       {},
 	"ListAttachedRolePolicies":       {},
+	"ListEntitiesForPolicy":          {},
 	"CreateGroup":                    {},
 	"DeleteGroup":                    {},
 	"GetGroup":                       {},
@@ -254,6 +255,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.listAttachedUserPolicies(w, r)
 	case "ListAttachedRolePolicies":
 		h.listAttachedRolePolicies(w, r)
+	case "ListEntitiesForPolicy":
+		h.listEntitiesForPolicy(w, r)
 	case "CreateGroup":
 		h.createGroup(w, r)
 	case "DeleteGroup":

--- a/server/aws/iam/list_entities_for_policy.go
+++ b/server/aws/iam/list_entities_for_policy.go
@@ -1,0 +1,158 @@
+package iam
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"sort"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// policyEntityLister is the AWS-specific reverse-lookup surface behind
+// ListEntitiesForPolicy. It's not part of the portable IAM driver, so the
+// handler type-asserts for it.
+type policyEntityLister interface {
+	ListEntitiesForPolicy(ctx context.Context, policyARN string) (iamdriver.PolicyEntities, error)
+}
+
+type policyUserXML struct {
+	UserName string `xml:"UserName"`
+	UserID   string `xml:"UserId"`
+}
+
+type policyGroupXML struct {
+	GroupName string `xml:"GroupName"`
+	GroupID   string `xml:"GroupId"`
+}
+
+type policyRoleXML struct {
+	RoleName string `xml:"RoleName"`
+	RoleID   string `xml:"RoleId"`
+}
+
+type policyUsersXML struct {
+	Member []policyUserXML `xml:"member,omitempty"`
+}
+
+type policyGroupsXML struct {
+	Member []policyGroupXML `xml:"member,omitempty"`
+}
+
+type policyRolesXML struct {
+	Member []policyRoleXML `xml:"member,omitempty"`
+}
+
+type listEntitiesForPolicyResult struct {
+	PolicyUsers  policyUsersXML  `xml:"PolicyUsers"`
+	PolicyGroups policyGroupsXML `xml:"PolicyGroups"`
+	PolicyRoles  policyRolesXML  `xml:"PolicyRoles"`
+	IsTruncated  bool            `xml:"IsTruncated"`
+	Marker       string          `xml:"Marker,omitempty"`
+}
+
+type listEntitiesForPolicyResponse struct {
+	XMLName  xml.Name                    `xml:"ListEntitiesForPolicyResponse"`
+	Xmlns    string                      `xml:"xmlns,attr"`
+	Result   listEntitiesForPolicyResult `xml:"ListEntitiesForPolicyResult"`
+	Metadata responseMetadata            `xml:"ResponseMetadata"`
+}
+
+// entityRow is one principal in the flattened, ordered view the handler
+// paginates over. typ is "User", "Group", or "Role".
+type entityRow struct {
+	typ  string
+	name string
+	id   string
+}
+
+func (h *Handler) listEntitiesForPolicy(w http.ResponseWriter, r *http.Request) {
+	lister, ok := h.iam.(policyEntityLister)
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "ListEntitiesForPolicy not supported"))
+		return
+	}
+
+	entities, err := lister.ListEntitiesForPolicy(r.Context(), r.Form.Get("PolicyArn"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	rows := flattenEntities(entities, r.Form.Get("EntityFilter"), r.Form.Get("PathPrefix"))
+
+	start, end, marker, truncated := pageWindow(len(rows), r.Form)
+	page := rows[start:end]
+
+	awsquery.WriteXMLResponse(w, listEntitiesForPolicyResponse{
+		Xmlns:    Namespace,
+		Result:   buildEntitiesResult(page, truncated, marker),
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// flattenEntities applies the EntityFilter and PathPrefix filters, then returns
+// a single deterministically ordered slice (users, then groups, then roles,
+// each sorted by name) so pagination yields a stable window with one Marker.
+func flattenEntities(e iamdriver.PolicyEntities, entityFilter, pathPrefix string) []entityRow {
+	rows := make([]entityRow, 0, len(e.Users)+len(e.Groups)+len(e.Roles))
+
+	if includeEntity(entityFilter, "User") {
+		rows = appendEntityRows(rows, "User", e.Users, pathPrefix)
+	}
+
+	if includeEntity(entityFilter, "Group") {
+		rows = appendEntityRows(rows, "Group", e.Groups, pathPrefix)
+	}
+
+	if includeEntity(entityFilter, "Role") {
+		rows = appendEntityRows(rows, "Role", e.Roles, pathPrefix)
+	}
+
+	return rows
+}
+
+func appendEntityRows(rows []entityRow, typ string, ents []iamdriver.PolicyEntity, pathPrefix string) []entityRow {
+	sort.Slice(ents, func(i, j int) bool { return ents[i].Name < ents[j].Name })
+
+	for i := range ents {
+		if pathPrefix != "" && !strings.HasPrefix(ents[i].Path, pathPrefix) {
+			continue
+		}
+
+		rows = append(rows, entityRow{typ: typ, name: ents[i].Name, id: ents[i].ID})
+	}
+
+	return rows
+}
+
+// includeEntity reports whether an entity type is selected by EntityFilter. An
+// empty filter selects all types; otherwise it selects only the named type
+// (User, Role, Group). LocalManagedPolicy/AWSManagedPolicy filters never match a
+// principal type, so they return no entities.
+func includeEntity(entityFilter, typ string) bool {
+	return entityFilter == "" || entityFilter == typ
+}
+
+func buildEntitiesResult(page []entityRow, truncated bool, marker string) listEntitiesForPolicyResult {
+	res := listEntitiesForPolicyResult{IsTruncated: truncated, Marker: marker}
+
+	for _, row := range page {
+		switch row.typ {
+		case "User":
+			res.PolicyUsers.Member = append(res.PolicyUsers.Member,
+				policyUserXML{UserName: row.name, UserID: row.id})
+		case "Group":
+			res.PolicyGroups.Member = append(res.PolicyGroups.Member,
+				policyGroupXML{GroupName: row.name, GroupID: row.id})
+		case "Role":
+			res.PolicyRoles.Member = append(res.PolicyRoles.Member,
+				policyRoleXML{RoleName: row.name, RoleID: row.id})
+		}
+	}
+
+	return res
+}

--- a/server/aws/iam/list_entities_for_policy_test.go
+++ b/server/aws/iam/list_entities_for_policy_test.go
@@ -1,0 +1,146 @@
+package iam_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// seedAttachedPolicy creates a managed policy and attaches it to a user, a
+// group, and a role, returning the policy ARN.
+func seedAttachedPolicy(t *testing.T, client *iam.Client) string {
+	t.Helper()
+
+	ctx := context.Background()
+
+	pol, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String("shared"),
+		PolicyDocument: aws.String(samplePolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	arn := aws.ToString(pol.Policy.Arn)
+
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("u1")}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if _, err := client.CreateGroup(ctx, &iam.CreateGroupInput{GroupName: aws.String("g1")}); err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("r1"),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	if _, err := client.AttachUserPolicy(ctx, &iam.AttachUserPolicyInput{
+		UserName: aws.String("u1"), PolicyArn: aws.String(arn),
+	}); err != nil {
+		t.Fatalf("AttachUserPolicy: %v", err)
+	}
+	if _, err := client.AttachGroupPolicy(ctx, &iam.AttachGroupPolicyInput{
+		GroupName: aws.String("g1"), PolicyArn: aws.String(arn),
+	}); err != nil {
+		t.Fatalf("AttachGroupPolicy: %v", err)
+	}
+	if _, err := client.AttachRolePolicy(ctx, &iam.AttachRolePolicyInput{
+		RoleName: aws.String("r1"), PolicyArn: aws.String(arn),
+	}); err != nil {
+		t.Fatalf("AttachRolePolicy: %v", err)
+	}
+
+	return arn
+}
+
+func TestSDKListEntitiesForPolicy(t *testing.T) {
+	client := newSDKClient(t)
+	arn := seedAttachedPolicy(t, client)
+
+	out, err := client.ListEntitiesForPolicy(context.Background(), &iam.ListEntitiesForPolicyInput{
+		PolicyArn: aws.String(arn),
+	})
+	if err != nil {
+		t.Fatalf("ListEntitiesForPolicy: %v", err)
+	}
+
+	if n := len(out.PolicyUsers); n != 1 || aws.ToString(out.PolicyUsers[0].UserName) != "u1" {
+		t.Fatalf("PolicyUsers = %+v, want [u1]", out.PolicyUsers)
+	}
+	if n := len(out.PolicyGroups); n != 1 || aws.ToString(out.PolicyGroups[0].GroupName) != "g1" {
+		t.Fatalf("PolicyGroups = %+v, want [g1]", out.PolicyGroups)
+	}
+	if n := len(out.PolicyRoles); n != 1 || aws.ToString(out.PolicyRoles[0].RoleName) != "r1" {
+		t.Fatalf("PolicyRoles = %+v, want [r1]", out.PolicyRoles)
+	}
+
+	// IDs must be populated (Name+Id shape).
+	if aws.ToString(out.PolicyUsers[0].UserId) == "" {
+		t.Fatalf("PolicyUsers[0].UserId is empty")
+	}
+}
+
+func TestSDKListEntitiesForPolicyEntityFilter(t *testing.T) {
+	client := newSDKClient(t)
+	arn := seedAttachedPolicy(t, client)
+
+	out, err := client.ListEntitiesForPolicy(context.Background(), &iam.ListEntitiesForPolicyInput{
+		PolicyArn:    aws.String(arn),
+		EntityFilter: iamtypes.EntityTypeUser,
+	})
+	if err != nil {
+		t.Fatalf("ListEntitiesForPolicy(EntityFilter=User): %v", err)
+	}
+
+	if len(out.PolicyUsers) != 1 {
+		t.Fatalf("PolicyUsers = %+v, want 1", out.PolicyUsers)
+	}
+	if len(out.PolicyGroups) != 0 || len(out.PolicyRoles) != 0 {
+		t.Fatalf("EntityFilter=User leaked groups/roles: groups=%d roles=%d",
+			len(out.PolicyGroups), len(out.PolicyRoles))
+	}
+}
+
+func TestSDKListEntitiesForPolicyPaginates(t *testing.T) {
+	client := newSDKClient(t)
+	arn := seedAttachedPolicy(t, client)
+	ctx := context.Background()
+
+	first, err := client.ListEntitiesForPolicy(ctx, &iam.ListEntitiesForPolicyInput{
+		PolicyArn: aws.String(arn),
+		MaxItems:  aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("ListEntitiesForPolicy(MaxItems=2): %v", err)
+	}
+
+	got := len(first.PolicyUsers) + len(first.PolicyGroups) + len(first.PolicyRoles)
+	if got != 2 {
+		t.Fatalf("first page returned %d entities, want 2", got)
+	}
+	if !first.IsTruncated || aws.ToString(first.Marker) == "" {
+		t.Fatalf("first page IsTruncated=%v Marker=%q, want truncated with marker",
+			first.IsTruncated, aws.ToString(first.Marker))
+	}
+
+	second, err := client.ListEntitiesForPolicy(ctx, &iam.ListEntitiesForPolicyInput{
+		PolicyArn: aws.String(arn),
+		Marker:    first.Marker,
+	})
+	if err != nil {
+		t.Fatalf("ListEntitiesForPolicy(page 2): %v", err)
+	}
+
+	got2 := len(second.PolicyUsers) + len(second.PolicyGroups) + len(second.PolicyRoles)
+	if got2 != 1 {
+		t.Fatalf("second page returned %d entities, want 1", got2)
+	}
+	if second.IsTruncated {
+		t.Fatalf("second page should not be truncated")
+	}
+}

--- a/server/aws/sts/assume_role_trust_test.go
+++ b/server/aws/sts/assume_role_trust_test.go
@@ -1,0 +1,161 @@
+package sts_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
+	awssts "github.com/aws/aws-sdk-go-v2/service/sts"
+	smithy "github.com/aws/smithy-go"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// loadTestConfig builds an aws.Config pointed at the test region with static
+// dummy credentials (cloudemu does not verify signatures).
+func loadTestConfig() (aws.Config, error) {
+	return awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion(testRegion),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+}
+
+const allowRootTrust = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+	`"Principal":{"AWS":"arn:aws:iam::123456789012:root"},"Action":"sts:AssumeRole"}]}`
+
+const denyTrust = `{"Version":"2012-10-17","Statement":[{"Effect":"Deny",` +
+	`"Principal":"*","Action":"sts:AssumeRole"}]}`
+
+// newTrustServer wires IAM + STS so AssumeRole enforces role trust policies.
+func newTrustServer(t *testing.T) (*httptest.Server, *awsiam.Client) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	ts := httptest.NewServer(awsserver.New(awsserver.Drivers{
+		IAM:       cloud.IAM,
+		STS:       true,
+		AccountID: testAccountID,
+		Region:    testRegion,
+	}))
+	t.Cleanup(ts.Close)
+
+	cfg, err := loadTestConfig()
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	iamClient := awsiam.NewFromConfig(cfg, func(o *awsiam.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+
+	return ts, iamClient
+}
+
+func TestSDKAssumeRoleTrustAllows(t *testing.T) {
+	ts, iamClient := newTrustServer(t)
+	ctx := context.Background()
+
+	if _, err := iamClient.CreateRole(ctx, &awsiam.CreateRoleInput{
+		RoleName:                 aws.String("allowrole"),
+		AssumeRolePolicyDocument: aws.String(allowRootTrust),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	out, err := stsClient(t, ts.URL).AssumeRole(ctx, &awssts.AssumeRoleInput{
+		RoleArn:         aws.String("arn:aws:iam::" + testAccountID + ":role/allowrole"),
+		RoleSessionName: aws.String("s"),
+	})
+	if err != nil {
+		t.Fatalf("AssumeRole (allow): %v", err)
+	}
+
+	if out.Credentials == nil || aws.ToString(out.Credentials.AccessKeyId) == "" {
+		t.Fatalf("AssumeRole (allow) returned no credentials")
+	}
+}
+
+func TestSDKAssumeRoleTrustDenies(t *testing.T) {
+	ts, iamClient := newTrustServer(t)
+	ctx := context.Background()
+
+	if _, err := iamClient.CreateRole(ctx, &awsiam.CreateRoleInput{
+		RoleName:                 aws.String("denyrole"),
+		AssumeRolePolicyDocument: aws.String(denyTrust),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	_, err := stsClient(t, ts.URL).AssumeRole(ctx, &awssts.AssumeRoleInput{
+		RoleArn:         aws.String("arn:aws:iam::" + testAccountID + ":role/denyrole"),
+		RoleSessionName: aws.String("s"),
+	})
+	assertAccessDenied(t, err)
+}
+
+func TestSDKAssumeRoleNonexistentRoleDenied(t *testing.T) {
+	ts, _ := newTrustServer(t)
+
+	_, err := stsClient(t, ts.URL).AssumeRole(context.Background(), &awssts.AssumeRoleInput{
+		RoleArn:         aws.String("arn:aws:iam::" + testAccountID + ":role/ghost"),
+		RoleSessionName: aws.String("s"),
+	})
+	assertAccessDenied(t, err)
+}
+
+// TestSDKAssumeRolePermissiveWithoutIAM confirms the standalone stance: with no
+// IAM driver wired, AssumeRole still returns creds (init-creds behavior).
+func TestSDKAssumeRolePermissiveWithoutIAM(t *testing.T) {
+	ts := newServer(t, awsserver.Drivers{
+		STS:       true,
+		AccountID: testAccountID,
+		Region:    testRegion,
+	})
+
+	out, err := stsClient(t, ts.URL).AssumeRole(context.Background(), &awssts.AssumeRoleInput{
+		RoleArn:         aws.String("arn:aws:iam::" + testAccountID + ":role/anything"),
+		RoleSessionName: aws.String("s"),
+	})
+	if err != nil {
+		t.Fatalf("AssumeRole (no IAM): %v", err)
+	}
+
+	if out.Credentials == nil {
+		t.Fatalf("AssumeRole (no IAM) returned no credentials")
+	}
+}
+
+func assertAccessDenied(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("AssumeRole: want AccessDenied, got nil (silent success)")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("AssumeRole: want smithy.APIError, got %T: %v", err, err)
+	}
+
+	if apiErr.ErrorCode() != "AccessDenied" {
+		t.Fatalf("AssumeRole: want code AccessDenied, got %q", apiErr.ErrorCode())
+	}
+
+	var respErr *awshttp.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("AssumeRole: want *awshttp.ResponseError, got %T", err)
+	}
+
+	if respErr.HTTPStatusCode() != 403 {
+		t.Fatalf("AssumeRole: want HTTP 403, got %d", respErr.HTTPStatusCode())
+	}
+}

--- a/server/aws/sts/handler.go
+++ b/server/aws/sts/handler.go
@@ -18,10 +18,12 @@
 package sts
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
 )
 
 // Namespace is the XML namespace for AWS STS responses.
@@ -45,17 +47,31 @@ var stsActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup
 	"DecodeAuthorizationMessage": {},
 }
 
+// roleTrustEvaluator is the AWS-specific trust-policy surface AssumeRole uses to
+// decide whether the caller may assume a role. It is not part of the portable
+// IAM driver, so the handler type-asserts the injected IAM driver for it. When
+// the driver does not implement it (or none was wired), AssumeRole stays
+// permissive — the standalone behavior for callers that only need init creds.
+type roleTrustEvaluator interface {
+	EvaluateAssumeRoleTrust(ctx context.Context, roleName, callerPrincipal string) (roleExists, allowed bool)
+}
+
 // Handler serves STS query-protocol requests. It carries the account and region
-// the AWS server was configured with; there is no backing driver.
+// the AWS server was configured with. It has no backing driver of its own, but
+// when an IAM driver that can evaluate trust policies is wired, AssumeRole
+// enforces the target role's trust policy and existence.
 type Handler struct {
 	accountID string
 	region    string
+	trust     roleTrustEvaluator
 }
 
-// New returns an STS handler that reports the given accountID and region.
-// Empty values fall back to sensible defaults so a well-formed identity is
-// always returned.
-func New(accountID, region string) *Handler {
+// New returns an STS handler that reports the given accountID and region. Empty
+// values fall back to sensible defaults so a well-formed identity is always
+// returned. When iam is non-nil and can evaluate trust policies, AssumeRole
+// checks the target role's trust policy (and existence); otherwise AssumeRole
+// stays permissive.
+func New(accountID, region string, iam iamdriver.IAM) *Handler {
 	if accountID == "" {
 		accountID = defaultAccountID
 	}
@@ -64,7 +80,12 @@ func New(accountID, region string) *Handler {
 		region = defaultRegion
 	}
 
-	return &Handler{accountID: accountID, region: region}
+	h := &Handler{accountID: accountID, region: region}
+	if te, ok := iam.(roleTrustEvaluator); ok {
+		h.trust = te
+	}
+
+	return h
 }
 
 const (

--- a/server/aws/sts/operations.go
+++ b/server/aws/sts/operations.go
@@ -36,7 +36,9 @@ func (h *Handler) getCallerIdentity(w http.ResponseWriter, _ *http.Request) {
 }
 
 // assumeRole returns synthetic temporary credentials and an AssumedRoleUser
-// derived from the requested RoleArn and RoleSessionName.
+// derived from the requested RoleArn and RoleSessionName. When an IAM trust
+// evaluator is wired, the target role must exist and its trust policy must allow
+// the caller to sts:AssumeRole; otherwise AWS returns AccessDenied (403).
 func (h *Handler) assumeRole(w http.ResponseWriter, r *http.Request) {
 	roleArn := r.Form.Get("RoleArn")
 	sessionName := r.Form.Get("RoleSessionName")
@@ -49,6 +51,16 @@ func (h *Handler) assumeRole(w http.ResponseWriter, r *http.Request) {
 	//   arn:aws:sts::{account}:assumed-role/{role-name}/{session-name}
 	// where role-name is the last path segment of the requested RoleArn.
 	roleName := roleNameFromArn(roleArn)
+
+	if !h.trustAllows(r, roleName) {
+		// Real STS returns AccessDenied (403) both when the trust policy denies
+		// the caller and when the role does not exist (it does not disclose which).
+		awsquery.WriteXMLError(w, http.StatusForbidden, "AccessDenied",
+			"User is not authorized to perform sts:AssumeRole on "+roleArn)
+
+		return
+	}
+
 	assumedArn := "arn:aws:sts::" + h.accountID + ":assumed-role/" + roleName + "/" + sessionName
 
 	awsquery.WriteXMLResponse(w, assumeRoleResponse{
@@ -62,6 +74,22 @@ func (h *Handler) assumeRole(w http.ResponseWriter, r *http.Request) {
 		},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
+}
+
+// trustAllows reports whether the caller may assume roleName. With no trust
+// evaluator wired it stays permissive (standalone init-creds behavior). With one
+// wired, a missing role or a trust policy that does not allow the caller both
+// deny. The caller principal is the account-root identity — cloudemu does not
+// verify SigV4, so it evaluates trust against a consistent same-account root.
+func (h *Handler) trustAllows(r *http.Request, roleName string) bool {
+	if h.trust == nil {
+		return true
+	}
+
+	callerPrincipal := "arn:aws:iam::" + h.accountID + ":root"
+	_, allowed := h.trust.EvaluateAssumeRoleTrust(r.Context(), roleName, callerPrincipal)
+
+	return allowed
 }
 
 // assumeRoleWithWebIdentity mirrors AssumeRole but is fed by an OIDC/WebIdentity

--- a/services/iam/driver/driver.go
+++ b/services/iam/driver/driver.go
@@ -135,6 +135,25 @@ type SimulationResult struct {
 	Decision     string
 }
 
+// PolicyEntity is one principal (user, group, or role) that a managed policy is
+// attached to. Path lets the wire layer apply the ListEntitiesForPolicy
+// PathPrefix filter. It is an AWS-only shape (ListEntitiesForPolicy), so it is
+// not referenced by the IAM interface below — providers that support it expose
+// it through a type-asserted optional method.
+type PolicyEntity struct {
+	Name string
+	ID   string
+	Path string
+}
+
+// PolicyEntities are the principals a managed policy is attached to, split by
+// type. AWS-only (ListEntitiesForPolicy).
+type PolicyEntities struct {
+	Users  []PolicyEntity
+	Groups []PolicyEntity
+	Roles  []PolicyEntity
+}
+
 // PasswordPolicy describes an AWS account password policy. ExpirePasswords is
 // derived (MaxPasswordAge > 0) and reported by the wire layer, not stored. It
 // is AWS-only and not referenced by the IAM interface.


### PR DESCRIPTION
## What

Fixes three AWS STS + IAM findings from the deep-e2e audit.

### #1 [MED, security] STS AssumeRole now evaluates the role trust policy
Previously the STS handler was driverless: `AssumeRole` synthesized credentials
for **any** `RoleArn` — a role whose trust policy explicitly *denies*, and even a
**nonexistent** role, both returned valid creds (`err=nil`). Every negative
security test was a false pass.

Now the STS handler receives the IAM driver (provider-factory wiring in
`server/aws/aws.go`). On `AssumeRole` it resolves the target role and evaluates
its `AssumeRolePolicyDocument` for an `sts:AssumeRole` Allow (with explicit Deny
overriding), reusing the IAM backend's policy-evaluation building blocks. A
denying trust policy or a missing role now returns **`AccessDenied` (HTTP 403)**,
matching real STS (which does not disclose which of the two failed). When no IAM
driver is wired (standalone STS-only), `AssumeRole` stays permissive so SDK
init-creds paths keep working. Caller principal is derived as the account-root
identity (`arn:aws:iam::<account>:root`) since cloudemu does not verify SigV4.

### #2 [MED gap] ListEntitiesForPolicy implemented
The standard `iam:ListEntitiesForPolicy` read API was undispatched →
`InvalidAction (400)`. Added the action, an XML shape
(`PolicyUsers`/`PolicyGroups`/`PolicyRoles` with Name+Id), and a backend
reverse-lookup over the existing `userPolicies`/`groupPolicies`/`rolePolicies`
attachment maps, honoring `EntityFilter`, `PathPrefix`, and `MaxItems`/`Marker`
pagination.

### #3 [LOW] AddRoleToInstanceProfile second role → LimitExceeded
Adding a *different* second role to an instance profile returned
`EntityAlreadyExists`; per the AWS one-role-per-profile quota it must be
`LimitExceeded`. Changed the provider to return `ResourceExhausted`
(maps to `LimitExceeded`).

## Why
Trust-policy bypass makes negative security tests silently pass; the missing read
API breaks audit/IaC tooling; the wrong error type misfires SDK retry/branch
logic keyed on `LimitExceededException`.

## Tests
Real `aws-sdk-go-v2` reproductions: AssumeRole with an allowing trust policy →
creds; denying trust policy → AccessDenied 403; nonexistent role → AccessDenied
403; permissive without IAM wired; ListEntitiesForPolicy returns attached
users/roles/groups + EntityFilter + pagination; AddRoleToInstanceProfile second
role → LimitExceeded. Plus provider-level trust-evaluation and reverse-lookup
unit tests. Existing STS/IAM tests remain green.
