### PR TITLE
fix(azure-sql): round-trip database sku.capacity, idempotent delete, GUID databaseId

### DIFF
--- a/providers/azure/sql/databases.go
+++ b/providers/azure/sql/databases.go
@@ -59,6 +59,7 @@ func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 		Tags:          copyTags(cfg.Tags),
 		SKUName:       skuName,
 		SKUTier:       skuTier,
+		SKUCapacity:   cfg.SKUCapacity,
 		ZoneRedundant: cfg.ZoneRedundant,
 		ElasticPoolID: cfg.ElasticPoolID,
 	}

--- a/server/azure/sql/capacity_delete_dbid_sdk_test.go
+++ b/server/azure/sql/capacity_delete_dbid_sdk_test.go
@@ -1,0 +1,180 @@
+package sql_test
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
+)
+
+// guidPattern matches a canonical 8-4-4-4-12 hex GUID.
+var guidPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+const vCoreCapacity = int32(4)
+
+// createServer creates a logical server the database tests hang databases off.
+func createServer(ctx context.Context, t *testing.T, servers *armsql.ServersClient, name string) {
+	t.Helper()
+
+	poller, err := servers.BeginCreateOrUpdate(ctx, "rg-1", name, armsql.Server{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("Server BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Server PollUntilDone: %v", err)
+	}
+}
+
+// createDB creates a database and returns its create response.
+func createDB(
+	ctx context.Context, t *testing.T, dbs *armsql.DatabasesClient, srv, name string, sku *armsql.SKU,
+) armsql.DatabasesClientCreateOrUpdateResponse {
+	t.Helper()
+
+	poller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", srv, name, armsql.Database{
+		Location: to.Ptr("eastus"),
+		SKU:      sku,
+	}, nil)
+	if err != nil {
+		t.Fatalf("DB BeginCreateOrUpdate: %v", err)
+	}
+
+	resp, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("DB PollUntilDone: %v", err)
+	}
+
+	return resp
+}
+
+// TestSDKAzureSQLDatabaseVCoreCapacity covers B1: a vCore SKU's capacity must
+// round-trip on both sku.capacity and properties.currentSku.capacity.
+func TestSDKAzureSQLDatabaseVCoreCapacity(t *testing.T) {
+	servers, dbs := newSDKClients(t)
+	ctx := context.Background()
+
+	createServer(ctx, t, servers, "srv1")
+
+	sku := &armsql.SKU{
+		Name:     to.Ptr("GP_Gen5_4"),
+		Tier:     to.Ptr("GeneralPurpose"),
+		Capacity: to.Ptr(vCoreCapacity),
+	}
+	createDB(ctx, t, dbs, "srv1", "appdb", sku)
+
+	got, err := dbs.Get(ctx, "rg-1", "srv1", "appdb", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Database.SKU == nil || got.Database.SKU.Capacity == nil {
+		t.Fatal("expected sku.capacity set on GET")
+	}
+
+	if *got.Database.SKU.Capacity != vCoreCapacity {
+		t.Fatalf("sku.capacity = %d, want %d", *got.Database.SKU.Capacity, vCoreCapacity)
+	}
+
+	if got.Database.Properties == nil || got.Database.Properties.CurrentSKU == nil ||
+		got.Database.Properties.CurrentSKU.Capacity == nil {
+		t.Fatal("expected properties.currentSku.capacity set on GET")
+	}
+
+	if *got.Database.Properties.CurrentSKU.Capacity != vCoreCapacity {
+		t.Fatalf("currentSku.capacity = %d, want %d", *got.Database.Properties.CurrentSKU.Capacity, vCoreCapacity)
+	}
+}
+
+// TestSDKAzureSQLDeleteIdempotent covers B2: deleting an absent database or
+// server succeeds (ARM DELETE is idempotent), while deleting an existing
+// database still works.
+func TestSDKAzureSQLDeleteIdempotent(t *testing.T) {
+	servers, dbs := newSDKClients(t)
+	ctx := context.Background()
+
+	createServer(ctx, t, servers, "srv1")
+
+	// DELETE a nonexistent database -> success, not 404.
+	dbDel, err := dbs.BeginDelete(ctx, "rg-1", "srv1", "ghost", nil)
+	if err != nil {
+		t.Fatalf("DB BeginDelete (absent): %v", err)
+	}
+
+	if _, err := dbDel.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("DB delete of absent database should succeed: %v", err)
+	}
+
+	// DELETE a nonexistent server -> success, not 404.
+	srvDel, err := servers.BeginDelete(ctx, "rg-1", "ghost-srv", nil)
+	if err != nil {
+		t.Fatalf("Server BeginDelete (absent): %v", err)
+	}
+
+	if _, err := srvDel.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("server delete of absent server should succeed: %v", err)
+	}
+
+	// DELETE an EXISTING database still works.
+	createDB(ctx, t, dbs, "srv1", "appdb", &armsql.SKU{Name: to.Ptr("S0")})
+
+	existingDel, err := dbs.BeginDelete(ctx, "rg-1", "srv1", "appdb", nil)
+	if err != nil {
+		t.Fatalf("DB BeginDelete (existing): %v", err)
+	}
+
+	if _, err := existingDel.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("existing DB delete poll: %v", err)
+	}
+
+	if _, err := dbs.Get(ctx, "rg-1", "srv1", "appdb", nil); err == nil {
+		t.Fatal("expected NotFound after deleting existing database")
+	}
+}
+
+// TestSDKAzureSQLDatabaseIDGUID covers B3: properties.databaseId is a GUID,
+// stable across repeated GETs and distinct per database.
+func TestSDKAzureSQLDatabaseIDGUID(t *testing.T) {
+	servers, dbs := newSDKClients(t)
+	ctx := context.Background()
+
+	createServer(ctx, t, servers, "srv1")
+	createDB(ctx, t, dbs, "srv1", "appdb", &armsql.SKU{Name: to.Ptr("S0")})
+	createDB(ctx, t, dbs, "srv1", "otherdb", &armsql.SKU{Name: to.Ptr("S0")})
+
+	id1 := databaseID(ctx, t, dbs, "appdb")
+	id2 := databaseID(ctx, t, dbs, "appdb")
+	id3 := databaseID(ctx, t, dbs, "otherdb")
+
+	if !guidPattern.MatchString(id1) {
+		t.Fatalf("databaseId %q is not a GUID", id1)
+	}
+
+	if id1 != id2 {
+		t.Fatalf("databaseId not stable across GETs: %q vs %q", id1, id2)
+	}
+
+	if id1 == id3 {
+		t.Fatalf("distinct databases share databaseId %q", id1)
+	}
+}
+
+// databaseID fetches a database's properties.databaseId.
+func databaseID(ctx context.Context, t *testing.T, dbs *armsql.DatabasesClient, name string) string {
+	t.Helper()
+
+	got, err := dbs.Get(ctx, "rg-1", "srv1", name, nil)
+	if err != nil {
+		t.Fatalf("Get %s: %v", name, err)
+	}
+
+	if got.Database.Properties == nil || got.Database.Properties.DatabaseID == nil {
+		t.Fatalf("expected databaseId set on %s", name)
+	}
+
+	return *got.Database.Properties.DatabaseID
+}

