### PR TITLE
feat(aws-route53): private hosted zone VPC association (Associate/Disassociate/CreateHostedZone VPC)

### DIFF
--- a/providers/aws/route53/route53.go
+++ b/providers/aws/route53/route53.go
@@ -134,6 +134,7 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 		Tags:            tags,
 		CallerReference: cfg.CallerReference,
 		Comment:         cfg.Comment,
+		VPCs:            copyVPCs(cfg.VPCs),
 		Scope:           cfg.Scope,
 	}
 
@@ -170,6 +171,7 @@ func (m *Mock) GetZone(_ context.Context, id string) (*driver.ZoneInfo, error) {
 	}
 
 	result := zone
+	result.VPCs = copyVPCs(zone.VPCs)
 
 	return &result, nil
 }
@@ -227,6 +229,78 @@ func (m *Mock) UpdateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 	result := updated
 
 	return &result, nil
+}
+
+// AssociateVPC adds an Amazon VPC to a private hosted zone's association list.
+// It is idempotent: associating an already-associated VPC is a no-op. Caller
+// validation (the zone must be private) is done at the wire layer, which has
+// the zone's Private flag from GetZone. This is the AWS-only private-hosted-zone
+// VPC-association extension; other DNS providers don't implement it.
+func (m *Mock) AssociateVPC(_ context.Context, zoneID string, vpc driver.VPCAssociation) error {
+	if _, ok := m.zones.Get(zoneID); !ok {
+		return errors.Newf(errors.NotFound, "zone %q not found", zoneID)
+	}
+
+	m.zones.Update(zoneID, func(z driver.ZoneInfo) driver.ZoneInfo {
+		if containsVPCAssoc(z.VPCs, vpc) {
+			return z
+		}
+
+		z.VPCs = append(copyVPCs(z.VPCs), vpc)
+
+		return z
+	})
+
+	return nil
+}
+
+// containsVPCAssoc reports whether a VPC-association list already holds vpc.
+func containsVPCAssoc(vpcs []driver.VPCAssociation, vpc driver.VPCAssociation) bool {
+	for _, v := range vpcs {
+		if v == vpc {
+			return true
+		}
+	}
+
+	return false
+}
+
+// DisassociateVPC removes an Amazon VPC from a private hosted zone's association
+// list. Caller validation (the VPC must be associated and must not be the last
+// one) is done at the wire layer from the zone's VPCs returned by GetZone.
+func (m *Mock) DisassociateVPC(_ context.Context, zoneID string, vpc driver.VPCAssociation) error {
+	if _, ok := m.zones.Get(zoneID); !ok {
+		return errors.Newf(errors.NotFound, "zone %q not found", zoneID)
+	}
+
+	m.zones.Update(zoneID, func(z driver.ZoneInfo) driver.ZoneInfo {
+		kept := make([]driver.VPCAssociation, 0, len(z.VPCs))
+
+		for _, v := range z.VPCs {
+			if v != vpc {
+				kept = append(kept, v)
+			}
+		}
+
+		z.VPCs = kept
+
+		return z
+	})
+
+	return nil
+}
+
+// copyVPCs returns a detached copy of a VPC-association slice so a stored zone
+// never aliases caller memory (and vice versa).
+func copyVPCs(vpcs []driver.VPCAssociation) []driver.VPCAssociation {
+	if len(vpcs) == 0 {
+		return nil
+	}
+
+	out := make([]driver.VPCAssociation, len(vpcs))
+	copy(out, vpcs)
+
+	return out
 }
 
 // CreateRecord creates a new DNS record in the specified zone.

