### PR TITLE
fix(aws-route53): paginate ListHostedZones/ListHealthChecks and continue ListResourceRecordSets by SetIdentifier

### DIFF
--- a/server/aws/route53/health_check.go
+++ b/server/aws/route53/health_check.go
@@ -63,8 +63,12 @@ type listHealthChecksResponse struct {
 	XMLName      xml.Name         `xml:"ListHealthChecksResponse"`
 	Xmlns        string           `xml:"xmlns,attr"`
 	HealthChecks []healthCheckXML `xml:"HealthChecks>HealthCheck"`
-	IsTruncated  bool             `xml:"IsTruncated"`
-	MaxItems     int              `xml:"MaxItems"`
+	// Marker echoes the request marker; NextMarker is present only on a truncated
+	// page and carries the health-check id the caller passes back as Marker.
+	Marker      string `xml:"Marker,omitempty"`
+	IsTruncated bool   `xml:"IsTruncated"`
+	NextMarker  string `xml:"NextMarker,omitempty"`
+	MaxItems    int    `xml:"MaxItems"`
 }
 
 type updateHealthCheckRequest struct {
@@ -153,6 +157,9 @@ func (h *Handler) getHealthCheck(w http.ResponseWriter, r *http.Request, id stri
 	wire.WriteXML(w, http.StatusOK, getHealthCheckResponse{Xmlns: xmlns, HealthCheck: toHealthCheckXML(info)})
 }
 
+// listHealthChecks answers ListHealthChecks. Health checks are returned in a
+// stable id order and paginated Route 53 Marker-style: maxitems bounds the page
+// and NextMarker (echoed back as the next marker) resumes at the following id.
 func (h *Handler) listHealthChecks(w http.ResponseWriter, r *http.Request) {
 	infos, err := h.dns.ListHealthChecks(r.Context())
 	if err != nil {
@@ -165,11 +172,17 @@ func (h *Handler) listHealthChecks(w http.ResponseWriter, r *http.Request) {
 		checks = append(checks, toHealthCheckXML(&infos[i]))
 	}
 
+	marker := r.URL.Query().Get("marker")
+	maxItems := parseMaxItems(r.URL.Query().Get("maxitems"))
+	page, next := markerPage(checks, marker, maxItems, func(c healthCheckXML) string { return c.ID })
+
 	wire.WriteXML(w, http.StatusOK, listHealthChecksResponse{
 		Xmlns:        xmlns,
-		HealthChecks: checks,
-		IsTruncated:  false,
-		MaxItems:     listMaxItems,
+		HealthChecks: page,
+		Marker:       marker,
+		IsTruncated:  next != "",
+		NextMarker:   next,
+		MaxItems:     maxItems,
 	})
 }
 

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -114,8 +114,11 @@ func (h *Handler) getHostedZone(w http.ResponseWriter, r *http.Request, id strin
 	})
 }
 
