### PR TITLE
fix(aws-vpc): ENI SourceDestCheck/defaults, route+subnet validation, exact error codes

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -4811,8 +4811,17 @@ func TestRouteTables(t *testing.T) {
 				t.Errorf("expected VPC %s, got %s", vpcInfo.ID, rt.VPCID)
 			}
 
-			// Create route
-			err = p.d.CreateRoute(ctx, rt.ID, "0.0.0.0/0", "igw-12345", "gateway")
+			// Create route. The AWS provider validates that the gateway target
+			// exists, so attach a real internet gateway to point the route at.
+			igw, err := p.d.CreateInternetGateway(ctx, netdriver.InternetGatewayConfig{})
+			if err != nil {
+				t.Fatalf("CreateInternetGateway: %v", err)
+			}
+			if err = p.d.AttachInternetGateway(ctx, igw.ID, vpcInfo.ID); err != nil {
+				t.Fatalf("AttachInternetGateway: %v", err)
+			}
+
+			err = p.d.CreateRoute(ctx, rt.ID, "0.0.0.0/0", igw.ID, "gateway")
 			if err != nil {
 				t.Fatalf("CreateRoute: %v", err)
 			}

--- a/docs/coverage/aws/vpc.md
+++ b/docs/coverage/aws/vpc.md
@@ -317,6 +317,14 @@ NetworkInterfaceCreator is the AWS-specific ENI-creation surface. It's kept
 | --- | --- |
 | `CreateNetworkInterface` |  |
 
+### NetworkInterfaceModifier
+
+NetworkInterfaceModifier is the AWS-specific ENI attribute-modify surface
+
+| Operation | Description |
+| --- | --- |
+| `ModifyNetworkInterfaceAttribute` |  |
+
 ### NetworkInterfaces
 
 NetworkInterfaces is an OPTIONAL capability, discovered by type assertion.

--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -317,6 +317,14 @@ NetworkInterfaceCreator is the AWS-specific ENI-creation surface. It's kept
 | --- | --- |
 | `CreateNetworkInterface` |  |
 
