### PR TITLE
fix(aws-vpc): enforce one-IGW-per-VPC + NACL default-deny-undeletable + no-duplicate-entry + entry error codes

### DIFF
--- a/providers/aws/vpc/acl.go
+++ b/providers/aws/vpc/acl.go
@@ -151,6 +151,16 @@ func (m *Mock) AddNetworkACLRule(_ context.Context, aclID string, rule *driver.N
 		return errors.Newf(errors.NotFound, "network ACL %q not found", aclID)
 	}
 
+	// A rule number is unique per direction. Real EC2 rejects a second entry at
+	// the same (ruleNumber, egress) with NetworkAclEntryAlreadyExists; replacing
+	// an entry is a distinct action (ReplaceNetworkAclEntry).
+	for _, r := range acl.Rules {
+		if r.RuleNumber == rule.RuleNumber && r.Egress == rule.Egress {
+			return errors.Newf(errors.AlreadyExists,
+				"entry with rule number %d already exists in network ACL %q", rule.RuleNumber, aclID)
+		}
+	}
+
 	acl.Rules = append(acl.Rules, *rule)
 	sort.Slice(acl.Rules, func(i, j int) bool {
 		return acl.Rules[i].RuleNumber < acl.Rules[j].RuleNumber
@@ -164,6 +174,13 @@ func (m *Mock) RemoveNetworkACLRule(_ context.Context, aclID string, ruleNumber 
 	acl, ok := m.networkACLs.Get(aclID)
 	if !ok {
 		return errors.Newf(errors.NotFound, "network ACL %q not found", aclID)
+	}
+
+	// The reserved catch-all '*' entry (rule 32767) is immutable: real EC2
+	// refuses to delete or replace it, preserving deny-by-default.
+	if ruleNumber == defaultDenyRuleNumber {
+		return errors.Newf(errors.InvalidArgument,
+			"the network ACL entry %d is the reserved default rule and cannot be deleted or modified", ruleNumber)
 	}
 
 	for i, r := range acl.Rules {

--- a/providers/aws/vpc/internet_gateway.go
+++ b/providers/aws/vpc/internet_gateway.go
@@ -92,10 +92,13 @@ func (m *Mock) AttachInternetGateway(
 		)
 	}
 
+	// An internet gateway attaches to exactly one VPC; re-attaching an
+	// already-attached gateway is Resource.AlreadyAssociated, not a dependency
+	// violation.
 	if igw.State == IGWStateAttached {
 		return errors.Newf(
-			errors.FailedPrecondition,
-			"internet gateway %q is already attached", igwID,
+			errors.AlreadyExists,
+			"internet gateway %q is already attached to vpc %q", igwID, igw.VpcID,
 		)
 	}
 
@@ -105,10 +108,32 @@ func (m *Mock) AttachInternetGateway(
 		)
 	}
 
+	// One internet gateway per VPC: reject if the target VPC already has one
+	// attached. Real EC2 answers Resource.AlreadyAssociated ("Network vpc-…
+	// already has an internet gateway attached").
+	if existing := m.vpcAttachedIGW(vpcID); existing != "" {
+		return errors.Newf(
+			errors.AlreadyExists,
+			"vpc %q already has internet gateway %q attached", vpcID, existing,
+		)
+	}
+
 	igw.VpcID = vpcID
 	igw.State = IGWStateAttached
 
 	return nil
+}
+
+// vpcAttachedIGW returns the id of the internet gateway already attached to the
+// VPC, or "" if none is. Enforces the one-IGW-per-VPC invariant.
+func (m *Mock) vpcAttachedIGW(vpcID string) string {
+	for _, igw := range m.igws.All() {
+		if igw.State == IGWStateAttached && igw.VpcID == vpcID {
+			return igw.ID
+		}
+	}
+
+	return ""
 }
 
 // DetachInternetGateway detaches an internet gateway from a VPC.

--- a/server/aws/ec2/internet_gateway.go
+++ b/server/aws/ec2/internet_gateway.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
@@ -84,7 +85,7 @@ func (h *Handler) createInternetGateway(w http.ResponseWriter, r *http.Request) 
 func (h *Handler) attachInternetGateway(w http.ResponseWriter, r *http.Request) {
 	if err := h.vpc.AttachInternetGateway(r.Context(),
 		r.Form.Get("InternetGatewayId"), r.Form.Get("VpcId")); err != nil {
-		writeIGWErr(w, err)
+		writeAttachIGWErr(w, err)
 		return
 	}
 
@@ -218,6 +219,19 @@ func toInternetGatewayXML(igw *netdriver.InternetGateway) internetGatewayXML {
 
 func writeIGWErr(w http.ResponseWriter, err error) {
 	writeErrWithNotFound(w, err, "InvalidInternetGatewayID.NotFound", "DependencyViolation")
+}
+
+// writeAttachIGWErr maps AttachInternetGateway errors. A gateway that is already
+// attached, or a VPC that already has an internet gateway, is
+// Resource.AlreadyAssociated (an internet gateway attaches to exactly one VPC),
+// not the generic ResourceAlreadyExists.
+func writeAttachIGWErr(w http.ResponseWriter, err error) {
+	if cerrors.IsAlreadyExists(err) {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "Resource.AlreadyAssociated", cerrors.Message(err))
+		return
+	}
+
+	writeIGWErr(w, err)
 }
 
 // writeDetachIGWErr maps DetachInternetGateway errors. Detaching an internet

--- a/server/aws/ec2/internet_gateway_test.go
+++ b/server/aws/ec2/internet_gateway_test.go
@@ -157,3 +157,73 @@ func TestDescribeInternetGatewaysPaginatesAllOnce(t *testing.T) {
 		}
 	}
 }
