### PR TITLE
fix(aws-ecr): dispatch PutImageTagMutability/PutImageScanningConfiguration (enforced); lifecycle policy round-trips with full fidelity

### DIFF
--- a/providers/aws/ecr/ecr.go
+++ b/providers/aws/ecr/ecr.go
@@ -123,6 +123,57 @@ func (m *Mock) CreateRepository(_ context.Context, cfg driver.RepositoryConfig) 
 	return &result, nil
 }
 
+// PutImageTagMutability updates a repository's image tag mutability setting.
+// This is AWS-specific (not part of the portable ContainerRegistry driver), so
+// the ECR wire handler reaches it via type assertion. The new value takes effect
+// immediately: it is read by checkTagMutability on subsequent pushes.
+func (m *Mock) PutImageTagMutability(
+	_ context.Context, repository, mutability string,
+) (*driver.Repository, error) {
+	if mutability != mutableTag && mutability != immutableTag {
+		return nil, errors.Newf(errors.InvalidArgument,
+			"invalid imageTagMutability %q; expected MUTABLE or IMMUTABLE", mutability)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	rd.tagMutability = mutability
+	rd.info.ImageTagMutability = mutability
+
+	result := rd.info
+	result.ImageCount = rd.images.Len()
+
+	return &result, nil
+}
+
+// PutImageScanningConfiguration updates a repository's scan-on-push setting.
+// AWS-specific; reached by the ECR wire handler via type assertion.
+func (m *Mock) PutImageScanningConfiguration(
+	_ context.Context, repository string, scanOnPush bool,
+) (*driver.Repository, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	rd.scanOnPush = scanOnPush
+	rd.info.ScanOnPush = scanOnPush
+
+	result := rd.info
+	result.ImageCount = rd.images.Len()
+
+	return &result, nil
+}
+
 // DeleteRepository deletes an ECR repository.
 func (m *Mock) DeleteRepository(_ context.Context, name string, force bool) error {
 	m.mu.Lock()
@@ -715,7 +766,7 @@ func copyLifecyclePolicy(p driver.LifecyclePolicy) driver.LifecyclePolicy {
 	rules := make([]driver.LifecycleRule, len(p.Rules))
 	copy(rules, p.Rules)
 
-	return driver.LifecyclePolicy{Rules: rules}
+	return driver.LifecyclePolicy{Rules: rules, Document: p.Document}
 }
 
 func removeTag(tags []string, tag string) []string {

--- a/server/aws/ecr/handler.go
+++ b/server/aws/ecr/handler.go
@@ -56,6 +56,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.describeRepositories(w, r)
 	case "DeleteRepository":
 		h.deleteRepository(w, r)
+	case "PutImageTagMutability":
+		h.putImageTagMutability(w, r)
+	case "PutImageScanningConfiguration":
+		h.putImageScanningConfiguration(w, r)
 	case "PutImage":
 		h.putImage(w, r)
 	case "ListImages":

--- a/server/aws/ecr/lifecycle_policy.go
+++ b/server/aws/ecr/lifecycle_policy.go
@@ -153,7 +153,10 @@ func parseLifecyclePolicyText(text string) (crdriver.LifecyclePolicy, error) {
 		})
 	}
 
-	return crdriver.LifecyclePolicy{Rules: rules}, nil
+	// Preserve the original document verbatim so GetLifecyclePolicy round-trips it
+	// byte-faithfully (Terraform sees no drift), while the structured Rules remain
+	// available for lifecycle evaluation.
+	return crdriver.LifecyclePolicy{Rules: rules, Document: text}, nil
 }
 
 func firstTagPattern(sel *lifecycleSelection) string {
@@ -169,6 +172,14 @@ func firstTagPattern(sel *lifecycleSelection) string {
 }
 
 func marshalLifecyclePolicyText(policy *crdriver.LifecyclePolicy) (string, error) {
+	// Return the stored document verbatim when available, so a multi-rule policy
+	// with full tagPrefixList/tagPatternList arrays comes back exactly as it went
+	// in. Fall back to re-serializing the structured rules for policies stored
+	// without a raw document.
+	if policy.Document != "" {
+		return policy.Document, nil
+	}
+
 	doc := lifecyclePolicyText{Rules: make([]lifecycleRuleText, 0, len(policy.Rules))}
 
 	for i := range policy.Rules {

--- a/server/aws/ecr/lifecycle_policy_test.go
+++ b/server/aws/ecr/lifecycle_policy_test.go
@@ -2,13 +2,26 @@ package ecr_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsecr "github.com/aws/aws-sdk-go-v2/service/ecr"
 	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 )
+
+// multiRulePolicyDoc is a two-rule policy whose first rule selects on a
+// multi-element tagPrefixList. Earlier code collapsed the list to its first
+// element on read; this document exercises full-fidelity round-tripping.
+const multiRulePolicyDoc = `{"rules":[` +
+	`{"rulePriority":1,"description":"keep recent prod/stg",` +
+	`"selection":{"tagStatus":"tagged","tagPrefixList":["prod","stg"],` +
+	`"countType":"imageCountMoreThan","countNumber":5},"action":{"type":"expire"}},` +
+	`{"rulePriority":2,"description":"expire untagged",` +
+	`"selection":{"tagStatus":"untagged","countType":"sinceImagePushed","countNumber":14},` +
+	`"action":{"type":"expire"}}]}`
 
 const lifecyclePolicyDoc = `{"rules":[{"rulePriority":1,"description":"expire",` +
 	`"selection":{"tagStatus":"untagged","countType":"imageCountMoreThan","countNumber":10},` +
@@ -52,6 +65,66 @@ func TestSDKECRLifecyclePolicyRegistryID(t *testing.T) {
 
 	if aws.ToString(got.RepositoryName) != "lc-repo" {
 		t.Fatalf("GetLifecyclePolicy repositoryName = %q, want lc-repo", aws.ToString(got.RepositoryName))
+	}
+}
+
+// TestSDKECRLifecyclePolicyRoundTrip guards fidelity of a multi-rule policy with
+// a multi-element tagPrefixList. GetLifecyclePolicy must return the document
+// exactly as PutLifecyclePolicy stored it — both rules and both prefix entries —
+// so Terraform's aws_ecr_lifecycle_policy refresh sees no drift.
+func TestSDKECRLifecyclePolicyRoundTrip(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("rt-repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	if _, err := client.PutLifecyclePolicy(ctx, &awsecr.PutLifecyclePolicyInput{
+		RepositoryName:      aws.String("rt-repo"),
+		LifecyclePolicyText: aws.String(multiRulePolicyDoc),
+	}); err != nil {
+		t.Fatalf("PutLifecyclePolicy: %v", err)
+	}
+
+	got, err := client.GetLifecyclePolicy(ctx, &awsecr.GetLifecyclePolicyInput{
+		RepositoryName: aws.String("rt-repo"),
+	})
+	if err != nil {
+		t.Fatalf("GetLifecyclePolicy: %v", err)
+	}
+
+	gotText := aws.ToString(got.LifecyclePolicyText)
+	if gotText != multiRulePolicyDoc {
+		t.Fatalf("GetLifecyclePolicy text not verbatim:\n got=%s\nwant=%s", gotText, multiRulePolicyDoc)
+	}
+
+	// Structural check independent of byte-for-byte equality: both rules present,
+	// and the first rule's tagPrefixList retains both elements.
+	var in, out map[string]any
+	if err := json.Unmarshal([]byte(multiRulePolicyDoc), &in); err != nil {
+		t.Fatalf("unmarshal input: %v", err)
+	}
+
+	if err := json.Unmarshal([]byte(gotText), &out); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("policy structure drifted:\n in=%v\nout=%v", in, out)
+	}
+
+	rules, _ := out["rules"].([]any)
+	if len(rules) != 2 {
+		t.Fatalf("got %d rules, want 2", len(rules))
+	}
+
+	sel, _ := rules[0].(map[string]any)["selection"].(map[string]any)
+	prefixes, _ := sel["tagPrefixList"].([]any)
+	if len(prefixes) != 2 {
+		t.Fatalf("tagPrefixList = %v, want 2 elements", prefixes)
 	}
 }
 

