### PR TITLE
fix(lambda): Publish, Architectures/EphemeralStorage/Layers round-trip, GetFunctionConcurrency 200 when unset

### DIFF
--- a/providers/aws/lambda/awsconfig.go
+++ b/providers/aws/lambda/awsconfig.go
@@ -14,6 +14,8 @@ import (
 // It implements the AWS-only optional interface the Lambda server type-asserts
 // for, keeping these AWS-specific settings off the provider-agnostic Serverless
 // surface.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) SetFunctionAWSConfig(_ context.Context, name string, cfg driver.AWSFunctionConfig, create bool) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -28,27 +30,50 @@ func (m *Mock) SetFunctionAWSConfig(_ context.Context, name string, cfg driver.A
 			VPCConfig:        cloneVPCConfig(cfg.VPCConfig),
 			DeadLetterConfig: cloneDeadLetterConfig(cfg.DeadLetterConfig),
 			TracingConfig:    tracingConfigOrDefault(cfg.TracingConfig),
+			Architectures:    cloneArchitectures(cfg.Architectures),
+			EphemeralStorage: cloneEphemeralStorage(cfg.EphemeralStorage),
+			Layers:           cloneLayers(cfg.Layers),
 		}
 		m.funcs.Set(name, fd)
 
 		return nil
 	}
 
-	if cfg.VPCConfig != nil {
-		fd.awsConfig.VPCConfig = cloneVPCConfig(cfg.VPCConfig)
-	}
-
-	if cfg.DeadLetterConfig != nil {
-		fd.awsConfig.DeadLetterConfig = cloneDeadLetterConfig(cfg.DeadLetterConfig)
-	}
-
-	if cfg.TracingConfig != nil {
-		fd.awsConfig.TracingConfig = cloneTracingConfig(cfg.TracingConfig)
-	}
-
+	overlayAWSConfig(&fd.awsConfig, cfg)
 	m.funcs.Set(name, fd)
 
 	return nil
+}
+
+// overlayAWSConfig applies only the non-nil fields of cfg onto dst, leaving the
+// rest of the stored AWS-only settings unchanged (the UpdateFunctionConfiguration
+// merge semantics).
+//
+//nolint:gocritic // hugeParam: cfg mirrors the SetFunctionAWSConfig value receiver.
+func overlayAWSConfig(dst *driver.AWSFunctionConfig, cfg driver.AWSFunctionConfig) {
+	if cfg.VPCConfig != nil {
+		dst.VPCConfig = cloneVPCConfig(cfg.VPCConfig)
+	}
+
+	if cfg.DeadLetterConfig != nil {
+		dst.DeadLetterConfig = cloneDeadLetterConfig(cfg.DeadLetterConfig)
+	}
+
+	if cfg.TracingConfig != nil {
+		dst.TracingConfig = cloneTracingConfig(cfg.TracingConfig)
+	}
+
+	if len(cfg.Architectures) > 0 {
+		dst.Architectures = cloneArchitectures(cfg.Architectures)
+	}
+
+	if cfg.EphemeralStorage != nil {
+		dst.EphemeralStorage = cloneEphemeralStorage(cfg.EphemeralStorage)
+	}
+
+	if cfg.Layers != nil {
+		dst.Layers = cloneLayers(cfg.Layers)
+	}
 }
 
 // GetFunctionAWSConfig returns a copy of the stored AWS-only settings for a
@@ -63,5 +88,8 @@ func (m *Mock) GetFunctionAWSConfig(_ context.Context, name string) (driver.AWSF
 		VPCConfig:        cloneVPCConfig(fd.awsConfig.VPCConfig),
 		DeadLetterConfig: cloneDeadLetterConfig(fd.awsConfig.DeadLetterConfig),
 		TracingConfig:    cloneTracingConfig(fd.awsConfig.TracingConfig),
+		Architectures:    cloneArchitectures(fd.awsConfig.Architectures),
+		EphemeralStorage: cloneEphemeralStorage(fd.awsConfig.EphemeralStorage),
+		Layers:           cloneLayers(fd.awsConfig.Layers),
 	}, nil
 }

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -542,6 +542,32 @@ func cloneTracingConfig(t *driver.TracingConfig) *driver.TracingConfig {
 	return &out
 }
 
