### PR TITLE
fix(pagination): reject negative-offset page tokens instead of panicking

### DIFF
--- a/internal/pagination/pagination.go
+++ b/internal/pagination/pagination.go
@@ -26,6 +26,12 @@ func Paginate[T any](items []T, pageToken string, maxResults int) (Page[T], erro
 	}
 
 	offset := token.Offset
+	// Defensive: DecodeToken already rejects negative offsets, but guard the
+	// slice bound directly so no token input can panic here.
+	if offset < 0 {
+		return Page[T]{}, ErrInvalidToken
+	}
+
 	if offset >= len(items) {
 		return Page[T]{Items: nil, HasMore: false}, nil
 	}

--- a/internal/pagination/pagination_test.go
+++ b/internal/pagination/pagination_test.go
@@ -1,6 +1,7 @@
 package pagination
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -157,6 +158,88 @@ func TestPaginate_OffsetBeyondItems(t *testing.T) {
 
 func TestPaginate_InvalidToken(t *testing.T) {
 	_, err := Paginate([]string{"a"}, "bad-token", 10)
+	assert.Error(t, err)
+}
+
+func TestDecodeToken_NegativeOffset(t *testing.T) {
+	// A well-formed token (valid base64 + valid JSON) carrying a negative
+	// offset must be rejected as invalid, not returned for use as a bound.
+	token := EncodeToken(-5)
+
+	_, err := DecodeToken(token)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidToken)
+}
+
+func TestPaginate_TokenInputsNeverPanic(t *testing.T) {
+	items := []string{"a", "b", "c", "d", "e"}
+
+	negativeToken := EncodeToken(-5)
+	// Hand-craft a base64+JSON token with an explicit negative offset, not via
+	// EncodeToken, to mirror a crafted/corrupted client token.
+	craftedNegative := base64.StdEncoding.EncodeToString([]byte(`{"offset":-1}`))
+	beyondLenToken := EncodeToken(100)
+	midListToken := EncodeToken(2)
+
+	tests := []struct {
+		name        string
+		token       string
+		wantErr     error
+		wantItems   []string
+		wantHasMore bool
+	}{
+		{
+			name:      "negative offset well-formed token is invalid",
+			token:     negativeToken,
+			wantErr:   ErrInvalidToken,
+			wantItems: nil,
+		},
+		{
+			name:      "crafted negative offset token is invalid",
+			token:     craftedNegative,
+			wantErr:   ErrInvalidToken,
+			wantItems: nil,
+		},
+		{
+			name:      "offset beyond len yields empty page no error",
+			token:     beyondLenToken,
+			wantItems: nil,
+		},
+		{
+			name:        "valid mid-list token returns correct page",
+			token:       midListToken,
+			wantItems:   []string{"c", "d"},
+			wantHasMore: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				page, err := Paginate(items, tc.token, 2)
+				if tc.wantErr != nil {
+					require.Error(t, err)
+					assert.ErrorIs(t, err, tc.wantErr)
+
+					return
+				}
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantItems, page.Items)
+				assert.Equal(t, tc.wantHasMore, page.HasMore)
+			})
+		})
+	}
+}
+
+func TestPaginate_MalformedTokenBehaviorUnchanged(t *testing.T) {
+	// The established contract for this helper: a non-base64 / non-JSON token
+	// returns an error (not a silent offset-0 restart). Keep it intact.
+	items := []string{"a", "b"}
+
+	_, err := Paginate(items, "!!!not-base64!!!", 10)
+	assert.Error(t, err)
+
+	_, err = Paginate(items, "aGVsbG8=", 10) // valid base64, not JSON
 	assert.Error(t, err)
 }
 

