### PR TITLE
fix(aws-lambda): resolve Qualifier on Get/GetConfiguration + per-qualifier policy + ESM function existence + principal shape

### DIFF
--- a/providers/aws/lambda/esm.go
+++ b/providers/aws/lambda/esm.go
@@ -28,6 +28,13 @@ func (m *Mock) CreateEventSourceMapping(
 		return nil, cerrors.New(cerrors.InvalidArgument, "event source ARN is required")
 	}
 
+	// The target function must exist. Real Lambda rejects an event-source mapping
+	// whose FunctionName points at a missing function with ResourceNotFoundException
+	// rather than creating a mapping that silently never fires.
+	if _, ok := m.funcs.Get(functionNameFromARN(cfg.FunctionName)); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "Function not found: %s", cfg.FunctionName)
+	}
+
 	batchSize := cfg.BatchSize
 	if batchSize == 0 {
 		batchSize = defaultBatchSize

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -82,8 +82,11 @@ type funcData struct {
 	nextVersion  int
 	aliases      *memstore.Store[*aliasData]
 	concurrency  *driver.ConcurrencyConfig
-	policy       map[string]driver.PermissionStatement
-	urlConfig    *driver.FunctionURLConfig // Lambda Function URL, nil until created
+	// policies is the resource-based policy keyed by qualifier (normalized via
+	// policyKey: "" and "$LATEST" collapse to the unqualified function policy),
+	// then by statement id. AWS keeps a separate policy per version/alias.
+	policies  map[string]map[string]driver.PermissionStatement
+	urlConfig *driver.FunctionURLConfig // Lambda Function URL, nil until created
 	// awsConfig holds the AWS-only settings (VpcConfig/DeadLetterConfig/
 	// TracingConfig) applied through the AWSConfigurable optional interface.
 	awsConfig driver.AWSFunctionConfig

--- a/providers/aws/lambda/policy.go
+++ b/providers/aws/lambda/policy.go
@@ -3,16 +3,34 @@ package lambda
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
 )
 
+// accountIDLen is the length of an AWS account id (12 digits). An account-id
+// principal renders as the account's IAM root ARN.
+const accountIDLen = 12
+
+// policyKey normalizes a Qualifier into the resource-policy map key. AWS keeps a
+// separate policy per version/alias; an empty or "$LATEST" qualifier is the
+// function's unqualified policy.
+func policyKey(qualifier string) string {
+	if qualifier == "" {
+		return latestVersion
+	}
+
+	return qualifier
+}
+
 // AddPermission adds a statement to a function's resource-based policy. This
 // backs Terraform's aws_lambda_permission and the grants S3/SNS/EventBridge
-// create to invoke a function. The emulator stores statements without
-// evaluating them — invocation is never actually denied.
-func (m *Mock) AddPermission(_ context.Context, functionName string, stmt driver.PermissionStatement) error {
+// create to invoke a function. A Qualifier scopes the statement to a single
+// published version or alias — AWS stores a separate policy per qualifier. The
+// emulator stores statements without evaluating them — invocation is never
+// actually denied.
+func (m *Mock) AddPermission(_ context.Context, functionName, qualifier string, stmt driver.PermissionStatement) error {
 	if stmt.StatementID == "" {
 		return cerrors.New(cerrors.InvalidArgument, "StatementId is required")
 	}
@@ -25,22 +43,34 @@ func (m *Mock) AddPermission(_ context.Context, functionName string, stmt driver
 		return cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
 	}
 
-	if fd.policy == nil {
-		fd.policy = make(map[string]driver.PermissionStatement)
+	// A qualifier must name a version/alias that exists; a grant on a missing one
+	// is a ResourceNotFoundException, matching real Lambda.
+	if _, err := m.resolveQualifier(&fd, qualifier); err != nil {
+		return err
 	}
 
-	if _, exists := fd.policy[stmt.StatementID]; exists {
+	if fd.policies == nil {
+		fd.policies = make(map[string]map[string]driver.PermissionStatement)
+	}
+
+	key := policyKey(qualifier)
+	if fd.policies[key] == nil {
+		fd.policies[key] = make(map[string]driver.PermissionStatement)
+	}
+
+	if _, exists := fd.policies[key][stmt.StatementID]; exists {
 		return cerrors.Newf(cerrors.AlreadyExists, "statement %s already exists", stmt.StatementID)
 	}
 
-	fd.policy[stmt.StatementID] = stmt
+	fd.policies[key][stmt.StatementID] = stmt
 	m.funcs.Set(functionName, fd)
 
 	return nil
 }
 
-// RemovePermission drops a statement from a function's resource-based policy.
-func (m *Mock) RemovePermission(_ context.Context, functionName, statementID string) error {
+// RemovePermission drops a statement from a function's (qualifier-scoped)
+// resource-based policy.
+func (m *Mock) RemovePermission(_ context.Context, functionName, qualifier, statementID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -49,20 +79,22 @@ func (m *Mock) RemovePermission(_ context.Context, functionName, statementID str
 		return cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
 	}
 
-	if _, exists := fd.policy[statementID]; !exists {
+	key := policyKey(qualifier)
+	if _, exists := fd.policies[key][statementID]; !exists {
 		return cerrors.Newf(cerrors.NotFound, "statement %s not found", statementID)
 	}
 
-	delete(fd.policy, statementID)
+	delete(fd.policies[key], statementID)
 	m.funcs.Set(functionName, fd)
 
 	return nil
 }
 
-// GetPolicy returns the function's resource-based policy as a JSON document,
-// matching the shape the AWS SDK expects (IAM policy with Sid/Principal/
-// Action/Resource per statement). Returns NotFound when no policy exists.
-func (m *Mock) GetPolicy(_ context.Context, functionName string) (string, error) {
+// GetPolicy returns the function's (qualifier-scoped) resource-based policy as a
+// JSON document, matching the shape the AWS SDK expects (IAM policy with Sid/
+// Principal/Action/Resource per statement). Returns NotFound when no policy
+// exists for the qualifier.
+func (m *Mock) GetPolicy(_ context.Context, functionName, qualifier string) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -71,26 +103,22 @@ func (m *Mock) GetPolicy(_ context.Context, functionName string) (string, error)
 		return "", cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
 	}
 
-	if len(fd.policy) == 0 {
+	key := policyKey(qualifier)
+
+	scoped := fd.policies[key]
+	if len(scoped) == 0 {
 		return "", cerrors.Newf(cerrors.NotFound, "no policy for function %s", functionName)
 	}
 
-	statements := make([]map[string]any, 0, len(fd.policy))
-	for _, s := range fd.policy {
-		stmt := map[string]any{
-			"Sid":       s.StatementID,
-			"Effect":    "Allow",
-			"Principal": map[string]string{"Service": s.Principal},
-			"Action":    s.Action,
-			"Resource":  fd.info.ARN,
-		}
-		if s.SourceARN != "" {
-			stmt["Condition"] = map[string]any{
-				"ArnLike": map[string]string{"AWS:SourceArn": s.SourceARN},
-			}
-		}
+	// A qualified policy is scoped to the qualified function ARN.
+	resource := fd.info.ARN
+	if key != latestVersion {
+		resource += ":" + key
+	}
 
-		statements = append(statements, stmt)
+	statements := make([]map[string]any, 0, len(scoped))
+	for _, s := range scoped {
+		statements = append(statements, statementJSON(s, resource))
 	}
 
 	doc, err := json.Marshal(map[string]any{
@@ -103,4 +131,56 @@ func (m *Mock) GetPolicy(_ context.Context, functionName string) (string, error)
 	}
 
 	return string(doc), nil
+}
+
+// statementJSON renders one resource-policy statement in the IAM shape AWS
+// returns, with the principal classified by type (see principalJSON).
+func statementJSON(s driver.PermissionStatement, resource string) map[string]any {
+	stmt := map[string]any{
+		"Sid":       s.StatementID,
+		"Effect":    "Allow",
+		"Principal": principalJSON(s.Principal),
+		"Action":    s.Action,
+		"Resource":  resource,
+	}
+
+	if s.SourceARN != "" {
+		stmt["Condition"] = map[string]any{
+			"ArnLike": map[string]string{"AWS:SourceArn": s.SourceARN},
+		}
+	}
+
+	return stmt
+}
+
+// principalJSON renders an AddPermission Principal in the shape AWS uses in the
+// resource policy: "*" stays a bare wildcard; a 12-digit account id becomes the
+// account's IAM root ARN under "AWS"; an IAM ARN stays under "AWS"; anything
+// else (a service domain such as s3.amazonaws.com) goes under "Service".
+func principalJSON(principal string) any {
+	switch {
+	case principal == "*":
+		return "*"
+	case strings.HasPrefix(principal, "arn:"):
+		return map[string]string{"AWS": principal}
+	case isAccountID(principal):
+		return map[string]string{"AWS": "arn:aws:iam::" + principal + ":root"}
+	default:
+		return map[string]string{"Service": principal}
+	}
+}
+
+// isAccountID reports whether s is a 12-digit AWS account id.
+func isAccountID(s string) bool {
+	if len(s) != accountIDLen {
+		return false
+	}
+
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return true
 }

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -102,9 +102,9 @@ const (
 // driver — resource policies are a Lambda concept — so the handler type-asserts
 // for it rather than requiring every cloud's function provider to implement it.
 type policyManager interface {
-	AddPermission(ctx context.Context, functionName string, stmt sdrv.PermissionStatement) error
-	RemovePermission(ctx context.Context, functionName, statementID string) error
-	GetPolicy(ctx context.Context, functionName string) (string, error)
+	AddPermission(ctx context.Context, functionName, qualifier string, stmt sdrv.PermissionStatement) error
+	RemovePermission(ctx context.Context, functionName, qualifier, statementID string) error
+	GetPolicy(ctx context.Context, functionName, qualifier string) (string, error)
 }
 
 // functionTagger is the AWS-specific Lambda tagging surface (not part of the
@@ -363,6 +363,8 @@ func (h *Handler) servePolicy(w http.ResponseWriter, r *http.Request, name strin
 		return
 	}
 
+	qualifier := r.URL.Query().Get("Qualifier")
+
 	switch r.Method {
 	case http.MethodPost:
 		var req addPermissionRequest
@@ -370,7 +372,7 @@ func (h *Handler) servePolicy(w http.ResponseWriter, r *http.Request, name strin
 			return
 		}
 
-		err := pm.AddPermission(r.Context(), name, sdrv.PermissionStatement{
+		err := pm.AddPermission(r.Context(), name, qualifier, sdrv.PermissionStatement{
 			StatementID: req.StatementID, Action: req.Action,
 			Principal: req.Principal, SourceARN: req.SourceArn,
 		})
@@ -379,20 +381,18 @@ func (h *Handler) servePolicy(w http.ResponseWriter, r *http.Request, name strin
 			return
 		}
 
-		stmt, jerr := json.Marshal(map[string]any{
-			"Sid":       req.StatementID,
-			"Effect":    "Allow",
-			"Principal": map[string]string{"Service": req.Principal},
-			"Action":    req.Action,
-		})
-		if jerr != nil {
-			writeErr(w, jerr)
+		// Echo the statement exactly as GetPolicy renders it (correct per-type
+		// Principal shape, qualified Resource) rather than re-deriving it here, so
+		// the AddPermission response and a subsequent GetPolicy agree.
+		stmt, err := addedStatement(r.Context(), pm, name, qualifier, req.StatementID)
+		if err != nil {
+			writeErr(w, err)
 			return
 		}
 
-		writeJSON(w, http.StatusCreated, map[string]string{"Statement": string(stmt)})
+		writeJSON(w, http.StatusCreated, map[string]string{"Statement": stmt})
 	case http.MethodGet:
-		policy, err := pm.GetPolicy(r.Context(), name)
+		policy, err := pm.GetPolicy(r.Context(), name, qualifier)
 		if err != nil {
 			writeErr(w, err)
 			return
@@ -402,6 +402,36 @@ func (h *Handler) servePolicy(w http.ResponseWriter, r *http.Request, name strin
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
 	}
+}
+
+// addedStatement returns the JSON of the single statement just added, pulled
+// back out of the qualifier-scoped policy so the AddPermission echo matches the
+// GetPolicy rendering (Principal shape, Resource ARN) instead of duplicating it.
+func addedStatement(ctx context.Context, pm policyManager, name, qualifier, statementID string) (string, error) {
+	policy, err := pm.GetPolicy(ctx, name, qualifier)
+	if err != nil {
+		return "", err
+	}
+
+	var doc struct {
+		Statement []json.RawMessage `json:"Statement"`
+	}
+
+	if err := json.Unmarshal([]byte(policy), &doc); err != nil {
+		return "", err
+	}
+
+	for _, raw := range doc.Statement {
+		var peek struct {
+			Sid string `json:"Sid"`
+		}
+
+		if json.Unmarshal(raw, &peek) == nil && peek.Sid == statementID {
+			return string(raw), nil
+		}
+	}
+
+	return "", cerrors.Newf(cerrors.NotFound, "statement %s not found", statementID)
 }
 
 // serveRemovePermission handles DELETE .../{name}/policy/{statementId}.
@@ -417,7 +447,7 @@ func (h *Handler) serveRemovePermission(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	if err := pm.RemovePermission(r.Context(), name, statementID); err != nil {
+	if err := pm.RemovePermission(r.Context(), name, r.URL.Query().Get("Qualifier"), statementID); err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -431,13 +461,13 @@ func (h *Handler) serveRemovePermission(w http.ResponseWriter, r *http.Request, 
 // UpdateFunctionConfiguration.
 func (h *Handler) serveConfiguration(w http.ResponseWriter, r *http.Request, name string) {
 	if r.Method == http.MethodGet {
-		info, err := h.fn.GetFunction(r.Context(), name)
+		cfg, err := h.resolvedConfiguration(r.Context(), name, r.URL.Query().Get("Qualifier"))
 		if err != nil {
 			writeErr(w, err)
 			return
 		}
 
-		writeJSON(w, http.StatusOK, toConfiguration(info, h.awsFnConfig(r.Context(), name)))
+		writeJSON(w, http.StatusOK, cfg)
 
 		return
 	}
@@ -822,8 +852,14 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, name string) {
 		return
 	}
 
+	cfg, err := h.resolvedConfiguration(r.Context(), name, r.URL.Query().Get("Qualifier"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	writeJSON(w, http.StatusOK, functionResource{
-		Configuration: toConfiguration(info, h.awsFnConfig(r.Context(), name)),
+		Configuration: cfg,
 		Code: codeLocation{
 			RepositoryType: "S3",
 			Location:       "https://cloudemu-mock/" + name,
@@ -831,6 +867,65 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, name string) {
 		Concurrency: h.reservedConcurrency(r.Context(), name),
 		Tags:        info.Tags,
 	})
+}
+
+// resolvedConfiguration renders a function's configuration for an optional
+// Qualifier. An empty or "$LATEST" qualifier returns the mutable $LATEST config;
+// a version number returns that published version's snapshot (its own
+// CodeSha256/Runtime/Timeout and a version-qualified ARN); an alias resolves to
+// its target version's config but keeps the alias-qualified ARN. A qualifier
+// that names neither an alias nor a published version is a
+// ResourceNotFoundException, matching real Lambda.
+func (h *Handler) resolvedConfiguration(ctx context.Context, name, qualifier string) (functionConfiguration, error) {
+	info, err := h.fn.GetFunction(ctx, name)
+	if err != nil {
+		return functionConfiguration{}, err
+	}
+
+	awsCfg := h.awsFnConfig(ctx, name)
+
+	if qualifier == "" || qualifier == latestVersion {
+		return toConfiguration(info, awsCfg), nil
+	}
+
+	// An alias resolves one hop to its target version's config; the ARN keeps the
+	// alias qualifier rather than the target version number.
+	if a, aerr := h.fn.GetAlias(ctx, name, qualifier); aerr == nil {
+		ver, verr := h.findVersion(ctx, name, a.FunctionVersion)
+		if verr != nil {
+			return functionConfiguration{}, verr
+		}
+
+		cfg := toVersionConfiguration(info, ver, awsCfg)
+		cfg.FunctionArn = info.ARN + ":" + qualifier
+
+		return cfg, nil
+	}
+
+	ver, verr := h.findVersion(ctx, name, qualifier)
+	if verr != nil {
+		return functionConfiguration{}, cerrors.Newf(cerrors.NotFound,
+			"function version or alias %q not found for %s", qualifier, name)
+	}
+
+	return toVersionConfiguration(info, ver, awsCfg), nil
+}
+
+// findVersion returns the published version (or $LATEST) snapshot matching
+// version, or a NotFound error.
+func (h *Handler) findVersion(ctx context.Context, name, version string) (*sdrv.FunctionVersion, error) {
+	vers, err := h.fn.ListVersions(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range vers {
+		if vers[i].Version == version {
+			return &vers[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "version %s not found for %s", version, name)
 }
 
 func (h *Handler) list(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/lambda/qualifier_policy_test.go
+++ b/server/aws/lambda/qualifier_policy_test.go
@@ -1,0 +1,317 @@
+package lambda_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/aws/smithy-go"
+)
+
+// errorCode returns the AWS error code from a smithy API error, or "" if err is
+// not an API error.
+func errorCode(err error) string {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorCode()
+	}
+
+	return ""
+}
+
+// TestSDKGetFunctionConfigurationQualifier is a regression guard for the audit's
+// F1: GetFunction/GetFunctionConfiguration ignored the Qualifier and always
+// returned $LATEST. A published version (or alias) must report its own
+// Version/Timeout/CodeSha256 and a qualified ARN.
+func TestSDKGetFunctionConfigurationQualifier(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("cfgqual"),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Timeout:      aws.Int32(3),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("v1-code")},
+	}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	pub, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{FunctionName: aws.String("cfgqual")})
+	if err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+
+	if aws.ToString(pub.Version) != "1" {
+		t.Fatalf("published version = %q, want 1", aws.ToString(pub.Version))
+	}
+
+	v1Sha := aws.ToString(pub.CodeSha256)
+
+	// Mutate $LATEST: new code (new CodeSha256) and a new Timeout.
+	if _, err = client.UpdateFunctionCode(ctx, &awslambda.UpdateFunctionCodeInput{
+		FunctionName: aws.String("cfgqual"), ZipFile: []byte("v2-code-different"),
+	}); err != nil {
+		t.Fatalf("UpdateFunctionCode: %v", err)
+	}
+
+	if _, err = client.UpdateFunctionConfiguration(ctx, &awslambda.UpdateFunctionConfigurationInput{
+		FunctionName: aws.String("cfgqual"), Timeout: aws.Int32(99),
+	}); err != nil {
+		t.Fatalf("UpdateFunctionConfiguration: %v", err)
+	}
+
+	// GetFunctionConfiguration(Qualifier="1") must return v1's snapshot.
+	v1cfg, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("cfgqual"), Qualifier: aws.String("1"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConfiguration(Qualifier=1): %v", err)
+	}
+
+	if got := aws.ToString(v1cfg.Version); got != "1" {
+		t.Fatalf("v1 Version = %q, want 1", got)
+	}
+
+	if got := aws.ToInt32(v1cfg.Timeout); got != 3 {
+		t.Fatalf("v1 Timeout = %d, want 3 (the published snapshot, not $LATEST's 99)", got)
+	}
+
+	if got := aws.ToString(v1cfg.CodeSha256); got != v1Sha {
+		t.Fatalf("v1 CodeSha256 = %q, want the published %q", got, v1Sha)
+	}
+
+	if got := aws.ToString(v1cfg.FunctionArn); !strings.HasSuffix(got, ":function:cfgqual:1") {
+		t.Fatalf("v1 FunctionArn = %q, want a :1-qualified ARN", got)
+	}
+
+	// Unqualified GetFunctionConfiguration is $LATEST — unchanged.
+	latest, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("cfgqual"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConfiguration($LATEST): %v", err)
+	}
+
+	if got := aws.ToString(latest.Version); got != "$LATEST" {
+		t.Fatalf("$LATEST Version = %q, want $LATEST", got)
+	}
+
+	if got := aws.ToInt32(latest.Timeout); got != 99 {
+		t.Fatalf("$LATEST Timeout = %d, want 99", got)
+	}
+
+	if aws.ToString(latest.CodeSha256) == v1Sha {
+		t.Fatal("$LATEST CodeSha256 equals v1's, want the updated code's hash")
+	}
+
+	if got := aws.ToString(latest.FunctionArn); strings.HasSuffix(got, ":1") {
+		t.Fatalf("$LATEST FunctionArn = %q, want no version suffix", got)
+	}
+
+	// GetFunction(Qualifier="1") resolves the same way.
+	getV1, err := client.GetFunction(ctx, &awslambda.GetFunctionInput{
+		FunctionName: aws.String("cfgqual"), Qualifier: aws.String("1"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunction(Qualifier=1): %v", err)
+	}
+
+	if got := aws.ToString(getV1.Configuration.Version); got != "1" {
+		t.Fatalf("GetFunction v1 Version = %q, want 1", got)
+	}
+
+	// A bad qualifier is ResourceNotFoundException.
+	if _, err = client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("cfgqual"), Qualifier: aws.String("99"),
+	}); errorCode(err) != "ResourceNotFoundException" {
+		t.Fatalf("GetFunctionConfiguration(Qualifier=99) error = %v, want ResourceNotFoundException", err)
+	}
+}
+
+// TestSDKGetFunctionConfigurationAliasQualifier covers an alias Qualifier: it
+// resolves to the target version's config but keeps the alias-qualified ARN.
+func TestSDKGetFunctionConfigurationAliasQualifier(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("aliascfg"),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Timeout:      aws.Int32(7),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("alias-code")},
+	}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	if _, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
+		FunctionName: aws.String("aliascfg"),
+	}); err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+
+	if _, err := client.CreateAlias(ctx, &awslambda.CreateAliasInput{
+		FunctionName: aws.String("aliascfg"), Name: aws.String("prod"), FunctionVersion: aws.String("1"),
+	}); err != nil {
+		t.Fatalf("CreateAlias: %v", err)
+	}
+
+	// Move $LATEST's Timeout so the alias (-> v1) must not read $LATEST.
+	if _, err := client.UpdateFunctionConfiguration(ctx, &awslambda.UpdateFunctionConfigurationInput{
+		FunctionName: aws.String("aliascfg"), Timeout: aws.Int32(88),
+	}); err != nil {
+		t.Fatalf("UpdateFunctionConfiguration: %v", err)
+	}
+
+	cfg, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("aliascfg"), Qualifier: aws.String("prod"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConfiguration(Qualifier=prod): %v", err)
+	}
+
+	if got := aws.ToString(cfg.Version); got != "1" {
+		t.Fatalf("alias Version = %q, want 1 (the target version)", got)
+	}
+
+	if got := aws.ToInt32(cfg.Timeout); got != 7 {
+		t.Fatalf("alias Timeout = %d, want 7 (v1's snapshot)", got)
+	}
+
+	if got := aws.ToString(cfg.FunctionArn); !strings.HasSuffix(got, ":function:aliascfg:prod") {
+		t.Fatalf("alias FunctionArn = %q, want a :prod-qualified ARN", got)
+	}
+}
+
+// TestSDKCreateEventSourceMappingNonexistentFunction is a regression guard for
+// F2: creating an ESM whose target function does not exist must fail with
+// ResourceNotFoundException instead of silently succeeding.
+func TestSDKCreateEventSourceMappingNonexistentFunction(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.CreateEventSourceMapping(ctx, &awslambda.CreateEventSourceMappingInput{
+		FunctionName:   aws.String("does-not-exist"),
+		EventSourceArn: aws.String("arn:aws:sqs:us-east-1:000000000000:ghost-queue"),
+	})
+	if errorCode(err) != "ResourceNotFoundException" {
+		t.Fatalf("CreateEventSourceMapping(nonexistent) error = %v, want ResourceNotFoundException", err)
+	}
+}
+
+// TestSDKAddPermissionQualifierScoped is a regression guard for F3: a grant with
+// a Qualifier must land on that alias/version's policy only, separate from the
+// unqualified ($LATEST) policy.
+func TestSDKAddPermissionQualifierScoped(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	createBasicFunction(t, client, "permqual")
+
+	if _, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
+		FunctionName: aws.String("permqual"),
+	}); err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+
+	if _, err := client.CreateAlias(ctx, &awslambda.CreateAliasInput{
+		FunctionName: aws.String("permqual"), Name: aws.String("live"), FunctionVersion: aws.String("1"),
+	}); err != nil {
+		t.Fatalf("CreateAlias: %v", err)
+	}
+
+	if _, err := client.AddPermission(ctx, &awslambda.AddPermissionInput{
+		FunctionName: aws.String("permqual"),
+		Qualifier:    aws.String("live"),
+		StatementId:  aws.String("acct-invoke"),
+		Action:       aws.String("lambda:InvokeFunction"),
+		Principal:    aws.String("123456789012"),
+	}); err != nil {
+		t.Fatalf("AddPermission(Qualifier=live): %v", err)
+	}
+
+	// The alias policy carries the statement.
+	livePolicy, err := client.GetPolicy(ctx, &awslambda.GetPolicyInput{
+		FunctionName: aws.String("permqual"), Qualifier: aws.String("live"),
+	})
+	if err != nil {
+		t.Fatalf("GetPolicy(Qualifier=live): %v", err)
+	}
+
+	if !strings.Contains(aws.ToString(livePolicy.Policy), `"Sid":"acct-invoke"`) {
+		t.Fatalf("alias policy missing statement: %s", aws.ToString(livePolicy.Policy))
+	}
+
+	// The unqualified ($LATEST) policy does not — a separate policy per qualifier.
+	if _, err := client.GetPolicy(ctx, &awslambda.GetPolicyInput{
+		FunctionName: aws.String("permqual"),
+	}); errorCode(err) != "ResourceNotFoundException" {
+		t.Fatalf("GetPolicy(unqualified) error = %v, want ResourceNotFoundException (no unqualified policy)", err)
+	}
+
+	// RemovePermission is also qualifier-scoped.
+	if _, err := client.RemovePermission(ctx, &awslambda.RemovePermissionInput{
+		FunctionName: aws.String("permqual"), Qualifier: aws.String("live"), StatementId: aws.String("acct-invoke"),
+	}); err != nil {
+		t.Fatalf("RemovePermission(Qualifier=live): %v", err)
+	}
+
+	if _, err := client.GetPolicy(ctx, &awslambda.GetPolicyInput{
+		FunctionName: aws.String("permqual"), Qualifier: aws.String("live"),
+	}); errorCode(err) != "ResourceNotFoundException" {
+		t.Fatalf("GetPolicy(Qualifier=live) after remove error = %v, want ResourceNotFoundException", err)
+	}
+}
+
+// TestSDKGetPolicyPrincipalShapes is a regression guard for F4: the Principal is
+// rendered per its type — Service for a service domain, AWS root ARN for an
+// account id, and a bare "*" wildcard.
+func TestSDKGetPolicyPrincipalShapes(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	createBasicFunction(t, client, "principals")
+
+	grants := []struct {
+		sid       string
+		principal string
+	}{
+		{"svc", "s3.amazonaws.com"},
+		{"acct", "123456789012"},
+		{"any", "*"},
+	}
+	for _, g := range grants {
+		if _, err := client.AddPermission(ctx, &awslambda.AddPermissionInput{
+			FunctionName: aws.String("principals"),
+			StatementId:  aws.String(g.sid),
+			Action:       aws.String("lambda:InvokeFunction"),
+			Principal:    aws.String(g.principal),
+		}); err != nil {
+			t.Fatalf("AddPermission(%s): %v", g.sid, err)
+		}
+	}
+
+	out, err := client.GetPolicy(ctx, &awslambda.GetPolicyInput{FunctionName: aws.String("principals")})
+	if err != nil {
+		t.Fatalf("GetPolicy: %v", err)
+	}
+
+	policy := aws.ToString(out.Policy)
+
+	for _, want := range []string{
+		`"Principal":{"Service":"s3.amazonaws.com"}`,
+		`"Principal":{"AWS":"arn:aws:iam::123456789012:root"}`,
+		`"Principal":"*"`,
+	} {
+		if !strings.Contains(policy, want) {
+			t.Fatalf("policy missing %s\ngot: %s", want, policy)
+		}
+	}
+}


### PR DESCRIPTION
## What

Fixes four AWS Lambda bugs found by the deep-e2e audit around qualifier resolution, resource policies, and event-source-mapping validation.

**F1 [HIGH] — GetFunction / GetFunctionConfiguration now honor `?Qualifier=`.**
Reading a published version's or alias's configuration previously always returned `$LATEST`. Now a version number resolves to that version's immutable snapshot (its own `Runtime`/`Handler`/`Timeout`/`MemorySize`/`CodeSha256`/`RevisionId` and a version-qualified ARN), and an alias resolves one hop to its target version's config while keeping the alias-qualified ARN. A qualifier that names neither an alias nor a published version returns `ResourceNotFoundException`. `$LATEST`/no-qualifier is unchanged. Mirrors the qualifier resolution Invoke already did.

**F2 [MED] — CreateEventSourceMapping rejects a nonexistent target function.**
Previously an ESM whose `FunctionName` pointed at a missing function was created `Enabled` and silently never fired. Now the target function must exist or the call returns `ResourceNotFoundException` (a documented error for this API). Cross-service DynamoDB/SQS delivery uses `InvokeExternal`, not this path, so it is unaffected.

**F3 [MED] — Resource policy scoped per (function, qualifier).**
`AddPermission`/`RemovePermission`/`GetPolicy` now thread the `Qualifier` from wire to provider and key the policy store by qualifier, so an alias/version grant lands on that qualifier's policy and no longer bleeds into the `$LATEST` policy. `GetPolicy(Qualifier=...)` reads back only that qualifier's statements.

**F4 [MED] — GetPolicy renders the principal per its type.**
A service principal (e.g. `s3.amazonaws.com`) renders as `{"Service": ...}`, an AWS account id as `{"AWS":"arn:aws:iam::<id>:root"}`, an IAM ARN as `{"AWS": <arn>}`, and `*` as a bare `"*"`. The `AddPermission` response echo now reuses the same rendering (pulled back from `GetPolicy`) so the two agree.

## Why

The Lambda surface was half-wired: Invoke resolved qualifiers but Get/GetFunctionConfiguration did not, so any client pinning a version/alias saw `$LATEST` — perpetual Terraform/CDK drift. Alias/version grants were mis-scoped, an account/`*` principal came back mis-shaped, and a typo'd ESM function silently succeeded.

## Tests

New `aws-sdk-go-v2` reproductions in `server/aws/lambda/qualifier_policy_test.go`: version/alias qualifier resolution (distinct CodeSha256/Timeout/ARN), bad qualifier -> RNF, `$LATEST` unchanged; ESM on a nonexistent function -> RNF; per-qualifier `AddPermission`/`GetPolicy`/`RemovePermission`; principal Service vs AWS-account vs `*` shapes. Existing Lambda suites (ESM delivery, alias-invoke, defaults, tagging, resource-policy) stay green.
