### PR TITLE
fix(gcp-networking): persist subnetwork secondaryIpRanges/description + network routingMode/mtu/description; reject firewall on missing network; expandIpCidrRange; aggregatedList

### DIFF
--- a/providers/gcp/vpc/vpc.go
+++ b/providers/gcp/vpc/vpc.go
@@ -166,6 +166,21 @@ func (m *Mock) DescribeSubnets(_ context.Context, ids []string) ([]driver.Subnet
 	return describeResources(m.subnets, ids, toSubnetInfo), nil
 }
 
+// ExpandSubnetCIDR widens a subnetwork's primary IP range, backing GCP's
+// subnetworks.expandIpCidrRange. The wire layer validates that cidr is a
+// superset of the current range before calling; here it just replaces the
+// stored block under the store lock.
+func (m *Mock) ExpandSubnetCIDR(_ context.Context, id, cidr string) error {
+	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
+		s.CIDRBlock = cidr
+		return s
+	}) {
+		return cerrors.Newf(cerrors.NotFound, "subnet %q not found", id)
+	}
+
+	return nil
+}
+
 // CreateSecurityGroup creates a new firewall rule group.
 func (m *Mock) CreateSecurityGroup(_ context.Context, cfg driver.SecurityGroupConfig) (*driver.SecurityGroupInfo, error) {
 	if cfg.Name == "" {

--- a/server/gcp/vpc/addresses.go
+++ b/server/gcp/vpc/addresses.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/stackshy/cloudemu/v2/internal/pagination"
@@ -89,6 +90,30 @@ func (s *addressStore) list(project, scope string) []json.RawMessage {
 	return out
 }
 
+// allByScope returns every stored address for a project grouped by the scope
+// ("global" or a region name) it was reserved in — the grouping aggregatedList
+// projects into per-scope buckets.
+func (s *addressStore) allByScope(project string) map[string][]json.RawMessage {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := map[string][]json.RawMessage{}
+	prefix := project + "/"
+
+	for k, byName := range s.addresses {
+		if !strings.HasPrefix(k, prefix) {
+			continue
+		}
+
+		scope := strings.TrimPrefix(k, prefix)
+		for _, b := range byName {
+			out[scope] = append(out[scope], b)
+		}
+	}
+
+	return out
+}
+
 func (s *addressStore) delete(project, scope, name string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -115,8 +140,18 @@ func scopeOf(rp gcprest.ResourcePath) string {
 	return rp.ScopeName
 }
 
-//nolint:gocritic,dupl // rp is a request-scoped value; CRUD route shape is duplicate-by-design across resource types
+//nolint:gocritic // rp is a request-scoped value
 func (h *Handler) routeAddresses(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.Scope == gcprest.ScopeAggregated {
+		if r.Method == http.MethodGet {
+			h.aggregatedListAddresses(w, r, rp)
+		} else {
+			gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+		}
+
+		return
+	}
+
 	if rp.ResourceName == "" {
 		switch r.Method {
 		case http.MethodPost:
@@ -249,6 +284,47 @@ func (h *Handler) listAddresses(w http.ResponseWriter, r *http.Request, rp gcpre
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) aggregatedListAddresses(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	byScope := h.addresses.allByScope(rp.Project)
+	filter := r.URL.Query().Get("filter")
+	host := hostOf(r)
+	items := map[string]addressesScopedList{}
+
+	for scope, bodies := range byScope {
+		key := "regions/" + scope
+		if scope == gcprest.ScopeGlobal {
+			key = gcprest.ScopeGlobal
+		}
+
+		list := make([]json.RawMessage, 0, len(bodies))
+
+		for _, b := range bodies {
+			if nameMatches(filter, rawName(b)) {
+				list = append(list, b)
+			}
+		}
+
+		sort.SliceStable(list, func(i, j int) bool { return rawName(list[i]) < rawName(list[j]) })
+
+		items[key] = addressesScopedList{Addresses: list}
+	}
+
+	// GCP always includes a global bucket, warned when it holds nothing.
+	if _, ok := items[gcprest.ScopeGlobal]; !ok {
+		items[gcprest.ScopeGlobal] = addressesScopedList{
+			Warning: &scopedWarning{Code: noResultsOnPageStr, Message: "There are no results for scope 'global' on this page."},
+		}
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, addressAggregatedListResponse{
+		Kind:     "compute#addressAggregatedList",
+		ID:       "projects/" + rp.Project + "/aggregated/addresses",
+		Items:    items,
+		SelfLink: host + "/compute/v1/projects/" + rp.Project + "/aggregated/addresses",
+	})
 }
 
 // rawName extracts the "name" field from a stored address body for filtering

--- a/server/gcp/vpc/aggregated_list_test.go
+++ b/server/gcp/vpc/aggregated_list_test.go
@@ -1,0 +1,115 @@
+package vpc_test
+
+import (
+	"context"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+// TestSDKSubnetworkAggregatedList covers the MED finding that subnetworks
+// aggregatedList returned zero items. gcloud/Terraform data sources depend on
+// it; results must be grouped by the subnet's own region.
+func TestSDKSubnetworkAggregatedList(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	_, subClient := newNetAndSubnetClients(t, ctx, ts, "vpc-agg")
+
+	insertSubnet2(t, ctx, subClient, "us-central1", "agg-central", "vpc-agg", "10.10.0.0/16")
+	insertSubnet2(t, ctx, subClient, "us-east1", "agg-east", "vpc-agg", "10.20.0.0/16")
+
+	it := subClient.AggregatedList(ctx, &computepb.AggregatedListSubnetworksRequest{Project: testProject})
+
+	found := map[string]string{} // subnet name -> scope key
+
+	for {
+		pair, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("AggregatedList Next: %v", err)
+		}
+
+		for _, s := range pair.Value.GetSubnetworks() {
+			found[s.GetName()] = pair.Key
+		}
+	}
+
+	if found["agg-central"] != "regions/us-central1" {
+		t.Errorf("agg-central scope=%q want regions/us-central1", found["agg-central"])
+	}
+
+	if found["agg-east"] != "regions/us-east1" {
+		t.Errorf("agg-east scope=%q want regions/us-east1", found["agg-east"])
+	}
+}
+
+// TestSDKAddressAggregatedList covers the MED finding that addresses
+// aggregatedList returned zero items; results must be grouped by region.
+func TestSDKAddressAggregatedList(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewAddressesRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewAddressesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	insertAddr(t, ctx, client, "us-central1", "addr-central")
+	insertAddr(t, ctx, client, "us-east1", "addr-east")
+
+	it := client.AggregatedList(ctx, &computepb.AggregatedListAddressesRequest{Project: testProject})
+
+	found := map[string]string{}
+
+	for {
+		pair, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("AggregatedList Next: %v", err)
+		}
+
+		for _, a := range pair.Value.GetAddresses() {
+			found[a.GetName()] = pair.Key
+		}
+	}
+
+	if found["addr-central"] != "regions/us-central1" {
+		t.Errorf("addr-central scope=%q want regions/us-central1", found["addr-central"])
+	}
+
+	if found["addr-east"] != "regions/us-east1" {
+		t.Errorf("addr-east scope=%q want regions/us-east1", found["addr-east"])
+	}
+}
+
+func insertAddr(t *testing.T, ctx context.Context, c *gcpcompute.AddressesClient, region, name string) {
+	t.Helper()
+
+	op, err := c.Insert(ctx, &computepb.InsertAddressRequest{
+		Project: testProject,
+		Region:  region,
+		AddressResource: &computepb.Address{
+			Name: ptrStr(name),
+		},
+	})
+	if err != nil {
+		t.Fatalf("address Insert %s/%s: %v", region, name, err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("address Insert wait %s/%s: %v", region, name, err)
+	}
+}

--- a/server/gcp/vpc/handler.go
+++ b/server/gcp/vpc/handler.go
@@ -52,12 +52,20 @@ const (
 	autoSubnetTag       = "cloudemu:gcpAutoSubnet"
 	legacyNetTag        = "cloudemu:gcpLegacyNet"
 	createdAtTag        = "cloudemu:gcpCreatedAt"
+	netDescTag          = "cloudemu:gcpNetDesc"
+	netRoutingModeTag   = "cloudemu:gcpNetRoutingMode"
+	netMtuTag           = "cloudemu:gcpNetMtu"
 	subnetPurposeTag    = "cloudemu:gcpSubnetPurpose"
 	subnetStackTag      = "cloudemu:gcpSubnetStack"
 	subnetPGATag        = "cloudemu:gcpSubnetPGA"
+	subnetDescTag       = "cloudemu:gcpSubnetDesc"
+	subnetSecondaryTag  = "cloudemu:gcpSubnetSecondary"
 	firewallNameTag     = "cloudemu:gcpFwName"
 	firewallSpecTag     = "cloudemu:gcpFwSpec"
 	trueValue           = "true"
+
+	expandAction       = "expandIpCidrRange"
+	noResultsOnPageStr = "NO_RESULTS_ON_PAGE"
 
 	defaultSubnetPurpose = "PRIVATE"
 	defaultStackType     = "IPV4_ONLY"
@@ -140,16 +148,16 @@ func (*Handler) Matches(r *http.Request) bool {
 		return false
 	}
 
-	// Aggregated-scope requests (aggregatedList) are not implemented for these
-	// networking resources; leave them unmatched so the dispatcher's default
-	// applies rather than mis-serving them as a scoped list.
-	if rp.Scope == gcprest.ScopeAggregated {
-		return false
-	}
-
 	switch rp.ResourceType {
 	case resourceNetworks, resourceSubnetworks, resourceFirewalls,
 		resourceRouters, resourceAddresses, resourceRoutes:
+		// aggregatedList is a real endpoint only for subnetworks and addresses;
+		// the other collections here are global (or list-only) and have no
+		// aggregated form, so leave those unmatched for the dispatcher default.
+		if rp.Scope == gcprest.ScopeAggregated {
+			return rp.ResourceType == resourceSubnetworks || rp.ResourceType == resourceAddresses
+		}
+
 		return true
 	}
 
@@ -207,8 +215,18 @@ func (h *Handler) routeNetworks(w http.ResponseWriter, r *http.Request, rp gcpre
 	}
 }
 
-//nolint:gocritic,dupl // rp is a request-scoped value; CRUD route shape is duplicate-by-design across resource types
+//nolint:gocritic // rp is a request-scoped value
 func (h *Handler) routeSubnetworks(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.Scope == gcprest.ScopeAggregated {
+		if r.Method == http.MethodGet {
+			h.aggregatedListSubnetworks(w, r, rp)
+		} else {
+			gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+		}
+
+		return
+	}
+
 	if rp.ResourceName == "" {
 		switch r.Method {
 		case http.MethodPost:
@@ -216,6 +234,17 @@ func (h *Handler) routeSubnetworks(w http.ResponseWriter, r *http.Request, rp gc
 		case http.MethodGet:
 			h.listSubnetworks(w, r, rp)
 		default:
+			gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+		}
+
+		return
+	}
+
+	// POST .../subnetworks/{name}/expandIpCidrRange widens the primary range.
+	if rp.Action == expandAction {
+		if r.Method == http.MethodPost {
+			h.expandSubnetIPCIDR(w, r, rp)
+		} else {
 			gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
 		}
 
@@ -284,21 +313,7 @@ func (h *Handler) insertNetwork(w http.ResponseWriter, r *http.Request, rp gcpre
 		return
 	}
 
-	// A network with an explicit IPv4Range is a (deprecated) legacy network;
-	// only those carry an IPv4Range on the wire. Auto/custom-mode networks must
-	// NOT report one — the driver still needs a non-empty CIDR internally, so a
-	// placeholder is stored but hidden from the response unless legacy.
-	cidr := internalNetCIDR
-	tags := map[string]string{netNameTag: req.Name, createdAtTag: nowRFC3339()}
-
-	if req.IPv4Range != "" {
-		cidr = req.IPv4Range
-		tags[legacyNetTag] = trueValue
-	}
-
-	if req.AutoCreateSubnetworks != nil && *req.AutoCreateSubnetworks {
-		tags[autoSubnetTag] = trueValue
-	}
+	cidr, tags := networkStorage(&req)
 
 	cfg := netdriver.VPCConfig{
 		CIDRBlock: cidr,
@@ -314,6 +329,41 @@ func (h *Handler) insertNetwork(w http.ResponseWriter, r *http.Request, rp gcpre
 		"networks", req.Name, "insert")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// networkStorage derives the internal CIDR and the tag set persisted for a
+// network insert. A network with an explicit IPv4Range is a (deprecated) legacy
+// network; only those carry an IPv4Range on the wire. Auto/custom-mode networks
+// must NOT report one — the driver still needs a non-empty CIDR internally, so a
+// placeholder is stored but hidden from the response unless legacy.
+// description/routingMode/mtu have no first-class VPC slots, so they ride in
+// tags and are reconstructed on read (else Terraform shows a perpetual diff).
+func networkStorage(req *networkRequest) (cidr string, tags map[string]string) {
+	cidr = internalNetCIDR
+	tags = map[string]string{netNameTag: req.Name, createdAtTag: nowRFC3339()}
+
+	if req.IPv4Range != "" {
+		cidr = req.IPv4Range
+		tags[legacyNetTag] = trueValue
+	}
+
+	if req.AutoCreateSubnetworks != nil && *req.AutoCreateSubnetworks {
+		tags[autoSubnetTag] = trueValue
+	}
+
+	if req.Description != "" {
+		tags[netDescTag] = req.Description
+	}
+
+	if req.RoutingConfig != nil && req.RoutingConfig.RoutingMode != "" {
+		tags[netRoutingModeTag] = req.RoutingConfig.RoutingMode
+	}
+
+	if req.Mtu > 0 {
+		tags[netMtuTag] = strconv.Itoa(int(req.Mtu))
+	}
+
+	return cidr, tags
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -426,11 +476,36 @@ func (h *Handler) insertSubnetwork(w http.ResponseWriter, r *http.Request, rp gc
 		return
 	}
 
+	cfg := netdriver.SubnetConfig{
+		VPCID:            vpcID,
+		CIDRBlock:        req.IPCIDRRange,
+		AvailabilityZone: rp.ScopeName,
+		Tags:             subnetTags(&req),
+	}
+
+	if _, err := h.net.CreateSubnet(r.Context(), cfg); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
+		"subnetworks", req.Name, "insert")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// subnetTags builds the tag set persisted for a subnetwork insert. purpose/
+// stackType/privateIpGoogleAccess/description have no first-class driver slots,
+// and secondaryIpRanges (GKE VPC-native / Terraform secondary_ip_range) is
+// stored verbatim as JSON — mirroring the firewall spec — so alias ranges
+// survive the round-trip.
+func subnetTags(req *subnetworkRequest) map[string]string {
 	tags := map[string]string{
 		subnetNameTag:    req.Name,
 		subnetNetworkTag: lastSegment(req.Network),
 		createdAtTag:     nowRFC3339(),
 	}
+
 	if req.Purpose != "" {
 		tags[subnetPurposeTag] = req.Purpose
 	}
@@ -443,22 +518,17 @@ func (h *Handler) insertSubnetwork(w http.ResponseWriter, r *http.Request, rp gc
 		tags[subnetPGATag] = trueValue
 	}
 
-	cfg := netdriver.SubnetConfig{
-		VPCID:            vpcID,
-		CIDRBlock:        req.IPCIDRRange,
-		AvailabilityZone: rp.ScopeName,
-		Tags:             tags,
+	if req.Description != "" {
+		tags[subnetDescTag] = req.Description
 	}
 
-	if _, err := h.net.CreateSubnet(r.Context(), cfg); err != nil {
-		gcprest.WriteCErr(w, err)
-		return
+	if len(req.SecondaryIPRanges) > 0 {
+		if b, err := json.Marshal(req.SecondaryIPRanges); err == nil {
+			tags[subnetSecondaryTag] = string(b)
+		}
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
-		"subnetworks", req.Name, "insert")
-
-	gcprest.WriteJSON(w, http.StatusOK, op)
+	return tags
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -536,6 +606,130 @@ func (h *Handler) deleteSubnetwork(w http.ResponseWriter, r *http.Request, rp gc
 	gcprest.WriteJSON(w, http.StatusOK, op)
 }
 
+// subnetCIDRExpander is the optional provider capability for widening a
+// subnetwork's primary IP range. Discovered by type assertion (mirroring
+// VPCAttributes/SubnetAttributes); GCP's expandIpCidrRange has no cross-cloud
+// analog, so it stays out of the portable Networking interface.
+type subnetCIDRExpander interface {
+	ExpandSubnetCIDR(ctx context.Context, id, cidr string) error
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) expandSubnetIPCIDR(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	s, err := findSubnetByName(r.Context(), h.net, rp.ResourceName, rp.ScopeName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	var req expandIPCIDRRequest
+
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.IPCIDRRange == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "ipCidrRange required")
+		return
+	}
+
+	// expandIpCidrRange only grows the range: the new range must strictly
+	// contain the current one. A subset (or equal) range is rejected.
+	if err := validateSuperset(s.CIDRBlock, req.IPCIDRRange); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	expander, ok := h.net.(subnetCIDRExpander)
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotImplemented, "notImplemented",
+			"subnetwork range expansion not supported")
+
+		return
+	}
+
+	if err := expander.ExpandSubnetCIDR(r.Context(), s.ID, req.IPCIDRRange); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
+		"subnetworks", rp.ResourceName, expandAction)
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// validateSuperset reports whether expanded strictly contains current — the
+// same-base, broader-prefix relationship GCP requires of expandIpCidrRange.
+func validateSuperset(current, expanded string) error {
+	_, curNet, err := net.ParseCIDR(current)
+	if err != nil {
+		return cerrors.Newf(cerrors.InvalidArgument, "current range %q is not a valid CIDR", current)
+	}
+
+	_, newNet, err := net.ParseCIDR(expanded)
+	if err != nil {
+		return cerrors.Newf(cerrors.InvalidArgument, "range %q is not a valid CIDR", expanded)
+	}
+
+	curOnes, _ := curNet.Mask.Size()
+	newOnes, _ := newNet.Mask.Size()
+
+	if newOnes >= curOnes || !newNet.Contains(curNet.IP) {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"range %q must be a superset of the current range %q", expanded, current)
+	}
+
+	return nil
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) aggregatedListSubnetworks(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	infos, err := h.net.DescribeSubnets(r.Context(), nil)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	host := hostOf(r)
+	filter := r.URL.Query().Get("filter")
+	items := map[string]subnetworksScopedList{}
+
+	for i := range infos {
+		region := infos[i].AvailabilityZone
+
+		scope := rp
+		scope.Scope = gcprest.ScopeRegions
+		scope.ScopeName = region
+		scope.ResourceName = tagOr(infos[i].Tags, subnetNameTag, infos[i].ID)
+
+		resp := toSubnetworkResponse(&infos[i], scope, host)
+		if !nameMatches(filter, resp.Name) {
+			continue
+		}
+
+		key := "regions/" + region
+		bucket := items[key]
+		bucket.Subnetworks = append(bucket.Subnetworks, resp)
+		items[key] = bucket
+	}
+
+	// Real GCP always includes a global bucket; subnetworks are regional, so it
+	// carries a NO_RESULTS_ON_PAGE warning rather than any items.
+	if _, ok := items[gcprest.ScopeGlobal]; !ok {
+		items[gcprest.ScopeGlobal] = subnetworksScopedList{
+			Warning: &scopedWarning{Code: noResultsOnPageStr, Message: "There are no results for scope 'global' on this page."},
+		}
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, subnetworkAggregatedListResponse{
+		Kind:     "compute#subnetworkAggregatedList",
+		ID:       "projects/" + rp.Project + "/aggregated/subnetworks",
+		Items:    items,
+		SelfLink: host + "/compute/v1/projects/" + rp.Project + "/aggregated/subnetworks",
+	})
+}
+
 // Firewall operations.
 
 //nolint:gocritic // rp is a request-scoped value
@@ -557,10 +751,18 @@ func (h *Handler) insertFirewall(w http.ResponseWriter, r *http.Request, rp gcpr
 	}
 
 	// Firewalls map onto driver SecurityGroups; the driver requires a VPC ID.
-	vpcID, _ := resolveNetwork(r.Context(), h.net, req.Network)
+	// A supplied network MUST exist — real GCP rejects a firewall insert that
+	// references an unknown network. Propagate the resolve error (404) rather
+	// than fabricating a phantom VPC that would then leak into networks.list.
+	vpcID, err := resolveNetwork(r.Context(), h.net, req.Network)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
 
 	if vpcID == "" {
-		// No network supplied — use any existing or create a synthetic.
+		// No network supplied — GCP defaults to the project's network; use any
+		// existing one or create the default.
 		vpcs, _ := h.net.DescribeVPCs(r.Context(), nil)
 		if len(vpcs) > 0 {
 			vpcID = vpcs[0].ID
@@ -790,9 +992,20 @@ func toNetworkResponse(info *netdriver.VPCInfo, rp gcprest.ResourcePath, host st
 		Kind:                  "compute#network",
 		ID:                    numericID(info.ID),
 		Name:                  name,
+		Description:           info.Tags[netDescTag],
 		AutoCreateSubnetworks: info.Tags[autoSubnetTag] == trueValue,
 		CreationTimestamp:     info.Tags[createdAtTag],
 		SelfLink:              gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "networks", name),
+	}
+
+	if rm := info.Tags[netRoutingModeTag]; rm != "" {
+		resp.RoutingConfig = &networkRoutingConfig{RoutingMode: rm}
+	}
+
+	if m := info.Tags[netMtuTag]; m != "" {
+		if v, err := strconv.ParseInt(m, 10, 32); err == nil {
+			resp.Mtu = int32(v)
+		}
 	}
 
 	// IPv4Range belongs only to a legacy network; a modern auto/custom network
@@ -835,8 +1048,16 @@ func toSubnetworkResponse(info *netdriver.SubnetInfo, rp gcprest.ResourcePath, h
 		Purpose:               tagOr(info.Tags, subnetPurposeTag, defaultSubnetPurpose),
 		StackType:             tagOr(info.Tags, subnetStackTag, defaultStackType),
 		PrivateIPGoogleAccess: info.Tags[subnetPGATag] == trueValue,
+		Description:           info.Tags[subnetDescTag],
 		Fingerprint:           fingerprintOf(name, info.CIDRBlock),
 		CreationTimestamp:     info.Tags[createdAtTag],
+	}
+
+	if s := info.Tags[subnetSecondaryTag]; s != "" {
+		var ranges []secondaryRange
+		if err := json.Unmarshal([]byte(s), &ranges); err == nil {
+			resp.SecondaryIPRanges = ranges
+		}
 	}
 
 	// Echo the parent network self-link so clients can discover a subnet's

--- a/server/gcp/vpc/networks_test.go
+++ b/server/gcp/vpc/networks_test.go
@@ -106,6 +106,109 @@ func TestSDKNetworkRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSDKNetworkRoutingModeMtuDescription covers the HIGH finding that a
+// network's description, routingConfig.routingMode and mtu were dropped on
+// insert (Terraform google_compute_network sees a perpetual plan diff).
+func TestSDKNetworkRoutingModeMtuDescription(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewNetworksRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewNetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	op, err := client.Insert(ctx, &computepb.InsertNetworkRequest{
+		Project: testProject,
+		NetworkResource: &computepb.Network{
+			Name:                  ptrStr("net-cfg"),
+			Description:           ptrStr("app network"),
+			AutoCreateSubnetworks: func() *bool { b := false; return &b }(),
+			RoutingConfig:         &computepb.NetworkRoutingConfig{RoutingMode: ptrStr("GLOBAL")},
+			Mtu:                   ptrInt32(1500),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetNetworkRequest{Project: testProject, Network: "net-cfg"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetDescription() != "app network" {
+		t.Errorf("description=%q want %q", got.GetDescription(), "app network")
+	}
+
+	if got.GetRoutingConfig().GetRoutingMode() != "GLOBAL" {
+		t.Errorf("routingMode=%q want GLOBAL", got.GetRoutingConfig().GetRoutingMode())
+	}
+
+	if got.GetMtu() != 1500 {
+		t.Errorf("mtu=%d want 1500", got.GetMtu())
+	}
+}
+
+// TestSDKFirewallMissingNetworkRejected covers the MED finding that a firewall
+// referencing an unknown network fabricated a phantom VPC that then leaked into
+// networks.list. Real GCP rejects the insert with 404; no VPC is created.
+func TestSDKFirewallMissingNetworkRejected(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	fwClient, err := gcpcompute.NewFirewallsRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewFirewallsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = fwClient.Close() })
+
+	_, err = fwClient.Insert(ctx, &computepb.InsertFirewallRequest{
+		Project: testProject,
+		FirewallResource: &computepb.Firewall{
+			Name:    ptrStr("fw-bad"),
+			Network: ptrStr("projects/" + testProject + "/global/networks/does-not-exist"),
+			Allowed: []*computepb.Allowed{{IPProtocol: ptrStr("tcp"), Ports: []string{"22"}}},
+		},
+	})
+	if err == nil {
+		t.Fatal("firewall Insert with missing network succeeded, want 404")
+	}
+
+	// No phantom network must have leaked into networks.list.
+	netClient, err := gcpcompute.NewNetworksRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewNetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = netClient.Close() })
+
+	it := netClient.List(ctx, &computepb.ListNetworksRequest{Project: testProject})
+
+	count := 0
+	for {
+		if _, err := it.Next(); err != nil {
+			break
+		}
+
+		count++
+	}
+
+	if count != 0 {
+		t.Errorf("networks.list returned %d networks, want 0 (phantom VPC leaked)", count)
+	}
+}
+
 func TestSDKFirewallRoundTrip(t *testing.T) {
 	ts := newGCPNetServer(t)
 	ctx := context.Background()

--- a/server/gcp/vpc/subnetworks_test.go
+++ b/server/gcp/vpc/subnetworks_test.go
@@ -2,6 +2,7 @@ package vpc_test
 
 import (
 	"context"
+	"net/http/httptest"
 	"testing"
 
 	gcpcompute "cloud.google.com/go/compute/apiv1"
@@ -78,6 +79,174 @@ func TestSDKSubnetworkRegionScoped(t *testing.T) {
 
 	if got.GetCreationTimestamp() == "" {
 		t.Error("creationTimestamp empty, want RFC3339")
+	}
+}
+
+// TestSDKSubnetworkSecondaryRangesAndDescription covers the HIGH finding that a
+// subnetwork's description and secondaryIpRanges (GKE VPC-native / Terraform
+// secondary_ip_range) were dropped on insert and read back empty.
+func TestSDKSubnetworkSecondaryRangesAndDescription(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	netClient, subClient := newNetAndSubnetClients(t, ctx, ts, "vpc-secondary")
+
+	op, err := subClient.Insert(ctx, &computepb.InsertSubnetworkRequest{
+		Project: testProject,
+		Region:  testRegion,
+		SubnetworkResource: &computepb.Subnetwork{
+			Name:        ptrStr("sub-sec"),
+			Network:     ptrStr("projects/" + testProject + "/global/networks/vpc-secondary"),
+			IpCidrRange: ptrStr("10.0.0.0/24"),
+			Description: ptrStr("primary subnet"),
+			SecondaryIpRanges: []*computepb.SubnetworkSecondaryRange{
+				{RangeName: ptrStr("pods"), IpCidrRange: ptrStr("10.1.0.0/16")},
+				{RangeName: ptrStr("services"), IpCidrRange: ptrStr("10.2.0.0/20")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("subnet Insert: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("subnet Insert wait: %v", err)
+	}
+
+	_ = netClient
+
+	got, err := subClient.Get(ctx, &computepb.GetSubnetworkRequest{
+		Project: testProject, Region: testRegion, Subnetwork: "sub-sec",
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetDescription() != "primary subnet" {
+		t.Errorf("description=%q want %q", got.GetDescription(), "primary subnet")
+	}
+
+	sec := got.GetSecondaryIpRanges()
+	if len(sec) != 2 {
+		t.Fatalf("secondaryIpRanges len=%d want 2: %+v", len(sec), sec)
+	}
+
+	if sec[0].GetRangeName() != "pods" || sec[0].GetIpCidrRange() != "10.1.0.0/16" {
+		t.Errorf("secondary[0]=%s/%s want pods/10.1.0.0/16", sec[0].GetRangeName(), sec[0].GetIpCidrRange())
+	}
+
+	if sec[1].GetRangeName() != "services" || sec[1].GetIpCidrRange() != "10.2.0.0/20" {
+		t.Errorf("secondary[1]=%s/%s want services/10.2.0.0/20", sec[1].GetRangeName(), sec[1].GetIpCidrRange())
+	}
+}
+
+// TestSDKSubnetworkExpandIpCidrRange covers the MED finding that
+// subnetworks.expandIpCidrRange was unrouted (405). A superset widens the
+// subnet; a subset is rejected.
+func TestSDKSubnetworkExpandIpCidrRange(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	_, subClient := newNetAndSubnetClients(t, ctx, ts, "vpc-expand")
+
+	insertSubnet2(t, ctx, subClient, testRegion, "sub-exp", "vpc-expand", "10.0.0.0/24")
+
+	op, err := subClient.ExpandIpCidrRange(ctx, &computepb.ExpandIpCidrRangeSubnetworkRequest{
+		Project: testProject, Region: testRegion, Subnetwork: "sub-exp",
+		SubnetworksExpandIpCidrRangeRequestResource: &computepb.SubnetworksExpandIpCidrRangeRequest{
+			IpCidrRange: ptrStr("10.0.0.0/20"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExpandIpCidrRange superset: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("ExpandIpCidrRange wait: %v", err)
+	}
+
+	got, err := subClient.Get(ctx, &computepb.GetSubnetworkRequest{
+		Project: testProject, Region: testRegion, Subnetwork: "sub-exp",
+	})
+	if err != nil {
+		t.Fatalf("Get after expand: %v", err)
+	}
+
+	if got.GetIpCidrRange() != "10.0.0.0/20" {
+		t.Errorf("ipCidrRange=%s want 10.0.0.0/20 (not widened)", got.GetIpCidrRange())
+	}
+
+	// A subset must be rejected — expandIpCidrRange only grows the range.
+	_, err = subClient.ExpandIpCidrRange(ctx, &computepb.ExpandIpCidrRangeSubnetworkRequest{
+		Project: testProject, Region: testRegion, Subnetwork: "sub-exp",
+		SubnetworksExpandIpCidrRangeRequestResource: &computepb.SubnetworksExpandIpCidrRangeRequest{
+			IpCidrRange: ptrStr("10.0.0.0/28"),
+		},
+	})
+	if err == nil {
+		t.Error("ExpandIpCidrRange subset succeeded, want error")
+	}
+}
+
+// newNetAndSubnetClients creates a custom-mode network and returns Networks +
+// Subnetworks clients for it.
+func newNetAndSubnetClients(t *testing.T, ctx context.Context, ts *httptest.Server, netName string,
+) (*gcpcompute.NetworksClient, *gcpcompute.SubnetworksClient) {
+	t.Helper()
+
+	netClient, err := gcpcompute.NewNetworksRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewNetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = netClient.Close() })
+
+	netOp, err := netClient.Insert(ctx, &computepb.InsertNetworkRequest{
+		Project: testProject,
+		NetworkResource: &computepb.Network{
+			Name:                  ptrStr(netName),
+			AutoCreateSubnetworks: func() *bool { b := false; return &b }(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("network Insert: %v", err)
+	}
+
+	if err := netOp.Wait(ctx); err != nil {
+		t.Fatalf("network Insert wait: %v", err)
+	}
+
+	subClient, err := gcpcompute.NewSubnetworksRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewSubnetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = subClient.Close() })
+
+	return netClient, subClient
+}
+
+// insertSubnet2 inserts a subnet referencing the named network.
+func insertSubnet2(t *testing.T, ctx context.Context, c *gcpcompute.SubnetworksClient, region, name, netName, cidr string) {
+	t.Helper()
+
+	op, err := c.Insert(ctx, &computepb.InsertSubnetworkRequest{
+		Project: testProject,
+		Region:  region,
+		SubnetworkResource: &computepb.Subnetwork{
+			Name:        ptrStr(name),
+			Network:     ptrStr("projects/" + testProject + "/global/networks/" + netName),
+			IpCidrRange: ptrStr(cidr),
+		},
+	})
+	if err != nil {
+		t.Fatalf("subnet Insert %s/%s: %v", region, name, err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("subnet Insert wait %s/%s: %v", region, name, err)
 	}
 }
 

--- a/server/gcp/vpc/types.go
+++ b/server/gcp/vpc/types.go
@@ -1,25 +1,35 @@
 package vpc
 
+import "encoding/json"
+
 // GCP Compute Engine networking REST shapes.
 
+// networkRoutingConfig is GCP's routingConfig block; only routingMode
+// (REGIONAL|GLOBAL) is modeled.
+type networkRoutingConfig struct {
+	RoutingMode string `json:"routingMode,omitempty"`
+}
+
 type networkRequest struct {
-	Name                  string `json:"name"`
-	Description           string `json:"description,omitempty"`
-	IPv4Range             string `json:"IPv4Range,omitempty"`
-	AutoCreateSubnetworks *bool  `json:"autoCreateSubnetworks,omitempty"`
-	RoutingConfig         any    `json:"routingConfig,omitempty"`
+	Name                  string                `json:"name"`
+	Description           string                `json:"description,omitempty"`
+	IPv4Range             string                `json:"IPv4Range,omitempty"`
+	AutoCreateSubnetworks *bool                 `json:"autoCreateSubnetworks,omitempty"`
+	RoutingConfig         *networkRoutingConfig `json:"routingConfig,omitempty"`
+	Mtu                   int32                 `json:"mtu,omitempty"`
 }
 
 type networkResponse struct {
-	Kind                  string `json:"kind"`
-	ID                    string `json:"id"`
-	Name                  string `json:"name"`
-	Description           string `json:"description,omitempty"`
-	SelfLink              string `json:"selfLink"`
-	IPv4Range             string `json:"IPv4Range,omitempty"`
-	AutoCreateSubnetworks bool   `json:"autoCreateSubnetworks"`
-	RoutingConfig         any    `json:"routingConfig,omitempty"`
-	CreationTimestamp     string `json:"creationTimestamp,omitempty"`
+	Kind                  string                `json:"kind"`
+	ID                    string                `json:"id"`
+	Name                  string                `json:"name"`
+	Description           string                `json:"description,omitempty"`
+	SelfLink              string                `json:"selfLink"`
+	IPv4Range             string                `json:"IPv4Range,omitempty"`
+	AutoCreateSubnetworks bool                  `json:"autoCreateSubnetworks"`
+	RoutingConfig         *networkRoutingConfig `json:"routingConfig,omitempty"`
+	Mtu                   int32                 `json:"mtu,omitempty"`
+	CreationTimestamp     string                `json:"creationTimestamp,omitempty"`
 }
 
 type networkListResponse struct {
@@ -30,30 +40,83 @@ type networkListResponse struct {
 	NextPageToken string            `json:"nextPageToken,omitempty"`
 }
 
+// secondaryRange is one alias IP range on a subnetwork (secondaryIpRanges[]),
+// the shape GKE VPC-native pods/services and Terraform secondary_ip_range use.
+type secondaryRange struct {
+	RangeName   string `json:"rangeName,omitempty"`
+	IPCIDRRange string `json:"ipCidrRange,omitempty"`
+}
+
 type subnetworkRequest struct {
-	Name                  string `json:"name"`
-	Network               string `json:"network,omitempty"`
-	IPCIDRRange           string `json:"ipCidrRange,omitempty"`
-	Region                string `json:"region,omitempty"`
-	Purpose               string `json:"purpose,omitempty"`
-	StackType             string `json:"stackType,omitempty"`
-	PrivateIPGoogleAccess *bool  `json:"privateIpGoogleAccess,omitempty"`
+	Name                  string           `json:"name"`
+	Network               string           `json:"network,omitempty"`
+	IPCIDRRange           string           `json:"ipCidrRange,omitempty"`
+	Region                string           `json:"region,omitempty"`
+	Description           string           `json:"description,omitempty"`
+	Purpose               string           `json:"purpose,omitempty"`
+	StackType             string           `json:"stackType,omitempty"`
+	PrivateIPGoogleAccess *bool            `json:"privateIpGoogleAccess,omitempty"`
+	SecondaryIPRanges     []secondaryRange `json:"secondaryIpRanges,omitempty"`
 }
 
 type subnetworkResponse struct {
-	Kind                  string `json:"kind"`
-	ID                    string `json:"id"`
-	Name                  string `json:"name"`
-	Network               string `json:"network,omitempty"`
-	IPCIDRRange           string `json:"ipCidrRange,omitempty"`
-	Region                string `json:"region,omitempty"`
-	SelfLink              string `json:"selfLink"`
-	GatewayAddress        string `json:"gatewayAddress,omitempty"`
-	Purpose               string `json:"purpose,omitempty"`
-	StackType             string `json:"stackType,omitempty"`
-	PrivateIPGoogleAccess bool   `json:"privateIpGoogleAccess"`
-	Fingerprint           string `json:"fingerprint,omitempty"`
-	CreationTimestamp     string `json:"creationTimestamp,omitempty"`
+	Kind                  string           `json:"kind"`
+	ID                    string           `json:"id"`
+	Name                  string           `json:"name"`
+	Network               string           `json:"network,omitempty"`
+	IPCIDRRange           string           `json:"ipCidrRange,omitempty"`
+	Region                string           `json:"region,omitempty"`
+	SelfLink              string           `json:"selfLink"`
+	Description           string           `json:"description,omitempty"`
+	GatewayAddress        string           `json:"gatewayAddress,omitempty"`
+	Purpose               string           `json:"purpose,omitempty"`
+	StackType             string           `json:"stackType,omitempty"`
+	PrivateIPGoogleAccess bool             `json:"privateIpGoogleAccess"`
+	SecondaryIPRanges     []secondaryRange `json:"secondaryIpRanges,omitempty"`
+	Fingerprint           string           `json:"fingerprint,omitempty"`
+	CreationTimestamp     string           `json:"creationTimestamp,omitempty"`
+}
+
+// expandIPCIDRRequest is the subnetworks.expandIpCidrRange body
+// (SubnetworksExpandIpCidrRangeRequest): the new, broader primary range.
+type expandIPCIDRRequest struct {
+	IPCIDRRange string `json:"ipCidrRange"`
+}
+
+// scopedWarning is the warning GCP stamps on an empty aggregatedList scope
+// bucket (code NO_RESULTS_ON_PAGE).
+type scopedWarning struct {
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// subnetworksScopedList is one scope bucket of a subnetworkAggregatedList.
+type subnetworksScopedList struct {
+	Subnetworks []subnetworkResponse `json:"subnetworks,omitempty"`
+	Warning     *scopedWarning       `json:"warning,omitempty"`
+}
+
+type subnetworkAggregatedListResponse struct {
+	Kind          string                           `json:"kind"`
+	ID            string                           `json:"id"`
+	Items         map[string]subnetworksScopedList `json:"items"`
+	SelfLink      string                           `json:"selfLink"`
+	NextPageToken string                           `json:"nextPageToken,omitempty"`
+}
+
+// addressesScopedList is one scope bucket of an addressAggregatedList. Address
+// bodies are stored verbatim, so they stay raw here.
+type addressesScopedList struct {
+	Addresses []json.RawMessage `json:"addresses,omitempty"`
+	Warning   *scopedWarning    `json:"warning,omitempty"`
+}
+
+type addressAggregatedListResponse struct {
+	Kind          string                         `json:"kind"`
+	ID            string                         `json:"id"`
+	Items         map[string]addressesScopedList `json:"items"`
+	SelfLink      string                         `json:"selfLink"`
+	NextPageToken string                         `json:"nextPageToken,omitempty"`
 }
 
 type subnetworkListResponse struct {


### PR DESCRIPTION
## Summary

Fixes GCP Compute networking (VPC/subnet/firewall) gaps found by a confirming re-audit against the official GCP Compute REST API. Builds on the first-round fixes (#635–#656: IPv4Range, dup-409, delete-in-use, region-scoping) without regressing them.

### Fixes
- **[HIGH] Subnetwork `description` + `secondaryIpRanges` dropped** — alias ranges (GKE VPC-native pods/services, Terraform `google_compute_subnetwork.secondary_ip_range`) and the subnet description were silently discarded on insert and read back empty. Now persisted (secondary ranges JSON-encoded verbatim in a reserved tag, mirroring the firewall spec) and reconstructed on Get/List.
- **[HIGH] Network `description`, `routingConfig.routingMode`, `mtu` dropped** — Terraform `google_compute_network` sets these; the silent drop produced a perpetual plan diff. Now persisted in VPC tags and emitted on read.
- **[MED] Firewall referencing an unknown network fabricated a phantom VPC** — `insertFirewall` swallowed the network-resolve error and created a synthetic VPC that then leaked into `networks.list`. A supplied-but-missing network now returns 404 (matching real GCP); no phantom VPC is created. Firewall inserts with no network keep the default-network fallback.
- **[MED] `subnetworks.expandIpCidrRange` returned 405 (unrouted)** — the verb is now routed: the new range is validated as a strict superset of the current range (subset/equal rejected) and the stored subnet CIDR is widened via a new provider capability (`ExpandSubnetCIDR`, discovered by type assertion; kept out of the portable Networking interface since GCP's expand verb has no cross-cloud analog).
- **[MED] `aggregatedList` returned zero items for subnetworks/addresses** — now emits `compute#subnetworkAggregatedList` / `compute#addressAggregatedList` with items grouped into `regions/{region}` buckets (plus a warned `global` bucket), as gcloud and Terraform data sources expect.

### Tests
Real `cloud.google.com/go/compute/apiv1` reproductions: subnetwork insert with description + 2 secondary ranges round-trips; network insert with description + `routingMode=GLOBAL` + `mtu=1500` round-trips; firewall insert against a missing network → error with no phantom in `networks.list`; `ExpandIpCidrRange` superset widens (subset errors); `SubnetworksClient.AggregatedList` / `AddressesClient.AggregatedList` return items grouped by region. First-round tests (region-scoping, routes, addresses) stay green, including `-race`.

### Gates
build · vet · test · `-race` · gofmt · golangci-lint (0 new) · `go generate` zero diff · compatgen zero diff. No driver-interface or compat-matrix change.