+
+// TestOneInternetGatewayPerVPC pins the one-IGW-per-VPC invariant. Attaching a
+// second, different internet gateway to a VPC that already has one must fail
+// with Resource.AlreadyAssociated (real EC2: "Network vpc-… already has an
+// internet gateway attached"); the first gateway stays attached. Attaching an
+// already-attached gateway onto a second VPC is the same error code, not a
+// DependencyViolation.
+func TestOneInternetGatewayPerVPC(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpcA, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc A: %v", err)
+	}
+
+	vpcAID := aws.ToString(vpcA.Vpc.VpcId)
+
+	vpcB, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.1.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc B: %v", err)
+	}
+
+	vpcBID := aws.ToString(vpcB.Vpc.VpcId)
+
+	igwA := mkIGW(ctx, t, c)
+	igwB := mkIGW(ctx, t, c)
+
+	if _, err := c.AttachInternetGateway(ctx, &ec2.AttachInternetGatewayInput{
+		InternetGatewayId: aws.String(igwA), VpcId: aws.String(vpcAID),
+	}); err != nil {
+		t.Fatalf("AttachInternetGateway A: %v", err)
+	}
+
+	// A second, different gateway onto the same VPC -> Resource.AlreadyAssociated.
+	_, err = c.AttachInternetGateway(ctx, &ec2.AttachInternetGatewayInput{
+		InternetGatewayId: aws.String(igwB), VpcId: aws.String(vpcAID),
+	})
+	if err == nil {
+		t.Fatal("attaching a second IGW to the same VPC succeeded, want Resource.AlreadyAssociated")
+	}
+
+	if code := apiCode(t, err); code != "Resource.AlreadyAssociated" {
+		t.Errorf("second-IGW error code = %q, want Resource.AlreadyAssociated", code)
+	}
+
+	// The first gateway is still the VPC's only attachment.
+	desc, err := c.DescribeInternetGateways(ctx, &ec2.DescribeInternetGatewaysInput{
+		Filters: []ec2types.Filter{{Name: aws.String("attachment.vpc-id"), Values: []string{vpcAID}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeInternetGateways: %v", err)
+	}
+
+	if len(desc.InternetGateways) != 1 || aws.ToString(desc.InternetGateways[0].InternetGatewayId) != igwA {
+		t.Fatalf("VPC attachments = %+v, want only %s", desc.InternetGateways, igwA)
+	}
+
+	// Attaching the already-attached igwA onto a second VPC -> same code.
+	_, err = c.AttachInternetGateway(ctx, &ec2.AttachInternetGatewayInput{
+		InternetGatewayId: aws.String(igwA), VpcId: aws.String(vpcBID),
+	})
+	if err == nil {
+		t.Fatal("attaching an already-attached IGW to a second VPC succeeded, want Resource.AlreadyAssociated")
+	}
+
+	if code := apiCode(t, err); code != "Resource.AlreadyAssociated" {
+		t.Errorf("already-attached-IGW error code = %q, want Resource.AlreadyAssociated", code)
+	}
+}

--- a/server/aws/ec2/network_acl.go
+++ b/server/aws/ec2/network_acl.go
@@ -159,7 +159,7 @@ func (h *Handler) createNetworkACLEntry(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := h.vpc.AddNetworkACLRule(r.Context(), r.Form.Get("NetworkAclId"), rule); err != nil {
-		writeNetworkACLErr(w, err)
+		writeNetworkACLEntryErr(w, err)
 		return
 	}
 
@@ -183,7 +183,7 @@ func (h *Handler) replaceNetworkACLEntry(w http.ResponseWriter, r *http.Request)
 	aclID := r.Form.Get("NetworkAclId")
 
 	if err := h.vpc.RemoveNetworkACLRule(r.Context(), aclID, ruleNum, egress); err != nil {
-		writeNetworkACLErr(w, err)
+		writeNetworkACLEntryErr(w, err)
 		return
 	}
 
@@ -198,7 +198,7 @@ func (h *Handler) replaceNetworkACLEntry(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := h.vpc.AddNetworkACLRule(r.Context(), aclID, rule); err != nil {
-		writeNetworkACLErr(w, err)
+		writeNetworkACLEntryErr(w, err)
 		return
 	}
 
@@ -216,7 +216,7 @@ func (h *Handler) deleteNetworkACLEntry(w http.ResponseWriter, r *http.Request) 
 	err := h.vpc.RemoveNetworkACLRule(r.Context(),
 		r.Form.Get("NetworkAclId"), ruleNum, egress)
 	if err != nil {
-		writeNetworkACLErr(w, err)
+		writeNetworkACLEntryErr(w, err)
 		return
 	}
 
@@ -314,4 +314,21 @@ func toNetworkACLXML(a *netdriver.NetworkACL) networkACLXML {
 
 func writeNetworkACLErr(w http.ResponseWriter, err error) {
 	writeErrWithNotFound(w, err, "InvalidNetworkAclID.NotFound", "DependencyViolation")
+}
+
+// writeNetworkACLEntryErr maps the per-entry actions (create/delete/replace).
+// The ACL and the entry are distinct resources: a missing entry on an existing
+// ACL is InvalidNetworkAclEntry.NotFound (not InvalidNetworkAclID.NotFound), and
+// a duplicate (ruleNumber, egress) is NetworkAclEntryAlreadyExists (not the
+// generic ResourceAlreadyExists). A missing ACL still maps through
+// writeNetworkACLErr to InvalidNetworkAclID.NotFound.
+func writeNetworkACLEntryErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err) && strings.Contains(err.Error(), "not found in network ACL"):
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidNetworkAclEntry.NotFound", cerrors.Message(err))
+	case cerrors.IsAlreadyExists(err):
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "NetworkAclEntryAlreadyExists", cerrors.Message(err))
+	default:
+		writeNetworkACLErr(w, err)
+	}
 }

--- a/server/aws/ec2/network_acl_test.go
+++ b/server/aws/ec2/network_acl_test.go
@@ -179,3 +179,135 @@ func TestDescribeNetworkAclsPaginatesAllOnce(t *testing.T) {
 		}
 	}
 }
