### PR TITLE
fix(aws-sesv2): emit event-destination sub-blocks (SNS/CloudWatch/Kinesis) + GetEmailIdentity Policies

### DIFF
--- a/providers/aws/sesv2/configset_options.go
+++ b/providers/aws/sesv2/configset_options.go
@@ -65,13 +65,13 @@ func (m *Mock) DeleteConfigurationSetEventDestination(_ context.Context, configS
 	err := m.withConfigSet(configSet, func(cs *driver.ConfigurationSet) {
 		kept := cs.EventDestinations[:0]
 
-		for _, ed := range cs.EventDestinations {
-			if ed.Name == name {
+		for i := range cs.EventDestinations {
+			if cs.EventDestinations[i].Name == name {
 				found = true
 				continue
 			}
 
-			kept = append(kept, ed)
+			kept = append(kept, cs.EventDestinations[i])
 		}
 
 		cs.EventDestinations = kept
@@ -102,12 +102,15 @@ func (m *Mock) GetConfigurationSetEventDestinations(_ context.Context, configSet
 
 func eventDestinationFromInput(in *driver.EventDestinationInput) driver.EventDestination {
 	return driver.EventDestination{
-		Name:                in.EventDestinationName,
-		Enabled:             in.Enabled,
-		MatchingEventTypes:  append([]string(nil), in.MatchingEventTypes...),
-		KinesisFirehoseARN:  in.KinesisFirehoseARN,
-		SNSTopicARN:         in.SNSTopicARN,
-		CloudWatchNamespace: in.CloudWatchNamespace,
+		Name:                   in.EventDestinationName,
+		Enabled:                in.Enabled,
+		MatchingEventTypes:     append([]string(nil), in.MatchingEventTypes...),
+		KinesisFirehoseARN:     in.KinesisFirehoseARN,
+		KinesisFirehoseRoleARN: in.KinesisFirehoseRoleARN,
+		SNSTopicARN:            in.SNSTopicARN,
+		CloudWatchNamespace:    in.CloudWatchNamespace,
+		CloudWatchDimensions:   append([]driver.CloudWatchDimension(nil), in.CloudWatchDimensions...),
+		PinpointApplicationARN: in.PinpointApplicationARN,
 	}
 }
 

--- a/providers/aws/sesv2/identities.go
+++ b/providers/aws/sesv2/identities.go
@@ -11,6 +11,7 @@ func copyIdentity(id *driver.Identity) driver.Identity {
 	out := *id
 	out.Tags = copyTags(id.Tags)
 	out.DkimTokens = append([]string(nil), id.DkimTokens...)
+	out.Policies = copyTags(id.Policies)
 
 	return out
 }

--- a/server/aws/sesv2/configset_extras.go
+++ b/server/aws/sesv2/configset_extras.go
@@ -43,6 +43,7 @@ func edInputFromJSON(configSet, name string, ed *eventDestinationDefJSON) driver
 
 	if ed.KinesisFirehoseDestination != nil {
 		in.KinesisFirehoseARN = ed.KinesisFirehoseDestination.DeliveryStreamArn
+		in.KinesisFirehoseRoleARN = ed.KinesisFirehoseDestination.IamRoleArn
 	}
 
 	if ed.SnsDestination != nil {
@@ -51,9 +52,77 @@ func edInputFromJSON(configSet, name string, ed *eventDestinationDefJSON) driver
 
 	if ed.CloudWatchDestination != nil {
 		in.CloudWatchNamespace = "cloudwatch"
+		in.CloudWatchDimensions = dimsToDriver(ed.CloudWatchDestination.DimensionConfigurations)
+	}
+
+	if ed.PinpointDestination != nil {
+		in.PinpointApplicationARN = ed.PinpointDestination.ApplicationArn
 	}
 
 	return in
+}
+
+func dimsToDriver(dims []cloudWatchDimensionConfigJSON) []driver.CloudWatchDimension {
+	if len(dims) == 0 {
+		return nil
+	}
+
+	out := make([]driver.CloudWatchDimension, 0, len(dims))
+	for i := range dims {
+		out = append(out, driver.CloudWatchDimension{
+			DimensionName:         dims[i].DimensionName,
+			DimensionValueSource:  dims[i].DimensionValueSource,
+			DefaultDimensionValue: dims[i].DefaultDimensionValue,
+		})
+	}
+
+	return out
+}
+
+func dimsToWire(dims []driver.CloudWatchDimension) []cloudWatchDimensionConfigJSON {
+	out := make([]cloudWatchDimensionConfigJSON, 0, len(dims))
+	for i := range dims {
+		out = append(out, cloudWatchDimensionConfigJSON{
+			DimensionName:         dims[i].DimensionName,
+			DimensionValueSource:  dims[i].DimensionValueSource,
+			DefaultDimensionValue: dims[i].DefaultDimensionValue,
+		})
+	}
+
+	return out
+}
+
+// eventDestinationToJSON renders a stored event destination as its wire shape,
+// including whichever destination sub-block was configured.
+func eventDestinationToJSON(ed *driver.EventDestination) eventDestinationJSON {
+	out := eventDestinationJSON{
+		Name:               ed.Name,
+		Enabled:            ed.Enabled,
+		MatchingEventTypes: ed.MatchingEventTypes,
+	}
+
+	if ed.SNSTopicARN != "" {
+		out.SnsDestination = &snsDestinationJSON{TopicArn: ed.SNSTopicARN}
+	}
+
+	if ed.KinesisFirehoseARN != "" || ed.KinesisFirehoseRoleARN != "" {
+		out.KinesisFirehoseDestination = &kinesisFirehoseDestinationJSON{
+			IamRoleArn:        ed.KinesisFirehoseRoleARN,
+			DeliveryStreamArn: ed.KinesisFirehoseARN,
+		}
+	}
+
+	if ed.CloudWatchNamespace != "" {
+		out.CloudWatchDestination = &cloudWatchDestinationJSON{
+			DimensionConfigurations: dimsToWire(ed.CloudWatchDimensions),
+		}
+	}
+
+	if ed.PinpointApplicationARN != "" {
+		out.PinpointDestination = &pinpointDestinationJSON{ApplicationArn: ed.PinpointApplicationARN}
+	}
+
+	return out
 }
 
 func (h *Handler) createEventDestination(w http.ResponseWriter, r *http.Request, configSet string) {
@@ -108,11 +177,7 @@ func (h *Handler) getEventDestinations(w http.ResponseWriter, r *http.Request, c
 
 	out := make([]eventDestinationJSON, 0, len(eds))
 	for i := range eds {
-		out = append(out, eventDestinationJSON{
-			Name:               eds[i].Name,
-			Enabled:            eds[i].Enabled,
-			MatchingEventTypes: eds[i].MatchingEventTypes,
-		})
+		out = append(out, eventDestinationToJSON(&eds[i]))
 	}
 
 	writeJSON(w, getEventDestinationsResponse{EventDestinations: out})

--- a/server/aws/sesv2/identities.go
+++ b/server/aws/sesv2/identities.go
@@ -216,6 +216,7 @@ func (h *Handler) getIdentity(w http.ResponseWriter, r *http.Request, name strin
 		VerificationStatus:       id.VerificationStatus,
 		ConfigurationSetName:     id.ConfigurationSetName,
 		DkimAttributes:           identityToDkimJSON(id),
+		Policies:                 id.Policies,
 		Tags:                     mapToTags(id.Tags),
 	}
 

--- a/server/aws/sesv2/sdk_roundtrip_ext_test.go
+++ b/server/aws/sesv2/sdk_roundtrip_ext_test.go
@@ -157,6 +157,117 @@ func TestSDKEventDestinations(t *testing.T) {
 	}
 }
 
+func TestSDKEventDestinationSubBlocksRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c := newSESClient(t)
+
+	if _, err := c.CreateConfigurationSet(ctx, &awsses.CreateConfigurationSetInput{
+		ConfigurationSetName: aws.String("cs-ed"),
+	}); err != nil {
+		t.Fatalf("CreateConfigurationSet: %v", err)
+	}
+
+	createED := func(name string, def *sestypes.EventDestinationDefinition) {
+		t.Helper()
+		if _, err := c.CreateConfigurationSetEventDestination(ctx, &awsses.CreateConfigurationSetEventDestinationInput{
+			ConfigurationSetName: aws.String("cs-ed"),
+			EventDestinationName: aws.String(name),
+			EventDestination:     def,
+		}); err != nil {
+			t.Fatalf("CreateConfigurationSetEventDestination(%s): %v", name, err)
+		}
+	}
+
+	createED("to-sns", &sestypes.EventDestinationDefinition{
+		Enabled:            true,
+		MatchingEventTypes: []sestypes.EventType{sestypes.EventTypeBounce, sestypes.EventTypeComplaint},
+		SnsDestination:     &sestypes.SnsDestination{TopicArn: aws.String("arn:aws:sns:us-east-1:123456789012:ses-events")},
+	})
+	createED("to-cw", &sestypes.EventDestinationDefinition{
+		Enabled:            true,
+		MatchingEventTypes: []sestypes.EventType{sestypes.EventTypeDelivery},
+		CloudWatchDestination: &sestypes.CloudWatchDestination{
+			DimensionConfigurations: []sestypes.CloudWatchDimensionConfiguration{{
+				DimensionName:         aws.String("ses:configuration-set"),
+				DimensionValueSource:  sestypes.DimensionValueSourceMessageTag,
+				DefaultDimensionValue: aws.String("default"),
+			}},
+		},
+	})
+	createED("to-firehose", &sestypes.EventDestinationDefinition{
+		Enabled:            true,
+		MatchingEventTypes: []sestypes.EventType{sestypes.EventTypeSend},
+		KinesisFirehoseDestination: &sestypes.KinesisFirehoseDestination{
+			IamRoleArn:        aws.String("arn:aws:iam::123456789012:role/ses-firehose"),
+			DeliveryStreamArn: aws.String("arn:aws:firehose:us-east-1:123456789012:deliverystream/ses"),
+		},
+	})
+
+	got, err := c.GetConfigurationSetEventDestinations(ctx, &awsses.GetConfigurationSetEventDestinationsInput{
+		ConfigurationSetName: aws.String("cs-ed"),
+	})
+	if err != nil {
+		t.Fatalf("GetConfigurationSetEventDestinations: %v", err)
+	}
+
+	byName := make(map[string]sestypes.EventDestination, len(got.EventDestinations))
+	for i := range got.EventDestinations {
+		byName[aws.ToString(got.EventDestinations[i].Name)] = got.EventDestinations[i]
+	}
+
+	sns := byName["to-sns"].SnsDestination
+	if sns == nil || aws.ToString(sns.TopicArn) != "arn:aws:sns:us-east-1:123456789012:ses-events" {
+		t.Fatalf("SnsDestination not round-tripped: %+v", sns)
+	}
+
+	cw := byName["to-cw"].CloudWatchDestination
+	if cw == nil || len(cw.DimensionConfigurations) != 1 {
+		t.Fatalf("CloudWatchDestination not round-tripped: %+v", cw)
+	}
+	dim := cw.DimensionConfigurations[0]
+	if aws.ToString(dim.DimensionName) != "ses:configuration-set" ||
+		dim.DimensionValueSource != sestypes.DimensionValueSourceMessageTag ||
+		aws.ToString(dim.DefaultDimensionValue) != "default" {
+		t.Fatalf("CloudWatch dimension not round-tripped: %+v", dim)
+	}
+
+	fh := byName["to-firehose"].KinesisFirehoseDestination
+	if fh == nil ||
+		aws.ToString(fh.IamRoleArn) != "arn:aws:iam::123456789012:role/ses-firehose" ||
+		aws.ToString(fh.DeliveryStreamArn) != "arn:aws:firehose:us-east-1:123456789012:deliverystream/ses" {
+		t.Fatalf("KinesisFirehoseDestination not round-tripped: %+v", fh)
+	}
+}
+
+func TestSDKGetEmailIdentityIncludesPolicies(t *testing.T) {
+	ctx := context.Background()
+	c := newSESClient(t)
+
+	if _, err := c.CreateEmailIdentity(ctx, &awsses.CreateEmailIdentityInput{
+		EmailIdentity: aws.String("example.com"),
+	}); err != nil {
+		t.Fatalf("CreateEmailIdentity: %v", err)
+	}
+
+	if _, err := c.CreateEmailIdentityPolicy(ctx, &awsses.CreateEmailIdentityPolicyInput{
+		EmailIdentity: aws.String("example.com"),
+		PolicyName:    aws.String("p1"),
+		Policy:        aws.String(`{"Version":"2012-10-17"}`),
+	}); err != nil {
+		t.Fatalf("CreateEmailIdentityPolicy: %v", err)
+	}
+
+	got, err := c.GetEmailIdentity(ctx, &awsses.GetEmailIdentityInput{
+		EmailIdentity: aws.String("example.com"),
+	})
+	if err != nil {
+		t.Fatalf("GetEmailIdentity: %v", err)
+	}
+	if _, ok := got.Policies["p1"]; !ok {
+		t.Fatalf("GetEmailIdentity.Policies missing p1: %+v", got.Policies)
+	}
+}
+
 func TestSDKConfigSetPutOptions(t *testing.T) {
 	ctx := context.Background()
 	c := newSESClient(t)

--- a/server/aws/sesv2/types.go
+++ b/server/aws/sesv2/types.go
@@ -79,6 +79,7 @@ type getEmailIdentityResponse struct {
 	ConfigurationSetName     string                  `json:"ConfigurationSetName,omitempty"`
 	DkimAttributes           dkimAttributesJSON      `json:"DkimAttributes"`
 	MailFromAttributes       *mailFromAttributesJSON `json:"MailFromAttributes,omitempty"`
+	Policies                 map[string]string       `json:"Policies,omitempty"`
 	Tags                     []tag                   `json:"Tags"`
 }
 

--- a/server/aws/sesv2/types_ext.go
+++ b/server/aws/sesv2/types_ext.go
@@ -23,8 +23,18 @@ type snsDestinationJSON struct {
 	TopicArn string `json:"TopicArn"`
 }
 
+type pinpointDestinationJSON struct {
+	ApplicationArn string `json:"ApplicationArn"`
+}
+
+type cloudWatchDimensionConfigJSON struct {
+	DimensionName         string `json:"DimensionName"`
+	DimensionValueSource  string `json:"DimensionValueSource"`
+	DefaultDimensionValue string `json:"DefaultDimensionValue"`
+}
+
 type cloudWatchDestinationJSON struct {
-	DimensionConfigurations []map[string]string `json:"DimensionConfigurations"`
+	DimensionConfigurations []cloudWatchDimensionConfigJSON `json:"DimensionConfigurations"`
 }
 
 type eventDestinationDefJSON struct {
@@ -33,6 +43,7 @@ type eventDestinationDefJSON struct {
 	KinesisFirehoseDestination *kinesisFirehoseDestinationJSON `json:"KinesisFirehoseDestination"`
 	SnsDestination             *snsDestinationJSON             `json:"SnsDestination"`
 	CloudWatchDestination      *cloudWatchDestinationJSON      `json:"CloudWatchDestination"`
+	PinpointDestination        *pinpointDestinationJSON        `json:"PinpointDestination"`
 }
 
 type createEventDestinationRequest struct {
@@ -45,9 +56,13 @@ type updateEventDestinationRequest struct {
 }
 
 type eventDestinationJSON struct {
-	Name               string   `json:"Name"`
-	Enabled            bool     `json:"Enabled"`
-	MatchingEventTypes []string `json:"MatchingEventTypes"`
+	Name                       string                          `json:"Name"`
+	Enabled                    bool                            `json:"Enabled"`
+	MatchingEventTypes         []string                        `json:"MatchingEventTypes"`
+	KinesisFirehoseDestination *kinesisFirehoseDestinationJSON `json:"KinesisFirehoseDestination,omitempty"`
+	SnsDestination             *snsDestinationJSON             `json:"SnsDestination,omitempty"`
+	CloudWatchDestination      *cloudWatchDestinationJSON      `json:"CloudWatchDestination,omitempty"`
+	PinpointDestination        *pinpointDestinationJSON        `json:"PinpointDestination,omitempty"`
 }
 
 type getEventDestinationsResponse struct {

--- a/services/sesv2/driver/types_ext.go
+++ b/services/sesv2/driver/types_ext.go
@@ -125,25 +125,39 @@ type CustomVerificationEmailTemplateInput struct {
 
 // Config-set event destination types.
 
+// CloudWatchDimension is a single CloudWatch dimension configuration on a
+// CloudWatch event destination.
+type CloudWatchDimension struct {
+	DimensionName         string
+	DimensionValueSource  string
+	DefaultDimensionValue string
+}
+
 // EventDestination is a destination configuration-set events are published to.
 type EventDestination struct {
-	Name                string
-	Enabled             bool
-	MatchingEventTypes  []string
-	KinesisFirehoseARN  string
-	SNSTopicARN         string
-	CloudWatchNamespace string
+	Name                   string
+	Enabled                bool
+	MatchingEventTypes     []string
+	KinesisFirehoseARN     string
+	KinesisFirehoseRoleARN string
+	SNSTopicARN            string
+	CloudWatchNamespace    string
+	CloudWatchDimensions   []CloudWatchDimension
+	PinpointApplicationARN string
 }
 
 // EventDestinationInput describes an event destination to create/update.
 type EventDestinationInput struct {
-	ConfigurationSetName string
-	EventDestinationName string
-	Enabled              bool
-	MatchingEventTypes   []string
-	KinesisFirehoseARN   string
-	SNSTopicARN          string
-	CloudWatchNamespace  string
+	ConfigurationSetName   string
+	EventDestinationName   string
+	Enabled                bool
+	MatchingEventTypes     []string
+	KinesisFirehoseARN     string
+	KinesisFirehoseRoleARN string
+	SNSTopicARN            string
+	CloudWatchNamespace    string
+	CloudWatchDimensions   []CloudWatchDimension
+	PinpointApplicationARN string
 }
 
 // Dedicated IP types.


### PR DESCRIPTION
## What

Two AWS SES v2 wire-serialization fixes found by the deep-e2e real-user audit. In both cases the driver + provider already **store** the data correctly — only the server wire response dropped it.

### [HIGH] GetConfigurationSetEventDestinations dropped the destination sub-block
`aws_sesv2_configuration_set_event_destination` reads the `event_destination` block on refresh (e.g. `sns_destination.topic_arn`). The wire response only emitted `Name`/`Enabled`/`MatchingEventTypes`, so the destination came back `nil` → perpetual Terraform drift for every event-destination user.

- `GetConfigurationSetEventDestinations` now emits the configured destination sub-object: `SnsDestination{TopicArn}`, `KinesisFirehoseDestination{IamRoleArn, DeliveryStreamArn}`, `CloudWatchDestination{DimensionConfigurations[]}`, and `PinpointDestination{ApplicationArn}`.
- The create/update input side now captures the Kinesis `IamRoleArn`, the CloudWatch `DimensionConfigurations` (name / value-source / default-value), and the Pinpoint `ApplicationArn` — previously discarded (dimensions were dropped and the namespace hardcoded).
- Driver `EventDestination` / `EventDestinationInput` gained the matching fields so each type round-trips.

### [MED] GetEmailIdentity omitted the Policies map
`GetEmailIdentity` never serialized `Policies`, even though `GetEmailIdentityPolicies` (and the stored `Identity.Policies`) had them.

- Added `Policies` to the `GetEmailIdentity` response, populated from the stored identity.
- `copyIdentity` now deep-copies the `Policies` map (avoids aliasing / data races).

## Why
Both are wire-only round-trip bugs that break IaC refresh/plan stability. Additive wire changes only — no driver interface method added; coverage docs and the compat matrix are zero-diff.

## Tests
Real `aws-sdk-go-v2/service/sesv2` reproductions:
- `TestSDKEventDestinationSubBlocksRoundTrip` — SNS, CloudWatch (with a dimension configuration), and Kinesis Firehose destinations each round-trip through create → get.
- `TestSDKGetEmailIdentityIncludesPolicies` — `CreateEmailIdentityPolicy(p1)` then `GetEmailIdentity.Policies` contains `p1`.

Existing SES v2 tests (DKIM tokens, config-set round-trip, SendEmail verified-sender, GetAccount, tags) stay green, including `-race`.
