### PR TITLE
fix(glue): GetPartitions Expression filter + crawler/job TF-drift round-trip

### DIFF
--- a/providers/aws/glue/copy.go
+++ b/providers/aws/glue/copy.go
@@ -97,6 +97,10 @@ func copyCrawler(in driver.Crawler) driver.Crawler {
 	out := in
 	out.Classifiers = copyStrings(in.Classifiers)
 	out.Targets = copyAnyMap(in.Targets)
+	out.SchemaChangePolicy = copyAnyMap(in.SchemaChangePolicy)
+	out.RecrawlPolicy = copyAnyMap(in.RecrawlPolicy)
+	out.LineageConfiguration = copyAnyMap(in.LineageConfiguration)
+	out.Tags = copyTags(in.Tags)
 
 	return out
 }
@@ -114,6 +118,10 @@ func copyJob(in driver.Job) driver.Job {
 	out := in
 	out.Command = copyAnyMap(in.Command)
 	out.DefaultArguments = copyTags(in.DefaultArguments)
+	out.ExecutionProperty = copyAnyMap(in.ExecutionProperty)
+	out.Connections = copyAnyMap(in.Connections)
+	out.NotificationProperty = copyAnyMap(in.NotificationProperty)
+	out.Tags = copyTags(in.Tags)
 
 	return out
 }

