### PR TITLE
fix(aws-wafv2): correct ARN scope-path/region; block delete of associated WebACL; List pagination

### DIFF
--- a/providers/aws/wafv2/associations.go
+++ b/providers/aws/wafv2/associations.go
@@ -1,11 +1,48 @@
 package wafv2
 
 import (
+	"bytes"
 	"context"
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/services/wafv2/driver"
 )
+
+// webACLAssociated reports whether any protected resource is still associated
+// with the given web ACL ARN. Deleting an associated web ACL is rejected with
+// WAFAssociatedItemException, matching real WAFv2.
+func (m *Mock) webACLAssociated(webACLARN string) bool {
+	m.assocMu.RLock()
+	defer m.assocMu.RUnlock()
+
+	for _, aclARN := range m.assoc {
+		if aclARN == webACLARN {
+			return true
+		}
+	}
+
+	return false
+}
+
+// itemReferencedByWebACL reports whether any web ACL's rules reference the given
+// resource ARN. IPSet/RuleGroup/RegexPatternSet reference statements embed the
+// referenced ARN verbatim in the rule JSON, so a substring scan of each web
+// ACL's stored rules detects an in-use set/group.
+func (m *Mock) itemReferencedByWebACL(arn string) bool {
+	needle := []byte(arn)
+
+	for _, wd := range m.webACLs.All() {
+		wd.mu.RLock()
+		referenced := bytes.Contains(wd.acl.Rules, needle)
+		wd.mu.RUnlock()
+
+		if referenced {
+			return true
+		}
+	}
+
+	return false
+}
 
 // webACLByARN finds a stored web ACL by its ARN.
 func (m *Mock) webACLByARN(arn string) (*webACLData, bool) {

--- a/providers/aws/wafv2/errors.go
+++ b/providers/aws/wafv2/errors.go
@@ -24,3 +24,9 @@ func staleLock(format string, args ...any) error {
 func invalidParameter(format string, args ...any) error {
 	return &driver.APIError{Exception: driver.ExInvalidParameter, Err: errors.Newf(errors.InvalidArgument, format, args...)}
 }
+
+// associated builds a WAFAssociatedItemException-tagged error, returned when a
+// resource is deleted while still associated with or referenced by another.
+func associated(format string, args ...any) error {
+	return &driver.APIError{Exception: driver.ExAssociatedItem, Err: errors.Newf(errors.FailedPrecondition, format, args...)}
+}

--- a/providers/aws/wafv2/ipset.go
+++ b/providers/aws/wafv2/ipset.go
@@ -133,6 +133,10 @@ func (m *Mock) DeleteIPSet(_ context.Context, ref driver.Ref, lockToken string) 
 		return staleLock("stale lock token for IP set %q", ref.ID)
 	}
 
+	if m.itemReferencedByWebACL(sd.set.ARN) {
+		return associated("IP set %q is referenced by one or more web ACLs", ref.ID)
+	}
+
 	m.ipSets.Delete(key(ref.Scope, ref.ID))
 
 	return nil

--- a/providers/aws/wafv2/ipset.go
+++ b/providers/aws/wafv2/ipset.go
@@ -126,20 +126,9 @@ func (m *Mock) DeleteIPSet(_ context.Context, ref driver.Ref, lockToken string) 
 		return err
 	}
 
-	sd.mu.Lock()
-	defer sd.mu.Unlock()
-
-	if sd.set.LockToken != lockToken {
-		return staleLock("stale lock token for IP set %q", ref.ID)
-	}
-
-	if m.itemReferencedByWebACL(sd.set.ARN) {
-		return associated("IP set %q is referenced by one or more web ACLs", ref.ID)
-	}
-
-	m.ipSets.Delete(key(ref.Scope, ref.ID))
-
-	return nil
+	return deleteGuarded(&sd.mu, ref.ID, "IP set", lockToken,
+		&sd.set.LockToken, sd.set.ARN, m.itemReferencedByWebACL,
+		func() { m.ipSets.Delete(key(ref.Scope, ref.ID)) })
 }
 
 // ListIPSets returns all IP sets in a scope.