+
+// mkCustomACL creates a VPC and a custom network ACL in it, returning the ACL id.
+func mkCustomACL(t *testing.T, c *ec2.Client) string {
+	t.Helper()
+
+	ctx := context.Background()
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	acl, err := c.CreateNetworkAcl(ctx, &ec2.CreateNetworkAclInput{VpcId: vpc.Vpc.VpcId})
+	if err != nil {
+		t.Fatalf("CreateNetworkAcl: %v", err)
+	}
+
+	return aws.ToString(acl.NetworkAcl.NetworkAclId)
+}
+
+// TestCreateDuplicateNetworkAclEntryRejected pins that a second
+// CreateNetworkAclEntry at the same (ruleNumber, egress) fails with
+// NetworkAclEntryAlreadyExists rather than silently creating an ambiguous
+// duplicate. Updating an entry is ReplaceNetworkAclEntry, not a second create.
+func TestCreateDuplicateNetworkAclEntryRejected(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	aclID := mkCustomACL(t, c)
+
+	entry := &ec2.CreateNetworkAclEntryInput{
+		NetworkAclId: aws.String(aclID),
+		RuleNumber:   aws.Int32(100),
+		Egress:       aws.Bool(false),
+		Protocol:     aws.String("-1"),
+		RuleAction:   ec2types.RuleActionAllow,
+		CidrBlock:    aws.String("10.10.0.0/16"),
+	}
+
+	if _, err := c.CreateNetworkAclEntry(ctx, entry); err != nil {
+		t.Fatalf("first CreateNetworkAclEntry: %v", err)
+	}
+
+	_, err := c.CreateNetworkAclEntry(ctx, entry)
+	if err == nil {
+		t.Fatal("duplicate CreateNetworkAclEntry succeeded, want NetworkAclEntryAlreadyExists")
+	}
+
+	if code := apiCode(t, err); code != "NetworkAclEntryAlreadyExists" {
+		t.Errorf("duplicate entry error code = %q, want NetworkAclEntryAlreadyExists", code)
+	}
+
+	// The ingress rule 100 must still exist exactly once (plus its egress sibling
+	// is a different key, so a same-number egress create is allowed).
+	if _, err := c.CreateNetworkAclEntry(ctx, &ec2.CreateNetworkAclEntryInput{
+		NetworkAclId: aws.String(aclID),
+		RuleNumber:   aws.Int32(100),
+		Egress:       aws.Bool(true),
+		Protocol:     aws.String("-1"),
+		RuleAction:   ec2types.RuleActionAllow,
+		CidrBlock:    aws.String("10.10.0.0/16"),
+	}); err != nil {
+		t.Fatalf("same-number egress entry should be allowed: %v", err)
+	}
+}
+
+// TestDeleteReservedNetworkAclEntryRejected pins that the immutable catch-all
+// '*' entry (rule 32767) cannot be deleted, so a NACL's deny-by-default posture
+// cannot be silently removed. The deny entry must survive the attempt.
+func TestDeleteReservedNetworkAclEntryRejected(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	aclID := mkCustomACL(t, c)
+
+	_, err := c.DeleteNetworkAclEntry(ctx, &ec2.DeleteNetworkAclEntryInput{
+		NetworkAclId: aws.String(aclID),
+		RuleNumber:   aws.Int32(32767),
+		Egress:       aws.Bool(false),
+	})
+	if err == nil {
+		t.Fatal("deleting reserved rule 32767 succeeded, want an error")
+	}
+
+	desc, err := c.DescribeNetworkAcls(ctx, &ec2.DescribeNetworkAclsInput{NetworkAclIds: []string{aclID}})
+	if err != nil {
+		t.Fatalf("DescribeNetworkAcls: %v", err)
+	}
+
+	deny := findACLEntry(desc.NetworkAcls[0].Entries, 32767, false)
+	if deny == nil || deny.RuleAction != ec2types.RuleActionDeny {
+		t.Fatalf("default deny (rule 32767, ingress) missing after delete attempt; entries: %+v",
+			desc.NetworkAcls[0].Entries)
+	}
+}
+
+// TestModifyNonexistentNetworkAclEntryNotFound pins that deleting or replacing a
+// rule number that does not exist on an ACL that does exist reports
+// InvalidNetworkAclEntry.NotFound (the entry is missing) rather than
+// InvalidNetworkAclID.NotFound (which would imply the ACL is missing).
+func TestModifyNonexistentNetworkAclEntryNotFound(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	aclID := mkCustomACL(t, c)
+
+	_, err := c.DeleteNetworkAclEntry(ctx, &ec2.DeleteNetworkAclEntryInput{
+		NetworkAclId: aws.String(aclID),
+		RuleNumber:   aws.Int32(500),
+		Egress:       aws.Bool(false),
+	})
+	if err == nil {
+		t.Fatal("deleting a nonexistent entry succeeded, want InvalidNetworkAclEntry.NotFound")
+	}
+
+	if code := apiCode(t, err); code != "InvalidNetworkAclEntry.NotFound" {
+		t.Errorf("delete nonexistent entry code = %q, want InvalidNetworkAclEntry.NotFound", code)
+	}
+
+	_, err = c.ReplaceNetworkAclEntry(ctx, &ec2.ReplaceNetworkAclEntryInput{
+		NetworkAclId: aws.String(aclID),
+		RuleNumber:   aws.Int32(500),
+		Egress:       aws.Bool(false),
+		Protocol:     aws.String("-1"),
+		RuleAction:   ec2types.RuleActionAllow,
+		CidrBlock:    aws.String("10.10.0.0/16"),
+	})
+	if err == nil {
+		t.Fatal("replacing a nonexistent entry succeeded, want InvalidNetworkAclEntry.NotFound")
+	}
+
+	if code := apiCode(t, err); code != "InvalidNetworkAclEntry.NotFound" {
+		t.Errorf("replace nonexistent entry code = %q, want InvalidNetworkAclEntry.NotFound", code)
+	}
+}


