### PR TITLE
fix(dynamodb): parallel-scan segments, Select mode, numeric key identity, transact idempotency+limit

### DIFF
--- a/providers/aws/dynamodb/conditional.go
+++ b/providers/aws/dynamodb/conditional.go
@@ -2,13 +2,30 @@ package dynamodb
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"maps"
 	"strings"
+	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/database/driver"
 	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
 )
+
+// transactIdempotencyWindow is how long a TransactWriteItems ClientRequestToken
+// is remembered so a retry with the same token is treated as a replay rather
+// than a second application (real DynamoDB uses ~10 minutes).
+const transactIdempotencyWindow = 10 * time.Minute
+
+// txIdempotencyRecord is a remembered ClientRequestToken: the fingerprint of the
+// request it first committed and when, so a replay with a matching body is a
+// no-op while a different body with the same token is a parameter mismatch.
+type txIdempotencyRecord struct {
+	fingerprint string
+	storedAt    time.Time
+}
 
 // This file holds the ATOMIC conditional-write and transaction primitives. The
 // wire handler must NOT evaluate a ConditionExpression with a standalone GetItem
@@ -244,12 +261,16 @@ func updateBaseImage(item map[string]any, present bool, key map[string]any) (bas
 // a single hold of m.mu, so the transaction is all-or-nothing and isolated from
 // concurrent single-item writes. On any failed condition it returns a
 // *driver.TransactionCanceled naming the failed operations and writes nothing.
-func (m *Mock) TransactWrite(ctx context.Context, ops []driver.TransactOp) error {
+func (m *Mock) TransactWrite(ctx context.Context, ops []driver.TransactOp, clientRequestToken string) error {
 	m.mu.Lock()
 	// flush registers before the unlock defer so it runs after the lock is
 	// released (defers are LIFO), delivering stream records outside m.mu.
 	defer func() { m.flushStreamDeliveries(ctx) }()
 	defer m.mu.Unlock()
+
+	if done, err := m.checkTransactToken(clientRequestToken, ops); done {
+		return err
+	}
 
 	tds, err := m.resolveTransactTables(ops)
 	if err != nil {
@@ -271,8 +292,74 @@ func (m *Mock) TransactWrite(ctx context.Context, ops []driver.TransactOp) error
 	}
 
 	m.commitTransactMutations(plans)
+	m.rememberTransactToken(clientRequestToken, ops)
 
 	return nil
+}
+
+// checkTransactToken applies TransactWriteItems idempotency. A replay carrying a
+// ClientRequestToken still inside the window short-circuits: done=true with a
+// nil error returns the cached success without re-applying when the request body
+// matches, or an *IdempotentParameterMismatch when the same token carries a
+// different body. done=false means apply the transaction normally. Caller holds
+// m.mu.
+func (m *Mock) checkTransactToken(token string, ops []driver.TransactOp) (done bool, err error) {
+	if token == "" {
+		return false, nil
+	}
+
+	m.pruneTransactTokens()
+
+	rec, ok := m.txIdempotency[token]
+	if !ok {
+		return false, nil
+	}
+
+	if rec.fingerprint != transactFingerprint(ops) {
+		return true, &driver.IdempotentParameterMismatch{}
+	}
+
+	return true, nil
+}
+
+// rememberTransactToken records a committed transaction's token and fingerprint
+// so a later retry is recognized as a replay. A no-op for an empty token. Caller
+// holds m.mu.
+func (m *Mock) rememberTransactToken(token string, ops []driver.TransactOp) {
+	if token == "" {
+		return
+	}
+
+	m.txIdempotency[token] = txIdempotencyRecord{
+		fingerprint: transactFingerprint(ops),
+		storedAt:    m.opts.Clock.Now(),
+	}
+}
+
+// pruneTransactTokens drops tokens older than the idempotency window so the map
+// does not grow without bound. Caller holds m.mu.
+func (m *Mock) pruneTransactTokens() {
+	now := m.opts.Clock.Now()
+	for tok, rec := range m.txIdempotency {
+		if now.Sub(rec.storedAt) > transactIdempotencyWindow {
+			delete(m.txIdempotency, tok)
+		}
+	}
+}
+
+// transactFingerprint is a stable digest of a transaction's operations, letting
+// a ClientRequestToken replay tell an identical request (idempotent no-op) from
+// a different one (parameter mismatch). json.Marshal sorts map keys, so the
+// digest is deterministic across replays.
+func transactFingerprint(ops []driver.TransactOp) string {
+	b, err := json.Marshal(ops)
+	if err != nil {
+		return ""
+	}
+
+	sum := sha256.Sum256(b)
+
+	return hex.EncodeToString(sum[:])
 }
 
 // resolveTransactTables resolves and structurally validates every operation's

--- a/providers/aws/dynamodb/conditional_test.go
+++ b/providers/aws/dynamodb/conditional_test.go
@@ -163,7 +163,7 @@ func TestTransactWriteAllOrNothing(t *testing.T) {
 		{Kind: driver.TransactPut, Table: "t", Item: map[string]any{"pk": "new2"}},
 	}
 
-	err := m.TransactWrite(ctx, ops)
+	err := m.TransactWrite(ctx, ops, "")
 
 	var canceled *driver.TransactionCanceled
 	if !errors.As(err, &canceled) {
@@ -216,7 +216,7 @@ func TestTransactWriteConcurrentConflict(t *testing.T) {
 					Condition: driver.Condition{Expression: "attribute_not_exists(pk)"},
 				}}
 
-				err := m.TransactWrite(ctx, ops)
+				err := m.TransactWrite(ctx, ops, "")
 				if err == nil {
 					winners.Add(1)
 					return

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"hash/fnv"
 	"maps"
 	"strconv"
 	"strings"
@@ -74,6 +75,10 @@ type Mock struct {
 	// runs after the lock is released (a mapped Lambda may write back into
 	// DynamoDB); guarded by m.mu.
 	pendingStream []pendingStreamEvent
+	// txIdempotency records recently used TransactWriteItems ClientRequestTokens
+	// (token -> request fingerprint + time) so a replay short-circuits instead of
+	// re-applying; guarded by m.mu. Mirrors the SQS FIFO deduplicationIndex.
+	txIdempotency map[string]txIdempotencyRecord
 }
 
 // StreamEventInvoker delivers a DynamoDB Streams event batch to whatever Lambda
@@ -117,7 +122,11 @@ func (m *Mock) emitMetric(metricName string, value float64, dims map[string]stri
 
 // New creates a new DynamoDB mock.
 func New(opts *config.Options) *Mock {
-	return &Mock{tables: make(map[string]*tableData), opts: opts}
+	return &Mock{
+		tables:        make(map[string]*tableData),
+		opts:          opts,
+		txIdempotency: make(map[string]txIdempotencyRecord),
+	}
 }
 
 // maxItemSizeBytes is the 400 KB ceiling DynamoDB enforces on a single item
@@ -305,9 +314,9 @@ func validateKeyType(cfg driver.TableConfig, keyName string, val any) error {
 }
 
 func itemKey(cfg driver.TableConfig, item map[string]any) string {
-	pk := fmt.Sprintf("%v", item[cfg.PartitionKey])
+	pk := expr.CanonicalKey(item[cfg.PartitionKey])
 	if cfg.SortKey != "" {
-		return pk + ":" + fmt.Sprintf("%v", item[cfg.SortKey])
+		return pk + ":" + expr.CanonicalKey(item[cfg.SortKey])
 	}
 
 	return pk
@@ -748,11 +757,12 @@ func passesFilter(node expr.Node, legacy []driver.ScanFilter, item map[string]an
 }
 
 // scanCandidates walks the table's items, skipping expired ones and (for an
-// index scan) those lacking the index partition key. The FilterExpression is
-// applied after paging (AWS reads up to Limit items, then filters), so it is
-// not applied here.
+// index scan) those lacking the index partition key. For a parallel scan
+// (total != nil) only items whose stable primary-key hash falls in segment are
+// kept. The FilterExpression is applied after paging (AWS reads up to Limit
+// items, then filters), so it is not applied here.
 func (m *Mock) scanCandidates(
-	td *tableData, idxPK string,
+	td *tableData, idxPK string, segment, total *int32,
 ) []map[string]any {
 	var matched []map[string]any
 
@@ -767,10 +777,74 @@ func (m *Mock) scanCandidates(
 			}
 		}
 
+		if !itemInSegment(itemKey(td.config, item), segment, total) {
+			continue
+		}
+
 		matched = append(matched, item)
 	}
 
 	return matched
+}
+
+// maxParallelScanSegments is the DynamoDB ceiling on a parallel scan's
+// TotalSegments.
+const maxParallelScanSegments = 1000000
+
+// validateScanSegments enforces the DynamoDB parallel-scan rules: Segment and
+// TotalSegments are given together, TotalSegments is 1..1000000, and Segment is
+// in [0,TotalSegments). Both nil is an ordinary full scan.
+func validateScanSegments(segment, total *int32) error {
+	if segment == nil && total == nil {
+		return nil
+	}
+
+	if segment == nil || total == nil {
+		return cerrors.New(cerrors.InvalidArgument,
+			"The request must contain both Segment and TotalSegments, or neither")
+	}
+
+	if *total < 1 || *total > maxParallelScanSegments {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"The TotalSegments parameter must be between 1 and %d", maxParallelScanSegments)
+	}
+
+	if *segment < 0 || *segment >= *total {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"The Segment parameter must be between 0 and TotalSegments-1 (%d)", *total-1)
+	}
+
+	return nil
+}
+
+// resolveScanIndexPK returns the partition-key attribute of the secondary index
+// a scan targets, or "" for a base-table scan. It also validates that a named
+// index exists.
+func resolveScanIndexPK(td *tableData, indexName string) (string, error) {
+	if indexName == "" {
+		return "", nil
+	}
+
+	pk, _, err := resolveKeyFields(td, indexName)
+
+	return pk, err
+}
+
+// itemInSegment reports whether an item belongs to a parallel scan's Segment,
+// hashing its primary key stably (FNV-1a) so every item maps to exactly one of
+// the TotalSegments shards — making the union of all shards cover the table
+// exactly once. A nil total (ordinary scan) always matches.
+func itemInSegment(key string, segment, total *int32) bool {
+	if total == nil {
+		return true
+	}
+
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(key))
+
+	// Compute the shard in int64 so there is no narrowing conversion: the FNV
+	// sum widens losslessly, and validateScanSegments guarantees total>=1.
+	return int64(h.Sum32())%int64(*total) == int64(*segment)
 }
 
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
@@ -788,18 +862,19 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 		return nil, err
 	}
 
