### PR TITLE
fix(azure-compute): VM PATCH applies vmSize/tags; in-place disk update (no dup, stable uniqueId); VMSS delete + RG cascade

### DIFF
--- a/docs/coverage/aws/ec2.md
+++ b/docs/coverage/aws/ec2.md
@@ -58,6 +58,14 @@ AzureDiskAccessor is an optional Azure-only capability for the managed-disk
 | `GrantDiskAccess` | GrantDiskAccess issues a time-bounded SAS URI granting the requested |
 | `RevokeDiskAccess` | RevokeDiskAccess revokes any SAS access previously granted to the disk. |
 
+### AzureDiskUpdater
+
+AzureDiskUpdater is an optional Azure-only capability for an in-place managed
+
+| Operation | Description |
+| --- | --- |
+| `UpdateVolume` | UpdateVolume mutates the existing volume id in place from cfg (size, sku/ |
+
 ### AzureSSHKeyUpdater
 
 AzureSSHKeyUpdater is an optional Azure-only capability for the sshPublicKeys
@@ -74,6 +82,7 @@ AzureVMController is an optional Azure-only capability supporting the ARM
 | --- | --- |
 | `Deallocate` | Deallocate stops the guest and releases the allocated compute |
 | `GeneralizeInstance` | GeneralizeInstance marks an instance as generalized (Azure Generalize |
+| `PatchInstance` | PatchInstance applies a merge-patch (ARM PATCH Update / BeginUpdate) to an |
 | `PowerOff` | PowerOff stops the guest OS while keeping the VM allocated |
 | `UpdateInstance` | UpdateInstance overwrites the mutable configuration of an existing |
 

--- a/docs/coverage/azure/virtualmachines.md
+++ b/docs/coverage/azure/virtualmachines.md
@@ -58,6 +58,14 @@ AzureDiskAccessor is an optional Azure-only capability for the managed-disk
 | `GrantDiskAccess` | GrantDiskAccess issues a time-bounded SAS URI granting the requested |
 | `RevokeDiskAccess` | RevokeDiskAccess revokes any SAS access previously granted to the disk. |
 
+### AzureDiskUpdater
+
+AzureDiskUpdater is an optional Azure-only capability for an in-place managed
+
+| Operation | Description |
+| --- | --- |
+| `UpdateVolume` | UpdateVolume mutates the existing volume id in place from cfg (size, sku/ |
+
 ### AzureSSHKeyUpdater
 
 AzureSSHKeyUpdater is an optional Azure-only capability for the sshPublicKeys
@@ -74,6 +82,7 @@ AzureVMController is an optional Azure-only capability supporting the ARM
 | --- | --- |
 | `Deallocate` | Deallocate stops the guest and releases the allocated compute |
 | `GeneralizeInstance` | GeneralizeInstance marks an instance as generalized (Azure Generalize |
+| `PatchInstance` | PatchInstance applies a merge-patch (ARM PATCH Update / BeginUpdate) to an |
 | `PowerOff` | PowerOff stops the guest OS while keeping the VM allocated |
 | `UpdateInstance` | UpdateInstance overwrites the mutable configuration of an existing |
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -2027,6 +2027,16 @@
         ]
       },
       {
+        "name": "AzureDiskUpdater",
+        "doc": "AzureDiskUpdater is an optional Azure-only capability for an in-place managed",
+        "operations": [
+          {
+            "name": "UpdateVolume",
+            "doc": "UpdateVolume mutates the existing volume id in place from cfg (size, sku/"
+          }
+        ]
+      },
+      {
         "name": "AzureSSHKeyUpdater",
         "doc": "AzureSSHKeyUpdater is an optional Azure-only capability for the sshPublicKeys",
         "operations": [
@@ -2047,6 +2057,10 @@
           {
             "name": "GeneralizeInstance",
             "doc": "GeneralizeInstance marks an instance as generalized (Azure Generalize"
+          },
+          {
+            "name": "PatchInstance",
+            "doc": "PatchInstance applies a merge-patch (ARM PATCH Update / BeginUpdate) to an"
           },
           {
             "name": "PowerOff",

--- a/docs/coverage/gcp/gce.md
+++ b/docs/coverage/gcp/gce.md
@@ -58,6 +58,14 @@ AzureDiskAccessor is an optional Azure-only capability for the managed-disk
 | `GrantDiskAccess` | GrantDiskAccess issues a time-bounded SAS URI granting the requested |
 | `RevokeDiskAccess` | RevokeDiskAccess revokes any SAS access previously granted to the disk. |
 
+### AzureDiskUpdater
+
+AzureDiskUpdater is an optional Azure-only capability for an in-place managed
+
+| Operation | Description |
+| --- | --- |
+| `UpdateVolume` | UpdateVolume mutates the existing volume id in place from cfg (size, sku/ |
+
 ### AzureSSHKeyUpdater
 
 AzureSSHKeyUpdater is an optional Azure-only capability for the sshPublicKeys
@@ -74,6 +82,7 @@ AzureVMController is an optional Azure-only capability supporting the ARM
 | --- | --- |
 | `Deallocate` | Deallocate stops the guest and releases the allocated compute |
 | `GeneralizeInstance` | GeneralizeInstance marks an instance as generalized (Azure Generalize |
+| `PatchInstance` | PatchInstance applies a merge-patch (ARM PATCH Update / BeginUpdate) to an |
 | `PowerOff` | PowerOff stops the guest OS while keeping the VM allocated |
 | `UpdateInstance` | UpdateInstance overwrites the mutable configuration of an existing |
 

--- a/providers/azure/virtualmachines/scaleset.go
+++ b/providers/azure/virtualmachines/scaleset.go
@@ -27,9 +27,14 @@ type ScaleSet struct {
 	LicenseType  string
 	OSType       string // Linux / Windows
 	Tags         map[string]string
+	// ResourceGroup is the ARM resource group the scale set belongs to, so a
+	// resource-group cascade delete can find and tear down its scale sets.
+	ResourceGroup string
 }
 
 // CreateScaleSet stores a VMSS, defaulting the fields real Azure fills in.
+//
+//nolint:gocritic // hugeParam: s mirrors the scaleSetStore interface signature.
 func (m *Mock) CreateScaleSet(_ context.Context, s ScaleSet) (*ScaleSet, error) {
 	if s.Name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "scale set name is required")
@@ -74,6 +79,16 @@ func (m *Mock) CreateScaleSet(_ context.Context, s ScaleSet) (*ScaleSet, error) 
 	out := stored
 
 	return &out, nil
+}
+
+// DeleteScaleSet removes a stored VMSS by name (ARM VMSS Delete). Returns
+// NotFound when no scale set with that name exists.
+func (m *Mock) DeleteScaleSet(_ context.Context, name string) error {
+	if !m.scaleSets.Delete(name) {
+		return cerrors.Newf(cerrors.NotFound, "virtualMachineScaleSet %q not found", name)
+	}
+
+	return nil
 }
 
 // ListScaleSets returns every stored VMSS.

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -34,6 +34,7 @@ var (
 	_ driver.Compute            = (*Mock)(nil)
 	_ driver.ConsoleReader      = (*Mock)(nil)
 	_ driver.AzureVMController  = (*Mock)(nil)
+	_ driver.AzureDiskUpdater   = (*Mock)(nil)
 	_ driver.KeyPairGenerator   = (*Mock)(nil)
 	_ driver.AzureDiskAccessor  = (*Mock)(nil)
 	_ driver.AzureSSHKeyUpdater = (*Mock)(nil)
@@ -680,6 +681,43 @@ func (m *Mock) UpdateInstance(_ context.Context, instanceID string, cfg driver.I
 	return nil
 }
 
+// PatchInstance applies an ARM PATCH Update (BeginUpdate) merge-patch to an
+// existing instance. Only the fields the request supplied are applied: a
+// non-empty VMSize resizes the VM, a non-nil Tags map is MERGED into the
+// existing tags (adding/overwriting supplied keys, leaving omitted keys —
+// including the internal ARM-name tag — in place), and a non-nil Identity
+// replaces the identity block. Everything else (priority, licenseType, image,
+// zones, …) is left untouched, unlike UpdateInstance's full-config replace.
+func (m *Mock) PatchInstance(_ context.Context, instanceID string, patch driver.AzureVMPatch) error {
+	ok := m.instances.Update(instanceID, func(inst *instanceData) *instanceData {
+		if patch.VMSize != "" {
+			inst.InstanceType = patch.VMSize
+		}
+
+		if patch.Tags != nil {
+			if inst.Tags == nil {
+				inst.Tags = make(map[string]string, len(patch.Tags))
+			}
+
+			for k, v := range patch.Tags {
+				inst.Tags[k] = v
+			}
+		}
+
+		if patch.Identity != nil {
+			inst.Identity = resolveIdentity(patch.Identity, instanceID)
+		}
+
+		return inst
+	})
+
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
+	}
+
+	return nil
+}
+
 // GeneralizeInstance marks an instance as generalized (Azure Generalize
 // action), a precondition for capturing it into a reusable image. Real Azure
 // requires the VM to be stopped or deallocated first: generalizing a running VM
@@ -897,6 +935,44 @@ func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver
 		Throughput:       cfg.Throughput,
 		Tier:             cfg.Tier,
 	}
+	m.volumes.Set(id, vol)
+
+	result := *vol
+
+	return &result, nil
+}
+
+// UpdateVolume mutates an existing managed disk in place (ARM Disks
+// CreateOrUpdate on a disk that already exists). It preserves the volume's ID,
+// CreatedAt, and current attachment (State/AttachedTo/Device) — so the derived
+// uniqueId and timeCreated stay stable and an attached disk is not duplicated —
+// while updating the mutable cost fields from cfg. A non-zero Size, non-empty
+// VolumeType/Tier are applied; IOPS/Throughput and Tags are replaced from cfg
+// (PUT is a full resource replacement).
+//
+//nolint:gocritic // hugeParam: cfg mirrors the driver-interface signature.
+func (m *Mock) UpdateVolume(_ context.Context, id string, cfg driver.VolumeConfig) (*driver.VolumeInfo, error) {
+	vol, ok := m.volumes.Get(id)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "disk %q not found", id)
+	}
+
+	if cfg.Size != 0 {
+		vol.Size = cfg.Size
+	}
+
+	if cfg.VolumeType != "" {
+		vol.VolumeType = cfg.VolumeType
+	}
+
+	if cfg.Tier != "" {
+		vol.Tier = cfg.Tier
+	}
+
+	vol.IOPS = cfg.IOPS
+	vol.Throughput = cfg.Throughput
+	vol.Tags = copyTags(cfg.Tags)
+
 	m.volumes.Set(id, vol)
 
 	result := *vol

--- a/server/azure/disks/handler.go
+++ b/server/azure/disks/handler.go
@@ -258,10 +258,21 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		Tags:       mergeDiskTags(req.Tags, rp.ResourceName, rp.ResourceGroup, createOption, sourceID),
 	}
 
-	// ARM CreateOrUpdate is idempotent: replace an existing disk in place
-	// rather than accumulating a duplicate under the same name.
+	// ARM CreateOrUpdate is idempotent: an existing disk is updated in place —
+	// preserving its ID (and derived uniqueId), timeCreated, and any live
+	// attachment — rather than delete+recreate, which would leave a duplicate
+	// phantom volume when the disk is attached (DeleteVolume rejects an attached
+	// disk) and churn the uniqueId/timeCreated on every re-PUT.
 	if existing, err := findDiskByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName); err == nil {
-		_ = h.compute.DeleteVolume(r.Context(), existing.ID)
+		vol, err := h.updateExistingDisk(r.Context(), existing, cfg)
+		if err != nil {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+
+		h.writeDiskCreateResponse(w, r, rp, req, vol)
+
+		return
 	}
 
 	vol, err := h.compute.CreateVolume(r.Context(), cfg)
@@ -270,6 +281,35 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		return
 	}
 
+	h.writeDiskCreateResponse(w, r, rp, req, vol)
+}
+
+// updateExistingDisk applies an idempotent CreateOrUpdate to an already-existing
+// disk. It uses the driver's in-place UpdateVolume when supported (preserving
+// the volume ID, CreatedAt, and attachment); a driver without that capability
+// falls back to the legacy delete+recreate, tolerated only for the unattached
+// case.
+//
+//nolint:gocritic // cfg mirrors the driver-interface signature.
+func (h *Handler) updateExistingDisk(
+	ctx context.Context, existing *computedriver.VolumeInfo, cfg computedriver.VolumeConfig,
+) (*computedriver.VolumeInfo, error) {
+	if updater, ok := h.compute.(computedriver.AzureDiskUpdater); ok {
+		return updater.UpdateVolume(ctx, existing.ID, cfg)
+	}
+
+	_ = h.compute.DeleteVolume(ctx, existing.ID)
+
+	return h.compute.CreateVolume(ctx, cfg)
+}
+
+// writeDiskCreateResponse writes the 202 + Azure-AsyncOperation CreateOrUpdate
+// reply for a created or updated disk.
+//
+//nolint:gocritic // rp/req are request-scoped values passed once per request.
+func (h *Handler) writeDiskCreateResponse(
+	w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, req diskRequest, vol *computedriver.VolumeInfo,
+) {
 	location := req.Location
 	if location == "" {
 		location = defaultLocation

--- a/server/azure/virtualmachines/disk_inplace_update_test.go
+++ b/server/azure/virtualmachines/disk_inplace_update_test.go
@@ -1,0 +1,162 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKDiskInPlaceUpdateOnAttachedDisk is the regression test for the disk
+// CreateOrUpdate fix: re-PUTting a disk that is already attached to a VM must
+// update it IN PLACE — exactly one backing volume, the new tag applied, and the
+// derived uniqueId + timeCreated unchanged from the first PUT. The old code did
+// delete+create, which (a) silently failed the delete on an attached disk and
+// created a duplicate phantom volume, and (b) regenerated the volume id, churning
+// uniqueId + timeCreated on every re-PUT.
+func TestSDKDiskInPlaceUpdateOnAttachedDisk(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		Disks:           cloudP.VirtualMachines,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	vmClient := newSDKClient(t, ts)
+
+	diskClient, err := armcompute.NewDisksClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	// A VM to attach the disk to.
+	vmPoller, err := vmClient.BeginCreateOrUpdate(ctx, "rg-1", "vm-inplace",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				OSProfile: &armcompute.OSProfile{ComputerName: to.Ptr("vm-inplace"), AdminUsername: to.Ptr("azureuser")},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate VM: %v", err)
+	}
+
+	if _, err := pollUntilDone(ctx, vmPoller); err != nil {
+		t.Fatalf("CreateOrUpdate VM poll: %v", err)
+	}
+
+	created, err := createDataDisk(ctx, t, diskClient, "d-att")
+	if err != nil {
+		t.Fatalf("create d-att: %v", err)
+	}
+
+	firstUID := diskUID(t, created)
+	firstCreated := diskTime(t, created)
+
+	// Attach d-att to the VM via PATCH (merge-patch attach at lun 0).
+	attachPoller, err := vmClient.BeginUpdate(ctx, "rg-1", "vm-inplace",
+		armcompute.VirtualMachineUpdate{
+			Properties: &armcompute.VirtualMachineProperties{
+				StorageProfile: &armcompute.StorageProfile{
+					DataDisks: []*armcompute.DataDisk{{
+						Lun:          to.Ptr[int32](0),
+						CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+						ManagedDisk:  &armcompute.ManagedDiskParameters{ID: created.ID},
+					}},
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate attach: %v", err)
+	}
+
+	if _, err := attachPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("attach poll: %v", err)
+	}
+
+	// Re-PUT the (now attached) disk adding a tag — the operation that used to
+	// duplicate the volume and drop the update.
+	rePoller, err := diskClient.BeginCreateOrUpdate(ctx, "rg-1", "d-att", armcompute.Disk{
+		Location: to.Ptr("eastus"),
+		SKU:      &armcompute.DiskSKU{Name: to.Ptr(armcompute.DiskStorageAccountTypesPremiumLRS)},
+		Tags:     map[string]*string{"stage": to.Ptr("qa")},
+		Properties: &armcompute.DiskProperties{
+			CreationData: &armcompute.CreationData{CreateOption: to.Ptr(armcompute.DiskCreateOptionEmpty)},
+			DiskSizeGB:   to.Ptr[int32](32),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("re-PUT d-att: %v", err)
+	}
+
+	if _, err := rePoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("re-PUT poll: %v", err)
+	}
+
+	// Exactly ONE backing volume — no duplicate phantom.
+	vols, err := cloudP.VirtualMachines.DescribeVolumes(ctx, nil)
+	if err != nil {
+		t.Fatalf("DescribeVolumes: %v", err)
+	}
+
+	if len(vols) != 1 {
+		t.Fatalf("backing volumes=%d, want exactly 1 (re-PUT of an attached disk must not duplicate it)", len(vols))
+	}
+
+	got, err := diskClient.Get(ctx, "rg-1", "d-att", nil)
+	if err != nil {
+		t.Fatalf("Get d-att: %v", err)
+	}
+
+	// Tag applied.
+	if got.Tags == nil || tagVal(got.Tags, "stage") != "qa" {
+		t.Errorf("tag stage=%q, want qa (re-PUT update was dropped)", tagVal(got.Tags, "stage"))
+	}
+
+	// Still attached (in-place update preserved the attachment).
+	if got.Properties == nil || got.Properties.DiskState == nil || *got.Properties.DiskState != armcompute.DiskStateAttached {
+		t.Errorf("diskState=%v, want Attached", diskStateOf(got))
+	}
+
+	// uniqueId + timeCreated stable across the update.
+	if uid := diskUID(t, got.Disk); uid != firstUID {
+		t.Errorf("uniqueId=%q, want %q (must be stable across an in-place update)", uid, firstUID)
+	}
+
+	if tc := diskTime(t, got.Disk); tc != firstCreated {
+		t.Errorf("timeCreated=%q, want %q (must be stable across an in-place update)", tc, firstCreated)
+	}
+}
+
+func diskUID(t *testing.T, d armcompute.Disk) string {
+	t.Helper()
+
+	if d.Properties == nil || d.Properties.UniqueID == nil {
+		t.Fatalf("disk uniqueId is nil")
+	}
+
+	return *d.Properties.UniqueID
+}
+
+func diskTime(t *testing.T, d armcompute.Disk) string {
+	t.Helper()
+
+	if d.Properties == nil || d.Properties.TimeCreated == nil {
+		t.Fatalf("disk timeCreated is nil")
+	}
+
+	return d.Properties.TimeCreated.Format(time.RFC3339Nano)
+}

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -210,12 +210,15 @@ func (h *Handler) updateExisting(
 }
 
 // update handles PATCH virtualMachines/{name} — ARM's BeginUpdate. Unlike PUT,
-// Update is a merge-patch: only the sections present in the body are applied,
-// and everything else is left untouched. We scope this to the operation's
-// primary real-world use — storageProfile.dataDisks attach/detach, the
-// standard non-recreating disk-attach path — rather than routing through
-// UpdateInstance (whose cfg-replace semantics assume PUT's full-body shape and
-// would blank tags/priority/licenseType a partial PATCH body omits).
+// Update is a merge-patch (RFC 7386): only the fields present in the body are
+// applied and everything else is left untouched. It applies the modeled
+// mutable fields a PATCH may carry — hardwareProfile.vmSize (resize), tags
+// (merged into the existing set), identity — via the driver's PatchInstance,
+// which leaves omitted fields (priority, licenseType, existing tags, …) intact,
+// rather than routing through UpdateInstance (whose full cfg-replace assumes
+// PUT's whole-body shape and would blank what a partial PATCH omits). Unmodeled
+// request props are preserved by the echo overlay; storageProfile.dataDisks is
+// reconciled below.
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) update(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
@@ -229,6 +232,21 @@ func (h *Handler) update(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
+	}
+
+	// Apply the modeled mutable fields the PATCH supplied (vmSize/tags/identity),
+	// merging into the existing VM rather than replacing its whole config.
+	if ctrl, ok := h.compute.(computedriver.AzureVMController); ok {
+		patch := computedriver.AzureVMPatch{
+			VMSize:   hardwareSize(req.Properties.HardwareProfile),
+			Tags:     req.Tags,
+			Identity: toDriverIdentity(req.Identity),
+		}
+
+		if err = ctrl.PatchInstance(r.Context(), inst.ID, patch); err != nil {
+			azurearm.WriteCErr(w, err)
+			return
+		}
 	}
 
 	// A PATCH that omits storageProfile.dataDisks entirely (nil slice) leaves the
@@ -608,7 +626,8 @@ func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 	writeAcceptedAsync(w, r, rp.Subscription, "delete-"+rp.ResourceName)
 }
 
-// PurgeResourceGroup terminates every virtual machine created under the given
+// PurgeResourceGroup terminates every virtual machine — and deletes every
+// virtual machine scale set (via purgeScaleSets) — created under the given
 // resource group, backing the resource-group cascade delete. Instances record
 // their group (Instance.ResourceGroup) on the ARM create path, so membership is
 // an exact match. Resource-group comparison is case-insensitive, matching ARM.
@@ -620,6 +639,23 @@ func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 // the now-deleted VM. Detach is best-effort: a single failure is recorded but
 // does not stop the remaining teardown.
 func (h *Handler) PurgeResourceGroup(ctx context.Context, _, resourceGroup string) error {
+	var firstErr error
+
+	if err := h.purgeInstances(ctx, resourceGroup); err != nil {
+		firstErr = err
+	}
+
+	if serr := h.purgeScaleSets(ctx, resourceGroup); serr != nil && firstErr == nil {
+		firstErr = serr
+	}
+
+	return firstErr
+}
+
+// purgeInstances detaches and terminates every virtual machine under the given
+// resource group — the VM half of the cascade. Detach is best-effort per VM so
+// one failure does not stop the rest.
+func (h *Handler) purgeInstances(ctx context.Context, resourceGroup string) error {
 	instances, err := h.compute.DescribeInstances(ctx, nil, nil)
 	if err != nil {
 		return err
@@ -647,6 +683,36 @@ func (h *Handler) PurgeResourceGroup(ctx context.Context, _, resourceGroup strin
 
 	if terr := h.compute.TerminateInstances(ctx, ids); terr != nil && firstErr == nil {
 		firstErr = terr
+	}
+
+	return firstErr
+}
+
+// purgeScaleSets deletes every virtual machine scale set under the given
+// resource group, so an RG cascade tears down its scale sets too (matching the
+// VM teardown above). A driver that does not implement the scale-set store is a
+// no-op. Resource-group comparison is case-insensitive, matching ARM.
+func (h *Handler) purgeScaleSets(ctx context.Context, resourceGroup string) error {
+	store, ok := h.compute.(scaleSetStore)
+	if !ok {
+		return nil
+	}
+
+	sets, err := store.ListScaleSets(ctx)
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+
+	for i := range sets {
+		if !strings.EqualFold(sets[i].ResourceGroup, resourceGroup) {
+			continue
+		}
+
+		if derr := store.DeleteScaleSet(ctx, sets[i].Name); derr != nil && firstErr == nil {
+			firstErr = derr
+		}
 	}
 
 	return firstErr

--- a/server/azure/virtualmachines/scalesets.go
+++ b/server/azure/virtualmachines/scalesets.go
@@ -15,6 +15,7 @@ import (
 type scaleSetStore interface {
 	CreateScaleSet(ctx context.Context, s providervm.ScaleSet) (*providervm.ScaleSet, error)
 	ListScaleSets(ctx context.Context) ([]providervm.ScaleSet, error)
+	DeleteScaleSet(ctx context.Context, name string) error
 }
 
 // serveScaleSet dispatches PUT/GET on Microsoft.Compute/virtualMachineScaleSets.
@@ -48,9 +49,26 @@ func (h *Handler) serveScaleSet(w http.ResponseWriter, r *http.Request, rp azure
 		createScaleSet(w, r, rp, store)
 	case http.MethodGet:
 		getScaleSet(w, r, rp, store)
+	case http.MethodDelete:
+		deleteScaleSet(w, r, rp, store)
 	default:
 		writeNotImplemented(w, r.Method+" "+r.URL.Path)
 	}
+}
+
+// deleteScaleSet handles DELETE virtualMachineScaleSets/{name}. Real Azure
+// returns 202 Accepted with the async-operation polling headers; the SDK's
+// poller then observes the operation Succeeded and a follow-up GET reports
+// NotFound.
+//
+//nolint:gocritic // rp is a request-scoped value
+func deleteScaleSet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store scaleSetStore) {
+	if err := store.DeleteScaleSet(r.Context(), rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "vmss-delete-"+rp.ResourceName)
 }
 
 // createScaleSet handles PUT virtualMachineScaleSets/{name}.
@@ -69,10 +87,11 @@ func createScaleSet(w http.ResponseWriter, r *http.Request, rp azurearm.Resource
 	}
 
 	set := providervm.ScaleSet{
-		Name:     rp.ResourceName,
-		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceTypeScaleSets, rp.ResourceName),
-		Location: req.Location,
-		Tags:     req.Tags,
+		Name:          rp.ResourceName,
+		ID:            azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceTypeScaleSets, rp.ResourceName),
+		Location:      req.Location,
+		Tags:          req.Tags,
+		ResourceGroup: rp.ResourceGroup,
 	}
 
 	if req.SKU != nil {

--- a/server/azure/virtualmachines/vm_patch_update_test.go
+++ b/server/azure/virtualmachines/vm_patch_update_test.go
@@ -1,0 +1,109 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKVMPatchUpdateAppliesVMSizeAndMergesTags is the regression test for the
+// PATCH Update fix: a real armcompute BeginUpdate that supplies
+// hardwareProfile.vmSize (a resize) and a new tag must take effect — Get shows
+// the new size and the added tag — while a tag the PATCH omitted (set at create)
+// is preserved (ARM PATCH is RFC 7386 merge-patch). Before the fix update() only
+// reconciled data disks and silently dropped vmSize/tags.
+func TestSDKVMPatchUpdateAppliesVMSizeAndMergesTags(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSDKClient(t, ts)
+	ctx := context.Background()
+
+	createPoller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "vm-patch",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Tags:     map[string]*string{"env": to.Ptr("prod")},
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				OSProfile: &armcompute.OSProfile{
+					ComputerName:  to.Ptr("vm-patch"),
+					AdminUsername: to.Ptr("azureuser"),
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := pollUntilDone(ctx, createPoller); err != nil {
+		t.Fatalf("CreateOrUpdate poll: %v", err)
+	}
+
+	// PATCH: resize to D4s_v3 and add a "team" tag. Neither the size nor the tag
+	// were touched by the create; "env" is not re-sent (merge-patch must keep it).
+	updatePoller, err := client.BeginUpdate(ctx, "rg-1", "vm-patch",
+		armcompute.VirtualMachineUpdate{
+			Tags: map[string]*string{"team": to.Ptr("blue")},
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD4SV3),
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate: %v", err)
+	}
+
+	if _, err := updatePoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("Update poll: %v", err)
+	}
+
+	got, err := client.Get(ctx, "rg-1", "vm-patch", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	// Resize applied.
+	if got.Properties == nil || got.Properties.HardwareProfile == nil || got.Properties.HardwareProfile.VMSize == nil ||
+		*got.Properties.HardwareProfile.VMSize != armcompute.VirtualMachineSizeTypesStandardD4SV3 {
+		t.Errorf("vmSize=%v, want Standard_D4s_v3", vmSizeOf(got.VirtualMachine))
+	}
+
+	// New tag added AND pre-existing tag preserved (merge, not replace).
+	if v := tagVal(got.Tags, "team"); v != "blue" {
+		t.Errorf("tag team=%q, want blue", v)
+	}
+
+	if v := tagVal(got.Tags, "env"); v != "prod" {
+		t.Errorf("tag env=%q, want prod (PATCH must not drop an omitted existing tag)", v)
+	}
+}
+
+func vmSizeOf(vm armcompute.VirtualMachine) string {
+	if vm.Properties == nil || vm.Properties.HardwareProfile == nil || vm.Properties.HardwareProfile.VMSize == nil {
+		return "<nil>"
+	}
+
+	return string(*vm.Properties.HardwareProfile.VMSize)
+}
+
+func tagVal(tags map[string]*string, key string) string {
+	v, ok := tags[key]
+	if !ok || v == nil {
+		return ""
+	}
+
+	return *v
+}

--- a/server/azure/virtualmachines/vmss_delete_test.go
+++ b/server/azure/virtualmachines/vmss_delete_test.go
@@ -1,0 +1,155 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKVMSSDelete is the regression test for the VMSS DELETE fix: BeginDelete
+// on a scale set must return 202 + a terminal async operation the SDK poller
+// settles, and a follow-up Get must report NotFound. Before the fix serveScaleSet
+// answered DELETE with 501 NotImplemented.
+func TestSDKVMSSDelete(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := armcompute.NewVirtualMachineScaleSetsClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	createVMSS(ctx, t, client, "rg-1", "del-vmss")
+
+	deletePoller, err := client.BeginDelete(ctx, "rg-1", "del-vmss", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+
+	if _, err := deletePoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("Delete poll: %v", err)
+	}
+
+	if _, err := client.Get(ctx, "rg-1", "del-vmss", nil); !isNotFound(err) {
+		t.Fatalf("Get after delete: err=%v, want 404 NotFound", err)
+	}
+}
+
+// TestSDKVMSSResourceGroupCascade asserts a scale set does not survive its
+// resource group: deleting the RG cascades into the VM handler's
+// PurgeResourceGroup, which now tears down scale sets too.
+func TestSDKVMSSResourceGroupCascade(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := armcompute.NewVirtualMachineScaleSetsClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	// The RG must exist for its DELETE to cascade (a delete of an absent group is
+	// a no-op 204 with no cascade), so create it, then the scale set inside it.
+	putResourceGroup(ctx, t, ts, "sub-1", "rg-cascade")
+	createVMSS(ctx, t, client, "rg-cascade", "cascade-vmss")
+
+	deleteResourceGroup(ctx, t, ts, "sub-1", "rg-cascade")
+
+	if _, err := client.Get(ctx, "rg-cascade", "cascade-vmss", nil); !isNotFound(err) {
+		t.Fatalf("Get scale set after RG delete: err=%v, want 404 NotFound (VMSS must not survive its RG)", err)
+	}
+}
+
+func createVMSS(ctx context.Context, t *testing.T, client *armcompute.VirtualMachineScaleSetsClient, rg, name string) {
+	t.Helper()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rg, name, armcompute.VirtualMachineScaleSet{
+		Location: to.Ptr("eastus"),
+		SKU: &armcompute.SKU{
+			Name:     to.Ptr("Standard_D2s_v3"),
+			Tier:     to.Ptr("Standard"),
+			Capacity: to.Ptr[int64](2),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("VMSS BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("VMSS create poll: %v", err)
+	}
+}
+
+// putResourceGroup / deleteResourceGroup drive the ARM resource-group endpoints
+// directly (there is no compute SDK for them) so the cascade can be exercised.
+func putResourceGroup(ctx context.Context, t *testing.T, ts *httptest.Server, sub, name string) {
+	t.Helper()
+
+	url := ts.URL + "/subscriptions/" + sub + "/resourcegroups/" + name + "?api-version=2021-04-01"
+	body := strings.NewReader(`{"location":"eastus"}`)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, body)
+	if err != nil {
+		t.Fatalf("new RG PUT request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("RG PUT: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		t.Fatalf("RG PUT status=%d, want 200/201", resp.StatusCode)
+	}
+}
+
+func deleteResourceGroup(ctx context.Context, t *testing.T, ts *httptest.Server, sub, name string) {
+	t.Helper()
+
+	url := ts.URL + "/subscriptions/" + sub + "/resourcegroups/" + name + "?api-version=2021-04-01"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		t.Fatalf("new RG DELETE request: %v", err)
+	}
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("RG DELETE: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("RG DELETE status=%d, want 202/204", resp.StatusCode)
+	}
+}
+
+func isNotFound(err error) bool {
+	var respErr *azcore.ResponseError
+
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
+}

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -643,10 +643,43 @@ type AzureVMController interface {
 	// instance in place (preserving its ID and launch time), for idempotent
 	// ARM CreateOrUpdate.
 	UpdateInstance(ctx context.Context, instanceID string, cfg InstanceConfig) error
+	// PatchInstance applies a merge-patch (ARM PATCH Update / BeginUpdate) to an
+	// existing instance: only the fields present in patch are applied — vmSize
+	// resizes the VM, tags are MERGED into the existing tag set, and a non-nil
+	// identity replaces it — while everything omitted (priority, licenseType,
+	// existing tags, …) is left untouched. Unlike UpdateInstance's full cfg
+	// replace, this never blanks a field the PATCH body omitted.
+	PatchInstance(ctx context.Context, instanceID string, patch AzureVMPatch) error
 	// GeneralizeInstance marks an instance as generalized (Azure Generalize
 	// action), a precondition for capturing it into a reusable image. It is
 	// idempotent: generalizing an already-generalized VM succeeds.
 	GeneralizeInstance(ctx context.Context, instanceID string) error
+}
+
+// AzureVMPatch carries the mutable fields an ARM PATCH Update may supply. A
+// zero/nil field means the PATCH body omitted it and the existing value is
+// preserved.
+type AzureVMPatch struct {
+	// VMSize, when non-empty, resizes the VM (hardwareProfile.vmSize).
+	VMSize string
+	// Tags, when non-nil, are merged into the existing tags (a PATCH adds or
+	// overwrites the supplied keys and leaves omitted keys in place).
+	Tags map[string]string
+	// Identity, when non-nil, replaces the managed identity block.
+	Identity *ManagedIdentity
+}
+
+// AzureDiskUpdater is an optional Azure-only capability for an in-place managed
+// disk update: ARM Disks CreateOrUpdate on a disk that already exists mutates
+// the existing volume by ID rather than delete+recreate, so its ID (and the
+// derived uniqueId), CreatedAt (timeCreated), and any live attachment are
+// preserved and no duplicate volume is produced. Only the Azure VM mock
+// implements it; the disks wire handler type-asserts for it.
+type AzureDiskUpdater interface {
+	// UpdateVolume mutates the existing volume id in place from cfg (size, sku/
+	// type, iops, throughput, tier, tags), preserving the volume's ID,
+	// CreatedAt, and current attachment. Returns NotFound when id is unknown.
+	UpdateVolume(ctx context.Context, id string, cfg VolumeConfig) (*VolumeInfo, error)
 }
 
 // AzureDiskAccessor is an optional Azure-only capability for the managed-disk


### PR DESCRIPTION
Confirming re-audit residue for Azure compute: fixes 2 HIGH data-loss bugs, a MED disk-identity churn, and a HIGH broken op, each verified against the official Azure ARM REST docs (VirtualMachines Update, Disks CreateOrUpdate, VirtualMachineScaleSets Delete) and covered by real azure-sdk-for-go (armcompute) reproduction tests.

## What changed

**VM PATCH Update dropped vmSize/tags (HIGH, silent drift).** `update()` only reconciled `storageProfile.dataDisks` and never applied the modeled mutable fields. It now applies the fields the PATCH body supplies — `hardwareProfile.vmSize` (resize), `tags` (RFC 7386 merge into the existing set), `identity` — via a new merge-aware driver `PatchInstance`, leaving omitted fields (priority, licenseType, existing tags) untouched rather than routing through `UpdateInstance`'s full cfg-replace. `az vm resize` / `az vm update --set tags.*` now take effect; no Terraform perpetual diff.

**Disk CreateOrUpdate on an attached disk duplicated the volume + dropped the update (HIGH).** The old path did `DeleteVolume` (which returns FailedPrecondition for an attached disk — the error was discarded) then `CreateVolume` anyway, yielding two volumes sharing the same disk-name tag with the VM's LUN pointing at the stale one. Replaced with an in-place `AzureDiskUpdater.UpdateVolume` that mutates the existing volume by ID.

**Disk uniqueId + timeCreated churned on every re-PUT (MED).** Because delete+create regenerated the volume ID (and thus the derived uniqueId) and CreatedAt. The in-place update preserves both, so `uniqueId` + `timeCreated` stay stable across updates.

**VMSS DELETE returned 501 (HIGH, broken op).** `serveScaleSet` handled only PUT/GET. Added a provider `DeleteScaleSet`, a DELETE branch returning 202 + async poller, and included scale sets in `PurgeResourceGroup` so an RG cascade tears them down. `terraform destroy` of a scale set now succeeds and a VMSS does not survive its resource group.

## Tests (real armcompute SDK)
- VM `BeginUpdate({Tags, VMSize})` → Get shows the resize + added tag; a pre-existing omitted tag is preserved.
- Disk: create → attach via VM PATCH → re-PUT with a new tag → exactly ONE backing volume, tag applied, `uniqueId` + `timeCreated` unchanged from the first PUT, still Attached.
- VMSS `BeginDelete` → 202 → DONE → Get NotFound; a VMSS in an RG is gone after the RG is deleted.

Existing compute tests (VM lifecycle, disk attach/detach, VMSS create/scale/scale-to-zero, cross-RG isolation) stay green, including `-race`.

Notes: `go generate` regenerated `docs/coverage` for the two new optional driver capabilities; the AWS compat suite passes (compatgen exit 0, `docs/compat` clean).