### PR TITLE
fix(sns): honor Publish MessageStructure=json, preserve attribute DataType, persist CreateTopic attributes

### DIFF
--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -27,6 +27,14 @@ const (
 	statusPending   = "pending"
 )
 
+// SNS message-structure and message-attribute constants.
+const (
+	messageStructureJSON  = "json"
+	defaultProtocolKey    = "default"
+	protocolSQS           = "sqs"
+	messageAttrTypeString = "String"
+)
+
 type publishedMessage struct {
 	ID         string
 	TopicID    string
@@ -142,13 +150,18 @@ func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 	}
 
 	info := driver.TopicInfo{
-		ID:                idgen.GenerateID("topic-"),
-		Name:              cfg.Name,
-		Scope:             cfg.Scope,
-		ResourceID:        arn,
-		DisplayName:       cfg.DisplayName,
-		SubscriptionCount: 0,
-		Tags:              tags,
+		ID:                        idgen.GenerateID("topic-"),
+		Name:                      cfg.Name,
+		Scope:                     cfg.Scope,
+		ResourceID:                arn,
+		DisplayName:               cfg.DisplayName,
+		Policy:                    cfg.Policy,
+		DeliveryPolicy:            cfg.DeliveryPolicy,
+		KmsMasterKeyID:            cfg.KmsMasterKeyID,
+		FifoTopic:                 cfg.FifoTopic,
+		ContentBasedDeduplication: cfg.ContentBasedDeduplication,
+		SubscriptionCount:         0,
+		Tags:                      tags,
 	}
 
 	td := &topicData{
@@ -356,6 +369,10 @@ func (m *Mock) Publish(ctx context.Context, input driver.PublishInput) (*driver.
 		return nil, errors.New(errors.InvalidArgument, "message is required")
 	}
 
+	if err := validateMessageStructure(&input); err != nil {
+		return nil, err
+	}
+
 	msgID := idgen.GenerateID("msg-")
 
 	attrs := make(map[string]string, len(input.Attributes))
@@ -407,6 +424,65 @@ func arnResource(arn string) string {
 	return arn
 }
 
+// validateMessageStructure enforces the SNS rules for a MessageStructure=json
+// publish: only "json" is accepted, the message must parse as a JSON object of
+// string values, and it must carry a "default" entry (used for any protocol
+// without a specific key). An empty structure leaves the message unchanged.
+func validateMessageStructure(input *driver.PublishInput) error {
+	if input.MessageStructure == "" {
+		return nil
+	}
+
+	if input.MessageStructure != messageStructureJSON {
+		return errors.New(errors.InvalidArgument, "Invalid parameter: Invalid message structure. Must be json")
+	}
+
+	parsed, ok := parseStructuredMessage(input.Message)
+	if !ok {
+		return errors.New(errors.InvalidArgument,
+			"Invalid parameter: Message Structure - JSON message body failed to parse")
+	}
+
+	if _, ok := parsed[defaultProtocolKey]; !ok {
+		return errors.New(errors.InvalidArgument,
+			"Invalid parameter: Message Structure - No default entry in JSON message body")
+	}
+
+	return nil
+}
+
+// parseStructuredMessage decodes a MessageStructure=json body into its
+// per-protocol string map. It reports false when the body is not a JSON object
+// of strings.
+func parseStructuredMessage(message string) (map[string]string, bool) {
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(message), &parsed); err != nil {
+		return nil, false
+	}
+
+	return parsed, true
+}
+
+// resolveProtocolMessage returns the body a subscriber of the given protocol
+// receives. For a MessageStructure=json publish it selects the protocol-specific
+// entry, falling back to "default"; otherwise the raw message is returned as-is.
+func resolveProtocolMessage(input *driver.PublishInput, protocol string) string {
+	if input.MessageStructure != messageStructureJSON {
+		return input.Message
+	}
+
+	parsed, ok := parseStructuredMessage(input.Message)
+	if !ok {
+		return input.Message
+	}
+
+	if v, present := parsed[protocol]; present {
+		return v
+	}
+
+	return parsed[defaultProtocolKey]
+}
+
 // fanOutToSQS delivers a published message to every SQS-protocol subscription
 // on the topic, wrapping it in the SNS notification envelope real SNS uses.
 func (m *Mock) fanOutToSQS(ctx context.Context, td *topicData, msgID string, input *driver.PublishInput) {
@@ -414,8 +490,10 @@ func (m *Mock) fanOutToSQS(ctx context.Context, td *topicData, msgID string, inp
 		return
 	}
 
+	message := resolveProtocolMessage(input, protocolSQS)
+
 	for _, sub := range td.subscriptions.All() {
-		if sub.Protocol != "sqs" || sub.Endpoint == "" {
+		if sub.Protocol != protocolSQS || sub.Endpoint == "" {
 			continue
 		}
 
@@ -427,10 +505,10 @@ func (m *Mock) fanOutToSQS(ctx context.Context, td *topicData, msgID string, inp
 
 		// With raw message delivery enabled, SNS strips its metadata and sends
 		// the published message body as-is instead of the Notification envelope.
-		body := input.Message
+		body := message
 
 		if !rawDeliveryEnabled(&sub) {
-			envelope, err := m.notificationEnvelope(td, msgID, input, sub.ID)
+			envelope, err := m.notificationEnvelope(td, msgID, input, message, sub.ID)
 			if err != nil {
 				continue
 			}
@@ -459,12 +537,14 @@ func (m *Mock) deliverToSQS(ctx context.Context, queueARN, body string, input *d
 
 // notificationEnvelope builds the SNS Notification JSON that wraps a published
 // message for a non-raw SQS subscription.
-func (m *Mock) notificationEnvelope(td *topicData, msgID string, input *driver.PublishInput, subARN string) (string, error) {
+func (m *Mock) notificationEnvelope(
+	td *topicData, msgID string, input *driver.PublishInput, message, subARN string,
+) (string, error) {
 	env := map[string]any{
 		"Type":             "Notification",
 		"MessageId":        msgID,
 		"TopicArn":         td.info.ResourceID,
-		"Message":          input.Message,
+		"Message":          message,
 		"Timestamp":        m.opts.Clock.Now().UTC().Format(time.RFC3339),
 		"SignatureVersion": "1",
 		"Signature":        "Q2xvdWRFbXVFeGFtcGxlU2lnbmF0dXJl",
@@ -481,14 +561,9 @@ func (m *Mock) notificationEnvelope(td *topicData, msgID string, input *driver.P
 	}
 
 	// Real SNS carries publish MessageAttributes into the SQS envelope as
-	// {name: {"Type": "String", "Value": v}}; preserve them end-to-end.
-	if len(input.Attributes) > 0 {
-		attrs := make(map[string]any, len(input.Attributes))
-		for k, v := range input.Attributes {
-			attrs[k] = map[string]string{"Type": "String", "Value": v}
-		}
-
-		env["MessageAttributes"] = attrs
+	// {name: {"Type": <DataType>, "Value": v}}; preserve the DataType end-to-end.
+	if len(input.AttributeEntries) > 0 || len(input.Attributes) > 0 {
+		env["MessageAttributes"] = envelopeAttributes(input)
 	}
 
 	body, err := json.Marshal(env)
@@ -497,4 +572,35 @@ func (m *Mock) notificationEnvelope(td *topicData, msgID string, input *driver.P
 	}
 
 	return string(body), nil
+}
+
+// envelopeAttributes renders the publish's message attributes into the
+// {name: {"Type": DataType, "Value": v}} shape SNS puts on the SQS envelope. It
+// prefers the typed AttributeEntries (preserving Number/Binary), falling back to
+// the flat string attributes as "String" for non-SNS publishes.
+func envelopeAttributes(input *driver.PublishInput) map[string]any {
+	if len(input.AttributeEntries) > 0 {
+		out := make(map[string]any, len(input.AttributeEntries))
+		for k, e := range input.AttributeEntries {
+			out[k] = map[string]string{"Type": defaultDataType(e.DataType), "Value": e.Value}
+		}
+
+		return out
+	}
+
+	out := make(map[string]any, len(input.Attributes))
+	for k, v := range input.Attributes {
+		out[k] = map[string]string{"Type": messageAttrTypeString, "Value": v}
+	}
+
+	return out
+}
+
+// defaultDataType returns dt, or "String" when dt is empty.
+func defaultDataType(dt string) string {
+	if dt == "" {
+		return messageAttrTypeString
+	}
+
+	return dt
 }

--- a/server/aws/sns/create_topic_attributes_sdk_test.go
+++ b/server/aws/sns/create_topic_attributes_sdk_test.go
@@ -1,0 +1,70 @@
+package sns_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+)
+
+// topicAttributes fetches a topic's GetTopicAttributes map.
+func topicAttributes(t *testing.T, sns *awssns.Client, arn string) map[string]string {
+	t.Helper()
+
+	out, err := sns.GetTopicAttributes(context.Background(), &awssns.GetTopicAttributesInput{
+		TopicArn: aws.String(arn),
+	})
+	if err != nil {
+		t.Fatalf("GetTopicAttributes: %v", err)
+	}
+
+	return out.Attributes
+}
+
+// TestSDKSNSCreateTopicDisplayName asserts CreateTopic Attributes.DisplayName is
+// persisted and echoed by GetTopicAttributes (was dropped at create time).
+func TestSDKSNSCreateTopicDisplayName(t *testing.T) {
+	sns := newSDKClient(t)
+	ctx := context.Background()
+
+	topic, err := sns.CreateTopic(ctx, &awssns.CreateTopicInput{
+		Name:       aws.String("named"),
+		Attributes: map[string]string{"DisplayName": "My Topic"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	if got := topicAttributes(t, sns, aws.ToString(topic.TopicArn))["DisplayName"]; got != "My Topic" {
+		t.Fatalf("DisplayName = %q, want %q", got, "My Topic")
+	}
+}
+
+// TestSDKSNSCreateTopicFifoFlags asserts a .fifo topic created with FifoTopic and
+// ContentBasedDeduplication persists both flags for GetTopicAttributes to reflect.
+func TestSDKSNSCreateTopicFifoFlags(t *testing.T) {
+	sns := newSDKClient(t)
+	ctx := context.Background()
+
+	topic, err := sns.CreateTopic(ctx, &awssns.CreateTopicInput{
+		Name: aws.String("orders.fifo"),
+		Attributes: map[string]string{
+			"FifoTopic":                 "true",
+			"ContentBasedDeduplication": "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateTopic(fifo): %v", err)
+	}
+
+	attrs := topicAttributes(t, sns, aws.ToString(topic.TopicArn))
+
+	if attrs["FifoTopic"] != "true" {
+		t.Fatalf("FifoTopic = %q, want true", attrs["FifoTopic"])
+	}
+
+	if attrs["ContentBasedDeduplication"] != "true" {
+		t.Fatalf("ContentBasedDeduplication = %q, want true", attrs["ContentBasedDeduplication"])
+	}
+}

--- a/server/aws/sns/operations.go
+++ b/server/aws/sns/operations.go
@@ -94,25 +94,25 @@ func (h *Handler) untagResource(w http.ResponseWriter, r *http.Request) {
 }
 
 // parseMessageAttributes reads SNS Publish MessageAttributes.entry.N.Name /
-// .Value.StringValue form parameters into a flat name->value map. Only string
-// values are modeled (the common case); binary values are ignored.
-func parseMessageAttributes(form url.Values) map[string]string {
+// .Value.{DataType,StringValue,BinaryValue} form parameters into typed
+// attributes, preserving the DataType (String/Number/Binary).
+func parseMessageAttributes(form url.Values) map[string]notifdriver.MessageAttribute {
 	return parseMessageAttributesAt(form, "MessageAttributes.entry")
 }
 
 // parseBatchMessageAttributes reads a PublishBatch entry's MessageAttributes,
 // which are nested under the entry's form prefix.
-func parseBatchMessageAttributes(form url.Values, entryPrefix string) map[string]string {
+func parseBatchMessageAttributes(form url.Values, entryPrefix string) map[string]notifdriver.MessageAttribute {
 	return parseMessageAttributesAt(form, entryPrefix+".MessageAttributes.entry")
 }
 
-func parseMessageAttributesAt(form url.Values, prefix string) map[string]string {
+func parseMessageAttributesAt(form url.Values, prefix string) map[string]notifdriver.MessageAttribute {
 	idx := awsquery.CollectIndices(form, prefix)
 	if len(idx) == 0 {
 		return nil
 	}
 
-	out := make(map[string]string, len(idx))
+	out := make(map[string]notifdriver.MessageAttribute, len(idx))
 
 	for _, i := range idx {
 		base := prefix + "." + strconv.Itoa(i)
@@ -122,7 +122,36 @@ func parseMessageAttributesAt(form url.Values, prefix string) map[string]string 
 			continue
 		}
 
-		out[name] = form.Get(base + ".Value.StringValue")
+		out[name] = messageAttributeFromForm(form, base)
+	}
+
+	return out
+}
+
+// messageAttributeFromForm reads one MessageAttributeValue (DataType plus the
+// string or base64 binary value) from its form prefix.
+func messageAttributeFromForm(form url.Values, base string) notifdriver.MessageAttribute {
+	value := form.Get(base + ".Value.StringValue")
+	if binary := form.Get(base + ".Value.BinaryValue"); binary != "" {
+		value = binary
+	}
+
+	return notifdriver.MessageAttribute{
+		DataType: form.Get(base + ".Value.DataType"),
+		Value:    value,
+	}
+}
+
+// attributeValues projects typed message attributes onto the flat name->value
+// map used for filter-policy matching and cross-cloud delivery.
+func attributeValues(entries map[string]notifdriver.MessageAttribute) map[string]string {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(entries))
+	for k, e := range entries {
+		out[k] = e.Value
 	}
 
 	return out
@@ -134,10 +163,17 @@ func parseMessageAttributesAt(form url.Values, prefix string) map[string]string 
 // lookup + echo of the existing topic.
 func (h *Handler) createTopic(w http.ResponseWriter, r *http.Request) {
 	name := r.Form.Get("Name")
+	attrs := parseSubscriptionAttributes(r.Form)
 
 	info, err := h.notif.CreateTopic(r.Context(), notifdriver.TopicConfig{
-		Name: name,
-		Tags: parseSNSTags(r.Form),
+		Name:                      name,
+		Tags:                      parseSNSTags(r.Form),
+		DisplayName:               attrs["DisplayName"],
+		Policy:                    attrs["Policy"],
+		DeliveryPolicy:            attrs["DeliveryPolicy"],
+		KmsMasterKeyID:            attrs["KmsMasterKeyId"],
+		FifoTopic:                 attrs["FifoTopic"] == attrTrue,
+		ContentBasedDeduplication: attrs["ContentBasedDeduplication"] == attrTrue,
 	})
 	if err != nil {
 		if cerrors.IsAlreadyExists(err) {
@@ -261,15 +297,45 @@ func (h *Handler) getTopicAttributes(w http.ResponseWriter, r *http.Request) {
 		{Key: "Policy", Value: policy},
 		{Key: "EffectiveDeliveryPolicy", Value: defaultEffectiveDeliveryPolicy},
 	}
-	if info.DisplayName != "" {
-		entries = append(entries, attributeEntry{Key: "DisplayName", Value: info.DisplayName})
-	}
+	entries = append(entries, optionalTopicAttributes(info)...)
 
 	awsquery.WriteXMLResponse(w, getTopicAttributesResponse{
 		Xmlns:    Namespace,
 		Result:   getTopicAttributesResult{Attributes: attributesMap{Entries: entries}},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
+}
+
+// optionalTopicAttributes returns the GetTopicAttributes entries SNS emits only
+// when set: DisplayName, DeliveryPolicy, KmsMasterKeyId, and — for a FIFO topic —
+// the FifoTopic / ContentBasedDeduplication flags.
+func optionalTopicAttributes(info *notifdriver.TopicInfo) []attributeEntry {
+	var entries []attributeEntry
+
+	entries = appendNonEmptyAttr(entries, "DisplayName", info.DisplayName)
+	entries = appendNonEmptyAttr(entries, "DeliveryPolicy", info.DeliveryPolicy)
+	entries = appendNonEmptyAttr(entries, "KmsMasterKeyId", info.KmsMasterKeyID)
+
+	if info.FifoTopic {
+		entries = append(entries,
+			attributeEntry{Key: "FifoTopic", Value: attrTrue},
+			attributeEntry{
+				Key:   "ContentBasedDeduplication",
+				Value: strconv.FormatBool(info.ContentBasedDeduplication),
+			},
+		)
+	}
+
+	return entries
+}
+
+// appendNonEmptyAttr appends a {key,value} entry only when value is non-empty.
+func appendNonEmptyAttr(entries []attributeEntry, key, value string) []attributeEntry {
+	if value == "" {
+		return entries
+	}
+
+	return append(entries, attributeEntry{Key: key, Value: value})
 }
 
 func (h *Handler) listTopics(w http.ResponseWriter, r *http.Request) {
@@ -429,11 +495,15 @@ func (h *Handler) publish(w http.ResponseWriter, r *http.Request) {
 		arn = r.Form.Get("TargetArn")
 	}
 
+	attrs := parseMessageAttributes(r.Form)
+
 	out, err := h.notif.Publish(r.Context(), notifdriver.PublishInput{
 		TopicID:                topicNameFromARN(arn),
 		Subject:                r.Form.Get("Subject"),
 		Message:                r.Form.Get("Message"),
-		Attributes:             parseMessageAttributes(r.Form),
+		Attributes:             attributeValues(attrs),
+		AttributeEntries:       attrs,
+		MessageStructure:       r.Form.Get("MessageStructure"),
 		MessageGroupID:         r.Form.Get("MessageGroupId"),
 		MessageDeduplicationID: r.Form.Get("MessageDeduplicationId"),
 	})

--- a/server/aws/sns/publish_message_shape_sdk_test.go
+++ b/server/aws/sns/publish_message_shape_sdk_test.go
@@ -1,0 +1,166 @@
+package sns_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+)
+
+// subscribeSQS creates a topic, subscribes an SQS queue to it, and returns the
+// topic ARN and the queue URL. Delivery uses the default (non-raw) envelope so
+// tests can inspect the SNS Notification JSON.
+func subscribeSQS(t *testing.T, sns *awssns.Client, sqs *awssqs.Client, topicName, queueName string) (topicARN, queueURL string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	url, arn := snsQueue(t, sqs, queueName)
+
+	topic, err := sns.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String(topicName)})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	if _, err := sns.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn:              topic.TopicArn,
+		Protocol:              aws.String("sqs"),
+		Endpoint:              aws.String(arn),
+		ReturnSubscriptionArn: true,
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	return aws.ToString(topic.TopicArn), url
+}
+
+// TestSDKSNSPublishMessageStructureJSON asserts a MessageStructure=json publish
+// resolves the per-protocol value: an SQS subscriber must receive the "sqs"
+// entry, not the raw {"default":...,"sqs":...} blob.
+func TestSDKSNSPublishMessageStructureJSON(t *testing.T) {
+	sns, sqs := newSNSAndSQS(t)
+	ctx := context.Background()
+
+	topicARN, url := subscribeSQS(t, sns, sqs, "structured", "structured-sink")
+
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn:         aws.String(topicARN),
+		Message:          aws.String(`{"default":"d","sqs":"s"}`),
+		MessageStructure: aws.String("json"),
+	}); err != nil {
+		t.Fatalf("Publish(json): %v", err)
+	}
+
+	bodies := drain(t, sqs, url)
+	if len(bodies) != 1 {
+		t.Fatalf("delivered %d messages, want 1", len(bodies))
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal([]byte(bodies[0]), &env); err != nil {
+		t.Fatalf("envelope not JSON: %v (%s)", err, bodies[0])
+	}
+
+	if got := env["Message"]; got != "s" {
+		t.Fatalf("Message = %v, want %q (the per-protocol sqs value)", got, "s")
+	}
+}
+
+// TestSDKSNSPublishMessageStructureFallbackDefault asserts a protocol without a
+// specific key falls back to "default", and that a missing default is rejected.
+func TestSDKSNSPublishMessageStructureFallbackDefault(t *testing.T) {
+	sns, sqs := newSNSAndSQS(t)
+	ctx := context.Background()
+
+	topicARN, url := subscribeSQS(t, sns, sqs, "fallback", "fallback-sink")
+
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn:         aws.String(topicARN),
+		Message:          aws.String(`{"default":"only-default"}`),
+		MessageStructure: aws.String("json"),
+	}); err != nil {
+		t.Fatalf("Publish(default-only): %v", err)
+	}
+
+	bodies := drain(t, sqs, url)
+	if len(bodies) != 1 {
+		t.Fatalf("delivered %d messages, want 1", len(bodies))
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal([]byte(bodies[0]), &env); err != nil {
+		t.Fatalf("envelope not JSON: %v", err)
+	}
+
+	if got := env["Message"]; got != "only-default" {
+		t.Fatalf("Message = %v, want fallback to default", got)
+	}
+
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn:         aws.String(topicARN),
+		Message:          aws.String(`{"sqs":"s"}`),
+		MessageStructure: aws.String("json"),
+	}); err == nil {
+		t.Fatal("Publish with no default entry succeeded, want InvalidParameter")
+	}
+
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn:         aws.String(topicARN),
+		Message:          aws.String("not json"),
+		MessageStructure: aws.String("json"),
+	}); err == nil {
+		t.Fatal("Publish of non-JSON body with json structure succeeded, want InvalidParameter")
+	}
+}
+
+// TestSDKSNSPublishNumberAttributeType asserts a Number message attribute keeps
+// its DataType end-to-end: the SNS->SQS envelope must show "Type":"Number", not
+// a flattened "String".
+func TestSDKSNSPublishNumberAttributeType(t *testing.T) {
+	sns, sqs := newSNSAndSQS(t)
+	ctx := context.Background()
+
+	topicARN, url := subscribeSQS(t, sns, sqs, "typed", "typed-sink")
+
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn: aws.String(topicARN),
+		Message:  aws.String("hi"),
+		MessageAttributes: map[string]snstypes.MessageAttributeValue{
+			"price": {DataType: aws.String("Number"), StringValue: aws.String("42")},
+		},
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	bodies := drain(t, sqs, url)
+	if len(bodies) != 1 {
+		t.Fatalf("delivered %d messages, want 1", len(bodies))
+	}
+
+	var env struct {
+		MessageAttributes map[string]struct {
+			Type  string `json:"Type"`
+			Value string `json:"Value"`
+		} `json:"MessageAttributes"`
+	}
+	if err := json.Unmarshal([]byte(bodies[0]), &env); err != nil {
+		t.Fatalf("envelope not JSON: %v", err)
+	}
+
+	price, ok := env.MessageAttributes["price"]
+	if !ok {
+		t.Fatalf("price attribute missing from envelope: %s", bodies[0])
+	}
+
+	if price.Type != "Number" {
+		t.Fatalf("price Type = %q, want Number", price.Type)
+	}
+
+	if price.Value != "42" {
+		t.Fatalf("price Value = %q, want 42", price.Value)
+	}
+}

--- a/server/aws/sns/subscription_attributes.go
+++ b/server/aws/sns/subscription_attributes.go
@@ -213,12 +213,15 @@ func (h *Handler) publishBatch(w http.ResponseWriter, r *http.Request) {
 	for _, i := range idx {
 		base := "PublishBatchRequestEntries.member." + strconv.Itoa(i)
 		entryID := r.Form.Get(base + ".Id")
+		attrs := parseBatchMessageAttributes(r.Form, base)
 
 		out, err := h.notif.Publish(r.Context(), notifdriver.PublishInput{
 			TopicID:                topicID,
 			Subject:                r.Form.Get(base + ".Subject"),
 			Message:                r.Form.Get(base + ".Message"),
-			Attributes:             parseBatchMessageAttributes(r.Form, base),
+			Attributes:             attributeValues(attrs),
+			AttributeEntries:       attrs,
+			MessageStructure:       r.Form.Get(base + ".MessageStructure"),
 			MessageGroupID:         r.Form.Get(base + ".MessageGroupId"),
 			MessageDeduplicationID: r.Form.Get(base + ".MessageDeduplicationId"),
 		})

--- a/services/notification/driver/driver.go
+++ b/services/notification/driver/driver.go
@@ -16,6 +16,16 @@ type TopicConfig struct {
 	// Policy is the JSON access policy (AWS SNS). Empty leaves the topic on
 	// its synthesized default policy.
 	Policy string
+	// DeliveryPolicy is the JSON HTTP delivery policy (AWS SNS). Empty leaves
+	// the topic on its synthesized default.
+	DeliveryPolicy string
+	// KmsMasterKeyID names the KMS key for server-side encryption (AWS SNS).
+	KmsMasterKeyID string
+	// FifoTopic marks the topic as FIFO. ContentBasedDeduplication toggles
+	// content-based deduplication on a FIFO topic. Both are persisted and echoed
+	// by GetTopicAttributes; FIFO publish ordering/dedup is not yet enforced.
+	FifoTopic                 bool
+	ContentBasedDeduplication bool
 
 	// Scope records where the resource lives (Azure subscription/resource
 	// group, GCP project). Zero for AWS and unscoped portable callers.
@@ -42,8 +52,17 @@ type TopicInfo struct {
 	SubscriptionsDeleted   int
 	// Policy is the JSON access policy (AWS SNS); empty means the default.
 	Policy string
-	Tags   map[string]string
-	Scope  scope.Scope
+	// DeliveryPolicy is the JSON HTTP delivery policy (AWS SNS); empty means the
+	// default. KmsMasterKeyID names the server-side-encryption KMS key.
+	DeliveryPolicy string
+	KmsMasterKeyID string
+	// FifoTopic / ContentBasedDeduplication reflect the FIFO flags captured at
+	// create time. GetTopicAttributes echoes them; publish ordering is not
+	// enforced.
+	FifoTopic                 bool
+	ContentBasedDeduplication bool
+	Tags                      map[string]string
+	Scope                     scope.Scope
 	// Region is the geographic location the resource was created in (Azure
 	// location). Empty for AWS and unscoped portable callers.
 	Region string
@@ -74,12 +93,28 @@ type SubscriptionInfo struct {
 	ConfirmationToken string
 }
 
+// MessageAttribute is a typed SNS message attribute carried on a publish.
+// DataType is "String", "Number", or "Binary". Value holds the string (or
+// Number) value; for a Binary attribute Value holds the base64-encoded bytes.
+type MessageAttribute struct {
+	DataType string
+	Value    string
+}
+
 // PublishInput configures a message publish operation.
 type PublishInput struct {
-	TopicID    string
-	Subject    string
-	Message    string
-	Attributes map[string]string
+	TopicID string
+	Subject string
+	Message string
+	// Attributes carries the flat name->value view of the message attributes,
+	// used for filter-policy matching and cross-cloud publishes. AttributeEntries
+	// carries the typed (DataType-preserving) view used to build the SNS delivery
+	// envelope; it is nil for non-SNS publishes.
+	Attributes       map[string]string
+	AttributeEntries map[string]MessageAttribute
+	// MessageStructure is "json" when Message is a per-protocol JSON blob
+	// ({"default":...,"sqs":...}); empty means Message is delivered verbatim.
+	MessageStructure string
 	// MessageGroupID / MessageDeduplicationID carry the FIFO ordering and
 	// deduplication identifiers of a publish to a FIFO topic. They are empty for
 	// standard topics and are threaded to a FIFO SQS subscription so the queue,


### PR DESCRIPTION
## Summary

Fixes three AWS SNS wire-server bugs, all verified end-to-end with the real `aws-sdk-go-v2/sns` and `/sqs` clients against a booted in-process server.

### 1. [HIGH] `Publish` `MessageStructure="json"` was ignored
The raw `{"default":"d","sqs":"s"}` blob was delivered verbatim. Now `MessageStructure` and the raw message are threaded through `PublishInput` and resolved **per-protocol at fan-out**: an SQS subscriber receives the `sqs` key, falling back to `default`. A non-JSON body with `MessageStructure=json`, or a JSON body with no `default` entry, is rejected with `InvalidParameter` (matching real SNS, which requires `default`). When `MessageStructure` is unset the message is delivered unchanged.

### 2. [MED] Message-attribute `DataType` (Number/Binary) was lost
The SNS→SQS envelope always emitted `"Type":"String"`. The wire parse now reads `DataType`/`BinaryValue`, carried through a new typed `PublishInput.AttributeEntries` (`map[string]MessageAttribute`) into the envelope, so `{"price":{"Type":"Number","Value":"42"}}` round-trips. The flat `Attributes` map is retained for filter-policy matching (numeric filters still work).

### 3. [MED] `CreateTopic` `Attributes` were dropped
`DisplayName`, `Policy`, `DeliveryPolicy`, `KmsMasterKeyId` are now parsed from the create-time `Attributes.entry.*` form params into `TopicConfig` and reflected by `GetTopicAttributes`. `FifoTopic` + `ContentBasedDeduplication` flags are persisted and echoed (full FIFO publish semantics — MessageGroupId validation, SequenceNumber — remain deferred).

## Tests added (real SNS + SQS SDKs)
- `TestSDKSNSPublishMessageStructureJSON` — queue receives `"s"`
- `TestSDKSNSPublishMessageStructureFallbackDefault` — default fallback + missing-default/non-JSON rejection
- `TestSDKSNSPublishNumberAttributeType` — envelope shows `"Type":"Number"`
- `TestSDKSNSCreateTopicDisplayName` — `GetTopicAttributes` returns the DisplayName
- `TestSDKSNSCreateTopicFifoFlags` — `.fifo` topic reflects `FifoTopic`/`ContentBasedDeduplication`
