### PR TITLE
fix(gcp-loadbalancer): round-trip backends/target/cdn, scope-aware keying, list filter+pagination, patch/update verbs

### DIFF
--- a/docs/coverage/aws/elb.md
+++ b/docs/coverage/aws/elb.md
@@ -64,6 +64,7 @@ GCPComputeResourceStore is an OPTIONAL, type-asserted capability implemented
 | `GetGCPResource` | GetGCPResource returns the stored resource, or NotFound. |
 | `ListGCPResources` | ListGCPResources returns every resource in a (collection, scope) bucket. |
 | `PutGCPResource` | PutGCPResource stores res, returning AlreadyExists when a resource with |
+| `UpdateGCPResource` | UpdateGCPResource applies mutate to the stored resource in place under the |
 
 ### LBAttributeUpdater
 

--- a/docs/coverage/azure/lb.md
+++ b/docs/coverage/azure/lb.md
@@ -64,6 +64,7 @@ GCPComputeResourceStore is an OPTIONAL, type-asserted capability implemented
 | `GetGCPResource` | GetGCPResource returns the stored resource, or NotFound. |
 | `ListGCPResources` | ListGCPResources returns every resource in a (collection, scope) bucket. |
 | `PutGCPResource` | PutGCPResource stores res, returning AlreadyExists when a resource with |
+| `UpdateGCPResource` | UpdateGCPResource applies mutate to the stored resource in place under the |
 
 ### LBAttributeUpdater
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -5783,6 +5783,10 @@
           {
             "name": "PutGCPResource",
             "doc": "PutGCPResource stores res, returning AlreadyExists when a resource with"
+          },
+          {
+            "name": "UpdateGCPResource",
+            "doc": "UpdateGCPResource applies mutate to the stored resource in place under the"
           }
         ]
       },

--- a/docs/coverage/gcp/lb.md
+++ b/docs/coverage/gcp/lb.md
@@ -64,6 +64,7 @@ GCPComputeResourceStore is an OPTIONAL, type-asserted capability implemented
 | `GetGCPResource` | GetGCPResource returns the stored resource, or NotFound. |
 | `ListGCPResources` | ListGCPResources returns every resource in a (collection, scope) bucket. |
 | `PutGCPResource` | PutGCPResource stores res, returning AlreadyExists when a resource with |
+| `UpdateGCPResource` | UpdateGCPResource applies mutate to the stored resource in place under the |
 
 ### LBAttributeUpdater
 

--- a/providers/gcp/loadbalancer/gcp_resources.go
+++ b/providers/gcp/loadbalancer/gcp_resources.go
@@ -61,6 +61,23 @@ func (m *Mock) DeleteGCPResource(_ context.Context, collection, scope, name stri
 	return nil
 }
 
+// UpdateGCPResource applies mutate to the stored opaque resource in place,
+// holding the store lock across the read-modify-write. Returns NotFound when no
+// resource with the (collection, scope, name) triple exists.
+func (m *Mock) UpdateGCPResource(_ context.Context, collection, scope, name string, mutate func(*driver.GCPResource)) error {
+	key := gcpResourceKey(collection, scope, name)
+
+	updated := m.gcpResources.Update(key, func(res driver.GCPResource) driver.GCPResource {
+		mutate(&res)
+		return res
+	})
+	if !updated {
+		return cerrors.Newf(cerrors.NotFound, "%s %q not found", collection, name)
+	}
+
+	return nil
+}
+
 // PatchGCPBackendService applies mutate to the target group named name, holding
 // the store lock across the read-modify-write. Returns NotFound when no backend
 // service with that name exists.

--- a/server/gcp/loadbalancer/backendservices_sdk_test.go
+++ b/server/gcp/loadbalancer/backendservices_sdk_test.go
@@ -2,14 +2,36 @@ package loadbalancer_test
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
 	"testing"
 
 	gcpcompute "cloud.google.com/go/compute/apiv1"
 	computepb "cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
 
 func ptrI32(v int32) *int32 { return &v }