+func cloneArchitectures(a []string) []string {
+	if a == nil {
+		return nil
+	}
+
+	return append([]string(nil), a...)
+}
+
+func cloneEphemeralStorage(e *driver.EphemeralStorage) *driver.EphemeralStorage {
+	if e == nil {
+		return nil
+	}
+
+	out := *e
+
+	return &out
+}
+
+func cloneLayers(l []driver.FunctionLayer) []driver.FunctionLayer {
+	if l == nil {
+		return nil
+	}
+
+	return append([]driver.FunctionLayer(nil), l...)
+}
+
 // tracingConfigOrDefault returns a copy of t, or the AWS default
 // {Mode: "PassThrough"} when the client supplied no tracing configuration.
 func tracingConfigOrDefault(t *driver.TracingConfig) *driver.TracingConfig {

--- a/server/aws/lambda/concurrency.go
+++ b/server/aws/lambda/concurrency.go
@@ -53,9 +53,18 @@ func (h *Handler) serveConcurrency(w http.ResponseWriter, r *http.Request, name 
 
 		writeJSON(w, http.StatusOK, map[string]any{"ReservedConcurrentExecutions": req.ReservedConcurrentExecutions})
 	case http.MethodGet:
+		// GetFunctionConcurrency 404s only when the FUNCTION is missing. A function
+		// with no reserved concurrency set is HTTP 200 with an empty body, matching
+		// AWS — the provider reports NotFound for both cases, so the function's
+		// existence is checked separately here.
+		if _, err := h.fn.GetFunction(r.Context(), name); err != nil {
+			writeErr(w, err)
+			return
+		}
+
 		cfg, err := h.fn.GetFunctionConcurrency(r.Context(), name)
 		if err != nil {
-			writeErr(w, err)
+			writeJSON(w, http.StatusOK, map[string]any{})
 			return
 		}
 

--- a/server/aws/lambda/config_roundtrip_test.go
+++ b/server/aws/lambda/config_roundtrip_test.go
@@ -1,0 +1,272 @@
+package lambda_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/aws/smithy-go"
+)
+
+// zipWith returns a minimal valid zip archive containing a single file, so a
+// function importing a layer can have the two packages merged (the overlay path
+// unzips both).
+func zipWith(t *testing.T, name, body string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	zw := zip.NewWriter(&buf)
+
+	f, err := zw.Create(name)
+	if err != nil {
+		t.Fatalf("zip create: %v", err)
+	}
+	if _, err := f.Write([]byte(body)); err != nil {
+		t.Fatalf("zip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+
+	return buf.Bytes()
+}
+
+// TestSDKCreateFunctionPublish covers CreateFunction with Publish=true: AWS
+// publishes version 1 and the response is that published version's configuration
+// (Version "1", :1-qualified ARN). Before the fix Publish was ignored — the
+// response stayed $LATEST and no version was cut, breaking Terraform
+// aws_lambda_function{publish=true}.
+func TestSDKCreateFunctionPublish(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("pubfn"),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Publish:      true,
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+	})
+	if err != nil {
+		t.Fatalf("CreateFunction(Publish): %v", err)
+	}
+
+	if aws.ToString(out.Version) != "1" {
+		t.Fatalf("Version = %q, want 1", aws.ToString(out.Version))
+	}
+	if !strings.HasSuffix(aws.ToString(out.FunctionArn), ":function:pubfn:1") {
+		t.Fatalf("FunctionArn = %q, want qualified with :1", aws.ToString(out.FunctionArn))
+	}
+
+	// The published version is retrievable via GetFunction Qualifier=1.
+	got, err := client.GetFunction(ctx, &awslambda.GetFunctionInput{
+		FunctionName: aws.String("pubfn"),
+		Qualifier:    aws.String("1"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunction(Qualifier=1): %v", err)
+	}
+	if aws.ToString(got.Configuration.Version) != "1" {
+		t.Fatalf("Get Version = %q, want 1", aws.ToString(got.Configuration.Version))
+	}
+}
+
+// TestSDKUpdateFunctionCodePublish covers UpdateFunctionCode with Publish=true
+// cutting a new version (2, after the create-time $LATEST) and returning that
+// version's qualified configuration.
+func TestSDKUpdateFunctionCodePublish(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "updpub")
+
+	out, err := client.UpdateFunctionCode(ctx, &awslambda.UpdateFunctionCodeInput{
+		FunctionName: aws.String("updpub"),
+		ZipFile:      []byte("new-code"),
+		Publish:      true,
+	})
+	if err != nil {
+		t.Fatalf("UpdateFunctionCode(Publish): %v", err)
+	}
+
+	if aws.ToString(out.Version) != "1" {
+		t.Fatalf("Version = %q, want 1", aws.ToString(out.Version))
+	}
+	if !strings.HasSuffix(aws.ToString(out.FunctionArn), ":function:updpub:1") {
+		t.Fatalf("FunctionArn = %q, want qualified with :1", aws.ToString(out.FunctionArn))
+	}
+}
+
+// TestSDKArchitecturesRoundtrip covers the Architectures field: an explicit
+// [arm64] round-trips and an omitted value defaults to [x86_64], matching AWS.
+func TestSDKArchitecturesRoundtrip(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName:  aws.String("arm"),
+		Runtime:       lambdatypes.RuntimeGo1x,
+		Role:          aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:       aws.String("main"),
+		Architectures: []lambdatypes.Architecture{lambdatypes.ArchitectureArm64},
+		Code:          &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+	}); err != nil {
+		t.Fatalf("CreateFunction(arm64): %v", err)
+	}
+
+	got, err := client.GetFunction(ctx, &awslambda.GetFunctionInput{FunctionName: aws.String("arm")})
+	if err != nil {
+		t.Fatalf("GetFunction: %v", err)
+	}
+	if archs := got.Configuration.Architectures; len(archs) != 1 || archs[0] != lambdatypes.ArchitectureArm64 {
+		t.Fatalf("Architectures = %v, want [arm64]", got.Configuration.Architectures)
+	}
+
+	// A function created without Architectures defaults to [x86_64].
+	createBasicFunction(t, client, "x86")
+
+	def, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("x86"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConfiguration: %v", err)
+	}
+	if archs := def.Architectures; len(archs) != 1 || archs[0] != lambdatypes.ArchitectureX8664 {
+		t.Fatalf("default Architectures = %v, want [x86_64]", def.Architectures)
+	}
+}
+
+// TestSDKEphemeralStorageRoundtrip covers the EphemeralStorage field: an
+// explicit size round-trips and an omitted value defaults to 512 MB, matching
+// AWS. An out-of-range size is rejected with InvalidParameterValueException.
+func TestSDKEphemeralStorageRoundtrip(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName:     aws.String("bigtmp"),
+		Runtime:          lambdatypes.RuntimeGo1x,
+		Role:             aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:          aws.String("main"),
+		EphemeralStorage: &lambdatypes.EphemeralStorage{Size: aws.Int32(2048)},
+		Code:             &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+	}); err != nil {
+		t.Fatalf("CreateFunction(EphemeralStorage): %v", err)
+	}
+
+	got, err := client.GetFunction(ctx, &awslambda.GetFunctionInput{FunctionName: aws.String("bigtmp")})
+	if err != nil {
+		t.Fatalf("GetFunction: %v", err)
+	}
+	if es := got.Configuration.EphemeralStorage; es == nil || aws.ToInt32(es.Size) != 2048 {
+		t.Fatalf("EphemeralStorage = %+v, want Size 2048", got.Configuration.EphemeralStorage)
+	}
+
+	// A function created without EphemeralStorage defaults to 512 MB.
+	createBasicFunction(t, client, "deftmp")
+
+	def, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("deftmp"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConfiguration: %v", err)
+	}
+	if es := def.EphemeralStorage; es == nil || aws.ToInt32(es.Size) != 512 {
+		t.Fatalf("default EphemeralStorage = %+v, want Size 512", def.EphemeralStorage)
+	}
+
+	// A size below the 512 MB floor is rejected.
+	_, err = client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName:     aws.String("toosmall"),
+		Runtime:          lambdatypes.RuntimeGo1x,
+		Role:             aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:          aws.String("main"),
+		EphemeralStorage: &lambdatypes.EphemeralStorage{Size: aws.Int32(256)},
+		Code:             &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValueException" {
+		t.Fatalf("CreateFunction(size 256) err = %v, want InvalidParameterValueException", err)
+	}
+}
+
+// TestSDKGetFunctionConcurrencyUnset covers GetFunctionConcurrency returning
+// HTTP 200 with an empty body when the function has no reserved concurrency set
+// (only a MISSING function is 404). Before the fix the provider's NotFound for
+// "concurrency unset" was mapped to a 404, breaking callers that read
+// concurrency on functions that never set it.
+func TestSDKGetFunctionConcurrencyUnset(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "noconc")
+
+	got, err := client.GetFunctionConcurrency(ctx, &awslambda.GetFunctionConcurrencyInput{
+		FunctionName: aws.String("noconc"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConcurrency(unset): %v, want 200 empty", err)
+	}
+	if got.ReservedConcurrentExecutions != nil {
+		t.Fatalf("ReservedConcurrentExecutions = %v, want nil when unset", *got.ReservedConcurrentExecutions)
+	}
+
+	// A missing function is still ResourceNotFoundException.
+	_, err = client.GetFunctionConcurrency(ctx, &awslambda.GetFunctionConcurrencyInput{
+		FunctionName: aws.String("ghost"),
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ResourceNotFoundException" {
+		t.Fatalf("GetFunctionConcurrency(missing) err = %v, want ResourceNotFoundException", err)
+	}
+}
+
+// TestSDKCreateFunctionLayersEchoed covers CreateFunction echoing the imported
+// layers in the function configuration's Layers list (with Arn and a non-zero
+// CodeSize). Before the fix Layers came back empty even when layers were passed.
+func TestSDKCreateFunctionLayersEchoed(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	pub, err := client.PublishLayerVersion(ctx, &awslambda.PublishLayerVersionInput{
+		LayerName:          aws.String("shared"),
+		CompatibleRuntimes: []lambdatypes.Runtime{lambdatypes.RuntimeGo1x},
+		Content:            &lambdatypes.LayerVersionContentInput{ZipFile: zipWith(t, "lib.txt", "lib")},
+	})
+	if err != nil {
+		t.Fatalf("PublishLayerVersion: %v", err)
+	}
+	layerARN := aws.ToString(pub.LayerVersionArn)
+
+	if _, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("withlayers"),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Layers:       []string{layerARN},
+		Code:         &lambdatypes.FunctionCode{ZipFile: zipWith(t, "main.txt", "fn")},
+	}); err != nil {
+		t.Fatalf("CreateFunction(Layers): %v", err)
+	}
+
+	got, err := client.GetFunction(ctx, &awslambda.GetFunctionInput{FunctionName: aws.String("withlayers")})
+	if err != nil {
+		t.Fatalf("GetFunction: %v", err)
+	}
+
+	layers := got.Configuration.Layers
+	if len(layers) != 1 || aws.ToString(layers[0].Arn) != layerARN {
+		t.Fatalf("Layers = %+v, want one with Arn %q", layers, layerARN)
+	}
+	if layers[0].CodeSize == 0 {
+		t.Fatal("layer CodeSize = 0, want non-zero")
+	}
+}

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -528,11 +528,6 @@ func (h *Handler) serveConfiguration(w http.ResponseWriter, r *http.Request, nam
 		Layers:           h.resolveLayers(req.Layers),
 	}, false)
 
