### PR TITLE
fix(gcp-memorystore): redisConfigs round-trip, updateMask-honoring PATCH, clearable labels, readReplicasMode-gated readEndpoint, list pagination

### DIFF
--- a/server/gcp/memorystore/configs_sdk_test.go
+++ b/server/gcp/memorystore/configs_sdk_test.go
@@ -104,6 +104,79 @@ func TestSDKMemorystorePatchLabelsClearable(t *testing.T) {
 	}
 }
 
+// TestSDKMemorystorePatchNoMaskPreservesMapFields guards the regression where a
+// PATCH omitting updateMask entirely silently wiped labels/redisConfigs: with no
+// mask the map fields must MERGE FORWARD (unspecified entries survive).
+func TestSDKMemorystorePatchNoMaskPreservesMapFields(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+		Tier:         "BASIC",
+		MemorySizeGb: 1,
+		Labels:       map[string]string{"env": "prod"},
+		RedisConfigs: map[string]string{"maxmemory-policy": "allkeys-lru"},
+	}).InstanceId("nomask").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// PATCH with NO updateMask, changing only displayName. The body carries no
+	// labels/redisConfigs, so they must be preserved (not whole-replaced away).
+	if _, err := svc.Projects.Locations.Instances.Patch(instanceName("nomask"), &redis.Instance{
+		DisplayName: "renamed",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch (no updateMask): %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Instances.Get(instanceName("nomask")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.DisplayName != "renamed" {
+		t.Errorf("displayName = %q, want renamed", got.DisplayName)
+	}
+
+	if got.Labels["env"] != "prod" {
+		t.Errorf("labels = %v, want env=prod preserved after no-mask patch", got.Labels)
+	}
+
+	if got.RedisConfigs["maxmemory-policy"] != "allkeys-lru" {
+		t.Errorf("redisConfigs = %v, want maxmemory-policy preserved after no-mask patch", got.RedisConfigs)
+	}
+}
+
+// TestSDKMemorystorePatchReplicaCountZero guards that replicaCount=0 under an
+// explicit updateMask=replicaCount is applied (0 is a valid "no replicas"
+// setting), not swallowed as if unset.
+func TestSDKMemorystorePatchReplicaCountZero(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+		Tier:         "STANDARD_HA",
+		MemorySizeGb: 5,
+		ReplicaCount: 2,
+	}).InstanceId("rc").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Instances.Patch(instanceName("rc"), &redis.Instance{
+		ReplicaCount: 0,
+	}).UpdateMask("replicaCount").Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Instances.Get(instanceName("rc")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.ReplicaCount != 0 {
+		t.Errorf("replicaCount = %d, want 0 applied under explicit updateMask", got.ReplicaCount)
+	}
+}
+
 // TestSDKMemorystoreSecurityFieldsRoundTrip (B4) guards that authEnabled,
 // transitEncryptionMode and replicaCount round-trip on create and get.
 func TestSDKMemorystoreSecurityFieldsRoundTrip(t *testing.T) {

--- a/server/gcp/memorystore/configs_sdk_test.go
+++ b/server/gcp/memorystore/configs_sdk_test.go
@@ -1,0 +1,247 @@
+package memorystore_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	redis "google.golang.org/api/redis/v1"
+)
+
+// TestSDKMemorystoreRedisConfigsRoundTrip (B1) guards that redis_configs (e.g.
+// maxmemory-policy) round-trips on create and get.
+func TestSDKMemorystoreRedisConfigsRoundTrip(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+		Tier:         "BASIC",
+		MemorySizeGb: 1,
+		RedisConfigs: map[string]string{"maxmemory-policy": "allkeys-lru"},
+	}).InstanceId("cfg").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Instances.Get(instanceName("cfg")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.RedisConfigs["maxmemory-policy"] != "allkeys-lru" {
+		t.Fatalf("redisConfigs did not round-trip: %v", got.RedisConfigs)
+	}
+}
+
+// TestSDKMemorystorePatchMaskHonored (B2) guards that PATCH applies only the
+// fields named in updateMask: a body memorySizeGb outside the mask must not
+// resize the instance.
+func TestSDKMemorystorePatchMaskHonored(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+		Tier:         "BASIC",
+		MemorySizeGb: 3,
+		DisplayName:  "before",
+	}).InstanceId("masked").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// updateMask names only displayName, yet the body also sets memorySizeGb=9.
+	if _, err := svc.Projects.Locations.Instances.Patch(instanceName("masked"), &redis.Instance{
+		DisplayName:  "after",
+		MemorySizeGb: 9,
+	}).UpdateMask("displayName").Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Instances.Get(instanceName("masked")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.DisplayName != "after" {
+		t.Errorf("displayName = %q, want it updated to %q", got.DisplayName, "after")
+	}
+
+	if got.MemorySizeGb != 3 {
+		t.Errorf("memorySizeGb = %d, want it UNCHANGED at 3 (outside updateMask)", got.MemorySizeGb)
+	}
+}
+
+// TestSDKMemorystorePatchLabelsClearable (B3) guards that updateMask=labels
+// whole-replaces the label set, so a removed label disappears (not merge-only).
+func TestSDKMemorystorePatchLabelsClearable(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+		Tier:         "BASIC",
+		MemorySizeGb: 1,
+		Labels:       map[string]string{"env": "prod", "team": "core"},
+	}).InstanceId("lbl").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Replace the label set with just env=prod; team must be dropped.
+	if _, err := svc.Projects.Locations.Instances.Patch(instanceName("lbl"), &redis.Instance{
+		Labels: map[string]string{"env": "prod"},
+	}).UpdateMask("labels").Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Instances.Get(instanceName("lbl")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if _, ok := got.Labels["team"]; ok {
+		t.Errorf("label team still present after whole-replace patch: %v", got.Labels)
+	}
+
+	if got.Labels["env"] != "prod" {
+		t.Errorf("label env = %q, want prod", got.Labels["env"])
+	}
+}
+
+// TestSDKMemorystoreSecurityFieldsRoundTrip (B4) guards that authEnabled,
+// transitEncryptionMode and replicaCount round-trip on create and get.
+func TestSDKMemorystoreSecurityFieldsRoundTrip(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+		Tier:                  "STANDARD_HA",
+		MemorySizeGb:          5,
+		AuthEnabled:           true,
+		TransitEncryptionMode: "SERVER_AUTHENTICATION",
+		ReplicaCount:          2,
+	}).InstanceId("sec").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Instances.Get(instanceName("sec")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if !got.AuthEnabled {
+		t.Errorf("authEnabled = false, want true")
+	}
+
+	if got.TransitEncryptionMode != "SERVER_AUTHENTICATION" {
+		t.Errorf("transitEncryptionMode = %q, want SERVER_AUTHENTICATION", got.TransitEncryptionMode)
+	}
+
+	if got.ReplicaCount != 2 {
+		t.Errorf("replicaCount = %d, want 2", got.ReplicaCount)
+	}
+}
+
+// TestSDKMemorystoreReadEndpointGating (B5) guards that the read endpoint is
+// gated on readReplicasMode, not tier: a STANDARD_HA instance with replicas
+// disabled has no read endpoint, while one with replicas enabled does.
+func TestSDKMemorystoreReadEndpointGating(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+		Tier:             "STANDARD_HA",
+		MemorySizeGb:     5,
+		ReadReplicasMode: "READ_REPLICAS_DISABLED",
+	}).InstanceId("no-rr").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create no-rr: %v", err)
+	}
+
+	noRR, err := svc.Projects.Locations.Instances.Get(instanceName("no-rr")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get no-rr: %v", err)
+	}
+
+	if noRR.ReadEndpoint != "" {
+		t.Errorf("readEndpoint = %q, want empty when read replicas disabled", noRR.ReadEndpoint)
+	}
+
+	if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+		Tier:             "STANDARD_HA",
+		MemorySizeGb:     5,
+		ReadReplicasMode: "READ_REPLICAS_ENABLED",
+	}).InstanceId("rr").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create rr: %v", err)
+	}
+
+	rr, err := svc.Projects.Locations.Instances.Get(instanceName("rr")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get rr: %v", err)
+	}
+
+	if rr.ReadEndpoint == "" || rr.ReadEndpointPort == 0 {
+		t.Errorf("read endpoint missing with replicas enabled: endpoint=%q port=%d",
+			rr.ReadEndpoint, rr.ReadEndpointPort)
+	}
+}
+
+// TestSDKMemorystoreListPagination (B6) guards that List honors pageSize and
+// pageToken: paging through with a small page size visits every instance exactly
+// once and terminates with an empty nextPageToken.
+func TestSDKMemorystoreListPagination(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	const total = 7
+
+	for i := range total {
+		id := fmt.Sprintf("inst-%02d", i)
+		if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+			Tier:         "BASIC",
+			MemorySizeGb: 1,
+		}).InstanceId(id).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create %s: %v", id, err)
+		}
+	}
+
+	seen := make(map[string]int)
+	pages := 0
+	token := ""
+
+	for {
+		call := svc.Projects.Locations.Instances.List(parent()).PageSize(3).Context(ctx)
+		if token != "" {
+			call = call.PageToken(token)
+		}
+
+		resp, err := call.Do()
+		if err != nil {
+			t.Fatalf("List page %d: %v", pages, err)
+		}
+
+		for _, inst := range resp.Instances {
+			seen[inst.Name]++
+		}
+
+		pages++
+		token = resp.NextPageToken
+
+		if token == "" {
+			break
+		}
+
+		if pages > total+1 {
+			t.Fatalf("pagination did not terminate after %d pages", pages)
+		}
+	}
+
+	if len(seen) != total {
+		t.Fatalf("saw %d distinct instances, want %d", len(seen), total)
+	}
+
+	for name, count := range seen {
+		if count != 1 {
+			t.Errorf("instance %s returned %d times, want exactly once", name, count)
+		}
+	}
+
+	if pages < 2 {
+		t.Errorf("expected multiple pages for %d instances at pageSize 3, got %d", total, pages)
+	}
+}

