### PR TITLE
feat(aws): paginate Redshift and ELBv2 Describe APIs (Marker/MaxRecords, Marker/PageSize)

### DIFF
--- a/server/aws/elbv2/describe_pagination_sdk_roundtrip_test.go
+++ b/server/aws/elbv2/describe_pagination_sdk_roundtrip_test.go
@@ -1,0 +1,294 @@
+package elbv2_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
+// listenerTestLB creates a load balancer and returns its ARN for pagination
+// fixtures.
+func listenerTestLB(ctx context.Context, t *testing.T, client *elb.Client, name string) string {
+	t.Helper()
+
+	out, err := client.CreateLoadBalancer(ctx, &elb.CreateLoadBalancerInput{
+		Name:    aws.String(name),
+		Subnets: []string{"subnet-a"},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer(%s): %v", name, err)
+	}
+
+	return aws.ToString(out.LoadBalancers[0].LoadBalancerArn)
+}
+
+// TestSDKDescribeListenersPagination proves DescribeListeners honors Marker and
+// PageSize: a PageSize of 1 returns one listener plus a NextMarker, and walking
+// the marker yields every listener exactly once before terminating.
+func TestSDKDescribeListenersPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN := listenerTestLB(ctx, t, client, "listeners-page-alb")
+
+	ports := []int32{80, 81, 82}
+	for _, p := range ports {
+		if _, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+			LoadBalancerArn: aws.String(lbARN),
+			Protocol:        elbtypes.ProtocolEnumHttp,
+			Port:            aws.Int32(p),
+			DefaultActions: []elbtypes.Action{{
+				Type:                elbtypes.ActionTypeEnumFixedResponse,
+				FixedResponseConfig: &elbtypes.FixedResponseActionConfig{StatusCode: aws.String("200")},
+			}},
+		}); err != nil {
+			t.Fatalf("CreateListener(port %d): %v", p, err)
+		}
+	}
+
+	seen := map[string]bool{}
+	marker := ""
+	pages := 0
+
+	for {
+		out, err := client.DescribeListeners(ctx, &elb.DescribeListenersInput{
+			LoadBalancerArn: aws.String(lbARN),
+			PageSize:        aws.Int32(1),
+			Marker:          markerPtr(marker),
+		})
+		if err != nil {
+			t.Fatalf("DescribeListeners page %d: %v", pages, err)
+		}
+
+		if len(out.Listeners) != 1 {
+			t.Fatalf("page %d returned %d listeners, want 1 (PageSize ignored?)", pages, len(out.Listeners))
+		}
+
+		seen[aws.ToString(out.Listeners[0].ListenerArn)] = true
+		pages++
+
+		if out.NextMarker == nil || aws.ToString(out.NextMarker) == "" {
+			break
+		}
+
+		marker = aws.ToString(out.NextMarker)
+
+		if pages > len(ports) {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+
+	if pages != len(ports) {
+		t.Errorf("walked %d pages, want %d", pages, len(ports))
+	}
+
+	if len(seen) != len(ports) {
+		t.Errorf("saw %d distinct listeners, want %d", len(seen), len(ports))
+	}
+}
+
+// TestSDKDescribeListenersSinglePageNoMarker proves a page large enough to hold
+// every listener returns no NextMarker.
+func TestSDKDescribeListenersSinglePageNoMarker(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN := listenerTestLB(ctx, t, client, "listeners-single-alb")
+
+	for _, p := range []int32{80, 81} {
+		if _, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+			LoadBalancerArn: aws.String(lbARN),
+			Protocol:        elbtypes.ProtocolEnumHttp,
+			Port:            aws.Int32(p),
+			DefaultActions: []elbtypes.Action{{
+				Type:                elbtypes.ActionTypeEnumFixedResponse,
+				FixedResponseConfig: &elbtypes.FixedResponseActionConfig{StatusCode: aws.String("200")},
+			}},
+		}); err != nil {
+			t.Fatalf("CreateListener(port %d): %v", p, err)
+		}
+	}
+
+	out, err := client.DescribeListeners(ctx, &elb.DescribeListenersInput{
+		LoadBalancerArn: aws.String(lbARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeListeners: %v", err)
+	}
+
+	if len(out.Listeners) != 2 {
+		t.Fatalf("got %d listeners, want 2", len(out.Listeners))
+	}
+
+	if out.NextMarker != nil && aws.ToString(out.NextMarker) != "" {
+		t.Errorf("single-page result carried NextMarker %q, want none", aws.ToString(out.NextMarker))
+	}
+}
+
+// TestSDKDescribeListenersInvalidMarker proves an unreadable Marker is rejected.
+func TestSDKDescribeListenersInvalidMarker(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN := listenerTestLB(ctx, t, client, "listeners-badmarker-alb")
+
+	_, err := client.DescribeListeners(ctx, &elb.DescribeListenersInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Marker:          aws.String("!!!not-base64!!!"),
+	})
+	if err == nil {
+		t.Fatal("DescribeListeners with an invalid Marker succeeded, want an error")
+	}
+}
+
+// TestSDKDescribeRulesPagination proves DescribeRules honors Marker and PageSize:
+// a PageSize of 1 returns one rule plus a NextMarker, and walking the marker
+// yields every rule exactly once before terminating.
+func TestSDKDescribeRulesPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	liARN := rulesTestListener(ctx, t, client, "rules-page-alb")
+
+	priorities := []int32{1, 2, 3}
+	for _, prio := range priorities {
+		if _, err := client.CreateRule(ctx, &elb.CreateRuleInput{
+			ListenerArn: aws.String(liARN),
+			Priority:    aws.Int32(prio),
+			Conditions: []elbtypes.RuleCondition{{
+				Field:  aws.String("path-pattern"),
+				Values: []string{"/p" + strings.Repeat("x", int(prio))},
+			}},
+			Actions: []elbtypes.Action{{
+				Type:                elbtypes.ActionTypeEnumFixedResponse,
+				FixedResponseConfig: &elbtypes.FixedResponseActionConfig{StatusCode: aws.String("200")},
+			}},
+		}); err != nil {
+			t.Fatalf("CreateRule(priority %d): %v", prio, err)
+		}
+	}
+
+	seen := map[string]bool{}
+	marker := ""
+	pages := 0
+
+	for {
+		out, err := client.DescribeRules(ctx, &elb.DescribeRulesInput{
+			ListenerArn: aws.String(liARN),
+			PageSize:    aws.Int32(1),
+			Marker:      markerPtr(marker),
+		})
+		if err != nil {
+			t.Fatalf("DescribeRules page %d: %v", pages, err)
+		}
+
+		if len(out.Rules) != 1 {
+			t.Fatalf("page %d returned %d rules, want 1 (PageSize ignored?)", pages, len(out.Rules))
+		}
+
+		seen[aws.ToString(out.Rules[0].RuleArn)] = true
+		pages++
+
+		if out.NextMarker == nil || aws.ToString(out.NextMarker) == "" {
+			break
+		}
+
+		marker = aws.ToString(out.NextMarker)
+
+		if pages > len(priorities) {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+
+	if pages != len(priorities) {
+		t.Errorf("walked %d pages, want %d", pages, len(priorities))
+	}
+
+	if len(seen) != len(priorities) {
+		t.Errorf("saw %d distinct rules, want %d", len(seen), len(priorities))
+	}
+}
+
+// TestSDKDescribeRulesSinglePageNoMarker proves a page large enough to hold
+// every rule returns no NextMarker.
+func TestSDKDescribeRulesSinglePageNoMarker(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	liARN := rulesTestListener(ctx, t, client, "rules-single-alb")
+
+	for _, prio := range []int32{1, 2} {
+		if _, err := client.CreateRule(ctx, &elb.CreateRuleInput{
+			ListenerArn: aws.String(liARN),
+			Priority:    aws.Int32(prio),
+			Conditions: []elbtypes.RuleCondition{{
+				Field:  aws.String("path-pattern"),
+				Values: []string{"/p" + strings.Repeat("x", int(prio))},
+			}},
+			Actions: []elbtypes.Action{{
+				Type:                elbtypes.ActionTypeEnumFixedResponse,
+				FixedResponseConfig: &elbtypes.FixedResponseActionConfig{StatusCode: aws.String("200")},
+			}},
+		}); err != nil {
+			t.Fatalf("CreateRule(priority %d): %v", prio, err)
+		}
+	}
+
+	out, err := client.DescribeRules(ctx, &elb.DescribeRulesInput{
+		ListenerArn: aws.String(liARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeRules: %v", err)
+	}
+
+	if len(out.Rules) != 2 {
+		t.Fatalf("got %d rules, want 2", len(out.Rules))
+	}
+
+	if out.NextMarker != nil && aws.ToString(out.NextMarker) != "" {
+		t.Errorf("single-page result carried NextMarker %q, want none", aws.ToString(out.NextMarker))
+	}
+}
+
+// TestSDKDescribeRulesInvalidMarker proves an unreadable Marker is rejected.
+func TestSDKDescribeRulesInvalidMarker(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	liARN := rulesTestListener(ctx, t, client, "rules-badmarker-alb")
+
+	_, err := client.DescribeRules(ctx, &elb.DescribeRulesInput{
+		ListenerArn: aws.String(liARN),
+		Marker:      aws.String("!!!not-base64!!!"),
+	})
+	if err == nil {
+		t.Fatal("DescribeRules with an invalid Marker succeeded, want an error")
+	}
+}
+
+// rulesTestListener creates a load balancer and an HTTP listener, returning the
+// listener ARN to attach rules to.
+func rulesTestListener(ctx context.Context, t *testing.T, client *elb.Client, lbName string) string {
+	t.Helper()
+
+	lbARN := listenerTestLB(ctx, t, client, lbName)
+
+	out, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type:                elbtypes.ActionTypeEnumFixedResponse,
+			FixedResponseConfig: &elbtypes.FixedResponseActionConfig{StatusCode: aws.String("200")},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	return aws.ToString(out.Listeners[0].ListenerArn)
+}

--- a/server/aws/elbv2/operations.go
+++ b/server/aws/elbv2/operations.go
@@ -286,6 +286,17 @@ func (h *Handler) describeListeners(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Sort for a stable order so the offset-based Marker is meaningful.
+	sort.Slice(lis, func(i, j int) bool { return lis[i].ARN < lis[j].ARN })
+
+	start, end, next, err := pageWindow(r.Form.Get("Marker"), formInt(r.Form.Get("PageSize")), len(lis))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	lis = lis[start:end]
+
 	out := listenersXML{Member: make([]listenerXML, 0, len(lis))}
 	for i := range lis {
 		out.Member = append(out.Member, toListenerXML(&lis[i]))
@@ -293,7 +304,7 @@ func (h *Handler) describeListeners(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, describeListenersResponse{
 		Xmlns:    Namespace,
-		Result:   listenersResult{Listeners: out},
+		Result:   listenersResult{Listeners: out, NextMarker: next},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -346,6 +357,17 @@ func (h *Handler) describeRules(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Sort for a stable order so the offset-based Marker is meaningful.
+	sort.Slice(rules, func(i, j int) bool { return rules[i].ARN < rules[j].ARN })
+
+	start, end, next, err := pageWindow(r.Form.Get("Marker"), formInt(r.Form.Get("PageSize")), len(rules))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	rules = rules[start:end]
+
 	out := rulesXML{Member: make([]ruleXML, 0, len(rules))}
 	for i := range rules {
 		out.Member = append(out.Member, toRuleXML(&rules[i]))
@@ -353,7 +375,7 @@ func (h *Handler) describeRules(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, describeRulesResponse{
 		Xmlns:    Namespace,
-		Result:   rulesResult{Rules: out},
+		Result:   rulesResult{Rules: out, NextMarker: next},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/elbv2/types.go
+++ b/server/aws/elbv2/types.go
@@ -199,7 +199,8 @@ type listenersXML struct {
 }
 
 type listenersResult struct {
-	Listeners listenersXML `xml:"Listeners"`
+	Listeners  listenersXML `xml:"Listeners"`
+	NextMarker string       `xml:"NextMarker,omitempty"`
 }
 
 type createListenerResponse struct {
@@ -281,7 +282,8 @@ type rulesXML struct {
 }
 
 type rulesResult struct {
-	Rules rulesXML `xml:"Rules"`
+	Rules      rulesXML `xml:"Rules"`
+	NextMarker string   `xml:"NextMarker,omitempty"`
 }
 
 type createRuleResponse struct {

--- a/server/aws/redshift/describe_pagination_sdk_roundtrip_test.go
+++ b/server/aws/redshift/describe_pagination_sdk_roundtrip_test.go
@@ -1,0 +1,330 @@
+package redshift_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsredshift "github.com/aws/aws-sdk-go-v2/service/redshift"
+)
+
+// pageMaxRecords is the smallest MaxRecords Redshift honors; using it lets a
+// modest fixture span more than one page.
+const pageMaxRecords = 20
+
+// multiPageCount is one more than a full page, so paging yields exactly two
+// pages (a full first page plus a one-item second page).
+const multiPageCount = pageMaxRecords + 1
+
+// TestSDKRedshiftDescribeClustersPagination proves DescribeClusters pages on
+// Marker/MaxRecords: the paginator walks every cluster exactly once across more
+// than one page and terminates.
+func TestSDKRedshiftDescribeClustersPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	want := map[string]bool{}
+	for i := range multiPageCount {
+		id := fmt.Sprintf("cluster-%02d", i)
+		want[id] = true
+
+		if _, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+			ClusterIdentifier:  aws.String(id),
+			MasterUsername:     aws.String("admin"),
+			MasterUserPassword: aws.String("Sup3rSecret!"),
+			NodeType:           aws.String("ra3.xlplus"),
+		}); err != nil {
+			t.Fatalf("CreateCluster(%s): %v", id, err)
+		}
+	}
+
+	pager := awsredshift.NewDescribeClustersPaginator(client, &awsredshift.DescribeClustersInput{
+		MaxRecords: aws.Int32(pageMaxRecords),
+	})
+
+	seen := map[string]int{}
+	pages := 0
+
+	for pager.HasMorePages() {
+		out, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("DescribeClusters page %d: %v", pages, err)
+		}
+
+		pages++
+		for i := range out.Clusters {
+			seen[aws.ToString(out.Clusters[i].ClusterIdentifier)]++
+		}
+
+		if pages > multiPageCount {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+
+	assertPagedExactlyOnce(t, pages, want, seen)
+}
+
+// TestSDKRedshiftDescribeClusterSnapshotsPagination proves DescribeClusterSnapshots
+// pages on Marker/MaxRecords.
+func TestSDKRedshiftDescribeClusterSnapshotsPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:  aws.String("snap-src"),
+		MasterUsername:     aws.String("admin"),
+		MasterUserPassword: aws.String("Sup3rSecret!"),
+		NodeType:           aws.String("ra3.xlplus"),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	want := map[string]bool{}
+	for i := range multiPageCount {
+		id := fmt.Sprintf("snap-%02d", i)
+		want[id] = true
+
+		if _, err := client.CreateClusterSnapshot(ctx, &awsredshift.CreateClusterSnapshotInput{
+			SnapshotIdentifier: aws.String(id),
+			ClusterIdentifier:  aws.String("snap-src"),
+		}); err != nil {
+			t.Fatalf("CreateClusterSnapshot(%s): %v", id, err)
+		}
+	}
+
+	pager := awsredshift.NewDescribeClusterSnapshotsPaginator(client, &awsredshift.DescribeClusterSnapshotsInput{
+		MaxRecords: aws.Int32(pageMaxRecords),
+	})
+
+	seen := map[string]int{}
+	pages := 0
+
+	for pager.HasMorePages() {
+		out, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("DescribeClusterSnapshots page %d: %v", pages, err)
+		}
+
+		pages++
+		for i := range out.Snapshots {
+			seen[aws.ToString(out.Snapshots[i].SnapshotIdentifier)]++
+		}
+
+		if pages > multiPageCount {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+
+	assertPagedExactlyOnce(t, pages, want, seen)
+}
+
+// TestSDKRedshiftDescribeClusterParameterGroupsPagination proves
+// DescribeClusterParameterGroups pages on Marker/MaxRecords.
+func TestSDKRedshiftDescribeClusterParameterGroupsPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	want := map[string]bool{}
+	for i := range multiPageCount {
+		name := fmt.Sprintf("pg-%02d", i)
+		want[name] = true
+
+		if _, err := client.CreateClusterParameterGroup(ctx, &awsredshift.CreateClusterParameterGroupInput{
+			ParameterGroupName:   aws.String(name),
+			ParameterGroupFamily: aws.String("redshift-1.0"),
+			Description:          aws.String("pg"),
+		}); err != nil {
+			t.Fatalf("CreateClusterParameterGroup(%s): %v", name, err)
+		}
+	}
+
+	pager := awsredshift.NewDescribeClusterParameterGroupsPaginator(client,
+		&awsredshift.DescribeClusterParameterGroupsInput{MaxRecords: aws.Int32(pageMaxRecords)})
+
+	seen := map[string]int{}
+	pages := 0
+
+	for pager.HasMorePages() {
+		out, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("DescribeClusterParameterGroups page %d: %v", pages, err)
+		}
+
+		pages++
+		for i := range out.ParameterGroups {
+			seen[aws.ToString(out.ParameterGroups[i].ParameterGroupName)]++
+		}
+
+		if pages > multiPageCount {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+
+	assertPagedExactlyOnce(t, pages, want, seen)
+}
+
+// TestSDKRedshiftDescribeClusterSubnetGroupsPagination proves
+// DescribeClusterSubnetGroups pages on Marker/MaxRecords.
+func TestSDKRedshiftDescribeClusterSubnetGroupsPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	want := map[string]bool{}
+	for i := range multiPageCount {
+		name := fmt.Sprintf("sg-%02d", i)
+		want[name] = true
+
+		if _, err := client.CreateClusterSubnetGroup(ctx, &awsredshift.CreateClusterSubnetGroupInput{
+			ClusterSubnetGroupName: aws.String(name),
+			Description:            aws.String("sg"),
+			SubnetIds:              []string{"subnet-1"},
+		}); err != nil {
+			t.Fatalf("CreateClusterSubnetGroup(%s): %v", name, err)
+		}
+	}
+
+	pager := awsredshift.NewDescribeClusterSubnetGroupsPaginator(client,
+		&awsredshift.DescribeClusterSubnetGroupsInput{MaxRecords: aws.Int32(pageMaxRecords)})
+
+	seen := map[string]int{}
+	pages := 0
+
+	for pager.HasMorePages() {
+		out, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("DescribeClusterSubnetGroups page %d: %v", pages, err)
+		}
+
+		pages++
+		for i := range out.ClusterSubnetGroups {
+			seen[aws.ToString(out.ClusterSubnetGroups[i].ClusterSubnetGroupName)]++
+		}
+
+		if pages > multiPageCount {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+
+	assertPagedExactlyOnce(t, pages, want, seen)
+}
+
+// TestSDKRedshiftDescribeSinglePageNoMarker proves a fixture that fits in one
+// page returns no Marker for each of the four Describe operations.
+func TestSDKRedshiftDescribeSinglePageNoMarker(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:  aws.String("solo"),
+		MasterUsername:     aws.String("admin"),
+		MasterUserPassword: aws.String("Sup3rSecret!"),
+		NodeType:           aws.String("ra3.xlplus"),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := client.CreateClusterSnapshot(ctx, &awsredshift.CreateClusterSnapshotInput{
+		SnapshotIdentifier: aws.String("solo-snap"),
+		ClusterIdentifier:  aws.String("solo"),
+	}); err != nil {
+		t.Fatalf("CreateClusterSnapshot: %v", err)
+	}
+
+	if _, err := client.CreateClusterParameterGroup(ctx, &awsredshift.CreateClusterParameterGroupInput{
+		ParameterGroupName:   aws.String("solo-pg"),
+		ParameterGroupFamily: aws.String("redshift-1.0"),
+		Description:          aws.String("pg"),
+	}); err != nil {
+		t.Fatalf("CreateClusterParameterGroup: %v", err)
+	}
+
+	if _, err := client.CreateClusterSubnetGroup(ctx, &awsredshift.CreateClusterSubnetGroupInput{
+		ClusterSubnetGroupName: aws.String("solo-sg"),
+		Description:            aws.String("sg"),
+		SubnetIds:              []string{"subnet-1"},
+	}); err != nil {
+		t.Fatalf("CreateClusterSubnetGroup: %v", err)
+	}
+
+	clusters, err := client.DescribeClusters(ctx, &awsredshift.DescribeClustersInput{})
+	if err != nil {
+		t.Fatalf("DescribeClusters: %v", err)
+	}
+	if aws.ToString(clusters.Marker) != "" {
+		t.Errorf("DescribeClusters single page carried Marker %q", aws.ToString(clusters.Marker))
+	}
+
+	snaps, err := client.DescribeClusterSnapshots(ctx, &awsredshift.DescribeClusterSnapshotsInput{})
+	if err != nil {
+		t.Fatalf("DescribeClusterSnapshots: %v", err)
+	}
+	if aws.ToString(snaps.Marker) != "" {
+		t.Errorf("DescribeClusterSnapshots single page carried Marker %q", aws.ToString(snaps.Marker))
+	}
+
+	pgs, err := client.DescribeClusterParameterGroups(ctx, &awsredshift.DescribeClusterParameterGroupsInput{})
+	if err != nil {
+		t.Fatalf("DescribeClusterParameterGroups: %v", err)
+	}
+	if aws.ToString(pgs.Marker) != "" {
+		t.Errorf("DescribeClusterParameterGroups single page carried Marker %q", aws.ToString(pgs.Marker))
+	}
+
+	sgs, err := client.DescribeClusterSubnetGroups(ctx, &awsredshift.DescribeClusterSubnetGroupsInput{})
+	if err != nil {
+		t.Fatalf("DescribeClusterSubnetGroups: %v", err)
+	}
+	if aws.ToString(sgs.Marker) != "" {
+		t.Errorf("DescribeClusterSubnetGroups single page carried Marker %q", aws.ToString(sgs.Marker))
+	}
+}
+
+// TestSDKRedshiftDescribeInvalidMarker proves an unreadable Marker is rejected by
+// each of the four Describe operations.
+func TestSDKRedshiftDescribeInvalidMarker(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	bad := aws.String("!!!not-base64!!!")
+
+	if _, err := client.DescribeClusters(ctx,
+		&awsredshift.DescribeClustersInput{Marker: bad}); err == nil {
+		t.Error("DescribeClusters with an invalid Marker succeeded, want an error")
+	}
+
+	if _, err := client.DescribeClusterSnapshots(ctx,
+		&awsredshift.DescribeClusterSnapshotsInput{Marker: bad}); err == nil {
+		t.Error("DescribeClusterSnapshots with an invalid Marker succeeded, want an error")
+	}
+
+	if _, err := client.DescribeClusterParameterGroups(ctx,
+		&awsredshift.DescribeClusterParameterGroupsInput{Marker: bad}); err == nil {
+		t.Error("DescribeClusterParameterGroups with an invalid Marker succeeded, want an error")
+	}
+
+	if _, err := client.DescribeClusterSubnetGroups(ctx,
+		&awsredshift.DescribeClusterSubnetGroupsInput{Marker: bad}); err == nil {
+		t.Error("DescribeClusterSubnetGroups with an invalid Marker succeeded, want an error")
+	}
+}
+
+// assertPagedExactlyOnce checks the walk spanned more than one page and that
+// every wanted id was returned exactly once.
+func assertPagedExactlyOnce(t *testing.T, pages int, want map[string]bool, seen map[string]int) {
+	t.Helper()
+
+	if pages < 2 {
+		t.Errorf("walked %d pages, want more than one", pages)
+	}
+
+	for id := range want {
+		if seen[id] != 1 {
+			t.Errorf("id %q returned %d times, want exactly 1", id, seen[id])
+		}
+	}
+
+	if len(seen) != len(want) {
+		t.Errorf("saw %d distinct ids, want %d", len(seen), len(want))
+	}
+}

--- a/server/aws/redshift/operations.go
+++ b/server/aws/redshift/operations.go
@@ -102,14 +102,21 @@ func (h *Handler) describeClusters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := clustersXML{Cluster: make([]clusterXML, 0, len(clusters))}
-	for i := range clusters {
-		out.Cluster = append(out.Cluster, toClusterXML(&clusters[i]))
+	page, err := paginateRedshift(clusters, func(c rdbdriver.Cluster) string { return c.ID },
+		r.Form.Get("Marker"), r.Form.Get("MaxRecords"))
+	if err != nil {
+		writeInvalidMarker(w)
+		return
+	}
+
+	out := clustersXML{Cluster: make([]clusterXML, 0, len(page.Items))}
+	for i := range page.Items {
+		out.Cluster = append(out.Cluster, toClusterXML(&page.Items[i]))
 	}
 
 	awsquery.WriteXMLResponse(w, describeClustersResponse{
 		Xmlns:    Namespace,
-		Result:   clustersResult{Clusters: out},
+		Result:   clustersResult{Clusters: out, Marker: page.NextPageToken},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -231,14 +238,21 @@ func (h *Handler) describeClusterSnapshots(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	out := snapshotsXML{Snapshot: make([]snapshotXML, 0, len(snaps))}
-	for i := range snaps {
-		out.Snapshot = append(out.Snapshot, toSnapshotXML(&snaps[i]))
+	page, err := paginateRedshift(snaps, func(s rdbdriver.ClusterSnapshot) string { return s.ID },
+		form.Get("Marker"), form.Get("MaxRecords"))
+	if err != nil {
+		writeInvalidMarker(w)
+		return
+	}
+
+	out := snapshotsXML{Snapshot: make([]snapshotXML, 0, len(page.Items))}
+	for i := range page.Items {
+		out.Snapshot = append(out.Snapshot, toSnapshotXML(&page.Items[i]))
 	}
 
 	awsquery.WriteXMLResponse(w, describeClusterSnapshotsResponse{
 		Xmlns:    Namespace,
-		Result:   snapshotsResult{Snapshots: out},
+		Result:   snapshotsResult{Snapshots: out, Marker: page.NextPageToken},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/redshift/paginate.go
+++ b/server/aws/redshift/paginate.go
@@ -1,0 +1,48 @@
+package redshift
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+)
+
+// Redshift describe operations page on Marker + MaxRecords. MaxRecords is
+// constrained to [20, 100] with a default of 100, matching the real API.
+const (
+	minMaxRecords     = 20
+	maxMaxRecords     = 100
+	defaultMaxRecords = 100
+)
+
+// paginateRedshift stable-sorts items by their identifier, then slices one
+// Marker/MaxRecords page. It returns the page (its NextPageToken is the Marker
+// to echo, empty when the result is not truncated). An unreadable Marker yields
+// an error the caller surfaces as InvalidParameterValue. Shared by all four
+// Redshift Describe handlers so their paging behaves identically.
+func paginateRedshift[T any](items []T, id func(T) string, marker, maxRecords string) (pagination.Page[T], error) {
+	less := func(a, b T) bool { return id(a) < id(b) }
+
+	return pagination.PaginateSorted(items, less, marker, clampMaxRecords(formInt(maxRecords)))
+}
+
+// writeInvalidMarker reports an unreadable pagination Marker the way real
+// Redshift does: an InvalidParameterValue query-protocol error.
+func writeInvalidMarker(w http.ResponseWriter) {
+	awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", "invalid Marker")
+}
+
+// clampMaxRecords applies the Redshift MaxRecords contract: unset (<= 0)
+// defaults to 100, and values outside [20, 100] are clamped into the range.
+func clampMaxRecords(n int) int {
+	switch {
+	case n <= 0:
+		return defaultMaxRecords
+	case n < minMaxRecords:
+		return minMaxRecords
+	case n > maxMaxRecords:
+		return maxMaxRecords
+	default:
+		return n
+	}
+}

--- a/server/aws/redshift/parameter_group.go
+++ b/server/aws/redshift/parameter_group.go
@@ -58,6 +58,7 @@ type describeClusterParameterGroupsResponse struct {
 	XMLName  xml.Name                   `xml:"DescribeClusterParameterGroupsResponse"`
 	Xmlns    string                     `xml:"xmlns,attr"`
 	Groups   []clusterParameterGroupXML `xml:"DescribeClusterParameterGroupsResult>ParameterGroups>ClusterParameterGroup"`
+	Marker   string                     `xml:"DescribeClusterParameterGroupsResult>Marker,omitempty"`
 	Metadata responseMetadata           `xml:"ResponseMetadata"`
 }
 
@@ -71,6 +72,7 @@ type describeClusterSubnetGroupsResponse struct {
 	XMLName  xml.Name                `xml:"DescribeClusterSubnetGroupsResponse"`
 	Xmlns    string                  `xml:"xmlns,attr"`
 	Groups   []clusterSubnetGroupXML `xml:"DescribeClusterSubnetGroupsResult>ClusterSubnetGroups>ClusterSubnetGroup"`
+	Marker   string                  `xml:"DescribeClusterSubnetGroupsResult>Marker,omitempty"`
 	Metadata responseMetadata        `xml:"ResponseMetadata"`
 }
 
@@ -332,18 +334,26 @@ func (h *Handler) describeClusterParameterGroups(w http.ResponseWriter, r *http.
 		return
 	}
 
-	out := make([]clusterParameterGroupXML, 0, len(groups))
-	for i := range groups {
+	page, err := paginateRedshift(groups, func(g redshiftprovider.ParameterGroup) string { return g.Name },
+		r.Form.Get("Marker"), r.Form.Get("MaxRecords"))
+	if err != nil {
+		writeInvalidMarker(w)
+		return
+	}
+
+	out := make([]clusterParameterGroupXML, 0, len(page.Items))
+	for i := range page.Items {
 		out = append(out, clusterParameterGroupXML{
-			ParameterGroupName:   groups[i].Name,
-			ParameterGroupFamily: groups[i].Family,
-			Description:          groups[i].Description,
+			ParameterGroupName:   page.Items[i].Name,
+			ParameterGroupFamily: page.Items[i].Family,
+			Description:          page.Items[i].Description,
 		})
 	}
 
 	awsquery.WriteXMLResponse(w, describeClusterParameterGroupsResponse{
 		Xmlns:    Namespace,
 		Groups:   out,
+		Marker:   page.NextPageToken,
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -384,14 +394,22 @@ func (h *Handler) describeClusterSubnetGroups(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	out := make([]clusterSubnetGroupXML, 0, len(groups))
-	for i := range groups {
-		out = append(out, toClusterSubnetGroupXML(&groups[i]))
+	page, err := paginateRedshift(groups, func(g redshiftprovider.SubnetGroup) string { return g.Name },
+		r.Form.Get("Marker"), r.Form.Get("MaxRecords"))
+	if err != nil {
+		writeInvalidMarker(w)
+		return
+	}
+
+	out := make([]clusterSubnetGroupXML, 0, len(page.Items))
+	for i := range page.Items {
+		out = append(out, toClusterSubnetGroupXML(&page.Items[i]))
 	}
 
 	awsquery.WriteXMLResponse(w, describeClusterSubnetGroupsResponse{
 		Xmlns:    Namespace,
 		Groups:   out,
+		Marker:   page.NextPageToken,
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/redshift/xml.go
+++ b/server/aws/redshift/xml.go
@@ -104,6 +104,7 @@ type clusterResult struct {
 
 type clustersResult struct {
 	Clusters clustersXML `xml:"Clusters"`
+	Marker   string      `xml:"Marker,omitempty"`
 }
 
 type clustersXML struct {
@@ -116,6 +117,7 @@ type snapshotResult struct {
 
 type snapshotsResult struct {
 	Snapshots snapshotsXML `xml:"Snapshots"`
+	Marker    string       `xml:"Marker,omitempty"`
 }
 
 type snapshotsXML struct {


### PR DESCRIPTION
## Summary

Adds offset-based pagination to the AWS Redshift and ELBv2 Describe APIs that previously returned their full result set in a single unpaginated response.

### Redshift (Marker + MaxRecords)
Previously had no pagination scaffolding. Now mirrors RDS DescribeDBInstances:
- `DescribeClusters` (sorted by ClusterIdentifier)
- `DescribeClusterSnapshots` (sorted by SnapshotIdentifier)
- `DescribeClusterParameterGroups` (sorted by ParameterGroupName)
- `DescribeClusterSubnetGroups` (sorted by ClusterSubnetGroupName)

Each stable-sorts by identifier, reads Marker + MaxRecords, pages via `internal/pagination`, emits a `Marker` output element when the result is truncated, honors MaxRecords (clamped to 20-100, default 100), and rejects an unreadable Marker with `InvalidParameterValue`. A single shared `paginateRedshift` generic helper backs all four handlers (no duplication).

### ELBv2 (Marker + PageSize)
Reuses the existing `pageWindow` helper already used by DescribeLoadBalancers/DescribeTargetGroups:
- `DescribeListeners` (sorted by ARN)
- `DescribeRules` (sorted by ARN)

Each stable-sorts by ARN, applies `pageWindow(Marker, PageSize, total)`, and adds `NextMarker` to the result, matching DescribeLoadBalancers/DescribeTargetGroups exactly.

All Describe handlers combine paging with their existing filters (DescribeListeners by LoadBalancerArn/ListenerArns; DescribeRules by ListenerArn; Redshift by identifier). Stable sort is applied before offset windowing so no item is skipped or duplicated across pages. No provider changes.

### Deferrals
- **Redshift DescribeTags**: the handler is scoped to a single `ResourceName` (the driver returns one resource's tags). Real Redshift paginates only over an account-wide listing, which would require a new provider capability (out of scope: no provider changes).
- **ELBv2 DescribeRules RuleArns-only**: resolving rules purely by RuleArns (no ListenerArn) would need a provider rule-by-ARN lookup; real ELBv2 treats ListenerArn and RuleArns as mutually exclusive, so a combined filter would be non-conformant. Left as-is.

## Tests
New real-SDK roundtrip tests (aws-sdk-go-v2 `redshift` + `elasticloadbalancingv2`) for each operation: multi-page walk that visits every item exactly once and terminates; single page returns no token; invalid token errors.

## Verification
- `go build ./...`, `go vet` clean
- `go test` (redshift/elbv2 server + provider packages) pass, including `-race`
- `gofmt -l` clean; golangci-lint 0 new issues (20 pre-existing, unchanged from base)
- `go generate ./...` zero diff; compatgen green with `git diff --exit-code docs/compat/` clean