### PR TITLE
fix(azure-eventgrid): round-trip topic/domain publicNetworkAccess & domain inputSchema; add Topics PATCH + RegenerateKey

### DIFF
--- a/providers/azure/eventgrid/eventgrid.go
+++ b/providers/azure/eventgrid/eventgrid.go
@@ -29,6 +29,9 @@ const (
 	// defaultInputSchema is the event schema a topic accepts when the caller
 	// doesn't specify one, matching real Event Grid's default.
 	defaultInputSchema = "EventGridSchema"
+	// defaultPublicNetworkAccess is the public-network-access setting a topic
+	// gets when the caller doesn't specify one, matching real Event Grid.
+	defaultPublicNetworkAccess = "Enabled"
 )
 
 // Compile-time check that Mock implements driver.EventBus.
@@ -128,15 +131,21 @@ func (m *Mock) CreateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 		inputSchema = defaultInputSchema
 	}
 
+	publicNetworkAccess := cfg.PublicNetworkAccess
+	if publicNetworkAccess == "" {
+		publicNetworkAccess = defaultPublicNetworkAccess
+	}
+
 	info := driver.EventBusInfo{
-		Name:        cfg.Name,
-		Scope:       cfg.Scope,
-		ARN:         topicID,
-		State:       activeTopicState,
-		CreatedAt:   m.opts.Clock.Now().UTC().Format(time.RFC3339),
-		Tags:        tags,
-		Region:      cfg.Region,
-		InputSchema: inputSchema,
+		Name:                cfg.Name,
+		Scope:               cfg.Scope,
+		ARN:                 topicID,
+		State:               activeTopicState,
+		CreatedAt:           m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:                tags,
+		Region:              cfg.Region,
+		InputSchema:         inputSchema,
+		PublicNetworkAccess: publicNetworkAccess,
 	}
 
 	bd := &busData{
@@ -558,6 +567,11 @@ func (m *Mock) UpdateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 	}
 	if cfg.Region != "" {
 		bd.info.Region = cfg.Region
+	}
+	// InputSchema is immutable after creation, so it is intentionally not
+	// updated here; PublicNetworkAccess is mutable and applied when supplied.
+	if cfg.PublicNetworkAccess != "" {
+		bd.info.PublicNetworkAccess = cfg.PublicNetworkAccess
 	}
 
 	m.buses.Set(cfg.Name, bd)

