### PR TITLE
fix(azure): overlay never reflects write-only secrets back on reads

### DIFF
--- a/server/azure/echo_properties.go
+++ b/server/azure/echo_properties.go
@@ -327,10 +327,70 @@ func captureUnmodeled(
 	return fresh
 }
 
+// writeOnlyProperty reports whether an ARM request-body property key is a
+// write-only secret that real Azure accepts on write but never returns on a
+// read. Such a key must never be captured by the overlay or echoed back:
+// because the owning handler deliberately omits it from its response (mirroring
+// Azure), the generic overlay would otherwise treat it as an unmodeled property
+// and reflect the caller's secret on the create response and on every later GET
+// — a credential leak. Matched case-insensitively at any nesting depth, since
+// missingProperties descends into nested objects.
+//
+// Every entry is a value some Azure handler in this server accepts on write and
+// drops from its to-ARM output, verified against how that handler models the
+// key:
+//   - administratorLoginPassword: the admin password for Microsoft.Sql/servers
+//     (server/azure/sql), Microsoft.DBforMySQL/flexibleServers
+//     (server/azure/mysqlflex), Microsoft.DBforPostgreSQL/flexibleServers
+//     (server/azure/postgresflex) and Cosmos DB for PostgreSQL clusters
+//     (server/azure/cosmospostgresql). Each handler's toARM* omits it.
+//   - adminPassword: the VM local-admin password under osProfile for
+//     Microsoft.Compute/virtualMachines (server/azure/virtualmachines). The
+//     handler's osProfile shape carries no password field, so it is dropped.
+//   - initialCassandraAdminPassword: the seed admin password for managed
+//     Cassandra clusters (server/azure/managedcassandra). toARMCluster omits it.
+//
+// The list is deliberately conservative: a key belongs here only when real
+// Azure genuinely omits it on read AND a handler relies on that omission, so it
+// never suppresses a field a handler legitimately returns.
+func writeOnlyProperty(key string) bool {
+	switch strings.ToLower(key) {
+	case "administratorloginpassword", "adminpassword", "initialcassandraadminpassword":
+		return true
+	default:
+		return false
+	}
+}
+
+// sanitizeUnmodeled deep-copies a captured request value with every write-only
+// secret key (writeOnlyProperty) removed at every depth. It guards the wholesale
+// capture path in missingProperties: when the handler drops an entire object,
+// that object is preserved as-is, so a secret nested inside it would otherwise
+// slip past the per-key denylist. A non-map value passes through unchanged.
+func sanitizeUnmodeled(v any) any {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return v
+	}
+
+	out := make(map[string]any, len(m))
+
+	for k, val := range m {
+		if writeOnlyProperty(k) {
+			continue
+		}
+
+		out[k] = sanitizeUnmodeled(val)
+	}
+
+	return out
+}
+
 // missingProperties returns the entries of req that resp does not already carry,
 // descending into nested objects so an unmodeled leaf under a modeled parent is
 // still captured. A key present in both as scalars is considered modeled (the
