### PR TITLE
fix(aws-ecr): content-addressed digest + digest->tags model; by-tag delete untags not nukes; tagStatus filter

### DIFF
--- a/providers/aws/ecr/ecr.go
+++ b/providers/aws/ecr/ecr.go
@@ -18,11 +18,10 @@ import (
 )
 
 const (
-	defaultMediaType     = "application/vnd.docker.distribution.manifest.v2+json"
-	mutableTag           = "MUTABLE"
-	immutableTag         = "IMMUTABLE"
-	scanStatusComplete   = "COMPLETE"
-	digestHashFormatByte = 8
+	defaultMediaType   = "application/vnd.docker.distribution.manifest.v2+json"
+	mutableTag         = "MUTABLE"
+	immutableTag       = "IMMUTABLE"
+	scanStatusComplete = "COMPLETE"
 )
 
 // Compile-time check that Mock implements driver.ContainerRegistry.
@@ -81,6 +80,9 @@ func (m *Mock) CreateRepository(_ context.Context, cfg driver.RepositoryConfig) 
 		return nil, errors.New(errors.InvalidArgument, "repository name is required")
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if m.repos.Has(cfg.Name) {
 		return nil, errors.Newf(errors.AlreadyExists, "repository %q already exists", cfg.Name)
 	}
