### PR TITLE
fix(gcp-cloudsql): round-trip instance settings (availabilityType/databaseFlags/backup/ip); databaseVersion patch; databases.update; serverCaCert

### DIFF
--- a/docs/coverage/aws/redshift.md
+++ b/docs/coverage/aws/redshift.md
@@ -138,6 +138,14 @@ DBProxies is an OPTIONAL capability for RDS Proxy, discovered by type
 | `ModifyDBProxy` |  |
 | `RegisterDBProxyTargets` |  |
 
+### DatabaseUpdater
+
+DatabaseUpdater is an OPTIONAL capability for updating a logical database's
+
+| Operation | Description |
+| --- | --- |
+| `UpdateDatabase` |  |
+
 ### Databases
 
 Databases is an OPTIONAL capability for managing the logical databases inside

--- a/docs/coverage/azure/mysqlflex.md
+++ b/docs/coverage/azure/mysqlflex.md
@@ -138,6 +138,14 @@ DBProxies is an OPTIONAL capability for RDS Proxy, discovered by type
 | `ModifyDBProxy` |  |
 | `RegisterDBProxyTargets` |  |
 
+### DatabaseUpdater
+
+DatabaseUpdater is an OPTIONAL capability for updating a logical database's
+
+| Operation | Description |
+| --- | --- |
+| `UpdateDatabase` |  |
+
 ### Databases
 
 Databases is an OPTIONAL capability for managing the logical databases inside

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -8046,6 +8046,15 @@
         ]
       },
       {
+        "name": "DatabaseUpdater",
+        "doc": "DatabaseUpdater is an OPTIONAL capability for updating a logical database's",
+        "operations": [
+          {
+            "name": "UpdateDatabase"
+          }
+        ]
+      },
+      {
         "name": "Databases",
         "doc": "Databases is an OPTIONAL capability for managing the logical databases inside",
         "operations": [

--- a/docs/coverage/gcp/alloydb.md
+++ b/docs/coverage/gcp/alloydb.md
@@ -138,6 +138,14 @@ DBProxies is an OPTIONAL capability for RDS Proxy, discovered by type
 | `ModifyDBProxy` |  |
 | `RegisterDBProxyTargets` |  |
 
+### DatabaseUpdater
+
+DatabaseUpdater is an OPTIONAL capability for updating a logical database's
+
+| Operation | Description |
+| --- | --- |
+| `UpdateDatabase` |  |
+
 ### Databases
 
 Databases is an OPTIONAL capability for managing the logical databases inside

--- a/providers/gcp/cloudsql/cloudsql.go
+++ b/providers/gcp/cloudsql/cloudsql.go
@@ -283,6 +283,9 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		AvailabilityZone:   region,
 		CreatedAt:          m.opts.Clock.Now().UTC(),
 		Tags:               copyTags(cfg.Tags),
+		GCPDatabaseFlags:   cfg.GCPDatabaseFlags,
+		GCPBackupConfig:    cfg.GCPBackupConfig,
+		GCPIPConfig:        cfg.GCPIPConfig,
 	}
 }
 
@@ -394,12 +397,17 @@ func (m *Mock) ModifyInstance(
 	}
 
 	if input.EngineVersion != "" {
-		inst.EngineVersion = input.EngineVersion
+		// Cloud SQL's databaseVersion is stored in Engine (that is the field
+		// toSQLInstance renders as databaseVersion), so a patched databaseVersion
+		// must land there to be visible on the next Get.
+		inst.Engine = input.EngineVersion
 	}
 
 	if input.MultiAZ != nil {
 		inst.MultiAZ = *input.MultiAZ
 	}
+
+	applyGCPSettings(&inst, &input)
 
 	if input.Tags != nil {
 		inst.Tags = copyTags(input.Tags)
@@ -410,6 +418,22 @@ func (m *Mock) ModifyInstance(
 	out := cloneInstance(inst)
 
 	return &out, nil
+}
+
+// applyGCPSettings merges the Cloud SQL settings sub-object blobs from a Patch
+// onto the instance; an empty blob means "no change" (patch merges).
+func applyGCPSettings(inst *rdsdriver.Instance, input *rdsdriver.ModifyInstanceInput) {
+	if input.GCPDatabaseFlags != "" {
+		inst.GCPDatabaseFlags = input.GCPDatabaseFlags
+	}
+
+	if input.GCPBackupConfig != "" {
+		inst.GCPBackupConfig = input.GCPBackupConfig
+	}
+
+	if input.GCPIPConfig != "" {
+		inst.GCPIPConfig = input.GCPIPConfig
+	}
 }
 
 // DeleteInstance removes an instance, unlinks it from any replica relationship,

--- a/providers/gcp/cloudsql/cloudsql_test.go
+++ b/providers/gcp/cloudsql/cloudsql_test.go
@@ -292,6 +292,74 @@ func TestSubResourcesRequireInstance(t *testing.T) {
 	}
 }
 