--- a/server/gcp/memorystore/endpoint_fields_sdk_test.go
+++ b/server/gcp/memorystore/endpoint_fields_sdk_test.go
@@ -125,15 +125,16 @@ func TestSDKMemorystoreNetworkDefaults(t *testing.T) {
 	}
 }
 
-// TestSDKMemorystoreReadEndpointStandardHA guards that Standard-tier instances
-// expose a read endpoint distinct from the primary host.
+// TestSDKMemorystoreReadEndpointStandardHA guards that instances with read
+// replicas enabled expose a read endpoint distinct from the primary host.
 func TestSDKMemorystoreReadEndpointStandardHA(t *testing.T) {
 	svc := newRedisService(t)
 	ctx := context.Background()
 
 	if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
-		Tier:         "STANDARD_HA",
-		MemorySizeGb: 5,
+		Tier:             "STANDARD_HA",
+		MemorySizeGb:     5,
+		ReadReplicasMode: "READ_REPLICAS_ENABLED",
 	}).InstanceId("ha-cache").Context(ctx).Do(); err != nil {
 		t.Fatalf("Create: %v", err)
 	}

--- a/server/gcp/memorystore/operations.go
+++ b/server/gcp/memorystore/operations.go
@@ -3,7 +3,10 @@ package memorystore
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"strings"
 
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
 	"github.com/stackshy/cloudemu/v2/services/scope"
