### PR TITLE
fix(config): recordingMode round-trip + EvaluationResultIdentifier in GetComplianceDetailsByConfigRule

### DIFF
--- a/providers/aws/configservice/evaluations.go
+++ b/providers/aws/configservice/evaluations.go
@@ -76,10 +76,18 @@ func (m *Mock) PutEvaluations(
 		return nil, invalidResultToken(resultToken)
 	}
 
+	now := m.now()
+
+	for i := range evals {
+		if evals[i].OrderingTimestamp.IsZero() {
+			evals[i].OrderingTimestamp = now
+		}
+	}
+
 	rd.mu.Lock()
 	rd.evals = append(rd.evals, evals...)
 	rd.rule.Compliance = rollUpCompliance(rd.evals)
-	rd.rule.LastSuccessfulEval = m.now()
+	rd.rule.LastSuccessfulEval = now
 	rd.mu.Unlock()
 
 	return nil, nil
@@ -143,6 +151,10 @@ func (m *Mock) PutExternalEvaluation(_ context.Context, ruleName string, eval dr
 	rd, ok := m.rules.Get(ruleName)
 	if !ok {
 		return noSuchConfigRule(ruleName)
+	}
+
+	if eval.OrderingTimestamp.IsZero() {
+		eval.OrderingTimestamp = m.now()
 	}
 
 	rd.mu.Lock()

--- a/providers/aws/configservice/recorders.go
+++ b/providers/aws/configservice/recorders.go
@@ -23,6 +23,10 @@ func (m *Mock) PutConfigurationRecorder(_ context.Context, rec driver.Configurat
 		return invalidParameter("RoleARN is required")
 	}
 
+	if err := validateRecordingMode(rec.RecordingMode); err != nil {
+		return err
+	}
+
 	now := m.now()
 
 	// Hold createMu across the scan+insert: the single-recorder cap is not atomic
@@ -42,6 +46,7 @@ func (m *Mock) PutConfigurationRecorder(_ context.Context, rec driver.Configurat
 		existing.mu.Lock()
 		existing.rec.RoleARN = rec.RoleARN
 		existing.rec.RecordingGroup = rec.RecordingGroup
+		existing.rec.RecordingMode = rec.RecordingMode
 		existing.rec.Tags = copyTags(rec.Tags)
 		existing.mu.Unlock()
 
@@ -70,7 +75,58 @@ func copyRecorder(r *driver.ConfigurationRecorder) driver.ConfigurationRecorder 
 		out.RecordingGroup = &rg
 	}
 
+	if r.RecordingMode != nil {
+		out.RecordingMode = copyRecordingMode(r.RecordingMode)
+	}
+
 	return out
+}
+
+func copyRecordingMode(rm *driver.RecordingMode) *driver.RecordingMode {
+	out := *rm
+
+	if rm.RecordingModeOverrides != nil {
+		overrides := make([]driver.RecordingModeOverride, len(rm.RecordingModeOverrides))
+
+		for i := range rm.RecordingModeOverrides {
+			ov := rm.RecordingModeOverrides[i]
+			ov.ResourceTypes = copyStrings(rm.RecordingModeOverrides[i].ResourceTypes)
+			overrides[i] = ov
+		}
+
+		out.RecordingModeOverrides = overrides
+	}
+
+	return &out
+}
+
+// validateRecordingMode rejects a recording frequency outside CONTINUOUS/DAILY.
+// An absent frequency is allowed (the field is optional).
+func validateRecordingMode(rm *driver.RecordingMode) error {
+	if rm == nil {
+		return nil
+	}
+
+	if err := validateRecordingFrequency(rm.RecordingFrequency); err != nil {
+		return err
+	}
+
+	for i := range rm.RecordingModeOverrides {
+		if err := validateRecordingFrequency(rm.RecordingModeOverrides[i].RecordingFrequency); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateRecordingFrequency(f string) error {
+	switch f {
+	case "", driver.RecordingFrequencyContinuous, driver.RecordingFrequencyDaily:
+		return nil
+	default:
+		return invalidParameter("RecordingFrequency %q is invalid", f)
+	}
 }
 
 func (m *Mock) allRecorders() []driver.ConfigurationRecorder {

--- a/server/aws/configservice/aggregate_query_ops.go
+++ b/server/aws/configservice/aggregate_query_ops.go
@@ -83,7 +83,10 @@ func (h *Handler) getAggregateComplianceDetailsByConfigRule(w http.ResponseWrite
 			return nil, err
 		}
 
-		return map[string]any{"AggregateEvaluationResults": evalResults(evals), "NextToken": next}, nil
+		return map[string]any{
+			"AggregateEvaluationResults": evalResults(req.ConfigRuleName, evals),
+			"NextToken":                  next,
+		}, nil
 	})
 }
 

