### PR TITLE
fix(aws-acm): wildcard DNS-validation record rooted at base domain + deduped; support EC/RSA-4096 KeyAlgorithm; validate DomainName; ListCertificates default-RSA filter + pagination

### DIFF
--- a/providers/aws/acm/acm.go
+++ b/providers/aws/acm/acm.go
@@ -24,6 +24,13 @@ const (
 	maxDomains = 100
 	// maxTags is ACM's cap on tags per certificate.
 	maxTags = 50
+	// maxDomainNameLen / maxLabelLen bound a valid FQDN (RFC 5280 / ACM pattern).
+	maxDomainNameLen = 253
+	maxLabelLen      = 63
+	// minTLDLen is the minimum length of the final (top-level) label; minLabels is
+	// the minimum number of dot-separated labels an FQDN must have.
+	minTLDLen = 2
+	minLabels = 2
 )
 
 // Mock is an in-memory implementation of AWS ACM.

--- a/providers/aws/acm/certificate_gen.go
+++ b/providers/aws/acm/certificate_gen.go
@@ -1,6 +1,7 @@
 package acm
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -18,31 +19,37 @@ import (
 )
 
 const (
-	rsaKeyBits    = 2048
 	rsaBits1024   = 1024
+	rsaBits2048   = 2048
+	rsaBits3072   = 3072
 	rsaBits4096   = 4096
 	certValidDays = 395 // ACM public certs are valid ~13 months
 	serialBits    = 128
+
+	sigAlgRSASHA256 = "SHA256WITHRSA"
 )
 
 // issuedMaterial is the generated PEM material for a certificate.
 type issuedMaterial struct {
-	certPEM  string
-	keyPEM   string
-	chainPEM string
-	serial   string
-	subject  string
-	issuer   string
-	notAfter time.Time
+	certPEM      string
+	keyPEM       string
+	chainPEM     string
+	serial       string
+	subject      string
+	issuer       string
+	notAfter     time.Time
+	keyAlgorithm string
+	sigAlgorithm string
 }
 
 // generateCertificate issues a real self-signed X.509 certificate for the given
-// domains, valid from now. The single self-signed cert doubles as its own chain
-// root, which is enough for a local emulator (clients that pin a CA can add it).
-func generateCertificate(domain string, sans []string, notBefore time.Time) (*issuedMaterial, error) {
-	key, err := rsa.GenerateKey(rand.Reader, rsaKeyBits)
+// domains and key algorithm, valid from now. The single self-signed cert doubles
+// as its own chain root, which is enough for a local emulator (clients that pin a
+// CA can add it). An unsupported keyAlg is an InvalidParameterException.
+func generateCertificate(keyAlg, domain string, sans []string, notBefore time.Time) (*issuedMaterial, error) {
+	signer, keyPEM, sigAlg, err := generateKeyMaterial(keyAlg)
 	if err != nil {
-		return nil, errors.Newf(errors.Internal, "generate key: %v", err)
+		return nil, err
 	}
 
 	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), serialBits))
@@ -65,25 +72,75 @@ func generateCertificate(domain string, sans []string, notBefore time.Time) (*is
 		DNSNames:              dnsNames,
 	}
 
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, signer.Public(), signer)
 	if err != nil {
 		return nil, errors.Newf(errors.Internal, "create certificate: %v", err)
 	}
 
 	certPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
-	keyPEM := string(pem.EncodeToMemory(&pem.Block{
-		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key),
-	}))
 
 	return &issuedMaterial{
-		certPEM:  certPEM,
-		keyPEM:   keyPEM,
-		chainPEM: certPEM, // self-signed: the cert is its own chain
-		serial:   formatSerial(serial),
-		subject:  "CN=" + domain,
-		issuer:   "Amazon",
-		notAfter: tmpl.NotAfter,
+		certPEM:      certPEM,
+		keyPEM:       keyPEM,
+		chainPEM:     certPEM, // self-signed: the cert is its own chain
+		serial:       formatSerial(serial),
+		subject:      "CN=" + domain,
+		issuer:       "Amazon",
+		notAfter:     tmpl.NotAfter,
+		keyAlgorithm: keyAlg,
+		sigAlgorithm: sigAlg,
 	}, nil
