### PR TITLE
fix(dynamodb): preserve exact decimal strings in Number Sets (NS)

### DIFF
--- a/server/aws/dynamodb/dynamodb_number_set_test.go
+++ b/server/aws/dynamodb/dynamodb_number_set_test.go
@@ -1,0 +1,160 @@
+// dynamodb_number_set_test.go — real aws-sdk-go-v2 round-trips proving the
+// DynamoDB Number Set (NS) preserves each element's exact decimal string.
+// Elements beyond float64's mantissa (large ids, high-precision decimals) must
+// not be corrupted by parsing through float64, and set operations (ADD/DELETE)
+// must act by numeric value while keeping the survivors' exact strings.
+package dynamodb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func nsAttr(vals ...string) ddbtypes.AttributeValue {
+	return &ddbtypes.AttributeValueMemberNS{Value: vals}
+}
+
+func attrNS(t *testing.T, item map[string]ddbtypes.AttributeValue, field string) []string {
+	t.Helper()
+
+	v, ok := item[field].(*ddbtypes.AttributeValueMemberNS)
+	require.True(t, ok, "attribute %q should be NS, got %T", field, item[field])
+
+	return v.Value
+}
+
+func suiteDDBUpdate(t *testing.T, client *dynamodb.Client, table, expr string,
+	key, vals map[string]ddbtypes.AttributeValue) {
+	t.Helper()
+
+	_, err := client.UpdateItem(context.Background(), &dynamodb.UpdateItemInput{
+		TableName:                 aws.String(table),
+		Key:                       key,
+		UpdateExpression:          aws.String(expr),
+		ExpressionAttributeValues: vals,
+	})
+	require.NoError(t, err, "UpdateItem %q on %q", expr, table)
+}
+
+// TestDDBNumberSetPrecision: an NS carrying two 30-digit integers that map to the
+// SAME float64 round-trips both exact strings — float parsing would corrupt them
+// and collapse them into one element.
+func TestDDBNumberSetPrecision(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	suiteDDBCreateTable(t, client, "nums", "id", "")
+
+	const (
+		bigA = "123456789012345678901234567890"
+		bigB = "123456789012345678901234567891"
+	)
+
+	suiteDDBPut(t, client, "nums", map[string]ddbtypes.AttributeValue{
+		"id":  sAttr("x"),
+		"ids": nsAttr(bigA, bigB),
+	})
+
+	got := suiteDDBGet(t, client, "nums", map[string]ddbtypes.AttributeValue{"id": sAttr("x")})
+	assert.ElementsMatch(t, []string{bigA, bigB}, attrNS(t, got.Item, "ids"),
+		"NS elements beyond 2^53 must round-trip as exact strings and stay distinct")
+}
+
+// TestDDBNumberSetDecimalPrecision: an NS decimal element with far more than 15
+// significant digits round-trips without float rounding.
+func TestDDBNumberSetDecimalPrecision(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	suiteDDBCreateTable(t, client, "nums", "id", "")
+
+	const pi = "3.141592653589793238462643383279"
+
+	suiteDDBPut(t, client, "nums", map[string]ddbtypes.AttributeValue{
+		"id":   sAttr("x"),
+		"vals": nsAttr(pi, "-0.5"),
+	})
+
+	got := suiteDDBGet(t, client, "nums", map[string]ddbtypes.AttributeValue{"id": sAttr("x")})
+	assert.ElementsMatch(t, []string{pi, "-0.5"}, attrNS(t, got.Item, "vals"),
+		"high-precision decimal NS elements must round-trip exactly")
+}
+
+// TestDDBNumberSetAddUnion: ADD unions by numeric value and keeps the exact
+// string of a large surviving element; a numerically-equal add is a no-op.
+func TestDDBNumberSetAddUnion(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	suiteDDBCreateTable(t, client, "nums", "id", "")
+
+	const big = "999999999999999999999999999999"
+
+	suiteDDBPut(t, client, "nums", map[string]ddbtypes.AttributeValue{
+		"id":  sAttr("x"),
+		"ids": nsAttr("1", big),
+	})
+
+	suiteDDBUpdate(t, client, "nums", "ADD ids :n",
+		map[string]ddbtypes.AttributeValue{"id": sAttr("x")},
+		map[string]ddbtypes.AttributeValue{":n": nsAttr("1.0", "42")})
+
+	got := suiteDDBGet(t, client, "nums", map[string]ddbtypes.AttributeValue{"id": sAttr("x")})
+	assert.ElementsMatch(t, []string{"1", big, "42"}, attrNS(t, got.Item, "ids"),
+		"ADD unions by numeric value; large element keeps its exact string, 1.0 dedups against 1")
+}
+
+// TestDDBNumberSetDelete: DELETE removes by numeric value and preserves the
+// exact strings of the survivors.
+func TestDDBNumberSetDelete(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	suiteDDBCreateTable(t, client, "nums", "id", "")
+
+	const big = "123456789012345678901234567890"
+
+	suiteDDBPut(t, client, "nums", map[string]ddbtypes.AttributeValue{
+		"id":  sAttr("x"),
+		"ids": nsAttr("1", "2", big),
+	})
+
+	suiteDDBUpdate(t, client, "nums", "DELETE ids :n",
+		map[string]ddbtypes.AttributeValue{"id": sAttr("x")},
+		map[string]ddbtypes.AttributeValue{":n": nsAttr("2")})
+
+	got := suiteDDBGet(t, client, "nums", map[string]ddbtypes.AttributeValue{"id": sAttr("x")})
+	assert.ElementsMatch(t, []string{"1", big}, attrNS(t, got.Item, "ids"),
+		"DELETE removes by numeric value, survivors keep exact strings")
+}
+
+// TestDDBNumberSetDuplicateDedup: numerically-equal elements in one NS collapse
+// to a single element (DynamoDB set semantics), keeping the first-seen string.
+func TestDDBNumberSetDuplicateDedup(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	suiteDDBCreateTable(t, client, "nums", "id", "")
+
+	suiteDDBPut(t, client, "nums", map[string]ddbtypes.AttributeValue{
+		"id":  sAttr("x"),
+		"ids": nsAttr("1", "1.0", "2"),
+	})
+
+	got := suiteDDBGet(t, client, "nums", map[string]ddbtypes.AttributeValue{"id": sAttr("x")})
+	assert.ElementsMatch(t, []string{"1", "2"}, attrNS(t, got.Item, "ids"),
+		"numerically-equal NS elements dedup to one")
+}
+
+// TestDDBScalarNumberStillRoundTrips: regression guard that the scalar N path
+// (which NS mirrors) still preserves an exact high-precision decimal.
+func TestDDBScalarNumberStillRoundTrips(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	suiteDDBCreateTable(t, client, "nums", "id", "")
+
+	const dec = "9.999999999999999999999999999999"
+
+	suiteDDBPut(t, client, "nums", map[string]ddbtypes.AttributeValue{
+		"id":  sAttr("x"),
+		"big": nAttr(dec),
+	})
+
+	got := suiteDDBGet(t, client, "nums", map[string]ddbtypes.AttributeValue{"id": sAttr("x")})
+	assert.Equal(t, dec, attrN(t, got.Item, "big"), "scalar N must still round-trip exactly")
+}

