### PR TITLE
fix(aws-route53): NoSuchHostedZone on missing-zone change; DNS reversed-label ordering; FQDN normalization; persist CallerReference/Comment; reject apex CNAME; exact-match DELETE

### DIFF
--- a/features/topology/resolve.go
+++ b/features/topology/resolve.go
@@ -25,7 +25,10 @@ func (e *Engine) Resolve(ctx context.Context, hostname string) ([]string, error)
 		}
 
 		for _, rec := range records {
-			if rec.Name == hostname && isResolvableType(rec.Type) {
+			// Route 53 stores record names as FQDNs (trailing dot) while a query
+			// hostname may omit it, so compare trailing-dot-insensitively.
+			if strings.TrimSuffix(rec.Name, ".") == strings.TrimSuffix(hostname, ".") &&
+				isResolvableType(rec.Type) {
 				return rec.Values, nil
 			}
 		}

--- a/providers/aws/route53/route53.go
+++ b/providers/aws/route53/route53.go
@@ -133,6 +133,7 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 		RecordCount:     0,
 		Tags:            tags,
 		CallerReference: cfg.CallerReference,
+		Comment:         cfg.Comment,
 		Scope:           cfg.Scope,
 	}
 

--- a/providers/aws/route53/route53.go
+++ b/providers/aws/route53/route53.go
@@ -127,12 +127,13 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 	}
 
 	zone := driver.ZoneInfo{
-		ID:          id,
-		Name:        cfg.Name,
-		Private:     cfg.Private,
-		RecordCount: 0,
-		Tags:        tags,
-		Scope:       cfg.Scope,
+		ID:              id,
+		Name:            cfg.Name,
+		Private:         cfg.Private,
+		RecordCount:     0,
+		Tags:            tags,
+		CallerReference: cfg.CallerReference,
+		Scope:           cfg.Scope,
 	}
 
 	m.zones.Set(id, zone)

--- a/server/aws/route53/apex_cname_test.go
+++ b/server/aws/route53/apex_cname_test.go
@@ -1,0 +1,62 @@
+package route53_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+// TestSDKApexCNAMERejected locks that a CNAME at the zone apex is rejected with
+// InvalidChangeBatch, as real Route 53 does — the apex must use A/AAAA or an
+// ALIAS, since it carries the SOA and NS records.
+func TestSDKApexCNAMERejected(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	created, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("apex-cname.com."),
+		CallerReference: aws.String("apex-ref"),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+	zoneID := aws.ToString(created.HostedZone.Id)
+
+	_, err = client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{Changes: []r53types.Change{{
+			Action: r53types.ChangeActionCreate,
+			ResourceRecordSet: &r53types.ResourceRecordSet{
+				Name:            aws.String("apex-cname.com."),
+				Type:            r53types.RRTypeCname,
+				TTL:             aws.Int64(300),
+				ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("target.example.com.")}},
+			},
+		}}},
+	})
+
+	var badBatch *r53types.InvalidChangeBatch
+	if !errors.As(err, &badBatch) {
+		t.Fatalf("apex CNAME: got %v, want InvalidChangeBatch", err)
+	}
+
+	// A CNAME below the apex is fine.
+	if _, cerr := client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{Changes: []r53types.Change{{
+			Action: r53types.ChangeActionCreate,
+			ResourceRecordSet: &r53types.ResourceRecordSet{
+				Name:            aws.String("www.apex-cname.com."),
+				Type:            r53types.RRTypeCname,
+				TTL:             aws.Int64(300),
+				ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("target.example.com.")}},
+			},
+		}}},
+	}); cerr != nil {
+		t.Fatalf("non-apex CNAME should be accepted, got: %v", cerr)
+	}
+}

