### PR TITLE
fix(azure): Queue Storage message-plane semantics (metadata, receipts, times, idempotency)

### DIFF
--- a/providers/azure/servicebus/servicebus.go
+++ b/providers/azure/servicebus/servicebus.go
@@ -154,6 +154,11 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		tags[k] = v
 	}
 
+	metadata := make(map[string]string, len(cfg.Metadata))
+	for k, v := range cfg.Metadata {
+		metadata[k] = v
+	}
+
 	visibilityTimeout := cfg.VisibilityTimeout
 	if visibilityTimeout == 0 {
 		visibilityTimeout = defaultVisibilityTimeout
@@ -182,7 +187,7 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		deduplicationIndex:     make(map[string]time.Time),
 		dlqConfig:              cfg.DeadLetterQueue,
 		deadLetterOnExpiration: cfg.DeadLetterOnExpiration,
-		metadata:               make(map[string]string),
+		metadata:               metadata,
 	}
 
 	m.queues.Set(url, qd)
@@ -292,6 +297,12 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 	// For a non-scheduled send visibleAt == now, so this is unchanged.
 	expiresAt := computeExpiry(visibleAt, input.MessageTTLSeconds)
 
+	// Mint a pop receipt at enqueue time so the message can be deleted or updated
+	// with the Put Message-returned receipt before its first dequeue, as Azure
+	// Queue Storage allows. A subsequent dequeue issues a fresh receipt that
+	// supersedes this one.
+	receiptHandle := idgen.GenerateID("sb-lock-")
+
 	msg := &sbMessage{
 		ID:              msgID,
 		Body:            input.Body,
@@ -299,6 +310,7 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		DeduplicationID: input.DeduplicationID,
 		Attributes:      attrs,
 		SystemProps:     sysProps,
+		ReceiptHandle:   receiptHandle,
 		VisibleAt:       visibleAt,
 		SentAt:          now,
 		ExpiresAt:       expiresAt,
@@ -331,8 +343,9 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 	})
 
 	return &driver.SendMessageOutput{
-		MessageID: msgID,
-		ExpiresAt: expiresAt,
+		MessageID:  msgID,
+		ExpiresAt:  expiresAt,
+		PopReceipt: receiptHandle,
 	}, nil
 }
 
@@ -517,6 +530,7 @@ func buildReceivedMessage(msg *sbMessage, visibilityTimeout int, now time.Time) 
 		GroupID:          msg.GroupID,
 		ReceiveCount:     msg.ReceiveCount,
 		ExpiresAt:        msg.ExpiresAt,
+		InsertedAt:       msg.SentAt,
 	}
 }
 