--- a/server/aws/dynamodb/types.go
+++ b/server/aws/dynamodb/types.go
@@ -2,7 +2,6 @@ package dynamodb
 
 import (
 	"encoding/base64"
-	"strconv"
 
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
@@ -136,14 +135,20 @@ func decodeNumberSet(v any) any {
 	out := make(expr.NumberSet, 0, len(list))
 
 	for _, e := range list {
+		// DynamoDB transmits NS as an array of decimal strings; keep each element's
+		// exact string (expr.Number) so large ids/high-precision decimals round-trip
+		// losslessly. Parsing through float64 here corrupts values beyond 2^53.
 		if s, ok := e.(string); ok {
-			if f, err := strconv.ParseFloat(s, 64); err == nil {
-				out = append(out, f)
-			}
+			out = append(out, expr.Number(s))
 		}
 	}
 
-	return out
+	// Dedup by numeric value (union with an empty set) so equal forms such as
+	// "1" and "1.0" collapse to one element, matching DynamoDB set semantics,
+	// while values that differ beyond float64 precision are preserved distinct.
+	deduped, _ := expr.UnionSets(nil, out)
+
+	return deduped
 }
 
 func decodeBinarySet(v any) any {

--- a/services/database/driver/expr/eval.go
+++ b/services/database/driver/expr/eval.go
@@ -187,7 +187,7 @@ func setContains(v, target any) bool {
 		t, ok := target.(string)
 		return ok && stringSetHas(s, t)
 	case NumberSet:
-		t, ok := toFloat(target)
+		t, ok := toNumber(target)
 		return ok && numberSetHas(s, t)
 	case BinarySet:
 		t, ok := target.([]byte)

--- a/services/database/driver/expr/number.go
+++ b/services/database/driver/expr/number.go
@@ -2,7 +2,9 @@ package expr
 
 import (
 	"encoding/json"
+	"math/big"
 	"strconv"
+	"strings"
 )
 
 // NumberJSONTag is the single key of the self-describing JSON object a Number
@@ -57,4 +59,46 @@ func (n Number) Float() (float64, bool) {
 	}
 
 	return f, true
+}
+
+// rat parses n into an exact rational so two decimals compare by their true
+// numeric value without ever passing through float64 — the difference between
+// two 30-digit ids that share the same float64 must survive. A leading '+' and
+// scientific notation are accepted; a malformed number reports ok=false.
+func (n Number) rat() (*big.Rat, bool) {
+	r, ok := new(big.Rat).SetString(strings.TrimPrefix(string(n), "+"))
+	return r, ok
+}
+
+// numberEqual reports whether a and b denote the same number. Equality is
+// numeric and exact (via big.Rat), so "1" == "1.0" == "+1" yet two values that
+// only differ beyond float64 precision stay distinct. Malformed operands fall
+// back to an exact string match so they stay type-segregated.
+func numberEqual(a, b Number) bool {
+	ra, aok := a.rat()
+	rb, bok := b.rat()
+
+	if aok && bok {
+		return ra.Cmp(rb) == 0
+	}
+
+	return string(a) == string(b)
+}
+
+// toNumber coerces the numeric kinds the drivers produce to an exact-decimal
+// Number for set membership. A Number is kept verbatim; a float/int is
+// formatted losslessly enough for membership. Non-numeric values report false.
+func toNumber(v any) (Number, bool) {
+	switch t := v.(type) {
+	case Number:
+		return t, true
+	case float64:
+		return Number(strconv.FormatFloat(t, 'f', -1, 64)), true
+	case int:
+		return Number(strconv.Itoa(t)), true
+	case int64:
+		return Number(strconv.FormatInt(t, 10)), true
+	}
+
+	return "", false
 }

--- a/services/database/driver/expr/sets.go
+++ b/services/database/driver/expr/sets.go
@@ -10,11 +10,13 @@ import "bytes"
 // StringSet is a DynamoDB String Set (SS).
 type StringSet []string
 
-// NumberSet is a DynamoDB Number Set (NS). Elements are numeric values, kept as
-// float64 to match how scalar numbers (N) are modeled; like scalar N, this does
-// not preserve DynamoDB's full decimal precision for very large or high-precision
-// numbers.
-type NumberSet []float64
+// NumberSet is a DynamoDB Number Set (NS). Each element is kept as its exact
+// decimal string (a Number), mirroring how the scalar N type is modeled, so
+// large ids and high-precision decimals round-trip without float64 corruption.
+// Uniqueness and membership are by numeric value (Number's exact comparison),
+// so "1", "1.0" and "+1" are one element, while values that differ only beyond
+// float64 precision stay distinct.
+type NumberSet []Number
 
 // BinarySet is a DynamoDB Binary Set (BS).
 type BinarySet [][]byte
@@ -30,10 +32,10 @@ func stringSetHas(s StringSet, v string) bool {
 	return false
 }
 
-// numberSetHas reports whether s contains v.
-func numberSetHas(s NumberSet, v float64) bool {
+// numberSetHas reports whether s contains v, comparing by exact numeric value.
+func numberSetHas(s NumberSet, v Number) bool {
 	for _, e := range s {
-		if e == v {
+		if numberEqual(e, v) {
 			return true
 		}
 	}

--- a/services/database/driver/expr/sets_test.go
+++ b/services/database/driver/expr/sets_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestDynamoTypeSets(t *testing.T) {
 	assert.Equal(t, "SS", dynamoType(StringSet{"a"}))
-	assert.Equal(t, "NS", dynamoType(NumberSet{1}))
+	assert.Equal(t, "NS", dynamoType(NumberSet{"1"}))
 	assert.Equal(t, "BS", dynamoType(BinarySet{{0x1}}))
 }
 
 func TestContainsOnSets(t *testing.T) {
 	item := map[string]any{
 		"ss": StringSet{"red", "blue"},
-		"ns": NumberSet{1, 2},
+		"ns": NumberSet{"1", "2"},
 		"bs": BinarySet{{0x1}, {0x2}},
 	}
 
@@ -47,7 +47,7 @@ func TestAttributeTypeSet(t *testing.T) {
 func TestSetsEqual(t *testing.T) {
 	assert.True(t, setsEqual(StringSet{"a", "b"}, StringSet{"b", "a"}), "order-independent")
 	assert.False(t, setsEqual(StringSet{"a"}, StringSet{"a", "b"}))
-	assert.False(t, setsEqual(StringSet{"a"}, NumberSet{1}), "different set types")
+	assert.False(t, setsEqual(StringSet{"a"}, NumberSet{"1"}), "different set types")
 }
 
 func TestUnionAndDifference(t *testing.T) {
@@ -56,12 +56,12 @@ func TestUnionAndDifference(t *testing.T) {
 	assert.ElementsMatch(t, StringSet{"a", "b"}, u)
 
 	// type mismatch
-	_, ok = UnionSets(StringSet{"a"}, NumberSet{1})
+	_, ok = UnionSets(StringSet{"a"}, NumberSet{"1"})
 	assert.False(t, ok)
 
-	d, ok := DifferenceSets(NumberSet{1, 2, 3}, NumberSet{2})
+	d, ok := DifferenceSets(NumberSet{"1", "2", "3"}, NumberSet{"2"})
 	require.True(t, ok)
-	assert.ElementsMatch(t, NumberSet{1, 3}, d)
+	assert.ElementsMatch(t, NumberSet{"1", "3"}, d)
 
 	assert.True(t, SetIsEmpty(StringSet{}))
 	assert.False(t, SetIsEmpty(StringSet{"a"}))

--- a/services/database/driver/expr/update_test.go
+++ b/services/database/driver/expr/update_test.go
@@ -73,12 +73,12 @@ func TestUpdateAddSet(t *testing.T) {
 }
 
 func TestUpdateAddNumberSet(t *testing.T) {
-	out := mustUpdate(t, map[string]any{"nums": NumberSet{1, 2}}, "ADD nums :n",
-		map[string]any{":n": NumberSet{2, 3}})
+	out := mustUpdate(t, map[string]any{"nums": NumberSet{"1", "2"}}, "ADD nums :n",
+		map[string]any{":n": NumberSet{"2", "3"}})
 
 	ns, ok := out["nums"].(NumberSet)
 	require.True(t, ok)
-	assert.ElementsMatch(t, NumberSet{1, 2, 3}, ns)
+	assert.ElementsMatch(t, NumberSet{"1", "2", "3"}, ns)
 }
 
 func TestUpdateDeleteSet(t *testing.T) {

--- a/services/database/driver/stream_event.go
+++ b/services/database/driver/stream_event.go
@@ -59,7 +59,7 @@ func marshalBinaryOrSet(v any) (map[string]any, bool) {
 	case expr.StringSet:
 		return map[string]any{"SS": []string(val)}, true
 	case expr.NumberSet:
-		return map[string]any{"NS": formatFloatSet(val)}, true
+		return map[string]any{"NS": formatNumberSet(val)}, true
 	case expr.BinarySet:
 		return map[string]any{"BS": formatBinarySet(val)}, true
 	default:
@@ -67,10 +67,12 @@ func marshalBinaryOrSet(v any) (map[string]any, bool) {
 	}
 }
 
-func formatFloatSet(ns expr.NumberSet) []string {
+// formatNumberSet renders an NS to the wire as an array of its exact decimal
+// strings, so elements beyond float64 precision encode without corruption.
+func formatNumberSet(ns expr.NumberSet) []string {
 	out := make([]string, 0, len(ns))
-	for _, f := range ns {
-		out = append(out, strconv.FormatFloat(f, 'f', -1, 64))
+	for _, n := range ns {
+		out = append(out, string(n))
 	}
 
 	return out


### PR DESCRIPTION
## Summary

DynamoDB Number Sets (NS) silently corrupted any element beyond `2^53`. `decodeNumberSet` parsed each element via `strconv.ParseFloat(s, 64)` and `NumberSet` was `[]float64`, so a `PutItem` NS of `["123456789012345678901234567890","1"]` read back `["123456789012345680000000000000","1"]`. Large ids, high-precision decimals, and money values were rounded away. The scalar `N` type was already fixed to keep its exact decimal string (`expr.Number`); NS never got the same treatment.

## Fix

Mirror the scalar-N approach for the set type:

- `expr.NumberSet` is now `[]expr.Number` (exact decimal strings) instead of `[]float64`.
- Uniqueness, membership, `contains()`, `ADD` (union) and `DELETE` (difference) compare by **exact numeric value** using `big.Rat` — so `"1"`, `"1.0"` and `"+1"` are one element, while two 30-digit values that share a `float64` stay distinct (the exact bug being fixed). Survivors keep their original strings.
- Wire decode keeps each element's exact string and dedups numerically-equal forms (union with an empty set); wire encode emits the exact strings.

### Why the shared `expr` package changed

`NumberSet`'s representation lives in `services/database/driver/expr` (`sets.go`, `number.go`, `eval.go`), and the exact-string wire encoder lives in `services/database/driver/stream_event.go` (shared by control-plane responses, Streams, and Lambda stream delivery). All were use-sites of the old `[]float64` set and had to move to the string-backed form together so N and NS stay consistent.

## Tests

`server/aws/dynamodb/dynamodb_number_set_test.go` — real aws-sdk-go-v2 round-trips:

- NS with two 30-digit integers sharing one `float64` → both exact strings back, distinct
- high-precision decimal NS element (>15 sig digits) round-trips exactly
- `ADD` unions by numeric value, large element keeps exact string, `1.0` dedups against `1`
- `DELETE` removes by numeric value, survivors keep exact strings
- numerically-equal NS elements dedup to one (set semantics)
- scalar `N` still round-trips (regression guard)
