### PR TITLE
fix(aws-secretsmanager): BatchGetSecretValue rejects empty SecretIdList with no Filters

### DIFF
--- a/server/aws/secretsmanager/batch.go
+++ b/server/aws/secretsmanager/batch.go
@@ -11,10 +11,18 @@ import (
 // batchGetSecretValue retrieves the AWSCURRENT value of up to a page of secrets
 // named by SecretIdList (or matched by Filters). A missing (or otherwise
 // unreadable) secret is reported per-item in Errors rather than failing the
-// whole batch, matching the real service.
+// whole batch, matching the real service. A request with neither SecretIdList
+// nor Filters is rejected as InvalidParameterException, as real AWS does.
 func (h *Handler) batchGetSecretValue(w http.ResponseWriter, r *http.Request) {
 	var req batchGetSecretValueRequest
 	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if len(req.SecretIDList) == 0 && len(req.Filters) == 0 {
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"InvalidParameterException", "either SecretIdList or Filters must be provided")
+
 		return
 	}
 

--- a/server/aws/secretsmanager/batch_get_secret_value_test.go
+++ b/server/aws/secretsmanager/batch_get_secret_value_test.go
@@ -2,10 +2,12 @@ package secretsmanager_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awssm "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 )
 
 // TestSDKBatchGetSecretValue is the F7 reproduction: BatchGetSecretValue over a
@@ -61,20 +63,19 @@ func TestSDKBatchGetSecretValue(t *testing.T) {
 	}
 }
 
-// TestSDKBatchGetSecretValueEmpty verifies an empty SecretIdList is handled
-// (no values, no errors) rather than erroring.
+// TestSDKBatchGetSecretValueEmpty verifies an empty SecretIdList with no Filters
+// is rejected as InvalidParameterException, matching real AWS (which requires
+// either SecretIdList or Filters).
 func TestSDKBatchGetSecretValueEmpty(t *testing.T) {
 	client := newSecretsClient(t)
 	ctx := context.Background()
 
-	out, err := client.BatchGetSecretValue(ctx, &awssm.BatchGetSecretValueInput{
+	_, err := client.BatchGetSecretValue(ctx, &awssm.BatchGetSecretValueInput{
 		SecretIdList: []string{},
 	})
-	if err != nil {
-		t.Fatalf("BatchGetSecretValue(empty): %v", err)
-	}
 
-	if len(out.SecretValues) != 0 || len(out.Errors) != 0 {
-		t.Fatalf("empty batch = values %+v errors %+v, want both empty", out.SecretValues, out.Errors)
+	var invalid *smtypes.InvalidParameterException
+	if !errors.As(err, &invalid) {
+		t.Fatalf("BatchGetSecretValue(empty): got %v, want InvalidParameterException", err)
 	}
 }


### PR DESCRIPTION
## Summary

The Secrets Manager resource-policy ops (Put/Get/Delete/ValidateResourcePolicy) and `BatchGetSecretValue` were already implemented and merged in #672. This PR closes the one remaining real-cloud-parity gap in `BatchGetSecretValue`.

Real AWS constrains `SecretIdList` to a minimum of 1 item and requires the caller to supply either `SecretIdList` or `Filters`. The previous implementation returned an empty result for an empty `SecretIdList` with no `Filters`; real AWS rejects it with `InvalidParameterException`.

## Changes
- `BatchGetSecretValue` now returns `InvalidParameterException` when neither `SecretIdList` nor `Filters` is provided (matching real AWS). When both are provided, the list is preferred (unchanged).
- Updated the real-SDK e2e test to assert `InvalidParameterException` for an empty `SecretIdList`.

## Verification
- `go build ./...`, `go vet`, `gofmt -l` clean
- `go test` + `go test -race` on server/provider secretsmanager packages pass (real aws-sdk-go-v2 client against a booted server)
- `golangci-lint` 0 issues on changed package
- `go generate ./...` and `compatgen` zero diff (ops surface unchanged)