### PR TITLE
fix(aws-dynamodb): atomic conditional writes + transactions (close TOCTOU race)

### DIFF
--- a/providers/aws/dynamodb/conditional.go
+++ b/providers/aws/dynamodb/conditional.go
@@ -1,0 +1,446 @@
+package dynamodb
+
+import (
+	"context"
+	"maps"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+)
+
+// This file holds the ATOMIC conditional-write and transaction primitives. The
+// wire handler must NOT evaluate a ConditionExpression with a standalone GetItem
+// and then issue the mutation as a separate call — dropping the table lock in
+// between opens a TOCTOU window where two concurrent conditional writes on one
+// key both succeed. Each method here evaluates the condition and applies the
+// write under a SINGLE hold of m.mu, so no concurrent writer can interleave.
+//
+// PutItem/DeleteItem/UpdateItem delegate to these with an empty Condition, so the
+// unconditional and conditional paths share one implementation.
+
+// evalCondition parses (reusing expr.ParseCondition — no duplicated parser) and
+// evaluates a ConditionExpression against the current stored item. An empty
+// expression always passes. A missing item is evaluated against an empty item so
+// attribute_not_exists is true and attribute_exists is false, matching DynamoDB
+// create-if-absent semantics.
+func evalCondition(cond driver.Condition, existing map[string]any) (bool, error) {
+	if strings.TrimSpace(cond.Expression) == "" {
+		return true, nil
+	}
+
+	node, err := expr.ParseCondition(cond.Expression, cond.Names, cond.Values)
+	if err != nil {
+		return false, err
+	}
+
+	if existing == nil {
+		existing = map[string]any{}
+	}
+
+	return expr.Eval(node, existing)
+}
+
+// condExisting returns the item to evaluate a condition against: the stored item
+// when present, otherwise nil (evalCondition treats nil as an empty item).
+func condExisting(item map[string]any, present bool) map[string]any {
+	if !present {
+		return nil
+	}
+
+	return item
+}
+
+// oldImage returns a defensive copy of the stored item for return to the caller
+// (ReturnValues=ALL_OLD / the conflicting item on a failed condition), or nil
+// when there was no stored item.
+func oldImage(item map[string]any, present bool) map[string]any {
+	if !present {
+		return nil
+	}
+
+	return maps.Clone(item)
+}
+
+// checkConditionLocked evaluates cond against the current stored item, returning
+// a *driver.ConditionalCheckFailed (carrying the conflicting item) on a failed
+// condition, the parse error on a malformed expression, or nil when it passes.
+// Caller must hold m.mu.
+func checkConditionLocked(cond driver.Condition, item map[string]any, present bool) error {
+	ok, err := evalCondition(cond, condExisting(item, present))
+	if err != nil {
+		return err
+	}
+
+	if !ok {
+		return &driver.ConditionalCheckFailed{Item: oldImage(item, present)}
+	}
+
+	return nil
+}
+
+// emitWriteMetrics pushes the per-write CloudWatch metrics shared by every
+// mutating operation.
+func (m *Mock) emitWriteMetrics(table string) {
+	dims := map[string]string{"TableName": table}
+	m.emitMetric("ConsumedWriteCapacityUnits", 1, dims)
+	m.emitMetric("SuccessfulRequestCount", 1, dims)
+}
+
+// PutItemConditional writes item only if cond passes, evaluating the condition
+// and the write atomically under m.mu. It returns the previous stored item (nil
+// if none) for ReturnValues=ALL_OLD, or a *driver.ConditionalCheckFailed when the
+// condition fails.
+func (m *Mock) PutItemConditional(
+	ctx context.Context, table string, item map[string]any, cond driver.Condition,
+) (map[string]any, error) {
+	m.mu.Lock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		m.mu.Unlock()
+		return nil, cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	if err := validateItemKeys(td.config, item); err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+
+	if err := validateItemSize(item); err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+
+	key := itemKey(td.config, item)
+	oldItem, hadOld := td.items.Get(key)
+
+	if err := checkConditionLocked(cond, oldItem, hadOld); err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+
+	stored := maps.Clone(item)
+	td.items.Set(key, stored)
+	m.recordStreamEvent(td, oldItem, stored, hadOld)
+	m.mu.Unlock()
+	m.flushStreamDeliveries(ctx)
+
+	m.emitWriteMetrics(table)
+
+	return oldImage(oldItem, hadOld), nil
+}
+
+// DeleteItemConditional deletes the item at key only if cond passes, evaluating
+// the condition and the delete atomically under m.mu. It returns the deleted
+// item (nil if none) for ReturnValues=ALL_OLD, or a *driver.ConditionalCheckFailed
+// when the condition fails.
+func (m *Mock) DeleteItemConditional(
+	ctx context.Context, table string, key map[string]any, cond driver.Condition,
+) (map[string]any, error) {
+	m.mu.Lock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		m.mu.Unlock()
+		return nil, cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	if err := validateKeyMapNotEmpty(td.config.PartitionKey, td.config.SortKey, key); err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+
+	k := itemKey(td.config, key)
+	oldItem, hadOld := td.items.Get(k)
+
+	if err := checkConditionLocked(cond, oldItem, hadOld); err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+
+	td.items.Delete(k)
+
+	if hadOld {
+		m.recordStreamRemove(td, oldItem)
+	}
+
+	m.mu.Unlock()
+	m.flushStreamDeliveries(ctx)
+
+	m.emitWriteMetrics(table)
+
+	return oldImage(oldItem, hadOld), nil
+}
+
+// UpdateItemConditional applies input's update only if cond passes, evaluating
+// the condition and the update atomically under m.mu (upserting a missing item
+// exactly like UpdateItem). It returns the post-update item and the pre-update
+// image (nil when the item was created), or a *driver.ConditionalCheckFailed when
+// the condition fails.
+//
+//nolint:gocritic // hugeParam: input mirrors the driver's UpdateItem signature.
+func (m *Mock) UpdateItemConditional(
+	ctx context.Context, input driver.UpdateItemInput, cond driver.Condition,
+) (updated, old map[string]any, err error) {
+	m.mu.Lock()
+
+	td, exists := m.tables[input.Table]
+	if !exists {
+		m.mu.Unlock()
+		return nil, nil, cerrors.Newf(cerrors.NotFound, "table %s not found", input.Table)
+	}
+
+	if verr := validateKeyMapNotEmpty(td.config.PartitionKey, td.config.SortKey, input.Key); verr != nil {
+		m.mu.Unlock()
+		return nil, nil, verr
+	}
+
+	k := itemKey(td.config, input.Key)
+	item, ok := td.items.Get(k)
+
+	if cerr := checkConditionLocked(cond, item, ok); cerr != nil {
+		m.mu.Unlock()
+		return nil, nil, cerr
+	}
+
+	base, oldItem := updateBaseImage(item, ok, input.Key)
+
+	result, aerr := driver.ApplyUpdate(base, input)
+	if aerr != nil {
+		m.mu.Unlock()
+		return nil, nil, aerr
+	}
+
+	if verr := validateItemSize(result); verr != nil {
+		m.mu.Unlock()
+		return nil, nil, verr
+	}
+
+	td.items.Set(k, result)
+	m.recordStreamEvent(td, oldItem, result, true)
+	m.mu.Unlock()
+	m.flushStreamDeliveries(ctx)
+
+	m.emitWriteMetrics(input.Table)
+
+	return maps.Clone(result), oldItem, nil
+}
+
+// updateBaseImage resolves the base item an UpdateExpression mutates and the
+// pre-update image reported for ALL_OLD/UPDATED_OLD. A present item seeds both; a
+// missing item upserts from the key attributes with no pre-image.
+func updateBaseImage(item map[string]any, present bool, key map[string]any) (base, old map[string]any) {
+	if present {
+		return copyItem(item), copyItem(item)
+	}
+
+	return copyItem(key), nil
+}
+
+// TransactWrite executes an atomic TransactWriteItems: every ConditionExpression
+// is evaluated, and only if all pass are all writes applied — the whole set under
+// a single hold of m.mu, so the transaction is all-or-nothing and isolated from
+// concurrent single-item writes. On any failed condition it returns a
+// *driver.TransactionCanceled naming the failed operations and writes nothing.
+func (m *Mock) TransactWrite(ctx context.Context, ops []driver.TransactOp) error {
+	m.mu.Lock()
+	// flush registers before the unlock defer so it runs after the lock is
+	// released (defers are LIFO), delivering stream records outside m.mu.
+	defer func() { m.flushStreamDeliveries(ctx) }()
+	defer m.mu.Unlock()
+
+	tds, err := m.resolveTransactTables(ops)
+	if err != nil {
+		return err
+	}
+
+	failed, err := evalTransactConditions(tds, ops)
+	if err != nil {
+		return err
+	}
+
+	if len(failed) > 0 {
+		return &driver.TransactionCanceled{FailedConditions: failed}
+	}
+
+	plans, err := planTransactMutations(tds, ops)
+	if err != nil {
+		return err
+	}
+
+	m.commitTransactMutations(plans)
+
+	return nil
+}
+
+// resolveTransactTables resolves and structurally validates every operation's
+// target before any condition is evaluated or any write applied. A missing table
+// is a ResourceNotFound (not a cancellation), matching real DynamoDB. Caller must
+// hold m.mu.
+func (m *Mock) resolveTransactTables(ops []driver.TransactOp) ([]*tableData, error) {
+	tds := make([]*tableData, len(ops))
+
+	for i := range ops {
+		td, exists := m.tables[ops[i].Table]
+		if !exists {
+			return nil, cerrors.Newf(cerrors.NotFound, "table %s not found", ops[i].Table)
+		}
+
+		if err := validateTransactOp(td, &ops[i]); err != nil {
+			return nil, err
+		}
+
+		tds[i] = td
+	}
+
+	return tds, nil
+}
+
+// validateTransactOp enforces the per-operation structural rules (a Put carries a
+// valid, sized item; the keyed operations carry a non-empty key) before the
+// transaction commits anything.
+func validateTransactOp(td *tableData, op *driver.TransactOp) error {
+	if op.Kind == driver.TransactPut {
+		if err := validateItemKeys(td.config, op.Item); err != nil {
+			return err
+		}
+
+		return validateItemSize(op.Item)
+	}
+
+	return validateKeyMapNotEmpty(td.config.PartitionKey, td.config.SortKey, op.Key)
+}
+
+// opKeySource returns the attributes that identify an operation's target item:
+// the full item for a Put, the Key for the others.
+func opKeySource(op *driver.TransactOp) map[string]any {
+	if op.Kind == driver.TransactPut {
+		return op.Item
+	}
+
+	return op.Key
+}
+
+// evalTransactConditions evaluates every operation's ConditionExpression against
+// current state, returning the indices (request order) whose condition failed. A
+// malformed expression surfaces as a non-nil error. Caller must hold m.mu.
+func evalTransactConditions(tds []*tableData, ops []driver.TransactOp) ([]int, error) {
+	var failed []int
+
+	for i := range ops {
+		td := tds[i]
+		cur, had := td.items.Get(itemKey(td.config, opKeySource(&ops[i])))
+
+		ok, err := evalCondition(ops[i].Condition, condExisting(cur, had))
+		if err != nil {
+			return nil, err
+		}
+
+		if !ok {
+			failed = append(failed, i)
+		}
+	}
+
+	return failed, nil
+}
+
+// txMutation is one planned, condition-passed transaction write, computed before
+// anything is committed so a compute error (e.g. an oversized update) aborts the
+// whole transaction with nothing written.
+type txMutation struct {
+	td       *tableData
+	key      string
+	newItem  map[string]any
+	oldItem  map[string]any
+	hadOld   bool
+	isDelete bool
+	isNoop   bool // ConditionCheck: asserts a condition, writes nothing
+}
+
+// planTransactMutations computes the resulting write for every operation without
+// applying any, so a compute/validation error leaves the store untouched. Caller
+// must hold m.mu.
+func planTransactMutations(tds []*tableData, ops []driver.TransactOp) ([]txMutation, error) {
+	plans := make([]txMutation, len(ops))
+
+	for i := range ops {
+		plan, err := planTransactOp(tds[i], &ops[i])
+		if err != nil {
+			return nil, err
+		}
+
+		plans[i] = plan
+	}
+
+	return plans, nil
+}
+
+// planTransactOp computes a single operation's write against current state.
+func planTransactOp(td *tableData, op *driver.TransactOp) (txMutation, error) {
+	switch op.Kind {
+	case driver.TransactPut:
+		key := itemKey(td.config, op.Item)
+		old, had := td.items.Get(key)
+
+		return txMutation{td: td, key: key, newItem: maps.Clone(op.Item), oldItem: old, hadOld: had}, nil
+	case driver.TransactDelete:
+		key := itemKey(td.config, op.Key)
+		old, had := td.items.Get(key)
+
+		return txMutation{td: td, key: key, oldItem: old, hadOld: had, isDelete: true}, nil
+	case driver.TransactUpdate:
+		return planTransactUpdate(td, op)
+	default: // ConditionCheck
+		return txMutation{isNoop: true}, nil
+	}
+}
+
+// planTransactUpdate runs the UpdateExpression against the current (or upserted)
+// item, validating the result size, and returns the staged write.
+func planTransactUpdate(td *tableData, op *driver.TransactOp) (txMutation, error) {
+	key := itemKey(td.config, op.Key)
+	item, ok := td.items.Get(key)
+	base, oldItem := updateBaseImage(item, ok, op.Key)
+
+	result, err := driver.ApplyUpdate(base, driver.UpdateItemInput{
+		Table:            op.Table,
+		Key:              op.Key,
+		UpdateExpression: op.UpdateExpression,
+		ExprNames:        op.ExprNames,
+		ExprValues:       op.ExprValues,
+	})
+	if err != nil {
+		return txMutation{}, err
+	}
+
+	if err := validateItemSize(result); err != nil {
+		return txMutation{}, err
+	}
+
+	return txMutation{td: td, key: key, newItem: result, oldItem: oldItem, hadOld: true}, nil
+}
+
+// commitTransactMutations applies every staged write and records its stream
+// event. Conditions and computes have already succeeded, so this cannot fail.
+// Caller must hold m.mu.
+func (m *Mock) commitTransactMutations(plans []txMutation) {
+	for i := range plans {
+		p := plans[i]
+
+		switch {
+		case p.isNoop:
+			continue
+		case p.isDelete:
+			p.td.items.Delete(p.key)
+
+			if p.hadOld {
+				m.recordStreamRemove(p.td, p.oldItem)
+			}
+		default:
+			p.td.items.Set(p.key, p.newItem)
+			m.recordStreamEvent(p.td, p.oldItem, p.newItem, p.hadOld)
+		}
+	}
+}