-// handler owns it) and is omitted.
+// handler owns it) and is omitted. Write-only secret keys (writeOnlyProperty)
+// are skipped at every level so they are never captured, persisted, or echoed.
 func missingProperties(req, resp map[string]any) map[string]any {
 	if len(req) == 0 {
 		return nil
@@ -339,9 +399,18 @@ func missingProperties(req, resp map[string]any) map[string]any {
 	out := map[string]any{}
 
 	for k, reqVal := range req {
+		if writeOnlyProperty(k) {
+			continue
+		}
+
 		respVal, present := resp[k]
 		if !present {
-			out[k] = reqVal
+			// A wholly-unmodeled object is captured verbatim, so strip any
+			// write-only secret nested inside it — the per-key skip above only
+			// covers keys the loop visits directly, not those buried in a
+			// subtree the handler dropped entirely (e.g. a VM osProfile the
+			// response omits, carrying adminPassword).
+			out[k] = sanitizeUnmodeled(reqVal)
 			continue
 		}
 

--- a/server/azure/echo_properties.go
+++ b/server/azure/echo_properties.go
@@ -336,49 +336,60 @@ func captureUnmodeled(
 // — a credential leak. Matched case-insensitively at any nesting depth, since
 // missingProperties descends into nested objects.
 //
-// Every entry is a value some Azure handler in this server accepts on write and
-// drops from its to-ARM output, verified against how that handler models the
-// key:
-//   - administratorLoginPassword: the admin password for Microsoft.Sql/servers
-//     (server/azure/sql), Microsoft.DBforMySQL/flexibleServers
-//     (server/azure/mysqlflex), Microsoft.DBforPostgreSQL/flexibleServers
-//     (server/azure/postgresflex) and Cosmos DB for PostgreSQL clusters
-//     (server/azure/cosmospostgresql). Each handler's toARM* omits it.
-//   - adminPassword: the VM local-admin password under osProfile for
-//     Microsoft.Compute/virtualMachines (server/azure/virtualmachines). The
-//     handler's osProfile shape carries no password field, so it is dropped.
-//   - initialCassandraAdminPassword: the seed admin password for managed
-//     Cassandra clusters (server/azure/managedcassandra). toARMCluster omits it.
-//   - password: a Cosmos DB for PostgreSQL role password (toARMRole,
-//     server/azure/cosmospostgresql, drops it) and a Container Instances
-//     imageRegistryCredentials[].password (server/azure/containerinstances does
-//     not model the array at all, so it is captured verbatim — inside an array,
-//     hence the []any recursion in sanitizeUnmodeled). Real Azure never returns
-//     either. The one place a `password` is legitimately returned is the
-//     Container Instances exec action response, but that is a bare
-//     {webSocketUri, password} object with no id/properties, so the overlay
-//     (which only rewrites ARM resources and only ever touches keys inside a
-//     properties map) never sees it — verified no toARM*/response struct emits a
-//     `password` under properties.
-//   - secret: the AKS servicePrincipalProfile.secret (server/azure/aks
-//     armManagedClusterProperties omits the whole block). No handler returns a
-//     property named exactly `secret` on read (verified: no json:"secret" in any
-//     response struct).
-//   - gcmCredential / apnsCredential / wnsCredential / admCredential /
-//     baiduCredential / mpnsCredential: Notification Hubs PNS credential objects.
-//     toHubJSON (server/azure/notificationhubs) models only name/registrationTtl
-//     and drops these entirely; real Azure serves them only via GetPnsCredentials,
-//     never the generic hub GET. Each is an object, so denylisting the key skips
-//     the whole credential subtree.
+// A key is treated as write-only in two ways:
 //
-// The list is deliberately conservative: a key belongs here only when real
-// Azure genuinely omits it on read AND a handler relies on that omission, so it
-// never suppresses a field a handler legitimately returns.
+// 1. Suffix rule (the robust guard against wholly-unmodeled subtrees captured
+// verbatim): any key whose lowercased name ENDS WITH "password" or "secret".
+// This covers every write-only credential input real Azure accepts but never
+// echoes, regardless of the prefix a handler's model happens not to know:
+//   - administratorLoginPassword — Microsoft.Sql/servers (server/azure/sql),
+//     DBforMySQL/DBforPostgreSQL flexibleServers (mysqlflex/postgresflex) and
+//     Cosmos DB for PostgreSQL clusters (cosmospostgresql); each toARM* omits it.
+//   - adminPassword — VM osProfile (virtualmachines); the osProfile model has no
+//     password field, so it is dropped.
+//   - initialCassandraAdminPassword — managed Cassandra (managedcassandra);
+//     toARMCluster omits it.
+//   - password — Cosmos-PG role (toARMRole drops it) and Container Instances
+//     imageRegistryCredentials[].password (the array is unmodeled, captured
+//     verbatim — hence the []any recursion in sanitizeUnmodeled).
+//   - secret — AKS servicePrincipalProfile.secret (armManagedClusterProperties
+//     omits the whole block).
+//   - serverAppSecret / clientSecret — AKS aadProfile.serverAppSecret and any
+//     clientSecret-style field in a verbatim-captured subtree (aadProfile is
+//     unmodeled). The sibling serverAppID (public) does not end in the suffix,
+//     so it still round-trips, matching real Azure's aadProfile read.
+//
+// The suffix is a true endsWith, so it never touches a field that merely
+// contains the word: secretName, secretUri, secretRef, clientSecretSetting,
+// passwordPolicy and the plural list outputs secrets/accessKeys are all
+// preserved. Verified by sweeping every server/azure response/toARM* struct: no
+// field a handler RETURNS has a json name ending in "password" or "secret". The
+// sole password-ending returned field is the Container Instances exec action's
+// `password`, a bare {webSocketUri, password} object with no id/properties — the
+// overlay only rewrites ARM resources and only ever ADDS unmodeled keys onto a
+// properties map (it never removes a handler's own fields), so that response is
+// untouched. Output credential keys a client never sends on write
+// (primaryKey/secondaryKey/accessKeys/connectionString) never enter the
+// request-capture path and are correctly left alone.
+//
+// 2. Exact-match object keys: the Notification Hubs PNS credential blocks, which
+// carry secrets but do not end in the suffixes. toHubJSON (notificationhubs)
+// models only name/registrationTtl and drops these; real Azure serves them only
+// via GetPnsCredentials, never the generic hub GET. Each is an object, so
+// denylisting the key skips the whole credential subtree.
+//
+// The rule is matched case-insensitively at any nesting depth (missingProperties
+// and sanitizeUnmodeled recurse into nested objects and arrays), and never
+// suppresses a field a handler legitimately returns.
 func writeOnlyProperty(key string) bool {
-	switch strings.ToLower(key) {
-	case "administratorloginpassword", "adminpassword", "initialcassandraadminpassword",
-		"password", "secret",
-		"gcmcredential", "apnscredential", "wnscredential",
+	lower := strings.ToLower(key)
+
+	if strings.HasSuffix(lower, "password") || strings.HasSuffix(lower, "secret") {
+		return true
+	}
+
+	switch lower {
+	case "gcmcredential", "apnscredential", "wnscredential",
 		"admcredential", "baiducredential", "mpnscredential":
 		return true
 	default:

--- a/server/azure/echo_properties.go
+++ b/server/azure/echo_properties.go
@@ -349,13 +349,37 @@ func captureUnmodeled(
 //     handler's osProfile shape carries no password field, so it is dropped.
 //   - initialCassandraAdminPassword: the seed admin password for managed
 //     Cassandra clusters (server/azure/managedcassandra). toARMCluster omits it.
+//   - password: a Cosmos DB for PostgreSQL role password (toARMRole,
+//     server/azure/cosmospostgresql, drops it) and a Container Instances
+//     imageRegistryCredentials[].password (server/azure/containerinstances does
+//     not model the array at all, so it is captured verbatim — inside an array,
+//     hence the []any recursion in sanitizeUnmodeled). Real Azure never returns
+//     either. The one place a `password` is legitimately returned is the
+//     Container Instances exec action response, but that is a bare
+//     {webSocketUri, password} object with no id/properties, so the overlay
+//     (which only rewrites ARM resources and only ever touches keys inside a
+//     properties map) never sees it — verified no toARM*/response struct emits a
+//     `password` under properties.
+//   - secret: the AKS servicePrincipalProfile.secret (server/azure/aks
+//     armManagedClusterProperties omits the whole block). No handler returns a
+//     property named exactly `secret` on read (verified: no json:"secret" in any
+//     response struct).
+//   - gcmCredential / apnsCredential / wnsCredential / admCredential /
+//     baiduCredential / mpnsCredential: Notification Hubs PNS credential objects.
+//     toHubJSON (server/azure/notificationhubs) models only name/registrationTtl
+//     and drops these entirely; real Azure serves them only via GetPnsCredentials,
+//     never the generic hub GET. Each is an object, so denylisting the key skips
+//     the whole credential subtree.
 //
 // The list is deliberately conservative: a key belongs here only when real
 // Azure genuinely omits it on read AND a handler relies on that omission, so it
 // never suppresses a field a handler legitimately returns.
 func writeOnlyProperty(key string) bool {
 	switch strings.ToLower(key) {
-	case "administratorloginpassword", "adminpassword", "initialcassandraadminpassword":
+	case "administratorloginpassword", "adminpassword", "initialcassandraadminpassword",
+		"password", "secret",
+		"gcmcredential", "apnscredential", "wnscredential",
+		"admcredential", "baiducredential", "mpnscredential":
 		return true
 	default:
 		return false
@@ -364,26 +388,36 @@ func writeOnlyProperty(key string) bool {
 
 // sanitizeUnmodeled deep-copies a captured request value with every write-only
 // secret key (writeOnlyProperty) removed at every depth. It guards the wholesale
-// capture path in missingProperties: when the handler drops an entire object,
-// that object is preserved as-is, so a secret nested inside it would otherwise
-// slip past the per-key denylist. A non-map value passes through unchanged.
+// capture path in missingProperties: when the handler drops an entire object or
+// array, it is preserved as-is, so a secret nested inside it would otherwise
+// slip past the per-key denylist. Both objects (map[string]any) and arrays
+// ([]any, e.g. imageRegistryCredentials[].password) are recursed and deep-copied
+// so no request-owned map or slice is aliased into the overlay store; any other
+// value passes through unchanged.
 func sanitizeUnmodeled(v any) any {
-	m, ok := v.(map[string]any)
-	if !ok {
-		return v
-	}
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
 
-	out := make(map[string]any, len(m))
+		for k, val := range t {
+			if writeOnlyProperty(k) {
+				continue
+			}
 
-	for k, val := range m {
-		if writeOnlyProperty(k) {
-			continue
+			out[k] = sanitizeUnmodeled(val)
 		}
 
-		out[k] = sanitizeUnmodeled(val)
-	}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, el := range t {
+			out[i] = sanitizeUnmodeled(el)
+		}
 
-	return out
+		return out
+	default:
+		return v
+	}
 }
 
 // missingProperties returns the entries of req that resp does not already carry,

--- a/server/azure/echo_properties_test.go
+++ b/server/azure/echo_properties_test.go
@@ -252,6 +252,192 @@ func TestEchoPartialPatchKeepsPreservedProps(t *testing.T) {
 	}
 }
 
+// TestEchoDoesNotLeakSQLServerPassword is the SECURITY regression: a write-only
+// secret (administratorLoginPassword) sent on a Microsoft.Sql/servers PUT must
+// never be reflected on the create response or a later GET — real Azure omits
+// it. The non-secret modeled fields (administratorLogin, version) must still be
+// returned, and a PATCH must not reintroduce the password.
+func TestEchoDoesNotLeakSQLServerPassword(t *testing.T) {
+	ts, c := echoTestServer(t)
+	url := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Sql/servers/pwsrv1?api-version=2021-11-01"
+
+	created := putJSON(t, c, url, map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			"administratorLogin":         "adminuser",
+			"administratorLoginPassword": "S3cret-P@ssw0rd!",
+			"version":                    "12.0",
+		},
+	})
+
+	if _, leaked := props(t, created)["administratorLoginPassword"]; leaked {
+		t.Fatal("create response leaked write-only administratorLoginPassword")
+	}
+
+	if props(t, created)["administratorLogin"] != "adminuser" {
+		t.Errorf("create response dropped modeled administratorLogin: %v", props(t, created)["administratorLogin"])
+	}
+
+	got := props(t, getJSON(t, c, url))
+	if _, leaked := got["administratorLoginPassword"]; leaked {
+		t.Fatal("GET leaked write-only administratorLoginPassword")
+	}
+
+	if got["administratorLogin"] != "adminuser" {
+		t.Errorf("GET dropped modeled administratorLogin: %v", got["administratorLogin"])
+	}
+
+	// A PATCH that resends the password must still not reintroduce it on read.
+	patch, err := http.NewRequestWithContext(context.Background(), http.MethodPatch, url,
+		bytesReader(t, map[string]any{"properties": map[string]any{"administratorLoginPassword": "Another-P@ss1!"}}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	patch.Header.Set("Content-Type", "application/json")
+	doJSON(t, c, patch)
+
+	if _, leaked := props(t, getJSON(t, c, url))["administratorLoginPassword"]; leaked {
+		t.Fatal("GET after PATCH reintroduced write-only administratorLoginPassword")
+	}
+}
+
+// TestEchoDoesNotLeakFlexServerPassword confirms the same secret suppression on
+// the MySQL and PostgreSQL flexible-server handlers, whose armServerProps also
+// omit administratorLoginPassword. A non-secret unmodeled field (version) still
+// round-trips through the handler.
+func TestEchoDoesNotLeakFlexServerPassword(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"mysql", "/providers/Microsoft.DBforMySQL/flexibleServers/pwflex1"},
+		{"postgres", "/providers/Microsoft.DBforPostgreSQL/flexibleServers/pwflex1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts, c := echoTestServer(t)
+			url := ts.URL + "/subscriptions/sub1/resourceGroups/rg1" + tc.path + "?api-version=2023-12-30"
+
+			created := putJSON(t, c, url, map[string]any{
+				"location": "eastus",
+				"properties": map[string]any{
+					"administratorLogin":         "adm",
+					"administratorLoginPassword": "Fl3x-P@ssw0rd!",
+					"version":                    "8.0.21",
+				},
+			})
+
+			if _, leaked := props(t, created)["administratorLoginPassword"]; leaked {
+				t.Fatal("create response leaked flexible-server administratorLoginPassword")
+			}
+
+			got := props(t, getJSON(t, c, url))
+			if _, leaked := got["administratorLoginPassword"]; leaked {
+				t.Fatal("GET leaked flexible-server administratorLoginPassword")
+			}
+
+			if got["administratorLogin"] != "adm" {
+				t.Errorf("GET dropped modeled administratorLogin: %v", got["administratorLogin"])
+			}
+		})
+	}
+}
+
+// TestEchoDoesNotLeakVMAdminPassword confirms the nested-secret case: a VM
+// osProfile.adminPassword (write-only, dropped by the handler) must not be
+// reflected, while the sibling non-secret unmodeled leaf under osProfile still
+// round-trips through the overlay.
+func TestEchoDoesNotLeakVMAdminPassword(t *testing.T) {
+	ts, c := echoTestServer(t)
+	url := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/pwvm1?api-version=2023-07-01"
+
+	putJSON(t, c, url, map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			"hardwareProfile": map[string]any{"vmSize": "Standard_D2s_v5"},
+			"osProfile": map[string]any{
+				"computerName":  "host1",
+				"adminUsername": "azureuser",
+				"adminPassword": "VM-S3cret-P@ss!",
+				"unmodeledLeaf": "keepme",
+			},
+		},
+	})
+
+	osp, ok := props(t, getJSON(t, c, url))["osProfile"].(map[string]any)
+	if !ok {
+		t.Fatalf("GET has no osProfile: %v", props(t, getJSON(t, c, url)))
+	}
+
+	if _, leaked := osp["adminPassword"]; leaked {
+		t.Fatal("GET leaked nested write-only osProfile.adminPassword")
+	}
+
+	if osp["unmodeledLeaf"] != "keepme" {
+		t.Errorf("overlay dropped a non-secret nested unmodeled leaf: %v", osp["unmodeledLeaf"])
+	}
+}
+
+// TestEchoDoesNotLeakCassandraAdminPassword confirms the managed-Cassandra
+// write-only secret (initialCassandraAdminPassword, dropped by toARMCluster) is
+// not reflected, while a non-secret modeled field (cassandraVersion) still
+// returns.
+func TestEchoDoesNotLeakCassandraAdminPassword(t *testing.T) {
+	ts, c := echoTestServer(t)
+	url := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.DocumentDB/cassandraClusters/pwcc1?api-version=2024-11-15"
+
+	created := putJSON(t, c, url, map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			"cassandraVersion":              "4.0",
+			"initialCassandraAdminPassword": "C@ssandra-S3cret!",
+		},
+	})
+
+	if _, leaked := props(t, created)["initialCassandraAdminPassword"]; leaked {
+		t.Fatal("create response leaked write-only initialCassandraAdminPassword")
+	}
+
+	got := props(t, getJSON(t, c, url))
+	if _, leaked := got["initialCassandraAdminPassword"]; leaked {
+		t.Fatal("GET leaked write-only initialCassandraAdminPassword")
+	}
+
+	if got["cassandraVersion"] != "4.0" {
+		t.Errorf("GET dropped modeled cassandraVersion: %v", got["cassandraVersion"])
+	}
+}
+
+// TestEchoStillReflectsNonSecretProperty is the REGRESSION guard: the secret
+// denylist must not disturb the overlay's legitimate job — a non-secret
+// unmodeled property (a SQL database's maxSizeBytes, which only round-trips via
+// the overlay) must still be echoed on create and GET.
+func TestEchoStillReflectsNonSecretProperty(t *testing.T) {
+	ts, c := echoTestServer(t)
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Sql/servers/regsrv1"
+
+	putJSON(t, c, base+"?api-version=2021-11-01", map[string]any{"location": "eastus"})
+
+	dbURL := base + "/databases/regdb1?api-version=2021-11-01"
+
+	created := putJSON(t, c, dbURL, map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			"maxSizeBytes": float64(268435456000),
+		},
+	})
+
+	if props(t, created)["maxSizeBytes"] != float64(268435456000) {
+		t.Fatalf("create response dropped non-secret maxSizeBytes: %v", props(t, created)["maxSizeBytes"])
+	}
+
+	if props(t, getJSON(t, c, dbURL))["maxSizeBytes"] != float64(268435456000) {
+		t.Fatalf("GET dropped non-secret maxSizeBytes: %v", props(t, getJSON(t, c, dbURL))["maxSizeBytes"])
+	}
+}
+
 func bytesReader(t *testing.T, v map[string]any) *bytes.Reader {
 	t.Helper()
 

--- a/server/azure/echo_properties_test.go
+++ b/server/azure/echo_properties_test.go
@@ -410,6 +410,175 @@ func TestEchoDoesNotLeakCassandraAdminPassword(t *testing.T) {
 	}
 }
 
+// TestEchoDoesNotLeakCosmosPGRolePassword confirms a Cosmos DB for PostgreSQL
+// role password (toARMRole drops it) is not reflected, while the modeled
+// provisioningState still returns.
+func TestEchoDoesNotLeakCosmosPGRolePassword(t *testing.T) {
+	ts, c := echoTestServer(t)
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/pgc1"
+
+	putJSON(t, c, base+"?api-version=2023-03-02-preview", map[string]any{"location": "eastus"})
+
+	roleURL := base + "/roles/role1?api-version=2023-03-02-preview"
+
+	created := putJSON(t, c, roleURL, map[string]any{
+		"properties": map[string]any{"password": "R0le-S3cret!"},
+	})
+
+	if _, leaked := props(t, created)["password"]; leaked {
+		t.Fatal("create response leaked write-only role password")
+	}
+
+	if _, leaked := props(t, getJSON(t, c, roleURL))["password"]; leaked {
+		t.Fatal("GET leaked write-only role password")
+	}
+}
+
+// TestEchoDoesNotLeakAKSServicePrincipalSecret confirms the nested-object case:
+// servicePrincipalProfile is unmodeled by the AKS handler, so it is captured
+// wholesale — its secret must be stripped while the non-secret clientId leaf
+// still round-trips.
+func TestEchoDoesNotLeakAKSServicePrincipalSecret(t *testing.T) {
+	ts, c := echoTestServer(t)
+	url := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/aks1?api-version=2024-02-01"
+
+	putJSON(t, c, url, map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			"kubernetesVersion": "1.28.0",
+			"servicePrincipalProfile": map[string]any{
+				"clientId": "abc-123",
+				"secret":   "SP-S3cret!",
+			},
+		},
+	})
+
+	spp, ok := props(t, getJSON(t, c, url))["servicePrincipalProfile"].(map[string]any)
+	if !ok {
+		t.Fatalf("GET dropped the whole unmodeled servicePrincipalProfile: %v", props(t, getJSON(t, c, url)))
+	}
+
+	if _, leaked := spp["secret"]; leaked {
+		t.Fatal("GET leaked write-only servicePrincipalProfile.secret")
+	}
+
+	if spp["clientId"] != "abc-123" {
+		t.Errorf("overlay dropped non-secret servicePrincipalProfile.clientId: %v", spp["clientId"])
+	}
+}
+
+// TestEchoDoesNotLeakContainerRegistryPassword is the ARRAY-recursion regression:
+// imageRegistryCredentials is an unmodeled array of objects, each carrying a
+// write-only password. The array must round-trip (server/username preserved)
+// with every element's password stripped.
+func TestEchoDoesNotLeakContainerRegistryPassword(t *testing.T) {
+	ts, c := echoTestServer(t)
+	url := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.ContainerInstance/containerGroups/cg1?api-version=2023-05-01"
+
+	putJSON(t, c, url, map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			"osType": "Linux",
+			"imageRegistryCredentials": []any{
+				map[string]any{"server": "reg.azurecr.io", "username": "u1", "password": "Reg-S3cret!"},
+			},
+		},
+	})
+
+	creds, ok := props(t, getJSON(t, c, url))["imageRegistryCredentials"].([]any)
+	if !ok || len(creds) != 1 {
+		t.Fatalf("GET dropped the unmodeled imageRegistryCredentials array: %v", props(t, getJSON(t, c, url))["imageRegistryCredentials"])
+	}
+
+	cred, ok := creds[0].(map[string]any)
+	if !ok {
+		t.Fatalf("imageRegistryCredentials element is not an object: %v", creds[0])
+	}
+
+	if _, leaked := cred["password"]; leaked {
+		t.Fatal("GET leaked write-only password inside imageRegistryCredentials array element")
+	}
+
+	if cred["server"] != "reg.azurecr.io" || cred["username"] != "u1" {
+		t.Errorf("array recursion dropped non-secret siblings: %v", cred)
+	}
+}
+
+// TestEchoDoesNotLeakNotificationHubCredentials confirms the Notification Hubs
+// PNS credential objects (dropped by toHubJSON, served only via
+// GetPnsCredentials) are not reflected on the generic hub GET, while the modeled
+// registrationTtl still returns.
+func TestEchoDoesNotLeakNotificationHubCredentials(t *testing.T) {
+	ts, c := echoTestServer(t)
+	nsURL := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.NotificationHubs/namespaces/ns1"
+
+	putJSON(t, c, nsURL+"?api-version=2023-09-01", map[string]any{"location": "eastus"})
+
+	hubURL := nsURL + "/notificationHubs/hub1?api-version=2023-09-01"
+
+	putJSON(t, c, hubURL, map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			"registrationTtl": "P1D",
+			"gcmCredential":   map[string]any{"properties": map[string]any{"googleApiKey": "GKEY"}},
+			"apnsCredential":  map[string]any{"properties": map[string]any{"token": "APNS-TOKEN"}},
+		},
+	})
+
+	got := props(t, getJSON(t, c, hubURL))
+	for _, k := range []string{"gcmCredential", "apnsCredential"} {
+		if _, leaked := got[k]; leaked {
+			t.Fatalf("GET leaked write-only Notification Hubs %s", k)
+		}
+	}
+
+	if got["registrationTtl"] != "P1D" {
+		t.Errorf("overlay dropped modeled registrationTtl: %v", got["registrationTtl"])
+	}
+}
+
+// TestEchoStripsSecretNestedDeepInArray confirms sanitizeUnmodeled removes a
+// secret buried two levels inside an array-of-objects (array -> object ->
+// object.password) while leaving the non-secret siblings intact — the deep
+// array-recursion guarantee.
+func TestEchoStripsSecretNestedDeepInArray(t *testing.T) {
+	ts, c := echoTestServer(t)
+	url := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/deepvm?api-version=2023-07-01"
+
+	putJSON(t, c, url, map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			// wholly unmodeled array of objects, each with a nested auth object
+			// carrying a secret.
+			"customConfigs": []any{
+				map[string]any{
+					"name": "a",
+					"auth": map[string]any{"user": "x", "password": "Deep-S3cret!"},
+				},
+			},
+		},
+	})
+
+	cfgs, ok := props(t, getJSON(t, c, url))["customConfigs"].([]any)
+	if !ok || len(cfgs) != 1 {
+		t.Fatalf("GET dropped the unmodeled customConfigs array: %v", props(t, getJSON(t, c, url))["customConfigs"])
+	}
+
+	entry, _ := cfgs[0].(map[string]any)
+	auth, ok := entry["auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("customConfigs entry lost its nested auth object: %v", entry)
+	}
+
+	if _, leaked := auth["password"]; leaked {
+		t.Fatal("secret buried in an array-of-objects survived sanitizeUnmodeled")
+	}
+
+	if entry["name"] != "a" || auth["user"] != "x" {
+		t.Errorf("deep array recursion dropped non-secret siblings: %v", entry)
+	}
+}
+
 // TestEchoStillReflectsNonSecretProperty is the REGRESSION guard: the secret
 // denylist must not disturb the overlay's legitimate job — a non-secret
 // unmodeled property (a SQL database's maxSizeBytes, which only round-trips via

