### PR TITLE
fix(aws-elasticache): persist Port/ParameterGroup; memcached 11211 + redis-only-no-cfg-endpoint; Modify scale/version; validate subnet group; RG member/reader fields

### DIFF
--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -214,18 +214,19 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 	}
 
 	info := driver.CacheInfo{
-		Name:            cfg.Name,
-		Scope:           cfg.Scope,
-		NodeType:        nodeType,
-		Engine:          engine,
-		EngineVersion:   engineVersion,
-		Status:          statusAvailable,
-		Endpoint:        endpoint,
-		ARN:             m.cacheARN(cfg.Name),
-		CreatedAt:       m.opts.Clock.Now().UTC().Format(time.RFC3339),
-		Tags:            tags,
-		NumCacheNodes:   numNodes,
-		SubnetGroupName: cfg.SubnetGroupName,
+		Name:               cfg.Name,
+		Scope:              cfg.Scope,
+		NodeType:           nodeType,
+		Engine:             engine,
+		EngineVersion:      engineVersion,
+		Status:             statusAvailable,
+		Endpoint:           endpoint,
+		ARN:                m.cacheARN(cfg.Name),
+		CreatedAt:          m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:               tags,
+		NumCacheNodes:      numNodes,
+		SubnetGroupName:    cfg.SubnetGroupName,
+		ParameterGroupName: cfg.ParameterGroupName,
 	}
 
 	// Opt-in: back the cache with a real server, replacing the synthetic

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -24,10 +24,13 @@ const (
 	defaultMemcachedPort = 11211
 )
 
