### PR TITLE
fix(aws-kinesis): honor ListStreams ExclusiveStartStreamName + ListShards ShardFilter

### DIFF
--- a/providers/aws/kinesis/kinesis.go
+++ b/providers/aws/kinesis/kinesis.go
@@ -33,13 +33,23 @@ const (
 	shardIDFmt  = "shardId-%012d"
 	hashKeyBits = 128
 	base10      = 10
+	// onDemandStartShards is the shard count an on-demand stream starts with.
+	onDemandStartShards = 4
+	// maxTargetShardCount / shardScaleFactor bound a single UpdateShardCount call:
+	// AWS caps the target at 10000 and permits scaling by at most a factor of two.
+	maxTargetShardCount = 10000
+	shardScaleFactor    = 2
 )
 
-// shardState is a shard plus its stored records and open/closed flag.
+// shardState is a shard plus its stored records and open/closed flag. createdAt
+// and closedAt (zero while open) time-stamp the shard's lifetime so ListShards
+// can honor the timestamp-based ShardFilter types.
 type shardState struct {
-	shard   driver.Shard
-	records []driver.Record
-	closed  bool
+	shard     driver.Shard
+	records   []driver.Record
+	closed    bool
+	createdAt time.Time
+	closedAt  time.Time
 }
 
 // streamData is the full server-side state of a stream.

