### PR TITLE
fix(azure-tables): Edm.Int64 $filter/$select fidelity and TableAlreadyExists error code

### DIFF
--- a/providers/azure/tablestorage/tablestorage.go
+++ b/providers/azure/tablestorage/tablestorage.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -26,6 +27,14 @@ const (
 
 	// numSystemProps is how many system properties render adds (Timestamp, etag).
 	numSystemProps = 2
+
+	// odataTypeSuffix marks the "<name>@odata.type" companion property Azure uses
+	// to annotate a value's EDM type (e.g. Amount@odata.type: "Edm.Int64").
+	odataTypeSuffix = "@odata.type"
+
+	// edmInt64 is the OData type for a 64-bit integer, which Azure encodes on the
+	// wire as a JSON string alongside an odataTypeSuffix companion.
+	edmInt64 = "Edm.Int64"
 )
 
 // storedEntity is one row plus its server-maintained system properties.
@@ -316,7 +325,31 @@ func sanitize(e driver.Entity) driver.Entity {
 		}
 	}
 
+	coerceEDMTypes(out)
+
 	return out
+}
+
+// coerceEDMTypes converts wire-encoded typed properties into native Go values so
+// $filter comparisons operate on numbers rather than strings. Azure encodes an
+// Edm.Int64 as a JSON string with an "<name>@odata.type" companion; we parse it
+// to int64 and keep the companion so reads re-emit the type annotation.
+func coerceEDMTypes(e driver.Entity) {
+	for k, v := range e {
+		edmType, _ := e[k+odataTypeSuffix].(string)
+		if edmType != edmInt64 {
+			continue
+		}
+
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+			e[k] = n
+		}
+	}
 }
 
 // QueryEntities returns a page of entities matching opts, ordered by