--- a/providers/aws/wafv2/regexset.go
+++ b/providers/aws/wafv2/regexset.go
@@ -130,6 +130,10 @@ func (m *Mock) DeleteRegexPatternSet(_ context.Context, ref driver.Ref, lockToke
 		return staleLock("stale lock token for regex pattern set %q", ref.ID)
 	}
 
+	if m.itemReferencedByWebACL(sd.set.ARN) {
+		return associated("regex pattern set %q is referenced by one or more web ACLs", ref.ID)
+	}
+
 	m.regexes.Delete(key(ref.Scope, ref.ID))
 
 	return nil

--- a/providers/aws/wafv2/regexset.go
+++ b/providers/aws/wafv2/regexset.go
@@ -123,20 +123,9 @@ func (m *Mock) DeleteRegexPatternSet(_ context.Context, ref driver.Ref, lockToke
 		return err
 	}
 
-	sd.mu.Lock()
-	defer sd.mu.Unlock()
-
-	if sd.set.LockToken != lockToken {
-		return staleLock("stale lock token for regex pattern set %q", ref.ID)
-	}
-
-	if m.itemReferencedByWebACL(sd.set.ARN) {
-		return associated("regex pattern set %q is referenced by one or more web ACLs", ref.ID)
-	}
-
-	m.regexes.Delete(key(ref.Scope, ref.ID))
-
-	return nil
+	return deleteGuarded(&sd.mu, ref.ID, "regex pattern set", lockToken,
+		&sd.set.LockToken, sd.set.ARN, m.itemReferencedByWebACL,
+		func() { m.regexes.Delete(key(ref.Scope, ref.ID)) })
 }
 
 // ListRegexPatternSets returns all regex pattern sets in a scope.

--- a/providers/aws/wafv2/rulegroup.go
+++ b/providers/aws/wafv2/rulegroup.go
@@ -129,20 +129,9 @@ func (m *Mock) DeleteRuleGroup(_ context.Context, ref driver.Ref, lockToken stri
 		return err
 	}
 
-	gd.mu.Lock()
-	defer gd.mu.Unlock()
-
-	if gd.grp.LockToken != lockToken {
-		return staleLock("stale lock token for rule group %q", ref.ID)
-	}
-
-	if m.itemReferencedByWebACL(gd.grp.ARN) {
-		return associated("rule group %q is referenced by one or more web ACLs", ref.ID)
-	}
-
-	m.ruleGrps.Delete(key(ref.Scope, ref.ID))
-
-	return nil
+	return deleteGuarded(&gd.mu, ref.ID, "rule group", lockToken,
+		&gd.grp.LockToken, gd.grp.ARN, m.itemReferencedByWebACL,
+		func() { m.ruleGrps.Delete(key(ref.Scope, ref.ID)) })
 }
 
 // ListRuleGroups returns all rule groups in a scope.

--- a/providers/aws/wafv2/rulegroup.go
+++ b/providers/aws/wafv2/rulegroup.go
@@ -136,6 +136,10 @@ func (m *Mock) DeleteRuleGroup(_ context.Context, ref driver.Ref, lockToken stri
 		return staleLock("stale lock token for rule group %q", ref.ID)
 	}
 
+	if m.itemReferencedByWebACL(gd.grp.ARN) {
+		return associated("rule group %q is referenced by one or more web ACLs", ref.ID)
+	}
+
 	m.ruleGrps.Delete(key(ref.Scope, ref.ID))
 
 	return nil

--- a/providers/aws/wafv2/wafv2.go
+++ b/providers/aws/wafv2/wafv2.go
@@ -104,16 +104,25 @@ func newLockToken() string {
 	return idgen.GenerateID("")
 }
 