--- a/server/azure/queue/handler.go
+++ b/server/azure/queue/handler.go
@@ -23,6 +23,7 @@ package queue
 import (
 	"encoding/xml"
 	"io"
+	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -57,6 +58,11 @@ const (
 	// defaultMessageTTLSeconds is the message time-to-live Put Message applies
 	// when the messagettl query parameter is omitted.
 	defaultMessageTTLSeconds = 7 * 24 * 60 * 60
+
+	// defaultVisibilityTimeoutSeconds is the visibility timeout Get Messages applies
+	// when the visibilitytimeout query parameter is omitted, matching the driver's
+	// effective default; used only to report TimeNextVisible on the dequeue response.
+	defaultVisibilityTimeoutSeconds = 30
 
 	// neverExpireTTL is the messagettl value meaning "the message never expires".
 	neverExpireTTL = -1
@@ -252,12 +258,12 @@ func setQueueMetadata(w http.ResponseWriter, r *http.Request, svc mqdriver.Azure
 }
 
 func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request, queue string) {
-	_, err := h.mq.CreateQueue(r.Context(), mqdriver.QueueConfig{Name: queue})
+	metadata := metadataFromHeaders(r.Header)
+
+	_, err := h.mq.CreateQueue(r.Context(), mqdriver.QueueConfig{Name: queue, Metadata: metadata})
 	if err != nil {
-		// Azure returns 204 No Content when the queue already exists with the
-		// same metadata (idempotent create).
 		if cerrors.IsAlreadyExists(err) {
-			w.WriteHeader(http.StatusNoContent)
+			h.handleDuplicateCreate(w, r, queue, metadata)
 			return
 		}
 
@@ -267,6 +273,36 @@ func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request, queue stri
 	}
 
 	w.WriteHeader(http.StatusCreated)
+}
+
+// handleDuplicateCreate resolves the idempotency of a Create Queue on a name that
+// already exists: Azure returns 204 No Content when the requested metadata matches
+// the existing queue's, and 409 QueueAlreadyExists when it differs.
+func (h *Handler) handleDuplicateCreate(w http.ResponseWriter, r *http.Request, queue string, requested map[string]string) {
+	svc, ok := h.mq.(mqdriver.AzureQueueStorage)
+	if !ok {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	url, err := h.resolveQueueURL(r, queue)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	meta, err := svc.GetQueueMetadata(r.Context(), url)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if maps.Equal(requested, meta.Metadata) {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	writeError(w, http.StatusConflict, "QueueAlreadyExists", "The specified queue already exists.")
 }
 
 func (h *Handler) deleteQueue(w http.ResponseWriter, r *http.Request, queue string) {
@@ -363,7 +399,7 @@ func (h *Handler) enqueue(w http.ResponseWriter, r *http.Request, queue string) 
 		MessageID:       out.MessageID,
 		InsertionTime:   now.Format(time.RFC1123),
 		ExpirationTime:  displayExpiry(out.ExpiresAt).UTC().Format(time.RFC1123),
-		PopReceipt:      out.MessageID,
+		PopReceipt:      out.PopReceipt,
 		TimeNextVisible: now.Add(time.Duration(visTimeout) * time.Second).Format(time.RFC1123),
 	}}}
 
@@ -393,16 +429,24 @@ func (h *Handler) dequeue(w http.ResponseWriter, r *http.Request, queue string) 
 	}
 
 	now := time.Now().UTC()