--- a/providers/aws/kinesis/list_params_test.go
+++ b/providers/aws/kinesis/list_params_test.go
@@ -1,0 +1,270 @@
+package kinesis_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/aws/kinesis"
+	"github.com/stackshy/cloudemu/v2/services/kinesis/driver"
+)
+
+func newClockMock(t *testing.T, clk config.Clock) *kinesis.Mock {
+	t.Helper()
+
+	return kinesis.New(config.NewOptions(config.WithClock(clk)))
+}
+
+func TestListStreamsExclusiveStartStreamName(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	for _, n := range []string{"s-a", "s-b", "s-c", "s-d"} {
+		if err := m.CreateStream(ctx, driver.CreateStreamInput{StreamName: n, ShardCount: 1}); err != nil {
+			t.Fatalf("CreateStream(%s): %v", n, err)
+		}
+	}
+
+	out, err := m.ListStreams(ctx, "", "s-b", 0)
+	if err != nil {
+		t.Fatalf("ListStreams: %v", err)
+	}
+
+	if got := out.StreamNames; len(got) != 2 || got[0] != "s-c" || got[1] != "s-d" {
+		t.Fatalf("ExclusiveStartStreamName=s-b returned %v, want [s-c s-d]", got)
+	}
+}
+
+func TestListStreamsNextTokenStillPaginates(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	for _, n := range []string{"s-a", "s-b", "s-c", "s-d"} {
+		if err := m.CreateStream(ctx, driver.CreateStreamInput{StreamName: n, ShardCount: 1}); err != nil {
+			t.Fatalf("CreateStream(%s): %v", n, err)
+		}
+	}
+
+	seen := map[string]int{}
+	token := ""
+
+	for i := 0; i < 10; i++ {
+		out, err := m.ListStreams(ctx, token, "", 2)
+		if err != nil {
+			t.Fatalf("ListStreams: %v", err)
+		}
+
+		for _, n := range out.StreamNames {
+			seen[n]++
+		}
+
+		if !out.HasMoreStreams {
+			break
+		}
+
+		token = out.NextToken
+	}
+
+	if len(seen) != 4 {
+		t.Fatalf("distinct streams walked = %d, want 4", len(seen))
+	}
+
+	for n, c := range seen {
+		if c != 1 {
+			t.Fatalf("stream %s returned %d times, want 1 (duplicate)", n, c)
+		}
+	}
+}
+
+// mergedStream creates a 2-shard stream and merges its two shards, leaving 2
+// closed parents and 1 open child. The clock is advanced around each phase so
+// the shards carry distinct creation/close timestamps.
+func mergedStream(t *testing.T, m *kinesis.Mock, clk *config.FakeClock) {
+	t.Helper()
+
+	ctx := context.Background()
+	if err := m.CreateStream(ctx, driver.CreateStreamInput{StreamName: "s", ShardCount: 2}); err != nil {
+		t.Fatalf("CreateStream: %v", err)
+	}
+
+	clk.Advance(time.Minute)
+
+	if err := m.MergeShards(ctx, "s", "", "shardId-000000000000", "shardId-000000000001"); err != nil {
+		t.Fatalf("MergeShards: %v", err)
+	}
+
+	clk.Advance(time.Minute)
+}
+
+func listShards(t *testing.T, m *kinesis.Mock, f *driver.ShardFilter) []driver.Shard {
+	t.Helper()
+
+	out, err := m.ListShards(context.Background(), driver.ListShardsInput{StreamName: "s", ShardFilter: f})
+	if err != nil {
+		t.Fatalf("ListShards: %v", err)
+	}
+
+	return out.Shards
+}
+
+func openShards(shards []driver.Shard) []driver.Shard {
+	var open []driver.Shard
+
+	for _, s := range shards {
+		if s.SequenceNumberRange.EndingSequenceNumber == "" {
+			open = append(open, s)
+		}
+	}
+
+	return open
+}
+
+func TestListShardsShardFilterAtLatest(t *testing.T) {
+	clk := config.NewFakeClock(time.Unix(1_000_000, 0).UTC())
+	m := newClockMock(t, clk)
+	mergedStream(t, m, clk)
+
+	if all := listShards(t, m, nil); len(all) != 3 {
+		t.Fatalf("no filter returned %d shards, want 3", len(all))
+	}
+
+	got := listShards(t, m, &driver.ShardFilter{Type: driver.ShardFilterAtLatest})
+	if len(got) != 1 {
+		t.Fatalf("AT_LATEST returned %d shards, want 1 (only the open child)", len(got))
+	}
+
+	if got[0].SequenceNumberRange.EndingSequenceNumber != "" {
+		t.Fatalf("AT_LATEST returned a closed shard %s", got[0].ShardID)
+	}
+}
+
+func TestListShardsShardFilterTypes(t *testing.T) {
+	base := time.Unix(1_000_000, 0).UTC()
+	clk := config.NewFakeClock(base)
+	m := newClockMock(t, clk)
+	mergedStream(t, m, clk) // create @base, merge @base+1m, now @base+2m
+
+	// AT_TRIM_HORIZON: only shards open at the trim horizon (stream creation) —
+	// the two originals, not the later child.
+	trim := listShards(t, m, &driver.ShardFilter{Type: driver.ShardFilterAtTrimHorizon})
+	if len(trim) != 2 {
+		t.Fatalf("AT_TRIM_HORIZON returned %d shards, want 2", len(trim))
+	}
+
+	// FROM_TRIM_HORIZON (default): the whole set.
+	if all := listShards(t, m, &driver.ShardFilter{Type: driver.ShardFilterFromTrimHorizon}); len(all) != 3 {
+		t.Fatalf("FROM_TRIM_HORIZON returned %d shards, want 3", len(all))
+	}
+
+	// AFTER_SHARD_ID: shards strictly after the given id.
+	after := listShards(t, m, &driver.ShardFilter{
+		Type: driver.ShardFilterAfterShardID, ShardID: "shardId-000000000000",
+	})
+	if len(after) != 2 {
+		t.Fatalf("AFTER_SHARD_ID returned %d shards, want 2", len(after))
+	}
+
+	for _, s := range after {
+		if s.ShardID == "shardId-000000000000" {
+			t.Fatal("AFTER_SHARD_ID included the exclusive-start shard")
+		}
+	}
+
+	// AT_TIMESTAMP after the merge: only the open child (parents already closed).
+	atTS := listShards(t, m, &driver.ShardFilter{
+		Type: driver.ShardFilterAtTimestamp, Timestamp: base.Add(2 * time.Minute),
+	})
+	if len(atTS) != 1 || len(openShards(atTS)) != 1 {
+		t.Fatalf("AT_TIMESTAMP(now) returned %d shards, want 1 open child", len(atTS))
+	}
+
+	// FROM_TIMESTAMP after the merge: open shards plus closed shards ending at/after
+	// ts; the parents closed before ts, so only the child qualifies.
+	fromTS := listShards(t, m, &driver.ShardFilter{
+		Type: driver.ShardFilterFromTimestamp, Timestamp: base.Add(2 * time.Minute),
+	})
+	if len(fromTS) != 1 {
+		t.Fatalf("FROM_TIMESTAMP(now) returned %d shards, want 1", len(fromTS))
+	}
+
+	// FROM_TIMESTAMP clamped below the trim horizon returns the whole set.
+	early := listShards(t, m, &driver.ShardFilter{
+		Type: driver.ShardFilterFromTimestamp, Timestamp: base.Add(-time.Hour),
+	})
+	if len(early) != 3 {
+		t.Fatalf("FROM_TIMESTAMP(pre-horizon) returned %d shards, want 3", len(early))
+	}
+}
+
+func TestListShardsShardFilterTimestampRequired(t *testing.T) {
+	clk := config.NewFakeClock(time.Unix(1_000_000, 0).UTC())
+	m := newClockMock(t, clk)
+
+	if err := m.CreateStream(context.Background(), driver.CreateStreamInput{StreamName: "s", ShardCount: 1}); err != nil {
+		t.Fatalf("CreateStream: %v", err)
+	}
+
+	if _, err := m.ListShards(context.Background(), driver.ListShardsInput{
+		StreamName: "s", ShardFilter: &driver.ShardFilter{Type: driver.ShardFilterAtTimestamp},
+	}); err == nil {
+		t.Fatal("AT_TIMESTAMP without a Timestamp should fail")
+	}
+}
+
+func TestCreateStreamOnDemandRejectsShardCount(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	err := m.CreateStream(ctx, driver.CreateStreamInput{
+		StreamName: "od-bad", ShardCount: 2, StreamMode: driver.ModeOnDemand,
+	})
+	if err == nil {
+		t.Fatal("ON_DEMAND with an explicit ShardCount should fail")
+	}
+
+	if err := m.CreateStream(ctx, driver.CreateStreamInput{
+		StreamName: "od-ok", StreamMode: driver.ModeOnDemand,
+	}); err != nil {
+		t.Fatalf("ON_DEMAND without ShardCount: %v", err)
+	}
+
+	desc, err := m.DescribeStream(ctx, "od-ok", "", 0, "")
+	if err != nil {
+		t.Fatalf("DescribeStream: %v", err)
+	}
+
+	if len(desc.Shards) != 4 {
+		t.Fatalf("on-demand stream started with %d shards, want 4", len(desc.Shards))
+	}
+}
+
+func TestUpdateShardCountBounds(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	if err := m.CreateStream(ctx, driver.CreateStreamInput{StreamName: "s", ShardCount: 2}); err != nil {
+		t.Fatalf("CreateStream: %v", err)
+	}
+
+	if _, _, err := m.UpdateShardCount(ctx, "s", "", 0, ""); err == nil {
+		t.Fatal("TargetShardCount 0 should fail")
+	}
+
+	if _, _, err := m.UpdateShardCount(ctx, "s", "", 5, ""); err == nil {
+		t.Fatal("scaling 2 -> 5 (more than 2x) should fail")
+	}
+
+	if _, _, err := m.UpdateShardCount(ctx, "s", "", 4, ""); err != nil {
+		t.Fatalf("scaling 2 -> 4 (exactly 2x): %v", err)
+	}
+
+	// Current open count is now 4; halving to 1 (below half) must fail, to 2 is ok.
+	if _, _, err := m.UpdateShardCount(ctx, "s", "", 1, ""); err == nil {
+		t.Fatal("scaling 4 -> 1 (below half) should fail")
+	}
+
+	if _, _, err := m.UpdateShardCount(ctx, "s", "", 2, ""); err != nil {
+		t.Fatalf("scaling 4 -> 2 (exactly half): %v", err)
+	}
+}

