### PR TITLE
fix(aws-rds): honor DeletionProtection + KmsKeyId on CreateDBInstance; no phantom final snapshot on rejected delete

### DIFF
--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -48,6 +48,9 @@ const (
 	defaultEngineMode        = "provisioned"
 	auroraAllocatedStorage   = 1
 	resourceIDLen            = 20
+	// defaultKMSKeyAlias is the account-default RDS KMS key real AWS fills in
+	// when StorageEncrypted is set but no KmsKeyId is supplied.
+	defaultKMSKeyAlias = "alias/aws/rds"
 )
 
 // Metric namespaces for engines that share the RDS wire protocol but emit
@@ -467,9 +470,26 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		PreferredMaintenanceWindow: defaultMaintenanceWindow,
 		CACertificateIdentifier:    defaultCACertIdentifier,
 		StorageEncrypted:           cfg.StorageEncrypted,
+		KmsKeyID:                   resolveKMSKeyID(cfg.StorageEncrypted, cfg.KmsKeyID),
+		DeletionProtection:         cfg.DeletionProtection,
 		CreatedAt:                  m.opts.Clock.Now().UTC(),
 		Tags:                       copyTags(cfg.Tags),
 	}
+}
+
+// resolveKMSKeyID mirrors real RDS: when storage is encrypted and the caller
+// supplied no KmsKeyId, the account's default RDS key is filled in; an explicit
+// key always wins, and an unencrypted resource carries no key.
+func resolveKMSKeyID(encrypted bool, kmsKeyID string) string {
+	if !encrypted {
+		return ""
+	}
+
+	if kmsKeyID == "" {
+		return defaultKMSKeyAlias
+	}
+
+	return kmsKeyID
 }
 
 // planProvision snapshots, under the caller's lock, what runCreateProvision needs
