### PR TITLE
feat(aws-elasticache): parameter-group contents — DescribeCacheParameters + ModifyCacheParameterGroup ParameterNameValues

### DIFF
--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -160,12 +160,17 @@ type Mock struct {
 }
 
 // ParameterGroup is an ElastiCache cache parameter group — a named, engine-family
-// set of engine parameters. The emulator stores its identity so IaC that creates
-// and references a custom group succeeds.
+// set of engine parameters. The emulator stores its identity plus any user
+// overrides (name→value) applied via ModifyCacheParameterGroup, so IaC that
+// creates a group, sets `parameter { … }` blocks, and reads them back on refresh
+// converges. The engine-family defaults themselves are synthesized on demand
+// (see defaultCacheParameters); Overrides holds only the parameters the user has
+// changed from their default.
 type ParameterGroup struct {
 	Name        string
 	Family      string
 	Description string
+	Overrides   map[string]string
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.

--- a/providers/aws/elasticache/parameters.go
+++ b/providers/aws/elasticache/parameters.go
@@ -1,0 +1,247 @@
+package elasticache
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// Parameter is one entry in a cache parameter group's detailed parameter list,
+// as returned by DescribeCacheParameters. Source is "system" for an
+// engine-default value and "user" once the parameter has been modified via
+// ModifyCacheParameterGroup.
+type Parameter struct {
+	Name                 string
+	Value                string
+	Source               string
+	DataType             string
+	AllowedValues        string
+	IsModifiable         bool
+	MinimumEngineVersion string
+	Description          string
+}
+
+// ParameterUpdate is one name→value pair from a ModifyCacheParameterGroup /
+// ResetCacheParameterGroup ParameterNameValues list. For a reset the Value is
+// ignored — only the Name identifies the parameter to restore to its default.
+type ParameterUpdate struct {
+	Name  string
+	Value string
+}
+
+const (
+	paramSourceSystem = "system"
+	paramSourceUser   = "user"
+
+	paramSourceEngineDefault = "engine-default"
+)
+
+// defaultCacheParameters returns a curated set of engine-default parameters for
+// a cache parameter group family (e.g. "redis7", "memcached1.6"). It is not the
+// full real list of hundreds — it is the representative subset IaC reads and the
+// parameters commonly set through Terraform (notably maxmemory-policy for
+// Redis). Every entry carries Source "system".
+func defaultCacheParameters(family string) []Parameter {
+	if isMemcachedFamily(family) {
+		return memcachedDefaultParameters()
+	}
+
+	return redisDefaultParameters()
+}
+
+// isMemcachedFamily reports whether a parameter-group family names the Memcached
+// engine. Anything else (redis*, valkey*, or an unknown family) is treated as
+// Redis-shaped, which is the ElastiCache default.
+func isMemcachedFamily(family string) bool {
+	f := strings.ToLower(strings.TrimPrefix(family, "default."))
+
+	return strings.HasPrefix(f, "memcached")
+}
+
+const maxmemoryPolicyAllowed = "volatile-lru,allkeys-lru,volatile-lfu,allkeys-lfu," +
+	"volatile-random,allkeys-random,volatile-ttl,noeviction"
+
+func redisDefaultParameters() []Parameter {
+	const minVer = "5.0.0"
+
+	return []Parameter{
+		{Name: "maxmemory-policy", Value: "volatile-lru", DataType: "string", AllowedValues: maxmemoryPolicyAllowed,
+			IsModifiable: true, MinimumEngineVersion: minVer, Description: "Max memory policy."},
+		{Name: "maxmemory-samples", Value: "3", DataType: "integer", AllowedValues: "1-",
+			IsModifiable: true, MinimumEngineVersion: minVer, Description: "Max memory samples."},
+		{Name: "timeout", Value: "0", DataType: "integer", AllowedValues: "0,20-",
+			IsModifiable: true, MinimumEngineVersion: minVer, Description: "Close idle client connections after N seconds."},
+		{Name: "tcp-keepalive", Value: "300", DataType: "integer", AllowedValues: "0-",
+			IsModifiable: true, MinimumEngineVersion: minVer, Description: "TCP keepalive interval in seconds."},
+		{Name: "slowlog-log-slower-than", Value: "10000", DataType: "integer", AllowedValues: "-1-",
+			IsModifiable: true, MinimumEngineVersion: minVer, Description: "Slowlog threshold in microseconds."},
+		{Name: "slowlog-max-len", Value: "128", DataType: "integer", AllowedValues: "0-",
+			IsModifiable: true, MinimumEngineVersion: minVer, Description: "Maximum number of slowlog entries."},
+		{Name: "notify-keyspace-events", Value: "", DataType: "string", AllowedValues: "",
+			IsModifiable: true, MinimumEngineVersion: minVer, Description: "Keyspace notifications configuration."},
+		{Name: "reserved-memory-percent", Value: "25", DataType: "integer", AllowedValues: "0-100",
+			IsModifiable: true, MinimumEngineVersion: minVer, Description: "Percent of memory reserved for non-data use."},
+		{Name: "databases", Value: "16", DataType: "integer", AllowedValues: "1-",
+			IsModifiable: false, MinimumEngineVersion: minVer, Description: "Number of logical databases."},
+		{Name: "maxclients", Value: "65000", DataType: "integer", AllowedValues: "1-",
+			IsModifiable: false, MinimumEngineVersion: minVer, Description: "Maximum number of client connections."},
+		{Name: "cluster-enabled", Value: "no", DataType: "string", AllowedValues: "yes,no",
+			IsModifiable: false, MinimumEngineVersion: minVer, Description: "Whether cluster mode is enabled."},
+	}
+}
+
+func memcachedDefaultParameters() []Parameter {
+	const minVer = "1.4.14"
+
+	return []Parameter{
+		{Name: "max_item_size", Value: "1048576", DataType: "integer", AllowedValues: "1024-1048576",
+			IsModifiable: true, MinimumEngineVersion: minVer, Description: "Maximum size of a stored item, in bytes."},
+		{Name: "maxconns_fast", Value: "0", DataType: "boolean", AllowedValues: "0,1",
+			IsModifiable: true, MinimumEngineVersion: minVer, Description: "Close new connections immediately when at the limit."},
+		{Name: "lru_crawler", Value: "0", DataType: "boolean", AllowedValues: "0,1",
+			IsModifiable: true, MinimumEngineVersion: minVer, Description: "Enable the LRU crawler background thread."},
+		{Name: "cas_disabled", Value: "0", DataType: "boolean", AllowedValues: "0,1",
+			IsModifiable: true, MinimumEngineVersion: minVer, Description: "Disable check-and-set operations."},
+		{Name: "slab_automove", Value: "0", DataType: "integer", AllowedValues: "0,1,2",
+			IsModifiable: true, MinimumEngineVersion: minVer, Description: "Automatic slab memory reassignment mode."},
+		{Name: "chunk_size", Value: "48", DataType: "integer", AllowedValues: "1-48",
+			IsModifiable: false, MinimumEngineVersion: "1.4.5", Description: "Minimum chunk size, in bytes."},
+		{Name: "chunk_size_growth_factor", Value: "1.25", DataType: "float", AllowedValues: "1.0-",
+			IsModifiable: false, MinimumEngineVersion: "1.4.5", Description: "Chunk size growth factor."},
+		{Name: "max_simultaneous_connections", Value: "65000", DataType: "integer", AllowedValues: "1-",
+			IsModifiable: false, MinimumEngineVersion: "1.4.5", Description: "Maximum simultaneous connections."},
+	}
+}
+
+// defaultParameterIndex builds a name→Parameter lookup of a family's defaults.
+func defaultParameterIndex(family string) map[string]Parameter {
+	defaults := defaultCacheParameters(family)
+
+	idx := make(map[string]Parameter, len(defaults))
+	for _, p := range defaults {
+		idx[p.Name] = p
+	}
+
+	return idx
+}
+
+// DescribeCacheParameters returns the detailed parameter list for a cache
+// parameter group: the engine-family defaults with any user overrides applied
+// (Source becomes "user" for a modified parameter). source, when non-empty,
+// narrows the result to "user" (only modified parameters) or "system" /
+// "engine-default" (only unmodified defaults). A missing group reports
+// CacheParameterGroupNotFound.
+func (m *Mock) DescribeCacheParameters(_ context.Context, name, source string) ([]Parameter, error) {
+	pg, ok := m.parameterGroups.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cache parameter group %q not found", name)
+	}
+
+	defaults := defaultCacheParameters(pg.Family)
+
+	out := make([]Parameter, 0, len(defaults))
+
+	for _, p := range defaults {
+		if v, overridden := pg.Overrides[p.Name]; overridden {
+			p.Value = v
+			p.Source = paramSourceUser
+		} else {
+			p.Source = paramSourceSystem
+		}
+
+		if !matchesParameterSource(source, p.Source) {
+			continue
+		}
+
+		out = append(out, p)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+
+	return out, nil
+}
+
+// matchesParameterSource reports whether a parameter whose effective source is
+// paramSource should be included given the requested source filter. An empty
+// filter matches everything; "engine-default" is treated as "system".
+func matchesParameterSource(filter, paramSource string) bool {
+	switch filter {
+	case "", paramSource:
+		return true
+	case paramSourceEngineDefault:
+		return paramSource == paramSourceSystem
+	default:
+		return false
+	}
+}
+
+// ModifyCacheParameterGroup applies the given name→value overrides to a cache
+// parameter group. Each name must be a known parameter for the group's family
+// and be modifiable; otherwise InvalidParameterValue is returned and no override
+// is applied. A missing group reports CacheParameterGroupNotFound.
+func (m *Mock) ModifyCacheParameterGroup(_ context.Context, name string, updates []ParameterUpdate) error {
+	pg, ok := m.parameterGroups.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "cache parameter group %q not found", name)
+	}
+
+	idx := defaultParameterIndex(pg.Family)
+
+	for _, u := range updates {
+		def, known := idx[u.Name]
+		if !known {
+			return cerrors.Newf(cerrors.InvalidArgument, "unknown parameter %q for family %q", u.Name, pg.Family)
+		}
+
+		if !def.IsModifiable {
+			return cerrors.Newf(cerrors.InvalidArgument, "parameter %q is not modifiable", u.Name)
+		}
+	}
+
+	if pg.Overrides == nil {
+		pg.Overrides = make(map[string]string, len(updates))
+	}
+
+	for _, u := range updates {
+		pg.Overrides[u.Name] = u.Value
+	}
+
+	m.parameterGroups.Set(name, pg)
+
+	return nil
+}
+
+// ResetCacheParameterGroup restores parameters to their engine defaults. When
+// resetAll is true every override is cleared; otherwise only the named
+// parameters are reset (each must be a known parameter for the family). A
+// missing group reports CacheParameterGroupNotFound.
+func (m *Mock) ResetCacheParameterGroup(_ context.Context, name string, resetAll bool, names []string) error {
+	pg, ok := m.parameterGroups.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "cache parameter group %q not found", name)
+	}
+
+	if resetAll {
+		pg.Overrides = nil
+		m.parameterGroups.Set(name, pg)
+
+		return nil
+	}
+
+	idx := defaultParameterIndex(pg.Family)
+	for _, n := range names {
+		if _, known := idx[n]; !known {
+			return cerrors.Newf(cerrors.InvalidArgument, "unknown parameter %q for family %q", n, pg.Family)
+		}
+	}
+
+	for _, n := range names {
+		delete(pg.Overrides, n)
+	}
+
+	m.parameterGroups.Set(name, pg)
+
+	return nil
+}

