### PR TITLE
fix(eventbridge): PutPermission/RemovePermission resource policy, ListRuleNamesByTarget, reject empty {} event pattern

### DIFF
--- a/internal/eventmatch/eventmatch.go
+++ b/internal/eventmatch/eventmatch.go
@@ -472,6 +472,13 @@ func ValidatePattern(raw string) error {
 		return &PatternError{Reason: "event pattern is not valid JSON"}
 	}
 
+	// A top-level empty object {} (or null) is rejected: real EventBridge refuses
+	// an empty pattern on PutRule. Empty nested objects stay legal — they are
+	// validated recursively by validatePatternObject, not here.
+	if len(p) == 0 {
+		return &PatternError{Reason: "Empty patterns are not allowed"}
+	}
+
 	return validatePatternObject(p)
 }
 

--- a/internal/eventmatch/eventmatch_test.go
+++ b/internal/eventmatch/eventmatch_test.go
@@ -280,3 +280,26 @@ func TestParsePatternRejectsGarbage(t *testing.T) {
 		t.Fatal("expected empty pattern to fail parse")
 	}
 }
+
+// TestValidatePatternEmptyObject asserts that a top-level empty pattern {} (and
+// null) is rejected the way real EventBridge rejects it, while a legitimately
+// empty NESTED object and ordinary valid patterns are still accepted.
+func TestValidatePatternEmptyObject(t *testing.T) {
+	reject := []string{"{}", " {} ", "null"}
+	for _, raw := range reject {
+		if err := eventmatch.ValidatePattern(raw); err == nil {
+			t.Fatalf("ValidatePattern(%q) = nil, want rejection", raw)
+		}
+	}
+
+	accept := []string{
+		`{"source":["aws.ec2"]}`,
+		`{"detail":{}}`,
+		`{"detail":{"state":["running"]}}`,
+	}
+	for _, raw := range accept {
+		if err := eventmatch.ValidatePattern(raw); err != nil {
+			t.Fatalf("ValidatePattern(%q) = %v, want nil", raw, err)
+		}
+	}
+}

--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -42,6 +42,9 @@ type busData struct {
 	rules  *memstore.Store[*ruleData]
 	mu     sync.RWMutex
 	events []driver.Event
+	// policyStmts holds the event bus's resource-policy statements in insertion
+	// order, keyed for removal by each statement's "Sid". Guarded by mu.
+	policyStmts []map[string]any
 }
 
 // SQSDeliverer delivers an event to an SQS queue identified by its ARN.
@@ -209,7 +212,11 @@ func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo
 		return nil, errors.Newf(errors.NotFound, "event bus %q not found", name)
 	}
 
+	bd.mu.RLock()
+	defer bd.mu.RUnlock()
+
 	result := bd.info
+	result.Policy = renderPolicy(bd.policyStmts)
 
 	return &result, nil
 }

