### PR TITLE
fix(aws-vpc): materialize instance primary ENI so subnet/SG delete guards fire

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -251,6 +251,10 @@ func New(opts ...config.Option) *Provider {
 	p.RDS.SetSubnetResolver(p.VPC)
 	p.ElastiCache.SetSubnetResolver(p.VPC)
 	p.EC2.SetSubnetResolver(p.VPC)
+	// RunInstances materializes the instance's primary (eth0) ENI in the VPC, and
+	// TerminateInstances releases it — so a running instance's interface blocks
+	// DeleteSubnet / DeleteSecurityGroup the way real EC2 does.
+	p.EC2.SetNetworking(p.VPC)
 	// A load balancer's VpcId is derived from its subnets, matching ELBv2.
 	p.ELB.SetSubnetResolver(p.VPC)
 	// EFS mount targets derive their VpcId and AZ from the subnet, so all mount

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -288,6 +288,10 @@ type Mock struct {
 	// role->profile->instance chain reads back on DescribeInstances. nil until
 	// wired by the provider.
 	instanceProfileResolver InstanceProfileResolver
+	// networking materializes an instance's primary (eth0) ENI at launch and
+	// releases it on terminate, so the VPC subnet / security-group delete guards
+	// see a running instance's interface. nil until wired by the provider.
+	networking Networking
 	// mu guards managedResourceVisibility, clientTokens and subnetIPCounters,
 	// which are scalar/map shared state that (unlike the memstores) has no
 	// internal locking of their own.
@@ -616,6 +620,14 @@ func (m *Mock) launchInstances(ctx context.Context, cfg driver.InstanceConfig, c
 		if !isManaged(inst) {
 			m.emitInstanceMetrics(ctx, id, inst.LaunchTime)
 		}
+
+		// Materialize the primary (eth0) ENI real EC2 attaches at launch, so the
+		// VPC subnet / security-group delete guards see this running instance's
+		// interface. vpcID is non-empty only when the subnet resolved, which is
+		// exactly when the networking mock can place the interface.
+		if vpcID != "" {
+			m.materializePrimaryENI(ctx, id, cfg.SubnetID, sg)
+		}
 	}
 
 	m.recordClientToken(cfg.ClientToken, created)
@@ -683,6 +695,29 @@ func (m *Mock) resolveSubnet(ctx context.Context, subnetID string) (vpcID, cidr 
 	return subs[0].VPCID, subs[0].CIDRBlock
 }
 
+// materializePrimaryENI asks the networking mock to create the instance's eth0
+// interface. It is best-effort: the interface is a side effect of the launch,
+// not a precondition, so a networking hiccup must not fail an otherwise-good
+// RunInstances (mirroring the metric emission above). A no-op until wired.
+func (m *Mock) materializePrimaryENI(ctx context.Context, instanceID, subnetID string, groups []string) {
+	if m.networking == nil {
+		return
+	}
+
+	_ = m.networking.CreatePrimaryNetworkInterface(ctx, instanceID, subnetID, groups)
+}
+
+// releasePrimaryENI asks the networking mock to drop the instance's primary
+// ENI, so a terminated instance no longer blocks DeleteSubnet /
+// DeleteSecurityGroup. A no-op until wired.
+func (m *Mock) releasePrimaryENI(ctx context.Context, instanceID string) {
+	if m.networking == nil {
+		return
+	}
+
+	_ = m.networking.ReleaseInstanceNetworkInterfaces(ctx, instanceID)
+}
+
 // allocatePrivateIP hands out the next private IPv4 inside the subnet's CIDR
 // (AWS allocates from the target subnet, e.g. 10.0.1.0/24 -> 10.0.1.x). It falls
 // back to the global 10.0.<n> pool when there is no subnet CIDR to draw from.
@@ -739,6 +774,9 @@ func (m *Mock) rollbackInstances(ctx context.Context, created []*instanceData) {
 
 		m.instances.Delete(inst.ID)
 		m.sm.Remove(inst.ID)
+		// Drop the primary ENI this instance may have materialized, so a
+		// rolled-back launch leaves no orphaned interface holding its subnet.
+		m.releasePrimaryENI(ctx, inst.ID)
 	}
 }
 
@@ -835,6 +873,15 @@ func (m *Mock) TerminateInstances(ctx context.Context, instanceIDs []string) err
 	// Every attached EBS volume must be released, otherwise it stays in-use
 	// against a dead instance forever and can never be deleted (VolumeInUse).
 	m.detachTerminatedVolumes(instanceIDs)
+
+	// Release each instance's primary (eth0) ENI, matching real EC2's
+	// delete-on-termination default. Until this happens the interface keeps
+	// residing in its subnet and referencing its security groups, which would
+	// (correctly) block a subsequent DeleteSubnet / DeleteSecurityGroup — but a
+	// terminated instance must no longer hold them.
+	for _, id := range instanceIDs {
+		m.releasePrimaryENI(ctx, id)
+	}
 
 	// Tear down the real backing for any engine-backed instances. Every id is now
 	// Terminated (transitionInstances verified they exist), and a Terminated

--- a/providers/aws/ec2/networking.go
+++ b/providers/aws/ec2/networking.go
@@ -1,0 +1,19 @@
+package ec2
+
+import "context"
+
+// Networking is the slice of the networking mock EC2 needs to keep an instance's
+// primary (eth0) network interface in step with its lifecycle. Real EC2 creates
+// an eth0 ENI in the instance's subnet at launch and deletes it on terminate;
+// that interface is what makes DeleteSubnet / DeleteSecurityGroup refuse while
+// the instance is running, so it has to be materialized rather than implied.
+type Networking interface {
+	CreatePrimaryNetworkInterface(ctx context.Context, instanceID, subnetID string, groups []string) error
+	ReleaseInstanceNetworkInterfaces(ctx context.Context, instanceID string) error
+}
+
+// SetNetworking wires the networking mock in. Without it an instance launches
+// with no materialized primary ENI, so the VPC delete guards can't see it.
+func (m *Mock) SetNetworking(n Networking) {
+	m.networking = n
+}

--- a/providers/aws/vpc/network_interface.go
+++ b/providers/aws/vpc/network_interface.go
@@ -34,6 +34,14 @@ const (
 	// layer can emit InvalidNetworkInterface.InUse rather than the generic
 	// DependencyViolation.
 	eniInUseErrPrefix = "InvalidNetworkInterface.InUse: "
+
+	// primaryDeviceIndex is the device index EC2 gives an instance's primary
+	// (eth0) network interface — always 0.
+	primaryDeviceIndex = 0
+
+	// primaryENIDescription is the description real EC2 stamps on the eth0 ENI
+	// it auto-creates for a launched instance.
+	primaryENIDescription = "Primary network interface"
 )
 
 type eniData struct {
@@ -50,6 +58,11 @@ type eniData struct {
 	SourceDestCheck bool
 	SecurityGroups  []string
 	Tags            map[string]string
+	// deleteOnTermination marks an ENI EC2 created as an instance's primary
+	// (eth0) interface at launch. Real EC2 deletes exactly these on
+	// TerminateInstances and leaves secondary/standalone ENIs in place, so the
+	// terminate-time release keys on this flag rather than the attachment alone.
+	deleteOnTermination bool
 }
 
 // CreateNetworkInterface creates a standalone, unattached ENI in the given
@@ -88,6 +101,67 @@ func (m *Mock) CreateNetworkInterface(
 	info := toENIInfo(eni)
 
 	return &info, nil
+}
+
+// CreatePrimaryNetworkInterface materializes the eth0 interface real EC2 creates
+// for an instance at launch: an in-use ENI in the instance's subnet, carrying
+// the instance's security groups, at device index 0, attached to the instance
+// and flagged delete-on-termination. Its existence is what makes DeleteSubnet
+// and DeleteSecurityGroup refuse while the instance is running, matching AWS.
+//
+// A launch with no subnet materializes nothing (there is no subnet to place the
+// interface in). An unknown subnet is NotFound, so a bad launch surfaces rather
+// than silently skipping the interface.
+func (m *Mock) CreatePrimaryNetworkInterface(_ context.Context, instanceID, subnetID string, groups []string) error {
+	if subnetID == "" {
+		return nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sub, ok := m.subnets.Get(subnetID)
+	if !ok {
+		return errors.Newf(errors.NotFound, "InvalidSubnetID.NotFound: subnet %q not found", subnetID)
+	}
+
+	id := idgen.GenerateID("eni-")
+	eni := &eniData{
+		ID:                  id,
+		VPCID:               sub.VPCID,
+		SubnetID:            subnetID,
+		Status:              ENIStatusInUse,
+		AttachmentID:        idgen.GenerateID("eni-attach-"),
+		InstanceID:          instanceID,
+		DeviceIndex:         primaryDeviceIndex,
+		Description:         primaryENIDescription,
+		PrivateIP:           m.allocateENIPrivateIP(subnetID, sub.CIDRBlock),
+		MacAddress:          mockMAC(id),
+		SourceDestCheck:     true,
+		SecurityGroups:      append([]string(nil), groups...),
+		deleteOnTermination: true,
+	}
+	m.enis.Set(id, eni)
+
+	return nil
+}
+
+// ReleaseInstanceNetworkInterfaces deletes the delete-on-termination interfaces
+// attached to instanceID — the primary ENIs CreatePrimaryNetworkInterface made.
+// Real EC2 releases these on TerminateInstances, which is what lets a subsequent
+// DeleteSubnet / DeleteSecurityGroup succeed. Standalone or managed interfaces
+// (deleteOnTermination false) are left untouched.
+func (m *Mock) ReleaseInstanceNetworkInterfaces(_ context.Context, instanceID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for id, eni := range m.enis.All() {
+		if eni.InstanceID == instanceID && eni.deleteOnTermination {
+			m.enis.Delete(id)
+		}
+	}
+
+	return nil
 }
 
 // DescribeNetworkInterfaces returns ENIs matching the given IDs, or all if empty.

--- a/server/aws/ec2/instance_delete_guards_test.go
+++ b/server/aws/ec2/instance_delete_guards_test.go
@@ -1,0 +1,149 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// runInstanceInSubnet launches one instance in the subnet (optionally in the
+// given security groups) and returns its id. Real EC2 gives every instance a
+// primary eth0 ENI in its subnet, so this is the setup the delete guards react to.
+func runInstanceInSubnet(t *testing.T, c *ec2.Client, subnetID string, groups []string) string {
+	t.Helper()
+
+	run, err := c.RunInstances(context.Background(), &ec2.RunInstancesInput{
+		ImageId:          aws.String("ami-12345"),
+		InstanceType:     ec2types.InstanceTypeT2Micro,
+		MinCount:         aws.Int32(1),
+		MaxCount:         aws.Int32(1),
+		SubnetId:         aws.String(subnetID),
+		SecurityGroupIds: groups,
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	return aws.ToString(run.Instances[0].InstanceId)
+}
+
+// terminate terminates the instance and fails the test on error.
+func terminate(t *testing.T, c *ec2.Client, instanceID string) {
+	t.Helper()
+
+	if _, err := c.TerminateInstances(context.Background(), &ec2.TerminateInstancesInput{
+		InstanceIds: []string{instanceID},
+	}); err != nil {
+		t.Fatalf("TerminateInstances: %v", err)
+	}
+}
+
+// TestDeleteSubnetBlockedByRunningInstance pins the real-EC2 rule that a subnet
+// holding a running instance cannot be deleted: the instance's primary ENI
+// resides in the subnet, so DeleteSubnet answers DependencyViolation. Once the
+// instance is terminated (releasing its ENI), the subnet deletes.
+func TestDeleteSubnetBlockedByRunningInstance(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	_, subnetID := mkVPCSubnet(t, c)
+
+	instanceID := runInstanceInSubnet(t, c, subnetID, nil)
+
+	if _, err := c.DeleteSubnet(ctx, &ec2.DeleteSubnetInput{SubnetId: aws.String(subnetID)}); err == nil {
+		t.Fatal("DeleteSubnet of a subnet with a running instance should fail")
+	} else if code := apiCode(t, err); code != "DependencyViolation" {
+		t.Fatalf("DeleteSubnet(running instance) code = %q, want DependencyViolation", code)
+	}
+
+	terminate(t, c, instanceID)
+
+	if _, err := c.DeleteSubnet(ctx, &ec2.DeleteSubnetInput{SubnetId: aws.String(subnetID)}); err != nil {
+		t.Fatalf("DeleteSubnet after terminate should succeed: %v", err)
+	}
+}
+
+// TestDeleteSecurityGroupBlockedByRunningInstance pins that a security group a
+// running instance uses cannot be deleted: the instance's primary ENI is a
+// member of the group, so DeleteSecurityGroup answers DependencyViolation. After
+// the instance is terminated (releasing its ENI), the group deletes.
+func TestDeleteSecurityGroupBlockedByRunningInstance(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	vpcID, subnetID := mkVPCSubnet(t, c)
+
+	sg, err := c.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+		GroupName: aws.String("app-sg"), Description: aws.String("app"), VpcId: aws.String(vpcID),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecurityGroup: %v", err)
+	}
+	sgID := aws.ToString(sg.GroupId)
+
+	instanceID := runInstanceInSubnet(t, c, subnetID, []string{sgID})
+
+	if _, err := c.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{GroupId: aws.String(sgID)}); err == nil {
+		t.Fatal("DeleteSecurityGroup of a group used by a running instance should fail")
+	} else if code := apiCode(t, err); code != "DependencyViolation" {
+		t.Fatalf("DeleteSecurityGroup(running instance) code = %q, want DependencyViolation", code)
+	}
+
+	terminate(t, c, instanceID)
+
+	if _, err := c.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{GroupId: aws.String(sgID)}); err != nil {
+		t.Fatalf("DeleteSecurityGroup after terminate should succeed: %v", err)
+	}
+}
+
+// TestRunInstancesMaterializesPrimaryENI pins that RunInstances creates the
+// instance's eth0 network interface the way real EC2 does: DescribeNetworkInterfaces
+// (filtered by subnet-id) reports one in-use interface attached at device index 0
+// and belonging to the instance.
+func TestRunInstancesMaterializesPrimaryENI(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	_, subnetID := mkVPCSubnet(t, c)
+
+	instanceID := runInstanceInSubnet(t, c, subnetID, nil)
+
+	desc, err := c.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("subnet-id"), Values: []string{subnetID}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNetworkInterfaces: %v", err)
+	}
+
+	if len(desc.NetworkInterfaces) != 1 {
+		t.Fatalf("network interfaces for instance = %d, want 1", len(desc.NetworkInterfaces))
+	}
+
+	eni := desc.NetworkInterfaces[0]
+	if aws.ToString(eni.SubnetId) != subnetID {
+		t.Errorf("ENI subnetId = %q, want %q", aws.ToString(eni.SubnetId), subnetID)
+	}
+	if eni.Status != ec2types.NetworkInterfaceStatusInUse {
+		t.Errorf("ENI status = %q, want in-use", eni.Status)
+	}
+	if eni.Attachment == nil || aws.ToInt32(eni.Attachment.DeviceIndex) != 0 {
+		t.Errorf("ENI attachment = %+v, want deviceIndex 0", eni.Attachment)
+	}
+	if eni.Attachment != nil && aws.ToString(eni.Attachment.InstanceId) != instanceID {
+		t.Errorf("ENI attachment instanceId = %q, want %q", aws.ToString(eni.Attachment.InstanceId), instanceID)
+	}
+
+	// After terminate the primary ENI is released, so the instance no longer
+	// appears among the VPC's interfaces.
+	terminate(t, c, instanceID)
+
+	desc, err = c.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("subnet-id"), Values: []string{subnetID}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNetworkInterfaces after terminate: %v", err)
+	}
+	if len(desc.NetworkInterfaces) != 0 {
+		t.Fatalf("network interfaces after terminate = %d, want 0", len(desc.NetworkInterfaces))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two AWS VPC delete-guard bugs: `DeleteSubnet` and `DeleteSecurityGroup` wrongly succeeded while a running instance used the subnet / security group.

Root cause: `RunInstances` never materialized an instance's primary (eth0) network interface in the VPC provider's ENI store, so the existing `eniInSubnet` and `securityGroupInUse` guards — which scan that store — saw nothing to block on.

## What changed (approach A — real-EC2-faithful)

- `RunInstances` now materializes the primary eth0 ENI real EC2 creates for every instance: in the instance's subnet, carrying its security groups, at device index 0, attached to the instance, delete-on-termination.
- `TerminateInstances` (and mid-batch launch rollback) releases that ENI.
- Wired compute -> VPC via a new EC2 `Networking` hook (`SetNetworking(p.VPC)`) in the provider factory, mirroring the existing `SetSubnetResolver` pattern. No import cycle — the hook interface is defined on the consumer (EC2) side.

With the primary ENI present, the existing guards work unchanged:
- `DeleteSubnet` with a running instance -> `DependencyViolation`; terminate -> succeeds.
- `DeleteSecurityGroup` referenced by a running instance -> `DependencyViolation`; terminate -> succeeds.

Side effect (correct AWS behavior): `DescribeNetworkInterfaces` now lists an instance's eth0 ENI.

## Tests

New real-SDK e2e tests in `server/aws/ec2/instance_delete_guards_test.go`:
- DeleteSubnet blocked by a running instance, then succeeds after terminate.
- DeleteSecurityGroup blocked by a running instance, then succeeds after terminate.
- RunInstances materializes the eth0 ENI (in-use, device index 0, attached to the instance); released on terminate.

Existing guards verified unregressed: SG-in-use-by-ENI, cannot-delete-default-SG, SG-referenced-by-another-SG rule, delete-VPC-with-subnet, delete-attached-ENI.
