### PR TITLE
fix(gcp-artifactregistry): round-trip dockerConfig.immutableTags + cleanupPolicies, honor list filter/orderBy

### DIFF
--- a/server/gcp/artifactregistry/operations.go
+++ b/server/gcp/artifactregistry/operations.go
@@ -34,11 +34,11 @@ func (h *Handler) createRepository(w http.ResponseWriter, r *http.Request, rt *r
 }
 
 // reservedTagsFrom folds the GCP-only Repository fields (format, description,
-// mode, kmsKeyName) the driver does not model into reserved tags alongside the
-// user labels, so they round-trip on read.
+// mode, kmsKeyName, dockerConfig, cleanupPolicies) the driver does not model
+// into reserved tags alongside the user labels, so they round-trip on read.
 // reservedFieldCount is the number of GCP-only Repository fields folded into
-// reserved tags (format, description, mode, kmsKeyName).
-const reservedFieldCount = 4
+// reserved tags.
+const reservedFieldCount = 7
 
 func reservedTagsFrom(body *repositoryJSON) map[string]string {
 	tags := make(map[string]string, len(body.Labels)+reservedFieldCount)
@@ -62,7 +62,41 @@ func reservedTagsFrom(body *repositoryJSON) map[string]string {
 		tags[kmsKeyTag] = body.KmsKeyName
 	}
 
+	addExtraTags(tags, body)
+
 	return tags
+}
+
+// addExtraTags folds the dockerConfig / cleanupPolicies / cleanupPolicyDryRun
+// fields into reserved tags. Shared with the patch path via the same setters so
+// create and update stay in lockstep.
+func addExtraTags(tags map[string]string, body *repositoryJSON) {
+	setBoolTag(tags, immutableTagsTag, body.DockerConfig != nil && body.DockerConfig.ImmutableTags)
+	setCleanupPolicies(tags, body.CleanupPolicies)
+	setBoolTag(tags, cleanupDryRunTag, body.CleanupPolicyDryRun)
+}
+
+// setBoolTag stores key="true" when val, else drops it.
+func setBoolTag(tags map[string]string, key string, val bool) {
+	if val {
+		tags[key] = trueTag
+		return
+	}
+
+	delete(tags, key)
+}
+
+// setCleanupPolicies stores the cleanupPolicies map as opaque JSON, or drops the
+// reserved tag when empty.
+func setCleanupPolicies(tags map[string]string, policies map[string]json.RawMessage) {
+	if len(policies) == 0 {
+		delete(tags, cleanupPolicyTag)
+		return
+	}
+
+	if b, err := json.Marshal(policies); err == nil {
+		tags[cleanupPolicyTag] = string(b)
+	}
 }
 
 // repositoryTypeURL is the protobuf Any type URL a GAPIC client expects in a
@@ -106,8 +140,9 @@ func (h *Handler) listRepositories(w http.ResponseWriter, r *http.Request, rt *r
 		return
 	}
 