--- a/server/azure/sql/operations.go
+++ b/server/azure/sql/operations.go
@@ -87,7 +87,9 @@ func (h *Handler) getServer(w http.ResponseWriter, r *http.Request, rp *azurearm
 }
 
 func (h *Handler) deleteServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	if err := h.db.DeleteCluster(r.Context(), rp.ResourceName); err != nil {
+	// ARM DELETE is idempotent: deleting an absent server is a success, not a
+	// 404 (Servers-Delete documents 204 = "does not exist").
+	if err := h.db.DeleteCluster(r.Context(), rp.ResourceName); err != nil && !cerrors.IsNotFound(err) {
 		azurearm.WriteCErr(w, err)
 		return
 	}
@@ -131,6 +133,7 @@ func dbCfgFromBody(body *armDatabase, rp *azurearm.ResourcePath) rdsdriver.Datab
 	if body.SKU != nil {
 		cfg.SKUName = body.SKU.Name
 		cfg.SKUTier = body.SKU.Tier
+		cfg.SKUCapacity = body.SKU.Capacity
 	}
 
 	if body.Properties != nil {
@@ -223,6 +226,10 @@ func mergeDatabaseFields(existing *rdsdriver.Database, body *armDatabase, cfg *r
 		merged.SKUTier = cfg.SKUTier
 	}
 
+	if cfg.SKUCapacity != 0 {
+		merged.SKUCapacity = cfg.SKUCapacity
+	}
+
 	if cfg.Collation != "" {
 		merged.Collation = cfg.Collation
 	}
@@ -282,6 +289,7 @@ func replaceDatabase(
 		Tags:          merged.Tags,
 		SKUName:       merged.SKUName,
 		SKUTier:       merged.SKUTier,
+		SKUCapacity:   merged.SKUCapacity,
 		ZoneRedundant: merged.ZoneRedundant,
 		ElasticPoolID: merged.ElasticPoolID,
 	})
@@ -320,7 +328,9 @@ func (*Handler) getDatabase(w http.ResponseWriter, r *http.Request, rp *azurearm
 func (*Handler) deleteDatabase(
 	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db rdsdriver.Databases,
 ) {
-	if err := db.DeleteDatabase(r.Context(), rp.ResourceName, rp.SubResourceName); err != nil {
+	// ARM DELETE is idempotent: deleting an absent database is a success, not a
+	// 404 (Databases-Delete documents 204 = "does not exist").
+	if err := db.DeleteDatabase(r.Context(), rp.ResourceName, rp.SubResourceName); err != nil && !cerrors.IsNotFound(err) {
 		azurearm.WriteCErr(w, err)
 		return
 	}

--- a/server/azure/sql/types.go
+++ b/server/azure/sql/types.go
@@ -1,6 +1,7 @@
 package sql
 
 import (
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
@@ -94,17 +95,26 @@ func toARMDatabase(db *rdsdriver.Database, rp *azurearm.ResourcePath) armDatabas
 		Type:     providerName + "/servers/databases",
 		Location: db.Location,
 		Tags:     db.Tags,
-		SKU:      &armSKU{Name: db.SKUName, Tier: db.SKUTier},
+		SKU:      &armSKU{Name: db.SKUName, Tier: db.SKUTier, Capacity: db.SKUCapacity},
 		Properties: &armDatabaseProps{
 			Status:                      dbStatusOnline,
 			Collation:                   db.Collation,
-			DatabaseID:                  db.ARN,
+			DatabaseID:                  databaseGUID(db),
 			CurrentServiceObjectiveName: db.SKUName,
-			CurrentSKU:                  &armSKU{Name: db.SKUName, Tier: db.SKUTier},
+			CurrentSKU:                  &armSKU{Name: db.SKUName, Tier: db.SKUTier, Capacity: db.SKUCapacity},
 			ZoneRedundant:               &zoneRedundant,
 			ElasticPoolID:               db.ElasticPoolID,
 		},
 	}
+}
+
+// databaseGUID derives the stable, GUID-shaped databaseId Azure reports for a
+// database. Real Azure's databaseId is an intrinsic GUID, not a resource path,
+// so it is seeded from the database's server/name (stable across reads,
+// distinct per database) rather than reusing db.ARN, whose region-based ARN
+// leaks us-east-1 into the value.
+func databaseGUID(db *rdsdriver.Database) string {
+	return idgen.SyntheticGUID(db.Server + "/" + db.Name)
 }
 
 func armServerID(subscription, resourceGroup, server string) string {

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -480,8 +480,12 @@ type DatabaseConfig struct {
 	// SKUName / SKUTier are the database compute SKU (e.g. "GP_Gen5_2" /
 	// "GeneralPurpose") and ZoneRedundant is the HA flag — cost inputs a
 	// discoverer reads from an Azure SQL database's sku / properties.
-	SKUName       string
-	SKUTier       string
+	SKUName string
+	SKUTier string
+	// SKUCapacity is the vCore/DTU count on an Azure SQL database SKU
+	// (sku.capacity). Optional — zero means unset, so a request that omits it
+	// carries no capacity. Only the Azure SQL provider populates it.
+	SKUCapacity   int
 	ZoneRedundant bool
 	// ElasticPoolID is the Azure SQL elastic pool this database belongs to (a
 	// bare pool name or a full ARM resource ID); empty for a standalone
@@ -503,8 +507,11 @@ type Database struct {
 	Tags     map[string]string
 	// SKUName / SKUTier / ZoneRedundant are echoed on read for cost discovery
 	// (Azure SQL database sku.name + properties.currentSku / zoneRedundant).
-	SKUName       string
-	SKUTier       string
+	SKUName string
+	SKUTier string
+	// SKUCapacity echoes the vCore/DTU count on read (sku.capacity /
+	// properties.currentSku.capacity); zero when unset. Azure SQL only.
+	SKUCapacity   int
 	ZoneRedundant bool
 	// ElasticPoolID echoes the elastic pool this database belongs to on read
 	// (properties.elasticPoolId); empty for a standalone database.


### PR DESCRIPTION
## Summary

Fixes three Azure SQL Database (`Microsoft.Sql`) fidelity bugs found against the real `armsql` SDK.

**B1 — Database `sku.capacity` (vCore SKUs) dropped on round-trip.**
A PUT with `sku: {name, tier, capacity: 4}` came back with no capacity, and `properties.currentSku` had none either. Added an optional `SKUCapacity int` to the shared `relationaldb` `DatabaseConfig`/`Database`, read it in `dbCfgFromBody`, persisted it in the provider's `CreateDatabase` and the merge/replace upsert paths, and emit it in `toARMDatabase` on both `sku` and `properties.currentSku`. The field is optional and Azure-SQL-only — RDS, Redshift and Cloud SQL neither set nor read it (no behavior change; their tests are unchanged).

**B2 — DELETE of a nonexistent database or server returned 404, not idempotent.**
ARM DELETE is idempotent (Databases/Servers-Delete document 204 = "does not exist"). Fixed at the server layer: `deleteServer` and `deleteDatabase` now treat a driver `NotFound` as success (200) instead of surfacing 404. The driver/provider is untouched, so a real delete of an existing resource still works and still emits its response.

**B3 — `properties.databaseId` was a region-based ARN, not a GUID.**
`toARMDatabase` set `databaseId` to `db.ARN`, which leaks `us-east-1` into the value. It now emits a deterministic GUID via the existing `idgen.SyntheticGUID`, seeded from the database's server/name — stable across repeated GETs and distinct per database.

## Tests

New real-SDK tests in `server/azure/sql/capacity_delete_dbid_sdk_test.go`:
- vCore database with `sku.capacity=4` → GET returns capacity on `sku` and `currentSku` (B1)
- DELETE nonexistent database → success, DELETE nonexistent server → success, DELETE existing database still works (B2)
- GET database twice → `databaseId` is a GUID, identical both times, and differs from another database's (B3)