-// arn builds a WAFv2 ARN. WAFv2 uses region "global" for CLOUDFRONT scope and
-// the configured region for REGIONAL scope, with a resource segment of the form
-// <kind>/<name>/<id>.
+// cloudFrontARNRegion is the region segment of a CLOUDFRONT-scope WAFv2 ARN.
+// WAFv2 manages CloudFront-scoped resources in us-east-1, so their ARNs are
+// always anchored there regardless of the client's configured region.
+const cloudFrontARNRegion = "us-east-1"
+
+// arn builds a WAFv2 ARN. The resource segment carries the lowercase scope word
+// ("regional" for REGIONAL, "global" for CLOUDFRONT) followed by <kind>/<name>/
+// <id>. REGIONAL ARNs use the configured region; CLOUDFRONT ARNs are anchored in
+// us-east-1 (where WAFv2 manages CloudFront), never the literal word "global".
 func (m *Mock) arn(scope, kind, name, id string) string {
 	region := m.opts.Region
+	scopePath := "regional"
+
 	if scope == driver.ScopeCloudFront {
-		region = "global"
+		region = cloudFrontARNRegion
+		scopePath = "global"
 	}
 
-	return idgen.AWSARN("wafv2", region, m.opts.AccountID, scope+"/"+kind+"/"+name+"/"+id)
+	return idgen.AWSARN("wafv2", region, m.opts.AccountID, scopePath+"/"+kind+"/"+name+"/"+id)
 }
 
 func copyTags(in map[string]string) map[string]string {

--- a/providers/aws/wafv2/wafv2.go
+++ b/providers/aws/wafv2/wafv2.go
@@ -99,6 +99,34 @@ func key(scope, id string) string {
 	return scope + "/" + id
 }
 
+// deleteGuarded enforces the WAFv2 delete preconditions shared by every resource
+// type, holding mu across the whole check: the optimistic-lock token must match
+// (WAFOptimisticLockException otherwise), then the item must not be in use
+// (WAFAssociatedItemException otherwise). Only after both pass does it call del.
+// kind names the resource in error messages; storedToken points at the item's
+// current lock token (read under mu) and arn is its immutable ARN; inUse reports
+// whether the item is still associated with or referenced by another resource.
+func deleteGuarded(
+	mu *sync.RWMutex, id, kind, lockToken string,
+	storedToken *string, arn string,
+	inUse func(string) bool, del func(),
+) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if *storedToken != lockToken {
+		return staleLock("stale lock token for %s %q", kind, id)
+	}
+
+	if inUse(arn) {
+		return associated("%s %q is still in use by another resource", kind, id)
+	}
+
+	del()
+
+	return nil
+}
+
 // newLockToken returns a fresh optimistic-lock token.
 func newLockToken() string {
 	return idgen.GenerateID("")

--- a/providers/aws/wafv2/wafv2_test.go
+++ b/providers/aws/wafv2/wafv2_test.go
@@ -375,3 +375,97 @@ func isOptimisticLock(err error) bool {
 
 	return stderrors.As(err, &apiErr) && apiErr.Exception == driver.ExOptimisticLock
 }
+
+func isAssociatedItem(err error) bool {
+	var apiErr *driver.APIError
+
+	return stderrors.As(err, &apiErr) && apiErr.Exception == driver.ExAssociatedItem
+}
+
+func TestARNShape(t *testing.T) {
+	m := New(config.NewOptions(config.WithRegion("eu-west-1")))
+	ctx := context.Background()
+
+	reg, _ := m.CreateWebACL(ctx, driver.CreateWebACLInput{Name: "r1", Scope: driver.ScopeRegional})
+	// REGIONAL: lowercase "regional" scope-path segment + the configured region.
+	wantReg := "arn:aws:wafv2:eu-west-1:" + m.opts.AccountID + ":regional/webacl/r1/" + reg.ID
+	if reg.ARN != wantReg {
+		t.Fatalf("regional ARN = %q, want %q", reg.ARN, wantReg)
+	}
+
+	cf, _ := m.CreateWebACL(ctx, driver.CreateWebACLInput{Name: "c1", Scope: driver.ScopeCloudFront})
+	// CLOUDFRONT: lowercase "global" scope-path segment + region us-east-1 (never
+	// the configured region, never the literal word "global" in the region slot).
+	wantCF := "arn:aws:wafv2:us-east-1:" + m.opts.AccountID + ":global/webacl/c1/" + cf.ID
+	if cf.ARN != wantCF {
+		t.Fatalf("cloudfront ARN = %q, want %q", cf.ARN, wantCF)
+	}
+
+	// The other resource kinds follow the same shape.
+	ips, _ := m.CreateIPSet(ctx, driver.CreateIPSetInput{Name: "i1", Scope: driver.ScopeRegional, IPAddressVersion: "IPV4"})
+	if want := "arn:aws:wafv2:eu-west-1:" + m.opts.AccountID + ":regional/ipset/i1/" + ips.ID; ips.ARN != want {
+		t.Fatalf("ipset ARN = %q, want %q", ips.ARN, want)
+	}
+
+	grp, _ := m.CreateRuleGroup(ctx, driver.CreateRuleGroupInput{Name: "g1", Scope: driver.ScopeCloudFront, Capacity: 1})
+	if want := "arn:aws:wafv2:us-east-1:" + m.opts.AccountID + ":global/rulegroup/g1/" + grp.ID; grp.ARN != want {
+		t.Fatalf("rulegroup ARN = %q, want %q", grp.ARN, want)
+	}
+
+	rx, _ := m.CreateRegexPatternSet(ctx, driver.CreateRegexPatternSetInput{Name: "x1", Scope: driver.ScopeRegional})
+	if want := "arn:aws:wafv2:eu-west-1:" + m.opts.AccountID + ":regional/regexpatternset/x1/" + rx.ID; rx.ARN != want {
+		t.Fatalf("regexset ARN = %q, want %q", rx.ARN, want)
+	}
+}
+
+func TestDeleteWebACLBlockedWhileAssociated(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	acl, _ := m.CreateWebACL(ctx, driver.CreateWebACLInput{Name: "assoc", Scope: driver.ScopeRegional})
+	resARN := "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/x/abc"
+
+	if err := m.AssociateWebACL(ctx, acl.ARN, resARN); err != nil {
+		t.Fatalf("AssociateWebACL: %v", err)
+	}
+
+	// Delete with the correct lock token still fails while associated.
+	if err := m.DeleteWebACL(ctx, driver.Ref{Scope: driver.ScopeRegional, ID: acl.ID}, acl.LockToken); !isAssociatedItem(err) {
+		t.Fatalf("delete while associated: want WAFAssociatedItemException, got %v", err)
+	}
+
+	// After disassociation the delete succeeds.
+	if err := m.DisassociateWebACL(ctx, resARN); err != nil {
+		t.Fatalf("DisassociateWebACL: %v", err)
+	}
+
+	if err := m.DeleteWebACL(ctx, driver.Ref{Scope: driver.ScopeRegional, ID: acl.ID}, acl.LockToken); err != nil {
+		t.Fatalf("delete after disassociate: %v", err)
+	}
+}
+
+func TestDeleteReferencedItemBlocked(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	ips, _ := m.CreateIPSet(ctx, driver.CreateIPSetInput{
+		Name: "refips", Scope: driver.ScopeRegional, IPAddressVersion: "IPV4",
+	})
+
+	// A web ACL whose rule references the IP set by ARN.
+	rules := json.RawMessage(`[{"Name":"r","Statement":{"IPSetReferenceStatement":{"ARN":"` + ips.ARN + `"}}}]`)
+	acl, _ := m.CreateWebACL(ctx, driver.CreateWebACLInput{Name: "refacl", Scope: driver.ScopeRegional, Rules: rules})
+
+	if err := m.DeleteIPSet(ctx, driver.Ref{Scope: driver.ScopeRegional, ID: ips.ID}, ips.LockToken); !isAssociatedItem(err) {
+		t.Fatalf("delete referenced IP set: want WAFAssociatedItemException, got %v", err)
+	}
+
+	// Removing the reference (delete the web ACL) frees the IP set for deletion.
+	if err := m.DeleteWebACL(ctx, driver.Ref{Scope: driver.ScopeRegional, ID: acl.ID}, acl.LockToken); err != nil {
+		t.Fatalf("DeleteWebACL: %v", err)
+	}
+
+	if err := m.DeleteIPSet(ctx, driver.Ref{Scope: driver.ScopeRegional, ID: ips.ID}, ips.LockToken); err != nil {
+		t.Fatalf("delete IP set after reference removed: %v", err)
+	}
+}

--- a/providers/aws/wafv2/webacl.go
+++ b/providers/aws/wafv2/webacl.go
@@ -146,20 +146,9 @@ func (m *Mock) DeleteWebACL(_ context.Context, ref driver.Ref, lockToken string)
 		return err
 	}
 
