### PR TITLE
fix(gcp-gcs): enforce delete/read/update/compose preconditions; versioned-delete archival; insert-time system props; generation-addressed reads; storageClass

### DIFF
--- a/docs/coverage/aws/s3.md
+++ b/docs/coverage/aws/s3.md
@@ -118,6 +118,9 @@ GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type
 | `BucketAttrsGCS` | BucketAttrsGCS returns the bucket's GCS-specific attributes. |
 | `BucketIAMPolicy` |  |
 | `ComposeObjectGCS` | ComposeObjectGCS concatenates the source objects' bytes (in order) into |
+| `DeleteObjectGCS` | DeleteObjectGCS deletes an object honoring pre and optional generation |
+| `GetObjectGCS` | GetObjectGCS returns an object's bytes+info, selecting a specific |
+| `HeadObjectGCS` | HeadObjectGCS returns an object's info, selecting a specific generation |
 | `ListObjectGenerations` | ListObjectGenerations returns every generation (current + archived) of the |
 | `PutObjectGCS` | PutObjectGCS writes an object honoring pre (a failed condition returns a |
 | `SetBucketAttrsGCS` | SetBucketAttrsGCS records the bucket's location and default storage class |

--- a/docs/coverage/azure/blobstorage.md
+++ b/docs/coverage/azure/blobstorage.md
@@ -118,6 +118,9 @@ GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type
 | `BucketAttrsGCS` | BucketAttrsGCS returns the bucket's GCS-specific attributes. |
 | `BucketIAMPolicy` |  |
 | `ComposeObjectGCS` | ComposeObjectGCS concatenates the source objects' bytes (in order) into |
+| `DeleteObjectGCS` | DeleteObjectGCS deletes an object honoring pre and optional generation |
+| `GetObjectGCS` | GetObjectGCS returns an object's bytes+info, selecting a specific |
+| `HeadObjectGCS` | HeadObjectGCS returns an object's info, selecting a specific generation |
 | `ListObjectGenerations` | ListObjectGenerations returns every generation (current + archived) of the |
 | `PutObjectGCS` | PutObjectGCS writes an object honoring pre (a failed condition returns a |
 | `SetBucketAttrsGCS` | SetBucketAttrsGCS records the bucket's location and default storage class |

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -10728,6 +10728,18 @@
             "doc": "ComposeObjectGCS concatenates the source objects' bytes (in order) into"
           },
           {
+            "name": "DeleteObjectGCS",
+            "doc": "DeleteObjectGCS deletes an object honoring pre and optional generation"
+          },
+          {
+            "name": "GetObjectGCS",
+            "doc": "GetObjectGCS returns an object's bytes+info, selecting a specific"
+          },
+          {
+            "name": "HeadObjectGCS",
+            "doc": "HeadObjectGCS returns an object's info, selecting a specific generation"
+          },
+          {
             "name": "ListObjectGenerations",
             "doc": "ListObjectGenerations returns every generation (current + archived) of the"
           },

--- a/docs/coverage/gcp/gcs.md
+++ b/docs/coverage/gcp/gcs.md
@@ -118,6 +118,9 @@ GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type
 | `BucketAttrsGCS` | BucketAttrsGCS returns the bucket's GCS-specific attributes. |
 | `BucketIAMPolicy` |  |
 | `ComposeObjectGCS` | ComposeObjectGCS concatenates the source objects' bytes (in order) into |
+| `DeleteObjectGCS` | DeleteObjectGCS deletes an object honoring pre and optional generation |
+| `GetObjectGCS` | GetObjectGCS returns an object's bytes+info, selecting a specific |
+| `HeadObjectGCS` | HeadObjectGCS returns an object's info, selecting a specific generation |
 | `ListObjectGenerations` | ListObjectGenerations returns every generation (current + archived) of the |
 | `PutObjectGCS` | PutObjectGCS writes an object honoring pre (a failed condition returns a |
 | `SetBucketAttrsGCS` | SetBucketAttrsGCS records the bucket's location and default storage class |

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -33,6 +33,7 @@ const (
 	gcsDefaultMaxKeys       = 1000
 	gcsTimeFormat           = "2006-01-02T15:04:05Z"
 	gcsHoursPerDay          = 24
+	gcsDefaultStorageClass  = "STANDARD"
 )
 
 // Compile-time check that Mock implements driver.Bucket and the GCS-specific
@@ -59,6 +60,7 @@ type gcsObject struct {
 	ContentEncoding    string
 	ContentDisposition string
 	ContentLanguage    string
+	StorageClass       string
 }
 
 type gcsMultipartUpload struct {
@@ -194,6 +196,7 @@ func toInfo(o *gcsObject, cloneMeta bool) driver.ObjectInfo {
 		MD5: o.MD5, CRC32C: o.CRC32C,
 		CacheControl: o.CacheControl, ContentEncoding: o.ContentEncoding,
 		ContentDisposition: o.ContentDisposition, ContentLanguage: o.ContentLanguage,
+		StorageClass: o.StorageClass,
 	}
 }
 
@@ -235,17 +238,24 @@ func (m *Mock) ListBuckets(_ context.Context) ([]driver.BucketInfo, error) {
 }
 
 func (m *Mock) PutObject(ctx context.Context, bucket, key string, data []byte, contentType string, metadata map[string]string) error {
-	_, err := m.putObject(ctx, bucket, key, data, contentType, metadata, driver.GCSPrecondition{})
+	_, err := m.putObject(ctx, bucket, key, data, contentType, metadata, nil, driver.GCSPrecondition{})
 
 	return err
 }
 
 // putObject is the shared write path behind PutObject and PutObjectGCS. It
 // evaluates any preconditions, archives the current generation when versioning
-// is enabled, mints a fresh generation, and returns the stored object's info.
+// is enabled, mints a fresh generation, and returns the stored object's info. A
+// non-nil attrs persists the insert-time system properties.
 func (m *Mock) putObject(
-	ctx context.Context, bucket, key string, data []byte, contentType string, metadata map[string]string, pre driver.GCSPrecondition,
+	ctx context.Context, bucket, key string, data []byte, contentType string,
+	metadata map[string]string, attrs *driver.GCSObjectAttrs, pre driver.GCSPrecondition,
 ) (*driver.ObjectInfo, error) {
+	var oa driver.GCSObjectAttrs
+	if attrs != nil {
+		oa = *attrs
+	}
+
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
@@ -282,17 +292,22 @@ func (m *Mock) putObject(
 	md5b64, crc32cb64 := checksums(data)
 
 	obj := &gcsObject{
-		Key:            key,
-		Data:           stored,
-		Size:           int64(len(data)),
-		ContentType:    contentType,
-		ETag:           fmt.Sprintf("%x", sha256.Sum256(data)),
-		LastModified:   m.opts.Clock.Now().UTC().Format(gcsTimeFormat),
-		Metadata:       metaCopy,
-		Generation:     m.gen.Add(1),
-		Metageneration: 1,
-		MD5:            md5b64,
-		CRC32C:         crc32cb64,
+		Key:                key,
+		Data:               stored,
+		Size:               int64(len(data)),
+		ContentType:        contentType,
+		ETag:               fmt.Sprintf("%x", sha256.Sum256(data)),
+		LastModified:       m.opts.Clock.Now().UTC().Format(gcsTimeFormat),
+		Metadata:           metaCopy,
+		Generation:         m.gen.Add(1),
+		Metageneration:     1,
+		MD5:                md5b64,
+		CRC32C:             crc32cb64,
+		CacheControl:       oa.CacheControl,
+		ContentEncoding:    oa.ContentEncoding,
+		ContentDisposition: oa.ContentDisposition,
+		ContentLanguage:    oa.ContentLanguage,
+		StorageClass:       defaultObjectStorageClass(bkt, oa.StorageClass),
 	}
 	bkt.objects.Set(key, obj)
 
@@ -378,6 +393,23 @@ func archiveVersion(bkt *bucketMeta, key string, current *gcsObject, exists bool
 	bkt.versions[key] = append(bkt.versions[key], current)
 }
 
+// defaultObjectStorageClass resolves an object's storage class: the explicit
+// class when supplied, else the bucket's default class, else STANDARD.
+func defaultObjectStorageClass(bkt *bucketMeta, explicit string) string {
+	if explicit != "" {
+		return explicit
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	if bkt.storageClass != "" {
+		return bkt.storageClass
+	}
+
+	return gcsDefaultStorageClass
+}
+
 func (m *Mock) GetObject(ctx context.Context, bucket, key string) (*driver.Object, error) {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
@@ -425,13 +457,40 @@ func (m *Mock) objectBytes(ctx context.Context, bucket string, obj *gcsObject) (
 }
 
 func (m *Mock) DeleteObject(ctx context.Context, bucket, key string) error {
+	return m.deleteObject(ctx, bucket, key, nil, driver.GCSPrecondition{})
+}
+
+// deleteObject is the shared delete path. Preconditions are evaluated against
+// the live object. A generation-addressed delete is always permanent; a live
+// delete on a versioning-enabled bucket archives the current generation as
+// noncurrent instead of removing it.
+func (m *Mock) deleteObject(ctx context.Context, bucket, key string, generation *int64, pre driver.GCSPrecondition) error {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
 	}
 
-	if !bkt.objects.Has(key) {
+	current, exists := bkt.objects.Get(key)
+	if err := checkPrecondition(pre, current, exists); err != nil {
+		return err
+	}
+
+	if generation != nil {
+		return m.deleteGeneration(ctx, bkt, bucket, key, *generation, current, exists)
+	}
+
+	if !exists {
 		return cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bucket)
+	}
+
+	// Versioning-enabled live delete archives the current generation (it becomes
+	// noncurrent) — real GCS retains it, listable via versions=true.
+	if bkt.versioning {
+		archiveVersion(bkt, key, current, true)
+		bkt.objects.Delete(key)
+		m.emitMetric(ctx, "api/request_count", 1, map[string]string{"bucket_name": bucket})
+
+		return nil
 	}
 
 	bkt.objects.Delete(key)
@@ -443,6 +502,135 @@ func (m *Mock) DeleteObject(ctx context.Context, bucket, key string) error {
 	m.emitMetric(ctx, "api/request_count", 1, map[string]string{"bucket_name": bucket})
 
 	return nil
+}
+
+// DeleteObjectGCS deletes an object honoring pre and optional generation
+// addressing.
+func (m *Mock) DeleteObjectGCS(ctx context.Context, bucket, key string, generation *int64, pre driver.GCSPrecondition) error {
+	return m.deleteObject(ctx, bucket, key, generation, pre)
+}
+
+// deleteGeneration permanently removes one specific generation (live or
+// archived) of a key. Deletions addressed by generation are never archived.
+func (m *Mock) deleteGeneration(
+	ctx context.Context, bkt *bucketMeta, bucket, key string, gen int64, current *gcsObject, liveExists bool,
+) error {
+	if liveExists && current.Generation == gen {
+		bkt.objects.Delete(key)
+		m.purgeIfGone(ctx, bkt, bucket, key)
+		m.emitMetric(ctx, "api/request_count", 1, map[string]string{"bucket_name": bucket})
+
+		return nil
+	}
+
+	bkt.mu.Lock()
+
+	versions := bkt.versions[key]
+	for i, v := range versions {
+		if v.Generation != gen {
+			continue
+		}
+
+		bkt.versions[key] = append(versions[:i], versions[i+1:]...)
+		if len(bkt.versions[key]) == 0 {
+			delete(bkt.versions, key)
+		}
+
+		bkt.mu.Unlock()
+		m.purgeIfGone(ctx, bkt, bucket, key)
+		m.emitMetric(ctx, "api/request_count", 1, map[string]string{"bucket_name": bucket})
+
+		return nil
+	}
+
+	bkt.mu.Unlock()
+
+	return cerrors.Newf(cerrors.NotFound, "object %q generation %d not found in bucket %q", key, gen, bucket)
+}
+
+// purgeIfGone drops the storage-engine bytes for a key only once no live or
+// archived generation references it (the engine is keyed by bucket/key).
+func (m *Mock) purgeIfGone(ctx context.Context, bkt *bucketMeta, bucket, key string) {
+	if bkt.objects.Has(key) {
+		return
+	}
+
+	bkt.mu.Lock()
+	remaining := len(bkt.versions[key])
+	bkt.mu.Unlock()
+
+	if remaining > 0 {
+		return
+	}
+
+	_ = storageengine.Delete(ctx, m.opts.StorageEngine, config.StorageRef{Bucket: bucket, Key: key})
+}
+
+// GetObjectGCS returns an object's bytes+info, selecting a specific generation
+// when generation is non-nil (else the live object).
+func (m *Mock) GetObjectGCS(ctx context.Context, bucket, key string, generation *int64) (*driver.Object, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	obj, ok := findGeneration(bkt, key, generation)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bucket)
+	}
+
+	dataCopy, err := m.objectBytes(ctx, bucket, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	dims := map[string]string{"bucket_name": bucket}
+	m.emitMetric(ctx, "api/request_count", 1, dims)
+	m.emitMetric(ctx, "network/sent_bytes_count", float64(obj.Size), dims)
+
+	return &driver.Object{Info: toInfo(obj, true), Data: dataCopy}, nil
+}
+
+// HeadObjectGCS returns an object's info, selecting a specific generation when
+// generation is non-nil (else the live object).
+func (m *Mock) HeadObjectGCS(_ context.Context, bucket, key string, generation *int64) (*driver.ObjectInfo, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	obj, ok := findGeneration(bkt, key, generation)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bucket)
+	}
+
+	info := toInfo(obj, true)
+
+	return &info, nil
+}
+
+// findGeneration resolves a key to its live object (generation nil, or matching
+// the live generation) or an archived generation.
+func findGeneration(bkt *bucketMeta, key string, generation *int64) (*gcsObject, bool) {
+	current, exists := bkt.objects.Get(key)
+	if generation == nil {
+		return current, exists
+	}
+
+	if exists && current.Generation == *generation {
+		return current, true
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	for _, v := range bkt.versions[key] {
+		if v.Generation == *generation {
+			return v, true
+		}
+	}
+
+	return nil, false
 }
 
 func (m *Mock) HeadObject(_ context.Context, bucket, key string) (*driver.ObjectInfo, error) {
@@ -577,6 +765,7 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 		MD5: srcObj.MD5, CRC32C: srcObj.CRC32C,
 		CacheControl: srcObj.CacheControl, ContentEncoding: srcObj.ContentEncoding,
 		ContentDisposition: srcObj.ContentDisposition, ContentLanguage: srcObj.ContentLanguage,
+		StorageClass: defaultObjectStorageClass(dstBkt, srcObj.StorageClass),
 	})
 
 	dims := map[string]string{"bucket_name": dstBucket}
@@ -842,6 +1031,7 @@ func (m *Mock) CompleteMultipartUpload(
 		Metageneration: 1,
 		MD5:            md5b64,
 		CRC32C:         crc32cb64,
+		StorageClass:   defaultObjectStorageClass(bkt, ""),
 	})
 
 	bkt.multiparts.Delete(uploadID)
@@ -1141,15 +1331,17 @@ func (m *Mock) DeleteBucketTagging(_ context.Context, bucket string) error {
 // PutObjectGCS writes an object honoring GCS write preconditions and returns the
 // stored object's info with the newly minted generation.
 func (m *Mock) PutObjectGCS(
-	ctx context.Context, bucket, key string, data []byte, contentType string, metadata map[string]string, pre driver.GCSPrecondition,
+	ctx context.Context, bucket, key string, data []byte, contentType string,
+	metadata map[string]string, attrs *driver.GCSObjectAttrs, pre driver.GCSPrecondition,
 ) (*driver.ObjectInfo, error) {
-	return m.putObject(ctx, bucket, key, data, contentType, metadata, pre)
+	return m.putObject(ctx, bucket, key, data, contentType, metadata, attrs, pre)
 }
 
 // UpdateObjectGCS mutates an existing object's system properties and/or custom
-// metadata without touching its data, bumping metageneration.
+// metadata without touching its data, bumping metageneration. A failed pre
+// returns a *driver.GCSPreconditionError.
 func (m *Mock) UpdateObjectGCS(
-	_ context.Context, bucket, key string, upd driver.GCSObjectUpdate,
+	_ context.Context, bucket, key string, upd driver.GCSObjectUpdate, pre driver.GCSPrecondition,
 ) (*driver.ObjectInfo, error) {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
@@ -1159,6 +1351,10 @@ func (m *Mock) UpdateObjectGCS(
 	cur, ok := bkt.objects.Get(key)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bucket)
+	}
+
+	if err := checkPrecondition(pre, cur, true); err != nil {
+		return nil, err
 	}
 
 	next := *cur
@@ -1205,9 +1401,11 @@ func mergeMetadata(cur map[string]string, patch map[string]*string) map[string]s
 }
 
 // ComposeObjectGCS concatenates the source objects' bytes (in order) into
-// dstKey, minting a new generation for the destination.
+// dstKey, minting a new generation for the destination and honoring the
+// destination pre and each source's pinned generation.
 func (m *Mock) ComposeObjectGCS(
-	ctx context.Context, bucket, dstKey string, srcKeys []string, contentType string, metadata map[string]string,
+	ctx context.Context, bucket, dstKey string, srcs []driver.GCSComposeSource,
+	contentType string, metadata map[string]string, pre driver.GCSPrecondition,
 ) (*driver.ObjectInfo, error) {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
@@ -1216,10 +1414,10 @@ func (m *Mock) ComposeObjectGCS(
 
 	var composed []byte
 
-	for _, sk := range srcKeys {
-		srcObj, ok := bkt.objects.Get(sk)
+	for _, s := range srcs {
+		srcObj, ok := findGeneration(bkt, s.Key, s.Generation)
 		if !ok {
-			return nil, cerrors.Newf(cerrors.NotFound, "source object %q not found in bucket %q", sk, bucket)
+			return nil, cerrors.Newf(cerrors.NotFound, "source object %q not found in bucket %q", s.Key, bucket)
 		}
 
 		bytesOf, err := m.objectBytes(ctx, bucket, srcObj)
@@ -1234,7 +1432,7 @@ func (m *Mock) ComposeObjectGCS(
 		}
 	}
 
-	return m.putObject(ctx, bucket, dstKey, composed, contentType, metadata, driver.GCSPrecondition{})
+	return m.putObject(ctx, bucket, dstKey, composed, contentType, metadata, nil, pre)
 }
 
 // ListObjectGenerations returns every generation (current + archived) of the
@@ -1274,15 +1472,23 @@ func (m *Mock) ListObjectGenerations(_ context.Context, bucket string, opts driv
 	}, nil
 }
 
-// collectAllVersions returns archived-then-current generations for every key,
-// sorted by (key, generation) so a versioned listing is deterministic.
+// collectAllVersions returns archived-then-current generations for every key
+// (including keys whose live generation was deleted but whose noncurrent
+// generations are retained), sorted by (key, generation) so a versioned listing
+// is deterministic.
 func collectAllVersions(bkt *bucketMeta) []*gcsObject {
+	liveKeys := bkt.objects.Keys()
+
 	bkt.mu.Lock()
 	defer bkt.mu.Unlock()
 
+	seen := make(map[string]struct{}, len(liveKeys))
+
 	var all []*gcsObject
 
-	for _, k := range bkt.objects.Keys() {
+	for _, k := range liveKeys {
+		seen[k] = struct{}{}
+
 		if archived := bkt.versions[k]; len(archived) > 0 {
 			all = append(all, archived...)
 		}
@@ -1292,8 +1498,16 @@ func collectAllVersions(bkt *bucketMeta) []*gcsObject {
 		}
 	}
 
-	// Archived versions of keys that were fully deleted still count in GCS, but
-	// this mock drops them on delete; only live keys are surfaced here.
+	// Keys whose live generation was deleted keep their noncurrent generations
+	// on a versioned bucket — real GCS still lists these under versions=true.
+	for k, archived := range bkt.versions {
+		if _, live := seen[k]; live {
+			continue
+		}
+
+		all = append(all, archived...)
+	}
+
 	sort.Slice(all, func(i, j int) bool {
 		if all[i].Key != all[j].Key {
 			return all[i].Key < all[j].Key

--- a/providers/gcp/gcs/snapshot.go
+++ b/providers/gcp/gcs/snapshot.go
@@ -57,6 +57,7 @@ type objectSnapshot struct {
 	ContentEncoding    string            `json:"contentEncoding,omitempty"`
 	ContentDisposition string            `json:"contentDisposition,omitempty"`
 	ContentLanguage    string            `json:"contentLanguage,omitempty"`
+	StorageClass       string            `json:"storageClass,omitempty"`
 }
 
 // Snapshot captures every bucket's state as JSON. When includeAssets is false
@@ -89,7 +90,7 @@ func snapshotBucket(bkt *bucketMeta, includeAssets bool) *bucketSnapshot {
 			Generation: obj.Generation, Metageneration: obj.Metageneration,
 			MD5: obj.MD5, CRC32C: obj.CRC32C, CacheControl: obj.CacheControl,
 			ContentEncoding: obj.ContentEncoding, ContentDisposition: obj.ContentDisposition,
-			ContentLanguage: obj.ContentLanguage,
+			ContentLanguage: obj.ContentLanguage, StorageClass: obj.StorageClass,
 		}
 	}
 
@@ -146,7 +147,7 @@ func restoreBucket(bs *bucketSnapshot) *bucketMeta {
 			Generation: os.Generation, Metageneration: os.Metageneration,
 			MD5: os.MD5, CRC32C: os.CRC32C, CacheControl: os.CacheControl,
 			ContentEncoding: os.ContentEncoding, ContentDisposition: os.ContentDisposition,
-			ContentLanguage: os.ContentLanguage,
+			ContentLanguage: os.ContentLanguage, StorageClass: os.StorageClass,
 		})
 	}
 

--- a/server/gcp/gcs/gcs_object_semantics_test.go
+++ b/server/gcp/gcs/gcs_object_semantics_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5" //nolint:gosec // verifying the GCS md5Hash content digest, not a security primitive
 	"errors"
 	"hash/crc32"
+	"io"
 	"net/http"
 	"testing"
 
@@ -209,5 +210,225 @@ func TestGCSObjectVersionsList(t *testing.T) {
 
 	if gens[0] == gens[1] {
 		t.Errorf("two retained generations share id %d", gens[0])
+	}
+}
+
+// TestGCSObjectDeletePrecondition proves a delete with a mismatched
+// ifGenerationMatch is rejected 412 and leaves the object untouched — the
+// optimistic-concurrency delete real GCS enforces.
+func TestGCSObjectDeletePrecondition(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "delprecond")
+
+	putObject(t, ctx, bkt, "k", "text/plain", []byte("v1"), nil)
+
+	err := bkt.Object("k").If(storage.Conditions{GenerationMatch: 999999}).Delete(ctx)
+	assertPreconditionFailed(t, err, "Delete with mismatched GenerationMatch")
+
+	if got := readObject(t, ctx, bkt, "k"); string(got) != "v1" {
+		t.Errorf("object deleted despite failed precondition: got %q, want v1", got)
+	}
+}
+
+// TestGCSVersionedDeleteRetainsGenerations proves a live delete on a
+// versioning-enabled bucket archives the current generation (it becomes
+// noncurrent) rather than dropping it — so a Versions=true list still returns
+// every prior generation after the live object is gone.
+func TestGCSVersionedDeleteRetainsGenerations(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "verdel")
+
+	if _, err := bkt.Update(ctx, storage.BucketAttrsToUpdate{VersioningEnabled: true}); err != nil {
+		t.Fatalf("enable versioning: %v", err)
+	}
+
+	putObject(t, ctx, bkt, "k", "text/plain", []byte("v1"), nil)
+	putObject(t, ctx, bkt, "k", "text/plain", []byte("v2"), nil)
+
+	if err := bkt.Object("k").Delete(ctx); err != nil {
+		t.Fatalf("delete live object: %v", err)
+	}
+
+	// Live read must now 404 — the object has no current generation.
+	if _, err := bkt.Object("k").Attrs(ctx); !errors.Is(err, storage.ErrObjectNotExist) {
+		t.Errorf("live Attrs after delete = %v, want ErrObjectNotExist", err)
+	}
+
+	var gens []int64
+
+	it := bkt.Objects(ctx, &storage.Query{Versions: true})
+
+	for {
+		a, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("versioned list: %v", err)
+		}
+
+		if a.Name == "k" {
+			gens = append(gens, a.Generation)
+		}
+	}
+
+	if len(gens) != 2 {
+		t.Fatalf("after live delete, versioned list returned %d generations, want 2 noncurrent: %v", len(gens), gens)
+	}
+}
+
+// TestGCSInsertSystemProperties proves cacheControl/contentEncoding/
+// contentDisposition/contentLanguage set at INSERT persist and read back on
+// Attrs (previously dropped, fixing google_storage_bucket_object drift).
+func TestGCSInsertSystemProperties(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "sysprops")
+
+	w := bkt.Object("k").NewWriter(ctx)
+	w.ContentType = "text/plain"
+	w.CacheControl = "public, max-age=3600"
+	w.ContentEncoding = "gzip"
+	w.ContentDisposition = "attachment; filename=\"f.txt\""
+	w.ContentLanguage = "en"
+
+	if _, err := w.Write([]byte("payload")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	a, err := bkt.Object("k").Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs: %v", err)
+	}
+
+	if a.CacheControl != "public, max-age=3600" {
+		t.Errorf("CacheControl = %q, want public, max-age=3600", a.CacheControl)
+	}
+
+	if a.ContentEncoding != "gzip" {
+		t.Errorf("ContentEncoding = %q, want gzip", a.ContentEncoding)
+	}
+
+	if a.ContentDisposition != "attachment; filename=\"f.txt\"" {
+		t.Errorf("ContentDisposition = %q, want attachment...", a.ContentDisposition)
+	}
+
+	if a.ContentLanguage != "en" {
+		t.Errorf("ContentLanguage = %q, want en", a.ContentLanguage)
+	}
+}
+
+// TestGCSGenerationAddressedRead proves ?generation reads the addressed
+// revision's bytes, not the current ones — a versioned bucket keeps prior
+// generations readable by id.
+func TestGCSGenerationAddressedRead(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "genread")
+
+	if _, err := bkt.Update(ctx, storage.BucketAttrsToUpdate{VersioningEnabled: true}); err != nil {
+		t.Fatalf("enable versioning: %v", err)
+	}
+
+	putObject(t, ctx, bkt, "k", "text/plain", []byte("v1"), nil)
+
+	a1, err := bkt.Object("k").Attrs(ctx)
+	if err != nil {
+		t.Fatalf("first Attrs: %v", err)
+	}
+
+	putObject(t, ctx, bkt, "k", "text/plain", []byte("v2"), nil)
+
+	if got := readObject(t, ctx, bkt, "k"); string(got) != "v2" {
+		t.Fatalf("live read = %q, want v2", got)
+	}
+
+	rd, err := bkt.Object("k").Generation(a1.Generation).NewReader(ctx)
+	if err != nil {
+		t.Fatalf("generation-addressed NewReader: %v", err)
+	}
+	defer rd.Close()
+
+	got, err := io.ReadAll(rd)
+	if err != nil {
+		t.Fatalf("read gen1: %v", err)
+	}
+
+	if string(got) != "v1" {
+		t.Errorf("generation(%d) read = %q, want v1", a1.Generation, got)
+	}
+}
+
+// TestGCSConditionalReadMismatch proves a conditional read with a mismatched
+// ifGenerationMatch is rejected 412.
+func TestGCSConditionalReadMismatch(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "condread")
+
+	putObject(t, ctx, bkt, "k", "text/plain", []byte("v1"), nil)
+
+	_, err := bkt.Object("k").If(storage.Conditions{GenerationMatch: 123456}).NewReader(ctx)
+	assertPreconditionFailed(t, err, "conditional read with mismatched GenerationMatch")
+
+	_, err = bkt.Object("k").If(storage.Conditions{MetagenerationMatch: 999}).Attrs(ctx)
+	assertPreconditionFailed(t, err, "conditional Attrs with mismatched MetagenerationMatch")
+}
+
+// TestGCSUpdatePrecondition proves an Objects: patch with a mismatched
+// ifMetagenerationMatch is rejected 412.
+func TestGCSUpdatePrecondition(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "updprecond")
+
+	putObject(t, ctx, bkt, "k", "text/plain", []byte("v"), nil)
+
+	_, err := bkt.Object("k").If(storage.Conditions{MetagenerationMatch: 999}).Update(ctx, storage.ObjectAttrsToUpdate{
+		ContentType: "application/json",
+	})
+	assertPreconditionFailed(t, err, "Update with mismatched MetagenerationMatch")
+}
+
+// TestGCSComposePrecondition proves a compose with DoesNotExist over an already
+// existing destination is rejected 412.
+func TestGCSComposePrecondition(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "compprecond")
+
+	putObject(t, ctx, bkt, "p1", "text/plain", []byte("foo"), nil)
+	putObject(t, ctx, bkt, "p2", "text/plain", []byte("bar"), nil)
+	putObject(t, ctx, bkt, "dst", "text/plain", []byte("existing"), nil)
+
+	comp := bkt.Object("dst").If(storage.Conditions{DoesNotExist: true}).ComposerFrom(bkt.Object("p1"), bkt.Object("p2"))
+
+	_, err := comp.Run(ctx)
+	assertPreconditionFailed(t, err, "compose DoesNotExist over existing destination")
+
+	if got := readObject(t, ctx, bkt, "dst"); string(got) != "existing" {
+		t.Errorf("destination overwritten despite failed precondition: got %q", got)
+	}
+}
+
+// TestGCSObjectStorageClass proves an object inherits its bucket's default
+// storage class (NEARLINE) instead of a hardcoded STANDARD.
+func TestGCSObjectStorageClass(t *testing.T) {
+	ctx, client := newStorageClient(t)
+
+	b := client.Bucket("nearline")
+	if err := b.Create(ctx, e2eProject, &storage.BucketAttrs{StorageClass: "NEARLINE"}); err != nil {
+		t.Fatalf("create NEARLINE bucket: %v", err)
+	}
+
+	putObject(t, ctx, b, "k", "text/plain", []byte("v"), nil)
+
+	a, err := b.Object("k").Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs: %v", err)
+	}
+
+	if a.StorageClass != "NEARLINE" {
+		t.Errorf("StorageClass = %q, want NEARLINE (bucket default)", a.StorageClass)
 	}
 }

