### PR TITLE
fix(cloudwatch): paginate CloudWatch reads so no history/metrics are lost or unreachable

### DIFF
--- a/server/aws/cloudwatch/metric_data_ops.go
+++ b/server/aws/cloudwatch/metric_data_ops.go
@@ -57,7 +57,13 @@ type getMetricDataInput struct {
 	MetricDataQueries []metricDataQueryCBR `cbor:"MetricDataQueries"`
 	StartTime         *time.Time           `cbor:"StartTime,omitempty"`
 	EndTime           *time.Time           `cbor:"EndTime,omitempty"`
+	MaxDatapoints     int                  `cbor:"MaxDatapoints,omitempty"`
+	NextToken         string               `cbor:"NextToken,omitempty"`
 }
+
+// defaultMaxDatapoints is the AWS GetMetricData datapoint budget per page when a
+// caller omits MaxDatapoints; results past it spill onto a NextToken page.
+const defaultMaxDatapoints = 100800
 
 type metricDataResultCBR struct {
 	ID         string      `cbor:"Id"`
@@ -69,6 +75,7 @@ type metricDataResultCBR struct {
 
 type getMetricDataOutput struct {
 	MetricDataResults []metricDataResultCBR `cbor:"MetricDataResults"`
+	NextToken         string                `cbor:"NextToken,omitempty"`
 }
 
 // getMetricData implements the modern GetMetricData read API used by SDK v2,
@@ -106,7 +113,47 @@ func (h *Handler) getMetricData(w http.ResponseWriter, r *http.Request, body []b
 		out = append(out, buildMetricDataResult(q, series))
 	}
 
-	writeCBORResponse(w, getMetricDataOutput{MetricDataResults: out})
+	rows, next := pageMetricData(out, &in)
+
+	resp := getMetricDataOutput{MetricDataResults: rows}
+	if next != "" {
+		resp.NextToken = next
+	}
+
+	writeCBORResponse(w, resp)
+}
+
+// pageMetricData returns the leading result rows that fit the MaxDatapoints
+// budget from the NextToken offset, plus the token for the next page (empty on
+// the last row). At least one row is returned so a row larger than the budget
+// still makes progress instead of stalling the paginator.
+func pageMetricData(rows []metricDataResultCBR, in *getMetricDataInput) (page []metricDataResultCBR, next string) {
+	budget := in.MaxDatapoints
+	if budget <= 0 {
+		budget = defaultMaxDatapoints
+	}
+
+	start := decodeOffsetToken(in.NextToken)
+	if start > len(rows) {
+		start = len(rows)
+	}
+
+	used, end := 0, start
+	for end < len(rows) {
+		n := len(rows[end].Values)
+		if end > start && used+n > budget {
+			break
+		}
+
+		used += n
+		end++
+	}
+
+	if end < len(rows) {
+		return rows[start:end], encodeOffsetToken(end)
+	}
+
+	return rows[start:end], ""
 }
 
 func buildMetricDataResult(q metricDataQueryCBR, series mathSeries) metricDataResultCBR {
@@ -210,7 +257,12 @@ type describeAlarmHistoryInput struct {
 	EndDate         *time.Time `cbor:"EndDate,omitempty"`
 	ScanBy          string     `cbor:"ScanBy,omitempty"`
 	MaxRecords      int        `cbor:"MaxRecords,omitempty"`
+	NextToken       string     `cbor:"NextToken,omitempty"`
 }
+
+// alarmHistoryPageSize is the AWS cap on DescribeAlarmHistory MaxRecords, used as
+// the page size when a caller pages but omits MaxRecords.
+const alarmHistoryPageSize = 100
 
 // scanByAscending requests oldest-first ordering; the default (and any other
 // value) is TimestampDescending, newest-first.
@@ -229,6 +281,7 @@ type alarmHistoryItemCBR struct {
 
 type describeAlarmHistoryOutput struct {
 	AlarmHistoryItems []alarmHistoryItemCBR `cbor:"AlarmHistoryItems"`
+	NextToken         string                `cbor:"NextToken,omitempty"`
 }
 
 // describeAlarmHistory surfaces the transition history recorded internally on
@@ -248,13 +301,20 @@ func (h *Handler) describeAlarmHistory(w http.ResponseWriter, r *http.Request, b
 		return
 	}
 
-	writeCBORResponse(w, describeAlarmHistoryOutput{AlarmHistoryItems: filterAlarmHistory(entries, &in)})
+	items, next := pageAlarmHistory(filterAlarmHistory(entries, &in), &in)
+
+	resp := describeAlarmHistoryOutput{AlarmHistoryItems: items}
+	if next != "" {
+		resp.NextToken = next
+	}
+
+	writeCBORResponse(w, resp)
 }
 
 // filterAlarmHistory applies the DescribeAlarmHistory request filters to the
-// newest-first entries: HistoryItemType, the StartDate/EndDate window, ScanBy
-// ordering, then the MaxRecords cap (kept last so it truncates the far end of the
-// chosen order).
+// newest-first entries — HistoryItemType, the StartDate/EndDate window, then
+// ScanBy ordering — returning every match in wire order. Paging is applied
+// separately by pageAlarmHistory so entries past the first page stay reachable.
 func filterAlarmHistory(entries []mondriver.AlarmHistoryEntry, in *describeAlarmHistoryInput) []alarmHistoryItemCBR {
 	start := timeOrZero(in.StartDate)
 	end := timeOrZero(in.EndDate)
@@ -271,11 +331,24 @@ func filterAlarmHistory(entries []mondriver.AlarmHistoryEntry, in *describeAlarm
 		reverseHistory(kept)
 	}
 
-	if in.MaxRecords > 0 && len(kept) > in.MaxRecords {
-		kept = kept[:in.MaxRecords]
+	return historyItemsToCBR(kept)
+}
+
+// pageAlarmHistory returns the requested page of history items and the NextToken
+// for the following page (empty on the last page). Paging by offset keeps every
+// entry retrievable instead of dropping the tail past MaxRecords.
+func pageAlarmHistory(items []alarmHistoryItemCBR, in *describeAlarmHistoryInput) (page []alarmHistoryItemCBR, next string) {
+	size := in.MaxRecords
+	if size <= 0 {
+		size = alarmHistoryPageSize
 	}
 
-	return historyItemsToCBR(kept)
+	from, to, nextOff := pageWindow(len(items), decodeOffsetToken(in.NextToken), size)
+	if nextOff > 0 {
+		return items[from:to], encodeOffsetToken(nextOff)
+	}
+
+	return items[from:to], ""
 }
 
 // historyEntryMatches reports whether an entry passes the HistoryItemType and

--- a/server/aws/cloudwatch/ops.go
+++ b/server/aws/cloudwatch/ops.go
@@ -653,14 +653,9 @@ func (h *Handler) describeAlarms(w http.ResponseWriter, r *http.Request, body []
 		matched = append(matched, toMetricAlarmCBR(&alarms[i]))
 	}
 
-	// Without paging inputs, preserve the historical "return everything" shape so
-	// existing callers are unaffected. Deterministic ordering only matters once a
-	// caller pages, so sort just in that branch.
-	if in.MaxRecords == 0 && in.NextToken == "" {
-		writeCBORResponse(w, describeAlarmsOutput{MetricAlarms: matched})
-		return
-	}
-
+	// Always paginate: real CloudWatch caps a page at 100 alarms and returns a
+	// NextToken for the rest, so an unpaged "return everything" reply would drop
+	// alarms past 100 for callers that don't pass paging inputs.
 	sort.SliceStable(matched, func(i, j int) bool {
 		return matched[i].AlarmName < matched[j].AlarmName
 	})

--- a/server/aws/cloudwatch/pagination_test.go
+++ b/server/aws/cloudwatch/pagination_test.go
@@ -1,0 +1,399 @@
+package cloudwatch_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awscw "github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+
+	cwprovider "github.com/stackshy/cloudemu/v2/providers/aws/cloudwatch"
+	cwserver "github.com/stackshy/cloudemu/v2/server/aws/cloudwatch"
+)
+
+// TestSDKDescribeAlarmHistoryPaginatorRetrievesAll is the data-loss regression:
+// with a history larger than one page, the paginator must retrieve every entry
+// across pages. Before the fix the handler truncated to MaxRecords and emitted no
+// NextToken, so page-2+ entries were silently unreachable.
+func TestSDKDescribeAlarmHistoryPaginatorRetrievesAll(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	const alarmName = "hist-alarm"
+	if _, err := client.PutMetricAlarm(ctx, &awscw.PutMetricAlarmInput{
+		AlarmName:          aws.String(alarmName),
+		Namespace:          aws.String("MyApp"),
+		MetricName:         aws.String("Latency"),
+		ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+		EvaluationPeriods:  aws.Int32(1),
+		Period:             aws.Int32(60),
+		Threshold:          aws.Float64(10),
+		Statistic:          cwtypes.StatisticAverage,
+	}); err != nil {
+		t.Fatalf("PutMetricAlarm: %v", err)
+	}
+
+	// Alternate the alarm state so each SetAlarmState records one history entry.
+	states := []cwtypes.StateValue{
+		cwtypes.StateValueAlarm, cwtypes.StateValueOk, cwtypes.StateValueAlarm,
+		cwtypes.StateValueOk, cwtypes.StateValueAlarm,
+	}
+	for i, s := range states {
+		if _, err := client.SetAlarmState(ctx, &awscw.SetAlarmStateInput{
+			AlarmName:   aws.String(alarmName),
+			StateValue:  s,
+			StateReason: aws.String(fmt.Sprintf("transition %d", i)),
+		}); err != nil {
+			t.Fatalf("SetAlarmState[%d]: %v", i, err)
+		}
+	}
+
+	// Ground truth: a single unpaged read (history < the default page cap) returns
+	// every recorded entry, so its count is the total we must retrieve by paging.
+	full, err := client.DescribeAlarmHistory(ctx, &awscw.DescribeAlarmHistoryInput{
+		AlarmName: aws.String(alarmName),
+	})
+	if err != nil {
+		t.Fatalf("DescribeAlarmHistory: %v", err)
+	}
+
+	total := len(full.AlarmHistoryItems)
+	if total != len(states) {
+		t.Fatalf("recorded history = %d, want %d", total, len(states))
+	}
+
+	// Page two at a time and collect every entry the paginator yields.
+	seen := map[string]int{}
+	pages := 0
+	p := awscw.NewDescribeAlarmHistoryPaginator(client, &awscw.DescribeAlarmHistoryInput{
+		AlarmName:  aws.String(alarmName),
+		MaxRecords: aws.Int32(2),
+	})
+
+	for p.HasMorePages() {
+		out, perr := p.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("NextPage: %v", perr)
+		}
+
+		pages++
+		for _, it := range out.AlarmHistoryItems {
+			seen[aws.ToTime(it.Timestamp).Format(time.RFC3339Nano)+"|"+aws.ToString(it.HistorySummary)]++
+		}
+	}
+
+	if pages < 2 {
+		t.Fatalf("pages = %d, want > 1 (history should span multiple pages)", pages)
+	}
+
+	if len(seen) != total {
+		t.Fatalf("distinct entries retrieved = %d, want %d (data lost across pages)", len(seen), total)
+	}
+
+	for k, n := range seen {
+		if n != 1 {
+			t.Fatalf("entry %q retrieved %d times, want exactly once", k, n)
+		}
+	}
+}
+
+// TestSDKGetMetricDataPaginatorWalksAllResults verifies GetMetricData paginates:
+// with MaxDatapoints forcing one result row per page, the paginator must walk
+// every query result once and terminate.
+func TestSDKGetMetricDataPaginatorWalksAllResults(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	base := time.Now().UTC().Truncate(time.Minute)
+	names := []string{"M1", "M2", "M3"}
+	for _, name := range names {
+		if _, err := client.PutMetricData(ctx, &awscw.PutMetricDataInput{
+			Namespace: aws.String("MyApp"),
+			MetricData: []cwtypes.MetricDatum{{
+				MetricName: aws.String(name),
+				Value:      aws.Float64(1),
+				Timestamp:  aws.Time(base),
+			}},
+		}); err != nil {
+			t.Fatalf("PutMetricData(%s): %v", name, err)
+		}
+	}
+
+	queries := make([]cwtypes.MetricDataQuery, 0, len(names))
+	for i, name := range names {
+		queries = append(queries, cwtypes.MetricDataQuery{
+			Id: aws.String(fmt.Sprintf("q%d", i)),
+			MetricStat: &cwtypes.MetricStat{
+				Metric: &cwtypes.Metric{Namespace: aws.String("MyApp"), MetricName: aws.String(name)},
+				Period: aws.Int32(60),
+				Stat:   aws.String("Sum"),
+			},
+		})
+	}
+
+	p := awscw.NewGetMetricDataPaginator(client, &awscw.GetMetricDataInput{
+		StartTime:         aws.Time(base.Add(-time.Minute)),
+		EndTime:           aws.Time(base.Add(time.Minute)),
+		MetricDataQueries: queries,
+		MaxDatapoints:     aws.Int32(1),
+	})
+
+	seen := map[string]int{}
+	pages := 0
+
+	for p.HasMorePages() {
+		out, err := p.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		pages++
+		for _, res := range out.MetricDataResults {
+			seen[aws.ToString(res.Id)]++
+		}
+	}
+
+	if pages < 2 {
+		t.Fatalf("pages = %d, want > 1", pages)
+	}
+
+	if len(seen) != len(names) {
+		t.Fatalf("distinct results = %d, want %d", len(seen), len(names))
+	}
+
+	for id, n := range seen {
+		if n != 1 {
+			t.Fatalf("result %q seen %d times, want once", id, n)
+		}
+	}
+}
+
+// TestSDKDescribeAlarmsCborPaginates covers the removed early-return: an unpaged
+// DescribeAlarms once returned everything without a NextToken. It must now cap a
+// page (100) and hand back a token so the paginator walks all alarms.
+func TestSDKDescribeAlarmsCborPaginates(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	const total = 101
+	for i := 0; i < total; i++ {
+		if _, err := client.PutMetricAlarm(ctx, &awscw.PutMetricAlarmInput{
+			AlarmName:          aws.String(fmt.Sprintf("alarm-%03d", i)),
+			Namespace:          aws.String("MyApp"),
+			MetricName:         aws.String("Latency"),
+			ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+			EvaluationPeriods:  aws.Int32(1),
+			Period:             aws.Int32(60),
+			Threshold:          aws.Float64(10),
+			Statistic:          cwtypes.StatisticAverage,
+		}); err != nil {
+			t.Fatalf("PutMetricAlarm[%d]: %v", i, err)
+		}
+	}
+
+	// No paging inputs: the default path must still paginate, not dump everything.
+	seen := map[string]int{}
+	pages := 0
+	p := awscw.NewDescribeAlarmsPaginator(client, &awscw.DescribeAlarmsInput{})
+
+	for p.HasMorePages() {
+		out, err := p.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		pages++
+		for _, a := range out.MetricAlarms {
+			seen[aws.ToString(a.AlarmName)]++
+		}
+	}
+
+	if pages < 2 {
+		t.Fatalf("pages = %d, want > 1 (default page must cap at 100)", pages)
+	}
+
+	if len(seen) != total {
+		t.Fatalf("distinct alarms = %d, want %d", len(seen), total)
+	}
+}
+
+// newSeededQueryServer builds a CloudWatch handler over a directly-seeded
+// provider and returns the provider, server URL, and a query-protocol POST
+// helper (form-encoded, monitoring-scoped, XML back).
+func newSeededQueryServer(t *testing.T) (*cwprovider.Mock, func(url.Values) (int, string)) {
+	t.Helper()
+
+	prov := cwprovider.New(config.NewOptions())
+	ts := httptest.NewServer(cwserver.New(prov))
+	t.Cleanup(ts.Close)
+
+	post := func(form url.Values) (int, string) {
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Authorization", monitoringAuth)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		defer resp.Body.Close()
+
+		b, _ := io.ReadAll(resp.Body)
+
+		return resp.StatusCode, string(b)
+	}
+
+	return prov, post
+}
+
+// xmlToken extracts a <NextToken> value from a query-protocol XML body, or "".
+func xmlToken(body string) string {
+	const openTag, closeTag = "<NextToken>", "</NextToken>"
+
+	i := strings.Index(body, openTag)
+	if i < 0 {
+		return ""
+	}
+
+	j := strings.Index(body[i:], closeTag)
+	if j < 0 {
+		return ""
+	}
+
+	return body[i+len(openTag) : i+j]
+}
+
+// TestQueryListMetricsPaginates walks the legacy XML ListMetrics path across more
+// than one 500-metric page and asserts every metric is returned exactly once.
+func TestQueryListMetricsPaginates(t *testing.T) {
+	prov, post := newSeededQueryServer(t)
+
+	const total = 501
+	data := make([]mondriver.MetricDatum, 0, total)
+	for i := 0; i < total; i++ {
+		data = append(data, mondriver.MetricDatum{
+			Namespace: "MyApp", MetricName: fmt.Sprintf("M%04d", i), Value: 1, Timestamp: time.Now().UTC(),
+		})
+	}
+
+	if err := prov.PutMetricData(context.Background(), data); err != nil {
+		t.Fatalf("seed PutMetricData: %v", err)
+	}
+
+	seen := map[string]int{}
+	token := ""
+	pages := 0
+
+	for {
+		form := url.Values{"Action": {"ListMetrics"}, "Namespace": {"MyApp"}}
+		if token != "" {
+			form.Set("NextToken", token)
+		}
+
+		code, body := post(form)
+		if code != http.StatusOK {
+			t.Fatalf("ListMetrics: code=%d body=%s", code, body)
+		}
+
+		pages++
+		for _, name := range extractTagValues(body, "MetricName") {
+			seen[name]++
+		}
+
+		token = xmlToken(body)
+		if token == "" {
+			break
+		}
+	}
+
+	if pages < 2 {
+		t.Fatalf("pages = %d, want > 1", pages)
+	}
+
+	if len(seen) != total {
+		t.Fatalf("distinct metrics = %d, want %d", len(seen), total)
+	}
+}
+
+// TestQueryDescribeAlarmsPaginates walks the legacy XML DescribeAlarms path with
+// MaxRecords forcing small pages and asserts every alarm is returned once.
+func TestQueryDescribeAlarmsPaginates(t *testing.T) {
+	prov, post := newSeededQueryServer(t)
+
+	const total = 3
+	for i := 0; i < total; i++ {
+		if err := prov.CreateAlarm(context.Background(), mondriver.AlarmConfig{
+			Name: fmt.Sprintf("alarm-%d", i), Namespace: "MyApp", MetricName: "Latency",
+			ComparisonOperator: "GreaterThanThreshold", Threshold: 10, Period: 60, EvaluationPeriods: 1,
+		}); err != nil {
+			t.Fatalf("seed CreateAlarm[%d]: %v", i, err)
+		}
+	}
+
+	seen := map[string]int{}
+	token := ""
+	pages := 0
+
+	for {
+		form := url.Values{"Action": {"DescribeAlarms"}, "MaxRecords": {"2"}}
+		if token != "" {
+			form.Set("NextToken", token)
+		}
+
+		code, body := post(form)
+		if code != http.StatusOK {
+			t.Fatalf("DescribeAlarms: code=%d body=%s", code, body)
+		}
+
+		pages++
+		for _, name := range extractTagValues(body, "AlarmName") {
+			seen[name]++
+		}
+
+		token = xmlToken(body)
+		if token == "" {
+			break
+		}
+	}
+
+	if pages < 2 {
+		t.Fatalf("pages = %d, want > 1", pages)
+	}
+
+	if len(seen) != total {
+		t.Fatalf("distinct alarms = %d, want %d", len(seen), total)
+	}
+}
+
+// extractTagValues returns every value enclosed in <tag>...</tag> in body.
+func extractTagValues(body, tag string) []string {
+	openTag, closeTag := "<"+tag+">", "</"+tag+">"
+
+	var out []string
+
+	rest := body
+	for {
+		i := strings.Index(rest, openTag)
+		if i < 0 {
+			return out
+		}
+
+		rest = rest[i+len(openTag):]
+
+		j := strings.Index(rest, closeTag)
+		if j < 0 {
+			return out
+		}
+
+		out = append(out, rest[:j])
+		rest = rest[j+len(closeTag):]
+	}
+}

--- a/server/aws/cloudwatch/query.go
+++ b/server/aws/cloudwatch/query.go
@@ -115,14 +115,22 @@ func (h *Handler) queryListMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ns := r.Form.Get("Namespace")
-	members := make([]metricMemberXML, 0, len(names))
+	sort.Strings(names)
 
-	for _, n := range names {
+	ns := r.Form.Get("Namespace")
+	from, to, next := pageWindow(len(names), decodeOffsetToken(r.Form.Get("NextToken")), listMetricsPageSize)
+
+	members := make([]metricMemberXML, 0, to-from)
+	for _, n := range names[from:to] {
 		members = append(members, metricMemberXML{Namespace: ns, MetricName: n})
 	}
 
-	writeQueryResponse(w, "ListMetricsResponse", listMetricsResultXML{Metrics: members})
+	result := listMetricsResultXML{Metrics: members}
+	if next > 0 {
+		result.NextToken = encodeOffsetToken(next)
+	}
+
+	writeQueryResponse(w, "ListMetricsResponse", result)
 }
 
 func (h *Handler) queryGetMetricStatistics(w http.ResponseWriter, r *http.Request) {
@@ -246,15 +254,29 @@ func (h *Handler) queryDescribeAlarms(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	members := make([]alarmMemberXML, 0, len(alarms))
-	for i := range alarms {
+	sort.SliceStable(alarms, func(i, j int) bool { return alarms[i].Name < alarms[j].Name })
+
+	size := maxAlarmPageSize
+	if v, _ := strconv.Atoi(r.Form.Get("MaxRecords")); v > 0 {
+		size = v
+	}
+
+	from, to, next := pageWindow(len(alarms), decodeOffsetToken(r.Form.Get("NextToken")), size)
+
+	members := make([]alarmMemberXML, 0, to-from)
+	for i := from; i < to; i++ {
 		members = append(members, alarmMemberXML{
 			AlarmName: alarms[i].Name, Namespace: alarms[i].Namespace, MetricName: alarms[i].MetricName,
 			StateValue: alarms[i].State, ComparisonOperator: alarms[i].ComparisonOperator, Threshold: alarms[i].Threshold,
 		})
 	}
 
-	writeQueryResponse(w, "DescribeAlarmsResponse", describeAlarmsResultXML{MetricAlarms: members})
+	result := describeAlarmsResultXML{MetricAlarms: members}
+	if next > 0 {
+		result.NextToken = encodeOffsetToken(next)
+	}
+
+	writeQueryResponse(w, "DescribeAlarmsResponse", result)
 }
 
 func (h *Handler) queryDeleteAlarms(w http.ResponseWriter, r *http.Request) {
@@ -373,8 +395,9 @@ type metricMemberXML struct {
 }
 
 type listMetricsResultXML struct {
-	XMLName xml.Name          `xml:"ListMetricsResult"`
-	Metrics []metricMemberXML `xml:"Metrics>member"`
+	XMLName   xml.Name          `xml:"ListMetricsResult"`
+	Metrics   []metricMemberXML `xml:"Metrics>member"`
+	NextToken string            `xml:"NextToken,omitempty"`
 }
 
 type datapointXML struct {
@@ -405,6 +428,7 @@ type alarmMemberXML struct {
 type describeAlarmsResultXML struct {
 	XMLName      xml.Name         `xml:"DescribeAlarmsResult"`
 	MetricAlarms []alarmMemberXML `xml:"MetricAlarms>member"`
+	NextToken    string           `xml:"NextToken,omitempty"`
 }
 
 // writeQueryResponse writes an AWS query-protocol XML envelope. result may be


### PR DESCRIPTION
## Summary

Fixes five CloudWatch pagination bugs across both wire paths (rpc-v2-cbor and the legacy query/XML path). CloudWatch reads either lost data or returned unbounded, tokenless responses that don't match real AWS.

### Bugs fixed

1. **DescribeAlarmHistory (data loss)** — the cbor handler truncated history to `MaxRecords` but the response carried **no `NextToken`**, so every entry past the first page was silently unreachable. Added `NextToken` to the request and response and switched to offset-based paging (default cap 100), so an SDK paginator retrieves **all** entries.
2. **GetMetricData** — had no paging fields. Added `MaxDatapoints` + `NextToken` to the request and `NextToken` to the response, paging over result rows within the datapoint budget.
3. **DescribeAlarms (cbor)** — the `MaxRecords==0 && NextToken==""` early-return bypassed pagination and returned every alarm tokenless. It now always sorts and paginates (cap 100 + token), matching AWS.
4. **ListMetrics (legacy XML)** — no pagination; now sorts and pages (500/page) with `NextToken`, mirroring the already-correct cbor path.
5. **DescribeAlarms (legacy XML)** — no pagination; now honors `MaxRecords`/`NextToken` with a stable sort.

All paths use the repo's existing offset-token helpers (`pageWindow`/`encode`/`decodeOffsetToken`) and stable sorting before slicing.

### Tests (real aws-sdk-go-v2/cloudwatch)

- **DescribeAlarmHistory**: builds a multi-page history and asserts the SDK paginator retrieves every entry exactly once across pages — proving the loss is fixed.
- **GetMetricData / DescribeAlarms (cbor)**: paginators walk more than one page, each result once, and terminate.
- **ListMetrics / DescribeAlarms (XML)**: legacy query path walked across pages via `NextToken` to completion; single page yields no token.