+	// The driver defaults an omitted visibilitytimeout to 30s; mirror that so the
+	// reported TimeNextVisible matches when the message actually reappears.
+	effectiveVis := visTimeout
+	if effectiveVis == 0 {
+		effectiveVis = defaultVisibilityTimeoutSeconds
+	}
+
+	timeNextVisible := now.Add(time.Duration(effectiveVis) * time.Second).Format(time.RFC1123)
 	out := messagesList{}
 
 	for i := range msgs {
 		m := &msgs[i]
 		out.Messages = append(out.Messages, messageXML{
 			MessageID:       m.MessageID,
-			InsertionTime:   now.Format(time.RFC1123),
+			InsertionTime:   m.InsertedAt.UTC().Format(time.RFC1123),
 			ExpirationTime:  displayExpiry(m.ExpiresAt).UTC().Format(time.RFC1123),
 			PopReceipt:      m.ReceiptHandle,
-			TimeNextVisible: now.Add(time.Duration(visTimeout) * time.Second).Format(time.RFC1123),
+			TimeNextVisible: timeNextVisible,
 			DequeueCount:    int64(m.ReceiveCount),
 			MessageText:     m.Body,
 		})
@@ -508,7 +552,15 @@ func (h *Handler) deleteMessage(w http.ResponseWriter, r *http.Request, queue st
 	}
 
 	if err := h.mq.DeleteMessage(r.Context(), url, popReceipt); err != nil {
+		// The queue was already resolved, so a NotFound here means the message or
+		// its pop receipt did not match — Azure returns 404 MessageNotFound.
+		if cerrors.IsNotFound(err) {
+			writeError(w, http.StatusNotFound, "MessageNotFound", err.Error())
+			return
+		}
+
 		writeErr(w, err)
+
 		return
 	}
 

--- a/server/azure/queue/message_semantics_test.go
+++ b/server/azure/queue/message_semantics_test.go
@@ -1,0 +1,215 @@
+package queue_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// minVisibilityGap is the lower bound we require between a dequeued message's
+// InsertionTime and TimeNextVisible: the driver defaults an omitted visibility
+// timeout to 30s, so the gap must be clearly non-zero (the pre-fix bug reported
+// TimeNextVisible == dequeue time, a ~0 gap).
+const minVisibilityGap = 20 * time.Second
+
+// newFullServerClient stands up the full Azure wire server from a real provider
+// (NewFromProvider) and returns an azqueue service client pointed at it, plus the
+// test server so callers can build per-queue clients that share its transport.
+func newFullServerClient(t *testing.T) (*azqueue.ServiceClient, *httptest.Server) {
+	t.Helper()
+
+	srv := azureserver.NewFromProvider(cloudemu.NewAzure())
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := azqueue.NewServiceClientWithNoCredential(ts.URL+"/", clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewServiceClientWithNoCredential: %v", err)
+	}
+
+	return svc, ts
+}
+
+func clientOpts(ts *httptest.Server) *azqueue.ClientOptions {
+	return &azqueue.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}},
+	}
+}
+
+func queueClientFor(t *testing.T, ts *httptest.Server, name string) *azqueue.QueueClient {
+	t.Helper()
+
+	qc, err := azqueue.NewQueueClientWithNoCredential(ts.URL+"/"+name, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewQueueClientWithNoCredential: %v", err)
+	}
+
+	return qc
+}
+
+// TestQueueCreateMetadataRoundTrips (BUG 1): metadata supplied on Create Queue is
+// persisted and returned by Get Properties.
+func TestQueueCreateMetadataRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	svc, ts := newFullServerClient(t)
+
+	// HTTP header canonicalization title-cases metadata keys, so use a canonical key.
+	opts := &azqueue.CreateOptions{Metadata: map[string]*string{"Team": to.Ptr("payments")}}
+	if _, err := svc.CreateQueue(ctx, "b1q", opts); err != nil {
+		t.Fatalf("CreateQueue with metadata: %v", err)
+	}
+
+	props, err := queueClientFor(t, ts, "b1q").GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties: %v", err)
+	}
+
+	if v, ok := props.Metadata["Team"]; !ok || v == nil || *v != "payments" {
+		t.Errorf("metadata Team = %v, want payments", props.Metadata["Team"])
+	}
+}
+
+// TestQueueDeleteStaleReceiptIsMessageNotFound (BUG 2): deleting with a pop
+// receipt that no longer matches returns 404 MessageNotFound, not QueueNotFound.
+func TestQueueDeleteStaleReceiptIsMessageNotFound(t *testing.T) {
+	ctx := context.Background()
+	svc, ts := newFullServerClient(t)
+
+	if _, err := svc.CreateQueue(ctx, "b2q", nil); err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	qc := queueClientFor(t, ts, "b2q")
+
+	enq, err := qc.EnqueueMessage(ctx, "m", nil)
+	if err != nil {
+		t.Fatalf("EnqueueMessage: %v", err)
+	}
+
+	msgID := *enq.Messages[0].MessageID
+
+	// A dequeue issues a fresh pop receipt, so the enqueue receipt is now stale.
+	if _, err := qc.DequeueMessage(ctx, nil); err != nil {
+		t.Fatalf("DequeueMessage: %v", err)
+	}
+
+	stale := *enq.Messages[0].PopReceipt
+
+	_, err = qc.DeleteMessage(ctx, msgID, stale, nil)
+	if err == nil || !strings.Contains(err.Error(), "MessageNotFound") {
+		t.Errorf("delete with stale receipt: got %v, want MessageNotFound", err)
+	}
+}
+
+// TestQueueEnqueueReceiptUsableBeforeDequeue (BUG 3): the pop receipt returned by
+// Put Message can delete the message before any dequeue.
+func TestQueueEnqueueReceiptUsableBeforeDequeue(t *testing.T) {
+	ctx := context.Background()
+	svc, ts := newFullServerClient(t)
+
+	if _, err := svc.CreateQueue(ctx, "b3q", nil); err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	qc := queueClientFor(t, ts, "b3q")
+
+	enq, err := qc.EnqueueMessage(ctx, "m", nil)
+	if err != nil {
+		t.Fatalf("EnqueueMessage: %v", err)
+	}
+
+	msg := enq.Messages[0]
+	if msg.MessageID == nil || msg.PopReceipt == nil {
+		t.Fatalf("enqueue returned no id/popreceipt: %+v", msg)
+	}
+
+	// Delete using the enqueue-returned receipt, without dequeuing first.
+	if _, err := qc.DeleteMessage(ctx, *msg.MessageID, *msg.PopReceipt, nil); err != nil {
+		t.Fatalf("DeleteMessage with enqueue receipt: %v", err)
+	}
+
+	peek, err := qc.PeekMessages(ctx, &azqueue.PeekMessagesOptions{NumberOfMessages: to.Ptr(int32(1))})
+	if err != nil {
+		t.Fatalf("PeekMessages: %v", err)
+	}
+
+	if len(peek.Messages) != 0 {
+		t.Errorf("queue still has %d messages after delete, want 0", len(peek.Messages))
+	}
+}
+
+// TestQueueDequeueReportsAccurateTimes (BUG 4): InsertionTime is the enqueue time
+// and TimeNextVisible is in the future by the effective (defaulted) visibility.
+func TestQueueDequeueReportsAccurateTimes(t *testing.T) {
+	ctx := context.Background()
+	svc, ts := newFullServerClient(t)
+
+	if _, err := svc.CreateQueue(ctx, "b4q", nil); err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	qc := queueClientFor(t, ts, "b4q")
+
+	before := time.Now()
+
+	if _, err := qc.EnqueueMessage(ctx, "m", nil); err != nil {
+		t.Fatalf("EnqueueMessage: %v", err)
+	}
+
+	deq, err := qc.DequeueMessage(ctx, nil)
+	if err != nil {
+		t.Fatalf("DequeueMessage: %v", err)
+	}
+
+	after := time.Now()
+
+	m := deq.Messages[0]
+	if m.InsertionTime == nil || m.TimeNextVisible == nil {
+		t.Fatalf("dequeue missing times: %+v", m)
+	}
+
+	// InsertionTime must be the enqueue instant, inside the test's real-time window
+	// (RFC1123 truncates to whole seconds, hence the 1s slack).
+	if m.InsertionTime.Before(before.Add(-time.Second)) || m.InsertionTime.After(after.Add(time.Second)) {
+		t.Errorf("InsertionTime %v outside enqueue window [%v, %v]", *m.InsertionTime, before, after)
+	}
+
+	// TimeNextVisible must be pushed out by the driver's effective 30s default.
+	if gap := m.TimeNextVisible.Sub(*m.InsertionTime); gap < minVisibilityGap {
+		t.Errorf("TimeNextVisible gap = %v, want >= %v (30s default applied)", gap, minVisibilityGap)
+	}
+}
+
+// TestQueueDuplicateCreateIdempotency (BUG 5): a duplicate Create with identical
+// metadata is a 204 no-op; different metadata is a 409 QueueAlreadyExists.
+func TestQueueDuplicateCreateIdempotency(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newFullServerClient(t)
+
+	same := &azqueue.CreateOptions{Metadata: map[string]*string{"Team": to.Ptr("payments")}}
+	if _, err := svc.CreateQueue(ctx, "b5q", same); err != nil {
+		t.Fatalf("initial CreateQueue: %v", err)
+	}
+
+	// Identical metadata -> idempotent success (204).
+	if _, err := svc.CreateQueue(ctx, "b5q", same); err != nil {
+		t.Errorf("duplicate CreateQueue with identical metadata: got %v, want success", err)
+	}
+
+	// Different metadata -> 409 QueueAlreadyExists.
+	diff := &azqueue.CreateOptions{Metadata: map[string]*string{"Team": to.Ptr("billing")}}
+
+	_, err := svc.CreateQueue(ctx, "b5q", diff)
+	if err == nil || !strings.Contains(err.Error(), "QueueAlreadyExists") {
+		t.Errorf("duplicate CreateQueue with different metadata: got %v, want QueueAlreadyExists", err)
+	}
+}