--- a/server/gcp/gcs/gcs_object_semantics_test.go
+++ b/server/gcp/gcs/gcs_object_semantics_test.go
@@ -411,6 +411,39 @@ func TestGCSComposePrecondition(t *testing.T) {
 	}
 }
 
+// TestGCSComposePinnedSourceGeneration proves compose honors a source's pinned
+// generation: it composes the exact addressed revision (decoded from the
+// JSON-string generation field), not the source's live bytes.
+func TestGCSComposePinnedSourceGeneration(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "comppin")
+
+	if _, err := bkt.Update(ctx, storage.BucketAttrsToUpdate{VersioningEnabled: true}); err != nil {
+		t.Fatalf("enable versioning: %v", err)
+	}
+
+	putObject(t, ctx, bkt, "src", "text/plain", []byte("old"), nil)
+
+	a1, err := bkt.Object("src").Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs: %v", err)
+	}
+
+	// Overwrite so the live generation differs from the pinned one.
+	putObject(t, ctx, bkt, "src", "text/plain", []byte("new"), nil)
+
+	comp := bkt.Object("dst").ComposerFrom(bkt.Object("src").Generation(a1.Generation))
+	comp.ContentType = "text/plain"
+
+	if _, err := comp.Run(ctx); err != nil {
+		t.Fatalf("compose with pinned source generation: %v", err)
+	}
+
+	if got := readObject(t, ctx, bkt, "dst"); string(got) != "old" {
+		t.Errorf("composed pinned generation = %q, want old (the pinned gen, not live)", got)
+	}
+}
+
 // TestGCSObjectStorageClass proves an object inherits its bucket's default
 // storage class (NEARLINE) instead of a hardcoded STANDARD.
 func TestGCSObjectStorageClass(t *testing.T) {

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -614,23 +614,102 @@ func parseInt64Ptr(s string) *int64 {
 	return &n
 }
 
+// readPrecondition extracts the conditional-read preconditions. The Go client
+// sends them on the JSON metadata request as query params but on the media
+// download as x-goog-if-* headers, so both are consulted (query wins).
+func readPrecondition(r *http.Request) storagedriver.GCSPrecondition {
+	q := r.URL.Query()
+	h := r.Header
+
+	return storagedriver.GCSPrecondition{
+		IfGenerationMatch:        firstInt64Ptr(q.Get("ifGenerationMatch"), h.Get("x-goog-if-generation-match")),
+		IfGenerationNotMatch:     firstInt64Ptr(q.Get("ifGenerationNotMatch"), h.Get("x-goog-if-generation-not-match")),
+		IfMetagenerationMatch:    firstInt64Ptr(q.Get("ifMetagenerationMatch"), h.Get("x-goog-if-metageneration-match")),
+		IfMetagenerationNotMatch: firstInt64Ptr(q.Get("ifMetagenerationNotMatch"), h.Get("x-goog-if-metageneration-not-match")),
+	}
+}
+
+// firstInt64Ptr returns the first parseable int64 pointer among its args.
+func firstInt64Ptr(vals ...string) *int64 {
+	for _, v := range vals {
+		if p := parseInt64Ptr(v); p != nil {
+			return p
+		}
+	}
+
+	return nil
+}
+
+// parseGeneration extracts the ?generation object-revision selector; nil (and a
+// meaningless generation=0) select the live object.
+func parseGeneration(q url.Values) *int64 {
+	g := parseInt64Ptr(q.Get("generation"))
+	if g != nil && *g == 0 {
+		return nil
+	}
+
+	return g
+}
+
+// evalReadPrecondition evaluates the conditional-read preconditions against the
+// object being returned. It reports the HTTP status the response must be
+// short-circuited with — 412 for a failed Match, 304 for a satisfied NotMatch —
+// and false when the read should proceed. This mirrors real GCS's conditional
+// GET semantics.
+func evalReadPrecondition(pre storagedriver.GCSPrecondition, gen, metagen int64) (int, bool) {
+	if pre.IfGenerationMatch != nil && gen != *pre.IfGenerationMatch {
+		return http.StatusPreconditionFailed, true
+	}
+
+	if pre.IfMetagenerationMatch != nil && metagen != *pre.IfMetagenerationMatch {
+		return http.StatusPreconditionFailed, true
+	}
+
+	if pre.IfGenerationNotMatch != nil && gen == *pre.IfGenerationNotMatch {
+		return http.StatusNotModified, true
+	}
+
+	if pre.IfMetagenerationNotMatch != nil && metagen == *pre.IfMetagenerationNotMatch {
+		return http.StatusNotModified, true
+	}
+
+	return 0, false
+}
+
+// writeConditionalRead writes the short-circuit response for a conditional read:
+// a 304 carries no body, a 412 the conditionNotMet error envelope.
+func writeConditionalRead(w http.ResponseWriter, status int) {
+	if status == http.StatusNotModified {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	writeError(w, http.StatusPreconditionFailed, "conditionNotMet", "conditionNotMet")
+}
+
+// writePreconditionOrErr maps a *GCSPreconditionError to a 412 conditionNotMet
+// response and any other error through writeErr.
+func writePreconditionOrErr(w http.ResponseWriter, err error) {
+	var preErr *storagedriver.GCSPreconditionError
+	if errors.As(err, &preErr) {
+		writeError(w, http.StatusPreconditionFailed, "conditionNotMet", preErr.Error())
+		return
+	}
+
+	writeErr(w, err)
+}
+
 // storeObject writes an object through the preconditioned GCS path when the
 // backing driver supports it (returning a 412 on a failed precondition), else
 // falls back to the plain Bucket.PutObject.
 func (h *Handler) storeObject(
-	w http.ResponseWriter, r *http.Request, bucket, name, contentType string, data []byte, metadata map[string]string,
+	w http.ResponseWriter, r *http.Request, bucket, name, contentType string,
+	data []byte, metadata map[string]string, attrs *storagedriver.GCSObjectAttrs,
 ) {
 	if h.ext != nil {
-		info, err := h.ext.PutObjectGCS(r.Context(), bucket, name, data, contentType, metadata, parsePrecondition(r.URL.Query()))
+		info, err := h.ext.PutObjectGCS(r.Context(), bucket, name, data, contentType, metadata, attrs, parsePrecondition(r.URL.Query()))
 		if err != nil {
-			var preErr *storagedriver.GCSPreconditionError
-			if errors.As(err, &preErr) {
-				writeError(w, http.StatusPreconditionFailed, "conditionNotMet", preErr.Error())
-				return
-			}
-
-			writeErr(w, err)
-
+			writePreconditionOrErr(w, err)
 			return
 		}
 
@@ -672,7 +751,7 @@ func (h *Handler) uploadMedia(w http.ResponseWriter, r *http.Request, bucket, na
 		contentType = contentTypeBinary
 	}
 
-	h.storeObject(w, r, bucket, name, contentType, data, nil)
+	h.storeObject(w, r, bucket, name, contentType, data, nil, nil)
 }
 
 // uploadMultipart parses a multipart/related body where the first part is a
@@ -709,7 +788,13 @@ func (h *Handler) uploadMultipart(w http.ResponseWriter, r *http.Request, bucket
 		payloadCT = contentTypeBinary
 	}
 
-	h.storeObject(w, r, bucket, meta.Name, payloadCT, payload, meta.Metadata)
+	h.storeObject(w, r, bucket, meta.Name, payloadCT, payload, meta.Metadata, &storagedriver.GCSObjectAttrs{
+		CacheControl:       meta.CacheControl,
+		ContentEncoding:    meta.ContentEncoding,
+		ContentDisposition: meta.ContentDisposition,
+		ContentLanguage:    meta.ContentLanguage,
+		StorageClass:       meta.StorageClass,
+	})
 }
 
 func (h *Handler) listObjects(w http.ResponseWriter, r *http.Request, bucket string) {
@@ -818,9 +903,9 @@ func (h *Handler) updateObject(w http.ResponseWriter, r *http.Request, bucket, k
 		ContentDisposition: body.ContentDisposition,
 		ContentLanguage:    body.ContentLanguage,
 		Metadata:           body.Metadata,
-	})
+	}, parsePrecondition(r.URL.Query()))
 	if err != nil {
-		writeErr(w, err)
+		writePreconditionOrErr(w, err)
 		return
 	}
 