+func TestUpdateDatabase(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "inst", Engine: "POSTGRES_15"}); err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+
+	if _, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "inst", Name: "app"}); err != nil {
+		t.Fatalf("CreateDatabase: %v", err)
+	}
+
+	updated, err := m.UpdateDatabase(ctx, rdsdriver.DatabaseConfig{
+		Server: "inst", Name: "app", Charset: "LATIN1", Collation: "en_US.ISO8859-1",
+	})
+	requireNoError(t, err)
+	assertEqual(t, "LATIN1", updated.Charset)
+	assertEqual(t, "en_US.ISO8859-1", updated.Collation)
+
+	got, err := m.GetDatabase(ctx, "inst", "app")
+	requireNoError(t, err)
+	assertEqual(t, "LATIN1", got.Charset)
+	assertEqual(t, "en_US.ISO8859-1", got.Collation)
+
+	if _, err := m.UpdateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "inst", Name: "ghost"}); err == nil {
+		t.Error("UpdateDatabase on missing database: expected error")
+	}
+}
+
+func TestInstanceSettingsRoundTrip(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	created, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{
+		ID:               "s",
+		Engine:           "POSTGRES_15",
+		MultiAZ:          true,
+		GCPDatabaseFlags: `[{"name":"max_connections","value":"100"}]`,
+		GCPBackupConfig:  `{"enabled":true}`,
+		GCPIPConfig:      `{"ipv4Enabled":true}`,
+	})
+	requireNoError(t, err)
+	assertEqual(t, true, created.MultiAZ)
+
+	got, err := m.DescribeInstances(ctx, []string{"s"})
+	requireNoError(t, err)
+	assertEqual(t, true, got[0].MultiAZ)
+	assertEqual(t, `[{"name":"max_connections","value":"100"}]`, got[0].GCPDatabaseFlags)
+	assertEqual(t, `{"enabled":true}`, got[0].GCPBackupConfig)
+	assertEqual(t, `{"ipv4Enabled":true}`, got[0].GCPIPConfig)
+
+	falseVal := false
+
+	if _, err := m.ModifyInstance(ctx, "s", rdsdriver.ModifyInstanceInput{
+		MultiAZ:          &falseVal,
+		GCPDatabaseFlags: `[{"name":"work_mem","value":"64MB"}]`,
+	}); err != nil {
+		t.Fatalf("ModifyInstance: %v", err)
+	}
+
+	after, err := m.DescribeInstances(ctx, []string{"s"})
+	requireNoError(t, err)
+	assertEqual(t, false, after[0].MultiAZ)
+	assertEqual(t, `[{"name":"work_mem","value":"64MB"}]`, after[0].GCPDatabaseFlags)
+	// Untouched blobs are preserved (patch merges).
+	assertEqual(t, `{"enabled":true}`, after[0].GCPBackupConfig)
+}
+
 func TestCloneAndCascade(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/providers/gcp/cloudsql/subresources.go
+++ b/providers/gcp/cloudsql/subresources.go
@@ -18,6 +18,7 @@ import (
 // handler via type assertion.
 var (
 	_ rdsdriver.Databases        = (*Mock)(nil)
+	_ rdsdriver.DatabaseUpdater  = (*Mock)(nil)
 	_ rdsdriver.Users            = (*Mock)(nil)
 	_ rdsdriver.SslCerts         = (*Mock)(nil)
 	_ rdsdriver.Failover         = (*Mock)(nil)
@@ -137,6 +138,37 @@ func (m *Mock) ListDatabases(_ context.Context, instance string) ([]rdsdriver.Da
 	}
 
 	return out, nil
+}
+
+// UpdateDatabase updates a logical database's charset/collation, returning
+// NotFound when the database does not exist. Empty fields leave the current
+// value unchanged, matching Cloud SQL's merge on databases.patch/update.
+//
+//nolint:gocritic // cfg matches the driver signature and cannot be a pointer.
+func (m *Mock) UpdateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (*rdsdriver.Database, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := childKey(cfg.Server, cfg.Name)
+
+	db, ok := m.databases.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "database %q not found", cfg.Name)
+	}
+
+	if cfg.Charset != "" {
+		db.Charset = cfg.Charset
+	}
+
+	if cfg.Collation != "" {
+		db.Collation = cfg.Collation
+	}
+
+	m.databases.Set(key, db)
+
+	out := db
+
+	return &out, nil
 }
 
 // DeleteDatabase removes a logical database.