--- a/server/aws/route53/caller_reference_test.go
+++ b/server/aws/route53/caller_reference_test.go
@@ -1,0 +1,51 @@
+package route53_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+)
+
+// TestSDKCallerReferencePersisted locks that the caller-supplied CallerReference
+// is persisted and returned verbatim on GetHostedZone and ListHostedZones — the
+// pre-fix bug returned the zone name instead.
+func TestSDKCallerReferencePersisted(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	created, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("cref.com."),
+		CallerReference: aws.String("my-idempotency-token-42"),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+	zoneID := aws.ToString(created.HostedZone.Id)
+
+	got, err := client.GetHostedZone(ctx, &awsr53.GetHostedZoneInput{Id: aws.String(zoneID)})
+	if err != nil {
+		t.Fatalf("GetHostedZone: %v", err)
+	}
+	if ref := aws.ToString(got.HostedZone.CallerReference); ref != "my-idempotency-token-42" {
+		t.Fatalf("GetHostedZone CallerReference = %q, want my-idempotency-token-42", ref)
+	}
+
+	list, err := client.ListHostedZones(ctx, &awsr53.ListHostedZonesInput{})
+	if err != nil {
+		t.Fatalf("ListHostedZones: %v", err)
+	}
+	var found bool
+	for i := range list.HostedZones {
+		if aws.ToString(list.HostedZones[i].Id) == zoneID {
+			found = true
+			if ref := aws.ToString(list.HostedZones[i].CallerReference); ref != "my-idempotency-token-42" {
+				t.Fatalf("ListHostedZones CallerReference = %q, want my-idempotency-token-42", ref)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("created zone not present in ListHostedZones")
+	}
+}

--- a/server/aws/route53/change.go
+++ b/server/aws/route53/change.go
@@ -128,7 +128,9 @@ func (h *Handler) testDNSAnswer(w http.ResponseWriter, r *http.Request) {
 
 	q := r.URL.Query()
 	zoneID := trimZonePrefix(q.Get("hostedzoneid"))
-	name := q.Get("recordname")
+	// Records are stored as FQDNs, so normalize the queried name to a trailing
+	// dot to match whether the client sent it dotted or not.
+	name := ensureTrailingDot(q.Get("recordname"))
 	rtype := q.Get("recordtype")
 
 	resp := testDNSAnswerResponse{

--- a/server/aws/route53/delete_exact_match_test.go
+++ b/server/aws/route53/delete_exact_match_test.go
@@ -1,0 +1,101 @@
+package route53_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+// TestSDKDeleteRequiresExactMatch locks that a DELETE must repeat the record
+// set's exact TTL and values: a mismatched DELETE is rejected with
+// InvalidChangeBatch (leaving the record intact), and an exact-match DELETE
+// succeeds. This mirrors real Route 53's concurrent-modification guard.
+func TestSDKDeleteRequiresExactMatch(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	created, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("delmatch.com."),
+		CallerReference: aws.String("del-ref"),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+	zoneID := aws.ToString(created.HostedZone.Id)
+
+	if _, cerr := client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{Changes: []r53types.Change{{
+			Action: r53types.ChangeActionCreate,
+			ResourceRecordSet: &r53types.ResourceRecordSet{
+				Name:            aws.String("host.delmatch.com."),
+				Type:            r53types.RRTypeA,
+				TTL:             aws.Int64(300),
+				ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.50")}},
+			},
+		}}},
+	}); cerr != nil {
+		t.Fatalf("create record: %v", cerr)
+	}
+
+	// A DELETE with a mismatched TTL and value must be rejected.
+	_, err = client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{Changes: []r53types.Change{{
+			Action: r53types.ChangeActionDelete,
+			ResourceRecordSet: &r53types.ResourceRecordSet{
+				Name:            aws.String("host.delmatch.com."),
+				Type:            r53types.RRTypeA,
+				TTL:             aws.Int64(999),
+				ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("10.0.0.99")}},
+			},
+		}}},
+	})
+
+	var badBatch *r53types.InvalidChangeBatch
+	if !errors.As(err, &badBatch) {
+		t.Fatalf("mismatched DELETE: got %v, want InvalidChangeBatch", err)
+	}
+
+	// The record must still be present after the rejected DELETE.
+	sets, err := client.ListResourceRecordSets(ctx, &awsr53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if err != nil {
+		t.Fatalf("ListResourceRecordSets: %v", err)
+	}
+	findRecordSet(t, sets.ResourceRecordSets, "host.delmatch.com.", r53types.RRTypeA)
+
+	// An exact-match DELETE succeeds.
+	if _, cerr := client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{Changes: []r53types.Change{{
+			Action: r53types.ChangeActionDelete,
+			ResourceRecordSet: &r53types.ResourceRecordSet{
+				Name:            aws.String("host.delmatch.com."),
+				Type:            r53types.RRTypeA,
+				TTL:             aws.Int64(300),
+				ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.50")}},
+			},
+		}}},
+	}); cerr != nil {
+		t.Fatalf("exact-match DELETE should succeed, got: %v", cerr)
+	}
+
+	after, err := client.ListResourceRecordSets(ctx, &awsr53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if err != nil {
+		t.Fatalf("ListResourceRecordSets after delete: %v", err)
+	}
+	for i := range after.ResourceRecordSets {
+		if aws.ToString(after.ResourceRecordSets[i].Name) == "host.delmatch.com." &&
+			after.ResourceRecordSets[i].Type == r53types.RRTypeA {
+			t.Fatal("record still present after exact-match DELETE")
+		}
+	}
+}

--- a/server/aws/route53/dns_order_test.go
+++ b/server/aws/route53/dns_order_test.go
@@ -79,6 +79,124 @@ func TestSDKListRecordSetsReversedLabelOrder(t *testing.T) {
 	}
 }
 
+// TestSDKListRecordSetsTrickyOrdering locks the flat reversed-dotted sort for the
+// cases a per-label compare gets wrong: a hyphen (0x2d) and wildcard (0x2a) both
+// sort below the label terminator '.' (0x2e). So api-v2.order.com. sorts BEFORE
+// api.order.com., *.order.com. sorts before a.order.com., and a nested
+// subdomain x.api.order.com. sorts after api.order.com. The full order is then
+// walked one record at a time to prove pagination matches the sort exactly.
+func TestSDKListRecordSetsTrickyOrdering(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	created, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("order.com."),
+		CallerReference: aws.String("tricky-ref"),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+	zoneID := aws.ToString(created.HostedZone.Id)
+
+	// Create in a deliberately scrambled input order.
+	for _, name := range []string{
+		"api.order.com.", "x.api.order.com.", "a.order.com.", "*.order.com.", "api-v2.order.com.",
+	} {
+		if _, cerr := client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+			HostedZoneId: aws.String(zoneID),
+			ChangeBatch: &r53types.ChangeBatch{Changes: []r53types.Change{{
+				Action: r53types.ChangeActionCreate,
+				ResourceRecordSet: &r53types.ResourceRecordSet{
+					Name:            aws.String(name),
+					Type:            r53types.RRTypeA,
+					TTL:             aws.Int64(300),
+					ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.1")}},
+				},
+			}}},
+		}); cerr != nil {
+			t.Fatalf("create %s: %v", name, cerr)
+		}
+	}
+
+	sets, err := client.ListResourceRecordSets(ctx, &awsr53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if err != nil {
+		t.Fatalf("ListResourceRecordSets: %v", err)
+	}
+
+	type nt struct {
+		name string
+		typ  r53types.RRType
+	}
+
+	got := make([]nt, 0, len(sets.ResourceRecordSets))
+	for i := range sets.ResourceRecordSets {
+		got = append(got, nt{aws.ToString(sets.ResourceRecordSets[i].Name), sets.ResourceRecordSets[i].Type})
+	}
+
+	want := []nt{
+		{"order.com.", r53types.RRTypeNs},
+		{"order.com.", r53types.RRTypeSoa},
+		{"*.order.com.", r53types.RRTypeA},
+		{"a.order.com.", r53types.RRTypeA},
+		{"api-v2.order.com.", r53types.RRTypeA},
+		{"api.order.com.", r53types.RRTypeA},
+		{"x.api.order.com.", r53types.RRTypeA},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d record sets, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order mismatch at %d: got %+v, want %+v (full: %+v)", i, got[i], want[i], got)
+		}
+	}
+
+	// Paginate MaxItems=1 through the whole set; page order must equal the sort.
+	key := func(n nt) string { return n.name + "/" + string(n.typ) }
+	wantSeq := make([]string, 0, len(want))
+	for i := range want {
+		wantSeq = append(wantSeq, key(want[i]))
+	}
+
+	gotSeq := make([]string, 0, len(wantSeq))
+	var startName *string
+	var startType r53types.RRType
+	for i := 0; i < len(wantSeq)+1; i++ {
+		page, perr := client.ListResourceRecordSets(ctx, &awsr53.ListResourceRecordSetsInput{
+			HostedZoneId:    aws.String(zoneID),
+			MaxItems:        aws.Int32(1),
+			StartRecordName: startName,
+			StartRecordType: startType,
+		})
+		if perr != nil {
+			t.Fatalf("ListResourceRecordSets(page): %v", perr)
+		}
+		if len(page.ResourceRecordSets) != 1 {
+			t.Fatalf("page returned %d records, want 1", len(page.ResourceRecordSets))
+		}
+
+		rr := page.ResourceRecordSets[0]
+		gotSeq = append(gotSeq, key(nt{aws.ToString(rr.Name), rr.Type}))
+
+		if !page.IsTruncated {
+			break
+		}
+		startName, startType = page.NextRecordName, page.NextRecordType
+	}
+
+	if len(gotSeq) != len(wantSeq) {
+		t.Fatalf("paged %d records, want %d: %v", len(gotSeq), len(wantSeq), gotSeq)
+	}
+	for i := range wantSeq {
+		if gotSeq[i] != wantSeq[i] {
+			t.Fatalf("pagination diverged from sort at %d: got %v, want %v", i, gotSeq, wantSeq)
+		}
+	}
+}
+
 // TestSDKListRecordSetsPaginationWalks locks that StartRecordName/StartRecordType
 // pagination walks the reversed-label order correctly: paging one record at a
 // time visits every record exactly once, in the same order as a full listing.

