### PR TITLE
fix(ssm): SecureString KeyId round-trip and AllowedPattern enforcement

### DIFF
--- a/providers/aws/ssm/keyid_allowedpattern_test.go
+++ b/providers/aws/ssm/keyid_allowedpattern_test.go
@@ -1,0 +1,213 @@
+package ssm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/parameterstore/driver"
+)
+
+// describeByName returns the metadata for a single parameter name.
+func describeByName(t *testing.T, m interface {
+	DescribeParameters(context.Context) ([]driver.ParameterMetadata, error)
+}, name string) driver.ParameterMetadata {
+	t.Helper()
+
+	metas, err := m.DescribeParameters(context.Background())
+	if err != nil {
+		t.Fatalf("DescribeParameters: %v", err)
+	}
+
+	for _, md := range metas {
+		if md.Name == name {
+			return md
+		}
+	}
+
+	t.Fatalf("parameter %q not found in DescribeParameters", name)
+
+	return driver.ParameterMetadata{}
+}
+
+func TestPutSecureStringDefaultsKeyID(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/sec", Value: "v", Type: driver.TypeSecureString,
+	}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	md := describeByName(t, m, "/sec")
+	if md.KeyID != driver.DefaultSecureStringKeyID {
+		t.Fatalf("KeyId = %q, want default %q", md.KeyID, driver.DefaultSecureStringKeyID)
+	}
+}
+
+func TestPutSecureStringExplicitKeyID(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	const key = "alias/my-key"
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/sec", Value: "v", Type: driver.TypeSecureString, KeyID: key,
+	}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	md := describeByName(t, m, "/sec")
+	if md.KeyID != key {
+		t.Fatalf("KeyId = %q, want %q", md.KeyID, key)
+	}
+}
+
+func TestPutKeyIDOnNonSecureRejected(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	for _, typ := range []string{driver.TypeString, driver.TypeStringList} {
+		_, _, err := m.PutParameter(ctx, driver.PutConfig{
+			Name: "/p-" + typ, Value: "v", Type: typ, KeyID: "alias/my-key",
+		})
+		if err == nil {
+			t.Fatalf("type %s with KeyId: want rejection, got nil", typ)
+		}
+
+		if !errors.Is(err, driver.ErrKeyIDOnNonSecure) {
+			t.Fatalf("type %s with KeyId: want ErrKeyIDOnNonSecure, got %v", typ, err)
+		}
+	}
+}
+
+// GetParameter (and GetParameters) must NOT expose KeyId — real SSM's Parameter
+// shape has no KeyId field; it only appears on DescribeParameters metadata.
+func TestGetParameterOmitsKeyID(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/sec", Value: "v", Type: driver.TypeSecureString, KeyID: "alias/my-key",
+	}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	got, err := m.GetParameter(ctx, "/sec", true)
+	if err != nil {
+		t.Fatalf("GetParameter: %v", err)
+	}
+
+	if got.KeyID != "" {
+		t.Fatalf("GetParameter KeyId = %q, want empty (not exposed)", got.KeyID)
+	}
+
+	if got.AllowedPattern != "" {
+		t.Fatalf("GetParameter AllowedPattern = %q, want empty (not exposed)", got.AllowedPattern)
+	}
+}
+
+func TestPutAllowedPatternMatchPasses(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/p", Value: "12345", Type: driver.TypeString, AllowedPattern: `^\d+$`,
+	}); err != nil {
+		t.Fatalf("PutParameter matching pattern: %v", err)
+	}
+
+	md := describeByName(t, m, "/p")
+	if md.AllowedPattern != `^\d+$` {
+		t.Fatalf("AllowedPattern = %q, want %q", md.AllowedPattern, `^\d+$`)
+	}
+}
+
+func TestPutAllowedPatternMismatchRejected(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	_, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/p", Value: "abc", Type: driver.TypeString, AllowedPattern: `^\d+$`,
+	})
+	if err == nil {
+		t.Fatal("value not matching pattern: want rejection, got nil")
+	}
+
+	if !errors.Is(err, driver.ErrValuePatternMismatch) {
+		t.Fatalf("want ErrValuePatternMismatch, got %v", err)
+	}
+}
+
+func TestPutAllowedPatternInvalidRegexRejected(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	_, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/p", Value: "x", Type: driver.TypeString, AllowedPattern: `[unterminated`,
+	})
+	if err == nil {
+		t.Fatal("invalid regex pattern: want rejection, got nil")
+	}
+
+	if !errors.Is(err, driver.ErrInvalidAllowedPattern) {
+		t.Fatalf("want ErrInvalidAllowedPattern, got %v", err)
+	}
+}
+
+func TestPutAllowedPatternEnforcedOnOverwrite(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/p", Value: "1", Type: driver.TypeString, AllowedPattern: `^\d+$`,
+	}); err != nil {
+		t.Fatalf("PutParameter create: %v", err)
+	}
+
+	// Overwrite with a value that violates the pattern must be rejected.
+	_, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/p", Value: "abc", Type: driver.TypeString, Overwrite: true, AllowedPattern: `^\d+$`,
+	})
+	if err == nil {
+		t.Fatal("overwrite violating pattern: want rejection, got nil")
+	}
+
+	if !errors.Is(err, driver.ErrValuePatternMismatch) {
+		t.Fatalf("want ErrValuePatternMismatch on overwrite, got %v", err)
+	}
+
+	// A matching overwrite still succeeds.
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/p", Value: "99", Type: driver.TypeString, Overwrite: true, AllowedPattern: `^\d+$`,
+	}); err != nil {
+		t.Fatalf("overwrite matching pattern: %v", err)
+	}
+}
+
+// DescribeParameters reflects both KeyId and AllowedPattern in one metadata entry.
+func TestDescribeParametersReflectsKeyIDAndPattern(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	const (
+		key     = "alias/combo-key"
+		pattern = `^[a-z]+$`
+	)
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/combo", Value: "abc", Type: driver.TypeSecureString, KeyID: key, AllowedPattern: pattern,
+	}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	md := describeByName(t, m, "/combo")
+	if md.KeyID != key {
+		t.Fatalf("KeyId = %q, want %q", md.KeyID, key)
+	}
+
+	if md.AllowedPattern != pattern {
+		t.Fatalf("AllowedPattern = %q, want %q", md.AllowedPattern, pattern)
+	}
+}

