### PR TITLE
fix(gcp-compute): zone-scope disk get/delete/resize/list/insert — no cross-zone resolution or data-loss

### DIFF
--- a/server/gcp/compute/disks.go
+++ b/server/gcp/compute/disks.go
@@ -71,7 +71,7 @@ func (h *Handler) insertDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 		return
 	}
 
-	if _, err := findDiskByName(r.Context(), h.compute, req.Name); conflictIfExists(w, err, "disk "+req.Name+" already exists") {
+	if _, err := findDiskByName(r.Context(), h.compute, req.Name, rp.ScopeName); conflictIfExists(w, err, "disk "+req.Name+" already exists") {
 		return
 	}
 
@@ -96,7 +96,7 @@ func (h *Handler) insertDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) getDisk(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	vol, err := findDiskByName(r.Context(), h.compute, rp.ResourceName)
+	vol, err := findDiskByName(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -121,6 +121,10 @@ func (h *Handler) listDisks(w http.ResponseWriter, r *http.Request, rp gcprest.R
 	out := make([]diskResponse, 0, len(vols))
 
 	for i := range vols {
+		if !diskInZone(&vols[i], rp.ScopeName) {
+			continue
+		}
+
 		scope := rp
 		name := tagOr(vols[i].Tags, gcpDiskNameTag, vols[i].ID)
 		scope.ResourceName = name
@@ -137,7 +141,7 @@ func (h *Handler) listDisks(w http.ResponseWriter, r *http.Request, rp gcprest.R
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) deleteDisk(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	vol, err := findDiskByName(r.Context(), h.compute, rp.ResourceName)
+	vol, err := findDiskByName(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -177,7 +181,7 @@ func (h *Handler) resizeDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 		return
 	}
 
-	vol, err := findDiskByName(r.Context(), h.compute, rp.ResourceName)
+	vol, err := findDiskByName(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -254,19 +258,35 @@ func (h *Handler) aggregatedListDisks(w http.ResponseWriter, r *http.Request, rp
 	})
 }
 
-func findDiskByName(ctx context.Context, c computedriver.Compute, name string) (*computedriver.VolumeInfo, error) {
+// findDiskByName looks up a disk by GCP name, scoped to zone. GCP disks are
+// zonal and unique per-zone, so the same name in a different zone is a distinct
+// disk. A disk with no recorded zone (created directly through the driver)
+// matches any zone so non-wire callers stay visible.
+func findDiskByName(
+	ctx context.Context, c computedriver.Compute, name, zone string,
+) (*computedriver.VolumeInfo, error) {
 	vols, err := c.DescribeVolumes(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	for i := range vols {
-		if tagOr(vols[i].Tags, gcpDiskNameTag, "") == name {
+		if tagOr(vols[i].Tags, gcpDiskNameTag, "") != name {
+			continue
+		}
+
+		if diskInZone(&vols[i], zone) {
 			return &vols[i], nil
 		}
 	}
 
 	return nil, cerrors.Newf(cerrors.NotFound, "disk %s not found", name)
+}
+
+// diskInZone reports whether vol belongs to zone. A disk with no recorded zone
+// matches any zone (defensive for driver-created disks).
+func diskInZone(vol *computedriver.VolumeInfo, zone string) bool {
+	return zone == "" || vol.AvailabilityZone == "" || vol.AvailabilityZone == zone
 }
 
 // diskStatusReady is the only status we report; the underlying driver doesn't
@@ -281,15 +301,23 @@ func toDiskResponse(vol *computedriver.VolumeInfo, rp gcprest.ResourcePath, host
 	name := tagOr(vol.Tags, gcpDiskNameTag, rp.ResourceName)
 	sourceImage := vol.Tags[gcpDiskSourceImageTag]
 
+	// A disk is zonal: its identity (zone, selfLink, type link) derives from the
+	// disk's own AvailabilityZone, not the request scope, so a read never
+	// mislabels a disk with the zone it was queried under.
+	zone := vol.AvailabilityZone
+	if zone == "" {
+		zone = rp.ScopeName
+	}
+
 	resp := diskResponse{
 		Kind:              "compute#disk",
 		ID:                numericID(vol.ID),
 		Name:              name,
 		SizeGb:            strconv.Itoa(vol.Size),
-		Type:              gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, "diskTypes", defaultDiskType(vol.VolumeType)),
+		Type:              gcprest.SelfLink(host, rp.Project, gcprest.ScopeZones, zone, "diskTypes", defaultDiskType(vol.VolumeType)),
 		Status:            diskStatusReady,
-		Zone:              host + "/compute/v1/projects/" + rp.Project + "/zones/" + rp.ScopeName,
-		SelfLink:          gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, "disks", name),
+		Zone:              host + "/compute/v1/projects/" + rp.Project + "/zones/" + zone,
+		SelfLink:          gcprest.SelfLink(host, rp.Project, gcprest.ScopeZones, zone, "disks", name),
 		SourceImage:       sourceImage,
 		Users:             users,
 		Labels:            userLabels(vol.Tags),

--- a/server/gcp/compute/disks_sdk_test.go
+++ b/server/gcp/compute/disks_sdk_test.go
@@ -129,18 +129,180 @@ func newGCPServer(t *testing.T) *httptest.Server {
 
 func insertDisk(t *testing.T, c *gcpcompute.DisksClient, disk *computepb.Disk) {
 	t.Helper()
+	insertDiskZone(t, c, testZone, disk)
+}
+
+// insertDiskZone inserts a disk into a specific zone and waits for the op.
+func insertDiskZone(t *testing.T, c *gcpcompute.DisksClient, zone string, disk *computepb.Disk) {
+	t.Helper()
 
 	ctx := context.Background()
 
 	op, err := c.Insert(ctx, &computepb.InsertDiskRequest{
-		Project: testProject, Zone: testZone, DiskResource: disk,
+		Project: testProject, Zone: zone, DiskResource: disk,
 	})
 	if err != nil {
-		t.Fatalf("disk Insert: %v", err)
+		t.Fatalf("disk Insert (%s): %v", zone, err)
 	}
 
 	if err := op.Wait(ctx); err != nil {
-		t.Fatalf("disk Insert wait: %v", err)
+		t.Fatalf("disk Insert wait (%s): %v", zone, err)
+	}
+}
+
+// otherZone is a second zone (distinct from testZone) used to prove disk
+// operations are zone-scoped and never resolve across zones.
+const otherZone = "us-west1-b"
+
+// TestSDKDiskGetCrossZoneNotFound proves get/delete/resize against a zone that
+// does not hold the disk return 404 instead of resolving another zone's disk
+// (the cross-zone data-loss bug for delete).
+func TestSDKDiskGetCrossZoneNotFound(t *testing.T) {
+	ts := newGCPServer(t)
+	client := newDisksSDKClient(t, ts)
+	ctx := context.Background()
+
+	// Disk lives in otherZone (us-west1-b).
+	insertDiskZone(t, client, otherZone, &computepb.Disk{Name: ptrStr("west-disk"), SizeGb: ptrInt64(10)})
+
+	// GET via testZone (us-central1-a) must NOT resolve the west disk.
+	if _, err := client.Get(ctx, &computepb.GetDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "west-disk",
+	}); err == nil {
+		t.Fatal("Get in wrong zone resolved a disk, want 404 notFound")
+	}
+
+	// DELETE via the wrong zone must 404 (must NOT destroy the west disk).
+	if _, err := client.Delete(ctx, &computepb.DeleteDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "west-disk",
+	}); err == nil {
+		t.Fatal("Delete in wrong zone succeeded, want 404 notFound (data loss)")
+	}
+
+	// RESIZE via the wrong zone must 404.
+	if _, err := client.Resize(ctx, &computepb.ResizeDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "west-disk",
+		DisksResizeRequestResource: &computepb.DisksResizeRequest{SizeGb: ptrInt64(50)},
+	}); err == nil {
+		t.Fatal("Resize in wrong zone succeeded, want 404 notFound")
+	}
+
+	// The west disk is untouched: still gettable in its own zone at its size.
+	got, err := client.Get(ctx, &computepb.GetDiskRequest{
+		Project: testProject, Zone: otherZone, Disk: "west-disk",
+	})
+	if err != nil {
+		t.Fatalf("Get west-disk in its own zone: %v", err)
+	}
+
+	if got.GetSizeGb() != 10 {
+		t.Errorf("west-disk sizeGb=%d want 10 (should be untouched)", got.GetSizeGb())
+	}
+
+	if !strings.HasSuffix(got.GetZone(), "/zones/"+otherZone) {
+		t.Errorf("west-disk zone=%s want suffix /zones/%s", got.GetZone(), otherZone)
+	}
+}
+
+// TestSDKDiskListZoneScoped proves disks.list returns only the requested zone's
+// disks, each labeled with its own zone selfLink.
+func TestSDKDiskListZoneScoped(t *testing.T) {
+	ts := newGCPServer(t)
+	client := newDisksSDKClient(t, ts)
+	ctx := context.Background()
+
+	insertDiskZone(t, client, testZone, &computepb.Disk{Name: ptrStr("central-disk"), SizeGb: ptrInt64(10)})
+	insertDiskZone(t, client, otherZone, &computepb.Disk{Name: ptrStr("west-disk"), SizeGb: ptrInt64(10)})
+
+	it := client.List(ctx, &computepb.ListDisksRequest{Project: testProject, Zone: testZone})
+
+	names := map[string]string{}
+	for {
+		d, err := it.Next()
+		if err != nil {
+			break
+		}
+
+		names[d.GetName()] = d.GetZone()
+	}
+
+	if _, ok := names["west-disk"]; ok {
+		t.Error("List(us-central1-a) leaked west-disk from another zone")
+	}
+
+	zone, ok := names["central-disk"]
+	if !ok {
+		t.Fatal("List(us-central1-a) did not return central-disk")
+	}
+
+	if !strings.HasSuffix(zone, "/zones/"+testZone) {
+		t.Errorf("central-disk zone=%s want suffix /zones/%s", zone, testZone)
+	}
+
+	if len(names) != 1 {
+		t.Errorf("List returned %d disks, want 1 (only the central zone)", len(names))
+	}
+}
+
+// TestSDKDiskSameNameDifferentZones proves the same disk name inserts
+// successfully in two different zones (disk names are unique per-zone).
+func TestSDKDiskSameNameDifferentZones(t *testing.T) {
+	ts := newGCPServer(t)
+	client := newDisksSDKClient(t, ts)
+	ctx := context.Background()
+
+	insertDiskZone(t, client, testZone, &computepb.Disk{Name: ptrStr("twin"), SizeGb: ptrInt64(10)})
+
+	// Same name in a different zone must succeed, not falsely 409.
+	if _, err := client.Insert(ctx, &computepb.InsertDiskRequest{
+		Project: testProject, Zone: otherZone,
+		DiskResource: &computepb.Disk{Name: ptrStr("twin"), SizeGb: ptrInt64(20)},
+	}); err != nil {
+		t.Fatalf("same-name insert in different zone failed: %v", err)
+	}
+
+	// Both are distinct disks, each in its own zone with its own size.
+	central, err := client.Get(ctx, &computepb.GetDiskRequest{Project: testProject, Zone: testZone, Disk: "twin"})
+	if err != nil {
+		t.Fatalf("Get twin in central: %v", err)
+	}
+
+	west, err := client.Get(ctx, &computepb.GetDiskRequest{Project: testProject, Zone: otherZone, Disk: "twin"})
+	if err != nil {
+		t.Fatalf("Get twin in west: %v", err)
+	}
+
+	if central.GetSizeGb() != 10 || west.GetSizeGb() != 20 {
+		t.Errorf("sizes central=%d west=%d want 10 and 20 (distinct disks)", central.GetSizeGb(), west.GetSizeGb())
+	}
+}
+
+// TestSDKDiskAggregatedListSpansZones proves aggregatedList still spans zones
+// after the get/list scoping fix, grouping each disk under its own zone.
+func TestSDKDiskAggregatedListSpansZones(t *testing.T) {
+	ts := newGCPServer(t)
+	client := newDisksSDKClient(t, ts)
+	ctx := context.Background()
+
+	insertDiskZone(t, client, testZone, &computepb.Disk{Name: ptrStr("central-agg"), SizeGb: ptrInt64(10)})
+	insertDiskZone(t, client, otherZone, &computepb.Disk{Name: ptrStr("west-agg"), SizeGb: ptrInt64(10)})
+
+	it := client.AggregatedList(ctx, &computepb.AggregatedListDisksRequest{Project: testProject})
+
+	seen := map[string]bool{}
+	for {
+		pair, err := it.Next()
+		if err != nil {
+			break
+		}
+
+		for _, d := range pair.Value.GetDisks() {
+			seen[d.GetName()] = true
+		}
+	}
+
+	if !seen["central-agg"] || !seen["west-agg"] {
+		t.Errorf("aggregatedList missing a zone's disk: seen=%v", seen)
 	}
 }
 

--- a/server/gcp/compute/images.go
+++ b/server/gcp/compute/images.go
@@ -246,8 +246,22 @@ func (h *Handler) imageDiskSizeGb(ctx context.Context, req *imageRequest) string
 		return ""
 	}
 
-	if vol, err := findDiskByName(ctx, h.compute, lastSegment(req.SourceDisk)); err == nil {
+	if vol, err := findDiskByName(ctx, h.compute, lastSegment(req.SourceDisk), zoneFromDiskURL(req.SourceDisk)); err == nil {
 		return strconv.Itoa(vol.Size)
+	}
+
+	return ""
+}
+
+// zoneFromDiskURL extracts the zone from a zonal disk self-link of the form
+// ".../zones/{zone}/disks/{name}". It returns "" when no zone segment is
+// present, which matches a disk in any zone (defensive for bare names).
+func zoneFromDiskURL(url string) string {
+	segs := strings.Split(url, "/")
+	for i := 0; i+1 < len(segs); i++ {
+		if segs[i] == "zones" {
+			return segs[i+1]
+		}
 	}
 
 	return ""


### PR DESCRIPTION
## Summary

A confirming re-audit surfaced residue in GCP Compute Engine disk handling: disks were keyed by name **project-wide** instead of **per-zone**, even though the zone is stored on `VolumeInfo.AvailabilityZone` (and already used correctly by `aggregatedList`). `findDiskByName` scanned `DescribeVolumes` matching only the disk-name tag, never the zone.

Root cause: zone-blind `findDiskByName`. It produced 3 real HIGH bugs:

- **[HIGH, DATA LOSS]** `get`/`delete`/`resize` on zone A resolved a disk living in zone B — a `DELETE` in the wrong zone destroyed another zone's disk, and responses mislabeled zone/selfLink as the request zone. GCP-correct: **404 notFound** when the disk isn't in the requested zone.
- **[HIGH]** `disks.list` returned **every** zone's disks, each mislabeled with the requested zone's selfLink/zone. GCP-correct: only the requested zone's disks, each with its own zone.
- **[HIGH]** A duplicate disk name across zones falsely returned **409**. GCP-correct: disk names are unique **per-zone** — the same name in a different zone must succeed.

## Changes

- `findDiskByName` now takes a zone and matches **both** the disk-name tag **and** `AvailabilityZone` (mirrors instances' `findInZone`); a disk with no recorded zone still matches any zone for driver-created disks.
- `get`/`delete`/`resize`/insert-conflict pass the request zone → 404 (GCP error shape) when the disk isn't in that zone.
- `toDiskResponse` derives zone / selfLink / type-link from the disk's own `AvailabilityZone`, not the request scope.
- `listDisks` filters to the requested zone; each response carries the disk's own zone.
- `images.go` source-disk size lookup extracts the zone from the disk self-link.
- `aggregatedList` still spans zones (unchanged).

Verified against GCP Compute disks REST semantics: disks are zonal and unique per-zone; get/delete/resize are zone-scoped; list is per-zone; aggregatedList spans zones.

## Tests

New real google-cloud-go DisksClient reproductions:
- insert in `us-west1-b`, then get/delete/resize via `us-central1-a` → 404 (west disk untouched)
- list(`us-central1-a`) with disks in two zones → only the central disk, correct selfLinks
- same disk name in two different zones → both insert OK, distinct sizes
- aggregatedList still spans both zones

Existing GCP compute tests remain green.