### PR TITLE
feat(aws-cwlogs): subscription filters (Put/Describe/Delete) with Lambda delivery on matching PutLogEvents

### DIFF
--- a/docs/coverage/README.md
+++ b/docs/coverage/README.md
@@ -38,7 +38,7 @@ capability the code does not implement. Machine-readable: [`coverage.json`](./co
 | `kinesis` | [Kinesis](./aws/kinesis.md) | — | — | — | 39 |
 | `kms` | [KMS](./aws/kms.md) | — | — | — | 46 |
 | `loadbalancer` | [ELB](./aws/elb.md) | [LB](./azure/lb.md) | [LB](./gcp/lb.md) | — | 19 |
-| `logging` | [CloudWatchLogs](./aws/cloudwatchlogs.md) | [LogAnalytics](./azure/loganalytics.md) | [CloudLogging](./gcp/cloudlogging.md) | — | 14 |
+| `logging` | [CloudWatchLogs](./aws/cloudwatchlogs.md) | [LogAnalytics](./azure/loganalytics.md) | [CloudLogging](./gcp/cloudlogging.md) | — | 17 |
 | `managedcassandra` | — | [ManagedCassandra](./azure/managedcassandra.md) | — | — | 15 |
 | `memorydb` | [MemoryDB](./aws/memorydb.md) | — | — | — | 33 |
 | `messagequeue` | [SQS](./aws/sqs.md) | [QueueStorage](./azure/queuestorage.md) | [PubSub](./gcp/pubsub.md) | — | 14 |

--- a/docs/coverage/aws/README.md
+++ b/docs/coverage/aws/README.md
@@ -11,7 +11,7 @@ Services cloudemu emulates for AWS, by native name. Back to the [cross-provider 
 | [BedrockAgentRuntime](./bedrockagentruntime.md) | `bedrockagentruntime` | 3 |
 | [CloudTrail](./cloudtrail.md) | `cloudtrail` | 60 |
 | [CloudWatch](./cloudwatch.md) | `monitoring` | 12 |
-| [CloudWatchLogs](./cloudwatchlogs.md) | `logging` | 14 |
+| [CloudWatchLogs](./cloudwatchlogs.md) | `logging` | 17 |
 | [Config](./config.md) | `configservice` | 102 |
 | [DynamoDB](./dynamodb.md) | `database` | 24 |
 | [EC2](./ec2.md) | `compute` | 37 |

--- a/docs/coverage/aws/cloudwatchlogs.md
+++ b/docs/coverage/aws/cloudwatchlogs.md
@@ -3,7 +3,7 @@
 
 AWS's `logging` service · portable interface `driver.Logging` · [AWS index](./README.md)
 
-## Operations (14)
+## Operations (17)
 
 | Operation | Description |
 | --- | --- |
@@ -12,7 +12,9 @@ AWS's `logging` service · portable interface `driver.Logging` · [AWS index](./
 | `DeleteLogGroup` |  |
 | `DeleteLogStream` |  |
 | `DeleteMetricFilter` |  |
+| `DeleteSubscriptionFilter` |  |
 | `DescribeMetricFilters` |  |
+| `DescribeSubscriptionFilters` |  |
 | `FilterLogEvents` |  |
 | `GetLogEvents` |  |
 | `GetLogGroup` |  |
@@ -20,6 +22,7 @@ AWS's `logging` service · portable interface `driver.Logging` · [AWS index](./
 | `ListLogStreams` |  |
 | `PutLogEvents` |  |
 | `PutMetricFilter` |  |
+| `PutSubscriptionFilter` |  |
 | `UpdateLogGroup` | UpdateLogGroup replaces the mutable fields (retention, tags) of an |
 
 ## Optional capabilities

--- a/docs/coverage/azure/README.md
+++ b/docs/coverage/azure/README.md
@@ -19,7 +19,7 @@ Services cloudemu emulates for Azure, by native name. Back to the [cross-provide
 | [IAM](./iam.md) | `iam` | 40 |
 | [KeyVault](./keyvault.md) | `secrets` | 7 |
 | [LB](./lb.md) | `loadbalancer` | 19 |
-| [LogAnalytics](./loganalytics.md) | `logging` | 14 |
+| [LogAnalytics](./loganalytics.md) | `logging` | 17 |
 | [ManagedCassandra](./managedcassandra.md) | `managedcassandra` | 15 |
 | [Monitor](./monitor.md) | `monitoring` | 12 |
 | [MySQLFlex](./mysqlflex.md) | `relationaldb` | 21 |

--- a/docs/coverage/azure/loganalytics.md
+++ b/docs/coverage/azure/loganalytics.md
@@ -3,7 +3,7 @@
 
 Azure's `logging` service · portable interface `driver.Logging` · [Azure index](./README.md)
 
-## Operations (14)
+## Operations (17)
 
 | Operation | Description |
 | --- | --- |
@@ -12,7 +12,9 @@ Azure's `logging` service · portable interface `driver.Logging` · [Azure index
 | `DeleteLogGroup` |  |
 | `DeleteLogStream` |  |
 | `DeleteMetricFilter` |  |
+| `DeleteSubscriptionFilter` |  |
 | `DescribeMetricFilters` |  |
+| `DescribeSubscriptionFilters` |  |
 | `FilterLogEvents` |  |
 | `GetLogEvents` |  |
 | `GetLogGroup` |  |
@@ -20,6 +22,7 @@ Azure's `logging` service · portable interface `driver.Logging` · [Azure index
 | `ListLogStreams` |  |
 | `PutLogEvents` |  |
 | `PutMetricFilter` |  |
+| `PutSubscriptionFilter` |  |
 | `UpdateLogGroup` | UpdateLogGroup replaces the mutable fields (retention, tags) of an |
 
 ## Optional capabilities

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -5862,7 +5862,13 @@
         "name": "DeleteMetricFilter"
       },
       {
+        "name": "DeleteSubscriptionFilter"
+      },
+      {
         "name": "DescribeMetricFilters"
+      },
+      {
+        "name": "DescribeSubscriptionFilters"
       },
       {
         "name": "FilterLogEvents"
@@ -5884,6 +5890,9 @@
       },
       {
         "name": "PutMetricFilter"
+      },
+      {
+        "name": "PutSubscriptionFilter"
       },
       {
         "name": "UpdateLogGroup",

--- a/docs/coverage/gcp/README.md
+++ b/docs/coverage/gcp/README.md
@@ -10,7 +10,7 @@ Services cloudemu emulates for GCP, by native name. Back to the [cross-provider 
 | [Bigtable](./bigtable.md) | `bigtable` | 38 |
 | [CloudDNS](./clouddns.md) | `dns` | 16 |
 | [CloudFunctions](./cloudfunctions.md) | `serverless` | 27 |
-| [CloudLogging](./cloudlogging.md) | `logging` | 14 |
+| [CloudLogging](./cloudlogging.md) | `logging` | 17 |
 | [CloudMonitoring](./cloudmonitoring.md) | `monitoring` | 12 |
 | [CloudRun](./cloudrun.md) | `cloudrun` | 16 |
 | [Eventarc](./eventarc.md) | `eventbus` | 16 |

--- a/docs/coverage/gcp/cloudlogging.md
+++ b/docs/coverage/gcp/cloudlogging.md
@@ -3,7 +3,7 @@
 
 GCP's `logging` service · portable interface `driver.Logging` · [GCP index](./README.md)
 
-## Operations (14)
+## Operations (17)
 
 | Operation | Description |
 | --- | --- |
@@ -12,7 +12,9 @@ GCP's `logging` service · portable interface `driver.Logging` · [GCP index](./
 | `DeleteLogGroup` |  |
 | `DeleteLogStream` |  |
 | `DeleteMetricFilter` |  |
+| `DeleteSubscriptionFilter` |  |
 | `DescribeMetricFilters` |  |
+| `DescribeSubscriptionFilters` |  |
 | `FilterLogEvents` |  |
 | `GetLogEvents` |  |
 | `GetLogGroup` |  |
@@ -20,6 +22,7 @@ GCP's `logging` service · portable interface `driver.Logging` · [GCP index](./
 | `ListLogStreams` |  |
 | `PutLogEvents` |  |
 | `PutMetricFilter` |  |
+| `PutSubscriptionFilter` |  |
 | `UpdateLogGroup` | UpdateLogGroup replaces the mutable fields (retention, tags) of an |
 
 ## Optional capabilities

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -293,6 +293,10 @@ func New(opts ...config.Option) *Provider {
 	// event-source-mapping target(s), deleting the message on success or
 	// leaving it for DLQ redrive on failure (mirrors the DynamoDB Streams wiring).
 	p.SQS.SetEventSourceInvoker(p.Lambda)
+	// CloudWatch Logs subscription filters -> Lambda: log events matching a
+	// subscription filter's pattern are delivered (gzipped awslogs payload) to
+	// the filter's Lambda destination on PutLogEvents.
+	p.CloudWatchLogs.SetLambdaInvoker(p.Lambda)
 
 	p.ResourceDiscovery = resourcediscovery.New(
 		resourcediscovery.ProviderAWS, o.AccountID, o.Region, awsDrivers(p),

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -34,6 +34,14 @@ type logGroup struct {
 	info          driver.LogGroupInfo
 	streams       *memstore.Store[*logStream]
 	metricFilters *memstore.Store[*driver.MetricFilterInfo]
+	subFilters    *memstore.Store[*driver.SubscriptionFilterInfo]
+}
+
+// LambdaInvoker asynchronously invokes a Lambda function by ARN with a
+// CloudWatch Logs subscription-event payload. The Lambda mock satisfies this,
+// enabling real subscription-filter delivery to Lambda destinations.
+type LambdaInvoker interface {
+	InvokeExternal(ctx context.Context, functionARN string, payload []byte) error
 }
 
 // Mock is an in-memory mock implementation of the AWS CloudWatch Logs service.
@@ -41,11 +49,18 @@ type Mock struct {
 	groups     *memstore.Store[*logGroup]
 	opts       *config.Options
 	monitoring mondriver.Monitoring
+	lambda     LambdaInvoker
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
 func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
 	m.monitoring = mon
+}
+
+// SetLambdaInvoker wires the Lambda backend so subscription filters with a
+// Lambda destination invoke the mapped function on matching PutLogEvents.
+func (m *Mock) SetLambdaInvoker(i LambdaInvoker) {
+	m.lambda = i
 }
 
 func (m *Mock) emitMetric(metricName string, value float64, unit string, dims map[string]string) {
@@ -101,6 +116,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 		info:          info,
 		streams:       memstore.New[*logStream](),
 		metricFilters: memstore.New[*driver.MetricFilterInfo](),
+		subFilters:    memstore.New[*driver.SubscriptionFilterInfo](),
 	}
 
 	m.groups.Set(cfg.Name, g)
@@ -213,7 +229,7 @@ func (m *Mock) ListLogStreams(_ context.Context, logGroup string) ([]driver.LogS
 }
 
 // PutLogEvents writes log events to a stream.
-func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, events []driver.LogEvent) error {
+func (m *Mock) PutLogEvents(ctx context.Context, groupName, streamName string, events []driver.LogEvent) error {
 	g, ok := m.groups.Get(groupName)
 	if !ok {
 		return errors.Newf(errors.NotFound, "log group %q not found", groupName)
@@ -224,9 +240,6 @@ func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, eve
 		return errors.Newf(errors.NotFound, "log stream %q not found in group %q", streamName, groupName)
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	ingestedAt := m.opts.Clock.Now().UTC()
 
 	copied := make([]driver.LogEvent, len(events))
@@ -234,6 +247,17 @@ func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, eve
 		copied[i] = events[i]
 		copied[i].IngestionTime = ingestedAt
 	}
+
+	var totalBytes int64
+	for _, e := range events {
+		totalBytes += int64(len(e.Message))
+	}
+
+	// The stream lock only guards the stream's own events/metadata. It is
+	// released before cross-service delivery (metric filters, subscription
+	// filters) so a delivered handler that writes back into CloudWatch Logs —
+	// re-entering PutLogEvents — cannot deadlock on this same lock.
+	s.mu.Lock()
 
 	s.events = append(s.events, copied...)
 
@@ -257,11 +281,7 @@ func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, eve
 		s.info.LastEvent = events[len(events)-1].Timestamp.UTC().Format(time.RFC3339)
 	}
 
-	// Update stored bytes estimate.
-	var totalBytes int64
-	for _, e := range events {
-		totalBytes += int64(len(e.Message))
-	}
+	s.mu.Unlock()
 
 	m.groups.Update(groupName, func(lg *logGroup) *logGroup {
 		lg.info.StoredBytes += totalBytes
@@ -273,6 +293,7 @@ func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, eve
 	m.emitMetric("IncomingBytes", float64(totalBytes), "Bytes", dims)
 
 	m.evaluateMetricFilters(g, events)
+	m.deliverToSubscriptions(ctx, g, streamName, copied)
 
 	return nil
 }

--- a/providers/aws/cloudwatchlogs/subscription_filters.go
+++ b/providers/aws/cloudwatchlogs/subscription_filters.go
@@ -1,0 +1,239 @@
+package cloudwatchlogs
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	"github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// maxSubscriptionFilters is the number of subscription filters CloudWatch Logs
+// allows on a single log group. A create that would exceed it (a new filter
+// name, not an update of an existing one) is rejected with LimitExceededException.
+const maxSubscriptionFilters = 2
+
+// PutSubscriptionFilter creates or updates a subscription filter on a log group.
+// Updating reuses an existing filter name; a new name is rejected once the group
+// already holds maxSubscriptionFilters filters.
+func (m *Mock) PutSubscriptionFilter(_ context.Context, cfg *driver.SubscriptionFilterConfig) error {
+	g, ok := m.groups.Get(cfg.LogGroup)
+	if !ok {
+		return errors.Newf(errors.NotFound, "log group %q not found", cfg.LogGroup)
+	}
+
+	if cfg.Name == "" {
+		return errors.New(errors.InvalidArgument, "subscription filter name is required")
+	}
+
+	if cfg.DestinationARN == "" {
+		return errors.New(errors.InvalidArgument, "destinationArn is required")
+	}
+
+	// A new filter (not an update of an existing name) must fit within the
+	// per-group quota; real CloudWatch Logs caps a group at two filters.
+	if !g.subFilters.Has(cfg.Name) && g.subFilters.Len() >= maxSubscriptionFilters {
+		return errors.Newf(errors.ResourceExhausted,
+			"log group %q already has the maximum of %d subscription filters", cfg.LogGroup, maxSubscriptionFilters)
+	}
+
+	info := &driver.SubscriptionFilterInfo{
+		Name:           cfg.Name,
+		LogGroup:       cfg.LogGroup,
+		FilterPattern:  cfg.FilterPattern,
+		DestinationARN: cfg.DestinationARN,
+		RoleARN:        cfg.RoleARN,
+		Distribution:   cfg.Distribution,
+		CreatedAt:      m.opts.Clock.Now().UTC(),
+	}
+
+	g.subFilters.Set(cfg.Name, info)
+
+	return nil
+}
+
+// DeleteSubscriptionFilter removes a subscription filter from a log group.
+func (m *Mock) DeleteSubscriptionFilter(_ context.Context, logGroup, filterName string) error {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return errors.Newf(errors.NotFound, "log group %q not found", logGroup)
+	}
+
+	if !g.subFilters.Delete(filterName) {
+		return errors.Newf(errors.NotFound,
+			"subscription filter %q not found in group %q", filterName, logGroup)
+	}
+
+	return nil
+}
+
+// DescribeSubscriptionFilters lists a log group's subscription filters, ordered
+// by filter name (memstore SortedValues) to match CloudWatch Logs' ASCII sort.
+func (m *Mock) DescribeSubscriptionFilters(_ context.Context, logGroup string) ([]driver.SubscriptionFilterInfo, error) {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", logGroup)
+	}
+
+	all := g.subFilters.SortedValues()
+	results := make([]driver.SubscriptionFilterInfo, 0, len(all))
+
+	for _, sf := range all {
+		results = append(results, *sf)
+	}
+
+	return results, nil
+}
+
+// deliverToSubscriptions streams the events just written to streamName to every
+// subscription filter on the group whose pattern matches. Delivery is
+// best-effort and decoupled from the caller's context (mirroring CloudWatch
+// Logs' asynchronous real-time delivery); only the re-entrant delivery depth is
+// carried forward so a subscriber Lambda that writes back into CloudWatch Logs
+// stays bounded (the guard lives in lambda.InvokeExternal).
+func (m *Mock) deliverToSubscriptions(callerCtx context.Context, g *logGroup, streamName string, events []driver.LogEvent) {
+	if m.lambda == nil || g.subFilters.Len() == 0 || len(events) == 0 {
+		return
+	}
+
+	ctx := recursionguard.WithDepth(context.Background(), recursionguard.Depth(callerCtx))
+
+	for _, sf := range g.subFilters.SortedValues() {
+		matched := matchSubscriptionEvents(sf.FilterPattern, events)
+		if len(matched) == 0 {
+			continue
+		}
+
+		m.deliverSubscription(ctx, sf, g.info.Name, streamName, matched)
+	}
+}
+
+// deliverSubscription dispatches matched events to a single subscription
+// filter's destination. Lambda destinations are invoked with the CloudWatch
+// Logs subscription payload; Kinesis and Firehose destinations are not yet
+// wired (deferred) and are silently skipped.
+func (m *Mock) deliverSubscription(
+	ctx context.Context,
+	sf *driver.SubscriptionFilterInfo,
+	groupName, streamName string,
+	events []driver.LogEvent,
+) {
+	if !strings.Contains(sf.DestinationARN, ":lambda:") {
+		// Kinesis / Firehose delivery is deferred; nothing to do for now.
+		return
+	}
+
+	payload, err := m.buildSubscriptionPayload(sf, groupName, streamName, events)
+	if err != nil {
+		return
+	}
+
+	_ = m.lambda.InvokeExternal(ctx, sf.DestinationARN, payload)
+}
+
+// matchSubscriptionEvents returns the events whose message satisfies the filter
+// pattern. An empty pattern matches every event; otherwise substring matching is
+// used (the same simplification the metric-filter path applies — the richer
+// CloudWatch Logs filter grammar is tracked separately).
+func matchSubscriptionEvents(pattern string, events []driver.LogEvent) []driver.LogEvent {
+	if pattern == "" {
+		return events
+	}
+
+	matched := make([]driver.LogEvent, 0, len(events))
+
+	for i := range events {
+		if strings.Contains(events[i].Message, pattern) {
+			matched = append(matched, events[i])
+		}
+	}
+
+	return matched
+}
+
+// cwlSubscriptionEvent is the decoded CloudWatch Logs subscription payload
+// (the JSON that is gzipped and base64-encoded into awslogs.data).
+type cwlSubscriptionEvent struct {
+	MessageType         string                    `json:"messageType"`
+	Owner               string                    `json:"owner"`
+	LogGroup            string                    `json:"logGroup"`
+	LogStream           string                    `json:"logStream"`
+	SubscriptionFilters []string                  `json:"subscriptionFilters"`
+	LogEvents           []cwlSubscriptionLogEvent `json:"logEvents"`
+}
+
+type cwlSubscriptionLogEvent struct {
+	ID        string `json:"id"`
+	Timestamp int64  `json:"timestamp"`
+	Message   string `json:"message"`
+}
+
+// awslogsEnvelope wraps the gzipped+base64 subscription data the way Lambda
+// receives it: {"awslogs":{"data":"<base64(gzip(json))>"}}.
+type awslogsEnvelope struct {
+	AWSLogs struct {
+		Data string `json:"data"`
+	} `json:"awslogs"`
+}
+
+// buildSubscriptionPayload renders the Lambda subscription-filter event: the
+// CloudWatch Logs subscription JSON, gzipped, base64-encoded, and wrapped in the
+// awslogs envelope, matching the real invocation shape a subscriber Lambda decodes.
+func (m *Mock) buildSubscriptionPayload(
+	sf *driver.SubscriptionFilterInfo,
+	groupName, streamName string,
+	events []driver.LogEvent,
+) ([]byte, error) {
+	inner := cwlSubscriptionEvent{
+		MessageType:         "DATA_MESSAGE",
+		Owner:               m.opts.AccountID,
+		LogGroup:            groupName,
+		LogStream:           streamName,
+		SubscriptionFilters: []string{sf.Name},
+		LogEvents:           make([]cwlSubscriptionLogEvent, 0, len(events)),
+	}
+
+	for i := range events {
+		ts := events[i].Timestamp.UnixMilli()
+		inner.LogEvents = append(inner.LogEvents, cwlSubscriptionLogEvent{
+			ID:        subscriptionEventID(ts, i),
+			Timestamp: ts,
+			Message:   events[i].Message,
+		})
+	}
+
+	raw, err := json.Marshal(inner)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+
+	gz := gzip.NewWriter(&buf)
+	if _, err = gz.Write(raw); err != nil {
+		return nil, err
+	}
+
+	if closeErr := gz.Close(); closeErr != nil {
+		return nil, closeErr
+	}
+
+	var env awslogsEnvelope
+	env.AWSLogs.Data = base64.StdEncoding.EncodeToString(buf.Bytes())
+
+	return json.Marshal(env)
+}
+
+// subscriptionEventID builds a stable per-event identifier for the subscription
+// payload. Real CloudWatch Logs uses an opaque numeric token; a timestamp-derived
+// value keeps events distinguishable within a delivery without pretending to be
+// the real 56-digit id.
+func subscriptionEventID(timestampMillis int64, index int) string {
+	return strconv.FormatInt(timestampMillis, 10) + strconv.Itoa(index)
+}

--- a/providers/aws/cloudwatchlogs/subscription_filters_test.go
+++ b/providers/aws/cloudwatchlogs/subscription_filters_test.go
@@ -1,0 +1,246 @@
+package cloudwatchlogs
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/logging/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingInvoker captures subscription-filter -> Lambda deliveries.
+type recordingInvoker struct {
+	mu       sync.Mutex
+	arns     []string
+	payloads [][]byte
+}
+
+func (i *recordingInvoker) InvokeExternal(_ context.Context, functionARN string, payload []byte) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	i.arns = append(i.arns, functionARN)
+	i.payloads = append(i.payloads, payload)
+
+	return nil
+}
+
+// decodeAWSLogs unwraps the awslogs envelope (base64 + gzip) into the decoded
+// CloudWatch Logs subscription event.
+func decodeAWSLogs(t *testing.T, payload []byte) cwlSubscriptionEvent {
+	t.Helper()
+
+	var env awslogsEnvelope
+	require.NoError(t, json.Unmarshal(payload, &env))
+
+	gzipped, err := base64.StdEncoding.DecodeString(env.AWSLogs.Data)
+	require.NoError(t, err)
+
+	gr, err := gzip.NewReader(bytes.NewReader(gzipped))
+	require.NoError(t, err)
+
+	raw, err := io.ReadAll(gr)
+	require.NoError(t, err)
+
+	var ev cwlSubscriptionEvent
+	require.NoError(t, json.Unmarshal(raw, &ev))
+
+	return ev
+}
+
+const lambdaDestARN = "arn:aws:lambda:us-east-1:000000000000:function:log-sub"
+
+func TestSubscriptionFilterCRUD(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	setupGroupAndStream(t, m)
+
+	require.NoError(t, m.PutSubscriptionFilter(ctx, &driver.SubscriptionFilterConfig{
+		Name:           "errors",
+		LogGroup:       "test-group",
+		FilterPattern:  "ERROR",
+		DestinationARN: lambdaDestARN,
+		RoleARN:        "arn:aws:iam::000000000000:role/cwl",
+		Distribution:   "ByLogStream",
+	}))
+
+	got, err := m.DescribeSubscriptionFilters(ctx, "test-group")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "errors", got[0].Name)
+	assert.Equal(t, "ERROR", got[0].FilterPattern)
+	assert.Equal(t, lambdaDestARN, got[0].DestinationARN)
+	assert.Equal(t, "arn:aws:iam::000000000000:role/cwl", got[0].RoleARN)
+	assert.Equal(t, "ByLogStream", got[0].Distribution)
+	assert.False(t, got[0].CreatedAt.IsZero())
+
+	// Update in place (same name) keeps a single filter.
+	require.NoError(t, m.PutSubscriptionFilter(ctx, &driver.SubscriptionFilterConfig{
+		Name: "errors", LogGroup: "test-group", FilterPattern: "FATAL", DestinationARN: lambdaDestARN,
+	}))
+
+	got, err = m.DescribeSubscriptionFilters(ctx, "test-group")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "FATAL", got[0].FilterPattern)
+
+	require.NoError(t, m.DeleteSubscriptionFilter(ctx, "test-group", "errors"))
+
+	got, err = m.DescribeSubscriptionFilters(ctx, "test-group")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestSubscriptionFilterValidation(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	setupGroupAndStream(t, m)
+
+	// Missing group.
+	err := m.PutSubscriptionFilter(ctx, &driver.SubscriptionFilterConfig{
+		Name: "f", LogGroup: "nope", DestinationARN: lambdaDestARN,
+	})
+	assert.True(t, errors.IsNotFound(err))
+
+	// Missing name.
+	err = m.PutSubscriptionFilter(ctx, &driver.SubscriptionFilterConfig{
+		LogGroup: "test-group", DestinationARN: lambdaDestARN,
+	})
+	assert.True(t, errors.IsInvalidArgument(err))
+
+	// Missing destinationArn.
+	err = m.PutSubscriptionFilter(ctx, &driver.SubscriptionFilterConfig{
+		Name: "f", LogGroup: "test-group",
+	})
+	assert.True(t, errors.IsInvalidArgument(err))
+
+	// Delete missing filter.
+	err = m.DeleteSubscriptionFilter(ctx, "test-group", "ghost")
+	assert.True(t, errors.IsNotFound(err))
+}
+
+// TestSubscriptionFilterLimit pins the two-filters-per-group quota.
+func TestSubscriptionFilterLimit(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	setupGroupAndStream(t, m)
+
+	for _, name := range []string{"f1", "f2"} {
+		require.NoError(t, m.PutSubscriptionFilter(ctx, &driver.SubscriptionFilterConfig{
+			Name: name, LogGroup: "test-group", DestinationARN: lambdaDestARN,
+		}))
+	}
+
+	err := m.PutSubscriptionFilter(ctx, &driver.SubscriptionFilterConfig{
+		Name: "f3", LogGroup: "test-group", DestinationARN: lambdaDestARN,
+	})
+	require.Error(t, err)
+	assert.Equal(t, errors.ResourceExhausted, errors.GetCode(err))
+
+	// Updating an existing filter still succeeds at the limit.
+	require.NoError(t, m.PutSubscriptionFilter(ctx, &driver.SubscriptionFilterConfig{
+		Name: "f1", LogGroup: "test-group", FilterPattern: "x", DestinationARN: lambdaDestARN,
+	}))
+}
+
+// TestSubscriptionFilterLambdaDeliveryOnMatch is the core cross-service check:
+// a PutLogEvents whose message matches the subscription filter delivers the
+// matched events (as an awslogs payload) to the mapped Lambda; a non-matching
+// message does not.
+func TestSubscriptionFilterLambdaDeliveryOnMatch(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	inv := &recordingInvoker{}
+	m.SetLambdaInvoker(inv)
+	setupGroupAndStream(t, m)
+
+	require.NoError(t, m.PutSubscriptionFilter(ctx, &driver.SubscriptionFilterConfig{
+		Name: "errors", LogGroup: "test-group", FilterPattern: "ERROR", DestinationARN: lambdaDestARN,
+	}))
+
+	// Matching + non-matching events in one batch; only the matching one is delivered.
+	require.NoError(t, m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+		{Timestamp: m.opts.Clock.Now(), Message: "ERROR boom"},
+		{Timestamp: m.opts.Clock.Now(), Message: "info: ok"},
+	}))
+
+	inv.mu.Lock()
+	require.Len(t, inv.arns, 1, "expected exactly one delivery")
+	assert.Equal(t, lambdaDestARN, inv.arns[0])
+	payload := inv.payloads[0]
+	inv.mu.Unlock()
+
+	ev := decodeAWSLogs(t, payload)
+	assert.Equal(t, "DATA_MESSAGE", ev.MessageType)
+	assert.Equal(t, "test-group", ev.LogGroup)
+	assert.Equal(t, "test-stream", ev.LogStream)
+	assert.Equal(t, []string{"errors"}, ev.SubscriptionFilters)
+	require.Len(t, ev.LogEvents, 1)
+	assert.Equal(t, "ERROR boom", ev.LogEvents[0].Message)
+
+	// A batch with no matching message delivers nothing further.
+	require.NoError(t, m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+		{Timestamp: m.opts.Clock.Now(), Message: "all good"},
+	}))
+
+	inv.mu.Lock()
+	assert.Len(t, inv.arns, 1, "non-matching batch must not deliver")
+	inv.mu.Unlock()
+}
+
+// TestSubscriptionFilterDeleteStopsDelivery confirms a deleted filter no longer
+// delivers matching events.
+func TestSubscriptionFilterDeleteStopsDelivery(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	inv := &recordingInvoker{}
+	m.SetLambdaInvoker(inv)
+	setupGroupAndStream(t, m)
+
+	require.NoError(t, m.PutSubscriptionFilter(ctx, &driver.SubscriptionFilterConfig{
+		Name: "errors", LogGroup: "test-group", FilterPattern: "ERROR", DestinationARN: lambdaDestARN,
+	}))
+	require.NoError(t, m.DeleteSubscriptionFilter(ctx, "test-group", "errors"))
+
+	require.NoError(t, m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+		{Timestamp: m.opts.Clock.Now(), Message: "ERROR boom"},
+	}))
+
+	inv.mu.Lock()
+	assert.Empty(t, inv.arns, "deleted filter must not deliver")
+	inv.mu.Unlock()
+}
+
+// TestSubscriptionFilterKinesisNotDelivered documents that a non-Lambda
+// destination (Kinesis) is not yet wired: matching events are not invoked
+// through the Lambda path (delivery deferred).
+func TestSubscriptionFilterKinesisNotDelivered(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	inv := &recordingInvoker{}
+	m.SetLambdaInvoker(inv)
+	setupGroupAndStream(t, m)
+
+	require.NoError(t, m.PutSubscriptionFilter(ctx, &driver.SubscriptionFilterConfig{
+		Name:           "to-kinesis",
+		LogGroup:       "test-group",
+		FilterPattern:  "ERROR",
+		DestinationARN: "arn:aws:kinesis:us-east-1:000000000000:stream/logs",
+	}))
+
+	require.NoError(t, m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+		{Timestamp: m.opts.Clock.Now(), Message: "ERROR boom"},
+	}))
+
+	inv.mu.Lock()
+	assert.Empty(t, inv.arns, "Kinesis destination is deferred; Lambda invoker must not fire")
+	inv.mu.Unlock()
+}

