### PR TITLE
fix(cloudwatch): support dashboards and composite alarms

### DIFF
--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -52,13 +52,15 @@ type metricKey struct {
 
 // Mock is an in-memory mock implementation of the AWS CloudWatch service.
 type Mock struct {
-	mu       sync.RWMutex
-	metrics  map[metricKey][]driver.MetricDatum
-	alarms   *memstore.Store[*alarmData]
-	channels *memstore.Store[*driver.NotificationChannelInfo]
-	history  []driver.AlarmHistoryEntry
-	opts     *config.Options
-	sns      ActionPublisher
+	mu              sync.RWMutex
+	metrics         map[metricKey][]driver.MetricDatum
+	alarms          *memstore.Store[*alarmData]
+	compositeAlarms *memstore.Store[*compositeAlarmData]
+	dashboards      *memstore.Store[*storedDashboard]
+	channels        *memstore.Store[*driver.NotificationChannelInfo]
+	history         []driver.AlarmHistoryEntry
+	opts            *config.Options
+	sns             ActionPublisher
 }
 
 // SetSNSPublisher wires the SNS backend so an alarm state transition delivers
@@ -97,10 +99,12 @@ type alarmData struct {
 // New creates a new CloudWatch mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		metrics:  make(map[metricKey][]driver.MetricDatum),
-		alarms:   memstore.New[*alarmData](),
-		channels: memstore.New[*driver.NotificationChannelInfo](),
-		opts:     opts,
+		metrics:         make(map[metricKey][]driver.MetricDatum),
+		alarms:          memstore.New[*alarmData](),
+		compositeAlarms: memstore.New[*compositeAlarmData](),
+		dashboards:      memstore.New[*storedDashboard](),
+		channels:        memstore.New[*driver.NotificationChannelInfo](),
+		opts:            opts,
 	}
 }
 

--- a/providers/aws/cloudwatch/composite_alarms.go
+++ b/providers/aws/cloudwatch/composite_alarms.go
@@ -1,0 +1,146 @@
+package cloudwatch
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// compositeAlarmData is a stored composite alarm. Its AlarmRule is a boolean
+// expression over other alarms' states. The rule is round-tripped faithfully so
+// Terraform's aws_cloudwatch_composite_alarm never drifts; the state is not
+// re-evaluated against child-alarm transitions (see PutCompositeAlarm).
+type compositeAlarmData struct {
+	Name                    string
+	ARN                     string
+	AlarmRule               string
+	AlarmDescription        string
+	State                   string
+	StateReason             string
+	StateUpdatedTimestamp   time.Time
+	ActionsEnabled          bool
+	AlarmActions            []string
+	OKActions               []string
+	InsufficientDataActions []string
+	Tags                    map[string]string
+}
+
+// PutCompositeAlarm creates or updates a composite alarm. The AlarmRule and
+// actions are stored verbatim. The alarm's StateValue is left at
+// INSUFFICIENT_DATA on create: cloudemu does not run the boolean rule engine
+// against child-alarm states (there is no trigger that re-evaluates a composite
+// when a referenced alarm transitions), so rather than ship a half-working
+// evaluator the definition is round-tripped faithfully. Updating an existing
+// composite alarm preserves its current state and tags, matching PutMetricAlarm.
+//
+//nolint:gocritic // hugeParam: matches the optional-capability interface signature.
+func (m *Mock) PutCompositeAlarm(_ context.Context, cfg driver.CompositeAlarmConfig) error {
+	if cfg.Name == "" {
+		return errors.Newf(errors.InvalidArgument, "alarm name is required")
+	}
+
+	if strings.TrimSpace(cfg.AlarmRule) == "" {
+		return errors.Newf(errors.InvalidArgument, "alarm rule is required")
+	}
+
+	actionsEnabled := true
+	if cfg.ActionsEnabled != nil {
+		actionsEnabled = *cfg.ActionsEnabled
+	}
+
+	state := stateInsufficientData
+	stateReason := "Unchecked: Initial alarm creation"
+	stateUpdated := m.opts.Clock.Now()
+
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
+	if existing, ok := m.compositeAlarms.Get(cfg.Name); ok {
+		state = existing.State
+		stateReason = existing.StateReason
+		stateUpdated = existing.StateUpdatedTimestamp
+		tags = existing.Tags
+	}
+
+	m.compositeAlarms.Set(cfg.Name, &compositeAlarmData{
+		Name:                    cfg.Name,
+		ARN:                     idgen.AWSARN("cloudwatch", m.opts.Region, m.opts.AccountID, "alarm:"+cfg.Name),
+		AlarmRule:               cfg.AlarmRule,
+		AlarmDescription:        cfg.AlarmDescription,
+		State:                   state,
+		StateReason:             stateReason,
+		StateUpdatedTimestamp:   stateUpdated,
+		ActionsEnabled:          actionsEnabled,
+		AlarmActions:            append([]string{}, cfg.AlarmActions...),
+		OKActions:               append([]string{}, cfg.OKActions...),
+		InsufficientDataActions: append([]string{}, cfg.InsufficientDataActions...),
+		Tags:                    tags,
+	})
+
+	return nil
+}
+
+// DescribeCompositeAlarms returns composite alarms matching the given names, or
+// all composite alarms when names is empty.
+func (m *Mock) DescribeCompositeAlarms(_ context.Context, names []string) ([]driver.CompositeAlarmInfo, error) {
+	if len(names) == 0 {
+		all := m.compositeAlarms.All()
+		out := make([]driver.CompositeAlarmInfo, 0, len(all))
+
+		for _, a := range all {
+			out = append(out, toCompositeAlarmInfo(a))
+		}
+
+		sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+
+		return out, nil
+	}
+
+	out := make([]driver.CompositeAlarmInfo, 0, len(names))
+
+	for _, name := range names {
+		a, ok := m.compositeAlarms.Get(name)
+		if !ok {
+			continue
+		}
+
+		out = append(out, toCompositeAlarmInfo(a))
+	}
+
+	return out, nil
+}
+
+// DeleteCompositeAlarms deletes every named composite alarm that exists,
+// silently skipping names that are absent. DeleteAlarms accepts both metric and
+// composite alarm names in one call, so a name that is not a composite alarm is
+// not an error here.
+func (m *Mock) DeleteCompositeAlarms(_ context.Context, names []string) error {
+	for _, name := range names {
+		m.compositeAlarms.Delete(name)
+	}
+
+	return nil
+}
+
+func toCompositeAlarmInfo(a *compositeAlarmData) driver.CompositeAlarmInfo {
+	return driver.CompositeAlarmInfo{
+		Name:                    a.Name,
+		ARN:                     a.ARN,
+		AlarmRule:               a.AlarmRule,
+		AlarmDescription:        a.AlarmDescription,
+		State:                   a.State,
+		StateReason:             a.StateReason,
+		StateUpdatedTimestamp:   a.StateUpdatedTimestamp,
+		ActionsEnabled:          a.ActionsEnabled,
+		AlarmActions:            append([]string{}, a.AlarmActions...),
+		OKActions:               append([]string{}, a.OKActions...),
+		InsufficientDataActions: append([]string{}, a.InsufficientDataActions...),
+	}
+}

