### PR TITLE
fix(gcp-cloudrun): honor updateMask on service PATCH; model resources.limits + template labels/annotations

### DIFF
--- a/providers/gcp/cloudrun/cloudrun.go
+++ b/providers/gcp/cloudrun/cloudrun.go
@@ -291,13 +291,35 @@ func cloneContainers(in []driver.Container) []driver.Container {
 	out := make([]driver.Container, len(in))
 	for i := range in {
 		out[i] = driver.Container{
-			Name:    in[i].Name,
-			Image:   in[i].Image,
-			Command: append([]string(nil), in[i].Command...),
-			Args:    append([]string(nil), in[i].Args...),
-			Env:     cloneMap(in[i].Env),
-			Ports:   append([]int(nil), in[i].Ports...),
+			Name:      in[i].Name,
+			Image:     in[i].Image,
+			Command:   append([]string(nil), in[i].Command...),
+			Args:      append([]string(nil), in[i].Args...),
+			Env:       cloneMap(in[i].Env),
+			Ports:     append([]int(nil), in[i].Ports...),
+			Resources: cloneResources(in[i].Resources),
 		}
+	}
+
+	return out
+}
+
+// cloneResources deep-copies a container's resource requirements, or nil.
+func cloneResources(in *driver.ResourceRequirements) *driver.ResourceRequirements {
+	if in == nil {
+		return nil
+	}
+
+	out := &driver.ResourceRequirements{Limits: cloneMap(in.Limits)}
+
+	if in.CPUIdle != nil {
+		v := *in.CPUIdle
+		out.CPUIdle = &v
+	}
+
+	if in.StartupCPUBoost != nil {
+		v := *in.StartupCPUBoost
+		out.StartupCPUBoost = &v
 	}
 
 	return out

--- a/providers/gcp/cloudrun/services.go
+++ b/providers/gcp/cloudrun/services.go
@@ -3,6 +3,7 @@ package cloudrun
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -99,17 +100,40 @@ func (m *Mock) UpdateService(_ context.Context, cfg driver.ServiceConfig) (*driv
 	}
 
 	created, uid, gen := svc.CreateTime, svc.UID, svc.Generation+1
+	before := snapshotTemplate(svc)
 
-	applyServiceConfig(svc, &cfg)
+	applyUpdate(svc, &cfg)
 
 	svc.CreateTime, svc.UID, svc.Generation = created, uid, gen
 	now := m.opts.Clock.Now()
-	rev := m.materializeRevision(svc, now)
-	reconcile(svc, rev, now, regionOrDefault(cfg.Location))
+	region := regionOrDefault(cfg.Location)
+	after := snapshotTemplate(svc)
+
+	// Real Cloud Run cuts a new revision only when the revision template changes.
+	// A traffic-, label-, or annotation-only update leaves the template intact,
+	// so we reconcile status without advancing the revision pointers.
+	if templatesEqual(&before, &after) {
+		reconcileStatus(svc, now, region)
+	} else {
+		rev := m.materializeRevision(svc, now)
+		reconcile(svc, rev, now, region)
+	}
 
 	m.services.Set(name, svc)
 
 	return cloneService(svc), nil
+}
+
+// applyUpdate overlays cfg onto svc: a maskless config (Terraform's full PUT)
+// replaces every mutable field; a masked config merges only the named paths,
+// preserving everything the caller did not send.
+func applyUpdate(svc *driver.Service, cfg *driver.ServiceConfig) {
+	if len(cfg.UpdateMask) == 0 {
+		applyServiceConfig(svc, cfg)
+		return
+	}
+
+	mergeServiceConfig(svc, cfg, newFieldMask(cfg.UpdateMask))
 }
 
 // DeleteService removes a service and all of its revisions.