+// listHostedZones answers ListHostedZones. Hosted zones are account-global, so
+// they list unscoped; they are returned in a stable id order and paginated
+// Route 53 Marker-style: maxitems bounds the page and NextMarker (echoed back as
+// the next marker) resumes listing at the following zone id.
 func (h *Handler) listHostedZones(w http.ResponseWriter, r *http.Request) {
-	// Route 53 hosted zones are account-global, so list them unscoped.
 	infos, err := h.dns.ListZones(r.Context(), scope.Scope{})
 	if err != nil {
 		writeErr(w, err)
@@ -127,12 +130,40 @@ func (h *Handler) listHostedZones(w http.ResponseWriter, r *http.Request) {
 		zones = append(zones, toHostedZoneXML(&infos[i]))
 	}
 
+	marker := r.URL.Query().Get("marker")
+	maxItems := parseMaxItems(r.URL.Query().Get("maxitems"))
+	page, next := markerPage(zones, marker, maxItems, func(z hostedZoneXML) string { return z.Id })
+
 	wire.WriteXML(w, http.StatusOK, listHostedZonesResponse{
 		Xmlns:       xmlns,
-		HostedZones: zones,
-		IsTruncated: false,
-		MaxItems:    listMaxItems,
+		HostedZones: page,
+		Marker:      marker,
+		IsTruncated: next != "",
+		NextMarker:  next,
+		//nolint:gosec // maxItems is clamped to [1,listMaxItems] by parseMaxItems
+		MaxItems: int32(maxItems),
 	})
+}
+
+// markerPage sorts items by id (stable), resumes at the marker id (inclusive),
+// and returns the page of up to maxItems items plus the next marker — the id the
+// following page resumes from, or "" when this page is the last. It implements
+// Route 53's Marker-style pagination shared by ListHostedZones and
+// ListHealthChecks.
+func markerPage[T any](items []T, marker string, maxItems int, id func(T) string) (page []T, next string) {
+	sort.SliceStable(items, func(i, j int) bool { return id(items[i]) < id(items[j]) })
+
+	if marker != "" {
+		for len(items) > 0 && id(items[0]) < marker {
+			items = items[1:]
+		}
+	}
+
+	if len(items) > maxItems {
+		return items[:maxItems], id(items[maxItems])
+	}
+
+	return items, ""
 }
 
 func (h *Handler) deleteHostedZone(w http.ResponseWriter, r *http.Request, id string) {
@@ -474,21 +505,30 @@ func (h *Handler) listResourceRecordSets(w http.ResponseWriter, r *http.Request,
 
 	// Real Route 53 returns record sets in DNS name order — sorted first by DNS
 	// name with the labels reversed (so the zone apex sorts before its
-	// subdomains: com.order. < com.order.a.), then by record type. This ordering
-	// is what NextRecordName/StartRecordName pagination walks.
+	// subdomains: com.order. < com.order.a.), then by record type, then by
+	// SetIdentifier so weighted/latency/failover/geo siblings at the same name+type
+	// have a stable total order. This ordering is what the
+	// StartRecordName/Type/Identifier continuation walks.
 	sort.Slice(records, func(i, j int) bool {
 		if c := compareDNSName(records[i].Name, records[j].Name); c != 0 {
 			return c < 0
 		}
 
-		return records[i].Type < records[j].Type
+		if records[i].Type != records[j].Type {
+			return records[i].Type < records[j].Type
+		}
+
+		return records[i].SetID < records[j].SetID
 	})
 
-	// StartRecordName (and optional StartRecordType) skip forward to the first
-	// record at or after the requested position, in the same reversed-label order.
+	// StartRecordName (with optional StartRecordType, then StartRecordIdentifier)
+	// skips forward to the first record at or after the requested position in that
+	// same order. The identifier is what keeps a multi-value group that straddles a
+	// page boundary from being re-emitted on the next page.
 	start := r.URL.Query().Get("name")
 	startType := r.URL.Query().Get("type")
-	records = recordsFrom(records, start, startType)
+	startID := r.URL.Query().Get("identifier")
+	records = recordsFrom(records, start, startType, startID)
 
 	maxItems := parseMaxItems(r.URL.Query().Get("maxitems"))
 
@@ -502,6 +542,7 @@ func (h *Handler) listResourceRecordSets(w http.ResponseWriter, r *http.Request,
 		resp.IsTruncated = true
 		resp.NextRecordName = next.Name
 		resp.NextRecordType = next.Type
+		resp.NextRecordIdentifier = next.SetID
 		records = records[:maxItems]
 	}
 
@@ -513,22 +554,39 @@ func (h *Handler) listResourceRecordSets(w http.ResponseWriter, r *http.Request,
 	wire.WriteXML(w, http.StatusOK, resp)
 }
 
-// recordsFrom returns the slice starting at the first record whose (name, type)
-// is at or after (start, startType) in reversed-label DNS order. An empty start
-// returns all records.
-func recordsFrom(records []dnsdriver.RecordInfo, start, startType string) []dnsdriver.RecordInfo {
+// recordsFrom returns the slice starting at the first record whose
+// (name, type, SetIdentifier) triple is at or after (start, startType, startID)
+// in reversed-label DNS order. An empty start returns all records. Honoring
+// startID is what resumes a same-name+type multi-value group at the exact
+// sibling the previous page stopped before, so none is duplicated or skipped.
+func recordsFrom(records []dnsdriver.RecordInfo, start, startType, startID string) []dnsdriver.RecordInfo {
 	if start == "" {
 		return records
 	}
 
 	for i := range records {
-		c := compareDNSName(records[i].Name, start)
-		if c > 0 || (c == 0 && (startType == "" || records[i].Type >= startType)) {
+		if recordAtOrAfter(&records[i], start, startType, startID) {
 			return records[i:]
 		}
 	}
 
 	return nil
+}
+
+// recordAtOrAfter reports whether rec is at or after the (start, startType,
+// startID) position in ListResourceRecordSets order. An empty startType matches
+// from the whole name; an empty startID matches from the first sibling of the
+// name+type.
+func recordAtOrAfter(rec *dnsdriver.RecordInfo, start, startType, startID string) bool {
+	if c := compareDNSName(rec.Name, start); c != 0 {
+		return c > 0
+	}
+
+	if startType == "" || rec.Type != startType {
+		return rec.Type >= startType
+	}
+
+	return startID == "" || rec.SetID >= startID
 }
 
 // compareDNSName orders two DNS names the way Route 53's ListResourceRecordSets

--- a/server/aws/route53/pagination_test.go
+++ b/server/aws/route53/pagination_test.go
@@ -1,0 +1,219 @@
+package route53_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+// pageWalkLimit guards the manual Marker walks against a non-terminating
+// paginator (a pagination bug that never clears IsTruncated).
+const pageWalkLimit = 100
+
+// TestSDKListHostedZonesPaginates walks ListHostedZones with a small MaxItems
+// and asserts the Marker/NextMarker/IsTruncated contract returns every zone
+// exactly once and terminates.
+func TestSDKListHostedZonesPaginates(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	const total = 5
+	want := make(map[string]int, total)
+	for i := range total {
+		id := createZone(t, client, fmt.Sprintf("zone-%d.com.", i), fmt.Sprintf("hz-ref-%d", i))
+		want[id] = 0
+	}
+
+	got := make(map[string]int, total)
+	var marker *string
+	for pages := 0; ; pages++ {
+		if pages > pageWalkLimit {
+			t.Fatal("ListHostedZones did not terminate — IsTruncated never cleared")
+		}
+
+		out, err := client.ListHostedZones(ctx, &awsr53.ListHostedZonesInput{
+			MaxItems: aws.Int32(2),
+			Marker:   marker,
+		})
+		if err != nil {
+			t.Fatalf("ListHostedZones: %v", err)
+		}
+
+		if n := len(out.HostedZones); n > 2 {
+			t.Fatalf("page returned %d zones, want <= MaxItems 2", n)
+		}
+
+		for i := range out.HostedZones {
+			got[aws.ToString(out.HostedZones[i].Id)]++
+		}
+
+		if !out.IsTruncated {
+			if aws.ToString(out.NextMarker) != "" {
+				t.Errorf("last page carries NextMarker %q, want empty", aws.ToString(out.NextMarker))
+			}
+
+			break
+		}
+
+		if aws.ToString(out.NextMarker) == "" {
+			t.Fatal("truncated page has empty NextMarker")
+		}
+
+		marker = out.NextMarker
+	}
+
+	assertEachOnce(t, want, got)
+}
+
+// TestSDKListHealthChecksPaginates walks ListHealthChecks with a small MaxItems
+// and asserts every health check is returned exactly once and the walk ends.
+func TestSDKListHealthChecksPaginates(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	const total = 5
+	want := make(map[string]int, total)
+	for i := range total {
+		out, err := client.CreateHealthCheck(ctx, &awsr53.CreateHealthCheckInput{
+			CallerReference: aws.String(fmt.Sprintf("hc-ref-%d", i)),
+			HealthCheckConfig: &r53types.HealthCheckConfig{
+				IPAddress: aws.String(fmt.Sprintf("192.0.2.%d", i+1)),
+				Port:      aws.Int32(80),
+				Type:      r53types.HealthCheckTypeHttp,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CreateHealthCheck: %v", err)
+		}
+
+		want[aws.ToString(out.HealthCheck.Id)] = 0
+	}
+
+	got := make(map[string]int, total)
+	var marker *string
+	for pages := 0; ; pages++ {
+		if pages > pageWalkLimit {
+			t.Fatal("ListHealthChecks did not terminate — IsTruncated never cleared")
+		}
+
+		out, err := client.ListHealthChecks(ctx, &awsr53.ListHealthChecksInput{
+			MaxItems: aws.Int32(2),
+			Marker:   marker,
+		})
+		if err != nil {
+			t.Fatalf("ListHealthChecks: %v", err)
+		}
+
+		if n := len(out.HealthChecks); n > 2 {
+			t.Fatalf("page returned %d checks, want <= MaxItems 2", n)
+		}
+
+		for i := range out.HealthChecks {
+			got[aws.ToString(out.HealthChecks[i].Id)]++
+		}
+
+		if !out.IsTruncated {
+			break
+		}
+
+		if aws.ToString(out.NextMarker) == "" {
+			t.Fatal("truncated page has empty NextMarker")
+		}
+
+		marker = out.NextMarker
+	}
+
+	assertEachOnce(t, want, got)
+}
+
+// TestSDKListResourceRecordSetsIdentifierNoDupSkip creates a weighted record set
+// whose siblings share one name+type but carry distinct SetIdentifiers, then
+// paginates with a MaxItems that forces a page boundary inside that group. It
+// asserts every sibling is returned exactly once — no duplicate (the old bug,
+// which re-emitted the whole group) and no skip.
+func TestSDKListResourceRecordSetsIdentifierNoDupSkip(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	zoneID := createZone(t, client, "weighted.com.", "wt-ref")
+
+	const name = "app.weighted.com."
+	setIDs := []string{"w1", "w2", "w3"}
+	for i, sid := range setIDs {
+		if _, err := client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+			HostedZoneId: aws.String(zoneID),
+			ChangeBatch: &r53types.ChangeBatch{
+				Changes: []r53types.Change{{
+					Action: r53types.ChangeActionCreate,
+					ResourceRecordSet: &r53types.ResourceRecordSet{
+						Name:            aws.String(name),
+						Type:            r53types.RRTypeA,
+						SetIdentifier:   aws.String(sid),
+						Weight:          aws.Int64(int64(i + 1)),
+						TTL:             aws.Int64(60),
+						ResourceRecords: []r53types.ResourceRecord{{Value: aws.String(fmt.Sprintf("192.0.2.%d", i+1))}},
+					},
+				}},
+			},
+		}); err != nil {
+			t.Fatalf("ChangeResourceRecordSets(%s): %v", sid, err)
+		}
+	}
+
+	// MaxItems 2 with the zone's SOA+NS ahead of the group guarantees the boundary
+	// falls between the weighted siblings, exercising NextRecordIdentifier.
+	paginator := awsr53.NewListResourceRecordSetsPaginator(client, &awsr53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		MaxItems:     aws.Int32(2),
+	})
+
+	seen := map[string]int{"w1": 0, "w2": 0, "w3": 0}
+	for pages := 0; paginator.HasMorePages(); pages++ {
+		if pages > pageWalkLimit {
+			t.Fatal("ListResourceRecordSets did not terminate")
+		}
+
+		out, err := paginator.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		for i := range out.ResourceRecordSets {
+			if sid := aws.ToString(out.ResourceRecordSets[i].SetIdentifier); sid != "" {
+				seen[sid]++
+			}
+		}
+	}
+
+	for _, sid := range setIDs {
+		if seen[sid] != 1 {
+			t.Errorf("weighted record %q returned %d times across pages, want exactly 1", sid, seen[sid])
+		}
+	}
+}
+
+// assertEachOnce fails the test unless got contains exactly the keys of want,
+// each seen exactly once.
+func assertEachOnce(t *testing.T, want, got map[string]int) {
+	t.Helper()
+
+	for id := range want {
+		switch got[id] {
+		case 1:
+		case 0:
+			t.Errorf("id %q was never returned across pages", id)
+		default:
+			t.Errorf("id %q returned %d times, want exactly 1", id, got[id])
+		}
+	}
+
+	for id := range got {
+		if _, ok := want[id]; !ok {
+			t.Errorf("unexpected id %q returned", id)
+		}
+	}
+}

--- a/server/aws/route53/types.go
+++ b/server/aws/route53/types.go
@@ -231,8 +231,13 @@ type listHostedZonesResponse struct {
 	XMLName     xml.Name        `xml:"ListHostedZonesResponse"`
 	Xmlns       string          `xml:"xmlns,attr"`
 	HostedZones []hostedZoneXML `xml:"HostedZones>HostedZone"`
-	IsTruncated bool            `xml:"IsTruncated"`
-	MaxItems    int32           `xml:"MaxItems"`
+	// Marker echoes the request marker (the id listing resumed from), empty on the
+	// first page. NextMarker is present only on a truncated page and carries the id
+	// the caller passes back as Marker to fetch the next page.
+	Marker      string `xml:"Marker,omitempty"`
+	IsTruncated bool   `xml:"IsTruncated"`
+	NextMarker  string `xml:"NextMarker,omitempty"`
+	MaxItems    int32  `xml:"MaxItems"`
 }
 
 type changeResourceRecordSetsResponse struct {
@@ -248,7 +253,11 @@ type listResourceRecordSetsResponse struct {
 	IsTruncated        bool                   `xml:"IsTruncated"`
 	NextRecordName     string                 `xml:"NextRecordName,omitempty"`
 	NextRecordType     string                 `xml:"NextRecordType,omitempty"`
-	MaxItems           int32                  `xml:"MaxItems"`
+	// NextRecordIdentifier continues a weighted/latency/failover/geo record set that
+	// straddles a page boundary: it names the exact SetIdentifier the next page
+	// resumes from so a multi-value group is never re-emitted or skipped.
+	NextRecordIdentifier string `xml:"NextRecordIdentifier,omitempty"`
+	MaxItems             int32  `xml:"MaxItems"`
 }
 
 // errorResponse is the Route 53 XML error body the SDK maps to a typed


### PR DESCRIPTION
## Summary

Fixes three AWS Route 53 pagination bugs so the real `aws-sdk-go-v2/route53` client walks every page correctly.

### 1. ListHostedZones
Previously hardcoded `IsTruncated: false`, ignored `marker`/`maxitems`, and never emitted a `NextMarker` — a large account came back as one untruncated page. Now sorts zones by id (stable), resumes at the request `marker` (inclusive), bounds the page by `maxitems`, and emits `IsTruncated` + `NextMarker` in Route 53 Marker style.

### 2. ListHealthChecks
Same bug, same fix: stable id sort, `marker`/`maxitems` honored, `IsTruncated` + `NextMarker` emitted. The shared logic lives in one generic `markerPage` helper.

### 3. ListResourceRecordSets — SetIdentifier continuation
The `StartRecordName`/`StartRecordType` -> `NextRecordName`/`NextRecordType` continuation was already correct, but `StartRecordIdentifier`/`NextRecordIdentifier` were not modeled. A weighted/latency/geo record **set** sharing one name+type whose siblings straddled a page boundary re-emitted the whole group, producing duplicate rows on the next page. Now the records sort by (name, type, SetIdentifier), the continuation resumes from the exact `SetIdentifier`, and `NextRecordIdentifier` is emitted — no record is duplicated or skipped.

## Tests (real route53 SDK)
- `TestSDKListHostedZonesPaginates` / `TestSDKListHealthChecksPaginates` — small `MaxItems` over 5 items, walk every page via Marker, assert each id appears exactly once and the walk terminates.
- `TestSDKListResourceRecordSetsIdentifierNoDupSkip` — a 3-record weighted set (distinct SetIdentifiers) straddling a `MaxItems=2` boundary, paginated with the SDK paginator; asserts each sibling appears exactly once. Verified to fail without the SetIdentifier continuation.

## Gates
build, vet, `-count=1` + `-race` tests, gofmt, golangci-lint (0 new), `go generate`, and `compatgen` + `git diff docs/compat` all clean.