-	page, err := pagination.PaginateSorted(repos,
-		func(a, b crdriver.Repository) bool { return repoName(a.Name) < repoName(b.Name) },
+	repos = filterRepositories(rt, repos, r.URL.Query().Get("filter"))
+
+	page, err := pagination.PaginateSorted(repos, repoLess(rt, r.URL.Query().Get("orderBy")),
 		r.URL.Query().Get("pageToken"), pageSize(r))
 	if err != nil {
 		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid page token")
@@ -123,6 +158,104 @@ func (h *Handler) listRepositories(w http.ResponseWriter, r *http.Request, rt *r
 
 	gcprest.WriteJSON(w, http.StatusOK,
 		listRepositoriesResponse{Repositories: out, NextPageToken: page.NextPageToken})
+}
+
+// filterRepositories honors the v1 List `filter` query param. Only the `name`
+// field is supported (exact, or prefix when the value ends with `*`); any other
+// or malformed expression returns the full set unfiltered, matching the API's
+// lenient behavior rather than erroring.
+func filterRepositories(rt *route, repos []crdriver.Repository, filter string) []crdriver.Repository {
+	want, ok := parseNameFilter(filter)
+	if !ok {
+		return repos
+	}
+
+	out := make([]crdriver.Repository, 0, len(repos))
+
+	for i := range repos {
+		full := repositoryResourceName(rt.project, rt.location, repoName(repos[i].Name))
+		if nameMatches(full, want) {
+			out = append(out, repos[i])
+		}
+	}
+
+	return out
+}
+
+// parseNameFilter extracts the value of a `name = "..."` filter expression.
+func parseNameFilter(filter string) (string, bool) {
+	const nameField = "name"
+
+	filter = strings.TrimSpace(filter)
+	if !strings.HasPrefix(filter, nameField) {
+		return "", false
+	}
+
+	rest := strings.TrimSpace(strings.TrimPrefix(filter, nameField))
+	if !strings.HasPrefix(rest, "=") {
+		return "", false
+	}
+
+	val := strings.Trim(strings.TrimSpace(rest[1:]), `"`)
+	if val == "" {
+		return "", false
+	}
+
+	return val, true
+}
+
+// nameMatches compares a repository's full resource name against a filter value,
+// treating a trailing `*` as a prefix match.
+func nameMatches(full, want string) bool {
+	if strings.HasSuffix(want, "*") {
+		return strings.HasPrefix(full, strings.TrimSuffix(want, "*"))
+	}
+
+	return full == want
+}
+
+// repoLess builds the less func for the v1 List `orderBy` query param. Supported
+// keys are name (default), createTime, updateTime, each with an optional " desc".
+func repoLess(rt *route, orderBy string) func(a, b crdriver.Repository) bool {
+	field, desc := parseOrderBy(orderBy)
+
+	return func(a, b crdriver.Repository) bool {
+		ka, kb := repoSortKey(rt, field, &a), repoSortKey(rt, field, &b)
+		if desc {
+			return ka > kb
+		}
+
+		return ka < kb
+	}
+}
+
+// parseOrderBy splits an orderBy clause into its field and descending flag.
+func parseOrderBy(orderBy string) (field string, desc bool) {
+	fields := strings.Fields(orderBy)
+	if len(fields) == 0 {
+		return "name", false
+	}
+
+	field = strings.TrimSuffix(fields[0], ",")
+	desc = len(fields) > 1 && strings.EqualFold(fields[1], "desc")
+
+	return field, desc
+}
+
+// repoSortKey returns the comparison key for a repository under the given field.
+func repoSortKey(rt *route, field string, r *crdriver.Repository) string {
+	switch field {
+	case "createTime":
+		return r.CreatedAt
+	case "updateTime":
+		if r.UpdatedAt != "" {
+			return r.UpdatedAt
+		}
+
+		return r.CreatedAt
+	default:
+		return repositoryResourceName(rt.project, rt.location, repoName(r.Name))
+	}
 }
 
 func (h *Handler) patchRepository(w http.ResponseWriter, r *http.Request, rt *route) {
@@ -183,7 +316,25 @@ func applyPatch(current map[string]string, body *repositoryJSON, mask map[string
 		setOrDelete(tags, kmsKeyTag, body.KmsKeyName)
 	}
 
+	applyExtrasPatch(tags, body, mask, all)
+
 	return tags
+}
+
+// applyExtrasPatch merges the dockerConfig / cleanupPolicies / cleanupPolicyDryRun
+// patch fields, honoring the update mask (or all when the mask is empty/"*").
+func applyExtrasPatch(tags map[string]string, body *repositoryJSON, mask map[string]bool, all bool) {
+	if all || mask["dockerConfig"] {
+		setBoolTag(tags, immutableTagsTag, body.DockerConfig != nil && body.DockerConfig.ImmutableTags)
+	}
+
+	if all || mask["cleanupPolicies"] {
+		setCleanupPolicies(tags, body.CleanupPolicies)
+	}
+
+	if all || mask["cleanupPolicyDryRun"] {
+		setBoolTag(tags, cleanupDryRunTag, body.CleanupPolicyDryRun)
+	}
 }
 
 // replaceLabels swaps every non-reserved (user label) key in tags for the ones

--- a/server/gcp/artifactregistry/operations.go
+++ b/server/gcp/artifactregistry/operations.go
@@ -216,11 +216,18 @@ func nameMatches(full, want string) bool {
 
 // repoLess builds the less func for the v1 List `orderBy` query param. Supported
 // keys are name (default), createTime, updateTime, each with an optional " desc".
+// createTime/updateTime are only second-granular, so equal primary keys fall back
+// to the unique repository name, giving a total order that is stable across calls
+// (m.repos.All() has randomized map iteration order) and safe for offset paging.
 func repoLess(rt *route, orderBy string) func(a, b crdriver.Repository) bool {
 	field, desc := parseOrderBy(orderBy)
 
 	return func(a, b crdriver.Repository) bool {
 		ka, kb := repoSortKey(rt, field, &a), repoSortKey(rt, field, &b)
+		if ka == kb {
+			ka, kb = repoName(a.Name), repoName(b.Name)
+		}
+
 		if desc {
 			return ka > kb
 		}

--- a/server/gcp/artifactregistry/repository_config_test.go
+++ b/server/gcp/artifactregistry/repository_config_test.go
@@ -1,0 +1,220 @@
+package artifactregistry_test
+
+import (
+	"context"
+	"testing"
+
+	ar "google.golang.org/api/artifactregistry/v1"
+)
+
+// TestSDKArtifactRegistryImmutableTagsRoundTrip guards B1: a repository created
+// with dockerConfig.immutableTags must return the same dockerConfig on Get
+// (previously dropped, causing perpetual Terraform drift), and a patch flipping
+// it must persist.
+func TestSDKArtifactRegistryImmutableTagsRoundTrip(t *testing.T) {
+	svc, _ := newARService(t)
+	ctx := context.Background()
+
+	name := testParent + "/repositories/immutable"
+
+	if _, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{
+		Format:       "DOCKER",
+		DockerConfig: &ar.DockerRepositoryConfig{ImmutableTags: true},
+	}).RepositoryId("immutable").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Repositories.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.DockerConfig == nil || !got.DockerConfig.ImmutableTags {
+		t.Fatalf("dockerConfig=%+v want immutableTags=true", got.DockerConfig)
+	}
+
+	if _, err := svc.Projects.Locations.Repositories.Patch(name, &ar.Repository{
+		DockerConfig:    &ar.DockerRepositoryConfig{ImmutableTags: false},
+		ForceSendFields: []string{"DockerConfig"},
+	}).UpdateMask("dockerConfig").Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch dockerConfig: %v", err)
+	}
+
+	got, err = svc.Projects.Locations.Repositories.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if got.DockerConfig != nil && got.DockerConfig.ImmutableTags {
+		t.Fatalf("dockerConfig=%+v want immutableTags cleared", got.DockerConfig)
+	}
+}
+
+// TestSDKArtifactRegistryCleanupPoliciesRoundTrip guards B2: cleanupPolicies and
+// cleanupPolicyDryRun must round-trip on create+get and honor a patch mask.
+func TestSDKArtifactRegistryCleanupPoliciesRoundTrip(t *testing.T) {
+	svc, _ := newARService(t)
+	ctx := context.Background()
+
+	name := testParent + "/repositories/cleanup"
+
+	const keepCount = 5
+
+	policies := map[string]ar.CleanupPolicy{
+		"keep-recent": {
+			Id:                 "keep-recent",
+			Action:             "KEEP",
+			MostRecentVersions: &ar.CleanupPolicyMostRecentVersions{KeepCount: keepCount},
+		},
+	}
+
+	if _, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{
+		Format:              "DOCKER",
+		CleanupPolicies:     policies,
+		CleanupPolicyDryRun: true,
+	}).RepositoryId("cleanup").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Repositories.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	pol, ok := got.CleanupPolicies["keep-recent"]
+	if !ok {
+		t.Fatalf("cleanupPolicies=%+v want key keep-recent", got.CleanupPolicies)
+	}
+
+	if pol.Action != "KEEP" || pol.MostRecentVersions == nil || pol.MostRecentVersions.KeepCount != keepCount {
+		t.Fatalf("cleanup policy=%+v want KEEP keepCount=%d", pol, keepCount)
+	}
+
+	if !got.CleanupPolicyDryRun {
+		t.Fatalf("cleanupPolicyDryRun=false want true")
+	}
+
+	if _, err := svc.Projects.Locations.Repositories.Patch(name, &ar.Repository{
+		CleanupPolicyDryRun: false,
+		ForceSendFields:     []string{"CleanupPolicyDryRun"},
+	}).UpdateMask("cleanupPolicyDryRun").Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch cleanupPolicyDryRun: %v", err)
+	}
+
+	got, err = svc.Projects.Locations.Repositories.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if got.CleanupPolicyDryRun {
+		t.Fatalf("cleanupPolicyDryRun=true want cleared after patch")
+	}
+
+	if _, ok := got.CleanupPolicies["keep-recent"]; !ok {
+		t.Fatalf("cleanupPolicies dropped by unrelated patch: %+v", got.CleanupPolicies)
+	}
+}
+
+// TestSDKArtifactRegistryListFilter guards B3: repositories.list must honor a
+// name= filter and narrow the result set.
+func TestSDKArtifactRegistryListFilter(t *testing.T) {
+	svc, _ := newARService(t)
+	ctx := context.Background()
+
+	for _, id := range []string{"alpha", "beta", "gamma"} {
+		if _, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{Format: "DOCKER"}).
+			RepositoryId(id).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create %s: %v", id, err)
+		}
+	}
+
+	want := testParent + "/repositories/beta"
+
+	list, err := svc.Projects.Locations.Repositories.List(testParent).
+		Filter(`name="` + want + `"`).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List with filter: %v", err)
+	}
+
+	if len(list.Repositories) != 1 || list.Repositories[0].Name != want {
+		t.Fatalf("filter returned %+v want only %s", list.Repositories, want)
+	}
+}
+
+// TestSDKArtifactRegistryListOrderBy guards B4: repositories.list must honor
+// orderBy=name desc instead of always sorting ascending.
+func TestSDKArtifactRegistryListOrderBy(t *testing.T) {
+	svc, _ := newARService(t)
+	ctx := context.Background()
+
+	for _, id := range []string{"aaa", "mmm", "zzz"} {
+		if _, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{Format: "DOCKER"}).
+			RepositoryId(id).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create %s: %v", id, err)
+		}
+	}
+
+	list, err := svc.Projects.Locations.Repositories.List(testParent).
+		OrderBy("name desc").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List orderBy: %v", err)
+	}
+
+	wantOrder := []string{
+		testParent + "/repositories/zzz",
+		testParent + "/repositories/mmm",
+		testParent + "/repositories/aaa",
+	}
+
+	if len(list.Repositories) != len(wantOrder) {
+		t.Fatalf("got %d repositories, want %d", len(list.Repositories), len(wantOrder))
+	}
+
+	for i, w := range wantOrder {
+		if list.Repositories[i].Name != w {
+			t.Fatalf("orderBy=name desc pos %d = %s want %s", i, list.Repositories[i].Name, w)
+		}
+	}
+}
+
+// TestSDKArtifactRegistryConfigNoRegression guards that the pre-existing
+// format/mode round-trip and updateMask PATCH still work alongside the new
+// fields.
+func TestSDKArtifactRegistryConfigNoRegression(t *testing.T) {
+	svc, _ := newARService(t)
+	ctx := context.Background()
+
+	name := testParent + "/repositories/noreg"
+
+	if _, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{
+		Format:      "DOCKER",
+		Mode:        "STANDARD_REPOSITORY",
+		Description: "orig",
+		Labels:      map[string]string{"env": "dev"},
+	}).RepositoryId("noreg").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Repositories.Patch(name, &ar.Repository{
+		Description: "updated",
+	}).UpdateMask("description").Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Repositories.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Format != "DOCKER" || got.Mode != "STANDARD_REPOSITORY" {
+		t.Fatalf("format=%q mode=%q want DOCKER/STANDARD_REPOSITORY", got.Format, got.Mode)
+	}
+
+	if got.Description != "updated" {
+		t.Fatalf("description=%q want updated", got.Description)
+	}
+
+	if got.Labels["env"] != "dev" {
+		t.Fatalf("labels=%+v want env=dev preserved through description patch", got.Labels)
+	}
+}