+}
+
+// generateKeyMaterial produces a private key for the requested ACM KeyAlgorithm,
+// returning the signer, its PEM encoding, and the matching SignatureAlgorithm.
+// It mirrors the RSA/EC algorithms real ACM accepts on RequestCertificate.
+func generateKeyMaterial(keyAlg string) (signer crypto.Signer, keyPEM, sigAlg string, err error) {
+	switch keyAlg {
+	case driver.KeyAlgRSA1024:
+		return rsaKeyMaterial(rsaBits1024)
+	case driver.KeyAlgRSA2048:
+		return rsaKeyMaterial(rsaBits2048)
+	case driver.KeyAlgRSA3072:
+		return rsaKeyMaterial(rsaBits3072)
+	case driver.KeyAlgRSA4096:
+		return rsaKeyMaterial(rsaBits4096)
+	case driver.KeyAlgECP256:
+		return ecKeyMaterial(elliptic.P256(), "ECDSAWITHSHA256")
+	case driver.KeyAlgECP384:
+		return ecKeyMaterial(elliptic.P384(), "ECDSAWITHSHA384")
+	case driver.KeyAlgECP521:
+		return ecKeyMaterial(elliptic.P521(), "ECDSAWITHSHA512")
+	default:
+		return nil, "", "", invalidParameter("KeyAlgorithm %q is not supported", keyAlg)
+	}
+}
+
+func rsaKeyMaterial(bits int) (signer crypto.Signer, keyPEM, sigAlg string, err error) {
+	key, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		return nil, "", "", errors.Newf(errors.Internal, "generate key: %v", err)
+	}
+
+	pemStr := string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}))
+
+	return key, pemStr, sigAlgRSASHA256, nil
+}
+
+func ecKeyMaterial(curve elliptic.Curve, sigAlg string) (signer crypto.Signer, keyPEM, sig string, err error) {
+	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		return nil, "", "", errors.Newf(errors.Internal, "generate key: %v", err)
+	}
+
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, "", "", errors.Newf(errors.Internal, "marshal EC key: %v", err)
+	}
+
+	pemStr := string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}))
+
+	return key, pemStr, sigAlg, nil
 }
 
 // formatSerial renders a serial number as colon-separated hex, matching ACM.
@@ -175,6 +232,6 @@ func signatureAlgorithmOf(leaf *x509.Certificate) string {
 	case x509.ECDSAWithSHA384:
 		return "ECDSAWITHSHA384"
 	default:
-		return "SHA256WITHRSA"
+		return sigAlgRSASHA256
 	}
 }

--- a/providers/aws/acm/certificates.go
+++ b/providers/aws/acm/certificates.go
@@ -20,6 +20,16 @@ func (m *Mock) RequestCertificate(_ context.Context, in driver.RequestCertificat
 		return "", invalidParameter("DomainName is required")
 	}
 