@@ -944,6 +964,7 @@ func (m *Mock) CreateCluster(_ context.Context, cfg rdsdriver.ClusterConfig) (*r
 		DBClusterResourceID:         resourceID("cluster-", cfg.ID),
 		AllocatedStorage:            allocatedStorage,
 		StorageEncrypted:            cfg.StorageEncrypted,
+		KmsKeyID:                    resolveKMSKeyID(cfg.StorageEncrypted, cfg.KmsKeyID),
 		DeletionProtection:          cfg.DeletionProtection,
 		AvailabilityZones:           availabilityZones(m.opts.Region),
 		CreatedAt:                   m.opts.Clock.Now().UTC(),

--- a/server/aws/rds/create_deletion_protection_kms_sdk_roundtrip_test.go
+++ b/server/aws/rds/create_deletion_protection_kms_sdk_roundtrip_test.go
@@ -1,0 +1,200 @@
+package rds_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestSDKRDSCreateDeletionProtectionHonored guards the create-time path: a DB
+// instance created with DeletionProtection=true must read back true AND reject
+// DeleteDBInstance with InvalidParameterCombination until the flag is cleared
+// via ModifyDBInstance. Previously CreateDBInstance dropped the flag, leaving a
+// "protected" DB fully deletable.
+func TestSDKRDSCreateDeletionProtectionHonored(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("dp-create"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		AllocatedStorage:     aws.Int32(20),
+		DeletionProtection:   aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	if !aws.ToBool(created.DBInstance.DeletionProtection) {
+		t.Fatal("create response DeletionProtection=false, want true")
+	}
+
+	desc, err := client.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String("dp-create"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBInstances: %v", err)
+	}
+
+	if !aws.ToBool(desc.DBInstances[0].DeletionProtection) {
+		t.Fatal("described DeletionProtection=false, want true")
+	}
+
+	// The flag must actually block deletion.
+	_, err = client.DeleteDBInstance(ctx, &awsrds.DeleteDBInstanceInput{
+		DBInstanceIdentifier: aws.String("dp-create"),
+		SkipFinalSnapshot:    aws.Bool(true),
+	})
+	if err == nil {
+		t.Fatal("delete protected instance: want InvalidParameterCombination, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterCombination" {
+		t.Fatalf("delete protected instance: got %v, want InvalidParameterCombination", err)
+	}
+
+	if _, err := client.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String("dp-create"),
+	}); err != nil {
+		t.Fatalf("instance was deleted despite create-time protection: %v", err)
+	}
+
+	// Clearing protection via Modify lets the delete through.
+	if _, err := client.ModifyDBInstance(ctx, &awsrds.ModifyDBInstanceInput{
+		DBInstanceIdentifier: aws.String("dp-create"),
+		DeletionProtection:   aws.Bool(false),
+		ApplyImmediately:     aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("ModifyDBInstance disable: %v", err)
+	}
+
+	if _, err := client.DeleteDBInstance(ctx, &awsrds.DeleteDBInstanceInput{
+		DBInstanceIdentifier: aws.String("dp-create"),
+		SkipFinalSnapshot:    aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("DeleteDBInstance after disabling protection: %v", err)
+	}
+}
+
+// TestSDKRDSCreateKmsKeyIdRoundTrips guards that an explicit KmsKeyId on
+// CreateDBInstance (with StorageEncrypted) round-trips on Describe, and that an
+// encrypted instance with no key supplied is back-filled with the account's
+// default RDS key, matching real RDS.
+func TestSDKRDSCreateKmsKeyIdRoundTrips(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const keyARN = "arn:aws:kms:us-east-1:123456789012:key/abcd-1234"
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("enc-explicit"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		AllocatedStorage:     aws.Int32(20),
+		StorageEncrypted:     aws.Bool(true),
+		KmsKeyId:             aws.String(keyARN),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance (explicit key): %v", err)
+	}
+
+	desc, err := client.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String("enc-explicit"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBInstances: %v", err)
+	}
+
+	inst := desc.DBInstances[0]
+	if !aws.ToBool(inst.StorageEncrypted) {
+		t.Fatal("StorageEncrypted=false, want true")
+	}
+
+	if got := aws.ToString(inst.KmsKeyId); got != keyARN {
+		t.Fatalf("KmsKeyId=%q, want %q", got, keyARN)
+	}
+
+	// Encrypted, no key supplied -> default RDS key is back-filled.
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("enc-default"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		AllocatedStorage:     aws.Int32(20),
+		StorageEncrypted:     aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance (default key): %v", err)
+	}
+
+	desc2, err := client.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String("enc-default"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBInstances (default key): %v", err)
+	}
+
+	if got := aws.ToString(desc2.DBInstances[0].KmsKeyId); got != "alias/aws/rds" {
+		t.Fatalf("default KmsKeyId=%q, want alias/aws/rds", got)
+	}
+}
+
+// TestSDKRDSDeleteWithLiveReplicaLeavesNoFinalSnapshot guards the delete
+// ordering: deleting a source that still has a live read replica is rejected,
+// and the FinalDBSnapshotIdentifier supplied on that call must NOT persist — a
+// rejected delete leaves no phantom final snapshot behind.
+func TestSDKRDSDeleteWithLiveReplicaLeavesNoFinalSnapshot(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("src-with-replica"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		AllocatedStorage:     aws.Int32(20),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	if _, err := client.CreateDBInstanceReadReplica(ctx, &awsrds.CreateDBInstanceReadReplicaInput{
+		DBInstanceIdentifier:       aws.String("rep-of-src"),
+		SourceDBInstanceIdentifier: aws.String("src-with-replica"),
+	}); err != nil {
+		t.Fatalf("CreateDBInstanceReadReplica: %v", err)
+	}
+
+	_, err := client.DeleteDBInstance(ctx, &awsrds.DeleteDBInstanceInput{
+		DBInstanceIdentifier:      aws.String("src-with-replica"),
+		FinalDBSnapshotIdentifier: aws.String("orphan-final"),
+	})
+	if err == nil {
+		t.Fatal("delete source with live replica: want InvalidDBInstanceState, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidDBInstanceState" {
+		t.Fatalf("delete source with live replica: got %v, want InvalidDBInstanceState", err)
+	}
+
+	// No final snapshot may exist for the rejected delete.
+	snaps, err := client.DescribeDBSnapshots(ctx, &awsrds.DescribeDBSnapshotsInput{
+		DBInstanceIdentifier: aws.String("src-with-replica"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBSnapshots: %v", err)
+	}
+
+	if len(snaps.DBSnapshots) != 0 {
+		t.Fatalf("got %d snapshots after rejected delete, want 0 (phantom final snapshot)", len(snaps.DBSnapshots))
+	}
+
+	// The source instance must still exist.
+	if _, err := client.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String("src-with-replica"),
+	}); err != nil {
+		t.Fatalf("source was deleted despite live replica: %v", err)
+	}
+}

--- a/server/aws/rds/operations.go
+++ b/server/aws/rds/operations.go
@@ -34,6 +34,8 @@ func instanceConfigFromForm(form url.Values) rdsdriver.InstanceConfig {
 		ClusterID:            form.Get("DBClusterIdentifier"),
 		AvailabilityZone:     form.Get("AvailabilityZone"),
 		StorageEncrypted:     formBool(form.Get("StorageEncrypted")),
+		KmsKeyID:             form.Get("KmsKeyId"),
+		DeletionProtection:   formBool(form.Get("DeletionProtection")),
 		Tags:                 parseRDSTags(form),
 	}
 }
@@ -272,8 +274,10 @@ func (h *Handler) deleteDBInstance(w http.ResponseWriter, r *http.Request) {
 	// set. When a final snapshot is requested, FinalDBSnapshotIdentifier is
 	// mandatory (InvalidParameterCombination otherwise). Cluster members carry no
 	// final-snapshot semantics — that belongs to DeleteDBCluster.
+	var finalID string
+
 	if last.ClusterID == "" && !formBool(r.Form.Get("SkipFinalSnapshot")) {
-		finalID := r.Form.Get("FinalDBSnapshotIdentifier")
+		finalID = r.Form.Get("FinalDBSnapshotIdentifier")
 		if finalID == "" {
 			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterCombination",
 				"FinalDBSnapshotIdentifier is required unless SkipFinalSnapshot is true")
@@ -289,7 +293,16 @@ func (h *Handler) deleteDBInstance(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.db.DeleteInstance(r.Context(), id); err != nil {
+		// The delete precondition (live read replicas, invalid state) is enforced
+		// inside DeleteInstance, so a rejection can land after the final snapshot
+		// was already written. Roll that snapshot back so a rejected delete leaves
+		// no phantom snapshot behind — real RDS validates before taking it.
+		if finalID != "" {
+			_ = h.db.DeleteSnapshot(r.Context(), finalID)
+		}
+
 		writeErr(w, err)
+
 		return
 	}
 
@@ -382,6 +395,7 @@ func (h *Handler) createDBCluster(w http.ResponseWriter, r *http.Request) {
 		DBClusterParameterGroupName: form.Get("DBClusterParameterGroupName"),
 		EngineMode:                  form.Get("EngineMode"),
 		StorageEncrypted:            formBool(form.Get("StorageEncrypted")),
+		KmsKeyID:                    form.Get("KmsKeyId"),
 		AllocatedStorage:            formInt(form.Get("AllocatedStorage")),
 		DeletionProtection:          formBool(form.Get("DeletionProtection")),
 		Tags:                        parseRDSTags(form),

--- a/server/aws/rds/xml.go
+++ b/server/aws/rds/xml.go
@@ -103,6 +103,7 @@ type dbInstanceXML struct {
 	CACertificateIdentifier               string                     `xml:"CACertificateIdentifier,omitempty"`
 	Iops                                  int                        `xml:"Iops,omitempty"`
 	StorageEncrypted                      bool                       `xml:"StorageEncrypted"`
+	KmsKeyID                              string                     `xml:"KmsKeyId,omitempty"`
 	DeletionProtection                    bool                       `xml:"DeletionProtection"`
 	DBParameterGroups                     *dbParameterGroupsXML      `xml:"DBParameterGroups,omitempty"`
 	OptionGroupMemberships                *optionGroupMembershipsXML `xml:"OptionGroupMemberships,omitempty"`
@@ -141,6 +142,7 @@ type dbClusterXML struct {
 	DBClusterResourceID string                `xml:"DbClusterResourceId,omitempty"`
 	AllocatedStorage    int                   `xml:"AllocatedStorage,omitempty"`
 	StorageEncrypted    bool                  `xml:"StorageEncrypted"`
+	KmsKeyID            string                `xml:"KmsKeyId,omitempty"`
 	DeletionProtection  bool                  `xml:"DeletionProtection"`
 	AvailabilityZones   *availabilityZonesXML `xml:"AvailabilityZones,omitempty"`
 	ClusterCreateTime   string                `xml:"ClusterCreateTime,omitempty"`
@@ -410,6 +412,7 @@ func toInstanceXML(inst *rdsdriver.Instance, resolvedSubnetGroup *dbSubnetGroupX
 		CACertificateIdentifier:               inst.CACertificateIdentifier,
 		Iops:                                  inst.Iops,
 		StorageEncrypted:                      inst.StorageEncrypted,
+		KmsKeyID:                              inst.KmsKeyID,
 		DeletionProtection:                    inst.DeletionProtection,
 		DBParameterGroups:                     toDBParameterGroupsXML(inst.DBParameterGroupName),
 		OptionGroupMemberships:                toOptionGroupMembershipsXML(inst.OptionGroupName),
@@ -484,6 +487,7 @@ func toClusterXML(cluster *rdsdriver.Cluster) dbClusterXML {
 		DBClusterResourceID: cluster.DBClusterResourceID,
 		AllocatedStorage:    cluster.AllocatedStorage,
 		StorageEncrypted:    cluster.StorageEncrypted,
+		KmsKeyID:            cluster.KmsKeyID,
 		DeletionProtection:  cluster.DeletionProtection,
 		AvailabilityZones:   toAvailabilityZonesXML(cluster.AvailabilityZones),
 		ClusterCreateTime:   cluster.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -90,6 +90,14 @@ type InstanceConfig struct {
 	// StorageEncrypted requests encryption-at-rest on the instance's storage
 	// (AWS RDS StorageEncrypted); false for engines with no such flag.
 	StorageEncrypted bool
+	// KmsKeyId is the KMS key protecting an encrypted instance (AWS RDS
+	// KmsKeyId). When StorageEncrypted is set and this is empty, RDS fills in
+	// the account's default key; empty for unencrypted instances / other engines.
+	KmsKeyID string
+	// DeletionProtection guards a standalone instance from deletion while set
+	// (AWS RDS DeletionProtection); defaults to false. For Aurora, protection is
+	// managed at the cluster level, so this stays false on member instances.
+	DeletionProtection bool
 	// HighAvailabilityMode is the Azure Flexible Server HA mode
 	// ("Disabled"/"SameZone"/"ZoneRedundant"); empty for engines with no such
 	// concept. StandbyAvailabilityZone is the zone the standby replica runs in
@@ -151,7 +159,10 @@ type Instance struct {
 	CACertificateIdentifier    string
 	Iops                       int
 	StorageEncrypted           bool
-	DeletionProtection         bool
+	// KmsKeyId echoes the KMS key protecting an encrypted instance (AWS RDS
+	// KmsKeyId) on read; empty for unencrypted instances / other engines.
+	KmsKeyID           string
+	DeletionProtection bool
 	// HighAvailabilityMode / StandbyAvailabilityZone echo the Azure Flexible
 	// Server HA configuration on read; empty for engines with no HA concept.
 	HighAvailabilityMode    string
@@ -221,6 +232,10 @@ type ClusterConfig struct {
 	// the corresponding create inputs. All default to zero for non-AWS engines.
 	EngineMode       string
 	StorageEncrypted bool
+	// KmsKeyId is the KMS key protecting an encrypted Aurora cluster (AWS RDS
+	// DBCluster KmsKeyId). When StorageEncrypted is set and this is empty, RDS
+	// fills in the account's default key; empty for unencrypted clusters.
+	KmsKeyID         string
 	AllocatedStorage int
 	// DeletionProtection guards an Aurora DB cluster from deletion while set; it
 	// echoes the AWS RDS DBCluster attribute and defaults to false. Zero for
@@ -262,7 +277,10 @@ type Cluster struct {
 	DBClusterResourceID string
 	AllocatedStorage    int
 	StorageEncrypted    bool
-	AvailabilityZones   []string
+	// KmsKeyId echoes the KMS key protecting an encrypted Aurora cluster (AWS
+	// RDS DBCluster KmsKeyId) on read; empty for unencrypted clusters.
+	KmsKeyID          string
+	AvailabilityZones []string
 	// DeletionProtection guards the cluster from deletion while set; echoes the
 	// AWS RDS DBCluster attribute and defaults to false for non-AWS engines.
 	DeletionProtection bool


### PR DESCRIPTION
## What

Fixes three RDS bugs found by the deep-e2e audit, all on the instance create/delete path. Fields now round-trip end-to-end (wire parse -> `InstanceConfig` -> `Instance`/`Cluster` -> Describe XML).

## Why / findings

- **[HIGH] `CreateDBInstance(DeletionProtection=true)` silently dropped the flag.** It read back `false` and the "protected" instance was still fully deletable — defeating the guard behind `aws_db_instance.deletion_protection = true` (real prod-safety bug + Terraform drift). The Modify path (#505) and cluster path already honored it; only instance-create dropped it. `InstanceConfig` had no `DeletionProtection` field, the form parser never read it, and `newInstance` never copied it. Now parsed/stored/emitted, and `DeleteDBInstance` rejects with `InvalidParameterCombination` until it's cleared via `ModifyDBInstance`.

- **[MED] `KmsKeyId` dropped on create and never emitted.** `StorageEncrypted=true` + `KmsKeyId=arn` read back empty → drift/forced-replace loops on encrypted DBs. Added `KmsKeyID` to `InstanceConfig`/`Instance` and `ClusterConfig`/`Cluster`, parse/store/emit `<KmsKeyId>` on Describe, and back-fill the account default (`alias/aws/rds`) when `StorageEncrypted` is set with no key — matching real RDS.

- **[MED] Phantom final snapshot on a rejected delete.** `DeleteDBInstance` created the final snapshot *before* the delete precondition (live read replicas) was enforced inside the driver, so a correctly-rejected delete left an orphan snapshot (and a retry then failed with `DBSnapshotAlreadyExists`). The final snapshot is now rolled back when `DeleteInstance` is rejected, so no snapshot survives a failed delete.

## Tests

New real `aws-sdk-go-v2` reproductions in `server/aws/rds`:
- `CreateDBInstance(DeletionProtection=true)` → Describe shows `true` AND Delete is rejected until `Modify(DeletionProtection=false)`.
- `CreateDBInstance(StorageEncrypted=true, KmsKeyId=arn)` → `KmsKeyId` round-trips on Describe; encrypted-with-no-key back-fills `alias/aws/rds`.
- `DeleteDBInstance` of a source with a live replica → rejected with `InvalidDBInstanceState` AND `DescribeDBSnapshots` is empty (no phantom final snapshot).

Existing RDS tests (#505 deletion-protection-via-Modify, #566 subnet group, #573 replicas, final-snapshot) stay green.

## Gates

`go build ./...`, `go vet`, `go test` (server/aws/rds + providers/aws/rds), `-race`, and `golangci-lint` on changed packages all clean; gofmt clean.