### PR TITLE
fix(aws-secretsmanager): resource-policy ops (Put/Get/Delete/Validate) + BatchGetSecretValue

### DIFF
--- a/providers/aws/secretsmanager/resource_policy.go
+++ b/providers/aws/secretsmanager/resource_policy.go
@@ -1,0 +1,71 @@
+package secretsmanager
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
+)
+
+// PutResourcePolicy attaches (or replaces) the JSON resource-based policy on a
+// secret, the write path Terraform's aws_secretsmanager_secret_policy uses. The
+// BlockPublicPolicy check lives in the wire layer, which rejects a public policy
+// before calling this. A secret scheduled for deletion is rejected.
+func (m *Mock) PutResourcePolicy(_ context.Context, name, policy string) (*driver.SecretInfo, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.New(errors.FailedPrecondition,
+			"secret is scheduled for deletion, so this operation is not allowed")
+	}
+
+	sd.resourcePolicy = policy
+	info := sd.info
+
+	return &info, nil
+}
+
+// GetResourcePolicy returns the secret's metadata and its resource policy JSON
+// (empty when none is set). It reads leniently so DescribeSecret-style reads
+// keep working; only a missing secret is a NotFound.
+func (m *Mock) GetResourcePolicy(_ context.Context, name string) (*driver.SecretInfo, string, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, "", errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	info := sd.info
+
+	return &info, sd.resourcePolicy, nil
+}
+
+// DeleteResourcePolicy clears the secret's resource policy. A secret scheduled
+// for deletion is rejected.
+func (m *Mock) DeleteResourcePolicy(_ context.Context, name string) (*driver.SecretInfo, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.New(errors.FailedPrecondition,
+			"secret is scheduled for deletion, so this operation is not allowed")
+	}
+
+	sd.resourcePolicy = ""
+	info := sd.info
+
+	return &info, nil
+}

--- a/providers/aws/secretsmanager/resource_policy_test.go
+++ b/providers/aws/secretsmanager/resource_policy_test.go
@@ -1,0 +1,71 @@
+package secretsmanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResourcePolicyRoundTrip verifies Put stores the policy, Get returns it,
+// and Delete clears it (Get then returns empty, not an error).
+func TestResourcePolicyRoundTrip(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	createTestSecret(t, m, "s", "v1")
+
+	const policy = `{"Version":"2012-10-17","Statement":[]}`
+
+	_, err := m.PutResourcePolicy(ctx, "s", policy)
+	require.NoError(t, err)
+
+	_, got, err := m.GetResourcePolicy(ctx, "s")
+	require.NoError(t, err)
+	assert.Equal(t, policy, got)
+
+	_, err = m.DeleteResourcePolicy(ctx, "s")
+	require.NoError(t, err)
+
+	_, cleared, err := m.GetResourcePolicy(ctx, "s")
+	require.NoError(t, err)
+	assert.Empty(t, cleared)
+}
+
+// TestResourcePolicyMissingSecret verifies a missing secret is a NotFound, not a
+// silent success.
+func TestResourcePolicyMissingSecret(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.PutResourcePolicy(ctx, "nope", "{}")
+	require.Error(t, err)
+
+	_, _, err = m.GetResourcePolicy(ctx, "nope")
+	require.Error(t, err)
+}
+
+// TestResourcePolicySurvivesSnapshot verifies the resource policy is preserved
+// across snapshot/restore.
+func TestResourcePolicySurvivesSnapshot(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	createTestSecret(t, m, "s", "v1")
+
+	const policy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow"}]}`
+
+	_, err := m.PutResourcePolicy(ctx, "s", policy)
+	require.NoError(t, err)
+
+	data, err := m.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	restored := newTestMock()
+	require.NoError(t, restored.Restore(ctx, data))
+
+	_, got, err := restored.GetResourcePolicy(ctx, "s")
+	require.NoError(t, err)
+	assert.Equal(t, policy, got)
+}

--- a/providers/aws/secretsmanager/secretsmanager.go
+++ b/providers/aws/secretsmanager/secretsmanager.go
@@ -30,6 +30,9 @@ type secretData struct {
 	// recoveryWindow is the number of days between the delete request and the
 	// scheduled deletion date, captured from DeleteSecret's RecoveryWindowInDays.
 	recoveryWindow int
+	// resourcePolicy is the JSON resource-based policy attached to the secret
+	// (PutResourcePolicy); empty when none is set.
+	resourcePolicy string
 	mu             sync.RWMutex
 }
 

