### PR TITLE
fix(vpc): round-trip CreateVpc InstanceTenancy instead of hardcoding default

### DIFF
--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -43,6 +43,14 @@ const (
 	defaultSGDescription = "default VPC security group"
 )
 
+// VPC instance tenancy. Real EC2 CreateVpc accepts only "default" and
+// "dedicated"; "host" is a valid instance placement tenancy but is rejected by
+// CreateVpc, and any other value is an InvalidParameterValue.
+const (
+	tenancyDefault   = "default"
+	tenancyDedicated = "dedicated"
+)
+
 // Compile-time checks. The optional capabilities are asserted too: without
 // this a signature drifting out of shape would silently stop satisfying the
 // interface and every call would answer InvalidAction at runtime instead of
@@ -176,6 +184,7 @@ type vpcData struct {
 	EnableDNSSupport   bool
 	EnableDNSHostnames bool
 	DhcpOptionsID      string
+	InstanceTenancy    string
 }
 
 type subnetData struct {
@@ -279,6 +288,11 @@ func (m *Mock) CreateVPC(_ context.Context, cfg driver.VPCConfig) (*driver.VPCIn
 		return nil, err
 	}
 
+	tenancy, err := validateInstanceTenancy(cfg.InstanceTenancy)
+	if err != nil {
+		return nil, err
+	}
+
 	id := idgen.GenerateID("vpc-")
 	tags := copyTags(cfg.Tags)
 
@@ -289,6 +303,7 @@ func (m *Mock) CreateVPC(_ context.Context, cfg driver.VPCConfig) (*driver.VPCIn
 		Tags:      tags,
 		// EC2 defaults DNS support on and DNS hostnames off for a new VPC.
 		EnableDNSSupport: true,
+		InstanceTenancy:  tenancy,
 	}
 	m.vpcs.Set(id, v)
 
@@ -619,6 +634,22 @@ func validateVPCCIDR(cidr string) error {
 	}
 
 	return nil
+}
+
+// validateInstanceTenancy normalizes and checks a VPC's requested instance
+// tenancy. An empty value defaults to "default". Real EC2 CreateVpc accepts only
+// "default" and "dedicated" — "host" and every other value are rejected with
+// InvalidParameterValue (the wire layer maps this InvalidArgument to that code).
+func validateInstanceTenancy(tenancy string) (string, error) {
+	switch tenancy {
+	case "":
+		return tenancyDefault, nil
+	case tenancyDefault, tenancyDedicated:
+		return tenancy, nil
+	default:
+		return "", errors.Newf(errors.InvalidArgument,
+			"invalid value %q for InstanceTenancy", tenancy)
+	}
 }
 
 // cidrWithinVPC reports whether the subnet CIDR sits entirely inside the VPC's
@@ -1097,6 +1128,7 @@ func toVPCInfo(v *vpcData) driver.VPCInfo {
 		EnableDNSSupport:   v.EnableDNSSupport,
 		EnableDNSHostnames: v.EnableDNSHostnames,
 		DhcpOptionsID:      v.DhcpOptionsID,
+		InstanceTenancy:    v.InstanceTenancy,
 	}
 }
 

--- a/providers/aws/vpc/vpc_test.go
+++ b/providers/aws/vpc/vpc_test.go
@@ -70,6 +70,44 @@ func TestCreateVPC(t *testing.T) {
 	}
 }
 
