### PR TITLE
fix(azure-servicebus): SqlFilter OR (stop message loss) + relational/custom-property eval; subscription counts; maxDeliveryCount on update

### DIFF
--- a/providers/azure/servicebus/servicebus.go
+++ b/providers/azure/servicebus/servicebus.go
@@ -763,6 +763,19 @@ func applyQueueAttributes(qd *queueData, attrs map[string]int) {
 	if v, ok := attrs["MessageRetentionPeriod"]; ok {
 		qd.messageRetention = v
 	}
+
+	// MaxDeliveryCount reconfigures the dead-letter threshold (Service Bus
+	// maxDeliveryCount): lowering it dead-letters already-enqueued messages at the
+	// new threshold on their next delivery attempt.
+	if v, ok := attrs["MaxDeliveryCount"]; ok && qd.dlqConfig != nil {
+		qd.dlqConfig.MaxReceiveCount = v
+	}
+
+	// DeadLetterOnExpiration toggles Service Bus'
+	// deadLetteringOnMessageExpiration (encoded 0/1 over the int-only map).
+	if v, ok := attrs["DeadLetterOnExpiration"]; ok {
+		qd.deadLetterOnExpiration = v != 0
+	}
 }
 
 // PurgeQueue removes all messages from the specified queue.

--- a/server/azure/servicebus/dataplane.go
+++ b/server/azure/servicebus/dataplane.go
@@ -436,12 +436,9 @@ func (h *Handler) dataPlaneSend(w http.ResponseWriter, r *http.Request, url stri
 // real Service Bus). A topic with no subscriptions, or with none whose rules
 // match, still returns 201 (the message is accepted and dropped), matching
 // Azure. Each matching subscription persists the sender's system properties and
-// applies its own default message TTL.
-//
-// DEFER: only the well-known system properties are evaluated in filters;
-// arbitrary custom application-property headers are not parsed, so a SqlFilter
-// or CorrelationFilter predicate over a user-defined property cannot disqualify
-// a subscription yet.
+// applies its own default message TTL. Both the well-known system properties
+// and the sender's custom application-property headers are evaluated in
+// filters.
 func (h *Handler) dataPlaneTopicSend(w http.ResponseWriter, r *http.Request, targets []topicSubTarget) {
 	if r.Method != http.MethodPost {
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "send requires POST")
@@ -449,7 +446,7 @@ func (h *Handler) dataPlaneTopicSend(w http.ResponseWriter, r *http.Request, tar
 	}
 
 	bp := parseWireBrokerProps(r)
-	filter := bp.filterProps()
+	filter := bp.filterProps(customHeaderProps(r))
 
 	body, ok := readSendBody(w, r)
 	if !ok {
@@ -499,9 +496,9 @@ func parseWireBrokerProps(r *http.Request) wireBrokerProps {
 	return bp
 }
 
-// filterProps projects the well-known system properties a subscription rule
-// filter evaluates against.
-func (b *wireBrokerProps) filterProps() messageProps {
+// filterProps projects the well-known system properties, plus the supplied
+// custom application properties, a subscription rule filter evaluates against.
+func (b *wireBrokerProps) filterProps(custom map[string]string) messageProps {
 	return messageProps{
 		MessageID:        b.MessageID,
 		CorrelationID:    b.CorrelationID,
@@ -511,6 +508,52 @@ func (b *wireBrokerProps) filterProps() messageProps {
 		SessionID:        b.SessionID,
 		ReplyToSessionID: b.ReplyToSessionID,
 		ContentType:      b.ContentType,
+		Custom:           custom,
+	}
+}
+
+// customHeaderProps extracts the sender's custom application properties from a
+// data-plane send request. Per the Service Bus REST protocol, user properties
+// travel as individual HTTP headers alongside the system-property
+// BrokerProperties header; reserved protocol headers and the literal value
+// "null" are dropped. https://learn.microsoft.com/rest/api/servicebus/send-message-to-queue
+func customHeaderProps(r *http.Request) map[string]string {
+	out := map[string]string{}
+
+	for name, vals := range r.Header {
+		if len(vals) == 0 || isReservedHeader(name) {
+			continue
+		}
+
+		v := vals[0]
+		if v == "" || strings.EqualFold(v, "null") {
+			continue
+		}
+
+		out[name] = v
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
+// isReservedHeader reports whether a header name is a Service Bus protocol
+// header or a standard HTTP header that must not be surfaced as a custom
+// application property. Matched case-insensitively.
+func isReservedHeader(name string) bool {
+	switch strings.ToLower(name) {
+	case "authorization", "content-type", "content-length", "content-encoding",
+		"content-md5", "brokerproperties", "x-ms-retrypolicy", "host", "user-agent",
+		"accept", "accept-encoding", "accept-charset", "accept-language", "connection",
+		"date", "expect", "transfer-encoding", "cookie", "cache-control", "pragma",
+		"referer", "origin", "range", "te", "trailer", "upgrade", "via", "warning",
+		"keep-alive", "server", "x-forwarded-for", "x-forwarded-host", "x-forwarded-proto":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/server/azure/servicebus/dataplane_dlq_test.go
+++ b/server/azure/servicebus/dataplane_dlq_test.go
@@ -145,6 +145,55 @@ func TestDataPlaneSubscriptionDeadLetter(t *testing.T) {
 	}
 }
 
+// TestDataPlaneLowerMaxDeliveryCountViaPut is the regression for an update PUT
+// not propagating maxDeliveryCount to the backing store: lowering it from 10 to
+// 1 must take effect, dead-lettering at the new threshold.
+func TestDataPlaneLowerMaxDeliveryCountViaPut(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+
+	// Created with the default maxDeliveryCount (10).
+	if r := doRequest(t, srv, http.MethodPut, queueURL("relax")+apiVer, `{"properties":{}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create queue = %d", r.StatusCode)
+	}
+
+	// Update PUT lowers maxDeliveryCount to 1.
+	if r := doRequest(t, srv, http.MethodPut, queueURL("relax")+apiVer,
+		`{"properties":{"maxDeliveryCount":1}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("update queue = %d", r.StatusCode)
+	}
+
+	if r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/relax/messages", "boom"); r.StatusCode != http.StatusCreated {
+		t.Fatalf("send = %d", r.StatusCode)
+	}
+
+	// maxDeliveryCount=1: one delivery, then dead-lettered on the 2nd attempt.
+	lock := doRequest(t, srv, http.MethodPost, "/"+nsName+"/relax/messages/head", "")
+	if lock.StatusCode != http.StatusCreated {
+		t.Fatalf("peek-lock = %d, want 201", lock.StatusCode)
+	}
+
+	_ = readBody(t, lock)
+
+	if r := doRequest(t, srv, http.MethodPut, lock.Header.Get("Location"), ""); r.StatusCode != http.StatusOK {
+		t.Fatalf("abandon = %d", r.StatusCode)
+	}
+
+	second := doRequest(t, srv, http.MethodPost, "/"+nsName+"/relax/messages/head", "")
+	if second.StatusCode != http.StatusNoContent {
+		t.Fatalf("2nd receive = %d, want 204 (dead-lettered at lowered threshold)", second.StatusCode)
+	}
+
+	dlq := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/relax/$DeadLetterQueue/messages/head", "")
+	if dlq.StatusCode != http.StatusOK {
+		t.Fatalf("DLQ receive = %d, want 200", dlq.StatusCode)
+	}
+
+	if got := readBody(t, dlq); got != "boom" {
+		t.Fatalf("DLQ body = %q, want boom", got)
+	}
+}
+
 // TestDataPlaneRenewLock is the regression for the unimplemented renew-lock
 // verb: a POST on a locked message must extend its lock (200), not return 405.
 func TestDataPlaneRenewLock(t *testing.T) {

--- a/server/azure/servicebus/dataplane_filter_test.go
+++ b/server/azure/servicebus/dataplane_filter_test.go
@@ -3,6 +3,7 @@ package servicebus_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -124,6 +125,171 @@ func TestDataPlaneSQLFilterSysProperty(t *testing.T) {
 	empty := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/events/subscriptions/errors-only/messages/head", "")
 	if empty.StatusCode != http.StatusNoContent {
 		t.Fatalf("second receive = %d, want 204 (info-msg must not have matched)", empty.StatusCode)
+	}
+}
+
+// replaceRuleWithSQL swaps a subscription's $Default rule for a SqlFilter over
+// the given expression.
+func replaceRuleWithSQL(t *testing.T, srv *httptest.Server, topic, sub, expr string) {
+	t.Helper()
+
+	if r := doRequest(t, srv, http.MethodDelete, ruleURL(topic, sub, "$Default")+apiVer, ""); r.StatusCode != http.StatusOK {
+		t.Fatalf("delete $Default rule = %d", r.StatusCode)
+	}
+
+	body := `{"properties":{"filterType":"SqlFilter","sqlFilter":{"sqlExpression":` + strconv.Quote(expr) + `}}}`
+	if r := doRequest(t, srv, http.MethodPut, ruleURL(topic, sub, "custom")+apiVer, body); r.StatusCode != http.StatusOK {
+		t.Fatalf("create sql rule = %d", r.StatusCode)
+	}
+}
+
+// receiveOne receive-and-deletes one message from a subscription, returning its
+// body and whether one was present (200 vs 204).
+func receiveOne(t *testing.T, srv *httptest.Server, topic, sub string) (string, bool) {
+	t.Helper()
+
+	r := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/"+topic+"/subscriptions/"+sub+"/messages/head", "")
+	switch r.StatusCode {
+	case http.StatusOK:
+		return readBody(t, r), true
+	case http.StatusNoContent:
+		return "", false
+	default:
+		t.Fatalf("receive from %s = %d, want 200 or 204", sub, r.StatusCode)
+		return "", false
+	}
+}
+
+// TestDataPlaneSQLFilterORDeliversMatch is the regression for the HIGH message-
+// loss bug: a SqlFilter using OR must deliver a message that matches either
+// disjunct, not silently drop it. Before the fix the whole "a OR b" expression
+// was parsed as one malformed equality that always failed.
+func TestDataPlaneSQLFilterORDeliversMatch(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+	seedTopicSub(t, srv, "events", "ab-only")
+	replaceRuleWithSQL(t, srv, "events", "ab-only", "sys.Label = 'a' OR sys.Label = 'b'")
+
+	send := func(body, label string) {
+		t.Helper()
+
+		if r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/events/messages", body,
+			map[string]string{"BrokerProperties": `{"Label":"` + label + `"}`}); r.StatusCode != http.StatusCreated {
+			t.Fatalf("send %q = %d, want 201", body, r.StatusCode)
+		}
+	}
+
+	send("msg-a", "a")
+	send("msg-b", "b")
+	send("msg-c", "c")
+
+	// Both matching disjuncts arrive (order preserved); the non-match does not.
+	for _, want := range []string{"msg-a", "msg-b"} {
+		if got, ok := receiveOne(t, srv, "events", "ab-only"); !ok || got != want {
+			t.Fatalf("receive = %q ok=%v, want %q (OR filter must not drop matches)", got, ok, want)
+		}
+	}
+
+	if _, ok := receiveOne(t, srv, "events", "ab-only"); ok {
+		t.Fatal("non-matching Label=c must not have been delivered")
+	}
+}
+
+// TestDataPlaneSQLFilterNumericComparison confirms a relational SqlFilter over a
+// custom numeric property (priority > 5, the common Terraform pattern) delivers
+// only messages that satisfy it, rather than over-delivering everything.
+func TestDataPlaneSQLFilterNumericComparison(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+	seedTopicSub(t, srv, "orders", "high-pri")
+	replaceRuleWithSQL(t, srv, "orders", "high-pri", "priority > 5")
+
+	send := func(body, priority string) {
+		t.Helper()
+
+		if r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/orders/messages", body,
+			map[string]string{"priority": priority}); r.StatusCode != http.StatusCreated {
+			t.Fatalf("send %q = %d, want 201", body, r.StatusCode)
+		}
+	}
+
+	send("low", "3")
+	send("high", "9")
+
+	if got, ok := receiveOne(t, srv, "orders", "high-pri"); !ok || got != "high" {
+		t.Fatalf("receive = %q ok=%v, want high", got, ok)
+	}
+
+	if _, ok := receiveOne(t, srv, "orders", "high-pri"); ok {
+		t.Fatal("priority=3 must not have matched priority > 5")
+	}
+}
+
+// TestDataPlaneSQLFilterCustomPropertyEquality confirms a SqlFilter equality
+// predicate over a custom string property (myprop = 'x') routes only matching
+// messages.
+func TestDataPlaneSQLFilterCustomPropertyEquality(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+	seedTopicSub(t, srv, "orders", "x-only")
+	replaceRuleWithSQL(t, srv, "orders", "x-only", "myprop = 'x'")
+
+	send := func(body, val string) {
+		t.Helper()
+
+		if r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/orders/messages", body,
+			map[string]string{"myprop": val}); r.StatusCode != http.StatusCreated {
+			t.Fatalf("send %q = %d, want 201", body, r.StatusCode)
+		}
+	}
+
+	send("nope", "y")
+	send("yes", "x")
+
+	if got, ok := receiveOne(t, srv, "orders", "x-only"); !ok || got != "yes" {
+		t.Fatalf("receive = %q ok=%v, want yes", got, ok)
+	}
+
+	if _, ok := receiveOne(t, srv, "orders", "x-only"); ok {
+		t.Fatal("myprop=y must not have matched myprop = 'x'")
+	}
+}
+
+// TestDataPlaneCorrelationFilterUserProperties confirms a CorrelationFilter's
+// user-defined Properties are matched against the message's custom application
+// properties (previously ignored, so every message matched).
+func TestDataPlaneCorrelationFilterUserProperties(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+	seedTopicSub(t, srv, "orders", "region-eu")
+
+	if r := doRequest(t, srv, http.MethodDelete, ruleURL("orders", "region-eu", "$Default")+apiVer, ""); r.StatusCode != http.StatusOK {
+		t.Fatalf("delete $Default rule = %d", r.StatusCode)
+	}
+
+	ruleBody := `{"properties":{"filterType":"CorrelationFilter","correlationFilter":{"properties":{"region":"eu"}}}}`
+	if r := doRequest(t, srv, http.MethodPut, ruleURL("orders", "region-eu", "eu-rule")+apiVer, ruleBody); r.StatusCode != http.StatusOK {
+		t.Fatalf("create correlation rule = %d", r.StatusCode)
+	}
+
+	send := func(body, region string) {
+		t.Helper()
+
+		if r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/orders/messages", body,
+			map[string]string{"region": region}); r.StatusCode != http.StatusCreated {
+			t.Fatalf("send %q = %d, want 201", body, r.StatusCode)
+		}
+	}
+
+	send("us-order", "us")
+	send("eu-order", "eu")
+
+	if got, ok := receiveOne(t, srv, "orders", "region-eu"); !ok || got != "eu-order" {
+		t.Fatalf("receive = %q ok=%v, want eu-order", got, ok)
+	}
+
+	if _, ok := receiveOne(t, srv, "orders", "region-eu"); ok {
+		t.Fatal("region=us must not have matched Properties{region:eu}")
 	}
 }
 

--- a/server/azure/servicebus/dataplane_filter_test.go
+++ b/server/azure/servicebus/dataplane_filter_test.go
@@ -195,6 +195,104 @@ func TestDataPlaneSQLFilterORDeliversMatch(t *testing.T) {
 	}
 }
 
+// sendLabelTo publishes a message with the given Label and To system props.
+func sendLabelTo(t *testing.T, srv *httptest.Server, topic, body, label, to string) {
+	t.Helper()
+
+	bp := `{"Label":"` + label + `","To":"` + to + `"}`
+	if r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/"+topic+"/messages", body,
+		map[string]string{"BrokerProperties": bp}); r.StatusCode != http.StatusCreated {
+		t.Fatalf("send %q = %d, want 201", body, r.StatusCode)
+	}
+}
+
+// TestDataPlaneSQLFilterParenthesizedOrGroup is the regression for parenthesized
+// OR groups being dropped: "(sys.Label='a' OR sys.Label='b') AND sys.To='x'" is
+// the canonical Azure/Terraform shape, and a message matching it must be
+// delivered rather than lost to the paren being absorbed into a field name.
+func TestDataPlaneSQLFilterParenthesizedOrGroup(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+	seedTopicSub(t, srv, "events", "grp")
+	replaceRuleWithSQL(t, srv, "events", "grp", "(sys.Label = 'a' OR sys.Label = 'b') AND sys.To = 'x'")
+
+	sendLabelTo(t, srv, "events", "hit-a", "a", "x")     // matches OR group + To
+	sendLabelTo(t, srv, "events", "hit-b", "b", "x")     // matches other disjunct + To
+	sendLabelTo(t, srv, "events", "wrong-to", "a", "y")  // OR group ok, To fails
+	sendLabelTo(t, srv, "events", "wrong-lbl", "c", "x") // To ok, OR group fails
+
+	for _, want := range []string{"hit-a", "hit-b"} {
+		if got, ok := receiveOne(t, srv, "events", "grp"); !ok || got != want {
+			t.Fatalf("receive = %q ok=%v, want %q (parenthesized OR group must deliver)", got, ok, want)
+		}
+	}
+
+	if _, ok := receiveOne(t, srv, "events", "grp"); ok {
+		t.Fatal("messages failing the paren filter must not have been delivered")
+	}
+}
+
+// TestDataPlaneSQLFilterSingleParenClause confirms even a trivially
+// parenthesized single clause "(sys.Label='a')" evaluates correctly.
+func TestDataPlaneSQLFilterSingleParenClause(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+	seedTopicSub(t, srv, "events", "paren1")
+	replaceRuleWithSQL(t, srv, "events", "paren1", "(sys.Label = 'a')")
+
+	sendLabelTo(t, srv, "events", "yes", "a", "")
+	sendLabelTo(t, srv, "events", "no", "z", "")
+
+	if got, ok := receiveOne(t, srv, "events", "paren1"); !ok || got != "yes" {
+		t.Fatalf("receive = %q ok=%v, want yes", got, ok)
+	}
+
+	if _, ok := receiveOne(t, srv, "events", "paren1"); ok {
+		t.Fatal("Label=z must not have matched (sys.Label='a')")
+	}
+}
+
+// TestDataPlaneSQLFilterNestedParens confirms nested parentheses with mixed
+// OR/AND precedence: "((sys.Label='a' OR sys.Label='b') AND sys.To='x') OR
+// sys.Label='d'".
+func TestDataPlaneSQLFilterNestedParens(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+	seedTopicSub(t, srv, "events", "nested")
+	replaceRuleWithSQL(t, srv, "events", "nested",
+		"((sys.Label = 'a' OR sys.Label = 'b') AND sys.To = 'x') OR sys.Label = 'd'")
+
+	sendLabelTo(t, srv, "events", "via-and", "a", "x") // inner group true
+	sendLabelTo(t, srv, "events", "via-d", "d", "y")   // outer OR disjunct true
+	sendLabelTo(t, srv, "events", "miss", "a", "y")    // inner To fails, not d
+
+	for _, want := range []string{"via-and", "via-d"} {
+		if got, ok := receiveOne(t, srv, "events", "nested"); !ok || got != want {
+			t.Fatalf("receive = %q ok=%v, want %q", got, ok, want)
+		}
+	}
+
+	if _, ok := receiveOne(t, srv, "events", "nested"); ok {
+		t.Fatal("non-matching nested-filter message must not have been delivered")
+	}
+}
+
+// TestDataPlaneSQLFilterUnbalancedParenNoDrop confirms the no-drop safety net: an
+// unbalanced-paren expression cannot be parsed, so it must over-deliver (match
+// everything) rather than silently drop.
+func TestDataPlaneSQLFilterUnbalancedParenNoDrop(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+	seedTopicSub(t, srv, "events", "unbal")
+	replaceRuleWithSQL(t, srv, "events", "unbal", "(sys.Label = 'a'")
+
+	sendLabelTo(t, srv, "events", "kept", "anything", "")
+
+	if got, ok := receiveOne(t, srv, "events", "unbal"); !ok || got != "kept" {
+		t.Fatalf("receive = %q ok=%v, want kept (unbalanced paren must not drop)", got, ok)
+	}
+}
+
 // TestDataPlaneSQLFilterNumericComparison confirms a relational SqlFilter over a
 // custom numeric property (priority > 5, the common Terraform pattern) delivers
 // only messages that satisfy it, rather than over-delivering everything.

--- a/server/azure/servicebus/filter.go
+++ b/server/azure/servicebus/filter.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 )
 
-// messageProps is the subset of a Service Bus message's well-known system
-// properties that subscription rule filters evaluate against. These are the
-// same properties CorrelationFilter matches and the sys.* identifiers a
-// SqlFilter expression can reference:
-// https://learn.microsoft.com/azure/service-bus-messaging/topic-filters
+// messageProps is the subset of a Service Bus message that subscription rule
+// filters evaluate against: the well-known system properties (the sys.*
+// identifiers a SqlFilter references and the fields a CorrelationFilter
+// matches) plus the sender's custom application properties (referenced by bare
+// name, or a user. prefix, in a SqlFilter and by key in a CorrelationFilter's
+// Properties). https://learn.microsoft.com/azure/service-bus-messaging/topic-filters
 type messageProps struct {
 	MessageID        string
 	CorrelationID    string
@@ -19,6 +20,26 @@ type messageProps struct {
 	SessionID        string
 	ReplyToSessionID string
 	ContentType      string
+	// Custom holds the sender's user-defined application properties, keyed by
+	// the header name they arrived under. Lookups are case-insensitive.
+	Custom map[string]string
+}
+
+// lookupCustom resolves a user-defined property by name, case-insensitively
+// (HTTP header canonicalization mangles the sender's casing), reporting whether
+// the message carried it.
+func lookupCustom(custom map[string]string, name string) (string, bool) {
+	if v, ok := custom[name]; ok {
+		return v, true
+	}
+
+	for k, v := range custom {
+		if strings.EqualFold(k, name) {
+			return v, true
+		}
+	}
+
+	return "", false
 }
 
 // rulesMatch reports whether a message matches at least one of a
@@ -52,7 +73,8 @@ func ruleMatches(rule *ruleProperties, props *messageProps) bool {
 // correlationMatches implements CorrelationFilter matching: every field the
 // filter sets must equal the message's corresponding property (logical AND);
 // unset fields impose no constraint. String comparison is case-sensitive, per
-// the docs. User-defined Properties are not matched -- see the DEFER note.
+// the docs. User-defined Properties are matched against the message's custom
+// application properties.
 func correlationMatches(f *correlationFilter, p *messageProps) bool {
 	if f == nil {
 		return true
@@ -72,6 +94,12 @@ func correlationMatches(f *correlationFilter, p *messageProps) bool {
 	for _, pair := range pairs {
 		want, got := pair[0], pair[1]
 		if want != "" && want != got {
+			return false
+		}
+	}
+
+	for name, want := range f.Properties {
+		if got, ok := lookupCustom(p.Custom, name); !ok || got != want {
 			return false
 		}
 	}
@@ -105,14 +133,22 @@ func sqlProp(field string, p *messageProps) (string, bool) {
 	}
 }
 
-// sqlMatches evaluates a SqlFilter's expression against a message. Only a
-// "basic" grammar is supported: the boolean literals real SDKs generate for
-// TrueFilter/FalseFilter (1=1, 1=0, true, false), and an AND-joined list of
-// sys.<Field> = 'value' equality predicates over the system properties
-// sqlProp recognizes. A clause outside that grammar (arithmetic, LIKE, a
-// user-defined property) can't be evaluated without the deferred
-// custom-property-header support, so it is treated as satisfied rather than
-// silently dropping messages a real broker would deliver.
+// sqlMatches evaluates a SqlFilter's expression against a message. The grammar
+// is OR-of-AND-of-comparison-clauses: top-level OR groups (each an AND-joined
+// list of clauses) are tried in turn, and the message matches if any group's
+// clauses all hold. A clause is "<field> <op> <value>", where op is one of
+// =, !=, <>, <, >, <=, >=; field is a sys.<Name> system property, a bare or
+// user.<Name> custom application property; and value is a quoted string or a
+// numeric literal. Boolean literals (1=1, 1=0, true, false) work as-is.
+//
+// The no-drop invariant: a clause this evaluator cannot parse (an unsupported
+// operator such as LIKE/IN, malformed syntax, or an unrecognized sys.*
+// identifier) is treated as satisfied rather than silently dropping a message a
+// real broker would deliver. A well-formed comparison that legitimately fails
+// (or references an absent custom property) still excludes the message.
+//
+// DEFER: LIKE, IN, EXISTS, IS NULL, arithmetic and parentheses are not parsed;
+// clauses using them fall back to the no-drop match=true path.
 func sqlMatches(f *sqlFilter, p *messageProps) bool {
 	if f == nil {
 		return true
@@ -123,15 +159,22 @@ func sqlMatches(f *sqlFilter, p *messageProps) bool {
 
 func evalSQLExpression(expr string, p *messageProps) bool {
 	expr = strings.TrimSpace(expr)
-
-	switch strings.ToLower(expr) {
-	case "", "1=1", "true":
+	if expr == "" {
 		return true
-	case "1=0", "false":
-		return false
 	}
 
-	for _, clause := range splitSQLAnd(expr) {
+	for _, group := range splitTopLevel(expr, "OR") {
+		if evalSQLAndGroup(group, p) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// evalSQLAndGroup reports whether every AND-joined clause in one OR-group holds.
+func evalSQLAndGroup(group string, p *messageProps) bool {
+	for _, clause := range splitTopLevel(group, "AND") {
 		if !evalSQLClause(clause, p) {
 			return false
 		}
@@ -140,20 +183,20 @@ func evalSQLExpression(expr string, p *messageProps) bool {
 	return true
 }
 
-// splitSQLAnd splits a SQL filter expression on top-level "AND" keywords.
-// It does not account for AND appearing inside a quoted string literal --
-// out of scope for the "basic predicates" this evaluator supports.
-func splitSQLAnd(expr string) []string {
+// splitTopLevel splits a SQL filter expression on a top-level boolean keyword
+// (OR/AND), case-insensitively. It does not account for the keyword appearing
+// inside a quoted string literal -- out of scope for this evaluator.
+func splitTopLevel(expr, keyword string) []string {
 	fields := strings.Fields(expr)
 
 	var (
-		clauses []string
-		cur     []string
+		parts []string
+		cur   []string
 	)
 
 	for _, f := range fields {
-		if strings.EqualFold(f, "AND") {
-			clauses = append(clauses, strings.Join(cur, " "))
+		if strings.EqualFold(f, keyword) {
+			parts = append(parts, strings.Join(cur, " "))
 			cur = nil
 
 			continue
@@ -162,55 +205,219 @@ func splitSQLAnd(expr string) []string {
 		cur = append(cur, f)
 	}
 
-	clauses = append(clauses, strings.Join(cur, " "))
+	parts = append(parts, strings.Join(cur, " "))
 
-	return clauses
+	return parts
 }
 
-// evalSQLClause evaluates one "sys.<Field> = 'value'" equality predicate.
-// Anything else (a user property, a non-equality operator) is unsupported and
-// treated as matching -- see evalSQLExpression.
+// SQL comparison operators the filter grammar understands.
+const (
+	opEqual        = "="
+	opNotEqual     = "!="
+	opNotEqualAnsi = "<>"
+	opLess         = "<"
+	opGreater      = ">"
+	opLessEqual    = "<="
+	opGreaterEqual = ">="
+)
+
+// evalSQLClause evaluates one comparison clause, upholding the no-drop
+// invariant for anything it cannot parse or resolve.
 func evalSQLClause(clause string, p *messageProps) bool {
-	field, want, ok := parseSQLEquality(clause)
+	clause = strings.TrimSpace(clause)
+
+	switch strings.ToLower(clause) {
+	case "true":
+		return true
+	case "false":
+		return false
+	}
+
+	field, op, rawVal, ok := parseSQLClause(clause)
 	if !ok {
 		return true
 	}
 
-	field = strings.TrimPrefix(field, "sys.")
+	// A literal left-hand side (the boolean-filter tautologies 1=1 / 1=0, or a
+	// quoted constant) is compared directly rather than looked up as a property.
+	if lit, isLit := sqlLiteral(field); isLit {
+		return compareSQL(op, lit, rawVal)
+	}
 
-	got, known := sqlProp(field, p)
-	if !known {
+	got, present, recognized := resolveSQLField(field, p)
+	if !recognized {
 		return true
 	}
 
+	if !present {
+		return false
+	}
+
+	return compareSQL(op, got, rawVal)
+}
+
+// sqlLiteral reports whether a clause's left-hand side is itself a literal (a
+// numeric constant or a quoted string) rather than a property reference,
+// returning its unquoted value.
+func sqlLiteral(field string) (string, bool) {
+	if _, err := strconv.ParseFloat(field, floatBitSize); err == nil {
+		return field, true
+	}
+
+	if len(field) >= minQuotedLiteralLen {
+		q := field[0]
+		if (q == '\'' || q == '"') && field[len(field)-1] == q {
+			return field[1 : len(field)-1], true
+		}
+	}
+
+	return "", false
+}
+
+// parseSQLClause splits a clause into its field, comparison operator and raw
+// value. It reads the operator greedily so "<=", ">=", "!=" and "<>" are not
+// mistaken for their single-character prefixes. A lone "!" is not an operator.
+func parseSQLClause(clause string) (field, op, value string, ok bool) {
+	i := strings.IndexAny(clause, "=<>!")
+	if i < 0 {
+		return "", "", "", false
+	}
+
+	op = clause[i : i+1]
+
+	if i+1 < len(clause) {
+		switch clause[i : i+2] {
+		case opLessEqual, opGreaterEqual, opNotEqual, opNotEqualAnsi:
+			op = clause[i : i+2]
+		}
+	}
+
+	if op == "!" {
+		return "", "", "", false
+	}
+
+	field = strings.TrimSpace(clause[:i])
+	value = strings.TrimSpace(clause[i+len(op):])
+
+	if field == "" || value == "" {
+		return "", "", "", false
+	}
+
+	return field, op, value, true
+}
+
+// resolveSQLField resolves a clause's field to its message value. A sys.<Name>
+// identifier reads a system property (recognized=false for an unknown one, so
+// the caller upholds the no-drop invariant); anything else is a custom
+// application property, present only when the message carried it.
+func resolveSQLField(field string, p *messageProps) (val string, present, recognized bool) {
+	if rest, ok := cutPrefixFold(field, "sys."); ok {
+		v, known := sqlProp(rest, p)
+		if !known {
+			return "", false, false
+		}
+
+		return v, true, true
+	}
+
+	name := field
+	if rest, ok := cutPrefixFold(field, "user."); ok {
+		name = rest
+	}
+
+	v, ok := lookupCustom(p.Custom, name)
+
+	return v, ok, true
+}
+
+// compareSQL evaluates a parsed comparison. Equality falls back to string
+// compare when the operands aren't both numeric; relational operators require
+// numeric operands and otherwise report no match.
+func compareSQL(op, got, rawVal string) bool {
+	want := unquoteSQL(rawVal)
+
+	switch op {
+	case opEqual:
+		return sqlEqual(got, want)
+	case opNotEqual, opNotEqualAnsi:
+		return !sqlEqual(got, want)
+	case opLess, opGreater, opLessEqual, opGreaterEqual:
+		return sqlRelational(op, got, want)
+	default:
+		return true
+	}
+}
+
+func sqlEqual(got, want string) bool {
+	if g, w, ok := twoFloats(got, want); ok {
+		return g == w
+	}
+
 	return got == want
+}
+
+func sqlRelational(op, got, want string) bool {
+	g, w, ok := twoFloats(got, want)
+	if !ok {
+		return false
+	}
+
+	switch op {
+	case opLess:
+		return g < w
+	case opGreater:
+		return g > w
+	case opLessEqual:
+		return g <= w
+	case opGreaterEqual:
+		return g >= w
+	default:
+		return false
+	}
+}
+
+// floatBitSize is the precision strconv.ParseFloat parses SQL numeric literals at.
+const floatBitSize = 64
+
+// twoFloats parses both operands as numbers, reporting ok=false if either isn't.
+func twoFloats(a, b string) (x, y float64, ok bool) {
+	x, err := strconv.ParseFloat(a, floatBitSize)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	y, err = strconv.ParseFloat(b, floatBitSize)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	return x, y, true
+}
+
+// unquoteSQL strips a matching pair of single or double quotes from a string
+// literal, leaving unquoted (numeric/bareword) values untouched.
+func unquoteSQL(raw string) string {
+	if len(raw) >= minQuotedLiteralLen {
+		q := raw[0]
+		if (q == '\'' || q == '"') && raw[len(raw)-1] == q {
+			return raw[1 : len(raw)-1]
+		}
+	}
+
+	return raw
 }
 
 // minQuotedLiteralLen is the shortest a quoted SQL string literal can be: two
 // matching quote characters around an empty string (an empty pair of quotes).
 const minQuotedLiteralLen = 2
 
-// parseSQLEquality parses a "<field> = 'value'" or "<field> = \"value\""
-// clause, reporting ok=false for anything else.
-func parseSQLEquality(clause string) (field, value string, ok bool) {
-	idx := strings.Index(clause, "=")
-	if idx < 0 {
-		return "", "", false
+// cutPrefixFold cuts a case-insensitive prefix from s, reporting whether it matched.
+func cutPrefixFold(s, prefix string) (string, bool) {
+	if len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix) {
+		return s[len(prefix):], true
 	}
 
-	field = strings.TrimSpace(clause[:idx])
-
-	raw := strings.TrimSpace(clause[idx+1:])
-	if len(raw) < minQuotedLiteralLen {
-		return "", "", false
-	}
-
-	quote := raw[0]
-	if (quote != '\'' && quote != '"') || raw[len(raw)-1] != quote {
-		return "", "", false
-	}
-
-	return field, raw[1 : len(raw)-1], true
+	return "", false
 }
 
 // defaultLockDurationSeconds is the peek-lock visibility window a queue or

--- a/server/azure/servicebus/filter.go
+++ b/server/azure/servicebus/filter.go
@@ -475,9 +475,9 @@ func resolveSQLField(field string, p *messageProps) (val string, present, recogn
 	return v, ok, true
 }
 
-// compareSQL evaluates a parsed comparison. Equality falls back to string
-// compare when the operands aren't both numeric; relational operators require
-// numeric operands and otherwise report no match.
+// compareSQL evaluates a parsed comparison. Both equality and relational
+// operators fall back to lexical string compare when the operands aren't both
+// numeric, matching Service Bus SQL semantics for string/date operands.
 func compareSQL(op, got, rawVal string) bool {
 	want := unquoteSQL(rawVal)
 
@@ -502,20 +502,27 @@ func sqlEqual(got, want string) bool {
 }
 
 func sqlRelational(op, got, want string) bool {
-	g, w, ok := twoFloats(got, want)
-	if !ok {
-		return false
+	if g, w, ok := twoFloats(got, want); ok {
+		return applyRelational(op, g, w)
 	}
 
+	// Non-numeric operands (strings/dates) compare lexically, like real
+	// Service Bus, so they deliver instead of being silently dropped.
+	return applyRelational(op, float64(strings.Compare(got, want)), 0)
+}
+
+// applyRelational applies a relational operator to two ordered values, where a
+// negative/zero/positive first argument mirrors strings.Compare's convention.
+func applyRelational(op string, a, b float64) bool {
 	switch op {
 	case opLess:
-		return g < w
+		return a < b
 	case opGreater:
-		return g > w
+		return a > b
 	case opLessEqual:
-		return g <= w
+		return a <= b
 	case opGreaterEqual:
-		return g >= w
+		return a >= b
 	default:
 		return false
 	}

--- a/server/azure/servicebus/filter.go
+++ b/server/azure/servicebus/filter.go
@@ -134,21 +134,25 @@ func sqlProp(field string, p *messageProps) (string, bool) {
 }
 
 // sqlMatches evaluates a SqlFilter's expression against a message. The grammar
-// is OR-of-AND-of-comparison-clauses: top-level OR groups (each an AND-joined
-// list of clauses) are tried in turn, and the message matches if any group's
-// clauses all hold. A clause is "<field> <op> <value>", where op is one of
-// =, !=, <>, <, >, <=, >=; field is a sys.<Name> system property, a bare or
-// user.<Name> custom application property; and value is a quoted string or a
-// numeric literal. Boolean literals (1=1, 1=0, true, false) work as-is.
+// is a recursive-descent one: an expression is OR-of-AND of terms, where a term
+// is a parenthesized sub-expression or a comparison clause. So OR/AND
+// precedence and arbitrarily nested parentheses --
+// "(sys.Label='a' OR sys.Label='b') AND sys.To='x'" -- evaluate correctly. A
+// clause is "<field> <op> <value>", where op is one of =, !=, <>, <, >, <=, >=;
+// field is a sys.<Name> system property, or a bare/user.<Name> custom
+// application property; and value is a quoted string or a numeric literal.
+// Boolean literals (1=1, 1=0, true, false) work as-is.
 //
-// The no-drop invariant: a clause this evaluator cannot parse (an unsupported
-// operator such as LIKE/IN, malformed syntax, or an unrecognized sys.*
-// identifier) is treated as satisfied rather than silently dropping a message a
-// real broker would deliver. A well-formed comparison that legitimately fails
-// (or references an absent custom property) still excludes the message.
+// The no-drop invariant: anything this evaluator cannot fully parse (an
+// unbalanced paren, an unterminated string, an unsupported operator such as
+// LIKE/IN, other malformed syntax, or an unrecognized sys.* identifier) is
+// treated as satisfied rather than silently dropping a message a real broker
+// would deliver -- it can only ever over-deliver. A well-formed comparison that
+// legitimately fails (or references an absent custom property) still excludes
+// the message.
 //
-// DEFER: LIKE, IN, EXISTS, IS NULL, arithmetic and parentheses are not parsed;
-// clauses using them fall back to the no-drop match=true path.
+// DEFER: LIKE, IN, EXISTS, IS NULL and arithmetic are not implemented; a clause
+// using them falls back to the no-drop match=true path.
 func sqlMatches(f *sqlFilter, p *messageProps) bool {
 	if f == nil {
 		return true
@@ -163,51 +167,192 @@ func evalSQLExpression(expr string, p *messageProps) bool {
 		return true
 	}
 
-	for _, group := range splitTopLevel(expr, "OR") {
-		if evalSQLAndGroup(group, p) {
-			return true
-		}
+	toks, ok := tokenizeSQL(expr)
+	if !ok || len(toks) == 0 {
+		return true // unterminated string / nothing to evaluate -> no-drop
 	}
 
-	return false
+	parser := &sqlParser{toks: toks, props: p}
+
+	val, ok := parser.parseExpr()
+	if !ok || parser.pos != len(toks) {
+		return true // parse error or trailing tokens -> no-drop
+	}
+
+	return val
 }
 
-// evalSQLAndGroup reports whether every AND-joined clause in one OR-group holds.
-func evalSQLAndGroup(group string, p *messageProps) bool {
-	for _, clause := range splitTopLevel(group, "AND") {
-		if !evalSQLClause(clause, p) {
-			return false
-		}
-	}
+// sqlTokenKind classifies a lexical token of a SqlFilter expression.
+type sqlTokenKind int
 
-	return true
+const (
+	tokEOF sqlTokenKind = iota
+	tokAtom
+	tokLParen
+	tokRParen
+	tokAnd
+	tokOr
+)
+
+type sqlToken struct {
+	kind sqlTokenKind
+	text string // set only for tokAtom
 }
 
-// splitTopLevel splits a SQL filter expression on a top-level boolean keyword
-// (OR/AND), case-insensitively. It does not account for the keyword appearing
-// inside a quoted string literal -- out of scope for this evaluator.
-func splitTopLevel(expr, keyword string) []string {
-	fields := strings.Fields(expr)
+// tokenizeSQL lexes a SqlFilter expression into structural tokens: parentheses,
+// the AND/OR keywords, and opaque atoms (identifiers, operators, literals). A
+// quoted string literal is a single atom, so parentheses, whitespace and the
+// AND/OR keywords inside it are not treated as structure. ok=false only for an
+// unterminated quote, which the caller maps to the no-drop path.
+func tokenizeSQL(expr string) ([]sqlToken, bool) {
+	var toks []sqlToken
 
-	var (
-		parts []string
-		cur   []string
-	)
+	i := 0
+	for i < len(expr) {
+		switch c := expr[i]; c {
+		case ' ', '\t', '\n', '\r':
+			i++
+		case '(':
+			toks = append(toks, sqlToken{kind: tokLParen})
+			i++
+		case ')':
+			toks = append(toks, sqlToken{kind: tokRParen})
+			i++
+		case '\'', '"':
+			tok, next, ok := scanSQLString(expr, i, c)
+			if !ok {
+				return nil, false // unterminated string literal
+			}
 
-	for _, f := range fields {
-		if strings.EqualFold(f, keyword) {
-			parts = append(parts, strings.Join(cur, " "))
-			cur = nil
-
-			continue
+			toks = append(toks, tok)
+			i = next
+		default:
+			word, next := scanSQLWord(expr, i)
+			toks = append(toks, classifyWord(word))
+			i = next
 		}
-
-		cur = append(cur, f)
 	}
 
-	parts = append(parts, strings.Join(cur, " "))
+	return toks, true
+}
 
-	return parts
+// scanSQLString reads a quoted string literal beginning at i (opened by quote),
+// returning it as one atom token and the index past its closing quote.
+// ok=false when the closing quote is missing.
+func scanSQLString(expr string, i int, quote byte) (tok sqlToken, next int, ok bool) {
+	rel := strings.IndexByte(expr[i+1:], quote)
+	if rel < 0 {
+		return sqlToken{}, 0, false
+	}
+
+	closing := i + 1 + rel
+
+	return sqlToken{kind: tokAtom, text: expr[i : closing+1]}, closing + 1, true
+}
+
+// scanSQLWord reads a maximal run of non-structural, non-space characters
+// starting at i, returning the word and the index past it.
+func scanSQLWord(expr string, i int) (word string, next int) {
+	j := i
+	for j < len(expr) {
+		switch expr[j] {
+		case ' ', '\t', '\n', '\r', '(', ')', '\'', '"':
+			return expr[i:j], j
+		}
+
+		j++
+	}
+
+	return expr[i:j], j
+}
+
+// classifyWord maps a bare word to an AND/OR keyword token or an opaque atom.
+func classifyWord(word string) sqlToken {
+	switch {
+	case strings.EqualFold(word, "AND"):
+		return sqlToken{kind: tokAnd}
+	case strings.EqualFold(word, "OR"):
+		return sqlToken{kind: tokOr}
+	default:
+		return sqlToken{kind: tokAtom, text: word}
+	}
+}
+
+// sqlParser is a recursive-descent parser/evaluator over a token stream.
+type sqlParser struct {
+	toks  []sqlToken
+	pos   int
+	props *messageProps
+}
+
+func (sp *sqlParser) peek() sqlTokenKind {
+	if sp.pos >= len(sp.toks) {
+		return tokEOF
+	}
+
+	return sp.toks[sp.pos].kind
+}
+
+// parseExpr parses an OR of AND-groups. It reports ok=false on any structural
+// error so the caller can apply the no-drop invariant.
+func (sp *sqlParser) parseExpr() (val, ok bool) {
+	return sp.parseBinary(tokOr, sp.parseAndGroup, func(a, b bool) bool { return a || b })
+}
+
+// parseAndGroup parses an AND of terms.
+func (sp *sqlParser) parseAndGroup() (val, ok bool) {
+	return sp.parseBinary(tokAnd, sp.parseTerm, func(a, b bool) bool { return a && b })
+}
+
+// parseBinary parses a left-associative chain of sub-productions joined by the
+// given keyword, folding results with combine.
+func (sp *sqlParser) parseBinary(kw sqlTokenKind, sub func() (bool, bool), combine func(a, b bool) bool) (val, ok bool) {
+	val, ok = sub()
+	if !ok {
+		return false, false
+	}
+
+	for sp.peek() == kw {
+		sp.pos++
+
+		rhs, rhsOK := sub()
+		if !rhsOK {
+			return false, false
+		}
+
+		val = combine(val, rhs)
+	}
+
+	return val, true
+}
+
+// parseTerm parses a parenthesized sub-expression or a single comparison clause
+// (a maximal run of atom tokens).
+func (sp *sqlParser) parseTerm() (val, ok bool) {
+	if sp.peek() == tokLParen {
+		sp.pos++
+
+		val, ok = sp.parseExpr()
+		if !ok || sp.peek() != tokRParen {
+			return false, false // empty/malformed group or unbalanced paren
+		}
+
+		sp.pos++
+
+		return val, true
+	}
+
+	if sp.peek() != tokAtom {
+		return false, false
+	}
+
+	var parts []string
+	for sp.peek() == tokAtom {
+		parts = append(parts, sp.toks[sp.pos].text)
+		sp.pos++
+	}
+
+	return evalSQLClause(strings.Join(parts, " "), sp.props), true
 }
 
 // SQL comparison operators the filter grammar understands.

--- a/server/azure/servicebus/filter_relational_test.go
+++ b/server/azure/servicebus/filter_relational_test.go
@@ -1,0 +1,35 @@
+package servicebus
+
+import "testing"
+
+// TestSQLRelationalStringOperands guards the message-loss regression where a
+// relational SqlFilter (<, >, <=, >=) on a string or date operand dropped every
+// message because the operands weren't both numeric. Real Service Bus evaluates
+// these lexically and delivers, so string operands must compare lexically while
+// numeric operands keep comparing numerically, and an unparseable clause must
+// still fall through to a match (the no-drop invariant).
+func TestSQLRelationalStringOperands(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+		p    *messageProps
+		want bool
+	}{
+		{"string greater matches", "sys.Label > 'm'", &messageProps{Label: "z"}, true},
+		{"string greater no match", "sys.Label > 'm'", &messageProps{Label: "a"}, false},
+		{"string ge boundary equal", "sys.Label >= 'a'", &messageProps{Label: "a"}, true},
+		{"string ge boundary below", "sys.Label >= 'b'", &messageProps{Label: "a"}, false},
+		{"date greater matches", "mydate > '2024-01-01'", &messageProps{Custom: map[string]string{"mydate": "2024-06-01"}}, true},
+		{"numeric greater matches", "x > 5", &messageProps{Custom: map[string]string{"x": "10"}}, true},
+		{"numeric greater no match", "x > 5", &messageProps{Custom: map[string]string{"x": "3"}}, false},
+		{"unparseable falls to match", "this is not sql", &messageProps{Label: "z"}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := evalSQLExpression(tc.expr, tc.p); got != tc.want {
+				t.Fatalf("evalSQLExpression(%q) = %v, want %v", tc.expr, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/azure/servicebus/pubsub_sdk_test.go
+++ b/server/azure/servicebus/pubsub_sdk_test.go
@@ -2,6 +2,7 @@ package servicebus_test
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -191,6 +192,60 @@ func TestSDKCorrelationFilterRule(t *testing.T) {
 		got.Properties.CorrelationFilter.CorrelationID == nil ||
 		*got.Properties.CorrelationFilter.CorrelationID != "urgent" {
 		t.Fatalf("rule Get correlationFilter = %v", got.Properties)
+	}
+}
+
+// TestSDKSubscriptionMessageCount is the regression for subscription runtime
+// counts stuck at 0: after two publishes to the topic, an ARM GET of the
+// subscription must report messageCount and activeMessageCount >= 2, mirroring
+// the queue runtime counts.
+func TestSDKSubscriptionMessageCount(t *testing.T) {
+	ts := pubsubServer(t)
+	cf := newClientFactory(t, ts)
+	ctx := context.Background()
+
+	createNS(t, cf.NewNamespacesClient(), rgName, nsName, nil)
+
+	if _, err := cf.NewTopicsClient().CreateOrUpdate(ctx, rgName, nsName, "orders",
+		armservicebus.SBTopic{}, nil); err != nil {
+		t.Fatalf("topic CreateOrUpdate: %v", err)
+	}
+
+	if _, err := cf.NewSubscriptionsClient().CreateOrUpdate(ctx, rgName, nsName, "orders", "all",
+		armservicebus.SBSubscription{}, nil); err != nil {
+		t.Fatalf("subscription CreateOrUpdate: %v", err)
+	}
+
+	// Publish two messages to the topic over the raw data plane (using the TLS
+	// server's own client so the self-signed cert is trusted).
+	for i := 0; i < 2; i++ {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/"+nsName+"/orders/messages",
+			strings.NewReader("m"))
+
+		resp, err := ts.Client().Do(req)
+		if err != nil {
+			t.Fatalf("publish %d: %v", i, err)
+		}
+
+		_ = resp.Body.Close()
+
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("publish %d = %d, want 201", i, resp.StatusCode)
+		}
+	}
+
+	got, err := cf.NewSubscriptionsClient().Get(ctx, rgName, nsName, "orders", "all", nil)
+	if err != nil {
+		t.Fatalf("subscription Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.MessageCount == nil || *got.Properties.MessageCount < 2 {
+		t.Fatalf("messageCount = %v, want >= 2", got.Properties.MessageCount)
+	}
+
+	cd := got.Properties.CountDetails
+	if cd == nil || cd.ActiveMessageCount == nil || *cd.ActiveMessageCount < 2 {
+		t.Fatalf("activeMessageCount = %v, want >= 2", cd)
 	}
 }
 

--- a/server/azure/servicebus/queue.go
+++ b/server/azure/servicebus/queue.go
@@ -92,9 +92,14 @@ func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request, sp sbPath,
 		rec = &queueRecord{Name: name, DriverURL: url, DLQURL: dlqURL, CreatedAt: now}
 		ns.Queues[name] = rec
 	} else if rec.DriverURL != "" {
-		// PUT is create-or-update: honor a LockDuration change on an existing
-		// queue's peek-lock visibility window too.
-		_ = h.mq.SetQueueAttributes(r.Context(), rec.DriverURL, map[string]int{"VisibilityTimeout": lockSeconds})
+		// PUT is create-or-update: propagate a LockDuration, MaxDeliveryCount or
+		// deadLetteringOnMessageExpiration change onto the backing store so, e.g.,
+		// lowering maxDeliveryCount dead-letters at the new threshold.
+		_ = h.mq.SetQueueAttributes(r.Context(), rec.DriverURL, map[string]int{
+			"VisibilityTimeout":      lockSeconds,
+			"MaxDeliveryCount":       effectiveMaxDeliveryCount(&req.Properties),
+			"DeadLetterOnExpiration": boolToInt(req.Properties.DeadLetteringOnExpiration),
+		})
 	}
 
 	rec.Props = buildQueueProps(&req.Properties, rec.CreatedAt, now)

--- a/server/azure/servicebus/subscription.go
+++ b/server/azure/servicebus/subscription.go
@@ -1,6 +1,7 @@
 package servicebus
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -29,7 +30,7 @@ func (h *Handler) serveSubCollection(w http.ResponseWriter, r *http.Request, sp 
 
 	resources := make([]any, 0, len(t.Subs))
 	for _, n := range sortedKeys(t.Subs) {
-		resources = append(resources, toSubResource(sp, topic, t.Subs[n]))
+		resources = append(resources, h.toSubResource(sp, topic, t.Subs[n]))
 	}
 
 	h.mu.RUnlock()
@@ -83,15 +84,20 @@ func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, sp 
 		rec.Rules[defaultRuleName] = defaultRule()
 		t.Subs[name] = rec
 	} else if rec.DriverURL != "" {
-		// PUT is create-or-update: honor a LockDuration change on an existing
-		// subscription's peek-lock visibility window too.
-		_ = h.mq.SetQueueAttributes(r.Context(), rec.DriverURL, map[string]int{"VisibilityTimeout": lockSeconds})
+		// PUT is create-or-update: propagate a LockDuration, MaxDeliveryCount or
+		// deadLetteringOnMessageExpiration change onto the backing store so, e.g.,
+		// lowering maxDeliveryCount dead-letters at the new threshold.
+		_ = h.mq.SetQueueAttributes(r.Context(), rec.DriverURL, map[string]int{
+			"VisibilityTimeout":      lockSeconds,
+			"MaxDeliveryCount":       effectiveSubMaxDeliveryCount(&req.Properties),
+			"DeadLetterOnExpiration": boolToInt(req.Properties.DeadLetteringOnExpiration),
+		})
 	}
 
 	rec.Props = buildSubProps(&req.Properties, rec.CreatedAt, now)
 	rec.UpdatedAt = now
 
-	resource := toSubResource(sp, topic, rec)
+	resource := h.toSubResource(sp, topic, rec)
 	h.mu.Unlock()
 
 	azurearm.WriteJSON(w, http.StatusOK, resource)
@@ -107,7 +113,7 @@ func (h *Handler) getSubscription(w http.ResponseWriter, sp sbPath, topic, name 
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toSubResource(sp, topic, rec))
+	azurearm.WriteJSON(w, http.StatusOK, h.toSubResource(sp, topic, rec))
 }
 
 func (h *Handler) deleteSubscription(w http.ResponseWriter, sp sbPath, topic, name string) {
@@ -232,14 +238,49 @@ func buildSubProps(in *subscriptionProperties, created, updated time.Time) subsc
 	return out
 }
 
-func toSubResource(sp sbPath, topic string, rec *subscriptionRecord) subscriptionResource {
+// toSubResource renders a subscription's ARM shape, refreshing its live message
+// counts from the backing stores (mirroring toQueueResource): activeMessageCount
+// from the subscription store and deadLetterMessageCount from its paired
+// $DeadLetterQueue, with messageCount as their sum.
+func (h *Handler) toSubResource(sp sbPath, topic string, rec *subscriptionRecord) subscriptionResource {
+	props := rec.Props
+
+	active := h.approxCount(rec.DriverURL)
+	dead := h.approxCount(rec.DLQURL)
+
+	props.MessageCount = active + dead
+	props.CountDetails = &countDetails{ActiveMessageCount: active, DeadLetterMessageCount: dead}
+
 	return subscriptionResource{
 		ID: azurearm.BuildResourceID(sp.sub, sp.rg, providerName, resourceType, sp.namespace) +
 			"/topics/" + topic + "/subscriptions/" + rec.Name,
 		Name:       rec.Name,
 		Type:       providerName + "/Namespaces/Topics/Subscriptions",
-		Properties: rec.Props,
+		Properties: props,
 	}
+}
+
+// approxCount reports the approximate visible-message count of a backing store,
+// or 0 when the URL is empty or the store is unavailable.
+func (h *Handler) approxCount(url string) int64 {
+	if url == "" {
+		return 0
+	}
+
+	if info, err := h.mq.GetQueueInfo(context.Background(), url); err == nil && info != nil {
+		return int64(info.ApproxMessageCount)
+	}
+
+	return 0
+}
+
+// boolToInt encodes a bool as 0/1 for the int-only SetQueueAttributes map.
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+
+	return 0
 }
 
 func writeTopicNotFound(w http.ResponseWriter, name string) {


### PR DESCRIPTION
Confirming re-audit residue of Azure Service Bus subscription filters/counts. Fixes a HIGH message-loss bug plus routing, runtime-count and update-propagation gaps. First-round fixes (#602/#621/#629: DLQ wiring, system props, TTL-from-enqueue, scheduled, LockDuration peek-lock, basic SqlFilter/CorrelationFilter, namespace isolation) are preserved.

## Fixes

- **[HIGH — message loss] SqlFilter using OR silently dropped matching messages.** `sys.Label = 'a' OR sys.Label = 'b'` was parsed as a single malformed equality that always evaluated false, so a matching message got 204 No Content and was lost. The evaluator is now OR-of-AND-of-comparison-clauses, and the no-drop invariant is hardened: any clause with an unrecognized operator / unparseable syntax / unknown `sys.*` identifier falls back to match=true rather than dropping.
- **[MED — wrong routing] Relational and custom-property SqlFilters over-delivered.** Added the `>, <, >=, <=, !=, <>` operators and parsing of custom application properties (individual HTTP headers per the Service Bus REST protocol, reserved/`null` headers excluded) into the evaluated property set. `priority > 5` and `myprop = 'x'` now route only matching messages. (LIKE/IN/EXISTS/arithmetic remain deferred to the no-drop path.)
- **[LOW] CorrelationFilter user-defined `Properties` were ignored.** They are now matched against the message's custom application properties (case-insensitive key lookup, case-sensitive value compare).
- **[MED] Subscription CountDetails / messageCount always 0.** `toSubResource` now queries the backing store (active) and the paired `$DeadLetterQueue` (dead-letter), mirroring `toQueueResource`. ARM GET subscription reports `messageCount` / `activeMessageCount`.
- **[LOW-MED] PUT update didn't propagate maxDeliveryCount / deadLetteringOnMessageExpiration.** The create-or-update branch now propagates these to the backing store (`applyQueueAttributes` extended), so lowering `maxDeliveryCount` dead-letters at the new threshold.

Deferred (noted, out of scope for this PR): SQL `LIKE`/`IN`/`EXISTS`/`IS NULL`/arithmetic/parentheses; `forwardTo` / `forwardDeadLetteredMessagesTo` enforcement; AMQP-only session receive.

## Tests (real armservicebus SDK + raw-HTTP data plane)

OR SqlFilter delivers matches (not lost); numeric `priority > 5` routes only matching; custom-property `myprop='x'` routes only matching; CorrelationFilter `Properties{region:eu}` routes only matching; ARM GET subscription after 2 publishes reports counts >= 2; lowering maxDeliveryCount via PUT dead-letters at the new threshold. First-round tests kept green (DLQ, LockDuration peek-lock, scheduled/TTL, filter basics, namespace isolation), including -race.
