### PR TITLE
fix(aws-ssm): persist PutParameter Tags; reject Overwrite+Tags and invalid Type; GetParametersByPath ParameterFilters

### DIFF
--- a/providers/aws/ssm/path_filter.go
+++ b/providers/aws/ssm/path_filter.go
@@ -1,0 +1,106 @@
+package ssm
+
+import (
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/services/parameterstore/driver"
+)
+
+// GetParametersByPath filter keys and options. GetParametersByPath supports the
+// Type, KeyId, and Label keys only (unlike DescribeParameters, which also
+// supports Name/Tier/DataType/tag).
+const (
+	byPathKeyType  = "Type"
+	byPathKeyKeyID = "KeyId"
+	byPathKeyLabel = "Label"
+
+	filterOptionEquals     = "Equals"
+	filterOptionBeginsWith = "BeginsWith"
+)
+
+// validateByPathFilters checks each ParameterFilters entry uses a key and option
+// GetParametersByPath supports, returning the AWS-distinct error otherwise.
+func validateByPathFilters(filters []driver.ParameterStringFilter) error {
+	for _, f := range filters {
+		switch f.Key {
+		case byPathKeyType, byPathKeyKeyID, byPathKeyLabel:
+		default:
+			return driver.ErrInvalidFilterKey
+		}
+
+		switch f.Option {
+		case "", filterOptionEquals, filterOptionBeginsWith:
+		default:
+			return driver.ErrInvalidFilterOption
+		}
+	}
+
+	return nil
+}
+
+// matchesByPathFilters reports whether version v of a parameter satisfies every
+// filter (filters are AND'd; a filter's Values are OR'd).
+func matchesByPathFilters(v *version, filters []driver.ParameterStringFilter) bool {
+	for i := range filters {
+		if !matchByPathFilter(v, &filters[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func matchByPathFilter(v *version, f *driver.ParameterStringFilter) bool {
+	switch f.Key {
+	case byPathKeyType:
+		return fieldMatchesFilter(v.typ, f.Option, f.Values)
+	case byPathKeyLabel:
+		return labelsMatchFilter(v.labels, f.Option, f.Values)
+	default:
+		// KeyId is a valid key but cloudemu doesn't model a per-parameter KMS
+		// KeyId (SecureString isn't encrypted), so it can't constrain results.
+		return true
+	}
+}
+
+// fieldMatchesFilter reports whether a single string field matches the option
+// against any of the values. Empty Values matches (an empty filter is a no-op).
+func fieldMatchesFilter(field, option string, values []string) bool {
+	if len(values) == 0 {
+		return true
+	}
+
+	for _, val := range values {
+		if optionMatch(field, option, val) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// labelsMatchFilter reports whether any of a version's labels matches the option
+// against any of the values.
+func labelsMatchFilter(labels []string, option string, values []string) bool {
+	if len(values) == 0 {
+		return true
+	}
+
+	for _, val := range values {
+		for _, lbl := range labels {
+			if optionMatch(lbl, option, val) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func optionMatch(field, option, val string) bool {
+	if option == filterOptionBeginsWith {
+		return strings.HasPrefix(field, val)
+	}
+
+	return field == val
+}

--- a/providers/aws/ssm/ssm.go
+++ b/providers/aws/ssm/ssm.go
@@ -86,13 +86,25 @@ func ensureLeadingSlash(name string) string {
 	return "/" + name
 }
 
-func defaultType(t string) string {
+// validType reports whether t is one of the parameter types AWS accepts.
+func validType(t string) bool {
 	switch t {
 	case driver.TypeString, driver.TypeStringList, driver.TypeSecureString:
-		return t
+		return true
 	default:
-		return driver.TypeString
+		return false
 	}
+}
+
+// defaultType returns t when it is a recognized type, and String otherwise —
+// used only for an omitted (empty) type, which defaults to String. An
+// explicitly invalid type is rejected earlier by PutParameter.
+func defaultType(t string) string {
+	if validType(t) {
+		return t
+	}
+
+	return driver.TypeString
 }
 
 // resolveOverwriteType decides the type of a new version appended to an existing
@@ -128,6 +140,14 @@ func (m *Mock) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, s
 
 	if cfg.Overwrite && len(cfg.Tags) > 0 {
 		return 0, "", driver.ErrTagsWithOverwrite
+	}
+
+	// An explicitly set Type must be one AWS recognizes; an unrecognized value
+	// is rejected (UnsupportedParameterType) rather than coerced to String. An
+	// omitted Type is allowed here: it defaults to String on create and retains
+	// the existing type on Overwrite.
+	if cfg.Type != "" && !validType(cfg.Type) {
+		return 0, "", driver.ErrUnsupportedType
 	}
 
 	tier := cfg.Tier

--- a/providers/aws/ssm/ssm.go
+++ b/providers/aws/ssm/ssm.go
@@ -387,6 +387,10 @@ func (m *Mock) GetParametersByPath(_ context.Context, in driver.GetByPathInput) 
 		return nil, errors.New(errors.InvalidArgument, "path must begin with '/'")
 	}
 
+	if err := validateByPathFilters(in.ParameterFilters); err != nil {
+		return nil, err
+	}
+
 	prefix := path
 	if !strings.HasSuffix(prefix, "/") {
 		prefix += "/"
@@ -407,7 +411,7 @@ func (m *Mock) GetParametersByPath(_ context.Context, in driver.GetByPathInput) 
 		}
 
 		pd.mu.RLock()
-		if v, ok := pd.versionByNumber(pd.latest); ok {
+		if v, ok := pd.versionByNumber(pd.latest); ok && matchesByPathFilters(v, in.ParameterFilters) {
 			out = append(out, m.toParameter(pd, v, ""))
 		}
 		pd.mu.RUnlock()

--- a/providers/aws/ssm/ssm.go
+++ b/providers/aws/ssm/ssm.go
@@ -119,9 +119,15 @@ func resolveOverwriteType(existing *paramData, requested string) (string, error)
 
 // PutParameter creates a new parameter or, when Overwrite is set, appends a new
 // version to an existing one.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, string, error) {
 	if cfg.Name == "" {
 		return 0, "", errors.New(errors.InvalidArgument, "parameter name is required")
+	}
+
+	if cfg.Overwrite && len(cfg.Tags) > 0 {
+		return 0, "", driver.ErrTagsWithOverwrite
 	}
 
 	tier := cfg.Tier
@@ -137,34 +143,50 @@ func (m *Mock) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, s
 	now := m.now()
 
 	if existing, ok := m.params.Get(cfg.Name); ok {
-		existing.mu.Lock()
-		defer existing.mu.Unlock()
-
-		if !cfg.Overwrite {
-			return 0, "", errors.Newf(errors.AlreadyExists,
-				"parameter %q already exists; set Overwrite to update it", cfg.Name)
-		}
-
-		newType, err := resolveOverwriteType(existing, cfg.Type)
-		if err != nil {
-			return 0, "", err
-		}
-
-		next := existing.latest + 1
-		existing.versions = append(existing.versions, &version{
-			value:        cfg.Value,
-			typ:          newType,
-			dataType:     dataType,
-			version:      next,
-			lastModified: now,
-		})
-		existing.latest = next
-		existing.description = cfg.Description
-		existing.tier = tier
-
-		return next, tier, nil
+		return overwriteParameter(existing, &cfg, tier, dataType, now)
 	}
 
+	return m.createParameter(ctx, &cfg, tier, dataType, now)
+}
+
+// overwriteParameter appends a new version to an existing parameter (the
+// Overwrite path). Overwrite without the flag is rejected, and changing the
+// type is rejected via resolveOverwriteType.
+func overwriteParameter(
+	existing *paramData, cfg *driver.PutConfig, tier, dataType, now string,
+) (ver int64, assignedTier string, err error) {
+	existing.mu.Lock()
+	defer existing.mu.Unlock()
+
+	if !cfg.Overwrite {
+		return 0, "", errors.Newf(errors.AlreadyExists,
+			"parameter %q already exists; set Overwrite to update it", cfg.Name)
+	}
+
+	newType, err := resolveOverwriteType(existing, cfg.Type)
+	if err != nil {
+		return 0, "", err
+	}
+
+	next := existing.latest + 1
+	existing.versions = append(existing.versions, &version{
+		value:        cfg.Value,
+		typ:          newType,
+		dataType:     dataType,
+		version:      next,
+		lastModified: now,
+	})
+	existing.latest = next
+	existing.description = cfg.Description
+	existing.tier = tier
+
+	return next, tier, nil
+}
+
+// createParameter stores a brand-new parameter (version 1) with its tags.
+func (m *Mock) createParameter(
+	ctx context.Context, cfg *driver.PutConfig, tier, dataType, now string,
+) (ver int64, assignedTier string, err error) {
 	pd := &paramData{
 		name:        cfg.Name,
 		description: cfg.Description,
@@ -177,6 +199,7 @@ func (m *Mock) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, s
 			version:      1,
 			lastModified: now,
 		}},
+		tags: copyTags(cfg.Tags),
 	}
 
 	// SetIfAbsent guards against a concurrent create racing between Get and Set.
@@ -189,7 +212,7 @@ func (m *Mock) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, s
 
 		cfg.Overwrite = true
 
-		return m.PutParameter(ctx, cfg)
+		return m.PutParameter(ctx, *cfg)
 	}
 
 	return 1, tier, nil

--- a/providers/aws/ssm/ssm_test.go
+++ b/providers/aws/ssm/ssm_test.go
@@ -116,6 +116,24 @@ func TestPutOverwriteChangingTypeRejected(t *testing.T) {
 	}
 }
 
+func TestPutParameterInvalidTypeRejected(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	_, _, err := m.PutParameter(ctx, driver.PutConfig{Name: "/bad", Value: "v", Type: "Bogus"})
+	if err == nil {
+		t.Fatal("PutParameter(invalid type): want error, got nil")
+	}
+
+	if !errors.Is(err, driver.ErrUnsupportedType) {
+		t.Fatalf("want ErrUnsupportedType, got %v", err)
+	}
+
+	if _, err := m.GetParameter(ctx, "/bad", false); !cerrors.IsNotFound(err) {
+		t.Fatalf("after rejected put, GetParameter err = %v, want NotFound", err)
+	}
+}
+
 func TestPutParameterTagsOnCreate(t *testing.T) {
 	m := newMock()
 	ctx := context.Background()

--- a/providers/aws/ssm/ssm_test.go
+++ b/providers/aws/ssm/ssm_test.go
@@ -116,6 +116,50 @@ func TestPutOverwriteChangingTypeRejected(t *testing.T) {
 	}
 }
 
+func TestPutParameterTagsOnCreate(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/t/p", Value: "v", Type: driver.TypeString,
+		Tags: map[string]string{"Env": "prod"},
+	}); err != nil {
+		t.Fatalf("PutParameter(create with tags): %v", err)
+	}
+
+	tags, err := m.ListParameterTags(ctx, "/t/p")
+	if err != nil {
+		t.Fatalf("ListParameterTags: %v", err)
+	}
+
+	if len(tags) != 1 || tags["Env"] != "prod" {
+		t.Fatalf("tags = %v, want {Env:prod}", tags)
+	}
+}
+
+func TestPutParameterOverwriteWithTagsRejected(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/t/ot", Value: "v1", Type: driver.TypeString,
+	}); err != nil {
+		t.Fatalf("PutParameter(create): %v", err)
+	}
+
+	_, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/t/ot", Value: "v2", Overwrite: true,
+		Tags: map[string]string{"K": "V"},
+	})
+	if err == nil {
+		t.Fatal("PutParameter(overwrite+tags): want error, got nil")
+	}
+
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("want InvalidArgument, got %v", err)
+	}
+}
+
 func TestLabelParameterVersionAndSelector(t *testing.T) {
 	m := newMock()
 	ctx := context.Background()

--- a/providers/aws/ssm/ssm_test.go
+++ b/providers/aws/ssm/ssm_test.go
@@ -249,6 +249,92 @@ func TestGetParametersByPathRecursive(t *testing.T) {
 	}
 }
 