@@ -417,6 +450,9 @@ func project(e driver.Entity, selectRaw string) driver.Entity {
 	for _, name := range strings.Split(selectRaw, ",") {
 		if name = strings.TrimSpace(name); name != "" {
 			keep[name] = true
+			// Keep the "<name>@odata.type" companion so a selected typed
+			// property (e.g. Edm.Int64) retains its OData type annotation.
+			keep[name+odataTypeSuffix] = true
 		}
 	}
 

--- a/providers/azure/tablestorage/tablestorage_test.go
+++ b/providers/azure/tablestorage/tablestorage_test.go
@@ -171,3 +171,44 @@ func sameSet(a, b []string) bool {
 
 	return true
 }
+
+// TestInt64TypedStoreFilter confirms an Edm.Int64 arriving as a wire string with
+// its @odata.type companion is stored as a native int64 so $filter compares it
+// numerically, and that the companion survives a $select projection.
+func TestInt64TypedStoreFilter(t *testing.T) {
+	m := newMock(t)
+	if err := m.CreateTable(context.Background(), "t"); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	seed(t, m, "t", "p", "big", driver.Entity{"Amount": "500", "Amount@odata.type": edmInt64})
+	seed(t, m, "t", "p", "small", driver.Entity{"Amount": "50", "Amount@odata.type": edmInt64})
+
+	got := queryRowKeys(t, m, "t", "Amount gt 100")
+	if !sameSet(got, []string{"big"}) {
+		t.Errorf("Amount gt 100 = %v, want [big]", got)
+	}
+
+	ent, err := m.GetEntity(context.Background(), "t", "p", "big")
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+
+	if n, ok := ent["Amount"].(int64); !ok || n != 500 {
+		t.Errorf("stored Amount = %v (%T), want int64(500)", ent["Amount"], ent["Amount"])
+	}
+
+	res, err := m.QueryEntities(context.Background(), "t", driver.QueryOptions{
+		Filter: "PartitionKey eq 'p'",
+		Select: "PartitionKey,RowKey,Amount",
+	})
+	if err != nil {
+		t.Fatalf("QueryEntities: %v", err)
+	}
+
+	for _, e := range res.Entities {
+		if e["Amount@odata.type"] != edmInt64 {
+			t.Errorf("projection dropped @odata.type companion: %v", e)
+		}
+	}
+}

--- a/server/azure/tablestorage/edm_int64_test.go
+++ b/server/azure/tablestorage/edm_int64_test.go
@@ -1,0 +1,195 @@
+package tablestorage_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
+)
+
+// addEDMEntity inserts an EDMEntity, marshalling it the way the aztables client
+// does so Edm.Int64 travels as a string with its @odata.type companion.
+func addEDMEntity(t *testing.T, client *aztables.Client, e aztables.EDMEntity) {
+	t.Helper()
+
+	marshalled, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal EDMEntity: %v", err)
+	}
+
+	if _, err := client.AddEntity(context.Background(), marshalled, nil); err != nil {
+		t.Fatalf("AddEntity: %v", err)
+	}
+}
+
+// listEDM runs a query and decodes every returned row into an EDMEntity.
+func listEDM(t *testing.T, client *aztables.Client, opts *aztables.ListEntitiesOptions) []aztables.EDMEntity {
+	t.Helper()
+
+	pager := client.NewListEntitiesPager(opts)
+
+	var out []aztables.EDMEntity
+
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatalf("ListEntities: %v", err)
+		}
+
+		for _, raw := range page.Entities {
+			var e aztables.EDMEntity
+			if uerr := json.Unmarshal(raw, &e); uerr != nil {
+				t.Fatalf("unmarshal EDMEntity: %v", uerr)
+			}
+
+			out = append(out, e)
+		}
+	}
+
+	return out
+}
+
+// TestSDKTableInt64FilterMatches confirms a $filter on an Edm.Int64 column
+// compares numerically: "Amount gt 100" must return only the larger value.
+func TestSDKTableInt64FilterMatches(t *testing.T) {
+	client, _ := newTableClient(t, "int64filter")
+
+	addEDMEntity(t, client, aztables.EDMEntity{
+		Entity:     aztables.Entity{PartitionKey: "org", RowKey: "big"},
+		Properties: map[string]any{"Amount": aztables.EDMInt64(500)},
+	})
+	addEDMEntity(t, client, aztables.EDMEntity{
+		Entity:     aztables.Entity{PartitionKey: "org", RowKey: "small"},
+		Properties: map[string]any{"Amount": aztables.EDMInt64(50)},
+	})
+
+	filter := "Amount gt 100"
+	rows := listEDM(t, client, &aztables.ListEntitiesOptions{Filter: &filter})
+
+	if len(rows) != 1 {
+		t.Fatalf("Amount gt 100 returned %d rows, want exactly 1: %+v", len(rows), rows)
+	}
+
+	if rows[0].RowKey != "big" {
+		t.Errorf("Amount gt 100 matched RowKey=%q, want big", rows[0].RowKey)
+	}
+
+	if v, ok := rows[0].Properties["Amount"].(aztables.EDMInt64); !ok || v != aztables.EDMInt64(500) {
+		t.Errorf("Amount = %v (%T), want EDMInt64(500)", rows[0].Properties["Amount"], rows[0].Properties["Amount"])
+	}
+}
+
+// TestSDKTableInt64SelectKeepsType confirms $select on an Edm.Int64 property
+// preserves the @odata.type companion so it decodes back as int64, not string.
+func TestSDKTableInt64SelectKeepsType(t *testing.T) {
+	client, _ := newTableClient(t, "int64select")
+
+	addEDMEntity(t, client, aztables.EDMEntity{
+		Entity:     aztables.Entity{PartitionKey: "org", RowKey: "row"},
+		Properties: map[string]any{"Amount": aztables.EDMInt64(999), "Note": "ignored"},
+	})
+
+	filter := "PartitionKey eq 'org'"
+	sel := "PartitionKey,RowKey,Amount"
+
+	rows := listEDM(t, client, &aztables.ListEntitiesOptions{Filter: &filter, Select: &sel})
+	if len(rows) != 1 {
+		t.Fatalf("query returned %d rows, want 1", len(rows))
+	}
+
+	amount := rows[0].Properties["Amount"]
+
+	v, ok := amount.(aztables.EDMInt64)
+	if !ok {
+		t.Fatalf("selected Amount decoded as %T (%v), want aztables.EDMInt64", amount, amount)
+	}
+
+	if v != aztables.EDMInt64(999) {
+		t.Errorf("Amount = %d, want 999", v)
+	}
+
+	if _, present := rows[0].Properties["Note"]; present {
+		t.Errorf("Note present in projection %v, want it dropped", rows[0].Properties)
+	}
+}
+
+// TestSDKTableNumericFilterInt32Double confirms plain numeric columns (int32
+// and float64) still filter numerically alongside the Int64 fix.
+func TestSDKTableNumericFilterInt32Double(t *testing.T) {
+	client, _ := newTableClient(t, "numfilter")
+
+	addEDMEntity(t, client, aztables.EDMEntity{
+		Entity:     aztables.Entity{PartitionKey: "org", RowKey: "a"},
+		Properties: map[string]any{"Count": int32(10), "Ratio": 1.5},
+	})
+	addEDMEntity(t, client, aztables.EDMEntity{
+		Entity:     aztables.Entity{PartitionKey: "org", RowKey: "b"},
+		Properties: map[string]any{"Count": int32(200), "Ratio": 9.5},
+	})
+
+	int32Filter := "Count gt 100"
+	if rows := listEDM(t, client, &aztables.ListEntitiesOptions{Filter: &int32Filter}); len(rows) != 1 || rows[0].RowKey != "b" {
+		t.Errorf("Count gt 100 = %+v, want exactly RowKey=b", rows)
+	}
+
+	doubleFilter := "Ratio lt 5.0"
+	if rows := listEDM(t, client, &aztables.ListEntitiesOptions{Filter: &doubleFilter}); len(rows) != 1 || rows[0].RowKey != "a" {
+		t.Errorf("Ratio lt 5.0 = %+v, want exactly RowKey=a", rows)
+	}
+}
+
+// TestSDKTableDuplicateCreateAndInsertCodes confirms a duplicate CreateTable
+// returns TableAlreadyExists while a duplicate entity insert returns the
+// distinct EntityAlreadyExists.
+func TestSDKTableDuplicateCreateAndInsertCodes(t *testing.T) {
+	client, ts := newTableClient(t, "dupcodes")
+
+	svc, err := aztables.NewServiceClientWithNoCredential(ts.URL+"/", &aztables.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}},
+	})
+	if err != nil {
+		t.Fatalf("NewServiceClientWithNoCredential: %v", err)
+	}
+
+	_, err = svc.CreateTable(context.Background(), "dupcodes", nil)
+	if err == nil {
+		t.Fatal("duplicate CreateTable succeeded, want an error")
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("CreateTable error is %T, want *azcore.ResponseError: %v", err, err)
+	}
+
+	if respErr.ErrorCode != "TableAlreadyExists" {
+		t.Errorf("duplicate table code = %q, want TableAlreadyExists", respErr.ErrorCode)
+	}
+
+	entity := map[string]any{"PartitionKey": "p", "RowKey": "r", "V": "1"}
+
+	marshalled, merr := json.Marshal(entity)
+	if merr != nil {
+		t.Fatalf("marshal entity: %v", merr)
+	}
+
+	if _, err := client.AddEntity(context.Background(), marshalled, nil); err != nil {
+		t.Fatalf("first AddEntity: %v", err)
+	}
+
+	_, err = client.AddEntity(context.Background(), marshalled, nil)
+	if err == nil {
+		t.Fatal("duplicate AddEntity succeeded, want an error")
+	}
+
+	if !errors.As(err, &respErr) {
+		t.Fatalf("AddEntity error is %T, want *azcore.ResponseError: %v", err, err)
+	}
+
+	if respErr.ErrorCode != "EntityAlreadyExists" {
+		t.Errorf("duplicate entity code = %q, want EntityAlreadyExists", respErr.ErrorCode)
+	}
+}