@@ -203,6 +227,127 @@ func applyServiceConfig(svc *driver.Service, cfg *driver.ServiceConfig) {
 	svc.Traffic = cloneTraffic(cfg.Traffic)
 	svc.Labels = cloneMap(cfg.Labels)
 	svc.Annotations = cloneMap(cfg.Annotations)
+	svc.TemplateLabels = cloneMap(cfg.TemplateLabels)
+	svc.TemplateAnnotations = cloneMap(cfg.TemplateAnnotations)
+}
+
+// fieldMask is a parsed FieldMask over a Service PATCH body. A top-level path
+// (e.g. "traffic") gates its field; a "template" (or "template.<sub>") path
+// gates a revision-template field.
+type fieldMask map[string]bool
+
+func newFieldMask(paths []string) fieldMask {
+	m := make(fieldMask, len(paths))
+	for _, p := range paths {
+		m[p] = true
+	}
+
+	return m
+}
+
+func (m fieldMask) has(field string) bool { return m[field] }
+
+// hasTemplate reports whether the template as a whole ("template") or the named
+// template subfield ("template.<sub>") is masked.
+func (m fieldMask) hasTemplate(sub string) bool {
+	return m["template"] || m["template."+sub]
+}
+
+// mergeServiceConfig overlays only the masked paths of cfg onto svc, leaving
+// every unmasked field (containers, scaling, description, …) untouched.
+func mergeServiceConfig(svc *driver.Service, cfg *driver.ServiceConfig, mask fieldMask) {
+	mergeServiceLevel(svc, cfg, mask)
+	mergeTemplateLevel(svc, cfg, mask)
+}
+
+func mergeServiceLevel(svc *driver.Service, cfg *driver.ServiceConfig, mask fieldMask) {
+	if mask.has("description") {
+		svc.Description = cfg.Description
+	}
+
+	if mask.has("ingress") {
+		if cfg.Ingress != "" {
+			svc.Ingress = cfg.Ingress
+		} else {
+			svc.Ingress = ingressDefault
+		}
+	}
+
+	if mask.has("labels") {
+		svc.Labels = cloneMap(cfg.Labels)
+	}
+
+	if mask.has("annotations") {
+		svc.Annotations = cloneMap(cfg.Annotations)
+	}
+
+	if mask.has("traffic") {
+		svc.Traffic = cloneTraffic(cfg.Traffic)
+	}
+}
+
+func mergeTemplateLevel(svc *driver.Service, cfg *driver.ServiceConfig, mask fieldMask) {
+	if mask.hasTemplate("containers") {
+		svc.Containers = cloneContainers(cfg.Containers)
+	}
+
+	if mask.hasTemplate("scaling") {
+		svc.Scaling = cloneScaling(cfg.Scaling)
+	}
+
+	if mask.hasTemplate("vpcAccess") {
+		svc.VPCAccess = cloneVPCAccess(cfg.VPCAccess)
+	}
+
+	if mask.hasTemplate("serviceAccount") {
+		svc.ServiceAccount = cfg.ServiceAccount
+	}
+
+	if mask.hasTemplate("timeout") {
+		svc.Timeout = cfg.Timeout
+	}
+
+	if mask.hasTemplate("executionEnvironment") {
+		svc.ExecutionEnvironment = cfg.ExecutionEnvironment
+	}
+
+	if mask.hasTemplate("labels") {
+		svc.TemplateLabels = cloneMap(cfg.TemplateLabels)
+	}
+
+	if mask.hasTemplate("annotations") {
+		svc.TemplateAnnotations = cloneMap(cfg.TemplateAnnotations)
+	}
+}
+
+// templateSnapshot captures the revision-defining fields of a service so an
+// update can tell whether the template changed (and thus a revision is due).
+type templateSnapshot struct {
+	Containers           []driver.Container
+	ServiceAccount       string
+	Timeout              string
+	ExecutionEnvironment string
+	VPCAccess            *driver.VpcAccess
+	Scaling              *driver.ServiceScaling
+	Labels               map[string]string
+	Annotations          map[string]string
+}
+
+func snapshotTemplate(svc *driver.Service) templateSnapshot {
+	return templateSnapshot{
+		Containers:           svc.Containers,
+		ServiceAccount:       svc.ServiceAccount,
+		Timeout:              svc.Timeout,
+		ExecutionEnvironment: svc.ExecutionEnvironment,
+		VPCAccess:            svc.VPCAccess,
+		Scaling:              svc.Scaling,
+		Labels:               svc.TemplateLabels,
+		Annotations:          svc.TemplateAnnotations,
+	}
+}
+
+func templatesEqual(a, b *templateSnapshot) bool {
+	return reflect.DeepEqual(a, b)
 }
 
 // materializeRevision creates and stores a new revision from svc's current