--- a/server/aws/configservice/compliance_ops.go
+++ b/server/aws/configservice/compliance_ops.go
@@ -73,10 +73,23 @@ func (h *Handler) describeComplianceByResource(w http.ResponseWriter, r *http.Re
 	})
 }
 
+type evaluationResultQualifierJSON struct {
+	ConfigRuleName string `json:"ConfigRuleName,omitempty"`
+	ResourceType   string `json:"ResourceType,omitempty"`
+	ResourceID     string `json:"ResourceId,omitempty"`
+}
+
+type evaluationResultIdentifierJSON struct {
+	EvaluationResultQualifier *evaluationResultQualifierJSON `json:"EvaluationResultQualifier,omitempty"`
+	OrderingTimestamp         *float64                       `json:"OrderingTimestamp,omitempty"`
+}
+
 type evaluationResultJSON struct {
-	ComplianceType     string   `json:"ComplianceType,omitempty"`
-	Annotation         string   `json:"Annotation,omitempty"`
-	ResultRecordedTime *float64 `json:"ResultRecordedTime,omitempty"`
+	EvaluationResultIdentifier *evaluationResultIdentifierJSON `json:"EvaluationResultIdentifier,omitempty"`
+	ComplianceType             string                          `json:"ComplianceType,omitempty"`
+	ConfigRuleInvokedTime      *float64                        `json:"ConfigRuleInvokedTime,omitempty"`
+	ResultRecordedTime         *float64                        `json:"ResultRecordedTime,omitempty"`
+	Annotation                 string                          `json:"Annotation,omitempty"`
 }
 
 type complianceDetailsResp struct {
@@ -92,7 +105,7 @@ func (h *Handler) getComplianceDetailsByConfigRule(w http.ResponseWriter, r *htt
 			return nil, err
 		}
 
-		return complianceDetailsResp{EvaluationResults: evalResults(evals), NextToken: next}, nil
+		return complianceDetailsResp{EvaluationResults: evalResults(req.ConfigRuleName, evals), NextToken: next}, nil
 	})
 }
 
@@ -104,7 +117,10 @@ func (h *Handler) getComplianceDetailsByResource(w http.ResponseWriter, r *http.
 			return nil, err
 		}
 
-		return complianceDetailsResp{EvaluationResults: evalResults(evals), NextToken: next}, nil
+		// The by-resource driver call spans every rule and does not surface which
+		// rule produced each evaluation, so the qualifier's ConfigRuleName is left
+		// empty; ResourceType/ResourceId still come from the stored evaluation.
+		return complianceDetailsResp{EvaluationResults: evalResults("", evals), NextToken: next}, nil
 	})
 }
 
@@ -160,14 +176,25 @@ func (h *Handler) getComplianceSummaryByResourceType(w http.ResponseWriter, r *h
 	})
 }
 
