### PR TITLE
fix(aws-rgta): ResourceTypeFilters from ARN; ElastiCache ARN; broaden TagResources coverage; pagination

### DIFF
--- a/providers/aws/rds_discovery.go
+++ b/providers/aws/rds_discovery.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
 )
@@ -20,6 +21,27 @@ type redshiftClusters interface {
 type rdsDiscovery struct {
 	m        rdsdriver.RelationalDB
 	redshift redshiftClusters
+}
+
+// AddTagsToResource lets the Resource Groups Tagging API apply tags to an RDS
+// resource by its ARN, delegating to the RDS mock's optional Tagging capability.
+func (a rdsDiscovery) AddTagsToResource(ctx context.Context, arn string, tags map[string]string) error {
+	tg, ok := a.m.(rdsdriver.Tagging)
+	if !ok {
+		return cerrors.New(cerrors.FailedPrecondition, "relational database driver does not support tagging")
+	}
+
+	return tg.AddTagsToResource(ctx, arn, tags)
+}
+
+// RemoveTagsFromResource removes tags from an RDS resource by its ARN.
+func (a rdsDiscovery) RemoveTagsFromResource(ctx context.Context, arn string, keys []string) error {
+	tg, ok := a.m.(rdsdriver.Tagging)
+	if !ok {
+		return cerrors.New(cerrors.FailedPrecondition, "relational database driver does not support tagging")
+	}
+
+	return tg.RemoveTagsFromResource(ctx, arn, keys)
 }
 
 func (a rdsDiscovery) DiscoverDatabases(ctx context.Context) ([]resourcediscovery.DiscoveredDatabase, error) {

--- a/server/aws/resourcegroupstaggingapi/handler.go
+++ b/server/aws/resourcegroupstaggingapi/handler.go
@@ -28,6 +28,10 @@ const (
 // resource-not-found.
 const errInvalidParameter = "InvalidParameterException"
 
+// tagPageSize is the internal page size for GetTagKeys/GetTagValues, which
+// (unlike GetResources) carry no client-supplied page-size parameter.
+const tagPageSize = 100
+
 // Handler serves Resource Groups Tagging API JSON-RPC requests.
 type Handler struct {
 	engine *resourcediscovery.Engine
@@ -73,6 +77,8 @@ func (h *Handler) getResources(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		ResourceTypeFilters []string    `json:"ResourceTypeFilters"`
 		TagFilters          []tagFilter `json:"TagFilters"`
+		ResourcesPerPage    int         `json:"ResourcesPerPage"`
+		PaginationToken     string      `json:"PaginationToken"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -85,18 +91,19 @@ func (h *Handler) getResources(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(all))
+	matched := make([]*resourcediscovery.Resource, 0, len(all))
 
 	for i := range all {
 		res := &all[i]
-		if !matchesTypeFilter(res, req.ResourceTypeFilters) {
-			continue
+		if matchesTypeFilter(res, req.ResourceTypeFilters) && matchesTagFilters(res, req.TagFilters) {
+			matched = append(matched, res)
 		}
+	}
 
-		if !matchesTagFilters(res, req.TagFilters) {
-			continue
-		}
+	from, to, next := page(len(matched), req.PaginationToken, req.ResourcesPerPage)
 
+	out := make([]map[string]any, 0, to-from)
+	for _, res := range matched[from:to] {
 		out = append(out, map[string]any{
 			"ResourceARN": res.ARN,
 			"Tags":        toTagList(res.Tags),
@@ -105,12 +112,15 @@ func (h *Handler) getResources(w http.ResponseWriter, r *http.Request) {
 
 	wire.WriteJSON(w, map[string]any{
 		"ResourceTagMappingList": out,
-		"PaginationToken":        "",
+		"PaginationToken":        next,
 	})
 }
 
 func (h *Handler) getTagKeys(w http.ResponseWriter, r *http.Request) {
-	var req struct{}
+	var req struct {
+		PaginationToken string `json:"PaginationToken"`
+	}
+
 	if !wire.DecodeJSON(w, r, &req) {
 		return
 	}
@@ -121,15 +131,18 @@ func (h *Handler) getTagKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	from, to, next := page(len(keys), req.PaginationToken, tagPageSize)
+
 	wire.WriteJSON(w, map[string]any{
-		"TagKeys":         keys,
-		"PaginationToken": "",
+		"TagKeys":         keys[from:to],
+		"PaginationToken": next,
 	})
 }
 
 func (h *Handler) getTagValues(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Key string `json:"Key"`
+		Key             string `json:"Key"`
+		PaginationToken string `json:"PaginationToken"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -147,9 +160,11 @@ func (h *Handler) getTagValues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	from, to, next := page(len(vals), req.PaginationToken, tagPageSize)
+
 	wire.WriteJSON(w, map[string]any{
-		"TagValues":       vals,
-		"PaginationToken": "",
+		"TagValues":       vals[from:to],
+		"PaginationToken": next,
 	})
 }
 
@@ -163,14 +178,17 @@ func (h *Handler) tagResources(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(req.ResourceARNList) == 0 {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException",
+			"1 validation error detected: ResourceARNList must have at least 1 element")
+		return
+	}
+
 	failed := map[string]map[string]string{}
 
 	for _, arn := range req.ResourceARNList {
 		if err := h.engine.TagResourceByARN(r.Context(), arn, req.Tags); err != nil {
-			failed[arn] = map[string]string{
-				"ErrorCode":    awsErrorCode(err),
-				"ErrorMessage": err.Error(),
-			}
+			failed[arn] = failedResource(arn, err)
 		}
 	}
 
@@ -189,14 +207,17 @@ func (h *Handler) untagResources(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(req.ResourceARNList) == 0 {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException",
+			"1 validation error detected: ResourceARNList must have at least 1 element")
+		return
+	}
+
 	failed := map[string]map[string]string{}
 
 	for _, arn := range req.ResourceARNList {
 		if err := h.engine.UntagResourceByARN(r.Context(), arn, req.TagKeys); err != nil {
-			failed[arn] = map[string]string{
-				"ErrorCode":    awsErrorCode(err),
-				"ErrorMessage": err.Error(),
-			}
+			failed[arn] = failedResource(arn, err)
 		}
 	}
 
@@ -210,12 +231,19 @@ func matchesTypeFilter(r *resourcediscovery.Resource, filters []string) bool {
 		return true
 	}
 
+	// The AWS service token is authoritative when read from the resource's own
+	// ARN (segment 3 of arn:aws:<service>:…), which every service populates. Fall
+	// back to the portable→AWS name map only for rows whose identifier is not a
+	// real ARN (e.g. a Route 53 hosted-zone id).
+	awsService := awsServiceFromARN(r.ARN)
+	if awsService == "" {
+		awsService = portableToAWSService(r.Service)
+	}
+
 	// Filter syntax: "service" (e.g., "s3") or "service:type" (e.g., "dynamodb:table").
 	for _, f := range filters {
 		svc, rt, hasType := strings.Cut(f, ":")
-		// Translate portable service to AWS service name for matching.
-		awsService := portableToAWSService(r.Service)
-		if svc != awsService {
+		if !strings.EqualFold(svc, awsService) {
 			continue
 		}
 
@@ -229,6 +257,22 @@ func matchesTypeFilter(r *resourcediscovery.Resource, filters []string) bool {
 	}
 
 	return false
+}
+
+// awsServiceFromARN returns the service token (segment 3) of an arn:aws:<service>:…
+// ARN, or "" when the identifier is not an AWS ARN.
+func awsServiceFromARN(arn string) string {
+	const prefix = "arn:aws:"
+	if !strings.HasPrefix(arn, prefix) {
+		return ""
+	}
+
+	svc, _, ok := strings.Cut(arn[len(prefix):], ":")
+	if !ok {
+		return ""
+	}
+
+	return svc
 }
 
 func portableToAWSService(s string) string {
@@ -281,6 +325,20 @@ func toTagList(tags map[string]string) []map[string]string {
 	}
 
 	return out
+}
+
+// failedResource renders a FailedResourcesMap entry without leaking internal
+// cerrors phrasing — the ErrorMessage is a stable, AWS-plausible string keyed on
+// the surfaced error code.
+func failedResource(arn string, err error) map[string]string {
+	code := awsErrorCode(err)
+
+	msg := "An internal error occurred while processing the resource"
+	if code == errInvalidParameter {
+		msg = "The specified resource ARN is not valid or the resource was not found: " + arn
+	}
+
+	return map[string]string{"ErrorCode": code, "ErrorMessage": msg}
 }
 
 func awsErrorCode(err error) string {

--- a/server/aws/resourcegroupstaggingapi/paging.go
+++ b/server/aws/resourcegroupstaggingapi/paging.go
@@ -1,0 +1,54 @@
+package resourcegroupstaggingapi
+
+import (
+	"encoding/base64"
+	"strconv"
+)
+
+// page resolves the [from,to) window and the next PaginationToken for a slice of
+// the given length, resuming from token and chunking in size-element pages. A
+// size <= 0 means "no client-imposed page size" — the rest of the slice is
+// returned in one page. next is "" when no further page remains.
+func page(total int, token string, size int) (from, to int, next string) {
+	start := decodeOffsetToken(token)
+	if start > total {
+		start = total
+	}
+
+	if size <= 0 {
+		size = total - start
+	}
+
+	end := start + size
+	if end >= total {
+		return start, total, ""
+	}
+
+	return start, end, encodeOffsetToken(end)
+}
+
+// decodeOffsetToken parses a PaginationToken produced by encodeOffsetToken back
+// into a slice offset. An empty or malformed token yields offset 0 so a stray
+// token never wedges pagination.
+func decodeOffsetToken(tok string) int {
+	if tok == "" {
+		return 0
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(tok)
+	if err != nil {
+		return 0
+	}
+
+	n, err := strconv.Atoi(string(raw))
+	if err != nil || n < 0 {
+		return 0
+	}
+
+	return n
+}
+
+// encodeOffsetToken renders a slice offset as an opaque PaginationToken.
+func encodeOffsetToken(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}

--- a/server/aws/resourcegroupstaggingapi/sdk_test.go
+++ b/server/aws/resourcegroupstaggingapi/sdk_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net/http/httptest"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -19,14 +20,17 @@ import (
 
 	"github.com/stackshy/cloudemu/v2"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
 	serverlessdriver "github.com/stackshy/cloudemu/v2/services/serverless/driver"
-	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 func TestSDKResourceGroupsTagging(t *testing.T) {
@@ -225,6 +229,180 @@ func TestSDKResourceGroupsTagging(t *testing.T) {
 		fail := out.FailedResourcesMap["arn:aws:kms:us-east-1:123456789012:key/abc"]
 		assert.Equal(t, "InvalidParameterException", string(fail.ErrorCode))
 	})
+}
+
+func TestSDKResourceGroupsTaggingTypeFilterAndPaging(t *testing.T) {
+	ctx := context.Background()
+	cloud := cloudemu.NewAWS()
+
+	// F1/F2 fixtures: one resource of several aggregated-but-previously-unfilterable
+	// services, each carrying a real ARN.
+	_, err := cloud.SecretsManager.CreateSecret(ctx, secretsdriver.SecretConfig{Name: "db-cred"}, []byte("v"))
+	require.NoError(t, err)
+
+	_, err = cloud.SQS.CreateQueue(ctx, mqdriver.QueueConfig{Name: "jobs"})
+	require.NoError(t, err)
+
+	_, err = cloud.ElastiCache.CreateCache(ctx, cachedriver.CacheConfig{
+		Name: "cache1", NodeType: "cache.t3.micro", Engine: "redis",
+	})
+	require.NoError(t, err)
+
+	_, err = cloud.RDS.CreateInstance(ctx, rdsdriver.InstanceConfig{
+		ID: "orders", Engine: "mysql", InstanceClass: "db.t3.micro",
+	})
+	require.NoError(t, err)
+
+	_, err = cloud.ECR.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "web"})
+	require.NoError(t, err)
+
+	srv := awsserver.New(awsserver.Drivers{
+		ResourceDiscovery: cloud.ResourceDiscovery,
+		AccountID:         "123456789012",
+		Region:            "us-east-1",
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newRGTAClient(t, ts.URL)
+
+	cacheARN := "arn:aws:elasticache:us-east-1:123456789012:cluster:cache1"
+	rdsARN := "arn:aws:rds:us-east-1:123456789012:db:orders"
+	ecrARN := "arn:aws:ecr:us-east-1:123456789012:repository/web"
+
+	t.Run("ResourceTypeFilters select the right service (F1)", func(t *testing.T) {
+		// Each service filter must return exactly its one resource, whose ARN
+		// carries that service token (segment 3). Secrets Manager appends a random
+		// suffix to the secret name, so match on the ARN prefix rather than a
+		// hardcoded id.
+		for _, filter := range []string{"secretsmanager", "sqs", "elasticache", "rds", "ecr"} {
+			out, err := client.GetResources(ctx, &rgta.GetResourcesInput{
+				ResourceTypeFilters: []string{filter},
+			})
+			require.NoError(t, err, filter)
+			arns := arnSet(out.ResourceTagMappingList)
+			require.Len(t, arns, 1, "filter %q should return exactly its one resource", filter)
+			assert.True(t, strings.HasPrefix(arns[0], "arn:aws:"+filter+":"),
+				"filter %q returned %q, want an arn:aws:%s ARN", filter, arns[0], filter)
+		}
+	})
+
+	t.Run("ElastiCache ResourceARN is an ARN, not an endpoint (F2)", func(t *testing.T) {
+		out, err := client.GetResources(ctx, &rgta.GetResourcesInput{
+			ResourceTypeFilters: []string{"elasticache"},
+		})
+		require.NoError(t, err)
+		require.Len(t, out.ResourceTagMappingList, 1)
+		assert.Equal(t, cacheARN, aws.ToString(out.ResourceTagMappingList[0].ResourceARN))
+	})
+
+	t.Run("TagResources round-trips on rds/elasticache/ecr (F3)", func(t *testing.T) {
+		out, err := client.TagResources(ctx, &rgta.TagResourcesInput{
+			ResourceARNList: []string{cacheARN, rdsARN, ecrARN},
+			Tags:            map[string]string{"Owner": "platform"},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, out.FailedResourcesMap, "all three should tag cleanly")
+
+		// Visible on each service's own read.
+		caches, err := cloud.ElastiCache.ListTags(ctx, cacheARN)
+		require.NoError(t, err)
+		assert.Equal(t, "platform", caches["Owner"])
+
+		rdsTags, err := cloud.RDS.ListTagsForResource(ctx, rdsARN)
+		require.NoError(t, err)
+		assert.Equal(t, "platform", rdsTags["Owner"])
+
+		repos, err := cloud.ECR.ListRepositories(ctx)
+		require.NoError(t, err)
+		ecrTags := map[string]string{}
+		for i := range repos {
+			if repos[i].Name == "web" {
+				ecrTags = repos[i].Tags
+			}
+		}
+		assert.Equal(t, "platform", ecrTags["Owner"])
+
+		// And visible on a subsequent GetResources for that ARN.
+		got, err := client.GetResources(ctx, &rgta.GetResourcesInput{
+			ResourceTypeFilters: []string{"rds"},
+		})
+		require.NoError(t, err)
+		require.Len(t, got.ResourceTagMappingList, 1)
+		assert.Equal(t, "platform", tagsToMap(got.ResourceTagMappingList[0].Tags)["Owner"])
+	})
+
+	t.Run("genuinely unsupported service still reports a failure (F3)", func(t *testing.T) {
+		badARN := "arn:aws:cloudwatch:us-east-1:123456789012:alarm:cpu-high"
+		out, err := client.TagResources(ctx, &rgta.TagResourcesInput{
+			ResourceARNList: []string{badARN},
+			Tags:            map[string]string{"k": "v"},
+		})
+		require.NoError(t, err)
+		require.Len(t, out.FailedResourcesMap, 1)
+		assert.Equal(t, "InvalidParameterException", string(out.FailedResourcesMap[badARN].ErrorCode))
+	})
+
+	t.Run("empty ResourceARNList is rejected", func(t *testing.T) {
+		_, err := client.TagResources(ctx, &rgta.TagResourcesInput{
+			ResourceARNList: []string{},
+			Tags:            map[string]string{"k": "v"},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("ResourcesPerPage + PaginationToken (F4)", func(t *testing.T) {
+		total := len(mustGetAll(ctx, t, client))
+		require.GreaterOrEqual(t, total, 5, "need several resources to page")
+
+		seen := map[string]bool{}
+		token := ""
+		pages := 0
+
+		for {
+			out, err := client.GetResources(ctx, &rgta.GetResourcesInput{
+				ResourcesPerPage: aws.Int32(2),
+				PaginationToken:  aws.String(token),
+			})
+			require.NoError(t, err)
+			assert.LessOrEqual(t, len(out.ResourceTagMappingList), 2, "page must not exceed ResourcesPerPage")
+
+			for _, m := range out.ResourceTagMappingList {
+				arn := aws.ToString(m.ResourceARN)
+				assert.False(t, seen[arn], "resource %q returned twice across pages", arn)
+				seen[arn] = true
+			}
+
+			pages++
+			token = aws.ToString(out.PaginationToken)
+			if token == "" {
+				break
+			}
+
+			require.Less(t, pages, total+2, "pagination did not terminate")
+		}
+
+		assert.Len(t, seen, total, "paging must cover every resource exactly once")
+		assert.Greater(t, pages, 1, "a page size of 2 over 5+ resources must span multiple pages")
+	})
+}
+
+func mustGetAll(ctx context.Context, t *testing.T, client *rgta.Client) []rgtatypes.ResourceTagMapping {
+	t.Helper()
+
+	out, err := client.GetResources(ctx, &rgta.GetResourcesInput{})
+	require.NoError(t, err)
+
+	return out.ResourceTagMappingList
+}
+
+func arnSet(list []rgtatypes.ResourceTagMapping) []string {
+	out := make([]string, 0, len(list))
+	for _, m := range list {
+		out = append(out, aws.ToString(m.ResourceARN))
+	}
+
+	return out
 }
 
 func newRGTAClient(t *testing.T, baseURL string) *rgta.Client {

--- a/services/resourcediscovery/tagging.go
+++ b/services/resourcediscovery/tagging.go
@@ -10,13 +10,18 @@ import (
 
 // AWS service identifiers as they appear in ARNs.
 const (
-	awsServiceS3       = "s3"
-	awsServiceDynamoDB = "dynamodb"
-	awsServiceEC2      = "ec2"
-	awsServiceLambda   = "lambda"
-	awsServiceSecrets  = "secretsmanager"
-	awsServiceSNS      = "sns"
-	awsServiceSQS      = "sqs"
+	awsServiceS3          = "s3"
+	awsServiceDynamoDB    = "dynamodb"
+	awsServiceEC2         = "ec2"
+	awsServiceLambda      = "lambda"
+	awsServiceSecrets     = "secretsmanager"
+	awsServiceSNS         = "sns"
+	awsServiceSQS         = "sqs"
+	awsServiceElastiCache = "elasticache"
+	awsServiceECR         = "ecr"
+	awsServiceLogs        = "logs"
+	awsServiceRDS         = "rds"
+	awsServiceIAM         = "iam"
 )
 
 // DynamoDB resource type within a DynamoDB ARN.
@@ -37,6 +42,14 @@ const (
 	secretsTypeSecret  = "secret"
 )
 
+// ECR / CloudWatch Logs / IAM resource-type prefixes within their ARNs.
+const (
+	ecrTypeRepository = "repository"
+	logsTypeLogGroup  = "log-group"
+	iamTypeRole       = "role"
+	iamTypeUser       = "user"
+)
+
 // arnParts is the number of colon-separated segments in a fully-qualified
 // AWS ARN: arn:partition:service:region:account:resource.
 const arnParts = 6
@@ -55,9 +68,15 @@ const arnParts = 6
 //   - Secrets Manager:      arn:aws:secretsmanager:region:account:secret:name
 //   - SNS topic:            arn:aws:sns:region:account:name
 //   - SQS queue:            arn:aws:sqs:region:account:name
+//   - ElastiCache:          arn:aws:elasticache:region:account:cluster:name
+//   - ECR repository:       arn:aws:ecr:region:account:repository/name
+//   - CloudWatch Logs:      arn:aws:logs:region:account:log-group:name
+//   - RDS:                  arn:aws:rds:region:account:db:name
+//   - IAM role/user:        arn:aws:iam::account:{role,user}/name
 //
 // Returns InvalidArgument for services/resource types without a tag store
-// (e.g. CloudWatch alarms, IAM, RDS) or for unparseable ARNs.
+// (e.g. CloudWatch alarms, Route 53 zones, IAM policies/groups) or for
+// unparseable ARNs.
 func (e *Engine) TagResourceByARN(ctx context.Context, arn string, tags map[string]string) error {
 	res, err := parseSupportedARN(arn)
 	if err != nil {
@@ -100,25 +119,31 @@ func parseSupportedARN(arn string) (parsedARN, error) {
 	service := parts[2]
 	resource := parts[5]
 
-	switch service {
-	case awsServiceS3:
-		return parseS3ARN(arn, resource)
-	case awsServiceDynamoDB:
-		return parseDynamoDBARN(arn, resource)
-	case awsServiceEC2:
-		return parseEC2ARN(arn, resource)
-	case awsServiceLambda:
-		return parseLambdaARN(arn, resource)
-	case awsServiceSecrets:
-		return parseSecretsARN(arn, resource)
-	case awsServiceSNS:
-		return parseSNSARN(arn, resource)
-	case awsServiceSQS:
-		return parseSQSARN(arn, resource)
-	default:
+	// Each supported AWS service parses its resource segment into the routing
+	// fragments the tag dispatcher needs. A service absent from the table has no
+	// tag store wired (or no ARN shape we tag), and is reported as unsupported.
+	parsers := map[string]func(arn, resource string) (parsedARN, error){
+		awsServiceS3:          parseS3ARN,
+		awsServiceDynamoDB:    parseDynamoDBARN,
+		awsServiceEC2:         parseEC2ARN,
+		awsServiceLambda:      parseLambdaARN,
+		awsServiceSecrets:     parseSecretsARN,
+		awsServiceSNS:         parseSNSARN,
+		awsServiceSQS:         parseSQSARN,
+		awsServiceElastiCache: parseElastiCacheARN,
+		awsServiceECR:         parseECRARN,
+		awsServiceLogs:        parseLogsARN,
+		awsServiceRDS:         parseRDSARN,
+		awsServiceIAM:         parseIAMARN,
+	}
+
+	parse, ok := parsers[service]
+	if !ok {
 		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument,
 			"tagging service %q is not yet supported", service)
 	}
+
+	return parse(arn, resource)
 }
 
 func parseS3ARN(arn, resource string) (parsedARN, error) {
@@ -214,6 +239,77 @@ func parseSQSARN(arn, resource string) (parsedARN, error) {
 	return parsedARN{service: awsServiceSQS, id: resource}, nil
 }
 
+// parseElastiCacheARN accepts arn:aws:elasticache:region:account:{cluster|
+// replicationgroup|snapshot|parametergroup|subnetgroup}:name. ElastiCache tags
+// are addressed by the full ARN, so the whole ARN is carried as the id.
+func parseElastiCacheARN(arn, resource string) (parsedARN, error) {
+	rt, id, ok := splitTypeID(resource, ':')
+	if !ok || id == "" {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "expected ElastiCache ARN, got %q", arn)
+	}
+
+	return parsedARN{service: awsServiceElastiCache, resourceType: rt, id: arn}, nil
+}
+
+// parseECRARN accepts arn:aws:ecr:region:account:repository/name.
+func parseECRARN(arn, resource string) (parsedARN, error) {
+	rt, id, ok := splitTypeID(resource, '/')
+	if !ok || rt != ecrTypeRepository || id == "" {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "expected ECR repository ARN, got %q", arn)
+	}
+
+	return parsedARN{service: awsServiceECR, resourceType: rt, id: id}, nil
+}
+
+// parseLogsARN accepts arn:aws:logs:region:account:log-group:name — and the
+// stream-qualified form (…:log-group:name:*) — resolving both to the group
+// name, since a log group's tags are the tag-operation target.
+func parseLogsARN(arn, resource string) (parsedARN, error) {
+	rt, rest, ok := splitTypeID(resource, ':')
+	if !ok || rt != logsTypeLogGroup || rest == "" {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "expected CloudWatch Logs log-group ARN, got %q", arn)
+	}
+
+	name := rest
+	if i := strings.IndexByte(rest, ':'); i >= 0 {
+		name = rest[:i] // strip a trailing :* stream qualifier
+	}
+
+	if name == "" {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "CloudWatch Logs ARN missing group name: %q", arn)
+	}
+
+	return parsedARN{service: awsServiceLogs, resourceType: rt, id: name}, nil
+}
+
+// parseRDSARN accepts arn:aws:rds:region:account:{db|cluster|snapshot|...}:name.
+// RDS tags are addressed by the full ARN, so the whole ARN is carried as the id.
+func parseRDSARN(arn, resource string) (parsedARN, error) {
+	rt, id, ok := splitTypeID(resource, ':')
+	if !ok || id == "" {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "expected RDS ARN, got %q", arn)
+	}
+
+	return parsedARN{service: awsServiceRDS, resourceType: rt, id: arn}, nil
+}
+
+// parseIAMARN accepts arn:aws:iam::account:{role|user}/name. Only roles and
+// users carry a tag store; other IAM resource types are rejected as untaggable.
+func parseIAMARN(arn, resource string) (parsedARN, error) {
+	rt, id, ok := splitTypeID(resource, '/')
+	if !ok || id == "" {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "malformed IAM ARN: %q", arn)
+	}
+
+	switch rt {
+	case iamTypeRole, iamTypeUser:
+		return parsedARN{service: awsServiceIAM, resourceType: rt, id: id}, nil
+	default:
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument,
+			"tagging IAM resource type %q is not supported", rt)
+	}
+}
+
 func splitTypeID(s string, sep rune) (rt, id string, ok bool) {
 	for i, r := range s {
 		if r == sep {
@@ -234,28 +330,38 @@ func isEC2ComputeType(rt string) bool {
 }
 
 func (e *Engine) dispatchTag(ctx context.Context, res parsedARN, tags map[string]string, set bool, keys []string) error {
-	switch res.service {
-	case awsServiceS3:
-		return e.tagS3(ctx, res.id, tags, set, keys)
-	case awsServiceDynamoDB:
-		return e.tagDynamoDB(ctx, res.id, tags, set, keys)
-	case awsServiceEC2:
-		if isEC2ComputeType(res.resourceType) {
-			return e.tagEC2Compute(ctx, res.id, tags, set, keys)
-		}
+	routes := map[string]func() error{
+		awsServiceS3:          func() error { return e.tagS3(ctx, res.id, tags, set, keys) },
+		awsServiceDynamoDB:    func() error { return e.tagDynamoDB(ctx, res.id, tags, set, keys) },
+		awsServiceEC2:         func() error { return e.tagEC2(ctx, res, tags, set, keys) },
+		awsServiceLambda:      func() error { return e.tagLambda(ctx, res.id, tags, set, keys) },
+		awsServiceSecrets:     func() error { return e.tagSecret(ctx, res.id, tags, set, keys) },
+		awsServiceSNS:         func() error { return e.tagTopic(ctx, res.id, tags, set, keys) },
+		awsServiceSQS:         func() error { return e.tagQueue(ctx, res.id, tags, set, keys) },
+		awsServiceElastiCache: func() error { return e.tagCache(ctx, res.id, tags, set, keys) },
+		awsServiceECR:         func() error { return e.tagRepository(ctx, res.id, tags, set, keys) },
+		awsServiceLogs:        func() error { return e.tagLogGroup(ctx, res.id, tags, set, keys) },
+		awsServiceRDS:         func() error { return e.tagRDS(ctx, res.id, tags, set, keys) },
+		awsServiceIAM:         func() error { return e.tagIAM(ctx, res.resourceType, res.id, tags, set, keys) },
+	}
 
-		return e.tagEC2Network(ctx, res.resourceType, res.id, tags, set, keys)
-	case awsServiceLambda:
-		return e.tagLambda(ctx, res.id, tags, set, keys)
-	case awsServiceSecrets:
-		return e.tagSecret(ctx, res.id, tags, set, keys)
-	case awsServiceSNS:
-		return e.tagTopic(ctx, res.id, tags, set, keys)
-	case awsServiceSQS:
-		return e.tagQueue(ctx, res.id, tags, set, keys)
-	default:
+	route, ok := routes[res.service]
+	if !ok {
 		return cerrors.Newf(cerrors.InvalidArgument, "internal: unrouted parsedARN %+v", res)
 	}
+
+	return route()
+}
+
+// tagEC2 routes an EC2 ARN to the compute or networking tag store by its
+// resource type (instance/volume/snapshot/image → compute; vpc/subnet/
+// security-group → networking).
+func (e *Engine) tagEC2(ctx context.Context, res parsedARN, tags map[string]string, set bool, keys []string) error {
+	if isEC2ComputeType(res.resourceType) {
+		return e.tagEC2Compute(ctx, res.id, tags, set, keys)
+	}
+
+	return e.tagEC2Network(ctx, res.resourceType, res.id, tags, set, keys)
 }
 
 // The tag-mutation methods below are provider-specific: only the AWS mocks
@@ -290,6 +396,42 @@ type topicTagger interface {
 type queueTagger interface {
 	TagQueue(ctx context.Context, queueURL string, tags map[string]string) error
 	UntagQueue(ctx context.Context, queueURL string, keys []string) error
+}
+
+// cacheTagger is implemented by the AWS ElastiCache mock; it tags a cache
+// cluster / replication group by its full ARN.
+type cacheTagger interface {
+	AddTags(ctx context.Context, arn string, tags map[string]string) error
+	RemoveTags(ctx context.Context, arn string, keys []string) error
+}
+
+// repositoryTagger is implemented by the AWS ECR mock; it tags a repository by
+// its short name.
+type repositoryTagger interface {
+	TagRepository(ctx context.Context, name string, tags map[string]string) error
+	UntagRepository(ctx context.Context, name string, keys []string) error
+}
+
+// logGroupTagger is implemented by the AWS CloudWatch Logs mock; it tags a log
+// group by its name.
+type logGroupTagger interface {
+	TagLogGroup(ctx context.Context, name string, tags map[string]string) error
+	UntagLogGroup(ctx context.Context, name string, keys []string) error
+}
+
+// relationalDBTagger is implemented by the AWS RDS discovery adapter (delegating
+// to the RDS mock); it tags an RDS instance/cluster/snapshot by its full ARN.
+type relationalDBTagger interface {
+	AddTagsToResource(ctx context.Context, arn string, tags map[string]string) error
+	RemoveTagsFromResource(ctx context.Context, arn string, keys []string) error
+}
+
+// iamTagger is implemented by the AWS IAM mock; it tags roles and users by name.
+type iamTagger interface {
+	TagRole(ctx context.Context, name string, tags map[string]string) error
+	UntagRole(ctx context.Context, name string, keys []string) error
+	TagUser(ctx context.Context, name string, tags map[string]string) error
+	UntagUser(ctx context.Context, name string, keys []string) error
 }
 
 func (e *Engine) tagS3(ctx context.Context, bucket string, tags map[string]string, set bool, keys []string) error {
@@ -442,6 +584,84 @@ func (e *Engine) tagQueue(ctx context.Context, name string, tags map[string]stri
 	}
 
 	return qt.UntagQueue(ctx, url, keys)
+}
+
+func (e *Engine) tagCache(ctx context.Context, arn string, tags map[string]string, set bool, keys []string) error {
+	ct, err := driverAs[cacheTagger](e.drivers.Cache, "cache")
+	if err != nil {
+		return err
+	}
+
+	if set {
+		return ct.AddTags(ctx, arn, tags)
+	}
+
+	return ct.RemoveTags(ctx, arn, keys)
+}
+
+func (e *Engine) tagRepository(ctx context.Context, name string, tags map[string]string, set bool, keys []string) error {
+	rt, err := driverAs[repositoryTagger](e.drivers.ContainerReg, "container registry")
+	if err != nil {
+		return err
+	}
+
+	if set {
+		return rt.TagRepository(ctx, name, tags)
+	}
+
+	return rt.UntagRepository(ctx, name, keys)
+}
+
+func (e *Engine) tagLogGroup(ctx context.Context, name string, tags map[string]string, set bool, keys []string) error {
+	lt, err := driverAs[logGroupTagger](e.drivers.Logging, "logging")
+	if err != nil {
+		return err
+	}
+
+	if set {
+		return lt.TagLogGroup(ctx, name, tags)
+	}
+
+	return lt.UntagLogGroup(ctx, name, keys)
+}
+
+func (e *Engine) tagRDS(ctx context.Context, arn string, tags map[string]string, set bool, keys []string) error {
+	rt, err := driverAs[relationalDBTagger](e.drivers.RelationalDB, "relational database")
+	if err != nil {
+		return err
+	}
+
+	if set {
+		return rt.AddTagsToResource(ctx, arn, tags)
+	}
+
+	return rt.RemoveTagsFromResource(ctx, arn, keys)
+}
+
+func (e *Engine) tagIAM(ctx context.Context, resourceType, id string,
+	tags map[string]string, set bool, keys []string,
+) error {
+	it, err := driverAs[iamTagger](e.drivers.IAM, "iam")
+	if err != nil {
+		return err
+	}
+
+	switch resourceType {
+	case iamTypeRole:
+		if set {
+			return it.TagRole(ctx, id, tags)
+		}
+
+		return it.UntagRole(ctx, id, keys)
+	case iamTypeUser:
+		if set {
+			return it.TagUser(ctx, id, tags)
+		}
+
+		return it.UntagUser(ctx, id, keys)
+	default:
+		return cerrors.Newf(cerrors.InvalidArgument, "tagging IAM resource type %q is not supported", resourceType)
+	}
 }
 
 func (e *Engine) resolveQueueURL(ctx context.Context, name string) (string, error) {

--- a/services/resourcediscovery/walkers.go
+++ b/services/resourcediscovery/walkers.go
@@ -765,6 +765,17 @@ func (e *Engine) walkAppServicePlans(ctx context.Context) ([]Resource, error) {
 	return out, nil
 }
 
+// firstNonEmpty returns a if it is non-empty, otherwise b. Used by the walkers
+// to pick a resource's tag-operation ARN with a fallback for providers that
+// model no ARN.
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+
+	return b
+}
+
 func copyTags(src map[string]string) map[string]string {
 	if len(src) == 0 {
 		return nil
@@ -906,7 +917,10 @@ func (e *Engine) walkContainerRegistry(ctx context.Context) ([]Resource, error) 
 
 	return e.emitSimple(ServiceContainer, TypeRepository, len(repos),
 		func(i int) (string, string, map[string]string) {
-			return repos[i].Name, repos[i].URI, repos[i].Tags
+			// Prefer the provider-native ARN (AWS ECR) as the tag-operation handle;
+			// fall back to the registry URI for providers that model no ARN (GCP
+			// Artifact Registry, ACR).
+			return repos[i].Name, firstNonEmpty(repos[i].Arn, repos[i].URI), repos[i].Tags
 		}), nil
 }
 
@@ -986,7 +1000,9 @@ func (e *Engine) walkCache(ctx context.Context) ([]Resource, error) {
 
 	return e.emitSimple(ServiceCache, TypeCacheCluster, len(caches),
 		func(i int) (string, string, map[string]string) {
-			return caches[i].Name, caches[i].Endpoint, caches[i].Tags
+			// The ARN is the tag-operation handle (AWS ElastiCache). Fall back to
+			// the endpoint for providers that model no ARN.
+			return caches[i].Name, firstNonEmpty(caches[i].ARN, caches[i].Endpoint), caches[i].Tags
 		}), nil
 }
 


### PR DESCRIPTION
## What

Fixes bugs in the AWS Resource Groups Tagging API found by a real-SDK deep e2e audit. The cross-service aggregation was already correct; type-filtering, ElastiCache ARNs, tagging coverage, and pagination had gaps.

- **ResourceTypeFilters from ARN (F1):** `GetResources` derives the AWS service token from each resource's own ARN (segment 3 of `arn:aws:<service>:…`) rather than a 4-entry portable→AWS name map. Filters like `secretsmanager`, `sqs`, `sns`, `elasticache`, `rds`, `ecr` now select their resources instead of silently returning nothing. Both `service` and `service:resourceType` filter forms are supported. Falls back to the portable→AWS map only for rows whose identifier is not a real ARN.
- **ElastiCache / ECR ARN (F2):** `walkCache` emits `CacheInfo.ARN` (fallback endpoint) instead of the `host:port` endpoint string; `walkContainerRegistry` emits the ECR ARN (fallback registry URI). These walkers also feed Resource Explorer / Cloud Asset, which now report real ARNs too.
- **Broaden TagResources coverage (F3):** `TagResources`/`UntagResources` now round-trip on `elasticache`, `ecr`, `logs`, `rds`, and `iam` (role/user) via narrow tagger capability interfaces (the existing pattern). RDS routes through the discovery adapter to the RDS `Tagging` capability. Services with no tag store (e.g. CloudWatch alarms, Route 53 zones, IAM policies/groups) still return a `FailedResourcesMap` entry.
- **Pagination (F4):** `ResourcesPerPage` + `PaginationToken` are honored on `GetResources`, and `PaginationToken` on `GetTagKeys`/`GetTagValues` (opaque base64 offset tokens); a token is returned when more remain and resumed without duplicates.
- **Nits:** an empty `ResourceARNList` is rejected with a `ValidationException`; `FailedResourcesMap` error messages no longer leak internal `cerrors` phrasing.

Deferred (out of scope): compliance/report operations + `IncludeComplianceDetails` (F5).

## Why

`ResourceTypeFilters` worked for only 4 services, ElastiCache surfaced an endpoint where an ARN was expected (breaking any consumer that parses `ResourceARN`), most aggregated services could not be tagged through the same API that lists them, and the documented paging contract was ignored.

## Tests

Real `aws-sdk-go-v2/resourcegroupstaggingapi` reproductions: per-service `ResourceTypeFilters`, ElastiCache ARN shape, `TagResources` round-trip on rds/elasticache/ecr (visible on each service's own read + a subsequent `GetResources`), genuinely-unsupported service still failing, empty-list rejection, and `ResourcesPerPage=2` paging with no duplicates. Existing RGTA / resourcediscovery / Resource Explorer / Cloud Asset / Resource Graph tests stay green (`-race` on resourcediscovery too).