--- a/server/gcp/artifactregistry/repository_list_paging_test.go
+++ b/server/gcp/artifactregistry/repository_list_paging_test.go
@@ -1,0 +1,130 @@
+package artifactregistry_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	ar "google.golang.org/api/artifactregistry/v1"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// newARServiceFixedClock boots an Artifact Registry SDK client whose server uses
+// a frozen clock, so every repository gets the same second-granular createTime /
+// updateTime — the tie condition that exposed the non-deterministic sort.
+func newARServiceFixedClock(t *testing.T) *ar.Service {
+	t.Helper()
+
+	clock := config.NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloud := cloudemu.NewGCP(config.WithClock(clock))
+	srv := gcpserver.New(gcpserver.Drivers{ArtifactRegistry: cloud.ArtifactRegistry})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := ar.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("artifactregistry.NewService: %v", err)
+	}
+
+	return svc
+}
+
+// paginateAllRepoNames walks every page of repositories.list one at a time under
+// the given orderBy, returning the names in page order.
+func paginateAllRepoNames(t *testing.T, svc *ar.Service, orderBy string) []string {
+	t.Helper()
+
+	ctx := context.Background()
+
+	var (
+		names []string
+		token string
+	)
+
+	const maxPages = 100
+
+	for range maxPages {
+		resp, err := svc.Projects.Locations.Repositories.List(testParent).
+			OrderBy(orderBy).PageSize(1).PageToken(token).Context(ctx).Do()
+		if err != nil {
+			t.Fatalf("List orderBy=%q: %v", orderBy, err)
+		}
+
+		for _, repo := range resp.Repositories {
+			names = append(names, repo.Name)
+		}
+
+		token = resp.NextPageToken
+		if token == "" {
+			return names
+		}
+	}
+
+	t.Fatalf("orderBy=%q did not terminate within %d pages", orderBy, maxPages)
+
+	return nil
+}
+
+// assertExactlyOnceAndStable checks that one-at-a-time pagination yields each of
+// wantIDs exactly once (no dup/skip) and that the page order is identical across
+// two independent list sweeps.
+func assertExactlyOnceAndStable(t *testing.T, svc *ar.Service, orderBy string, wantIDs []string) {
+	t.Helper()
+
+	first := paginateAllRepoNames(t, svc, orderBy)
+
+	seen := make(map[string]int, len(first))
+	for _, n := range first {
+		seen[n]++
+	}
+
+	if len(seen) != len(wantIDs) || len(first) != len(wantIDs) {
+		t.Fatalf("orderBy=%q paged %d names (%d unique), want %d exactly once: %v",
+			orderBy, len(first), len(seen), len(wantIDs), first)
+	}
+
+	for _, id := range wantIDs {
+		if got := seen[testParent+"/repositories/"+id]; got != 1 {
+			t.Fatalf("orderBy=%q: repo %q appeared %d times, want exactly 1", orderBy, id, got)
+		}
+	}
+
+	second := paginateAllRepoNames(t, svc, orderBy)
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("orderBy=%q order not stable across calls: pos %d %q vs %q",
+				orderBy, i, first[i], second[i])
+		}
+	}
+}
+
+// TestSDKArtifactRegistryOrderByTiesDeterministic guards the HIGH pagination bug:
+// createTime/updateTime are only second-granular, so repos created in the same
+// second tie on the sort key. Without a stable secondary key the map-backed list
+// resolved ties differently each call, so offset paging duplicated/skipped repos.
+// The name tiebreaker must make one-at-a-time paging return each repo exactly
+// once, in an order that is identical across repeated identical requests.
+func TestSDKArtifactRegistryOrderByTiesDeterministic(t *testing.T) {
+	svc := newARServiceFixedClock(t)
+	ctx := context.Background()
+
+	ids := []string{"repo-a", "repo-b", "repo-c", "repo-d", "repo-e"}
+	for _, id := range ids {
+		if _, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{Format: "DOCKER"}).
+			RepositoryId(id).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create %s: %v", id, err)
+		}
+	}
+
+	assertExactlyOnceAndStable(t, svc, "createTime", ids)
+	assertExactlyOnceAndStable(t, svc, "updateTime", ids)
+}

