### PR TITLE
fix(aws): paginate messaging list APIs across Lambda/SQS/SNS/EventBridge/StepFunctions/SESv2

### DIFF
--- a/server/aws/eventbridge/operations.go
+++ b/server/aws/eventbridge/operations.go
@@ -87,7 +87,9 @@ func (h *Handler) listEventBuses(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	wire.WriteJSON(w, listEventBusesResponse{EventBuses: entries})
+	entries, nextToken := paginateByCursor(entries, req.NextToken, req.Limit, func(e eventBusEntry) string { return e.Name })
+
+	wire.WriteJSON(w, listEventBusesResponse{EventBuses: entries, NextToken: nextToken})
 }
 
 func (h *Handler) deleteEventBus(w http.ResponseWriter, r *http.Request) {
@@ -302,7 +304,9 @@ func (h *Handler) listTargetsByRule(w http.ResponseWriter, r *http.Request) {
 		out = append(out, toTargetJSON(&targets[i]))
 	}
 
-	wire.WriteJSON(w, listTargetsByRuleResponse{Targets: out})
+	out, nextToken := paginateByCursor(out, req.NextToken, req.Limit, func(t targetJSON) string { return t.ID })
+
+	wire.WriteJSON(w, listTargetsByRuleResponse{Targets: out, NextToken: nextToken})
 }
 
 // --- events ---

