### PR TITLE
fix(aws-efs): derive mount-target VpcId/AZ from subnet; honor Backup + One Zone AZ; FileSystemAlreadyExists carries id; access-point ClientToken idempotency

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -253,6 +253,9 @@ func New(opts ...config.Option) *Provider {
 	p.EC2.SetSubnetResolver(p.VPC)
 	// A load balancer's VpcId is derived from its subnets, matching ELBv2.
 	p.ELB.SetSubnetResolver(p.VPC)
+	// EFS mount targets derive their VpcId and AZ from the subnet, so all mount
+	// targets of a file system share a VpcId and each reflects its subnet's zone.
+	p.EFS.SetSubnetResolver(p.VPC)
 	// An IamInstanceProfile passed to RunInstances resolves through IAM so the
 	// role->profile->instance chain reads back on DescribeInstances.
 	p.EC2.SetInstanceProfileResolver(p.IAM)

--- a/providers/aws/efs/efs.go
+++ b/providers/aws/efs/efs.go
@@ -38,6 +38,10 @@ type Mock struct {
 	// via SetIfAbsent so concurrent same-token CreateFileSystem calls can't both
 	// create (EFS idempotency).
 	tokenIndex *memstore.Store[string]
+	// apTokenIndex maps a CreateAccessPoint ClientToken to its access-point id,
+	// claimed atomically via SetIfAbsent so a repeated ClientToken returns the
+	// existing access point rather than creating a duplicate (EFS idempotency).
+	apTokenIndex *memstore.Store[string]
 
 	// accountPref is the account-level resource-id preference ("LONG_ID" |
 	// "SHORT_ID"); empty until PutAccountPreferences is called.
@@ -55,11 +59,12 @@ type Mock struct {
 // New creates a new EFS mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		fileSystems: memstore.New[*fsData](),
-		mtIndex:     memstore.New[string](),
-		apIndex:     memstore.New[string](),
-		tokenIndex:  memstore.New[string](),
-		opts:        opts,
+		fileSystems:  memstore.New[*fsData](),
+		mtIndex:      memstore.New[string](),
+		apIndex:      memstore.New[string](),
+		tokenIndex:   memstore.New[string](),
+		apTokenIndex: memstore.New[string](),
+		opts:         opts,
 	}
 }
 

--- a/providers/aws/efs/efs.go
+++ b/providers/aws/efs/efs.go
@@ -44,6 +44,11 @@ type Mock struct {
 	accountPref string
 	prefMu      sync.RWMutex
 
+	// subnetResolver derives a mount target's VpcId and AZ from its subnet. Real
+	// EFS infers both from the subnet; without a resolver a deterministic
+	// per-file-system fallback is used instead of a random per-call VpcId.
+	subnetResolver SubnetResolver
+
 	opts *config.Options
 }
 

--- a/providers/aws/efs/efs_test.go
+++ b/providers/aws/efs/efs_test.go
@@ -2,6 +2,7 @@ package efs_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -83,5 +84,71 @@ func TestDefaultsAndPolicy(t *testing.T) {
 
 	if _, err := m.DescribeFileSystemPolicy(ctx, fs.FileSystemID); !errors.IsNotFound(err) {
 		t.Fatalf("policy after delete should be NotFound, got %v", err)
+	}
+}
+
+// TestCreateAccessPointClientTokenConcurrent stresses the ClientToken
+// idempotency contract under contention: many concurrent CreateAccessPoint calls
+// with the same token on one file system must all return the SAME access point
+// (exactly one created), and a racing loser must never see AccessPointNotFound.
+// Run with `go test -race -count=200 ./providers/aws/efs/...` to catch the TOCTOU
+// window between claiming the token and publishing the access point.
+func TestCreateAccessPointClientTokenConcurrent(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	fs, err := m.CreateFileSystem(ctx, driver.CreateFileSystemInput{CreationToken: "ct-fs"})
+	if err != nil {
+		t.Fatalf("create fs: %v", err)
+	}
+
+	const workers = 40
+
+	var (
+		wg   sync.WaitGroup
+		mu   sync.Mutex
+		ids  = make(map[string]struct{})
+		errs []error
+	)
+
+	wg.Add(workers)
+
+	for range workers {
+		go func() {
+			defer wg.Done()
+
+			ap, apErr := m.CreateAccessPoint(ctx, driver.CreateAccessPointInput{
+				FileSystemID: fs.FileSystemID, ClientToken: "ct-1",
+			})
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			if apErr != nil {
+				errs = append(errs, apErr)
+				return
+			}
+
+			ids[ap.AccessPointID] = struct{}{}
+		}()
+	}
+
+	wg.Wait()
+
+	if len(errs) != 0 {
+		t.Fatalf("racing same-token creates returned %d error(s); first: %v", len(errs), errs[0])
+	}
+
+	if len(ids) != 1 {
+		t.Fatalf("same ClientToken produced %d distinct access-point ids, want 1: %v", len(ids), ids)
+	}
+
+	aps, err := m.DescribeAccessPoints(ctx, fs.FileSystemID, "")
+	if err != nil {
+		t.Fatalf("describe access points: %v", err)
+	}
+
+	if len(aps) != 1 {
+		t.Fatalf("want exactly 1 access point after idempotent races, got %d", len(aps))
 	}
 }

--- a/providers/aws/efs/errors.go
+++ b/providers/aws/efs/errors.go
@@ -16,6 +16,17 @@ func conflict(kind, format string, args ...any) error {
 	return &driver.ResourceError{Kind: kind, Err: errors.Newf(errors.AlreadyExists, format, args...)}
 }
 
+// conflictWithID builds a kind-tagged AlreadyExists error that carries the id of
+// the existing resource, so the wire layer can surface it (e.g. the existing
+// file-system id inside a FileSystemAlreadyExists error for idempotent retries).
+func conflictWithID(kind, resourceID, format string, args ...any) error {
+	return &driver.ResourceError{
+		Kind:       kind,
+		ResourceID: resourceID,
+		Err:        errors.Newf(errors.AlreadyExists, format, args...),
+	}
+}
+
 // inUse builds a kind-tagged FailedPrecondition error.
 func inUse(kind, format string, args ...any) error {
 	return &driver.ResourceError{Kind: kind, Err: errors.Newf(errors.FailedPrecondition, format, args...)}

--- a/providers/aws/efs/file_systems.go
+++ b/providers/aws/efs/file_systems.go
@@ -41,9 +41,12 @@ func (m *Mock) CreateFileSystem(_ context.Context, in driver.CreateFileSystemInp
 	id := "fs-" + idgen.GenerateID("")
 
 	// Atomically claim the creation token. If another call already owns it, this
-	// is a duplicate — reject without creating.
+	// is a duplicate — reject without creating, echoing the existing file
+	// system's id so an idempotent retry can recover it (real EFS behavior).
 	if !m.tokenIndex.SetIfAbsent(in.CreationToken, id) {
-		return nil, conflict(driver.KindFileSystem,
+		existingID, _ := m.tokenIndex.Get(in.CreationToken)
+
+		return nil, conflictWithID(driver.KindFileSystem, existingID,
 			"file system with creation token %q already exists", in.CreationToken)
 	}
 

--- a/providers/aws/efs/file_systems.go
+++ b/providers/aws/efs/file_systems.go
@@ -53,14 +53,6 @@ func (m *Mock) CreateFileSystem(_ context.Context, in driver.CreateFileSystemInp
 	now := m.opts.Clock.Now().UTC()
 	name := in.Tags[nameTag]
 
-	// Automatic backups default to DISABLED, honoring the Backup flag. One Zone
-	// file systems (AvailabilityZoneName set) default to ENABLED per real EFS; a
-	// later PutBackupPolicy still overrides.
-	backup := driver.BackupDisabled
-	if in.Backup || in.AvailabilityZoneName != "" {
-		backup = driver.BackupEnabled
-	}
-
 	// An encrypted file system with no explicit key uses the account's
 	// AWS-managed aws/elasticfilesystem CMK.
 	kmsKeyID := in.KMSKeyID
@@ -93,12 +85,23 @@ func (m *Mock) CreateFileSystem(_ context.Context, in driver.CreateFileSystemInp
 		fs:        fs,
 		mountTgts: map[string]*driver.MountTarget{},
 		accessPts: map[string]*driver.AccessPoint{},
-		backup:    backup,
+		backup:    backupOnCreate(in.Backup, in.AvailabilityZoneName),
 	})
 
 	out := fs
 
 	return &out, nil
+}
+
+// backupOnCreate reports the initial automatic-backup status. Backups default to
+// DISABLED, honoring the Backup flag; One Zone file systems (AvailabilityZoneName
+// set) default to ENABLED per real EFS. A later PutBackupPolicy still overrides.
+func backupOnCreate(backup bool, availabilityZoneName string) string {
+	if backup || availabilityZoneName != "" {
+		return driver.BackupEnabled
+	}
+
+	return driver.BackupDisabled
 }
 
 // DeleteFileSystem deletes a file system. It must have no mount targets or

--- a/providers/aws/efs/file_systems.go
+++ b/providers/aws/efs/file_systems.go
@@ -53,6 +53,14 @@ func (m *Mock) CreateFileSystem(_ context.Context, in driver.CreateFileSystemInp
 	now := m.opts.Clock.Now().UTC()
 	name := in.Tags[nameTag]
 
+	// Automatic backups default to DISABLED, honoring the Backup flag. One Zone
+	// file systems (AvailabilityZoneName set) default to ENABLED per real EFS; a
+	// later PutBackupPolicy still overrides.
+	backup := driver.BackupDisabled
+	if in.Backup || in.AvailabilityZoneName != "" {
+		backup = driver.BackupEnabled
+	}
+
 	// An encrypted file system with no explicit key uses the account's
 	// AWS-managed aws/elasticfilesystem CMK.
 	kmsKeyID := in.KMSKeyID
@@ -84,7 +92,7 @@ func (m *Mock) CreateFileSystem(_ context.Context, in driver.CreateFileSystemInp
 		fs:        fs,
 		mountTgts: map[string]*driver.MountTarget{},
 		accessPts: map[string]*driver.AccessPoint{},
-		backup:    driver.BackupDisabled,
+		backup:    backup,
 	})
 
 	out := fs

--- a/providers/aws/efs/file_systems.go
+++ b/providers/aws/efs/file_systems.go
@@ -84,6 +84,7 @@ func (m *Mock) CreateFileSystem(_ context.Context, in driver.CreateFileSystemInp
 		ThroughputMode:               tput,
 		ProvisionedThroughputInMibps: in.ProvisionedThroughputInMibps,
 		AvailabilityZoneName:         in.AvailabilityZoneName,
+		AvailabilityZoneID:           azIDFromName(in.AvailabilityZoneName),
 		Tags:                         copyTags(in.Tags),
 		Protection:                   driver.FileSystemProtection{ReplicationOverwriteProtection: "ENABLED"},
 	}

--- a/providers/aws/efs/mount_targets.go
+++ b/providers/aws/efs/mount_targets.go
@@ -8,10 +8,15 @@ import (
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/services/efs/driver"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
-// CreateMountTarget creates a mount target for a file system in a subnet.
-func (m *Mock) CreateMountTarget(_ context.Context, in driver.CreateMountTargetInput) (*driver.MountTarget, error) {
+// CreateMountTarget creates a mount target for a file system in a subnet. The
+// VpcId and Availability Zone are derived from the subnet (real EFS behavior):
+// all mount targets of one file system share a VpcId, and each reports its
+// subnet's AZ. When the subnet can't be resolved, a deterministic per-file-
+// system VpcId and the region's first AZ are used instead of a random VpcId.
+func (m *Mock) CreateMountTarget(ctx context.Context, in driver.CreateMountTargetInput) (*driver.MountTarget, error) {
 	if in.SubnetID == "" {
 		return nil, errors.New(errors.InvalidArgument, "SubnetId is required")
 	}
@@ -21,16 +26,17 @@ func (m *Mock) CreateMountTarget(_ context.Context, in driver.CreateMountTargetI
 		return nil, notFound(driver.KindFileSystem, "file system %q not found", in.FileSystemID)
 	}
 
+	subnet := m.resolveSubnet(ctx, in.SubnetID)
+	vpcID, azName, azIdent := m.mountTargetPlacement(fd.fs.FileSystemID, subnet)
+
 	fd.mu.Lock()
 	defer fd.mu.Unlock()
 
-	// EFS allows one mount target per Availability Zone. The emulator models a
-	// subnet as its own AZ, so reject a second mount target in the same subnet.
-	for _, mt := range fd.mountTgts {
-		if mt.SubnetID == in.SubnetID {
-			return nil, conflict(driver.KindMountTarget,
-				"mount target already exists in subnet %q", in.SubnetID)
-		}
+	// EFS allows one mount target per Availability Zone. When the subnet's AZ is
+	// known, enforce that (two subnets in one AZ conflict); otherwise fall back to
+	// one per subnet.
+	if err := m.checkMountTargetConflict(fd, in.SubnetID, azName, subnet != nil); err != nil {
+		return nil, err
 	}
 
 	id := "fsmt-" + idgen.GenerateID("")
@@ -44,9 +50,9 @@ func (m *Mock) CreateMountTarget(_ context.Context, in driver.CreateMountTargetI
 		LifeCycleState:       driver.StateAvailable,
 		IPAddress:            ipAddressOrDefault(in.IPAddress),
 		NetworkInterfaceID:   eni,
-		AvailabilityZoneID:   azID(m.opts.Region),
-		AvailabilityZoneName: m.opts.Region + "a",
-		VPCID:                "vpc-" + idgen.GenerateID(""),
+		AvailabilityZoneID:   azIdent,
+		AvailabilityZoneName: azName,
+		VPCID:                vpcID,
 		SecurityGroups:       append([]string(nil), in.SecurityGroups...),
 	}
 
@@ -58,6 +64,55 @@ func (m *Mock) CreateMountTarget(_ context.Context, in driver.CreateMountTargetI
 	out := *mt
 
 	return &out, nil
+}
+
+// mountTargetPlacement resolves the VpcId and Availability Zone for a mount
+// target. A resolved subnet supplies the real VPC and AZ; otherwise the VpcId is
+// a deterministic value tied to the file system (so every mount target of one
+// file system shares it) and the AZ defaults to the region's first zone.
+func (m *Mock) mountTargetPlacement(
+	fileSystemID string, subnet *netdriver.SubnetInfo,
+) (vpcID, azName, azIdent string) {
+	azName = m.opts.Region + "a"
+	azIdent = azID(m.opts.Region)
+
+	if subnet != nil {
+		vpcID = subnet.VPCID
+
+		if subnet.AvailabilityZone != "" {
+			azName = subnet.AvailabilityZone
+			azIdent = azIDFromName(subnet.AvailabilityZone)
+		}
+	}
+
+	if vpcID == "" {
+		vpcID = "vpc-" + strings.TrimPrefix(fileSystemID, "fs-")
+	}
+
+	return vpcID, azName, azIdent
+}
+
+// checkMountTargetConflict enforces EFS's one-mount-target-per-AZ rule. When the
+// subnet's AZ is known, two mount targets in the same AZ conflict; otherwise the
+// check falls back to one mount target per subnet. Callers hold fd.mu.
+func (m *Mock) checkMountTargetConflict(fd *fsData, subnetID, azName string, azKnown bool) error {
+	for _, mt := range fd.mountTgts {
+		if azKnown {
+			if mt.AvailabilityZoneName == azName {
+				return conflict(driver.KindMountTarget,
+					"mount target already exists in availability zone %q", azName)
+			}
+
+			continue
+		}
+
+		if mt.SubnetID == subnetID {
+			return conflict(driver.KindMountTarget,
+				"mount target already exists in subnet %q", subnetID)
+		}
+	}
+
+	return nil
 }
 
 // regionShortCode builds an AWS-style region short code (e.g. us-east-1 → use1,

--- a/providers/aws/efs/mount_targets.go
+++ b/providers/aws/efs/mount_targets.go
@@ -35,7 +35,7 @@ func (m *Mock) CreateMountTarget(ctx context.Context, in driver.CreateMountTarge
 	// EFS allows one mount target per Availability Zone. When the subnet's AZ is
 	// known, enforce that (two subnets in one AZ conflict); otherwise fall back to
 	// one per subnet.
-	if err := m.checkMountTargetConflict(fd, in.SubnetID, azName, subnet != nil); err != nil {
+	if err := checkMountTargetConflict(fd, in.SubnetID, azName, subnet != nil); err != nil {
 		return nil, err
 	}
 
@@ -95,7 +95,7 @@ func (m *Mock) mountTargetPlacement(
 // checkMountTargetConflict enforces EFS's one-mount-target-per-AZ rule. When the
 // subnet's AZ is known, two mount targets in the same AZ conflict; otherwise the
 // check falls back to one mount target per subnet. Callers hold fd.mu.
-func (m *Mock) checkMountTargetConflict(fd *fsData, subnetID, azName string, azKnown bool) error {
+func checkMountTargetConflict(fd *fsData, subnetID, azName string, azKnown bool) error {
 	for _, mt := range fd.mountTgts {
 		if azKnown {
 			if mt.AvailabilityZoneName == azName {
@@ -333,6 +333,7 @@ func (m *Mock) CreateAccessPoint(_ context.Context, in driver.CreateAccessPointI
 	if name == "" {
 		name = in.Tags[nameTag]
 	}
+
 	ap := &driver.AccessPoint{
 		ClientToken:    in.ClientToken,
 		Name:           name,

--- a/providers/aws/efs/mount_targets.go
+++ b/providers/aws/efs/mount_targets.go
@@ -316,6 +316,16 @@ func (m *Mock) CreateAccessPoint(_ context.Context, in driver.CreateAccessPointI
 		return nil, notFound(driver.KindFileSystem, "file system %q not found", in.FileSystemID)
 	}
 
+	id := "fsap-" + idgen.GenerateID("")
+
+	// ClientToken idempotency: atomically claim the token. A repeat returns the
+	// existing access point rather than creating a duplicate (real EFS behavior).
+	if in.ClientToken != "" && !m.apTokenIndex.SetIfAbsent(in.ClientToken, id) {
+		existingID, _ := m.apTokenIndex.Get(in.ClientToken)
+
+		return m.accessPointByID(existingID)
+	}
+
 	fd.mu.Lock()
 	defer fd.mu.Unlock()
 
@@ -323,8 +333,6 @@ func (m *Mock) CreateAccessPoint(_ context.Context, in driver.CreateAccessPointI
 	if name == "" {
 		name = in.Tags[nameTag]
 	}
-
-	id := "fsap-" + idgen.GenerateID("")
 	ap := &driver.AccessPoint{
 		ClientToken:    in.ClientToken,
 		Name:           name,
@@ -340,6 +348,32 @@ func (m *Mock) CreateAccessPoint(_ context.Context, in driver.CreateAccessPointI
 
 	fd.accessPts[id] = ap
 	m.apIndex.Set(id, fd.fs.FileSystemID)
+
+	out := *ap
+
+	return &out, nil
+}
+
+// accessPointByID returns a copy of an access point by id, used to satisfy an
+// idempotent CreateAccessPoint retry from the existing access point.
+func (m *Mock) accessPointByID(accessPointID string) (*driver.AccessPoint, error) {
+	fsID, ok := m.apIndex.Get(accessPointID)
+	if !ok {
+		return nil, notFound(driver.KindAccessPoint, "access point %q not found", accessPointID)
+	}
+
+	fd, ok := m.getFS(fsID)
+	if !ok {
+		return nil, notFound(driver.KindAccessPoint, "access point %q not found", accessPointID)
+	}
+
+	fd.mu.RLock()
+	defer fd.mu.RUnlock()
+
+	ap, ok := fd.accessPts[accessPointID]
+	if !ok {
+		return nil, notFound(driver.KindAccessPoint, "access point %q not found", accessPointID)
+	}
 
 	out := *ap
 
@@ -395,6 +429,10 @@ func (m *Mock) DeleteAccessPoint(_ context.Context, accessPointID string) error 
 
 	fd.mu.Lock()
 	defer fd.mu.Unlock()
+
+	if ap := fd.accessPts[accessPointID]; ap != nil && ap.ClientToken != "" {
+		m.apTokenIndex.Delete(ap.ClientToken)
+	}
 
 	delete(fd.accessPts, accessPointID)
 	m.apIndex.Delete(accessPointID)

--- a/providers/aws/efs/mount_targets.go
+++ b/providers/aws/efs/mount_targets.go
@@ -2,6 +2,7 @@ package efs
 
 import (
 	"context"
+	"strconv"
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/errors"
@@ -59,12 +60,12 @@ func (m *Mock) CreateMountTarget(_ context.Context, in driver.CreateMountTargetI
 	return &out, nil
 }
 
-// azID builds an AWS-style AZ id (e.g. "use1-az1") from a region. AWS's real
-// AZ-id short codes are hand-maintained abbreviations; this approximates them by
-// keeping the first region token whole and abbreviating the rest to their first
-// letter (us-east-1 → use1, eu-west-1 → euw1), which is exact for the common
-// single-word regions.
-func azID(region string) string {
+// regionShortCode builds an AWS-style region short code (e.g. us-east-1 → use1,
+// eu-west-1 → euw1) used as the prefix of an AZ id. AWS's real short codes are
+// hand-maintained abbreviations; this approximates them by keeping the first
+// region token whole and abbreviating the rest to their first letter, which is
+// exact for the common single-word regions.
+func regionShortCode(region string) string {
 	short := ""
 
 	for i, part := range strings.Split(region, "-") {
@@ -80,7 +81,33 @@ func azID(region string) string {
 		}
 	}
 
-	return short + "-az1"
+	return short
+}
+
+// azID builds an AWS-style AZ id (e.g. "use1-az1") from a region, defaulting to
+// the first AZ. Callers that know the AZ name should use azIDFromName instead.
+func azID(region string) string {
+	return regionShortCode(region) + "-az1"
+}
+
+// azIDFromName maps an AZ name (e.g. "us-west-2b") to its consistent AZ id
+// ("usew2-az2") the way real EFS reports it: the region short code, then "-az"
+// plus the zone-letter's ordinal (a→1, b→2, …). A name without a trailing
+// letter falls back to az1.
+func azIDFromName(azName string) string {
+	if azName == "" {
+		return ""
+	}
+
+	last := azName[len(azName)-1]
+	if last < 'a' || last > 'z' {
+		return regionShortCode(azName) + "-az1"
+	}
+
+	region := azName[:len(azName)-1]
+	ordinal := int(last-'a') + 1
+
+	return regionShortCode(region) + "-az" + strconv.Itoa(ordinal)
 }
 
 func ipAddressOrDefault(ip string) string {

--- a/providers/aws/efs/mount_targets.go
+++ b/providers/aws/efs/mount_targets.go
@@ -316,24 +316,19 @@ func (m *Mock) CreateAccessPoint(_ context.Context, in driver.CreateAccessPointI
 		return nil, notFound(driver.KindFileSystem, "file system %q not found", in.FileSystemID)
 	}
 
-	id := "fsap-" + idgen.GenerateID("")
-
-	// ClientToken idempotency: atomically claim the token. A repeat returns the
-	// existing access point rather than creating a duplicate (real EFS behavior).
-	if in.ClientToken != "" && !m.apTokenIndex.SetIfAbsent(in.ClientToken, id) {
-		existingID, _ := m.apTokenIndex.Get(in.ClientToken)
-
-		return m.accessPointByID(existingID)
-	}
-
-	fd.mu.Lock()
-	defer fd.mu.Unlock()
-
 	name := in.Name
 	if name == "" {
 		name = in.Tags[nameTag]
 	}
 
+	id := "fsap-" + idgen.GenerateID("")
+
+	// Store the access point and publish it via apIndex BEFORE claiming the
+	// ClientToken, so a racing same-token loser can always resolve the winner's
+	// access point by id — there is no lookup-before-store window (the F1
+	// file-system path is safe the same way: its loser recovers by id, not by
+	// object lookup).
+	fd.mu.Lock()
 	ap := &driver.AccessPoint{
 		ClientToken:    in.ClientToken,
 		Name:           name,
@@ -346,11 +341,25 @@ func (m *Mock) CreateAccessPoint(_ context.Context, in driver.CreateAccessPointI
 		RootDirectory:  rootDirOrDefault(in.RootDirectory),
 		Tags:           copyTags(in.Tags),
 	}
-
 	fd.accessPts[id] = ap
-	m.apIndex.Set(id, fd.fs.FileSystemID)
-
 	out := *ap
+	fd.mu.Unlock()
+
+	m.apIndex.Set(id, in.FileSystemID)
+
+	// ClientToken idempotency: claim the token. If another same-token call won the
+	// race, roll back this just-created access point and return the existing one —
+	// never a duplicate, never AccessPointNotFound.
+	if in.ClientToken != "" && !m.apTokenIndex.SetIfAbsent(in.ClientToken, id) {
+		fd.mu.Lock()
+		delete(fd.accessPts, id)
+		fd.mu.Unlock()
+		m.apIndex.Delete(id)
+
+		existingID, _ := m.apTokenIndex.Get(in.ClientToken)
+
+		return m.accessPointByID(existingID)
+	}
 
 	return &out, nil
 }

--- a/providers/aws/efs/subnet_resolver.go
+++ b/providers/aws/efs/subnet_resolver.go
@@ -1,0 +1,37 @@
+package efs
+
+import (
+	"context"
+
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// SubnetResolver is the slice of the networking mock EFS needs to derive a mount
+// target's VPC and Availability Zone from its subnet. Real EFS infers both from
+// the subnet rather than taking them as input, so mount targets of one file
+// system always report the same VpcId and each reports its subnet's AZ.
+type SubnetResolver interface {
+	DescribeSubnets(ctx context.Context, ids []string) ([]netdriver.SubnetInfo, error)
+}
+
+// SetSubnetResolver wires the networking mock in. Without it a mount target
+// still resolves a deterministic per-file-system VpcId and the region's first
+// AZ, but it can't reflect the subnet's real VPC or zone.
+func (m *Mock) SetSubnetResolver(r SubnetResolver) {
+	m.subnetResolver = r
+}
+
+// resolveSubnet returns the subnet's info, or nil when no resolver is wired or
+// the subnet cannot be resolved (unknown id, resolver error).
+func (m *Mock) resolveSubnet(ctx context.Context, subnetID string) *netdriver.SubnetInfo {
+	if m.subnetResolver == nil || subnetID == "" {
+		return nil
+	}
+
+	subnets, err := m.subnetResolver.DescribeSubnets(ctx, []string{subnetID})
+	if err != nil || len(subnets) == 0 {
+		return nil
+	}
+
+	return &subnets[0]
+}

--- a/server/aws/efs/errors.go
+++ b/server/aws/efs/errors.go
@@ -16,20 +16,29 @@ const (
 
 // errorBody is the restJson1 error body. The SDK reads the X-Amzn-Errortype
 // header to select a typed exception, falling back to the body's __type.
+// FileSystemId is set on a FileSystemAlreadyExists error so the SDK exception's
+// FileSystemId member is populated for idempotent CreateFileSystem retries.
 type errorBody struct {
-	Type      string `json:"__type"`
-	ErrorCode string `json:"ErrorCode"`
-	Message   string `json:"Message"`
+	Type         string `json:"__type"`
+	ErrorCode    string `json:"ErrorCode"`
+	Message      string `json:"Message"`
+	FileSystemID string `json:"FileSystemId,omitempty"`
 }
 
 // writeError writes a restJson1 error response. EFS error bodies carry both
 // ErrorCode and Message; the header selects the typed exception.
 func writeError(w http.ResponseWriter, status int, errType, msg string) {
+	writeErrorBody(w, status, errType, errorBody{Type: errType, ErrorCode: errType, Message: msg})
+}
+
+// writeErrorBody writes a restJson1 error response from a fully-built body,
+// letting callers attach extra members (e.g. FileSystemId).
+func writeErrorBody(w http.ResponseWriter, status int, errType string, body errorBody) {
 	w.Header().Set("Content-Type", contentTypeJSON)
 	w.Header().Set("X-Amzn-Errortype", errType)
 	w.WriteHeader(status)
 
-	_ = json.NewEncoder(w).Encode(errorBody{Type: errType, ErrorCode: errType, Message: msg})
+	_ = json.NewEncoder(w).Encode(body)
 }
 
 // exceptionFor returns the EFS X-Amzn-Errortype for a resource kind + canonical
@@ -74,14 +83,22 @@ func exceptionFor(kind string, err error) (status int, errType string) {
 // the resource kind carried by driver.ResourceError when present.
 func writeErr(w http.ResponseWriter, err error) {
 	kind := ""
+	resourceID := ""
 
 	var re *driver.ResourceError
 	if errors.As(err, &re) {
 		kind = re.Kind
+		resourceID = re.ResourceID
 	}
 
 	status, errType := exceptionFor(kind, err)
-	writeError(w, status, errType, err.Error())
+
+	body := errorBody{Type: errType, ErrorCode: errType, Message: err.Error()}
+	if kind == driver.KindFileSystem {
+		body.FileSystemID = resourceID
+	}
+
+	writeErrorBody(w, status, errType, body)
 }
 
 func notFound(w http.ResponseWriter, path string) {

--- a/server/aws/efs/mount_target_placement_sdk_test.go
+++ b/server/aws/efs/mount_target_placement_sdk_test.go
@@ -1,0 +1,94 @@
+package efs_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsefs "github.com/aws/aws-sdk-go-v2/service/efs"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// TestSDKMountTargetPlacementFromSubnet verifies that mount targets of one file
+// system, placed in different subnets of the same VPC, all report that VPC's id
+// and each reflects its subnet's Availability Zone (real EFS behavior).
+func TestSDKMountTargetPlacementFromSubnet(t *testing.T) {
+	ctx := context.Background()
+
+	cloud := cloudemu.NewAWS()
+
+	vpcInfo, err := cloud.VPC.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	if err != nil {
+		t.Fatalf("CreateVPC: %v", err)
+	}
+
+	subnetA, err := cloud.VPC.CreateSubnet(ctx, netdriver.SubnetConfig{
+		VPCID: vpcInfo.ID, CIDRBlock: "10.0.1.0/24", AvailabilityZone: "us-east-1a",
+	})
+	if err != nil {
+		t.Fatalf("CreateSubnet A: %v", err)
+	}
+
+	subnetB, err := cloud.VPC.CreateSubnet(ctx, netdriver.SubnetConfig{
+		VPCID: vpcInfo.ID, CIDRBlock: "10.0.2.0/24", AvailabilityZone: "us-east-1b",
+	})
+	if err != nil {
+		t.Fatalf("CreateSubnet B: %v", err)
+	}
+
+	srv := awsserver.New(awsserver.Drivers{EFS: cloud.EFS})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	c := awsefs.NewFromConfig(cfg, func(o *awsefs.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+
+	fs, err := c.CreateFileSystem(ctx, &awsefs.CreateFileSystemInput{CreationToken: aws.String("mt-vpc")})
+	if err != nil {
+		t.Fatalf("CreateFileSystem: %v", err)
+	}
+
+	mtA, err := c.CreateMountTarget(ctx, &awsefs.CreateMountTargetInput{
+		FileSystemId: fs.FileSystemId, SubnetId: aws.String(subnetA.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateMountTarget A: %v", err)
+	}
+
+	mtB, err := c.CreateMountTarget(ctx, &awsefs.CreateMountTargetInput{
+		FileSystemId: fs.FileSystemId, SubnetId: aws.String(subnetB.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateMountTarget B: %v", err)
+	}
+
+	// Both mount targets live in the same VPC.
+	if aws.ToString(mtA.VpcId) != vpcInfo.ID || aws.ToString(mtB.VpcId) != vpcInfo.ID {
+		t.Fatalf("VpcId mismatch: A=%q B=%q, want both %q",
+			aws.ToString(mtA.VpcId), aws.ToString(mtB.VpcId), vpcInfo.ID)
+	}
+
+	// Each mount target reflects its subnet's Availability Zone.
+	if aws.ToString(mtA.AvailabilityZoneName) != "us-east-1a" || aws.ToString(mtA.AvailabilityZoneId) != "use1-az1" {
+		t.Fatalf("mtA AZ = %q/%q, want us-east-1a/use1-az1",
+			aws.ToString(mtA.AvailabilityZoneName), aws.ToString(mtA.AvailabilityZoneId))
+	}
+
+	if aws.ToString(mtB.AvailabilityZoneName) != "us-east-1b" || aws.ToString(mtB.AvailabilityZoneId) != "use1-az2" {
+		t.Fatalf("mtB AZ = %q/%q, want us-east-1b/use1-az2",
+			aws.ToString(mtB.AvailabilityZoneName), aws.ToString(mtB.AvailabilityZoneId))
+	}
+}

--- a/server/aws/efs/mount_targets_sdk_test.go
+++ b/server/aws/efs/mount_targets_sdk_test.go
@@ -144,3 +144,42 @@ func TestSDKAccessPoints(t *testing.T) {
 		t.Fatalf("DeleteAccessPoint: %v", err)
 	}
 }
+
+// TestSDKAccessPointClientTokenIdempotency verifies that two CreateAccessPoint
+// calls with the same ClientToken on one file system return the same access
+// point rather than creating duplicates.
+func TestSDKAccessPointClientTokenIdempotency(t *testing.T) {
+	ctx := context.Background()
+	c := newEFSClient(t)
+
+	fs, _ := c.CreateFileSystem(ctx, &awsefs.CreateFileSystemInput{CreationToken: aws.String("ap-idem")})
+
+	in := &awsefs.CreateAccessPointInput{
+		FileSystemId: fs.FileSystemId,
+		ClientToken:  aws.String("ct-1"),
+	}
+
+	first, err := c.CreateAccessPoint(ctx, in)
+	if err != nil {
+		t.Fatalf("first CreateAccessPoint: %v", err)
+	}
+
+	second, err := c.CreateAccessPoint(ctx, in)
+	if err != nil {
+		t.Fatalf("second CreateAccessPoint: %v", err)
+	}
+
+	if aws.ToString(first.AccessPointId) != aws.ToString(second.AccessPointId) {
+		t.Fatalf("idempotent ClientToken produced distinct ids: %q vs %q",
+			aws.ToString(first.AccessPointId), aws.ToString(second.AccessPointId))
+	}
+
+	aps, err := c.DescribeAccessPoints(ctx, &awsefs.DescribeAccessPointsInput{FileSystemId: fs.FileSystemId})
+	if err != nil {
+		t.Fatalf("DescribeAccessPoints: %v", err)
+	}
+
+	if len(aps.AccessPoints) != 1 {
+		t.Fatalf("want 1 access point after idempotent retry, got %d", len(aps.AccessPoints))
+	}
+}

--- a/server/aws/efs/sdk_roundtrip_test.go
+++ b/server/aws/efs/sdk_roundtrip_test.go
@@ -435,3 +435,35 @@ func TestSDKDuplicateTokenCarriesFileSystemId(t *testing.T) {
 			aws.ToString(already.FileSystemId), aws.ToString(first.FileSystemId))
 	}
 }
+
+// TestSDKOneZoneAvailabilityZoneId verifies a One Zone file system reports a
+// consistent AvailabilityZoneId derived from the AvailabilityZoneName.
+func TestSDKOneZoneAvailabilityZoneId(t *testing.T) {
+	ctx := context.Background()
+	c := newEFSClient(t)
+
+	fs, err := c.CreateFileSystem(ctx, &awsefs.CreateFileSystemInput{
+		CreationToken: aws.String("oz-1"), AvailabilityZoneName: aws.String("us-east-1b"),
+	})
+	if err != nil {
+		t.Fatalf("CreateFileSystem(One Zone): %v", err)
+	}
+
+	if aws.ToString(fs.AvailabilityZoneName) != "us-east-1b" {
+		t.Fatalf("AvailabilityZoneName = %q, want us-east-1b", aws.ToString(fs.AvailabilityZoneName))
+	}
+
+	if aws.ToString(fs.AvailabilityZoneId) != "use1-az2" {
+		t.Fatalf("AvailabilityZoneId = %q, want use1-az2", aws.ToString(fs.AvailabilityZoneId))
+	}
+
+	desc, err := c.DescribeFileSystems(ctx, &awsefs.DescribeFileSystemsInput{FileSystemId: fs.FileSystemId})
+	if err != nil || len(desc.FileSystems) != 1 {
+		t.Fatalf("DescribeFileSystems = %d, %v", len(desc.FileSystems), err)
+	}
+
+	if aws.ToString(desc.FileSystems[0].AvailabilityZoneId) != "use1-az2" {
+		t.Fatalf("Describe AvailabilityZoneId = %q, want use1-az2",
+			aws.ToString(desc.FileSystems[0].AvailabilityZoneId))
+	}
+}

--- a/server/aws/efs/sdk_roundtrip_test.go
+++ b/server/aws/efs/sdk_roundtrip_test.go
@@ -407,3 +407,31 @@ func TestSDKDescribeMountTargetsByID(t *testing.T) {
 		t.Fatalf("describe by AP id: want 1 mount target, got %d", len(byAP.MountTargets))
 	}
 }
+
+// TestSDKDuplicateTokenCarriesFileSystemId verifies a duplicate CreationToken is
+// rejected with a FileSystemAlreadyExists error that carries the existing file
+// system's id, so an idempotent CreateFileSystem retry can recover it.
+func TestSDKDuplicateTokenCarriesFileSystemId(t *testing.T) {
+	ctx := context.Background()
+	c := newEFSClient(t)
+
+	first, err := c.CreateFileSystem(ctx, &awsefs.CreateFileSystemInput{CreationToken: aws.String("idem-token")})
+	if err != nil {
+		t.Fatalf("first CreateFileSystem: %v", err)
+	}
+
+	_, err = c.CreateFileSystem(ctx, &awsefs.CreateFileSystemInput{CreationToken: aws.String("idem-token")})
+	if err == nil {
+		t.Fatal("duplicate token: want FileSystemAlreadyExists, got nil")
+	}
+
+	var already *efstypes.FileSystemAlreadyExists
+	if !errors.As(err, &already) {
+		t.Fatalf("want FileSystemAlreadyExists, got %T: %v", err, err)
+	}
+
+	if aws.ToString(already.FileSystemId) != aws.ToString(first.FileSystemId) {
+		t.Fatalf("FileSystemAlreadyExists.FileSystemId = %q, want %q",
+			aws.ToString(already.FileSystemId), aws.ToString(first.FileSystemId))
+	}
+}

--- a/services/efs/driver/errors.go
+++ b/services/efs/driver/errors.go
@@ -15,9 +15,15 @@ const (
 // concerns, so the server can emit the right X-Amzn-Errortype (e.g.
 // MountTargetNotFound vs FileSystemNotFound) while GetCode still resolves the
 // HTTP status through Unwrap.
+//
+// ResourceID optionally carries the id of the conflicting resource. Real EFS
+// returns the existing file system's id inside a FileSystemAlreadyExists error
+// so an idempotent CreateFileSystem retry (same CreationToken) can recover it;
+// the wire layer surfaces it as the exception's FileSystemId member.
 type ResourceError struct {
-	Kind string
-	Err  error
+	Kind       string
+	ResourceID string
+	Err        error
 }
 
 func (e *ResourceError) Error() string { return e.Err.Error() }


### PR DESCRIPTION
## Summary

Five real AWS EFS bugs found by a deep end-to-end audit (real `aws-sdk-go-v2/service/efs` client over the wire), each fixed at the correct 3-layer location and verified against the official EFS API docs.

### Fixes (one commit each)

- **FileSystemAlreadyExists carries the existing FileSystemId** — a duplicate `CreationToken` now returns a `FileSystemAlreadyExists` error that includes the existing file system's id, so an idempotent retry can recover it (the whole point of the idempotency contract). Driver `ResourceError` grew an optional `ResourceID`; the restJson1 error body emits `FileSystemId`.
- **Honor `CreateFileSystem` Backup + One Zone default** — the `Backup` flag was ignored, leaving every file system's backup policy DISABLED. `Backup=true` now enables it, and One Zone file systems (AvailabilityZoneName set) default to ENABLED per real EFS. `PutBackupPolicy` still overrides.
- **Set AvailabilityZoneId on One Zone file systems** — a One Zone file system now reports the consistent `AvailabilityZoneId` (e.g. `us-east-1b` → `use1-az2`) derived from the zone name; DescribeFileSystems emits it.
- **Derive mount-target VpcId and AZ from the subnet** — `CreateMountTarget` fabricated a fresh random `VpcId` per call and hardcoded the region's first AZ, so mount targets of one file system reported different VPCs and a constant zone. A `SubnetResolver` (wired to VPC, mirroring RDS/ELB/ElastiCache) now derives the VpcId and AZ from the subnet: all mount targets of a file system share a VpcId and each reflects its subnet's zone, with the one-per-AZ conflict keyed on AZ. When the subnet is unresolvable it falls back to a deterministic per-file-system VpcId instead of a random one.
- **Enforce CreateAccessPoint ClientToken idempotency** — a repeated `ClientToken` created a brand-new access point every call. It now atomically claims the token and a repeat returns the existing access point, mirroring the `CreateFileSystem` CreationToken idempotency.

A final refactor commit extracts small helpers so the fixes stay under the lint complexity/receiver/cuddle rules.

### Tests

Real aws-sdk-go-v2 EFS reproductions added: duplicate-token error carries the id; Backup=true and One Zone default → ENABLED; One Zone AvailabilityZoneId; two mount targets in subnets of one VPC → same VpcId + subnet-matched AZ; two CreateAccessPoint with one ClientToken → one fsap id. Existing EFS tests (CreationToken idempotency, per-subnet MountTargetConflict, NumberOfMountTargets, FileSystemInUse guard, mode round-trip, tags) stay green.

### Gates

`go build ./...`, `go vet`, scoped `go test` (server/providers/services efs), `go test -race` (providers/aws/efs), `golangci-lint` (0 issues), `gofmt` all green. Coverage docs regenerated with no diff (no driver method signatures changed).
