### PR TITLE
fix(aws-redshift): honor ModifyCluster resize; parameter-group contents; subnet-group VpcId/Subnets; validate subnet group; restore fields; KmsKeyId

### DIFF
--- a/docs/compat/README.md
+++ b/docs/compat/README.md
@@ -255,7 +255,9 @@ Legend: ✅ verified via Go SDK · `·` supported but not yet compat-tested · `
 | DeleteLogGroup | ✅ | ✅ | ✅ |
 | DeleteLogStream | ✅ | · | · |
 | DeleteMetricFilter | · | · | · |
+| DeleteSubscriptionFilter | · | · | · |
 | DescribeMetricFilters | · | · | · |
+| DescribeSubscriptionFilters | · | · | · |
 | FilterLogEvents | ✅ | · | · |
 | GetLogEvents | ✅ | · | ✅ |
 | GetLogGroup | ✅ | ✅ | · |
@@ -263,9 +265,10 @@ Legend: ✅ verified via Go SDK · `·` supported but not yet compat-tested · `
 | ListLogStreams | ✅ | · | · |
 | PutLogEvents | ✅ | · | ✅ |
 | PutMetricFilter | · | · | · |
+| PutSubscriptionFilter | · | · | · |
 | UpdateLogGroup | ✅ | ✅ | · |
 
-**logging verified via Go SDK:** AWS 11/14 · Azure 5/14 · GCP 4/14.
+**logging verified via Go SDK:** AWS 11/17 · Azure 5/17 · GCP 4/17.
 
 ## messagequeue
 