--- a/providers/aws/route53/vpc_association_test.go
+++ b/providers/aws/route53/vpc_association_test.go
@@ -1,0 +1,87 @@
+package route53
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+)
+
+// TestCreateZoneWithVPCs proves create-time VPC associations are stored and
+// returned on GetZone, detached from the caller's slice.
+func TestCreateZoneWithVPCs(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	vpcs := []driver.VPCAssociation{{VPCID: "vpc-1", VPCRegion: "us-east-1"}}
+
+	info, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "internal.com", Private: true, VPCs: vpcs})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(info.VPCs))
+
+	// Mutating the caller's slice must not reach the store.
+	vpcs[0].VPCID = "mutated"
+
+	got, err := m.GetZone(ctx, info.ID)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(got.VPCs))
+	assertEqual(t, "vpc-1", got.VPCs[0].VPCID)
+}
+
+// TestAssociateVPCIdempotent proves associating adds a VPC and is a no-op when
+// the VPC is already associated.
+func TestAssociateVPCIdempotent(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	info, err := m.CreateZone(ctx, driver.ZoneConfig{
+		Name:    "internal.com",
+		Private: true,
+		VPCs:    []driver.VPCAssociation{{VPCID: "vpc-1", VPCRegion: "us-east-1"}},
+	})
+	requireNoError(t, err)
+
+	requireNoError(t, m.AssociateVPC(ctx, info.ID, driver.VPCAssociation{VPCID: "vpc-2", VPCRegion: "us-east-1"}))
+
+	got, err := m.GetZone(ctx, info.ID)
+	requireNoError(t, err)
+	assertEqual(t, 2, len(got.VPCs))
+
+	// Re-associating vpc-2 is idempotent.
+	requireNoError(t, m.AssociateVPC(ctx, info.ID, driver.VPCAssociation{VPCID: "vpc-2", VPCRegion: "us-east-1"}))
+
+	got, err = m.GetZone(ctx, info.ID)
+	requireNoError(t, err)
+	assertEqual(t, 2, len(got.VPCs))
+}
+
+// TestDisassociateVPC proves disassociating removes exactly the requested VPC.
+func TestDisassociateVPC(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	info, err := m.CreateZone(ctx, driver.ZoneConfig{
+		Name:    "internal.com",
+		Private: true,
+		VPCs: []driver.VPCAssociation{
+			{VPCID: "vpc-1", VPCRegion: "us-east-1"},
+			{VPCID: "vpc-2", VPCRegion: "us-east-1"},
+		},
+	})
+	requireNoError(t, err)
+
+	requireNoError(t, m.DisassociateVPC(ctx, info.ID, driver.VPCAssociation{VPCID: "vpc-1", VPCRegion: "us-east-1"}))
+
+	got, err := m.GetZone(ctx, info.ID)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(got.VPCs))
+	assertEqual(t, "vpc-2", got.VPCs[0].VPCID)
+}
+
+// TestAssociateVPCMissingZone proves a missing zone is a NotFound.
+func TestAssociateVPCMissingZone(t *testing.T) {
+	m := newTestMock()
+
+	err := m.AssociateVPC(context.Background(), "ZNONE", driver.VPCAssociation{VPCID: "vpc-1", VPCRegion: "us-east-1"})
+	assertError(t, err, true)
+}

--- a/server/aws/route53/handler.go
+++ b/server/aws/route53/handler.go
@@ -33,11 +33,18 @@ const tagsPrefix = "/2013-04-01/tags/"
 
 const rrsetSeg = "rrset"
 
+// Sub-resource path segments under /hostedzone/{id}.
+const (
+	associateVPCSeg    = "associatevpc"
+	disassociateVPCSeg = "disassociatevpc"
+)
+
 // Additional Route 53 REST roots handled by this dispatcher.
 const (
 	changePrefix          = "/2013-04-01/change/"
 	hostedZoneCountPath   = "/2013-04-01/hostedzonecount"
 	hostedZonesByNamePath = "/2013-04-01/hostedzonesbyname"
+	hostedZonesByVPCPath  = "/2013-04-01/hostedzonesbyvpc"
 	testDNSAnswerPath     = "/2013-04-01/testdnsanswer"
 )
 
@@ -63,6 +70,7 @@ func (*Handler) Matches(r *http.Request) bool {
 		strings.HasPrefix(r.URL.Path, changePrefix) ||
 		r.URL.Path == hostedZoneCountPath ||
 		r.URL.Path == hostedZonesByNamePath ||
+		r.URL.Path == hostedZonesByVPCPath ||
 		r.URL.Path == testDNSAnswerPath
 }
 
@@ -90,31 +98,62 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case hostedZonesByNamePath:
 		h.listHostedZonesByName(w, r)
 		return
+	case hostedZonesByVPCPath:
+		h.listHostedZonesByVPC(w, r)
+		return
 	case testDNSAnswerPath:
 		h.testDNSAnswer(w, r)
 		return
 	}
 
+	h.serveHostedZonePath(w, r)
+}
+
+// serveHostedZonePath dispatches the /hostedzone[/{id}[/sub]] path space:
+// the collection, a single zone, and the rrset / associatevpc / disassociatevpc
+// sub-resources.
+func (h *Handler) serveHostedZonePath(w http.ResponseWriter, r *http.Request) {
 	tail := strings.Trim(strings.TrimPrefix(r.URL.Path, pathPrefix), "/")
 	if tail == "" {
 		h.serveZoneCollection(w, r)
 		return
 	}
 
-	// tail is "{id}" or "{id}/rrset".
+	// tail is "{id}" or "{id}/{sub}".
 	id, sub, _ := strings.Cut(tail, "/")
 
-	if sub == rrsetSeg {
+	switch sub {
+	case "":
+		h.serveZone(w, r, id)
+	case rrsetSeg:
 		h.serveRRSet(w, r, id)
-		return
-	}
-
-	if sub != "" {
+	case associateVPCSeg:
+		h.serveAssociateVPC(w, r, id)
+	case disassociateVPCSeg:
+		h.serveDisassociateVPC(w, r, id)
+	default:
 		writeError(w, http.StatusNotFound, "NoSuchHostedZone", "unrecognized Route 53 path")
+	}
+}
+
+// serveAssociateVPC dispatches POST /hostedzone/{id}/associatevpc.
+func (h *Handler) serveAssociateVPC(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
 		return
 	}
 
-	h.serveZone(w, r, id)
+	h.associateVPCWithHostedZone(w, r, id)
+}
+
+// serveDisassociateVPC dispatches POST /hostedzone/{id}/disassociatevpc.
+func (h *Handler) serveDisassociateVPC(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	h.disassociateVPCFromHostedZone(w, r, id)
 }
 
 // serveZoneCollection dispatches /hostedzone collection requests.

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -40,6 +40,14 @@ func (h *Handler) createHostedZone(w http.ResponseWriter, r *http.Request) {
 		cfg.Comment = req.HostedZoneConfig.Comment
 	}
 
