### PR TITLE
fix(aks): round-trip networkProfile and inline agentPool advanced fields

### DIFF
--- a/providers/azure/aks/aks.go
+++ b/providers/azure/aks/aks.go
@@ -37,10 +37,18 @@ const (
 	defaultPoolType      = "VirtualMachineScaleSets"
 	defaultNodeImage     = "AKSUbuntu-2204gen2containerd-202401.09.0"
 	poolPowerRunning     = "Running"
-	emulatorTenantID     = "11111111-1111-1111-1111-111111111111"
-	cpuMetricRunning     = 0.35
-	memMetricRunning     = 0.50
-	podMetricRunning     = 12.0
+	// Network-profile defaults the real AKS service synthesizes when a create
+	// omits properties.networkProfile entirely.
+	defaultNetworkPlugin   = "kubenet"
+	defaultServiceCidr     = "10.0.0.0/16"
+	defaultDNSServiceIP    = "10.0.0.10"
+	defaultPodCidr         = "10.244.0.0/16"
+	defaultLoadBalancerSKU = "standard"
+	defaultOutboundType    = "loadBalancer"
+	emulatorTenantID       = "11111111-1111-1111-1111-111111111111"
+	cpuMetricRunning       = 0.35
+	memMetricRunning       = 0.50
+	podMetricRunning       = 12.0
 )
 
 // ManagedCluster is the in-memory representation of an AKS cluster.