--- a/providers/aws/eventbridge/permissions.go
+++ b/providers/aws/eventbridge/permissions.go
@@ -1,0 +1,227 @@
+package eventbridge
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+)
+
+const (
+	// putEventsAction is the only action a legacy PutPermission call may grant.
+	putEventsAction = "events:PutEvents"
+	// policyVersion is the IAM policy language version EventBridge stamps on a
+	// bus resource policy.
+	policyVersion = "2012-10-17"
+)
+
+// busNameOrDefault resolves an empty bus name to the default bus.
+func busNameOrDefault(name string) string {
+	if name == "" {
+		return defaultBusName
+	}
+
+	return name
+}
+
+// PutPermission attaches a statement to an event bus's resource policy. Two
+// mutually-exclusive forms are accepted: the legacy Action/Principal/StatementID
+// trio (optionally with a Condition), which adds or replaces a single statement
+// keyed by StatementID; or a full Policy JSON document, which replaces the whole
+// policy. It mirrors the AWS EventBridge PutPermission API.
+func (m *Mock) PutPermission(_ context.Context, busName string, in driver.PermissionInput) error {
+	bd, ok := m.buses.Get(busNameOrDefault(busName))
+	if !ok {
+		return errors.Newf(errors.NotFound, "event bus %q not found", busNameOrDefault(busName))
+	}
+
+	if err := validatePutPermission(in); err != nil {
+		return err
+	}
+
+	bd.mu.Lock()
+	defer bd.mu.Unlock()
+
+	if in.Policy != "" {
+		stmts, err := parsePolicyStatements(in.Policy)
+		if err != nil {
+			return err
+		}
+
+		bd.policyStmts = stmts
+
+		return nil
+	}
+
+	bd.policyStmts = upsertStatement(bd.policyStmts, buildStatement(in, bd.info.ARN))
+
+	return nil
+}
+
+// validatePutPermission enforces the mutually-exclusive form rules and the
+// legacy-form constraints of a PutPermission call.
+func validatePutPermission(in driver.PermissionInput) error {
+	legacy := in.Action != "" || in.Principal != "" || in.StatementID != ""
+	hasPolicy := in.Policy != ""
+
+	if legacy && hasPolicy {
+		return errors.New(errors.InvalidArgument,
+			"policy cannot be specified together with statementId, action, or principal")
+	}
+
+	if !legacy && !hasPolicy {
+		return errors.New(errors.InvalidArgument,
+			"either a policy or the statementId, action, and principal parameters must be specified")
+	}
+
+	if hasPolicy {
+		return nil
+	}
+
+	return validateLegacyPermission(in)
+}
+
+// validateLegacyPermission checks the field constraints of the legacy
+// Action/Principal/StatementID PutPermission form.
+func validateLegacyPermission(in driver.PermissionInput) error {
+	if in.Action != putEventsAction {
+		return errors.Newf(errors.InvalidArgument, "action %q is not supported; only events:PutEvents is allowed", in.Action)
+	}
+
+	if in.StatementID == "" || in.Principal == "" {
+		return errors.New(errors.InvalidArgument, "statementId and principal are required")
+	}
+
+	return nil
+}
+
+// RemovePermission removes a statement from an event bus's resource policy by
+// StatementID, or clears the entire policy when removeAll is set. An unknown
+// StatementID is reported as NotFound (ResourceNotFoundException on the wire).
+func (m *Mock) RemovePermission(_ context.Context, busName, statementID string, removeAll bool) error {
+	bd, ok := m.buses.Get(busNameOrDefault(busName))
+	if !ok {
+		return errors.Newf(errors.NotFound, "event bus %q not found", busNameOrDefault(busName))
+	}
+
+	bd.mu.Lock()
+	defer bd.mu.Unlock()
+
+	if removeAll {
+		bd.policyStmts = nil
+
+		return nil
+	}
+
+	if statementID == "" {
+		return errors.New(errors.InvalidArgument, "statementId or removeAllPermissions must be specified")
+	}
+
+	idx := indexOfStatement(bd.policyStmts, statementID)
+	if idx < 0 {
+		return errors.Newf(errors.NotFound, "Statement with the id %q does not exist on the resource policy.", statementID)
+	}
+
+	bd.policyStmts = append(bd.policyStmts[:idx], bd.policyStmts[idx+1:]...)
+
+	return nil
+}
+
+// buildStatement renders a legacy PutPermission trio into an IAM policy
+// statement. A "*" principal grants everyone; a 12-digit account id is expanded
+// to its root ARN, matching how EventBridge stores the statement.
+func buildStatement(in driver.PermissionInput, busARN string) map[string]any {
+	var principal any = "*"
+	if in.Principal != "*" {
+		principal = map[string]any{"AWS": "arn:aws:iam::" + in.Principal + ":root"}
+	}
+
+	stmt := map[string]any{
+		"Sid":       in.StatementID,
+		"Effect":    "Allow",
+		"Principal": principal,
+		"Action":    in.Action,
+		"Resource":  busARN,
+	}
+
+	if in.Condition != nil {
+		stmt["Condition"] = map[string]any{
+			in.Condition.Type: map[string]any{in.Condition.Key: in.Condition.Value},
+		}
+	}
+
+	return stmt
+}
+
+// upsertStatement replaces the statement with a matching Sid, or appends a new
+// one, preserving insertion order.
+func upsertStatement(stmts []map[string]any, stmt map[string]any) []map[string]any {
+	sid, _ := stmt["Sid"].(string)
+	if idx := indexOfStatement(stmts, sid); idx >= 0 {
+		stmts[idx] = stmt
+
+		return stmts
+	}
+
+	return append(stmts, stmt)
+}
+
+// indexOfStatement returns the position of the statement whose "Sid" equals sid,
+// or -1 when none matches.
+func indexOfStatement(stmts []map[string]any, sid string) int {
+	for i, s := range stmts {
+		if got, _ := s["Sid"].(string); got == sid {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// parsePolicyStatements extracts the statement list from a full policy document.
+// A single-object "Statement" is normalized to a one-element list.
+func parsePolicyStatements(policy string) ([]map[string]any, error) {
+	var doc struct {
+		Statement json.RawMessage `json:"Statement"`
+	}
+
+	if err := json.Unmarshal([]byte(policy), &doc); err != nil {
+		return nil, errors.New(errors.InvalidArgument, "policy is not a valid JSON policy document")
+	}
+
+	if len(doc.Statement) == 0 {
+		return nil, errors.New(errors.InvalidArgument, "policy must contain a statement")
+	}
+
+	var list []map[string]any
+	if err := json.Unmarshal(doc.Statement, &list); err == nil {
+		return list, nil
+	}
+
+	var single map[string]any
+	if err := json.Unmarshal(doc.Statement, &single); err != nil {
+		return nil, errors.New(errors.InvalidArgument, "policy statement is malformed")
+	}
+
+	return []map[string]any{single}, nil
+}
+
+// renderPolicy serializes the bus's statements into an IAM policy document
+// string. It returns "" when there are no statements, so DescribeEventBus omits
+// the Policy field for a bus without a resource policy.
+func renderPolicy(stmts []map[string]any) string {
+	if len(stmts) == 0 {
+		return ""
+	}
+
+	out, err := json.Marshal(map[string]any{
+		"Version":   policyVersion,
+		"Statement": stmts,
+	})
+	if err != nil {
+		return ""
+	}
+
+	return string(out)
+}

--- a/providers/aws/eventbridge/permissions_test.go
+++ b/providers/aws/eventbridge/permissions_test.go
@@ -1,0 +1,231 @@
+package eventbridge
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+)
+
+func requireNoErr(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func requireErr(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// busPolicy reads the default bus policy through the public GetEventBus path.
+func busPolicy(t *testing.T, m *Mock) string {
+	t.Helper()
+
+	info, err := m.GetEventBus(context.Background(), defaultBusName)
+	requireNoErr(t, err)
+
+	return info.Policy
+}
+
+// policyStatements decodes the rendered policy document into its statement list.
+func policyStatements(t *testing.T, policy string) []map[string]any {
+	t.Helper()
+
+	if policy == "" {
+		return nil
+	}
+
+	var doc struct {
+		Version   string           `json:"Version"`
+		Statement []map[string]any `json:"Statement"`
+	}
+
+	if err := json.Unmarshal([]byte(policy), &doc); err != nil {
+		t.Fatalf("policy is not valid JSON: %v (%s)", err, policy)
+	}
+
+	return doc.Statement
+}
+
+func TestPutPermissionLegacy(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	err := m.PutPermission(ctx, "", driver.PermissionInput{
+		StatementID: "acct-123",
+		Action:      "events:PutEvents",
+		Principal:   "123456789012",
+	})
+	requireNoErr(t, err)
+
+	stmts := policyStatements(t, busPolicy(t, m))
+	if len(stmts) != 1 {
+		t.Fatalf("want 1 statement, got %d", len(stmts))
+	}
+
+	if stmts[0]["Sid"] != "acct-123" || stmts[0]["Action"] != "events:PutEvents" {
+		t.Fatalf("unexpected statement: %#v", stmts[0])
+	}
+
+	principal, ok := stmts[0]["Principal"].(map[string]any)
+	if !ok || principal["AWS"] != "arn:aws:iam::123456789012:root" {
+		t.Fatalf("unexpected principal: %#v", stmts[0]["Principal"])
+	}
+}
+
+func TestPutPermissionWildcardPrincipal(t *testing.T) {
+	m, _ := newTestMock()
+
+	err := m.PutPermission(context.Background(), "", driver.PermissionInput{
+		StatementID: "everyone",
+		Action:      "events:PutEvents",
+		Principal:   "*",
+	})
+	requireNoErr(t, err)
+
+	stmts := policyStatements(t, busPolicy(t, m))
+	if stmts[0]["Principal"] != "*" {
+		t.Fatalf("want wildcard principal, got %#v", stmts[0]["Principal"])
+	}
+}
+
+func TestPutPermissionCondition(t *testing.T) {
+	m, _ := newTestMock()
+
+	err := m.PutPermission(context.Background(), "", driver.PermissionInput{
+		StatementID: "org-only",
+		Action:      "events:PutEvents",
+		Principal:   "*",
+		Condition:   &driver.PermissionCondition{Type: "StringEquals", Key: "aws:PrincipalOrgID", Value: "o-abc123"},
+	})
+	requireNoErr(t, err)
+
+	policy := busPolicy(t, m)
+	if !strings.Contains(policy, "aws:PrincipalOrgID") || !strings.Contains(policy, "o-abc123") {
+		t.Fatalf("condition not reflected in policy: %s", policy)
+	}
+
+	cond, ok := policyStatements(t, policy)[0]["Condition"].(map[string]any)
+	if !ok {
+		t.Fatalf("Condition missing: %#v", policyStatements(t, policy)[0])
+	}
+
+	se, ok := cond["StringEquals"].(map[string]any)
+	if !ok || se["aws:PrincipalOrgID"] != "o-abc123" {
+		t.Fatalf("unexpected condition shape: %#v", cond)
+	}
+}
+
+func TestPutPermissionPolicyDocument(t *testing.T) {
+	m, _ := newTestMock()
+
+	doc := `{"Version":"2012-10-17","Statement":[` +
+		`{"Sid":"a","Effect":"Allow","Principal":"*","Action":"events:PutEvents","Resource":"arn"},` +
+		`{"Sid":"b","Effect":"Allow","Principal":"*","Action":"events:PutEvents","Resource":"arn"}]}`
+
+	requireNoErr(t, m.PutPermission(context.Background(), "", driver.PermissionInput{Policy: doc}))
+
+	stmts := policyStatements(t, busPolicy(t, m))
+	if len(stmts) != 2 {
+		t.Fatalf("want 2 statements from policy doc, got %d", len(stmts))
+	}
+
+	// A subsequent full-policy PutPermission replaces the whole policy.
+	single := `{"Statement":{"Sid":"c","Effect":"Allow","Principal":"*","Action":"events:PutEvents","Resource":"arn"}}`
+	requireNoErr(t, m.PutPermission(context.Background(), "", driver.PermissionInput{Policy: single}))
+
+	stmts = policyStatements(t, busPolicy(t, m))
+	if len(stmts) != 1 || stmts[0]["Sid"] != "c" {
+		t.Fatalf("policy doc did not replace prior policy: %#v", stmts)
+	}
+}
+
+func TestPutPermissionUpsertBySid(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	in := driver.PermissionInput{StatementID: "s1", Action: "events:PutEvents", Principal: "111111111111"}
+	requireNoErr(t, m.PutPermission(ctx, "", in))
+
+	in.Principal = "222222222222"
+	requireNoErr(t, m.PutPermission(ctx, "", in))
+
+	stmts := policyStatements(t, busPolicy(t, m))
+	if len(stmts) != 1 {
+		t.Fatalf("want statement replaced in place, got %d statements", len(stmts))
+	}
+
+	principal, _ := stmts[0]["Principal"].(map[string]any)
+	if principal["AWS"] != "arn:aws:iam::222222222222:root" {
+		t.Fatalf("statement not updated: %#v", stmts[0])
+	}
+}
+
+func TestPutPermissionValidation(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	// neither legacy trio nor Policy
+	requireErr(t, m.PutPermission(ctx, "", driver.PermissionInput{}))
+
+	// both legacy and Policy
+	requireErr(t, m.PutPermission(ctx, "", driver.PermissionInput{
+		StatementID: "s", Action: "events:PutEvents", Principal: "*", Policy: `{"Statement":[]}`,
+	}))
+
+	// wrong action
+	requireErr(t, m.PutPermission(ctx, "", driver.PermissionInput{
+		StatementID: "s", Action: "events:PutRule", Principal: "*",
+	}))
+
+	// unknown bus
+	requireErr(t, m.PutPermission(ctx, "missing", driver.PermissionInput{
+		StatementID: "s", Action: "events:PutEvents", Principal: "*",
+	}))
+}
+
+func TestRemovePermission(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	requireNoErr(t, m.PutPermission(ctx, "", driver.PermissionInput{StatementID: "s1", Action: "events:PutEvents", Principal: "*"}))
+	requireNoErr(t, m.PutPermission(ctx, "", driver.PermissionInput{StatementID: "s2", Action: "events:PutEvents", Principal: "*"}))
+
+	// remove by id
+	requireNoErr(t, m.RemovePermission(ctx, "", "s1", false))
+
+	stmts := policyStatements(t, busPolicy(t, m))
+	if len(stmts) != 1 || stmts[0]["Sid"] != "s2" {
+		t.Fatalf("remove by id failed: %#v", stmts)
+	}
+
+	// unknown id -> NotFound
+	requireErr(t, m.RemovePermission(ctx, "", "nope", false))
+
+	// remove all clears the policy
+	requireNoErr(t, m.RemovePermission(ctx, "", "", true))
+	if pol := busPolicy(t, m); pol != "" {
+		t.Fatalf("want empty policy after RemoveAll, got %q", pol)
+	}
+}
+
+func TestPutRuleRejectsEmptyPattern(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.PutRule(ctx, &driver.RuleConfig{Name: "r", EventPattern: "{}"}); err == nil {
+		t.Fatal("PutRule with empty {} pattern should fail")
+	}
+
+	if _, err := m.PutRule(ctx, &driver.RuleConfig{Name: "ok", EventPattern: `{"source":["aws.ec2"]}`}); err != nil {
+		t.Fatalf("PutRule with valid pattern should succeed: %v", err)
+	}
+}

--- a/server/aws/eventbridge/handler.go
+++ b/server/aws/eventbridge/handler.go
@@ -70,6 +70,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.removeTargets(w, r)
 	case "ListTargetsByRule":
 		h.listTargetsByRule(w, r)
+	case "ListRuleNamesByTarget":
+		h.listRuleNamesByTarget(w, r)
+	case "PutPermission":
+		h.putPermission(w, r)
+	case "RemovePermission":
+		h.removePermission(w, r)
 	case "PutEvents":
 		h.putEvents(w, r)
 	case "TestEventPattern":

--- a/server/aws/eventbridge/operations.go
+++ b/server/aws/eventbridge/operations.go
@@ -59,6 +59,7 @@ func (h *Handler) describeEventBus(w http.ResponseWriter, r *http.Request) {
 		Arn:          info.ARN,
 		Name:         info.Name,
 		CreationTime: epochSeconds(info.CreatedAt),
+		Policy:       info.Policy,
 	})
 }
 

--- a/server/aws/eventbridge/permissions.go
+++ b/server/aws/eventbridge/permissions.go
@@ -1,0 +1,157 @@
+package eventbridge
+
+import (
+	"context"
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+)
+
+// permissionManager is the AWS-specific EventBridge resource-policy surface,
+// asserted against the provider (not part of the portable EventBus driver, since
+// event-bus resource policies are an AWS-only concept).
+type permissionManager interface {
+	PutPermission(ctx context.Context, busName string, in ebdriver.PermissionInput) error
+	RemovePermission(ctx context.Context, busName, statementID string, removeAll bool) error
+}
+
+func (h *Handler) permissions() (permissionManager, bool) {
+	p, ok := h.bus.(permissionManager)
+
+	return p, ok
+}
+
+type conditionJSON struct {
+	Type  string `json:"Type"`
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}
+
+type putPermissionRequest struct {
+	EventBusName string         `json:"EventBusName"`
+	Action       string         `json:"Action"`
+	Principal    string         `json:"Principal"`
+	StatementID  string         `json:"StatementId"`
+	Policy       string         `json:"Policy"`
+	Condition    *conditionJSON `json:"Condition"`
+}
+
+type removePermissionRequest struct {
+	EventBusName         string `json:"EventBusName"`
+	StatementID          string `json:"StatementId"`
+	RemoveAllPermissions bool   `json:"RemoveAllPermissions"`
+}
+
+func (h *Handler) putPermission(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.permissions()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "resource policies not supported"))
+		return
+	}
+
+	var req putPermissionRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	in := ebdriver.PermissionInput{
+		StatementID: req.StatementID,
+		Action:      req.Action,
+		Principal:   req.Principal,
+		Policy:      req.Policy,
+	}
+
+	if req.Condition != nil {
+		in.Condition = &ebdriver.PermissionCondition{
+			Type:  req.Condition.Type,
+			Key:   req.Condition.Key,
+			Value: req.Condition.Value,
+		}
+	}
+
+	if err := mgr.PutPermission(r.Context(), req.EventBusName, in); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, struct{}{})
+}
+
+func (h *Handler) removePermission(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.permissions()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "resource policies not supported"))
+		return
+	}
+
+	var req removePermissionRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := mgr.RemovePermission(r.Context(), req.EventBusName, req.StatementID, req.RemoveAllPermissions); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, struct{}{})
+}
+
+type listRuleNamesByTargetRequest struct {
+	TargetArn    string `json:"TargetArn"`
+	EventBusName string `json:"EventBusName"`
+	Limit        int    `json:"Limit"`
+	NextToken    string `json:"NextToken"`
+}
+
+type listRuleNamesByTargetResponse struct {
+	RuleNames []string `json:"RuleNames"`
+	NextToken string   `json:"NextToken,omitempty"`
+}
+
+// listRuleNamesByTarget returns the names of the rules on a bus that route to a
+// given target ARN. It is derived from the portable ListRules/ListTargets driver
+// methods, so no AWS-specific provider hook is needed.
+func (h *Handler) listRuleNamesByTarget(w http.ResponseWriter, r *http.Request) {
+	var req listRuleNamesByTargetRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.TargetArn == "" {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException",
+			"Parameter TargetArn must be specified.")
+		return
+	}
+
+	bus := busNameOrDefault(req.EventBusName)
+
+	rules, err := h.bus.ListRules(r.Context(), bus)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	names := make([]string, 0, len(rules))
+
+	for i := range rules {
+		targets, tErr := h.bus.ListTargets(r.Context(), bus, rules[i].Name)
+		if tErr != nil {
+			continue
+		}
+
+		for j := range targets {
+			if targets[j].ARN == req.TargetArn {
+				names = append(names, rules[i].Name)
+
+				break
+			}
+		}
+	}
+
+	names, nextToken := paginateByCursor(names, req.NextToken, req.Limit, func(s string) string { return s })
+
+	wire.WriteJSON(w, listRuleNamesByTargetResponse{RuleNames: names, NextToken: nextToken})
+}

