### PR TITLE
fix(aws-eventbridge): scope matching to the event's own bus; validate EventPattern; TestEventPattern; ListEventBuses NamePrefix; clean error messages

### DIFF
--- a/internal/eventmatch/eventmatch.go
+++ b/internal/eventmatch/eventmatch.go
@@ -446,6 +446,54 @@ func numericValue(value any, coerceNum bool) (float64, bool) {
 	return toFloat(value)
 }
 
+// PatternError describes why an event pattern is structurally invalid. Its
+// message is safe to surface verbatim to a client (no internal code prefix).
+type PatternError struct {
+	Reason string
+}
+
+func (e *PatternError) Error() string {
+	return "Event pattern is not valid. Reason: " + e.Reason
+}
+
+// ValidatePattern reports whether raw is a structurally valid EventBridge event
+// pattern / SNS filter policy. A pattern is a JSON object whose every leaf value
+// is an array (of match values or content-operator objects); a value that is a
+// nested object is validated recursively. A scalar leaf (string/number/bool), a
+// non-object top level, or malformed JSON is invalid — real EventBridge rejects
+// these with InvalidEventPatternException rather than silently matching nothing.
+func ValidatePattern(raw string) error {
+	if strings.TrimSpace(raw) == "" {
+		return &PatternError{Reason: "event pattern must not be empty"}
+	}
+
+	var p map[string]any
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		return &PatternError{Reason: "event pattern is not valid JSON"}
+	}
+
+	return validatePatternObject(p)
+}
+
+// validatePatternObject enforces the array/object leaf rule over every field of
+// a pattern object, recursing into nested objects.
+func validatePatternObject(obj map[string]any) error {
+	for key, val := range obj {
+		switch v := val.(type) {
+		case []any:
+			continue
+		case map[string]any:
+			if err := validatePatternObject(v); err != nil {
+				return err
+			}
+		default:
+			return &PatternError{Reason: "\"" + key + "\" must be an object or an array"}
+		}
+	}
+
+	return nil
+}
+
 // ParsePattern decodes a JSON event pattern / filter policy into the object form
 // MatchEvent and MatchLeaf consume. It returns false when the JSON is not a
 // well-formed object.

--- a/internal/eventmatch/validate_test.go
+++ b/internal/eventmatch/validate_test.go
@@ -1,0 +1,40 @@
+package eventmatch_test
+
+import (
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/internal/eventmatch"
+)
+
+func TestValidatePattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		wantErr bool
+	}{
+		{"array leaf", `{"source":["aws.ec2"]}`, false},
+		{"multiple array leaves", `{"source":["a"],"detail-type":["b"]}`, false},
+		{"nested detail object", `{"detail":{"state":["running"]}}`, false},
+		{"content operator", `{"source":[{"prefix":"aws."}]}`, false},
+		{"or clause", `{"$or":[{"source":["a"]},{"detail-type":["b"]}]}`, false},
+		{"scalar string leaf", `{"source":"not-an-array"}`, true},
+		{"scalar number leaf", `{"detail-type":123}`, true},
+		{"nested scalar leaf", `{"detail":{"state":"running"}}`, true},
+		{"malformed json", `{not json`, true},
+		{"non-object top level", `["a"]`, true},
+		{"empty", ``, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := eventmatch.ValidatePattern(tt.pattern)
+			if tt.wantErr && err == nil {
+				t.Fatalf("ValidatePattern(%s) = nil, want error", tt.pattern)
+			}
+
+			if !tt.wantErr && err != nil {
+				t.Fatalf("ValidatePattern(%s) = %v, want nil", tt.pattern, err)
+			}
+		})
+	}
+}

--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -771,21 +771,30 @@ func (m *Mock) UpdateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 	return &result, nil
 }
 