--- a/providers/aws/cloudwatch/composite_alarms_test.go
+++ b/providers/aws/cloudwatch/composite_alarms_test.go
@@ -1,0 +1,114 @@
+package cloudwatch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+func TestPutCompositeAlarmRoundTrip(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cfg := driver.CompositeAlarmConfig{
+		Name:             "app-unhealthy",
+		AlarmRule:        `ALARM("cpu-high") OR ALARM("mem-high")`,
+		AlarmDescription: "app is unhealthy",
+		AlarmActions:     []string{"arn:aws:sns:us-east-1:123456789012:ops"},
+		OKActions:        []string{"arn:aws:sns:us-east-1:123456789012:ok"},
+	}
+
+	t.Run("create then describe returns what was put", func(t *testing.T) {
+		requireNoError(t, m.PutCompositeAlarm(ctx, cfg))
+
+		out, err := m.DescribeCompositeAlarms(ctx, nil)
+		requireNoError(t, err)
+		assertEqual(t, 1, len(out))
+
+		a := out[0]
+		assertEqual(t, cfg.Name, a.Name)
+		assertEqual(t, cfg.AlarmRule, a.AlarmRule)
+		assertEqual(t, cfg.AlarmDescription, a.AlarmDescription)
+		assertEqual(t, true, a.ActionsEnabled)
+		assertEqual(t, 1, len(a.AlarmActions))
+		assertEqual(t, cfg.AlarmActions[0], a.AlarmActions[0])
+		assertEqual(t, 1, len(a.OKActions))
+		// Round-trip only: no boolean rule engine, so state stays INSUFFICIENT_DATA.
+		assertEqual(t, stateInsufficientData, a.State)
+		if a.ARN == "" {
+			t.Fatal("expected a non-empty composite alarm ARN")
+		}
+	})
+
+	t.Run("describe by name", func(t *testing.T) {
+		out, err := m.DescribeCompositeAlarms(ctx, []string{"app-unhealthy"})
+		requireNoError(t, err)
+		assertEqual(t, 1, len(out))
+		assertEqual(t, "app-unhealthy", out[0].Name)
+	})
+
+	t.Run("describe unknown name returns none", func(t *testing.T) {
+		out, err := m.DescribeCompositeAlarms(ctx, []string{"nope"})
+		requireNoError(t, err)
+		assertEqual(t, 0, len(out))
+	})
+
+	t.Run("empty name is rejected", func(t *testing.T) {
+		assertError(t, m.PutCompositeAlarm(ctx, driver.CompositeAlarmConfig{AlarmRule: "ALARM(x)"}), true)
+	})
+
+	t.Run("empty rule is rejected", func(t *testing.T) {
+		assertError(t, m.PutCompositeAlarm(ctx, driver.CompositeAlarmConfig{Name: "x"}), true)
+	})
+}
+
+func TestCompositeAlarmActionsEnabledFalse(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	disabled := false
+	requireNoError(t, m.PutCompositeAlarm(ctx, driver.CompositeAlarmConfig{
+		Name:           "quiet",
+		AlarmRule:      "ALARM(x)",
+		ActionsEnabled: &disabled,
+	}))
+
+	out, err := m.DescribeCompositeAlarms(ctx, []string{"quiet"})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(out))
+	assertEqual(t, false, out[0].ActionsEnabled)
+}
+
+func TestDeleteCompositeAlarms(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.PutCompositeAlarm(ctx, driver.CompositeAlarmConfig{Name: "c1", AlarmRule: "ALARM(x)"}))
+	requireNoError(t, m.PutCompositeAlarm(ctx, driver.CompositeAlarmConfig{Name: "c2", AlarmRule: "ALARM(y)"}))
+
+	// Deleting a mix of present and absent names is not an error (DeleteAlarms
+	// accepts both metric and composite alarm names in one call).
+	requireNoError(t, m.DeleteCompositeAlarms(ctx, []string{"c1", "absent"}))
+
+	out, err := m.DescribeCompositeAlarms(ctx, nil)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(out))
+	assertEqual(t, "c2", out[0].Name)
+}
+
+func TestPutCompositeAlarmUpdatePreservesState(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.PutCompositeAlarm(ctx, driver.CompositeAlarmConfig{Name: "u", AlarmRule: "ALARM(x)"}))
+
+	// Update the rule; a subsequent describe should reflect the new rule while
+	// the alarm remains a single entry.
+	requireNoError(t, m.PutCompositeAlarm(ctx, driver.CompositeAlarmConfig{Name: "u", AlarmRule: "ALARM(y)"}))
+
+	out, err := m.DescribeCompositeAlarms(ctx, []string{"u"})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(out))
+	assertEqual(t, "ALARM(y)", out[0].AlarmRule)
+}