+func TestCreateVPCInstanceTenancy(t *testing.T) {
+	tests := []struct {
+		name      string
+		tenancy   string
+		want      string
+		expectErr bool
+	}{
+		{name: "unset defaults to default", tenancy: "", want: "default"},
+		{name: "explicit default", tenancy: "default", want: "default"},
+		{name: "dedicated round-trips", tenancy: "dedicated", want: "dedicated"},
+		{name: "host rejected on create", tenancy: "host", expectErr: true},
+		{name: "bogus rejected", tenancy: "bogus", expectErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			ctx := context.Background()
+
+			info, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16", InstanceTenancy: tc.tenancy})
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				if !cerrors.IsInvalidArgument(err) {
+					t.Fatalf("error = %v, want InvalidArgument", err)
+				}
+				return
+			}
+
+			assertEqual(t, tc.want, info.InstanceTenancy)
+
+			vpcs, derr := m.DescribeVPCs(ctx, []string{info.ID})
+			requireNoError(t, derr)
+			assertEqual(t, tc.want, vpcs[0].InstanceTenancy)
+		})
+	}
+}
+
 func TestDeleteVPC(t *testing.T) {
 	m := newTestMock()
 	v := createTestVPC(m)

--- a/server/aws/ec2/vpc.go
+++ b/server/aws/ec2/vpc.go
@@ -23,6 +23,11 @@ const dhcpDefault = "default"
 // association in cidrBlockAssociationSet.
 const cidrAssocIDPrefix = "vpc-cidr-assoc-"
 
+// tenancyDefaultXML is the instanceTenancy value EC2 reports for a VPC created
+// without an explicit tenancy (the provider stores this too, so this only
+// covers records created outside the AWS wire layer).
+const tenancyDefaultXML = "default"
+
 // cidrStateAssociated is the terminal state AWS reports for an in-use VPC CIDR
 // association.
 const cidrStateAssociated = "associated"
@@ -76,8 +81,9 @@ type deleteVpcResponseXML struct {
 
 func (h *Handler) createVpc(w http.ResponseWriter, r *http.Request) {
 	cfg := netdriver.VPCConfig{
-		CIDRBlock: r.Form.Get("CidrBlock"),
-		Tags:      mergeTagSpecs(awsquery.TagSpecs(r.Form), "vpc"),
+		CIDRBlock:       r.Form.Get("CidrBlock"),
+		InstanceTenancy: r.Form.Get("InstanceTenancy"),
+		Tags:            mergeTagSpecs(awsquery.TagSpecs(r.Form), "vpc"),
 	}
 
 	info, err := h.vpc.CreateVPC(r.Context(), cfg)
@@ -145,7 +151,7 @@ func toVpcXML(v *netdriver.VPCInfo) vpcXML {
 		State:                   state,
 		CidrBlock:               v.CIDRBlock,
 		DhcpOptionsID:           nonEmpty(v.DhcpOptionsID, dhcpDefault),
-		InstanceTenancy:         "default",
+		InstanceTenancy:         nonEmpty(v.InstanceTenancy, tenancyDefaultXML),
 		IsDefault:               false,
 		OwnerID:                 ownerID,
 		CidrBlockAssociationSet: vpcCidrAssociationSet(v),

--- a/server/aws/ec2/vpc_tenancy_test.go
+++ b/server/aws/ec2/vpc_tenancy_test.go
@@ -1,0 +1,82 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestCreateVpcInstanceTenancyRoundTrips pins that a VPC created with
+// InstanceTenancy=dedicated reads back as "dedicated" on DescribeVpcs rather
+// than the hardcoded "default" — the perpetual-drift bug on
+// aws_vpc.instance_tenancy.
+func TestCreateVpcInstanceTenancyRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	created, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{
+		CidrBlock:       aws.String("10.0.0.0/16"),
+		InstanceTenancy: ec2types.TenancyDedicated,
+	})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	if created.Vpc.InstanceTenancy != ec2types.TenancyDedicated {
+		t.Errorf("CreateVpc InstanceTenancy = %q, want dedicated", created.Vpc.InstanceTenancy)
+	}
+
+	vpcID := aws.ToString(created.Vpc.VpcId)
+
+	out, err := c.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{VpcIds: []string{vpcID}})
+	if err != nil {
+		t.Fatalf("DescribeVpcs: %v", err)
+	}
+
+	if got := out.Vpcs[0].InstanceTenancy; got != ec2types.TenancyDedicated {
+		t.Errorf("DescribeVpcs InstanceTenancy = %q, want dedicated", got)
+	}
+}
+
+// TestCreateVpcInstanceTenancyDefaultsWhenUnset pins that omitting InstanceTenancy
+// yields "default".
+func TestCreateVpcInstanceTenancyDefaultsWhenUnset(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	vpcID := mkVPC(ctx, t, c, "10.0.0.0/16")
+
+	out, err := c.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{VpcIds: []string{vpcID}})
+	if err != nil {
+		t.Fatalf("DescribeVpcs: %v", err)
+	}
+
+	if got := out.Vpcs[0].InstanceTenancy; got != ec2types.TenancyDefault {
+		t.Errorf("DescribeVpcs InstanceTenancy = %q, want default", got)
+	}
+}
+
+// TestCreateVpcInstanceTenancyInvalidRejected pins that a bogus tenancy — and the
+// "host" value, which real EC2 CreateVpc rejects — both fail with
+// InvalidParameterValue rather than being silently accepted.
+func TestCreateVpcInstanceTenancyInvalidRejected(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	for _, tenancy := range []ec2types.Tenancy{ec2types.TenancyHost, "bogus"} {
+		_, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{
+			CidrBlock:       aws.String("10.0.0.0/16"),
+			InstanceTenancy: tenancy,
+		})
+		if err == nil {
+			t.Fatalf("CreateVpc(InstanceTenancy=%q): expected error, got nil", tenancy)
+		}
+
+		if code := apiCode(t, err); code != "InvalidParameterValue" {
+			t.Errorf("CreateVpc(InstanceTenancy=%q) error code = %q, want InvalidParameterValue", tenancy, code)
+		}
+	}
+}

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -7,6 +7,10 @@ import "context"
 type VPCConfig struct {
 	CIDRBlock string
 	Tags      map[string]string
+	// InstanceTenancy is the default tenancy of instances launched into the VPC
+	// ("default" or "dedicated"). An AWS concept; empty means "default". Azure and
+	// GCP do not model per-network tenancy and leave it unset.
+	InstanceTenancy string
 }
 
 // VPCInfo describes a VPC.
