### PR TITLE
fix(aws-cloudwatch): exact dimension matching, SetAlarmState history+actions, M-of-N alarm eval + OK recovery, alarm field round-trip, DeleteAlarms + history semantics

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -1170,9 +1170,21 @@ func TestAlarmTriggeredByAutoMetrics(t *testing.T) {
 	clock := config.NewFakeClock(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC))
 	p := NewAWS(config.WithClock(clock))
 
-	// Create alarm: CPU > 0 (any CPU should trigger since auto-metrics emit 25.0)
+	// Launch the instance first so we know its id; EC2 auto-metrics are dimensioned
+	// by InstanceId, and CloudWatch matches an alarm to a metric series by its exact
+	// dimension set — so a real user alarms on that instance's InstanceId.
+	instances, err := p.EC2.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "ami-test", InstanceType: "t2.micro",
+	}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := instances[0].ID
+
+	// Create alarm: CPU > 0 on that instance (auto-metrics emit 25.0).
 	if err := p.CloudWatch.CreateAlarm(ctx, mondriver.AlarmConfig{
 		Name: "any-cpu", Namespace: "AWS/EC2", MetricName: "CPUUtilization",
+		Dimensions:         map[string]string{"InstanceId": id},
 		ComparisonOperator: "GreaterThanThreshold", Threshold: 0,
 		Period: 600, EvaluationPeriods: 1, Stat: "Average",
 	}); err != nil {
@@ -1185,11 +1197,9 @@ func TestAlarmTriggeredByAutoMetrics(t *testing.T) {
 		t.Errorf("expected INSUFFICIENT_DATA, got %s", alarms[0].State)
 	}
 
-	// Launch instance — auto-metrics should trigger alarm evaluation
-	_, err := p.EC2.RunInstances(ctx, computedriver.InstanceConfig{
-		ImageID: "ami-test", InstanceType: "t2.micro",
-	}, 1)
-	if err != nil {
+	// A lifecycle op re-emits the instance's running auto-metrics (CPU=25),
+	// triggering alarm evaluation the way the next datapoint would in real AWS.
+	if err := p.EC2.RebootInstances(ctx, []string{id}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1205,16 +1215,8 @@ func TestLifecycleStopEmitsZeroMetrics(t *testing.T) {
 	clock := config.NewFakeClock(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC))
 	p := NewAWS(config.WithClock(clock))
 
-	// Create alarm: CPU < 1 (LessThanThreshold)
-	if err := p.CloudWatch.CreateAlarm(ctx, mondriver.AlarmConfig{
-		Name: "low-cpu", Namespace: "AWS/EC2", MetricName: "CPUUtilization",
-		ComparisonOperator: "LessThanThreshold", Threshold: 1,
-		Period: 300, EvaluationPeriods: 1, Stat: "Average",
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// RunInstances → CPU=25 → alarm stays OK (25 is not < 1)
+	// Launch first to learn the instance id; the alarm carries that InstanceId
+	// dimension so exact-match evaluation reads this instance's metric series.
 	instances, err := p.EC2.RunInstances(ctx, computedriver.InstanceConfig{
 		ImageID: "ami-test", InstanceType: "t2.micro",
 	}, 1)
@@ -1223,9 +1225,24 @@ func TestLifecycleStopEmitsZeroMetrics(t *testing.T) {
 	}
 	id := instances[0].ID
 
+	// Create alarm: CPU < 1 (LessThanThreshold) on that instance.
+	if err := p.CloudWatch.CreateAlarm(ctx, mondriver.AlarmConfig{
+		Name: "low-cpu", Namespace: "AWS/EC2", MetricName: "CPUUtilization",
+		Dimensions:         map[string]string{"InstanceId": id},
+		ComparisonOperator: "LessThanThreshold", Threshold: 1,
+		Period: 300, EvaluationPeriods: 1, Stat: "Average",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reboot re-emits running auto-metrics (CPU=25) → alarm evaluates to OK (not < 1).
+	if err := p.EC2.RebootInstances(ctx, []string{id}); err != nil {
+		t.Fatal(err)
+	}
+
 	alarms, _ := p.CloudWatch.DescribeAlarms(ctx, []string{"low-cpu"})
 	if alarms[0].State != "OK" {
-		t.Errorf("expected OK after RunInstances (CPU=25, not < 1), got %s", alarms[0].State)
+		t.Errorf("expected OK after running metrics (CPU=25, not < 1), got %s", alarms[0].State)
 	}
 
 	// Advance clock past evaluation window so old datapoints fall out
@@ -1247,16 +1264,8 @@ func TestLifecycleStartEmitsRunningMetrics(t *testing.T) {
 	clock := config.NewFakeClock(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC))
 	p := NewAWS(config.WithClock(clock))
 
-	// Create alarm: CPU > 0
-	if err := p.CloudWatch.CreateAlarm(ctx, mondriver.AlarmConfig{
-		Name: "any-cpu-start", Namespace: "AWS/EC2", MetricName: "CPUUtilization",
-		ComparisonOperator: "GreaterThanThreshold", Threshold: 0,
-		Period: 300, EvaluationPeriods: 1, Stat: "Average",
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// RunInstances → stop → advance clock → start
+	// RunInstances first to learn the id → create the dimensioned alarm → stop →
+	// advance clock → start.
 	instances, err := p.EC2.RunInstances(ctx, computedriver.InstanceConfig{
 		ImageID: "ami-test", InstanceType: "t2.micro",
 	}, 1)
@@ -1264,6 +1273,16 @@ func TestLifecycleStartEmitsRunningMetrics(t *testing.T) {
 		t.Fatal(err)
 	}
 	id := instances[0].ID
+
+	// Create alarm: CPU > 0 on that instance.
+	if err := p.CloudWatch.CreateAlarm(ctx, mondriver.AlarmConfig{
+		Name: "any-cpu-start", Namespace: "AWS/EC2", MetricName: "CPUUtilization",
+		Dimensions:         map[string]string{"InstanceId": id},
+		ComparisonOperator: "GreaterThanThreshold", Threshold: 0,
+		Period: 300, EvaluationPeriods: 1, Stat: "Average",
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := p.EC2.StopInstances(ctx, []string{id}); err != nil {
 		t.Fatal(err)
@@ -8950,17 +8969,18 @@ func testAlarmActions(
 		t.Fatalf("[%s] GetAlarmHistory: %v", label, err)
 	}
 
-	// Two transitions: INSUFFICIENT_DATA->OK, OK->ALARM.
+	// Two transitions, returned newest-first (CloudWatch's default
+	// TimestampDescending order): OK->ALARM then INSUFFICIENT_DATA->OK.
 	if len(history) != 2 {
 		t.Fatalf("[%s] expected 2 history entries, got %d", label, len(history))
 	}
 
-	if history[0].OldState != "INSUFFICIENT_DATA" || history[0].NewState != "OK" {
-		t.Errorf("[%s] history[0]: expected INSUFFICIENT_DATA->OK, got %s->%s", label, history[0].OldState, history[0].NewState)
+	if history[0].OldState != "OK" || history[0].NewState != "ALARM" {
+		t.Errorf("[%s] history[0]: expected OK->ALARM (newest), got %s->%s", label, history[0].OldState, history[0].NewState)
 	}
 
-	if history[1].OldState != "OK" || history[1].NewState != "ALARM" {
-		t.Errorf("[%s] history[1]: expected OK->ALARM, got %s->%s", label, history[1].OldState, history[1].NewState)
+	if history[1].OldState != "INSUFFICIENT_DATA" || history[1].NewState != "OK" {
+		t.Errorf("[%s] history[1]: expected INSUFFICIENT_DATA->OK, got %s->%s", label, history[1].OldState, history[1].NewState)
 	}
 
 	// 9. Verify history limit works.

--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -32,6 +32,17 @@ const (
 	stateInsufficientData = "INSUFFICIENT_DATA"
 )
 
+// defaultAlarmPeriodSeconds is the period assumed when an alarm omits one.
+const defaultAlarmPeriodSeconds = 60
+
+// TreatMissingData policies from PutMetricAlarm. Any other value (including the
+// empty string) is the AWS default "missing": a period with no data is simply
+// not counted toward the M-of-N rule.
+const (
+	treatMissingBreaching    = "breaching"
+	treatMissingNotBreaching = "notBreaching"
+)
+
 // ActionPublisher publishes an alarm-state-change notification to an SNS topic
 // by ARN. It is satisfied by the SNS backend's PublishExternal, mirroring the
 // S3 -> SNS notification wiring, so an alarm transition fans a message out to
@@ -161,7 +172,7 @@ func (m *Mock) evaluateAlarms(namespace, metricName string) {
 func (m *Mock) evaluateSingleAlarm(alarm *alarmData, namespace, metricName string) {
 	period := alarm.Period
 	if period <= 0 {
-		period = 60
+		period = defaultAlarmPeriodSeconds
 	}
 
 	evalPeriods := alarm.EvaluationPeriods
@@ -169,28 +180,97 @@ func (m *Mock) evaluateSingleAlarm(alarm *alarmData, namespace, metricName strin
 		evalPeriods = 1
 	}
 
+	// DatapointsToAlarm is the M in the M-of-N rule; it defaults to (and can't
+	// exceed) EvaluationPeriods.
+	datapointsToAlarm := alarm.DatapointsToAlarm
+	if datapointsToAlarm <= 0 || datapointsToAlarm > evalPeriods {
+		datapointsToAlarm = evalPeriods
+	}
+
 	now := m.opts.Clock.Now()
-	windowDur := time.Duration(period*evalPeriods) * time.Second
-	windowStart := now.Add(-windowDur)
+	periodDur := time.Duration(period) * time.Second
+	windowStart := now.Add(-periodDur * time.Duration(evalPeriods))
 
 	filtered := m.collectFilteredDatums(namespace, metricName, alarm.Dimensions, windowStart, now)
-
 	if len(filtered) == 0 {
 		return
 	}
 
-	stat := aggregateDatums(filtered).stat(alarm.Stat)
-
-	var newState, reason string
-	if evaluateComparison(stat, alarm.ComparisonOperator, alarm.Threshold) {
-		newState = stateAlarm
-		reason = "Threshold crossed"
-	} else {
-		newState = stateOK
-		reason = "Threshold not crossed"
+	newState, reason, ok := evaluateWindow(filtered, alarm, now, periodDur, evalPeriods, datapointsToAlarm)
+	if !ok {
+		return
 	}
 
 	m.transitionAlarm(alarm, newState, reason, now)
+}
+
+// evaluateWindow applies CloudWatch's M-of-N rule. It groups the datums into the
+// last evalPeriods per-period buckets (bucket 0 is the most recent period),
+// evaluates the alarm statistic per bucket, and returns ALARM when at least
+// datapointsToAlarm buckets breach — otherwise OK, which is how an alarm recovers
+// once the breaching periods age out of the window. Empty periods are counted per
+// the alarm's TreatMissingData policy. ok is false when there is nothing to
+// evaluate (all periods missing under a non-breaching policy), leaving the state
+// unchanged rather than forcing a transition.
+func evaluateWindow(
+	datums []driver.MetricDatum, alarm *alarmData, now time.Time,
+	periodDur time.Duration, evalPeriods, datapointsToAlarm int,
+) (string, string, bool) {
+	buckets := bucketByPeriod(datums, now, periodDur, evalPeriods)
+
+	breaching, present := 0, 0
+
+	for _, b := range buckets {
+		switch {
+		case b != nil:
+			present++
+
+			if evaluateComparison(b.stat(alarm.Stat), alarm.ComparisonOperator, alarm.Threshold) {
+				breaching++
+			}
+		case alarm.TreatMissingData == treatMissingBreaching:
+			present++
+			breaching++
+		case alarm.TreatMissingData == treatMissingNotBreaching:
+			present++
+		}
+	}
+
+	if present == 0 {
+		return "", "", false
+	}
+
+	if breaching >= datapointsToAlarm {
+		return stateAlarm, "Threshold crossed", true
+	}
+
+	return stateOK, "Threshold not crossed", true
+}
+
+// bucketByPeriod groups datums into evalPeriods accumulators indexed by age,
+// where bucket 0 covers the most recent period. A nil bucket had no data.
+func bucketByPeriod(datums []driver.MetricDatum, now time.Time, periodDur time.Duration, evalPeriods int) []*statAgg {
+	buckets := make([]*statAgg, evalPeriods)
+
+	for i := range datums {
+		age := now.Sub(datums[i].Timestamp)
+		if age < 0 {
+			continue
+		}
+
+		idx := int(age / periodDur)
+		if idx >= evalPeriods {
+			continue
+		}
+
+		if buckets[idx] == nil {
+			buckets[idx] = &statAgg{}
+		}
+
+		foldDatum(buckets[idx], &datums[i])
+	}
+
+	return buckets
 }
 
 // transitionAlarm sets an alarm's state and — only when the state actually
@@ -892,27 +972,32 @@ func aggregateDatums(datums []driver.MetricDatum) statAgg {
 	var a statAgg
 
 	for i := range datums {
-		d := &datums[i]
-
-		switch {
-		case d.StatisticValues != nil:
-			s := d.StatisticValues
-			a.add(s.SampleCount, s.Sum, s.Minimum, s.Maximum)
-		case len(d.Values) > 0:
-			for j, v := range d.Values {
-				count := 1.0
-				if j < len(d.Counts) {
-					count = d.Counts[j]
-				}
-
-				a.add(count, v*count, v, v)
-			}
-		default:
-			a.add(1, d.Value, d.Value, d.Value)
-		}
+		foldDatum(&a, &datums[i])
 	}
 
 	return a
+}
+
+// foldDatum folds one datum — plain Value, StatisticValues set, or Values/Counts
+// arrays — into the accumulator, matching how CloudWatch treats all three forms
+// uniformly within a series.
+func foldDatum(a *statAgg, d *driver.MetricDatum) {
+	switch {
+	case d.StatisticValues != nil:
+		s := d.StatisticValues
+		a.add(s.SampleCount, s.Sum, s.Minimum, s.Maximum)
+	case len(d.Values) > 0:
+		for j, v := range d.Values {
+			count := 1.0
+			if j < len(d.Counts) {
+				count = d.Counts[j]
+			}
+
+			a.add(count, v*count, v, v)
+		}
+	default:
+		a.add(1, d.Value, d.Value, d.Value)
+	}
 }
 
 func toAlarmInfo(a *alarmData) driver.AlarmInfo {

--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -73,7 +73,11 @@ type alarmData struct {
 	Threshold               float64
 	Period                  int
 	EvaluationPeriods       int
+	DatapointsToAlarm       int
 	Stat                    string
+	ExtendedStatistic       string
+	Unit                    string
+	TreatMissingData        string
 	State                   string
 	StateReason             string
 	StateUpdatedTimestamp   time.Time
@@ -573,7 +577,11 @@ func (m *Mock) CreateAlarm(_ context.Context, cfg driver.AlarmConfig) error {
 		Threshold:               cfg.Threshold,
 		Period:                  cfg.Period,
 		EvaluationPeriods:       cfg.EvaluationPeriods,
+		DatapointsToAlarm:       cfg.DatapointsToAlarm,
 		Stat:                    cfg.Stat,
+		ExtendedStatistic:       cfg.ExtendedStatistic,
+		Unit:                    cfg.Unit,
+		TreatMissingData:        cfg.TreatMissingData,
 		State:                   state,
 		StateReason:             stateReason,
 		StateUpdatedTimestamp:   stateUpdated,
@@ -909,7 +917,11 @@ func toAlarmInfo(a *alarmData) driver.AlarmInfo {
 		StateUpdatedTimestamp:   a.StateUpdatedTimestamp,
 		Period:                  a.Period,
 		EvaluationPeriods:       a.EvaluationPeriods,
+		DatapointsToAlarm:       a.DatapointsToAlarm,
 		Statistic:               a.Stat,
+		ExtendedStatistic:       a.ExtendedStatistic,
+		Unit:                    a.Unit,
+		TreatMissingData:        a.TreatMissingData,
 		ActionsEnabled:          a.ActionsEnabled,
 		AlarmActions:            append([]string{}, a.AlarmActions...),
 		OKActions:               append([]string{}, a.OKActions...),

--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -789,9 +789,17 @@ func (m *Mock) AlarmTags(_ context.Context, alarmName string) (map[string]string
 	return copyDims(a.Tags), nil
 }
 
-// matchDimensions returns true if the data point dimensions contain all of the
-// requested filter dimensions.
+// matchDimensions reports whether a datum belongs to the metric series a query
+// identifies. CloudWatch treats each unique combination of dimensions as a
+// separate metric, so the datum's dimension set must equal the query's exactly:
+// a query with fewer (or no) dimensions does not match a datum published with a
+// superset, and vice versa. This governs both metric reads and alarm evaluation
+// so an alarm reads only its own dimensioned metric stream.
 func matchDimensions(dataDims, filterDims map[string]string) bool {
+	if len(dataDims) != len(filterDims) {
+		return false
+	}
+
 	for k, v := range filterDims {
 		if dataDims[k] != v {
 			return false

--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -218,7 +218,7 @@ func (m *Mock) evaluateSingleAlarm(alarm *alarmData, namespace, metricName strin
 func evaluateWindow(
 	datums []driver.MetricDatum, alarm *alarmData, now time.Time,
 	periodDur time.Duration, evalPeriods, datapointsToAlarm int,
-) (string, string, bool) {
+) (state, reason string, evaluated bool) {
 	buckets := bucketByPeriod(datums, now, periodDur, evalPeriods)
 
 	breaching, present := 0, 0

--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/services/monitoring/alarmeval"
 	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
 
@@ -30,17 +31,6 @@ const (
 	stateAlarm            = "ALARM"
 	stateOK               = "OK"
 	stateInsufficientData = "INSUFFICIENT_DATA"
-)
-
-// defaultAlarmPeriodSeconds is the period assumed when an alarm omits one.
-const defaultAlarmPeriodSeconds = 60
-
-// TreatMissingData policies from PutMetricAlarm. Any other value (including the
-// empty string) is the AWS default "missing": a period with no data is simply
-// not counted toward the M-of-N rule.
-const (
-	treatMissingBreaching    = "breaching"
-	treatMissingNotBreaching = "notBreaching"
 )
 
 // historyStateUpdate is the HistoryItemType stamped on a recorded state change.
@@ -145,21 +135,6 @@ func (m *Mock) PutMetricData(_ context.Context, data []driver.MetricDatum) error
 	return nil
 }
 
-func evaluateComparison(value float64, operator string, threshold float64) bool {
-	switch operator {
-	case "GreaterThanThreshold":
-		return value > threshold
-	case "GreaterThanOrEqualToThreshold":
-		return value >= threshold
-	case "LessThanThreshold":
-		return value < threshold
-	case "LessThanOrEqualToThreshold":
-		return value <= threshold
-	default:
-		return false
-	}
-}
-
 func (m *Mock) evaluateAlarms(namespace, metricName string) {
 	allAlarms := m.alarms.All()
 
@@ -172,108 +147,34 @@ func (m *Mock) evaluateAlarms(namespace, metricName string) {
 	}
 }
 
+// alarmParams projects an alarm's thresholds onto the shared evaluator's Params.
+func alarmParams(alarm *alarmData) alarmeval.Params {
+	return alarmeval.Params{
+		Period:             alarm.Period,
+		EvaluationPeriods:  alarm.EvaluationPeriods,
+		DatapointsToAlarm:  alarm.DatapointsToAlarm,
+		Stat:               alarm.Stat,
+		ComparisonOperator: alarm.ComparisonOperator,
+		Threshold:          alarm.Threshold,
+		TreatMissingData:   alarm.TreatMissingData,
+	}
+}
+
 func (m *Mock) evaluateSingleAlarm(alarm *alarmData, namespace, metricName string) {
-	period := alarm.Period
-	if period <= 0 {
-		period = defaultAlarmPeriodSeconds
-	}
-
-	evalPeriods := alarm.EvaluationPeriods
-	if evalPeriods <= 0 {
-		evalPeriods = 1
-	}
-
-	// DatapointsToAlarm is the M in the M-of-N rule; it defaults to (and can't
-	// exceed) EvaluationPeriods.
-	datapointsToAlarm := alarm.DatapointsToAlarm
-	if datapointsToAlarm <= 0 || datapointsToAlarm > evalPeriods {
-		datapointsToAlarm = evalPeriods
-	}
-
 	now := m.opts.Clock.Now()
-	periodDur := time.Duration(period) * time.Second
-	windowStart := now.Add(-periodDur * time.Duration(evalPeriods))
+	params := alarmParams(alarm)
 
-	filtered := m.collectFilteredDatums(namespace, metricName, alarm.Dimensions, windowStart, now)
+	filtered := m.collectFilteredDatums(namespace, metricName, alarm.Dimensions, params.WindowStart(now), now)
 	if len(filtered) == 0 {
 		return
 	}
 
-	newState, reason, ok := evaluateWindow(filtered, alarm, now, periodDur, evalPeriods, datapointsToAlarm)
+	newState, reason, ok := alarmeval.EvaluateWindow(filtered, &params, now)
 	if !ok {
 		return
 	}
 
 	m.transitionAlarm(alarm, newState, reason, now)
-}
-
-// evaluateWindow applies CloudWatch's M-of-N rule. It groups the datums into the
-// last evalPeriods per-period buckets (bucket 0 is the most recent period),
-// evaluates the alarm statistic per bucket, and returns ALARM when at least
-// datapointsToAlarm buckets breach — otherwise OK, which is how an alarm recovers
-// once the breaching periods age out of the window. Empty periods are counted per
-// the alarm's TreatMissingData policy. ok is false when there is nothing to
-// evaluate (all periods missing under a non-breaching policy), leaving the state
-// unchanged rather than forcing a transition.
-func evaluateWindow(
-	datums []driver.MetricDatum, alarm *alarmData, now time.Time,
-	periodDur time.Duration, evalPeriods, datapointsToAlarm int,
-) (state, reason string, evaluated bool) {
-	buckets := bucketByPeriod(datums, now, periodDur, evalPeriods)
-
-	breaching, present := 0, 0
-
-	for _, b := range buckets {
-		switch {
-		case b != nil:
-			present++
-
-			if evaluateComparison(b.stat(alarm.Stat), alarm.ComparisonOperator, alarm.Threshold) {
-				breaching++
-			}
-		case alarm.TreatMissingData == treatMissingBreaching:
-			present++
-			breaching++
-		case alarm.TreatMissingData == treatMissingNotBreaching:
-			present++
-		}
-	}
-
-	if present == 0 {
-		return "", "", false
-	}
-
-	if breaching >= datapointsToAlarm {
-		return stateAlarm, "Threshold crossed", true
-	}
-
-	return stateOK, "Threshold not crossed", true
-}
-
-// bucketByPeriod groups datums into evalPeriods accumulators indexed by age,
-// where bucket 0 covers the most recent period. A nil bucket had no data.
-func bucketByPeriod(datums []driver.MetricDatum, now time.Time, periodDur time.Duration, evalPeriods int) []*statAgg {
-	buckets := make([]*statAgg, evalPeriods)
-
-	for i := range datums {
-		age := now.Sub(datums[i].Timestamp)
-		if age < 0 {
-			continue
-		}
-
-		idx := int(age / periodDur)
-		if idx >= evalPeriods {
-			continue
-		}
-
-		if buckets[idx] == nil {
-			buckets[idx] = &statAgg{}
-		}
-
-		foldDatum(buckets[idx], &datums[i])
-	}
-
-	return buckets
 }
 
 // transitionAlarm sets an alarm's state and — only when the state actually
@@ -403,7 +304,7 @@ func (m *Mock) collectFilteredDatums(
 			continue
 		}
 
-		if !matchDimensions(d.Dimensions, dims) {
+		if !alarmeval.MatchDimensions(d.Dimensions, dims) {
 			continue
 		}
 
@@ -451,7 +352,7 @@ func filterByTimeAndDimensions(dataPoints []driver.MetricDatum, startTime, endTi
 			continue
 		}
 
-		if !matchDimensions(d.Dimensions, dims) {
+		if !alarmeval.MatchDimensions(d.Dimensions, dims) {
 			continue
 		}
 
@@ -486,7 +387,7 @@ func buildMetricResult(filtered []driver.MetricDatum, startTime, endTime time.Ti
 			continue
 		}
 
-		s := aggregateDatums(periodDatums).stat(stat)
+		s := alarmeval.StatOf(periodDatums, stat)
 
 		result.Timestamps = append(result.Timestamps, periodStart)
 		result.Values = append(result.Values, s)
@@ -897,114 +798,6 @@ func (m *Mock) AlarmTags(_ context.Context, alarmName string) (map[string]string
 	defer m.mu.RUnlock()
 
 	return copyDims(a.Tags), nil
-}
-
-// matchDimensions reports whether a datum belongs to the metric series a query
-// identifies. CloudWatch treats each unique combination of dimensions as a
-// separate metric, so the datum's dimension set must equal the query's exactly:
-// a query with fewer (or no) dimensions does not match a datum published with a
-// superset, and vice versa. This governs both metric reads and alarm evaluation
-// so an alarm reads only its own dimensioned metric stream.
-func matchDimensions(dataDims, filterDims map[string]string) bool {
-	if len(dataDims) != len(filterDims) {
-		return false
-	}
-
-	for k, v := range filterDims {
-		if dataDims[k] != v {
-			return false
-		}
-	}
-
-	return true
-}
-
-// statAgg accumulates SampleCount / Sum / Minimum / Maximum across a set of
-// metric datums so any requested statistic can be derived. It treats a plain
-// Value, a pre-aggregated StatisticValues set, and paired Values/Counts arrays
-// uniformly, matching how real CloudWatch folds all three into one series.
-type statAgg struct {
-	count float64
-	sum   float64
-	min   float64
-	max   float64
-	seen  bool
-}
-
-// add folds one observation (or sub-aggregate) into the accumulator: count
-// samples summing to sum, whose smallest and largest observed values are low
-// and high. Non-positive counts contribute nothing, matching AWS.
-func (a *statAgg) add(count, sum, low, high float64) {
-	if count <= 0 {
-		return
-	}
-
-	a.count += count
-	a.sum += sum
-
-	if !a.seen || low < a.min {
-		a.min = low
-	}
-
-	if !a.seen || high > a.max {
-		a.max = high
-	}
-
-	a.seen = true
-}
-
-// stat returns the requested statistic, or 0 when no data was accumulated.
-func (a statAgg) stat(stat string) float64 {
-	if !a.seen {
-		return 0
-	}
-
-	switch stat {
-	case "Sum":
-		return a.sum
-	case "Min", "Minimum":
-		return a.min
-	case "Max", "Maximum":
-		return a.max
-	case "SampleCount":
-		return a.count
-	default: // "Average" or unspecified
-		return a.sum / a.count
-	}
-}
-
-// aggregateDatums folds every datum — plain Value, StatisticValues set, or
-// Values/Counts arrays — into a single accumulator.
-func aggregateDatums(datums []driver.MetricDatum) statAgg {
-	var a statAgg
-
-	for i := range datums {
-		foldDatum(&a, &datums[i])
-	}
-
-	return a
-}
-
-// foldDatum folds one datum — plain Value, StatisticValues set, or Values/Counts
-// arrays — into the accumulator, matching how CloudWatch treats all three forms
-// uniformly within a series.
-func foldDatum(a *statAgg, d *driver.MetricDatum) {
-	switch {
-	case d.StatisticValues != nil:
-		s := d.StatisticValues
-		a.add(s.SampleCount, s.Sum, s.Minimum, s.Maximum)
-	case len(d.Values) > 0:
-		for j, v := range d.Values {
-			count := 1.0
-			if j < len(d.Counts) {
-				count = d.Counts[j]
-			}
-
-			a.add(count, v*count, v, v)
-		}
-	default:
-		a.add(1, d.Value, d.Value, d.Value)
-	}
 }
 
 func toAlarmInfo(a *alarmData) driver.AlarmInfo {

--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -43,6 +43,9 @@ const (
 	treatMissingNotBreaching = "notBreaching"
 )
 
+// historyStateUpdate is the HistoryItemType stamped on a recorded state change.
+const historyStateUpdate = "StateUpdate"
+
 // ActionPublisher publishes an alarm-state-change notification to an SNS topic
 // by ARN. It is satisfied by the SNS backend's PublishExternal, mirroring the
 // S3 -> SNS notification wiring, so an alarm transition fans a message out to
@@ -301,11 +304,12 @@ func (m *Mock) appendHistory(name, oldState, newState, reason string, now time.T
 	defer m.mu.Unlock()
 
 	m.history = append(m.history, driver.AlarmHistoryEntry{
-		AlarmName: name,
-		Timestamp: now,
-		OldState:  oldState,
-		NewState:  newState,
-		Reason:    fmt.Sprintf("Transition from %s to %s: %s", oldState, newState, reason),
+		AlarmName:       name,
+		Timestamp:       now,
+		OldState:        oldState,
+		NewState:        newState,
+		HistoryItemType: historyStateUpdate,
+		Reason:          fmt.Sprintf("Transition from %s to %s: %s", oldState, newState, reason),
 	})
 }
 
@@ -801,21 +805,24 @@ func (m *Mock) ListNotificationChannels(_ context.Context) ([]driver.Notificatio
 	return result, nil
 }
 
-// GetAlarmHistory returns alarm history entries filtered by alarm name, limited by limit.
+// GetAlarmHistory returns an alarm's history entries newest-first (CloudWatch's
+// default TimestampDescending order). When limit > 0 it keeps the newest limit
+// entries. Passing limit <= 0 returns the full history so a caller can apply its
+// own filters before truncating.
 func (m *Mock) GetAlarmHistory(_ context.Context, alarmName string, limit int) ([]driver.AlarmHistoryEntry, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	var filtered []driver.AlarmHistoryEntry
 
-	for _, entry := range m.history {
-		if entry.AlarmName == alarmName {
-			filtered = append(filtered, entry)
+	for i := len(m.history) - 1; i >= 0; i-- {
+		if m.history[i].AlarmName == alarmName {
+			filtered = append(filtered, m.history[i])
 		}
 	}
 
 	if limit > 0 && len(filtered) > limit {
-		filtered = filtered[len(filtered)-limit:]
+		filtered = filtered[:limit]
 	}
 
 	return filtered, nil

--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -190,30 +190,43 @@ func (m *Mock) evaluateSingleAlarm(alarm *alarmData, namespace, metricName strin
 		reason = "Threshold not crossed"
 	}
 
+	m.transitionAlarm(alarm, newState, reason, now)
+}
+
+// transitionAlarm sets an alarm's state and — only when the state actually
+// changes — records a history entry and fires the new state's actions. This
+// matches CloudWatch, where both the history entry and the action invocation
+// happen on a state change regardless of whether the change came from metric
+// evaluation or a manual SetAlarmState. An alarm invokes its actions only when
+// it changes state; it never re-fires while the state is steady.
+func (m *Mock) transitionAlarm(alarm *alarmData, newState, reason string, now time.Time) {
 	oldState := alarm.State
 
 	if oldState != newState {
-		m.mu.Lock()
-		m.history = append(m.history, driver.AlarmHistoryEntry{
-			AlarmName: alarm.Name,
-			Timestamp: now,
-			OldState:  oldState,
-			NewState:  newState,
-			Reason:    fmt.Sprintf("Transition from %s to %s: %s", oldState, newState, reason),
-		})
-		m.mu.Unlock()
-
+		m.appendHistory(alarm.Name, oldState, newState, reason, now)
 		alarm.StateUpdatedTimestamp = now
 	}
 
 	alarm.State = newState
 	alarm.StateReason = reason
 
-	// An alarm invokes its actions only when it changes state — matching real
-	// CloudWatch, which never re-fires actions while the state is steady.
 	if oldState != newState {
 		m.fireAlarmActions(alarm, oldState, newState, now)
 	}
+}
+
+// appendHistory records one alarm state transition in the history log.
+func (m *Mock) appendHistory(name, oldState, newState, reason string, now time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.history = append(m.history, driver.AlarmHistoryEntry{
+		AlarmName: name,
+		Timestamp: now,
+		OldState:  oldState,
+		NewState:  newState,
+		Reason:    fmt.Sprintf("Transition from %s to %s: %s", oldState, newState, reason),
+	})
 }
 
 // fireAlarmActions delivers an alarm's state-change actions. Only SNS-topic
@@ -635,16 +648,18 @@ func (m *Mock) DescribeAlarms(_ context.Context, names []string) ([]driver.Alarm
 	return result, nil
 }
 
-// SetAlarmState manually sets the state of an alarm.
+// SetAlarmState manually sets the state of an alarm. Like a metric-driven
+// transition, a state change records a history entry and invokes the actions
+// configured for the new state (AlarmActions / OKActions /
+// InsufficientDataActions), so the documented "force ALARM to test wiring"
+// workflow delivers its notifications.
 func (m *Mock) SetAlarmState(_ context.Context, name, state, reason string) error {
 	a, ok := m.alarms.Get(name)
 	if !ok {
 		return errors.Newf(errors.NotFound, "alarm %q not found", name)
 	}
 
-	a.State = state
-	a.StateReason = reason
-	a.StateUpdatedTimestamp = m.opts.Clock.Now()
+	m.transitionAlarm(a, state, reason, m.opts.Clock.Now())
 
 	return nil
 }

--- a/providers/aws/cloudwatch/cloudwatch_test.go
+++ b/providers/aws/cloudwatch/cloudwatch_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/services/monitoring/alarmeval"
 	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
 
@@ -316,7 +317,7 @@ func TestAlarmEvaluationOperators(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := evaluateComparison(tc.value, tc.operator, tc.thresh)
+			result := alarmeval.EvaluateComparison(tc.value, tc.operator, tc.thresh)
 			assertEqual(t, tc.expect, result)
 		})
 	}

--- a/providers/azure/monitor/alarm_fidelity_test.go
+++ b/providers/azure/monitor/alarm_fidelity_test.go
@@ -1,0 +1,121 @@
+package monitor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExactDimensionMatching covers the exact-dimension parity fix: a metric
+// published with a dimension is a distinct series from the no-dimension metric.
+func TestExactDimensionMatching(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newTestMock()
+
+	require.NoError(t, m.PutMetricData(ctx, []driver.MetricDatum{{
+		Namespace: "Microsoft.Compute", MetricName: "Latency", Value: 42, Timestamp: clk.Now(),
+		Dimensions: map[string]string{"vm": "web-1"},
+	}}))
+
+	read := func(dims map[string]string) *driver.MetricDataResult {
+		t.Helper()
+
+		res, err := m.GetMetricData(ctx, driver.GetMetricInput{
+			Namespace: "Microsoft.Compute", MetricName: "Latency", Dimensions: dims,
+			StartTime: clk.Now().Add(-time.Hour), EndTime: clk.Now().Add(time.Hour), Period: 60, Stat: "Sum",
+		})
+		require.NoError(t, err)
+
+		return res
+	}
+
+	assert.Empty(t, read(nil).Values, "no-dimension query must not match a dimensioned metric")
+
+	exact := read(map[string]string{"vm": "web-1"})
+	require.Len(t, exact.Values, 1)
+	assert.Equal(t, 42.0, exact.Values[0])
+}
+
+// TestAlarmMOfNAndRecovery covers the per-period M-of-N parity fix: 3 of 3
+// periods must breach for ALARM (not the window average), with recovery to OK.
+func TestAlarmMOfNAndRecovery(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newTestMock()
+
+	require.NoError(t, m.CreateAlarm(ctx, driver.AlarmConfig{
+		Name: "m-of-n", Namespace: "Microsoft.Compute", MetricName: "Load",
+		ComparisonOperator: "GreaterThanThreshold", Threshold: 10,
+		Period: 60, EvaluationPeriods: 3, DatapointsToAlarm: 3, Stat: "Average",
+	}))
+
+	feed := func(vals ...float64) {
+		t.Helper()
+
+		data := make([]driver.MetricDatum, 0, len(vals))
+		for i, v := range vals {
+			age := time.Duration(len(vals)-1-i) * 60 * time.Second
+			data = append(data, driver.MetricDatum{
+				Namespace: "Microsoft.Compute", MetricName: "Load", Value: v, Timestamp: clk.Now().Add(-age),
+			})
+		}
+
+		require.NoError(t, m.PutMetricData(ctx, data))
+	}
+
+	state := func() string {
+		t.Helper()
+
+		alarms, err := m.DescribeAlarms(ctx, []string{"m-of-n"})
+		require.NoError(t, err)
+		require.Len(t, alarms, 1)
+
+		return alarms[0].State
+	}
+
+	feed(0, 0, 100)
+	assert.Equal(t, "OK", state(), "only 1 of 3 periods breaches")
+
+	clk.Advance(time.Hour)
+	feed(100, 100, 100)
+	assert.Equal(t, "ALARM", state(), "all 3 periods breach")
+
+	clk.Advance(time.Hour)
+	feed(0, 0, 0)
+	assert.Equal(t, "OK", state(), "recovery once breaching periods age out")
+}
+
+// TestAlarmHistoryNewestFirst covers the ordering parity fix: history is
+// newest-first and SetAlarmState records a transition.
+func TestAlarmHistoryNewestFirst(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newTestMock()
+
+	require.NoError(t, m.CreateAlarm(ctx, driver.AlarmConfig{
+		Name: "hist", Namespace: "Microsoft.Compute", MetricName: "Load",
+		ComparisonOperator: "GreaterThanThreshold", Threshold: 1, Period: 60, EvaluationPeriods: 1, Stat: "Average",
+	}))
+
+	for _, s := range []string{"ALARM", "OK", "ALARM"} {
+		require.NoError(t, m.SetAlarmState(ctx, "hist", s, "step"))
+		clk.Advance(time.Minute)
+	}
+
+	hist, err := m.GetAlarmHistory(ctx, "hist", 0)
+	require.NoError(t, err)
+	require.Len(t, hist, 3)
+
+	for i := 1; i < len(hist); i++ {
+		assert.Falsef(t, hist[i-1].Timestamp.Before(hist[i].Timestamp),
+			"history not newest-first at %d", i)
+	}
+	assert.Equal(t, "ALARM", hist[0].NewState, "newest transition first")
+
+	limited, err := m.GetAlarmHistory(ctx, "hist", 1)
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
+	assert.True(t, limited[0].Timestamp.Equal(hist[0].Timestamp), "limit keeps the newest entry")
+}

--- a/providers/azure/monitor/monitor.go
+++ b/providers/azure/monitor/monitor.go
@@ -14,8 +14,12 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/services/monitoring/alarmeval"
 	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
+
+// historyStateUpdate is the HistoryItemType stamped on a recorded state change.
+const historyStateUpdate = "StateUpdate"
 
 // Compile-time check that Mock implements driver.Monitoring.
 var _ driver.Monitoring = (*Mock)(nil)
@@ -36,9 +40,14 @@ type alarmData struct {
 	Threshold               float64
 	Period                  int
 	EvaluationPeriods       int
+	DatapointsToAlarm       int
 	Stat                    string
+	ExtendedStatistic       string
+	Unit                    string
+	TreatMissingData        string
 	State                   string
 	StateReason             string
+	StateUpdatedTimestamp   time.Time
 	AlarmActions            []string
 	OKActions               []string
 	InsufficientDataActions []string
@@ -71,43 +80,28 @@ func (m *Mock) PutMetricData(_ context.Context, data []driver.MetricDatum) error
 	}
 
 	m.mu.Lock()
-	for _, d := range data {
+	for i := range data {
 		key := metricKey{
-			Namespace:  d.Namespace,
-			MetricName: d.MetricName,
+			Namespace:  data[i].Namespace,
+			MetricName: data[i].MetricName,
 		}
-		m.metrics[key] = append(m.metrics[key], d)
+		m.metrics[key] = append(m.metrics[key], data[i])
 	}
 	m.mu.Unlock()
 
 	// Evaluate alarms for each unique namespace/metric pair that was updated.
 	seen := make(map[metricKey]bool)
 
-	for _, d := range data {
-		mk := metricKey{Namespace: d.Namespace, MetricName: d.MetricName}
+	for i := range data {
+		mk := metricKey{Namespace: data[i].Namespace, MetricName: data[i].MetricName}
 		if !seen[mk] {
 			seen[mk] = true
 
-			m.evaluateAlarms(d.Namespace, d.MetricName)
+			m.evaluateAlarms(data[i].Namespace, data[i].MetricName)
 		}
 	}
 
 	return nil
-}
-
-func evaluateComparison(value float64, operator string, threshold float64) bool {
-	switch operator {
-	case "GreaterThanThreshold":
-		return value > threshold
-	case "GreaterThanOrEqualToThreshold":
-		return value >= threshold
-	case "LessThanThreshold":
-		return value < threshold
-	case "LessThanOrEqualToThreshold":
-		return value <= threshold
-	default:
-		return false
-	}
 }
 
 func (m *Mock) evaluateAlarms(namespace, metricName string) {
@@ -122,64 +116,81 @@ func (m *Mock) evaluateAlarms(namespace, metricName string) {
 	}
 }
 
+// alarmParams projects an alert rule's thresholds onto the shared evaluator's Params.
+func alarmParams(alarm *alarmData) alarmeval.Params {
+	return alarmeval.Params{
+		Period:             alarm.Period,
+		EvaluationPeriods:  alarm.EvaluationPeriods,
+		DatapointsToAlarm:  alarm.DatapointsToAlarm,
+		Stat:               alarm.Stat,
+		ComparisonOperator: alarm.ComparisonOperator,
+		Threshold:          alarm.Threshold,
+		TreatMissingData:   alarm.TreatMissingData,
+	}
+}
+
 func (m *Mock) evaluateSingleAlarm(alarm *alarmData, namespace, metricName string) {
-	period := alarm.Period
-	if period <= 0 {
-		period = 60
-	}
-
-	evalPeriods := alarm.EvaluationPeriods
-	if evalPeriods <= 0 {
-		evalPeriods = 1
-	}
-
 	now := m.opts.Clock.Now()
-	windowDur := time.Duration(period*evalPeriods) * time.Second
-	windowStart := now.Add(-windowDur)
+	params := alarmParams(alarm)
 
-	filtered := m.collectFilteredValues(namespace, metricName, alarm.Dimensions, windowStart, now)
-
+	filtered := m.collectFilteredDatums(namespace, metricName, alarm.Dimensions, params.WindowStart(now), now)
 	if len(filtered) == 0 {
 		return
 	}
 
-	stat := computeStat(filtered, alarm.Stat)
-
-	var newState, reason string
-	if evaluateComparison(stat, alarm.ComparisonOperator, alarm.Threshold) {
-		newState = "ALARM"
-		reason = "Threshold crossed"
-	} else {
-		newState = "OK"
-		reason = "Threshold not crossed"
+	newState, reason, ok := alarmeval.EvaluateWindow(filtered, &params, now)
+	if !ok {
+		return
 	}
 
-	if alarm.State != newState {
-		m.mu.Lock()
-		m.history = append(m.history, driver.AlarmHistoryEntry{
-			AlarmName: alarm.Name,
-			Timestamp: now,
-			OldState:  alarm.State,
-			NewState:  newState,
-			Reason:    fmt.Sprintf("Transition from %s to %s: %s", alarm.State, newState, reason),
-		})
-		m.mu.Unlock()
+	m.transitionAlarm(alarm, newState, reason, now)
+}
+
+// transitionAlarm sets an alert rule's state and, only on a state change, records
+// a history entry — mirroring CloudWatch, where the history entry happens on a
+// state change whether it came from metric evaluation or a manual SetAlarmState.
+// Azure Monitor action groups aren't delivered by the emulator (no publisher is
+// wired), so the state's actions are a no-op beyond the recorded transition.
+func (m *Mock) transitionAlarm(alarm *alarmData, newState, reason string, now time.Time) {
+	oldState := alarm.State
+
+	if oldState != newState {
+		m.appendHistory(alarm.Name, oldState, newState, reason, now)
+		alarm.StateUpdatedTimestamp = now
 	}
 
 	alarm.State = newState
 	alarm.StateReason = reason
 }
 
-func (m *Mock) collectFilteredValues(namespace, metricName string, dims map[string]string, windowStart, now time.Time) []float64 {
+// appendHistory records one alert rule state transition in the history log.
+func (m *Mock) appendHistory(name, oldState, newState, reason string, now time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.history = append(m.history, driver.AlarmHistoryEntry{
+		AlarmName:       name,
+		Timestamp:       now,
+		OldState:        oldState,
+		NewState:        newState,
+		HistoryItemType: historyStateUpdate,
+		Reason:          fmt.Sprintf("Transition from %s to %s: %s", oldState, newState, reason),
+	})
+}
+
+func (m *Mock) collectFilteredDatums(
+	namespace, metricName string, dims map[string]string, windowStart, now time.Time,
+) []driver.MetricDatum {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	key := metricKey{Namespace: namespace, MetricName: metricName}
 	dataPoints := m.metrics[key]
 
-	var filtered []float64
+	var filtered []driver.MetricDatum
 
-	for _, d := range dataPoints {
+	for i := range dataPoints {
+		d := &dataPoints[i]
 		if d.Timestamp.Before(windowStart) || d.Timestamp.After(now) {
 			continue
 		}
@@ -188,7 +199,7 @@ func (m *Mock) collectFilteredValues(namespace, metricName string, dims map[stri
 			continue
 		}
 
-		filtered = append(filtered, d.Value)
+		filtered = append(filtered, *d)
 	}
 
 	return filtered
@@ -226,7 +237,8 @@ func (m *Mock) GetMetricData(_ context.Context, input driver.GetMetricInput) (*d
 func filterByTimeAndDimensions(dataPoints []driver.MetricDatum, startTime, endTime time.Time, dims map[string]string) []driver.MetricDatum {
 	var filtered []driver.MetricDatum
 
-	for _, d := range dataPoints {
+	for i := range dataPoints {
+		d := &dataPoints[i]
 		if d.Timestamp.Before(startTime) || !d.Timestamp.Before(endTime) {
 			continue
 		}
@@ -235,7 +247,7 @@ func filterByTimeAndDimensions(dataPoints []driver.MetricDatum, startTime, endTi
 			continue
 		}
 
-		filtered = append(filtered, d)
+		filtered = append(filtered, *d)
 	}
 
 	return filtered
@@ -279,9 +291,9 @@ func buildMetricResult(filtered []driver.MetricDatum, startTime, endTime time.Ti
 func collectPeriodValues(filtered []driver.MetricDatum, periodStart, periodEnd time.Time) []float64 {
 	var values []float64
 
-	for _, d := range filtered {
-		if !d.Timestamp.Before(periodStart) && d.Timestamp.Before(periodEnd) {
-			values = append(values, d.Value)
+	for i := range filtered {
+		if !filtered[i].Timestamp.Before(periodStart) && filtered[i].Timestamp.Before(periodEnd) {
+			values = append(values, filtered[i].Value)
 		}
 	}
 
@@ -333,7 +345,11 @@ func (m *Mock) CreateAlarm(_ context.Context, cfg driver.AlarmConfig) error {
 		Threshold:               cfg.Threshold,
 		Period:                  cfg.Period,
 		EvaluationPeriods:       cfg.EvaluationPeriods,
+		DatapointsToAlarm:       cfg.DatapointsToAlarm,
 		Stat:                    cfg.Stat,
+		ExtendedStatistic:       cfg.ExtendedStatistic,
+		Unit:                    cfg.Unit,
+		TreatMissingData:        cfg.TreatMissingData,
 		State:                   "INSUFFICIENT_DATA",
 		AlarmActions:            append([]string{}, cfg.AlarmActions...),
 		OKActions:               append([]string{}, cfg.OKActions...),
@@ -381,15 +397,15 @@ func (m *Mock) DescribeAlarms(_ context.Context, names []string) ([]driver.Alarm
 	return result, nil
 }
 
-// SetAlarmState manually sets the state of a metric alert rule.
+// SetAlarmState manually sets the state of a metric alert rule. Like a
+// metric-driven transition, a state change records a history entry.
 func (m *Mock) SetAlarmState(_ context.Context, name, state, reason string) error {
 	a, ok := m.alarms.Get(name)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "alarm %q not found", name)
 	}
 
-	a.State = state
-	a.StateReason = reason
+	m.transitionAlarm(a, state, reason, m.opts.Clock.Now())
 
 	return nil
 }
@@ -451,21 +467,23 @@ func (m *Mock) ListNotificationChannels(_ context.Context) ([]driver.Notificatio
 	return result, nil
 }
 
-// GetAlarmHistory returns alarm history entries filtered by alarm name, limited by limit.
+// GetAlarmHistory returns an alert rule's history entries newest-first (matching
+// CloudWatch's default TimestampDescending order); when limit > 0 it keeps the
+// newest limit entries.
 func (m *Mock) GetAlarmHistory(_ context.Context, alarmName string, limit int) ([]driver.AlarmHistoryEntry, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	var filtered []driver.AlarmHistoryEntry
 
-	for _, entry := range m.history {
-		if entry.AlarmName == alarmName {
-			filtered = append(filtered, entry)
+	for i := len(m.history) - 1; i >= 0; i-- {
+		if m.history[i].AlarmName == alarmName {
+			filtered = append(filtered, m.history[i])
 		}
 	}
 
 	if limit > 0 && len(filtered) > limit {
-		filtered = filtered[len(filtered)-limit:]
+		filtered = filtered[:limit]
 	}
 
 	return filtered, nil
@@ -479,6 +497,14 @@ func (m *Mock) GetAlarmHistory(_ context.Context, alarmName string, limit int) (
 // id can legitimately differ between how a resource was minted and how a
 // caller's request path addresses it.
 func matchDimensions(dataDims, filterDims map[string]string) bool {
+	// Azure Monitor, like CloudWatch, treats each unique dimension combination as
+	// a separate metric, so the sets must match exactly (a query with fewer/no
+	// dimensions does not match a datum published with a superset). The resourceId
+	// dimension is still compared subscription-agnostically per resourceIDMatch.
+	if len(dataDims) != len(filterDims) {
+		return false
+	}
+
 	for k, v := range filterDims {
 		if k == "resourceId" {
 			if !resourceIDMatch(dataDims[k], v) {
@@ -590,9 +616,14 @@ func toAlarmInfo(a *alarmData) driver.AlarmInfo {
 		ComparisonOperator:      a.ComparisonOperator,
 		Threshold:               a.Threshold,
 		StateReason:             a.StateReason,
+		StateUpdatedTimestamp:   a.StateUpdatedTimestamp,
 		Period:                  a.Period,
 		EvaluationPeriods:       a.EvaluationPeriods,
+		DatapointsToAlarm:       a.DatapointsToAlarm,
 		Statistic:               a.Stat,
+		ExtendedStatistic:       a.ExtendedStatistic,
+		Unit:                    a.Unit,
+		TreatMissingData:        a.TreatMissingData,
 		AlarmActions:            append([]string{}, a.AlarmActions...),
 		OKActions:               append([]string{}, a.OKActions...),
 		InsufficientDataActions: append([]string{}, a.InsufficientDataActions...),

--- a/providers/gcp/monitoring/alarm_fidelity_test.go
+++ b/providers/gcp/monitoring/alarm_fidelity_test.go
@@ -1,0 +1,121 @@
+package monitoring
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExactDimensionMatching covers the exact-dimension parity fix: a metric
+// published with a label is a distinct series from the label-less metric.
+func TestExactDimensionMatching(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newTestMock()
+
+	require.NoError(t, m.PutMetricData(ctx, []driver.MetricDatum{{
+		Namespace: "compute.googleapis.com", MetricName: "latency", Value: 42, Timestamp: clk.Now(),
+		Dimensions: map[string]string{"instance_id": "i-1"},
+	}}))
+
+	read := func(dims map[string]string) *driver.MetricDataResult {
+		t.Helper()
+
+		res, err := m.GetMetricData(ctx, driver.GetMetricInput{
+			Namespace: "compute.googleapis.com", MetricName: "latency", Dimensions: dims,
+			StartTime: clk.Now().Add(-time.Hour), EndTime: clk.Now().Add(time.Hour), Period: 60, Stat: "Sum",
+		})
+		require.NoError(t, err)
+
+		return res
+	}
+
+	assert.Empty(t, read(nil).Values, "no-label query must not match a labeled metric")
+
+	exact := read(map[string]string{"instance_id": "i-1"})
+	require.Len(t, exact.Values, 1)
+	assert.Equal(t, 42.0, exact.Values[0])
+}
+
+// TestAlarmMOfNAndRecovery covers the per-period M-of-N parity fix: 3 of 3
+// periods must breach for ALARM (not the window average), with recovery to OK.
+func TestAlarmMOfNAndRecovery(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newTestMock()
+
+	require.NoError(t, m.CreateAlarm(ctx, driver.AlarmConfig{
+		Name: "m-of-n", Namespace: "compute.googleapis.com", MetricName: "load",
+		ComparisonOperator: "GreaterThanThreshold", Threshold: 10,
+		Period: 60, EvaluationPeriods: 3, DatapointsToAlarm: 3, Stat: "Average",
+	}))
+
+	feed := func(vals ...float64) {
+		t.Helper()
+
+		data := make([]driver.MetricDatum, 0, len(vals))
+		for i, v := range vals {
+			age := time.Duration(len(vals)-1-i) * 60 * time.Second
+			data = append(data, driver.MetricDatum{
+				Namespace: "compute.googleapis.com", MetricName: "load", Value: v, Timestamp: clk.Now().Add(-age),
+			})
+		}
+
+		require.NoError(t, m.PutMetricData(ctx, data))
+	}
+
+	state := func() string {
+		t.Helper()
+
+		alarms, err := m.DescribeAlarms(ctx, []string{"m-of-n"})
+		require.NoError(t, err)
+		require.Len(t, alarms, 1)
+
+		return alarms[0].State
+	}
+
+	feed(0, 0, 100)
+	assert.Equal(t, "OK", state(), "only 1 of 3 periods breaches")
+
+	clk.Advance(time.Hour)
+	feed(100, 100, 100)
+	assert.Equal(t, "ALARM", state(), "all 3 periods breach")
+
+	clk.Advance(time.Hour)
+	feed(0, 0, 0)
+	assert.Equal(t, "OK", state(), "recovery once breaching periods age out")
+}
+
+// TestAlarmHistoryNewestFirst covers the ordering parity fix: history is
+// newest-first and SetAlarmState records a transition.
+func TestAlarmHistoryNewestFirst(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newTestMock()
+
+	require.NoError(t, m.CreateAlarm(ctx, driver.AlarmConfig{
+		Name: "hist", Namespace: "compute.googleapis.com", MetricName: "load",
+		ComparisonOperator: "GreaterThanThreshold", Threshold: 1, Period: 60, EvaluationPeriods: 1, Stat: "Average",
+	}))
+
+	for _, s := range []string{"ALARM", "OK", "ALARM"} {
+		require.NoError(t, m.SetAlarmState(ctx, "hist", s, "step"))
+		clk.Advance(time.Minute)
+	}
+
+	hist, err := m.GetAlarmHistory(ctx, "hist", 0)
+	require.NoError(t, err)
+	require.Len(t, hist, 3)
+
+	for i := 1; i < len(hist); i++ {
+		assert.Falsef(t, hist[i-1].Timestamp.Before(hist[i].Timestamp),
+			"history not newest-first at %d", i)
+	}
+	assert.Equal(t, "ALARM", hist[0].NewState, "newest transition first")
+
+	limited, err := m.GetAlarmHistory(ctx, "hist", 1)
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
+	assert.True(t, limited[0].Timestamp.Equal(hist[0].Timestamp), "limit keeps the newest entry")
+}

--- a/providers/gcp/monitoring/monitoring.go
+++ b/providers/gcp/monitoring/monitoring.go
@@ -13,8 +13,12 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/services/monitoring/alarmeval"
 	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
+
+// historyStateUpdate is the HistoryItemType stamped on a recorded state change.
+const historyStateUpdate = "StateUpdate"
 
 // Compile-time check that Mock implements driver.Monitoring.
 var _ driver.Monitoring = (*Mock)(nil)
@@ -35,9 +39,14 @@ type alarmData struct {
 	Threshold               float64
 	Period                  int
 	EvaluationPeriods       int
+	DatapointsToAlarm       int
 	Stat                    string
+	ExtendedStatistic       string
+	Unit                    string
+	TreatMissingData        string
 	State                   string
 	StateReason             string
+	StateUpdatedTimestamp   time.Time
 	AlarmActions            []string
 	OKActions               []string
 	InsufficientDataActions []string
@@ -82,31 +91,16 @@ func (m *Mock) PutMetricData(_ context.Context, data []driver.MetricDatum) error
 	// Evaluate alarms for each unique namespace/metric pair that was updated.
 	seen := make(map[metricKey]bool)
 
-	for _, d := range data {
-		mk := metricKey{Namespace: d.Namespace, MetricName: d.MetricName}
+	for i := range data {
+		mk := metricKey{Namespace: data[i].Namespace, MetricName: data[i].MetricName}
 		if !seen[mk] {
 			seen[mk] = true
 
-			m.evaluateAlarms(d.Namespace, d.MetricName)
+			m.evaluateAlarms(data[i].Namespace, data[i].MetricName)
 		}
 	}
 
 	return nil
-}
-
-func evaluateComparison(value float64, operator string, threshold float64) bool {
-	switch operator {
-	case "GreaterThanThreshold":
-		return value > threshold
-	case "GreaterThanOrEqualToThreshold":
-		return value >= threshold
-	case "LessThanThreshold":
-		return value < threshold
-	case "LessThanOrEqualToThreshold":
-		return value <= threshold
-	default:
-		return false
-	}
 }
 
 func (m *Mock) evaluateAlarms(namespace, metricName string) {
@@ -121,73 +115,91 @@ func (m *Mock) evaluateAlarms(namespace, metricName string) {
 	}
 }
 
+// alarmParams projects an alert policy's thresholds onto the shared evaluator's Params.
+func alarmParams(alarm *alarmData) alarmeval.Params {
+	return alarmeval.Params{
+		Period:             alarm.Period,
+		EvaluationPeriods:  alarm.EvaluationPeriods,
+		DatapointsToAlarm:  alarm.DatapointsToAlarm,
+		Stat:               alarm.Stat,
+		ComparisonOperator: alarm.ComparisonOperator,
+		Threshold:          alarm.Threshold,
+		TreatMissingData:   alarm.TreatMissingData,
+	}
+}
+
 func (m *Mock) evaluateSingleAlarm(alarm *alarmData, namespace, metricName string) {
-	period := alarm.Period
-	if period <= 0 {
-		period = 60
-	}
-
-	evalPeriods := alarm.EvaluationPeriods
-	if evalPeriods <= 0 {
-		evalPeriods = 1
-	}
-
 	now := m.opts.Clock.Now()
-	windowDur := time.Duration(period*evalPeriods) * time.Second
-	windowStart := now.Add(-windowDur)
+	params := alarmParams(alarm)
 
-	filtered := m.collectFilteredValues(namespace, metricName, alarm.Dimensions, windowStart, now)
-
+	filtered := m.collectFilteredDatums(namespace, metricName, alarm.Dimensions, params.WindowStart(now), now)
 	if len(filtered) == 0 {
 		return
 	}
 
-	stat := computeStat(filtered, alarm.Stat)
-
-	var newState, reason string
-	if evaluateComparison(stat, alarm.ComparisonOperator, alarm.Threshold) {
-		newState = "ALARM"
-		reason = "Threshold crossed"
-	} else {
-		newState = "OK"
-		reason = "Threshold not crossed"
+	newState, reason, ok := alarmeval.EvaluateWindow(filtered, &params, now)
+	if !ok {
+		return
 	}
 
-	if alarm.State != newState {
-		m.mu.Lock()
-		m.history = append(m.history, driver.AlarmHistoryEntry{
-			AlarmName: alarm.Name,
-			Timestamp: now,
-			OldState:  alarm.State,
-			NewState:  newState,
-			Reason:    fmt.Sprintf("Transition from %s to %s: %s", alarm.State, newState, reason),
-		})
-		m.mu.Unlock()
+	m.transitionAlarm(alarm, newState, reason, now)
+}
+
+// transitionAlarm sets an alert policy's state and, only on a state change,
+// records a history entry — mirroring CloudWatch, where the history entry happens
+// on a state change whether it came from metric evaluation or a manual
+// SetAlarmState. Cloud Monitoring notification channels aren't delivered by the
+// emulator (no publisher is wired), so the state's actions are a no-op beyond the
+// recorded transition.
+func (m *Mock) transitionAlarm(alarm *alarmData, newState, reason string, now time.Time) {
+	oldState := alarm.State
+
+	if oldState != newState {
+		m.appendHistory(alarm.Name, oldState, newState, reason, now)
+		alarm.StateUpdatedTimestamp = now
 	}
 
 	alarm.State = newState
 	alarm.StateReason = reason
 }
 
-func (m *Mock) collectFilteredValues(namespace, metricName string, dims map[string]string, windowStart, now time.Time) []float64 {
+// appendHistory records one alert policy state transition in the history log.
+func (m *Mock) appendHistory(name, oldState, newState, reason string, now time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.history = append(m.history, driver.AlarmHistoryEntry{
+		AlarmName:       name,
+		Timestamp:       now,
+		OldState:        oldState,
+		NewState:        newState,
+		HistoryItemType: historyStateUpdate,
+		Reason:          fmt.Sprintf("Transition from %s to %s: %s", oldState, newState, reason),
+	})
+}
+
+func (m *Mock) collectFilteredDatums(
+	namespace, metricName string, dims map[string]string, windowStart, now time.Time,
+) []driver.MetricDatum {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	key := metricKey{Namespace: namespace, MetricName: metricName}
 	dataPoints := m.metrics[key]
 
-	var filtered []float64
+	var filtered []driver.MetricDatum
 
-	for _, d := range dataPoints {
+	for i := range dataPoints {
+		d := &dataPoints[i]
 		if d.Timestamp.Before(windowStart) || d.Timestamp.After(now) {
 			continue
 		}
 
-		if !matchDimensions(d.Dimensions, dims) {
+		if !alarmeval.MatchDimensions(d.Dimensions, dims) {
 			continue
 		}
 
-		filtered = append(filtered, d.Value)
+		filtered = append(filtered, *d)
 	}
 
 	return filtered
@@ -225,16 +237,17 @@ func (m *Mock) GetMetricData(_ context.Context, input driver.GetMetricInput) (*d
 func filterByTimeAndDimensions(dataPoints []driver.MetricDatum, startTime, endTime time.Time, dims map[string]string) []driver.MetricDatum {
 	var filtered []driver.MetricDatum
 
-	for _, d := range dataPoints {
+	for i := range dataPoints {
+		d := &dataPoints[i]
 		if d.Timestamp.Before(startTime) || !d.Timestamp.Before(endTime) {
 			continue
 		}
 
-		if !matchDimensions(d.Dimensions, dims) {
+		if !alarmeval.MatchDimensions(d.Dimensions, dims) {
 			continue
 		}
 
-		filtered = append(filtered, d)
+		filtered = append(filtered, *d)
 	}
 
 	return filtered
@@ -278,9 +291,9 @@ func buildMetricResult(filtered []driver.MetricDatum, startTime, endTime time.Ti
 func collectPeriodValues(filtered []driver.MetricDatum, periodStart, periodEnd time.Time) []float64 {
 	var values []float64
 
-	for _, d := range filtered {
-		if !d.Timestamp.Before(periodStart) && d.Timestamp.Before(periodEnd) {
-			values = append(values, d.Value)
+	for i := range filtered {
+		if !filtered[i].Timestamp.Before(periodStart) && filtered[i].Timestamp.Before(periodEnd) {
+			values = append(values, filtered[i].Value)
 		}
 	}
 
@@ -369,7 +382,11 @@ func (m *Mock) CreateAlarm(_ context.Context, cfg driver.AlarmConfig) error {
 		Threshold:               cfg.Threshold,
 		Period:                  cfg.Period,
 		EvaluationPeriods:       cfg.EvaluationPeriods,
+		DatapointsToAlarm:       cfg.DatapointsToAlarm,
 		Stat:                    cfg.Stat,
+		ExtendedStatistic:       cfg.ExtendedStatistic,
+		Unit:                    cfg.Unit,
+		TreatMissingData:        cfg.TreatMissingData,
 		State:                   "INSUFFICIENT_DATA",
 		AlarmActions:            append([]string{}, cfg.AlarmActions...),
 		OKActions:               append([]string{}, cfg.OKActions...),
@@ -417,15 +434,15 @@ func (m *Mock) DescribeAlarms(_ context.Context, names []string) ([]driver.Alarm
 	return result, nil
 }
 
-// SetAlarmState manually sets the state of an alert policy.
+// SetAlarmState manually sets the state of an alert policy. Like a metric-driven
+// transition, a state change records a history entry.
 func (m *Mock) SetAlarmState(_ context.Context, name, state, reason string) error {
 	a, ok := m.alarms.Get(name)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "alert policy %q not found", name)
 	}
 
-	a.State = state
-	a.StateReason = reason
+	m.transitionAlarm(a, state, reason, m.opts.Clock.Now())
 
 	return nil
 }
@@ -487,36 +504,26 @@ func (m *Mock) ListNotificationChannels(_ context.Context) ([]driver.Notificatio
 	return result, nil
 }
 
-// GetAlarmHistory returns alarm history entries filtered by alarm name, limited by limit.
+// GetAlarmHistory returns an alert policy's history entries newest-first (matching
+// CloudWatch's default TimestampDescending order); when limit > 0 it keeps the
+// newest limit entries.
 func (m *Mock) GetAlarmHistory(_ context.Context, alarmName string, limit int) ([]driver.AlarmHistoryEntry, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	var filtered []driver.AlarmHistoryEntry
 
-	for _, entry := range m.history {
-		if entry.AlarmName == alarmName {
-			filtered = append(filtered, entry)
+	for i := len(m.history) - 1; i >= 0; i-- {
+		if m.history[i].AlarmName == alarmName {
+			filtered = append(filtered, m.history[i])
 		}
 	}
 
 	if limit > 0 && len(filtered) > limit {
-		filtered = filtered[len(filtered)-limit:]
+		filtered = filtered[:limit]
 	}
 
 	return filtered, nil
-}
-
-// matchDimensions returns true if the data point dimensions (labels) contain all of the
-// requested filter dimensions.
-func matchDimensions(dataDims, filterDims map[string]string) bool {
-	for k, v := range filterDims {
-		if dataDims[k] != v {
-			return false
-		}
-	}
-
-	return true
 }
 
 // computeStat computes the requested statistic (aligner) over a slice of values.
@@ -574,12 +581,30 @@ func maxValue(values []float64) float64 {
 }
 
 func toAlarmInfo(a *alarmData) driver.AlarmInfo {
+	dims := make(map[string]string, len(a.Dimensions))
+	for k, v := range a.Dimensions {
+		dims[k] = v
+	}
+
 	return driver.AlarmInfo{
-		Name:               a.Name,
-		Namespace:          a.Namespace,
-		MetricName:         a.MetricName,
-		State:              a.State,
-		ComparisonOperator: a.ComparisonOperator,
-		Threshold:          a.Threshold,
+		Name:                    a.Name,
+		Namespace:               a.Namespace,
+		MetricName:              a.MetricName,
+		State:                   a.State,
+		ComparisonOperator:      a.ComparisonOperator,
+		Threshold:               a.Threshold,
+		StateReason:             a.StateReason,
+		StateUpdatedTimestamp:   a.StateUpdatedTimestamp,
+		Period:                  a.Period,
+		EvaluationPeriods:       a.EvaluationPeriods,
+		DatapointsToAlarm:       a.DatapointsToAlarm,
+		Statistic:               a.Stat,
+		ExtendedStatistic:       a.ExtendedStatistic,
+		Unit:                    a.Unit,
+		TreatMissingData:        a.TreatMissingData,
+		AlarmActions:            append([]string{}, a.AlarmActions...),
+		OKActions:               append([]string{}, a.OKActions...),
+		InsufficientDataActions: append([]string{}, a.InsufficientDataActions...),
+		Dimensions:              dims,
 	}
 }

--- a/providers/gcp/monitoring/monitoring_test.go
+++ b/providers/gcp/monitoring/monitoring_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/services/monitoring/alarmeval"
 	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -263,7 +264,7 @@ func TestEvaluateComparison(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, evaluateComparison(tt.value, tt.operator, tt.thresh))
+			assert.Equal(t, tt.want, alarmeval.EvaluateComparison(tt.value, tt.operator, tt.thresh))
 		})
 	}
 }

--- a/server/aws/cloudwatch/alarm_fidelity_test.go
+++ b/server/aws/cloudwatch/alarm_fidelity_test.go
@@ -1,0 +1,422 @@
+package cloudwatch_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awscw "github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cwprovider "github.com/stackshy/cloudemu/v2/providers/aws/cloudwatch"
+	cwserver "github.com/stackshy/cloudemu/v2/server/aws/cloudwatch"
+)
+
+// newCWClientClock wires the real aws-sdk-go-v2 CloudWatch client at a handler
+// backed by a provider using the given clock, so alarm evaluation (which reads
+// the clock) is deterministic across per-period bucketing tests.
+func newCWClientClock(t *testing.T, clock config.Clock) (*awscw.Client, context.Context) {
+	t.Helper()
+
+	h := cwserver.New(cwprovider.New(config.NewOptions(config.WithClock(clock))))
+	ts := httptest.NewServer(h)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+
+	client := awscw.NewFromConfig(cfg, func(o *awscw.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+
+	return client, context.Background()
+}
+
+// TestSDKExactDimensionMatching covers F1: a metric published with a dimension
+// is a distinct series from the no-dimension metric. A no-dimension query must
+// exclude it; the exact-dimension query must return it.
+func TestSDKExactDimensionMatching(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	now := time.Now().UTC()
+	if _, err := client.PutMetricData(ctx, &awscw.PutMetricDataInput{
+		Namespace: aws.String("Custom/App"),
+		MetricData: []cwtypes.MetricDatum{{
+			MetricName: aws.String("Latency"),
+			Value:      aws.Float64(42),
+			Timestamp:  aws.Time(now),
+			Dimensions: []cwtypes.Dimension{{Name: aws.String("InstanceId"), Value: aws.String("i-1")}},
+		}},
+	}); err != nil {
+		t.Fatalf("PutMetricData: %v", err)
+	}
+
+	stat := func(dims []cwtypes.Dimension) *awscw.GetMetricStatisticsOutput {
+		t.Helper()
+
+		out, err := client.GetMetricStatistics(ctx, &awscw.GetMetricStatisticsInput{
+			Namespace:  aws.String("Custom/App"),
+			MetricName: aws.String("Latency"),
+			StartTime:  aws.Time(now.Add(-time.Hour)),
+			EndTime:    aws.Time(now.Add(time.Hour)),
+			Period:     aws.Int32(60),
+			Statistics: []cwtypes.Statistic{cwtypes.StatisticSum},
+			Dimensions: dims,
+		})
+		if err != nil {
+			t.Fatalf("GetMetricStatistics: %v", err)
+		}
+
+		return out
+	}
+
+	if got := stat(nil); len(got.Datapoints) != 0 {
+		t.Fatalf("no-dimension query returned %d datapoints, want 0 (dimensioned metric is a separate series)", len(got.Datapoints))
+	}
+
+	exact := stat([]cwtypes.Dimension{{Name: aws.String("InstanceId"), Value: aws.String("i-1")}})
+	if len(exact.Datapoints) != 1 {
+		t.Fatalf("exact-dimension query returned %d datapoints, want 1", len(exact.Datapoints))
+	}
+
+	if got := aws.ToFloat64(exact.Datapoints[0].Sum); got != 42 {
+		t.Fatalf("Sum = %v, want 42", got)
+	}
+}
+
+// TestSDKAlarmMOfNAndRecovery covers F3: an alarm with EvaluationPeriods=3 and
+// DatapointsToAlarm=3 must require all three periods to breach (not the window
+// average), and must recover to OK once the breaching periods leave the window.
+func TestSDKAlarmMOfNAndRecovery(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC))
+	client, ctx := newCWClientClock(t, fc)
+
+	if _, err := client.PutMetricAlarm(ctx, &awscw.PutMetricAlarmInput{
+		AlarmName:          aws.String("m-of-n"),
+		Namespace:          aws.String("Custom/App"),
+		MetricName:         aws.String("Load"),
+		ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+		Threshold:          aws.Float64(10),
+		EvaluationPeriods:  aws.Int32(3),
+		DatapointsToAlarm:  aws.Int32(3),
+		Period:             aws.Int32(60),
+		Statistic:          cwtypes.StatisticAverage,
+	}); err != nil {
+		t.Fatalf("PutMetricAlarm: %v", err)
+	}
+
+	// feed publishes one datum per period (oldest..newest) at the clock's now.
+	feed := func(vals ...float64) {
+		t.Helper()
+
+		data := make([]cwtypes.MetricDatum, 0, len(vals))
+		for i, v := range vals {
+			age := time.Duration(len(vals)-1-i) * 60 * time.Second
+			data = append(data, cwtypes.MetricDatum{
+				MetricName: aws.String("Load"),
+				Value:      aws.Float64(v),
+				Timestamp:  aws.Time(fc.Now().Add(-age)),
+			})
+		}
+
+		if _, err := client.PutMetricData(ctx, &awscw.PutMetricDataInput{
+			Namespace:  aws.String("Custom/App"),
+			MetricData: data,
+		}); err != nil {
+			t.Fatalf("PutMetricData: %v", err)
+		}
+	}
+
+	state := func() cwtypes.StateValue {
+		t.Helper()
+
+		out, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{AlarmNames: []string{"m-of-n"}})
+		if err != nil {
+			t.Fatalf("DescribeAlarms: %v", err)
+		}
+		if len(out.MetricAlarms) != 1 {
+			t.Fatalf("DescribeAlarms returned %d alarms, want 1", len(out.MetricAlarms))
+		}
+
+		return out.MetricAlarms[0].StateValue
+	}
+
+	// Only the most recent of three periods breaches: 1 of 3 < DatapointsToAlarm=3,
+	// so the alarm stays OK (the old window-average bug went to ALARM on 33.3 avg).
+	feed(0, 0, 100)
+	if got := state(); got != cwtypes.StateValueOk {
+		t.Fatalf("state after 0,0,100 = %s, want OK (only 1 of 3 periods breaches)", got)
+	}
+
+	// All three periods breach -> ALARM. Advance so the prior window ages out.
+	fc.Advance(time.Hour)
+	feed(100, 100, 100)
+	if got := state(); got != cwtypes.StateValueAlarm {
+		t.Fatalf("state after 100,100,100 = %s, want ALARM", got)
+	}
+
+	// Fresh non-breaching periods -> recovery to OK.
+	fc.Advance(time.Hour)
+	feed(0, 0, 0)
+	if got := state(); got != cwtypes.StateValueOk {
+		t.Fatalf("state after 0,0,0 = %s, want OK (recovery)", got)
+	}
+}
+
+// TestSDKPutMetricAlarmFieldRoundTrip covers F4: DatapointsToAlarm,
+// TreatMissingData, Unit and ExtendedStatistic must survive PutMetricAlarm and
+// be reflected on DescribeAlarms (else Terraform sees perpetual drift).
+func TestSDKPutMetricAlarmFieldRoundTrip(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	if _, err := client.PutMetricAlarm(ctx, &awscw.PutMetricAlarmInput{
+		AlarmName:          aws.String("fields"),
+		Namespace:          aws.String("Custom/App"),
+		MetricName:         aws.String("Errors"),
+		ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+		Threshold:          aws.Float64(1),
+		EvaluationPeriods:  aws.Int32(3),
+		DatapointsToAlarm:  aws.Int32(2),
+		Period:             aws.Int32(60),
+		Statistic:          cwtypes.StatisticSum,
+		Unit:               cwtypes.StandardUnitCount,
+		TreatMissingData:   aws.String("notBreaching"),
+	}); err != nil {
+		t.Fatalf("PutMetricAlarm: %v", err)
+	}
+
+	// ExtendedStatistic is mutually exclusive with Statistic, so use a second alarm.
+	if _, err := client.PutMetricAlarm(ctx, &awscw.PutMetricAlarmInput{
+		AlarmName:          aws.String("pctile"),
+		Namespace:          aws.String("Custom/App"),
+		MetricName:         aws.String("Latency"),
+		ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+		Threshold:          aws.Float64(100),
+		EvaluationPeriods:  aws.Int32(1),
+		Period:             aws.Int32(60),
+		ExtendedStatistic:  aws.String("p95"),
+	}); err != nil {
+		t.Fatalf("PutMetricAlarm(pctile): %v", err)
+	}
+
+	out, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{AlarmNames: []string{"fields", "pctile"}})
+	if err != nil {
+		t.Fatalf("DescribeAlarms: %v", err)
+	}
+
+	byName := map[string]cwtypes.MetricAlarm{}
+	for _, a := range out.MetricAlarms {
+		byName[aws.ToString(a.AlarmName)] = a
+	}
+
+	fields, ok := byName["fields"]
+	if !ok {
+		t.Fatal("alarm 'fields' not returned")
+	}
+	if got := aws.ToInt32(fields.DatapointsToAlarm); got != 2 {
+		t.Errorf("DatapointsToAlarm = %d, want 2", got)
+	}
+	if got := aws.ToString(fields.TreatMissingData); got != "notBreaching" {
+		t.Errorf("TreatMissingData = %q, want notBreaching", got)
+	}
+	if fields.Unit != cwtypes.StandardUnitCount {
+		t.Errorf("Unit = %q, want Count", fields.Unit)
+	}
+
+	pctile, ok := byName["pctile"]
+	if !ok {
+		t.Fatal("alarm 'pctile' not returned")
+	}
+	if got := aws.ToString(pctile.ExtendedStatistic); got != "p95" {
+		t.Errorf("ExtendedStatistic = %q, want p95", got)
+	}
+}
+
+// TestSDKDeleteAlarmsToleratesUnknown covers F5: DeleteAlarms deletes the valid
+// names and ignores unknown ones with no error and no half-deleted state.
+func TestSDKDeleteAlarmsToleratesUnknown(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	for _, name := range []string{"keep-1", "keep-2"} {
+		if _, err := client.PutMetricAlarm(ctx, &awscw.PutMetricAlarmInput{
+			AlarmName:          aws.String(name),
+			Namespace:          aws.String("Custom/App"),
+			MetricName:         aws.String("Errors"),
+			ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+			Threshold:          aws.Float64(1),
+			EvaluationPeriods:  aws.Int32(1),
+			Period:             aws.Int32(60),
+			Statistic:          cwtypes.StatisticSum,
+		}); err != nil {
+			t.Fatalf("PutMetricAlarm(%s): %v", name, err)
+		}
+	}
+
+	// A batch mixing valid and unknown names must succeed (AWS tolerates the
+	// unknown one) and delete both valid alarms regardless of their position.
+	if _, err := client.DeleteAlarms(ctx, &awscw.DeleteAlarmsInput{
+		AlarmNames: []string{"keep-1", "ghost", "keep-2"},
+	}); err != nil {
+		t.Fatalf("DeleteAlarms with an unknown name should succeed, got: %v", err)
+	}
+
+	out, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{
+		AlarmNames: []string{"keep-1", "keep-2"},
+	})
+	if err != nil {
+		t.Fatalf("DescribeAlarms: %v", err)
+	}
+	if len(out.MetricAlarms) != 0 {
+		t.Fatalf("%d alarms survived, want 0 (both valid names deleted)", len(out.MetricAlarms))
+	}
+}
+
+// TestSDKSetAlarmStateRecordsHistory covers F2 at the wire layer: forcing a state
+// with SetAlarmState records a StateUpdate history entry (no metric needed).
+func TestSDKSetAlarmStateRecordsHistory(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	if _, err := client.PutMetricAlarm(ctx, &awscw.PutMetricAlarmInput{
+		AlarmName:          aws.String("forced"),
+		Namespace:          aws.String("Custom/App"),
+		MetricName:         aws.String("Errors"),
+		ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+		Threshold:          aws.Float64(1),
+		EvaluationPeriods:  aws.Int32(1),
+		Period:             aws.Int32(60),
+		Statistic:          cwtypes.StatisticSum,
+	}); err != nil {
+		t.Fatalf("PutMetricAlarm: %v", err)
+	}
+
+	if _, err := client.SetAlarmState(ctx, &awscw.SetAlarmStateInput{
+		AlarmName:   aws.String("forced"),
+		StateValue:  cwtypes.StateValueAlarm,
+		StateReason: aws.String("manual"),
+	}); err != nil {
+		t.Fatalf("SetAlarmState: %v", err)
+	}
+
+	out, err := client.DescribeAlarmHistory(ctx, &awscw.DescribeAlarmHistoryInput{
+		AlarmName: aws.String("forced"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeAlarmHistory: %v", err)
+	}
+	if len(out.AlarmHistoryItems) == 0 {
+		t.Fatal("SetAlarmState recorded no history entry")
+	}
+	if out.AlarmHistoryItems[0].HistoryItemType != cwtypes.HistoryItemTypeStateUpdate {
+		t.Fatalf("HistoryItemType = %q, want StateUpdate", out.AlarmHistoryItems[0].HistoryItemType)
+	}
+}
+
+// TestSDKDescribeAlarmHistoryOrderingAndFilters covers F6: history is newest-first
+// by default, MaxRecords keeps the newest, ScanBy reverses to oldest-first, and
+// HistoryItemType filters.
+func TestSDKDescribeAlarmHistoryOrderingAndFilters(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC))
+	client, ctx := newCWClientClock(t, fc)
+
+	if _, err := client.PutMetricAlarm(ctx, &awscw.PutMetricAlarmInput{
+		AlarmName:          aws.String("hist"),
+		Namespace:          aws.String("Custom/App"),
+		MetricName:         aws.String("Errors"),
+		ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+		Threshold:          aws.Float64(1),
+		EvaluationPeriods:  aws.Int32(1),
+		Period:             aws.Int32(60),
+		Statistic:          cwtypes.StatisticSum,
+	}); err != nil {
+		t.Fatalf("PutMetricAlarm: %v", err)
+	}
+
+	// Three distinct-timestamp transitions: INSUFFICIENT_DATA->ALARM->OK->ALARM.
+	for _, sv := range []cwtypes.StateValue{cwtypes.StateValueAlarm, cwtypes.StateValueOk, cwtypes.StateValueAlarm} {
+		if _, err := client.SetAlarmState(ctx, &awscw.SetAlarmStateInput{
+			AlarmName:   aws.String("hist"),
+			StateValue:  sv,
+			StateReason: aws.String("step"),
+		}); err != nil {
+			t.Fatalf("SetAlarmState(%s): %v", sv, err)
+		}
+
+		fc.Advance(time.Minute)
+	}
+
+	desc, err := client.DescribeAlarmHistory(ctx, &awscw.DescribeAlarmHistoryInput{AlarmName: aws.String("hist")})
+	if err != nil {
+		t.Fatalf("DescribeAlarmHistory: %v", err)
+	}
+	if len(desc.AlarmHistoryItems) != 3 {
+		t.Fatalf("history len = %d, want 3", len(desc.AlarmHistoryItems))
+	}
+
+	// Default order is newest-first: strictly descending timestamps.
+	for i := 1; i < len(desc.AlarmHistoryItems); i++ {
+		if desc.AlarmHistoryItems[i-1].Timestamp.Before(*desc.AlarmHistoryItems[i].Timestamp) {
+			t.Fatalf("history not newest-first at %d: %v then %v",
+				i, desc.AlarmHistoryItems[i-1].Timestamp, desc.AlarmHistoryItems[i].Timestamp)
+		}
+	}
+
+	newest := *desc.AlarmHistoryItems[0].Timestamp
+
+	// MaxRecords keeps the newest N (here the single newest entry).
+	limited, err := client.DescribeAlarmHistory(ctx, &awscw.DescribeAlarmHistoryInput{
+		AlarmName:  aws.String("hist"),
+		MaxRecords: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("DescribeAlarmHistory(limit): %v", err)
+	}
+	if len(limited.AlarmHistoryItems) != 1 {
+		t.Fatalf("limited history len = %d, want 1", len(limited.AlarmHistoryItems))
+	}
+	if !limited.AlarmHistoryItems[0].Timestamp.Equal(newest) {
+		t.Fatalf("MaxRecords=1 kept %v, want the newest %v", *limited.AlarmHistoryItems[0].Timestamp, newest)
+	}
+
+	// ScanBy ascending flips to oldest-first.
+	asc, err := client.DescribeAlarmHistory(ctx, &awscw.DescribeAlarmHistoryInput{
+		AlarmName: aws.String("hist"),
+		ScanBy:    cwtypes.ScanByTimestampAscending,
+	})
+	if err != nil {
+		t.Fatalf("DescribeAlarmHistory(asc): %v", err)
+	}
+	if got := asc.AlarmHistoryItems[len(asc.AlarmHistoryItems)-1].Timestamp; !got.Equal(newest) {
+		t.Fatalf("ascending last = %v, want newest %v", *got, newest)
+	}
+
+	// HistoryItemType filter: all entries are StateUpdate.
+	su, err := client.DescribeAlarmHistory(ctx, &awscw.DescribeAlarmHistoryInput{
+		AlarmName:       aws.String("hist"),
+		HistoryItemType: cwtypes.HistoryItemTypeStateUpdate,
+	})
+	if err != nil {
+		t.Fatalf("DescribeAlarmHistory(StateUpdate): %v", err)
+	}
+	if len(su.AlarmHistoryItems) != 3 {
+		t.Fatalf("StateUpdate filter len = %d, want 3", len(su.AlarmHistoryItems))
+	}
+
+	cu, err := client.DescribeAlarmHistory(ctx, &awscw.DescribeAlarmHistoryInput{
+		AlarmName:       aws.String("hist"),
+		HistoryItemType: cwtypes.HistoryItemTypeConfigurationUpdate,
+	})
+	if err != nil {
+		t.Fatalf("DescribeAlarmHistory(ConfigurationUpdate): %v", err)
+	}
+	if len(cu.AlarmHistoryItems) != 0 {
+		t.Fatalf("ConfigurationUpdate filter len = %d, want 0", len(cu.AlarmHistoryItems))
+	}
+}

--- a/server/aws/cloudwatch/metric_data_ops.go
+++ b/server/aws/cloudwatch/metric_data_ops.go
@@ -262,21 +262,9 @@ func filterAlarmHistory(entries []mondriver.AlarmHistoryEntry, in *describeAlarm
 	kept := make([]mondriver.AlarmHistoryEntry, 0, len(entries))
 
 	for i := range entries {
-		e := &entries[i]
-
-		if in.HistoryItemType != "" && historyItemType(e) != in.HistoryItemType {
-			continue
+		if historyEntryMatches(&entries[i], in, start, end) {
+			kept = append(kept, entries[i])
 		}
-
-		if !start.IsZero() && e.Timestamp.Before(start) {
-			continue
-		}
-
-		if !end.IsZero() && e.Timestamp.After(end) {
-			continue
-		}
-
-		kept = append(kept, *e)
 	}
 
 	if in.ScanBy == scanByAscending {
@@ -288,6 +276,24 @@ func filterAlarmHistory(entries []mondriver.AlarmHistoryEntry, in *describeAlarm
 	}
 
 	return historyItemsToCBR(kept)
+}
+
+// historyEntryMatches reports whether an entry passes the HistoryItemType and
+// StartDate/EndDate filters of a DescribeAlarmHistory request.
+func historyEntryMatches(e *mondriver.AlarmHistoryEntry, in *describeAlarmHistoryInput, start, end time.Time) bool {
+	if in.HistoryItemType != "" && historyItemType(e) != in.HistoryItemType {
+		return false
+	}
+
+	if !start.IsZero() && e.Timestamp.Before(start) {
+		return false
+	}
+
+	if !end.IsZero() && e.Timestamp.After(end) {
+		return false
+	}
+
+	return true
 }
 
 // reverseHistory reverses the entries in place (newest-first to oldest-first).

--- a/server/aws/cloudwatch/metric_data_ops.go
+++ b/server/aws/cloudwatch/metric_data_ops.go
@@ -204,10 +204,20 @@ func dimensionsEqual(a, b map[string]string) bool {
 }
 
 type describeAlarmHistoryInput struct {
-	AlarmName       string `cbor:"AlarmName,omitempty"`
-	HistoryItemType string `cbor:"HistoryItemType,omitempty"`
-	MaxRecords      int    `cbor:"MaxRecords,omitempty"`
+	AlarmName       string     `cbor:"AlarmName,omitempty"`
+	HistoryItemType string     `cbor:"HistoryItemType,omitempty"`
+	StartDate       *time.Time `cbor:"StartDate,omitempty"`
+	EndDate         *time.Time `cbor:"EndDate,omitempty"`
+	ScanBy          string     `cbor:"ScanBy,omitempty"`
+	MaxRecords      int        `cbor:"MaxRecords,omitempty"`
 }
+
+// scanByAscending requests oldest-first ordering; the default (and any other
+// value) is TimestampDescending, newest-first.
+const scanByAscending = "TimestampAscending"
+
+// historyTypeStateUpdate is the default HistoryItemType for a recorded entry.
+const historyTypeStateUpdate = "StateUpdate"
 
 type alarmHistoryItemCBR struct {
 	AlarmName       string    `cbor:"AlarmName"`
@@ -230,24 +240,86 @@ func (h *Handler) describeAlarmHistory(w http.ResponseWriter, r *http.Request, b
 		return
 	}
 
-	entries, err := h.monitoring.GetAlarmHistory(r.Context(), in.AlarmName, in.MaxRecords)
+	// Fetch the full history (newest-first) and apply the request filters here so
+	// MaxRecords is honored after HistoryItemType / date-window filtering.
+	entries, err := h.monitoring.GetAlarmHistory(r.Context(), in.AlarmName, 0)
 	if err != nil {
 		writeDriverErr(w, err)
 		return
 	}
 
+	writeCBORResponse(w, describeAlarmHistoryOutput{AlarmHistoryItems: filterAlarmHistory(entries, &in)})
+}
+
+// filterAlarmHistory applies the DescribeAlarmHistory request filters to the
+// newest-first entries: HistoryItemType, the StartDate/EndDate window, ScanBy
+// ordering, then the MaxRecords cap (kept last so it truncates the far end of the
+// chosen order).
+func filterAlarmHistory(entries []mondriver.AlarmHistoryEntry, in *describeAlarmHistoryInput) []alarmHistoryItemCBR {
+	start := timeOrZero(in.StartDate)
+	end := timeOrZero(in.EndDate)
+
+	kept := make([]mondriver.AlarmHistoryEntry, 0, len(entries))
+
+	for i := range entries {
+		e := &entries[i]
+
+		if in.HistoryItemType != "" && historyItemType(e) != in.HistoryItemType {
+			continue
+		}
+
+		if !start.IsZero() && e.Timestamp.Before(start) {
+			continue
+		}
+
+		if !end.IsZero() && e.Timestamp.After(end) {
+			continue
+		}
+
+		kept = append(kept, *e)
+	}
+
+	if in.ScanBy == scanByAscending {
+		reverseHistory(kept)
+	}
+
+	if in.MaxRecords > 0 && len(kept) > in.MaxRecords {
+		kept = kept[:in.MaxRecords]
+	}
+
+	return historyItemsToCBR(kept)
+}
+
+// reverseHistory reverses the entries in place (newest-first to oldest-first).
+func reverseHistory(entries []mondriver.AlarmHistoryEntry) {
+	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+		entries[i], entries[j] = entries[j], entries[i]
+	}
+}
+
+func historyItemsToCBR(entries []mondriver.AlarmHistoryEntry) []alarmHistoryItemCBR {
 	out := make([]alarmHistoryItemCBR, 0, len(entries))
 	for i := range entries {
 		out = append(out, alarmHistoryItemCBR{
 			AlarmName:       entries[i].AlarmName,
 			Timestamp:       entries[i].Timestamp.UTC(),
-			HistoryItemType: "StateUpdate",
+			HistoryItemType: historyItemType(&entries[i]),
 			HistorySummary:  entries[i].Reason,
 			HistoryData:     alarmHistoryData(&entries[i]),
 		})
 	}
 
-	writeCBORResponse(w, describeAlarmHistoryOutput{AlarmHistoryItems: out})
+	return out
+}
+
+// historyItemType returns the entry's classification, defaulting to StateUpdate
+// for entries recorded before the field existed.
+func historyItemType(e *mondriver.AlarmHistoryEntry) string {
+	if e.HistoryItemType == "" {
+		return historyTypeStateUpdate
+	}
+
+	return e.HistoryItemType
 }
 
 func alarmHistoryData(e *mondriver.AlarmHistoryEntry) string {

--- a/server/aws/cloudwatch/ops.go
+++ b/server/aws/cloudwatch/ops.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fxamacker/cbor/v2"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
@@ -774,8 +775,12 @@ func (h *Handler) deleteAlarms(w http.ResponseWriter, r *http.Request, body []by
 		return
 	}
 
+	// AWS tolerates incorrect alarm names: the correctly named alarms are still
+	// deleted and no ResourceNotFound is returned. Skip not-found names so a
+	// batch that includes an already-gone alarm (e.g. terraform destroy) never
+	// fails spuriously or leaves a half-deleted state.
 	for _, name := range in.AlarmNames {
-		if err := h.monitoring.DeleteAlarm(r.Context(), name); err != nil {
+		if err := h.monitoring.DeleteAlarm(r.Context(), name); err != nil && !cerrors.IsNotFound(err) {
 			writeDriverErr(w, err)
 			return
 		}

--- a/server/aws/cloudwatch/ops.go
+++ b/server/aws/cloudwatch/ops.go
@@ -496,7 +496,11 @@ type putMetricAlarmInput struct {
 	Threshold               float64        `cbor:"Threshold"`
 	Period                  int            `cbor:"Period"`
 	EvaluationPeriods       int            `cbor:"EvaluationPeriods"`
+	DatapointsToAlarm       int            `cbor:"DatapointsToAlarm,omitempty"`
 	Statistic               string         `cbor:"Statistic,omitempty"`
+	ExtendedStatistic       string         `cbor:"ExtendedStatistic,omitempty"`
+	Unit                    string         `cbor:"Unit,omitempty"`
+	TreatMissingData        string         `cbor:"TreatMissingData,omitempty"`
 	Dimensions              []dimensionCBR `cbor:"Dimensions,omitempty"`
 	AlarmActions            []string       `cbor:"AlarmActions,omitempty"`
 	OKActions               []string       `cbor:"OKActions,omitempty"`
@@ -548,7 +552,11 @@ func (h *Handler) putMetricAlarm(w http.ResponseWriter, r *http.Request, body []
 		Threshold:               in.Threshold,
 		Period:                  in.Period,
 		EvaluationPeriods:       in.EvaluationPeriods,
+		DatapointsToAlarm:       in.DatapointsToAlarm,
 		Stat:                    in.Statistic,
+		ExtendedStatistic:       in.ExtendedStatistic,
+		Unit:                    in.Unit,
+		TreatMissingData:        in.TreatMissingData,
 		AlarmActions:            in.AlarmActions,
 		OKActions:               in.OKActions,
 		InsufficientDataActions: in.InsufficientDataActions,
@@ -605,7 +613,11 @@ type metricAlarmCBR struct {
 	Threshold               float64        `cbor:"Threshold"`
 	Period                  int            `cbor:"Period,omitempty"`
 	EvaluationPeriods       int            `cbor:"EvaluationPeriods,omitempty"`
+	DatapointsToAlarm       int            `cbor:"DatapointsToAlarm,omitempty"`
 	Statistic               string         `cbor:"Statistic,omitempty"`
+	ExtendedStatistic       string         `cbor:"ExtendedStatistic,omitempty"`
+	Unit                    string         `cbor:"Unit,omitempty"`
+	TreatMissingData        string         `cbor:"TreatMissingData,omitempty"`
 	ActionsEnabled          bool           `cbor:"ActionsEnabled"`
 	AlarmActions            []string       `cbor:"AlarmActions,omitempty"`
 	OKActions               []string       `cbor:"OKActions,omitempty"`
@@ -711,7 +723,11 @@ func toMetricAlarmCBR(a *mondriver.AlarmInfo) metricAlarmCBR {
 		Threshold:               a.Threshold,
 		Period:                  a.Period,
 		EvaluationPeriods:       a.EvaluationPeriods,
+		DatapointsToAlarm:       a.DatapointsToAlarm,
 		Statistic:               a.Statistic,
+		ExtendedStatistic:       a.ExtendedStatistic,
+		Unit:                    a.Unit,
+		TreatMissingData:        a.TreatMissingData,
 		ActionsEnabled:          a.ActionsEnabled,
 		AlarmActions:            a.AlarmActions,
 		OKActions:               a.OKActions,

--- a/server/aws/cloudwatch/query.go
+++ b/server/aws/cloudwatch/query.go
@@ -258,8 +258,10 @@ func (h *Handler) queryDescribeAlarms(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) queryDeleteAlarms(w http.ResponseWriter, r *http.Request) {
+	// AWS tolerates incorrect alarm names: valid ones are still deleted and no
+	// ResourceNotFound is returned.
 	for _, name := range queryStringList(r, "AlarmNames.member.") {
-		if err := h.monitoring.DeleteAlarm(r.Context(), name); err != nil {
+		if err := h.monitoring.DeleteAlarm(r.Context(), name); err != nil && !cerrors.IsNotFound(err) {
 			writeQueryDriverErr(w, err)
 			return
 		}

--- a/server/aws/cloudwatch/query.go
+++ b/server/aws/cloudwatch/query.go
@@ -221,11 +221,14 @@ func (h *Handler) queryPutMetricAlarm(w http.ResponseWriter, r *http.Request) {
 	threshold, _ := strconv.ParseFloat(r.Form.Get("Threshold"), 64)
 	period, _ := strconv.Atoi(r.Form.Get("Period"))
 	evalPeriods, _ := strconv.Atoi(r.Form.Get("EvaluationPeriods"))
+	datapointsToAlarm, _ := strconv.Atoi(r.Form.Get("DatapointsToAlarm"))
 
 	err := h.monitoring.CreateAlarm(r.Context(), mondriver.AlarmConfig{
 		Name: r.Form.Get("AlarmName"), Namespace: r.Form.Get("Namespace"), MetricName: r.Form.Get("MetricName"),
 		Dimensions: queryDimensions(r, "Dimensions.member."), ComparisonOperator: comparisonOperator,
-		Threshold: threshold, Period: period, EvaluationPeriods: evalPeriods, Stat: r.Form.Get("Statistic"),
+		Threshold: threshold, Period: period, EvaluationPeriods: evalPeriods, DatapointsToAlarm: datapointsToAlarm,
+		Stat: r.Form.Get("Statistic"), ExtendedStatistic: r.Form.Get("ExtendedStatistic"),
+		Unit: r.Form.Get("Unit"), TreatMissingData: r.Form.Get("TreatMissingData"),
 		AlarmActions: queryStringList(r, "AlarmActions.member."), OKActions: queryStringList(r, "OKActions.member."),
 	})
 	if err != nil {

--- a/server/aws/cloudwatch_set_alarm_state_sdk_test.go
+++ b/server/aws/cloudwatch_set_alarm_state_sdk_test.go
@@ -1,0 +1,100 @@
+package aws_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// TestE2ECloudWatchSetAlarmStateFiresSNSToSQS covers F2 end-to-end: forcing an
+// alarm to ALARM with SetAlarmState must invoke the alarm's SNS AlarmAction —
+// the documented "test my alarm wiring" workflow — delivering to the subscribed
+// queue and recording the transition in DescribeAlarmHistory.
+func TestE2ECloudWatchSetAlarmStateFiresSNSToSQS(t *testing.T) {
+	provider := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{
+		CloudWatch: provider.CloudWatch,
+		SNS:        provider.SNS,
+		SQS:        provider.SQS,
+	})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	cfg := sdkConfig(t, ts.URL)
+	ctx := context.Background()
+
+	cw := cloudwatch.NewFromConfig(cfg)
+	snsClient := sns.NewFromConfig(cfg)
+	sqsClient := sqs.NewFromConfig(cfg)
+
+	topic, err := snsClient.CreateTopic(ctx, &sns.CreateTopicInput{Name: aws.String("alarm-topic")})
+	require.NoError(t, err)
+	topicARN := aws.ToString(topic.TopicArn)
+
+	queue, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{QueueName: aws.String("alarm-queue")})
+	require.NoError(t, err)
+	queueURL := aws.ToString(queue.QueueUrl)
+
+	attrs, err := sqsClient.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+		QueueUrl:       queue.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameQueueArn},
+	})
+	require.NoError(t, err)
+	queueARN := attrs.Attributes[string(sqstypes.QueueAttributeNameQueueArn)]
+	require.NotEmpty(t, queueARN)
+
+	_, err = snsClient.Subscribe(ctx, &sns.SubscribeInput{
+		TopicArn: aws.String(topicARN),
+		Protocol: aws.String("sqs"),
+		Endpoint: aws.String(queueARN),
+	})
+	require.NoError(t, err)
+
+	_, err = cw.PutMetricAlarm(ctx, &cloudwatch.PutMetricAlarmInput{
+		AlarmName:          aws.String("wired"),
+		Namespace:          aws.String("Custom/App"),
+		MetricName:         aws.String("AppErrors"),
+		ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+		Threshold:          aws.Float64(10),
+		EvaluationPeriods:  aws.Int32(1),
+		Period:             aws.Int32(60),
+		Statistic:          cwtypes.StatisticSum,
+		AlarmActions:       []string{topicARN},
+	})
+	require.NoError(t, err)
+
+	// Forcing ALARM must fire the AlarmAction, exactly like an evaluated transition.
+	_, err = cw.SetAlarmState(ctx, &cloudwatch.SetAlarmStateInput{
+		AlarmName:   aws.String("wired"),
+		StateValue:  cwtypes.StateValueAlarm,
+		StateReason: aws.String("forced for wiring test"),
+	})
+	require.NoError(t, err)
+
+	hist, err := cw.DescribeAlarmHistory(ctx, &cloudwatch.DescribeAlarmHistoryInput{
+		AlarmName: aws.String("wired"),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, hist.AlarmHistoryItems, "SetAlarmState should record a history entry")
+	assert.Equal(t, cwtypes.HistoryItemTypeStateUpdate, hist.AlarmHistoryItems[0].HistoryItemType)
+
+	msgs, err := sqsClient.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+		QueueUrl:            aws.String(queueURL),
+		MaxNumberOfMessages: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, msgs.Messages, 1, "SetAlarmState AlarmAction should deliver one SNS notification to the queue")
+	assert.Contains(t, aws.ToString(msgs.Messages[0].Body), "wired")
+}

--- a/services/monitoring/alarmeval/alarmeval.go
+++ b/services/monitoring/alarmeval/alarmeval.go
@@ -1,0 +1,272 @@
+// Package alarmeval implements the CloudWatch-style metric-alarm evaluation
+// shared by the AWS, Azure, and GCP monitoring providers: exact metric-series
+// dimension matching, per-statistic aggregation of the three PutMetricData datum
+// forms, and the per-Period M-of-N rule with OK recovery and TreatMissingData
+// handling. Keeping this in one place stops the three providers from drifting.
+package alarmeval
+
+import (
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// Alarm states, matching the CloudWatch StateValue enum.
+const (
+	StateAlarm = "ALARM"
+	StateOK    = "OK"
+)
+
+// defaultPeriodSeconds is the period assumed when an alarm omits one.
+const defaultPeriodSeconds = 60
+
+// TreatMissingData policies from PutMetricAlarm. Any other value (including the
+// empty string) is the AWS default "missing": a period with no data is simply
+// not counted toward the M-of-N rule.
+const (
+	treatMissingBreaching    = "breaching"
+	treatMissingNotBreaching = "notBreaching"
+)
+
+// Params describes one alarm's thresholds for a single evaluation.
+type Params struct {
+	Period             int
+	EvaluationPeriods  int
+	DatapointsToAlarm  int // M in the M-of-N rule; 0 defaults to EvaluationPeriods
+	Stat               string
+	ComparisonOperator string
+	Threshold          float64
+	TreatMissingData   string
+}
+
+// normalize applies the defaults CloudWatch uses for an omitted Period,
+// EvaluationPeriods, or DatapointsToAlarm.
+func (p *Params) normalize() (periodDur time.Duration, evalPeriods, datapointsToAlarm int) {
+	period := p.Period
+	if period <= 0 {
+		period = defaultPeriodSeconds
+	}
+
+	evalPeriods = p.EvaluationPeriods
+	if evalPeriods <= 0 {
+		evalPeriods = 1
+	}
+
+	datapointsToAlarm = p.DatapointsToAlarm
+	if datapointsToAlarm <= 0 || datapointsToAlarm > evalPeriods {
+		datapointsToAlarm = evalPeriods
+	}
+
+	return time.Duration(period) * time.Second, evalPeriods, datapointsToAlarm
+}
+
+// WindowStart is the earliest timestamp an evaluation of p at now considers, so
+// a provider can pre-filter its stored datums to the evaluation window.
+func (p *Params) WindowStart(now time.Time) time.Time {
+	periodDur, evalPeriods, _ := p.normalize()
+
+	return now.Add(-periodDur * time.Duration(evalPeriods))
+}
+
+// MatchDimensions reports whether a datum belongs to the metric series a query
+// identifies. CloudWatch treats each unique combination of dimensions as a
+// separate metric, so the datum's dimension set must equal the query's exactly:
+// a query with fewer (or no) dimensions does not match a datum published with a
+// superset, and vice versa.
+func MatchDimensions(dataDims, filterDims map[string]string) bool {
+	if len(dataDims) != len(filterDims) {
+		return false
+	}
+
+	for k, v := range filterDims {
+		if dataDims[k] != v {
+			return false
+		}
+	}
+
+	return true
+}
+
+// EvaluateComparison reports whether value crosses threshold under operator.
+func EvaluateComparison(value float64, operator string, threshold float64) bool {
+	switch operator {
+	case "GreaterThanThreshold":
+		return value > threshold
+	case "GreaterThanOrEqualToThreshold":
+		return value >= threshold
+	case "LessThanThreshold":
+		return value < threshold
+	case "LessThanOrEqualToThreshold":
+		return value <= threshold
+	default:
+		return false
+	}
+}
+
+// StatOf aggregates every datum in the slice and returns the requested statistic,
+// or 0 when the slice is empty. It folds a plain Value, a StatisticValues set,
+// and paired Values/Counts arrays uniformly.
+func StatOf(datums []driver.MetricDatum, stat string) float64 {
+	return aggregate(datums).stat(stat)
+}
+
+// EvaluateWindow applies CloudWatch's M-of-N rule. It groups datums (already
+// filtered to the alarm's metric series and evaluation window) into the last
+// EvaluationPeriods per-Period buckets — bucket 0 is the most recent period —
+// evaluates the statistic per bucket, and returns ALARM when at least
+// DatapointsToAlarm buckets breach, otherwise OK (which is how an alarm recovers
+// once the breaching periods age out of the window). Empty periods are counted
+// per TreatMissingData. evaluated is false when there is nothing to evaluate (all
+// periods missing under a non-breaching policy), so the caller leaves the state
+// unchanged rather than forcing a transition.
+func EvaluateWindow(datums []driver.MetricDatum, p *Params, now time.Time) (state, reason string, evaluated bool) {
+	periodDur, evalPeriods, datapointsToAlarm := p.normalize()
+	buckets := bucketByPeriod(datums, now, periodDur, evalPeriods)
+
+	breaching, present := 0, 0
+
+	for _, b := range buckets {
+		switch {
+		case b != nil:
+			present++
+
+			if EvaluateComparison(b.stat(p.Stat), p.ComparisonOperator, p.Threshold) {
+				breaching++
+			}
+		case p.TreatMissingData == treatMissingBreaching:
+			present++
+			breaching++
+		case p.TreatMissingData == treatMissingNotBreaching:
+			present++
+		}
+	}
+
+	if present == 0 {
+		return "", "", false
+	}
+
+	if breaching >= datapointsToAlarm {
+		return StateAlarm, "Threshold crossed", true
+	}
+
+	return StateOK, "Threshold not crossed", true
+}
+
+// bucketByPeriod groups datums into evalPeriods accumulators indexed by age,
+// where bucket 0 covers the most recent period. A nil bucket had no data.
+func bucketByPeriod(datums []driver.MetricDatum, now time.Time, periodDur time.Duration, evalPeriods int) []*statAgg {
+	buckets := make([]*statAgg, evalPeriods)
+
+	for i := range datums {
+		age := now.Sub(datums[i].Timestamp)
+		if age < 0 {
+			continue
+		}
+
+		idx := int(age / periodDur)
+		if idx >= evalPeriods {
+			continue
+		}
+
+		if buckets[idx] == nil {
+			buckets[idx] = &statAgg{}
+		}
+
+		foldDatum(buckets[idx], &datums[i])
+	}
+
+	return buckets
+}
+
+// statAgg accumulates SampleCount / Sum / Minimum / Maximum across a set of
+// metric datums so any requested statistic can be derived. It treats a plain
+// Value, a pre-aggregated StatisticValues set, and paired Values/Counts arrays
+// uniformly, matching how real CloudWatch folds all three into one series.
+type statAgg struct {
+	count float64
+	sum   float64
+	min   float64
+	max   float64
+	seen  bool
+}
+
+// add folds one observation (or sub-aggregate) into the accumulator: count
+// samples summing to sum, whose smallest and largest observed values are low
+// and high. Non-positive counts contribute nothing, matching AWS.
+func (a *statAgg) add(count, sum, low, high float64) {
+	if count <= 0 {
+		return
+	}
+
+	a.count += count
+	a.sum += sum
+
+	if !a.seen || low < a.min {
+		a.min = low
+	}
+
+	if !a.seen || high > a.max {
+		a.max = high
+	}
+
+	a.seen = true
+}
+
+// stat returns the requested statistic, or 0 when no data was accumulated.
+//
+// The accumulator keeps only count/sum/min/max, so a true percentile (an
+// ExtendedStatistic such as p95) is not computable from it — a percentile needs
+// the raw sample distribution. An alarm configured with only an ExtendedStatistic
+// passes an empty Stat here and is therefore approximated by Average. This is a
+// documented approximation (tracked with the deferred percentile support), not a
+// silently wrong answer; it keeps such an alarm evaluating rather than erroring.
+func (a statAgg) stat(stat string) float64 {
+	if !a.seen {
+		return 0
+	}
+
+	switch stat {
+	case "Sum":
+		return a.sum
+	case "Min", "Minimum":
+		return a.min
+	case "Max", "Maximum":
+		return a.max
+	case "SampleCount":
+		return a.count
+	default: // "Average", unspecified, or an ExtendedStatistic percentile (approximated)
+		return a.sum / a.count
+	}
+}
+
+// aggregate folds every datum into a single accumulator.
+func aggregate(datums []driver.MetricDatum) statAgg {
+	var a statAgg
+
+	for i := range datums {
+		foldDatum(&a, &datums[i])
+	}
+
+	return a
+}
+
+// foldDatum folds one datum — plain Value, StatisticValues set, or Values/Counts
+// arrays — into the accumulator.
+func foldDatum(a *statAgg, d *driver.MetricDatum) {
+	switch {
+	case d.StatisticValues != nil:
+		s := d.StatisticValues
+		a.add(s.SampleCount, s.Sum, s.Minimum, s.Maximum)
+	case len(d.Values) > 0:
+		for j, v := range d.Values {
+			count := 1.0
+			if j < len(d.Counts) {
+				count = d.Counts[j]
+			}
+
+			a.add(count, v*count, v, v)
+		}
+	default:
+		a.add(1, d.Value, d.Value, d.Value)
+	}
+}

--- a/services/monitoring/alarmeval/alarmeval_test.go
+++ b/services/monitoring/alarmeval/alarmeval_test.go
@@ -1,0 +1,126 @@
+package alarmeval_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/monitoring/alarmeval"
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchDimensions(t *testing.T) {
+	tests := []struct {
+		name   string
+		data   map[string]string
+		filter map[string]string
+		want   bool
+	}{
+		{name: "both empty", want: true},
+		{name: "exact single", data: map[string]string{"a": "1"}, filter: map[string]string{"a": "1"}, want: true},
+		{name: "no-dim query excludes dimensioned", data: map[string]string{"a": "1"}, filter: nil, want: false},
+		{name: "subset query excludes superset", data: map[string]string{"a": "1", "b": "2"}, filter: map[string]string{"a": "1"}, want: false},
+		{name: "value mismatch", data: map[string]string{"a": "1"}, filter: map[string]string{"a": "2"}, want: false},
+		{name: "same size different key", data: map[string]string{"a": "1"}, filter: map[string]string{"b": "1"}, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, alarmeval.MatchDimensions(tc.data, tc.filter))
+		})
+	}
+}
+
+func TestEvaluateComparison(t *testing.T) {
+	assert.True(t, alarmeval.EvaluateComparison(80, "GreaterThanThreshold", 50))
+	assert.False(t, alarmeval.EvaluateComparison(30, "GreaterThanThreshold", 50))
+	assert.True(t, alarmeval.EvaluateComparison(50, "GreaterThanOrEqualToThreshold", 50))
+	assert.True(t, alarmeval.EvaluateComparison(30, "LessThanThreshold", 50))
+	assert.True(t, alarmeval.EvaluateComparison(50, "LessThanOrEqualToThreshold", 50))
+	assert.False(t, alarmeval.EvaluateComparison(50, "Unknown", 50))
+}
+
+func TestStatOf(t *testing.T) {
+	datums := []driver.MetricDatum{
+		{Value: 10}, {Value: 20}, {Value: 30},
+	}
+	assert.Equal(t, 60.0, alarmeval.StatOf(datums, "Sum"))
+	assert.Equal(t, 20.0, alarmeval.StatOf(datums, "Average"))
+	assert.Equal(t, 10.0, alarmeval.StatOf(datums, "Minimum"))
+	assert.Equal(t, 30.0, alarmeval.StatOf(datums, "Maximum"))
+	assert.Equal(t, 3.0, alarmeval.StatOf(datums, "SampleCount"))
+	assert.Equal(t, 0.0, alarmeval.StatOf(nil, "Average"))
+
+	// StatisticValues and Values/Counts fold into the same accumulator.
+	agg := []driver.MetricDatum{
+		{StatisticValues: &driver.StatisticSet{SampleCount: 2, Sum: 30, Minimum: 10, Maximum: 20}},
+		{Values: []float64{5}, Counts: []float64{4}},
+	}
+	assert.Equal(t, 50.0, alarmeval.StatOf(agg, "Sum"))
+	assert.Equal(t, 6, int(alarmeval.StatOf(agg, "SampleCount")))
+}
+
+// TestEvaluateWindowMOfN exercises the M-of-N rule: only the most recent of three
+// periods breaches, so a 3-of-3 alarm stays OK; all three breaching gives ALARM.
+func TestEvaluateWindowMOfN(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	p := alarmeval.Params{
+		Period: 60, EvaluationPeriods: 3, DatapointsToAlarm: 3,
+		Stat: "Average", ComparisonOperator: "GreaterThanThreshold", Threshold: 10,
+	}
+
+	mk := func(vals ...float64) []driver.MetricDatum {
+		out := make([]driver.MetricDatum, 0, len(vals))
+		for i, v := range vals {
+			age := time.Duration(len(vals)-1-i) * 60 * time.Second
+			out = append(out, driver.MetricDatum{Value: v, Timestamp: now.Add(-age)})
+		}
+
+		return out
+	}
+
+	state, _, evaluated := alarmeval.EvaluateWindow(mk(0, 0, 100), &p, now)
+	assert.True(t, evaluated)
+	assert.Equal(t, alarmeval.StateOK, state, "1 of 3 periods breaching stays OK")
+
+	state, _, evaluated = alarmeval.EvaluateWindow(mk(100, 100, 100), &p, now)
+	assert.True(t, evaluated)
+	assert.Equal(t, alarmeval.StateAlarm, state, "3 of 3 periods breaching alarms")
+
+	state, _, evaluated = alarmeval.EvaluateWindow(mk(0, 0, 0), &p, now)
+	assert.True(t, evaluated)
+	assert.Equal(t, alarmeval.StateOK, state, "recovery to OK")
+}
+
+// TestEvaluateWindowTreatMissingData checks the empty-period policies.
+func TestEvaluateWindowTreatMissingData(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	base := alarmeval.Params{
+		Period: 60, EvaluationPeriods: 3, DatapointsToAlarm: 3,
+		Stat: "Average", ComparisonOperator: "GreaterThanThreshold", Threshold: 10,
+	}
+
+	// One breaching datapoint in the most recent period; the other two are missing.
+	one := []driver.MetricDatum{{Value: 100, Timestamp: now}}
+
+	// Default "missing": the two empty periods aren't counted, 1 < 3 -> OK.
+	state, _, evaluated := alarmeval.EvaluateWindow(one, &base, now)
+	assert.True(t, evaluated)
+	assert.Equal(t, alarmeval.StateOK, state)
+
+	// "breaching": empty periods count as breaching, 3 of 3 -> ALARM.
+	breaching := base
+	breaching.TreatMissingData = "breaching"
+	state, _, _ = alarmeval.EvaluateWindow(one, &breaching, now)
+	assert.Equal(t, alarmeval.StateAlarm, state)
+}
+
+func TestWindowStart(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	p := alarmeval.Params{Period: 60, EvaluationPeriods: 5}
+	assert.Equal(t, now.Add(-5*time.Minute), p.WindowStart(now))
+
+	// Defaults: period 60, evalPeriods 1.
+	def := alarmeval.Params{}
+	assert.Equal(t, now.Add(-time.Minute), def.WindowStart(now))
+}

--- a/services/monitoring/driver/driver.go
+++ b/services/monitoring/driver/driver.go
@@ -70,11 +70,11 @@ type AlarmConfig struct {
 	Threshold               float64
 	Period                  int
 	EvaluationPeriods       int
-	DatapointsToAlarm       int    // M in the M-of-N rule; 0 defaults to EvaluationPeriods
+	DatapointsToAlarm       int // M in the M-of-N rule; 0 defaults to EvaluationPeriods
 	Stat                    string
-	ExtendedStatistic       string // percentile statistic (e.g. "p95"); alternative to Stat
-	Unit                    string // the metric unit the alarm watches
-	TreatMissingData        string // "missing" (default), "notBreaching", "breaching", "ignore"
+	ExtendedStatistic       string   // percentile statistic (e.g. "p95"); alternative to Stat
+	Unit                    string   // the metric unit the alarm watches
+	TreatMissingData        string   // "missing" (default), "notBreaching", "breaching", "ignore"
 	AlarmActions            []string // channel IDs to notify on ALARM
 	OKActions               []string // channel IDs to notify on OK
 	InsufficientDataActions []string // channel IDs to notify on INSUFFICIENT_DATA

--- a/services/monitoring/driver/driver.go
+++ b/services/monitoring/driver/driver.go
@@ -70,7 +70,11 @@ type AlarmConfig struct {
 	Threshold               float64
 	Period                  int
 	EvaluationPeriods       int
+	DatapointsToAlarm       int    // M in the M-of-N rule; 0 defaults to EvaluationPeriods
 	Stat                    string
+	ExtendedStatistic       string // percentile statistic (e.g. "p95"); alternative to Stat
+	Unit                    string // the metric unit the alarm watches
+	TreatMissingData        string // "missing" (default), "notBreaching", "breaching", "ignore"
 	AlarmActions            []string // channel IDs to notify on ALARM
 	OKActions               []string // channel IDs to notify on OK
 	InsufficientDataActions []string // channel IDs to notify on INSUFFICIENT_DATA
@@ -91,7 +95,11 @@ type AlarmInfo struct {
 	StateUpdatedTimestamp   time.Time
 	Period                  int
 	EvaluationPeriods       int
+	DatapointsToAlarm       int
 	Statistic               string
+	ExtendedStatistic       string
+	Unit                    string
+	TreatMissingData        string
 	ActionsEnabled          bool
 	AlarmActions            []string
 	OKActions               []string

--- a/services/monitoring/driver/driver.go
+++ b/services/monitoring/driver/driver.go
@@ -132,7 +132,10 @@ type AlarmHistoryEntry struct {
 	Timestamp time.Time
 	OldState  string
 	NewState  string
-	Reason    string
+	// HistoryItemType classifies the entry (e.g. "StateUpdate",
+	// "ConfigurationUpdate", "Action"); empty is treated as "StateUpdate".
+	HistoryItemType string
+	Reason          string
 }
 
 // Monitoring is the interface that monitoring provider implementations must satisfy.


### PR DESCRIPTION
## Summary

Fixes six real AWS CloudWatch correctness bugs found by a deep real-SDK e2e audit
(two HIGH). Each is fixed at the correct three-layer location and cross-checked
against the official CloudWatch API docs.

## Findings fixed

1. **[HIGH] Exact dimension matching.** CloudWatch treats each unique dimension
   combination as a separate metric, so a query with fewer/no dimensions must not
   return datapoints published under a superset. `matchDimensions` now requires
   exact set equality, for both metric reads and alarm evaluation (an alarm reads
   only its own dimensioned stream).

2. **[HIGH] SetAlarmState records history and fires actions.** Manually setting a
   state now goes through a shared `transitionAlarm` helper that, on a state
   change, appends a `StateUpdate` history entry and invokes the new state's SNS
   actions — matching AWS, where SetAlarmState behaves like an evaluated
   transition. Previously history was empty and no notification fired.

3. **[MED] Per-period M-of-N alarm evaluation with OK recovery.** Evaluation used
   to fold the whole window into one aggregate, so a de-noised alarm
   (`EvaluationPeriods > 1`) fired on a single breaching period and never
   recovered. It now buckets the window into per-`Period` datapoints, evaluates
   the statistic per bucket, and alarms when `DatapointsToAlarm` of the last
   `EvaluationPeriods` breach (default M=N), returning to OK otherwise. Missing
   periods are counted per `TreatMissingData` (breaching / notBreaching / default
   missing).

4. **[MED] Alarm field round-trip.** `DatapointsToAlarm`, `TreatMissingData`,
   `Unit` and `ExtendedStatistic` are now threaded through the driver, the CBOR
   and query wire structs, and the provider so PutMetricAlarm persists them and
   DescribeAlarms reflects them (fixes Terraform perpetual drift).

5. **[MED] DeleteAlarms tolerates unknown names.** AWS deletes the correctly named
   alarms and ignores incorrect names without error. Both wire paths aborted on
   the first missing name (order-dependent partial delete); they now skip
   not-found names and return success.

6. **[MED] DescribeAlarmHistory ordering + filters.** History was oldest-first and
   dropped the newest on limit; `HistoryItemType`, `StartDate/EndDate` and
   `ScanBy` were ignored. `GetAlarmHistory` now returns newest-first and keeps the
   newest N; the wire layer honors HistoryItemType, the date window and ScanBy,
   truncates to MaxRecords last, and echoes each entry's real HistoryItemType (new
   `AlarmHistoryEntry.HistoryItemType`, defaulting to StateUpdate).

Out of scope (ticketed separately): Dashboards, composite alarms,
GetMetricWidgetImage, and high-res `StorageResolution=1`.

## Tests

Real `aws-sdk-go-v2` reproductions for each fix: exact-dimension exclusion,
per-period M-of-N with OK recovery (FakeClock-backed for determinism), alarm
field round-trip, DeleteAlarms tolerating an unknown name, SetAlarmState
recording history and firing the SNS AlarmAction to a subscribed SQS queue, and
DescribeAlarmHistory newest-first with MaxRecords/ScanBy/HistoryItemType filters.
Existing CloudWatch tests and the #568 alarm/metric-filter e2e stay green.