+	// A VPC in the request associates the new zone with that VPC and makes it a
+	// private hosted zone — the presence of a VPC implies PrivateZone whether or
+	// not HostedZoneConfig said so.
+	if req.VPC != nil {
+		cfg.Private = true
+		cfg.VPCs = []dnsdriver.VPCAssociation{{VPCID: req.VPC.VPCId, VPCRegion: req.VPC.VPCRegion}}
+	}
+
 	info, err := h.dns.CreateZone(r.Context(), cfg)
 	if err != nil {
 		writeErr(w, err)
@@ -62,12 +70,19 @@ func (h *Handler) createHostedZone(w http.ResponseWriter, r *http.Request) {
 	// Real Route 53 returns a Location header pointing at the new zone.
 	w.Header().Set("Location", pathPrefix+"/"+info.ID)
 
-	wire.WriteXML(w, http.StatusCreated, createHostedZoneResponse{
+	resp := createHostedZoneResponse{
 		Xmlns:         xmlns,
 		HostedZone:    hz,
 		ChangeInfo:    newChangeInfo(),
 		DelegationSet: delegationSetXML{NameServers: nameServers},
-	})
+	}
+
+	// A private zone created with a VPC echoes that VPC back at the top level.
+	if req.VPC != nil {
+		resp.VPC = &vpcXML{VPCRegion: req.VPC.VPCRegion, VPCId: req.VPC.VPCId}
+	}
+
+	wire.WriteXML(w, http.StatusCreated, resp)
 }
 
 // seedZoneRecords creates the SOA and NS records a new hosted zone is born with.
@@ -95,6 +110,7 @@ func (h *Handler) getHostedZone(w http.ResponseWriter, r *http.Request, id strin
 		Xmlns:         xmlns,
 		HostedZone:    toHostedZoneXML(info),
 		DelegationSet: delegationSetXML{NameServers: nameServersFor(info.ID)},
+		VPCs:          toVPCsXML(info.VPCs),
 	})
 }
 

--- a/server/aws/route53/types.go
+++ b/server/aws/route53/types.go
@@ -59,6 +59,13 @@ type resourceRecordSetXML struct {
 	AliasTarget      *aliasTargetXML     `xml:"AliasTarget,omitempty"`
 }
 