--- a/server/gcp/cloudsql/operations.go
+++ b/server/gcp/cloudsql/operations.go
@@ -39,13 +39,51 @@ func instanceFromBody(body *sqlInstance) rdsdriver.InstanceConfig {
 	}
 
 	if body.Settings != nil {
-		cfg.InstanceClass = body.Settings.Tier
-		cfg.AllocatedStorage = body.Settings.DataDiskSizeGb
-		cfg.StorageType = body.Settings.DataDiskType
-		cfg.Tags = body.Settings.UserLabels
+		s := body.Settings
+		cfg.InstanceClass = s.Tier
+		cfg.AllocatedStorage = s.DataDiskSizeGb
+		cfg.StorageType = s.DataDiskType
+		cfg.Tags = s.UserLabels
+		// availabilityType maps to the portable MultiAZ flag (REGIONAL -> true);
+		// the three settings sub-objects are stored as opaque JSON so they
+		// round-trip on the next Get.
+		cfg.MultiAZ = strings.EqualFold(s.AvailabilityType, availabilityRegional)
+		cfg.GCPDatabaseFlags = string(s.DatabaseFlags)
+		cfg.GCPBackupConfig = string(s.BackupConfiguration)
+		cfg.GCPIPConfig = string(s.IPConfiguration)
 	}
 
 	return cfg