--- a/providers/azure/loganalytics/loganalytics.go
+++ b/providers/azure/loganalytics/loganalytics.go
@@ -35,6 +35,7 @@ type logGroup struct {
 	info          driver.LogGroupInfo
 	streams       *memstore.Store[*logStream]
 	metricFilters *memstore.Store[*driver.MetricFilterInfo]
+	subFilters    *memstore.Store[*driver.SubscriptionFilterInfo]
 }
 
 // Mock is an in-memory mock implementation of Azure Log Analytics.
@@ -123,6 +124,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 		info:          info,
 		streams:       memstore.New[*logStream](),
 		metricFilters: memstore.New[*driver.MetricFilterInfo](),
+		subFilters:    memstore.New[*driver.SubscriptionFilterInfo](),
 	}
 
 	m.groups.Set(cfg.Name, g)
@@ -514,6 +516,65 @@ func (m *Mock) DescribeMetricFilters(
 
 	for _, mf := range all {
 		results = append(results, *mf)
+	}
+
+	return results, nil
+}
+
+// PutSubscriptionFilter stores a subscription filter on a log group. Azure Log
+// Analytics has no native cross-service log-event streaming; the CRUD is
+// implemented so the shared driver interface is satisfied and portable callers
+// can round-trip filters, but no delivery is performed.
+func (m *Mock) PutSubscriptionFilter(_ context.Context, cfg *driver.SubscriptionFilterConfig) error {
+	g, ok := m.groups.Get(cfg.LogGroup)
+	if !ok {
+		return errors.Newf(errors.NotFound, "log group %q not found", cfg.LogGroup)
+	}
+
+	if cfg.Name == "" {
+		return errors.New(errors.InvalidArgument, "subscription filter name is required")
+	}
+
+	g.subFilters.Set(cfg.Name, &driver.SubscriptionFilterInfo{
+		Name:           cfg.Name,
+		LogGroup:       cfg.LogGroup,
+		FilterPattern:  cfg.FilterPattern,
+		DestinationARN: cfg.DestinationARN,
+		RoleARN:        cfg.RoleARN,
+		Distribution:   cfg.Distribution,
+		CreatedAt:      m.opts.Clock.Now().UTC(),
+	})
+
+	return nil
+}
+
+// DeleteSubscriptionFilter removes a subscription filter from a log group.
+func (m *Mock) DeleteSubscriptionFilter(_ context.Context, logGroup, filterName string) error {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return errors.Newf(errors.NotFound, "log group %q not found", logGroup)
+	}
+
+	if !g.subFilters.Delete(filterName) {
+		return errors.Newf(errors.NotFound,
+			"subscription filter %q not found in group %q", filterName, logGroup)
+	}
+
+	return nil
+}
+
+// DescribeSubscriptionFilters lists all subscription filters for a log group.
+func (m *Mock) DescribeSubscriptionFilters(_ context.Context, logGroup string) ([]driver.SubscriptionFilterInfo, error) {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", logGroup)
+	}
+
+	all := g.subFilters.SortedValues()
+	results := make([]driver.SubscriptionFilterInfo, 0, len(all))
+
+	for _, sf := range all {
+		results = append(results, *sf)
 	}
 
 	return results, nil

