### PR TITLE
fix(s3): system object metadata, storage class, GetObjectAttributes, HeadBucket region

### DIFF
--- a/docs/coverage/aws/s3.md
+++ b/docs/coverage/aws/s3.md
@@ -163,6 +163,14 @@ StorageAccountKeys is an OPTIONAL Azure-specific capability, discovered by
 | `ListStorageAccountKeys` | ListStorageAccountKeys returns the account's access keys, generating a |
 | `RegenerateStorageAccountKey` | RegenerateStorageAccountKey rotates the value of the named key (key1/key2) |
 
+### SystemPropsBucket
+
+SystemPropsBucket is an OPTIONAL capability (discovered by type assertion like
+
+| Operation | Description |
+| --- | --- |
+| `PutObjectWithSystemProps` |  |
+
 ### VersionedBucket
 
 VersionedBucket is an optional extension a storage provider implements when

--- a/docs/coverage/azure/blobstorage.md
+++ b/docs/coverage/azure/blobstorage.md
@@ -163,6 +163,14 @@ StorageAccountKeys is an OPTIONAL Azure-specific capability, discovered by
 | `ListStorageAccountKeys` | ListStorageAccountKeys returns the account's access keys, generating a |
 | `RegenerateStorageAccountKey` | RegenerateStorageAccountKey rotates the value of the named key (key1/key2) |
 
+### SystemPropsBucket
+
+SystemPropsBucket is an OPTIONAL capability (discovered by type assertion like
+
+| Operation | Description |
+| --- | --- |
+| `PutObjectWithSystemProps` |  |
+
 ### VersionedBucket
 
 VersionedBucket is an optional extension a storage provider implements when

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -10851,6 +10851,15 @@
         ]
       },
       {
+        "name": "SystemPropsBucket",
+        "doc": "SystemPropsBucket is an OPTIONAL capability (discovered by type assertion like",
+        "operations": [
+          {
+            "name": "PutObjectWithSystemProps"
+          }
+        ]
+      },
+      {
         "name": "VersionedBucket",
         "doc": "VersionedBucket is an optional extension a storage provider implements when",
         "operations": [

--- a/docs/coverage/gcp/gcs.md
+++ b/docs/coverage/gcp/gcs.md
@@ -163,6 +163,14 @@ StorageAccountKeys is an OPTIONAL Azure-specific capability, discovered by
 | `ListStorageAccountKeys` | ListStorageAccountKeys returns the account's access keys, generating a |
 | `RegenerateStorageAccountKey` | RegenerateStorageAccountKey rotates the value of the named key (key1/key2) |
 
+### SystemPropsBucket
+
+SystemPropsBucket is an OPTIONAL capability (discovered by type assertion like
+
+| Operation | Description |
+| --- | --- |
+| `PutObjectWithSystemProps` |  |
+
 ### VersionedBucket
 
 VersionedBucket is an optional extension a storage provider implements when

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -33,11 +33,12 @@ const (
 )
 
 var (
-	_ driver.Bucket          = (*Mock)(nil)
-	_ driver.VersionedBucket = (*Mock)(nil)
-	_ driver.RawBucketConfig = (*Mock)(nil)
-	_ driver.ObjectCopier    = (*Mock)(nil)
-	_ driver.RegionalBucket  = (*Mock)(nil)
+	_ driver.Bucket            = (*Mock)(nil)
+	_ driver.VersionedBucket   = (*Mock)(nil)
+	_ driver.RawBucketConfig   = (*Mock)(nil)
+	_ driver.ObjectCopier      = (*Mock)(nil)
+	_ driver.RegionalBucket    = (*Mock)(nil)
+	_ driver.SystemPropsBucket = (*Mock)(nil)
 )
 
 type s3Object struct {
@@ -55,6 +56,10 @@ type s3Object struct {
 	// VersionID is the version id of the current object on a versioned bucket
 	// ("null" when suspended, empty when the bucket never had versioning).
 	VersionID string
+	// SystemProps holds the S3 system-defined object properties (Cache-Control,
+	// Content-Encoding, Content-Disposition, Content-Language, Expires) and the
+	// object's storage class, recorded on PutObject and echoed back on read.
+	SystemProps driver.ObjectSystemProps
 }
 
 // s3Version is one entry in a key's version history (a stored object or a
@@ -68,6 +73,7 @@ type s3Version struct {
 	lastModified string
 	metadata     map[string]string
 	deleteMarker bool
+	storageClass string
 }
 
 type multipartUpload struct {
@@ -350,12 +356,27 @@ func multipartETag(orderedParts [][]byte) string {
 }
 
 func (m *Mock) PutObject(ctx context.Context, bucket, key string, data []byte, contentType string, metadata map[string]string) error {
+	return m.PutObjectWithSystemProps(ctx, bucket, key, data, contentType, metadata, nil)
+}
+
+// PutObjectWithSystemProps implements driver.SystemPropsBucket: it writes the
+// object like PutObject and additionally records the S3 system-defined object
+// properties (Cache-Control, Content-Encoding, …) and storage class carried by
+// props (nil = none), so a later Head/Get/List reflects them.
+func (m *Mock) PutObjectWithSystemProps(
+	ctx context.Context, bucket, key string, data []byte, contentType string,
+	metadata map[string]string, props *driver.ObjectSystemProps,
+) error {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
 	}
 
 	obj := m.newObject(key, data, contentType, metadata)
+	if props != nil {
+		obj.SystemProps = *props
+	}
+
 	m.storeObject(bkt, key, obj)
 
 	return m.afterPut(ctx, bkt, bucket, key, obj, data, contentType, metadata)
@@ -539,6 +560,7 @@ func versionFromObject(obj *s3Object, dropData bool) *s3Version {
 		etag:         obj.ETag,
 		lastModified: obj.LastModified,
 		metadata:     obj.Metadata,
+		storageClass: obj.SystemProps.StorageClass,
 	}
 }
 
@@ -588,14 +610,14 @@ func (m *Mock) GetObject(ctx context.Context, bucket, key string) (*driver.Objec
 	m.emitMetric("GetRequests", 1, "Count", dims)
 	m.emitMetric("BytesDownloaded", float64(obj.Size), "Bytes", dims)
 
-	return &driver.Object{
-		Info: driver.ObjectInfo{
-			Key: obj.Key, Size: obj.Size, ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
-			VersionID: obj.VersionID,
-		},
-		Data: dataCopy,
-	}, nil
+	info := driver.ObjectInfo{
+		Key: obj.Key, Size: obj.Size, ContentType: obj.ContentType,
+		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
+		VersionID: obj.VersionID,
+	}
+	applyObjectSystemProps(&info, obj)
+
+	return &driver.Object{Info: info, Data: dataCopy}, nil
 }
 
 func (m *Mock) DeleteObject(ctx context.Context, bucket, key string) error {
@@ -673,11 +695,26 @@ func (m *Mock) HeadObject(_ context.Context, bucket, key string) (*driver.Object
 		return nil, cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bucket)
 	}
 
-	return &driver.ObjectInfo{
+	info := &driver.ObjectInfo{
 		Key: obj.Key, Size: obj.Size, ContentType: obj.ContentType,
 		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 		VersionID: obj.VersionID,
-	}, nil
+	}
+	applyObjectSystemProps(info, obj)
+
+	return info, nil
+}
+
+// applyObjectSystemProps copies obj's S3 system-defined object properties and
+// storage class onto info, so a Head/Get/List response reflects what PutObject
+// recorded.
+func applyObjectSystemProps(info *driver.ObjectInfo, obj *s3Object) {
+	info.CacheControl = obj.SystemProps.CacheControl
+	info.ContentEncoding = obj.SystemProps.ContentEncoding
+	info.ContentDisposition = obj.SystemProps.ContentDisposition
+	info.ContentLanguage = obj.SystemProps.ContentLanguage
+	info.Expires = obj.SystemProps.Expires
+	info.StorageClass = obj.SystemProps.StorageClass
 }
 
 func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOptions) (*driver.ListResult, error) {
@@ -761,10 +798,12 @@ func matchListKeys(
 			continue
 		}
 
-		matchedObjects = append(matchedObjects, driver.ObjectInfo{
+		info := driver.ObjectInfo{
 			Key: obj.Key, Size: obj.Size, ContentType: obj.ContentType,
 			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
-		})
+		}
+		applyObjectSystemProps(&info, obj)
+		matchedObjects = append(matchedObjects, info)
 	}
 
 	return matchedObjects, commonPrefixSet
@@ -797,7 +836,7 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 	dstObj := &s3Object{
 		Key: dstKey, Data: dataCopy, Size: srcObj.Size, ContentType: srcObj.ContentType,
 		ETag: srcObj.ETag, LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
-		Metadata: meta, Tags: maps.Clone(srcObj.Tags),
+		Metadata: meta, Tags: maps.Clone(srcObj.Tags), SystemProps: srcObj.SystemProps,
 	}
 	m.storeObject(dstBkt, dstKey, dstObj)
 
@@ -830,6 +869,22 @@ type copySrcSnapshot struct {
 	metadata     map[string]string
 	tags         map[string]string
 	versionID    string
+	systemProps  driver.ObjectSystemProps
+}
+
+// copyDstSystemProps resolves the destination object's system properties for a
+// server-side copy: the content properties inherit from the source (default
+// COPY directive) or come from the request (REPLACE), while the storage class
+// always comes from the request's x-amz-storage-class (never inherited).
+func copyDstSystemProps(req *driver.CopyObjectRequest, src *copySrcSnapshot) driver.ObjectSystemProps {
+	props := src.systemProps
+	if req.ReplaceMetadata {
+		props = req.SystemProps
+	}
+
+	props.StorageClass = req.SystemProps.StorageClass
+
+	return props
 }
 
 // CopyObjectV2 performs a full-fidelity S3 server-side copy: it honors a
@@ -875,7 +930,7 @@ func (m *Mock) CopyObjectV2(ctx context.Context, req *driver.CopyObjectRequest) 
 	dstObj := &s3Object{
 		Key: req.DstKey, Data: dataCopy, Size: src.size, ContentType: contentType,
 		ETag: src.etag, LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
-		Metadata: maps.Clone(metadata), Tags: maps.Clone(tags),
+		Metadata: maps.Clone(metadata), Tags: maps.Clone(tags), SystemProps: copyDstSystemProps(req, src),
 	}
 	m.storeObject(dstBkt, req.DstKey, dstObj)
 
@@ -925,6 +980,7 @@ func (m *Mock) resolveCopySource(ctx context.Context, src driver.CopySource, ver
 	return &copySrcSnapshot{
 		data: data, size: srcObj.Size, contentType: srcObj.ContentType, etag: srcObj.ETag,
 		lastModified: srcObj.LastModified, metadata: srcObj.Metadata, tags: srcObj.Tags, versionID: srcObj.VersionID,
+		systemProps: srcObj.SystemProps,
 	}, nil
 }
 
@@ -951,6 +1007,7 @@ func (m *Mock) resolveCopySourceVersion(
 	return &copySrcSnapshot{
 		data: data, size: v.size, contentType: v.contentType, etag: v.etag,
 		lastModified: v.lastModified, metadata: v.metadata, versionID: versionID,
+		systemProps: driver.ObjectSystemProps{StorageClass: v.storageClass},
 	}, nil
 }
 
@@ -1587,6 +1644,7 @@ func (m *Mock) ListObjectVersions(_ context.Context, bucket string, opts driver.
 					Key: k, VersionID: nullVersionID, IsLatest: true,
 					Size: obj.Size, ETag: obj.ETag,
 					ContentType: obj.ContentType, LastModified: obj.LastModified,
+					StorageClass: obj.SystemProps.StorageClass,
 				})
 			}
 
