### PR TITLE
fix(rds): Marker/MaxRecords pagination on RDS Describe list APIs

### DIFF
--- a/server/aws/rds/describe_pagination_sdk_roundtrip_test.go
+++ b/server/aws/rds/describe_pagination_sdk_roundtrip_test.go
@@ -1,0 +1,321 @@
+package rds_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+)
+
+// The Marker/MaxRecords contract is identical across the RDS Describe list
+// APIs, so the tests below share one page count and one over-a-single-page
+// item count: 25 items paged 20 at a time yield exactly two pages (20 + 5).
+const (
+	paginationPageSize   = 20
+	paginationItemCount  = 25
+	paginationTotalPages = 2
+)
+
+// pageWalk drives a Marker/MaxRecords describe closure to exhaustion, returning
+// the identifiers seen and the number of pages fetched. It fails if any
+// identifier repeats across pages — the invariant offset pagination must hold.
+func pageWalk(t *testing.T,
+	describe func(marker *string) (ids []string, next *string, err error),
+) (seen map[string]bool, pages int) {
+	t.Helper()
+
+	seen = map[string]bool{}
+
+	var marker *string
+
+	for {
+		ids, next, err := describe(marker)
+		if err != nil {
+			t.Fatalf("describe page %d: %v", pages+1, err)
+		}
+
+		pages++
+
+		for _, id := range ids {
+			if seen[id] {
+				t.Fatalf("identifier %q appeared on two pages", id)
+			}
+
+			seen[id] = true
+		}
+
+		if aws.ToString(next) == "" {
+			return seen, pages
+		}
+
+		marker = next
+	}
+}
+
+func TestSDKRDSDescribeDBClustersPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	for i := range paginationItemCount {
+		id := fmt.Sprintf("cl-%02d", i)
+		if _, err := client.CreateDBCluster(ctx, &awsrds.CreateDBClusterInput{
+			DBClusterIdentifier: aws.String(id),
+			Engine:              aws.String("aurora-mysql"),
+		}); err != nil {
+			t.Fatalf("CreateDBCluster(%s): %v", id, err)
+		}
+	}
+
+	seen, pages := pageWalk(t, func(marker *string) ([]string, *string, error) {
+		out, err := client.DescribeDBClusters(ctx, &awsrds.DescribeDBClustersInput{
+			MaxRecords: aws.Int32(paginationPageSize), Marker: marker,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		ids := make([]string, 0, len(out.DBClusters))
+		for _, c := range out.DBClusters {
+			ids = append(ids, aws.ToString(c.DBClusterIdentifier))
+		}
+
+		return ids, out.Marker, nil
+	})
+
+	if len(seen) != paginationItemCount || pages != paginationTotalPages {
+		t.Fatalf("walked %d clusters over %d pages, want %d over %d",
+			len(seen), pages, paginationItemCount, paginationTotalPages)
+	}
+
+	single, err := client.DescribeDBClusters(ctx, &awsrds.DescribeDBClustersInput{})
+	if err != nil {
+		t.Fatalf("DescribeDBClusters single page: %v", err)
+	}
+
+	if aws.ToString(single.Marker) != "" {
+		t.Fatal("single page returned a Marker; want none")
+	}
+
+	if _, err := client.DescribeDBClusters(ctx, &awsrds.DescribeDBClustersInput{
+		Marker: aws.String("not-a-valid-marker"),
+	}); err == nil {
+		t.Fatal("invalid Marker accepted; want an error")
+	}
+}
+
+func TestSDKRDSDescribeDBSnapshotsPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("snap-src"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	for i := range paginationItemCount {
+		id := fmt.Sprintf("snap-%02d", i)
+		if _, err := client.CreateDBSnapshot(ctx, &awsrds.CreateDBSnapshotInput{
+			DBSnapshotIdentifier: aws.String(id),
+			DBInstanceIdentifier: aws.String("snap-src"),
+		}); err != nil {
+			t.Fatalf("CreateDBSnapshot(%s): %v", id, err)
+		}
+	}
+
+	seen, pages := pageWalk(t, func(marker *string) ([]string, *string, error) {
+		out, err := client.DescribeDBSnapshots(ctx, &awsrds.DescribeDBSnapshotsInput{
+			MaxRecords: aws.Int32(paginationPageSize), Marker: marker,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		ids := make([]string, 0, len(out.DBSnapshots))
+		for _, s := range out.DBSnapshots {
+			ids = append(ids, aws.ToString(s.DBSnapshotIdentifier))
+		}
+
+		return ids, out.Marker, nil
+	})
+
+	if len(seen) != paginationItemCount || pages != paginationTotalPages {
+		t.Fatalf("walked %d snapshots over %d pages, want %d over %d",
+			len(seen), pages, paginationItemCount, paginationTotalPages)
+	}
+
+	single, err := client.DescribeDBSnapshots(ctx, &awsrds.DescribeDBSnapshotsInput{})
+	if err != nil {
+		t.Fatalf("DescribeDBSnapshots single page: %v", err)
+	}
+
+	if aws.ToString(single.Marker) != "" {
+		t.Fatal("single page returned a Marker; want none")
+	}
+
+	if _, err := client.DescribeDBSnapshots(ctx, &awsrds.DescribeDBSnapshotsInput{
+		Marker: aws.String("not-a-valid-marker"),
+	}); err == nil {
+		t.Fatal("invalid Marker accepted; want an error")
+	}
+}
+
+func TestSDKRDSDescribeDBSubnetGroupsPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	for i := range paginationItemCount {
+		id := fmt.Sprintf("subnet-grp-%02d", i)
+		if _, err := client.CreateDBSubnetGroup(ctx, &awsrds.CreateDBSubnetGroupInput{
+			DBSubnetGroupName:        aws.String(id),
+			DBSubnetGroupDescription: aws.String("test"),
+			SubnetIds:                []string{"subnet-1", "subnet-2"},
+		}); err != nil {
+			t.Fatalf("CreateDBSubnetGroup(%s): %v", id, err)
+		}
+	}
+
+	seen, pages := pageWalk(t, func(marker *string) ([]string, *string, error) {
+		out, err := client.DescribeDBSubnetGroups(ctx, &awsrds.DescribeDBSubnetGroupsInput{
+			MaxRecords: aws.Int32(paginationPageSize), Marker: marker,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		ids := make([]string, 0, len(out.DBSubnetGroups))
+		for _, g := range out.DBSubnetGroups {
+			ids = append(ids, aws.ToString(g.DBSubnetGroupName))
+		}
+
+		return ids, out.Marker, nil
+	})
+
+	if len(seen) != paginationItemCount || pages != paginationTotalPages {
+		t.Fatalf("walked %d subnet groups over %d pages, want %d over %d",
+			len(seen), pages, paginationItemCount, paginationTotalPages)
+	}
+
+	single, err := client.DescribeDBSubnetGroups(ctx, &awsrds.DescribeDBSubnetGroupsInput{})
+	if err != nil {
+		t.Fatalf("DescribeDBSubnetGroups single page: %v", err)
+	}
+
+	if aws.ToString(single.Marker) != "" {
+		t.Fatal("single page returned a Marker; want none")
+	}
+
+	if _, err := client.DescribeDBSubnetGroups(ctx, &awsrds.DescribeDBSubnetGroupsInput{
+		Marker: aws.String("not-a-valid-marker"),
+	}); err == nil {
+		t.Fatal("invalid Marker accepted; want an error")
+	}
+}
+
+func TestSDKRDSDescribeDBParameterGroupsPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	for i := range paginationItemCount {
+		id := fmt.Sprintf("param-grp-%02d", i)
+		if _, err := client.CreateDBParameterGroup(ctx, &awsrds.CreateDBParameterGroupInput{
+			DBParameterGroupName:   aws.String(id),
+			DBParameterGroupFamily: aws.String("mysql8.0"),
+			Description:            aws.String("test"),
+		}); err != nil {
+			t.Fatalf("CreateDBParameterGroup(%s): %v", id, err)
+		}
+	}
+
+	seen, pages := pageWalk(t, func(marker *string) ([]string, *string, error) {
+		out, err := client.DescribeDBParameterGroups(ctx, &awsrds.DescribeDBParameterGroupsInput{
+			MaxRecords: aws.Int32(paginationPageSize), Marker: marker,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		ids := make([]string, 0, len(out.DBParameterGroups))
+		for _, g := range out.DBParameterGroups {
+			ids = append(ids, aws.ToString(g.DBParameterGroupName))
+		}
+
+		return ids, out.Marker, nil
+	})
+
+	if len(seen) != paginationItemCount || pages != paginationTotalPages {
+		t.Fatalf("walked %d parameter groups over %d pages, want %d over %d",
+			len(seen), pages, paginationItemCount, paginationTotalPages)
+	}
+
+	single, err := client.DescribeDBParameterGroups(ctx, &awsrds.DescribeDBParameterGroupsInput{})
+	if err != nil {
+		t.Fatalf("DescribeDBParameterGroups single page: %v", err)
+	}
+
+	if aws.ToString(single.Marker) != "" {
+		t.Fatal("single page returned a Marker; want none")
+	}
+
+	if _, err := client.DescribeDBParameterGroups(ctx, &awsrds.DescribeDBParameterGroupsInput{
+		Marker: aws.String("not-a-valid-marker"),
+	}); err == nil {
+		t.Fatal("invalid Marker accepted; want an error")
+	}
+}
+
+func TestSDKRDSDescribeDBClusterParameterGroupsPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	for i := range paginationItemCount {
+		id := fmt.Sprintf("cluster-param-grp-%02d", i)
+		if _, err := client.CreateDBClusterParameterGroup(ctx, &awsrds.CreateDBClusterParameterGroupInput{
+			DBClusterParameterGroupName: aws.String(id),
+			DBParameterGroupFamily:      aws.String("aurora-mysql8.0"),
+			Description:                 aws.String("test"),
+		}); err != nil {
+			t.Fatalf("CreateDBClusterParameterGroup(%s): %v", id, err)
+		}
+	}
+
+	seen, pages := pageWalk(t, func(marker *string) ([]string, *string, error) {
+		out, err := client.DescribeDBClusterParameterGroups(ctx, &awsrds.DescribeDBClusterParameterGroupsInput{
+			MaxRecords: aws.Int32(paginationPageSize), Marker: marker,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		ids := make([]string, 0, len(out.DBClusterParameterGroups))
+		for _, g := range out.DBClusterParameterGroups {
+			ids = append(ids, aws.ToString(g.DBClusterParameterGroupName))
+		}
+
+		return ids, out.Marker, nil
+	})
+
+	if len(seen) != paginationItemCount || pages != paginationTotalPages {
+		t.Fatalf("walked %d cluster parameter groups over %d pages, want %d over %d",
+			len(seen), pages, paginationItemCount, paginationTotalPages)
+	}
+
+	single, err := client.DescribeDBClusterParameterGroups(ctx, &awsrds.DescribeDBClusterParameterGroupsInput{})
+	if err != nil {
+		t.Fatalf("DescribeDBClusterParameterGroups single page: %v", err)
+	}
+
+	if aws.ToString(single.Marker) != "" {
+		t.Fatal("single page returned a Marker; want none")
+	}
+
+	if _, err := client.DescribeDBClusterParameterGroups(ctx, &awsrds.DescribeDBClusterParameterGroupsInput{
+		Marker: aws.String("not-a-valid-marker"),
+	}); err == nil {
+		t.Fatal("invalid Marker accepted; want an error")
+	}
+}

--- a/server/aws/rds/operations.go
+++ b/server/aws/rds/operations.go
@@ -3,13 +3,31 @@ package rds
 import (
 	"net/http"
 	"net/url"
-	"sort"
 	"strconv"
 
 	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
+
+// paginateRDS stable-sorts items by the identifier that key returns, then slices a
+// Marker/MaxRecords page out of them — the shared body behind every RDS
+// Describe* list handler. On an invalid Marker it writes the RDS
+// InvalidParameterValue wire error and returns ok=false so the caller returns
+// without emitting a result.
+func paginateRDS[T any](w http.ResponseWriter, r *http.Request,
+	items []T, key func(*T) string,
+) (pagination.Page[T], bool) {
+	page, err := pagination.PaginateSorted(items,
+		func(a, b T) bool { return key(&a) < key(&b) },
+		r.Form.Get("Marker"), formInt(r.Form.Get("MaxRecords")))
+	if err != nil {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", "invalid Marker")
+		return pagination.Page[T]{}, false
+	}
+
+	return page, true
+}
 
 // instanceFromForm pulls the common DBInstance fields out of a form. Used by
 // CreateDBInstance and as the basis for ModifyDBInstance.
@@ -100,12 +118,8 @@ func (h *Handler) describeDBInstances(w http.ResponseWriter, r *http.Request) {
 
 	insts = filterInstances(insts, parseInstanceFilters(r.Form))
 
-	// Offset tokens require a stable ordering; sort by identifier before paging.
-	sort.Slice(insts, func(i, j int) bool { return insts[i].ID < insts[j].ID })
-
-	page, err := pagination.Paginate(insts, r.Form.Get("Marker"), formInt(r.Form.Get("MaxRecords")))
-	if err != nil {
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", "invalid Marker")
+	page, ok := paginateRDS(w, r, insts, func(i *rdsdriver.Instance) string { return i.ID })
+	if !ok {
 		return
 	}
 
@@ -428,14 +442,19 @@ func (h *Handler) describeDBClusters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := dbClustersXML{DBCluster: make([]dbClusterXML, 0, len(clusters))}
-	for i := range clusters {
-		out.DBCluster = append(out.DBCluster, toClusterXML(&clusters[i]))
+	page, ok := paginateRDS(w, r, clusters, func(c *rdsdriver.Cluster) string { return c.ID })
+	if !ok {
+		return
+	}
+
+	out := dbClustersXML{DBCluster: make([]dbClusterXML, 0, len(page.Items))}
+	for i := range page.Items {
+		out.DBCluster = append(out.DBCluster, toClusterXML(&page.Items[i]))
 	}
 
 	awsquery.WriteXMLResponse(w, describeDBClustersResponse{
 		Xmlns:    Namespace,
-		Result:   dbClustersResult{DBClusters: out},
+		Result:   dbClustersResult{Marker: page.NextPageToken, DBClusters: out},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -620,14 +639,19 @@ func (h *Handler) describeDBSnapshots(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := dbSnapshotsXML{DBSnapshot: make([]dbSnapshotXML, 0, len(snaps))}
-	for i := range snaps {
-		out.DBSnapshot = append(out.DBSnapshot, toSnapshotXML(&snaps[i]))
+	page, ok := paginateRDS(w, r, snaps, func(s *rdsdriver.Snapshot) string { return s.ID })
+	if !ok {
+		return
+	}
+
+	out := dbSnapshotsXML{DBSnapshot: make([]dbSnapshotXML, 0, len(page.Items))}
+	for i := range page.Items {
+		out.DBSnapshot = append(out.DBSnapshot, toSnapshotXML(&page.Items[i]))
 	}
 
 	awsquery.WriteXMLResponse(w, describeDBSnapshotsResponse{
 		Xmlns:    Namespace,
-		Result:   dbSnapshotsResult{DBSnapshots: out},
+		Result:   dbSnapshotsResult{Marker: page.NextPageToken, DBSnapshots: out},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/rds/parameter_group.go
+++ b/server/aws/rds/parameter_group.go
@@ -62,6 +62,7 @@ type describeDBParameterGroupsResponse struct {
 }
 
 type dbParameterGroupsList struct {
+	Marker            string                `xml:"Marker,omitempty"`
 	DBParameterGroups []dbParameterGroupXML `xml:"DBParameterGroups>DBParameterGroup"`
 }
 
@@ -126,6 +127,7 @@ type describeDBClusterParameterGroupsResponse struct {
 }
 
 type dbClusterParameterGroupsList struct {
+	Marker                   string                       `xml:"Marker,omitempty"`
 	DBClusterParameterGroups []dbClusterParameterGroupXML `xml:"DBClusterParameterGroups>DBClusterParameterGroup"`
 }
 
@@ -289,14 +291,19 @@ func (h *Handler) describeDBParameterGroups(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	out := make([]dbParameterGroupXML, 0, len(groups))
-	for i := range groups {
-		out = append(out, toParameterGroupXML(&groups[i]))
+	page, ok := paginateRDS(w, r, groups, func(g *rdsdriver.ParameterGroup) string { return g.Name })
+	if !ok {
+		return
+	}
+
+	out := make([]dbParameterGroupXML, 0, len(page.Items))
+	for i := range page.Items {
+		out = append(out, toParameterGroupXML(&page.Items[i]))
 	}
 
 	awsquery.WriteXMLResponse(w, describeDBParameterGroupsResponse{
 		Xmlns:    Namespace,
-		Result:   dbParameterGroupsList{DBParameterGroups: out},
+		Result:   dbParameterGroupsList{Marker: page.NextPageToken, DBParameterGroups: out},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -454,14 +461,19 @@ func (h *Handler) describeDBClusterParameterGroups(w http.ResponseWriter, r *htt
 		return
 	}
 
-	out := make([]dbClusterParameterGroupXML, 0, len(groups))
-	for i := range groups {
-		out = append(out, toClusterParameterGroupXML(&groups[i]))
+	page, ok := paginateRDS(w, r, groups, func(g *rdsdriver.ClusterParameterGroup) string { return g.Name })
+	if !ok {
+		return
+	}
+
+	out := make([]dbClusterParameterGroupXML, 0, len(page.Items))
+	for i := range page.Items {
+		out = append(out, toClusterParameterGroupXML(&page.Items[i]))
 	}
 
 	awsquery.WriteXMLResponse(w, describeDBClusterParameterGroupsResponse{
 		Xmlns:    Namespace,
-		Result:   dbClusterParameterGroupsList{DBClusterParameterGroups: out},
+		Result:   dbClusterParameterGroupsList{Marker: page.NextPageToken, DBClusterParameterGroups: out},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/rds/subnet_group.go
+++ b/server/aws/rds/subnet_group.go
@@ -42,6 +42,7 @@ type describeDBSubnetGroupsResponse struct {
 }
 
 type subnetGroupsList struct {
+	Marker         string             `xml:"Marker,omitempty"`
 	DBSubnetGroups []dbSubnetGroupXML `xml:"DBSubnetGroups>DBSubnetGroup"`
 }
 
@@ -104,14 +105,19 @@ func (h *Handler) describeDBSubnetGroups(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	out := make([]dbSubnetGroupXML, 0, len(groups))
-	for i := range groups {
-		out = append(out, toSubnetGroupXML(&groups[i]))
+	page, ok := paginateRDS(w, r, groups, func(g *rdsdriver.SubnetGroup) string { return g.Name })
+	if !ok {
+		return
+	}
+
+	out := make([]dbSubnetGroupXML, 0, len(page.Items))
+	for i := range page.Items {
+		out = append(out, toSubnetGroupXML(&page.Items[i]))
 	}
 
 	awsquery.WriteXMLResponse(w, describeDBSubnetGroupsResponse{
 		Xmlns:    Namespace,
-		Result:   subnetGroupsList{DBSubnetGroups: out},
+		Result:   subnetGroupsList{Marker: page.NextPageToken, DBSubnetGroups: out},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/rds/xml.go
+++ b/server/aws/rds/xml.go
@@ -295,6 +295,7 @@ type dbClusterResult struct {
 }
 
 type dbClustersResult struct {
+	Marker     string        `xml:"Marker,omitempty"`
 	DBClusters dbClustersXML `xml:"DBClusters"`
 }
 
@@ -328,6 +329,7 @@ type dbSnapshotResult struct {
 }
 
 type dbSnapshotsResult struct {
+	Marker      string         `xml:"Marker,omitempty"`
 	DBSnapshots dbSnapshotsXML `xml:"DBSnapshots"`
 }
 


### PR DESCRIPTION
## Summary

Adds Marker/MaxRecords pagination to the AWS RDS Describe list APIs that were returning the full result set in one unpaged response, matching the behavior DescribeDBInstances already had.

Ops fixed:
- DescribeDBClusters
- DescribeDBSnapshots
- DescribeDBSubnetGroups
- DescribeDBParameterGroups
- DescribeDBClusterParameterGroups

## What changed

- Extracted a shared generic `paginateRDS` helper: stable-sorts the result by its identifier, slices one `Marker`/`MaxRecords` page (default 100, mirroring DescribeDBInstances), and on an invalid `Marker` writes `InvalidParameterValue` and stops. This collapses what would otherwise be five copies of the same block.
- Routed the five list handlers — and DescribeDBInstances itself — through the helper, so there is one pagination code path.
- Added the `Marker` output element to `dbClustersResult`, `dbSnapshotsResult`, `subnetGroupsList`, `dbParameterGroupsList`, and `dbClusterParameterGroupsList` (emitted only when the page is truncated).
- Existing filter args are preserved: instance filters, and DescribeDBSnapshots' DBInstanceIdentifier scoping, are applied before paging.

## Tests

Real `aws-sdk-go-v2/rds` round-trip tests against a booted server, one per op: create 25 items, walk with `MaxRecords=20` and assert the paginator visits every item exactly once across two pages and terminates; a default (single-page) describe returns no `Marker`; and an invalid `Marker` errors.