@@ -28,7 +31,7 @@ func (h *Handler) createInstance(w http.ResponseWriter, r *http.Request, rt rout
 		Name:     instanceID,
 		Engine:   "redis",
 		NodeType: body.Tier,
-		Tags:     instanceTags(&body, nil),
+		Tags:     instanceTags(&body, nil, nil),
 		Scope:    scope.Scope{Project: rt.project},
 	})
 	if err != nil {
@@ -61,7 +64,8 @@ func (h *Handler) getInstance(w http.ResponseWriter, r *http.Request, rt route) 
 }
 
 // listInstances handles GET .../instances — List, scoped to the request's
-// project.
+// project. It honors the pageSize/pageToken/filter query parameters and
+// advertises a nextPageToken when the result set is truncated.
 func (h *Handler) listInstances(w http.ResponseWriter, r *http.Request, rt route) {
 	infos, err := h.cache.ListCaches(r.Context(), scope.Scope{Project: rt.project})
 	if err != nil {
@@ -69,20 +73,116 @@ func (h *Handler) listInstances(w http.ResponseWriter, r *http.Request, rt route
 		return
 	}
 
+	q := r.URL.Query()
+	filter := q.Get("filter")
+
 	out := make([]instanceJSON, 0, len(infos))
 	for i := range infos {
 		// CacheInfo.Name carries the driver's own resource id; the short
 		// instance id (the map key) is recovered from its trailing segment.
 		id := shortInstanceID(infos[i].Name)
-		out = append(out, toInstanceJSON(rt.project, rt.location, id, &infos[i]))
+		inst := toInstanceJSON(rt.project, rt.location, id, &infos[i])
+
+		if matchesFilter(&inst, filter) {
+			out = append(out, inst)
+		}
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, listInstancesResponse{Instances: out})
+	page, perr := pagination.PaginateSorted(out,
+		func(a, b instanceJSON) bool { return a.Name < b.Name },
+		q.Get("pageToken"), atoiOr(q.Get("pageSize"), 0))
+	if perr != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid pageToken")
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listInstancesResponse{
+		Instances:     page.Items,
+		NextPageToken: page.NextPageToken,
+	})
+}
+
+// atoiOr parses s as a non-negative int, returning def when s is empty or
+// invalid.
+func atoiOr(s string, def int) int {
+	if s == "" {
+		return def
+	}
+
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 {
+		return def
+	}
+
+	return n
+}
+
+// matchesFilter applies a single AIP-160 equality term (e.g. "labels.env=prod")
+// to an instance. An empty or unsupported filter matches everything, so results
+// are never silently hidden by a filter cloudemu doesn't model.
+func matchesFilter(inst *instanceJSON, filter string) bool {
+	if strings.TrimSpace(filter) == "" {
+		return true
+	}
+
+	field, want, ok := parseEqualityFilter(filter)
+	if !ok {
+		return true
+	}
+
+	got, known := instanceFieldValue(inst, field)
+	if !known {
+		return true
+	}
+
+	return got == want
+}
+
+// parseEqualityFilter splits "field = value" into its trimmed, unquoted parts.
+func parseEqualityFilter(filter string) (field, value string, ok bool) {
+	i := strings.Index(filter, "=")
+	if i < 0 {
+		return "", "", false
+	}
+
+	field = strings.TrimSpace(filter[:i])
+	value = strings.Trim(strings.TrimSpace(filter[i+1:]), `"`)
+
+	if field == "" {
+		return "", "", false
+	}
+
+	return field, value, true
+}
+
+// instanceFieldValue resolves a filter field path against an instance, reporting
+// whether the field is one cloudemu can filter on.
+func instanceFieldValue(inst *instanceJSON, field string) (value string, known bool) {
+	switch field {
+	case "name":
+		return inst.Name, true
+	case "displayName":
+		return inst.DisplayName, true
+	case "tier":
+		return inst.Tier, true
+	case "state":
+		return inst.State, true
+	}
+
+	if k, ok := strings.CutPrefix(field, "labels."); ok {
+		return inst.Labels[k], true
+	}
+
+	if k, ok := strings.CutPrefix(field, "redisConfigs."); ok {
+		return inst.RedisConfigs[k], true
+	}
+
+	return "", false
 }
 
 // patchInstance handles PATCH .../instances/{i} — Update. Real clients change
