### PR TITLE
fix(aws-iam,secretsmanager): paginate ListInstanceProfiles, GetGroup members, ListSecretVersionIds

### DIFF
--- a/server/aws/iam/operations.go
+++ b/server/aws/iam/operations.go
@@ -705,12 +705,15 @@ func (h *Handler) getGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	members, marker, truncated := h.groupMembersXML(r.Context(), g.Name, r.Form)
+
 	awsquery.WriteXMLResponse(w, getGroupResponse{
 		Xmlns: Namespace,
 		Result: getGroupResult{
 			Group:       toGroupXML(g),
-			Users:       h.groupMembersXML(r.Context(), g.Name),
-			IsTruncated: false,
+			Users:       members,
+			IsTruncated: truncated,
+			Marker:      marker,
 		},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
@@ -722,27 +725,34 @@ type groupMemberLister interface {
 	ListGroupMembers(ctx context.Context, groupName string) ([]iamdriver.UserInfo, error)
 }
 
-// groupMembersXML returns the users in a group as the wire shape GetGroup
-// expects, or an empty list when the driver does not track membership.
-func (h *Handler) groupMembersXML(ctx context.Context, groupName string) usersListXML {
+// groupMembersXML returns a page of the users in a group as the wire shape
+// GetGroup expects, along with the next Marker and truncation flag. It returns
+// an empty list when the driver does not track membership. Real IAM paginates a
+// group's members via Marker/MaxItems.
+func (h *Handler) groupMembersXML(
+	ctx context.Context, groupName string, form url.Values,
+) (users usersListXML, nextMarker string, truncated bool) {
 	lister, ok := h.iam.(groupMemberLister)
 	if !ok {
-		return usersListXML{}
+		return usersListXML{}, "", false
 	}
 
-	users, err := lister.ListGroupMembers(ctx, groupName)
+	members, err := lister.ListGroupMembers(ctx, groupName)
 	if err != nil {
-		return usersListXML{}
+		return usersListXML{}, "", false
 	}
 
-	sort.Slice(users, func(i, j int) bool { return users[i].Name < users[j].Name })
+	sort.Slice(members, func(i, j int) bool { return members[i].Name < members[j].Name })
 
-	out := usersListXML{Member: make([]userXML, 0, len(users))}
-	for i := range users {
-		out.Member = append(out.Member, toUserXML(&users[i]))
+	start, end, marker, isTruncated := pageWindow(len(members), form)
+	page := members[start:end]
+
+	out := usersListXML{Member: make([]userXML, 0, len(page))}
+	for i := range page {
+		out.Member = append(out.Member, toUserXML(&page[i]))
 	}
 
-	return out
+	return out, marker, isTruncated
 }
 
 //nolint:dupl // list handlers share shape but operate on different driver types and response envelopes.
@@ -928,14 +938,19 @@ func (h *Handler) listInstanceProfiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := instanceProfilesListXML{Member: make([]instanceProfileXML, 0, len(profiles))}
-	for i := range profiles {
-		out.Member = append(out.Member, toInstanceProfileXML(&profiles[i], h.lookupRole(r, profiles[i].RoleName)))
+	sort.Slice(profiles, func(i, j int) bool { return profiles[i].Name < profiles[j].Name })
+
+	start, end, marker, truncated := pageWindow(len(profiles), r.Form)
+	page := profiles[start:end]
+
+	out := instanceProfilesListXML{Member: make([]instanceProfileXML, 0, len(page))}
+	for i := range page {
+		out.Member = append(out.Member, toInstanceProfileXML(&page[i], h.lookupRole(r, page[i].RoleName)))
 	}
 
 	awsquery.WriteXMLResponse(w, listInstanceProfilesResponse{
 		Xmlns:    Namespace,
-		Result:   listInstanceProfilesResult{InstanceProfiles: out, IsTruncated: false},
+		Result:   listInstanceProfilesResult{InstanceProfiles: out, IsTruncated: truncated, Marker: marker},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/iam/pagination_test.go
+++ b/server/aws/iam/pagination_test.go
@@ -1,0 +1,195 @@
+package iam_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+)
+
+// pageSize is the MaxItems used across the pagination tests: small enough that
+// the fixtures span several pages.
+const pageSize = 2
+
+// TestSDKListInstanceProfilesPaginates proves ListInstanceProfiles honors
+// MaxItems/Marker: the SDK paginator walks every profile exactly once and
+// terminates (previously the handler returned all profiles with IsTruncated
+// hardcoded false, so a paginator only ever saw one page).
+func TestSDKListInstanceProfilesPaginates(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const total = 5
+
+	want := map[string]bool{}
+
+	for i := range total {
+		name := fmt.Sprintf("profile-%02d", i)
+		want[name] = true
+
+		if _, err := client.CreateInstanceProfile(ctx, &iam.CreateInstanceProfileInput{
+			InstanceProfileName: aws.String(name),
+		}); err != nil {
+			t.Fatalf("CreateInstanceProfile %s: %v", name, err)
+		}
+	}
+
+	paginator := iam.NewListInstanceProfilesPaginator(client, &iam.ListInstanceProfilesInput{
+		MaxItems: aws.Int32(pageSize),
+	})
+
+	got := map[string]bool{}
+	pages := 0
+
+	for paginator.HasMorePages() {
+		out, err := paginator.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		pages++
+
+		if len(out.InstanceProfiles) > pageSize {
+			t.Fatalf("page returned %d profiles, want <= %d", len(out.InstanceProfiles), pageSize)
+		}
+
+		for _, p := range out.InstanceProfiles {
+			name := aws.ToString(p.InstanceProfileName)
+			if got[name] {
+				t.Fatalf("profile %s returned twice", name)
+			}
+
+			got[name] = true
+		}
+	}
+
+	if len(got) != total {
+		t.Fatalf("walked %d profiles, want %d", len(got), total)
+	}
+
+	for name := range want {
+		if !got[name] {
+			t.Fatalf("profile %s never returned", name)
+		}
+	}
+
+	// total=5, pageSize=2 -> pages of 2, 2, 1.
+	if wantPages := 3; pages != wantPages {
+		t.Fatalf("walked %d pages, want %d", pages, wantPages)
+	}
+}
+
+// TestSDKGetGroupMembersPaginate proves GetGroup pages its member list via
+// Marker/MaxItems: the SDK paginator walks every group member exactly once and
+// terminates (previously the Users list was returned whole with IsTruncated
+// hardcoded false).
+func TestSDKGetGroupMembersPaginate(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateGroup(ctx, &iam.CreateGroupInput{GroupName: aws.String("devs")}); err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+
+	const total = 5
+
+	want := map[string]bool{}
+
+	for i := range total {
+		name := fmt.Sprintf("user-%02d", i)
+		want[name] = true
+
+		if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String(name)}); err != nil {
+			t.Fatalf("CreateUser %s: %v", name, err)
+		}
+
+		if _, err := client.AddUserToGroup(ctx, &iam.AddUserToGroupInput{
+			GroupName: aws.String("devs"), UserName: aws.String(name),
+		}); err != nil {
+			t.Fatalf("AddUserToGroup %s: %v", name, err)
+		}
+	}
+
+	paginator := iam.NewGetGroupPaginator(client, &iam.GetGroupInput{
+		GroupName: aws.String("devs"),
+		MaxItems:  aws.Int32(pageSize),
+	})
+
+	got := map[string]bool{}
+	pages := 0
+
+	for paginator.HasMorePages() {
+		out, err := paginator.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		pages++
+
+		if len(out.Users) > pageSize {
+			t.Fatalf("page returned %d users, want <= %d", len(out.Users), pageSize)
+		}
+
+		for _, u := range out.Users {
+			name := aws.ToString(u.UserName)
+			if got[name] {
+				t.Fatalf("user %s returned twice", name)
+			}
+
+			got[name] = true
+		}
+	}
+
+	if len(got) != total {
+		t.Fatalf("walked %d members, want %d", len(got), total)
+	}
+
+	for name := range want {
+		if !got[name] {
+			t.Fatalf("member %s never returned", name)
+		}
+	}
+
+	if wantPages := 3; pages != wantPages {
+		t.Fatalf("walked %d pages, want %d", pages, wantPages)
+	}
+}
+
+// TestSDKGetGroupSinglePageNoMarker proves a group whose members fit in one page
+// reports no Marker (the paginator stops after one page).
+func TestSDKGetGroupSinglePageNoMarker(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateGroup(ctx, &iam.CreateGroupInput{GroupName: aws.String("ops")}); err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("solo")}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.AddUserToGroup(ctx, &iam.AddUserToGroupInput{
+		GroupName: aws.String("ops"), UserName: aws.String("solo"),
+	}); err != nil {
+		t.Fatalf("AddUserToGroup: %v", err)
+	}
+
+	out, err := client.GetGroup(ctx, &iam.GetGroupInput{
+		GroupName: aws.String("ops"),
+		MaxItems:  aws.Int32(pageSize),
+	})
+	if err != nil {
+		t.Fatalf("GetGroup: %v", err)
+	}
+
+	if out.IsTruncated {
+		t.Fatal("IsTruncated = true, want false for a single-page group")
+	}
+
+	if aws.ToString(out.Marker) != "" {
+		t.Fatalf("Marker = %q, want empty for a single-page group", aws.ToString(out.Marker))
+	}
+}

--- a/server/aws/iam/xml.go
+++ b/server/aws/iam/xml.go
@@ -521,6 +521,7 @@ type getGroupResult struct {
 	Group       groupXML     `xml:"Group"`
 	Users       usersListXML `xml:"Users"`
 	IsTruncated bool         `xml:"IsTruncated"`
+	Marker      string       `xml:"Marker,omitempty"`
 }
 
 type listGroupsResponse struct {
@@ -628,6 +629,7 @@ type listInstanceProfilesResponse struct {
 type listInstanceProfilesResult struct {
 	InstanceProfiles instanceProfilesListXML `xml:"InstanceProfiles"`
 	IsTruncated      bool                    `xml:"IsTruncated"`
+	Marker           string                  `xml:"Marker,omitempty"`
 }
 
 type addRoleToInstanceProfileResponse struct {

--- a/server/aws/secretsmanager/list_secret_version_ids_pagination_test.go
+++ b/server/aws/secretsmanager/list_secret_version_ids_pagination_test.go
@@ -1,0 +1,109 @@
+package secretsmanager_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssm "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/smithy-go"
+)
+
+// versionPageSize is the MaxResults used in the pagination tests: small enough
+// that the fixtures span several pages.
+const versionPageSize = 2
+
+// TestSDKListSecretVersionIdsPaginates proves ListSecretVersionIds honors
+// MaxResults/NextToken: the paginator walks every version exactly once and
+// terminates (previously the handler returned every version with no token).
+func TestSDKListSecretVersionIdsPaginates(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	putVersions(t, client, "api-key", []string{"v1", "v2", "v3", "v4", "v5"})
+
+	paginator := awssm.NewListSecretVersionIdsPaginator(client, &awssm.ListSecretVersionIdsInput{
+		SecretId:          aws.String("api-key"),
+		IncludeDeprecated: aws.Bool(true),
+		MaxResults:        aws.Int32(versionPageSize),
+	})
+
+	got := map[string]bool{}
+	pages := 0
+
+	for paginator.HasMorePages() {
+		out, err := paginator.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		pages++
+
+		if len(out.Versions) > versionPageSize {
+			t.Fatalf("page returned %d versions, want <= %d", len(out.Versions), versionPageSize)
+		}
+
+		for _, v := range out.Versions {
+			id := aws.ToString(v.VersionId)
+			if got[id] {
+				t.Fatalf("version %s returned twice", id)
+			}
+
+			got[id] = true
+		}
+	}
+
+	// 5 versions returned when IncludeDeprecated is set.
+	if len(got) != 5 {
+		t.Fatalf("walked %d versions, want 5", len(got))
+	}
+
+	// 5 versions, page size 2 -> pages of 2, 2, 1.
+	if wantPages := 3; pages != wantPages {
+		t.Fatalf("walked %d pages, want %d", pages, wantPages)
+	}
+}
+
+// TestSDKListSecretVersionIdsSinglePageNoToken proves a version set that fits in
+// one page returns no NextToken.
+func TestSDKListSecretVersionIdsSinglePageNoToken(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	putVersions(t, client, "api-key", []string{"v1", "v2"})
+
+	out, err := client.ListSecretVersionIds(ctx, &awssm.ListSecretVersionIdsInput{
+		SecretId:   aws.String("api-key"),
+		MaxResults: aws.Int32(versionPageSize),
+	})
+	if err != nil {
+		t.Fatalf("ListSecretVersionIds: %v", err)
+	}
+
+	if out.NextToken != nil {
+		t.Fatalf("NextToken = %q, want nil for a single page", aws.ToString(out.NextToken))
+	}
+}
+
+// TestSDKListSecretVersionIdsInvalidToken proves a malformed NextToken surfaces
+// as an API error rather than being silently ignored.
+func TestSDKListSecretVersionIdsInvalidToken(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	putVersions(t, client, "api-key", []string{"v1", "v2"})
+
+	_, err := client.ListSecretVersionIds(ctx, &awssm.ListSecretVersionIdsInput{
+		SecretId:  aws.String("api-key"),
+		NextToken: aws.String("!!not-base64!!"),
+	})
+	if err == nil {
+		t.Fatal("ListSecretVersionIds with a bad NextToken succeeded, want an error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not an API error: %v", err)
+	}
+}

--- a/server/aws/secretsmanager/operations.go
+++ b/server/aws/secretsmanager/operations.go
@@ -394,7 +394,7 @@ func (h *Handler) listSecretVersionIDs(w http.ResponseWriter, r *http.Request) {
 	// staging labels) and are omitted unless IncludeDeprecated is set.
 	stageMap := h.versionStages(r, name)
 
-	out := make([]versionJSON, 0, len(versions))
+	all := make([]versionJSON, 0, len(versions))
 
 	for _, v := range versions {
 		stages := stagesForVersion(stageMap, &v)
@@ -402,14 +402,32 @@ func (h *Handler) listSecretVersionIDs(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		out = append(out, versionJSON{
+		all = append(all, versionJSON{
 			VersionID:     v.VersionID,
 			VersionStages: stages,
 			CreatedDate:   epochSeconds(v.CreatedAt),
 		})
 	}
 
-	wire.WriteJSON(w, listSecretVersionIDsResponse{ARN: info.ResourceID, Name: info.Name, Versions: out})
+	// Newest first, VersionId as the tiebreaker so the offset NextToken stays
+	// stable across pages when two versions share a CreatedDate.
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].CreatedDate != all[j].CreatedDate {
+			return all[i].CreatedDate > all[j].CreatedDate
+		}
+
+		return all[i].VersionID < all[j].VersionID
+	})
+
+	start, end, next, err := pageWindow(req.NextToken, req.MaxResults, len(all))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, listSecretVersionIDsResponse{
+		ARN: info.ResourceID, Name: info.Name, Versions: all[start:end], NextToken: next,
+	})
 }
 
 func (h *Handler) updateSecret(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/secretsmanager/types.go
+++ b/server/aws/secretsmanager/types.go
@@ -62,7 +62,9 @@ type listSecretVersionIDsRequest struct {
 	SecretID string `json:"SecretId"`
 	// IncludeDeprecated, when true, also returns versions that carry no staging
 	// labels (deprecated versions). By default AWS omits them.
-	IncludeDeprecated bool `json:"IncludeDeprecated"`
+	IncludeDeprecated bool   `json:"IncludeDeprecated"`
+	MaxResults        int32  `json:"MaxResults"`
+	NextToken         string `json:"NextToken"`
 }
 
 type deleteSecretRequest struct {
@@ -199,9 +201,10 @@ type putSecretValueResponse struct {
 }
 
 type listSecretVersionIDsResponse struct {
-	ARN      string        `json:"ARN"`
-	Name     string        `json:"Name"`
-	Versions []versionJSON `json:"Versions"`
+	ARN       string        `json:"ARN"`
+	Name      string        `json:"Name"`
+	Versions  []versionJSON `json:"Versions"`
+	NextToken string        `json:"NextToken,omitempty"`
 }
 
 type putResourcePolicyRequest struct {


### PR DESCRIPTION
## Summary

Three AWS list operations ignored their pagination parameters and returned every item in a single response with `IsTruncated`/token hardcoded, so real SDK paginators only ever saw one page.

- **ListInstanceProfiles** (`server/aws/iam`): returned all profiles, ignored `Marker`/`MaxItems`, hardcoded `IsTruncated:false`. Now sorts by `InstanceProfileName` and applies the existing `pageWindow`, emitting `Marker` + `IsTruncated` (mirrors `ListUsers`/`ListRoles`).
- **GetGroup member list** (`server/aws/iam`): the `Users` membership list returned whole, hardcoded `IsTruncated:false`. Now paginates members via `Marker`/`MaxItems`, matching real IAM which pages a group's members.
- **ListSecretVersionIds** (`server/aws/secretsmanager`): had no paging fields and returned every version. Added `MaxResults`/`NextToken` to request and `NextToken` to response; sorts versions (newest first, `VersionId` tiebreaker for stable offset tokens) and pages via the existing `pageWindow` helper. Invalid `NextToken` surfaces as an API error, consistent with `ListSecrets`.

All offset-token paging sorts deterministically before slicing so tokens stay valid across pages.

## Tests

Real `aws-sdk-go-v2` iam + secretsmanager clients against a booted `httptest` server:
- ListInstanceProfiles paginator walks all profiles once and terminates; page sizes respected.
- GetGroup paginator walks all members once; single-page group reports no Marker.
- ListSecretVersionIds paginator walks all versions once; single page emits no token; invalid token errors.