+func TestGetParametersByPathTypeFilter(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{Name: "/f/a", Value: "1", Type: driver.TypeString}); err != nil {
+		t.Fatalf("Put /f/a: %v", err)
+	}
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{Name: "/f/b", Value: "x,y", Type: driver.TypeStringList}); err != nil {
+		t.Fatalf("Put /f/b: %v", err)
+	}
+
+	got, err := m.GetParametersByPath(ctx, driver.GetByPathInput{
+		Path: "/f",
+		ParameterFilters: []driver.ParameterStringFilter{
+			{Key: "Type", Option: "Equals", Values: []string{driver.TypeString}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetParametersByPath(Type=String): %v", err)
+	}
+
+	if len(got) != 1 || got[0].Name != "/f/a" {
+		t.Fatalf("got %+v, want only /f/a", paramNamesOf(got))
+	}
+}
+
+func TestGetParametersByPathLabelFilter(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	for _, n := range []string{"/g/a", "/g/b"} {
+		if _, _, err := m.PutParameter(ctx, driver.PutConfig{Name: n, Value: "v", Type: driver.TypeString}); err != nil {
+			t.Fatalf("Put %s: %v", n, err)
+		}
+	}
+
+	if _, _, err := m.LabelParameterVersion(ctx, "/g/a", 0, []string{"prod"}); err != nil {
+		t.Fatalf("LabelParameterVersion: %v", err)
+	}
+
+	got, err := m.GetParametersByPath(ctx, driver.GetByPathInput{
+		Path: "/g",
+		ParameterFilters: []driver.ParameterStringFilter{
+			{Key: "Label", Option: "Equals", Values: []string{"prod"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetParametersByPath(Label=prod): %v", err)
+	}
+
+	if len(got) != 1 || got[0].Name != "/g/a" {
+		t.Fatalf("got %v, want only /g/a", paramNamesOf(got))
+	}
+}
+
+func TestGetParametersByPathInvalidFilter(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	_, err := m.GetParametersByPath(ctx, driver.GetByPathInput{
+		Path:             "/f",
+		ParameterFilters: []driver.ParameterStringFilter{{Key: "Name", Option: "Equals", Values: []string{"x"}}},
+	})
+	if !errors.Is(err, driver.ErrInvalidFilterKey) {
+		t.Fatalf("unsupported key: got %v, want ErrInvalidFilterKey", err)
+	}
+
+	_, err = m.GetParametersByPath(ctx, driver.GetByPathInput{
+		Path:             "/f",
+		ParameterFilters: []driver.ParameterStringFilter{{Key: "Type", Option: "Contains", Values: []string{"String"}}},
+	})
+	if !errors.Is(err, driver.ErrInvalidFilterOption) {
+		t.Fatalf("unsupported option: got %v, want ErrInvalidFilterOption", err)
+	}
+}
+
+func paramNamesOf(ps []driver.Parameter) []string {
+	out := make([]string, 0, len(ps))
+	for _, p := range ps {
+		out = append(out, p.Name)
+	}
+
+	return out
+}
+
 // TestDeleteParameterStripsSelector covers #266: DeleteParameter strips a
 // ":version"/":label" selector (like the read paths) so a selector addresses
 // the base parameter rather than a literal name containing ':'.

--- a/providers/aws/ssm/tags.go
+++ b/providers/aws/ssm/tags.go
@@ -46,6 +46,20 @@ func (m *Mock) UntagParameter(_ context.Context, name string, keys []string) err
 	return nil
 }
 
+// copyTags returns a defensive copy of the given tag map, or nil when empty.
+func copyTags(tags map[string]string) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(tags))
+	for k, v := range tags {
+		out[k] = v
+	}
+
+	return out
+}
+
 // ListParameterTags returns a parameter's tags (SSM ListTagsForResource).
 func (m *Mock) ListParameterTags(_ context.Context, name string) (map[string]string, error) {
 	pd, ok := m.params.Get(name)

--- a/server/aws/ssm/get_parameters_by_path_filter_test.go
+++ b/server/aws/ssm/get_parameters_by_path_filter_test.go
@@ -1,0 +1,72 @@
+package ssm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsssm "github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKGetParametersByPathTypeFilter verifies GetParametersByPath honors a
+// ParameterFilters Type=Equals=String filter, returning only String parameters.
+func TestSDKGetParametersByPathTypeFilter(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := context.Background()
+
+	if _, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name: aws.String("/f/a"), Value: aws.String("1"), Type: ssmtypes.ParameterTypeString,
+	}); err != nil {
+		t.Fatalf("PutParameter /f/a: %v", err)
+	}
+
+	if _, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name: aws.String("/f/b"), Value: aws.String("x,y"), Type: ssmtypes.ParameterTypeStringList,
+	}); err != nil {
+		t.Fatalf("PutParameter /f/b: %v", err)
+	}
+
+	got, err := client.GetParametersByPath(ctx, &awsssm.GetParametersByPathInput{
+		Path: aws.String("/f"),
+		ParameterFilters: []ssmtypes.ParameterStringFilter{
+			{Key: aws.String("Type"), Option: aws.String("Equals"), Values: []string{"String"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetParametersByPath(Type=String): %v", err)
+	}
+
+	if names := paramNames(got.Parameters); !equalStrings(names, []string{"/f/a"}) {
+		t.Fatalf("names = %v, want [/f/a]", names)
+	}
+}
+
+// TestSDKGetParametersByPathInvalidFilterKey verifies that a filter key
+// GetParametersByPath doesn't support (e.g. Name) is rejected with
+// InvalidFilterKey.
+func TestSDKGetParametersByPathInvalidFilterKey(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := context.Background()
+
+	_, err := client.GetParametersByPath(ctx, &awsssm.GetParametersByPathInput{
+		Path: aws.String("/f"),
+		ParameterFilters: []ssmtypes.ParameterStringFilter{
+			{Key: aws.String("Name"), Option: aws.String("BeginsWith"), Values: []string{"/f"}},
+		},
+	})
+	if err == nil {
+		t.Fatal("GetParametersByPath(Name filter): expected error, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not an API error: %v", err)
+	}
+
+	if apiErr.ErrorCode() != "InvalidFilterKey" {
+		t.Fatalf("error code = %q, want InvalidFilterKey", apiErr.ErrorCode())
+	}
+}

--- a/server/aws/ssm/operations.go
+++ b/server/aws/ssm/operations.go
@@ -14,6 +14,14 @@ func (h *Handler) putParameter(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var tags map[string]string
+	if len(req.Tags) > 0 {
+		tags = make(map[string]string, len(req.Tags))
+		for _, t := range req.Tags {
+			tags[t.Key] = t.Value
+		}
+	}
+
 	version, tier, err := h.store.PutParameter(r.Context(), ssmdriver.PutConfig{
 		Name:        req.Name,
 		Value:       req.Value,
@@ -22,6 +30,7 @@ func (h *Handler) putParameter(w http.ResponseWriter, r *http.Request) {
 		Overwrite:   req.Overwrite,
 		Tier:        req.Tier,
 		DataType:    req.DataType,
+		Tags:        tags,
 	})
 	if err != nil {
 		// Changing a parameter's type on an Overwrite update is rejected by

--- a/server/aws/ssm/operations.go
+++ b/server/aws/ssm/operations.go
@@ -103,11 +103,24 @@ func (h *Handler) getParametersByPath(w http.ResponseWriter, r *http.Request) {
 	}
 
 	found, err := h.store.GetParametersByPath(r.Context(), ssmdriver.GetByPathInput{
-		Path:           req.Path,
-		Recursive:      req.Recursive,
-		WithDecryption: req.WithDecryption,
+		Path:             req.Path,
+		Recursive:        req.Recursive,
+		WithDecryption:   req.WithDecryption,
+		ParameterFilters: toDriverFilters(req.ParameterFilters),
 	})
 	if err != nil {
+		// GetParametersByPath rejects an unsupported filter key/option with the
+		// distinct InvalidFilterKey/InvalidFilterOption, not ValidationException.
+		if errors.Is(err, ssmdriver.ErrInvalidFilterKey) {
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidFilterKey", err.Error())
+			return
+		}
+
+		if errors.Is(err, ssmdriver.ErrInvalidFilterOption) {
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidFilterOption", err.Error())
+			return
+		}
+
 		writeErr(w, err)
 		return
 	}

--- a/server/aws/ssm/operations.go
+++ b/server/aws/ssm/operations.go
@@ -41,6 +41,13 @@ func (h *Handler) putParameter(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// An unrecognized Type is UnsupportedParameterType, not the generic
+		// ValidationException that InvalidArgument maps to.
+		if errors.Is(err, ssmdriver.ErrUnsupportedType) {
+			wire.WriteJSONError(w, http.StatusBadRequest, "UnsupportedParameterType", err.Error())
+			return
+		}
+
 		writeErr(w, err)
 		return
 	}

--- a/server/aws/ssm/put_parameter_tags_test.go
+++ b/server/aws/ssm/put_parameter_tags_test.go
@@ -1,0 +1,83 @@
+package ssm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsssm "github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKPutParameterTagsOnCreate verifies that Tags supplied inline on
+// PutParameter (create) are persisted and returned by ListTagsForResource.
+// Regression for the Terraform tag-drift bug where create-time Tags were
+// silently dropped.
+func TestSDKPutParameterTagsOnCreate(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := context.Background()
+
+	if _, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name:  aws.String("/app/tagged"),
+		Value: aws.String("v"),
+		Type:  ssmtypes.ParameterTypeString,
+		Tags: []ssmtypes.Tag{
+			{Key: aws.String("Env"), Value: aws.String("prod")},
+		},
+	}); err != nil {
+		t.Fatalf("PutParameter(create with tags): %v", err)
+	}
+
+	list, err := client.ListTagsForResource(ctx, &awsssm.ListTagsForResourceInput{
+		ResourceType: ssmtypes.ResourceTypeForTaggingParameter,
+		ResourceId:   aws.String("/app/tagged"),
+	})
+	if err != nil {
+		t.Fatalf("ListTagsForResource: %v", err)
+	}
+
+	if len(list.TagList) != 1 ||
+		aws.ToString(list.TagList[0].Key) != "Env" ||
+		aws.ToString(list.TagList[0].Value) != "prod" {
+		t.Fatalf("TagList = %+v, want [{Env prod}]", list.TagList)
+	}
+}
+
+// TestSDKPutParameterOverwriteWithTagsRejected verifies that supplying Tags
+// together with Overwrite=true is rejected with ValidationException, matching
+// real Parameter Store.
+func TestSDKPutParameterOverwriteWithTagsRejected(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := context.Background()
+
+	if _, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name:  aws.String("/app/ot"),
+		Value: aws.String("v1"),
+		Type:  ssmtypes.ParameterTypeString,
+	}); err != nil {
+		t.Fatalf("PutParameter(create): %v", err)
+	}
+
+	_, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name:      aws.String("/app/ot"),
+		Value:     aws.String("v2"),
+		Overwrite: aws.Bool(true),
+		Tags: []ssmtypes.Tag{
+			{Key: aws.String("K"), Value: aws.String("V")},
+		},
+	})
+	if err == nil {
+		t.Fatal("PutParameter(overwrite+tags): expected error, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not an API error: %v", err)
+	}
+
+	if apiErr.ErrorCode() != "ValidationException" {
+		t.Fatalf("error code = %q, want ValidationException", apiErr.ErrorCode())
+	}
+}

--- a/server/aws/ssm/put_parameter_type_test.go
+++ b/server/aws/ssm/put_parameter_type_test.go
@@ -52,6 +52,66 @@ func TestSDKPutParameterOverwriteRetainsType(t *testing.T) {
 	}
 }
 