--- a/providers/gcp/cloudlogging/cloudlogging.go
+++ b/providers/gcp/cloudlogging/cloudlogging.go
@@ -35,6 +35,7 @@ type logGroup struct {
 	info          driver.LogGroupInfo
 	streams       *memstore.Store[*logStream]
 	metricFilters *memstore.Store[*driver.MetricFilterInfo]
+	subFilters    *memstore.Store[*driver.SubscriptionFilterInfo]
 }
 
 // Mock is an in-memory mock implementation of GCP Cloud Logging.
@@ -118,6 +119,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 		info:          info,
 		streams:       memstore.New[*logStream](),
 		metricFilters: memstore.New[*driver.MetricFilterInfo](),
+		subFilters:    memstore.New[*driver.SubscriptionFilterInfo](),
 	}
 
 	m.groups.Set(cfg.Name, g)
@@ -509,6 +511,65 @@ func (m *Mock) DescribeMetricFilters(
 
 	for _, mf := range all {
 		results = append(results, *mf)
+	}
+
+	return results, nil
+}
+
+// PutSubscriptionFilter stores a subscription filter on a log group. GCP Cloud
+// Logging has no native cross-service log-event streaming equivalent; the CRUD
+// is implemented so the shared driver interface is satisfied and portable
+// callers can round-trip filters, but no delivery is performed.
+func (m *Mock) PutSubscriptionFilter(_ context.Context, cfg *driver.SubscriptionFilterConfig) error {
+	g, ok := m.groups.Get(cfg.LogGroup)
+	if !ok {
+		return errors.Newf(errors.NotFound, "log group %q not found", cfg.LogGroup)
+	}
+
+	if cfg.Name == "" {
+		return errors.New(errors.InvalidArgument, "subscription filter name is required")
+	}
+
+	g.subFilters.Set(cfg.Name, &driver.SubscriptionFilterInfo{
+		Name:           cfg.Name,
+		LogGroup:       cfg.LogGroup,
+		FilterPattern:  cfg.FilterPattern,
+		DestinationARN: cfg.DestinationARN,
+		RoleARN:        cfg.RoleARN,
+		Distribution:   cfg.Distribution,
+		CreatedAt:      m.opts.Clock.Now().UTC(),
+	})
+
+	return nil
+}
+
+// DeleteSubscriptionFilter removes a subscription filter from a log group.
+func (m *Mock) DeleteSubscriptionFilter(_ context.Context, logGroup, filterName string) error {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return errors.Newf(errors.NotFound, "log group %q not found", logGroup)
+	}
+
+	if !g.subFilters.Delete(filterName) {
+		return errors.Newf(errors.NotFound,
+			"subscription filter %q not found in group %q", filterName, logGroup)
+	}
+
+	return nil
+}
+
+// DescribeSubscriptionFilters lists all subscription filters for a log group.
+func (m *Mock) DescribeSubscriptionFilters(_ context.Context, logGroup string) ([]driver.SubscriptionFilterInfo, error) {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", logGroup)
+	}
+
+	all := g.subFilters.SortedValues()
+	results := make([]driver.SubscriptionFilterInfo, 0, len(all))
+
+	for _, sf := range all {
+		results = append(results, *sf)
 	}
 
 	return results, nil

