### PR TITLE
fix(gcp-clouddns): validate zone/record semantics and round-trip dnssec + private visibility

### DIFF
--- a/providers/gcp/clouddns/dns.go
+++ b/providers/gcp/clouddns/dns.go
@@ -46,6 +46,51 @@ func recordKey(zoneID, name, recordType, setID string) string {
 	return key
 }
 
+// cloneDNSSEC deep-copies a DNSSEC config so the stored zone does not alias the
+// caller's value. Returns nil for a nil input.
+func cloneDNSSEC(in *driver.DNSSECConfig) *driver.DNSSECConfig {
+	if in == nil {
+		return nil
+	}
+
+	out := &driver.DNSSECConfig{State: in.State, NonExistence: in.NonExistence}
+	if in.DefaultKeySpecs != nil {
+		out.DefaultKeySpecs = append([]driver.DNSKeySpec(nil), in.DefaultKeySpecs...)
+	}
+
+	return out
+}
+
+// cloneNetworks copies a visibility-network slice so the stored zone does not
+// alias the caller's slice. Returns nil for a nil input.
+func cloneNetworks(in []driver.VisibilityNetwork) []driver.VisibilityNetwork {
+	if in == nil {
+		return nil
+	}
+
+	return append([]driver.VisibilityNetwork(nil), in...)
+}
+
+// mergeDNSSEC returns the incoming DNSSEC config (cloned) when a patch carries
+// one, else preserves the existing value — so a patch that omits it is a no-op.
+func mergeDNSSEC(existing, incoming *driver.DNSSECConfig) *driver.DNSSECConfig {
+	if incoming == nil {
+		return existing
+	}
+
+	return cloneDNSSEC(incoming)
+}
+
+// mergeNetworks returns the incoming visibility networks (cloned) when a patch
+// carries them, else preserves the existing slice.
+func mergeNetworks(existing, incoming []driver.VisibilityNetwork) []driver.VisibilityNetwork {
+	if incoming == nil {
+		return existing
+	}
+
+	return cloneNetworks(incoming)
+}
+
 // CreateZone creates a new Cloud DNS managed zone.
 func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.ZoneInfo, error) {
 	if cfg.Name == "" {
@@ -56,8 +101,9 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 	// same project (the wire always carries one); the portable API, which
 	// creates with a zero scope, is unaffected.
 	if cfg.Scope.Project != "" {
-		for _, z := range m.zones.SortedValues() {
-			if z.Name == cfg.Name && z.Scope.Project == cfg.Scope.Project {
+		existing := m.zones.SortedValues()
+		for i := range existing {
+			if existing[i].Name == cfg.Name && existing[i].Scope.Project == cfg.Scope.Project {
 				return nil, cerrors.Newf(cerrors.AlreadyExists,
 					"managed zone %q already exists in project %q", cfg.Name, cfg.Scope.Project)
 			}
@@ -72,12 +118,14 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 	}
 
 	zone := driver.ZoneInfo{
-		ID:          id,
-		Name:        cfg.Name,
-		Private:     cfg.Private,
-		RecordCount: 0,
-		Tags:        tags,
-		Scope:       cfg.Scope,
+		ID:                 id,
+		Name:               cfg.Name,
+		Private:            cfg.Private,
+		RecordCount:        0,
+		Tags:               tags,
+		Scope:              cfg.Scope,
+		DNSSECConfig:       cloneDNSSEC(cfg.DNSSECConfig),
+		VisibilityNetworks: cloneNetworks(cfg.VisibilityNetworks),
 	}
 
 	m.zones.Set(id, zone)
@@ -121,11 +169,13 @@ func (m *Mock) ListZones(_ context.Context, filter scope.Scope) ([]driver.ZoneIn
 	all := m.zones.SortedValues()
 
 	zones := make([]driver.ZoneInfo, 0, len(all))
-	for _, z := range all {
-		if !z.Scope.Matches(filter) {
+
+	for i := range all {
+		if !all[i].Scope.Matches(filter) {
 			continue
 		}
-		zones = append(zones, z)
+
+		zones = append(zones, all[i])
 	}
 
 	return zones, nil
@@ -149,6 +199,11 @@ func (m *Mock) UpdateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 		if !cfg.Scope.IsZero() {
 			z.Scope = cfg.Scope
 		}
+
+		// Preserve the GCP-only zone config across a patch that omits it; a patch
+		// that carries it replaces the stored value.
+		z.DNSSECConfig = mergeDNSSEC(z.DNSSECConfig, cfg.DNSSECConfig)
+		z.VisibilityNetworks = mergeNetworks(z.VisibilityNetworks, cfg.VisibilityNetworks)
 
 		m.zones.Set(z.ID, z)
 

--- a/server/gcp/clouddns/handler.go
+++ b/server/gcp/clouddns/handler.go
@@ -45,12 +45,15 @@ const (
 
 // Handler serves dns.googleapis.com v1 requests against a dns driver.
 type Handler struct {
-	dns       dnsdriver.DNS
-	changeSeq atomic.Uint64
+	dns dnsdriver.DNS
+	// opSeq numbers managed-zone Operations (patch/update). It is independent of
+	// per-zone change ids, which are sequential within a zone's change log.
+	opSeq atomic.Uint64
 
 	// changes records applied changes per driver zone id so changes.list/get can
 	// replay them. Cloud DNS keeps this change log itself; the dns driver models
-	// only the end state, so the wire layer owns it. Guarded by mu.
+	// only the end state, so the wire layer owns it. Change ids are the change's
+	// index within this per-zone log. Guarded by mu.
 	mu      sync.Mutex
 	changes map[string][]changeJSON
 }

--- a/server/gcp/clouddns/management_api_sdk_test.go
+++ b/server/gcp/clouddns/management_api_sdk_test.go
@@ -202,12 +202,18 @@ func TestSDKChangesListAndGet(t *testing.T) {
 		t.Fatalf("Changes.List: %v", err)
 	}
 
-	if len(list.Changes) != 1 {
-		t.Fatalf("changes.list = %d, want 1: %+v", len(list.Changes), list.Changes)
+	// A fresh zone already logs the initial apex SOA/NS provisioning change
+	// (id "0"), so after one user change the log holds two entries.
+	if len(list.Changes) != 2 {
+		t.Fatalf("changes.list = %d, want 2 (seed + created): %+v", len(list.Changes), list.Changes)
 	}
 
-	if list.Changes[0].Id != created.Id {
-		t.Errorf("listed change id = %q, want %q", list.Changes[0].Id, created.Id)
+	if list.Changes[0].Id != "0" {
+		t.Errorf("first listed change id = %q, want the seeded \"0\"", list.Changes[0].Id)
+	}
+
+	if list.Changes[1].Id != created.Id {
+		t.Errorf("listed change id = %q, want %q", list.Changes[1].Id, created.Id)
 	}
 
 	got, err := svc.Changes.Get(testProject, "chg-zone", created.Id).Context(ctx).Do()

--- a/server/gcp/clouddns/operations.go
+++ b/server/gcp/clouddns/operations.go
@@ -37,10 +37,12 @@ func (h *Handler) createZone(w http.ResponseWriter, r *http.Request, rt route) {
 	tags[creationTimeTag] = time.Now().UTC().Format(time.RFC3339)
 
 	info, err := h.dns.CreateZone(r.Context(), dnsdriver.ZoneConfig{
-		Name:    req.Name,
-		Private: privateFor(req.Visibility),
-		Tags:    tags,
-		Scope:   scope.Scope{Project: rt.project},
+		Name:               req.Name,
+		Private:            privateFor(req.Visibility),
+		Tags:               tags,
+		Scope:              scope.Scope{Project: rt.project},
+		DNSSECConfig:       dnssecFromJSON(req.DnssecConfig),
+		VisibilityNetworks: visibilityFromJSON(req.PrivateVisibilityConfig),
 	})
 	if err != nil {
 		gcprest.WriteCErr(w, err)
@@ -54,17 +56,47 @@ func (h *Handler) createZone(w http.ResponseWriter, r *http.Request, rt route) {
 
 // seedApexRecords creates the SOA and NS record sets Cloud DNS auto-provisions
 // at a new zone's apex, so rrsets.list on a fresh zone returns them (2 records)
-// as real Cloud DNS does. A best-effort operation: a record that somehow
-// already exists is left as-is rather than failing zone creation.
+// as real Cloud DNS does, and logs the initial change (id "0") that Cloud DNS
+// records for that provisioning so changes.list on a fresh zone returns it. A
+// best-effort create: a record that somehow already exists is left as-is rather
+// than failing zone creation.
 func (h *Handler) seedApexRecords(r *http.Request, info *dnsdriver.ZoneInfo) {
-	dnsName := info.Name
-	if v, ok := info.Tags[dnsNameTag]; ok && v != "" {
-		dnsName = v
-	}
+	cfgs := apexRecordConfigs(info.ID, apexDNSName(info))
+	additions := make([]resourceRecordSetJSON, 0, len(cfgs))
 
-	cfgs := apexRecordConfigs(info.ID, dnsName)
 	for i := range cfgs {
 		_, _ = h.dns.CreateRecord(r.Context(), cfgs[i])
+		additions = append(additions, recordConfigToJSON(&cfgs[i]))
+	}
+
+	change := changeJSON{
+		Kind:      kindChange,
+		Additions: additions,
+		Status:    changeStatusDone,
+		StartTime: time.Now().UTC().Format(time.RFC3339),
+	}
+	h.recordChange(info.ID, &change)
+}
+
+// apexDNSName returns the zone's DNS suffix (the reserved dnsName tag), falling
+// back to the zone name when the tag is absent.
+func apexDNSName(info *dnsdriver.ZoneInfo) string {
+	if v, ok := info.Tags[dnsNameTag]; ok && v != "" {
+		return v
+	}
+
+	return info.Name
+}
+
+// recordConfigToJSON renders a driver RecordConfig as the wire rrset shape, used
+// to describe the apex records in the seeded initial change.
+func recordConfigToJSON(c *dnsdriver.RecordConfig) resourceRecordSetJSON {
+	return resourceRecordSetJSON{
+		Kind:    kindResourceRecordSet,
+		Name:    c.Name,
+		Type:    c.Type,
+		TTL:     int64(c.TTL),
+		Rrdatas: c.Values,
 	}
 }
 
@@ -133,10 +165,12 @@ func (h *Handler) patchZone(w http.ResponseWriter, r *http.Request, rt route) {
 	tags := mergeZoneTags(info.Tags, &req)
 
 	if _, uerr := h.dns.UpdateZone(r.Context(), dnsdriver.ZoneConfig{
-		Name:    info.Name,
-		Private: info.Private,
-		Tags:    tags,
-		Scope:   info.Scope,
+		Name:               info.Name,
+		Private:            info.Private,
+		Tags:               tags,
+		Scope:              info.Scope,
+		DNSSECConfig:       dnssecFromJSON(req.DnssecConfig),
+		VisibilityNetworks: visibilityFromJSON(req.PrivateVisibilityConfig),
 	}); uerr != nil {
 		gcprest.WriteCErr(w, uerr)
 		return
@@ -144,7 +178,7 @@ func (h *Handler) patchZone(w http.ResponseWriter, r *http.Request, rt route) {
 
 	gcprest.WriteJSON(w, http.StatusOK, operationJSON{
 		Kind:      kindOperation,
-		ID:        strconv.FormatUint(h.changeSeq.Add(1), 10),
+		ID:        strconv.FormatUint(h.opSeq.Add(1), 10),
 		StartTime: time.Now().UTC().Format(time.RFC3339),
 		Status:    operationStatusDone,
 		Type:      "update",
@@ -191,6 +225,12 @@ func (h *Handler) deleteZone(w http.ResponseWriter, r *http.Request, rt route) {
 		return
 	}
 
+	// Cloud DNS refuses to delete a zone that still holds user record sets; only
+	// the auto-created apex SOA/NS may remain. Anything else → 400 containerNotEmpty.
+	if ok := h.rejectIfNotEmpty(w, r, id); !ok {
+		return
+	}
+
 	if derr := h.dns.DeleteZone(r.Context(), id); derr != nil {
 		gcprest.WriteCErr(w, derr)
 		return
@@ -198,6 +238,39 @@ func (h *Handler) deleteZone(w http.ResponseWriter, r *http.Request, rt route) {
 
 	// Cloud DNS Delete returns an empty 200 body.
 	gcprest.WriteJSON(w, http.StatusOK, struct{}{})
+}
+
+// rejectIfNotEmpty writes a 400 containerNotEmpty and returns false when the
+// zone holds any record set beyond the apex SOA/NS Cloud DNS auto-creates.
+func (h *Handler) rejectIfNotEmpty(w http.ResponseWriter, r *http.Request, id string) bool {
+	info, err := h.dns.GetZone(r.Context(), id)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return false
+	}
+
+	records, err := h.dns.ListRecords(r.Context(), id)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return false
+	}
+
+	dnsName := apexDNSName(info)
+	for i := range records {
+		if !isApexRRSet(records[i].Name, records[i].Type, dnsName) {
+			gcprest.WriteError(w, http.StatusBadRequest, "containerNotEmpty",
+				"the managed zone still has user-created record sets and cannot be deleted")
+			return false
+		}
+	}
+
+	return true
+}
+
+// isApexRRSet reports whether name/rtype is the zone's apex NS or SOA record set,
+// which Cloud DNS auto-creates and protects from direct deletion.
+func isApexRRSet(name, rtype, dnsName string) bool {
+	return name == dnsName && (rtype == "NS" || rtype == "SOA")
 }
 
 // createChange applies a batch of record additions and deletions atomically,
@@ -215,24 +288,73 @@ func (h *Handler) createChange(w http.ResponseWriter, r *http.Request, rt route)
 		return
 	}
 
+	info, err := h.dns.GetZone(r.Context(), id)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
 	// Cloud DNS applies a change atomically. The dns driver has no batch/
-	// transaction primitive, so validate the whole batch up front — every
-	// deletion must resolve and no addition may already exist — before any
-	// mutation. This makes a bad batch fail cleanly without half-applying it.
-	// (A concurrent writer between validation and apply could still race; a
-	// true fix needs a driver-level transaction — tracked as a follow-up.)
+	// transaction primitive, so validate the whole batch up front — deletions
+	// resolve and don't strip the apex, additions don't collide, and no name is
+	// left with a CNAME beside another type — before any mutation, so a bad batch
+	// fails cleanly without half-applying. (A concurrent writer between validation
+	// and apply could still race; a true fix needs a driver-level transaction.)
+	if !h.checkDeletions(w, r, id, apexDNSName(info), &req) ||
+		!h.checkAdditions(w, r, id, &req) ||
+		!h.checkCNAME(w, r, id, &req) {
+		return
+	}
+
+	if !h.applyChange(w, r, id, &req) {
+		return
+	}
+
+	change := changeJSON{
+		Kind:      kindChange,
+		Additions: req.Additions,
+		Deletions: req.Deletions,
+		Status:    changeStatusDone,
+		StartTime: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	h.recordChange(id, &change)
+
+	gcprest.WriteJSON(w, http.StatusOK, change)
+}
+
+// checkDeletions validates a change's deletions: each must resolve, and a pure
+// deletion of the apex NS/SOA (one not paired with a re-adding of the same
+// rrset) is rejected as Cloud DNS forbids removing them.
+func (h *Handler) checkDeletions(w http.ResponseWriter, r *http.Request, id, dnsName string, req *changeJSON) bool {
+	adding := make(map[string]bool, len(req.Additions))
+	for i := range req.Additions {
+		adding[rrsetKey(req.Additions[i].Name, req.Additions[i].Type)] = true
+	}
+
 	for i := range req.Deletions {
 		d := &req.Deletions[i]
+		if isApexRRSet(d.Name, d.Type, dnsName) && !adding[rrsetKey(d.Name, d.Type)] {
+			gcprest.WriteError(w, http.StatusBadRequest, "invalid",
+				"the resource record set at the zone apex ("+d.Type+") cannot be deleted")
+			return false
+		}
+
 		if _, gerr := h.dns.GetRecord(r.Context(), id, d.Name, d.Type); gerr != nil {
 			gcprest.WriteCErr(w, gerr)
-			return
+			return false
 		}
 	}
 
-	// The canonical "update a record set" change deletes the old rrset and adds
-	// a new one with the SAME name+type in one batch. Such an addition is not a
-	// real conflict — it replaces a record this same change removes — so exempt
-	// additions whose (name,type) also appears in the deletions.
+	return true
+}
+
+// checkAdditions validates that no addition collides with an existing record
+// set. The canonical "update a record set" change deletes the old rrset and adds
+// a new one with the SAME name+type in one batch; such an addition is not a real
+// conflict — it replaces a record this same change removes — so exempt additions
+// whose (name,type) also appears in the deletions.
+func (h *Handler) checkAdditions(w http.ResponseWriter, r *http.Request, id string, req *changeJSON) bool {
 	deleting := make(map[string]bool, len(req.Deletions))
 	for i := range req.Deletions {
 		deleting[rrsetKey(req.Deletions[i].Name, req.Deletions[i].Type)] = true
@@ -247,54 +369,106 @@ func (h *Handler) createChange(w http.ResponseWriter, r *http.Request, rt route)
 		if _, gerr := h.dns.GetRecord(r.Context(), id, a.Name, a.Type); gerr == nil {
 			gcprest.WriteCErr(w, cerrors.Newf(cerrors.AlreadyExists,
 				"record set %q %s already exists", a.Name, a.Type))
-			return
+			return false
 		}
 	}
 
+	return true
+}
+
+// checkCNAME rejects a change that would leave any name with a CNAME record set
+// beside a record set of another type, which Cloud DNS forbids.
+func (h *Handler) checkCNAME(w http.ResponseWriter, r *http.Request, id string, req *changeJSON) bool {
+	current, err := h.dns.ListRecords(r.Context(), id)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return false
+	}
+
+	if name, bad := cnameConflict(postApplyTypes(current, req)); bad {
+		gcprest.WriteError(w, http.StatusBadRequest, "cnameResourceRecordSetConflict",
+			"the resource record set at "+name+" would have a CNAME alongside another type")
+		return false
+	}
+
+	return true
+}
+
+// applyChange performs the change's deletions then additions against the driver.
+func (h *Handler) applyChange(w http.ResponseWriter, r *http.Request, id string, req *changeJSON) bool {
 	for i := range req.Deletions {
 		d := &req.Deletions[i]
 		if derr := h.dns.DeleteRecord(r.Context(), id, d.Name, d.Type); derr != nil {
 			gcprest.WriteCErr(w, derr)
-			return
+			return false
 		}
 	}
 
 	for i := range req.Additions {
 		a := &req.Additions[i]
-
-		_, aerr := h.dns.CreateRecord(r.Context(), dnsdriver.RecordConfig{
-			ZoneID: id,
-			Name:   a.Name,
-			Type:   a.Type,
-			TTL:    int(a.TTL),
-			Values: a.Rrdatas,
-		})
-		if aerr != nil {
+		if _, aerr := h.dns.CreateRecord(r.Context(), dnsdriver.RecordConfig{
+			ZoneID: id, Name: a.Name, Type: a.Type, TTL: int(a.TTL), Values: a.Rrdatas,
+		}); aerr != nil {
 			gcprest.WriteCErr(w, aerr)
-			return
+			return false
 		}
 	}
 
-	change := changeJSON{
-		Kind:      kindChange,
-		ID:        strconv.FormatUint(h.changeSeq.Add(1), 10),
-		Additions: req.Additions,
-		Deletions: req.Deletions,
-		Status:    changeStatusDone,
-		StartTime: time.Now().UTC().Format(time.RFC3339),
-	}
-
-	h.recordChange(id, &change)
-
-	gcprest.WriteJSON(w, http.StatusOK, change)
+	return true
 }
 
-// recordChange appends an applied change to the zone's change log for later
-// retrieval via changes.list/get.
+// postApplyTypes computes, per record-set name, the set of record types present
+// after req's deletions and additions apply to the zone's current records.
+func postApplyTypes(current []dnsdriver.RecordInfo, req *changeJSON) map[string]map[string]bool {
+	deleting := make(map[string]bool, len(req.Deletions))
+	for i := range req.Deletions {
+		deleting[rrsetKey(req.Deletions[i].Name, req.Deletions[i].Type)] = true
+	}
+
+	byName := make(map[string]map[string]bool)
+	add := func(name, rtype string) {
+		if byName[name] == nil {
+			byName[name] = make(map[string]bool)
+		}
+
+		byName[name][rtype] = true
+	}
+
+	for i := range current {
+		if deleting[rrsetKey(current[i].Name, current[i].Type)] {
+			continue
+		}
+
+		add(current[i].Name, current[i].Type)
+	}
+
+	for i := range req.Additions {
+		add(req.Additions[i].Name, req.Additions[i].Type)
+	}
+
+	return byName
+}
+
+// cnameConflict reports the first name that would carry a CNAME record set
+// alongside a record set of another type.
+func cnameConflict(byName map[string]map[string]bool) (string, bool) {
+	for name, types := range byName {
+		if types["CNAME"] && len(types) > 1 {
+			return name, true
+		}
+	}
+
+	return "", false
+}
+
+// recordChange assigns the change its per-zone id (its index in the zone's
+// change log) and appends it, so changes are numbered sequentially per zone
+// starting at "0" — independent of managed-zone operation ids.
 func (h *Handler) recordChange(zoneID string, change *changeJSON) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	change.ID = strconv.Itoa(len(h.changes[zoneID]))
 	h.changes[zoneID] = append(h.changes[zoneID], *change)
 }
 

--- a/server/gcp/clouddns/types.go
+++ b/server/gcp/clouddns/types.go
@@ -34,6 +34,10 @@ const (
 	kindChange                 = "dns#change"
 	kindChangesList            = "dns#changesListResponse"
 	kindOperation              = "dns#operation"
+	kindDNSSECConfig           = "dns#managedZoneDnsSecConfig"
+	kindDNSKeySpec             = "dns#dnsKeySpec"
+	kindPrivateVisibility      = "dns#managedZonePrivateVisibilityConfig"
+	kindVisibilityNetwork      = "dns#managedZonePrivateVisibilityConfigNetwork"
 )
 
 // changeStatusDone is the terminal state Cloud DNS reports once a change has
@@ -57,6 +61,106 @@ type managedZoneJSON struct {
 	Labels       map[string]string `json:"labels,omitempty"`
 	CreationTime string            `json:"creationTime,omitempty"`
 	NameServers  []string          `json:"nameServers,omitempty"`
+	// DnssecConfig and PrivateVisibilityConfig round-trip the GCP-only zone
+	// settings the dns driver models as ZoneInfo.DNSSECConfig/VisibilityNetworks.
+	DnssecConfig            *dnssecConfigJSON            `json:"dnssecConfig,omitempty"`
+	PrivateVisibilityConfig *privateVisibilityConfigJSON `json:"privateVisibilityConfig,omitempty"`
+}
+
+// dnssecConfigJSON is the Cloud DNS ManagedZoneDnsSecConfig resource.
+type dnssecConfigJSON struct {
+	Kind            string           `json:"kind,omitempty"`
+	State           string           `json:"state,omitempty"`
+	NonExistence    string           `json:"nonExistence,omitempty"`
+	DefaultKeySpecs []dnsKeySpecJSON `json:"defaultKeySpecs,omitempty"`
+}
+
+// dnsKeySpecJSON is one entry of dnssecConfig.defaultKeySpecs.
+type dnsKeySpecJSON struct {
+	Kind      string `json:"kind,omitempty"`
+	Algorithm string `json:"algorithm,omitempty"`
+	KeyLength int64  `json:"keyLength,omitempty"`
+	KeyType   string `json:"keyType,omitempty"`
+}
+
+// privateVisibilityConfigJSON is the Cloud DNS
+// ManagedZonePrivateVisibilityConfig resource (networks subset).
+type privateVisibilityConfigJSON struct {
+	Kind     string                  `json:"kind,omitempty"`
+	Networks []visibilityNetworkJSON `json:"networks,omitempty"`
+}
+
+// visibilityNetworkJSON is one entry of privateVisibilityConfig.networks.
+type visibilityNetworkJSON struct {
+	Kind       string `json:"kind,omitempty"`
+	NetworkURL string `json:"networkUrl,omitempty"`
+}
+
+// dnssecToJSON converts the driver's DNSSEC config to its wire form.
+func dnssecToJSON(c *dnsdriver.DNSSECConfig) *dnssecConfigJSON {
+	if c == nil {
+		return nil
+	}
+
+	out := &dnssecConfigJSON{Kind: kindDNSSECConfig, State: c.State, NonExistence: c.NonExistence}
+
+	for i := range c.DefaultKeySpecs {
+		k := &c.DefaultKeySpecs[i]
+		out.DefaultKeySpecs = append(out.DefaultKeySpecs, dnsKeySpecJSON{
+			Kind: kindDNSKeySpec, Algorithm: k.Algorithm, KeyLength: int64(k.KeyLength), KeyType: k.KeyType,
+		})
+	}
+
+	return out
+}
+
+// dnssecFromJSON converts a wire DNSSEC config to the driver's form.
+func dnssecFromJSON(j *dnssecConfigJSON) *dnsdriver.DNSSECConfig {
+	if j == nil {
+		return nil
+	}
+
+	out := &dnsdriver.DNSSECConfig{State: j.State, NonExistence: j.NonExistence}
+
+	for i := range j.DefaultKeySpecs {
+		k := &j.DefaultKeySpecs[i]
+		out.DefaultKeySpecs = append(out.DefaultKeySpecs, dnsdriver.DNSKeySpec{
+			Algorithm: k.Algorithm, KeyLength: int(k.KeyLength), KeyType: k.KeyType,
+		})
+	}
+
+	return out
+}
+
+// visibilityToJSON converts the driver's visibility networks to their wire form.
+func visibilityToJSON(nets []dnsdriver.VisibilityNetwork) *privateVisibilityConfigJSON {
+	if len(nets) == 0 {
+		return nil
+	}
+
+	out := &privateVisibilityConfigJSON{Kind: kindPrivateVisibility}
+	for i := range nets {
+		out.Networks = append(out.Networks, visibilityNetworkJSON{
+			Kind: kindVisibilityNetwork, NetworkURL: nets[i].NetworkURL,
+		})
+	}
+
+	return out
+}
+
+// visibilityFromJSON converts a wire privateVisibilityConfig to the driver's
+// visibility-network slice.
+func visibilityFromJSON(j *privateVisibilityConfigJSON) []dnsdriver.VisibilityNetwork {
+	if j == nil || len(j.Networks) == 0 {
+		return nil
+	}
+
+	out := make([]dnsdriver.VisibilityNetwork, 0, len(j.Networks))
+	for i := range j.Networks {
+		out = append(out, dnsdriver.VisibilityNetwork{NetworkURL: j.Networks[i].NetworkURL})
+	}
+
+	return out
 }
 
 type managedZonesListResponse struct {
@@ -152,6 +256,9 @@ func toManagedZoneJSON(info *dnsdriver.ZoneInfo) managedZoneJSON {
 		Description:  info.Tags[descriptionTag],
 		CreationTime: info.Tags[creationTimeTag],
 		NameServers:  nameServersFor(info.ID),
+
+		DnssecConfig:            dnssecToJSON(info.DNSSECConfig),
+		PrivateVisibilityConfig: visibilityToJSON(info.VisibilityNetworks),
 	}
 }
 

--- a/server/gcp/clouddns/validation_sdk_test.go
+++ b/server/gcp/clouddns/validation_sdk_test.go
@@ -1,0 +1,314 @@
+package clouddns_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	dns "google.golang.org/api/dns/v1"
+	"google.golang.org/api/googleapi"
+)
+
+// apiCode extracts the HTTP status code from a googleapi error, failing the test
+// when err is not a googleapi.Error.
+func apiCode(t *testing.T, err error) int {
+	t.Helper()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		t.Fatalf("want googleapi.Error, got %v", err)
+	}
+
+	return gerr.Code
+}
+
+// createZone is a test helper that creates a managed zone and fails on error.
+func createZone(t *testing.T, svc *dns.Service, z *dns.ManagedZone) *dns.ManagedZone {
+	t.Helper()
+
+	created, err := svc.ManagedZones.Create(testProject, z).Context(context.Background()).Do()
+	if err != nil {
+		t.Fatalf("ManagedZones.Create(%s): %v", z.Name, err)
+	}
+
+	return created
+}
+
+// addRecord is a test helper that applies a single-addition change.
+func addRecord(t *testing.T, svc *dns.Service, zone string, rr *dns.ResourceRecordSet) error {
+	t.Helper()
+
+	_, err := svc.Changes.Create(testProject, zone, &dns.Change{
+		Additions: []*dns.ResourceRecordSet{rr},
+	}).Context(context.Background()).Do()
+
+	return err
+}
+
+// TestSDKDeleteNonEmptyZoneRejected (B1) asserts a zone holding a user record set
+// cannot be deleted (400 containerNotEmpty), while a zone with only the apex
+// SOA/NS deletes cleanly.
+func TestSDKDeleteNonEmptyZoneRejected(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	createZone(t, svc, &dns.ManagedZone{Name: "full-zone", DnsName: "full.example.com."})
+
+	if err := addRecord(t, svc, "full-zone", &dns.ResourceRecordSet{
+		Name: "www.full.example.com.", Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1"},
+	}); err != nil {
+		t.Fatalf("addRecord: %v", err)
+	}
+
+	err := svc.ManagedZones.Delete(testProject, "full-zone").Context(ctx).Do()
+	if code := apiCode(t, err); code != 400 {
+		t.Fatalf("Delete non-empty zone: got %d, want 400 containerNotEmpty", code)
+	}
+
+	// A zone with only the auto-created apex records deletes without error.
+	createZone(t, svc, &dns.ManagedZone{Name: "empty-zone", DnsName: "empty.example.com."})
+	if err := svc.ManagedZones.Delete(testProject, "empty-zone").Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete apex-only zone: %v", err)
+	}
+}
+
+// TestSDKCNAMECoexistenceRejected (B2) asserts a CNAME cannot coexist with
+// another record type at the same name, in either add order.
+func TestSDKCNAMECoexistenceRejected(t *testing.T) {
+	svc := newDNSService(t)
+
+	createZone(t, svc, &dns.ManagedZone{Name: "cname-zone", DnsName: "cname.example.com."})
+
+	// A exists, then adding a CNAME at the same name conflicts.
+	if err := addRecord(t, svc, "cname-zone", &dns.ResourceRecordSet{
+		Name: "a.cname.example.com.", Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1"},
+	}); err != nil {
+		t.Fatalf("add A: %v", err)
+	}
+
+	err := addRecord(t, svc, "cname-zone", &dns.ResourceRecordSet{
+		Name: "a.cname.example.com.", Type: "CNAME", Ttl: 300, Rrdatas: []string{"target.example.com."},
+	})
+	if code := apiCode(t, err); code != 400 {
+		t.Fatalf("add CNAME beside A: got %d, want 400", code)
+	}
+
+	// CNAME exists, then adding an A at the same name conflicts.
+	if err := addRecord(t, svc, "cname-zone", &dns.ResourceRecordSet{
+		Name: "c.cname.example.com.", Type: "CNAME", Ttl: 300, Rrdatas: []string{"target.example.com."},
+	}); err != nil {
+		t.Fatalf("add CNAME: %v", err)
+	}
+
+	err = addRecord(t, svc, "cname-zone", &dns.ResourceRecordSet{
+		Name: "c.cname.example.com.", Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.2"},
+	})
+	if code := apiCode(t, err); code != 400 {
+		t.Fatalf("add A beside CNAME: got %d, want 400", code)
+	}
+}
+
+// apexRecord fetches the zone's apex record set of the given type via the SDK.
+func apexRecord(t *testing.T, svc *dns.Service, zone, dnsName, rtype string) *dns.ResourceRecordSet {
+	t.Helper()
+
+	list, err := svc.ResourceRecordSets.List(testProject, zone).
+		Name(dnsName).Type(rtype).Context(context.Background()).Do()
+	if err != nil {
+		t.Fatalf("List apex %s: %v", rtype, err)
+	}
+
+	if len(list.Rrsets) != 1 {
+		t.Fatalf("apex %s rrsets = %d, want 1", rtype, len(list.Rrsets))
+	}
+
+	return list.Rrsets[0]
+}
+
+// TestSDKApexNSSOADeletionRejected (B3) asserts the apex NS and SOA record sets
+// cannot be removed by a plain deletion change.
+func TestSDKApexNSSOADeletionRejected(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	const dnsName = "apex.example.com."
+	createZone(t, svc, &dns.ManagedZone{Name: "apex-zone", DnsName: dnsName})
+
+	for _, rtype := range []string{"NS", "SOA"} {
+		rr := apexRecord(t, svc, "apex-zone", dnsName, rtype)
+
+		_, err := svc.Changes.Create(testProject, "apex-zone", &dns.Change{
+			Deletions: []*dns.ResourceRecordSet{rr},
+		}).Context(ctx).Do()
+		if code := apiCode(t, err); code != 400 {
+			t.Fatalf("delete apex %s: got %d, want 400", rtype, code)
+		}
+	}
+}
+
+// TestSDKFreshZoneChangeLogged (B4) asserts a freshly created zone already has
+// the initial apex-provisioning change (id "0") in its change log.
+func TestSDKFreshZoneChangeLogged(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	createZone(t, svc, &dns.ManagedZone{Name: "seed-zone", DnsName: "seed.example.com."})
+
+	list, err := svc.Changes.List(testProject, "seed-zone").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Changes.List: %v", err)
+	}
+
+	if len(list.Changes) != 1 {
+		t.Fatalf("fresh-zone changes = %d, want 1: %+v", len(list.Changes), list.Changes)
+	}
+
+	c := list.Changes[0]
+	if c.Id != "0" || c.Status != "done" {
+		t.Fatalf("seed change = id %q status %q, want id \"0\" status done", c.Id, c.Status)
+	}
+
+	if len(userRrsets(c.Additions)) != 0 || len(c.Additions) != 2 {
+		t.Fatalf("seed change additions = %+v, want the apex SOA+NS", c.Additions)
+	}
+}
+
+// TestSDKChangeIdSequentialAfterPatch (B5) asserts change ids stay sequential
+// within a zone and are not perturbed by a managed-zone patch (which uses a
+// separate operation-id counter).
+func TestSDKChangeIdSequentialAfterPatch(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	createZone(t, svc, &dns.ManagedZone{Name: "seq-zone", DnsName: "seq.example.com."})
+
+	first, err := svc.Changes.Create(testProject, "seq-zone", &dns.Change{
+		Additions: []*dns.ResourceRecordSet{
+			{Name: "a.seq.example.com.", Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1"}},
+		},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("first change: %v", err)
+	}
+
+	if first.Id != "1" {
+		t.Fatalf("first user change id = %q, want \"1\" (after seeded \"0\")", first.Id)
+	}
+
+	// A zone patch must not consume a change id.
+	if _, err := svc.ManagedZones.Patch(testProject, "seq-zone", &dns.ManagedZone{
+		Description: "patched",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	second, err := svc.Changes.Create(testProject, "seq-zone", &dns.Change{
+		Additions: []*dns.ResourceRecordSet{
+			{Name: "b.seq.example.com.", Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.2"}},
+		},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("second change: %v", err)
+	}
+
+	if second.Id != "2" {
+		t.Fatalf("second user change id = %q, want \"2\" (sequential, patch did not skip)", second.Id)
+	}
+}
+
+// TestSDKDnssecConfigRoundTrip (B6) asserts a zone's dnssecConfig survives
+// create → get (and a subsequent patch that omits it).
+func TestSDKDnssecConfigRoundTrip(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	createZone(t, svc, &dns.ManagedZone{
+		Name:    "dnssec-zone",
+		DnsName: "dnssec.example.com.",
+		DnssecConfig: &dns.ManagedZoneDnsSecConfig{
+			State:        "on",
+			NonExistence: "nsec3",
+			DefaultKeySpecs: []*dns.DnsKeySpec{
+				{Algorithm: "rsasha256", KeyLength: 2048, KeyType: "keySigning"},
+				{Algorithm: "rsasha256", KeyLength: 1024, KeyType: "zoneSigning"},
+			},
+		},
+	})
+
+	got, err := svc.ManagedZones.Get(testProject, "dnssec-zone").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	assertDnssecOn(t, got.DnssecConfig)
+
+	// A patch that does not touch dnssecConfig must preserve it.
+	if _, err := svc.ManagedZones.Patch(testProject, "dnssec-zone", &dns.ManagedZone{
+		Description: "unrelated",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	after, err := svc.ManagedZones.Get(testProject, "dnssec-zone").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	assertDnssecOn(t, after.DnssecConfig)
+}
+
+// assertDnssecOn checks the round-tripped dnssecConfig matches what B6 created.
+func assertDnssecOn(t *testing.T, c *dns.ManagedZoneDnsSecConfig) {
+	t.Helper()
+
+	if c == nil {
+		t.Fatal("dnssecConfig dropped after round-trip")
+	}
+
+	if c.State != "on" || c.NonExistence != "nsec3" {
+		t.Fatalf("dnssecConfig = state %q nonExistence %q, want on/nsec3", c.State, c.NonExistence)
+	}
+
+	if len(c.DefaultKeySpecs) != 2 {
+		t.Fatalf("defaultKeySpecs = %d, want 2", len(c.DefaultKeySpecs))
+	}
+
+	if c.DefaultKeySpecs[0].KeyLength != 2048 || c.DefaultKeySpecs[0].KeyType != "keySigning" {
+		t.Fatalf("keySpec[0] = %+v, want 2048/keySigning", c.DefaultKeySpecs[0])
+	}
+}
+
+// TestSDKPrivateVisibilityNetworksRoundTrip (B7) asserts a private zone's
+// privateVisibilityConfig.networks survive create → get.
+func TestSDKPrivateVisibilityNetworksRoundTrip(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	const netURL = "https://www.googleapis.com/compute/v1/projects/demo/global/networks/vpc-a"
+
+	createZone(t, svc, &dns.ManagedZone{
+		Name:       "private-zone",
+		DnsName:    "private.example.com.",
+		Visibility: "private",
+		PrivateVisibilityConfig: &dns.ManagedZonePrivateVisibilityConfig{
+			Networks: []*dns.ManagedZonePrivateVisibilityConfigNetwork{{NetworkUrl: netURL}},
+		},
+	})
+
+	got, err := svc.ManagedZones.Get(testProject, "private-zone").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Visibility != "private" {
+		t.Fatalf("visibility = %q, want private", got.Visibility)
+	}
+
+	if got.PrivateVisibilityConfig == nil || len(got.PrivateVisibilityConfig.Networks) != 1 {
+		t.Fatalf("privateVisibilityConfig.networks dropped: %+v", got.PrivateVisibilityConfig)
+	}
+
+	if got.PrivateVisibilityConfig.Networks[0].NetworkUrl != netURL {
+		t.Fatalf("networkUrl = %q, want %q", got.PrivateVisibilityConfig.Networks[0].NetworkUrl, netURL)
+	}
+}

--- a/services/dns/driver/driver.go
+++ b/services/dns/driver/driver.go
@@ -14,6 +14,28 @@ type VPCAssociation struct {
 	VPCRegion string
 }
 
+// DNSKeySpec is one key specification within a GCP Cloud DNS DNSSEC config.
+// Other providers leave it unused.
+type DNSKeySpec struct {
+	Algorithm string
+	KeyLength int
+	KeyType   string // "keySigning" | "zoneSigning"
+}
+
+// DNSSECConfig is the GCP Cloud DNS DNSSEC configuration of a managed zone.
+// Other providers leave it nil.
+type DNSSECConfig struct {
+	State           string // "off" | "on" | "transfer"
+	NonExistence    string // "nsec" | "nsec3"
+	DefaultKeySpecs []DNSKeySpec
+}
+
+// VisibilityNetwork is a VPC network a GCP Cloud DNS private zone is visible
+// to (privateVisibilityConfig.networks[]). Other providers leave it nil.
+type VisibilityNetwork struct {
+	NetworkURL string
+}
+
 // ZoneConfig describes a DNS zone to create.
 type ZoneConfig struct {
 	Name    string
@@ -33,6 +55,12 @@ type ZoneConfig struct {
 	// Scope records the cloud-side container the zone was created in (Azure
 	// subscription/resource group or GCP project). The zero value is unscoped.
 	Scope scope.Scope
+	// DNSSECConfig is the GCP Cloud DNS DNSSEC configuration to apply. Other
+	// providers leave it nil.
+	DNSSECConfig *DNSSECConfig
+	// VisibilityNetworks are the VPC networks a GCP Cloud DNS private zone is
+	// visible to. Other providers leave it nil.
+	VisibilityNetworks []VisibilityNetwork
 }
 
 // ZoneInfo describes a DNS zone.
@@ -54,6 +82,12 @@ type ZoneInfo struct {
 	// Scope is the container the zone lives in; scoped list endpoints filter
 	// on it. The zero value is unscoped and visible everywhere.
 	Scope scope.Scope
+	// DNSSECConfig is the GCP Cloud DNS DNSSEC configuration as stored on
+	// create/patch. Other providers leave it nil.
+	DNSSECConfig *DNSSECConfig
+	// VisibilityNetworks are the VPC networks a GCP Cloud DNS private zone is
+	// visible to. Other providers leave it nil.
+	VisibilityNetworks []VisibilityNetwork
 }
 
 // AliasTarget describes an AWS Route 53 alias target (an A/AAAA record that


### PR DESCRIPTION
## Summary

Fixes seven real-cloud-parity bugs in the GCP Cloud DNS (dns.googleapis.com v1) wire handler, verified end-to-end against the real `google.golang.org/api/dns/v1` SDK pointed at a booted `gcpserver`.

### Validation / semantics
- **Non-empty zone delete (data-shaped):** `managedZones.delete` on a zone that still holds user record sets now returns `400 containerNotEmpty` instead of silently cascading every record and returning 200. Only the auto-created apex SOA/NS may remain for a delete to succeed.
- **CNAME coexistence:** a change that would leave any name with a CNAME beside another record type (in either add order) is rejected `400`.
- **Apex NS/SOA protection:** a plain deletion of the apex NS or SOA rrset is rejected `400`. A delete paired with a re-add of the same rrset (the canonical apex update) is still allowed.
- **Fresh-zone change log:** zone creation now logs the initial apex-provisioning change (id `"0"`), so `changes.list` on a fresh zone returns it as real Cloud DNS does.
- **Change-id sequencing:** change ids are now numbered per-zone from `"0"` via the change log, independent of the managed-zone Operation-id counter, so change ids no longer skip after a zone patch.

### Round-trip (Terraform drift)
- **dnssecConfig** (state / nonExistence / defaultKeySpecs) now round-trips on create, get, and patch.
- **privateVisibilityConfig.networks[].networkUrl** now round-trips.

Both are modeled on `driver.ZoneInfo`/`ZoneConfig` (GCP-only, other providers leave them nil), mirroring the existing `VPCAssociation`/`AliasTarget` pattern.

### Tests
New real-SDK e2e coverage in `validation_sdk_test.go` for each of the seven behaviors, plus an update to `TestSDKChangesListAndGet` for the seeded initial change.

Out of scope (not implemented): forwardingConfig/peeringConfig/reverseLookup/cloudLogging config, rrsets direct create/patch/delete API, DNS Policies, Response Policies.