-	if req.Publish {
-		h.writePublished(r.Context(), w, http.StatusOK, name, info, awsCfg)
-		return
-	}
-
 	writeJSON(w, http.StatusOK, toConfiguration(info, awsCfg))
 }
 

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -97,6 +97,26 @@ const (
 	maxBodyBytes    = 6 << 20 // 6 MiB — Lambda's sync invocation payload limit.
 )
 
+// AWS Lambda configuration defaults the handler emits when the client omitted
+// the field on create: Architectures defaults to ["x86_64"] and EphemeralStorage
+// (the /tmp size) to 512 MB.
+const (
+	archX8664                 = "x86_64"
+	defaultEphemeralStorageMB = 512
+)
+
+// EphemeralStorage accepted range: real Lambda rejects a size outside 512–10240
+// with InvalidParameterValueException.
+const (
+	minEphemeralStorageMB = 512
+	maxEphemeralStorageMB = 10240
+)
+
+// defaultLayerCodeSize is the CodeSize reported for an imported layer whose
+// content was not published to this emulator (e.g. an S3-sourced layer we did
+// not fetch), so the Layers list still carries a non-zero size.
+const defaultLayerCodeSize int64 = 1024
+
 // policyManager is the AWS-specific resource-policy surface (AddPermission /
 // GetPolicy / RemovePermission). It's not part of the portable Serverless
 // driver — resource policies are a Lambda concept — so the handler type-asserts
