### PR TITLE
fix(pagination): pace DynamoDB ListTagsOfResource and EFS Describe* in the handler

### DIFF
--- a/server/aws/dynamodb/list_tags_pagination_sdk_test.go
+++ b/server/aws/dynamodb/list_tags_pagination_sdk_test.go
@@ -1,0 +1,70 @@
+// list_tags_pagination_sdk_test.go — real aws-sdk-go-v2 journeys for
+// ListTagsOfResource pagination: a resource's tags (well under the 50-tag cap)
+// return in a single page with no NextToken, and a malformed NextToken is
+// rejected with a ValidationException.
+package dynamodb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDDBListTagsSinglePageNoToken(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "tagged", "pk", "")
+
+	desc, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("tagged")})
+	require.NoError(t, err)
+	arn := aws.ToString(desc.Table.TableArn)
+
+	_, err = client.TagResource(ctx, &dynamodb.TagResourceInput{
+		ResourceArn: aws.String(arn),
+		Tags: []ddbtypes.Tag{
+			{Key: aws.String("env"), Value: aws.String("prod")},
+			{Key: aws.String("team"), Value: aws.String("core")},
+			{Key: aws.String("cost"), Value: aws.String("42")},
+		},
+	})
+	require.NoError(t, err)
+
+	out, err := client.ListTagsOfResource(ctx, &dynamodb.ListTagsOfResourceInput{ResourceArn: aws.String(arn)})
+	require.NoError(t, err)
+	assert.Len(t, out.Tags, 3)
+	assert.Nil(t, out.NextToken, "a sub-cap tag set must not emit a NextToken")
+
+	got := map[string]string{}
+	for _, tg := range out.Tags {
+		got[aws.ToString(tg.Key)] = aws.ToString(tg.Value)
+	}
+
+	assert.Equal(t, map[string]string{"env": "prod", "team": "core", "cost": "42"}, got)
+}
+
+func TestDDBListTagsInvalidNextTokenRejected(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "tagged2", "pk", "")
+
+	desc, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("tagged2")})
+	require.NoError(t, err)
+
+	_, err = client.ListTagsOfResource(ctx, &dynamodb.ListTagsOfResourceInput{
+		ResourceArn: desc.Table.TableArn,
+		NextToken:   aws.String("!!not-base64!!"),
+	})
+	require.Error(t, err)
+
+	var apiErr smithy.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, "ValidationException", apiErr.ErrorCode())
+}

