### PR TITLE
fix(aws-eks): tag nodegroup/fargate/addon ARNs; nodegroup taints round-trip; clusterSecurityGroupId+vpcId on DescribeCluster; clean errors + scaling validation

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -270,6 +270,9 @@ func New(opts ...config.Option) *Provider {
 	p.ECS.SetTargetRegistrar(p.ELB)
 	p.Redshift.SetMonitoring(p.CloudWatch)
 	p.EKS.SetMonitoring(p.CloudWatch)
+	// An EKS cluster's resourcesVpcConfig.vpcId is derived from its subnets,
+	// matching real EKS (which auto-creates the cluster SG and infers the VPC).
+	p.EKS.SetSubnetResolver(p.VPC)
 	p.SageMaker.SetMonitoring(p.CloudWatch)
 	// CloudWatch alarm -> SNS: an alarm state transition fires its configured
 	// SNS-topic actions, fanning a notification out to the topic's subscribers.

--- a/providers/aws/eks/driver/driver.go
+++ b/providers/aws/eks/driver/driver.go
@@ -107,6 +107,15 @@ type NodegroupScalingConfig struct {
 	DesiredSize int
 }
 
+// Taint is a Kubernetes taint applied to a managed node group's nodes. Effect
+// is one of NO_SCHEDULE, PREFER_NO_SCHEDULE, or NO_EXECUTE. A taint is
+// identified by its Key+Effect pair.
+type Taint struct {
+	Key    string
+	Value  string
+	Effect string
+}
+
 // NodegroupConfig configures a new managed node group.
 type NodegroupConfig struct {
 	ClusterName    string
@@ -121,6 +130,7 @@ type NodegroupConfig struct {
 	ReleaseVersion string
 	ScalingConfig  NodegroupScalingConfig
 	Labels         map[string]string
+	Taints         []Taint
 	Tags           map[string]string
 }
 
@@ -140,8 +150,24 @@ type Nodegroup struct {
 	ScalingConfig  NodegroupScalingConfig
 	Status         string
 	Labels         map[string]string
+	Taints         []Taint
 	Tags           map[string]string
 	CreatedAt      time.Time
+	// ModifiedAt advances on every mutating op (config/version update); on a
+	// freshly created nodegroup it equals CreatedAt.
+	ModifiedAt time.Time
+}
+
+// NodegroupConfigUpdate carries the mutable fields UpdateNodegroupConfig
+// applies. Scaling, when non-nil, is the already-merged target sizing (the
+// caller overlays partial requests). Label and taint changes are expressed as
+// add/update and remove deltas, matching the real EKS request shape.
+type NodegroupConfigUpdate struct {
+	Scaling           *NodegroupScalingConfig
+	AddOrUpdateLabels map[string]string
+	RemoveLabels      []string
+	AddOrUpdateTaints []Taint
+	RemoveTaints      []Taint
 }
 
 // FargateProfileSelector matches Pods to a Fargate profile.
@@ -218,7 +244,7 @@ type EKS interface {
 	ListNodegroups(ctx context.Context, clusterName string) ([]string, error)
 	UpdateNodegroupConfig(
 		ctx context.Context, clusterName, nodegroupName string,
-		scaling *NodegroupScalingConfig, labels map[string]string,
+		upd NodegroupConfigUpdate,
 	) (*ClusterUpdate, error)
 	UpdateNodegroupVersion(
 		ctx context.Context, clusterName, nodegroupName, version, releaseVersion string,

--- a/providers/aws/eks/driver/driver.go
+++ b/providers/aws/eks/driver/driver.go
@@ -55,6 +55,11 @@ type VPCConfig struct {
 	EndpointPublicAccess  bool
 	EndpointPrivateAccess bool
 	PublicAccessCidrs     []string
+	// ClusterSecurityGroupID and VpcID are populated by the provider on cluster
+	// create (they are not caller inputs): real EKS auto-creates a cluster
+	// security group and reports it here, and derives vpcId from the subnets.
+	ClusterSecurityGroupID string
+	VpcID                  string
 }
 
 // ClusterConfig configures a new EKS cluster.

--- a/providers/aws/eks/eks.go
+++ b/providers/aws/eks/eks.go
@@ -222,6 +222,112 @@ func copyStrings(src []string) []string {
 	return out
 }
 
+func copyTaints(src []eksdriver.Taint) []eksdriver.Taint {
+	if len(src) == 0 {
+		return nil
+	}
+
+	out := make([]eksdriver.Taint, len(src))
+	copy(out, src)
+
+	return out
+}
+
+// taintKey identifies a taint for merge/remove; real EKS treats Key+Effect as
+// the identity, so add/update replaces a matching pair and remove deletes it.
+func taintKey(t eksdriver.Taint) string {
+	return t.Key + "\x00" + t.Effect
+}
+
+// applyTaints overlays add/update taints onto cur and removes any matching the
+// remove set, preserving order. A nil result is returned when nothing remains.
+func applyTaints(cur, addOrUpdate, remove []eksdriver.Taint) []eksdriver.Taint {
+	byKey := make(map[string]eksdriver.Taint, len(cur)+len(addOrUpdate))
+	order := make([]string, 0, len(cur)+len(addOrUpdate))
+
+	upsert := func(t eksdriver.Taint) {
+		k := taintKey(t)
+		if _, ok := byKey[k]; !ok {
+			order = append(order, k)
+		}
+
+		byKey[k] = t
+	}
+
+	for _, t := range cur {
+		upsert(t)
+	}
+
+	for _, t := range addOrUpdate {
+		upsert(t)
+	}
+
+	for _, t := range remove {
+		delete(byKey, taintKey(t))
+	}
+
+	out := make([]eksdriver.Taint, 0, len(byKey))
+
+	for _, k := range order {
+		if t, ok := byKey[k]; ok {
+			out = append(out, t)
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
+// mergeLabels overlays addOrUpdate onto cur and deletes the remove keys,
+// returning a fresh map (nil when empty). This is the merge semantics real EKS
+// applies, unlike a wholesale replace.
+func mergeLabels(cur, addOrUpdate map[string]string, remove []string) map[string]string {
+	if len(cur) == 0 && len(addOrUpdate) == 0 {
+		return cur
+	}
+
+	out := copyTags(cur)
+	if out == nil {
+		out = make(map[string]string, len(addOrUpdate))
+	}
+
+	for k, v := range addOrUpdate {
+		out[k] = v
+	}
+
+	for _, k := range remove {
+		delete(out, k)
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
+// validateScaling rejects an inconsistent scaling config the way real EKS does
+// (InvalidParameterException): minSize must not exceed maxSize and desiredSize
+// must fall within [minSize, maxSize]. An all-zero config (scaling omitted) is
+// valid and left to defaults.
+func validateScaling(s eksdriver.NodegroupScalingConfig) error {
+	if s.MinSize > s.MaxSize {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"minSize (%d) must not be greater than maxSize (%d)", s.MinSize, s.MaxSize)
+	}
+
+	if s.DesiredSize < s.MinSize || s.DesiredSize > s.MaxSize {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"desiredSize (%d) must be between minSize (%d) and maxSize (%d)",
+			s.DesiredSize, s.MinSize, s.MaxSize)
+	}
+
+	return nil
+}
+
 func (m *Mock) emitClusterMetrics(name string) {
 	if m.monitoring == nil {
 		return
@@ -567,6 +673,12 @@ func (m *Mock) CreateNodegroup(_ context.Context, cfg eksdriver.NodegroupConfig)
 			"nodegroup %q already exists in cluster %q", cfg.NodegroupName, cfg.ClusterName)
 	}
 
+	if err := validateScaling(cfg.ScalingConfig); err != nil {
+		return nil, err
+	}
+
+	now := m.opts.Clock.Now().UTC()
+
 	ng := eksdriver.Nodegroup{
 		ClusterName:    cfg.ClusterName,
 		NodegroupName:  cfg.NodegroupName,
@@ -582,8 +694,10 @@ func (m *Mock) CreateNodegroup(_ context.Context, cfg eksdriver.NodegroupConfig)
 		ScalingConfig:  cfg.ScalingConfig,
 		Status:         eksdriver.NodegroupStatusActive,
 		Labels:         copyTags(cfg.Labels),
+		Taints:         copyTaints(cfg.Taints),
 		Tags:           copyTags(cfg.Tags),
-		CreatedAt:      m.opts.Clock.Now().UTC(),
+		CreatedAt:      now,
+		ModifiedAt:     now,
 	}
 
 	m.nodegroups.Set(key, ng)
@@ -630,10 +744,14 @@ func (m *Mock) ListNodegroups(_ context.Context, clusterName string) ([]string, 
 	return out, nil
 }
 
-// UpdateNodegroupConfig applies scaling and label changes to a nodegroup.
+// UpdateNodegroupConfig applies scaling, label, and taint changes to a
+// nodegroup. Labels and taints are merged as add/update + remove deltas so a
+// change touches only the keys named, matching real EKS.
+//
+//nolint:gocritic // upd matches the driver interface signature; copied once on entry.
 func (m *Mock) UpdateNodegroupConfig(
 	_ context.Context, clusterName, nodegroupName string,
-	scaling *eksdriver.NodegroupScalingConfig, labels map[string]string,
+	upd eksdriver.NodegroupConfigUpdate,
 ) (*eksdriver.ClusterUpdate, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -646,13 +764,17 @@ func (m *Mock) UpdateNodegroupConfig(
 			"nodegroup %q not found in cluster %q", nodegroupName, clusterName)
 	}
 
-	if scaling != nil {
-		ng.ScalingConfig = *scaling
+	if upd.Scaling != nil {
+		if err := validateScaling(*upd.Scaling); err != nil {
+			return nil, err
+		}
+
+		ng.ScalingConfig = *upd.Scaling
 	}
 
-	if labels != nil {
-		ng.Labels = copyTags(labels)
-	}
+	ng.Labels = mergeLabels(ng.Labels, upd.AddOrUpdateLabels, upd.RemoveLabels)
+	ng.Taints = applyTaints(ng.Taints, upd.AddOrUpdateTaints, upd.RemoveTaints)
+	ng.ModifiedAt = m.opts.Clock.Now().UTC()
 
 	m.nodegroups.Set(key, ng)
 
@@ -688,6 +810,8 @@ func (m *Mock) UpdateNodegroupVersion(
 	if releaseVersion != "" {
 		ng.ReleaseVersion = releaseVersion
 	}
+
+	ng.ModifiedAt = m.opts.Clock.Now().UTC()
 
 	m.nodegroups.Set(key, ng)
 

--- a/providers/aws/eks/eks.go
+++ b/providers/aws/eks/eks.go
@@ -36,6 +36,11 @@ const (
 	defaultPlatformVersion   = "eks.1"
 	defaultKubernetesVersion = "1.29"
 	namespaceEKS             = "AWS/EKS"
+
+	// Managed-nodegroup defaults real EKS applies when the caller omits them.
+	defaultNodegroupInstanceType = "t3.medium"
+	defaultNodegroupAmiType      = "AL2_x86_64"
+	defaultNodegroupDiskSize     = 20
 )
 
 // CloudWatch-style metric values emitted on cluster create. The numbers are
@@ -692,16 +697,31 @@ func (m *Mock) CreateNodegroup(_ context.Context, cfg eksdriver.NodegroupConfig)
 
 	now := m.opts.Clock.Now().UTC()
 
+	instanceTypes := copyStrings(cfg.InstanceTypes)
+	if len(instanceTypes) == 0 {
+		instanceTypes = []string{defaultNodegroupInstanceType}
+	}
+
+	amiType := cfg.AmiType
+	if amiType == "" {
+		amiType = defaultNodegroupAmiType
+	}
+
+	diskSize := cfg.DiskSize
+	if diskSize == 0 {
+		diskSize = defaultNodegroupDiskSize
+	}
+
 	ng := eksdriver.Nodegroup{
 		ClusterName:    cfg.ClusterName,
 		NodegroupName:  cfg.NodegroupName,
 		ARN:            m.nodegroupARN(cfg.ClusterName, cfg.NodegroupName),
 		NodeRole:       cfg.NodeRole,
 		Subnets:        copyStrings(cfg.Subnets),
-		InstanceTypes:  copyStrings(cfg.InstanceTypes),
-		AmiType:        cfg.AmiType,
+		InstanceTypes:  instanceTypes,
+		AmiType:        amiType,
 		CapacityType:   cfg.CapacityType,
-		DiskSize:       cfg.DiskSize,
+		DiskSize:       diskSize,
 		Version:        cfg.Version,
 		ReleaseVersion: cfg.ReleaseVersion,
 		ScalingConfig:  cfg.ScalingConfig,

--- a/providers/aws/eks/eks.go
+++ b/providers/aws/eks/eks.go
@@ -61,8 +61,9 @@ type Mock struct {
 	addons          *memstore.Store[eksdriver.Addon]
 	updates         *memstore.Store[eksdriver.ClusterUpdate]
 
-	opts       *config.Options
-	monitoring mondriver.Monitoring
+	opts           *config.Options
+	monitoring     mondriver.Monitoring
+	subnetResolver SubnetResolver
 
 	// k8sAPI is the shared in-memory Kubernetes data-plane server. When set,
 	// CreateCluster registers a fresh ClusterState with it and DescribeCluster
@@ -181,6 +182,16 @@ func (m *Mock) oidcIssuer(name string) string {
 	id := strings.ToUpper(hex.EncodeToString(sum[:16]))
 
 	return fmt.Sprintf("https://oidc.eks.%s.amazonaws.com/id/%s", m.opts.Region, id)
+}
+
+// clusterSecurityGroupID synthesizes the deterministic cluster security group
+// id real EKS creates for a cluster ("sg-<hash>"). It is stable across
+// DescribeCluster calls so downstream references (worker attach, SG rules) stay
+// fixed.
+func (m *Mock) clusterSecurityGroupID(name string) string {
+	sum := sha256.Sum256([]byte("eks-cluster-sg/" + m.opts.AccountID + "/" + name))
+
+	return "sg-" + hex.EncodeToString(sum[:8])
 }
 
 func (m *Mock) nodegroupARN(clusterName, nodegroupName string) string {
@@ -363,7 +374,7 @@ func (m *Mock) emitClusterMetrics(name string) {
 // CreateCluster creates a new cluster.
 //
 //nolint:gocritic // cfg matches the driver interface signature; copied once on entry.
-func (m *Mock) CreateCluster(_ context.Context, cfg eksdriver.ClusterConfig) (*eksdriver.Cluster, error) {
+func (m *Mock) CreateCluster(ctx context.Context, cfg eksdriver.ClusterConfig) (*eksdriver.Cluster, error) {
 	if cfg.Name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "cluster name is required")
 	}
@@ -393,11 +404,13 @@ func (m *Mock) CreateCluster(_ context.Context, cfg eksdriver.ClusterConfig) (*e
 		Status:               eksdriver.ClusterStatusActive,
 		OIDCIssuer:           m.oidcIssuer(cfg.Name),
 		VPCConfig: eksdriver.VPCConfig{
-			SubnetIDs:             copyStrings(cfg.VPCConfig.SubnetIDs),
-			SecurityGroupIDs:      copyStrings(cfg.VPCConfig.SecurityGroupIDs),
-			EndpointPublicAccess:  cfg.VPCConfig.EndpointPublicAccess,
-			EndpointPrivateAccess: cfg.VPCConfig.EndpointPrivateAccess,
-			PublicAccessCidrs:     copyStrings(cfg.VPCConfig.PublicAccessCidrs),
+			SubnetIDs:              copyStrings(cfg.VPCConfig.SubnetIDs),
+			SecurityGroupIDs:       copyStrings(cfg.VPCConfig.SecurityGroupIDs),
+			EndpointPublicAccess:   cfg.VPCConfig.EndpointPublicAccess,
+			EndpointPrivateAccess:  cfg.VPCConfig.EndpointPrivateAccess,
+			PublicAccessCidrs:      copyStrings(cfg.VPCConfig.PublicAccessCidrs),
+			ClusterSecurityGroupID: m.clusterSecurityGroupID(cfg.Name),
+			VpcID:                  m.resolveVpcID(ctx, cfg.VPCConfig.SubnetIDs),
 		},
 		Tags:      copyTags(cfg.Tags),
 		CreatedAt: m.opts.Clock.Now().UTC(),

--- a/providers/aws/eks/eks_test.go
+++ b/providers/aws/eks/eks_test.go
@@ -157,8 +157,9 @@ func TestNodegroupLifecycle(t *testing.T) {
 	requireNoError(t, err)
 	assertEqual(t, 1, len(names))
 
-	upd, err := m.UpdateNodegroupConfig(ctx, "c1", "ng1",
-		&eksdriver.NodegroupScalingConfig{MinSize: 2, MaxSize: 5, DesiredSize: 3}, nil)
+	upd, err := m.UpdateNodegroupConfig(ctx, "c1", "ng1", eksdriver.NodegroupConfigUpdate{
+		Scaling: &eksdriver.NodegroupScalingConfig{MinSize: 2, MaxSize: 5, DesiredSize: 3},
+	})
 	requireNoError(t, err)
 	assertEqual(t, "Successful", upd.Status)
 
@@ -178,6 +179,102 @@ func TestNodegroupLifecycle(t *testing.T) {
 
 	if _, err := m.DescribeNodegroup(ctx, "c1", "ng1"); err == nil {
 		t.Fatal("expected NotFound after delete")
+	}
+}
+
+func TestNodegroupTaintsAndModifiedAt(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	m := New(config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("us-east-1"),
+		config.WithAccountID("123456789012"),
+	))
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, eksdriver.ClusterConfig{Name: "c1", Version: "1.30"})
+	requireNoError(t, err)
+
+	ng, err := m.CreateNodegroup(ctx, eksdriver.NodegroupConfig{
+		ClusterName:   "c1",
+		NodegroupName: "ng1",
+		NodeRole:      "arn:aws:iam::123456789012:role/eks-node",
+		Subnets:       []string{"subnet-1"},
+		ScalingConfig: eksdriver.NodegroupScalingConfig{MinSize: 1, MaxSize: 3, DesiredSize: 2},
+		Taints:        []eksdriver.Taint{{Key: "dedicated", Value: "gpu", Effect: "NO_SCHEDULE"}},
+	})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(ng.Taints))
+	assertEqual(t, "dedicated", ng.Taints[0].Key)
+
+	if !ng.ModifiedAt.Equal(ng.CreatedAt) {
+		t.Fatalf("fresh nodegroup modifiedAt %v != createdAt %v", ng.ModifiedAt, ng.CreatedAt)
+	}
+
+	fc.Advance(5 * time.Minute)
+
+	_, err = m.UpdateNodegroupConfig(ctx, "c1", "ng1", eksdriver.NodegroupConfigUpdate{
+		AddOrUpdateTaints: []eksdriver.Taint{{Key: "spot", Value: "true", Effect: "PREFER_NO_SCHEDULE"}},
+		RemoveTaints:      []eksdriver.Taint{{Key: "dedicated", Effect: "NO_SCHEDULE"}},
+	})
+	requireNoError(t, err)
+
+	got, err := m.DescribeNodegroup(ctx, "c1", "ng1")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(got.Taints))
+	assertEqual(t, "spot", got.Taints[0].Key)
+
+	if !got.ModifiedAt.After(got.CreatedAt) {
+		t.Fatalf("modifiedAt %v did not advance past createdAt %v", got.ModifiedAt, got.CreatedAt)
+	}
+}
+
+func TestNodegroupLabelMergeAndRemove(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, eksdriver.ClusterConfig{Name: "c1"})
+	requireNoError(t, err)
+
+	_, err = m.CreateNodegroup(ctx, eksdriver.NodegroupConfig{
+		ClusterName:   "c1",
+		NodegroupName: "ng1",
+		NodeRole:      "arn:aws:iam::123456789012:role/eks-node",
+		Subnets:       []string{"subnet-1"},
+		ScalingConfig: eksdriver.NodegroupScalingConfig{MinSize: 1, MaxSize: 2, DesiredSize: 1},
+		Labels:        map[string]string{"a": "1", "b": "2"},
+	})
+	requireNoError(t, err)
+
+	_, err = m.UpdateNodegroupConfig(ctx, "c1", "ng1", eksdriver.NodegroupConfigUpdate{
+		AddOrUpdateLabels: map[string]string{"b": "22", "c": "3"},
+		RemoveLabels:      []string{"a"},
+	})
+	requireNoError(t, err)
+
+	got, err := m.DescribeNodegroup(ctx, "c1", "ng1")
+	requireNoError(t, err)
+
+	if got.Labels["a"] != "" || got.Labels["b"] != "22" || got.Labels["c"] != "3" {
+		t.Fatalf("label merge/remove wrong: %v", got.Labels)
+	}
+}
+
+func TestNodegroupScalingValidation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, eksdriver.ClusterConfig{Name: "c1"})
+	requireNoError(t, err)
+
+	_, err = m.CreateNodegroup(ctx, eksdriver.NodegroupConfig{
+		ClusterName:   "c1",
+		NodegroupName: "bad",
+		NodeRole:      "arn:aws:iam::123456789012:role/eks-node",
+		Subnets:       []string{"subnet-1"},
+		ScalingConfig: eksdriver.NodegroupScalingConfig{MinSize: 5, MaxSize: 2, DesiredSize: 1},
+	})
+	if err == nil {
+		t.Fatal("expected InvalidArgument for minSize > maxSize")
 	}
 }
 

--- a/providers/aws/eks/eks_test.go
+++ b/providers/aws/eks/eks_test.go
@@ -278,6 +278,27 @@ func TestNodegroupScalingValidation(t *testing.T) {
 	}
 }
 
+func TestCreateNodegroup_Defaults(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, eksdriver.ClusterConfig{Name: "c1"})
+	requireNoError(t, err)
+
+	ng, err := m.CreateNodegroup(ctx, eksdriver.NodegroupConfig{
+		ClusterName:   "c1",
+		NodegroupName: "ng1",
+		NodeRole:      "arn:aws:iam::123456789012:role/eks-node",
+		Subnets:       []string{"subnet-1"},
+		ScalingConfig: eksdriver.NodegroupScalingConfig{MinSize: 1, MaxSize: 2, DesiredSize: 1},
+	})
+	requireNoError(t, err)
+	assertEqual(t, 20, ng.DiskSize)
+	assertEqual(t, "AL2_x86_64", ng.AmiType)
+	assertEqual(t, 1, len(ng.InstanceTypes))
+	assertEqual(t, "t3.medium", ng.InstanceTypes[0])
+}
+
 func TestCreateNodegroup_ClusterMustExist(t *testing.T) {
 	m := newTestMock()
 

--- a/providers/aws/eks/subnet_resolver.go
+++ b/providers/aws/eks/subnet_resolver.go
@@ -1,0 +1,43 @@
+package eks
+
+import (
+	"context"
+
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// SubnetResolver is the slice of the networking mock EKS needs to derive a
+// cluster's VPC from its subnets. Real EKS infers resourcesVpcConfig.vpcId from
+// the subnets passed to CreateCluster rather than taking it as input.
+type SubnetResolver interface {
+	DescribeSubnets(ctx context.Context, ids []string) ([]netdriver.SubnetInfo, error)
+}
+
+// SetSubnetResolver wires the networking mock in so DescribeCluster can report
+// the VPC the cluster's subnets belong to. Without it vpcId is left empty.
+func (m *Mock) SetSubnetResolver(r SubnetResolver) {
+	m.mu.Lock()
+	m.subnetResolver = r
+	m.mu.Unlock()
+}
+
+// resolveVpcID returns the VPC that the given subnets belong to, or "" when no
+// resolver is wired or none of the subnets resolve. Caller holds m.mu.
+func (m *Mock) resolveVpcID(ctx context.Context, subnetIDs []string) string {
+	if m.subnetResolver == nil || len(subnetIDs) == 0 {
+		return ""
+	}
+
+	subnets, err := m.subnetResolver.DescribeSubnets(ctx, subnetIDs)
+	if err != nil {
+		return ""
+	}
+
+	for _, s := range subnets {
+		if s.VPCID != "" {
+			return s.VPCID
+		}
+	}
+
+	return ""
+}

--- a/providers/aws/eks/tags.go
+++ b/providers/aws/eks/tags.go
@@ -7,71 +7,169 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 )
 
-// clusterNameFromARN resolves an EKS cluster ARN
-// ("arn:aws:eks:<region>:<account>:cluster/<name>") to the bare cluster name.
-// A non-ARN value is returned unchanged.
-func clusterNameFromARN(arn string) string {
-	const marker = ":cluster/"
+// arnKind identifies which EKS store an ARN points at.
+type arnKind int
 
-	if i := strings.LastIndex(arn, marker); i >= 0 {
-		return arn[i+len(marker):]
+const (
+	arnCluster arnKind = iota
+	arnNodegroup
+	arnFargate
+	arnAddon
+)
+
+// arnParts is the number of colon-separated fields in a full EKS ARN
+// (arn:aws:eks:<region>:<account>:<resource-path>); the resource path is the
+// sixth field and itself may contain slashes.
+const arnParts = 6
+
+// childSegs is the minimum slash-separated segment count for a child-resource
+// ARN path (<kind>/<cluster>/<name>[/<uuid>]); clusterSegs is the minimum for a
+// cluster ARN path (cluster/<name>).
+const (
+	childSegs   = 3
+	clusterSegs = 2
+)
+
+// parseResourceRef resolves an EKS resource ARN to the store it lives in and
+// the key that store is indexed by. Real EKS tags every resource type
+// (cluster, nodegroup, Fargate profile, add-on); the resource path segment
+// selects the kind:
+//
+//	cluster/<name>
+//	nodegroup/<cluster>/<name>[/<uuid>]
+//	fargateprofile/<cluster>/<name>[/<uuid>]
+//	addon/<cluster>/<name>[/<uuid>]
+//
+// A bare, non-ARN value is treated as a cluster name so direct programmatic
+// callers keep working.
+func parseResourceRef(arn string) (kind arnKind, key string) {
+	path := arn
+	if fields := strings.SplitN(arn, ":", arnParts); len(fields) == arnParts {
+		path = fields[arnParts-1]
 	}
 
-	return arn
+	segs := strings.Split(path, "/")
+
+	switch segs[0] {
+	case "nodegroup":
+		if len(segs) >= childSegs {
+			return arnNodegroup, nodegroupKey(segs[1], segs[2])
+		}
+	case "fargateprofile":
+		if len(segs) >= childSegs {
+			return arnFargate, fargateKey(segs[1], segs[2])
+		}
+	case "addon":
+		if len(segs) >= childSegs {
+			return arnAddon, addonKey(segs[1], segs[2])
+		}
+	case "cluster":
+		if len(segs) >= clusterSegs {
+			return arnCluster, segs[1]
+		}
+	}
+
+	// Fallback: the value is not a recognizable EKS resource path, so treat it
+	// as a bare cluster name.
+	return arnCluster, path
 }
 
-// TagResource adds or overwrites tags on a cluster identified by ARN (EKS
-// TagResource).
-func (m *Mock) TagResource(_ context.Context, arn string, tags map[string]string) error {
-	name := clusterNameFromARN(arn)
+// resourceTags returns a copy of the tags on the resource the ARN identifies
+// and a setter that writes an updated tag map back. NotFound is returned when
+// the resource does not exist. Callers hold m.mu.
+func (m *Mock) resourceTags(arn string) (tags map[string]string, set func(map[string]string), err error) {
+	kind, key := parseResourceRef(arn)
 
-	c, ok := m.clusters.Get(name)
-	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "cluster %q not found", name)
+	//nolint:exhaustive // arnCluster (and any fallback) is handled by the default branch.
+	switch kind {
+	case arnNodegroup:
+		ng, ok := m.nodegroups.Get(key)
+		if !ok {
+			return nil, nil, cerrors.Newf(cerrors.NotFound, "resource %q not found", arn)
+		}
+
+		return ng.Tags, func(t map[string]string) { ng.Tags = t; m.nodegroups.Set(key, ng) }, nil
+	case arnFargate:
+		fp, ok := m.fargateProfiles.Get(key)
+		if !ok {
+			return nil, nil, cerrors.Newf(cerrors.NotFound, "resource %q not found", arn)
+		}
+
+		return fp.Tags, func(t map[string]string) { fp.Tags = t; m.fargateProfiles.Set(key, fp) }, nil
+	case arnAddon:
+		ad, ok := m.addons.Get(key)
+		if !ok {
+			return nil, nil, cerrors.Newf(cerrors.NotFound, "resource %q not found", arn)
+		}
+
+		return ad.Tags, func(t map[string]string) { ad.Tags = t; m.addons.Set(key, ad) }, nil
+	default: // arnCluster
+		c, ok := m.clusters.Get(key)
+		if !ok {
+			return nil, nil, cerrors.Newf(cerrors.NotFound, "resource %q not found", arn)
+		}
+
+		return c.Tags, func(t map[string]string) { c.Tags = t; m.clusters.Set(key, c) }, nil
+	}
+}
+
+// TagResource adds or overwrites tags on any EKS resource identified by ARN
+// (cluster, nodegroup, Fargate profile, or add-on).
+func (m *Mock) TagResource(_ context.Context, arn string, tags map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cur, set, err := m.resourceTags(arn)
+	if err != nil {
+		return err
 	}
 
-	if c.Tags == nil {
-		c.Tags = make(map[string]string, len(tags))
+	merged := copyTags(cur)
+	if merged == nil {
+		merged = make(map[string]string, len(tags))
 	}
 
 	for k, v := range tags {
-		c.Tags[k] = v
+		merged[k] = v
 	}
 
-	m.clusters.Set(name, c)
+	set(merged)
 
 	return nil
 }
 
-// UntagResource removes tags by key from a cluster identified by ARN.
+// UntagResource removes tags by key from any EKS resource identified by ARN.
 func (m *Mock) UntagResource(_ context.Context, arn string, keys []string) error {
-	name := clusterNameFromARN(arn)
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-	c, ok := m.clusters.Get(name)
-	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "cluster %q not found", name)
+	cur, set, err := m.resourceTags(arn)
+	if err != nil {
+		return err
 	}
 
+	merged := copyTags(cur)
 	for _, k := range keys {
-		delete(c.Tags, k)
+		delete(merged, k)
 	}
 
-	m.clusters.Set(name, c)
+	set(merged)
 
 	return nil
 }
 
-// ListResourceTags returns the tags on a cluster identified by ARN.
+// ListResourceTags returns the tags on any EKS resource identified by ARN.
 func (m *Mock) ListResourceTags(_ context.Context, arn string) (map[string]string, error) {
-	name := clusterNameFromARN(arn)
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
-	c, ok := m.clusters.Get(name)
-	if !ok {
-		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", name)
+	cur, _, err := m.resourceTags(arn)
+	if err != nil {
+		return nil, err
 	}
 
-	out := make(map[string]string, len(c.Tags))
-	for k, v := range c.Tags {
+	out := make(map[string]string, len(cur))
+	for k, v := range cur {
 		out[k] = v
 	}
 

--- a/server/aws/eks/errors.go
+++ b/server/aws/eks/errors.go
@@ -44,17 +44,19 @@ func writeErr(w http.ResponseWriter, err error) {
 		return
 	}
 
+	// wireMessage strips the internal "<Code>: " prefix so the surfaced message
+	// reads like real AWS (the X-Amzn-ErrorType header already carries the code).
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", wireMessage(err))
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "ResourceInUseException", err.Error())
+		writeError(w, http.StatusConflict, "ResourceInUseException", wireMessage(err))
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "InvalidParameterException", err.Error())
+		writeError(w, http.StatusBadRequest, "InvalidParameterException", wireMessage(err))
 	case cerrors.IsFailedPrecondition(err):
-		writeError(w, http.StatusBadRequest, "InvalidRequestException", err.Error())
+		writeError(w, http.StatusBadRequest, "InvalidRequestException", wireMessage(err))
 	default:
-		writeError(w, http.StatusInternalServerError, "ServerException", err.Error())
+		writeError(w, http.StatusInternalServerError, "ServerException", wireMessage(err))
 	}
 }
 

--- a/server/aws/eks/operations.go
+++ b/server/aws/eks/operations.go
@@ -212,6 +212,7 @@ func (h *Handler) createNodegroup(w http.ResponseWriter, r *http.Request, cluste
 		Version:        body.Version,
 		ReleaseVersion: body.ReleaseVersion,
 		Labels:         body.Labels,
+		Taints:         taintsToDriver(body.Taints),
 		Tags:           body.Tags,
 	}
 
@@ -266,10 +267,7 @@ func (h *Handler) updateNodegroupConfig(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	var (
-		scaling *eksdriver.NodegroupScalingConfig
-		labels  map[string]string
-	)
+	update := eksdriver.NodegroupConfigUpdate{}
 
 	if body.ScalingConfig != nil {
 		// Real EKS applies only the sizes present in the request; the driver
@@ -284,14 +282,20 @@ func (h *Handler) updateNodegroupConfig(w http.ResponseWriter, r *http.Request, 
 
 		merged := cur.ScalingConfig
 		mergeScaling(&merged, body.ScalingConfig)
-		scaling = &merged
+		update.Scaling = &merged
 	}
 
 	if body.Labels != nil {
-		labels = body.Labels.AddOrUpdateLabels
+		update.AddOrUpdateLabels = body.Labels.AddOrUpdateLabels
+		update.RemoveLabels = body.Labels.RemoveLabels
 	}
 
-	upd, err := h.eks.UpdateNodegroupConfig(r.Context(), clusterName, ngName, scaling, labels)
+	if body.Taints != nil {
+		update.AddOrUpdateTaints = taintsToDriver(body.Taints.AddOrUpdateTaints)
+		update.RemoveTaints = taintsToDriver(body.Taints.RemoveTaints)
+	}
+
+	upd, err := h.eks.UpdateNodegroupConfig(r.Context(), clusterName, ngName, update)
 	if err != nil {
 		writeErr(w, err)
 
@@ -524,6 +528,34 @@ func mergeScaling(dst *eksdriver.NodegroupScalingConfig, s *nodegroupScalingConf
 	}
 }
 
+// taintsToDriver converts wire taints to driver taints.
+func taintsToDriver(in []taintJSON) []eksdriver.Taint {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]eksdriver.Taint, 0, len(in))
+	for _, t := range in {
+		out = append(out, eksdriver.Taint{Key: t.Key, Value: t.Value, Effect: t.Effect})
+	}
+
+	return out
+}
+
+// taintsToJSON converts driver taints to their wire shape.
+func taintsToJSON(in []eksdriver.Taint) []taintJSON {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]taintJSON, 0, len(in))
+	for _, t := range in {
+		out = append(out, taintJSON{Key: t.Key, Value: t.Value, Effect: t.Effect})
+	}
+
+	return out
+}
+
 func scalingFromJSON(s *nodegroupScalingConfigJSON) eksdriver.NodegroupScalingConfig {
 	out := eksdriver.NodegroupScalingConfig{}
 
@@ -586,7 +618,7 @@ func toNodegroupJSON(n *eksdriver.Nodegroup) nodegroupJSON {
 		Version:        n.Version,
 		ReleaseVersion: n.ReleaseVersion,
 		CreatedAt:      epochSeconds(n.CreatedAt),
-		ModifiedAt:     epochSeconds(n.CreatedAt),
+		ModifiedAt:     epochSeconds(n.ModifiedAt),
 		Status:         n.Status,
 		CapacityType:   n.CapacityType,
 		ScalingConfig: &nodegroupScalingConfigJSON{
@@ -599,6 +631,7 @@ func toNodegroupJSON(n *eksdriver.Nodegroup) nodegroupJSON {
 		AmiType:       n.AmiType,
 		NodeRole:      n.NodeRole,
 		Labels:        n.Labels,
+		Taints:        taintsToJSON(n.Taints),
 		Tags:          n.Tags,
 	}
 

--- a/server/aws/eks/operations.go
+++ b/server/aws/eks/operations.go
@@ -586,11 +586,13 @@ func toClusterJSON(c *eksdriver.Cluster) clusterJSON {
 		PlatformVersion: c.PlatformVersion,
 		Tags:            c.Tags,
 		ResourcesVpcConfig: &vpcConfigResponse{
-			SubnetIDs:             c.VPCConfig.SubnetIDs,
-			SecurityGroupIDs:      c.VPCConfig.SecurityGroupIDs,
-			EndpointPublicAccess:  c.VPCConfig.EndpointPublicAccess,
-			EndpointPrivateAccess: c.VPCConfig.EndpointPrivateAccess,
-			PublicAccessCidrs:     c.VPCConfig.PublicAccessCidrs,
+			SubnetIDs:              c.VPCConfig.SubnetIDs,
+			SecurityGroupIDs:       c.VPCConfig.SecurityGroupIDs,
+			ClusterSecurityGroupID: c.VPCConfig.ClusterSecurityGroupID,
+			VpcID:                  c.VPCConfig.VpcID,
+			EndpointPublicAccess:   c.VPCConfig.EndpointPublicAccess,
+			EndpointPrivateAccess:  c.VPCConfig.EndpointPrivateAccess,
+			PublicAccessCidrs:      c.VPCConfig.PublicAccessCidrs,
 		},
 	}
 

--- a/server/aws/eks/sdk_errors_test.go
+++ b/server/aws/eks/sdk_errors_test.go
@@ -1,0 +1,38 @@
+package eks_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKEKSErrorMessageNoCodePrefix guards that generic errors surface a clean
+// message without the internal canonical-code prefix (e.g. "NotFound: ...").
+// The wire ErrorType header still carries the typed code.
+func TestSDKEKSErrorMessageNoCodePrefix(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.DescribeCluster(ctx, &awseks.DescribeClusterInput{Name: aws.String("nope")})
+	if err == nil {
+		t.Fatal("expected error for missing cluster")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected smithy.APIError, got %T: %v", err, err)
+	}
+
+	if apiErr.ErrorCode() != "ResourceNotFoundException" {
+		t.Fatalf("error code = %q, want ResourceNotFoundException", apiErr.ErrorCode())
+	}
+
+	if msg := apiErr.ErrorMessage(); strings.Contains(msg, "NotFound:") {
+		t.Fatalf("error message leaks canonical-code prefix: %q", msg)
+	}
+}

--- a/server/aws/eks/sdk_nodegroup_config_test.go
+++ b/server/aws/eks/sdk_nodegroup_config_test.go
@@ -1,0 +1,84 @@
+package eks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+)
+
+// TestSDKEKSNodegroupTaints verifies taints round-trip on create/describe and
+// that UpdateNodegroupConfig honors addOrUpdateTaints/removeTaints. Terraform
+// aws_eks_node_group taint{} blocks otherwise show perpetual drift.
+func TestSDKEKSNodegroupTaints(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awseks.CreateClusterInput{
+		Name:    aws.String("c1"),
+		RoleArn: aws.String("arn:aws:iam::123456789012:role/eks-cluster"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{
+			SubnetIds: []string{"subnet-1"},
+		},
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	ng, err := client.CreateNodegroup(ctx, &awseks.CreateNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+		NodeRole:      aws.String("arn:aws:iam::123456789012:role/eks-node"),
+		Subnets:       []string{"subnet-1"},
+		Taints: []ekstypes.Taint{
+			{Key: aws.String("dedicated"), Value: aws.String("gpu"), Effect: ekstypes.TaintEffectNoSchedule},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNodegroup: %v", err)
+	}
+
+	if len(ng.Nodegroup.Taints) != 1 || aws.ToString(ng.Nodegroup.Taints[0].Key) != "dedicated" {
+		t.Fatalf("create did not return taint, got %+v", ng.Nodegroup.Taints)
+	}
+
+	got, err := client.DescribeNodegroup(ctx, &awseks.DescribeNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeNodegroup: %v", err)
+	}
+
+	if len(got.Nodegroup.Taints) != 1 || got.Nodegroup.Taints[0].Effect != ekstypes.TaintEffectNoSchedule {
+		t.Fatalf("describe did not persist taint, got %+v", got.Nodegroup.Taints)
+	}
+
+	if _, err := client.UpdateNodegroupConfig(ctx, &awseks.UpdateNodegroupConfigInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+		Taints: &ekstypes.UpdateTaintsPayload{
+			AddOrUpdateTaints: []ekstypes.Taint{
+				{Key: aws.String("spot"), Value: aws.String("true"), Effect: ekstypes.TaintEffectPreferNoSchedule},
+			},
+			RemoveTaints: []ekstypes.Taint{
+				{Key: aws.String("dedicated"), Effect: ekstypes.TaintEffectNoSchedule},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("UpdateNodegroupConfig: %v", err)
+	}
+
+	got, err = client.DescribeNodegroup(ctx, &awseks.DescribeNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeNodegroup after taint update: %v", err)
+	}
+
+	if len(got.Nodegroup.Taints) != 1 || aws.ToString(got.Nodegroup.Taints[0].Key) != "spot" {
+		t.Fatalf("taint add/remove not applied, got %+v", got.Nodegroup.Taints)
+	}
+}

--- a/server/aws/eks/sdk_tagging_test.go
+++ b/server/aws/eks/sdk_tagging_test.go
@@ -1,0 +1,115 @@
+package eks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+)
+
+// TestSDKEKSTagResourceAllARNTypes verifies the tagging API works against every
+// EKS resource ARN — cluster, nodegroup, Fargate profile, and add-on — not just
+// clusters. Terraform tag updates on aws_eks_node_group / aws_eks_fargate_profile
+// / aws_eks_addon call TagResource against the child resource ARN.
+func TestSDKEKSTagResourceAllARNTypes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awseks.CreateClusterInput{
+		Name:    aws.String("c1"),
+		RoleArn: aws.String("arn:aws:iam::123456789012:role/eks-cluster"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{
+			SubnetIds: []string{"subnet-1", "subnet-2"},
+		},
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	ngOut, err := client.CreateNodegroup(ctx, &awseks.CreateNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+		NodeRole:      aws.String("arn:aws:iam::123456789012:role/eks-node"),
+		Subnets:       []string{"subnet-1"},
+	})
+	if err != nil {
+		t.Fatalf("CreateNodegroup: %v", err)
+	}
+
+	fpOut, err := client.CreateFargateProfile(ctx, &awseks.CreateFargateProfileInput{
+		ClusterName:         aws.String("c1"),
+		FargateProfileName:  aws.String("fp1"),
+		PodExecutionRoleArn: aws.String("arn:aws:iam::123456789012:role/eks-fargate"),
+	})
+	if err != nil {
+		t.Fatalf("CreateFargateProfile: %v", err)
+	}
+
+	adOut, err := client.CreateAddon(ctx, &awseks.CreateAddonInput{
+		ClusterName: aws.String("c1"),
+		AddonName:   aws.String("vpc-cni"),
+	})
+	if err != nil {
+		t.Fatalf("CreateAddon: %v", err)
+	}
+
+	clusterOut, err := client.DescribeCluster(ctx, &awseks.DescribeClusterInput{Name: aws.String("c1")})
+	if err != nil {
+		t.Fatalf("DescribeCluster: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		arn  string
+	}{
+		{"cluster", aws.ToString(clusterOut.Cluster.Arn)},
+		{"nodegroup", aws.ToString(ngOut.Nodegroup.NodegroupArn)},
+		{"fargateprofile", aws.ToString(fpOut.FargateProfile.FargateProfileArn)},
+		{"addon", aws.ToString(adOut.Addon.AddonArn)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.arn == "" {
+				t.Fatalf("%s ARN is empty", tc.name)
+			}
+
+			if _, err := client.TagResource(ctx, &awseks.TagResourceInput{
+				ResourceArn: aws.String(tc.arn),
+				Tags:        map[string]string{"team": "platform"},
+			}); err != nil {
+				t.Fatalf("TagResource(%s): %v", tc.name, err)
+			}
+
+			got, err := client.ListTagsForResource(ctx, &awseks.ListTagsForResourceInput{
+				ResourceArn: aws.String(tc.arn),
+			})
+			if err != nil {
+				t.Fatalf("ListTagsForResource(%s): %v", tc.name, err)
+			}
+
+			if got.Tags["team"] != "platform" {
+				t.Fatalf("%s: tag not returned, got %v", tc.name, got.Tags)
+			}
+
+			if _, err := client.UntagResource(ctx, &awseks.UntagResourceInput{
+				ResourceArn: aws.String(tc.arn),
+				TagKeys:     []string{"team"},
+			}); err != nil {
+				t.Fatalf("UntagResource(%s): %v", tc.name, err)
+			}
+
+			got, err = client.ListTagsForResource(ctx, &awseks.ListTagsForResourceInput{
+				ResourceArn: aws.String(tc.arn),
+			})
+			if err != nil {
+				t.Fatalf("ListTagsForResource(%s) after untag: %v", tc.name, err)
+			}
+
+			if _, ok := got.Tags["team"]; ok {
+				t.Fatalf("%s: tag not removed, got %v", tc.name, got.Tags)
+			}
+		})
+	}
+}

--- a/server/aws/eks/sdk_vpc_config_test.go
+++ b/server/aws/eks/sdk_vpc_config_test.go
@@ -1,0 +1,86 @@
+package eks_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// TestSDKEKSDescribeClusterVPCConfig verifies DescribeCluster reports a
+// synthesized clusterSecurityGroupId (sg-...) and derives vpcId from the
+// cluster's subnets. Terraform node-group modules reference
+// aws_eks_cluster.vpc_config[0].cluster_security_group_id and vpc_id.
+func TestSDKEKSDescribeClusterVPCConfig(t *testing.T) {
+	ctx := context.Background()
+	cloud := cloudemu.NewAWS()
+
+	vpc, err := cloud.VPC.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	if err != nil {
+		t.Fatalf("CreateVPC: %v", err)
+	}
+
+	subnet, err := cloud.VPC.CreateSubnet(ctx, netdriver.SubnetConfig{
+		VPCID:     vpc.ID,
+		CIDRBlock: "10.0.1.0/24",
+	})
+	if err != nil {
+		t.Fatalf("CreateSubnet: %v", err)
+	}
+
+	srv := awsserver.New(awsserver.Drivers{EKS: cloud.EKS, S3: cloud.S3})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	client := awseks.NewFromConfig(cfg, func(o *awseks.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+
+	if _, err := client.CreateCluster(ctx, &awseks.CreateClusterInput{
+		Name:    aws.String("c1"),
+		RoleArn: aws.String("arn:aws:iam::123456789012:role/eks-cluster"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{
+			SubnetIds: []string{subnet.ID},
+		},
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	got, err := client.DescribeCluster(ctx, &awseks.DescribeClusterInput{Name: aws.String("c1")})
+	if err != nil {
+		t.Fatalf("DescribeCluster: %v", err)
+	}
+
+	vc := got.Cluster.ResourcesVpcConfig
+	if vc == nil {
+		t.Fatal("resourcesVpcConfig is nil")
+	}
+
+	if sg := aws.ToString(vc.ClusterSecurityGroupId); !strings.HasPrefix(sg, "sg-") {
+		t.Fatalf("clusterSecurityGroupId = %q, want sg- prefix", sg)
+	}
+
+	if id := aws.ToString(vc.VpcId); id != vpc.ID {
+		t.Fatalf("vpcId = %q, want %q (derived from subnet)", id, vpc.ID)
+	}
+}

--- a/server/aws/eks/types.go
+++ b/server/aws/eks/types.go
@@ -66,6 +66,14 @@ type nodegroupScalingConfigJSON struct {
 	DesiredSize *int32 `json:"desiredSize,omitempty"`
 }
 
+// taintJSON mirrors the SDK Taint shape (key, value, effect) used on
+// CreateNodegroup, DescribeNodegroup, and UpdateNodegroupConfig.
+type taintJSON struct {
+	Key    string `json:"key,omitempty"`
+	Value  string `json:"value,omitempty"`
+	Effect string `json:"effect,omitempty"`
+}
+
 // nodegroupJSON is the EKS nodegroup resource shape.
 type nodegroupJSON struct {
 	NodegroupName  string                      `json:"nodegroupName"`
@@ -83,6 +91,7 @@ type nodegroupJSON struct {
 	AmiType        string                      `json:"amiType,omitempty"`
 	NodeRole       string                      `json:"nodeRole,omitempty"`
 	Labels         map[string]string           `json:"labels,omitempty"`
+	Taints         []taintJSON                 `json:"taints,omitempty"`
 	DiskSize       *int32                      `json:"diskSize,omitempty"`
 	Health         *nodegroupHealthJSON        `json:"health,omitempty"`
 	Resources      *nodegroupResourcesJSON     `json:"resources,omitempty"`
@@ -186,20 +195,28 @@ type createNodegroupRequest struct {
 	ReleaseVersion string                      `json:"releaseVersion,omitempty"`
 	ScalingConfig  *nodegroupScalingConfigJSON `json:"scalingConfig,omitempty"`
 	Labels         map[string]string           `json:"labels,omitempty"`
+	Taints         []taintJSON                 `json:"taints,omitempty"`
 	Tags           map[string]string           `json:"tags,omitempty"`
 }
 
 type updateNodegroupConfigRequest struct {
 	ScalingConfig *nodegroupScalingConfigJSON `json:"scalingConfig,omitempty"`
 	Labels        *labelsUpdate               `json:"labels,omitempty"`
+	Taints        *taintsUpdate               `json:"taints,omitempty"`
 }
 
 // labelsUpdate is the request shape for nodegroup label changes; the SDK
-// sends addOrUpdateLabels and removeLabels separately. The mock applies
-// addOrUpdateLabels and ignores removeLabels for Wave 1.
+// sends addOrUpdateLabels and removeLabels separately.
 type labelsUpdate struct {
 	AddOrUpdateLabels map[string]string `json:"addOrUpdateLabels,omitempty"`
 	RemoveLabels      []string          `json:"removeLabels,omitempty"`
+}
+
+// taintsUpdate is the request shape for nodegroup taint changes; the SDK sends
+// addOrUpdateTaints and removeTaints separately.
+type taintsUpdate struct {
+	AddOrUpdateTaints []taintJSON `json:"addOrUpdateTaints,omitempty"`
+	RemoveTaints      []taintJSON `json:"removeTaints,omitempty"`
 }
 
 type updateNodegroupVersionRequest struct {


### PR DESCRIPTION
## What

Fixes a batch of AWS EKS control-plane parity gaps found by a deep-e2e real-SDK audit (`aws-sdk-go-v2/service/eks`).

- **[HIGH] Tagging works on every EKS resource ARN, not just clusters.** `TagResource`/`UntagResource`/`ListTagsForResource` previously only resolved `:cluster/` ARNs; nodegroup/Fargate-profile/addon ARNs 404'd. The provider now parses the ARN resource segment and routes tag read/write to the matching store.
- **[MED] Nodegroup taints round-trip end-to-end.** `taints` is threaded through the driver, provider, and wire: stored on `CreateNodegroup`, returned on `DescribeNodegroup`, and `UpdateNodegroupConfig` applies `addOrUpdateTaints`/`removeTaints`. Label updates now merge `addOrUpdateLabels` and honor `removeLabels` (was a wholesale replace that ignored removes).
- **[MED] `DescribeCluster` reports `resourcesVpcConfig.clusterSecurityGroupId` and `vpcId`.** A deterministic `sg-` cluster security group is synthesized on create and the VPC is derived from the cluster's subnets via the shared `SubnetResolver` (`SetSubnetResolver(p.VPC)`, mirroring EFS/ELB).
- **[LOW] Clean error messages.** Generic error branches used `err.Error()`, leaking the internal `NotFound:`/`AlreadyExists:` prefix; they now use `wireMessage(err)` (the `X-Amzn-ErrorType` header still carries the typed code).
- **[LOW] Nodegroup mutation faithfulness.** `modifiedAt` advances on every mutating op, inconsistent scaling (`minSize>maxSize`, desired out of range) is rejected with `InvalidParameterException`, and managed-nodegroup defaults (`diskSize=20`, `instanceTypes=[t3.medium]`, `amiType=AL2_x86_64`) are applied when omitted.

## Why

These break real-user flows: terraform tag updates on `aws_eks_node_group`/`aws_eks_fargate_profile`/`aws_eks_addon` hard-fail; `aws_eks_node_group` `taint{}` blocks show perpetual drift; node-group modules reference `aws_eks_cluster.vpc_config[0].cluster_security_group_id` and `vpc_id`, which were empty.

## Tests

Real-SDK reproductions added: tagging across all four ARN types; taints create/describe + add/remove via `UpdateNodegroupConfig`; `clusterSecurityGroupId`+`vpcId` derivation from real subnets; clean error message; plus provider-level modifiedAt/label-merge/scaling-validation/defaults. Existing EKS tests (OIDC, delete guards, DescribeUpdate/ListUpdates, partial-scaling merge, pagination, data plane) stay green.

## Findings source

Deep-e2e audit `eks.md`: findings #1 (tagging), #2 (taints), #3 (clusterSG/vpcId), #5 (modifiedAt), #6 (error prefix), #7 (scaling validation), #8 (defaults), #9 (removeLabels). Deferred as feature gaps: #4 (logging/kubernetesNetworkConfig/accessConfig blocks) and #9's addon health block.