@@ -845,9 +930,17 @@ func (h *Handler) composeObject(w http.ResponseWriter, r *http.Request, bucket, 
 		return
 	}
 
-	srcKeys := make([]string, 0, len(body.SourceObjects))
+	srcs := make([]storagedriver.GCSComposeSource, 0, len(body.SourceObjects))
+
 	for _, s := range body.SourceObjects {
-		srcKeys = append(srcKeys, s.Name)
+		var gen *int64
+
+		if s.Generation != 0 {
+			g := s.Generation
+			gen = &g
+		}
+
+		srcs = append(srcs, storagedriver.GCSComposeSource{Key: s.Name, Generation: gen})
 	}
 
 	contentType := ""
@@ -855,9 +948,11 @@ func (h *Handler) composeObject(w http.ResponseWriter, r *http.Request, bucket, 
 		contentType = body.Destination.ContentType
 	}
 
-	info, err := h.ext.ComposeObjectGCS(r.Context(), bucket, dstKey, srcKeys, contentType, destinationMetadata(body.Destination))
+	info, err := h.ext.ComposeObjectGCS(
+		r.Context(), bucket, dstKey, srcs, contentType, destinationMetadata(body.Destination), parsePrecondition(r.URL.Query()),
+	)
 	if err != nil {
-		writeErr(w, err)
+		writePreconditionOrErr(w, err)
 		return
 	}
 