@@ -123,6 +125,9 @@ func (m *Mock) CreateRepository(_ context.Context, cfg driver.RepositoryConfig) 
 
 // DeleteRepository deletes an ECR repository.
 func (m *Mock) DeleteRepository(_ context.Context, name string, force bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(name)
 	if !ok {
 		return errors.Newf(errors.NotFound, "repository %q not found", name)
@@ -139,6 +144,9 @@ func (m *Mock) DeleteRepository(_ context.Context, name string, force bool) erro
 
 // GetRepository retrieves information about an ECR repository.
 func (m *Mock) GetRepository(_ context.Context, name string) (*driver.Repository, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(name)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", name)
@@ -152,6 +160,9 @@ func (m *Mock) GetRepository(_ context.Context, name string) (*driver.Repository
 
 // ListRepositories lists all ECR repositories.
 func (m *Mock) ListRepositories(_ context.Context) ([]driver.Repository, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	all := m.repos.All()
 	repos := make([]driver.Repository, 0, len(all))
 
@@ -180,27 +191,8 @@ func (m *Mock) PutImage(_ context.Context, manifest *driver.ImageManifest) (*dri
 		return nil, err
 	}
 
-	digest := resolveDigest(manifest, m.opts.Clock.Now())
-	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
-	mediaType := resolveMediaType(manifest.MediaType)
-
-	detail := driver.ImageDetail{
-		RegistryID: m.opts.AccountID,
-		Repository: manifest.Repository,
-		Digest:     digest,
-		Tags:       []string{manifest.Tag},
-		SizeBytes:  manifest.SizeBytes,
-		PushedAt:   now,
-		MediaType:  mediaType,
-		Manifest:   manifest.Manifest,
-	}
-
-	img := &imageData{detail: detail, layers: manifest.Layers}
-	rd.images.Set(digest, img)
-
-	if manifest.Tag != "" {
-		updateTagIndex(rd, digest, manifest.Tag)
-	}
+	digest := resolveDigest(manifest)
+	img := m.storeImage(rd, manifest, digest)
 
 	rd.info.ImageCount = rd.images.Len()
 
@@ -210,13 +202,46 @@ func (m *Mock) PutImage(_ context.Context, manifest *driver.ImageManifest) (*dri
 
 	m.emitMetric("ImagePushCount", 1, map[string]string{"RepositoryName": manifest.Repository})
 
-	result := detail
+	result := img.detail
 
 	return &result, nil
 }
 
+// storeImage adds or updates the image identified by digest. An image is
+// identified by its digest and carries a SET of tags: re-pushing the same
+// manifest under a new tag accumulates the tag onto the existing manifest
+// (preserving its original push time) rather than replacing it, and the tag is
+// moved off any other manifest that currently holds it.
+func (m *Mock) storeImage(rd *repoData, manifest *driver.ImageManifest, digest string) *imageData {
+	img, ok := rd.images.Get(digest)
+	if !ok {
+		img = &imageData{
+			detail: driver.ImageDetail{
+				RegistryID: m.opts.AccountID,
+				Repository: manifest.Repository,
+				Digest:     digest,
+				SizeBytes:  manifest.SizeBytes,
+				PushedAt:   m.opts.Clock.Now().UTC().Format(time.RFC3339),
+				MediaType:  resolveMediaType(manifest.MediaType),
+				Manifest:   manifest.Manifest,
+			},
+			layers: manifest.Layers,
+		}
+		rd.images.Set(digest, img)
+	}
+
+	if manifest.Tag != "" {
+		updateTagIndex(rd, digest, manifest.Tag)
+	}
+
+	return img
+}
+
 // GetImage retrieves image details by repository and reference.
 func (m *Mock) GetImage(_ context.Context, repository, reference string) (*driver.ImageDetail, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -236,6 +261,9 @@ func (m *Mock) GetImage(_ context.Context, repository, reference string) (*drive
 
 // ListImages lists all images in an ECR repository.
 func (m *Mock) ListImages(_ context.Context, repository string) ([]driver.ImageDetail, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -264,6 +292,19 @@ func (m *Mock) DeleteImage(_ context.Context, repository, reference string) erro
 	img := findImage(rd, reference)
 	if img == nil {
 		return errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
+	}
+
+	// A reference that resolves to the manifest digest deletes the whole image
+	// and all of its tags. A tag reference removes only that tag; the manifest
+	// survives while other tags remain, and is deleted only with its last tag.
+	if reference != img.detail.Digest {
+		remaining := removeTag(img.detail.Tags, reference)
+		if len(remaining) > 0 {
+			img.detail.Tags = remaining
+			rd.images.Set(img.detail.Digest, img)
+
+			return nil
+		}
 	}
 
 	rd.images.Delete(img.detail.Digest)
@@ -304,6 +345,9 @@ func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag stri
 
 // PutLifecyclePolicy sets a lifecycle policy on an ECR repository.
 func (m *Mock) PutLifecyclePolicy(_ context.Context, repository string, policy driver.LifecyclePolicy) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -317,6 +361,9 @@ func (m *Mock) PutLifecyclePolicy(_ context.Context, repository string, policy d
 
 // GetLifecyclePolicy retrieves the lifecycle policy for an ECR repository.
 func (m *Mock) GetLifecyclePolicy(_ context.Context, repository string) (*driver.LifecyclePolicy, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -334,6 +381,9 @@ func (m *Mock) GetLifecyclePolicy(_ context.Context, repository string) (*driver
 // DeleteLifecyclePolicy removes the lifecycle policy from an ECR repository and
 // returns the policy that was deleted.
 func (m *Mock) DeleteLifecyclePolicy(_ context.Context, repository string) (*driver.LifecyclePolicy, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -351,6 +401,9 @@ func (m *Mock) DeleteLifecyclePolicy(_ context.Context, repository string) (*dri
 
 // EvaluateLifecyclePolicy evaluates the lifecycle policy and returns digests to expire.
 func (m *Mock) EvaluateLifecyclePolicy(_ context.Context, repository string) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -365,6 +418,9 @@ func (m *Mock) EvaluateLifecyclePolicy(_ context.Context, repository string) ([]
 
 // StartImageScan starts a vulnerability scan on an image in an ECR repository.
 func (m *Mock) StartImageScan(_ context.Context, repository, reference string) (*driver.ScanResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return nil, apiErrf(excRepositoryNotFound, "repository %q not found", repository)
@@ -387,6 +443,9 @@ func (m *Mock) StartImageScan(_ context.Context, repository, reference string) (
 func (m *Mock) GetImageScanResults(
 	_ context.Context, repository, reference string,
 ) (*driver.ScanResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return nil, apiErrf(excRepositoryNotFound, "repository %q not found", repository)
@@ -450,16 +509,18 @@ func checkTagMutability(rd *repoData, tag string) error {
 	return nil
 }
 
-// resolveDigest generates a digest from the manifest if not provided.
-func resolveDigest(manifest *driver.ImageManifest, now time.Time) string {
+// resolveDigest returns the image digest. When the client supplies an explicit
+// imageDigest it is respected; otherwise the digest is content-addressed as the
+// full sha256 of the manifest bytes, so identical manifest content yields the
+// same 64-hex digest regardless of tag or push time (matching real ECR).
+func resolveDigest(manifest *driver.ImageManifest) string {
 	if manifest.Digest != "" {
 		return manifest.Digest
 	}
 
-	input := fmt.Sprintf("%s:%s:%s", manifest.Repository, manifest.Tag, now.String())
-	hash := sha256.Sum256([]byte(input))
+	hash := sha256.Sum256([]byte(manifest.Manifest))
 
-	return fmt.Sprintf("sha256:%x", hash[:digestHashFormatByte])
+	return fmt.Sprintf("sha256:%x", hash)
 }
 
 // updateTagIndex removes a tag from any existing image and adds it to the target digest.

--- a/providers/aws/ecr/ecr_test.go
+++ b/providers/aws/ecr/ecr_test.go
@@ -2,6 +2,9 @@ package ecr
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,10 +32,13 @@ func createTestRepo(t *testing.T, m *Mock, name string) {
 func pushTestImage(t *testing.T, m *Mock, repo, tag string) *driver.ImageDetail {
 	t.Helper()
 
+	// Distinct tags carry distinct manifest content so they content-address to
+	// distinct digests (distinct images), matching how real images differ.
 	detail, err := m.PutImage(context.Background(), &driver.ImageManifest{
 		Repository: repo,
 		Tag:        tag,
 		SizeBytes:  1024,
+		Manifest:   fmt.Sprintf(`{"repo":%q,"tag":%q}`, repo, tag),
 	})
 	require.NoError(t, err)
 
@@ -825,4 +831,159 @@ func TestRepositoryTagging(t *testing.T) {
 	assert.False(t, has)
 
 	assert.Error(t, m.TagRepository(ctx, "missing", map[string]string{"a": "b"}))
+}
+
+// pushManifest pushes a raw manifest with an optional explicit digest and tag,
+// used by the image/digest-model tests.
+func pushManifest(t *testing.T, m *Mock, repo, tag, digest, manifest string) *driver.ImageDetail {
+	t.Helper()
+
+	detail, err := m.PutImage(context.Background(), &driver.ImageManifest{
+		Repository: repo,
+		Tag:        tag,
+		Digest:     digest,
+		Manifest:   manifest,
+		SizeBytes:  int64(len(manifest)),
+	})
+	require.NoError(t, err)
+
+	return detail
+}
+
+func findByDigest(images []driver.ImageDetail, digest string) *driver.ImageDetail {
+	for i := range images {
+		if images[i].Digest == digest {
+			return &images[i]
+		}
+	}
+
+	return nil
+}
+
+// TestPutImageContentAddressedDigest: an omitted digest is the full sha256 of
+// the manifest bytes, so identical content yields the same 64-hex digest under
+// any tag, and the two pushes collapse into ONE image carrying both tags.
+func TestPutImageContentAddressedDigest(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestRepo(t, m, "repo")
+
+	body := `{"schemaVersion":2,"layers":[]}`
+	d1 := pushManifest(t, m, "repo", "v1", "", body)
+	d2 := pushManifest(t, m, "repo", "v2", "", body)
+
+	assert.Equal(t, d1.Digest, d2.Digest)
+	assert.True(t, strings.HasPrefix(d1.Digest, "sha256:"))
+	assert.Len(t, strings.TrimPrefix(d1.Digest, "sha256:"), 64)
+
+	// Different manifest content -> a different digest.
+	d3 := pushManifest(t, m, "repo", "v3", "", body+" ")
+	assert.NotEqual(t, d1.Digest, d3.Digest)
+
+	images, err := m.ListImages(ctx, "repo")
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(images)) // (v1,v2) manifest + (v3) manifest
+
+	img := findByDigest(images, d1.Digest)
+	require.NotNil(t, img)
+	assert.ElementsMatch(t, []string{"v1", "v2"}, img.Tags)
+}
+
+// TestPutImageExplicitDigestAccumulatesTags: pushing the same digest under a
+// second tag accumulates the tag onto the one manifest instead of replacing it.
+func TestPutImageExplicitDigestAccumulatesTags(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestRepo(t, m, "repo")
+
+	const digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	first := pushManifest(t, m, "repo", "v1", digest, `{"a":1}`)
+	assert.ElementsMatch(t, []string{"v1"}, first.Tags)
+
+	second := pushManifest(t, m, "repo", "v2", digest, `{"a":1}`)
+	assert.Equal(t, digest, second.Digest)
+	assert.ElementsMatch(t, []string{"v1", "v2"}, second.Tags)
+
+	images, err := m.ListImages(ctx, "repo")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(images))
+	assert.ElementsMatch(t, []string{"v1", "v2"}, images[0].Tags)
+}
+
+// TestDeleteImageByTagUntagsOnly: deleting by tag removes only that tag while
+// other tags remain; removing the last tag deletes the manifest.
+func TestDeleteImageByTagUntagsOnly(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestRepo(t, m, "repo")
+
+	const digest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	pushManifest(t, m, "repo", "v1", digest, `{"b":1}`)
+	pushManifest(t, m, "repo", "v2", digest, `{"b":1}`)
+
+	require.NoError(t, m.DeleteImage(ctx, "repo", "v1"))
+
+	images, err := m.ListImages(ctx, "repo")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(images))
+	assert.ElementsMatch(t, []string{"v2"}, images[0].Tags)
+
+	require.NoError(t, m.DeleteImage(ctx, "repo", "v2"))
+	images, err = m.ListImages(ctx, "repo")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(images))
+}
+
+// TestDeleteImageByDigestRemovesManifest: deleting by digest removes the image
+// and every one of its tags.
+func TestDeleteImageByDigestRemovesManifest(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestRepo(t, m, "repo")
+
+	const digest = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+	pushManifest(t, m, "repo", "v1", digest, `{"c":1}`)
+	pushManifest(t, m, "repo", "v2", digest, `{"c":1}`)
+
+	require.NoError(t, m.DeleteImage(ctx, "repo", digest))
+
+	images, err := m.ListImages(ctx, "repo")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(images))
+}
+
+// TestConcurrentPutAndDelete exercises the model under -race: concurrent
+// PutImage/DeleteImage/GetRepository/ListImages on one repository.
+func TestConcurrentPutAndDelete(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestRepo(t, m, "race")
+
+	const workers = 20
+
+	var wg sync.WaitGroup
+
+	for i := range workers {
+		tag := fmt.Sprintf("v%d", i)
+
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+
+			_, _ = m.PutImage(ctx, &driver.ImageManifest{
+				Repository: "race", Tag: tag, Manifest: fmt.Sprintf(`{"t":%q}`, tag),
+			})
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			_ = m.DeleteImage(ctx, "race", tag)
+			_, _ = m.GetRepository(ctx, "race")
+			_, _ = m.ListImages(ctx, "race")
+		}()
+	}
+
+	wg.Wait()
 }

--- a/server/aws/ecr/image_model_test.go
+++ b/server/aws/ecr/image_model_test.go
@@ -1,0 +1,179 @@
+package ecr_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsecr "github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+)
+
+// TestSDKECRSameManifestTwoTags pushes one manifest under two tags (no explicit
+// digest) and asserts real ECR semantics: ONE image, both tags, one 64-hex
+// sha256 digest.
+func TestSDKECRSameManifestTwoTags(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	mustCreateRepo(ctx, t, client, "imgs")
+
+	first := mustPutImage(ctx, t, client, "imgs", sampleManifest, "v1")
+	second := mustPutImage(ctx, t, client, "imgs", sampleManifest, "v2")
+
+	// Content-addressed: identical manifest -> identical digest across tags.
+	digest := aws.ToString(first.Image.ImageId.ImageDigest)
+	if digest != aws.ToString(second.Image.ImageId.ImageDigest) {
+		t.Fatalf("digest changed across tags: %q vs %q", digest,
+			aws.ToString(second.Image.ImageId.ImageDigest))
+	}
+
+	if !strings.HasPrefix(digest, "sha256:") || len(strings.TrimPrefix(digest, "sha256:")) != 64 {
+		t.Fatalf("digest is not a full sha256: %q", digest)
+	}
+
+	described, err := client.DescribeImages(ctx, &awsecr.DescribeImagesInput{
+		RepositoryName: aws.String("imgs"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeImages: %v", err)
+	}
+
+	if len(described.ImageDetails) != 1 {
+		t.Fatalf("want 1 image, got %d: %+v", len(described.ImageDetails), described.ImageDetails)
+	}
+
+	tags := described.ImageDetails[0].ImageTags
+	if !contains(tags, "v1") || !contains(tags, "v2") || len(tags) != 2 {
+		t.Fatalf("want tags [v1 v2], got %+v", tags)
+	}
+}
+
+// TestSDKECRBatchDeleteByTagUntags verifies that deleting by tag on a
+// multi-tagged manifest untags only that tag (echoing digest+tag), while a
+// later delete of the last tag removes the manifest.
+func TestSDKECRBatchDeleteByTagUntags(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	mustCreateRepo(ctx, t, client, "imgs")
+	mustPutImage(ctx, t, client, "imgs", sampleManifest, "v1")
+	put := mustPutImage(ctx, t, client, "imgs", sampleManifest, "v2")
+	digest := aws.ToString(put.Image.ImageId.ImageDigest)
+
+	del, err := client.BatchDeleteImage(ctx, &awsecr.BatchDeleteImageInput{
+		RepositoryName: aws.String("imgs"),
+		ImageIds:       []ecrtypes.ImageIdentifier{{ImageTag: aws.String("v1")}},
+	})
+	if err != nil {
+		t.Fatalf("BatchDeleteImage(v1): %v", err)
+	}
+
+	if len(del.Failures) != 0 || len(del.ImageIds) != 1 {
+		t.Fatalf("want one deleted id, got ids=%+v failures=%+v", del.ImageIds, del.Failures)
+	}
+
+	// Real ECR echoes both the tag removed and the manifest digest.
+	if aws.ToString(del.ImageIds[0].ImageTag) != "v1" ||
+		aws.ToString(del.ImageIds[0].ImageDigest) != digest {
+		t.Fatalf("delete echo missing digest+tag: %+v", del.ImageIds[0])
+	}
+
+	// The manifest survives, tagged only [v2].
+	described, err := client.DescribeImages(ctx, &awsecr.DescribeImagesInput{
+		RepositoryName: aws.String("imgs"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeImages: %v", err)
+	}
+
+	if len(described.ImageDetails) != 1 ||
+		len(described.ImageDetails[0].ImageTags) != 1 ||
+		!contains(described.ImageDetails[0].ImageTags, "v2") {
+		t.Fatalf("want single image tagged [v2], got %+v", described.ImageDetails)
+	}
+
+	// Deleting the last tag removes the manifest entirely.
+	if _, err := client.BatchDeleteImage(ctx, &awsecr.BatchDeleteImageInput{
+		RepositoryName: aws.String("imgs"),
+		ImageIds:       []ecrtypes.ImageIdentifier{{ImageTag: aws.String("v2")}},
+	}); err != nil {
+		t.Fatalf("BatchDeleteImage(v2): %v", err)
+	}
+
+	listed, err := client.ListImages(ctx, &awsecr.ListImagesInput{RepositoryName: aws.String("imgs")})
+	if err != nil {
+		t.Fatalf("ListImages: %v", err)
+	}
+
+	if len(listed.ImageIds) != 0 {
+		t.Fatalf("want empty repository, got %+v", listed.ImageIds)
+	}
+}
+
+// TestSDKECRListImagesTagStatus verifies the tagStatus filter selects the
+// correct subset for TAGGED / UNTAGGED / ANY.
+func TestSDKECRListImagesTagStatus(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	mustCreateRepo(ctx, t, client, "mix")
+	mustPutImage(ctx, t, client, "mix", sampleManifest, "tagged")
+	// Distinct manifest content, pushed with no tag -> an untagged image.
+	mustPutImage(ctx, t, client, "mix", sampleManifest+" ", "")
+
+	cases := []struct {
+		status ecrtypes.TagStatus
+		want   int
+	}{
+		{ecrtypes.TagStatusTagged, 1},
+		{ecrtypes.TagStatusUntagged, 1},
+		{ecrtypes.TagStatusAny, 2},
+	}
+
+	for _, tc := range cases {
+		out, err := client.ListImages(ctx, &awsecr.ListImagesInput{
+			RepositoryName: aws.String("mix"),
+			Filter:         &ecrtypes.ListImagesFilter{TagStatus: tc.status},
+		})
+		if err != nil {
+			t.Fatalf("ListImages(%s): %v", tc.status, err)
+		}
+
+		if len(out.ImageIds) != tc.want {
+			t.Fatalf("tagStatus=%s: want %d ids, got %d (%+v)", tc.status, tc.want, len(out.ImageIds), out.ImageIds)
+		}
+	}
+}
+
+func mustCreateRepo(ctx context.Context, t *testing.T, client *awsecr.Client, name string) {
+	t.Helper()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String(name),
+	}); err != nil {
+		t.Fatalf("CreateRepository(%s): %v", name, err)
+	}
+}
+
+func mustPutImage(
+	ctx context.Context, t *testing.T, client *awsecr.Client, repo, manifest, tag string,
+) *awsecr.PutImageOutput {
+	t.Helper()
+
+	in := &awsecr.PutImageInput{
+		RepositoryName: aws.String(repo),
+		ImageManifest:  aws.String(manifest),
+	}
+	if tag != "" {
+		in.ImageTag = aws.String(tag)
+	}
+
+	out, err := client.PutImage(ctx, in)
+	if err != nil {
+		t.Fatalf("PutImage(%s:%s): %v", repo, tag, err)
+	}
+
+	return out
+}

--- a/server/aws/ecr/operations.go
+++ b/server/aws/ecr/operations.go
@@ -2,10 +2,16 @@ package ecr
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+const (
+	tagStatusTagged   = "TAGGED"
+	tagStatusUntagged = "UNTAGGED"
 )
 
 func (h *Handler) createRepository(w http.ResponseWriter, r *http.Request) {
@@ -138,6 +144,8 @@ func (h *Handler) listImages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	images = filterByTagStatus(images, req.Filter.TagStatus)
+
 	ids := make([]imageIDJSON, 0, len(images))
 	for i := range images {
 		ids = append(ids, imageIDsForDetail(&images[i])...)
@@ -200,6 +208,12 @@ func (h *Handler) describeImages(w http.ResponseWriter, r *http.Request) {
 		wire.WriteJSONError(w, http.StatusBadRequest, "ImageNotFoundException",
 			"The image with imageId "+imageReference(*missing)+" does not exist within the repository")
 		return
+	}
+
+	// The tagStatus filter applies to the repository-wide listing (it is not
+	// combined with an explicit imageIds selection in real ECR).
+	if len(req.ImageIDs) == 0 {
+		images = filterByTagStatus(images, req.Filter.TagStatus)
 	}
 
 	details := make([]imageDetailJSON, 0, len(images))
@@ -320,8 +334,10 @@ func (h *Handler) batchDeleteImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// A missing repository is a thrown error; missing images become per-image
-	// failures, matching real ECR.
-	if _, err := h.registry.GetRepository(r.Context(), req.RepositoryName); err != nil {
+	// failures, matching real ECR. Snapshotting the images before deletion lets
+	// the response echo the digest and every tag a delete removes.
+	images, err := h.registry.ListImages(r.Context(), req.RepositoryName)
+	if err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -330,7 +346,9 @@ func (h *Handler) batchDeleteImage(w http.ResponseWriter, r *http.Request) {
 	failures := make([]imageFailureJSON, 0)
 
 	for _, id := range req.ImageIDs {
-		if err := h.registry.DeleteImage(r.Context(), req.RepositoryName, imageReference(id)); err != nil {
+		detail := findImageDetail(images, id)
+
+		if derr := h.registry.DeleteImage(r.Context(), req.RepositoryName, deleteReference(id)); derr != nil {
 			failures = append(failures, imageFailureJSON{
 				ImageID:       id,
 				FailureCode:   "ImageNotFound",
@@ -340,10 +358,76 @@ func (h *Handler) batchDeleteImage(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		deleted = append(deleted, id)
+		deleted = append(deleted, deletedImageIDs(detail, id)...)
 	}
 
 	wire.WriteJSON(w, batchDeleteImageResponse{ImageIDs: deleted, Failures: failures})
+}
+
+// deleteReference chooses the delete target: a tag reference (untag) when a tag
+// is given, otherwise the digest (delete the whole manifest). This mirrors ECR,
+// where specifying a tag removes just that tag and specifying a digest removes
+// the image and all of its tags.
+func deleteReference(id imageIDJSON) string {
+	if id.ImageTag != "" {
+		return id.ImageTag
+	}
+
+	return id.ImageDigest
+}
+
+// deletedImageIDs builds the imageIds echoed for a successful delete. A tag
+// delete echoes the digest plus that tag; a digest delete echoes the digest
+// with every tag it removed (or a digest-only id when the image was untagged).
+func deletedImageIDs(detail *crdriver.ImageDetail, id imageIDJSON) []imageIDJSON {
+	if detail == nil {
+		return []imageIDJSON{id}
+	}
+
+	if id.ImageTag != "" {
+		return []imageIDJSON{{ImageDigest: detail.Digest, ImageTag: id.ImageTag}}
+	}
+
+	if len(detail.Tags) == 0 {
+		return []imageIDJSON{{ImageDigest: detail.Digest}}
+	}
+
+	out := make([]imageIDJSON, 0, len(detail.Tags))
+	for _, tag := range detail.Tags {
+		out = append(out, imageIDJSON{ImageDigest: detail.Digest, ImageTag: tag})
+	}
+
+	return out
+}
+
+// filterByTagStatus keeps only images matching an ECR tagStatus filter. An
+// empty value or ANY passes every image through.
+func filterByTagStatus(images []crdriver.ImageDetail, tagStatus string) []crdriver.ImageDetail {
+	want := strings.ToUpper(tagStatus)
+	if want != tagStatusTagged && want != tagStatusUntagged {
+		return images
+	}
+
+	out := make([]crdriver.ImageDetail, 0, len(images))
+
+	for i := range images {
+		if (want == tagStatusTagged) == hasAnyTag(&images[i]) {
+			out = append(out, images[i])
+		}
+	}
+
+	return out
+}
+
+// hasAnyTag reports whether an image carries at least one non-empty tag.
+func hasAnyTag(d *crdriver.ImageDetail) bool {
+	for _, t := range d.Tags {
+		if t != "" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func tagsToMap(tags []tagJSON) map[string]string {

--- a/server/aws/ecr/types.go
+++ b/server/aws/ecr/types.go
@@ -81,17 +81,25 @@ type putImageRequest struct {
 	ImageDigest            string `json:"imageDigest"`
 }
 
+// imageFilterJSON is the ECR filter object; tagStatus is TAGGED, UNTAGGED, or
+// ANY (ListImages/DescribeImages).
+type imageFilterJSON struct {
+	TagStatus string `json:"tagStatus"`
+}
+
 type repositoryNameRequest struct {
-	RepositoryName string `json:"repositoryName"`
-	MaxResults     int    `json:"maxResults"`
-	NextToken      string `json:"nextToken"`
+	RepositoryName string          `json:"repositoryName"`
+	Filter         imageFilterJSON `json:"filter"`
+	MaxResults     int             `json:"maxResults"`
+	NextToken      string          `json:"nextToken"`
 }
 
 type imageIDsRequest struct {
-	RepositoryName string        `json:"repositoryName"`
-	ImageIDs       []imageIDJSON `json:"imageIds"`
-	MaxResults     int           `json:"maxResults"`
-	NextToken      string        `json:"nextToken"`
+	RepositoryName string          `json:"repositoryName"`
+	ImageIDs       []imageIDJSON   `json:"imageIds"`
+	Filter         imageFilterJSON `json:"filter"`
+	MaxResults     int             `json:"maxResults"`
+	NextToken      string          `json:"nextToken"`
 }
 
 // --- response envelopes ---


### PR DESCRIPTION
## What

Fixes the ECR image/digest model so it matches real ECR content-addressing and tag semantics, plus the tagStatus listing filter. Found by the AWS deep-e2e audit (real aws-sdk-go-v2 client over the wire server).

## Findings addressed

1. **[HIGH] PutImage digest is not sha256(manifest).** The digest was a truncated 16-hex value derived from `repo:tag:now`, so it changed on every push and per tag. It is now the full sha256 of the manifest bytes (64-hex, `sha256:` prefixed), content-addressed — identical manifest content yields the same digest regardless of tag or time. An explicit client-supplied `imageDigest` is still respected.

2. **[HIGH] PutImage same-digest new-tag replaced the image, dropping prior tags.** PutImage rebuilt a fresh `ImageDetail{Tags:[tag]}` and overwrote the entry at the digest. An image is now identified by its digest and carries a SET of tags: pushing the same manifest under a second tag accumulates the tag onto the one manifest (moving it off any other manifest that held it, and preserving the original push time).

3. **[HIGH] BatchDeleteImage/DeleteImage by tag deleted the whole manifest.** Delete is now tag-vs-digest aware: a tag reference removes only that tag (the manifest survives while other tags remain, and is deleted with its last tag); a digest reference removes the manifest and all its tags. The response echoes imageIds the way real ECR does — a by-tag delete returns the digest plus that tag; a by-digest delete returns the digest with every tag it removed.

4. **[MED] ListImages/DescribeImages ignored filter.tagStatus.** The `filter.tagStatus` (TAGGED/UNTAGGED/ANY) is now decoded and applied.

Also: the provider read/mutate paths now take the mutex, so the model is race-clean (verified with `-race`).

## Why

Without content-addressing, pull-by-digest never resolves and DescribeImages dedup is wrong; CI that pushes `:latest` and `:<sha>` for one build, or `docker tag` + re-push, lost tags; and cleanup scripts that list only UNTAGGED images to prune got wrong results.

## Scope

Image/digest model + tagStatus only. Feature gaps (layer/registry-v2 upload ops, registry policy, PutImageTagMutability / PutImageScanningConfiguration dispatch, lifecycle-policy fidelity) are a separate follow-up.

## Tests

New real-SDK reproductions (same manifest under two tags -> one image/two tags/one 64-hex digest; by-tag delete untags and survives; last-tag/by-digest delete removes the manifest; tagStatus subsets) and provider-level model + `-race` concurrency tests. Existing 8 ECR tests stay green.