--- a/server/azure/tablestorage/handler.go
+++ b/server/azure/tablestorage/handler.go
@@ -158,7 +158,15 @@ func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.ts.CreateTable(r.Context(), body.TableName); err != nil {
+		// A duplicate table is TableAlreadyExists, distinct from the generic
+		// EntityAlreadyExists that a duplicate entity insert reports.
+		if cerrors.IsAlreadyExists(err) {
+			writeError(w, http.StatusConflict, "TableAlreadyExists", err.Error())
+			return
+		}
+
 		writeErr(w, err)
+
 		return
 	}
 

--- a/server/azure/tablestorage/helpers.go
+++ b/server/azure/tablestorage/helpers.go
@@ -113,10 +113,17 @@ func unquote(s string) string {
 }
 
 // entityToJSON copies an entity's properties into a fresh JSON map. The
-// PartitionKey/RowKey and user properties round-trip verbatim.
+// PartitionKey/RowKey and user properties round-trip verbatim, except an
+// Edm.Int64 (stored as a native int64) is rendered as a JSON string, which is
+// how Table Storage encodes 64-bit integers on the wire.
 func entityToJSON(e driver.Entity) map[string]any {
 	out := make(map[string]any, len(e)+1)
 	for k, v := range e {
+		if n, ok := v.(int64); ok {
+			out[k] = strconv.FormatInt(n, 10)
+			continue
+		}
+
 		out[k] = v
 	}
 


### PR DESCRIPTION
## Summary

Fixes three Azure Table Storage fidelity bugs surfaced with the real `aztables` SDK.

**BUG 1 (HIGH) — `$filter` on `Edm.Int64` never matched.** `aztables.EDMInt64` travels as a JSON string (`"500"`) plus an `Amount@odata.type: "Edm.Int64"` companion, but filter numeric literals compile to `float64`, so the store's string value could never compare against them and every `eq/gt/ge/lt/le` on an Int64 column silently failed. The provider now parses the companion on insert/update and stores a **native `int64`**, so `$filter` compares numerically. The server wire codec re-encodes `int64` as a JSON string on read, matching how Table Storage renders 64-bit integers.

**BUG 2 (MED) — `$select` dropped the `@odata.type` companion.** Selecting `PartitionKey,RowKey,Amount` returned `Amount` as a bare string (type lost). `project()` now also retains `<name>@odata.type` whenever it keeps `<name>`, so a selected typed property keeps its OData annotation and decodes back as `int64`.

**BUG 3 (LOW/MED) — duplicate `CreateTable` returned the wrong code.** It returned `EntityAlreadyExists`; Azure returns `TableAlreadyExists`. `createTable` now special-cases `IsAlreadyExists` → 409 `TableAlreadyExists`, while duplicate entity inserts still map to `EntityAlreadyExists`.

## Tests

Focused tests using the real `aztables` SDK against the booted server (hand-rolled helpers, no testify):
- `Amount gt 100` over two `EDMInt64` rows returns exactly the larger one (BUG 1)
- `$select PartitionKey,RowKey,Amount` decodes `Amount` back as `EDMInt64`, not string (BUG 2)
- numeric `$filter` still works for `int32` and `float64` columns
- duplicate `CreateTable` → `TableAlreadyExists`; duplicate entity insert → `EntityAlreadyExists` (BUG 3)
- provider-level unit test for the typed store + companion retention

## Gates

build, vet, `go test` (both packages), `-race`, gofmt, golangci-lint (0 new), `go generate` (zero diff), compatgen + `docs/compat/` (zero diff) — all green.