### PR TITLE
fix(azure-blob): enforce conditional headers on all mutating ops + conditional reads; Copy Blob metadata override

### DIFF
--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -569,26 +569,53 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 	}, nil
 }
 
-// CopyObject copies a blob from one location to another.
+// CopyObject copies a blob from one location to another, inheriting the source
+// blob's metadata (the default Azure Copy Blob behavior when the request carries
+// no x-ms-meta-* headers).
 func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src driver.CopySource) error {
+	_, err := m.copyBlobInternal(ctx, dstBucket, dstKey, src, nil, false)
+
+	return err
+}
+
+// CopyObjectV2 implements the ObjectCopier capability so the Azure Blob wire
+// layer can express Copy Blob's metadata override: when ReplaceMetadata is set
+// the destination takes exactly req.Metadata instead of inheriting the source's.
+// Content properties are always inherited from the source (Azure Copy Blob does
+// not let the caller override them).
+func (m *Mock) CopyObjectV2(ctx context.Context, req *driver.CopyObjectRequest) (*driver.CopyObjectResult, error) {
+	info, err := m.copyBlobInternal(ctx, req.DstBucket, req.DstKey, req.Src, req.Metadata, req.ReplaceMetadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return &driver.CopyObjectResult{ETag: info.ETag, LastModified: info.LastModified}, nil
+}
+
+// copyBlobInternal is the shared copy path for CopyObject and CopyObjectV2. When
+// replaceMeta is true the destination's metadata is exactly overrideMeta;
+// otherwise it inherits the source blob's metadata.
+func (m *Mock) copyBlobInternal(
+	ctx context.Context, dstBucket, dstKey string, src driver.CopySource, overrideMeta map[string]string, replaceMeta bool,
+) (*driver.ObjectInfo, error) {
 	srcCtr, ok := m.containers.Get(src.Bucket)
 	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "source container %q not found", src.Bucket)
+		return nil, cerrors.Newf(cerrors.NotFound, "source container %q not found", src.Bucket)
 	}
 
 	srcObj, ok := srcCtr.objects.Get(src.Key)
 	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "source blob %q not found", src.Key)
+		return nil, cerrors.Newf(cerrors.NotFound, "source blob %q not found", src.Key)
 	}
 
 	dstCtr, ok := m.containers.Get(dstBucket)
 	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "destination container %q not found", dstBucket)
+		return nil, cerrors.Newf(cerrors.NotFound, "destination container %q not found", dstBucket)
 	}
 