--- a/providers/aws/cloudwatch/dashboards.go
+++ b/providers/aws/cloudwatch/dashboards.go
@@ -1,0 +1,105 @@
+package cloudwatch
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// storedDashboard is a persisted CloudWatch dashboard.
+type storedDashboard struct {
+	Name         string
+	Body         string
+	ARN          string
+	LastModified time.Time
+	Size         int
+}
+
+// PutDashboard creates or overwrites a dashboard. The DashboardBody must be a
+// valid JSON document, matching the real CloudWatch DashboardInvalidInputError
+// validation; an existing dashboard with the same name is replaced.
+func (m *Mock) PutDashboard(_ context.Context, name, body string) error {
+	if name == "" {
+		return errors.Newf(errors.InvalidArgument, "dashboard name is required")
+	}
+
+	if !json.Valid([]byte(body)) {
+		return errors.Newf(errors.InvalidArgument, "the dashboard body for %q is not valid JSON", name)
+	}
+
+	d := &storedDashboard{
+		Name:         name,
+		Body:         body,
+		ARN:          idgen.AWSARN("cloudwatch", m.opts.Region, m.opts.AccountID, "dashboard/"+name),
+		LastModified: m.opts.Clock.Now(),
+		Size:         len(body),
+	}
+
+	m.dashboards.Set(name, d)
+
+	return nil
+}
+
+// GetDashboard returns the named dashboard, or NotFound (the CloudWatch
+// DashboardNotFoundError) when it does not exist.
+func (m *Mock) GetDashboard(_ context.Context, name string) (*driver.DashboardInfo, error) {
+	d, ok := m.dashboards.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "dashboard %q not found", name)
+	}
+
+	return &driver.DashboardInfo{
+		Name:         d.Name,
+		Body:         d.Body,
+		ARN:          d.ARN,
+		LastModified: d.LastModified,
+		Size:         d.Size,
+	}, nil
+}
+
+// ListDashboards returns dashboard summaries (no body) whose name starts with
+// prefix, sorted by name. An empty prefix lists all dashboards.
+func (m *Mock) ListDashboards(_ context.Context, prefix string) ([]driver.DashboardEntry, error) {
+	all := m.dashboards.All()
+	out := make([]driver.DashboardEntry, 0, len(all))
+
+	for _, d := range all {
+		if prefix != "" && !strings.HasPrefix(d.Name, prefix) {
+			continue
+		}
+
+		out = append(out, driver.DashboardEntry{
+			Name:         d.Name,
+			ARN:          d.ARN,
+			LastModified: d.LastModified,
+			Size:         d.Size,
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+
+	return out, nil
+}
+
+// DeleteDashboards deletes every named dashboard. It mirrors the real API's
+// all-or-nothing semantics: if any name is missing, NotFound is returned and no
+// dashboard is deleted.
+func (m *Mock) DeleteDashboards(_ context.Context, names []string) error {
+	for _, name := range names {
+		if _, ok := m.dashboards.Get(name); !ok {
+			return errors.Newf(errors.NotFound, "dashboard %q not found", name)
+		}
+	}
+
+	for _, name := range names {
+		m.dashboards.Delete(name)
+	}
+
+	return nil
+}

--- a/providers/aws/cloudwatch/dashboards_test.go
+++ b/providers/aws/cloudwatch/dashboards_test.go
@@ -1,0 +1,116 @@
+package cloudwatch
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPutGetDashboard(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	body := `{"widgets":[{"type":"metric","x":0,"y":0}]}`
+
+	t.Run("put valid then get", func(t *testing.T) {
+		requireNoError(t, m.PutDashboard(ctx, "ops", body))
+
+		d, err := m.GetDashboard(ctx, "ops")
+		requireNoError(t, err)
+		assertEqual(t, "ops", d.Name)
+		assertEqual(t, body, d.Body)
+		assertEqual(t, len(body), d.Size)
+		if d.ARN == "" {
+			t.Fatal("expected a non-empty dashboard ARN")
+		}
+		if d.LastModified.IsZero() {
+			t.Fatal("expected a non-zero LastModified")
+		}
+	})
+
+	t.Run("put invalid JSON is rejected", func(t *testing.T) {
+		assertError(t, m.PutDashboard(ctx, "bad", "not-json"), true)
+	})
+
+	t.Run("empty name is rejected", func(t *testing.T) {
+		assertError(t, m.PutDashboard(ctx, "", body), true)
+	})
+
+	t.Run("get unknown is not found", func(t *testing.T) {
+		_, err := m.GetDashboard(ctx, "missing")
+		assertError(t, err, true)
+	})
+
+	t.Run("put overwrites existing", func(t *testing.T) {
+		newBody := `{"widgets":[]}`
+		requireNoError(t, m.PutDashboard(ctx, "ops", newBody))
+
+		d, err := m.GetDashboard(ctx, "ops")
+		requireNoError(t, err)
+		assertEqual(t, newBody, d.Body)
+	})
+}
+
+func TestListDashboards(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	body := `{}`
+	requireNoError(t, m.PutDashboard(ctx, "prod-web", body))
+	requireNoError(t, m.PutDashboard(ctx, "prod-api", body))
+	requireNoError(t, m.PutDashboard(ctx, "staging-web", body))
+
+	t.Run("no prefix lists all sorted", func(t *testing.T) {
+		entries, err := m.ListDashboards(ctx, "")
+		requireNoError(t, err)
+		assertEqual(t, 3, len(entries))
+		assertEqual(t, "prod-api", entries[0].Name)
+		assertEqual(t, "prod-web", entries[1].Name)
+		assertEqual(t, "staging-web", entries[2].Name)
+	})
+
+	t.Run("prefix filters", func(t *testing.T) {
+		entries, err := m.ListDashboards(ctx, "prod-")
+		requireNoError(t, err)
+		assertEqual(t, 2, len(entries))
+		assertEqual(t, "prod-api", entries[0].Name)
+		assertEqual(t, "prod-web", entries[1].Name)
+	})
+
+	t.Run("entries carry arn and size", func(t *testing.T) {
+		entries, err := m.ListDashboards(ctx, "staging-web")
+		requireNoError(t, err)
+		assertEqual(t, 1, len(entries))
+		assertEqual(t, len(body), entries[0].Size)
+		if entries[0].ARN == "" {
+			t.Fatal("expected a non-empty ARN on the list entry")
+		}
+	})
+}
+
+func TestDeleteDashboards(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.PutDashboard(ctx, "a", `{}`))
+	requireNoError(t, m.PutDashboard(ctx, "b", `{}`))
+
+	t.Run("deletes each named", func(t *testing.T) {
+		requireNoError(t, m.DeleteDashboards(ctx, []string{"a", "b"}))
+
+		_, err := m.GetDashboard(ctx, "a")
+		assertError(t, err, true)
+		_, err = m.GetDashboard(ctx, "b")
+		assertError(t, err, true)
+	})
+
+	t.Run("unknown name is not found and deletes none", func(t *testing.T) {
+		requireNoError(t, m.PutDashboard(ctx, "keep", `{}`))
+
+		err := m.DeleteDashboards(ctx, []string{"keep", "gone"})
+		assertError(t, err, true)
+
+		// all-or-nothing: "keep" must still exist.
+		_, err = m.GetDashboard(ctx, "keep")
+		requireNoError(t, err)
+	})
+}

--- a/server/aws/cloudwatch/composite_alarms.go
+++ b/server/aws/cloudwatch/composite_alarms.go
@@ -1,0 +1,159 @@
+package cloudwatch
+
+// This file implements the CloudWatch composite-alarm operations over the
+// rpc-v2-cbor protocol, backing the aws_cloudwatch_composite_alarm Terraform
+// resource: PutCompositeAlarm creates one, DescribeAlarms surfaces them in the
+// CompositeAlarms list, and DeleteAlarms removes them. The store is an AWS-local
+// optional capability so the shared Monitoring interface stays unchanged.
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+const (
+	alarmTypeComposite = "CompositeAlarm"
+	alarmTypeMetric    = "MetricAlarm"
+)
+
+// compositeAlarmStore is the AWS-local capability behind the composite-alarm
+// operations.
+type compositeAlarmStore interface {
+	PutCompositeAlarm(ctx context.Context, cfg mondriver.CompositeAlarmConfig) error
+	DescribeCompositeAlarms(ctx context.Context, names []string) ([]mondriver.CompositeAlarmInfo, error)
+	DeleteCompositeAlarms(ctx context.Context, names []string) error
+}
+
+type putCompositeAlarmInput struct {
+	AlarmName               string   `cbor:"AlarmName"`
+	AlarmRule               string   `cbor:"AlarmRule"`
+	AlarmDescription        string   `cbor:"AlarmDescription,omitempty"`
+	ActionsEnabled          *bool    `cbor:"ActionsEnabled,omitempty"`
+	AlarmActions            []string `cbor:"AlarmActions,omitempty"`
+	OKActions               []string `cbor:"OKActions,omitempty"`
+	InsufficientDataActions []string `cbor:"InsufficientDataActions,omitempty"`
+	Tags                    []tagCBR `cbor:"Tags,omitempty"`
+}
+
+func (h *Handler) putCompositeAlarm(w http.ResponseWriter, r *http.Request, body []byte) {
+	store, ok := h.monitoring.(compositeAlarmStore)
+	if !ok {
+		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "composite alarms not supported")
+		return
+	}
+
+	var in putCompositeAlarmInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	err := store.PutCompositeAlarm(r.Context(), mondriver.CompositeAlarmConfig{
+		Name:                    in.AlarmName,
+		AlarmRule:               in.AlarmRule,
+		AlarmDescription:        in.AlarmDescription,
+		ActionsEnabled:          in.ActionsEnabled,
+		AlarmActions:            in.AlarmActions,
+		OKActions:               in.OKActions,
+		InsufficientDataActions: in.InsufficientDataActions,
+		Tags:                    tagsToMap(in.Tags),
+	})
+	if err != nil {
+		writeDriverErr(w, err)
+		return
+	}
+
+	writeCBORResponse(w, struct{}{})
+}
+
+type compositeAlarmCBR struct {
+	AlarmName               string     `cbor:"AlarmName"`
+	AlarmArn                string     `cbor:"AlarmArn,omitempty"`
+	AlarmRule               string     `cbor:"AlarmRule"`
+	AlarmDescription        string     `cbor:"AlarmDescription,omitempty"`
+	StateValue              string     `cbor:"StateValue"`
+	StateReason             string     `cbor:"StateReason,omitempty"`
+	StateUpdatedTimestamp   *time.Time `cbor:"StateUpdatedTimestamp,omitempty"`
+	ActionsEnabled          bool       `cbor:"ActionsEnabled"`
+	AlarmActions            []string   `cbor:"AlarmActions,omitempty"`
+	OKActions               []string   `cbor:"OKActions,omitempty"`
+	InsufficientDataActions []string   `cbor:"InsufficientDataActions,omitempty"`
+}
+
+// wantsAlarmType reports whether a DescribeAlarms request that lists alarmTypes
+// asks for the given type. An empty list means "both", matching modern AWS.
+func wantsAlarmType(alarmTypes []string, want string) bool {
+	if len(alarmTypes) == 0 {
+		return true
+	}
+
+	for _, t := range alarmTypes {
+		if t == want {
+			return true
+		}
+	}
+
+	return false
+}
+
+// compositeAlarmRows returns the composite alarms matching the DescribeAlarms
+// filters (names, name prefix, state), sorted by name and rendered for the wire.
+func (h *Handler) compositeAlarmRows(r *http.Request, in *describeAlarmsInput) ([]compositeAlarmCBR, error) {
+	store, ok := h.monitoring.(compositeAlarmStore)
+	if !ok {
+		return nil, nil
+	}
+
+	alarms, err := store.DescribeCompositeAlarms(r.Context(), in.AlarmNames)
+	if err != nil {
+		return nil, err
+	}
+
+	rows := make([]compositeAlarmCBR, 0, len(alarms))
+
+	for i := range alarms {
+		a := &alarms[i]
+		if in.AlarmNamePrefix != "" && !strings.HasPrefix(a.Name, in.AlarmNamePrefix) {
+			continue
+		}
+
+		if in.StateValue != "" && a.State != in.StateValue {
+			continue
+		}
+
+		rows = append(rows, toCompositeAlarmCBR(a))
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].AlarmName < rows[j].AlarmName })
+
+	return rows, nil
+}
+
+func toCompositeAlarmCBR(a *mondriver.CompositeAlarmInfo) compositeAlarmCBR {
+	c := compositeAlarmCBR{
+		AlarmName:               a.Name,
+		AlarmArn:                a.ARN,
+		AlarmRule:               a.AlarmRule,
+		AlarmDescription:        a.AlarmDescription,
+		StateValue:              a.State,
+		StateReason:             a.StateReason,
+		ActionsEnabled:          a.ActionsEnabled,
+		AlarmActions:            a.AlarmActions,
+		OKActions:               a.OKActions,
+		InsufficientDataActions: a.InsufficientDataActions,
+	}
+
+	if !a.StateUpdatedTimestamp.IsZero() {
+		ts := a.StateUpdatedTimestamp.UTC()
+		c.StateUpdatedTimestamp = &ts
+	}
+
+	return c
+}

