### PR TITLE
fix(aws-sfn): require an updatable field on UpdateStateMachine + roleArn on CreateStateMachine

### DIFF
--- a/providers/aws/sfn/errors.go
+++ b/providers/aws/sfn/errors.go
@@ -78,6 +78,12 @@ func invalidName(msg string) error {
 	return &driver.APIError{Exception: driver.ExInvalidName, Err: errors.New(errors.InvalidArgument, msg)}
 }
 
+// missingRequiredParameter builds a MissingRequiredParameter-tagged error,
+// returned when UpdateStateMachine supplies none of its updatable fields.
+func missingRequiredParameter(msg string) error {
+	return &driver.APIError{Exception: driver.ExMissingRequiredParameter, Err: errors.New(errors.InvalidArgument, msg)}
+}
+
 // invalidExecutionInput builds an InvalidExecutionInput-tagged error, returned
 // when a StartExecution Input is not valid JSON.
 func invalidExecutionInput(msg string) error {

--- a/providers/aws/sfn/sfn.go
+++ b/providers/aws/sfn/sfn.go
@@ -30,6 +30,8 @@ const (
 	arnScheme = "arn"
 	// statesService is the SFN service segment of a states ARN.
 	statesService = "states"
+	// iamService is the IAM service segment of a role ARN.
+	iamService = "iam"
 	// emptyJSON is the default output/input payload when none is supplied.
 	emptyJSON = "{}"
 )
@@ -158,6 +160,20 @@ func validActivityARN(arn string) bool {
 // validMapRunARN reports whether arn has the SFN Map Run ARN shape.
 func validMapRunARN(arn string) bool {
 	return statesResourcePrefix(arn, "mapRun:")
+}
+
+// validRoleARN reports whether arn has the IAM role ARN shape
+// (arn:<partition>:iam::<account>:role/<name>). Step Functions requires a
+// valid IAM role ARN on CreateStateMachine and rejects anything else as
+// InvalidArn.
+func validRoleARN(arn string) bool {
+	seg := strings.SplitN(arn, ":", arnParts)
+	if len(seg) != arnParts {
+		return false
+	}
+
+	return seg[0] == arnScheme && seg[2] == iamService &&
+		strings.HasPrefix(seg[5], "role/") && len(seg[5]) > len("role/")
 }
 
 func copyTags(in map[string]string) map[string]string {

--- a/providers/aws/sfn/sfn_test.go
+++ b/providers/aws/sfn/sfn_test.go
@@ -2,6 +2,7 @@ package sfn_test
 
 import (
 	"context"
+	stderrors "errors"
 	"strings"
 	"testing"
 	"time"
@@ -50,6 +51,83 @@ func TestCreateRequiresNameAndDefinition(t *testing.T) {
 	}
 }
 
+// exceptionOf returns the SFN exception name tagged on err, or "" if err is not
+// a driver.APIError.
+func exceptionOf(err error) string {
+	var apiErr *driver.APIError
+	if stderrors.As(err, &apiErr) {
+		return apiErr.Exception
+	}
+
+	return ""
+}
+
+func TestCreateRequiresRoleArn(t *testing.T) {
+	m := newMock(t)
+	ctx := context.Background()
+
+	// Missing roleArn is InvalidArn (empty is not a valid IAM role ARN).
+	_, _, _, err := m.CreateStateMachine(ctx, driver.CreateStateMachineInput{
+		Name: "no-role", Definition: definition,
+	})
+	if ex := exceptionOf(err); ex != driver.ExInvalidArn {
+		t.Fatalf("missing roleArn: want InvalidArn, got %q (err=%v)", ex, err)
+	}
+
+	// A malformed roleArn is also InvalidArn.
+	_, _, _, err = m.CreateStateMachine(ctx, driver.CreateStateMachineInput{
+		Name: "bad-role", Definition: definition, RoleArn: "arn:aws:states:::not-a-role",
+	})
+	if ex := exceptionOf(err); ex != driver.ExInvalidArn {
+		t.Fatalf("malformed roleArn: want InvalidArn, got %q (err=%v)", ex, err)
+	}
+
+	// A valid IAM role ARN creates the machine.
+	if _, _, _, err := m.CreateStateMachine(ctx, driver.CreateStateMachineInput{
+		Name: "ok-role", Definition: definition, RoleArn: "arn:aws:iam::000000000000:role/svc",
+	}); err != nil {
+		t.Fatalf("valid roleArn should create, got %v", err)
+	}
+}
+
+func TestUpdateRequiresUpdatableField(t *testing.T) {
+	m := newMock(t)
+	ctx := context.Background()
+	arn := createSM(t, m, "upd")
+
+	before, err := m.DescribeStateMachine(ctx, arn)
+	if err != nil {
+		t.Fatalf("DescribeStateMachine: %v", err)
+	}
+	rev0 := before.RevisionID
+
+	// An update supplying none of the updatable fields is MissingRequiredParameter.
+	_, err = m.UpdateStateMachine(ctx, driver.UpdateStateMachineInput{ARN: arn})
+	if ex := exceptionOf(err); ex != driver.ExMissingRequiredParameter {
+		t.Fatalf("empty update: want MissingRequiredParameter, got %q (err=%v)", ex, err)
+	}
+
+	// The rejected update must not bump the revision.
+	after, err := m.DescribeStateMachine(ctx, arn)
+	if err != nil {
+		t.Fatalf("DescribeStateMachine: %v", err)
+	}
+	if after.RevisionID != rev0 {
+		t.Fatalf("rejected update bumped revision: %q -> %q", rev0, after.RevisionID)
+	}
+
+	// A valid update (new definition) succeeds and changes the revision.
+	res, err := m.UpdateStateMachine(ctx, driver.UpdateStateMachineInput{
+		ARN: arn, Definition: `{"StartAt":"Done","States":{"Done":{"Type":"Succeed"}}}`,
+	})
+	if err != nil {
+		t.Fatalf("valid update should succeed, got %v", err)
+	}
+	if res.RevisionID == "" || res.RevisionID == rev0 {
+		t.Fatalf("valid update should change revision, got %q (was %q)", res.RevisionID, rev0)
+	}
+}
+
 func TestCreateDescribeStateMachine(t *testing.T) {
 	m := newMock(t)
 	ctx := context.Background()
@@ -80,6 +158,7 @@ func TestCreateDuplicateNameFails(t *testing.T) {
 	// A differing definition on the same name is a genuine collision.
 	_, _, _, err := m.CreateStateMachine(context.Background(), driver.CreateStateMachineInput{
 		Name: "dup", Definition: `{"StartAt":"Done","States":{"Done":{"Type":"Succeed"}}}`,
+		RoleArn: "arn:aws:iam::000000000000:role/r",
 	})
 	if !errors.IsAlreadyExists(err) {
 		t.Fatalf("duplicate name should be AlreadyExists, got %v", err)

--- a/providers/aws/sfn/statemachines.go
+++ b/providers/aws/sfn/statemachines.go
@@ -67,6 +67,12 @@ func (m *Mock) CreateStateMachine(
 		return "", "", time.Time{}, err
 	}
 
+	// roleArn is required and must be a valid IAM role ARN. An empty or
+	// malformed value is InvalidArn (real SFN validates the role ARN shape).
+	if !validRoleARN(in.RoleArn) {
+		return "", "", time.Time{}, invalidArn("%q is not a valid IAM role ARN", in.RoleArn)
+	}
+
 	smType := in.Type
 	if smType == "" {
 		smType = driver.TypeStandard
@@ -151,6 +157,16 @@ func (m *Mock) DescribeStateMachine(_ context.Context, arn string) (*driver.Stat
 	return &out, nil
 }
 
+// hasUpdatableField reports whether an UpdateStateMachine request supplies at
+// least one field it can mutate. Real SFN rejects an update carrying none of
+// them with MissingRequiredParameter.
+//
+//nolint:gocritic // in is a value to satisfy the driver.SFN interface signature.
+func hasUpdatableField(in driver.UpdateStateMachineInput) bool {
+	return in.Definition != "" || in.RoleArn != "" || in.LoggingConfigJSON != "" ||
+		in.TracingConfigJSON != "" || in.EncryptionCfgJSON != ""
+}
+
 //nolint:gocritic // in is a value to satisfy the driver.SFN interface signature.
 func (m *Mock) UpdateStateMachine(
 	_ context.Context, in driver.UpdateStateMachineInput,
@@ -158,6 +174,14 @@ func (m *Mock) UpdateStateMachine(
 	sd, err := m.getSM(in.ARN)
 	if err != nil {
 		return nil, err
+	}
+
+	// UpdateStateMachine must change at least one updatable field. Supplying
+	// none is a no-op that real SFN rejects with MissingRequiredParameter (and
+	// it must not bump the revision).
+	if !hasUpdatableField(in) {
+		return nil, missingRequiredParameter(
+			"UpdateStateMachine requires at least one of definition or roleArn")
 	}
 
 	sd.mu.Lock()

--- a/server/aws/sfn/state_machine_validation_test.go
+++ b/server/aws/sfn/state_machine_validation_test.go
@@ -1,0 +1,108 @@
+package sfn_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssfn "github.com/aws/aws-sdk-go-v2/service/sfn"
+	"github.com/aws/smithy-go"
+)
+
+// errorCode returns the SFN service error code carried by err, or "" if err is
+// not a modeled API error.
+func errorCode(err error) string {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorCode()
+	}
+
+	return ""
+}
+
+// TestSDKCreateStateMachineRequiresRoleArn covers F5: roleArn is required and
+// validated as an IAM role ARN. An empty or malformed value is InvalidArn.
+func TestSDKCreateStateMachineRequiresRoleArn(t *testing.T) {
+	ctx := context.Background()
+	c := newSFNClient(t)
+
+	// Empty roleArn: the SDK's client-side required check is a nil-check, so an
+	// explicit empty string reaches the server and must be rejected.
+	_, err := c.CreateStateMachine(ctx, &awssfn.CreateStateMachineInput{
+		Name: aws.String("empty-role"), Definition: aws.String(definition),
+		RoleArn: aws.String(""),
+	})
+	if code := errorCode(err); code != "InvalidArn" {
+		t.Fatalf("empty roleArn: want InvalidArn, got %q (err=%v)", code, err)
+	}
+
+	// Malformed roleArn: not an IAM role ARN.
+	_, err = c.CreateStateMachine(ctx, &awssfn.CreateStateMachineInput{
+		Name: aws.String("bad-role"), Definition: aws.String(definition),
+		RoleArn: aws.String("not-an-arn"),
+	})
+	if code := errorCode(err); code != "InvalidArn" {
+		t.Fatalf("malformed roleArn: want InvalidArn, got %q (err=%v)", code, err)
+	}
+
+	// A valid IAM role ARN still creates the state machine.
+	out, err := c.CreateStateMachine(ctx, &awssfn.CreateStateMachineInput{
+		Name: aws.String("good-role"), Definition: aws.String(definition),
+		RoleArn: aws.String("arn:aws:iam::123456789012:role/svc"),
+	})
+	if err != nil {
+		t.Fatalf("valid roleArn should create, got %v", err)
+	}
+	if aws.ToString(out.StateMachineArn) == "" {
+		t.Fatalf("expected a state machine ARN")
+	}
+}
+
+// TestSDKUpdateStateMachineRequiresUpdatableField covers F3: UpdateStateMachine
+// with neither definition nor roleArn is MissingRequiredParameter and must not
+// bump the revision; a real update succeeds and changes the revision.
+func TestSDKUpdateStateMachineRequiresUpdatableField(t *testing.T) {
+	ctx := context.Background()
+	c := newSFNClient(t)
+	arn := createSM(t, c, "upd")
+
+	before, err := c.DescribeStateMachine(ctx, &awssfn.DescribeStateMachineInput{
+		StateMachineArn: aws.String(arn),
+	})
+	if err != nil {
+		t.Fatalf("DescribeStateMachine: %v", err)
+	}
+	rev0 := aws.ToString(before.RevisionId)
+
+	// Update with only the ARN (no updatable field) is rejected.
+	_, err = c.UpdateStateMachine(ctx, &awssfn.UpdateStateMachineInput{
+		StateMachineArn: aws.String(arn),
+	})
+	if code := errorCode(err); code != "MissingRequiredParameter" {
+		t.Fatalf("empty update: want MissingRequiredParameter, got %q (err=%v)", code, err)
+	}
+
+	// The rejected update must not have bumped the revision.
+	mid, err := c.DescribeStateMachine(ctx, &awssfn.DescribeStateMachineInput{
+		StateMachineArn: aws.String(arn),
+	})
+	if err != nil {
+		t.Fatalf("DescribeStateMachine: %v", err)
+	}
+	if got := aws.ToString(mid.RevisionId); got != rev0 {
+		t.Fatalf("rejected update bumped revision: %q -> %q", rev0, got)
+	}
+
+	// A valid update (new definition) succeeds and changes the revision.
+	newDef := `{"StartAt":"Done","States":{"Done":{"Type":"Succeed"}}}`
+	upd, err := c.UpdateStateMachine(ctx, &awssfn.UpdateStateMachineInput{
+		StateMachineArn: aws.String(arn), Definition: aws.String(newDef),
+	})
+	if err != nil {
+		t.Fatalf("valid update should succeed, got %v", err)
+	}
+	if got := aws.ToString(upd.RevisionId); got == "" || got == rev0 {
+		t.Fatalf("valid update should return a new revision, got %q (was %q)", got, rev0)
+	}
+}

--- a/services/sfn/driver/errors.go
+++ b/services/sfn/driver/errors.go
@@ -20,6 +20,7 @@ const (
 	ExTooManyTags               = "TooManyTags"
 	ExConflict                  = "ConflictException"
 	ExValidation                = "ValidationException"
+	ExMissingRequiredParameter  = "MissingRequiredParameter"
 )
 
 // APIError tags a canonical cloudemu error with the SFN exception name it


### PR DESCRIPTION
## What

Two AWS Step Functions state-machine validation fixes found by the real-user e2e audit (F3, F5). Scoped to CreateStateMachine / UpdateStateMachine request validation — the ASL execution engine is untouched (separately deferred).

### [MED F3] UpdateStateMachine with no updatable field silently succeeded
`UpdateStateMachine` accepted a request carrying neither `definition`, `roleArn`, nor logging/tracing/encryption config, returned HTTP 200, and bumped `revisionId` on a no-op. Real SFN rejects this with `MissingRequiredParameter` ("This error occurs if both definition and roleArn are not specified" — API_UpdateStateMachine).

Fix: reject an update supplying none of the updatable fields with `MissingRequiredParameter`, before any mutation, so the revision is not bumped. A valid update (definition/roleArn/logging/tracing/encryption present) still works and bumps the revision.

### [LOW F5] roleArn not required/validated on CreateStateMachine
`CreateStateMachine` accepted an empty or malformed `roleArn` and stored it. AWS marks `roleArn` required (a valid IAM role ARN). The aws-sdk-go-v2 client-side check is a nil-check, so an explicit empty string reaches the server.

Fix: require a valid IAM role ARN shape (`arn:<partition>:iam::<account>:role/<name>`); empty or malformed → `InvalidArn` (the error real SFN returns for a bad role ARN), validated after name/definition checks so those errors still take precedence.

## Why

Both are real deviations from the AWS Step Functions API verified against the official API reference (API_CreateStateMachine, API_UpdateStateMachine) with a real aws-sdk-go-v2 sfn client. Errors surface as their own exception types via the existing `driver.APIError` wire mapping (new `MissingRequiredParameter` exception constant added).

## Tests

- Server (real aws-sdk-go-v2): empty/malformed roleArn → `InvalidArn`, valid → create; empty update → `MissingRequiredParameter` with unchanged `revisionId`, definition update → new `revisionId`.
- Provider: direct-driver equivalents asserting the exact SFN exception.
- Existing SFN suite (create/idempotency/versions/aliases/error-codes/pagination) green, `-race` clean.

Coverage docs regenerated — no diff (no driver interface change).
