### PR TITLE
fix(gcp): hard-delete Secret Manager secrets, 400 on illegal version transition, stable IAM list pagination

### DIFF
--- a/providers/gcp/secretmanager/iam.go
+++ b/providers/gcp/secretmanager/iam.go
@@ -19,10 +19,6 @@ func (m *Mock) GetSecretIAMPolicy(_ context.Context, name string) (*driver.GCPIA
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
 
-	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
-	}
-
 	if sd.iam == nil {
 		return &driver.GCPIAMPolicy{Version: 1, Etag: newEtag()}, nil
 	}
@@ -40,10 +36,6 @@ func (m *Mock) SetSecretIAMPolicy(_ context.Context, name string, policy driver.
 
 	sd.mu.Lock()
 	defer sd.mu.Unlock()
-
-	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
-	}
 
 	stored := clonePolicy(&policy)
 	if stored.Version == 0 {
@@ -66,10 +58,6 @@ func (m *Mock) TestSecretIAMPermissions(_ context.Context, name string, permissi
 
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
-
-	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
-	}
 
 	granted := make([]string, len(permissions))
 	copy(granted, permissions)

--- a/providers/gcp/secretmanager/lifecycle.go
+++ b/providers/gcp/secretmanager/lifecycle.go
@@ -42,10 +42,6 @@ func (m *Mock) mutateVersion(name, versionID string,
 	sd.mu.Lock()
 	defer sd.mu.Unlock()
 
-	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
-	}
-
 	v, ok := findVersion(sd, versionID)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "version %q not found for secret %q", versionID, name)
@@ -114,10 +110,6 @@ func (m *Mock) PatchSecret(_ context.Context, name string, patch driver.GCPSecre
 
 	sd.mu.Lock()
 	defer sd.mu.Unlock()
-
-	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
-	}
 
 	if patch.SetLabels {
 		labels := make(map[string]string, len(patch.Labels))

--- a/providers/gcp/secretmanager/secretmanager.go
+++ b/providers/gcp/secretmanager/secretmanager.go
@@ -22,7 +22,6 @@ type secretData struct {
 	versions   []driver.SecretVersion
 	verCounter int                  // monotonic version-number allocator (GCP numbers versions 1,2,3…)
 	iam        *driver.GCPIAMPolicy // stored IAM policy; nil until first set
-	deletedAt  time.Time
 	mu         sync.RWMutex
 }
 
@@ -102,21 +101,15 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 	return &result, nil
 }
 
-// DeleteSecret soft-deletes a secret by name, scheduling it for deletion after a recovery window.
+// DeleteSecret permanently removes a secret and all its versions. GCP Secret
+// Manager's secrets.delete is a hard delete with no recovery window, so the same
+// secretId is creatable again immediately.
 func (m *Mock) DeleteSecret(_ context.Context, name string) error {
-	sd, ok := m.secrets.Get(name)
-	if !ok {
+	if !m.secrets.Has(name) {
 		return errors.Newf(errors.NotFound, "secret %q not found", name)
 	}
 
-	sd.mu.Lock()
-	defer sd.mu.Unlock()
-
-	if !sd.deletedAt.IsZero() {
-		return errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
-	}
-
-	sd.deletedAt = m.opts.Clock.Now().UTC()
+	m.secrets.Delete(name)
 
 	return nil
 }
@@ -131,16 +124,12 @@ func (m *Mock) GetSecret(_ context.Context, name string) (*driver.SecretInfo, er
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
 
-	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
-	}
-
 	result := sd.info
 
 	return &result, nil
 }
 
-// ListSecrets lists all secrets, excluding soft-deleted ones.
+// ListSecrets lists all secrets.
 func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
 	all := m.secrets.All()
 
@@ -148,9 +137,7 @@ func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
 
 	for _, sd := range all {
 		sd.mu.RLock()
-		if sd.deletedAt.IsZero() {
-			secrets = append(secrets, sd.info)
-		}
+		secrets = append(secrets, sd.info)
 		sd.mu.RUnlock()
 	}
 