-	meta := make(map[string]string, len(srcObj.Metadata))
-	for k, v := range srcObj.Metadata {
-		meta[k] = v
+	meta := maps.Clone(srcObj.Metadata)
+	if replaceMeta {
+		meta = maps.Clone(overrideMeta)
 	}
 
 	dstObj := &blobObject{
@@ -603,7 +630,7 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 		if err := storageengine.Copy(ctx, m.opts.StorageEngine,
 			config.StorageRef{Bucket: dstBucket, Key: dstKey},
 			config.StorageRef{Bucket: src.Bucket, Key: src.Key}); err != nil {
-			return err
+			return nil, err
 		}
 	} else {
 		dataCopy := make([]byte, len(srcObj.Data))
@@ -616,7 +643,9 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 
 	m.emitMetric(dstBucket, map[string]float64{"Transactions": 1})
 
-	return nil
+	info := objectInfo(dstObj)
+
+	return &info, nil
 }
 
 // GeneratePresignedURL generates a mock presigned URL.

--- a/providers/azure/blobstorage/copy_test.go
+++ b/providers/azure/blobstorage/copy_test.go
@@ -1,0 +1,65 @@
+package blobstorage
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/storage/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyObjectInheritsMetadata(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "src"))
+	require.NoError(t, m.CreateBucket(ctx, "dst"))
+	require.NoError(t, m.PutObject(ctx, "src", "k", []byte("data"), "text/plain", map[string]string{"orig": "yes"}))
+
+	require.NoError(t, m.CopyObject(ctx, "dst", "k2", driver.CopySource{Bucket: "src", Key: "k"}))
+
+	info, err := m.HeadObject(ctx, "dst", "k2")
+	require.NoError(t, err)
+	assert.Equal(t, "yes", info.Metadata["orig"], "copy with no override inherits source metadata")
+}
+
+func TestCopyObjectV2ReplaceMetadata(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "src"))
+	require.NoError(t, m.CreateBucket(ctx, "dst"))
+	require.NoError(t, m.PutObject(ctx, "src", "k", []byte("data"), "text/plain", map[string]string{"orig": "yes"}))
+
+	res, err := m.CopyObjectV2(ctx, &driver.CopyObjectRequest{
+		DstBucket: "dst", DstKey: "k2",
+		Src:             driver.CopySource{Bucket: "src", Key: "k"},
+		ReplaceMetadata: true,
+		Metadata:        map[string]string{"fresh": "new"},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, res.ETag)
+
+	info, err := m.HeadObject(ctx, "dst", "k2")
+	require.NoError(t, err)
+	assert.Equal(t, "new", info.Metadata["fresh"], "override metadata applied to destination")
+	_, inherited := info.Metadata["orig"]
+	assert.False(t, inherited, "full replace must drop source metadata")
+}
+
+func TestCopyObjectV2InheritWhenNotReplacing(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "src"))
+	require.NoError(t, m.CreateBucket(ctx, "dst"))
+	require.NoError(t, m.PutObject(ctx, "src", "k", []byte("data"), "text/plain", map[string]string{"orig": "yes"}))
+
+	_, err := m.CopyObjectV2(ctx, &driver.CopyObjectRequest{
+		DstBucket: "dst", DstKey: "k2",
+		Src: driver.CopySource{Bucket: "src", Key: "k"},
+	})
+	require.NoError(t, err)
+
+	info, err := m.HeadObject(ctx, "dst", "k2")
+	require.NoError(t, err)
+	assert.Equal(t, "yes", info.Metadata["orig"], "no override inherits source metadata")
+}

