### PR TITLE
fix(azure-dns): RecordSets.ListByType, CNAME coexistence, apex SOA/NS delete protection, maxRecordSets=10000

### DIFF
--- a/providers/azure/dns/dns.go
+++ b/providers/azure/dns/dns.go
@@ -35,6 +35,10 @@ func New(opts *config.Options) *Mock {
 	}
 }
 
+// cnameType is the DNS CNAME record type. Azure enforces CNAME coexistence
+// rules against it (a CNAME cannot share a name with any other record set).
+const cnameType = "CNAME"
+
 // recordKey builds the key used to store a record in the memstore.
 // For weighted records (non-empty SetID), the SetID is appended.
 func recordKey(zoneID, name, recordType, setID string) string {
@@ -172,6 +176,11 @@ func (m *Mock) CreateRecord(_ context.Context, cfg driver.RecordConfig) (*driver
 		return nil, cerrors.New(cerrors.InvalidArgument, "record type is required")
 	}
 
+	if m.hasCNAMEConflict(cfg.ZoneID, cfg.Name, cfg.Type) {
+		return nil, cerrors.Newf(cerrors.InvalidArgument,
+			"a CNAME record set cannot coexist with another record set of a different type at name %q", cfg.Name)
+	}
+
 	key := recordKey(cfg.ZoneID, cfg.Name, cfg.Type, cfg.SetID)
 
 	if m.records.Has(key) {
@@ -204,6 +213,33 @@ func (m *Mock) CreateRecord(_ context.Context, cfg driver.RecordConfig) (*driver
 	result := rec
 
 	return &result, nil
+}
+
+// hasCNAMEConflict reports whether creating a record of recordType at name
+// would violate Azure's CNAME coexistence rule: a CNAME cannot share a name
+// with any other record set, and no other record set can share a name with a
+// CNAME. Both orders are checked. A same-type match (e.g. a second CNAME) is
+// not a coexistence conflict here — it is handled as AlreadyExists.
+func (m *Mock) hasCNAMEConflict(zoneID, name, recordType string) bool {
+	newIsCNAME := strings.EqualFold(recordType, cnameType)
+	existing := m.records.SortedValues()
+
+	for i := range existing {
+		r := &existing[i]
+		if r.ZoneID != zoneID || !strings.EqualFold(r.Name, name) {
+			continue
+		}
+
+		if strings.EqualFold(r.Type, recordType) {
+			continue
+		}
+
+		if newIsCNAME || strings.EqualFold(r.Type, cnameType) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // DeleteRecord deletes a DNS record set from the specified zone.

--- a/server/azure/dns/constraints_sdk_test.go
+++ b/server/azure/dns/constraints_sdk_test.go
@@ -1,0 +1,156 @@
+package dns_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
+)
+
+// TestSDKAzureDNSMaxNumberOfRecordSets asserts a public zone reports the real
+// Azure default record-set cap (10000), not the old 5000.
+func TestSDKAzureDNSMaxNumberOfRecordSets(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	const zone = "cap.com"
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, zone, armdns.Zone{Location: to.Ptr("global")}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	got, err := zones.Get(ctx, testRG, zone, nil)
+	if err != nil {
+		t.Fatalf("Zones.Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.MaxNumberOfRecordSets == nil {
+		t.Fatalf("maxNumberOfRecordSets missing: %+v", got.Properties)
+	}
+
+	if v := *got.Properties.MaxNumberOfRecordSets; v != 10000 {
+		t.Fatalf("maxNumberOfRecordSets = %d, want 10000", v)
+	}
+}
+
+// TestSDKAzureDNSListByType asserts RecordSets.ListByType returns the zone's
+// record sets of the requested type — previously a type-only GET fell through
+// to a single-record Get and 404'd.
+func TestSDKAzureDNSListByType(t *testing.T) {
+	zones, records := newDNSClients(t)
+	ctx := context.Background()
+
+	const zone = "bytype.com"
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, zone, armdns.Zone{Location: to.Ptr("global")}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	for _, name := range []string{"www", "api"} {
+		if _, err := records.CreateOrUpdate(ctx, testRG, zone, name, armdns.RecordTypeA, armdns.RecordSet{
+			Properties: &armdns.RecordSetProperties{
+				TTL:      to.Ptr(int64(300)),
+				ARecords: []*armdns.ARecord{{IPv4Address: to.Ptr("192.0.2.1")}},
+			},
+		}, nil); err != nil {
+			t.Fatalf("RecordSets.CreateOrUpdate %s: %v", name, err)
+		}
+	}
+
+	pager := records.NewListByTypePager(testRG, zone, armdns.RecordTypeA, nil)
+
+	var names []string
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListByType(A): %v", err)
+		}
+
+		for _, rs := range page.Value {
+			if rs.Type == nil || *rs.Type != "Microsoft.Network/dnsZones/A" {
+				t.Errorf("ListByType(A) returned a non-A record set: %+v", rs.Type)
+			}
+
+			names = append(names, *rs.Name)
+		}
+	}
+
+	if !contains(names, "www") || !contains(names, "api") {
+		t.Fatalf("ListByType(A) = %v, want to contain www and api", names)
+	}
+}
+
+// TestSDKAzureDNSCNAMECoexistence asserts Azure's CNAME coexistence rule in
+// both orders: a CNAME cannot be added where another type exists, and another
+// type cannot be added where a CNAME exists. Both must fail with 400.
+func TestSDKAzureDNSCNAMECoexistence(t *testing.T) {
+	zones, records := newDNSClients(t)
+	ctx := context.Background()
+
+	const zone = "coexist.com"
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, zone, armdns.Zone{Location: to.Ptr("global")}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	aSet := armdns.RecordSet{Properties: &armdns.RecordSetProperties{
+		TTL:      to.Ptr(int64(300)),
+		ARecords: []*armdns.ARecord{{IPv4Address: to.Ptr("192.0.2.1")}},
+	}}
+	cnameSet := armdns.RecordSet{Properties: &armdns.RecordSetProperties{
+		TTL:         to.Ptr(int64(300)),
+		CnameRecord: &armdns.CnameRecord{Cname: to.Ptr("target.example.com")},
+	}}
+
+	// A exists at "shop" → adding a CNAME at "shop" is rejected.
+	if _, err := records.CreateOrUpdate(ctx, testRG, zone, "shop", armdns.RecordTypeA, aSet, nil); err != nil {
+		t.Fatalf("seed A shop: %v", err)
+	}
+
+	if _, err := records.CreateOrUpdate(ctx, testRG, zone, "shop", armdns.RecordTypeCNAME, cnameSet, nil); !isStatus(err, 400) {
+		t.Fatalf("CNAME over existing A: got %v, want 400", err)
+	}
+
+	// CNAME exists at "blog" → adding an A at "blog" is rejected.
+	if _, err := records.CreateOrUpdate(ctx, testRG, zone, "blog", armdns.RecordTypeCNAME, cnameSet, nil); err != nil {
+		t.Fatalf("seed CNAME blog: %v", err)
+	}
+
+	if _, err := records.CreateOrUpdate(ctx, testRG, zone, "blog", armdns.RecordTypeA, aSet, nil); !isStatus(err, 400) {
+		t.Fatalf("A over existing CNAME: got %v, want 400", err)
+	}
+}
+
+// TestSDKAzureDNSDeleteApexSOAProtected asserts the auto-provisioned apex SOA
+// record set cannot be deleted, matching Azure.
+func TestSDKAzureDNSDeleteApexSOAProtected(t *testing.T) {
+	zones, records := newDNSClients(t)
+	ctx := context.Background()
+
+	const zone = "apex.com"
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, zone, armdns.Zone{Location: to.Ptr("global")}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	if _, err := records.Delete(ctx, testRG, zone, "@", armdns.RecordTypeSOA, nil); !isStatus(err, 400) {
+		t.Fatalf("Delete apex SOA: got %v, want 400", err)
+	}
+
+	// The apex NS record set is likewise protected.
+	if _, err := records.Delete(ctx, testRG, zone, "@", armdns.RecordTypeNS, nil); !isStatus(err, 400) {
+		t.Fatalf("Delete apex NS: got %v, want 400", err)
+	}
+}
+
+// isStatus reports whether err is an ARM response error carrying the given
+// HTTP status code.
+func isStatus(err error, code int) bool {
+	var respErr *azcore.ResponseError
+
+	return errors.As(err, &respErr) && respErr.StatusCode == code
+}

--- a/server/azure/dns/handler.go
+++ b/server/azure/dns/handler.go
@@ -135,6 +135,14 @@ func (h *Handler) serveRecordSetCollection(w http.ResponseWriter, r *http.Reques
 }
 
 func (h *Handler) serveRecordSet(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	// A type-only path (…/dnsZones/{zone}/{type} with no record name) is
+	// RecordSets.ListByType — a type-filtered list of the zone's record sets,
+	// not a single-record Get.
+	if rp.SubResourceName == "" && r.Method == http.MethodGet {
+		h.listRecordSetsByType(w, r, rp)
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPut:
 		h.createOrUpdateRecordSet(w, r, rp)

--- a/server/azure/dns/operations.go
+++ b/server/azure/dns/operations.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
@@ -209,13 +210,24 @@ func (h *Handler) getRecordSet(w http.ResponseWriter, r *http.Request, rp *azure
 }
 
 func (h *Handler) deleteRecordSet(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	recordType := recordTypeSegment(rp.SubResource)
+
+	// Azure auto-creates the apex SOA and NS record sets with the zone and
+	// forbids deleting them; the zone must own an SOA and its apex NS for its
+	// lifetime. Reject the delete rather than orphaning the zone.
+	if isApexProtectedRecord(rp.SubResourceName, recordType) {
+		azurearm.WriteError(w, http.StatusBadRequest, "BadRequest",
+			"the record set of type "+recordType+" at the zone apex cannot be deleted")
+		return
+	}
+
 	zoneID, err := h.resolveZoneID(r.Context(), rp)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
-	derr := h.dns.DeleteRecord(r.Context(), zoneID, rp.SubResourceName, recordTypeSegment(rp.SubResource))
+	derr := h.dns.DeleteRecord(r.Context(), zoneID, rp.SubResourceName, recordType)
 	if derr != nil && !cerrors.IsNotFound(derr) {
 		azurearm.WriteCErr(w, derr)
 		return
@@ -231,7 +243,22 @@ func (h *Handler) deleteRecordSet(w http.ResponseWriter, r *http.Request, rp *az
 	w.WriteHeader(http.StatusOK)
 }
 
+// listRecordSets backs RecordSets.ListByDnsZone / ListAllByDnsZone: every
+// record set in the zone, unfiltered.
 func (h *Handler) listRecordSets(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	h.writeRecordSetList(w, r, rp, "")
+}
+
+// listRecordSetsByType backs RecordSets.ListByType: the zone's record sets of
+// the single type named in the URL (…/dnsZones/{zone}/{type}).
+func (h *Handler) listRecordSetsByType(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	h.writeRecordSetList(w, r, rp, recordTypeSegment(rp.SubResource))
+}
+
+// writeRecordSetList lists a zone's record sets, optionally filtered to a
+// single record type. An empty filterType returns every record set.
+func (h *Handler) writeRecordSetList(w http.ResponseWriter, r *http.Request,
+	rp *azurearm.ResourcePath, filterType string) {
 	zoneID, err := h.resolveZoneID(r.Context(), rp)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
@@ -245,7 +272,12 @@ func (h *Handler) listRecordSets(w http.ResponseWriter, r *http.Request, rp *azu
 	}
 
 	out := make([]recordSetJSON, 0, len(records))
+
 	for i := range records {
+		if filterType != "" && !strings.EqualFold(records[i].Type, filterType) {
+			continue
+		}
+
 		out = append(out, toRecordSetJSON(rp, rp.ResourceName, &records[i]))
 	}
 

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -29,8 +29,8 @@ const (
 	recTypeSOA   = "SOA"
 
 	// maxNumberOfRecordSets is the fixed per-zone record-set cap Azure DNS
-	// reports (a read-only property).
-	maxNumberOfRecordSets = 5000
+	// reports for a public zone (a read-only property).
+	maxNumberOfRecordSets = 10000
 	// maxNumberOfRecordsPerRecordSet is the fixed per-record-set record cap
 	// Azure DNS reports (read-only).
 	maxNumberOfRecordsPerRecordSet = 20
@@ -391,6 +391,18 @@ func ttlOrDefault(props *recordSetProperties) int {
 // upper-case type the driver stores.
 func recordTypeSegment(s string) string {
 	return strings.ToUpper(s)
+}
+
+// isApexProtectedRecord reports whether the record set is the apex SOA or NS
+// that Azure DNS auto-provisions with every zone and forbids deleting. name is
+// the relative record name from the URL ("@" for the apex); recordType is the
+// canonical upper-case type.
+func isApexProtectedRecord(name, recordType string) bool {
+	if name != apexRecordName {
+		return false
+	}
+
+	return recordType == recTypeSOA || recordType == recTypeNS
 }
 
 // resolveZoneID maps the SDK-facing zone name to the driver's internal zone id


### PR DESCRIPTION
## Summary

Fixes four Azure DNS (Microsoft.Network/dnsZones) fidelity gaps against the real armdns SDK, verified end-to-end through a booted azureserver + real `armdns` client.

- **RecordSets.ListByType (MED, functional):** A type-only GET `.../dnsZones/{zone}/{type}` (no record name) parsed with an empty record name and was routed to `getRecordSet` → `GetRecord(zone,"",type)` → 404. It now routes to a type-filtered list of the zone's record sets, matching `RecordSets.ListByType`. `ListByDnsZone`/`ListAllByDnsZone` share the same list machinery via a new `writeRecordSetList(filterType)` helper (no new duplication).
- **CNAME coexistence (LOW):** The Azure Mock's `CreateRecord` now rejects (400) a CNAME at a name that already holds another record type, and any other type at a name that already holds a CNAME (both orders). Same-type collisions remain `AlreadyExists`.
- **Apex SOA/NS delete protection (LOW):** `deleteRecordSet` now rejects deleting the auto-provisioned apex SOA and apex NS record sets (name `@`) with a 400, matching Azure.
- **maxNumberOfRecordSets (LOW, cosmetic):** Corrected the reported public-zone cap from 5000 to 10000.

## Tests

New real-`armdns` SDK e2e tests in `server/azure/dns/constraints_sdk_test.go`:
- `ListByType(A)` returns the zone's A record sets (not 404)
- CNAME-over-A and A-over-CNAME both 400
- Delete apex SOA and apex NS both 400
- `maxNumberOfRecordSets == 10000` on zone GET

Existing round-trip / list-by-zone / apex auto-provision / idempotent-delete tests remain green.

## Not in scope (deferred)

PATCH Update, ETag If-Match/If-None-Match, privateDnsZones, list `$top`/nextLink pagination, and 201-vs-200 status are intentionally untouched.