-// memorySizeGb, displayName, tier, and labels here; without it those are stuck
-// at their create-time values.
+// memorySizeGb, displayName, labels, redisConfigs, and replicaCount here, scoped
+// by the updateMask: a field outside the mask is left untouched.
 func (h *Handler) patchInstance(w http.ResponseWriter, r *http.Request, rt route) {
 	existing, err := h.cache.GetCache(r.Context(), rt.name)
 	if err != nil {
@@ -95,8 +195,10 @@ func (h *Handler) patchInstance(w http.ResponseWriter, r *http.Request, rt route
 		return
 	}
 
+	mask := parseFieldMask(r.URL.Query().Get("updateMask"))
+
 	nodeType := existing.NodeType
-	if body.Tier != "" {
+	if mask.has("tier") && body.Tier != "" {
 		nodeType = body.Tier
 	}
 
@@ -104,7 +206,7 @@ func (h *Handler) patchInstance(w http.ResponseWriter, r *http.Request, rt route
 		Name:     rt.name,
 		Engine:   "redis",
 		NodeType: nodeType,
-		Tags:     instanceTags(&body, existing.Tags),
+		Tags:     instanceTags(&body, existing.Tags, mask),
 	})
 	if err != nil {
 		gcprest.WriteCErr(w, err)

--- a/server/gcp/memorystore/types.go
+++ b/server/gcp/memorystore/types.go
@@ -291,6 +291,8 @@ const (
 	transitEncryptionTag = "cloudemu:gcpTransitEncryptionMode"
 	replicaCountTag      = "cloudemu:gcpReplicaCount"
 	readReplicasModeTag  = "cloudemu:gcpReadReplicasMode"
+	// tagTrue is the stored value for a set boolean reserved tag.
+	tagTrue = "true"
 )
 
 // fieldMask is the set of instance fields a PATCH updateMask selects. A nil mask
@@ -320,6 +322,44 @@ func (m fieldMask) has(field string) bool {
 	return m == nil || m[field]
 }
 
+// explicit reports whether field is named in a non-nil mask. Unlike has, a nil
+// mask is NOT treated as selecting the field — used where a nil mask must
+// preserve the existing value (map whole-replace, clearing a scalar to its zero)
+// rather than overwrite it from an omitted body field.
+func (m fieldMask) explicit(field string) bool {
+	return m != nil && m[field]
+}
+
+// mapFieldMode selects how a map-valued field (labels, redisConfigs) folds into
+// the tag set.
+type mapFieldMode int
+
+const (
+	// mapModePreserve leaves the existing value untouched (non-nil mask that omits
+	// the field).
+	mapModePreserve mapFieldMode = iota
+	// mapModeMerge overlays the request value onto the existing one so unspecified
+	// entries survive (nil mask — no updateMask).
+	mapModeMerge
+	// mapModeReplace whole-replaces the field with the request value so a removed
+	// entry is cleared (field explicitly named in the mask).
+	mapModeReplace
+)
+
+// mapMode resolves the fold mode for a map-valued field. A nil mask merges
+// forward (preserving existing entries); an explicit mask whole-replaces; a
+// non-nil mask that omits the field preserves it untouched.
+func (m fieldMask) mapMode(field string) mapFieldMode {
+	switch {
+	case m == nil:
+		return mapModeMerge
+	case m[field]:
+		return mapModeReplace
+	default:
+		return mapModePreserve
+	}
+}
+
 // stringTagField pairs an updateMask field path with the reserved tag key and
 // request value that back it, so simple string fields fold in via one loop.
 type stringTagField struct {
@@ -328,10 +368,12 @@ type stringTagField struct {
 	value string
 }
 
-// instanceTags folds the GCP-specific request fields into the tag map. Only
-// masked fields are applied, so a PATCH leaves fields outside its updateMask
-// untouched; labels and redisConfigs are whole-replaced when masked so a removed
-// entry disappears rather than lingering.
+// instanceTags folds the GCP-specific request fields into the tag map. A non-nil
+// mask (PATCH updateMask) applies only its named fields, leaving the rest
+// untouched, and whole-replaces the map fields it names so a removed entry
+// disappears. A nil mask (Create, or a PATCH without updateMask) applies every
+// provided field and MERGES the map fields forward, so unspecified labels /
+// redisConfigs survive.
 func instanceTags(body *instanceJSON, existing map[string]string, mask fieldMask) map[string]string {
 	out := carryForwardTags(existing, mask)
 
@@ -343,11 +385,12 @@ func instanceTags(body *instanceJSON, existing map[string]string, mask fieldMask
 	return out
 }
 
-// carryForwardTags copies existing tags forward, dropping user labels when the
-// mask replaces the whole label set (reserved keys always carry forward).
+// carryForwardTags copies existing tags forward, dropping user labels only for an
+// explicit labels whole-replace; a nil mask merges forward, so existing labels
+// must survive. Reserved keys always carry forward.
 func carryForwardTags(existing map[string]string, mask fieldMask) map[string]string {
 	out := make(map[string]string, len(existing)+1)
-	dropLabels := mask.has("labels")
+	dropLabels := mask.mapMode("labels") == mapModeReplace
 
 	for k, v := range existing {
 		if dropLabels && !strings.HasPrefix(k, reservedPrefix) {
@@ -360,9 +403,11 @@ func carryForwardTags(existing map[string]string, mask fieldMask) map[string]str
 	return out
 }
 
-// applyLabels writes the request's labels as the whole label set when masked.
+// applyLabels overlays the request's labels. Merge and replace both overlay;
+// replace additionally dropped the existing labels in carryForwardTags. Preserve
+// applies nothing, leaving the carried-forward labels untouched.
 func applyLabels(out map[string]string, body *instanceJSON, mask fieldMask) {
-	if !mask.has("labels") {
+	if mask.mapMode("labels") == mapModePreserve {
 		return
 	}
 
@@ -399,19 +444,45 @@ func applyScalarTags(out map[string]string, body *instanceJSON, mask fieldMask) 
 		out[memorySizeTag] = strconv.FormatInt(body.MemorySizeGb, 10)
 	}
 
-	if mask.has("replicaCount") && body.ReplicaCount > 0 {
+	applyReplicaCount(out, body, mask)
+	applyAuthEnabled(out, body, mask)
+}
+
+// applyReplicaCount folds replicaCount in. An explicit mask applies the value
+// including 0 (a valid "no replicas" setting, so it can be cleared); a nil mask
+// can't distinguish an omitted 0 from an intentional one, so it applies only a
+// positive value and otherwise preserves the existing count.
+func applyReplicaCount(out map[string]string, body *instanceJSON, mask fieldMask) {
+	if mask.explicit("replicaCount") {
 		out[replicaCountTag] = strconv.FormatInt(body.ReplicaCount, 10)
+
+		return
 	}
 
-	if mask.has("authEnabled") {
+	if mask == nil && body.ReplicaCount > 0 {
+		out[replicaCountTag] = strconv.FormatInt(body.ReplicaCount, 10)
+	}
+}
+
+// applyAuthEnabled folds authEnabled in. An explicit mask sets or clears it; a
+// nil mask can't distinguish an omitted false from an intentional one, so it sets
+// only a true value and otherwise preserves the existing flag.
+func applyAuthEnabled(out map[string]string, body *instanceJSON, mask fieldMask) {
+	if mask.explicit("authEnabled") {
 		setBoolTag(out, authEnabledTag, body.AuthEnabled)
+
+		return
+	}
+
+	if mask == nil && body.AuthEnabled {
+		out[authEnabledTag] = tagTrue
 	}
 }
 
 // setBoolTag records a true boolean and clears the tag when false.
 func setBoolTag(out map[string]string, key string, val bool) {
 	if val {
-		out[key] = "true"
+		out[key] = tagTrue
 
 		return
 	}
@@ -419,22 +490,51 @@ func setBoolTag(out map[string]string, key string, val bool) {
 	delete(out, key)
 }
 
-// applyRedisConfigs whole-replaces the JSON-encoded redisConfigs map when masked
-// (an empty map clears it), matching real Memorystore's replace semantics.
+// applyRedisConfigs folds the JSON-encoded redisConfigs map in per its mask mode:
+// preserve leaves the stored value untouched, replace whole-replaces it (an empty
+// map clears it), and merge overlays the request onto the existing configs so
+// unspecified entries survive a no-updateMask PATCH.
 func applyRedisConfigs(out map[string]string, body *instanceJSON, mask fieldMask) {
-	if !mask.has("redisConfigs") {
+	switch mask.mapMode("redisConfigs") {
+	case mapModePreserve:
 		return
+	case mapModeReplace:
+		setRedisConfigs(out, body.RedisConfigs)
+	case mapModeMerge:
+		mergeRedisConfigs(out, body.RedisConfigs)
 	}
+}
 
+// setRedisConfigs whole-replaces the redisConfigs tag; an empty map clears it.
+func setRedisConfigs(out, cfg map[string]string) {
 	delete(out, redisConfigsTag)
 
-	if len(body.RedisConfigs) == 0 {
+	if len(cfg) == 0 {
 		return
 	}
 
-	if raw, err := json.Marshal(body.RedisConfigs); err == nil {
+	if raw, err := json.Marshal(cfg); err == nil {
 		out[redisConfigsTag] = string(raw)
 	}
+}
+
+// mergeRedisConfigs overlays the request configs onto the existing ones, leaving
+// the stored value untouched when the request supplies none.
+func mergeRedisConfigs(out, cfg map[string]string) {
+	if len(cfg) == 0 {
+		return
+	}
+
+	merged := redisConfigsFromTags(out)
+	if merged == nil {
+		merged = make(map[string]string, len(cfg))
+	}
+
+	for k, v := range cfg {
+		merged[k] = v
+	}
+
+	setRedisConfigs(out, merged)
 }
 
 // stripReservedTags returns user labels without cloudemu-internal keys.

--- a/server/gcp/memorystore/types.go
+++ b/server/gcp/memorystore/types.go
@@ -12,10 +12,16 @@ const (
 	defaultRedisPort    = 6379
 	defaultRedisVersion = "REDIS_6_X"
 	defaultTier         = "BASIC"
-	tierStandardHA      = "STANDARD_HA"
 	defaultConnectMode  = "DIRECT_PEERING"
 	defaultNetwork      = "default"
 	defaultZoneSuffix   = "-a"
+	defaultMemorySizeGb = 1
+	// readReplicasEnabled is the readReplicasMode that makes Memorystore expose a
+	// read endpoint (independent of tier).
+	readReplicasEnabled = "READ_REPLICAS_ENABLED"
+	// reservedPrefix marks tag keys that carry cloudemu-internal fields, not user
+	// labels.
+	reservedPrefix = "cloudemu:"
 	// stateReady is Memorystore's terminal instance state; the mock provisions
 	// synchronously so every instance reports READY.
 	stateReady = "READY"
@@ -44,11 +50,17 @@ type instanceJSON struct {
 	ReadEndpoint      string            `json:"readEndpoint,omitempty"`
 	ReadEndpointPort  int64             `json:"readEndpointPort,omitempty"`
 	PersistenceIAMID  string            `json:"persistenceIamIdentity,omitempty"`
+	RedisConfigs      map[string]string `json:"redisConfigs,omitempty"`
+	AuthEnabled       bool              `json:"authEnabled,omitempty"`
+	TransitEncryption string            `json:"transitEncryptionMode,omitempty"`
+	ReplicaCount      int64             `json:"replicaCount,omitempty"`
+	ReadReplicasMode  string            `json:"readReplicasMode,omitempty"`
 }
 
 // listInstancesResponse mirrors redis/v1 ListInstancesResponse.
 type listInstancesResponse struct {
-	Instances []instanceJSON `json:"instances"`
+	Instances     []instanceJSON `json:"instances"`
+	NextPageToken string         `json:"nextPageToken,omitempty"`
 }
 
 // operationJSON mirrors google.longrunning.Operation. Mutating ops complete
@@ -114,24 +126,14 @@ func toInstanceJSON(project, location, instanceID string, info *cachedriver.Cach
 		tier = info.NodeType
 	}
 
-	memSize := int64(1)
-	if v, err := strconv.ParseInt(info.Tags[memorySizeTag], 10, 64); err == nil && v > 0 {
-		memSize = v
-	}
-
-	redisVersion := defaultRedisVersion
-	if v := info.Tags[redisVersionTag]; v != "" {
-		redisVersion = v
-	}
-
 	zone := zoneForLocation(location, info.Tags[locationIDTag])
 
 	inst := instanceJSON{
 		Name:              instanceResourceName(project, location, instanceID),
 		DisplayName:       info.Tags[displayNameTag],
 		Tier:              tier,
-		MemorySizeGb:      memSize,
-		RedisVersion:      redisVersion,
+		MemorySizeGb:      memorySizeFromTags(info.Tags),
+		RedisVersion:      redisVersionFromTags(info.Tags),
 		State:             stateOrReady(info.Status),
 		Host:              host,
 		Port:              port,
@@ -143,16 +145,75 @@ func toInstanceJSON(project, location, instanceID string, info *cachedriver.Cach
 		AuthorizedNetwork: authorizedNetworkOrDefault(project, info.Tags[authorizedNetworkTag]),
 		ConnectMode:       connectModeOrDefault(info.Tags[connectModeTag]),
 		PersistenceIAMID:  persistenceIAMIdentity(project),
+		RedisConfigs:      redisConfigsFromTags(info.Tags),
+		AuthEnabled:       boolFromTag(info.Tags[authEnabledTag]),
+		TransitEncryption: info.Tags[transitEncryptionTag],
+		ReplicaCount:      intFromTag(info.Tags[replicaCountTag]),
+		ReadReplicasMode:  info.Tags[readReplicasModeTag],
 	}
 
-	// The read endpoint is a Standard-tier-only replica endpoint; BASIC
-	// standalone instances leave it unset (matching real Memorystore).
-	if strings.EqualFold(tier, tierStandardHA) {
+	// The read endpoint is provided only when read replicas are enabled (matching
+	// real Memorystore); tier alone does not expose it.
+	if strings.EqualFold(inst.ReadReplicasMode, readReplicasEnabled) {
 		inst.ReadEndpoint = readReplicaHost(host)
 		inst.ReadEndpointPort = port
 	}
 
 	return inst
+}
+
+// memorySizeFromTags reads the round-tripped memorySizeGb, defaulting to the
+// stub the API surface requires when unset.
+func memorySizeFromTags(tags map[string]string) int64 {
+	if v, err := strconv.ParseInt(tags[memorySizeTag], 10, 64); err == nil && v > 0 {
+		return v
+	}
+
+	return defaultMemorySizeGb
+}
+
+// redisVersionFromTags reads the round-tripped redisVersion, defaulting to the
+// stub version when unset.
+func redisVersionFromTags(tags map[string]string) string {
+	if v := tags[redisVersionTag]; v != "" {
+		return v
+	}
+
+	return defaultRedisVersion
+}
+
+// redisConfigsFromTags decodes the JSON-encoded redisConfigs map round-tripped
+// through the reserved tag; a missing or malformed value yields no configs.
+func redisConfigsFromTags(tags map[string]string) map[string]string {
+	raw := tags[redisConfigsTag]
+	if raw == "" {
+		return nil
+	}
+
+	var cfg map[string]string
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		return nil
+	}
+
+	return cfg
+}
+
+// boolFromTag parses a boolean reserved tag, treating any unparseable value as
+// false.
+func boolFromTag(v string) bool {
+	b, _ := strconv.ParseBool(v)
+	return b
+}
+
+// intFromTag parses an integer reserved tag, treating any unparseable value as
+// zero.
+func intFromTag(v string) int64 {
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	return n
 }
 
 // zoneForLocation resolves the instance's zone. Real Memorystore reports a zone
@@ -225,50 +286,155 @@ const (
 	authorizedNetworkTag = "cloudemu:gcpAuthorizedNetwork"
 	connectModeTag       = "cloudemu:gcpConnectMode"
 	locationIDTag        = "cloudemu:gcpLocationId"
+	redisConfigsTag      = "cloudemu:gcpRedisConfigs"
+	authEnabledTag       = "cloudemu:gcpAuthEnabled"
+	transitEncryptionTag = "cloudemu:gcpTransitEncryptionMode"
+	replicaCountTag      = "cloudemu:gcpReplicaCount"
+	readReplicasModeTag  = "cloudemu:gcpReadReplicasMode"
 )
 
-// instanceTags folds the GCP-specific request fields into the tag map, layered
-// over existing tags so a partial PATCH keeps unspecified values.
-func instanceTags(body *instanceJSON, existing map[string]string) map[string]string {
-	out := make(map[string]string, len(existing)+len(body.Labels))
+// fieldMask is the set of instance fields a PATCH updateMask selects. A nil mask
+// (Create, or a PATCH with no updateMask) applies every field the body provides.
+type fieldMask map[string]bool
+
+// parseFieldMask parses an updateMask query value into a set of field paths. An
+// empty value yields a nil mask, meaning "apply all provided fields".
+func parseFieldMask(raw string) fieldMask {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+
+	m := make(fieldMask)
+
+	for _, f := range strings.Split(raw, ",") {
+		if f = strings.TrimSpace(f); f != "" {
+			m[f] = true
+		}
+	}
+
+	return m
+}
+
+// has reports whether field is selected. A nil mask selects every field.
+func (m fieldMask) has(field string) bool {
+	return m == nil || m[field]
+}
+
+// stringTagField pairs an updateMask field path with the reserved tag key and
+// request value that back it, so simple string fields fold in via one loop.
+type stringTagField struct {
+	field string
+	tag   string
+	value string
+}
+
+// instanceTags folds the GCP-specific request fields into the tag map. Only
+// masked fields are applied, so a PATCH leaves fields outside its updateMask
+// untouched; labels and redisConfigs are whole-replaced when masked so a removed
+// entry disappears rather than lingering.
+func instanceTags(body *instanceJSON, existing map[string]string, mask fieldMask) map[string]string {
+	out := carryForwardTags(existing, mask)
+
+	applyLabels(out, body, mask)
+	applyStringTags(out, body, mask)
+	applyScalarTags(out, body, mask)
+	applyRedisConfigs(out, body, mask)
+
+	return out
+}
+
+// carryForwardTags copies existing tags forward, dropping user labels when the
+// mask replaces the whole label set (reserved keys always carry forward).
+func carryForwardTags(existing map[string]string, mask fieldMask) map[string]string {
+	out := make(map[string]string, len(existing)+1)
+	dropLabels := mask.has("labels")
 
 	for k, v := range existing {
+		if dropLabels && !strings.HasPrefix(k, reservedPrefix) {
+			continue
+		}
+
 		out[k] = v
+	}
+
+	return out
+}
+
+// applyLabels writes the request's labels as the whole label set when masked.
+func applyLabels(out map[string]string, body *instanceJSON, mask fieldMask) {
+	if !mask.has("labels") {
+		return
 	}
 
 	for k, v := range body.Labels {
 		out[k] = v
 	}
+}
 
-	if body.MemorySizeGb > 0 {
+// applyStringTags folds the simple string fields in, honoring the mask.
+func applyStringTags(out map[string]string, body *instanceJSON, mask fieldMask) {
+	for _, f := range stringTagFields(body) {
+		if mask.has(f.field) && f.value != "" {
+			out[f.tag] = f.value
+		}
+	}
+}
+
+func stringTagFields(body *instanceJSON) []stringTagField {
+	return []stringTagField{
+		{"redisVersion", redisVersionTag, body.RedisVersion},
+		{"displayName", displayNameTag, body.DisplayName},
+		{"reservedIpRange", reservedIPTag, body.ReservedIPRng},
+		{"authorizedNetwork", authorizedNetworkTag, body.AuthorizedNetwork},
+		{"connectMode", connectModeTag, body.ConnectMode},
+		{"locationId", locationIDTag, body.LocationID},
+		{"transitEncryptionMode", transitEncryptionTag, body.TransitEncryption},
+		{"readReplicasMode", readReplicasModeTag, body.ReadReplicasMode},
+	}
+}
+
+// applyScalarTags folds the numeric and boolean fields in, honoring the mask.
+func applyScalarTags(out map[string]string, body *instanceJSON, mask fieldMask) {
+	if mask.has("memorySizeGb") && body.MemorySizeGb > 0 {
 		out[memorySizeTag] = strconv.FormatInt(body.MemorySizeGb, 10)
 	}
 
-	if body.RedisVersion != "" {
-		out[redisVersionTag] = body.RedisVersion
+	if mask.has("replicaCount") && body.ReplicaCount > 0 {
+		out[replicaCountTag] = strconv.FormatInt(body.ReplicaCount, 10)
 	}
 
-	if body.DisplayName != "" {
-		out[displayNameTag] = body.DisplayName
+	if mask.has("authEnabled") {
+		setBoolTag(out, authEnabledTag, body.AuthEnabled)
+	}
+}
+
+// setBoolTag records a true boolean and clears the tag when false.
+func setBoolTag(out map[string]string, key string, val bool) {
+	if val {
+		out[key] = "true"
+
+		return
 	}
 
-	if body.ReservedIPRng != "" {
-		out[reservedIPTag] = body.ReservedIPRng
+	delete(out, key)
+}
+
+// applyRedisConfigs whole-replaces the JSON-encoded redisConfigs map when masked
+// (an empty map clears it), matching real Memorystore's replace semantics.
+func applyRedisConfigs(out map[string]string, body *instanceJSON, mask fieldMask) {
+	if !mask.has("redisConfigs") {
+		return
 	}
 
-	if body.AuthorizedNetwork != "" {
-		out[authorizedNetworkTag] = body.AuthorizedNetwork
+	delete(out, redisConfigsTag)
+
+	if len(body.RedisConfigs) == 0 {
+		return
 	}
 
-	if body.ConnectMode != "" {
-		out[connectModeTag] = body.ConnectMode
+	if raw, err := json.Marshal(body.RedisConfigs); err == nil {
+		out[redisConfigsTag] = string(raw)
 	}
-
-	if body.LocationID != "" {
-		out[locationIDTag] = body.LocationID
-	}
-
-	return out
 }
 
 // stripReservedTags returns user labels without cloudemu-internal keys.
@@ -280,7 +446,7 @@ func stripReservedTags(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
 
 	for k, v := range in {
-		if strings.HasPrefix(k, "cloudemu:") {
+		if strings.HasPrefix(k, reservedPrefix) {
 			continue
 		}
 


### PR DESCRIPTION
## Summary

Fixes several TF-drift and semantic bugs in the GCP Memorystore for Redis (redis.googleapis.com v1) server layer, verified end-to-end with the real `google.golang.org/api/redis/v1` SDK against a booted server.

All GCP-specific fields round-trip through the existing reserved-tag pattern (JSON-encoded for maps); the provider `ListCaches` already returns a stable sort, so no provider change was needed.

## Changes

- **redisConfigs round-trip** — `redisConfigs` (e.g. `{maxmemory-policy: allkeys-lru}`) now round-trips on create, get, and patch via a JSON-encoded reserved tag.
- **PATCH honors updateMask** — the update mask is parsed and only masked fields are applied; a body field outside the mask (e.g. `memorySizeGb` under `updateMask=displayName`) is left untouched. Absent updateMask keeps the prior apply-all behavior.
- **Labels/redisConfigs are whole-replaced when masked** — a removed label (or config) disappears instead of merge-lingering.
- **New modeled fields** — `authEnabled`, `transitEncryptionMode`, `replicaCount`, `readReplicasMode` round-trip on create/get/patch.
- **readEndpoint gating fixed** — `readEndpoint`/`readEndpointPort` are now emitted only when `readReplicasMode == READ_REPLICAS_ENABLED` (matching real Memorystore), not on `tier == STANDARD_HA`.
- **List pagination + filter** — `listInstances` now honors `pageSize`/`pageToken` (stable-sorted, emits `nextPageToken` when truncated) and a single AIP-160 equality `filter` term.

Custom verbs (`:upgrade`/`:failover`/`:getAuthString`/`:import`/`:export`) and a CREATING→READY transition are intentionally out of scope.

## Tests

Added real-SDK e2e tests: redisConfigs round-trip; updateMask honored (size unchanged outside mask); labels clearable via whole-replace; auth/transit/replica round-trip; readEndpoint gated on readReplicasMode; list pagination visits every instance once and terminates. Updated the existing read-endpoint test to the new gating.
