### PR TITLE
chore(compat): regenerate docs/compat matrix

### DIFF
--- a/docs/compat/README.md
+++ b/docs/compat/README.md
@@ -255,7 +255,9 @@ Legend: ✅ verified via Go SDK · `·` supported but not yet compat-tested · `
 | DeleteLogGroup | ✅ | ✅ | ✅ |
 | DeleteLogStream | ✅ | · | · |
 | DeleteMetricFilter | · | · | · |
+| DeleteSubscriptionFilter | · | · | · |
 | DescribeMetricFilters | · | · | · |
+| DescribeSubscriptionFilters | · | · | · |
 | FilterLogEvents | ✅ | · | · |
 | GetLogEvents | ✅ | · | ✅ |
 | GetLogGroup | ✅ | ✅ | · |
@@ -263,9 +265,10 @@ Legend: ✅ verified via Go SDK · `·` supported but not yet compat-tested · `
 | ListLogStreams | ✅ | · | · |
 | PutLogEvents | ✅ | · | ✅ |
 | PutMetricFilter | · | · | · |
+| PutSubscriptionFilter | · | · | · |
 | UpdateLogGroup | ✅ | ✅ | · |
 
-**logging verified via Go SDK:** AWS 11/14 · Azure 5/14 · GCP 4/14.
+**logging verified via Go SDK:** AWS 11/17 · Azure 5/17 · GCP 4/17.
 
 ## messagequeue
 

--- a/docs/compat/compat.json
+++ b/docs/compat/compat.json
@@ -3275,7 +3275,39 @@
   },
   {
     "service": "logging",
+    "operation": "DeleteSubscriptionFilter",
+    "providers": {
+      "aws": {
+        "native": "CloudWatchLogs"
+      },
+      "azure": {
+        "native": "LogAnalytics"
+      },
+      "gcp": {
+        "native": "CloudLogging"
+      }
+    },
+    "status": "amber"
+  },
+  {
+    "service": "logging",
     "operation": "DescribeMetricFilters",
+    "providers": {
+      "aws": {
+        "native": "CloudWatchLogs"
+      },
+      "azure": {
+        "native": "LogAnalytics"
+      },
+      "gcp": {
+        "native": "CloudLogging"
+      }
+    },
+    "status": "amber"
+  },
+  {
+    "service": "logging",
+    "operation": "DescribeSubscriptionFilters",
     "providers": {
       "aws": {
         "native": "CloudWatchLogs"
@@ -3399,6 +3431,22 @@
   {
     "service": "logging",
     "operation": "PutMetricFilter",
+    "providers": {
+      "aws": {
+        "native": "CloudWatchLogs"
+      },
+      "azure": {
+        "native": "LogAnalytics"
+      },
+      "gcp": {
+        "native": "CloudLogging"
+      }
+    },
+    "status": "amber"
+  },
+  {
+    "service": "logging",
+    "operation": "PutSubscriptionFilter",
     "providers": {
       "aws": {
         "native": "CloudWatchLogs"


### PR DESCRIPTION
CI Compat-matrix was red because compatgen output drifted after #681/#683 added ops (CloudWatchLogs subscription filters). Regenerated docs/compat/ from coverage.json + the in-process SDK-compat suite. Change is purely additive (3 new logging ops added as amber/supported-not-yet-compat-tested); no existing cell regressed. Idempotent: a second compatgen run produces zero further diff (exactly what CI checks).