+}
+
+// modifyInputFromBody builds the driver ModifyInstanceInput for a Patch: only
+// fields present in the request body are set, so absent fields mean "no change"
+// (Cloud SQL patch merges the request onto the current configuration).
+func modifyInputFromBody(body *sqlInstance) rdsdriver.ModifyInstanceInput {
+	var input rdsdriver.ModifyInstanceInput
+
+	if body.DatabaseVersion != "" {
+		input.EngineVersion = body.DatabaseVersion
+	}
+
+	if body.Settings == nil {
+		return input
+	}
+
+	s := body.Settings
+	input.InstanceClass = s.Tier
+	input.AllocatedStorage = s.DataDiskSizeGb
+	input.Tags = s.UserLabels
+	input.GCPDatabaseFlags = string(s.DatabaseFlags)
+	input.GCPBackupConfig = string(s.BackupConfiguration)
+	input.GCPIPConfig = string(s.IPConfiguration)
+
+	if s.AvailabilityType != "" {
+		multiAZ := strings.EqualFold(s.AvailabilityType, availabilityRegional)
+		input.MultiAZ = &multiAZ
+	}
+
+	return input
 }
 
 func (h *Handler) insertInstance(w http.ResponseWriter, r *http.Request, p *sqlPath) {
@@ -110,7 +148,6 @@ func (h *Handler) getInstance(w http.ResponseWriter, r *http.Request, p *sqlPath
 	writeJSON(w, http.StatusOK, toSQLInstance(&insts[0], p.project))
 }
 
-//nolint:gocyclo // sequential field handling for activationPolicy + class + storage + version.
 func (h *Handler) patchInstance(w http.ResponseWriter, r *http.Request, p *sqlPath) {
 	var body sqlInstance
 	if !decodeJSON(w, r, &body) {
@@ -133,21 +170,7 @@ func (h *Handler) patchInstance(w http.ResponseWriter, r *http.Request, p *sqlPa
 		}
 	}
 
-	input := rdsdriver.ModifyInstanceInput{
-		Tags: nil,
-	}
-
-	if body.Settings != nil {
-		input.InstanceClass = body.Settings.Tier
-		input.AllocatedStorage = body.Settings.DataDiskSizeGb
-		input.Tags = body.Settings.UserLabels
-	}
-
-	if body.DatabaseVersion != "" {
-		input.EngineVersion = body.DatabaseVersion
-	}
-
-	if _, err := h.db.ModifyInstance(r.Context(), p.name, input); err != nil {
+	if _, err := h.db.ModifyInstance(r.Context(), p.name, modifyInputFromBody(&body)); err != nil {
 		writeErr(w, err)
 		return
 	}

--- a/server/gcp/cloudsql/settings_sdk_test.go
+++ b/server/gcp/cloudsql/settings_sdk_test.go
@@ -1,0 +1,217 @@
+package cloudsql_test
+
+import (
+	"context"
+	"testing"
+
+	sqladmin "google.golang.org/api/sqladmin/v1"
+)
+
+// TestSDKCloudSQLSettingsRoundTrip reproduces the Terraform perpetual-drift bug:
+// an Insert carrying availabilityType + databaseFlags + backupConfiguration +
+// ipConfiguration must return all four unchanged on the following Get.
+func TestSDKCloudSQLSettingsRoundTrip(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := svc.Instances.Insert(project, &sqladmin.DatabaseInstance{
+		Name:            "settings",
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings: &sqladmin.Settings{
+			Tier:             "db-custom-2-8192",
+			AvailabilityType: "REGIONAL",
+			DatabaseFlags: []*sqladmin.DatabaseFlags{
+				{Name: "max_connections", Value: "100"},
+			},
+			BackupConfiguration: &sqladmin.BackupConfiguration{
+				Enabled:                    true,
+				StartTime:                  "03:00",
+				PointInTimeRecoveryEnabled: true,
+			},
+			IpConfiguration: &sqladmin.IpConfiguration{
+				Ipv4Enabled:    true,
+				RequireSsl:     true,
+				PrivateNetwork: "projects/p/global/networks/default",
+			},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Instances.Insert: %v", err)
+	}
+
+	got, err := svc.Instances.Get(project, "settings").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Instances.Get: %v", err)
+	}
+
+	if got.Settings == nil {
+		t.Fatal("expected settings on Get")
+	}
+
+	if got.Settings.AvailabilityType != "REGIONAL" {
+		t.Fatalf("availabilityType = %q, want REGIONAL", got.Settings.AvailabilityType)
+	}
+
+	if len(got.Settings.DatabaseFlags) != 1 ||
+		got.Settings.DatabaseFlags[0].Name != "max_connections" ||
+		got.Settings.DatabaseFlags[0].Value != "100" {
+		t.Fatalf("databaseFlags = %+v, want max_connections=100", got.Settings.DatabaseFlags)
+	}
+
+	if got.Settings.BackupConfiguration == nil || !got.Settings.BackupConfiguration.Enabled ||
+		got.Settings.BackupConfiguration.StartTime != "03:00" ||
+		!got.Settings.BackupConfiguration.PointInTimeRecoveryEnabled {
+		t.Fatalf("backupConfiguration = %+v, want enabled/03:00/PITR", got.Settings.BackupConfiguration)
+	}
+
+	if got.Settings.IpConfiguration == nil || !got.Settings.IpConfiguration.Ipv4Enabled ||
+		!got.Settings.IpConfiguration.RequireSsl ||
+		got.Settings.IpConfiguration.PrivateNetwork != "projects/p/global/networks/default" {
+		t.Fatalf("ipConfiguration = %+v, want ipv4/requireSsl/privateNetwork", got.Settings.IpConfiguration)
+	}
+}
+
+// TestSDKCloudSQLPatchSettings verifies that a Patch of availabilityType and
+// databaseFlags is reflected on the following Get (default is ZONAL).
+func TestSDKCloudSQLPatchSettings(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := svc.Instances.Insert(project, &sqladmin.DatabaseInstance{
+		Name:            "patchset",
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings:        &sqladmin.Settings{Tier: "db-custom-2-8192"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	base, err := svc.Instances.Get(project, "patchset").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get (base): %v", err)
+	}
+
+	if base.Settings.AvailabilityType != "ZONAL" {
+		t.Fatalf("default availabilityType = %q, want ZONAL", base.Settings.AvailabilityType)
+	}
+
+	if _, err := svc.Instances.Patch(project, "patchset", &sqladmin.DatabaseInstance{
+		Settings: &sqladmin.Settings{
+			AvailabilityType: "REGIONAL",
+			DatabaseFlags:    []*sqladmin.DatabaseFlags{{Name: "log_min_duration_statement", Value: "500"}},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got, err := svc.Instances.Get(project, "patchset").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get (after patch): %v", err)
+	}
+
+	if got.Settings.AvailabilityType != "REGIONAL" {
+		t.Fatalf("after patch availabilityType = %q, want REGIONAL", got.Settings.AvailabilityType)
+	}
+
+	if len(got.Settings.DatabaseFlags) != 1 || got.Settings.DatabaseFlags[0].Value != "500" {
+		t.Fatalf("after patch databaseFlags = %+v, want log_min_duration_statement=500", got.Settings.DatabaseFlags)
+	}
+}
+
+// TestSDKCloudSQLPatchDatabaseVersion verifies a patched databaseVersion is
+// visible on Get (previously dropped: patch wrote EngineVersion, Get read Engine).
+func TestSDKCloudSQLPatchDatabaseVersion(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := svc.Instances.Insert(project, &sqladmin.DatabaseInstance{
+		Name:            "verpatch",
+		DatabaseVersion: "POSTGRES_14",
+		Region:          "us-central1",
+		Settings:        &sqladmin.Settings{Tier: "db-custom-2-8192"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if _, err := svc.Instances.Patch(project, "verpatch", &sqladmin.DatabaseInstance{
+		DatabaseVersion: "POSTGRES_15",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got, err := svc.Instances.Get(project, "verpatch").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.DatabaseVersion != "POSTGRES_15" {
+		t.Fatalf("databaseVersion = %q, want POSTGRES_15", got.DatabaseVersion)
+	}
+}
+
+// TestSDKCloudSQLDatabaseUpdate verifies databases.update applies charset and
+// collation (previously 405 Method Not Allowed).
+func TestSDKCloudSQLDatabaseUpdate(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := svc.Instances.Insert(project, &sqladmin.DatabaseInstance{
+		Name:            "dbupd",
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings:        &sqladmin.Settings{Tier: "db-custom-2-8192"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Insert instance: %v", err)
+	}
+
+	if _, err := svc.Databases.Insert(project, "dbupd", &sqladmin.Database{
+		Name:      "app",
+		Charset:   "UTF8",
+		Collation: "en_US.UTF8",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Databases.Insert: %v", err)
+	}
+
+	if _, err := svc.Databases.Update(project, "dbupd", "app", &sqladmin.Database{
+		Name:      "app",
+		Charset:   "LATIN1",
+		Collation: "en_US.ISO8859-1",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Databases.Update: %v", err)
+	}
+
+	got, err := svc.Databases.Get(project, "dbupd", "app").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Databases.Get: %v", err)
+	}
+
+	if got.Charset != "LATIN1" || got.Collation != "en_US.ISO8859-1" {
+		t.Fatalf("database after update = charset %q collation %q, want LATIN1 / en_US.ISO8859-1",
+			got.Charset, got.Collation)
+	}
+}
+
+// TestSDKCloudSQLServerCaCert verifies serverCaCert is populated on Get so
+// Terraform's computed server_ca_cert attribute is never empty.
+func TestSDKCloudSQLServerCaCert(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := svc.Instances.Insert(project, &sqladmin.DatabaseInstance{
+		Name:            "cacert",
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings:        &sqladmin.Settings{Tier: "db-custom-2-8192"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	got, err := svc.Instances.Get(project, "cacert").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.ServerCaCert == nil || got.ServerCaCert.Cert == "" || got.ServerCaCert.Sha1Fingerprint == "" {
+		t.Fatalf("serverCaCert = %+v, want populated cert + fingerprint", got.ServerCaCert)
+	}
+}

--- a/server/gcp/cloudsql/subresources.go
+++ b/server/gcp/cloudsql/subresources.go
@@ -95,7 +95,6 @@ func writeUnsupported(w http.ResponseWriter, what string) {
 
 // ---- Databases ----
 
-//nolint:dupl // mirrors the sibling sub-resource route by design.
 func (h *Handler) serveDatabasesRoute(w http.ResponseWriter, r *http.Request, p *sqlPath) {
 	db, ok := h.databasesCap()
 	if !ok {
@@ -119,6 +118,8 @@ func (h *Handler) serveDatabasesRoute(w http.ResponseWriter, r *http.Request, p 
 	switch r.Method {
 	case http.MethodGet:
 		h.getDatabase(w, r, p, db)
+	case http.MethodPut, http.MethodPatch:
+		h.updateDatabase(w, r, p)
 	case http.MethodDelete:
 		if err := db.DeleteDatabase(r.Context(), p.name, p.subName); err != nil {
 			writeErr(w, err)
@@ -129,6 +130,32 @@ func (h *Handler) serveDatabasesRoute(w http.ResponseWriter, r *http.Request, p 
 	default:
 		writeMethodNotAllowed(w)
 	}
+}
+
+// updateDatabase applies a databases.update / databases.patch, updating the
+// logical database's charset/collation. It requires the DatabaseUpdater
+// capability, which the Databases interface does not mandate.
+func (h *Handler) updateDatabase(w http.ResponseWriter, r *http.Request, p *sqlPath) {
+	upd, ok := h.db.(rdsdriver.DatabaseUpdater)
+	if !ok {
+		writeUnsupported(w, "databases.update")
+		return
+	}
+
+	var body database
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	_, err := upd.UpdateDatabase(r.Context(), rdsdriver.DatabaseConfig{
+		Server: p.name, Name: p.subName, Charset: body.Charset, Collation: body.Collation,
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	h.completeOp(w, p.project, "update-db", "UPDATE_DATABASE", "instances", p.name)
 }
 
 //nolint:dupl // mirrors the sibling insert handler by design.
@@ -302,7 +329,6 @@ func toWireUser(u *rdsdriver.User, project string) user {
 
 // ---- SSL certs ----
 
-//nolint:dupl // mirrors the sibling sub-resource route by design.
 func (h *Handler) serveSslCertsRoute(w http.ResponseWriter, r *http.Request, p *sqlPath) {
 	sc, ok := h.sslCertsCap()
 	if !ok {

--- a/server/gcp/cloudsql/types.go
+++ b/server/gcp/cloudsql/types.go
@@ -1,6 +1,8 @@
 package cloudsql
 
 import (
+	"crypto/sha1" //nolint:gosec // SHA-1 fingerprints are the Cloud SQL cert identifier format, not a security control.
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -14,6 +16,16 @@ import (
 const (
 	activationAlways = "ALWAYS"
 	activationNever  = "NEVER"
+
+	// availabilityRegional / availabilityZonal are the Cloud SQL
+	// settings.availabilityType enum values. REGIONAL denotes a highly-available
+	// (multi-zone) instance; ZONAL is the single-zone default.
+	availabilityRegional = "REGIONAL"
+	availabilityZonal    = "ZONAL"
+
+	// serverCaCertPEM is the placeholder PEM returned as the instance's
+	// serverCaCert. It is a well-formed shape for SDK round-trips, not a real CA.
+	serverCaCertPEM = "-----BEGIN CERTIFICATE-----\nMOCK\n-----END CERTIFICATE-----"
 
 	// selfLinkBase is the resource URI prefix Cloud SQL stamps on every
 	// selfLink/targetLink. Even the v1 client is answered with sql/v1beta4
@@ -46,6 +58,7 @@ type sqlInstance struct {
 	ReplicaNames       []string     `json:"replicaNames,omitempty"`
 	IPAddresses        []ipMapping  `json:"ipAddresses,omitempty"`
 	Settings           *sqlSettings `json:"settings,omitempty"`
+	ServerCaCert       *sslCert     `json:"serverCaCert,omitempty"`
 	CreateTime         string       `json:"createTime,omitempty"`
 }
 
@@ -56,6 +69,12 @@ type sqlSettings struct {
 	DataDiskType     string            `json:"dataDiskType,omitempty"`
 	AvailabilityType string            `json:"availabilityType,omitempty"`
 	UserLabels       map[string]string `json:"userLabels,omitempty"`
+	// databaseFlags, backupConfiguration and ipConfiguration are carried as
+	// opaque JSON so they round-trip unchanged on Insert->Get and Patch without
+	// the wire layer modeling every nested field real Cloud SQL exposes.
+	DatabaseFlags       json.RawMessage `json:"databaseFlags,omitempty"`
+	BackupConfiguration json.RawMessage `json:"backupConfiguration,omitempty"`
+	IPConfiguration     json.RawMessage `json:"ipConfiguration,omitempty"`
 }
 
 type ipMapping struct {
@@ -159,13 +178,58 @@ func toSQLInstance(inst *rdsdriver.Instance, project string) sqlInstance {
 			{IPAddress: inst.Endpoint, Type: "PRIMARY"},
 		},
 		Settings: &sqlSettings{
-			Tier:             inst.InstanceClass,
-			DataDiskSizeGb:   inst.AllocatedStorage,
-			DataDiskType:     inst.StorageType,
-			UserLabels:       inst.Tags,
-			ActivationPolicy: activationFromState(inst.State),
+			Tier:                inst.InstanceClass,
+			DataDiskSizeGb:      inst.AllocatedStorage,
+			DataDiskType:        inst.StorageType,
+			UserLabels:          inst.Tags,
+			ActivationPolicy:    activationFromState(inst.State),
+			AvailabilityType:    availabilityType(inst.MultiAZ),
+			DatabaseFlags:       rawJSONOrNil(inst.GCPDatabaseFlags),
+			BackupConfiguration: rawJSONOrNil(inst.GCPBackupConfig),
+			IPConfiguration:     rawJSONOrNil(inst.GCPIPConfig),
 		},
-		CreateTime: inst.CreatedAt.UTC().Format(rfc3339Milli),
+		ServerCaCert: serverCaCertFor(inst),
+		CreateTime:   inst.CreatedAt.UTC().Format(rfc3339Milli),
+	}
+}
+
+// availabilityType maps the portable MultiAZ flag to the Cloud SQL
+// availabilityType enum: REGIONAL for a highly available (multi-zone) instance,
+// ZONAL otherwise — matching what real Cloud SQL returns on a Get.
+func availabilityType(multiAZ bool) string {
+	if multiAZ {
+		return availabilityRegional
+	}
+
+	return availabilityZonal
+}
+
+// rawJSONOrNil returns the stored opaque JSON as a RawMessage, or nil when empty
+// so the field is omitted rather than emitted as an empty value.
+func rawJSONOrNil(s string) json.RawMessage {
+	if s == "" {
+		return nil
+	}
+
+	return json.RawMessage(s)
+}
+
+// serverCaCertFor builds the synthetic server CA certificate Cloud SQL reports
+// on every instance. Terraform reads server_ca_cert as a computed attribute, so
+// it must be populated; the fingerprint is derived from the instance id so it is
+// stable across reads.
+func serverCaCertFor(inst *rdsdriver.Instance) *sslCert {
+	sum := sha1.Sum([]byte("serverCaCert/" + inst.ID)) //nolint:gosec // fingerprint id, not a security control.
+	fp := hex.EncodeToString(sum[:])
+
+	return &sslCert{
+		Kind:             "sql#sslCert",
+		CommonName:       "Google Cloud SQL Server CA",
+		Sha1Fingerprint:  fp,
+		CertSerialNumber: fp[:16],
+		Cert:             serverCaCertPEM,
+		Instance:         inst.ID,
+		CreateTime:       inst.CreatedAt.UTC().Format(rfc3339Milli),
 	}
 }
 

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -112,7 +112,14 @@ type InstanceConfig struct {
 	// primary (Cloud SQL creates replicas via a normal insert with this field);
 	// empty for a standalone primary.
 	MasterInstanceName string
-	Tags               map[string]string
+	// GCPDatabaseFlags / GCPBackupConfig / GCPIPConfig carry the Cloud SQL
+	// settings sub-objects (databaseFlags, backupConfiguration, ipConfiguration)
+	// as opaque JSON so they round-trip on Insert->Get. They are a Cloud SQL-only
+	// concern; AWS RDS and Redshift never set or read them.
+	GCPDatabaseFlags string
+	GCPBackupConfig  string
+	GCPIPConfig      string
+	Tags             map[string]string
 	// Scope records where the resource lives (Azure subscription/resource
 	// group). Zero for AWS/GCP and unscoped portable callers.
 	Scope scope.Scope
@@ -175,6 +182,13 @@ type Instance struct {
 	// replica identifiers reading from this instance.
 	ReadReplicaSource  string
 	ReadReplicaTargets []string
+	// GCPDatabaseFlags / GCPBackupConfig / GCPIPConfig echo the Cloud SQL
+	// settings sub-objects (databaseFlags, backupConfiguration, ipConfiguration)
+	// as opaque JSON so they round-trip on read. Empty for AWS RDS / Redshift,
+	// which never set or read them.
+	GCPDatabaseFlags string
+	GCPBackupConfig  string
+	GCPIPConfig      string
 	// Scope records where the resource lives (Azure subscription/resource
 	// group), echoed from the InstanceConfig it was created with. Zero for
 	// AWS/GCP and unscoped portable callers — Scope.Matches treats a zero
@@ -217,7 +231,13 @@ type ModifyInstanceInput struct {
 	NodeType      string
 	NumberOfNodes int
 	ClusterType   string
-	Tags          map[string]string
+	// GCPDatabaseFlags / GCPBackupConfig / GCPIPConfig update the Cloud SQL
+	// settings sub-objects (opaque JSON); empty means "no change". Cloud SQL-only;
+	// RDS/Redshift ignore them.
+	GCPDatabaseFlags string
+	GCPBackupConfig  string
+	GCPIPConfig      string
+	Tags             map[string]string
 }
 
 // ClusterConfig configures an Aurora-style cluster. Members are added by
@@ -499,6 +519,14 @@ type Databases interface {
 	GetDatabase(ctx context.Context, server, name string) (*Database, error)
 	ListDatabases(ctx context.Context, server string) ([]Database, error)
 	DeleteDatabase(ctx context.Context, server, name string) error
+}
+
+// DatabaseUpdater is an OPTIONAL capability for updating a logical database's
+// charset/collation (Cloud SQL databases.update / databases.patch), discovered
+// by type assertion. Kept separate from Databases so providers that only expose
+// create/get/list/delete are unaffected.
+type DatabaseUpdater interface {
+	UpdateDatabase(ctx context.Context, cfg DatabaseConfig) (*Database, error)
 }
 
 // FirewallRuleConfig describes a server firewall rule to create or replace.


### PR DESCRIPTION
Confirming re-audit residue on GCP Cloud SQL against the official Cloud SQL Admin REST docs. Fixes the HIGH Terraform perpetual-drift bug plus four lower-severity gaps.

## Fixes
- **[HIGH] Instance settings now round-trip.** `availabilityType`, `databaseFlags`, `backupConfiguration` and `ipConfiguration` were silently dropped on Insert/Patch, causing Terraform perpetual drift. `availabilityType` maps to the existing driver `Instance.MultiAZ` (REGIONAL<->true) purely in the wire layer. The other three are threaded through new **optional** opaque-JSON `Instance`/`InstanceConfig`/`ModifyInstanceInput` fields and round-trip on Insert->Get and Patch->Get.
- **[MED] Patched `databaseVersion` now visible on Get.** Patch mapped `databaseVersion`->`EngineVersion`, but Get renders from `Engine`. Cloud SQL's `ModifyInstance` now lands a patched version on `Engine`.
- **[LOW] `databases.update` (PUT/PATCH) no longer 405s.** Backed by a new optional `DatabaseUpdater` capability (charset/collation update); kept out of the shared `Databases` interface so Azure/AlloyDB are unaffected.
- **[LOW] `serverCaCert` populated.** Emitted as a synthetic `sslCert` so Terraform's computed `server_ca_cert` is never empty.

## Deferred
- **PUT `/instances/{i}` (Update) full-replace semantics.** Both PATCH and PUT still route to the merge path. True full-replace (absent settings fields reset-to-default) needs a clear/no-change distinction the shared `ModifyInstanceInput` does not carry; Terraform uses PATCH, so impact is low. Deferred rather than done unclean.

## Shared driver / no regression
The shared `services/relationaldb/driver` (RDS + Redshift + Cloud SQL) gains only **optional** fields and one optional interface that RDS/Redshift never set or read. RDS + Redshift server and provider tests pass unchanged.

## Tests
Real `sqladmin/v1` reproductions: settings round-trip (all four), patch availabilityType/databaseFlags, patch `POSTGRES_14`->`15`, `Databases.Update` charset/collation, `serverCaCert` populated. Plus provider-level `UpdateDatabase` and settings-persistence tests. #641 tests remain green.

Docs regenerated (`go generate`, `compatgen`), idempotent.