--- a/providers/aws/ssm/path_filter.go
+++ b/providers/aws/ssm/path_filter.go
@@ -57,9 +57,10 @@ func matchByPathFilter(v *version, f *driver.ParameterStringFilter) bool {
 	case byPathKeyLabel:
 		return labelsMatchFilter(v.labels, f.Option, f.Values)
 	default:
-		// KeyId is a valid key but cloudemu doesn't model a per-parameter KMS
-		// KeyId (SecureString isn't encrypted), so it can't constrain results.
-		return true
+		// KeyId: a SecureString records its KMS KeyId (defaulting to
+		// alias/aws/ssm); String/StringList have none, so this narrows to
+		// SecureString parameters with a matching key.
+		return fieldMatchesFilter(v.keyID, f.Option, f.Values)
 	}
 }
 

--- a/providers/aws/ssm/ssm.go
+++ b/providers/aws/ssm/ssm.go
@@ -7,11 +7,14 @@
 //
 // Values are stored verbatim regardless of Type; SecureString parameters are
 // NOT encrypted (there is no real KMS integration), so WithDecryption is a
-// no-op and the raw value is always returned.
+// no-op and the raw value is always returned. A SecureString's KeyId is still
+// recorded and round-tripped (defaulting to alias/aws/ssm) — the emulator
+// models the KeyId association without performing the encryption.
 package ssm
 
 import (
 	"context"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -30,12 +33,14 @@ var _ driver.ParameterStore = (*Mock)(nil)
 
 // version is a single stored revision of a parameter.
 type version struct {
-	value        string
-	typ          string
-	dataType     string
-	version      int64
-	lastModified string
-	labels       []string
+	value          string
+	typ            string
+	dataType       string
+	version        int64
+	lastModified   string
+	labels         []string
+	keyID          string
+	allowedPattern string
 }
 
 // paramData holds all versions and current metadata for a parameter name.
@@ -107,6 +112,46 @@ func defaultType(t string) string {
 	return driver.TypeString
 }
 
+// resolveKeyID validates and resolves the KMS KeyId for a parameter of the
+// given effective type. KeyId is only valid for SecureString: supplying it for
+// a String/StringList is rejected. An omitted KeyId on a SecureString defaults
+// to the AWS-managed key alias/aws/ssm.
+func resolveKeyID(effectiveType, keyID string) (string, error) {
+	if effectiveType != driver.TypeSecureString {
+		if keyID != "" {
+			return "", driver.ErrKeyIDOnNonSecure
+		}
+
+		return "", nil
+	}
+
+	if keyID == "" {
+		return driver.DefaultSecureStringKeyID, nil
+	}
+
+	return keyID, nil
+}
+
+// validateAllowedPattern checks that value satisfies pattern. An empty pattern
+// is a no-op. A pattern that is not a valid regexp is rejected, as is a value
+// that does not match it — matching real Parameter Store validation.
+func validateAllowedPattern(pattern, value string) error {
+	if pattern == "" {
+		return nil
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return driver.ErrInvalidAllowedPattern
+	}
+
+	if !re.MatchString(value) {
+		return driver.ErrValuePatternMismatch
+	}
+
+	return nil
+}
+
 // resolveOverwriteType decides the type of a new version appended to an existing
 // parameter. A type isn't required when updating: omitting it retains the
 // existing type (a SecureString stays SecureString). Specifying a type that
@@ -150,6 +195,12 @@ func (m *Mock) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, s
 		return 0, "", driver.ErrUnsupportedType
 	}
 