+	if err = validateScanSegments(input.Segment, input.TotalSegments); err != nil {
+		return nil, err
+	}
+
 	// A scan on a secondary index only visits items carrying that index's
 	// partition key (a sparse index), so resolve it up front — this also
 	// validates the index exists.
-	var idxPK string
-
-	if input.IndexName != "" {
-		if idxPK, _, err = resolveKeyFields(td, input.IndexName); err != nil {
-			return nil, err
-		}
+	idxPK, err := resolveScanIndexPK(td, input.IndexName)
+	if err != nil {
+		return nil, err
 	}
 
-	candidates := m.scanCandidates(td, idxPK)
+	candidates := m.scanCandidates(td, idxPK, input.Segment, input.TotalSegments)
 
 	limit := input.Limit
 	if limit <= 0 {

--- a/server/aws/dynamodb/advanced.go
+++ b/server/aws/dynamodb/advanced.go
@@ -18,6 +18,7 @@ import (
 const (
 	maxBatchWriteItems = 25  // BatchWriteItem: total put/delete requests per call
 	maxBatchGetItems   = 100 // BatchGetItem: total keys per call
+	maxTransactItems   = 100 // TransactWriteItems / TransactGetItems: operations per call
 )
 
 // updateItem handles UpdateItem. Supports the common cases:
@@ -153,9 +154,17 @@ func (h *Handler) scan(w http.ResponseWriter, r *http.Request) {
 		Limit                     int               `json:"Limit"`
 		ExclusiveStartKey         map[string]any    `json:"ExclusiveStartKey"`
 		ReturnConsumedCapacity    string            `json:"ReturnConsumedCapacity"`
+		Select                    string            `json:"Select"`
+		Segment                   *int32            `json:"Segment"`
+		TotalSegments             *int32            `json:"TotalSegments"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if serr := validateSelect(req.Select, req.ProjectionExpression, req.IndexName); serr != nil {
+		writeErr(w, serr)
 		return
 	}
 
@@ -172,6 +181,8 @@ func (h *Handler) scan(w http.ResponseWriter, r *http.Request) {
 		Limit:               req.Limit,
 		ExclusiveStartKey:   fromWireItem(req.ExclusiveStartKey),
 		ProjectionRequested: req.ProjectionExpression != "",
+		Segment:             req.Segment,
+		TotalSegments:       req.TotalSegments,
 	})
 	if err != nil {
 		writeErr(w, err)
@@ -190,7 +201,7 @@ func (h *Handler) scan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := map[string]any{
-		"Items":        items,
+		"Items":        selectItems(req.Select, items),
 		"Count":        len(items),
 		"ScannedCount": result.ScannedCount,
 	}
@@ -290,9 +301,9 @@ func batchRequestKeySource(req *batchWriteRequest) map[string]any {
 // keyIdentity builds a stable identity string from an item's primary-key
 // attributes, used to detect two operations targeting the same item.
 func keyIdentity(cfg *dbdriver.TableConfig, item map[string]any) string {
-	id := fmt.Sprintf("%v", item[cfg.PartitionKey])
+	id := expr.CanonicalKey(item[cfg.PartitionKey])
 	if cfg.SortKey != "" {
-		id += "\x00" + fmt.Sprintf("%v", item[cfg.SortKey])
+		id += "\x00" + expr.CanonicalKey(item[cfg.SortKey])
 	}
 
 	return id
@@ -405,6 +416,11 @@ func (h *Handler) transactGetItems(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(req.TransactItems) > maxTransactItems {
+		writeTransactItemsTooLong(w)
+		return
+	}
+
 	responses := make([]map[string]any, 0, len(req.TransactItems))
 
 	for _, t := range req.TransactItems {
@@ -497,10 +513,16 @@ type txOp struct {
 // and writes nothing).
 func (h *Handler) transactWriteItems(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		TransactItems []transactWriteJSON `json:"TransactItems"`
+		TransactItems      []transactWriteJSON `json:"TransactItems"`
+		ClientRequestToken string              `json:"ClientRequestToken"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if len(req.TransactItems) > maxTransactItems {
+		writeTransactItemsTooLong(w)
 		return
 	}
 
@@ -517,8 +539,15 @@ func (h *Handler) transactWriteItems(w http.ResponseWriter, r *http.Request) {
 	// (all-or-nothing) and isolated from concurrent single-item writes. This
 	// replaces the former handler-level evaluate-then-apply, which dropped the
 	// lock between the check and the write (a TOCTOU that let two conflicting
-	// transactions both commit).
-	err := h.writer().TransactWrite(ctx, toDriverTransactOps(ops))
+	// transactions both commit). ClientRequestToken makes a retried call
+	// idempotent: a replay short-circuits instead of applying the writes again.
+	err := h.writer().TransactWrite(ctx, toDriverTransactOps(ops), req.ClientRequestToken)
+
+	var mismatch *dbdriver.IdempotentParameterMismatch
+	if errors.As(err, &mismatch) {
+		wire.WriteJSONError(w, http.StatusBadRequest, "IdempotentParameterMismatchException", mismatch.Error())
+		return
+	}
 
 	var canceled *dbdriver.TransactionCanceled
 	if errors.As(err, &canceled) {
@@ -532,6 +561,14 @@ func (h *Handler) transactWriteItems(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wire.WriteJSON(w, map[string]any{})
+}
+
+// writeTransactItemsTooLong rejects a transaction whose TransactItems array
+// exceeds the 100-operation limit, matching real DynamoDB's ValidationException.
+func writeTransactItemsTooLong(w http.ResponseWriter) {
+	wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException",
+		"1 validation error detected: Value at 'transactItems' failed to satisfy constraint: "+
+			"Member must have length less than or equal to 100")
 }
 
 // toDriverTransactOps maps the decoded wire operations onto the provider's

--- a/server/aws/dynamodb/dynamodb_scan_select_key_idempotency_test.go
+++ b/server/aws/dynamodb/dynamodb_scan_select_key_idempotency_test.go
@@ -1,0 +1,305 @@
+// dynamodb_scan_select_key_idempotency_test.go — real-user-journey tests
+// driving the genuine aws-sdk-go-v2 DynamoDB client against the emulator's
+// HTTP server for four correctness fixes: parallel-scan segmentation, the
+// Select projection mode, numeric-key identity normalization, and
+// TransactWriteItems ClientRequestToken idempotency / the 100-op limit.
+package dynamodb_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createNumberKeyTable creates a table whose HASH key is a Number (N) attribute,
+// used to prove numeric key identity normalization.
+func createNumberKeyTable(t *testing.T, client *dynamodb.Client, table, pk string) {
+	t.Helper()
+
+	_, err := client.CreateTable(context.Background(), &dynamodb.CreateTableInput{
+		TableName: aws.String(table),
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String(pk), KeyType: ddbtypes.KeyTypeHash},
+		},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String(pk), AttributeType: ddbtypes.ScalarAttributeTypeN},
+		},
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+	})
+	require.NoError(t, err, "CreateTable %q", table)
+}
+
+// TestSuiteDDBParallelScanDisjoint (B1) proves a parallel scan partitions the
+// table: the union of all TotalSegments segments covers every item exactly once
+// — no duplicate, no skip — where the old whole-table-per-segment behavior would
+// have returned every item in every segment.
+func TestSuiteDDBParallelScanDisjoint(t *testing.T) {
+	t.Parallel()
+
+	const (
+		table         = "pscan"
+		itemCount     = 10
+		totalSegments = 4
+	)
+
+	client, _ := newSuiteDDBEnv(t)
+	suiteDDBCreateTable(t, client, table, "pk", "")
+
+	for i := 0; i < itemCount; i++ {
+		suiteDDBPut(t, client, table, map[string]ddbtypes.AttributeValue{
+			"pk": &ddbtypes.AttributeValueMemberS{Value: fmt.Sprintf("item-%d", i)},
+		})
+	}
+
+	seen := map[string]int{}
+
+	for seg := int32(0); seg < totalSegments; seg++ {
+		out, err := client.Scan(context.Background(), &dynamodb.ScanInput{
+			TableName:     aws.String(table),
+			Segment:       aws.Int32(seg),
+			TotalSegments: aws.Int32(totalSegments),
+		})
+		require.NoError(t, err, "Scan segment %d", seg)
+
+		for _, item := range out.Items {
+			pk := item["pk"].(*ddbtypes.AttributeValueMemberS).Value
+			seen[pk]++
+		}
+	}
+
+	require.Len(t, seen, itemCount, "union of segments must cover every item")
+	for pk, n := range seen {
+		assert.Equalf(t, 1, n, "item %q appeared in %d segments (want exactly one)", pk, n)
+	}
+}
+
+// TestSuiteDDBParallelScanValidation (B1) rejects a malformed parallel-scan
+// request (Segment without TotalSegments, and Segment >= TotalSegments) with a
+// ValidationException.
+func TestSuiteDDBParallelScanValidation(t *testing.T) {
+	t.Parallel()
+
+	const table = "pscanval"
+
+	client, _ := newSuiteDDBEnv(t)
+	suiteDDBCreateTable(t, client, table, "pk", "")
+
+	_, err := client.Scan(context.Background(), &dynamodb.ScanInput{
+		TableName: aws.String(table),
+		Segment:   aws.Int32(0),
+	})
+	assertValidationException(t, err, "Segment without TotalSegments")
+
+	_, err = client.Scan(context.Background(), &dynamodb.ScanInput{
+		TableName:     aws.String(table),
+		Segment:       aws.Int32(4),
+		TotalSegments: aws.Int32(4),
+	})
+	assertValidationException(t, err, "Segment >= TotalSegments")
+}
+
+// TestSuiteDDBSelectCountEmptyItems (B2) proves Select=COUNT returns the counts
+// only, with an empty Items array, on both Scan and Query — where the old
+// behavior returned the full items.
+func TestSuiteDDBSelectCountEmptyItems(t *testing.T) {
+	t.Parallel()
+
+	const (
+		table     = "selcount"
+		itemCount = 3
+	)
+
+	client, _ := newSuiteDDBEnv(t)
+	suiteDDBCreateTable(t, client, table, "pk", "sk")
+
+	for i := 0; i < itemCount; i++ {
+		suiteDDBPut(t, client, table, map[string]ddbtypes.AttributeValue{
+			"pk": &ddbtypes.AttributeValueMemberS{Value: "p"},
+			"sk": &ddbtypes.AttributeValueMemberS{Value: fmt.Sprintf("s-%d", i)},
+		})
+	}
+
+	scanOut, err := client.Scan(context.Background(), &dynamodb.ScanInput{
+		TableName: aws.String(table),
+		Select:    ddbtypes.SelectCount,
+	})
+	require.NoError(t, err, "Scan COUNT")
+	assert.Empty(t, scanOut.Items, "Scan COUNT must return no items")
+	assert.Equal(t, int32(itemCount), scanOut.Count, "Scan COUNT Count")
+
+	queryOut, err := client.Query(context.Background(), &dynamodb.QueryInput{
+		TableName:                 aws.String(table),
+		KeyConditionExpression:    aws.String("pk = :p"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":p": &ddbtypes.AttributeValueMemberS{Value: "p"}},
+		Select:                    ddbtypes.SelectCount,
+	})
+	require.NoError(t, err, "Query COUNT")
+	assert.Empty(t, queryOut.Items, "Query COUNT must return no items")
+	assert.Equal(t, int32(itemCount), queryOut.Count, "Query COUNT Count")
+}
+
+// TestSuiteDDBSelectProjectionConflict (B2) rejects the Select vs
+// ProjectionExpression conflicts DynamoDB forbids.
+func TestSuiteDDBSelectProjectionConflict(t *testing.T) {
+	t.Parallel()
+
+	const table = "selconflict"
+
+	client, _ := newSuiteDDBEnv(t)
+	suiteDDBCreateTable(t, client, table, "pk", "")
+
+	// ALL_ATTRIBUTES with a ProjectionExpression is invalid.
+	_, err := client.Scan(context.Background(), &dynamodb.ScanInput{
+		TableName:                aws.String(table),
+		Select:                   ddbtypes.SelectAllAttributes,
+		ProjectionExpression:     aws.String("#a"),
+		ExpressionAttributeNames: map[string]string{"#a": "pk"},
+	})
+	assertValidationException(t, err, "ALL_ATTRIBUTES with ProjectionExpression")
+
+	// ALL_PROJECTED_ATTRIBUTES is only valid on an index query/scan.
+	_, err = client.Scan(context.Background(), &dynamodb.ScanInput{
+		TableName: aws.String(table),
+		Select:    ddbtypes.SelectAllProjectedAttributes,
+	})
+	assertValidationException(t, err, "ALL_PROJECTED_ATTRIBUTES off an index")
+}
+
+// TestSuiteDDBNumericKeyIdentity (B3) proves a Number key compares numerically:
+// putting "100" then "100.0" writes ONE item (the second overwrites the first),
+// and GetItem "100" resolves that canonical item — where the old raw-string key
+// stored two distinct items.
+func TestSuiteDDBNumericKeyIdentity(t *testing.T) {
+	t.Parallel()
+
+	const table = "numkey"
+
+	client, _ := newSuiteDDBEnv(t)
+	createNumberKeyTable(t, client, table, "id")
+
+	put := func(id, val string) {
+		suiteDDBPut(t, client, table, map[string]ddbtypes.AttributeValue{
+			"id":  &ddbtypes.AttributeValueMemberN{Value: id},
+			"val": &ddbtypes.AttributeValueMemberS{Value: val},
+		})
+	}
+
+	put("100", "first")
+	put("100.0", "second")
+
+	got := suiteDDBGet(t, client, table, map[string]ddbtypes.AttributeValue{
+		"id": &ddbtypes.AttributeValueMemberN{Value: "100"},
+	})
+	require.NotNil(t, got.Item, "GetItem 100 must resolve the canonical item")
+	assert.Equal(t, "second", got.Item["val"].(*ddbtypes.AttributeValueMemberS).Value,
+		"the second write must have overwritten the first")
+
+	// "1e2" is the same number, so it must resolve the same single item.
+	gotSci := suiteDDBGet(t, client, table, map[string]ddbtypes.AttributeValue{
+		"id": &ddbtypes.AttributeValueMemberN{Value: "1e2"},
+	})
+	require.NotNil(t, gotSci.Item, "GetItem 1e2 must resolve the same canonical item")
+
+	scanOut, err := client.Scan(context.Background(), &dynamodb.ScanInput{TableName: aws.String(table)})
+	require.NoError(t, err, "Scan")
+	assert.Equal(t, int32(1), scanOut.Count, "table must hold exactly one item")
+}
+
+// TestSuiteDDBTransactIdempotencyToken (B4) proves TransactWriteItems is
+// idempotent under a reused ClientRequestToken: an ADD counter transaction
+// replayed three times with the same token increments the counter ONCE — where
+// the old behavior re-applied every replay (counter = 3).
+func TestSuiteDDBTransactIdempotencyToken(t *testing.T) {
+	t.Parallel()
+
+	const (
+		table = "txidem"
+		token = "fixed-client-request-token"
+	)
+
+	client, _ := newSuiteDDBEnv(t)
+	suiteDDBCreateTable(t, client, table, "id", "")
+
+	addOne := func(clientToken string, delta string) error {
+		_, err := client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+			ClientRequestToken: aws.String(clientToken),
+			TransactItems: []ddbtypes.TransactWriteItem{{
+				Update: &ddbtypes.Update{
+					TableName:                 aws.String(table),
+					Key:                       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "counter"}},
+					UpdateExpression:          aws.String("ADD cnt :d"),
+					ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":d": &ddbtypes.AttributeValueMemberN{Value: delta}},
+				},
+			}},
+		})
+
+		return err
+	}
+
+	for i := 0; i < 3; i++ {
+		require.NoErrorf(t, addOne(token, "1"), "replay %d", i)
+	}
+
+	got := suiteDDBGet(t, client, table, map[string]ddbtypes.AttributeValue{
+		"id": &ddbtypes.AttributeValueMemberS{Value: "counter"},
+	})
+	require.NotNil(t, got.Item, "counter item must exist")
+	assert.Equal(t, "1", got.Item["cnt"].(*ddbtypes.AttributeValueMemberN).Value,
+		"three token-idempotent replays must increment the counter exactly once")
+
+	// The same token with a DIFFERENT request body is an
+	// IdempotentParameterMismatchException.
+	err := addOne(token, "5")
+	require.Error(t, err, "same token, different body")
+
+	var apiErr smithy.APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, "IdempotentParameterMismatchException", apiErr.ErrorCode())
+}
+
+// TestSuiteDDBTransactHundredLimit (B5) rejects a transaction of more than 100
+// operations with a ValidationException, before anything is applied.
+func TestSuiteDDBTransactHundredLimit(t *testing.T) {
+	t.Parallel()
+
+	const table = "txlimit"
+
+	client, _ := newSuiteDDBEnv(t)
+	suiteDDBCreateTable(t, client, table, "id", "")
+
+	items := make([]ddbtypes.TransactWriteItem, 0, 101)
+	for i := 0; i < 101; i++ {
+		items = append(items, ddbtypes.TransactWriteItem{
+			Put: &ddbtypes.Put{
+				TableName: aws.String(table),
+				Item:      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: fmt.Sprintf("k-%d", i)}},
+			},
+		})
+	}
+
+	_, err := client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{TransactItems: items})
+	assertValidationException(t, err, "101-op transaction")
+
+	// Nothing was applied.
+	scanOut, serr := client.Scan(context.Background(), &dynamodb.ScanInput{TableName: aws.String(table)})
+	require.NoError(t, serr, "Scan")
+	assert.Equal(t, int32(0), scanOut.Count, "an over-limit transaction must write nothing")
+}
+
+// assertValidationException asserts err is a DynamoDB ValidationException.
+func assertValidationException(t *testing.T, err error, context string) {
+	t.Helper()
+	require.Errorf(t, err, "%s must be rejected", context)
+
+	var apiErr smithy.APIError
+	require.Truef(t, errors.As(err, &apiErr), "%s: expected an API error, got %v", context, err)
+	assert.Equalf(t, "ValidationException", apiErr.ErrorCode(), "%s", context)
+}

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -34,6 +34,60 @@ const (
 	billingProvisioned = "PROVISIONED"
 )
 