--- a/providers/aws/kinesis/records.go
+++ b/providers/aws/kinesis/records.go
@@ -380,11 +380,49 @@ func childShardsOf(shards []*shardState, parentID string) []driver.ChildShard {
 }
 
 // listShardsToken is the opaque NextToken ListShards hands back: real Kinesis
-// forbids passing StreamName alongside NextToken, so the token must carry the
-// stream identity plus the cursor to resume after.
+// forbids passing StreamName or ShardFilter alongside NextToken, so the token
+// must carry the stream identity, the cursor to resume after, and any active
+// filter so later pages stay consistent with the first.
 type listShardsToken struct {
 	StreamName string `json:"s"`
 	AfterShard string `json:"a"`
+	FilterType string `json:"f,omitempty"`
+	FilterTS   int64  `json:"t,omitempty"` // Unix seconds; 0 when no timestamp
+}
+
+// filter reconstructs the ShardFilter a paginating token must keep applying.
+// Full-set and AFTER_SHARD_ID filters aren't persisted — the AfterShard cursor
+// already captures them — so only the state-narrowing types come back here.
+func (t listShardsToken) filter() *driver.ShardFilter {
+	if t.FilterType == "" {
+		return nil
+	}
+
+	f := &driver.ShardFilter{Type: t.FilterType}
+	if t.FilterTS != 0 {
+		f.Timestamp = time.Unix(t.FilterTS, 0).UTC()
+	}
+
+	return f
+}
+
+// newListShardsToken builds the next-page token, persisting only filters that
+// still constrain subsequent pages.
+func newListShardsToken(streamName, afterShard string, f *driver.ShardFilter) listShardsToken {
+	t := listShardsToken{StreamName: streamName, AfterShard: afterShard}
+
+	if f != nil {
+		switch f.Type {
+		case driver.ShardFilterAtLatest, driver.ShardFilterAtTrimHorizon,
+			driver.ShardFilterAtTimestamp, driver.ShardFilterFromTimestamp:
+			t.FilterType = f.Type
+			if !f.Timestamp.IsZero() {
+				t.FilterTS = f.Timestamp.Unix()
+			}
+		}
+	}
+
+	return t
 }
 
 func encodeListShardsToken(t listShardsToken) string {
@@ -407,20 +445,27 @@ func decodeListShardsToken(s string) (listShardsToken, error) {
 	return t, nil
 }
 
-// ListShards lists a stream's shards.
+// ListShards lists a stream's shards, optionally narrowed by a ShardFilter.
+//
+//nolint:gocritic // in is the public ListShards input, taken by value to match the driver API
 func (m *Mock) ListShards(_ context.Context, in driver.ListShardsInput) (*driver.ListShardsOutput, error) {
 	streamName, streamARN := in.StreamName, in.StreamARN
 
-	// A NextToken from a prior page carries the stream identity + resume cursor.
+	// A NextToken from a prior page carries the stream identity + resume cursor
+	// (+ any active filter). Otherwise AFTER_SHARD_ID sets the initial cursor.
 	start := in.ExclusiveStartShardID
+	filter := in.ShardFilter
 
-	if in.NextToken != "" {
+	switch {
+	case in.NextToken != "":
 		tok, err := decodeListShardsToken(in.NextToken)
 		if err != nil {
 			return nil, err
 		}
 
-		streamName, streamARN, start = tok.StreamName, "", tok.AfterShard
+		streamName, streamARN, start, filter = tok.StreamName, "", tok.AfterShard, tok.filter()
+	case filter != nil && filter.Type == driver.ShardFilterAfterShardID:
+		start = filter.ShardID
 	}
 
 	sd, err := m.resolve(streamName, streamARN)
@@ -431,15 +476,86 @@ func (m *Mock) ListShards(_ context.Context, in driver.ListShardsInput) (*driver
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
 
-	shards, more := pageShards(sd.shards, in.MaxResults, start)
+	filtered, err := filterShards(sd.shards, filter, sd.desc.StreamCreationTimestamp)
+	if err != nil {
+		return nil, err
+	}
+
+	shards, more := pageShards(filtered, in.MaxResults, start)
 
 	out := &driver.ListShardsOutput{Shards: shards}
 	if more && len(shards) > 0 {
-		out.NextToken = encodeListShardsToken(listShardsToken{
-			StreamName: sd.desc.StreamName,
-			AfterShard: shards[len(shards)-1].ShardID,
-		})
+		out.NextToken = encodeListShardsToken(
+			newListShardsToken(sd.desc.StreamName, shards[len(shards)-1].ShardID, filter))
 	}
 
 	return out, nil
+}
+
+// filterShards returns the subset of shards a ShardFilter selects. Records are
+// never trimmed in the emulator, so the trim horizon is the stream's creation
+// time and the retention window spans creation→now.
+func filterShards(shards []*shardState, f *driver.ShardFilter, trimHorizon time.Time) ([]*shardState, error) {
+	if f == nil || f.Type == "" {
+		return shards, nil
+	}
+
+	switch f.Type {
+	case driver.ShardFilterFromTrimHorizon, driver.ShardFilterAfterShardID:
+		// Whole shard set; AFTER_SHARD_ID additionally advances the start cursor.
+		return shards, nil
+	case driver.ShardFilterAtLatest:
+		return selectShards(shards, func(ss *shardState) bool { return !ss.closed }), nil
+	case driver.ShardFilterAtTrimHorizon:
+		return selectShards(shards, func(ss *shardState) bool { return openAt(ss, trimHorizon) }), nil
+	case driver.ShardFilterAtTimestamp, driver.ShardFilterFromTimestamp:
+		return filterByTimestamp(shards, f, trimHorizon)
+	default:
+		return nil, invalidArg("unsupported ShardFilter type %q", f.Type)
+	}
+}
+
+// filterByTimestamp applies the AT_TIMESTAMP / FROM_TIMESTAMP filters, both of
+// which require a Timestamp. AT_TIMESTAMP returns shards open at that instant;
+// FROM_TIMESTAMP returns open shards plus closed shards ending at/after it
+// (clamped up to the trim horizon).
+func filterByTimestamp(shards []*shardState, f *driver.ShardFilter, trimHorizon time.Time) ([]*shardState, error) {
+	if f.Timestamp.IsZero() {
+		return nil, invalidArg("ShardFilter %s requires a Timestamp", f.Type)
+	}
+
+	if f.Type == driver.ShardFilterAtTimestamp {
+		return selectShards(shards, func(ss *shardState) bool { return openAt(ss, f.Timestamp) }), nil
+	}
+
+	ts := f.Timestamp
+	if ts.Before(trimHorizon) {
+		ts = trimHorizon
+	}
+
+	return selectShards(shards, func(ss *shardState) bool {
+		return !ss.closed || !ss.closedAt.Before(ts)
+	}), nil
+}
+
+// openAt reports whether a shard was open at ts: created at or before ts and not
+// yet closed at ts (start <= ts <= end, or still open).
+func openAt(ss *shardState, ts time.Time) bool {
+	if ss.createdAt.After(ts) {
+		return false
+	}
+
+	return ss.closedAt.IsZero() || !ss.closedAt.Before(ts)
+}
+
+func selectShards(shards []*shardState, keep func(*shardState) bool) []*shardState {
+	out := make([]*shardState, 0, len(shards))
+
+	for _, ss := range shards {
+		if keep(ss) {
+			out = append(out, ss)
+		}
+	}
+
+	return out
 }

--- a/providers/aws/kinesis/resharding.go
+++ b/providers/aws/kinesis/resharding.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/stackshy/cloudemu/v2/services/kinesis/driver"
 )
@@ -46,14 +47,16 @@ func (m *Mock) SplitShard(_ context.Context, name, arn, shardToSplit, newStartin
 		return invalidArg("NewStartingHashKey must fall within the parent shard's hash-key range")
 	}
 
+	now := m.now()
 	endSeq := sd.nextSeq()
 	parent.closed = true
+	parent.closedAt = now
 	parent.shard.SequenceNumberRange.EndingSequenceNumber = endSeq
 
 	startSeq := sd.nextSeq()
 	left := m.childShard(len(sd.shards), start.String(),
-		new(big.Int).Sub(newStart, big.NewInt(1)).String(), startSeq, shardToSplit, "")
-	right := m.childShard(len(sd.shards)+1, newStart.String(), end.String(), startSeq, shardToSplit, "")
+		new(big.Int).Sub(newStart, big.NewInt(1)).String(), startSeq, shardToSplit, "", now)
+	right := m.childShard(len(sd.shards)+1, newStart.String(), end.String(), startSeq, shardToSplit, "", now)
 	sd.shards = append(sd.shards, left, right)
 
 	return nil
@@ -83,22 +86,27 @@ func (m *Mock) MergeShards(_ context.Context, name, arn, shardToMerge, adjacentS
 		return invalidArg("shards %q and %q are not adjacent", shardToMerge, adjacentShardToMerge)
 	}
 
+	now := m.now()
 	endSeq := sd.nextSeq()
 
 	for _, ss := range []*shardState{a, b} {
 		ss.closed = true
+		ss.closedAt = now
 		ss.shard.SequenceNumberRange.EndingSequenceNumber = endSeq
 	}
 
 	child := m.childShard(len(sd.shards), a.shard.HashKeyRange.StartingHashKey,
-		b.shard.HashKeyRange.EndingHashKey, sd.nextSeq(), shardToMerge, adjacentShardToMerge)
+		b.shard.HashKeyRange.EndingHashKey, sd.nextSeq(), shardToMerge, adjacentShardToMerge, now)
 	sd.shards = append(sd.shards, child)
 
 	return nil
 }
 