+	// AllowedPattern (if set) must be a valid regexp and the Value must match it.
+	// This is independent of the parameter type, so validate it up front.
+	if err := validateAllowedPattern(cfg.AllowedPattern, cfg.Value); err != nil {
+		return 0, "", err
+	}
+
 	tier := cfg.Tier
 	if tier == "" {
 		tier = "Standard"
@@ -188,13 +239,20 @@ func overwriteParameter(
 		return 0, "", err
 	}
 
+	keyID, err := resolveKeyID(newType, cfg.KeyID)
+	if err != nil {
+		return 0, "", err
+	}
+
 	next := existing.latest + 1
 	existing.versions = append(existing.versions, &version{
-		value:        cfg.Value,
-		typ:          newType,
-		dataType:     dataType,
-		version:      next,
-		lastModified: now,
+		value:          cfg.Value,
+		typ:            newType,
+		dataType:       dataType,
+		version:        next,
+		lastModified:   now,
+		keyID:          keyID,
+		allowedPattern: cfg.AllowedPattern,
 	})
 	existing.latest = next
 	existing.description = cfg.Description
@@ -207,17 +265,26 @@ func overwriteParameter(
 func (m *Mock) createParameter(
 	ctx context.Context, cfg *driver.PutConfig, tier, dataType, now string,
 ) (ver int64, assignedTier string, err error) {
+	newType := defaultType(cfg.Type)
+
+	keyID, err := resolveKeyID(newType, cfg.KeyID)
+	if err != nil {
+		return 0, "", err
+	}
+
 	pd := &paramData{
 		name:        cfg.Name,
 		description: cfg.Description,
 		tier:        tier,
 		latest:      1,
 		versions: []*version{{
-			value:        cfg.Value,
-			typ:          defaultType(cfg.Type),
-			dataType:     dataType,
-			version:      1,
-			lastModified: now,
+			value:          cfg.Value,
+			typ:            newType,
+			dataType:       dataType,
+			version:        1,
+			lastModified:   now,
+			keyID:          keyID,
+			allowedPattern: cfg.AllowedPattern,
 		}},
 		tags: copyTags(cfg.Tags),
 	}
@@ -470,6 +537,8 @@ func (m *Mock) DescribeParameters(_ context.Context) ([]driver.ParameterMetadata
 				DataType:         v.dataType,
 				LastModified:     v.lastModified,
 				LastModifiedUser: idgen.AWSARN("iam", "", m.opts.AccountID, "user/cloudemu"),
+				KeyID:            v.keyID,
+				AllowedPattern:   v.allowedPattern,
 			})
 		}
 		pd.mu.RUnlock()
@@ -507,6 +576,8 @@ func (m *Mock) GetParameterHistory(_ context.Context, name string) ([]driver.Par
 			Description:      pd.description,
 			Tier:             pd.tier,
 			LastModifiedUser: lastModifiedUser,
+			KeyID:            v.keyID,
+			AllowedPattern:   v.allowedPattern,
 		})
 	}
 

