### PR TITLE
fix(azure): Queue Storage message plane no longer shadowed by Service Bus routing

### DIFF
--- a/server/azure/queue_servicebus_routing_test.go
+++ b/server/azure/queue_servicebus_routing_test.go
@@ -1,0 +1,345 @@
+package azure_test
+
+// Routing regression tests for the Azure Queue Storage / Service Bus data-plane
+// collision (real-user BLOCKER). Both surfaces address a flat
+// "/{entity}/messages" URL; behind CloudEmu's shared endpoint the hostname that
+// separates them on real Azure is unavailable. The Service Bus handler is
+// registered before Queue Storage and used to claim EVERY "/messages" path,
+// which swallowed the entire Queue Storage message plane (create/list still
+// worked, but enqueue/dequeue/peek/delete/clear 404'd as "Service Bus entity
+// not found").
+//
+// The fix narrows Service Bus's Matches so it claims a flat "/{entity}/messages"
+// request only when {entity} resolves to a Service Bus queue or topic it holds.
+// These tests drive the FULL production server (NewFromProvider — the same
+// wiring `cloudemu serve` uses) with the real azqueue/azblob/aztables SDKs plus
+// the Service Bus REST data plane, proving both planes work simultaneously.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+const (
+	sbAPIVer = "?api-version=2022-10-01-preview"
+	sbSubID  = "sub-routing"
+	sbRG     = "rg-routing"
+	sbNS     = "ns-routing"
+)
+
+// newFullAzureServer boots the full production Azure server (all handlers
+// registered, same as `cloudemu serve`).
+func newFullAzureServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	ts := httptest.NewServer(azureserver.NewFromProvider(cloudemu.NewAzure()))
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+// anonOpts returns SDK client options that route through the test server with
+// retries disabled (anonymous access; no SharedKey signing needed).
+func anonOpts(ts *httptest.Server) policy.ClientOptions {
+	return policy.ClientOptions{
+		Transport: ts.Client(),
+		Retry:     policy.RetryOptions{MaxRetries: -1},
+	}
+}
+
+// sbDo issues a raw HTTP request against the full server (Service Bus REST),
+// asserts the status code, and returns the response body as a string.
+func sbDo(t *testing.T, ts *httptest.Server, method, path, body string, wantStatus int) string {
+	t.Helper()
+
+	var rdr io.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), method, ts.URL+path, rdr)
+	if err != nil {
+		t.Fatalf("new request %s %s: %v", method, path, err)
+	}
+
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+
+	defer resp.Body.Close()
+
+	out, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != wantStatus {
+		t.Fatalf("%s %s = %d, want %d (body %q)", method, path, resp.StatusCode, wantStatus, string(out))
+	}
+
+	return string(out)
+}
+
+// nsScope is the ARM namespace path prefix.
+func nsScope() string {
+	return "/subscriptions/" + sbSubID + "/resourceGroups/" + sbRG +
+		"/providers/Microsoft.ServiceBus/namespaces/" + sbNS
+}
+
+// seedSBNamespace creates the Service Bus namespace via ARM.
+func seedSBNamespace(t *testing.T, ts *httptest.Server) {
+	t.Helper()
+
+	sbDo(t, ts, http.MethodPut, nsScope()+sbAPIVer, `{"location":"eastus"}`, http.StatusOK)
+}
+
+// newStorageQueueClient returns an azqueue client for a named Storage queue on
+// the full server.
+func newStorageQueueClient(t *testing.T, ts *httptest.Server, queue string) *azqueue.QueueClient {
+	t.Helper()
+
+	qc, err := azqueue.NewQueueClientWithNoCredential(ts.URL+"/"+queue,
+		&azqueue.ClientOptions{ClientOptions: anonOpts(ts)})
+	if err != nil {
+		t.Fatalf("new queue client: %v", err)
+	}
+
+	return qc
+}
+
+// createStorageQueue creates a Storage queue via the azqueue service client.
+func createStorageQueue(t *testing.T, ts *httptest.Server, queue string) {
+	t.Helper()
+
+	svc, err := azqueue.NewServiceClientWithNoCredential(ts.URL+"/",
+		&azqueue.ClientOptions{ClientOptions: anonOpts(ts)})
+	if err != nil {
+		t.Fatalf("new service client: %v", err)
+	}
+
+	if _, err := svc.CreateQueue(context.Background(), queue, nil); err != nil {
+		t.Fatalf("CreateQueue %q: %v", queue, err)
+	}
+}
+
+// TestQueueStoragePlaneAliveOnFullServer is the core proof: the full azqueue
+// message-plane round-trip must succeed against the full server (no 404s from
+// Service Bus swallowing the /messages path).
+func TestQueueStoragePlaneAliveOnFullServer(t *testing.T) {
+	ts := newFullAzureServer(t)
+	ctx := context.Background()
+
+	createStorageQueue(t, ts, "sq")
+	qc := newStorageQueueClient(t, ts, "sq")
+
+	const payload = "hello-queue-storage"
+
+	if _, err := qc.EnqueueMessage(ctx, payload, nil); err != nil {
+		t.Fatalf("EnqueueMessage: %v", err)
+	}
+
+	peek, err := qc.PeekMessage(ctx, nil)
+	if err != nil {
+		t.Fatalf("PeekMessage: %v", err)
+	}
+
+	if len(peek.Messages) != 1 || peek.Messages[0].MessageText == nil || *peek.Messages[0].MessageText != payload {
+		t.Fatalf("PeekMessage = %+v, want one message %q", peek.Messages, payload)
+	}
+
+	deq, err := qc.DequeueMessage(ctx, nil)
+	if err != nil {
+		t.Fatalf("DequeueMessage: %v", err)
+	}
+
+	if len(deq.Messages) != 1 {
+		t.Fatalf("DequeueMessage returned %d messages, want 1", len(deq.Messages))
+	}
+
+	msg := deq.Messages[0]
+	if msg.MessageText == nil || *msg.MessageText != payload {
+		t.Fatalf("dequeued body = %v, want %q", msg.MessageText, payload)
+	}
+
+	if _, err := qc.DeleteMessage(ctx, *msg.MessageID, *msg.PopReceipt, nil); err != nil {
+		t.Fatalf("DeleteMessage: %v", err)
+	}
+
+	// Enqueue again then clear the whole queue.
+	if _, err := qc.EnqueueMessage(ctx, "to-be-cleared", nil); err != nil {
+		t.Fatalf("EnqueueMessage (2): %v", err)
+	}
+
+	if _, err := qc.ClearMessages(ctx, nil); err != nil {
+		t.Fatalf("ClearMessages: %v", err)
+	}
+
+	after, err := qc.PeekMessage(ctx, nil)
+	if err != nil {
+		t.Fatalf("PeekMessage after clear: %v", err)
+	}
+
+	if len(after.Messages) != 0 {
+		t.Fatalf("queue not empty after ClearMessages: %+v", after.Messages)
+	}
+}
+
+// TestServiceBusUnaffectedOnFullServer confirms a Service Bus flat-queue
+// send/receive round-trip still works end-to-end on the full server.
+func TestServiceBusUnaffectedOnFullServer(t *testing.T) {
+	ts := newFullAzureServer(t)
+	seedSBNamespace(t, ts)
+
+	sbDo(t, ts, http.MethodPut, nsScope()+"/queues/orders"+sbAPIVer, `{"properties":{}}`, http.StatusOK)
+	sbDo(t, ts, http.MethodPost, "/"+sbNS+"/orders/messages", "sb-payload", http.StatusCreated)
+
+	got := sbDo(t, ts, http.MethodDelete, "/"+sbNS+"/orders/messages/head", "", http.StatusOK)
+	if got != "sb-payload" {
+		t.Fatalf("SB received body = %q, want sb-payload", got)
+	}
+}
+
+// TestServiceBusTopicSubUnaffectedOnFullServer confirms topic publish +
+// subscription receive still works on the full server (the subscription path
+// shape is unambiguously Service Bus).
+func TestServiceBusTopicSubUnaffectedOnFullServer(t *testing.T) {
+	ts := newFullAzureServer(t)
+	seedSBNamespace(t, ts)
+
+	sbDo(t, ts, http.MethodPut, nsScope()+"/topics/events"+sbAPIVer, `{"properties":{}}`, http.StatusOK)
+	sbDo(t, ts, http.MethodPut, nsScope()+"/topics/events/subscriptions/s1"+sbAPIVer, `{"properties":{}}`, http.StatusOK)
+
+	// Publish to the topic (fans out to s1).
+	sbDo(t, ts, http.MethodPost, "/"+sbNS+"/events/messages", "topic-payload", http.StatusCreated)
+
+	got := sbDo(t, ts, http.MethodDelete, "/"+sbNS+"/events/subscriptions/s1/messages/head", "", http.StatusOK)
+	if got != "topic-payload" {
+		t.Fatalf("SB subscription body = %q, want topic-payload", got)
+	}
+}
+
+// TestStorageQueueAndServiceBusQueueCoexist confirms a Storage queue and a
+// Service Bus queue with DIFFERENT names both work at the same time on the full
+// server, with no cross-talk.
+func TestStorageQueueAndServiceBusQueueCoexist(t *testing.T) {
+	ts := newFullAzureServer(t)
+	ctx := context.Background()
+
+	// Service Bus queue "sb-queue".
+	seedSBNamespace(t, ts)
+	sbDo(t, ts, http.MethodPut, nsScope()+"/queues/sb-queue"+sbAPIVer, `{"properties":{}}`, http.StatusOK)
+
+	// Storage queue "store-queue".
+	createStorageQueue(t, ts, "store-queue")
+	qc := newStorageQueueClient(t, ts, "store-queue")
+
+	// Enqueue to Storage queue; send to SB queue.
+	if _, err := qc.EnqueueMessage(ctx, "store-msg", nil); err != nil {
+		t.Fatalf("Storage EnqueueMessage: %v", err)
+	}
+
+	sbDo(t, ts, http.MethodPost, "/"+sbNS+"/sb-queue/messages", "sb-msg", http.StatusCreated)
+
+	// Storage queue returns its own message.
+	deq, err := qc.DequeueMessage(ctx, nil)
+	if err != nil {
+		t.Fatalf("Storage DequeueMessage: %v", err)
+	}
+
+	if len(deq.Messages) != 1 || deq.Messages[0].MessageText == nil || *deq.Messages[0].MessageText != "store-msg" {
+		t.Fatalf("Storage dequeue = %+v, want store-msg", deq.Messages)
+	}
+
+	// SB queue returns its own message.
+	got := sbDo(t, ts, http.MethodDelete, "/"+sbNS+"/sb-queue/messages/head", "", http.StatusOK)
+	if got != "sb-msg" {
+		t.Fatalf("SB received body = %q, want sb-msg", got)
+	}
+}
+
+// TestBlobTableRoutingUnaffected smoke-checks that blob and table routing still
+// works on the full server (the routing change must not disturb the other
+// storage data planes).
+func TestBlobTableRoutingUnaffected(t *testing.T) {
+	ts := newFullAzureServer(t)
+	ctx := context.Background()
+
+	// Blob PUT/GET.
+	blobSvc, err := azblob.NewClientWithNoCredential(ts.URL+"/",
+		&azblob.ClientOptions{ClientOptions: anonOpts(ts)})
+	if err != nil {
+		t.Fatalf("new blob client: %v", err)
+	}
+
+	if _, err := blobSvc.CreateContainer(ctx, "c1", nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	if _, err := blobSvc.UploadBuffer(ctx, "c1", "k1", []byte("blob-body"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	dl, err := blobSvc.DownloadStream(ctx, "c1", "k1", nil)
+	if err != nil {
+		t.Fatalf("DownloadStream: %v", err)
+	}
+
+	body, _ := io.ReadAll(dl.Body)
+	_ = dl.Body.Close()
+
+	if string(body) != "blob-body" {
+		t.Fatalf("blob body = %q, want blob-body", string(body))
+	}
+
+	// Table insert/query.
+	tableSvc, err := aztables.NewServiceClientWithNoCredential(ts.URL+"/",
+		&aztables.ClientOptions{ClientOptions: anonOpts(ts)})
+	if err != nil {
+		t.Fatalf("new table client: %v", err)
+	}
+
+	if _, err := tableSvc.CreateTable(ctx, "people", nil); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	tc := tableSvc.NewClient("people")
+
+	entity, _ := json.Marshal(map[string]any{
+		"PartitionKey": "org",
+		"RowKey":       "alice",
+		"Email":        "alice@example.com",
+	})
+
+	if _, err := tc.AddEntity(ctx, entity, nil); err != nil {
+		t.Fatalf("AddEntity: %v", err)
+	}
+
+	got, err := tc.GetEntity(ctx, "org", "alice", nil)
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(got.Value, &out); err != nil {
+		t.Fatalf("unmarshal entity: %v", err)
+	}
+
+	if out["Email"] != "alice@example.com" {
+		t.Fatalf("table entity Email = %v, want alice@example.com", out["Email"])
+	}
+}

--- a/server/azure/servicebus/handler.go
+++ b/server/azure/servicebus/handler.go
@@ -153,14 +153,54 @@ func parseScope(parts []string, providerIdx int) sbPath {
 
 // Matches accepts Service Bus ARM paths plus data-plane URLs ending in
 // /messages or /messages/head.
-func (*Handler) Matches(r *http.Request) bool {
+//
+// The flat "/{entity}/messages" data-plane shape is NOT unique to Service Bus:
+// Azure Queue Storage's azqueue SDK addresses "/{queue}/messages" the same way.
+// Real Azure separates the two by hostname (*.servicebus.windows.net vs
+// *.queue.core.windows.net), which is unavailable behind CloudEmu's shared
+// endpoint. To keep the Queue Storage message plane alive, Service Bus claims a
+// flat "/{entity}/messages" request ONLY when {entity} resolves to a Service
+// Bus queue or topic it actually holds; otherwise it declines so the request
+// falls through to the Queue Storage handler (registered after this one).
+// Subscription-addressed paths ("/{topic}/subscriptions/{sub}/messages") have
+// no Queue Storage counterpart, so they are always Service Bus's to serve.
+func (h *Handler) Matches(r *http.Request) bool {
 	if isDataPlanePath(r.URL.Path) {
-		return true
+		return h.claimsDataPlane(r.URL.Path)
 	}
 
 	_, _, ok := parseSBPath(r.URL.Path)
 
 	return ok
+}
+
+// claimsDataPlane reports whether a data-plane URL addresses a Service Bus
+// entity this handler holds. A subscription path is unambiguously Service Bus.
+// A flat "/{entity}/messages" path (which Queue Storage's azqueue SDK shares)
+// is claimed only when the entity resolves to a known Service Bus queue or
+// topic; an unknown entity is declined so Queue Storage can serve it.
+func (h *Handler) claimsDataPlane(p string) bool {
+	tgt, parsed := parseDataPlanePath(p)
+	if !parsed || tgt.entity == "" {
+		return false
+	}
+
+	if tgt.sub != "" {
+		// A "/{topic}/subscriptions/{sub}/messages" request is Service Bus's to
+		// serve whenever the parent topic exists (Queue Storage has no such
+		// shape). serveSubscriptionData then 404s a missing subscription.
+		_, ok := h.resolveTopicSubURLs(tgt.namespace, tgt.entity)
+
+		return ok
+	}
+
+	if _, ok := h.resolveQueue(tgt.namespace, tgt.entity); ok {
+		return true
+	}
+
+	_, isTopic := h.resolveTopicSubURLs(tgt.namespace, tgt.entity)
+
+	return isTopic
 }
 
 // ServeHTTP routes by URL shape.

--- a/server/azure/servicebus/servicebus_test.go
+++ b/server/azure/servicebus/servicebus_test.go
@@ -201,13 +201,22 @@ func TestDataPlaneSendReceive(t *testing.T) {
 	}
 }
 
-func TestDataPlaneSendToMissingQueue(t *testing.T) {
+// TestDataPlaneUnknownFlatEntityDeclined confirms the Service Bus handler does
+// NOT claim a flat "/{entity}/messages" request for an entity it holds no queue
+// or topic for. That shape is shared with Azure Queue Storage's azqueue SDK, so
+// Service Bus must decline unknown entities and let the Queue Storage handler
+// serve them. With only Service Bus registered here, a declined request reaches
+// no handler and returns 501; in the full server it falls through to Queue
+// Storage. (A genuinely-addressed Service Bus miss still 404s — see
+// TestDataPlaneSubscriptionNotFound for the subscription path.)
+func TestDataPlaneUnknownFlatEntityDeclined(t *testing.T) {
 	srv, _ := newTestServer(t)
 	seedNamespace(t, srv)
 
 	resp := doRequest(t, srv, http.MethodPost, "/"+nsName+"/no-such/messages", "x")
-	if resp.StatusCode != http.StatusNotFound {
-		t.Fatalf("send to missing queue = %d, want 404", resp.StatusCode)
+	if resp.StatusCode != http.StatusNotImplemented {
+		t.Fatalf("send to unknown flat entity = %d, want 501 (Service Bus must decline so Queue Storage can serve it)",
+			resp.StatusCode)
 	}
 }
 


### PR DESCRIPTION
## Summary

Azure Queue Storage's message plane was **entirely dead** in the full wire server. The dispatcher is first-match-wins, and the Service Bus handler (registered before Queue Storage) claimed **any** non-`/subscriptions/` path containing `/messages` via `isDataPlanePath`. So a real `azqueue` SDK call — `POST/GET/DELETE /{queue}/messages` — was swallowed by Service Bus, which found no SB entity named `{queue}` and returned `404 ResourceNotFound`. Queue create/delete/list/metadata have no `/messages` segment, so only the message plane (enqueue/dequeue/peek/delete/clear) was broken.

## Root cause

Both Queue Storage and Service Bus address a flat `/{entity}/messages` URL. Real Azure separates them by hostname (`*.queue.core.windows.net` vs `*.servicebus.windows.net`), which isn't available behind CloudEmu's shared emulator endpoint. Registration order can't disambiguate — both shapes genuinely collide.

## Fix (entity-resolution, least blast radius)

Narrowed the Service Bus data-plane `Matches`: a flat `/{entity}/messages` request is claimed **only when `{entity}` resolves to a Service Bus queue or topic the handler actually holds** (consulting the SB provider store it already owns). Otherwise it declines and the request falls through to the Queue Storage handler. Subscription paths (`/{topic}/subscriptions/{sub}/messages`) have no Queue Storage counterpart, so they remain unambiguously Service Bus (claimed when the parent topic resolves). Because Service Bus is registered first, a name collision still resolves in Service Bus's favor for entities it holds.

### Trade-off (documented)

A flat send to a **non-existent** Service Bus entity is no longer 404'd by Service Bus — it falls through to Queue Storage (which itself 404s an unknown queue). Real Service Bus also requires the entity to exist, so the outcome (a not-found error) is preserved; only the error's wire shape differs. A genuinely-addressed Service Bus miss on the subscription path still 404s correctly. Same-name collision on the namespace-less bare path is a known limitation, consistent with the existing Blob/Queue shared-endpoint collision docs.

## Verification (adversarial, full server)

New `server/azure/queue_servicebus_routing_test.go` boots the **full production server** (`NewFromProvider(cloudemu.NewAzure())` — the same wiring `cloudemu serve` uses) and drives the real `azqueue`/`azblob`/`aztables` SDKs plus the Service Bus REST data plane:

- **Queue plane alive**: azqueue CreateQueue -> EnqueueMessage -> PeekMessage -> DequeueMessage -> DeleteMessage -> EnqueueMessage -> ClearMessages, all succeed (no 404).
- **Service Bus unaffected**: create SB queue via ARM, REST send + receive.
- **SB topic+subscription unaffected**: create topic + subscription, publish to topic, receive on subscription.
- **Coexistence**: a Storage queue and an SB queue with different names both work simultaneously, no cross-talk.
- **Blob/Table unaffected**: blob PUT/GET and table insert/query still route correctly.

The pre-existing `TestDataPlaneSendToMissingQueue` (which encoded the old "SB owns every /messages path" contract) was updated to `TestDataPlaneUnknownFlatEntityDeclined`, asserting the new decline behavior.

## Gates

`go build ./...`, `go vet`, `go test ./server/azure/... ./providers/azure/...`, `go test -race ./server/azure/queue/... ./server/azure/servicebus/...`, root integration `go test .`, `gofmt -l` clean, `golangci-lint` 0 issues on changed packages, `go generate ./...` zero diff, compatgen + `git diff docs/compat/` zero — all green.