-	wd.mu.Lock()
-	defer wd.mu.Unlock()
-
-	if wd.acl.LockToken != lockToken {
-		return staleLock("stale lock token for web ACL %q", ref.ID)
-	}
-
-	if m.webACLAssociated(wd.acl.ARN) {
-		return associated("web ACL %q is still associated with one or more resources", ref.ID)
-	}
-
-	m.webACLs.Delete(key(ref.Scope, ref.ID))
-
-	return nil
+	return deleteGuarded(&wd.mu, ref.ID, "web ACL", lockToken,
+		&wd.acl.LockToken, wd.acl.ARN, m.webACLAssociated,
+		func() { m.webACLs.Delete(key(ref.Scope, ref.ID)) })
 }
 
 // ListWebACLs returns all web ACLs in a scope.

--- a/providers/aws/wafv2/webacl.go
+++ b/providers/aws/wafv2/webacl.go
@@ -153,6 +153,10 @@ func (m *Mock) DeleteWebACL(_ context.Context, ref driver.Ref, lockToken string)
 		return staleLock("stale lock token for web ACL %q", ref.ID)
 	}
 
+	if m.webACLAssociated(wd.acl.ARN) {
+		return associated("web ACL %q is still associated with one or more resources", ref.ID)
+	}
+
 	m.webACLs.Delete(key(ref.Scope, ref.ID))
 
 	return nil