+// vpcXML is the Route 53 VPC element identifying an Amazon VPC associated with a
+// private hosted zone.
+type vpcXML struct {
+	VPCRegion string `xml:"VPCRegion"`
+	VPCId     string `xml:"VPCId"`
+}
+
 // --- hosted zone elements ---
 
 type hostedZoneConfigXML struct {
@@ -96,6 +103,21 @@ type createHostedZoneRequest struct {
 	Name             string               `xml:"Name"`
 	CallerReference  string               `xml:"CallerReference"`
 	HostedZoneConfig *hostedZoneConfigXML `xml:"HostedZoneConfig"`
+	VPC              *vpcXML              `xml:"VPC"`
+}
+
+// associateVPCRequest is the AssociateVPCWithHostedZone request body.
+type associateVPCRequest struct {
+	XMLName xml.Name `xml:"AssociateVPCWithHostedZoneRequest"`
+	Comment string   `xml:"Comment"`
+	VPC     vpcXML   `xml:"VPC"`
+}
+
+// disassociateVPCRequest is the DisassociateVPCFromHostedZone request body.
+type disassociateVPCRequest struct {
+	XMLName xml.Name `xml:"DisassociateVPCFromHostedZoneRequest"`
+	Comment string   `xml:"Comment"`
+	VPC     vpcXML   `xml:"VPC"`
 }
 
 type changeResourceRecordSetsRequest struct {
@@ -121,6 +143,8 @@ type createHostedZoneResponse struct {
 	HostedZone    hostedZoneXML    `xml:"HostedZone"`
 	ChangeInfo    changeInfoXML    `xml:"ChangeInfo"`
 	DelegationSet delegationSetXML `xml:"DelegationSet"`
+	// VPC is returned only for a private hosted zone created with a VPC.
+	VPC *vpcXML `xml:"VPC,omitempty"`
 }
 
 type getHostedZoneResponse struct {
@@ -128,6 +152,45 @@ type getHostedZoneResponse struct {
 	Xmlns         string           `xml:"xmlns,attr"`
 	HostedZone    hostedZoneXML    `xml:"HostedZone"`
 	DelegationSet delegationSetXML `xml:"DelegationSet"`
+	// VPCs lists the Amazon VPCs a private hosted zone is associated with; empty
+	// for a public zone.
+	VPCs []vpcXML `xml:"VPCs>VPC,omitempty"`
+}
+
+// associateVPCResponse / disassociateVPCResponse each carry the ChangeInfo the
+// SDK returns from an (Dis)AssociateVPCWithHostedZone call.
+type associateVPCResponse struct {
+	XMLName    xml.Name      `xml:"AssociateVPCWithHostedZoneResponse"`
+	Xmlns      string        `xml:"xmlns,attr"`
+	ChangeInfo changeInfoXML `xml:"ChangeInfo"`
+}
+
+type disassociateVPCResponse struct {
+	XMLName    xml.Name      `xml:"DisassociateVPCFromHostedZoneResponse"`
+	Xmlns      string        `xml:"xmlns,attr"`
+	ChangeInfo changeInfoXML `xml:"ChangeInfo"`
+}
+
+// hostedZoneOwnerXML identifies who owns a hosted zone in a ListHostedZonesByVPC
+// summary. Zones created through this API are owned by the account.
+type hostedZoneOwnerXML struct {
+	OwningAccount string `xml:"OwningAccount,omitempty"`
+	OwningService string `xml:"OwningService,omitempty"`
+}
+
+// hostedZoneSummaryXML is one entry in a ListHostedZonesByVPC response.
+type hostedZoneSummaryXML struct {
+	HostedZoneId string             `xml:"HostedZoneId"`
+	Name         string             `xml:"Name"`
+	Owner        hostedZoneOwnerXML `xml:"Owner"`
+}
+
+type listHostedZonesByVPCResponse struct {
+	XMLName             xml.Name               `xml:"ListHostedZonesByVPCResponse"`
+	Xmlns               string                 `xml:"xmlns,attr"`
+	HostedZoneSummaries []hostedZoneSummaryXML `xml:"HostedZoneSummaries>HostedZoneSummary"`
+	MaxItems            string                 `xml:"MaxItems"`
+	NextToken           string                 `xml:"NextToken,omitempty"`
 }
 
 type getChangeResponse struct {
@@ -229,6 +292,21 @@ func toHostedZoneXML(info *dnsdriver.ZoneInfo) hostedZoneXML {
 		},
 		ResourceRecordSetCount: int64(info.RecordCount),
 	}
+}
+
+// toVPCsXML converts a zone's driver VPC associations into their Route 53 VPC
+// elements, or nil when the zone has none (a public zone).
+func toVPCsXML(vpcs []dnsdriver.VPCAssociation) []vpcXML {
+	if len(vpcs) == 0 {
+		return nil
+	}
+
+	out := make([]vpcXML, 0, len(vpcs))
+	for _, v := range vpcs {
+		out = append(out, vpcXML{VPCRegion: v.VPCRegion, VPCId: v.VPCID})
+	}
+
+	return out
 }
 
 // toRecordSetXML converts a driver record into its Route 53 element. An alias

--- a/server/aws/route53/vpc.go
+++ b/server/aws/route53/vpc.go
@@ -1,0 +1,188 @@
+package route53
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+)
+
+// defaultOwningAccount is the account id reported as the owner of a private
+// hosted zone in ListHostedZonesByVPC — cloudemu's single default account.
+const defaultOwningAccount = "123456789012"
+
+// vpcAssociator is the AWS-only extension a Route 53 backend implements to
+// associate and disassociate Amazon VPCs with a private hosted zone. The wire
+// layer does all the state-dependent validation (zone privacy, last-VPC,
+// not-associated) from the zone returned by GetZone, so these mutators just
+// add or remove one association idempotently. Backends without it (Azure/GCP
+// DNS) don't support the private-hosted-zone VPC association API.
+type vpcAssociator interface {
+	AssociateVPC(ctx context.Context, zoneID string, vpc dnsdriver.VPCAssociation) error
+	DisassociateVPC(ctx context.Context, zoneID string, vpc dnsdriver.VPCAssociation) error
+}
+
+// containsVPC reports whether a zone's association list already holds vpc.
+func containsVPC(vpcs []dnsdriver.VPCAssociation, vpc dnsdriver.VPCAssociation) bool {
+	for _, v := range vpcs {
+		if v == vpc {
+			return true
+		}
+	}
+
+	return false
+}
+
+// associateVPCWithHostedZone answers AssociateVPCWithHostedZone: it adds a VPC
+// to a private hosted zone's association list. Real Route 53 rejects a public
+// zone (PublicZoneVPCAssociation) and a missing zone (NoSuchHostedZone), and is
+// idempotent for an already-associated VPC.
+func (h *Handler) associateVPCWithHostedZone(w http.ResponseWriter, r *http.Request, id string) {
+	assoc, ok := h.dns.(vpcAssociator)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "InvalidInput", "VPC association is not supported")
+		return
+	}
+
+	var req associateVPCRequest
+	if !decodeXML(w, r, &req) {
+		return
+	}
+
+	zoneID := trimZonePrefix(id)
+
+	zone, err := h.dns.GetZone(r.Context(), zoneID)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if !zone.Private {
+		writeError(w, http.StatusBadRequest, "PublicZoneVPCAssociation",
+			"You're trying to associate a VPC with a public hosted zone. "+
+				"Amazon Route 53 doesn't support associating a VPC with a public hosted zone.")
+
+		return
+	}
+
+	vpc := dnsdriver.VPCAssociation{VPCID: req.VPC.VPCId, VPCRegion: req.VPC.VPCRegion}
+
+	if err := assoc.AssociateVPC(r.Context(), zoneID, vpc); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteXML(w, http.StatusOK, associateVPCResponse{
+		Xmlns:      xmlns,
+		ChangeInfo: newChangeInfo(),
+	})
+}
+
+// disassociateVPCFromHostedZone answers DisassociateVPCFromHostedZone: it removes
+// a VPC from a private hosted zone. Real Route 53 rejects removing a VPC that
+// isn't associated (VPCAssociationNotFound) and removing the last VPC of a zone
+// (LastVPCAssociation).
+func (h *Handler) disassociateVPCFromHostedZone(w http.ResponseWriter, r *http.Request, id string) {
+	assoc, ok := h.dns.(vpcAssociator)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "InvalidInput", "VPC association is not supported")
+		return
+	}
+
+	var req disassociateVPCRequest
+	if !decodeXML(w, r, &req) {
+		return
+	}
+
+	zoneID := trimZonePrefix(id)
+
+	zone, err := h.dns.GetZone(r.Context(), zoneID)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	vpc := dnsdriver.VPCAssociation{VPCID: req.VPC.VPCId, VPCRegion: req.VPC.VPCRegion}
+
+	if !containsVPC(zone.VPCs, vpc) {
+		writeError(w, http.StatusNotFound, "VPCAssociationNotFound",
+			"The specified VPC and hosted zone are not currently associated.")
+
+		return
+	}
+
+	if len(zone.VPCs) == 1 {
+		writeError(w, http.StatusBadRequest, "LastVPCAssociation",
+			"The VPC that you're trying to disassociate from the private hosted zone is the last VPC "+
+				"that is associated with the hosted zone. Amazon Route 53 doesn't support disassociating "+
+				"the last VPC from a hosted zone.")
+
+		return
+	}
+
+	if err := assoc.DisassociateVPC(r.Context(), zoneID, vpc); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteXML(w, http.StatusOK, disassociateVPCResponse{
+		Xmlns:      xmlns,
+		ChangeInfo: newChangeInfo(),
+	})
+}
+
+// listHostedZonesByVPC answers ListHostedZonesByVPC, returning the private hosted
+// zones associated with the requested VPC. vpcid and vpcregion are required.
+func (h *Handler) listHostedZonesByVPC(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	q := r.URL.Query()
+	vpcID := q.Get("vpcid")
+	vpcRegion := q.Get("vpcregion")
+
+	if vpcID == "" || vpcRegion == "" {
+		writeError(w, http.StatusBadRequest, "InvalidInput", "vpcid and vpcregion are required")
+		return
+	}
+
+	infos, err := h.dns.ListZones(r.Context(), scope.Scope{})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	want := dnsdriver.VPCAssociation{VPCID: vpcID, VPCRegion: vpcRegion}
+	summaries := make([]hostedZoneSummaryXML, 0)
+
+	for i := range infos {
+		if !containsVPC(infos[i].VPCs, want) {
+			continue
+		}
+
+		summaries = append(summaries, hostedZoneSummaryXML{
+			HostedZoneId: infos[i].ID,
+			Name:         infos[i].Name,
+			Owner:        hostedZoneOwnerXML{OwningAccount: defaultOwningAccount},
+		})
+	}
+
+	maxItems := listMaxItems
+
+	if v := q.Get("maxitems"); v != "" {
+		if n, cerr := strconv.Atoi(v); cerr == nil && n > 0 {
+			maxItems = n
+		}
+	}
+
+	wire.WriteXML(w, http.StatusOK, listHostedZonesByVPCResponse{
+		Xmlns:               xmlns,
+		HostedZoneSummaries: summaries,
+		MaxItems:            strconv.Itoa(maxItems),
+	})
+}

