### PR TITLE
fix(iam): embed entity Path in ARN on create; guard tag-map reads

### DIFF
--- a/providers/aws/iam/arn_path_test.go
+++ b/providers/aws/iam/arn_path_test.go
@@ -1,0 +1,131 @@
+package iam
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+const nestedPath = "/div/sub/"
+
+// TestCreateEntityARNEmbedsPath verifies that a non-default Path is folded into
+// the entity ARN (arn:aws:iam::123456789012:user/div/sub/bob), while the default
+// path "/" leaves the ARN unchanged (regression guard).
+func TestCreateEntityARNEmbedsPath(t *testing.T) {
+	ctx := context.Background()
+
+	makeUser := func(m *Mock, path string) (string, error) {
+		info, err := m.CreateUser(ctx, driver.UserConfig{Name: "bob", Path: path})
+		if err != nil {
+			return "", err
+		}
+		return info.ARN, nil
+	}
+	makeRole := func(m *Mock, path string) (string, error) {
+		info, err := m.CreateRole(ctx, driver.RoleConfig{Name: "r1", Path: path})
+		if err != nil {
+			return "", err
+		}
+		return info.ARN, nil
+	}
+	makePolicy := func(m *Mock, path string) (string, error) {
+		info, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "p1", Path: path, PolicyDocument: makePolicyDoc(nil)})
+		if err != nil {
+			return "", err
+		}
+		return info.ARN, nil
+	}
+	makeGroup := func(m *Mock, path string) (string, error) {
+		info, err := m.CreateGroup(ctx, driver.GroupConfig{Name: "g1", Path: path})
+		if err != nil {
+			return "", err
+		}
+		return info.ARN, nil
+	}
+	makeProfile := func(m *Mock, path string) (string, error) {
+		info, err := m.CreateInstanceProfile(ctx, driver.InstanceProfileConfig{Name: "ip1", Path: path})
+		if err != nil {
+			return "", err
+		}
+		return info.ARN, nil
+	}
+
+	tests := []struct {
+		name        string
+		make        func(*Mock, string) (string, error)
+		wantNested  string
+		wantDefault string
+	}{
+		{"user", makeUser, "arn:aws:iam::123456789012:user/div/sub/bob", "arn:aws:iam::123456789012:user/bob"},
+		{"role", makeRole, "arn:aws:iam::123456789012:role/div/sub/r1", "arn:aws:iam::123456789012:role/r1"},
+		{"policy", makePolicy, "arn:aws:iam::123456789012:policy/div/sub/p1", "arn:aws:iam::123456789012:policy/p1"},
+		{"group", makeGroup, "arn:aws:iam::123456789012:group/div/sub/g1", "arn:aws:iam::123456789012:group/g1"},
+		{
+			"instance-profile", makeProfile,
+			"arn:aws:iam::123456789012:instance-profile/div/sub/ip1",
+			"arn:aws:iam::123456789012:instance-profile/ip1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name+" nested path", func(t *testing.T) {
+			arn, err := tc.make(newTestMock(), nestedPath)
+			requireNoError(t, err)
+			assertEqual(t, tc.wantNested, arn)
+		})
+
+		t.Run(tc.name+" default path unchanged", func(t *testing.T) {
+			arn, err := tc.make(newTestMock(), "")
+			requireNoError(t, err)
+			assertEqual(t, tc.wantDefault, arn)
+		})
+	}
+}
+
+// TestConcurrentTagAndGet exercises the tag-map read/write paths concurrently so
+// that `go test -race` flags any unsynchronized access to an entity's Tags map.
+func TestConcurrentTagAndGet(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateUser(ctx, driver.UserConfig{Name: "alice"})
+	requireNoError(t, err)
+	_, err = m.CreateRole(ctx, driver.RoleConfig{Name: "svc"})
+	requireNoError(t, err)
+
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(4)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = m.TagUser(ctx, "alice", map[string]string{"team": "dev"})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_, _ = m.GetUser(ctx, "alice")
+			_, _ = m.ListUsers(ctx)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = m.TagRole(ctx, "svc", map[string]string{"env": "test"})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_, _ = m.GetRole(ctx, "svc")
+			_, _ = m.ListRoles(ctx)
+		}
+	}()
+
+	wg.Wait()
+}

--- a/providers/aws/iam/iam.go
+++ b/providers/aws/iam/iam.go
@@ -142,7 +142,7 @@ func (m *Mock) CreateUser(_ context.Context, cfg driver.UserConfig) (*driver.Use
 	}
 
 	id := idgen.GenerateID("AIDA")