--- a/server/aws/route53/dns_order_test.go
+++ b/server/aws/route53/dns_order_test.go
@@ -1,0 +1,165 @@
+package route53_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+// TestSDKListRecordSetsReversedLabelOrder locks the AWS ordering guarantee:
+// ListResourceRecordSets sorts by DNS name with the labels reversed (so the
+// zone apex sorts before its subdomains), then by record type. The apex NS+SOA
+// must come first, then the a/m/z subdomains in order.
+func TestSDKListRecordSetsReversedLabelOrder(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	created, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("order.com."),
+		CallerReference: aws.String("order-ref"),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+	zoneID := aws.ToString(created.HostedZone.Id)
+
+	for _, sub := range []string{"z", "a", "m"} {
+		if _, cerr := client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+			HostedZoneId: aws.String(zoneID),
+			ChangeBatch: &r53types.ChangeBatch{Changes: []r53types.Change{{
+				Action: r53types.ChangeActionCreate,
+				ResourceRecordSet: &r53types.ResourceRecordSet{
+					Name:            aws.String(sub + ".order.com."),
+					Type:            r53types.RRTypeA,
+					TTL:             aws.Int64(300),
+					ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.1")}},
+				},
+			}}},
+		}); cerr != nil {
+			t.Fatalf("create %s: %v", sub, cerr)
+		}
+	}
+
+	sets, err := client.ListResourceRecordSets(ctx, &awsr53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if err != nil {
+		t.Fatalf("ListResourceRecordSets: %v", err)
+	}
+
+	type nt struct {
+		name string
+		typ  r53types.RRType
+	}
+
+	got := make([]nt, 0, len(sets.ResourceRecordSets))
+	for i := range sets.ResourceRecordSets {
+		got = append(got, nt{aws.ToString(sets.ResourceRecordSets[i].Name), sets.ResourceRecordSets[i].Type})
+	}
+
+	// Apex first (NS before SOA in ASCII type order), then subdomains a/m/z.
+	want := []nt{
+		{"order.com.", r53types.RRTypeNs},
+		{"order.com.", r53types.RRTypeSoa},
+		{"a.order.com.", r53types.RRTypeA},
+		{"m.order.com.", r53types.RRTypeA},
+		{"z.order.com.", r53types.RRTypeA},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d record sets, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order mismatch at %d: got %+v, want %+v (full: %+v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestSDKListRecordSetsPaginationWalks locks that StartRecordName/StartRecordType
+// pagination walks the reversed-label order correctly: paging one record at a
+// time visits every record exactly once, in the same order as a full listing.
+func TestSDKListRecordSetsPaginationWalks(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	created, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("page.com."),
+		CallerReference: aws.String("page-ref"),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+	zoneID := aws.ToString(created.HostedZone.Id)
+
+	for _, sub := range []string{"z", "a", "m", "b", "y"} {
+		if _, cerr := client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+			HostedZoneId: aws.String(zoneID),
+			ChangeBatch: &r53types.ChangeBatch{Changes: []r53types.Change{{
+				Action: r53types.ChangeActionCreate,
+				ResourceRecordSet: &r53types.ResourceRecordSet{
+					Name:            aws.String(sub + ".page.com."),
+					Type:            r53types.RRTypeA,
+					TTL:             aws.Int64(300),
+					ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.1")}},
+				},
+			}}},
+		}); cerr != nil {
+			t.Fatalf("create %s: %v", sub, cerr)
+		}
+	}
+
+	full, err := client.ListResourceRecordSets(ctx, &awsr53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if err != nil {
+		t.Fatalf("ListResourceRecordSets(full): %v", err)
+	}
+
+	key := func(name string, typ r53types.RRType) string { return name + "/" + string(typ) }
+
+	wantSeq := make([]string, 0, len(full.ResourceRecordSets))
+	for i := range full.ResourceRecordSets {
+		wantSeq = append(wantSeq,
+			key(aws.ToString(full.ResourceRecordSets[i].Name), full.ResourceRecordSets[i].Type))
+	}
+
+	// Page one record at a time following NextRecordName/NextRecordType.
+	gotSeq := make([]string, 0, len(wantSeq))
+	var startName *string
+	var startType r53types.RRType
+	for i := 0; i < len(wantSeq)+1; i++ {
+		page, perr := client.ListResourceRecordSets(ctx, &awsr53.ListResourceRecordSetsInput{
+			HostedZoneId:    aws.String(zoneID),
+			MaxItems:        aws.Int32(1),
+			StartRecordName: startName,
+			StartRecordType: startType,
+		})
+		if perr != nil {
+			t.Fatalf("ListResourceRecordSets(page): %v", perr)
+		}
+		if len(page.ResourceRecordSets) != 1 {
+			t.Fatalf("page returned %d records, want 1", len(page.ResourceRecordSets))
+		}
+
+		rr := page.ResourceRecordSets[0]
+		gotSeq = append(gotSeq, key(aws.ToString(rr.Name), rr.Type))
+
+		if !page.IsTruncated {
+			break
+		}
+		startName, startType = page.NextRecordName, page.NextRecordType
+	}
+
+	if len(gotSeq) != len(wantSeq) {
+		t.Fatalf("paged %d records, want %d: %v", len(gotSeq), len(wantSeq), gotSeq)
+	}
+	for i := range wantSeq {
+		if gotSeq[i] != wantSeq[i] {
+			t.Fatalf("pagination diverged at %d: got %v, want %v", i, gotSeq, wantSeq)
+		}
+	}
+}

--- a/server/aws/route53/normalization_test.go
+++ b/server/aws/route53/normalization_test.go
@@ -1,0 +1,97 @@
+package route53_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+// TestSDKZoneNameNormalizedToFQDN locks that a zone created without a trailing
+// dot is stored and returned as an FQDN (with the dot), matching real Route 53.
+func TestSDKZoneNameNormalizedToFQDN(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	created, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("nodot-zone.com"),
+		CallerReference: aws.String("nd-1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+
+	if got := aws.ToString(created.HostedZone.Name); got != "nodot-zone.com." {
+		t.Fatalf("CreateHostedZone name = %q, want nodot-zone.com.", got)
+	}
+
+	got, err := client.GetHostedZone(ctx, &awsr53.GetHostedZoneInput{Id: created.HostedZone.Id})
+	if err != nil {
+		t.Fatalf("GetHostedZone: %v", err)
+	}
+	if name := aws.ToString(got.HostedZone.Name); name != "nodot-zone.com." {
+		t.Fatalf("GetHostedZone name = %q, want nodot-zone.com.", name)
+	}
+}
+
+// TestSDKRecordNameNormalizedToFQDN locks that a record created without a
+// trailing dot is stored and returned as an FQDN, and can be resolved with
+// either the dotted or undotted name (TestDNSAnswer).
+func TestSDKRecordNameNormalizedToFQDN(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	created, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("recnorm.com."),
+		CallerReference: aws.String("rn-1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+	zoneID := aws.ToString(created.HostedZone.Id)
+
+	// Create the record with NO trailing dot.
+	if _, cerr := client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{Changes: []r53types.Change{{
+			Action: r53types.ChangeActionCreate,
+			ResourceRecordSet: &r53types.ResourceRecordSet{
+				Name:            aws.String("www.recnorm.com"),
+				Type:            r53types.RRTypeA,
+				TTL:             aws.Int64(300),
+				ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.7")}},
+			},
+		}}},
+	}); cerr != nil {
+		t.Fatalf("ChangeResourceRecordSets(CREATE): %v", cerr)
+	}
+
+	// It is listed back with the trailing dot.
+	sets, err := client.ListResourceRecordSets(ctx, &awsr53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if err != nil {
+		t.Fatalf("ListResourceRecordSets: %v", err)
+	}
+	findRecordSet(t, sets.ResourceRecordSets, "www.recnorm.com.", r53types.RRTypeA)
+
+	// Lookup works both ways: dotted and undotted query names resolve.
+	for _, q := range []string{"www.recnorm.com.", "www.recnorm.com"} {
+		out, aerr := client.TestDNSAnswer(ctx, &awsr53.TestDNSAnswerInput{
+			HostedZoneId: aws.String(zoneID),
+			RecordName:   aws.String(q),
+			RecordType:   r53types.RRTypeA,
+		})
+		if aerr != nil {
+			t.Fatalf("TestDNSAnswer(%q): %v", q, aerr)
+		}
+		if aws.ToString(out.ResponseCode) != "NOERROR" {
+			t.Fatalf("TestDNSAnswer(%q) response = %q, want NOERROR", q, aws.ToString(out.ResponseCode))
+		}
+		if len(out.RecordData) != 1 || out.RecordData[0] != "192.0.2.7" {
+			t.Fatalf("TestDNSAnswer(%q) data = %v, want [192.0.2.7]", q, out.RecordData)
+		}
+	}
+}

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -203,12 +203,13 @@ func (h *Handler) changeResourceRecordSets(w http.ResponseWriter, r *http.Reques
 	// against a missing zone is NoSuchHostedZone (404), not the batch-level
 	// InvalidChangeBatch (400). Only record-level errors from batch validation
 	// map to InvalidChangeBatch.
-	if _, err := h.dns.GetZone(r.Context(), zoneID); err != nil {
+	zone, err := h.dns.GetZone(r.Context(), zoneID)
+	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	if err := h.validateChangeBatch(r, zoneID, req.ChangeBatch.Changes); err != nil {
+	if err := h.validateChangeBatch(r, zone, req.ChangeBatch.Changes); err != nil {
 		writeChangeErr(w, err)
 		return
 	}
@@ -235,10 +236,20 @@ func rrSetKey(name, rtype, setID string) string {
 
 // validateRecordSet checks a single record set's fields are self-consistent,
 // independent of the zone's current state. Real Route 53 rejects these as part
-// of change-batch validation before any change is applied.
-func validateRecordSet(rr *resourceRecordSetXML) error {
+// of change-batch validation before any change is applied. apex is the zone's
+// FQDN, used to reject a CNAME at the zone apex.
+func validateRecordSet(rr *resourceRecordSetXML, apex string) error {
 	if rr.Name == "" || rr.Type == "" {
 		return cerrors.New(cerrors.InvalidArgument, "record set name and type are required")
+	}
+
+	// A CNAME is not permitted at the zone apex — the apex must carry the SOA and
+	// NS records, so it can only use an A/AAAA or an ALIAS. Real Route 53 rejects
+	// an apex CNAME as an InvalidChangeBatch (FailedPrecondition maps to that).
+	if strings.EqualFold(rr.Type, "CNAME") && sameDNSName(rr.Name, apex) {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"RRSet of type CNAME with DNS name %s is not permitted at apex in zone %s",
+			ensureTrailingDot(rr.Name), ensureTrailingDot(apex))
 	}
 
 	// Weighted routing record sets require a non-empty SetIdentifier that
@@ -253,12 +264,18 @@ func validateRecordSet(rr *resourceRecordSetXML) error {
 	return nil
 }
 
+// sameDNSName reports whether two DNS names are equal, case- and
+// trailing-dot-insensitively.
+func sameDNSName(a, b string) bool {
+	return strings.EqualFold(strings.TrimSuffix(a, "."), strings.TrimSuffix(b, "."))
+}
+
 // validateChangeBatch checks every change would apply cleanly before any is
 // applied, so an invalid batch is rejected whole (nothing half-applied). It
 // simulates the batch against the zone's current record sets, folding in each
 // change's effect so ordering within the batch is respected.
-func (h *Handler) validateChangeBatch(r *http.Request, zoneID string, changes []changeItem) error {
-	existing, err := h.dns.ListRecords(r.Context(), zoneID)
+func (h *Handler) validateChangeBatch(r *http.Request, zone *dnsdriver.ZoneInfo, changes []changeItem) error {
+	existing, err := h.dns.ListRecords(r.Context(), zone.ID)
 	if err != nil {
 		return err
 	}
@@ -271,7 +288,7 @@ func (h *Handler) validateChangeBatch(r *http.Request, zoneID string, changes []
 	for i := range changes {
 		rr := &changes[i].ResourceRecordSet
 
-		if err := validateRecordSet(rr); err != nil {
+		if err := validateRecordSet(rr, zone.Name); err != nil {
 			return err
 		}
 

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -270,6 +270,59 @@ func sameDNSName(a, b string) bool {
 	return strings.EqualFold(strings.TrimSuffix(a, "."), strings.TrimSuffix(b, "."))
 }
 
+// deleteMatchesRecord reports whether a DELETE request's TTL and values exactly
+// match the stored record set — Route 53's rule that a DELETE must repeat the
+// record's current values. Alias records match on their alias target instead of
+// a TTL and resource records.
+func deleteMatchesRecord(cur *dnsdriver.RecordInfo, rr *resourceRecordSetXML) bool {
+	if cur.AliasTarget != nil || rr.AliasTarget != nil {
+		if cur.AliasTarget == nil || rr.AliasTarget == nil {
+			return false
+		}
+
+		return sameDNSName(cur.AliasTarget.DNSName, rr.AliasTarget.DNSName) &&
+			cur.AliasTarget.HostedZoneID == rr.AliasTarget.HostedZoneId
+	}
+
+	reqTTL := 0
+	if rr.TTL != nil {
+		reqTTL = int(*rr.TTL)
+	}
+
+	if cur.TTL != reqTTL {
+		return false
+	}
+
+	reqValues := make([]string, 0, len(rr.ResourceRecords))
+	for _, v := range rr.ResourceRecords {
+		reqValues = append(reqValues, v.Value)
+	}
+
+	return sameValueSet(cur.Values, reqValues)
+}
+
+// sameValueSet reports whether two resource-record value lists are equal as
+// sets (order-independent), matching how Route 53 compares a DELETE's values.
+func sameValueSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	as := append([]string(nil), a...)
+	sort.Strings(as)
+
+	bs := append([]string(nil), b...)
+	sort.Strings(bs)
+
+	for i := range as {
+		if as[i] != bs[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
 // validateChangeBatch checks every change would apply cleanly before any is
 // applied, so an invalid batch is rejected whole (nothing half-applied). It
 // simulates the batch against the zone's current record sets, folding in each
@@ -281,38 +334,62 @@ func (h *Handler) validateChangeBatch(r *http.Request, zone *dnsdriver.ZoneInfo,
 	}
 
 	present := make(map[string]bool, len(existing))
+	byKey := make(map[string]*dnsdriver.RecordInfo, len(existing))
 	for i := range existing {
-		present[rrSetKey(existing[i].Name, existing[i].Type, existing[i].SetID)] = true
+		key := rrSetKey(existing[i].Name, existing[i].Type, existing[i].SetID)
+		present[key] = true
+		byKey[key] = &existing[i]
 	}
 
 	for i := range changes {
-		rr := &changes[i].ResourceRecordSet
-
-		if err := validateRecordSet(rr, zone.Name); err != nil {
+		if err := validateChange(&changes[i], zone.Name, present, byKey); err != nil {
 			return err
 		}
+	}
 
-		key := rrSetKey(rr.Name, rr.Type, rr.SetIdentifier)
+	return nil
+}
 
-		switch changes[i].Action {
-		case actionCreate:
-			if present[key] {
-				return cerrors.Newf(cerrors.AlreadyExists,
-					"record set %q %s already exists", rr.Name, rr.Type)
-			}
-			present[key] = true
-		case actionDelete:
-			if !present[key] {
-				return cerrors.Newf(cerrors.NotFound,
-					"record set %q %s not found", rr.Name, rr.Type)
-			}
-			present[key] = false
-		case actionUpsert:
-			present[key] = true
-		default:
-			return cerrors.Newf(cerrors.InvalidArgument,
-				"unsupported change action %q", changes[i].Action)
+// validateChange checks one change against the batch's simulated presence set
+// (present) and the zone's pre-batch record sets (byKey), folding the change's
+// effect back into present so later changes in the batch see it.
+func validateChange(
+	ch *changeItem, apex string, present map[string]bool, byKey map[string]*dnsdriver.RecordInfo,
+) error {
+	rr := &ch.ResourceRecordSet
+
+	if err := validateRecordSet(rr, apex); err != nil {
+		return err
+	}
+
+	key := rrSetKey(rr.Name, rr.Type, rr.SetIdentifier)
+
+	switch ch.Action {
+	case actionCreate:
+		if present[key] {
+			return cerrors.Newf(cerrors.AlreadyExists, "record set %q %s already exists", rr.Name, rr.Type)
 		}
+
+		present[key] = true
+	case actionDelete:
+		if !present[key] {
+			return cerrors.Newf(cerrors.NotFound, "record set %q %s not found", rr.Name, rr.Type)
+		}
+		// Route 53 requires a DELETE to specify the exact TTL and values of the
+		// existing record set. Enforce it only against a record that was already
+		// present before this batch (byKey); one created earlier in the same
+		// batch has no pre-existing values to match against.
+		if cur, ok := byKey[key]; ok && !deleteMatchesRecord(cur, rr) {
+			return cerrors.Newf(cerrors.FailedPrecondition,
+				"Tried to delete resource record set [name=%s, type=%s] but the values provided do not match the current values",
+				ensureTrailingDot(rr.Name), rr.Type)
+		}
+
+		present[key] = false
+	case actionUpsert:
+		present[key] = true
+	default:
+		return cerrors.Newf(cerrors.InvalidArgument, "unsupported change action %q", ch.Action)
 	}
 
 	return nil

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -37,6 +37,7 @@ func (h *Handler) createHostedZone(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.HostedZoneConfig != nil {
 		cfg.Private = req.HostedZoneConfig.PrivateZone
+		cfg.Comment = req.HostedZoneConfig.Comment
 	}
 
 	info, err := h.dns.CreateZone(r.Context(), cfg)

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -31,7 +31,10 @@ func (h *Handler) createHostedZone(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cfg := dnsdriver.ZoneConfig{Name: ensureTrailingDot(req.Name)}
+	cfg := dnsdriver.ZoneConfig{
+		Name:            ensureTrailingDot(req.Name),
+		CallerReference: req.CallerReference,
+	}
 	if req.HostedZoneConfig != nil {
 		cfg.Private = req.HostedZoneConfig.PrivateZone
 	}
@@ -53,12 +56,7 @@ func (h *Handler) createHostedZone(w http.ResponseWriter, r *http.Request) {
 		info = refreshed
 	}
 
-	// Echo the caller's CallerReference back faithfully (the driver doesn't
-	// persist it, so this is only recoverable on the create response).
 	hz := toHostedZoneXML(info)
-	if req.CallerReference != "" {
-		hz.CallerReference = req.CallerReference
-	}
 
 	// Real Route 53 returns a Location header pointing at the new zone.
 	w.Header().Set("Location", pathPrefix+"/"+info.ID)

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -355,21 +355,21 @@ func (h *Handler) listResourceRecordSets(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	// Real Route 53 returns record sets in DNS name order. Sort by name
-	// (case-insensitive) then type so the sequence is deterministic and honors
-	// StartRecordName paging below.
+	// Real Route 53 returns record sets in DNS name order — sorted first by DNS
+	// name with the labels reversed (so the zone apex sorts before its
+	// subdomains: com.order. < com.order.a.), then by record type. This ordering
+	// is what NextRecordName/StartRecordName pagination walks.
 	sort.Slice(records, func(i, j int) bool {
-		ni, nj := strings.ToLower(records[i].Name), strings.ToLower(records[j].Name)
-		if ni != nj {
-			return ni < nj
+		if c := compareDNSName(records[i].Name, records[j].Name); c != 0 {
+			return c < 0
 		}
 
 		return records[i].Type < records[j].Type
 	})
 
 	// StartRecordName (and optional StartRecordType) skip forward to the first
-	// record at or after the requested position.
-	start := strings.ToLower(r.URL.Query().Get("name"))
+	// record at or after the requested position, in the same reversed-label order.
+	start := r.URL.Query().Get("name")
 	startType := r.URL.Query().Get("type")
 	records = recordsFrom(records, start, startType)
 
@@ -397,20 +397,64 @@ func (h *Handler) listResourceRecordSets(w http.ResponseWriter, r *http.Request,
 }
 
 // recordsFrom returns the slice starting at the first record whose (name, type)
-// is at or after (start, startType). An empty start returns all records.
+// is at or after (start, startType) in reversed-label DNS order. An empty start
+// returns all records.
 func recordsFrom(records []dnsdriver.RecordInfo, start, startType string) []dnsdriver.RecordInfo {
 	if start == "" {
 		return records
 	}
 
 	for i := range records {
-		name := strings.ToLower(records[i].Name)
-		if name > start || (name == start && (startType == "" || records[i].Type >= startType)) {
+		c := compareDNSName(records[i].Name, start)
+		if c > 0 || (c == 0 && (startType == "" || records[i].Type >= startType)) {
 			return records[i:]
 		}
 	}
 
 	return nil
+}
+
+// compareDNSName orders two DNS names the way Route 53's ListResourceRecordSets
+// does: by the name's labels reversed (TLD first), so a zone apex sorts before
+// its subdomains. Comparison is case- and trailing-dot-insensitive. It returns
+// -1, 0, or 1.
+func compareDNSName(a, b string) int {
+	la, lb := reversedLabels(a), reversedLabels(b)
+
+	for i := 0; i < len(la) && i < len(lb); i++ {
+		if la[i] != lb[i] {
+			if la[i] < lb[i] {
+				return -1
+			}
+
+			return 1
+		}
+	}
+
+	switch {
+	case len(la) < len(lb):
+		return -1
+	case len(la) > len(lb):
+		return 1
+	default:
+		return 0
+	}
+}
+
+// reversedLabels lower-cases a DNS name, drops the trailing dot, and returns its
+// labels reversed (TLD first): "www.Order.com." → ["com", "order", "www"].
+func reversedLabels(name string) []string {
+	name = strings.ToLower(strings.TrimSuffix(name, "."))
+	if name == "" {
+		return nil
+	}
+
+	labels := strings.Split(name, ".")
+	for i, j := 0, len(labels)-1; i < j; i, j = i+1, j-1 {
+		labels[i], labels[j] = labels[j], labels[i]
+	}
+
+	return labels
 }
 
 // parseMaxItems reads the maxitems query param, clamping to the fixed page size

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -31,7 +31,7 @@ func (h *Handler) createHostedZone(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cfg := dnsdriver.ZoneConfig{Name: req.Name}
+	cfg := dnsdriver.ZoneConfig{Name: ensureTrailingDot(req.Name)}
 	if req.HostedZoneConfig != nil {
 		cfg.Private = req.HostedZoneConfig.PrivateZone
 	}
@@ -191,6 +191,14 @@ func (h *Handler) changeResourceRecordSets(w http.ResponseWriter, r *http.Reques
 	}
 
 	zoneID := trimZonePrefix(id)
+
+	// Route 53 stores and returns record names as FQDNs (with a trailing dot).
+	// Normalize once here so validation, create, delete, and upsert all agree on
+	// the stored name whether the client sent the dot or not.
+	for i := range req.ChangeBatch.Changes {
+		rr := &req.ChangeBatch.Changes[i].ResourceRecordSet
+		rr.Name = ensureTrailingDot(rr.Name)
+	}
 
 	// The hosted zone must exist before the change batch is validated: a change
 	// against a missing zone is NoSuchHostedZone (404), not the batch-level
@@ -470,6 +478,17 @@ func parseMaxItems(v string) int {
 	}
 
 	return n
+}
+
+// ensureTrailingDot returns name as an FQDN (with a trailing dot), the form
+// Route 53 stores and returns zone and record names in. An empty name is left
+// as-is, and a name that already ends in a dot is unchanged.
+func ensureTrailingDot(name string) string {
+	if name == "" || strings.HasSuffix(name, ".") {
+		return name
+	}
+
+	return name + "."
 }
 
 // recordConfig builds a driver RecordConfig from a parsed record set element.

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -192,6 +192,15 @@ func (h *Handler) changeResourceRecordSets(w http.ResponseWriter, r *http.Reques
 
 	zoneID := trimZonePrefix(id)
 
+	// The hosted zone must exist before the change batch is validated: a change
+	// against a missing zone is NoSuchHostedZone (404), not the batch-level
+	// InvalidChangeBatch (400). Only record-level errors from batch validation
+	// map to InvalidChangeBatch.
+	if _, err := h.dns.GetZone(r.Context(), zoneID); err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	if err := h.validateChangeBatch(r, zoneID, req.ChangeBatch.Changes); err != nil {
 		writeChangeErr(w, err)
 		return

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -516,38 +516,25 @@ func recordsFrom(records []dnsdriver.RecordInfo, start, startType string) []dnsd
 }
 
 // compareDNSName orders two DNS names the way Route 53's ListResourceRecordSets
-// does: by the name's labels reversed (TLD first), so a zone apex sorts before
-// its subdomains. Comparison is case- and trailing-dot-insensitive. It returns
-// -1, 0, or 1.
+// does: by the name with its labels reversed (TLD first), compared as a flat
+// ASCII string with the dots — including the trailing dot — kept in place. The
+// trailing dot matters: a character whose ASCII value is below '.' (0x2e), such
+// as '-' (0x2d) or the wildcard '*' (0x2a), sorts a longer label before the
+// terminator, so "com.order.api-v2." < "com.order.api." (api-v2 sorts first).
+// A per-label compare would wrongly treat "api" as the prefix that wins.
+// Comparison is case-insensitive (DNS names are); it returns -1, 0, or 1.
 func compareDNSName(a, b string) int {
-	la, lb := reversedLabels(a), reversedLabels(b)
-
-	for i := 0; i < len(la) && i < len(lb); i++ {
-		if la[i] != lb[i] {
-			if la[i] < lb[i] {
-				return -1
-			}
-
-			return 1
-		}
-	}
-
-	switch {
-	case len(la) < len(lb):
-		return -1
-	case len(la) > len(lb):
-		return 1
-	default:
-		return 0
-	}
+	return strings.Compare(reversedDotted(a), reversedDotted(b))
 }
 
-// reversedLabels lower-cases a DNS name, drops the trailing dot, and returns its
-// labels reversed (TLD first): "www.Order.com." → ["com", "order", "www"].
-func reversedLabels(name string) []string {
+// reversedDotted lower-cases a DNS name, drops the trailing dot, reverses the
+// LABEL order, and rejoins with dots plus a trailing dot — the flat key Route 53
+// sorts on: "api-v2.Order.com." → "com.order.api-v2.". Comparing these keys as
+// plain strings (dots included) reproduces Route 53's ordering exactly.
+func reversedDotted(name string) string {
 	name = strings.ToLower(strings.TrimSuffix(name, "."))
 	if name == "" {
-		return nil
+		return "."
 	}
 
 	labels := strings.Split(name, ".")
@@ -555,7 +542,7 @@ func reversedLabels(name string) []string {
 		labels[i], labels[j] = labels[j], labels[i]
 	}
 
-	return labels
+	return strings.Join(labels, ".") + "."
 }
 
 // parseMaxItems reads the maxitems query param, clamping to the fixed page size

--- a/server/aws/route53/sdk_roundtrip_test.go
+++ b/server/aws/route53/sdk_roundtrip_test.go
@@ -257,8 +257,12 @@ func TestSDKRoute53Errors(t *testing.T) {
 			}},
 		},
 	})
-	if err == nil {
-		t.Fatal("ChangeResourceRecordSets(missing zone): want error, got nil")
+
+	// A change against a missing zone is NoSuchHostedZone (404), not the
+	// batch-level InvalidChangeBatch (400) — asserting only err != nil would mask
+	// the wrong code.
+	if !errors.As(err, &notFound) {
+		t.Fatalf("ChangeResourceRecordSets(missing zone): got %v, want NoSuchHostedZone", err)
 	}
 
 	// A record-level conflict on an existing zone must surface as

--- a/server/aws/route53/types.go
+++ b/server/aws/route53/types.go
@@ -224,6 +224,7 @@ func toHostedZoneXML(info *dnsdriver.ZoneInfo) hostedZoneXML {
 		Name:            info.Name,
 		CallerReference: info.CallerReference,
 		Config: &hostedZoneConfigXML{
+			Comment:     info.Comment,
 			PrivateZone: info.Private,
 		},
 		ResourceRecordSetCount: int64(info.RecordCount),

--- a/server/aws/route53/types.go
+++ b/server/aws/route53/types.go
@@ -216,15 +216,13 @@ func trimZonePrefix(id string) string {
 // the request URL path with no prefix stripping, so echoing the bare driver id
 // keeps Get/Delete round-trips addressing the same resource.
 //
-// The dns driver does not persist the caller-supplied CallerReference, so on
-// Get/List we surface the zone name (a stable, meaningful value) rather than
-// leaking the internal zone id. CreateHostedZone overrides this with the actual
-// reference the caller sent so a create round-trip is faithful.
+// CallerReference is the caller-supplied idempotency token, persisted on create
+// and returned verbatim here so Get/List round-trip faithfully.
 func toHostedZoneXML(info *dnsdriver.ZoneInfo) hostedZoneXML {
 	return hostedZoneXML{
 		Id:              info.ID,
 		Name:            info.Name,
-		CallerReference: info.Name,
+		CallerReference: info.CallerReference,
 		Config: &hostedZoneConfigXML{
 			PrivateZone: info.Private,
 		},

--- a/server/aws/route53/zone_comment_test.go
+++ b/server/aws/route53/zone_comment_test.go
@@ -1,0 +1,45 @@
+package route53_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+// TestSDKZoneCommentPersisted locks that HostedZoneConfig.Comment is persisted
+// and returned on both Create and Get — a perpetual-diff risk for Terraform's
+// aws_route53_zone, which reads the comment back after setting it.
+func TestSDKZoneCommentPersisted(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	created, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("commented.com."),
+		CallerReference: aws.String("comment-ref"),
+		HostedZoneConfig: &r53types.HostedZoneConfig{
+			Comment: aws.String("my important zone"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+
+	if created.HostedZone.Config == nil ||
+		aws.ToString(created.HostedZone.Config.Comment) != "my important zone" {
+		t.Fatalf("CreateHostedZone comment = %+v, want \"my important zone\"", created.HostedZone.Config)
+	}
+
+	zoneID := aws.ToString(created.HostedZone.Id)
+	got, err := client.GetHostedZone(ctx, &awsr53.GetHostedZoneInput{Id: aws.String(zoneID)})
+	if err != nil {
+		t.Fatalf("GetHostedZone: %v", err)
+	}
+
+	if got.HostedZone.Config == nil ||
+		aws.ToString(got.HostedZone.Config.Comment) != "my important zone" {
+		t.Fatalf("GetHostedZone comment = %+v, want \"my important zone\"", got.HostedZone.Config)
+	}
+}

--- a/services/dns/driver/driver.go
+++ b/services/dns/driver/driver.go
@@ -16,6 +16,9 @@ type ZoneConfig struct {
 	// persisted and returned verbatim on Get/List. Other providers leave it
 	// empty.
 	CallerReference string
+	// Comment is the AWS Route 53 hosted-zone comment, persisted and returned on
+	// Create/Get. Other providers leave it empty.
+	Comment string
 	// Scope records the cloud-side container the zone was created in (Azure
 	// subscription/resource group or GCP project). The zero value is unscoped.
 	Scope scope.Scope
@@ -31,6 +34,9 @@ type ZoneInfo struct {
 	// CallerReference is the AWS Route 53 caller-supplied idempotency token as
 	// stored on create. Other providers leave it empty.
 	CallerReference string
+	// Comment is the AWS Route 53 hosted-zone comment as stored on create. Other
+	// providers leave it empty.
+	Comment string
 	// Scope is the container the zone lives in; scoped list endpoints filter
 	// on it. The zero value is unscoped and visible everywhere.
 	Scope scope.Scope

--- a/services/dns/driver/driver.go
+++ b/services/dns/driver/driver.go
@@ -12,6 +12,10 @@ type ZoneConfig struct {
 	Name    string
 	Private bool
 	Tags    map[string]string
+	// CallerReference is the AWS Route 53 caller-supplied idempotency token,
+	// persisted and returned verbatim on Get/List. Other providers leave it
+	// empty.
+	CallerReference string
 	// Scope records the cloud-side container the zone was created in (Azure
 	// subscription/resource group or GCP project). The zero value is unscoped.
 	Scope scope.Scope
@@ -24,6 +28,9 @@ type ZoneInfo struct {
 	Private     bool
 	RecordCount int
 	Tags        map[string]string
+	// CallerReference is the AWS Route 53 caller-supplied idempotency token as
+	// stored on create. Other providers leave it empty.
+	CallerReference string
 	// Scope is the container the zone lives in; scoped list endpoints filter
 	// on it. The zero value is unscoped and visible everywhere.
 	Scope scope.Scope


### PR DESCRIPTION
Fixes 7 AWS Route 53 correctness bugs (1 HIGH + 6 MED) found by a deep real-SDK
end-to-end audit (aws-sdk-go-v2 against an in-process wire server). Each fix is
at the correct 3-layer location and cross-checked against the official Route 53
API docs. One commit per bug.

## What & why

- **[HIGH] NoSuchHostedZone on a change to a missing zone.**
  `ChangeResourceRecordSets` against a non-existent zone returned
  `InvalidChangeBatch` (400) because batch validation hit the driver's
  zone-not-found first. The zone is now checked before the batch is validated,
  so a missing zone maps to `NoSuchHostedZone` (404) as real Route 53 does. The
  existing test only asserted `err != nil` (masking the code) — strengthened to
  assert the 404/code.

- **[MED-HIGH] Reversed-label DNS ordering + pagination.**
  `ListResourceRecordSets` sorted forward-lexical, putting the zone apex in the
  middle of its subdomains. Route 53 sorts by DNS name with the labels reversed
  (apex first: `com.order.` < `com.order.a.`), then by type, and
  `NextRecordName`/`StartRecordName` pagination walks that order. Added a
  reversed-label comparator applied to both the sort and the paging start
  position, so apex NS+SOA lead and one-at-a-time paging never skips or repeats.

- **[MED] FQDN normalization.** Zone and record names are normalized to a
  trailing dot on create/change and returned as FQDNs, matching Route 53.
  Lookups match whether the client sends the dot or not; the topology `Resolve`
  engine now compares names trailing-dot-insensitively so it still resolves.

- **[MED] Persist CallerReference.** Get/List returned the zone name as the
  `CallerReference`. Added it to the DNS driver `ZoneConfig`/`ZoneInfo`,
  persisted on create, and returned verbatim.

- **[MED] Persist HostedZoneConfig.Comment.** Create/Get always returned an
  empty comment (Terraform `aws_route53_zone` perpetual-diff). Now persisted and
  emitted.

- **[MED] Reject apex CNAME.** A CNAME at the zone apex was accepted; Route 53
  rejects it (`InvalidChangeBatch`) since the apex carries SOA/NS. Now rejected.

- **[MED] Exact-match DELETE.** A DELETE with a stale/wrong TTL or values still
  removed the record. The DELETE target's TTL and value set (or alias target) is
  now validated against the stored record; a mismatch is `InvalidChangeBatch`.

Out of scope (deferred): `AssociateVPCWithHostedZone` (private-zone VPC) and the
4 low nits from the audit.

## Tests

Real aws-sdk-go-v2 reproductions added for every fix: missing-zone change ->
NoSuchHostedZone; reversed-label ordering (apex NS+SOA first, then a/m/z) and
one-record-at-a-time pagination walk; FQDN normalization with dotted/undotted
lookup; CallerReference persisted on Get/List; Comment persisted on Create/Get;
apex CNAME rejected (non-apex accepted); mismatched DELETE rejected + exact
DELETE succeeds. Existing route53 and topology Resolve tests stay green
(#467/#532/#553).

## Notes

`CallerReference`/`Comment` are additive fields on the shared DNS driver types;
Azure/GCP DNS providers carry them as zero-value pass-throughs (no behavior
change there). `go generate ./...` is idempotent (no coverage-doc diff).