+// TestSDKPutParameterInvalidTypeRejected verifies that an unrecognized Type is
+// rejected with UnsupportedParameterType rather than being silently coerced to
+// String.
+func TestSDKPutParameterInvalidTypeRejected(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := context.Background()
+
+	_, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name:  aws.String("/app/badtype"),
+		Value: aws.String("v"),
+		Type:  ssmtypes.ParameterType("Bogus"),
+	})
+	if err == nil {
+		t.Fatal("PutParameter(invalid type): expected error, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not an API error: %v", err)
+	}
+
+	if apiErr.ErrorCode() != "UnsupportedParameterType" {
+		t.Fatalf("error code = %q, want UnsupportedParameterType", apiErr.ErrorCode())
+	}
+
+	// The parameter must not have been stored.
+	_, err = client.GetParameter(ctx, &awsssm.GetParameterInput{Name: aws.String("/app/badtype")})
+
+	var notFound *ssmtypes.ParameterNotFound
+	if !errors.As(err, &notFound) {
+		t.Fatalf("GetParameter after rejected put: got %v, want ParameterNotFound", err)
+	}
+}
+
+// TestSDKPutParameterValidTypesAccepted verifies each recognized Type is
+// accepted (regression guard for the invalid-type validation).
+func TestSDKPutParameterValidTypesAccepted(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		typ  ssmtypes.ParameterType
+	}{
+		{"/valid/str", ssmtypes.ParameterTypeString},
+		{"/valid/list", ssmtypes.ParameterTypeStringList},
+		{"/valid/secure", ssmtypes.ParameterTypeSecureString},
+	}
+
+	for _, tc := range cases {
+		if _, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+			Name:  aws.String(tc.name),
+			Value: aws.String("a,b"),
+			Type:  tc.typ,
+		}); err != nil {
+			t.Fatalf("PutParameter(%s): %v", tc.typ, err)
+		}
+	}
+}
+
 // TestSDKPutParameterOverwriteSameTypeAllowed verifies that re-sending the same
 // type on an Overwrite update is accepted.
 func TestSDKPutParameterOverwriteSameTypeAllowed(t *testing.T) {

--- a/server/aws/ssm/types.go
+++ b/server/aws/ssm/types.go
@@ -56,11 +56,12 @@ type getParametersRequest struct {
 }
 
 type getParametersByPathRequest struct {
-	Path           string `json:"Path"`
-	Recursive      bool   `json:"Recursive"`
-	WithDecryption bool   `json:"WithDecryption"`
-	MaxResults     int32  `json:"MaxResults"`
-	NextToken      string `json:"NextToken"`
+	Path             string                  `json:"Path"`
+	Recursive        bool                    `json:"Recursive"`
+	WithDecryption   bool                    `json:"WithDecryption"`
+	MaxResults       int32                   `json:"MaxResults"`
+	NextToken        string                  `json:"NextToken"`
+	ParameterFilters []parameterStringFilter `json:"ParameterFilters"`
 }
 
 // parameterStringFilter is the modern DescribeParameters ParameterFilters shape
@@ -169,6 +170,24 @@ func epochSeconds(iso string) float64 {
 	}
 
 	return float64(t.Unix())
+}
+
+// toDriverFilters converts wire ParameterFilters to the driver shape.
+func toDriverFilters(filters []parameterStringFilter) []ssmdriver.ParameterStringFilter {
+	if len(filters) == 0 {
+		return nil
+	}
+
+	out := make([]ssmdriver.ParameterStringFilter, 0, len(filters))
+	for _, f := range filters {
+		out = append(out, ssmdriver.ParameterStringFilter{
+			Key:    f.Key,
+			Option: f.Option,
+			Values: f.Values,
+		})
+	}
+
+	return out
 }
 
 func toParameterJSON(p ssmdriver.Parameter) parameterJSON {

--- a/server/aws/ssm/types.go
+++ b/server/aws/ssm/types.go
@@ -35,13 +35,14 @@ type parameterMetadataJSON struct {
 // --- request envelopes ---
 
 type putParameterRequest struct {
-	Name        string `json:"Name"`
-	Value       string `json:"Value"`
-	Type        string `json:"Type"`
-	Description string `json:"Description"`
-	Overwrite   bool   `json:"Overwrite"`
-	Tier        string `json:"Tier"`
-	DataType    string `json:"DataType"`
+	Name        string   `json:"Name"`
+	Value       string   `json:"Value"`
+	Type        string   `json:"Type"`
+	Description string   `json:"Description"`
+	Overwrite   bool     `json:"Overwrite"`
+	Tier        string   `json:"Tier"`
+	DataType    string   `json:"DataType"`
+	Tags        []ssmTag `json:"Tags"`
 }
 
 type getParameterRequest struct {

--- a/services/parameterstore/driver/driver.go
+++ b/services/parameterstore/driver/driver.go
@@ -36,6 +36,15 @@ var ErrTagsWithOverwrite = errors.New(errors.InvalidArgument,
 	"The Tags and Overwrite parameters "+
 		"can't be used at the same time.")
 
+// ErrUnsupportedType is returned by PutParameter when Type is set to a value
+// outside {String, StringList, SecureString}. Real Parameter Store rejects an
+// unrecognized type with UnsupportedParameterType rather than silently coercing
+// it. It carries the InvalidArgument code; the SDK-compat layer matches it with
+// errors.Is to return the distinct UnsupportedParameterType wire error.
+var ErrUnsupportedType = errors.New(errors.InvalidArgument,
+	"The parameter type "+
+		"isn't supported.")
+
 // Parameter types, matching AWS SSM Parameter Store.
 const (
 	// TypeString is a plain single-value string parameter.

--- a/services/parameterstore/driver/driver.go
+++ b/services/parameterstore/driver/driver.go
@@ -27,6 +27,15 @@ var ErrTypeMismatch = errors.New(errors.InvalidArgument,
 		"For example, you can't change a parameter from a String type to a SecureString type. "+
 		"You must create a new, unique parameter.")
 
+// ErrTagsWithOverwrite is returned by PutParameter when Tags are supplied
+// together with Overwrite=true. Real Parameter Store rejects that combination —
+// tags can only be set when a parameter is first created (AddTagsToResource
+// changes tags on an existing one). It carries the InvalidArgument code so the
+// SDK-compat layer surfaces it as ValidationException.
+var ErrTagsWithOverwrite = errors.New(errors.InvalidArgument,
+	"The Tags and Overwrite parameters "+
+		"can't be used at the same time.")
+
 // Parameter types, matching AWS SSM Parameter Store.
 const (
 	// TypeString is a plain single-value string parameter.
@@ -47,6 +56,10 @@ type PutConfig struct {
 	Overwrite   bool
 	Tier        string
 	DataType    string
+	// Tags are applied to the parameter at create time. Real Parameter Store
+	// rejects supplying Tags together with Overwrite=true, so Tags are only
+	// meaningful on a create.
+	Tags map[string]string
 }
 
 // Parameter is a single version of a stored parameter.

--- a/services/parameterstore/driver/driver.go
+++ b/services/parameterstore/driver/driver.go
@@ -45,6 +45,21 @@ var ErrUnsupportedType = errors.New(errors.InvalidArgument,
 	"The parameter type "+
 		"isn't supported.")
 
+// ErrInvalidFilterKey is returned by GetParametersByPath when a ParameterFilters
+// entry uses a Key the operation doesn't support (only Type, KeyId, and Label
+// are valid). It carries InvalidArgument; the SDK-compat layer maps it to the
+// distinct InvalidFilterKey wire error.
+var ErrInvalidFilterKey = errors.New(errors.InvalidArgument,
+	"The specified key "+
+		"isn't valid.")
+
+// ErrInvalidFilterOption is returned by GetParametersByPath when a
+// ParameterFilters entry uses an Option other than Equals or BeginsWith. It
+// carries InvalidArgument; the SDK-compat layer maps it to InvalidFilterOption.
+var ErrInvalidFilterOption = errors.New(errors.InvalidArgument,
+	"The specified filter option isn't valid. "+
+		"Valid options are Equals and BeginsWith.")
+
 // Parameter types, matching AWS SSM Parameter Store.
 const (
 	// TypeString is a plain single-value string parameter.
@@ -105,11 +120,23 @@ type ParameterMetadata struct {
 	LastModifiedUser string
 }
 
+// ParameterStringFilter is a GetParametersByPath filter: a Key, an Option
+// (Equals or BeginsWith; empty means Equals), and one or more Values that are
+// OR'd. Multiple filters are AND'd.
+type ParameterStringFilter struct {
+	Key    string
+	Option string
+	Values []string
+}
+
 // GetByPathInput describes a GetParametersByPath request.
 type GetByPathInput struct {
 	Path           string
 	Recursive      bool
 	WithDecryption bool
+	// ParameterFilters narrows the result. GetParametersByPath supports the
+	// Type, KeyId, and Label keys only; other keys are rejected.
+	ParameterFilters []ParameterStringFilter
 }
 
 // ParameterStore is the interface SSM Parameter Store provider implementations

--- a/services/parameterstore/parameterstore.go
+++ b/services/parameterstore/parameterstore.go
@@ -99,6 +99,8 @@ func (p *ParameterStore) rec(op string, input, output any, err error, dur time.D
 }
 
 // PutParameter creates or updates a parameter, returning the new version and tier.
+//
+//nolint:gocritic // hugeParam: PutConfig mirrors the driver interface signature.
 func (p *ParameterStore) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, string, error) {
 	type result struct {
 		version int64


### PR DESCRIPTION
## What

Fixes 4 real AWS SSM Parameter Store bugs found by a deep real-SDK e2e audit (repros with `aws-sdk-go-v2/service/ssm`).

### [HIGH] PutParameter dropped create-time Tags → Terraform tag drift
`PutParameter` accepted a `Tags` array but the wire request and driver `PutConfig` had no `Tags` field, so tags supplied at create were silently discarded. Terraform/CDK/CloudFormation set parameter tags inline on create and read them back with `ListTagsForResource` → cloudemu returned none → perpetual plan diff. Threaded `Tags` through the wire request → `PutConfig` → provider and store them on the parameter at create; `ListTagsForResource` now returns them.

### [MED] Overwrite + Tags accepted (AWS rejects)
`PutParameter` with both `Overwrite=true` and `Tags` is now rejected with `ValidationException` ("The Tags and Overwrite parameters can't be used at the same time."), matching real Parameter Store. Tags are only settable on create.

### [MED] Invalid Type silently coerced to String
An unrecognized `Type` (a typo like `Strng`) was coerced to `String` and stored, masking client bugs. An explicitly set `Type` is now validated against `{String, StringList, SecureString}` and an invalid value is rejected with `UnsupportedParameterType` (HTTP 400). Omitted `Type` still defaults to String on create and retains the existing type on Overwrite (unchanged).

### [MED] GetParametersByPath ignored ParameterFilters
`GetParametersByPath` returned the whole subtree regardless of `ParameterFilters`, so callers filtering a hierarchy by `Type`/`Label` received parameters they had excluded. Threaded `ParameterFilters` through the wire request → `GetByPathInput` and apply them. Supports the `Type`, `KeyId`, and `Label` keys AWS allows for this operation (Equals/BeginsWith); an unsupported key or option is rejected with `InvalidFilterKey` / `InvalidFilterOption`.

## Why

Each behavior was cross-checked against the official AWS SSM API reference (PutParameter, GetParametersByPath). The tag-drift bug in particular breaks IaC round-tripping against cloudemu.

## Tests

Real `aws-sdk-go-v2` SDK reproductions at the wire layer plus provider-level unit tests:
- Tags persisted on create; Overwrite+Tags → ValidationException
- Invalid Type → UnsupportedParameterType; valid types accepted; Overwrite with omitted Type retains type
- ByPath Type=String filter returns only String params; Label filter; unsupported key → InvalidFilterKey; unsupported option → InvalidFilterOption

Existing SSM tests (versioning/overwrite/selectors/history/labels/path/pagination) stay green. Deferred (not in scope): AllowedPattern enforcement, SecureString KeyId/ciphertext-at-rest, parameter-name validation, Intelligent-Tiering echo.
