### PR TITLE
fix(azure-functions): model site kind and managed identity on Microsoft.Web/sites

### DIFF
--- a/providers/azure/functions/site_meta.go
+++ b/providers/azure/functions/site_meta.go
@@ -6,8 +6,10 @@ import (
 	"encoding/base64"
 	"maps"
 	"sort"
+	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
 )
 
@@ -17,6 +19,79 @@ const keyBytes = 32
 // defaultKeyName is the name of the default key Azure provisions for a host and
 // for each function.
 const defaultKeyName = "default"
+
+// emulatorTenantID is the single Azure AD directory all emulated resources
+// report as their tenant, matching the value used by VM/AKS/ACR identity.
+const emulatorTenantID = "11111111-1111-1111-1111-111111111111"
+
+// identityTypeNone is the ARM ResourceIdentityType "None" value: no identity
+// attached.
+const identityTypeNone = "None"
+
+// SiteIdentity is the managed-service-identity attached to a function app
+// (Microsoft.Web/sites identity envelope). For a system-assigned identity the
+// PrincipalID/TenantID are synthesized on store; for each user-assigned
+// identity the per-identity PrincipalID/ClientID are synthesized. On input only
+// Type and the UserAssigned keys (the identities to attach) are meaningful.
+type SiteIdentity struct {
+	Type         string
+	PrincipalID  string
+	TenantID     string
+	UserAssigned map[string]UserAssignedIdentity
+}
+
+// UserAssignedIdentity is one entry of SiteIdentity.UserAssigned: the
+// synthesized principal/client id pair Azure reports for an attached
+// user-assigned identity.
+type UserAssignedIdentity struct {
+	PrincipalID string
+	ClientID    string
+}
+
+// clone returns a deep copy safe to hand outside the store lock.
+func (i *SiteIdentity) clone() *SiteIdentity {
+	out := *i
+	out.UserAssigned = maps.Clone(i.UserAssigned)
+
+	return &out
+}
+
+// identitySeed derives the deterministic system-assigned principal seed for a
+// site from its (resourceGroup, name), so the synthesized principalId is stable
+// across GET/List for the same site.
+func identitySeed(in *SiteMeta) string {
+	return in.ResourceGroup + "/" + in.Name
+}
+
+// resolveSiteIdentity normalizes a submitted managed identity: for a
+// system-assigned identity it synthesizes a deterministic principal/tenant GUID
+// pair, and for each user-assigned identity a deterministic principal/client
+// GUID pair, keyed by seed so the same site always reports the same identity
+// across GET/List. A nil or "None" identity resolves to nil (no identity).
+func resolveSiteIdentity(in *SiteIdentity, seed string) *SiteIdentity {
+	if in == nil || in.Type == "" || strings.EqualFold(in.Type, identityTypeNone) {
+		return nil
+	}
+
+	out := &SiteIdentity{Type: in.Type}
+
+	if strings.Contains(strings.ToLower(in.Type), "systemassigned") {
+		out.PrincipalID = idgen.SyntheticGUID("principal/site/" + seed)
+		out.TenantID = emulatorTenantID
+	}
+
+	if len(in.UserAssigned) > 0 {
+		out.UserAssigned = make(map[string]UserAssignedIdentity, len(in.UserAssigned))
+		for id := range in.UserAssigned {
+			out.UserAssigned[id] = UserAssignedIdentity{
+				PrincipalID: idgen.SyntheticGUID("principal/uai/" + id),
+				ClientID:    idgen.SyntheticGUID("client/uai/" + id),
+			}
+		}
+	}
+
+	return out
+}
 
 // SiteFunction is one function deployed to a function app
 // (Microsoft.Web/sites/functions). Azure discovers these from the deployed
@@ -39,16 +114,20 @@ type SiteMeta struct {
 	Subscription      string
 	ResourceGroup     string
 	Location          string
+	Kind              string
 	ServerFarmID      string
 	HTTPSOnly         bool
 	Reserved          bool
 	LinuxFxVersion    string
 	ProvisioningState string
-	AppSettings       map[string]string
-	MasterKey         string
-	HostFunctionKeys  map[string]string
-	SystemKeys        map[string]string
-	Functions         map[string]*SiteFunction
+	// Identity is the resolved managed-service-identity, nil when the site has
+	// none attached. It is resolved (synthesized) on upsert.
+	Identity         *SiteIdentity
+	AppSettings      map[string]string
+	MasterKey        string
+	HostFunctionKeys map[string]string
+	SystemKeys       map[string]string
+	Functions        map[string]*SiteFunction
 }
 
 // clone returns a deep copy safe to hand outside the store lock.
