### PR TITLE
fix(aws-sns): FIFO topic→FIFO SQS fanout carries MessageGroupId (no silent drop); numeric filter policy matches string attributes; malformed receipt handle

### DIFF
--- a/internal/eventmatch/eventmatch.go
+++ b/internal/eventmatch/eventmatch.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"math"
 	"net"
+	"strconv"
 	"strings"
 )
 
@@ -131,22 +132,35 @@ func isReservedOperator(name string) bool {
 // at least one entry of a leaf constraint array. When the event value is itself
 // an array, the constraint matches if any element matches.
 func MatchLeaf(allowed []any, value any, present bool) bool {
+	return matchLeaf(allowed, value, present, false)
+}
+
+// MatchLeafAttr is MatchLeaf for SNS message-attribute matching, where values
+// arrive as strings even when their DataType is Number. It lets a numeric
+// operator parse a numeric string (so a "150" attribute satisfies {"numeric":
+// [">",100]}), while body/EventBridge matching via MatchLeaf keeps the stricter
+// rule that a JSON string never satisfies a numeric operator.
+func MatchLeafAttr(allowed []any, value any, present bool) bool {
+	return matchLeaf(allowed, value, present, true)
+}
+
+func matchLeaf(allowed []any, value any, present, coerceNum bool) bool {
 	// When the event value is an array, the leaf matches if any element does;
 	// otherwise fall through so exists-style operators can evaluate presence.
 	if arr, ok := value.([]any); ok && present {
 		for _, el := range arr {
-			if matchAnyEntry(allowed, el, true) {
+			if matchAnyEntry(allowed, el, true, coerceNum) {
 				return true
 			}
 		}
 	}
 
-	return matchAnyEntry(allowed, value, present)
+	return matchAnyEntry(allowed, value, present, coerceNum)
 }
 
-func matchAnyEntry(allowed []any, value any, present bool) bool {
+func matchAnyEntry(allowed []any, value any, present, coerceNum bool) bool {
 	for _, a := range allowed {
-		if matchEntry(a, value, present) {
+		if matchEntry(a, value, present, coerceNum) {
 			return true
 		}
 	}
@@ -154,10 +168,10 @@ func matchAnyEntry(allowed []any, value any, present bool) bool {
 	return false
 }
 
-func matchEntry(allowed, value any, present bool) bool {
+func matchEntry(allowed, value any, present, coerceNum bool) bool {
 	switch a := allowed.(type) {
 	case map[string]any:
-		return matchOperator(a, value, present)
+		return matchOperator(a, value, present, coerceNum)
 	case nil:
 		return present && value == nil
 	default:
@@ -165,9 +179,9 @@ func matchEntry(allowed, value any, present bool) bool {
 	}
 }
 
-func matchOperator(op map[string]any, value any, present bool) bool {
+func matchOperator(op map[string]any, value any, present, coerceNum bool) bool {
 	for name, spec := range op {
-		if !matchNamedOperator(name, spec, value, present) {
+		if !matchNamedOperator(name, spec, value, present, coerceNum) {
 			return false
 		}
 	}
@@ -175,7 +189,7 @@ func matchOperator(op map[string]any, value any, present bool) bool {
 	return true
 }
 
-func matchNamedOperator(name string, spec, value any, present bool) bool {
+func matchNamedOperator(name string, spec, value any, present, coerceNum bool) bool {
 	// exists is the only operator that evaluates the absent case; every other
 	// operator requires a present value.
 	if name == opExists {
@@ -184,10 +198,10 @@ func matchNamedOperator(name string, spec, value any, present bool) bool {
 		return want == present
 	}
 
-	return present && matchPresentOperator(name, spec, value)
+	return present && matchPresentOperator(name, spec, value, coerceNum)
 }
 
-func matchPresentOperator(name string, spec, value any) bool {
+func matchPresentOperator(name string, spec, value any, coerceNum bool) bool {
 	switch name {
 	case opPrefix:
 		return matchAffix(spec, value, strings.HasPrefix)
@@ -196,9 +210,9 @@ func matchPresentOperator(name string, spec, value any) bool {
 	case opEqualsIgnoreCase:
 		return matchEqualsIgnoreCase(spec, value)
 	case opAnythingBut:
-		return matchAnythingBut(spec, value)
+		return matchAnythingBut(spec, value, coerceNum)
 	case opNumeric:
-		return matchNumeric(spec, value)
+		return matchNumeric(spec, value, coerceNum)
 	case opCIDR:
 		return matchCIDR(spec, value)
 	case opWildcard:
@@ -253,7 +267,7 @@ func matchEqualsIgnoreCase(spec, value any) bool {
 	return ok && strings.EqualFold(got, want)
 }
 
-func matchAnythingBut(spec, value any) bool {
+func matchAnythingBut(spec, value any, coerceNum bool) bool {
 	switch s := spec.(type) {
 	case []any:
 		for _, e := range s {
@@ -264,14 +278,14 @@ func matchAnythingBut(spec, value any) bool {
 
 		return true
 	case map[string]any:
-		return !matchOperator(s, value, true)
+		return !matchOperator(s, value, true, coerceNum)
 	default:
 		return !equalScalar(spec, value)
 	}
 }
 
-func matchNumeric(spec, value any) bool {
-	v, ok := toFloat(value)
+func matchNumeric(spec, value any, coerceNum bool) bool {
+	v, ok := numericValue(value, coerceNum)
 	if !ok {
 		return false
 	}
@@ -413,6 +427,23 @@ func toFloat(v any) (float64, bool) {
 	default:
 		return 0, false
 	}
+}
+
+// numericValue resolves an event value to a float for numeric comparison. With
+// coerceNum set (SNS message-attribute scope), a numeric string is parsed, since
+// attribute values travel the wire as strings; a non-numeric string still fails.
+// Without it (body/EventBridge scope), a JSON string never satisfies a numeric
+// operator, so string values are not coerced.
+func numericValue(value any, coerceNum bool) (float64, bool) {
+	if coerceNum {
+		if s, ok := value.(string); ok {
+			f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+
+			return f, err == nil
+		}
+	}
+
+	return toFloat(value)
 }
 
 // ParsePattern decodes a JSON event pattern / filter policy into the object form

--- a/internal/eventmatch/eventmatch_test.go
+++ b/internal/eventmatch/eventmatch_test.go
@@ -236,6 +236,41 @@ func TestMatchEventArrayValueIntersection(t *testing.T) {
 	}
 }
 
+// TestMatchLeafAttrNumericStrings asserts the SNS message-attribute rule: a
+// numeric operator matches a numeric STRING (attribute values arrive as strings)
+// under MatchLeafAttr, while MatchLeaf keeps the stricter body/EventBridge rule
+// that a string never satisfies a numeric operator. Non-numeric strings match
+// neither.
+func TestMatchLeafAttrNumericStrings(t *testing.T) {
+	cases := []struct {
+		name     string
+		pattern  string
+		value    any
+		attrWant bool
+		leafWant bool
+	}{
+		{"numeric string above", `{"price":[{"numeric":[">",100]}]}`, "150", true, false},
+		{"numeric string below", `{"price":[{"numeric":[">",100]}]}`, "50", false, false},
+		{"numeric float above", `{"price":[{"numeric":[">",100]}]}`, float64(150), true, true},
+		{"non-numeric string", `{"price":[{"numeric":[">",100]}]}`, "cheap", false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := mustPattern(t, tc.pattern)
+			allowed, _ := p["price"].([]any)
+
+			if got := eventmatch.MatchLeafAttr(allowed, tc.value, true); got != tc.attrWant {
+				t.Fatalf("MatchLeafAttr = %v, want %v", got, tc.attrWant)
+			}
+
+			if got := eventmatch.MatchLeaf(allowed, tc.value, true); got != tc.leafWant {
+				t.Fatalf("MatchLeaf = %v, want %v", got, tc.leafWant)
+			}
+		})
+	}
+}
+
 func TestParsePatternRejectsGarbage(t *testing.T) {
 	if _, ok := eventmatch.ParsePattern("not json"); ok {
 		t.Fatal("expected garbage pattern to fail parse")

--- a/providers/aws/sns/filter_policy.go
+++ b/providers/aws/sns/filter_policy.go
@@ -57,7 +57,7 @@ func matchesMessageAttributes(policy map[string]any, attrs map[string]string) bo
 		}
 
 		value, present := attrs[key]
-		if !eventmatch.MatchLeaf(allowed, value, present) {
+		if !eventmatch.MatchLeafAttr(allowed, value, present) {
 			return false
 		}
 	}

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -79,8 +79,12 @@ func isValidProtocol(protocol string) bool {
 
 // SQSDeliverer delivers an SNS notification into an SQS queue identified by
 // its ARN. The SQS mock satisfies this, enabling real SNS -> SQS fan-out.
+// DeliverExternalFIFO carries the FIFO MessageGroupId / MessageDeduplicationId so
+// a FIFO topic fanning out to a FIFO SQS queue (which requires a group id) is not
+// silently rejected; group/dedup are empty for standard delivery.
 type SQSDeliverer interface {
 	DeliverExternal(ctx context.Context, queueARN, body string) error
+	DeliverExternalFIFO(ctx context.Context, queueARN, body, groupID, dedupID string) error
 }
 
 // Mock is an in-memory mock implementation of the AWS SNS service.
@@ -340,6 +344,8 @@ func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.Su
 }
 
 // Publish publishes a message to an SNS topic.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) Publish(ctx context.Context, input driver.PublishInput) (*driver.PublishOutput, error) {
 	td, ok := m.topics.Get(input.TopicID)
 	if !ok {
@@ -367,7 +373,7 @@ func (m *Mock) Publish(ctx context.Context, input driver.PublishInput) (*driver.
 	})
 	td.mu.Unlock()
 
-	m.fanOutToSQS(ctx, td, msgID, input)
+	m.fanOutToSQS(ctx, td, msgID, &input)
 
 	dims := map[string]string{"TopicName": input.TopicID}
 	m.emitMetric("NumberOfMessagesPublished", 1, "Count", dims)
@@ -403,7 +409,7 @@ func arnResource(arn string) string {
 
 // fanOutToSQS delivers a published message to every SQS-protocol subscription
 // on the topic, wrapping it in the SNS notification envelope real SNS uses.
-func (m *Mock) fanOutToSQS(ctx context.Context, td *topicData, msgID string, input driver.PublishInput) {
+func (m *Mock) fanOutToSQS(ctx context.Context, td *topicData, msgID string, input *driver.PublishInput) {
 	if m.sqs == nil {
 		return
 	}
@@ -415,30 +421,45 @@ func (m *Mock) fanOutToSQS(ctx context.Context, td *topicData, msgID string, inp
 
 		// A filter policy gates delivery: the message reaches the subscriber
 		// only when its attributes (or body) satisfy the policy.
-		if !subscriptionAccepts(&sub, &input) {
+		if !subscriptionAccepts(&sub, input) {
 			continue
 		}
 
 		// With raw message delivery enabled, SNS strips its metadata and sends
 		// the published message body as-is instead of the Notification envelope.
-		if rawDeliveryEnabled(&sub) {
-			_ = m.sqs.DeliverExternal(ctx, sub.Endpoint, input.Message)
+		body := input.Message
 
-			continue
+		if !rawDeliveryEnabled(&sub) {
+			envelope, err := m.notificationEnvelope(td, msgID, input, sub.ID)
+			if err != nil {
+				continue
+			}
+
+			body = envelope
 		}
 
-		envelope, err := m.notificationEnvelope(td, msgID, input, sub.ID)
-		if err != nil {
-			continue
-		}
-
-		_ = m.sqs.DeliverExternal(ctx, sub.Endpoint, envelope)
+		m.deliverToSQS(ctx, sub.Endpoint, body, input)
 	}
+}
+
+// deliverToSQS fans one message out to a single SQS subscription, carrying the
+// publish's FIFO group/dedup ids so a FIFO queue accepts it. A delivery failure
+// is recorded as an SNS metric rather than swallowed, so a real misconfiguration
+// (e.g. a FIFO target without a group id) is observable instead of a silent drop.
+func (m *Mock) deliverToSQS(ctx context.Context, queueARN, body string, input *driver.PublishInput) {
+	err := m.sqs.DeliverExternalFIFO(ctx, queueARN, body, input.MessageGroupID, input.MessageDeduplicationID)
+
+	metric := "NumberOfNotificationsDelivered"
+	if err != nil {
+		metric = "NumberOfNotificationsFailed"
+	}
+
+	m.emitMetric(metric, 1, "Count", map[string]string{"TopicName": input.TopicID})
 }
 
 // notificationEnvelope builds the SNS Notification JSON that wraps a published
 // message for a non-raw SQS subscription.
-func (m *Mock) notificationEnvelope(td *topicData, msgID string, input driver.PublishInput, subARN string) (string, error) {
+func (m *Mock) notificationEnvelope(td *topicData, msgID string, input *driver.PublishInput, subARN string) (string, error) {
 	env := map[string]any{
 		"Type":             "Notification",
 		"MessageId":        msgID,

--- a/providers/aws/sqs/sqs.go
+++ b/providers/aws/sqs/sqs.go
@@ -140,6 +140,14 @@ func (m *Mock) SetEventSourceInvoker(i EventSourceInvoker) {
 // the source only knows the target queue's ARN. Returns NotFound if no queue
 // matches the ARN.
 func (m *Mock) DeliverExternal(ctx context.Context, queueARN, body string) error {
+	return m.DeliverExternalFIFO(ctx, queueARN, body, "", "")
+}
+
+// DeliverExternalFIFO is DeliverExternal carrying the FIFO MessageGroupId /
+// MessageDeduplicationId. A FIFO queue rejects a send without a MessageGroupId,
+// so an SNS FIFO topic fanning out to a FIFO SQS queue must pass the group id
+// through; groupID/dedupID are empty for standard delivery.
+func (m *Mock) DeliverExternalFIFO(ctx context.Context, queueARN, body, groupID, dedupID string) error {
 	var url string
 
 	for _, qd := range m.queues.SortedValues() {
@@ -153,7 +161,12 @@ func (m *Mock) DeliverExternal(ctx context.Context, queueARN, body string) error
 		return errors.Newf(errors.NotFound, "no queue found for arn %q", queueARN)
 	}
 
-	_, err := m.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: body})
+	_, err := m.SendMessage(ctx, driver.SendMessageInput{
+		QueueURL:        url,
+		Body:            body,
+		GroupID:         groupID,
+		DeduplicationID: dedupID,
+	})
 
 	return err
 }
@@ -897,6 +910,13 @@ func (m *Mock) DeleteMessage(_ context.Context, queueURL, receiptHandle string) 
 		return errors.Newf(errors.NotFound, "queue %q not found", queueURL)
 	}
 
+	if !isWellFormedReceiptHandle(receiptHandle) {
+		// AWS rejects a syntactically-invalid receipt handle with
+		// ReceiptHandleIsInvalid (FailedPrecondition maps to that wire code),
+		// distinct from the idempotent no-op for a stale but well-formed handle.
+		return errors.Newf(errors.FailedPrecondition, "receipt handle %q is invalid", receiptHandle)
+	}
+
 	qd.mu.Lock()
 	defer qd.mu.Unlock()
 
@@ -912,6 +932,28 @@ func (m *Mock) DeleteMessage(_ context.Context, queueURL, receiptHandle string) 
 	// DeleteMessage is idempotent: an old/stale (but well-formed) receipt handle
 	// against an existing queue succeeds without deleting anything.
 	return nil
+}
+
+// isWellFormedReceiptHandle reports whether a receipt handle is syntactically
+// valid: non-empty and built only from the characters a real SQS receipt handle
+// (a base64url token) and this emulator's own handles use. A stale handle from a
+// prior receive still passes, so DeleteMessage stays idempotent for it; a
+// syntactically-invalid handle (e.g. "!!!not-a-handle!!!") is rejected.
+func isWellFormedReceiptHandle(handle string) bool {
+	if handle == "" {
+		return false
+	}
+
+	for _, r := range handle {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+		case r == '+', r == '/', r == '=', r == '-', r == '_':
+		default:
+			return false
+		}
+	}
+
+	return true
 }
 
 // ChangeVisibility changes the visibility timeout of a message in the specified queue.

--- a/server/aws/sns/fifo_fanout_sdk_test.go
+++ b/server/aws/sns/fifo_fanout_sdk_test.go
@@ -1,0 +1,232 @@
+package sns_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+)
+
+// fifoQueue creates a FIFO SQS queue (content-based dedup on) and returns its
+// URL and ARN.
+func fifoQueue(t *testing.T, sqs *awssqs.Client, name string) (url, arn string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	q, err := sqs.CreateQueue(ctx, &awssqs.CreateQueueInput{
+		QueueName: aws.String(name),
+		Attributes: map[string]string{
+			"FifoQueue":                 "true",
+			"ContentBasedDeduplication": "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue(fifo): %v", err)
+	}
+
+	attrs, err := sqs.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       q.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameQueueArn},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes: %v", err)
+	}
+
+	return aws.ToString(q.QueueUrl), attrs.Attributes["QueueArn"]
+}
+
+// TestSDKSNSFifoTopicToFifoQueueDelivers reproduces the ordered-fanout pattern:
+// an SNS FIFO topic subscribed by a FIFO SQS queue. Publishing with a
+// MessageGroupId must deliver (was a silent zero-delivery loss when the wire
+// dropped the group id), and the group id must be carried onto the SQS message.
+func TestSDKSNSFifoTopicToFifoQueueDelivers(t *testing.T) {
+	sns, sqs := newSNSAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := fifoQueue(t, sqs, "ord-sink.fifo")
+
+	topic, err := sns.CreateTopic(ctx, &awssns.CreateTopicInput{
+		Name: aws.String("ord.fifo"),
+		Attributes: map[string]string{
+			"FifoTopic":                 "true",
+			"ContentBasedDeduplication": "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateTopic(fifo): %v", err)
+	}
+
+	sub, err := sns.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn:              topic.TopicArn,
+		Protocol:              aws.String("sqs"),
+		Endpoint:              aws.String(arn),
+		ReturnSubscriptionArn: true,
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if _, err := sns.SetSubscriptionAttributes(ctx, &awssns.SetSubscriptionAttributesInput{
+		SubscriptionArn: sub.SubscriptionArn,
+		AttributeName:   aws.String("RawMessageDelivery"),
+		AttributeValue:  aws.String("true"),
+	}); err != nil {
+		t.Fatalf("SetSubscriptionAttributes: %v", err)
+	}
+
+	const n = 5
+	for i := range [n]struct{}{} {
+		if _, err := sns.Publish(ctx, &awssns.PublishInput{
+			TopicArn:       topic.TopicArn,
+			Message:        aws.String(string(rune('a' + i))),
+			MessageGroupId: aws.String("g1"),
+		}); err != nil {
+			t.Fatalf("Publish %d: %v", i, err)
+		}
+	}
+
+	rcv, err := sqs.ReceiveMessage(ctx, &awssqs.ReceiveMessageInput{
+		QueueUrl:            aws.String(url),
+		MaxNumberOfMessages: 10,
+		MessageSystemAttributeNames: []sqstypes.MessageSystemAttributeName{
+			sqstypes.MessageSystemAttributeNameMessageGroupId,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReceiveMessage: %v", err)
+	}
+
+	if len(rcv.Messages) != n {
+		t.Fatalf("FIFO fanout delivered %d messages, want %d (was 0 before fix)", len(rcv.Messages), n)
+	}
+
+	for i := range rcv.Messages {
+		if got := rcv.Messages[i].Attributes["MessageGroupId"]; got != "g1" {
+			t.Fatalf("message %d MessageGroupId = %q, want g1 (group id must carry through fanout)", i, got)
+		}
+	}
+}
+
+// TestSDKSNSNumericAttributeFilterPolicy reproduces a numeric filter policy on a
+// message ATTRIBUTE: attribute values travel the wire as strings, so a numeric
+// operator must still match one that encodes a number. A matching message was
+// silently dropped before the fix.
+func TestSDKSNSNumericAttributeFilterPolicy(t *testing.T) {
+	sns, sqs := newSNSAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := snsQueue(t, sqs, "priced")
+
+	topic, err := sns.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("prices")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	sub, err := sns.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn:              topic.TopicArn,
+		Protocol:              aws.String("sqs"),
+		Endpoint:              aws.String(arn),
+		ReturnSubscriptionArn: true,
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if _, err := sns.SetSubscriptionAttributes(ctx, &awssns.SetSubscriptionAttributesInput{
+		SubscriptionArn: sub.SubscriptionArn,
+		AttributeName:   aws.String("FilterPolicy"),
+		AttributeValue:  aws.String(`{"price":[{"numeric":[">",100]}]}`),
+	}); err != nil {
+		t.Fatalf("SetSubscriptionAttributes: %v", err)
+	}
+
+	publish := func(price string) {
+		if _, err := sns.Publish(ctx, &awssns.PublishInput{
+			TopicArn: topic.TopicArn,
+			Message:  aws.String("hi"),
+			MessageAttributes: map[string]snstypes.MessageAttributeValue{
+				"price": {DataType: aws.String("Number"), StringValue: aws.String(price)},
+			},
+		}); err != nil {
+			t.Fatalf("Publish(price=%s): %v", price, err)
+		}
+	}
+
+	publish("50")
+
+	if got := drain(t, sqs, url); len(got) != 0 {
+		t.Fatalf("price=50 delivered %d, want 0 (below threshold, filtered)", len(got))
+	}
+
+	publish("150")
+
+	if got := drain(t, sqs, url); len(got) != 1 {
+		t.Fatalf("price=150 delivered %d, want 1 (numeric attribute above threshold)", len(got))
+	}
+}
+
+// TestSDKSNSMessageBodyNumericFilterUnchanged guards that the attribute-scope
+// numeric coercion did not change body-scope semantics: a JSON number in the
+// body still matches, and the policy still gates below-threshold messages.
+func TestSDKSNSMessageBodyNumericFilterUnchanged(t *testing.T) {
+	sns, sqs := newSNSAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := snsQueue(t, sqs, "body-priced")
+
+	topic, err := sns.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("body-prices")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	sub, err := sns.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn:              topic.TopicArn,
+		Protocol:              aws.String("sqs"),
+		Endpoint:              aws.String(arn),
+		ReturnSubscriptionArn: true,
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	for name, value := range map[string]string{
+		"FilterPolicyScope":  "MessageBody",
+		"FilterPolicy":       `{"price":[{"numeric":[">",100]}]}`,
+		"RawMessageDelivery": "true",
+	} {
+		if _, err := sns.SetSubscriptionAttributes(ctx, &awssns.SetSubscriptionAttributesInput{
+			SubscriptionArn: sub.SubscriptionArn,
+			AttributeName:   aws.String(name),
+			AttributeValue:  aws.String(value),
+		}); err != nil {
+			t.Fatalf("SetSubscriptionAttributes(%s): %v", name, err)
+		}
+	}
+
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn: topic.TopicArn,
+		Message:  aws.String(`{"price":50}`),
+	}); err != nil {
+		t.Fatalf("Publish(50): %v", err)
+	}
+
+	if got := drain(t, sqs, url); len(got) != 0 {
+		t.Fatalf("body price=50 delivered %d, want 0", len(got))
+	}
+
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn: topic.TopicArn,
+		Message:  aws.String(`{"price":150}`),
+	}); err != nil {
+		t.Fatalf("Publish(150): %v", err)
+	}
+
+	if got := drain(t, sqs, url); len(got) != 1 {
+		t.Fatalf("body price=150 delivered %d, want 1", len(got))
+	}
+}

--- a/server/aws/sns/operations.go
+++ b/server/aws/sns/operations.go
@@ -423,10 +423,12 @@ func (h *Handler) publish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	out, err := h.notif.Publish(r.Context(), notifdriver.PublishInput{
-		TopicID:    topicNameFromARN(arn),
-		Subject:    r.Form.Get("Subject"),
-		Message:    r.Form.Get("Message"),
-		Attributes: parseMessageAttributes(r.Form),
+		TopicID:                topicNameFromARN(arn),
+		Subject:                r.Form.Get("Subject"),
+		Message:                r.Form.Get("Message"),
+		Attributes:             parseMessageAttributes(r.Form),
+		MessageGroupID:         r.Form.Get("MessageGroupId"),
+		MessageDeduplicationID: r.Form.Get("MessageDeduplicationId"),
 	})
 	if err != nil {
 		writeErr(w, err)

--- a/server/aws/sns/subscription_attributes.go
+++ b/server/aws/sns/subscription_attributes.go
@@ -215,10 +215,12 @@ func (h *Handler) publishBatch(w http.ResponseWriter, r *http.Request) {
 		entryID := r.Form.Get(base + ".Id")
 
 		out, err := h.notif.Publish(r.Context(), notifdriver.PublishInput{
-			TopicID:    topicID,
-			Subject:    r.Form.Get(base + ".Subject"),
-			Message:    r.Form.Get(base + ".Message"),
-			Attributes: parseBatchMessageAttributes(r.Form, base),
+			TopicID:                topicID,
+			Subject:                r.Form.Get(base + ".Subject"),
+			Message:                r.Form.Get(base + ".Message"),
+			Attributes:             parseBatchMessageAttributes(r.Form, base),
+			MessageGroupID:         r.Form.Get(base + ".MessageGroupId"),
+			MessageDeduplicationID: r.Form.Get(base + ".MessageDeduplicationId"),
 		})
 		if err != nil {
 			failures = append(failures, batchErrorEntry{

--- a/server/aws/sqs/delete_message_receipt_test.go
+++ b/server/aws/sqs/delete_message_receipt_test.go
@@ -1,0 +1,38 @@
+package sqs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+)
+
+// TestSDKSQSDeleteMessageMalformedHandle asserts a syntactically-invalid receipt
+// handle is rejected with ReceiptHandleIsInvalid, while a stale but well-formed
+// handle stays an idempotent no-op (200).
+func TestSDKSQSDeleteMessageMalformedHandle(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	q, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("del-malformed-q")})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	_, err = client.DeleteMessage(ctx, &awssqs.DeleteMessageInput{
+		QueueUrl:      q.QueueUrl,
+		ReceiptHandle: aws.String("!!!not-a-handle!!!"),
+	})
+	if code := apiErrorCode(t, err); code != "ReceiptHandleIsInvalid" {
+		t.Fatalf("malformed handle: error code = %q, want ReceiptHandleIsInvalid", code)
+	}
+
+	// A stale but well-formed handle remains an idempotent success.
+	if _, err := client.DeleteMessage(ctx, &awssqs.DeleteMessageInput{
+		QueueUrl:      q.QueueUrl,
+		ReceiptHandle: aws.String("AQEBstalebutwellformed1234567890"),
+	}); err != nil {
+		t.Fatalf("stale well-formed handle should succeed, got: %v", err)
+	}
+}

--- a/server/aws/sqs/handler.go
+++ b/server/aws/sqs/handler.go
@@ -372,7 +372,7 @@ func (h *Handler) deleteMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.mq.DeleteMessage(r.Context(), req.QueueURL, req.ReceiptHandle); err != nil {
-		writeErr(w, err)
+		writeReceiptErr(w, err)
 		return
 	}
 

--- a/services/notification/driver/driver.go
+++ b/services/notification/driver/driver.go
@@ -80,6 +80,12 @@ type PublishInput struct {
 	Subject    string
 	Message    string
 	Attributes map[string]string
+	// MessageGroupID / MessageDeduplicationID carry the FIFO ordering and
+	// deduplication identifiers of a publish to a FIFO topic. They are empty for
+	// standard topics and are threaded to a FIFO SQS subscription so the queue,
+	// which requires a message group id, accepts the fan-out delivery.
+	MessageGroupID         string
+	MessageDeduplicationID string
 }
 
 // PublishOutput is the result of publishing a message.


### PR DESCRIPTION
Fixes three real-user AWS SNS/SQS bugs found by a deep end-to-end audit (real aws-sdk-go-v2 clients over the wire server). Two are silent message loss.

## F1 — [HIGH/BLOCKER] SNS FIFO topic → FIFO SQS fanout delivered ZERO messages
Publishing to a FIFO SNS topic subscribed by a FIFO SQS queue delivered nothing, with no error to the caller. Two compounding gaps:
- The publish wire dropped `MessageGroupId` / `MessageDeduplicationId`, and `PublishInput` had no fields for them.
- Fanout called SQS `SendMessage` with no group id, which a FIFO queue correctly rejects — and the error was swallowed (`_ = DeliverExternal(...)`).

Fix (3-layer): add `MessageGroupID`/`MessageDeduplicationID` to `PublishInput`; parse them in `publish` and `publishBatch`; thread them through a new group-aware `DeliverExternalFIFO` on the SQS backend so the FIFO queue accepts the send; and record each delivery as an SNS metric (`NumberOfNotificationsDelivered` / `NumberOfNotificationsFailed`) so a real misconfiguration is observable instead of a silent drop. The group id is carried onto the delivered SQS message.

## F2 — [HIGH] Numeric FilterPolicy on a message ATTRIBUTE dropped all matches
A policy like `{"price":[{"numeric":[">",100]}]}` never matched an attribute, so subscribers silently lost every message. Attribute values travel the wire as strings, and the matcher's `toFloat` did not parse strings.

Fix: add `eventmatch.MatchLeafAttr`, an attribute-scope numeric path that parses a numeric string, while `MatchLeaf` keeps the stricter body/EventBridge rule (a JSON string never satisfies a numeric operator). MessageBody-scope numeric behavior is unchanged; non-numeric strings still don't match numeric conditions.

## N1 — [LOW] DeleteMessage with a malformed receipt handle returned 200
AWS returns `ReceiptHandleIsInvalid` for a syntactically-invalid handle. `DeleteMessage` now rejects a malformed handle with that code while keeping #515's idempotent 200 for a stale but well-formed handle.

## Tests
Real aws-sdk-go-v2 reproductions: FIFO topic→FIFO queue delivers all messages and carries the group id; numeric attribute filter delivers matching / drops non-matching; body-scope numeric filter unchanged; malformed vs stale receipt handle on DeleteMessage; and an eventmatch unit test pinning the attribute-vs-body numeric-string distinction.