@@ -166,10 +153,6 @@ func (m *Mock) PutSecretValue(_ context.Context, name string, value []byte) (*dr
 
 	sd.mu.Lock()
 	defer sd.mu.Unlock()
-
-	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
-	}
 
 	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
 
@@ -208,10 +191,6 @@ func (m *Mock) GetSecretValue(_ context.Context, name, versionID string) (*drive
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
 
-	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
-	}
-
 	for _, v := range sd.versions {
 		if versionID == "" && v.Current {
 			result := v
@@ -246,10 +225,6 @@ func (m *Mock) ListSecretVersions(_ context.Context, name string) ([]driver.Secr
 
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
-
-	if !sd.deletedAt.IsZero() {
-		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
-	}
 
 	versions := make([]driver.SecretVersion, len(sd.versions))
 	for i, v := range sd.versions {

--- a/providers/gcp/secretmanager/secretmanager_test.go
+++ b/providers/gcp/secretmanager/secretmanager_test.go
@@ -370,6 +370,36 @@ func TestDeleteThenGetReturnsError(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestDeleteIsHardDeleteRecreatable proves GCP secrets.delete is a permanent
+// hard delete: the same secretId is creatable again immediately (no recovery
+// window), GetSecret 404s after delete, and ListSecrets omits it.
+func TestDeleteIsHardDeleteRecreatable(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	createTestSecret(t, m, "recreate-me", "v1")
+
+	require.NoError(t, m.DeleteSecret(ctx, "recreate-me"))
+
+	_, err := m.GetSecret(ctx, "recreate-me")
+	require.Error(t, err)
+
+	list, err := m.ListSecrets(ctx)
+	require.NoError(t, err)
+	for _, s := range list {
+		assert.NotEqual(t, "recreate-me", s.Name, "deleted secret must not appear in ListSecrets")
+	}
+
+	// Same secretId re-creates cleanly — no AlreadyExists.
+	info, err := m.CreateSecret(ctx, driver.SecretConfig{Name: "recreate-me"}, []byte("v2"))
+	require.NoError(t, err)
+	assert.Equal(t, "recreate-me", info.Name)
+
+	got, err := m.GetSecretValue(ctx, "recreate-me", "")
+	require.NoError(t, err)
+	assert.Equal(t, "v2", string(got.Value))
+}
+
 func TestCreateSecretTagsCopied(t *testing.T) {
 	m := newTestMock()
 	tags := map[string]string{"key": "original"}

--- a/providers/gcp/secretmanager/snapshot.go
+++ b/providers/gcp/secretmanager/snapshot.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/stackshy/cloudemu/v2/internal/snapshot"
 	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
@@ -13,8 +12,8 @@ import (
 var _ snapshot.Snapshottable = (*Mock)(nil)
 
 // secretsSnapshot is the full serialized state of the GCP Secret Manager mock:
-// every secret keyed by name, each with its metadata, version history, and
-// soft-delete state, so identifiers (self-link, version ids) restore unchanged.
+// every secret keyed by name, each with its metadata and version history, so
+// identifiers (self-link, version ids) restore unchanged.
 type secretsSnapshot struct {
 	Secrets map[string]*secretSnapshot `json:"secrets,omitempty"`
 }
@@ -24,7 +23,6 @@ type secretSnapshot struct {
 	Versions   []driver.SecretVersion `json:"versions,omitempty"`
 	VerCounter int                    `json:"verCounter,omitempty"`
 	IAM        *driver.GCPIAMPolicy   `json:"iam,omitempty"`
-	DeletedAt  time.Time              `json:"deletedAt,omitempty"`
 }
 
 // Snapshot captures every secret's full state as JSON. includeAssets is unused —
@@ -40,7 +38,6 @@ func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
 			Versions:   sd.versions,
 			VerCounter: sd.verCounter,
 			IAM:        sd.iam,
-			DeletedAt:  sd.deletedAt,
 		}
 		sd.mu.RUnlock()
 	}
@@ -62,7 +59,6 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 			versions:   ss.Versions,
 			verCounter: ss.VerCounter,
 			iam:        ss.IAM,
-			deletedAt:  ss.DeletedAt,
 		})
 	}
 

--- a/server/gcp/iam/operations.go
+++ b/server/gcp/iam/operations.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"time"
 
@@ -107,6 +108,11 @@ func (h *Handler) listServiceAccounts(w http.ResponseWriter, r *http.Request, pr
 		matched = append(matched, toServiceAccountJSON(responseProject, u.Name, &sa))
 	}
 	h.mu.RUnlock()
+
+	// ListUsers returns map order (random), so sort by the stable resource name
+	// before applying the offset page token — otherwise page boundaries shift
+	// between requests and callers see duplicated or skipped accounts.
+	sort.Slice(matched, func(i, j int) bool { return matched[i].Name < matched[j].Name })
 
 	page, next := paginate(matched, pageSizeParam(r), decodePageToken(pageTokenParam(r)))
 
@@ -273,6 +279,11 @@ func (h *Handler) listRoles(w http.ResponseWriter, r *http.Request, project stri
 		props, _ := decodeRoleProps(dr.AssumeRolePolicyDoc)
 		matched = append(matched, toRoleJSON(project, dr.Name, &props))
 	}
+
+	// ListRoles returns map order (random), so sort by the stable role name
+	// before applying the offset page token to keep page boundaries consistent
+	// across requests (no duplicated or skipped roles).
+	sort.Slice(matched, func(i, j int) bool { return matched[i].Name < matched[j].Name })
 
 	page, next := paginate(matched, pageSizeParam(r), decodePageToken(pageTokenParam(r)))
 

--- a/server/gcp/iam/sdk_iam_compat_test.go
+++ b/server/gcp/iam/sdk_iam_compat_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -402,5 +403,105 @@ func TestSDKGCPIAMListPagination(t *testing.T) {
 
 	if got.Etag == "" {
 		t.Fatal("role etag is empty, want populated")
+	}
+}
+
+const (
+	bigListCount = 150 // exceeds the default page size so multiple pages are forced
+	pageWindow   = 40  // small page size to force several round-trips
+	maxPages     = 100 // loop guard so a pagination bug can't spin forever
+)
+
+// TestSDKGCPIAMListPaginationNoDupsOrSkips guards the pagination-stability bug:
+// service accounts and roles are stored in random map order, so an offset page
+// token over an unsorted slice used to duplicate or skip entries across pages.
+// Walking every page must yield each resource exactly once.
+func TestSDKGCPIAMListPaginationNoDupsOrSkips(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	wantSAs := make(map[string]bool, bigListCount)
+	for i := range bigListCount {
+		wantSAs[createSA(t, svc, fmt.Sprintf("sa-%03d", i))] = true
+	}
+
+	gotSAs := map[string]bool{}
+	token := ""
+
+	for page := 0; page < maxPages; page++ {
+		resp, err := svc.Projects.ServiceAccounts.List("projects/" + testProject).
+			PageSize(pageWindow).PageToken(token).Context(ctx).Do()
+		if err != nil {
+			t.Fatalf("SA List page %d: %v", page, err)
+		}
+
+		for _, sa := range resp.Accounts {
+			if gotSAs[sa.Email] {
+				t.Fatalf("service account %q returned on more than one page", sa.Email)
+			}
+
+			gotSAs[sa.Email] = true
+		}
+
+		token = resp.NextPageToken
+		if token == "" {
+			break
+		}
+	}
+
+	assertSameKeys(t, "service accounts", wantSAs, gotSAs)
+
+	wantRoles := make(map[string]bool, bigListCount)
+	for i := range bigListCount {
+		id := fmt.Sprintf("role_%03d", i)
+		if _, err := svc.Projects.Roles.Create("projects/"+testProject, &iamv1.CreateRoleRequest{
+			RoleId: id,
+			Role:   &iamv1.Role{Title: "Role " + id, Stage: "GA"},
+		}).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create role %s: %v", id, err)
+		}
+
+		wantRoles["projects/"+testProject+"/roles/"+id] = true
+	}
+
+	gotRoles := map[string]bool{}
+	token = ""
+
+	for page := 0; page < maxPages; page++ {
+		resp, err := svc.Projects.Roles.List("projects/" + testProject).
+			PageSize(pageWindow).PageToken(token).Context(ctx).Do()
+		if err != nil {
+			t.Fatalf("Roles List page %d: %v", page, err)
+		}
+
+		for _, ro := range resp.Roles {
+			if gotRoles[ro.Name] {
+				t.Fatalf("role %q returned on more than one page", ro.Name)
+			}
+
+			gotRoles[ro.Name] = true
+		}
+
+		token = resp.NextPageToken
+		if token == "" {
+			break
+		}
+	}
+
+	assertSameKeys(t, "roles", wantRoles, gotRoles)
+}
+
+// assertSameKeys fails if got and want don't hold exactly the same key set.
+func assertSameKeys(t *testing.T, what string, want, got map[string]bool) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("%s: paged %d unique, want %d (dup or skip across pages)", what, len(got), len(want))
+	}
+
+	for k := range want {
+		if !got[k] {
+			t.Fatalf("%s: %q missing from paged union", what, k)
+		}
 	}
 }