-func (*Mock) childShard(index int, startKey, endKey, startSeq, parent, adjacentParent string) *shardState {
+func (*Mock) childShard(
+	index int, startKey, endKey, startSeq, parent, adjacentParent string, createdAt time.Time,
+) *shardState {
 	return &shardState{
+		createdAt: createdAt,
 		shard: driver.Shard{
 			ShardID:               fmt.Sprintf(shardIDFmt, index),
 			ParentShardID:         parent,

--- a/providers/aws/kinesis/streams.go
+++ b/providers/aws/kinesis/streams.go
@@ -5,13 +5,15 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
+	"time"
 
 	"github.com/stackshy/cloudemu/v2/services/kinesis/driver"
 )
 
 // buildShards partitions the full 128-bit hash-key space into count open shards
-// numbered from startIndex, each seeded with the given starting sequence number.
-func (*Mock) buildShards(count int32, startIndex int, startSeq string) []*shardState {
+// numbered from startIndex, each seeded with the given starting sequence number
+// and creation time.
+func (*Mock) buildShards(count int32, startIndex int, startSeq string, createdAt time.Time) []*shardState {
 	shards := make([]*shardState, 0, count)
 	maxKey := maxHashKey()
 	span := new(big.Int).Div(new(big.Int).Add(maxKey, big.NewInt(1)), big.NewInt(int64(count)))
@@ -27,6 +29,7 @@ func (*Mock) buildShards(count int32, startIndex int, startSeq string) []*shardS
 		}
 
 		shards = append(shards, &shardState{
+			createdAt: createdAt,
 			shard: driver.Shard{
 				ShardID:             fmt.Sprintf(shardIDFmt, startIndex+int(i)),
 				HashKeyRange:        driver.HashKeyRange{StartingHashKey: start.String(), EndingHashKey: end.String()},
@@ -51,8 +54,15 @@ func (m *Mock) CreateStream(_ context.Context, in driver.CreateStreamInput) erro
 	}
 
 	shardCount := in.ShardCount
+
 	if mode == driver.ModeOnDemand {
-		shardCount = 4 // on-demand streams start with 4 shards
+		// On-demand streams manage their own shards; AWS rejects an explicit
+		// ShardCount for them and starts the stream with 4 shards.
+		if in.ShardCount != 0 {
+			return invalidArg("ShardCount is not supported for on-demand streams")
+		}
+
+		shardCount = onDemandStartShards
 	}
 
 	if shardCount < 1 {
@@ -75,7 +85,7 @@ func (m *Mock) CreateStream(_ context.Context, in driver.CreateStreamInput) erro
 		consumers: map[string]*driver.Consumer{},
 		tags:      copyTags(in.Tags),
 	}
-	sd.shards = m.buildShards(shardCount, 0, formatSeq(0))
+	sd.shards = m.buildShards(shardCount, 0, formatSeq(0), now)
 
 	if !m.streams.SetIfAbsent(in.StreamName, sd) {
 		return errInUse("stream %q already exists", in.StreamName)
@@ -197,8 +207,11 @@ func openShardCount(shards []*shardState) int32 {
 }
 
 // ListStreams returns stream names and summaries, ordered by name and paginated
-// by limit (a returned NextToken/HasMoreStreams resumes after the last name).
-func (m *Mock) ListStreams(_ context.Context, nextToken string, limit int32) (*driver.ListStreamsOutput, error) {
+// by limit. Results resume strictly after a cursor name: the opaque NextToken
+// (modern paginator) when set, otherwise the legacy ExclusiveStartStreamName.
+func (m *Mock) ListStreams(
+	_ context.Context, nextToken, exclusiveStartStreamName string, limit int32,
+) (*driver.ListStreamsOutput, error) {
 	all := m.streams.All()
 
 	names := make([]string, 0, len(all))
@@ -213,12 +226,18 @@ func (m *Mock) ListStreams(_ context.Context, nextToken string, limit int32) (*d
 		maxOut = int(limit)
 	}
 
+	// NextToken takes precedence; ExclusiveStartStreamName is the legacy cursor.
+	after := nextToken
+	if after == "" {
+		after = exclusiveStartStreamName
+	}
+
 	out := &driver.ListStreamsOutput{}
-	started := nextToken == ""
+	started := after == ""
 
 	for _, name := range names {
 		if !started {
-			if name == nextToken {
+			if name == after {
 				started = true
 			}
 
@@ -294,8 +313,8 @@ func (m *Mock) setRetention(name, arn string, hours int32, increase bool) error 
 func (m *Mock) UpdateShardCount(
 	_ context.Context, name, arn string, targetCount int32, _ string,
 ) (current, target int32, err error) {
-	if targetCount < 1 {
-		return 0, 0, invalidArg("TargetShardCount must be at least 1")
+	if targetCount < 1 || targetCount > maxTargetShardCount {
+		return 0, 0, invalidArg("TargetShardCount must be between 1 and %d", maxTargetShardCount)
 	}
 
 	sd, err := m.resolve(name, arn)
@@ -307,19 +326,41 @@ func (m *Mock) UpdateShardCount(
 	defer sd.mu.Unlock()
 
 	before := openShardCount(sd.shards)
-	endSeq := sd.nextSeq()
-	nextIdx := len(sd.shards)
 
-	// Snapshot the open shards' hash ranges, then close them, so each new shard
-	// can be linked to the parent(s) whose range it overlaps.
-	type parentRange struct {
-		id         string
-		start, end *big.Int
+	// AWS allows scaling by at most a factor of 2 (up or down) in a single call.
+	if targetCount > before*shardScaleFactor || targetCount*shardScaleFactor < before {
+		return 0, 0, invalidArg(
+			"TargetShardCount %d must be within half to double the current shard count %d", targetCount, before)
 	}
 
+	now := m.now()
+	nextIdx := len(sd.shards)
+
+	// Close the open shards (snapshotting their ranges), build the new open shards,
+	// then link each child to the parent(s) it overlaps so draining a closed shard
+	// reports its children — otherwise a following consumer dead-ends.
+	parents := closeOpenShards(sd.shards, now, sd.nextSeq())
+	children := m.buildShards(targetCount, nextIdx, sd.nextSeq(), now)
+	linkChildren(children, parents)
+
+	sd.shards = append(sd.shards, children...)
+
+	return before, targetCount, nil
+}
+
+// parentRange is a closed shard's id and hash-key range, used to link the child
+// shards a reshard creates back to the parents whose range they overlap.
+type parentRange struct {
+	id         string
+	start, end *big.Int
+}
+
+// closeOpenShards closes every open shard, stamping its end sequence and close
+// time, and returns the hash ranges of the shards that were open.
+func closeOpenShards(shards []*shardState, closedAt time.Time, endSeq string) []parentRange {
 	var parents []parentRange
 
-	for _, ss := range sd.shards {
+	for _, ss := range shards {
 		if ss.closed {
 			continue
 		}
@@ -328,14 +369,16 @@ func (m *Mock) UpdateShardCount(
 		e, _ := new(big.Int).SetString(ss.shard.HashKeyRange.EndingHashKey, base10)
 		parents = append(parents, parentRange{ss.shard.ShardID, s, e})
 		ss.closed = true
+		ss.closedAt = closedAt
 		ss.shard.SequenceNumberRange.EndingSequenceNumber = endSeq
 	}
 
-	children := m.buildShards(targetCount, nextIdx, sd.nextSeq())
+	return parents
+}
 
-	// Link each child to the parent shard(s) it overlaps, so draining a closed
-	// shard reports its children (closed-shard→child contract), matching
-	// SplitShard/MergeShards — otherwise a following consumer dead-ends.
+// linkChildren records, on each child shard, the parent range(s) its hash-key
+// range overlaps (up to two, matching the split/merge parent contract).
+func linkChildren(children []*shardState, parents []parentRange) {
 	for _, ch := range children {
 		cs, _ := new(big.Int).SetString(ch.shard.HashKeyRange.StartingHashKey, base10)
 		ce, _ := new(big.Int).SetString(ch.shard.HashKeyRange.EndingHashKey, base10)
@@ -356,10 +399,6 @@ func (m *Mock) UpdateShardCount(
 			ch.shard.AdjacentParentShardID = overlap[1]
 		}
 	}
-
-	sd.shards = append(sd.shards, children...)
-
-	return before, targetCount, nil
 }
 
 // UpdateStreamMode switches a stream between PROVISIONED and ON_DEMAND.

--- a/server/aws/kinesis/records_ops.go
+++ b/server/aws/kinesis/records_ops.go
@@ -152,12 +152,32 @@ func (h *Handler) getRecords(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+type shardFilterJSON struct {
+	Type      string   `json:"Type"`
+	ShardID   string   `json:"ShardId"`
+	Timestamp *float64 `json:"Timestamp"`
+}
+
+func (f *shardFilterJSON) toDriver() *kinesisdriver.ShardFilter {
+	if f == nil {
+		return nil
+	}
+
+	out := &kinesisdriver.ShardFilter{Type: f.Type, ShardID: f.ShardID}
+	if f.Timestamp != nil {
+		out.Timestamp = time.Unix(int64(*f.Timestamp), 0).UTC()
+	}
+
+	return out
+}
+
 type listShardsRequest struct {
-	StreamName            string `json:"StreamName"`
-	StreamARN             string `json:"StreamARN"`
-	NextToken             string `json:"NextToken"`
-	MaxResults            int32  `json:"MaxResults"`
-	ExclusiveStartShardID string `json:"ExclusiveStartShardId"`
+	StreamName            string           `json:"StreamName"`
+	StreamARN             string           `json:"StreamARN"`
+	NextToken             string           `json:"NextToken"`
+	MaxResults            int32            `json:"MaxResults"`
+	ExclusiveStartShardID string           `json:"ExclusiveStartShardId"`
+	ShardFilter           *shardFilterJSON `json:"ShardFilter"`
 }
 
 func (h *Handler) listShards(w http.ResponseWriter, r *http.Request) {
@@ -168,6 +188,7 @@ func (h *Handler) listShards(w http.ResponseWriter, r *http.Request) {
 			NextToken:             req.NextToken,
 			MaxResults:            req.MaxResults,
 			ExclusiveStartShardID: req.ExclusiveStartShardID,
+			ShardFilter:           req.ShardFilter.toDriver(),
 		})
 		if err != nil {
 			return nil, err

--- a/server/aws/kinesis/sdk_roundtrip_list_params_test.go
+++ b/server/aws/kinesis/sdk_roundtrip_list_params_test.go
@@ -1,0 +1,82 @@
+package kinesis_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awskinesis "github.com/aws/aws-sdk-go-v2/service/kinesis"
+	kinesistypes "github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+)
+
+func TestSDKListStreamsExclusiveStartStreamName(t *testing.T) {
+	ctx := context.Background()
+	c := newKinesisClient(t)
+
+	for _, n := range []string{"s-a", "s-b", "s-c", "s-d"} {
+		mustCreate(t, c, n, 1)
+	}
+
+	out, err := c.ListStreams(ctx, &awskinesis.ListStreamsInput{
+		ExclusiveStartStreamName: aws.String("s-b"),
+	})
+	if err != nil {
+		t.Fatalf("ListStreams: %v", err)
+	}
+
+	if len(out.StreamNames) != 2 || out.StreamNames[0] != "s-c" || out.StreamNames[1] != "s-d" {
+		t.Fatalf("ExclusiveStartStreamName=s-b returned %v, want [s-c s-d]", out.StreamNames)
+	}
+}
+
+func TestSDKListShardsShardFilterAtLatest(t *testing.T) {
+	ctx := context.Background()
+	c := newKinesisClient(t)
+
+	mustCreate(t, c, "merge", 2)
+
+	desc, err := c.DescribeStream(ctx, &awskinesis.DescribeStreamInput{StreamName: aws.String("merge")})
+	if err != nil {
+		t.Fatalf("DescribeStream: %v", err)
+	}
+
+	shards := desc.StreamDescription.Shards
+	if len(shards) != 2 {
+		t.Fatalf("want 2 shards to merge, got %d", len(shards))
+	}
+
+	if _, err := c.MergeShards(ctx, &awskinesis.MergeShardsInput{
+		StreamName:           aws.String("merge"),
+		ShardToMerge:         shards[0].ShardId,
+		AdjacentShardToMerge: shards[1].ShardId,
+	}); err != nil {
+		t.Fatalf("MergeShards: %v", err)
+	}
+
+	// Unfiltered: 2 closed parents + 1 open child.
+	all, err := c.ListShards(ctx, &awskinesis.ListShardsInput{StreamName: aws.String("merge")})
+	if err != nil {
+		t.Fatalf("ListShards: %v", err)
+	}
+
+	if len(all.Shards) != 3 {
+		t.Fatalf("unfiltered ListShards = %d shards, want 3", len(all.Shards))
+	}
+
+	// AT_LATEST: only the currently open child shard.
+	latest, err := c.ListShards(ctx, &awskinesis.ListShardsInput{
+		StreamName:  aws.String("merge"),
+		ShardFilter: &kinesistypes.ShardFilter{Type: kinesistypes.ShardFilterTypeAtLatest},
+	})
+	if err != nil {
+		t.Fatalf("ListShards AT_LATEST: %v", err)
+	}
+
+	if len(latest.Shards) != 1 {
+		t.Fatalf("AT_LATEST = %d shards, want 1 open child", len(latest.Shards))
+	}
+
+	if latest.Shards[0].SequenceNumberRange.EndingSequenceNumber != nil {
+		t.Fatalf("AT_LATEST returned a closed shard %s", aws.ToString(latest.Shards[0].ShardId))
+	}
+}

--- a/server/aws/kinesis/streams_ops.go
+++ b/server/aws/kinesis/streams_ops.go
@@ -133,13 +133,14 @@ func (h *Handler) describeStreamSummary(w http.ResponseWriter, r *http.Request) 
 }
 
 type listStreamsRequest struct {
-	Limit     int32  `json:"Limit"`
-	NextToken string `json:"NextToken"`
+	Limit                    int32  `json:"Limit"`
+	NextToken                string `json:"NextToken"`
+	ExclusiveStartStreamName string `json:"ExclusiveStartStreamName"`
 }
 
 func (h *Handler) listStreams(w http.ResponseWriter, r *http.Request) {
 	dispatch(h, w, r, func(h *Handler, ctx context.Context, req *listStreamsRequest) (any, error) {
-		out, err := h.kinesis.ListStreams(ctx, req.NextToken, req.Limit)
+		out, err := h.kinesis.ListStreams(ctx, req.NextToken, req.ExclusiveStartStreamName, req.Limit)
 		if err != nil {
 			return nil, err
 		}

--- a/services/kinesis/driver/driver.go
+++ b/services/kinesis/driver/driver.go
@@ -45,6 +45,16 @@ const (
 	ConsumerActive   = "ACTIVE"
 )
 
+// ShardFilter types narrow ListShards to a subset of a stream's shards.
+const (
+	ShardFilterAfterShardID    = "AFTER_SHARD_ID"
+	ShardFilterAtTrimHorizon   = "AT_TRIM_HORIZON"
+	ShardFilterFromTrimHorizon = "FROM_TRIM_HORIZON"
+	ShardFilterAtLatest        = "AT_LATEST"
+	ShardFilterAtTimestamp     = "AT_TIMESTAMP"
+	ShardFilterFromTimestamp   = "FROM_TIMESTAMP"
+)
+
 // HashKeyRange is the range of MD5 hash-key values a shard owns.
 type HashKeyRange struct {
 	StartingHashKey string
@@ -199,6 +209,15 @@ type SubscribeToShardResult struct {
 	MillisBehindLatest         int64
 }
 
+// ShardFilter narrows ListShards to a subset of shards. Type is one of the
+// ShardFilter* constants; ShardID applies only to AFTER_SHARD_ID and Timestamp
+// only to AT_TIMESTAMP / FROM_TIMESTAMP.
+type ShardFilter struct {
+	Type      string
+	ShardID   string
+	Timestamp time.Time
+}
+
 // ListShardsInput narrows ListShards.
 type ListShardsInput struct {
 	StreamName            string
@@ -206,6 +225,7 @@ type ListShardsInput struct {
 	NextToken             string
 	MaxResults            int32
 	ExclusiveStartShardID string
+	ShardFilter           *ShardFilter
 }
 
 // ListShardsOutput is the result of ListShards.
@@ -247,7 +267,7 @@ type Kinesis interface {
 	DeleteStream(ctx context.Context, name, arn string, enforceConsumerDeletion bool) error
 	DescribeStream(ctx context.Context, name, arn string, limit int32, exclusiveStartShardID string) (*StreamDescription, error)
 	DescribeStreamSummary(ctx context.Context, name, arn string) (*StreamSummary, error)
-	ListStreams(ctx context.Context, nextToken string, limit int32) (*ListStreamsOutput, error)
+	ListStreams(ctx context.Context, nextToken, exclusiveStartStreamName string, limit int32) (*ListStreamsOutput, error)
 	IncreaseStreamRetentionPeriod(ctx context.Context, name, arn string, hours int32) error
 	DecreaseStreamRetentionPeriod(ctx context.Context, name, arn string, hours int32) error
 	UpdateShardCount(ctx context.Context, name, arn string, targetCount int32, scalingType string) (current, target int32, err error)


### PR DESCRIPTION
## What

Two MED bugs found by the Kinesis deep-e2e real-user audit, plus two low-risk nits — all fixed at the correct 3-layer location (wire → driver → provider).

**F1 [MED] ListStreams ignored `ExclusiveStartStreamName`.** The legacy/CLI pagination cursor was silently dropped, so callers paginating with `ExclusiveStartStreamName` re-read from the top every call (duplicate results / non-terminating loop). Now threaded through wire→driver→provider: results resume strictly *after* the named stream (lexicographic order). The modern opaque `NextToken` paginator still works and takes precedence — both coexist.

**F2 [MED] ListShards ignored `ShardFilter`.** KCL 2.x uses `ShardFilter{Type: AT_LATEST}` to discover the live shard set; we returned *all* shards (including CLOSED parents after a reshard), so KCL could lease already-closed shards. Now honored end-to-end:
- `AT_LATEST` → only currently-open shards
- `AT_TRIM_HORIZON` → shards open at the trim horizon (stream creation, since the emulator never trims)
- `FROM_TRIM_HORIZON` (default) → whole set
- `AFTER_SHARD_ID` → shards after the given id
- `AT_TIMESTAMP` / `FROM_TIMESTAMP` → shards active at / from a timestamp

Implemented via per-shard `createdAt`/`closedAt` timestamps. The active filter is persisted into the `NextToken` so later pages stay consistent with the first.

**Nits (low-risk):**
- CreateStream now rejects an explicit `ShardCount` for `ON_DEMAND` streams (AWS does; on-demand still starts at 4 shards otherwise).
- UpdateShardCount now enforces `TargetShardCount` bounds: `1..10000` and within half-to-double the current shard count in a single call.

Deferred (out of scope, larger): shard-iterator expiry (needs a clock/TTL on iterators).

## Why

Each behavior was cross-checked against the official AWS Kinesis API docs (ListStreams, ShardFilter, CreateStream). These are real divergences a KCL / CLI / boto user hits during pagination and shard discovery.

## Tests

Real `aws-sdk-go-v2` reproductions + provider-level matrix:
- `ListStreams(ExclusiveStartStreamName="s-b")` over s-a..s-d → `[s-c, s-d]`; NextToken paginator still walks all streams with no dupes.
- `ListShards(ShardFilter{AT_LATEST})` after MergeShards → only the open child; unfiltered → all 3.
- Full filter matrix (AT/FROM_TRIM_HORIZON, AFTER_SHARD_ID, AT/FROM_TIMESTAMP), plus timestamp-required validation.
- Nits: ON_DEMAND+ShardCount rejection, UpdateShardCount half-to-double bounds.
- All existing Kinesis tests (#469 / #535 pagination + iterator + resharding) stay green.

Gates: build, vet, `go test`, `-race`, golangci-lint (0 new), gofmt — all clean. Coverage docs regenerated (no diff — operation set unchanged).