--- a/server/aws/ecr/repository_config.go
+++ b/server/aws/ecr/repository_config.go
@@ -1,0 +1,86 @@
+package ecr
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+// imageTagMutabilitySetter is the AWS-specific PutImageTagMutability surface.
+// Tag mutability is an ECR concept (Azure ACR and GCP Artifact Registry model it
+// differently), so it is not part of the portable ContainerRegistry driver; the
+// handler type-asserts for it rather than widening the shared interface.
+type imageTagMutabilitySetter interface {
+	PutImageTagMutability(ctx context.Context, repository, mutability string) (*crdriver.Repository, error)
+}
+
+// imageScanningConfigSetter is the AWS-specific PutImageScanningConfiguration
+// surface, reached by the same type-assertion pattern.
+type imageScanningConfigSetter interface {
+	PutImageScanningConfiguration(ctx context.Context, repository string, scanOnPush bool) (*crdriver.Repository, error)
+}
+
+// putImageTagMutability updates a repository's imageTagMutability and echoes the
+// new value. The mutated setting takes effect immediately: a later re-push of an
+// existing tag on a now-IMMUTABLE repository fails with ImageTagAlreadyExists.
+func (h *Handler) putImageTagMutability(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		RepositoryName     string `json:"repositoryName"`
+		ImageTagMutability string `json:"imageTagMutability"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	setter, ok := h.registry.(imageTagMutabilitySetter)
+	if !ok {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ServerException", "image tag mutability not supported")
+		return
+	}
+
+	repo, err := setter.PutImageTagMutability(r.Context(), req.RepositoryName, req.ImageTagMutability)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"registryId":         repo.RegistryID,
+		"repositoryName":     repo.Name,
+		"imageTagMutability": repo.ImageTagMutability,
+	})
+}
+
+// putImageScanningConfiguration updates a repository's scan-on-push setting and
+// echoes the imageScanningConfiguration object.
+func (h *Handler) putImageScanningConfiguration(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		RepositoryName             string                  `json:"repositoryName"`
+		ImageScanningConfiguration imageScanningConfigJSON `json:"imageScanningConfiguration"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	setter, ok := h.registry.(imageScanningConfigSetter)
+	if !ok {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ServerException", "image scanning configuration not supported")
+		return
+	}
+
+	repo, err := setter.PutImageScanningConfiguration(r.Context(), req.RepositoryName, req.ImageScanningConfiguration.ScanOnPush)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"registryId":                 repo.RegistryID,
+		"repositoryName":             repo.Name,
+		"imageScanningConfiguration": imageScanningConfigJSON{ScanOnPush: repo.ScanOnPush},
+	})
+}