@@ -873,9 +968,16 @@ func destinationMetadata(dst *objectResource) map[string]string {
 }
 
 func (h *Handler) getObjectMetadata(w http.ResponseWriter, r *http.Request, bucket, key string) {
-	info, err := h.bucket.HeadObject(r.Context(), bucket, key)
+	q := r.URL.Query()
+
+	info, err := h.headObject(r, bucket, key, parseGeneration(q))
 	if err != nil {
 		writeErr(w, err)
+		return
+	}
+
+	if status, short := evalReadPrecondition(readPrecondition(r), info.Generation, info.Metageneration); short {
+		writeConditionalRead(w, status)
 		return
 	}
 
@@ -883,9 +985,16 @@ func (h *Handler) getObjectMetadata(w http.ResponseWriter, r *http.Request, buck
 }
 
 func (h *Handler) downloadObject(w http.ResponseWriter, r *http.Request, bucket, key string) {
-	obj, err := h.bucket.GetObject(r.Context(), bucket, key)
+	q := r.URL.Query()
+
+	obj, err := h.fetchObject(r, bucket, key, parseGeneration(q))
 	if err != nil {
 		writeErr(w, err)
+		return
+	}
+
+	if status, short := evalReadPrecondition(readPrecondition(r), obj.Info.Generation, obj.Info.Metageneration); short {
+		writeConditionalRead(w, status)
 		return
 	}
 
@@ -896,7 +1005,39 @@ func (h *Handler) downloadObject(w http.ResponseWriter, r *http.Request, bucket,
 	_, _ = w.Write(obj.Data) //nolint:gosec // raw object bytes
 }
 
+// headObject fetches an object's metadata, addressing a specific generation
+// through the GCS extension when available.
+func (h *Handler) headObject(r *http.Request, bucket, key string, gen *int64) (*storagedriver.ObjectInfo, error) {
+	if h.ext != nil {
+		return h.ext.HeadObjectGCS(r.Context(), bucket, key, gen)
+	}
+
+	return h.bucket.HeadObject(r.Context(), bucket, key)
+}
+
+// fetchObject fetches an object's bytes+metadata, addressing a specific
+// generation through the GCS extension when available.
+func (h *Handler) fetchObject(r *http.Request, bucket, key string, gen *int64) (*storagedriver.Object, error) {
+	if h.ext != nil {
+		return h.ext.GetObjectGCS(r.Context(), bucket, key, gen)
+	}
+
+	return h.bucket.GetObject(r.Context(), bucket, key)
+}
+
 func (h *Handler) deleteObject(w http.ResponseWriter, r *http.Request, bucket, key string) {
+	if h.ext != nil {
+		q := r.URL.Query()
+		if err := h.ext.DeleteObjectGCS(r.Context(), bucket, key, parseGeneration(q), parsePrecondition(q)); err != nil {
+			writePreconditionOrErr(w, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+
+		return
+	}
+
 	if err := h.bucket.DeleteObject(r.Context(), bucket, key); err != nil {
 		writeErr(w, err)
 		return
@@ -990,6 +1131,11 @@ func toObjectResource(info *storagedriver.ObjectInfo, bucket string, r *http.Req
 
 	genStr := strconv.FormatInt(generation, 10)
 
+	storageClass := info.StorageClass
+	if storageClass == "" {
+		storageClass = defaultStorageClass
+	}
+
 	return objectResource{
 		Kind:               "storage#object",
 		ID:                 bucket + "/" + info.Key + "/" + genStr,
@@ -1002,7 +1148,7 @@ func toObjectResource(info *storagedriver.ObjectInfo, bucket string, r *http.Req
 		MD5Hash:            info.MD5,
 		CRC32C:             info.CRC32C,
 		ETag:               info.ETag,
-		StorageClass:       "STANDARD",
+		StorageClass:       storageClass,
 		CacheControl:       info.CacheControl,
 		ContentEncoding:    info.ContentEncoding,
 		ContentDisposition: info.ContentDisposition,
@@ -1091,9 +1237,14 @@ func extractBoundary(ct string) string {
 
 // uploadMetadata is the JSON metadata part of a multipart upload.
 type uploadMetadata struct {
-	Name        string            `json:"name"`
-	ContentType string            `json:"contentType,omitempty"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
+	Name               string            `json:"name"`
+	ContentType        string            `json:"contentType,omitempty"`
+	CacheControl       string            `json:"cacheControl,omitempty"`
+	ContentEncoding    string            `json:"contentEncoding,omitempty"`
+	ContentDisposition string            `json:"contentDisposition,omitempty"`
+	ContentLanguage    string            `json:"contentLanguage,omitempty"`
+	StorageClass       string            `json:"storageClass,omitempty"`
+	Metadata           map[string]string `json:"metadata,omitempty"`
 }
 
 // parseMultipart extracts metadata, payload, and payload content-type from a

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -622,10 +622,10 @@ func readPrecondition(r *http.Request) storagedriver.GCSPrecondition {
 	h := r.Header
 
 	return storagedriver.GCSPrecondition{
-		IfGenerationMatch:        firstInt64Ptr(q.Get("ifGenerationMatch"), h.Get("x-goog-if-generation-match")),
-		IfGenerationNotMatch:     firstInt64Ptr(q.Get("ifGenerationNotMatch"), h.Get("x-goog-if-generation-not-match")),
-		IfMetagenerationMatch:    firstInt64Ptr(q.Get("ifMetagenerationMatch"), h.Get("x-goog-if-metageneration-match")),
-		IfMetagenerationNotMatch: firstInt64Ptr(q.Get("ifMetagenerationNotMatch"), h.Get("x-goog-if-metageneration-not-match")),
+		IfGenerationMatch:        firstInt64Ptr(q.Get("ifGenerationMatch"), h.Get("X-Goog-If-Generation-Match")),
+		IfGenerationNotMatch:     firstInt64Ptr(q.Get("ifGenerationNotMatch"), h.Get("X-Goog-If-Generation-Not-Match")),
+		IfMetagenerationMatch:    firstInt64Ptr(q.Get("ifMetagenerationMatch"), h.Get("X-Goog-If-Metageneration-Match")),
+		IfMetagenerationNotMatch: firstInt64Ptr(q.Get("ifMetagenerationNotMatch"), h.Get("X-Goog-If-Metageneration-Not-Match")),
 	}
 }
 

--- a/server/gcp/gcs/types.go
+++ b/server/gcp/gcs/types.go
@@ -107,8 +107,10 @@ type composeRequest struct {
 }
 
 type composeSource struct {
-	Name       string `json:"name"`
-	Generation int64  `json:"generation,omitempty"`
+	Name string `json:"name"`
+	// Generation is JSON-encoded as a string by the GCS API / Go storage SDK
+	// (like objectResource.Generation), so it needs the ,string option.
+	Generation int64 `json:"generation,omitempty,string"`
 }
 
 // iamPolicyResource is the storage#policy document (Buckets: get/setIamPolicy).

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -322,6 +322,10 @@ type ObjectInfo struct {
 	ContentEncoding    string
 	ContentDisposition string
 	ContentLanguage    string
+	// StorageClass is the GCS object storage class (STANDARD/NEARLINE/COLDLINE/
+	// ARCHIVE), defaulting to the bucket's default class at insert. Empty for
+	// providers that don't model it.
+	StorageClass string
 }
 
 // Object is an object with its data.
@@ -692,6 +696,25 @@ type GCSObjectUpdate struct {
 	Metadata           map[string]*string
 }
 
+// GCSObjectAttrs carries the object system properties settable at INSERT time
+// (Objects: insert), so they persist on the first write rather than only via a
+// later patch. Empty StorageClass means "use the bucket's default class".
+type GCSObjectAttrs struct {
+	CacheControl       string
+	ContentEncoding    string
+	ContentDisposition string
+	ContentLanguage    string
+	StorageClass       string
+}
+
+// GCSComposeSource names one source component of an Objects: compose request.
+// Generation is nil to use the source's live generation, or a specific
+// archived/live generation to pin.
+type GCSComposeSource struct {
+	Key        string
+	Generation *int64
+}
+
 // GCSBucketMeta are the GCS-specific bucket attributes the shared BucketInfo
 // doesn't carry: multi-region/region location, default storage class, and the
 // metageneration/updated pair that back etag/ifMetagenerationMatch concurrency.
@@ -711,17 +734,33 @@ type GCSBucketMeta struct {
 type GCSExtensions interface {
 	// PutObjectGCS writes an object honoring pre (a failed condition returns a
 	// *GCSPreconditionError) and returns the stored object's info with the newly
-	// minted generation.
+	// minted generation. A non-nil attrs persists the insert-time system
+	// properties.
 	PutObjectGCS(
-		ctx context.Context, bucket, key string, data []byte, contentType string, metadata map[string]string, pre GCSPrecondition,
+		ctx context.Context, bucket, key string, data []byte, contentType string,
+		metadata map[string]string, attrs *GCSObjectAttrs, pre GCSPrecondition,
 	) (*ObjectInfo, error)
+	// GetObjectGCS returns an object's bytes+info, selecting a specific
+	// generation when generation is non-nil (else the live object).
+	GetObjectGCS(ctx context.Context, bucket, key string, generation *int64) (*Object, error)
+	// HeadObjectGCS returns an object's info, selecting a specific generation
+	// when generation is non-nil (else the live object).
+	HeadObjectGCS(ctx context.Context, bucket, key string, generation *int64) (*ObjectInfo, error)
+	// DeleteObjectGCS deletes an object honoring pre and optional generation
+	// addressing. On a versioning-enabled bucket a live delete (nil generation)
+	// archives the current generation as noncurrent instead of removing it; a
+	// generation-addressed delete is always permanent.
+	DeleteObjectGCS(ctx context.Context, bucket, key string, generation *int64, pre GCSPrecondition) error
 	// UpdateObjectGCS mutates an existing object's system properties and/or
-	// custom metadata without touching its data, bumping metageneration.
-	UpdateObjectGCS(ctx context.Context, bucket, key string, upd GCSObjectUpdate) (*ObjectInfo, error)
+	// custom metadata without touching its data, bumping metageneration; a failed
+	// pre returns a *GCSPreconditionError.
+	UpdateObjectGCS(ctx context.Context, bucket, key string, upd GCSObjectUpdate, pre GCSPrecondition) (*ObjectInfo, error)
 	// ComposeObjectGCS concatenates the source objects' bytes (in order) into
-	// dstKey, minting a new generation for the destination.
+	// dstKey, minting a new generation for the destination and honoring the
+	// destination pre and each source's pinned generation.
 	ComposeObjectGCS(
-		ctx context.Context, bucket, dstKey string, srcKeys []string, contentType string, metadata map[string]string,
+		ctx context.Context, bucket, dstKey string, srcs []GCSComposeSource,
+		contentType string, metadata map[string]string, pre GCSPrecondition,
 	) (*ObjectInfo, error)
 	// ListObjectGenerations returns every generation (current + archived) of the
 	// objects matching opts, for a versions=true listing.


### PR DESCRIPTION
Confirming re-audit residue for GCS object semantics — 2 HIGH (incl. a versioned-delete data-loss bug) plus 5 MED/LOW, concentrated in the read/delete/update/compose precondition surface, versioning, and insert-time system properties. Every behavior cross-checked against the official GCS JSON API docs.

## Bugs fixed

- **[HIGH — data-integrity] Delete precondition not enforced.** `deleteObject` ignored `ifGenerationMatch`/`ifMetagenerationMatch` (+`?generation`). Now routed through a preconditioned delete; mismatch → 412 `conditionNotMet` with the object untouched.
- **[HIGH — DATA LOSS] Versioned delete lost data.** A live `DELETE` on a versioning-enabled bucket unconditionally removed the key (archival only happened on overwrite). Now the current generation is archived as noncurrent, and `list?versions=true` surfaces archived generations of keys that are no longer live. A generation-addressed delete stays permanent (matching GCS).
- **[MED] Insert-time object system properties dropped.** `cacheControl`/`contentEncoding`/`contentDisposition`/`contentLanguage` are now parsed in the multipart metadata and threaded through `storeObject` → `PutObjectGCS` (new `GCSObjectAttrs`) so they persist at INSERT.
- **[MED] `?generation` ignored on read.** `Attrs` and media download now honor `?generation`, reading the addressed revision from live/archived generations.
- **[MED] Conditional read preconditions ignored.** Read handlers now evaluate `ifGenerationMatch`/`ifMetagenerationMatch` (412) and the NotMatch variants (304), consulting both query params (JSON) and `x-goog-if-*` headers (media download).
- **[MED] Object update/patch precondition ignored.** `UpdateObjectGCS` now enforces the precondition → 412.
- **[LOW] Compose destination precondition + source generations ignored.** Compose threads the destination precondition (DoesNotExist/`ifGenerationMatch`) and honors each source's pinned generation.
- **[LOW] Object `storageClass` hardcoded STANDARD.** Objects now store a storage class, defaulting to the bucket's default class, and surface it on read.

## Layering
Driver `GCSExtensions` extended (new `DeleteObjectGCS`/`GetObjectGCS`/`HeadObjectGCS`; `PutObjectGCS`/`UpdateObjectGCS`/`ComposeObjectGCS` take preconditions/attrs/pinned generations). Provider implements archival + generation addressing; wire handler parses params/headers and maps `GCSPreconditionError` → HTTP 412. Prior-round fixes (write preconditions, generation minting, checksums, patch-merge, versioned-list-on-overwrite, bucket attrs/IAM) preserved and still green.

## Tests
Real `cloud.google.com/go/storage` reproductions added: delete-with-mismatched-`ifGenerationMatch` (412, survives), versioned live delete retains 2 noncurrent generations, insert-time system props round-trip, `Generation(gen1).NewReader` → v1 bytes, conditional read mismatch → 412, update bad `MetagenerationMatch` → 412, compose DoesNotExist over existing dst → 412, NEARLINE bucket → object `StorageClass=NEARLINE`.

Gates: build, vet, `-race`, target tests, `golangci-lint` (0 new), gofmt, `go generate` (coverage docs regenerated), and compatgen (no `docs/compat` diff) all green.