@@ -236,10 +381,18 @@ func (m *Mock) materializeRevision(svc *driver.Service, now time.Time) *driver.R
 // pointers, URL, traffic status, terminal condition, generation echoes, and
 // etag — the observed state a real reconcile would report.
 func reconcile(svc *driver.Service, rev *driver.Revision, now time.Time, region string) {
-	svc.UpdateTime = now
-	svc.ObservedGeneration = svc.Generation
 	svc.LatestCreatedRevision = rev.Name
 	svc.LatestReadyRevision = rev.Name
+	reconcileStatus(svc, now, region)
+}
+
+// reconcileStatus rolls the observed status a real reconcile would report onto
+// svc without touching the revision pointers, so a template-unchanged update
+// (e.g. traffic-only) can update traffic status and etag without cutting a
+// spurious revision.
+func reconcileStatus(svc *driver.Service, now time.Time, region string) {
+	svc.UpdateTime = now
+	svc.ObservedGeneration = svc.Generation
 	svc.Reconciling = false
 	svc.Etag = newEtag(now, svc.Generation)
 
@@ -317,6 +470,8 @@ func cloneService(s *driver.Service) *driver.Service {
 	cp.Containers = cloneContainers(s.Containers)
 	cp.Labels = cloneMap(s.Labels)
 	cp.Annotations = cloneMap(s.Annotations)
+	cp.TemplateLabels = cloneMap(s.TemplateLabels)
+	cp.TemplateAnnotations = cloneMap(s.TemplateAnnotations)
 	cp.Conditions = append([]driver.Condition(nil), s.Conditions...)
 	cp.Traffic = cloneTraffic(s.Traffic)
 	cp.TrafficStatuses = cloneTraffic(s.TrafficStatuses)

--- a/server/gcp/cloudrun/conv.go
+++ b/server/gcp/cloudrun/conv.go
@@ -30,12 +30,13 @@ func toDriverContainers(in []container) []driver.Container {
 	out := make([]driver.Container, 0, len(in))
 	for i := range in {
 		out = append(out, driver.Container{
-			Name:    in[i].Name,
-			Image:   in[i].Image,
-			Command: in[i].Command,
-			Args:    in[i].Args,
-			Env:     envToMap(in[i].Env),
-			Ports:   toDriverPorts(in[i].Ports),
+			Name:      in[i].Name,
+			Image:     in[i].Image,
+			Command:   in[i].Command,
+			Args:      in[i].Args,
+			Env:       envToMap(in[i].Env),
+			Ports:     toDriverPorts(in[i].Ports),
+			Resources: toDriverResources(in[i].Resources),
 		})
 	}
 
@@ -98,16 +99,33 @@ func toContainers(in []driver.Container) []container {
 	out := make([]container, 0, len(in))
 	for i := range in {
 		out = append(out, container{
-			Name:    in[i].Name,
-			Image:   in[i].Image,
-			Command: in[i].Command,
-			Args:    in[i].Args,
-			Env:     envToList(in[i].Env),
-			Ports:   toWirePorts(in[i].Ports),
+			Name:      in[i].Name,
+			Image:     in[i].Image,
+			Command:   in[i].Command,
+			Args:      in[i].Args,
+			Env:       envToList(in[i].Env),
+			Ports:     toWirePorts(in[i].Ports),
+			Resources: toWireResources(in[i].Resources),
 		})
 	}
 
 	return out
+}
+
+func toDriverResources(in *resourceRequirements) *driver.ResourceRequirements {
+	if in == nil {
+		return nil
+	}
+
+	return &driver.ResourceRequirements{Limits: in.Limits, CPUIdle: in.CPUIdle, StartupCPUBoost: in.StartupCPUBoost}
+}
+
+func toWireResources(in *driver.ResourceRequirements) *resourceRequirements {
+	if in == nil {
+		return nil
+	}
+
+	return &resourceRequirements{Limits: in.Limits, CPUIdle: in.CPUIdle, StartupCPUBoost: in.StartupCPUBoost}
 }
 
 func toDriverVPC(in *vpcAccess) *driver.VpcAccess {

--- a/server/gcp/cloudrun/services.go
+++ b/server/gcp/cloudrun/services.go
@@ -3,6 +3,7 @@ package cloudrun
 import (
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
 )
@@ -183,7 +184,10 @@ func (h *Handler) updateService(w http.ResponseWriter, r *http.Request, p *crPat
 		return
 	}
 
-	svc, err := h.cr.UpdateService(r.Context(), serviceConfigFromWire(p.name, p.location, &body))
+	cfg := serviceConfigFromWire(p.name, p.location, &body)
+	cfg.UpdateMask = maskPaths(r.URL.Query().Get("updateMask"))
+
+	svc, err := h.cr.UpdateService(r.Context(), cfg)
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -276,7 +280,28 @@ func serviceConfigFromWire(name, location string, body *serviceResource) driver.
 		Traffic:              toDriverTraffic(body.Traffic),
 		Labels:               body.Labels,
 		Annotations:          body.Annotations,
+		TemplateLabels:       t.Labels,
+		TemplateAnnotations:  t.Annotations,
 	}
+}
+
+// maskPaths splits a FieldMask query value (comma-separated field paths) into a
+// slice, returning nil for an absent or empty mask (a maskless full replace).
+func maskPaths(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "*" {
+		return nil
+	}
+
+	var out []string
+
+	for _, f := range strings.Split(raw, ",") {
+		if f = strings.TrimSpace(f); f != "" {
+			out = append(out, f)
+		}
+	}
+
+	return out
 }
 
 func toDriverScaling(in *revisionScaling) *driver.ServiceScaling {
@@ -359,6 +384,8 @@ func toServiceResource(s *driver.Service, p *crPath) serviceResource {
 		Reconciling:           s.Reconciling,
 		Etag:                  s.Etag,
 		Template: revisionTemplate{
+			Labels:               s.TemplateLabels,
+			Annotations:          s.TemplateAnnotations,
 			Scaling:              toWireScaling(s.Scaling),
 			VPCAccess:            toWireVPC(s.VPCAccess),
 			Timeout:              s.Timeout,

--- a/server/gcp/cloudrun/services_updatemask_sdk_test.go
+++ b/server/gcp/cloudrun/services_updatemask_sdk_test.go
@@ -1,0 +1,257 @@
+package cloudrun_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/api/option"
+	run "google.golang.org/api/run/v2"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// newRunWithURL boots an in-process GCP server and returns both a run/v2 SDK
+// client and the base URL, so tests can also issue raw field-masked PATCHes the
+// SDK's Patch helper does not model precisely.
+func newRunWithURL(t *testing.T) (*run.Service, string) {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP(config.WithContainerEngine(nil))
+	ts := httptest.NewServer(gcpserver.New(gcpserver.Drivers{CloudRun: cloud.CloudRun}))
+	t.Cleanup(ts.Close)
+
+	svc, err := run.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("run.NewService: %v", err)
+	}
+
+	return svc, ts.URL
+}
+
+// rawPatch issues a raw JSON PATCH with the given updateMask and returns the
+// decoded response, mirroring a field-masked SDK/gcloud request.
+func rawPatch(t *testing.T, base, resource, mask string, body any) map[string]any {
+	t.Helper()
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(body); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	url := base + "/v2/" + resource + "?updateMask=" + mask
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPatch, url, &buf)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH %s: %v", url, err)
+	}
+
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PATCH %s -> %d: %s", url, resp.StatusCode, string(raw))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("decode %q: %v", string(raw), err)
+	}
+
+	return m
+}
+
+func createWebService(t *testing.T, svc *run.Service, in *run.GoogleCloudRunV2Service) {
+	t.Helper()
+
+	if _, err := svc.Projects.Locations.Services.Create(parent, in).
+		ServiceId("web").Context(context.Background()).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
+// TestSDKServicePatchTrafficMaskPreservesTemplate covers B1: a field-masked
+// PATCH carrying only traffic must update traffic without wiping the container
+// template (the data-loss bug).
+func TestSDKServicePatchTrafficMaskPreservesTemplate(t *testing.T) {
+	svc, base := newRunWithURL(t)
+	ctx := context.Background()
+
+	createWebService(t, svc, sdkService())
+
+	rawPatch(t, base, parent+"/services/web", "traffic", map[string]any{
+		"traffic": []map[string]any{
+			{"type": "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST", "percent": 100, "tag": "prod"},
+		},
+	})
+
+	got, err := svc.Projects.Locations.Services.Get(parent + "/services/web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if len(got.Template.Containers) != 1 || got.Template.Containers[0].Image != "gcr.io/demo/web:v1" {
+		t.Fatalf("container wiped by masked PATCH: %+v", got.Template.Containers)
+	}
+
+	if got.Template.ServiceAccount != "web@demo-project.iam.gserviceaccount.com" {
+		t.Errorf("serviceAccount wiped: %q", got.Template.ServiceAccount)
+	}
+
+	if len(got.Traffic) != 1 || got.Traffic[0].Tag != "prod" {
+		t.Errorf("traffic not updated: %+v", got.Traffic)
+	}
+}
+
+// TestSDKServicePatchTrafficMaskNoNewRevision covers B2: a traffic-only update
+// leaves the template intact, so no new revision is cut and latestCreated stays.
+func TestSDKServicePatchTrafficMaskNoNewRevision(t *testing.T) {
+	svc, base := newRunWithURL(t)
+	ctx := context.Background()
+
+	createWebService(t, svc, sdkService())
+
+	before, err := svc.Projects.Locations.Services.Get(parent + "/services/web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get before: %v", err)
+	}
+
+	rawPatch(t, base, parent+"/services/web", "traffic", map[string]any{
+		"traffic": []map[string]any{
+			{"type": "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST", "percent": 100, "tag": "prod"},
+		},
+	})
+
+	after, err := svc.Projects.Locations.Services.Get(parent + "/services/web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after: %v", err)
+	}
+
+	if after.LatestCreatedRevision != before.LatestCreatedRevision {
+		t.Errorf("latestCreatedRevision advanced: %q -> %q", before.LatestCreatedRevision, after.LatestCreatedRevision)
+	}
+
+	list, err := svc.Projects.Locations.Services.Revisions.List(parent + "/services/web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Revisions.List: %v", err)
+	}
+
+	if len(list.Revisions) != 1 {
+		t.Errorf("revisions = %d, want 1 (no spurious revision)", len(list.Revisions))
+	}
+
+	if after.Traffic[0].Tag != "prod" {
+		t.Errorf("traffic not updated: %+v", after.Traffic)
+	}
+}
+
+// TestSDKServiceResourceLimitsRoundTrip covers B3: container resources.limits
+// (cpu/memory) survive create -> get.
+func TestSDKServiceResourceLimitsRoundTrip(t *testing.T) {
+	svc, _ := newRunWithURL(t)
+	ctx := context.Background()
+
+	in := sdkService()
+	in.Template.Containers[0].Resources = &run.GoogleCloudRunV2ResourceRequirements{
+		Limits: map[string]string{"cpu": "1000m", "memory": "512Mi"},
+	}
+	createWebService(t, svc, in)
+
+	got, err := svc.Projects.Locations.Services.Get(parent + "/services/web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	res := got.Template.Containers[0].Resources
+	if res == nil {
+		t.Fatal("resources dropped on round-trip")
+	}
+
+	if res.Limits["cpu"] != "1000m" || res.Limits["memory"] != "512Mi" {
+		t.Errorf("limits = %+v, want cpu=1000m memory=512Mi", res.Limits)
+	}
+}
+
+// TestSDKServiceTemplateLabelsAnnotationsRoundTrip covers B4: revisionTemplate
+// labels and annotations survive create -> get.
+func TestSDKServiceTemplateLabelsAnnotationsRoundTrip(t *testing.T) {
+	svc, _ := newRunWithURL(t)
+	ctx := context.Background()
+
+	in := sdkService()
+	in.Template.Labels = map[string]string{"team": "web"}
+	in.Template.Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}
+	createWebService(t, svc, in)
+
+	got, err := svc.Projects.Locations.Services.Get(parent + "/services/web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Template.Labels["team"] != "web" {
+		t.Errorf("template labels = %+v, want team=web", got.Template.Labels)
+	}
+
+	if got.Template.Annotations["autoscaling.knative.dev/maxScale"] != "10" {
+		t.Errorf("template annotations = %+v, want maxScale=10", got.Template.Annotations)
+	}
+}
+
+// TestSDKServiceFullPutStillReplaces covers the regression: a maskless PUT
+// (Terraform-style) still full-replaces — a field omitted from the new body is
+// cleared, not preserved.
+func TestSDKServiceFullPutStillReplaces(t *testing.T) {
+	svc, _ := newRunWithURL(t)
+	ctx := context.Background()
+
+	createWebService(t, svc, sdkService())
+
+	replacement := &run.GoogleCloudRunV2Service{
+		Description: "replaced",
+		Template: &run.GoogleCloudRunV2RevisionTemplate{
+			Containers: []*run.GoogleCloudRunV2Container{{Image: "gcr.io/demo/web:v2"}},
+		},
+	}
+
+	if _, err := svc.Projects.Locations.Services.Patch(parent+"/services/web", replacement).
+		Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Services.Get(parent + "/services/web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Description != "replaced" {
+		t.Errorf("description = %q, want replaced", got.Description)
+	}
+
+	if got.Template.Containers[0].Image != "gcr.io/demo/web:v2" {
+		t.Errorf("image = %q, want v2", got.Template.Containers[0].Image)
+	}
+
+	if got.Template.ServiceAccount != "" {
+		t.Errorf("serviceAccount = %q, want cleared by full replace", got.Template.ServiceAccount)
+	}
+
+	if got.Generation != 2 {
+		t.Errorf("generation = %d, want 2", got.Generation)
+	}
+}