--- a/server/aws/eventbridge/pagination_sdk_test.go
+++ b/server/aws/eventbridge/pagination_sdk_test.go
@@ -1,0 +1,138 @@
+package eventbridge_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+)
+
+// TestSDKListEventBusesPagination walks ListEventBuses across pages over three
+// buses (a NamePrefix filter excludes the always-present default bus), asserting
+// Limit caps the page, the token resumes, and each bus appears once.
+func TestSDKListEventBusesPagination(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"bus1", "bus2", "bus3"} {
+		if _, err := client.CreateEventBus(ctx, &awseb.CreateEventBusInput{Name: aws.String(name)}); err != nil {
+			t.Fatalf("CreateEventBus(%s): %v", name, err)
+		}
+	}
+
+	page1, err := client.ListEventBuses(ctx, &awseb.ListEventBusesInput{
+		NamePrefix: aws.String("bus"), Limit: aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("ListEventBuses page1: %v", err)
+	}
+
+	if len(page1.EventBuses) != 2 || aws.ToString(page1.NextToken) == "" {
+		t.Fatalf("page1 = %d buses token=%q, want 2 with token", len(page1.EventBuses), aws.ToString(page1.NextToken))
+	}
+
+	page2, err := client.ListEventBuses(ctx, &awseb.ListEventBusesInput{
+		NamePrefix: aws.String("bus"), Limit: aws.Int32(2), NextToken: page1.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("ListEventBuses page2: %v", err)
+	}
+
+	if len(page2.EventBuses) != 1 || aws.ToString(page2.NextToken) != "" {
+		t.Fatalf("page2 = %d buses token=%q, want 1 no token", len(page2.EventBuses), aws.ToString(page2.NextToken))
+	}
+
+	seen := map[string]bool{}
+	for _, b := range append(page1.EventBuses, page2.EventBuses...) {
+		name := aws.ToString(b.Name)
+		if seen[name] {
+			t.Fatalf("bus %q returned twice across pages", name)
+		}
+
+		seen[name] = true
+	}
+
+	if len(seen) != 3 {
+		t.Fatalf("walked %d unique buses, want 3", len(seen))
+	}
+
+	all, err := client.ListEventBuses(ctx, &awseb.ListEventBusesInput{NamePrefix: aws.String("bus")})
+	if err != nil {
+		t.Fatalf("ListEventBuses all: %v", err)
+	}
+
+	if len(all.EventBuses) != 3 || aws.ToString(all.NextToken) != "" {
+		t.Fatalf("single page = %d buses token=%q, want 3 no token", len(all.EventBuses), aws.ToString(all.NextToken))
+	}
+}
+
+// TestSDKListTargetsByRulePagination walks ListTargetsByRule across pages over
+// three targets on one rule.
+func TestSDKListTargetsByRulePagination(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	if _, err := client.PutRule(ctx, &awseb.PutRuleInput{
+		Name: aws.String("rule"), EventPattern: aws.String(`{"source":["app"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	targets := []ebtypes.Target{
+		{Id: aws.String("t1"), Arn: aws.String("arn:aws:sqs:us-east-1:000000000000:q1")},
+		{Id: aws.String("t2"), Arn: aws.String("arn:aws:sqs:us-east-1:000000000000:q2")},
+		{Id: aws.String("t3"), Arn: aws.String("arn:aws:sqs:us-east-1:000000000000:q3")},
+	}
+	if _, err := client.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule: aws.String("rule"), Targets: targets,
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	page1, err := client.ListTargetsByRule(ctx, &awseb.ListTargetsByRuleInput{
+		Rule: aws.String("rule"), Limit: aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("ListTargetsByRule page1: %v", err)
+	}
+
+	if len(page1.Targets) != 2 || aws.ToString(page1.NextToken) == "" {
+		t.Fatalf("page1 = %d targets token=%q, want 2 with token", len(page1.Targets), aws.ToString(page1.NextToken))
+	}
+
+	page2, err := client.ListTargetsByRule(ctx, &awseb.ListTargetsByRuleInput{
+		Rule: aws.String("rule"), Limit: aws.Int32(2), NextToken: page1.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("ListTargetsByRule page2: %v", err)
+	}
+
+	if len(page2.Targets) != 1 || aws.ToString(page2.NextToken) != "" {
+		t.Fatalf("page2 = %d targets token=%q, want 1 no token", len(page2.Targets), aws.ToString(page2.NextToken))
+	}
+
+	seen := map[string]bool{}
+	for _, tg := range append(page1.Targets, page2.Targets...) {
+		id := aws.ToString(tg.Id)
+		if seen[id] {
+			t.Fatalf("target %q returned twice across pages", id)
+		}
+
+		seen[id] = true
+	}
+
+	if len(seen) != 3 {
+		t.Fatalf("walked %d unique targets, want 3", len(seen))
+	}
+
+	all, err := client.ListTargetsByRule(ctx, &awseb.ListTargetsByRuleInput{Rule: aws.String("rule")})
+	if err != nil {
+		t.Fatalf("ListTargetsByRule all: %v", err)
+	}
+
+	if len(all.Targets) != 3 || aws.ToString(all.NextToken) != "" {
+		t.Fatalf("single page = %d targets token=%q, want 3 no token", len(all.Targets), aws.ToString(all.NextToken))
+	}
+}

--- a/server/aws/eventbridge/types.go
+++ b/server/aws/eventbridge/types.go
@@ -31,6 +31,8 @@ type nameRequest struct {
 
 type listEventBusesRequest struct {
 	NamePrefix string `json:"NamePrefix"`
+	Limit      int    `json:"Limit"`
+	NextToken  string `json:"NextToken"`
 }
 
 type putRuleRequest struct {
@@ -81,6 +83,8 @@ type removeTargetsRequest struct {
 type listTargetsByRuleRequest struct {
 	Rule         string `json:"Rule"`
 	EventBusName string `json:"EventBusName"`
+	Limit        int    `json:"Limit"`
+	NextToken    string `json:"NextToken"`
 }
 
 type putEventsEntry struct {
@@ -123,6 +127,7 @@ type eventBusEntry struct {
 
 type listEventBusesResponse struct {
 	EventBuses []eventBusEntry `json:"EventBuses"`
+	NextToken  string          `json:"NextToken,omitempty"`
 }
 
 type putRuleResponse struct {
@@ -167,7 +172,8 @@ type removeTargetsResponse struct {
 }
 
 type listTargetsByRuleResponse struct {
-	Targets []targetJSON `json:"Targets"`
+	Targets   []targetJSON `json:"Targets"`
+	NextToken string       `json:"NextToken,omitempty"`
 }
 
 type putEventsResultEntry struct {
@@ -239,27 +245,35 @@ func (h *Handler) ruleARN(bus, rule string) string {
 // the prior page, and Limit caps the page size. The returned token is empty
 // when the page is the last one.
 func paginateRules(entries []ruleEntry, nextToken string, limit int) (page []ruleEntry, next string) {
-	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	return paginateByCursor(entries, nextToken, limit, func(e ruleEntry) string { return e.Name })
+}
+
+// paginateByCursor applies EventBridge's value-cursor pagination over a slice
+// sorted by the key returned by keyOf: NextToken resumes after the item whose
+// key equals the token, and Limit caps the page size. The returned token is the
+// key of the last item on a truncated page, or empty when the page is the last.
+func paginateByCursor[T any](items []T, nextToken string, limit int, keyOf func(T) string) (page []T, next string) {
+	sort.Slice(items, func(i, j int) bool { return keyOf(items[i]) < keyOf(items[j]) })
 
 	if nextToken != "" {
 		start := 0
 
-		for i := range entries {
-			if entries[i].Name == nextToken {
+		for i := range items {
+			if keyOf(items[i]) == nextToken {
 				start = i + 1
 
 				break
 			}
 		}
 
-		entries = entries[start:]
+		items = items[start:]
 	}
 
-	if limit > 0 && limit < len(entries) {
-		return entries[:limit], entries[limit-1].Name
+	if limit > 0 && limit < len(items) {
+		return items[:limit], keyOf(items[limit-1])
 	}
 
-	return entries, ""
+	return items, ""
 }
 
 // isValidDetail reports whether a PutEvents entry's Detail is acceptable:

--- a/server/aws/lambda/esm.go
+++ b/server/aws/lambda/esm.go
@@ -2,6 +2,7 @@ package lambda
 
 import (
 	"net/http"
+	"sort"
 	"time"
 
 	sdrv "github.com/stackshy/cloudemu/v2/services/serverless/driver"
@@ -190,15 +191,31 @@ func (h *Handler) listEventSourceMappings(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	out := make([]eventSourceMappingJSON, 0, len(infos))
+	// Apply the EventSourceArn filter first, then sort by UUID so Marker
+	// offsets stay stable across paginated calls.
+	filtered := make([]sdrv.EventSourceMappingInfo, 0, len(infos))
 
 	for i := range infos {
 		if eventSourceArn != "" && infos[i].EventSourceArn != eventSourceArn {
 			continue
 		}
 
-		out = append(out, toESMJSON(&infos[i]))
+		filtered = append(filtered, infos[i])
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{"EventSourceMappings": out})
+	sort.Slice(filtered, func(i, j int) bool { return filtered[i].UUID < filtered[j].UUID })
+
+	start, end, nextMarker, truncated := pageWindow(len(filtered), r.URL.Query())
+
+	out := make([]eventSourceMappingJSON, 0, end-start)
+	for i := start; i < end; i++ {
+		out = append(out, toESMJSON(&filtered[i]))
+	}
+
+	body := map[string]any{"EventSourceMappings": out}
+	if truncated {
+		body["NextMarker"] = nextMarker
+	}
+
+	writeJSON(w, http.StatusOK, body)
 }

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -590,10 +590,18 @@ func (h *Handler) serveVersions(w http.ResponseWriter, r *http.Request, name str
 
 		awsCfg := h.awsFnConfig(r.Context(), name)
 
-		out := listVersionsResponse{Versions: make([]functionConfiguration, 0, len(vers))}
-		for i := range vers {
+		// Sort by version so Marker offsets stay stable across paginated calls
+		// (ListVersions returns versions in publish order, but page deterministically).
+		sort.Slice(vers, func(i, j int) bool { return vers[i].Version < vers[j].Version })
+
+		start, end, nextMarker, _ := pageWindow(len(vers), r.URL.Query())
+
+		out := listVersionsResponse{Versions: make([]functionConfiguration, 0, end-start)}
+		for i := start; i < end; i++ {
 			out.Versions = append(out.Versions, toVersionConfiguration(info, &vers[i], awsCfg))
 		}
+
+		out.NextMarker = nextMarker
 
 		writeJSON(w, http.StatusOK, out)
 	default:
@@ -629,10 +637,17 @@ func (h *Handler) serveAliases(w http.ResponseWriter, r *http.Request, name stri
 			return
 		}
 
-		out := listAliasesResponse{Aliases: make([]aliasResponse, 0, len(aliases))}
-		for i := range aliases {
+		// Sort by name so Marker offsets stay stable across paginated calls.
+		sort.Slice(aliases, func(i, j int) bool { return aliases[i].Name < aliases[j].Name })
+
+		start, end, nextMarker, _ := pageWindow(len(aliases), r.URL.Query())
+
+		out := listAliasesResponse{Aliases: make([]aliasResponse, 0, end-start)}
+		for i := start; i < end; i++ {
 			out.Aliases = append(out.Aliases, toAliasResponse(&aliases[i]))
 		}
+
+		out.NextMarker = nextMarker
 
 		writeJSON(w, http.StatusOK, out)
 	default:

--- a/server/aws/lambda/layers.go
+++ b/server/aws/lambda/layers.go
@@ -2,6 +2,7 @@ package lambda
 
 import (
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -218,8 +219,13 @@ func (h *Handler) listLayers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items := make([]layersListItem, 0, len(layers))
-	for i := range layers {
+	// Sort by name so Marker offsets stay stable across paginated calls.
+	sort.Slice(layers, func(i, j int) bool { return layers[i].Name < layers[j].Name })
+
+	start, end, nextMarker, truncated := pageWindow(len(layers), r.URL.Query())
+
+	items := make([]layersListItem, 0, end-start)
+	for i := start; i < end; i++ {
 		items = append(items, layersListItem{
 			LayerName:             layers[i].Name,
 			LayerArn:              layerARN(&layers[i]),
@@ -227,5 +233,10 @@ func (h *Handler) listLayers(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{"Layers": items})
+	body := map[string]any{"Layers": items}
+	if truncated {
+		body["NextMarker"] = nextMarker
+	}
+
+	writeJSON(w, http.StatusOK, body)
 }

--- a/server/aws/lambda/pagination_sdk_test.go
+++ b/server/aws/lambda/pagination_sdk_test.go
@@ -1,0 +1,248 @@
+package lambda_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+)
+
+// TestSDKListVersionsByFunctionPagination walks ListVersionsByFunction across
+// pages: two publishes plus $LATEST give three versions, so MaxItems=2 yields a
+// full page with a marker then a final page without one, each version once.
+func TestSDKListVersionsByFunctionPagination(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "vfn")
+
+	for range 2 {
+		if _, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
+			FunctionName: aws.String("vfn"),
+		}); err != nil {
+			t.Fatalf("PublishVersion: %v", err)
+		}
+	}
+
+	page1, err := client.ListVersionsByFunction(ctx, &awslambda.ListVersionsByFunctionInput{
+		FunctionName: aws.String("vfn"), MaxItems: aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("ListVersionsByFunction page1: %v", err)
+	}
+
+	if len(page1.Versions) != 2 || aws.ToString(page1.NextMarker) == "" {
+		t.Fatalf("page1 = %d versions marker=%q, want 2 with marker", len(page1.Versions), aws.ToString(page1.NextMarker))
+	}
+
+	page2, err := client.ListVersionsByFunction(ctx, &awslambda.ListVersionsByFunctionInput{
+		FunctionName: aws.String("vfn"), MaxItems: aws.Int32(2), Marker: page1.NextMarker,
+	})
+	if err != nil {
+		t.Fatalf("ListVersionsByFunction page2: %v", err)
+	}
+
+	if len(page2.Versions) != 1 || aws.ToString(page2.NextMarker) != "" {
+		t.Fatalf("page2 = %d versions marker=%q, want 1 no marker", len(page2.Versions), aws.ToString(page2.NextMarker))
+	}
+
+	seen := map[string]bool{}
+	for _, v := range append(page1.Versions, page2.Versions...) {
+		ver := aws.ToString(v.Version)
+		if seen[ver] {
+			t.Fatalf("version %q returned twice across pages", ver)
+		}
+
+		seen[ver] = true
+	}
+
+	if len(seen) != 3 {
+		t.Fatalf("walked %d unique versions, want 3", len(seen))
+	}
+
+	// A single unpaged call returns every version and no marker.
+	all, err := client.ListVersionsByFunction(ctx, &awslambda.ListVersionsByFunctionInput{
+		FunctionName: aws.String("vfn"),
+	})
+	if err != nil {
+		t.Fatalf("ListVersionsByFunction all: %v", err)
+	}
+
+	if len(all.Versions) != 3 || aws.ToString(all.NextMarker) != "" {
+		t.Fatalf("single page = %d versions marker=%q, want 3 no marker", len(all.Versions), aws.ToString(all.NextMarker))
+	}
+}
+
+// TestSDKListAliasesPagination walks ListAliases across pages over three aliases.
+func TestSDKListAliasesPagination(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "afn")
+
+	for _, name := range []string{"a1", "a2", "a3"} {
+		if _, err := client.CreateAlias(ctx, &awslambda.CreateAliasInput{
+			FunctionName: aws.String("afn"), Name: aws.String(name), FunctionVersion: aws.String("$LATEST"),
+		}); err != nil {
+			t.Fatalf("CreateAlias(%s): %v", name, err)
+		}
+	}
+
+	page1, err := client.ListAliases(ctx, &awslambda.ListAliasesInput{
+		FunctionName: aws.String("afn"), MaxItems: aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("ListAliases page1: %v", err)
+	}
+
+	if len(page1.Aliases) != 2 || aws.ToString(page1.NextMarker) == "" {
+		t.Fatalf("page1 = %d aliases marker=%q, want 2 with marker", len(page1.Aliases), aws.ToString(page1.NextMarker))
+	}
+
+	page2, err := client.ListAliases(ctx, &awslambda.ListAliasesInput{
+		FunctionName: aws.String("afn"), MaxItems: aws.Int32(2), Marker: page1.NextMarker,
+	})
+	if err != nil {
+		t.Fatalf("ListAliases page2: %v", err)
+	}
+
+	if len(page2.Aliases) != 1 || aws.ToString(page2.NextMarker) != "" {
+		t.Fatalf("page2 = %d aliases marker=%q, want 1 no marker", len(page2.Aliases), aws.ToString(page2.NextMarker))
+	}
+
+	seen := map[string]bool{}
+	for _, a := range append(page1.Aliases, page2.Aliases...) {
+		seen[aws.ToString(a.Name)] = true
+	}
+
+	if len(seen) != 3 {
+		t.Fatalf("walked %d unique aliases, want 3", len(seen))
+	}
+
+	all, err := client.ListAliases(ctx, &awslambda.ListAliasesInput{FunctionName: aws.String("afn")})
+	if err != nil {
+		t.Fatalf("ListAliases all: %v", err)
+	}
+
+	if len(all.Aliases) != 3 || aws.ToString(all.NextMarker) != "" {
+		t.Fatalf("single page = %d aliases marker=%q, want 3 no marker", len(all.Aliases), aws.ToString(all.NextMarker))
+	}
+}
+
+// TestSDKListEventSourceMappingsPagination walks ListEventSourceMappings across
+// pages over three mappings.
+func TestSDKListEventSourceMappingsPagination(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "efn")
+
+	for _, arn := range []string{
+		"arn:aws:sqs:us-east-1:000000000000:q1",
+		"arn:aws:sqs:us-east-1:000000000000:q2",
+		"arn:aws:sqs:us-east-1:000000000000:q3",
+	} {
+		if _, err := client.CreateEventSourceMapping(ctx, &awslambda.CreateEventSourceMappingInput{
+			FunctionName: aws.String("efn"), EventSourceArn: aws.String(arn),
+		}); err != nil {
+			t.Fatalf("CreateEventSourceMapping(%s): %v", arn, err)
+		}
+	}
+
+	page1, err := client.ListEventSourceMappings(ctx, &awslambda.ListEventSourceMappingsInput{
+		FunctionName: aws.String("efn"), MaxItems: aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("ListEventSourceMappings page1: %v", err)
+	}
+
+	if len(page1.EventSourceMappings) != 2 || aws.ToString(page1.NextMarker) == "" {
+		t.Fatalf("page1 = %d mappings marker=%q, want 2 with marker",
+			len(page1.EventSourceMappings), aws.ToString(page1.NextMarker))
+	}
+
+	page2, err := client.ListEventSourceMappings(ctx, &awslambda.ListEventSourceMappingsInput{
+		FunctionName: aws.String("efn"), MaxItems: aws.Int32(2), Marker: page1.NextMarker,
+	})
+	if err != nil {
+		t.Fatalf("ListEventSourceMappings page2: %v", err)
+	}
+
+	if len(page2.EventSourceMappings) != 1 || aws.ToString(page2.NextMarker) != "" {
+		t.Fatalf("page2 = %d mappings marker=%q, want 1 no marker",
+			len(page2.EventSourceMappings), aws.ToString(page2.NextMarker))
+	}
+
+	seen := map[string]bool{}
+	for _, m := range append(page1.EventSourceMappings, page2.EventSourceMappings...) {
+		seen[aws.ToString(m.UUID)] = true
+	}
+
+	if len(seen) != 3 {
+		t.Fatalf("walked %d unique mappings, want 3", len(seen))
+	}
+
+	all, err := client.ListEventSourceMappings(ctx, &awslambda.ListEventSourceMappingsInput{
+		FunctionName: aws.String("efn"),
+	})
+	if err != nil {
+		t.Fatalf("ListEventSourceMappings all: %v", err)
+	}
+
+	if len(all.EventSourceMappings) != 3 || aws.ToString(all.NextMarker) != "" {
+		t.Fatalf("single page = %d mappings marker=%q, want 3 no marker",
+			len(all.EventSourceMappings), aws.ToString(all.NextMarker))
+	}
+}
+
+// TestSDKListLayersPagination walks ListLayers across pages over three layers.
+func TestSDKListLayersPagination(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"layer1", "layer2", "layer3"} {
+		if _, err := client.PublishLayerVersion(ctx, &awslambda.PublishLayerVersionInput{
+			LayerName: aws.String(name),
+			Content:   &lambdatypes.LayerVersionContentInput{ZipFile: []byte("z-" + name)},
+		}); err != nil {
+			t.Fatalf("PublishLayerVersion(%s): %v", name, err)
+		}
+	}
+
+	page1, err := client.ListLayers(ctx, &awslambda.ListLayersInput{MaxItems: aws.Int32(2)})
+	if err != nil {
+		t.Fatalf("ListLayers page1: %v", err)
+	}
+
+	if len(page1.Layers) != 2 || aws.ToString(page1.NextMarker) == "" {
+		t.Fatalf("page1 = %d layers marker=%q, want 2 with marker", len(page1.Layers), aws.ToString(page1.NextMarker))
+	}
+
+	page2, err := client.ListLayers(ctx, &awslambda.ListLayersInput{
+		MaxItems: aws.Int32(2), Marker: page1.NextMarker,
+	})
+	if err != nil {
+		t.Fatalf("ListLayers page2: %v", err)
+	}
+
+	if len(page2.Layers) != 1 || aws.ToString(page2.NextMarker) != "" {
+		t.Fatalf("page2 = %d layers marker=%q, want 1 no marker", len(page2.Layers), aws.ToString(page2.NextMarker))
+	}
+
+	seen := map[string]bool{}
+	for _, l := range append(page1.Layers, page2.Layers...) {
+		seen[aws.ToString(l.LayerName)] = true
+	}
+
+	if len(seen) != 3 {
+		t.Fatalf("walked %d unique layers, want 3", len(seen))
+	}
+
+	all, err := client.ListLayers(ctx, &awslambda.ListLayersInput{})
+	if err != nil {
+		t.Fatalf("ListLayers all: %v", err)
+	}
+
+	if len(all.Layers) != 3 || aws.ToString(all.NextMarker) != "" {
+		t.Fatalf("single page = %d layers marker=%q, want 3 no marker", len(all.Layers), aws.ToString(all.NextMarker))
+	}
+}

--- a/server/aws/lambda/types.go
+++ b/server/aws/lambda/types.go
@@ -88,7 +88,8 @@ type publishVersionRequest struct {
 
 // listVersionsResponse is the ListVersionsByFunction envelope.
 type listVersionsResponse struct {
-	Versions []functionConfiguration `json:"Versions"`
+	Versions   []functionConfiguration `json:"Versions"`
+	NextMarker string                  `json:"NextMarker,omitempty"`
 }
 
 // aliasRequest is the body of Create/UpdateAlias.
@@ -117,7 +118,8 @@ type aliasRoutingConfig struct {
 
 // listAliasesResponse is the ListAliases envelope.
 type listAliasesResponse struct {
-	Aliases []aliasResponse `json:"Aliases"`
+	Aliases    []aliasResponse `json:"Aliases"`
+	NextMarker string          `json:"NextMarker,omitempty"`
 }
 
 // addPermissionRequest is the body of AddPermission (POST .../{name}/policy).

--- a/server/aws/sesv2/configsets.go
+++ b/server/aws/sesv2/configsets.go
@@ -122,5 +122,7 @@ func (h *Handler) listConfigSets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, listConfigurationSetsResponse{ConfigurationSets: names})
+	start, end, next := pageWindow(len(names), r.URL.Query())
+
+	writeJSON(w, listConfigurationSetsResponse{ConfigurationSets: names[start:end], NextToken: next})
 }

--- a/server/aws/sesv2/identities.go
+++ b/server/aws/sesv2/identities.go
@@ -249,6 +249,9 @@ func (h *Handler) listIdentities(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	start, end, next := pageWindow(len(ids), r.URL.Query())
+	ids = ids[start:end]
+
 	out := make([]identityInfoJSON, 0, len(ids))
 	for i := range ids {
 		out = append(out, identityInfoJSON{
@@ -259,7 +262,7 @@ func (h *Handler) listIdentities(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	writeJSON(w, listEmailIdentitiesResponse{EmailIdentities: out})
+	writeJSON(w, listEmailIdentitiesResponse{EmailIdentities: out, NextToken: next})
 }
 
 func (h *Handler) putIdentityDkim(w http.ResponseWriter, r *http.Request, name string) {

--- a/server/aws/sesv2/pagination.go
+++ b/server/aws/sesv2/pagination.go
@@ -1,0 +1,52 @@
+package sesv2
+
+import (
+	"encoding/base64"
+	"net/url"
+	"strconv"
+)
+
+// pageWindow computes the [start,end) slice bounds for a SESv2 list request from
+// its NextToken/PageSize query parameters and the total number of (already
+// sorted) items. NextToken is an opaque base64-encoded offset into the list; an
+// empty returned token means the last page was reached.
+func pageWindow(total int, q url.Values) (start, end int, next string) {
+	start = decodePageToken(q.Get("NextToken"))
+	if start > total {
+		start = total
+	}
+
+	end = total
+
+	if n, err := strconv.Atoi(q.Get("PageSize")); err == nil && n > 0 && start+n < total {
+		end = start + n
+		next = encodePageToken(end)
+	}
+
+	return start, end, next
+}
+
+// decodePageToken parses an opaque NextToken back into an offset. A missing or
+// malformed token resets to the start of the list.
+func decodePageToken(token string) int {
+	if token == "" {
+		return 0
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return 0
+	}
+
+	n, err := strconv.Atoi(string(raw))
+	if err != nil || n < 0 {
+		return 0
+	}
+
+	return n
+}
+
+// encodePageToken turns an offset into an opaque NextToken.
+func encodePageToken(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}

--- a/server/aws/sesv2/pagination_sdk_test.go
+++ b/server/aws/sesv2/pagination_sdk_test.go
@@ -1,0 +1,131 @@
+package sesv2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsses "github.com/aws/aws-sdk-go-v2/service/sesv2"
+)
+
+// TestSDKListEmailIdentitiesPagination walks ListEmailIdentities across pages
+// over three identities: PageSize=2 yields a full page with a token then a final
+// page without one, each identity once.
+func TestSDKListEmailIdentitiesPagination(t *testing.T) {
+	c := newSESClient(t)
+	ctx := context.Background()
+
+	for _, id := range []string{"a@example.com", "b@example.com", "c@example.com"} {
+		if _, err := c.CreateEmailIdentity(ctx, &awsses.CreateEmailIdentityInput{
+			EmailIdentity: aws.String(id),
+		}); err != nil {
+			t.Fatalf("CreateEmailIdentity(%s): %v", id, err)
+		}
+	}
+
+	page1, err := c.ListEmailIdentities(ctx, &awsses.ListEmailIdentitiesInput{PageSize: aws.Int32(2)})
+	if err != nil {
+		t.Fatalf("ListEmailIdentities page1: %v", err)
+	}
+
+	if len(page1.EmailIdentities) != 2 || aws.ToString(page1.NextToken) == "" {
+		t.Fatalf("page1 = %d identities token=%q, want 2 with token",
+			len(page1.EmailIdentities), aws.ToString(page1.NextToken))
+	}
+
+	page2, err := c.ListEmailIdentities(ctx, &awsses.ListEmailIdentitiesInput{
+		PageSize: aws.Int32(2), NextToken: page1.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("ListEmailIdentities page2: %v", err)
+	}
+
+	if len(page2.EmailIdentities) != 1 || aws.ToString(page2.NextToken) != "" {
+		t.Fatalf("page2 = %d identities token=%q, want 1 no token",
+			len(page2.EmailIdentities), aws.ToString(page2.NextToken))
+	}
+
+	seen := map[string]bool{}
+	for _, id := range append(page1.EmailIdentities, page2.EmailIdentities...) {
+		name := aws.ToString(id.IdentityName)
+		if seen[name] {
+			t.Fatalf("identity %q returned twice across pages", name)
+		}
+
+		seen[name] = true
+	}
+
+	if len(seen) != 3 {
+		t.Fatalf("walked %d unique identities, want 3", len(seen))
+	}
+
+	all, err := c.ListEmailIdentities(ctx, &awsses.ListEmailIdentitiesInput{})
+	if err != nil {
+		t.Fatalf("ListEmailIdentities all: %v", err)
+	}
+
+	if len(all.EmailIdentities) != 3 || aws.ToString(all.NextToken) != "" {
+		t.Fatalf("single page = %d identities token=%q, want 3 no token",
+			len(all.EmailIdentities), aws.ToString(all.NextToken))
+	}
+}
+
+// TestSDKListConfigurationSetsPagination walks ListConfigurationSets across pages
+// over three configuration sets.
+func TestSDKListConfigurationSetsPagination(t *testing.T) {
+	c := newSESClient(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"cs1", "cs2", "cs3"} {
+		if _, err := c.CreateConfigurationSet(ctx, &awsses.CreateConfigurationSetInput{
+			ConfigurationSetName: aws.String(name),
+		}); err != nil {
+			t.Fatalf("CreateConfigurationSet(%s): %v", name, err)
+		}
+	}
+
+	page1, err := c.ListConfigurationSets(ctx, &awsses.ListConfigurationSetsInput{PageSize: aws.Int32(2)})
+	if err != nil {
+		t.Fatalf("ListConfigurationSets page1: %v", err)
+	}
+
+	if len(page1.ConfigurationSets) != 2 || aws.ToString(page1.NextToken) == "" {
+		t.Fatalf("page1 = %d sets token=%q, want 2 with token",
+			len(page1.ConfigurationSets), aws.ToString(page1.NextToken))
+	}
+
+	page2, err := c.ListConfigurationSets(ctx, &awsses.ListConfigurationSetsInput{
+		PageSize: aws.Int32(2), NextToken: page1.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("ListConfigurationSets page2: %v", err)
+	}
+
+	if len(page2.ConfigurationSets) != 1 || aws.ToString(page2.NextToken) != "" {
+		t.Fatalf("page2 = %d sets token=%q, want 1 no token",
+			len(page2.ConfigurationSets), aws.ToString(page2.NextToken))
+	}
+
+	seen := map[string]bool{}
+	for _, name := range append(page1.ConfigurationSets, page2.ConfigurationSets...) {
+		if seen[name] {
+			t.Fatalf("config set %q returned twice across pages", name)
+		}
+
+		seen[name] = true
+	}
+
+	if len(seen) != 3 {
+		t.Fatalf("walked %d unique config sets, want 3", len(seen))
+	}
+
+	all, err := c.ListConfigurationSets(ctx, &awsses.ListConfigurationSetsInput{})
+	if err != nil {
+		t.Fatalf("ListConfigurationSets all: %v", err)
+	}
+
+	if len(all.ConfigurationSets) != 3 || aws.ToString(all.NextToken) != "" {
+		t.Fatalf("single page = %d sets token=%q, want 3 no token",
+			len(all.ConfigurationSets), aws.ToString(all.NextToken))
+	}
+}

--- a/server/aws/sfn/operations_extra.go
+++ b/server/aws/sfn/operations_extra.go
@@ -146,11 +146,14 @@ func (h *Handler) deleteActivity(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) listActivities(w http.ResponseWriter, r *http.Request) {
-	dispatch(h, w, r, func(h *Handler, ctx context.Context, _ *struct{}) (any, error) {
+	dispatch(h, w, r, func(h *Handler, ctx context.Context, req *listActivitiesRequest) (any, error) {
 		activities, err := h.sfn.ListActivities(ctx)
 		if err != nil {
 			return nil, err
 		}
+
+		start, end, next := pageWindow(len(activities), req.NextToken, req.MaxResults)
+		activities = activities[start:end]
 
 		items := make([]activityListItem, 0, len(activities))
 
@@ -159,7 +162,7 @@ func (h *Handler) listActivities(w http.ResponseWriter, r *http.Request) {
 			items = append(items, activityListItem{ActivityArn: a.ARN, Name: a.Name, CreationDate: epoch(a.CreationDate)})
 		}
 
-		return listActivitiesResponse{Activities: items}, nil
+		return listActivitiesResponse{Activities: items, NextToken: next}, nil
 	})
 }
 

--- a/server/aws/sfn/pagination_sdk_test.go
+++ b/server/aws/sfn/pagination_sdk_test.go
@@ -1,0 +1,69 @@
+package sfn_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssfn "github.com/aws/aws-sdk-go-v2/service/sfn"
+)
+
+// TestSDKListActivitiesPagination walks ListActivities across pages over three
+// activities: maxResults=2 yields a full page with a token then a final page
+// without one, each activity ARN once.
+func TestSDKListActivitiesPagination(t *testing.T) {
+	client := newSFNClient(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"act1", "act2", "act3"} {
+		if _, err := client.CreateActivity(ctx, &awssfn.CreateActivityInput{Name: aws.String(name)}); err != nil {
+			t.Fatalf("CreateActivity(%s): %v", name, err)
+		}
+	}
+
+	page1, err := client.ListActivities(ctx, &awssfn.ListActivitiesInput{MaxResults: 2})
+	if err != nil {
+		t.Fatalf("ListActivities page1: %v", err)
+	}
+
+	if len(page1.Activities) != 2 || aws.ToString(page1.NextToken) == "" {
+		t.Fatalf("page1 = %d activities token=%q, want 2 with token",
+			len(page1.Activities), aws.ToString(page1.NextToken))
+	}
+
+	page2, err := client.ListActivities(ctx, &awssfn.ListActivitiesInput{
+		MaxResults: 2, NextToken: page1.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("ListActivities page2: %v", err)
+	}
+
+	if len(page2.Activities) != 1 || aws.ToString(page2.NextToken) != "" {
+		t.Fatalf("page2 = %d activities token=%q, want 1 no token",
+			len(page2.Activities), aws.ToString(page2.NextToken))
+	}
+
+	seen := map[string]bool{}
+	for _, a := range append(page1.Activities, page2.Activities...) {
+		arn := aws.ToString(a.ActivityArn)
+		if seen[arn] {
+			t.Fatalf("activity %q returned twice across pages", arn)
+		}
+
+		seen[arn] = true
+	}
+
+	if len(seen) != 3 {
+		t.Fatalf("walked %d unique activities, want 3", len(seen))
+	}
+
+	all, err := client.ListActivities(ctx, &awssfn.ListActivitiesInput{})
+	if err != nil {
+		t.Fatalf("ListActivities all: %v", err)
+	}
+
+	if len(all.Activities) != 3 || aws.ToString(all.NextToken) != "" {
+		t.Fatalf("single page = %d activities token=%q, want 3 no token",
+			len(all.Activities), aws.ToString(all.NextToken))
+	}
+}

--- a/server/aws/sfn/types.go
+++ b/server/aws/sfn/types.go
@@ -138,6 +138,11 @@ type listStateMachinesRequest struct {
 	NextToken  string `json:"nextToken"`
 }
 
+type listActivitiesRequest struct {
+	MaxResults int32  `json:"maxResults"`
+	NextToken  string `json:"nextToken"`
+}
+
 type getExecutionHistoryRequest struct {
 	ExecutionArn string `json:"executionArn"`
 	ReverseOrder bool   `json:"reverseOrder"`

--- a/server/aws/sns/operations.go
+++ b/server/aws/sns/operations.go
@@ -406,10 +406,17 @@ func (h *Handler) listSubscriptionsByTopic(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Sort by subscription ARN so NextToken offsets stay stable across pages.
+	members := subscriptionMembers(info.ResourceID, subs)
+	sort.Slice(members, func(i, j int) bool { return members[i].SubscriptionArn < members[j].SubscriptionArn })
+
+	start, end, next := pageWindow(len(members), r.Form.Get("NextToken"))
+
 	awsquery.WriteXMLResponse(w, listSubscriptionsByTopicResponse{
 		Xmlns: Namespace,
 		Result: listSubscriptionsByTopicResult{
-			Subscriptions: subscriptionsList{Members: subscriptionMembers(info.ResourceID, subs)},
+			Subscriptions: subscriptionsList{Members: members[start:end]},
+			NextToken:     next,
 		},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})

--- a/server/aws/sns/pagination_sdk_test.go
+++ b/server/aws/sns/pagination_sdk_test.go
@@ -1,0 +1,95 @@
+package sns_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+)
+
+// TestSDKListSubscriptionsByTopicPagination walks ListSubscriptionsByTopic across
+// pages. SNS returns a fixed 100 per page, so 101 subscriptions yield a full page
+// with a token then a final page of one without one, each subscription once.
+func TestSDKListSubscriptionsByTopicPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	topic, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("paged")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	const total = 101
+	for i := range total {
+		if _, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+			TopicArn:              topic.TopicArn,
+			Protocol:              aws.String("email"),
+			Endpoint:              aws.String(fmt.Sprintf("u%d@example.com", i)),
+			ReturnSubscriptionArn: true,
+		}); err != nil {
+			t.Fatalf("Subscribe %d: %v", i, err)
+		}
+	}
+
+	page1, err := client.ListSubscriptionsByTopic(ctx, &awssns.ListSubscriptionsByTopicInput{
+		TopicArn: topic.TopicArn,
+	})
+	if err != nil {
+		t.Fatalf("ListSubscriptionsByTopic page1: %v", err)
+	}
+
+	if len(page1.Subscriptions) != 100 || aws.ToString(page1.NextToken) == "" {
+		t.Fatalf("page1 = %d subs token=%q, want 100 with token", len(page1.Subscriptions), aws.ToString(page1.NextToken))
+	}
+
+	page2, err := client.ListSubscriptionsByTopic(ctx, &awssns.ListSubscriptionsByTopicInput{
+		TopicArn: topic.TopicArn, NextToken: page1.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("ListSubscriptionsByTopic page2: %v", err)
+	}
+
+	if len(page2.Subscriptions) != 1 || aws.ToString(page2.NextToken) != "" {
+		t.Fatalf("page2 = %d subs token=%q, want 1 no token", len(page2.Subscriptions), aws.ToString(page2.NextToken))
+	}
+
+	seen := map[string]bool{}
+	for _, s := range append(page1.Subscriptions, page2.Subscriptions...) {
+		arn := aws.ToString(s.SubscriptionArn)
+		if seen[arn] {
+			t.Fatalf("subscription %q returned twice across pages", arn)
+		}
+
+		seen[arn] = true
+	}
+
+	if len(seen) != total {
+		t.Fatalf("walked %d unique subscriptions, want %d", len(seen), total)
+	}
+
+	// A topic with a single page of subscriptions returns no token.
+	small, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("small")})
+	if err != nil {
+		t.Fatalf("CreateTopic small: %v", err)
+	}
+
+	if _, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn: small.TopicArn, Protocol: aws.String("email"),
+		Endpoint: aws.String("one@example.com"), ReturnSubscriptionArn: true,
+	}); err != nil {
+		t.Fatalf("Subscribe small: %v", err)
+	}
+
+	one, err := client.ListSubscriptionsByTopic(ctx, &awssns.ListSubscriptionsByTopicInput{
+		TopicArn: small.TopicArn,
+	})
+	if err != nil {
+		t.Fatalf("ListSubscriptionsByTopic small: %v", err)
+	}
+
+	if len(one.Subscriptions) != 1 || aws.ToString(one.NextToken) != "" {
+		t.Fatalf("single page = %d subs token=%q, want 1 no token", len(one.Subscriptions), aws.ToString(one.NextToken))
+	}
+}

--- a/server/aws/sns/types.go
+++ b/server/aws/sns/types.go
@@ -166,6 +166,7 @@ type listSubscriptionsResponse struct {
 
 type listSubscriptionsByTopicResult struct {
 	Subscriptions subscriptionsList `xml:"Subscriptions"`
+	NextToken     string            `xml:"NextToken,omitempty"`
 }
 
 type listSubscriptionsByTopicResponse struct {

--- a/server/aws/sqs/handler.go
+++ b/server/aws/sqs/handler.go
@@ -461,7 +461,9 @@ func (h *Handler) listDeadLetterSourceQueues(w http.ResponseWriter, r *http.Requ
 	}
 
 	var req struct {
-		QueueURL string `json:"QueueUrl"`
+		QueueURL   string `json:"QueueUrl"`
+		MaxResults int    `json:"MaxResults"`
+		NextToken  string `json:"NextToken"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -478,7 +480,16 @@ func (h *Handler) listDeadLetterSourceQueues(w http.ResponseWriter, r *http.Requ
 		sources = []string{}
 	}
 
-	wire.WriteJSON(w, map[string]any{"queueUrls": sources})
+	sort.Strings(sources)
+
+	page, next := paginateURLs(sources, req.MaxResults, req.NextToken)
+
+	resp := map[string]any{"queueUrls": page}
+	if next != "" {
+		resp["NextToken"] = next
+	}
+
+	wire.WriteJSON(w, resp)
 }
 
 func (h *Handler) sendMessageBatch(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/sqs/pagination_sdk_test.go
+++ b/server/aws/sqs/pagination_sdk_test.go
@@ -1,0 +1,89 @@
+package sqs_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+)
+
+// TestSDKListDeadLetterSourceQueuesPagination walks ListDeadLetterSourceQueues
+// across pages: three source queues redrive to one DLQ, so MaxResults=2 yields a
+// full page with a token then a final page without one, each source URL once.
+func TestSDKListDeadLetterSourceQueuesPagination(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	dlq, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("dlq")})
+	if err != nil {
+		t.Fatalf("create dlq: %v", err)
+	}
+
+	dlqAttrs, err := client.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       dlq.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameQueueArn},
+	})
+	if err != nil {
+		t.Fatalf("get dlq arn: %v", err)
+	}
+
+	redrive := fmt.Sprintf(`{"deadLetterTargetArn":%q,"maxReceiveCount":2}`, dlqAttrs.Attributes["QueueArn"])
+
+	for _, name := range []string{"src1", "src2", "src3"} {
+		if _, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{
+			QueueName:  aws.String(name),
+			Attributes: map[string]string{"RedrivePolicy": redrive},
+		}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	page1, err := client.ListDeadLetterSourceQueues(ctx, &awssqs.ListDeadLetterSourceQueuesInput{
+		QueueUrl: dlq.QueueUrl, MaxResults: aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("ListDeadLetterSourceQueues page1: %v", err)
+	}
+
+	if len(page1.QueueUrls) != 2 || aws.ToString(page1.NextToken) == "" {
+		t.Fatalf("page1 = %d urls token=%q, want 2 with token", len(page1.QueueUrls), aws.ToString(page1.NextToken))
+	}
+
+	page2, err := client.ListDeadLetterSourceQueues(ctx, &awssqs.ListDeadLetterSourceQueuesInput{
+		QueueUrl: dlq.QueueUrl, MaxResults: aws.Int32(2), NextToken: page1.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("ListDeadLetterSourceQueues page2: %v", err)
+	}
+
+	if len(page2.QueueUrls) != 1 || aws.ToString(page2.NextToken) != "" {
+		t.Fatalf("page2 = %d urls token=%q, want 1 no token", len(page2.QueueUrls), aws.ToString(page2.NextToken))
+	}
+
+	seen := map[string]bool{}
+	for _, u := range append(page1.QueueUrls, page2.QueueUrls...) {
+		if seen[u] {
+			t.Fatalf("source url %q returned twice across pages", u)
+		}
+
+		seen[u] = true
+	}
+
+	if len(seen) != 3 {
+		t.Fatalf("walked %d unique source urls, want 3", len(seen))
+	}
+
+	all, err := client.ListDeadLetterSourceQueues(ctx, &awssqs.ListDeadLetterSourceQueuesInput{
+		QueueUrl: dlq.QueueUrl,
+	})
+	if err != nil {
+		t.Fatalf("ListDeadLetterSourceQueues all: %v", err)
+	}
+
+	if len(all.QueueUrls) != 3 || aws.ToString(all.NextToken) != "" {
+		t.Fatalf("single page = %d urls token=%q, want 3 no token", len(all.QueueUrls), aws.ToString(all.NextToken))
+	}
+}


### PR DESCRIPTION
## Summary

Eleven AWS "list" operations across the messaging/serverless services accepted the caller's pagination inputs but ignored them: they returned every item in one response and never emitted a next-page token. SDK paginators therefore looped forever or silently saw the whole set as a single page. This wires up real pagination for each, mirroring the already-correct sibling handler in the same package (so the token field name matches each API exactly).

## Operations fixed

| Service | Operation | Token / page-size fields |
|---|---|---|
| Lambda | ListVersionsByFunction, ListAliases, ListEventSourceMappings, ListLayers | Marker / MaxItems |
| SQS | ListDeadLetterSourceQueues | NextToken / MaxResults |
| SNS | ListSubscriptionsByTopic | NextToken (fixed 100/page) |
| EventBridge | ListEventBuses, ListTargetsByRule | NextToken / Limit |
| Step Functions | ListActivities | nextToken / maxResults |
| SESv2 | ListEmailIdentities, ListConfigurationSets | NextToken / PageSize |

## How

- Each op stable-sorts its source before offset/value-cursor windowing, decodes the inbound token + page size, emits the token only when the result is truncated, and preserves any existing filter (NamePrefix, EventSourceArn, RedrivePolicy source set).
- Handlers reuse each package's existing paginate helper rather than copying logic:
  - Lambda → `pageWindow` (+ `NextMarker` on the version/alias/ESM/layer envelopes)
  - SQS → `paginateURLs`
  - SNS → `pageWindow`
  - EventBridge → `paginateRules`, refactored to a generic value-cursor helper `paginateByCursor` shared by rules/buses/targets
  - Step Functions → `pageWindow` (the request was typed `*struct{}`, which dropped nextToken/maxResults; it now decodes into a real struct)
  - SESv2 had no paginator, so a small `pageWindow` helper was added and used by both ops
- Invalid tokens reset to the start of the list, matching each package's sibling decode behavior.

## Tests

Real aws-sdk-go-v2 round-trip tests per package (hand-rolled style): each op creates more than one page and asserts the walk covers every item exactly once and terminates, and that a single page returns no token.