--- a/server/aws/route53/vpc_association_test.go
+++ b/server/aws/route53/vpc_association_test.go
@@ -1,0 +1,276 @@
+package route53_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+// createPrivateZone creates a private hosted zone associated with one VPC and
+// returns its id.
+func createPrivateZone(t *testing.T, client *awsr53.Client, name, ref, vpcID string) string {
+	t.Helper()
+
+	out, err := client.CreateHostedZone(context.Background(), &awsr53.CreateHostedZoneInput{
+		Name:            aws.String(name),
+		CallerReference: aws.String(ref),
+		VPC: &r53types.VPC{
+			VPCId:     aws.String(vpcID),
+			VPCRegion: r53types.VPCRegionUsEast1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone(%s): %v", name, err)
+	}
+
+	return aws.ToString(out.HostedZone.Id)
+}
+
+// TestSDKCreateHostedZoneWithVPC proves a zone created with a VPC is private,
+// echoes the VPC on create, and GetHostedZone returns PrivateZone + the VPC.
+func TestSDKCreateHostedZoneWithVPC(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	out, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("private.internal."),
+		CallerReference: aws.String("pz-ref"),
+		VPC: &r53types.VPC{
+			VPCId:     aws.String("vpc-aaaa1111"),
+			VPCRegion: r53types.VPCRegionUsEast1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+
+	if out.HostedZone.Config == nil || !out.HostedZone.Config.PrivateZone {
+		t.Fatalf("Config = %+v, want PrivateZone=true", out.HostedZone.Config)
+	}
+
+	if out.VPC == nil || aws.ToString(out.VPC.VPCId) != "vpc-aaaa1111" {
+		t.Fatalf("create VPC = %+v, want vpc-aaaa1111", out.VPC)
+	}
+
+	id := aws.ToString(out.HostedZone.Id)
+
+	got, err := client.GetHostedZone(ctx, &awsr53.GetHostedZoneInput{Id: aws.String(id)})
+	if err != nil {
+		t.Fatalf("GetHostedZone: %v", err)
+	}
+
+	if got.HostedZone.Config == nil || !got.HostedZone.Config.PrivateZone {
+		t.Errorf("GetHostedZone Config = %+v, want PrivateZone=true", got.HostedZone.Config)
+	}
+
+	if len(got.VPCs) != 1 || aws.ToString(got.VPCs[0].VPCId) != "vpc-aaaa1111" {
+		t.Fatalf("GetHostedZone VPCs = %+v, want [vpc-aaaa1111]", got.VPCs)
+	}
+
+	if got.VPCs[0].VPCRegion != r53types.VPCRegionUsEast1 {
+		t.Errorf("VPCRegion = %q, want us-east-1", got.VPCs[0].VPCRegion)
+	}
+}
+
+// TestSDKAssociateVPCWithHostedZone proves a second VPC can be associated and
+// GetHostedZone then lists both, with a ChangeInfo returned.
+func TestSDKAssociateVPCWithHostedZone(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	id := createPrivateZone(t, client, "assoc.internal.", "assoc-ref", "vpc-1111")
+
+	assoc, err := client.AssociateVPCWithHostedZone(ctx, &awsr53.AssociateVPCWithHostedZoneInput{
+		HostedZoneId: aws.String(id),
+		VPC: &r53types.VPC{
+			VPCId:     aws.String("vpc-2222"),
+			VPCRegion: r53types.VPCRegionUsEast1,
+		},
+		Comment: aws.String("add second vpc"),
+	})
+	if err != nil {
+		t.Fatalf("AssociateVPCWithHostedZone: %v", err)
+	}
+
+	if assoc.ChangeInfo == nil || assoc.ChangeInfo.Status != r53types.ChangeStatusInsync {
+		t.Fatalf("ChangeInfo = %+v, want INSYNC", assoc.ChangeInfo)
+	}
+
+	got, err := client.GetHostedZone(ctx, &awsr53.GetHostedZoneInput{Id: aws.String(id)})
+	if err != nil {
+		t.Fatalf("GetHostedZone: %v", err)
+	}
+
+	ids := map[string]bool{}
+	for _, v := range got.VPCs {
+		ids[aws.ToString(v.VPCId)] = true
+	}
+
+	if len(got.VPCs) != 2 || !ids["vpc-1111"] || !ids["vpc-2222"] {
+		t.Fatalf("GetHostedZone VPCs = %+v, want both vpc-1111 and vpc-2222", got.VPCs)
+	}
+}
+
+// TestSDKAssociateVPCIdempotent proves re-associating an already-associated VPC
+// succeeds without duplicating it.
+func TestSDKAssociateVPCIdempotent(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	id := createPrivateZone(t, client, "idem.internal.", "idem-ref", "vpc-1111")
+
+	if _, err := client.AssociateVPCWithHostedZone(ctx, &awsr53.AssociateVPCWithHostedZoneInput{
+		HostedZoneId: aws.String(id),
+		VPC:          &r53types.VPC{VPCId: aws.String("vpc-1111"), VPCRegion: r53types.VPCRegionUsEast1},
+	}); err != nil {
+		t.Fatalf("AssociateVPCWithHostedZone (idempotent): %v", err)
+	}
+
+	got, err := client.GetHostedZone(ctx, &awsr53.GetHostedZoneInput{Id: aws.String(id)})
+	if err != nil {
+		t.Fatalf("GetHostedZone: %v", err)
+	}
+
+	if len(got.VPCs) != 1 {
+		t.Fatalf("GetHostedZone VPCs = %+v, want exactly one (no duplicate)", got.VPCs)
+	}
+}
+
+// TestSDKDisassociateVPCFromHostedZone proves a VPC can be removed while the
+// others remain.
+func TestSDKDisassociateVPCFromHostedZone(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	id := createPrivateZone(t, client, "disassoc.internal.", "dis-ref", "vpc-1111")
+
+	if _, err := client.AssociateVPCWithHostedZone(ctx, &awsr53.AssociateVPCWithHostedZoneInput{
+		HostedZoneId: aws.String(id),
+		VPC:          &r53types.VPC{VPCId: aws.String("vpc-2222"), VPCRegion: r53types.VPCRegionUsEast1},
+	}); err != nil {
+		t.Fatalf("AssociateVPCWithHostedZone: %v", err)
+	}
+
+	dis, err := client.DisassociateVPCFromHostedZone(ctx, &awsr53.DisassociateVPCFromHostedZoneInput{
+		HostedZoneId: aws.String(id),
+		VPC:          &r53types.VPC{VPCId: aws.String("vpc-1111"), VPCRegion: r53types.VPCRegionUsEast1},
+	})
+	if err != nil {
+		t.Fatalf("DisassociateVPCFromHostedZone: %v", err)
+	}
+
+	if dis.ChangeInfo == nil || dis.ChangeInfo.Status != r53types.ChangeStatusInsync {
+		t.Fatalf("ChangeInfo = %+v, want INSYNC", dis.ChangeInfo)
+	}
+
+	got, err := client.GetHostedZone(ctx, &awsr53.GetHostedZoneInput{Id: aws.String(id)})
+	if err != nil {
+		t.Fatalf("GetHostedZone: %v", err)
+	}
+
+	if len(got.VPCs) != 1 || aws.ToString(got.VPCs[0].VPCId) != "vpc-2222" {
+		t.Fatalf("GetHostedZone VPCs = %+v, want only vpc-2222", got.VPCs)
+	}
+}
+
+// TestSDKDisassociateLastVPC proves removing the only VPC is rejected with
+// LastVPCAssociation, matching real Route 53.
+func TestSDKDisassociateLastVPC(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	id := createPrivateZone(t, client, "last.internal.", "last-ref", "vpc-1111")
+
+	_, err := client.DisassociateVPCFromHostedZone(ctx, &awsr53.DisassociateVPCFromHostedZoneInput{
+		HostedZoneId: aws.String(id),
+		VPC:          &r53types.VPC{VPCId: aws.String("vpc-1111"), VPCRegion: r53types.VPCRegionUsEast1},
+	})
+	if err == nil {
+		t.Fatal("DisassociateVPCFromHostedZone(last VPC) succeeded, want LastVPCAssociation error")
+	}
+
+	var last *r53types.LastVPCAssociation
+	if !errors.As(err, &last) {
+		t.Fatalf("error = %v, want *LastVPCAssociation", err)
+	}
+}
+
+// TestSDKDisassociateVPCNotAssociated proves removing a VPC that isn't
+// associated is rejected with VPCAssociationNotFound.
+func TestSDKDisassociateVPCNotAssociated(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	id := createPrivateZone(t, client, "notassoc.internal.", "na-ref", "vpc-1111")
+
+	_, err := client.DisassociateVPCFromHostedZone(ctx, &awsr53.DisassociateVPCFromHostedZoneInput{
+		HostedZoneId: aws.String(id),
+		VPC:          &r53types.VPC{VPCId: aws.String("vpc-9999"), VPCRegion: r53types.VPCRegionUsEast1},
+	})
+	if err == nil {
+		t.Fatal("DisassociateVPCFromHostedZone(unassociated VPC) succeeded, want VPCAssociationNotFound")
+	}
+
+	var notFound *r53types.VPCAssociationNotFound
+	if !errors.As(err, &notFound) {
+		t.Fatalf("error = %v, want *VPCAssociationNotFound", err)
+	}
+}
+
+// TestSDKAssociateVPCOnPublicZone proves associating a VPC with a public hosted
+// zone is rejected with PublicZoneVPCAssociation.
+func TestSDKAssociateVPCOnPublicZone(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	id := createZone(t, client, "public.example.", "pub-ref")
+
+	_, err := client.AssociateVPCWithHostedZone(ctx, &awsr53.AssociateVPCWithHostedZoneInput{
+		HostedZoneId: aws.String(id),
+		VPC:          &r53types.VPC{VPCId: aws.String("vpc-1111"), VPCRegion: r53types.VPCRegionUsEast1},
+	})
+	if err == nil {
+		t.Fatal("AssociateVPCWithHostedZone(public zone) succeeded, want PublicZoneVPCAssociation")
+	}
+
+	var pub *r53types.PublicZoneVPCAssociation
+	if !errors.As(err, &pub) {
+		t.Fatalf("error = %v, want *PublicZoneVPCAssociation", err)
+	}
+}
+
+// TestSDKListHostedZonesByVPC proves the private zones a VPC is associated with
+// are listed, and unassociated zones are excluded.
+func TestSDKListHostedZonesByVPC(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	shared := createPrivateZone(t, client, "shared.internal.", "shared-ref", "vpc-shared")
+	createPrivateZone(t, client, "other.internal.", "other-ref", "vpc-other")
+
+	out, err := client.ListHostedZonesByVPC(ctx, &awsr53.ListHostedZonesByVPCInput{
+		VPCId:     aws.String("vpc-shared"),
+		VPCRegion: r53types.VPCRegionUsEast1,
+	})
+	if err != nil {
+		t.Fatalf("ListHostedZonesByVPC: %v", err)
+	}
+
+	if len(out.HostedZoneSummaries) != 1 {
+		t.Fatalf("got %d summaries, want 1", len(out.HostedZoneSummaries))
+	}
+
+	if aws.ToString(out.HostedZoneSummaries[0].HostedZoneId) != shared {
+		t.Errorf("summary zone id = %q, want %q",
+			aws.ToString(out.HostedZoneSummaries[0].HostedZoneId), shared)
+	}
+
+	if out.HostedZoneSummaries[0].Owner == nil ||
+		aws.ToString(out.HostedZoneSummaries[0].Owner.OwningAccount) == "" {
+		t.Errorf("summary Owner = %+v, want an OwningAccount", out.HostedZoneSummaries[0].Owner)
+	}
+}

--- a/services/dns/driver/driver.go
+++ b/services/dns/driver/driver.go
@@ -7,6 +7,13 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
+// VPCAssociation identifies an Amazon VPC associated with an AWS Route 53
+// private hosted zone. Other providers leave it unused.
+type VPCAssociation struct {
+	VPCID     string
+	VPCRegion string
+}
+
 // ZoneConfig describes a DNS zone to create.
 type ZoneConfig struct {
 	Name    string
@@ -19,6 +26,10 @@ type ZoneConfig struct {
 	// Comment is the AWS Route 53 hosted-zone comment, persisted and returned on
 	// Create/Get. Other providers leave it empty.
 	Comment string
+	// VPCs are the Amazon VPCs a Route 53 private hosted zone is associated with
+	// at create time. A non-empty list marks the zone private. Other providers
+	// leave it nil.
+	VPCs []VPCAssociation
 	// Scope records the cloud-side container the zone was created in (Azure
 	// subscription/resource group or GCP project). The zero value is unscoped.
 	Scope scope.Scope
@@ -37,6 +48,9 @@ type ZoneInfo struct {
 	// Comment is the AWS Route 53 hosted-zone comment as stored on create. Other
 	// providers leave it empty.
 	Comment string
+	// VPCs are the Amazon VPCs a Route 53 private hosted zone is currently
+	// associated with. Other providers leave it nil.
+	VPCs []VPCAssociation
 	// Scope is the container the zone lives in; scoped list endpoints filter
 	// on it. The zero value is unscoped and visible everywhere.
 	Scope scope.Scope


### PR DESCRIPTION
## What

Implements AWS Route 53 private-hosted-zone VPC association — the real Terraform gap (`aws_route53_zone` with a `vpc {}` block, `aws_route53_zone_association`) deferred from the deep-e2e audit (finding F8).

- **CreateHostedZone with a `<VPC>` block** → the zone becomes PRIVATE (`Config.PrivateZone=true`) and is associated with that VPC. The create response echoes the `<VPC>` element; a zone created without a VPC stays public.
- **AssociateVPCWithHostedZone** (`POST /2013-04-01/hostedzone/{id}/associatevpc`) → adds the VPC to the private zone's association list and returns a `ChangeInfo` (INSYNC). Idempotent for an already-associated VPC. A public zone is rejected with `PublicZoneVPCAssociation`.
- **DisassociateVPCFromHostedZone** (`POST .../disassociatevpc`) → removes the VPC. Removing a VPC that isn't associated → `VPCAssociationNotFound`; removing the last VPC → `LastVPCAssociation`.
- **GetHostedZone** → emits the `<VPCs>` list for a private zone (empty for a public zone).
- **ListHostedZonesByVPC** (`GET /2013-04-01/hostedzonesbyvpc?vpcid=&vpcregion=`) → returns the private zones a VPC is associated with, as `HostedZoneSummaries` with an `OwningAccount` owner.

## Why

Previously a POST to `{id}/associatevpc` fell through `serveZone` (GET/DELETE only) and returned `404 NoSuchHostedZone: unrecognized Route 53 path`, and the driver had no VPC storage — so private hosted zones and `aws_route53_zone_association` could not work against the emulator. All request/response shapes and error codes were cross-checked against the official Route 53 API reference (CreateHostedZone, AssociateVPCWithHostedZone, DisassociateVPCFromHostedZone, GetHostedZone, ListHostedZonesByVPC).

## Design (3-layer)

- **Driver** (`services/dns/driver`): new `VPCAssociation` type + `VPCs []VPCAssociation` on `ZoneConfig`/`ZoneInfo` (shared struct fields; Azure/GCP DNS leave them nil — zero-value pass-through, no re-implementation of their private-zone semantics). No new methods on the shared `driver.DNS` interface, so generated `docs/coverage` is unchanged (`go generate` is a no-op).
- **Provider** (`providers/aws/route53`): `CreateZone` stores the VPCs; new `AssociateVPC`/`DisassociateVPC` mutators (idempotent add / exact remove, deep-copied to detach from caller memory).
- **Wire** (`server/aws/route53`): routes `associatevpc`/`disassociatevpc` POSTs and the `hostedzonesbyvpc` GET; all state-dependent validation (privacy, last-VPC, not-associated) is done at the wire layer from the zone returned by `GetZone`, via an AWS-only `vpcAssociator` extension interface (mirroring the existing `recordSetDeleter` pattern). `ServeHTTP` tail dispatch extracted into a helper to keep complexity in check.

The existing zone CRUD and the #674 correctness fixes are untouched; existing route53 + topology tests stay green.

## Tests

Real `aws-sdk-go-v2/service/route53` reproductions: create-with-VPC → private + VPC on Get; associate second VPC → both listed + ChangeInfo; disassociate one → removed; disassociate last → `LastVPCAssociation`; disassociate unassociated → `VPCAssociationNotFound`; associate on a public zone → `PublicZoneVPCAssociation`; idempotent re-associate; `ListHostedZonesByVPC` filtering. Plus provider-level unit tests for store/idempotency/deep-copy.