@@ -1599,6 +1657,7 @@ func (m *Mock) ListObjectVersions(_ context.Context, bucket string, opts driver.
 				Key: k, VersionID: v.versionID, IsLatest: i == len(chain)-1,
 				DeleteMarker: v.deleteMarker, Size: v.size, ETag: v.etag,
 				ContentType: v.contentType, LastModified: v.lastModified,
+				StorageClass: v.storageClass,
 			})
 		}
 	}

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -34,6 +34,9 @@ const (
 	// minBucketNameLen / maxBucketNameLen bound a general-purpose bucket name.
 	minBucketNameLen = 3
 	maxBucketNameLen = 63
+	// storageClassStandard is S3's default storage class; it is never emitted in
+	// the x-amz-storage-class response header (real S3 omits it for STANDARD).
+	storageClassStandard = "STANDARD"
 )
 
 // Handler serves S3 REST requests against a storage.Bucket driver.
@@ -57,6 +60,10 @@ type Handler struct {
 	// conditional is set when the driver can perform an atomic conditional
 	// PutObject; the handler then enforces If-None-Match/If-Match on writes.
 	conditional driver.ConditionalBucket
+	// sysProps is set when the driver persists the S3 system-defined object
+	// properties (Cache-Control, Content-Encoding, …) and storage class; the
+	// handler then records them on PutObject and reflects them on read.
+	sysProps driver.SystemPropsBucket
 }
 
 // New returns an S3 handler backed by b.
