### PR TITLE
fix(gcp-pubsub): Topic/Subscription PATCH update; evaluate subscription filter; enforce deadLetterPolicy; detach subs on topic delete

### DIFF
--- a/server/gcp/pubsub/filter.go
+++ b/server/gcp/pubsub/filter.go
@@ -1,0 +1,476 @@
+package pubsub
+
+import (
+	"strconv"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// filterExpr is a parsed Pub/Sub subscription filter, evaluated against a
+// message's attributes. See
+// https://cloud.google.com/pubsub/docs/subscription-message-filter for the
+// grammar: attributes.KEY = "V" | attributes.KEY != "V" | attributes:KEY |
+// hasPrefix(attributes.KEY, "P"), combined with NOT / AND / OR and parentheses.
+type filterExpr interface {
+	eval(attrs map[string]string) bool
+}
+
+// filterAll matches every message (empty filter).
+type filterAll struct{}
+
+func (filterAll) eval(map[string]string) bool { return true }
+
+// hasAttr is `attributes:KEY` — true when the attribute is present.
+type hasAttr struct{ key string }
+
+func (h hasAttr) eval(a map[string]string) bool {
+	_, ok := a[h.key]
+	return ok
+}
+
+// equals is `attributes.KEY = "V"` (or != when negate) — exact value match.
+type equals struct {
+	key, val string
+	negate   bool
+}
+
+func (e equals) eval(a map[string]string) bool {
+	v, ok := a[e.key]
+	match := ok && v == e.val
+
+	if e.negate {
+		return !match
+	}
+
+	return match
+}
+
+// prefix is `hasPrefix(attributes.KEY, "P")`.
+type prefix struct{ key, pfx string }
+
+func (p prefix) eval(a map[string]string) bool {
+	v, ok := a[p.key]
+	return ok && strings.HasPrefix(v, p.pfx)
+}
+
+type notExpr struct{ x filterExpr }
+
+func (n notExpr) eval(a map[string]string) bool { return !n.x.eval(a) }
+
+type andExpr struct{ l, r filterExpr }
+
+func (n andExpr) eval(a map[string]string) bool { return n.l.eval(a) && n.r.eval(a) }
+
+type orExpr struct{ l, r filterExpr }
+
+func (n orExpr) eval(a map[string]string) bool { return n.l.eval(a) || n.r.eval(a) }
+
+func errFilter() error {
+	return cerrors.New(cerrors.InvalidArgument, "invalid filter expression")
+}
+
+// parseFilter compiles a Pub/Sub filter string. An empty filter matches all.
+func parseFilter(s string) (filterExpr, error) {
+	if strings.TrimSpace(s) == "" {
+		return filterAll{}, nil
+	}
+
+	toks, err := tokenize(s)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &parser{toks: toks}
+
+	expr, err := p.parseOr()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.peek().kind != tEOF {
+		return nil, errFilter()
+	}
+
+	return expr, nil
+}
+
+// ---------- tokenizer ----------
+
+type tokKind int
+
+const (
+	tEOF tokKind = iota
+	tIdent
+	tString
+	tDot
+	tColon
+	tEq
+	tNe
+	tLParen
+	tRParen
+	tComma
+	tMinus
+)
+
+type token struct {
+	kind tokKind
+	val  string
+}
+
+const (
+	// escLen is the length of a two-character escape (backslash + one char).
+	escLen = 2
+	// unicodeEscLen is the length of a \uXXXX escape.
+	unicodeEscLen = 6
+)
+
+func tokenize(s string) ([]token, error) {
+	var toks []token
+
+	for i := 0; i < len(s); {
+		if c := s[i]; c == ' ' || c == '\t' || c == '\n' {
+			i++
+			continue
+		}
+
+		tok, n, err := scanToken(s, i)
+		if err != nil {
+			return nil, err
+		}
+
+		toks = append(toks, tok)
+		i = n
+	}
+
+	return append(toks, token{tEOF, ""}), nil
+}
+
+// scanToken reads the single token starting at s[i], returning it and the index
+// just past it.
+func scanToken(s string, i int) (tok token, next int, err error) {
+	c := s[i]
+
+	switch {
+	case c == '"':
+		str, n, rerr := readString(s, i)
+		if rerr != nil {
+			return token{}, 0, rerr
+		}
+
+		return token{tString, str}, n, nil
+	case c == '!':
+		if i+1 >= len(s) || s[i+1] != '=' {
+			return token{}, 0, errFilter()
+		}
+
+		return token{tNe, "!="}, i + len("!="), nil
+	case isIdentStart(c):
+		id, n := readIdent(s, i)
+		return token{tIdent, id}, n, nil
+	}
+
+	k, ok := punctKind(c)
+	if !ok {
+		return token{}, 0, errFilter()
+	}
+
+	return token{k, string(c)}, i + 1, nil
+}
+
+func punctKind(c byte) (tokKind, bool) {
+	switch c {
+	case '.':
+		return tDot, true
+	case ':':
+		return tColon, true
+	case '(':
+		return tLParen, true
+	case ')':
+		return tRParen, true
+	case ',':
+		return tComma, true
+	case '-':
+		return tMinus, true
+	case '=':
+		return tEq, true
+	}
+
+	return tEOF, false
+}
+
+func isIdentStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isIdentPart(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9') || c == '-'
+}
+
+func readIdent(s string, start int) (ident string, next int) {
+	i := start
+	for i < len(s) && isIdentPart(s[i]) {
+		i++
+	}
+
+	return s[start:i], i
+}
+
+func readString(s string, start int) (result string, next int, err error) {
+	var b strings.Builder
+
+	i := start + 1
+	for i < len(s) {
+		c := s[i]
+		if c == '"' {
+			return b.String(), i + 1, nil
+		}
+
+		if c != '\\' {
+			b.WriteByte(c)
+
+			i++
+
+			continue
+		}
+
+		n, werr := writeEscape(&b, s, i)
+		if werr != nil {
+			return "", 0, werr
+		}
+
+		i = n
+	}
+
+	return "", 0, errFilter()
+}
+
+// writeEscape decodes the escape sequence at s[i] into b and returns the index
+// just past it.
+func writeEscape(b *strings.Builder, s string, i int) (next int, err error) {
+	if i+1 >= len(s) {
+		return 0, errFilter()
+	}
+
+	c := s[i+1]
+	if c == 'u' {
+		return writeUnicodeEscape(b, s, i)
+	}
+
+	switch c {
+	case 'n':
+		b.WriteByte('\n')
+	case 't':
+		b.WriteByte('\t')
+	default:
+		b.WriteByte(c)
+	}
+
+	return i + escLen, nil
+}
+
+func writeUnicodeEscape(b *strings.Builder, s string, i int) (next int, err error) {
+	if i+unicodeEscLen > len(s) {
+		return 0, errFilter()
+	}
+
+	v, perr := strconv.ParseUint(s[i+escLen:i+unicodeEscLen], 16, 32)
+	if perr != nil {
+		return 0, errFilter()
+	}
+
+	b.WriteRune(rune(v)) //nolint:gosec // 4 hex digits (<=0xFFFF) always fit in rune
+
+	return i + unicodeEscLen, nil
+}
+
+// ---------- recursive-descent parser (NOT > AND > OR) ----------
+
+type parser struct {
+	toks []token
+	pos  int
+}
+
+func (p *parser) peek() token { return p.toks[p.pos] }
+
+func (p *parser) next() token {
+	t := p.toks[p.pos]
+	p.pos++
+
+	return t
+}
+
+func (p *parser) isKeyword(kw string) bool {
+	t := p.peek()
+	return t.kind == tIdent && t.val == kw
+}
+
+func (p *parser) parseOr() (filterExpr, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.isKeyword("OR") {
+		p.next()
+
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+
+		left = orExpr{left, right}
+	}
+
+	return left, nil
+}
+
+func (p *parser) parseAnd() (filterExpr, error) {
+	left, err := p.parseNot()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.isKeyword("AND") {
+		p.next()
+
+		right, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+
+		left = andExpr{left, right}
+	}
+
+	return left, nil
+}
+
+func (p *parser) parseNot() (filterExpr, error) {
+	if p.isKeyword("NOT") || p.peek().kind == tMinus {
+		p.next()
+
+		x, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+
+		return notExpr{x}, nil
+	}
+
+	return p.parsePrimary()
+}
+
+func (p *parser) parsePrimary() (filterExpr, error) {
+	if p.peek().kind == tLParen {
+		p.next()
+
+		x, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+
+		if p.next().kind != tRParen {
+			return nil, errFilter()
+		}
+
+		return x, nil
+	}
+
+	t := p.peek()
+	if t.kind != tIdent {
+		return nil, errFilter()
+	}
+
+	switch t.val {
+	case "hasPrefix":
+		return p.parseHasPrefix()
+	case "attributes":
+		return p.parseAttr()
+	}
+
+	return nil, errFilter()
+}
+
+func (p *parser) parseAttr() (filterExpr, error) {
+	p.next() // attributes
+
+	kind := p.peek().kind
+	if kind != tColon && kind != tDot {
+		return nil, errFilter()
+	}
+
+	p.next()
+
+	key, err := p.parseKey()
+	if err != nil {
+		return nil, err
+	}
+
+	if kind == tColon {
+		return hasAttr{key}, nil
+	}
+
+	return p.parseComparison(key)
+}
+
+func (p *parser) parseComparison(key string) (filterExpr, error) {
+	op := p.next()
+	if op.kind != tEq && op.kind != tNe {
+		return nil, errFilter()
+	}
+
+	v := p.next()
+	if v.kind != tString {
+		return nil, errFilter()
+	}
+
+	return equals{key: key, val: v.val, negate: op.kind == tNe}, nil
+}
+
+func (p *parser) parseHasPrefix() (filterExpr, error) {
+	p.next() // hasPrefix
+
+	if p.next().kind != tLParen {
+		return nil, errFilter()
+	}
+
+	if !p.isKeyword("attributes") {
+		return nil, errFilter()
+	}
+
+	p.next() // attributes
+
+	if p.next().kind != tDot {
+		return nil, errFilter()
+	}
+
+	key, err := p.parseKey()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.next().kind != tComma {
+		return nil, errFilter()
+	}
+
+	v := p.next()
+	if v.kind != tString {
+		return nil, errFilter()
+	}
+
+	if p.next().kind != tRParen {
+		return nil, errFilter()
+	}
+
+	return prefix{key: key, pfx: v.val}, nil
+}
+
+// parseKey accepts an identifier or a quoted string as an attribute key.
+func (p *parser) parseKey() (string, error) {
+	t := p.next()
+	if t.kind == tIdent || t.kind == tString {
+		return t.val, nil
+	}
+
+	return "", errFilter()
+}

--- a/server/gcp/pubsub/handler.go
+++ b/server/gcp/pubsub/handler.go
@@ -169,6 +169,8 @@ func (h *Handler) serveTopic(w http.ResponseWriter, r *http.Request, project, na
 		h.createTopic(w, r, project, name)
 	case http.MethodGet:
 		h.getTopic(w, r, project, name)
+	case http.MethodPatch:
+		h.patchTopic(w, r, project, name)
 	case http.MethodDelete:
 		h.deleteTopic(w, r, name)
 	default:
@@ -190,7 +192,9 @@ func (h *Handler) createTopic(w http.ResponseWriter, r *http.Request, project, n
 	}
 
 	h.mu.Lock()
-	h.topicLog(name)
+	ts := h.topicLog(name)
+	ts.labels = copyLabels(info.Tags)
+	ts.labelsSet = true
 	h.mu.Unlock()
 
 	writeJSON(w, http.StatusOK, topic{
@@ -208,8 +212,48 @@ func (h *Handler) getTopic(w http.ResponseWriter, r *http.Request, project, name
 
 	writeJSON(w, http.StatusOK, topic{
 		Name:   topicName(project, q.Name),
-		Labels: q.Tags,
+		Labels: h.topicLabels(name, q.Tags),
 	})
+}
+
+// patchTopic applies topics.patch: only the fields named by updateMask are
+// merged. Labels are the modeled updatable field.
+func (h *Handler) patchTopic(w http.ResponseWriter, r *http.Request, project, name string) {
+	var req updateTopicRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	q, err := h.findQueueByName(r, name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	masks := parseMask(req.UpdateMask)
+	if len(masks) == 0 {
+		writeError(w, http.StatusBadRequest, reasonInvalidArgument, "updateMask must be specified and non-empty")
+		return
+	}
+
+	h.mu.Lock()
+	ts := h.topicLog(name)
+
+	if !ts.labelsSet {
+		ts.labels = copyLabels(q.Tags)
+		ts.labelsSet = true
+	}
+
+	for _, m := range masks {
+		if m == "labels" {
+			ts.labels = copyLabels(req.Topic.Labels)
+		}
+	}
+
+	labels := ts.labels
+	h.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, topic{Name: topicName(project, name), Labels: labels})
 }
 
 func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request, name string) {
@@ -224,8 +268,15 @@ func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request, name strin
 		return
 	}
 
+	// Detach subscriptions from the deleted topic (real Pub/Sub reports their
+	// topic as "_deleted-topic_"). The message log is kept so already-published
+	// messages can still drain.
 	h.mu.Lock()
-	delete(h.topics, name)
+	for _, sub := range h.subs {
+		if sub.topic == name {
+			sub.cfg.Topic = deletedTopicName
+		}
+	}
 	h.mu.Unlock()
 
 	writeJSON(w, http.StatusOK, map[string]any{})
@@ -240,7 +291,10 @@ func (h *Handler) listTopics(w http.ResponseWriter, r *http.Request, project str
 
 	items := make([]topic, 0, len(queues))
 	for i := range queues {
-		items = append(items, topic{Name: topicName(project, queues[i].Name), Labels: queues[i].Tags})
+		items = append(items, topic{
+			Name:   topicName(project, queues[i].Name),
+			Labels: h.topicLabels(queues[i].Name, queues[i].Tags),
+		})
 	}
 
 	page, err := pagination.PaginateSorted(items, func(a, b topic) bool { return a.Name < b.Name },
@@ -315,6 +369,46 @@ func subscriptionName(project, name string) string {
 
 func snapshotName(project, name string) string {
 	return "projects/" + project + "/snapshots/" + name
+}
+
+// topicLabels returns a topic's effective labels: the handler-side override
+// (set on create/patch) when present, otherwise the messagequeue driver's tags.
+func (h *Handler) topicLabels(name string, fallback map[string]string) map[string]string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if ts, ok := h.topics[name]; ok && ts.labelsSet {
+		return ts.labels
+	}
+
+	return fallback
+}
+
+// parseMask splits a comma-separated updateMask into trimmed, non-empty paths.
+func parseMask(mask string) []string {
+	parts := strings.Split(mask, ",")
+	out := make([]string, 0, len(parts))
+
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+
+	return out
+}
+
+func copyLabels(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+
+	return dst
 }
 
 // shortName returns the trailing segment of a resource path.

--- a/server/gcp/pubsub/model.go
+++ b/server/gcp/pubsub/model.go
@@ -1,6 +1,7 @@
 package pubsub
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -9,7 +10,15 @@ import (
 	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
 )
 
-const defaultAckDeadlineSeconds = 10
+const (
+	defaultAckDeadlineSeconds = 10
+	// defaultMaxDeliveryAttempts is Pub/Sub's default when a deadLetterPolicy
+	// sets a dead-letter topic but omits maxDeliveryAttempts.
+	defaultMaxDeliveryAttempts = 5
+	// deletedTopicName is what real Pub/Sub reports as a subscription's topic
+	// after the topic it was attached to is deleted.
+	deletedTopicName = "_deleted-topic_"
+)
 
 // storedMessage is one message in a topic's append-only log. Every subscription
 // on the topic reads from this shared log by index; per-subscription ack state
@@ -29,6 +38,13 @@ type storedMessage struct {
 type topicState struct {
 	messages []storedMessage
 	iam      *iamPolicy
+
+	// labels overrides the messagequeue driver's tags once a topic is created or
+	// patched through this handler, so topics.patch on labels is reflected on
+	// subsequent Get/List. labelsSet distinguishes an explicit empty map from
+	// "no override, fall back to the driver's tags".
+	labels    map[string]string
+	labelsSet bool
 }
 
 // lease is an outstanding (delivered, not-yet-acked) message on a subscription.
@@ -48,6 +64,10 @@ type subState struct {
 	outstanding      map[string]*lease // ackID -> leased message
 	deliveryAttempts map[int]int       // per-index delivery count (dead-letter surface)
 	iam              *iamPolicy
+
+	// filter is the parsed (immutable) subscription filter. nil means no filter
+	// was set, so every message is deliverable.
+	filter filterExpr
 }
 
 // snapState captures a subscription's ack cursor for later seek/replay.
@@ -101,6 +121,12 @@ func (h *Handler) appendMessage(topicName string, msg *storedMessage) string {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	return h.appendMessageLocked(topicName, msg)
+}
+
+// appendMessageLocked is appendMessage for callers already holding h.mu (e.g.
+// dead-letter routing from within deliver).
+func (h *Handler) appendMessageLocked(topicName string, msg *storedMessage) string {
 	ts := h.topicLog(topicName)
 	msg.id = fmt.Sprintf("%d", h.ackCounter.Add(1))
 	ts.messages = append(ts.messages, *msg)
@@ -111,7 +137,7 @@ func (h *Handler) appendMessage(topicName string, msg *storedMessage) string {
 // newSub registers a subscription that starts fresh: all messages already on
 // the topic are treated as consumed, so it only receives future publishes
 // (matching real Pub/Sub, where a new subscription has no backlog).
-func (h *Handler) newSub(name, topicShort string, cfg *subscription) {
+func (h *Handler) newSub(name, topicShort string, cfg *subscription, filter filterExpr) {
 	acked := make(map[int]bool)
 
 	if ts, ok := h.topics[topicShort]; ok {
@@ -127,6 +153,7 @@ func (h *Handler) newSub(name, topicShort string, cfg *subscription) {
 		acked:            acked,
 		outstanding:      make(map[string]*lease),
 		deliveryAttempts: make(map[int]int),
+		filter:           filter,
 	}
 }
 
@@ -142,16 +169,8 @@ func (h *Handler) deliver(sub *subState, maxMessages int) []receivedMessage {
 	now := time.Now().UTC()
 	sweepExpired(sub, now)
 
-	leased := make(map[int]bool, len(sub.outstanding))
-	for _, l := range sub.outstanding {
-		leased[l.msgIdx] = true
-	}
-
-	ackDeadline := sub.cfg.AckDeadlineSeconds
-	if ackDeadline <= 0 {
-		ackDeadline = defaultAckDeadlineSeconds
-	}
-
+	leased := leasedIndices(sub)
+	ackDeadline := effectiveAckDeadline(sub)
 	out := make([]receivedMessage, 0, maxMessages)
 
 	for idx := range ts.messages {
@@ -163,19 +182,109 @@ func (h *Handler) deliver(sub *subState, maxMessages int) []receivedMessage {
 			continue
 		}
 
-		ackID := fmt.Sprintf("ack-%d", h.ackCounter.Add(1))
-		sub.outstanding[ackID] = &lease{msgIdx: idx, deadline: now.Add(time.Duration(ackDeadline) * time.Second)}
-		sub.deliveryAttempts[idx]++
-
-		attempt := 0
-		if len(sub.cfg.DeadLetterPolicy) > 0 {
-			attempt = sub.deliveryAttempts[idx]
+		if msg, ok := h.tryDeliver(sub, ts, idx, now, ackDeadline); ok {
+			out = append(out, msg)
 		}
-
-		out = append(out, buildReceived(ackID, &ts.messages[idx], attempt))
 	}
 
 	return out
+}
+
+// tryDeliver decides one message's fate for a subscription: filtered-out and
+// dead-lettered messages are auto-acked and not returned; otherwise the message
+// is leased and returned. The caller holds h.mu.
+func (h *Handler) tryDeliver(
+	sub *subState, ts *topicState, idx int, now time.Time, ackDeadline int,
+) (receivedMessage, bool) {
+	// A message the filter rejects is never delivered and never backlogged:
+	// real Pub/Sub auto-acknowledges it for this subscription.
+	if sub.filter != nil && !sub.filter.eval(ts.messages[idx].attributes) {
+		sub.acked[idx] = true
+		return receivedMessage{}, false
+	}
+
+	sub.deliveryAttempts[idx]++
+	attempts := sub.deliveryAttempts[idx]
+
+	// Once delivery attempts exceed the dead-letter policy's limit, forward the
+	// message to the dead-letter topic and stop redelivering it here.
+	if h.routeToDeadLetter(sub, idx, attempts) {
+		sub.acked[idx] = true
+		return receivedMessage{}, false
+	}
+
+	ackID := fmt.Sprintf("ack-%d", h.ackCounter.Add(1))
+	sub.outstanding[ackID] = &lease{msgIdx: idx, deadline: now.Add(time.Duration(ackDeadline) * time.Second)}
+
+	attempt := 0
+	if len(sub.cfg.DeadLetterPolicy) > 0 {
+		attempt = attempts
+	}
+
+	return buildReceived(ackID, &ts.messages[idx], attempt), true
+}
+
+func leasedIndices(sub *subState) map[int]bool {
+	leased := make(map[int]bool, len(sub.outstanding))
+	for _, l := range sub.outstanding {
+		leased[l.msgIdx] = true
+	}
+
+	return leased
+}
+
+func effectiveAckDeadline(sub *subState) int {
+	if sub.cfg.AckDeadlineSeconds <= 0 {
+		return defaultAckDeadlineSeconds
+	}
+
+	return sub.cfg.AckDeadlineSeconds
+}
+
+// routeToDeadLetter forwards message idx to the subscription's dead-letter topic
+// when its delivery attempts have exceeded the configured limit, returning true
+// when the message was dead-lettered (and must not be delivered on the source).
+// The caller holds h.mu.
+func (h *Handler) routeToDeadLetter(sub *subState, idx, attempts int) bool {
+	dlqTopic, maxAttempts, ok := parseDeadLetter(sub.cfg.DeadLetterPolicy)
+	if !ok || attempts <= maxAttempts {
+		return false
+	}
+
+	src, ok := h.topics[sub.topic]
+	if !ok || idx >= len(src.messages) {
+		return false
+	}
+
+	msg := src.messages[idx]
+	h.appendMessageLocked(dlqTopic, &storedMessage{
+		body:        msg.body,
+		attributes:  msg.attributes,
+		orderingKey: msg.orderingKey,
+		publishTime: time.Now().UTC(),
+	})
+
+	return true
+}
+
+// parseDeadLetter extracts the dead-letter topic short-name and effective
+// max-delivery-attempts from a subscription's deadLetterPolicy raw JSON.
+func parseDeadLetter(raw json.RawMessage) (topicShort string, maxAttempts int, ok bool) {
+	if len(raw) == 0 {
+		return "", 0, false
+	}
+
+	var p deadLetterPolicyJSON
+	if err := json.Unmarshal(raw, &p); err != nil || p.DeadLetterTopic == "" {
+		return "", 0, false
+	}
+
+	maxAttempts = p.MaxDeliveryAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = defaultMaxDeliveryAttempts
+	}
+
+	return shortName(p.DeadLetterTopic), maxAttempts, true
 }
 
 // sweepExpired drops leases whose deadline has passed, making those messages

--- a/server/gcp/pubsub/sdk_deadletter_test.go
+++ b/server/gcp/pubsub/sdk_deadletter_test.go
@@ -1,0 +1,89 @@
+package pubsub_test
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	pubsubv1 "google.golang.org/api/pubsub/v1"
+)
+
+func nack(t *testing.T, svc *pubsubv1.Service, sub, ackID string) {
+	t.Helper()
+
+	if _, err := svc.Projects.Subscriptions.ModifyAckDeadline(sub,
+		&pubsubv1.ModifyAckDeadlineRequest{AckIds: []string{ackID}, AckDeadlineSeconds: 0}).
+		Context(context.Background()).Do(); err != nil {
+		t.Fatalf("ModifyAckDeadline(nack): %v", err)
+	}
+}
+
+// TestSDKPubSubDeadLetterRouting guards deadLetterPolicy enforcement: after the
+// message exceeds maxDeliveryAttempts nacks on the source subscription, it is
+// forwarded to the dead-letter topic (a subscription there receives it) and
+// stops redelivering on the source (no infinite redelivery).
+func TestSDKPubSubDeadLetterRouting(t *testing.T) {
+	svc := newSDKService(t)
+
+	mustTopic(t, svc, "projects/demo/topics/dl-src")
+	mustTopic(t, svc, "projects/demo/topics/dl-dlq")
+
+	mustSub(t, svc, "projects/demo/subscriptions/dl-src-sub", &pubsubv1.Subscription{
+		Topic: "projects/demo/topics/dl-src",
+		DeadLetterPolicy: &pubsubv1.DeadLetterPolicy{
+			DeadLetterTopic:     "projects/demo/topics/dl-dlq",
+			MaxDeliveryAttempts: 5,
+		},
+	})
+	mustSub(t, svc, "projects/demo/subscriptions/dl-dlq-sub",
+		&pubsubv1.Subscription{Topic: "projects/demo/topics/dl-dlq"})
+
+	publish(t, svc, "projects/demo/topics/dl-src",
+		&pubsubv1.PubsubMessage{Data: base64.StdEncoding.EncodeToString([]byte("poison"))})
+
+	// Pull + nack until the source stops delivering (message dead-lettered).
+	routed := false
+
+	for i := 0; i < 10; i++ {
+		resp := pull(t, svc, "projects/demo/subscriptions/dl-src-sub", 1)
+		if len(resp.ReceivedMessages) == 0 {
+			routed = true
+			break
+		}
+
+		nack(t, svc, "projects/demo/subscriptions/dl-src-sub", resp.ReceivedMessages[0].AckId)
+	}
+
+	if !routed {
+		t.Fatal("source kept redelivering past maxDeliveryAttempts — message never dead-lettered")
+	}
+
+	dlq := pull(t, svc, "projects/demo/subscriptions/dl-dlq-sub", 1)
+	if len(dlq.ReceivedMessages) != 1 {
+		t.Fatalf("dead-letter subscription got %d messages, want 1", len(dlq.ReceivedMessages))
+	}
+}
+
+// TestSDKPubSubDeleteTopicDetachesSub guards that deleting a topic detaches its
+// subscriptions: their topic becomes "_deleted-topic_" (real Pub/Sub behavior).
+func TestSDKPubSubDeleteTopicDetachesSub(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/det")
+	mustSub(t, svc, "projects/demo/subscriptions/det-sub",
+		&pubsubv1.Subscription{Topic: "projects/demo/topics/det"})
+
+	if _, err := svc.Projects.Topics.Delete("projects/demo/topics/det").Context(ctx).Do(); err != nil {
+		t.Fatalf("Topics.Delete: %v", err)
+	}
+
+	got, err := svc.Projects.Subscriptions.Get("projects/demo/subscriptions/det-sub").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get subscription: %v", err)
+	}
+
+	if got.Topic != "_deleted-topic_" {
+		t.Fatalf("subscription topic=%q, want _deleted-topic_", got.Topic)
+	}
+}

--- a/server/gcp/pubsub/sdk_patch_filter_test.go
+++ b/server/gcp/pubsub/sdk_patch_filter_test.go
@@ -1,0 +1,182 @@
+package pubsub_test
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	pubsubv1 "google.golang.org/api/pubsub/v1"
+)
+
+// TestSDKPubSubSubscriptionPatch guards subscriptions.patch: an in-place update
+// of ackDeadlineSeconds via updateMask is reflected on a subsequent Get (real
+// Terraform / SDK Update path; previously returned 405).
+func TestSDKPubSubSubscriptionPatch(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/pt")
+	mustSub(t, svc, "projects/demo/subscriptions/ps",
+		&pubsubv1.Subscription{Topic: "projects/demo/topics/pt", AckDeadlineSeconds: 10})
+
+	_, err := svc.Projects.Subscriptions.Patch("projects/demo/subscriptions/ps",
+		&pubsubv1.UpdateSubscriptionRequest{
+			Subscription: &pubsubv1.Subscription{AckDeadlineSeconds: 30},
+			UpdateMask:   "ackDeadlineSeconds",
+		}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Subscriptions.Patch: %v", err)
+	}
+
+	got, err := svc.Projects.Subscriptions.Get("projects/demo/subscriptions/ps").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.AckDeadlineSeconds != 30 {
+		t.Fatalf("ackDeadlineSeconds=%d, want 30", got.AckDeadlineSeconds)
+	}
+}
+
+// TestSDKPubSubSubscriptionPatchMaskScope guards that only masked fields change:
+// patching labels leaves ackDeadlineSeconds untouched.
+func TestSDKPubSubSubscriptionPatchMaskScope(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/pms")
+	mustSub(t, svc, "projects/demo/subscriptions/pms",
+		&pubsubv1.Subscription{Topic: "projects/demo/topics/pms", AckDeadlineSeconds: 25})
+
+	if _, err := svc.Projects.Subscriptions.Patch("projects/demo/subscriptions/pms",
+		&pubsubv1.UpdateSubscriptionRequest{
+			Subscription: &pubsubv1.Subscription{Labels: map[string]string{"env": "prod"}, AckDeadlineSeconds: 99},
+			UpdateMask:   "labels",
+		}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got, err := svc.Projects.Subscriptions.Get("projects/demo/subscriptions/pms").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.AckDeadlineSeconds != 25 {
+		t.Errorf("ackDeadlineSeconds=%d, want 25 (not in mask, must be unchanged)", got.AckDeadlineSeconds)
+	}
+
+	if got.Labels["env"] != "prod" {
+		t.Errorf("labels[env]=%q, want prod", got.Labels["env"])
+	}
+}
+
+// TestSDKPubSubSubscriptionPatchFilterImmutable guards that changing the
+// immutable filter field is rejected.
+func TestSDKPubSubSubscriptionPatchFilterImmutable(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/pf")
+	mustSub(t, svc, "projects/demo/subscriptions/pf",
+		&pubsubv1.Subscription{Topic: "projects/demo/topics/pf", Filter: `attributes.a = "1"`})
+
+	_, err := svc.Projects.Subscriptions.Patch("projects/demo/subscriptions/pf",
+		&pubsubv1.UpdateSubscriptionRequest{
+			Subscription: &pubsubv1.Subscription{Filter: `attributes.a = "2"`},
+			UpdateMask:   "filter",
+		}).Context(ctx).Do()
+	if err == nil {
+		t.Fatal("patching immutable filter returned nil error, want rejection")
+	}
+}
+
+// TestSDKPubSubTopicPatch guards topics.patch: labels update is reflected on Get.
+func TestSDKPubSubTopicPatch(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/tp")
+
+	if _, err := svc.Projects.Topics.Patch("projects/demo/topics/tp",
+		&pubsubv1.UpdateTopicRequest{
+			Topic:      &pubsubv1.Topic{Labels: map[string]string{"team": "core"}},
+			UpdateMask: "labels",
+		}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Topics.Patch: %v", err)
+	}
+
+	got, err := svc.Projects.Topics.Get("projects/demo/topics/tp").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Labels["team"] != "core" {
+		t.Fatalf("labels[team]=%q, want core", got.Labels["team"])
+	}
+}
+
+// TestSDKPubSubFilterDelivery guards that a subscription filter is evaluated on
+// delivery: only messages whose attributes match are pulled; non-matching ones
+// are filtered out (auto-acked) and never delivered.
+func TestSDKPubSubFilterDelivery(t *testing.T) {
+	svc := newSDKService(t)
+
+	mustTopic(t, svc, "projects/demo/topics/flt")
+	mustSub(t, svc, "projects/demo/subscriptions/flt",
+		&pubsubv1.Subscription{Topic: "projects/demo/topics/flt", Filter: `attributes.color = "red"`})
+
+	publish(t, svc, "projects/demo/topics/flt",
+		&pubsubv1.PubsubMessage{
+			Data:       base64.StdEncoding.EncodeToString([]byte("r")),
+			Attributes: map[string]string{"color": "red"},
+		},
+		&pubsubv1.PubsubMessage{
+			Data:       base64.StdEncoding.EncodeToString([]byte("b")),
+			Attributes: map[string]string{"color": "blue"},
+		},
+	)
+
+	resp := pull(t, svc, "projects/demo/subscriptions/flt", 10)
+	if len(resp.ReceivedMessages) != 1 {
+		t.Fatalf("filtered pull got %d messages, want 1 (only red)", len(resp.ReceivedMessages))
+	}
+
+	if got := resp.ReceivedMessages[0].Message.Attributes["color"]; got != "red" {
+		t.Fatalf("delivered color=%q, want red", got)
+	}
+}
+
+// TestSDKPubSubFilterPrefixAndBoolean guards hasPrefix + AND/OR/NOT combinations.
+func TestSDKPubSubFilterPrefixAndBoolean(t *testing.T) {
+	svc := newSDKService(t)
+
+	mustTopic(t, svc, "projects/demo/topics/fltp")
+	mustSub(t, svc, "projects/demo/subscriptions/fltp", &pubsubv1.Subscription{
+		Topic:  "projects/demo/topics/fltp",
+		Filter: `hasPrefix(attributes.name, "co") AND NOT attributes:skip`,
+	})
+
+	publish(t, svc, "projects/demo/topics/fltp",
+		&pubsubv1.PubsubMessage{ // matches: name starts with "co", no skip attr
+			Data:       base64.StdEncoding.EncodeToString([]byte("1")),
+			Attributes: map[string]string{"name": "com"},
+		},
+		&pubsubv1.PubsubMessage{ // rejected: has skip attribute
+			Data:       base64.StdEncoding.EncodeToString([]byte("2")),
+			Attributes: map[string]string{"name": "core", "skip": "yes"},
+		},
+		&pubsubv1.PubsubMessage{ // rejected: wrong prefix
+			Data:       base64.StdEncoding.EncodeToString([]byte("3")),
+			Attributes: map[string]string{"name": "net"},
+		},
+	)
+
+	resp := pull(t, svc, "projects/demo/subscriptions/fltp", 10)
+	if len(resp.ReceivedMessages) != 1 {
+		t.Fatalf("boolean-filter pull got %d, want 1", len(resp.ReceivedMessages))
+	}
+
+	if got := resp.ReceivedMessages[0].Message.Attributes["name"]; got != "com" {
+		t.Fatalf("delivered name=%q, want com", got)
+	}
+}

--- a/server/gcp/pubsub/subscription.go
+++ b/server/gcp/pubsub/subscription.go
@@ -5,30 +5,14 @@ import (
 	"sort"
 	"time"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/pagination"
 )
 
 // ---------- Subscriptions ----------
 
 func (h *Handler) serveSubscription(w http.ResponseWriter, r *http.Request, project, name, action string) {
-	switch action {
-	case "pull":
-		h.pull(w, r, name)
-		return
-	case "acknowledge":
-		h.acknowledge(w, r, name)
-		return
-	case "modifyAckDeadline":
-		h.modifyAckDeadline(w, r, name)
-		return
-	case "modifyPushConfig":
-		h.modifyPushConfig(w, r, name)
-		return
-	case "seek":
-		h.seek(w, r, name)
-		return
-	case verbGetIamPolicy, verbSetIamPolicy, verbTestIamPermissions:
-		h.serveIam(w, r, resSubscriptions, name, action)
+	if h.serveSubscriptionVerb(w, r, name, action) {
 		return
 	}
 
@@ -37,11 +21,36 @@ func (h *Handler) serveSubscription(w http.ResponseWriter, r *http.Request, proj
 		h.createSubscription(w, r, project, name)
 	case http.MethodGet:
 		h.getSubscription(w, project, name)
+	case http.MethodPatch:
+		h.patchSubscription(w, r, name)
 	case http.MethodDelete:
 		h.deleteSubscription(w, name)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "method not allowed")
 	}
+}
+
+// serveSubscriptionVerb dispatches the :verb sub-resource actions, returning
+// true when it handled the request.
+func (h *Handler) serveSubscriptionVerb(w http.ResponseWriter, r *http.Request, name, action string) bool {
+	switch action {
+	case "pull":
+		h.pull(w, r, name)
+	case "acknowledge":
+		h.acknowledge(w, r, name)
+	case "modifyAckDeadline":
+		h.modifyAckDeadline(w, r, name)
+	case "modifyPushConfig":
+		h.modifyPushConfig(w, r, name)
+	case "seek":
+		h.seek(w, r, name)
+	case verbGetIamPolicy, verbSetIamPolicy, verbTestIamPermissions:
+		h.serveIam(w, r, resSubscriptions, name, action)
+	default:
+		return false
+	}
+
+	return true
 }
 
 func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, project, name string) {
@@ -64,6 +73,12 @@ func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, pro
 		body.AckDeadlineSeconds = defaultAckDeadlineSeconds
 	}
 
+	filter, err := parseFilter(body.Filter)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, reasonInvalidArgument, "invalid filter: "+err.Error())
+		return
+	}
+
 	cfg := body
 	cfg.Name = subscriptionName(project, name)
 	cfg.Topic = topicName(project, topicShort)
@@ -76,10 +91,84 @@ func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, pro
 		return
 	}
 
-	h.newSub(name, topicShort, &cfg)
+	h.newSub(name, topicShort, &cfg, filter)
 	h.mu.Unlock()
 
 	writeJSON(w, http.StatusOK, cfg)
+}
+
+// patchSubscription applies subscriptions.patch: it merges only the fields named
+// by updateMask into the stored config. filter/topic/name are immutable.
+func (h *Handler) patchSubscription(w http.ResponseWriter, r *http.Request, name string) {
+	var req updateSubscriptionRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	masks := parseMask(req.UpdateMask)
+	if len(masks) == 0 {
+		writeError(w, http.StatusBadRequest, reasonInvalidArgument, "updateMask must be specified and non-empty")
+		return
+	}
+
+	h.mu.Lock()
+
+	sub, ok := h.subs[name]
+	if !ok {
+		h.mu.Unlock()
+		writeError(w, http.StatusNotFound, reasonNotFound, "subscription "+name+" not found")
+
+		return
+	}
+
+	if err := applySubMask(&sub.cfg, &req.Subscription, masks); err != nil {
+		h.mu.Unlock()
+		writeError(w, http.StatusBadRequest, reasonInvalidArgument, err.Error())
+
+		return
+	}
+
+	cfg := sub.cfg
+	h.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, cfg)
+}
+
+// applySubMask merges the masked fields of src into dst. filter, topic and name
+// are immutable in real Pub/Sub, so naming them in the mask is rejected;
+// unsupported masks are ignored.
+func applySubMask(dst, src *subscription, masks []string) error {
+	setters := subMaskSetters()
+
+	for _, m := range masks {
+		switch m {
+		case "filter", "topic", "name":
+			return cerrors.Newf(cerrors.InvalidArgument, "field %q is immutable and cannot be updated", m)
+		}
+
+		if set, ok := setters[m]; ok {
+			set(dst, src)
+		}
+	}
+
+	return nil
+}
+
+// subMaskSetters maps a subscriptions.patch field-mask path to the merge that
+// copies that one field from the request into the stored config.
+func subMaskSetters() map[string]func(dst, src *subscription) {
+	return map[string]func(dst, src *subscription){
+		"ackDeadlineSeconds":       func(d, s *subscription) { d.AckDeadlineSeconds = s.AckDeadlineSeconds },
+		"retryPolicy":              func(d, s *subscription) { d.RetryPolicy = s.RetryPolicy },
+		"deadLetterPolicy":         func(d, s *subscription) { d.DeadLetterPolicy = s.DeadLetterPolicy },
+		"pushConfig":               func(d, s *subscription) { d.PushConfig = s.PushConfig },
+		"labels":                   func(d, s *subscription) { d.Labels = s.Labels },
+		"messageRetentionDuration": func(d, s *subscription) { d.MessageRetentionDuration = s.MessageRetentionDuration },
+		"expirationPolicy":         func(d, s *subscription) { d.ExpirationPolicy = s.ExpirationPolicy },
+		"retainAckedMessages":      func(d, s *subscription) { d.RetainAckedMessages = s.RetainAckedMessages },
+		"enableMessageOrdering":    func(d, s *subscription) { d.EnableMessageOrdering = s.EnableMessageOrdering },
+		"detached":                 func(d, s *subscription) { d.Detached = s.Detached },
+	}
 }
 
 func (h *Handler) getSubscription(w http.ResponseWriter, _, name string) {

--- a/server/gcp/pubsub/types.go
+++ b/server/gcp/pubsub/types.go
@@ -27,6 +27,26 @@ type subscription struct {
 	Detached                 bool              `json:"detached,omitempty"`
 }
 
+// updateTopicRequest is PATCH topics/{name} (topics.patch): the topic fields to
+// update plus the field mask naming which of them to apply.
+type updateTopicRequest struct {
+	Topic      topic  `json:"topic"`
+	UpdateMask string `json:"updateMask"`
+}
+
+// updateSubscriptionRequest is PATCH subscriptions/{name} (subscriptions.patch).
+type updateSubscriptionRequest struct {
+	Subscription subscription `json:"subscription"`
+	UpdateMask   string       `json:"updateMask"`
+}
+
+// deadLetterPolicyJSON is the parsed shape of subscription.deadLetterPolicy,
+// used to route exhausted messages to the dead-letter topic.
+type deadLetterPolicyJSON struct {
+	DeadLetterTopic     string `json:"deadLetterTopic"`
+	MaxDeliveryAttempts int    `json:"maxDeliveryAttempts"`
+}
+
 type listTopicsResponse struct {
 	Topics        []topic `json:"topics"`
 	NextPageToken string  `json:"nextPageToken,omitempty"`


### PR DESCRIPTION
Confirming re-audit residue on GCP Pub/Sub — 2 HIGH + 2 correctness gaps, all reconciled against the Pub/Sub v1 REST docs (projects.subscriptions.patch, projects.topics.patch, Filtering syntax, DeadLetterPolicy).

## Fixes

- **[HIGH] Topic/Subscription PATCH (update) returned 405.** `serveTopic`/`serveSubscription` only accepted PUT/GET/DELETE, so any in-place update — Terraform `google_pubsub_topic`/`google_pubsub_subscription` apply, or the Go SDK `Subscription.Update`/`Topic.Update` — failed. Added `http.MethodPatch` handlers that decode `UpdateTopicRequest`/`UpdateSubscriptionRequest`, honor `updateMask` field paths, and merge only the masked fields. Supported subscription masks: `ackDeadlineSeconds`, `retryPolicy`, `deadLetterPolicy`, `pushConfig`, `labels`, `messageRetentionDuration`, `expirationPolicy`, `retainAckedMessages`, `enableMessageOrdering`, `detached`. `filter`/`topic`/`name` are immutable and rejected. Topic patch supports `labels`.

- **[HIGH] Subscription filter stored but never evaluated.** `deliver()` ignored `sub.cfg.Filter`, so non-matching messages were delivered. Added a Pub/Sub filter evaluator (`attributes.key = "v"`, `!=`, `attributes:key`, `hasPrefix(...)`, `NOT`/`AND`/`OR`, parentheses). The filter is immutable, so it is parsed once at create and evaluated on delivery; a filtered-out message is auto-acked (not delivered, not backlogged), matching real Pub/Sub.

- **[MED] deadLetterPolicy not enforced.** Delivery counted attempts and surfaced `deliveryAttempt` but never routed. Now once attempts exceed `maxDeliveryAttempts` (default 5), the message is forwarded to the dead-letter topic's log and auto-acked on the source, so a subscription on the DLQ topic receives it and the source stops redelivering.

- **[LOW] Topic delete didn't detach subscriptions.** `deleteTopic` now sets `subscription.topic = "_deleted-topic_"` for attached subs and keeps their message log so already-published messages can still drain.

## Notes
- Server-local only; no driver/interface change. `go generate` and `internal/compatgen` produce zero diff.
- Round #638 behavior preserved (fan-out, ordering, ackDeadline/modifyAckDeadline, snapshots/seek, extended-field round-trip, IAM, pagination) — existing tests stay green, including `-race`.

## Tests
Real `google.golang.org/api/pubsub/v1` reproductions: subscription/topic PATCH reflected on Get; mask scoping; immutable-filter rejection; `attributes.color="red"` delivers only red; `hasPrefix(...) AND NOT attributes:skip`; DLQ routing after nacks; topic-delete detach.