-// defaultPort is the TCP port real ElastiCache assigns a cluster of the given
-// engine when the caller omits Port: Memcached listens on 11211, Redis/Valkey
-// on 6379.
-func defaultPort(engine string) int {
+// resolvePort returns the requested port, or the engine default when unset:
+// Memcached listens on 11211, Redis/Valkey on 6379.
+func resolvePort(engine string, port int) int {
+	if port != 0 {
+		return port
+	}
+
 	if engine == engineMemcached {
 		return defaultMemcachedPort
 	}
@@ -93,6 +96,34 @@ func validateNodeCount(engine string, numNodes int) error {
 	if numNodes > 1 {
 		return errors.Newf(errors.InvalidArgument,
 			"NumCacheNodes must be 1 for engine %q", engine)
+	}
+
+	return nil
+}
+
+// normalizeNodeCount defaults an unset node count to 1 and validates it against
+// the engine's limits.
+func normalizeNodeCount(engine string, requested int) (int, error) {
+	n := requested
+	if n < 1 {
+		n = 1
+	}
+
+	if err := validateNodeCount(engine, n); err != nil {
+		return 0, err
+	}
+
+	return n, nil
+}
+
+// requireSubnetGroup rejects a create that names a cache subnet group which does
+// not exist, matching real ElastiCache (CacheSubnetGroupNotFoundFault) rather
+// than silently accepting a typo (mirrors RDS CreateDBInstance's DBSubnetGroup
+// check). An empty name places the cluster in the default subnet group.
+func (m *Mock) requireSubnetGroup(name string) error {
+	if name != "" && !m.subnetGroups.Has(name) {
+		return errors.Newf(errors.NotFound,
+			"CacheSubnetGroupNotFoundFault: cache subnet group %q not found", name)
 	}
 
 	return nil
@@ -192,29 +223,16 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 		engineVersion = defaultEngineVersion(engine)
 	}
 
-	numNodes := cfg.NumCacheNodes
-	if numNodes < 1 {
-		numNodes = 1
-	}
-
-	if err := validateNodeCount(engine, numNodes); err != nil {
+	numNodes, err := normalizeNodeCount(engine, cfg.NumCacheNodes)
+	if err != nil {
 		return nil, err
 	}
 
-	// A named subnet group must already exist — real ElastiCache rejects a
-	// missing one with CacheSubnetGroupNotFoundFault rather than silently
-	// accepting a typo (mirrors RDS CreateDBInstance's DBSubnetGroup check).
-	if cfg.SubnetGroupName != "" && !m.subnetGroups.Has(cfg.SubnetGroupName) {
-		return nil, errors.Newf(errors.NotFound,
-			"CacheSubnetGroupNotFoundFault: cache subnet group %q not found", cfg.SubnetGroupName)
+	if err := m.requireSubnetGroup(cfg.SubnetGroupName); err != nil {
+		return nil, err
 	}
 
-	port := cfg.Port
-	if port == 0 {
-		port = defaultPort(engine)
-	}
-
-	endpoint := clusterEndpoint(cfg.Name, m.opts.Region, engine, port)
+	endpoint := clusterEndpoint(cfg.Name, m.opts.Region, engine, resolvePort(engine, cfg.Port))
 
 	tags := make(map[string]string, len(cfg.Tags))
 	for k, v := range cfg.Tags {
@@ -276,9 +294,11 @@ func (m *Mock) ModifyCache(_ context.Context, cfg driver.ModifyCacheConfig) (*dr
 	if cfg.NodeType != "" {
 		cd.info.NodeType = cfg.NodeType
 	}
+
 	if cfg.EngineVersion != "" {
 		cd.info.EngineVersion = cfg.EngineVersion
 	}
+
 	if cfg.NumCacheNodes > 0 {
 		cd.info.NumCacheNodes = cfg.NumCacheNodes
 	}

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -248,23 +248,34 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 	return &result, nil
 }
 
-// ModifyCache updates the mutable fields (node type, engine) of an existing
-// cache cluster (ElastiCache ModifyCacheCluster). Empty arguments leave the
-// corresponding field unchanged.
-func (m *Mock) ModifyCache(_ context.Context, name, nodeType, engine string) (*driver.CacheInfo, error) {
-	cd, ok := m.caches.Get(name)
+// ModifyCache updates the mutable fields (node type, engine version, node
+// count) of an existing cache cluster (ElastiCache ModifyCacheCluster). Empty or
+// zero fields leave the corresponding attribute unchanged. A NumCacheNodes
+// change is re-validated against the cluster's engine (Memcached scales 1-40;
+// Redis/Valkey stays at 1).
+func (m *Mock) ModifyCache(_ context.Context, cfg driver.ModifyCacheConfig) (*driver.CacheInfo, error) {
+	cd, ok := m.caches.Get(cfg.Name)
 	if !ok {
-		return nil, errors.Newf(errors.NotFound, "cache %q not found", name)
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", cfg.Name)
 	}
 
-	if nodeType != "" {
-		cd.info.NodeType = nodeType
-	}
-	if engine != "" {
-		cd.info.Engine = engine
+	if cfg.NumCacheNodes > 0 {
+		if err := validateNodeCount(cd.info.Engine, cfg.NumCacheNodes); err != nil {
+			return nil, err
+		}
 	}
 
-	m.caches.Set(name, cd)
+	if cfg.NodeType != "" {
+		cd.info.NodeType = cfg.NodeType
+	}
+	if cfg.EngineVersion != "" {
+		cd.info.EngineVersion = cfg.EngineVersion
+	}
+	if cfg.NumCacheNodes > 0 {
+		cd.info.NumCacheNodes = cfg.NumCacheNodes
+	}
+
+	m.caches.Set(cfg.Name, cd)
 
 	result := cd.info
 

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -19,7 +19,32 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
-const defaultRedisPort = 6379
+const (
+	defaultRedisPort     = 6379
+	defaultMemcachedPort = 11211
+)
+
+// defaultPort is the TCP port real ElastiCache assigns a cluster of the given
+// engine when the caller omits Port: Memcached listens on 11211, Redis/Valkey
+// on 6379.
+func defaultPort(engine string) int {
+	if engine == engineMemcached {
+		return defaultMemcachedPort
+	}
+
+	return defaultRedisPort
+}
+
+// clusterEndpoint builds the synthetic host:port a client connects to. Memcached
+// exposes a single configuration endpoint whose host carries the ".cfg" segment
+// real AWS uses; Redis/Valkey use a plain per-cluster host.
+func clusterEndpoint(name, region, engine string, port int) string {
+	if engine == engineMemcached {
+		return fmt.Sprintf("%s.cfg.%s.cache.amazonaws.com:%d", name, region, port)
+	}
+
+	return fmt.Sprintf("%s.%s.cache.amazonaws.com:%d", name, region, port)
+}
 
 // Compile-time check that Mock implements driver.Cache.
 var _ driver.Cache = (*Mock)(nil)
@@ -176,7 +201,12 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 		return nil, err
 	}
 
-	endpoint := fmt.Sprintf("%s.%s.cache.amazonaws.com:%d", cfg.Name, m.opts.Region, defaultRedisPort)
+	port := cfg.Port
+	if port == 0 {
+		port = defaultPort(engine)
+	}
+
+	endpoint := clusterEndpoint(cfg.Name, m.opts.Region, engine, port)
 
 	tags := make(map[string]string, len(cfg.Tags))
 	for k, v := range cfg.Tags {

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -201,6 +201,14 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 		return nil, err
 	}
 
+	// A named subnet group must already exist — real ElastiCache rejects a
+	// missing one with CacheSubnetGroupNotFoundFault rather than silently
+	// accepting a typo (mirrors RDS CreateDBInstance's DBSubnetGroup check).
+	if cfg.SubnetGroupName != "" && !m.subnetGroups.Has(cfg.SubnetGroupName) {
+		return nil, errors.Newf(errors.NotFound,
+			"CacheSubnetGroupNotFoundFault: cache subnet group %q not found", cfg.SubnetGroupName)
+	}
+
 	port := cfg.Port
 	if port == 0 {
 		port = defaultPort(engine)

--- a/providers/aws/elasticache/replication_group.go
+++ b/providers/aws/elasticache/replication_group.go
@@ -45,20 +45,31 @@ func (m *Mock) CreateReplicationGroup(
 		nodes = 1
 	}
 
+	engineVersion := cfg.EngineVersion
+	if engineVersion == "" {
+		engineVersion = defaultEngineVersion(engine)
+	}
+
 	rg := cachedriver.ReplicationGroup{
 		ID:            cfg.ID,
 		Description:   cfg.Description,
 		Status:        statusAvailable,
 		Engine:        engine,
-		EngineVersion: cfg.EngineVersion,
+		EngineVersion: engineVersion,
 		NodeType:      nodeType,
 		NumCacheNodes: nodes,
 		// Callers read the primary endpoint to build a connection string; a
 		// group without one is indistinguishable from a broken provision.
 		PrimaryAddress: fmt.Sprintf("%s.%s.cache.amazonaws.com",
 			cfg.ID, m.opts.Region),
-		PrimaryPort:     defaultRedisPort,
-		SubnetGroupName: cfg.SubnetGroupName,
+		PrimaryPort: defaultRedisPort,
+		// The reader endpoint lets clients scale reads across the replicas.
+		ReaderAddress: fmt.Sprintf("%s-ro.%s.cache.amazonaws.com",
+			cfg.ID, m.opts.Region),
+		ReaderPort:        defaultRedisPort,
+		MemberClusters:    memberClusters(cfg.ID, nodes),
+		AutomaticFailover: failoverStatus(cfg.AutomaticFailoverEnabled),
+		SubnetGroupName:   cfg.SubnetGroupName,
 		ARN: "arn:aws:elasticache:" + m.opts.Region + ":" + m.opts.AccountID +
 			":replicationgroup:" + cfg.ID,
 	}
@@ -73,6 +84,27 @@ func (m *Mock) CreateReplicationGroup(
 	m.replicationGroups.Set(cfg.ID, rg)
 
 	return &rg, nil
+}
+
+// memberClusters synthesizes the cache cluster ids that make up a replication
+// group, matching the "<id>-001", "<id>-002", … naming real ElastiCache assigns.
+func memberClusters(id string, nodes int) []string {
+	members := make([]string, 0, nodes)
+	for i := 1; i <= nodes; i++ {
+		members = append(members, fmt.Sprintf("%s-%03d", id, i))
+	}
+
+	return members
+}
+
+// failoverStatus maps the requested AutomaticFailoverEnabled flag to the
+// "enabled"/"disabled" status ElastiCache reports on Describe.
+func failoverStatus(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+
+	return "disabled"
 }
 
 // provisionPrimaryEndpoint backs the replication group's primary with the
@@ -151,6 +183,7 @@ func (m *Mock) ModifyReplicationGroup(
 
 	if numCacheNodes > 0 {
 		rg.NumCacheNodes = numCacheNodes
+		rg.MemberClusters = memberClusters(id, numCacheNodes)
 	}
 
 	m.replicationGroups.Set(id, rg)

--- a/server/aws/elasticache/endpoints_sdk_roundtrip_test.go
+++ b/server/aws/elasticache/endpoints_sdk_roundtrip_test.go
@@ -1,0 +1,142 @@
+package elasticache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+)
+
+// TestSDKCacheClusterCustomPort covers that a submitted Port is honored on the
+// per-node endpoint, and that an omitted Port defaults to the Redis port.
+func TestSDKCacheClusterCustomPort(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("cp"), Engine: aws.String("redis"),
+		CacheNodeType: aws.String("cache.t3.micro"), NumCacheNodes: aws.Int32(1),
+		Port: aws.Int32(6380),
+	}); err != nil {
+		t.Fatalf("CreateCacheCluster: %v", err)
+	}
+
+	got, err := client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String("cp"), ShowCacheNodeInfo: aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheClusters: %v", err)
+	}
+
+	nodes := got.CacheClusters[0].CacheNodes
+	if len(nodes) != 1 || nodes[0].Endpoint == nil {
+		t.Fatalf("CacheNodes = %+v", nodes)
+	}
+
+	if p := aws.ToInt32(nodes[0].Endpoint.Port); p != 6380 {
+		t.Fatalf("custom port = %d, want 6380", p)
+	}
+}
+
+// TestSDKCacheClusterDefaultRedisPort covers that an omitted Port on a Redis
+// cluster defaults to 6379.
+func TestSDKCacheClusterDefaultRedisPort(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("dp"), Engine: aws.String("redis"),
+		CacheNodeType: aws.String("cache.t3.micro"), NumCacheNodes: aws.Int32(1),
+	}); err != nil {
+		t.Fatalf("CreateCacheCluster: %v", err)
+	}
+
+	got, err := client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String("dp"), ShowCacheNodeInfo: aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheClusters: %v", err)
+	}
+
+	nodes := got.CacheClusters[0].CacheNodes
+	if len(nodes) != 1 || nodes[0].Endpoint == nil {
+		t.Fatalf("CacheNodes = %+v", nodes)
+	}
+
+	if p := aws.ToInt32(nodes[0].Endpoint.Port); p != 6379 {
+		t.Fatalf("default redis port = %d, want 6379", p)
+	}
+}
+
+// TestSDKRedisNoConfigurationEndpoint covers that a Redis cluster returns no
+// ConfigurationEndpoint (a Memcached-only field in the real API); its address
+// lives on the per-node endpoint instead.
+func TestSDKRedisNoConfigurationEndpoint(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("rc"), Engine: aws.String("redis"),
+		CacheNodeType: aws.String("cache.t3.micro"), NumCacheNodes: aws.Int32(1),
+	}); err != nil {
+		t.Fatalf("CreateCacheCluster: %v", err)
+	}
+
+	got, err := client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String("rc"), ShowCacheNodeInfo: aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheClusters: %v", err)
+	}
+
+	c := got.CacheClusters[0]
+	if c.ConfigurationEndpoint != nil {
+		t.Fatalf("Redis ConfigurationEndpoint = %+v, want nil", c.ConfigurationEndpoint)
+	}
+
+	if len(c.CacheNodes) != 1 || c.CacheNodes[0].Endpoint == nil {
+		t.Fatalf("Redis per-node endpoint missing: %+v", c.CacheNodes)
+	}
+}
+
+// TestSDKMemcachedEndpoints covers that a Memcached cluster returns a
+// ConfigurationEndpoint on port 11211 (host carrying ".cfg") and per-node
+// endpoints on 11211, both when the port is omitted (defaulted per engine).
+func TestSDKMemcachedEndpoints(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("mc"), Engine: aws.String("memcached"),
+		CacheNodeType: aws.String("cache.t3.micro"), NumCacheNodes: aws.Int32(2),
+	}); err != nil {
+		t.Fatalf("CreateCacheCluster: %v", err)
+	}
+
+	got, err := client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String("mc"), ShowCacheNodeInfo: aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheClusters: %v", err)
+	}
+
+	c := got.CacheClusters[0]
+	if c.ConfigurationEndpoint == nil {
+		t.Fatal("Memcached ConfigurationEndpoint = nil, want non-nil")
+	}
+
+	if p := aws.ToInt32(c.ConfigurationEndpoint.Port); p != 11211 {
+		t.Fatalf("Memcached ConfigurationEndpoint port = %d, want 11211", p)
+	}
+
+	if len(c.CacheNodes) != 2 {
+		t.Fatalf("Memcached CacheNodes = %d, want 2", len(c.CacheNodes))
+	}
+
+	for i := range c.CacheNodes {
+		if c.CacheNodes[i].Endpoint == nil || aws.ToInt32(c.CacheNodes[i].Endpoint.Port) != 11211 {
+			t.Fatalf("Memcached node %d endpoint = %+v, want port 11211", i, c.CacheNodes[i].Endpoint)
+		}
+	}
+}

