### PR TITLE
fix(aws-msk): reflect UpdateBrokerStorage in Describe; ZookeeperConnectString; operation source/target deltas

### DIFF
--- a/providers/aws/kafka/cluster_updates.go
+++ b/providers/aws/kafka/cluster_updates.go
@@ -53,13 +53,17 @@ func (m *Mock) UpdateBrokerCount(
 	})
 }
 
-// UpdateBrokerStorage carries the requested storage change verbatim into the
-// cluster's raw options so a subsequent Describe reflects it.
+// UpdateBrokerStorage rewrites the broker EBS volume size from the request's
+// targetBrokerEBSVolumeInfo[ALL].volumeSizeGB so a subsequent DescribeCluster
+// reflects the new size (real MSK surfaces it under
+// brokerNodeGroupInfo.storageInfo.ebsStorageInfo.volumeSize).
 func (m *Mock) UpdateBrokerStorage(
 	_ context.Context, arn, currentVersion string, body json.RawMessage,
 ) (*driver.ClusterOperation, error) {
 	return m.mutateClusterBR(arn, currentVersion, opTypeUpdateBrokerStorage, func(c *driver.Cluster) {
-		setRawOption(c, "targetBrokerEBSVolumeInfo", body)
+		if size, ok := targetVolumeSizeGB(body); ok {
+			applyStorageVolume(c, size)
+		}
 	})
 }
 
@@ -90,7 +94,9 @@ func (m *Mock) UpdateStorage(
 			c.StorageMode = mode
 		}
 
-		setRawOption(c, "storageUpdate", body)
+		if size, ok := int64Field(body, "volumeSizeGB"); ok {
+			applyStorageVolume(c, size)
+		}
 	})
 }
 
@@ -203,6 +209,98 @@ func stringField(body json.RawMessage, key string) string {
 	}
 
 	return s
+}
+
+// int64Field extracts a top-level integer field from a JSON body, reporting
+// whether one was present.
+func int64Field(body json.RawMessage, key string) (int64, bool) {
+	if len(body) == 0 {
+		return 0, false
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(body, &m); err != nil {
+		return 0, false
+	}
+
+	raw, ok := m[key]
+	if !ok {
+		return 0, false
+	}
+
+	var n int64
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return 0, false
+	}
+
+	return n, true
+}
+
+// targetVolumeSizeGB extracts the requested EBS volume size from an
+// UpdateBrokerStorage body's targetBrokerEBSVolumeInfo, taking the ALL-broker
+// entry (the only value real MSK allows).
+func targetVolumeSizeGB(body json.RawMessage) (int64, bool) {
+	raw := rawField(body, "targetBrokerEBSVolumeInfo", nil)
+	if len(raw) == 0 {
+		return 0, false
+	}
+
+	var entries []struct {
+		KafkaBrokerNodeID string `json:"kafkaBrokerNodeId"`
+		VolumeSizeGB      *int64 `json:"volumeSizeGB"`
+	}
+
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return 0, false
+	}
+
+	for _, e := range entries {
+		if (e.KafkaBrokerNodeID == "ALL" || e.KafkaBrokerNodeID == "") && e.VolumeSizeGB != nil {
+			return *e.VolumeSizeGB, true
+		}
+	}
+
+	return 0, false
+}
+
+// applyStorageVolume rewrites brokerNodeGroupInfo.storageInfo.ebsStorageInfo.volumeSize
+// to sizeGB, allocating the storageInfo/ebsStorageInfo blocks when absent and
+// preserving any sibling fields (e.g. provisionedThroughput). A non-positive
+// size or a cluster with no broker node group is a no-op.
+func applyStorageVolume(c *driver.Cluster, sizeGB int64) {
+	if sizeGB <= 0 || c.BrokerNodeGroupInfo == nil {
+		return
+	}
+
+	bng := c.BrokerNodeGroupInfo
+
+	storageInfo := decodeObject(bng.RawFields["storageInfo"])
+	ebs := decodeObject(storageInfo["ebsStorageInfo"])
+
+	size, _ := json.Marshal(sizeGB)
+	ebs["volumeSize"] = size
+	storageInfo["ebsStorageInfo"], _ = json.Marshal(ebs)
+
+	if bng.RawFields == nil {
+		bng.RawFields = map[string]json.RawMessage{}
+	}
+
+	bng.RawFields["storageInfo"], _ = json.Marshal(storageInfo)
+}
+
+// decodeObject unmarshals a raw JSON object into a field map, returning a fresh
+// empty map when the input is absent or not an object.
+func decodeObject(raw json.RawMessage) map[string]json.RawMessage {
+	out := map[string]json.RawMessage{}
+	if len(raw) == 0 {
+		return out
+	}
+
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return map[string]json.RawMessage{}
+	}
+
+	return out
 }
 
 // rawField returns the raw JSON of a top-level field, or fallback when absent.