### PR DESCRIPTION
## What

Enforces a cohesive cluster of AWS VPC resource invariants (internet gateway + network ACL) surfaced by the deep-e2e real-SDK audit, and corrects the related error codes.

- **#1 One IGW per VPC** — `AttachInternetGateway` now rejects attaching a second internet gateway to a VPC that already has one. Previously the second attach silently succeeded, leaving a VPC with two IGWs. Returns `Resource.AlreadyAssociated`.
- **#6 (IGW)** — Re-attaching an already-attached internet gateway (to the same or a different VPC) now returns `Resource.AlreadyAssociated` instead of `DependencyViolation`, matching the real EC2 error reference ("You also cannot attach an internet gateway to more than one VPC at a time").
- **#2 Reserved NACL entry undeletable** — `DeleteNetworkAclEntry` / `ReplaceNetworkAclEntry` now refuse to touch the reserved catch-all `*` DENY entry (rule 32767), preserving a network ACL's deny-by-default posture. Previously it could be deleted, silently flipping the security posture.
- **#3 No duplicate NACL entry** — `CreateNetworkAclEntry` now rejects a duplicate `(ruleNumber, egress)` with `NetworkAclEntryAlreadyExists` instead of blindly appending a second entry at the same key (which made rule ordering ambiguous). Updating an entry remains `ReplaceNetworkAclEntry`.
- **#6 (NACL) entry error codes** — Deleting/replacing a rule number that does not exist on an ACL that *does* exist now maps to `InvalidNetworkAclEntry.NotFound` instead of `InvalidNetworkAclID.NotFound` (which implied the ACL was missing).