--- a/providers/aws/glue/crawlers.go
+++ b/providers/aws/glue/crawlers.go
@@ -16,7 +16,7 @@ type crawlerData struct {
 // CreateCrawler creates a crawler in the READY state, atomically.
 //
 //nolint:gocritic // hugeParam: taken by value to match the driver interface / copy semantics
-func (m *Mock) CreateCrawler(_ context.Context, c driver.Crawler) error {
+func (m *Mock) CreateCrawler(ctx context.Context, c driver.Crawler) error {
 	if !validName(c.Name) {
 		return invalidInput("crawler name %q is invalid", c.Name)
 	}
@@ -25,10 +25,18 @@ func (m *Mock) CreateCrawler(_ context.Context, c driver.Crawler) error {
 	c.State = driver.CrawlerReady
 	c.CreationTime = now
 	c.LastUpdated = now
+	tags := c.Tags
+	c.Tags = nil
 	stored := copyCrawler(c)
 
 	if !m.crawlers.SetIfAbsent(c.Name, &crawlerData{crawler: stored}) {
 		return alreadyExists("Crawler already exists: %s", c.Name)
+	}
+
+	if len(tags) > 0 {
+		// Tags on a crawler live in the tag store under its ARN, so GetTags (what
+		// Terraform reads) returns them; GetCrawler intentionally omits tags.
+		_ = m.TagResource(ctx, m.arn("crawler/"+c.Name), tags)
 	}
 
 	return nil

--- a/providers/aws/glue/jobs.go
+++ b/providers/aws/glue/jobs.go
@@ -30,7 +30,7 @@ type jobRunData struct {
 // CreateJob creates an ETL job definition, atomically, returning its name.
 //
 //nolint:gocritic // hugeParam: taken by value to match the driver interface / copy semantics
-func (m *Mock) CreateJob(_ context.Context, j driver.Job) (string, error) {
+func (m *Mock) CreateJob(ctx context.Context, j driver.Job) (string, error) {
 	if !validName(j.Name) {
 		return "", invalidInput("job name %q is invalid", j.Name)
 	}
@@ -46,10 +46,18 @@ func (m *Mock) CreateJob(_ context.Context, j driver.Job) (string, error) {
 	now := m.now()
 	j.CreatedOn = now
 	j.LastModifiedOn = now
+	tags := j.Tags
+	j.Tags = nil
 	stored := copyJob(j)
 
 	if !m.jobs.SetIfAbsent(j.Name, &jobData{job: stored}) {
 		return "", alreadyExists("Job already exists: %s", j.Name)
+	}
+
+	if len(tags) > 0 {
+		// Tags on a job live in the tag store under its ARN, so GetTags (what
+		// Terraform reads) returns them; GetJob intentionally omits tags.
+		_ = m.TagResource(ctx, m.arn("job/"+j.Name), tags)
 	}
 
 	return j.Name, nil

--- a/providers/aws/glue/partition_filter.go
+++ b/providers/aws/glue/partition_filter.go
@@ -1,0 +1,367 @@
+package glue
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+)
+
+// Comparison operators recognized in a partition-filter expression.
+const (
+	opEq = "="
+	opNe = "<>"
+	opGt = ">"
+	opLt = "<"
+	opGe = ">="
+	opLe = "<="
+)
+
+// twoCharOpLen is the byte length of a two-character comparison operator.
+const twoCharOpLen = 2
+
+// filterErrf builds an InvalidArgument-typed error for a malformed filter.
+func filterErrf(format string, args ...any) error {
+	return errors.Newf(errors.InvalidArgument, format, args...)
+}
+
+// This file implements the subset of the AWS Glue GetPartitions filter grammar
+// that Terraform and Athena emit in practice: comparisons of a partition key
+// against a string or number literal (= <> > < >= <=), combined with AND / OR
+// and grouped with parentheses. Keys are matched positionally against a
+// partition's Values via the table's partition-key order. Numeric literals
+// compare numerically when the value parses as a number, else lexically. An
+// unsupported or malformed expression is reported as an InvalidInputException by
+// the caller.
+
+// partPredicate reports whether a partition's ordered Values satisfy a filter.
+// idx maps a partition-key name to its position in Values.
+type partPredicate func(values []string, idx map[string]int) bool
+
+type tokenKind int
+
+const (
+	tkEOF tokenKind = iota
+	tkIdent
+	tkString
+	tkNumber
+	tkOp
+	tkAnd
+	tkOr
+	tkLParen
+	tkRParen
+)
+
+type token struct {
+	kind tokenKind
+	text string
+}
+
+func isSpace(c byte) bool { return c == ' ' || c == '\t' || c == '\n' || c == '\r' }
+
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }
+
+func isDigitOrSign(c byte) bool { return isDigit(c) || c == '-' || c == '+' }
+
+func isOpStart(c byte) bool { return c == '=' || c == '<' || c == '>' }
+
+func isIdentStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isIdentPart(c byte) bool { return isIdentStart(c) || isDigit(c) }
+
+// tokenizeFilter splits a filter expression into tokens, skipping whitespace.
+func tokenizeFilter(s string) ([]token, error) {
+	var toks []token
+
+	for i := 0; i < len(s); {
+		if isSpace(s[i]) {
+			i++
+
+			continue
+		}
+
+		t, next, err := nextToken(s, i)
+		if err != nil {
+			return nil, err
+		}
+
+		toks = append(toks, t)
+		i = next
+	}
+
+	return append(toks, token{kind: tkEOF}), nil
+}
+
+// nextToken scans the single token beginning at s[i].
+func nextToken(s string, i int) (token, int, error) {
+	c := s[i]
+
+	switch {
+	case c == '(':
+		return token{kind: tkLParen}, i + 1, nil
+	case c == ')':
+		return token{kind: tkRParen}, i + 1, nil
+	case c == '\'':
+		return scanString(s, i)
+	case isOpStart(c):
+		t, n := scanOp(s, i)
+
+		return t, n, nil
+	case isDigitOrSign(c):
+		t, n := scanNumber(s, i)
+
+		return t, n, nil
+	case isIdentStart(c):
+		t, n := scanIdentOrKeyword(s, i)
+
+		return t, n, nil
+	default:
+		return token{}, i, filterErrf("unexpected character %q", string(c))
+	}
+}
+
+// scanString reads a single-quoted string literal starting at s[i].
+func scanString(s string, i int) (token, int, error) {
+	var b strings.Builder
+
+	for j := i + 1; j < len(s); j++ {
+		if s[j] == '\'' {
+			return token{kind: tkString, text: b.String()}, j + 1, nil
+		}
+
+		b.WriteByte(s[j])
+	}
+
+	return token{}, i, filterErrf("unterminated string literal")
+}
+
+// scanOp reads a comparison operator (one or two characters) starting at s[i].
+func scanOp(s string, i int) (tok token, next int) {
+	if i+twoCharOpLen <= len(s) {
+		if two := s[i : i+twoCharOpLen]; two == opGe || two == opLe || two == opNe {
+			return token{kind: tkOp, text: two}, i + twoCharOpLen
+		}
+	}
+
+	return token{kind: tkOp, text: s[i : i+1]}, i + 1
+}
+
+// scanNumber reads a signed decimal number starting at s[i].
+func scanNumber(s string, i int) (tok token, next int) {
+	j := i
+	if s[j] == '-' || s[j] == '+' {
+		j++
+	}
+
+	for j < len(s) && (isDigit(s[j]) || s[j] == '.') {
+		j++
+	}
+
+	return token{kind: tkNumber, text: s[i:j]}, j
+}
+
+// scanIdentOrKeyword reads an identifier, mapping AND/OR to boolean keywords.
+func scanIdentOrKeyword(s string, i int) (tok token, next int) {
+	j := i
+	for j < len(s) && isIdentPart(s[j]) {
+		j++
+	}
+
+	word := s[i:j]
+
+	switch strings.ToUpper(word) {
+	case "AND":
+		return token{kind: tkAnd, text: word}, j
+	case "OR":
+		return token{kind: tkOr, text: word}, j
+	default:
+		return token{kind: tkIdent, text: word}, j
+	}
+}
+
+type filterParser struct {
+	toks []token
+	pos  int
+}
+
+func (p *filterParser) peek() token { return p.toks[p.pos] }
+
+func (p *filterParser) next() token {
+	t := p.toks[p.pos]
+	p.pos++
+
+	return t
+}
+
+// parseOr parses OR-joined AND groups (lowest precedence).
+func (p *filterParser) parseOr() (partPredicate, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.peek().kind == tkOr {
+		p.next()
+
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+
+		left = orPred(left, right)
+	}
+
+	return left, nil
+}
+
+// parseAnd parses AND-joined primary comparisons.
+func (p *filterParser) parseAnd() (partPredicate, error) {
+	left, err := p.parsePrimary()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.peek().kind == tkAnd {
+		p.next()
+
+		right, err := p.parsePrimary()
+		if err != nil {
+			return nil, err
+		}
+
+		left = andPred(left, right)
+	}
+
+	return left, nil
+}
+
+// parsePrimary parses a parenthesized expression or a single comparison.
+func (p *filterParser) parsePrimary() (partPredicate, error) {
+	if p.peek().kind == tkLParen {
+		p.next()
+
+		inner, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+
+		if p.next().kind != tkRParen {
+			return nil, filterErrf("expected closing parenthesis")
+		}
+
+		return inner, nil
+	}
+
+	return p.parseComparison()
+}
+
+// parseComparison parses "<key> <op> <literal>".
+func (p *filterParser) parseComparison() (partPredicate, error) {
+	key := p.next()
+	if key.kind != tkIdent {
+		return nil, filterErrf("expected a partition key")
+	}
+
+	op := p.next()
+	if op.kind != tkOp {
+		return nil, filterErrf("expected a comparison operator")
+	}
+
+	lit := p.next()
+	if lit.kind != tkString && lit.kind != tkNumber {
+		return nil, filterErrf("expected a string or number literal")
+	}
+
+	return comparePred(key.text, op.text, lit), nil
+}
+
+func orPred(a, b partPredicate) partPredicate {
+	return func(v []string, idx map[string]int) bool { return a(v, idx) || b(v, idx) }
+}
+
+func andPred(a, b partPredicate) partPredicate {
+	return func(v []string, idx map[string]int) bool { return a(v, idx) && b(v, idx) }
+}
+
+// comparePred builds a predicate comparing one partition key to a literal.
+func comparePred(key, op string, lit token) partPredicate {
+	isNum := lit.kind == tkNumber
+	num, _ := strconv.ParseFloat(lit.text, 64)
+
+	return func(v []string, idx map[string]int) bool {
+		i, ok := idx[key]
+		if !ok || i >= len(v) {
+			return false
+		}
+
+		return matchValue(v[i], op, lit.text, isNum, num)
+	}
+}
+
+// matchValue compares a partition value against a literal, numerically when both
+// are numbers and lexically otherwise.
+func matchValue(val, op, lit string, isNum bool, num float64) bool {
+	if isNum {
+		if fv, err := strconv.ParseFloat(val, 64); err == nil {
+			return satisfies(op, compareFloat(fv, num))
+		}
+	}
+
+	return satisfies(op, strings.Compare(val, lit))
+}
+
+// satisfies maps a three-way comparison result to a comparison operator.
+func satisfies(op string, cmp int) bool {
+	switch op {
+	case opEq:
+		return cmp == 0
+	case opNe:
+		return cmp != 0
+	case opGt:
+		return cmp > 0
+	case opLt:
+		return cmp < 0
+	case opGe:
+		return cmp >= 0
+	case opLe:
+		return cmp <= 0
+	default:
+		return false
+	}
+}
+
+// compareFloat returns -1, 0 or 1 as a is less than, equal to, or greater than b.
+func compareFloat(a, b float64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// compilePartitionFilter parses a Glue partition-filter expression into a
+// predicate. A malformed or unsupported expression yields an error.
+func compilePartitionFilter(expr string) (partPredicate, error) {
+	toks, err := tokenizeFilter(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &filterParser{toks: toks}
+
+	pred, err := p.parseOr()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.peek().kind != tkEOF {
+		return nil, filterErrf("unexpected trailing tokens in expression")
+	}
+
+	return pred, nil
+}

--- a/providers/aws/glue/partitions.go
+++ b/providers/aws/glue/partitions.go
@@ -162,13 +162,49 @@ func (m *Mock) DeletePartition(_ context.Context, catalogID, dbName, tblName str
 	return nil
 }
 
-// GetPartitions lists a table's partitions with pagination.
+// partitionFilter compiles the request's Expression into a predicate plus the
+// table's partition-key name→index map. An empty expression yields a nil
+// predicate (match everything); a malformed one is an InvalidInputException.
+func (m *Mock) partitionFilter(cat, db, table, expr string) (partPredicate, map[string]int, error) {
+	if expr == "" {
+		return nil, nil, nil
+	}
+
+	td, ok := m.tables.Get(nameKey(cat, db, table))
+	if !ok {
+		return nil, nil, nil
+	}
+
+	td.mu.RLock()
+	keys := td.table.PartitionKeys
+	idx := make(map[string]int, len(keys))
+
+	for i := range keys {
+		idx[keys[i].Name] = i
+	}
+	td.mu.RUnlock()
+
+	pred, err := compilePartitionFilter(expr)
+	if err != nil {
+		return nil, nil, invalidInput("invalid partition filter expression %q: %v", expr, err)
+	}
+
+	return pred, idx, nil
+}
+
+// GetPartitions lists a table's partitions with pagination, narrowing by the
+// optional Expression filter before paginating (as real Glue does).
 func (m *Mock) GetPartitions(
 	_ context.Context, catalogID, dbName, tblName string, page driver.TablePagination,
 ) ([]driver.Partition, string, error) {
 	cat := m.catalogOrDefault(catalogID)
 
 	if err := m.requireTable(cat, dbName, tblName); err != nil {
+		return nil, "", err
+	}
+
+	pred, idx, err := m.partitionFilter(cat, dbName, tblName, page.Expression)
+	if err != nil {
 		return nil, "", err
 	}
 
@@ -187,8 +223,12 @@ func (m *Mock) GetPartitions(
 		}
 
 		pd.mu.RLock()
-		all = append(all, copyPartition(pd.part))
+		part := copyPartition(pd.part)
 		pd.mu.RUnlock()
+
+		if pred == nil || pred(part.Values, idx) {
+			all = append(all, part)
+		}
 	}
 
 	return paginate(all, page)

--- a/server/aws/glue/crawler_ops.go
+++ b/server/aws/glue/crawler_ops.go
@@ -8,19 +8,23 @@ import (
 )
 
 type crawlerJSON struct {
-	Name          string         `json:"Name"`
-	Role          string         `json:"Role,omitempty"`
-	DatabaseName  string         `json:"DatabaseName,omitempty"`
-	Description   string         `json:"Description,omitempty"`
-	Targets       map[string]any `json:"Targets,omitempty"`
-	Classifiers   []string       `json:"Classifiers,omitempty"`
-	TablePrefix   string         `json:"TablePrefix,omitempty"`
-	State         string         `json:"State,omitempty"`
-	Schedule      map[string]any `json:"Schedule,omitempty"`
-	Configuration string         `json:"Configuration,omitempty"`
-	CreationTime  *float64       `json:"CreationTime,omitempty"`
-	LastUpdated   *float64       `json:"LastUpdated,omitempty"`
-	Version       int64          `json:"Version,omitempty"`
+	Name                         string         `json:"Name"`
+	Role                         string         `json:"Role,omitempty"`
+	DatabaseName                 string         `json:"DatabaseName,omitempty"`
+	Description                  string         `json:"Description,omitempty"`
+	Targets                      map[string]any `json:"Targets,omitempty"`
+	Classifiers                  []string       `json:"Classifiers,omitempty"`
+	TablePrefix                  string         `json:"TablePrefix,omitempty"`
+	State                        string         `json:"State,omitempty"`
+	Schedule                     map[string]any `json:"Schedule,omitempty"`
+	Configuration                string         `json:"Configuration,omitempty"`
+	SchemaChangePolicy           map[string]any `json:"SchemaChangePolicy,omitempty"`
+	RecrawlPolicy                map[string]any `json:"RecrawlPolicy,omitempty"`
+	LineageConfiguration         map[string]any `json:"LineageConfiguration,omitempty"`
+	CrawlerSecurityConfiguration string         `json:"CrawlerSecurityConfiguration,omitempty"`
+	CreationTime                 *float64       `json:"CreationTime,omitempty"`
+	LastUpdated                  *float64       `json:"LastUpdated,omitempty"`
+	Version                      int64          `json:"Version,omitempty"`
 }
 
 func crawlerToWire(c *driver.Crawler) crawlerJSON {
@@ -32,30 +36,44 @@ func crawlerToWire(c *driver.Crawler) crawlerJSON {
 	return crawlerJSON{
 		Name: c.Name, Role: c.Role, DatabaseName: c.DatabaseName, Description: c.Description,
 		Targets: c.Targets, Classifiers: c.Classifiers, TablePrefix: c.TablePrefix, State: c.State,
-		Schedule: sched, Configuration: c.Configuration, CreationTime: epochOrNil(c.CreationTime),
+		Schedule: sched, Configuration: c.Configuration, SchemaChangePolicy: c.SchemaChangePolicy,
+		RecrawlPolicy: c.RecrawlPolicy, LineageConfiguration: c.LineageConfiguration,
+		CrawlerSecurityConfiguration: c.SecurityConfiguration, CreationTime: epochOrNil(c.CreationTime),
 		LastUpdated: epochOrNil(c.LastUpdated), Version: c.Version,
 	}
 }
 
 type createCrawlerRequest struct {
-	Name          string         `json:"Name"`
-	Role          string         `json:"Role"`
-	DatabaseName  string         `json:"DatabaseName"`
-	Description   string         `json:"Description"`
-	Targets       map[string]any `json:"Targets"`
-	Classifiers   []string       `json:"Classifiers"`
-	TablePrefix   string         `json:"TablePrefix"`
-	Schedule      string         `json:"Schedule"`
-	Configuration string         `json:"Configuration"`
+	Name                         string            `json:"Name"`
+	Role                         string            `json:"Role"`
+	DatabaseName                 string            `json:"DatabaseName"`
+	Description                  string            `json:"Description"`
+	Targets                      map[string]any    `json:"Targets"`
+	Classifiers                  []string          `json:"Classifiers"`
+	TablePrefix                  string            `json:"TablePrefix"`
+	Schedule                     string            `json:"Schedule"`
+	Configuration                string            `json:"Configuration"`
+	SchemaChangePolicy           map[string]any    `json:"SchemaChangePolicy"`
+	RecrawlPolicy                map[string]any    `json:"RecrawlPolicy"`
+	LineageConfiguration         map[string]any    `json:"LineageConfiguration"`
+	CrawlerSecurityConfiguration string            `json:"CrawlerSecurityConfiguration"`
+	Tags                         map[string]string `json:"Tags"`
+}
+
+//nolint:gocritic // hugeParam: request is decoded once; a pointer adds no value here
+func crawlerFromRequest(req createCrawlerRequest) driver.Crawler {
+	return driver.Crawler{
+		Name: req.Name, Role: req.Role, DatabaseName: req.DatabaseName, Description: req.Description,
+		Targets: req.Targets, Classifiers: req.Classifiers, TablePrefix: req.TablePrefix,
+		Schedule: req.Schedule, Configuration: req.Configuration, SchemaChangePolicy: req.SchemaChangePolicy,
+		RecrawlPolicy: req.RecrawlPolicy, LineageConfiguration: req.LineageConfiguration,
+		SecurityConfiguration: req.CrawlerSecurityConfiguration, Tags: req.Tags,
+	}
 }
 
 func (h *Handler) createCrawler(w http.ResponseWriter, r *http.Request) {
 	dispatch(h, w, r, func(h *Handler, ctx context.Context, req *createCrawlerRequest) (any, error) {
-		if err := h.glue.CreateCrawler(ctx, driver.Crawler{
-			Name: req.Name, Role: req.Role, DatabaseName: req.DatabaseName, Description: req.Description,
-			Targets: req.Targets, Classifiers: req.Classifiers, TablePrefix: req.TablePrefix,
-			Schedule: req.Schedule, Configuration: req.Configuration,
-		}); err != nil {
+		if err := h.glue.CreateCrawler(ctx, crawlerFromRequest(*req)); err != nil {
 			return nil, err
 		}
 
@@ -84,11 +102,7 @@ func (h *Handler) getCrawler(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) updateCrawler(w http.ResponseWriter, r *http.Request) {
 	dispatch(h, w, r, func(h *Handler, ctx context.Context, req *createCrawlerRequest) (any, error) {
-		if err := h.glue.UpdateCrawler(ctx, req.Name, driver.Crawler{
-			Name: req.Name, Role: req.Role, DatabaseName: req.DatabaseName, Description: req.Description,
-			Targets: req.Targets, Classifiers: req.Classifiers, TablePrefix: req.TablePrefix,
-			Schedule: req.Schedule, Configuration: req.Configuration,
-		}); err != nil {
+		if err := h.glue.UpdateCrawler(ctx, req.Name, crawlerFromRequest(*req)); err != nil {
 			return nil, err
 		}
 

--- a/server/aws/glue/job_ops.go
+++ b/server/aws/glue/job_ops.go
@@ -8,19 +8,23 @@ import (
 )
 
 type jobJSON struct {
-	Name             string            `json:"Name"`
-	Description      string            `json:"Description,omitempty"`
-	Role             string            `json:"Role,omitempty"`
-	Command          map[string]any    `json:"Command,omitempty"`
-	DefaultArguments map[string]string `json:"DefaultArguments,omitempty"`
-	MaxRetries       int32             `json:"MaxRetries,omitempty"`
-	Timeout          int32             `json:"Timeout,omitempty"`
-	GlueVersion      string            `json:"GlueVersion,omitempty"`
-	WorkerType       string            `json:"WorkerType,omitempty"`
-	NumberOfWorkers  int32             `json:"NumberOfWorkers,omitempty"`
-	MaxCapacity      float64           `json:"MaxCapacity,omitempty"`
-	CreatedOn        *float64          `json:"CreatedOn,omitempty"`
-	LastModifiedOn   *float64          `json:"LastModifiedOn,omitempty"`
+	Name                  string            `json:"Name"`
+	Description           string            `json:"Description,omitempty"`
+	Role                  string            `json:"Role,omitempty"`
+	Command               map[string]any    `json:"Command,omitempty"`
+	DefaultArguments      map[string]string `json:"DefaultArguments,omitempty"`
+	MaxRetries            int32             `json:"MaxRetries,omitempty"`
+	Timeout               int32             `json:"Timeout,omitempty"`
+	GlueVersion           string            `json:"GlueVersion,omitempty"`
+	WorkerType            string            `json:"WorkerType,omitempty"`
+	NumberOfWorkers       int32             `json:"NumberOfWorkers,omitempty"`
+	MaxCapacity           float64           `json:"MaxCapacity,omitempty"`
+	ExecutionProperty     map[string]any    `json:"ExecutionProperty,omitempty"`
+	Connections           map[string]any    `json:"Connections,omitempty"`
+	NotificationProperty  map[string]any    `json:"NotificationProperty,omitempty"`
+	SecurityConfiguration string            `json:"SecurityConfiguration,omitempty"`
+	CreatedOn             *float64          `json:"CreatedOn,omitempty"`
+	LastModifiedOn        *float64          `json:"LastModifiedOn,omitempty"`
 }
 
 func jobToWire(j *driver.Job) jobJSON {
@@ -28,21 +32,27 @@ func jobToWire(j *driver.Job) jobJSON {
 		Name: j.Name, Description: j.Description, Role: j.Role, Command: j.Command,
 		DefaultArguments: j.DefaultArguments, MaxRetries: j.MaxRetries, Timeout: j.Timeout,
 		GlueVersion: j.GlueVersion, WorkerType: j.WorkerType, NumberOfWorkers: j.NumberOfWorkers,
-		MaxCapacity: j.MaxCapacity, CreatedOn: epochOrNil(j.CreatedOn), LastModifiedOn: epochOrNil(j.LastModifiedOn),
+		MaxCapacity: j.MaxCapacity, ExecutionProperty: j.ExecutionProperty, Connections: j.Connections,
+		NotificationProperty: j.NotificationProperty, SecurityConfiguration: j.SecurityConfiguration,
+		CreatedOn: epochOrNil(j.CreatedOn), LastModifiedOn: epochOrNil(j.LastModifiedOn),
 	}
 }
 
 type jobInputJSON struct {
-	Description      string            `json:"Description"`
-	Role             string            `json:"Role"`
-	Command          map[string]any    `json:"Command"`
-	DefaultArguments map[string]string `json:"DefaultArguments"`
-	MaxRetries       int32             `json:"MaxRetries"`
-	Timeout          int32             `json:"Timeout"`
-	GlueVersion      string            `json:"GlueVersion"`
-	WorkerType       string            `json:"WorkerType"`
-	NumberOfWorkers  int32             `json:"NumberOfWorkers"`
-	MaxCapacity      float64           `json:"MaxCapacity"`
+	Description           string            `json:"Description"`
+	Role                  string            `json:"Role"`
+	Command               map[string]any    `json:"Command"`
+	DefaultArguments      map[string]string `json:"DefaultArguments"`
+	MaxRetries            int32             `json:"MaxRetries"`
+	Timeout               int32             `json:"Timeout"`
+	GlueVersion           string            `json:"GlueVersion"`
+	WorkerType            string            `json:"WorkerType"`
+	NumberOfWorkers       int32             `json:"NumberOfWorkers"`
+	MaxCapacity           float64           `json:"MaxCapacity"`
+	ExecutionProperty     map[string]any    `json:"ExecutionProperty"`
+	Connections           map[string]any    `json:"Connections"`
+	NotificationProperty  map[string]any    `json:"NotificationProperty"`
+	SecurityConfiguration string            `json:"SecurityConfiguration"`
 }
 
 //nolint:gocritic // hugeParam: taken by value to match the driver interface / copy semantics
@@ -51,22 +61,28 @@ func jobFromInput(name string, in jobInputJSON) driver.Job {
 		Name: name, Description: in.Description, Role: in.Role, Command: in.Command,
 		DefaultArguments: in.DefaultArguments, MaxRetries: in.MaxRetries, Timeout: in.Timeout,
 		GlueVersion: in.GlueVersion, WorkerType: in.WorkerType, NumberOfWorkers: in.NumberOfWorkers,
-		MaxCapacity: in.MaxCapacity,
+		MaxCapacity: in.MaxCapacity, ExecutionProperty: in.ExecutionProperty, Connections: in.Connections,
+		NotificationProperty: in.NotificationProperty, SecurityConfiguration: in.SecurityConfiguration,
 	}
 }
 
 type createJobRequest struct {
-	Name             string            `json:"Name"`
-	Description      string            `json:"Description"`
-	Role             string            `json:"Role"`
-	Command          map[string]any    `json:"Command"`
-	DefaultArguments map[string]string `json:"DefaultArguments"`
-	MaxRetries       int32             `json:"MaxRetries"`
-	Timeout          int32             `json:"Timeout"`
-	GlueVersion      string            `json:"GlueVersion"`
-	WorkerType       string            `json:"WorkerType"`
-	NumberOfWorkers  int32             `json:"NumberOfWorkers"`
-	MaxCapacity      float64           `json:"MaxCapacity"`
+	Name                  string            `json:"Name"`
+	Description           string            `json:"Description"`
+	Role                  string            `json:"Role"`
+	Command               map[string]any    `json:"Command"`
+	DefaultArguments      map[string]string `json:"DefaultArguments"`
+	MaxRetries            int32             `json:"MaxRetries"`
+	Timeout               int32             `json:"Timeout"`
+	GlueVersion           string            `json:"GlueVersion"`
+	WorkerType            string            `json:"WorkerType"`
+	NumberOfWorkers       int32             `json:"NumberOfWorkers"`
+	MaxCapacity           float64           `json:"MaxCapacity"`
+	ExecutionProperty     map[string]any    `json:"ExecutionProperty"`
+	Connections           map[string]any    `json:"Connections"`
+	NotificationProperty  map[string]any    `json:"NotificationProperty"`
+	SecurityConfiguration string            `json:"SecurityConfiguration"`
+	Tags                  map[string]string `json:"Tags"`
 }
 
 type nameResponse struct {
@@ -79,7 +95,9 @@ func (h *Handler) createJob(w http.ResponseWriter, r *http.Request) {
 			Name: req.Name, Description: req.Description, Role: req.Role, Command: req.Command,
 			DefaultArguments: req.DefaultArguments, MaxRetries: req.MaxRetries, Timeout: req.Timeout,
 			GlueVersion: req.GlueVersion, WorkerType: req.WorkerType, NumberOfWorkers: req.NumberOfWorkers,
-			MaxCapacity: req.MaxCapacity,
+			MaxCapacity: req.MaxCapacity, ExecutionProperty: req.ExecutionProperty, Connections: req.Connections,
+			NotificationProperty: req.NotificationProperty, SecurityConfiguration: req.SecurityConfiguration,
+			Tags: req.Tags,
 		}
 
 		name, err := h.glue.CreateJob(ctx, j)

--- a/server/aws/glue/partition_ops.go
+++ b/server/aws/glue/partition_ops.go
@@ -89,6 +89,7 @@ type getPartitionsRequest struct {
 	CatalogID    string `json:"CatalogId"`
 	DatabaseName string `json:"DatabaseName"`
 	TableName    string `json:"TableName"`
+	Expression   string `json:"Expression"`
 	NextToken    string `json:"NextToken"`
 	MaxResults   int32  `json:"MaxResults"`
 }
@@ -101,7 +102,7 @@ type getPartitionsResponse struct {
 func (h *Handler) getPartitions(w http.ResponseWriter, r *http.Request) {
 	dispatch(h, w, r, func(h *Handler, ctx context.Context, req *getPartitionsRequest) (any, error) {
 		ps, next, err := h.glue.GetPartitions(ctx, req.CatalogID, req.DatabaseName, req.TableName,
-			driver.TablePagination{NextToken: req.NextToken, MaxResults: req.MaxResults})
+			driver.TablePagination{NextToken: req.NextToken, MaxResults: req.MaxResults, Expression: req.Expression})
 		if err != nil {
 			return nil, err
 		}

--- a/server/aws/glue/sdk_roundtrip_test.go
+++ b/server/aws/glue/sdk_roundtrip_test.go
@@ -317,5 +317,222 @@ func TestSDKDeleteSchemaVersionsReportsFailingVersion(t *testing.T) {
 	}
 }
 
+// seedPartitions creates a database + a two-partition-key table (country, dt)
+// and the given partition value pairs, for the GetPartitions filter tests.
+func seedPartitions(t *testing.T, c *awsglue.Client, values [][]string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	if _, err := c.CreateDatabase(ctx, &awsglue.CreateDatabaseInput{
+		DatabaseInput: &gluetypes.DatabaseInput{Name: aws.String("pf")},
+	}); err != nil {
+		t.Fatalf("CreateDatabase: %v", err)
+	}
+
+	if _, err := c.CreateTable(ctx, &awsglue.CreateTableInput{
+		DatabaseName: aws.String("pf"),
+		TableInput: &gluetypes.TableInput{
+			Name: aws.String("t"),
+			PartitionKeys: []gluetypes.Column{
+				{Name: aws.String("country"), Type: aws.String("string")},
+				{Name: aws.String("dt"), Type: aws.String("string")},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	for _, v := range values {
+		if _, err := c.CreatePartition(ctx, &awsglue.CreatePartitionInput{
+			DatabaseName: aws.String("pf"), TableName: aws.String("t"),
+			PartitionInput: &gluetypes.PartitionInput{Values: v},
+		}); err != nil {
+			t.Fatalf("CreatePartition %v: %v", v, err)
+		}
+	}
+}
+
+// TestSDKGetPartitionsExpressionFilter verifies GetPartitions honors the
+// Expression filter (single equality and AND of two keys) rather than returning
+// every partition.
+func TestSDKGetPartitionsExpressionFilter(t *testing.T) {
+	ctx := context.Background()
+	c := newGlueClient(t)
+
+	seedPartitions(t, c, [][]string{
+		{"us", "2024-01-01"}, {"us", "2024-01-02"}, {"eu", "2024-01-01"},
+	})
+
+	single, err := c.GetPartitions(ctx, &awsglue.GetPartitionsInput{
+		DatabaseName: aws.String("pf"), TableName: aws.String("t"),
+		Expression: aws.String("country = 'us'"),
+	})
+	if err != nil {
+		t.Fatalf("GetPartitions single: %v", err)
+	}
+
+	if len(single.Partitions) != 2 {
+		t.Fatalf("country='us' returned %d partitions, want 2", len(single.Partitions))
+	}
+
+	for _, p := range single.Partitions {
+		if p.Values[0] != "us" {
+			t.Fatalf("filter leaked a non-us partition: %v", p.Values)
+		}
+	}
+
+	both, err := c.GetPartitions(ctx, &awsglue.GetPartitionsInput{
+		DatabaseName: aws.String("pf"), TableName: aws.String("t"),
+		Expression: aws.String("country = 'us' AND dt = '2024-01-01'"),
+	})
+	if err != nil {
+		t.Fatalf("GetPartitions AND: %v", err)
+	}
+
+	if len(both.Partitions) != 1 || both.Partitions[0].Values[1] != "2024-01-01" {
+		t.Fatalf("AND filter returned %d partitions (%v), want exactly [us 2024-01-01]",
+			len(both.Partitions), both.Partitions)
+	}
+}
+
+// TestSDKGetPartitionsNoExpressionReturnsAll verifies that omitting Expression
+// still returns every partition (unchanged behavior).
+func TestSDKGetPartitionsNoExpressionReturnsAll(t *testing.T) {
+	ctx := context.Background()
+	c := newGlueClient(t)
+
+	seedPartitions(t, c, [][]string{{"us", "2024-01-01"}, {"eu", "2024-01-01"}})
+
+	out, err := c.GetPartitions(ctx, &awsglue.GetPartitionsInput{
+		DatabaseName: aws.String("pf"), TableName: aws.String("t"),
+	})
+	if err != nil {
+		t.Fatalf("GetPartitions: %v", err)
+	}
+
+	if len(out.Partitions) != 2 {
+		t.Fatalf("no-filter returned %d partitions, want 2", len(out.Partitions))
+	}
+}
+
+// TestSDKGetPartitionsBadExpression verifies a malformed filter is a typed
+// InvalidInputException rather than being silently ignored.
+func TestSDKGetPartitionsBadExpression(t *testing.T) {
+	ctx := context.Background()
+	c := newGlueClient(t)
+
+	seedPartitions(t, c, [][]string{{"us", "2024-01-01"}})
+
+	_, err := c.GetPartitions(ctx, &awsglue.GetPartitionsInput{
+		DatabaseName: aws.String("pf"), TableName: aws.String("t"),
+		Expression: aws.String("country ="),
+	})
+
+	var invalid *gluetypes.InvalidInputException
+	if !errors.As(err, &invalid) {
+		t.Fatalf("bad expression err = %v, want *InvalidInputException", err)
+	}
+}
+
+// TestSDKCrawlerFieldsRoundTrip verifies SchemaChangePolicy and RecrawlPolicy
+// survive CreateCrawler -> GetCrawler and that Tags are readable via GetTags,
+// matching real Glue (GetCrawler omits tags).
+func TestSDKCrawlerFieldsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c := newGlueClient(t)
+
+	if _, err := c.CreateCrawler(ctx, &awsglue.CreateCrawlerInput{
+		Name: aws.String("cw"), Role: aws.String("r"), DatabaseName: aws.String("db"),
+		Targets: &gluetypes.CrawlerTargets{
+			S3Targets: []gluetypes.S3Target{{Path: aws.String("s3://bucket/prefix")}},
+		},
+		SchemaChangePolicy: &gluetypes.SchemaChangePolicy{
+			UpdateBehavior: gluetypes.UpdateBehaviorLog, DeleteBehavior: gluetypes.DeleteBehaviorLog,
+		},
+		RecrawlPolicy: &gluetypes.RecrawlPolicy{RecrawlBehavior: gluetypes.RecrawlBehaviorCrawlEverything},
+		Tags:          map[string]string{"env": "prod"},
+	}); err != nil {
+		t.Fatalf("CreateCrawler: %v", err)
+	}
+
+	got, err := c.GetCrawler(ctx, &awsglue.GetCrawlerInput{Name: aws.String("cw")})
+	if err != nil {
+		t.Fatalf("GetCrawler: %v", err)
+	}
+
+	scp := got.Crawler.SchemaChangePolicy
+	if scp == nil || scp.UpdateBehavior != gluetypes.UpdateBehaviorLog ||
+		scp.DeleteBehavior != gluetypes.DeleteBehaviorLog {
+		t.Fatalf("SchemaChangePolicy = %+v, want LOG/LOG", scp)
+	}
+
+	if got.Crawler.RecrawlPolicy == nil ||
+		got.Crawler.RecrawlPolicy.RecrawlBehavior != gluetypes.RecrawlBehaviorCrawlEverything {
+		t.Fatalf("RecrawlPolicy = %+v, want CRAWL_EVERYTHING", got.Crawler.RecrawlPolicy)
+	}
+
+	tags, err := c.GetTags(ctx, &awsglue.GetTagsInput{
+		ResourceArn: aws.String("arn:aws:glue:us-east-1:123456789012:crawler/cw"),
+	})
+	if err != nil {
+		t.Fatalf("GetTags: %v", err)
+	}
+
+	if tags.Tags["env"] != "prod" {
+		t.Fatalf("crawler tags = %v, want env=prod", tags.Tags)
+	}
+}
+
+// TestSDKJobFieldsRoundTrip verifies ExecutionProperty, Connections and
+// NotificationProperty survive CreateJob -> GetJob, and Tags are readable via
+// GetTags.
+func TestSDKJobFieldsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c := newGlueClient(t)
+
+	if _, err := c.CreateJob(ctx, &awsglue.CreateJobInput{
+		Name: aws.String("j"), Role: aws.String("arn:aws:iam::123456789012:role/r"),
+		Command:           &gluetypes.JobCommand{Name: aws.String("glueetl")},
+		ExecutionProperty: &gluetypes.ExecutionProperty{MaxConcurrentRuns: 3},
+		Connections:       &gluetypes.ConnectionsList{Connections: []string{"conn-a"}},
+		NotificationProperty: &gluetypes.NotificationProperty{
+			NotifyDelayAfter: aws.Int32(10),
+		},
+		Tags: map[string]string{"team": "data"},
+	}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+
+	got, err := c.GetJob(ctx, &awsglue.GetJobInput{JobName: aws.String("j")})
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+
+	if got.Job.ExecutionProperty == nil || got.Job.ExecutionProperty.MaxConcurrentRuns != 3 {
+		t.Fatalf("ExecutionProperty = %+v, want MaxConcurrentRuns=3", got.Job.ExecutionProperty)
+	}
+
+	if got.Job.Connections == nil || len(got.Job.Connections.Connections) != 1 ||
+		got.Job.Connections.Connections[0] != "conn-a" {
+		t.Fatalf("Connections = %+v, want [conn-a]", got.Job.Connections)
+	}
+
+	if got.Job.NotificationProperty == nil || aws.ToInt32(got.Job.NotificationProperty.NotifyDelayAfter) != 10 {
+		t.Fatalf("NotificationProperty = %+v, want NotifyDelayAfter=10", got.Job.NotificationProperty)
+	}
+
+	tags, err := c.GetTags(ctx, &awsglue.GetTagsInput{
+		ResourceArn: aws.String("arn:aws:glue:us-east-1:123456789012:job/j"),
+	})
+	if err != nil {
+		t.Fatalf("GetTags: %v", err)
+	}
+
+	if tags.Tags["team"] != "data" {
+		t.Fatalf("job tags = %v, want team=data", tags.Tags)
+	}
+}
+
 // smithyAPIError is asserted to ensure our error type is a modeled smithy error.
 var _ smithy.APIError = (*gluetypes.EntityNotFoundException)(nil)

--- a/services/glue/driver/types.go
+++ b/services/glue/driver/types.go
@@ -142,22 +142,31 @@ type ResourceURI struct {
 	URI          string
 }
 
-// Crawler is a Data Catalog crawler.
+// Crawler is a Data Catalog crawler. SchemaChangePolicy, RecrawlPolicy and
+// LineageConfiguration are round-tripped opaquely (stored as decoded JSON) so
+// aws_glue_crawler does not report drift; Tags are stored in the tag store under
+// the crawler ARN, matching real Glue where GetCrawler omits tags and GetTags
+// returns them.
 type Crawler struct {
-	Name            string
-	Role            string
-	DatabaseName    string
-	Description     string
-	Targets         map[string]any
-	Classifiers     []string
-	TablePrefix     string
-	State           string
-	Schedule        string
-	Configuration   string
-	CreationTime    time.Time
-	LastUpdated     time.Time
-	Version         int64
-	LastCrawlStatus string
+	Name                  string
+	Role                  string
+	DatabaseName          string
+	Description           string
+	Targets               map[string]any
+	Classifiers           []string
+	TablePrefix           string
+	State                 string
+	Schedule              string
+	Configuration         string
+	SchemaChangePolicy    map[string]any
+	RecrawlPolicy         map[string]any
+	LineageConfiguration  map[string]any
+	SecurityConfiguration string
+	Tags                  map[string]string
+	CreationTime          time.Time
+	LastUpdated           time.Time
+	Version               int64
+	LastCrawlStatus       string
 }
 
 // Classifier is a Data Catalog classifier (grok/json/csv/xml union).
@@ -182,21 +191,29 @@ type Connection struct {
 	LastUpdatedTime      time.Time
 }
 
-// Job is a Glue ETL job definition.
+// Job is a Glue ETL job definition. ExecutionProperty, Connections and
+// NotificationProperty are round-tripped opaquely (stored as decoded JSON) so
+// aws_glue_job does not report drift; Tags are stored in the tag store under the
+// job ARN, matching real Glue where GetJob omits tags and GetTags returns them.
 type Job struct {
-	Name             string
-	Description      string
-	Role             string
-	Command          map[string]any
-	DefaultArguments map[string]string
-	MaxRetries       int32
-	Timeout          int32
-	GlueVersion      string
-	WorkerType       string
-	NumberOfWorkers  int32
-	MaxCapacity      float64
-	CreatedOn        time.Time
-	LastModifiedOn   time.Time
+	Name                  string
+	Description           string
+	Role                  string
+	Command               map[string]any
+	DefaultArguments      map[string]string
+	MaxRetries            int32
+	Timeout               int32
+	GlueVersion           string
+	WorkerType            string
+	NumberOfWorkers       int32
+	MaxCapacity           float64
+	ExecutionProperty     map[string]any
+	Connections           map[string]any
+	NotificationProperty  map[string]any
+	SecurityConfiguration string
+	Tags                  map[string]string
+	CreatedOn             time.Time
+	LastModifiedOn        time.Time
 }
 
 // JobRun is a single execution of a Job.


### PR DESCRIPTION
## Summary

Fixes three AWS Glue gaps that caused wrong query results and Terraform drift. All verified end-to-end against `aws-sdk-go-v2/service/glue`.

### 1. GetPartitions honors the Expression filter
Previously `GetPartitions` ignored `Expression` and returned **all** partitions. Implemented the common Glue partition-filter grammar (a small tokenizer + recursive-descent parser):
- `key = 'value'`, comparison operators `=`, `<>`, `>`, `<`, `>=`, `<=`
- `AND` / `OR`, parentheses, string and number literals
- keys matched positionally against a partition's `Values` via the table's partition-key order; numeric literals compare numerically when the value parses as a number, else lexically
- a malformed expression is a typed `InvalidInputException`; no `Expression` still returns all partitions (unchanged)

### 2. Crawler fields round-trip (aws_glue_crawler drift)
`SchemaChangePolicy`, `RecrawlPolicy`, `LineageConfiguration` and `CrawlerSecurityConfiguration` now round-trip `CreateCrawler`/`UpdateCrawler` -> `GetCrawler` (stored opaquely as decoded JSON). Create-time `Tags` are stored under the crawler ARN and read back via `GetTags`, matching real Glue (GetCrawler omits tags).

### 3. Job fields round-trip (aws_glue_job drift)
`ExecutionProperty`, `Connections`, `NotificationProperty` and `SecurityConfiguration` now round-trip `CreateJob`/`UpdateJob` -> `GetJob`. Create-time `Tags` are stored under the job ARN and read back via `GetTags`.

## Tests (real glue SDK, booted httptest server)
- `TestSDKGetPartitionsExpressionFilter` — single equality and AND of two keys return only matching partitions
- `TestSDKGetPartitionsNoExpressionReturnsAll` — no filter returns all
- `TestSDKGetPartitionsBadExpression` — malformed filter -> InvalidInputException
- `TestSDKCrawlerFieldsRoundTrip` — SchemaChangePolicy/RecrawlPolicy via GetCrawler, Tags via GetTags
- `TestSDKJobFieldsRoundTrip` — ExecutionProperty/Connections/NotificationProperty via GetJob, Tags via GetTags

## Gates
build, vet, `go test` (server+provider glue), `-race` (provider), gofmt, `go generate` (zero diff), compatgen (`docs/compat` zero diff), golangci-lint (no new issues) — all green.
