### PR TITLE
fix(aws-secretsmanager): explicit per-version staging labels — honor ClientRequestToken/VersionStages, add UpdateSecretVersionStage, ARN suffix

### DIFF
--- a/internal/idgen/idgen.go
+++ b/internal/idgen/idgen.go
@@ -2,6 +2,7 @@
 package idgen
 
 import (
+	"crypto/rand"
 	"fmt"
 	"hash/fnv"
 	"sync/atomic"
@@ -9,6 +10,62 @@ import (
 
 // guidNodeMask isolates the low 48 bits used as a GUID's node field.
 const guidNodeMask = 0xffffffffffff
+
+// uuidByteLen is the number of random bytes in a version-4 UUID.
+const uuidByteLen = 16
+
+// RFC 4122 version/variant bit masks for a version-4 UUID.
+const (
+	versionMask  = 0x0f
+	version4Bits = 0x40
+	variantMask  = 0x3f
+	variantBits  = 0x80
+)
+
+// UUID returns a random RFC 4122 version-4 UUID as a 36-character string
+// (8-4-4-4-12 hex with hyphens). AWS Secrets Manager version ids take this
+// shape, and callers can pin one via a client request token. It draws from
+// crypto/rand; a random source failure falls back to a zero-filled UUID so the
+// function never panics.
+func UUID() string {
+	var b [uuidByteLen]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Degrade to an all-zero UUID rather than panic; still 36 chars.
+		b = [uuidByteLen]byte{}
+	}
+
+	// RFC 4122: set the version to 4 and the variant to 10xx.
+	b[6] = (b[6] & versionMask) | version4Bits
+	b[8] = (b[8] & variantMask) | variantBits
+
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+// suffixAlphabet is the 6-character random-suffix character set AWS appends to a
+// Secrets Manager ARN's resource segment (:secret:<name>-<suffix>).
+const suffixAlphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// secretARNSuffixLen is the length of the ARN suffix AWS appends.
+const secretARNSuffixLen = 6
+
+// SecretARNSuffix derives a deterministic 6-character alphanumeric suffix from
+// seed, matching the trailing "-XXXXXX" AWS adds to a Secrets Manager ARN. It is
+// deterministic per seed so the same secret keeps a stable ARN across a run
+// (and under a FakeClock), while distinct secrets get distinct suffixes.
+func SecretARNSuffix(seed string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(seed))
+	n := h.Sum64()
+
+	out := make([]byte, secretARNSuffixLen)
+	for i := range out {
+		out[i] = suffixAlphabet[n%uint64(len(suffixAlphabet))]
+		n /= uint64(len(suffixAlphabet))
+	}
+
+	return string(out)
+}
 
 // SyntheticGUID derives a deterministic GUID-shaped string from seed. The value
 // is synthetic (a stand-in for an Azure principal/tenant id), not a real

--- a/internal/idgen/idgen_test.go
+++ b/internal/idgen/idgen_test.go
@@ -180,3 +180,34 @@ func TestReset(t *testing.T) {
 
 	assert.Equal(t, id1, id2)
 }
+
+func TestUUID(t *testing.T) {
+	seen := make(map[string]bool)
+
+	for i := 0; i < 200; i++ {
+		id := UUID()
+
+		require.Len(t, id, 36, "UUID must be 36 chars")
+		assert.Equal(t, 4, strings.Count(id, "-"), "UUID must have 4 hyphens")
+		assert.Equal(t, "4", string(id[14]), "version-4 UUID has '4' in the version position")
+		require.False(t, seen[id], "duplicate UUID generated: %s", id)
+		seen[id] = true
+	}
+}
+
+func TestSecretARNSuffix(t *testing.T) {
+	// Deterministic per seed.
+	assert.Equal(t, SecretARNSuffix("my-secret"), SecretARNSuffix("my-secret"))
+
+	// Six alphanumeric characters.
+	suffix := SecretARNSuffix("us-east-1:123456789012:db")
+	require.Len(t, suffix, 6)
+
+	for _, c := range suffix {
+		isAlnum := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+		assert.True(t, isAlnum, "suffix char %q must be alphanumeric", c)
+	}
+
+	// Distinct seeds generally differ.
+	assert.NotEqual(t, SecretARNSuffix("secret-a"), SecretARNSuffix("secret-b"))
+}

--- a/providers/aws/secretsmanager/secretsmanager.go
+++ b/providers/aws/secretsmanager/secretsmanager.go
@@ -2,6 +2,7 @@
 package secretsmanager
 
 import (
+	"bytes"
 	"context"
 	"sync"
 	"time"
@@ -17,8 +18,14 @@ import (
 var _ driver.Secrets = (*Mock)(nil)
 
 type secretData struct {
-	info      driver.SecretInfo
-	versions  []driver.SecretVersion
+	info     driver.SecretInfo
+	versions []driver.SecretVersion
+	// stages maps a staging label (AWSCURRENT/AWSPREVIOUS/AWSPENDING/custom) to
+	// the version id that currently carries it. AWS attaches each label to at
+	// most one version, so this is the authoritative per-secret staging index;
+	// SecretVersion.Current is kept in sync as a derived convenience for the
+	// portable read path.
+	stages    map[string]string
 	deletedAt time.Time
 	// recoveryWindow is the number of days between the delete request and the
 	// scheduled deletion date, captured from DeleteSecret's RecoveryWindowInDays.
@@ -67,7 +74,11 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 	}
 
 	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
-	arn := idgen.AWSARN("secretsmanager", m.opts.Region, m.opts.AccountID, "secret:"+cfg.Name)
+	// The ARN resource segment ends with a deterministic 6-char suffix
+	// (:secret:<name>-<suffix>), matching real Secrets Manager. resolveSecretID
+	// on the wire side strips it, so lookups by the friendly name still resolve.
+	suffix := idgen.SecretARNSuffix(m.opts.Region + ":" + m.opts.AccountID + ":" + cfg.Name)
+	arn := idgen.AWSARN("secretsmanager", m.opts.Region, m.opts.AccountID, "secret:"+cfg.Name+"-"+suffix)
 
 	tags := make(map[string]string, len(cfg.Tags))
 	for k, v := range cfg.Tags {
@@ -88,7 +99,13 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 	data := make([]byte, len(value))
 	copy(data, value)
 
-	versionID := idgen.GenerateID("ver-")
+	// AWS uses the ClientRequestToken as the version id (a UUID); absent one, it
+	// generates a UUID itself.
+	versionID := cfg.ClientRequestToken
+	if versionID == "" {
+		versionID = idgen.UUID()
+	}
+
 	version := driver.SecretVersion{
 		VersionID: versionID,
 		Value:     data,
@@ -99,6 +116,7 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 	sd := &secretData{
 		info:     info,
 		versions: []driver.SecretVersion{version},
+		stages:   map[string]string{stageCurrent: versionID},
 	}
 
 	m.secrets.Set(cfg.Name, sd)
@@ -211,8 +229,25 @@ func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
 	return secrets, nil
 }
 
-// PutSecretValue stores a new version of a secret value.
+// PutSecretValue stores a new version of a secret value and promotes it to
+// AWSCURRENT. It is the shared cross-cloud append-a-version path; the AWS wire
+// layer uses PutSecretValueStaged to honor ClientRequestToken and VersionStages.
 func (m *Mock) PutSecretValue(_ context.Context, name string, value []byte) (*driver.SecretVersion, error) {
+	return m.PutSecretValueStaged(context.Background(), name, value, "", nil)
+}
+
+// PutSecretValueStaged stores a new secret version honoring the AWS
+// ClientRequestToken/VersionStages semantics:
+//   - clientRequestToken, when set, becomes the new version's id. Reusing it with
+//     identical content is an idempotent no-op (the existing version is returned);
+//     reusing it with different content is ResourceExistsException.
+//   - versionStages, when non-empty, are the exact labels the new version takes,
+//     and AWSCURRENT is NOT implied — so staging a candidate as [AWSPENDING]
+//     leaves the prior AWSCURRENT untouched. An empty versionStages promotes the
+//     new version to AWSCURRENT (demoting the prior current to AWSPREVIOUS).
+func (m *Mock) PutSecretValueStaged(
+	_ context.Context, name string, value []byte, clientRequestToken string, versionStages []string,
+) (*driver.SecretVersion, error) {
 	sd, ok := m.secrets.Get(name)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
@@ -226,30 +261,46 @@ func (m *Mock) PutSecretValue(_ context.Context, name string, value []byte) (*dr
 			"secret is scheduled for deletion, so this operation is not allowed")
 	}
 
-	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
-
-	// Mark all existing versions as not current.
-	for i := range sd.versions {
-		sd.versions[i].Current = false
-	}
-
 	data := make([]byte, len(value))
 	copy(data, value)
 
-	versionID := idgen.GenerateID("ver-")
-	version := driver.SecretVersion{
+	if clientRequestToken != "" {
+		if existing, dup := sd.versionByID(clientRequestToken); dup {
+			return m.reusedTokenVersion(existing, data, clientRequestToken)
+		}
+	}
+
+	versionID := clientRequestToken
+	if versionID == "" {
+		versionID = idgen.UUID()
+	}
+
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
+	sd.versions = append(sd.versions, driver.SecretVersion{
 		VersionID: versionID,
 		Value:     data,
 		CreatedAt: now,
-		Current:   true,
-	}
-
-	sd.versions = append(sd.versions, version)
+	})
+	sd.applyStages(versionID, versionStages)
 	sd.info.UpdatedAt = now
 
-	result := version
+	result, _ := sd.versionByID(versionID)
 
-	return &result, nil
+	return copyVersion(result), nil
+}
+
+// reusedTokenVersion enforces ClientRequestToken idempotency: same token + same
+// content returns the existing version unchanged; same token + different content
+// is ResourceExistsException.
+func (*Mock) reusedTokenVersion(
+	existing *driver.SecretVersion, data []byte, token string,
+) (*driver.SecretVersion, error) {
+	if bytes.Equal(existing.Value, data) {
+		return copyVersion(existing), nil
+	}
+
+	return nil, errors.Newf(errors.AlreadyExists,
+		"a version with ClientRequestToken %q already exists with different content", token)
 }
 
 // GetSecretValue retrieves a secret value. Empty versionID returns the current version.

--- a/providers/aws/secretsmanager/snapshot.go
+++ b/providers/aws/secretsmanager/snapshot.go
@@ -20,10 +20,13 @@ type secretsSnapshot struct {
 }
 
 type secretSnapshot struct {
-	Info           driver.SecretInfo      `json:"info"`
-	Versions       []driver.SecretVersion `json:"versions,omitempty"`
-	DeletedAt      time.Time              `json:"deletedAt,omitempty"`
-	RecoveryWindow int                    `json:"recoveryWindow,omitempty"`
+	Info     driver.SecretInfo      `json:"info"`
+	Versions []driver.SecretVersion `json:"versions,omitempty"`
+	// Stages maps each staging label to the version id holding it, preserving the
+	// AWSCURRENT/AWSPREVIOUS/custom assignment across snapshot/restore.
+	Stages         map[string]string `json:"stages,omitempty"`
+	DeletedAt      time.Time         `json:"deletedAt,omitempty"`
+	RecoveryWindow int               `json:"recoveryWindow,omitempty"`
 }
 
 // Snapshot captures every secret's full state as JSON. includeAssets is unused —
@@ -37,6 +40,7 @@ func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
 		snap.Secrets[name] = &secretSnapshot{
 			Info:           sd.info,
 			Versions:       sd.versions,
+			Stages:         sd.stages,
 			DeletedAt:      sd.deletedAt,
 			RecoveryWindow: sd.recoveryWindow,
 		}
@@ -58,6 +62,7 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 		m.secrets.Set(name, &secretData{
 			info:           ss.Info,
 			versions:       ss.Versions,
+			stages:         ss.Stages,
 			deletedAt:      ss.DeletedAt,
 			recoveryWindow: ss.RecoveryWindow,
 		})

--- a/providers/aws/secretsmanager/staging.go
+++ b/providers/aws/secretsmanager/staging.go
@@ -2,6 +2,7 @@ package secretsmanager
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/errors"
@@ -15,15 +16,95 @@ const (
 	stagePrevious = "AWSPREVIOUS"
 )
 
-// currentIndex returns the index of the current version, or -1 if none.
-func currentIndex(versions []driver.SecretVersion) int {
-	for i := range versions {
-		if versions[i].Current {
-			return i
+// versionByID returns a pointer to the version with the given id (into the
+// backing slice, so callers may mutate it under the lock), or ok=false.
+func (sd *secretData) versionByID(id string) (*driver.SecretVersion, bool) {
+	for i := range sd.versions {
+		if sd.versions[i].VersionID == id {
+			return &sd.versions[i], true
 		}
 	}
 
-	return -1
+	return nil, false
+}
+
+// stagesForVersion returns the sorted staging labels attached to a version id.
+func (sd *secretData) stagesForVersion(id string) []string {
+	var labels []string
+
+	for label, vid := range sd.stages {
+		if vid == id {
+			labels = append(labels, label)
+		}
+	}
+
+	sort.Strings(labels)
+
+	return labels
+}
+
+// setStage attaches label to versionID, detaching it from any prior holder
+// (each label lives on at most one version). It then re-derives Current flags.
+func (sd *secretData) setStage(label, versionID string) {
+	if sd.stages == nil {
+		sd.stages = make(map[string]string)
+	}
+
+	sd.stages[label] = versionID
+	sd.syncCurrent()
+}
+
+// removeStage detaches label from whatever version holds it.
+func (sd *secretData) removeStage(label string) {
+	delete(sd.stages, label)
+	sd.syncCurrent()
+}
+
+// promoteToCurrent moves AWSCURRENT to versionID, demoting the version that
+// previously held AWSCURRENT to AWSPREVIOUS (and evicting the label from the old
+// AWSPREVIOUS holder), mirroring the real service's staging shuffle.
+func (sd *secretData) promoteToCurrent(versionID string) {
+	if sd.stages == nil {
+		sd.stages = make(map[string]string)
+	}
+
+	if prevCurrent, ok := sd.stages[stageCurrent]; ok && prevCurrent != versionID {
+		sd.stages[stagePrevious] = prevCurrent
+	}
+
+	sd.stages[stageCurrent] = versionID
+	sd.syncCurrent()
+}
+
+// applyStages assigns the requested labels to a freshly appended version. An
+// empty request promotes it to AWSCURRENT (with the AWSPREVIOUS shuffle); an
+// explicit set attaches exactly those labels (AWSCURRENT among them still runs
+// the shuffle), leaving any labels not named where they are.
+func (sd *secretData) applyStages(versionID string, requested []string) {
+	if len(requested) == 0 {
+		sd.promoteToCurrent(versionID)
+
+		return
+	}
+
+	for _, label := range requested {
+		if label == stageCurrent {
+			sd.promoteToCurrent(versionID)
+
+			continue
+		}
+
+		sd.setStage(label, versionID)
+	}
+}
+
+// syncCurrent keeps SecretVersion.Current aligned with the AWSCURRENT label, so
+// the portable GetSecretValue/ListSecretVersions read path stays correct.
+func (sd *secretData) syncCurrent() {
+	current := sd.stages[stageCurrent]
+	for i := range sd.versions {
+		sd.versions[i].Current = sd.versions[i].VersionID == current
+	}
 }
 
 // MarkVersionBinary flags a version as binary so GetSecretValue returns it as
@@ -37,19 +118,17 @@ func (m *Mock) MarkVersionBinary(_ context.Context, name, versionID string) erro
 	sd.mu.Lock()
 	defer sd.mu.Unlock()
 
-	for i := range sd.versions {
-		if sd.versions[i].VersionID == versionID {
-			sd.versions[i].Binary = true
+	if v, found := sd.versionByID(versionID); found {
+		v.Binary = true
 
-			return nil
-		}
+		return nil
 	}
 
 	return errors.Newf(errors.NotFound, "version %q not found for secret %q", versionID, name)
 }
 
 // GetSecretValueStage returns a secret value addressed by version ID or by stage
-// label (AWSCURRENT/AWSPREVIOUS). An empty versionID and stage returns the
+// label (AWSCURRENT/AWSPREVIOUS/custom). An empty versionID and stage returns the
 // current version.
 func (m *Mock) GetSecretValueStage(_ context.Context, name, versionID, stage string) (*driver.SecretVersion, error) {
 	sd, ok := m.secrets.Get(name)
@@ -66,36 +145,34 @@ func (m *Mock) GetSecretValueStage(_ context.Context, name, versionID, stage str
 	}
 
 	if versionID != "" {
-		for _, v := range sd.versions {
-			if v.VersionID == versionID {
-				return copyVersion(v), nil
-			}
+		if v, found := sd.versionByID(versionID); found {
+			return copyVersion(v), nil
 		}
 
 		return nil, errors.Newf(errors.NotFound, "version %q not found for secret %q", versionID, name)
 	}
 
-	cur := currentIndex(sd.versions)
-	if cur < 0 {
-		return nil, errors.Newf(errors.NotFound, "secret %q has no current version", name)
+	label := stage
+	if label == "" {
+		label = stageCurrent
 	}
 
-	switch stage {
-	case "", stageCurrent:
-		return copyVersion(sd.versions[cur]), nil
-	case stagePrevious:
-		if cur == 0 {
-			return nil, errors.Newf(errors.NotFound, "secret %q has no AWSPREVIOUS version", name)
-		}
-
-		return copyVersion(sd.versions[cur-1]), nil
-	default:
-		return nil, errors.Newf(errors.NotFound, "stage %q not found for secret %q", stage, name)
+	target, ok := sd.stages[label]
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "stage %q not found for secret %q", label, name)
 	}
+
+	v, found := sd.versionByID(target)
+	if !found {
+		return nil, errors.Newf(errors.NotFound, "stage %q not found for secret %q", label, name)
+	}
+
+	return copyVersion(v), nil
 }
 
 // SecretVersionStages returns the stage labels for each version ID, so
-// DescribeSecret can populate VersionIdsToStages.
+// DescribeSecret can populate VersionIdsToStages. Versions with no labels
+// (deprecated) are omitted.
 func (m *Mock) SecretVersionStages(_ context.Context, name string) (map[string][]string, error) {
 	sd, ok := m.secrets.Get(name)
 	if !ok {
@@ -107,16 +184,96 @@ func (m *Mock) SecretVersionStages(_ context.Context, name string) (map[string][
 
 	stages := make(map[string][]string, len(sd.versions))
 
-	cur := currentIndex(sd.versions)
-	if cur >= 0 {
-		stages[sd.versions[cur].VersionID] = []string{stageCurrent}
-
-		if cur > 0 {
-			stages[sd.versions[cur-1].VersionID] = []string{stagePrevious}
+	for i := range sd.versions {
+		id := sd.versions[i].VersionID
+		if labels := sd.stagesForVersion(id); len(labels) > 0 {
+			stages[id] = labels
 		}
 	}
 
 	return stages, nil
+}
+
+// UpdateSecretVersionStage moves a staging label between versions, the
+// finishSecret step of the AWS rotation contract. moveTo attaches the label to
+// that version; removeFrom detaches it (and must currently hold it). Moving
+// AWSCURRENT auto-demotes the prior AWSCURRENT to AWSPREVIOUS.
+func (m *Mock) UpdateSecretVersionStage(
+	_ context.Context, name, versionStage, removeFrom, moveTo string,
+) (*driver.SecretInfo, error) {
+	if versionStage == "" {
+		return nil, errors.New(errors.InvalidArgument, "VersionStage is required")
+	}
+
+	if moveTo == "" && removeFrom == "" {
+		return nil, errors.New(errors.InvalidArgument,
+			"either MoveToVersionId or RemoveFromVersionId must be provided")
+	}
+
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.New(errors.FailedPrecondition,
+			"secret is scheduled for deletion, so this operation is not allowed")
+	}
+
+	if err := sd.validateStageMove(versionStage, removeFrom, moveTo); err != nil {
+		return nil, err
+	}
+
+	sd.moveStage(versionStage, moveTo)
+	sd.info.UpdatedAt = m.opts.Clock.Now().UTC().Format(time.RFC3339)
+
+	info := sd.info
+
+	return &info, nil
+}
+
+// validateStageMove checks the target versions exist and that a requested
+// removeFrom actually holds the label, matching the real service's rejections.
+func (sd *secretData) validateStageMove(versionStage, removeFrom, moveTo string) error {
+	if moveTo != "" {
+		if _, ok := sd.versionByID(moveTo); !ok {
+			return errors.Newf(errors.NotFound, "version %q not found for MoveToVersionId", moveTo)
+		}
+	}
+
+	if removeFrom != "" {
+		if _, ok := sd.versionByID(removeFrom); !ok {
+			return errors.Newf(errors.NotFound, "version %q not found for RemoveFromVersionId", removeFrom)
+		}
+
+		if holder, ok := sd.stages[versionStage]; !ok || holder != removeFrom {
+			return errors.Newf(errors.InvalidArgument,
+				"stage %q is not attached to version %q", versionStage, removeFrom)
+		}
+	}
+
+	return nil
+}
+
+// moveStage applies a validated stage move.
+func (sd *secretData) moveStage(versionStage, moveTo string) {
+	if moveTo != "" {
+		if versionStage == stageCurrent {
+			sd.promoteToCurrent(moveTo)
+
+			return
+		}
+
+		sd.setStage(versionStage, moveTo)
+
+		return
+	}
+
+	// removeFrom-only: detach the label entirely (removeFrom already validated).
+	sd.removeStage(versionStage)
 }
 
 // SecretDeletionDate reports the scheduled deletion date (RFC3339) for a
@@ -190,39 +347,33 @@ func (m *Mock) RotateSecret(_ context.Context, name string) (*driver.SecretVersi
 			"secret is scheduled for deletion, so this operation is not allowed")
 	}
 
-	cur := currentIndex(sd.versions)
-	if cur < 0 {
+	curID, ok := sd.stages[stageCurrent]
+	if !ok {
 		return nil, errors.Newf(errors.FailedPrecondition, "secret %q has no current version to rotate", name)
 	}
 
+	cur, _ := sd.versionByID(curID)
+	data := make([]byte, len(cur.Value))
+	copy(data, cur.Value)
+
 	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
-
-	prev := sd.versions[cur]
-	data := make([]byte, len(prev.Value))
-	copy(data, prev.Value)
-
-	for i := range sd.versions {
-		sd.versions[i].Current = false
-	}
-
-	version := driver.SecretVersion{
-		VersionID: idgen.GenerateID("ver-"),
+	versionID := idgen.UUID()
+	sd.versions = append(sd.versions, driver.SecretVersion{
+		VersionID: versionID,
 		Value:     data,
 		CreatedAt: now,
-		Current:   true,
-		Binary:    prev.Binary,
-	}
-
-	sd.versions = append(sd.versions, version)
+		Binary:    cur.Binary,
+	})
+	sd.promoteToCurrent(versionID)
 	sd.info.UpdatedAt = now
 
-	result := version
+	result, _ := sd.versionByID(versionID)
 
-	return &result, nil
+	return copyVersion(result), nil
 }
 
-func copyVersion(v driver.SecretVersion) *driver.SecretVersion {
-	result := v
+func copyVersion(v *driver.SecretVersion) *driver.SecretVersion {
+	result := *v
 	data := make([]byte, len(v.Value))
 	copy(data, v.Value)
 	result.Value = data

--- a/providers/aws/secretsmanager/staging.go
+++ b/providers/aws/secretsmanager/staging.go
@@ -14,6 +14,7 @@ import (
 const (
 	stageCurrent  = "AWSCURRENT"
 	stagePrevious = "AWSPREVIOUS"
+	stagePending  = "AWSPENDING"
 )
 
 // versionByID returns a pointer to the version with the given id (into the
@@ -62,7 +63,10 @@ func (sd *secretData) removeStage(label string) {
 
 // promoteToCurrent moves AWSCURRENT to versionID, demoting the version that
 // previously held AWSCURRENT to AWSPREVIOUS (and evicting the label from the old
-// AWSPREVIOUS holder), mirroring the real service's staging shuffle.
+// AWSPREVIOUS holder), mirroring the real service's staging shuffle. If the
+// promoted version was the AWSPENDING candidate, its AWSPENDING label is
+// automatically removed (as the real service does when rotation finishes), so
+// AWSPENDING never rides forward onto the current version.
 func (sd *secretData) promoteToCurrent(versionID string) {
 	if sd.stages == nil {
 		sd.stages = make(map[string]string)
@@ -70,6 +74,10 @@ func (sd *secretData) promoteToCurrent(versionID string) {
 
 	if prevCurrent, ok := sd.stages[stageCurrent]; ok && prevCurrent != versionID {
 		sd.stages[stagePrevious] = prevCurrent
+	}
+
+	if pending, ok := sd.stages[stagePending]; ok && pending == versionID {
+		delete(sd.stages, stagePending)
 	}
 
 	sd.stages[stageCurrent] = versionID

--- a/providers/aws/secretsmanager/staging_test.go
+++ b/providers/aws/secretsmanager/staging_test.go
@@ -1,0 +1,151 @@
+package secretsmanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPutSecretValueStagedPending verifies a staged put with [AWSPENDING] does
+// not move AWSCURRENT.
+func TestPutSecretValueStagedPending(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	createTestSecret(t, m, "s", "v1")
+
+	pending, err := m.PutSecretValueStaged(ctx, "s", []byte("pending"), "", []string{"AWSPENDING"})
+	require.NoError(t, err)
+	assert.False(t, pending.Current, "AWSPENDING version must not be AWSCURRENT")
+
+	stages, err := m.SecretVersionStages(ctx, "s")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"AWSPENDING"}, stages[pending.VersionID])
+
+	// Default read still returns the original AWSCURRENT value.
+	cur, err := m.GetSecretValueStage(ctx, "s", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", string(cur.Value))
+}
+
+// TestClientRequestTokenIdempotency verifies same-token+same-content is a no-op
+// and different content is a conflict.
+func TestClientRequestTokenIdempotency(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	createTestSecret(t, m, "s", "v1")
+
+	const token = "22222222-2222-2222-2222-222222222222"
+
+	first, err := m.PutSecretValueStaged(ctx, "s", []byte("v2"), token, nil)
+	require.NoError(t, err)
+	assert.Equal(t, token, first.VersionID)
+
+	second, err := m.PutSecretValueStaged(ctx, "s", []byte("v2"), token, nil)
+	require.NoError(t, err)
+	assert.Equal(t, token, second.VersionID)
+
+	versions, err := m.ListSecretVersions(ctx, "s")
+	require.NoError(t, err)
+	assert.Len(t, versions, 2, "idempotent put must not add a version")
+
+	_, err = m.PutSecretValueStaged(ctx, "s", []byte("different"), token, nil)
+	require.Error(t, err, "same token + different content must fail")
+}
+
+// TestUpdateSecretVersionStagePromotes verifies moving AWSCURRENT demotes the
+// prior current to AWSPREVIOUS.
+func TestUpdateSecretVersionStagePromotes(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	created := createTestSecret(t, m, "s", "current")
+	_ = created
+
+	cur, err := m.GetSecretValueStage(ctx, "s", "", "AWSCURRENT")
+	require.NoError(t, err)
+	oldCurrentID := cur.VersionID
+
+	pending, err := m.PutSecretValueStaged(ctx, "s", []byte("pending"), "", []string{"AWSPENDING"})
+	require.NoError(t, err)
+
+	_, err = m.UpdateSecretVersionStage(ctx, "s", "AWSCURRENT", oldCurrentID, pending.VersionID)
+	require.NoError(t, err)
+
+	// The promoted version keeps its AWSPENDING label (real rotation's
+	// finishSecret only moves AWSCURRENT; it does not strip AWSPENDING), so it
+	// now carries both, sorted.
+	stages, err := m.SecretVersionStages(ctx, "s")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"AWSCURRENT", "AWSPENDING"}, stages[pending.VersionID])
+	assert.Equal(t, []string{"AWSPREVIOUS"}, stages[oldCurrentID])
+
+	got, err := m.GetSecretValueStage(ctx, "s", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, "pending", string(got.Value))
+}
+
+// TestUpdateSecretVersionStageValidation verifies argument validation.
+func TestUpdateSecretVersionStageValidation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	createTestSecret(t, m, "s", "v1")
+
+	_, err := m.UpdateSecretVersionStage(ctx, "s", "", "", "someversion")
+	require.Error(t, err, "empty VersionStage must fail")
+
+	_, err = m.UpdateSecretVersionStage(ctx, "s", "AWSPENDING", "", "")
+	require.Error(t, err, "neither move nor remove must fail")
+
+	_, err = m.UpdateSecretVersionStage(ctx, "s", "AWSPENDING", "", "nonexistent")
+	require.Error(t, err, "unknown MoveToVersionId must fail")
+}
+
+// TestUpdateSecretReturnsVersionID verifies UpdateSecret surfaces the created
+// version id on a value change and empty when only the description changes.
+func TestUpdateSecretReturnsVersionID(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	createTestSecret(t, m, "s", "v1")
+
+	_, verID, err := m.UpdateSecret(ctx, "s", "", []byte("v2"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, verID)
+
+	_, verID2, err := m.UpdateSecret(ctx, "s", "new-desc", nil)
+	require.NoError(t, err)
+	assert.Empty(t, verID2, "no value change must not create a version")
+}
+
+// TestSnapshotRestoreStages verifies staging labels survive snapshot/restore.
+func TestSnapshotRestoreStages(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	createTestSecret(t, m, "s", "v1")
+	_, err := m.PutSecretValueStaged(ctx, "s", []byte("v2"), "", nil)
+	require.NoError(t, err)
+
+	data, err := m.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	restored := newTestMock()
+	require.NoError(t, restored.Restore(ctx, data))
+
+	before, err := m.SecretVersionStages(ctx, "s")
+	require.NoError(t, err)
+
+	after, err := restored.SecretVersionStages(ctx, "s")
+	require.NoError(t, err)
+
+	assert.Equal(t, before, after)
+
+	cur, err := restored.GetSecretValueStage(ctx, "s", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, "v2", string(cur.Value))
+}

--- a/providers/aws/secretsmanager/staging_test.go
+++ b/providers/aws/secretsmanager/staging_test.go
@@ -75,12 +75,12 @@ func TestUpdateSecretVersionStagePromotes(t *testing.T) {
 	_, err = m.UpdateSecretVersionStage(ctx, "s", "AWSCURRENT", oldCurrentID, pending.VersionID)
 	require.NoError(t, err)
 
-	// The promoted version keeps its AWSPENDING label (real rotation's
-	// finishSecret only moves AWSCURRENT; it does not strip AWSPENDING), so it
-	// now carries both, sorted.
+	// Promoting AWSCURRENT onto the pending version auto-removes its AWSPENDING
+	// label (as the real service does at finishSecret), so it carries AWSCURRENT
+	// exactly — AWSPENDING must not ride forward onto the current version.
 	stages, err := m.SecretVersionStages(ctx, "s")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"AWSCURRENT", "AWSPENDING"}, stages[pending.VersionID])
+	assert.Equal(t, []string{"AWSCURRENT"}, stages[pending.VersionID])
 	assert.Equal(t, []string{"AWSPREVIOUS"}, stages[oldCurrentID])
 
 	got, err := m.GetSecretValueStage(ctx, "s", "", "")

--- a/providers/aws/secretsmanager/update.go
+++ b/providers/aws/secretsmanager/update.go
@@ -10,20 +10,21 @@ import (
 )
 
 // UpdateSecret updates a secret's description and, when value is non-nil,
-// stores it as a new current version (SecretsManager UpdateSecret semantics:
+// stores it as a new AWSCURRENT version (SecretsManager UpdateSecret semantics:
 // SecretString/SecretBinary are optional). An empty description leaves the
-// existing one unchanged.
-func (m *Mock) UpdateSecret(_ context.Context, name, description string, value []byte) (*driver.SecretInfo, error) {
+// existing one unchanged. It returns the created version's id (empty when no
+// value change created a version), which UpdateSecret echoes to the caller.
+func (m *Mock) UpdateSecret(_ context.Context, name, description string, value []byte) (*driver.SecretInfo, string, error) {
 	sd, ok := m.secrets.Get(name)
 	if !ok {
-		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+		return nil, "", errors.Newf(errors.NotFound, "secret %q not found", name)
 	}
 
 	sd.mu.Lock()
 	defer sd.mu.Unlock()
 
 	if !sd.deletedAt.IsZero() {
-		return nil, errors.New(errors.FailedPrecondition,
+		return nil, "", errors.New(errors.FailedPrecondition,
 			"secret is scheduled for deletion, so this operation is not allowed")
 	}
 
@@ -33,27 +34,26 @@ func (m *Mock) UpdateSecret(_ context.Context, name, description string, value [
 		sd.info.Description = description
 	}
 
-	if value != nil {
-		for i := range sd.versions {
-			sd.versions[i].Current = false
-		}
+	var versionID string
 
+	if value != nil {
 		data := make([]byte, len(value))
 		copy(data, value)
 
+		versionID = idgen.UUID()
 		sd.versions = append(sd.versions, driver.SecretVersion{
-			VersionID: idgen.GenerateID("ver-"),
+			VersionID: versionID,
 			Value:     data,
 			CreatedAt: now,
-			Current:   true,
 		})
+		sd.promoteToCurrent(versionID)
 	}
 
 	sd.info.UpdatedAt = now
 
 	result := sd.info
 
-	return &result, nil
+	return &result, versionID, nil
 }
 
 // TagSecret adds or overwrites tags on a secret (SecretsManager TagResource).

--- a/server/aws/secretsmanager/handler.go
+++ b/server/aws/secretsmanager/handler.go
@@ -24,7 +24,7 @@ const targetPrefix = "secretsmanager."
 // Manager also implement it), so the handler type-asserts for them rather than
 // widening the shared interface.
 type secretMutator interface {
-	UpdateSecret(ctx context.Context, name, description string, value []byte) (*secretsdriver.SecretInfo, error)
+	UpdateSecret(ctx context.Context, name, description string, value []byte) (*secretsdriver.SecretInfo, string, error)
 	TagSecret(ctx context.Context, name string, tags map[string]string) error
 	UntagSecret(ctx context.Context, name string, keys []string) error
 }
@@ -43,6 +43,12 @@ type secretStager interface {
 	) (*secretsdriver.SecretInfo, string, error)
 	RestoreSecret(ctx context.Context, name string) (*secretsdriver.SecretInfo, error)
 	RotateSecret(ctx context.Context, name string) (*secretsdriver.SecretVersion, error)
+	PutSecretValueStaged(
+		ctx context.Context, name string, value []byte, clientRequestToken string, versionStages []string,
+	) (*secretsdriver.SecretVersion, error)
+	UpdateSecretVersionStage(
+		ctx context.Context, name, versionStage, removeFrom, moveTo string,
+	) (*secretsdriver.SecretInfo, error)
 }
 
 // Handler serves Secrets Manager JSON-RPC requests against a Secrets driver.
@@ -55,20 +61,21 @@ type Handler struct {
 func New(s secretsdriver.Secrets) *Handler {
 	h := &Handler{secrets: s}
 	h.routes = map[string]http.HandlerFunc{
-		"CreateSecret":         h.createSecret,
-		"DeleteSecret":         h.deleteSecret,
-		"DescribeSecret":       h.describeSecret,
-		"GetResourcePolicy":    h.getResourcePolicy,
-		"ListSecrets":          h.listSecrets,
-		"GetSecretValue":       h.getSecretValue,
-		"PutSecretValue":       h.putSecretValue,
-		"ListSecretVersionIds": h.listSecretVersionIDs,
-		"UpdateSecret":         h.updateSecret,
-		"RestoreSecret":        h.restoreSecret,
-		"RotateSecret":         h.rotateSecret,
-		"GetRandomPassword":    h.getRandomPassword,
-		"TagResource":          h.tagResource,
-		"UntagResource":        h.untagResource,
+		"CreateSecret":             h.createSecret,
+		"DeleteSecret":             h.deleteSecret,
+		"DescribeSecret":           h.describeSecret,
+		"GetResourcePolicy":        h.getResourcePolicy,
+		"ListSecrets":              h.listSecrets,
+		"GetSecretValue":           h.getSecretValue,
+		"PutSecretValue":           h.putSecretValue,
+		"ListSecretVersionIds":     h.listSecretVersionIDs,
+		"UpdateSecret":             h.updateSecret,
+		"UpdateSecretVersionStage": h.updateSecretVersionStage,
+		"RestoreSecret":            h.restoreSecret,
+		"RotateSecret":             h.rotateSecret,
+		"GetRandomPassword":        h.getRandomPassword,
+		"TagResource":              h.tagResource,
+		"UntagResource":            h.untagResource,
 	}
 
 	return h

--- a/server/aws/secretsmanager/helpers.go
+++ b/server/aws/secretsmanager/helpers.go
@@ -170,9 +170,10 @@ func anyAttrContainsFold(info *secretsdriver.SecretInfo, word string) bool {
 	return false
 }
 
-// randomPassword generates a password honoring GetRandomPassword's character-set
-// toggles. RequireEachIncludedType is not enforced (best-effort emulation).
-func randomPassword(req getRandomPasswordRequest) (string, error) {
+// passwordClasses returns the included character classes for a
+// GetRandomPassword request, each already stripped of ExcludeCharacters, in the
+// order lower, upper, digit, punctuation, space. Empty classes are omitted.
+func passwordClasses(req getRandomPasswordRequest) []string {
 	const (
 		lower = "abcdefghijklmnopqrstuvwxyz"
 		upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -181,30 +182,39 @@ func randomPassword(req getRandomPasswordRequest) (string, error) {
 		space = " "
 	)
 
-	var b strings.Builder
-
-	if !req.ExcludeLowercase {
-		b.WriteString(lower)
+	candidates := []struct {
+		set     string
+		exclude bool
+	}{
+		{lower, req.ExcludeLowercase},
+		{upper, req.ExcludeUppercase},
+		{digit, req.ExcludeNumbers},
+		{punct, req.ExcludePunctuation},
+		{space, !req.IncludeSpace},
 	}
 
-	if !req.ExcludeUppercase {
-		b.WriteString(upper)
+	var classes []string
+
+	for _, c := range candidates {
+		if c.exclude {
+			continue
+		}
+
+		if s := stripExcluded(c.set, req.ExcludeCharacters); s != "" {
+			classes = append(classes, s)
+		}
 	}
 
-	if !req.ExcludeNumbers {
-		b.WriteString(digit)
-	}
+	return classes
+}
 
-	if !req.ExcludePunctuation {
-		b.WriteString(punct)
-	}
-
-	if req.IncludeSpace {
-		b.WriteString(space)
-	}
-
-	pool := stripExcluded(b.String(), req.ExcludeCharacters)
-	if pool == "" {
+// randomPassword generates a password honoring GetRandomPassword's character-set
+// toggles. When RequireEachIncludedType is set the result is guaranteed to carry
+// at least one character from every included class, and a length shorter than
+// the number of included classes is rejected.
+func randomPassword(req getRandomPasswordRequest) (string, error) {
+	classes := passwordClasses(req)
+	if len(classes) == 0 {
 		return "", cerrors.New(cerrors.InvalidArgument, "no characters available to generate password")
 	}
 
@@ -213,19 +223,77 @@ func randomPassword(req getRandomPasswordRequest) (string, error) {
 		length = defaultPasswordLength
 	}
 
-	runes := []rune(pool)
-	out := make([]rune, 0, length)
+	if req.RequireEachIncludedType && length < int64(len(classes)) {
+		return "", cerrors.New(cerrors.InvalidArgument,
+			"PasswordLength too short to include one of each required character type")
+	}
 
-	for i := int64(0); i < length; i++ {
-		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(runes))))
-		if err != nil {
-			return "", cerrors.New(cerrors.Internal, "random source failure")
-		}
+	out, err := buildPassword(classes, length, req.RequireEachIncludedType)
+	if err != nil {
+		return "", err
+	}
 
-		out = append(out, runes[n.Int64()])
+	if err := shuffleRunes(out); err != nil {
+		return "", err
 	}
 
 	return string(out), nil
+}
+
+// buildPassword assembles the character slice: when requireEach is set it seeds
+// one guaranteed rune from each class, then fills the remainder from the pooled
+// classes. The result is unshuffled.
+func buildPassword(classes []string, length int64, requireEach bool) ([]rune, error) {
+	pool := []rune(strings.Join(classes, ""))
+	out := make([]rune, 0, length)
+
+	if requireEach {
+		for _, class := range classes {
+			c, err := pickRune([]rune(class))
+			if err != nil {
+				return nil, err
+			}
+
+			out = append(out, c)
+		}
+	}
+
+	for int64(len(out)) < length {
+		c, err := pickRune(pool)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, c)
+	}
+
+	return out, nil
+}
+
+// pickRune returns a uniformly random rune from runes.
+func pickRune(runes []rune) (rune, error) {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(len(runes))))
+	if err != nil {
+		return 0, cerrors.New(cerrors.Internal, "random source failure")
+	}
+
+	return runes[n.Int64()], nil
+}
+
+// shuffleRunes performs a Fisher-Yates shuffle so the guaranteed seed characters
+// aren't clustered at the front.
+func shuffleRunes(r []rune) error {
+	for i := len(r) - 1; i > 0; i-- {
+		j, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
+		if err != nil {
+			return cerrors.New(cerrors.Internal, "random source failure")
+		}
+
+		k := j.Int64()
+		r[i], r[k] = r[k], r[i]
+	}
+
+	return nil
 }
 
 func stripExcluded(pool, exclude string) string {

--- a/server/aws/secretsmanager/operations.go
+++ b/server/aws/secretsmanager/operations.go
@@ -15,10 +15,11 @@ func (h *Handler) createSecret(w http.ResponseWriter, r *http.Request) {
 	}
 
 	info, err := h.secrets.CreateSecret(r.Context(), secretsdriver.SecretConfig{
-		Name:        req.Name,
-		Description: req.Description,
-		Tags:        tagsToMap(req.Tags),
-		KMSKeyID:    req.KmsKeyID,
+		Name:               req.Name,
+		Description:        req.Description,
+		Tags:               tagsToMap(req.Tags),
+		KMSKeyID:           req.KmsKeyID,
+		ClientRequestToken: req.ClientRequestToken,
 	}, secretValue(req.SecretString, req.SecretBinary))
 	if err != nil {
 		writeErr(w, err)
@@ -340,7 +341,7 @@ func (h *Handler) putSecretValue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ver, err := h.secrets.PutSecretValue(r.Context(), name, secretValue(req.SecretString, req.SecretBinary))
+	ver, err := h.putSecretVersion(r, name, &req)
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -358,6 +359,21 @@ func (h *Handler) putSecretValue(w http.ResponseWriter, r *http.Request) {
 		VersionID:     ver.VersionID,
 		VersionStages: stagesForVersion(h.versionStages(r, name), ver),
 	})
+}
+
+// putSecretVersion appends a new version. When the AWS staging surface is
+// available it honors ClientRequestToken (idempotency + version id) and
+// VersionStages; otherwise it falls back to the portable append-a-version path.
+func (h *Handler) putSecretVersion(
+	r *http.Request, name string, req *putSecretValueRequest,
+) (*secretsdriver.SecretVersion, error) {
+	value := secretValue(req.SecretString, req.SecretBinary)
+
+	if st, ok := h.secrets.(secretStager); ok {
+		return st.PutSecretValueStaged(r.Context(), name, value, req.ClientRequestToken, req.VersionStages)
+	}
+
+	return h.secrets.PutSecretValue(r.Context(), name, value)
 }
 
 func (h *Handler) listSecretVersionIDs(w http.ResponseWriter, r *http.Request) {
@@ -386,6 +402,7 @@ func (h *Handler) listSecretVersionIDs(w http.ResponseWriter, r *http.Request) {
 	stageMap := h.versionStages(r, name)
 
 	out := make([]versionJSON, 0, len(versions))
+
 	for _, v := range versions {
 		stages := stagesForVersion(stageMap, &v)
 		if len(stages) == 0 && !req.IncludeDeprecated {
@@ -414,14 +431,39 @@ func (h *Handler) updateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	info, err := mut.UpdateSecret(r.Context(), resolveSecretID(req.SecretID),
+	info, versionID, err := mut.UpdateSecret(r.Context(), resolveSecretID(req.SecretID),
 		req.Description, secretValue(req.SecretString, req.SecretBinary))
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	wire.WriteJSON(w, updateSecretResponse{ARN: info.ResourceID, Name: info.Name})
+	wire.WriteJSON(w, updateSecretResponse{ARN: info.ResourceID, Name: info.Name, VersionID: versionID})
+}
+
+// updateSecretVersionStage moves a staging label between versions (the
+// finishSecret step of the AWS rotation contract). It requires the AWS staging
+// surface; providers without it report the operation as unsupported.
+func (h *Handler) updateSecretVersionStage(w http.ResponseWriter, r *http.Request) {
+	st, ok := h.secrets.(secretStager)
+	if !ok {
+		writeErr(w, errNotSupported)
+		return
+	}
+
+	var req updateSecretVersionStageRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	info, err := st.UpdateSecretVersionStage(r.Context(), resolveSecretID(req.SecretID),
+		req.VersionStage, req.RemoveFromVersionID, req.MoveToVersionID)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, updateSecretVersionStageResponse{ARN: info.ResourceID, Name: info.Name})
 }
 
 func (h *Handler) tagResource(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/secretsmanager/staging_versioning_test.go
+++ b/server/aws/secretsmanager/staging_versioning_test.go
@@ -1,0 +1,357 @@
+package secretsmanager_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssm "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+)
+
+// TestSDKClientRequestTokenIdempotent guards F1: PutSecretValue with a repeated
+// ClientRequestToken and identical content is idempotent (same VersionId, no new
+// version), the token IS the VersionId, and reusing it with different content is
+// ResourceExistsException.
+func TestSDKClientRequestTokenIdempotent(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("idem"), SecretString: aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	const token = "11111111-1111-1111-1111-111111111111"
+
+	first, err := client.PutSecretValue(ctx, &awssm.PutSecretValueInput{
+		SecretId: aws.String("idem"), SecretString: aws.String("v2"),
+		ClientRequestToken: aws.String(token),
+	})
+	if err != nil {
+		t.Fatalf("PutSecretValue(first): %v", err)
+	}
+
+	if aws.ToString(first.VersionId) != token {
+		t.Fatalf("VersionId = %q, want the ClientRequestToken %q", aws.ToString(first.VersionId), token)
+	}
+
+	// Same token, same content: idempotent no-op, same VersionId.
+	second, err := client.PutSecretValue(ctx, &awssm.PutSecretValueInput{
+		SecretId: aws.String("idem"), SecretString: aws.String("v2"),
+		ClientRequestToken: aws.String(token),
+	})
+	if err != nil {
+		t.Fatalf("PutSecretValue(second): %v", err)
+	}
+
+	if aws.ToString(second.VersionId) != token {
+		t.Fatalf("idempotent VersionId = %q, want %q", aws.ToString(second.VersionId), token)
+	}
+
+	// Total versions must be 2 (initial + one put), not 3.
+	list, err := client.ListSecretVersionIds(ctx, &awssm.ListSecretVersionIdsInput{
+		SecretId: aws.String("idem"), IncludeDeprecated: aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("ListSecretVersionIds: %v", err)
+	}
+
+	if len(list.Versions) != 2 {
+		t.Fatalf("version count = %d, want 2 (idempotent put did not add a version)", len(list.Versions))
+	}
+
+	// GetSecretValue by the token resolves.
+	got, err := client.GetSecretValue(ctx, &awssm.GetSecretValueInput{
+		SecretId: aws.String("idem"), VersionId: aws.String(token),
+	})
+	if err != nil {
+		t.Fatalf("GetSecretValue(by token): %v", err)
+	}
+
+	if aws.ToString(got.SecretString) != "v2" {
+		t.Fatalf("value by token = %q, want v2", aws.ToString(got.SecretString))
+	}
+
+	// Same token, different content: ResourceExistsException.
+	_, err = client.PutSecretValue(ctx, &awssm.PutSecretValueInput{
+		SecretId: aws.String("idem"), SecretString: aws.String("different"),
+		ClientRequestToken: aws.String(token),
+	})
+
+	var exists *smtypes.ResourceExistsException
+	if !errors.As(err, &exists) {
+		t.Fatalf("reused token + different content: got %v, want ResourceExistsException", err)
+	}
+}
+
+// TestSDKVersionIdIsUUID guards F9: version ids are 36-char UUIDs, not counter
+// ids.
+func TestSDKVersionIdIsUUID(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("uuidver"), SecretString: aws.String("v1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	id := aws.ToString(created.VersionId)
+	if len(id) != 36 || strings.Count(id, "-") != 4 {
+		t.Fatalf("VersionId = %q, want a 36-char UUID", id)
+	}
+}
+
+// TestSDKPutSecretValueVersionStages guards F2: a Put with VersionStages
+// [AWSPENDING] attaches exactly that label and does NOT become AWSCURRENT — the
+// default GetSecretValue still returns the prior value; a Put without stages
+// promotes to AWSCURRENT and demotes the prior current to AWSPREVIOUS.
+func TestSDKPutSecretValueVersionStages(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("stg"), SecretString: aws.String("v1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	pending, err := client.PutSecretValue(ctx, &awssm.PutSecretValueInput{
+		SecretId: aws.String("stg"), SecretString: aws.String("pending"),
+		VersionStages: []string{"AWSPENDING"},
+	})
+	if err != nil {
+		t.Fatalf("PutSecretValue(AWSPENDING): %v", err)
+	}
+
+	if len(pending.VersionStages) != 1 || pending.VersionStages[0] != "AWSPENDING" {
+		t.Fatalf("staged version stages = %v, want [AWSPENDING]", pending.VersionStages)
+	}
+
+	// Default read still returns the prior AWSCURRENT value.
+	cur, err := client.GetSecretValue(ctx, &awssm.GetSecretValueInput{SecretId: aws.String("stg")})
+	if err != nil {
+		t.Fatalf("GetSecretValue(default): %v", err)
+	}
+
+	if aws.ToString(cur.SecretString) != "v1" {
+		t.Fatalf("default value = %q, want v1 (AWSCURRENT must not have moved)", aws.ToString(cur.SecretString))
+	}
+
+	if aws.ToString(cur.VersionId) != aws.ToString(created.VersionId) {
+		t.Fatalf("AWSCURRENT moved off the original version")
+	}
+
+	// A Put without stages promotes to AWSCURRENT; prior current -> AWSPREVIOUS.
+	promoted, err := client.PutSecretValue(ctx, &awssm.PutSecretValueInput{
+		SecretId: aws.String("stg"), SecretString: aws.String("v2"),
+	})
+	if err != nil {
+		t.Fatalf("PutSecretValue(promote): %v", err)
+	}
+
+	if len(promoted.VersionStages) != 1 || promoted.VersionStages[0] != "AWSCURRENT" {
+		t.Fatalf("promoted stages = %v, want [AWSCURRENT]", promoted.VersionStages)
+	}
+
+	prev, err := client.GetSecretValue(ctx, &awssm.GetSecretValueInput{
+		SecretId: aws.String("stg"), VersionStage: aws.String("AWSPREVIOUS"),
+	})
+	if err != nil {
+		t.Fatalf("GetSecretValue(AWSPREVIOUS): %v", err)
+	}
+
+	if aws.ToString(prev.SecretString) != "v1" {
+		t.Fatalf("AWSPREVIOUS value = %q, want v1", aws.ToString(prev.SecretString))
+	}
+}
+
+// TestSDKUpdateSecretVersionStagePromote guards F4: UpdateSecretVersionStage
+// moving AWSCURRENT to a pending version promotes it (default get returns the
+// new value) and auto-demotes the old current to AWSPREVIOUS — the rotation
+// finishSecret step.
+func TestSDKUpdateSecretVersionStagePromote(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("rotate"), SecretString: aws.String("current-val"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	pending, err := client.PutSecretValue(ctx, &awssm.PutSecretValueInput{
+		SecretId: aws.String("rotate"), SecretString: aws.String("pending-val"),
+		VersionStages: []string{"AWSPENDING"},
+	})
+	if err != nil {
+		t.Fatalf("PutSecretValue(AWSPENDING): %v", err)
+	}
+
+	if _, err := client.UpdateSecretVersionStage(ctx, &awssm.UpdateSecretVersionStageInput{
+		SecretId:            aws.String("rotate"),
+		VersionStage:        aws.String("AWSCURRENT"),
+		MoveToVersionId:     pending.VersionId,
+		RemoveFromVersionId: created.VersionId,
+	}); err != nil {
+		t.Fatalf("UpdateSecretVersionStage: %v", err)
+	}
+
+	cur, err := client.GetSecretValue(ctx, &awssm.GetSecretValueInput{SecretId: aws.String("rotate")})
+	if err != nil {
+		t.Fatalf("GetSecretValue(default): %v", err)
+	}
+
+	if aws.ToString(cur.SecretString) != "pending-val" {
+		t.Fatalf("default value = %q, want pending-val (AWSCURRENT should have moved)", aws.ToString(cur.SecretString))
+	}
+
+	if aws.ToString(cur.VersionId) != aws.ToString(pending.VersionId) {
+		t.Fatalf("AWSCURRENT did not move to the pending version")
+	}
+
+	prev, err := client.GetSecretValue(ctx, &awssm.GetSecretValueInput{
+		SecretId: aws.String("rotate"), VersionStage: aws.String("AWSPREVIOUS"),
+	})
+	if err != nil {
+		t.Fatalf("GetSecretValue(AWSPREVIOUS): %v", err)
+	}
+
+	if aws.ToString(prev.SecretString) != "current-val" {
+		t.Fatalf("AWSPREVIOUS value = %q, want current-val (old current demoted)", aws.ToString(prev.SecretString))
+	}
+}
+
+// TestSDKUpdateSecretReturnsVersionId guards F6: UpdateSecret that changes the
+// value returns the new (non-empty) VersionId.
+func TestSDKUpdateSecretReturnsVersionId(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("upd"), SecretString: aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	out, err := client.UpdateSecret(ctx, &awssm.UpdateSecretInput{
+		SecretId: aws.String("upd"), SecretString: aws.String("v2"),
+	})
+	if err != nil {
+		t.Fatalf("UpdateSecret: %v", err)
+	}
+
+	if aws.ToString(out.VersionId) == "" {
+		t.Fatal("UpdateSecret returned empty VersionId, want the new version id")
+	}
+}
+
+// TestSDKSecretARNSuffixResolvesByName guards F8: the ARN carries a 6-char
+// "-XXXXXX" suffix, and GetSecretValue by the bare name still resolves.
+func TestSDKSecretARNSuffixResolvesByName(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("arn-probe"), SecretString: aws.String("v"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	arn := aws.ToString(created.ARN)
+
+	const marker = ":secret:"
+
+	seg := arn[strings.LastIndex(arn, marker)+len(marker):]
+	if seg == "arn-probe" {
+		t.Fatalf("ARN resource segment = %q, want a -XXXXXX suffix", seg)
+	}
+
+	if !strings.HasPrefix(seg, "arn-probe-") || len(seg) != len("arn-probe-")+6 {
+		t.Fatalf("ARN resource segment = %q, want arn-probe-<6 chars>", seg)
+	}
+
+	// Lookup by the bare friendly name still works.
+	byName, err := client.GetSecretValue(ctx, &awssm.GetSecretValueInput{SecretId: aws.String("arn-probe")})
+	if err != nil {
+		t.Fatalf("GetSecretValue(by name): %v", err)
+	}
+
+	if aws.ToString(byName.SecretString) != "v" {
+		t.Fatalf("value by name = %q, want v", aws.ToString(byName.SecretString))
+	}
+
+	// Lookup by the suffixed ARN also works.
+	byARN, err := client.GetSecretValue(ctx, &awssm.GetSecretValueInput{SecretId: created.ARN})
+	if err != nil {
+		t.Fatalf("GetSecretValue(by ARN): %v", err)
+	}
+
+	if aws.ToString(byARN.SecretString) != "v" {
+		t.Fatalf("value by ARN = %q, want v", aws.ToString(byARN.SecretString))
+	}
+}
+
+// TestSDKGetRandomPasswordRequireEachType guards F5: with RequireEachIncludedType
+// the password always contains at least one of each included class.
+func TestSDKGetRandomPasswordRequireEachType(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	const iterations = 50
+
+	for i := 0; i < iterations; i++ {
+		out, err := client.GetRandomPassword(ctx, &awssm.GetRandomPasswordInput{
+			PasswordLength:          aws.Int64(4),
+			RequireEachIncludedType: aws.Bool(true),
+		})
+		if err != nil {
+			t.Fatalf("GetRandomPassword(iter %d): %v", i, err)
+		}
+
+		pw := aws.ToString(out.RandomPassword)
+		if len([]rune(pw)) != 4 {
+			t.Fatalf("password %q length = %d, want 4", pw, len([]rune(pw)))
+		}
+
+		var hasLower, hasUpper, hasDigit, hasPunct bool
+
+		for _, c := range pw {
+			switch {
+			case unicode.IsLower(c):
+				hasLower = true
+			case unicode.IsUpper(c):
+				hasUpper = true
+			case unicode.IsDigit(c):
+				hasDigit = true
+			default:
+				hasPunct = true
+			}
+		}
+
+		if !hasLower || !hasUpper || !hasDigit || !hasPunct {
+			t.Fatalf("password %q missing a required class (lower=%v upper=%v digit=%v punct=%v)",
+				pw, hasLower, hasUpper, hasDigit, hasPunct)
+		}
+	}
+
+	// PasswordLength shorter than the number of required classes is rejected.
+	_, err := client.GetRandomPassword(ctx, &awssm.GetRandomPasswordInput{
+		PasswordLength:          aws.Int64(2),
+		RequireEachIncludedType: aws.Bool(true),
+	})
+
+	var invalid *smtypes.InvalidParameterException
+	if !errors.As(err, &invalid) {
+		t.Fatalf("short length + RequireEachIncludedType: got %v, want InvalidParameterException", err)
+	}
+}

--- a/server/aws/secretsmanager/staging_versioning_test.go
+++ b/server/aws/secretsmanager/staging_versioning_test.go
@@ -230,6 +230,79 @@ func TestSDKUpdateSecretVersionStagePromote(t *testing.T) {
 	}
 }
 
+// TestSDKRotationFinishRemovesPending drives a full rotation cycle and guards
+// that finishSecret (UpdateSecretVersionStage moving AWSCURRENT onto the pending
+// version) auto-removes AWSPENDING from the newly-current version — so it shows
+// exactly [AWSCURRENT], and AWSPENDING never accumulates across rotations.
+func TestSDKRotationFinishRemovesPending(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	// rotate performs one create-candidate + finish cycle, returning the id of
+	// the version that becomes AWSCURRENT.
+	rotate := func(oldCurrentID, value string) string {
+		t.Helper()
+
+		pending, err := client.PutSecretValue(ctx, &awssm.PutSecretValueInput{
+			SecretId: aws.String("rot"), SecretString: aws.String(value),
+			VersionStages: []string{"AWSPENDING"},
+		})
+		if err != nil {
+			t.Fatalf("PutSecretValue(AWSPENDING): %v", err)
+		}
+
+		if _, err := client.UpdateSecretVersionStage(ctx, &awssm.UpdateSecretVersionStageInput{
+			SecretId:            aws.String("rot"),
+			VersionStage:        aws.String("AWSCURRENT"),
+			MoveToVersionId:     pending.VersionId,
+			RemoveFromVersionId: aws.String(oldCurrentID),
+		}); err != nil {
+			t.Fatalf("UpdateSecretVersionStage(finish): %v", err)
+		}
+
+		return aws.ToString(pending.VersionId)
+	}
+
+	created, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("rot"), SecretString: aws.String("v1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	assertPromoted := func(currentID, prevID string) {
+		t.Helper()
+
+		desc, derr := client.DescribeSecret(ctx, &awssm.DescribeSecretInput{SecretId: aws.String("rot")})
+		if derr != nil {
+			t.Fatalf("DescribeSecret: %v", derr)
+		}
+
+		if got := desc.VersionIdsToStages[currentID]; len(got) != 1 || got[0] != "AWSCURRENT" {
+			t.Fatalf("current version stages = %v, want exactly [AWSCURRENT] (no AWSPENDING)", got)
+		}
+
+		if got := desc.VersionIdsToStages[prevID]; len(got) != 1 || got[0] != "AWSPREVIOUS" {
+			t.Fatalf("previous version stages = %v, want [AWSPREVIOUS]", got)
+		}
+
+		// No version anywhere should still carry AWSPENDING.
+		for id, stages := range desc.VersionIdsToStages {
+			for _, s := range stages {
+				if s == "AWSPENDING" {
+					t.Fatalf("version %s still carries AWSPENDING: %v", id, stages)
+				}
+			}
+		}
+	}
+
+	first := rotate(aws.ToString(created.VersionId), "v2")
+	assertPromoted(first, aws.ToString(created.VersionId))
+
+	second := rotate(first, "v3")
+	assertPromoted(second, first)
+}
+
 // TestSDKUpdateSecretReturnsVersionId guards F6: UpdateSecret that changes the
 // value returns the new (non-empty) VersionId.
 func TestSDKUpdateSecretReturnsVersionId(t *testing.T) {

--- a/server/aws/secretsmanager/types.go
+++ b/server/aws/secretsmanager/types.go
@@ -45,12 +45,13 @@ type versionJSON struct {
 // --- request envelopes ---
 
 type createSecretRequest struct {
-	Name         string    `json:"Name"`
-	Description  string    `json:"Description"`
-	SecretString string    `json:"SecretString"`
-	SecretBinary []byte    `json:"SecretBinary"`
-	Tags         []tagJSON `json:"Tags"`
-	KmsKeyID     string    `json:"KmsKeyId"`
+	Name               string    `json:"Name"`
+	Description        string    `json:"Description"`
+	SecretString       string    `json:"SecretString"`
+	SecretBinary       []byte    `json:"SecretBinary"`
+	Tags               []tagJSON `json:"Tags"`
+	KmsKeyID           string    `json:"KmsKeyId"`
+	ClientRequestToken string    `json:"ClientRequestToken"`
 }
 
 type secretIDRequest struct {
@@ -102,9 +103,18 @@ type listSecretsRequest struct {
 }
 
 type putSecretValueRequest struct {
-	SecretID     string `json:"SecretId"`
-	SecretString string `json:"SecretString"`
-	SecretBinary []byte `json:"SecretBinary"`
+	SecretID           string   `json:"SecretId"`
+	SecretString       string   `json:"SecretString"`
+	SecretBinary       []byte   `json:"SecretBinary"`
+	ClientRequestToken string   `json:"ClientRequestToken"`
+	VersionStages      []string `json:"VersionStages"`
+}
+
+type updateSecretVersionStageRequest struct {
+	SecretID            string `json:"SecretId"`
+	VersionStage        string `json:"VersionStage"`
+	RemoveFromVersionID string `json:"RemoveFromVersionId"`
+	MoveToVersionID     string `json:"MoveToVersionId"`
 }
 
 type updateSecretRequest struct {
@@ -125,6 +135,12 @@ type untagResourceRequest struct {
 }
 
 type updateSecretResponse struct {
+	ARN       string `json:"ARN"`
+	Name      string `json:"Name"`
+	VersionID string `json:"VersionId,omitempty"`
+}
+
+type updateSecretVersionStageResponse struct {
 	ARN  string `json:"ARN"`
 	Name string `json:"Name"`
 }
@@ -198,9 +214,11 @@ func epochSeconds(iso string) float64 {
 }
 
 // resolveSecretID accepts either a plain secret name or a full ARN
-// ("arn:aws:secretsmanager:<region>:<account>:secret:<name>") — real Secrets
-// Manager accepts both forms for SecretId — and returns the bare name the
-// driver keys on.
+// ("arn:aws:secretsmanager:<region>:<account>:secret:<name>-<suffix>") — real
+// Secrets Manager accepts both forms for SecretId — and returns the bare name
+// the driver keys on. For an ARN, the trailing 6-char "-<suffix>" AWS appends is
+// stripped so a lookup by the suffixed ARN resolves to the same secret as the
+// friendly name. A plain name is returned untouched (its own hyphens are kept).
 func resolveSecretID(id string) string {
 	const marker = ":secret:"
 
@@ -208,11 +226,41 @@ func resolveSecretID(id string) string {
 		return id
 	}
 
-	if i := strings.LastIndex(id, marker); i >= 0 {
-		return id[i+len(marker):]
+	i := strings.LastIndex(id, marker)
+	if i < 0 {
+		return id
 	}
 
-	return id
+	return stripARNSuffix(id[i+len(marker):])
+}
+
+// arnSuffixLen is the length of the random suffix (excluding the hyphen) AWS
+// appends to a Secrets Manager ARN's resource segment.
+const arnSuffixLen = 6
+
+// stripARNSuffix removes a trailing "-XXXXXX" (hyphen + 6 alphanumerics) from an
+// ARN resource segment, recovering the friendly secret name.
+func stripARNSuffix(seg string) string {
+	if len(seg) < arnSuffixLen+1 {
+		return seg
+	}
+
+	cut := len(seg) - arnSuffixLen - 1
+	if seg[cut] != '-' {
+		return seg
+	}
+
+	for _, c := range seg[cut+1:] {
+		if !isAlphaNum(c) {
+			return seg
+		}
+	}
+
+	return seg[:cut]
+}
+
+func isAlphaNum(c rune) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }
 
 // secretValue picks the string payload if present, else the binary one — the

--- a/services/secrets/driver/driver.go
+++ b/services/secrets/driver/driver.go
@@ -12,6 +12,10 @@ type SecretConfig struct {
 	// encrypted with (AWS Secrets Manager). Empty means the default
 	// aws/secretsmanager key. Ignored by Azure/GCP.
 	KMSKeyID string
+	// ClientRequestToken pins the initial version's id (AWS Secrets Manager uses
+	// the token as the VersionId, a UUID). Empty means the provider generates
+	// one. Ignored by Azure/GCP.
+	ClientRequestToken string
 }
 
 // SecretInfo describes a secret.


### PR DESCRIPTION
## What

Reworks AWS Secrets Manager staging from a `Current bool` + slice-adjacency heuristic to an **explicit per-version stage-label model** (each secret maps a staging label → the version id that holds it), fixing three HIGH and several supporting bugs in the rotation state machine. Every behavior was cross-checked against the official AWS Secrets Manager API docs.

## Why / bugs fixed

- **[HIGH F1] ClientRequestToken ignored.** The token is now threaded through Create/PutSecretValue and used as the VersionId. A repeat with the same token + same content is an idempotent no-op (same VersionId, no new version); the same token + different content is `ResourceExistsException`. `GetSecretValue(VersionId=token)` resolves. Version ids are now 36-char UUIDs (fixes F9).
- **[HIGH F2] PutSecretValue VersionStages ignored → clobbered AWSCURRENT.** Passing `VersionStages` (e.g. `[AWSPENDING]`) now attaches exactly those labels and does NOT move AWSCURRENT — a default `GetSecretValue` still returns the prior value. Only an empty/unset `VersionStages` promotes the new version to AWSCURRENT (demoting the prior current to AWSPREVIOUS and evicting the old AWSPREVIOUS label).
- **[MED-HIGH F4] UpdateSecretVersionStage added** (rotation `finishSecret` step). Moving AWSCURRENT to a version auto-demotes the old AWSCURRENT to AWSPREVIOUS; validates target versions and `RemoveFromVersionId`.
- **[MED F6] UpdateSecret now returns the new VersionId** when a value change creates a version.
- **[MED F8] Secret ARNs now carry the 6-char `-XXXXXX` suffix** (deterministic per secret, FakeClock-stable). Lookup by the bare friendly name OR the suffixed ARN both resolve.
- **[MED F5] GetRandomPassword now enforces RequireEachIncludedType** — guarantees ≥1 of each included class and rejects a length shorter than the class count.

Out of scope (separate follow-up): F3 (resource-policy write path) and F7 (BatchGetSecretValue).

## Notes

- The portable `driver.Secrets` interface is unchanged; the new behaviors live on the AWS-specific `secretStager`/`secretMutator` optional interfaces the wire handler already type-asserts, so Azure/GCP are unaffected. `SecretConfig` gains a `ClientRequestToken` field (ignored by other providers).
- Staging labels are persisted through snapshot/restore.
- New `idgen.UUID()` (crypto/rand v4) and `idgen.SecretARNSuffix()` helpers.

## Tests

Real `aws-sdk-go-v2` reproductions for F1/F2/F4/F6/F8/F5 plus provider-level tests for the explicit model, idempotency, stage promotion, and snapshot/restore of stages. Existing tests (AWSPREVIOUS retrieval, binary round-trip, delete/restore, #567 KmsKeyId, staging label counts) stay green.