--- a/providers/aws/elasticache/parameters_test.go
+++ b/providers/aws/elasticache/parameters_test.go
@@ -1,0 +1,158 @@
+package elasticache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createTestParamGroup(t *testing.T, m *Mock, name, family string) {
+	t.Helper()
+
+	_, err := m.CreateCacheParameterGroup(context.Background(), name, family, "desc")
+	require.NoError(t, err)
+}
+
+func findParameter(params []Parameter, name string) (Parameter, bool) {
+	for _, p := range params {
+		if p.Name == name {
+			return p, true
+		}
+	}
+
+	return Parameter{}, false
+}
+
+func TestDescribeCacheParametersDefaults(t *testing.T) {
+	m, _ := newTestMock()
+	createTestParamGroup(t, m, "pg", "redis7")
+
+	params, err := m.DescribeCacheParameters(context.Background(), "pg", "")
+	require.NoError(t, err)
+	require.NotEmpty(t, params)
+
+	mp, ok := findParameter(params, "maxmemory-policy")
+	require.True(t, ok, "maxmemory-policy should be present")
+	assert.Equal(t, "volatile-lru", mp.Value)
+	assert.Equal(t, "system", mp.Source)
+}
+
+func TestDescribeCacheParametersMemcachedFamily(t *testing.T) {
+	m, _ := newTestMock()
+	createTestParamGroup(t, m, "mc", "memcached1.6")
+
+	params, err := m.DescribeCacheParameters(context.Background(), "mc", "")
+	require.NoError(t, err)
+	require.NotEmpty(t, params)
+
+	_, ok := findParameter(params, "max_item_size")
+	assert.True(t, ok, "memcached family should expose max_item_size")
+
+	_, redisLeak := findParameter(params, "maxmemory-policy")
+	assert.False(t, redisLeak, "memcached family must not expose redis parameters")
+}
+
+func TestModifyCacheParametersApplied(t *testing.T) {
+	m, _ := newTestMock()
+	createTestParamGroup(t, m, "pg", "redis7")
+
+	err := m.ModifyCacheParameterGroup(context.Background(), "pg",
+		[]ParameterUpdate{{Name: "maxmemory-policy", Value: "allkeys-lru"}})
+	require.NoError(t, err)
+
+	params, err := m.DescribeCacheParameters(context.Background(), "pg", "")
+	require.NoError(t, err)
+
+	mp, ok := findParameter(params, "maxmemory-policy")
+	require.True(t, ok)
+	assert.Equal(t, "allkeys-lru", mp.Value)
+	assert.Equal(t, "user", mp.Source)
+}
+
+func TestModifyCacheParametersUnknownRejected(t *testing.T) {
+	m, _ := newTestMock()
+	createTestParamGroup(t, m, "pg", "redis7")
+
+	err := m.ModifyCacheParameterGroup(context.Background(), "pg",
+		[]ParameterUpdate{{Name: "bogus", Value: "x"}})
+	require.Error(t, err)
+}
+
+func TestModifyCacheParametersNotModifiableRejected(t *testing.T) {
+	m, _ := newTestMock()
+	createTestParamGroup(t, m, "pg", "redis7")
+
+	err := m.ModifyCacheParameterGroup(context.Background(), "pg",
+		[]ParameterUpdate{{Name: "databases", Value: "32"}})
+	require.Error(t, err)
+}
+
+func TestModifyCacheParametersMissingGroup(t *testing.T) {
+	m, _ := newTestMock()
+
+	err := m.ModifyCacheParameterGroup(context.Background(), "nope",
+		[]ParameterUpdate{{Name: "maxmemory-policy", Value: "allkeys-lru"}})
+	require.Error(t, err)
+}
+
+func TestDescribeCacheParametersSourceFilter(t *testing.T) {
+	m, _ := newTestMock()
+	createTestParamGroup(t, m, "pg", "redis7")
+
+	require.NoError(t, m.ModifyCacheParameterGroup(context.Background(), "pg",
+		[]ParameterUpdate{{Name: "maxmemory-policy", Value: "allkeys-lru"}}))
+
+	user, err := m.DescribeCacheParameters(context.Background(), "pg", "user")
+	require.NoError(t, err)
+	require.Len(t, user, 1)
+	assert.Equal(t, "maxmemory-policy", user[0].Name)
+
+	system, err := m.DescribeCacheParameters(context.Background(), "pg", "system")
+	require.NoError(t, err)
+
+	_, leaked := findParameter(system, "maxmemory-policy")
+	assert.False(t, leaked, "system filter must exclude user-modified parameters")
+}
+
+func TestResetCacheParameterGroupAll(t *testing.T) {
+	m, _ := newTestMock()
+	createTestParamGroup(t, m, "pg", "redis7")
+
+	require.NoError(t, m.ModifyCacheParameterGroup(context.Background(), "pg",
+		[]ParameterUpdate{{Name: "maxmemory-policy", Value: "allkeys-lru"}}))
+
+	require.NoError(t, m.ResetCacheParameterGroup(context.Background(), "pg", true, nil))
+
+	params, err := m.DescribeCacheParameters(context.Background(), "pg", "")
+	require.NoError(t, err)
+
+	mp, ok := findParameter(params, "maxmemory-policy")
+	require.True(t, ok)
+	assert.Equal(t, "volatile-lru", mp.Value)
+	assert.Equal(t, "system", mp.Source)
+}
+
+func TestResetCacheParameterGroupNamed(t *testing.T) {
+	m, _ := newTestMock()
+	createTestParamGroup(t, m, "pg", "redis7")
+
+	require.NoError(t, m.ModifyCacheParameterGroup(context.Background(), "pg", []ParameterUpdate{
+		{Name: "maxmemory-policy", Value: "allkeys-lru"},
+		{Name: "timeout", Value: "60"},
+	}))
+
+	require.NoError(t, m.ResetCacheParameterGroup(context.Background(), "pg", false, []string{"timeout"}))
+
+	params, err := m.DescribeCacheParameters(context.Background(), "pg", "")
+	require.NoError(t, err)
+
+	tmo, ok := findParameter(params, "timeout")
+	require.True(t, ok)
+	assert.Equal(t, "system", tmo.Source, "reset parameter returns to system source")
+
+	mp, ok := findParameter(params, "maxmemory-policy")
+	require.True(t, ok)
+	assert.Equal(t, "user", mp.Source, "un-reset parameter keeps its user override")
+}