+	if err := validateDomainName(in.DomainName); err != nil {
+		return "", err
+	}
+
+	for _, san := range in.SubjectAlternativeNames {
+		if err := validateDomainName(san); err != nil {
+			return "", err
+		}
+	}
+
 	sans := dedupeDomains(in.DomainName, in.SubjectAlternativeNames)
 	if len(sans) > maxDomains {
 		return "", invalidParameter("a certificate may cover at most %d domains, got %d", maxDomains, len(sans))
@@ -30,17 +40,9 @@ func (m *Mock) RequestCertificate(_ context.Context, in driver.RequestCertificat
 		method = driver.ValidationDNS
 	}
 
-	// The emulator issues RSA-2048 material, so it can only honestly report
-	// RSA_2048. Reject a request for a different algorithm rather than echoing an
-	// algorithm the generated PEM won't match.
 	keyAlg := in.KeyAlgorithm
 	if keyAlg == "" {
 		keyAlg = driver.KeyAlgRSA2048
-	}
-
-	if keyAlg != driver.KeyAlgRSA2048 {
-		return "", invalidParameter(
-			"KeyAlgorithm %q is not supported; the emulator issues RSA_2048 certificates", keyAlg)
 	}
 
 	ct := in.CTLoggingPreference
@@ -50,7 +52,10 @@ func (m *Mock) RequestCertificate(_ context.Context, in driver.RequestCertificat
 
 	now := m.now()
 
-	mat, err := generateCertificate(in.DomainName, in.SubjectAlternativeNames, now)
+	// generateCertificate issues real key material for the requested algorithm
+	// (RSA/EC) and rejects a genuinely-unsupported one with
+	// InvalidParameterException, so Describe reflects the actual key + signature.
+	mat, err := generateCertificate(keyAlg, in.DomainName, in.SubjectAlternativeNames, now)
 	if err != nil {
 		return "", err
 	}
@@ -70,8 +75,8 @@ func (m *Mock) RequestCertificate(_ context.Context, in driver.RequestCertificat
 		NotBefore:               now,
 		NotAfter:                mat.notAfter,
 		Status:                  driver.StatusIssued,
-		KeyAlgorithm:            keyAlg,
-		SignatureAlgorithm:      "SHA256WITHRSA",
+		KeyAlgorithm:            mat.keyAlgorithm,
+		SignatureAlgorithm:      mat.sigAlgorithm,
 		Type:                    driver.TypeAmazonIssued,
 		RenewalEligibility:      driver.RenewalEligible,
 		ValidationMethod:        method,
@@ -91,10 +96,23 @@ func (m *Mock) RequestCertificate(_ context.Context, in driver.RequestCertificat
 
 // validationOptions builds the per-domain validation records for a set of
 // domains (DNS validation exposes a CNAME record to add).
+//
+// A wildcard domain ("*.example.com") is validated against its BASE domain, so
+// the DNS record is rooted at "example.com" (never a literal "*", which Route53
+// rejects as a leftmost label). A wildcard and its apex SAN ("*.example.com" and
+// "example.com") share a single validation record, matching real ACM, so they
+// collapse to one DomainValidation rather than emitting a duplicate CNAME.
 func validationOptions(domains []string, method string) []driver.DomainValidation {
 	out := make([]driver.DomainValidation, 0, len(domains))
+	seenRecord := make(map[string]bool)
 
 	for _, d := range domains {
+		base := strings.TrimPrefix(d, "*.")
+
+		if method == driver.ValidationDNS && seenRecord[base] {
+			continue
+		}
+
 		dv := driver.DomainValidation{
 			DomainName:       d,
 			ValidationDomain: d,
@@ -103,15 +121,69 @@ func validationOptions(domains []string, method string) []driver.DomainValidatio
 		}
 
 		if method == driver.ValidationDNS {
-			dv.ResourceRecordN = "_acm-validations." + d + "."
+			seenRecord[base] = true
+			dv.ResourceRecordN = "_acm-validations." + base + "."
 			dv.ResourceRecordT = "CNAME"
-			dv.ResourceRecordV = "_" + strings.ReplaceAll(d, ".", "-") + ".acm-validations.aws."
+			dv.ResourceRecordV = "_" + strings.ReplaceAll(base, ".", "-") + ".acm-validations.aws."
 		}
 
 		out = append(out, dv)
 	}
 
 	return out
+}
+
+// validateDomainName reports whether name is a valid ACM fully qualified domain
+// name, mirroring the RequestCertificate DomainName/SAN pattern
+// `(\*\.)?(label\.)+tld`. A single leading "*." wildcard label is allowed; the
+// remaining name must be a dotted FQDN whose top-level label is at least two
+// characters. A malformed name is an InvalidParameterException in real ACM.
+func validateDomainName(name string) error {
+	if name == "" || len(name) > maxDomainNameLen {
+		return invalidParameter("DomainName %q is not a valid fully qualified domain name", name)
+	}
+
+	labels := strings.Split(strings.TrimPrefix(name, "*."), ".")
+	if len(labels) < minLabels {
+		return invalidParameter("DomainName %q is not a valid fully qualified domain name", name)
+	}
+
+	for i, label := range labels {
+		minLen := 1
+		if i == len(labels)-1 {
+			minLen = minTLDLen
+		}
+
+		if !validLabel(label, minLen) {
+			return invalidParameter("DomainName %q is not a valid fully qualified domain name", name)
+		}
+	}
+
+	return nil
+}
+
+// validLabel reports whether label is a valid DNS label of at least minLen
+// characters: alphanumeric or hyphen, never starting or ending with a hyphen.
+func validLabel(label string, minLen int) bool {
+	if len(label) < minLen || len(label) > maxLabelLen {
+		return false
+	}
+
+	if label[0] == '-' || label[len(label)-1] == '-' {
+		return false
+	}
+
+	for i := 0; i < len(label); i++ {
+		if !isLabelChar(label[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isLabelChar(c byte) bool {
+	return c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z' || c >= '0' && c <= '9' || c == '-'
 }
 
 // DescribeCertificate returns a certificate's metadata.
@@ -129,10 +201,17 @@ func (m *Mock) DescribeCertificate(_ context.Context, arn string) (*driver.Certi
 	return &out, nil
 }
 
-// ListCertificates returns all certificates, optionally filtered by status.
+// ListCertificates returns all certificates, filtered by status and key type.
+// Following real ACM, the default (empty KeyTypes) returns only RSA_2048
+// certificates; other key types appear only when explicitly requested.
 func (m *Mock) ListCertificates(_ context.Context, filter driver.ListFilter) ([]driver.Certificate, error) {
 	all := m.certs.All()
 	out := make([]driver.Certificate, 0, len(all))
+
+	keyTypes := filter.KeyTypes
+	if len(keyTypes) == 0 {
+		keyTypes = []string{driver.KeyAlgRSA2048}
+	}
 
 	now := m.now()
 
@@ -141,7 +220,7 @@ func (m *Mock) ListCertificates(_ context.Context, filter driver.ListFilter) ([]
 		oc := observeCert(&cd.cert, cd.settle, now)
 		cd.mu.RUnlock()
 
-		if statusMatches(oc.Status, filter.Statuses) {
+		if statusMatches(oc.Status, filter.Statuses) && contains(keyTypes, oc.KeyAlgorithm) {
 			out = append(out, oc)
 		}
 	}
@@ -154,8 +233,12 @@ func statusMatches(status string, want []string) bool {
 		return true
 	}
 
-	for _, s := range want {
-		if s == status {
+	return contains(want, status)
+}
+
+func contains(set []string, v string) bool {
+	for _, s := range set {
+		if s == v {
 			return true
 		}
 	}

--- a/providers/aws/acm/keyalg_validation_test.go
+++ b/providers/aws/acm/keyalg_validation_test.go
@@ -1,0 +1,114 @@
+package acm_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/acm/driver"
+)
+
+func TestRequestECKeyAlgorithmReflected(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	arn, err := m.RequestCertificate(ctx, driver.RequestCertificateInput{
+		DomainName:   "ec.example.com",
+		KeyAlgorithm: driver.KeyAlgECP384,
+	})
+	if err != nil {
+		t.Fatalf("RequestCertificate(EC_secp384r1): %v", err)
+	}
+
+	d, _ := m.DescribeCertificate(ctx, arn)
+	if d.KeyAlgorithm != driver.KeyAlgECP384 {
+		t.Fatalf("KeyAlgorithm = %s, want EC_secp384r1", d.KeyAlgorithm)
+	}
+
+	if d.SignatureAlgorithm != "ECDSAWITHSHA384" {
+		t.Fatalf("SignatureAlgorithm = %s, want ECDSAWITHSHA384", d.SignatureAlgorithm)
+	}
+}
+
+func TestRequestUnsupportedKeyAlgorithmRejected(t *testing.T) {
+	m := newMock(t)
+
+	_, err := m.RequestCertificate(context.Background(), driver.RequestCertificateInput{
+		DomainName:   "bad.example.com",
+		KeyAlgorithm: "RSA_9999",
+	})
+	if !errors.IsInvalidArgument(err) {
+		t.Fatalf("unsupported KeyAlgorithm should be InvalidArgument, got %v", err)
+	}
+}
+
+func TestWildcardValidationRecordRootedAndDeduped(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	arn, err := m.RequestCertificate(ctx, driver.RequestCertificateInput{
+		DomainName:              "*.example.com",
+		SubjectAlternativeNames: []string{"example.com"},
+	})
+	if err != nil {
+		t.Fatalf("RequestCertificate wildcard+apex: %v", err)
+	}
+
+	d, _ := m.DescribeCertificate(ctx, arn)
+	if len(d.DomainValidationOptions) != 1 {
+		t.Fatalf("wildcard + apex should collapse to 1 DVO, got %d", len(d.DomainValidationOptions))
+	}
+
+	rec := d.DomainValidationOptions[0].ResourceRecordN
+	if strings.Contains(rec, "*") {
+		t.Fatalf("validation record name contains '*': %q", rec)
+	}
+
+	if rec != "_acm-validations.example.com." {
+		t.Fatalf("validation record name = %q, want _acm-validations.example.com.", rec)
+	}
+}
+
+func TestRequestMalformedDomainRejected(t *testing.T) {
+	m := newMock(t)
+
+	for _, bad := range []string{"not a valid domain!!", "single", "a.b", "-lead.example.com"} {
+		if _, err := m.RequestCertificate(context.Background(),
+			driver.RequestCertificateInput{DomainName: bad}); !errors.IsInvalidArgument(err) {
+			t.Fatalf("DomainName %q should be InvalidArgument, got %v", bad, err)
+		}
+	}
+
+	// Valid FQDN + wildcard accepted.
+	if _, err := m.RequestCertificate(context.Background(),
+		driver.RequestCertificateInput{DomainName: "*.good.example.com"}); err != nil {
+		t.Fatalf("valid wildcard should be accepted: %v", err)
+	}
+}
+
+func TestListDefaultRSAFilterAndKeyTypes(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	if _, err := m.RequestCertificate(ctx,
+		driver.RequestCertificateInput{DomainName: "rsa.example.com"}); err != nil {
+		t.Fatalf("request RSA: %v", err)
+	}
+
+	if _, err := m.RequestCertificate(ctx, driver.RequestCertificateInput{
+		DomainName: "ec.example.com", KeyAlgorithm: driver.KeyAlgECP256,
+	}); err != nil {
+		t.Fatalf("request EC: %v", err)
+	}
+
+	def, _ := m.ListCertificates(ctx, driver.ListFilter{})
+	if len(def) != 1 || def[0].KeyAlgorithm != driver.KeyAlgRSA2048 {
+		t.Fatalf("default list want 1 RSA_2048 cert, got %+v", def)
+	}
+
+	ec, _ := m.ListCertificates(ctx, driver.ListFilter{KeyTypes: []string{driver.KeyAlgECP256}})
+	if len(ec) != 1 || ec[0].KeyAlgorithm != driver.KeyAlgECP256 {
+		t.Fatalf("KeyTypes=[EC] want 1 EC cert, got %+v", ec)
+	}
+}

--- a/providers/aws/acm/operations.go
+++ b/providers/aws/acm/operations.go
@@ -131,7 +131,7 @@ func (m *Mock) RenewCertificate(_ context.Context, arn string) error {
 
 		now := m.now()
 
-		mat, err := generateCertificate(cd.cert.DomainName, cd.cert.SubjectAlternativeNames, now)
+		mat, err := generateCertificate(cd.cert.KeyAlgorithm, cd.cert.DomainName, cd.cert.SubjectAlternativeNames, now)
 		if err != nil {
 			return err
 		}

--- a/server/aws/acm/keyalg_wildcard_sdk_test.go
+++ b/server/aws/acm/keyalg_wildcard_sdk_test.go
@@ -1,0 +1,339 @@
+package acm_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsacm "github.com/aws/aws-sdk-go-v2/service/acm"
+	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
+)
+
+// F1 — RequestCertificate honors the documented EC/RSA KeyAlgorithm set.
+func TestSDKRequestECKeyAlgorithm(t *testing.T) {
+	ctx := context.Background()
+	c := newACMClient(t)
+
+	req, err := c.RequestCertificate(ctx, &awsacm.RequestCertificateInput{
+		DomainName:   aws.String("ec.example.com"),
+		KeyAlgorithm: acmtypes.KeyAlgorithmEcPrime256v1,
+	})
+	if err != nil {
+		t.Fatalf("RequestCertificate(EC_prime256v1): %v", err)
+	}
+
+	desc, err := c.DescribeCertificate(ctx, &awsacm.DescribeCertificateInput{CertificateArn: req.CertificateArn})
+	if err != nil {
+		t.Fatalf("DescribeCertificate: %v", err)
+	}
+
+	if desc.Certificate.KeyAlgorithm != acmtypes.KeyAlgorithmEcPrime256v1 {
+		t.Fatalf("KeyAlgorithm = %s, want EC_prime256v1", desc.Certificate.KeyAlgorithm)
+	}
+
+	if sig := aws.ToString(desc.Certificate.SignatureAlgorithm); !strings.HasPrefix(sig, "ECDSA") {
+		t.Fatalf("SignatureAlgorithm = %q, want an ECDSA signature", sig)
+	}
+
+	// The issued material must actually carry an EC public key.
+	got, err := c.GetCertificate(ctx, &awsacm.GetCertificateInput{CertificateArn: req.CertificateArn})
+	if err != nil {
+		t.Fatalf("GetCertificate: %v", err)
+	}
+
+	block, _ := pem.Decode([]byte(aws.ToString(got.Certificate)))
+	leaf, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse issued cert: %v", err)
+	}
+
+	if _, ok := leaf.PublicKey.(*ecdsa.PublicKey); !ok {
+		t.Fatalf("issued cert public key = %T, want *ecdsa.PublicKey", leaf.PublicKey)
+	}
+}
+
+func TestSDKRequestRSA4096(t *testing.T) {
+	ctx := context.Background()
+	c := newACMClient(t)
+
+	req, err := c.RequestCertificate(ctx, &awsacm.RequestCertificateInput{
+		DomainName:   aws.String("rsa4096.example.com"),
+		KeyAlgorithm: acmtypes.KeyAlgorithmRsa4096,
+	})
+	if err != nil {
+		t.Fatalf("RequestCertificate(RSA_4096): %v", err)
+	}
+
+	desc, _ := c.DescribeCertificate(ctx, &awsacm.DescribeCertificateInput{CertificateArn: req.CertificateArn})
+	if desc.Certificate.KeyAlgorithm != acmtypes.KeyAlgorithmRsa4096 {
+		t.Fatalf("KeyAlgorithm = %s, want RSA_4096", desc.Certificate.KeyAlgorithm)
+	}
+}
+
+func TestSDKRequestBogusKeyAlgorithmRejected(t *testing.T) {
+	ctx := context.Background()
+	c := newACMClient(t)
+
+	_, err := c.RequestCertificate(ctx, &awsacm.RequestCertificateInput{
+		DomainName:   aws.String("bogus.example.com"),
+		KeyAlgorithm: acmtypes.KeyAlgorithm("RSA_9999"),
+	})
+	if err == nil {
+		t.Fatal("an unsupported KeyAlgorithm should be rejected")
+	}
+
+	assertAPIErrorCode(t, err, "InvalidParameterException")
+}
+
+// F2 — wildcard DNS validation record is rooted at the base domain (no literal
+// '*') and a wildcard + its apex share a single validation record.
+func TestSDKWildcardValidationRecordRooted(t *testing.T) {
+	ctx := context.Background()
+	c := newACMClient(t)
+
+	req, err := c.RequestCertificate(ctx, &awsacm.RequestCertificateInput{
+		DomainName:       aws.String("*.example.com"),
+		ValidationMethod: acmtypes.ValidationMethodDns,
+	})
+	if err != nil {
+		t.Fatalf("RequestCertificate(*.example.com): %v", err)
+	}
+
+	desc, _ := c.DescribeCertificate(ctx, &awsacm.DescribeCertificateInput{CertificateArn: req.CertificateArn})
+	dvos := desc.Certificate.DomainValidationOptions
+
+	if len(dvos) != 1 || dvos[0].ResourceRecord == nil {
+		t.Fatalf("want 1 DVO with a ResourceRecord, got %+v", dvos)
+	}
+
+	name := aws.ToString(dvos[0].ResourceRecord.Name)
+	if strings.Contains(name, "*") {
+		t.Fatalf("validation record name contains a literal '*': %q", name)
+	}
+
+	if !strings.HasSuffix(name, ".example.com.") {
+		t.Fatalf("validation record name = %q, want it rooted at example.com", name)
+	}
+
+	value := aws.ToString(dvos[0].ResourceRecord.Value)
+	if strings.Contains(value, "*") {
+		t.Fatalf("validation record value contains a literal '*': %q", value)
+	}
+}
+
+func TestSDKWildcardApexShareOneRecord(t *testing.T) {
+	ctx := context.Background()
+	c := newACMClient(t)
+
+	req, err := c.RequestCertificate(ctx, &awsacm.RequestCertificateInput{
+		DomainName:              aws.String("*.example.com"),
+		SubjectAlternativeNames: []string{"example.com"},
+		ValidationMethod:        acmtypes.ValidationMethodDns,
+	})
+	if err != nil {
+		t.Fatalf("RequestCertificate wildcard+apex: %v", err)
+	}
+
+	desc, _ := c.DescribeCertificate(ctx, &awsacm.DescribeCertificateInput{CertificateArn: req.CertificateArn})
+	dvos := desc.Certificate.DomainValidationOptions
+
+	if len(dvos) != 1 {
+		t.Fatalf("wildcard + apex should share one validation record, got %d DVOs", len(dvos))
+	}
+
+	if name := aws.ToString(dvos[0].ResourceRecord.Name); !strings.HasSuffix(name, ".example.com.") {
+		t.Fatalf("shared record name = %q, want rooted at example.com", name)
+	}
+}
+
+func TestSDKNonWildcardValidationRecordUnchanged(t *testing.T) {
+	ctx := context.Background()
+	c := newACMClient(t)
+
+	req, _ := c.RequestCertificate(ctx, &awsacm.RequestCertificateInput{
+		DomainName:       aws.String("plain.example.com"),
+		ValidationMethod: acmtypes.ValidationMethodDns,
+	})
+
+	desc, _ := c.DescribeCertificate(ctx, &awsacm.DescribeCertificateInput{CertificateArn: req.CertificateArn})
+	dvos := desc.Certificate.DomainValidationOptions
+
+	if len(dvos) != 1 || dvos[0].ResourceRecord == nil {
+		t.Fatalf("want 1 DVO with a ResourceRecord, got %+v", dvos)
+	}
+
+	if name := aws.ToString(dvos[0].ResourceRecord.Name); name != "_acm-validations.plain.example.com." {
+		t.Fatalf("non-wildcard record name = %q, want _acm-validations.plain.example.com.", name)
+	}
+}
+
+// F4 — RequestCertificate validates the DomainName (and each SAN) as an FQDN.
+func TestSDKRequestMalformedDomainRejected(t *testing.T) {
+	ctx := context.Background()
+	c := newACMClient(t)
+
+	if _, err := c.RequestCertificate(ctx, &awsacm.RequestCertificateInput{
+		DomainName: aws.String("not a valid domain!!"),
+	}); err == nil {
+		t.Fatal("a malformed DomainName should be rejected")
+	} else {
+		assertAPIErrorCode(t, err, "InvalidParameterException")
+	}
+
+	// A malformed SAN is rejected too.
+	if _, err := c.RequestCertificate(ctx, &awsacm.RequestCertificateInput{
+		DomainName:              aws.String("good.example.com"),
+		SubjectAlternativeNames: []string{"bad san!"},
+	}); err == nil {
+		t.Fatal("a malformed SAN should be rejected")
+	}
+
+	// A valid FQDN and a wildcard are accepted.
+	if _, err := c.RequestCertificate(ctx, &awsacm.RequestCertificateInput{
+		DomainName:              aws.String("good.example.com"),
+		SubjectAlternativeNames: []string{"*.good.example.com"},
+	}); err != nil {
+		t.Fatalf("valid FQDN + wildcard should be accepted: %v", err)
+	}
+}
+
+// F5 — default ListCertificates returns only RSA_2048; Includes.keyTypes widens
+// it, and MaxItems/NextToken paginate.
+func TestSDKListDefaultRSAFilterAndIncludes(t *testing.T) {
+	ctx := context.Background()
+	c := newACMClient(t)
+
+	// A default RSA_2048 managed cert.
+	if _, err := c.RequestCertificate(ctx, &awsacm.RequestCertificateInput{
+		DomainName: aws.String("rsa.example.com"),
+	}); err != nil {
+		t.Fatalf("request RSA cert: %v", err)
+	}
+
+	// An imported EC certificate.
+	certPEM, keyPEM := makeECCertPEM(t, "ec-import.example.com")
+	if _, err := c.ImportCertificate(ctx, &awsacm.ImportCertificateInput{
+		Certificate: []byte(certPEM), PrivateKey: []byte(keyPEM),
+	}); err != nil {
+		t.Fatalf("ImportCertificate(EC): %v", err)
+	}
+
+	// Default list excludes the EC cert.
+	def, _ := c.ListCertificates(ctx, &awsacm.ListCertificatesInput{})
+	for _, s := range def.CertificateSummaryList {
+		if s.KeyAlgorithm == acmtypes.KeyAlgorithmEcPrime256v1 {
+			t.Fatal("default ListCertificates should not return EC certs")
+		}
+	}
+
+	if len(def.CertificateSummaryList) != 1 {
+		t.Fatalf("default list want 1 RSA cert, got %d", len(def.CertificateSummaryList))
+	}
+
+	// Includes.keyTypes=[EC_prime256v1] surfaces the EC cert.
+	inc, _ := c.ListCertificates(ctx, &awsacm.ListCertificatesInput{
+		Includes: &acmtypes.Filters{KeyTypes: []acmtypes.KeyAlgorithm{acmtypes.KeyAlgorithmEcPrime256v1}},
+	})
+	if len(inc.CertificateSummaryList) != 1 ||
+		inc.CertificateSummaryList[0].KeyAlgorithm != acmtypes.KeyAlgorithmEcPrime256v1 {
+		t.Fatalf("Includes.keyTypes=[EC] should return the EC cert, got %+v", inc.CertificateSummaryList)
+	}
+}
+
+func TestSDKListPagination(t *testing.T) {
+	ctx := context.Background()
+	c := newACMClient(t)
+
+	const total = 5
+	for i := 0; i < total; i++ {
+		if _, err := c.RequestCertificate(ctx, &awsacm.RequestCertificateInput{
+			DomainName: aws.String(fmt.Sprintf("p%d.example.com", i)),
+		}); err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+	}
+
+	seen := map[string]bool{}
+	var token *string
+	pages := 0
+
+	for {
+		out, err := c.ListCertificates(ctx, &awsacm.ListCertificatesInput{
+			MaxItems: aws.Int32(2), NextToken: token,
+		})
+		if err != nil {
+			t.Fatalf("ListCertificates page: %v", err)
+		}
+
+		if len(out.CertificateSummaryList) > 2 {
+			t.Fatalf("page returned %d items, want <= MaxItems (2)", len(out.CertificateSummaryList))
+		}
+
+		for _, s := range out.CertificateSummaryList {
+			seen[aws.ToString(s.CertificateArn)] = true
+		}
+
+		pages++
+
+		if out.NextToken == nil {
+			break
+		}
+
+		token = out.NextToken
+
+		if pages > total+2 {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+
+	if len(seen) != total {
+		t.Fatalf("paginated set = %d certs, want %d", len(seen), total)
+	}
+
+	if pages < 2 {
+		t.Fatalf("MaxItems=2 over %d certs should span multiple pages, got %d", total, pages)
+	}
+}
+
+// makeECCertPEM generates a real self-signed EC (P-256) cert + key as PEM.
+func makeECCertPEM(t *testing.T, cn string) (certPEM, keyPEM string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate EC key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		DNSNames:     []string{cn},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create EC cert: %v", err)
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal EC key: %v", err)
+	}
+
+	certPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	keyPEM = string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
+
+	return certPEM, keyPEM
+}

--- a/server/aws/acm/operations.go
+++ b/server/aws/acm/operations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	acmdriver "github.com/stackshy/cloudemu/v2/services/acm/driver"
 )
 
@@ -64,12 +65,29 @@ func (h *Handler) describeCertificate(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) listCertificates(w http.ResponseWriter, r *http.Request) {
 	dispatch(h, w, r, func(h *Handler, ctx context.Context, req *listCertificatesRequest) (any, error) {
-		certs, err := h.acm.ListCertificates(ctx, acmdriver.ListFilter{Statuses: req.CertificateStatuses})
+		certs, err := h.acm.ListCertificates(ctx,
+			acmdriver.ListFilter{Statuses: req.CertificateStatuses, KeyTypes: req.keyTypes()})
 		if err != nil {
 			return nil, err
 		}
 
-		return listCertificatesResponse{CertificateSummaryList: summaries(certs)}, nil
+		// Paginate over a stable ARN ordering so MaxItems/NextToken tokens stay
+		// meaningful across calls (the driver's map iteration is unordered).
+		limit := 0
+		if req.MaxItems != nil {
+			limit = int(*req.MaxItems)
+		}
+
+		page, err := pagination.PaginateSorted(certs,
+			func(a, b acmdriver.Certificate) bool { return a.ARN < b.ARN }, req.NextToken, limit)
+		if err != nil {
+			return nil, err
+		}
+
+		return listCertificatesResponse{
+			CertificateSummaryList: summaries(page.Items),
+			NextToken:              page.NextPageToken,
+		}, nil
 	})
 }
 
@@ -158,7 +176,8 @@ func (h *Handler) revokeCertificate(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) searchCertificates(w http.ResponseWriter, r *http.Request) {
 	dispatch(h, w, r, func(h *Handler, ctx context.Context, req *listCertificatesRequest) (any, error) {
-		certs, err := h.acm.SearchCertificates(ctx, acmdriver.ListFilter{Statuses: req.CertificateStatuses})
+		certs, err := h.acm.SearchCertificates(ctx,
+			acmdriver.ListFilter{Statuses: req.CertificateStatuses, KeyTypes: req.keyTypes()})
 		if err != nil {
 			return nil, err
 		}

--- a/server/aws/acm/types.go
+++ b/server/aws/acm/types.go
@@ -168,8 +168,23 @@ type certArnRequest struct {
 	CertificateArn string `json:"CertificateArn"`
 }
 
+type listFiltersJSON struct {
+	KeyTypes []string `json:"keyTypes"`
+}
+
 type listCertificatesRequest struct {
-	CertificateStatuses []string `json:"CertificateStatuses"`
+	CertificateStatuses []string         `json:"CertificateStatuses"`
+	Includes            *listFiltersJSON `json:"Includes"`
+	MaxItems            *int32           `json:"MaxItems"`
+	NextToken           string           `json:"NextToken"`
+}
+
+func (r *listCertificatesRequest) keyTypes() []string {
+	if r.Includes == nil {
+		return nil
+	}
+
+	return r.Includes.KeyTypes
 }
 
 type exportCertificateRequest struct {

--- a/services/acm/driver/driver.go
+++ b/services/acm/driver/driver.go
@@ -36,9 +36,11 @@ const (
 const (
 	KeyAlgRSA2048 = "RSA_2048"
 	KeyAlgRSA1024 = "RSA_1024"
+	KeyAlgRSA3072 = "RSA_3072"
 	KeyAlgRSA4096 = "RSA_4096"
 	KeyAlgECP256  = "EC_prime256v1"
 	KeyAlgECP384  = "EC_secp384r1"
+	KeyAlgECP521  = "EC_secp521r1"
 )
 
 // Certificate transparency logging preferences.
@@ -117,9 +119,12 @@ type ImportCertificateInput struct {
 	Tags           map[string]string
 }
 
-// ListFilter narrows ListCertificates.
+// ListFilter narrows ListCertificates. An empty KeyTypes applies ACM's default
+// filtering, which returns only RSA_2048 certificates; a non-empty KeyTypes
+// returns only certificates whose key algorithm is in the set.
 type ListFilter struct {
 	Statuses []string
+	KeyTypes []string
 }
 
 // AccountConfiguration is the account-level ACM configuration.


### PR DESCRIPTION
## What

Fixes four AWS ACM correctness issues found by a real-user aws-sdk-go-v2 e2e audit, at the correct 3-layer locations (driver / provider / wire).

**F2 (real bug) — Wildcard DNS-validation record contained a literal `*`; wildcard+apex not deduplicated.**
For `*.example.com`, the DNS validation `ResourceRecord.Name` was `_acm-validations.*.example.com.` — Route53 rejects `*` as a non-leftmost label, breaking the common `aws_acm_certificate_validation` + `aws_route53_record` wildcard flow. Now the record is rooted at the base domain (`_acm-validations.example.com.`, no `*`), and a wildcard together with its apex SAN collapse to a single shared validation record, matching real ACM.

**F1 (Terraform-breaker) — RequestCertificate rejected every KeyAlgorithm except RSA_2048.**
Terraform `aws_acm_certificate { key_algorithm = "EC_prime256v1" }` failed against cloudemu. Now the documented EC/RSA set is accepted (`RSA_1024/2048/3072/4096`, `EC_prime256v1/secp384r1/secp521r1`); real key material is generated for the requested algorithm, and `DescribeCertificate` reflects the requested `KeyAlgorithm` plus a matching `SignatureAlgorithm`. A genuinely-unsupported value is rejected with `InvalidParameterException`.

**F4 — RequestCertificate accepted malformed DomainName.**
`DomainName`/`SubjectAlternativeNames` are now validated as FQDNs (mirroring ACM's `(\*\.)?(label\.)+tld` pattern, leading `*.` wildcard allowed); malformed input returns `InvalidParameterException`.

**F5 — Default ListCertificates returned non-RSA_2048 certs and ignored pagination/Includes.**
Per AWS, the default (no `Includes.keyTypes`) list returns only RSA_2048 certificates. Now default-filters to RSA_2048, honors `Includes.keyTypes`, and honors `MaxItems`/`NextToken` pagination over a stable ARN ordering.

Deferred (out of scope, tracked): F3 (EMAIL ValidationEmails) and F7 (DeleteCertificate in-use guard — currently unreachable, nothing populates `InUseBy`).

## Why

These diverge from real AWS ACM and break common Terraform flows (ECDSA certs, wildcard DNS validation). Verified against the official ACM API reference for RequestCertificate (KeyAlgorithm valid values, DomainName pattern) and ListCertificates (default RSA filtering, Includes.keyTypes, MaxItems/NextToken).

## Tests

New real aws-sdk-go-v2 reproductions plus provider-level unit tests: EC/RSA-4096 key algorithms issue and reflect correctly (bogus rejected); wildcard record rooted with no `*` and wildcard+apex sharing one record; non-wildcard record unchanged; malformed DomainName/SAN rejected and valid FQDN+wildcard accepted; default list excludes an imported EC cert while `Includes.keyTypes` includes it; MaxItems/NextToken paginate. Existing ACM tests (lifecycle, import, export guards, tags) stay green.