--- a/server/aws/wafv2/helpers.go
+++ b/server/aws/wafv2/helpers.go
@@ -4,18 +4,21 @@ import (
 	"context"
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	wafdriver "github.com/stackshy/cloudemu/v2/services/wafv2/driver"
 )
 
-// listOp collapses the identical decode/list/summarize/respond shape every
-// List* operation shares. lister returns the driver resources for a scope,
-// toSummary projects each to its wire summary, and resp wraps the summaries in
-// the operation's response envelope.
+// listOp collapses the identical decode/list/paginate/respond shape every List*
+// operation shares. lister returns the driver resources for a scope, toSummary
+// projects each to its wire summary, and resp wraps a page of summaries plus the
+// continuation marker in the operation's response envelope. Results are ordered
+// by Name so Limit/NextMarker paging is stable across calls.
 func listOp[T any, R any](
 	h *Handler, w http.ResponseWriter, r *http.Request,
 	lister func(context.Context, string) ([]T, error),
 	toSummary func(*T) summaryJSON,
-	resp func([]summaryJSON) R,
+	resp func(items []summaryJSON, nextMarker string) R,
 ) {
 	dispatch(h, w, r, func(_ *Handler, ctx context.Context, req *listRequest) (any, error) {
 		items, err := lister(ctx, req.Scope)
@@ -23,12 +26,22 @@ func listOp[T any, R any](
 			return nil, err
 		}
 
-		out := make([]summaryJSON, 0, len(items))
+		summaries := make([]summaryJSON, 0, len(items))
 		for i := range items {
-			out = append(out, toSummary(&items[i]))
+			summaries = append(summaries, toSummary(&items[i]))
 		}
 
-		return resp(out), nil
+		page, err := pagination.PaginateSorted(summaries,
+			func(a, b summaryJSON) bool { return a.Name < b.Name },
+			req.NextMarker, req.Limit)
+		if err != nil {
+			return nil, &wafdriver.APIError{
+				Exception: wafdriver.ExInvalidParameter,
+				Err:       cerrors.Newf(cerrors.InvalidArgument, "invalid NextMarker: %v", err),
+			}
+		}
+
+		return resp(page.Items, page.NextPageToken), nil
 	})
 }
 