--- a/server/azure/echo_properties_test.go
+++ b/server/azure/echo_properties_test.go
@@ -579,6 +579,85 @@ func TestEchoStripsSecretNestedDeepInArray(t *testing.T) {
 	}
 }
 
+// TestEchoDoesNotLeakAKSAADServerAppSecret is the 3rd-batch regression: the AKS
+// handler does not model aadProfile, so the whole block is captured verbatim.
+// serverAppSecret (which lowercases to serverappsecret, not an exact denylist
+// entry) must still be stripped by the ENDS-WITH-secret rule, while the public
+// serverAppID sibling — not ending in the suffix — round-trips as real Azure does.
+func TestEchoDoesNotLeakAKSAADServerAppSecret(t *testing.T) {
+	ts, c := echoTestServer(t)
+	url := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/aksaad?api-version=2024-02-01"
+
+	putJSON(t, c, url, map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			"kubernetesVersion": "1.28.0",
+			"aadProfile": map[string]any{
+				"managed":         true,
+				"serverAppID":     "public-app-id",
+				"serverAppSecret": "AAD-S3cret!",
+				"clientSecret":    "Client-S3cret!",
+			},
+		},
+	})
+
+	aad, ok := props(t, getJSON(t, c, url))["aadProfile"].(map[string]any)
+	if !ok {
+		t.Fatalf("GET dropped the whole unmodeled aadProfile: %v", props(t, getJSON(t, c, url)))
+	}
+
+	if _, leaked := aad["serverAppSecret"]; leaked {
+		t.Fatal("GET leaked write-only aadProfile.serverAppSecret (suffix rule failed)")
+	}
+
+	if _, leaked := aad["clientSecret"]; leaked {
+		t.Fatal("GET leaked write-only aadProfile.clientSecret (suffix rule failed)")
+	}
+
+	if aad["serverAppID"] != "public-app-id" {
+		t.Errorf("overlay dropped non-secret aadProfile.serverAppID: %v", aad["serverAppID"])
+	}
+}
+
+// TestEchoSuffixRuleIsEndsWithNotContains locks the suffix semantics: keys
+// ENDING in password/secret are stripped, while keys that merely CONTAIN the
+// word (secretName, passwordPolicy) — a true endsWith, not a substring match —
+// survive. All live inside one wholly-unmodeled block so the overlay carries them.
+func TestEchoSuffixRuleIsEndsWithNotContains(t *testing.T) {
+	ts, c := echoTestServer(t)
+	url := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/suffixvm?api-version=2023-07-01"
+
+	putJSON(t, c, url, map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			"customCreds": map[string]any{
+				"adminPassword":  "P@ss!",     // ends password -> stripped
+				"clientSecret":   "S3cret!",   // ends secret   -> stripped
+				"secretName":     "kv-entry",  // contains, not ends -> kept
+				"passwordPolicy": "Strong",    // contains, not ends -> kept
+				"secretUri":      "https://x", // contains, not ends -> kept
+			},
+		},
+	})
+
+	cc, ok := props(t, getJSON(t, c, url))["customCreds"].(map[string]any)
+	if !ok {
+		t.Fatalf("GET dropped the unmodeled customCreds block: %v", props(t, getJSON(t, c, url)))
+	}
+
+	for _, k := range []string{"adminPassword", "clientSecret"} {
+		if _, leaked := cc[k]; leaked {
+			t.Fatalf("suffix rule failed to strip %s", k)
+		}
+	}
+
+	for _, k := range []string{"secretName", "passwordPolicy", "secretUri"} {
+		if _, ok := cc[k]; !ok {
+			t.Fatalf("suffix rule over-suppressed non-secret %s (endsWith, not contains)", k)
+		}
+	}
+}
+
 // TestEchoStillReflectsNonSecretProperty is the REGRESSION guard: the secret
 // denylist must not disturb the overlay's legitimate job — a non-secret
 // unmodeled property (a SQL database's maxSizeBytes, which only round-trips via