-// MatchedRules returns all rules that match the given event (exported for testing).
+// MatchedRules returns the rules on the event's own bus that match it (exported
+// for testing). Matching is scoped to event.EventBus (empty resolves to the
+// default bus) so a rule on one bus never fires for an event published to a
+// different bus — real EventBridge isolates buses from each other.
 func (m *Mock) MatchedRules(event *driver.Event) []driver.Rule {
+	busName := event.EventBus
+	if busName == "" {
+		busName = defaultBusName
+	}
+
+	bd, ok := m.buses.Get(busName)
+	if !ok {
+		return nil
+	}
+
 	var matched []driver.Rule
 
-	all := m.buses.All()
-	for _, bd := range all {
-		rules := bd.rules.All()
-		for _, rd := range rules {
-			if rd.rule.State != defaultRuleState {
-				continue
-			}
+	for _, rd := range bd.rules.All() {
+		if rd.rule.State != defaultRuleState {
+			continue
+		}
 
-			if matchesPattern(event, rd.rule.EventPattern) {
-				matched = append(matched, rd.rule)
-			}
+		if matchesPattern(event, rd.rule.EventPattern) {
+			matched = append(matched, rd.rule)
 		}
 	}
 

--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -245,6 +245,16 @@ func (m *Mock) PutRule(_ context.Context, cfg *driver.RuleConfig) (*driver.Rule,
 		return nil, errors.Newf(errors.NotFound, "event bus %q not found", busName)
 	}
 
+	// Reject a structurally invalid event pattern at deploy time. Without this a
+	// typo'd pattern (e.g. a non-array leaf) would store "successfully" and then
+	// silently match nothing, so targets never fire — the worst failure mode for
+	// an event-driven app.
+	if cfg.EventPattern != "" {
+		if err := eventmatch.ValidatePattern(cfg.EventPattern); err != nil {
+			return nil, errors.New(errors.InvalidArgument, err.Error())
+		}
+	}
+
 	state := cfg.State
 	if state == "" {
 		state = defaultRuleState

--- a/server/aws/eventbridge/bus_isolation_sdk_test.go
+++ b/server/aws/eventbridge/bus_isolation_sdk_test.go
@@ -1,0 +1,109 @@
+package eventbridge_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+)
+
+// TestSDKEventBridgeBusIsolation locks the fix for the cross-bus leak: a rule on
+// a custom bus must only fire for events published to that same bus. An event on
+// the default bus must never trigger a custom-bus rule's target, and vice-versa.
+func TestSDKEventBridgeBusIsolation(t *testing.T) {
+	eb, sqs := newEBAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := makeQueue(t, sqs, "eb-custombus")
+
+	if _, err := eb.CreateEventBus(ctx, &awseb.CreateEventBusInput{Name: aws.String("custombus")}); err != nil {
+		t.Fatalf("CreateEventBus: %v", err)
+	}
+
+	if _, err := eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r-custom"),
+		EventBusName: aws.String("custombus"),
+		EventPattern: aws.String(`{"source":["probe.x"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule(custombus): %v", err)
+	}
+
+	if _, err := eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule:         aws.String("r-custom"),
+		EventBusName: aws.String("custombus"),
+		Targets:      []ebtypes.Target{{Id: aws.String("1"), Arn: aws.String(arn)}},
+	}); err != nil {
+		t.Fatalf("PutTargets(custombus): %v", err)
+	}
+
+	// An event on the DEFAULT bus must NOT trigger the custom-bus rule.
+	if _, err := eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("probe.x"), DetailType: aws.String("t"), Detail: aws.String(`{}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents(default): %v", err)
+	}
+
+	if _, count := receiveOne(t, sqs, url); count != 0 {
+		t.Fatalf("event on default bus leaked to custom-bus rule: %d messages, want 0", count)
+	}
+
+	// An event on the CUSTOM bus DOES trigger the custom-bus rule.
+	if _, err := eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{
+			Source:       aws.String("probe.x"),
+			DetailType:   aws.String("t"),
+			Detail:       aws.String(`{}`),
+			EventBusName: aws.String("custombus"),
+		},
+	}}); err != nil {
+		t.Fatalf("PutEvents(custombus): %v", err)
+	}
+
+	if _, count := receiveOne(t, sqs, url); count != 1 {
+		t.Fatalf("event on custom bus delivered %d messages, want 1", count)
+	}
+}
+
+// TestSDKEventBridgeDefaultBusRuleNotFiredByCustomBus is the reverse direction:
+// a rule on the default bus must not fire for an event published to a custom bus.
+func TestSDKEventBridgeDefaultBusRuleNotFiredByCustomBus(t *testing.T) {
+	eb, sqs := newEBAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := makeQueue(t, sqs, "eb-defaultbus")
+
+	if _, err := eb.CreateEventBus(ctx, &awseb.CreateEventBusInput{Name: aws.String("otherbus")}); err != nil {
+		t.Fatalf("CreateEventBus: %v", err)
+	}
+
+	if _, err := eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r-default"),
+		EventPattern: aws.String(`{"source":["probe.y"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule(default): %v", err)
+	}
+
+	if _, err := eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule:    aws.String("r-default"),
+		Targets: []ebtypes.Target{{Id: aws.String("1"), Arn: aws.String(arn)}},
+	}); err != nil {
+		t.Fatalf("PutTargets(default): %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{
+			Source:       aws.String("probe.y"),
+			DetailType:   aws.String("t"),
+			Detail:       aws.String(`{}`),
+			EventBusName: aws.String("otherbus"),
+		},
+	}}); err != nil {
+		t.Fatalf("PutEvents(otherbus): %v", err)
+	}
+
+	if _, count := receiveOne(t, sqs, url); count != 0 {
+		t.Fatalf("event on custom bus leaked to default-bus rule: %d messages, want 0", count)
+	}
+}

--- a/server/aws/eventbridge/error_message_sdk_test.go
+++ b/server/aws/eventbridge/error_message_sdk_test.go
@@ -1,0 +1,55 @@
+package eventbridge_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKEventBridgeErrorMessageNoInternalPrefix verifies wire error messages
+// carry only the human text, without the cloudemu-internal "<Code>: " prefix.
+// The DeleteRule-with-targets message must arrive as the verbatim AWS wording.
+func TestSDKEventBridgeErrorMessageNoInternalPrefix(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	if _, err := client.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("has-targets"),
+		EventPattern: aws.String(`{"source":["app"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := client.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule:    aws.String("has-targets"),
+		Targets: []ebtypes.Target{{Id: aws.String("t1"), Arn: aws.String("arn:aws:sqs:us-east-1:000000000000:q")}},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	_, err := client.DeleteRule(ctx, &awseb.DeleteRuleInput{Name: aws.String("has-targets")})
+	if err == nil {
+		t.Fatal("DeleteRule with targets should fail")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("not an API error: %T: %v", err, err)
+	}
+
+	msg := apiErr.ErrorMessage()
+
+	if strings.HasPrefix(msg, "InvalidArgument:") {
+		t.Fatalf("error message leaks internal code prefix: %q", msg)
+	}
+
+	if msg != "Rule can't be deleted since it has targets." {
+		t.Fatalf("message = %q, want the verbatim AWS wording", msg)
+	}
+}

--- a/server/aws/eventbridge/handler.go
+++ b/server/aws/eventbridge/handler.go
@@ -72,6 +72,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.listTargetsByRule(w, r)
 	case "PutEvents":
 		h.putEvents(w, r)
+	case "TestEventPattern":
+		h.testEventPattern(w, r)
 	case "TagResource":
 		h.tagResource(w, r)
 	case "UntagResource":

--- a/server/aws/eventbridge/handler.go
+++ b/server/aws/eventbridge/handler.go
@@ -90,18 +90,23 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // EventBridge returns errors as HTTP 400 with a "__type" body the SDK maps to a
 // typed exception.
 func writeErr(w http.ResponseWriter, err error) {
+	// Message strips the internal "<Code>: " prefix Error() prepends, so the wire
+	// message carries only the human text — real AWS never leaks a taxonomy name,
+	// and the deliberately-verbatim DeleteRule wording must arrive intact.
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", msg)
 	case cerrors.IsAlreadyExists(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceAlreadyExistsException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceAlreadyExistsException", msg)
 	case cerrors.IsInvalidArgument(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", msg)
 	case cerrors.IsFailedPrecondition(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidStateException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidStateException", msg)
 	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
-		wire.WriteJSONError(w, http.StatusBadRequest, "LimitExceededException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "LimitExceededException", msg)
 	default:
-		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalException", err.Error())
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalException", msg)
 	}
 }

--- a/server/aws/eventbridge/list_event_buses_prefix_sdk_test.go
+++ b/server/aws/eventbridge/list_event_buses_prefix_sdk_test.go
@@ -1,0 +1,50 @@
+package eventbridge_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+)
+
+// TestSDKEventBridgeListEventBusesNamePrefix verifies ListEventBuses honors the
+// NamePrefix filter instead of returning every bus.
+func TestSDKEventBridgeListEventBusesNamePrefix(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"alpha-bus", "beta-bus"} {
+		if _, err := client.CreateEventBus(ctx, &awseb.CreateEventBusInput{Name: aws.String(name)}); err != nil {
+			t.Fatalf("CreateEventBus(%s): %v", name, err)
+		}
+	}
+
+	out, err := client.ListEventBuses(ctx, &awseb.ListEventBusesInput{NamePrefix: aws.String("alpha")})
+	if err != nil {
+		t.Fatalf("ListEventBuses: %v", err)
+	}
+
+	if len(out.EventBuses) != 1 {
+		names := make([]string, 0, len(out.EventBuses))
+		for i := range out.EventBuses {
+			names = append(names, aws.ToString(out.EventBuses[i].Name))
+		}
+
+		t.Fatalf("NamePrefix=alpha returned %v, want only [alpha-bus]", names)
+	}
+
+	if aws.ToString(out.EventBuses[0].Name) != "alpha-bus" {
+		t.Fatalf("got %q, want alpha-bus", aws.ToString(out.EventBuses[0].Name))
+	}
+
+	// No prefix still lists everything (default + both custom buses).
+	all, err := client.ListEventBuses(ctx, &awseb.ListEventBusesInput{})
+	if err != nil {
+		t.Fatalf("ListEventBuses(all): %v", err)
+	}
+
+	if len(all.EventBuses) != 3 {
+		t.Fatalf("no-prefix returned %d buses, want 3", len(all.EventBuses))
+	}
+}

--- a/server/aws/eventbridge/operations.go
+++ b/server/aws/eventbridge/operations.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/stackshy/cloudemu/v2/internal/eventmatch"
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	"github.com/stackshy/cloudemu/v2/services/scope"
@@ -107,6 +108,15 @@ func (h *Handler) putRule(w http.ResponseWriter, r *http.Request) {
 		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException",
 			"Parameter(s) EventPattern or ScheduleExpression must be specified.")
 		return
+	}
+
+	// A structurally invalid event pattern is rejected up front with
+	// InvalidEventPatternException, the exact exception real EventBridge returns.
+	if req.EventPattern != "" {
+		if err := eventmatch.ValidatePattern(req.EventPattern); err != nil {
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidEventPatternException", err.Error())
+			return
+		}
 	}
 
 	rule, err := h.bus.PutRule(r.Context(), &ebdriver.RuleConfig{

--- a/server/aws/eventbridge/operations.go
+++ b/server/aws/eventbridge/operations.go
@@ -1,6 +1,7 @@
 package eventbridge
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -354,4 +355,33 @@ func (h *Handler) putEvents(w http.ResponseWriter, r *http.Request) {
 		FailedEntryCount: failed + res.FailCount,
 		Entries:          results,
 	})
+}
+
+// testEventPattern evaluates a sample event against an event pattern using the
+// same matcher PutEvents delivery uses, so "would this rule fire?" answered here
+// is consistent with what actually gets delivered. Real users / the console call
+// it to debug a pattern before deploying a rule.
+func (*Handler) testEventPattern(w http.ResponseWriter, r *http.Request) {
+	var req testEventPatternRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	// The pattern is validated with the same rule PutRule enforces, so a pattern
+	// that would be rejected at deploy time is rejected here too.
+	if err := eventmatch.ValidatePattern(req.EventPattern); err != nil {
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidEventPatternException", err.Error())
+		return
+	}
+
+	var event map[string]any
+	if err := json.Unmarshal([]byte(req.Event), &event); err != nil {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException",
+			"Event is not a valid JSON object.")
+		return
+	}
+
+	pattern, _ := eventmatch.ParsePattern(req.EventPattern)
+
+	wire.WriteJSON(w, testEventPatternResponse{Result: eventmatch.MatchEvent(pattern, event)})
 }

--- a/server/aws/eventbridge/operations.go
+++ b/server/aws/eventbridge/operations.go
@@ -63,6 +63,11 @@ func (h *Handler) describeEventBus(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) listEventBuses(w http.ResponseWriter, r *http.Request) {
+	var req listEventBusesRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
 	infos, err := h.bus.ListEventBuses(r.Context(), scope.Scope{})
 	if err != nil {
 		writeErr(w, err)
@@ -71,6 +76,10 @@ func (h *Handler) listEventBuses(w http.ResponseWriter, r *http.Request) {
 
 	entries := make([]eventBusEntry, 0, len(infos))
 	for i := range infos {
+		if req.NamePrefix != "" && !strings.HasPrefix(infos[i].Name, req.NamePrefix) {
+			continue
+		}
+
 		entries = append(entries, eventBusEntry{
 			Arn:          infos[i].ARN,
 			Name:         infos[i].Name,

--- a/server/aws/eventbridge/pattern_validation_sdk_test.go
+++ b/server/aws/eventbridge/pattern_validation_sdk_test.go
@@ -1,0 +1,66 @@
+package eventbridge_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKEventBridgePutRuleInvalidPattern verifies PutRule rejects a structurally
+// invalid event pattern with InvalidEventPatternException instead of storing a
+// pattern that silently matches nothing.
+func TestSDKEventBridgePutRuleInvalidPattern(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name    string
+		pattern string
+	}{
+		{"non-array leaf", `{"source":"not-an-array"}`},
+		{"malformed json", `{not json`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := client.PutRule(ctx, &awseb.PutRuleInput{
+				Name:         aws.String("bad-" + tc.name),
+				EventPattern: aws.String(tc.pattern),
+			})
+			if err == nil {
+				t.Fatalf("PutRule(%s) should fail, got nil", tc.pattern)
+			}
+
+			var apiErr smithy.APIError
+			if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidEventPatternException" {
+				t.Fatalf("want InvalidEventPatternException, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+// TestSDKEventBridgePutRuleValidPatternAccepted verifies patterns using arrays,
+// content operators, and nested detail still pass validation.
+func TestSDKEventBridgePutRuleValidPatternAccepted(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	valid := []string{
+		`{"source":["aws.ec2"]}`,
+		`{"source":[{"prefix":"aws."}]}`,
+		`{"detail":{"state":["running"]},"detail-type":["EC2 Instance State-change Notification"]}`,
+	}
+
+	for i, pattern := range valid {
+		if _, err := client.PutRule(ctx, &awseb.PutRuleInput{
+			Name:         aws.String("good-" + string(rune('a'+i))),
+			EventPattern: aws.String(pattern),
+		}); err != nil {
+			t.Fatalf("PutRule(%s) should succeed, got %v", pattern, err)
+		}
+	}
+}

--- a/server/aws/eventbridge/test_event_pattern_sdk_test.go
+++ b/server/aws/eventbridge/test_event_pattern_sdk_test.go
@@ -1,0 +1,117 @@
+package eventbridge_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+	"github.com/aws/smithy-go"
+)
+
+const testEventPatternSample = `{"id":"1","account":"123456789012","time":"2016-01-10T01:29:23Z",` +
+	`"region":"us-east-1","resources":[],"source":"com.myapp","detail-type":"t",` +
+	`"detail":{"state":"running"}}`
+
+// TestSDKEventBridgeTestEventPattern verifies the TestEventPattern operation:
+// a matching event returns Result=true, a non-matching event returns false.
+func TestSDKEventBridgeTestEventPattern(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	match, err := client.TestEventPattern(ctx, &awseb.TestEventPatternInput{
+		EventPattern: aws.String(`{"source":["com.myapp"],"detail":{"state":["running"]}}`),
+		Event:        aws.String(testEventPatternSample),
+	})
+	if err != nil {
+		t.Fatalf("TestEventPattern(match): %v", err)
+	}
+
+	if !match.Result {
+		t.Fatal("TestEventPattern match = false, want true")
+	}
+
+	noMatch, err := client.TestEventPattern(ctx, &awseb.TestEventPatternInput{
+		EventPattern: aws.String(`{"source":["com.myapp"],"detail":{"state":["stopped"]}}`),
+		Event:        aws.String(testEventPatternSample),
+	})
+	if err != nil {
+		t.Fatalf("TestEventPattern(no-match): %v", err)
+	}
+
+	if noMatch.Result {
+		t.Fatal("TestEventPattern no-match = true, want false")
+	}
+}
+
+// TestSDKEventBridgeTestEventPatternInvalid verifies TestEventPattern rejects a
+// structurally invalid pattern with InvalidEventPatternException, consistent with
+// PutRule.
+func TestSDKEventBridgeTestEventPatternInvalid(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	_, err := client.TestEventPattern(ctx, &awseb.TestEventPatternInput{
+		EventPattern: aws.String(`{"source":"not-an-array"}`),
+		Event:        aws.String(testEventPatternSample),
+	})
+	if err == nil {
+		t.Fatal("TestEventPattern with invalid pattern should fail, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidEventPatternException" {
+		t.Fatalf("want InvalidEventPatternException, got %T: %v", err, err)
+	}
+}
+
+// TestSDKEventBridgeTestEventPatternConsistentWithDelivery verifies TestEventPattern's
+// verdict matches actual PutEvents delivery for the same pattern and event.
+func TestSDKEventBridgeTestEventPatternConsistentWithDelivery(t *testing.T) {
+	eb, sqs := newEBAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := makeQueue(t, sqs, "eb-consistency")
+	pattern := `{"source":["com.myapp"],"detail":{"state":["running"]}}`
+
+	if _, err := eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventPattern: aws.String(pattern),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule:    aws.String("r"),
+		Targets: []ebtypes.Target{{Id: aws.String("1"), Arn: aws.String(arn)}},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	res, err := eb.TestEventPattern(ctx, &awseb.TestEventPatternInput{
+		EventPattern: aws.String(pattern),
+		Event:        aws.String(testEventPatternSample),
+	})
+	if err != nil {
+		t.Fatalf("TestEventPattern: %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("com.myapp"), DetailType: aws.String("t"), Detail: aws.String(`{"state":"running"}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	_, count := receiveOne(t, sqs, url)
+	delivered := count == 1
+
+	if res.Result != delivered {
+		t.Fatalf("TestEventPattern Result=%v but delivery happened=%v — inconsistent", res.Result, delivered)
+	}
+
+	if !res.Result {
+		t.Fatal("expected both match and delivery to be true")
+	}
+}

--- a/server/aws/eventbridge/types.go
+++ b/server/aws/eventbridge/types.go
@@ -29,6 +29,10 @@ type nameRequest struct {
 	Name string `json:"Name"`
 }
 
+type listEventBusesRequest struct {
+	NamePrefix string `json:"NamePrefix"`
+}
+
 type putRuleRequest struct {
 	Name               string `json:"Name"`
 	EventBusName       string `json:"EventBusName"`

--- a/server/aws/eventbridge/types.go
+++ b/server/aws/eventbridge/types.go
@@ -91,6 +91,11 @@ type putEventsRequest struct {
 	Entries []putEventsEntry `json:"Entries"`
 }
 
+type testEventPatternRequest struct {
+	Event        string `json:"Event"`
+	EventPattern string `json:"EventPattern"`
+}
+
 // --- response envelopes ---
 
 type createEventBusResponse struct {
@@ -170,6 +175,10 @@ type putEventsResultEntry struct {
 type putEventsResponse struct {
 	FailedEntryCount int                    `json:"FailedEntryCount"`
 	Entries          []putEventsResultEntry `json:"Entries"`
+}
+
+type testEventPatternResponse struct {
+	Result bool `json:"Result"`
 }
 
 // --- helpers ---


### PR DESCRIPTION
## Summary

Deep real-user (aws-sdk-go-v2) e2e audit of AWS EventBridge found one blocker plus four correctness/coverage gaps. Each is fixed at its correct 3-layer location and reproduced with the real SDK.

## What changed

- **[BLOCKER] Event-bus isolation** — `MatchedRules` scanned every bus, so a rule on a custom bus fired for events published to the default bus (and vice-versa), defeating the whole point of custom buses (isolation/routing) and inflating the `MatchedEvents` metric. Matching is now scoped to the event's own bus (empty → default).
- **[HIGH] TestEventPattern** — was `UnknownOperationException`. Added the wire op: it validates the pattern and evaluates the sample event with the **same matcher PutEvents delivery uses**, so its verdict is consistent with actual delivery. Returns `{Result: bool}`.
- **[MED] Invalid EventPattern accepted** — `PutRule` stored a structurally invalid pattern verbatim (`{"source":"not-an-array"}`, malformed JSON), which then silently matched nothing so targets never fired. Now validated (leaf values must be arrays / content-operators; nested objects recurse) and rejected with `InvalidEventPatternException` at both PutRule and TestEventPattern. Valid array/content-operator/nested-detail patterns still pass.
- **[MED] ListEventBuses ignored NamePrefix** — the handler never decoded it, returning every bus. Now decoded and filtered by prefix.
- **[LOW] Error messages leaked internal code prefix** — `writeErr` used `err.Error()` (`"InvalidArgument: ..."`), corrupting the deliberately-verbatim DeleteRule wording. Now uses `cerrors.Message(err)`, mirroring ec2/iam/lambda.

Out of scope (deferred separately): PutPermission/RemovePermission, ListRuleNamesByTarget.

## Why

Cross-bus leakage breaks multi-tenant/multi-app isolation; silently-accepted bad patterns are the worst failure mode for event-driven apps (deploy succeeds, nothing ever fires); TestEventPattern is the canonical way users debug patterns before deploying.

## Tests

Real aws-sdk-go-v2 reproductions: bus isolation (both directions, asserted via SQS delivery), TestEventPattern (match/no-match + consistency with real delivery + invalid-pattern rejection), PutRule invalid/valid patterns, ListEventBuses NamePrefix, and the clean DeleteRule error message. Existing EventBridge tests remain green. No driver-interface change, so no coverage regeneration needed.