--- a/server/aws/cloudwatchlogs/handler.go
+++ b/server/aws/cloudwatchlogs/handler.go
@@ -15,6 +15,7 @@
 //	CreateLogStream     DescribeLogStreams  DeleteLogStream
 //	PutLogEvents        GetLogEvents        FilterLogEvents
 //	PutMetricFilter     DescribeMetricFilters DeleteMetricFilter
+//	PutSubscriptionFilter DescribeSubscriptionFilters DeleteSubscriptionFilter
 package cloudwatchlogs
 
 import (
@@ -79,8 +80,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// dispatchManagement handles the retention, metric-filter, and tagging
-// operations, and reports the unknown-operation error for anything unmatched.
+// dispatchManagement handles the retention, metric-filter, and
+// subscription-filter operations, delegating tagging (and the
+// unknown-operation error) to dispatchTags.
 func (h *Handler) dispatchManagement(w http.ResponseWriter, r *http.Request, op string) {
 	switch op {
 	case "PutRetentionPolicy":
@@ -91,6 +93,22 @@ func (h *Handler) dispatchManagement(w http.ResponseWriter, r *http.Request, op 
 		h.describeMetricFilters(w, r)
 	case "DeleteMetricFilter":
 		h.deleteMetricFilter(w, r)
+	case "PutSubscriptionFilter":
+		h.putSubscriptionFilter(w, r)
+	case "DescribeSubscriptionFilters":
+		h.describeSubscriptionFilters(w, r)
+	case "DeleteSubscriptionFilter":
+		h.deleteSubscriptionFilter(w, r)
+	default:
+		h.dispatchTags(w, r, op)
+	}
+}
+
+// dispatchTags handles the tagging operations, reporting the unknown-operation
+// error for anything unmatched. Split out of dispatchManagement to keep each
+// switch within the cyclomatic-complexity budget.
+func (h *Handler) dispatchTags(w http.ResponseWriter, r *http.Request, op string) {
+	switch op {
 	case "TagResource", "TagLogGroup":
 		h.tagLogGroup(w, r)
 	case "UntagResource", "UntagLogGroup":

--- a/server/aws/cloudwatchlogs/subscription_filters.go
+++ b/server/aws/cloudwatchlogs/subscription_filters.go
@@ -1,0 +1,132 @@
+package cloudwatchlogs
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+type putSubscriptionFilterRequest struct {
+	LogGroupName   string `json:"logGroupName"`
+	FilterName     string `json:"filterName"`
+	FilterPattern  string `json:"filterPattern"`
+	DestinationArn string `json:"destinationArn"`
+	RoleArn        string `json:"roleArn"`
+	Distribution   string `json:"distribution"`
+}
+
+type describeSubscriptionFiltersRequest struct {
+	LogGroupName     string `json:"logGroupName"`
+	FilterNamePrefix string `json:"filterNamePrefix"`
+	Limit            int32  `json:"limit"`
+	NextToken        string `json:"nextToken"`
+}
+
+type deleteSubscriptionFilterRequest struct {
+	LogGroupName string `json:"logGroupName"`
+	FilterName   string `json:"filterName"`
+}
+
+// subscriptionFilterJSON is a DescribeSubscriptionFilters response element.
+type subscriptionFilterJSON struct {
+	FilterName     string `json:"filterName"`
+	LogGroupName   string `json:"logGroupName"`
+	FilterPattern  string `json:"filterPattern"`
+	DestinationArn string `json:"destinationArn"`
+	RoleArn        string `json:"roleArn,omitempty"`
+	Distribution   string `json:"distribution,omitempty"`
+	CreationTime   int64  `json:"creationTime"`
+}
+
+type describeSubscriptionFiltersResponse struct {
+	SubscriptionFilters []subscriptionFilterJSON `json:"subscriptionFilters"`
+	NextToken           string                   `json:"nextToken,omitempty"`
+}
+
+// putSubscriptionFilter creates or updates a subscription filter
+// (Logs_20140328.PutSubscriptionFilter). A successful call returns an empty body.
+func (h *Handler) putSubscriptionFilter(w http.ResponseWriter, r *http.Request) {
+	var req putSubscriptionFilterRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.logs.PutSubscriptionFilter(r.Context(), &logdriver.SubscriptionFilterConfig{
+		Name:           req.FilterName,
+		LogGroup:       req.LogGroupName,
+		FilterPattern:  req.FilterPattern,
+		DestinationARN: req.DestinationArn,
+		RoleARN:        req.RoleArn,
+		Distribution:   req.Distribution,
+	}); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, struct{}{})
+}
+
+// describeSubscriptionFilters lists a log group's subscription filters,
+// ASCII-sorted by filter name and optionally narrowed by filterNamePrefix.
+func (h *Handler) describeSubscriptionFilters(w http.ResponseWriter, r *http.Request) {
+	var req describeSubscriptionFiltersRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	filters, err := h.logs.DescribeSubscriptionFilters(r.Context(), req.LogGroupName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	matched := make([]logdriver.SubscriptionFilterInfo, 0, len(filters))
+
+	for i := range filters {
+		if req.FilterNamePrefix != "" && !strings.HasPrefix(filters[i].Name, req.FilterNamePrefix) {
+			continue
+		}
+
+		matched = append(matched, filters[i])
+	}
+
+	from, to, next := pageBounds(len(matched), decodeOffsetToken(req.NextToken), req.Limit)
+
+	out := make([]subscriptionFilterJSON, 0, to-from)
+	for i := from; i < to; i++ {
+		out = append(out, subscriptionFilterJSON{
+			FilterName:     matched[i].Name,
+			LogGroupName:   matched[i].LogGroup,
+			FilterPattern:  matched[i].FilterPattern,
+			DestinationArn: matched[i].DestinationARN,
+			RoleArn:        matched[i].RoleARN,
+			Distribution:   matched[i].Distribution,
+			CreationTime:   epochMillis(matched[i].CreatedAt),
+		})
+	}
+
+	resp := describeSubscriptionFiltersResponse{SubscriptionFilters: out}
+	if next > 0 {
+		resp.NextToken = encodeOffsetToken(next)
+	}
+
+	wire.WriteJSON(w, resp)
+}
+
+// deleteSubscriptionFilter removes a subscription filter from a log group. A
+// successful call returns an empty body.
+func (h *Handler) deleteSubscriptionFilter(w http.ResponseWriter, r *http.Request) {
+	var req deleteSubscriptionFilterRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.logs.DeleteSubscriptionFilter(r.Context(), req.LogGroupName, req.FilterName); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, struct{}{})
+}

--- a/server/aws/cloudwatchlogs/subscription_filters_sdk_test.go
+++ b/server/aws/cloudwatchlogs/subscription_filters_sdk_test.go
@@ -1,0 +1,146 @@
+package cloudwatchlogs_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cwl "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+)
+
+// TestSDKSubscriptionFilterRoundTrip drives PutSubscriptionFilter /
+// DescribeSubscriptionFilters / DeleteSubscriptionFilter with the real SDK,
+// guarding the Terraform aws_cloudwatch_log_subscription_filter flow that
+// previously failed with UnknownOperationException.
+func TestSDKSubscriptionFilterRoundTrip(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	const (
+		group = "/sub/app"
+		dest  = "arn:aws:lambda:us-east-1:000000000000:function:log-sub"
+		role  = "arn:aws:iam::000000000000:role/cwl"
+	)
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String(group)}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	if _, err := client.PutSubscriptionFilter(ctx, &cwl.PutSubscriptionFilterInput{
+		LogGroupName:   aws.String(group),
+		FilterName:     aws.String("to-lambda"),
+		FilterPattern:  aws.String("ERROR"),
+		DestinationArn: aws.String(dest),
+		RoleArn:        aws.String(role),
+		Distribution:   cwltypes.DistributionByLogStream,
+	}); err != nil {
+		t.Fatalf("PutSubscriptionFilter: %v", err)
+	}
+
+	desc, err := client.DescribeSubscriptionFilters(ctx, &cwl.DescribeSubscriptionFiltersInput{
+		LogGroupName: aws.String(group),
+	})
+	if err != nil {
+		t.Fatalf("DescribeSubscriptionFilters: %v", err)
+	}
+
+	if len(desc.SubscriptionFilters) != 1 {
+		t.Fatalf("got %d filters, want 1: %+v", len(desc.SubscriptionFilters), desc.SubscriptionFilters)
+	}
+
+	sf := desc.SubscriptionFilters[0]
+	if aws.ToString(sf.FilterName) != "to-lambda" ||
+		aws.ToString(sf.FilterPattern) != "ERROR" ||
+		aws.ToString(sf.DestinationArn) != dest ||
+		aws.ToString(sf.RoleArn) != role ||
+		aws.ToString(sf.LogGroupName) != group {
+		t.Fatalf("filter round-trip mismatch: %+v", sf)
+	}
+
+	if sf.Distribution != cwltypes.DistributionByLogStream {
+		t.Fatalf("distribution = %q, want ByLogStream", sf.Distribution)
+	}
+
+	if aws.ToInt64(sf.CreationTime) == 0 {
+		t.Fatalf("creationTime is zero: %+v", sf)
+	}
+
+	// filterNamePrefix narrows the listing.
+	none, err := client.DescribeSubscriptionFilters(ctx, &cwl.DescribeSubscriptionFiltersInput{
+		LogGroupName: aws.String(group), FilterNamePrefix: aws.String("zzz"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeSubscriptionFilters(prefix): %v", err)
+	}
+
+	if len(none.SubscriptionFilters) != 0 {
+		t.Fatalf("prefix zzz = %d filters, want 0", len(none.SubscriptionFilters))
+	}
+
+	if _, err := client.DeleteSubscriptionFilter(ctx, &cwl.DeleteSubscriptionFilterInput{
+		LogGroupName: aws.String(group), FilterName: aws.String("to-lambda"),
+	}); err != nil {
+		t.Fatalf("DeleteSubscriptionFilter: %v", err)
+	}
+
+	after, err := client.DescribeSubscriptionFilters(ctx, &cwl.DescribeSubscriptionFiltersInput{
+		LogGroupName: aws.String(group),
+	})
+	if err != nil {
+		t.Fatalf("DescribeSubscriptionFilters after delete: %v", err)
+	}
+
+	if len(after.SubscriptionFilters) != 0 {
+		t.Fatalf("got %d filters after delete, want 0", len(after.SubscriptionFilters))
+	}
+}
+
+// TestSDKSubscriptionFilterErrors guards the error surface: a missing log group
+// is ResourceNotFoundException and a third distinct filter is LimitExceededException.
+func TestSDKSubscriptionFilterErrors(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	const dest = "arn:aws:lambda:us-east-1:000000000000:function:log-sub"
+
+	_, err := client.PutSubscriptionFilter(ctx, &cwl.PutSubscriptionFilterInput{
+		LogGroupName:   aws.String("/missing/grp"),
+		FilterName:     aws.String("f"),
+		FilterPattern:  aws.String(""),
+		DestinationArn: aws.String(dest),
+	})
+
+	var notFound *cwltypes.ResourceNotFoundException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("PutSubscriptionFilter(missing group): got %v, want ResourceNotFoundException", err)
+	}
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String("/lim/grp")}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	for _, name := range []string{"f1", "f2"} {
+		if _, err := client.PutSubscriptionFilter(ctx, &cwl.PutSubscriptionFilterInput{
+			LogGroupName:   aws.String("/lim/grp"),
+			FilterName:     aws.String(name),
+			FilterPattern:  aws.String(""),
+			DestinationArn: aws.String(dest),
+		}); err != nil {
+			t.Fatalf("PutSubscriptionFilter(%s): %v", name, err)
+		}
+	}
+
+	_, err = client.PutSubscriptionFilter(ctx, &cwl.PutSubscriptionFilterInput{
+		LogGroupName:   aws.String("/lim/grp"),
+		FilterName:     aws.String("f3"),
+		FilterPattern:  aws.String(""),
+		DestinationArn: aws.String(dest),
+	})
+
+	var limit *cwltypes.LimitExceededException
+	if !errors.As(err, &limit) {
+		t.Fatalf("third PutSubscriptionFilter: got %v, want LimitExceededException", err)
+	}
+}

--- a/services/logging/driver/driver.go
+++ b/services/logging/driver/driver.go
@@ -112,6 +112,32 @@ type MetricFilterInfo struct {
 	CreatedAt    time.Time
 }
 
+// SubscriptionFilterConfig describes a subscription filter to create or update.
+// A subscription filter streams matching log events (as they are ingested via
+// PutLogEvents) to a destination — a Lambda function, Kinesis stream, or
+// Firehose delivery stream identified by DestinationARN.
+type SubscriptionFilterConfig struct {
+	Name           string
+	LogGroup       string
+	FilterPattern  string
+	DestinationARN string
+	RoleARN        string
+	// Distribution controls how Kinesis destinations spread data across shards
+	// ("Random" or "ByLogStream"); ignored for other destination types.
+	Distribution string
+}
+
+// SubscriptionFilterInfo describes a subscription filter.
+type SubscriptionFilterInfo struct {
+	Name           string
+	LogGroup       string
+	FilterPattern  string
+	DestinationARN string
+	RoleARN        string
+	Distribution   string
+	CreatedAt      time.Time
+}
+
 // Logging is the interface that logging provider implementations must satisfy.
 type Logging interface {
 	CreateLogGroup(ctx context.Context, config LogGroupConfig) (*LogGroupInfo, error)
@@ -134,4 +160,8 @@ type Logging interface {
 	PutMetricFilter(ctx context.Context, config *MetricFilterConfig) error
 	DeleteMetricFilter(ctx context.Context, logGroup, filterName string) error
 	DescribeMetricFilters(ctx context.Context, logGroup string) ([]MetricFilterInfo, error)
+
+	PutSubscriptionFilter(ctx context.Context, config *SubscriptionFilterConfig) error
+	DeleteSubscriptionFilter(ctx context.Context, logGroup, filterName string) error
+	DescribeSubscriptionFilters(ctx context.Context, logGroup string) ([]SubscriptionFilterInfo, error)
 }

--- a/services/logging/logging.go
+++ b/services/logging/logging.go
@@ -251,3 +251,53 @@ func (l *Logging) DescribeMetricFilters(
 
 	return out.([]driver.MetricFilterInfo), nil
 }
+
+// PutSubscriptionFilter creates or updates a subscription filter for a log group.
+func (l *Logging) PutSubscriptionFilter(
+	ctx context.Context,
+	cfg *driver.SubscriptionFilterConfig,
+) error {
+	_, err := l.do(ctx, "PutSubscriptionFilter", cfg, func() (any, error) {
+		return nil, l.driver.PutSubscriptionFilter(ctx, cfg)
+	})
+
+	return err
+}
+
+// DeleteSubscriptionFilter deletes a subscription filter from a log group.
+func (l *Logging) DeleteSubscriptionFilter(
+	ctx context.Context,
+	logGroup, filterName string,
+) error {
+	_, err := l.do(
+		ctx, "DeleteSubscriptionFilter",
+		map[string]string{
+			"logGroup": logGroup, "filterName": filterName,
+		},
+		func() (any, error) {
+			return nil, l.driver.DeleteSubscriptionFilter(
+				ctx, logGroup, filterName,
+			)
+		},
+	)
+
+	return err
+}
+
+// DescribeSubscriptionFilters lists all subscription filters for a log group.
+func (l *Logging) DescribeSubscriptionFilters(
+	ctx context.Context,
+	logGroup string,
+) ([]driver.SubscriptionFilterInfo, error) {
+	out, err := l.do(
+		ctx, "DescribeSubscriptionFilters", logGroup,
+		func() (any, error) {
+			return l.driver.DescribeSubscriptionFilters(ctx, logGroup)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.SubscriptionFilterInfo), nil
+}


### PR DESCRIPTION
## What

Implements AWS **CloudWatch Logs subscription filters** end-to-end, with real-time delivery of matching log events to a Lambda destination.

- **PutSubscriptionFilter / DescribeSubscriptionFilters / DeleteSubscriptionFilter** — previously unrouted (`UnknownOperationException`), so Terraform `aws_cloudwatch_log_subscription_filter` failed outright. Now fully wired through the 3-layer stack:
  - `driver.Logging` gains `SubscriptionFilterConfig` / `SubscriptionFilterInfo` and the three CRUD methods; all three providers (AWS/Azure/GCP) implement store-backed CRUD; the portable `services/logging` wrapper forwards them.
  - Wire dispatch added in `server/aws/cloudwatchlogs` (new `subscription_filters.go`).
- **Delivery (the real point)** — on `PutLogEvents`, events whose message matches a subscription filter's pattern are delivered to the filter's **Lambda** destination via the shared `InvokeExternal` choke point (recursion-guarded), mirroring the existing S3 → Lambda and DynamoDB-Stream → Lambda wiring. Wired only on AWS via the optional `SetLambdaInvoker` pattern in `providers/aws/aws.go`.
  - Payload matches the real CloudWatch Logs subscription shape: gzipped + base64 `awslogs.data` wrapping `{messageType, owner, logGroup, logStream, subscriptionFilters, logEvents[]}`.
  - The stream lock is released before delivery so a subscriber Lambda that writes back into CloudWatch Logs cannot deadlock.
- **Two-filters-per-group quota** enforced (`LimitExceededException`); updating an existing filter name is not counted against the quota.

## Why

Deferred HIGH Terraform-breaker from the AWS deep-e2e audit (`cloudwatchlogs.md` BUG D). Subscription filters are the CloudWatch Logs analogue of the X → Lambda delivery already present for S3/DynamoDB/EventBridge/SNS; the audit found them entirely unimplemented.

## Deferred

- **Kinesis / Firehose delivery.** The destination ARN type is detected and only the Lambda path delivers; a Kinesis/Firehose `destinationArn` is stored and returned by DescribeSubscriptionFilters but does not yet stream records (cross-service Kinesis/Firehose deliverer wiring is a larger lift). Filter matching remains substring-level (richer CWL filter-pattern grammar is separately deferred — audit BUG C).

## Tests (real aws-sdk-go-v2)

- Provider: CRUD round-trip, validation, two-filter limit, **Lambda delivery on matching PutLogEvents** (decodes the gzipped awslogs payload and asserts logGroup/logStream/logEvents), non-matching → not delivered, delete stops delivery, Kinesis destination → not delivered (deferred). Passes under `-race`.
- Wire (SDK): PutSubscriptionFilter(Lambda ARN) → DescribeSubscriptionFilters round-trip (pattern/destinationArn/roleArn/distribution/creationTime), filterNamePrefix, DeleteSubscriptionFilter, ResourceNotFound + LimitExceeded errors.
- Existing CW Logs tests (#568 metric filter, #678 ordering/retention, pagination, cascade delete) stay green.

Coverage docs regenerated (logging 14 → 17 ops).