--- a/server/aws/ecr/repository_config_test.go
+++ b/server/aws/ecr/repository_config_test.go
@@ -1,0 +1,152 @@
+package ecr_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsecr "github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+)
+
+// TestSDKECRPutImageTagMutability exercises the Terraform in-place update of
+// aws_ecr_repository.image_tag_mutability: PutImageTagMutability was previously
+// undispatched (UnknownOperationException). The new setting must be reflected by
+// DescribeRepositories and, critically, take effect on subsequent pushes.
+func TestSDKECRPutImageTagMutability(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("mut-repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	if _, err := client.PutImage(ctx, &awsecr.PutImageInput{
+		RepositoryName: aws.String("mut-repo"),
+		ImageManifest:  aws.String(sampleManifest),
+		ImageTag:       aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("PutImage v1: %v", err)
+	}
+
+	// Flip to IMMUTABLE.
+	put, err := client.PutImageTagMutability(ctx, &awsecr.PutImageTagMutabilityInput{
+		RepositoryName:     aws.String("mut-repo"),
+		ImageTagMutability: ecrtypes.ImageTagMutabilityImmutable,
+	})
+	if err != nil {
+		t.Fatalf("PutImageTagMutability(IMMUTABLE): %v", err)
+	}
+
+	if put.ImageTagMutability != ecrtypes.ImageTagMutabilityImmutable {
+		t.Fatalf("PutImageTagMutability echoed %q, want IMMUTABLE", put.ImageTagMutability)
+	}
+
+	if aws.ToString(put.RegistryId) != "123456789012" || aws.ToString(put.RepositoryName) != "mut-repo" {
+		t.Fatalf("PutImageTagMutability response registryId=%q repositoryName=%q",
+			aws.ToString(put.RegistryId), aws.ToString(put.RepositoryName))
+	}
+
+	// DescribeRepositories reflects the new value.
+	desc, err := client.DescribeRepositories(ctx, &awsecr.DescribeRepositoriesInput{
+		RepositoryNames: []string{"mut-repo"},
+	})
+	if err != nil {
+		t.Fatalf("DescribeRepositories: %v", err)
+	}
+
+	if desc.Repositories[0].ImageTagMutability != ecrtypes.ImageTagMutabilityImmutable {
+		t.Fatalf("DescribeRepositories mutability = %q, want IMMUTABLE",
+			desc.Repositories[0].ImageTagMutability)
+	}
+
+	// The setting takes effect: re-pushing an existing tag now fails.
+	_, err = client.PutImage(ctx, &awsecr.PutImageInput{
+		RepositoryName: aws.String("mut-repo"),
+		ImageManifest:  aws.String(sampleManifest),
+		ImageTag:       aws.String("v1"),
+	})
+
+	var already *ecrtypes.ImageTagAlreadyExistsException
+	if !errors.As(err, &already) {
+		t.Fatalf("re-push to IMMUTABLE repo: want ImageTagAlreadyExistsException, got %v", err)
+	}
+
+	// Flip back to MUTABLE; re-push succeeds again.
+	if _, err := client.PutImageTagMutability(ctx, &awsecr.PutImageTagMutabilityInput{
+		RepositoryName:     aws.String("mut-repo"),
+		ImageTagMutability: ecrtypes.ImageTagMutabilityMutable,
+	}); err != nil {
+		t.Fatalf("PutImageTagMutability(MUTABLE): %v", err)
+	}
+
+	if _, err := client.PutImage(ctx, &awsecr.PutImageInput{
+		RepositoryName: aws.String("mut-repo"),
+		ImageManifest:  aws.String(sampleManifest),
+		ImageTag:       aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("re-push after MUTABLE: %v", err)
+	}
+}
+
+// TestSDKECRPutImageScanningConfiguration exercises the Terraform in-place update
+// of aws_ecr_repository.image_scanning_configuration.scan_on_push, previously
+// undispatched.
+func TestSDKECRPutImageScanningConfiguration(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("scan-repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	put, err := client.PutImageScanningConfiguration(ctx, &awsecr.PutImageScanningConfigurationInput{
+		RepositoryName:             aws.String("scan-repo"),
+		ImageScanningConfiguration: &ecrtypes.ImageScanningConfiguration{ScanOnPush: true},
+	})
+	if err != nil {
+		t.Fatalf("PutImageScanningConfiguration: %v", err)
+	}
+
+	if put.ImageScanningConfiguration == nil || !put.ImageScanningConfiguration.ScanOnPush {
+		t.Fatalf("PutImageScanningConfiguration echoed %+v, want scanOnPush=true",
+			put.ImageScanningConfiguration)
+	}
+
+	if aws.ToString(put.RepositoryName) != "scan-repo" {
+		t.Fatalf("PutImageScanningConfiguration repositoryName = %q", aws.ToString(put.RepositoryName))
+	}
+
+	desc, err := client.DescribeRepositories(ctx, &awsecr.DescribeRepositoriesInput{
+		RepositoryNames: []string{"scan-repo"},
+	})
+	if err != nil {
+		t.Fatalf("DescribeRepositories: %v", err)
+	}
+
+	cfg := desc.Repositories[0].ImageScanningConfiguration
+	if cfg == nil || !cfg.ScanOnPush {
+		t.Fatalf("DescribeRepositories scanning config = %+v, want scanOnPush=true", cfg)
+	}
+}
+
+// TestSDKECRPutImageTagMutabilityMissingRepo asserts the operation surfaces
+// RepositoryNotFoundException for an unknown repository.
+func TestSDKECRPutImageTagMutabilityMissingRepo(t *testing.T) {
+	client := newECRClient(t)
+
+	_, err := client.PutImageTagMutability(context.Background(), &awsecr.PutImageTagMutabilityInput{
+		RepositoryName:     aws.String("ghost-repo"),
+		ImageTagMutability: ecrtypes.ImageTagMutabilityImmutable,
+	})
+
+	var notFound *ecrtypes.RepositoryNotFoundException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("mutability on missing repo: want RepositoryNotFoundException, got %v", err)
+	}
+}