--- a/server/aws/elasticache/modify_sdk_roundtrip_test.go
+++ b/server/aws/elasticache/modify_sdk_roundtrip_test.go
@@ -1,0 +1,52 @@
+package elasticache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+)
+
+// TestSDKModifyCacheClusterScaleAndVersion covers that ModifyCacheCluster
+// applies a Memcached NumCacheNodes rescale and an EngineVersion bump, both
+// reflected on Describe (Terraform convergence).
+func TestSDKModifyCacheClusterScaleAndVersion(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("mm"), Engine: aws.String("memcached"),
+		CacheNodeType: aws.String("cache.t3.micro"), NumCacheNodes: aws.Int32(1),
+		EngineVersion: aws.String("1.6.17"),
+	}); err != nil {
+		t.Fatalf("CreateCacheCluster: %v", err)
+	}
+
+	if _, err := client.ModifyCacheCluster(ctx, &awselasticache.ModifyCacheClusterInput{
+		CacheClusterId: aws.String("mm"), NumCacheNodes: aws.Int32(3),
+		EngineVersion: aws.String("1.6.22"), ApplyImmediately: aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("ModifyCacheCluster: %v", err)
+	}
+
+	got, err := client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String("mm"), ShowCacheNodeInfo: aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheClusters: %v", err)
+	}
+
+	c := got.CacheClusters[0]
+	if aws.ToInt32(c.NumCacheNodes) != 3 {
+		t.Fatalf("NumCacheNodes = %d, want 3", aws.ToInt32(c.NumCacheNodes))
+	}
+
+	if len(c.CacheNodes) != 3 {
+		t.Fatalf("CacheNodes = %d, want 3", len(c.CacheNodes))
+	}
+
+	if aws.ToString(c.EngineVersion) != "1.6.22" {
+		t.Fatalf("EngineVersion = %q, want 1.6.22", aws.ToString(c.EngineVersion))
+	}
+}