+
+func ptrF32(v float32) *float32 { return &v }
+
+func ptrBool(v bool) *bool { return &v }
+
+func newBackendServicesClient(t *testing.T, url string, httpc option.ClientOption) *gcpcompute.BackendServicesClient {
+	t.Helper()
+
+	client, err := gcpcompute.NewBackendServicesRESTClient(context.Background(),
+		option.WithEndpoint(url), option.WithoutAuthentication(), httpc)
+	if err != nil {
+		t.Fatalf("NewBackendServicesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
 
 // TestSDKGCPBackendServicePatch reproduces the [BLOCKER] finding that
 // compute.backendServices.patch returned 405 (no update path), leaving the
@@ -171,5 +193,272 @@ func TestSDKGCPBackendServiceDuplicate(t *testing.T) {
 
 	if err := insert(); err == nil {
 		t.Fatal("second insert of duplicate name: want error, got nil")
+	}
+}
+
+// TestSDKGCPBackendServiceBackendsRoundTrip covers the round-trip drops for a
+// google_compute_backend_service: backends[] (group/balancingMode/
+// capacityScaler), connectionDraining, cdnPolicy and enableCDN were all dropped
+// on get, guaranteeing perpetual Terraform drift.
+func TestSDKGCPBackendServiceBackendsRoundTrip(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	client := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+
+	group := "projects/" + testProject + "/zones/us-central1-a/instanceGroups/ig-1"
+
+	op, err := client.Insert(ctx, &computepb.InsertBackendServiceRequest{
+		Project: testProject,
+		BackendServiceResource: &computepb.BackendService{
+			Name:                ptrStr("cdn-bs"),
+			Protocol:            ptrStr("HTTP"),
+			LoadBalancingScheme: ptrStr("EXTERNAL_MANAGED"),
+			Backends: []*computepb.Backend{{
+				Group:          ptrStr(group),
+				BalancingMode:  ptrStr("UTILIZATION"),
+				CapacityScaler: ptrF32(0.5),
+			}},
+			ConnectionDraining: &computepb.ConnectionDraining{DrainingTimeoutSec: ptrI32(45)},
+			EnableCDN:          ptrBool(true),
+			CdnPolicy: &computepb.BackendServiceCdnPolicy{
+				CacheMode:  ptrStr("CACHE_ALL_STATIC"),
+				DefaultTtl: ptrI32(3600),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetBackendServiceRequest{Project: testProject, BackendService: "cdn-bs"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	backends := got.GetBackends()
+	if len(backends) != 1 {
+		t.Fatalf("backends len = %d, want 1 (backends[] dropped)", len(backends))
+	}
+
+	if backends[0].GetGroup() != group {
+		t.Errorf("backend group = %q, want %q", backends[0].GetGroup(), group)
+	}
+
+	if backends[0].GetBalancingMode() != "UTILIZATION" {
+		t.Errorf("balancingMode = %q, want UTILIZATION", backends[0].GetBalancingMode())
+	}
+
+	if backends[0].GetCapacityScaler() != 0.5 {
+		t.Errorf("capacityScaler = %v, want 0.5", backends[0].GetCapacityScaler())
+	}
+
+	if got.GetConnectionDraining().GetDrainingTimeoutSec() != 45 {
+		t.Errorf("drainingTimeoutSec = %d, want 45", got.GetConnectionDraining().GetDrainingTimeoutSec())
+	}
+
+	if !got.GetEnableCDN() {
+		t.Error("enableCDN = false, want true")
+	}
+
+	if got.GetCdnPolicy().GetCacheMode() != "CACHE_ALL_STATIC" {
+		t.Errorf("cdnPolicy.cacheMode = %q, want CACHE_ALL_STATIC", got.GetCdnPolicy().GetCacheMode())
+	}
+
+	if got.GetCdnPolicy().GetDefaultTtl() != 3600 {
+		t.Errorf("cdnPolicy.defaultTtl = %d, want 3600", got.GetCdnPolicy().GetDefaultTtl())
+	}
+}
+
+// insertBS is a small create helper for the list tests below.
+func insertBS(ctx context.Context, t *testing.T, client *gcpcompute.BackendServicesClient, name string) {
+	t.Helper()
+
+	op, err := client.Insert(ctx, &computepb.InsertBackendServiceRequest{
+		Project:                testProject,
+		BackendServiceResource: &computepb.BackendService{Name: ptrStr(name), Protocol: ptrStr("TCP")},
+	})
+	if err != nil {
+		t.Fatalf("Insert %s: %v", name, err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("Insert %s wait: %v", name, err)
+	}
+}
+
+func listBSNames(t *testing.T, it *gcpcompute.BackendServiceIterator) []string {
+	t.Helper()
+
+	var names []string
+
+	for {
+		bs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+
+		names = append(names, bs.GetName())
+	}
+
+	return names
+}
+
+// TestSDKGCPBackendServiceListFilter covers the list filter defect: List with a
+// "name eq" filter must return only the matching backend service.
+func TestSDKGCPBackendServiceListFilter(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	client := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+
+	for _, n := range []string{"bs-a", "bs-b", "bs-c"} {
+		insertBS(ctx, t, client, n)
+	}
+
+	it := client.List(ctx, &computepb.ListBackendServicesRequest{
+		Project: testProject,
+		Filter:  ptrStr(`name eq "bs-b"`),
+	})
+
+	names := listBSNames(t, it)
+	if len(names) != 1 || names[0] != "bs-b" {
+		t.Fatalf("filtered list = %v, want [bs-b]", names)
+	}
+}
+
+// TestSDKGCPBackendServiceListPagination covers the pagination defect: a page
+// size of 1 must walk every backend service via nextPageToken, returning them
+// all exactly once.
+func TestSDKGCPBackendServiceListPagination(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	client := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+
+	want := []string{"pg-a", "pg-b", "pg-c"}
+	for _, n := range want {
+		insertBS(ctx, t, client, n)
+	}
+
+	it := client.List(ctx, &computepb.ListBackendServicesRequest{
+		Project:    testProject,
+		MaxResults: func() *uint32 { v := uint32(1); return &v }(),
+	})
+
+	names := listBSNames(t, it)
+	if len(names) != len(want) {
+		t.Fatalf("paginated list = %v, want %v (page token not followed)", names, want)
+	}
+
+	seen := map[string]int{}
+	for _, n := range names {
+		seen[n]++
+	}
+
+	for _, n := range want {
+		if seen[n] != 1 {
+			t.Errorf("%s seen %d times, want exactly 1", n, seen[n])
+		}
+	}
+}
+
+// TestSDKGCPBackendServiceRegionalScope covers the scope-collision defect: a
+// global and a regional backend service of the same name must coexist, each
+// re-emitted at its own scope, and a regional insert's Operation must carry the
+// region self-link.
+func TestSDKGCPBackendServiceRegionalScope(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	const region = "us-central1"
+
+	global := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+	insertBS(ctx, t, global, "shared-bs")
+
+	regional, err := gcpcompute.NewRegionBackendServicesRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewRegionBackendServicesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = regional.Close() })
+
+	rOp, err := regional.Insert(ctx, &computepb.InsertRegionBackendServiceRequest{
+		Project:                testProject,
+		Region:                 region,
+		BackendServiceResource: &computepb.BackendService{Name: ptrStr("shared-bs"), Protocol: ptrStr("TCP")},
+	})
+	if err != nil {
+		t.Fatalf("regional Insert: %v", err)
+	}
+
+	if err := rOp.Wait(ctx); err != nil {
+		t.Fatalf("regional Insert wait: %v", err)
+	}
+
+	// Both records must survive: the global create was not clobbered, and the
+	// regional read resolves to its own scope.
+	gGot, err := global.Get(ctx, &computepb.GetBackendServiceRequest{Project: testProject, BackendService: "shared-bs"})
+	if err != nil {
+		t.Fatalf("global Get: %v", err)
+	}
+
+	if !strings.Contains(gGot.GetSelfLink(), "/global/backendServices/shared-bs") {
+		t.Errorf("global selfLink = %q, want a /global/ link", gGot.GetSelfLink())
+	}
+
+	rGot, err := regional.Get(ctx, &computepb.GetRegionBackendServiceRequest{
+		Project: testProject, Region: region, BackendService: "shared-bs",
+	})
+	if err != nil {
+		t.Fatalf("regional Get: %v", err)
+	}
+
+	if !strings.Contains(rGot.GetSelfLink(), "/regions/"+region+"/backendServices/shared-bs") {
+		t.Errorf("regional selfLink = %q, want a /regions/%s/ link", rGot.GetSelfLink(), region)
+	}
+
+	assertRegionalOpCarriesRegion(t, ts.Client(), ts.URL, region)
+}
+
+// assertRegionalOpCarriesRegion issues a raw regional insert and checks the
+// returned Operation is DONE and carries the region self-link, which the async
+// SDK poller needs to resolve a regional operation.
+func assertRegionalOpCarriesRegion(t *testing.T, httpc *http.Client, base, region string) {
+	t.Helper()
+
+	url := base + "/compute/v1/projects/" + testProject + "/regions/" + region + "/backendServices"
+
+	resp, err := httpc.Post(url, "application/json", strings.NewReader(`{"name":"raw-rbs","protocol":"TCP"}`))
+	if err != nil {
+		t.Fatalf("raw regional insert: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	var op struct {
+		Status string `json:"status"`
+		Region string `json:"region"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&op); err != nil {
+		t.Fatalf("decode operation: %v", err)
+	}
+
+	if op.Status != "DONE" {
+		t.Errorf("operation status = %q, want DONE", op.Status)
+	}
+
+	if !strings.Contains(op.Region, "/regions/"+region) {
+		t.Errorf("operation region = %q, want a /regions/%s link", op.Region, region)
 	}
 }

--- a/server/gcp/loadbalancer/forwardingrules_sdk_test.go
+++ b/server/gcp/loadbalancer/forwardingrules_sdk_test.go
@@ -108,3 +108,42 @@ func TestSDKGCPForwardingRuleDuplicate(t *testing.T) {
 		t.Fatal("duplicate forwarding rule insert: want error, got nil")
 	}
 }
+
+// TestSDKGCPForwardingRuleTargetRoundTrip covers the dropped-target defect: a
+// forwarding rule's target (the proxy/service it fronts) was never stored, so on
+// get the load balancer had no entrypoint and Terraform saw perpetual drift.
+func TestSDKGCPForwardingRuleTargetRoundTrip(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	client := newForwardingRulesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+
+	target := "projects/" + testProject + "/global/targetHttpProxies/web-proxy"
+
+	op, err := client.Insert(ctx, &computepb.InsertGlobalForwardingRuleRequest{
+		Project: testProject,
+		ForwardingRuleResource: &computepb.ForwardingRule{
+			Name:                ptrStr("proxy-fr"),
+			IPProtocol:          ptrStr("TCP"),
+			PortRange:           ptrStr("80"),
+			Target:              ptrStr(target),
+			LoadBalancingScheme: ptrStr("EXTERNAL_MANAGED"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetGlobalForwardingRuleRequest{Project: testProject, ForwardingRule: "proxy-fr"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetTarget() != target {
+		t.Errorf("target = %q, want %q (dropped on get)", got.GetTarget(), target)
+	}
+}

--- a/server/gcp/loadbalancer/handler.go
+++ b/server/gcp/loadbalancer/handler.go
@@ -127,7 +127,7 @@ func (h *Handler) routeBackendServices(w http.ResponseWriter, r *http.Request, r
 	}
 }
 
-//nolint:gocritic,dupl // rp is a request-scoped value; CRUD route shape is duplicate-by-design across resource types
+//nolint:gocritic // rp is a request-scoped value
 func (h *Handler) routeForwardingRules(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
 	if rp.ResourceName == "" {
 		switch r.Method {

--- a/server/gcp/loadbalancer/healthchecks_sdk_test.go
+++ b/server/gcp/loadbalancer/healthchecks_sdk_test.go
@@ -118,3 +118,62 @@ func TestSDKGCPHealthCheckRoundTrip(t *testing.T) {
 		t.Fatal("Get after delete: want error, got nil")
 	}
 }
+
+// TestSDKGCPHealthCheckPatch covers the missing PATCH verb: healthChecks.patch
+// previously 405'd, breaking terraform apply on any change. The patch must merge
+// onto the stored resource and be visible on the next get.
+func TestSDKGCPHealthCheckPatch(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewHealthChecksRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewHealthChecksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertHealthCheckRequest{
+		Project: testProject,
+		HealthCheckResource: &computepb.HealthCheck{
+			Name:             ptrStr("hc-patch"),
+			Type:             ptrStr("HTTP"),
+			CheckIntervalSec: ptrI32(5),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	patchOp, err := client.Patch(ctx, &computepb.PatchHealthCheckRequest{
+		Project:             testProject,
+		HealthCheck:         "hc-patch",
+		HealthCheckResource: &computepb.HealthCheck{CheckIntervalSec: ptrI32(15)},
+	})
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	if err := patchOp.Wait(ctx); err != nil {
+		t.Fatalf("Patch wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetHealthCheckRequest{Project: testProject, HealthCheck: "hc-patch"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetCheckIntervalSec() != 15 {
+		t.Errorf("checkIntervalSec = %d, want 15 (patch not applied)", got.GetCheckIntervalSec())
+	}
+
+	// A field omitted from the patch body must survive the merge.
+	if got.GetType() != "HTTP" {
+		t.Errorf("type = %q, want HTTP (patch clobbered an omitted field)", got.GetType())
+	}
+}

--- a/server/gcp/loadbalancer/operations.go
+++ b/server/gcp/loadbalancer/operations.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/json"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
 )
@@ -29,15 +32,20 @@ func (h *Handler) insertBackendService(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
-	if _, err := h.findTGByName(r.Context(), req.Name); conflictIfExists(w, err, "backend service "+req.Name+" already exists") {
+	if _, err := h.findTGByName(r.Context(), rp, req.Name); conflictIfExists(w, err, "backend service "+req.Name+" already exists") {
 		return
 	}
 
 	tags := backendServiceTags(&req)
 	tags[bsCreationTag] = time.Now().UTC().Format(time.RFC3339)
+	tags[bsNameTag] = req.Name
+	tags[bsScopeTag] = scopeKeyOf(rp)
 
 	if _, err := h.lb.CreateTargetGroup(r.Context(), lbdriver.TargetGroupConfig{
-		Name:     req.Name,
+		// A scope-prefixed driver name keeps a global and a regional backend
+		// service of the same name in distinct store slots (the driver keys by
+		// name); the client-facing name is preserved in bsNameTag.
+		Name:     scopedDriverName(rp, req.Name),
 		Protocol: req.Protocol,
 		Port:     req.Port,
 		// The driver TargetGroup can't hold these GCP fields, so round-trip them
@@ -48,7 +56,7 @@ func (h *Handler) insertBackendService(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName,
 		resourceBackendServices, req.Name, "insert")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -72,7 +80,7 @@ func (h *Handler) patchBackendService(w http.ResponseWriter, r *http.Request, rp
 		return
 	}
 
-	err := patcher.PatchGCPBackendService(r.Context(), rp.ResourceName, func(tg *lbdriver.TargetGroupInfo) {
+	err := patcher.PatchGCPBackendService(r.Context(), scopedDriverName(rp, rp.ResourceName), func(tg *lbdriver.TargetGroupInfo) {
 		if req.Protocol != "" {
 			tg.Protocol = req.Protocol
 		}
@@ -92,7 +100,7 @@ func (h *Handler) patchBackendService(w http.ResponseWriter, r *http.Request, rp
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName,
 		resourceBackendServices, rp.ResourceName, "patch")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -100,7 +108,7 @@ func (h *Handler) patchBackendService(w http.ResponseWriter, r *http.Request, rp
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) getBackendService(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	tg, err := h.findTGByName(r.Context(), rp.ResourceName)
+	tg, err := h.findTGByName(r.Context(), rp, rp.ResourceName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -118,14 +126,38 @@ func (h *Handler) listBackendServices(w http.ResponseWriter, r *http.Request, rp
 	}
 
 	host := hostOf(r)
-	out := backendServiceListResponse{
-		Kind:     "compute#backendServiceList",
-		ID:       "projects/" + rp.Project + "/global/backendServices",
-		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", resourceBackendServices, ""),
-	}
+	scopeKey := scopeKeyOf(rp)
+	filter := r.URL.Query().Get("filter")
+
+	items := make([]backendServiceResponse, 0, len(tgs))
 
 	for i := range tgs {
-		out.Items = append(out.Items, toBackendServiceResponse(&tgs[i], rp, host))
+		// A global list must not leak regional backend services (and vice versa),
+		// so select only this scope's records before filtering by name.
+		if tgs[i].Tags[bsScopeTag] != scopeKey {
+			continue
+		}
+
+		if resp := toBackendServiceResponse(&tgs[i], rp, host); gcprest.NameMatches(filter, resp.Name) {
+			items = append(items, resp)
+		}
+	}
+
+	sort.SliceStable(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+
+	page, err := pagination.Paginate(items, r.URL.Query().Get("pageToken"),
+		gcprest.MaxResults(r.URL.Query().Get("maxResults")))
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid pageToken")
+		return
+	}
+
+	out := backendServiceListResponse{
+		Kind:          "compute#backendServiceList",
+		ID:            "projects/" + rp.Project + "/" + listScopeSegment(rp) + "/backendServices",
+		Items:         page.Items,
+		NextPageToken: page.NextPageToken,
+		SelfLink:      gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, resourceBackendServices, ""),
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, out)
@@ -133,7 +165,7 @@ func (h *Handler) listBackendServices(w http.ResponseWriter, r *http.Request, rp
 
 //nolint:gocritic,dupl // rp is a request-scoped value; CRUD delete shape is duplicate-by-design across resource types
 func (h *Handler) deleteBackendService(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	tg, err := h.findTGByName(r.Context(), rp.ResourceName)
+	tg, err := h.findTGByName(r.Context(), rp, rp.ResourceName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -144,7 +176,7 @@ func (h *Handler) deleteBackendService(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName,
 		resourceBackendServices, rp.ResourceName, "delete")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -165,17 +197,23 @@ func (h *Handler) insertForwardingRule(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
-	if _, err := h.findLBByName(r.Context(), req.Name); conflictIfExists(w, err, "forwarding rule "+req.Name+" already exists") {
+	if _, err := h.findLBByName(r.Context(), rp, req.Name); conflictIfExists(w, err, "forwarding rule "+req.Name+" already exists") {
 		return
 	}
 
+	tags := forwardingRuleTags(&req)
+	tags[frNameTag] = req.Name
+	tags[frScopeTag] = scopeKeyOf(rp)
+
 	lb, err := h.lb.CreateLoadBalancer(r.Context(), lbdriver.LBConfig{
-		Name:   req.Name,
+		// A scope-prefixed driver name keeps a global and a regional forwarding
+		// rule of the same name distinct; the client-facing name lives in frNameTag.
+		Name:   scopedDriverName(rp, req.Name),
 		Type:   "network",
 		Scheme: schemeFromRule(&req),
 		// Round-trip the GCP forwarding-rule fields the driver LB can't model
-		// (exact scheme, portRange, IPProtocol, IPAddress, …) through tags.
-		Tags: forwardingRuleTags(&req),
+		// (exact scheme, portRange, IPProtocol, IPAddress, target, …) through tags.
+		Tags: tags,
 	})
 	if err != nil {
 		gcprest.WriteCErr(w, err)
@@ -187,7 +225,7 @@ func (h *Handler) insertForwardingRule(w http.ResponseWriter, r *http.Request, r
 	// non-existent backend service is an error (as in real GCP), and a failed
 	// link must not be swallowed into a phantom success.
 	if bsName := backendServiceName(req.BackendService); bsName != "" {
-		tg, ferr := h.findTGByName(r.Context(), bsName)
+		tg, ferr := h.findTGByName(r.Context(), rp, bsName)
 		if ferr != nil {
 			gcprest.WriteCErr(w, ferr)
 			return
@@ -204,7 +242,7 @@ func (h *Handler) insertForwardingRule(w http.ResponseWriter, r *http.Request, r
 		}
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName,
 		resourceForwardingRules, req.Name, "insert")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -212,7 +250,7 @@ func (h *Handler) insertForwardingRule(w http.ResponseWriter, r *http.Request, r
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) getForwardingRule(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	lb, err := h.findLBByName(r.Context(), rp.ResourceName)
+	lb, err := h.findLBByName(r.Context(), rp, rp.ResourceName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -230,14 +268,36 @@ func (h *Handler) listForwardingRules(w http.ResponseWriter, r *http.Request, rp
 	}
 
 	host := hostOf(r)
-	out := forwardingRuleListResponse{
-		Kind:     "compute#forwardingRuleList",
-		ID:       "projects/" + rp.Project + "/global/forwardingRules",
-		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", resourceForwardingRules, ""),
-	}
+	scopeKey := scopeKeyOf(rp)
+	filter := r.URL.Query().Get("filter")
+
+	items := make([]forwardingRuleResponse, 0, len(lbs))
 
 	for i := range lbs {
-		out.Items = append(out.Items, h.toForwardingRuleResponse(r.Context(), &lbs[i], rp, host))
+		if lbs[i].Tags[frScopeTag] != scopeKey {
+			continue
+		}
+
+		if resp := h.toForwardingRuleResponse(r.Context(), &lbs[i], rp, host); gcprest.NameMatches(filter, resp.Name) {
+			items = append(items, resp)
+		}
+	}
+
+	sort.SliceStable(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+
+	page, err := pagination.Paginate(items, r.URL.Query().Get("pageToken"),
+		gcprest.MaxResults(r.URL.Query().Get("maxResults")))
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid pageToken")
+		return
+	}
+
+	out := forwardingRuleListResponse{
+		Kind:          "compute#forwardingRuleList",
+		ID:            "projects/" + rp.Project + "/" + listScopeSegment(rp) + "/forwardingRules",
+		Items:         page.Items,
+		NextPageToken: page.NextPageToken,
+		SelfLink:      gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, resourceForwardingRules, ""),
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, out)
@@ -245,7 +305,7 @@ func (h *Handler) listForwardingRules(w http.ResponseWriter, r *http.Request, rp
 
 //nolint:gocritic,dupl // rp is a request-scoped value; CRUD delete shape is duplicate-by-design across resource types
 func (h *Handler) deleteForwardingRule(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	lb, err := h.findLBByName(r.Context(), rp.ResourceName)
+	lb, err := h.findLBByName(r.Context(), rp, rp.ResourceName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -256,7 +316,7 @@ func (h *Handler) deleteForwardingRule(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName,
 		resourceForwardingRules, rp.ResourceName, "delete")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -264,14 +324,35 @@ func (h *Handler) deleteForwardingRule(w http.ResponseWriter, r *http.Request, r
 
 // --- lookups + response shaping ---
 
-func (h *Handler) findTGByName(ctx context.Context, name string) (*lbdriver.TargetGroupInfo, error) {
+// scopeSep separates the scope key from the client name in a scope-prefixed
+// driver key. A NUL byte can't appear in a GCP resource name, so it can't
+// collide with a legitimate name segment.
+const scopeSep = "\x00"
+
+// scopedDriverName maps a client-facing name to the scope-qualified name used
+// as the driver's store key. Global resources keep their plain name (so
+// existing global links stay stable); regional ones are prefixed with the
+// region so a same-name global/regional pair does not collide.
+//
+//nolint:gocritic // rp is a request-scoped value
+func scopedDriverName(rp gcprest.ResourcePath, name string) string {
+	if rp.Scope == gcprest.ScopeGlobal {
+		return name
+	}
+
+	return scopeKeyOf(rp) + scopeSep + name
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) findTGByName(ctx context.Context, rp gcprest.ResourcePath, name string) (*lbdriver.TargetGroupInfo, error) {
 	tgs, err := h.lb.DescribeTargetGroups(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
+	key := scopedDriverName(rp, name)
 	for i := range tgs {
-		if tgs[i].Name == name {
+		if tgs[i].Name == key {
 			return &tgs[i], nil
 		}
 	}
@@ -279,14 +360,16 @@ func (h *Handler) findTGByName(ctx context.Context, name string) (*lbdriver.Targ
 	return nil, cerrors.Newf(cerrors.NotFound, "backend service %q not found", name)
 }
 
-func (h *Handler) findLBByName(ctx context.Context, name string) (*lbdriver.LBInfo, error) {
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) findLBByName(ctx context.Context, rp gcprest.ResourcePath, name string) (*lbdriver.LBInfo, error) {
 	lbs, err := h.lb.DescribeLoadBalancers(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
+	key := scopedDriverName(rp, name)
 	for i := range lbs {
-		if lbs[i].Name == name {
+		if lbs[i].Name == key {
 			return &lbs[i], nil
 		}
 	}
@@ -296,13 +379,14 @@ func (h *Handler) findLBByName(ctx context.Context, name string) (*lbdriver.LBIn
 
 //nolint:gocritic // rp is a request-scoped value
 func toBackendServiceResponse(tg *lbdriver.TargetGroupInfo, rp gcprest.ResourcePath, host string) backendServiceResponse {
+	name := displayName(tg.Tags, bsNameTag, tg.Name)
 	resp := backendServiceResponse{
 		Kind:     "compute#backendService",
 		ID:       numericID(tg.ID),
-		Name:     tg.Name,
+		Name:     name,
 		Protocol: tg.Protocol,
 		Port:     tg.Port,
-		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", resourceBackendServices, tg.Name),
+		SelfLink: gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, resourceBackendServices, name),
 	}
 
 	resp.Description = tg.Tags[bsDescriptionTag]
@@ -312,7 +396,7 @@ func toBackendServiceResponse(tg *lbdriver.TargetGroupInfo, rp gcprest.ResourceP
 	resp.CreationTimestamp = tg.Tags[bsCreationTag]
 	// A non-empty fingerprint is required for every future patch; real GCP always
 	// returns one, so derive a stable value from the resource name.
-	resp.Fingerprint = fingerprintOf(tg.Name)
+	resp.Fingerprint = fingerprintOf(name)
 
 	if ts := tg.Tags[bsTimeoutSecTag]; ts != "" {
 		if n, err := strconv.Atoi(ts); err == nil {
@@ -324,7 +408,50 @@ func toBackendServiceResponse(tg *lbdriver.TargetGroupInfo, rp gcprest.ResourceP
 		resp.HealthChecks = strings.Split(hc, ",")
 	}
 
+	decodeJSONTag(tg.Tags, bsBackendsTag, &resp.Backends)
+	decodeJSONTag(tg.Tags, bsConnDrainTag, &resp.ConnectionDraining)
+	decodeJSONTag(tg.Tags, bsCdnPolicyTag, &resp.CdnPolicy)
+	resp.EnableCDN = boolTag(tg.Tags, bsEnableCDNTag)
+
 	return resp
+}
+
+// displayName returns the client-facing name stored in nameTag, falling back to
+// the driver's own name when the tag is absent (legacy records).
+func displayName(tags map[string]string, nameTag, fallback string) string {
+	if n := tags[nameTag]; n != "" {
+		return n
+	}
+
+	return fallback
+}
+
+// decodeJSONTag unmarshals a JSON-encoded reserved tag into out, leaving out
+// untouched when the tag is absent.
+func decodeJSONTag(tags map[string]string, key string, out any) {
+	if s := tags[key]; s != "" {
+		_ = json.Unmarshal([]byte(s), out)
+	}
+}
+
+// encodeJSONTag stores v as a JSON string under key.
+func encodeJSONTag(tags map[string]string, key string, v any) {
+	if b, err := json.Marshal(v); err == nil {
+		tags[key] = string(b)
+	}
+}
+
+// boolTag reads a "true"/"false" reserved tag, returning nil when absent so an
+// unset enableCDN stays omitted rather than defaulting to false.
+func boolTag(tags map[string]string, key string) *bool {
+	s, ok := tags[key]
+	if !ok {
+		return nil
+	}
+
+	v := s == "true"
+
+	return &v
 }
 
 // Reserved tag keys carry the GCP backend-service fields the driver's target
@@ -337,6 +464,14 @@ const (
 	bsSessionAffinityTag = "cloudemu:gcpBsSessionAffinity"
 	bsTimeoutSecTag      = "cloudemu:gcpBsTimeoutSec"
 	bsCreationTag        = "cloudemu:gcpBsCreationTimestamp"
+	bsBackendsTag        = "cloudemu:gcpBsBackends"
+	bsConnDrainTag       = "cloudemu:gcpBsConnectionDraining"
+	bsCdnPolicyTag       = "cloudemu:gcpBsCdnPolicy"
+	bsEnableCDNTag       = "cloudemu:gcpBsEnableCDN"
+	// bsNameTag/bsScopeTag carry the client-facing name and scope key so a
+	// scope-prefixed driver record re-emits its real name at its real scope.
+	bsNameTag  = "cloudemu:gcpBsName"
+	bsScopeTag = "cloudemu:gcpBsScope"
 )
 
 // backendServiceTags folds the GCP-specific backend-service fields into a fresh
@@ -374,23 +509,48 @@ func mergeBackendServiceTags(tags map[string]string, req *backendServiceRequest)
 	if req.TimeoutSec != 0 {
 		tags[bsTimeoutSecTag] = strconv.Itoa(req.TimeoutSec)
 	}
+
+	mergeBackendServiceCDNTags(tags, req)
+}
+
+// mergeBackendServiceCDNTags folds the nested backend-service fields
+// (backends[], connectionDraining, cdnPolicy, enableCDN) into tags as JSON so
+// they round-trip through the driver's flat tag map.
+func mergeBackendServiceCDNTags(tags map[string]string, req *backendServiceRequest) {
+	if len(req.Backends) > 0 {
+		encodeJSONTag(tags, bsBackendsTag, req.Backends)
+	}
+
+	if req.ConnectionDraining != nil {
+		encodeJSONTag(tags, bsConnDrainTag, req.ConnectionDraining)
+	}
+
+	if req.CdnPolicy != nil {
+		encodeJSONTag(tags, bsCdnPolicyTag, req.CdnPolicy)
+	}
+
+	if req.EnableCDN != nil {
+		tags[bsEnableCDNTag] = strconv.FormatBool(*req.EnableCDN)
+	}
 }
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) toForwardingRuleResponse(ctx context.Context, lb *lbdriver.LBInfo,
 	rp gcprest.ResourcePath, host string,
 ) forwardingRuleResponse {
+	name := displayName(lb.Tags, frNameTag, lb.Name)
 	out := forwardingRuleResponse{
 		Kind:                "compute#forwardingRule",
 		ID:                  numericID(lb.ID),
-		Name:                lb.Name,
+		Name:                name,
 		IPAddress:           forwardingRuleIP(lb),
 		IPProtocol:          tagOrDefault(lb.Tags, frProtocolTag, "TCP"),
 		PortRange:           lb.Tags[frPortRangeTag],
+		Target:              lb.Tags[frTargetTag],
 		Description:         lb.Tags[frDescriptionTag],
 		LoadBalancingScheme: forwardingRuleScheme(lb),
 		CreationTimestamp:   lb.Tags[frCreationTag],
-		SelfLink:            gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", resourceForwardingRules, lb.Name),
+		SelfLink:            gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, resourceForwardingRules, name),
 	}
 
 	// A linked listener (a rule referencing a backend service) supersedes the
@@ -400,7 +560,7 @@ func (h *Handler) toForwardingRuleResponse(ctx context.Context, lb *lbdriver.LBI
 		out.PortRange = strconv.Itoa(listeners[0].Port)
 
 		if tgName := h.tgNameByARN(ctx, listeners[0].TargetGroupARN); tgName != "" {
-			out.BackendService = gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "",
+			out.BackendService = gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName,
 				resourceBackendServices, tgName)
 		}
 	}
@@ -408,7 +568,8 @@ func (h *Handler) toForwardingRuleResponse(ctx context.Context, lb *lbdriver.LBI
 	return out
 }
 
-// tgNameByARN resolves a target-group ARN back to its name for response links.
+// tgNameByARN resolves a target-group ARN back to its client-facing name for
+// response links.
 func (h *Handler) tgNameByARN(ctx context.Context, arn string) string {
 	if arn == "" {
 		return ""
@@ -419,7 +580,7 @@ func (h *Handler) tgNameByARN(ctx context.Context, arn string) string {
 		return ""
 	}
 
-	return tgs[0].Name
+	return displayName(tgs[0].Tags, bsNameTag, tgs[0].Name)
 }
 
 // backendServiceName extracts the trailing backend-service name from a compute
@@ -528,6 +689,11 @@ const (
 	frIPAddressTag   = "cloudemu:gcpFrIPAddress"
 	frDescriptionTag = "cloudemu:gcpFrDescription"
 	frCreationTag    = "cloudemu:gcpFrCreationTimestamp"
+	frTargetTag      = "cloudemu:gcpFrTarget"
+	// frNameTag/frScopeTag carry the client-facing name and scope key so a
+	// scope-prefixed driver record re-emits its real name at its real scope.
+	frNameTag  = "cloudemu:gcpFrName"
+	frScopeTag = "cloudemu:gcpFrScope"
 )
 
 // forwardingRuleTags folds the GCP-specific forwarding-rule fields into a tag
@@ -543,6 +709,10 @@ func forwardingRuleTags(req *forwardingRuleRequest) map[string]string {
 
 	if req.IPProtocol != "" {
 		tags[frProtocolTag] = req.IPProtocol
+	}
+
+	if req.Target != "" {
+		tags[frTargetTag] = req.Target
 	}
 
 	if req.LoadBalancingScheme != "" {

--- a/server/gcp/loadbalancer/resources.go
+++ b/server/gcp/loadbalancer/resources.go
@@ -2,8 +2,10 @@ package loadbalancer
 
 import (
 	"net/http"
+	"sort"
 	"time"
 
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
 )
@@ -49,7 +51,7 @@ func scopeKeyOf(rp gcprest.ResourcePath) string {
 	return rp.ScopeName
 }
 
-//nolint:gocritic,dupl // rp is a request-scoped value; CRUD route shape is duplicate-by-design across resource types
+//nolint:gocritic // rp is a request-scoped value
 func (h *Handler) routeGCPResource(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
 	if rp.ResourceName == "" {
 		switch r.Method {
@@ -67,11 +69,65 @@ func (h *Handler) routeGCPResource(w http.ResponseWriter, r *http.Request, rp gc
 	switch r.Method {
 	case http.MethodGet:
 		h.getGCPResource(w, r, rp)
+	case http.MethodPatch:
+		h.mutateGCPResource(w, r, rp, true)
+	case http.MethodPut:
+		h.mutateGCPResource(w, r, rp, false)
 	case http.MethodDelete:
 		h.deleteGCPResource(w, r, rp)
 	default:
 		gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
 	}
+}
+
+// mutateGCPResource serves compute *.patch (merge=true) and *.update
+// (merge=false) for the opaque resources. Patch merges the request body's
+// members onto the stored body; update replaces the body wholesale. Both return
+// a DONE Operation, matching real GCP, so Terraform apply-on-change succeeds
+// instead of hitting a 405.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) mutateGCPResource(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath, merge bool) {
+	store, ok := h.gcpStore()
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotImplemented, "notImplemented", "load balancer driver has no GCP resource store")
+		return
+	}
+
+	var body map[string]any
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	err := store.UpdateGCPResource(r.Context(), rp.ResourceType, scopeKeyOf(rp), rp.ResourceName,
+		func(res *lbdriver.GCPResource) { applyBody(res, body, merge) })
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	verb := "update"
+	if merge {
+		verb = "patch"
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName, rp.ResourceType, rp.ResourceName, verb)
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// applyBody merges (patch) or replaces (update) a stored resource's body with
+// the request body, always preserving the resource name so a body that omits or
+// changes it can't orphan the record from its store key.
+func applyBody(res *lbdriver.GCPResource, body map[string]any, merge bool) {
+	if !merge || res.Body == nil {
+		res.Body = map[string]any{}
+	}
+
+	for k, v := range body {
+		res.Body[k] = v
+	}
+
+	res.Body["name"] = res.Name
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -142,21 +198,45 @@ func (h *Handler) listGCPResource(w http.ResponseWriter, r *http.Request, rp gcp
 		return
 	}
 
-	host := hostOf(r)
-	out := make([]map[string]any, 0, len(items))
+	filter := r.URL.Query().Get("filter")
+
+	matched := make([]lbdriver.GCPResource, 0, len(items))
 
 	for i := range items {
-		scope := rp
-		scope.ResourceName = items[i].Name
-		out = append(out, gcpResourceJSON(&items[i], scope, host))
+		if gcprest.NameMatches(filter, items[i].Name) {
+			matched = append(matched, items[i])
+		}
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, map[string]any{
+	sort.SliceStable(matched, func(i, j int) bool { return matched[i].Name < matched[j].Name })
+
+	page, err := pagination.Paginate(matched, r.URL.Query().Get("pageToken"),
+		gcprest.MaxResults(r.URL.Query().Get("maxResults")))
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid pageToken")
+		return
+	}
+
+	host := hostOf(r)
+	out := make([]map[string]any, 0, len(page.Items))
+
+	for i := range page.Items {
+		scope := rp
+		scope.ResourceName = page.Items[i].Name
+		out = append(out, gcpResourceJSON(&page.Items[i], scope, host))
+	}
+
+	envelope := map[string]any{
 		"kind":     resourceKind[rp.ResourceType] + "List",
 		"id":       "projects/" + rp.Project + "/" + listScopeSegment(rp) + "/" + rp.ResourceType,
 		"items":    out,
 		"selfLink": gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, rp.ResourceType, ""),
-	})
+	}
+	if page.NextPageToken != "" {
+		envelope["nextPageToken"] = page.NextPageToken
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, envelope)
 }
 
 //nolint:gocritic // rp is a request-scoped value

--- a/server/gcp/loadbalancer/types.go
+++ b/server/gcp/loadbalancer/types.go
@@ -6,40 +6,73 @@ package loadbalancer
 
 // --- backend services (→ driver target groups) ---
 
+// backend is one entry of a backend service's backends[] — the instance-group
+// or NEG reference plus its balancing knobs. google_compute_backend_service
+// sends this on every apply, so it must round-trip.
+type backend struct {
+	Group          string  `json:"group,omitempty"`
+	BalancingMode  string  `json:"balancingMode,omitempty"`
+	CapacityScaler float64 `json:"capacityScaler,omitempty"`
+	MaxUtilization float64 `json:"maxUtilization,omitempty"`
+}
+
+// connectionDraining is the backend service's connection-draining policy.
+type connectionDraining struct {
+	DrainingTimeoutSec int `json:"drainingTimeoutSec,omitempty"`
+}
+
+// cdnPolicy is the subset of a backend service's Cloud CDN policy the emulator
+// round-trips verbatim (the full body is preserved as an opaque JSON blob).
+type cdnPolicy struct {
+	CacheMode  string `json:"cacheMode,omitempty"`
+	DefaultTTL int    `json:"defaultTtl,omitempty"`
+	ClientTTL  int    `json:"clientTtl,omitempty"`
+	MaxTTL     int    `json:"maxTtl,omitempty"`
+}
+
 type backendServiceRequest struct {
-	Name                string   `json:"name"`
-	Description         string   `json:"description,omitempty"`
-	Protocol            string   `json:"protocol,omitempty"`
-	Port                int      `json:"port,omitempty"`
-	PortName            string   `json:"portName,omitempty"`
-	HealthChecks        []string `json:"healthChecks,omitempty"`
-	LoadBalancingScheme string   `json:"loadBalancingScheme,omitempty"`
-	SessionAffinity     string   `json:"sessionAffinity,omitempty"`
-	TimeoutSec          int      `json:"timeoutSec,omitempty"`
+	Name                string              `json:"name"`
+	Description         string              `json:"description,omitempty"`
+	Protocol            string              `json:"protocol,omitempty"`
+	Port                int                 `json:"port,omitempty"`
+	PortName            string              `json:"portName,omitempty"`
+	HealthChecks        []string            `json:"healthChecks,omitempty"`
+	LoadBalancingScheme string              `json:"loadBalancingScheme,omitempty"`
+	SessionAffinity     string              `json:"sessionAffinity,omitempty"`
+	TimeoutSec          int                 `json:"timeoutSec,omitempty"`
+	Backends            []backend           `json:"backends,omitempty"`
+	ConnectionDraining  *connectionDraining `json:"connectionDraining,omitempty"`
+	CdnPolicy           *cdnPolicy          `json:"cdnPolicy,omitempty"`
+	EnableCDN           *bool               `json:"enableCDN,omitempty"`
 }
 
 type backendServiceResponse struct {
-	Kind                string   `json:"kind"`
-	ID                  string   `json:"id"`
-	Name                string   `json:"name"`
-	Description         string   `json:"description,omitempty"`
-	Protocol            string   `json:"protocol,omitempty"`
-	Port                int      `json:"port,omitempty"`
-	PortName            string   `json:"portName,omitempty"`
-	HealthChecks        []string `json:"healthChecks,omitempty"`
-	LoadBalancingScheme string   `json:"loadBalancingScheme,omitempty"`
-	SessionAffinity     string   `json:"sessionAffinity,omitempty"`
-	TimeoutSec          int      `json:"timeoutSec,omitempty"`
-	Fingerprint         string   `json:"fingerprint,omitempty"`
-	CreationTimestamp   string   `json:"creationTimestamp,omitempty"`
-	SelfLink            string   `json:"selfLink"`
+	Kind                string              `json:"kind"`
+	ID                  string              `json:"id"`
+	Name                string              `json:"name"`
+	Description         string              `json:"description,omitempty"`
+	Protocol            string              `json:"protocol,omitempty"`
+	Port                int                 `json:"port,omitempty"`
+	PortName            string              `json:"portName,omitempty"`
+	HealthChecks        []string            `json:"healthChecks,omitempty"`
+	LoadBalancingScheme string              `json:"loadBalancingScheme,omitempty"`
+	SessionAffinity     string              `json:"sessionAffinity,omitempty"`
+	TimeoutSec          int                 `json:"timeoutSec,omitempty"`
+	Backends            []backend           `json:"backends,omitempty"`
+	ConnectionDraining  *connectionDraining `json:"connectionDraining,omitempty"`
+	CdnPolicy           *cdnPolicy          `json:"cdnPolicy,omitempty"`
+	EnableCDN           *bool               `json:"enableCDN,omitempty"`
+	Fingerprint         string              `json:"fingerprint,omitempty"`
+	CreationTimestamp   string              `json:"creationTimestamp,omitempty"`
+	SelfLink            string              `json:"selfLink"`
 }
 
 type backendServiceListResponse struct {
-	Kind     string                   `json:"kind"`
-	ID       string                   `json:"id"`
-	Items    []backendServiceResponse `json:"items"`
-	SelfLink string                   `json:"selfLink"`
+	Kind          string                   `json:"kind"`
+	ID            string                   `json:"id"`
+	Items         []backendServiceResponse `json:"items"`
+	NextPageToken string                   `json:"nextPageToken,omitempty"`
+	SelfLink      string                   `json:"selfLink"`
 }
 
 // --- forwarding rules (→ driver load balancers) ---
@@ -71,8 +104,9 @@ type forwardingRuleResponse struct {
 }
 
 type forwardingRuleListResponse struct {
-	Kind     string                   `json:"kind"`
-	ID       string                   `json:"id"`
-	Items    []forwardingRuleResponse `json:"items"`
-	SelfLink string                   `json:"selfLink"`
+	Kind          string                   `json:"kind"`
+	ID            string                   `json:"id"`
+	Items         []forwardingRuleResponse `json:"items"`
+	NextPageToken string                   `json:"nextPageToken,omitempty"`
+	SelfLink      string                   `json:"selfLink"`
 }

--- a/server/gcp/loadbalancer/urlmaps_sdk_test.go
+++ b/server/gcp/loadbalancer/urlmaps_sdk_test.go
@@ -93,3 +93,56 @@ func TestSDKGCPURLMapRoundTrip(t *testing.T) {
 		t.Fatal("Get after delete: want error, got nil")
 	}
 }
+
+// TestSDKGCPURLMapUpdate covers the missing UPDATE verb: urlMaps.update
+// previously 405'd, so google_compute_url_map could never change its routing.
+// The update must replace the stored resource and be visible on the next get.
+func TestSDKGCPURLMapUpdate(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewUrlMapsRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewUrlMapsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	svcA := "projects/" + testProject + "/global/backendServices/bs-a"
+	svcB := "projects/" + testProject + "/global/backendServices/bs-b"
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertUrlMapRequest{
+		Project:        testProject,
+		UrlMapResource: &computepb.UrlMap{Name: ptrStr("edit-map"), DefaultService: ptrStr(svcA)},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	updOp, err := client.Update(ctx, &computepb.UpdateUrlMapRequest{
+		Project:        testProject,
+		UrlMap:         "edit-map",
+		UrlMapResource: &computepb.UrlMap{Name: ptrStr("edit-map"), DefaultService: ptrStr(svcB)},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if err := updOp.Wait(ctx); err != nil {
+		t.Fatalf("Update wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetUrlMapRequest{Project: testProject, UrlMap: "edit-map"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetDefaultService() != svcB {
+		t.Errorf("defaultService = %q, want %q (update not applied)", got.GetDefaultService(), svcB)
+	}
+}

--- a/server/gcp/vpc/handler.go
+++ b/server/gcp/vpc/handler.go
@@ -72,56 +72,16 @@ const (
 	internalNetCIDR      = "10.0.0.0/16"
 )
 
-// defaultListMax is GCP's default page size when maxResults is absent.
-const defaultListMax = 500
-
 // nowRFC3339 returns the current time formatted the way GCP stamps
 // creationTimestamp on every resource.
 func nowRFC3339() string { return time.Now().UTC().Format(time.RFC3339) }
 
-// nameMatches reports whether name satisfies a GCP list filter. Only the
-// common single-clause "name (=|!=|eq|ne) value" form is supported; any other
-// filter (or none) matches everything.
-func nameMatches(filter, name string) bool {
-	filter = strings.TrimSpace(filter)
-	if filter == "" {
-		return true
-	}
-
-	for _, cand := range []string{"!=", "=", " ne ", " eq "} {
-		idx := strings.Index(filter, cand)
-		if idx < 0 {
-			continue
-		}
-
-		field := strings.TrimSpace(filter[:idx])
-		if field != "name" {
-			return true
-		}
-
-		value := strings.Trim(strings.TrimSpace(filter[idx+len(cand):]), `"'`)
-		op := strings.TrimSpace(cand)
-		negate := op == "!=" || op == "ne"
-
-		return (name == value) != negate
-	}
-
-	return true
-}
+// nameMatches reports whether name satisfies a GCP list filter, delegating to
+// the shared gcprest codec so every GCP handler applies filters identically.
+func nameMatches(filter, name string) bool { return gcprest.NameMatches(filter, name) }
 
 // maxResultsOf parses the maxResults query param, defaulting when absent/invalid.
-func maxResultsOf(raw string) int {
-	if raw == "" {
-		return defaultListMax
-	}
-
-	n, err := strconv.Atoi(raw)
-	if err != nil || n <= 0 {
-		return defaultListMax
-	}
-
-	return n
-}
+func maxResultsOf(raw string) int { return gcprest.MaxResults(raw) }
 
 // Handler serves the GCP networking REST surface.
 type Handler struct {

--- a/server/wire/gcprest/gcprest.go
+++ b/server/wire/gcprest/gcprest.go
@@ -222,6 +222,7 @@ type Operation struct {
 	EndTime       string `json:"endTime"`
 	SelfLink      string `json:"selfLink"`
 	Zone          string `json:"zone,omitempty"`
+	Region        string `json:"region,omitempty"`
 }
 
 // NewDoneOperation builds an Operation in DONE state for opType targeting the
@@ -252,5 +253,58 @@ func NewDoneOperation(host, project, scope, scopeName, resourceType, name, opTyp
 		op.Zone = strings.TrimSuffix(host, "/") + "/compute/v1/projects/" + project + "/zones/" + scopeName
 	}
 
+	if scope == ScopeRegions {
+		op.Region = strings.TrimSuffix(host, "/") + "/compute/v1/projects/" + project + "/regions/" + scopeName
+	}
+
 	return op
+}
+
+// DefaultListMax is GCP's default list page size when maxResults is absent.
+const DefaultListMax = 500
+
+// NameMatches reports whether name satisfies a GCP list filter. Only the common
+// single-clause "name (=|!=|eq|ne) value" form is supported; any other filter
+// (or none) matches everything, matching real GCP's lenient behavior for the
+// filter shapes the emulator does not model.
+func NameMatches(filter, name string) bool {
+	filter = strings.TrimSpace(filter)
+	if filter == "" {
+		return true
+	}
+
+	for _, cand := range []string{"!=", "=", " ne ", " eq "} {
+		idx := strings.Index(filter, cand)
+		if idx < 0 {
+			continue
+		}
+
+		field := strings.TrimSpace(filter[:idx])
+		if field != "name" {
+			return true
+		}
+
+		value := strings.Trim(strings.TrimSpace(filter[idx+len(cand):]), `"'`)
+		op := strings.TrimSpace(cand)
+		negate := op == "!=" || op == "ne"
+
+		return (name == value) != negate
+	}
+
+	return true
+}
+
+// MaxResults parses the maxResults query param, defaulting to DefaultListMax
+// when absent, non-numeric, or non-positive.
+func MaxResults(raw string) int {
+	if raw == "" {
+		return DefaultListMax
+	}
+
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return DefaultListMax
+	}
+
+	return n
 }

--- a/services/loadbalancer/driver/gcp.go
+++ b/services/loadbalancer/driver/gcp.go
@@ -31,6 +31,10 @@ type GCPComputeResourceStore interface {
 	ListGCPResources(ctx context.Context, collection, scope string) ([]GCPResource, error)
 	// DeleteGCPResource removes the resource, returning NotFound when absent.
 	DeleteGCPResource(ctx context.Context, collection, scope, name string) error
+	// UpdateGCPResource applies mutate to the stored resource in place under the
+	// store lock (compute *.patch / *.update), returning NotFound when absent.
+	// The handler decides patch-merge vs full-replace by what mutate does to Body.
+	UpdateGCPResource(ctx context.Context, collection, scope, name string, mutate func(*GCPResource)) error
 }
 
 // GCPBackendServicePatcher is an OPTIONAL, type-asserted capability implemented


### PR DESCRIPTION
## Summary

Fixes 8 GCP Cloud Load Balancing bugs surfaced by driving the booted wire server (`gcpserver.New`) with the real `google.golang.org/api/compute/v1` SDK. All fixes are server-layer (reserved-tag serialization + list/verb plumbing); the portable `TargetGroup`/`LBInfo` drivers are unchanged except for one opaque-store update method.

### Round-trip drops (Terraform drift)
- **backendServices** `backends[]` (group/balancingMode/capacityScaler), `connectionDraining`, `cdnPolicy`, `enableCDN` now round-trip via reserved tags (patch preserves them).
- **forwardingRules** `target` is now stored and re-emitted, so the LB has an entrypoint on read.

### List defects
- BackendServices / ForwardingRules / HealthChecks / TargetPools / UrlMaps list endpoints now honor `filter` (`name eq/=/ne/!=`) and `maxResults`/`pageToken`, emitting `nextPageToken`. The filter/pagination helpers (`NameMatches`, `MaxResults`) are centralized in `server/wire/gcprest` and reused by the vpc addresses handler (removing its private copies).

### Verbs + scope
- healthChecks / urlMaps / targetPools now accept **PATCH** (merge into stored body) and **UPDATE** (replace body), returning a DONE Operation instead of 405 — so `terraform apply` on change works.
- Regional vs global resources of the same name no longer collide: the driver store key is scope-prefixed and lists are scope-filtered, and a regional Operation now carries a `region` self-link (new `Operation.Region` field mirroring `Zone`).

Not in scope (separate deferral): the L7 proxy tier (targetHttp(s)Proxies / sslCertificates / targetTcpProxies).

### Deferral
A fully scope-keyed opaque store would need a deeper driver change; this PR does the collision-avoidance at the server layer (scope-prefixed driver key + scope-filtered lists + scope-aware Operation metadata), which is sufficient for the global/regional same-name case.

## Tests

Real-SDK e2e added against a booted server:
- backends[] + connectionDraining + cdnPolicy + enableCDN round-trip
- forwardingRule target round-trip
- List `Filter("name eq ...")` returns only matches
- List `MaxResults(1)` paginates via nextPageToken, all items once
- HealthChecks.Patch merge + UrlMaps.Update replace reflect on Get
- global + regional same-name backendService coexist; regional insert Operation carries the region

## Gates
build, vet, `go test` (loadbalancer server/provider/service + vpc + gcprest), `-race` (provider), gofmt, golangci-lint (0 new on changed pkgs), `go generate` idempotent (coverage regenerated), compatgen + `docs/compat` clean.