--- a/server/gcp/secretmanager/lifecycle_sdk_test.go
+++ b/server/gcp/secretmanager/lifecycle_sdk_test.go
@@ -139,6 +139,72 @@ func TestSDKVersionLifecycle(t *testing.T) {
 	}
 }
 
+// TestSDKDestroyedVersionLifecycleIs400 proves an illegal state transition on a
+// version — destroy/disable/enable applied to an already-DESTROYED version —
+// surfaces as HTTP 400 FAILED_PRECONDITION (real GCP), not the 409 that the
+// shared gcprest FailedPrecondition mapping would otherwise produce.
+func TestSDKDestroyedVersionLifecycleIs400(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+	name := mustCreateSecret(t, svc, "illegal-transition")
+
+	v1, err := svc.Projects.Secrets.AddVersion(name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode("secret")},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("AddVersion: %v", err)
+	}
+
+	if _, err := svc.Projects.Secrets.Versions.Destroy(v1.Name, &sm.DestroySecretVersionRequest{}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+
+	var gerr *googleapi.Error
+
+	// Re-destroy an already-destroyed version → 400 FAILED_PRECONDITION.
+	_, err = svc.Projects.Secrets.Versions.Destroy(v1.Name, &sm.DestroySecretVersionRequest{}).Context(ctx).Do()
+	if !errors.As(err, &gerr) || gerr.Code != 400 {
+		t.Fatalf("Destroy(destroyed): got %v, want 400 FAILED_PRECONDITION", err)
+	}
+
+	// Disable a destroyed version → 400 FAILED_PRECONDITION.
+	_, err = svc.Projects.Secrets.Versions.Disable(v1.Name, &sm.DisableSecretVersionRequest{}).Context(ctx).Do()
+	if !errors.As(err, &gerr) || gerr.Code != 400 {
+		t.Fatalf("Disable(destroyed): got %v, want 400 FAILED_PRECONDITION", err)
+	}
+
+	// Enable a destroyed version → 400 FAILED_PRECONDITION.
+	_, err = svc.Projects.Secrets.Versions.Enable(v1.Name, &sm.EnableSecretVersionRequest{}).Context(ctx).Do()
+	if !errors.As(err, &gerr) || gerr.Code != 400 {
+		t.Fatalf("Enable(destroyed): got %v, want 400 FAILED_PRECONDITION", err)
+	}
+}
+
+// TestSDKDeleteThenRecreateSameID proves GCP secrets.delete is a permanent hard
+// delete: Get 404s afterwards and the same secretId is creatable again with no
+// ALREADY_EXISTS (no recovery window).
+func TestSDKDeleteThenRecreateSameID(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+	name := mustCreateSecret(t, svc, "reborn")
+
+	if _, err := svc.Projects.Secrets.Delete(name).Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	var gerr *googleapi.Error
+	if _, err := svc.Projects.Secrets.Get(name).Context(ctx).Do(); !errors.As(err, &gerr) || gerr.Code != 404 {
+		t.Fatalf("Get after Delete: got %v, want 404 NOT_FOUND", err)
+	}
+
+	// Same secretId re-creates cleanly.
+	if _, err := svc.Projects.Secrets.Create(testParent, &sm.Secret{
+		Replication: &sm.Replication{Automatic: &sm.Automatic{}},
+	}).SecretId("reborn").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create(reborn) after Delete: %v", err)
+	}
+}
+
 // TestSDKSecretPatch proves secrets.patch updates labels (audit: Secrets.patch).
 func TestSDKSecretPatch(t *testing.T) {
 	svc := newSMService(t)

--- a/server/gcp/secretmanager/operations.go
+++ b/server/gcp/secretmanager/operations.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
@@ -227,7 +228,17 @@ func (h *Handler) mutateVersion(w http.ResponseWriter, r *http.Request, rt route
 	}
 
 	if err != nil {
+		// An illegal state transition (e.g. destroy/disable/enable on a DESTROYED
+		// version) is FAILED_PRECONDITION, which GCP reports as HTTP 400. The
+		// shared gcprest mapping would turn it into 409, so answer 400 locally
+		// without altering that cross-cutting mapping.
+		if cerrors.IsFailedPrecondition(err) {
+			gcprest.WriteError(w, http.StatusBadRequest, "failedPrecondition", err.Error())
+			return
+		}
+
 		gcprest.WriteCErr(w, err)
+
 		return
 	}
 


### PR DESCRIPTION
## Summary

Fixes three real correctness bugs in GCP Secret Manager and GCP IAM.

### Bug 1 (HIGH) — DeleteSecret then re-create same name wrongly 409 ALREADY_EXISTS
GCP Secret Manager `secrets.delete` is a permanent hard delete with no recovery window; the same `secretId` must be creatable immediately afterwards. The GCP provider previously soft-deleted (stamped `deletedAt` and kept the entry), so `CreateSecret`'s existence guard still saw it and returned AlreadyExists. `DeleteSecret` now hard-deletes (`m.secrets.Delete`, dropping versions) and all GCP-only `deletedAt`/soft-delete machinery is removed from the GCP path. After delete: GetSecret 404s, ListSecrets omits it, and re-creating the same id succeeds. **AWS Secrets Manager soft-delete + recovery window + RestoreSecret is a separate provider and is untouched** (proven green).

### Bug 2 (LOW) — illegal version-lifecycle transition returned 409 instead of 400
Enable/Disable/Destroy on a DESTROYED (illegal-state) version returns `FailedPrecondition`, which the shared `gcprest.WriteCErr` maps to 409 conditionNotMet. Real GCP returns HTTP 400 FAILED_PRECONDITION. Fixed **locally** in the secretmanager version-lifecycle handler (hardcoded 400, mirroring the existing `:access` path) — the global `gcprest` mapping is left unchanged to avoid cross-service blast radius.

### Bug 3 (MED) — ListServiceAccounts / ListRoles pagination duplicated/skipped across pages
`listServiceAccounts`/`listRoles` build their result from `ListUsers`/`ListRoles`, which return `memstore.All()` in random map order, then an offset page token indexes into that unsorted slice — so page boundaries shifted between requests, duplicating or skipping entries. Both now sort `matched` by a stable key (resource name) before `paginate`.

## Tests
- Provider: delete then re-create same id succeeds; GetSecret 404 and ListSecrets omits after delete.
- Server (real GCP SDK): Enable/Disable/Destroy on a destroyed version each returns HTTP 400 FAILED_PRECONDITION; delete then recreate same secretId succeeds with Get 404 in between.
- Server (real GCP SDK): 150 service accounts and 150 roles paged fully with a small page size — union across pages equals the full set, each returned exactly once (no dups/skips).

## Deferrals (out of scope, tracked separately)
replication/ttl/rotation decode, `?filter=`, project-level cloudresourcemanager IAM, etag preconditions, dataCrc32c, role etag.