-// evalResults converts driver evaluations into wire EvaluationResult records.
-func evalResults(evals []cfgEvaluation) []evaluationResultJSON {
+// evalResults converts driver evaluations into wire EvaluationResult records,
+// each carrying the EvaluationResultIdentifier that consumers key results by.
+func evalResults(configRuleName string, evals []cfgEvaluation) []evaluationResultJSON {
 	out := make([]evaluationResultJSON, 0, len(evals))
 	for i := range evals {
+		ordering := epochOrNil(evals[i].OrderingTimestamp)
 		out = append(out, evaluationResultJSON{
-			ComplianceType:     evals[i].ComplianceType,
-			Annotation:         evals[i].Annotation,
-			ResultRecordedTime: epochOrNil(evals[i].OrderingTimestamp),
+			EvaluationResultIdentifier: &evaluationResultIdentifierJSON{
+				EvaluationResultQualifier: &evaluationResultQualifierJSON{
+					ConfigRuleName: configRuleName,
+					ResourceType:   evals[i].ComplianceResourceType,
+					ResourceID:     evals[i].ComplianceResourceID,
+				},
+				OrderingTimestamp: ordering,
+			},
+			ComplianceType:        evals[i].ComplianceType,
+			ConfigRuleInvokedTime: ordering,
+			ResultRecordedTime:    ordering,
+			Annotation:            evals[i].Annotation,
 		})
 	}
 

--- a/server/aws/configservice/pack_ops.go
+++ b/server/aws/configservice/pack_ops.go
@@ -142,7 +142,7 @@ func (h *Handler) getConformancePackComplianceDetails(w http.ResponseWriter, r *
 
 		return packComplianceDetailsResp{
 			ConformancePackName:                  req.ConformancePackName,
-			ConformancePackRuleEvaluationResults: evalResults(evals),
+			ConformancePackRuleEvaluationResults: evalResults("", evals),
 			NextToken:                            next,
 		}, nil
 	})

--- a/server/aws/configservice/sdk_roundtrip_test.go
+++ b/server/aws/configservice/sdk_roundtrip_test.go
@@ -337,6 +337,162 @@ func TestSDKRecorderExclusionRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSDKRecorderRecordingModeRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c := newConfigClient(t)
+
+	putMode := func(freq cfgtypes.RecordingFrequency, overrides []cfgtypes.RecordingModeOverride) {
+		if _, err := c.PutConfigurationRecorder(ctx, &cfgsdk.PutConfigurationRecorderInput{
+			ConfigurationRecorder: &cfgtypes.ConfigurationRecorder{
+				Name:    aws.String("default"),
+				RoleARN: aws.String("arn:aws:iam::123456789012:role/config"),
+				RecordingGroup: &cfgtypes.RecordingGroup{
+					AllSupported: true,
+				},
+				RecordingMode: &cfgtypes.RecordingMode{
+					RecordingFrequency:     freq,
+					RecordingModeOverrides: overrides,
+				},
+			},
+		}); err != nil {
+			t.Fatalf("PutConfigurationRecorder(%s): %v", freq, err)
+		}
+	}
+
+	readMode := func() *cfgtypes.RecordingMode {
+		recs, err := c.DescribeConfigurationRecorders(ctx, &cfgsdk.DescribeConfigurationRecordersInput{})
+		if err != nil {
+			t.Fatalf("DescribeConfigurationRecorders: %v", err)
+		}
+
+		if len(recs.ConfigurationRecorders) != 1 {
+			t.Fatalf("want 1 recorder, got %d", len(recs.ConfigurationRecorders))
+		}
+
+		return recs.ConfigurationRecorders[0].RecordingMode
+	}
+
+	// CONTINUOUS round-trips.
+	putMode(cfgtypes.RecordingFrequencyContinuous, nil)
+
+	if rm := readMode(); rm == nil || rm.RecordingFrequency != cfgtypes.RecordingFrequencyContinuous {
+		t.Fatalf("recordingMode dropped/wrong on read-back: %+v", rm)
+	}
+
+	// DAILY with an override round-trips (upsert onto the existing recorder).
+	putMode(cfgtypes.RecordingFrequencyDaily, []cfgtypes.RecordingModeOverride{{
+		Description:        aws.String("hot types"),
+		RecordingFrequency: cfgtypes.RecordingFrequencyContinuous,
+		ResourceTypes:      []cfgtypes.ResourceType{cfgtypes.ResourceTypeInstance},
+	}})
+
+	rm := readMode()
+	if rm == nil || rm.RecordingFrequency != cfgtypes.RecordingFrequencyDaily {
+		t.Fatalf("daily recordingMode dropped/wrong on read-back: %+v", rm)
+	}
+
+	if len(rm.RecordingModeOverrides) != 1 {
+		t.Fatalf("want 1 override, got %d: %+v", len(rm.RecordingModeOverrides), rm.RecordingModeOverrides)
+	}
+
+	ov := rm.RecordingModeOverrides[0]
+	if aws.ToString(ov.Description) != "hot types" ||
+		ov.RecordingFrequency != cfgtypes.RecordingFrequencyContinuous ||
+		len(ov.ResourceTypes) != 1 || ov.ResourceTypes[0] != cfgtypes.ResourceTypeInstance {
+		t.Fatalf("override not round-tripped faithfully: %+v", ov)
+	}
+}
+
+func TestSDKRecorderInvalidRecordingFrequency(t *testing.T) {
+	ctx := context.Background()
+	c := newConfigClient(t)
+
+	_, err := c.PutConfigurationRecorder(ctx, &cfgsdk.PutConfigurationRecorderInput{
+		ConfigurationRecorder: &cfgtypes.ConfigurationRecorder{
+			Name:    aws.String("default"),
+			RoleARN: aws.String("arn:aws:iam::123456789012:role/config"),
+			RecordingMode: &cfgtypes.RecordingMode{
+				RecordingFrequency: cfgtypes.RecordingFrequency("HOURLY"),
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected an error for an invalid RecordingFrequency, got nil")
+	}
+}
+
+func TestSDKComplianceDetailsEvaluationResultIdentifier(t *testing.T) {
+	ctx := context.Background()
+	c, drv := newConfigClientWithDriver(t)
+
+	if _, err := c.PutConfigRule(ctx, &cfgsdk.PutConfigRuleInput{
+		ConfigRule: &cfgtypes.ConfigRule{
+			ConfigRuleName: aws.String("s3-sse"),
+			Source: &cfgtypes.Source{
+				Owner: cfgtypes.OwnerAws, SourceIdentifier: aws.String("S3_BUCKET_SSE_ENABLED"),
+			},
+			Scope: &cfgtypes.Scope{ComplianceResourceTypes: []string{"AWS::S3::Bucket"}},
+		},
+	}); err != nil {
+		t.Fatalf("PutConfigRule: %v", err)
+	}
+
+	token, ok := drv.ResultTokenForRule("s3-sse")
+	if !ok {
+		t.Fatal("no result token issued for rule s3-sse")
+	}
+
+	ordering := nowUTC().Truncate(time.Second)
+	if _, err := c.PutEvaluations(ctx, &cfgsdk.PutEvaluationsInput{
+		ResultToken: aws.String(token),
+		Evaluations: []cfgtypes.Evaluation{{
+			ComplianceResourceType: aws.String("AWS::S3::Bucket"),
+			ComplianceResourceId:   aws.String("bucket-42"),
+			ComplianceType:         cfgtypes.ComplianceTypeNonCompliant,
+			OrderingTimestamp:      aws.Time(ordering),
+		}},
+	}); err != nil {
+		t.Fatalf("PutEvaluations: %v", err)
+	}
+
+	details, err := c.GetComplianceDetailsByConfigRule(ctx, &cfgsdk.GetComplianceDetailsByConfigRuleInput{
+		ConfigRuleName: aws.String("s3-sse"),
+	})
+	if err != nil {
+		t.Fatalf("GetComplianceDetailsByConfigRule: %v", err)
+	}
+
+	if len(details.EvaluationResults) != 1 {
+		t.Fatalf("want 1 evaluation result, got %d", len(details.EvaluationResults))
+	}
+
+	res := details.EvaluationResults[0]
+	if res.EvaluationResultIdentifier == nil || res.EvaluationResultIdentifier.EvaluationResultQualifier == nil {
+		t.Fatalf("EvaluationResultIdentifier not populated: %+v", res)
+	}
+
+	q := res.EvaluationResultIdentifier.EvaluationResultQualifier
+	if aws.ToString(q.ConfigRuleName) != "s3-sse" ||
+		aws.ToString(q.ResourceType) != "AWS::S3::Bucket" ||
+		aws.ToString(q.ResourceId) != "bucket-42" {
+		t.Fatalf("qualifier fields wrong: %+v", q)
+	}
+
+	if res.EvaluationResultIdentifier.OrderingTimestamp == nil ||
+		!res.EvaluationResultIdentifier.OrderingTimestamp.Equal(ordering) {
+		t.Fatalf("OrderingTimestamp wrong: got %v want %v",
+			res.EvaluationResultIdentifier.OrderingTimestamp, ordering)
+	}
+
+	if res.ConfigRuleInvokedTime == nil || res.ResultRecordedTime == nil {
+		t.Fatalf("ConfigRuleInvokedTime/ResultRecordedTime not populated: %+v", res)
+	}
+
+	if res.ComplianceType != cfgtypes.ComplianceTypeNonCompliant {
+		t.Fatalf("unexpected compliance type: %v", res.ComplianceType)
+	}
+}
+
 func TestSDKConformancePackRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	c := newConfigClient(t)

--- a/server/aws/configservice/types.go
+++ b/server/aws/configservice/types.go
@@ -51,6 +51,14 @@ func epochOrNil(t time.Time) *float64 {
 	return &secs
 }
 
+func timeFromEpoch(secs *float64) time.Time {
+	if secs == nil {
+		return time.Time{}
+	}
+
+	return time.Unix(int64(*secs), 0).UTC()
+}
+
 // --- Recording group / recorder (lowerCamel document members) ---
 
 type recordingGroupJSON struct {
@@ -115,11 +123,61 @@ func recordingGroupToWire(g *cfgdriver.RecordingGroup) *recordingGroupJSON {
 	return out
 }
 
+type recordingModeOverrideJSON struct {
+	Description        string   `json:"description,omitempty"`
+	ResourceTypes      []string `json:"resourceTypes,omitempty"`
+	RecordingFrequency string   `json:"recordingFrequency,omitempty"`
+}
+
+type recordingModeJSON struct {
+	RecordingFrequency     string                      `json:"recordingFrequency,omitempty"`
+	RecordingModeOverrides []recordingModeOverrideJSON `json:"recordingModeOverrides,omitempty"`
+}
+
+func (m *recordingModeJSON) toDriver() *cfgdriver.RecordingMode {
+	if m == nil {
+		return nil
+	}
+
+	out := &cfgdriver.RecordingMode{RecordingFrequency: m.RecordingFrequency}
+
+	for i := range m.RecordingModeOverrides {
+		o := m.RecordingModeOverrides[i]
+		out.RecordingModeOverrides = append(out.RecordingModeOverrides, cfgdriver.RecordingModeOverride{
+			Description:        o.Description,
+			ResourceTypes:      o.ResourceTypes,
+			RecordingFrequency: o.RecordingFrequency,
+		})
+	}
+
+	return out
+}
+
+func recordingModeToWire(m *cfgdriver.RecordingMode) *recordingModeJSON {
+	if m == nil {
+		return nil
+	}
+
+	out := &recordingModeJSON{RecordingFrequency: m.RecordingFrequency}
+
+	for i := range m.RecordingModeOverrides {
+		o := m.RecordingModeOverrides[i]
+		out.RecordingModeOverrides = append(out.RecordingModeOverrides, recordingModeOverrideJSON{
+			Description:        o.Description,
+			ResourceTypes:      o.ResourceTypes,
+			RecordingFrequency: o.RecordingFrequency,
+		})
+	}
+
+	return out
+}
+
 type configurationRecorderJSON struct {
 	Arn            string              `json:"arn,omitempty"`
 	Name           string              `json:"name,omitempty"`
 	RoleARN        string              `json:"roleARN,omitempty"`
 	RecordingGroup *recordingGroupJSON `json:"recordingGroup,omitempty"`
+	RecordingMode  *recordingModeJSON  `json:"recordingMode,omitempty"`
 }
 
 func (c *configurationRecorderJSON) toDriver() cfgdriver.ConfigurationRecorder {
@@ -131,6 +189,7 @@ func (c *configurationRecorderJSON) toDriver() cfgdriver.ConfigurationRecorder {
 		Name:           c.Name,
 		RoleARN:        c.RoleARN,
 		RecordingGroup: c.RecordingGroup.toDriver(),
+		RecordingMode:  c.RecordingMode.toDriver(),
 	}
 }
 
@@ -140,6 +199,7 @@ func recorderToWire(r *cfgdriver.ConfigurationRecorder) configurationRecorderJSO
 		Name:           r.Name,
 		RoleARN:        r.RoleARN,
 		RecordingGroup: recordingGroupToWire(r.RecordingGroup),
+		RecordingMode:  recordingModeToWire(r.RecordingMode),
 	}
 }
 
@@ -327,6 +387,7 @@ func (e *evaluationJSON) toDriver() cfgdriver.Evaluation {
 		ComplianceResourceID:   e.ComplianceResourceID,
 		ComplianceType:         e.ComplianceType,
 		Annotation:             e.Annotation,
+		OrderingTimestamp:      timeFromEpoch(e.OrderingTimestamp),
 	}
 }
 

--- a/services/configservice/driver/types.go
+++ b/services/configservice/driver/types.go
@@ -41,12 +41,34 @@ type RecordingGroup struct {
 	ExclusionByResources []string
 }
 
+// Recording frequencies accepted by a recorder's RecordingMode.
+const (
+	RecordingFrequencyContinuous = "CONTINUOUS"
+	RecordingFrequencyDaily      = "DAILY"
+)
+
+// RecordingModeOverride overrides the recording frequency for a set of resource
+// types.
+type RecordingModeOverride struct {
+	Description        string
+	ResourceTypes      []string
+	RecordingFrequency string
+}
+
+// RecordingMode controls how frequently a recorder captures resource changes,
+// with optional per-resource-type overrides.
+type RecordingMode struct {
+	RecordingFrequency     string
+	RecordingModeOverrides []RecordingModeOverride
+}
+
 // ConfigurationRecorder mirrors the customer-managed Config recorder.
 type ConfigurationRecorder struct {
 	Arn            string
 	Name           string
 	RoleARN        string
 	RecordingGroup *RecordingGroup
+	RecordingMode  *RecordingMode
 	Tags           map[string]string
 
 	// Runtime status, mutated by Start/StopConfigurationRecorder.


### PR DESCRIPTION
## Summary

Two AWS Config fidelity gaps that caused Terraform/SDK drift.

### 1. recordingMode round-trip on the configuration recorder
Real `PutConfigurationRecorder` accepts a `RecordingMode { RecordingFrequency, RecordingModeOverrides[] }` alongside `recordingGroup`. It was not modeled anywhere, so `DescribeConfigurationRecorders` never echoed it and Terraform saw perpetual drift.

- Added `RecordingMode` / `RecordingModeOverride` to the recorder driver model.
- Stored what `PutConfigurationRecorder` sends (create + idempotent upsert paths) and reflected it faithfully on `DescribeConfigurationRecorders`, including per-resource-type overrides.
- Validate `RecordingFrequency` is `CONTINUOUS` or `DAILY` when present (top-level and per override).
- Round-trip fidelity only; actual recording behavior is unchanged.

### 2. EvaluationResultIdentifier in GetComplianceDetailsByConfigRule
The response only carried `ComplianceType` / `Annotation` / `ResultRecordedTime`. Consumers that key results by resource need the full identifier.

- Populated `EvaluationResultIdentifier.EvaluationResultQualifier` (`ConfigRuleName`, `ResourceType`, `ResourceId`) plus `OrderingTimestamp`, `ConfigRuleInvokedTime`, and `ResultRecordedTime`.
- `ResourceType` / `ResourceId` come from the stored evaluation (already carried on the record — nothing fabricated). `ConfigRuleName` comes from the request. The wire `toDriver` now threads the client-supplied `OrderingTimestamp` (previously dropped); `PutEvaluations` / `PutExternalEvaluation` default it to now when omitted so timestamps are always populated.
- The by-resource and conformance-pack paths span multiple rules and do not surface a single rule name, so their qualifier's `ConfigRuleName` is left empty (ResourceType/ResourceId still populated).

## Tests
- `TestSDKRecorderRecordingModeRoundTrip` — CONTINUOUS, then DAILY + override, round-trip Put -> Describe.
- `TestSDKRecorderInvalidRecordingFrequency` — invalid frequency rejected.
- `TestSDKComplianceDetailsEvaluationResultIdentifier` — identifier qualifier fields + timestamps match the recorded evaluation.

All via the real AWS SDK against the wire server; no testify.