--- a/server/azure/blobstorage/blob_conditional_test.go
+++ b/server/azure/blobstorage/blob_conditional_test.go
@@ -1,0 +1,360 @@
+package blobstorage_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/appendblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+)
+
+// condWrongETag is an ETag that never matches a real blob, used to force an
+// If-Match mismatch.
+const condWrongETag = azcore.ETag(`"0xDEADBEEFDEADBEEF"`)
+
+// condIfMatch builds the AccessConditions carrying an If-Match precondition.
+func condIfMatch(e azcore.ETag) *blob.AccessConditions {
+	return &blob.AccessConditions{ModifiedAccessConditions: &blob.ModifiedAccessConditions{IfMatch: &e}}
+}
+
+// requireHTTPStatus asserts err is an azcore.ResponseError with the given HTTP
+// status code.
+func requireHTTPStatus(t *testing.T, err error, want int) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("expected HTTP %d error, got nil", want)
+	}
+
+	var re *azcore.ResponseError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected *azcore.ResponseError with status %d, got %T: %v", want, err, err)
+	}
+
+	if re.StatusCode != want {
+		t.Fatalf("status = %d, want %d", re.StatusCode, want)
+	}
+}
+
+// rawStatus issues a bare HTTP request through the test transport and returns
+// the response status code. It is used for conditions the typed SDK never puts
+// on the wire (Set Blob Tier forwards only x-ms-if-tags) or surfaces as a
+// non-error (Download treats 304 as a success code), so the wire behavior must
+// be asserted directly.
+func (e *blobEnv) rawStatus(t *testing.T, method, path string, headers map[string]string) int {
+	t.Helper()
+
+	req, err := http.NewRequest(method, e.base+path, nil)
+	if err != nil {
+		t.Fatalf("new request %s %s: %v", method, path, err)
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := e.tr.Do(req)
+	if err != nil {
+		t.Fatalf("do %s %s: %v", method, path, err)
+	}
+
+	_ = resp.Body.Close()
+
+	return resp.StatusCode
+}
+
+// currentETag returns a blob's current ETag via GetProperties.
+func (e *blobEnv) currentETag(t *testing.T, path string) azcore.ETag {
+	t.Helper()
+
+	props, err := e.blob(t, path).GetProperties(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("GetProperties(%s): %v", path, err)
+	}
+
+	if props.ETag == nil {
+		t.Fatalf("GetProperties(%s): nil ETag", path)
+	}
+
+	return *props.ETag
+}
+
+func TestSDKConditionalCommitBlockList(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	bb := e.blockBlob(t, "/c1/cbl")
+
+	stage := func(id, data string) string {
+		bid := base64.StdEncoding.EncodeToString([]byte(id))
+		if _, err := bb.StageBlock(ctx, bid, streaming.NopCloser(bytes.NewReader([]byte(data))), nil); err != nil {
+			t.Fatalf("StageBlock %q: %v", id, err)
+		}
+
+		return bid
+	}
+
+	a := stage("blk-a", "v1")
+	if _, err := bb.CommitBlockList(ctx, []string{a}, nil); err != nil {
+		t.Fatalf("initial CommitBlockList: %v", err)
+	}
+
+	etag := e.currentETag(t, "/c1/cbl")
+
+	b := stage("blk-b", "v2")
+
+	// Mismatched If-Match must fail with 412 and leave the blob unchanged.
+	_, err := bb.CommitBlockList(ctx, []string{b}, &blockblob.CommitBlockListOptions{AccessConditions: condIfMatch(condWrongETag)})
+	requireHTTPStatus(t, err, http.StatusPreconditionFailed)
+
+	if got := e.download(t, "cbl"); got != "v1" {
+		t.Errorf("blob mutated despite failed If-Match: %q", got)
+	}
+
+	// Matching If-Match succeeds.
+	if _, err := bb.CommitBlockList(ctx, []string{b}, &blockblob.CommitBlockListOptions{AccessConditions: condIfMatch(etag)}); err != nil {
+		t.Fatalf("CommitBlockList with matching If-Match: %v", err)
+	}
+
+	if got := e.download(t, "cbl"); got != "v2" {
+		t.Errorf("content after matching commit = %q, want v2", got)
+	}
+}
+
+func TestSDKConditionalSetMetadata(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "sm", []byte("body"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	etag := e.currentETag(t, "/c1/sm")
+	bc := e.blob(t, "/c1/sm")
+	meta := map[string]*string{"k": ptr("v")}
+
+	_, err := bc.SetMetadata(ctx, meta, &blob.SetMetadataOptions{AccessConditions: condIfMatch(condWrongETag)})
+	requireHTTPStatus(t, err, http.StatusPreconditionFailed)
+
+	if _, err := bc.SetMetadata(ctx, meta, &blob.SetMetadataOptions{AccessConditions: condIfMatch(etag)}); err != nil {
+		t.Fatalf("SetMetadata with matching If-Match: %v", err)
+	}
+}
+
+func TestSDKConditionalSetProperties(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "sp", []byte("body"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	etag := e.currentETag(t, "/c1/sp")
+	bc := e.blob(t, "/c1/sp")
+	headers := blob.HTTPHeaders{BlobContentType: ptr("text/plain")}
+
+	_, err := bc.SetHTTPHeaders(ctx, headers, &blob.SetHTTPHeadersOptions{AccessConditions: condIfMatch(condWrongETag)})
+	requireHTTPStatus(t, err, http.StatusPreconditionFailed)
+
+	if _, err := bc.SetHTTPHeaders(ctx, headers, &blob.SetHTTPHeadersOptions{AccessConditions: condIfMatch(etag)}); err != nil {
+		t.Fatalf("SetHTTPHeaders with matching If-Match: %v", err)
+	}
+}
+
+func TestSDKConditionalSetTier(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "st", []byte("body"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	etag := e.currentETag(t, "/c1/st")
+
+	// The azblob SetTier client forwards only x-ms-if-tags, so If-Match is
+	// asserted at the wire level directly.
+	if got := e.rawStatus(t, http.MethodPut, "/c1/st?comp=tier",
+		map[string]string{"x-ms-access-tier": "Cool", "If-Match": string(condWrongETag)}); got != http.StatusPreconditionFailed {
+		t.Errorf("SetTier mismatched If-Match status = %d, want 412", got)
+	}
+
+	if got := e.rawStatus(t, http.MethodPut, "/c1/st?comp=tier",
+		map[string]string{"x-ms-access-tier": "Cool", "If-Match": string(etag)}); got != http.StatusOK {
+		t.Errorf("SetTier matching If-Match status = %d, want 200", got)
+	}
+}
+
+func TestSDKConditionalAppendBlock(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	ac, err := appendblob.NewClientWithNoCredential(e.base+"/c1/ab", &appendblob.ClientOptions{ClientOptions: e.clientOpts()})
+	if err != nil {
+		t.Fatalf("appendblob.NewClient: %v", err)
+	}
+
+	if _, err := ac.Create(ctx, nil); err != nil {
+		t.Fatalf("Create append blob: %v", err)
+	}
+
+	etag := e.currentETag(t, "/c1/ab")
+	body := streaming.NopCloser(bytes.NewReader([]byte("chunk")))
+
+	_, err = ac.AppendBlock(ctx, body, &appendblob.AppendBlockOptions{AccessConditions: condIfMatch(condWrongETag)})
+	requireHTTPStatus(t, err, http.StatusPreconditionFailed)
+
+	if _, err := ac.AppendBlock(ctx, streaming.NopCloser(bytes.NewReader([]byte("chunk"))),
+		&appendblob.AppendBlockOptions{AccessConditions: condIfMatch(etag)}); err != nil {
+		t.Fatalf("AppendBlock with matching If-Match: %v", err)
+	}
+}
+
+func TestSDKConditionalDelete(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "del", []byte("body"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	etag := e.currentETag(t, "/c1/del")
+	bc := e.blob(t, "/c1/del")
+
+	_, err := bc.Delete(ctx, &blob.DeleteOptions{AccessConditions: condIfMatch(condWrongETag)})
+	requireHTTPStatus(t, err, http.StatusPreconditionFailed)
+
+	// Still present after the failed conditional delete.
+	if _, err := bc.GetProperties(ctx, nil); err != nil {
+		t.Fatalf("blob deleted despite failed If-Match: %v", err)
+	}
+
+	if _, err := bc.Delete(ctx, &blob.DeleteOptions{AccessConditions: condIfMatch(etag)}); err != nil {
+		t.Fatalf("Delete with matching If-Match: %v", err)
+	}
+
+	if _, err := bc.GetProperties(ctx, nil); err == nil {
+		t.Fatal("blob still present after matching conditional delete")
+	}
+}
+
+func TestSDKGetConditionalReads(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "rd", []byte("payload"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	etag := e.currentETag(t, "/c1/rd")
+
+	// GET with If-None-Match matching the current ETag -> 304 Not Modified.
+	// The azblob client treats 304 as a success status, so assert the wire
+	// status directly.
+	if got := e.rawStatus(t, http.MethodGet, "/c1/rd",
+		map[string]string{"If-None-Match": string(etag)}); got != http.StatusNotModified {
+		t.Errorf("GET If-None-Match:<current> status = %d, want 304", got)
+	}
+
+	// HEAD with If-None-Match matching -> 304 Not Modified.
+	if got := e.rawStatus(t, http.MethodHead, "/c1/rd",
+		map[string]string{"If-None-Match": string(etag)}); got != http.StatusNotModified {
+		t.Errorf("HEAD If-None-Match:<current> status = %d, want 304", got)
+	}
+
+	// GET with a mismatched If-Match -> 412 Precondition Failed (the SDK
+	// surfaces this as an error).
+	_, err := e.svc.DownloadStream(ctx, "c1", "rd", &blob.DownloadStreamOptions{AccessConditions: condIfMatch(condWrongETag)})
+	requireHTTPStatus(t, err, http.StatusPreconditionFailed)
+
+	// A matching If-Match read still succeeds and returns the body.
+	dl, err := e.svc.DownloadStream(ctx, "c1", "rd", &blob.DownloadStreamOptions{AccessConditions: condIfMatch(etag)})
+	if err != nil {
+		t.Fatalf("DownloadStream with matching If-Match: %v", err)
+	}
+
+	_ = dl.Body.Close()
+}
+
+func TestSDKCopyMetadataOverride(t *testing.T) {
+	env := newSuiteEnv(t)
+	ctx := context.Background()
+
+	for _, c := range []string{"src-c", "dst-c"} {
+		if _, err := env.client.CreateContainer(ctx, c, nil); err != nil {
+			t.Fatalf("CreateContainer(%s): %v", c, err)
+		}
+	}
+
+	_, err := env.client.UploadBuffer(ctx, "src-c", "orig", []byte("data"), &azblob.UploadBufferOptions{
+		Metadata: map[string]*string{"orig": ptr("yes")},
+	})
+	if err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	// Copy supplying fresh metadata -> destination has EXACTLY that, nothing
+	// inherited from the source.
+	dst := env.client.ServiceClient().NewContainerClient("dst-c").NewBlobClient("over")
+
+	_, err = dst.StartCopyFromURL(ctx, env.ts.URL+"/src-c/orig", &blob.StartCopyFromURLOptions{
+		Metadata: map[string]*string{"fresh": ptr("new")},
+	})
+	if err != nil {
+		t.Fatalf("StartCopyFromURL(override): %v", err)
+	}
+
+	props, err := dst.GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties(over): %v", err)
+	}
+
+	if v, ok := metaGet(props.Metadata, "fresh"); !ok || v != "new" {
+		t.Errorf("dst metadata fresh=%q ok=%v, want new", v, ok)
+	}
+
+	if _, ok := metaGet(props.Metadata, "orig"); ok {
+		t.Error("dst inherited source metadata despite override (full replace expected)")
+	}
+}
+
+func TestSDKCopyInheritsMetadata(t *testing.T) {
+	env := newSuiteEnv(t)
+	ctx := context.Background()
+
+	for _, c := range []string{"src-c", "dst-c"} {
+		if _, err := env.client.CreateContainer(ctx, c, nil); err != nil {
+			t.Fatalf("CreateContainer(%s): %v", c, err)
+		}
+	}
+
+	_, err := env.client.UploadBuffer(ctx, "src-c", "orig", []byte("data"), &azblob.UploadBufferOptions{
+		Metadata: map[string]*string{"orig": ptr("yes")},
+	})
+	if err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	// Copy with no metadata -> destination inherits the source's metadata.
+	dst := env.client.ServiceClient().NewContainerClient("dst-c").NewBlobClient("inh")
+
+	if _, err := dst.StartCopyFromURL(ctx, env.ts.URL+"/src-c/orig", nil); err != nil {
+		t.Fatalf("StartCopyFromURL(inherit): %v", err)
+	}
+
+	props, err := dst.GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties(inh): %v", err)
+	}
+
+	if v, ok := metaGet(props.Metadata, "orig"); !ok || v != "yes" {
+		t.Errorf("dst metadata orig=%q ok=%v, want yes (inherited)", v, ok)
+	}
+}

--- a/server/azure/blobstorage/blob_extensions.go
+++ b/server/azure/blobstorage/blob_extensions.go
@@ -48,6 +48,10 @@ func (h *Handler) commitBlockList(w http.ResponseWriter, r *http.Request, ext bl
 		return
 	}
 
+	if h.conditionFailed(w, r, container, blob, false) {
+		return
+	}
+
 	body, ok := readLimitedBody(w, r)
 	if !ok {
 		return
@@ -74,6 +78,10 @@ func (h *Handler) setBlobMetadata(w http.ResponseWriter, r *http.Request, ext bl
 		return
 	}
 
+	if h.conditionFailed(w, r, container, blob, false) {
+		return
+	}
+
 	info, err := ext.SetBlobMetadata(r.Context(), container, blob, extractMetadata(r.Header))
 	if err != nil {
 		writeErr(w, err)
@@ -86,6 +94,10 @@ func (h *Handler) setBlobMetadata(w http.ResponseWriter, r *http.Request, ext bl
 // setBlobProperties handles PUT /{container}/{blob}?comp=properties.
 func (h *Handler) setBlobProperties(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
 	if h.checkLease(w, r, container, blob) {
+		return
+	}
+
+	if h.conditionFailed(w, r, container, blob, false) {
 		return
 	}
 
@@ -107,10 +119,14 @@ func (h *Handler) setBlobProperties(w http.ResponseWriter, r *http.Request, ext 
 }
 
 // setBlobTier handles PUT /{container}/{blob}?comp=tier.
-func (*Handler) setBlobTier(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+func (h *Handler) setBlobTier(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
 	tier := r.Header.Get("x-ms-access-tier")
 	if tier == "" {
 		writeError(w, http.StatusBadRequest, "MissingRequiredHeader", "x-ms-access-tier is required")
+		return
+	}
+
+	if h.conditionFailed(w, r, container, blob, false) {
 		return
 	}
 
@@ -124,7 +140,11 @@ func (*Handler) setBlobTier(w http.ResponseWriter, r *http.Request, ext blobExt,
 }
 
 // snapshotBlob handles PUT /{container}/{blob}?comp=snapshot.
-func (*Handler) snapshotBlob(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+func (h *Handler) snapshotBlob(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
+	if h.conditionFailed(w, r, container, blob, false) {
+		return
+	}
+
 	snapshot, info, err := ext.CreateBlobSnapshot(r.Context(), container, blob)
 	if err != nil {
 		writeErr(w, err)
@@ -141,6 +161,10 @@ func (h *Handler) createAppendBlob(w http.ResponseWriter, r *http.Request, ext b
 		return
 	}
 
+	if h.conditionFailed(w, r, container, blob, true) {
+		return
+	}
+
 	info, err := ext.CreateAppendBlob(r.Context(), container, blob, blobContentType(r), extractMetadata(r.Header))
 	if err != nil {
 		writeErr(w, err)
@@ -154,6 +178,10 @@ func (h *Handler) createAppendBlob(w http.ResponseWriter, r *http.Request, ext b
 // appendBlock handles PUT /{container}/{blob}?comp=appendblock.
 func (h *Handler) appendBlock(w http.ResponseWriter, r *http.Request, ext blobExt, container, blob string) {
 	if h.checkLease(w, r, container, blob) {
+		return
+	}
+
+	if h.conditionFailed(w, r, container, blob, false) {
 		return
 	}
 

--- a/server/azure/blobstorage/handler.go
+++ b/server/azure/blobstorage/handler.go
@@ -513,7 +513,7 @@ func (h *Handler) putBlob(w http.ResponseWriter, r *http.Request, container, blo
 		return
 	}
 
-	if h.conditionFailed(w, r, container, blob) {
+	if h.conditionFailed(w, r, container, blob, true) {
 		return
 	}
 
@@ -561,10 +561,13 @@ func (h *Handler) putBlob(w http.ResponseWriter, r *http.Request, container, blo
 
 // conditionFailed evaluates the If-None-Match / If-Match conditional write
 // headers against the current blob and, if a condition is not met, writes the
-// Azure error and returns true. Real Azure Put Blob returns 409 when
-// If-None-Match:* hits an existing blob (create-if-absent conflict) and 412
-// when If-Match does not match the current ETag.
-func (h *Handler) conditionFailed(w http.ResponseWriter, r *http.Request, container, blob string) bool {
+// Azure error and returns true. Every mutating data-plane op must call this so
+// optimistic-concurrency writes on a stale ETag are rejected rather than
+// silently losing the update. isCreate selects create semantics for a
+// If-None-Match:* conflict: a create (Put Blob / create Append Blob) returns
+// 409 BlobAlreadyExists, every other write returns 412 (per the write-operations
+// response-code table). A mismatched If-Match always yields 412.
+func (h *Handler) conditionFailed(w http.ResponseWriter, r *http.Request, container, blob string, isCreate bool) bool {
 	ifNoneMatch := r.Header.Get("If-None-Match")
 	ifMatch := r.Header.Get("If-Match")
 
@@ -580,7 +583,7 @@ func (h *Handler) conditionFailed(w http.ResponseWriter, r *http.Request, contai
 		curETag = info.ETag
 	}
 
-	status, code := evalWriteConditions(ifNoneMatch, ifMatch, curETag, exists)
+	status, code := evalWriteConditions(ifNoneMatch, ifMatch, curETag, exists, isCreate)
 	if status == 0 {
 		return false
 	}
@@ -593,11 +596,15 @@ func (h *Handler) conditionFailed(w http.ResponseWriter, r *http.Request, contai
 // evalWriteConditions evaluates the If-None-Match / If-Match write conditions
 // against the current blob state. It returns the HTTP status and Azure error
 // code to fail with, or (0, "") when the write may proceed.
-func evalWriteConditions(ifNoneMatch, ifMatch, curETag string, exists bool) (status int, code string) {
+func evalWriteConditions(ifNoneMatch, ifMatch, curETag string, exists, isCreate bool) (status int, code string) {
 	const conditionNotMet = "ConditionNotMet"
 
 	if ifNoneMatch == "*" && exists {
-		return http.StatusConflict, "BlobAlreadyExists"
+		if isCreate {
+			return http.StatusConflict, "BlobAlreadyExists"
+		}
+
+		return http.StatusPreconditionFailed, conditionNotMet
 	}
 
 	if ifMatch != "" && (!exists || !etagMatches(ifMatch, curETag)) {
@@ -638,9 +645,53 @@ func (h *Handler) getBlob(w http.ResponseWriter, r *http.Request, container, blo
 		return
 	}
 
+	if readConditionHandled(w, r, obj.Info.ETag, obj.Info.LastModified) {
+		return
+	}
+
 	writeBlobHeaders(w, &obj.Info, int64(len(obj.Data)))
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(obj.Data) //nolint:gosec // raw object bytes
+}
+
+// readConditionHandled evaluates the If-Match / If-None-Match read conditional
+// headers against the current blob ETag before any body is written. It returns
+// true, having written the response, when the read must short-circuit: a
+// mismatched If-Match yields 412 Precondition Failed, and an If-None-Match that
+// matches the current ETag (including the wildcard *) yields 304 Not Modified
+// with no body. Returns false to let the read proceed.
+func readConditionHandled(w http.ResponseWriter, r *http.Request, curETag, lastModified string) bool {
+	ifNoneMatch := r.Header.Get("If-None-Match")
+	ifMatch := r.Header.Get("If-Match")
+
+	if ifNoneMatch == "" && ifMatch == "" {
+		return false
+	}
+
+	if ifMatch != "" && !etagCondMatches(ifMatch, curETag) {
+		writeError(w, http.StatusPreconditionFailed, "ConditionNotMet", conditionMessage(http.StatusPreconditionFailed))
+		return true
+	}
+
+	if ifNoneMatch != "" && etagCondMatches(ifNoneMatch, curETag) {
+		w.Header().Set("ETag", fmt.Sprintf("%q", curETag))
+		w.Header().Set("Last-Modified", httpDate(lastModified))
+		w.WriteHeader(http.StatusNotModified)
+
+		return true
+	}
+
+	return false
+}
+
+// etagCondMatches reports whether a conditional-header ETag matches the stored
+// ETag. The wildcard "*" matches any existing resource.
+func etagCondMatches(header, stored string) bool {
+	if strings.TrimSpace(header) == "*" {
+		return true
+	}
+
+	return etagMatches(header, stored)
 }
 
 // getBlobSnapshot serves GET /{container}/{blob}?snapshot=… reading an
@@ -668,6 +719,10 @@ func (h *Handler) headBlob(w http.ResponseWriter, r *http.Request, container, bl
 	info, err := h.bucket.HeadObject(r.Context(), container, blob)
 	if err != nil {
 		writeErr(w, err)
+		return
+	}
+
+	if readConditionHandled(w, r, info.ETag, info.LastModified) {
 		return
 	}
 
@@ -702,6 +757,10 @@ func (h *Handler) deleteBlob(w http.ResponseWriter, r *http.Request, container, 
 		return
 	}
 
+	if h.conditionFailed(w, r, container, blob, false) {
+		return
+	}
+
 	deleteBase := true
 
 	if ext, ok := h.bucket.(storagedriver.AzureBlobExtensions); ok {
@@ -731,6 +790,12 @@ func (h *Handler) copyBlob(w http.ResponseWriter, r *http.Request, container, bl
 		return
 	}
 
+	// The bare If-*/If-None-Match conditional headers apply to the destination
+	// blob (source conditions use the x-ms-source-if-* headers, unsupported here).
+	if h.conditionFailed(w, r, container, blob, false) {
+		return
+	}
+
 	src := r.Header.Get("X-Ms-Copy-Source")
 	srcBucket, srcKey := extractCopySource(src)
 
@@ -739,7 +804,7 @@ func (h *Handler) copyBlob(w http.ResponseWriter, r *http.Request, container, bl
 		return
 	}
 
-	if err := h.bucket.CopyObject(r.Context(), container, blob, storagedriver.CopySource{
+	if err := h.performCopy(r, container, blob, storagedriver.CopySource{
 		Bucket: srcBucket, Key: srcKey,
 	}); err != nil {
 		writeErr(w, err)
@@ -753,6 +818,28 @@ func (h *Handler) copyBlob(w http.ResponseWriter, r *http.Request, container, bl
 		w.Header().Set("Last-Modified", httpDate(info.LastModified))
 	}
 	w.WriteHeader(http.StatusAccepted)
+}
+
+// performCopy runs the server-side copy, honoring Azure Copy Blob metadata
+// semantics: when the request supplies any x-ms-meta-* header the destination
+// takes EXACTLY that metadata (full replace, nothing inherited); with none, the
+// destination inherits the source's metadata. The override path routes through
+// the ObjectCopier capability; the inherit path uses the basic CopyObject.
+func (h *Handler) performCopy(r *http.Request, container, blob string, src storagedriver.CopySource) error {
+	override := extractMetadata(r.Header)
+
+	if override != nil {
+		if copier, ok := h.bucket.(storagedriver.ObjectCopier); ok {
+			_, err := copier.CopyObjectV2(r.Context(), &storagedriver.CopyObjectRequest{
+				DstBucket: container, DstKey: blob, Src: src,
+				ReplaceMetadata: true, Metadata: override,
+			})
+
+			return err
+		}
+	}
+
+	return h.bucket.CopyObject(r.Context(), container, blob, src)
 }
 
 // extractCopySource parses x-ms-copy-source which is a full URL like


### PR DESCRIPTION
## Summary

Residue from a confirming re-audit of Azure Blob Storage conditional-header handling. The precondition evaluator existed but was wired into `putBlob` only, so optimistic-concurrency writes on a stale ETag silently succeeded on every other mutating op — a lost-update hazard.

### HIGH — silent lost-update: conditional WRITE preconditions enforced on all mutating ops
`If-Match`/`If-None-Match` are now evaluated on every mutating data-plane op, not just plain Put Blob: `CommitBlockList`, `SetMetadata`, `SetProperties`, `SetTier`, `AppendBlock`, `Snapshot`, create Append Blob, `Copy`, and `DELETE`. Lease checks are preserved (both lease AND conditional headers apply). A mismatched `If-Match` returns 412 `ConditionNotMet`; `If-None-Match:*` on an existing blob returns 409 `BlobAlreadyExists` for creates (Put Blob / create Append Blob) and 412 for other writes, per the Azure write-operations response-code table.

### MED — Copy Blob honors x-ms-meta-* override
Per the Azure Copy Blob spec: if the copy request supplies any `x-ms-meta-*`, the destination gets exactly that metadata (full replace, none inherited); with none supplied, the destination inherits the source's. Routed through the existing `ObjectCopier`/`CopyObjectRequest.ReplaceMetadata` capability (mirroring S3); the Azure provider now implements `CopyObjectV2`, sharing a single copy path with `CopyObject`.

### MED — conditional READS
`getBlob`/`headBlob` now evaluate read conditionals before writing a body: `If-None-Match` matching the current ETag (including `*`) returns 304 Not Modified; a mismatched `If-Match` returns 412.

## Tests
Real azblob reproductions: CommitBlockList/SetMetadata/SetProperties/SetTier/AppendBlock/DELETE with a mismatched `If-Match` → 412 (blob unchanged) and a matching `If-Match` → success; Copy with fresh metadata over a source → destination has only the fresh set; Copy with no metadata → destination inherits the source's; GET/HEAD `If-None-Match:<current etag>` → 304; GET `If-Match:<wrong>` → 412. Provider-level `CopyObjectV2` replace/inherit tests added. First-round tests (lease carry-over, snapshot immutability, SAS, fail-closed comp, -race) stay green.

Gates: build, vet, scoped tests, -race, gofmt, golangci-lint (0 new), go generate (zero diff), compatgen (zero diff) all green.