### PR TITLE
fix(rds): ModifyDBInstance honors ApplyImmediately and records PendingModifiedValues

### DIFF
--- a/providers/aws/rds/engine_test.go
+++ b/providers/aws/rds/engine_test.go
@@ -357,7 +357,9 @@ func TestModifyInstanceRotatesPassword(t *testing.T) {
 		t.Fatalf("CreateInstance: %v", err)
 	}
 
-	if _, err := m.ModifyInstance(ctx, "pg", rdsdriver.ModifyInstanceInput{MasterUserPassword: "new"}); err != nil {
+	if _, err := m.ModifyInstance(ctx, "pg", rdsdriver.ModifyInstanceInput{
+		MasterUserPassword: "new", ApplyImmediately: true,
+	}); err != nil {
 		t.Fatalf("ModifyInstance: %v", err)
 	}
 

--- a/providers/aws/rds/instance_config_validation_test.go
+++ b/providers/aws/rds/instance_config_validation_test.go
@@ -83,7 +83,8 @@ func TestModifyInstanceAcceptsValidAndEmptyClass(t *testing.T) {
 	}
 
 	out, err := m.ModifyInstance(context.Background(), "db1", rdsdriver.ModifyInstanceInput{
-		InstanceClass: "db.r5.large",
+		InstanceClass:    "db.r5.large",
+		ApplyImmediately: true,
 	})
 	if err != nil {
 		t.Fatalf("valid class modify should succeed: %v", err)

--- a/providers/aws/rds/modify_apply_immediately_test.go
+++ b/providers/aws/rds/modify_apply_immediately_test.go
@@ -1,0 +1,168 @@
+package rds
+
+import (
+	"context"
+	"testing"
+
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// seedModifyInstance creates a standalone db.t3.micro instance the
+// ApplyImmediately tests modify.
+func seedModifyInstance(t *testing.T, m *Mock) {
+	t.Helper()
+
+	_, err := m.CreateInstance(context.Background(), rdsdriver.InstanceConfig{
+		ID:               "db1",
+		Engine:           "mysql",
+		MasterUsername:   "admin",
+		InstanceClass:    "db.t3.micro",
+		AllocatedStorage: 20,
+	})
+	requireNoError(t, err)
+}
+
+// TestModifyInstanceApplyImmediatelyTrue: the target fields update now and no
+// pending changes are recorded.
+func TestModifyInstanceApplyImmediatelyTrue(t *testing.T) {
+	m := newTestMock()
+	seedModifyInstance(t, m)
+
+	out, err := m.ModifyInstance(context.Background(), "db1", rdsdriver.ModifyInstanceInput{
+		InstanceClass:    "db.t3.large",
+		AllocatedStorage: 50,
+		ApplyImmediately: true,
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "db.t3.large", out.InstanceClass)
+	assertEqual(t, 50, out.AllocatedStorage)
+
+	if out.PendingModifiedValues != nil {
+		t.Fatalf("expected no pending values with ApplyImmediately, got %+v", out.PendingModifiedValues)
+	}
+
+	// Describe reflects the applied change with nothing pending.
+	got := describeOne(t, m, "db1")
+	assertEqual(t, "db.t3.large", got.InstanceClass)
+
+	if got.PendingModifiedValues != nil {
+		t.Fatalf("describe: expected no pending values, got %+v", got.PendingModifiedValues)
+	}
+}
+
+// TestModifyInstanceApplyImmediatelyFalse: the current values stay unchanged and
+// the requested changes are recorded in PendingModifiedValues, reflected on
+// describe.
+func TestModifyInstanceApplyImmediatelyFalse(t *testing.T) {
+	m := newTestMock()
+	seedModifyInstance(t, m)
+
+	out, err := m.ModifyInstance(context.Background(), "db1", rdsdriver.ModifyInstanceInput{
+		InstanceClass:    "db.t3.large",
+		AllocatedStorage: 50,
+	})
+	requireNoError(t, err)
+
+	// Current values are untouched.
+	assertEqual(t, "db.t3.micro", out.InstanceClass)
+	assertEqual(t, 20, out.AllocatedStorage)
+
+	if out.PendingModifiedValues == nil {
+		t.Fatal("expected PendingModifiedValues to be recorded")
+	}
+
+	assertEqual(t, "db.t3.large", out.PendingModifiedValues.InstanceClass)
+	assertEqual(t, 50, out.PendingModifiedValues.AllocatedStorage)
+
+	// Describe returns the same populated pending block over the unchanged row.
+	got := describeOne(t, m, "db1")
+	assertEqual(t, "db.t3.micro", got.InstanceClass)
+
+	if got.PendingModifiedValues == nil {
+		t.Fatal("describe: expected PendingModifiedValues to be reflected")
+	}
+
+	assertEqual(t, "db.t3.large", got.PendingModifiedValues.InstanceClass)
+	assertEqual(t, 50, got.PendingModifiedValues.AllocatedStorage)
+}
+
+// TestModifyInstancePendingPasswordMasked: a deferred password change is stored
+// masked and the plaintext is never exposed anywhere.
+func TestModifyInstancePendingPasswordMasked(t *testing.T) {
+	m := newTestMock()
+	seedModifyInstance(t, m)
+
+	const secret = "SuperSecret123!"
+
+	out, err := m.ModifyInstance(context.Background(), "db1", rdsdriver.ModifyInstanceInput{
+		MasterUserPassword: secret,
+	})
+	requireNoError(t, err)
+
+	if out.PendingModifiedValues == nil {
+		t.Fatal("expected PendingModifiedValues for a deferred password change")
+	}
+
+	assertEqual(t, rdsdriver.MaskedPassword, out.PendingModifiedValues.MasterUserPassword)
+
+	if out.PendingModifiedValues.MasterUserPassword == secret {
+		t.Fatal("plaintext password leaked into PendingModifiedValues")
+	}
+
+	// A deferred change must not rotate the stored engine credential.
+	if pw, ok := m.rootPasswords["db1"]; ok && pw == secret {
+		t.Fatal("deferred password change unexpectedly rotated the engine credential")
+	}
+}
+
+// TestModifyInstanceNoOpNotPending: requesting a value equal to the current one
+// records nothing (real RDS omits no-op changes).
+func TestModifyInstanceNoOpNotPending(t *testing.T) {
+	m := newTestMock()
+	seedModifyInstance(t, m)
+
+	// Same class as current, plus a real storage change.
+	out, err := m.ModifyInstance(context.Background(), "db1", rdsdriver.ModifyInstanceInput{
+		InstanceClass:    "db.t3.micro",
+		AllocatedStorage: 100,
+	})
+	requireNoError(t, err)
+
+	if out.PendingModifiedValues == nil {
+		t.Fatal("expected PendingModifiedValues for the storage change")
+	}
+
+	assertEqual(t, "", out.PendingModifiedValues.InstanceClass)
+	assertEqual(t, 100, out.PendingModifiedValues.AllocatedStorage)
+}
+
+// TestModifyInstanceNoDeferrableChangeClearsPending: an all-no-op deferred modify
+// leaves PendingModifiedValues nil.
+func TestModifyInstanceNoDeferrableChangeClearsPending(t *testing.T) {
+	m := newTestMock()
+	seedModifyInstance(t, m)
+
+	out, err := m.ModifyInstance(context.Background(), "db1", rdsdriver.ModifyInstanceInput{
+		InstanceClass:    "db.t3.micro",
+		AllocatedStorage: 20,
+	})
+	requireNoError(t, err)
+
+	if out.PendingModifiedValues != nil {
+		t.Fatalf("expected nil PendingModifiedValues for a no-op modify, got %+v", out.PendingModifiedValues)
+	}
+}
+
+func describeOne(t *testing.T, m *Mock, id string) rdsdriver.Instance {
+	t.Helper()
+
+	insts, err := m.DescribeInstances(context.Background(), []string{id})
+	requireNoError(t, err)
+
+	if len(insts) != 1 {
+		t.Fatalf("expected 1 instance for %q, got %d", id, len(insts))
+	}
+
+	return insts[0]
+}

--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -641,14 +641,26 @@ func (m *Mock) ModifyInstance(
 		return nil, err
 	}
 
-	// Rotate the master password on the backing engine so the new credential
-	// actually authenticates.
-	if err := m.rotateEnginePassword(ctx, &inst, input.MasterUserPassword); err != nil {
-		return nil, err
+	// ApplyImmediately (default false) governs the deferrable resize/version/
+	// password/storage changes. When set they take effect now and clear any
+	// pending changes; otherwise they are recorded in PendingModifiedValues and
+	// the instance keeps its current values until the maintenance window.
+	if input.ApplyImmediately {
+		// Rotate the master password on the backing engine so the new credential
+		// actually authenticates.
+		if err := m.rotateEnginePassword(ctx, &inst, input.MasterUserPassword); err != nil {
+			return nil, err
+		}
+
+		applyDeferrableMods(&inst, &input)
+		inst.PendingModifiedValues = nil
+	} else {
+		inst.PendingModifiedValues = pendingModifiedValues(&inst, &input)
 	}
 
-	applyInstanceCoreMods(&inst, &input)
-	applyInstanceStorageMods(&inst, &input)
+	// Parameter/option groups, tags, backup/maintenance windows and deletion
+	// protection always apply immediately in real RDS, regardless of the flag.
+	applyImmediateMods(&inst, &input)
 
 	// A rename re-keys the store and rewrites the ARN + any replica references.
 	// Apply the scalar changes first so the renamed row carries them.
@@ -669,8 +681,9 @@ func renameRequested(id string, input *rdsdriver.ModifyInstanceInput) bool {
 	return input.NewInstanceID != "" && input.NewInstanceID != id
 }
 
-// applyInstanceCoreMods applies the class/storage/version/param-group changes.
-func applyInstanceCoreMods(inst *rdsdriver.Instance, input *rdsdriver.ModifyInstanceInput) {
+// applyDeferrableMods applies the class/storage/version/MultiAZ changes real RDS
+// defers to the maintenance window unless ApplyImmediately is set.
+func applyDeferrableMods(inst *rdsdriver.Instance, input *rdsdriver.ModifyInstanceInput) {
 	if input.InstanceClass != "" {
 		inst.InstanceClass = input.InstanceClass
 	}
@@ -687,28 +700,29 @@ func applyInstanceCoreMods(inst *rdsdriver.Instance, input *rdsdriver.ModifyInst
 		inst.MultiAZ = *input.MultiAZ
 	}
 
-	if input.DBParameterGroupName != "" {
-		inst.DBParameterGroupName = input.DBParameterGroupName
-	}
-
-	if input.OptionGroupName != "" {
-		inst.OptionGroupName = input.OptionGroupName
-	}
-
-	if input.Tags != nil {
-		inst.Tags = copyTags(input.Tags)
-	}
-}
-
-// applyInstanceStorageMods applies the storage/backup/maintenance/protection
-// attributes real RDS honors on ModifyDBInstance.
-func applyInstanceStorageMods(inst *rdsdriver.Instance, input *rdsdriver.ModifyInstanceInput) {
 	if input.StorageType != "" {
 		inst.StorageType = input.StorageType
 	}
 
 	if input.BackupRetentionPeriod > 0 {
 		inst.BackupRetentionPeriod = input.BackupRetentionPeriod
+	}
+
+	if input.Iops > 0 {
+		inst.Iops = input.Iops
+	}
+}
+
+// applyImmediateMods applies the attributes real RDS honors right away on
+// ModifyDBInstance regardless of ApplyImmediately: parameter/option groups,
+// backup/maintenance windows, deletion protection and tags.
+func applyImmediateMods(inst *rdsdriver.Instance, input *rdsdriver.ModifyInstanceInput) {
+	if input.DBParameterGroupName != "" {
+		inst.DBParameterGroupName = input.DBParameterGroupName
+	}
+
+	if input.OptionGroupName != "" {
+		inst.OptionGroupName = input.OptionGroupName
 	}
 
 	if input.PreferredBackupWindow != "" {
@@ -719,13 +733,69 @@ func applyInstanceStorageMods(inst *rdsdriver.Instance, input *rdsdriver.ModifyI
 		inst.PreferredMaintenanceWindow = input.PreferredMaintenanceWindow
 	}
 
-	if input.Iops > 0 {
-		inst.Iops = input.Iops
-	}
-
 	if input.DeletionProtection != nil {
 		inst.DeletionProtection = *input.DeletionProtection
 	}
+
+	if input.Tags != nil {
+		inst.Tags = copyTags(input.Tags)
+	}
+}
+
+// pendingModifiedValues computes the deferrable changes that differ from the
+// instance's current values, returning nil when nothing is pending. A pending
+// password change is recorded masked — the plaintext is never stored here.
+func pendingModifiedValues(
+	inst *rdsdriver.Instance, input *rdsdriver.ModifyInstanceInput,
+) *rdsdriver.PendingModifiedValues {
+	p := &rdsdriver.PendingModifiedValues{
+		InstanceClass:         pendingStr(inst.InstanceClass, input.InstanceClass),
+		AllocatedStorage:      pendingInt(inst.AllocatedStorage, input.AllocatedStorage),
+		EngineVersion:         pendingStr(inst.EngineVersion, input.EngineVersion),
+		BackupRetentionPeriod: pendingInt(inst.BackupRetentionPeriod, input.BackupRetentionPeriod),
+		MultiAZ:               pendingBool(inst.MultiAZ, input.MultiAZ),
+		Iops:                  pendingInt(inst.Iops, input.Iops),
+		StorageType:           pendingStr(inst.StorageType, input.StorageType),
+	}
+
+	if input.MasterUserPassword != "" {
+		p.MasterUserPassword = rdsdriver.MaskedPassword
+	}
+
+	if p.IsEmpty() {
+		return nil
+	}
+
+	return p
+}
+
+// pendingStr/pendingInt/pendingBool return the requested value only when it is
+// set and differs from the current one, so a no-op change is omitted from
+// PendingModifiedValues (matching real RDS).
+func pendingStr(cur, req string) string {
+	if req != "" && req != cur {
+		return req
+	}
+
+	return ""
+}
+
+func pendingInt(cur, req int) int {
+	if req > 0 && req != cur {
+		return req
+	}
+
+	return 0
+}
+
+func pendingBool(cur bool, req *bool) *bool {
+	if req != nil && *req != cur {
+		v := *req
+
+		return &v
+	}
+
+	return nil
 }
 
 // renameInstance re-keys an instance to newID under the caller's write lock:

--- a/providers/aws/rds/rds_test.go
+++ b/providers/aws/rds/rds_test.go
@@ -131,6 +131,7 @@ func TestModifyInstance(t *testing.T) {
 		EngineVersion:    "8.0.32",
 		MultiAZ:          &multi,
 		Tags:             map[string]string{"env": "prod"},
+		ApplyImmediately: true,
 	})
 	requireNoError(t, err)
 

--- a/server/aws/rds/create_instance_validation_sdk_roundtrip_test.go
+++ b/server/aws/rds/create_instance_validation_sdk_roundtrip_test.go
@@ -124,6 +124,7 @@ func TestSDKRDSModifyInstanceValidClass(t *testing.T) {
 	out, err := client.ModifyDBInstance(ctx, &awsrds.ModifyDBInstanceInput{
 		DBInstanceIdentifier: aws.String("mod-good-class"),
 		DBInstanceClass:      aws.String("db.r5.large"),
+		ApplyImmediately:     aws.Bool(true),
 	})
 	if err != nil {
 		t.Fatalf("ModifyDBInstance with a valid instance class should succeed: %v", err)

--- a/server/aws/rds/instance_attributes_sdk_roundtrip_test.go
+++ b/server/aws/rds/instance_attributes_sdk_roundtrip_test.go
@@ -80,6 +80,7 @@ func TestSDKRDSModifyInstanceAttributes(t *testing.T) {
 		StorageType:                aws.String("io1"),
 		Iops:                       aws.Int32(3000),
 		DeletionProtection:         aws.Bool(true),
+		ApplyImmediately:           aws.Bool(true),
 	})
 	if err != nil {
 		t.Fatalf("ModifyDBInstance: %v", err)
@@ -153,5 +154,108 @@ func TestSDKRDSRenameInstance(t *testing.T) {
 		DBInstanceIdentifier: aws.String("oldname"),
 	}); err == nil {
 		t.Fatal("expected oldname to be gone after rename")
+	}
+}
+
+// TestSDKRDSModifyPendingModifiedValues asserts a deferred ModifyDBInstance
+// (ApplyImmediately=false) leaves the current values unchanged and reports the
+// requested changes in the nested PendingModifiedValues element on
+// DescribeDBInstances, with the master password masked.
+func TestSDKRDSModifyPendingModifiedValues(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("pending"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		AllocatedStorage:     aws.Int32(20),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	out, err := client.ModifyDBInstance(ctx, &awsrds.ModifyDBInstanceInput{
+		DBInstanceIdentifier: aws.String("pending"),
+		DBInstanceClass:      aws.String("db.t3.large"),
+		AllocatedStorage:     aws.Int32(50),
+		MasterUserPassword:   aws.String("SuperSecret123!"),
+		ApplyImmediately:     aws.Bool(false),
+	})
+	if err != nil {
+		t.Fatalf("ModifyDBInstance: %v", err)
+	}
+
+	// The instance keeps its current class/storage; the change is only pending.
+	if aws.ToString(out.DBInstance.DBInstanceClass) != "db.t3.micro" {
+		t.Fatalf("class applied immediately=%q, want unchanged db.t3.micro", aws.ToString(out.DBInstance.DBInstanceClass))
+	}
+
+	got, err := client.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String("pending"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBInstances: %v", err)
+	}
+
+	if len(got.DBInstances) != 1 {
+		t.Fatalf("got %d instances, want 1", len(got.DBInstances))
+	}
+
+	inst := got.DBInstances[0]
+
+	if aws.ToString(inst.DBInstanceClass) != "db.t3.micro" || aws.ToInt32(inst.AllocatedStorage) != 20 {
+		t.Fatalf("current values changed: class=%q storage=%d, want db.t3.micro/20",
+			aws.ToString(inst.DBInstanceClass), aws.ToInt32(inst.AllocatedStorage))
+	}
+
+	pmv := inst.PendingModifiedValues
+	if pmv == nil {
+		t.Fatal("PendingModifiedValues nil; want the deferred changes")
+	}
+
+	if aws.ToString(pmv.DBInstanceClass) != "db.t3.large" {
+		t.Fatalf("PendingModifiedValues.DBInstanceClass=%q, want db.t3.large", aws.ToString(pmv.DBInstanceClass))
+	}
+
+	if aws.ToInt32(pmv.AllocatedStorage) != 50 {
+		t.Fatalf("PendingModifiedValues.AllocatedStorage=%d, want 50", aws.ToInt32(pmv.AllocatedStorage))
+	}
+
+	if aws.ToString(pmv.MasterUserPassword) != "****" {
+		t.Fatalf("PendingModifiedValues.MasterUserPassword=%q, want masked ****", aws.ToString(pmv.MasterUserPassword))
+	}
+}
+
+// TestSDKRDSModifyApplyImmediatelyClearsPending asserts ApplyImmediately=true
+// updates the instance now and reports no PendingModifiedValues.
+func TestSDKRDSModifyApplyImmediatelyClearsPending(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("applynow"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	out, err := client.ModifyDBInstance(ctx, &awsrds.ModifyDBInstanceInput{
+		DBInstanceIdentifier: aws.String("applynow"),
+		DBInstanceClass:      aws.String("db.t3.large"),
+		ApplyImmediately:     aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("ModifyDBInstance: %v", err)
+	}
+
+	if aws.ToString(out.DBInstance.DBInstanceClass) != "db.t3.large" {
+		t.Fatalf("class=%q, want db.t3.large applied now", aws.ToString(out.DBInstance.DBInstanceClass))
+	}
+
+	if out.DBInstance.PendingModifiedValues != nil &&
+		aws.ToString(out.DBInstance.PendingModifiedValues.DBInstanceClass) != "" {
+		t.Fatalf("expected no pending class, got %q",
+			aws.ToString(out.DBInstance.PendingModifiedValues.DBInstanceClass))
 	}
 }

--- a/server/aws/rds/operations.go
+++ b/server/aws/rds/operations.go
@@ -231,6 +231,7 @@ func (h *Handler) modifyDBInstance(w http.ResponseWriter, r *http.Request) {
 		PreferredMaintenanceWindow: form.Get("PreferredMaintenanceWindow"),
 		StorageType:                form.Get("StorageType"),
 		Iops:                       formInt(form.Get("Iops")),
+		ApplyImmediately:           formBool(form.Get("ApplyImmediately")),
 		Tags:                       parseRDSTags(form),
 	}
 

--- a/server/aws/rds/sdk_roundtrip_test.go
+++ b/server/aws/rds/sdk_roundtrip_test.go
@@ -145,6 +145,7 @@ func TestSDKRDSInstanceLifecycle(t *testing.T) {
 	if _, err := client.ModifyDBInstance(ctx, &awsrds.ModifyDBInstanceInput{
 		DBInstanceIdentifier: aws.String("life"),
 		AllocatedStorage:     aws.Int32(100),
+		ApplyImmediately:     aws.Bool(true),
 	}); err != nil {
 		t.Fatalf("ModifyDBInstance: %v", err)
 	}

--- a/server/aws/rds/xml.go
+++ b/server/aws/rds/xml.go
@@ -111,6 +111,21 @@ type dbInstanceXML struct {
 	TagList                               *tagListXML                `xml:"TagList,omitempty"`
 	ReadReplicaSourceDBInstanceIdentifier string                     `xml:"ReadReplicaSourceDBInstanceIdentifier,omitempty"`
 	ReadReplicaDBInstanceIdentifiers      *readReplicaIDsXML         `xml:"ReadReplicaDBInstanceIdentifiers,omitempty"`
+	PendingModifiedValues                 *pendingModifiedValuesXML  `xml:"PendingModifiedValues,omitempty"`
+}
+
+// pendingModifiedValuesXML is the nested DBInstance element listing the
+// deferrable ModifyDBInstance changes requested with ApplyImmediately=false but
+// not yet applied. MasterUserPassword is echoed masked ("****"), never in clear.
+type pendingModifiedValuesXML struct {
+	DBInstanceClass       string `xml:"DBInstanceClass,omitempty"`
+	AllocatedStorage      int    `xml:"AllocatedStorage,omitempty"`
+	EngineVersion         string `xml:"EngineVersion,omitempty"`
+	MasterUserPassword    string `xml:"MasterUserPassword,omitempty"`
+	BackupRetentionPeriod int    `xml:"BackupRetentionPeriod,omitempty"`
+	MultiAZ               *bool  `xml:"MultiAZ,omitempty"`
+	Iops                  int    `xml:"Iops,omitempty"`
+	StorageType           string `xml:"StorageType,omitempty"`
 }
 
 type readReplicaIDsXML struct {
@@ -422,9 +437,29 @@ func toInstanceXML(inst *rdsdriver.Instance, resolvedSubnetGroup *dbSubnetGroupX
 		TagList:                               toTagListXML(inst.Tags),
 		ReadReplicaSourceDBInstanceIdentifier: inst.ReadReplicaSource,
 		ReadReplicaDBInstanceIdentifiers:      toReadReplicaIDsXML(inst.ReadReplicaTargets),
+		PendingModifiedValues:                 toPendingModifiedValuesXML(inst.PendingModifiedValues),
 	}
 
 	return x
+}
+
+// toPendingModifiedValuesXML maps the driver's PendingModifiedValues onto its
+// nested wire element, returning nil (an omitted element) when nothing is pending.
+func toPendingModifiedValuesXML(p *rdsdriver.PendingModifiedValues) *pendingModifiedValuesXML {
+	if p == nil {
+		return nil
+	}
+
+	return &pendingModifiedValuesXML{
+		DBInstanceClass:       p.InstanceClass,
+		AllocatedStorage:      p.AllocatedStorage,
+		EngineVersion:         p.EngineVersion,
+		MasterUserPassword:    p.MasterUserPassword,
+		BackupRetentionPeriod: p.BackupRetentionPeriod,
+		MultiAZ:               p.MultiAZ,
+		Iops:                  p.Iops,
+		StorageType:           p.StorageType,
+	}
 }
 
 func toDBParameterGroupsXML(name string) *dbParameterGroupsXML {

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -182,6 +182,10 @@ type Instance struct {
 	// replica identifiers reading from this instance.
 	ReadReplicaSource  string
 	ReadReplicaTargets []string
+	// PendingModifiedValues holds the deferrable ModifyDBInstance changes that
+	// have been requested with ApplyImmediately=false but not yet applied. It is
+	// nil when nothing is pending (AWS RDS DBInstance.PendingModifiedValues).
+	PendingModifiedValues *PendingModifiedValues
 	// GCPDatabaseFlags / GCPBackupConfig / GCPIPConfig echo the Cloud SQL
 	// settings sub-objects (databaseFlags, backupConfiguration, ipConfiguration)
 	// as opaque JSON so they round-trip on read. Empty for AWS RDS / Redshift,
@@ -238,6 +242,43 @@ type ModifyInstanceInput struct {
 	GCPBackupConfig  string
 	GCPIPConfig      string
 	Tags             map[string]string
+	// ApplyImmediately controls when the deferrable changes above take effect
+	// (AWS RDS ModifyDBInstance ApplyImmediately, default false). When true the
+	// target fields are updated on the instance now and PendingModifiedValues is
+	// cleared; when false the requested-but-not-yet-applied deferrable changes
+	// are recorded in Instance.PendingModifiedValues and the current values stay
+	// unchanged until the next maintenance window. Non-AWS engines ignore it.
+	ApplyImmediately bool
+}
+
+// MaskedPassword is the placeholder RDS echoes for a pending master-password
+// change; the real password is never surfaced on a read.
+const MaskedPassword = "****"
+
+// PendingModifiedValues records the deferrable ModifyDBInstance changes that are
+// scheduled but not yet applied (ApplyImmediately=false). Each field is set only
+// when the requested value actually differs from the instance's current value,
+// mirroring real AWS which omits no-op changes. It is an AWS RDS concept; other
+// engines leave it nil.
+type PendingModifiedValues struct {
+	InstanceClass    string
+	AllocatedStorage int
+	EngineVersion    string
+	// MasterUserPassword is always MaskedPassword ("****") when a password
+	// change is pending — the plaintext is never echoed.
+	MasterUserPassword    string
+	BackupRetentionPeriod int
+	MultiAZ               *bool
+	Iops                  int
+	StorageType           string
+}
+
+// IsEmpty reports whether no deferrable change is pending, so callers can store
+// a nil PendingModifiedValues (which reads as absent) instead of an empty one.
+func (p *PendingModifiedValues) IsEmpty() bool {
+	return p.InstanceClass == "" && p.AllocatedStorage == 0 && p.EngineVersion == "" &&
+		p.MasterUserPassword == "" && p.BackupRetentionPeriod == 0 && p.MultiAZ == nil &&
+		p.Iops == 0 && p.StorageType == ""
 }
 
 // ClusterConfig configures an Aurora-style cluster. Members are added by


### PR DESCRIPTION
## What

AWS RDS `ModifyDBInstance` now honors the `ApplyImmediately` flag and exposes `PendingModifiedValues`, matching real RDS semantics. Previously the flag was ignored — every modification applied immediately and no pending state was ever surfaced, so a user's deferred change (e.g. an instance-class resize meant to wait for the maintenance window) was silently applied and `PendingModifiedValues` was always absent. This drove `aws_db_instance` Terraform drift.

## Behavior (matches real AWS)

- **`ApplyImmediately=true`**: the deferrable target fields (DBInstanceClass, AllocatedStorage, EngineVersion, MasterUserPassword, MultiAZ, BackupRetentionPeriod, Iops, StorageType) update on the instance now; `PendingModifiedValues` is cleared. The master password is rotated on the backing engine.
- **`ApplyImmediately=false` (default)**: the instance keeps its current values; the requested changes are recorded in `PendingModifiedValues` (nested `DBInstance` element on `DescribeDBInstances`) and the engine password is left untouched.
- Only fields that actually **differ** from the current value are recorded (real RDS omits no-op changes).
- A pending master-password change is echoed masked as `****` — the plaintext is never stored or returned.
- Parameter/option groups, tags, backup/maintenance windows and deletion protection continue to apply immediately regardless of the flag.

## Layers touched

- `services/relationaldb/driver` — `ModifyInstanceInput.ApplyImmediately`, `Instance.PendingModifiedValues`, `PendingModifiedValues` type + `MaskedPassword`.
- `providers/aws/rds` — deferred-vs-immediate branch in `ModifyInstance`; pending-diff computation.
- `server/aws/rds` — parse the `ApplyImmediately` form field; nested `PendingModifiedValues` wire element on the `DBInstance` response.

## Tests

Provider-level (hand-rolled helpers) and SDK wire round-trip tests cover: apply-immediately updates now with empty pending; deferred records pending + leaves current unchanged + reflected on describe; password masked in pending / never rotated when deferred; no-op field omitted from pending. Existing tests that relied on the old always-immediate default were updated to set `ApplyImmediately=true`.