+// Query/Scan Select modes controlling which attributes (or only the counts) the
+// result carries.
+const (
+	selectAllAttributes      = "ALL_ATTRIBUTES"
+	selectAllProjected       = "ALL_PROJECTED_ATTRIBUTES"
+	selectSpecificAttributes = "SPECIFIC_ATTRIBUTES"
+	selectCount              = "COUNT"
+)
+
+// validateSelect enforces the DynamoDB rules relating a Query/Scan Select mode
+// to ProjectionExpression and index use. An empty Select is always valid.
+//   - SPECIFIC_ATTRIBUTES requires a ProjectionExpression.
+//   - ALL_PROJECTED_ATTRIBUTES is only valid on an index query/scan.
+//   - A ProjectionExpression may only accompany SPECIFIC_ATTRIBUTES (so
+//     ALL_ATTRIBUTES/COUNT/ALL_PROJECTED_ATTRIBUTES with one is invalid).
+func validateSelect(sel, projectionExpr, indexName string) error {
+	up := strings.ToUpper(sel)
+	hasProj := projectionExpr != ""
+
+	switch up {
+	case "", selectCount, selectAllAttributes, selectSpecificAttributes, selectAllProjected:
+	default:
+		return cerrors.Newf(cerrors.InvalidArgument, "Unknown value for Select: %s", sel)
+	}
+
+	if up == selectSpecificAttributes && !hasProj {
+		return cerrors.New(cerrors.InvalidArgument,
+			"Select type SPECIFIC_ATTRIBUTES requires a ProjectionExpression to be specified")
+	}
+
+	if up == selectAllProjected && indexName == "" {
+		return cerrors.New(cerrors.InvalidArgument,
+			"Select type ALL_PROJECTED_ATTRIBUTES is only valid when querying or scanning an index")
+	}
+
+	if hasProj && up != "" && up != selectSpecificAttributes {
+		return cerrors.New(cerrors.InvalidArgument,
+			"Cannot specify both ProjectionExpression and Select, unless Select is SPECIFIC_ATTRIBUTES")
+	}
+
+	return nil
+}
+
+// selectItems resolves the Items array a Query/Scan response carries for the
+// given Select mode: Select=COUNT returns only the counts, so the Items array is
+// emptied; every other mode returns the projected items unchanged.
+func selectItems(sel string, items []map[string]any) []map[string]any {
+	if strings.EqualFold(sel, selectCount) {
+		return []map[string]any{}
+	}
+
+	return items
+}
+
 // projectionBlock builds the Projection wire block echoed by a describe. An
 // INCLUDE projection also carries the NonKeyAttributes it copied so the
 // declared index round-trips exactly.