--- a/services/containerregistry/driver/driver.go
+++ b/services/containerregistry/driver/driver.go
@@ -84,6 +84,11 @@ type LifecycleRule struct {
 // LifecyclePolicy is a set of lifecycle rules.
 type LifecyclePolicy struct {
 	Rules []LifecycleRule
+	// Document is the original policy document text, preserved verbatim so it can
+	// be returned byte-faithfully on read (AWS ECR lifecyclePolicyText round-trips
+	// without drift). Optional; providers that model policies purely structurally
+	// leave it empty and callers fall back to serializing Rules.
+	Document string
 }
 
 // ScanResult represents an image vulnerability scan result.


### PR DESCRIPTION
## What

Fixes two AWS ECR bugs found by the deep real-user e2e audit, both of which break Terraform in-place update paths on `aws_ecr_repository` / `aws_ecr_lifecycle_policy`.

### 1. PutImageTagMutability + PutImageScanningConfiguration were undispatched
Both operations returned `UnknownOperationException`, so a `terraform apply` that changed `image_tag_mutability` or `image_scanning_configuration.scan_on_push` on an existing repository failed hard.

- Dispatched both in the ECR wire handler.
- Added AWS-specific provider methods (`PutImageTagMutability`, `PutImageScanningConfiguration`) reached via type assertion — same optional-interface pattern as `GetAuthorizationToken`, keeping them out of the portable ContainerRegistry driver (Azure ACR / GCP Artifact Registry model these differently).
- Responses echo the real AWS shapes: `{registryId, repositoryName, imageTagMutability}` and `{registryId, repositoryName, imageScanningConfiguration:{scanOnPush}}`.
- The mutability change **takes effect**: it updates the value `checkTagMutability` reads, so after setting `IMMUTABLE` a re-push of an existing tag returns `ImageTagAlreadyExistsException`, and after setting back to `MUTABLE` the re-push succeeds. `DescribeRepositories` reflects both new values.

### 2. GetLifecyclePolicy lost fidelity on re-serialization
`parseLifecyclePolicyText` kept only the first pattern (`firstTagPattern`) and collapsed a multi-element `tagPrefixList`/`tagPatternList` into a single `tagPattern`, so `GetLifecyclePolicy` returned a structurally different, semantically lossy document — Terraform saw perpetual drift.

- `driver.LifecyclePolicy` now carries an optional `Document` field preserving the original policy text verbatim.
- The AWS wire layer stores the raw `lifecyclePolicyText` on Put and returns it byte-faithfully on Get/Delete; the structured `Rules` remain available for lifecycle evaluation.

## Why
Terraform (and `aws ecr put-image-tag-mutability` / `put-image-scanning-configuration`) drive these operations on repository updates; the gaps caused apply failures and perpetual-diff drift.

## Tests
Real `aws-sdk-go-v2` reproductions:
- `PutImageTagMutability(IMMUTABLE)` -> DescribeRepositories shows IMMUTABLE AND re-push existing tag -> `ImageTagAlreadyExistsException`; set MUTABLE -> re-push succeeds; missing-repo -> `RepositoryNotFoundException`.
- `PutImageScanningConfiguration(scanOnPush=true)` -> DescribeRepositories reflects it.
- `PutLifecyclePolicy` with a 2-rule policy whose first rule has `tagPrefixList:["prod","stg"]` -> `GetLifecyclePolicy` returns both rules with the full lists intact (verbatim + structural check).

Merged #668 image-model tests and the prior ECR SDK tests stay green.