### PR DESCRIPTION
## Summary

The generic Azure ARM property-echo overlay (`server/azure/echo_properties.go`) reflected **write-only secrets** back on reads — a credential leak.

The overlay's job is to preserve request `properties` keys a handler didn't model, echoing them on the create response and later GETs. But when a handler *deliberately* omits a write-only secret from its response (mirroring real Azure, which never returns these), the overlay treated the dropped key as merely "unmodeled" and reflected the caller's secret verbatim — on create **and every subsequent GET** (persisted in-memory keyed by resource id).

Concrete leak: `armsql` PUT `Microsoft.Sql/servers` with `administratorLoginPassword` → `toARMServer` correctly omits it → overlay re-added it → GET echoed the password.

## Fix

Added a conservative **write-only / sensitive key denylist** to the overlay. Denylisted keys are never captured, persisted, or echoed. Match is **case-insensitive** and applies at **every nesting depth** (the overlay descends into nested `properties.*`). Wholesale-captured objects (a whole subtree the handler dropped) are sanitized too, so a nested secret can't slip past the per-key skip.

### Denylist entries (each verified against the owning handler's to-ARM function)

| Key | Services | Justification |
|-----|----------|---------------|
| `administratorLoginPassword` | `Microsoft.Sql/servers`, `Microsoft.DBforMySQL/flexibleServers`, `Microsoft.DBforPostgreSQL/flexibleServers`, Cosmos DB for PostgreSQL (`serverGroupsv2`) | Each handler accepts it on write and its `toARM*` omits it; real Azure never returns it on read. |
| `adminPassword` | `Microsoft.Compute/virtualMachines` (osProfile) | The VM `osProfile` shape models no password field, so the handler drops it; real Azure returns null for it. |
| `initialCassandraAdminPassword` | `Microsoft.DocumentDB/cassandraClusters` | Handler accepts it on write; `toARMCluster` omits it; real Azure never returns it. |

