### PR TITLE
fix(azure-monitor): restore metric-alert dimension aggregation (no-filter matches all) — regressed by #666; also gcp

### DIFF
--- a/providers/azure/monitor/monitor.go
+++ b/providers/azure/monitor/monitor.go
@@ -195,7 +195,7 @@ func (m *Mock) collectFilteredDatums(
 			continue
 		}
 
-		if !matchDimensions(d.Dimensions, dims) {
+		if !matchAlarmDimensions(d.Dimensions, dims) {
 			continue
 		}
 
@@ -489,22 +489,44 @@ func (m *Mock) GetAlarmHistory(_ context.Context, alarmName string, limit int) (
 	return filtered, nil
 }
 
-// matchDimensions returns true if the data point dimensions contain all of the
-// requested filter dimensions. The "resourceId" dimension is compared with
+// matchDimensions reports whether a datum belongs to the exact metric series a
+// Metrics-List read query identifies. Reading a specific timeseries treats each
+// unique dimension combination as a distinct series, so the sets must match
+// exactly: a query with fewer (or no) dimensions does not match a datum
+// published with a superset. The "resourceId" dimension is compared with
 // resourceIDMatch rather than exact equality: cloudemu does not enforce a
 // single subscription across a deployment (the wire layer accepts requests
 // under any subscription id), so the subscription segment of an ARM resource
 // id can legitimately differ between how a resource was minted and how a
 // caller's request path addresses it.
 func matchDimensions(dataDims, filterDims map[string]string) bool {
-	// Azure Monitor, like CloudWatch, treats each unique dimension combination as
-	// a separate metric, so the sets must match exactly (a query with fewer/no
-	// dimensions does not match a datum published with a superset). The resourceId
-	// dimension is still compared subscription-agnostically per resourceIDMatch.
 	if len(dataDims) != len(filterDims) {
 		return false
 	}
 
+	return dimensionsContain(dataDims, filterDims)
+}
+
+// matchAlarmDimensions reports whether a datum contributes to a metric alert's
+// evaluation. Azure Monitor metric-alert semantics differ from a raw metric read
+// (and from CloudWatch's exact-series alarms): a criterion with no dimension
+// filter aggregates across ALL timeseries of the metric/namespace, so a
+// dimensionless alert matches every datum (including ones published with a
+// resourceId or other dimensions). When dimension filters are present, a datum
+// matches if its dimensions CONTAIN all of the filters (a superset is allowed);
+// only a missing or mismatched filter dimension rejects it.
+func matchAlarmDimensions(dataDims, filterDims map[string]string) bool {
+	if len(filterDims) == 0 {
+		return true
+	}
+
+	return dimensionsContain(dataDims, filterDims)
+}
+
+// dimensionsContain reports whether dataDims satisfies every (k,v) in filterDims,
+// comparing the "resourceId" dimension subscription-agnostically per
+// resourceIDMatch and all others by exact equality.
+func dimensionsContain(dataDims, filterDims map[string]string) bool {
 	for k, v := range filterDims {
 		if k == "resourceId" {
 			if !resourceIDMatch(dataDims[k], v) {

--- a/providers/gcp/monitoring/alarm_fidelity_test.go
+++ b/providers/gcp/monitoring/alarm_fidelity_test.go
@@ -40,6 +40,32 @@ func TestExactDimensionMatching(t *testing.T) {
 	assert.Equal(t, 42.0, exact.Values[0])
 }
 
+// TestDimensionlessAlarmAggregatesLabeledMetric covers GCP alerting's aggregate
+// semantics: an alert policy with no dimension filter evaluates across ALL
+// timeseries of the metric, so a metric published with a resource label (as VM
+// auto-metrics are) still drives a label-less alarm to ALARM.
+func TestDimensionlessAlarmAggregatesLabeledMetric(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newTestMock()
+
+	require.NoError(t, m.CreateAlarm(ctx, driver.AlarmConfig{
+		Name: "cpu-hot", Namespace: "compute.googleapis.com", MetricName: "instance/cpu/utilization",
+		ComparisonOperator: "GreaterThanThreshold", Threshold: 20,
+		Period: 60, EvaluationPeriods: 1, Stat: "Average",
+	}))
+
+	require.NoError(t, m.PutMetricData(ctx, []driver.MetricDatum{{
+		Namespace: "compute.googleapis.com", MetricName: "instance/cpu/utilization",
+		Value: 25, Timestamp: clk.Now(),
+		Dimensions: map[string]string{"instance_id": "i-1"},
+	}}))
+
+	alarms, err := m.DescribeAlarms(ctx, []string{"cpu-hot"})
+	require.NoError(t, err)
+	require.Len(t, alarms, 1)
+	assert.Equal(t, "ALARM", alarms[0].State, "label-less alarm must fire from a labeled metric")
+}
+
 // TestAlarmMOfNAndRecovery covers the per-period M-of-N parity fix: 3 of 3
 // periods must breach for ALARM (not the window average), with recovery to OK.
 func TestAlarmMOfNAndRecovery(t *testing.T) {

--- a/providers/gcp/monitoring/monitoring.go
+++ b/providers/gcp/monitoring/monitoring.go
@@ -195,7 +195,7 @@ func (m *Mock) collectFilteredDatums(
 			continue
 		}
 
-		if !alarmeval.MatchDimensions(d.Dimensions, dims) {
+		if !alarmeval.MatchAlarmDimensions(d.Dimensions, dims) {
 			continue
 		}
 

--- a/services/monitoring/alarmeval/alarmeval.go
+++ b/services/monitoring/alarmeval/alarmeval.go
@@ -87,6 +87,24 @@ func MatchDimensions(dataDims, filterDims map[string]string) bool {
 	return true
 }
 
+// MatchAlarmDimensions reports whether a datum contributes to a metric alert's
+// evaluation. Unlike MatchDimensions — which pins down one exact metric series
+// for a read query, matching how CloudWatch alarms monitor a single series —
+// Azure Monitor and GCP alerting aggregate across unspecified dimensions: a
+// criterion carrying no dimension filter evaluates over ALL timeseries of the
+// metric, and a filter naming some dimensions matches any datum whose dimensions
+// CONTAIN them (a superset is allowed). AWS/CloudWatch alarm evaluation keeps
+// using MatchDimensions; the aggregating providers use this.
+func MatchAlarmDimensions(dataDims, filterDims map[string]string) bool {
+	for k, v := range filterDims {
+		if dataDims[k] != v {
+			return false
+		}
+	}
+
+	return true
+}
+
 // EvaluateComparison reports whether value crosses threshold under operator.
 func EvaluateComparison(value float64, operator string, threshold float64) bool {
 	switch operator {


### PR DESCRIPTION
## Root cause

PR #666 (CloudWatch cross-provider mirror) over-tightened Azure and GCP alarm
evaluation by mirroring CloudWatch's **exact-set-equality** dimension matching
onto them. A VM's auto-metrics carry a resource dimension (`resourceId` on Azure,
`instance_id` on GCP), so a metric alert created with **no dimension filter**
never matched those datapoints and stayed `INSUFFICIENT_DATA` instead of `ALARM`
— failing CI-red `TestMetricAlertEvaluatesMetric` (development's full
`go test ./...` was red on this one test; every recent AWS PR branched off it and
inherited the red).

## Fix

Azure Monitor and GCP alerting **aggregate across unspecified dimensions**
(confirmed against Azure/GCP alerting docs): a criterion with no dimension filter
evaluates over **all** timeseries of the metric, and a filter with dimensions
matches any datapoint whose dimensions **contain** them (superset allowed).

- **Azure** (`providers/azure/monitor/monitor.go`): alarm-eval path now uses a
  new `matchAlarmDimensions` (empty filter → match all; else contains-all, with
  the existing subscription-agnostic `resourceId` compare). The metric-read
  (`GetMetricData`) path keeps exact-set-equality.
- **GCP** (`providers/gcp/monitoring/monitoring.go`): alarm-eval path now uses a
  new shared `alarmeval.MatchAlarmDimensions`; the metric-read path keeps exact
  `alarmeval.MatchDimensions`.
- **AWS is untouched** — CloudWatch alarms monitor one exact series and keep
  exact-set-equality (`alarmeval.MatchDimensions`).

## Tests

- Existing `TestMetricAlertEvaluatesMetric` now passes **unedited**.
- Existing `TestExactDimensionMatching` (metric-read path) still passes on both
  providers.
- Added `TestDimensionlessAlarmAggregatesLabeledMetric` (GCP) covering a
  label-less alarm firing from a labeled metric.
- Full `go test ./...` green (294 ok, 0 fail); `-race` on changed packages green.