--- a/providers/aws/secretsmanager/snapshot.go
+++ b/providers/aws/secretsmanager/snapshot.go
@@ -27,6 +27,9 @@ type secretSnapshot struct {
 	Stages         map[string]string `json:"stages,omitempty"`
 	DeletedAt      time.Time         `json:"deletedAt,omitempty"`
 	RecoveryWindow int               `json:"recoveryWindow,omitempty"`
+	// ResourcePolicy is the JSON resource-based policy attached to the secret,
+	// preserved across snapshot/restore.
+	ResourcePolicy string `json:"resourcePolicy,omitempty"`
 }
 
 // Snapshot captures every secret's full state as JSON. includeAssets is unused —
@@ -43,6 +46,7 @@ func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
 			Stages:         sd.stages,
 			DeletedAt:      sd.deletedAt,
 			RecoveryWindow: sd.recoveryWindow,
+			ResourcePolicy: sd.resourcePolicy,
 		}
 		sd.mu.RUnlock()
 	}
@@ -65,6 +69,7 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 			stages:         ss.Stages,
 			deletedAt:      ss.DeletedAt,
 			recoveryWindow: ss.RecoveryWindow,
+			resourcePolicy: ss.ResourcePolicy,
 		})
 	}
 

--- a/server/aws/secretsmanager/batch.go
+++ b/server/aws/secretsmanager/batch.go
@@ -1,0 +1,121 @@
+package secretsmanager
+
+import (
+	"net/http"
+	"sort"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire"
+)
+
+// batchGetSecretValue retrieves the AWSCURRENT value of up to a page of secrets
+// named by SecretIdList (or matched by Filters). A missing (or otherwise
+// unreadable) secret is reported per-item in Errors rather than failing the
+// whole batch, matching the real service.
+func (h *Handler) batchGetSecretValue(w http.ResponseWriter, r *http.Request) {
+	var req batchGetSecretValueRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	ids := req.SecretIDList
+	if len(ids) == 0 && len(req.Filters) > 0 {
+		matched, err := h.filteredSecretIDs(r, req.Filters)
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		ids = matched
+	}
+
+	start, end, next, err := pageWindow(req.NextToken, req.MaxResults, len(ids))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	values := make([]secretValueEntry, 0, end-start)
+	errs := make([]batchErrorEntry, 0)
+
+	for _, id := range ids[start:end] {
+		entry, apiErr := h.batchLookup(r, id)
+		if apiErr != nil {
+			errs = append(errs, *apiErr)
+			continue
+		}
+
+		values = append(values, *entry)
+	}
+
+	wire.WriteJSON(w, batchGetSecretValueResponse{SecretValues: values, Errors: errs, NextToken: next})
+}
+
+// filteredSecretIDs returns the names of secrets matching the BatchGetSecretValue
+// filters, in the stable (by-name) order the offset NextToken relies on.
+func (h *Handler) filteredSecretIDs(r *http.Request, filters []secretFilter) ([]string, error) {
+	infos, err := h.secrets.ListSecrets(r.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, 0, len(infos))
+
+	for i := range infos {
+		if matchesSecretFilters(&infos[i], filters) {
+			ids = append(ids, infos[i].Name)
+		}
+	}
+
+	sort.Strings(ids)
+
+	return ids, nil
+}
+
+// batchLookup resolves one secret id to its AWSCURRENT value, returning a
+// per-item error entry (rather than a fatal error) when the secret is missing or
+// unreadable.
+func (h *Handler) batchLookup(r *http.Request, secretID string) (*secretValueEntry, *batchErrorEntry) {
+	name := resolveSecretID(secretID)
+
+	info, err := h.secrets.GetSecret(r.Context(), name)
+	if err != nil {
+		return nil, &batchErrorEntry{SecretID: secretID, ErrorCode: batchErrorCode(err), Message: err.Error()}
+	}
+
+	ver, err := h.getVersion(r, name, "", "")
+	if err != nil {
+		return nil, &batchErrorEntry{SecretID: secretID, ErrorCode: batchErrorCode(err), Message: err.Error()}
+	}
+
+	entry := secretValueEntry{
+		ARN:           info.ResourceID,
+		Name:          info.Name,
+		VersionID:     ver.VersionID,
+		VersionStages: stagesForVersion(h.versionStages(r, name), ver),
+		CreatedDate:   epochSeconds(ver.CreatedAt),
+	}
+
+	if ver.Binary {
+		entry.SecretBinary = ver.Value
+	} else {
+		entry.SecretString = string(ver.Value)
+	}
+
+	return &entry, nil
+}
+
+// batchErrorCode maps a canonical cloudemu error to the per-item ErrorCode
+// BatchGetSecretValue reports.
+func batchErrorCode(err error) string {
+	switch {
+	case cerrors.IsNotFound(err):
+		return "ResourceNotFoundException"
+	case cerrors.IsFailedPrecondition(err):
+		return "InvalidRequestException"
+	case cerrors.IsInvalidArgument(err):
+		return "InvalidParameterException"
+	default:
+		return "InternalServiceError"
+	}
+}

