### PR TITLE
fix(ec2): apply request Filters to 5 VPC Describe handlers (NetworkAcls/NatGateways/Addresses/VpcPeeringConnections/DhcpOptions)

### DIFF
--- a/server/aws/ec2/address.go
+++ b/server/aws/ec2/address.go
@@ -112,9 +112,20 @@ func (h *Handler) describeAddresses(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	filters := awsquery.Filters(r.Form)
+	if err := validateNetworkingFilters(filters, addressFilterMatch); err != nil {
+		writeVPCErr(w, err)
+
+		return
+	}
+
 	out := make([]addressXML, 0, len(eips))
 
 	for i := range eips {
+		if !matchNetworkingFilters(&eips[i], filters, addressFilterMatch) {
+			continue
+		}
+
 		addr := addressXML{
 			PublicIP:           eips[i].PublicIP,
 			AllocationID:       eips[i].AllocationID,
@@ -138,6 +149,26 @@ func (h *Handler) describeAddresses(w http.ResponseWriter, r *http.Request) {
 	awsquery.WriteXMLResponse(w, describeAddressesResponseXML{
 		Xmlns: awsquery.Namespace, RequestID: awsquery.RequestID, AddressSet: out,
 	})
+}
+
+// addressFilterMatch reports whether e satisfies filter f and whether f is a
+// filter DescribeAddresses recognizes. Every allocation is a VPC domain address
+// (EC2-Classic is retired), so a domain filter only matches "vpc".
+func addressFilterMatch(e *netdriver.ElasticIP, f awsquery.Filter) (matched, known bool) {
+	switch f.Name {
+	case "allocation-id":
+		return containsString(f.Values, e.AllocationID), true
+	case "public-ip":
+		return containsString(f.Values, e.PublicIP), true
+	case "association-id":
+		return containsString(f.Values, e.AssociationID), true
+	case "instance-id":
+		return containsString(f.Values, e.InstanceID), true
+	case "domain":
+		return containsString(f.Values, domainVPC), true
+	default:
+		return tagFilterMatch(f.Name, f.Values, e.Tags)
+	}
 }
 
 // allocationIDForPublicIP resolves a public address back to its allocation id.

--- a/server/aws/ec2/address_association_test.go
+++ b/server/aws/ec2/address_association_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
 // TestAssociateAddressToNetworkInterface pins the EIP-on-ENI flow (Terraform
@@ -216,5 +217,103 @@ func TestAssociateAddressInstanceAndENIExclusive(t *testing.T) {
 
 	if code := apiCode(t, err); code != "InvalidParameterCombination" {
 		t.Errorf("error code = %q, want InvalidParameterCombination", code)
+	}
+}
+
+// TestDescribeAddressesFilters pins that the allocation-id / public-ip /
+// association-id / domain filters narrow the result instead of returning every
+// address, that a non-matching filter yields an empty set, and that an explicit
+// allocation-id list still resolves.
+func TestDescribeAddressesFilters(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	_, subnetID := mkVPCSubnet(t, c)
+
+	eni, err := c.CreateNetworkInterface(ctx, &ec2.CreateNetworkInterfaceInput{SubnetId: aws.String(subnetID)})
+	if err != nil {
+		t.Fatalf("CreateNetworkInterface: %v", err)
+	}
+
+	eip1, err := c.AllocateAddress(ctx, &ec2.AllocateAddressInput{})
+	if err != nil {
+		t.Fatalf("AllocateAddress(1): %v", err)
+	}
+
+	assoc, err := c.AssociateAddress(ctx, &ec2.AssociateAddressInput{
+		AllocationId:       eip1.AllocationId,
+		NetworkInterfaceId: eni.NetworkInterface.NetworkInterfaceId,
+	})
+	if err != nil {
+		t.Fatalf("AssociateAddress: %v", err)
+	}
+
+	eip2, err := c.AllocateAddress(ctx, &ec2.AllocateAddressInput{})
+	if err != nil {
+		t.Fatalf("AllocateAddress(2): %v", err)
+	}
+
+	byAlloc, err := c.DescribeAddresses(ctx, &ec2.DescribeAddressesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("allocation-id"), Values: []string{aws.ToString(eip1.AllocationId)}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeAddresses(allocation-id): %v", err)
+	}
+
+	if len(byAlloc.Addresses) != 1 || aws.ToString(byAlloc.Addresses[0].AllocationId) != aws.ToString(eip1.AllocationId) {
+		t.Fatalf("allocation-id filter = %d addresses, want only %s", len(byAlloc.Addresses), aws.ToString(eip1.AllocationId))
+	}
+
+	byIP, err := c.DescribeAddresses(ctx, &ec2.DescribeAddressesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("public-ip"), Values: []string{aws.ToString(eip2.PublicIp)}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeAddresses(public-ip): %v", err)
+	}
+
+	if len(byIP.Addresses) != 1 || aws.ToString(byIP.Addresses[0].PublicIp) != aws.ToString(eip2.PublicIp) {
+		t.Fatalf("public-ip filter = %d addresses, want only %s", len(byIP.Addresses), aws.ToString(eip2.PublicIp))
+	}
+
+	byAssoc, err := c.DescribeAddresses(ctx, &ec2.DescribeAddressesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("association-id"), Values: []string{aws.ToString(assoc.AssociationId)}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeAddresses(association-id): %v", err)
+	}
+
+	if len(byAssoc.Addresses) != 1 || aws.ToString(byAssoc.Addresses[0].AllocationId) != aws.ToString(eip1.AllocationId) {
+		t.Fatalf("association-id filter = %d addresses, want only eip1", len(byAssoc.Addresses))
+	}
+
+	byDomain, err := c.DescribeAddresses(ctx, &ec2.DescribeAddressesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("domain"), Values: []string{"vpc"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeAddresses(domain): %v", err)
+	}
+
+	if len(byDomain.Addresses) != 2 {
+		t.Fatalf("domain=vpc filter = %d addresses, want both (2)", len(byDomain.Addresses))
+	}
+
+	none, err := c.DescribeAddresses(ctx, &ec2.DescribeAddressesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("allocation-id"), Values: []string{"eipalloc-nope"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeAddresses(bogus): %v", err)
+	}
+
+	if len(none.Addresses) != 0 {
+		t.Fatalf("non-matching filter returned %d addresses, want 0", len(none.Addresses))
+	}
+
+	byList, err := c.DescribeAddresses(ctx, &ec2.DescribeAddressesInput{AllocationIds: []string{aws.ToString(eip2.AllocationId)}})
+	if err != nil {
+		t.Fatalf("DescribeAddresses(id list): %v", err)
+	}
+
+	if len(byList.Addresses) != 1 || aws.ToString(byList.Addresses[0].AllocationId) != aws.ToString(eip2.AllocationId) {
+		t.Fatalf("id list = %d addresses, want only %s", len(byList.Addresses), aws.ToString(eip2.AllocationId))
 	}
 }

--- a/server/aws/ec2/dhcp_options.go
+++ b/server/aws/ec2/dhcp_options.go
@@ -81,7 +81,6 @@ func (*Handler) deleteDHCPOptions(w http.ResponseWriter, r *http.Request, d netd
 	writeReturnTrue(w, "DeleteDhcpOptionsResponse")
 }
 
-//nolint:dupl // parallel per-resource marshaling
 func (*Handler) describeDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
 	items, err := d.DescribeDHCPOptions(r.Context(), awsquery.ListStrings(r.Form, "DhcpOptionsId"))
 	if err != nil {
@@ -89,10 +88,13 @@ func (*Handler) describeDHCPOptions(w http.ResponseWriter, r *http.Request, d ne
 		return
 	}
 
-	out := make([]dhcpOptionsXML, 0, len(items))
-	for i := range items {
-		out = append(out, toDHCPOptionsXML(&items[i]))
+	filters := awsquery.Filters(r.Form)
+	if err := validateNetworkingFilters(filters, dhcpFilterMatch); err != nil {
+		writeDHCPErr(w, err)
+		return
 	}
+
+	out := filterXML(items, filters, dhcpMatchesFilters, toDHCPOptionsXML)
 
 	awsquery.WriteXMLResponse(w, struct {
 		XMLName xml.Name         `xml:"DescribeDhcpOptionsResponse"`
@@ -151,6 +153,48 @@ func toDHCPOptionsXML(d *netdriver.DHCPOptions) dhcpOptionsXML {
 	}
 
 	return dhcpOptionsXML{DhcpOptionsID: d.ID, OwnerID: ownerID, DhcpConfigurations: cfgs, Tags: toTagItems(d.Tags)}
+}
+
+func dhcpMatchesFilters(d *netdriver.DHCPOptions, filters []awsquery.Filter) bool {
+	return matchNetworkingFilters(d, filters, dhcpFilterMatch)
+}
+
+// dhcpFilterMatch reports whether d satisfies filter f and whether f is a filter
+// DescribeDhcpOptions recognizes. The key/value filters match against the option
+// set's configuration entries (e.g. key=domain-name-servers).
+func dhcpFilterMatch(d *netdriver.DHCPOptions, f awsquery.Filter) (matched, known bool) {
+	switch f.Name {
+	case filterDHCPOptionsID:
+		return containsString(f.Values, d.ID), true
+	case "key":
+		return dhcpConfigHasKey(d.Configuration, f.Values), true
+	case "value":
+		return dhcpConfigHasValue(d.Configuration, f.Values), true
+	default:
+		return tagFilterMatch(f.Name, f.Values, d.Tags)
+	}
+}
+
+func dhcpConfigHasKey(cfg map[string][]string, values []string) bool {
+	for k := range cfg {
+		if containsString(values, k) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func dhcpConfigHasValue(cfg map[string][]string, values []string) bool {
+	for _, vals := range cfg {
+		for _, v := range vals {
+			if containsString(values, v) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func writeDHCPErr(w http.ResponseWriter, err error) {

--- a/server/aws/ec2/dhcp_options_test.go
+++ b/server/aws/ec2/dhcp_options_test.go
@@ -85,3 +85,85 @@ func TestDescribeDhcpOptionsUnknownIDNotFound(t *testing.T) {
 		t.Fatalf("error = %v, want InvalidDhcpOptionID.NotFound", err)
 	}
 }
+
+// TestDescribeDhcpOptionsFilters pins that the key / value / dhcp-options-id
+// filters narrow the result to the matching option sets instead of returning
+// every set, that a non-matching filter yields an empty set, and that an explicit
+// id list still resolves.
+func TestDescribeDhcpOptionsFilters(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	optA := mkDhcpOptions(ctx, t, client, "domain-name-servers", "10.0.0.2")
+	optB := mkDhcpOptions(ctx, t, client, "domain-name", "example.internal")
+
+	byKey, err := client.DescribeDhcpOptions(ctx, &ec2.DescribeDhcpOptionsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("key"), Values: []string{"domain-name-servers"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeDhcpOptions(key): %v", err)
+	}
+
+	if len(byKey.DhcpOptions) != 1 || aws.ToString(byKey.DhcpOptions[0].DhcpOptionsId) != optA {
+		t.Fatalf("key filter = %d option sets, want only %s", len(byKey.DhcpOptions), optA)
+	}
+
+	byValue, err := client.DescribeDhcpOptions(ctx, &ec2.DescribeDhcpOptionsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("value"), Values: []string{"example.internal"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeDhcpOptions(value): %v", err)
+	}
+
+	if len(byValue.DhcpOptions) != 1 || aws.ToString(byValue.DhcpOptions[0].DhcpOptionsId) != optB {
+		t.Fatalf("value filter = %d option sets, want only %s", len(byValue.DhcpOptions), optB)
+	}
+
+	byID, err := client.DescribeDhcpOptions(ctx, &ec2.DescribeDhcpOptionsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("dhcp-options-id"), Values: []string{optA}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeDhcpOptions(dhcp-options-id): %v", err)
+	}
+
+	if len(byID.DhcpOptions) != 1 || aws.ToString(byID.DhcpOptions[0].DhcpOptionsId) != optA {
+		t.Fatalf("dhcp-options-id filter = %d option sets, want only %s", len(byID.DhcpOptions), optA)
+	}
+
+	none, err := client.DescribeDhcpOptions(ctx, &ec2.DescribeDhcpOptionsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("key"), Values: []string{"ntp-servers"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeDhcpOptions(bogus): %v", err)
+	}
+
+	if len(none.DhcpOptions) != 0 {
+		t.Fatalf("non-matching filter returned %d option sets, want 0", len(none.DhcpOptions))
+	}
+
+	byList, err := client.DescribeDhcpOptions(ctx, &ec2.DescribeDhcpOptionsInput{DhcpOptionsIds: []string{optB}})
+	if err != nil {
+		t.Fatalf("DescribeDhcpOptions(id list): %v", err)
+	}
+
+	if len(byList.DhcpOptions) != 1 || aws.ToString(byList.DhcpOptions[0].DhcpOptionsId) != optB {
+		t.Fatalf("id list = %d option sets, want only %s", len(byList.DhcpOptions), optB)
+	}
+}
+
+// mkDhcpOptions creates a DHCP option set with one key/value and returns its id.
+func mkDhcpOptions(ctx context.Context, t *testing.T, c *ec2.Client, key, value string) string {
+	t.Helper()
+
+	out, err := c.CreateDhcpOptions(ctx, &ec2.CreateDhcpOptionsInput{
+		DhcpConfigurations: []ec2types.NewDhcpConfiguration{{
+			Key:    aws.String(key),
+			Values: []string{value},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateDhcpOptions(%s): %v", key, err)
+	}
+
+	return aws.ToString(out.DhcpOptions.DhcpOptionsId)
+}

--- a/server/aws/ec2/nat_gateway.go
+++ b/server/aws/ec2/nat_gateway.go
@@ -40,6 +40,7 @@ type describeNatGatewaysResponseXML struct {
 	Xmlns         string          `xml:"xmlns,attr"`
 	RequestID     string          `xml:"requestId"`
 	NatGatewaySet []natGatewayXML `xml:"natGatewaySet>item"`
+	NextToken     string          `xml:"nextToken,omitempty"`
 }
 
 type deleteNatGatewayResponseXML struct {
@@ -83,7 +84,7 @@ func (h *Handler) deleteNatGateway(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // per-resource describe pattern
+//nolint:dupl // per-resource describe+filter pattern, mirrors describeNetworkACLs
 func (h *Handler) describeNatGateways(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "NatGatewayId")
 
@@ -93,16 +94,44 @@ func (h *Handler) describeNatGateways(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]natGatewayXML, 0, len(nats))
-	for i := range nats {
-		out = append(out, toNatGatewayXML(&nats[i]))
+	filters := awsquery.Filters(r.Form)
+	if err := validateNetworkingFilters(filters, natFilterMatch); err != nil {
+		writeNatErr(w, err)
+		return
 	}
+
+	out := filterXML(nats, filters, natMatchesFilters, toNatGatewayXML)
+	page, next := pageNetworkingXML(out, r, func(n natGatewayXML) string { return n.NatGatewayID })
 
 	awsquery.WriteXMLResponse(w, describeNatGatewaysResponseXML{
 		Xmlns:         awsquery.Namespace,
 		RequestID:     awsquery.RequestID,
-		NatGatewaySet: out,
+		NatGatewaySet: page,
+		NextToken:     next,
 	})
+}
+
+func natMatchesFilters(n *netdriver.NATGateway, filters []awsquery.Filter) bool {
+	return matchNetworkingFilters(n, filters, natFilterMatch)
+}
+
+// natFilterMatch reports whether n satisfies filter f and whether f is a filter
+// DescribeNatGateways recognizes. State falls back to "available", matching how
+// toNatGatewayXML renders an unset state, so a state=available filter finds a
+// freshly created gateway.
+func natFilterMatch(n *netdriver.NATGateway, f awsquery.Filter) (matched, known bool) {
+	switch f.Name {
+	case "nat-gateway-id":
+		return containsString(f.Values, n.ID), true
+	case filterVPCID:
+		return containsString(f.Values, n.VPCID), true
+	case filterSubnetID:
+		return containsString(f.Values, n.SubnetID), true
+	case filterState:
+		return containsString(f.Values, nonEmpty(n.State, stateAvailable)), true
+	default:
+		return tagFilterMatch(f.Name, f.Values, n.Tags)
+	}
 }
 
 func toNatGatewayXML(n *netdriver.NATGateway) natGatewayXML {

--- a/server/aws/ec2/nat_gateway_test.go
+++ b/server/aws/ec2/nat_gateway_test.go
@@ -158,3 +158,144 @@ func TestNatGatewayPrivateConnectivity(t *testing.T) {
 		t.Error("private NAT gateway privateIp is empty")
 	}
 }
+
+// mkNat creates a public NAT gateway in the given subnet and returns its id.
+func mkNat(ctx context.Context, t *testing.T, c *ec2.Client, subnetID, alloc string) string {
+	t.Helper()
+
+	out, err := c.CreateNatGateway(ctx, &ec2.CreateNatGatewayInput{
+		SubnetId:     aws.String(subnetID),
+		AllocationId: aws.String(alloc),
+	})
+	if err != nil {
+		t.Fatalf("CreateNatGateway: %v", err)
+	}
+
+	return aws.ToString(out.NatGateway.NatGatewayId)
+}
+
+// TestDescribeNatGatewaysFilters pins that the vpc-id / subnet-id / nat-gateway-id
+// filters narrow the result to the matching gateways instead of returning every
+// gateway, that a non-matching filter yields an empty set, and that an explicit
+// id list still resolves.
+func TestDescribeNatGatewaysFilters(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpcA, subnetA := mkVPCSubnet(t, c)
+	_, subnetB := mkVPCSubnet(t, c)
+
+	natA := mkNat(ctx, t, c, subnetA, "eipalloc-aaaa1111")
+	natB := mkNat(ctx, t, c, subnetB, "eipalloc-bbbb2222")
+
+	byVPC, err := c.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+		Filter: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcA}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNatGateways(vpc-id): %v", err)
+	}
+
+	if len(byVPC.NatGateways) != 1 || aws.ToString(byVPC.NatGateways[0].NatGatewayId) != natA {
+		t.Fatalf("vpc-id filter = %d gateways, want only %s", len(byVPC.NatGateways), natA)
+	}
+
+	bySubnet, err := c.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+		Filter: []ec2types.Filter{{Name: aws.String("subnet-id"), Values: []string{subnetB}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNatGateways(subnet-id): %v", err)
+	}
+
+	if len(bySubnet.NatGateways) != 1 || aws.ToString(bySubnet.NatGateways[0].NatGatewayId) != natB {
+		t.Fatalf("subnet-id filter = %d gateways, want only %s", len(bySubnet.NatGateways), natB)
+	}
+
+	byID, err := c.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+		Filter: []ec2types.Filter{{Name: aws.String("nat-gateway-id"), Values: []string{natA}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNatGateways(nat-gateway-id): %v", err)
+	}
+
+	if len(byID.NatGateways) != 1 || aws.ToString(byID.NatGateways[0].NatGatewayId) != natA {
+		t.Fatalf("nat-gateway-id filter = %d gateways, want only %s", len(byID.NatGateways), natA)
+	}
+
+	none, err := c.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+		Filter: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{"vpc-nope"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNatGateways(bogus): %v", err)
+	}
+
+	if len(none.NatGateways) != 0 {
+		t.Fatalf("non-matching filter returned %d gateways, want 0", len(none.NatGateways))
+	}
+
+	byList, err := c.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{NatGatewayIds: []string{natB}})
+	if err != nil {
+		t.Fatalf("DescribeNatGateways(id list): %v", err)
+	}
+
+	if len(byList.NatGateways) != 1 || aws.ToString(byList.NatGateways[0].NatGatewayId) != natB {
+		t.Fatalf("id list = %d gateways, want only %s", len(byList.NatGateways), natB)
+	}
+}
+
+// TestDescribeNatGatewaysPaginates pins that MaxResults=1 returns a NextToken and
+// that walking the pages visits every gateway exactly once.
+func TestDescribeNatGatewaysPaginates(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	want := map[string]int{}
+
+	for range 3 {
+		_, subnetID := mkVPCSubnet(t, c)
+		want[mkNat(ctx, t, c, subnetID, "eipalloc-page")] = 0
+	}
+
+	first, err := c.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{MaxResults: aws.Int32(1)})
+	if err != nil {
+		t.Fatalf("DescribeNatGateways(page 1): %v", err)
+	}
+
+	if len(first.NatGateways) != 1 || aws.ToString(first.NextToken) == "" {
+		t.Fatalf("first page = %d gateways / token %q, want 1 and a non-empty token",
+			len(first.NatGateways), aws.ToString(first.NextToken))
+	}
+
+	seen := map[string]int{}
+
+	var token *string
+
+	for {
+		out, err := c.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+			MaxResults: aws.Int32(1),
+			NextToken:  token,
+		})
+		if err != nil {
+			t.Fatalf("DescribeNatGateways: %v", err)
+		}
+
+		if len(out.NatGateways) > 1 {
+			t.Fatalf("page returned %d gateways, want at most 1", len(out.NatGateways))
+		}
+
+		for _, n := range out.NatGateways {
+			seen[aws.ToString(n.NatGatewayId)]++
+		}
+
+		if aws.ToString(out.NextToken) == "" {
+			break
+		}
+
+		token = out.NextToken
+	}
+
+	for id := range want {
+		if seen[id] != 1 {
+			t.Fatalf("gateway %s seen %d times across pages, want exactly 1", id, seen[id])
+		}
+	}
+}

--- a/server/aws/ec2/network_acl.go
+++ b/server/aws/ec2/network_acl.go
@@ -118,6 +118,7 @@ func (h *Handler) deleteNetworkACL(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+//nolint:dupl // per-resource describe+filter pattern, mirrors describeNatGateways
 func (h *Handler) describeNetworkACLs(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "NetworkAclId")
 
@@ -127,11 +128,13 @@ func (h *Handler) describeNetworkACLs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]networkACLXML, 0, len(acls))
-	for i := range acls {
-		out = append(out, toNetworkACLXML(&acls[i]))
+	filters := awsquery.Filters(r.Form)
+	if err := validateNetworkingFilters(filters, naclFilterMatch); err != nil {
+		writeNetworkACLErr(w, err)
+		return
 	}
 
+	out := filterXML(acls, filters, naclMatchesFilters, toNetworkACLXML)
 	page, next := pageNetworkingXML(out, r, func(a networkACLXML) string { return a.NetworkACLID })
 
 	awsquery.WriteXMLResponse(w, describeNetworkACLsResponseXML{
@@ -310,6 +313,35 @@ func toNetworkACLXML(a *netdriver.NetworkACL) networkACLXML {
 	}
 
 	return x
+}
+
+func naclMatchesFilters(a *netdriver.NetworkACL, filters []awsquery.Filter) bool {
+	return matchNetworkingFilters(a, filters, naclFilterMatch)
+}
+
+// naclFilterMatch reports whether a satisfies filter f and whether f is a filter
+// DescribeNetworkAcls recognizes. Terraform's aws_network_acl data source looks a
+// network ACL up by vpc-id / association.subnet-id and expects only the matching
+// ACL back; without honoring the filter every ACL in the account is returned.
+func naclFilterMatch(a *netdriver.NetworkACL, f awsquery.Filter) (matched, known bool) {
+	switch f.Name {
+	case "network-acl-id":
+		return containsString(f.Values, a.ID), true
+	case filterVPCID:
+		return containsString(f.Values, a.VPCID), true
+	case "default":
+		return containsString(f.Values, boolFilterValue(a.IsDefault)), true
+	case filterAssocSubnetID:
+		for i := range a.Associations {
+			if containsString(f.Values, a.Associations[i].SubnetID) {
+				return true, true
+			}
+		}
+
+		return false, true
+	default:
+		return tagFilterMatch(f.Name, f.Values, a.Tags)
+	}
 }
 
 func writeNetworkACLErr(w http.ResponseWriter, err error) {

--- a/server/aws/ec2/network_acl_test.go
+++ b/server/aws/ec2/network_acl_test.go
@@ -180,6 +180,87 @@ func TestDescribeNetworkAclsPaginatesAllOnce(t *testing.T) {
 	}
 }
 
+// TestDescribeNetworkAclsFilters pins that the vpc-id / network-acl-id filters
+// narrow the result to the matching ACLs instead of returning every ACL in the
+// account, that a non-matching filter yields an empty set, and that an explicit
+// id list still resolves.
+func TestDescribeNetworkAclsFilters(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	vpcA := mkVPC(ctx, t, c, "10.0.0.0/16")
+	vpcB := mkVPC(ctx, t, c, "10.1.0.0/16")
+
+	aclA, err := c.CreateNetworkAcl(ctx, &ec2.CreateNetworkAclInput{VpcId: aws.String(vpcA)})
+	if err != nil {
+		t.Fatalf("CreateNetworkAcl(A): %v", err)
+	}
+
+	aclAID := aws.ToString(aclA.NetworkAcl.NetworkAclId)
+
+	if _, err := c.CreateNetworkAcl(ctx, &ec2.CreateNetworkAclInput{VpcId: aws.String(vpcB)}); err != nil {
+		t.Fatalf("CreateNetworkAcl(B): %v", err)
+	}
+
+	byVPC, err := c.DescribeNetworkAcls(ctx, &ec2.DescribeNetworkAclsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcA}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNetworkAcls(vpc-id): %v", err)
+	}
+
+	for _, a := range byVPC.NetworkAcls {
+		if aws.ToString(a.VpcId) != vpcA {
+			t.Fatalf("vpc-id filter returned an ACL from %s, want only %s", aws.ToString(a.VpcId), vpcA)
+		}
+	}
+
+	if !hasNetworkACL(byVPC.NetworkAcls, aclAID) {
+		t.Fatalf("vpc-id filter dropped the custom ACL %s", aclAID)
+	}
+
+	byID, err := c.DescribeNetworkAcls(ctx, &ec2.DescribeNetworkAclsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("network-acl-id"), Values: []string{aclAID}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNetworkAcls(network-acl-id): %v", err)
+	}
+
+	if len(byID.NetworkAcls) != 1 || aws.ToString(byID.NetworkAcls[0].NetworkAclId) != aclAID {
+		t.Fatalf("network-acl-id filter = %d ACLs, want only %s", len(byID.NetworkAcls), aclAID)
+	}
+
+	none, err := c.DescribeNetworkAcls(ctx, &ec2.DescribeNetworkAclsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{"vpc-nope"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNetworkAcls(bogus): %v", err)
+	}
+
+	if len(none.NetworkAcls) != 0 {
+		t.Fatalf("non-matching filter returned %d ACLs, want 0", len(none.NetworkAcls))
+	}
+
+	byList, err := c.DescribeNetworkAcls(ctx, &ec2.DescribeNetworkAclsInput{NetworkAclIds: []string{aclAID}})
+	if err != nil {
+		t.Fatalf("DescribeNetworkAcls(id list): %v", err)
+	}
+
+	if len(byList.NetworkAcls) != 1 || aws.ToString(byList.NetworkAcls[0].NetworkAclId) != aclAID {
+		t.Fatalf("id list = %d ACLs, want only %s", len(byList.NetworkAcls), aclAID)
+	}
+}
+
+func hasNetworkACL(acls []ec2types.NetworkAcl, id string) bool {
+	for _, a := range acls {
+		if aws.ToString(a.NetworkAclId) == id {
+			return true
+		}
+	}
+
+	return false
+}
+
 // mkCustomACL creates a VPC and a custom network ACL in it, returning the ACL id.
 func mkCustomACL(t *testing.T, c *ec2.Client) string {
 	t.Helper()

--- a/server/aws/ec2/networking_common.go
+++ b/server/aws/ec2/networking_common.go
@@ -11,13 +11,15 @@ import (
 
 // Shared EC2 Describe filter names, reused across the VPC-family handlers.
 const (
-	tagFilterPrefix = "tag:"
-	filterTagKey    = "tag-key"
-	filterVPCID     = "vpc-id"
-	filterSubnetID  = "subnet-id"
-	filterCIDR      = "cidr"
-	filterCIDRBlock = "cidr-block"
-	filterState     = "state"
+	tagFilterPrefix     = "tag:"
+	filterTagKey        = "tag-key"
+	filterVPCID         = "vpc-id"
+	filterSubnetID      = "subnet-id"
+	filterCIDR          = "cidr"
+	filterCIDRBlock     = "cidr-block"
+	filterState         = "state"
+	filterAssocSubnetID = "association.subnet-id"
+	filterDHCPOptionsID = "dhcp-options-id"
 )
 
 // filterXML keeps the items that satisfy every filter and projects them to
@@ -52,6 +54,45 @@ func pageNetworkingXML[X any](items []X, r *http.Request, idOf func(X) string) (
 	sort.Slice(items, func(i, j int) bool { return idOf(items[i]) < idOf(items[j]) })
 
 	return paginateXML(items, r.Form.Get("MaxResults"), r.Form.Get("NextToken"), idOf)
+}
+
+// validateNetworkingFilters rejects any filter name the matcher does not model,
+// mirroring how real EC2 answers an unmodeled filter with InvalidParameterValue
+// rather than silently matching nothing (which would tell a data-source lookup a
+// resource is absent). The matcher reports (matched, known); only known is
+// consulted here — probing a zero value — so the accepted set can never drift
+// from what the matcher actually honors.
+func validateNetworkingFilters[T any](
+	filters []awsquery.Filter,
+	match func(*T, awsquery.Filter) (matched, known bool),
+) error {
+	var zero T
+
+	for _, f := range filters {
+		if _, known := match(&zero, f); !known {
+			return newInvalidParameterErr("The filter '" + f.Name + "' is invalid")
+		}
+	}
+
+	return nil
+}
+
+// matchNetworkingFilters reports whether item satisfies every filter (filters are
+// AND-ed, values within one filter are OR-ed), using a matcher that also reports
+// whether each name is known. Filter names are validated up front, so an unknown
+// name never reaches here.
+func matchNetworkingFilters[T any](
+	item *T,
+	filters []awsquery.Filter,
+	match func(*T, awsquery.Filter) (matched, known bool),
+) bool {
+	for _, f := range filters {
+		if matched, _ := match(item, f); !matched {
+			return false
+		}
+	}
+
+	return true
 }
 
 // tagFilterMatch evaluates a "tag:<key>" or "tag-key" filter against a resource's

--- a/server/aws/ec2/peering.go
+++ b/server/aws/ec2/peering.go
@@ -145,8 +145,19 @@ func (h *Handler) describeVpcPeeringConnections(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	filters := awsquery.Filters(r.Form)
+	if err := validateNetworkingFilters(filters, peeringFilterMatch); err != nil {
+		writePeeringErr(w, err)
+		return
+	}
+
 	out := make([]peeringConnectionXML, 0, len(peerings))
+
 	for i := range peerings {
+		if !matchNetworkingFilters(&peerings[i], filters, peeringFilterMatch) {
+			continue
+		}
+
 		out = append(out, h.enrichedPeeringXML(r, &peerings[i]))
 	}
 
@@ -155,6 +166,25 @@ func (h *Handler) describeVpcPeeringConnections(w http.ResponseWriter, r *http.R
 		RequestID:            awsquery.RequestID,
 		VpcPeeringConnection: out,
 	})
+}
+
+// peeringFilterMatch reports whether p satisfies filter f and whether f is a
+// filter DescribeVpcPeeringConnections recognizes. Terraform's
+// aws_vpc_peering_connection data source looks a connection up by status-code and
+// requester/accepter vpc id; without honoring the filter every connection returns.
+func peeringFilterMatch(p *netdriver.PeeringConnection, f awsquery.Filter) (matched, known bool) {
+	switch f.Name {
+	case "vpc-peering-connection-id":
+		return containsString(f.Values, p.ID), true
+	case "status-code":
+		return containsString(f.Values, p.Status), true
+	case "requester-vpc-info.vpc-id":
+		return containsString(f.Values, p.RequesterVPC), true
+	case "accepter-vpc-info.vpc-id":
+		return containsString(f.Values, p.AccepterVPC), true
+	default:
+		return tagFilterMatch(f.Name, f.Values, p.Tags)
+	}
 }
 
 func toPeeringXML(p *netdriver.PeeringConnection) peeringConnectionXML {

--- a/server/aws/ec2/route_table.go
+++ b/server/aws/ec2/route_table.go
@@ -335,7 +335,7 @@ func routeTableFilterKnown(name string) bool {
 	switch name {
 	case "route-table-id", "vpc-id",
 		"association.route-table-association-id", "association.route-table-id",
-		"association.subnet-id", "association.main":
+		filterAssocSubnetID, "association.main":
 		return true
 	default:
 		return false
@@ -370,7 +370,7 @@ func routeTableMatchesFilter(rt *netdriver.RouteTable, f awsquery.Filter) bool {
 		return anyAssoc(rt, func(a netdriver.RouteTableAssociation) bool {
 			return containsString(f.Values, nonEmpty(a.RouteTableID, rt.ID))
 		})
-	case "association.subnet-id":
+	case filterAssocSubnetID:
 		return anyAssoc(rt, func(a netdriver.RouteTableAssociation) bool { return containsString(f.Values, a.SubnetID) })
 	case "association.main":
 		return anyAssoc(rt, func(a netdriver.RouteTableAssociation) bool {

--- a/server/aws/ec2/route_table.go
+++ b/server/aws/ec2/route_table.go
@@ -23,6 +23,10 @@ const (
 	// reports for routes a caller added afterward.
 	routeOriginCreateRouteTable = "CreateRouteTable"
 	routeOriginCreateRoute      = "CreateRoute"
+
+	// filterAssocMain is the DescribeRouteTables filter selecting the VPC's main
+	// route table (association.main = true/false).
+	filterAssocMain = "association.main"
 )
 
 type routeXML struct {
@@ -335,7 +339,7 @@ func routeTableFilterKnown(name string) bool {
 	switch name {
 	case "route-table-id", "vpc-id",
 		"association.route-table-association-id", "association.route-table-id",
-		filterAssocSubnetID, "association.main":
+		filterAssocSubnetID, filterAssocMain:
 		return true
 	default:
 		return false
@@ -372,7 +376,7 @@ func routeTableMatchesFilter(rt *netdriver.RouteTable, f awsquery.Filter) bool {
 		})
 	case filterAssocSubnetID:
 		return anyAssoc(rt, func(a netdriver.RouteTableAssociation) bool { return containsString(f.Values, a.SubnetID) })
-	case "association.main":
+	case filterAssocMain:
 		return anyAssoc(rt, func(a netdriver.RouteTableAssociation) bool {
 			return containsString(f.Values, boolFilterValue(a.Main))
 		})

--- a/server/aws/ec2/vpc.go
+++ b/server/aws/ec2/vpc.go
@@ -204,7 +204,7 @@ func vpcFilterMatch(v *netdriver.VPCInfo, f awsquery.Filter) (matched, known boo
 		return containsString(f.Values, v.CIDRBlock), true
 	case filterState:
 		return containsString(f.Values, nonEmpty(v.State, stateAvailable)), true
-	case "dhcp-options-id":
+	case filterDHCPOptionsID:
 		return containsString(f.Values, nonEmpty(v.DhcpOptionsID, dhcpDefault)), true
 	case "isDefault", "is-default":
 		return containsString(f.Values, boolFilterValue(false)), true

--- a/server/aws/ec2/vpc_peering_test.go
+++ b/server/aws/ec2/vpc_peering_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	smithy "github.com/aws/smithy-go"
 )
 
@@ -111,6 +112,92 @@ func TestRejectVpcPeeringConnection(t *testing.T) {
 	if got := string(desc.VpcPeeringConnections[0].Status.Code); got != "rejected" {
 		t.Errorf("status code = %q, want rejected", got)
 	}
+}
+
+// TestDescribeVpcPeeringConnectionsFilters pins that the requester-vpc-info.vpc-id
+// / status-code filters narrow the result instead of returning every connection,
+// that a non-matching filter yields an empty set, and that an explicit id list
+// still resolves.
+func TestDescribeVpcPeeringConnectionsFilters(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	reqA := mkPeeringVPC(t, c, "10.0.0.0/16")
+	accA := mkPeeringVPC(t, c, "10.1.0.0/16")
+	reqB := mkPeeringVPC(t, c, "10.2.0.0/16")
+	accB := mkPeeringVPC(t, c, "10.3.0.0/16")
+
+	pcxA := mkPeering(ctx, t, c, reqA, accA)
+	pcxB := mkPeering(ctx, t, c, reqB, accB)
+
+	// Reject B so status-code distinguishes the two connections.
+	if _, err := c.RejectVpcPeeringConnection(ctx, &ec2.RejectVpcPeeringConnectionInput{
+		VpcPeeringConnectionId: aws.String(pcxB),
+	}); err != nil {
+		t.Fatalf("RejectVpcPeeringConnection: %v", err)
+	}
+
+	byReq, err := c.DescribeVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("requester-vpc-info.vpc-id"), Values: []string{reqA}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVpcPeeringConnections(requester): %v", err)
+	}
+
+	if len(byReq.VpcPeeringConnections) != 1 ||
+		aws.ToString(byReq.VpcPeeringConnections[0].VpcPeeringConnectionId) != pcxA {
+		t.Fatalf("requester filter = %d connections, want only %s", len(byReq.VpcPeeringConnections), pcxA)
+	}
+
+	byStatus, err := c.DescribeVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("status-code"), Values: []string{"rejected"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVpcPeeringConnections(status-code): %v", err)
+	}
+
+	if len(byStatus.VpcPeeringConnections) != 1 ||
+		aws.ToString(byStatus.VpcPeeringConnections[0].VpcPeeringConnectionId) != pcxB {
+		t.Fatalf("status-code filter = %d connections, want only %s", len(byStatus.VpcPeeringConnections), pcxB)
+	}
+
+	none, err := c.DescribeVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("status-code"), Values: []string{"deleted"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVpcPeeringConnections(bogus): %v", err)
+	}
+
+	if len(none.VpcPeeringConnections) != 0 {
+		t.Fatalf("non-matching filter returned %d connections, want 0", len(none.VpcPeeringConnections))
+	}
+
+	byList, err := c.DescribeVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
+		VpcPeeringConnectionIds: []string{pcxA},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVpcPeeringConnections(id list): %v", err)
+	}
+
+	if len(byList.VpcPeeringConnections) != 1 ||
+		aws.ToString(byList.VpcPeeringConnections[0].VpcPeeringConnectionId) != pcxA {
+		t.Fatalf("id list = %d connections, want only %s", len(byList.VpcPeeringConnections), pcxA)
+	}
+}
+
+// mkPeering creates a peering connection and returns its id.
+func mkPeering(ctx context.Context, t *testing.T, c *ec2.Client, reqVPC, accVPC string) string {
+	t.Helper()
+
+	out, err := c.CreateVpcPeeringConnection(ctx, &ec2.CreateVpcPeeringConnectionInput{
+		VpcId:     aws.String(reqVPC),
+		PeerVpcId: aws.String(accVPC),
+	})
+	if err != nil {
+		t.Fatalf("CreateVpcPeeringConnection: %v", err)
+	}
+
+	return aws.ToString(out.VpcPeeringConnection.VpcPeeringConnectionId)
 }
 
 func mkPeeringVPC(t *testing.T, c *ec2.Client, cidr string) string {


### PR DESCRIPTION
## Summary

Five EC2 `Describe*` handlers read only their resource-id list and never applied request `Filters`, so `--filter` queries and Terraform data-source lookups returned **every** resource across all VPCs instead of the matching subset. This mirrors the existing working pattern in `describeSubnets` for each:

| Handler | Filters added |
|---|---|
| `DescribeNetworkAcls` | `vpc-id`, `default`, `association.subnet-id`, `network-acl-id`, `tag:*`, `tag-key` |
| `DescribeNatGateways` | `vpc-id`, `subnet-id`, `state`, `nat-gateway-id`, `tag:*` — **plus MaxResults/NextToken pagination** |
| `DescribeAddresses` | `domain`, `instance-id`, `allocation-id`, `public-ip`, `association-id`, `tag:*` |
| `DescribeVpcPeeringConnections` | `status-code`, `requester-vpc-info.vpc-id`, `accepter-vpc-info.vpc-id`, `vpc-peering-connection-id`, `tag:*` |
| `DescribeDhcpOptions` | `key`, `value`, `dhcp-options-id`, `tag:*` |

## Approach

- Reuses the shared `awsquery.Filters` parser and the `tagFilterMatch` tag helper — no divergent hand-rolled matcher.
- Two small generic helpers added to `networking_common.go` (`validateNetworkingFilters`, `matchNetworkingFilters`) so the five handlers do not each duplicate the validate/match loop. Matchers report `(matched, known)`; an unrecognized filter name is rejected with `InvalidParameterValue`, matching real EC2 (and the existing subnet/route-table handlers).
- Multiple filters AND together; multiple values within one filter OR; the explicit id list still works and combines with filters.
- Driver and provider layers are untouched — pure server-layer filter additions. Only DescribeNatGateways gains pagination (mirroring the sibling paginating describe handlers).

## Tests

Real `aws-sdk-go-v2/ec2` tests against the booted server, one per handler: resources created in 2+ VPCs / with distinct attributes, then a filtered Describe returns only the matching subset, a non-matching filter returns empty, and an id-list still resolves. DescribeNatGateways adds a pagination test asserting a NextToken and a clean multi-page walk.

## Gates

`go build`, `go vet`, `go test ./server/aws/ec2/... ./providers/aws/...`, `go test -race ./server/aws/ec2/...`, `gofmt -l`, `golangci-lint` (0 new), `go generate` (zero diff), `compatgen` + `docs/compat` (zero diff) — all green.