### PR TITLE
fix(azure-acr): round-trip UserAssigned identity map; stop webhook callback config leaking on GET; add getCallbackConfig

### DIFF
--- a/providers/azure/acr/registry.go
+++ b/providers/azure/acr/registry.go
@@ -45,6 +45,8 @@ func subResourceKey(rg, registry, name string) string {
 // CreateOrUpdateRegistry creates or replaces an ACR registry (ARM PUT). It
 // reports whether the registry was newly created (vs. replaced) so the wire
 // layer can distinguish 201 Created from 200 OK.
+//
+//nolint:gocritic // cfg mirrors the driver interface's value-type config; pointer would invite caller mutation.
 func (m *Mock) CreateOrUpdateRegistry(
 	_ context.Context, rg, name string, cfg driver.AzureRegistryConfig,
 ) (*driver.AzureRegistry, bool, error) {
@@ -82,7 +84,7 @@ func (m *Mock) CreateOrUpdateRegistry(
 	rd.reg.AdminUserEnabled = cfg.AdminUserEnabled
 	rd.reg.ProvisioningState = registryProvisioned
 	rd.reg.Tags = copyTags(cfg.Tags)
-	applyIdentity(&rd.reg, cfg.IdentityType, rg, name)
+	applyIdentity(&rd.reg, cfg.IdentityType, cfg.UserAssignedIdentities, rg, name)
 
 	m.registries.Set(key, rd)
 
@@ -122,7 +124,7 @@ func (m *Mock) UpdateRegistry(
 	}
 
 	if upd.IdentityType != nil {
-		applyIdentity(&rd.reg, *upd.IdentityType, rg, name)
+		applyIdentity(&rd.reg, *upd.IdentityType, upd.UserAssignedIdentities, rg, name)
 	}
 
 	m.registries.Set(key, rd)
@@ -133,11 +135,13 @@ func (m *Mock) UpdateRegistry(
 }
 
 // applyIdentity echoes the submitted managed-identity block, generating a
-// deterministic principal/tenant pair for a system-assigned identity.
-func applyIdentity(reg *driver.AzureRegistry, identityType, rg, name string) {
+// deterministic principal/tenant pair for a system-assigned identity and a
+// synthesized principal/client pair per user-assigned identity.
+func applyIdentity(reg *driver.AzureRegistry, identityType string, userAssigned []string, rg, name string) {
 	reg.IdentityType = identityType
 	reg.PrincipalID = ""
 	reg.TenantID = ""
+	reg.UserAssignedIdentities = nil
 
 	if identityType == "" || identityType == identityNone {
 		return
@@ -147,6 +151,28 @@ func applyIdentity(reg *driver.AzureRegistry, identityType, rg, name string) {
 		reg.PrincipalID = idgen.SyntheticGUID("principal/registry/" + rg + "/" + name)
 		reg.TenantID = emulatorTenantID
 	}
+
+	if strings.Contains(identityType, "UserAssigned") {
+		reg.UserAssignedIdentities = synthUserAssigned(userAssigned)
+	}
+}
+
+// synthUserAssigned builds the deterministic principal/client pair Azure returns
+// for each attached user-assigned identity resource ID.
+func synthUserAssigned(ids []string) map[string]driver.AzureUserAssignedIdentity {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	out := make(map[string]driver.AzureUserAssignedIdentity, len(ids))
+	for _, id := range ids {
+		out[id] = driver.AzureUserAssignedIdentity{
+			PrincipalID: idgen.SyntheticGUID("uai-principal/" + id),
+			ClientID:    idgen.SyntheticGUID("uai-client/" + id),
+		}
+	}
+
+	return out
 }
 
 func defaultIfEmpty(v, def string) string {

--- a/server/azure/acr/arm_registry_roundtrip_test.go
+++ b/server/azure/acr/arm_registry_roundtrip_test.go
@@ -16,7 +16,7 @@ import (
 	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
 )
 
-func newACRARMFactory(t *testing.T) *armcontainerregistry.ClientFactory {
+func newACRARMServer(t *testing.T) *httptest.Server {
 	t.Helper()
 
 	cloudP := cloudemu.NewAzure()
@@ -24,6 +24,12 @@ func newACRARMFactory(t *testing.T) *armcontainerregistry.ClientFactory {
 
 	ts := httptest.NewTLSServer(srv)
 	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func armFactoryFor(t *testing.T, ts *httptest.Server) *armcontainerregistry.ClientFactory {
+	t.Helper()
 
 	myCloud := cloud.Configuration{
 		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
@@ -46,6 +52,12 @@ func newACRARMFactory(t *testing.T) *armcontainerregistry.ClientFactory {
 	}
 
 	return cf
+}
+
+func newACRARMFactory(t *testing.T) *armcontainerregistry.ClientFactory {
+	t.Helper()
+
+	return armFactoryFor(t, newACRARMServer(t))
 }
 
 func createRegistry(t *testing.T, client *armcontainerregistry.RegistriesClient, rg, name string) armcontainerregistry.Registry {

--- a/server/azure/acr/identity_webhook_callback_test.go
+++ b/server/azure/acr/identity_webhook_callback_test.go
@@ -1,0 +1,252 @@
+package acr_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
+
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+)
+
+const uaResourceID = "/subscriptions/sub-1/resourceGroups/rg-1/providers/" +
+	"Microsoft.ManagedIdentity/userAssignedIdentities/uai1"
+
+// TestSDKACRRegistryUserAssignedIdentity is B1: a UserAssigned identity map must
+// survive the create→GET round trip with a synthesized, deterministic
+// principal/client pair per identity (the TF-drift bug was the map being
+// dropped on GET).
+func TestSDKACRRegistryUserAssignedIdentity(t *testing.T) {
+	cf := newACRARMFactory(t)
+	client := cf.NewRegistriesClient()
+	ctx := context.Background()
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "uareg", armcontainerregistry.Registry{
+		Location: to.Ptr("eastus"),
+		SKU:      &armcontainerregistry.SKU{Name: to.Ptr(armcontainerregistry.SKUNameStandard)},
+		Identity: &armcontainerregistry.IdentityProperties{
+			Type: to.Ptr(armcontainerregistry.ResourceIdentityTypeUserAssigned),
+			UserAssignedIdentities: map[string]*armcontainerregistry.UserIdentityProperties{
+				uaResourceID: {},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err = poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Create PollUntilDone: %v", err)
+	}
+
+	got, err := client.Get(ctx, "rg-1", "uareg", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	assertUserAssigned(t, got.Identity)
+}
+
+func assertUserAssigned(t *testing.T, id *armcontainerregistry.IdentityProperties) {
+	t.Helper()
+
+	if id == nil || id.Type == nil || *id.Type != armcontainerregistry.ResourceIdentityTypeUserAssigned {
+		t.Fatalf("got identity %+v, want type UserAssigned", id)
+	}
+
+	if len(id.UserAssignedIdentities) != 1 {
+		t.Fatalf("got %d user-assigned identities, want 1 (map dropped)", len(id.UserAssignedIdentities))
+	}
+
+	uai := id.UserAssignedIdentities[uaResourceID]
+	if uai == nil || uai.PrincipalID == nil || uai.ClientID == nil {
+		t.Fatalf("user-assigned identity %q missing principal/client: %+v", uaResourceID, uai)
+	}
+
+	if want := idgen.SyntheticGUID("uai-principal/" + uaResourceID); *uai.PrincipalID != want {
+		t.Fatalf("got principalId %q, want deterministic %q", *uai.PrincipalID, want)
+	}
+
+	if want := idgen.SyntheticGUID("uai-client/" + uaResourceID); *uai.ClientID != want {
+		t.Fatalf("got clientId %q, want deterministic %q", *uai.ClientID, want)
+	}
+}
+
+// TestSDKACRRegistrySystemAssignedIdentity is B1b: system-assigned still yields a
+// principal/tenant pair and carries no user-assigned map. It also covers the
+// combined SystemAssigned,UserAssigned type.
+func TestSDKACRRegistrySystemAssignedIdentity(t *testing.T) {
+	cf := newACRARMFactory(t)
+	client := cf.NewRegistriesClient()
+	ctx := context.Background()
+
+	reg := createRegistry(t, client, "rg-1", "sysreg") // system-assigned
+	if reg.Identity == nil || reg.Identity.PrincipalID == nil || *reg.Identity.PrincipalID == "" {
+		t.Fatal("expected system-assigned identity with principalId")
+	}
+
+	if len(reg.Identity.UserAssignedIdentities) != 0 {
+		t.Fatalf("system-assigned must carry no user-assigned map, got %d", len(reg.Identity.UserAssignedIdentities))
+	}
+
+	got, err := client.Get(ctx, "rg-1", "sysreg", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Identity.TenantID == nil || *got.Identity.TenantID == "" {
+		t.Fatal("expected system-assigned identity tenantId on GET")
+	}
+
+	combined := combinedIdentityRegistry(t, client)
+	if combined.PrincipalID == nil || *combined.PrincipalID == "" {
+		t.Fatal("combined identity: expected system-assigned principalId")
+	}
+
+	if len(combined.UserAssignedIdentities) != 1 {
+		t.Fatalf("combined identity: got %d user-assigned identities, want 1", len(combined.UserAssignedIdentities))
+	}
+}
+
+func combinedIdentityRegistry(t *testing.T, client *armcontainerregistry.RegistriesClient) *armcontainerregistry.IdentityProperties {
+	t.Helper()
+
+	ctx := context.Background()
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "bothreg", armcontainerregistry.Registry{
+		Location: to.Ptr("eastus"),
+		SKU:      &armcontainerregistry.SKU{Name: to.Ptr(armcontainerregistry.SKUNameStandard)},
+		Identity: &armcontainerregistry.IdentityProperties{
+			Type: to.Ptr(armcontainerregistry.ResourceIdentityTypeSystemAssignedUserAssigned),
+			UserAssignedIdentities: map[string]*armcontainerregistry.UserIdentityProperties{
+				uaResourceID: {},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("combined BeginCreate: %v", err)
+	}
+
+	if _, err = poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("combined PollUntilDone: %v", err)
+	}
+
+	got, err := client.Get(ctx, "rg-1", "bothreg", nil)
+	if err != nil {
+		t.Fatalf("combined Get: %v", err)
+	}
+
+	return got.Identity
+}
+
+// TestSDKACRWebhookCallbackConfig is B2+B3: a plain Webhooks_Get must NOT expose
+// serviceUri or customHeaders (an Authorization bearer header among them), while
+// getCallbackConfig — the only supported read path — returns both.
+func TestSDKACRWebhookCallbackConfig(t *testing.T) {
+	ts := newACRARMServer(t)
+	cf := armFactoryFor(t, ts)
+	ctx := context.Background()
+
+	createRegistry(t, cf.NewRegistriesClient(), "rg-1", "cbreg")
+
+	const authHeader = "Bearer sekret-token"
+
+	whClient := cf.NewWebhooksClient()
+
+	poller, err := whClient.BeginCreate(ctx, "rg-1", "cbreg", "wh1", armcontainerregistry.WebhookCreateParameters{
+		Location: to.Ptr("eastus"),
+		Properties: &armcontainerregistry.WebhookPropertiesCreateParameters{
+			ServiceURI:    to.Ptr("https://example.com/hook"),
+			Actions:       []*armcontainerregistry.WebhookAction{to.Ptr(armcontainerregistry.WebhookActionPush)},
+			Status:        to.Ptr(armcontainerregistry.WebhookStatusEnabled),
+			CustomHeaders: map[string]*string{"Authorization": to.Ptr(authHeader)},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Webhook BeginCreate: %v", err)
+	}
+
+	if _, err = poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Webhook PollUntilDone: %v", err)
+	}
+
+	assertPlainGetNoLeak(t, ts)
+	assertCallbackConfig(t, whClient, authHeader)
+}
+
+func assertPlainGetNoLeak(t *testing.T, ts *httptest.Server) {
+	t.Helper()
+
+	url := ts.URL + "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.ContainerRegistry/" +
+		"registries/cbreg/webhooks/wh1?api-version=2023-07-01"
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("build raw GET: %v", err)
+	}
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("raw webhook GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read raw body: %v", err)
+	}
+
+	body := string(raw)
+	for _, leak := range []string{"serviceUri", "customHeaders", "Authorization", "example.com", "sekret"} {
+		if strings.Contains(body, leak) {
+			t.Fatalf("plain Webhooks_Get leaked %q: %s", leak, body)
+		}
+	}
+}
+
+func assertCallbackConfig(t *testing.T, whClient *armcontainerregistry.WebhooksClient, authHeader string) {
+	t.Helper()
+
+	cb, err := whClient.GetCallbackConfig(context.Background(), "rg-1", "cbreg", "wh1", nil)
+	if err != nil {
+		t.Fatalf("GetCallbackConfig: %v", err)
+	}
+
+	if cb.ServiceURI == nil || *cb.ServiceURI != "https://example.com/hook" {
+		t.Fatalf("getCallbackConfig serviceUri = %v, want https://example.com/hook", cb.ServiceURI)
+	}
+
+	if got := cb.CustomHeaders["Authorization"]; got == nil || *got != authHeader {
+		t.Fatalf("getCallbackConfig customHeaders[Authorization] = %v, want %q", got, authHeader)
+	}
+}
+
+// TestSDKACRListCredentialsNotStripped guards #715: listCredentials admin
+// passwords are legitimately returned and must not be stripped as secrets.
+func TestSDKACRListCredentialsNotStripped(t *testing.T) {
+	cf := newACRARMFactory(t)
+	client := cf.NewRegistriesClient()
+	ctx := context.Background()
+
+	createRegistry(t, client, "rg-1", "credregx") // admin user enabled
+
+	creds, err := client.ListCredentials(ctx, "rg-1", "credregx", nil)
+	if err != nil {
+		t.Fatalf("ListCredentials: %v", err)
+	}
+
+	if len(creds.Passwords) != 2 {
+		t.Fatalf("got %d passwords, want 2", len(creds.Passwords))
+	}
+
+	for i, p := range creds.Passwords {
+		if p.Value == nil || *p.Value == "" {
+			t.Fatalf("password %d empty — #715 regression (admin password stripped)", i)
+		}
+	}
+}

--- a/server/azure/acr/registry.go
+++ b/server/azure/acr/registry.go
@@ -2,6 +2,7 @@ package acr
 
 import (
 	"net/http"
+	"sort"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -119,6 +120,7 @@ func (h *ARMHandler) createOrUpdateRegistry(w http.ResponseWriter, r *http.Reque
 
 	if body.Identity != nil {
 		cfg.IdentityType = body.Identity.Type
+		cfg.UserAssignedIdentities = identityKeys(body.Identity.UserAssignedIdentities)
 	}
 
 	if body.Properties != nil {
@@ -156,6 +158,7 @@ func (h *ARMHandler) updateRegistry(w http.ResponseWriter, r *http.Request, rp *
 	if body.Identity != nil {
 		id := body.Identity.Type
 		upd.IdentityType = &id
+		upd.UserAssignedIdentities = identityKeys(body.Identity.UserAssignedIdentities)
 	}
 
 	if body.Properties != nil && body.Properties.AdminUserEnabled != nil {
@@ -268,6 +271,23 @@ func (h *ARMHandler) getListUsages(w http.ResponseWriter, r *http.Request, rp *a
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, armRegistryUsageListResult{Value: out})
+}
+
+// identityKeys returns the user-assigned identity resource IDs (the map keys) in
+// deterministic order so the synthesized principal/client pairs are stable.
+func identityKeys(m map[string]*armUserAssignedIdentity) []string {
+	if len(m) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+
+	sort.Strings(out)
+
+	return out
 }
 
 func armMethodNotAllowed(w http.ResponseWriter) {

--- a/server/azure/acr/registry_types.go
+++ b/server/azure/acr/registry_types.go
@@ -33,9 +33,19 @@ type armRegistrySKU struct {
 }
 
 type armRegistryIdentity struct {
-	Type        string `json:"type,omitempty"`
+	Type                   string                              `json:"type,omitempty"`
+	PrincipalID            string                              `json:"principalId,omitempty"`
+	TenantID               string                              `json:"tenantId,omitempty"`
+	UserAssignedIdentities map[string]*armUserAssignedIdentity `json:"userAssignedIdentities,omitempty"`
+}
+
+// armUserAssignedIdentity mirrors armcontainerregistry.UserIdentityProperties:
+// the principal/client pair Azure returns for one attached user-assigned
+// identity. On a request the values are empty ({}); the response synthesizes
+// them.
+type armUserAssignedIdentity struct {
 	PrincipalID string `json:"principalId,omitempty"`
-	TenantID    string `json:"tenantId,omitempty"`
+	ClientID    string `json:"clientId,omitempty"`
 }
 
 type armRegistryProperties struct {
@@ -90,9 +100,10 @@ type armRegistryUsage struct {
 }
 
 // armWebhook mirrors armcontainerregistry.Webhook. Properties on create carry
-// serviceUri and customHeaders (WebhookPropertiesCreateParameters); the GET
-// response omits them (WebhookProperties), so serviceUri/customHeaders are
-// decode-only and left off the response shape.
+// serviceUri and customHeaders (WebhookPropertiesCreateParameters); the plain
+// GET response omits them (WebhookProperties) — they are exposed only via
+// getCallbackConfig. toARMWebhook builds the read shape (omitting them) and
+// toARMWebhookWithCallback the create/update shape (including them).
 type armWebhook struct {
 	ID         string             `json:"id,omitempty"`
 	Name       string             `json:"name,omitempty"`
@@ -155,15 +166,34 @@ func toARMRegistry(reg *crdriver.AzureRegistry, subscription string) armRegistry
 
 	if reg.IdentityType != "" && reg.IdentityType != "None" {
 		out.Identity = &armRegistryIdentity{
-			Type:        reg.IdentityType,
-			PrincipalID: reg.PrincipalID,
-			TenantID:    reg.TenantID,
+			Type:                   reg.IdentityType,
+			PrincipalID:            reg.PrincipalID,
+			TenantID:               reg.TenantID,
+			UserAssignedIdentities: toARMUserAssigned(reg.UserAssignedIdentities),
 		}
 	}
 
 	return out
 }
 
+// toARMUserAssigned echoes each stored user-assigned identity with its
+// synthesized principal/client pair, keyed by the identity resource ID.
+func toARMUserAssigned(in map[string]crdriver.AzureUserAssignedIdentity) map[string]*armUserAssignedIdentity {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]*armUserAssignedIdentity, len(in))
+	for id, v := range in {
+		out[id] = &armUserAssignedIdentity{PrincipalID: v.PrincipalID, ClientID: v.ClientID}
+	}
+
+	return out
+}
+
+// toARMWebhook is the read (GET/List) shape: it deliberately omits serviceUri
+// and customHeaders, mirroring real ACR's Webhooks_Get (WebhookProperties). The
+// two write-only fields are retrievable only via getCallbackConfig.
 func toARMWebhook(wh *crdriver.AzureWebhook, subscription string) armWebhook {
 	return armWebhook{
 		ID:       registryResourceID(subscription, wh.ResourceGroup, wh.RegistryName) + "/webhooks/" + wh.Name,
@@ -178,6 +208,26 @@ func toARMWebhook(wh *crdriver.AzureWebhook, subscription string) armWebhook {
 			ProvisioningState: wh.ProvisioningState,
 		},
 	}
+}
+
+// toARMWebhookWithCallback is the create/update (PUT/PATCH) response shape: it
+// carries serviceUri and customHeaders so the Azure property overlay sees them
+// as modeled and does NOT capture-and-replay them onto later plain GETs (which
+// use toARMWebhook and must never leak them). Real ACR exposes these two only
+// through getCallbackConfig.
+func toARMWebhookWithCallback(wh *crdriver.AzureWebhook, subscription string) armWebhook {
+	out := toARMWebhook(wh, subscription)
+	out.Properties.ServiceURI = wh.ServiceURI
+	out.Properties.CustomHeaders = toPtrTags(wh.CustomHeaders)
+
+	return out
+}
+
+// armCallbackConfig mirrors armcontainerregistry.CallbackConfig, the sole read
+// path for a webhook's serviceUri and customHeaders (getCallbackConfig).
+type armCallbackConfig struct {
+	ServiceURI    string             `json:"serviceUri,omitempty"`
+	CustomHeaders map[string]*string `json:"customHeaders,omitempty"`
 }
 
 func toARMReplication(rep *crdriver.AzureReplication, subscription string) armReplication {

--- a/server/azure/acr/replication.go
+++ b/server/azure/acr/replication.go
@@ -8,8 +8,6 @@ import (
 )
 
 // serveReplication routes .../registries/{registry}/replications[/{name}].
-//
-//nolint:dupl // webhook and replication sub-resource routers are intentionally typed; sharing via generics adds noise.
 func (h *ARMHandler) serveReplication(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	if rp.SubResourceName == "" {
 		if r.Method != http.MethodGet {

--- a/server/azure/acr/webhook.go
+++ b/server/azure/acr/webhook.go
@@ -2,15 +2,20 @@ package acr
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
 )
 
-// serveWebhook routes .../registries/{registry}/webhooks[/{name}].
-//
-//nolint:dupl // webhook and replication sub-resource routers are intentionally typed; sharing via generics adds noise.
+// serveWebhook routes .../registries/{registry}/webhooks[/{name}] and the
+// POST getCallbackConfig action.
 func (h *ARMHandler) serveWebhook(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if rp.SubResourceAction != "" {
+		h.serveWebhookAction(w, r, rp)
+		return
+	}
+
 	if rp.SubResourceName == "" {
 		if r.Method != http.MethodGet {
 			armMethodNotAllowed(w)
@@ -62,7 +67,7 @@ func (h *ARMHandler) createOrUpdateWebhook(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	azurearm.WriteJSON(w, createdStatus(created), toARMWebhook(wh, rp.Subscription))
+	azurearm.WriteJSON(w, createdStatus(created), toARMWebhookWithCallback(wh, rp.Subscription))
 }
 
 // updateWebhook handles the ARM PATCH (partial update): only properties present
@@ -87,7 +92,7 @@ func (h *ARMHandler) updateWebhook(w http.ResponseWriter, r *http.Request, rp *a
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toARMWebhook(wh, rp.Subscription))
+	azurearm.WriteJSON(w, http.StatusOK, toARMWebhookWithCallback(wh, rp.Subscription))
 }
 
 // applyWebhookProps copies the properties present in a PATCH body onto upd,
@@ -129,6 +134,33 @@ func (h *ARMHandler) getWebhook(w http.ResponseWriter, r *http.Request, rp *azur
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, toARMWebhook(wh, rp.Subscription))
+}
+
+// serveWebhookAction handles the POST action verbs under a named webhook. Only
+// getCallbackConfig is modeled — the sole read path for a webhook's serviceUri
+// and customHeaders.
+func (h *ARMHandler) serveWebhookAction(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if !strings.EqualFold(rp.SubResourceAction, "getCallbackConfig") {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"ACR webhook action not implemented: "+rp.SubResourceAction)
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		armMethodNotAllowed(w)
+		return
+	}
+
+	wh, err := h.mgr.GetWebhook(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armCallbackConfig{
+		ServiceURI:    wh.ServiceURI,
+		CustomHeaders: toPtrTags(wh.CustomHeaders),
+	})
 }
 
 func (h *ARMHandler) deleteWebhook(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {

--- a/services/containerregistry/driver/azure.go
+++ b/services/containerregistry/driver/azure.go
@@ -25,6 +25,10 @@ type AzureRegistryConfig struct {
 	// block: "SystemAssigned", "UserAssigned", "SystemAssigned, UserAssigned"
 	// or "None"/"" for no identity.
 	IdentityType string
+	// UserAssignedIdentities holds the user-assigned managed-identity resource
+	// IDs submitted in the identity block's userAssignedIdentities map. Only
+	// meaningful when IdentityType includes "UserAssigned".
+	UserAssignedIdentities []string
 }
 
 // AzureRegistryUpdate is the partial-update payload for an ACR registry (ARM
@@ -36,6 +40,17 @@ type AzureRegistryUpdate struct {
 	SKUName          *string
 	AdminUserEnabled *bool
 	IdentityType     *string
+	// UserAssignedIdentities is the user-assigned identity resource-ID set to
+	// apply when IdentityType is updated to include "UserAssigned"; nil leaves
+	// the stored identity untouched (only consulted when IdentityType is set).
+	UserAssignedIdentities []string
+}
+
+// AzureUserAssignedIdentity is the synthesized principal/client pair Azure
+// returns for each user-assigned managed identity attached to a resource.
+type AzureUserAssignedIdentity struct {
+	PrincipalID string
+	ClientID    string
 }
 
 // AzureRegistry is a stored/returned ACR registry resource.
@@ -56,6 +71,10 @@ type AzureRegistry struct {
 	IdentityType string
 	PrincipalID  string
 	TenantID     string
+	// UserAssignedIdentities maps each attached user-assigned identity resource
+	// ID to its synthesized principal/client pair; populated only when
+	// IdentityType includes "UserAssigned".
+	UserAssignedIdentities map[string]AzureUserAssignedIdentity
 }
 
 // AzureRegistryCredentials is the admin username / password pair returned by


### PR DESCRIPTION
## Summary

Fixes three real-user Azure Container Registry (`Microsoft.ContainerRegistry`) bugs, verified end-to-end against a booted `azureserver` and the real `armcontainerregistry` SDK.

### 1. UserAssigned identity map was dropped on GET (Terraform drift)
`PUT identity{type:UserAssigned, userAssignedIdentities:{<id>:{}}}` then GET returned the identity type but an empty `userAssignedIdentities` map, causing perpetual drift on `azurerm_container_registry.identity`. The map is a top-level field, so the property overlay could not rescue it.

- Added `UserAssignedIdentities` to the driver config/update/stored types plus `AzureUserAssignedIdentity{PrincipalID, ClientID}`.
- The provider synthesizes a deterministic principal/client pair per identity; the wire layer decodes the request map and echoes it on GET.
- SystemAssigned (principalId/tenantId) and combined `SystemAssigned,UserAssigned` still work; `None`/omitted yields no identity.

### 2. Webhook `serviceUri` + `customHeaders` leaked on plain GET
Real ACR `Webhooks_Get` returns only `{status, scope, actions, provisioningState}`; `serviceUri`/`customHeaders` are write-only and readable only via `getCallbackConfig`. Because `toARMWebhook` omitted them, the generic property overlay captured them from the create request and replayed them on every read — leaking a webhook `Authorization: Bearer` header.

- Model `serviceUri`/`customHeaders` on the create/update response (`toARMWebhookWithCallback`) so the overlay treats them as modeled and does not capture them.
- The plain read shape (`toARMWebhook`) still omits them, so GET/List no longer leak.

### 3. Webhook `getCallbackConfig` returned 405
`POST .../webhooks/{w}/getCallbackConfig` now returns `{serviceUri, customHeaders}` — the only supported read path for those two fields (Terraform `azurerm_container_registry_webhook` read calls it).

## Tests (real armcontainerregistry SDK)
- UserAssigned round-trip: GET echoes the map with deterministic principalId/clientId.
- SystemAssigned still works + combined type.
- Webhook create with `customHeaders{Authorization}`: raw plain GET contains no `serviceUri`/`customHeaders`/`Authorization`; `getCallbackConfig` returns them. (Confirmed the test fails without the fix.)
- #715 regression guard: registries `listCredentials` still returns admin passwords (not stripped).

## Gates
build, vet, scoped tests, `-race`, gofmt, `go generate` (zero diff), compatgen (zero `docs/compat` diff), golangci-lint (0 new) all green.