@@ -57,6 +136,11 @@ func (s *SiteMeta) clone() *SiteMeta {
 	out.AppSettings = maps.Clone(s.AppSettings)
 	out.HostFunctionKeys = maps.Clone(s.HostFunctionKeys)
 	out.SystemKeys = maps.Clone(s.SystemKeys)
+
+	if s.Identity != nil {
+		out.Identity = s.Identity.clone()
+	}
+
 	out.Functions = make(map[string]*SiteFunction, len(s.Functions))
 
 	for name, fn := range s.Functions {
@@ -84,17 +168,26 @@ func (m *Mock) UpsertSiteMeta(_ context.Context, in SiteMeta) (*SiteMeta, error)
 
 	if existing, ok := m.sites.Get(in.Name); ok {
 		existing.Location = in.Location
+		existing.Kind = in.Kind
 		existing.ServerFarmID = in.ServerFarmID
 		existing.HTTPSOnly = in.HTTPSOnly
 		existing.Reserved = in.Reserved
 		existing.LinuxFxVersion = in.LinuxFxVersion
 		existing.AppSettings = maps.Clone(in.AppSettings)
+
+		// A nil in.Identity means the request omitted the identity block, so the
+		// already-attached identity is preserved (real ARM PUT semantics).
+		if in.Identity != nil {
+			existing.Identity = resolveSiteIdentity(in.Identity, identitySeed(&in))
+		}
+
 		m.sites.Set(in.Name, existing)
 
 		return existing.clone(), nil
 	}
 
 	meta := in.clone()
+	meta.Identity = resolveSiteIdentity(in.Identity, identitySeed(&in))
 	meta.ProvisioningState = "Succeeded"
 	meta.MasterKey = generateKey()
 	meta.HostFunctionKeys = map[string]string{defaultKeyName: generateKey()}

--- a/providers/azure/functions/site_meta.go
+++ b/providers/azure/functions/site_meta.go
@@ -168,12 +168,17 @@ func (m *Mock) UpsertSiteMeta(_ context.Context, in SiteMeta) (*SiteMeta, error)
 
 	if existing, ok := m.sites.Get(in.Name); ok {
 		existing.Location = in.Location
-		existing.Kind = in.Kind
 		existing.ServerFarmID = in.ServerFarmID
 		existing.HTTPSOnly = in.HTTPSOnly
 		existing.Reserved = in.Reserved
 		existing.LinuxFxVersion = in.LinuxFxVersion
 		existing.AppSettings = maps.Clone(in.AppSettings)
+
+		// An empty in.Kind means the request omitted kind, so the existing kind
+		// is preserved rather than reverting to the create-time default.
+		if in.Kind != "" {
+			existing.Kind = in.Kind
+		}
 
 		// A nil in.Identity means the request omitted the identity block, so the
 		// already-attached identity is preserved (real ARM PUT semantics).

--- a/server/azure/functions/handler.go
+++ b/server/azure/functions/handler.go
@@ -272,10 +272,12 @@ func (h *Handler) upsertSiteMeta(
 		Subscription:   rp.Subscription,
 		ResourceGroup:  rp.ResourceGroup,
 		Location:       location,
+		Kind:           req.Kind,
 		ServerFarmID:   req.Properties.ServerFarmID,
 		HTTPSOnly:      req.Properties.HTTPSOnly,
 		Reserved:       req.Properties.Reserved,
 		LinuxFxVersion: req.Properties.SiteConfig.LinuxFxVersion,
+		Identity:       toSiteMetaIdentity(req.Identity),
 		AppSettings:    appSettingsToMap(settings),
 	})
 	if err != nil {
@@ -732,10 +734,13 @@ func upsertFunction(r *http.Request, fn sdrv.Serverless, cfg sdrv.FunctionConfig
 func toSiteResource(rp azurearm.ResourcePath, info *sdrv.FunctionInfo, meta *azfunctions.SiteMeta) siteResource {
 	location := defaultLocation
 	provisioningState := "Succeeded"
+	kind := functionAppKind
 
 	var serverFarmID string
 
 	var httpsOnly, reserved bool
+
+	var identity *siteIdentity
 
 	if meta != nil {
 		location = meta.Location
@@ -743,6 +748,11 @@ func toSiteResource(rp azurearm.ResourcePath, info *sdrv.FunctionInfo, meta *azf
 		serverFarmID = meta.ServerFarmID
 		httpsOnly = meta.HTTPSOnly
 		reserved = meta.Reserved
+		identity = fromSiteMetaIdentity(meta.Identity)
+
+		if meta.Kind != "" {
+			kind = meta.Kind
+		}
 	}
 
 	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup,
@@ -754,8 +764,9 @@ func toSiteResource(rp azurearm.ResourcePath, info *sdrv.FunctionInfo, meta *azf
 		ID:       id,
 		Name:     info.Name,
 		Type:     providerName + "/" + resourceType,
-		Kind:     functionAppKind,
+		Kind:     kind,
 		Location: location,
+		Identity: identity,
 		Tags:     info.Tags,
 		Properties: siteProperties{
 			State:             "Running",
@@ -797,6 +808,48 @@ func extractHandlerSetting(settings []nameValue) (handler string, remaining []na
 	}
 
 	return handler, remaining
+}
+
+// toSiteMetaIdentity maps an inbound ARM identity block onto the provider shape.
+// Only Type and the UserAssignedIdentities keys (the identity resource IDs to
+// attach) are meaningful on input; principalId/tenantId/clientId are read-only
+// and discarded. Returns nil when the request omitted the identity block.
+func toSiteMetaIdentity(in *siteIdentity) *azfunctions.SiteIdentity {
+	if in == nil {
+		return nil
+	}
+
+	out := &azfunctions.SiteIdentity{Type: in.Type}
+
+	if len(in.UserAssignedIdentities) > 0 {
+		out.UserAssigned = make(map[string]azfunctions.UserAssignedIdentity, len(in.UserAssignedIdentities))
+		for id := range in.UserAssignedIdentities {
+			out.UserAssigned[id] = azfunctions.UserAssignedIdentity{}
+		}
+	}
+
+	return out
+}
+
+// fromSiteMetaIdentity builds the ARM identity response block from the resolved
+// provider shape, echoing each user-assigned identity's synthesized
+// principalId/clientId. Returns nil when the site has no identity attached, so
+// the response omits the field entirely (matching real Azure).
+func fromSiteMetaIdentity(in *azfunctions.SiteIdentity) *siteIdentity {
+	if in == nil {
+		return nil
+	}
+
+	out := &siteIdentity{Type: in.Type, PrincipalID: in.PrincipalID, TenantID: in.TenantID}
+
+	if len(in.UserAssigned) > 0 {
+		out.UserAssignedIdentities = make(map[string]*siteUserAssignedIdentity, len(in.UserAssigned))
+		for id, u := range in.UserAssigned {
+			out.UserAssignedIdentities[id] = &siteUserAssignedIdentity{PrincipalID: u.PrincipalID, ClientID: u.ClientID}
+		}
+	}
+
+	return out
 }
 
 func appSettingsToMap(settings []nameValue) map[string]string {

--- a/server/azure/functions/sites_identity_sdk_test.go
+++ b/server/azure/functions/sites_identity_sdk_test.go
@@ -68,6 +68,43 @@ func TestSDKSiteKindRoundTrips(t *testing.T) {
 	}
 }
 
+// TestSDKSiteKindPreservedOnUpdateOmit confirms an update PUT that omits kind
+// (e.g. changing only app settings) preserves the existing kind rather than
+// reverting it to the create-time "functionapp" default.
+func TestSDKSiteKindPreservedOnUpdateOmit(t *testing.T) {
+	client, ctx := newFunctionsTestServer(t)
+
+	createSite(t, ctx, client, "sdk-kind-upd", armappservice.Site{
+		Kind:       to.Ptr("app,linux"),
+		Location:   to.Ptr("eastus"),
+		Properties: &armappservice.SiteProperties{SiteConfig: &armappservice.SiteConfig{}},
+	})
+
+	// Update PUT with kind omitted, touching only app settings.
+	updated := createSite(t, ctx, client, "sdk-kind-upd", armappservice.Site{
+		Location: to.Ptr("eastus"),
+		Properties: &armappservice.SiteProperties{
+			SiteConfig: &armappservice.SiteConfig{
+				AppSettings: []*armappservice.NameValuePair{
+					{Name: to.Ptr("FOO"), Value: to.Ptr("bar")},
+				},
+			},
+		},
+	})
+	if updated.Kind == nil || *updated.Kind != "app,linux" {
+		t.Fatalf("updated Kind = %v, want app,linux preserved", updated.Kind)
+	}
+
+	got, err := client.Get(ctx, rgName, "sdk-kind-upd", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Kind == nil || *got.Kind != "app,linux" {
+		t.Fatalf("got Kind = %v, want app,linux preserved after update", got.Kind)
+	}
+}
+
 // TestSDKSiteKindDefaultsWhenOmitted confirms an omitted kind still reports the
 // "functionapp" default.
 func TestSDKSiteKindDefaultsWhenOmitted(t *testing.T) {

--- a/server/azure/functions/sites_identity_sdk_test.go
+++ b/server/azure/functions/sites_identity_sdk_test.go
@@ -1,0 +1,230 @@
+package functions_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3"
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// guidLen is the character length of a canonical GUID (8-4-4-4-12 + 4 dashes).
+const guidLen = 36
+
+func newFunctionsTestServer(t *testing.T) (*armappservice.WebAppsClient, context.Context) {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{Functions: cloudP.Functions}))
+	t.Cleanup(ts.Close)
+
+	return newWebAppsClient(t, ts), context.Background()
+}
+
+//nolint:gocritic // site mirrors the SDK request payload; copying once per create is fine.
+func createSite(
+	t *testing.T, ctx context.Context, client *armappservice.WebAppsClient, name string, site armappservice.Site,
+) armappservice.Site {
+	t.Helper()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rgName, name, site, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate(%s): %v", name, err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, &runtimePollerOptions)
+	if err != nil {
+		t.Fatalf("PollUntilDone(%s): %v", name, err)
+	}
+
+	return created.Site
+}
+
+// TestSDKSiteKindRoundTrips confirms a non-default kind ("app,linux") survives
+// create and GET rather than being overwritten to "functionapp".
+func TestSDKSiteKindRoundTrips(t *testing.T) {
+	client, ctx := newFunctionsTestServer(t)
+
+	created := createSite(t, ctx, client, "sdk-kind", armappservice.Site{
+		Kind:       to.Ptr("app,linux"),
+		Location:   to.Ptr("eastus"),
+		Properties: &armappservice.SiteProperties{SiteConfig: &armappservice.SiteConfig{}},
+	})
+	if created.Kind == nil || *created.Kind != "app,linux" {
+		t.Fatalf("created Kind = %v, want app,linux", created.Kind)
+	}
+
+	got, err := client.Get(ctx, rgName, "sdk-kind", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Kind == nil || *got.Kind != "app,linux" {
+		t.Fatalf("got Kind = %v, want app,linux", got.Kind)
+	}
+}
+
+// TestSDKSiteKindDefaultsWhenOmitted confirms an omitted kind still reports the
+// "functionapp" default.
+func TestSDKSiteKindDefaultsWhenOmitted(t *testing.T) {
+	client, ctx := newFunctionsTestServer(t)
+
+	created := createSite(t, ctx, client, "sdk-nokind", armappservice.Site{
+		Location:   to.Ptr("eastus"),
+		Properties: &armappservice.SiteProperties{SiteConfig: &armappservice.SiteConfig{}},
+	})
+	if created.Kind == nil || *created.Kind != "functionapp" {
+		t.Fatalf("created Kind = %v, want functionapp", created.Kind)
+	}
+}
+
+// TestSDKSiteSystemAssignedIdentity confirms a system-assigned identity is
+// modeled: the create and GET responses carry a non-empty, deterministic
+// principalId + tenantId, so azurerm's identity[0].principal_id is present.
+func TestSDKSiteSystemAssignedIdentity(t *testing.T) {
+	client, ctx := newFunctionsTestServer(t)
+
+	created := createSite(t, ctx, client, "sdk-sa", armappservice.Site{
+		Location:   to.Ptr("eastus"),
+		Identity:   &armappservice.ManagedServiceIdentity{Type: to.Ptr(armappservice.ManagedServiceIdentityTypeSystemAssigned)},
+		Properties: &armappservice.SiteProperties{SiteConfig: &armappservice.SiteConfig{}},
+	})
+
+	assertSystemAssigned(t, created.Identity)
+	created1 := *created.Identity.PrincipalID
+
+	got, err := client.Get(ctx, rgName, "sdk-sa", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	assertSystemAssigned(t, got.Identity)
+
+	if *got.Identity.PrincipalID != created1 {
+		t.Fatalf("principalId not deterministic: create=%s get=%s", created1, *got.Identity.PrincipalID)
+	}
+
+	got2, err := client.Get(ctx, rgName, "sdk-sa", nil)
+	if err != nil {
+		t.Fatalf("Get #2: %v", err)
+	}
+
+	if *got2.Identity.PrincipalID != created1 {
+		t.Fatalf("principalId drifted across GETs: %s vs %s", created1, *got2.Identity.PrincipalID)
+	}
+}
+
+func assertSystemAssigned(t *testing.T, id *armappservice.ManagedServiceIdentity) {
+	t.Helper()
+
+	if id == nil {
+		t.Fatal("identity nil, want SystemAssigned block")
+	}
+
+	if id.PrincipalID == nil || len(*id.PrincipalID) != guidLen {
+		t.Fatalf("principalId = %v, want %d-char GUID", id.PrincipalID, guidLen)
+	}
+
+	if id.TenantID == nil || len(*id.TenantID) != guidLen {
+		t.Fatalf("tenantId = %v, want %d-char GUID", id.TenantID, guidLen)
+	}
+}
+
+// TestSDKSiteUserAssignedIdentity confirms a user-assigned identity echoes the
+// submitted identity keys back, each with a synthesized principal/client id.
+func TestSDKSiteUserAssignedIdentity(t *testing.T) {
+	client, ctx := newFunctionsTestServer(t)
+
+	uaID := "/subscriptions/" + subID +
+		"/resourceGroups/" + rgName +
+		"/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-uai"
+
+	created := createSite(t, ctx, client, "sdk-ua", armappservice.Site{
+		Location: to.Ptr("eastus"),
+		Identity: &armappservice.ManagedServiceIdentity{
+			Type:                   to.Ptr(armappservice.ManagedServiceIdentityTypeUserAssigned),
+			UserAssignedIdentities: map[string]*armappservice.UserAssignedIdentity{uaID: {}},
+		},
+		Properties: &armappservice.SiteProperties{SiteConfig: &armappservice.SiteConfig{}},
+	})
+
+	got, err := client.Get(ctx, rgName, "sdk-ua", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	for _, id := range []*armappservice.ManagedServiceIdentity{created.Identity, got.Identity} {
+		if id == nil || id.UserAssignedIdentities == nil {
+			t.Fatalf("user-assigned identity missing: %+v", id)
+		}
+
+		entry, ok := id.UserAssignedIdentities[uaID]
+		if !ok || entry == nil {
+			t.Fatalf("submitted identity key %q not echoed: %+v", uaID, id.UserAssignedIdentities)
+		}
+
+		if entry.PrincipalID == nil || *entry.PrincipalID == "" ||
+			entry.ClientID == nil || *entry.ClientID == "" {
+			t.Fatalf("user-assigned identity ids not synthesized: %+v", entry)
+		}
+	}
+}
+
+// TestSDKSiteNoIdentity confirms a site created without an identity block
+// reports no identity on GET (Identity nil).
+func TestSDKSiteNoIdentity(t *testing.T) {
+	client, ctx := newFunctionsTestServer(t)
+
+	createSite(t, ctx, client, "sdk-noid", armappservice.Site{
+		Location:   to.Ptr("eastus"),
+		Properties: &armappservice.SiteProperties{SiteConfig: &armappservice.SiteConfig{}},
+	})
+
+	got, err := client.Get(ctx, rgName, "sdk-noid", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Identity != nil {
+		t.Fatalf("Identity = %+v, want nil for a site with no identity", got.Identity)
+	}
+}
+
+// TestSDKSiteSecretNotLeakedOnGet is a #715 regression: an app-setting secret
+// submitted at create time must NOT appear on a plain site GET (it is exposed
+// only via ListApplicationSettings).
+func TestSDKSiteSecretNotLeakedOnGet(t *testing.T) {
+	client, ctx := newFunctionsTestServer(t)
+
+	const secretVal = "super-secret-value"
+
+	createSite(t, ctx, client, "sdk-secret", armappservice.Site{
+		Location: to.Ptr("eastus"),
+		Properties: &armappservice.SiteProperties{
+			SiteConfig: &armappservice.SiteConfig{
+				AppSettings: []*armappservice.NameValuePair{
+					{Name: to.Ptr("API_KEY"), Value: to.Ptr(secretVal)},
+				},
+			},
+		},
+	})
+
+	got, err := client.Get(ctx, rgName, "sdk-secret", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.SiteConfig == nil {
+		t.Fatal("site properties missing")
+	}
+
+	for _, s := range got.Properties.SiteConfig.AppSettings {
+		if s != nil && s.Value != nil && strings.Contains(*s.Value, secretVal) {
+			t.Fatalf("secret leaked on plain GET: %+v", s)
+		}
+	}
+}

--- a/server/azure/functions/types.go
+++ b/server/azure/functions/types.go
@@ -5,13 +5,43 @@ package functions
 // (id, name, type, kind, location, basic properties) and skip the long tail
 // of feature flags real App Service surfaces.
 type siteResource struct {
-	ID         string            `json:"id"`
-	Name       string            `json:"name"`
-	Type       string            `json:"type"`
-	Kind       string            `json:"kind"`
-	Location   string            `json:"location"`
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Kind     string `json:"kind"`
+	Location string `json:"location"`
+	// Identity is the managed-service-identity envelope, a sibling of properties
+	// at the resource root. Omitted (nil) when the site has no identity attached,
+	// matching real Azure.
+	Identity   *siteIdentity     `json:"identity,omitempty"`
 	Tags       map[string]string `json:"tags,omitempty"`
 	Properties siteProperties    `json:"properties"`
+}
+
+// siteIdentity is the ARM ManagedServiceIdentity envelope for a function app:
+// system-assigned and/or user-assigned identity configuration.
+type siteIdentity struct {
+	// Type is one of "None", "SystemAssigned", "UserAssigned",
+	// "SystemAssigned,UserAssigned".
+	Type string `json:"type,omitempty"`
+	// PrincipalID/TenantID are read-only: Azure populates them once a
+	// system-assigned identity is attached. A request sends neither; we decode
+	// them so a client that round-trips a GET response back into a PUT still
+	// decodes.
+	PrincipalID string `json:"principalId,omitempty"`
+	TenantID    string `json:"tenantId,omitempty"`
+	// UserAssignedIdentities is keyed by the full ARM resource ID of a
+	// user-assigned identity to attach. A request sends an empty object per key;
+	// principalId/clientId are read-only, populated on the response.
+	UserAssignedIdentities map[string]*siteUserAssignedIdentity `json:"userAssignedIdentities,omitempty"`
+}
+
+// siteUserAssignedIdentity is one entry of siteIdentity.userAssignedIdentities:
+// the read-only principal/client id pair Azure reports for an attached
+// user-assigned identity.
+type siteUserAssignedIdentity struct {
+	PrincipalID string `json:"principalId,omitempty"`
+	ClientID    string `json:"clientId,omitempty"`
 }
 
 type siteProperties struct {
@@ -52,6 +82,7 @@ type siteListResponse struct {
 type createSiteRequest struct {
 	Kind       string               `json:"kind"`
 	Location   string               `json:"location"`
+	Identity   *siteIdentity        `json:"identity"`
 	Tags       map[string]string    `json:"tags"`
 	Properties createSiteProperties `json:"properties"`
 }


### PR DESCRIPTION
## Summary

Two Azure Functions (`Microsoft.Web/sites`) bugs surfaced by driving the real `armappservice/v3` SDK against a booted `azureserver`:

1. **`kind` always overwritten to `functionapp`.** A site PUT with `kind="app,linux"` (or any non-default) came back as `functionapp` on both create and GET because `toSiteResource` hardcoded the kind. The request kind is now stored on `SiteMeta.Kind` and echoed, falling back to `functionapp` only when the request omits kind.

2. **Managed identity not modeled (hard failure for Terraform).** A PUT with `identity:{type:SystemAssigned}` dropped the `identity` envelope entirely, so azurerm's `identity[0].principal_id` hit index-out-of-range. The top-level `identity` field is now modeled:
   - **SystemAssigned** synthesizes a deterministic `principalId` + emulator `tenantId` (via `idgen.SyntheticGUID`, matching the VM/AKS/ACR pattern), stable across GET/List.
   - **UserAssigned** echoes each submitted identity key back with a synthesized `principalId`/`clientId`.
   - **SystemAssigned,UserAssigned** does both.
   - `None`/omitted yields no identity block.

The `echoUnmodeledProperties` overlay only rescues unmodeled `properties.*`, not top-level envelope fields, so both required real modeling. `echo_properties.go` is untouched (the #715 secret-stripping stays intact).

Deferred (unchanged): PATCH update, connection strings, publish profile, slots, source control.

## Tests

New real-SDK e2e (`sites_identity_sdk_test.go`): kind round-trip; kind default when omitted; SystemAssigned deterministic principal/tenant GUIDs across GETs; UserAssigned key echo; no-identity nil; and a #715 regression asserting an app-setting secret is still not exposed on a plain GET.