--- a/providers/aws/elasticache/tags.go
+++ b/providers/aws/elasticache/tags.go
@@ -114,7 +114,7 @@ func (m *Mock) CreateCacheParameterGroup(_ context.Context, name, family, descri
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "cache parameter group %q already exists", name)
 	}
 
-	pg := ParameterGroup{Name: name, Family: family, Description: description}
+	pg := ParameterGroup{Name: name, Family: family, Description: description, Overrides: map[string]string{}}
 	m.parameterGroups.Set(name, pg)
 
 	return &pg, nil
@@ -138,16 +138,6 @@ func (m *Mock) DescribeCacheParameterGroups(_ context.Context, names []string) (
 	}
 
 	return out, nil
-}
-
-// ModifyCacheParameterGroup is a no-op beyond validating the group exists —
-// the emulator does not track individual parameter values, only group identity.
-func (m *Mock) ModifyCacheParameterGroup(_ context.Context, name string) error {
-	if !m.parameterGroups.Has(name) {
-		return cerrors.Newf(cerrors.NotFound, "cache parameter group %q not found", name)
-	}
-
-	return nil
 }
 
 // DeleteCacheParameterGroup removes an ElastiCache cache parameter group.

--- a/server/aws/elasticache/cacheparameters_sdk_roundtrip_test.go
+++ b/server/aws/elasticache/cacheparameters_sdk_roundtrip_test.go
@@ -1,0 +1,233 @@
+package elasticache_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+	ectypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/aws/smithy-go"
+)
+
+// createRedis7ParamGroup creates a redis7 cache parameter group named `name`.
+func createRedis7ParamGroup(t *testing.T, client *awselasticache.Client, name string) {
+	t.Helper()
+
+	if _, err := client.CreateCacheParameterGroup(context.Background(), &awselasticache.CreateCacheParameterGroupInput{
+		CacheParameterGroupName:   aws.String(name),
+		CacheParameterGroupFamily: aws.String("redis7"),
+		Description:               aws.String("custom"),
+	}); err != nil {
+		t.Fatalf("CreateCacheParameterGroup: %v", err)
+	}
+}
+
+// findParam returns the parameter with the given name, or nil.
+func findParam(params []ectypes.Parameter, name string) *ectypes.Parameter {
+	for i := range params {
+		if aws.ToString(params[i].ParameterName) == name {
+			return &params[i]
+		}
+	}
+
+	return nil
+}
+
+// TestSDKDescribeCacheParametersDefaults covers that a freshly created group
+// returns a non-empty engine-default parameter list including maxmemory-policy
+// with Source=system.
+func TestSDKDescribeCacheParametersDefaults(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	createRedis7ParamGroup(t, client, "pg-defaults")
+
+	got, err := client.DescribeCacheParameters(ctx, &awselasticache.DescribeCacheParametersInput{
+		CacheParameterGroupName: aws.String("pg-defaults"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheParameters: %v", err)
+	}
+
+	if len(got.Parameters) == 0 {
+		t.Fatalf("expected a non-empty default parameter list")
+	}
+
+	mp := findParam(got.Parameters, "maxmemory-policy")
+	if mp == nil {
+		t.Fatalf("expected maxmemory-policy in default parameters")
+	}
+
+	if aws.ToString(mp.ParameterValue) != "volatile-lru" {
+		t.Errorf("maxmemory-policy default = %q, want volatile-lru", aws.ToString(mp.ParameterValue))
+	}
+
+	if aws.ToString(mp.Source) != "system" {
+		t.Errorf("maxmemory-policy Source = %q, want system", aws.ToString(mp.Source))
+	}
+}
+
+// TestSDKModifyCacheParametersApplied covers that ModifyCacheParameterGroup with
+// ParameterNameValues is reflected on the next DescribeCacheParameters with
+// Source=user.
+func TestSDKModifyCacheParametersApplied(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	createRedis7ParamGroup(t, client, "pg-modify")
+
+	if _, err := client.ModifyCacheParameterGroup(ctx, &awselasticache.ModifyCacheParameterGroupInput{
+		CacheParameterGroupName: aws.String("pg-modify"),
+		ParameterNameValues: []ectypes.ParameterNameValue{
+			{ParameterName: aws.String("maxmemory-policy"), ParameterValue: aws.String("allkeys-lru")},
+		},
+	}); err != nil {
+		t.Fatalf("ModifyCacheParameterGroup: %v", err)
+	}
+
+	got, err := client.DescribeCacheParameters(ctx, &awselasticache.DescribeCacheParametersInput{
+		CacheParameterGroupName: aws.String("pg-modify"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheParameters: %v", err)
+	}
+
+	mp := findParam(got.Parameters, "maxmemory-policy")
+	if mp == nil {
+		t.Fatalf("maxmemory-policy missing after modify")
+	}
+
+	if aws.ToString(mp.ParameterValue) != "allkeys-lru" {
+		t.Errorf("maxmemory-policy = %q, want allkeys-lru", aws.ToString(mp.ParameterValue))
+	}
+
+	if aws.ToString(mp.Source) != "user" {
+		t.Errorf("maxmemory-policy Source = %q, want user", aws.ToString(mp.Source))
+	}
+}
+
+// TestSDKModifyCacheParametersUnknownRejected covers that an unknown parameter
+// name is rejected with InvalidParameterValue.
+func TestSDKModifyCacheParametersUnknownRejected(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	createRedis7ParamGroup(t, client, "pg-unknown")
+
+	_, err := client.ModifyCacheParameterGroup(ctx, &awselasticache.ModifyCacheParameterGroupInput{
+		CacheParameterGroupName: aws.String("pg-unknown"),
+		ParameterNameValues: []ectypes.ParameterNameValue{
+			{ParameterName: aws.String("not-a-real-parameter"), ParameterValue: aws.String("x")},
+		},
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("unknown parameter must surface InvalidParameterValue, got %T: %v", err, err)
+	}
+}
+
+// TestSDKDescribeCacheParametersMissingGroup covers that a missing group reports
+// CacheParameterGroupNotFound.
+func TestSDKDescribeCacheParametersMissingGroup(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.DescribeCacheParameters(ctx, &awselasticache.DescribeCacheParametersInput{
+		CacheParameterGroupName: aws.String("does-not-exist"),
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "CacheParameterGroupNotFound" {
+		t.Fatalf("missing group must surface CacheParameterGroupNotFound, got %T: %v", err, err)
+	}
+}
+
+// TestSDKDescribeCacheParametersSourceFilter covers that the Source filter
+// narrows the result: user returns only modified parameters, system excludes
+// them.
+func TestSDKDescribeCacheParametersSourceFilter(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	createRedis7ParamGroup(t, client, "pg-filter")
+
+	if _, err := client.ModifyCacheParameterGroup(ctx, &awselasticache.ModifyCacheParameterGroupInput{
+		CacheParameterGroupName: aws.String("pg-filter"),
+		ParameterNameValues: []ectypes.ParameterNameValue{
+			{ParameterName: aws.String("maxmemory-policy"), ParameterValue: aws.String("allkeys-lru")},
+		},
+	}); err != nil {
+		t.Fatalf("ModifyCacheParameterGroup: %v", err)
+	}
+
+	user, err := client.DescribeCacheParameters(ctx, &awselasticache.DescribeCacheParametersInput{
+		CacheParameterGroupName: aws.String("pg-filter"), Source: aws.String("user"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheParameters(user): %v", err)
+	}
+
+	if len(user.Parameters) != 1 || findParam(user.Parameters, "maxmemory-policy") == nil {
+		t.Fatalf("user filter = %d params, want only maxmemory-policy", len(user.Parameters))
+	}
+
+	system, err := client.DescribeCacheParameters(ctx, &awselasticache.DescribeCacheParametersInput{
+		CacheParameterGroupName: aws.String("pg-filter"), Source: aws.String("system"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheParameters(system): %v", err)
+	}
+
+	if findParam(system.Parameters, "maxmemory-policy") != nil {
+		t.Errorf("system filter must exclude the user-modified maxmemory-policy")
+	}
+
+	if len(system.Parameters) == 0 {
+		t.Errorf("system filter should still return the unmodified defaults")
+	}
+}
+
+// TestSDKResetCacheParameterGroup covers that ResetCacheParameterGroup restores
+// a modified parameter back to its engine default (Source=system).
+func TestSDKResetCacheParameterGroup(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	createRedis7ParamGroup(t, client, "pg-reset")
+
+	if _, err := client.ModifyCacheParameterGroup(ctx, &awselasticache.ModifyCacheParameterGroupInput{
+		CacheParameterGroupName: aws.String("pg-reset"),
+		ParameterNameValues: []ectypes.ParameterNameValue{
+			{ParameterName: aws.String("maxmemory-policy"), ParameterValue: aws.String("allkeys-lru")},
+		},
+	}); err != nil {
+		t.Fatalf("ModifyCacheParameterGroup: %v", err)
+	}
+
+	if _, err := client.ResetCacheParameterGroup(ctx, &awselasticache.ResetCacheParameterGroupInput{
+		CacheParameterGroupName: aws.String("pg-reset"),
+		ResetAllParameters:      aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("ResetCacheParameterGroup: %v", err)
+	}
+
+	got, err := client.DescribeCacheParameters(ctx, &awselasticache.DescribeCacheParametersInput{
+		CacheParameterGroupName: aws.String("pg-reset"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheParameters: %v", err)
+	}
+
+	mp := findParam(got.Parameters, "maxmemory-policy")
+	if mp == nil {
+		t.Fatalf("maxmemory-policy missing after reset")
+	}
+
+	if aws.ToString(mp.ParameterValue) != "volatile-lru" || aws.ToString(mp.Source) != "system" {
+		t.Errorf("after reset maxmemory-policy = %q/%q, want volatile-lru/system",
+			aws.ToString(mp.ParameterValue), aws.ToString(mp.Source))
+	}
+}

--- a/server/aws/elasticache/handler.go
+++ b/server/aws/elasticache/handler.go
@@ -53,7 +53,9 @@ var elastiCacheActions = map[string]struct{}{ //nolint:gochecknoglobals // stati
 	"CreateCacheParameterGroup":    {},
 	"DescribeCacheParameterGroups": {},
 	"ModifyCacheParameterGroup":    {},
+	"ResetCacheParameterGroup":     {},
 	"DeleteCacheParameterGroup":    {},
+	"DescribeCacheParameters":      {},
 	"DescribeCacheEngineVersions":  {},
 	"CreateReplicationGroup":       {},
 	"DescribeReplicationGroups":    {},
@@ -145,7 +147,7 @@ func (*Handler) Matches(r *http.Request) bool {
 
 // ServeHTTP dispatches on Action. The form has already been parsed by Matches.
 //
-//nolint:gocyclo // one case per action; the flat dispatch switch grows with the surface and reads clearer than sub-routers.
+//nolint:gocyclo,funlen // one case per action; the flat dispatch switch grows with the surface and reads clearer than sub-routers.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.Form.Get("Action") {
 	case "CreateCacheSubnetGroup":
@@ -184,6 +186,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.describeCacheParameterGroups(w, r)
 	case "ModifyCacheParameterGroup":
 		h.modifyCacheParameterGroup(w, r)
+	case "ResetCacheParameterGroup":
+		h.resetCacheParameterGroup(w, r)
+	case "DescribeCacheParameters":
+		h.describeCacheParameters(w, r)
 	case "DeleteCacheParameterGroup":
 		h.deleteCacheParameterGroup(w, r)
 	case "DescribeCacheEngineVersions":

--- a/server/aws/elasticache/tags.go
+++ b/server/aws/elasticache/tags.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/xml"
 	"net/http"
+	"net/url"
 	"sort"
+	"strconv"
+	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	ecprovider "github.com/stackshy/cloudemu/v2/providers/aws/elasticache"
@@ -23,7 +26,9 @@ type resourceTagger interface {
 type parameterGroupManager interface {
 	CreateCacheParameterGroup(ctx context.Context, name, family, description string) (*ecprovider.ParameterGroup, error)
 	DescribeCacheParameterGroups(ctx context.Context, names []string) ([]ecprovider.ParameterGroup, error)
-	ModifyCacheParameterGroup(ctx context.Context, name string) error
+	DescribeCacheParameters(ctx context.Context, name, source string) ([]ecprovider.Parameter, error)
+	ModifyCacheParameterGroup(ctx context.Context, name string, updates []ecprovider.ParameterUpdate) error
+	ResetCacheParameterGroup(ctx context.Context, name string, resetAll bool, names []string) error
 	DeleteCacheParameterGroup(ctx context.Context, name string) error
 }
 
@@ -181,6 +186,31 @@ type deleteCacheParameterGroupResponse struct {
 	Metadata responseMetadata `xml:"ResponseMetadata"`
 }
 
+type resetCacheParameterGroupResponse struct {
+	XMLName  xml.Name         `xml:"ResetCacheParameterGroupResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Name     string           `xml:"ResetCacheParameterGroupResult>CacheParameterGroupName"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type parameterXML struct {
+	ParameterName        string `xml:"ParameterName"`
+	ParameterValue       string `xml:"ParameterValue"`
+	Description          string `xml:"Description"`
+	Source               string `xml:"Source"`
+	DataType             string `xml:"DataType"`
+	AllowedValues        string `xml:"AllowedValues"`
+	IsModifiable         bool   `xml:"IsModifiable"`
+	MinimumEngineVersion string `xml:"MinimumEngineVersion"`
+}
+
+type describeCacheParametersResponse struct {
+	XMLName    xml.Name         `xml:"DescribeCacheParametersResponse"`
+	Xmlns      string           `xml:"xmlns,attr"`
+	Parameters []parameterXML   `xml:"DescribeCacheParametersResult>Parameters>Parameter"`
+	Metadata   responseMetadata `xml:"ResponseMetadata"`
+}
+
 func (h *Handler) paramGroups() (parameterGroupManager, bool) {
 	m, ok := h.cache.(parameterGroupManager)
 
@@ -254,7 +284,7 @@ func (h *Handler) modifyCacheParameterGroup(w http.ResponseWriter, r *http.Reque
 	}
 
 	name := r.Form.Get("CacheParameterGroupName")
-	if err := mgr.ModifyCacheParameterGroup(r.Context(), name); err != nil {
+	if err := mgr.ModifyCacheParameterGroup(r.Context(), name, parseParameterNameValues(r.Form)); err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -264,6 +294,97 @@ func (h *Handler) modifyCacheParameterGroup(w http.ResponseWriter, r *http.Reque
 		Name:     name,
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
+}
+
+func (h *Handler) resetCacheParameterGroup(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.paramGroups()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "cache parameter groups not supported"))
+		return
+	}
+
+	name := r.Form.Get("CacheParameterGroupName")
+	resetAll := strings.EqualFold(r.Form.Get("ResetAllParameters"), "true")
+
+	updates := parseParameterNameValues(r.Form)
+
+	names := make([]string, 0, len(updates))
+	for _, u := range updates {
+		names = append(names, u.Name)
+	}
+
+	if err := mgr.ResetCacheParameterGroup(r.Context(), name, resetAll, names); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, resetCacheParameterGroupResponse{
+		Xmlns:    Namespace,
+		Name:     name,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) describeCacheParameters(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.paramGroups()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "cache parameter groups not supported"))
+		return
+	}
+
+	params, err := mgr.DescribeCacheParameters(r.Context(),
+		r.Form.Get("CacheParameterGroupName"), r.Form.Get("Source"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]parameterXML, 0, len(params))
+	for i := range params {
+		out = append(out, parameterXML{
+			ParameterName:        params[i].Name,
+			ParameterValue:       params[i].Value,
+			Description:          params[i].Description,
+			Source:               params[i].Source,
+			DataType:             params[i].DataType,
+			AllowedValues:        params[i].AllowedValues,
+			IsModifiable:         params[i].IsModifiable,
+			MinimumEngineVersion: params[i].MinimumEngineVersion,
+		})
+	}
+
+	awsquery.WriteXMLResponse(w, describeCacheParametersResponse{
+		Xmlns:      Namespace,
+		Parameters: out,
+		Metadata:   responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// parseParameterNameValues parses the ParameterNameValues.ParameterNameValue.N
+// list (each with a ParameterName and optional ParameterValue) shared by
+// ModifyCacheParameterGroup and ResetCacheParameterGroup.
+func parseParameterNameValues(form url.Values) []ecprovider.ParameterUpdate {
+	const prefix = "ParameterNameValues.ParameterNameValue"
+
+	indices := awsquery.CollectIndices(form, prefix)
+	if len(indices) == 0 {
+		return nil
+	}
+
+	out := make([]ecprovider.ParameterUpdate, 0, len(indices))
+
+	for _, idx := range indices {
+		base := prefix + "." + strconv.Itoa(idx)
+
+		name := form.Get(base + ".ParameterName")
+		if name == "" {
+			continue
+		}
+
+		out = append(out, ecprovider.ParameterUpdate{Name: name, Value: form.Get(base + ".ParameterValue")})
+	}
+
+	return out
 }
 
 func (h *Handler) deleteCacheParameterGroup(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What

Implements the **contents** of AWS ElastiCache cache parameter groups so
`aws_elasticache_parameter_group` with `parameter { name=… value=… }` blocks
works end-to-end.

- **DescribeCacheParameters** — previously unimplemented (fell through to the EC2
  catch-all → `InvalidAction`). Now returns a group's parameter list: engine-family
  defaults with any user overrides applied. Supports the `Source` filter
  (`user` / `system` / `engine-default`). A missing group returns
  `CacheParameterGroupNotFound`.
- **ModifyCacheParameterGroup** — previously ignored `ParameterNameValues` (no-op
  beyond existence check). Now parses `ParameterNameValues.ParameterNameValue.N`
  and applies each name→value (Source becomes `user`), reflected on the next
  DescribeCacheParameters. Unknown / non-modifiable parameter name →
  `InvalidParameterValue`.
- **ResetCacheParameterGroup** — newly dispatched. `ResetAllParameters=true` clears
  all overrides; a named list resets only those parameters back to their engine
  default (Source → `system`).
- Each parameter group now carries a per-family default parameter set (curated,
  not the full real hundreds) for `redis*` and `memcached*` families, including the
  parameters commonly set via Terraform (notably `maxmemory-policy` for Redis).
  Each parameter exposes ParameterName / ParameterValue / Source / DataType /
  AllowedValues / IsModifiable / MinimumEngineVersion / Description.

## Why

Deferred real-Terraform-breaker from the AWS deep-e2e audit (elasticache finding
#8). `aws_elasticache_parameter_group` with any non-empty `parameter {}` block
calls DescribeCacheParameters on refresh — which failed with `InvalidAction` — and
applied parameters never persisted. End-to-end broken for any non-empty parameter
group; now converges.

## Layers

- Driver interface (`services/cache/driver`) is **unchanged** — parameter groups are
  an AWS-only surface asserted via the wire handler's `parameterGroupManager`
  interface, so coverage docs are unaffected (no regeneration).
- Provider (`providers/aws/elasticache/parameters.go`): default parameter sets +
  per-group override store + the three ops.
- Wire (`server/aws/elasticache`): dispatch for DescribeCacheParameters /
  ResetCacheParameterGroup, ParameterNameValues parsing, XML response shapes.

## Tests

Real `aws-sdk-go-v2/service/elasticache` round-trips plus provider-level tests:
default list non-empty (incl. maxmemory-policy=volatile-lru, Source=system),
Modify applies `maxmemory-policy=allkeys-lru` with Source=user, unknown param →
InvalidParameterValue, missing group → CacheParameterGroupNotFound, Source filter,
ResetAllParameters and named reset. Existing ElastiCache tests (#516/#468/#677) stay
green.

## Notes

ResetCacheParameterGroup was implemented (not deferred) as it was low-risk given the
override-store model. Node-type-specific parameters (`CacheNodeTypeSpecificParameters`)
are returned empty, matching a simple single-node emulator.
