### PR TITLE
fix(aws-cwlogs): timestamp-order GetLogEvents + deterministic FilterLogEvents interleave; unset default retention; metric-filter fields; orderBy; missing-stream error

### DIFF
--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -456,9 +456,20 @@ func (m *Mock) FilterLogEvents(
 		results = m.filterStreamEvents(g, input.LogStream, input)
 	} else {
 		for name, s := range g.streams.All() {
-			events := m.matchEvents(s, name, input)
-			results = append(results, events...)
+			results = append(results, m.matchEvents(s, name, input)...)
 		}
+
+		// CloudWatch Logs interleaves matches across streams in ascending
+		// timestamp order; sort by (timestamp, stream) so the result is both
+		// time-ordered and deterministic run-to-run regardless of the random
+		// map-iteration order above. Ties break on stream name.
+		sort.SliceStable(results, func(i, j int) bool {
+			if !results[i].Timestamp.Equal(results[j].Timestamp) {
+				return results[i].Timestamp.Before(results[j].Timestamp)
+			}
+
+			return results[i].LogStream < results[j].LogStream
+		})
 	}
 
 	// A negative limit means "no cap" — the wire handler fetches the full

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -558,6 +558,9 @@ func (m *Mock) PutMetricFilter(
 		MetricName:      cfg.MetricName,
 		MetricNamespace: cfg.MetricNamespace,
 		MetricValue:     cfg.MetricValue,
+		DefaultValue:    cfg.DefaultValue,
+		Unit:            cfg.Unit,
+		Dimensions:      maps.Clone(cfg.Dimensions),
 		CreatedAt:       m.opts.Clock.Now().UTC(),
 	}
 

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -4,6 +4,7 @@ package cloudwatchlogs
 import (
 	"context"
 	"maps"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -18,10 +19,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
-const (
-	defaultRetentionDays = 30
-	defaultLogLimit      = 100
-)
+const defaultLogLimit = 100
 
 // Compile-time check that Mock implements driver.Logging.
 var _ driver.Logging = (*Mock)(nil)
@@ -79,11 +77,9 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 		return nil, errors.Newf(errors.AlreadyExists, "log group %q already exists", cfg.Name)
 	}
 
-	retentionDays := cfg.RetentionDays
-	if retentionDays == 0 {
-		retentionDays = defaultRetentionDays
-	}
-
+	// A log group created without a retention policy never expires: AWS leaves
+	// retentionInDays unset (nil on the SDK) rather than defaulting to 30 days.
+	// The zero value flows through to DescribeLogGroups, which omits the field.
 	arn := idgen.AWSARN("logs", m.opts.Region, m.opts.AccountID, "log-group:"+cfg.Name)
 
 	tags := make(map[string]string, len(cfg.Tags))
@@ -95,7 +91,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 		Name:          cfg.Name,
 		Scope:         cfg.Scope,
 		ResourceID:    arn,
-		RetentionDays: retentionDays,
+		RetentionDays: cfg.RetentionDays,
 		CreatedAt:     m.opts.Clock.Now().UTC().Format(time.RFC3339),
 		StoredBytes:   0,
 		Tags:          tags,
@@ -241,6 +237,11 @@ func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, eve
 
 	s.events = append(s.events, copied...)
 