--- a/server/gcp/artifactregistry/types.go
+++ b/server/gcp/artifactregistry/types.go
@@ -64,16 +64,25 @@ func (f *repoFormat) UnmarshalJSON(b []byte) error {
 
 // repositoryJSON is the artifactregistry.googleapis.com v1 Repository shape.
 type repositoryJSON struct {
-	Name         string            `json:"name"`
-	Format       repoFormat        `json:"format,omitempty"`
-	Mode         string            `json:"mode,omitempty"`
-	Description  string            `json:"description,omitempty"`
-	Labels       map[string]string `json:"labels,omitempty"`
-	KmsKeyName   string            `json:"kmsKeyName,omitempty"`
-	SizeBytes    string            `json:"sizeBytes,omitempty"`
-	SatisfiesPzs bool              `json:"satisfiesPzs,omitempty"`
-	CreateTime   string            `json:"createTime,omitempty"`
-	UpdateTime   string            `json:"updateTime,omitempty"`
+	Name                string                     `json:"name"`
+	Format              repoFormat                 `json:"format,omitempty"`
+	Mode                string                     `json:"mode,omitempty"`
+	Description         string                     `json:"description,omitempty"`
+	Labels              map[string]string          `json:"labels,omitempty"`
+	KmsKeyName          string                     `json:"kmsKeyName,omitempty"`
+	DockerConfig        *dockerConfigJSON          `json:"dockerConfig,omitempty"`
+	CleanupPolicies     map[string]json.RawMessage `json:"cleanupPolicies,omitempty"`
+	CleanupPolicyDryRun bool                       `json:"cleanupPolicyDryRun,omitempty"`
+	SizeBytes           string                     `json:"sizeBytes,omitempty"`
+	SatisfiesPzs        bool                       `json:"satisfiesPzs,omitempty"`
+	CreateTime          string                     `json:"createTime,omitempty"`
+	UpdateTime          string                     `json:"updateTime,omitempty"`
+}
+
+// dockerConfigJSON is the v1 DockerRepositoryConfig shape. immutableTags marks a
+// Docker repository whose tags cannot be reassigned.
+type dockerConfigJSON struct {
+	ImmutableTags bool `json:"immutableTags,omitempty"`
 }
 
 // dockerImageJSON is the v1 DockerImage shape. imageSizeBytes is an int64
@@ -164,7 +173,11 @@ const (
 	descriptionTag    = "cloudemu:gcpArDescription"
 	modeTag           = "cloudemu:gcpArMode"
 	kmsKeyTag         = "cloudemu:gcpArKmsKeyName"
+	immutableTagsTag  = "cloudemu:gcpArImmutableTags"
+	cleanupPolicyTag  = "cloudemu:gcpArCleanupPolicies"
+	cleanupDryRunTag  = "cloudemu:gcpArCleanupPolicyDryRun"
 	reservedTagPrefix = "cloudemu:"
+	trueTag           = "true"
 	packagesSeg       = "packages"
 	versionsSeg       = "versions"
 	tagsSeg           = "tags"
@@ -221,7 +234,29 @@ func toRepositoryJSON(project, location string, r *crdriver.Repository, sizeByte
 		out.SizeBytes = strconv.FormatInt(sizeBytes, 10)
 	}
 
+	out.DockerConfig, out.CleanupPolicies, out.CleanupPolicyDryRun = repoExtrasFromTags(r.Tags)
+
 	return out
+}
+
+// repoExtrasFromTags reconstructs the GCP-only Repository fields (dockerConfig,
+// cleanupPolicies, cleanupPolicyDryRun) that the driver stores as reserved tags
+// so they round-trip on get/list without Terraform drift.
+func repoExtrasFromTags(
+	tags map[string]string,
+) (docker *dockerConfigJSON, policies map[string]json.RawMessage, dryRun bool) {
+	if tags[immutableTagsTag] == trueTag {
+		docker = &dockerConfigJSON{ImmutableTags: true}
+	}
+
+	if raw := tags[cleanupPolicyTag]; raw != "" {
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(raw), &m); err == nil {
+			policies = m
+		}
+	}
+
+	return docker, policies, tags[cleanupDryRunTag] == trueTag
 }
 
 // stripReservedTags returns user labels without cloudemu-internal keys.