--- a/server/aws/cloudwatch/composite_alarms_test.go
+++ b/server/aws/cloudwatch/composite_alarms_test.go
@@ -1,0 +1,140 @@
+package cloudwatch_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awscw "github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+)
+
+// TestSDKCompositeAlarmRoundTrip drives the aws-sdk-go-v2 client through the
+// aws_cloudwatch_composite_alarm flow: PutCompositeAlarm, then DescribeAlarms
+// surfacing it in the CompositeAlarms list (separate from MetricAlarms).
+func TestSDKCompositeAlarmRoundTrip(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	rule := `ALARM("cpu-high") OR ALARM("mem-high")`
+
+	if _, err := client.PutCompositeAlarm(ctx, &awscw.PutCompositeAlarmInput{
+		AlarmName:        aws.String("app-unhealthy"),
+		AlarmRule:        aws.String(rule),
+		AlarmDescription: aws.String("app is unhealthy"),
+		AlarmActions:     []string{"arn:aws:sns:us-east-1:123456789012:ops"},
+	}); err != nil {
+		t.Fatalf("PutCompositeAlarm: %v", err)
+	}
+
+	out, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{})
+	if err != nil {
+		t.Fatalf("DescribeAlarms: %v", err)
+	}
+
+	if len(out.CompositeAlarms) != 1 {
+		t.Fatalf("CompositeAlarms = %d, want 1", len(out.CompositeAlarms))
+	}
+	c := out.CompositeAlarms[0]
+	if aws.ToString(c.AlarmName) != "app-unhealthy" {
+		t.Fatalf("AlarmName = %q, want app-unhealthy", aws.ToString(c.AlarmName))
+	}
+	if aws.ToString(c.AlarmRule) != rule {
+		t.Fatalf("AlarmRule = %q, want %q", aws.ToString(c.AlarmRule), rule)
+	}
+	if len(c.AlarmActions) != 1 || c.AlarmActions[0] != "arn:aws:sns:us-east-1:123456789012:ops" {
+		t.Fatalf("AlarmActions = %v, want the one SNS action", c.AlarmActions)
+	}
+	if aws.ToString(c.AlarmArn) == "" {
+		t.Fatal("AlarmArn is empty")
+	}
+	// Round-trip only: no boolean rule engine, so state is INSUFFICIENT_DATA.
+	if c.StateValue != cwtypes.StateValueInsufficientData {
+		t.Fatalf("StateValue = %q, want INSUFFICIENT_DATA", c.StateValue)
+	}
+}
+
+// TestSDKDescribeAlarmsAlarmTypesFilter confirms the AlarmTypes filter selects
+// composite vs metric alarms, so a request for one type excludes the other.
+func TestSDKDescribeAlarmsAlarmTypesFilter(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	if _, err := client.PutMetricAlarm(ctx, &awscw.PutMetricAlarmInput{
+		AlarmName:          aws.String("cpu-high"),
+		Namespace:          aws.String("AWS/EC2"),
+		MetricName:         aws.String("CPUUtilization"),
+		ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+		Threshold:          aws.Float64(80),
+		EvaluationPeriods:  aws.Int32(1),
+		Period:             aws.Int32(60),
+		Statistic:          cwtypes.StatisticAverage,
+	}); err != nil {
+		t.Fatalf("PutMetricAlarm: %v", err)
+	}
+
+	if _, err := client.PutCompositeAlarm(ctx, &awscw.PutCompositeAlarmInput{
+		AlarmName: aws.String("app-unhealthy"),
+		AlarmRule: aws.String(`ALARM("cpu-high")`),
+	}); err != nil {
+		t.Fatalf("PutCompositeAlarm: %v", err)
+	}
+
+	// Composite only.
+	comp, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{
+		AlarmTypes: []cwtypes.AlarmType{cwtypes.AlarmTypeCompositeAlarm},
+	})
+	if err != nil {
+		t.Fatalf("DescribeAlarms composite: %v", err)
+	}
+	if len(comp.CompositeAlarms) != 1 || len(comp.MetricAlarms) != 0 {
+		t.Fatalf("composite-only filter: MetricAlarms=%d CompositeAlarms=%d, want 0/1",
+			len(comp.MetricAlarms), len(comp.CompositeAlarms))
+	}
+
+	// Metric only.
+	metr, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{
+		AlarmTypes: []cwtypes.AlarmType{cwtypes.AlarmTypeMetricAlarm},
+	})
+	if err != nil {
+		t.Fatalf("DescribeAlarms metric: %v", err)
+	}
+	if len(metr.MetricAlarms) != 1 || len(metr.CompositeAlarms) != 0 {
+		t.Fatalf("metric-only filter: MetricAlarms=%d CompositeAlarms=%d, want 1/0",
+			len(metr.MetricAlarms), len(metr.CompositeAlarms))
+	}
+
+	// Both when unset.
+	both, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{})
+	if err != nil {
+		t.Fatalf("DescribeAlarms both: %v", err)
+	}
+	if len(both.MetricAlarms) != 1 || len(both.CompositeAlarms) != 1 {
+		t.Fatalf("no filter: MetricAlarms=%d CompositeAlarms=%d, want 1/1",
+			len(both.MetricAlarms), len(both.CompositeAlarms))
+	}
+}
+
+// TestSDKDeleteAlarmsDeletesComposite confirms DeleteAlarms removes composite
+// alarms too (they share the DeleteAlarms operation with metric alarms).
+func TestSDKDeleteAlarmsDeletesComposite(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	if _, err := client.PutCompositeAlarm(ctx, &awscw.PutCompositeAlarmInput{
+		AlarmName: aws.String("app-unhealthy"),
+		AlarmRule: aws.String(`ALARM("cpu-high")`),
+	}); err != nil {
+		t.Fatalf("PutCompositeAlarm: %v", err)
+	}
+
+	if _, err := client.DeleteAlarms(ctx, &awscw.DeleteAlarmsInput{
+		AlarmNames: []string{"app-unhealthy"},
+	}); err != nil {
+		t.Fatalf("DeleteAlarms: %v", err)
+	}
+
+	out, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{})
+	if err != nil {
+		t.Fatalf("DescribeAlarms: %v", err)
+	}
+	if len(out.CompositeAlarms) != 0 {
+		t.Fatalf("CompositeAlarms after delete = %d, want 0", len(out.CompositeAlarms))
+	}
+}