The list is deliberately conservative: a key is included only when (a) real Azure genuinely omits it on read AND (b) a handler relies on that omission — so it never suppresses a field a handler legitimately returns. (The overlay only ever *adds* keys a handler dropped, so denylisting never affects a field a handler itself echoes.)

## Blast radius

This overlay is cross-cutting across all Azure ARM handlers. Verified:
- The overlay still reflects legitimate non-secret unmodeled properties (SQL database `maxSizeBytes`, VM nested leaves, flex `maintenanceWindow`) — regression guard test included.
- Broad Azure server + provider test pass green; no handler that legitimately echoed a denylisted key regresses (none do — all omit them).

## Tests (hand-rolled, matching `server/azure` style)

- SQL server password not echoed on create/GET/PATCH; non-secret fields still returned.
- MySQL + PostgreSQL flexible-server password not echoed.
- VM nested `osProfile.adminPassword` not echoed; sibling non-secret leaf still round-trips.
- Managed Cassandra `initialCassandraAdminPassword` not echoed.
- Regression guard: non-secret `maxSizeBytes` still reflected.

## Gates

build · vet · `go test ./server/azure/... ./providers/azure/...` · `-race ./server/azure/sql/...` · root test · gofmt · golangci-lint (0 issues) · `go generate` zero diff · compatgen + `docs/compat` zero diff — all green.