## Why

These are core VPC invariants a real user hits through the SDK/Terraform. The one-IGW-per-VPC and immutable default-deny guarantees are security/data-integrity properties that were unenforced; the mismatched error codes broke callers that branch on the documented AWS codes.

## Where (3-layer)

- Provider invariants: `providers/aws/vpc/internet_gateway.go` (one-IGW-per-VPC scan), `providers/aws/vpc/acl.go` (duplicate-entry guard, reserved-rule guard).
- Wire error mapping: `server/aws/ec2/internet_gateway.go` (`writeAttachIGWErr` → `Resource.AlreadyAssociated`), `server/aws/ec2/network_acl.go` (`writeNetworkACLEntryErr` → `InvalidNetworkAclEntry.NotFound` / `NetworkAclEntryAlreadyExists`).

All error codes verified against the official EC2 API error reference.

## Tests

Real `aws-sdk-go-v2` EC2 reproductions:
- `TestOneInternetGatewayPerVPC` — 2nd IGW attach → `Resource.AlreadyAssociated`, first stays; already-attached IGW onto a 2nd VPC → same code.
- `TestDeleteReservedNetworkAclEntryRejected` — deleting rule 32767 errors, default deny survives.
- `TestCreateDuplicateNetworkAclEntryRejected` — duplicate `(ruleNumber, egress)` → `NetworkAclEntryAlreadyExists`; same-number opposite direction still allowed.
- `TestModifyNonexistentNetworkAclEntryNotFound` — delete/replace nonexistent entry → `InvalidNetworkAclEntry.NotFound`.

Existing IGW/NACL tests (DependencyViolation teardown, deny-by-default) stay green.