@@ -60,6 +68,11 @@ type ManagedCluster struct {
 	Tags           map[string]string
 	AgentPoolNames []string
 
+	// NetworkProfile echoes properties.networkProfile. When a create omits it,
+	// the mock stores the standard AKS defaults (see defaultNetworkProfile);
+	// otherwise it stores exactly the submitted values so a read round-trips.
+	NetworkProfile NetworkProfile
+
 	// EnableRBAC mirrors properties.enableRBAC; defaults to true, the AKS
 	// default when a create omits it.
 	EnableRBAC bool
@@ -72,6 +85,34 @@ type ManagedCluster struct {
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
+}
+
+// NetworkProfile captures the cluster network configuration echoed back on read.
+// A pointer to it on ClusterInput distinguishes "caller omitted networkProfile"
+// (nil → synthesize defaults) from "caller submitted it" (echo verbatim). Only
+// the sub-keys the emulator models live here; any sub-key a caller sets but the
+// emulator does not model still round-trips through the property overlay.
+type NetworkProfile struct {
+	NetworkPlugin   string
+	NetworkPolicy   string
+	ServiceCidr     string
+	DNSServiceIP    string
+	PodCidr         string
+	LoadBalancerSKU string
+	OutboundType    string
+}
+
+// defaultNetworkProfile returns the network-profile values the real AKS service
+// synthesizes when a create omits properties.networkProfile.
+func defaultNetworkProfile() NetworkProfile {
+	return NetworkProfile{
+		NetworkPlugin:   defaultNetworkPlugin,
+		ServiceCidr:     defaultServiceCidr,
+		DNSServiceIP:    defaultDNSServiceIP,
+		PodCidr:         defaultPodCidr,
+		LoadBalancerSKU: defaultLoadBalancerSKU,
+		OutboundType:    defaultOutboundType,
+	}
 }
 
 // AgentPool is a node pool attached to a managed cluster.
@@ -99,6 +140,16 @@ type AgentPool struct {
 	Type             string
 	PowerState       string
 	NodeImageVersion string
+	// Advanced pool fields Terraform's default_node_pool commonly submits. They
+	// are echoed exactly as submitted (nil/empty when omitted) so a read
+	// round-trips; the emulator synthesizes no defaults for them.
+	AvailabilityZones  []string
+	EnableAutoScaling  *bool
+	MinCount           *int32
+	MaxCount           *int32
+	VnetSubnetID       string
+	OSSKU              string
+	EnableNodePublicIP *bool
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
@@ -268,6 +319,10 @@ type ClusterInput struct {
 	// EnableRBAC mirrors properties.enableRBAC. Nil means "not submitted", which
 	// the mock resolves to the AKS default (true).
 	EnableRBAC *bool
+	// NetworkProfile mirrors properties.networkProfile. Nil means "not
+	// submitted", which the mock resolves to the AKS defaults; a non-nil value
+	// is echoed verbatim so a read round-trips the submitted configuration.
+	NetworkProfile *NetworkProfile
 	// AgentPools may be nil for an empty cluster; otherwise these are the
 	// pools shipped inline at create time (system pool typically).
 	AgentPools []AgentPoolInput
@@ -288,6 +343,15 @@ type AgentPoolInput struct {
 	// MaxPods is the submitted max-pods-per-node; 0 means "not submitted" and
 	// the mock applies the standard default.
 	MaxPods int32
+	// Advanced pool fields (autoscaler bounds, availability zones, subnet, OS
+	// SKU, public-IP flag) echoed verbatim; nil/empty when omitted.
+	AvailabilityZones  []string
+	EnableAutoScaling  *bool
+	MinCount           *int32
+	MaxCount           *int32
+	VnetSubnetID       string
+	OSSKU              string
+	EnableNodePublicIP *bool
 }
 
 // CreateOrUpdateCluster creates a new managed cluster or updates an existing
@@ -329,6 +393,7 @@ func (m *Mock) CreateOrUpdateCluster(_ context.Context, input ClusterInput) (*Ma
 	cluster.Tags = copyTags(input.Tags)
 	cluster.EnableRBAC = input.EnableRBAC == nil || *input.EnableRBAC
 	applyClusterIdentity(&cluster, input.IdentityType)
+	applyNetworkProfile(&cluster, input.NetworkProfile)
 	cluster.UpdatedAt = now
 
 	// Inline pools — replace what we have for this cluster.
@@ -371,6 +436,17 @@ func applyClusterIdentity(cluster *ManagedCluster, identityType string) {
 			"principal/cluster/" + cluster.ResourceGroup + "/" + cluster.Name)
 		cluster.TenantID = emulatorTenantID
 	}
+}
+
+// applyNetworkProfile stores the submitted network profile verbatim, or the
+// standard AKS defaults when the caller omitted properties.networkProfile.
+func applyNetworkProfile(cluster *ManagedCluster, np *NetworkProfile) {
+	if np == nil {
+		cluster.NetworkProfile = defaultNetworkProfile()
+		return
+	}
+
+	cluster.NetworkProfile = *np
 }
 
 // replaceInlinePools wipes any pre-existing pools for the cluster and re-adds
@@ -418,27 +494,54 @@ func buildAgentPool(rg, cluster, clusterVersion string, in AgentPoolInput, now t
 	}
 
 	return AgentPool{
-		Name:              in.Name,
-		ClusterName:       cluster,
-		ResourceGroup:     rg,
-		Count:             count,
-		VMSize:            defaultIfEmpty(in.VMSize, defaultVMSize),
-		OSDiskSizeGB:      disk,
-		OSType:            defaultIfEmpty(in.OSType, "Linux"),
-		Mode:              defaultIfEmpty(in.Mode, "User"),
-		OrchestratorVer:   defaultIfEmpty(in.OrchestratorVer, defaultIfEmpty(clusterVersion, defaultK8sVersion)),
-		ProvisioningState: "Succeeded",
-		ScaleSetPriority:  defaultIfEmpty(in.ScaleSetPriority, "Regular"),
-		NodeLabels:        copyLabels(in.NodeLabels),
-		NodeTaints:        copyTaints(in.NodeTaints),
-		MaxPods:           maxPods,
-		OSDiskType:        defaultOSDiskType,
-		Type:              defaultPoolType,
-		PowerState:        poolPowerRunning,
-		NodeImageVersion:  defaultNodeImage,
-		CreatedAt:         now,
-		UpdatedAt:         now,
+		Name:               in.Name,
+		ClusterName:        cluster,
+		ResourceGroup:      rg,
+		Count:              count,
+		VMSize:             defaultIfEmpty(in.VMSize, defaultVMSize),
+		OSDiskSizeGB:       disk,
+		OSType:             defaultIfEmpty(in.OSType, "Linux"),
+		Mode:               defaultIfEmpty(in.Mode, "User"),
+		OrchestratorVer:    defaultIfEmpty(in.OrchestratorVer, defaultIfEmpty(clusterVersion, defaultK8sVersion)),
+		ProvisioningState:  "Succeeded",
+		ScaleSetPriority:   defaultIfEmpty(in.ScaleSetPriority, "Regular"),
+		NodeLabels:         copyLabels(in.NodeLabels),
+		NodeTaints:         copyTaints(in.NodeTaints),
+		MaxPods:            maxPods,
+		OSDiskType:         defaultOSDiskType,
+		Type:               defaultPoolType,
+		PowerState:         poolPowerRunning,
+		NodeImageVersion:   defaultNodeImage,
+		AvailabilityZones:  copyTaints(in.AvailabilityZones),
+		EnableAutoScaling:  copyBoolPtr(in.EnableAutoScaling),
+		MinCount:           copyInt32Ptr(in.MinCount),
+		MaxCount:           copyInt32Ptr(in.MaxCount),
+		VnetSubnetID:       in.VnetSubnetID,
+		OSSKU:              in.OSSKU,
+		EnableNodePublicIP: copyBoolPtr(in.EnableNodePublicIP),
+		CreatedAt:          now,
+		UpdatedAt:          now,
 	}
+}
+
+func copyBoolPtr(p *bool) *bool {
+	if p == nil {
+		return nil
+	}
+
+	v := *p
+
+	return &v
+}
+
+func copyInt32Ptr(p *int32) *int32 {
+	if p == nil {
+		return nil
+	}
+
+	v := *p
+
+	return &v
 }
 
 func totalNodeCount(pools []AgentPoolInput) int32 {

--- a/server/azure/aks/operations.go
+++ b/server/azure/aks/operations.go
@@ -49,26 +49,63 @@ func buildClusterInput(body *armManagedCluster, rp *azurearm.ResourcePath) aks.C
 		in.DNSPrefix = body.Properties.DNSPrefix
 		in.NodeResourceGroup = body.Properties.NodeResourceGroup
 		in.EnableRBAC = body.Properties.EnableRBAC
-
-		for i := range body.Properties.AgentPoolProfiles {
-			p := &body.Properties.AgentPoolProfiles[i]
-			in.AgentPools = append(in.AgentPools, aks.AgentPoolInput{
-				Name:             p.Name,
-				Count:            p.Count,
-				VMSize:           p.VMSize,
-				OSDiskSizeGB:     p.OSDiskSizeGB,
-				OSType:           p.OSType,
-				Mode:             p.Mode,
-				OrchestratorVer:  p.OrchestratorVer,
-				ScaleSetPriority: p.ScaleSetPriority,
-				NodeLabels:       fromPtrTags(p.NodeLabels),
-				NodeTaints:       p.NodeTaints,
-				MaxPods:          p.MaxPods,
-			})
-		}
+		in.NetworkProfile = networkProfileInput(body.Properties.NetworkProfile)
+		in.AgentPools = inlineAgentPoolInputs(body.Properties.AgentPoolProfiles)
 	}
 
 	return in
+}
+
+// networkProfileInput maps the submitted ARM networkProfile onto the driver
+// input, or nil when the caller omitted it (so the backend synthesizes the AKS
+// defaults). Only the modeled sub-keys are carried; an unmodeled sub-key the
+// caller set still round-trips through the property overlay.
+func networkProfileInput(np *armNetworkProfile) *aks.NetworkProfile {
+	if np == nil {
+		return nil
+	}
+
+	return &aks.NetworkProfile{
+		NetworkPlugin:   np.NetworkPlugin,
+		NetworkPolicy:   np.NetworkPolicy,
+		ServiceCidr:     np.ServiceCidr,
+		DNSServiceIP:    np.DNSServiceIP,
+		PodCidr:         np.PodCidr,
+		LoadBalancerSKU: np.LoadBalancerSKU,
+		OutboundType:    np.OutboundType,
+	}
+}
+
+// inlineAgentPoolInputs maps the inline agentPoolProfiles submitted in a cluster
+// PUT onto driver inputs. It shares the advanced-field mapping with the
+// standalone agentPools path so both wire paths round-trip identically.
+func inlineAgentPoolInputs(profiles []armAgentPoolProfile) []aks.AgentPoolInput {
+	if len(profiles) == 0 {
+		return nil
+	}
+
+	out := make([]aks.AgentPoolInput, 0, len(profiles))
+
+	for i := range profiles {
+		p := &profiles[i]
+		in := aks.AgentPoolInput{
+			Name:             p.Name,
+			Count:            p.Count,
+			VMSize:           p.VMSize,
+			OSDiskSizeGB:     p.OSDiskSizeGB,
+			OSType:           p.OSType,
+			Mode:             p.Mode,
+			OrchestratorVer:  p.OrchestratorVer,
+			ScaleSetPriority: p.ScaleSetPriority,
+			NodeLabels:       fromPtrTags(p.NodeLabels),
+			NodeTaints:       p.NodeTaints,
+			MaxPods:          p.MaxPods,
+		}
+		p.armAgentPoolAdvanced.applyTo(&in)
+		out = append(out, in)
+	}
+
+	return out
 }
 
 func (h *Handler) getCluster(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
@@ -164,6 +201,7 @@ func (h *Handler) createOrUpdateAgentPool(w http.ResponseWriter, r *http.Request
 		in.NodeLabels = fromPtrTags(body.Properties.NodeLabels)
 		in.NodeTaints = body.Properties.NodeTaints
 		in.MaxPods = body.Properties.MaxPods
+		body.Properties.armAgentPoolAdvanced.applyTo(&in)
 	}
 
 	pool, err := h.be.CreateOrUpdateAgentPool(r.Context(), rp.ResourceGroup, rp.ResourceName, in)

--- a/server/azure/aks/sdk_terraform_drift_test.go
+++ b/server/azure/aks/sdk_terraform_drift_test.go
@@ -1,0 +1,277 @@
+package aks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
+)
+
+const testSubnetID = "/subscriptions/sub-1/resourceGroups/rg-1/providers/" +
+	"Microsoft.Network/virtualNetworks/vnet-1/subnets/nodes"
+
+// createDriftCluster PUTs a cluster and blocks until the LRO settles. Shared by
+// the Terraform-drift round-trip tests so each stays under the length limit.
+func createDriftCluster(t *testing.T, c *armcontainerservice.ManagedClustersClient, mc armcontainerservice.ManagedCluster) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	poller, err := c.BeginCreateOrUpdate(ctx, "rg-1", "k8s-1", mc, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+}
+
+// getClusterProps GETs the cluster and returns its non-nil properties.
+func getClusterProps(t *testing.T, c *armcontainerservice.ManagedClustersClient) *armcontainerservice.ManagedClusterProperties {
+	t.Helper()
+
+	got, err := c.Get(context.Background(), "rg-1", "k8s-1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Properties == nil {
+		t.Fatal("nil properties on GET")
+	}
+
+	return got.Properties
+}
+
+// TestSDKAKSNetworkProfileRoundTrips is B1: a submitted networkProfile is echoed
+// back verbatim on GET, instead of being replaced by fabricated defaults.
+func TestSDKAKSNetworkProfileRoundTrips(t *testing.T) {
+	clusters, _, _ := newSDKClients(t)
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			NetworkProfile: &armcontainerservice.NetworkProfile{
+				NetworkPlugin: to.Ptr(armcontainerservice.NetworkPluginAzure),
+				ServiceCidr:   to.Ptr("10.99.0.0/16"),
+				DNSServiceIP:  to.Ptr("10.99.0.10"),
+			},
+		},
+	})
+
+	np := getClusterProps(t, clusters).NetworkProfile
+	if np == nil {
+		t.Fatal("expected networkProfile on GET")
+	}
+
+	if np.NetworkPlugin == nil || *np.NetworkPlugin != armcontainerservice.NetworkPluginAzure {
+		t.Fatalf("networkPlugin: got %v, want azure", np.NetworkPlugin)
+	}
+
+	if np.ServiceCidr == nil || *np.ServiceCidr != "10.99.0.0/16" {
+		t.Fatalf("serviceCidr: got %v, want 10.99.0.0/16", np.ServiceCidr)
+	}
+
+	if np.DNSServiceIP == nil || *np.DNSServiceIP != "10.99.0.10" {
+		t.Fatalf("dnsServiceIP: got %v, want 10.99.0.10", np.DNSServiceIP)
+	}
+
+	// Sub-keys the caller never sent must not be fabricated.
+	if np.PodCidr != nil {
+		t.Fatalf("podCidr fabricated: %v", *np.PodCidr)
+	}
+}
+
+// TestSDKAKSNetworkProfileDefaultWhenOmitted is B1-default: omitting
+// networkProfile yields the real AKS defaults (kubenet / 10.0.0.0/16 / .10).
+func TestSDKAKSNetworkProfileDefaultWhenOmitted(t *testing.T) {
+	clusters, _, _ := newSDKClients(t)
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+	})
+
+	np := getClusterProps(t, clusters).NetworkProfile
+	if np == nil || np.NetworkPlugin == nil {
+		t.Fatal("expected default networkProfile with networkPlugin")
+	}
+
+	if *np.NetworkPlugin != armcontainerservice.NetworkPluginKubenet {
+		t.Fatalf("networkPlugin: got %v, want kubenet", *np.NetworkPlugin)
+	}
+
+	if np.ServiceCidr == nil || *np.ServiceCidr != "10.0.0.0/16" {
+		t.Fatalf("serviceCidr: got %v, want 10.0.0.0/16", np.ServiceCidr)
+	}
+
+	if np.DNSServiceIP == nil || *np.DNSServiceIP != "10.0.0.10" {
+		t.Fatalf("dnsServiceIP: got %v, want 10.0.0.10", np.DNSServiceIP)
+	}
+}
+
+// TestSDKAKSInlineAgentPoolAdvancedFields is B2: the advanced fields Terraform's
+// default_node_pool submits inline in the cluster PUT survive to GET.
+func TestSDKAKSInlineAgentPoolAdvancedFields(t *testing.T) {
+	clusters, _, _ := newSDKClients(t)
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			AgentPoolProfiles: []*armcontainerservice.ManagedClusterAgentPoolProfile{
+				{
+					Name:              to.Ptr("system"),
+					Count:             to.Ptr[int32](1),
+					VMSize:            to.Ptr("Standard_DS2_v2"),
+					Mode:              to.Ptr(armcontainerservice.AgentPoolModeSystem),
+					AvailabilityZones: []*string{to.Ptr("1"), to.Ptr("2"), to.Ptr("3")},
+					EnableAutoScaling: to.Ptr(true),
+					MinCount:          to.Ptr[int32](1),
+					MaxCount:          to.Ptr[int32](5),
+					VnetSubnetID:      to.Ptr(testSubnetID),
+					OSSKU:             to.Ptr(armcontainerservice.OSSKUAzureLinux),
+				},
+			},
+		},
+	})
+
+	pools := getClusterProps(t, clusters).AgentPoolProfiles
+	if len(pools) != 1 {
+		t.Fatalf("got %d pools, want 1", len(pools))
+	}
+
+	assertAdvancedProfile(t, pools[0])
+}
+
+// TestSDKAKSStandaloneAgentPoolAdvancedFields is the regression guard: the
+// standalone agentPools PUT→GET path still round-trips the same advanced fields.
+func TestSDKAKSStandaloneAgentPoolAdvancedFields(t *testing.T) {
+	clusters, poolsClient, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{Location: to.Ptr("eastus")})
+
+	poller, err := poolsClient.BeginCreateOrUpdate(ctx, "rg-1", "k8s-1", "userpool", armcontainerservice.AgentPool{
+		Properties: &armcontainerservice.ManagedClusterAgentPoolProfileProperties{
+			Count:             to.Ptr[int32](1),
+			VMSize:            to.Ptr("Standard_DS2_v2"),
+			Mode:              to.Ptr(armcontainerservice.AgentPoolModeUser),
+			AvailabilityZones: []*string{to.Ptr("1"), to.Ptr("2"), to.Ptr("3")},
+			EnableAutoScaling: to.Ptr(true),
+			MinCount:          to.Ptr[int32](1),
+			MaxCount:          to.Ptr[int32](5),
+			VnetSubnetID:      to.Ptr(testSubnetID),
+			OSSKU:             to.Ptr(armcontainerservice.OSSKUAzureLinux),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Pool BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Pool PollUntilDone: %v", err)
+	}
+
+	got, err := poolsClient.Get(ctx, "rg-1", "k8s-1", "userpool", nil)
+	if err != nil {
+		t.Fatalf("Pool Get: %v", err)
+	}
+
+	assertAdvancedPoolProps(t, got.Properties)
+}
+
+// TestSDKAKSServicePrincipalSecretStripped is the #715 regression: the write-only
+// servicePrincipalProfile.secret is never echoed, while clientId round-trips.
+func TestSDKAKSServicePrincipalSecretStripped(t *testing.T) {
+	clusters, _, _ := newSDKClients(t)
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			ServicePrincipalProfile: &armcontainerservice.ManagedClusterServicePrincipalProfile{
+				ClientID: to.Ptr("client-id-123"),
+				Secret:   to.Ptr("super-secret-value"),
+			},
+		},
+	})
+
+	spp := getClusterProps(t, clusters).ServicePrincipalProfile
+	if spp != nil && spp.Secret != nil {
+		t.Fatalf("GET leaked write-only servicePrincipalProfile.secret: %v", *spp.Secret)
+	}
+
+	if spp == nil || spp.ClientID == nil || *spp.ClientID != "client-id-123" {
+		t.Fatalf("clientId did not round-trip: %v", spp)
+	}
+}
+
+// assertAdvancedProfile checks the inline-profile advanced fields.
+func assertAdvancedProfile(t *testing.T, p *armcontainerservice.ManagedClusterAgentPoolProfile) {
+	t.Helper()
+
+	assertZones(t, p.AvailabilityZones)
+
+	if p.EnableAutoScaling == nil || !*p.EnableAutoScaling {
+		t.Fatalf("enableAutoScaling: got %v, want true", p.EnableAutoScaling)
+	}
+
+	assertBounds(t, p.MinCount, p.MaxCount)
+	assertSubnetAndSKU(t, p.VnetSubnetID, p.OSSKU)
+}
+
+// assertAdvancedPoolProps checks the standalone-pool advanced fields.
+func assertAdvancedPoolProps(t *testing.T, p *armcontainerservice.ManagedClusterAgentPoolProfileProperties) {
+	t.Helper()
+
+	if p == nil {
+		t.Fatal("nil pool properties")
+	}
+
+	assertZones(t, p.AvailabilityZones)
+
+	if p.EnableAutoScaling == nil || !*p.EnableAutoScaling {
+		t.Fatalf("enableAutoScaling: got %v, want true", p.EnableAutoScaling)
+	}
+
+	assertBounds(t, p.MinCount, p.MaxCount)
+	assertSubnetAndSKU(t, p.VnetSubnetID, p.OSSKU)
+}
+
+func assertZones(t *testing.T, zones []*string) {
+	t.Helper()
+
+	want := []string{"1", "2", "3"}
+	if len(zones) != len(want) {
+		t.Fatalf("availabilityZones: got %d, want %d", len(zones), len(want))
+	}
+
+	for i, z := range zones {
+		if z == nil || *z != want[i] {
+			t.Fatalf("availabilityZones[%d]: got %v, want %s", i, z, want[i])
+		}
+	}
+}
+
+func assertBounds(t *testing.T, minCount, maxCount *int32) {
+	t.Helper()
+
+	if minCount == nil || *minCount != 1 {
+		t.Fatalf("minCount: got %v, want 1", minCount)
+	}
+
+	if maxCount == nil || *maxCount != 5 {
+		t.Fatalf("maxCount: got %v, want 5", maxCount)
+	}
+}
+
+func assertSubnetAndSKU(t *testing.T, vnetSubnetID *string, osSKU *armcontainerservice.OSSKU) {
+	t.Helper()
+
+	if vnetSubnetID == nil || *vnetSubnetID != testSubnetID {
+		t.Fatalf("vnetSubnetID: got %v, want %s", vnetSubnetID, testSubnetID)
+	}
+
+	if osSKU == nil || *osSKU != armcontainerservice.OSSKUAzureLinux {
+		t.Fatalf("osSKU: got %v, want AzureLinux", osSKU)
+	}
+}