--- a/server/aws/secretsmanager/batch_get_secret_value_test.go
+++ b/server/aws/secretsmanager/batch_get_secret_value_test.go
@@ -1,0 +1,80 @@
+package secretsmanager_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssm "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+)
+
+// TestSDKBatchGetSecretValue is the F7 reproduction: BatchGetSecretValue over a
+// SecretIdList returns SecretValues for the secrets that exist and a per-item
+// Errors entry for a missing one, rather than failing the whole call.
+func TestSDKBatchGetSecretValue(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	for name, val := range map[string]string{"a": "va", "b": "vb"} {
+		if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+			Name: aws.String(name), SecretString: aws.String(val),
+		}); err != nil {
+			t.Fatalf("CreateSecret(%s): %v", name, err)
+		}
+	}
+
+	out, err := client.BatchGetSecretValue(ctx, &awssm.BatchGetSecretValueInput{
+		SecretIdList: []string{"a", "b", "missing"},
+	})
+	if err != nil {
+		t.Fatalf("BatchGetSecretValue: %v", err)
+	}
+
+	if len(out.SecretValues) != 2 {
+		t.Fatalf("got %d SecretValues, want 2: %+v", len(out.SecretValues), out.SecretValues)
+	}
+
+	byName := map[string]string{}
+	for _, v := range out.SecretValues {
+		byName[aws.ToString(v.Name)] = aws.ToString(v.SecretString)
+
+		if aws.ToString(v.VersionId) == "" {
+			t.Errorf("SecretValue %q has empty VersionId", aws.ToString(v.Name))
+		}
+
+		if len(v.VersionStages) != 1 || v.VersionStages[0] != "AWSCURRENT" {
+			t.Errorf("SecretValue %q stages = %v, want [AWSCURRENT]", aws.ToString(v.Name), v.VersionStages)
+		}
+	}
+
+	if byName["a"] != "va" || byName["b"] != "vb" {
+		t.Fatalf("values = %+v, want a=va b=vb", byName)
+	}
+
+	if len(out.Errors) != 1 {
+		t.Fatalf("got %d Errors, want 1: %+v", len(out.Errors), out.Errors)
+	}
+
+	if aws.ToString(out.Errors[0].SecretId) != "missing" ||
+		aws.ToString(out.Errors[0].ErrorCode) != "ResourceNotFoundException" {
+		t.Fatalf("Errors[0] = %+v, want SecretId=missing ErrorCode=ResourceNotFoundException", out.Errors[0])
+	}
+}
+
+// TestSDKBatchGetSecretValueEmpty verifies an empty SecretIdList is handled
+// (no values, no errors) rather than erroring.
+func TestSDKBatchGetSecretValueEmpty(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	out, err := client.BatchGetSecretValue(ctx, &awssm.BatchGetSecretValueInput{
+		SecretIdList: []string{},
+	})
+	if err != nil {
+		t.Fatalf("BatchGetSecretValue(empty): %v", err)
+	}
+
+	if len(out.SecretValues) != 0 || len(out.Errors) != 0 {
+		t.Fatalf("empty batch = values %+v errors %+v, want both empty", out.SecretValues, out.Errors)
+	}
+}