--- a/server/aws/cloudwatch/dashboards.go
+++ b/server/aws/cloudwatch/dashboards.go
@@ -1,0 +1,182 @@
+package cloudwatch
+
+// This file implements the CloudWatch dashboard operations (PutDashboard,
+// GetDashboard, ListDashboards, DeleteDashboards) over the rpc-v2-cbor
+// protocol, backing the aws_cloudwatch_dashboard Terraform resource. The store
+// is an AWS-local optional capability so the shared Monitoring interface — and
+// the Azure/GCP providers — stay unchanged.
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// dashboardStore is the AWS-local capability behind the dashboard operations.
+type dashboardStore interface {
+	PutDashboard(ctx context.Context, name, body string) error
+	GetDashboard(ctx context.Context, name string) (*mondriver.DashboardInfo, error)
+	ListDashboards(ctx context.Context, prefix string) ([]mondriver.DashboardEntry, error)
+	DeleteDashboards(ctx context.Context, names []string) error
+}
+
+type putDashboardInput struct {
+	DashboardName string `cbor:"DashboardName"`
+	DashboardBody string `cbor:"DashboardBody"`
+}
+
+// dashboardValidationMessageCBR mirrors the wire shape; cloudemu accepts any
+// valid-JSON body, so the list is always empty on success.
+type dashboardValidationMessageCBR struct {
+	DataPath string `cbor:"DataPath,omitempty"`
+	Message  string `cbor:"Message,omitempty"`
+}
+
+type putDashboardOutput struct {
+	DashboardValidationMessages []dashboardValidationMessageCBR `cbor:"DashboardValidationMessages"`
+}
+
+func (h *Handler) putDashboard(w http.ResponseWriter, r *http.Request, body []byte) {
+	store, ok := h.monitoring.(dashboardStore)
+	if !ok {
+		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "dashboards not supported")
+		return
+	}
+
+	var in putDashboardInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	if err := store.PutDashboard(r.Context(), in.DashboardName, in.DashboardBody); err != nil {
+		writeDriverErr(w, err)
+		return
+	}
+
+	writeCBORResponse(w, putDashboardOutput{DashboardValidationMessages: []dashboardValidationMessageCBR{}})
+}
+
+type getDashboardInput struct {
+	DashboardName string `cbor:"DashboardName"`
+}
+
+type getDashboardOutput struct {
+	DashboardArn  string `cbor:"DashboardArn"`
+	DashboardName string `cbor:"DashboardName"`
+	DashboardBody string `cbor:"DashboardBody"`
+}
+
+func (h *Handler) getDashboard(w http.ResponseWriter, r *http.Request, body []byte) {
+	store, ok := h.monitoring.(dashboardStore)
+	if !ok {
+		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "dashboards not supported")
+		return
+	}
+
+	var in getDashboardInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	d, err := store.GetDashboard(r.Context(), in.DashboardName)
+	if err != nil {
+		writeDriverErr(w, err)
+		return
+	}
+
+	writeCBORResponse(w, getDashboardOutput{
+		DashboardArn:  d.ARN,
+		DashboardName: d.Name,
+		DashboardBody: d.Body,
+	})
+}
+
+type listDashboardsInput struct {
+	DashboardNamePrefix string `cbor:"DashboardNamePrefix,omitempty"`
+	NextToken           string `cbor:"NextToken,omitempty"`
+}
+
+type dashboardEntryCBR struct {
+	DashboardName string    `cbor:"DashboardName"`
+	DashboardArn  string    `cbor:"DashboardArn"`
+	LastModified  time.Time `cbor:"LastModified"`
+	Size          int64     `cbor:"Size"`
+}
+
+type listDashboardsOutput struct {
+	DashboardEntries []dashboardEntryCBR `cbor:"DashboardEntries"`
+	NextToken        string              `cbor:"NextToken,omitempty"`
+}
+
+// dashboardPageSize is the number of dashboard entries returned per page.
+const dashboardPageSize = 1000
+
+func (h *Handler) listDashboards(w http.ResponseWriter, r *http.Request, body []byte) {
+	store, ok := h.monitoring.(dashboardStore)
+	if !ok {
+		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "dashboards not supported")
+		return
+	}
+
+	var in listDashboardsInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	entries, err := store.ListDashboards(r.Context(), in.DashboardNamePrefix)
+	if err != nil {
+		writeDriverErr(w, err)
+		return
+	}
+
+	from, to, next := pageWindow(len(entries), decodeOffsetToken(in.NextToken), dashboardPageSize)
+
+	rows := make([]dashboardEntryCBR, 0, to-from)
+	for _, e := range entries[from:to] {
+		rows = append(rows, dashboardEntryCBR{
+			DashboardName: e.Name,
+			DashboardArn:  e.ARN,
+			LastModified:  e.LastModified.UTC(),
+			Size:          int64(e.Size),
+		})
+	}
+
+	resp := listDashboardsOutput{DashboardEntries: rows}
+	if next > 0 {
+		resp.NextToken = encodeOffsetToken(next)
+	}
+
+	writeCBORResponse(w, resp)
+}
+
+type deleteDashboardsInput struct {
+	DashboardNames []string `cbor:"DashboardNames"`
+}
+
+func (h *Handler) deleteDashboards(w http.ResponseWriter, r *http.Request, body []byte) {
+	store, ok := h.monitoring.(dashboardStore)
+	if !ok {
+		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "dashboards not supported")
+		return
+	}
+
+	var in deleteDashboardsInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	if err := store.DeleteDashboards(r.Context(), in.DashboardNames); err != nil {
+		writeDriverErr(w, err)
+		return
+	}
+
+	writeCBORResponse(w, struct{}{})
+}