--- a/internal/pagination/token.go
+++ b/internal/pagination/token.go
@@ -4,7 +4,15 @@ package pagination
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 )
+
+// ErrInvalidToken indicates a page token that decoded successfully as
+// base64+JSON but carries a semantically invalid value (e.g. a negative
+// offset). Callers can map it to their API's invalid-token response
+// (InvalidParameterValue / InvalidNextTokenException / etc.) instead of
+// panicking on an out-of-range slice bound.
+var ErrInvalidToken = errors.New("pagination: invalid page token")
 
 // PageToken holds pagination state.
 type PageToken struct {
@@ -34,6 +42,12 @@ func DecodeToken(token string) (PageToken, error) {
 	var t PageToken
 	if err := json.Unmarshal(data, &t); err != nil {
 		return PageToken{}, err
+	}
+
+	// A negative offset is never a token we produced; treat it as invalid
+	// rather than letting it flow through to a slice bound (which panics).
+	if t.Offset < 0 {
+		return PageToken{}, ErrInvalidToken
 	}
 
 	return t, nil

--- a/server/aws/rds/describe_pagination_sdk_roundtrip_test.go
+++ b/server/aws/rds/describe_pagination_sdk_roundtrip_test.go
@@ -2,6 +2,7 @@ package rds_test
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"testing"
 
@@ -102,6 +103,24 @@ func TestSDKRDSDescribeDBClustersPagination(t *testing.T) {
 		Marker: aws.String("not-a-valid-marker"),
 	}); err == nil {
 		t.Fatal("invalid Marker accepted; want an error")
+	}
+}
+
+// TestSDKRDSDescribeNegativeOffsetMarker proves a well-formed Marker (valid
+// base64 + valid JSON) carrying a negative offset is rejected as
+// InvalidParameterValue rather than panicking on an out-of-range slice bound
+// (which surfaced as a connection reset to the SDK).
+func TestSDKRDSDescribeNegativeOffsetMarker(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	// {"offset":-5}: decodes cleanly as base64+JSON, but the offset is invalid.
+	negative := aws.String(base64.StdEncoding.EncodeToString([]byte(`{"offset":-5}`)))
+
+	if _, err := client.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		Marker: negative,
+	}); err == nil {
+		t.Fatal("DescribeDBInstances with a negative-offset Marker succeeded, want an error")
 	}
 }
 

--- a/server/aws/redshift/describe_pagination_sdk_roundtrip_test.go
+++ b/server/aws/redshift/describe_pagination_sdk_roundtrip_test.go
@@ -2,6 +2,7 @@ package redshift_test
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"testing"
 
@@ -306,6 +307,23 @@ func TestSDKRedshiftDescribeInvalidMarker(t *testing.T) {
 	if _, err := client.DescribeClusterSubnetGroups(ctx,
 		&awsredshift.DescribeClusterSubnetGroupsInput{Marker: bad}); err == nil {
 		t.Error("DescribeClusterSubnetGroups with an invalid Marker succeeded, want an error")
+	}
+}
+
+// TestSDKRedshiftDescribeNegativeOffsetMarker proves a well-formed Marker (valid
+// base64 + valid JSON) carrying a negative offset is rejected as invalid rather
+// than panicking on an out-of-range slice bound (which surfaced as a connection
+// reset to the SDK).
+func TestSDKRedshiftDescribeNegativeOffsetMarker(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	// {"offset":-5}: decodes cleanly as base64+JSON, but the offset is invalid.
+	negative := aws.String(base64.StdEncoding.EncodeToString([]byte(`{"offset":-5}`)))
+
+	if _, err := client.DescribeClusters(ctx,
+		&awsredshift.DescribeClustersInput{Marker: negative}); err == nil {
+		t.Error("DescribeClusters with a negative-offset Marker succeeded, want an error")
 	}
 }
 


### PR DESCRIPTION
## Summary

A well-formed continuation token (valid base64 + valid JSON) carrying a **negative** offset made the shared `internal/pagination.Paginate` helper panic with "slice bounds out of range". `net/http` recovers per-connection, so callers saw a connection reset instead of a proper error. Real AWS returns an invalid-token error.

This affects ~15 callers that route through this helper (RDS, Redshift, ACM, ECS, EKS, DynamoDB ListTagsOfResource, EFS, plus several GCP/Azure handlers).

## Root cause

`DecodeToken` accepted any integer offset. `Paginate` guarded `offset >= len(items)` but not `offset < 0`, so a negative offset slid past the guard straight into `items[offset:end]` and panicked.

## Fix

- Added an exported sentinel `pagination.ErrInvalidToken`.
- `DecodeToken` now rejects a decoded negative offset with `ErrInvalidToken` (a negative offset is never a token we produced).
- `Paginate` adds a defensive `offset < 0` guard at the slice site so no token input can panic there regardless of decode path.

The behavior is **consistent with the existing contract**: this helper already returns an error for malformed (non-base64 / non-JSON) tokens, and an empty page (no error) for offset-beyond-len. Negative offset now returns an error, matching the malformed-token path. Malformed and offset-beyond-len behavior are unchanged. No caller changes were needed — RDS and Redshift already map any pagination error to `InvalidParameterValue`.

## Tests

- Helper unit tests: negative offset (via `EncodeToken` and a hand-crafted `{"offset":-1}` token) rejected with `ErrInvalidToken`; offset-beyond-len still returns empty page; malformed token behavior unchanged; valid mid-list token returns the correct page; explicit `NotPanics` assertions.
- Caller-level SDK round-trip tests: RDS `DescribeDBInstances` and Redshift `DescribeClusters` with a well-formed negative-offset Marker return an error (mapped to `InvalidParameterValue`), not a connection reset. Existing normal-pagination round-trips continue to pass.