--- a/server/azure/eventgrid/domain_schema_sdk_test.go
+++ b/server/azure/eventgrid/domain_schema_sdk_test.go
@@ -1,0 +1,96 @@
+package eventgrid_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+)
+
+// TestSDKDomainInputSchemaAndNetworkRoundTrip locks B4: a domain created with a
+// non-default InputSchema and PublicNetworkAccess=Disabled must echo both back
+// on the create response and a subsequent Get, not the hardcoded defaults.
+func TestSDKDomainInputSchemaAndNetworkRoundTrip(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	dc := cf.NewDomainsClient()
+	ctx := context.Background()
+
+	poller, err := dc.BeginCreateOrUpdate(ctx, testRG, "schema-domain", armeventgrid.Domain{
+		Location: to.Ptr("eastus"),
+		Properties: &armeventgrid.DomainProperties{
+			InputSchema:         to.Ptr(armeventgrid.InputSchemaCloudEventSchemaV10),
+			PublicNetworkAccess: to.Ptr(armeventgrid.PublicNetworkAccessDisabled),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Domains.BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("create PollUntilDone: %v", err)
+	}
+
+	if created.Properties == nil || created.Properties.InputSchema == nil ||
+		*created.Properties.InputSchema != armeventgrid.InputSchemaCloudEventSchemaV10 {
+		t.Fatalf("create inputSchema = %v, want CloudEventSchemaV1_0", created.Properties)
+	}
+
+	if created.Properties.PublicNetworkAccess == nil ||
+		*created.Properties.PublicNetworkAccess != armeventgrid.PublicNetworkAccessDisabled {
+		t.Fatalf("create publicNetworkAccess = %v, want Disabled", created.Properties)
+	}
+
+	got, err := dc.Get(ctx, testRG, "schema-domain", nil)
+	if err != nil {
+		t.Fatalf("Domains.Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.InputSchema == nil ||
+		*got.Properties.InputSchema != armeventgrid.InputSchemaCloudEventSchemaV10 {
+		t.Fatalf("Get inputSchema = %v, want CloudEventSchemaV1_0", got.Properties)
+	}
+
+	if got.Properties.PublicNetworkAccess == nil ||
+		*got.Properties.PublicNetworkAccess != armeventgrid.PublicNetworkAccessDisabled {
+		t.Fatalf("Get publicNetworkAccess = %v, want Disabled", got.Properties)
+	}
+}
+
+// TestSDKDomainInputSchemaImmutable asserts a domain's input schema cannot be
+// changed by a later CreateOrUpdate, mirroring topic input-schema immutability.
+func TestSDKDomainInputSchemaImmutable(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	dc := cf.NewDomainsClient()
+	ctx := context.Background()
+
+	mk := func(schema armeventgrid.InputSchema) {
+		poller, err := dc.BeginCreateOrUpdate(ctx, testRG, "immutable-domain", armeventgrid.Domain{
+			Location: to.Ptr("eastus"),
+			Properties: &armeventgrid.DomainProperties{
+				InputSchema: to.Ptr(schema),
+			},
+		}, nil)
+		if err != nil {
+			t.Fatalf("BeginCreateOrUpdate: %v", err)
+		}
+
+		if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("PollUntilDone: %v", err)
+		}
+	}
+
+	mk(armeventgrid.InputSchemaCloudEventSchemaV10)
+	mk(armeventgrid.InputSchemaEventGridSchema)
+
+	got, err := dc.Get(ctx, testRG, "immutable-domain", nil)
+	if err != nil {
+		t.Fatalf("Domains.Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.InputSchema == nil ||
+		*got.Properties.InputSchema != armeventgrid.InputSchemaCloudEventSchemaV10 {
+		t.Fatalf("inputSchema changed after re-create = %v, want CloudEventSchemaV1_0", got.Properties)
+	}
+}

--- a/server/azure/eventgrid/domains.go
+++ b/server/azure/eventgrid/domains.go
@@ -16,6 +16,10 @@ const (
 	domainDefaultNetworkAcces = "Enabled"
 	subActionListKeys         = "listKeys"
 	subActionRegenerateKey    = "regenerateKey"
+	// keyName1 and keyName2 are the two shared-access-key identifiers a topic
+	// or domain exposes, used both to derive keys and to route RegenerateKey.
+	keyName1 = "key1"
+	keyName2 = "key2"
 )
 
 // domainRecord is the wire-handler-owned state for one Event Grid domain. A
@@ -31,6 +35,10 @@ type domainRecord struct {
 	tags     map[string]string
 	key1     string
 	key2     string
+	// inputSchema is fixed at creation (immutable, like a topic's);
+	// publicNetworkAccess is mutable across CreateOrUpdate calls.
+	inputSchema         string
+	publicNetworkAccess string
 	// topics holds the DomainTopics sub-resources created under this domain.
 	// A domain topic carries no state of its own beyond existing (real Event
 	// Grid domain topics are typically auto-created on first publish and
@@ -82,6 +90,35 @@ func domainID(rp *azurearm.ResourcePath) string {
 	return azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeDomains, rp.ResourceName)
 }
 
+// orDefault returns v, or def when v is empty.
+func orDefault(v, def string) string {
+	if v == "" {
+		return def
+	}
+
+	return v
+}
+
+// domainInputSchemaFromBody reads the caller's requested InputSchema off a
+// Domains CreateOrUpdate body (empty when properties are omitted).
+func domainInputSchemaFromBody(body *domainJSON) string {
+	if body.Properties == nil {
+		return ""
+	}
+
+	return body.Properties.InputSchema
+}
+
+// domainPublicNetworkAccessFromBody reads the caller's requested
+// PublicNetworkAccess off a Domains CreateOrUpdate body (empty when omitted).
+func domainPublicNetworkAccessFromBody(body *domainJSON) string {
+	if body.Properties == nil {
+		return ""
+	}
+
+	return body.Properties.PublicNetworkAccess
+}
+
 func (rec *domainRecord) toJSON(rp *azurearm.ResourcePath) domainJSON {
 	id := domainID(rp)
 
@@ -95,8 +132,8 @@ func (rec *domainRecord) toJSON(rp *azurearm.ResourcePath) domainJSON {
 			Endpoint:            topicEndpoint(rec.name, rec.location),
 			MetricResourceID:    id,
 			ProvisioningState:   domainProvisioningState,
-			InputSchema:         domainDefaultInputSchema,
-			PublicNetworkAccess: domainDefaultNetworkAcces,
+			InputSchema:         orDefault(rec.inputSchema, domainDefaultInputSchema),
+			PublicNetworkAccess: orDefault(rec.publicNetworkAccess, domainDefaultNetworkAcces),
 		},
 	}
 }
@@ -165,15 +202,21 @@ func (h *Handler) createOrUpdateDomain(w http.ResponseWriter, r *http.Request, r
 			name:   rp.ResourceName,
 			sub:    rp.Subscription,
 			rg:     rp.ResourceGroup,
-			key1:   domainKey(rp.ResourceName, "key1", 0),
-			key2:   domainKey(rp.ResourceName, "key2", 0),
+			key1:   domainKey(rp.ResourceName, keyName1, 0),
+			key2:   domainKey(rp.ResourceName, keyName2, 0),
 			topics: make(map[string]struct{}),
+			// inputSchema is immutable, so it is stamped only on creation.
+			inputSchema: orDefault(domainInputSchemaFromBody(&body), domainDefaultInputSchema),
 		}
 		h.domains[key] = rec
 	}
 
 	rec.location = loc
 	rec.tags = tagsFromPtr(body.Tags)
+
+	if pna := domainPublicNetworkAccessFromBody(&body); pna != "" {
+		rec.publicNetworkAccess = pna
+	}
 
 	out := rec.toJSON(rp)
 	h.mu.Unlock()
@@ -275,10 +318,10 @@ func (h *Handler) regenerateDomainKey(w http.ResponseWriter, r *http.Request, rp
 	}
 
 	switch body.KeyName {
-	case "key1":
-		rec.key1 = domainKey(rec.name, "key1", nextKeyGen(rec.key1))
-	case "key2":
-		rec.key2 = domainKey(rec.name, "key2", nextKeyGen(rec.key2))
+	case keyName1:
+		rec.key1 = domainKey(rec.name, keyName1, nextKeyGen(rec.key1))
+	case keyName2:
+		rec.key2 = domainKey(rec.name, keyName2, nextKeyGen(rec.key2))
 	default:
 		h.mu.Unlock()
 		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "keyName must be key1 or key2")

--- a/server/azure/eventgrid/event_subscriptions.go
+++ b/server/azure/eventgrid/event_subscriptions.go
@@ -5,10 +5,17 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
+	"strconv"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 )
+
+// topicRegenerateKeyRequest is the Topics.RegenerateKey request body
+// (armeventgrid.TopicRegenerateKeyRequest).
+type topicRegenerateKeyRequest struct {
+	KeyName string `json:"keyName"`
+}
 
 // eventSubscriptionJSON is the ARM EventSubscription resource shape. The
 // properties are stored and echoed verbatim so the caller's destination/filter
@@ -24,10 +31,27 @@ type eventSubscriptionListResult struct {
 	Value []eventSubscriptionJSON `json:"value"`
 }
 
-// subscriptionKey derives the deterministic topic access keys.
-func topicKey(topicName, which string) string {
-	sum := sha256.Sum256([]byte("eventgrid" + "\x00" + topicName + "\x00" + which))
+// topicKey derives a deterministic topic shared access key. gen bumps on each
+// regeneration so a rotated key differs from its predecessor.
+func topicKey(topicName, which string, gen int) string {
+	sum := sha256.Sum256([]byte("eventgrid" + "\x00" + topicName + "\x00" + which + "\x00" + strconv.Itoa(gen)))
 	return base64.StdEncoding.EncodeToString(sum[:])
+}
+
+// topicKeysFor returns the current key1/key2 for a topic at their present
+// generations. The caller must hold at least a read lock.
+func (h *Handler) topicKeysFor(rp *azurearm.ResourcePath) topicSharedAccessKeys {
+	gens := h.topicKeyGens[storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)]
+
+	g1, g2 := 0, 0
+	if gens != nil {
+		g1, g2 = gens.key1Gen, gens.key2Gen
+	}
+
+	return topicSharedAccessKeys{
+		Key1: topicKey(rp.ResourceName, keyName1, g1),
+		Key2: topicKey(rp.ResourceName, keyName2, g2),
+	}
 }
 
 // listTopicKeys serves Topics.ListSharedAccessKeys.
@@ -37,10 +61,52 @@ func (h *Handler) listTopicKeys(w http.ResponseWriter, r *http.Request, rp *azur
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, topicSharedAccessKeys{
-		Key1: topicKey(rp.ResourceName, "key1"),
-		Key2: topicKey(rp.ResourceName, "key2"),
-	})
+	h.mu.RLock()
+	keys := h.topicKeysFor(rp)
+	h.mu.RUnlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, keys)
+}
+
+// regenerateTopicKey serves Topics.RegenerateKey: it bumps the requested key's
+// generation (leaving the other untouched) and returns the refreshed keys.
+func (h *Handler) regenerateTopicKey(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if _, err := h.bus.GetEventBus(r.Context(), rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	var body topicRegenerateKeyRequest
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	h.mu.Lock()
+
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	gens := h.topicKeyGens[key]
+	if gens == nil {
+		gens = &topicKeyGens{}
+		h.topicKeyGens[key] = gens
+	}
+
+	switch body.KeyName {
+	case keyName1:
+		gens.key1Gen++
+	case keyName2:
+		gens.key2Gen++
+	default:
+		h.mu.Unlock()
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "keyName must be key1 or key2")
+
+		return
+	}
+
+	keys := h.topicKeysFor(rp)
+	h.mu.Unlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, keys)
 }
 
 // enrichSubscriptionProperties parses stored properties, stamps the read-only