@@ -501,9 +521,35 @@ func (h *Handler) serveConfiguration(w http.ResponseWriter, r *http.Request, nam
 		return
 	}
 
-	awsCfg := h.applyAWSConfig(r.Context(), name, req.VpcConfig, req.DeadLetterConfig, req.TracingConfig, false)
+	awsCfg := h.applyAWSConfig(r.Context(), name, sdrv.AWSFunctionConfig{
+		VPCConfig:        toDriverVPCConfig(req.VpcConfig),
+		DeadLetterConfig: toDriverDeadLetter(req.DeadLetterConfig),
+		TracingConfig:    toDriverTracing(req.TracingConfig),
+		Layers:           h.resolveLayers(req.Layers),
+	}, false)
+
+	if req.Publish {
+		h.writePublished(r.Context(), w, http.StatusOK, name, info, awsCfg)
+		return
+	}
 
 	writeJSON(w, http.StatusOK, toConfiguration(info, awsCfg))
+}
+
+// writePublished publishes a new version of name and writes that version's
+// configuration with the given status, or the underlying error. It is the shared
+// tail of the Publish=true UpdateFunctionCode/UpdateFunctionConfiguration paths.
+func (h *Handler) writePublished(
+	ctx context.Context, w http.ResponseWriter, status int,
+	name string, info *sdrv.FunctionInfo, awsCfg *sdrv.AWSFunctionConfig,
+) {
+	cfg, err := h.publishConfiguration(ctx, name, "", info, awsCfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, status, cfg)
 }
 
 // serveCode handles PUT .../{name}/code (UpdateFunctionCode). It resolves the
@@ -549,7 +595,14 @@ func (h *Handler) serveCode(w http.ResponseWriter, r *http.Request, name string)
 		return
 	}
 
-	writeJSON(w, http.StatusOK, toConfiguration(info, h.awsFnConfig(r.Context(), name)))
+	awsCfg := h.awsFnConfig(r.Context(), name)
+
+	if req.Publish {
+		h.writePublished(r.Context(), w, http.StatusOK, name, info, awsCfg)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toConfiguration(info, awsCfg))
 }
 
 // serveVersions handles POST (PublishVersion) and GET (ListVersionsByFunction)
