### PR TITLE
fix(aws-cloudtrail): default event selector on fresh trail; ListTags ARN validation; basic-selector defaults

### DIFF
--- a/providers/aws/cloudtrail/cloudtrail.go
+++ b/providers/aws/cloudtrail/cloudtrail.go
@@ -36,6 +36,7 @@ const (
 	maxEventSizeStd   = "Standard"
 	arnPrefix         = "arn"
 	serviceName       = "cloudtrail"
+	readWriteAll      = "All"
 )
 
 // trailData is a trail plus its logging status, selectors, and lock.

--- a/providers/aws/cloudtrail/cloudtrail_test.go
+++ b/providers/aws/cloudtrail/cloudtrail_test.go
@@ -246,6 +246,100 @@ func TestEventSelectorsMutualExclusion(t *testing.T) {
 	assert.Equal(t, "WriteOnly", gotSel[0].ReadWriteType)
 }
 
+// TestGetEventSelectorsDefaultOnFreshTrail asserts a trail created without
+// explicit selectors reports CloudTrail's implicit default management selector
+// (ReadWriteType "All", IncludeManagementEvents true), and that an explicit
+// PutEventSelectors then overrides it.
+func TestGetEventSelectorsDefaultOnFreshTrail(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	_, err := m.CreateTrail(ctx, driver.CreateTrailInput{Name: "fresh-trail", S3BucketName: "b"})
+	require.NoError(t, err)
+
+	_, sel, adv, err := m.GetEventSelectors(ctx, "fresh-trail")
+	require.NoError(t, err)
+	assert.Empty(t, adv)
+	require.Len(t, sel, 1)
+	assert.Equal(t, "All", sel[0].ReadWriteType)
+	require.NotNil(t, sel[0].IncludeManagementEvents)
+	assert.True(t, *sel[0].IncludeManagementEvents)
+	assert.Empty(t, sel[0].DataResources)
+
+	// The default selector is not "custom".
+	tr, err := m.GetTrail(ctx, "fresh-trail")
+	require.NoError(t, err)
+	assert.False(t, tr.HasCustomEventSelectors)
+
+	// An explicit put overrides the default.
+	_, _, _, err = m.PutEventSelectors(ctx, "fresh-trail",
+		[]driver.EventSelector{{ReadWriteType: "WriteOnly"}}, nil)
+	require.NoError(t, err)
+
+	_, sel, _, err = m.GetEventSelectors(ctx, "fresh-trail")
+	require.NoError(t, err)
+	require.Len(t, sel, 1)
+	assert.Equal(t, "WriteOnly", sel[0].ReadWriteType)
+}
+
+// TestPutEventSelectorsBasicDefaults asserts a basic selector with fields
+// omitted reads back with CloudTrail's defaults applied: ReadWriteType "All"
+// and IncludeManagementEvents true.
+func TestPutEventSelectorsBasicDefaults(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	_, err := m.CreateTrail(ctx, driver.CreateTrailInput{Name: "def-trail", S3BucketName: "b"})
+	require.NoError(t, err)
+
+	include := true
+	_, sel, _, err := m.PutEventSelectors(ctx, "def-trail",
+		[]driver.EventSelector{{IncludeManagementEvents: &include}}, nil)
+	require.NoError(t, err)
+	require.Len(t, sel, 1)
+	assert.Equal(t, "All", sel[0].ReadWriteType)
+
+	_, sel, _, err = m.GetEventSelectors(ctx, "def-trail")
+	require.NoError(t, err)
+	require.Len(t, sel, 1)
+	assert.Equal(t, "All", sel[0].ReadWriteType)
+	require.NotNil(t, sel[0].IncludeManagementEvents)
+	assert.True(t, *sel[0].IncludeManagementEvents)
+}
+
+// TestListTagsARNValidation asserts ListTags validates each resource ARN like
+// AddTags/RemoveTags: malformed → CloudTrailARNInvalidException, well-formed
+// but absent → ResourceNotFoundException, valid trail ARN → its tags.
+func TestListTagsARNValidation(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	tr, err := m.CreateTrail(ctx, driver.CreateTrailInput{
+		Name: "tag-trail", S3BucketName: "b", Tags: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	// Malformed ARN.
+	_, err = m.ListTags(ctx, []string{"not-an-arn"})
+	require.Error(t, err)
+	var apiErr *driver.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, driver.ExCloudTrailARNInvalid, apiErr.Exception)
+
+	// Well-formed but absent trail ARN.
+	absent := "arn:aws:cloudtrail:us-east-1:123456789012:trail/nope"
+	_, err = m.ListTags(ctx, []string{absent})
+	require.Error(t, err)
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, driver.ExResourceNotFound, apiErr.Exception)
+	assert.True(t, cerrors.IsNotFound(err))
+
+	// Valid trail ARN returns its tags.
+	tags, err := m.ListTags(ctx, []string{tr.TrailARN})
+	require.NoError(t, err)
+	assert.Equal(t, "prod", tags[tr.TrailARN]["env"])
+}
+
 // TestNoAliasOnReads asserts Get returns deep copies: mutating a returned
 // value's Tags map or nested selector slices must not affect stored state.
 func TestNoAliasOnReads(t *testing.T) {
@@ -585,10 +679,12 @@ func TestTagNonexistentResource(t *testing.T) {
 	require.ErrorAs(t, err, &apiErr)
 	assert.Equal(t, driver.ExResourceNotFound, apiErr.Exception)
 
-	// A phantom tag must not have been created.
-	tags, err := m.ListTags(ctx, []string{absent})
-	require.NoError(t, err)
-	assert.Empty(t, tags[absent])
+	// ListTags on the same absent-but-well-formed ARN is ResourceNotFoundException
+	// (no phantom tag was created, and the ARN is validated like AddTags).
+	_, err = m.ListTags(ctx, []string{absent})
+	require.Error(t, err)
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, driver.ExResourceNotFound, apiErr.Exception)
 
 	err = m.RemoveTags(ctx, absent, []string{"k"})
 	require.Error(t, err)

--- a/providers/aws/cloudtrail/selectors.go
+++ b/providers/aws/cloudtrail/selectors.go
@@ -24,11 +24,44 @@ func (m *Mock) PutEventSelectors(
 	td.mu.Lock()
 	defer td.mu.Unlock()
 
-	td.selors = copyEventSelectors(sel)
+	td.selors = normalizeEventSelectors(copyEventSelectors(sel))
 	td.advSel = copyAdvSelectors(adv)
 	td.trail.HasCustomEventSelectors = len(sel) > 0 || len(adv) > 0
 
 	return td.trail.TrailARN, copyEventSelectors(td.selors), copyAdvSelectors(td.advSel), nil
+}
+
+// normalizeEventSelectors applies CloudTrail's basic-selector field defaults:
+// an omitted ReadWriteType defaults to "All" and an omitted
+// IncludeManagementEvents defaults to true, so they read back the way AWS
+// stores them.
+func normalizeEventSelectors(sel []driver.EventSelector) []driver.EventSelector {
+	for i := range sel {
+		if sel[i].ReadWriteType == "" {
+			sel[i].ReadWriteType = readWriteAll
+		}
+
+		if sel[i].IncludeManagementEvents == nil {
+			include := true
+			sel[i].IncludeManagementEvents = &include
+		}
+	}
+
+	return sel
+}
+
+// defaultEventSelectors is the implicit selector CloudTrail reports for a trail
+// created without explicit selectors: one basic selector logging all read and
+// write management events, and no data events.
+func defaultEventSelectors() []driver.EventSelector {
+	include := true
+
+	return []driver.EventSelector{{
+		ReadWriteType:                 readWriteAll,
+		IncludeManagementEvents:       &include,
+		DataResources:                 []driver.DataResource{},
+		ExcludeManagementEventSources: []string{},
+	}}
 }
 
 // GetEventSelectors returns a trail's event selectors.
@@ -42,6 +75,12 @@ func (m *Mock) GetEventSelectors(
 
 	td.mu.RLock()
 	defer td.mu.RUnlock()
+
+	// A trail with no explicit selectors reports CloudTrail's implicit default:
+	// one basic selector logging all management events.
+	if len(td.selors) == 0 && len(td.advSel) == 0 {
+		return td.trail.TrailARN, defaultEventSelectors(), nil, nil
+	}
 
 	return td.trail.TrailARN, copyEventSelectors(td.selors), copyAdvSelectors(td.advSel), nil
 }

--- a/providers/aws/cloudtrail/tagging.go
+++ b/providers/aws/cloudtrail/tagging.go
@@ -115,8 +115,17 @@ func (m *Mock) RemoveTags(_ context.Context, resourceID string, tagKeys []string
 	return nil
 }
 
-// ListTags returns a copy of the tags for each requested resource ID.
+// ListTags returns a copy of the tags for each requested resource ID. Each ARN
+// is validated like AddTags/RemoveTags: a malformed ARN yields
+// CloudTrailARNInvalidException and a well-formed-but-absent ARN yields
+// ResourceNotFoundException.
 func (m *Mock) ListTags(_ context.Context, resourceIDs []string) (map[string]map[string]string, error) {
+	for _, id := range resourceIDs {
+		if err := m.resourceARNExists(id); err != nil {
+			return nil, err
+		}
+	}
+
 	m.tagsMu.RLock()
 	defer m.tagsMu.RUnlock()
 


### PR DESCRIPTION
## What

Fixes 3 AWS CloudTrail fidelity gaps found by the deep real-user e2e audit (all provider-layer, no driver/wire interface changes).

- **[MED F1] Default event selector on a fresh trail.** `GetEventSelectors` on a trail created without explicit selectors now returns CloudTrail's implicit default — one basic `EventSelector{ReadWriteType: "All", IncludeManagementEvents: true, DataResources: []}` — instead of an empty list. Once `PutEventSelectors` sets explicit basic or advanced selectors, those are returned. `Trail.HasCustomEventSelectors` stays `false` for the implicit default, so GetTrail/DescribeTrails are unaffected.
- **[MED F2] ListTags ARN validation.** `ListTags` now validates each `ResourceIdList` ARN exactly like `AddTags`/`RemoveTags`: a malformed ARN yields `CloudTrailARNInvalidException`, a well-formed-but-absent ARN yields `ResourceNotFoundException`. A valid trail ARN still returns its tags. Previously it returned a false-success empty tag set for any ARN.
- **[LOW F3] Basic-selector field defaults.** `PutEventSelectors` now normalizes each basic selector on store — omitted `ReadWriteType` defaults to `"All"`, omitted `IncludeManagementEvents` defaults to `true` — so they read back the way AWS stores them.

## Why

Matches official AWS CloudTrail API semantics (PutEventSelectors/GetEventSelectors defaults and ListTags Errors). Raw SDK/CLI callers previously saw an empty selector list on fresh trails, silent empty tags for wrong ARNs, and unnormalized selector fields.

## Tests

- `TestGetEventSelectorsDefaultOnFreshTrail` — fresh trail returns one default `All`/management selector; explicit put overrides it; default is not marked custom.
- `TestPutEventSelectorsBasicDefaults` — omitted fields read back as `All`/true.
- `TestListTagsARNValidation` — malformed → CloudTrailARNInvalidException, absent → ResourceNotFoundException, valid trail ARN → its tags.
- Updated `TestTagNonexistentResource` to assert ListTags on an absent ARN now errors (it previously encoded the F2 bug).
- Existing CloudTrail tests (field round-trip, StartLogging→IsLogging, advanced selectors, describe filter, tags, #502 LookupEvents) stay green.