### PR TITLE
fix(aws-opensearch): DescribeDomainConfig {Options,Status} envelope; VPC domain Endpoints["vpc"]; VPCId enrichment

### DIFF
--- a/providers/aws/opensearch/domains.go
+++ b/providers/aws/opensearch/domains.go
@@ -3,6 +3,8 @@ package opensearch
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"hash/fnv"
 	"sort"
 	"strings"
 
@@ -61,6 +63,20 @@ func (m *Mock) CreateDomain(_ context.Context, in driver.CreateDomainInput) (*dr
 
 	now := m.now()
 	cfg := copyClusterConfig(in.ClusterConfig)
+	raw := copyRaw(in.RawOptions)
+
+	// A VPC-access domain (created with VPCOptions carrying subnets) has no
+	// public Endpoint; instead it exposes Endpoints["vpc"], and AWS enriches the
+	// returned VPCOptions with a derived VPCId and AvailabilityZones.
+	endpoint := m.endpointFor(in.DomainName)
+
+	var endpoints map[string]string
+
+	if vpcEndpoints, enriched, ok := m.deriveVPC(raw, in.DomainName); ok {
+		endpoint = ""
+		endpoints = vpcEndpoints
+		raw["VPCOptions"] = enriched
+	}
 
 	status := driver.DomainStatus{
 		DomainID:               m.opts.AccountID + "/" + in.DomainName,
@@ -70,14 +86,15 @@ func (m *Mock) CreateDomain(_ context.Context, in driver.CreateDomainInput) (*dr
 		Deleted:                false,
 		Processing:             false,
 		EngineVersion:          engine,
-		Endpoint:               m.endpointFor(in.DomainName),
+		Endpoint:               endpoint,
+		Endpoints:              endpoints,
 		DomainProcessingStatus: driver.ProcessingActive,
 		ClusterConfig:          cfg,
 		AccessPolicies:         in.AccessPolicies,
 		AdvancedOptions:        copyTags(in.AdvancedOptions),
 		IPAddressType:          in.IPAddressType,
 		EngineMode:             in.EngineMode,
-		RawOptions:             copyRaw(in.RawOptions),
+		RawOptions:             copyRaw(raw),
 		CreatedAt:              now,
 	}
 
@@ -89,7 +106,8 @@ func (m *Mock) CreateDomain(_ context.Context, in driver.CreateDomainInput) (*dr
 			AccessPolicies:  in.AccessPolicies,
 			AdvancedOptions: copyTags(in.AdvancedOptions),
 			IPAddressType:   in.IPAddressType,
-			RawOptions:      copyRaw(in.RawOptions),
+			RawOptions:      copyRaw(raw),
+			CreatedAt:       now,
 			UpdatedAt:       now,
 		},
 		tags:     copyTags(in.Tags),
@@ -104,6 +122,95 @@ func (m *Mock) CreateDomain(_ context.Context, in driver.CreateDomainInput) (*dr
 	out := snapshotStatus(status)
 
 	return &out, nil
+}
+
+// vpcInput is the subset of a request's VPCOptions the emulator reads to derive
+// AWS-computed VPC placement.
+type vpcInput struct {
+	SubnetIDs []string `json:"SubnetIds"`
+}
+
+// deriveVPC inspects the caller-supplied VPCOptions block. When it carries
+// subnets, the domain is VPC-access: deriveVPC returns the Endpoints map
+// (a single "vpc" host), the VPCOptions block enriched with a derived VPCId and
+// AvailabilityZones (as real AWS returns in VPCDerivedInfo), and ok=true. It
+// returns ok=false for a public domain (no VPCOptions, or none with subnets).
+func (m *Mock) deriveVPC(
+	raw map[string]json.RawMessage, domainName string,
+) (endpoints map[string]string, enriched json.RawMessage, ok bool) {
+	rawVPC, present := raw["VPCOptions"]
+	if !present {
+		return nil, nil, false
+	}
+
+	var block map[string]json.RawMessage
+	if err := json.Unmarshal(rawVPC, &block); err != nil {
+		return nil, nil, false
+	}
+
+	var in vpcInput
+	if err := json.Unmarshal(rawVPC, &in); err != nil || len(in.SubnetIDs) == 0 {
+		return nil, nil, false
+	}
+
+	block["VPCId"] = marshalJSON(deterministicVPCID(in.SubnetIDs))
+	block["AvailabilityZones"] = marshalJSON(azsForSubnets(m.opts.Region, in.SubnetIDs))
+
+	enriched, err := json.Marshal(block)
+	if err != nil {
+		return nil, nil, false
+	}
+
+	return map[string]string{"vpc": m.vpcEndpointHost(domainName)}, enriched, true
+}
+
+// vpcEndpointHost builds the private VPC endpoint host for a VPC-access domain.
+func (m *Mock) vpcEndpointHost(name string) string {
+	return "vpc-" + name + "-" + idgen.GenerateID("") + "." + m.opts.Region + ".es.amazonaws.com"
+}
+
+// deterministicVPCID synthesizes a stable vpc-xxxx id from the domain's subnets,
+// since the emulator has no EC2 backend to resolve the real owning VPC.
+func deterministicVPCID(subnets []string) string {
+	sorted := append([]string(nil), subnets...)
+	sort.Strings(sorted)
+
+	h := fnv.New32a()
+	for _, s := range sorted {
+		_, _ = h.Write([]byte(s))
+	}
+
+	return fmt.Sprintf("vpc-%08x", h.Sum32())
+}
+
+// azsForSubnets derives the distinct availability zones the subnets span,
+// cycling deterministically through the region's a/b/c zones.
+func azsForSubnets(region string, subnets []string) []string {
+	zones := []string{"a", "b", "c"}
+	seen := map[string]bool{}
+
+	out := make([]string, 0, len(subnets))
+
+	for i := range subnets {
+		az := region + zones[i%len(zones)]
+		if !seen[az] {
+			seen[az] = true
+
+			out = append(out, az)
+		}
+	}
+
+	return out
+}
+
+// marshalJSON marshals v to a json.RawMessage, falling back to null on error.
+func marshalJSON(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return json.RawMessage("null")
+	}
+
+	return b
 }
 
 // DescribeDomain returns a deep copy of the stored domain status.

--- a/server/aws/opensearch/sdk_roundtrip_test.go
+++ b/server/aws/opensearch/sdk_roundtrip_test.go
@@ -213,6 +213,125 @@ func TestSDKCreateInvalidNameReturnsValidation(t *testing.T) {
 	}
 }
 