--- a/services/messagequeue/driver/driver.go
+++ b/services/messagequeue/driver/driver.go
@@ -38,6 +38,11 @@ type QueueConfig struct {
 	// omitted value (defaulted to 30). The wire handler sets it from attribute
 	// presence; the typed Go API leaves it false, where 0 means "use the default".
 	VisibilityTimeoutSet bool
+
+	// Metadata is Azure Queue Storage's user metadata (the x-ms-meta-* headers on
+	// Create Queue), persisted so Get Queue Metadata / Get Properties returns it.
+	// Ignored by non-Azure providers.
+	Metadata map[string]string
 }
 
 // DeadLetterConfig configures a dead-letter queue for failed messages.
@@ -96,6 +101,11 @@ type SendMessageOutput struct {
 	// MessageTTLSeconds (Azure Queue Storage). Providers that don't track
 	// per-message TTL leave it zero.
 	ExpiresAt time.Time
+	// PopReceipt is the pop receipt minted for the just-enqueued message (Azure
+	// Queue Storage Put Message), usable to delete or update the message before
+	// its first dequeue. Providers that don't issue enqueue-time receipts leave
+	// it empty.
+	PopReceipt string
 }
 
 // ReceiveMessageInput configures a message receive operation.
@@ -126,6 +136,9 @@ type Message struct {
 	// ExpiresAt is the message's absolute expiration time (Azure Queue Storage's
 	// per-message TTL). Providers that don't track per-message TTL leave it zero.
 	ExpiresAt time.Time
+	// InsertedAt is the message's enqueue time, surfaced by Azure Queue Storage as
+	// InsertionTime. Providers that don't track it leave it zero.
+	InsertedAt time.Time
 	// SystemProperties carries Azure Service Bus brokered-message system
 	// properties preserved from the send (see SendMessageInput.SystemProperties).
 	SystemProperties map[string]string


### PR DESCRIPTION
## Summary

Fixes five Azure Queue Storage message-plane bugs, verified end-to-end against the full wire server (`azureserver.NewFromProvider(cloudemu.NewAzure())`) with the real `azqueue` SDK. These were previously e2e-blocked behind the Queue↔Service Bus routing fix (#710), now merged.

1. **CreateQueue metadata dropped** — `x-ms-meta-*` headers on Create Queue were ignored. Added `QueueConfig.Metadata`, persisted it in the provider, and populated it in the handler via the existing `metadataFromHeaders` helper. Get Properties / Get Metadata now returns it.
2. **DeleteMessage wrong error code** — a stale/invalid pop receipt returned `QueueNotFound`; now returns 404 `MessageNotFound`, mirroring the Update Message path.
3. **Enqueue pop receipt unusable until first dequeue** — Put Message returned the message ID as the pop receipt, but the stored receipt was empty until dequeue, so delete/update of a just-enqueued message failed. The provider now mints a real pop receipt at enqueue time and returns it (`SendMessageOutput.PopReceipt`); a later dequeue supersedes it, matching Azure.
4. **Dequeue reported times wrong** — response reported `InsertionTime = now` and `TimeNextVisible = now + rawVisibilityTimeout` (so `= now` when omitted). Added an insertion timestamp to the message model; the dequeue response now reports the actual enqueue time and `TimeNextVisible` pushed out by the effective visibility (30s default applied).
5. **Duplicate CreateQueue idempotency** — a duplicate create always returned 204. Now 204 when the requested metadata matches the existing queue's, and 409 `QueueAlreadyExists` when it differs.

Service Bus routing and behavior are untouched; the shared provider change (enqueue-time receipt) is verified not to affect the Service Bus wire package.

## Tests

New `server/azure/queue/message_semantics_test.go` (full server + real `azqueue`, one test per bug):
- create-with-metadata → GetProperties returns it (B1)
- delete with stale receipt → MessageNotFound (B2)
- enqueue then delete using the enqueue-returned receipt without dequeue → succeeds (B3)
- dequeue reports InsertionTime ≈ enqueue time and TimeNextVisible in the future by the effective visibility (B4)
- duplicate create same metadata → 204, different metadata → 409 (B5)

## Gates

`go build ./...`, `go vet`, `go test` (queue / servicebus provider / messagequeue / servicebus wire), `-race` on the queue package, root integration test, `gofmt -l`, `go generate` (zero diff), and `compatgen` (zero `docs/compat` diff) all green. golangci-lint on changed packages: 0 new issues.