### PR TITLE
fix(gcp-gke): honor nodeConfig, node-pool management/oauthScopes, and disabled-autoscaling block on create

### DIFF
--- a/providers/gcp/gke/gke.go
+++ b/providers/gcp/gke/gke.go
@@ -84,21 +84,23 @@ type Cluster struct {
 
 // NodePool is the in-memory representation of a GKE node pool.
 type NodePool struct {
-	Name              string
-	ClusterName       string
-	Location          string
-	NodeCount         int64
-	MachineType       string
-	DiskSizeGB        int64
-	Version           string
-	AutoscalingMin    int64
-	AutoscalingMax    int64
-	AutoscalingOn     bool
-	AutoUpgrade       bool
-	AutoRepair        bool
-	Status            string
-	UpgradeRolledBack bool
-	CreatedAt         time.Time
+	Name                  string
+	ClusterName           string
+	Location              string
+	NodeCount             int64
+	MachineType           string
+	DiskSizeGB            int64
+	OauthScopes           []string
+	Version               string
+	AutoscalingMin        int64
+	AutoscalingMax        int64
+	AutoscalingOn         bool
+	AutoscalingConfigured bool
+	AutoUpgrade           bool
+	AutoRepair            bool
+	Status                string
+	UpgradeRolledBack     bool
+	CreatedAt             time.Time
 }
 
 // Operation tracks GKE long-running operations. The mock completes every
@@ -256,7 +258,24 @@ type CreateClusterInput struct {
 	LoggingService    string
 	MonitoringService string
 	ResourceLabels    map[string]string
+	NodeConfig        *NodeConfigSpec
 	NodePools         []NodePoolSpec
+}
+
+// NodeConfigSpec captures the cluster-level nodeConfig that seeds the
+// auto-created default node pool when no explicit node pools are given.
+type NodeConfigSpec struct {
+	MachineType string
+	DiskSizeGB  int64
+	OauthScopes []string
+}
+
+// NodePoolManagement captures the node auto-management flags a create request
+// may set. A nil pointer means the request omitted the management block, so the
+// mock applies GKE's true/true defaults.
+type NodePoolManagement struct {
+	AutoUpgrade bool
+	AutoRepair  bool
 }
 
 // NodePoolSpec captures the node-pool fields we keep when bootstrapping a
@@ -266,10 +285,12 @@ type NodePoolSpec struct {
 	InitialNodeCount int64
 	MachineType      string
 	DiskSizeGB       int64
+	OauthScopes      []string
 	Version          string
 	AutoscalingMin   int64
 	AutoscalingMax   int64
 	AutoscalingOn    bool
+	Management       *NodePoolManagement
 }
 
 // CreateCluster registers a new cluster and any nested node pools.
@@ -309,7 +330,9 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 		CreatedAt:         m.opts.Clock.Now().UTC(),
 	}
 
-	// Bootstrap default node pool when none specified — matches real GKE.
+	// Bootstrap default node pool when none specified — matches real GKE. The
+	// cluster-level nodeConfig (when present) configures that pool; absent
+	// fields fall back to defaults via nodePoolFromSpec.
 	pools := input.NodePools
 	if len(pools) == 0 {
 		count := input.InitialNodeCount
@@ -317,13 +340,19 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 			count = defaultNodeCount
 		}
 
-		pools = []NodePoolSpec{{
+		spec := NodePoolSpec{
 			Name:             "default-pool",
 			InitialNodeCount: count,
-			MachineType:      defaultMachineType,
-			DiskSizeGB:       defaultDiskSizeGB,
 			Version:          stubNodeVersion,
-		}}
+		}
+
+		if nc := input.NodeConfig; nc != nil {
+			spec.MachineType = nc.MachineType
+			spec.DiskSizeGB = nc.DiskSizeGB
+			spec.OauthScopes = nc.OauthScopes
+		}
+
+		pools = []NodePoolSpec{spec}
 	}
 
 	for i := range pools {
@@ -358,6 +387,14 @@ func nodePoolFromSpec(spec *NodePoolSpec, clusterName, location string, now time
 		count = defaultNodeCount
 	}
 
+	// GKE defaults auto-upgrade/auto-repair to true; an explicit management
+	// block (even one setting them false) must survive the round-trip.
+	autoUpgrade, autoRepair := true, true
+	if spec.Management != nil {
+		autoUpgrade = spec.Management.AutoUpgrade
+		autoRepair = spec.Management.AutoRepair
+	}
+
 	return NodePool{
 		Name:           spec.Name,
 		ClusterName:    clusterName,
@@ -365,12 +402,13 @@ func nodePoolFromSpec(spec *NodePoolSpec, clusterName, location string, now time
 		NodeCount:      count,
 		MachineType:    defaultIfEmpty(spec.MachineType, defaultMachineType),
 		DiskSizeGB:     defaultIfZero(spec.DiskSizeGB, defaultDiskSizeGB),
+		OauthScopes:    spec.OauthScopes,
 		Version:        defaultIfEmpty(spec.Version, stubNodeVersion),
 		AutoscalingMin: spec.AutoscalingMin,
 		AutoscalingMax: spec.AutoscalingMax,
 		AutoscalingOn:  spec.AutoscalingOn,
-		AutoUpgrade:    true,
-		AutoRepair:     true,
+		AutoUpgrade:    autoUpgrade,
+		AutoRepair:     autoRepair,
 		Status:         "RUNNING",
 		CreatedAt:      now,
 	}
@@ -705,6 +743,7 @@ func (m *Mock) SetNodePoolAutoscaling(
 		np.AutoscalingOn = on
 		np.AutoscalingMin = minNodes
 		np.AutoscalingMax = maxNodes
+		np.AutoscalingConfigured = true
 	})
 }
 