--- a/server/aws/secretsmanager/handler.go
+++ b/server/aws/secretsmanager/handler.go
@@ -51,6 +51,15 @@ type secretStager interface {
 	) (*secretsdriver.SecretInfo, error)
 }
 
+// secretPolicyManager is the AWS-specific resource-based-policy surface the
+// handler type-asserts for (implemented by the AWS provider), keeping the
+// portable Secrets driver minimal so Azure/GCP are unaffected.
+type secretPolicyManager interface {
+	PutResourcePolicy(ctx context.Context, name, policy string) (*secretsdriver.SecretInfo, error)
+	GetResourcePolicy(ctx context.Context, name string) (*secretsdriver.SecretInfo, string, error)
+	DeleteResourcePolicy(ctx context.Context, name string) (*secretsdriver.SecretInfo, error)
+}
+
 // Handler serves Secrets Manager JSON-RPC requests against a Secrets driver.
 type Handler struct {
 	secrets secretsdriver.Secrets
@@ -65,8 +74,12 @@ func New(s secretsdriver.Secrets) *Handler {
 		"DeleteSecret":             h.deleteSecret,
 		"DescribeSecret":           h.describeSecret,
 		"GetResourcePolicy":        h.getResourcePolicy,
+		"PutResourcePolicy":        h.putResourcePolicy,
+		"DeleteResourcePolicy":     h.deleteResourcePolicy,
+		"ValidateResourcePolicy":   h.validateResourcePolicy,
 		"ListSecrets":              h.listSecrets,
 		"GetSecretValue":           h.getSecretValue,
+		"BatchGetSecretValue":      h.batchGetSecretValue,
 		"PutSecretValue":           h.putSecretValue,
 		"ListSecretVersionIds":     h.listSecretVersionIDs,
 		"UpdateSecret":             h.updateSecret,

--- a/server/aws/secretsmanager/operations.go
+++ b/server/aws/secretsmanager/operations.go
@@ -1,6 +1,7 @@
 package secretsmanager
 
 import (
+	"context"
 	"net/http"
 	"sort"
 
@@ -136,18 +137,28 @@ func (h *Handler) restoreSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	respondSecretRef(w, r, st.RestoreSecret)
+}
+
+// respondSecretRef decodes a SecretId request, runs op against the resolved
+// secret name, and writes the shared {ARN, Name} envelope. It is the common
+// shape of RestoreSecret and DeleteResourcePolicy.
+func respondSecretRef(
+	w http.ResponseWriter, r *http.Request,
+	op func(ctx context.Context, name string) (*secretsdriver.SecretInfo, error),
+) {
 	var req secretIDRequest
 	if !wire.DecodeJSON(w, r, &req) {
 		return
 	}
 
-	info, err := st.RestoreSecret(r.Context(), resolveSecretID(req.SecretID))
+	info, err := op(r.Context(), resolveSecretID(req.SecretID))
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	wire.WriteJSON(w, restoreSecretResponse{ARN: info.ResourceID, Name: info.Name})
+	wire.WriteJSON(w, secretRefResponse{ARN: info.ResourceID, Name: info.Name})
 }
 
 func (h *Handler) rotateSecret(w http.ResponseWriter, r *http.Request) {
@@ -192,24 +203,6 @@ func (*Handler) getRandomPassword(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wire.WriteJSON(w, getRandomPasswordResponse{RandomPassword: pw})
-}
-
-// getResourcePolicy returns the secret's resource policy. None is modeled, so
-// ResourcePolicy is absent — which the aws_secretsmanager_secret resource reads
-// as "no policy". Without the operation the read fails outright.
-func (h *Handler) getResourcePolicy(w http.ResponseWriter, r *http.Request) {
-	var req secretIDRequest
-	if !wire.DecodeJSON(w, r, &req) {
-		return
-	}
-
-	info, err := h.secrets.GetSecret(r.Context(), resolveSecretID(req.SecretID))
-	if err != nil {
-		writeErr(w, err)
-		return
-	}
-
-	wire.WriteJSON(w, map[string]any{"ARN": info.ResourceID, "Name": info.Name})
 }
 
 func (h *Handler) listSecrets(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/secretsmanager/resource_policy.go
+++ b/server/aws/secretsmanager/resource_policy.go
@@ -1,0 +1,235 @@
+package secretsmanager
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+)
+
+// effectAllow is the policy Effect that grants (rather than denies) access; only
+// an Allow statement can widen access to the public.
+const effectAllow = "Allow"
+
+// getResourcePolicy returns the secret's ARN/Name and its resource policy (the
+// ResourcePolicy field is omitted when none is set, which the SDK reads as "no
+// policy"). Backing drivers without the policy surface report no policy.
+func (h *Handler) getResourcePolicy(w http.ResponseWriter, r *http.Request) {
+	var req secretIDRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	name := resolveSecretID(req.SecretID)
+
+	pm, ok := h.secrets.(secretPolicyManager)
+	if !ok {
+		info, err := h.secrets.GetSecret(r.Context(), name)
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		wire.WriteJSON(w, getResourcePolicyResponse{ARN: info.ResourceID, Name: info.Name})
+
+		return
+	}
+
+	info, policy, err := pm.GetResourcePolicy(r.Context(), name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, getResourcePolicyResponse{ARN: info.ResourceID, Name: info.Name, ResourcePolicy: policy})
+}
+
+// putResourcePolicy attaches a JSON resource-based policy to the secret, the
+// write path Terraform's aws_secretsmanager_secret_policy uses. A malformed
+// policy is rejected as MalformedPolicyDocumentException; a public policy with
+// BlockPublicPolicy set is rejected as PublicPolicyException.
+func (h *Handler) putResourcePolicy(w http.ResponseWriter, r *http.Request) {
+	pm, ok := h.secrets.(secretPolicyManager)
+	if !ok {
+		writeErr(w, errNotSupported)
+		return
+	}
+
+	var req putResourcePolicyRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if !isValidPolicyJSON(req.ResourcePolicy) {
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"MalformedPolicyDocumentException", "the resource policy is not valid JSON")
+
+		return
+	}
+
+	if req.BlockPublicPolicy && policyGrantsPublicAccess(req.ResourcePolicy) {
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"PublicPolicyException", "the resource policy grants broad access and BlockPublicPolicy is set")
+
+		return
+	}
+
+	info, err := pm.PutResourcePolicy(r.Context(), resolveSecretID(req.SecretID), req.ResourcePolicy)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, secretRefResponse{ARN: info.ResourceID, Name: info.Name})
+}
+
+// deleteResourcePolicy clears the secret's resource policy.
+func (h *Handler) deleteResourcePolicy(w http.ResponseWriter, r *http.Request) {
+	pm, ok := h.secrets.(secretPolicyManager)
+	if !ok {
+		writeErr(w, errNotSupported)
+		return
+	}
+
+	respondSecretRef(w, r, pm.DeleteResourcePolicy)
+}
+
+// validateResourcePolicy checks a policy's JSON syntax and whether it grants
+// broad access, without storing it. A malformed or public policy returns
+// PolicyValidationPassed=false with the specific ValidationErrors.
+func (*Handler) validateResourcePolicy(w http.ResponseWriter, r *http.Request) {
+	var req validateResourcePolicyRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	errs := validatePolicy(req.ResourcePolicy)
+
+	wire.WriteJSON(w, validateResourcePolicyResponse{
+		PolicyValidationPassed: len(errs) == 0,
+		ValidationErrors:       errs,
+	})
+}
+
+// validatePolicy returns the validation errors for a resource policy: a syntax
+// error when it is not valid JSON, and a broad-access error when it grants
+// public access. An empty result means the policy passed.
+func validatePolicy(policy string) []validationErrorEntry {
+	if !isValidPolicyJSON(policy) {
+		return []validationErrorEntry{{
+			CheckName:    "SYNTAX",
+			ErrorMessage: "The resource policy is not valid JSON.",
+		}}
+	}
+
+	if policyGrantsPublicAccess(policy) {
+		return []validationErrorEntry{{
+			CheckName:    "PUBLIC_ACCESS",
+			ErrorMessage: "The resource policy grants broad access to the secret.",
+		}}
+	}
+
+	return nil
+}
+
+// isValidPolicyJSON reports whether policy parses as a JSON object.
+func isValidPolicyJSON(policy string) bool {
+	var doc map[string]json.RawMessage
+
+	return json.Unmarshal([]byte(policy), &doc) == nil
+}
+
+// policyStatement is the subset of an IAM statement needed to detect a public
+// grant: an Allow with a wildcard Principal and no Condition narrowing it.
+type policyStatement struct {
+	Effect    string          `json:"Effect"`
+	Principal json.RawMessage `json:"Principal"`
+	Condition json.RawMessage `json:"Condition"`
+}
+
+// policyGrantsPublicAccess reports whether any statement grants public access —
+// Effect Allow, a wildcard ("*") Principal, and no Condition. It mirrors the
+// broad-access check AWS runs for BlockPublicPolicy/ValidateResourcePolicy.
+func policyGrantsPublicAccess(policy string) bool {
+	var doc struct {
+		Statement json.RawMessage `json:"Statement"`
+	}
+
+	if json.Unmarshal([]byte(policy), &doc) != nil {
+		return false
+	}
+
+	for _, s := range parseStatements(doc.Statement) {
+		if s.Effect == effectAllow && len(s.Condition) == 0 && principalIsWildcard(s.Principal) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// parseStatements decodes a Statement that may be a single object or an array
+// of objects into a slice.
+func parseStatements(raw json.RawMessage) []policyStatement {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var many []policyStatement
+	if json.Unmarshal(raw, &many) == nil {
+		return many
+	}
+
+	var one policyStatement
+	if json.Unmarshal(raw, &one) == nil {
+		return []policyStatement{one}
+	}
+
+	return nil
+}
+
+// principalIsWildcard reports whether a Principal grants everyone: the string
+// "*", or a map whose values include "*" (e.g. {"AWS":"*"}).
+func principalIsWildcard(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+
+	var asString string
+	if json.Unmarshal(raw, &asString) == nil {
+		return asString == "*"
+	}
+
+	var asMap map[string]json.RawMessage
+	if json.Unmarshal(raw, &asMap) != nil {
+		return false
+	}
+
+	for _, v := range asMap {
+		if rawContainsWildcard(v) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// rawContainsWildcard reports whether a principal map value ("*", or a list
+// containing "*") is a wildcard.
+func rawContainsWildcard(raw json.RawMessage) bool {
+	var asString string
+	if json.Unmarshal(raw, &asString) == nil {
+		return asString == "*"
+	}
+
+	var asList []string
+	if json.Unmarshal(raw, &asList) == nil {
+		for _, v := range asList {
+			if v == "*" {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/server/aws/secretsmanager/resource_policy_test.go
+++ b/server/aws/secretsmanager/resource_policy_test.go
@@ -1,0 +1,126 @@
+package secretsmanager_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssm "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+)
+
+const samplePolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+	`"Principal":{"AWS":"arn:aws:iam::111122223333:root"},` +
+	`"Action":"secretsmanager:GetSecretValue","Resource":"*"}]}`
+
+const publicPolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+	`"Principal":"*","Action":"secretsmanager:GetSecretValue","Resource":"*"}]}`
+
+// TestSDKResourcePolicyRoundTrip is the F3 reproduction: Put/Get/Delete round-trip
+// the JSON resource policy, the write path Terraform's
+// aws_secretsmanager_secret_policy needs.
+func TestSDKResourcePolicyRoundTrip(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("policy-secret"), SecretString: aws.String("v1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	if _, err := client.PutResourcePolicy(ctx, &awssm.PutResourcePolicyInput{
+		SecretId: created.ARN, ResourcePolicy: aws.String(samplePolicy),
+	}); err != nil {
+		t.Fatalf("PutResourcePolicy: %v", err)
+	}
+
+	got, err := client.GetResourcePolicy(ctx, &awssm.GetResourcePolicyInput{SecretId: created.ARN})
+	if err != nil {
+		t.Fatalf("GetResourcePolicy: %v", err)
+	}
+
+	if aws.ToString(got.ResourcePolicy) != samplePolicy {
+		t.Fatalf("ResourcePolicy round-trip = %q, want %q", aws.ToString(got.ResourcePolicy), samplePolicy)
+	}
+
+	if _, err := client.DeleteResourcePolicy(ctx, &awssm.DeleteResourcePolicyInput{SecretId: created.ARN}); err != nil {
+		t.Fatalf("DeleteResourcePolicy: %v", err)
+	}
+
+	// After delete, GetResourcePolicy still succeeds (not an error) with no policy.
+	cleared, err := client.GetResourcePolicy(ctx, &awssm.GetResourcePolicyInput{SecretId: created.ARN})
+	if err != nil {
+		t.Fatalf("GetResourcePolicy after delete: %v", err)
+	}
+
+	if cleared.ResourcePolicy != nil {
+		t.Fatalf("ResourcePolicy after delete = %q, want nil", aws.ToString(cleared.ResourcePolicy))
+	}
+}
+
+// TestSDKValidateResourcePolicy verifies a valid policy passes and a malformed
+// one fails with validation errors (without being stored).
+func TestSDKValidateResourcePolicy(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	valid, err := client.ValidateResourcePolicy(ctx, &awssm.ValidateResourcePolicyInput{
+		ResourcePolicy: aws.String(samplePolicy),
+	})
+	if err != nil {
+		t.Fatalf("ValidateResourcePolicy(valid): %v", err)
+	}
+
+	if !valid.PolicyValidationPassed {
+		t.Fatalf("valid policy: PolicyValidationPassed = false, errors = %+v", valid.ValidationErrors)
+	}
+
+	malformed, err := client.ValidateResourcePolicy(ctx, &awssm.ValidateResourcePolicyInput{
+		ResourcePolicy: aws.String("{not valid json"),
+	})
+	if err != nil {
+		t.Fatalf("ValidateResourcePolicy(malformed): %v", err)
+	}
+
+	if malformed.PolicyValidationPassed {
+		t.Fatal("malformed policy: PolicyValidationPassed = true, want false")
+	}
+
+	if len(malformed.ValidationErrors) == 0 {
+		t.Fatal("malformed policy: no ValidationErrors returned")
+	}
+}
+
+// TestSDKBlockPublicPolicy verifies BlockPublicPolicy rejects a policy that
+// grants public access ("Principal":"*").
+func TestSDKBlockPublicPolicy(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("blocked"), SecretString: aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	_, err := client.PutResourcePolicy(ctx, &awssm.PutResourcePolicyInput{
+		SecretId:          aws.String("blocked"),
+		ResourcePolicy:    aws.String(publicPolicy),
+		BlockPublicPolicy: aws.Bool(true),
+	})
+
+	var public *smtypes.PublicPolicyException
+	if !errors.As(err, &public) {
+		t.Fatalf("BlockPublicPolicy on public policy: got %v, want PublicPolicyException", err)
+	}
+
+	// Without BlockPublicPolicy the same policy is accepted.
+	if _, err := client.PutResourcePolicy(ctx, &awssm.PutResourcePolicyInput{
+		SecretId: aws.String("blocked"), ResourcePolicy: aws.String(publicPolicy),
+	}); err != nil {
+		t.Fatalf("PutResourcePolicy(public, no block): %v", err)
+	}
+}

--- a/server/aws/secretsmanager/types.go
+++ b/server/aws/secretsmanager/types.go
@@ -159,7 +159,9 @@ type deleteSecretResponse struct {
 	DeletionDate float64 `json:"DeletionDate,omitempty"`
 }
 
-type restoreSecretResponse struct {
+// secretRefResponse is the {ARN, Name} envelope returned by the operations that
+// only echo the secret reference: RestoreSecret and Put/DeleteResourcePolicy.
+type secretRefResponse struct {
 	ARN  string `json:"ARN"`
 	Name string `json:"Name"`
 }
@@ -200,6 +202,67 @@ type listSecretVersionIDsResponse struct {
 	ARN      string        `json:"ARN"`
 	Name     string        `json:"Name"`
 	Versions []versionJSON `json:"Versions"`
+}
+
+type putResourcePolicyRequest struct {
+	SecretID          string `json:"SecretId"`
+	ResourcePolicy    string `json:"ResourcePolicy"`
+	BlockPublicPolicy bool   `json:"BlockPublicPolicy"`
+}
+
+// getResourcePolicyResponse omits ResourcePolicy when none is set, which the SDK
+// reads as "no policy".
+type getResourcePolicyResponse struct {
+	ARN            string `json:"ARN"`
+	Name           string `json:"Name"`
+	ResourcePolicy string `json:"ResourcePolicy,omitempty"`
+}
+
+type validateResourcePolicyRequest struct {
+	SecretID       string `json:"SecretId"`
+	ResourcePolicy string `json:"ResourcePolicy"`
+}
+
+type validationErrorEntry struct {
+	CheckName    string `json:"CheckName"`
+	ErrorMessage string `json:"ErrorMessage"`
+}
+
+type validateResourcePolicyResponse struct {
+	PolicyValidationPassed bool                   `json:"PolicyValidationPassed"`
+	ValidationErrors       []validationErrorEntry `json:"ValidationErrors"`
+}
+
+type batchGetSecretValueRequest struct {
+	SecretIDList []string       `json:"SecretIdList"`
+	Filters      []secretFilter `json:"Filters"`
+	MaxResults   int32          `json:"MaxResults"`
+	NextToken    string         `json:"NextToken"`
+}
+
+// secretValueEntry is one resolved secret in a BatchGetSecretValue response.
+type secretValueEntry struct {
+	ARN           string   `json:"ARN"`
+	Name          string   `json:"Name"`
+	VersionID     string   `json:"VersionId"`
+	SecretString  string   `json:"SecretString,omitempty"`
+	SecretBinary  []byte   `json:"SecretBinary,omitempty"`
+	VersionStages []string `json:"VersionStages,omitempty"`
+	CreatedDate   float64  `json:"CreatedDate,omitempty"`
+}
+
+// batchErrorEntry reports a per-secret failure (e.g. a missing secret) in a
+// BatchGetSecretValue response, so one bad id does not fail the whole batch.
+type batchErrorEntry struct {
+	SecretID  string `json:"SecretId"`
+	ErrorCode string `json:"ErrorCode"`
+	Message   string `json:"Message"`
+}
+
+type batchGetSecretValueResponse struct {
+	SecretValues []secretValueEntry `json:"SecretValues"`
+	Errors       []batchErrorEntry  `json:"Errors"`
+	NextToken    string             `json:"NextToken,omitempty"`
 }
 
 // epochSeconds converts an RFC3339 timestamp to Unix epoch seconds, the form


### PR DESCRIPTION
## What

Adds the AWS Secrets Manager resource-policy control-plane ops and the batch read, all previously returning `UnknownOperationException`:

- **PutResourcePolicy** — stores the JSON policy on the secret; `BlockPublicPolicy=true` rejects a policy that grants public access (wildcard `Principal` with no `Condition`) as `PublicPolicyException`; malformed JSON is `MalformedPolicyDocumentException`.
- **GetResourcePolicy** — returns `{ARN, Name, ResourcePolicy}`; `ResourcePolicy` is omitted (nil) when none is set, which the SDK reads as "no policy" (not an error).
- **DeleteResourcePolicy** — clears the policy.
- **ValidateResourcePolicy** — checks JSON syntax + broad access without storing; returns `PolicyValidationPassed` with `ValidationErrors` (passed=false + errors on malformed/public).
- **BatchGetSecretValue** — resolves `SecretIdList` (or `Filters`), returning `SecretValues` for the secrets that exist and a per-item `Errors` entry (`ResourceNotFoundException`) for missing ones, rather than failing the whole batch. Supports `MaxResults`/`NextToken` via the existing offset paginator.

## Why

`PutResourcePolicy`/`DeleteResourcePolicy` being unimplemented broke Terraform's `aws_secretsmanager_secret_policy` (create/update/destroy). `BatchGetSecretValue` is a common startup path for apps fetching many secrets. Found by the AWS real-user e2e deep audit (findings F3 [HIGH], F7 [MED]).

## How

Resource policies are stored per-secret in the AWS provider and exposed through a type-asserted `secretPolicyManager` optional interface (same pattern as the existing `secretStager`/`secretMutator`), so the portable `driver.Secrets` interface stays stable and Azure/GCP are untouched. The policy survives snapshot/restore.

## Tests

Real `aws-sdk-go-v2` reproductions: resource-policy Put/Get/Delete round-trip; Get-after-delete returns empty (not error); ValidateResourcePolicy valid→passed / malformed→failed+errors; BlockPublicPolicy rejects a public policy; BatchGetSecretValue over `[a,b,missing]` yields values for a,b + an error entry for missing; empty list handled. Provider-level round-trip + snapshot tests. Existing SecretsManager tests remain green.
