### PR TITLE
fix(gcp-firestore): implement field transforms (serverTimestamp/increment/arrayUnion/arrayRemove) — stop transform-only writes wiping the document; != absent-field; updateTime/delete preconditions

### DIFF
--- a/server/gcp/firestore/firestore_transform_test.go
+++ b/server/gcp/firestore/firestore_transform_test.go
@@ -1,0 +1,329 @@
+// These tests drive the REAL cloud.google.com/go/firestore SDK against the
+// emulator's GCP HTTP server, asserting field-transform write semantics
+// (serverTimestamp / increment / arrayUnion / arrayRemove), the "!=" absent-
+// field exclusion, and currentDocument.updateTime / delete preconditions.
+//
+// The central regression they guard: a transform-only write (e.g. Update with
+// only firestore.Increment) must MERGE onto the stored document, never replace
+// it with an empty doc.
+package firestore_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gcpfirestore "cloud.google.com/go/firestore"
+	"google.golang.org/grpc/codes"
+)
+
+// TestDatabaseIncrementNoDataLoss is the CRITICAL data-loss regression: a
+// transform-only Update must increment the target and preserve every other
+// field, not wipe the document.
+func TestDatabaseIncrementNoDataLoss(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "counters")
+
+	doc := client.Collection("counters").Doc("c1")
+
+	if _, err := doc.Set(ctx, map[string]any{"count": 10, "keep": "me"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	if _, err := doc.Update(ctx, []gcpfirestore.Update{
+		{Path: "count", Value: gcpfirestore.Increment(5)},
+	}); err != nil {
+		t.Fatalf("Update Increment: %v", err)
+	}
+
+	snap, err := doc.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	got := snap.Data()
+	if got["count"] != int64(15) {
+		t.Errorf("count=%v (%T), want int64(15)", got["count"], got["count"])
+	}
+
+	if got["keep"] != "me" {
+		t.Errorf("keep=%v, want %q (transform-only write must not wipe other fields)", got["keep"], "me")
+	}
+}
+
+// TestDatabaseIncrementTyping pins numeric typing: int increments stay int64,
+// double increments stay float64, and an increment on an absent field starts
+// from zero.
+func TestDatabaseIncrementTyping(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "typed")
+
+	doc := client.Collection("typed").Doc("t1")
+
+	if _, err := doc.Set(ctx, map[string]any{"i": 10, "f": 1.5}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	if _, err := doc.Update(ctx, []gcpfirestore.Update{
+		{Path: "i", Value: gcpfirestore.Increment(5)},
+		{Path: "f", Value: gcpfirestore.Increment(2.0)},
+		{Path: "fresh", Value: gcpfirestore.Increment(7)},
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	got := mustGet(ctx, t, doc)
+
+	if got["i"] != int64(15) {
+		t.Errorf("i=%v (%T), want int64(15)", got["i"], got["i"])
+	}
+
+	if got["f"] != 3.5 {
+		t.Errorf("f=%v (%T), want float64(3.5)", got["f"], got["f"])
+	}
+
+	// Increment on an absent field starts from 0.
+	if got["fresh"] != int64(7) {
+		t.Errorf("fresh=%v (%T), want int64(7)", got["fresh"], got["fresh"])
+	}
+}
+
+// TestDatabaseServerTimestamp asserts a ServerTimestamp sentinel resolves to a
+// timestamp near now while the plain field is preserved.
+func TestDatabaseServerTimestamp(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "stamps")
+
+	doc := client.Collection("stamps").Doc("s1")
+
+	before := time.Now().Add(-time.Minute)
+
+	if _, err := doc.Set(ctx, map[string]any{"n": 1, "at": gcpfirestore.ServerTimestamp}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	got := mustGet(ctx, t, doc)
+
+	if got["n"] != int64(1) {
+		t.Errorf("n=%v, want int64(1)", got["n"])
+	}
+
+	at, ok := got["at"].(time.Time)
+	if !ok {
+		t.Fatalf("at=%v (%T), want time.Time", got["at"], got["at"])
+	}
+
+	if at.Before(before) || at.After(time.Now().Add(time.Minute)) {
+		t.Errorf("at=%v not within a sane window of now", at)
+	}
+}
+
+// TestDatabaseArrayTransforms asserts ArrayUnion appends only missing elements
+// and ArrayRemove strips all matches, both merging onto the stored array.
+func TestDatabaseArrayTransforms(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "arrays")
+
+	doc := client.Collection("arrays").Doc("a1")
+
+	if _, err := doc.Set(ctx, map[string]any{"tags": []string{"a", "b"}, "keep": "x"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	if _, err := doc.Update(ctx, []gcpfirestore.Update{
+		{Path: "tags", Value: gcpfirestore.ArrayUnion("b", "c")},
+	}); err != nil {
+		t.Fatalf("ArrayUnion: %v", err)
+	}
+
+	got := mustGet(ctx, t, doc)
+	if !equalStrs(toStrs(got["tags"]), []string{"a", "b", "c"}) {
+		t.Errorf("after ArrayUnion tags=%v, want [a b c]", got["tags"])
+	}
+
+	if got["keep"] != "x" {
+		t.Errorf("keep=%v, want x (array transform must not wipe siblings)", got["keep"])
+	}
+
+	if _, err := doc.Update(ctx, []gcpfirestore.Update{
+		{Path: "tags", Value: gcpfirestore.ArrayRemove("a")},
+	}); err != nil {
+		t.Fatalf("ArrayRemove: %v", err)
+	}
+
+	got = mustGet(ctx, t, doc)
+	if !equalStrs(toStrs(got["tags"]), []string{"b", "c"}) {
+		t.Errorf("after ArrayRemove tags=%v, want [b c]", got["tags"])
+	}
+}
+
+// TestDatabaseTransformInBatch asserts a transform inside a WriteBatch commit
+// applies and merges.
+func TestDatabaseTransformInBatch(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "bcount")
+
+	doc := client.Collection("bcount").Doc("b1")
+
+	if _, err := doc.Set(ctx, map[string]any{"count": 100, "keep": "y"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	batch := client.Batch()
+	batch.Update(doc, []gcpfirestore.Update{{Path: "count", Value: gcpfirestore.Increment(1)}})
+
+	if _, err := batch.Commit(ctx); err != nil {
+		t.Fatalf("batch Commit: %v", err)
+	}
+
+	got := mustGet(ctx, t, doc)
+	if got["count"] != int64(101) {
+		t.Errorf("count=%v, want int64(101)", got["count"])
+	}
+
+	if got["keep"] != "y" {
+		t.Errorf("keep=%v, want y", got["keep"])
+	}
+}
+
+// TestDatabaseTransformInTransaction asserts a transform inside RunTransaction
+// applies and merges.
+func TestDatabaseTransformInTransaction(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "tcount")
+
+	doc := client.Collection("tcount").Doc("t1")
+
+	if _, err := doc.Set(ctx, map[string]any{"count": 5, "keep": "z"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	err := client.RunTransaction(ctx, func(_ context.Context, tx *gcpfirestore.Transaction) error {
+		return tx.Update(doc, []gcpfirestore.Update{{Path: "count", Value: gcpfirestore.Increment(2)}})
+	})
+	if err != nil {
+		t.Fatalf("RunTransaction: %v", err)
+	}
+
+	got := mustGet(ctx, t, doc)
+	if got["count"] != int64(7) {
+		t.Errorf("count=%v, want int64(7)", got["count"])
+	}
+
+	if got["keep"] != "z" {
+		t.Errorf("keep=%v, want z", got["keep"])
+	}
+}
+
+// TestDatabaseNotEqualExcludesAbsent asserts a "!=" filter excludes documents
+// whose field is absent, matching real Firestore.
+func TestDatabaseNotEqualExcludesAbsent(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "ne")
+
+	coll := client.Collection("ne")
+
+	if _, err := coll.Doc("has1").Set(ctx, map[string]any{"status": "active"}); err != nil {
+		t.Fatalf("Set has1: %v", err)
+	}
+
+	if _, err := coll.Doc("has2").Set(ctx, map[string]any{"status": "inactive"}); err != nil {
+		t.Fatalf("Set has2: %v", err)
+	}
+
+	// Document with NO status field must be excluded from status != "active".
+	if _, err := coll.Doc("absent").Set(ctx, map[string]any{"other": "1"}); err != nil {
+		t.Fatalf("Set absent: %v", err)
+	}
+
+	got := dbCollectAll(t, coll.Where("status", "!=", "active").Documents(ctx))
+	if len(got) != 1 {
+		t.Errorf("status != active returned %d docs (%v), want 1 (absent-field doc excluded)", len(got), keysOfDB(got))
+	}
+
+	if _, ok := got["has2"]; !ok {
+		t.Errorf("expected only has2 to match, got %v", keysOfDB(got))
+	}
+}
+
+// TestDatabaseUpdateTimePrecondition asserts a stale currentDocument.updateTime
+// guard fails with FAILED_PRECONDITION while the exact stored time succeeds.
+func TestDatabaseUpdateTimePrecondition(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "occ")
+
+	doc := client.Collection("occ").Doc("o1")
+
+	if _, err := doc.Set(ctx, map[string]any{"v": 1}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	snap, err := doc.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	// Stale guard: an update time an hour in the past must be rejected.
+	stale := snap.UpdateTime.Add(-time.Hour)
+
+	_, err = doc.Update(ctx,
+		[]gcpfirestore.Update{{Path: "v", Value: 2}},
+		gcpfirestore.LastUpdateTime(stale))
+	if code := dbSDKCode(err); code != codes.FailedPrecondition {
+		t.Errorf("stale updateTime guard: code=%v err=%v, want FailedPrecondition", code, err)
+	}
+
+	// Matching guard: the exact stored update time must succeed.
+	if _, err := doc.Update(ctx,
+		[]gcpfirestore.Update{{Path: "v", Value: 3}},
+		gcpfirestore.LastUpdateTime(snap.UpdateTime)); err != nil {
+		t.Errorf("matching updateTime guard: unexpected err=%v", err)
+	}
+}
+
+// TestDatabaseDeleteExistsPrecondition asserts a Delete guarded by exists=true
+// on a missing document is rejected.
+func TestDatabaseDeleteExistsPrecondition(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "del")
+
+	missing := client.Collection("del").Doc("ghost")
+
+	_, err := missing.Delete(ctx, gcpfirestore.Exists)
+	if code := dbSDKCode(err); code != codes.NotFound {
+		t.Errorf("Delete(Exists) on missing doc: code=%v err=%v, want NotFound", code, err)
+	}
+}
+
+// mustGet fetches a document's data, failing the test on error.
+func mustGet(ctx context.Context, t *testing.T, doc *gcpfirestore.DocumentRef) map[string]any {
+	t.Helper()
+
+	snap, err := doc.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	return snap.Data()
+}
+
+// toStrs coerces a decoded []interface{} of strings to []string.
+func toStrs(v any) []string {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+
+	out := make([]string, 0, len(arr))
+	for _, e := range arr {
+		s, _ := e.(string)
+		out = append(out, s)
+	}
+
+	return out
+}
+
+func equalStrs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/server/gcp/firestore/handler.go
+++ b/server/gcp/firestore/handler.go
@@ -183,17 +183,64 @@ type commitRequest struct {
 }
 
 type writeOp struct {
-	Update          *document     `json:"update,omitempty"`
-	Delete          string        `json:"delete,omitempty"`
-	CurrentDocument *precondition `json:"currentDocument,omitempty"`
-	UpdateMask      *struct {
+	Update           *document        `json:"update,omitempty"`
+	Delete           string           `json:"delete,omitempty"`
+	CurrentDocument  *precondition    `json:"currentDocument,omitempty"`
+	UpdateTransforms []fieldTransform `json:"updateTransforms,omitempty"`
+	UpdateMask       *struct {
 		FieldPaths []string `json:"fieldPaths"`
 	} `json:"updateMask,omitempty"`
 }
 
-// precondition mirrors google.firestore.v1.Precondition (exists only).
+// fieldTransform mirrors google.firestore.v1.DocumentTransform.FieldTransform:
+// a field path plus exactly one transform kind. The SDK sends these in
+// Write.updateTransforms, applied atomically after the update against the
+// document's current server value.
+type fieldTransform struct {
+	FieldPath             string      `json:"fieldPath"`
+	SetToServerValue      serverValue `json:"setToServerValue,omitempty"` // "REQUEST_TIME"
+	Increment             *value      `json:"increment,omitempty"`
+	Maximum               *value      `json:"maximum,omitempty"`
+	Minimum               *value      `json:"minimum,omitempty"`
+	AppendMissingElements *arrayValue `json:"appendMissingElements,omitempty"`
+	RemoveAllFromArray    *arrayValue `json:"removeAllFromArray,omitempty"`
+}
+
+// serverValue decodes a DocumentTransform.FieldTransform.ServerValue sent as
+// its enum name ("REQUEST_TIME") or its protobuf number (REQUEST_TIME=1), as
+// the REST client does.
+type serverValue string
+
+//nolint:gochecknoglobals // static lookup table
+var serverValueNames = map[int]serverValue{1: serverValueRequestTime}
+
+func (s *serverValue) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 && b[0] == '"' {
+		var v string
+		if err := json.Unmarshal(b, &v); err != nil {
+			return err
+		}
+
+		*s = serverValue(v)
+
+		return nil
+	}
+
+	var n int
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+
+	*s = serverValueNames[n] // unknown numbers stay "" and are ignored downstream
+
+	return nil
+}
+
+// precondition mirrors google.firestore.v1.Precondition: an exists check or an
+// optimistic-concurrency updateTime match.
 type precondition struct {
-	Exists *bool `json:"exists,omitempty"`
+	Exists     *bool   `json:"exists,omitempty"`
+	UpdateTime *string `json:"updateTime,omitempty"`
 }
 
 type commitResponse struct {
@@ -202,7 +249,8 @@ type commitResponse struct {
 }
 
 type writeResult struct {
-	UpdateTime string `json:"updateTime"`
+	UpdateTime       string  `json:"updateTime"`
+	TransformResults []value `json:"transformResults,omitempty"`
 }
 
 // commit handles POST .../documents:commit — the batch-write endpoint the
@@ -225,13 +273,15 @@ func (h *Handler) commit(w http.ResponseWriter, r *http.Request, _ string) {
 
 		switch {
 		case op.Update != nil:
-			if !h.commitUpdate(w, r, op, now) {
+			transformResults, ok := h.commitUpdate(w, r, op, now)
+			if !ok {
 				return
 			}
 
-			out.WriteResults = append(out.WriteResults, writeResult{UpdateTime: nowStr})
+			out.WriteResults = append(out.WriteResults,
+				writeResult{UpdateTime: nowStr, TransformResults: transformResults})
 		case op.Delete != "":
-			if !h.commitDelete(w, r, op.Delete) {
+			if !h.commitDelete(w, r, op) {
 				return
 			}
 
@@ -242,10 +292,78 @@ func (h *Handler) commit(w http.ResponseWriter, r *http.Request, _ string) {
 	writeJSON(w, http.StatusOK, out)
 }
 
-// commitUpdate applies one Update write. It returns false when it has already
-// written an error response and the caller must stop.
-func (h *Handler) commitUpdate(w http.ResponseWriter, r *http.Request, op *writeOp, now time.Time) bool {
+// commitUpdate applies one Update write. It returns the transform results and a
+// false ok when it has already written an error response and the caller must
+// stop.
+//
+// A write that carries field transforms is always treated as a MERGE against the
+// stored document: a transform-only write (empty update.fields, empty mask) must
+// increment/append/stamp its target fields WITHOUT wiping the rest of the
+// document. Only a plain Set (no mask, no transforms) replaces wholesale.
+func (h *Handler) commitUpdate(w http.ResponseWriter, r *http.Request, op *writeOp, now time.Time) ([]value, bool) {
 	p, id, err := splitDocumentName(op.Update.Name)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		return nil, false
+	}
+
+	existing, gerr := h.db.GetItem(r.Context(), p.collection, map[string]any{fieldID: id})
+	if gerr != nil && !cerrors.IsNotFound(gerr) {
+		writeErr(w, gerr)
+		return nil, false
+	}
+
+	exists := gerr == nil
+
+	updateTime := existingUpdateTime(existing)
+	if !checkPrecondition(w, op.CurrentDocument, exists, updateTime, op.Update.Name) {
+		return nil, false
+	}
+
+	body := fieldsToMap(op.Update.Fields)
+	body[fieldID] = id
+
+	item := mergeUpdateBase(existing, body, id, op)
+
+	var results []value
+	if len(op.UpdateTransforms) > 0 {
+		results = applyTransforms(item, existing, op.UpdateTransforms, now)
+	}
+
+	stampTimes(item, existing, now)
+
+	h.ensureCollection(r.Context(), p.collection)
+
+	if perr := h.db.PutItem(r.Context(), p.collection, item); perr != nil {
+		writeErr(w, perr)
+		return nil, false
+	}
+
+	return results, true
+}
+
+// mergeUpdateBase produces the item to write before transforms are applied.
+// A masked write merges the masked paths onto the stored document. A
+// transform-carrying write with no field writes also merges (clones the stored
+// document) so the transforms layer onto the existing fields rather than
+// replacing them. A plain Set (no mask, no transforms) replaces wholesale.
+func mergeUpdateBase(existing, body map[string]any, id string, op *writeOp) map[string]any {
+	switch {
+	case op.UpdateMask != nil:
+		return mergeMasked(existing, body, id, op.UpdateMask.FieldPaths)
+	case len(op.UpdateTransforms) > 0 && len(op.Update.Fields) == 0:
+		return mergeMasked(existing, body, id, nil)
+	default:
+		return body
+	}
+}
+
+// commitDelete applies one Delete write, returning false when an error
+// response has already been written. A currentDocument precondition is enforced
+// (a Delete guarded by exists=true on a missing document → NOT_FOUND, an
+// updateTime guard on a stale document → FAILED_PRECONDITION).
+func (h *Handler) commitDelete(w http.ResponseWriter, r *http.Request, op *writeOp) bool {
+	p, id, err := splitDocumentName(op.Delete)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
 		return false
@@ -258,37 +376,9 @@ func (h *Handler) commitUpdate(w http.ResponseWriter, r *http.Request, op *write
 	}
 
 	exists := gerr == nil
-	if !checkPrecondition(w, op.CurrentDocument, exists, op.Update.Name) {
-		return false
-	}
 
-	item := fieldsToMap(op.Update.Fields)
-	item[fieldID] = id
-
-	// updateMask selects merge semantics: masked paths written (or deleted when
-	// absent from the body), all other stored fields kept.
-	if op.UpdateMask != nil && len(op.UpdateMask.FieldPaths) > 0 {
-		item = mergeMasked(existing, item, id, op.UpdateMask.FieldPaths)
-	}
-
-	stampTimes(item, existing, now)
-
-	h.ensureCollection(r.Context(), p.collection)
-
-	if perr := h.db.PutItem(r.Context(), p.collection, item); perr != nil {
-		writeErr(w, perr)
-		return false
-	}
-
-	return true
-}
-
-// commitDelete applies one Delete write, returning false when an error
-// response has already been written.
-func (h *Handler) commitDelete(w http.ResponseWriter, r *http.Request, name string) bool {
-	p, id, err := splitDocumentName(name)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+	updateTime := existingUpdateTime(existing)
+	if !checkPrecondition(w, op.CurrentDocument, exists, updateTime, op.Delete) {
 		return false
 	}
 
@@ -300,10 +390,35 @@ func (h *Handler) commitDelete(w http.ResponseWriter, r *http.Request, name stri
 	return true
 }
 
-// checkPrecondition enforces a currentDocument.exists precondition, writing the
-// matching Firestore error and returning false on violation.
-func checkPrecondition(w http.ResponseWriter, pc *precondition, exists bool, name string) bool {
-	if pc == nil || pc.Exists == nil {
+// existingUpdateTime reads the stored commit timestamp of a document, returning
+// the zero time when the item is absent or predates timestamp tracking.
+func existingUpdateTime(item map[string]any) time.Time {
+	if t, ok := item[fieldUpdateTime].(time.Time); ok {
+		return t
+	}
+
+	return time.Time{}
+}
+
+// checkPrecondition enforces a currentDocument precondition, writing the
+// matching Firestore error and returning false on violation. An exists check
+// gates presence; an updateTime check enforces optimistic concurrency (the
+// stored commit time must match exactly).
+func checkPrecondition(w http.ResponseWriter, pc *precondition, exists bool, updateTime time.Time, name string) bool {
+	if pc == nil {
+		return true
+	}
+
+	if !checkExistsPrecondition(w, pc, exists, name) {
+		return false
+	}
+
+	return checkUpdateTimePrecondition(w, pc, exists, updateTime, name)
+}
+
+// checkExistsPrecondition enforces currentDocument.exists.
+func checkExistsPrecondition(w http.ResponseWriter, pc *precondition, exists bool, name string) bool {
+	if pc.Exists == nil {
 		return true
 	}
 
@@ -314,6 +429,29 @@ func checkPrecondition(w http.ResponseWriter, pc *precondition, exists bool, nam
 
 	if *pc.Exists && !exists {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", "no document to update: "+name)
+		return false
+	}
+
+	return true
+}
+
+// checkUpdateTimePrecondition enforces currentDocument.updateTime: the stored
+// commit time must exist and match exactly (optimistic concurrency).
+func checkUpdateTimePrecondition(w http.ResponseWriter, pc *precondition, exists bool, updateTime time.Time, name string) bool {
+	if pc.UpdateTime == nil {
+		return true
+	}
+
+	want, perr := time.Parse(time.RFC3339Nano, *pc.UpdateTime)
+	if perr != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "invalid updateTime precondition: "+*pc.UpdateTime)
+		return false
+	}
+
+	if !exists || !updateTime.Equal(want) {
+		writeError(w, http.StatusPreconditionFailed, "FAILED_PRECONDITION",
+			"document update time mismatch: "+name)
+
 		return false
 	}
 

--- a/server/gcp/firestore/query.go
+++ b/server/gcp/firestore/query.go
@@ -33,7 +33,6 @@ func buildFilterNode(f *queryFilter) (expr.Node, error) {
 //nolint:gochecknoglobals // static lookup table
 var firestoreCompareOps = map[fieldOp]string{
 	"EQUAL":                 "=",
-	"NOT_EQUAL":             "<>",
 	"LESS_THAN":             "<",
 	"LESS_THAN_OR_EQUAL":    "<=",
 	"GREATER_THAN":          ">",
@@ -42,6 +41,10 @@ var firestoreCompareOps = map[fieldOp]string{
 
 func fieldFilterNode(ff *fieldFilter) (expr.Node, error) {
 	path := fieldPathToOperand(ff.Field.FieldPath)
+
+	if ff.Op == "NOT_EQUAL" {
+		return notEqualNode(path, valueOperand(ff.Value)), nil
+	}
 
 	if op, ok := firestoreCompareOps[ff.Op]; ok {
 		return &expr.Comparison{Op: op, Left: path, Right: valueOperand(ff.Value)}, nil
@@ -52,6 +55,16 @@ func fieldFilterNode(ff *fieldFilter) (expr.Node, error) {
 	}
 
 	return listFilterNode(ff)
+}
+
+// notEqualNode matches documents whose field is present, non-null, and not
+// equal to the value — Firestore excludes absent and null fields from a !=
+// filter (a bare negation would wrongly include them), mirroring notInNode.
+func notEqualNode(path *expr.PathOperand, val *expr.ValueOperand) expr.Node {
+	presentAndNotNull := &expr.Comparison{Op: "<>", Left: path, Right: &expr.ValueOperand{Value: nil}}
+	notEqual := &expr.Comparison{Op: "<>", Left: path, Right: val}
+
+	return &expr.And{Left: presentAndNotNull, Right: notEqual}
 }
 
 // listFilterNode handles the array-operand operators IN, NOT_IN and

--- a/server/gcp/firestore/transform.go
+++ b/server/gcp/firestore/transform.go
@@ -1,0 +1,215 @@
+package firestore
+
+import (
+	"reflect"
+	"strconv"
+	"time"
+)
+
+// serverValueRequestTime is the SERVER_VALUE enum the SDK sends for a
+// ServerTimestamp sentinel.
+const serverValueRequestTime serverValue = "REQUEST_TIME"
+
+// applyTransforms mutates base in place, applying each field transform against
+// the document's existing (pre-write) value, and returns the per-transform
+// results in order for writeResults[].transformResults. serverTimestamp uses
+// the commit time; numeric and array transforms read their current value from
+// existing so a transform-only write layers onto the stored document.
+func applyTransforms(base, existing map[string]any, transforms []fieldTransform, commit time.Time) []value {
+	results := make([]value, 0, len(transforms))
+
+	for i := range transforms {
+		ft := &transforms[i]
+		segs := splitFieldPath(ft.FieldPath)
+		cur, _ := getNestedPath(existing, segs)
+
+		res, ok := transformResult(ft, cur, commit)
+		if !ok {
+			continue
+		}
+
+		setNestedPath(base, segs, res)
+		results = append(results, goValueToFirestore(res))
+	}
+
+	return results
+}
+
+// transformResult computes a single transform's result value given the current
+// (existing) value, reporting false for an unrecognized transform kind.
+func transformResult(ft *fieldTransform, cur any, commit time.Time) (any, bool) {
+	switch {
+	case ft.SetToServerValue == serverValueRequestTime:
+		return commit, true
+	case ft.Increment != nil:
+		return applyIncrement(cur, ft.Increment), true
+	case ft.Maximum != nil:
+		return applyMinMax(cur, ft.Maximum, true), true
+	case ft.Minimum != nil:
+		return applyMinMax(cur, ft.Minimum, false), true
+	case ft.AppendMissingElements != nil:
+		return applyArrayUnion(cur, ft.AppendMissingElements), true
+	case ft.RemoveAllFromArray != nil:
+		return applyArrayRemove(cur, ft.RemoveAllFromArray), true
+	default:
+		return nil, false
+	}
+}
+
+// applyIncrement adds the operand to the current value. An absent or
+// non-numeric current value is treated as 0. The result stays an int64 when
+// both operands are integers, and a float64 when either is a double — matching
+// Firestore's numeric typing.
+func applyIncrement(cur any, operand *value) any {
+	opI, opF, opIsInt, opOk := wireNumber(operand)
+	if !opOk {
+		return cur
+	}
+
+	curI, curF, curIsInt, curOk := goNumber(cur)
+	if !curOk {
+		if opIsInt {
+			return opI
+		}
+
+		return opF
+	}
+
+	if curIsInt && opIsInt {
+		return curI + opI
+	}
+
+	return curF + opF
+}
+
+// applyMinMax sets the field to the max (wantMax) or min of the current value
+// and the operand. A tie keeps the current value; an absent or non-numeric
+// current value yields the operand.
+func applyMinMax(cur any, operand *value, wantMax bool) any {
+	opI, opF, opIsInt, opOk := wireNumber(operand)
+	if !opOk {
+		return cur
+	}
+
+	curI, curF, curIsInt, curOk := goNumber(cur)
+	if !curOk {
+		if opIsInt {
+			return opI
+		}
+
+		return opF
+	}
+
+	takeOperand := (wantMax && opF > curF) || (!wantMax && opF < curF)
+	if takeOperand {
+		if opIsInt {
+			return opI
+		}
+
+		return opF
+	}
+
+	if curIsInt {
+		return curI
+	}
+
+	return curF
+}
+
+// applyArrayUnion appends each operand element not already present to the
+// current array, comparing by value. A current value that is not an array is
+// treated as empty.
+func applyArrayUnion(cur any, elems *arrayValue) any {
+	result := toAnyArray(cur)
+
+	for i := range elems.Values {
+		gv := firestoreValueToGo(elems.Values[i])
+		if !containsValue(result, gv) {
+			result = append(result, gv)
+		}
+	}
+
+	return result
+}
+
+// applyArrayRemove removes every element equal to any operand element from the
+// current array. A current value that is not an array yields an empty array.
+func applyArrayRemove(cur any, elems *arrayValue) any {
+	src := toAnyArray(cur)
+
+	remove := make([]any, len(elems.Values))
+	for i := range elems.Values {
+		remove[i] = firestoreValueToGo(elems.Values[i])
+	}
+
+	out := make([]any, 0, len(src))
+
+	for _, x := range src {
+		if !containsValue(remove, x) {
+			out = append(out, x)
+		}
+	}
+
+	return out
+}
+
+// wireNumber extracts the int and float views of a numeric transform operand,
+// reporting whether it was an integerValue and whether it was numeric at all.
+func wireNumber(v *value) (i int64, f float64, isInt, ok bool) {
+	switch {
+	case v == nil:
+		return 0, 0, false, false
+	case v.IntegerValue != nil:
+		n, err := strconv.ParseInt(*v.IntegerValue, 10, 64)
+		if err != nil {
+			return 0, 0, false, false
+		}
+
+		return n, float64(n), true, true
+	case v.DoubleValue != nil:
+		return int64(*v.DoubleValue), *v.DoubleValue, false, true
+	default:
+		return 0, 0, false, false
+	}
+}
+
+// goNumber extracts the int and float views of a stored Go value, reporting
+// whether it was an integer and whether it was numeric at all.
+func goNumber(x any) (i int64, f float64, isInt, ok bool) {
+	switch n := x.(type) {
+	case int64:
+		return n, float64(n), true, true
+	case int:
+		return int64(n), float64(n), true, true
+	case int32:
+		return int64(n), float64(n), true, true
+	case float64:
+		return int64(n), n, false, true
+	default:
+		return 0, 0, false, false
+	}
+}
+
+// toAnyArray returns a shallow copy of x when it is a []any, or a fresh empty
+// slice otherwise.
+func toAnyArray(x any) []any {
+	if a, ok := x.([]any); ok {
+		out := make([]any, len(a))
+		copy(out, a)
+
+		return out
+	}
+
+	return []any{}
+}
+
+// containsValue reports whether list holds a value deep-equal to v.
+func containsValue(list []any, v any) bool {
+	for _, x := range list {
+		if reflect.DeepEqual(x, v) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
## Summary

A confirming re-audit surfaced a CRITICAL data-loss residue in the GCP Firestore wire handler: **field transforms were entirely unimplemented**, and a transform-only write **destroyed the stored document**.

The Go SDK sends transform fields (serverTimestamp / increment / arrayUnion / arrayRemove) in `Write.updateTransforms` with empty `update.fields` and an empty `updateMask`. The handler had no `UpdateTransforms` field on `writeOp` and never read/applied them, so such a write fell into the wholesale-REPLACE path and wiped the document to `{}`.

Repro (now fixed): `Set({count:10, keep:"me"})` then `Update([{count, Increment(5)}])` → `Get` previously returned `{}` (count not incremented AND keep wiped).

## Changes

- **Field transforms implemented** (`transform.go`, new): `setToServerValue=REQUEST_TIME` (commit timestamp), `increment` (numeric add, int/double typing preserved, absent field starts at 0), `appendMissingElements` (arrayUnion), `removeAllFromArray` (arrayRemove), `maximum`/`minimum`. Applied against the existing stored value, with results echoed in `writeResults[].transformResults`.
- **Transform-carrying writes MERGE, never replace** — a transform-only write layers onto the stored document and preserves untouched fields. Wired through single `:commit`, `WriteBatch`, and `RunTransaction`.
- **`setToServerValue` enum decoding** — accepts the SDK's protobuf number (REQUEST_TIME=1) and the string name.
- **`!=` (NOT_EQUAL)** now excludes absent/null-field docs — built as `AND(present-and-not-null, <> value)`, matching the existing `NOT_IN` shape.
- **Preconditions** — `currentDocument.updateTime` optimistic-concurrency support added (mismatch → FAILED_PRECONDITION), and Delete now honors its `currentDocument` precondition (guarded exists=true on a missing doc → NOT_FOUND).

Deferred (noted, out of scope for this PR): `showMissing`, `IS_NAN`/`IS_NOT_NAN`.

## Tests

Real `cloud.google.com/go/firestore` SDK reproductions: no-data-loss increment, int-vs-double typing + absent-field-from-zero, ServerTimestamp, ArrayUnion/ArrayRemove, transform inside WriteBatch and RunTransaction, `!=` absent-field exclusion, stale/matching updateTime precondition, Delete-guarded-by-exists on missing. The #639/#655 tests (value types, dotted updateMask, cursors, operators, paging) stay green.