--- a/providers/aws/dynamodb/conditional_test.go
+++ b/providers/aws/dynamodb/conditional_test.go
@@ -1,0 +1,238 @@
+package dynamodb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+)
+
+// newHashTable creates a single-partition-key table (no sort key), the shape a
+// put-if-absent / optimistic-lock test needs.
+func newHashTable(m *Mock, name string) {
+	_ = m.CreateTable(context.Background(), driver.TableConfig{Name: name, PartitionKey: "pk"})
+}
+
+// TestPutItemConditionalPutIfAbsentAtomic proves that attribute_not_exists
+// put-if-absent is atomic: when N goroutines race to create the SAME key, EXACTLY
+// one succeeds and every other gets ConditionalCheckFailed. The race is LOGICAL
+// (each op is individually mutex-guarded, so -race alone stays silent), so the
+// winners==1 invariant is asserted across many high-contention rounds.
+func TestPutItemConditionalPutIfAbsentAtomic(t *testing.T) {
+	const (
+		rounds     = 300
+		goroutines = 8
+	)
+
+	m := newTestMock()
+	newHashTable(m, "t")
+
+	ctx := context.Background()
+	cond := driver.Condition{Expression: "attribute_not_exists(pk)"}
+
+	for r := 0; r < rounds; r++ {
+		pk := fmt.Sprintf("k-%d", r)
+
+		var (
+			winners atomic.Int64
+			wg      sync.WaitGroup
+		)
+
+		wg.Add(goroutines)
+
+		for g := 0; g < goroutines; g++ {
+			go func() {
+				defer wg.Done()
+
+				item := map[string]any{"pk": pk, "v": expr.Number("1")}
+
+				_, err := m.PutItemConditional(ctx, "t", item, cond)
+				if err == nil {
+					winners.Add(1)
+					return
+				}
+
+				var ccf *driver.ConditionalCheckFailed
+				if !errors.As(err, &ccf) {
+					t.Errorf("round %d: unexpected error: %v", r, err)
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		if got := winners.Load(); got != 1 {
+			t.Fatalf("round %d: put-if-absent not atomic: %d writers succeeded, want exactly 1", r, got)
+		}
+	}
+}
+
+// TestUpdateItemConditionalOptimisticLockAtomic proves optimistic locking is
+// atomic: many goroutines race to bump a version-guarded item; exactly one wins
+// per version and the final version equals the number of rounds (no lost update,
+// no double-advance).
+func TestUpdateItemConditionalOptimisticLockAtomic(t *testing.T) {
+	const (
+		rounds     = 200
+		goroutines = 8
+	)
+
+	m := newTestMock()
+	newHashTable(m, "t")
+
+	ctx := context.Background()
+	if err := m.PutItem(ctx, "t", map[string]any{"pk": "x", "ver": expr.Number("0")}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	for r := 0; r < rounds; r++ {
+		values := map[string]any{
+			":cur": expr.Number(fmt.Sprintf("%d", r)),
+			":new": expr.Number(fmt.Sprintf("%d", r+1)),
+		}
+		input := driver.UpdateItemInput{
+			Table:            "t",
+			Key:              map[string]any{"pk": "x"},
+			UpdateExpression: "SET ver = :new",
+			ExprValues:       values,
+		}
+		cond := driver.Condition{Expression: "ver = :cur", Values: values}
+
+		var (
+			winners atomic.Int64
+			wg      sync.WaitGroup
+		)
+
+		wg.Add(goroutines)
+
+		for g := 0; g < goroutines; g++ {
+			go func() {
+				defer wg.Done()
+
+				_, _, err := m.UpdateItemConditional(ctx, input, cond)
+				if err == nil {
+					winners.Add(1)
+					return
+				}
+
+				var ccf *driver.ConditionalCheckFailed
+				if !errors.As(err, &ccf) {
+					t.Errorf("round %d: unexpected error: %v", r, err)
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		if got := winners.Load(); got != 1 {
+			t.Fatalf("round %d: optimistic update not atomic: %d writers won, want exactly 1", r, got)
+		}
+	}
+
+	final, err := m.GetItem(ctx, "t", map[string]any{"pk": "x"})
+	if err != nil {
+		t.Fatalf("final read: %v", err)
+	}
+
+	if got := final["ver"]; got != expr.Number(fmt.Sprintf("%d", rounds)) {
+		t.Fatalf("final version = %v, want %d (a lost update or double-advance occurred)", got, rounds)
+	}
+}
+
+// TestTransactWriteAllOrNothing proves a transaction is all-or-nothing: one
+// failing ConditionCheck cancels every write in the transaction, and the
+// CancellationReasons name the exact failing operation.
+func TestTransactWriteAllOrNothing(t *testing.T) {
+	m := newTestMock()
+	newHashTable(m, "t")
+
+	ctx := context.Background()
+	if err := m.PutItem(ctx, "t", map[string]any{"pk": "exists"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	ops := []driver.TransactOp{
+		{Kind: driver.TransactPut, Table: "t", Item: map[string]any{"pk": "new1"}},
+		{Kind: driver.TransactPut, Table: "t", Item: map[string]any{"pk": "exists"},
+			Condition: driver.Condition{Expression: "attribute_not_exists(pk)"}},
+		{Kind: driver.TransactPut, Table: "t", Item: map[string]any{"pk": "new2"}},
+	}
+
+	err := m.TransactWrite(ctx, ops)
+
+	var canceled *driver.TransactionCanceled
+	if !errors.As(err, &canceled) {
+		t.Fatalf("expected TransactionCanceled, got %v", err)
+	}
+
+	if len(canceled.FailedConditions) != 1 || canceled.FailedConditions[0] != 1 {
+		t.Fatalf("FailedConditions = %v, want [1]", canceled.FailedConditions)
+	}
+
+	// The two unconditional puts must NOT have been applied.
+	for _, pk := range []string{"new1", "new2"} {
+		if _, gerr := m.GetItem(ctx, "t", map[string]any{"pk": pk}); gerr == nil {
+			t.Fatalf("op wrote %q despite cancellation — transaction was not all-or-nothing", pk)
+		}
+	}
+}
+
+// TestTransactWriteConcurrentConflict proves two conflicting transactions cannot
+// both commit: N goroutines each run a put-if-absent transaction on the same key,
+// and exactly one commits per round.
+func TestTransactWriteConcurrentConflict(t *testing.T) {
+	const (
+		rounds     = 300
+		goroutines = 8
+	)
+
+	m := newTestMock()
+	newHashTable(m, "t")
+
+	ctx := context.Background()
+
+	for r := 0; r < rounds; r++ {
+		pk := fmt.Sprintf("k-%d", r)
+
+		var (
+			winners atomic.Int64
+			wg      sync.WaitGroup
+		)
+
+		wg.Add(goroutines)
+
+		for g := 0; g < goroutines; g++ {
+			go func() {
+				defer wg.Done()
+
+				ops := []driver.TransactOp{{
+					Kind: driver.TransactPut, Table: "t",
+					Item:      map[string]any{"pk": pk},
+					Condition: driver.Condition{Expression: "attribute_not_exists(pk)"},
+				}}
+
+				err := m.TransactWrite(ctx, ops)
+				if err == nil {
+					winners.Add(1)
+					return
+				}
+
+				var canceled *driver.TransactionCanceled
+				if !errors.As(err, &canceled) {
+					t.Errorf("round %d: unexpected error: %v", r, err)
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		if got := winners.Load(); got != 1 {
+			t.Fatalf("round %d: conflicting transactions not isolated: %d committed, want exactly 1", r, got)
+		}
+	}
+}

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -407,38 +407,13 @@ func (m *Mock) ListTables(_ context.Context) ([]string, error) {
 	return names, nil
 }
 
+// PutItem writes item unconditionally. It is the empty-condition case of
+// PutItemConditional, so the conditional and unconditional paths share one atomic
+// implementation.
 func (m *Mock) PutItem(ctx context.Context, table string, item map[string]any) error {
-	m.mu.Lock()
+	_, err := m.PutItemConditional(ctx, table, item, driver.Condition{})
 
-	td, exists := m.tables[table]
-	if !exists {
-		m.mu.Unlock()
-		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
-	}
-
-	if err := validateItemKeys(td.config, item); err != nil {
-		m.mu.Unlock()
-		return err
-	}
-
-	if err := validateItemSize(item); err != nil {
-		m.mu.Unlock()
-		return err
-	}
-
-	key := itemKey(td.config, item)
-	oldItem, hadOld := td.items.Get(key)
-	item = maps.Clone(item)
-	td.items.Set(key, item)
-	m.recordStreamEvent(td, oldItem, item, hadOld)
-	m.mu.Unlock()
-	m.flushStreamDeliveries(ctx)
-
-	dims := map[string]string{"TableName": table}
-	m.emitMetric("ConsumedWriteCapacityUnits", 1, dims)
-	m.emitMetric("SuccessfulRequestCount", 1, dims)
-
-	return nil
+	return err
 }
 
 func (m *Mock) GetItem(_ context.Context, table string, key map[string]any) (map[string]any, error) {
@@ -469,91 +444,22 @@ func (m *Mock) GetItem(_ context.Context, table string, key map[string]any) (map
 	return maps.Clone(item), nil
 }
 
-// UpdateItem applies partial updates to an existing item.
+// UpdateItem applies partial updates to an item (upserting when absent). It is
+// the empty-condition case of UpdateItemConditional.
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) UpdateItem(ctx context.Context, input driver.UpdateItemInput) (map[string]any, error) {
-	m.mu.Lock()
+	updated, _, err := m.UpdateItemConditional(ctx, input, driver.Condition{})
 
-	td, exists := m.tables[input.Table]
-	if !exists {
-		m.mu.Unlock()
-		return nil, cerrors.Newf(cerrors.NotFound, "table %s not found", input.Table)
-	}
-
-	if err := validateKeyMapNotEmpty(td.config.PartitionKey, td.config.SortKey, input.Key); err != nil {
-		m.mu.Unlock()
-		return nil, err
-	}
-
-	k := itemKey(td.config, input.Key)
-	item, ok := td.items.Get(k)
-
-	// Real DynamoDB UpdateItem upserts: a missing item is created from the key
-	// attributes and the update expression, rather than erroring. Any
-	// ConditionExpression has already been evaluated by the caller (the wire
-	// handler / transaction), so applying here is unconditional.
-	var base, oldItem map[string]any
-	if ok {
-		base = copyItem(item)
-		oldItem = copyItem(item)
-	} else {
-		base = copyItem(input.Key)
-	}
-
-	updated, err := driver.ApplyUpdate(base, input)
-	if err != nil {
-		m.mu.Unlock()
-		return nil, err
-	}
-
-	if err := validateItemSize(updated); err != nil {
-		m.mu.Unlock()
-		return nil, err
-	}
-
-	td.items.Set(k, updated)
-	m.recordStreamEvent(td, oldItem, updated, true)
-	m.mu.Unlock()
-	m.flushStreamDeliveries(ctx)
-
-	dims := map[string]string{"TableName": input.Table}
-	m.emitMetric("ConsumedWriteCapacityUnits", 1, dims)
-	m.emitMetric("SuccessfulRequestCount", 1, dims)
-
-	return maps.Clone(updated), nil
+	return updated, err
 }
 
+// DeleteItem removes the item at key unconditionally. It is the empty-condition
+// case of DeleteItemConditional.
 func (m *Mock) DeleteItem(ctx context.Context, table string, key map[string]any) error {
-	m.mu.Lock()
+	_, err := m.DeleteItemConditional(ctx, table, key, driver.Condition{})
 
-	td, exists := m.tables[table]
-	if !exists {
-		m.mu.Unlock()
-		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
-	}
-
-	if err := validateKeyMapNotEmpty(td.config.PartitionKey, td.config.SortKey, key); err != nil {
-		m.mu.Unlock()
-		return err
-	}
-
-	k := itemKey(td.config, key)
-	oldItem, hadOld := td.items.Get(k)
-	td.items.Delete(k)
-
-	if hadOld {
-		m.recordStreamRemove(td, oldItem)
-	}
-
-	m.mu.Unlock()
-	m.flushStreamDeliveries(ctx)
-
-	dims := map[string]string{"TableName": table}
-	m.emitMetric("ConsumedWriteCapacityUnits", 1, dims)
-	m.emitMetric("SuccessfulRequestCount", 1, dims)
-
-	return nil
+	return err
 }
 
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.

--- a/server/aws/dynamodb/advanced.go
+++ b/server/aws/dynamodb/advanced.go
@@ -3,6 +3,7 @@ package dynamodb
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -45,21 +46,19 @@ func (h *Handler) updateItem(w http.ResponseWriter, r *http.Request) {
 	vals := fromWireItem(req.ExpressionAttributeValues)
 
 	// ExpressionAttributeValues serve both the UpdateExpression and the
-	// ConditionExpression, matching real DynamoDB. Gate the mutation on the
-	// condition (evaluated against the current item) before applying actions.
-	if !h.gateCondition(r.Context(), w, req.TableName, key,
-		req.ConditionExpression, req.ExpressionAttributeNames, vals,
-		req.ReturnValuesOnConditionCheckFailure) {
-		return
+	// ConditionExpression, matching real DynamoDB. The condition is evaluated and
+	// the update applied atomically inside the provider (single lock hold), so an
+	// optimistic-lock update cannot race a concurrent writer.
+	cond := dbdriver.Condition{
+		Expression: req.ConditionExpression,
+		Names:      req.ExpressionAttributeNames,
+		Values:     vals,
 	}
-
-	// Capture the pre-update image so ALL_OLD/UPDATED_OLD/UPDATED_NEW can report
-	// the changed attributes relative to it.
-	old := h.previousItem(r.Context(), req.TableName, key)
 
 	// The raw UpdateExpression flows to the driver, which parses and evaluates
 	// the full grammar (SET arithmetic, if_not_exists, list_append, ADD, DELETE)
-	// against the stored item.
+	// against the stored item. old is the pre-update image for
+	// ALL_OLD/UPDATED_OLD/UPDATED_NEW.
 	input := dbdriver.UpdateItemInput{
 		Table:            req.TableName,
 		Key:              key,
@@ -68,9 +67,8 @@ func (h *Handler) updateItem(w http.ResponseWriter, r *http.Request) {
 		ExprValues:       vals,
 	}
 
-	updated, err := h.db.UpdateItem(r.Context(), input)
-	if err != nil {
-		writeErr(w, err)
+	updated, old, err := h.writer().UpdateItemConditional(r.Context(), input, cond)
+	if handleConditionalError(w, err, req.ReturnValuesOnConditionCheckFailure) {
 		return
 	}
 
@@ -514,23 +512,71 @@ func (h *Handler) transactWriteItems(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reasons, canceled, err := h.evaluateTransactConditions(ctx, ops)
+	// The whole transaction — every ConditionExpression check and every write —
+	// runs under a single hold of the provider's table lock, so it is atomic
+	// (all-or-nothing) and isolated from concurrent single-item writes. This
+	// replaces the former handler-level evaluate-then-apply, which dropped the
+	// lock between the check and the write (a TOCTOU that let two conflicting
+	// transactions both commit).
+	err := h.writer().TransactWrite(ctx, toDriverTransactOps(ops))
+
+	var canceled *dbdriver.TransactionCanceled
+	if errors.As(err, &canceled) {
+		writeTransactionCancelled(w, buildCancelReasons(len(ops), canceled.FailedConditions))
+		return
+	}
+
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	if canceled {
-		writeTransactionCancelled(w, reasons)
-		return
-	}
-
-	if aerr := h.applyTransactOps(ctx, ops); aerr != nil {
-		writeTransactErr(w, aerr)
-		return
-	}
-
 	wire.WriteJSON(w, map[string]any{})
+}
+
+// toDriverTransactOps maps the decoded wire operations onto the provider's
+// atomic transaction ops. For a Put, keySrc equals item (set by toTxOp) and the
+// provider keys off the item; for the other kinds keySrc is the operation's Key.
+func toDriverTransactOps(ops []txOp) []dbdriver.TransactOp {
+	out := make([]dbdriver.TransactOp, len(ops))
+
+	for i := range ops {
+		out[i] = dbdriver.TransactOp{
+			Kind:  ops[i].kind,
+			Table: ops[i].table,
+			Item:  ops[i].item,
+			Key:   ops[i].keySrc,
+			Condition: dbdriver.Condition{
+				Expression: ops[i].condition,
+				Names:      ops[i].names,
+				Values:     ops[i].values,
+			},
+			UpdateExpression: ops[i].updateExpr,
+			ExprNames:        ops[i].names,
+			ExprValues:       ops[i].values,
+		}
+	}
+
+	return out
+}
+
+// buildCancelReasons builds the per-operation CancellationReasons array: "None"
+// for every operation, overwritten with ConditionalCheckFailed for the indices
+// whose condition failed. The shape matches what real DynamoDB returns in a
+// TransactionCanceledException.
+func buildCancelReasons(n int, failed []int) []map[string]any {
+	reasons := make([]map[string]any, n)
+	for i := range reasons {
+		reasons[i] = map[string]any{"Code": "None"}
+	}
+
+	for _, idx := range failed {
+		if idx >= 0 && idx < n {
+			reasons[idx] = map[string]any{"Code": "ConditionalCheckFailed", "Message": "The conditional request failed"}
+		}
+	}
+
+	return reasons
 }
 
 // normalizeTransactItems decodes each wire item into a kind-tagged txOp,
@@ -612,114 +658,6 @@ func (h *Handler) checkTransactDuplicates(ctx context.Context, ops []txOp) error
 	return nil
 }
 
-// evaluateTransactConditions checks every operation's ConditionExpression
-// against current state. It returns a per-operation CancellationReasons array
-// (in request order) and whether any condition failed. A malformed expression
-// or a missing table surfaces as a non-nil error.
-func (h *Handler) evaluateTransactConditions(
-	ctx context.Context, ops []txOp,
-) (reasons []map[string]any, canceled bool, err error) {
-	reasons = make([]map[string]any, len(ops))
-
-	for i := range ops {
-		reasons[i] = map[string]any{"Code": "None"}
-
-		if ops[i].condition == "" {
-			continue
-		}
-
-		ok, cerr := h.checkCondition(ctx, ops[i].table, ops[i].keySrc,
-			ops[i].condition, ops[i].names, ops[i].values)
-		if cerr != nil {
-			return nil, false, cerr
-		}
-
-		if !ok {
-			reasons[i] = map[string]any{"Code": "ConditionalCheckFailed", "Message": "The conditional request failed"}
-			canceled = true
-		}
-	}
-
-	return reasons, canceled, nil
-}
-
-// txSnapshot is a pre-image of an item a transaction op will change, kept so a
-// mid-apply failure can be rolled back (DynamoDB transactions are all-or-nothing).
-type txSnapshot struct {
-	table   string
-	key     map[string]any
-	before  map[string]any
-	existed bool
-}
-
-// applyTransactOps applies every operation atomically. Conditions have already
-// passed; should any op still fail structurally, every already-applied op is
-// rolled back so the transaction is all-or-nothing. checkTransactDuplicates
-// guarantees each item is touched by at most one op, so the snapshots don't
-// alias.
-func (h *Handler) applyTransactOps(ctx context.Context, ops []txOp) error {
-	snaps := make([]txSnapshot, 0, len(ops))
-
-	for i := range ops {
-		if ops[i].kind == "ConditionCheck" {
-			continue
-		}
-
-		before, err := h.db.GetItem(ctx, ops[i].table, ops[i].keySrc)
-		// A missing item (or table) is expected — the op may create it; only a
-		// real read failure aborts. Treat NotFound as "no pre-image".
-		if err != nil && !cerrors.IsNotFound(err) {
-			h.rollbackTransact(ctx, snaps)
-			return err
-		}
-
-		snaps = append(snaps, txSnapshot{ops[i].table, ops[i].keySrc, before, err == nil && before != nil})
-	}
-
-	for i := range ops {
-		if err := h.applyTransactOp(ctx, &ops[i]); err != nil {
-			h.rollbackTransact(ctx, snaps)
-			return err
-		}
-	}
-
-	return nil
-}
-
-// rollbackTransact restores each snapshotted item to its pre-image (re-putting
-// what existed, deleting what the transaction created), in reverse order.
-func (h *Handler) rollbackTransact(ctx context.Context, snaps []txSnapshot) {
-	for i := len(snaps) - 1; i >= 0; i-- {
-		s := snaps[i]
-		if s.existed {
-			_ = h.db.PutItem(ctx, s.table, s.before)
-		} else {
-			_ = h.db.DeleteItem(ctx, s.table, s.key)
-		}
-	}
-}
-
-func (h *Handler) applyTransactOp(ctx context.Context, op *txOp) error {
-	switch op.kind {
-	case "Put":
-		return h.db.PutItem(ctx, op.table, op.item)
-	case "Delete":
-		return h.db.DeleteItem(ctx, op.table, op.keySrc)
-	case "Update":
-		_, err := h.db.UpdateItem(ctx, dbdriver.UpdateItemInput{
-			Table:            op.table,
-			Key:              op.keySrc,
-			UpdateExpression: op.updateExpr,
-			ExprNames:        op.names,
-			ExprValues:       op.values,
-		})
-
-		return err
-	default: // ConditionCheck asserts a condition but writes nothing.
-		return nil
-	}
-}
-
 // writeTransactionCancelled emits the TransactionCanceledException carrying the
 // per-operation CancellationReasons array, which SDK clients read to learn which
 // condition failed.
@@ -734,17 +672,4 @@ func writeTransactionCancelled(w http.ResponseWriter, reasons []map[string]any) 
 		"Message":             "Transaction cancelled, please refer cancellation reasons for specific reasons",
 		"CancellationReasons": reasons,
 	})
-}
-
-// writeTransactErr uses a TransactionCanceledException code so real SDK
-// clients recognize transaction failures distinctly from generic errors.
-func writeTransactErr(w http.ResponseWriter, err error) {
-	if cerrors.IsFailedPrecondition(err) || cerrors.IsAlreadyExists(err) {
-		wire.WriteJSONError(w, http.StatusBadRequest,
-			"TransactionCanceledException", err.Error())
-
-		return
-	}
-
-	writeErr(w, err)
 }

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -50,9 +50,72 @@ func projectionBlock(projType string, nonKey []string) map[string]any {
 	return block
 }
 
+// conditionalWriter is the optional provider capability backing ATOMIC
+// conditional writes and transactions. Discovered by type assertion (like
+// throughputUpdater / pitrController) so it stays off the cross-cloud Database
+// interface — only the AWS mock implements it. Each method evaluates the
+// ConditionExpression(s) and applies the mutation under a single hold of the
+// table lock, closing the check-then-act TOCTOU window a handler-level
+// pre-check would leave open. A failed condition surfaces as a
+// *dbdriver.ConditionalCheckFailed (single write) or *dbdriver.TransactionCanceled
+// (transaction).
+type conditionalWriter interface {
+	PutItemConditional(ctx context.Context, table string, item map[string]any, cond dbdriver.Condition) (map[string]any, error)
+	DeleteItemConditional(ctx context.Context, table string, key map[string]any, cond dbdriver.Condition) (map[string]any, error)
+	UpdateItemConditional(
+		ctx context.Context, input dbdriver.UpdateItemInput, cond dbdriver.Condition,
+	) (updated, old map[string]any, err error)
+	TransactWrite(ctx context.Context, ops []dbdriver.TransactOp) error
+}
+
 // Handler serves DynamoDB JSON-RPC requests against a database.Database driver.
 type Handler struct {
 	db dbdriver.Database
+}
+
+// writer returns the atomic conditional-write capability. The AWS mock always
+// implements it; a driver that does not is a programming error (the AWS wire
+// handler is only ever wired to the AWS mock).
+func (h *Handler) writer() conditionalWriter {
+	w, ok := h.db.(conditionalWriter)
+	if !ok {
+		panic("dynamodb: driver does not implement conditionalWriter")
+	}
+
+	return w
+}
+
+// writeConditionalCheckFailed emits the ConditionalCheckFailedException. When the
+// request asked for ReturnValuesOnConditionCheckFailure=ALL_OLD and a conflicting
+// item exists, it is echoed in the exception's Item member.
+func writeConditionalCheckFailed(w http.ResponseWriter, conflict map[string]any, returnValuesOnCondFail string) {
+	var extra map[string]any
+	if strings.EqualFold(returnValuesOnCondFail, "ALL_OLD") && conflict != nil {
+		extra = map[string]any{"Item": toWireItem(conflict)}
+	}
+
+	wire.WriteJSONErrorFields(w, http.StatusBadRequest,
+		"ConditionalCheckFailedException", "The conditional request failed", extra)
+}
+
+// handleConditionalError writes the response for an error returned by a
+// conditional write, returning true when it handled one. A
+// *dbdriver.ConditionalCheckFailed becomes a ConditionalCheckFailedException;
+// anything else is mapped by writeErr.
+func handleConditionalError(w http.ResponseWriter, err error, returnValuesOnCondFail string) bool {
+	if err == nil {
+		return false
+	}
+
+	var ccf *dbdriver.ConditionalCheckFailed
+	if errors.As(err, &ccf) {
+		writeConditionalCheckFailed(w, ccf.Item, returnValuesOnCondFail)
+		return true
+	}
+
+	writeErr(w, err)
+
+	return true
 }
 
 // New returns a DynamoDB handler backed by db.
@@ -620,157 +683,60 @@ func (h *Handler) listTables(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, resp)
 }
 
-func (h *Handler) putItem(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		TableName                 string            `json:"TableName"`
-		Item                      map[string]any    `json:"Item"`
-		ConditionExpression       string            `json:"ConditionExpression"`
-		ExpressionAttributeNames  map[string]string `json:"ExpressionAttributeNames"`
-		ExpressionAttributeValues map[string]any    `json:"ExpressionAttributeValues"`
-		ReturnValues              string            `json:"ReturnValues"`
-		ReturnConsumedCapacity    string            `json:"ReturnConsumedCapacity"`
+// writeItemRequest is the shared wire shape of PutItem and DeleteItem: both carry
+// a ConditionExpression plus the ReturnValues / ReturnValuesOnConditionCheckFailure
+// controls. PutItem populates Item (the full item); DeleteItem populates Key.
+type writeItemRequest struct {
+	TableName                 string            `json:"TableName"`
+	Item                      map[string]any    `json:"Item"`
+	Key                       map[string]any    `json:"Key"`
+	ConditionExpression       string            `json:"ConditionExpression"`
+	ExpressionAttributeNames  map[string]string `json:"ExpressionAttributeNames"`
+	ExpressionAttributeValues map[string]any    `json:"ExpressionAttributeValues"`
+	ReturnValues              string            `json:"ReturnValues"`
+	ReturnConsumedCapacity    string            `json:"ReturnConsumedCapacity"`
 
-		ReturnValuesOnConditionCheckFailure string `json:"ReturnValuesOnConditionCheckFailure"`
+	ReturnValuesOnConditionCheckFailure string `json:"ReturnValuesOnConditionCheckFailure"`
+}
+
+// condition builds the driver Condition carried down for atomic evaluation.
+func (req *writeItemRequest) condition() dbdriver.Condition {
+	return dbdriver.Condition{
+		Expression: req.ConditionExpression,
+		Names:      req.ExpressionAttributeNames,
+		Values:     fromWireItem(req.ExpressionAttributeValues),
 	}
+}
 
-	if !wire.DecodeJSON(w, r, &req) {
-		return
-	}
-
-	item := fromWireItem(req.Item)
-	vals := fromWireItem(req.ExpressionAttributeValues)
-
-	if !h.gateCondition(r.Context(), w, req.TableName, item,
-		req.ConditionExpression, req.ExpressionAttributeNames, vals,
-		req.ReturnValuesOnConditionCheckFailure) {
+// writeConditionalResult writes the response shared by PutItem and DeleteItem: it
+// maps a failed condition to ConditionalCheckFailedException, otherwise echoes the
+// prior item under ReturnValues=ALL_OLD plus the consumed-capacity block. old is
+// the item as it stood before the (successful) mutation.
+func writeConditionalResult(w http.ResponseWriter, req *writeItemRequest, old map[string]any, err error) {
+	if handleConditionalError(w, err, req.ReturnValuesOnConditionCheckFailure) {
 		return
 	}
 
 	resp := map[string]any{}
-
-	// ReturnValues=ALL_OLD returns the item as it was before the overwrite, so
-	// read it before the mutation.
-	if strings.EqualFold(req.ReturnValues, "ALL_OLD") {
-		if old := h.previousItem(r.Context(), req.TableName, item); old != nil {
-			resp["Attributes"] = toWireItem(old)
-		}
-	}
-
-	if err := h.db.PutItem(r.Context(), req.TableName, item); err != nil {
-		writeErr(w, err)
-		return
+	if old != nil && strings.EqualFold(req.ReturnValues, "ALL_OLD") {
+		resp["Attributes"] = toWireItem(old)
 	}
 
 	addConsumedCapacity(resp, req.ReturnConsumedCapacity, req.TableName)
 	wire.WriteJSON(w, resp)
 }
 
-// previousItem fetches the stored item identified by keySource's key attributes,
-// returning nil when the table or item is missing. Used to satisfy
-// ReturnValues=ALL_OLD on Put/Delete without surfacing a lookup error.
-func (h *Handler) previousItem(ctx context.Context, table string, keySource map[string]any) map[string]any {
-	cfg, err := h.db.DescribeTable(ctx, table)
-	if err != nil {
-		return nil
+func (h *Handler) putItem(w http.ResponseWriter, r *http.Request) {
+	var req writeItemRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
 	}
 
-	key := map[string]any{cfg.PartitionKey: keySource[cfg.PartitionKey]}
-	if cfg.SortKey != "" {
-		key[cfg.SortKey] = keySource[cfg.SortKey]
-	}
-
-	old, err := h.db.GetItem(ctx, table, key)
-	if err != nil {
-		return nil
-	}
-
-	return old
-}
-
-// gateCondition evaluates a ConditionExpression and, on failure, writes the
-// matching DynamoDB error response. It returns true when the caller should
-// proceed with the mutation. Shared by PutItem, UpdateItem and DeleteItem.
-func (h *Handler) gateCondition(
-	ctx context.Context,
-	w http.ResponseWriter,
-	table string,
-	keySource map[string]any,
-	condExpr string,
-	names map[string]string,
-	values map[string]any,
-	returnValuesOnCondFail string,
-) bool {
-	ok, err := h.checkCondition(ctx, table, keySource, condExpr, names, values)
-	if err != nil {
-		writeErr(w, err)
-		return false
-	}
-
-	if !ok {
-		var extra map[string]any
-		// ReturnValuesOnConditionCheckFailure=ALL_OLD asks DynamoDB to return the
-		// conflicting item in the exception's Item member.
-		if strings.EqualFold(returnValuesOnCondFail, "ALL_OLD") {
-			if old := h.previousItem(ctx, table, keySource); old != nil {
-				extra = map[string]any{"Item": toWireItem(old)}
-			}
-		}
-
-		wire.WriteJSONErrorFields(w, http.StatusBadRequest,
-			"ConditionalCheckFailedException", "The conditional request failed", extra)
-
-		return false
-	}
-
-	return true
-}
-
-// checkCondition evaluates a DynamoDB ConditionExpression against the current
-// stored item, using the full expression grammar (functions, boolean
-// operators, IN/BETWEEN, size(), type-aware comparisons). keySource carries
-// the item's key attributes (the full item for PutItem, the Key map for
-// Update/Delete). A missing item is evaluated against an empty item, so
-// attribute_not_exists is true and attribute_exists is false — matching real
-// DynamoDB create-if-absent semantics. A malformed expression is a
-// cerrors.InvalidArgument; a well-formed but unmet condition returns false.
-func (h *Handler) checkCondition(
-	ctx context.Context,
-	table string,
-	keySource map[string]any,
-	condExpr string,
-	names map[string]string,
-	values map[string]any,
-) (bool, error) {
-	condExpr = strings.TrimSpace(condExpr)
-	if condExpr == "" {
-		return true, nil
-	}
-
-	cfg, err := h.db.DescribeTable(ctx, table)
-	if err != nil {
-		return false, err
-	}
-
-	key := map[string]any{cfg.PartitionKey: keySource[cfg.PartitionKey]}
-	if cfg.SortKey != "" {
-		key[cfg.SortKey] = keySource[cfg.SortKey]
-	}
-
-	existing, err := h.db.GetItem(ctx, table, key)
-	if err != nil && !cerrors.IsNotFound(err) {
-		return false, err
-	}
-
-	node, err := expr.ParseCondition(condExpr, names, values)
-	if err != nil {
-		return false, err
-	}
-
-	if existing == nil {
-		existing = map[string]any{}
-	}
-
-	return expr.Eval(node, existing)
+	// The condition is evaluated and the write applied atomically inside the
+	// provider (single lock hold), so two concurrent conditional puts on one key
+	// cannot both succeed.
+	old, err := h.writer().PutItemConditional(r.Context(), req.TableName, fromWireItem(req.Item), req.condition())
+	writeConditionalResult(w, &req, old, err)
 }
 
 func (h *Handler) getItem(w http.ResponseWriter, r *http.Request) {
@@ -844,47 +810,14 @@ func addConsumedCapacity(resp map[string]any, returnConsumed, table string) {
 }
 
 func (h *Handler) deleteItem(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		TableName                 string            `json:"TableName"`
-		Key                       map[string]any    `json:"Key"`
-		ConditionExpression       string            `json:"ConditionExpression"`
-		ExpressionAttributeNames  map[string]string `json:"ExpressionAttributeNames"`
-		ExpressionAttributeValues map[string]any    `json:"ExpressionAttributeValues"`
-		ReturnValues              string            `json:"ReturnValues"`
-		ReturnConsumedCapacity    string            `json:"ReturnConsumedCapacity"`
-
-		ReturnValuesOnConditionCheckFailure string `json:"ReturnValuesOnConditionCheckFailure"`
-	}
-
+	var req writeItemRequest
 	if !wire.DecodeJSON(w, r, &req) {
 		return
 	}
 
-	key := fromWireItem(req.Key)
-	vals := fromWireItem(req.ExpressionAttributeValues)
-
-	if !h.gateCondition(r.Context(), w, req.TableName, key,
-		req.ConditionExpression, req.ExpressionAttributeNames, vals,
-		req.ReturnValuesOnConditionCheckFailure) {
-		return
-	}
-
-	resp := map[string]any{}
-
-	// ReturnValues=ALL_OLD returns the deleted item, so read it before removal.
-	if strings.EqualFold(req.ReturnValues, "ALL_OLD") {
-		if old := h.previousItem(r.Context(), req.TableName, key); old != nil {
-			resp["Attributes"] = toWireItem(old)
-		}
-	}
-
-	if err := h.db.DeleteItem(r.Context(), req.TableName, key); err != nil {
-		writeErr(w, err)
-		return
-	}
-
-	addConsumedCapacity(resp, req.ReturnConsumedCapacity, req.TableName)
-	wire.WriteJSON(w, resp)
+	// Condition eval + delete are atomic inside the provider (single lock hold).
+	old, err := h.writer().DeleteItemConditional(r.Context(), req.TableName, fromWireItem(req.Key), req.condition())
+	writeConditionalResult(w, &req, old, err)
 }
 
 func (h *Handler) query(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/dynamodb_conditional_test.go
+++ b/server/aws/dynamodb_conditional_test.go
@@ -1,0 +1,233 @@
+package aws_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createDDBHashTable creates a single-partition-key on-demand table for the
+// conditional-write reproductions.
+func createDDBHashTable(t *testing.T, client *dynamodb.Client, name string) {
+	t.Helper()
+
+	_, err := client.CreateTable(context.Background(), &dynamodb.CreateTableInput{
+		TableName: aws.String(name),
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: ddbtypes.KeyTypeHash},
+		},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+	})
+	require.NoError(t, err)
+}
+
+func ddbStr(v string) ddbtypes.AttributeValue { return &ddbtypes.AttributeValueMemberS{Value: v} }
+
+// TestDDBConditionalPutIfAbsentRace drives the real aws-sdk-go-v2 client: many
+// concurrent PutItem(attribute_not_exists) calls race to create the same key.
+// Real DynamoDB guarantees exactly one succeeds and the rest get
+// ConditionalCheckFailedException — asserted across many rounds so the (logical)
+// TOCTOU that let two writers both succeed cannot pass.
+func TestDDBConditionalPutIfAbsentRace(t *testing.T) {
+	const (
+		rounds     = 40
+		goroutines = 6
+	)
+
+	client := newDDBClient(t)
+	createDDBHashTable(t, client, "cwrite")
+
+	ctx := context.Background()
+
+	for r := 0; r < rounds; r++ {
+		pk := fmt.Sprintf("k-%d", r)
+
+		var (
+			winners   atomic.Int64
+			condFails atomic.Int64
+			wg        sync.WaitGroup
+		)
+
+		wg.Add(goroutines)
+
+		for g := 0; g < goroutines; g++ {
+			go func() {
+				defer wg.Done()
+
+				_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+					TableName:           aws.String("cwrite"),
+					Item:                map[string]ddbtypes.AttributeValue{"pk": ddbStr(pk)},
+					ConditionExpression: aws.String("attribute_not_exists(pk)"),
+				})
+				if err == nil {
+					winners.Add(1)
+					return
+				}
+
+				var ccf *ddbtypes.ConditionalCheckFailedException
+				if errors.As(err, &ccf) {
+					condFails.Add(1)
+					return
+				}
+
+				t.Errorf("round %d: unexpected error: %v", r, err)
+			}()
+		}
+
+		wg.Wait()
+
+		require.Equalf(t, int64(1), winners.Load(),
+			"round %d: exactly one put-if-absent must succeed", r)
+		require.Equalf(t, int64(goroutines-1), condFails.Load(),
+			"round %d: every other writer must get ConditionalCheckFailedException", r)
+	}
+}
+
+// TestDDBConditionalOptimisticLock exercises the UpdateItem conditional path over
+// the wire: a version-guarded update succeeds once, and a replay guarded on the
+// now-stale version is rejected with ConditionalCheckFailedException.
+func TestDDBConditionalOptimisticLock(t *testing.T) {
+	client := newDDBClient(t)
+	createDDBHashTable(t, client, "optlock")
+
+	ctx := context.Background()
+
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String("optlock"),
+		Item: map[string]ddbtypes.AttributeValue{
+			"pk":  ddbStr("x"),
+			"ver": &ddbtypes.AttributeValueMemberN{Value: "0"},
+		},
+	})
+	require.NoError(t, err)
+
+	bump := func() error {
+		_, uerr := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+			TableName:           aws.String("optlock"),
+			Key:                 map[string]ddbtypes.AttributeValue{"pk": ddbStr("x")},
+			UpdateExpression:    aws.String("SET ver = :new"),
+			ConditionExpression: aws.String("ver = :cur"),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+				":cur": &ddbtypes.AttributeValueMemberN{Value: "0"},
+				":new": &ddbtypes.AttributeValueMemberN{Value: "1"},
+			},
+		})
+
+		return uerr
+	}
+
+	require.NoError(t, bump(), "first version-guarded update should win")
+
+	var ccf *ddbtypes.ConditionalCheckFailedException
+	require.ErrorAs(t, bump(), &ccf, "replay on stale version must fail the condition")
+}
+
+// TestDDBTransactWriteAllOrNothing drives TransactWriteItems over the wire: a
+// transaction whose middle Put fails its condition is entirely canceled — the
+// CancellationReasons name the failing op and NEITHER unconditional put is
+// applied.
+func TestDDBTransactWriteAllOrNothing(t *testing.T) {
+	client := newDDBClient(t)
+	createDDBHashTable(t, client, "txall")
+
+	ctx := context.Background()
+
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String("txall"),
+		Item:      map[string]ddbtypes.AttributeValue{"pk": ddbStr("exists")},
+	})
+	require.NoError(t, err)
+
+	_, err = client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+		TransactItems: []ddbtypes.TransactWriteItem{
+			{Put: &ddbtypes.Put{TableName: aws.String("txall"),
+				Item: map[string]ddbtypes.AttributeValue{"pk": ddbStr("new1")}}},
+			{Put: &ddbtypes.Put{TableName: aws.String("txall"),
+				Item:                map[string]ddbtypes.AttributeValue{"pk": ddbStr("exists")},
+				ConditionExpression: aws.String("attribute_not_exists(pk)")}},
+			{Put: &ddbtypes.Put{TableName: aws.String("txall"),
+				Item: map[string]ddbtypes.AttributeValue{"pk": ddbStr("new2")}}},
+		},
+	})
+
+	var canceled *ddbtypes.TransactionCanceledException
+	require.ErrorAs(t, err, &canceled)
+	require.Len(t, canceled.CancellationReasons, 3)
+	assert.Equal(t, "None", aws.ToString(canceled.CancellationReasons[0].Code))
+	assert.Equal(t, "ConditionalCheckFailed", aws.ToString(canceled.CancellationReasons[1].Code))
+	assert.Equal(t, "None", aws.ToString(canceled.CancellationReasons[2].Code))
+
+	for _, pk := range []string{"new1", "new2"} {
+		out, gerr := client.GetItem(ctx, &dynamodb.GetItemInput{
+			TableName: aws.String("txall"),
+			Key:       map[string]ddbtypes.AttributeValue{"pk": ddbStr(pk)},
+		})
+		require.NoError(t, gerr)
+		assert.Nilf(t, out.Item, "put %q applied despite cancellation — not all-or-nothing", pk)
+	}
+}
+
+// TestDDBTransactWriteConcurrentConflict runs concurrent put-if-absent
+// transactions on one key over the wire; exactly one commits per round.
+func TestDDBTransactWriteConcurrentConflict(t *testing.T) {
+	const (
+		rounds     = 30
+		goroutines = 6
+	)
+
+	client := newDDBClient(t)
+	createDDBHashTable(t, client, "txrace")
+
+	ctx := context.Background()
+
+	for r := 0; r < rounds; r++ {
+		pk := fmt.Sprintf("k-%d", r)
+
+		var (
+			winners atomic.Int64
+			wg      sync.WaitGroup
+		)
+
+		wg.Add(goroutines)
+
+		for g := 0; g < goroutines; g++ {
+			go func() {
+				defer wg.Done()
+
+				_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+					TransactItems: []ddbtypes.TransactWriteItem{
+						{Put: &ddbtypes.Put{TableName: aws.String("txrace"),
+							Item:                map[string]ddbtypes.AttributeValue{"pk": ddbStr(pk)},
+							ConditionExpression: aws.String("attribute_not_exists(pk)")}},
+					},
+				})
+				if err == nil {
+					winners.Add(1)
+					return
+				}
+
+				var canceled *ddbtypes.TransactionCanceledException
+				if !errors.As(err, &canceled) {
+					t.Errorf("round %d: unexpected error: %v", r, err)
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		require.Equalf(t, int64(1), winners.Load(),
+			"round %d: exactly one conflicting transaction must commit", r)
+	}
+}

--- a/services/database/driver/conditional.go
+++ b/services/database/driver/conditional.go
@@ -1,0 +1,78 @@
+package driver
+
+// This file defines the shared types for ATOMIC conditional writes and
+// transactions. A DynamoDB ConditionExpression must be evaluated and the write
+// applied under a single hold of the provider's table lock; evaluating it in the
+// wire layer with a separate GetItem (check) followed by a separate mutation
+// (act) leaves a TOCTOU window in which two concurrent conditional writes on one
+// key can both succeed. These types carry the raw condition down to the provider
+// so the check and the write are one atomic step.
+//
+// They are consumed by the AWS DynamoDB wire handler and the AWS provider via an
+// optional, type-asserted capability (like UpdateThroughput / SetPITR) and are
+// deliberately kept off the cross-cloud Database interface.
+
+// Condition is a DynamoDB ConditionExpression carried to the provider so it can
+// parse (via expr.ParseCondition) and evaluate the condition against the current
+// stored item while holding the table lock, making the check and the subsequent
+// write atomic. An empty Expression is an unconditional write (always passes).
+// Values are already decoded to native Go (expr.Number, []byte, nested maps),
+// matching the stored item shape the evaluator compares against.
+type Condition struct {
+	Expression string
+	Names      map[string]string
+	Values     map[string]any
+}
+
+// TransactOp kinds, mirroring the four DynamoDB TransactWriteItems actions.
+const (
+	TransactPut            = "Put"
+	TransactDelete         = "Delete"
+	TransactUpdate         = "Update"
+	TransactConditionCheck = "ConditionCheck"
+)
+
+// TransactOp is one operation in an atomic TransactWriteItems. Kind selects the
+// mutation. Condition (optional) is evaluated against the current item before
+// ANY op is applied — all conditions are checked, then all writes applied, under
+// a single lock hold, so the transaction is all-or-nothing. For a Put, Item
+// carries the full item; for the others Key identifies the target and
+// UpdateExpression/ExprNames/ExprValues drive an Update. A ConditionCheck asserts
+// its Condition but writes nothing.
+type TransactOp struct {
+	Kind             string
+	Table            string
+	Item             map[string]any
+	Key              map[string]any
+	Condition        Condition
+	UpdateExpression string
+	ExprNames        map[string]string
+	ExprValues       map[string]any
+}
+
+// ConditionalCheckFailed is returned by a conditional write whose
+// ConditionExpression evaluated to false. Item carries the conflicting stored
+// item (nil when the item was absent) so the wire layer can satisfy
+// ReturnValuesOnConditionCheckFailure=ALL_OLD without a second, racy lookup.
+type ConditionalCheckFailed struct {
+	Item map[string]any
+}
+
+// Error reports the exact DynamoDB message a ConditionalCheckFailedException
+// carries.
+func (*ConditionalCheckFailed) Error() string { return "The conditional request failed" }
+
+// TransactionCanceled is returned by an atomic transaction when one or more
+// ConditionExpressions evaluated to false. FailedConditions holds the indices
+// (in request order) of the operations whose condition failed; the wire layer
+// maps them onto the per-operation CancellationReasons array (ConditionalCheckFailed
+// for those indices, None for the rest). No write is applied when this is returned.
+type TransactionCanceled struct {
+	FailedConditions []int
+}
+
+// Error describes the transaction cancellation. The verbatim DynamoDB wire
+// message is written by the wire layer, not here.
+func (*TransactionCanceled) Error() string {
+	return "transaction canceled: one or more condition checks failed"
+}


### PR DESCRIPTION
## What

Make AWS DynamoDB conditional writes and transactions **atomic**, closing a data-integrity TOCTOU race found by the deep-e2e audit.

The wire handler used to evaluate a `ConditionExpression` with a standalone `GetItem` (check) and then issue the mutation as a **separate** provider call (act), dropping the table lock in between. The provider exposed no conditional-write primitive, so nothing held a lock across check+write. As a result:

- **#1 conditional-write TOCTOU** — two concurrent `PutItem`/`UpdateItem`/`DeleteItem` with a `ConditionExpression` on the same key (e.g. `attribute_not_exists(pk)` put-if-absent, or optimistic-lock `SET v=:new IF v=:cur`) could **both** succeed. Reproduced deterministically (2 winners in a race).
- **#2 TransactWriteItems TOCTOU** — the transaction evaluated all conditions, then applied all writes, in **separate** lock acquisitions, and bypassed the provider's already-atomic path entirely (the wire layer reimplemented a non-atomic version with hand-rolled rollback). Two conflicting transactions could both commit.

## Why / Fix

Condition evaluation is pushed **down into the provider**, where the check and the write happen under a **single hold of the table lock** (`m.mu`) — the atomic check-and-set pattern, mirroring how S3 conditional writes (#657) and EC2 AttachVolume (#658) were fixed.

- Add `PutItemConditional` / `UpdateItemConditional` / `DeleteItemConditional` to the AWS DynamoDB provider. `PutItem`/`UpdateItem`/`DeleteItem` now delegate to them with an empty condition, so the conditional and unconditional paths share one atomic implementation.
- Add an atomic `TransactWrite` that evaluates **every** `ConditionExpression` and applies **every** write under one lock hold (all-or-nothing), driven from the wire handler. The old handler-level `evaluateTransactConditions` / `applyTransactOps` / rollback machinery is removed (dead code gone).
- These are exposed as a **type-asserted capability** (`conditionalWriter`), like `UpdateThroughput` / `SetPITR`, so the cross-cloud `Database` interface is untouched (no Azure/GCP churn).
- Condition parsing/evaluation reuses `expr.ParseCondition` / `expr.Eval` — no duplicated parser.
- Exact AWS semantics preserved (verified against the official API docs): `ConditionalCheckFailedException` ("The conditional request failed" + optional `Item` for `ReturnValuesOnConditionCheckFailure=ALL_OLD`), and `TransactionCanceledException` with per-op `CancellationReasons` (`None` / `ConditionalCheckFailed`), all-or-nothing.

## Tests

- Provider `-race` + high-iteration concurrency tests asserting the **logical** invariant (winners == 1) that `-race` alone can't catch: concurrent put-if-absent, concurrent optimistic-lock update, transaction all-or-nothing, concurrent conflicting transactions.
- Real `aws-sdk-go-v2` reproductions over the wire: concurrent put-if-absent (exactly one 200, rest `ConditionalCheckFailedException`), optimistic-lock update, `TransactWriteItems` all-or-nothing with `CancellationReasons`, concurrent conflicting transactions.
- Existing DynamoDB tests stay green.