+### NetworkInterfaceModifier
+
+NetworkInterfaceModifier is the AWS-specific ENI attribute-modify surface
+
+| Operation | Description |
+| --- | --- |
+| `ModifyNetworkInterfaceAttribute` |  |
+
 ### NetworkInterfaces
 
 NetworkInterfaces is an OPTIONAL capability, discovered by type assertion.

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -7036,6 +7036,15 @@
         ]
       },
       {
+        "name": "NetworkInterfaceModifier",
+        "doc": "NetworkInterfaceModifier is the AWS-specific ENI attribute-modify surface",
+        "operations": [
+          {
+            "name": "ModifyNetworkInterfaceAttribute"
+          }
+        ]
+      },
+      {
         "name": "NetworkInterfaces",
         "doc": "NetworkInterfaces is an OPTIONAL capability, discovered by type assertion.",
         "operations": [

--- a/docs/coverage/gcp/vpc.md
+++ b/docs/coverage/gcp/vpc.md
@@ -317,6 +317,14 @@ NetworkInterfaceCreator is the AWS-specific ENI-creation surface. It's kept
 | --- | --- |
 | `CreateNetworkInterface` |  |
 
+### NetworkInterfaceModifier
+
+NetworkInterfaceModifier is the AWS-specific ENI attribute-modify surface
+
+| Operation | Description |
+| --- | --- |
+| `ModifyNetworkInterfaceAttribute` |  |
+
 ### NetworkInterfaces
 
 NetworkInterfaces is an OPTIONAL capability, discovered by type assertion.

--- a/docs/coverage/oci/vcn.md
+++ b/docs/coverage/oci/vcn.md
@@ -317,6 +317,14 @@ NetworkInterfaceCreator is the AWS-specific ENI-creation surface. It's kept
 | --- | --- |
 | `CreateNetworkInterface` |  |
 
+### NetworkInterfaceModifier
+
+NetworkInterfaceModifier is the AWS-specific ENI attribute-modify surface
+
+| Operation | Description |
+| --- | --- |
+| `ModifyNetworkInterfaceAttribute` |  |
+
 ### NetworkInterfaces
 
 NetworkInterfaces is an OPTIONAL capability, discovered by type assertion.

--- a/features/topology/topology_test.go
+++ b/features/topology/topology_test.go
@@ -27,6 +27,19 @@ func newTestEngine() (*Engine, *ec2.Mock, *vpc.Mock, *route53.Mock) {
 	return engine, ec2Mock, vpcMock, dnsMock
 }
 
+// attachIGW creates an internet gateway attached to vpcID and returns its id.
+// CreateRoute validates its target exists, so route tests need a real gateway.
+func attachIGW(t *testing.T, vpcMock *vpc.Mock, vpcID string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	igw, err := vpcMock.CreateInternetGateway(ctx, netdriver.InternetGatewayConfig{})
+	require.NoError(t, err)
+	require.NoError(t, vpcMock.AttachInternetGateway(ctx, igw.ID, vpcID))
+
+	return igw.ID
+}
+
 // CIDR helper tests
 func TestIPInCIDR(t *testing.T) {
 	tests := []struct {
@@ -568,7 +581,8 @@ func TestTraceRoute(t *testing.T) {
 	rt, err := vpcMock.CreateRouteTable(ctx, netdriver.RouteTableConfig{VPCID: v.ID})
 	require.NoError(t, err)
 
-	err = vpcMock.CreateRoute(ctx, rt.ID, "0.0.0.0/0", "igw-123", "gateway")
+	igwID := attachIGW(t, vpcMock, v.ID)
+	err = vpcMock.CreateRoute(ctx, rt.ID, "0.0.0.0/0", igwID, "gateway")
 	require.NoError(t, err)
 
 	// The subnet has to be associated with this table for its routes to
@@ -610,7 +624,7 @@ func TestTraceRoute(t *testing.T) {
 
 	// Fourth hop: gateway via the 0.0.0.0/0 route.
 	assert.Equal(t, "gateway", hops[3].Type)
-	assert.Equal(t, "igw-123", hops[3].ResourceID)
+	assert.Equal(t, igwID, hops[3].ResourceID)
 }
 
 // Resolve tests
@@ -668,7 +682,7 @@ func TestTraceRouteUnassociatedSubnetUsesMainTable(t *testing.T) {
 	// with it, so it does not govern this subnet's traffic.
 	rt, err := vpcMock.CreateRouteTable(ctx, netdriver.RouteTableConfig{VPCID: v.ID})
 	require.NoError(t, err)
-	require.NoError(t, vpcMock.CreateRoute(ctx, rt.ID, "0.0.0.0/0", "igw-123", "gateway"))
+	require.NoError(t, vpcMock.CreateRoute(ctx, rt.ID, "0.0.0.0/0", attachIGW(t, vpcMock, v.ID), "gateway"))
 
 	sg, err := vpcMock.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{
 		VPCID: v.ID, Name: "unassoc-sg", Description: "unassociated subnet",

--- a/providers/aws/vpc/network_interface.go
+++ b/providers/aws/vpc/network_interface.go
@@ -2,6 +2,8 @@ package vpc
 
 import (
 	"context"
+	"fmt"
+	"net"
 
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
@@ -12,19 +14,42 @@ import (
 const (
 	ENIStatusAvailable = "available"
 	ENIStatusInUse     = "in-use"
+
+	// eniFirstHostOffset is the offset of the first ENI-assignable host address
+	// inside a subnet CIDR. EC2 reserves the first four addresses (.0-.3) of
+	// every subnet, so the first usable host is at offset 4.
+	eniFirstHostOffset = 4
+
+	// eniMACPrefix is the OUI ENI MACs carry; 0a is a locally-administered
+	// address, matching the shape real EC2 hands back.
+	eniMACPrefix = "0a"
+	// macByteCount is the number of hashed bytes after the fixed OUI prefix,
+	// macHashPrime seeds the rolling hash, and bitsPerByte splits the hash into
+	// address octets.
+	macByteCount = 5
+	macHashPrime = 131
+	bitsPerByte  = 8
+
+	// eniInUseErrPrefix marks the delete-while-attached precondition so the wire
+	// layer can emit InvalidNetworkInterface.InUse rather than the generic
+	// DependencyViolation.
+	eniInUseErrPrefix = "InvalidNetworkInterface.InUse: "
 )
 
 type eniData struct {
-	ID             string
-	VPCID          string
-	SubnetID       string
-	Status         string
-	AttachmentID   string
-	InstanceID     string
-	DeviceIndex    int
-	Description    string
-	SecurityGroups []string
-	Tags           map[string]string
+	ID              string
+	VPCID           string
+	SubnetID        string
+	Status          string
+	AttachmentID    string
+	InstanceID      string
+	DeviceIndex     int
+	Description     string
+	PrivateIP       string
+	MacAddress      string
+	SourceDestCheck bool
+	SecurityGroups  []string
+	Tags            map[string]string
 }
 
 // CreateNetworkInterface creates a standalone, unattached ENI in the given
@@ -44,13 +69,19 @@ func (m *Mock) CreateNetworkInterface(
 
 	id := idgen.GenerateID("eni-")
 	eni := &eniData{
-		ID:             id,
-		VPCID:          sub.VPCID,
-		SubnetID:       subnetID,
-		Status:         ENIStatusAvailable,
-		Description:    description,
-		SecurityGroups: append([]string(nil), groups...),
-		Tags:           copyTags(tags),
+		ID:       id,
+		VPCID:    sub.VPCID,
+		SubnetID: subnetID,
+		Status:   ENIStatusAvailable,
+		// Real EC2 auto-assigns a private IPv4 from the subnet, a MAC address,
+		// and defaults source/dest check on. IaC tools (aws_network_interface)
+		// read all three straight off the create/describe response.
+		PrivateIP:       m.allocateENIPrivateIP(subnetID, sub.CIDRBlock),
+		MacAddress:      mockMAC(id),
+		SourceDestCheck: true,
+		Description:     description,
+		SecurityGroups:  append([]string(nil), groups...),
+		Tags:            copyTags(tags),
 	}
 	m.enis.Set(id, eni)
 
@@ -148,12 +179,98 @@ func (m *Mock) DeleteNetworkInterface(_ context.Context, id string) error {
 
 	if eni.AttachmentID != "" {
 		return errors.Newf(errors.FailedPrecondition,
-			"network interface %q is still attached", id)
+			"%snetwork interface %q is currently in use and cannot be deleted", eniInUseErrPrefix, id)
 	}
 
 	m.enis.Delete(id)
 
 	return nil
+}
+
+// ModifyNetworkInterfaceAttribute changes one or more ENI attributes
+// (ec2:ModifyNetworkInterfaceAttribute). A nil field in update leaves that
+// attribute untouched, matching an API that accepts one attribute per call.
+// SourceDestCheck=false is the required step for a NAT-instance / firewall /
+// router VM; Groups swaps the interface's security groups; Description renames it.
+func (m *Mock) ModifyNetworkInterfaceAttribute(
+	_ context.Context, id string, update driver.NetworkInterfaceAttributeUpdate,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	eni, ok := m.enis.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "network interface %q not found", id)
+	}
+
+	if update.SourceDestCheck != nil {
+		eni.SourceDestCheck = *update.SourceDestCheck
+	}
+
+	if update.Description != nil {
+		eni.Description = *update.Description
+	}
+
+	if update.Groups != nil {
+		eni.SecurityGroups = append([]string(nil), update.Groups...)
+	}
+
+	return nil
+}
+
+// allocateENIPrivateIP hands out the next private IPv4 inside the subnet's CIDR,
+// skipping the four addresses EC2 reserves at the front of every subnet. The
+// caller already holds m.mu. An unparseable CIDR yields an empty string rather
+// than a bogus address.
+func (m *Mock) allocateENIPrivateIP(subnetID, cidr string) string {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return ""
+	}
+
+	base := ipNet.IP.To4()
+	if base == nil {
+		return ""
+	}
+
+	if m.eniIPCounters == nil {
+		m.eniIPCounters = map[string]int{}
+	}
+
+	offset := m.eniIPCounters[subnetID] + eniFirstHostOffset
+	m.eniIPCounters[subnetID]++
+
+	host := make(net.IP, len(base))
+	copy(host, base)
+
+	carry := offset
+	for i := len(host) - 1; i >= 0 && carry > 0; i-- {
+		sum := int(host[i]) + carry
+		host[i] = byte(sum % maxOctetValue) //nolint:gosec // sum%256 is always in [0,255]
+		carry = sum / maxOctetValue
+	}
+
+	if !ipNet.Contains(host) {
+		return ""
+	}
+
+	return host.String()
+}
+
+// mockMAC derives a stable locally-administered MAC address from an ENI id, so
+// the same interface always reports the same address across describes.
+func mockMAC(seed string) string {
+	var sum uint64
+	for _, c := range []byte(seed) {
+		sum = sum*macHashPrime + uint64(c)
+	}
+
+	b := make([]byte, macByteCount)
+	for i := range b {
+		b[i] = byte(sum >> (uint(i) * bitsPerByte)) //nolint:gosec // byte() intentionally truncates to one octet
+	}
+
+	return fmt.Sprintf("%s:%02x:%02x:%02x:%02x:%02x", eniMACPrefix, b[0], b[1], b[2], b[3], b[4])
 }
 
 // attachManagedENI records the interface a managed resource (NAT gateway,
@@ -190,14 +307,17 @@ func (m *Mock) releaseManagedENIs(description string) {
 
 func toENIInfo(e *eniData) driver.NetworkInterface {
 	return driver.NetworkInterface{
-		ID:           e.ID,
-		VPCID:        e.VPCID,
-		SubnetID:     e.SubnetID,
-		Status:       e.Status,
-		AttachmentID: e.AttachmentID,
-		InstanceID:   e.InstanceID,
-		DeviceIndex:  e.DeviceIndex,
-		Description:  e.Description,
-		Tags:         copyTags(e.Tags),
+		ID:              e.ID,
+		VPCID:           e.VPCID,
+		SubnetID:        e.SubnetID,
+		Status:          e.Status,
+		AttachmentID:    e.AttachmentID,
+		InstanceID:      e.InstanceID,
+		DeviceIndex:     e.DeviceIndex,
+		Description:     e.Description,
+		PrivateIP:       e.PrivateIP,
+		MacAddress:      e.MacAddress,
+		SourceDestCheck: e.SourceDestCheck,
+		Tags:            copyTags(e.Tags),
 	}
 }

--- a/providers/aws/vpc/network_interface_test.go
+++ b/providers/aws/vpc/network_interface_test.go
@@ -1,0 +1,152 @@
+package vpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// mkSubnet creates a VPC + subnet and returns the subnet id.
+func mkSubnet(t *testing.T, m *Mock) string {
+	t.Helper()
+
+	v := createTestVPC(m)
+
+	sub, err := m.CreateSubnet(context.Background(), driver.SubnetConfig{
+		VPCID: v.ID, CIDRBlock: "10.0.1.0/24",
+	})
+	requireNoError(t, err)
+
+	return sub.ID
+}
+
+// TestCreateNetworkInterfaceDefaults pins the provider auto-assigns a subnet-scoped
+// private IP + MAC and defaults SourceDestCheck to true.
+func TestCreateNetworkInterfaceDefaults(t *testing.T) {
+	m := newTestMock()
+	subnetID := mkSubnet(t, m)
+
+	eni, err := m.CreateNetworkInterface(context.Background(), subnetID, "app", nil, nil)
+	requireNoError(t, err)
+
+	if !strings.HasPrefix(eni.PrivateIP, "10.0.1.") {
+		t.Errorf("privateIP = %q, want inside 10.0.1.0/24", eni.PrivateIP)
+	}
+
+	if eni.MacAddress == "" {
+		t.Error("macAddress is empty")
+	}
+
+	if !eni.SourceDestCheck {
+		t.Error("sourceDestCheck = false, want true by default")
+	}
+
+	// Two ENIs in the same subnet get distinct private IPs.
+	eni2, err := m.CreateNetworkInterface(context.Background(), subnetID, "app2", nil, nil)
+	requireNoError(t, err)
+
+	if eni2.PrivateIP == eni.PrivateIP {
+		t.Errorf("second ENI reused private IP %q", eni.PrivateIP)
+	}
+}
+
+// TestModifyNetworkInterfaceAttribute pins that SourceDestCheck, Description and
+// Groups each round-trip and that a nil field leaves the attribute untouched.
+func TestModifyNetworkInterfaceAttribute(t *testing.T) {
+	m := newTestMock()
+	subnetID := mkSubnet(t, m)
+	ctx := context.Background()
+
+	eni, err := m.CreateNetworkInterface(ctx, subnetID, "orig", []string{"sg-1"}, nil)
+	requireNoError(t, err)
+
+	falseVal := false
+	newDesc := "changed"
+
+	requireNoError(t, m.ModifyNetworkInterfaceAttribute(ctx, eni.ID, driver.NetworkInterfaceAttributeUpdate{
+		SourceDestCheck: &falseVal,
+		Description:     &newDesc,
+		Groups:          []string{"sg-2", "sg-3"},
+	}))
+
+	got, err := m.DescribeNetworkInterfaces(ctx, []string{eni.ID})
+	requireNoError(t, err)
+
+	if got[0].SourceDestCheck {
+		t.Error("sourceDestCheck = true after modify, want false")
+	}
+
+	if got[0].Description != "changed" {
+		t.Errorf("description = %q, want changed", got[0].Description)
+	}
+
+	// A no-op update leaves everything in place.
+	requireNoError(t, m.ModifyNetworkInterfaceAttribute(ctx, eni.ID, driver.NetworkInterfaceAttributeUpdate{}))
+
+	got, err = m.DescribeNetworkInterfaces(ctx, []string{eni.ID})
+	requireNoError(t, err)
+
+	if got[0].Description != "changed" || got[0].SourceDestCheck {
+		t.Errorf("no-op modify changed state: %+v", got[0])
+	}
+
+	// An unknown ENI is NotFound.
+	if err := m.ModifyNetworkInterfaceAttribute(ctx, "eni-nope", driver.NetworkInterfaceAttributeUpdate{
+		SourceDestCheck: &falseVal,
+	}); !cerrors.IsNotFound(err) {
+		t.Errorf("modify unknown ENI err = %v, want NotFound", err)
+	}
+}
+
+// TestCreateRouteValidatesTarget pins that a route pointing at a nonexistent
+// gateway / NAT / peering is rejected with the target-specific marker, while a
+// valid target is accepted.
+func TestCreateRouteValidatesTarget(t *testing.T) {
+	m := newTestMock()
+	v := createTestVPC(m)
+	ctx := context.Background()
+
+	rt, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: v.ID})
+	requireNoError(t, err)
+
+	cases := []struct {
+		name, target, marker string
+	}{
+		{"bad igw", "igw-bogus", routeTargetIGWNotFound},
+		{"bad nat", "nat-bogus", routeTargetNATNotFound},
+		{"bad peering", "pcx-bogus", routeTargetPeeringNotFound},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := m.CreateRoute(ctx, rt.ID, "0.0.0.0/0", tc.target, "gateway")
+			if !cerrors.IsNotFound(err) || !strings.Contains(err.Error(), tc.marker) {
+				t.Fatalf("err = %v, want NotFound carrying %q", err, tc.marker)
+			}
+		})
+	}
+
+	// A real IGW target is accepted.
+	igwID := attachTestIGW(t, m, v.ID)
+	requireNoError(t, m.CreateRoute(ctx, rt.ID, "0.0.0.0/0", igwID, "gateway"))
+}
+
+// TestCreateSubnetRange pins that a subnet CIDR outside the VPC block is rejected
+// while an in-range block is accepted.
+func TestCreateSubnetRange(t *testing.T) {
+	m := newTestMock()
+	v := createTestVPC(m) // 10.0.0.0/16
+	ctx := context.Background()
+
+	_, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "192.168.5.0/24"})
+	if !cerrors.IsInvalidArgument(err) || !strings.Contains(err.Error(), "InvalidSubnet.Range") {
+		t.Fatalf("out-of-range subnet err = %v, want InvalidSubnet.Range", err)
+	}
+
+	// A block inside the VPC range still works.
+	_, err = m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.2.0/24"})
+	requireNoError(t, err)
+}

--- a/providers/aws/vpc/race_test.go
+++ b/providers/aws/vpc/race_test.go
@@ -80,6 +80,17 @@ func TestCreateRoute_ConcurrentCreatesAllLand(t *testing.T) {
 		t.Fatalf("CreateRouteTable: %v", err)
 	}
 
+	// CreateRoute validates its target exists, so attach a real gateway to point
+	// the concurrent routes at.
+	igw, err := m.CreateInternetGateway(ctx, driver.InternetGatewayConfig{})
+	if err != nil {
+		t.Fatalf("CreateInternetGateway: %v", err)
+	}
+
+	if err := m.AttachInternetGateway(ctx, igw.ID, vpcID); err != nil {
+		t.Fatalf("AttachInternetGateway: %v", err)
+	}
+
 	var wg sync.WaitGroup
 
 	for i := range raceGoroutines {
@@ -89,7 +100,7 @@ func TestCreateRoute_ConcurrentCreatesAllLand(t *testing.T) {
 			defer wg.Done()
 
 			cidr := "10." + strconv.Itoa(i+1) + ".0.0/16"
-			if err := m.CreateRoute(ctx, rt.ID, cidr, "igw-test", "gateway"); err != nil {
+			if err := m.CreateRoute(ctx, rt.ID, cidr, igw.ID, "gateway"); err != nil {
 				t.Errorf("CreateRoute: %v", err)
 			}
 		}()

--- a/providers/aws/vpc/route_table.go
+++ b/providers/aws/vpc/route_table.go
@@ -3,6 +3,7 @@ package vpc
 import (
 	"context"
 	"sort"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
@@ -12,6 +13,16 @@ import (
 // Route target type constants.
 const (
 	RouteTargetLocal = "local"
+)
+
+// Route-target not-found markers. A CreateRoute pointing at a gateway / NAT /
+// peering that does not exist carries the matching marker so the wire layer can
+// emit the resource-specific EC2 error code rather than a generic route-table
+// not-found.
+const (
+	routeTargetIGWNotFound     = "InvalidInternetGatewayID.NotFound"
+	routeTargetNATNotFound     = "InvalidNatGatewayID.NotFound"
+	routeTargetPeeringNotFound = "InvalidVpcPeeringConnectionID.NotFound"
 )
 
 type routeTableData struct {
@@ -145,12 +156,43 @@ func (m *Mock) CreateRoute(
 		}
 	}
 
+	if err := m.validateRouteTarget(targetID); err != nil {
+		return err
+	}
+
 	rt.Routes = append(rt.Routes, driver.Route{
 		DestinationCIDR: destinationCIDR,
 		TargetID:        targetID,
 		TargetType:      targetType,
 		State:           "active",
 	})
+
+	return nil
+}
+
+// validateRouteTarget rejects a route pointing at a gateway / NAT / peering that
+// does not exist, matching real EC2 (silently storing a dangling target is the
+// bug this closes). Targets are keyed by id prefix so the rarer target types
+// (virtual gateways, egress-only IGWs, transit gateways) pass through
+// unvalidated rather than being wrongly rejected. The caller holds m.mu.
+func (m *Mock) validateRouteTarget(targetID string) error {
+	switch {
+	case strings.HasPrefix(targetID, "igw-"):
+		if !m.igws.Has(targetID) {
+			return errors.Newf(errors.NotFound,
+				"%s: internet gateway %q does not exist", routeTargetIGWNotFound, targetID)
+		}
+	case strings.HasPrefix(targetID, "nat-"):
+		if !m.natGateways.Has(targetID) {
+			return errors.Newf(errors.NotFound,
+				"%s: NAT gateway %q does not exist", routeTargetNATNotFound, targetID)
+		}
+	case strings.HasPrefix(targetID, "pcx-"):
+		if !m.peerings.Has(targetID) {
+			return errors.Newf(errors.NotFound,
+				"%s: peering connection %q does not exist", routeTargetPeeringNotFound, targetID)
+		}
+	}
 
 	return nil
 }

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -30,6 +30,10 @@ const (
 	// resource-specific InvalidVpcRange code (mirrors the InvalidSubnet.* prefix
 	// convention used for subnet CIDR conflicts).
 	vpcRangeErrPrefix = "InvalidVpcRange: "
+	// subnetRangeErrPrefix marks a subnet CIDR that falls outside the VPC's CIDR
+	// block so the wire layer can emit the resource-specific InvalidSubnet.Range
+	// code (mirrors the InvalidSubnet.Conflict prefix convention).
+	subnetRangeErrPrefix = "InvalidSubnet.Range: "
 )
 
 // Default security group identity. EC2 gives every VPC a group named "default"
@@ -46,6 +50,7 @@ const (
 var (
 	_ driver.Networking                 = (*Mock)(nil)
 	_ driver.NetworkInterfaces          = (*Mock)(nil)
+	_ driver.NetworkInterfaceModifier   = (*Mock)(nil)
 	_ driver.NetworkACLAssociator       = (*Mock)(nil)
 	_ driver.VPCAttributes              = (*Mock)(nil)
 	_ driver.SubnetAttributes           = (*Mock)(nil)
@@ -155,6 +160,11 @@ type Mock struct {
 	// re-derived from VPCs/subnets on every read. Guarded by mu.
 	ipamResourceOverrides map[string]ipamResourceOverride
 
+	// eniIPCounters tracks the next private-IP offset handed out per subnet when
+	// a standalone ENI is created, so each interface gets a distinct address.
+	// Guarded by mu.
+	eniIPCounters map[string]int
+
 	opts *config.Options
 }
 
@@ -253,6 +263,7 @@ func New(opts *config.Options) *Mock {
 		ipamPoolByCidr:        map[string]string{},
 		ipamPoolByAllocation:  map[string]string{},
 		ipamResourceOverrides: map[string]ipamResourceOverride{},
+		eniIPCounters:         map[string]int{},
 
 		opts: opts,
 	}
@@ -505,7 +516,8 @@ func (m *Mock) CreateSubnet(_ context.Context, cfg driver.SubnetConfig) (*driver
 		return nil, errors.Newf(errors.InvalidArgument, "CIDR block is required")
 	}
 
-	if !m.vpcs.Has(cfg.VPCID) {
+	v, ok := m.vpcs.Get(cfg.VPCID)
+	if !ok {
 		return nil, errors.Newf(errors.NotFound, "vpc %q not found", cfg.VPCID)
 	}
 
@@ -514,6 +526,13 @@ func (m *Mock) CreateSubnet(_ context.Context, cfg driver.SubnetConfig) (*driver
 	} else if conflict != "" {
 		return nil, errors.Newf(errors.AlreadyExists,
 			"InvalidSubnet.Conflict: subnet CIDR %q conflicts with existing subnet %q", cfg.CIDRBlock, conflict)
+	}
+
+	// A subnet's CIDR must sit entirely inside the VPC's CIDR block; real EC2
+	// rejects an out-of-range block with InvalidSubnet.Range.
+	if !cidrWithinVPC(cfg.CIDRBlock, v.CIDRBlock) {
+		return nil, errors.Newf(errors.InvalidArgument,
+			"%sThe CIDR '%s' is invalid", subnetRangeErrPrefix, cfg.CIDRBlock)
 	}
 
 	id := idgen.GenerateID("subnet-")
@@ -600,6 +619,28 @@ func validateVPCCIDR(cidr string) error {
 	}
 
 	return nil
+}
+
+// cidrWithinVPC reports whether the subnet CIDR sits entirely inside the VPC's
+// CIDR block: its network address must fall within the VPC block and its prefix
+// must be at least as long (a smaller-or-equal block). An unparseable subnet CIDR
+// is not contained; an unparseable VPC CIDR does not block (validation happens at
+// VPC-create time).
+func cidrWithinVPC(subnetCIDR, vpcCIDR string) bool {
+	_, subnet, err := net.ParseCIDR(subnetCIDR)
+	if err != nil {
+		return false
+	}
+
+	_, vpcNet, err := net.ParseCIDR(vpcCIDR)
+	if err != nil {
+		return true
+	}
+
+	subnetOnes, _ := subnet.Mask.Size()
+	vpcOnes, _ := vpcNet.Mask.Size()
+
+	return subnetOnes >= vpcOnes && vpcNet.Contains(subnet.IP)
 }
 
 // subnetCIDRConflict reports an existing subnet in the same VPC whose CIDR

--- a/providers/aws/vpc/vpc_test.go
+++ b/providers/aws/vpc/vpc_test.go
@@ -24,6 +24,19 @@ func createTestVPC(m *Mock) *driver.VPCInfo {
 	return info
 }
 
+// attachTestIGW creates an internet gateway attached to vpcID and returns its id,
+// for tests that need a real route target (CreateRoute validates target existence).
+func attachTestIGW(t *testing.T, m *Mock, vpcID string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	igw, err := m.CreateInternetGateway(ctx, driver.InternetGatewayConfig{})
+	requireNoError(t, err)
+	requireNoError(t, m.AttachInternetGateway(ctx, igw.ID, vpcID))
+
+	return igw.ID
+}
+
 func TestCreateVPC(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -869,9 +882,10 @@ func TestCreateRoute(t *testing.T) {
 	ctx := context.Background()
 	v := createTestVPC(m)
 	rt, _ := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: v.ID})
+	igwID := attachTestIGW(t, m, v.ID)
 
 	t.Run("add route", func(t *testing.T) {
-		err := m.CreateRoute(ctx, rt.ID, "0.0.0.0/0", "igw-12345", "gateway")
+		err := m.CreateRoute(ctx, rt.ID, "0.0.0.0/0", igwID, "gateway")
 		requireNoError(t, err)
 
 		rts, _ := m.DescribeRouteTables(ctx, []string{rt.ID})
@@ -894,7 +908,8 @@ func TestDeleteRoute(t *testing.T) {
 	ctx := context.Background()
 	v := createTestVPC(m)
 	rt, _ := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: v.ID})
-	_ = m.CreateRoute(ctx, rt.ID, "0.0.0.0/0", "igw-12345", "gateway")
+	igwID := attachTestIGW(t, m, v.ID)
+	requireNoError(t, m.CreateRoute(ctx, rt.ID, "0.0.0.0/0", igwID, "gateway"))
 
 	t.Run("delete existing route", func(t *testing.T) {
 		err := m.DeleteRoute(ctx, rt.ID, "0.0.0.0/0")

--- a/server/aws/ec2/address.go
+++ b/server/aws/ec2/address.go
@@ -89,13 +89,10 @@ func (h *Handler) releaseAddress(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.vpc.ReleaseAddress(r.Context(), id); err != nil {
 		// An Elastic IP still associated (e.g. held by a NAT gateway) can't be
-		// released; real EC2 answers InvalidIPAddress.InUse.
-		if cerrors.IsFailedPrecondition(err) {
-			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidIPAddress.InUse", err.Error())
-			return
-		}
-
-		writeVPCErr(w, err)
+		// released; real EC2 answers InvalidIPAddress.InUse. An unknown allocation
+		// id is InvalidAllocationID.NotFound — not the VPC code the generic mapper
+		// would emit.
+		writeErrWithNotFound(w, err, "InvalidAllocationID.NotFound", "InvalidIPAddress.InUse")
 
 		return
 	}

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -548,6 +548,8 @@ func (h *Handler) routeVPCNetworkInterfaces(w http.ResponseWriter, r *http.Reque
 		h.detachNetworkInterface(w, r)
 	case "DeleteNetworkInterface":
 		h.deleteNetworkInterface(w, r)
+	case "ModifyNetworkInterfaceAttribute":
+		h.modifyNetworkInterfaceAttribute(w, r)
 	default:
 		return false
 	}

--- a/server/aws/ec2/nat_gateway.go
+++ b/server/aws/ec2/nat_gateway.go
@@ -3,7 +3,9 @@ package ec2
 import (
 	"encoding/xml"
 	"net/http"
+	"strings"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
@@ -55,7 +57,7 @@ func (h *Handler) createNatGateway(w http.ResponseWriter, r *http.Request) {
 		Tags:             mergeTagSpecs(awsquery.TagSpecs(r.Form), "natgateway"),
 	})
 	if err != nil {
-		writeNatErr(w, err)
+		writeCreateNatErr(w, err)
 		return
 	}
 
@@ -128,4 +130,16 @@ func toNatGatewayXML(n *netdriver.NATGateway) natGatewayXML {
 
 func writeNatErr(w http.ResponseWriter, err error) {
 	writeErrWithNotFound(w, err, "NatGatewayNotFound", "DependencyViolation")
+}
+
+// writeCreateNatErr maps CreateNatGateway's not-found: the NAT does not exist yet,
+// so a not-found on create is the target subnet — InvalidSubnetID.NotFound, not
+// the NatGatewayNotFound the generic mapper would emit.
+func writeCreateNatErr(w http.ResponseWriter, err error) {
+	if cerrors.IsNotFound(err) && strings.Contains(err.Error(), "subnet") {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSubnetID.NotFound", cerrors.Message(err))
+		return
+	}
+
+	writeNatErr(w, err)
 }

--- a/server/aws/ec2/network_interface.go
+++ b/server/aws/ec2/network_interface.go
@@ -24,8 +24,18 @@ type networkInterfaceXML struct {
 	SubnetID           string            `xml:"subnetId,omitempty"`
 	Status             string            `xml:"status"`
 	Description        string            `xml:"description,omitempty"`
+	PrivateIPAddress   string            `xml:"privateIpAddress,omitempty"`
+	MacAddress         string            `xml:"macAddress,omitempty"`
+	SourceDestCheck    bool              `xml:"sourceDestCheck"`
 	Attachment         *eniAttachmentXML `xml:"attachment,omitempty"`
 	Tags               []tagItem         `xml:"tagSet>item,omitempty"`
+}
+
+type modifyNetworkInterfaceAttributeResponseXML struct {
+	XMLName   xml.Name `xml:"ModifyNetworkInterfaceAttributeResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
 }
 
 type describeNetworkInterfacesResponseXML struct {
@@ -281,7 +291,7 @@ func (h *Handler) deleteNetworkInterface(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := store.DeleteNetworkInterface(r.Context(), r.Form.Get("NetworkInterfaceId")); err != nil {
-		writeENIErr(w, err)
+		writeENIDeleteErr(w, err)
 		return
 	}
 
@@ -292,6 +302,56 @@ func (h *Handler) deleteNetworkInterface(w http.ResponseWriter, r *http.Request)
 	})
 }
 
+// modifyNetworkInterfaceAttribute changes an ENI's SourceDestCheck, Description,
+// or security groups (ec2:ModifyNetworkInterfaceAttribute). Disabling
+// SourceDestCheck is the required step for a NAT-instance / firewall / router VM.
+func (h *Handler) modifyNetworkInterfaceAttribute(w http.ResponseWriter, r *http.Request) {
+	modifier, ok := h.vpc.(netdriver.NetworkInterfaceModifier)
+	if !ok {
+		writeUnsupportedENI(w)
+		return
+	}
+
+	var update netdriver.NetworkInterfaceAttributeUpdate
+
+	if v := r.Form.Get("SourceDestCheck.Value"); v != "" {
+		b := v == formTrue
+		update.SourceDestCheck = &b
+	}
+
+	if _, present := r.Form["Description.Value"]; present {
+		d := r.Form.Get("Description.Value")
+		update.Description = &d
+	}
+
+	if groups := awsquery.ListStrings(r.Form, "SecurityGroupId"); len(groups) > 0 {
+		update.Groups = groups
+	}
+
+	if err := modifier.ModifyNetworkInterfaceAttribute(r.Context(), r.Form.Get("NetworkInterfaceId"), update); err != nil {
+		writeENIErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, modifyNetworkInterfaceAttributeResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Return:    true,
+	})
+}
+
+// writeENIDeleteErr maps a delete-while-attached interface to
+// InvalidNetworkInterface.InUse (real EC2's code), falling back to the shared ENI
+// error mapping otherwise.
+func writeENIDeleteErr(w http.ResponseWriter, err error) {
+	if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "InvalidNetworkInterface.InUse:") {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidNetworkInterface.InUse", err.Error())
+		return
+	}
+
+	writeENIErr(w, err)
+}
+
 func toNetworkInterfaceXML(e *netdriver.NetworkInterface) networkInterfaceXML {
 	x := networkInterfaceXML{
 		NetworkInterfaceID: e.ID,
@@ -299,6 +359,9 @@ func toNetworkInterfaceXML(e *netdriver.NetworkInterface) networkInterfaceXML {
 		SubnetID:           e.SubnetID,
 		Status:             nonEmpty(e.Status, "available"),
 		Description:        e.Description,
+		PrivateIPAddress:   e.PrivateIP,
+		MacAddress:         e.MacAddress,
+		SourceDestCheck:    e.SourceDestCheck,
 		Tags:               toTagItems(e.Tags),
 	}
 

--- a/server/aws/ec2/network_interface_attribute_test.go
+++ b/server/aws/ec2/network_interface_attribute_test.go
@@ -1,0 +1,196 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestCreateNetworkInterfaceDefaults pins the attributes real EC2 auto-assigns to
+// a standalone ENI: a private IPv4 from the subnet CIDR, a MAC address, and
+// SourceDestCheck defaulting to true. Terraform aws_network_interface reads all
+// three straight off the create/describe response.
+func TestCreateNetworkInterfaceDefaults(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	_, subnetID := mkVPCSubnet(t, c)
+
+	created, err := c.CreateNetworkInterface(ctx, &ec2.CreateNetworkInterfaceInput{
+		SubnetId:    aws.String(subnetID),
+		Description: aws.String("app-eni"),
+	})
+	if err != nil {
+		t.Fatalf("CreateNetworkInterface: %v", err)
+	}
+
+	eni := created.NetworkInterface
+	if got := aws.ToString(eni.PrivateIpAddress); got == "" {
+		t.Error("create: privateIpAddress is empty, want a subnet-scoped address")
+	}
+
+	if got := aws.ToString(eni.MacAddress); got == "" {
+		t.Error("create: macAddress is empty")
+	}
+
+	if eni.SourceDestCheck == nil || !aws.ToBool(eni.SourceDestCheck) {
+		t.Errorf("create: sourceDestCheck = %v, want true", eni.SourceDestCheck)
+	}
+
+	// The same attributes must survive a Describe round-trip.
+	id := aws.ToString(eni.NetworkInterfaceId)
+
+	desc, err := c.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		NetworkInterfaceIds: []string{id},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNetworkInterfaces: %v", err)
+	}
+
+	got := desc.NetworkInterfaces[0]
+	if aws.ToString(got.PrivateIpAddress) != aws.ToString(eni.PrivateIpAddress) {
+		t.Errorf("describe privateIpAddress = %q, want %q",
+			aws.ToString(got.PrivateIpAddress), aws.ToString(eni.PrivateIpAddress))
+	}
+
+	if got.SourceDestCheck == nil || !aws.ToBool(got.SourceDestCheck) {
+		t.Errorf("describe sourceDestCheck = %v, want true", got.SourceDestCheck)
+	}
+}
+
+// TestModifyNetworkInterfaceSourceDestCheck pins that
+// ModifyNetworkInterfaceAttribute(SourceDestCheck=false) is honored and readable
+// back — the required step for a NAT-instance / firewall / router VM.
+func TestModifyNetworkInterfaceSourceDestCheck(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	_, subnetID := mkVPCSubnet(t, c)
+
+	created, err := c.CreateNetworkInterface(ctx, &ec2.CreateNetworkInterfaceInput{
+		SubnetId: aws.String(subnetID),
+	})
+	if err != nil {
+		t.Fatalf("CreateNetworkInterface: %v", err)
+	}
+
+	id := aws.ToString(created.NetworkInterface.NetworkInterfaceId)
+
+	if _, err := c.ModifyNetworkInterfaceAttribute(ctx, &ec2.ModifyNetworkInterfaceAttributeInput{
+		NetworkInterfaceId: aws.String(id),
+		SourceDestCheck:    &ec2types.AttributeBooleanValue{Value: aws.Bool(false)},
+	}); err != nil {
+		t.Fatalf("ModifyNetworkInterfaceAttribute: %v", err)
+	}
+
+	desc, err := c.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		NetworkInterfaceIds: []string{id},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNetworkInterfaces: %v", err)
+	}
+
+	if got := desc.NetworkInterfaces[0].SourceDestCheck; got == nil || aws.ToBool(got) {
+		t.Errorf("sourceDestCheck after modify = %v, want false", got)
+	}
+}
+
+// TestModifyNetworkInterfaceDescription pins that a Description update round-trips.
+func TestModifyNetworkInterfaceDescription(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	_, subnetID := mkVPCSubnet(t, c)
+
+	created, err := c.CreateNetworkInterface(ctx, &ec2.CreateNetworkInterfaceInput{
+		SubnetId:    aws.String(subnetID),
+		Description: aws.String("before"),
+	})
+	if err != nil {
+		t.Fatalf("CreateNetworkInterface: %v", err)
+	}
+
+	id := aws.ToString(created.NetworkInterface.NetworkInterfaceId)
+
+	if _, err := c.ModifyNetworkInterfaceAttribute(ctx, &ec2.ModifyNetworkInterfaceAttributeInput{
+		NetworkInterfaceId: aws.String(id),
+		Description:        &ec2types.AttributeValue{Value: aws.String("after")},
+	}); err != nil {
+		t.Fatalf("ModifyNetworkInterfaceAttribute: %v", err)
+	}
+
+	desc, err := c.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		NetworkInterfaceIds: []string{id},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNetworkInterfaces: %v", err)
+	}
+
+	if got := aws.ToString(desc.NetworkInterfaces[0].Description); got != "after" {
+		t.Errorf("description after modify = %q, want after", got)
+	}
+}
+
+// TestDeleteMissingNetworkInterfaceCode pins that deleting an ENI that does not
+// exist answers InvalidNetworkInterfaceID.NotFound, not a generic error.
+func TestDeleteMissingNetworkInterfaceCode(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	_, err := c.DeleteNetworkInterface(ctx, &ec2.DeleteNetworkInterfaceInput{
+		NetworkInterfaceId: aws.String("eni-deadbeef"),
+	})
+	if err == nil {
+		t.Fatal("DeleteNetworkInterface(missing) succeeded, want an error")
+	}
+
+	if got := apiCode(t, err); got != "InvalidNetworkInterfaceID.NotFound" {
+		t.Errorf("code = %q, want InvalidNetworkInterfaceID.NotFound", got)
+	}
+}
+
+// TestDeleteAttachedNetworkInterfaceCode pins that deleting an ENI attached to an
+// instance answers InvalidNetworkInterface.InUse, not DependencyViolation.
+func TestDeleteAttachedNetworkInterfaceCode(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	_, subnetID := mkVPCSubnet(t, c)
+
+	run, err := c.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId: aws.String("ami-12345"), InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1), SubnetId: aws.String(subnetID),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	instanceID := aws.ToString(run.Instances[0].InstanceId)
+
+	created, err := c.CreateNetworkInterface(ctx, &ec2.CreateNetworkInterfaceInput{
+		SubnetId: aws.String(subnetID),
+	})
+	if err != nil {
+		t.Fatalf("CreateNetworkInterface: %v", err)
+	}
+
+	eniID := aws.ToString(created.NetworkInterface.NetworkInterfaceId)
+
+	if _, err := c.AttachNetworkInterface(ctx, &ec2.AttachNetworkInterfaceInput{
+		NetworkInterfaceId: aws.String(eniID),
+		InstanceId:         aws.String(instanceID),
+		DeviceIndex:        aws.Int32(1),
+	}); err != nil {
+		t.Fatalf("AttachNetworkInterface: %v", err)
+	}
+
+	_, err = c.DeleteNetworkInterface(ctx, &ec2.DeleteNetworkInterfaceInput{
+		NetworkInterfaceId: aws.String(eniID),
+	})
+	if err == nil {
+		t.Fatal("DeleteNetworkInterface(attached) succeeded, want an error")
+	}
+
+	if got := apiCode(t, err); got != "InvalidNetworkInterface.InUse" {
+		t.Errorf("code = %q, want InvalidNetworkInterface.InUse", got)
+	}
+}

--- a/server/aws/ec2/networking_error_codes_test.go
+++ b/server/aws/ec2/networking_error_codes_test.go
@@ -1,0 +1,260 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+// mkAttachedIGW creates an internet gateway attached to vpcID and returns its id.
+func mkAttachedIGW(t *testing.T, c *ec2.Client, vpcID string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	igw, err := c.CreateInternetGateway(ctx, &ec2.CreateInternetGatewayInput{})
+	if err != nil {
+		t.Fatalf("CreateInternetGateway: %v", err)
+	}
+
+	id := aws.ToString(igw.InternetGateway.InternetGatewayId)
+
+	if _, err := c.AttachInternetGateway(ctx, &ec2.AttachInternetGatewayInput{
+		InternetGatewayId: aws.String(id), VpcId: aws.String(vpcID),
+	}); err != nil {
+		t.Fatalf("AttachInternetGateway: %v", err)
+	}
+
+	return id
+}
+
+// mkRouteTable creates a route table in vpcID and returns its id.
+func mkRouteTable(t *testing.T, c *ec2.Client, vpcID string) string {
+	t.Helper()
+
+	rt, err := c.CreateRouteTable(context.Background(), &ec2.CreateRouteTableInput{
+		VpcId: aws.String(vpcID),
+	})
+	if err != nil {
+		t.Fatalf("CreateRouteTable: %v", err)
+	}
+
+	return aws.ToString(rt.RouteTable.RouteTableId)
+}
+
+// TestCreateRouteBadGatewayCode pins that a route pointing at a nonexistent
+// internet gateway is rejected with InvalidInternetGatewayID.NotFound rather than
+// silently stored.
+func TestCreateRouteBadGatewayCode(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	vpcID, _ := mkVPCSubnet(t, c)
+	rtID := mkRouteTable(t, c, vpcID)
+
+	_, err := c.CreateRoute(ctx, &ec2.CreateRouteInput{
+		RouteTableId:         aws.String(rtID),
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		GatewayId:            aws.String("igw-bogus00"),
+	})
+	if err == nil {
+		t.Fatal("CreateRoute(bad gateway) succeeded, want an error")
+	}
+
+	if got := apiCode(t, err); got != "InvalidInternetGatewayID.NotFound" {
+		t.Errorf("code = %q, want InvalidInternetGatewayID.NotFound", got)
+	}
+}
+
+// TestCreateRouteBadNatGatewayCode pins the NAT equivalent.
+func TestCreateRouteBadNatGatewayCode(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	vpcID, _ := mkVPCSubnet(t, c)
+	rtID := mkRouteTable(t, c, vpcID)
+
+	_, err := c.CreateRoute(ctx, &ec2.CreateRouteInput{
+		RouteTableId:         aws.String(rtID),
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		NatGatewayId:         aws.String("nat-bogus00"),
+	})
+	if err == nil {
+		t.Fatal("CreateRoute(bad NAT) succeeded, want an error")
+	}
+
+	if got := apiCode(t, err); got != "InvalidNatGatewayID.NotFound" {
+		t.Errorf("code = %q, want InvalidNatGatewayID.NotFound", got)
+	}
+}
+
+// TestCreateRouteBadPeeringCode pins the peering equivalent.
+func TestCreateRouteBadPeeringCode(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	vpcID, _ := mkVPCSubnet(t, c)
+	rtID := mkRouteTable(t, c, vpcID)
+
+	_, err := c.CreateRoute(ctx, &ec2.CreateRouteInput{
+		RouteTableId:           aws.String(rtID),
+		DestinationCidrBlock:   aws.String("10.9.0.0/16"),
+		VpcPeeringConnectionId: aws.String("pcx-bogus00"),
+	})
+	if err == nil {
+		t.Fatal("CreateRoute(bad peering) succeeded, want an error")
+	}
+
+	if got := apiCode(t, err); got != "InvalidVpcPeeringConnectionID.NotFound" {
+		t.Errorf("code = %q, want InvalidVpcPeeringConnectionID.NotFound", got)
+	}
+}
+
+// TestDuplicateRouteCode pins that a second route for the same destination CIDR
+// answers RouteAlreadyExists, not the generic ResourceAlreadyExists.
+func TestDuplicateRouteCode(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	vpcID, _ := mkVPCSubnet(t, c)
+	igwID := mkAttachedIGW(t, c, vpcID)
+	rtID := mkRouteTable(t, c, vpcID)
+
+	if _, err := c.CreateRoute(ctx, &ec2.CreateRouteInput{
+		RouteTableId:         aws.String(rtID),
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		GatewayId:            aws.String(igwID),
+	}); err != nil {
+		t.Fatalf("CreateRoute: %v", err)
+	}
+
+	_, err := c.CreateRoute(ctx, &ec2.CreateRouteInput{
+		RouteTableId:         aws.String(rtID),
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		GatewayId:            aws.String(igwID),
+	})
+	if err == nil {
+		t.Fatal("duplicate CreateRoute succeeded, want an error")
+	}
+
+	if got := apiCode(t, err); got != "RouteAlreadyExists" {
+		t.Errorf("code = %q, want RouteAlreadyExists", got)
+	}
+}
+
+// TestDeleteMissingRouteCode pins that deleting a route that does not exist on an
+// existing route table answers InvalidRoute.NotFound — not the route-table code,
+// which would falsely imply the table itself is missing.
+func TestDeleteMissingRouteCode(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	vpcID, _ := mkVPCSubnet(t, c)
+	rtID := mkRouteTable(t, c, vpcID)
+
+	_, err := c.DeleteRoute(ctx, &ec2.DeleteRouteInput{
+		RouteTableId:         aws.String(rtID),
+		DestinationCidrBlock: aws.String("172.16.0.0/16"),
+	})
+	if err == nil {
+		t.Fatal("DeleteRoute(missing) succeeded, want an error")
+	}
+
+	if got := apiCode(t, err); got != "InvalidRoute.NotFound" {
+		t.Errorf("code = %q, want InvalidRoute.NotFound", got)
+	}
+}
+
+// TestSubnetOutOfVPCRangeCode pins that a subnet CIDR outside the VPC CIDR block
+// is rejected with InvalidSubnet.Range rather than silently created.
+func TestSubnetOutOfVPCRangeCode(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	vpcID, _ := mkVPCSubnet(t, c) // 10.0.0.0/16
+
+	_, err := c.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId:     aws.String(vpcID),
+		CidrBlock: aws.String("192.168.5.0/24"),
+	})
+	if err == nil {
+		t.Fatal("CreateSubnet(out-of-range CIDR) succeeded, want an error")
+	}
+
+	if got := apiCode(t, err); got != "InvalidSubnet.Range" {
+		t.Errorf("code = %q, want InvalidSubnet.Range", got)
+	}
+}
+
+// TestReleaseBogusAllocationCode pins that releasing an unknown allocation id
+// answers InvalidAllocationID.NotFound — not the unrelated InvalidVpcID.NotFound.
+func TestReleaseBogusAllocationCode(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	_, err := c.ReleaseAddress(ctx, &ec2.ReleaseAddressInput{
+		AllocationId: aws.String("eipalloc-bogus00"),
+	})
+	if err == nil {
+		t.Fatal("ReleaseAddress(bogus) succeeded, want an error")
+	}
+
+	if got := apiCode(t, err); got != "InvalidAllocationID.NotFound" {
+		t.Errorf("code = %q, want InvalidAllocationID.NotFound", got)
+	}
+}
+
+// TestNatGatewayBadSubnetCode pins that a NAT gateway in a nonexistent subnet
+// answers InvalidSubnetID.NotFound — the subnet is what's missing, not the NAT.
+func TestNatGatewayBadSubnetCode(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	_, err := c.CreateNatGateway(ctx, &ec2.CreateNatGatewayInput{
+		SubnetId: aws.String("subnet-bogus00"),
+	})
+	if err == nil {
+		t.Fatal("CreateNatGateway(bogus subnet) succeeded, want an error")
+	}
+
+	if got := apiCode(t, err); got != "InvalidSubnetID.NotFound" {
+		t.Errorf("code = %q, want InvalidSubnetID.NotFound", got)
+	}
+}
+
+// TestPeeringNonPendingAcceptCode pins that accepting a peering that is not in
+// pending-acceptance state answers InvalidStateTransition, not DependencyViolation.
+func TestPeeringNonPendingAcceptCode(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	vpcID, _ := mkVPCSubnet(t, c) // 10.0.0.0/16
+
+	peer, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.1.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc(peer): %v", err)
+	}
+
+	peerID := aws.ToString(peer.Vpc.VpcId)
+
+	created, err := c.CreateVpcPeeringConnection(ctx, &ec2.CreateVpcPeeringConnectionInput{
+		VpcId: aws.String(vpcID), PeerVpcId: aws.String(peerID),
+	})
+	if err != nil {
+		t.Fatalf("CreateVpcPeeringConnection: %v", err)
+	}
+
+	pcxID := aws.ToString(created.VpcPeeringConnection.VpcPeeringConnectionId)
+
+	if _, err := c.AcceptVpcPeeringConnection(ctx, &ec2.AcceptVpcPeeringConnectionInput{
+		VpcPeeringConnectionId: aws.String(pcxID),
+	}); err != nil {
+		t.Fatalf("AcceptVpcPeeringConnection: %v", err)
+	}
+
+	// Accepting an already-active peering is the illegal transition.
+	_, err = c.AcceptVpcPeeringConnection(ctx, &ec2.AcceptVpcPeeringConnectionInput{
+		VpcPeeringConnectionId: aws.String(pcxID),
+	})
+	if err == nil {
+		t.Fatal("accepting an active peering succeeded, want an error")
+	}
+
+	if got := apiCode(t, err); got != "InvalidStateTransition" {
+		t.Errorf("code = %q, want InvalidStateTransition", got)
+	}
+}

--- a/server/aws/ec2/peering.go
+++ b/server/aws/ec2/peering.go
@@ -218,6 +218,9 @@ func peeringStatusMessage(code string) string {
 	}
 }
 
+// writePeeringErr maps peering errors. A state precondition (accepting/rejecting
+// a connection that is not pending-acceptance) is InvalidStateTransition — real
+// EC2's code for "not in the correct state" — not a dependency violation.
 func writePeeringErr(w http.ResponseWriter, err error) {
-	writeErrWithNotFound(w, err, "InvalidVpcPeeringConnectionID.NotFound", "DependencyViolation")
+	writeErrWithNotFound(w, err, "InvalidVpcPeeringConnectionID.NotFound", "InvalidStateTransition")
 }

--- a/server/aws/ec2/route_table.go
+++ b/server/aws/ec2/route_table.go
@@ -3,7 +3,9 @@ package ec2
 import (
 	"encoding/xml"
 	"net/http"
+	"strings"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
@@ -180,7 +182,7 @@ func (h *Handler) createRoute(w http.ResponseWriter, r *http.Request) {
 		r.Form.Get("DestinationCidrBlock"),
 		target, targetType)
 	if err != nil {
-		writeRouteTableErr(w, err)
+		writeCreateRouteErr(w, err)
 		return
 	}
 
@@ -239,7 +241,7 @@ func (h *Handler) deleteRoute(w http.ResponseWriter, r *http.Request) {
 	err := h.vpc.DeleteRoute(r.Context(),
 		r.Form.Get("RouteTableId"), r.Form.Get("DestinationCidrBlock"))
 	if err != nil {
-		writeRouteTableErr(w, err)
+		writeDeleteRouteErr(w, err)
 		return
 	}
 
@@ -465,9 +467,68 @@ func writeRouteTableErr(w http.ResponseWriter, err error) {
 	writeErrWithNotFound(w, err, "InvalidRouteTableID.NotFound", "DependencyViolation")
 }
 
+// writeCreateRouteErr maps CreateRoute's resource-specific errors: a destination
+// CIDR that already exists is RouteAlreadyExists (not the generic
+// ResourceAlreadyExists), and a route pointing at a gateway / NAT / peering that
+// does not exist maps to that target's not-found code. A missing route table
+// still falls through to InvalidRouteTableID.NotFound.
+func writeCreateRouteErr(w http.ResponseWriter, err error) {
+	if cerrors.IsAlreadyExists(err) {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "RouteAlreadyExists", cerrors.Message(err))
+		return
+	}
+
+	if code, ok := routeTargetNotFoundCode(err); ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, code, cerrors.Message(err))
+		return
+	}
+
+	writeRouteTableErr(w, err)
+}
+
+// writeDeleteRouteErr maps a miss on an existing route table to
+// InvalidRoute.NotFound (the route is what's absent), while a missing route table
+// still maps to InvalidRouteTableID.NotFound. The provider's message
+// disambiguates the two ("not found in route table" is the route miss).
+func writeDeleteRouteErr(w http.ResponseWriter, err error) {
+	if cerrors.IsNotFound(err) && strings.Contains(err.Error(), "not found in route table") {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidRoute.NotFound", cerrors.Message(err))
+		return
+	}
+
+	writeRouteTableErr(w, err)
+}
+
 // writeReplaceRouteErr maps a NotFound to InvalidRoute.NotFound: ReplaceRoute's
 // precondition is that the route already exists, so the delete-step miss reports
-// the missing route, matching real EC2, rather than the route-table code.
+// the missing route, matching real EC2, rather than the route-table code. A
+// re-create pointing at a nonexistent target still maps to that target's code.
 func writeReplaceRouteErr(w http.ResponseWriter, err error) {
+	if code, ok := routeTargetNotFoundCode(err); ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, code, cerrors.Message(err))
+		return
+	}
+
 	writeErrWithNotFound(w, err, "InvalidRoute.NotFound", "DependencyViolation")
+}
+
+// routeTargetNotFoundCode reports the target-specific EC2 error code a CreateRoute
+// carries when its gateway / NAT / peering target does not exist. The provider
+// marks each with the code as a message prefix.
+func routeTargetNotFoundCode(err error) (string, bool) {
+	if !cerrors.IsNotFound(err) {
+		return "", false
+	}
+
+	for _, code := range []string{
+		"InvalidInternetGatewayID.NotFound",
+		"InvalidNatGatewayID.NotFound",
+		"InvalidVpcPeeringConnectionID.NotFound",
+	} {
+		if strings.Contains(err.Error(), code+":") {
+			return code, true
+		}
+	}
+
+	return "", false
 }

--- a/server/aws/ec2/subnet.go
+++ b/server/aws/ec2/subnet.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"net"
 	"net/http"
+	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
@@ -272,12 +273,20 @@ func writeSubnetErr(w http.ResponseWriter, err error) {
 	writeErrWithNotFound(w, err, "InvalidSubnetID.NotFound", "DependencyViolation")
 }
 
-// writeCreateSubnetErr adds the CreateSubnet-only InvalidSubnet.Conflict code
-// for an overlapping CIDR (surfaced as AlreadyExists by the driver), falling
-// back to the shared subnet error mapping otherwise.
+// writeCreateSubnetErr adds the CreateSubnet-only codes: InvalidSubnet.Conflict
+// for an overlapping CIDR (surfaced as AlreadyExists by the driver) and
+// InvalidSubnet.Range for a CIDR outside the VPC block, falling back to the
+// shared subnet error mapping otherwise.
 func writeCreateSubnetErr(w http.ResponseWriter, err error) {
 	if cerrors.IsAlreadyExists(err) {
 		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSubnet.Conflict", err.Error())
+		return
+	}
+
+	// A subnet CIDR outside the VPC's CIDR block is InvalidSubnet.Range, not the
+	// generic InvalidParameterValue the shared mapper would emit.
+	if cerrors.IsInvalidArgument(err) && strings.Contains(err.Error(), "InvalidSubnet.Range:") {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSubnet.Range", cerrors.Message(err))
 		return
 	}
 

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -360,6 +360,14 @@ type NetworkInterface struct {
 	// for an available interface.
 	InstanceID  string
 	DeviceIndex int
+	// PrivateIP is the primary private IPv4 address the interface holds inside
+	// its subnet, MacAddress its hardware address, and SourceDestCheck the
+	// source/destination check flag. Real EC2 auto-assigns a private IP and MAC
+	// on create and defaults SourceDestCheck to true — the flag a NAT-instance /
+	// firewall / router VM disables via ModifyNetworkInterfaceAttribute.
+	PrivateIP       string
+	MacAddress      string
+	SourceDestCheck bool
 }
 
 // Azure network interface (Microsoft.Network/networkInterfaces) is an
@@ -599,6 +607,23 @@ type NetworkInterfaces interface {
 // (e.g. resourcediscovery's read-only walker, which only needs Describe).
 type NetworkInterfaceCreator interface {
 	CreateNetworkInterface(ctx context.Context, subnetID, description string, groups []string, tags map[string]string) (*NetworkInterface, error)
+}
+
+// NetworkInterfaceAttributeUpdate carries the ENI attributes a caller wants
+// changed via ec2:ModifyNetworkInterfaceAttribute. A nil pointer (or nil Groups)
+// leaves that attribute untouched, matching an API that accepts one attribute
+// per call.
+type NetworkInterfaceAttributeUpdate struct {
+	SourceDestCheck *bool
+	Description     *string
+	Groups          []string
+}
+
+// NetworkInterfaceModifier is the AWS-specific ENI attribute-modify surface
+// (ec2:ModifyNetworkInterfaceAttribute). It is kept out of NetworkInterfaces so
+// adding it doesn't break subset assertions, mirroring NetworkInterfaceCreator.
+type NetworkInterfaceModifier interface {
+	ModifyNetworkInterfaceAttribute(ctx context.Context, id string, update NetworkInterfaceAttributeUpdate) error
 }
 
 // NetworkInterfaceAttacher is the AWS-specific ENI attach surface


### PR DESCRIPTION
## What

VPC batch-2 fixes from the deep-e2e audit (`aws-e2e/vpc.md`), covering ENI attributes, route/subnet validation, and typed error-code mismatches. Batch-1's IGW/NACL invariants (#662) are untouched.

### ENI (finding #14, #15, #11)
- `CreateNetworkInterface` now auto-assigns a subnet-scoped private IPv4 + MAC address and defaults `SourceDestCheck` to `true` (real EC2 behavior; `aws_network_interface` reads all three). Emitted in the ENI XML and round-tripped through Describe.
- Added `ModifyNetworkInterfaceAttribute` (wire dispatch + `NetworkInterfaceModifier` driver interface + provider impl) for `SourceDestCheck` / `Description` / `Groups` — the required step for NAT-instance / firewall / router VMs.
- Delete-while-attached now maps to `InvalidNetworkInterface.InUse` (was `DependencyViolation`); delete-missing stays `InvalidNetworkInterfaceID.NotFound`.

### Route / subnet validation (finding #12, #13)
- `CreateRoute` rejects a nonexistent gateway / NAT / peering target instead of silently storing a dangling route (`InvalidInternetGatewayID.NotFound` / `InvalidNatGatewayID.NotFound` / `InvalidVpcPeeringConnectionID.NotFound`).
- `CreateSubnet` rejects a CIDR outside the VPC's CIDR block with `InvalidSubnet.Range`.

### Error-code mismatches (findings #4, #5, #8, #9, #10)
- `DeleteRoute` of a missing route on an existing table -> `InvalidRoute.NotFound` (was `InvalidRouteTableID.NotFound`).
- Duplicate `CreateRoute` -> `RouteAlreadyExists` (was `ResourceAlreadyExists`).
- `CreateNatGateway` in a missing subnet -> `InvalidSubnetID.NotFound` (was `NatGatewayNotFound`).
- `ReleaseAddress` with a bad allocation id -> `InvalidAllocationID.NotFound` (was `InvalidVpcID.NotFound`).
- Accept/Reject a non-pending peering -> `InvalidStateTransition` (was `DependencyViolation`).

## Why

Every mismatch was reproduced through the real `aws-sdk-go-v2` EC2 client and each expected code verified against the official EC2 API error reference. Silent successes mask real IaC misconfig; wrong typed codes break SDK/Terraform error handling (e.g. an EIP-release naming an unrelated VPC resource type).

## Where (3-layer)

- Real validation / state invariants: `providers/aws/vpc/*` (ENI defaults + modify, CreateRoute target check, subnet-range check).
- Error-code mapping: `server/aws/ec2/*` `write*Err` helpers, matching the batch-1 marker/message-based pattern.
- Driver interface change regenerated `docs/coverage/` (idempotent).

## Tests

Real `aws-sdk-go-v2` reproductions for each fix (ENI defaults + SourceDestCheck modify/read, delete missing/attached codes; CreateRoute bad gateway/NAT/peering, duplicate route, delete-missing route, subnet out-of-range; release-bad-alloc, NAT-bad-subnet, peering-state) plus provider-level tests. Existing VPC/EC2 suites (incl. #662 IGW/NACL) stay green; a few tests using placeholder `igw-*` route targets were updated to attach a real gateway.