### PR TITLE
test(aws-route53): assert AssociateVPCWithHostedZone on missing zone returns NoSuchHostedZone

### DIFF
--- a/server/aws/route53/vpc_association_test.go
+++ b/server/aws/route53/vpc_association_test.go
@@ -243,6 +243,26 @@ func TestSDKAssociateVPCOnPublicZone(t *testing.T) {
 	}
 }
 
+// TestSDKAssociateVPCMissingZone proves associating a VPC with a hosted zone
+// that doesn't exist is rejected with NoSuchHostedZone.
+func TestSDKAssociateVPCMissingZone(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	_, err := client.AssociateVPCWithHostedZone(ctx, &awsr53.AssociateVPCWithHostedZoneInput{
+		HostedZoneId: aws.String("ZDOESNOTEXIST"),
+		VPC:          &r53types.VPC{VPCId: aws.String("vpc-1111"), VPCRegion: r53types.VPCRegionUsEast1},
+	})
+	if err == nil {
+		t.Fatal("AssociateVPCWithHostedZone(missing zone) succeeded, want NoSuchHostedZone")
+	}
+
+	var notFound *r53types.NoSuchHostedZone
+	if !errors.As(err, &notFound) {
+		t.Fatalf("error = %v, want *NoSuchHostedZone", err)
+	}
+}
+
 // TestSDKListHostedZonesByVPC proves the private zones a VPC is associated with
 // are listed, and unassociated zones are excluded.
 func TestSDKListHostedZonesByVPC(t *testing.T) {


### PR DESCRIPTION
## Summary

The private-hosted-zone VPC association feature (AssociateVPCWithHostedZone / DisassociateVPCFromHostedZone / CreateHostedZone-with-VPC / ListHostedZonesByVPC) landed in #684. That PR covered create-with-VPC, associate, disassociate (incl. last-VPC and not-associated errors), public-zone rejection, idempotency and ListHostedZonesByVPC with real-SDK e2e tests.

One requested real-user assertion was missing at the wire/SDK level: associating a VPC with a **non-existent** hosted zone must be rejected with `NoSuchHostedZone`. The wire already maps this correctly (GetZone NotFound -> NoSuchHostedZone); this adds the SDK-level test that pins the behavior.

## Change
- Add `TestSDKAssociateVPCMissingZone` in `server/aws/route53/vpc_association_test.go` — boots the server and drives a real `aws-sdk-go-v2/service/route53` client, asserting the typed `*route53types.NoSuchHostedZone` error.

Test-only; no production behavior change.