--- a/server/gcp/gke/operations.go
+++ b/server/gcp/gke/operations.go
@@ -29,6 +29,14 @@ func (h *Handler) createCluster(w http.ResponseWriter, r *http.Request, p *gkePa
 		ResourceLabels:    body.Cluster.ResourceLabels,
 	}
 
+	if nc := body.Cluster.NodeConfig; nc != nil {
+		in.NodeConfig = &gke.NodeConfigSpec{
+			MachineType: nc.MachineType,
+			DiskSizeGB:  nc.DiskSizeGb,
+			OauthScopes: nc.OauthScopes,
+		}
+	}
+
 	for i := range body.Cluster.NodePools {
 		in.NodePools = append(in.NodePools, nodePoolSpecFromWire(&body.Cluster.NodePools[i]))
 	}
@@ -52,12 +60,20 @@ func nodePoolSpecFromWire(np *gkeNodePool) gke.NodePoolSpec {
 	if np.Config != nil {
 		spec.MachineType = np.Config.MachineType
 		spec.DiskSizeGB = np.Config.DiskSizeGb
+		spec.OauthScopes = np.Config.OauthScopes
 	}
 
 	if np.Autoscaling != nil {
 		spec.AutoscalingOn = np.Autoscaling.Enabled
 		spec.AutoscalingMin = np.Autoscaling.MinNodeCount
 		spec.AutoscalingMax = np.Autoscaling.MaxNodeCount
+	}
+
+	if np.Management != nil {
+		spec.Management = &gke.NodePoolManagement{
+			AutoUpgrade: np.Management.AutoUpgrade,
+			AutoRepair:  np.Management.AutoRepair,
+		}
 	}
 
 	return spec

--- a/server/gcp/gke/sdk_create_fields_test.go
+++ b/server/gcp/gke/sdk_create_fields_test.go
@@ -1,0 +1,183 @@
+// Reproduction tests for the GKE create-path field-drop bugs: cluster-level
+// nodeConfig seeding the default pool (B1), node-pool management + oauthScopes
+// round-tripping on create (B2), and a disabled autoscaling block surviving as
+// {enabled:false} rather than a nil pointer (B3).
+
+package gke_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/api/container/v1"
+)
+
+const (
+	cfMachineType = "n1-standard-4"
+	cfDiskSizeGb  = 250
+	cfOauthScope  = "https://www.googleapis.com/auth/cloud-platform"
+)
+
+// TestSDKGKEClusterNodeConfigSeedsDefaultPool proves the cluster-level
+// nodeConfig{machineType,diskSizeGb,oauthScopes} configures the auto-created
+// default node pool instead of being replaced with hardcoded defaults (B1).
+func TestSDKGKEClusterNodeConfigSeedsDefaultPool(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{
+			Name:             "cfg",
+			InitialNodeCount: 1,
+			NodeConfig: &container.NodeConfig{
+				MachineType: cfMachineType,
+				DiskSizeGb:  cfDiskSizeGb,
+				OauthScopes: []string{cfOauthScope},
+			},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.Get(clusterName(project, loc, "cfg")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if len(got.NodePools) == 0 || got.NodePools[0].Config == nil {
+		t.Fatal("expected a default node pool with config")
+	}
+
+	cfg := got.NodePools[0].Config
+	if cfg.MachineType != cfMachineType {
+		t.Fatalf("machineType = %q, want %q", cfg.MachineType, cfMachineType)
+	}
+
+	if cfg.DiskSizeGb != cfDiskSizeGb {
+		t.Fatalf("diskSizeGb = %d, want %d", cfg.DiskSizeGb, cfDiskSizeGb)
+	}
+
+	if len(cfg.OauthScopes) != 1 || cfg.OauthScopes[0] != cfOauthScope {
+		t.Fatalf("oauthScopes = %v, want [%s]", cfg.OauthScopes, cfOauthScope)
+	}
+}
+
+// TestSDKGKENodePoolManagementAndOAuthRoundTrip proves an explicit management
+// block (autoUpgrade/autoRepair false) and config.oauthScopes survive a
+// CreateNodePool round-trip (B2).
+func TestSDKGKENodePoolManagementAndOAuthRoundTrip(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+	parentClus := clusterName(project, loc, "mgmt")
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "mgmt"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.NodePools.Create(parentClus, &container.CreateNodePoolRequest{
+		NodePool: &container.NodePool{
+			Name:             "custom",
+			InitialNodeCount: 1,
+			Config:           &container.NodeConfig{OauthScopes: []string{cfOauthScope}},
+			Management:       &container.NodeManagement{AutoUpgrade: false, AutoRepair: false},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("nodepool create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.NodePools.Get(nodePoolName(project, loc, "mgmt", "custom")).
+		Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("nodepool get: %v", err)
+	}
+
+	if got.Management == nil {
+		t.Fatal("expected management block")
+	}
+
+	if got.Management.AutoUpgrade || got.Management.AutoRepair {
+		t.Fatalf("management = %+v, want autoUpgrade=false autoRepair=false", got.Management)
+	}
+
+	if got.Config == nil || len(got.Config.OauthScopes) != 1 || got.Config.OauthScopes[0] != cfOauthScope {
+		t.Fatalf("oauthScopes not round-tripped: %+v", got.Config)
+	}
+}
+
+// TestSDKGKENodePoolManagementDefaultsWhenAbsent proves a node pool created
+// WITHOUT a management block still defaults autoUpgrade/autoRepair to true (B2).
+func TestSDKGKENodePoolManagementDefaultsWhenAbsent(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+	parentClus := clusterName(project, loc, "defs")
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "defs"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.NodePools.Create(parentClus, &container.CreateNodePoolRequest{
+		NodePool: &container.NodePool{Name: "plain", InitialNodeCount: 1},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("nodepool create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.NodePools.Get(nodePoolName(project, loc, "defs", "plain")).
+		Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("nodepool get: %v", err)
+	}
+
+	if got.Management == nil || !got.Management.AutoUpgrade || !got.Management.AutoRepair {
+		t.Fatalf("management = %+v, want autoUpgrade=true autoRepair=true", got.Management)
+	}
+}
+
+// TestSDKGKEDisabledAutoscalingEmitsBlock proves that after disabling
+// autoscaling, GetNodePool returns autoscaling{enabled:false} rather than a nil
+// pointer, so a client reading .Autoscaling.Enabled sees the disable (B3).
+func TestSDKGKEDisabledAutoscalingEmitsBlock(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+	parentClus := clusterName(project, loc, "as")
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "as"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.NodePools.Create(parentClus, &container.CreateNodePoolRequest{
+		NodePool: &container.NodePool{Name: "pool", InitialNodeCount: 1},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("nodepool create: %v", err)
+	}
+
+	npFull := nodePoolName(project, loc, "as", "pool")
+	if _, err := svc.Projects.Locations.Clusters.NodePools.SetAutoscaling(npFull,
+		&container.SetNodePoolAutoscalingRequest{
+			Autoscaling: &container.NodePoolAutoscaling{Enabled: false},
+		}).Context(ctx).Do(); err != nil {
+		t.Fatalf("setAutoscaling: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.NodePools.Get(npFull).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("nodepool get: %v", err)
+	}
+
+	if got.Autoscaling == nil {
+		t.Fatal("autoscaling block missing after disable, want {enabled:false}")
+	}
+
+	if got.Autoscaling.Enabled {
+		t.Fatalf("autoscaling.enabled = true, want false")
+	}
+}

--- a/server/gcp/gke/types.go
+++ b/server/gcp/gke/types.go
@@ -21,6 +21,7 @@ type gkeCluster struct {
 	Network           string            `json:"network,omitempty"`
 	Subnetwork        string            `json:"subnetwork,omitempty"`
 	InitialNodeCount  int64             `json:"initialNodeCount,omitempty"`
+	NodeConfig        *gkeNodeConfig    `json:"nodeConfig,omitempty"`
 	CurrentNodeCount  int64             `json:"currentNodeCount,omitempty"`
 	LoggingService    string            `json:"loggingService,omitempty"`
 	MonitoringService string            `json:"monitoringService,omitempty"`
@@ -59,12 +60,15 @@ type gkeNodePool struct {
 }
 
 type gkeNodeConfig struct {
-	MachineType string `json:"machineType,omitempty"`
-	DiskSizeGb  int64  `json:"diskSizeGb,omitempty"`
+	MachineType string   `json:"machineType,omitempty"`
+	DiskSizeGb  int64    `json:"diskSizeGb,omitempty"`
+	OauthScopes []string `json:"oauthScopes,omitempty"`
 }
 
 type gkeAutoscaling struct {
-	Enabled      bool  `json:"enabled,omitempty"`
+	// Enabled has no omitempty so a disabled pool still emits {enabled:false}
+	// rather than dropping the field — clients read it to confirm the disable.
+	Enabled      bool  `json:"enabled"`
 	MinNodeCount int64 `json:"minNodeCount,omitempty"`
 	MaxNodeCount int64 `json:"maxNodeCount,omitempty"`
 }
@@ -255,6 +259,7 @@ func toNodePoolResource(np *gke.NodePool, project string) gkeNodePool {
 		Config: &gkeNodeConfig{
 			MachineType: np.MachineType,
 			DiskSizeGb:  np.DiskSizeGB,
+			OauthScopes: np.OauthScopes,
 		},
 		Management: &gkeNodeManagement{
 			AutoUpgrade: np.AutoUpgrade,
@@ -265,11 +270,15 @@ func toNodePoolResource(np *gke.NodePool, project string) gkeNodePool {
 			"/clusters/" + np.ClusterName + "/nodePools/" + np.Name,
 	}
 
-	if np.AutoscalingOn || np.AutoscalingMin > 0 || np.AutoscalingMax > 0 {
-		out.Autoscaling = &gkeAutoscaling{
-			Enabled:      np.AutoscalingOn,
-			MinNodeCount: np.AutoscalingMin,
-			MaxNodeCount: np.AutoscalingMax,
+	// Emit the autoscaling block whenever the pool has it enabled or has been
+	// explicitly configured (e.g. disabled via :setAutoscaling), so a client
+	// confirming a disable reads {enabled:false} instead of a nil pointer. When
+	// disabled, min/max are omitted.
+	if np.AutoscalingOn || np.AutoscalingConfigured || np.AutoscalingMin > 0 || np.AutoscalingMax > 0 {
+		out.Autoscaling = &gkeAutoscaling{Enabled: np.AutoscalingOn}
+		if np.AutoscalingOn {
+			out.Autoscaling.MinNodeCount = np.AutoscalingMin
+			out.Autoscaling.MaxNodeCount = np.AutoscalingMax
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes three GKE (container.googleapis.com) create-path field-drop bugs where fields sent on the most common create paths were silently dropped, causing Terraform drift and broken round-trips.

**Bug 1 (HIGH) — cluster-level nodeConfig dropped on CreateCluster.** `Cluster{initialNodeCount, nodeConfig:{machineType,diskSizeGb,oauthScopes}}` should configure the auto-created default node pool, but only initialNodeCount propagated — machineType/diskSizeGb/oauthScopes were replaced with hardcoded defaults (e2-medium/100/[]). The bootstrap `default-pool` spec is now seeded from the cluster-level nodeConfig, falling back to defaults only when a field is absent.

**Bug 2 (MED) — node-pool management + config.oauthScopes dropped on create.** `NodePool{management:{autoUpgrade,autoRepair}, config:{oauthScopes}}` on CreateNodePool (and cluster.nodePools[]) previously returned hardcoded autoUpgrade=true/autoRepair=true and oauth=[]. Now round-trips via GetNodePool; management defaults to true/true ONLY when the wire `management` block is absent (an explicit false survives). The `:setManagement` path is unchanged.

**Bug 3 (LOW) — disabling autoscaling omitted the block.** After SetNodePoolAutoscaling(enabled=false), the whole autoscaling block was gated behind `on || min>0 || max>0` and returned nil. It now emits `{enabled:false}` (min/max omitted when disabled) so a client reading `.Autoscaling.Enabled` sees the disable.

Out-of-scope deferrals (releaseChannel, ipAllocationPolicy, update-mask addons/imageType, extra NodeConfig fields, addons/privateCluster/workloadIdentity/autopilot) are intentionally not implemented here.

## Tests

Added real `google.golang.org/api/container/v1` SDK e2e tests against the booted wire server (`server/gcp/gke/sdk_create_fields_test.go`):
- CreateCluster with nodeConfig{n1-standard-4, 250, cloud-platform} → GetCluster default-pool reflects all three (B1)
- CreateNodePool with management{false,false}+oauthScopes → GetNodePool round-trips (B2)
- CreateNodePool WITHOUT management → still defaults to true/true (B2)
- SetNodePoolAutoscaling(false) → GetNodePool autoscaling.enabled==false, not nil (B3)

## Gates
build, vet, targeted + -race tests, gofmt, golangci-lint (0 issues), go generate (zero diff), compatgen + docs/compat diff (clean) — all green.