--- a/server/aws/eventbridge/permissions_sdk_test.go
+++ b/server/aws/eventbridge/permissions_sdk_test.go
@@ -1,0 +1,173 @@
+package eventbridge_test
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKEventBridgePutPermissionReflectedOnDescribe drives PutPermission with a
+// legacy trio + Condition through the real SDK and verifies DescribeEventBus
+// surfaces the resulting resource policy.
+func TestSDKEventBridgePutPermissionReflectedOnDescribe(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	_, err := client.PutPermission(ctx, &awseb.PutPermissionInput{
+		Action:      aws.String("events:PutEvents"),
+		Principal:   aws.String("123456789012"),
+		StatementId: aws.String("cross-acct"),
+		Condition: &ebtypes.Condition{
+			Type:  aws.String("StringEquals"),
+			Key:   aws.String("aws:PrincipalOrgID"),
+			Value: aws.String("o-abc123"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("PutPermission: %v", err)
+	}
+
+	out, err := client.DescribeEventBus(ctx, &awseb.DescribeEventBusInput{})
+	if err != nil {
+		t.Fatalf("DescribeEventBus: %v", err)
+	}
+
+	if out.Policy == nil {
+		t.Fatal("DescribeEventBus returned no Policy")
+	}
+
+	for _, want := range []string{"cross-acct", "events:PutEvents", "123456789012", "aws:PrincipalOrgID", "o-abc123"} {
+		if !strings.Contains(*out.Policy, want) {
+			t.Fatalf("policy missing %q: %s", want, *out.Policy)
+		}
+	}
+}
+
+func TestSDKEventBridgeRemovePermission(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	for _, sid := range []string{"s1", "s2"} {
+		if _, err := client.PutPermission(ctx, &awseb.PutPermissionInput{
+			Action:      aws.String("events:PutEvents"),
+			Principal:   aws.String("*"),
+			StatementId: aws.String(sid),
+		}); err != nil {
+			t.Fatalf("PutPermission(%s): %v", sid, err)
+		}
+	}
+
+	if _, err := client.RemovePermission(ctx, &awseb.RemovePermissionInput{StatementId: aws.String("s1")}); err != nil {
+		t.Fatalf("RemovePermission: %v", err)
+	}
+
+	out, err := client.DescribeEventBus(ctx, &awseb.DescribeEventBusInput{})
+	if err != nil {
+		t.Fatalf("DescribeEventBus: %v", err)
+	}
+
+	if out.Policy == nil || strings.Contains(*out.Policy, `"s1"`) || !strings.Contains(*out.Policy, `"s2"`) {
+		t.Fatalf("unexpected policy after removal: %v", aws.ToString(out.Policy))
+	}
+
+	// unknown statement id -> ResourceNotFoundException
+	_, err = client.RemovePermission(ctx, &awseb.RemovePermissionInput{StatementId: aws.String("ghost")})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ResourceNotFoundException" {
+		t.Fatalf("want ResourceNotFoundException, got %T: %v", err, err)
+	}
+
+	// RemoveAllPermissions clears the policy entirely.
+	if _, err := client.RemovePermission(ctx, &awseb.RemovePermissionInput{
+		RemoveAllPermissions: true,
+	}); err != nil {
+		t.Fatalf("RemovePermission(all): %v", err)
+	}
+
+	out, err = client.DescribeEventBus(ctx, &awseb.DescribeEventBusInput{})
+	if err != nil {
+		t.Fatalf("DescribeEventBus: %v", err)
+	}
+
+	if aws.ToString(out.Policy) != "" {
+		t.Fatalf("policy not cleared: %q", aws.ToString(out.Policy))
+	}
+}
+
+func TestSDKEventBridgeListRuleNamesByTarget(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	const targetArn = "arn:aws:sqs:us-east-1:123456789012:orders"
+
+	// Two rules point at targetArn; one points elsewhere.
+	rules := map[string]string{
+		"rule-a": targetArn,
+		"rule-b": targetArn,
+		"rule-c": "arn:aws:sqs:us-east-1:123456789012:other",
+	}
+
+	for name, arn := range rules {
+		if _, err := client.PutRule(ctx, &awseb.PutRuleInput{
+			Name:         aws.String(name),
+			EventPattern: aws.String(`{"source":["app"]}`),
+		}); err != nil {
+			t.Fatalf("PutRule(%s): %v", name, err)
+		}
+
+		if _, err := client.PutTargets(ctx, &awseb.PutTargetsInput{
+			Rule:    aws.String(name),
+			Targets: []ebtypes.Target{{Id: aws.String("t1"), Arn: aws.String(arn)}},
+		}); err != nil {
+			t.Fatalf("PutTargets(%s): %v", name, err)
+		}
+	}
+
+	out, err := client.ListRuleNamesByTarget(ctx, &awseb.ListRuleNamesByTargetInput{
+		TargetArn: aws.String(targetArn),
+	})
+	if err != nil {
+		t.Fatalf("ListRuleNamesByTarget: %v", err)
+	}
+
+	got := out.RuleNames
+	sort.Strings(got)
+
+	if len(got) != 2 || got[0] != "rule-a" || got[1] != "rule-b" {
+		t.Fatalf("want [rule-a rule-b], got %v", got)
+	}
+
+	// Pagination: Limit=1 returns one name plus a NextToken that resumes.
+	page1, err := client.ListRuleNamesByTarget(ctx, &awseb.ListRuleNamesByTargetInput{
+		TargetArn: aws.String(targetArn),
+		Limit:     aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("ListRuleNamesByTarget page1: %v", err)
+	}
+
+	if len(page1.RuleNames) != 1 || page1.NextToken == nil {
+		t.Fatalf("want 1 name + NextToken, got names=%v token=%v", page1.RuleNames, page1.NextToken)
+	}
+
+	page2, err := client.ListRuleNamesByTarget(ctx, &awseb.ListRuleNamesByTargetInput{
+		TargetArn: aws.String(targetArn),
+		Limit:     aws.Int32(1),
+		NextToken: page1.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("ListRuleNamesByTarget page2: %v", err)
+	}
+
+	if len(page2.RuleNames) != 1 || page2.RuleNames[0] == page1.RuleNames[0] {
+		t.Fatalf("page2 should return the other name, got %v (page1 %v)", page2.RuleNames, page1.RuleNames)
+	}
+}

--- a/server/aws/eventbridge/types.go
+++ b/server/aws/eventbridge/types.go
@@ -116,6 +116,7 @@ type describeEventBusResponse struct {
 	Name         string  `json:"Name"`
 	Description  string  `json:"Description,omitempty"`
 	CreationTime float64 `json:"CreationTime,omitempty"`
+	Policy       string  `json:"Policy,omitempty"`
 }
 
 type eventBusEntry struct {

--- a/services/eventbus/driver/driver.go
+++ b/services/eventbus/driver/driver.go
@@ -27,6 +27,32 @@ type EventBusInfo struct {
 	// public network (Azure Event Grid: "Enabled", "Disabled"). Empty for AWS
 	// and GCP.
 	PublicNetworkAccess string
+	// Policy is the resource-based (IAM) policy document attached to the event
+	// bus, as a JSON string. Managed by EventBridge PutPermission/RemovePermission
+	// and surfaced on DescribeEventBus. Empty when the bus has no policy, and for
+	// Azure and GCP.
+	Policy string
+}
+
+// PermissionCondition is an optional condition on an EventBridge event-bus
+// resource-policy statement, e.g. StringEquals on aws:PrincipalOrgID.
+type PermissionCondition struct {
+	Type  string // condition operator, e.g. "StringEquals"
+	Key   string // condition key, e.g. "aws:PrincipalOrgID"
+	Value string // condition value, e.g. "o-1234567890"
+}
+
+// PermissionInput carries the parameters of an EventBridge PutPermission call.
+// It is either the legacy Action/Principal/StatementID trio (optionally with a
+// Condition) or a full Policy JSON document — the two forms are mutually
+// exclusive. Resource-based policies are an AWS-EventBridge concept, so this is
+// consumed through an AWS-specific optional interface, not the portable driver.
+type PermissionInput struct {
+	StatementID string
+	Action      string
+	Principal   string
+	Policy      string
+	Condition   *PermissionCondition
 }
 
 // EventBusConfig configures a new event bus.


### PR DESCRIPTION
## Summary

Closes three genuinely-open AWS EventBridge gaps.

### 1. Event-bus resource policy — `PutPermission` / `RemovePermission`
Adds the resource-based policy surface behind `aws_cloudwatch_event_permission`:
- **PutPermission** supports both forms — the legacy `Action` (must be `events:PutEvents`) / `Principal` (12-digit account id or `*`) / `StatementId` trio, optionally with a `Condition` (Type/Key/Value, e.g. `StringEquals aws:PrincipalOrgID`), and a full `Policy` JSON document (mutually exclusive with the trio). Legacy statements are stored keyed by `StatementId`; a `*` principal is stored as-is while an account id expands to its root ARN.
- **RemovePermission** removes a statement by `StatementId` (unknown id → `ResourceNotFoundException`) or clears the whole policy with `RemoveAllPermissions`.
- The resulting policy document is reflected on **DescribeEventBus** (`Policy` field).
- Validation: wrong `Action`, and the both-forms / neither-form cases, are rejected as `ValidationException`.

Resource policies are AWS-EventBridge-specific, so — following the existing `resourceTagger` precedent — this is exposed through an AWS-only optional interface (`permissionManager`) asserted against the provider, not the portable `EventBus` driver. The shared `PermissionInput`/`PermissionCondition` types and an `EventBusInfo.Policy` data field live in the driver package.

### 2. `ListRuleNamesByTarget`
Given a `TargetArn`, returns the names of rules routing to it on the given bus (default bus when omitted), with `NextToken`/`Limit` pagination like the other list ops. Derived purely from the existing `ListRules`/`ListTargets` driver methods, so no new provider hook is required.

### 3. Reject empty `{}` event pattern
`eventmatch.ValidatePattern` now rejects a top-level empty pattern `{}` (and `null`) with `InvalidEventPatternException` ("Empty patterns are not allowed"), matching real EventBridge on `PutRule`/`TestEventPattern`. Legitimately-empty **nested** objects and all existing valid patterns still pass (gate is exactly the top-level object).

## Tests
- Provider (hand-rolled helpers): PutPermission legacy / wildcard principal / Policy-doc / Condition / upsert-by-Sid; RemovePermission by-id, RemoveAll, unknown-id error; both-forms & neither-form & wrong-action & unknown-bus validation; DescribeEventBus reflects the policy; empty `{}` pattern rejected while a valid pattern passes.
- Wire (real aws-sdk-go-v2): PutPermission+Condition reflected on DescribeEventBus; RemovePermission by-id / RemoveAll / unknown-id → ResourceNotFoundException; ListRuleNamesByTarget correct names + pagination.
- `eventmatch` unit test for the empty-pattern gate.

## Gates
`go build ./...`, `go vet`, scoped `go test`, `gofmt -l`, and `golangci-lint --new-from-rev=origin/development` all clean. `go generate ./...` (coverage) and `go run ./internal/compatgen` (compat) produce zero diff — consistent with the tags precedent, these AWS-specific optional-interface ops are not on the portable driver, so they don't add coverage/compat rows.