--- a/server/aws/elasticache/operations.go
+++ b/server/aws/elasticache/operations.go
@@ -47,14 +47,15 @@ func (h *Handler) createCacheCluster(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cfg := cachedriver.CacheConfig{
-		Name:            form.Get("CacheClusterId"),
-		NodeType:        form.Get("CacheNodeType"),
-		Engine:          form.Get("Engine"),
-		EngineVersion:   form.Get("EngineVersion"),
-		NumCacheNodes:   nodes,
-		Port:            port,
-		SubnetGroupName: form.Get("CacheSubnetGroupName"),
-		Tags:            parseTags(form),
+		Name:               form.Get("CacheClusterId"),
+		NodeType:           form.Get("CacheNodeType"),
+		Engine:             form.Get("Engine"),
+		EngineVersion:      form.Get("EngineVersion"),
+		NumCacheNodes:      nodes,
+		Port:               port,
+		SubnetGroupName:    form.Get("CacheSubnetGroupName"),
+		ParameterGroupName: form.Get("CacheParameterGroupName"),
+		Tags:               parseTags(form),
 	}
 
 	info, err := h.cache.CreateCache(r.Context(), cfg)

--- a/server/aws/elasticache/operations.go
+++ b/server/aws/elasticache/operations.go
@@ -40,12 +40,19 @@ func (h *Handler) createCacheCluster(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	port, err := parseNodeCount("Port", form.Get("Port"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	cfg := cachedriver.CacheConfig{
 		Name:            form.Get("CacheClusterId"),
 		NodeType:        form.Get("CacheNodeType"),
 		Engine:          form.Get("Engine"),
 		EngineVersion:   form.Get("EngineVersion"),
 		NumCacheNodes:   nodes,
+		Port:            port,
 		SubnetGroupName: form.Get("CacheSubnetGroupName"),
 		Tags:            parseTags(form),
 	}

--- a/server/aws/elasticache/operations.go
+++ b/server/aws/elasticache/operations.go
@@ -72,10 +72,9 @@ func (h *Handler) createCacheCluster(w http.ResponseWriter, r *http.Request) {
 }
 
 // cacheModifier is the AWS-specific ModifyCacheCluster surface. It's not part
-// of the portable Cache driver (Azure Cache and GCP Memorystore also implement
-// it), so the handler type-asserts for it.
+// of the portable Cache driver, so the handler type-asserts for it.
 type cacheModifier interface {
-	ModifyCache(ctx context.Context, name, nodeType, engine string) (*cachedriver.CacheInfo, error)
+	ModifyCache(ctx context.Context, cfg cachedriver.ModifyCacheConfig) (*cachedriver.CacheInfo, error)
 }
 
 func (h *Handler) modifyCacheCluster(w http.ResponseWriter, r *http.Request) {
@@ -85,8 +84,18 @@ func (h *Handler) modifyCacheCluster(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	info, err := mod.ModifyCache(r.Context(),
-		r.Form.Get("CacheClusterId"), r.Form.Get("CacheNodeType"), r.Form.Get("Engine"))
+	nodes, err := parseNodeCount("NumCacheNodes", r.Form.Get("NumCacheNodes"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	info, err := mod.ModifyCache(r.Context(), cachedriver.ModifyCacheConfig{
+		Name:          r.Form.Get("CacheClusterId"),
+		NodeType:      r.Form.Get("CacheNodeType"),
+		EngineVersion: r.Form.Get("EngineVersion"),
+		NumCacheNodes: nodes,
+	})
 	if err != nil {
 		writeErr(w, err)
 		return

--- a/server/aws/elasticache/paramgroup_sdk_roundtrip_test.go
+++ b/server/aws/elasticache/paramgroup_sdk_roundtrip_test.go
@@ -1,0 +1,71 @@
+package elasticache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+)
+
+// TestSDKCustomParameterGroupPersisted covers that a submitted
+// CacheParameterGroupName is echoed back on Describe (IaC convergence), while an
+// omitted one still reports the engine family's default.
+func TestSDKCustomParameterGroupPersisted(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCacheParameterGroup(ctx, &awselasticache.CreateCacheParameterGroupInput{
+		CacheParameterGroupName:   aws.String("myredis"),
+		CacheParameterGroupFamily: aws.String("redis7"),
+		Description:               aws.String("custom"),
+	}); err != nil {
+		t.Fatalf("CreateCacheParameterGroup: %v", err)
+	}
+
+	if _, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("c1"), Engine: aws.String("redis"),
+		CacheNodeType: aws.String("cache.t3.micro"), NumCacheNodes: aws.Int32(1),
+		CacheParameterGroupName: aws.String("myredis"),
+	}); err != nil {
+		t.Fatalf("CreateCacheCluster: %v", err)
+	}
+
+	got, err := client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String("c1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheClusters: %v", err)
+	}
+
+	pg := got.CacheClusters[0].CacheParameterGroup
+	if pg == nil || aws.ToString(pg.CacheParameterGroupName) != "myredis" {
+		t.Fatalf("CacheParameterGroup = %+v, want myredis", pg)
+	}
+}
+
+// TestSDKDefaultParameterGroupWhenOmitted covers that omitting
+// CacheParameterGroupName keeps the derived default.<family> value.
+func TestSDKDefaultParameterGroupWhenOmitted(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("c2"), Engine: aws.String("redis"),
+		CacheNodeType: aws.String("cache.t3.micro"), NumCacheNodes: aws.Int32(1),
+	}); err != nil {
+		t.Fatalf("CreateCacheCluster: %v", err)
+	}
+
+	got, err := client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String("c2"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheClusters: %v", err)
+	}
+
+	pg := got.CacheClusters[0].CacheParameterGroup
+	if pg == nil || aws.ToString(pg.CacheParameterGroupName) != "default.redis7" {
+		t.Fatalf("CacheParameterGroup = %+v, want default.redis7", pg)
+	}
+}

--- a/server/aws/elasticache/replication_group.go
+++ b/server/aws/elasticache/replication_group.go
@@ -10,6 +10,9 @@ import (
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
 )
 
+// formTrue is the query-protocol encoding of a boolean-true flag.
+const formTrue = "true"
+
 // nodeGroupMemberXML mirrors AWS's NodeGroupMember — the per-node membership
 // record a caller reads to enumerate the primary and replicas of a shard.
 type nodeGroupMemberXML struct {
@@ -101,7 +104,7 @@ func (h *Handler) createReplicationGroup(w http.ResponseWriter, r *http.Request)
 		NumCacheNodes:            nodes,
 		SubnetGroupName:          r.Form.Get("CacheSubnetGroupName"),
 		SecurityGroupIDs:         awsquery.ListStrings(r.Form, "SecurityGroupIds.SecurityGroupId"),
-		AutomaticFailoverEnabled: r.Form.Get("AutomaticFailoverEnabled") == "true",
+		AutomaticFailoverEnabled: r.Form.Get("AutomaticFailoverEnabled") == formTrue,
 	})
 	if err != nil {
 		writeErr(w, err)
@@ -193,7 +196,7 @@ func (h *Handler) deleteReplicationGroup(w http.ResponseWriter, r *http.Request)
 	last := groups[0]
 
 	opts := cachedriver.DeleteReplicationGroupOptions{
-		RetainPrimaryCluster:    r.Form.Get("RetainPrimaryCluster") == "true",
+		RetainPrimaryCluster:    r.Form.Get("RetainPrimaryCluster") == formTrue,
 		FinalSnapshotIdentifier: r.Form.Get("FinalSnapshotIdentifier"),
 	}
 

--- a/server/aws/elasticache/replication_group.go
+++ b/server/aws/elasticache/replication_group.go
@@ -10,10 +10,20 @@ import (
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
 )
 
+// nodeGroupMemberXML mirrors AWS's NodeGroupMember — the per-node membership
+// record a caller reads to enumerate the primary and replicas of a shard.
+type nodeGroupMemberXML struct {
+	CacheClusterID string `xml:"CacheClusterId"`
+	CacheNodeID    string `xml:"CacheNodeId"`
+	CurrentRole    string `xml:"CurrentRole,omitempty"`
+}
+
 type nodeGroupXML struct {
-	NodeGroupID     string       `xml:"NodeGroupId"`
-	Status          string       `xml:"Status"`
-	PrimaryEndpoint *endpointXML `xml:"PrimaryEndpoint,omitempty"`
+	NodeGroupID      string               `xml:"NodeGroupId"`
+	Status           string               `xml:"Status"`
+	PrimaryEndpoint  *endpointXML         `xml:"PrimaryEndpoint,omitempty"`
+	ReaderEndpoint   *endpointXML         `xml:"ReaderEndpoint,omitempty"`
+	NodeGroupMembers []nodeGroupMemberXML `xml:"NodeGroupMembers>NodeGroupMember,omitempty"`
 }
 
 type replicationGroupXML struct {
@@ -21,6 +31,8 @@ type replicationGroupXML struct {
 	Description        string         `xml:"Description,omitempty"`
 	Status             string         `xml:"Status"`
 	CacheNodeType      string         `xml:"CacheNodeType,omitempty"`
+	AutomaticFailover  string         `xml:"AutomaticFailover,omitempty"`
+	MemberClusters     []string       `xml:"MemberClusters>ClusterId,omitempty"`
 	ARN                string         `xml:"ARN,omitempty"`
 	NodeGroups         []nodeGroupXML `xml:"NodeGroups>NodeGroup,omitempty"`
 }
@@ -81,14 +93,15 @@ func (h *Handler) createReplicationGroup(w http.ResponseWriter, r *http.Request)
 	}
 
 	rg, err := store.CreateReplicationGroup(r.Context(), cachedriver.ReplicationGroupConfig{
-		ID:               r.Form.Get("ReplicationGroupId"),
-		Description:      r.Form.Get("ReplicationGroupDescription"),
-		Engine:           r.Form.Get("Engine"),
-		EngineVersion:    r.Form.Get("EngineVersion"),
-		NodeType:         r.Form.Get("CacheNodeType"),
-		NumCacheNodes:    nodes,
-		SubnetGroupName:  r.Form.Get("CacheSubnetGroupName"),
-		SecurityGroupIDs: awsquery.ListStrings(r.Form, "SecurityGroupIds.SecurityGroupId"),
+		ID:                       r.Form.Get("ReplicationGroupId"),
+		Description:              r.Form.Get("ReplicationGroupDescription"),
+		Engine:                   r.Form.Get("Engine"),
+		EngineVersion:            r.Form.Get("EngineVersion"),
+		NodeType:                 r.Form.Get("CacheNodeType"),
+		NumCacheNodes:            nodes,
+		SubnetGroupName:          r.Form.Get("CacheSubnetGroupName"),
+		SecurityGroupIDs:         awsquery.ListStrings(r.Form, "SecurityGroupIds.SecurityGroupId"),
+		AutomaticFailoverEnabled: r.Form.Get("AutomaticFailoverEnabled") == "true",
 	})
 	if err != nil {
 		writeErr(w, err)
@@ -223,19 +236,51 @@ func toReplicationGroupXML(rg *cachedriver.ReplicationGroup) replicationGroupXML
 		Description:        rg.Description,
 		Status:             rg.Status,
 		CacheNodeType:      rg.NodeType,
+		AutomaticFailover:  rg.AutomaticFailover,
+		MemberClusters:     rg.MemberClusters,
 		ARN:                rg.ARN,
 	}
 
 	// The primary endpoint is how a caller reaches the cache at all — it reads
 	// NodeGroups[0].PrimaryEndpoint.Address to build the connection string, so
-	// the node group has to be present even for a single-node group.
+	// the node group has to be present even for a single-node group. The reader
+	// endpoint and per-node membership let clients scale reads and enumerate the
+	// group's nodes.
 	if rg.PrimaryAddress != "" {
-		x.NodeGroups = []nodeGroupXML{{
-			NodeGroupID:     "0001",
-			Status:          rg.Status,
-			PrimaryEndpoint: &endpointXML{Address: rg.PrimaryAddress, Port: rg.PrimaryPort},
-		}}
+		ng := nodeGroupXML{
+			NodeGroupID:      "0001",
+			Status:           rg.Status,
+			PrimaryEndpoint:  &endpointXML{Address: rg.PrimaryAddress, Port: rg.PrimaryPort},
+			NodeGroupMembers: nodeGroupMembers(rg.MemberClusters),
+		}
+
+		if rg.ReaderAddress != "" {
+			ng.ReaderEndpoint = &endpointXML{Address: rg.ReaderAddress, Port: rg.ReaderPort}
+		}
+
+		x.NodeGroups = []nodeGroupXML{ng}
 	}
 
 	return x
+}
+
+// nodeGroupMembers builds the per-node membership list from the group's member
+// cluster ids: the first is the primary, the rest are replicas.
+func nodeGroupMembers(members []string) []nodeGroupMemberXML {
+	out := make([]nodeGroupMemberXML, 0, len(members))
+
+	for i, id := range members {
+		role := "replica"
+		if i == 0 {
+			role = "primary"
+		}
+
+		out = append(out, nodeGroupMemberXML{
+			CacheClusterID: id,
+			CacheNodeID:    "0001",
+			CurrentRole:    role,
+		})
+	}
+
+	return out
 }

--- a/server/aws/elasticache/replicationgroup_sdk_roundtrip_test.go
+++ b/server/aws/elasticache/replicationgroup_sdk_roundtrip_test.go
@@ -108,6 +108,59 @@ func TestReplicationGroupSDKRoundTrip(t *testing.T) {
 	}
 }
 
+// TestReplicationGroupMemberAndReaderFields covers that Describe populates
+// MemberClusters, the reader endpoint, per-node membership, and the failover
+// status a caller reads back (Terraform aws_elasticache_replication_group).
+func TestReplicationGroupMemberAndReaderFields(t *testing.T) {
+	ctx := context.Background()
+	c := newReplicationGroupClient(t)
+
+	if _, err := c.CreateReplicationGroup(ctx, &awselasticache.CreateReplicationGroupInput{
+		ReplicationGroupId:          aws.String("rg-fields"),
+		ReplicationGroupDescription: aws.String("with reader + members"),
+		CacheNodeType:               aws.String("cache.t3.micro"),
+		Engine:                      aws.String("redis"),
+		NumCacheClusters:            aws.Int32(2),
+		AutomaticFailoverEnabled:    aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("CreateReplicationGroup: %v", err)
+	}
+
+	desc, err := c.DescribeReplicationGroups(ctx, &awselasticache.DescribeReplicationGroupsInput{
+		ReplicationGroupId: aws.String("rg-fields"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeReplicationGroups: %v", err)
+	}
+
+	rg := desc.ReplicationGroups[0]
+
+	if len(rg.MemberClusters) != 2 {
+		t.Fatalf("MemberClusters = %v, want 2 entries", rg.MemberClusters)
+	}
+
+	if rg.MemberClusters[0] != "rg-fields-001" || rg.MemberClusters[1] != "rg-fields-002" {
+		t.Fatalf("MemberClusters = %v, want rg-fields-001/-002", rg.MemberClusters)
+	}
+
+	if rg.AutomaticFailover != cachetypes.AutomaticFailoverStatusEnabled {
+		t.Fatalf("AutomaticFailover = %q, want enabled", rg.AutomaticFailover)
+	}
+
+	ng := rg.NodeGroups[0]
+	if ng.ReaderEndpoint == nil || aws.ToString(ng.ReaderEndpoint.Address) == "" {
+		t.Fatalf("ReaderEndpoint = %+v, want non-empty", ng.ReaderEndpoint)
+	}
+
+	if len(ng.NodeGroupMembers) != 2 {
+		t.Fatalf("NodeGroupMembers = %d, want 2", len(ng.NodeGroupMembers))
+	}
+
+	if aws.ToString(ng.NodeGroupMembers[0].CurrentRole) != "primary" {
+		t.Fatalf("first member role = %q, want primary", aws.ToString(ng.NodeGroupMembers[0].CurrentRole))
+	}
+}
+
 // TestDeleteReplicationGroupFinalSnapshot guards that DeleteReplicationGroup
 // with FinalSnapshotIdentifier takes a final snapshot before deletion — real
 // ElastiCache does, and the snapshot then shows up in DescribeSnapshots.

--- a/server/aws/elasticache/subnetvalidation_sdk_roundtrip_test.go
+++ b/server/aws/elasticache/subnetvalidation_sdk_roundtrip_test.go
@@ -1,0 +1,50 @@
+package elasticache_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+	ectypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+)
+
+// TestSDKCreateCacheClusterMissingSubnetGroup covers that creating a cluster
+// against a non-existent cache subnet group is rejected with
+// CacheSubnetGroupNotFoundFault, while an existing group succeeds.
+func TestSDKCreateCacheClusterMissingSubnetGroup(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("cs"), Engine: aws.String("redis"),
+		CacheNodeType: aws.String("cache.t3.micro"), NumCacheNodes: aws.Int32(1),
+		CacheSubnetGroupName: aws.String("does-not-exist"),
+	})
+	if err == nil {
+		t.Fatal("CreateCacheCluster with missing subnet group succeeded, want error")
+	}
+
+	var notFound *ectypes.CacheSubnetGroupNotFoundFault
+	if !errors.As(err, &notFound) {
+		t.Fatalf("error = %v, want CacheSubnetGroupNotFoundFault", err)
+	}
+
+	// An existing subnet group is accepted.
+	if _, err := client.CreateCacheSubnetGroup(ctx, &awselasticache.CreateCacheSubnetGroupInput{
+		CacheSubnetGroupName:        aws.String("sg1"),
+		CacheSubnetGroupDescription: aws.String("test"),
+		SubnetIds:                   []string{"subnet-123"},
+	}); err != nil {
+		t.Fatalf("CreateCacheSubnetGroup: %v", err)
+	}
+
+	if _, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("cs2"), Engine: aws.String("redis"),
+		CacheNodeType: aws.String("cache.t3.micro"), NumCacheNodes: aws.Int32(1),
+		CacheSubnetGroupName: aws.String("sg1"),
+	}); err != nil {
+		t.Fatalf("CreateCacheCluster with existing subnet group: %v", err)
+	}
+}