+	// CloudWatch Logs returns events in timestamp order regardless of the order
+	// they were ingested, so keep the stream's backing slice sorted on insert.
+	// The sort is stable, so equal timestamps retain ingestion order.
+	sortLogEventsAscending(s.events)
+
 	if len(events) > 0 {
 		earliest := events[0].Timestamp
 		for i := range events {
@@ -352,19 +353,29 @@ func (m *Mock) GetLogEvents(_ context.Context, input *driver.LogQueryInput) ([]d
 		limit = defaultLogLimit
 	}
 
-	retentionCutoff := m.opts.Clock.Now().AddDate(0, 0, -g.info.RetentionDays)
+	// Only a configured retention policy drops old events. A group with no
+	// retention (RetentionDays == 0) never expires, so the cutoff stays zero.
+	var retentionCutoff time.Time
+	if g.info.RetentionDays > 0 {
+		retentionCutoff = m.opts.Clock.Now().AddDate(0, 0, -g.info.RetentionDays)
+	}
 
 	var results []driver.LogEvent
 
 	if input.LogStream != "" {
-		events := m.getStreamEvents(g, input.LogStream, input, retentionCutoff)
-		results = append(results, events...)
+		s, ok := g.streams.Get(input.LogStream)
+		if !ok {
+			return nil, errors.Newf(errors.NotFound, "log stream %q not found in group %q", input.LogStream, input.LogGroup)
+		}
+
+		results = append(results, m.filterEvents(s, input, retentionCutoff)...)
 	} else {
-		all := g.streams.All()
-		for _, s := range all {
+		for _, s := range g.streams.SortedValues() {
 			events := m.filterEvents(s, input, retentionCutoff)
 			results = append(results, events...)
 		}
+
+		sortLogEventsAscending(results)
 	}
 
 	// A negative limit means "no cap" — the wire handler fetches the full
@@ -380,13 +391,13 @@ func (m *Mock) GetLogEvents(_ context.Context, input *driver.LogQueryInput) ([]d
 	return results, nil
 }
 
-func (m *Mock) getStreamEvents(g *logGroup, streamName string, input *driver.LogQueryInput, retentionCutoff time.Time) []driver.LogEvent {
-	s, ok := g.streams.Get(streamName)
-	if !ok {
-		return nil
-	}
-
-	return m.filterEvents(s, input, retentionCutoff)
+// sortLogEventsAscending orders log events by timestamp ascending, keeping the
+// relative order of equal-timestamp events (their ingestion order) stable —
+// matching how CloudWatch Logs returns events in timestamp order.
+func sortLogEventsAscending(events []driver.LogEvent) {
+	sort.SliceStable(events, func(i, j int) bool {
+		return events[i].Timestamp.Before(events[j].Timestamp)
+	})
 }
 
 func (*Mock) filterEvents(

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs_test.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/logging/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,7 +49,7 @@ func TestCreateLogGroup(t *testing.T) {
 		assert.Equal(t, int64(0), info.StoredBytes)
 	})
 
-	t.Run("default retention 30 days", func(t *testing.T) {
+	t.Run("no retention policy means never-expire (unset)", func(t *testing.T) {
 		m := newTestMock()
 
 		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
@@ -56,7 +57,8 @@ func TestCreateLogGroup(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		assert.Equal(t, 30, info.RetentionDays)
+		// AWS leaves retentionInDays unset (never expire) when no policy is set.
+		assert.Equal(t, 0, info.RetentionDays)
 	})
 
 	t.Run("custom retention", func(t *testing.T) {
@@ -485,19 +487,20 @@ func TestGetLogEvents(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("nonexistent stream returns empty", func(t *testing.T) {
+	t.Run("nonexistent stream is not found", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
+		// AWS returns ResourceNotFoundException for GetLogEvents on a missing
+		// stream, not an empty page.
+		_, err = m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup:  "grp",
 			LogStream: "no-stream",
 		})
-		require.NoError(t, err)
-
-		assert.Equal(t, 0, len(events))
+		require.Error(t, err)
+		assert.True(t, errors.IsNotFound(err))
 	})
 
 	t.Run("default limit 100", func(t *testing.T) {

--- a/providers/aws/cloudwatchlogs/event_retrieval_test.go
+++ b/providers/aws/cloudwatchlogs/event_retrieval_test.go
@@ -1,0 +1,65 @@
+package cloudwatchlogs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/logging/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetLogEventsTimestampOrder locks the ordering fix: GetLogEvents returns
+// events in timestamp order regardless of the order they were ingested. A
+// "late" batch is put before an "early" one, yet the query returns [early, late].
+func TestGetLogEventsTimestampOrder(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g"})
+	require.NoError(t, err)
+	_, err = m.CreateLogStream(ctx, "g", "s")
+	require.NoError(t, err)
+
+	base := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	require.NoError(t, m.PutLogEvents(ctx, "g", "s", []driver.LogEvent{
+		{Timestamp: base.Add(5000 * time.Millisecond), Message: "late"},
+	}))
+	require.NoError(t, m.PutLogEvents(ctx, "g", "s", []driver.LogEvent{
+		{Timestamp: base.Add(1000 * time.Millisecond), Message: "early"},
+	}))
+
+	got, err := m.GetLogEvents(ctx, &driver.LogQueryInput{LogGroup: "g", LogStream: "s"})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "early", got[0].Message)
+	assert.Equal(t, "late", got[1].Message)
+}
+
+// TestRetentionUnsetNeverDrops locks the retention fix: a group with no retention
+// policy never expires, so events far older than 30 days are still retained and
+// returned by GetLogEvents (no phantom 30-day cutoff).
+func TestRetentionUnsetNeverDrops(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, info.RetentionDays)
+
+	_, err = m.CreateLogStream(ctx, "g", "s")
+	require.NoError(t, err)
+
+	// Clock is 2025-01-01; this event is ~1 year old.
+	old := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, m.PutLogEvents(ctx, "g", "s", []driver.LogEvent{
+		{Timestamp: old, Message: "ancient"},
+	}))
+
+	got, err := m.GetLogEvents(ctx, &driver.LogQueryInput{LogGroup: "g", LogStream: "s"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "ancient", got[0].Message)
+}

--- a/providers/aws/cloudwatchlogs/filter_log_events_order_test.go
+++ b/providers/aws/cloudwatchlogs/filter_log_events_order_test.go
@@ -1,0 +1,57 @@
+package cloudwatchlogs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/logging/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFilterLogEventsAscendingDeterministic locks the multi-stream ordering fix:
+// FilterLogEvents interleaves matches across streams in ascending timestamp
+// order, and the result is stable run-to-run (never random map order).
+func TestFilterLogEventsAscendingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g"})
+	require.NoError(t, err)
+
+	base := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	puts := []struct {
+		stream string
+		ms     int
+	}{
+		{"s1", 1000}, {"s3", 3000}, {"s2", 2000}, {"s1", 4000},
+	}
+
+	for _, p := range puts {
+		_, _ = m.CreateLogStream(ctx, "g", p.stream)
+		require.NoError(t, m.PutLogEvents(ctx, "g", p.stream, []driver.LogEvent{
+			{Timestamp: base.Add(time.Duration(p.ms) * time.Millisecond), Message: p.stream},
+		}))
+	}
+
+	want := []int64{
+		base.Add(1000 * time.Millisecond).UnixMilli(),
+		base.Add(2000 * time.Millisecond).UnixMilli(),
+		base.Add(3000 * time.Millisecond).UnixMilli(),
+		base.Add(4000 * time.Millisecond).UnixMilli(),
+	}
+
+	// Repeat to catch map-iteration nondeterminism.
+	for range 10 {
+		got, err := m.FilterLogEvents(ctx, &driver.FilterLogEventsInput{LogGroup: "g"})
+		require.NoError(t, err)
+		require.Len(t, got, 4)
+
+		gotMs := make([]int64, len(got))
+		for i := range got {
+			gotMs[i] = got[i].Timestamp.UnixMilli()
+		}
+		assert.Equal(t, want, gotMs)
+	}
+}

--- a/providers/aws/cloudwatchlogs/metric_filter_fields_test.go
+++ b/providers/aws/cloudwatchlogs/metric_filter_fields_test.go
@@ -1,0 +1,43 @@
+package cloudwatchlogs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/logging/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMetricFilterFieldsRoundTrip locks the metric-filter round-trip fix:
+// DefaultValue, Unit, and Dimensions set on PutMetricFilter survive to
+// DescribeMetricFilters (previously dropped).
+func TestMetricFilterFieldsRoundTrip(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g"})
+	require.NoError(t, err)
+
+	def := 0.0
+	require.NoError(t, m.PutMetricFilter(ctx, &driver.MetricFilterConfig{
+		Name:            "f",
+		LogGroup:        "g",
+		FilterPattern:   "ERROR",
+		MetricName:      "ErrCount",
+		MetricNamespace: "MyApp",
+		MetricValue:     "1",
+		DefaultValue:    &def,
+		Unit:            "Count",
+		Dimensions:      map[string]string{"Service": "api"},
+	}))
+
+	filters, err := m.DescribeMetricFilters(ctx, "g")
+	require.NoError(t, err)
+	require.Len(t, filters, 1)
+
+	require.NotNil(t, filters[0].DefaultValue)
+	assert.InDelta(t, 0.0, *filters[0].DefaultValue, 0)
+	assert.Equal(t, "Count", filters[0].Unit)
+	assert.Equal(t, "api", filters[0].Dimensions["Service"])
+}

--- a/server/aws/cloudwatchlogs/describe_log_streams_orderby_sdk_test.go
+++ b/server/aws/cloudwatchlogs/describe_log_streams_orderby_sdk_test.go
@@ -1,0 +1,70 @@
+package cloudwatchlogs_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cwl "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+)
+
+// TestSDKDescribeLogStreamsOrderByLastEventTime reproduces the orderBy bug:
+// stream "a" gets the newest event, so DescribeLogStreams with
+// orderBy=LastEventTime + descending must return it first (name order would put
+// "a" first anyway, so "a" is deliberately given the newest event while "b"
+// sorts first by name — descending LastEventTime must still surface "a").
+func TestSDKDescribeLogStreamsOrderByLastEventTime(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String("/ord/g")}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	base := time.Now().UTC().Truncate(time.Millisecond)
+
+	// "b" is name-first but has the older last event; "a" has the newest.
+	streamsToEvents := []struct {
+		stream string
+		off    time.Duration
+	}{
+		{"b", 1 * time.Second},
+		{"a", 10 * time.Second},
+	}
+
+	for _, se := range streamsToEvents {
+		if _, err := client.CreateLogStream(ctx, &cwl.CreateLogStreamInput{
+			LogGroupName: aws.String("/ord/g"), LogStreamName: aws.String(se.stream),
+		}); err != nil {
+			t.Fatalf("CreateLogStream %s: %v", se.stream, err)
+		}
+		if _, err := client.PutLogEvents(ctx, &cwl.PutLogEventsInput{
+			LogGroupName: aws.String("/ord/g"), LogStreamName: aws.String(se.stream),
+			LogEvents: []cwltypes.InputLogEvent{
+				{Timestamp: aws.Int64(base.Add(se.off).UnixMilli()), Message: aws.String("m")},
+			},
+		}); err != nil {
+			t.Fatalf("PutLogEvents %s: %v", se.stream, err)
+		}
+	}
+
+	out, err := client.DescribeLogStreams(ctx, &cwl.DescribeLogStreamsInput{
+		LogGroupName: aws.String("/ord/g"),
+		OrderBy:      cwltypes.OrderByLastEventTime,
+		Descending:   aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("DescribeLogStreams: %v", err)
+	}
+
+	if len(out.LogStreams) != 2 {
+		t.Fatalf("got %d streams, want 2", len(out.LogStreams))
+	}
+
+	if aws.ToString(out.LogStreams[0].LogStreamName) != "a" {
+		t.Fatalf("orderBy=LastEventTime descending first = %q, want a (newest event)",
+			aws.ToString(out.LogStreams[0].LogStreamName))
+	}
+}

--- a/server/aws/cloudwatchlogs/event_retrieval_sdk_test.go
+++ b/server/aws/cloudwatchlogs/event_retrieval_sdk_test.go
@@ -1,0 +1,122 @@
+package cloudwatchlogs_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cwl "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+)
+
+// TestSDKGetLogEventsTimestampOrder reproduces the out-of-order ingestion bug:
+// a batch stamped later is put before an earlier one, yet GetLogEvents
+// (startFromHead=true) must return them in timestamp order [early, late].
+func TestSDKGetLogEventsTimestampOrder(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	mustLogGroupStream(t, client, "/order/g", "s1")
+
+	base := time.Now().UTC().Truncate(time.Millisecond)
+
+	if _, err := client.PutLogEvents(ctx, &cwl.PutLogEventsInput{
+		LogGroupName: aws.String("/order/g"), LogStreamName: aws.String("s1"),
+		LogEvents: []cwltypes.InputLogEvent{
+			{Timestamp: aws.Int64(base.Add(5 * time.Second).UnixMilli()), Message: aws.String("late")},
+		},
+	}); err != nil {
+		t.Fatalf("PutLogEvents late: %v", err)
+	}
+
+	if _, err := client.PutLogEvents(ctx, &cwl.PutLogEventsInput{
+		LogGroupName: aws.String("/order/g"), LogStreamName: aws.String("s1"),
+		LogEvents: []cwltypes.InputLogEvent{
+			{Timestamp: aws.Int64(base.Add(1 * time.Second).UnixMilli()), Message: aws.String("early")},
+		},
+	}); err != nil {
+		t.Fatalf("PutLogEvents early: %v", err)
+	}
+
+	out, err := client.GetLogEvents(ctx, &cwl.GetLogEventsInput{
+		LogGroupName: aws.String("/order/g"), LogStreamName: aws.String("s1"),
+		StartFromHead: aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("GetLogEvents: %v", err)
+	}
+
+	if len(out.Events) != 2 ||
+		aws.ToString(out.Events[0].Message) != "early" ||
+		aws.ToString(out.Events[1].Message) != "late" {
+		t.Fatalf("GetLogEvents = %+v, want [early late] in timestamp order", out.Events)
+	}
+}
+
+// TestSDKRetentionUnsetAndPut reproduces the retention default bug: a group made
+// without a retention policy reports retentionInDays as nil (never expire), and
+// PutRetentionPolicy(7) is then reflected.
+func TestSDKRetentionUnsetAndPut(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String("/ret/g")}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	desc, err := client.DescribeLogGroups(ctx, &cwl.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String("/ret/g"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeLogGroups: %v", err)
+	}
+
+	if len(desc.LogGroups) != 1 {
+		t.Fatalf("got %d groups, want 1", len(desc.LogGroups))
+	}
+
+	if desc.LogGroups[0].RetentionInDays != nil {
+		t.Fatalf("RetentionInDays = %d, want nil (never expire) for a group with no policy",
+			aws.ToInt32(desc.LogGroups[0].RetentionInDays))
+	}
+
+	if _, err := client.PutRetentionPolicy(ctx, &cwl.PutRetentionPolicyInput{
+		LogGroupName: aws.String("/ret/g"), RetentionInDays: aws.Int32(7),
+	}); err != nil {
+		t.Fatalf("PutRetentionPolicy: %v", err)
+	}
+
+	after, err := client.DescribeLogGroups(ctx, &cwl.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String("/ret/g"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeLogGroups after put: %v", err)
+	}
+
+	if aws.ToInt32(after.LogGroups[0].RetentionInDays) != 7 {
+		t.Fatalf("RetentionInDays = %d, want 7", aws.ToInt32(after.LogGroups[0].RetentionInDays))
+	}
+}
+
+// TestSDKGetLogEventsMissingStream reproduces the missing-stream bug:
+// GetLogEvents on a stream that does not exist must return
+// ResourceNotFoundException, not an empty page.
+func TestSDKGetLogEventsMissingStream(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String("/miss/g")}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	_, err := client.GetLogEvents(ctx, &cwl.GetLogEventsInput{
+		LogGroupName: aws.String("/miss/g"), LogStreamName: aws.String("nope"),
+	})
+
+	var notFound *cwltypes.ResourceNotFoundException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("GetLogEvents(missing stream): got %v, want ResourceNotFoundException", err)
+	}
+}

--- a/server/aws/cloudwatchlogs/filter_log_events_order_sdk_test.go
+++ b/server/aws/cloudwatchlogs/filter_log_events_order_sdk_test.go
@@ -1,0 +1,84 @@
+package cloudwatchlogs_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cwl "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+)
+
+// TestSDKFilterLogEventsAscendingDeterministic reproduces the multi-stream
+// ordering bug: matches across three streams (ts 1000/3000/2000/4000) must come
+// back interleaved ascending [1000 2000 3000 4000] on every run.
+func TestSDKFilterLogEventsAscendingDeterministic(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String("/fla/g")}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	base := time.Now().UTC().Truncate(time.Millisecond)
+	puts := []struct {
+		stream string
+		off    time.Duration
+	}{
+		{"s1", 1000 * time.Millisecond},
+		{"s3", 3000 * time.Millisecond},
+		{"s2", 2000 * time.Millisecond},
+		{"s1", 4000 * time.Millisecond},
+	}
+
+	for _, p := range puts {
+		_, _ = client.CreateLogStream(ctx, &cwl.CreateLogStreamInput{
+			LogGroupName: aws.String("/fla/g"), LogStreamName: aws.String(p.stream),
+		})
+		if _, err := client.PutLogEvents(ctx, &cwl.PutLogEventsInput{
+			LogGroupName: aws.String("/fla/g"), LogStreamName: aws.String(p.stream),
+			LogEvents: []cwltypes.InputLogEvent{
+				{Timestamp: aws.Int64(base.Add(p.off).UnixMilli()), Message: aws.String("m")},
+			},
+		}); err != nil {
+			t.Fatalf("PutLogEvents %s: %v", p.stream, err)
+		}
+	}
+
+	want := []int64{
+		base.Add(1000 * time.Millisecond).UnixMilli(),
+		base.Add(2000 * time.Millisecond).UnixMilli(),
+		base.Add(3000 * time.Millisecond).UnixMilli(),
+		base.Add(4000 * time.Millisecond).UnixMilli(),
+	}
+
+	for run := 0; run < 8; run++ {
+		out, err := client.FilterLogEvents(ctx, &cwl.FilterLogEventsInput{
+			LogGroupName: aws.String("/fla/g"),
+		})
+		if err != nil {
+			t.Fatalf("FilterLogEvents run %d: %v", run, err)
+		}
+
+		if len(out.Events) != 4 {
+			t.Fatalf("run %d: got %d events, want 4", run, len(out.Events))
+		}
+
+		for i := range out.Events {
+			if aws.ToInt64(out.Events[i].Timestamp) != want[i] {
+				t.Fatalf("run %d: event[%d] ts = %d, want %d (order = %v)",
+					run, i, aws.ToInt64(out.Events[i].Timestamp), want[i], filteredTimestamps(out.Events))
+			}
+		}
+	}
+}
+
+func filteredTimestamps(events []cwltypes.FilteredLogEvent) []int64 {
+	ms := make([]int64, len(events))
+	for i := range events {
+		ms[i] = aws.ToInt64(events[i].Timestamp)
+	}
+
+	return ms
+}

--- a/server/aws/cloudwatchlogs/metric_filter_fields_sdk_test.go
+++ b/server/aws/cloudwatchlogs/metric_filter_fields_sdk_test.go
@@ -1,0 +1,58 @@
+package cloudwatchlogs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cwl "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+)
+
+// TestSDKMetricFilterTransformationFields reproduces the metric-filter round-trip
+// bug: DefaultValue and Unit set on PutMetricFilter must survive to
+// DescribeMetricFilters (previously dropped to nil / "").
+func TestSDKMetricFilterTransformationFields(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String("/mf/g")}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	if _, err := client.PutMetricFilter(ctx, &cwl.PutMetricFilterInput{
+		LogGroupName:  aws.String("/mf/g"),
+		FilterName:    aws.String("errors"),
+		FilterPattern: aws.String("ERROR"),
+		MetricTransformations: []cwltypes.MetricTransformation{{
+			MetricName:      aws.String("ErrorCount"),
+			MetricNamespace: aws.String("MyApp"),
+			MetricValue:     aws.String("1"),
+			DefaultValue:    aws.Float64(0),
+			Unit:            cwltypes.StandardUnitCount,
+		}},
+	}); err != nil {
+		t.Fatalf("PutMetricFilter: %v", err)
+	}
+
+	desc, err := client.DescribeMetricFilters(ctx, &cwl.DescribeMetricFiltersInput{
+		LogGroupName: aws.String("/mf/g"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeMetricFilters: %v", err)
+	}
+
+	if len(desc.MetricFilters) != 1 || len(desc.MetricFilters[0].MetricTransformations) != 1 {
+		t.Fatalf("DescribeMetricFilters = %+v, want one filter with one transformation", desc.MetricFilters)
+	}
+
+	mt := desc.MetricFilters[0].MetricTransformations[0]
+
+	if mt.DefaultValue == nil || aws.ToFloat64(mt.DefaultValue) != 0 {
+		t.Fatalf("DefaultValue = %v, want 0", mt.DefaultValue)
+	}
+
+	if mt.Unit != cwltypes.StandardUnitCount {
+		t.Fatalf("Unit = %q, want Count", mt.Unit)
+	}
+}

--- a/server/aws/cloudwatchlogs/metric_filters.go
+++ b/server/aws/cloudwatchlogs/metric_filters.go
@@ -80,6 +80,9 @@ func (h *Handler) putMetricFilter(w http.ResponseWriter, r *http.Request) {
 		MetricName:      mt.MetricName,
 		MetricNamespace: mt.MetricNamespace,
 		MetricValue:     mt.MetricValue,
+		DefaultValue:    mt.DefaultValue,
+		Unit:            mt.Unit,
+		Dimensions:      mt.Dimensions,
 	}); err != nil {
 		writeErr(w, err)
 		return
@@ -119,6 +122,9 @@ func (h *Handler) describeMetricFilters(w http.ResponseWriter, r *http.Request) 
 				MetricName:      mf.MetricName,
 				MetricNamespace: mf.MetricNamespace,
 				MetricValue:     mf.MetricValue,
+				DefaultValue:    mf.DefaultValue,
+				Unit:            mf.Unit,
+				Dimensions:      mf.Dimensions,
 			}},
 		})
 	}

--- a/server/aws/cloudwatchlogs/operations.go
+++ b/server/aws/cloudwatchlogs/operations.go
@@ -3,6 +3,7 @@ package cloudwatchlogs
 import (
 	"encoding/base64"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -202,6 +203,10 @@ func (h *Handler) describeLogStreams(w http.ResponseWriter, r *http.Request) {
 		infos = filtered
 	}
 
+	// Order the streams: LogStreamName (the driver's default) or LastEventTime,
+	// each optionally reversed by descending.
+	orderLogStreams(infos, req.OrderBy, req.Descending)
+
 	// The stream ARN is derived from the owning group's ARN, which the driver
 	// carries on the group, not the stream.
 	groupARN := ""
@@ -222,6 +227,28 @@ func (h *Handler) describeLogStreams(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wire.WriteJSON(w, resp)
+}
+
+// orderByLastEventTime is the DescribeLogStreams orderBy value that sorts by
+// each stream's most recent event timestamp instead of its name.
+const orderByLastEventTime = "LastEventTime"
+
+// orderLogStreams sorts streams in place to honor DescribeLogStreams orderBy /
+// descending. The driver already returns streams name-sorted ascending, so the
+// default (LogStreamName, ascending) is a no-op; LastEventTime sorts by each
+// stream's last-event timestamp, and descending reverses whichever key is used.
+func orderLogStreams(infos []logdriver.LogStreamInfo, orderBy string, descending bool) {
+	if orderBy == orderByLastEventTime {
+		sort.SliceStable(infos, func(i, j int) bool {
+			return isoToEpochMillis(infos[i].LastEvent) < isoToEpochMillis(infos[j].LastEvent)
+		})
+	}
+
+	if descending {
+		for i, j := 0, len(infos)-1; i < j; i, j = i+1, j-1 {
+			infos[i], infos[j] = infos[j], infos[i]
+		}
+	}
 }
 
 func (h *Handler) deleteLogStream(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/cloudwatchlogs/types.go
+++ b/server/aws/cloudwatchlogs/types.go
@@ -31,6 +31,8 @@ type createLogStreamRequest struct {
 type describeLogStreamsRequest struct {
 	LogGroupName        string `json:"logGroupName"`
 	LogStreamNamePrefix string `json:"logStreamNamePrefix"`
+	OrderBy             string `json:"orderBy"`
+	Descending          bool   `json:"descending"`
 	Limit               int32  `json:"limit"`
 	NextToken           string `json:"nextToken"`
 }

--- a/services/logging/driver/driver.go
+++ b/services/logging/driver/driver.go
@@ -86,6 +86,14 @@ type MetricFilterConfig struct {
 	MetricName      string
 	MetricNamespace string
 	MetricValue     string
+	// DefaultValue is emitted for the metric when a log event does not match
+	// the filter pattern. Nil means no default (the metric is simply not
+	// published for non-matching events).
+	DefaultValue *float64
+	// Unit is the CloudWatch unit of the emitted metric (e.g. "Count").
+	Unit string
+	// Dimensions are the dimension name→value pairs attached to the metric.
+	Dimensions map[string]string
 }
 
 // MetricFilterInfo describes a metric filter.
@@ -96,7 +104,12 @@ type MetricFilterInfo struct {
 	MetricName      string
 	MetricNamespace string
 	MetricValue     string
-	CreatedAt       time.Time
+	// DefaultValue, Unit, and Dimensions mirror the MetricTransformation fields
+	// (see MetricFilterConfig); zero/nil when the filter did not set them.
+	DefaultValue *float64
+	Unit         string
+	Dimensions   map[string]string
+	CreatedAt    time.Time
 }
 
 // Logging is the interface that logging provider implementations must satisfy.


### PR DESCRIPTION
## What

Fixes six CloudWatch Logs ordering / retrieval / retention / metric-filter divergences found by the AWS deep-e2e real-user audit (driven with the real `aws-sdk-go-v2/cloudwatchlogs` client). Each is committed separately.

- **Timestamp-order GetLogEvents** — events are returned in timestamp order (stable on ties), not ingestion order. The stream's backing slice is kept sorted on insert and the multi-stream merge is sorted. Fixes out-of-order puts returning `[late, early]`.
- **Deterministic FilterLogEvents interleave** — matches across streams are sorted by `(timestamp, stream)` after collection, so results are ascending and identical run-to-run instead of grouped per stream in random map order.
- **Unset default log-group retention** — a group created without a retention policy stays unset (never expire) instead of defaulting to 30 days; `DescribeLogGroups` omits `retentionInDays`, and the phantom 30-day event-drop cutoff no longer runs when retention is unset. `PutRetentionPolicy` still sets and reflects it.
- **Metric-filter round-trip** — `MetricTransformation` `DefaultValue` / `Unit` / `Dimensions` are added to the logging driver config/info, persisted, and echoed back on `DescribeMetricFilters` (previously dropped).
- **DescribeLogStreams orderBy + descending** — decode `orderBy` (`LogStreamName` default, or `LastEventTime`) and the `descending` flag; the newest-stream lookup now returns the right stream.
- **Missing-stream error** — `GetLogEvents` on a nonexistent stream returns `ResourceNotFoundException` instead of an empty page.

## Why

These are real behavioral divergences from AWS (verified against the official CloudWatch Logs API reference): log-tail tooling and Terraform data sources depend on timestamp ordering; `aws_cloudwatch_log_group` with no `retention_in_days` and `aws_cloudwatch_log_metric_filter` with `default_value`/`unit` were showing perpetual drift; the `orderBy=LastEventTime, descending, limit=1` newest-stream pattern returned the wrong stream.

Subscription filters and CWL filter-pattern grammar are intentionally out of scope (separate follow-ups).

## Tests

Real `aws-sdk-go-v2` wire reproductions plus provider-level tests for each fix. Existing CW Logs tests (metric-filter increment, pagination, retention table, DeleteLogGroup cascade, `-race` concurrent PutLogEvents) stay green; two existing assertions that encoded the old buggy behavior (default retention 30, missing-stream empty) were updated to the AWS-correct expectations. Coverage docs regenerated (no diff).