--- a/server/aws/ssm/filter.go
+++ b/server/aws/ssm/filter.go
@@ -78,6 +78,8 @@ func parameterFilterField(md *ssmdriver.ParameterMetadata, key string) (string, 
 		return md.Tier, true
 	case "DataType":
 		return md.DataType, true
+	case "KeyId":
+		return md.KeyID, true
 	default:
 		return "", false
 	}

--- a/server/aws/ssm/keyid_allowedpattern_test.go
+++ b/server/aws/ssm/keyid_allowedpattern_test.go
@@ -1,0 +1,119 @@
+package ssm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsssm "github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/smithy-go"
+)
+
+// describeOne returns the single ParameterMetadata for name via DescribeParameters.
+func describeOne(t *testing.T, client *awsssm.Client, name string) ssmtypes.ParameterMetadata {
+	t.Helper()
+
+	out, err := client.DescribeParameters(context.Background(), &awsssm.DescribeParametersInput{})
+	if err != nil {
+		t.Fatalf("DescribeParameters: %v", err)
+	}
+
+	for _, md := range out.Parameters {
+		if aws.ToString(md.Name) == name {
+			return md
+		}
+	}
+
+	t.Fatalf("parameter %q not found in DescribeParameters", name)
+
+	return ssmtypes.ParameterMetadata{}
+}
+
+// TestSDKSecureStringKeyIDRoundTrip verifies that a SecureString's KeyId is
+// surfaced on DescribeParameters ParameterMetadata (defaulting to alias/aws/ssm
+// when omitted) — and NOT on the GetParameter Parameter shape, matching AWS.
+func TestSDKSecureStringKeyIDRoundTrip(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := context.Background()
+
+	if _, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name:  aws.String("/app/secure-default"),
+		Value: aws.String("v"),
+		Type:  ssmtypes.ParameterTypeSecureString,
+	}); err != nil {
+		t.Fatalf("PutParameter(default key): %v", err)
+	}
+
+	if got := aws.ToString(describeOne(t, client, "/app/secure-default").KeyId); got != "alias/aws/ssm" {
+		t.Fatalf("default KeyId = %q, want alias/aws/ssm", got)
+	}
+
+	if _, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name:  aws.String("/app/secure-explicit"),
+		Value: aws.String("v"),
+		Type:  ssmtypes.ParameterTypeSecureString,
+		KeyId: aws.String("alias/my-key"),
+	}); err != nil {
+		t.Fatalf("PutParameter(explicit key): %v", err)
+	}
+
+	if got := aws.ToString(describeOne(t, client, "/app/secure-explicit").KeyId); got != "alias/my-key" {
+		t.Fatalf("explicit KeyId = %q, want alias/my-key", got)
+	}
+
+	// GetParameter's Parameter shape has no KeyId field, so nothing to assert
+	// there; a String parameter carrying a KeyId is rejected instead.
+	_, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name:  aws.String("/app/plain"),
+		Value: aws.String("v"),
+		Type:  ssmtypes.ParameterTypeString,
+		KeyId: aws.String("alias/my-key"),
+	})
+	if err == nil {
+		t.Fatal("PutParameter(String with KeyId): expected error, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ValidationException" {
+		t.Fatalf("String+KeyId error = %v, want ValidationException", err)
+	}
+}
+
+// TestSDKAllowedPatternRoundTrip verifies AllowedPattern enforcement on put and
+// that it is reflected on DescribeParameters ParameterMetadata.
+func TestSDKAllowedPatternRoundTrip(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := context.Background()
+
+	if _, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name:           aws.String("/app/num"),
+		Value:          aws.String("12345"),
+		Type:           ssmtypes.ParameterTypeString,
+		AllowedPattern: aws.String(`^\d+$`),
+	}); err != nil {
+		t.Fatalf("PutParameter(matching): %v", err)
+	}
+
+	if got := aws.ToString(describeOne(t, client, "/app/num").AllowedPattern); got != `^\d+$` {
+		t.Fatalf("AllowedPattern = %q, want ^\\d+$", got)
+	}
+
+	// A value that violates the pattern is rejected as ValidationException.
+	_, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name:           aws.String("/app/num"),
+		Value:          aws.String("abc"),
+		Type:           ssmtypes.ParameterTypeString,
+		Overwrite:      aws.Bool(true),
+		AllowedPattern: aws.String(`^\d+$`),
+	})
+	if err == nil {
+		t.Fatal("PutParameter(mismatch on overwrite): expected error, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ValidationException" {
+		t.Fatalf("mismatch error = %v, want ValidationException", err)
+	}
+}

--- a/server/aws/ssm/operations.go
+++ b/server/aws/ssm/operations.go
@@ -23,14 +23,16 @@ func (h *Handler) putParameter(w http.ResponseWriter, r *http.Request) {
 	}
 
 	version, tier, err := h.store.PutParameter(r.Context(), ssmdriver.PutConfig{
-		Name:        req.Name,
-		Value:       req.Value,
-		Type:        req.Type,
-		Description: req.Description,
-		Overwrite:   req.Overwrite,
-		Tier:        req.Tier,
-		DataType:    req.DataType,
-		Tags:        tags,
+		Name:           req.Name,
+		Value:          req.Value,
+		Type:           req.Type,
+		Description:    req.Description,
+		Overwrite:      req.Overwrite,
+		Tier:           req.Tier,
+		DataType:       req.DataType,
+		KeyID:          req.KeyID,
+		AllowedPattern: req.AllowedPattern,
+		Tags:           tags,
 	})
 	if err != nil {
 		// Changing a parameter's type on an Overwrite update is rejected by
@@ -206,9 +208,11 @@ func (h *Handler) describeParameters(w http.ResponseWriter, r *http.Request) {
 	out := make([]parameterMetadataJSON, 0, end-start)
 	for _, md := range metas[start:end] {
 		out = append(out, parameterMetadataJSON{
+			AllowedPattern:   md.AllowedPattern,
 			ARN:              md.ARN,
 			DataType:         md.DataType,
 			Description:      md.Description,
+			KeyID:            md.KeyID,
 			LastModifiedDate: epochSeconds(md.LastModified),
 			LastModifiedUser: md.LastModifiedUser,
 			Name:             md.Name,
@@ -243,9 +247,11 @@ func (h *Handler) getParameterHistory(w http.ResponseWriter, r *http.Request) {
 	out := make([]parameterHistoryJSON, 0, end-start)
 	for _, p := range history[start:end] {
 		out = append(out, parameterHistoryJSON{
+			AllowedPattern:   p.AllowedPattern,
 			ARN:              p.ARN,
 			DataType:         p.DataType,
 			Description:      p.Description,
+			KeyID:            p.KeyID,
 			Labels:           p.Labels,
 			LastModifiedDate: epochSeconds(p.LastModified),
 			LastModifiedUser: p.LastModifiedUser,

--- a/server/aws/ssm/types.go
+++ b/server/aws/ssm/types.go
@@ -21,9 +21,11 @@ type parameterJSON struct {
 
 // parameterMetadataJSON is the wire shape for ParameterMetadata (DescribeParameters).
 type parameterMetadataJSON struct {
+	AllowedPattern   string  `json:"AllowedPattern,omitempty"`
 	ARN              string  `json:"ARN,omitempty"`
 	DataType         string  `json:"DataType,omitempty"`
 	Description      string  `json:"Description,omitempty"`
+	KeyID            string  `json:"KeyId,omitempty"`
 	LastModifiedDate float64 `json:"LastModifiedDate,omitempty"`
 	LastModifiedUser string  `json:"LastModifiedUser,omitempty"`
 	Name             string  `json:"Name"`
@@ -35,14 +37,16 @@ type parameterMetadataJSON struct {
 // --- request envelopes ---
 
 type putParameterRequest struct {
-	Name        string   `json:"Name"`
-	Value       string   `json:"Value"`
-	Type        string   `json:"Type"`
-	Description string   `json:"Description"`
-	Overwrite   bool     `json:"Overwrite"`
-	Tier        string   `json:"Tier"`
-	DataType    string   `json:"DataType"`
-	Tags        []ssmTag `json:"Tags"`
+	Name           string   `json:"Name"`
+	Value          string   `json:"Value"`
+	Type           string   `json:"Type"`
+	Description    string   `json:"Description"`
+	Overwrite      bool     `json:"Overwrite"`
+	Tier           string   `json:"Tier"`
+	DataType       string   `json:"DataType"`
+	KeyID          string   `json:"KeyId"`
+	AllowedPattern string   `json:"AllowedPattern"`
+	Tags           []ssmTag `json:"Tags"`
 }
 
 type getParameterRequest struct {
@@ -148,9 +152,11 @@ type getParameterHistoryResponse struct {
 
 // parameterHistoryJSON is the wire shape for a ParameterHistory entry.
 type parameterHistoryJSON struct {
+	AllowedPattern   string   `json:"AllowedPattern,omitempty"`
 	ARN              string   `json:"ARN,omitempty"`
 	DataType         string   `json:"DataType,omitempty"`
 	Description      string   `json:"Description,omitempty"`
+	KeyID            string   `json:"KeyId,omitempty"`
 	Labels           []string `json:"Labels,omitempty"`
 	LastModifiedDate float64  `json:"LastModifiedDate,omitempty"`
 	LastModifiedUser string   `json:"LastModifiedUser,omitempty"`

--- a/services/parameterstore/driver/driver.go
+++ b/services/parameterstore/driver/driver.go
@@ -60,6 +60,33 @@ var ErrInvalidFilterOption = errors.New(errors.InvalidArgument,
 	"The specified filter option isn't valid. "+
 		"Valid options are Equals and BeginsWith.")
 
+// ErrKeyIDOnNonSecure is returned by PutParameter when a KeyId is supplied for a
+// String or StringList parameter. Real Parameter Store only honors KeyId for
+// SecureString parameters and rejects it otherwise with ValidationException. It
+// carries InvalidArgument so the SDK-compat layer surfaces ValidationException.
+var ErrKeyIDOnNonSecure = errors.New(errors.InvalidArgument,
+	"The parameter type isn't supported for the specified KeyId. "+
+		"KeyId is only supported for SecureString parameters.")
+
+// ErrInvalidAllowedPattern is returned by PutParameter when AllowedPattern is
+// not a valid regular expression. It carries InvalidArgument so the SDK-compat
+// layer surfaces ValidationException.
+var ErrInvalidAllowedPattern = errors.New(errors.InvalidArgument,
+	"The following parameter values are not valid: AllowedPattern. "+
+		"The allowed pattern isn't a valid regular expression.")
+
+// ErrValuePatternMismatch is returned by PutParameter when the Value does not
+// match the parameter's AllowedPattern. It carries InvalidArgument so the
+// SDK-compat layer surfaces ValidationException.
+var ErrValuePatternMismatch = errors.New(errors.InvalidArgument,
+	"Parameter value "+
+		"doesn't match the allowed pattern.")
+
+// DefaultSecureStringKeyID is the KMS key Parameter Store assigns to a
+// SecureString parameter when PutParameter omits KeyId — the AWS-managed
+// default key alias.
+const DefaultSecureStringKeyID = "alias/aws/ssm"
+
 // Parameter types, matching AWS SSM Parameter Store.
 const (
 	// TypeString is a plain single-value string parameter.
@@ -80,6 +107,15 @@ type PutConfig struct {
 	Overwrite   bool
 	Tier        string
 	DataType    string
+	// KeyID is the KMS key (id or alias) used to encrypt a SecureString value.
+	// It is only valid for SecureString parameters; supplying it for a
+	// String/StringList is rejected. When omitted for a SecureString it defaults
+	// to DefaultSecureStringKeyID (alias/aws/ssm).
+	KeyID string
+	// AllowedPattern is an optional regular expression the Value must match.
+	// A non-empty pattern that is not a valid regexp, or a Value that fails to
+	// match it, is rejected.
+	AllowedPattern string
 	// Tags are applied to the parameter at create time. Real Parameter Store
 	// rejects supplying Tags together with Overwrite=true, so Tags are only
 	// meaningful on a create.
@@ -98,13 +134,17 @@ type Parameter struct {
 	// Selector records how this value was addressed (e.g. ":3" for a version
 	// or ":prod" for a label), for the SDK's Selector response field.
 	Selector string
-	// Labels, Description, Tier, and LastModifiedUser are populated by
-	// GetParameterHistory so labelled/tiered versions round-trip. They are left
-	// empty by the value-read paths (GetParameter et al.), matching real SSM.
+	// Labels, Description, Tier, LastModifiedUser, KeyID, and AllowedPattern are
+	// populated by GetParameterHistory so labeled/tiered versions round-trip.
+	// They are left empty by the value-read paths (GetParameter et al.) —
+	// matching real SSM, whose Parameter shape has no KeyId or AllowedPattern
+	// even though its ParameterHistory entry does.
 	Labels           []string
 	Description      string
 	Tier             string
 	LastModifiedUser string
+	KeyID            string
+	AllowedPattern   string
 }
 
 // ParameterMetadata describes a parameter without its value.
@@ -118,6 +158,11 @@ type ParameterMetadata struct {
 	DataType         string
 	LastModified     string
 	LastModifiedUser string
+	// KeyID is the KMS key of a SecureString parameter (empty otherwise), and
+	// AllowedPattern is the parameter's value-validation regex. Real
+	// DescribeParameters reflects both in ParameterMetadata.
+	KeyID          string
+	AllowedPattern string
 }
 
 // ParameterStringFilter is a GetParametersByPath filter: a Key, an Option


### PR DESCRIPTION
## Summary

Closes two AWS SSM Parameter Store fidelity gaps around `aws_ssm_parameter` `key_id` and `allowed_pattern`.

### 1. SecureString KeyId round-trip + validation
- `PutParameter` with `Type=SecureString` accepts `KeyId`, defaulting to `alias/aws/ssm` (the AWS-managed key) when omitted.
- Supplying `KeyId` for a `String`/`StringList` parameter is rejected with `ValidationException` (real Parameter Store only honors `KeyId` for SecureString).
- `KeyId` is reflected back **only** on `DescribeParameters` `ParameterMetadata.KeyId` (and `GetParameterHistory`), matching real AWS — the `GetParameter`/`GetParameters` `Parameter` shape has no `KeyId` field and does not echo it.

### 2. AllowedPattern enforcement
- `PutParameter` accepts `AllowedPattern` (a regex); the `Value` must match or the call is rejected with `ValidationException`.
- An `AllowedPattern` that is not a valid regular expression is rejected with `ValidationException`.
- Enforced on overwrite as well, and reflected back on `DescribeParameters` `ParameterMetadata.AllowedPattern`.

## Why
Without these, IaC/SDK callers that set `key_id` or `allowed_pattern` on a parameter saw the fields silently dropped and invalid values silently accepted — drift from real Parameter Store behavior and its validation errors.

## Notes
- SecureString values remain stored in the clear (no real KMS integration); this change models the `KeyId` **association** and round-trip, not encryption.

## Tests
- Provider-level: KeyId default/explicit/rejection on non-SecureString; AllowedPattern match/mismatch/invalid-regex/overwrite; DescribeParameters reflects both; GetParameter omits both.
- Server-level (real aws-sdk-go-v2): KeyId + AllowedPattern round-trip through DescribeParameters, ValidationException on String+KeyId and on pattern mismatch.