--- a/server/aws/elasticache/types.go
+++ b/server/aws/elasticache/types.go
@@ -16,6 +16,10 @@ import (
 
 const defaultRedisPort = 6379
 
+// memcachedEngine is the ElastiCache engine name whose endpoint semantics differ
+// from Redis/Valkey (single configuration endpoint on port 11211).
+const memcachedEngine = "memcached"
+
 type responseMetadata struct {
 	RequestID string `xml:"RequestId"`
 }
@@ -259,7 +263,12 @@ func toCacheClusterXML(info *cachedriver.CacheInfo) cacheClusterXML {
 	}
 
 	if ep := splitEndpoint(info.Endpoint); ep != nil {
-		out.ConfigurationEndpt = ep
+		// ConfigurationEndpoint is a Memcached-only field in the real API (its
+		// host always carries ".cfg"). Redis/Valkey clusters leave it nil and
+		// expose their address through the per-node CacheNodes endpoint instead.
+		if info.Engine == memcachedEngine {
+			out.ConfigurationEndpt = ep
+		}
 
 		nodes := make([]cacheNodeXML, 0, numNodes)
 		for i := 1; i <= numNodes; i++ {

--- a/server/aws/elasticache/types.go
+++ b/server/aws/elasticache/types.go
@@ -256,8 +256,15 @@ func toCacheClusterXML(info *cachedriver.CacheInfo) cacheClusterXML {
 	}
 
 	if info.Engine != "" {
+		// A custom parameter group the caller attached is echoed verbatim;
+		// otherwise report the engine family's default (default.<family>).
+		paramGroup := info.ParameterGroupName
+		if paramGroup == "" {
+			paramGroup = defaultParamGroupName(info.Engine, info.EngineVersion)
+		}
+
 		out.CacheParameterGroup = &cacheParameterGroupStatusXML{
-			CacheParameterGroupName: defaultParamGroupName(info.Engine, info.EngineVersion),
+			CacheParameterGroupName: paramGroup,
 			ParameterApplyStatus:    "in-sync",
 		}
 	}

--- a/services/cache/driver/driver.go
+++ b/services/cache/driver/driver.go
@@ -62,6 +62,12 @@ type CacheInfo struct {
 	// it. Both are empty/zero for non-AWS providers.
 	NumCacheNodes   int
 	SubnetGroupName string
+
+	// ParameterGroupName is the custom AWS ElastiCache cache parameter group
+	// attached to the cluster, echoed back on Describe so IaC that references a
+	// custom group converges. Empty means the backend reports the engine's
+	// default (default.<family>). AWS-only and left empty by other callers.
+	ParameterGroupName string
 }
 
 // CacheConfig describes a cache instance to create.
@@ -99,6 +105,11 @@ type CacheConfig struct {
 	// zero means unspecified and the backend defaults it per engine (Redis
 	// 6379, Memcached 11211). AWS-only and left zero by other callers.
 	Port int
+
+	// ParameterGroupName names a custom AWS ElastiCache cache parameter group
+	// to attach; empty means the backend reports the engine's default
+	// (default.<family>). AWS-only and left empty by other callers.
+	ParameterGroupName string
 }
 
 // Cache is the interface that cache provider implementations must satisfy.

--- a/services/cache/driver/driver.go
+++ b/services/cache/driver/driver.go
@@ -195,6 +195,19 @@ type ReplicationGroup struct {
 	PrimaryPort     int
 	SubnetGroupName string
 	ARN             string
+
+	// ReaderAddress / ReaderPort are the read-only endpoint clients use to scale
+	// reads across the group's replicas. AWS-only; empty for other clouds.
+	ReaderAddress string
+	ReaderPort    int
+
+	// MemberClusters is the set of cache cluster ids that make up the group
+	// (`<id>-001`, `<id>-002`, …), read by IaC to enumerate the group's nodes.
+	MemberClusters []string
+
+	// AutomaticFailover is the failover status ("enabled" / "disabled") IaC
+	// reads back to confirm the requested setting took effect.
+	AutomaticFailover string
 }
 
 // ReplicationGroupConfig describes a replication group to create.
@@ -207,6 +220,10 @@ type ReplicationGroupConfig struct {
 	NumCacheNodes    int
 	SubnetGroupName  string
 	SecurityGroupIDs []string
+
+	// AutomaticFailoverEnabled requests automatic failover for the group,
+	// reflected as AutomaticFailover ("enabled"/"disabled") on Describe.
+	AutomaticFailoverEnabled bool
 }
 
 // DeleteReplicationGroupOptions carries the optional delete-time behaviors of

--- a/services/cache/driver/driver.go
+++ b/services/cache/driver/driver.go
@@ -112,6 +112,20 @@ type CacheConfig struct {
 	ParameterGroupName string
 }
 
+// ModifyCacheConfig carries the mutable fields of an AWS ElastiCache
+// ModifyCacheCluster call. It is an AWS-only surface (not part of the portable
+// Cache interface); the wire handler type-asserts for a modifier that accepts
+// it. Empty/zero fields leave the corresponding attribute unchanged.
+type ModifyCacheConfig struct {
+	Name          string
+	NodeType      string
+	EngineVersion string
+
+	// NumCacheNodes rescales a Memcached cluster; zero leaves the node count
+	// unchanged. The backend re-validates it against the cluster's engine.
+	NumCacheNodes int
+}
+
 // Cache is the interface that cache provider implementations must satisfy.
 type Cache interface {
 	CreateCache(ctx context.Context, config CacheConfig) (*CacheInfo, error)

--- a/services/cache/driver/driver.go
+++ b/services/cache/driver/driver.go
@@ -94,6 +94,11 @@ type CacheConfig struct {
 	// Both are AWS-only and left zero/empty by other callers.
 	NumCacheNodes   int
 	SubnetGroupName string
+
+	// Port is the requested TCP port the AWS ElastiCache cluster listens on;
+	// zero means unspecified and the backend defaults it per engine (Redis
+	// 6379, Memcached 11211). AWS-only and left zero by other callers.
+	Port int
 }
 
 // Cache is the interface that cache provider implementations must satisfy.


### PR DESCRIPTION
## What

Fixes six real AWS ElastiCache fidelity bugs found by a deep real-user (aws-sdk-go-v2) e2e audit. Each is fixed at the correct 3-layer location and cross-checked against the official ElastiCache API.

- **Custom `Port` was ignored; endpoints always 6379.** `CacheConfig` now carries `Port`; the provider honors it and defaults per engine (Redis 6379, Memcached 11211). Node endpoints report the real port.
- **Memcached endpoints were on 6379.** Memcached now defaults to `11211` and its configuration-endpoint host carries the `.cfg` segment.
- **Redis wrongly returned a `ConfigurationEndpoint`.** That field is Memcached-only in the real API; Redis now returns `nil` and exposes its address through the per-node `CacheNodes` endpoint.
- **Custom `CacheParameterGroupName` was ignored** (`Describe` always echoed `default.<family>`). It is now persisted and echoed back; an omitted one still reports the engine-family default.
- **`ModifyCacheCluster` dropped `NumCacheNodes` and `EngineVersion`.** Both now apply (Memcached rescale re-validated per engine) and reflect on `Describe`.
- **`CreateCacheCluster` did not validate `CacheSubnetGroupName`.** A missing named subnet group is now rejected with `CacheSubnetGroupNotFoundFault` (mirrors RDS's DBSubnetGroup check); an existing one works.
- **`DescribeReplicationGroups` omitted member/reader fields.** Now populates `MemberClusters` (`<id>-001`, …), the node group's `ReaderEndpoint` and `NodeGroupMembers` (primary/replica roles), and `AutomaticFailover`; the provider also defaults `EngineVersion`.

## Why

These caused permanent Terraform drift (`parameter_group_name`, `port`, `configuration_endpoint`, `member_clusters`, `reader_endpoint_address`, `automatic_failover_enabled`) and wrong connection ports for real clients — Memcached clients could not connect at all.

## Tests

Real aws-sdk-go-v2 reproductions added for every fix (custom/default port, memcached 11211 + `.cfg`, redis no config endpoint, param-group persistence, modify scale/version, subnet-group validation, RG member/reader/failover fields). Existing ElastiCache suites remain green.

## Notes

The parameter-group *contents* feature gap (`DescribeCacheParameters` / `ModifyCacheParameterGroup` `ParameterNameValues`) and pagination are intentionally out of scope here.