--- a/docs/compat/compat.json
+++ b/docs/compat/compat.json
@@ -3275,7 +3275,39 @@
   },
   {
     "service": "logging",
+    "operation": "DeleteSubscriptionFilter",
+    "providers": {
+      "aws": {
+        "native": "CloudWatchLogs"
+      },
+      "azure": {
+        "native": "LogAnalytics"
+      },
+      "gcp": {
+        "native": "CloudLogging"
+      }
+    },
+    "status": "amber"
+  },
+  {
+    "service": "logging",
     "operation": "DescribeMetricFilters",
+    "providers": {
+      "aws": {
+        "native": "CloudWatchLogs"
+      },
+      "azure": {
+        "native": "LogAnalytics"
+      },
+      "gcp": {
+        "native": "CloudLogging"
+      }
+    },
+    "status": "amber"
+  },
+  {
+    "service": "logging",
+    "operation": "DescribeSubscriptionFilters",
     "providers": {
       "aws": {
         "native": "CloudWatchLogs"
@@ -3399,6 +3431,22 @@
   {
     "service": "logging",
     "operation": "PutMetricFilter",
+    "providers": {
+      "aws": {
+        "native": "CloudWatchLogs"
+      },
+      "azure": {
+        "native": "LogAnalytics"
+      },
+      "gcp": {
+        "native": "CloudLogging"
+      }
+    },
+    "status": "amber"
+  },
+  {
+    "service": "logging",
+    "operation": "PutSubscriptionFilter",
     "providers": {
       "aws": {
         "native": "CloudWatchLogs"

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -269,6 +269,9 @@ func New(opts ...config.Option) *Provider {
 	// ELBv2 target group as the scheduler converges/drains the service.
 	p.ECS.SetTargetRegistrar(p.ELB)
 	p.Redshift.SetMonitoring(p.CloudWatch)
+	// A Redshift cluster subnet group derives its VpcId and per-subnet AZs from
+	// the member subnets, matching RDS/ElastiCache DB subnet groups.
+	p.Redshift.SetSubnetResolver(p.VPC)
 	p.EKS.SetMonitoring(p.CloudWatch)
 	p.SageMaker.SetMonitoring(p.CloudWatch)
 	// CloudWatch alarm -> SNS: an alarm state transition fires its configured

--- a/providers/aws/redshift/parameters.go
+++ b/providers/aws/redshift/parameters.go
@@ -1,0 +1,60 @@
+package redshift
+
+import rdbdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+
+// Redshift parameter apply types.
+const (
+	applyTypeStatic  = "static"
+	applyTypeDynamic = "dynamic"
+	sourceEngine     = "engine-default"
+)
+
+// redshiftDefaultParameter describes one seeded engine-default parameter.
+type redshiftDefaultParameter struct {
+	name      string
+	value     string
+	dataType  string
+	applyType string
+}
+
+// redshiftDefaultParameterSpecs is the curated set of default parameters real
+// Redshift exposes in a parameter group family (values from the AWS "Default
+// parameter values" table). It doubles as the validation set: a
+// ModifyClusterParameterGroup naming a parameter outside this set is rejected,
+// matching Redshift's rejection of parameters not in the family.
+//
+//nolint:gochecknoglobals // static default-parameter catalog.
+var redshiftDefaultParameterSpecs = []redshiftDefaultParameter{
+	{"auto_analyze", "true", "boolean", applyTypeDynamic},
+	{"auto_mv", "true", "boolean", applyTypeDynamic},
+	{"datestyle", "ISO, MDY", "string", applyTypeDynamic},
+	{"enable_case_sensitive_identifier", "false", "boolean", applyTypeDynamic},
+	{"enable_user_activity_logging", "false", "boolean", applyTypeStatic},
+	{"extra_float_digits", "0", "integer", applyTypeDynamic},
+	{"max_concurrency_scaling_clusters", "1", "integer", applyTypeDynamic},
+	{"max_cursor_result_set_size", "0", "integer", applyTypeDynamic},
+	{"query_group", "default", "string", applyTypeDynamic},
+	{"require_ssl", "false", "boolean", applyTypeStatic},
+	{"search_path", "$user, public", "string", applyTypeDynamic},
+	{"statement_timeout", "0", "integer", applyTypeDynamic},
+	{"use_fips_ssl", "false", "boolean", applyTypeStatic},
+	{"wlm_json_configuration", `[{"auto_wlm":true}]`, "string", applyTypeDynamic},
+}
+
+// defaultRedshiftParameters returns a fresh copy of the seeded engine-default
+// parameters, keyed by name. Each call returns a new map so a group never
+// shares mutable parameter state with another.
+func defaultRedshiftParameters() map[string]rdbdriver.Parameter {
+	out := make(map[string]rdbdriver.Parameter, len(redshiftDefaultParameterSpecs))
+	for _, p := range redshiftDefaultParameterSpecs {
+		out[p.name] = rdbdriver.Parameter{
+			Name:      p.name,
+			Value:     p.value,
+			Source:    sourceEngine,
+			DataType:  p.dataType,
+			ApplyType: p.applyType,
+		}
+	}
+
+	return out
+}

--- a/providers/aws/redshift/redshift.go
+++ b/providers/aws/redshift/redshift.go
@@ -620,7 +620,7 @@ func (m *Mock) ModifyCluster(
 		cluster.EngineVersion = input.EngineVersion
 	}
 
-	applyResize(&cluster, input)
+	applyResize(&cluster, &input)
 
 	if input.Tags != nil {
 		cluster.Tags = copyTags(input.Tags)
@@ -637,7 +637,7 @@ func (m *Mock) ModifyCluster(
 // / ClusterType) onto the cluster. A "single-node" ClusterType forces one node;
 // otherwise a positive NumberOfNodes is applied. Zero / empty inputs mean "no
 // change", so RDS/Aurora modifications (which never set these) are unaffected.
-func applyResize(cluster *rdbdriver.Cluster, input rdbdriver.ModifyInstanceInput) {
+func applyResize(cluster *rdbdriver.Cluster, input *rdbdriver.ModifyInstanceInput) {
 	if input.NodeType != "" {
 		cluster.NodeType = input.NodeType
 	}

--- a/providers/aws/redshift/redshift.go
+++ b/providers/aws/redshift/redshift.go
@@ -466,6 +466,8 @@ func (m *Mock) ModifyCluster(
 		cluster.EngineVersion = input.EngineVersion
 	}
 
+	applyResize(&cluster, input)
+
 	if input.Tags != nil {
 		cluster.Tags = copyTags(input.Tags)
 	}
@@ -475,6 +477,29 @@ func (m *Mock) ModifyCluster(
 	out := cluster
 
 	return &out, nil
+}
+
+// applyResize applies a Redshift ModifyCluster resize (NodeType / NumberOfNodes
+// / ClusterType) onto the cluster. A "single-node" ClusterType forces one node;
+// otherwise a positive NumberOfNodes is applied. Zero / empty inputs mean "no
+// change", so RDS/Aurora modifications (which never set these) are unaffected.
+func applyResize(cluster *rdbdriver.Cluster, input rdbdriver.ModifyInstanceInput) {
+	if input.NodeType != "" {
+		cluster.NodeType = input.NodeType
+	}
+
+	switch input.ClusterType {
+	case "single-node":
+		cluster.NumberOfNodes = singleNodeCount
+	case "multi-node":
+		if input.NumberOfNodes > 0 {
+			cluster.NumberOfNodes = input.NumberOfNodes
+		}
+	default:
+		if input.NumberOfNodes > 0 {
+			cluster.NumberOfNodes = input.NumberOfNodes
+		}
+	}
 }
 
 // DeleteCluster removes a cluster and tears down the real database backing it,

--- a/providers/aws/redshift/redshift.go
+++ b/providers/aws/redshift/redshift.go
@@ -692,6 +692,8 @@ func (m *Mock) CreateClusterSnapshot(
 		NumberOfNodes:              cluster.NumberOfNodes,
 		Encrypted:                  cluster.Encrypted,
 		TotalBackupSizeInMegaBytes: snapshotBackupSizeMB,
+		MasterUsername:             cluster.MasterUsername,
+		DatabaseName:               cluster.DatabaseName,
 		CreatedAt:                  m.opts.Clock.Now().UTC(),
 		Tags:                       copyTags(cfg.Tags),
 	}
@@ -767,16 +769,26 @@ func (m *Mock) RestoreClusterFromSnapshot(
 
 	now := m.opts.Clock.Now().UTC()
 
+	numberOfNodes := snap.NumberOfNodes
+	if numberOfNodes == 0 {
+		numberOfNodes = singleNodeCount
+	}
+
 	cluster := rdbdriver.Cluster{
-		ID:            input.NewClusterID,
-		ARN:           clusterARN(m.opts.Region, m.opts.AccountID, input.NewClusterID),
-		Engine:        snap.Engine,
-		EngineVersion: snap.EngineVersion,
-		Endpoint:      endpointFor(input.NewClusterID),
-		Port:          defaultPort,
-		State:         rdbdriver.StateAvailable,
-		CreatedAt:     now,
-		Tags:          copyTags(input.Tags),
+		ID:             input.NewClusterID,
+		ARN:            clusterARN(m.opts.Region, m.opts.AccountID, input.NewClusterID),
+		Engine:         snap.Engine,
+		EngineVersion:  snap.EngineVersion,
+		MasterUsername: snap.MasterUsername,
+		DatabaseName:   snap.DatabaseName,
+		Endpoint:       endpointFor(input.NewClusterID),
+		Port:           defaultPort,
+		State:          rdbdriver.StateAvailable,
+		NodeType:       snap.NodeType,
+		NumberOfNodes:  numberOfNodes,
+		Encrypted:      snap.Encrypted,
+		CreatedAt:      now,
+		Tags:           copyTags(input.Tags),
 	}
 
 	m.clusters.Set(input.NewClusterID, cluster)

--- a/providers/aws/redshift/redshift.go
+++ b/providers/aws/redshift/redshift.go
@@ -347,6 +347,7 @@ func (m *Mock) reserveCluster(cfg rdbdriver.ClusterConfig) (rdbdriver.Cluster, e
 		NodeType:                    cfg.NodeType,
 		NumberOfNodes:               numberOfNodes,
 		Encrypted:                   cfg.Encrypted,
+		KmsKeyID:                    cfg.KmsKeyID,
 		PubliclyAccessible:          cfg.PubliclyAccessible,
 		AvailabilityZone:            cfg.AvailabilityZone,
 		CreatedAt:                   m.opts.Clock.Now().UTC(),

--- a/providers/aws/redshift/redshift.go
+++ b/providers/aws/redshift/redshift.go
@@ -12,6 +12,7 @@ package redshift
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -49,6 +50,10 @@ type ParameterGroup struct {
 	Name        string
 	Family      string
 	Description string
+	// Parameters holds the group's engine parameters keyed by name. A freshly
+	// created group is seeded with the family's engine-default values; a
+	// ModifyClusterParameterGroup override flips a parameter's Source to "user".
+	Parameters map[string]rdbdriver.Parameter
 }
 
 type SubnetGroup struct {
@@ -106,10 +111,128 @@ func (m *Mock) CreateClusterParameterGroup(_ context.Context, name, family, desc
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "parameter group %q already exists", name)
 	}
 
-	pg := ParameterGroup{Name: name, Family: family, Description: description}
+	pg := ParameterGroup{
+		Name:        name,
+		Family:      family,
+		Description: description,
+		Parameters:  defaultRedshiftParameters(),
+	}
 	m.parameterGroups.Set(name, pg)
 
 	return &pg, nil
+}
+
+// ModifyClusterParameterGroup applies parameter overrides to a group. Each
+// modified parameter's Source becomes "user". An unknown parameter name is an
+// InvalidArgument (mapped to InvalidParameterValue), matching real Redshift's
+// rejection of parameters not in the group's family.
+func (m *Mock) ModifyClusterParameterGroup(
+	_ context.Context, name string, params []rdbdriver.Parameter,
+) (*ParameterGroup, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	pg, ok := m.parameterGroups.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "parameter group %q not found", name)
+	}
+
+	if pg.Parameters == nil {
+		pg.Parameters = defaultRedshiftParameters()
+	}
+
+	// Validate every parameter before applying any, so a bad entry never leaves
+	// earlier ones half-applied.
+	for i := range params {
+		if _, known := pg.Parameters[params[i].Name]; !known {
+			return nil, cerrors.Newf(cerrors.InvalidArgument,
+				"could not find parameter with name: %s", params[i].Name)
+		}
+	}
+
+	for i := range params {
+		cur := pg.Parameters[params[i].Name]
+		cur.Value = params[i].Value
+		cur.Source = "user"
+		pg.Parameters[params[i].Name] = cur
+	}
+
+	m.parameterGroups.Set(name, pg)
+
+	out := pg
+
+	return &out, nil
+}
+
+// DescribeClusterParameters returns the parameters of a group, sorted by name.
+func (m *Mock) DescribeClusterParameters(_ context.Context, name string) ([]rdbdriver.Parameter, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	pg, ok := m.parameterGroups.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "parameter group %q not found", name)
+	}
+
+	params := pg.Parameters
+	if params == nil {
+		params = defaultRedshiftParameters()
+	}
+
+	names := make([]string, 0, len(params))
+	for n := range params {
+		names = append(names, n)
+	}
+
+	sort.Strings(names)
+
+	out := make([]rdbdriver.Parameter, 0, len(names))
+	for _, n := range names {
+		out = append(out, params[n])
+	}
+
+	return out, nil
+}
+
+// ResetClusterParameterGroup restores parameters to their engine defaults —
+// the named ones, or all of them when resetAll is set.
+func (m *Mock) ResetClusterParameterGroup(
+	_ context.Context, name string, paramNames []string, resetAll bool,
+) (*ParameterGroup, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	pg, ok := m.parameterGroups.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "parameter group %q not found", name)
+	}
+
+	defaults := defaultRedshiftParameters()
+
+	if resetAll {
+		pg.Parameters = defaults
+		m.parameterGroups.Set(name, pg)
+
+		out := pg
+
+		return &out, nil
+	}
+
+	if pg.Parameters == nil {
+		pg.Parameters = defaultRedshiftParameters()
+	}
+
+	for _, n := range paramNames {
+		if def, known := defaults[n]; known {
+			pg.Parameters[n] = def
+		}
+	}
+
+	m.parameterGroups.Set(name, pg)
+
+	out := pg
+
+	return &out, nil
 }
 
 // DescribeClusterParameterGroups returns the named parameter groups, or all of

--- a/providers/aws/redshift/redshift.go
+++ b/providers/aws/redshift/redshift.go
@@ -55,6 +55,19 @@ type SubnetGroup struct {
 	Name        string
 	Description string
 	SubnetIDs   []string
+	// VPCID is derived from the member subnets (real Redshift infers it rather
+	// than taking it as input); empty when no subnet resolver is wired in.
+	VPCID string
+	// Subnets carries each member subnet with its availability zone, resolved at
+	// create time, so DescribeClusterSubnetGroups can emit the full Subnets list.
+	Subnets []Subnet
+}
+
+// Subnet is a member subnet of a cluster subnet group with its availability
+// zone, mirroring the AWS Redshift Subnet shape returned on describe.
+type Subnet struct {
+	ID               string
+	AvailabilityZone string
 }
 
 // Mock is the in-memory AWS Redshift implementation.
@@ -67,8 +80,9 @@ type Mock struct {
 	subnetGroups     *memstore.Store[SubnetGroup]
 	tagsByARN        map[string]map[string]string // ResourceName (ARN) -> tags
 
-	opts       *config.Options
-	monitoring mondriver.Monitoring
+	opts           *config.Options
+	monitoring     mondriver.Monitoring
+	subnetResolver SubnetResolver
 }
 
 // New creates a new AWS Redshift mock.
@@ -129,7 +143,7 @@ func (m *Mock) DeleteClusterParameterGroup(_ context.Context, name string) error
 }
 
 // CreateClusterSubnetGroup registers a redshift cluster subnet group.
-func (m *Mock) CreateClusterSubnetGroup(_ context.Context, name, description string, subnetIDs []string) (*SubnetGroup, error) {
+func (m *Mock) CreateClusterSubnetGroup(ctx context.Context, name, description string, subnetIDs []string) (*SubnetGroup, error) {
 	if name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "subnet group name is required")
 	}
@@ -138,7 +152,15 @@ func (m *Mock) CreateClusterSubnetGroup(_ context.Context, name, description str
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "subnet group %q already exists", name)
 	}
 
-	sg := SubnetGroup{Name: name, Description: description, SubnetIDs: subnetIDs}
+	vpcID, subnets := m.resolveSubnets(ctx, subnetIDs)
+
+	sg := SubnetGroup{
+		Name:        name,
+		Description: description,
+		SubnetIDs:   append([]string(nil), subnetIDs...),
+		VPCID:       vpcID,
+		Subnets:     subnets,
+	}
 	m.subnetGroups.Set(name, sg)
 
 	return &sg, nil

--- a/providers/aws/redshift/redshift.go
+++ b/providers/aws/redshift/redshift.go
@@ -316,6 +316,14 @@ func (m *Mock) reserveCluster(cfg rdbdriver.ClusterConfig) (rdbdriver.Cluster, e
 		return rdbdriver.Cluster{}, cerrors.Newf(cerrors.AlreadyExists, "Redshift cluster %q already exists", cfg.ID)
 	}
 
+	// A referenced subnet group must exist, matching real Redshift's
+	// ClusterSubnetGroupNotFoundFault (the handler maps "subnet group" NotFound
+	// to that code); otherwise IaC ordering mistakes are silently masked.
+	if cfg.SubnetGroupName != "" && !m.subnetGroups.Has(cfg.SubnetGroupName) {
+		return rdbdriver.Cluster{}, cerrors.Newf(cerrors.NotFound,
+			"cluster subnet group %q not found", cfg.SubnetGroupName)
+	}
+
 	engine := cfg.Engine
 	if engine == "" {
 		engine = defaultEngine

--- a/providers/aws/redshift/subnet_resolver.go
+++ b/providers/aws/redshift/subnet_resolver.go
@@ -49,18 +49,17 @@ func (m *Mock) resolveSubnets(ctx context.Context, subnetIDs []string) (string, 
 // lookupSubnets resolves the requested subnets into an id→AZ map and the VPC id
 // they belong to (the first non-empty one). Subnets spanning more than one VPC
 // is not a case real Redshift accepts, so the first match is the answer.
-func (m *Mock) lookupSubnets(ctx context.Context, subnetIDs []string) (map[string]string, string) {
+func (m *Mock) lookupSubnets(ctx context.Context, subnetIDs []string) (azByID map[string]string, vpcID string) {
 	subnets, err := m.subnetResolver.DescribeSubnets(ctx, subnetIDs)
 	if err != nil || len(subnets) == 0 {
 		return nil, ""
 	}
 
-	azByID := make(map[string]string, len(subnets))
-
-	var vpcID string
+	azByID = make(map[string]string, len(subnets))
 
 	for i := range subnets {
 		azByID[subnets[i].ID] = subnets[i].AvailabilityZone
+
 		if vpcID == "" && subnets[i].VPCID != "" {
 			vpcID = subnets[i].VPCID
 		}

--- a/providers/aws/redshift/subnet_resolver.go
+++ b/providers/aws/redshift/subnet_resolver.go
@@ -1,0 +1,70 @@
+package redshift
+
+import (
+	"context"
+
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// SubnetResolver is the slice of the networking mock this package needs to
+// derive a cluster subnet group's VPC and per-subnet availability zones. Real
+// Redshift infers VpcId from the member subnets rather than taking it as input,
+// and returns each subnet's availability zone on describe — so both have to be
+// resolved, not left blank.
+type SubnetResolver interface {
+	DescribeSubnets(ctx context.Context, ids []string) ([]netdriver.SubnetInfo, error)
+}
+
+// SetSubnetResolver wires the networking mock in. Without it a subnet group
+// still stores its members, but its VpcId is empty and the Subnets list carries
+// no availability zones.
+func (m *Mock) SetSubnetResolver(r SubnetResolver) {
+	m.subnetResolver = r
+}
+
+// resolveSubnets reports the VPC the member subnets belong to and builds the
+// per-subnet detail list (id + availability zone). Every input subnet id is
+// preserved in the returned list even when the resolver can't see it, so
+// subnet_ids always round-trip; the AZ is filled in when known.
+func (m *Mock) resolveSubnets(ctx context.Context, subnetIDs []string) (string, []Subnet) {
+	details := make([]Subnet, 0, len(subnetIDs))
+
+	if m.subnetResolver == nil {
+		for _, id := range subnetIDs {
+			details = append(details, Subnet{ID: id})
+		}
+
+		return "", details
+	}
+
+	azByID, vpcID := m.lookupSubnets(ctx, subnetIDs)
+
+	for _, id := range subnetIDs {
+		details = append(details, Subnet{ID: id, AvailabilityZone: azByID[id]})
+	}
+
+	return vpcID, details
+}
+
+// lookupSubnets resolves the requested subnets into an id→AZ map and the VPC id
+// they belong to (the first non-empty one). Subnets spanning more than one VPC
+// is not a case real Redshift accepts, so the first match is the answer.
+func (m *Mock) lookupSubnets(ctx context.Context, subnetIDs []string) (map[string]string, string) {
+	subnets, err := m.subnetResolver.DescribeSubnets(ctx, subnetIDs)
+	if err != nil || len(subnets) == 0 {
+		return nil, ""
+	}
+
+	azByID := make(map[string]string, len(subnets))
+
+	var vpcID string
+
+	for i := range subnets {
+		azByID[subnets[i].ID] = subnets[i].AvailabilityZone
+		if vpcID == "" && subnets[i].VPCID != "" {
+			vpcID = subnets[i].VPCID
+		}
+	}
+
+	return azByID, vpcID
+}

--- a/server/aws/redshift/cluster_kms_sdk_roundtrip_test.go
+++ b/server/aws/redshift/cluster_kms_sdk_roundtrip_test.go
@@ -1,0 +1,47 @@
+package redshift_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsredshift "github.com/aws/aws-sdk-go-v2/service/redshift"
+)
+
+// TestSDKRedshiftEncryptedClusterKmsKeyId proves an encrypted cluster round-trips
+// its KmsKeyId on create and DescribeClusters — without it a Terraform
+// aws_redshift_cluster.kms_key_id reads back empty and drifts.
+func TestSDKRedshiftEncryptedClusterKmsKeyId(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const kmsARN = "arn:aws:kms:us-east-1:123456789012:key/abc-123"
+
+	out, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:  aws.String("enc"),
+		MasterUsername:     aws.String("admin"),
+		MasterUserPassword: aws.String("Sup3rSecret!"),
+		NodeType:           aws.String("ra3.xlplus"),
+		Encrypted:          aws.Bool(true),
+		KmsKeyId:           aws.String(kmsARN),
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if !aws.ToBool(out.Cluster.Encrypted) || aws.ToString(out.Cluster.KmsKeyId) != kmsARN {
+		t.Fatalf("create Encrypted/KmsKeyId = %v/%q, want true/%q",
+			aws.ToBool(out.Cluster.Encrypted), aws.ToString(out.Cluster.KmsKeyId), kmsARN)
+	}
+
+	got, err := client.DescribeClusters(ctx, &awsredshift.DescribeClustersInput{
+		ClusterIdentifier: aws.String("enc"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusters: %v", err)
+	}
+
+	if aws.ToString(got.Clusters[0].KmsKeyId) != kmsARN {
+		t.Fatalf("describe KmsKeyId = %q, want %q", aws.ToString(got.Clusters[0].KmsKeyId), kmsARN)
+	}
+}

--- a/server/aws/redshift/cluster_parameters_sdk_roundtrip_test.go
+++ b/server/aws/redshift/cluster_parameters_sdk_roundtrip_test.go
@@ -1,0 +1,99 @@
+package redshift_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsredshift "github.com/aws/aws-sdk-go-v2/service/redshift"
+	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKRedshiftClusterParameters proves the parameter-group parameter surface
+// real Terraform aws_redshift_parameter_group relies on: DescribeClusterParameters
+// returns the family defaults, ModifyClusterParameterGroup applies overrides
+// (flipping Source to "user"), and an unknown parameter is rejected with
+// InvalidParameterValue. Before this, both actions returned InvalidAction 400.
+func TestSDKRedshiftClusterParameters(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateClusterParameterGroup(ctx, &awsredshift.CreateClusterParameterGroupInput{
+		ParameterGroupName:   aws.String("pg1"),
+		ParameterGroupFamily: aws.String("redshift-1.0"),
+		Description:          aws.String("my pg"),
+	}); err != nil {
+		t.Fatalf("CreateClusterParameterGroup: %v", err)
+	}
+
+	// Defaults are readable and non-empty, all engine-default sourced.
+	desc, err := client.DescribeClusterParameters(ctx, &awsredshift.DescribeClusterParametersInput{
+		ParameterGroupName: aws.String("pg1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusterParameters: %v", err)
+	}
+	if len(desc.Parameters) == 0 {
+		t.Fatal("expected non-empty default parameters")
+	}
+	if !hasParam(desc.Parameters, "require_ssl") {
+		t.Fatal("expected require_ssl among defaults")
+	}
+	for _, p := range desc.Parameters {
+		if aws.ToString(p.Source) != "engine-default" {
+			t.Fatalf("param %q Source = %q, want engine-default", aws.ToString(p.ParameterName), aws.ToString(p.Source))
+		}
+	}
+
+	// Apply an override; Source flips to user and value reflects.
+	if _, err := client.ModifyClusterParameterGroup(ctx, &awsredshift.ModifyClusterParameterGroupInput{
+		ParameterGroupName: aws.String("pg1"),
+		Parameters: []redshifttypes.Parameter{
+			{ParameterName: aws.String("require_ssl"), ParameterValue: aws.String("true")},
+		},
+	}); err != nil {
+		t.Fatalf("ModifyClusterParameterGroup: %v", err)
+	}
+
+	after, err := client.DescribeClusterParameters(ctx, &awsredshift.DescribeClusterParametersInput{
+		ParameterGroupName: aws.String("pg1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusterParameters(after): %v", err)
+	}
+	rs := findParam(after.Parameters, "require_ssl")
+	if rs == nil || aws.ToString(rs.ParameterValue) != "true" || aws.ToString(rs.Source) != "user" {
+		t.Fatalf("require_ssl after modify = %+v, want value=true source=user", rs)
+	}
+
+	// An unknown parameter is rejected with InvalidParameterValue.
+	_, err = client.ModifyClusterParameterGroup(ctx, &awsredshift.ModifyClusterParameterGroupInput{
+		ParameterGroupName: aws.String("pg1"),
+		Parameters: []redshifttypes.Parameter{
+			{ParameterName: aws.String("not_a_real_param"), ParameterValue: aws.String("x")},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown parameter")
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("unknown-parameter ErrorCode = %v, want InvalidParameterValue", err)
+	}
+}
+
+func hasParam(params []redshifttypes.Parameter, name string) bool {
+	return findParam(params, name) != nil
+}
+
+func findParam(params []redshifttypes.Parameter, name string) *redshifttypes.Parameter {
+	for i := range params {
+		if aws.ToString(params[i].ParameterName) == name {
+			return &params[i]
+		}
+	}
+
+	return nil
+}

--- a/server/aws/redshift/cluster_resize_sdk_roundtrip_test.go
+++ b/server/aws/redshift/cluster_resize_sdk_roundtrip_test.go
@@ -1,0 +1,86 @@
+package redshift_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsredshift "github.com/aws/aws-sdk-go-v2/service/redshift"
+)
+
+// TestSDKRedshiftModifyClusterResize proves ModifyCluster applies a NodeType /
+// NumberOfNodes resize and that DescribeClusters reflects it — without this a
+// Terraform aws_redshift_cluster changing node_type/number_of_nodes never
+// converges (perpetual drift).
+func TestSDKRedshiftModifyClusterResize(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:  aws.String("wh"),
+		MasterUsername:     aws.String("admin"),
+		MasterUserPassword: aws.String("Sup3rSecret!"),
+		NodeType:           aws.String("dc2.large"),
+		ClusterType:        aws.String("multi-node"),
+		NumberOfNodes:      aws.Int32(2),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	out, err := client.ModifyCluster(ctx, &awsredshift.ModifyClusterInput{
+		ClusterIdentifier: aws.String("wh"),
+		NodeType:          aws.String("ra3.xlplus"),
+		NumberOfNodes:     aws.Int32(4),
+	})
+	if err != nil {
+		t.Fatalf("ModifyCluster: %v", err)
+	}
+
+	if aws.ToString(out.Cluster.NodeType) != "ra3.xlplus" || aws.ToInt32(out.Cluster.NumberOfNodes) != 4 {
+		t.Fatalf("ModifyCluster response node config = %q/%d, want ra3.xlplus/4",
+			aws.ToString(out.Cluster.NodeType), aws.ToInt32(out.Cluster.NumberOfNodes))
+	}
+
+	got, err := client.DescribeClusters(ctx, &awsredshift.DescribeClustersInput{
+		ClusterIdentifier: aws.String("wh"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusters: %v", err)
+	}
+
+	if aws.ToString(got.Clusters[0].NodeType) != "ra3.xlplus" || aws.ToInt32(got.Clusters[0].NumberOfNodes) != 4 {
+		t.Fatalf("after resize DescribeClusters node config = %q/%d, want ra3.xlplus/4",
+			aws.ToString(got.Clusters[0].NodeType), aws.ToInt32(got.Clusters[0].NumberOfNodes))
+	}
+}
+
+// TestSDKRedshiftModifyClusterSingleNode proves ClusterType single-node forces
+// NumberOfNodes to 1 on resize.
+func TestSDKRedshiftModifyClusterSingleNode(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:  aws.String("wh2"),
+		MasterUsername:     aws.String("admin"),
+		MasterUserPassword: aws.String("Sup3rSecret!"),
+		NodeType:           aws.String("dc2.large"),
+		ClusterType:        aws.String("multi-node"),
+		NumberOfNodes:      aws.Int32(3),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	out, err := client.ModifyCluster(ctx, &awsredshift.ModifyClusterInput{
+		ClusterIdentifier: aws.String("wh2"),
+		NodeType:          aws.String("dc2.large"),
+		ClusterType:       aws.String("single-node"),
+	})
+	if err != nil {
+		t.Fatalf("ModifyCluster: %v", err)
+	}
+
+	if aws.ToInt32(out.Cluster.NumberOfNodes) != 1 {
+		t.Fatalf("single-node resize NumberOfNodes = %d, want 1", aws.ToInt32(out.Cluster.NumberOfNodes))
+	}
+}

--- a/server/aws/redshift/cluster_restore_fields_sdk_roundtrip_test.go
+++ b/server/aws/redshift/cluster_restore_fields_sdk_roundtrip_test.go
@@ -1,0 +1,65 @@
+package redshift_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsredshift "github.com/aws/aws-sdk-go-v2/service/redshift"
+)
+
+// TestSDKRedshiftRestorePreservesConfig proves a cluster restored from a snapshot
+// carries the snapshot's node config and the source cluster's admin user / DB
+// name — without it a restored cluster reads back with empty NodeType, zero
+// NumberOfNodes and no MasterUsername/DBName, so IaC sees the wrong shape.
+func TestSDKRedshiftRestorePreservesConfig(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:  aws.String("src"),
+		MasterUsername:     aws.String("admin"),
+		MasterUserPassword: aws.String("Sup3rSecret!"),
+		NodeType:           aws.String("ra3.xlplus"),
+		ClusterType:        aws.String("multi-node"),
+		NumberOfNodes:      aws.Int32(3),
+		DBName:             aws.String("dev"),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := client.CreateClusterSnapshot(ctx, &awsredshift.CreateClusterSnapshotInput{
+		SnapshotIdentifier: aws.String("snap1"),
+		ClusterIdentifier:  aws.String("src"),
+	}); err != nil {
+		t.Fatalf("CreateClusterSnapshot: %v", err)
+	}
+
+	restored, err := client.RestoreFromClusterSnapshot(ctx, &awsredshift.RestoreFromClusterSnapshotInput{
+		ClusterIdentifier:  aws.String("restored"),
+		SnapshotIdentifier: aws.String("snap1"),
+	})
+	if err != nil {
+		t.Fatalf("RestoreFromClusterSnapshot: %v", err)
+	}
+
+	c := restored.Cluster
+	if aws.ToString(c.NodeType) != "ra3.xlplus" || aws.ToInt32(c.NumberOfNodes) != 3 ||
+		aws.ToString(c.MasterUsername) != "admin" || aws.ToString(c.DBName) != "dev" {
+		t.Fatalf("restored config = node %q/%d user %q db %q, want ra3.xlplus/3/admin/dev",
+			aws.ToString(c.NodeType), aws.ToInt32(c.NumberOfNodes),
+			aws.ToString(c.MasterUsername), aws.ToString(c.DBName))
+	}
+
+	// The synthesized ClusterNodes list should be present (NumberOfNodes > 0).
+	got, err := client.DescribeClusters(ctx, &awsredshift.DescribeClustersInput{
+		ClusterIdentifier: aws.String("restored"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusters: %v", err)
+	}
+
+	if len(got.Clusters[0].ClusterNodes) == 0 {
+		t.Fatal("restored cluster has no ClusterNodes (NumberOfNodes not preserved)")
+	}
+}

--- a/server/aws/redshift/cluster_subnet_group_validation_sdk_roundtrip_test.go
+++ b/server/aws/redshift/cluster_subnet_group_validation_sdk_roundtrip_test.go
@@ -1,0 +1,36 @@
+package redshift_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsredshift "github.com/aws/aws-sdk-go-v2/service/redshift"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKRedshiftCreateClusterMissingSubnetGroup proves CreateCluster rejects a
+// reference to a non-existent cluster subnet group with
+// ClusterSubnetGroupNotFoundFault instead of silently succeeding — masking an
+// IaC ordering error (cluster created before its subnet group).
+func TestSDKRedshiftCreateClusterMissingSubnetGroup(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:      aws.String("c1"),
+		MasterUsername:         aws.String("admin"),
+		MasterUserPassword:     aws.String("Sup3rSecret!"),
+		NodeType:               aws.String("ra3.xlplus"),
+		ClusterSubnetGroupName: aws.String("does-not-exist"),
+	})
+	if err == nil {
+		t.Fatal("expected ClusterSubnetGroupNotFoundFault, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ClusterSubnetGroupNotFoundFault" {
+		t.Fatalf("ErrorCode = %v, want ClusterSubnetGroupNotFoundFault", err)
+	}
+}

--- a/server/aws/redshift/cluster_subnet_group_vpc_sdk_roundtrip_test.go
+++ b/server/aws/redshift/cluster_subnet_group_vpc_sdk_roundtrip_test.go
@@ -1,0 +1,111 @@
+package redshift_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	awsredshift "github.com/aws/aws-sdk-go-v2/service/redshift"
+	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// TestSDKRedshiftSubnetGroupVpcAndSubnets proves CreateClusterSubnetGroup /
+// DescribeClusterSubnetGroups return the derived VpcId and the full Subnets list
+// (with availability zones). Without it a Terraform aws_redshift_subnet_group
+// reads subnet_ids/vpc_id back empty and drifts on every plan.
+func TestSDKRedshiftSubnetGroupVpcAndSubnets(t *testing.T) {
+	ctx := context.Background()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.DriversFrom(cloud))
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfg.BaseEndpoint = aws.String(ts.URL)
+
+	ec2c := awsec2.NewFromConfig(cfg)
+	rsc := awsredshift.NewFromConfig(cfg)
+
+	vpc, err := ec2c.CreateVpc(ctx, &awsec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+	vpcID := aws.ToString(vpc.Vpc.VpcId)
+
+	subnetAZs := map[string]string{"10.0.1.0/24": "us-east-1a", "10.0.2.0/24": "us-east-1b"}
+
+	var subnetIDs []string
+	for _, cidr := range []string{"10.0.1.0/24", "10.0.2.0/24"} {
+		sub, err := ec2c.CreateSubnet(ctx, &awsec2.CreateSubnetInput{
+			VpcId: aws.String(vpcID), CidrBlock: aws.String(cidr),
+			AvailabilityZone: aws.String(subnetAZs[cidr]),
+		})
+		if err != nil {
+			t.Fatalf("CreateSubnet(%s): %v", cidr, err)
+		}
+		subnetIDs = append(subnetIDs, aws.ToString(sub.Subnet.SubnetId))
+	}
+
+	created, err := rsc.CreateClusterSubnetGroup(ctx, &awsredshift.CreateClusterSubnetGroupInput{
+		ClusterSubnetGroupName: aws.String("sg1"),
+		Description:            aws.String("my sg"),
+		SubnetIds:              subnetIDs,
+	})
+	if err != nil {
+		t.Fatalf("CreateClusterSubnetGroup: %v", err)
+	}
+
+	assertSubnetGroup(t, "create", created.ClusterSubnetGroup, vpcID, subnetIDs)
+
+	listed, err := rsc.DescribeClusterSubnetGroups(ctx, &awsredshift.DescribeClusterSubnetGroupsInput{
+		ClusterSubnetGroupName: aws.String("sg1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusterSubnetGroups: %v", err)
+	}
+	if len(listed.ClusterSubnetGroups) != 1 {
+		t.Fatalf("got %d groups, want 1", len(listed.ClusterSubnetGroups))
+	}
+
+	assertSubnetGroup(t, "describe", &listed.ClusterSubnetGroups[0], vpcID, subnetIDs)
+}
+
+func assertSubnetGroup(t *testing.T, where string, g *redshifttypes.ClusterSubnetGroup, wantVpc string, wantSubnets []string) {
+	t.Helper()
+
+	if aws.ToString(g.VpcId) != wantVpc {
+		t.Errorf("%s: VpcId = %q, want %q", where, aws.ToString(g.VpcId), wantVpc)
+	}
+
+	if len(g.Subnets) != len(wantSubnets) {
+		t.Fatalf("%s: got %d subnets, want %d", where, len(g.Subnets), len(wantSubnets))
+	}
+
+	got := make(map[string]bool, len(g.Subnets))
+	for _, s := range g.Subnets {
+		got[aws.ToString(s.SubnetIdentifier)] = true
+		if s.SubnetAvailabilityZone == nil || aws.ToString(s.SubnetAvailabilityZone.Name) == "" {
+			t.Errorf("%s: subnet %q has no availability zone", where, aws.ToString(s.SubnetIdentifier))
+		}
+	}
+	for _, id := range wantSubnets {
+		if !got[id] {
+			t.Errorf("%s: subnet %q missing from Subnets", where, id)
+		}
+	}
+}

--- a/server/aws/redshift/handler.go
+++ b/server/aws/redshift/handler.go
@@ -48,6 +48,9 @@ var redshiftActions = map[string]struct{}{ //nolint:gochecknoglobals // static l
 	"CreateClusterParameterGroup":    {},
 	"DescribeClusterParameterGroups": {},
 	"DeleteClusterParameterGroup":    {},
+	"ModifyClusterParameterGroup":    {},
+	"DescribeClusterParameters":      {},
+	"ResetClusterParameterGroup":     {},
 	"CreateClusterSubnetGroup":       {},
 	"DescribeClusterSubnetGroups":    {},
 	"DeleteClusterSubnetGroup":       {},
@@ -62,6 +65,13 @@ type clusterGroupManager interface {
 	CreateClusterParameterGroup(ctx context.Context, name, family, description string) (*redshiftprovider.ParameterGroup, error)
 	DescribeClusterParameterGroups(ctx context.Context, names []string) ([]redshiftprovider.ParameterGroup, error)
 	DeleteClusterParameterGroup(ctx context.Context, name string) error
+	ModifyClusterParameterGroup(
+		ctx context.Context, name string, params []rdbdriver.Parameter,
+	) (*redshiftprovider.ParameterGroup, error)
+	DescribeClusterParameters(ctx context.Context, name string) ([]rdbdriver.Parameter, error)
+	ResetClusterParameterGroup(
+		ctx context.Context, name string, paramNames []string, resetAll bool,
+	) (*redshiftprovider.ParameterGroup, error)
 	CreateClusterSubnetGroup(ctx context.Context, name, description string, subnetIDs []string) (*redshiftprovider.SubnetGroup, error)
 	DescribeClusterSubnetGroups(ctx context.Context, names []string) ([]redshiftprovider.SubnetGroup, error)
 	DeleteClusterSubnetGroup(ctx context.Context, name string) error
@@ -173,6 +183,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.describeClusterParameterGroups(w, r)
 	case "DeleteClusterParameterGroup":
 		h.deleteClusterParameterGroup(w, r)
+	case "ModifyClusterParameterGroup":
+		h.modifyClusterParameterGroup(w, r)
+	case "DescribeClusterParameters":
+		h.describeClusterParameters(w, r)
+	case "ResetClusterParameterGroup":
+		h.resetClusterParameterGroup(w, r)
 	case "CreateClusterSubnetGroup":
 		h.createClusterSubnetGroup(w, r)
 	case "DescribeClusterSubnetGroups":

--- a/server/aws/redshift/operations.go
+++ b/server/aws/redshift/operations.go
@@ -37,6 +37,7 @@ func clusterConfigFromForm(form url.Values) rdbdriver.ClusterConfig {
 		NodeType:                    form.Get("NodeType"),
 		NumberOfNodes:               formInt(form.Get("NumberOfNodes")),
 		Encrypted:                   formBool(form.Get("Encrypted")),
+		KmsKeyID:                    form.Get("KmsKeyId"),
 		PubliclyAccessible:          formBool(form.Get("PubliclyAccessible")),
 		AvailabilityZone:            form.Get("AvailabilityZone"),
 		Tags:                        parseRedshiftTags(form),

--- a/server/aws/redshift/operations.go
+++ b/server/aws/redshift/operations.go
@@ -121,6 +121,9 @@ func (h *Handler) modifyCluster(w http.ResponseWriter, r *http.Request) {
 	input := rdbdriver.ModifyInstanceInput{
 		EngineVersion:      form.Get("ClusterVersion"),
 		MasterUserPassword: form.Get("MasterUserPassword"),
+		NodeType:           form.Get("NodeType"),
+		NumberOfNodes:      formInt(form.Get("NumberOfNodes")),
+		ClusterType:        form.Get("ClusterType"),
 		Tags:               parseRedshiftTags(form),
 	}
 

--- a/server/aws/redshift/parameter_group.go
+++ b/server/aws/redshift/parameter_group.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	redshiftprovider "github.com/stackshy/cloudemu/v2/providers/aws/redshift"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 )
 
@@ -21,10 +22,26 @@ type createClusterParameterGroupResponse struct {
 	Metadata responseMetadata         `xml:"ResponseMetadata"`
 }
 
+type subnetAvailabilityZoneXML struct {
+	Name string `xml:"Name,omitempty"`
+}
+
+type subnetXML struct {
+	SubnetIdentifier       string                    `xml:"SubnetIdentifier"`
+	SubnetAvailabilityZone subnetAvailabilityZoneXML `xml:"SubnetAvailabilityZone"`
+	SubnetStatus           string                    `xml:"SubnetStatus"`
+}
+
+type subnetsXML struct {
+	Subnet []subnetXML `xml:"Subnet,omitempty"`
+}
+
 type clusterSubnetGroupXML struct {
-	ClusterSubnetGroupName string `xml:"ClusterSubnetGroupName"`
-	Description            string `xml:"Description"`
-	SubnetGroupStatus      string `xml:"SubnetGroupStatus"`
+	ClusterSubnetGroupName string      `xml:"ClusterSubnetGroupName"`
+	Description            string      `xml:"Description"`
+	VpcID                  string      `xml:"VpcId,omitempty"`
+	SubnetGroupStatus      string      `xml:"SubnetGroupStatus"`
+	Subnets                *subnetsXML `xml:"Subnets,omitempty"`
 }
 
 type createClusterSubnetGroupResponse struct {
@@ -107,14 +124,37 @@ func (h *Handler) createClusterSubnetGroup(w http.ResponseWriter, r *http.Reques
 	}
 
 	awsquery.WriteXMLResponse(w, createClusterSubnetGroupResponse{
-		Xmlns: Namespace,
-		Group: clusterSubnetGroupXML{
-			ClusterSubnetGroupName: sg.Name,
-			Description:            sg.Description,
-			SubnetGroupStatus:      "Complete",
-		},
+		Xmlns:    Namespace,
+		Group:    toClusterSubnetGroupXML(sg),
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
+}
+
+// toClusterSubnetGroupXML renders a provider subnet group into the wire shape,
+// emitting the derived VpcId and the full Subnets list (each with its
+// availability zone) real Redshift returns.
+func toClusterSubnetGroupXML(sg *redshiftprovider.SubnetGroup) clusterSubnetGroupXML {
+	out := clusterSubnetGroupXML{
+		ClusterSubnetGroupName: sg.Name,
+		Description:            sg.Description,
+		VpcID:                  sg.VPCID,
+		SubnetGroupStatus:      "Complete",
+	}
+
+	if len(sg.Subnets) > 0 {
+		subnets := &subnetsXML{Subnet: make([]subnetXML, 0, len(sg.Subnets))}
+		for _, s := range sg.Subnets {
+			subnets.Subnet = append(subnets.Subnet, subnetXML{
+				SubnetIdentifier:       s.ID,
+				SubnetAvailabilityZone: subnetAvailabilityZoneXML{Name: s.AvailabilityZone},
+				SubnetStatus:           "Active",
+			})
+		}
+
+		out.Subnets = subnets
+	}
+
+	return out
 }
 
 func (h *Handler) describeClusterParameterGroups(w http.ResponseWriter, r *http.Request) {
@@ -189,11 +229,7 @@ func (h *Handler) describeClusterSubnetGroups(w http.ResponseWriter, r *http.Req
 
 	out := make([]clusterSubnetGroupXML, 0, len(groups))
 	for i := range groups {
-		out = append(out, clusterSubnetGroupXML{
-			ClusterSubnetGroupName: groups[i].Name,
-			Description:            groups[i].Description,
-			SubnetGroupStatus:      "Complete",
-		})
+		out = append(out, toClusterSubnetGroupXML(&groups[i]))
 	}
 
 	awsquery.WriteXMLResponse(w, describeClusterSubnetGroupsResponse{

--- a/server/aws/redshift/parameter_group.go
+++ b/server/aws/redshift/parameter_group.go
@@ -3,10 +3,13 @@ package redshift
 import (
 	"encoding/xml"
 	"net/http"
+	"net/url"
+	"strconv"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	redshiftprovider "github.com/stackshy/cloudemu/v2/providers/aws/redshift"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	rdbdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
 
 type clusterParameterGroupXML struct {
@@ -77,6 +80,44 @@ type deleteClusterSubnetGroupResponse struct {
 	Metadata responseMetadata `xml:"ResponseMetadata"`
 }
 
+type redshiftParameterXML struct {
+	ParameterName  string `xml:"ParameterName"`
+	ParameterValue string `xml:"ParameterValue,omitempty"`
+	Description    string `xml:"Description,omitempty"`
+	Source         string `xml:"Source,omitempty"`
+	DataType       string `xml:"DataType,omitempty"`
+	ApplyType      string `xml:"ApplyType,omitempty"`
+	IsModifiable   bool   `xml:"IsModifiable"`
+}
+
+type modifyClusterParameterGroupResponse struct {
+	XMLName              xml.Name         `xml:"ModifyClusterParameterGroupResponse"`
+	Xmlns                string           `xml:"xmlns,attr"`
+	ParameterGroupName   string           `xml:"ModifyClusterParameterGroupResult>ParameterGroupName"`
+	ParameterGroupStatus string           `xml:"ModifyClusterParameterGroupResult>ParameterGroupStatus"`
+	Metadata             responseMetadata `xml:"ResponseMetadata"`
+}
+
+type resetClusterParameterGroupResponse struct {
+	XMLName              xml.Name         `xml:"ResetClusterParameterGroupResponse"`
+	Xmlns                string           `xml:"xmlns,attr"`
+	ParameterGroupName   string           `xml:"ResetClusterParameterGroupResult>ParameterGroupName"`
+	ParameterGroupStatus string           `xml:"ResetClusterParameterGroupResult>ParameterGroupStatus"`
+	Metadata             responseMetadata `xml:"ResponseMetadata"`
+}
+
+type describeClusterParametersResponse struct {
+	XMLName    xml.Name               `xml:"DescribeClusterParametersResponse"`
+	Xmlns      string                 `xml:"xmlns,attr"`
+	Parameters []redshiftParameterXML `xml:"DescribeClusterParametersResult>Parameters>Parameter"`
+	Metadata   responseMetadata       `xml:"ResponseMetadata"`
+}
+
+// paramGroupUpdatedStatus is the human-readable status real Redshift returns
+// from ModifyClusterParameterGroup / ResetClusterParameterGroup.
+const paramGroupUpdatedStatus = "Your parameter group has been updated but changes " +
+	"won't get applied until you reboot the associated clusters."
+
 func (h *Handler) clusterGroups() (clusterGroupManager, bool) {
 	m, ok := h.db.(clusterGroupManager)
 
@@ -106,6 +147,122 @@ func (h *Handler) createClusterParameterGroup(w http.ResponseWriter, r *http.Req
 		},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
+}
+
+func (h *Handler) modifyClusterParameterGroup(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.clusterGroups()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "parameter groups not supported"))
+		return
+	}
+
+	name := r.Form.Get("ParameterGroupName")
+
+	if _, err := mgr.ModifyClusterParameterGroup(r.Context(), name, parseRedshiftParameters(r.Form)); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, modifyClusterParameterGroupResponse{
+		Xmlns:                Namespace,
+		ParameterGroupName:   name,
+		ParameterGroupStatus: paramGroupUpdatedStatus,
+		Metadata:             responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) describeClusterParameters(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.clusterGroups()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "parameter groups not supported"))
+		return
+	}
+
+	params, err := mgr.DescribeClusterParameters(r.Context(), r.Form.Get("ParameterGroupName"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]redshiftParameterXML, 0, len(params))
+	for i := range params {
+		out = append(out, redshiftParameterXML{
+			ParameterName:  params[i].Name,
+			ParameterValue: params[i].Value,
+			Description:    params[i].Description,
+			Source:         params[i].Source,
+			DataType:       params[i].DataType,
+			ApplyType:      params[i].ApplyType,
+			IsModifiable:   true,
+		})
+	}
+
+	awsquery.WriteXMLResponse(w, describeClusterParametersResponse{
+		Xmlns:      Namespace,
+		Parameters: out,
+		Metadata:   responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) resetClusterParameterGroup(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.clusterGroups()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "parameter groups not supported"))
+		return
+	}
+
+	name := r.Form.Get("ParameterGroupName")
+	resetAll := formBool(r.Form.Get("ResetAllParameters"))
+
+	if _, err := mgr.ResetClusterParameterGroup(r.Context(), name, parseRedshiftParameterNames(r.Form), resetAll); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, resetClusterParameterGroupResponse{
+		Xmlns:                Namespace,
+		ParameterGroupName:   name,
+		ParameterGroupStatus: paramGroupUpdatedStatus,
+		Metadata:             responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// parseRedshiftParameters reads Parameters.Parameter.N.{ParameterName,ParameterValue}.
+func parseRedshiftParameters(form url.Values) []rdbdriver.Parameter {
+	indices := awsquery.CollectIndices(form, "Parameters.Parameter")
+	if len(indices) == 0 {
+		return nil
+	}
+
+	out := make([]rdbdriver.Parameter, 0, len(indices))
+
+	for _, n := range indices {
+		base := "Parameters.Parameter." + strconv.Itoa(n)
+
+		pname := form.Get(base + ".ParameterName")
+		if pname == "" {
+			continue
+		}
+
+		out = append(out, rdbdriver.Parameter{
+			Name:  pname,
+			Value: form.Get(base + ".ParameterValue"),
+		})
+	}
+
+	return out
+}
+
+// parseRedshiftParameterNames reads just the ParameterName entries (used by Reset).
+func parseRedshiftParameterNames(form url.Values) []string {
+	params := parseRedshiftParameters(form)
+
+	names := make([]string, 0, len(params))
+	for i := range params {
+		names = append(names, params[i].Name)
+	}
+
+	return names
 }
 
 func (h *Handler) createClusterSubnetGroup(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/redshift/xml.go
+++ b/server/aws/redshift/xml.go
@@ -54,6 +54,7 @@ type clusterXML struct {
 	NodeType               string                     `xml:"NodeType,omitempty"`
 	NumberOfNodes          int                        `xml:"NumberOfNodes,omitempty"`
 	Encrypted              bool                       `xml:"Encrypted"`
+	KmsKeyID               string                     `xml:"KmsKeyId,omitempty"`
 	PubliclyAccessible     bool                       `xml:"PubliclyAccessible"`
 	AvailabilityZone       string                     `xml:"AvailabilityZone,omitempty"`
 	VpcID                  string                     `xml:"VpcId,omitempty"`
@@ -228,6 +229,7 @@ func toClusterXML(cluster *rdbdriver.Cluster) clusterXML {
 		NodeType:               cluster.NodeType,
 		NumberOfNodes:          cluster.NumberOfNodes,
 		Encrypted:              cluster.Encrypted,
+		KmsKeyID:               cluster.KmsKeyID,
 		PubliclyAccessible:     cluster.PubliclyAccessible,
 		AvailabilityZone:       cluster.AvailabilityZone,
 		VpcID:                  cluster.VpcID,

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -359,6 +359,11 @@ type ClusterSnapshot struct {
 	NumberOfNodes              int
 	Encrypted                  bool
 	TotalBackupSizeInMegaBytes float64
+	// MasterUsername / DatabaseName capture the source cluster's admin user and
+	// database at snapshot time so a Redshift restore is a self-contained image
+	// (the restored cluster reads them back). Empty for RDS/Aurora/Azure/GCP.
+	MasterUsername string
+	DatabaseName   string
 	CreatedAt                  time.Time
 	Tags                       map[string]string
 }

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -211,7 +211,13 @@ type ModifyInstanceInput struct {
 	// enabled; it is cleared automatically when HA is disabled.
 	HighAvailabilityMode    string
 	StandbyAvailabilityZone string
-	Tags                    map[string]string
+	// NodeType / NumberOfNodes / ClusterType are Redshift resize inputs on
+	// ModifyCluster (empty / zero means "no change"); RDS/Aurora ignore them.
+	// ClusterType is "single-node" | "multi-node"; single-node forces one node.
+	NodeType      string
+	NumberOfNodes int
+	ClusterType   string
+	Tags          map[string]string
 }
 
 // ClusterConfig configures an Aurora-style cluster. Members are added by

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -364,8 +364,8 @@ type ClusterSnapshot struct {
 	// (the restored cluster reads them back). Empty for RDS/Aurora/Azure/GCP.
 	MasterUsername string
 	DatabaseName   string
-	CreatedAt                  time.Time
-	Tags                       map[string]string
+	CreatedAt      time.Time
+	Tags           map[string]string
 }
 
 // RestoreInstanceInput configures restoring an instance from a snapshot.


### PR DESCRIPTION
## What

Fixes six real-user Redshift bugs found in a deep e2e SDK audit (3 HIGH incl. 2 Terraform-killers, 3 MEDIUM), each reproduced with a real `aws-sdk-go-v2` redshift client over the wire:

- **[HIGH] ModifyCluster honors resize.** NodeType/NumberOfNodes/ClusterType were silently ignored, so a `aws_redshift_cluster` changing `node_type`/`number_of_nodes` never converged (perpetual drift). Now parsed from the wire, applied on the cluster, and reflected on the response + DescribeClusters. `single-node` ClusterType forces one node.
- **[HIGH] Parameter groups carry contents.** `ModifyClusterParameterGroup` and `DescribeClusterParameters` were undispatched (`InvalidAction` 400), so Terraform `aws_redshift_parameter_group` with `parameter {}` blocks failed outright. A created group is now seeded with the family's engine-default parameters; DescribeClusterParameters returns them; ModifyClusterParameterGroup applies overrides (Source=user) and rejects an unknown parameter with `InvalidParameterValue`; ResetClusterParameterGroup restores defaults.
- **[HIGH] Cluster subnet group VpcId + Subnets.** Create/DescribeClusterSubnetGroups omitted VpcId and the Subnets list, so `aws_redshift_subnet_group` read `subnet_ids`/`vpc_id` back empty and drifted. Derived VpcId and per-subnet AZs from the member subnets via a SubnetResolver wired to the VPC mock (RDS/ElastiCache precedent); the full Subnets list is now emitted.
- **[MED] CreateCluster validates ClusterSubnetGroupName.** A reference to an unknown subnet group succeeded silently; now `ClusterSubnetGroupNotFoundFault`.
- **[MED] RestoreFromClusterSnapshot preserves fields.** The restored cluster dropped NodeType/NumberOfNodes/MasterUsername/DBName; the snapshot now captures MasterUsername/DatabaseName and the restore copies node config + user/db (defaulting NumberOfNodes to 1).
- **[MED] KmsKeyId round-trips** on encrypted clusters (create + DescribeClusters).

## Why

Each bug breaks an unmodified Terraform/SDK workflow against the emulator. Behaviors verified against the official AWS Redshift API docs (ModifyCluster requires both NodeType+NumberOfNodes to resize; ModifyClusterParameterGroup returns ParameterGroupName+ParameterGroupStatus; the default parameter table for the parameter-group family).

## RDS unaffected (shared driver)

`services/relationaldb/driver` (ModifyInstanceInput / ClusterSnapshot) is shared by RDS and Redshift. The new fields (ModifyInstanceInput.NodeType/NumberOfNodes/ClusterType, ClusterSnapshot.MasterUsername/DatabaseName) are optional and only read on the Redshift path — RDS never sets or reads them. The full RDS suites (`./server/aws/rds/...`, `./providers/aws/rds/...`, `./services/relationaldb/...`) stay green.

## Tests

Real `aws-sdk-go-v2` reproductions added for every fix (resize, single-node resize, parameter defaults/override/unknown-rejection, subnet-group VpcId+Subnets, missing-subnet-group fault, restore-preserves-config, encrypted KmsKeyId round-trip).

## Docs

`go generate` is zero-diff (no new driver methods). The compat-matrix regen commit is pre-existing `logging` SubscriptionFilter drift (unrelated to Redshift, which is not in the compat matrix), brought back in sync so the compatgen drift gate is green; regen is idempotent.