--- a/server/azure/eventgrid/handler.go
+++ b/server/azure/eventgrid/handler.go
@@ -16,8 +16,10 @@
 // Coverage:
 //
 //	PUT/GET/DELETE .../topics/{t}                           — Topics CRUD (LRO, completes inline)
+//	PATCH          .../topics/{t}                           — Topics.Update (merge tags + mutable properties)
 //	GET            .../topics                               — Topics.ListBySubscription / ListByResourceGroup
 //	POST           .../topics/{t}/listKeys                  — Topics.ListSharedAccessKeys
+//	POST           .../topics/{t}/regenerateKey            — Topics.RegenerateKey
 //	PUT/GET/DELETE .../topics/{t}/eventSubscriptions/{s}    — TopicEventSubscriptions CRUD
 //	GET            .../topics/{t}/eventSubscriptions        — TopicEventSubscriptions.List
 //	PUT/GET/DELETE .../domains/{d}/topics/{t}               — DomainTopics CRUD
@@ -58,6 +60,19 @@ type Handler struct {
 	// These have no eventbus-driver topic to hang off, so — like systemTopics
 	// and domains — the wire handler owns their state. Keyed by scope+name.
 	scopedSubs map[string]*scopedSubRecord
+	// topicKeyGens holds the per-topic shared-access-key generation counters.
+	// A topic's keys are derived deterministically from its name plus a
+	// per-key generation; RegenerateKey bumps the requested key's generation so
+	// the rotated key differs while the other is left untouched. Keyed by
+	// scope+name; a missing entry means both keys are at generation zero.
+	topicKeyGens map[string]*topicKeyGens
+}
+
+// topicKeyGens tracks the generation counter of each of a topic's two shared
+// access keys. Bumping a counter rotates only that key.
+type topicKeyGens struct {
+	key1Gen int
+	key2Gen int
 }
 
 // New returns an Azure Event Grid handler backed by b.