--- a/server/aws/cloudwatch/dashboards_test.go
+++ b/server/aws/cloudwatch/dashboards_test.go
@@ -1,0 +1,100 @@
+package cloudwatch_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awscw "github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+)
+
+// TestSDKDashboardLifecycle drives the aws-sdk-go-v2 client through the
+// aws_cloudwatch_dashboard flow: PutDashboard, GetDashboard, ListDashboards
+// (with a name prefix), and DeleteDashboards.
+func TestSDKDashboardLifecycle(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	body := `{"widgets":[{"type":"metric","x":0,"y":0,"width":6,"height":6}]}`
+
+	if _, err := client.PutDashboard(ctx, &awscw.PutDashboardInput{
+		DashboardName: aws.String("ops"),
+		DashboardBody: aws.String(body),
+	}); err != nil {
+		t.Fatalf("PutDashboard: %v", err)
+	}
+
+	got, err := client.GetDashboard(ctx, &awscw.GetDashboardInput{DashboardName: aws.String("ops")})
+	if err != nil {
+		t.Fatalf("GetDashboard: %v", err)
+	}
+
+	if aws.ToString(got.DashboardName) != "ops" {
+		t.Fatalf("DashboardName = %q, want ops", aws.ToString(got.DashboardName))
+	}
+	if aws.ToString(got.DashboardBody) != body {
+		t.Fatalf("DashboardBody = %q, want %q", aws.ToString(got.DashboardBody), body)
+	}
+	if aws.ToString(got.DashboardArn) == "" {
+		t.Fatal("DashboardArn is empty")
+	}
+
+	// A second dashboard so the prefix filter has something to exclude.
+	if _, err := client.PutDashboard(ctx, &awscw.PutDashboardInput{
+		DashboardName: aws.String("other"),
+		DashboardBody: aws.String(`{}`),
+	}); err != nil {
+		t.Fatalf("PutDashboard other: %v", err)
+	}
+
+	list, err := client.ListDashboards(ctx, &awscw.ListDashboardsInput{DashboardNamePrefix: aws.String("ops")})
+	if err != nil {
+		t.Fatalf("ListDashboards: %v", err)
+	}
+	if len(list.DashboardEntries) != 1 {
+		t.Fatalf("DashboardEntries = %d, want 1 (prefix ops)", len(list.DashboardEntries))
+	}
+	e := list.DashboardEntries[0]
+	if aws.ToString(e.DashboardName) != "ops" {
+		t.Fatalf("entry name = %q, want ops", aws.ToString(e.DashboardName))
+	}
+	if e.LastModified == nil {
+		t.Fatal("entry LastModified is nil")
+	}
+	if aws.ToInt64(e.Size) != int64(len(body)) {
+		t.Fatalf("entry Size = %d, want %d", aws.ToInt64(e.Size), len(body))
+	}
+
+	if _, err := client.DeleteDashboards(ctx, &awscw.DeleteDashboardsInput{
+		DashboardNames: []string{"ops"},
+	}); err != nil {
+		t.Fatalf("DeleteDashboards: %v", err)
+	}
+
+	if _, err := client.GetDashboard(ctx, &awscw.GetDashboardInput{DashboardName: aws.String("ops")}); err == nil {
+		t.Fatal("GetDashboard after delete: expected error, got nil")
+	}
+}
+
+// TestSDKPutDashboardInvalidJSON confirms a non-JSON body is rejected, matching
+// CloudWatch's server-side dashboard-body validation.
+func TestSDKPutDashboardInvalidJSON(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	_, err := client.PutDashboard(ctx, &awscw.PutDashboardInput{
+		DashboardName: aws.String("bad"),
+		DashboardBody: aws.String("this is not json"),
+	})
+	if err == nil {
+		t.Fatal("PutDashboard with invalid JSON: expected error, got nil")
+	}
+}
+
+// TestSDKGetDashboardNotFound confirms an unknown dashboard is a client error.
+func TestSDKGetDashboardNotFound(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	if _, err := client.GetDashboard(ctx, &awscw.GetDashboardInput{
+		DashboardName: aws.String("missing"),
+	}); err == nil {
+		t.Fatal("GetDashboard for unknown name: expected error, got nil")
+	}
+}

