### PR TITLE
fix(azure-networking): in-place subnet update + NSG/NAT (dis)association; peering-delete disconnects reciprocal; RG-scoped NSG validation

### DIFF
--- a/docs/coverage/aws/vpc.md
+++ b/docs/coverage/aws/vpc.md
@@ -364,6 +364,14 @@ SubnetAttributes is an OPTIONAL capability, discovered by type assertion.
 | --- | --- |
 | `ModifySubnetAttribute` |  |
 
+### SubnetCIDRUpdater
+
+SubnetCIDRUpdater is an OPTIONAL capability, discovered by type assertion. It
+
+| Operation | Description |
+| --- | --- |
+| `UpdateSubnetCIDR` |  |
+
 ### TrafficMirroring
 
 TrafficMirroring is an OPTIONAL AWS capability (type-asserted).

--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -364,6 +364,14 @@ SubnetAttributes is an OPTIONAL capability, discovered by type assertion.
 | --- | --- |
 | `ModifySubnetAttribute` |  |
 
+### SubnetCIDRUpdater
+
+SubnetCIDRUpdater is an OPTIONAL capability, discovered by type assertion. It
+
+| Operation | Description |
+| --- | --- |
+| `UpdateSubnetCIDR` |  |
+
 ### TrafficMirroring
 
 TrafficMirroring is an OPTIONAL AWS capability (type-asserted).

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -7117,6 +7117,15 @@
         ]
       },
       {
+        "name": "SubnetCIDRUpdater",
+        "doc": "SubnetCIDRUpdater is an OPTIONAL capability, discovered by type assertion. It",
+        "operations": [
+          {
+            "name": "UpdateSubnetCIDR"
+          }
+        ]
+      },
+      {
         "name": "TrafficMirroring",
         "doc": "TrafficMirroring is an OPTIONAL AWS capability (type-asserted).",
         "operations": [

--- a/docs/coverage/gcp/vpc.md
+++ b/docs/coverage/gcp/vpc.md
@@ -364,6 +364,14 @@ SubnetAttributes is an OPTIONAL capability, discovered by type assertion.
 | --- | --- |
 | `ModifySubnetAttribute` |  |
 
+### SubnetCIDRUpdater
+
+SubnetCIDRUpdater is an OPTIONAL capability, discovered by type assertion. It
+
+| Operation | Description |
+| --- | --- |
+| `UpdateSubnetCIDR` |  |
+
 ### TrafficMirroring
 
 TrafficMirroring is an OPTIONAL AWS capability (type-asserted).

--- a/docs/coverage/oci/vcn.md
+++ b/docs/coverage/oci/vcn.md
@@ -364,6 +364,14 @@ SubnetAttributes is an OPTIONAL capability, discovered by type assertion.
 | --- | --- |
 | `ModifySubnetAttribute` |  |
 
+### SubnetCIDRUpdater
+
+SubnetCIDRUpdater is an OPTIONAL capability, discovered by type assertion. It
+
+| Operation | Description |
+| --- | --- |
+| `UpdateSubnetCIDR` |  |
+
 ### TrafficMirroring
 
 TrafficMirroring is an OPTIONAL AWS capability (type-asserted).

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -355,6 +355,23 @@ func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error 
 	return nil
 }
 
+// UpdateSubnetCIDR changes a subnet's address prefix in place, implementing the
+// SubnetCIDRUpdater capability (the ARM Subnets.CreateOrUpdate re-PUT path).
+func (m *Mock) UpdateSubnetCIDR(_ context.Context, id, cidr string) error {
+	if cidr == "" {
+		return cerrors.New(cerrors.InvalidArgument, "CIDR block is required")
+	}
+
+	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
+		s.CIDRBlock = cidr
+		return s
+	}) {
+		return cerrors.Newf(cerrors.NotFound, "subnet %q not found", id)
+	}
+
+	return nil
+}
+
 // UpdateSubnetTags merges tags into the subnet's tag map.
 func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
 	if !m.subnets.Update(id, func(s *subnetData) *subnetData {

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -354,7 +354,7 @@ func (h *Handler) materializeSubnets(ctx context.Context, vpcID string, subs []s
 		}
 	}
 
-	wanted, err := h.createMissingSubnets(ctx, vpcID, subs, haveByName)
+	wanted, err := h.upsertWantedSubnets(ctx, vpcID, subs, haveByName)
 	if err != nil {
 		return err
 	}
@@ -362,11 +362,12 @@ func (h *Handler) materializeSubnets(ctx context.Context, vpcID string, subs []s
 	return h.deleteOmittedSubnets(ctx, haveByName, wanted)
 }
 
-// createMissingSubnets creates every named subnet in subs that isn't already
-// in haveByName, validating its CIDR first, and returns the set of names this
-// PUT's body wants — the input deleteOmittedSubnets needs to find what to
-// remove.
-func (h *Handler) createMissingSubnets(
+// upsertWantedSubnets creates every named subnet in subs that isn't already in
+// haveByName and applies an in-place CreateOrUpdate to those that are (changed
+// address prefix, replaced NSG / NAT gateway associations), validating each
+// CIDR first, and returns the set of names this PUT's body wants — the input
+// deleteOmittedSubnets needs to find what to remove.
+func (h *Handler) upsertWantedSubnets(
 	ctx context.Context, vpcID string, subs []subnetRequest, haveByName map[string]netdriver.SubnetInfo,
 ) (map[string]struct{}, error) {
 	wanted := make(map[string]struct{}, len(subs))
@@ -378,7 +379,11 @@ func (h *Handler) createMissingSubnets(
 
 		wanted[subs[i].Name] = struct{}{}
 
-		if _, ok := haveByName[subs[i].Name]; ok {
+		if existing, ok := haveByName[subs[i].Name]; ok {
+			if err := h.updateInlineSubnet(ctx, vpcID, &subs[i], &existing); err != nil {
+				return nil, err
+			}
+
 			continue
 		}
 
@@ -396,6 +401,39 @@ func (h *Handler) createMissingSubnets(
 	}
 
 	return wanted, nil
+}
+
+// updateInlineSubnet applies a whole-VNet PUT's inline subnet body to an
+// existing subnet: it validates and changes the address prefix when it differs
+// and REPLACES the NSG / NAT gateway associations from the body (an omitted
+// reference clears the association), the same full-replacement semantics as the
+// standalone subnet CreateOrUpdate.
+func (h *Handler) updateInlineSubnet(
+	ctx context.Context, vpcID string, sub *subnetRequest, existing *netdriver.SubnetInfo,
+) error {
+	cidr := sub.Properties.AddressPrefix
+	if cidr != "" && cidr != existing.CIDRBlock {
+		if verr := h.validateSubnetCIDR(ctx, vpcID, sub.Name, cidr); verr != nil {
+			return verr
+		}
+	}
+
+	natID := inlineRefID(sub.Properties.NatGateway)
+	nsgID := inlineRefID(sub.Properties.NetworkSecurityGroup)
+
+	_, err := h.updateExistingSubnet(ctx, existing, cidr, natID, nsgID)
+
+	return err
+}
+
+// inlineRefID returns an armIDRef's id, or "" when the reference is nil (the
+// property was omitted from the request body).
+func inlineRefID(ref *armIDRef) string {
+	if ref == nil {
+		return ""
+	}
+
+	return ref.ID
 }
 
 // inlineSubnetTags builds the tag set for a subnet materialized from a
@@ -773,40 +811,46 @@ func (h *Handler) createSubnet(w http.ResponseWriter, r *http.Request, rp azurea
 // itself. ok is false when a response was already written and the caller
 // must stop.
 func (h *Handler) resolveSubnetNATGateway(w http.ResponseWriter, r *http.Request, ref *armIDRef) (id string, ok bool) {
-	if ref == nil {
-		return "", true
-	}
-
-	ngRP, parsed := azurearm.ParsePath(ref.ID)
-	if !parsed || ngRP.ResourceType != typeNATGateway {
-		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "malformed natGateway id")
-		return "", false
-	}
-
-	if _, err := findNATGatewayByName(r.Context(), h.net, ngRP.ResourceGroup, ngRP.ResourceName); err != nil {
-		azurearm.WriteCErr(w, err)
-		return "", false
-	}
-
-	return ref.ID, true
+	return h.resolveSubnetRef(w, r, ref, typeNATGateway, "natGateway",
+		func(ctx context.Context, rg, name string) error {
+			_, err := findNATGatewayByName(ctx, h.net, rg, name)
+			return err
+		})
 }
 
 // resolveSubnetNSG validates and resolves an optional networkSecurityGroup
 // reference on a subnet PUT body, writing the appropriate error response
 // itself. ok is false when a response was already written and the caller
-// must stop.
+// must stop. The reference is resolved within its own resource group so a
+// subnet cannot associate an NSG that only exists in a different group.
 func (h *Handler) resolveSubnetNSG(w http.ResponseWriter, r *http.Request, ref *armIDRef) (id string, ok bool) {
+	return h.resolveSubnetRef(w, r, ref, typeNSG, "networkSecurityGroup",
+		func(ctx context.Context, rg, name string) error {
+			_, err := findNSGInGroup(ctx, h.net, rg, name)
+			return err
+		})
+}
+
+// resolveSubnetRef validates an optional armIDRef on a subnet PUT body: an
+// absent reference is a no-op, a malformed one (unparseable or the wrong
+// resource type) writes a 400, and validate resolves the reference within its
+// own resource group. It returns the reference's own id when valid; ok is false
+// when a response was already written and the caller must stop.
+func (*Handler) resolveSubnetRef(
+	w http.ResponseWriter, r *http.Request, ref *armIDRef, expectType, label string,
+	validate func(ctx context.Context, rg, name string) error,
+) (id string, ok bool) {
 	if ref == nil {
 		return "", true
 	}
 
-	nsgRP, parsed := azurearm.ParsePath(ref.ID)
-	if !parsed || nsgRP.ResourceType != typeNSG {
-		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "malformed networkSecurityGroup id")
+	rp, parsed := azurearm.ParsePath(ref.ID)
+	if !parsed || rp.ResourceType != expectType {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "malformed "+label+" id")
 		return "", false
 	}
 
-	if _, err := findNSGByName(r.Context(), h.net, nsgRP.ResourceName); err != nil {
+	if err := validate(r.Context(), rp.ResourceGroup, rp.ResourceName); err != nil {
 		azurearm.WriteCErr(w, err)
 		return "", false
 	}
@@ -814,37 +858,16 @@ func (h *Handler) resolveSubnetNSG(w http.ResponseWriter, r *http.Request, ref *
 	return ref.ID, true
 }
 
-// upsertSubnet creates the named subnet, or — when it already exists — merges
-// in a NAT gateway and/or NSG reference so a subnet can be attached via a
-// second PUT (armnetwork's SubnetsClient.BeginCreateOrUpdate, the real ARM
-// mechanism: both associations live on the subnet's own natGateway /
-// networkSecurityGroup properties). Other subnet properties are not merged on
-// update, matching this handler's existing create-only behavior for subnets.
+// upsertSubnet creates the named subnet, or — when it already exists — applies
+// an in-place update (armnetwork's SubnetsClient.BeginCreateOrUpdate, the real
+// ARM mechanism). CreateOrUpdate is a full replacement: the address prefix is
+// changed when it differs, and the NAT gateway / NSG associations are REPLACED
+// from the request body so an omitted reference (empty id) CLEARS the existing
+// association. Both associations live on the subnet's own natGateway /
+// networkSecurityGroup properties.
 func (h *Handler) upsertSubnet(ctx context.Context, vpcID, name, cidr, natGatewayID, nsgID string) (*netdriver.SubnetInfo, error) {
 	if existing, err := findSubnetInVNet(ctx, h.net, vpcID, name); err == nil {
-		merge := make(map[string]string)
-
-		if natGatewayID != "" {
-			merge[armSubnetNATTag] = natGatewayID
-		}
-
-		if nsgID != "" {
-			merge[armSubnetNSGTag] = nsgID
-		}
-
-		if len(merge) == 0 {
-			return existing, nil
-		}
-
-		if err := h.net.UpdateSubnetTags(ctx, existing.ID, merge); err != nil {
-			return nil, err
-		}
-
-		for k, v := range merge {
-			existing.Tags = mergeTags(existing.Tags, k, v)
-		}
-
-		return existing, nil
+		return h.updateExistingSubnet(ctx, existing, cidr, natGatewayID, nsgID)
 	}
 
 	tags := mergeTags(nil, armSubnetTag, name)
@@ -861,6 +884,75 @@ func (h *Handler) upsertSubnet(ctx context.Context, vpcID, name, cidr, natGatewa
 		CIDRBlock: cidr,
 		Tags:      tags,
 	})
+}
+
+// updateExistingSubnet applies an in-place CreateOrUpdate to an existing subnet:
+// it changes the address prefix when it differs and REPLACES the NSG / NAT
+// gateway associations from the request body (an omitted reference — empty id —
+// clears that association, matching ARM's full-replacement semantics).
+func (h *Handler) updateExistingSubnet(
+	ctx context.Context, existing *netdriver.SubnetInfo, cidr, natGatewayID, nsgID string,
+) (*netdriver.SubnetInfo, error) {
+	if cidr != "" && cidr != existing.CIDRBlock {
+		if u, ok := h.net.(netdriver.SubnetCIDRUpdater); ok {
+			if err := u.UpdateSubnetCIDR(ctx, existing.ID, cidr); err != nil {
+				return nil, err
+			}
+
+			existing.CIDRBlock = cidr
+		}
+	}
+
+	if err := h.replaceSubnetAssociation(ctx, existing, armSubnetNSGTag, nsgID); err != nil {
+		return nil, err
+	}
+
+	if err := h.replaceSubnetAssociation(ctx, existing, armSubnetNATTag, natGatewayID); err != nil {
+		return nil, err
+	}
+
+	return existing, nil
+}
+
+// replaceSubnetAssociation sets the subnet tag identified by tagKey to id, or —
+// when id is empty (the reference was omitted from the request body) — clears
+// it, so a CreateOrUpdate that drops an NSG / NAT gateway reference removes the
+// association. existing.Tags is updated to mirror the store mutation.
+func (h *Handler) replaceSubnetAssociation(ctx context.Context, existing *netdriver.SubnetInfo, tagKey, id string) error {
+	if id != "" {
+		if err := h.net.UpdateSubnetTags(ctx, existing.ID, map[string]string{tagKey: id}); err != nil {
+			return err
+		}
+
+		existing.Tags = mergeTags(existing.Tags, tagKey, id)
+
+		return nil
+	}
+
+	if tagOr(existing.Tags, tagKey, "") == "" {
+		return nil
+	}
+
+	if err := h.net.RemoveSubnetTags(ctx, existing.ID, []string{tagKey}); err != nil {
+		return err
+	}
+
+	existing.Tags = tagsWithout(existing.Tags, tagKey)
+
+	return nil
+}
+
+// tagsWithout returns a copy of in with key removed.
+func tagsWithout(in map[string]string, key string) map[string]string {
+	out := make(map[string]string, len(in))
+
+	for k, v := range in {
+		if k != key {
+			out[k] = v
+		}
+	}
+
+	return out
 }
 
 // findSubnetInVNet resolves a subnet by (vnet, name) — subnet names are only

--- a/server/azure/vnet/network_interface.go
+++ b/server/azure/vnet/network_interface.go
@@ -168,7 +168,7 @@ func (h *Handler) createNIC(w http.ResponseWriter, r *http.Request, rp azurearm.
 			return
 		}
 
-		if _, nsgErr := findNSGByName(r.Context(), h.net, nsgRP.ResourceName); nsgErr != nil {
+		if _, nsgErr := findNSGInGroup(r.Context(), h.net, nsgRP.ResourceGroup, nsgRP.ResourceName); nsgErr != nil {
 			azurearm.WriteCErr(w, nsgErr)
 			return
 		}

--- a/server/azure/vnet/subnet_update_test.go
+++ b/server/azure/vnet/subnet_update_test.go
@@ -1,0 +1,270 @@
+package vnet_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// Finding: a subnet CreateOrUpdate was create-only — re-PUTting an existing
+// subnet with a new addressPrefix silently dropped the change (GET returned the
+// old CIDR). Real ARM replaces the addressPrefix in place.
+func TestSDKSubnetUpdateAddressPrefix(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnets, _ := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	subnets, _ := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+
+	createTestVNet(t, ctx, vnets, "rg-1", "vnet-cidr", "10.0.0.0/16")
+
+	p, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-cidr", "sn1", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create subnet: %v", err)
+	}
+
+	pollDone(t, p)
+
+	p2, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-cidr", "sn1", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.5.0/24")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("re-PUT subnet with new CIDR: %v", err)
+	}
+
+	pollDone(t, p2)
+
+	got, err := subnets.Get(ctx, "rg-1", "vnet-cidr", "sn1", nil)
+	if err != nil {
+		t.Fatalf("subnet Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.AddressPrefix == nil || *got.Properties.AddressPrefix != "10.0.5.0/24" {
+		t.Fatalf("subnet addressPrefix after re-PUT = %+v, want 10.0.5.0/24", got.Properties)
+	}
+}
+
+// Finding: an associated NSG could never be removed — re-PUTting a subnet
+// WITHOUT networkSecurityGroup left the association in place. Real ARM's
+// CreateOrUpdate is a full replacement: an omitted networkSecurityGroup clears
+// the association (the azurerm_subnet_network_security_group_association delete
+// path).
+func TestSDKSubnetNSGDisassociation(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnets, _ := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	subnets, _ := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+	nsgs, _ := armnetwork.NewSecurityGroupsClient("sub-1", fakeCred{}, opts)
+
+	nsgP, err := nsgs.BeginCreateOrUpdate(ctx, "rg-1", "nsg-disassoc", armnetwork.SecurityGroup{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create nsg: %v", err)
+	}
+
+	pollDone(t, nsgP)
+
+	nsgID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/networkSecurityGroups/nsg-disassoc"
+
+	createTestVNet(t, ctx, vnets, "rg-1", "vnet-disassoc", "10.0.0.0/16")
+
+	p, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-disassoc", "sn1", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix:        to.Ptr("10.0.1.0/24"),
+			NetworkSecurityGroup: &armnetwork.SecurityGroup{ID: to.Ptr(nsgID)},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("associate NSG: %v", err)
+	}
+
+	assoc := pollDone(t, p)
+	if assoc.Properties == nil || assoc.Properties.NetworkSecurityGroup == nil {
+		t.Fatal("subnet did not carry the NSG association after the first PUT")
+	}
+
+	// Re-PUT WITHOUT networkSecurityGroup: the association must be cleared.
+	p2, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-disassoc", "sn1", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("re-PUT subnet without NSG: %v", err)
+	}
+
+	pollDone(t, p2)
+
+	got, err := subnets.Get(ctx, "rg-1", "vnet-disassoc", "sn1", nil)
+	if err != nil {
+		t.Fatalf("subnet Get: %v", err)
+	}
+
+	if got.Properties != nil && got.Properties.NetworkSecurityGroup != nil {
+		t.Fatalf("subnet NSG after disassociating re-PUT = %+v, want none", got.Properties.NetworkSecurityGroup)
+	}
+}
+
+// Finding: deleting one side of a two-way VNet peering left the surviving
+// reciprocal side stuck reporting Connected. Real ARM transitions the orphaned
+// side to Disconnected.
+func TestSDKPeeringDeleteDisconnectsReciprocal(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnets, _ := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	peerings, _ := armnetwork.NewVirtualNetworkPeeringsClient("sub-1", fakeCred{}, opts)
+
+	createTestVNet(t, ctx, vnets, "rg-1", "vnet-a", "10.0.0.0/16")
+	createTestVNet(t, ctx, vnets, "rg-1", "vnet-b", "10.1.0.0/16")
+
+	vnetAID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/virtualNetworks/vnet-a"
+	vnetBID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/virtualNetworks/vnet-b"
+
+	pa, err := peerings.BeginCreateOrUpdate(ctx, "rg-1", "vnet-a", "a-to-b", armnetwork.VirtualNetworkPeering{
+		Properties: &armnetwork.VirtualNetworkPeeringPropertiesFormat{
+			RemoteVirtualNetwork: &armnetwork.SubResource{ID: to.Ptr(vnetBID)},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create a-to-b: %v", err)
+	}
+
+	pollDone(t, pa)
+
+	pb, err := peerings.BeginCreateOrUpdate(ctx, "rg-1", "vnet-b", "b-to-a", armnetwork.VirtualNetworkPeering{
+		Properties: &armnetwork.VirtualNetworkPeeringPropertiesFormat{
+			RemoteVirtualNetwork: &armnetwork.SubResource{ID: to.Ptr(vnetAID)},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create b-to-a: %v", err)
+	}
+
+	pollDone(t, pb)
+
+	// Delete the b-to-a side; the surviving a-to-b must become Disconnected.
+	dp, err := peerings.BeginDelete(ctx, "rg-1", "vnet-b", "b-to-a", nil)
+	if err != nil {
+		t.Fatalf("delete b-to-a: %v", err)
+	}
+
+	pollDone(t, dp)
+
+	aSide, err := peerings.Get(ctx, "rg-1", "vnet-a", "a-to-b", nil)
+	if err != nil {
+		t.Fatalf("Get a-to-b after reciprocal delete: %v", err)
+	}
+
+	if aSide.Properties == nil || aSide.Properties.PeeringState == nil ||
+		*aSide.Properties.PeeringState != armnetwork.VirtualNetworkPeeringStateDisconnected {
+		t.Fatalf("surviving peering state = %v, want Disconnected", aSide.Properties.PeeringState)
+	}
+}
+
+// Finding: NSG references were resolved by name only, not resource-group
+// scoped — a NIC in rgA could reference an NSG that exists only in rgB and be
+// accepted. The reference must resolve within the NSG id's own resource group.
+func TestSDKNICNSGCrossRGRejected(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnets, _ := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	subnets, _ := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+	nsgs, _ := armnetwork.NewSecurityGroupsClient("sub-1", fakeCred{}, opts)
+	nics, _ := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, opts)
+
+	// The NSG lives only in rgB.
+	nsgP, err := nsgs.BeginCreateOrUpdate(ctx, "rg-b", "nsg-x", armnetwork.SecurityGroup{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create nsg in rg-b: %v", err)
+	}
+
+	pollDone(t, nsgP)
+
+	createTestVNet(t, ctx, vnets, "rg-a", "vnet-a", "10.0.0.0/16")
+
+	subP, err := subnets.BeginCreateOrUpdate(ctx, "rg-a", "vnet-a", "default", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create subnet: %v", err)
+	}
+
+	pollDone(t, subP)
+
+	subnetID := "/subscriptions/sub-1/resourceGroups/rg-a/providers/Microsoft.Network/" +
+		"virtualNetworks/vnet-a/subnets/default"
+
+	// The NIC in rg-a references the NSG by its rg-a id, where it does not exist.
+	badNSGID := "/subscriptions/sub-1/resourceGroups/rg-a/providers/Microsoft.Network/networkSecurityGroups/nsg-x"
+
+	_, err = nics.BeginCreateOrUpdate(ctx, "rg-a", "nic-x", armnetwork.Interface{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			NetworkSecurityGroup: &armnetwork.SecurityGroup{ID: to.Ptr(badNSGID)},
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig1"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					Subnet: &armnetwork.Subnet{ID: to.Ptr(subnetID)},
+				},
+			}},
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("NIC referencing an NSG absent in its own RG: want error, got nil")
+	}
+
+	if got := respStatus(t, err); got != 404 {
+		t.Fatalf("cross-RG NSG reference: status = %d, want 404", got)
+	}
+}
+
+// Companion to TestSDKNICNSGCrossRGRejected: a subnet in rg-a referencing an
+// NSG that exists only in rg-b must likewise be rejected as not found.
+func TestSDKSubnetNSGCrossRGRejected(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnets, _ := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	subnets, _ := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+	nsgs, _ := armnetwork.NewSecurityGroupsClient("sub-1", fakeCred{}, opts)
+
+	nsgP, err := nsgs.BeginCreateOrUpdate(ctx, "rg-b", "nsg-y", armnetwork.SecurityGroup{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create nsg in rg-b: %v", err)
+	}
+
+	pollDone(t, nsgP)
+
+	createTestVNet(t, ctx, vnets, "rg-a", "vnet-sub", "10.0.0.0/16")
+
+	badNSGID := "/subscriptions/sub-1/resourceGroups/rg-a/providers/Microsoft.Network/networkSecurityGroups/nsg-y"
+
+	_, err = subnets.BeginCreateOrUpdate(ctx, "rg-a", "vnet-sub", "default", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix:        to.Ptr("10.0.1.0/24"),
+			NetworkSecurityGroup: &armnetwork.SecurityGroup{ID: to.Ptr(badNSGID)},
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("subnet referencing an NSG absent in its own RG: want error, got nil")
+	}
+
+	if got := respStatus(t, err); got != 404 {
+		t.Fatalf("cross-RG NSG reference: status = %d, want 404", got)
+	}
+}

--- a/server/azure/vnet/vnet_peering_subresource.go
+++ b/server/azure/vnet/vnet_peering_subresource.go
@@ -215,12 +215,48 @@ func (h *Handler) deleteVNetPeering(w http.ResponseWriter, r *http.Request, rp a
 		return
 	}
 
+	// Capture the peering's remote VNet before deleting it so the reciprocal
+	// side can be transitioned to Disconnected afterward.
+	deleted, hadPeering := meta.GetAzureVNetPeering(r.Context(), vnet.ID, rp.SubResourceName)
+
 	if err := meta.DeleteAzureVNetPeering(r.Context(), vnet.ID, rp.SubResourceName); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
+	if hadPeering {
+		localID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeVNet, rp.ResourceName)
+		h.disconnectReciprocalPeering(r.Context(), meta, deleted.RemoteVirtualNetworkID, localID)
+	}
+
 	writeAcceptedAsync(w, r, rp.Subscription, "peering-delete-"+rp.SubResourceName, nil)
+}
+
+// disconnectReciprocalPeering transitions the surviving reciprocal peering — the
+// one on the remote VNet pointing back at localVNetARMID — to Disconnected after
+// its counterpart has been deleted, matching real ARM: deleting one side of a
+// two-way peering leaves the other side stuck in Disconnected rather than
+// Connected. Best-effort: a remote VNet or reciprocal that can't be resolved
+// (e.g. it never existed, or the delete already removed both sides) is a no-op.
+func (h *Handler) disconnectReciprocalPeering(
+	ctx context.Context, meta netdriver.AzureNetworkMetadata, remoteVNetARMID, localVNetARMID string,
+) {
+	remoteRP, parsed := azurearm.ParsePath(remoteVNetARMID)
+	if !parsed || remoteRP.ResourceType != typeVNet {
+		return
+	}
+
+	remoteVNet, err := findVNetInGroup(ctx, h.net, remoteRP.ResourceGroup, remoteRP.ResourceName)
+	if err != nil {
+		return
+	}
+
+	reciprocal := findReciprocalPeering(ctx, meta, remoteVNet.ID, localVNetARMID)
+	if reciprocal == "" {
+		return
+	}
+
+	_ = meta.SetAzureVNetPeeringState(ctx, remoteVNet.ID, reciprocal, netdriver.AzurePeeringStateDisconnected)
 }
 
 //nolint:gocritic // rp is a request-scoped value

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -590,6 +590,15 @@ type SubnetAttributes interface {
 	ModifySubnetAttribute(ctx context.Context, id string, update SubnetAttributeUpdate) error
 }
 
+// SubnetCIDRUpdater is an OPTIONAL capability, discovered by type assertion. It
+// changes a subnet's address prefix in place — the Azure ARM
+// Subnets.CreateOrUpdate re-PUT path allows editing a subnet's addressPrefix,
+// unlike AWS where a subnet CIDR is immutable. Providers that model an
+// immutable subnet CIDR do not implement it.
+type SubnetCIDRUpdater interface {
+	UpdateSubnetCIDR(ctx context.Context, id, cidr string) error
+}
+
 // NetworkInterfaces is an OPTIONAL capability, discovered by type assertion.
 //
 // Kept out of the Networking interface for the same reason as VPCAttributes:


### PR DESCRIPTION
## Summary

A confirming re-audit of the Azure networking wire layer surfaced residue from the first round. This lands three fixes, all reproduced with the real `azure-sdk-for-go/armnetwork` SDK.

### 1. [HIGH] Subnet CreateOrUpdate was create-only (one root, three symptoms)
`upsertSubnet`'s existing-subnet branch was merge-only, so an in-place update was a silent no-op. Real ARM's `Subnets.CreateOrUpdate` is a full replacement. Fixed so the existing-subnet path:
- **updates the address prefix** when the body's `addressPrefix` differs (via a new optional `SubnetCIDRUpdater` driver capability, type-asserted; AWS/GCP model an immutable subnet CIDR and do not implement it);
- **replaces** the NSG / NAT gateway associations from the request body — an omitted `networkSecurityGroup` / `natGateway` now **clears** the association (the `azurerm_subnet` in-place update + `azurerm_subnet_network_security_group_association` delete path).

The same in-place update is now applied on the whole-VNet PUT path for inline subnets (changed CIDR + replaced NSG). The subnet-in-use guard and full-replace-on-whole-VNet-PUT semantics (an omitted subnet is still deleted) are preserved.

### 2. [MED] Peering delete leaves the surviving side stuck 'Connected'
Deleting one side of a two-way VNet peering now transitions the orphaned reciprocal side to `Disconnected` (wiring the previously-dead `AzurePeeringStateDisconnected` constant), matching real ARM.

### 3. [LOW] Cross-RG NSG reference leak
`resolveSubnetNSG` and the NIC-create NSG validation were name-only. They now resolve within the NSG id's own resource group (`findNSGInGroup`), mirroring how NAT gateways are scoped — a NIC/subnet in one RG can no longer reference an NSG that exists only in another.

## Tests
New real-SDK reproductions (`server/azure/vnet/subnet_update_test.go`): subnet CIDR re-PUT, NSG disassociation, peering-delete reciprocal disconnect, and cross-RG NSG rejection (NIC + subnet). First-round tests remain green.