--- a/server/aws/dynamodb/list_tags_pagination_test.go
+++ b/server/aws/dynamodb/list_tags_pagination_test.go
@@ -1,0 +1,67 @@
+// list_tags_pagination_test.go — unit coverage for the ListTagsOfResource
+// pagination plumbing. DynamoDB caps a resource at 50 tags, so a real response
+// fits one page; these tests drive pageTags with a deliberately small page size
+// to prove the offset-token cursor walks a stable-sorted order exactly once
+// (no duplicate, no skip), terminates, and rejects a malformed token.
+package dynamodb
+
+import "testing"
+
+func TestPageTagsWalksAllPagesStable(t *testing.T) {
+	// Deliberately unsorted so the result order cannot depend on input order.
+	tags := []tagJSON{
+		{Key: "e", Value: "5"}, {Key: "a", Value: "1"}, {Key: "d", Value: "4"},
+		{Key: "b", Value: "2"}, {Key: "c", Value: "3"},
+	}
+
+	const pageSize = 2
+
+	var (
+		order []string
+		token string
+		pages int
+	)
+
+	for {
+		page, err := pageTags(tags, token, pageSize)
+		if err != nil {
+			t.Fatalf("pageTags: %v", err)
+		}
+
+		if len(page.Items) > pageSize {
+			t.Fatalf("page has %d items, want <= %d", len(page.Items), pageSize)
+		}
+
+		for _, tg := range page.Items {
+			order = append(order, tg.Key)
+		}
+
+		pages++
+		if page.NextPageToken == "" {
+			break
+		}
+
+		token = page.NextPageToken
+
+		if pages > len(tags) {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+
+	want := []string{"a", "b", "c", "d", "e"}
+	if len(order) != len(want) {
+		t.Fatalf("walked %d keys, want %d (%v)", len(order), len(want), order)
+	}
+
+	for i, k := range want {
+		if order[i] != k {
+			t.Fatalf("key at %d = %q, want %q (order %v)", i, order[i], k, order)
+		}
+	}
+}
+
+func TestPageTagsInvalidTokenErrors(t *testing.T) {
+	if _, err := pageTags([]tagJSON{{Key: "a"}}, "!!not-base64!!", listTagsPageSize); err == nil {
+		t.Fatal("want error for malformed token, got nil")
+	}
+}

--- a/server/aws/dynamodb/tags.go
+++ b/server/aws/dynamodb/tags.go
@@ -4,12 +4,27 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/server/wire"
 )
 
 type tagJSON struct {
 	Key   string `json:"Key"`
 	Value string `json:"Value"`
+}
+
+// listTagsPageSize caps the tags returned per ListTagsOfResource page. DynamoDB
+// allows at most 50 tags per resource, so a real response fits in one page and
+// emits no NextToken; the token plumbing still pages correctly with a smaller
+// size.
+const listTagsPageSize = 50
+
+// pageTags stable-sorts tags by key and slices the page named by token. A
+// malformed token is surfaced as an error the caller maps to a
+// ValidationException.
+func pageTags(tags []tagJSON, token string, size int) (pagination.Page[tagJSON], error) {
+	return pagination.PaginateSorted(tags,
+		func(a, b tagJSON) bool { return a.Key < b.Key }, token, size)
 }
 
 // tableFromARN resolves a DynamoDB ResourceArn ("arn:aws:dynamodb:<region>:
@@ -91,6 +106,7 @@ func (h *Handler) untagResource(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) listTagsOfResource(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		ResourceArn string `json:"ResourceArn"`
+		NextToken   string `json:"NextToken"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -108,5 +124,21 @@ func (h *Handler) listTagsOfResource(w http.ResponseWriter, r *http.Request) {
 		out = append(out, tagJSON{Key: k, Value: v})
 	}
 
-	wire.WriteJSON(w, map[string]any{"Tags": out})
+	page, perr := pageTags(out, req.NextToken, listTagsPageSize)
+	if perr != nil {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", "Invalid NextToken")
+		return
+	}
+
+	items := page.Items
+	if items == nil {
+		items = []tagJSON{}
+	}
+
+	resp := map[string]any{"Tags": items}
+	if page.NextPageToken != "" {
+		resp["NextToken"] = page.NextPageToken
+	}
+
+	wire.WriteJSON(w, resp)
 }

--- a/server/aws/efs/errors.go
+++ b/server/aws/efs/errors.go
@@ -25,10 +25,17 @@ type errorBody struct {
 	FileSystemID string `json:"FileSystemId,omitempty"`
 }
 
-// writeError writes a restJson1 error response. EFS error bodies carry both
-// ErrorCode and Message; the header selects the typed exception.
-func writeError(w http.ResponseWriter, status int, errType, msg string) {
-	writeErrorBody(w, status, errType, errorBody{Type: errType, ErrorCode: errType, Message: msg})
+// genericErrorType is the X-Amzn-Errortype EFS uses for protocol-level errors
+// (bad path, method, JSON body, pagination token) that carry no per-resource
+// typed exception.
+const genericErrorType = "BadRequest"
+
+// writeError writes a restJson1 error response for a protocol-level fault. EFS
+// error bodies carry both ErrorCode and Message; the header selects the typed
+// exception (always BadRequest here).
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeErrorBody(w, status, genericErrorType,
+		errorBody{Type: genericErrorType, ErrorCode: genericErrorType, Message: msg})
 }
 
 // writeErrorBody writes a restJson1 error response from a fully-built body,
@@ -102,11 +109,11 @@ func writeErr(w http.ResponseWriter, err error) {
 }
 
 func notFound(w http.ResponseWriter, path string) {
-	writeError(w, http.StatusNotFound, "BadRequest", "unsupported path: "+path)
+	writeError(w, http.StatusNotFound, "unsupported path: "+path)
 }
 
 func methodNotAllowed(w http.ResponseWriter) {
-	writeError(w, http.StatusMethodNotAllowed, "BadRequest", "method not allowed")
+	writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 }
 
 // decodeJSON decodes the request body into v. An empty body is treated as an
@@ -119,7 +126,7 @@ func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 			return true
 		}
 
-		writeError(w, http.StatusBadRequest, "BadRequest", "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 
 		return false
 	}

--- a/server/aws/efs/file_systems.go
+++ b/server/aws/efs/file_systems.go
@@ -139,17 +139,15 @@ func (h *Handler) describeFileSystems(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
 	systems, err := h.efs.DescribeFileSystems(r.Context(), q.Get("FileSystemId"), q.Get("CreationToken"))
-	if err != nil {
-		writeErr(w, err)
-		return
-	}
 
-	out := make([]fileSystemJSON, 0, len(systems))
-	for i := range systems {
-		out = append(out, fileSystemToWire(&systems[i]))
-	}
+	respondPaged(w, systems, err, lessFileSystem,
+		q.Get("Marker"), parseMax(q.Get("MaxItems"), defaultPageSize), fileSystemToWire, buildFileSystems)
+}
 
-	writeJSON(w, describeFileSystemsResponse{FileSystems: out})
+func lessFileSystem(a, b *driver.FileSystem) bool { return a.FileSystemID < b.FileSystemID }
+
+func buildFileSystems(out []fileSystemJSON, next string) any {
+	return describeFileSystemsResponse{FileSystems: out, NextMarker: next}
 }
 
 func (h *Handler) updateFileSystem(w http.ResponseWriter, r *http.Request, id string) {

--- a/server/aws/efs/mount_targets.go
+++ b/server/aws/efs/mount_targets.go
@@ -223,17 +223,15 @@ func (h *Handler) describeMountTargets(w http.ResponseWriter, r *http.Request) {
 
 	mts, err := h.efs.DescribeMountTargets(r.Context(),
 		q.Get("FileSystemId"), q.Get("MountTargetId"), q.Get("AccessPointId"))
-	if err != nil {
-		writeErr(w, err)
-		return
-	}
 
-	out := make([]mountTargetJSON, 0, len(mts))
-	for i := range mts {
-		out = append(out, mountTargetToWire(&mts[i]))
-	}
+	respondPaged(w, mts, err, lessMountTarget,
+		q.Get("Marker"), parseMax(q.Get("MaxItems"), defaultPageSize), mountTargetToWire, buildMountTargets)
+}
 
-	writeJSON(w, describeMountTargetsResponse{MountTargets: out})
+func lessMountTarget(a, b *driver.MountTarget) bool { return a.MountTargetID < b.MountTargetID }
+
+func buildMountTargets(out []mountTargetJSON, next string) any {
+	return describeMountTargetsResponse{MountTargets: out, NextMarker: next}
 }
 
 func (h *Handler) deleteMountTarget(w http.ResponseWriter, r *http.Request, id string) {
@@ -317,17 +315,15 @@ func (h *Handler) describeAccessPoints(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
 	aps, err := h.efs.DescribeAccessPoints(r.Context(), q.Get("FileSystemId"), q.Get("AccessPointId"))
-	if err != nil {
-		writeErr(w, err)
-		return
-	}
 
-	out := make([]accessPointJSON, 0, len(aps))
-	for i := range aps {
-		out = append(out, accessPointToWire(&aps[i]))
-	}
+	respondPaged(w, aps, err, lessAccessPoint,
+		q.Get("NextToken"), parseMax(q.Get("MaxResults"), defaultPageSize), accessPointToWire, buildAccessPoints)
+}
 
-	writeJSON(w, describeAccessPointsResponse{AccessPoints: out})
+func lessAccessPoint(a, b *driver.AccessPoint) bool { return a.AccessPointID < b.AccessPointID }
+
+func buildAccessPoints(out []accessPointJSON, next string) any {
+	return describeAccessPointsResponse{AccessPoints: out, NextToken: next}
 }
 
 func (h *Handler) deleteAccessPoint(w http.ResponseWriter, r *http.Request, id string) {

--- a/server/aws/efs/pagination.go
+++ b/server/aws/efs/pagination.go
@@ -1,0 +1,61 @@
+package efs
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
+)
+
+// defaultPageSize is the page size EFS applies when MaxItems/MaxResults is
+// absent or non-positive on a Describe request.
+const defaultPageSize = 100
+
+// parseMax reads a positive page-size query value (MaxItems/MaxResults),
+// falling back to def when the value is missing or not a positive integer.
+func parseMax(raw string, def int) int {
+	if raw == "" {
+		return def
+	}
+
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return def
+	}
+
+	return n
+}
+
+// respondPaged renders a paginated EFS Describe response. When listErr is nil it
+// stable-sorts items by less, slices the page named by token, maps each element
+// to its wire shape with toWire, and writes the JSON built by build. A driver
+// error is surfaced via writeErr; a malformed token is an EFS BadRequest. In
+// either error case no success response is written.
+func respondPaged[T, W any](
+	w http.ResponseWriter, items []T, listErr error, less func(a, b *T) bool, token string, maxItems int,
+	toWire func(*T) W, build func(out []W, next string) any,
+) {
+	if listErr != nil {
+		writeErr(w, listErr)
+		return
+	}
+
+	// Stable-sort (via element pointers, so large records are not copied per
+	// comparison) before offset-paging: an unsorted slice would let the same
+	// offset duplicate or skip a record across page boundaries.
+	sort.SliceStable(items, func(i, j int) bool { return less(&items[i], &items[j]) })
+
+	page, err := pagination.Paginate(items, token, maxItems)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid pagination token")
+		return
+	}
+
+	out := make([]W, 0, len(page.Items))
+	for i := range page.Items {
+		out = append(out, toWire(&page.Items[i]))
+	}
+
+	writeJSON(w, build(out, page.NextPageToken))
+}

--- a/server/aws/efs/pagination_sdk_test.go
+++ b/server/aws/efs/pagination_sdk_test.go
@@ -1,0 +1,235 @@
+// pagination_sdk_test.go — real aws-sdk-go-v2 journeys asserting the EFS
+// Describe* endpoints paginate: MaxItems/MaxResults caps the page, the
+// Marker/NextToken cursor walks a stable order so the SDK paginator visits
+// every resource exactly once (no duplicate, no skip) and terminates, a single
+// page under the cap emits no cursor, and a malformed cursor is a BadRequest.
+package efs_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsefs "github.com/aws/aws-sdk-go-v2/service/efs"
+	"github.com/aws/smithy-go"
+)
+
+const paginationPageSize = 2
+
+// assertBadRequest fails unless err is an EFS BadRequest API error.
+func assertBadRequest(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("want BadRequest, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "BadRequest" {
+		t.Fatalf("want BadRequest, got %T: %v", err, err)
+	}
+}
+
+func TestSDKDescribeFileSystemsPaginatorWalksAll(t *testing.T) {
+	ctx := context.Background()
+	c := newEFSClient(t)
+
+	want := map[string]bool{}
+
+	for _, tok := range []string{"fs-a", "fs-b", "fs-c", "fs-d", "fs-e"} {
+		fs, err := c.CreateFileSystem(ctx, &awsefs.CreateFileSystemInput{CreationToken: aws.String(tok)})
+		if err != nil {
+			t.Fatalf("CreateFileSystem %s: %v", tok, err)
+		}
+
+		want[aws.ToString(fs.FileSystemId)] = true
+	}
+
+	seen := map[string]int{}
+
+	p := awsefs.NewDescribeFileSystemsPaginator(c, &awsefs.DescribeFileSystemsInput{},
+		func(o *awsefs.DescribeFileSystemsPaginatorOptions) { o.Limit = paginationPageSize })
+	for p.HasMorePages() {
+		out, err := p.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		if len(out.FileSystems) > paginationPageSize {
+			t.Fatalf("page has %d items, want <= %d", len(out.FileSystems), paginationPageSize)
+		}
+
+		for i := range out.FileSystems {
+			seen[aws.ToString(out.FileSystems[i].FileSystemId)]++
+		}
+	}
+
+	assertSeenEachOnce(t, want, seen)
+}
+
+func TestSDKDescribeFileSystemsSinglePageNoCursor(t *testing.T) {
+	ctx := context.Background()
+	c := newEFSClient(t)
+
+	if _, err := c.CreateFileSystem(ctx, &awsefs.CreateFileSystemInput{CreationToken: aws.String("only")}); err != nil {
+		t.Fatalf("CreateFileSystem: %v", err)
+	}
+
+	out, err := c.DescribeFileSystems(ctx, &awsefs.DescribeFileSystemsInput{})
+	if err != nil {
+		t.Fatalf("DescribeFileSystems: %v", err)
+	}
+
+	if len(out.FileSystems) != 1 {
+		t.Fatalf("want 1 file system, got %d", len(out.FileSystems))
+	}
+
+	if aws.ToString(out.NextMarker) != "" {
+		t.Fatalf("NextMarker = %q, want empty on a single page", aws.ToString(out.NextMarker))
+	}
+}
+
+func TestSDKDescribeFileSystemsInvalidMarker(t *testing.T) {
+	ctx := context.Background()
+	c := newEFSClient(t)
+
+	_, err := c.DescribeFileSystems(ctx, &awsefs.DescribeFileSystemsInput{Marker: aws.String("!!not-base64!!")})
+	assertBadRequest(t, err)
+}
+
+func TestSDKDescribeMountTargetsPaginatorWalksAll(t *testing.T) {
+	ctx := context.Background()
+	c := newEFSClient(t)
+
+	fs, err := c.CreateFileSystem(ctx, &awsefs.CreateFileSystemInput{CreationToken: aws.String("mt-fs")})
+	if err != nil {
+		t.Fatalf("CreateFileSystem: %v", err)
+	}
+
+	fsID := aws.ToString(fs.FileSystemId)
+	want := map[string]bool{}
+
+	for i := 0; i < 5; i++ {
+		mt, err := c.CreateMountTarget(ctx, &awsefs.CreateMountTargetInput{
+			FileSystemId: aws.String(fsID),
+			SubnetId:     aws.String(fmt.Sprintf("subnet-0abcd1234ef56780%d", i)),
+		})
+		if err != nil {
+			t.Fatalf("CreateMountTarget %d: %v", i, err)
+		}
+
+		want[aws.ToString(mt.MountTargetId)] = true
+	}
+
+	seen := map[string]int{}
+
+	p := awsefs.NewDescribeMountTargetsPaginator(c,
+		&awsefs.DescribeMountTargetsInput{FileSystemId: aws.String(fsID)},
+		func(o *awsefs.DescribeMountTargetsPaginatorOptions) { o.Limit = paginationPageSize })
+	for p.HasMorePages() {
+		out, err := p.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		if len(out.MountTargets) > paginationPageSize {
+			t.Fatalf("page has %d items, want <= %d", len(out.MountTargets), paginationPageSize)
+		}
+
+		for i := range out.MountTargets {
+			seen[aws.ToString(out.MountTargets[i].MountTargetId)]++
+		}
+	}
+
+	assertSeenEachOnce(t, want, seen)
+}
+
+func TestSDKDescribeMountTargetsInvalidMarker(t *testing.T) {
+	ctx := context.Background()
+	c := newEFSClient(t)
+
+	fs, err := c.CreateFileSystem(ctx, &awsefs.CreateFileSystemInput{CreationToken: aws.String("mt-bad")})
+	if err != nil {
+		t.Fatalf("CreateFileSystem: %v", err)
+	}
+
+	_, err = c.DescribeMountTargets(ctx, &awsefs.DescribeMountTargetsInput{
+		FileSystemId: fs.FileSystemId, Marker: aws.String("%%bad%%"),
+	})
+	assertBadRequest(t, err)
+}
+
+func TestSDKDescribeAccessPointsPaginatorWalksAll(t *testing.T) {
+	ctx := context.Background()
+	c := newEFSClient(t)
+
+	fs, err := c.CreateFileSystem(ctx, &awsefs.CreateFileSystemInput{CreationToken: aws.String("ap-fs")})
+	if err != nil {
+		t.Fatalf("CreateFileSystem: %v", err)
+	}
+
+	fsID := aws.ToString(fs.FileSystemId)
+	want := map[string]bool{}
+
+	for i := 0; i < 5; i++ {
+		ap, err := c.CreateAccessPoint(ctx, &awsefs.CreateAccessPointInput{FileSystemId: aws.String(fsID)})
+		if err != nil {
+			t.Fatalf("CreateAccessPoint %d: %v", i, err)
+		}
+
+		want[aws.ToString(ap.AccessPointId)] = true
+	}
+
+	seen := map[string]int{}
+
+	p := awsefs.NewDescribeAccessPointsPaginator(c,
+		&awsefs.DescribeAccessPointsInput{FileSystemId: aws.String(fsID)},
+		func(o *awsefs.DescribeAccessPointsPaginatorOptions) { o.Limit = paginationPageSize })
+	for p.HasMorePages() {
+		out, err := p.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		if len(out.AccessPoints) > paginationPageSize {
+			t.Fatalf("page has %d items, want <= %d", len(out.AccessPoints), paginationPageSize)
+		}
+
+		for i := range out.AccessPoints {
+			seen[aws.ToString(out.AccessPoints[i].AccessPointId)]++
+		}
+	}
+
+	assertSeenEachOnce(t, want, seen)
+}
+
+func TestSDKDescribeAccessPointsInvalidNextToken(t *testing.T) {
+	ctx := context.Background()
+	c := newEFSClient(t)
+
+	_, err := c.DescribeAccessPoints(ctx, &awsefs.DescribeAccessPointsInput{NextToken: aws.String("!!bad!!")})
+	assertBadRequest(t, err)
+}
+
+// assertSeenEachOnce checks the paginator visited exactly the wanted ids, each
+// exactly once — proving stable-sorted offset paging neither duplicates nor
+// skips an item across page boundaries.
+func assertSeenEachOnce(t *testing.T, want map[string]bool, seen map[string]int) {
+	t.Helper()
+
+	if len(seen) != len(want) {
+		t.Fatalf("saw %d distinct ids, want %d (%v)", len(seen), len(want), seen)
+	}
+
+	for id := range want {
+		switch seen[id] {
+		case 1:
+		case 0:
+			t.Fatalf("id %s was skipped", id)
+		default:
+			t.Fatalf("id %s seen %d times (duplicated)", id, seen[id])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Four AWS list endpoints ignored their page-size/token inputs: the provider returned the full slice and the **server handler** wrote it all back, never emitting a continuation cursor. This pages each one in the handler via the repo `internal/pagination` helper over a **stable-sorted** slice, so a real SDK paginator walks every record exactly once and terminates.

Fixed endpoints:

- **DynamoDB `ListTagsOfResource`** — decode `NextToken`, sort tags by key, emit `NextToken` when truncated. DynamoDB caps a resource at 50 tags so a real response is a single page (matching AWS); the plumbing is exercised with a small page size. Invalid token -> `ValidationException`.
- **EFS `DescribeFileSystems`** — `Marker`/`MaxItems` -> `NextMarker`, sorted by `FileSystemId`.
- **EFS `DescribeMountTargets`** — `Marker`/`MaxItems` -> `NextMarker`, sorted by `MountTargetId`, existing FileSystemId/AccessPointId filter preserved.
- **EFS `DescribeAccessPoints`** — `MaxResults`/`NextToken` -> `NextToken`, sorted by `AccessPointId`.

A malformed EFS cursor returns the real `BadRequest`. Stable sort precedes offset paging so a page boundary never duplicates or skips a record. Providers were not changed.

## Why

Offset-token pagination over an unsorted, map-iteration-ordered slice would duplicate or skip records across page boundaries; the handlers also never returned a cursor, so paginators saw everything as one page.

## Tests (real aws-sdk-go-v2)

- EFS: three SDK paginator journeys (page size 2, 5 items) assert every record is visited exactly once and the walk terminates; single page emits no cursor; invalid Marker/NextToken -> BadRequest.
- DynamoDB: SDK single-page-no-token + invalid-NextToken -> ValidationException, plus a unit test driving the pagination plumbing with a small page size to prove the stable-sorted cursor walks all pages once.

## Gates

build, vet, `go test` (server+provider+pagination), `-race` on EFS, gofmt, golangci-lint (0 new), go generate (no diff), compatgen (no docs/compat diff) — all green.