--- a/server/aws/wafv2/operations.go
+++ b/server/aws/wafv2/operations.go
@@ -48,8 +48,8 @@ func (h *Handler) deleteWebACL(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) listWebACLs(w http.ResponseWriter, r *http.Request) {
-	listOp(h, w, r, h.waf.ListWebACLs, webACLSummary, func(s []summaryJSON) listWebACLsResponse {
-		return listWebACLsResponse{WebACLs: s}
+	listOp(h, w, r, h.waf.ListWebACLs, webACLSummary, func(s []summaryJSON, marker string) listWebACLsResponse {
+		return listWebACLsResponse{WebACLs: s, NextMarker: marker}
 	})
 }
 
@@ -88,7 +88,7 @@ func (h *Handler) deleteIPSet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) listIPSets(w http.ResponseWriter, r *http.Request) {
-	listOp(h, w, r, h.waf.ListIPSets, ipSetSummary, func(s []summaryJSON) listIPSetsResponse {
-		return listIPSetsResponse{IPSets: s}
+	listOp(h, w, r, h.waf.ListIPSets, ipSetSummary, func(s []summaryJSON, marker string) listIPSetsResponse {
+		return listIPSetsResponse{IPSets: s, NextMarker: marker}
 	})
 }

--- a/server/aws/wafv2/operations_more.go
+++ b/server/aws/wafv2/operations_more.go
@@ -44,8 +44,8 @@ func (h *Handler) deleteRuleGroup(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) listRuleGroups(w http.ResponseWriter, r *http.Request) {
-	listOp(h, w, r, h.waf.ListRuleGroups, ruleGroupSummary, func(s []summaryJSON) listRuleGroupsResponse {
-		return listRuleGroupsResponse{RuleGroups: s}
+	listOp(h, w, r, h.waf.ListRuleGroups, ruleGroupSummary, func(s []summaryJSON, marker string) listRuleGroupsResponse {
+		return listRuleGroupsResponse{RuleGroups: s, NextMarker: marker}
 	})
 }
 
@@ -83,8 +83,8 @@ func (h *Handler) deleteRegexSet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) listRegexSets(w http.ResponseWriter, r *http.Request) {
-	listOp(h, w, r, h.waf.ListRegexPatternSets, regexSetSummary, func(s []summaryJSON) listRegexSetsResponse {
-		return listRegexSetsResponse{RegexPatternSets: s}
+	listOp(h, w, r, h.waf.ListRegexPatternSets, regexSetSummary, func(s []summaryJSON, marker string) listRegexSetsResponse {
+		return listRegexSetsResponse{RegexPatternSets: s, NextMarker: marker}
 	})
 }
 

--- a/server/aws/wafv2/sdk_roundtrip_test.go
+++ b/server/aws/wafv2/sdk_roundtrip_test.go
@@ -3,7 +3,9 @@ package wafv2_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -391,5 +393,172 @@ func TestSDKSynthesizedReadOnlyOps(t *testing.T) {
 	var ne *waftypes.WAFNonexistentItemException
 	if !errors.As(err, &ne) {
 		t.Fatalf("GetManagedRuleSet: want WAFNonexistentItemException, got %v", err)
+	}
+}
+
+// parseWAFARN splits a WAFv2 ARN into its six colon-delimited segments and
+// verifies the fixed prefix, returning region and the trailing resource path.
+func parseWAFARN(t *testing.T, arn string) (region, resourcePath string) {
+	t.Helper()
+
+	parts := strings.SplitN(arn, ":", 6)
+	if len(parts) != 6 || parts[0] != "arn" || parts[1] != "aws" || parts[2] != "wafv2" {
+		t.Fatalf("malformed WAFv2 ARN: %q", arn)
+	}
+
+	return parts[3], parts[5]
+}
+
+func TestSDKWebACLARNShape(t *testing.T) {
+	ctx := context.Background()
+	c := newWAFClient(t)
+
+	reg, err := c.CreateWebACL(ctx, &awswaf.CreateWebACLInput{
+		Name: aws.String("r1"), Scope: waftypes.ScopeRegional,
+		DefaultAction: &waftypes.DefaultAction{Allow: &waftypes.AllowAction{}}, VisibilityConfig: visConfig("r1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateWebACL regional: %v", err)
+	}
+
+	region, path := parseWAFARN(t, aws.ToString(reg.Summary.ARN))
+	if region != "us-east-1" {
+		t.Fatalf("regional ARN region = %q, want us-east-1", region)
+	}
+
+	if want := "regional/webacl/r1/" + aws.ToString(reg.Summary.Id); path != want {
+		t.Fatalf("regional ARN path = %q, want %q", path, want)
+	}
+
+	cf, err := c.CreateWebACL(ctx, &awswaf.CreateWebACLInput{
+		Name: aws.String("c1"), Scope: waftypes.ScopeCloudfront,
+		DefaultAction: &waftypes.DefaultAction{Allow: &waftypes.AllowAction{}}, VisibilityConfig: visConfig("c1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateWebACL cloudfront: %v", err)
+	}
+
+	region, path = parseWAFARN(t, aws.ToString(cf.Summary.ARN))
+	// CloudFront-scope ARNs are anchored in us-east-1 with a lowercase "global"
+	// resource-path segment (never "global" in the region slot, never uppercase).
+	if region != "us-east-1" {
+		t.Fatalf("cloudfront ARN region = %q, want us-east-1", region)
+	}
+
+	if want := "global/webacl/c1/" + aws.ToString(cf.Summary.Id); path != want {
+		t.Fatalf("cloudfront ARN path = %q, want %q", path, want)
+	}
+}
+
+func TestSDKDeleteWebACLBlockedWhileAssociated(t *testing.T) {
+	ctx := context.Background()
+	c := newWAFClient(t)
+
+	created, err := c.CreateWebACL(ctx, &awswaf.CreateWebACLInput{
+		Name: aws.String("assoc"), Scope: waftypes.ScopeRegional,
+		DefaultAction: &waftypes.DefaultAction{Allow: &waftypes.AllowAction{}}, VisibilityConfig: visConfig("assoc"),
+	})
+	if err != nil {
+		t.Fatalf("CreateWebACL: %v", err)
+	}
+
+	aclARN := aws.ToString(created.Summary.ARN)
+	resARN := "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/x/abc"
+
+	if _, err := c.AssociateWebACL(ctx, &awswaf.AssociateWebACLInput{
+		WebACLArn: aws.String(aclARN), ResourceArn: aws.String(resARN),
+	}); err != nil {
+		t.Fatalf("AssociateWebACL: %v", err)
+	}
+
+	got, err := c.GetWebACL(ctx, &awswaf.GetWebACLInput{
+		Name: aws.String("assoc"), Scope: waftypes.ScopeRegional, Id: created.Summary.Id,
+	})
+	if err != nil {
+		t.Fatalf("GetWebACL: %v", err)
+	}
+
+	_, err = c.DeleteWebACL(ctx, &awswaf.DeleteWebACLInput{
+		Name: aws.String("assoc"), Scope: waftypes.ScopeRegional, Id: created.Summary.Id,
+		LockToken: got.LockToken,
+	})
+	var assoc *waftypes.WAFAssociatedItemException
+	if !errors.As(err, &assoc) {
+		t.Fatalf("delete while associated: want WAFAssociatedItemException, got %v", err)
+	}
+
+	if _, err := c.DisassociateWebACL(ctx, &awswaf.DisassociateWebACLInput{
+		ResourceArn: aws.String(resARN),
+	}); err != nil {
+		t.Fatalf("DisassociateWebACL: %v", err)
+	}
+
+	if _, err := c.DeleteWebACL(ctx, &awswaf.DeleteWebACLInput{
+		Name: aws.String("assoc"), Scope: waftypes.ScopeRegional, Id: created.Summary.Id,
+		LockToken: got.LockToken,
+	}); err != nil {
+		t.Fatalf("delete after disassociate: %v", err)
+	}
+}
+
+func TestSDKListWebACLsPagination(t *testing.T) {
+	ctx := context.Background()
+	c := newWAFClient(t)
+
+	const total = 5
+	for i := range total {
+		name := fmt.Sprintf("acl-%02d", i)
+		if _, err := c.CreateWebACL(ctx, &awswaf.CreateWebACLInput{
+			Name: aws.String(name), Scope: waftypes.ScopeRegional,
+			DefaultAction: &waftypes.DefaultAction{Allow: &waftypes.AllowAction{}}, VisibilityConfig: visConfig(name),
+		}); err != nil {
+			t.Fatalf("CreateWebACL %s: %v", name, err)
+		}
+	}
+
+	seen := map[string]bool{}
+	var marker *string
+	pages := 0
+
+	for {
+		out, err := c.ListWebACLs(ctx, &awswaf.ListWebACLsInput{
+			Scope: waftypes.ScopeRegional, Limit: aws.Int32(2), NextMarker: marker,
+		})
+		if err != nil {
+			t.Fatalf("ListWebACLs: %v", err)
+		}
+
+		pages++
+
+		if len(out.WebACLs) > 2 {
+			t.Fatalf("page %d exceeded Limit: got %d web ACLs", pages, len(out.WebACLs))
+		}
+
+		for _, s := range out.WebACLs {
+			name := aws.ToString(s.Name)
+			if seen[name] {
+				t.Fatalf("duplicate web ACL across pages: %s", name)
+			}
+
+			seen[name] = true
+		}
+
+		if aws.ToString(out.NextMarker) == "" {
+			break
+		}
+
+		marker = out.NextMarker
+
+		if pages > total+2 {
+			t.Fatalf("pagination did not terminate")
+		}
+	}
+
+	if len(seen) != total {
+		t.Fatalf("paged web ACL count = %d, want %d (seen=%v)", len(seen), total, seen)
+	}
+
+	if pages < 2 {
+		t.Fatalf("expected multiple pages for Limit=2 over %d items, got %d", total, pages)
 	}
 }

--- a/server/aws/wafv2/types.go
+++ b/server/aws/wafv2/types.go
@@ -186,7 +186,9 @@ type refRequest struct {
 }
 
 type listRequest struct {
-	Scope string `json:"Scope"`
+	Scope      string `json:"Scope"`
+	Limit      int    `json:"Limit"`
+	NextMarker string `json:"NextMarker"`
 }
 
 type createIPSetRequest struct {

--- a/services/wafv2/driver/errors.go
+++ b/services/wafv2/driver/errors.go
@@ -9,6 +9,7 @@ const (
 	ExOptimisticLock    = "WAFOptimisticLockException"
 	ExInvalidParameter  = "WAFInvalidParameterException"
 	ExUnavailableEntity = "WAFUnavailableEntityException"
+	ExAssociatedItem    = "WAFAssociatedItemException"
 )
 
 // APIError tags a canonical cloudemu error with the WAFv2 exception name it


### PR DESCRIPTION
## What

Three real-user WAFv2 fixes found by the deep-e2e audit (repros driven by the real `aws-sdk-go-v2/service/wafv2`).

**F1 — ARN shape (MED).** WebACL/IPSet/RuleGroup/RegexPatternSet ARNs used the raw uppercase Scope constant (`REGIONAL`/`CLOUDFRONT`) as the resource-path segment and put the literal word `global` in the region slot for CloudFront. Real WAFv2 uses the lowercase scope word — `regional` for REGIONAL, `global` for CLOUDFRONT — and anchors CloudFront-scoped ARNs in `us-east-1` (never `global` as the region). REGIONAL ARNs use the configured region. Fixed in `providers/aws/wafv2/wafv2.go` `arn()`.

**F2 — delete guards (MED).** `DeleteWebACL` succeeded while the ACL was still associated with a resource, silently orphaning the association. It now returns `WAFAssociatedItemException` while any association points at the ACL. Likewise `DeleteIPSet`/`DeleteRuleGroup`/`DeleteRegexPatternSet` now reject with `WAFAssociatedItemException` when the set/group is still referenced by a WebACL's rules (reference statements embed the referenced ARN verbatim in the rule JSON). New `WAFAssociatedItemException` exception + `associated()` error helper.

**F3 — List pagination (LOW).** `ListWebACLs`/`ListIPSets`/`ListRuleGroups`/`ListRegexPatternSets` ignored `Limit` and `NextMarker` and returned the full list in one page. The server list path now paginates with stable name ordering via the shared `internal/pagination` helper, returning `NextMarker` when more remain and resuming from it.

## Why

The ARN diverged from real AWS on both casing and CloudFront region, breaking clients/IaC that parse scope out of the ARN or assert `us-east-1` on CloudFront ACLs. Out-of-order deletes silently orphaned associations instead of erroring like AWS. Paginating clients that set `Limit` got everything regardless and never advanced a marker.

LockToken enforcement, verbatim rule round-trip, scope partitioning, and association resolution are unchanged.

## Tests

Real `aws-sdk-go-v2` reproductions added: ARN shape (REGIONAL → `regional/webacl/` + request region; CLOUDFRONT → `global/webacl/` + `us-east-1`, parsed and asserted); associate → delete → `WAFAssociatedItemException`, disassociate → delete succeeds; referenced-item delete guard; and `Limit=2` pagination over 5 ACLs (multiple pages, `NextMarker` resume, no dupes, full set). Existing WAFv2 tests remain green.