@@ -22,6 +26,9 @@ type VPCInfo struct {
 	// DhcpOptionsID is the DHCP option set associated with the VPC. Empty means
 	// the Amazon-provided default set; AssociateDhcpOptions changes it.
 	DhcpOptionsID string
+	// InstanceTenancy is the default tenancy of instances launched into the VPC
+	// ("default" or "dedicated"). An AWS concept; Azure and GCP leave it empty.
+	InstanceTenancy string
 }
 
 // SubnetConfig describes a subnet to create.


### PR DESCRIPTION
## Summary

`CreateVpc` with `InstanceTenancy=dedicated` was accepted but `DescribeVpcs` always reported `default`, causing perpetual Terraform drift on `aws_vpc.instance_tenancy`. Root cause: the wire `createVpc` never read `InstanceTenancy` from the request, `toVpcXML` hardcoded `"default"`, and the shared networking driver's `VPCConfig`/`VPCInfo` lacked the field.

## Changes

- **Driver** (`services/networking/driver`): add optional `InstanceTenancy` to `VPCConfig` and `VPCInfo`. Azure/GCP/OCI use keyed struct literals and leave it unset — no behavior change.
- **Provider** (`providers/aws/vpc`): `CreateVPC` reads and stores tenancy, defaulting to `default` when empty and validating it is `default` or `dedicated`. Real EC2 `CreateVpc` rejects `host` (a placement-only tenancy) and any other value with `InvalidParameterValue`, so those are rejected too. Returned on `VPCInfo`.
- **Server** (`server/aws/ec2/vpc.go`): `createVpc` reads `InstanceTenancy` from the form; `toVpcXML` emits the stored value.

## Tests

Real aws-sdk-go-v2 EC2 client against a booted in-process server, plus provider-level:
- `dedicated` create round-trips to `dedicated` on describe
- unset defaults to `default`
- `host` and a bogus value are rejected with `InvalidParameterValue`

## Deferral

`ModifyVpcTenancy` (dedicated→default) is not implemented and is out of scope here; this PR covers the create+describe round-trip only.