### PR DESCRIPTION
## Summary

Fixes four Artifact Registry (`artifactregistry.googleapis.com` v1) round-trip / list gaps that cause perpetual Terraform drift on `google_artifact_registry_repository`. No logic bugs existed — these were wire-layer fields being dropped or query params being ignored.

## Changes

- **dockerConfig.immutableTags** — was dropped on create → `get` returned `dockerConfig=nil`. Now folded into a reserved tag and re-emitted, so it round-trips on create + get + patch (`updateMask=dockerConfig`).
- **cleanupPolicies + cleanupPolicyDryRun** — both were dropped on create. `cleanupPolicies` now round-trips as opaque JSON in a reserved tag; `cleanupPolicyDryRun` as a bool reserved tag. Honored by the existing updateMask PATCH path.
- **list filter** — `repositories.list?filter=` was ignored. Now honors `name=` (exact, or prefix when the value ends with `*`); unsupported/malformed expressions return the full set unfiltered (lenient, no error) to match API behavior.
- **list orderBy** — `repositories.list?orderBy=` was ignored (always name asc). Now honors `name`, `createTime`, `updateTime`, each with an optional ` desc`.

Implementation follows the package's existing reserved-tag pattern (already used for format/description/mode/kmsKeyName), so create/get/patch stay in lockstep and the driver interface is untouched.

## Tests

Added real `google.golang.org/api/artifactregistry/v1` SDK e2e tests against a booted `gcpserver.New`:
- immutableTags round-trip (create+get+patch)
- cleanupPolicies + cleanupPolicyDryRun round-trip (create+get+patch)
- list filter `name=` narrows results
- list `orderBy=name desc` reorders
- regression: format/mode round-trip + updateMask PATCH + label preservation

## Gates

`go build ./...`, `go vet`, scoped + `-race` tests, `gofmt -l`, golangci-lint (0 issues), `go generate` (zero diff), `compatgen` + `docs/compat` (zero diff) — all green.
