### PR TITLE
fix(aws-elbv2): enforce deletion_protection; model redirect/fixed-response actions + certs + rule conditions round-trip; SetRulePriorities uniqueness

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -251,6 +251,8 @@ func New(opts ...config.Option) *Provider {
 	p.RDS.SetSubnetResolver(p.VPC)
 	p.ElastiCache.SetSubnetResolver(p.VPC)
 	p.EC2.SetSubnetResolver(p.VPC)
+	// A load balancer's VpcId is derived from its subnets, matching ELBv2.
+	p.ELB.SetSubnetResolver(p.VPC)
 	// An IamInstanceProfile passed to RunInstances resolves through IAM so the
 	// role->profile->instance chain reads back on DescribeInstances.
 	p.EC2.SetInstanceProfileResolver(p.IAM)

--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -169,16 +169,49 @@ func canonicalHostedZoneID(region string) string {
 // balancer does not exist or has already been deleted, the call succeeds." So a
 // second delete (or a delete of an ARN that never existed) returns no error,
 // which keeps idempotent teardown flows (terraform destroy retries) working.
+//
+// A load balancer with deletion_protection.enabled=true cannot be deleted: real
+// ELBv2 rejects the call with OperationNotPermitted. This is the exact scenario
+// deletion protection exists to prevent, so honoring it stops an errant delete
+// (or a terraform destroy) from wiping a load balancer the user protected.
 func (m *Mock) DeleteLoadBalancer(_ context.Context, arn string) error {
-	m.lbs.Delete(arn)
+	// Only an existing load balancer can be protected; a missing ARN stays
+	// idempotent (no error), matching the API reference.
+	if _, ok := m.lbs.Get(arn); ok {
+		m.attrsMu.RLock()
+		protected := m.attrs[arn].DeletionProtection
+		m.attrsMu.RUnlock()
 
-	// Delete all listeners associated with this load balancer.
-	all := m.listeners.All()
-	for key, li := range all {
-		if li.LBARN == arn {
-			m.listeners.Delete(key)
+		if protected {
+			return errors.Newf(errors.FailedPrecondition,
+				"load balancer %q cannot be deleted because deletion protection is enabled", arn)
 		}
 	}
+
+	m.lbs.Delete(arn)
+
+	// Delete listeners for this load balancer and, with them, the rules under
+	// those listeners. Leaving the rules behind would leak them for the life of
+	// the process (their parent listener is gone, so nothing ever reaches them).
+	for key, li := range m.listeners.All() {
+		if li.LBARN != arn {
+			continue
+		}
+
+		for rkey, r := range m.rules.All() {
+			if r.ListenerARN == li.ARN {
+				m.rules.Delete(rkey)
+			}
+		}
+
+		m.listeners.Delete(key)
+	}
+
+	// Drop the stored load-balancer attributes so a recreated ARN does not
+	// inherit a prior deletion-protection flag.
+	m.attrsMu.Lock()
+	delete(m.attrs, arn)
+	m.attrsMu.Unlock()
 
 	return nil
 }

--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -728,10 +728,16 @@ func (m *Mock) ModifyRule(_ context.Context, input driver.ModifyRuleInput) (*dri
 
 // SetRulePriorities reassigns the priorities of the named rules and returns the
 // updated rules.
+//
+// A listener can't have two rules with the same priority, and the reorder path
+// must enforce that just as the create path does: real ELBv2 rejects a target
+// priority already held by another rule on the same listener with PriorityInUse.
+// Every rule is resolved and validated before any write, so a conflict leaves
+// the existing priorities untouched rather than half-applied.
 func (m *Mock) SetRulePriorities(
 	_ context.Context, pairs []driver.RulePriorityPair,
 ) ([]driver.RuleInfo, error) {
-	out := make([]driver.RuleInfo, 0, len(pairs))
+	moving := make(map[string]driver.RuleInfo, len(pairs))
 
 	for _, p := range pairs {
 		rule, ok := m.rules.Get(p.RuleARN)
@@ -739,12 +745,73 @@ func (m *Mock) SetRulePriorities(
 			return nil, errors.Newf(errors.NotFound, "rule %q not found", p.RuleARN)
 		}
 
+		moving[p.RuleARN] = rule
+	}
+
+	if err := m.checkPriorityConflicts(pairs, moving); err != nil {
+		return nil, err
+	}
+
+	out := make([]driver.RuleInfo, 0, len(pairs))
+
+	for _, p := range pairs {
+		rule := moving[p.RuleARN]
 		rule.Priority = p.Priority
 		m.rules.Set(p.RuleARN, rule)
 		out = append(out, rule)
 	}
 
 	return out, nil
+}
+
+// prioritySlot identifies a priority within one listener.
+type prioritySlot struct {
+	listener string
+	priority int
+}
+
+// checkPriorityConflicts reports FailedPrecondition (mapped to PriorityInUse)
+// when a requested priority collides with another rule on the same listener —
+// either a rule outside the batch or a second rule inside it.
+func (m *Mock) checkPriorityConflicts(
+	pairs []driver.RulePriorityPair, moving map[string]driver.RuleInfo,
+) error {
+	claimed := make(map[prioritySlot]struct{}, len(pairs))
+
+	for _, p := range pairs {
+		rule := moving[p.RuleARN]
+		slot := prioritySlot{listener: rule.ListenerARN, priority: p.Priority}
+
+		if _, dup := claimed[slot]; dup {
+			return errors.Newf(errors.FailedPrecondition, "priority %d is currently in use", p.Priority)
+		}
+
+		claimed[slot] = struct{}{}
+
+		if m.priorityHeldByOther(slot, moving) {
+			return errors.Newf(errors.FailedPrecondition, "priority %d is currently in use", p.Priority)
+		}
+	}
+
+	return nil
+}
+
+// priorityHeldByOther reports whether a rule not in the batch already holds the
+// given priority on the same listener. Default rules (priority 0) are ignored.
+func (m *Mock) priorityHeldByOther(slot prioritySlot, moving map[string]driver.RuleInfo) bool {
+	for _, other := range m.rules.All() {
+		if other.IsDefault || other.ListenerARN != slot.listener || other.Priority != slot.priority {
+			continue
+		}
+
+		if _, isMoving := moving[other.ARN]; isMoving {
+			continue
+		}
+
+		return true
+	}
+
+	return false
 }
 
 // SetSecurityGroups replaces the security groups attached to a load balancer.

--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -475,6 +475,8 @@ func filterToSlice[T any](store *memstore.Store[T], pred func(string, T) bool) [
 }
 
 // CreateListener creates a new listener on a load balancer.
+//
+//nolint:gocritic // hugeParam: interface method signature is fixed.
 func (m *Mock) CreateListener(_ context.Context, cfg driver.ListenerConfig) (*driver.ListenerInfo, error) {
 	lb, ok := m.lbs.Get(cfg.LBARN)
 	if !ok {
@@ -660,6 +662,8 @@ func (m *Mock) DescribeRules(_ context.Context, listenerARN string) ([]driver.Ru
 }
 
 // ModifyListener modifies an existing listener's port, protocol, or default actions.
+//
+//nolint:gocritic // hugeParam: interface method signature is fixed.
 func (m *Mock) ModifyListener(_ context.Context, input driver.ModifyListenerInput) error {
 	li, ok := m.listeners.Get(input.ListenerARN)
 	if !ok {

--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -199,13 +199,17 @@ func (m *Mock) DeleteLoadBalancer(_ context.Context, arn string) error {
 	// Delete listeners for this load balancer and, with them, the rules under
 	// those listeners. Leaving the rules behind would leak them for the life of
 	// the process (their parent listener is gone, so nothing ever reaches them).
-	for key, li := range m.listeners.All() {
-		if li.LBARN != arn {
+	// Range over keys and index the map for field access so the large
+	// ListenerInfo value is never copied per iteration.
+	listeners := m.listeners.All()
+	for key := range listeners {
+		if listeners[key].LBARN != arn {
 			continue
 		}
 
+		listenerARN := listeners[key].ARN
 		for rkey, r := range m.rules.All() {
-			if r.ListenerARN == li.ARN {
+			if r.ListenerARN == listenerARN {
 				m.rules.Delete(rkey)
 			}
 		}
@@ -396,8 +400,11 @@ func (m *Mock) DeleteTargetGroup(_ context.Context, arn string) error {
 // target group is still referenced by a listener default action or a rule
 // action, so a delete cannot silently orphan a forward target.
 func (m *Mock) checkTargetGroupNotInUse(arn string) error {
-	for _, li := range m.listeners.All() {
-		for _, a := range li.DefaultActions {
+	// Range over keys and index the map so the large ListenerInfo value is not
+	// copied per iteration.
+	listeners := m.listeners.All()
+	for key := range listeners {
+		for _, a := range listeners[key].DefaultActions {
 			if a.TargetGroupARN == arn {
 				return errors.Newf(errors.FailedPrecondition,
 					"target group %q is currently in use by a listener", arn)

--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -59,6 +59,11 @@ type Mock struct {
 
 	tgAttrsMu sync.RWMutex
 	tgAttrs   map[string]map[string]string // tgARN -> attribute overrides
+
+	// subnetResolver derives a load balancer's VpcId from its subnets. Real
+	// ELBv2 infers VpcId rather than taking it as input; without the resolver
+	// wired in the field is simply left empty.
+	subnetResolver SubnetResolver
 }
 
 // New creates a new ELB mock with the given configuration options.
@@ -78,7 +83,7 @@ func New(opts *config.Options) *Mock {
 // CreateLoadBalancer creates a new load balancer.
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func (m *Mock) CreateLoadBalancer(_ context.Context, cfg driver.LBConfig) (*driver.LBInfo, error) {
+func (m *Mock) CreateLoadBalancer(ctx context.Context, cfg driver.LBConfig) (*driver.LBInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "load balancer name is required")
 	}
@@ -124,6 +129,7 @@ func (m *Mock) CreateLoadBalancer(_ context.Context, cfg driver.LBConfig) (*driv
 		SecurityGroups:        sgs,
 		IPAddressType:         ipType,
 		CanonicalHostedZoneID: canonicalHostedZoneID(m.opts.Region),
+		VPCID:                 m.resolveVPCID(ctx, cfg.Subnets),
 		CreatedTime:           m.opts.Clock.Now().UTC(),
 		Tags:                  tags,
 	}

--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -494,6 +494,8 @@ func (m *Mock) CreateListener(_ context.Context, cfg driver.ListenerConfig) (*dr
 		Protocol:       cfg.Protocol,
 		Port:           cfg.Port,
 		DefaultActions: cloneActions(cfg.DefaultActions),
+		SslPolicy:      cfg.SslPolicy,
+		Certificates:   cloneCertificates(cfg.Certificates),
 	}
 
 	m.listeners.Set(arn, li)
@@ -501,6 +503,15 @@ func (m *Mock) CreateListener(_ context.Context, cfg driver.ListenerConfig) (*dr
 	result := li
 
 	return &result, nil
+}
+
+// cloneCertificates returns an independent copy of a certificate slice.
+func cloneCertificates(certs []driver.Certificate) []driver.Certificate {
+	if len(certs) == 0 {
+		return nil
+	}
+
+	return append([]driver.Certificate(nil), certs...)
 }
 
 // validateForwardActions reports TargetGroupNotFound when any forward action
@@ -663,6 +674,14 @@ func (m *Mock) ModifyListener(_ context.Context, input driver.ModifyListenerInpu
 
 	if len(input.DefaultActions) > 0 {
 		li.DefaultActions = cloneActions(input.DefaultActions)
+	}
+
+	if input.SslPolicy != "" {
+		li.SslPolicy = input.SslPolicy
+	}
+
+	if len(input.Certificates) > 0 {
+		li.Certificates = cloneCertificates(input.Certificates)
 	}
 
 	m.listeners.Set(input.ListenerARN, li)

--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -391,9 +391,11 @@ func (m *Mock) DeleteTargetGroup(_ context.Context, arn string) error {
 // action, so a delete cannot silently orphan a forward target.
 func (m *Mock) checkTargetGroupNotInUse(arn string) error {
 	for _, li := range m.listeners.All() {
-		if li.TargetGroupARN == arn {
-			return errors.Newf(errors.FailedPrecondition,
-				"target group %q is currently in use by a listener", arn)
+		for _, a := range li.DefaultActions {
+			if a.TargetGroupARN == arn {
+				return errors.Newf(errors.FailedPrecondition,
+					"target group %q is currently in use by a listener", arn)
+			}
 		}
 	}
 
@@ -473,10 +475,10 @@ func (m *Mock) CreateListener(_ context.Context, cfg driver.ListenerConfig) (*dr
 		return nil, errors.Newf(errors.NotFound, "load balancer %q not found", cfg.LBARN)
 	}
 
-	// A default action that forwards to a target group must reference one that
-	// exists; real ELBv2 rejects a bogus TargetGroupArn with TargetGroupNotFound.
-	if cfg.TargetGroupARN != "" && !m.tgs.Has(cfg.TargetGroupARN) {
-		return nil, errors.Newf(errors.NotFound, "target group %q not found", cfg.TargetGroupARN)
+	// Any forward default action must reference a target group that exists;
+	// real ELBv2 rejects a bogus TargetGroupArn with TargetGroupNotFound.
+	if err := m.validateForwardActions(cfg.DefaultActions); err != nil {
+		return nil, err
 	}
 
 	// A listener ARN embeds the load balancer's resource path plus a unique
@@ -491,7 +493,7 @@ func (m *Mock) CreateListener(_ context.Context, cfg driver.ListenerConfig) (*dr
 		LBARN:          cfg.LBARN,
 		Protocol:       cfg.Protocol,
 		Port:           cfg.Port,
-		TargetGroupARN: cfg.TargetGroupARN,
+		DefaultActions: cloneActions(cfg.DefaultActions),
 	}
 
 	m.listeners.Set(arn, li)
@@ -499,6 +501,28 @@ func (m *Mock) CreateListener(_ context.Context, cfg driver.ListenerConfig) (*dr
 	result := li
 
 	return &result, nil
+}
+
+// validateForwardActions reports TargetGroupNotFound when any forward action
+// references a target group that does not exist.
+func (m *Mock) validateForwardActions(actions []driver.RuleAction) error {
+	for _, a := range actions {
+		if a.TargetGroupARN != "" && !m.tgs.Has(a.TargetGroupARN) {
+			return errors.Newf(errors.NotFound, "target group %q not found", a.TargetGroupARN)
+		}
+	}
+
+	return nil
+}
+
+// cloneActions returns an independent copy of an action slice so stored state
+// never aliases the caller's input.
+func cloneActions(actions []driver.RuleAction) []driver.RuleAction {
+	if len(actions) == 0 {
+		return nil
+	}
+
+	return append([]driver.RuleAction(nil), actions...)
 }
 
 // DeleteListener deletes a listener by ARN.
@@ -625,6 +649,10 @@ func (m *Mock) ModifyListener(_ context.Context, input driver.ModifyListenerInpu
 		return errors.Newf(errors.NotFound, "listener %q not found", input.ListenerARN)
 	}
 
+	if err := m.validateForwardActions(input.DefaultActions); err != nil {
+		return err
+	}
+
 	if input.Port != 0 {
 		li.Port = input.Port
 	}
@@ -634,7 +662,7 @@ func (m *Mock) ModifyListener(_ context.Context, input driver.ModifyListenerInpu
 	}
 
 	if len(input.DefaultActions) > 0 {
-		li.TargetGroupARN = input.DefaultActions[0].TargetGroupARN
+		li.DefaultActions = cloneActions(input.DefaultActions)
 	}
 
 	m.listeners.Set(input.ListenerARN, li)

--- a/providers/aws/elbv2/elb_test.go
+++ b/providers/aws/elbv2/elb_test.go
@@ -248,6 +248,53 @@ func TestDeleteLoadBalancerCascadesListeners(t *testing.T) {
 	assertEqual(t, 0, len(lbs))
 }
 
+func TestDeleteLoadBalancerDeletionProtection(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	lb := createTestLB(m)
+
+	requireNoError(t, m.PutLBAttributes(ctx, lb.ARN, driver.LBAttributes{DeletionProtection: true}))
+
+	// A protected load balancer cannot be deleted.
+	assertError(t, m.DeleteLoadBalancer(ctx, lb.ARN), true)
+
+	lbs, _ := m.DescribeLoadBalancers(ctx, []string{lb.ARN})
+	assertEqual(t, 1, len(lbs))
+
+	// Clearing the flag lets the delete through.
+	requireNoError(t, m.PutLBAttributes(ctx, lb.ARN, driver.LBAttributes{DeletionProtection: false}))
+	requireNoError(t, m.DeleteLoadBalancer(ctx, lb.ARN))
+}
+
+func TestDeleteLoadBalancerCascadesRulesAndAttributes(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	lb := createTestLB(m)
+	tg := createTestTG(m)
+
+	li, err := m.CreateListener(ctx, driver.ListenerConfig{LBARN: lb.ARN, Protocol: "HTTP", Port: 80})
+	requireNoError(t, err)
+
+	_, err = m.CreateRule(ctx, driver.RuleConfig{
+		ListenerARN: li.ARN,
+		Priority:    10,
+		Conditions:  []driver.RuleCondition{{Field: "path-pattern", Values: []string{"/*"}}},
+		Actions:     []driver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
+	})
+	requireNoError(t, err)
+
+	requireNoError(t, m.PutLBAttributes(ctx, lb.ARN, driver.LBAttributes{IdleTimeout: 120}))
+	requireNoError(t, m.DeleteLoadBalancer(ctx, lb.ARN))
+
+	// The rule under the deleted listener must be gone (no orphan leak); the
+	// listener no longer exists, so DescribeRules reports ListenerNotFound.
+	_, err = m.DescribeRules(ctx, li.ARN)
+	assertError(t, err, true)
+
+	// Deleting the target group must now succeed: no rule still references it.
+	requireNoError(t, m.DeleteTargetGroup(ctx, tg.ARN))
+}
+
 func TestRegisterTargets(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/providers/aws/elbv2/elb_test.go
+++ b/providers/aws/elbv2/elb_test.go
@@ -181,7 +181,7 @@ func TestCreateListener(t *testing.T) {
 			LBARN:          lb.ARN,
 			Protocol:       "HTTP",
 			Port:           80,
-			TargetGroupARN: tg.ARN,
+			DefaultActions: []driver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
 		})
 		requireNoError(t, err)
 		assertNotEmpty(t, li.ARN)
@@ -453,7 +453,8 @@ func TestCreateRule(t *testing.T) {
 	lb := createTestLB(m)
 	tg := createTestTG(m)
 	li, _ := m.CreateListener(ctx, driver.ListenerConfig{
-		LBARN: lb.ARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tg.ARN,
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80,
+		DefaultActions: []driver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -497,7 +498,8 @@ func TestDescribeRules(t *testing.T) {
 	lb := createTestLB(m)
 	tg := createTestTG(m)
 	li, _ := m.CreateListener(ctx, driver.ListenerConfig{
-		LBARN: lb.ARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tg.ARN,
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80,
+		DefaultActions: []driver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
 	})
 
 	_, _ = m.CreateRule(ctx, driver.RuleConfig{
@@ -562,7 +564,8 @@ func TestModifyListener(t *testing.T) {
 	lb := createTestLB(m)
 	tg := createTestTG(m)
 	li, _ := m.CreateListener(ctx, driver.ListenerConfig{
-		LBARN: lb.ARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tg.ARN,
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80,
+		DefaultActions: []driver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
 	})
 
 	t.Run("modify port", func(t *testing.T) {

--- a/providers/aws/elbv2/elb_test.go
+++ b/providers/aws/elbv2/elb_test.go
@@ -523,6 +523,39 @@ func TestDescribeRules(t *testing.T) {
 	})
 }
 
+func TestSetRulePrioritiesUniqueness(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	lb := createTestLB(m)
+	li, _ := m.CreateListener(ctx, driver.ListenerConfig{LBARN: lb.ARN, Protocol: "HTTP", Port: 80})
+
+	r1, _ := m.CreateRule(ctx, driver.RuleConfig{ListenerARN: li.ARN, Priority: 10})
+	r2, _ := m.CreateRule(ctx, driver.RuleConfig{ListenerARN: li.ARN, Priority: 20})
+
+	// Moving r2 onto r1's priority collides.
+	_, err := m.SetRulePriorities(ctx, []driver.RulePriorityPair{{RuleARN: r2.ARN, Priority: 10}})
+	assertError(t, err, true)
+
+	// The rejected reorder left both priorities intact.
+	rules, _ := m.DescribeRules(ctx, li.ARN)
+	for _, r := range rules {
+		switch r.ARN {
+		case r1.ARN:
+			assertEqual(t, 10, r.Priority)
+		case r2.ARN:
+			assertEqual(t, 20, r.Priority)
+		}
+	}
+
+	// Swapping both at once (10<->20) is allowed: neither target is held by a
+	// rule outside the batch.
+	_, err = m.SetRulePriorities(ctx, []driver.RulePriorityPair{
+		{RuleARN: r1.ARN, Priority: 20},
+		{RuleARN: r2.ARN, Priority: 10},
+	})
+	requireNoError(t, err)
+}
+
 func TestModifyListener(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/providers/aws/elbv2/subnet_resolver.go
+++ b/providers/aws/elbv2/subnet_resolver.go
@@ -1,0 +1,43 @@
+package elbv2
+
+import (
+	"context"
+
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// SubnetResolver is the slice of the networking mock this package needs to
+// derive a load balancer's VPC. Real ELBv2 infers VpcId from the member subnets
+// rather than taking it as input, and callers wiring a load balancer to a
+// target group or security group by VpcId read that field — so it has to be
+// resolved, not left blank.
+type SubnetResolver interface {
+	DescribeSubnets(ctx context.Context, ids []string) ([]netdriver.SubnetInfo, error)
+}
+
+// SetSubnetResolver wires the networking mock in. Without it a load balancer
+// still stores its subnets, but its VpcId is empty.
+func (m *Mock) SetSubnetResolver(r SubnetResolver) {
+	m.subnetResolver = r
+}
+
+// resolveVPCID reports the VPC the member subnets belong to, or "" when no
+// resolver is wired or the subnets cannot be resolved.
+func (m *Mock) resolveVPCID(ctx context.Context, subnetIDs []string) string {
+	if m.subnetResolver == nil || len(subnetIDs) == 0 {
+		return ""
+	}
+
+	subnets, err := m.subnetResolver.DescribeSubnets(ctx, subnetIDs)
+	if err != nil || len(subnets) == 0 {
+		return ""
+	}
+
+	for i := range subnets {
+		if subnets[i].VPCID != "" {
+			return subnets[i].VPCID
+		}
+	}
+
+	return ""
+}

--- a/providers/aws/elbv2/subnet_resolver_test.go
+++ b/providers/aws/elbv2/subnet_resolver_test.go
@@ -1,0 +1,45 @@
+package elbv2
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/aws/vpc"
+	"github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// TestCreateLoadBalancerResolvesVPCID proves that, with the networking mock
+// wired in, a load balancer's VpcId is derived from its member subnets — as
+// real ELBv2 does — instead of being left empty.
+func TestCreateLoadBalancerResolvesVPCID(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))
+	ctx := context.Background()
+
+	vpcMock := vpc.New(opts)
+	m := New(opts)
+	m.SetSubnetResolver(vpcMock)
+
+	v, err := vpcMock.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	requireNoError(t, err)
+
+	sn, err := vpcMock.CreateSubnet(ctx, netdriver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+	requireNoError(t, err)
+
+	lb, err := m.CreateLoadBalancer(ctx, driver.LBConfig{Name: "vpc-lb", Subnets: []string{sn.ID}})
+	requireNoError(t, err)
+	assertEqual(t, v.ID, lb.VPCID)
+}
+
+// TestCreateLoadBalancerNoResolverLeavesVPCIDEmpty proves the field stays empty
+// (not a crash) when no resolver is wired.
+func TestCreateLoadBalancerNoResolverLeavesVPCIDEmpty(t *testing.T) {
+	m := newTestMock()
+	lb, err := m.CreateLoadBalancer(context.Background(),
+		driver.LBConfig{Name: "no-vpc-lb", Subnets: []string{"subnet-1"}})
+	requireNoError(t, err)
+	assertEqual(t, "", lb.VPCID)
+}

--- a/server/aws/elbv2/deletion_protection_sdk_test.go
+++ b/server/aws/elbv2/deletion_protection_sdk_test.go
@@ -1,0 +1,74 @@
+package elbv2_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestSDKELBDeletionProtectionBlocksDelete proves deletion_protection.enabled
+// is honored: a protected load balancer cannot be deleted (OperationNotPermitted),
+// and clearing the flag lets the delete succeed.
+func TestSDKELBDeletionProtectionBlocksDelete(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateLoadBalancer(ctx, &elb.CreateLoadBalancerInput{
+		Name:    aws.String("protected-alb"),
+		Subnets: []string{"subnet-a"},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer: %v", err)
+	}
+
+	arn := aws.ToString(created.LoadBalancers[0].LoadBalancerArn)
+
+	if _, err := client.ModifyLoadBalancerAttributes(ctx, &elb.ModifyLoadBalancerAttributesInput{
+		LoadBalancerArn: aws.String(arn),
+		Attributes: []elbtypes.LoadBalancerAttribute{
+			{Key: aws.String("deletion_protection.enabled"), Value: aws.String("true")},
+		},
+	}); err != nil {
+		t.Fatalf("ModifyLoadBalancerAttributes(enable): %v", err)
+	}
+
+	_, err = client.DeleteLoadBalancer(ctx, &elb.DeleteLoadBalancerInput{
+		LoadBalancerArn: aws.String(arn),
+	})
+	if err == nil {
+		t.Fatal("DeleteLoadBalancer on a protected LB: want error, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "OperationNotPermitted" {
+		t.Fatalf("DeleteLoadBalancer error = %v, want OperationNotPermitted", err)
+	}
+
+	// The load balancer must still exist after the rejected delete.
+	if _, err := client.DescribeLoadBalancers(ctx, &elb.DescribeLoadBalancersInput{
+		LoadBalancerArns: []string{arn},
+	}); err != nil {
+		t.Fatalf("DescribeLoadBalancers after rejected delete: %v", err)
+	}
+
+	// Clear the flag; the delete now succeeds.
+	if _, err := client.ModifyLoadBalancerAttributes(ctx, &elb.ModifyLoadBalancerAttributesInput{
+		LoadBalancerArn: aws.String(arn),
+		Attributes: []elbtypes.LoadBalancerAttribute{
+			{Key: aws.String("deletion_protection.enabled"), Value: aws.String("false")},
+		},
+	}); err != nil {
+		t.Fatalf("ModifyLoadBalancerAttributes(disable): %v", err)
+	}
+
+	if _, err := client.DeleteLoadBalancer(ctx, &elb.DeleteLoadBalancerInput{
+		LoadBalancerArn: aws.String(arn),
+	}); err != nil {
+		t.Fatalf("DeleteLoadBalancer after clearing protection: %v", err)
+	}
+}

--- a/server/aws/elbv2/handler.go
+++ b/server/aws/elbv2/handler.go
@@ -192,21 +192,27 @@ func writeErr(w http.ResponseWriter, err error) {
 	case cerrors.IsInvalidArgument(err):
 		awsquery.WriteXMLError(w, http.StatusBadRequest, "ValidationError", err.Error())
 	case cerrors.IsFailedPrecondition(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, inUseCode(err), err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, failedPreconditionCode(err), err.Error())
 	default:
 		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
 	}
 }
 
-// inUseCode picks the AWS "in use" error code for a FailedPrecondition. A
+// failedPreconditionCode picks the AWS error code for a FailedPrecondition.
+// Deleting a deletion-protected load balancer is OperationNotPermitted; a
 // listener rule reusing a priority is PriorityInUse; everything else (a target
 // group still referenced by an action) is ResourceInUse.
-func inUseCode(err error) string {
-	if strings.Contains(err.Error(), "priority") {
-		return "PriorityInUse"
-	}
+func failedPreconditionCode(err error) string {
+	msg := err.Error()
 
-	return "ResourceInUse"
+	switch {
+	case strings.Contains(msg, "deletion protection"):
+		return "OperationNotPermitted"
+	case strings.Contains(msg, "priority"):
+		return "PriorityInUse"
+	default:
+		return "ResourceInUse"
+	}
 }
 
 // duplicateNameCode distinguishes a duplicate target-group name from a

--- a/server/aws/elbv2/listener_actions_sdk_test.go
+++ b/server/aws/elbv2/listener_actions_sdk_test.go
@@ -1,0 +1,134 @@
+package elbv2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
+func createTestLBForListener(t *testing.T, client *elb.Client, name string) string {
+	t.Helper()
+
+	out, err := client.CreateLoadBalancer(context.Background(), &elb.CreateLoadBalancerInput{
+		Name:    aws.String(name),
+		Subnets: []string{"subnet-a"},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer: %v", err)
+	}
+
+	return aws.ToString(out.LoadBalancers[0].LoadBalancerArn)
+}
+
+// TestSDKListenerRedirectAction proves an HTTP listener whose only default
+// action is a redirect (the HTTP->HTTPS pattern) round-trips the full redirect
+// config on both CreateListener and DescribeListeners.
+func TestSDKListenerRedirectAction(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN := createTestLBForListener(t, client, "redirect-alb")
+
+	created, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type: elbtypes.ActionTypeEnumRedirect,
+			RedirectConfig: &elbtypes.RedirectActionConfig{
+				Protocol:   aws.String("HTTPS"),
+				Port:       aws.String("443"),
+				StatusCode: elbtypes.RedirectActionStatusCodeEnumHttp301,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	assertRedirect(t, created.Listeners[0].DefaultActions, "CreateListener")
+
+	liARN := aws.ToString(created.Listeners[0].ListenerArn)
+
+	desc, err := client.DescribeListeners(ctx, &elb.DescribeListenersInput{
+		ListenerArns: []string{liARN},
+	})
+	if err != nil {
+		t.Fatalf("DescribeListeners: %v", err)
+	}
+
+	assertRedirect(t, desc.Listeners[0].DefaultActions, "DescribeListeners")
+}
+
+func assertRedirect(t *testing.T, actions []elbtypes.Action, where string) {
+	t.Helper()
+
+	if len(actions) != 1 {
+		t.Fatalf("%s: got %d default actions, want 1", where, len(actions))
+	}
+
+	a := actions[0]
+	if a.Type != elbtypes.ActionTypeEnumRedirect {
+		t.Fatalf("%s: action type = %q, want redirect", where, a.Type)
+	}
+
+	if a.RedirectConfig == nil {
+		t.Fatalf("%s: redirect config dropped", where)
+	}
+
+	if aws.ToString(a.RedirectConfig.Protocol) != "HTTPS" ||
+		aws.ToString(a.RedirectConfig.Port) != "443" ||
+		a.RedirectConfig.StatusCode != elbtypes.RedirectActionStatusCodeEnumHttp301 {
+		t.Fatalf("%s: redirect config = %+v, want HTTPS:443 HTTP_301", where, a.RedirectConfig)
+	}
+}
+
+// TestSDKListenerFixedResponseAction proves a fixed-response default action
+// round-trips its status code, content type and message body.
+func TestSDKListenerFixedResponseAction(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN := createTestLBForListener(t, client, "fixed-alb")
+
+	created, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type: elbtypes.ActionTypeEnumFixedResponse,
+			FixedResponseConfig: &elbtypes.FixedResponseActionConfig{
+				StatusCode:  aws.String("503"),
+				ContentType: aws.String("text/plain"),
+				MessageBody: aws.String("service unavailable"),
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	liARN := aws.ToString(created.Listeners[0].ListenerArn)
+
+	desc, err := client.DescribeListeners(ctx, &elb.DescribeListenersInput{
+		ListenerArns: []string{liARN},
+	})
+	if err != nil {
+		t.Fatalf("DescribeListeners: %v", err)
+	}
+
+	acts := desc.Listeners[0].DefaultActions
+	if len(acts) != 1 || acts[0].Type != elbtypes.ActionTypeEnumFixedResponse {
+		t.Fatalf("default actions = %+v, want one fixed-response", acts)
+	}
+
+	fr := acts[0].FixedResponseConfig
+	if fr == nil || aws.ToString(fr.StatusCode) != "503" ||
+		aws.ToString(fr.ContentType) != "text/plain" ||
+		aws.ToString(fr.MessageBody) != "service unavailable" {
+		t.Fatalf("fixed-response config = %+v, want 503/text-plain/body", fr)
+	}
+}

--- a/server/aws/elbv2/listener_actions_sdk_test.go
+++ b/server/aws/elbv2/listener_actions_sdk_test.go
@@ -86,6 +86,65 @@ func assertRedirect(t *testing.T, actions []elbtypes.Action, where string) {
 	}
 }
 
+// TestSDKListenerHTTPSCertificatesAndSslPolicy proves an HTTPS listener stores
+// and round-trips its SslPolicy and default certificate.
+func TestSDKListenerHTTPSCertificatesAndSslPolicy(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN := createTestLBForListener(t, client, "https-alb")
+
+	tgOut, err := client.CreateTargetGroup(ctx, &elb.CreateTargetGroupInput{
+		Name:     aws.String("https-tg"),
+		Protocol: elbtypes.ProtocolEnumHttps,
+		Port:     aws.Int32(443),
+		VpcId:    aws.String("vpc-1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	tgARN := aws.ToString(tgOut.TargetGroups[0].TargetGroupArn)
+	certARN := "arn:aws:acm:us-east-1:000000000000:certificate/abc"
+
+	created, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttps,
+		Port:            aws.Int32(443),
+		SslPolicy:       aws.String("ELBSecurityPolicy-2016-08"),
+		Certificates:    []elbtypes.Certificate{{CertificateArn: aws.String(certARN)}},
+		DefaultActions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	liARN := aws.ToString(created.Listeners[0].ListenerArn)
+
+	desc, err := client.DescribeListeners(ctx, &elb.DescribeListenersInput{
+		ListenerArns: []string{liARN},
+	})
+	if err != nil {
+		t.Fatalf("DescribeListeners: %v", err)
+	}
+
+	li := desc.Listeners[0]
+	if aws.ToString(li.SslPolicy) != "ELBSecurityPolicy-2016-08" {
+		t.Fatalf("SslPolicy = %q, want ELBSecurityPolicy-2016-08", aws.ToString(li.SslPolicy))
+	}
+
+	if len(li.Certificates) != 1 || aws.ToString(li.Certificates[0].CertificateArn) != certARN {
+		t.Fatalf("Certificates = %+v, want the default cert %s", li.Certificates, certARN)
+	}
+
+	if !aws.ToBool(li.Certificates[0].IsDefault) {
+		t.Fatalf("create certificate should be the default (IsDefault=true), got %+v", li.Certificates[0])
+	}
+}
+
 // TestSDKListenerFixedResponseAction proves a fixed-response default action
 // round-trips its status code, content type and message body.
 func TestSDKListenerFixedResponseAction(t *testing.T) {

--- a/server/aws/elbv2/modify.go
+++ b/server/aws/elbv2/modify.go
@@ -29,6 +29,8 @@ func (h *Handler) modifyListener(w http.ResponseWriter, r *http.Request) {
 		Port:           formInt(form.Get("Port")),
 		Protocol:       form.Get("Protocol"),
 		DefaultActions: parseActions(form, "DefaultActions.member"),
+		SslPolicy:      form.Get("SslPolicy"),
+		Certificates:   parseCertificates(form, "Certificates.member"),
 	}
 
 	if err := h.lb.ModifyListener(r.Context(), input); err != nil {

--- a/server/aws/elbv2/modify_test.go
+++ b/server/aws/elbv2/modify_test.go
@@ -295,6 +295,82 @@ func TestSDKModifyRuleAndPriorities(t *testing.T) {
 	}
 }
 
+// TestSDKSetRulePrioritiesUniqueness proves SetRulePriorities rejects moving a
+// rule onto a priority another rule on the same listener already holds
+// (PriorityInUse), and leaves the existing priorities untouched.
+func TestSDKSetRulePrioritiesUniqueness(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN, tgARN := setupLBAndTG(t, client, "prio-alb", "prio-tg")
+
+	liOut, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	liARN := aws.ToString(liOut.Listeners[0].ListenerArn)
+
+	makeRule := func(priority int32) string {
+		out, err := client.CreateRule(ctx, &elb.CreateRuleInput{
+			ListenerArn: aws.String(liARN),
+			Priority:    aws.Int32(priority),
+			Conditions: []elbtypes.RuleCondition{{
+				Field:  aws.String("path-pattern"),
+				Values: []string{"/p*"},
+			}},
+			Actions: []elbtypes.Action{{
+				Type:           elbtypes.ActionTypeEnumForward,
+				TargetGroupArn: aws.String(tgARN),
+			}},
+		})
+		if err != nil {
+			t.Fatalf("CreateRule(%d): %v", priority, err)
+		}
+
+		return aws.ToString(out.Rules[0].RuleArn)
+	}
+
+	_ = makeRule(10)
+	rule2 := makeRule(20)
+
+	// Moving rule2 onto priority 10 collides with the first rule.
+	_, err = client.SetRulePriorities(ctx, &elb.SetRulePrioritiesInput{
+		RulePriorities: []elbtypes.RulePriorityPair{{
+			RuleArn:  aws.String(rule2),
+			Priority: aws.Int32(10),
+		}},
+	})
+	if err == nil {
+		t.Fatal("SetRulePriorities onto a used priority: want error, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "PriorityInUse" {
+		t.Fatalf("SetRulePriorities error = %v, want PriorityInUse", err)
+	}
+
+	// The collision left rule2 at its original priority.
+	rules, err := client.DescribeRules(ctx, &elb.DescribeRulesInput{ListenerArn: aws.String(liARN)})
+	if err != nil {
+		t.Fatalf("DescribeRules: %v", err)
+	}
+
+	for _, r := range rules.Rules {
+		if aws.ToString(r.RuleArn) == rule2 && aws.ToString(r.Priority) != "20" {
+			t.Fatalf("rule2 priority = %q, want unchanged 20", aws.ToString(r.Priority))
+		}
+	}
+}
+
 // TestSDKSetSecurityGroupsAndSubnets proves both network-modify ops dispatch.
 func TestSDKSetSecurityGroupsAndSubnets(t *testing.T) {
 	client := newSDKClient(t)

--- a/server/aws/elbv2/operations.go
+++ b/server/aws/elbv2/operations.go
@@ -243,6 +243,8 @@ func (h *Handler) createListener(w http.ResponseWriter, r *http.Request) {
 		Protocol:       form.Get("Protocol"),
 		Port:           formInt(form.Get("Port")),
 		DefaultActions: parseActions(form, "DefaultActions.member"),
+		SslPolicy:      form.Get("SslPolicy"),
+		Certificates:   parseCertificates(form, "Certificates.member"),
 	}
 
 	li, err := h.lb.CreateListener(r.Context(), cfg)
@@ -541,6 +543,29 @@ func parseFixedResponseConfig(form url.Values, base string) *lbdriver.FixedRespo
 	}
 
 	return &fr
+}
+
+// parseCertificates parses a listener Certificates member list. The listener's
+// create certificate is its default, so the first entry is marked IsDefault —
+// matching what real ELBv2 reports on DescribeListeners.
+func parseCertificates(form url.Values, prefix string) []lbdriver.Certificate {
+	indices := awsquery.CollectIndices(form, prefix)
+	if len(indices) == 0 {
+		return nil
+	}
+
+	out := make([]lbdriver.Certificate, 0, len(indices))
+
+	for i, n := range indices {
+		arn := form.Get(prefix + "." + strconv.Itoa(n) + ".CertificateArn")
+		if arn == "" {
+			continue
+		}
+
+		out = append(out, lbdriver.Certificate{CertificateArn: arn, IsDefault: i == 0})
+	}
+
+	return out
 }
 
 // parseConditions parses a Conditions member list into driver RuleConditions.

--- a/server/aws/elbv2/operations.go
+++ b/server/aws/elbv2/operations.go
@@ -568,7 +568,8 @@ func parseCertificates(form url.Values, prefix string) []lbdriver.Certificate {
 	return out
 }
 
-// parseConditions parses a Conditions member list into driver RuleConditions.
+// parseConditions parses a Conditions member list into driver RuleConditions,
+// preserving each condition's typed config so it round-trips on DescribeRules.
 func parseConditions(form url.Values, prefix string) []lbdriver.RuleCondition {
 	indices := awsquery.CollectIndices(form, prefix)
 	if len(indices) == 0 {
@@ -576,26 +577,84 @@ func parseConditions(form url.Values, prefix string) []lbdriver.RuleCondition {
 	}
 
 	out := make([]lbdriver.RuleCondition, 0, len(indices))
-
 	for _, n := range indices {
-		base := prefix + "." + strconv.Itoa(n)
-
-		field := form.Get(base + ".Field")
-
-		values := awsquery.ListStrings(form, base+".Values.member")
-		if len(values) == 0 {
-			// Some SDKs nest values under the typed config
-			// (PathPatternConfig / HostHeaderConfig).
-			values = append(values,
-				awsquery.ListStrings(form, base+".PathPatternConfig.Values.member")...)
-			values = append(values,
-				awsquery.ListStrings(form, base+".HostHeaderConfig.Values.member")...)
-		}
-
-		out = append(out, lbdriver.RuleCondition{Field: field, Values: values})
+		out = append(out, parseCondition(form, prefix+"."+strconv.Itoa(n)))
 	}
 
 	return out
+}
+
+// parseCondition parses a single rule condition at the given form prefix.
+func parseCondition(form url.Values, base string) lbdriver.RuleCondition {
+	c := lbdriver.RuleCondition{
+		Field:  form.Get(base + ".Field"),
+		Values: awsquery.ListStrings(form, base+".Values.member"),
+	}
+
+	if v := awsquery.ListStrings(form, base+".HostHeaderConfig.Values.member"); len(v) > 0 {
+		c.HostHeaderConfig = &lbdriver.HostHeaderConditionConfig{Values: v}
+	}
+
+	if v := awsquery.ListStrings(form, base+".PathPatternConfig.Values.member"); len(v) > 0 {
+		c.PathPatternConfig = &lbdriver.PathPatternConditionConfig{Values: v}
+	}
+
+	c.HTTPHeaderConfig = parseHTTPHeaderConfig(form, base+".HttpHeaderConfig")
+	c.QueryStringConfig = parseQueryStringConfig(form, base+".QueryStringConfig")
+
+	if v := awsquery.ListStrings(form, base+".SourceIpConfig.Values.member"); len(v) > 0 {
+		c.SourceIPConfig = &lbdriver.SourceIPConditionConfig{Values: v}
+	}
+
+	if v := awsquery.ListStrings(form, base+".HttpRequestMethodConfig.Values.member"); len(v) > 0 {
+		c.HTTPRequestMethodConfig = &lbdriver.HTTPRequestMethodConditionConfig{Values: v}
+	}
+
+	// AWS still echoes the deprecated flat Values for path-pattern/host-header,
+	// so backfill it from the typed config when the caller only sent the config.
+	if len(c.Values) == 0 {
+		switch {
+		case c.PathPatternConfig != nil:
+			c.Values = c.PathPatternConfig.Values
+		case c.HostHeaderConfig != nil:
+			c.Values = c.HostHeaderConfig.Values
+		}
+	}
+
+	return c
+}
+
+// parseHTTPHeaderConfig parses an HttpHeaderConfig sub-structure, returning nil
+// when absent.
+func parseHTTPHeaderConfig(form url.Values, base string) *lbdriver.HTTPHeaderConditionConfig {
+	name := form.Get(base + ".HttpHeaderName")
+	values := awsquery.ListStrings(form, base+".Values.member")
+
+	if name == "" && len(values) == 0 {
+		return nil
+	}
+
+	return &lbdriver.HTTPHeaderConditionConfig{HTTPHeaderName: name, Values: values}
+}
+
+// parseQueryStringConfig parses a QueryStringConfig sub-structure (a list of
+// key/value pairs), returning nil when absent.
+func parseQueryStringConfig(form url.Values, base string) *lbdriver.QueryStringConditionConfig {
+	indices := awsquery.CollectIndices(form, base+".Values.member")
+	if len(indices) == 0 {
+		return nil
+	}
+
+	pairs := make([]lbdriver.QueryStringKeyValue, 0, len(indices))
+	for _, n := range indices {
+		p := base + ".Values.member." + strconv.Itoa(n)
+		pairs = append(pairs, lbdriver.QueryStringKeyValue{
+			Key:   form.Get(p + ".Key"),
+			Value: form.Get(p + ".Value"),
+		})
+	}
+
+	return &lbdriver.QueryStringConditionConfig{Values: pairs}
 }
 
 // parseTargets parses a Targets member list into driver Targets.
@@ -688,17 +747,65 @@ func toRuleXML(rule *lbdriver.RuleInfo) ruleXML {
 
 	if len(rule.Conditions) > 0 {
 		conds := &ruleConditionsXML{}
-		for _, c := range rule.Conditions {
-			conds.Member = append(conds.Member, ruleConditionXML{
-				Field:  c.Field,
-				Values: &stringListXML{Member: c.Values},
-			})
+		for i := range rule.Conditions {
+			conds.Member = append(conds.Member, toConditionXML(rule.Conditions[i]))
 		}
 
 		out.Conditions = conds
 	}
 
 	out.Actions = toActionsXML(rule.Actions)
+
+	return out
+}
+
+// toConditionXML renders a driver rule condition, echoing both the deprecated
+// flat Values and whichever typed config the condition carries.
+//
+//nolint:gocritic // hugeParam: value receiver keeps the call site simple; copy cost is negligible.
+func toConditionXML(c lbdriver.RuleCondition) ruleConditionXML {
+	x := ruleConditionXML{Field: c.Field}
+
+	if len(c.Values) > 0 {
+		x.Values = &stringListXML{Member: c.Values}
+	}
+
+	if c.HostHeaderConfig != nil {
+		x.HostHeaderConfig = &valuesConfigXML{Values: &stringListXML{Member: c.HostHeaderConfig.Values}}
+	}
+
+	if c.PathPatternConfig != nil {
+		x.PathPatternConfig = &valuesConfigXML{Values: &stringListXML{Member: c.PathPatternConfig.Values}}
+	}
+
+	if c.SourceIPConfig != nil {
+		x.SourceIPConfig = &valuesConfigXML{Values: &stringListXML{Member: c.SourceIPConfig.Values}}
+	}
+
+	if c.HTTPRequestMethodConfig != nil {
+		x.HTTPRequestMethodConfig = &valuesConfigXML{Values: &stringListXML{Member: c.HTTPRequestMethodConfig.Values}}
+	}
+
+	if hc := c.HTTPHeaderConfig; hc != nil {
+		x.HTTPHeaderConfig = &httpHeaderConfigXML{
+			HTTPHeaderName: hc.HTTPHeaderName,
+			Values:         &stringListXML{Member: hc.Values},
+		}
+	}
+
+	if qc := c.QueryStringConfig; qc != nil {
+		x.QueryStringConfig = toQueryStringConfigXML(qc)
+	}
+
+	return x
+}
+
+// toQueryStringConfigXML renders a query-string condition's key/value pairs.
+func toQueryStringConfigXML(qc *lbdriver.QueryStringConditionConfig) *queryStringConfigXML {
+	out := &queryStringConfigXML{Values: &queryStringValuesXML{}}
+	for _, kv := range qc.Values {
+		out.Values.Member = append(out.Values.Member, queryStringKVXML{Key: kv.Key, Value: kv.Value})
+	}
 
 	return out
 }

--- a/server/aws/elbv2/operations.go
+++ b/server/aws/elbv2/operations.go
@@ -646,6 +646,7 @@ func parseQueryStringConfig(form url.Values, base string) *lbdriver.QueryStringC
 	}
 
 	pairs := make([]lbdriver.QueryStringKeyValue, 0, len(indices))
+
 	for _, n := range indices {
 		p := base + ".Values.member." + strconv.Itoa(n)
 		pairs = append(pairs, lbdriver.QueryStringKeyValue{

--- a/server/aws/elbv2/operations.go
+++ b/server/aws/elbv2/operations.go
@@ -242,7 +242,7 @@ func (h *Handler) createListener(w http.ResponseWriter, r *http.Request) {
 		LBARN:          form.Get("LoadBalancerArn"),
 		Protocol:       form.Get("Protocol"),
 		Port:           formInt(form.Get("Port")),
-		TargetGroupARN: firstForwardTargetGroup(form, "DefaultActions.member"),
+		DefaultActions: parseActions(form, "DefaultActions.member"),
 	}
 
 	li, err := h.lb.CreateListener(r.Context(), cfg)
@@ -473,22 +473,9 @@ func parseTags(form url.Values) map[string]string {
 	return out
 }
 
-// firstForwardTargetGroup returns the TargetGroupArn of the first forward
-// action in the given action-list prefix, checking both the flat form
-// (member.N.TargetGroupArn) and the ForwardConfig shape.
-func firstForwardTargetGroup(form url.Values, prefix string) string {
-	for _, a := range parseActions(form, prefix) {
-		if a.TargetGroupARN != "" {
-			return a.TargetGroupARN
-		}
-	}
-
-	return ""
-}
-
 // parseActions parses an Actions/DefaultActions member list into driver
-// RuleActions. Both the flat TargetGroupArn field and the
-// ForwardConfig.TargetGroups.member.N.TargetGroupArn nesting are accepted.
+// RuleActions, preserving the full shape of forward, redirect and
+// fixed-response actions so they round-trip on Describe.
 func parseActions(form url.Values, prefix string) []lbdriver.RuleAction {
 	indices := awsquery.CollectIndices(form, prefix)
 	if len(indices) == 0 {
@@ -496,22 +483,64 @@ func parseActions(form url.Values, prefix string) []lbdriver.RuleAction {
 	}
 
 	out := make([]lbdriver.RuleAction, 0, len(indices))
-
 	for _, n := range indices {
-		base := prefix + "." + strconv.Itoa(n)
-
-		tgARN := form.Get(base + ".TargetGroupArn")
-		if tgARN == "" {
-			tgARN = form.Get(base + ".ForwardConfig.TargetGroups.member.1.TargetGroupArn")
-		}
-
-		out = append(out, lbdriver.RuleAction{
-			Type:           typeOr(form.Get(base+".Type"), "forward"),
-			TargetGroupARN: tgARN,
-		})
+		out = append(out, parseAction(form, prefix+"."+strconv.Itoa(n)))
 	}
 
 	return out
+}
+
+// parseAction parses a single action at the given form prefix. Both the flat
+// TargetGroupArn field and the ForwardConfig.TargetGroups.member.N nesting are
+// accepted for forward actions.
+func parseAction(form url.Values, base string) lbdriver.RuleAction {
+	tgARN := form.Get(base + ".TargetGroupArn")
+	if tgARN == "" {
+		tgARN = form.Get(base + ".ForwardConfig.TargetGroups.member.1.TargetGroupArn")
+	}
+
+	return lbdriver.RuleAction{
+		Type:                typeOr(form.Get(base+".Type"), "forward"),
+		TargetGroupARN:      tgARN,
+		Order:               formInt(form.Get(base + ".Order")),
+		RedirectConfig:      parseRedirectConfig(form, base+".RedirectConfig"),
+		FixedResponseConfig: parseFixedResponseConfig(form, base+".FixedResponseConfig"),
+	}
+}
+
+// parseRedirectConfig parses a RedirectConfig sub-structure, returning nil when
+// none of its fields are present.
+func parseRedirectConfig(form url.Values, base string) *lbdriver.RedirectActionConfig {
+	rc := lbdriver.RedirectActionConfig{
+		Protocol:   form.Get(base + ".Protocol"),
+		Port:       form.Get(base + ".Port"),
+		Host:       form.Get(base + ".Host"),
+		Path:       form.Get(base + ".Path"),
+		Query:      form.Get(base + ".Query"),
+		StatusCode: form.Get(base + ".StatusCode"),
+	}
+
+	if rc == (lbdriver.RedirectActionConfig{}) {
+		return nil
+	}
+
+	return &rc
+}
+
+// parseFixedResponseConfig parses a FixedResponseConfig sub-structure, returning
+// nil when none of its fields are present.
+func parseFixedResponseConfig(form url.Values, base string) *lbdriver.FixedResponseActionConfig {
+	fr := lbdriver.FixedResponseActionConfig{
+		StatusCode:  form.Get(base + ".StatusCode"),
+		ContentType: form.Get(base + ".ContentType"),
+		MessageBody: form.Get(base + ".MessageBody"),
+	}
+
+	if fr == (lbdriver.FixedResponseActionConfig{}) {
+		return nil
+	}
+
+	return &fr
 }
 
 // parseConditions parses a Conditions member list into driver RuleConditions.
@@ -644,17 +673,7 @@ func toRuleXML(rule *lbdriver.RuleInfo) ruleXML {
 		out.Conditions = conds
 	}
 
-	if len(rule.Actions) > 0 {
-		acts := &actionsXML{}
-		for _, a := range rule.Actions {
-			acts.Member = append(acts.Member, actionXML{
-				Type:           a.Type,
-				TargetGroupArn: a.TargetGroupARN,
-			})
-		}
-
-		out.Actions = acts
-	}
+	out.Actions = toActionsXML(rule.Actions)
 
 	return out
 }

--- a/server/aws/elbv2/rule_conditions_sdk_test.go
+++ b/server/aws/elbv2/rule_conditions_sdk_test.go
@@ -1,0 +1,106 @@
+package elbv2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
+// TestSDKRuleConditionsRoundTrip proves the typed rule conditions
+// (http-header, query-string, source-ip) survive CreateRule -> DescribeRules
+// instead of being flattened away.
+func TestSDKRuleConditionsRoundTrip(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN, tgARN := setupLBAndTG(t, client, "cond-alb", "cond-tg")
+
+	liOut, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	liARN := aws.ToString(liOut.Listeners[0].ListenerArn)
+
+	createdRule, err := client.CreateRule(ctx, &elb.CreateRuleInput{
+		ListenerArn: aws.String(liARN),
+		Priority:    aws.Int32(10),
+		Conditions: []elbtypes.RuleCondition{
+			{
+				Field: aws.String("http-header"),
+				HttpHeaderConfig: &elbtypes.HttpHeaderConditionConfig{
+					HttpHeaderName: aws.String("X-Custom"),
+					Values:         []string{"v1", "v2"},
+				},
+			},
+			{
+				Field: aws.String("query-string"),
+				QueryStringConfig: &elbtypes.QueryStringConditionConfig{
+					Values: []elbtypes.QueryStringKeyValuePair{
+						{Key: aws.String("env"), Value: aws.String("prod")},
+					},
+				},
+			},
+			{
+				Field: aws.String("source-ip"),
+				SourceIpConfig: &elbtypes.SourceIpConditionConfig{
+					Values: []string{"10.0.0.0/8"},
+				},
+			},
+		},
+		Actions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	ruleARN := aws.ToString(createdRule.Rules[0].RuleArn)
+
+	desc, err := client.DescribeRules(ctx, &elb.DescribeRulesInput{ListenerArn: aws.String(liARN)})
+	if err != nil {
+		t.Fatalf("DescribeRules: %v", err)
+	}
+
+	var conds []elbtypes.RuleCondition
+	for _, r := range desc.Rules {
+		if aws.ToString(r.RuleArn) == ruleARN {
+			conds = r.Conditions
+		}
+	}
+
+	byField := map[string]elbtypes.RuleCondition{}
+	for _, c := range conds {
+		byField[aws.ToString(c.Field)] = c
+	}
+
+	hh := byField["http-header"].HttpHeaderConfig
+	if hh == nil || aws.ToString(hh.HttpHeaderName) != "X-Custom" ||
+		len(hh.Values) != 2 || hh.Values[0] != "v1" {
+		t.Fatalf("http-header config = %+v, want X-Custom/[v1 v2]", hh)
+	}
+
+	qs := byField["query-string"].QueryStringConfig
+	if qs == nil || len(qs.Values) != 1 ||
+		aws.ToString(qs.Values[0].Key) != "env" || aws.ToString(qs.Values[0].Value) != "prod" {
+		t.Fatalf("query-string config = %+v, want env=prod", qs)
+	}
+
+	sip := byField["source-ip"].SourceIpConfig
+	if sip == nil || len(sip.Values) != 1 || sip.Values[0] != "10.0.0.0/8" {
+		t.Fatalf("source-ip config = %+v, want [10.0.0.0/8]", sip)
+	}
+}

--- a/server/aws/elbv2/types.go
+++ b/server/aws/elbv2/types.go
@@ -225,9 +225,39 @@ type deleteListenerResponse struct {
 
 // --- rules ---
 
-type ruleConditionXML struct {
-	Field  string         `xml:"Field,omitempty"`
+// valuesConfigXML is the shared shape of the condition configs that carry only
+// a Values list (host-header, path-pattern, source-ip, http-request-method).
+type valuesConfigXML struct {
 	Values *stringListXML `xml:"Values,omitempty"`
+}
+
+type httpHeaderConfigXML struct {
+	HTTPHeaderName string         `xml:"HttpHeaderName,omitempty"`
+	Values         *stringListXML `xml:"Values,omitempty"`
+}
+
+type queryStringKVXML struct {
+	Key   string `xml:"Key,omitempty"`
+	Value string `xml:"Value,omitempty"`
+}
+
+type queryStringValuesXML struct {
+	Member []queryStringKVXML `xml:"member,omitempty"`
+}
+
+type queryStringConfigXML struct {
+	Values *queryStringValuesXML `xml:"Values,omitempty"`
+}
+
+type ruleConditionXML struct {
+	Field                   string                `xml:"Field,omitempty"`
+	Values                  *stringListXML        `xml:"Values,omitempty"`
+	HostHeaderConfig        *valuesConfigXML      `xml:"HostHeaderConfig,omitempty"`
+	PathPatternConfig       *valuesConfigXML      `xml:"PathPatternConfig,omitempty"`
+	HTTPHeaderConfig        *httpHeaderConfigXML  `xml:"HttpHeaderConfig,omitempty"`
+	QueryStringConfig       *queryStringConfigXML `xml:"QueryStringConfig,omitempty"`
+	SourceIPConfig          *valuesConfigXML      `xml:"SourceIpConfig,omitempty"`
+	HTTPRequestMethodConfig *valuesConfigXML      `xml:"HttpRequestMethodConfig,omitempty"`
 }
 
 type ruleConditionsXML struct {

--- a/server/aws/elbv2/types.go
+++ b/server/aws/elbv2/types.go
@@ -148,10 +148,27 @@ type deleteTargetGroupResponse struct {
 
 // --- listener / actions ---
 
+type redirectConfigXML struct {
+	Protocol   string `xml:"Protocol,omitempty"`
+	Port       string `xml:"Port,omitempty"`
+	Host       string `xml:"Host,omitempty"`
+	Path       string `xml:"Path,omitempty"`
+	Query      string `xml:"Query,omitempty"`
+	StatusCode string `xml:"StatusCode,omitempty"`
+}
+
+type fixedResponseConfigXML struct {
+	StatusCode  string `xml:"StatusCode,omitempty"`
+	ContentType string `xml:"ContentType,omitempty"`
+	MessageBody string `xml:"MessageBody,omitempty"`
+}
+
 type actionXML struct {
-	Type           string `xml:"Type"`
-	TargetGroupArn string `xml:"TargetGroupArn,omitempty"`
-	Order          int    `xml:"Order,omitempty"`
+	Type                string                  `xml:"Type"`
+	TargetGroupArn      string                  `xml:"TargetGroupArn,omitempty"`
+	Order               int                     `xml:"Order,omitempty"`
+	RedirectConfig      *redirectConfigXML      `xml:"RedirectConfig,omitempty"`
+	FixedResponseConfig *fixedResponseConfigXML `xml:"FixedResponseConfig,omitempty"`
 }
 
 type actionsXML struct {
@@ -369,24 +386,63 @@ func toTargetGroupXML(tg *lbdriver.TargetGroupInfo) targetGroupXML {
 	return out
 }
 
-// toListenerXML converts a driver ListenerInfo to its XML representation. The
-// forward-to-target-group default action is reconstructed from the stored
-// TargetGroupARN.
+// toListenerXML converts a driver ListenerInfo to its XML representation,
+// echoing every stored default action (forward, redirect, fixed-response) so a
+// listener round-trips exactly what it was created with.
 func toListenerXML(li *lbdriver.ListenerInfo) listenerXML {
-	out := listenerXML{
+	return listenerXML{
 		ListenerArn:     li.ARN,
 		LoadBalancerArn: li.LBARN,
 		Protocol:        li.Protocol,
 		Port:            li.Port,
+		DefaultActions:  toActionsXML(li.DefaultActions),
+	}
+}
+
+// toActionsXML renders a driver action slice as ELBv2 action members, or nil
+// when there are none. Shared by listener default actions and rule actions.
+func toActionsXML(actions []lbdriver.RuleAction) *actionsXML {
+	if len(actions) == 0 {
+		return nil
 	}
 
-	if li.TargetGroupARN != "" {
-		out.DefaultActions = &actionsXML{Member: []actionXML{{
-			Type:           "forward",
-			TargetGroupArn: li.TargetGroupARN,
-			Order:          1,
-		}}}
+	out := &actionsXML{Member: make([]actionXML, 0, len(actions))}
+	for i := range actions {
+		out.Member = append(out.Member, toActionXML(actions[i]))
 	}
 
 	return out
+}
+
+// toActionXML renders a single driver action, preserving redirect and
+// fixed-response configuration.
+//
+//nolint:gocritic // hugeParam: value receiver keeps the call site simple; copy cost is negligible.
+func toActionXML(a lbdriver.RuleAction) actionXML {
+	x := actionXML{
+		Type:           a.Type,
+		TargetGroupArn: a.TargetGroupARN,
+		Order:          a.Order,
+	}
+
+	if rc := a.RedirectConfig; rc != nil {
+		x.RedirectConfig = &redirectConfigXML{
+			Protocol:   rc.Protocol,
+			Port:       rc.Port,
+			Host:       rc.Host,
+			Path:       rc.Path,
+			Query:      rc.Query,
+			StatusCode: rc.StatusCode,
+		}
+	}
+
+	if fr := a.FixedResponseConfig; fr != nil {
+		x.FixedResponseConfig = &fixedResponseConfigXML{
+			StatusCode:  fr.StatusCode,
+			ContentType: fr.ContentType,
+			MessageBody: fr.MessageBody,
+		}
+	}
+
+	return x
 }

--- a/server/aws/elbv2/types.go
+++ b/server/aws/elbv2/types.go
@@ -175,12 +175,23 @@ type actionsXML struct {
 	Member []actionXML `xml:"member,omitempty"`
 }
 
+type certificateXML struct {
+	CertificateArn string `xml:"CertificateArn,omitempty"`
+	IsDefault      bool   `xml:"IsDefault,omitempty"`
+}
+
+type certificatesXML struct {
+	Member []certificateXML `xml:"member,omitempty"`
+}
+
 type listenerXML struct {
-	ListenerArn     string      `xml:"ListenerArn"`
-	LoadBalancerArn string      `xml:"LoadBalancerArn,omitempty"`
-	Protocol        string      `xml:"Protocol,omitempty"`
-	Port            int         `xml:"Port,omitempty"`
-	DefaultActions  *actionsXML `xml:"DefaultActions,omitempty"`
+	ListenerArn     string           `xml:"ListenerArn"`
+	LoadBalancerArn string           `xml:"LoadBalancerArn,omitempty"`
+	Protocol        string           `xml:"Protocol,omitempty"`
+	Port            int              `xml:"Port,omitempty"`
+	SslPolicy       string           `xml:"SslPolicy,omitempty"`
+	Certificates    *certificatesXML `xml:"Certificates,omitempty"`
+	DefaultActions  *actionsXML      `xml:"DefaultActions,omitempty"`
 }
 
 type listenersXML struct {
@@ -395,8 +406,27 @@ func toListenerXML(li *lbdriver.ListenerInfo) listenerXML {
 		LoadBalancerArn: li.LBARN,
 		Protocol:        li.Protocol,
 		Port:            li.Port,
+		SslPolicy:       li.SslPolicy,
+		Certificates:    toCertificatesXML(li.Certificates),
 		DefaultActions:  toActionsXML(li.DefaultActions),
 	}
+}
+
+// toCertificatesXML renders a listener's certificate list, or nil when empty.
+func toCertificatesXML(certs []lbdriver.Certificate) *certificatesXML {
+	if len(certs) == 0 {
+		return nil
+	}
+
+	out := &certificatesXML{Member: make([]certificateXML, 0, len(certs))}
+	for _, c := range certs {
+		out.Member = append(out.Member, certificateXML{
+			CertificateArn: c.CertificateArn,
+			IsDefault:      c.IsDefault,
+		})
+	}
+
+	return out
 }
 
 // toActionsXML renders a driver action slice as ELBv2 action members, or nil

--- a/server/aws/elbv2/types.go
+++ b/server/aws/elbv2/types.go
@@ -476,8 +476,6 @@ func toActionsXML(actions []lbdriver.RuleAction) *actionsXML {
 
 // toActionXML renders a single driver action, preserving redirect and
 // fixed-response configuration.
-//
-//nolint:gocritic // hugeParam: value receiver keeps the call site simple; copy cost is negligible.
 func toActionXML(a lbdriver.RuleAction) actionXML {
 	x := actionXML{
 		Type:           a.Type,

--- a/services/loadbalancer/driver/driver.go
+++ b/services/loadbalancer/driver/driver.go
@@ -110,20 +110,28 @@ type RulePriorityPair struct {
 }
 
 // ListenerConfig describes a listener to create.
+//
+// DefaultActions carries the full ELBv2 default-action list (forward, redirect,
+// fixed-response), which AWS round-trips verbatim. TargetGroupARN is the simple
+// single-forward shortcut the Azure/GCP providers use; AWS ignores it in favor
+// of DefaultActions.
 type ListenerConfig struct {
 	LBARN          string
 	Protocol       string
 	Port           int
 	TargetGroupARN string
+	DefaultActions []RuleAction
 }
 
-// ListenerInfo describes a listener.
+// ListenerInfo describes a listener. See ListenerConfig for the relationship
+// between TargetGroupARN and DefaultActions.
 type ListenerInfo struct {
 	ARN            string
 	LBARN          string
 	Protocol       string
 	Port           int
 	TargetGroupARN string
+	DefaultActions []RuleAction
 }
 
 // RuleCondition describes a condition for a listener rule (e.g., path-pattern or host-header).
@@ -132,10 +140,36 @@ type RuleCondition struct {
 	Values []string
 }
 
-// RuleAction describes an action for a listener rule (e.g., forward to a target group).
+// RuleAction describes an action for a listener default action or a listener
+// rule. AWS supports several action types; the emulator round-trips the two
+// terminating non-forward actions (redirect, fixed-response) in full alongside
+// forward, so the common HTTP->HTTPS redirect and custom fixed-response
+// patterns survive a create/describe cycle instead of being silently dropped.
 type RuleAction struct {
-	Type           string // "forward"
-	TargetGroupARN string
+	Type                string // "forward", "redirect", "fixed-response", "authenticate-cognito", "authenticate-oidc"
+	TargetGroupARN      string
+	Order               int
+	RedirectConfig      *RedirectActionConfig
+	FixedResponseConfig *FixedResponseActionConfig
+}
+
+// RedirectActionConfig is the configuration of a "redirect" action. AWS requires
+// StatusCode (HTTP_301 or HTTP_302); the remaining fields default to the
+// "#{...}" pass-through tokens when unset.
+type RedirectActionConfig struct {
+	Protocol   string
+	Port       string
+	Host       string
+	Path       string
+	Query      string
+	StatusCode string
+}
+
+// FixedResponseActionConfig is the configuration of a "fixed-response" action.
+type FixedResponseActionConfig struct {
+	StatusCode  string
+	ContentType string
+	MessageBody string
 }
 
 // RuleConfig describes a listener rule to create.

--- a/services/loadbalancer/driver/driver.go
+++ b/services/loadbalancer/driver/driver.go
@@ -121,6 +121,9 @@ type ListenerConfig struct {
 	Port           int
 	TargetGroupARN string
 	DefaultActions []RuleAction
+	// SslPolicy and Certificates apply to TLS-terminating (HTTPS/TLS) listeners.
+	SslPolicy    string
+	Certificates []Certificate
 }
 
 // ListenerInfo describes a listener. See ListenerConfig for the relationship
@@ -132,6 +135,15 @@ type ListenerInfo struct {
 	Port           int
 	TargetGroupARN string
 	DefaultActions []RuleAction
+	SslPolicy      string
+	Certificates   []Certificate
+}
+
+// Certificate is a server certificate bound to an HTTPS/TLS listener. The
+// listener's default certificate has IsDefault set.
+type Certificate struct {
+	CertificateArn string
+	IsDefault      bool
 }
 
 // RuleCondition describes a condition for a listener rule (e.g., path-pattern or host-header).
@@ -190,12 +202,15 @@ type RuleInfo struct {
 	IsDefault   bool
 }
 
-// ModifyListenerInput describes modifications to apply to a listener.
+// ModifyListenerInput describes modifications to apply to a listener. A
+// zero/empty field means "leave unchanged".
 type ModifyListenerInput struct {
 	ListenerARN    string
 	Port           int
 	Protocol       string
 	DefaultActions []RuleAction
+	SslPolicy      string
+	Certificates   []Certificate
 }
 
 // LBAttributes describes configurable attributes of a load balancer.

--- a/services/loadbalancer/driver/driver.go
+++ b/services/loadbalancer/driver/driver.go
@@ -146,9 +146,56 @@ type Certificate struct {
 	IsDefault      bool
 }
 
-// RuleCondition describes a condition for a listener rule (e.g., path-pattern or host-header).
+// RuleCondition describes a condition for a listener rule. Field names the
+// condition type; Values carries the deprecated flat value list AWS still
+// echoes for path-pattern/host-header, while the typed *Config pointers carry
+// the full shape of each condition (host-header, path-pattern, http-header,
+// query-string, source-ip, http-request-method) so they round-trip on Describe.
 type RuleCondition struct {
-	Field  string // "path-pattern" or "host-header"
+	Field                   string
+	Values                  []string
+	HostHeaderConfig        *HostHeaderConditionConfig
+	PathPatternConfig       *PathPatternConditionConfig
+	HTTPHeaderConfig        *HTTPHeaderConditionConfig
+	QueryStringConfig       *QueryStringConditionConfig
+	SourceIPConfig          *SourceIPConditionConfig
+	HTTPRequestMethodConfig *HTTPRequestMethodConditionConfig
+}
+
+// HostHeaderConditionConfig matches the request Host header against patterns.
+type HostHeaderConditionConfig struct {
+	Values []string
+}
+
+// PathPatternConditionConfig matches the request path against patterns.
+type PathPatternConditionConfig struct {
+	Values []string
+}
+
+// HTTPHeaderConditionConfig matches a named HTTP header against patterns.
+type HTTPHeaderConditionConfig struct {
+	HTTPHeaderName string
+	Values         []string
+}
+
+// QueryStringConditionConfig matches query-string key/value pairs.
+type QueryStringConditionConfig struct {
+	Values []QueryStringKeyValue
+}
+
+// QueryStringKeyValue is one query-string key/value pattern.
+type QueryStringKeyValue struct {
+	Key   string
+	Value string
+}
+
+// SourceIPConditionConfig matches the source IP against CIDRs.
+type SourceIPConditionConfig struct {
+	Values []string
+}
+
+// HTTPRequestMethodConditionConfig matches the HTTP request method.
+type HTTPRequestMethodConditionConfig struct {
 	Values []string
 }
 

--- a/services/loadbalancer/loadbalancer.go
+++ b/services/loadbalancer/loadbalancer.go
@@ -131,6 +131,7 @@ func (lb *LB) DescribeTargetGroups(ctx context.Context, arns []string) ([]driver
 	return out.([]driver.TargetGroupInfo), nil
 }
 
+//nolint:gocritic // config passed by value to match driver.LoadBalancer interface pattern
 func (lb *LB) CreateListener(ctx context.Context, config driver.ListenerConfig) (*driver.ListenerInfo, error) {
 	out, err := lb.do(ctx, "CreateListener", config, func() (any, error) { return lb.driver.CreateListener(ctx, config) })
 	if err != nil {
@@ -177,6 +178,7 @@ func (lb *LB) DescribeRules(ctx context.Context, listenerARN string) ([]driver.R
 	return out.([]driver.RuleInfo), nil
 }
 
+//nolint:gocritic // input passed by value to match driver.LoadBalancer interface pattern
 func (lb *LB) ModifyListener(ctx context.Context, input driver.ModifyListenerInput) error {
 	_, err := lb.do(ctx, "ModifyListener", input, func() (any, error) { return nil, lb.driver.ModifyListener(ctx, input) })
 	return err


### PR DESCRIPTION
## What

Fixes six AWS ELBv2 correctness bugs found by a deep real-user (aws-sdk-go-v2) e2e audit. All were empirically reproduced and each is verified against the official ELBv2 API reference.

- **deletion_protection honored** — `DeleteLoadBalancer` ignored `deletion_protection.enabled`, silently wiping a protected load balancer (data loss; the exact scenario a `terraform destroy` hits). It now rejects the delete with `OperationNotPermitted` while a missing ARN stays idempotent. Delete also cascades the rules under the LB's listeners and drops stored LB attributes (was an in-memory leak).
- **Redirect / fixed-response default actions round-trip** — the listener stored only a single forward `TargetGroupArn`, so a `redirect` or `fixed-response` default action was silently dropped. The HTTP→HTTPS redirect (the most common ALB pattern) came back with an empty `default_action` → permanent Terraform drift. The listener now stores the full default-action list and the wire layer parses/echoes forward, redirect and fixed-response actions verbatim.
- **HTTPS `SslPolicy` + `Certificates` round-trip** — both were parsed off the request but never stored; Describe returned them empty. Now stored and echoed, with the create certificate marked `IsDefault=true` as real ELBv2 does.
- **`SetRulePriorities` uniqueness** — the reorder path had no collision check, so two rules on one listener could share a priority (silent routing corruption). It now validates each requested priority against the listener's other rules (and within the batch) before any write, returning `PriorityInUse`; a same-batch swap stays allowed.
- **Typed rule conditions round-trip** — a condition stored only `Field` + a flat `Values` list, so `http-header` / `query-string` / `source-ip` conditions lost their typed config on Create→Describe. `RuleCondition` now carries the full typed config for host-header, path-pattern, http-header, query-string, source-ip and http-request-method.
- **LoadBalancer `VpcId` populated (F6 fixed, not deferred)** — `VpcId` came back empty. The ELB mock now derives it from the member subnets via a `SubnetResolver` wired to the VPC mock in the AWS factory — the same cross-service pattern RDS/ElastiCache/EC2 already use. Unwired, the field stays empty rather than failing.

Extras included: DeleteLoadBalancer rule + attribute orphan cleanup (F11).

## Why

Each bug causes real data loss or permanent IaC drift against unmodified SDK/Terraform code. Behaviors cross-checked against the official AWS ELBv2 API docs (DeleteLoadBalancer → OperationNotPermitted; RedirectActionConfig required StatusCode HTTP_301/HTTP_302; SetRulePriorities → PriorityInUse).

## Notes on the shared driver

The `loadbalancer` driver is shared by Azure/GCP. To keep this PR AWS-scoped and non-breaking, `ListenerConfig`/`ListenerInfo` keep the simple single-forward `TargetGroupARN` field (used by the Azure/GCP providers) and gain the full `DefaultActions` list that AWS uses.

## Tests

Real aws-sdk-go-v2 reproductions for every fix (deletion-protection block+clear, redirect + fixed-response round-trip, HTTPS certs/SslPolicy, SetRulePriorities PriorityInUse + swap, http-header/query-string/source-ip conditions, VpcId from subnets) plus provider-level tests. Existing ELB tests remain green. Coverage docs regenerate with zero diff (interface methods unchanged).