@@ -65,7 +119,7 @@ type conditionalWriter interface {
 	UpdateItemConditional(
 		ctx context.Context, input dbdriver.UpdateItemInput, cond dbdriver.Condition,
 	) (updated, old map[string]any, err error)
-	TransactWrite(ctx context.Context, ops []dbdriver.TransactOp) error
+	TransactWrite(ctx context.Context, ops []dbdriver.TransactOp, clientRequestToken string) error
 }
 
 // Handler serves DynamoDB JSON-RPC requests against a database.Database driver.
@@ -833,9 +887,15 @@ func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
 		IndexName                 string            `json:"IndexName"`
 		ExclusiveStartKey         map[string]any    `json:"ExclusiveStartKey"`
 		ReturnConsumedCapacity    string            `json:"ReturnConsumedCapacity"`
+		Select                    string            `json:"Select"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if serr := validateSelect(req.Select, req.ProjectionExpression, req.IndexName); serr != nil {
+		writeErr(w, serr)
 		return
 	}
 
@@ -884,7 +944,7 @@ func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := map[string]any{
-		"Items":        items,
+		"Items":        selectItems(req.Select, items),
 		"Count":        len(items),
 		"ScannedCount": result.ScannedCount,
 	}

--- a/services/database/driver/conditional.go
+++ b/services/database/driver/conditional.go
@@ -76,3 +76,15 @@ type TransactionCanceled struct {
 func (*TransactionCanceled) Error() string {
 	return "transaction canceled: one or more condition checks failed"
 }
+
+// IdempotentParameterMismatch is returned by an atomic transaction replayed with
+// a ClientRequestToken that was already used within the idempotency window for a
+// DIFFERENT request body. Real DynamoDB rejects this with an
+// IdempotentParameterMismatchException; the wire layer maps this type onto it.
+type IdempotentParameterMismatch struct{}
+
+// Error reports the DynamoDB message an IdempotentParameterMismatchException
+// carries.
+func (*IdempotentParameterMismatch) Error() string {
+	return "Request parameters do not match the parameters of a previous call with the same client request token"
+}

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -253,6 +253,14 @@ type ScanInput struct {
 	// the driver expose the full base item so non-projected attributes can be
 	// fetched, matching real DynamoDB.
 	ProjectionRequested bool
+
+	// Segment/TotalSegments select one shard of a parallel scan. When
+	// TotalSegments is non-nil the scan returns only the items whose stable
+	// primary-key hash falls in Segment, so the union of all TotalSegments shards
+	// covers every item exactly once (no duplicate, no skip). Both nil is an
+	// ordinary full scan. The AWS wire layer validates the pair before calling.
+	Segment       *int32
+	TotalSegments *int32
 }
 
 // QueryResult is the result of a query or scan.

--- a/services/database/driver/expr/number.go
+++ b/services/database/driver/expr/number.go
@@ -2,6 +2,7 @@ package expr
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"strconv"
 	"strings"
@@ -68,6 +69,30 @@ func (n Number) Float() (float64, bool) {
 func (n Number) rat() (*big.Rat, bool) {
 	r, ok := new(big.Rat).SetString(strings.TrimPrefix(string(n), "+"))
 	return r, ok
+}
+
+// Canonical returns a stable representation of n's numeric value, collapsing
+// distinct decimal spellings of the same number ("100", "100.0", "1e2") to one
+// string via the exact rational form. A malformed number falls back to its raw
+// text so it stays distinct and type-segregated.
+func (n Number) Canonical() string {
+	if r, ok := n.rat(); ok {
+		return r.RatString()
+	}
+
+	return string(n)
+}
+
+// CanonicalKey renders a primary-key attribute value into a stable identity
+// component. A Number collapses to its canonical numeric form so "100" and
+// "100.0" resolve to one item key; every other type formats by value exactly as
+// before, leaving String/Binary keys byte-for-byte unaffected.
+func CanonicalKey(v any) string {
+	if n, ok := v.(Number); ok {
+		return n.Canonical()
+	}
+
+	return fmt.Sprintf("%v", v)
 }
 
 // numberEqual reports whether a and b denote the same number. Equality is


### PR DESCRIPTION
## Summary

Fixes five AWS DynamoDB correctness bugs, verified end-to-end against the real `aws-sdk-go-v2/dynamodb` client driving the emulator's HTTP server.

### 1. Parallel Scan `Segment`/`TotalSegments` (HIGH, data-duplication)
`Scan` ignored the parallel-scan parameters, so every segment returned the whole table (4 segments × 10 items = 40, each item 4×), breaking parallel-scan ETL/worker patterns. Now `Segment`/`TotalSegments` thread through `ScanInput` into the provider, which keeps an item only when a stable FNV-1a hash of its (canonical) primary key falls in the segment. The union of all segments covers every item **exactly once** — no duplicates, no skips. Validated (`Segment` required with `TotalSegments`; `0 <= Segment < TotalSegments`; `TotalSegments` 1..1,000,000 → `ValidationException`).

### 2. `Select` mode on Scan + Query (MED)
`Select` was ignored. Now `Select=COUNT` returns `Count`/`ScannedCount` with an empty `Items` array; `SPECIFIC_ATTRIBUTES` requires a `ProjectionExpression`; `ALL_PROJECTED_ATTRIBUTES` is only valid on an index; and `Select`/`ProjectionExpression` conflicts (e.g. `ALL_ATTRIBUTES` + a projection) are `ValidationException`s.

### 3. Numeric key identity normalization (MED, data-correctness)
`PutItem` "100" then "100.0" created two distinct items because the key string used the raw value text. DynamoDB compares Number keys numerically, so both (and "1e2") must map to one item. `itemKey` and `keyIdentity` now canonicalize an `expr.Number` via its exact rational form (reusing the same big.Rat comparison the Number-set dedup relies on). String/Binary keys are unaffected. Applies to hash and composite sort keys, and to Get/Delete/Batch/Transact resolution.

### 4. `TransactWriteItems` `ClientRequestToken` idempotency (MED)
A retried transaction re-applied its writes (e.g. `ADD cnt :one` applied 3× → 3 instead of 1). The provider now remembers recent tokens (10-minute window, mirroring the SQS FIFO dedup index) and short-circuits a replay, returning the cached success without re-applying. The same token with a **different** request body is an `IdempotentParameterMismatchException`.

### 5. Transaction 100-op limit (LOW)
`TransactWriteItems` and `TransactGetItems` now reject more than 100 operations with a `ValidationException` before applying anything (mirroring the existing BatchWrite=25 / BatchGet=100 checks).

## Tests
New real-SDK e2e tests: parallel-scan segment union is disjoint and complete; `Select=COUNT` returns empty Items; numeric-key put "100"/"100.0" leaves one item that GetItem "100"/"1e2" resolves; token-idempotent transact replays increment once (and mismatch is rejected); 101-op transaction is a `ValidationException` that writes nothing.

## Gates
`go build`, `go vet`, targeted `go test` (+ `-race` on the provider), `gofmt`, `go generate` (zero diff), `compatgen` (zero diff) all green; no new golangci-lint findings in the changed packages.