--- a/server/aws/cloudwatch/handler.go
+++ b/server/aws/cloudwatch/handler.go
@@ -42,6 +42,11 @@ const (
 	opDescribeAlarms      = "DescribeAlarms"
 	opDeleteAlarms        = "DeleteAlarms"
 	opSetAlarmState       = "SetAlarmState"
+	opPutCompositeAlarm   = "PutCompositeAlarm"
+	opPutDashboard        = "PutDashboard"
+	opGetDashboard        = "GetDashboard"
+	opListDashboards      = "ListDashboards"
+	opDeleteDashboards    = "DeleteDashboards"
 )
 
 // Handler serves CloudWatch rpc-v2-cbor requests against a monitoring driver.
@@ -127,6 +132,16 @@ func (h *Handler) dispatch(w http.ResponseWriter, r *http.Request, op string, bo
 		h.deleteAlarms(w, r, body)
 	case opSetAlarmState:
 		h.setAlarmState(w, r, body)
+	case opPutCompositeAlarm:
+		h.putCompositeAlarm(w, r, body)
+	case opPutDashboard:
+		h.putDashboard(w, r, body)
+	case opGetDashboard:
+		h.getDashboard(w, r, body)
+	case opListDashboards:
+		h.listDashboards(w, r, body)
+	case opDeleteDashboards:
+		h.deleteDashboards(w, r, body)
 	case "EnableAlarmActions":
 		h.setAlarmActionsEnabled(w, r, body, true)
 	case "DisableAlarmActions":

--- a/server/aws/cloudwatch/ops.go
+++ b/server/aws/cloudwatch/ops.go
@@ -590,6 +590,7 @@ func tagsToMap(tags []tagCBR) map[string]string {
 type describeAlarmsInput struct {
 	AlarmNames      []string `cbor:"AlarmNames,omitempty"`
 	AlarmNamePrefix string   `cbor:"AlarmNamePrefix,omitempty"`
+	AlarmTypes      []string `cbor:"AlarmTypes,omitempty"`
 	StateValue      string   `cbor:"StateValue,omitempty"`
 	ActionPrefix    string   `cbor:"ActionPrefix,omitempty"`
 	MaxRecords      int      `cbor:"MaxRecords,omitempty"`
@@ -626,8 +627,9 @@ type metricAlarmCBR struct {
 }
 
 type describeAlarmsOutput struct {
-	MetricAlarms []metricAlarmCBR `cbor:"MetricAlarms"`
-	NextToken    string           `cbor:"NextToken,omitempty"`
+	MetricAlarms    []metricAlarmCBR    `cbor:"MetricAlarms"`
+	CompositeAlarms []compositeAlarmCBR `cbor:"CompositeAlarms,omitempty"`
+	NextToken       string              `cbor:"NextToken,omitempty"`
 }
 
 func (h *Handler) describeAlarms(w http.ResponseWriter, r *http.Request, body []byte) {
@@ -637,20 +639,23 @@ func (h *Handler) describeAlarms(w http.ResponseWriter, r *http.Request, body []
 		return
 	}
 
-	alarms, err := h.monitoring.DescribeAlarms(r.Context(), in.AlarmNames)
-	if err != nil {
-		writeDriverErr(w, err)
-		return
-	}
+	matched := make([]metricAlarmCBR, 0)
 
-	matched := make([]metricAlarmCBR, 0, len(alarms))
-
-	for i := range alarms {
-		if !alarmMatchesFilters(&alarms[i], &in) {
-			continue
+	// AlarmTypes selects metric alarms, composite alarms, or (when omitted) both.
+	if wantsAlarmType(in.AlarmTypes, alarmTypeMetric) {
+		alarms, err := h.monitoring.DescribeAlarms(r.Context(), in.AlarmNames)
+		if err != nil {
+			writeDriverErr(w, err)
+			return
 		}
 
-		matched = append(matched, toMetricAlarmCBR(&alarms[i]))
+		for i := range alarms {
+			if !alarmMatchesFilters(&alarms[i], &in) {
+				continue
+			}
+
+			matched = append(matched, toMetricAlarmCBR(&alarms[i]))
+		}
 	}
 
 	// Always paginate: real CloudWatch caps a page at 100 alarms and returns a
@@ -665,11 +670,24 @@ func (h *Handler) describeAlarms(w http.ResponseWriter, r *http.Request, body []
 		size = maxAlarmPageSize
 	}
 
-	from, to, next := pageWindow(len(matched), decodeOffsetToken(in.NextToken), size)
+	offset := decodeOffsetToken(in.NextToken)
+	from, to, next := pageWindow(len(matched), offset, size)
 
 	resp := describeAlarmsOutput{MetricAlarms: matched[from:to]}
 	if next > 0 {
 		resp.NextToken = encodeOffsetToken(next)
+	}
+
+	// Composite alarms are a small, separate collection; return them all on the
+	// first page (offset 0) so they aren't duplicated across metric-alarm pages.
+	if offset == 0 && wantsAlarmType(in.AlarmTypes, alarmTypeComposite) {
+		composites, err := h.compositeAlarmRows(r, &in)
+		if err != nil {
+			writeDriverErr(w, err)
+			return
+		}
+
+		resp.CompositeAlarms = composites
 	}
 
 	writeCBORResponse(w, resp)
@@ -776,6 +794,15 @@ func (h *Handler) deleteAlarms(w http.ResponseWriter, r *http.Request, body []by
 	// fails spuriously or leaves a half-deleted state.
 	for _, name := range in.AlarmNames {
 		if err := h.monitoring.DeleteAlarm(r.Context(), name); err != nil && !cerrors.IsNotFound(err) {
+			writeDriverErr(w, err)
+			return
+		}
+	}
+
+	// DeleteAlarms accepts both metric and composite alarm names in one call; a
+	// name that isn't a metric alarm (tolerated above) may be a composite alarm.
+	if store, ok := h.monitoring.(compositeAlarmStore); ok {
+		if err := store.DeleteCompositeAlarms(r.Context(), in.AlarmNames); err != nil {
 			writeDriverErr(w, err)
 			return
 		}

--- a/services/monitoring/driver/dashboard.go
+++ b/services/monitoring/driver/dashboard.go
@@ -1,0 +1,52 @@
+package driver
+
+import "time"
+
+// DashboardInfo is a stored CloudWatch dashboard returned by GetDashboard: its
+// name, the JSON DashboardBody, its ARN, last-modified time, and the body size
+// in bytes.
+type DashboardInfo struct {
+	Name         string
+	Body         string
+	ARN          string
+	LastModified time.Time
+	Size         int
+}
+
+// DashboardEntry is a ListDashboards summary row — the dashboard's name, ARN,
+// last-modified time, and body size, without the body itself.
+type DashboardEntry struct {
+	Name         string
+	ARN          string
+	LastModified time.Time
+	Size         int
+}
+
+// CompositeAlarmConfig describes a composite alarm to create or update. The
+// AlarmRule is a boolean expression over other alarms' states (e.g.
+// `ALARM("cpu-high") OR ALARM("mem-high")`).
+type CompositeAlarmConfig struct {
+	Name                    string
+	AlarmRule               string
+	AlarmDescription        string
+	ActionsEnabled          *bool // nil defaults to true (AWS semantics)
+	AlarmActions            []string
+	OKActions               []string
+	InsufficientDataActions []string
+	Tags                    map[string]string
+}
+
+// CompositeAlarmInfo describes a stored composite alarm.
+type CompositeAlarmInfo struct {
+	Name                    string
+	ARN                     string
+	AlarmRule               string
+	AlarmDescription        string
+	State                   string // "OK", "ALARM", "INSUFFICIENT_DATA"
+	StateReason             string
+	StateUpdatedTimestamp   time.Time
+	ActionsEnabled          bool
+	AlarmActions            []string
+	OKActions               []string
+	InsufficientDataActions []string
+}


### PR DESCRIPTION
## Summary

Adds two AWS CloudWatch capabilities that unblock common Terraform workflows against the emulator:

- **Dashboards** — `PutDashboard`, `GetDashboard`, `ListDashboards`, `DeleteDashboards` (backs the `aws_cloudwatch_dashboard` resource).
- **Composite alarms** — `PutCompositeAlarm`, with `DescribeAlarms` surfacing them in the `CompositeAlarms` list (separate from `MetricAlarms`) and `DeleteAlarms` removing them alongside metric alarms (backs the `aws_cloudwatch_composite_alarm` resource).

## Behavior (matched to real AWS)

- `PutDashboard` validates the body is valid JSON; a non-JSON body is rejected (CloudWatch's dashboard-body validation). Existing dashboards are overwritten.
- `GetDashboard` returns `DashboardArn` + `DashboardName` + `DashboardBody`; an unknown name is a not-found error.
- `ListDashboards` honors `DashboardNamePrefix` and paginates with `NextToken`; entries carry `LastModified` and `Size`.
- `DeleteDashboards` is plural and all-or-nothing: an unknown name returns not-found and deletes nothing.
- `PutCompositeAlarm` stores `AlarmRule` + actions verbatim and round-trips faithfully. `DescribeAlarms` supports the `AlarmTypes` filter (`CompositeAlarm` / `MetricAlarm`, both when omitted). Composite state is left at `INSUFFICIENT_DATA` — the definition is round-tripped rather than shipping a half-working boolean rule evaluator (there is no trigger that re-evaluates a composite when a referenced alarm transitions).

## Implementation notes

Dashboards and composite alarms are AWS-local optional capabilities reached by type assertion in the wire handler, so the shared `driver.Monitoring` interface — and the Azure/GCP providers — stay unchanged. Operations are dispatched over the existing rpc-v2-cbor path (the protocol modern aws-sdk-go-v2 / Terraform use).

## Tests

Provider-level (in-memory) and wire-level (real aws-sdk-go-v2 client against an in-process server) tests cover: dashboard put/get/list(prefix)/delete, bad-JSON rejection, not-found; composite alarm put + describe (`AlarmTypes` filter round-trip) + delete-via-DeleteAlarms.