--- a/server/azure/aks/types.go
+++ b/server/azure/aks/types.go
@@ -62,6 +62,7 @@ type armPowerState struct {
 // armcontainerservice.NetworkProfile the emulator synthesizes as defaults.
 type armNetworkProfile struct {
 	NetworkPlugin   string `json:"networkPlugin,omitempty"`
+	NetworkPolicy   string `json:"networkPolicy,omitempty"`
 	LoadBalancerSKU string `json:"loadBalancerSku,omitempty"`
 	ServiceCidr     string `json:"serviceCidr,omitempty"`
 	DNSServiceIP    string `json:"dnsServiceIP,omitempty"`
@@ -86,6 +87,36 @@ type armAgentPoolProfile struct {
 	Type              string             `json:"type,omitempty"`
 	PowerState        *armPowerState     `json:"powerState,omitempty"`
 	NodeImageVersion  string             `json:"nodeImageVersion,omitempty"`
+	armAgentPoolAdvanced
+}
+
+// armAgentPoolAdvanced holds the optional node-pool fields Terraform's
+// default_node_pool commonly submits. Embedded in both the inline profile and
+// the standalone-pool shapes so both wire paths model them identically. Every
+// field is omitempty so a value absent on the request is absent on the
+// response — which keeps any unmodeled sibling sub-key round-tripping through
+// the property overlay.
+type armAgentPoolAdvanced struct {
+	AvailabilityZones  []string `json:"availabilityZones,omitempty"`
+	EnableAutoScaling  *bool    `json:"enableAutoScaling,omitempty"`
+	MinCount           *int32   `json:"minCount,omitempty"`
+	MaxCount           *int32   `json:"maxCount,omitempty"`
+	VnetSubnetID       string   `json:"vnetSubnetID,omitempty"`
+	OSSKU              string   `json:"osSKU,omitempty"`
+	EnableNodePublicIP *bool    `json:"enableNodePublicIP,omitempty"`
+}
+
+// applyTo copies the submitted advanced fields onto a driver AgentPoolInput.
+// Shared by the inline and standalone agent-pool wire paths so both behave
+// identically.
+func (a *armAgentPoolAdvanced) applyTo(in *aks.AgentPoolInput) {
+	in.AvailabilityZones = a.AvailabilityZones
+	in.EnableAutoScaling = a.EnableAutoScaling
+	in.MinCount = a.MinCount
+	in.MaxCount = a.MaxCount
+	in.VnetSubnetID = a.VnetSubnetID
+	in.OSSKU = a.OSSKU
+	in.EnableNodePublicIP = a.EnableNodePublicIP
 }
 
 // armAgentPool is the standalone (sub-resource) shape used by the
@@ -114,6 +145,7 @@ type armAgentPoolProperties struct {
 	Type              string             `json:"type,omitempty"`
 	PowerState        *armPowerState     `json:"powerState,omitempty"`
 	NodeImageVersion  string             `json:"nodeImageVersion,omitempty"`
+	armAgentPoolAdvanced
 }
 
 // armMaintenanceConfig is the wire shape for the maintenanceConfigurations
@@ -169,7 +201,7 @@ func toARMCluster(c *aks.ManagedCluster, pools []aks.AgentPool, subscription str
 			AgentPoolProfiles:        toAgentPoolProfiles(pools),
 			PowerState:               &armPowerState{Code: c.PowerState},
 			EnableRBAC:               &enableRBAC,
-			NetworkProfile:           defaultNetworkProfile(),
+			NetworkProfile:           toNetworkProfile(&c.NetworkProfile),
 		},
 	}
 
@@ -184,16 +216,34 @@ func toARMCluster(c *aks.ManagedCluster, pools []aks.AgentPool, subscription str
 	return out
 }
 
-// defaultNetworkProfile returns the standard AKS network-profile defaults the
-// real service synthesizes when a create omits networkProfile.
-func defaultNetworkProfile() *armNetworkProfile {
+// toNetworkProfile renders the stored network profile onto the ARM shape. The
+// values are whatever CreateOrUpdateCluster stored — the caller's submitted
+// values, or the AKS defaults when the caller omitted networkProfile. Every
+// field is omitempty, so a sub-key the caller never set is not emitted (and a
+// sub-key the emulator does not model still round-trips via the overlay).
+func toNetworkProfile(np *aks.NetworkProfile) *armNetworkProfile {
 	return &armNetworkProfile{
-		NetworkPlugin:   "kubenet",
-		LoadBalancerSKU: "standard",
-		ServiceCidr:     "10.0.0.0/16",
-		DNSServiceIP:    "10.0.0.10",
-		PodCidr:         "10.244.0.0/16",
-		OutboundType:    "loadBalancer",
+		NetworkPlugin:   np.NetworkPlugin,
+		NetworkPolicy:   np.NetworkPolicy,
+		LoadBalancerSKU: np.LoadBalancerSKU,
+		ServiceCidr:     np.ServiceCidr,
+		DNSServiceIP:    np.DNSServiceIP,
+		PodCidr:         np.PodCidr,
+		OutboundType:    np.OutboundType,
+	}
+}
+
+// toAgentPoolAdvanced renders the optional advanced pool fields onto the shared
+// embedded ARM shape used by both the inline and standalone pool responses.
+func toAgentPoolAdvanced(p *aks.AgentPool) armAgentPoolAdvanced {
+	return armAgentPoolAdvanced{
+		AvailabilityZones:  p.AvailabilityZones,
+		EnableAutoScaling:  p.EnableAutoScaling,
+		MinCount:           p.MinCount,
+		MaxCount:           p.MaxCount,
+		VnetSubnetID:       p.VnetSubnetID,
+		OSSKU:              p.OSSKU,
+		EnableNodePublicIP: p.EnableNodePublicIP,
 	}
 }
 
@@ -205,22 +255,23 @@ func toAgentPoolProfiles(pools []aks.AgentPool) []armAgentPoolProfile {
 	out := make([]armAgentPoolProfile, 0, len(pools))
 	for i := range pools {
 		out = append(out, armAgentPoolProfile{
-			Name:              pools[i].Name,
-			Count:             pools[i].Count,
-			VMSize:            pools[i].VMSize,
-			OSDiskSizeGB:      pools[i].OSDiskSizeGB,
-			OSType:            pools[i].OSType,
-			Mode:              pools[i].Mode,
-			OrchestratorVer:   pools[i].OrchestratorVer,
-			ScaleSetPriority:  pools[i].ScaleSetPriority,
-			NodeLabels:        toPtrTags(pools[i].NodeLabels),
-			NodeTaints:        pools[i].NodeTaints,
-			ProvisioningState: pools[i].ProvisioningState,
-			MaxPods:           pools[i].MaxPods,
-			OSDiskType:        pools[i].OSDiskType,
-			Type:              pools[i].Type,
-			PowerState:        &armPowerState{Code: pools[i].PowerState},
-			NodeImageVersion:  pools[i].NodeImageVersion,
+			Name:                 pools[i].Name,
+			Count:                pools[i].Count,
+			VMSize:               pools[i].VMSize,
+			OSDiskSizeGB:         pools[i].OSDiskSizeGB,
+			OSType:               pools[i].OSType,
+			Mode:                 pools[i].Mode,
+			OrchestratorVer:      pools[i].OrchestratorVer,
+			ScaleSetPriority:     pools[i].ScaleSetPriority,
+			NodeLabels:           toPtrTags(pools[i].NodeLabels),
+			NodeTaints:           pools[i].NodeTaints,
+			ProvisioningState:    pools[i].ProvisioningState,
+			MaxPods:              pools[i].MaxPods,
+			OSDiskType:           pools[i].OSDiskType,
+			Type:                 pools[i].Type,
+			PowerState:           &armPowerState{Code: pools[i].PowerState},
+			NodeImageVersion:     pools[i].NodeImageVersion,
+			armAgentPoolAdvanced: toAgentPoolAdvanced(&pools[i]),
 		})
 	}
 
@@ -235,21 +286,22 @@ func toARMAgentPool(p *aks.AgentPool, subscription string) armAgentPool {
 		Name: p.Name,
 		Type: resourceTypeAgentPool,
 		Properties: &armAgentPoolProperties{
-			Count:             p.Count,
-			VMSize:            p.VMSize,
-			OSDiskSizeGB:      p.OSDiskSizeGB,
-			OSType:            p.OSType,
-			Mode:              p.Mode,
-			OrchestratorVer:   p.OrchestratorVer,
-			ScaleSetPriority:  p.ScaleSetPriority,
-			NodeLabels:        toPtrTags(p.NodeLabels),
-			NodeTaints:        p.NodeTaints,
-			ProvisioningState: p.ProvisioningState,
-			MaxPods:           p.MaxPods,
-			OSDiskType:        p.OSDiskType,
-			Type:              p.Type,
-			PowerState:        &armPowerState{Code: p.PowerState},
-			NodeImageVersion:  p.NodeImageVersion,
+			Count:                p.Count,
+			VMSize:               p.VMSize,
+			OSDiskSizeGB:         p.OSDiskSizeGB,
+			OSType:               p.OSType,
+			Mode:                 p.Mode,
+			OrchestratorVer:      p.OrchestratorVer,
+			ScaleSetPriority:     p.ScaleSetPriority,
+			NodeLabels:           toPtrTags(p.NodeLabels),
+			NodeTaints:           p.NodeTaints,
+			ProvisioningState:    p.ProvisioningState,
+			MaxPods:              p.MaxPods,
+			OSDiskType:           p.OSDiskType,
+			Type:                 p.Type,
+			PowerState:           &armPowerState{Code: p.PowerState},
+			NodeImageVersion:     p.NodeImageVersion,
+			armAgentPoolAdvanced: toAgentPoolAdvanced(p),
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Fixes two HIGH Terraform-drift bugs in Azure AKS (`Microsoft.ContainerService/managedClusters`) where a submitted cluster PUT did not round-trip on GET.

Root cause (both bugs): the AKS handler is wrapped by `echoUnmodeledProperties`, which echoes any request `properties.*` subtree the handler does not model. But when the handler emitted a **partial hardcoded model** of a field, the overlay treated those keys as "modeled" and dropped the caller's real values. The fix fully models each field: parse the caller's value, echo it, synthesize a default only when omitted.

### 1. networkProfile fabricated / did not round-trip
`toARMCluster` emitted `defaultNetworkProfile()` unconditionally (hardcoded kubenet / 10.0.0.0/16 / 10.0.0.10), and `buildClusterInput` never read `body.Properties.NetworkProfile`. Now `networkProfile` (networkPlugin, networkPolicy, serviceCidr, dnsServiceIP, podCidr, loadBalancerSku, outboundType) is modeled on `ManagedCluster` + `ClusterInput`, parsed from the request, and echoed verbatim. The default block is synthesized only when the caller omits `networkProfile` entirely (real AKS defaults: kubenet / 10.0.0.0/16 / 10.0.0.10). Sub-keys the caller sets but we do not model are not fabricated, so they still round-trip through the overlay.

### 2. Inline agentPoolProfiles advanced fields dropped
Terraform submits `default_node_pool` inline in the cluster PUT, but `availabilityZones`, `enableAutoScaling`, `minCount`, `maxCount`, `vnetSubnetID`, `osSKU`, and `enableNodePublicIP` were dropped on GET. These are now modeled on a shared embedded `armAgentPoolAdvanced` struct (used by both the inline profile and the standalone-pool shapes), on `AgentPool`/`AgentPoolInput`/`buildAgentPool`, and parsed on both the inline and standalone wire paths through a shared `applyTo` mapping — so both paths behave identically.

Out of scope (deferred, untouched): upgradeProfile, UserAssigned identity map, systemData/etag, sku.name, data-plane kubeconfig. `echo_properties.go` is unchanged — the #715 write-only secret stripping stays intact.

## Tests

New real-SDK e2e tests (`armcontainerservice/v6`) in `sdk_terraform_drift_test.go`:
- networkProfile submitted -> GET echoes exactly (B1)
- networkProfile omitted -> GET returns real defaults (B1-default)
- inline agentPoolProfiles advanced fields -> GET echoes all (B2)
- standalone agentPools PUT->GET still round-trips (regression)
- servicePrincipalProfile.secret absent on GET (#715 regression)

## Gates
build, vet, `-race`, gofmt, golangci-lint (0 new), `go generate` (zero diff), compatgen + `docs/compat` (zero diff) all green.