@@ -767,22 +820,9 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// For a .zip file archive package (the default when PackageType is omitted or
-	// "Zip"), AWS requires both Runtime and Handler and rejects a create that omits
-	// either with InvalidParameterValueException. Image packages carry the runtime
-	// in the container, so they don't.
-	if req.PackageType == "" || req.PackageType == packageTypeZip {
-		if req.Runtime == "" {
-			writeError(w, http.StatusBadRequest, "InvalidParameterValueException",
-				"Runtime is required if the deployment package is a .zip file archive.")
-			return
-		}
-
-		if req.Handler == "" {
-			writeError(w, http.StatusBadRequest, "InvalidParameterValueException",
-				"Handler is required if the deployment package is a .zip file archive.")
-			return
-		}
+	if err := validateCreateRequest(&req); err != nil {
+		writeErr(w, err)
+		return
 	}
 
 	cfg := sdrv.FunctionConfig{
@@ -819,9 +859,110 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	awsCfg := h.applyAWSConfig(r.Context(), req.FunctionName, req.VpcConfig, req.DeadLetterConfig, req.TracingConfig, true)
+	awsCfg := h.applyAWSConfig(r.Context(), req.FunctionName, h.createAWSConfig(&req), true)
+
+	// Publish=true cuts version 1 from the just-created function and returns that
+	// published version's configuration (Version "1", :1-qualified ARN), matching
+	// AWS and Terraform's aws_lambda_function{publish=true}.
+	if req.Publish {
+		cfg, perr := h.publishConfiguration(r.Context(), req.FunctionName, req.Description, info, awsCfg)
+		if perr != nil {
+			writeErr(w, perr)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, cfg)
+
+		return
+	}
 
 	writeJSON(w, http.StatusCreated, toConfiguration(info, awsCfg))
+}
+
+// validateCreateRequest enforces the CreateFunction input rules the emulator
+// checks up front: a .zip package requires Runtime and Handler, and an
+// EphemeralStorage size must be within the accepted range. Each violation is an
+// InvalidArgument error the wire layer maps to InvalidParameterValueException.
+func validateCreateRequest(req *createFunctionRequest) error {
+	if req.PackageType == "" || req.PackageType == packageTypeZip {
+		if req.Runtime == "" {
+			return cerrors.New(cerrors.InvalidArgument,
+				"Runtime is required if the deployment package is a .zip file archive.")
+		}
+
+		if req.Handler == "" {
+			return cerrors.New(cerrors.InvalidArgument,
+				"Handler is required if the deployment package is a .zip file archive.")
+		}
+	}
+
+	return validateEphemeralStorage(req.EphemeralStorage)
+}
+
+// validateEphemeralStorage rejects a /tmp size outside the AWS 512–10240 MB range.
+func validateEphemeralStorage(e *ephemeralStorageEnvelope) error {
+	if e == nil {
+		return nil
+	}
+
+	if e.Size < minEphemeralStorageMB || e.Size > maxEphemeralStorageMB {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"'ephemeralStorage.size' value %d must be >= %d and <= %d",
+			e.Size, minEphemeralStorageMB, maxEphemeralStorageMB)
+	}
+
+	return nil
+}
+
+// createAWSConfig assembles the AWS-only settings supplied on a CreateFunction
+// request (VpcConfig/DeadLetterConfig/TracingConfig plus Architectures,
+// EphemeralStorage and the imported Layers) for applyAWSConfig to store.
+func (h *Handler) createAWSConfig(req *createFunctionRequest) sdrv.AWSFunctionConfig {
+	return sdrv.AWSFunctionConfig{
+		VPCConfig:        toDriverVPCConfig(req.VpcConfig),
+		DeadLetterConfig: toDriverDeadLetter(req.DeadLetterConfig),
+		TracingConfig:    toDriverTracing(req.TracingConfig),
+		Architectures:    req.Architectures,
+		EphemeralStorage: toDriverEphemeral(req.EphemeralStorage),
+		Layers:           h.resolveLayers(req.Layers),
+	}
+}
+
+// publishConfiguration publishes a new version of name and renders that version's
+// configuration (its own version number and a qualified ARN), the response body
+// AWS returns for a Publish=true Create/UpdateFunctionCode/Configuration.
+func (h *Handler) publishConfiguration(
+	ctx context.Context, name, description string,
+	info *sdrv.FunctionInfo, awsCfg *sdrv.AWSFunctionConfig,
+) (functionConfiguration, error) {
+	ver, err := h.fn.PublishVersion(ctx, name, description)
+	if err != nil {
+		return functionConfiguration{}, err
+	}
+
+	return toVersionConfiguration(info, ver, awsCfg), nil
+}
+
+// resolveLayers maps the requested layer ARNs to the echoed Layers list,
+// resolving each layer version's CodeSize from its staged content when the layer
+// was published to this emulator, or a sane default otherwise.
+func (h *Handler) resolveLayers(arns []string) []sdrv.FunctionLayer {
+	if len(arns) == 0 {
+		return nil
+	}
+
+	out := make([]sdrv.FunctionLayer, 0, len(arns))
+
+	for _, arn := range arns {
+		size := int64(len(h.layerContentFor(arn)))
+		if size == 0 {
+			size = defaultLayerCodeSize
+		}
+
+		out = append(out, sdrv.FunctionLayer{ARN: arn, CodeSize: size})
+	}
+
+	return out
 }
 
 // resolveCode returns the deployment-package bytes for a CreateFunction request.
@@ -1118,25 +1259,49 @@ func toConfiguration(info *sdrv.FunctionInfo, awsCfg *sdrv.AWSFunctionConfig) fu
 		cfg.Environment = &envEnvelope{Variables: info.Environment}
 	}
 