@@ -67,6 +82,7 @@ func New(b ebdriver.EventBus) *Handler {
 		systemTopics: make(map[string]*systemTopicRecord),
 		domains:      make(map[string]*domainRecord),
 		scopedSubs:   make(map[string]*scopedSubRecord),
+		topicKeyGens: make(map[string]*topicKeyGens),
 	}
 }
 
@@ -149,6 +165,13 @@ func (h *Handler) serveTopicResource(w http.ResponseWriter, r *http.Request, rp 
 		}
 
 		h.listTopicKeys(w, r, rp)
+	case subActionRegenerateKey:
+		if r.Method != http.MethodPost {
+			writeMethodNotAllowed(w)
+			return
+		}
+
+		h.regenerateTopicKey(w, r, rp)
 	case subEventSubscriptions:
 		h.serveEventSubscription(w, r, rp)
 	case "":
@@ -162,6 +185,8 @@ func (h *Handler) serveTopic(w http.ResponseWriter, r *http.Request, rp *azurear
 	switch r.Method {
 	case http.MethodPut:
 		h.createOrUpdateTopic(w, r, rp)
+	case http.MethodPatch:
+		h.updateTopic(w, r, rp)
 	case http.MethodGet:
 		h.getTopic(w, r, rp)
 	case http.MethodDelete:

--- a/server/azure/eventgrid/operations.go
+++ b/server/azure/eventgrid/operations.go
@@ -19,11 +19,12 @@ func (h *Handler) createOrUpdateTopic(w http.ResponseWriter, r *http.Request, rp
 	}
 
 	cfg := ebdriver.EventBusConfig{
-		Name:        rp.ResourceName,
-		Tags:        tagsFromPtr(body.Tags),
-		Scope:       scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
-		Region:      body.Location,
-		InputSchema: inputSchemaFromBody(&body),
+		Name:                rp.ResourceName,
+		Tags:                tagsFromPtr(body.Tags),
+		Scope:               scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
+		Region:              body.Location,
+		InputSchema:         inputSchemaFromBody(&body),
+		PublicNetworkAccess: publicNetworkAccessFromBody(&body),
 	}
 
 	if _, err := h.bus.GetEventBus(r.Context(), rp.ResourceName); err == nil {
@@ -60,6 +61,87 @@ func inputSchemaFromBody(body *topicJSON) string {
 	}
 
 	return body.Properties.InputSchema
+}
+
+// publicNetworkAccessFromBody reads the caller's requested PublicNetworkAccess
+// off a Topics CreateOrUpdate request body. CreateEventBus falls back to the
+// real default (Enabled) when this is empty.
+func publicNetworkAccessFromBody(body *topicJSON) string {
+	if body.Properties == nil {
+		return ""
+	}
+
+	return body.Properties.PublicNetworkAccess
+}
+
+// topicUpdateJSON is the Topics.Update (PATCH) request body: mutable tags plus
+// mutable properties (publicNetworkAccess). Identity and input schema are not
+// changeable here, mirroring real Event Grid.
+type topicUpdateJSON struct {
+	Tags       map[string]*string `json:"tags,omitempty"`
+	Properties *struct {
+		PublicNetworkAccess string `json:"publicNetworkAccess,omitempty"`
+	} `json:"properties,omitempty"`
+}
+
+// updateTopic maps Topics.Update (PATCH) onto UpdateEventBus: it merges the
+// supplied tags onto the topic's existing tags and applies the mutable
+// publicNetworkAccess, returning the updated topic (200).
+func (h *Handler) updateTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body topicUpdateJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	current, err := h.bus.GetEventBus(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	cfg := ebdriver.EventBusConfig{
+		Name:                rp.ResourceName,
+		Tags:                mergeTags(current.Tags, tagsFromPtr(body.Tags)),
+		PublicNetworkAccess: updatePublicNetworkAccess(&body),
+	}
+
+	info, uerr := h.bus.UpdateEventBus(r.Context(), cfg)
+	if uerr != nil {
+		azurearm.WriteCErr(w, uerr)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toTopicJSON(rp, info))
+}
+
+// updatePublicNetworkAccess pulls the mutable publicNetworkAccess off a PATCH
+// body, empty when the caller omitted properties (UpdateEventBus then leaves it
+// unchanged).
+func updatePublicNetworkAccess(body *topicUpdateJSON) string {
+	if body.Properties == nil {
+		return ""
+	}
+
+	return body.Properties.PublicNetworkAccess
+}
+
+// mergeTags overlays patch onto base, returning the merged set. A nil result
+// (both empty) leaves UpdateEventBus's existing tags untouched.
+func mergeTags(base, patch map[string]string) map[string]string {
+	if len(base) == 0 && len(patch) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(base)+len(patch))
+	for k, v := range base {
+		out[k] = v
+	}
+
+	for k, v := range patch {
+		out[k] = v
+	}
+
+	return out
 }
 
 func (h *Handler) getTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {

--- a/server/azure/eventgrid/topic_network_regen_sdk_test.go
+++ b/server/azure/eventgrid/topic_network_regen_sdk_test.go
@@ -1,0 +1,183 @@
+package eventgrid_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+)
+
+// TestSDKTopicPublicNetworkAccessRoundTrips locks B1: a topic created with
+// PublicNetworkAccess=Disabled must echo Disabled on both the create response
+// and a subsequent Get, not the hardcoded Enabled default.
+func TestSDKTopicPublicNetworkAccessRoundTrips(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	topics := cf.NewTopicsClient()
+	ctx := context.Background()
+
+	poller, err := topics.BeginCreateOrUpdate(ctx, testRG, "private-topic", armeventgrid.Topic{
+		Location: to.Ptr("eastus"),
+		Properties: &armeventgrid.TopicProperties{
+			PublicNetworkAccess: to.Ptr(armeventgrid.PublicNetworkAccessDisabled),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	if created.Properties == nil || created.Properties.PublicNetworkAccess == nil ||
+		*created.Properties.PublicNetworkAccess != armeventgrid.PublicNetworkAccessDisabled {
+		t.Fatalf("create response publicNetworkAccess = %v, want Disabled", created.Properties)
+	}
+
+	got, err := topics.Get(ctx, testRG, "private-topic", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.PublicNetworkAccess == nil ||
+		*got.Properties.PublicNetworkAccess != armeventgrid.PublicNetworkAccessDisabled {
+		t.Fatalf("Get publicNetworkAccess = %v, want Disabled", got.Properties)
+	}
+}
+
+// TestSDKTopicPublicNetworkAccessDefaultsToEnabled covers the unset case: a
+// topic created without PublicNetworkAccess still gets the real default.
+func TestSDKTopicPublicNetworkAccessDefaultsToEnabled(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	topics := cf.NewTopicsClient()
+	ctx := context.Background()
+
+	poller, err := topics.BeginCreateOrUpdate(ctx, testRG, "public-topic", armeventgrid.Topic{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	if created.Properties == nil || created.Properties.PublicNetworkAccess == nil ||
+		*created.Properties.PublicNetworkAccess != armeventgrid.PublicNetworkAccessEnabled {
+		t.Fatalf("publicNetworkAccess = %v, want Enabled default", created.Properties)
+	}
+}
+
+// TestSDKTopicUpdatePatchMergesTags locks B2: Topics.BeginUpdate (PATCH)
+// succeeds, merges the supplied tags onto the existing ones, and applies the
+// mutable publicNetworkAccess.
+func TestSDKTopicUpdatePatchMergesTags(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	topics := cf.NewTopicsClient()
+	ctx := context.Background()
+
+	createPoller, err := topics.BeginCreateOrUpdate(ctx, testRG, "patch-topic", armeventgrid.Topic{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("create PollUntilDone: %v", err)
+	}
+
+	updPoller, err := topics.BeginUpdate(ctx, testRG, "patch-topic", armeventgrid.TopicUpdateParameters{
+		Tags: map[string]*string{"team": to.Ptr("data")},
+		Properties: &armeventgrid.TopicUpdateParameterProperties{
+			PublicNetworkAccess: to.Ptr(armeventgrid.PublicNetworkAccessDisabled),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Topics.BeginUpdate: %v", err)
+	}
+
+	updated, err := updPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("Update PollUntilDone: %v", err)
+	}
+
+	if updated.Tags["env"] == nil || *updated.Tags["env"] != "test" {
+		t.Fatalf("update dropped existing tag env: %+v", updated.Tags)
+	}
+
+	if updated.Tags["team"] == nil || *updated.Tags["team"] != "data" {
+		t.Fatalf("update missing new tag team: %+v", updated.Tags)
+	}
+
+	got, err := topics.Get(ctx, testRG, "patch-topic", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Tags["env"] == nil || got.Tags["team"] == nil {
+		t.Fatalf("Get after patch missing merged tags: %+v", got.Tags)
+	}
+
+	if got.Properties == nil || got.Properties.PublicNetworkAccess == nil ||
+		*got.Properties.PublicNetworkAccess != armeventgrid.PublicNetworkAccessDisabled {
+		t.Fatalf("patch did not apply publicNetworkAccess: %v", got.Properties)
+	}
+}
+
+// TestSDKTopicRegenerateKey locks B3: BeginRegenerateKey("key1") changes key1
+// but not key2, and ListSharedAccessKeys reflects the rotated value.
+func TestSDKTopicRegenerateKey(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	topics := cf.NewTopicsClient()
+	ctx := context.Background()
+
+	mkTopicLoc(t, topics, "regen-topic", "eastus")
+
+	before, err := topics.ListSharedAccessKeys(ctx, testRG, "regen-topic", nil)
+	if err != nil {
+		t.Fatalf("ListSharedAccessKeys: %v", err)
+	}
+
+	if before.Key1 == nil || before.Key2 == nil || *before.Key1 == "" || *before.Key2 == "" {
+		t.Fatalf("initial keys empty: %+v", before)
+	}
+
+	regenPoller, err := topics.BeginRegenerateKey(ctx, testRG, "regen-topic", armeventgrid.TopicRegenerateKeyRequest{
+		KeyName: to.Ptr("key1"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginRegenerateKey: %v", err)
+	}
+
+	regen, err := regenPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("RegenerateKey PollUntilDone: %v", err)
+	}
+
+	if *regen.Key1 == *before.Key1 {
+		t.Fatalf("key1 did not change after regenerate: %q", *regen.Key1)
+	}
+
+	if *regen.Key2 != *before.Key2 {
+		t.Fatalf("key2 changed on key1 regenerate: %q vs %q", *regen.Key2, *before.Key2)
+	}
+
+	after, err := topics.ListSharedAccessKeys(ctx, testRG, "regen-topic", nil)
+	if err != nil {
+		t.Fatalf("ListSharedAccessKeys after regen: %v", err)
+	}
+
+	if *after.Key1 != *regen.Key1 {
+		t.Fatalf("listKeys key1 = %q, want rotated %q", *after.Key1, *regen.Key1)
+	}
+
+	if *after.Key2 != *before.Key2 {
+		t.Fatalf("listKeys key2 = %q, want unchanged %q", *after.Key2, *before.Key2)
+	}
+}

--- a/server/azure/eventgrid/types.go
+++ b/server/azure/eventgrid/types.go
@@ -80,6 +80,11 @@ func toTopicJSON(rp *azurearm.ResourcePath, info *ebdriver.EventBusInfo) topicJS
 		inputSchema = defaultInputSchema
 	}
 
+	publicNetworkAccess := info.PublicNetworkAccess
+	if publicNetworkAccess == "" {
+		publicNetworkAccess = defaultPublicNetworkAccess
+	}
+
 	return topicJSON{
 		ID:       id,
 		Name:     info.Name,
@@ -90,7 +95,7 @@ func toTopicJSON(rp *azurearm.ResourcePath, info *ebdriver.EventBusInfo) topicJS
 			ProvisioningState:   provisioningSucceeded,
 			Endpoint:            topicEndpoint(info.Name, loc),
 			InputSchema:         inputSchema,
-			PublicNetworkAccess: defaultPublicNetworkAccess,
+			PublicNetworkAccess: publicNetworkAccess,
 			MetricResourceID:    id,
 		},
 	}

--- a/services/eventbus/driver/driver.go
+++ b/services/eventbus/driver/driver.go
@@ -23,6 +23,10 @@ type EventBusInfo struct {
 	// Grid: "EventGridSchema", "CustomEventSchema", "CloudEventSchemaV1_0").
 	// Empty for AWS and GCP.
 	InputSchema string
+	// PublicNetworkAccess records whether the topic accepts traffic over the
+	// public network (Azure Event Grid: "Enabled", "Disabled"). Empty for AWS
+	// and GCP.
+	PublicNetworkAccess string
 }
 
 // EventBusConfig configures a new event bus.
@@ -40,6 +44,10 @@ type EventBusConfig struct {
 	// Grid: "EventGridSchema", "CustomEventSchema", "CloudEventSchemaV1_0").
 	// Empty for AWS and GCP, and for an Azure caller accepting the default.
 	InputSchema string
+	// PublicNetworkAccess records whether the topic accepts traffic over the
+	// public network (Azure Event Grid: "Enabled", "Disabled"). Empty for AWS
+	// and GCP, and for an Azure caller accepting the default.
+	PublicNetworkAccess string
 }
 
 // Rule defines an event routing rule with filtering.


### PR DESCRIPTION
## Summary

Fixes 4 Azure Event Grid (`Microsoft.EventGrid`) real bugs where topic/domain properties were echoed from hardcoded defaults instead of stored request state, and two topic operations were missing.

### Bugs fixed
1. **Topic `publicNetworkAccess` not round-tripped** — a topic created with `PublicNetworkAccess=Disabled` returned `Enabled` on both the create response and GET. Added `PublicNetworkAccess` to the eventbus driver (mirroring `InputSchema`), stored it in the provider (default `Enabled` only when omitted), and echoed the stored value from the wire handler.
2. **`Topics.Update` (PATCH) → 405** — the topic router only handled PUT/GET/DELETE. Added `PATCH`, which merges the supplied tags onto the topic's existing tags and applies the mutable `publicNetworkAccess` via `UpdateEventBus`, returning the updated topic (200).
3. **`Topics.RegenerateKey` → 400** — topics only handled `listKeys`. Added a per-topic key-generation counter (handler-owned state); `regenerateKey(key1|key2)` bumps only that key's generation, so key1 rotates while key2 is untouched and `listKeys` reflects the new value. Mirrors the existing domain `regenerateKey` behavior.
4. **Domain `inputSchema`/`publicNetworkAccess` hardcoded** — a domain created with `CloudEventSchemaV1_0` GETs back `EventGridSchema`. The domain create path now reads both from the request body, stores them, and echoes them. `inputSchema` is immutable on update (like topics); `publicNetworkAccess` is mutable.

### Unregressed
Topic `inputSchema` round-trip + immutability, endpoint synthesis, event-subscription destination/filter round-trip, the filter engine, WebHook cross-service delivery, and `listKeys` returning real `key1`/`key2` (#715) are all preserved and still covered by their tests.

### Tests (real `armeventgrid/v2` SDK against a booted `httptest.NewTLSServer`)
- Topic `PublicNetworkAccess=Disabled` round-trips + defaults to `Enabled` when omitted.
- `Topics.BeginUpdate` PATCH succeeds and merges tags + applies `publicNetworkAccess`.
- `Topics.BeginRegenerateKey` key1 → key1 changes, key2 unchanged, `listKeys` reflects it.
- Domain `CloudEventSchemaV1_0` + `PublicNetworkAccess` round-trip, and domain `inputSchema` immutability.

### Gates
`go build`, `go vet`, targeted `go test` (server/provider/eventbus), `-race` on the provider, `gofmt -l`, `go generate` (zero diff), and `compatgen` (zero `docs/compat` diff) all clean. No new lint issues on authored lines.