+func TestSDKDescribeDomainConfigEnvelope(t *testing.T) {
+	ctx := context.Background()
+	c := newOSClient(t)
+
+	if _, err := c.CreateDomain(ctx, &awsos.CreateDomainInput{
+		DomainName:    aws.String("cfg-domain"),
+		EngineVersion: aws.String("OpenSearch_2.11"),
+		EBSOptions: &ostypes.EBSOptions{
+			EBSEnabled: aws.Bool(true),
+			VolumeType: ostypes.VolumeTypeGp3,
+			VolumeSize: aws.Int32(20),
+		},
+		VPCOptions: &ostypes.VPCOptions{
+			SubnetIds: []string{"subnet-aaa", "subnet-bbb"},
+		},
+		EncryptionAtRestOptions: &ostypes.EncryptionAtRestOptions{
+			Enabled: aws.Bool(true),
+		},
+	}); err != nil {
+		t.Fatalf("CreateDomain: %v", err)
+	}
+
+	cfg, err := c.DescribeDomainConfig(ctx, &awsos.DescribeDomainConfigInput{DomainName: aws.String("cfg-domain")})
+	if err != nil {
+		t.Fatalf("DescribeDomainConfig: %v", err)
+	}
+
+	dc := cfg.DomainConfig
+
+	if dc.EBSOptions == nil || dc.EBSOptions.Options == nil {
+		t.Fatalf("EBSOptions envelope not populated: %+v", dc.EBSOptions)
+	}
+
+	if got := aws.ToInt32(dc.EBSOptions.Options.VolumeSize); got != 20 {
+		t.Fatalf("EBSOptions.Options.VolumeSize = %d, want 20", got)
+	}
+
+	if dc.EBSOptions.Status == nil || dc.EBSOptions.Status.State != ostypes.OptionStateActive {
+		t.Fatalf("EBSOptions.Status.State not Active: %+v", dc.EBSOptions.Status)
+	}
+
+	if dc.VPCOptions == nil || dc.VPCOptions.Options == nil {
+		t.Fatalf("VPCOptions envelope not populated: %+v", dc.VPCOptions)
+	}
+
+	if dc.EncryptionAtRestOptions == nil || dc.EncryptionAtRestOptions.Options == nil ||
+		!aws.ToBool(dc.EncryptionAtRestOptions.Options.Enabled) {
+		t.Fatalf("EncryptionAtRestOptions envelope not populated: %+v", dc.EncryptionAtRestOptions)
+	}
+
+	// Modeled blocks stay wrapped too.
+	if dc.ClusterConfig == nil || dc.ClusterConfig.Options == nil || dc.ClusterConfig.Status == nil {
+		t.Fatalf("ClusterConfig envelope regressed: %+v", dc.ClusterConfig)
+	}
+
+	// UpdateDomainConfig response returns the changed block in the envelope.
+	upd, err := c.UpdateDomainConfig(ctx, &awsos.UpdateDomainConfigInput{
+		DomainName: aws.String("cfg-domain"),
+		EBSOptions: &ostypes.EBSOptions{
+			EBSEnabled: aws.Bool(true),
+			VolumeType: ostypes.VolumeTypeGp3,
+			VolumeSize: aws.Int32(50),
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateDomainConfig: %v", err)
+	}
+
+	if upd.DomainConfig.EBSOptions == nil || upd.DomainConfig.EBSOptions.Options == nil ||
+		aws.ToInt32(upd.DomainConfig.EBSOptions.Options.VolumeSize) != 50 {
+		t.Fatalf("UpdateDomainConfig EBS envelope = %+v, want VolumeSize=50", upd.DomainConfig.EBSOptions)
+	}
+}
+
+func TestSDKVPCDomainEndpoints(t *testing.T) {
+	ctx := context.Background()
+	c := newOSClient(t)
+
+	// VPC-access domain: no public Endpoint, Endpoints["vpc"] set, VPCId derived.
+	vpc, err := c.CreateDomain(ctx, &awsos.CreateDomainInput{
+		DomainName: aws.String("vpc-domain"),
+		VPCOptions: &ostypes.VPCOptions{SubnetIds: []string{"subnet-123"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateDomain (vpc): %v", err)
+	}
+
+	if aws.ToString(vpc.DomainStatus.Endpoint) != "" {
+		t.Fatalf("VPC domain should have empty Endpoint, got %q", aws.ToString(vpc.DomainStatus.Endpoint))
+	}
+
+	if vpc.DomainStatus.Endpoints["vpc"] == "" {
+		t.Fatalf("VPC domain should expose Endpoints[vpc], got %+v", vpc.DomainStatus.Endpoints)
+	}
+
+	desc, err := c.DescribeDomain(ctx, &awsos.DescribeDomainInput{DomainName: aws.String("vpc-domain")})
+	if err != nil {
+		t.Fatalf("DescribeDomain (vpc): %v", err)
+	}
+
+	if desc.DomainStatus.VPCOptions == nil || aws.ToString(desc.DomainStatus.VPCOptions.VPCId) == "" {
+		t.Fatalf("VPCOptions.VPCId not enriched: %+v", desc.DomainStatus.VPCOptions)
+	}
+
+	// Public domain: keeps its single Endpoint, no vpc key.
+	pub, err := c.CreateDomain(ctx, &awsos.CreateDomainInput{DomainName: aws.String("pub-domain")})
+	if err != nil {
+		t.Fatalf("CreateDomain (public): %v", err)
+	}
+
+	if aws.ToString(pub.DomainStatus.Endpoint) == "" {
+		t.Fatalf("public domain should have an Endpoint")
+	}
+
+	if _, ok := pub.DomainStatus.Endpoints["vpc"]; ok {
+		t.Fatalf("public domain should not expose Endpoints[vpc], got %+v", pub.DomainStatus.Endpoints)
+	}
+}
+
 func TestSDKVersionsAndPackages(t *testing.T) {
 	ctx := context.Background()
 	c := newOSClient(t)

--- a/server/aws/opensearch/types.go
+++ b/server/aws/opensearch/types.go
@@ -225,36 +225,46 @@ func domainStatusToWire(s *driver.DomainStatus) map[string]json.RawMessage {
 }
 
 // statusEnvelope wraps a value in the {Options, Status} shape DescribeDomainConfig
-// uses for each option block.
-func statusEnvelope(options any) map[string]any {
+// uses for each option block. The Status is an AWS OptionStatus, whose State,
+// CreationDate, and UpdateDate are required; timestamps are epoch seconds.
+func statusEnvelope(options any, created, updated int64) map[string]any {
 	return map[string]any{
 		"Options": options,
 		"Status": map[string]any{
 			"State":           "Active",
 			"PendingDeletion": false,
+			"CreationDate":    created,
+			"UpdateDate":      updated,
+			"UpdateVersion":   1,
 		},
 	}
 }
 
 // domainConfigToWire renders a driver domain config as the DomainConfig wire
-// shape, wrapping each modeled block in a status envelope.
+// shape, wrapping every block — modeled and raw-passthrough alike — in the
+// {Options, Status} envelope the DescribeDomainConfig/UpdateDomainConfig API
+// requires. (DomainStatus, in contrast, emits the raw blocks flat; see
+// domainStatusToWire.)
 func domainConfigToWire(c *driver.DomainConfig) map[string]json.RawMessage {
+	created := c.CreatedAt.Unix()
+	updated := c.UpdatedAt.Unix()
+
 	base := map[string]any{
-		"EngineVersion":   statusEnvelope(c.EngineVersion),
-		"ClusterConfig":   statusEnvelope(clusterConfigToWire(c.ClusterConfig)),
-		"AccessPolicies":  statusEnvelope(c.AccessPolicies),
-		"AdvancedOptions": statusEnvelope(c.AdvancedOptions),
-		"IPAddressType":   statusEnvelope(c.IPAddressType),
+		"EngineVersion":   statusEnvelope(c.EngineVersion, created, updated),
+		"ClusterConfig":   statusEnvelope(clusterConfigToWire(c.ClusterConfig), created, updated),
+		"AccessPolicies":  statusEnvelope(c.AccessPolicies, created, updated),
+		"AdvancedOptions": statusEnvelope(c.AdvancedOptions, created, updated),
+		"IPAddressType":   statusEnvelope(c.IPAddressType, created, updated),
+	}
+
+	for k, v := range c.RawOptions {
+		base[k] = statusEnvelope(v, created, updated)
 	}
 
 	raw, _ := json.Marshal(base)
 
 	var out map[string]json.RawMessage
 	_ = json.Unmarshal(raw, &out)
-
-	for k, v := range c.RawOptions {
-		out[k] = v
-	}
 
 	return out
 }

--- a/services/opensearch/driver/driver.go
+++ b/services/opensearch/driver/driver.go
@@ -134,6 +134,7 @@ type DomainConfig struct {
 	AdvancedOptions map[string]string
 	IPAddressType   string
 	RawOptions      map[string]json.RawMessage
+	CreatedAt       time.Time
 	UpdatedAt       time.Time
 }
 


### PR DESCRIPTION
## What

Fixes three real-user bugs in AWS OpenSearch Service found by a deep real-SDK (aws-sdk-go-v2) e2e audit. The primary `DescribeDomain` (DomainStatus) round-trip was already correct and is left unchanged.

### F1 (HIGH) — DescribeDomainConfig/UpdateDomainConfig config-view envelope
`domainConfigToWire` emitted every raw option block (EBSOptions, VPCOptions, EncryptionAtRestOptions, NodeToNodeEncryptionOptions, DomainEndpointOptions, AdvancedSecurityOptions, AccessPolicies, …) **flat**, so the SDK deserialized `Options == nil` and `Status == nil` on the config view. AWS `DomainConfig` wraps every block in an `{Options, Status}` envelope (`OptionStatus`). Now every block — modeled and raw-passthrough alike — is wrapped, with a proper `OptionStatus` (`State: Active`, `PendingDeletion: false`, `CreationDate`, `UpdateDate`, `UpdateVersion`). `UpdateDomainConfig` returns the updated block in the same envelope.

### F2 (MED) — VPC-access domains
`CreateDomain` always set a public `Endpoint` and never populated `Endpoints`. AWS: a domain created with `VPCOptions` has **no** public `Endpoint`; it exposes `Endpoints["vpc"]` instead (Terraform reads `endpoint` from there). Now, when `VPCOptions` carries subnets, `Endpoint` is left empty and `Endpoints["vpc"]` is set; public domains keep their single `Endpoint`.

### F3 (LOW) — VPCOptions enrichment
The echoed `VPCOptions` omitted the AWS-derived `VPCId`/`AvailabilityZones`. Now enriched on create: a deterministic `VPCId` (hash of subnets, since the emulator has no EC2 backend to resolve the real VPC) and `AvailabilityZones` derived from the subnets. `DescribeDomain.VPCOptions.VPCId` is now populated.

## Why
The config-view API (`aws opensearch describe-domain-config`, Terraform reading EBS/VPC/encryption off the config view) returned unreadable `null` Options for every unmodeled block. VPC-domain users read an empty vpc endpoint. These match real AWS now.

## Tests
Real aws-sdk-go-v2 reproductions added: `TestSDKDescribeDomainConfigEnvelope` (EBS/VPC/encryption `.Options` populated + `.Status.State==Active`; UpdateDomainConfig EBS=50 in the envelope) and `TestSDKVPCDomainEndpoints` (VPC domain → `Endpoints["vpc"]` set, `Endpoint` empty, `VPCId` enriched; public domain → `Endpoint` set, no vpc key). Existing lifecycle/tags/update-persist tests stay green; `-race` clean.

## Notes
- No driver interface ops changed (only a `DomainConfig.CreatedAt` struct field); `docs/coverage` and `docs/compat` are zero-diff.
- The pre-existing `handler.go:156` nolintlint drift is untouched by this PR.