-	if awsCfg != nil {
-		if awsCfg.VPCConfig != nil {
-			cfg.VpcConfig = &vpcConfigEnvelope{
-				SubnetIDs:        awsCfg.VPCConfig.SubnetIDs,
-				SecurityGroupIDs: awsCfg.VPCConfig.SecurityGroupIDs,
-				VpcID:            awsCfg.VPCConfig.VpcID,
-			}
-		}
+	// AWS always reports Architectures and EphemeralStorage, defaulting to
+	// ["x86_64"] and 512 MB when the function was created without them.
+	cfg.Architectures = []string{archX8664}
+	cfg.EphemeralStorage = &ephemeralStorageEnvelope{Size: defaultEphemeralStorageMB}
 
-		if awsCfg.DeadLetterConfig != nil {
-			cfg.DeadLetterConfig = &deadLetterConfigEnvelope{TargetArn: awsCfg.DeadLetterConfig.TargetArn}
-		}
+	applyAWSConfigToResponse(&cfg, awsCfg)
 
-		if awsCfg.TracingConfig != nil {
-			cfg.TracingConfig = &tracingConfigEnvelope{Mode: awsCfg.TracingConfig.Mode}
+	return cfg
+}
+
+// applyAWSConfigToResponse overlays the stored AWS-only settings onto a function
+// configuration response: the imported layers, plus VpcConfig/DeadLetterConfig/
+// TracingConfig, and the non-default Architectures/EphemeralStorage.
+func applyAWSConfigToResponse(cfg *functionConfiguration, awsCfg *sdrv.AWSFunctionConfig) {
+	if awsCfg == nil {
+		return
+	}
+
+	if len(awsCfg.Architectures) > 0 {
+		cfg.Architectures = awsCfg.Architectures
+	}
+
+	if awsCfg.EphemeralStorage != nil {
+		cfg.EphemeralStorage = &ephemeralStorageEnvelope{Size: awsCfg.EphemeralStorage.Size}
+	}
+
+	cfg.Layers = toLayerReferences(awsCfg.Layers)
+
+	if awsCfg.VPCConfig != nil {
+		cfg.VpcConfig = &vpcConfigEnvelope{
+			SubnetIDs:        awsCfg.VPCConfig.SubnetIDs,
+			SecurityGroupIDs: awsCfg.VPCConfig.SecurityGroupIDs,
+			VpcID:            awsCfg.VPCConfig.VpcID,
 		}
 	}
 
-	return cfg
+	if awsCfg.DeadLetterConfig != nil {
+		cfg.DeadLetterConfig = &deadLetterConfigEnvelope{TargetArn: awsCfg.DeadLetterConfig.TargetArn}
+	}
+
+	if awsCfg.TracingConfig != nil {
+		cfg.TracingConfig = &tracingConfigEnvelope{Mode: awsCfg.TracingConfig.Mode}
+	}
 }
 
 // reservedConcurrency returns the function's reserved-concurrency envelope for
@@ -1175,20 +1340,16 @@ func (h *Handler) awsFnConfig(ctx context.Context, name string) *sdrv.AWSFunctio
 // request through the AWS-only optional interface, then returns the resulting
 // stored config for the response. It is a no-op returning nil when the backend
 // does not model these settings.
+//
+//nolint:gocritic // hugeParam: cfg mirrors the SetFunctionAWSConfig value receiver.
 func (h *Handler) applyAWSConfig(
-	ctx context.Context, name string,
-	vpc *vpcConfigEnvelope, dlq *deadLetterConfigEnvelope, tracing *tracingConfigEnvelope, create bool,
+	ctx context.Context, name string, cfg sdrv.AWSFunctionConfig, create bool,
 ) *sdrv.AWSFunctionConfig {
 	mgr, ok := h.fn.(awsConfigManager)
 	if !ok {
 		return nil
 	}
 
-	cfg := sdrv.AWSFunctionConfig{
-		VPCConfig:        toDriverVPCConfig(vpc),
-		DeadLetterConfig: toDriverDeadLetter(dlq),
-		TracingConfig:    toDriverTracing(tracing),
-	}
 	if err := mgr.SetFunctionAWSConfig(ctx, name, cfg, create); err != nil {
 		return nil
 	}
@@ -1226,6 +1387,30 @@ func toDriverTracing(e *tracingConfigEnvelope) *sdrv.TracingConfig {
 	}
 
 	return &sdrv.TracingConfig{Mode: e.Mode}
+}
+
+// toDriverEphemeral maps a wire EphemeralStorage envelope to the driver type.
+func toDriverEphemeral(e *ephemeralStorageEnvelope) *sdrv.EphemeralStorage {
+	if e == nil {
+		return nil
+	}
+
+	return &sdrv.EphemeralStorage{Size: e.Size}
+}
+
+// toLayerReferences maps the stored imported layers to the function
+// configuration's Layers list.
+func toLayerReferences(layers []sdrv.FunctionLayer) []layerReference {
+	if len(layers) == 0 {
+		return nil
+	}
+
+	out := make([]layerReference, 0, len(layers))
+	for i := range layers {
+		out = append(out, layerReference{Arn: layers[i].ARN, CodeSize: layers[i].CodeSize})
+	}
+
+	return out
 }
 
 func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {

--- a/server/aws/lambda/sdk_roundtrip_test.go
+++ b/server/aws/lambda/sdk_roundtrip_test.go
@@ -219,10 +219,17 @@ func TestSDKLambdaConcurrencyRoundtrip(t *testing.T) {
 		t.Fatalf("DeleteFunctionConcurrency: %v", err)
 	}
 
-	if _, err := client.GetFunctionConcurrency(ctx, &awslambda.GetFunctionConcurrencyInput{
+	// After delete the function still exists with no reserved concurrency, so
+	// GetFunctionConcurrency is HTTP 200 with an empty body (nil executions), not
+	// a 404 — only a missing function is NotFound.
+	after, err := client.GetFunctionConcurrency(ctx, &awslambda.GetFunctionConcurrencyInput{
 		FunctionName: aws.String("busy"),
-	}); err == nil {
-		t.Fatal("GetFunctionConcurrency after delete returned nil error, want NotFound")
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConcurrency after delete: %v, want 200 empty", err)
+	}
+	if after.ReservedConcurrentExecutions != nil {
+		t.Fatalf("ReservedConcurrentExecutions = %v, want nil after delete", *after.ReservedConcurrentExecutions)
 	}
 }
 

--- a/server/aws/lambda/types.go
+++ b/server/aws/lambda/types.go
@@ -26,6 +26,19 @@ type tracingConfigEnvelope struct {
 	Mode string `json:"Mode,omitempty"`
 }
 
+// ephemeralStorageEnvelope is the Lambda EphemeralStorage request/response shape:
+// the function's /tmp size in MB.
+type ephemeralStorageEnvelope struct {
+	Size int `json:"Size"`
+}
+
+// layerReference is one entry of the function configuration's Layers list (the
+// AWS Layer output shape). Only Arn and CodeSize are modeled.
+type layerReference struct {
+	Arn      string `json:"Arn"`
+	CodeSize int64  `json:"CodeSize,omitempty"`
+}
+
 // functionConfiguration is the response body shared by Create / Get / Update.
 // Field set is the minimum the AWS SDK populates for a function description.
 type functionConfiguration struct {
@@ -51,6 +64,12 @@ type functionConfiguration struct {
 	VpcConfig        *vpcConfigEnvelope        `json:"VpcConfig,omitempty"`
 	DeadLetterConfig *deadLetterConfigEnvelope `json:"DeadLetterConfig,omitempty"`
 	TracingConfig    *tracingConfigEnvelope    `json:"TracingConfig,omitempty"`
+	// Architectures echoes the function's instruction set (["x86_64"] or
+	// ["arm64"]); EphemeralStorage its /tmp size; Layers the imported layer
+	// versions. All default when the function was created without them.
+	Architectures    []string                  `json:"Architectures,omitempty"`
+	EphemeralStorage *ephemeralStorageEnvelope `json:"EphemeralStorage,omitempty"`
+	Layers           []layerReference          `json:"Layers,omitempty"`
 }
 
 // updateFunctionConfigurationRequest captures the mutable fields of
@@ -66,6 +85,11 @@ type updateFunctionConfigurationRequest struct {
 	VpcConfig        *vpcConfigEnvelope        `json:"VpcConfig"`
 	DeadLetterConfig *deadLetterConfigEnvelope `json:"DeadLetterConfig"`
 	TracingConfig    *tracingConfigEnvelope    `json:"TracingConfig"`
+	// Layers replaces the function's imported layer versions (their ARNs).
+	Layers []string `json:"Layers"`
+	// Publish, when true, cuts a new version from the updated configuration and
+	// returns that version's configuration (qualified ARN), matching AWS.
+	Publish bool `json:"Publish"`
 }
 
 // updateFunctionCodeRequest captures the deployment-package fields of
@@ -79,6 +103,9 @@ type updateFunctionCodeRequest struct {
 	S3Key           string   `json:"S3Key"`
 	S3ObjectVersion string   `json:"S3ObjectVersion"`
 	Layers          []string `json:"Layers"`
+	// Publish, when true, cuts a new version from the updated code and returns
+	// that version's configuration (qualified ARN), matching AWS.
+	Publish bool `json:"Publish"`
 }
 
 // publishVersionRequest is the body of PublishVersion (POST .../{name}/versions).
@@ -182,6 +209,11 @@ type createFunctionRequest struct {
 	VpcConfig        *vpcConfigEnvelope        `json:"VpcConfig"`
 	DeadLetterConfig *deadLetterConfigEnvelope `json:"DeadLetterConfig"`
 	TracingConfig    *tracingConfigEnvelope    `json:"TracingConfig"`
+	Architectures    []string                  `json:"Architectures"`
+	EphemeralStorage *ephemeralStorageEnvelope `json:"EphemeralStorage"`
+	// Publish, when true, publishes version 1 from the created function and
+	// returns that version's configuration (Version "1", qualified ARN).
+	Publish bool `json:"Publish"`
 }
 
 // functionCode is the deployment package in a CreateFunction body. The AWS SDK

--- a/server/aws/lambda/types.go
+++ b/server/aws/lambda/types.go
@@ -87,9 +87,6 @@ type updateFunctionConfigurationRequest struct {
 	TracingConfig    *tracingConfigEnvelope    `json:"TracingConfig"`
 	// Layers replaces the function's imported layer versions (their ARNs).
 	Layers []string `json:"Layers"`
-	// Publish, when true, cuts a new version from the updated configuration and
-	// returns that version's configuration (qualified ARN), matching AWS.
-	Publish bool `json:"Publish"`
 }
 
 // updateFunctionCodeRequest captures the deployment-package fields of

--- a/services/serverless/driver/driver.go
+++ b/services/serverless/driver/driver.go
@@ -139,16 +139,38 @@ type TracingConfig struct {
 	Mode string
 }
 
+// EphemeralStorage is a function's /tmp size in MB (AWS Lambda EphemeralStorage).
+// Real Lambda accepts 512–10240 and defaults to 512 when the client omits it.
+type EphemeralStorage struct {
+	Size int
+}
+
+// FunctionLayer is one layer version imported by a function, echoed back in the
+// function configuration's Layers list (AWS Lambda Layer). CodeSize is the layer
+// version's deployment-package size.
+type FunctionLayer struct {
+	ARN      string
+	CodeSize int64
+}
+
 // AWSFunctionConfig bundles the AWS Lambda-only function settings — VpcConfig,
-// DeadLetterConfig and TracingConfig. These have no Azure Functions or GCP Cloud
-// Functions equivalent, so they are kept off the shared FunctionConfig/
-// FunctionInfo structs and applied/read back through an AWS-only optional
-// interface (type-asserted by the AWS Lambda server handler), the same way
-// Function URLs are exposed.
+// DeadLetterConfig, TracingConfig, Architectures, EphemeralStorage and the
+// imported Layers. These have no Azure Functions or GCP Cloud Functions
+// equivalent, so they are kept off the shared FunctionConfig/FunctionInfo structs
+// and applied/read back through an AWS-only optional interface (type-asserted by
+// the AWS Lambda server handler), the same way Function URLs are exposed.
 type AWSFunctionConfig struct {
 	VPCConfig        *VPCConfig
 	DeadLetterConfig *DeadLetterConfig
 	TracingConfig    *TracingConfig
+	// Architectures is the instruction-set list (["x86_64"] or ["arm64"]). Empty
+	// means the handler emits the AWS default ["x86_64"].
+	Architectures []string
+	// EphemeralStorage is the /tmp size; nil means the handler emits the default 512.
+	EphemeralStorage *EphemeralStorage
+	// Layers is the ordered list of imported layer versions echoed back on the
+	// function configuration.
+	Layers []FunctionLayer
 }
 
 // FunctionConfig describes a serverless function to create.


### PR DESCRIPTION
## Summary

Fixes 5 real AWS Lambda parity bugs surfaced by driving a real `aws-sdk-go-v2/lambda` client at the booted wire server.

1. **CreateFunction `Publish=true` was ignored** — Version stayed `$LATEST` and no version was cut. Now `Publish=true` publishes version 1 and the response is that version's configuration (`Version:"1"`, `:1`-qualified ARN). Also honored on `UpdateFunctionCode` (both APIs really carry a `Publish` field). Fixes Terraform `aws_lambda_function{publish=true}`.
2. **`Architectures` never round-tripped** — now echoes `[arm64]` when set and defaults to `[x86_64]` when omitted.
3. **`EphemeralStorage` never round-tripped** — now echoes `{Size:2048}` when set and defaults to `{Size:512}`; a size outside 512–10240 is rejected with `InvalidParameterValueException`.
4. **`GetFunctionConcurrency` returned 404 when reserved concurrency was unset** — real AWS returns HTTP 200 with an empty body; only a missing function is 404. The wire GET now checks function existence separately from concurrency being set.
5. **`Layers` were not echoed** — imported layers are now persisted and returned as `[{Arn, CodeSize}]` on Create/Get and after an UpdateFunctionConfiguration that changes them.

## Approach

The AWS-only fields (`Architectures`, `EphemeralStorage`, `Layers`) are carried on `AWSFunctionConfig` and applied/read through the existing AWS-only optional interface, consistent with how `VpcConfig`/`DeadLetterConfig`/`TracingConfig` are already kept off the provider-agnostic `Serverless` surface. `toConfiguration` applies the `[x86_64]` / `512` defaults.

`Publish` is honored only on the two APIs that really expose it — `CreateFunction` and `UpdateFunctionCode`; `UpdateFunctionConfiguration` has no `Publish` parameter in the AWS API and is left unchanged.

## Tests

Added hand-rolled real-SDK e2e tests: Publish round-trip on Create + `GetFunction Qualifier=1`, Publish on UpdateFunctionCode, Architectures round-trip + default, EphemeralStorage round-trip + default + range rejection, GetFunctionConcurrency 200-when-unset / 404-when-missing, and Layers echoed. Updated the existing concurrency roundtrip test whose post-delete assertion encoded the old (buggy) 404 behavior.

## Gates

build, vet, `go test` (lambda + serverless + server/persist/seed/root), `-race`, gofmt, golangci-lint (0 new), `go generate` (zero diff), compatgen (exit 0, `docs/compat` clean).
