### PR TITLE
fix(eks): DescribeCluster returns logging, kubernetesNetworkConfig, and accessConfig

### DIFF
--- a/providers/aws/eks/cluster_config_test.go
+++ b/providers/aws/eks/cluster_config_test.go
@@ -1,0 +1,114 @@
+package eks
+
+import (
+	"context"
+	"testing"
+
+	eksdriver "github.com/stackshy/cloudemu/v2/providers/aws/eks/driver"
+)
+
+// TestCreateClusterConfigEcho verifies CreateCluster faithfully round-trips the
+// caller's logging, kubernetesNetworkConfig, and accessConfig into the stored
+// cluster read back by DescribeCluster.
+func TestCreateClusterConfigEcho(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	bootstrap := false
+	cfg := eksdriver.ClusterConfig{
+		Name:    "echo-cluster",
+		RoleArn: "arn:aws:iam::123456789012:role/eks-cluster",
+		Logging: []eksdriver.ClusterLogging{
+			{Types: []string{"api", "audit"}, Enabled: true},
+			{Types: []string{"authenticator", "controllerManager", "scheduler"}, Enabled: false},
+		},
+		NetworkConfig: eksdriver.NetworkConfig{
+			ServiceIPv4CIDR: "172.20.0.0/16",
+			IPFamily:        "ipv4",
+		},
+		AccessConfig: eksdriver.AccessConfigRequest{
+			AuthenticationMode:                      "API",
+			BootstrapClusterCreatorAdminPermissions: &bootstrap,
+		},
+	}
+
+	if _, err := m.CreateCluster(ctx, cfg); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	got, err := m.DescribeCluster(ctx, "echo-cluster")
+	requireNoError(t, err)
+
+	if len(got.Logging) != 2 {
+		t.Fatalf("logging entries = %d, want 2", len(got.Logging))
+	}
+
+	assertEqual(t, true, got.Logging[0].Enabled)
+	assertEqual(t, "api", got.Logging[0].Types[0])
+	assertEqual(t, false, got.Logging[1].Enabled)
+
+	assertEqual(t, "172.20.0.0/16", got.NetworkConfig.ServiceIPv4CIDR)
+	assertEqual(t, "ipv4", got.NetworkConfig.IPFamily)
+
+	assertEqual(t, "API", got.AccessConfig.AuthenticationMode)
+	assertEqual(t, false, got.AccessConfig.BootstrapClusterCreatorAdminPermissions)
+}
+
+// TestCreateClusterConfigDefaults verifies that omitting logging,
+// kubernetesNetworkConfig, and accessConfig yields the real-EKS defaults so an
+// aws_eks_cluster read does not drift after create.
+func TestCreateClusterConfigDefaults(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateCluster(ctx, eksdriver.ClusterConfig{
+		Name:    "default-cluster",
+		RoleArn: "arn:aws:iam::123456789012:role/eks-cluster",
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	got, err := m.DescribeCluster(ctx, "default-cluster")
+	requireNoError(t, err)
+
+	// Logging default: one entry, all five control-plane types, disabled.
+	if len(got.Logging) != 1 {
+		t.Fatalf("logging entries = %d, want 1", len(got.Logging))
+	}
+
+	assertEqual(t, false, got.Logging[0].Enabled)
+	assertEqual(t, 5, len(got.Logging[0].Types))
+	assertEqual(t, "api", got.Logging[0].Types[0])
+	assertEqual(t, "scheduler", got.Logging[0].Types[4])
+
+	// Network default: ipv4 family with an auto-assigned service CIDR.
+	assertEqual(t, "ipv4", got.NetworkConfig.IPFamily)
+	assertEqual(t, "10.100.0.0/16", got.NetworkConfig.ServiceIPv4CIDR)
+	assertEqual(t, "", got.NetworkConfig.ServiceIPv6CIDR)
+
+	// Access default: CONFIG_MAP (EKS API/SDK path) + bootstrap true.
+	assertEqual(t, "CONFIG_MAP", got.AccessConfig.AuthenticationMode)
+	assertEqual(t, true, got.AccessConfig.BootstrapClusterCreatorAdminPermissions)
+}
+
+// TestCreateClusterConfigIPv6 verifies the ipv6 ipFamily path assigns a service
+// IPv6 CIDR rather than an IPv4 one.
+func TestCreateClusterConfigIPv6(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateCluster(ctx, eksdriver.ClusterConfig{
+		Name:          "ipv6-cluster",
+		RoleArn:       "arn:aws:iam::123456789012:role/eks-cluster",
+		NetworkConfig: eksdriver.NetworkConfig{IPFamily: "ipv6"},
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	got, err := m.DescribeCluster(ctx, "ipv6-cluster")
+	requireNoError(t, err)
+
+	assertEqual(t, "ipv6", got.NetworkConfig.IPFamily)
+	assertEqual(t, "fd00::/108", got.NetworkConfig.ServiceIPv6CIDR)
+	assertEqual(t, "", got.NetworkConfig.ServiceIPv4CIDR)
+}

--- a/providers/aws/eks/driver/driver.go
+++ b/providers/aws/eks/driver/driver.go
@@ -62,13 +62,51 @@ type VPCConfig struct {
 	VpcID                  string
 }
 
+// ClusterLogging is one EKS control-plane log-type group and whether it is
+// enabled. Real EKS normalizes cluster logging into (up to) two entries: the
+// enabled log types and the disabled ones. The recognized types are api,
+// audit, authenticator, controllerManager, and scheduler.
+type ClusterLogging struct {
+	Types   []string
+	Enabled bool
+}
+
+// NetworkConfig captures the Kubernetes networking configuration surfaced under
+// DescribeCluster kubernetesNetworkConfig. ServiceIPv4CIDR and IPFamily are
+// caller inputs; ServiceIPv6CIDR is provider-assigned for IPv6 clusters (the
+// caller cannot choose it), mirroring how VpcID is derived on VPCConfig.
+type NetworkConfig struct {
+	ServiceIPv4CIDR string
+	ServiceIPv6CIDR string
+	IPFamily        string
+}
+
+// AccessConfigRequest is the caller-supplied access configuration on
+// CreateCluster. BootstrapClusterCreatorAdminPermissions is a pointer so the
+// provider can distinguish "omitted" (apply the AWS default of true) from an
+// explicit false.
+type AccessConfigRequest struct {
+	AuthenticationMode                      string
+	BootstrapClusterCreatorAdminPermissions *bool
+}
+
+// AccessConfig is the resolved cluster access-management configuration surfaced
+// under DescribeCluster accessConfig.
+type AccessConfig struct {
+	AuthenticationMode                      string
+	BootstrapClusterCreatorAdminPermissions bool
+}
+
 // ClusterConfig configures a new EKS cluster.
 type ClusterConfig struct {
-	Name      string
-	Version   string
-	RoleArn   string
-	VPCConfig VPCConfig
-	Tags      map[string]string
+	Name          string
+	Version       string
+	RoleArn       string
+	VPCConfig     VPCConfig
+	Logging       []ClusterLogging
+	NetworkConfig NetworkConfig
+	AccessConfig  AccessConfigRequest
+	Tags          map[string]string
 }
 
 // Cluster is the mock-side representation of an EKS cluster.
@@ -82,6 +120,9 @@ type Cluster struct {
 	CertificateAuthority string
 	Status               string
 	VPCConfig            VPCConfig
+	Logging              []ClusterLogging
+	NetworkConfig        NetworkConfig
+	AccessConfig         AccessConfig
 	Tags                 map[string]string
 	CreatedAt            time.Time
 	// OIDCIssuer is the cluster's OpenID Connect issuer URL, surfaced under

--- a/providers/aws/eks/eks.go
+++ b/providers/aws/eks/eks.go
@@ -41,6 +41,16 @@ const (
 	defaultNodegroupInstanceType = "t3.medium"
 	defaultNodegroupAmiType      = "AL2_x86_64"
 	defaultNodegroupDiskSize     = 20
+
+	// Cluster networking and access-config defaults real EKS applies when the
+	// caller omits them. authenticationMode defaults to CONFIG_MAP on the
+	// EKS API / SDK / CloudFormation path (only the AWS console defaults to
+	// API_AND_CONFIG_MAP); Terraform's aws_eks_cluster uses the SDK path.
+	defaultServiceIPv4CIDR    = "10.100.0.0/16"
+	defaultServiceIPv6CIDR    = "fd00::/108"
+	ipFamilyIPv4              = "ipv4"
+	ipFamilyIPv6              = "ipv6"
+	defaultAuthenticationMode = "CONFIG_MAP"
 )
 
 // CloudWatch-style metric values emitted on cluster create. The numbers are
@@ -238,6 +248,70 @@ func copyStrings(src []string) []string {
 	return out
 }
 
+// allClusterLogTypes is the full EKS control-plane log-type set, in the order
+// AWS reports them.
+func allClusterLogTypes() []string {
+	return []string{"api", "audit", "authenticator", "controllerManager", "scheduler"}
+}
+
+// resolveClusterLogging echoes the caller's cluster logging, or applies the AWS
+// default when it is omitted: all control-plane log types present but disabled.
+func resolveClusterLogging(in []eksdriver.ClusterLogging) []eksdriver.ClusterLogging {
+	if len(in) == 0 {
+		return []eksdriver.ClusterLogging{{Types: allClusterLogTypes(), Enabled: false}}
+	}
+
+	out := make([]eksdriver.ClusterLogging, 0, len(in))
+	for _, l := range in {
+		out = append(out, eksdriver.ClusterLogging{Types: copyStrings(l.Types), Enabled: l.Enabled})
+	}
+
+	return out
+}
+
+// resolveNetworkConfig fills in the EKS networking defaults: ipFamily "ipv4",
+// and a service CIDR for the chosen family when the caller omits it (real EKS
+// auto-assigns one so DescribeCluster is always populated).
+func resolveNetworkConfig(in eksdriver.NetworkConfig) eksdriver.NetworkConfig {
+	out := in
+	if out.IPFamily == "" {
+		out.IPFamily = ipFamilyIPv4
+	}
+
+	switch out.IPFamily {
+	case ipFamilyIPv6:
+		if out.ServiceIPv6CIDR == "" {
+			out.ServiceIPv6CIDR = defaultServiceIPv6CIDR
+		}
+	default:
+		if out.ServiceIPv4CIDR == "" {
+			out.ServiceIPv4CIDR = defaultServiceIPv4CIDR
+		}
+	}
+
+	return out
+}
+
+// resolveAccessConfig fills in the EKS access-config defaults: authentication
+// mode CONFIG_MAP and bootstrapClusterCreatorAdminPermissions true when the
+// caller omits them.
+func resolveAccessConfig(in eksdriver.AccessConfigRequest) eksdriver.AccessConfig {
+	mode := in.AuthenticationMode
+	if mode == "" {
+		mode = defaultAuthenticationMode
+	}
+
+	bootstrap := true
+	if in.BootstrapClusterCreatorAdminPermissions != nil {
+		bootstrap = *in.BootstrapClusterCreatorAdminPermissions
+	}
+
+	return eksdriver.AccessConfig{
+		AuthenticationMode:                      mode,
+		BootstrapClusterCreatorAdminPermissions: bootstrap,
+	}
+}
+
 func copyTaints(src []eksdriver.Taint) []eksdriver.Taint {
 	if len(src) == 0 {
 		return nil
@@ -417,8 +491,11 @@ func (m *Mock) CreateCluster(ctx context.Context, cfg eksdriver.ClusterConfig) (
 			ClusterSecurityGroupID: m.clusterSecurityGroupID(cfg.Name),
 			VpcID:                  m.resolveVpcID(ctx, cfg.VPCConfig.SubnetIDs),
 		},
-		Tags:      copyTags(cfg.Tags),
-		CreatedAt: m.opts.Clock.Now().UTC(),
+		Logging:       resolveClusterLogging(cfg.Logging),
+		NetworkConfig: resolveNetworkConfig(cfg.NetworkConfig),
+		AccessConfig:  resolveAccessConfig(cfg.AccessConfig),
+		Tags:          copyTags(cfg.Tags),
+		CreatedAt:     m.opts.Clock.Now().UTC(),
 	}
 
 	// Wave 2: if a Kubernetes data-plane server is wired, register a fresh

--- a/server/aws/eks/operations.go
+++ b/server/aws/eks/operations.go
@@ -77,6 +77,18 @@ func (h *Handler) createCluster(w http.ResponseWriter, r *http.Request) {
 		cfg.VPCConfig = vpcRequestToDriver(body.ResourcesVpcConfig)
 	}
 
+	if body.KubernetesNetworkConfig != nil {
+		cfg.NetworkConfig = networkConfigRequestToDriver(body.KubernetesNetworkConfig)
+	}
+
+	if body.Logging != nil {
+		cfg.Logging = loggingRequestToDriver(body.Logging)
+	}
+
+	if body.AccessConfig != nil {
+		cfg.AccessConfig = accessConfigRequestToDriver(body.AccessConfig)
+	}
+
 	cluster, err := h.eks.CreateCluster(r.Context(), cfg)
 	if err != nil {
 		writeErr(w, err)
@@ -512,6 +524,38 @@ func vpcRequestToDriver(v *vpcConfigRequest) eksdriver.VPCConfig {
 	return out
 }
 
+// networkConfigRequestToDriver converts the wire kubernetesNetworkConfig to the
+// driver shape. serviceIpv6Cidr is provider-assigned, not a caller input.
+func networkConfigRequestToDriver(n *kubernetesNetworkConfigRequest) eksdriver.NetworkConfig {
+	return eksdriver.NetworkConfig{
+		ServiceIPv4CIDR: n.ServiceIPv4CIDR,
+		IPFamily:        n.IPFamily,
+	}
+}
+
+// loggingRequestToDriver converts the wire logging block to driver logging.
+func loggingRequestToDriver(l *loggingJSON) []eksdriver.ClusterLogging {
+	if len(l.ClusterLogging) == 0 {
+		return nil
+	}
+
+	out := make([]eksdriver.ClusterLogging, 0, len(l.ClusterLogging))
+	for _, e := range l.ClusterLogging {
+		out = append(out, eksdriver.ClusterLogging{Types: e.Types, Enabled: e.Enabled})
+	}
+
+	return out
+}
+
+// accessConfigRequestToDriver converts the wire accessConfig to the driver
+// request shape, preserving the omitted/false distinction on the bootstrap flag.
+func accessConfigRequestToDriver(a *accessConfigRequest) eksdriver.AccessConfigRequest {
+	return eksdriver.AccessConfigRequest{
+		AuthenticationMode:                      a.AuthenticationMode,
+		BootstrapClusterCreatorAdminPermissions: a.BootstrapClusterCreatorAdminPermissions,
+	}
+}
+
 // mergeScaling overlays only the sizes present in s onto dst, leaving omitted
 // fields untouched. This is the partial-update semantics real EKS applies.
 func mergeScaling(dst *eksdriver.NodegroupScalingConfig, s *nodegroupScalingConfigJSON) {
@@ -604,7 +648,52 @@ func toClusterJSON(c *eksdriver.Cluster) clusterJSON {
 		out.Identity = &identityJSON{OIDC: oidcJSON{Issuer: c.OIDCIssuer}}
 	}
 
+	out.KubernetesNetworkConfig = networkConfigToJSON(c.NetworkConfig)
+	out.Logging = loggingToJSON(c.Logging)
+	out.AccessConfig = accessConfigToJSON(c.AccessConfig)
+
 	return out
+}
+
+// networkConfigToJSON renders driver networking to the wire response shape,
+// returning nil when nothing is set so the field is omitted.
+func networkConfigToJSON(n eksdriver.NetworkConfig) *kubernetesNetworkConfigResponse {
+	if n.IPFamily == "" && n.ServiceIPv4CIDR == "" && n.ServiceIPv6CIDR == "" {
+		return nil
+	}
+
+	return &kubernetesNetworkConfigResponse{
+		ServiceIPv4CIDR: n.ServiceIPv4CIDR,
+		ServiceIPv6CIDR: n.ServiceIPv6CIDR,
+		IPFamily:        n.IPFamily,
+	}
+}
+
+// loggingToJSON renders driver logging to the wire response shape.
+func loggingToJSON(in []eksdriver.ClusterLogging) *loggingJSON {
+	if len(in) == 0 {
+		return nil
+	}
+
+	entries := make([]logSetupJSON, 0, len(in))
+	for _, l := range in {
+		entries = append(entries, logSetupJSON{Types: l.Types, Enabled: l.Enabled})
+	}
+
+	return &loggingJSON{ClusterLogging: entries}
+}
+
+// accessConfigToJSON renders driver access config to the wire response shape,
+// returning nil when unset so the field is omitted.
+func accessConfigToJSON(a eksdriver.AccessConfig) *accessConfigResponse {
+	if a.AuthenticationMode == "" {
+		return nil
+	}
+
+	return &accessConfigResponse{
+		AuthenticationMode:                      a.AuthenticationMode,
+		BootstrapClusterCreatorAdminPermissions: a.BootstrapClusterCreatorAdminPermissions,
+	}
 }
 
 func toNodegroupJSON(n *eksdriver.Nodegroup) nodegroupJSON {

--- a/server/aws/eks/sdk_cluster_config_test.go
+++ b/server/aws/eks/sdk_cluster_config_test.go
@@ -1,0 +1,137 @@
+package eks_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newEKSConfigClient stands up an EKS wire server backed by a fresh AWS cloud
+// and returns a real aws-sdk-go-v2 EKS client pointed at it.
+func newEKSConfigClient(t *testing.T) *awseks.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{EKS: cloud.EKS, S3: cloud.S3})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return newEKSClient(t, ts.URL)
+}
+
+// TestSDKEKSDescribeClusterConfigEcho verifies CreateCluster -> DescribeCluster
+// round-trips logging, kubernetesNetworkConfig, and accessConfig over the wire.
+func TestSDKEKSDescribeClusterConfigEcho(t *testing.T) {
+	ctx := context.Background()
+	client := newEKSConfigClient(t)
+
+	if _, err := client.CreateCluster(ctx, &awseks.CreateClusterInput{
+		Name:               aws.String("c1"),
+		RoleArn:            aws.String("arn:aws:iam::123456789012:role/eks-cluster"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{SubnetIds: []string{"subnet-1"}},
+		Logging: &ekstypes.Logging{
+			ClusterLogging: []ekstypes.LogSetup{
+				{Types: []ekstypes.LogType{ekstypes.LogTypeApi, ekstypes.LogTypeAudit}, Enabled: aws.Bool(true)},
+			},
+		},
+		KubernetesNetworkConfig: &ekstypes.KubernetesNetworkConfigRequest{
+			ServiceIpv4Cidr: aws.String("172.20.0.0/16"),
+			IpFamily:        ekstypes.IpFamilyIpv4,
+		},
+		AccessConfig: &ekstypes.CreateAccessConfigRequest{
+			AuthenticationMode:                      ekstypes.AuthenticationModeApi,
+			BootstrapClusterCreatorAdminPermissions: aws.Bool(false),
+		},
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	got, err := client.DescribeCluster(ctx, &awseks.DescribeClusterInput{Name: aws.String("c1")})
+	if err != nil {
+		t.Fatalf("DescribeCluster: %v", err)
+	}
+
+	cl := got.Cluster
+
+	if cl.Logging == nil || len(cl.Logging.ClusterLogging) != 1 {
+		t.Fatalf("logging not echoed: %+v", cl.Logging)
+	}
+
+	if !aws.ToBool(cl.Logging.ClusterLogging[0].Enabled) {
+		t.Fatal("logging[0].enabled = false, want true")
+	}
+
+	if cl.KubernetesNetworkConfig == nil ||
+		aws.ToString(cl.KubernetesNetworkConfig.ServiceIpv4Cidr) != "172.20.0.0/16" {
+		t.Fatalf("serviceIpv4Cidr not echoed: %+v", cl.KubernetesNetworkConfig)
+	}
+
+	if cl.KubernetesNetworkConfig.IpFamily != ekstypes.IpFamilyIpv4 {
+		t.Fatalf("ipFamily = %q, want ipv4", cl.KubernetesNetworkConfig.IpFamily)
+	}
+
+	if cl.AccessConfig == nil || cl.AccessConfig.AuthenticationMode != ekstypes.AuthenticationModeApi {
+		t.Fatalf("authenticationMode not echoed: %+v", cl.AccessConfig)
+	}
+
+	if aws.ToBool(cl.AccessConfig.BootstrapClusterCreatorAdminPermissions) {
+		t.Fatal("bootstrapClusterCreatorAdminPermissions = true, want false (explicit)")
+	}
+}
+
+// TestSDKEKSDescribeClusterConfigDefaults verifies that a cluster created
+// without logging / networkConfig / accessConfig reports the AWS defaults, so
+// an aws_eks_cluster read after create does not drift.
+func TestSDKEKSDescribeClusterConfigDefaults(t *testing.T) {
+	ctx := context.Background()
+	client := newEKSConfigClient(t)
+
+	if _, err := client.CreateCluster(ctx, &awseks.CreateClusterInput{
+		Name:               aws.String("c2"),
+		RoleArn:            aws.String("arn:aws:iam::123456789012:role/eks-cluster"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{SubnetIds: []string{"subnet-1"}},
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	got, err := client.DescribeCluster(ctx, &awseks.DescribeClusterInput{Name: aws.String("c2")})
+	if err != nil {
+		t.Fatalf("DescribeCluster: %v", err)
+	}
+
+	cl := got.Cluster
+
+	if cl.Logging == nil || len(cl.Logging.ClusterLogging) != 1 {
+		t.Fatalf("default logging = %+v, want one entry", cl.Logging)
+	}
+
+	entry := cl.Logging.ClusterLogging[0]
+	if aws.ToBool(entry.Enabled) {
+		t.Fatal("default logging enabled = true, want false")
+	}
+
+	if len(entry.Types) != 5 {
+		t.Fatalf("default logging types = %d, want 5", len(entry.Types))
+	}
+
+	if cl.KubernetesNetworkConfig == nil ||
+		aws.ToString(cl.KubernetesNetworkConfig.ServiceIpv4Cidr) != "10.100.0.0/16" ||
+		cl.KubernetesNetworkConfig.IpFamily != ekstypes.IpFamilyIpv4 {
+		t.Fatalf("default kubernetesNetworkConfig = %+v", cl.KubernetesNetworkConfig)
+	}
+
+	if cl.AccessConfig == nil || cl.AccessConfig.AuthenticationMode != ekstypes.AuthenticationModeConfigMap {
+		t.Fatalf("default authenticationMode = %+v, want CONFIG_MAP", cl.AccessConfig)
+	}
+
+	if !aws.ToBool(cl.AccessConfig.BootstrapClusterCreatorAdminPermissions) {
+		t.Fatal("default bootstrapClusterCreatorAdminPermissions = false, want true")
+	}
+}

--- a/server/aws/eks/types.go
+++ b/server/aws/eks/types.go
@@ -43,20 +43,64 @@ type oidcJSON struct {
 	Issuer string `json:"issuer"`
 }
 
+// loggingJSON is the EKS cluster logging shape, used on both CreateCluster
+// (request) and DescribeCluster (response).
+type loggingJSON struct {
+	ClusterLogging []logSetupJSON `json:"clusterLogging"`
+}
+
+// logSetupJSON is one control-plane log-type group and whether it is enabled.
+type logSetupJSON struct {
+	Types   []string `json:"types"`
+	Enabled bool     `json:"enabled"`
+}
+
+// kubernetesNetworkConfigRequest is the CreateCluster request shape for cluster
+// networking: the caller may set serviceIpv4Cidr and ipFamily.
+type kubernetesNetworkConfigRequest struct {
+	ServiceIPv4CIDR string `json:"serviceIpv4Cidr,omitempty"`
+	IPFamily        string `json:"ipFamily,omitempty"`
+}
+
+// kubernetesNetworkConfigResponse is the DescribeCluster response shape; EKS
+// echoes the service CIDR for the chosen family plus the ipFamily.
+type kubernetesNetworkConfigResponse struct {
+	ServiceIPv4CIDR string `json:"serviceIpv4Cidr,omitempty"`
+	ServiceIPv6CIDR string `json:"serviceIpv6Cidr,omitempty"`
+	IPFamily        string `json:"ipFamily,omitempty"`
+}
+
+// accessConfigRequest is the CreateCluster request shape for cluster access
+// management. bootstrapClusterCreatorAdminPermissions is a pointer so an
+// omitted value is distinguishable from an explicit false.
+type accessConfigRequest struct {
+	AuthenticationMode                      string `json:"authenticationMode,omitempty"`
+	BootstrapClusterCreatorAdminPermissions *bool  `json:"bootstrapClusterCreatorAdminPermissions,omitempty"`
+}
+
+// accessConfigResponse is the DescribeCluster response shape for access config.
+type accessConfigResponse struct {
+	AuthenticationMode                      string `json:"authenticationMode,omitempty"`
+	BootstrapClusterCreatorAdminPermissions bool   `json:"bootstrapClusterCreatorAdminPermissions"`
+}
+
 // clusterJSON is the EKS cluster resource shape.
 type clusterJSON struct {
-	Name                 string             `json:"name"`
-	Arn                  string             `json:"arn"`
-	CreatedAt            float64            `json:"createdAt"`
-	Version              string             `json:"version,omitempty"`
-	Endpoint             string             `json:"endpoint,omitempty"`
-	RoleArn              string             `json:"roleArn,omitempty"`
-	ResourcesVpcConfig   *vpcConfigResponse `json:"resourcesVpcConfig,omitempty"`
-	Status               string             `json:"status"`
-	CertificateAuthority *certificate       `json:"certificateAuthority,omitempty"`
-	Identity             *identityJSON      `json:"identity,omitempty"`
-	PlatformVersion      string             `json:"platformVersion,omitempty"`
-	Tags                 map[string]string  `json:"tags,omitempty"`
+	Name                    string                           `json:"name"`
+	Arn                     string                           `json:"arn"`
+	CreatedAt               float64                          `json:"createdAt"`
+	Version                 string                           `json:"version,omitempty"`
+	Endpoint                string                           `json:"endpoint,omitempty"`
+	RoleArn                 string                           `json:"roleArn,omitempty"`
+	ResourcesVpcConfig      *vpcConfigResponse               `json:"resourcesVpcConfig,omitempty"`
+	KubernetesNetworkConfig *kubernetesNetworkConfigResponse `json:"kubernetesNetworkConfig,omitempty"`
+	Logging                 *loggingJSON                     `json:"logging,omitempty"`
+	AccessConfig            *accessConfigResponse            `json:"accessConfig,omitempty"`
+	Status                  string                           `json:"status"`
+	CertificateAuthority    *certificate                     `json:"certificateAuthority,omitempty"`
+	Identity                *identityJSON                    `json:"identity,omitempty"`
+	PlatformVersion         string                           `json:"platformVersion,omitempty"`
+	Tags                    map[string]string                `json:"tags,omitempty"`
 }
 
 // nodegroupScalingConfigJSON mirrors the SDK shape for nodegroup scaling.
@@ -167,11 +211,14 @@ type updateJSON struct {
 // Request bodies decoded from POST/PUT JSON.
 
 type createClusterRequest struct {
-	Name               string            `json:"name"`
-	Version            string            `json:"version,omitempty"`
-	RoleArn            string            `json:"roleArn,omitempty"`
-	ResourcesVpcConfig *vpcConfigRequest `json:"resourcesVpcConfig,omitempty"`
-	Tags               map[string]string `json:"tags,omitempty"`
+	Name                    string                          `json:"name"`
+	Version                 string                          `json:"version,omitempty"`
+	RoleArn                 string                          `json:"roleArn,omitempty"`
+	ResourcesVpcConfig      *vpcConfigRequest               `json:"resourcesVpcConfig,omitempty"`
+	KubernetesNetworkConfig *kubernetesNetworkConfigRequest `json:"kubernetesNetworkConfig,omitempty"`
+	Logging                 *loggingJSON                    `json:"logging,omitempty"`
+	AccessConfig            *accessConfigRequest            `json:"accessConfig,omitempty"`
+	Tags                    map[string]string               `json:"tags,omitempty"`
 }
 
 type updateClusterConfigRequest struct {


### PR DESCRIPTION
## What

`DescribeCluster` now returns three fields it previously dropped, so `aws_eks_cluster` Terraform no longer drifts after create:

- **logging** — `{ "clusterLogging": [ { "types": [...], "enabled": bool } ] }`
- **kubernetesNetworkConfig** — `{ "serviceIpv4Cidr", "serviceIpv6Cidr", "ipFamily" }`
- **accessConfig** — `{ "authenticationMode", "bootstrapClusterCreatorAdminPermissions" }`

`CreateCluster` accepts all three and `DescribeCluster` faithfully echoes them (round-trip). When omitted on create, the real-EKS defaults are applied so the post-create read is populated and drift-free.

## Why

The wire `clusterJSON` had no `logging`, `kubernetesNetworkConfig`, or `accessConfig`, so an `aws_eks_cluster` resource read back empty values for these attributes right after apply, producing perpetual Terraform diffs.

## Defaults (AWS-accurate)

- **logging**: omitted -> one `clusterLogging` entry with all five control-plane types (`api, audit, authenticator, controllerManager, scheduler`) and `enabled: false` (the AWS default state).
- **kubernetesNetworkConfig**: `ipFamily` defaults to `ipv4`; `serviceIpv4Cidr` auto-assigned `10.100.0.0/16` when omitted. `ipFamily: ipv6` assigns a `serviceIpv6Cidr` (`fd00::/108`) instead.
- **accessConfig**: `authenticationMode` defaults to `CONFIG_MAP` — the documented default on the EKS API / SDK / CloudFormation path (only the AWS Console defaults to `API_AND_CONFIG_MAP`), which is the path Terraform uses. `bootstrapClusterCreatorAdminPermissions` defaults to `true`.

## Layering

Threaded through all three layers, following the existing VPCConfig pattern: driver model (`providers/aws/eks/driver`) -> provider store defaults/echo (`providers/aws/eks`) -> wire `toWire`/`toDriver` (`server/aws/eks`).

## Tests

- Provider-level (hand-rolled helpers): explicit echo, omitted-defaults, and the ipv6 path.
- Wire-level (real aws-sdk-go-v2 EKS client): CreateCluster -> DescribeCluster echo and defaults over the wire.