-	arn := idgen.AWSARN("iam", "", m.opts.AccountID, "user/"+cfg.Name)
+	arn := idgen.AWSARN("iam", "", m.opts.AccountID, "user/"+strings.TrimPrefix(path, "/")+cfg.Name)
 	tags := copyTags(cfg.Tags)
 
 	u := &userData{
@@ -210,6 +210,9 @@ func (m *Mock) GetUser(_ context.Context, name string) (*driver.UserInfo, error)
 		return nil, errors.Newf(errors.NotFound, "user %q not found", name)
 	}
 
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	info := toUserInfo(u)
 
 	return &info, nil
@@ -219,6 +222,9 @@ func (m *Mock) GetUser(_ context.Context, name string) (*driver.UserInfo, error)
 func (m *Mock) ListUsers(_ context.Context) ([]driver.UserInfo, error) {
 	all := m.users.All()
 	result := make([]driver.UserInfo, 0, len(all))
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	for _, u := range all {
 		result = append(result, toUserInfo(u))
@@ -243,7 +249,7 @@ func (m *Mock) CreateRole(_ context.Context, cfg driver.RoleConfig) (*driver.Rol
 	}
 
 	id := idgen.GenerateID("AROA")
-	arn := idgen.AWSARN("iam", "", m.opts.AccountID, "role/"+cfg.Name)
+	arn := idgen.AWSARN("iam", "", m.opts.AccountID, "role/"+strings.TrimPrefix(path, "/")+cfg.Name)
 	tags := copyTags(cfg.Tags)
 
 	maxSession := cfg.MaxSessionDuration
@@ -312,6 +318,9 @@ func (m *Mock) GetRole(_ context.Context, name string) (*driver.RoleInfo, error)
 		return nil, errors.Newf(errors.NotFound, "role %q not found", name)
 	}
 
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	info := toRoleInfo(r)
 
 	return &info, nil
@@ -321,6 +330,9 @@ func (m *Mock) GetRole(_ context.Context, name string) (*driver.RoleInfo, error)
 func (m *Mock) ListRoles(_ context.Context) ([]driver.RoleInfo, error) {
 	all := m.roles.All()
 	result := make([]driver.RoleInfo, 0, len(all))
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	for _, r := range all {
 		result = append(result, toRoleInfo(r))
@@ -341,7 +353,7 @@ func (m *Mock) CreatePolicy(_ context.Context, cfg driver.PolicyConfig) (*driver
 	}
 
 	id := idgen.GenerateID("ANPA")
-	arn := idgen.AWSARN("iam", "", m.opts.AccountID, "policy/"+cfg.Name)
+	arn := idgen.AWSARN("iam", "", m.opts.AccountID, "policy/"+strings.TrimPrefix(path, "/")+cfg.Name)
 
 	if m.policies.Has(arn) {
 		return nil, errors.Newf(errors.AlreadyExists, "policy %q already exists", cfg.Name)
@@ -906,7 +918,7 @@ func (m *Mock) CreateGroup(
 	}
 
 	arn := idgen.AWSARN(
-		"iam", "", m.opts.AccountID, "group/"+cfg.Name,
+		"iam", "", m.opts.AccountID, "group/"+strings.TrimPrefix(path, "/")+cfg.Name,
 	)
 
 	g := &groupData{
@@ -1222,16 +1234,16 @@ func (m *Mock) CreateInstanceProfile(
 		)
 	}
 
-	id := idgen.GenerateID("AIPA")
-	arn := idgen.AWSARN(
-		"iam", "", m.opts.AccountID,
-		"instance-profile/"+cfg.Name,
-	)
-
 	path := cfg.Path
 	if path == "" {
 		path = "/"
 	}
+
+	id := idgen.GenerateID("AIPA")
+	arn := idgen.AWSARN(
+		"iam", "", m.opts.AccountID,
+		"instance-profile/"+strings.TrimPrefix(path, "/")+cfg.Name,
+	)
 
 	info := &driver.InstanceProfileInfo{
 		ID:        id,

--- a/server/aws/iam/arn_path_test.go
+++ b/server/aws/iam/arn_path_test.go
@@ -1,0 +1,95 @@
+package iam_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+)
+
+// TestSDKEntityARNEmbedsPath proves that a non-default Path is folded into the
+// ARN of every path-bearing IAM entity, over the real wire protocol and the
+// aws-sdk-go-v2 iam client. A path-less entity keeps the flat ARN (regression).
+func TestSDKEntityARNEmbedsPath(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const path = "/div/sub/"
+
+	user, err := client.CreateUser(ctx, &iam.CreateUserInput{
+		UserName: aws.String("bob"), Path: aws.String(path),
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	assertARN(t, "user", user.User.Arn,
+		"arn:aws:iam::123456789012:user/div/sub/bob")
+
+	role, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName: aws.String("r1"), Path: aws.String(path),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	assertARN(t, "role", role.Role.Arn,
+		"arn:aws:iam::123456789012:role/div/sub/r1")
+
+	policy, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName: aws.String("p1"), Path: aws.String(path),
+		PolicyDocument: aws.String(samplePolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+	assertARN(t, "policy", policy.Policy.Arn,
+		"arn:aws:iam::123456789012:policy/div/sub/p1")
+
+	group, err := client.CreateGroup(ctx, &iam.CreateGroupInput{
+		GroupName: aws.String("g1"), Path: aws.String(path),
+	})
+	if err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+	assertARN(t, "group", group.Group.Arn,
+		"arn:aws:iam::123456789012:group/div/sub/g1")
+
+	profile, err := client.CreateInstanceProfile(ctx, &iam.CreateInstanceProfileInput{
+		InstanceProfileName: aws.String("ip1"), Path: aws.String(path),
+	})
+	if err != nil {
+		t.Fatalf("CreateInstanceProfile: %v", err)
+	}
+	assertARN(t, "instance-profile", profile.InstanceProfile.Arn,
+		"arn:aws:iam::123456789012:instance-profile/div/sub/ip1")
+}
+
+// TestSDKDefaultPathARNUnchanged is the regression guard: a create with no Path
+// yields the flat ARN, exactly as before the path fix.
+func TestSDKDefaultPathARNUnchanged(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	user, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("flat")})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	assertARN(t, "user", user.User.Arn, "arn:aws:iam::123456789012:user/flat")
+
+	role, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName: aws.String("flatrole"), AssumeRolePolicyDocument: aws.String(trustPolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	assertARN(t, "role", role.Role.Arn, "arn:aws:iam::123456789012:role/flatrole")
+}
+
+func assertARN(t *testing.T, kind string, got *string, want string) {
+	t.Helper()
+
+	if actual := aws.ToString(got); actual != want {
+		t.Fatalf("%s ARN = %q, want %q", kind, actual, want)
+	}
+}


### PR DESCRIPTION
Fixes two AWS IAM bugs in `providers/aws/iam/iam.go`.

## Bug 1 (MED) — entity Path dropped from ARN on create
An IAM entity created with a non-default `Path` did not embed the path in its ARN. `CreateUser/CreateRole/CreatePolicy/CreateGroup/CreateInstanceProfile` built the ARN resource as `"<type>/"+Name`, so a path-set entity got `.../user/bob` instead of `.../user/div/sub/bob`. The `Path` field was returned correctly; only the ARN was wrong. This broke Terraform `aws_iam_{user,role,policy}.arn` and any trust/resource policy interpolating the ARN whenever a path was set.

Fix: build the resource as `"<type>/" + strings.TrimPrefix(path, "/") + Name` using the normalized (leading+trailing slash) path — matching `service_linked_role.go`. Default path `/` yields the exact old ARN (regression-safe).

## Bug 2 (LOW, concurrency) — tag map read without lock
User/Role `Tags` maps are mutated under `m.mu` (TagUser/TagRole) but were read via `toUserInfo`/`toRoleInfo` in GetUser/ListUsers/GetRole/ListRoles without holding `m.mu` — a data race on the inner map. Fixed by taking `m.mu.RLock()` on those read paths (lock ordering matches the rest of the file; `go test -race` now clean).

## Tests
- `providers/aws/iam/arn_path_test.go` — all five entities with `Path="/div/sub/"` embed the path; default path unchanged; a `-race` concurrent Tag+Get loop (confirmed to catch the race when the guard is removed).
- `server/aws/iam/arn_path_test.go` — real `aws-sdk-go-v2/service/iam` e2e over the booted wire server asserting the ARN for all five entities, plus a default-path regression guard.

## Gates (GOMAXPROCS=3)
build, vet, `go test` on server/providers/services iam, `go test -race` on providers/aws/iam, gofmt, golangci-lint (0 new), `go generate` zero-diff, compatgen + `docs/compat` zero-diff — all green.

Not included (tracked separately): UpdateUser/UpdateGroup rename, account alias CRUD, login profile CRUD, policy/instance-profile tagging.