@@ -80,6 +87,10 @@ func New(b driver.Bucket) *Handler {
 
 	if cb, ok := b.(driver.ConditionalBucket); ok {
 		h.conditional = cb
+	}
+
+	if sp, ok := b.(driver.SystemPropsBucket); ok {
+		h.sysProps = sp
 	}
 
 	return h
@@ -247,6 +258,13 @@ func (h *Handler) headBucket(w http.ResponseWriter, r *http.Request, bucket stri
 
 	for _, b := range buckets {
 		if b.Name == bucket {
+			region := b.Region
+			if region == "" {
+				region = usEast1
+			}
+			// Real S3 returns the bucket's region on a 200 HeadBucket; the SDK reads
+			// it into HeadBucketOutput.BucketRegion.
+			w.Header().Set("X-Amz-Bucket-Region", region)
 			w.WriteHeader(http.StatusOK)
 			return
 		}
@@ -531,7 +549,7 @@ func (h *Handler) listObjects(w http.ResponseWriter, r *http.Request, bucket str
 			LastModified: obj.LastModified,
 			ETag:         fmt.Sprintf("%q", obj.ETag),
 			Size:         int(obj.Size),
-			StorageClass: "STANDARD",
+			StorageClass: storageClassOrDefault(obj.StorageClass),
 			Owner:        owner,
 		})
 	}
@@ -547,6 +565,12 @@ func (h *Handler) objectOp(w http.ResponseWriter, r *http.Request, bucket, key s
 	q := r.URL.Query()
 
 	switch {
+	case q.Has("attributes"):
+		// GET /{bucket}/{key}?attributes => GetObjectAttributes. Without this it
+		// falls through to getObject and the SDK decodes an object body as the
+		// attributes response, reading zero-valued attributes.
+		h.getObjectAttributes(w, r, bucket, key)
+		return
 	case q.Has("tagging"):
 		h.objectTaggingOp(w, r, bucket, key)
 		return
@@ -608,6 +632,10 @@ func (h *Handler) putObject(w http.ResponseWriter, r *http.Request, bucket, key 
 		return // error response already written
 	}
 
+	if sc := r.Header.Get("X-Amz-Storage-Class"); sc != "" && sc != storageClassStandard {
+		w.Header().Set("X-Amz-Storage-Class", sc)
+	}
+
 	// x-amz-tagging sets the object's tag set at upload time; apply it so
 	// GetObjectTagging returns it (real S3 stores it atomically with the object).
 	if !h.applyPutTagging(w, r, bucket, key) {
@@ -638,7 +666,7 @@ func (h *Handler) storePut(
 		return h.storePutConditional(w, r, bucket, key, data, contentType, metadata, ifNoneMatch, ifMatch)
 	}
 
-	if err := h.bucket.PutObject(r.Context(), bucket, key, data, contentType, metadata); err != nil {
+	if err := h.putObjectData(r, bucket, key, data, contentType, metadata); err != nil {
 		writeErr(w, err)
 		return "", "", false
 	}
@@ -654,6 +682,21 @@ func (h *Handler) storePut(
 	}
 
 	return etag, versionID, true
+}
+
+// putObjectData writes the object, routing through the system-properties
+// capability (recording Cache-Control/Content-Encoding/… and storage class)
+// when the driver and the request supply them, and falling back to the plain
+// PutObject otherwise.
+func (h *Handler) putObjectData(
+	r *http.Request, bucket, key string, data []byte, contentType string, metadata map[string]string,
+) error {
+	props := extractSystemProps(r.Header)
+	if h.sysProps != nil && props != (driver.ObjectSystemProps{}) {
+		return h.sysProps.PutObjectWithSystemProps(r.Context(), bucket, key, data, contentType, metadata, &props)
+	}
+
+	return h.bucket.PutObject(r.Context(), bucket, key, data, contentType, metadata)
 }
 
 // storePutConditional performs an atomic If-None-Match/If-Match PutObject. A
@@ -872,6 +915,74 @@ func (h *Handler) headObject(w http.ResponseWriter, r *http.Request, bucket, key
 	w.WriteHeader(http.StatusOK)
 }
 
+// getObjectAttributes answers GET /{bucket}/{key}?attributes (GetObjectAttributes):
+// it returns the object's ETag, size, and storage class as selected by the
+// x-amz-object-attributes header, plus the Last-Modified and version-id headers.
+// A missing object is NoSuchKey; a missing bucket is NoSuchBucket.
+func (h *Handler) getObjectAttributes(w http.ResponseWriter, r *http.Request, bucket, key string) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	versionID := r.URL.Query().Get("versionId")
+
+	var (
+		info *driver.ObjectInfo
+		err  error
+	)
+
+	if versionID != "" && h.versioned != nil {
+		info, err = h.versioned.HeadObjectVersion(r.Context(), bucket, key, versionID)
+	} else {
+		info, err = h.bucket.HeadObject(r.Context(), bucket, key)
+	}
+
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if info.VersionID != "" {
+		w.Header().Set("X-Amz-Version-Id", info.VersionID)
+	}
+
+	w.Header().Set("Last-Modified", wire.ToHTTPDate(info.LastModified))
+
+	wire.WriteXML(w, http.StatusOK, buildObjectAttributes(r.Header.Values("X-Amz-Object-Attributes"), info))
+}
+
+// buildObjectAttributes assembles the GetObjectAttributes response body, filling
+// only the attributes named in the x-amz-object-attributes header. The SDK sends
+// one header line per attribute, each of which may itself be comma-separated.
+// ObjectSize is a pointer so a zero-length object still emits <ObjectSize>0.
+func buildObjectAttributes(requested []string, info *driver.ObjectInfo) getObjectAttributesOutput {
+	want := make(map[string]bool)
+
+	for _, line := range requested {
+		for _, a := range strings.Split(line, ",") {
+			want[strings.TrimSpace(a)] = true
+		}
+	}
+
+	out := getObjectAttributesOutput{Xmlns: xmlns}
+
+	if want["ETag"] {
+		out.ETag = strings.Trim(info.ETag, `"`)
+	}
+
+	if want["ObjectSize"] {
+		size := info.Size
+		out.ObjectSize = &size
+	}
+
+	if want["StorageClass"] {
+		out.StorageClass = storageClassOrDefault(info.StorageClass)
+	}
+
+	return out
+}
+
 // condReadOutcome classifies a GET/HEAD conditional-header evaluation.
 type condReadOutcome int
 
@@ -988,8 +1099,32 @@ func writeObjectHeaders(w http.ResponseWriter, info *driver.ObjectInfo, size int
 		w.Header().Set("X-Amz-Delete-Marker", "true")
 	}
 
+	writeSystemPropHeaders(w, info)
+
 	for k, v := range info.Metadata {
 		w.Header().Set("X-Amz-Meta-"+k, v)
+	}
+}
+
+// writeSystemPropHeaders emits the S3 system-defined object property response
+// headers that carry a stored value. x-amz-storage-class is emitted only for a
+// non-STANDARD class (real S3 omits it for STANDARD).
+func writeSystemPropHeaders(w http.ResponseWriter, info *driver.ObjectInfo) {
+	setIfNotEmpty(w, "Cache-Control", info.CacheControl)
+	setIfNotEmpty(w, "Content-Encoding", info.ContentEncoding)
+	setIfNotEmpty(w, "Content-Disposition", info.ContentDisposition)
+	setIfNotEmpty(w, "Content-Language", info.ContentLanguage)
+	setIfNotEmpty(w, "Expires", info.Expires)
+
+	if info.StorageClass != "" && info.StorageClass != storageClassStandard {
+		w.Header().Set("X-Amz-Storage-Class", info.StorageClass)
+	}
+}
+
+// setIfNotEmpty sets header k to v only when v is non-empty.
+func setIfNotEmpty(w http.ResponseWriter, k, v string) {
+	if v != "" {
+		w.Header().Set(k, v)
 	}
 }
 
@@ -1214,7 +1349,12 @@ func buildCopyRequest(
 	if replace {
 		req.Metadata = extractMetadata(r.Header)
 		req.ContentType = r.Header.Get("Content-Type")
+		req.SystemProps = extractSystemProps(r.Header)
 	}
+
+	// The destination storage class always comes from x-amz-storage-class (never
+	// inherited from the source), regardless of the metadata directive.
+	req.SystemProps.StorageClass = r.Header.Get("X-Amz-Storage-Class")
 
 	// x-amz-tagging-directive: REPLACE takes the destination tag set from the
 	// x-amz-tagging header; the default COPY inherits the source object's tags.
@@ -2023,7 +2163,7 @@ func (h *Handler) listObjectVersions(w http.ResponseWriter, r *http.Request, buc
 
 		resp.Versions = append(resp.Versions, objectVersionXML{
 			Key: v.Key, VersionID: v.VersionID, IsLatest: v.IsLatest, LastModified: v.LastModified,
-			ETag: fmt.Sprintf("%q", v.ETag), Size: v.Size, StorageClass: "STANDARD",
+			ETag: fmt.Sprintf("%q", v.ETag), Size: v.Size, StorageClass: storageClassOrDefault(v.StorageClass),
 		})
 	}
 
@@ -2070,6 +2210,7 @@ func (h *Handler) collectObjectVersions(
 		entries = append(entries, driver.ObjectVersion{
 			Key: obj.Key, VersionID: "null", IsLatest: true,
 			Size: obj.Size, ETag: obj.ETag, LastModified: obj.LastModified,
+			StorageClass: obj.StorageClass,
 		})
 	}
 
@@ -2106,6 +2247,31 @@ func skipToVersionMarker(entries []driver.ObjectVersion, keyMarker, versionIDMar
 	}
 
 	return nil
+}
+
+// extractSystemProps pulls the S3 system-defined object property request headers
+// (Cache-Control, Content-Encoding, Content-Disposition, Content-Language,
+// Expires) and the x-amz-storage-class header into an ObjectSystemProps. A zero
+// value means the caller sent none of them.
+func extractSystemProps(h http.Header) driver.ObjectSystemProps {
+	return driver.ObjectSystemProps{
+		CacheControl:       h.Get("Cache-Control"),
+		ContentEncoding:    h.Get("Content-Encoding"),
+		ContentDisposition: h.Get("Content-Disposition"),
+		ContentLanguage:    h.Get("Content-Language"),
+		Expires:            h.Get("Expires"),
+		StorageClass:       h.Get("X-Amz-Storage-Class"),
+	}
+}
+
+// storageClassOrDefault returns sc, or STANDARD when sc is empty — the value S3
+// reports in a listing's <StorageClass> element for a default-class object.
+func storageClassOrDefault(sc string) string {
+	if sc == "" {
+		return storageClassStandard
+	}
+
+	return sc
 }
 
 // extractMetadata pulls x-amz-meta-* headers into a map.

--- a/server/aws/s3/system_props_sdk_test.go
+++ b/server/aws/s3/system_props_sdk_test.go
@@ -1,0 +1,205 @@
+package s3_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// TestSDKSystemMetadataRoundTrip (B1): PutObject with the S3 system-defined
+// object properties round-trips them on HeadObject, and a default CopyObject
+// inherits Cache-Control from the source.
+func TestSDKSystemMetadataRoundTrip(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "sysprops-bucket"
+	const key = "doc.txt"
+
+	mustCreateBucket(t, client, bucket)
+
+	_, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket:             aws.String(bucket),
+		Key:                aws.String(key),
+		Body:               bytes.NewReader([]byte("hello world")),
+		CacheControl:       aws.String("max-age=3600"),
+		ContentEncoding:    aws.String("gzip"),
+		ContentDisposition: aws.String("attachment; filename=\"doc.txt\""),
+		ContentLanguage:    aws.String("en-US"),
+	})
+	if err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	head, err := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: aws.String(bucket), Key: aws.String(key)})
+	if err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+
+	assertStr(t, "CacheControl", aws.ToString(head.CacheControl), "max-age=3600")
+	assertStr(t, "ContentEncoding", aws.ToString(head.ContentEncoding), "gzip")
+	assertStr(t, "ContentDisposition", aws.ToString(head.ContentDisposition), "attachment; filename=\"doc.txt\"")
+	assertStr(t, "ContentLanguage", aws.ToString(head.ContentLanguage), "en-US")
+
+	const dstKey = "copy.txt"
+
+	_, err = client.CopyObject(ctx, &awss3.CopyObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String(dstKey), CopySource: aws.String(bucket + "/" + key),
+	})
+	if err != nil {
+		t.Fatalf("CopyObject: %v", err)
+	}
+
+	copied, err := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: aws.String(bucket), Key: aws.String(dstKey)})
+	if err != nil {
+		t.Fatalf("HeadObject(copy): %v", err)
+	}
+
+	assertStr(t, "copy CacheControl", aws.ToString(copied.CacheControl), "max-age=3600")
+}
+
+// TestSDKStorageClassRoundTrip (B2): a non-STANDARD storage class is persisted
+// and reported on HeadObject and ListObjectsV2; a STANDARD object omits the
+// x-amz-storage-class header (the SDK reports an empty class).
+func TestSDKStorageClassRoundTrip(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "storageclass-bucket"
+
+	mustCreateBucket(t, client, bucket)
+
+	_, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String("cold.txt"),
+		Body: bytes.NewReader([]byte("cold")), StorageClass: types.StorageClassStandardIa,
+	})
+	if err != nil {
+		t.Fatalf("PutObject(IA): %v", err)
+	}
+
+	_, err = client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String("warm.txt"), Body: bytes.NewReader([]byte("warm")),
+	})
+	if err != nil {
+		t.Fatalf("PutObject(STANDARD): %v", err)
+	}
+
+	head, err := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: aws.String(bucket), Key: aws.String("cold.txt")})
+	if err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+
+	assertStr(t, "HeadObject StorageClass", string(head.StorageClass), string(types.StorageClassStandardIa))
+
+	warm, err := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: aws.String(bucket), Key: aws.String("warm.txt")})
+	if err != nil {
+		t.Fatalf("HeadObject(warm): %v", err)
+	}
+
+	// Real S3 omits x-amz-storage-class for a STANDARD object, so the SDK reports
+	// an empty class.
+	assertStr(t, "STANDARD StorageClass omitted", string(warm.StorageClass), "")
+
+	assertListStorageClass(t, client, bucket)
+}
+
+// assertListStorageClass verifies ListObjectsV2 reports the recorded class per key.
+func assertListStorageClass(t *testing.T, client *awss3.Client, bucket string) {
+	t.Helper()
+
+	listed, err := client.ListObjectsV2(context.Background(), &awss3.ListObjectsV2Input{Bucket: aws.String(bucket)})
+	if err != nil {
+		t.Fatalf("ListObjectsV2: %v", err)
+	}
+
+	classes := make(map[string]string, len(listed.Contents))
+	for _, o := range listed.Contents {
+		classes[aws.ToString(o.Key)] = string(o.StorageClass)
+	}
+
+	assertStr(t, "list cold.txt class", classes["cold.txt"], string(types.StorageClassStandardIa))
+	assertStr(t, "list warm.txt class", classes["warm.txt"], "STANDARD")
+}
+
+// TestSDKGetObjectAttributes (B3): GetObjectAttributes populates ETag, ObjectSize,
+// and StorageClass; a missing key answers NoSuchKey.
+func TestSDKGetObjectAttributes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "attrs-bucket"
+	const key = "obj.bin"
+
+	mustCreateBucket(t, client, bucket)
+
+	body := bytes.Repeat([]byte("x"), 512)
+
+	_, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String(key),
+		Body: bytes.NewReader(body), StorageClass: types.StorageClassStandardIa,
+	})
+	if err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	attrs, err := client.GetObjectAttributes(ctx, &awss3.GetObjectAttributesInput{
+		Bucket: aws.String(bucket), Key: aws.String(key),
+		ObjectAttributes: []types.ObjectAttributes{
+			types.ObjectAttributesEtag, types.ObjectAttributesObjectSize, types.ObjectAttributesStorageClass,
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetObjectAttributes: %v", err)
+	}
+
+	if aws.ToString(attrs.ETag) == "" {
+		t.Error("GetObjectAttributes: empty ETag")
+	}
+
+	if got := aws.ToInt64(attrs.ObjectSize); got != int64(len(body)) {
+		t.Errorf("GetObjectAttributes ObjectSize = %d, want %d", got, len(body))
+	}
+
+	assertStr(t, "attrs StorageClass", string(attrs.StorageClass), string(types.StorageClassStandardIa))
+
+	_, err = client.GetObjectAttributes(ctx, &awss3.GetObjectAttributesInput{
+		Bucket: aws.String(bucket), Key: aws.String("missing.bin"),
+		ObjectAttributes: []types.ObjectAttributes{types.ObjectAttributesEtag},
+	})
+
+	var nsk *types.NoSuchKey
+	if !errors.As(err, &nsk) {
+		t.Errorf("GetObjectAttributes(missing) error = %v, want NoSuchKey", err)
+	}
+}
+
+// TestSDKHeadBucketRegion (B4): HeadBucket reports the bucket's region.
+func TestSDKHeadBucketRegion(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "region-bucket"
+
+	mustCreateBucket(t, client, bucket)
+
+	head, err := client.HeadBucket(ctx, &awss3.HeadBucketInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		t.Fatalf("HeadBucket: %v", err)
+	}
+
+	assertStr(t, "BucketRegion", aws.ToString(head.BucketRegion), "us-east-1")
+}
+
+// assertStr fails the test when got != want.
+func assertStr(t *testing.T, name, got, want string) {
+	t.Helper()
+
+	if got != want {
+		t.Errorf("%s = %q, want %q", name, got, want)
+	}
+}

--- a/server/aws/s3/xml.go
+++ b/server/aws/s3/xml.go
@@ -62,6 +62,18 @@ type copyObjectResult struct {
 	LastModified string   `xml:"LastModified"`
 }
 
+// getObjectAttributesOutput is the XML response for GetObjectAttributes. The SDK
+// deserializes children by name regardless of the root element, and reads
+// LastModified/VersionId from response headers, so only the selected attributes
+// appear here. ObjectSize is a pointer so a zero-size object still emits the tag.
+type getObjectAttributesOutput struct {
+	XMLName      xml.Name `xml:"GetObjectAttributesOutput"`
+	Xmlns        string   `xml:"xmlns,attr"`
+	ETag         string   `xml:"ETag,omitempty"`
+	StorageClass string   `xml:"StorageClass,omitempty"`
+	ObjectSize   *int64   `xml:"ObjectSize,omitempty"`
+}
+
 // copyPartResult is the XML response for UploadPartCopy.
 type copyPartResult struct {
 	XMLName      xml.Name `xml:"CopyPartResult"`

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -323,9 +323,14 @@ type ObjectInfo struct {
 	ContentDisposition string
 	ContentLanguage    string
 	// StorageClass is the GCS object storage class (STANDARD/NEARLINE/COLDLINE/
-	// ARCHIVE), defaulting to the bucket's default class at insert. Empty for
-	// providers that don't model it.
+	// ARCHIVE), defaulting to the bucket's default class at insert; on S3 it is
+	// the object's storage class (STANDARD, STANDARD_IA, GLACIER, …), where empty
+	// is treated as STANDARD. Empty for providers that don't model it.
 	StorageClass string
+	// Expires is the S3 Expires system header (an HTTP-date string) recorded on
+	// PutObject and echoed on GET/HEAD. Empty when unset; providers that don't
+	// model it leave it empty.
+	Expires string
 }
 
 // Object is an object with its data.
@@ -366,6 +371,9 @@ type ObjectVersion struct {
 	ETag         string
 	ContentType  string
 	LastModified string
+	// StorageClass is the version's S3 storage class; empty is treated as
+	// STANDARD. Providers that don't model it leave it empty.
+	StorageClass string
 }
 
 // VersionListResult is the result of a ListObjectVersions operation: every
@@ -450,6 +458,11 @@ type CopyObjectRequest struct {
 	// source object's tags.
 	Tags        map[string]string
 	ReplaceTags bool
+	// SystemProps carries the destination's storage class (from x-amz-storage-class,
+	// which is never inherited from the source) and, when ReplaceMetadata is set,
+	// the replacement system properties. With ReplaceMetadata false the destination
+	// inherits the source object's system properties; StorageClass still applies.
+	SystemProps ObjectSystemProps
 	// Copy-source preconditions; a zero value means the header was absent. A
 	// failed precondition must abort the copy with a FailedPrecondition error.
 	IfMatch           string
@@ -652,6 +665,34 @@ type ConditionalBucket interface {
 		ctx context.Context, bucket, key string, data []byte, contentType string,
 		metadata map[string]string, pre S3PutPrecondition,
 	) (*ObjectInfo, error)
+}
+
+// ObjectSystemProps carries the S3 system-defined object properties and storage
+// class that travel with an object on PutObject/CopyObject. Every field is
+// optional; an empty field means the property is unset (StorageClass empty is
+// treated as STANDARD). It is kept separate from the shared PutObject signature
+// so drivers that don't model these properties are unaffected.
+type ObjectSystemProps struct {
+	CacheControl       string
+	ContentEncoding    string
+	ContentDisposition string
+	ContentLanguage    string
+	Expires            string
+	StorageClass       string
+}
+
+// SystemPropsBucket is an OPTIONAL capability (discovered by type assertion like
+// ConditionalBucket) for a driver that persists the S3 system-defined object
+// properties (Cache-Control, Content-Encoding, Content-Disposition,
+// Content-Language, Expires) and storage class alongside an object, so the wire
+// handler can round-trip them on GET/HEAD/List. props is nil when the caller
+// sent none of them. Providers without it keep the plain PutObject behavior and
+// leave these properties unset.
+type SystemPropsBucket interface {
+	PutObjectWithSystemProps(
+		ctx context.Context, bucket, key string, data []byte, contentType string,
+		metadata map[string]string, props *ObjectSystemProps,
+	) error
 }
 
 // GCSPrecondition carries the GCS write preconditions


### PR DESCRIPTION
## Summary

Fixes four AWS S3 fidelity gaps around object system metadata, storage class, and bucket/object attribute reads.

1. **System-defined object metadata** — `Cache-Control`, `Content-Encoding`, `Content-Disposition`, `Content-Language`, and `Expires` are now recorded on `PutObject` and returned on `GetObject`/`HeadObject`. `CopyObject`/`CopyObjectV2` inherit them from the source (unless `REPLACE` overrides). Carried through a new optional `driver.SystemPropsBucket` capability so the shared `Bucket.PutObject` signature is unchanged and GCS/Azure Blob are unaffected.
2. **Storage class** — persisted from the `x-amz-storage-class` request header, echoed in `ListObjectsV2`/`ListObjectVersions`, and emitted on read as `x-amz-storage-class` for non-STANDARD classes only (S3 omits it for STANDARD).
3. **GetObjectAttributes** — new `GET /{bucket}/{key}?attributes` branch returning `ETag`, `ObjectSize`, and `StorageClass` per the `x-amz-object-attributes` header, plus `Last-Modified`/version-id headers. Missing key → `NoSuchKey`, missing bucket → `NoSuchBucket`.
4. **HeadBucket** — returns `x-amz-bucket-region` on 200 (SDK `HeadBucketOutput.BucketRegion`).

## Shared-driver safety

`driver.PutObject`/`ObjectInfo` stay backward-compatible: system props travel through the optional `SystemPropsBucket` capability and additive struct fields. GCS and Azure Blob providers compile unchanged and their tests pass — verified in the gate below.

## Tests

Real `aws-sdk-go-v2/s3` against a booted `httptest` server (`server/aws/s3/system_props_sdk_test.go`):
- system metadata round-trips PUT→HEAD and CopyObject inherits Cache-Control
- StorageClass=STANDARD_IA reported on HeadObject + ListObjectsV2; STANDARD omits the header
- GetObjectAttributes populates ETag/ObjectSize/StorageClass; missing key → NoSuchKey
- HeadBucket returns BucketRegion

Gates: build, vet, `-p=3` tests (AWS S3 + storage + GCS + Azure Blob), `-race`, gofmt, golangci-lint (0 new), `go generate` (coverage docs regenerated), compatgen (no compat diff).
