### PR TITLE
fix(aws-kms): implement GetPublicKey + advertise Signing/Mac/asymmetric-Encryption algorithms on KeyMetadata

### DIFF
--- a/docs/coverage/README.md
+++ b/docs/coverage/README.md
@@ -36,7 +36,7 @@ capability the code does not implement. Machine-readable: [`coverage.json`](./co
 | `kafka` | [Kafka](./aws/kafka.md) | — | — | — | 59 |
 | `keyspaces` | [Keyspaces](./aws/keyspaces.md) | — | — | — | 18 |
 | `kinesis` | [Kinesis](./aws/kinesis.md) | — | — | — | 39 |
-| `kms` | [KMS](./aws/kms.md) | — | — | — | 45 |
+| `kms` | [KMS](./aws/kms.md) | — | — | — | 46 |
 | `loadbalancer` | [ELB](./aws/elb.md) | [LB](./azure/lb.md) | [LB](./gcp/lb.md) | — | 19 |
 | `logging` | [CloudWatchLogs](./aws/cloudwatchlogs.md) | [LogAnalytics](./azure/loganalytics.md) | [CloudLogging](./gcp/cloudlogging.md) | — | 14 |
 | `managedcassandra` | — | [ManagedCassandra](./azure/managedcassandra.md) | — | — | 15 |

--- a/docs/coverage/aws/README.md
+++ b/docs/coverage/aws/README.md
@@ -24,7 +24,7 @@ Services cloudemu emulates for AWS, by native name. Back to the [cross-provider 
 | [Glue](./glue.md) | `glue` | 299 |
 | [GuardDuty](./guardduty.md) | `guardduty` | 87 |
 | [IAM](./iam.md) | `iam` | 40 |
-| [KMS](./kms.md) | `kms` | 45 |
+| [KMS](./kms.md) | `kms` | 46 |
 | [Kafka](./kafka.md) | `kafka` | 59 |
 | [Keyspaces](./keyspaces.md) | `keyspaces` | 18 |
 | [Kinesis](./kinesis.md) | `kinesis` | 39 |

--- a/docs/coverage/aws/kms.md
+++ b/docs/coverage/aws/kms.md
@@ -3,7 +3,7 @@
 
 AWS's `kms` service · portable interface `driver.KMS` · [AWS index](./README.md)
 
-## Operations (45)
+## Operations (46)
 
 | Operation | Description |
 | --- | --- |
@@ -29,6 +29,7 @@ AWS's `kms` service · portable interface `driver.KMS` · [AWS index](./README.m
 | `GetKeyPolicy` | Key policies. |
 | `GetKeyRotationStatus` |  |
 | `GetParametersForImport` |  |
+| `GetPublicKey` |  |
 | `ImportKeyMaterial` |  |
 | `ListAliases` |  |
 | `ListGrants` |  |
@@ -71,6 +72,7 @@ Crypto is the cryptographic surface of KMS. It is embedded in the KMS
 | `GenerateDataKeyWithoutPlaintext` |  |
 | `GenerateMac` |  |
 | `GenerateRandom` |  |
+| `GetPublicKey` |  |
 | `ReEncrypt` |  |
 | `Sign` |  |
 | `Verify` |  |

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -5450,6 +5450,9 @@
         "name": "GetParametersForImport"
       },
       {
+        "name": "GetPublicKey"
+      },
+      {
         "name": "ImportKeyMaterial"
       },
       {
@@ -5548,6 +5551,9 @@
           },
           {
             "name": "GenerateRandom"
+          },
+          {
+            "name": "GetPublicKey"
           },
           {
             "name": "ReEncrypt"

--- a/providers/aws/kms/crypto.go
+++ b/providers/aws/kms/crypto.go
@@ -246,28 +246,73 @@ func rsaAlgOrDefault(alg string) string {
 	return driver.EncRSAOAEPSHA256
 }
 
-// Decrypt decrypts a ciphertext blob. The blob is self-describing, so KeyID is
-// optional for symmetric keys but validated when supplied.
+// Decrypt decrypts a ciphertext blob. A self-describing wrapped blob (the
+// emulator's own symmetric AES-GCM or RSA output) names its own key and
+// decrypts without a KeyId. Raw RSA-OAEP ciphertext produced offline from a
+// downloaded public key (see GetPublicKey) carries no envelope, so it is
+// decrypted via the asymmetric fallback using the explicit KeyId — matching
+// real KMS, where asymmetric Decrypt requires the key identifier.
 func (m *Mock) Decrypt(_ context.Context, in driver.DecryptInput) (*driver.DecryptOutput, error) {
-	magic, keyID, body, err := decodeBlob(in.CiphertextBlob)
-	if err != nil {
-		return nil, err
+	if out, matched, err := m.decryptWrapped(in); matched {
+		return out, err
+	}
+
+	return m.decryptRawAsymmetric(in)
+}
+
+// decryptWrapped handles the self-describing blob format. matched is true when
+// the blob is one of the emulator's recognized wrapped blobs for a known key,
+// in which case the returned error (if any) is authoritative; matched is false
+// when the input is not such a blob, so the caller can try the raw-asymmetric
+// path instead.
+func (m *Mock) decryptWrapped(in driver.DecryptInput) (out *driver.DecryptOutput, matched bool, err error) {
+	magic, keyID, body, derr := decodeBlob(in.CiphertextBlob)
+	if derr != nil || (magic != blobMagicGCM && magic != blobMagicRSAOAEP) {
+		return nil, false, nil
+	}
+
+	kd, ok := m.keys.Get(keyID)
+	if !ok {
+		return nil, false, nil
 	}
 
 	if in.KeyID != "" {
 		resolved, rerr := m.resolveKeyID(in.KeyID)
 		if rerr != nil {
-			return nil, rerr
+			return nil, true, rerr
 		}
 
 		if resolved != keyID {
-			return nil, driver.ErrIncorrectKey
+			return nil, true, driver.ErrIncorrectKey
 		}
 	}
 
-	kd, ok := m.keys.Get(keyID)
-	if !ok {
-		return nil, errors.Newf(errors.NotFound, "key %q not found", keyID)
+	kd.mu.RLock()
+	defer kd.mu.RUnlock()
+
+	if uerr := requireUsable(kd); uerr != nil {
+		return nil, true, uerr
+	}
+
+	pt, alg, err := decryptBody(kd, magic, body, in.EncryptionContext)
+	if err != nil {
+		return nil, true, err
+	}
+
+	return &driver.DecryptOutput{KeyID: kd.meta.KeyID, Plaintext: pt, EncryptionAlgorithm: alg}, true, nil
+}
+
+// decryptRawAsymmetric decrypts raw RSA-OAEP ciphertext (no envelope) under the
+// asymmetric key named by KeyId. A missing/symmetric/non-RSA key yields the same
+// InvalidCiphertext/InvalidKeyUsage errors real KMS returns.
+func (m *Mock) decryptRawAsymmetric(in driver.DecryptInput) (*driver.DecryptOutput, error) {
+	if in.KeyID == "" {
+		return nil, driver.ErrInvalidCiphertext
+	}
+
+	kd, err := m.getKey(in.KeyID)
+	if err != nil {
+		return nil, err
 	}
 
 	kd.mu.RLock()
@@ -277,7 +322,15 @@ func (m *Mock) Decrypt(_ context.Context, in driver.DecryptInput) (*driver.Decry
 		return nil, uerr
 	}
 
-	pt, alg, err := decryptBody(kd, magic, body, in.EncryptionContext)
+	if _, ok := kd.privKey.(*rsa.PrivateKey); !ok {
+		return nil, driver.ErrInvalidCiphertext
+	}
+
+	if kd.meta.KeyUsage != driver.UsageEncryptDecrypt {
+		return nil, driver.ErrInvalidKeyUsage
+	}
+
+	pt, alg, err := decryptRSA(kd, in.CiphertextBlob)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/aws/kms/crypto_asym.go
+++ b/providers/aws/kms/crypto_asym.go
@@ -84,6 +84,44 @@ func (m *Mock) GenerateDataKeyPairWithoutPlaintext(
 	return out, nil
 }
 
+// GetPublicKey returns the DER-encoded (SPKI, RFC 5280) public key of an
+// asymmetric key, along with its spec/usage and the algorithms it supports so a
+// caller can encrypt or verify offline. Symmetric (and other keys with no
+// public half) are rejected with UnsupportedOperationException, matching real
+// KMS.
+func (m *Mock) GetPublicKey(_ context.Context, in driver.GetPublicKeyInput) (*driver.GetPublicKeyOutput, error) {
+	kd, err := m.getKey(in.KeyID)
+	if err != nil {
+		return nil, err
+	}
+
+	kd.mu.RLock()
+	defer kd.mu.RUnlock()
+
+	if uerr := requireUsable(kd); uerr != nil {
+		return nil, uerr
+	}
+
+	pub := publicKeyOf(kd.privKey)
+	if pub == nil {
+		return nil, driver.ErrUnsupportedOperation
+	}
+
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, errors.Newf(errors.Internal, "marshal public key: %v", err)
+	}
+
+	return &driver.GetPublicKeyOutput{
+		KeyID:                kd.meta.KeyID,
+		PublicKey:            pubDER,
+		KeySpec:              kd.meta.KeySpec,
+		KeyUsage:             kd.meta.KeyUsage,
+		EncryptionAlgorithms: driver.EncryptionAlgorithmsFor(kd.meta.KeySpec, kd.meta.KeyUsage),
+		SigningAlgorithms:    driver.SigningAlgorithmsFor(kd.meta.KeySpec, kd.meta.KeyUsage),
+	}, nil
+}
+
 func publicKeyOf(priv crypto.PrivateKey) crypto.PublicKey {
 	switch k := priv.(type) {
 	case *rsa.PrivateKey:

--- a/providers/aws/kms/get_public_key_test.go
+++ b/providers/aws/kms/get_public_key_test.go
@@ -1,0 +1,165 @@
+package kms_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"errors"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/kms/driver"
+)
+
+func TestGetPublicKeyRSASignVerify(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	k, err := m.CreateKey(ctx, driver.CreateKeyInput{
+		KeySpec: driver.SpecRSA2048, KeyUsage: driver.UsageSignVerify,
+	})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	out, err := m.GetPublicKey(ctx, driver.GetPublicKeyInput{KeyID: k.KeyID})
+	if err != nil {
+		t.Fatalf("GetPublicKey: %v", err)
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(out.PublicKey)
+	if err != nil {
+		t.Fatalf("ParsePKIXPublicKey: %v", err)
+	}
+
+	rsaPub, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		t.Fatalf("public key type = %T, want *rsa.PublicKey", pub)
+	}
+
+	if out.KeySpec != driver.SpecRSA2048 || out.KeyUsage != driver.UsageSignVerify {
+		t.Fatalf("spec/usage = %s/%s", out.KeySpec, out.KeyUsage)
+	}
+
+	if len(out.SigningAlgorithms) != 6 || len(out.EncryptionAlgorithms) != 0 {
+		t.Fatalf("SigningAlgorithms=%v EncryptionAlgorithms=%v", out.SigningAlgorithms, out.EncryptionAlgorithms)
+	}
+
+	// A signature produced by KMS Sign verifies offline against the returned key.
+	msg := []byte("verify me offline")
+	digest := sha256.Sum256(msg)
+
+	sig, err := m.Sign(ctx, driver.SignInput{
+		KeyID: k.KeyID, Message: msg, MessageType: driver.MessageTypeRaw,
+		SigningAlgorithm: driver.SignRSASSAPSSSHA256,
+	})
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	if err := rsa.VerifyPSS(rsaPub, crypto.SHA256, digest[:], sig.Signature, nil); err != nil {
+		t.Fatalf("offline VerifyPSS: %v", err)
+	}
+}
+
+func TestGetPublicKeyRSAEncryptDecrypt(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	k, err := m.CreateKey(ctx, driver.CreateKeyInput{
+		KeySpec: driver.SpecRSA2048, KeyUsage: driver.UsageEncryptDecrypt,
+	})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	out, err := m.GetPublicKey(ctx, driver.GetPublicKeyInput{KeyID: k.KeyID})
+	if err != nil {
+		t.Fatalf("GetPublicKey: %v", err)
+	}
+
+	if len(out.EncryptionAlgorithms) != 2 || len(out.SigningAlgorithms) != 0 {
+		t.Fatalf("EncryptionAlgorithms=%v SigningAlgorithms=%v", out.EncryptionAlgorithms, out.SigningAlgorithms)
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(out.PublicKey)
+	if err != nil {
+		t.Fatalf("ParsePKIXPublicKey: %v", err)
+	}
+
+	rsaPub, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		t.Fatalf("public key type = %T, want *rsa.PublicKey", pub)
+	}
+
+	// Offline RSA-OAEP-SHA-256 encrypt with the downloaded public key, then KMS
+	// Decrypt (with the KeyId) must recover the plaintext.
+	plaintext := []byte("hybrid crypto payload")
+
+	ct, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, rsaPub, plaintext, nil)
+	if err != nil {
+		t.Fatalf("offline EncryptOAEP: %v", err)
+	}
+
+	dec, err := m.Decrypt(ctx, driver.DecryptInput{KeyID: k.KeyID, CiphertextBlob: ct})
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+
+	if string(dec.Plaintext) != string(plaintext) {
+		t.Fatalf("Decrypt = %q, want %q", dec.Plaintext, plaintext)
+	}
+}
+
+func TestGetPublicKeyECC(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	k, err := m.CreateKey(ctx, driver.CreateKeyInput{
+		KeySpec: driver.SpecECCNISTP256, KeyUsage: driver.UsageSignVerify,
+	})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	out, err := m.GetPublicKey(ctx, driver.GetPublicKeyInput{KeyID: k.KeyID})
+	if err != nil {
+		t.Fatalf("GetPublicKey: %v", err)
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(out.PublicKey)
+	if err != nil {
+		t.Fatalf("ParsePKIXPublicKey: %v", err)
+	}
+
+	if _, ok := pub.(*ecdsa.PublicKey); !ok {
+		t.Fatalf("public key type = %T, want *ecdsa.PublicKey", pub)
+	}
+
+	if out.KeySpec != driver.SpecECCNISTP256 {
+		t.Fatalf("KeySpec = %s, want ECC_NIST_P256", out.KeySpec)
+	}
+
+	if len(out.SigningAlgorithms) != 1 || out.SigningAlgorithms[0] != driver.SignECDSASHA256 {
+		t.Fatalf("SigningAlgorithms = %v, want [ECDSA_SHA_256]", out.SigningAlgorithms)
+	}
+}
+
+func TestGetPublicKeySymmetricRejected(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	k, _ := m.CreateKey(ctx, driver.CreateKeyInput{})
+
+	_, err := m.GetPublicKey(ctx, driver.GetPublicKeyInput{KeyID: k.KeyID})
+	if err == nil {
+		t.Fatal("GetPublicKey on a symmetric key should fail")
+	}
+
+	if !errors.Is(err, driver.ErrUnsupportedOperation) {
+		t.Fatalf("GetPublicKey(symmetric) = %v, want ErrUnsupportedOperation", err)
+	}
+}

--- a/providers/aws/kms/lifecycle.go
+++ b/providers/aws/kms/lifecycle.go
@@ -61,6 +61,10 @@ func (m *Mock) CreateKey(_ context.Context, in driver.CreateKeyInput) (*driver.K
 		policies: map[string]string{driver.DefaultPolicyName: defaultKeyPolicy(in.Policy, m.opts.AccountID)},
 	}
 
+	kd.meta.EncryptionAlgorithms = driver.EncryptionAlgorithmsFor(spec, usage)
+	kd.meta.SigningAlgorithms = driver.SigningAlgorithmsFor(spec, usage)
+	kd.meta.MacAlgorithms = driver.MacAlgorithmsFor(spec, usage)
+
 	if in.MultiRegion {
 		kd.meta.MultiRegionKeyType = "PRIMARY"
 		kd.meta.PrimaryRegion = m.opts.Region

--- a/server/aws/kms/crypto_ops.go
+++ b/server/aws/kms/crypto_ops.go
@@ -149,6 +149,25 @@ func (h *Handler) generateRandom(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (h *Handler) getPublicKey(w http.ResponseWriter, r *http.Request) {
+	dispatch(h, w, r, func(h *Handler, ctx context.Context, req *getPublicKeyRequest) (any, error) {
+		out, err := h.kms.GetPublicKey(ctx, kmsdriver.GetPublicKeyInput{KeyID: req.KeyID})
+		if err != nil {
+			return nil, err
+		}
+
+		return getPublicKeyResponse{
+			KeyID:                 out.KeyID,
+			PublicKey:             out.PublicKey,
+			KeySpec:               out.KeySpec,
+			CustomerMasterKeySpec: out.KeySpec,
+			KeyUsage:              out.KeyUsage,
+			EncryptionAlgorithms:  out.EncryptionAlgorithms,
+			SigningAlgorithms:     out.SigningAlgorithms,
+		}, nil
+	})
+}
+
 //nolint:dupl // templated KMS wire handler; the decode/call/respond shape is intrinsic
 func (h *Handler) sign(w http.ResponseWriter, r *http.Request) {
 	dispatch(h, w, r, func(h *Handler, ctx context.Context, req *signRequest) (any, error) {

--- a/server/aws/kms/crypto_types.go
+++ b/server/aws/kms/crypto_types.go
@@ -82,6 +82,20 @@ type generateRandomResponse struct {
 	Plaintext []byte `json:"Plaintext"`
 }
 
+type getPublicKeyRequest struct {
+	KeyID string `json:"KeyId"`
+}
+
+type getPublicKeyResponse struct {
+	KeyID                 string   `json:"KeyId"`
+	PublicKey             []byte   `json:"PublicKey"`
+	KeySpec               string   `json:"KeySpec"`
+	CustomerMasterKeySpec string   `json:"CustomerMasterKeySpec"`
+	KeyUsage              string   `json:"KeyUsage"`
+	EncryptionAlgorithms  []string `json:"EncryptionAlgorithms,omitempty"`
+	SigningAlgorithms     []string `json:"SigningAlgorithms,omitempty"`
+}
+
 type signRequest struct {
 	KeyID            string `json:"KeyId"`
 	Message          []byte `json:"Message"`

--- a/server/aws/kms/get_public_key_sdk_test.go
+++ b/server/aws/kms/get_public_key_sdk_test.go
@@ -1,0 +1,184 @@
+package kms_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+)
+
+// TestSDKGetPublicKeyRSASignVerify: a real client downloads the public key of a
+// SIGN_VERIFY RSA key, parses the DER, and offline-verifies a KMS signature.
+func TestSDKGetPublicKeyRSASignVerify(t *testing.T) {
+	ctx := context.Background()
+	c := newKMSClient(t)
+
+	key, err := c.CreateKey(ctx, &awskms.CreateKeyInput{
+		KeySpec: kmstypes.KeySpecRsa2048, KeyUsage: kmstypes.KeyUsageTypeSignVerify,
+	})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	keyID := aws.ToString(key.KeyMetadata.KeyId)
+
+	pubOut, err := c.GetPublicKey(ctx, &awskms.GetPublicKeyInput{KeyId: aws.String(keyID)})
+	if err != nil {
+		t.Fatalf("GetPublicKey: %v", err)
+	}
+
+	if pubOut.KeySpec != kmstypes.KeySpecRsa2048 || pubOut.KeyUsage != kmstypes.KeyUsageTypeSignVerify {
+		t.Fatalf("spec/usage = %s/%s", pubOut.KeySpec, pubOut.KeyUsage)
+	}
+
+	if len(pubOut.SigningAlgorithms) != 6 {
+		t.Fatalf("SigningAlgorithms = %v, want 6", pubOut.SigningAlgorithms)
+	}
+
+	if len(pubOut.EncryptionAlgorithms) != 0 {
+		t.Fatalf("EncryptionAlgorithms = %v, want none for SIGN_VERIFY", pubOut.EncryptionAlgorithms)
+	}
+
+	parsed, err := x509.ParsePKIXPublicKey(pubOut.PublicKey)
+	if err != nil {
+		t.Fatalf("ParsePKIXPublicKey: %v", err)
+	}
+
+	rsaPub, ok := parsed.(*rsa.PublicKey)
+	if !ok {
+		t.Fatalf("public key type = %T, want *rsa.PublicKey", parsed)
+	}
+
+	// KMS Sign, then verify the signature offline against the downloaded key.
+	msg := []byte("sign this with kms, verify offline")
+
+	sig, err := c.Sign(ctx, &awskms.SignInput{
+		KeyId: aws.String(keyID), Message: msg,
+		MessageType: kmstypes.MessageTypeRaw, SigningAlgorithm: kmstypes.SigningAlgorithmSpecRsassaPssSha256,
+	})
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	digest := sha256.Sum256(msg)
+	if err := rsa.VerifyPSS(rsaPub, crypto.SHA256, digest[:], sig.Signature, nil); err != nil {
+		t.Fatalf("offline VerifyPSS against downloaded public key: %v", err)
+	}
+}
+
+// TestSDKGetPublicKeyRSAEncryptDecrypt: download the public key of an
+// ENCRYPT_DECRYPT RSA key, encrypt offline, and recover via KMS Decrypt.
+func TestSDKGetPublicKeyRSAEncryptDecrypt(t *testing.T) {
+	ctx := context.Background()
+	c := newKMSClient(t)
+
+	key, err := c.CreateKey(ctx, &awskms.CreateKeyInput{
+		KeySpec: kmstypes.KeySpecRsa2048, KeyUsage: kmstypes.KeyUsageTypeEncryptDecrypt,
+	})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	keyID := aws.ToString(key.KeyMetadata.KeyId)
+
+	pubOut, err := c.GetPublicKey(ctx, &awskms.GetPublicKeyInput{KeyId: aws.String(keyID)})
+	if err != nil {
+		t.Fatalf("GetPublicKey: %v", err)
+	}
+
+	if len(pubOut.EncryptionAlgorithms) != 2 || len(pubOut.SigningAlgorithms) != 0 {
+		t.Fatalf("EncryptionAlgorithms=%v SigningAlgorithms=%v", pubOut.EncryptionAlgorithms, pubOut.SigningAlgorithms)
+	}
+
+	parsed, err := x509.ParsePKIXPublicKey(pubOut.PublicKey)
+	if err != nil {
+		t.Fatalf("ParsePKIXPublicKey: %v", err)
+	}
+
+	rsaPub := parsed.(*rsa.PublicKey)
+	plaintext := []byte("encrypt me offline")
+
+	ct, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, rsaPub, plaintext, nil)
+	if err != nil {
+		t.Fatalf("offline EncryptOAEP: %v", err)
+	}
+
+	dec, err := c.Decrypt(ctx, &awskms.DecryptInput{
+		KeyId: aws.String(keyID), CiphertextBlob: ct,
+		EncryptionAlgorithm: kmstypes.EncryptionAlgorithmSpecRsaesOaepSha256,
+	})
+	if err != nil {
+		t.Fatalf("Decrypt offline ciphertext: %v", err)
+	}
+
+	if string(dec.Plaintext) != string(plaintext) {
+		t.Fatalf("Decrypt = %q, want %q", dec.Plaintext, plaintext)
+	}
+}
+
+// TestSDKGetPublicKeyECC: an ECC key returns an *ecdsa.PublicKey and the
+// spec-matched single signing algorithm.
+func TestSDKGetPublicKeyECC(t *testing.T) {
+	ctx := context.Background()
+	c := newKMSClient(t)
+
+	key, err := c.CreateKey(ctx, &awskms.CreateKeyInput{
+		KeySpec: kmstypes.KeySpecEccNistP384, KeyUsage: kmstypes.KeyUsageTypeSignVerify,
+	})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	pubOut, err := c.GetPublicKey(ctx, &awskms.GetPublicKeyInput{KeyId: key.KeyMetadata.KeyId})
+	if err != nil {
+		t.Fatalf("GetPublicKey: %v", err)
+	}
+
+	if pubOut.KeySpec != kmstypes.KeySpecEccNistP384 {
+		t.Fatalf("KeySpec = %s, want ECC_NIST_P384", pubOut.KeySpec)
+	}
+
+	if len(pubOut.SigningAlgorithms) != 1 || pubOut.SigningAlgorithms[0] != kmstypes.SigningAlgorithmSpecEcdsaSha384 {
+		t.Fatalf("SigningAlgorithms = %v, want [ECDSA_SHA_384]", pubOut.SigningAlgorithms)
+	}
+
+	parsed, err := x509.ParsePKIXPublicKey(pubOut.PublicKey)
+	if err != nil {
+		t.Fatalf("ParsePKIXPublicKey: %v", err)
+	}
+
+	if _, ok := parsed.(*ecdsa.PublicKey); !ok {
+		t.Fatalf("public key type = %T, want *ecdsa.PublicKey", parsed)
+	}
+}
+
+// TestSDKGetPublicKeySymmetricRejected: GetPublicKey on a symmetric key returns
+// UnsupportedOperationException.
+func TestSDKGetPublicKeySymmetricRejected(t *testing.T) {
+	ctx := context.Background()
+	c := newKMSClient(t)
+
+	key, err := c.CreateKey(ctx, &awskms.CreateKeyInput{})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	_, err = c.GetPublicKey(ctx, &awskms.GetPublicKeyInput{KeyId: key.KeyMetadata.KeyId})
+	if err == nil {
+		t.Fatal("GetPublicKey on a symmetric key should fail")
+	}
+
+	var unsupported *kmstypes.UnsupportedOperationException
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("GetPublicKey(symmetric) = %v, want UnsupportedOperationException", err)
+	}
+}

--- a/server/aws/kms/handler.go
+++ b/server/aws/kms/handler.go
@@ -54,6 +54,7 @@ func New(k kmsdriver.KMS) *Handler {
 		"GenerateDataKeyPair":                 h.generateDataKeyPair,
 		"GenerateDataKeyPairWithoutPlaintext": h.generateDataKeyPairWithoutPlaintext,
 		"GenerateRandom":                      h.generateRandom,
+		"GetPublicKey":                        h.getPublicKey,
 		"Sign":                                h.sign,
 		"Verify":                              h.verify,
 		"GenerateMac":                         h.generateMac,
@@ -144,6 +145,8 @@ func sentinelException(err error) string {
 		return "KMSInvalidStateException"
 	case errors.Is(err, kmsdriver.ErrInvalidKeyUsage):
 		return "InvalidKeyUsageException"
+	case errors.Is(err, kmsdriver.ErrUnsupportedOperation):
+		return "UnsupportedOperationException"
 	default:
 		return ""
 	}

--- a/server/aws/kms/key_metadata_algorithms_sdk_test.go
+++ b/server/aws/kms/key_metadata_algorithms_sdk_test.go
@@ -1,0 +1,128 @@
+package kms_test
+
+import (
+	"context"
+	"testing"
+
+	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+)
+
+// TestSDKKeyMetadataAlgorithmLists checks that CreateKey and DescribeKey both
+// advertise the algorithm list matching a key's KeySpec + KeyUsage, as real KMS
+// does: SigningAlgorithms for SIGN_VERIFY, EncryptionAlgorithms for
+// ENCRYPT_DECRYPT, MacAlgorithms for HMAC keys.
+func TestSDKKeyMetadataAlgorithmLists(t *testing.T) {
+	ctx := context.Background()
+	c := newKMSClient(t)
+
+	cases := []struct {
+		name    string
+		spec    kmstypes.KeySpec
+		usage   kmstypes.KeyUsageType
+		signing []kmstypes.SigningAlgorithmSpec
+		encrypt []kmstypes.EncryptionAlgorithmSpec
+		mac     []kmstypes.MacAlgorithmSpec
+	}{
+		{
+			name:  "RSA_2048 SIGN_VERIFY",
+			spec:  kmstypes.KeySpecRsa2048,
+			usage: kmstypes.KeyUsageTypeSignVerify,
+			signing: []kmstypes.SigningAlgorithmSpec{
+				kmstypes.SigningAlgorithmSpecRsassaPssSha256,
+				kmstypes.SigningAlgorithmSpecRsassaPssSha384,
+				kmstypes.SigningAlgorithmSpecRsassaPssSha512,
+				kmstypes.SigningAlgorithmSpecRsassaPkcs1V15Sha256,
+				kmstypes.SigningAlgorithmSpecRsassaPkcs1V15Sha384,
+				kmstypes.SigningAlgorithmSpecRsassaPkcs1V15Sha512,
+			},
+		},
+		{
+			name:  "RSA_2048 ENCRYPT_DECRYPT",
+			spec:  kmstypes.KeySpecRsa2048,
+			usage: kmstypes.KeyUsageTypeEncryptDecrypt,
+			encrypt: []kmstypes.EncryptionAlgorithmSpec{
+				kmstypes.EncryptionAlgorithmSpecRsaesOaepSha1,
+				kmstypes.EncryptionAlgorithmSpecRsaesOaepSha256,
+			},
+		},
+		{
+			name:    "ECC_NIST_P256 SIGN_VERIFY",
+			spec:    kmstypes.KeySpecEccNistP256,
+			usage:   kmstypes.KeyUsageTypeSignVerify,
+			signing: []kmstypes.SigningAlgorithmSpec{kmstypes.SigningAlgorithmSpecEcdsaSha256},
+		},
+		{
+			name:    "ECC_NIST_P521 SIGN_VERIFY",
+			spec:    kmstypes.KeySpecEccNistP521,
+			usage:   kmstypes.KeyUsageTypeSignVerify,
+			signing: []kmstypes.SigningAlgorithmSpec{kmstypes.SigningAlgorithmSpecEcdsaSha512},
+		},
+		{
+			name:  "HMAC_256 GENERATE_VERIFY_MAC",
+			spec:  kmstypes.KeySpecHmac256,
+			usage: kmstypes.KeyUsageTypeGenerateVerifyMac,
+			mac:   []kmstypes.MacAlgorithmSpec{kmstypes.MacAlgorithmSpecHmacSha256},
+		},
+		{
+			name:    "SYMMETRIC_DEFAULT ENCRYPT_DECRYPT",
+			spec:    kmstypes.KeySpecSymmetricDefault,
+			usage:   kmstypes.KeyUsageTypeEncryptDecrypt,
+			encrypt: []kmstypes.EncryptionAlgorithmSpec{kmstypes.EncryptionAlgorithmSpecSymmetricDefault},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			created, err := c.CreateKey(ctx, &awskms.CreateKeyInput{KeySpec: tc.spec, KeyUsage: tc.usage})
+			if err != nil {
+				t.Fatalf("CreateKey: %v", err)
+			}
+
+			assertAlgorithms(t, "CreateKey", created.KeyMetadata, tc.signing, tc.encrypt, tc.mac)
+
+			desc, err := c.DescribeKey(ctx, &awskms.DescribeKeyInput{KeyId: created.KeyMetadata.KeyId})
+			if err != nil {
+				t.Fatalf("DescribeKey: %v", err)
+			}
+
+			assertAlgorithms(t, "DescribeKey", desc.KeyMetadata, tc.signing, tc.encrypt, tc.mac)
+		})
+	}
+}
+
+func assertAlgorithms(
+	t *testing.T, op string, md *kmstypes.KeyMetadata,
+	signing []kmstypes.SigningAlgorithmSpec,
+	encrypt []kmstypes.EncryptionAlgorithmSpec,
+	mac []kmstypes.MacAlgorithmSpec,
+) {
+	t.Helper()
+
+	if !equalSpecs(md.SigningAlgorithms, signing) {
+		t.Fatalf("%s SigningAlgorithms = %v, want %v", op, md.SigningAlgorithms, signing)
+	}
+
+	if !equalSpecs(md.EncryptionAlgorithms, encrypt) {
+		t.Fatalf("%s EncryptionAlgorithms = %v, want %v", op, md.EncryptionAlgorithms, encrypt)
+	}
+
+	if !equalSpecs(md.MacAlgorithms, mac) {
+		t.Fatalf("%s MacAlgorithms = %v, want %v", op, md.MacAlgorithms, mac)
+	}
+}
+
+// equalSpecs compares two ordered lists of enum-string specs of any type.
+func equalSpecs[A, B ~string](got []A, want []B) bool {
+	if len(got) != len(want) {
+		return false
+	}
+
+	for i := range got {
+		if string(got[i]) != string(want[i]) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/server/aws/kms/types.go
+++ b/server/aws/kms/types.go
@@ -73,6 +73,8 @@ type keyMetadataJSON struct {
 	DeletionDate             *float64               `json:"DeletionDate,omitempty"`
 	ValidTo                  *float64               `json:"ValidTo,omitempty"`
 	EncryptionAlgorithms     []string               `json:"EncryptionAlgorithms,omitempty"`
+	SigningAlgorithms        []string               `json:"SigningAlgorithms,omitempty"`
+	MacAlgorithms            []string               `json:"MacAlgorithms,omitempty"`
 	MultiRegionConfiguration *multiRegionConfigJSON `json:"MultiRegionConfiguration,omitempty"`
 }
 
@@ -95,11 +97,14 @@ func metadataJSON(md *kmsdriver.KeyMetadata) keyMetadataJSON {
 		ValidTo:               epochOrNil(md.ValidTo),
 	}
 
-	// A symmetric ENCRYPT_DECRYPT key advertises the single SYMMETRIC_DEFAULT
-	// encryption algorithm, matching real KMS KeyMetadata.
-	if md.KeySpec == kmsdriver.SpecSymmetricDefault && md.KeyUsage == kmsdriver.UsageEncryptDecrypt {
-		out.EncryptionAlgorithms = []string{kmsdriver.SpecSymmetricDefault}
-	}
+	// KMS KeyMetadata advertises the algorithm list matching the key's usage:
+	// EncryptionAlgorithms for ENCRYPT_DECRYPT (SYMMETRIC_DEFAULT for a symmetric
+	// key, RSAES_OAEP_* for RSA), SigningAlgorithms for SIGN_VERIFY, and
+	// MacAlgorithms for HMAC keys. These are populated on the driver metadata at
+	// CreateKey from KeySpec+KeyUsage.
+	out.EncryptionAlgorithms = md.EncryptionAlgorithms
+	out.SigningAlgorithms = md.SigningAlgorithms
+	out.MacAlgorithms = md.MacAlgorithms
 
 	if md.MultiRegion {
 		cfg := &multiRegionConfigJSON{MultiRegionKeyType: md.MultiRegionKeyType}

--- a/services/kms/driver/crypto.go
+++ b/services/kms/driver/crypto.go
@@ -27,6 +27,9 @@ var (
 	// ErrInvalidKeyUsage — the key's usage/spec doesn't support the requested
 	// operation or algorithm (→ InvalidKeyUsageException).
 	ErrInvalidKeyUsage = errors.New(errors.InvalidArgument, "key usage does not permit this operation")
+	// ErrUnsupportedOperation — the operation is not valid for this key's spec,
+	// e.g. GetPublicKey on a symmetric key (→ UnsupportedOperationException).
+	ErrUnsupportedOperation = errors.New(errors.InvalidArgument, "operation not supported for this key spec")
 )
 
 // Encryption algorithms.
@@ -51,10 +54,74 @@ const (
 
 // MAC algorithms.
 const (
+	MacHMACSHA224 = "HMAC_SHA_224"
 	MacHMACSHA256 = "HMAC_SHA_256"
 	MacHMACSHA384 = "HMAC_SHA_384"
 	MacHMACSHA512 = "HMAC_SHA_512"
 )
+
+// SigningAlgorithmsFor returns the signing algorithms KMS advertises for a
+// SIGN_VERIFY key of the given spec (empty for any other usage/spec). This is
+// the single source of truth reused by KeyMetadata and GetPublicKey.
+func SigningAlgorithmsFor(spec, usage string) []string {
+	if usage != UsageSignVerify {
+		return nil
+	}
+
+	switch spec {
+	case SpecRSA2048, SpecRSA3072, SpecRSA4096:
+		return []string{
+			SignRSASSAPSSSHA256, SignRSASSAPSSSHA384, SignRSASSAPSSSHA512,
+			SignRSASSAPKCS1SHA256, SignRSASSAPKCS1SHA384, SignRSASSAPKCS1SHA512,
+		}
+	case SpecECCNISTP256:
+		return []string{SignECDSASHA256}
+	case SpecECCNISTP384:
+		return []string{SignECDSASHA384}
+	case SpecECCNISTP521:
+		return []string{SignECDSASHA512}
+	default:
+		return nil
+	}
+}
+
+// EncryptionAlgorithmsFor returns the encryption algorithms KMS advertises for
+// an ENCRYPT_DECRYPT key of the given spec (empty for any other usage/spec).
+func EncryptionAlgorithmsFor(spec, usage string) []string {
+	if usage != UsageEncryptDecrypt {
+		return nil
+	}
+
+	switch spec {
+	case SpecSymmetricDefault:
+		return []string{EncSymmetricDefault}
+	case SpecRSA2048, SpecRSA3072, SpecRSA4096:
+		return []string{EncRSAOAEPSHA1, EncRSAOAEPSHA256}
+	default:
+		return nil
+	}
+}
+
+// MacAlgorithmsFor returns the MAC algorithms KMS advertises for a
+// GENERATE_VERIFY_MAC key of the given spec (empty for any other usage/spec).
+func MacAlgorithmsFor(spec, usage string) []string {
+	if usage != UsageGenerateVerifyMac {
+		return nil
+	}
+
+	switch spec {
+	case SpecHMAC224:
+		return []string{MacHMACSHA224}
+	case SpecHMAC256:
+		return []string{MacHMACSHA256}
+	case SpecHMAC384:
+		return []string{MacHMACSHA384}
+	case SpecHMAC512:
+		return []string{MacHMACSHA512}
+	default:
+		return nil
+	}
+}
 
 // Message types for Sign/Verify.
 const (
@@ -222,6 +289,22 @@ type VerifyMacOutput struct {
 	MacAlgorithm string
 }
 
+// GetPublicKeyInput describes a GetPublicKey request.
+type GetPublicKeyInput struct {
+	KeyID string
+}
+
+// GetPublicKeyOutput carries the DER-encoded (SPKI, RFC 5280) public key of an
+// asymmetric key plus the spec/usage and the algorithms the key supports.
+type GetPublicKeyOutput struct {
+	KeyID                string
+	PublicKey            []byte
+	KeySpec              string
+	KeyUsage             string
+	EncryptionAlgorithms []string
+	SigningAlgorithms    []string
+}
+
 // Crypto is the cryptographic surface of KMS. It is embedded in the KMS
 // interface; kept separate here to group the operations.
 type Crypto interface {
@@ -233,6 +316,7 @@ type Crypto interface {
 	GenerateDataKeyPair(ctx context.Context, in GenerateDataKeyPairInput) (*GenerateDataKeyPairOutput, error)
 	GenerateDataKeyPairWithoutPlaintext(ctx context.Context, in GenerateDataKeyPairInput) (*GenerateDataKeyPairOutput, error)
 	GenerateRandom(ctx context.Context, numberOfBytes int32) ([]byte, error)
+	GetPublicKey(ctx context.Context, in GetPublicKeyInput) (*GetPublicKeyOutput, error)
 	Sign(ctx context.Context, in SignInput) (*SignOutput, error)
 	Verify(ctx context.Context, in VerifyInput) (*VerifyOutput, error)
 	GenerateMac(ctx context.Context, in GenerateMacInput) (*GenerateMacOutput, error)

--- a/services/kms/driver/driver.go
+++ b/services/kms/driver/driver.go
@@ -71,6 +71,14 @@ type KeyMetadata struct {
 	// ValidTo is the expiry of imported key material (zero when not set).
 	ValidTo time.Time
 
+	// Algorithm lists advertised for the key, populated from KeySpec+KeyUsage.
+	// Only the one matching the usage is set: EncryptionAlgorithms for
+	// ENCRYPT_DECRYPT, SigningAlgorithms for SIGN_VERIFY, MacAlgorithms for
+	// GENERATE_VERIFY_MAC.
+	EncryptionAlgorithms []string
+	SigningAlgorithms    []string
+	MacAlgorithms        []string
+
 	// Multi-region configuration (populated only when MultiRegion is true).
 	// MultiRegionKeyType is "PRIMARY" or "REPLICA".
 	MultiRegionKeyType string


### PR DESCRIPTION
## What

Two fixes to the AWS KMS asymmetric-key surface found by the deep real-user e2e audit.

### [HIGH] Implement `GetPublicKey`
`GetPublicKey` was unrouted, so the wire server returned `UnknownOperationException`. Every real user of an asymmetric KMS key (SIGN_VERIFY, or RSA ENCRYPT_DECRYPT) calls it to download the public key for offline signature verification / offline encryption / hybrid crypto (JWT signers, mTLS, `data.aws_kms_public_key` in Terraform).

- Added `GetPublicKey` to the driver `Crypto` interface, a provider impl (`crypto_asym.go`) that marshals the existing `keyData.privKey` to DER `SubjectPublicKeyInfo` via `x509.MarshalPKIXPublicKey`, and a wire op registered in the handler.
- Response carries `KeyId`, `PublicKey` (DER SPKI), `KeySpec`/`CustomerMasterKeySpec`, `KeyUsage`, and the spec-matched `SigningAlgorithms` (SIGN_VERIFY) or `EncryptionAlgorithms` (ENCRYPT_DECRYPT).
- A symmetric key is rejected with `UnsupportedOperationException` (new `ErrUnsupportedOperation` sentinel).
- `Decrypt` now also accepts **raw RSA-OAEP ciphertext** produced offline from the downloaded public key (asymmetric path keyed on the supplied `KeyId`), so offline-encrypt then KMS `Decrypt` round-trips. The existing self-describing wrapped-blob path and every confirmed behavior (IncorrectKey, InvalidCiphertext, encryption-context binding) are unchanged.

### [MED] KeyMetadata algorithm lists
`CreateKey`/`DescribeKey` returned empty algorithm lists for asymmetric and HMAC keys. Real KMS always advertises, per KeySpec+KeyUsage:

- RSA SIGN_VERIFY -> `SigningAlgorithms` (RSASSA_PSS + RSASSA_PKCS1_V1_5, SHA 256/384/512)
- ECC P256/P384/P521 -> `SigningAlgorithms` (ECDSA_SHA_256/384/512)
- RSA ENCRYPT_DECRYPT -> `EncryptionAlgorithms` (RSAES_OAEP_SHA_1, RSAES_OAEP_SHA_256)
- SYMMETRIC_DEFAULT -> `EncryptionAlgorithms` (SYMMETRIC_DEFAULT)
- HMAC_* -> `MacAlgorithms` (HMAC_SHA_*)

Added `EncryptionAlgorithms`/`SigningAlgorithms`/`MacAlgorithms` to the driver `KeyMetadata` and wire shape, populated on `CreateKey` from one spec->algorithms mapping in the driver (reused by `GetPublicKey`), and rendered on `CreateKey`/`DescribeKey`. `ReplicateKey` carries them via its metadata copy.

## Why

Both were flagged in the KMS deep real-user e2e audit as the only remaining gaps in an otherwise strong real-crypto KMS. Without `GetPublicKey` and the algorithm lists, offline crypto workflows and any SDK/app that inspects the advertised algorithms break against the emulator.

## Tests

Real `aws-sdk-go-v2/kms` reproductions plus provider-level tests:
- GetPublicKey on RSA SIGN_VERIFY -> DER parses to `*rsa.PublicKey`; offline `VerifyPSS` of a KMS `Sign` signature succeeds.
- GetPublicKey on RSA ENCRYPT_DECRYPT -> offline RSA-OAEP encrypt then KMS `Decrypt` recovers the plaintext.
- GetPublicKey on ECC -> correct spec + `*ecdsa.PublicKey` + single ECDSA algorithm.
- GetPublicKey on a symmetric key -> `UnsupportedOperationException`.
- KeyMetadata algorithm lists for RSA SIGN_VERIFY / RSA ENCRYPT_DECRYPT / ECC / HMAC / SYMMETRIC on both `CreateKey` and `DescribeKey`.

All existing KMS tests stay green. Coverage docs regenerated via `go generate`.