--- a/server/gcp/cloudrun/types.go
+++ b/server/gcp/cloudrun/types.go
@@ -39,12 +39,21 @@ type taskTemplate struct {
 }
 
 type container struct {
-	Name    string          `json:"name,omitempty"`
-	Image   string          `json:"image"`
-	Command []string        `json:"command,omitempty"`
-	Args    []string        `json:"args,omitempty"`
-	Env     []envVar        `json:"env,omitempty"`
-	Ports   []containerPort `json:"ports,omitempty"`
+	Name      string                `json:"name,omitempty"`
+	Image     string                `json:"image"`
+	Command   []string              `json:"command,omitempty"`
+	Args      []string              `json:"args,omitempty"`
+	Env       []envVar              `json:"env,omitempty"`
+	Ports     []containerPort       `json:"ports,omitempty"`
+	Resources *resourceRequirements `json:"resources,omitempty"`
+}
+
+// resourceRequirements is Container.resources — cpu/memory limits and CPU
+// behavior toggles that every Terraform/gcloud deploy sends and reads back.
+type resourceRequirements struct {
+	Limits          map[string]string `json:"limits,omitempty"`
+	CPUIdle         *bool             `json:"cpuIdle,omitempty"`
+	StartupCPUBoost *bool             `json:"startupCpuBoost,omitempty"`
 }
 
 type containerPort struct {

--- a/services/cloudrun/driver/driver.go
+++ b/services/cloudrun/driver/driver.go
@@ -94,12 +94,22 @@ type JobConfig struct {
 
 // Container is one container in a job or service task template.
 type Container struct {
-	Name    string
-	Image   string
-	Command []string          // entrypoint override
-	Args    []string          // arguments to the entrypoint
-	Env     map[string]string // environment variables
-	Ports   []int             // container ports (services)
+	Name      string
+	Image     string
+	Command   []string              // entrypoint override
+	Args      []string              // arguments to the entrypoint
+	Env       map[string]string     // environment variables
+	Ports     []int                 // container ports (services)
+	Resources *ResourceRequirements // cpu/memory limits and CPU behavior
+}
+
+// ResourceRequirements is a container's compute allocation — the limits map
+// (e.g. {"cpu":"1000m","memory":"512Mi"}) plus CPU behavior toggles. Every
+// Terraform/gcloud deploy sends and reads these back, so they must round-trip.
+type ResourceRequirements struct {
+	Limits          map[string]string
+	CPUIdle         *bool
+	StartupCPUBoost *bool
 }
 
 // VpcAccess is the VPC connectivity configuration of a job or service template.
@@ -214,6 +224,12 @@ type ServiceConfig struct {
 	Traffic              []TrafficTarget
 	Labels               map[string]string
 	Annotations          map[string]string
+	TemplateLabels       map[string]string // revisionTemplate.labels
+	TemplateAnnotations  map[string]string // revisionTemplate.annotations (autoscaling.knative.dev/*)
+	// UpdateMask names the top-level (or dotted template.*) field paths a PATCH
+	// touches. Empty means full replace (a maskless PUT, as Terraform sends);
+	// non-empty means merge only the named paths onto the existing service.
+	UpdateMask []string
 }
 
 // ServiceScaling is a service's revision-template scaling bounds.
@@ -257,6 +273,8 @@ type Service struct {
 	LatestCreatedRevision string
 	Labels                map[string]string
 	Annotations           map[string]string
+	TemplateLabels        map[string]string // revisionTemplate.labels
+	TemplateAnnotations   map[string]string // revisionTemplate.annotations
 	Conditions            []Condition
 	TerminalCondition     *Condition
 	Etag                  string


### PR DESCRIPTION
## Summary

Fixes four GCP Cloud Run (`run.googleapis.com` v2) Services bugs that caused data loss and Terraform/gcloud round-trip drift.

### 1. [HIGH data-loss] Field-masked PATCH ignored `updateMask` and wiped unspecified fields
A `PATCH .../services/{id}?updateMask=traffic` carrying only `traffic` (what `gcloud run services update-traffic` and field-masked SDK clients send) previously overwrote every mutable field from the partial body, wiping `template.containers` etc. Now `updateService` parses `updateMask` and the driver merges only the masked paths onto the existing service, preserving everything unmasked. A maskless PUT (Terraform's `google_cloud_run_v2_service`) still full-replaces. Supported masks: `traffic`, `template` (and dotted `template.<sub>`), `labels`, `annotations`, `ingress`, `description`.

### 2. [LOW] Spurious revision on template-unchanged update
Every update materialized a new revision and advanced `latestCreated`/`latestReady`, even for a traffic-only change. Now a new revision is cut only when the revision template actually changes; a traffic-only update updates traffic without a new revision.

### 3. [HIGH drift] `template.containers[].resources.limits` not modeled
`resources` (limits map + `cpuIdle`/`startupCpuBoost`) is now modeled end to end (wire, driver, conv, clone) and round-trips on create->get and update.

### 4. `template.labels` / `template.annotations` dropped
`revisionTemplate` labels/annotations (where `autoscaling.knative.dev/maxScale` etc. live) are now mapped through the driver and emitted on Get.

## Tests
New real-SDK (`google.golang.org/api/run/v2`) + raw field-masked PATCH e2e tests against a booted `gcpserver.New`:
- masked `updateMask=traffic` PATCH preserves the container template and updates traffic (B1)
- traffic-only update cuts no new revision, `latestCreatedRevision` unchanged (B2)
- `resources.limits{cpu,memory}` round-trips on create+get (B3)
- `template.labels`/`annotations` round-trip (B4)
- maskless full PUT still full-replaces, clearing omitted fields (regression)
