### PR TITLE
fix(azure-cosmos): reject partition-key mutation on Replace (no orphan) + 404 on replace-missing

### DIFF
--- a/server/azure/cosmosdb/cosmos_lifecycle_test.go
+++ b/server/azure/cosmosdb/cosmos_lifecycle_test.go
@@ -428,6 +428,54 @@ func TestCosmosWriteDivergences(t *testing.T) {
 	}
 }
 
+// TestCosmosReplaceSemantics pins the two replace-path invariants real Cosmos
+// enforces: the partition key is immutable (a replace that would move the
+// document to a new partition is rejected 400 and leaves no orphan), and a
+// replace of a non-existent id is a 404, not a silent create.
+func TestCosmosReplaceSemantics(t *testing.T) {
+	ctx := context.Background()
+	env := newCosmosEnv(t)
+	cc := env.container(ctx, t, "repldb", "items")
+
+	createDoc(ctx, t, cc, "books", map[string]any{"id": "i1", "pk": "books", "title": "Dune"})
+
+	// Replacing the document with a body that changes the partition key value
+	// is rejected 400 — the partition key is immutable.
+	moved, _ := json.Marshal(map[string]any{"id": "i1", "pk": "movies", "title": "Dune"})
+
+	_, err := cc.ReplaceItem(ctx, azcosmos.NewPartitionKeyString("books"), "i1", moved, nil)
+	wantRespErr(t, err, 400, "ReplaceItem with mutated partition key")
+
+	// No orphan landed under the attempted new partition.
+	_, err = cc.ReadItem(ctx, azcosmos.NewPartitionKeyString("movies"), "i1", nil)
+	wantRespErr(t, err, 404, "point read under new partition (no orphan)")
+
+	// The original document under the real partition is untouched.
+	if got := readDoc(ctx, t, cc, "books", "i1"); got["title"] != "Dune" || got["pk"] != "books" {
+		t.Errorf("original doc mutated: title=%v pk=%v want Dune/books", got["title"], got["pk"])
+	}
+
+	// A same-partition replace (other fields change) still succeeds.
+	same, _ := json.Marshal(map[string]any{"id": "i1", "pk": "books", "title": "Dune Messiah"})
+	if _, err := cc.ReplaceItem(ctx, azcosmos.NewPartitionKeyString("books"), "i1", same, nil); err != nil {
+		t.Fatalf("same-partition ReplaceItem: %v", err)
+	}
+
+	if got := readDoc(ctx, t, cc, "books", "i1"); got["title"] != "Dune Messiah" {
+		t.Errorf("after same-pk replace title=%v want Dune Messiah", got["title"])
+	}
+
+	// Replacing an id that does not exist is a 404, not a create.
+	ghost, _ := json.Marshal(map[string]any{"id": "ghost", "pk": "books", "title": "Nope"})
+
+	_, err = cc.ReplaceItem(ctx, azcosmos.NewPartitionKeyString("books"), "ghost", ghost, nil)
+	wantRespErr(t, err, 404, "ReplaceItem on non-existent id")
+
+	// The rejected replace did not create the document.
+	_, err = cc.ReadItem(ctx, azcosmos.NewPartitionKeyString("books"), "ghost", nil)
+	wantRespErr(t, err, 404, "point read of ghost after rejected replace")
+}
+
 // TestCosmosQueryAndPagination drives the SDK query pager: empty container
 // first, then 30 documents across two partitions. The WHERE clause is
 // evaluated faithfully, so `c.part = 'part-a'` returns exactly the 15 part-a

--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -746,6 +746,14 @@ func (h *Handler) replaceDocument(ctx context.Context, coll string, cfg *dbdrive
 	unlock := h.writeMu.lock(coll)
 	defer unlock()
 
+	// A replace targets a document that already exists: real Cosmos returns 404
+	// for a replace of a missing id (creation is the upsert path). The existence
+	// check runs under the write lock already held, so the check and the PutItem
+	// stay atomic and no new race is introduced.
+	if !h.documentExists(ctx, coll, cfg, item) {
+		return cerrors.New(cerrors.NotFound, "Entity with the specified id does not exist in the system.")
+	}
+
 	if err := h.db.PutItem(ctx, coll, item); err != nil {
 		return err
 	}
@@ -973,6 +981,19 @@ func (h *Handler) documentResource(w http.ResponseWriter, r *http.Request, accou
 			item[idAttr] = id
 		}
 
+		// The partition key is immutable: a replace whose body carries a
+		// different partition-key value than the one addressed by the request
+		// would land the document under a new partition and orphan the
+		// original. Real Cosmos rejects the mutation with 400 rather than
+		// writing the duplicate.
+		if partitionKeyMutated(cfg, pk, item) {
+			writeErr(w, cerrors.New(cerrors.InvalidArgument,
+				"Partition key provided either doesn't correspond to definition in the collection "+
+					"or doesn't match partition key field values specified in the document."))
+
+			return
+		}
+
 		if err := h.replaceDocument(r.Context(), coll, cfg, item); err != nil {
 			writeErr(w, err)
 			return
@@ -1040,6 +1061,27 @@ func buildKey(pkAttr, pkVal, id string) map[string]any {
 	}
 
 	return key
+}
+
+// partitionKeyMutated reports whether a replace body would move the document to
+// a different partition than the one addressed by the request. Cosmos treats the
+// partition key as immutable, so the body's partition-key value must match the
+// x-ms-documentdb-partitionkey header. Only meaningful for a custom partition
+// key — an /id (or unset) partition key is pinned by the request URL's document
+// id. A body omitting the partition-key attribute is left to the normal write
+// path (it stores under the same identity), so only a present-and-different
+// value is flagged.
+func partitionKeyMutated(cfg *dbdriver.TableConfig, headerPK string, item map[string]any) bool {
+	if cfg == nil || cfg.PartitionKey == "" || cfg.PartitionKey == idAttr {
+		return false
+	}
+
+	bodyPK, ok := item[cfg.PartitionKey]
+	if !ok {
+		return false
+	}
+
+	return fmt.Sprintf("%v", bodyPK) != headerPK
 }
 
 // isUpsert reports whether a document write carries the Cosmos upsert flag,


### PR DESCRIPTION
Confirming re-audit residue in the Cosmos DB data-plane replace path (server/azure/cosmosdb/handler.go). Two localized data-integrity/correctness fixes:

- **[MED — data integrity] Partition-key change on ReplaceItem silently orphaned the document.** A PUT /docs replace whose body carried a different partition-key value than the request's `x-ms-documentdb-partitionkey` header was PutItem'd under the NEW key without removing the original, leaving the document duplicated under both partitions. The partition key is immutable in real Cosmos, which rejects the mutation with 400 BadRequest. The PUT branch now compares the body's partition-key value against the addressed key before writing and returns 400 on mismatch (no orphan written).
- **[LOW] ReplaceItem on a non-existent id created it (200) instead of 404.** `replaceDocument`'s PutItem was an unconditional upsert. It now gates the write behind an existence check under the write lock already held (no new race), returning NotFound so the wire maps to 404.

Documented-as-designed divergences are unchanged (DeleteItem-on-missing 204, PATCH 405, ReplaceItem ignores IfMatchEtag). Round-1 fixes (isolation, custom-pk routing, throughput, indexing/uniqueKeys/TTL, multi-region) are not touched.

Tests: real azcosmos SDK reproduction (TestCosmosReplaceSemantics) asserting the 400 + no-orphan point read + unchanged original + same-pk replace still succeeds + replace-missing 404. All Cosmos gates green (build, vet, test, -race, lint 0, gofmt, go generate zero diff, compatgen zero diff).