--- a/providers/aws/kafka/clusters.go
+++ b/providers/aws/kafka/clusters.go
@@ -138,7 +138,10 @@ func (m *Mock) getCluster(arn string) (*clusterData, error) {
 // absent. Several ops (GetBootstrapBrokers, ListClusterOperations v1,
 // ListClientVpcConnections, RejectClientVpcConnection, PutClusterPolicy,
 // ListTopics, UpdateBrokerCount/Storage, UpdateMonitoring) reference a cluster
-// but do NOT model NotFoundException, so a missing cluster there is a 400.
+// but do NOT model NotFoundException in the aws-sdk-go-v2 smithy model, so a
+// missing cluster there must be a 400 BadRequestException (a 404 NotFoundException
+// would deserialize as an untyped generic error — the REST API reference lists a
+// generic 404, but the smithy model, which the SDK uses, does not model it here).
 func (m *Mock) getClusterBR(arn string) (*clusterData, error) {
 	return m.getClusterErr(arn, badRequest)
 }

--- a/providers/aws/kafka/kafka_test.go
+++ b/providers/aws/kafka/kafka_test.go
@@ -589,27 +589,80 @@ func TestConcurrentTagNoLostUpdate(t *testing.T) {
 	}
 }
 
-// TestOperationNoAlias asserts DescribeClusterOperation deep-copies RawOptions.
-func TestOperationNoAlias(t *testing.T) {
+// storageVolumeSize parses the EBS volume size from a broker node group's
+// storageInfo raw block, or -1 when absent.
+func storageVolumeSize(t *testing.T, bng *driver.BrokerNodeGroupInfo) int64 {
+	t.Helper()
+
+	if bng == nil {
+		return -1
+	}
+
+	raw, ok := bng.RawFields["storageInfo"]
+	if !ok {
+		return -1
+	}
+
+	var si struct {
+		EBSStorageInfo struct {
+			VolumeSize *int64 `json:"volumeSize"`
+		} `json:"ebsStorageInfo"`
+	}
+
+	if err := json.Unmarshal(raw, &si); err != nil || si.EBSStorageInfo.VolumeSize == nil {
+		return -1
+	}
+
+	return *si.EBSStorageInfo.VolumeSize
+}
+
+// TestUpdateBrokerStorageReflectedInDescribe asserts UpdateBrokerStorage rewrites
+// the broker EBS volume size so a subsequent DescribeCluster reflects it (guards
+// the Terraform storage-drift fix), and that the recorded operation deep-copies
+// its source/target snapshots and carries the before/after delta.
+func TestUpdateBrokerStorageReflectedInDescribe(t *testing.T) {
 	m := newMock(t)
 	ctx := context.Background()
 
-	c, _ := m.CreateCluster(ctx, driver.CreateClusterInput{ClusterName: "op-alias", NumberOfBrokerNodes: 3, BrokerNodeGroupInfo: bng()})
+	c, _ := m.CreateCluster(ctx, driver.CreateClusterInput{
+		ClusterName: "op-alias", NumberOfBrokerNodes: 3,
+		BrokerNodeGroupInfo: &driver.BrokerNodeGroupInfo{
+			InstanceType: "kafka.m5.large",
+			RawFields:    map[string]json.RawMessage{"storageInfo": json.RawMessage(`{"ebsStorageInfo":{"volumeSize":100}}`)},
+		},
+	})
 
-	op, err := m.UpdateBrokerStorage(ctx, c.ClusterARN, c.CurrentVersion, []byte(`{"targetBrokerEBSVolumeInfo":[]}`))
+	op, err := m.UpdateBrokerStorage(ctx, c.ClusterARN, c.CurrentVersion,
+		[]byte(`{"targetBrokerEBSVolumeInfo":[{"kafkaBrokerNodeId":"ALL","volumeSizeGB":200}]}`))
 	if err != nil {
 		t.Fatalf("UpdateBrokerStorage: %v", err)
 	}
 
-	// A subsequent Describe must reflect the raw option carried by the update.
 	desc, _ := m.DescribeCluster(ctx, c.ClusterARN)
-	if _, ok := desc.RawOptions["targetBrokerEBSVolumeInfo"]; !ok {
-		t.Fatal("update raw option not reflected in Describe")
+	if got := storageVolumeSize(t, desc.BrokerNodeGroupInfo); got != 200 {
+		t.Fatalf("storage volume not reflected in Describe: got %d, want 200", got)
 	}
 
+	if op.SourceClusterInfo == nil || op.SourceClusterInfo.EBSVolumeSizeGB != 100 {
+		t.Fatalf("source snapshot volume = %+v, want 100", op.SourceClusterInfo)
+	}
+
+	if op.TargetClusterInfo == nil || op.TargetClusterInfo.EBSVolumeSizeGB != 200 {
+		t.Fatalf("target snapshot volume = %+v, want 200", op.TargetClusterInfo)
+	}
+
+	// DescribeClusterOperation must deep-copy: mutating the result cannot alias
+	// stored state.
 	got, _ := m.DescribeClusterOperation(ctx, op.OperationARN)
 	if got.OperationARN != op.OperationARN {
 		t.Fatalf("operation mismatch: %s", got.OperationARN)
+	}
+
+	got.TargetClusterInfo.EBSVolumeSizeGB = 999
+
+	again, _ := m.DescribeClusterOperation(ctx, op.OperationARN)
+	if again.TargetClusterInfo.EBSVolumeSizeGB != 200 {
+		t.Fatal("operation snapshot aliased through the returned copy")
 	}
 }
 

--- a/providers/aws/kafka/operations.go
+++ b/providers/aws/kafka/operations.go
@@ -14,27 +14,66 @@ const (
 )
 
 // copyOperation returns a deep copy of an operation record so a reader cannot
-// alias the stored RawOptions map.
+// alias the stored RawOptions map or the source/target snapshots.
 //
 //nolint:gocritic // hugeParam: takes a value to return an alias-free copy.
 func copyOperation(op driver.ClusterOperation) driver.ClusterOperation {
 	out := op
 	out.RawOptions = copyRaw(op.RawOptions)
+	out.SourceClusterInfo = copyMutableInfo(op.SourceClusterInfo)
+	out.TargetClusterInfo = copyMutableInfo(op.TargetClusterInfo)
 
 	return out
+}
+
+// copyMutableInfo returns a copy of a mutable-cluster-info snapshot (all value
+// fields, so a shallow struct copy fully de-aliases it), or nil.
+func copyMutableInfo(mi *driver.MutableClusterInfo) *driver.MutableClusterInfo {
+	if mi == nil {
+		return nil
+	}
+
+	out := *mi
+
+	return &out
+}
+
+// mutableSnapshot captures the modeled mutable attributes of a cluster so an
+// operation can record the before/after of a mutation. It reads the EBS volume
+// size by value, so the snapshot is stable even after fn rewrites storageInfo.
+func mutableSnapshot(c *driver.Cluster) *driver.MutableClusterInfo {
+	info := &driver.MutableClusterInfo{
+		NumberOfBrokerNodes: c.NumberOfBrokerNodes,
+		KafkaVersion:        c.KafkaVersion,
+		StorageMode:         c.StorageMode,
+		EnhancedMonitoring:  c.EnhancedMonitoring,
+	}
+
+	if c.BrokerNodeGroupInfo != nil {
+		info.InstanceType = c.BrokerNodeGroupInfo.InstanceType
+		if size, ok := ebsVolumeSize(c.BrokerNodeGroupInfo); ok {
+			info.EBSVolumeSizeGB = size
+		}
+	}
+
+	return info
 }
 
 // recordOperation appends a COMPLETED operation record of the given type to the
 // cluster and indexes it globally by its ARN. The caller MUST already hold
 // cd.mu for writing; recording is part of the same atomic mutation so a
 // concurrent reader never sees the new cluster state without its operation.
-func (m *Mock) recordOperation(cd *clusterData, opType string) driver.ClusterOperation {
+func (m *Mock) recordOperation(
+	cd *clusterData, opType string, source, target *driver.MutableClusterInfo,
+) driver.ClusterOperation {
 	op := driver.ClusterOperation{
-		OperationARN:   m.operationARN(),
-		ClusterARN:     cd.cluster.ClusterARN,
-		OperationType:  opType,
-		OperationState: operationStateCompleted,
-		CreationTime:   m.now(),
+		OperationARN:      m.operationARN(),
+		ClusterARN:        cd.cluster.ClusterARN,
+		OperationType:     opType,
+		OperationState:    operationStateCompleted,
+		CreationTime:      m.now(),
+		SourceClusterInfo: source,
+		TargetClusterInfo: target,
 	}
 
 	cd.operations = append(cd.operations, op)
@@ -81,13 +120,19 @@ func (m *Mock) mutateClusterErr(
 			currentVersion, cd.cluster.CurrentVersion)
 	}
 
+	// Snapshot the mutable attributes before and after fn so the recorded
+	// operation carries the source/target delta real MSK reports.
+	source := mutableSnapshot(&cd.cluster)
+
 	if fn != nil {
 		fn(&cd.cluster)
 	}
 
 	cd.cluster.CurrentVersion = bumpVersion()
 
-	op := m.recordOperation(cd, opType)
+	target := mutableSnapshot(&cd.cluster)
+
+	op := m.recordOperation(cd, opType, source, target)
 	out := copyOperation(op)
 
 	return &out, nil
@@ -100,7 +145,9 @@ func bumpVersion() string {
 }
 
 // ListClusterOperations lists a cluster's operations, oldest first, paginated.
-// The v1 op does NOT model NotFoundException, so a missing cluster is a 400.
+// The v1 op does NOT model NotFoundException in the aws-sdk-go-v2 smithy model,
+// so a missing cluster is a 400 (a 404 would deserialize as an untyped generic
+// error). The v2 op DOES model it — see ListClusterOperationsV2.
 func (m *Mock) ListClusterOperations(
 	_ context.Context, arn string, page driver.Page,
 ) (ops []driver.ClusterOperation, next string, err error) {

--- a/server/aws/kafka/sdk_roundtrip_test.go
+++ b/server/aws/kafka/sdk_roundtrip_test.go
@@ -753,3 +753,186 @@ func TestSDKReplicatorLifecycle(t *testing.T) {
 		t.Fatalf("DeleteReplicator: %v", err)
 	}
 }
+
+// createStorageCluster creates a provisioned cluster whose broker EBS volume is
+// sized to volumeGB, returning the SDK client and the cluster ARN.
+func createStorageCluster(t *testing.T, name string, volumeGB int32) (*awskafka.Client, string) {
+	t.Helper()
+
+	ctx := context.Background()
+	c := newKafkaClient(t)
+
+	create, err := c.CreateCluster(ctx, &awskafka.CreateClusterInput{
+		ClusterName:         aws.String(name),
+		KafkaVersion:        aws.String("3.6.0"),
+		NumberOfBrokerNodes: aws.Int32(3),
+		BrokerNodeGroupInfo: &kafkatypes.BrokerNodeGroupInfo{
+			ClientSubnets: []string{"subnet-1", "subnet-2", "subnet-3"},
+			InstanceType:  aws.String("kafka.m5.large"),
+			StorageInfo: &kafkatypes.StorageInfo{
+				EbsStorageInfo: &kafkatypes.EBSStorageInfo{VolumeSize: aws.Int32(volumeGB)},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	return c, aws.ToString(create.ClusterArn)
+}
+
+func clusterVersion(t *testing.T, c *awskafka.Client, arn string) string {
+	t.Helper()
+
+	desc, err := c.DescribeCluster(context.Background(), &awskafka.DescribeClusterInput{ClusterArn: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("DescribeCluster: %v", err)
+	}
+
+	return aws.ToString(desc.ClusterInfo.CurrentVersion)
+}
+
+// TestSDKUpdateBrokerStorageReflectedInDescribe reproduces the Terraform
+// storage-drift bug: after UpdateBrokerStorage, DescribeCluster must return the
+// new EBS volume size (not the stale create-time value).
+func TestSDKUpdateBrokerStorageReflectedInDescribe(t *testing.T) {
+	ctx := context.Background()
+	c, arn := createStorageCluster(t, "sdk-storage", 100)
+
+	if _, err := c.UpdateBrokerStorage(ctx, &awskafka.UpdateBrokerStorageInput{
+		ClusterArn:     aws.String(arn),
+		CurrentVersion: aws.String(clusterVersion(t, c, arn)),
+		TargetBrokerEBSVolumeInfo: []kafkatypes.BrokerEBSVolumeInfo{{
+			KafkaBrokerNodeId: aws.String("ALL"),
+			VolumeSizeGB:      aws.Int32(200),
+		}},
+	}); err != nil {
+		t.Fatalf("UpdateBrokerStorage: %v", err)
+	}
+
+	desc, err := c.DescribeCluster(ctx, &awskafka.DescribeClusterInput{ClusterArn: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("DescribeCluster: %v", err)
+	}
+
+	bng := desc.ClusterInfo.BrokerNodeGroupInfo
+	if bng == nil || bng.StorageInfo == nil || bng.StorageInfo.EbsStorageInfo == nil {
+		t.Fatalf("storage info missing: %+v", bng)
+	}
+
+	if got := aws.ToInt32(bng.StorageInfo.EbsStorageInfo.VolumeSize); got != 200 {
+		t.Fatalf("volume size = %d, want 200 (storage drift)", got)
+	}
+}
+
+// TestSDKDescribeClusterZookeeperConnect asserts a provisioned cluster exports a
+// non-empty ZookeeperConnectString (+ Tls) that Terraform's aws_msk_cluster reads.
+func TestSDKDescribeClusterZookeeperConnect(t *testing.T) {
+	ctx := context.Background()
+	c, arn := createStorageCluster(t, "sdk-zk", 100)
+
+	desc, err := c.DescribeCluster(ctx, &awskafka.DescribeClusterInput{ClusterArn: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("DescribeCluster: %v", err)
+	}
+
+	zk := aws.ToString(desc.ClusterInfo.ZookeeperConnectString)
+	if !strings.Contains(zk, ":2181") {
+		t.Fatalf("ZookeeperConnectString = %q, want a plausible :2181 endpoint", zk)
+	}
+
+	if !strings.Contains(aws.ToString(desc.ClusterInfo.ZookeeperConnectStringTls), ":2182") {
+		t.Fatalf("ZookeeperConnectStringTls = %q, want :2182",
+			aws.ToString(desc.ClusterInfo.ZookeeperConnectStringTls))
+	}
+}
+
+// TestSDKMissingClusterBadRequest asserts GetBootstrapBrokers and
+// ListClusterOperations (v1) return the SDK-typed BadRequestException for a
+// well-formed but missing cluster ARN. The aws-sdk-go-v2 smithy model does NOT
+// model NotFoundException for these two ops, so returning a 404 would only
+// deserialize as an untyped generic error — BadRequest is the correct,
+// typed-deserializable behavior. ListClusterOperationsV2 does model 404.
+func TestSDKMissingClusterBadRequest(t *testing.T) {
+	ctx := context.Background()
+	c := newKafkaClient(t)
+	missing := aws.String("arn:aws:kafka:us-east-1:123456789012:cluster/missing/x")
+
+	_, err := c.GetBootstrapBrokers(ctx, &awskafka.GetBootstrapBrokersInput{ClusterArn: missing})
+
+	var bad *kafkatypes.BadRequestException
+	if !errors.As(err, &bad) {
+		t.Fatalf("GetBootstrapBrokers missing = %v, want BadRequestException", err)
+	}
+
+	_, err = c.ListClusterOperations(ctx, &awskafka.ListClusterOperationsInput{ClusterArn: missing})
+	if !errors.As(err, &bad) {
+		t.Fatalf("ListClusterOperations missing = %v, want BadRequestException", err)
+	}
+}
+
+// TestSDKOperationSourceTargetDeltas asserts a broker-count update and a storage
+// update each record an operation carrying the before/after source/target delta.
+func TestSDKOperationSourceTargetDeltas(t *testing.T) {
+	ctx := context.Background()
+	c, arn := createStorageCluster(t, "sdk-deltas", 100)
+
+	if _, err := c.UpdateBrokerCount(ctx, &awskafka.UpdateBrokerCountInput{
+		ClusterArn:                aws.String(arn),
+		CurrentVersion:            aws.String(clusterVersion(t, c, arn)),
+		TargetNumberOfBrokerNodes: aws.Int32(6),
+	}); err != nil {
+		t.Fatalf("UpdateBrokerCount: %v", err)
+	}
+
+	if _, err := c.UpdateBrokerStorage(ctx, &awskafka.UpdateBrokerStorageInput{
+		ClusterArn:     aws.String(arn),
+		CurrentVersion: aws.String(clusterVersion(t, c, arn)),
+		TargetBrokerEBSVolumeInfo: []kafkatypes.BrokerEBSVolumeInfo{{
+			KafkaBrokerNodeId: aws.String("ALL"),
+			VolumeSizeGB:      aws.Int32(200),
+		}},
+	}); err != nil {
+		t.Fatalf("UpdateBrokerStorage: %v", err)
+	}
+
+	ops, err := c.ListClusterOperations(ctx, &awskafka.ListClusterOperationsInput{ClusterArn: aws.String(arn)})
+	if err != nil || len(ops.ClusterOperationInfoList) != 2 {
+		t.Fatalf("ListClusterOperations: %v len=%d", err, len(ops.ClusterOperationInfoList))
+	}
+
+	assertBrokerCountDelta(t, ops.ClusterOperationInfoList[0])
+	assertStorageDelta(t, ops.ClusterOperationInfoList[1])
+}
+
+func assertBrokerCountDelta(t *testing.T, op kafkatypes.ClusterOperationInfo) {
+	t.Helper()
+
+	if op.SourceClusterInfo == nil || aws.ToInt32(op.SourceClusterInfo.NumberOfBrokerNodes) != 3 {
+		t.Fatalf("broker-count source = %+v, want 3", op.SourceClusterInfo)
+	}
+
+	if op.TargetClusterInfo == nil || aws.ToInt32(op.TargetClusterInfo.NumberOfBrokerNodes) != 6 {
+		t.Fatalf("broker-count target = %+v, want 6", op.TargetClusterInfo)
+	}
+}
+
+func assertStorageDelta(t *testing.T, op kafkatypes.ClusterOperationInfo) {
+	t.Helper()
+
+	if op.SourceClusterInfo == nil || volumeOf(op.SourceClusterInfo) != 100 {
+		t.Fatalf("storage source volume = %+v, want 100", op.SourceClusterInfo)
+	}
+
+	if op.TargetClusterInfo == nil || volumeOf(op.TargetClusterInfo) != 200 {
+		t.Fatalf("storage target volume = %+v, want 200", op.TargetClusterInfo)
+	}
+}
+
+func volumeOf(mi *kafkatypes.MutableClusterInfo) int32 {
+	if len(mi.BrokerEBSVolumeInfo) == 0 {
+		return -1
+	}
+
+	return aws.ToInt32(mi.BrokerEBSVolumeInfo[0].VolumeSizeGB)
+}

--- a/server/aws/kafka/types.go
+++ b/server/aws/kafka/types.go
@@ -2,6 +2,8 @@ package kafka
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/services/kafka/driver"
@@ -140,7 +142,55 @@ func clusterToWire(c *driver.Cluster) map[string]json.RawMessage {
 		base["encryptionInfo"] = defaultEncryptionInfo()
 	}
 
+	addZookeeperConnect(base, c)
+
 	return mergeRaw(base, c.RawOptions)
+}
+
+// addZookeeperConnect synthesizes the ZooKeeper connect strings a provisioned
+// (ZooKeeper-mode) cluster exports (real MSK's ClusterInfo.zookeeperConnectString
+// / zookeeperConnectStringTls, which Terraform's aws_msk_cluster surfaces).
+// Serverless clusters have no ZooKeeper, so they are skipped.
+func addZookeeperConnect(base map[string]any, c *driver.Cluster) {
+	if c.ClusterType == driver.ClusterTypeServerless {
+		return
+	}
+
+	plain, tls := zookeeperConnectStrings(c.ClusterName, regionFromARN(c.ClusterARN))
+	base["zookeeperConnectString"] = plain
+	base["zookeeperConnectStringTls"] = tls
+}
+
+// zookeeperConnectStrings builds a plausible three-node ZooKeeper ensemble
+// connect string (plaintext :2181, TLS :2182), synthesized deterministically
+// from the cluster name and region — mirroring how bootstrap brokers are
+// synthesized.
+func zookeeperConnectStrings(name, region string) (plain, tls string) {
+	const zkNodes = 3
+
+	var plainHosts, tlsHosts []string
+
+	for i := 1; i <= zkNodes; i++ {
+		host := "z-" + strconv.Itoa(i) + "." + name + ".kafka." + region + ".amazonaws.com"
+		plainHosts = append(plainHosts, host+":2181")
+		tlsHosts = append(tlsHosts, host+":2182")
+	}
+
+	return strings.Join(plainHosts, ","), strings.Join(tlsHosts, ",")
+}
+
+// regionFromARN extracts the region (4th colon-delimited field) from an AWS ARN.
+// Cluster ARNs are minted by the emulator and always well-formed; an unexpected
+// shape yields an empty region rather than a panic.
+func regionFromARN(arn string) string {
+	parts := strings.Split(arn, ":")
+
+	const regionIndex = 3
+	if len(parts) <= regionIndex {
+		return ""
+	}
+
+	return parts[regionIndex]
 }
 
 // defaultEncryptionInfo returns the MSK default encryption configuration that
@@ -211,6 +261,8 @@ func provisionedBlock(c *driver.Cluster) map[string]any {
 		block["encryptionInfo"] = defaultEncryptionInfo()
 	}
 
+	addZookeeperConnect(block, c)
+
 	return block
 }
 
@@ -230,7 +282,7 @@ func serverlessBlock(c *driver.Cluster) json.RawMessage {
 //
 //nolint:gocritic // hugeParam: rendered from a value copy.
 func operationToWire(op driver.ClusterOperation) map[string]any {
-	return map[string]any{
+	out := map[string]any{
 		"clusterArn":     op.ClusterARN,
 		"operationArn":   op.OperationARN,
 		"operationState": op.OperationState,
@@ -238,6 +290,66 @@ func operationToWire(op driver.ClusterOperation) map[string]any {
 		"creationTime":   timeRFC3339(op.CreationTime),
 		"endTime":        timeRFC3339(op.CreationTime),
 	}
+
+	addOperationDeltas(out, op)
+
+	return out
+}
+
+// addOperationDeltas renders the operation's before/after cluster snapshots as
+// sourceClusterInfo / targetClusterInfo (real MSK's MutableClusterInfo).
+//
+//nolint:gocritic // hugeParam: rendered from a value copy alongside operationToWire.
+func addOperationDeltas(out map[string]any, op driver.ClusterOperation) {
+	if src := mutableClusterInfoToWire(op.SourceClusterInfo); src != nil {
+		out["sourceClusterInfo"] = src
+	}
+
+	if tgt := mutableClusterInfoToWire(op.TargetClusterInfo); tgt != nil {
+		out["targetClusterInfo"] = tgt
+	}
+}
+
+// mutableClusterInfoToWire renders a mutable-cluster-info snapshot as its wire
+// shape, omitting zero-valued attributes. Returns nil when nothing is set.
+func mutableClusterInfoToWire(mi *driver.MutableClusterInfo) map[string]any {
+	if mi == nil {
+		return nil
+	}
+
+	out := map[string]any{}
+
+	if mi.NumberOfBrokerNodes > 0 {
+		out["numberOfBrokerNodes"] = mi.NumberOfBrokerNodes
+	}
+
+	if mi.InstanceType != "" {
+		out["instanceType"] = mi.InstanceType
+	}
+
+	if mi.KafkaVersion != "" {
+		out["kafkaVersion"] = mi.KafkaVersion
+	}
+
+	if mi.StorageMode != "" {
+		out["storageMode"] = mi.StorageMode
+	}
+
+	if mi.EnhancedMonitoring != "" {
+		out["enhancedMonitoring"] = mi.EnhancedMonitoring
+	}
+
+	if mi.EBSVolumeSizeGB > 0 {
+		out["brokerEBSVolumeInfo"] = []map[string]any{
+			{"kafkaBrokerNodeId": "ALL", "volumeSizeGB": mi.EBSVolumeSizeGB},
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
 }
 
 // operationToWireV2 renders a cluster operation as the ClusterOperationV2 /
@@ -245,7 +357,7 @@ func operationToWire(op driver.ClusterOperation) map[string]any {
 //
 //nolint:gocritic // hugeParam: rendered from a value copy.
 func operationToWireV2(op driver.ClusterOperation, clusterType string) map[string]any {
-	return map[string]any{
+	out := map[string]any{
 		"clusterArn":     op.ClusterARN,
 		"clusterType":    clusterType,
 		"operationArn":   op.OperationARN,
@@ -254,6 +366,10 @@ func operationToWireV2(op driver.ClusterOperation, clusterType string) map[strin
 		"startTime":      timeRFC3339(op.CreationTime),
 		"endTime":        timeRFC3339(op.CreationTime),
 	}
+
+	addOperationDeltas(out, op)
+
+	return out
 }
 
 // nodeToWire renders a broker node as the NodeInfo wire shape.

--- a/services/kafka/driver/types.go
+++ b/services/kafka/driver/types.go
@@ -159,13 +159,32 @@ type Topic struct {
 }
 
 // ClusterOperation is a record of an in-flight or completed cluster mutation.
+// SourceClusterInfo / TargetClusterInfo carry the modeled cluster attributes
+// before and after the mutation (real MSK's ClusterOperationInfo.sourceClusterInfo
+// / targetClusterInfo), so a caller can inspect the before/after delta.
 type ClusterOperation struct {
-	OperationARN   string
-	ClusterARN     string
-	OperationType  string
-	OperationState string
-	CreationTime   time.Time
-	RawOptions     map[string]json.RawMessage
+	OperationARN      string
+	ClusterARN        string
+	OperationType     string
+	OperationState    string
+	CreationTime      time.Time
+	SourceClusterInfo *MutableClusterInfo
+	TargetClusterInfo *MutableClusterInfo
+	RawOptions        map[string]json.RawMessage
+}
+
+// MutableClusterInfo is the subset of cluster attributes that update APIs can
+// change (real MSK's MutableClusterInfo). A zero-valued field is omitted from
+// the wire rendering, so an operation's source/target snapshots surface only the
+// attributes the emulator models. EBSVolumeSizeGB renders as a brokerEBSVolumeInfo
+// entry keyed to the ALL broker.
+type MutableClusterInfo struct {
+	NumberOfBrokerNodes int32
+	InstanceType        string
+	KafkaVersion        string
+	StorageMode         string
+	EnhancedMonitoring  string
+	EBSVolumeSizeGB     int64
 }
 
 // Replicator is an MSK Replicator (cross-cluster replication).


### PR DESCRIPTION
## What

Fixes AWS MSK (Kafka) drift/visibility bugs found by the deep-e2e real-user audit.

- **UpdateBrokerStorage / UpdateStorage now reflected in DescribeCluster.** Both now rewrite `brokerNodeGroupInfo.storageInfo.ebsStorageInfo.volumeSize` (allocating the block when absent, preserving siblings like `provisionedThroughput`) instead of stashing a bogus raw option that the SDK dropped. Previously DescribeCluster kept returning the create-time size, so Terraform `aws_msk_cluster.broker_node_group_info.storage_info.ebs_storage_info.volume_size` read stale and re-issued the storage update on every `apply` (perpetual diff).
- **ZookeeperConnectString / ZookeeperConnectStringTls now populated** for provisioned clusters in DescribeCluster, ListClusters, and the v2 provisioned block — synthesized deterministically (3-node ensemble, `:2181` plaintext / `:2182` TLS) the same way bootstrap brokers are. Skipped for serverless. Terraform `aws_msk_cluster` exports these.
- **Cluster operations now carry `sourceClusterInfo` / `targetClusterInfo`.** Every mutation captures a before/after `MutableClusterInfo` snapshot (numberOfBrokerNodes, brokerEBSVolumeInfo, instanceType, kafkaVersion, storageMode, enhancedMonitoring), rendered on ListClusterOperations / DescribeClusterOperation (v1 + v2). A broker-count or storage update now shows its delta.

## Verified and deliberately NOT changed

The audit also proposed flipping `GetBootstrapBrokers` and `ListClusterOperations` (v1) from 400 BadRequest to 404 NotFound on a missing cluster. Checked against the **aws-sdk-go-v2 smithy model**: neither op models `NotFoundException` (only BadRequest/Conflict/Forbidden/InternalServerError/Unauthorized) — a 404 there deserializes as an **untyped generic error**, breaking callers that branch on the typed exception. `ListClusterOperationsV2` does model 404. The original typed `BadRequestException` is correct; kept it and documented the reasoning, with a wire test asserting the SDK deserializes the typed error.

## Tests

Real `aws-sdk-go-v2/service/kafka` round-trips (httptest wire server): storage reflected in Describe; non-empty Zookeeper strings; operation source/target deltas after broker-count + storage updates; typed BadRequestException on missing cluster. Provider-level test strengthened to assert Describe reflects the new size and the operation snapshot deep-copies. Existing MSK tests unchanged and green.

Gates: build, vet, scoped tests, `-race`, gofmt, golangci-lint (0 new), `go generate` (zero diff), compatgen (zero diff) all green.
