### PR TITLE
fix(acm): model EMAIL validation on RequestCertificate/DescribeCertificate

### DIFF
--- a/providers/aws/acm/acm.go
+++ b/providers/aws/acm/acm.go
@@ -139,5 +139,10 @@ func copyCert(c *driver.Certificate) driver.Certificate {
 	out.InUseBy = append([]string(nil), c.InUseBy...)
 	out.DomainValidationOptions = append([]driver.DomainValidation(nil), c.DomainValidationOptions...)
 
+	for i := range out.DomainValidationOptions {
+		out.DomainValidationOptions[i].ValidationEmails =
+			append([]string(nil), c.DomainValidationOptions[i].ValidationEmails...)
+	}
+
 	return out
 }

--- a/providers/aws/acm/certificates.go
+++ b/providers/aws/acm/certificates.go
@@ -66,7 +66,7 @@ func (m *Mock) RequestCertificate(_ context.Context, in driver.RequestCertificat
 		ARN:                     arn,
 		DomainName:              in.DomainName,
 		SubjectAlternativeNames: sans,
-		DomainValidationOptions: validationOptions(sans, method),
+		DomainValidationOptions: validationOptions(sans, method, in.DomainValidationOptions),
 		Serial:                  mat.serial,
 		Subject:                 mat.subject,
 		Issuer:                  mat.issuer,
@@ -94,15 +94,36 @@ func (m *Mock) RequestCertificate(_ context.Context, in driver.RequestCertificat
 	return arn, nil
 }
 
+// wellKnownMailboxes are the deterministic approver addresses ACM emails for
+// EMAIL validation (real ACM also adds WHOIS-derived contacts, which an emulator
+// cannot resolve). Each is prefixed onto the domain's validation domain.
+//
+//nolint:gochecknoglobals // fixed lookup table for EMAIL validation mailboxes
+var wellKnownMailboxes = []string{"admin", "administrator", "hostmaster", "postmaster", "webmaster"}
+
 // validationOptions builds the per-domain validation records for a set of
-// domains (DNS validation exposes a CNAME record to add).
+// domains. DNS validation exposes a CNAME record to add; EMAIL validation
+// exposes the approver mailbox list rooted at each domain's validation domain.
 //
 // A wildcard domain ("*.example.com") is validated against its BASE domain, so
-// the DNS record is rooted at "example.com" (never a literal "*", which Route53
-// rejects as a leftmost label). A wildcard and its apex SAN ("*.example.com" and
-// "example.com") share a single validation record, matching real ACM, so they
-// collapse to one DomainValidation rather than emitting a duplicate CNAME.
-func validationOptions(domains []string, method string) []driver.DomainValidation {
+// the DNS record (or email domain) is rooted at "example.com" (never a literal
+// "*", which Route53 rejects as a leftmost label). A wildcard and its apex SAN
+// ("*.example.com" and "example.com") share a single DNS validation record,
+// matching real ACM, so they collapse to one DomainValidation rather than
+// emitting a duplicate CNAME.
+//
+// reqOpts carries any caller-supplied DomainValidationOptions, letting an EMAIL
+// request route approval to a superdomain (validation domain defaults to the
+// domain itself, with any wildcard label stripped).
+func validationOptions(domains []string, method string, reqOpts []driver.DomainValidationOption) []driver.DomainValidation {
+	overrides := make(map[string]string, len(reqOpts))
+
+	for _, o := range reqOpts {
+		if o.ValidationDomain != "" {
+			overrides[o.DomainName] = o.ValidationDomain
+		}
+	}
+
 	out := make([]driver.DomainValidation, 0, len(domains))
 	seenRecord := make(map[string]bool)
 
@@ -125,9 +146,28 @@ func validationOptions(domains []string, method string) []driver.DomainValidatio
 			dv.ResourceRecordN = "_acm-validations." + base + "."
 			dv.ResourceRecordT = "CNAME"
 			dv.ResourceRecordV = "_" + strings.ReplaceAll(base, ".", "-") + ".acm-validations.aws."
+		} else {
+			validationDomain := base
+			if v, ok := overrides[d]; ok {
+				validationDomain = v
+			}
+
+			dv.ValidationDomain = validationDomain
+			dv.ValidationEmails = validationEmails(validationDomain)
 		}
 
 		out = append(out, dv)
+	}
+
+	return out
+}
+
+// validationEmails returns the well-known approver mailbox addresses for a
+// validation domain.
+func validationEmails(validationDomain string) []string {
+	out := make([]string, 0, len(wellKnownMailboxes))
+	for _, mbox := range wellKnownMailboxes {
+		out = append(out, mbox+"@"+validationDomain)
 	}
 
 	return out

--- a/providers/aws/acm/email_validation_test.go
+++ b/providers/aws/acm/email_validation_test.go
@@ -1,0 +1,141 @@
+package acm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/providers/aws/acm"
+	"github.com/stackshy/cloudemu/v2/services/acm/driver"
+)
+
+func onlyDV(t *testing.T, m *acm.Mock, arn string) driver.DomainValidation {
+	t.Helper()
+
+	cert, err := m.DescribeCertificate(context.Background(), arn)
+	if err != nil {
+		t.Fatalf("DescribeCertificate: %v", err)
+	}
+
+	if len(cert.DomainValidationOptions) != 1 {
+		t.Fatalf("want 1 DomainValidation, got %d", len(cert.DomainValidationOptions))
+	}
+
+	return cert.DomainValidationOptions[0]
+}
+
+func assertEmails(t *testing.T, got []string, domain string) {
+	t.Helper()
+
+	want := []string{
+		"admin@" + domain, "administrator@" + domain, "hostmaster@" + domain,
+		"postmaster@" + domain, "webmaster@" + domain,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("ValidationEmails = %v, want %v", got, want)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ValidationEmails[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestEmailValidationEmits pins that an EMAIL-validated certificate exposes the
+// five well-known approver mailboxes and no DNS ResourceRecord.
+func TestEmailValidationEmits(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	arn, err := m.RequestCertificate(ctx, driver.RequestCertificateInput{
+		DomainName: "example.com", ValidationMethod: driver.ValidationEmail,
+	})
+	if err != nil {
+		t.Fatalf("RequestCertificate: %v", err)
+	}
+
+	dv := onlyDV(t, m, arn)
+	if dv.ValidationMethod != driver.ValidationEmail {
+		t.Fatalf("ValidationMethod = %q, want EMAIL", dv.ValidationMethod)
+	}
+	if dv.ValidationDomain != "example.com" {
+		t.Fatalf("ValidationDomain = %q, want example.com", dv.ValidationDomain)
+	}
+	if dv.ResourceRecordN != "" || dv.ResourceRecordT != "" || dv.ResourceRecordV != "" {
+		t.Fatalf("EMAIL cert must not carry a DNS ResourceRecord, got %+v", dv)
+	}
+
+	assertEmails(t, dv.ValidationEmails, "example.com")
+}
+
+// TestEmailValidationWildcardRoot pins that a wildcard domain roots its approver
+// mailboxes at the base domain (never a literal "*").
+func TestEmailValidationWildcardRoot(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	arn, err := m.RequestCertificate(ctx, driver.RequestCertificateInput{
+		DomainName: "*.example.com", ValidationMethod: driver.ValidationEmail,
+	})
+	if err != nil {
+		t.Fatalf("RequestCertificate: %v", err)
+	}
+
+	dv := onlyDV(t, m, arn)
+	if dv.ValidationDomain != "example.com" {
+		t.Fatalf("ValidationDomain = %q, want example.com", dv.ValidationDomain)
+	}
+
+	assertEmails(t, dv.ValidationEmails, "example.com")
+}
+
+// TestEmailValidationHonorsValidationDomain pins that an explicit ValidationDomain
+// in DomainValidationOptions routes the approver mailboxes to that superdomain.
+func TestEmailValidationHonorsValidationDomain(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	arn, err := m.RequestCertificate(ctx, driver.RequestCertificateInput{
+		DomainName:       "www.example.com",
+		ValidationMethod: driver.ValidationEmail,
+		DomainValidationOptions: []driver.DomainValidationOption{
+			{DomainName: "www.example.com", ValidationDomain: "example.com"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RequestCertificate: %v", err)
+	}
+
+	dv := onlyDV(t, m, arn)
+	if dv.ValidationDomain != "example.com" {
+		t.Fatalf("ValidationDomain = %q, want example.com", dv.ValidationDomain)
+	}
+
+	assertEmails(t, dv.ValidationEmails, "example.com")
+}
+
+// TestDNSValidationUnchanged guards that the default (DNS) path still exposes a
+// CNAME ResourceRecord and never a ValidationEmails list.
+func TestDNSValidationUnchanged(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	arn, err := m.RequestCertificate(ctx, driver.RequestCertificateInput{DomainName: "example.com"})
+	if err != nil {
+		t.Fatalf("RequestCertificate: %v", err)
+	}
+
+	dv := onlyDV(t, m, arn)
+	if dv.ValidationMethod != driver.ValidationDNS {
+		t.Fatalf("default ValidationMethod = %q, want DNS", dv.ValidationMethod)
+	}
+	if dv.ResourceRecordN == "" || dv.ResourceRecordT != "CNAME" {
+		t.Fatalf("DNS cert must carry a CNAME ResourceRecord, got %+v", dv)
+	}
+	if len(dv.ValidationEmails) != 0 {
+		t.Fatalf("DNS cert must not carry ValidationEmails, got %v", dv.ValidationEmails)
+	}
+	if dv.ValidationDomain != "example.com" {
+		t.Fatalf("ValidationDomain = %q, want example.com", dv.ValidationDomain)
+	}
+}

--- a/server/aws/acm/email_validation_sdk_test.go
+++ b/server/aws/acm/email_validation_sdk_test.go
@@ -1,0 +1,64 @@
+package acm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsacm "github.com/aws/aws-sdk-go-v2/service/acm"
+	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
+)
+
+// TestSDKEmailValidation pins that an EMAIL-validated certificate round-trips the
+// approver mailbox list (and no DNS ResourceRecord) through the wire, honoring an
+// explicit ValidationDomain from DomainValidationOptions.
+func TestSDKEmailValidation(t *testing.T) {
+	ctx := context.Background()
+	c := newACMClient(t)
+
+	req, err := c.RequestCertificate(ctx, &awsacm.RequestCertificateInput{
+		DomainName:       aws.String("www.example.com"),
+		ValidationMethod: acmtypes.ValidationMethodEmail,
+		DomainValidationOptions: []acmtypes.DomainValidationOption{
+			{DomainName: aws.String("www.example.com"), ValidationDomain: aws.String("example.com")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RequestCertificate: %v", err)
+	}
+
+	desc, err := c.DescribeCertificate(ctx, &awsacm.DescribeCertificateInput{CertificateArn: req.CertificateArn})
+	if err != nil {
+		t.Fatalf("DescribeCertificate: %v", err)
+	}
+
+	dvos := desc.Certificate.DomainValidationOptions
+	if len(dvos) != 1 {
+		t.Fatalf("want 1 DomainValidation, got %d", len(dvos))
+	}
+
+	dv := dvos[0]
+	if dv.ValidationMethod != acmtypes.ValidationMethodEmail {
+		t.Fatalf("ValidationMethod = %s, want EMAIL", dv.ValidationMethod)
+	}
+	if aws.ToString(dv.ValidationDomain) != "example.com" {
+		t.Fatalf("ValidationDomain = %q, want example.com", aws.ToString(dv.ValidationDomain))
+	}
+	if dv.ResourceRecord != nil {
+		t.Fatalf("EMAIL cert must not carry a DNS ResourceRecord, got %+v", dv.ResourceRecord)
+	}
+
+	want := []string{
+		"admin@example.com", "administrator@example.com", "hostmaster@example.com",
+		"postmaster@example.com", "webmaster@example.com",
+	}
+	if len(dv.ValidationEmails) != len(want) {
+		t.Fatalf("ValidationEmails = %v, want %v", dv.ValidationEmails, want)
+	}
+
+	for i := range want {
+		if dv.ValidationEmails[i] != want[i] {
+			t.Fatalf("ValidationEmails[%d] = %q, want %q", i, dv.ValidationEmails[i], want[i])
+		}
+	}
+}

--- a/server/aws/acm/operations.go
+++ b/server/aws/acm/operations.go
@@ -22,6 +22,7 @@ func (h *Handler) requestCertificate(w http.ResponseWriter, r *http.Request) {
 			DomainName:              req.DomainName,
 			SubjectAlternativeNames: req.SubjectAlternativeNames,
 			ValidationMethod:        req.ValidationMethod,
+			DomainValidationOptions: req.validationOptions(),
 			KeyAlgorithm:            req.KeyAlgorithm,
 			IdempotencyToken:        req.IdempotencyToken,
 			CTLoggingPreference:     ctPref(req.Options),

--- a/server/aws/acm/types.go
+++ b/server/aws/acm/types.go
@@ -50,6 +50,7 @@ type domainValidationJSON struct {
 	ValidationDomain string              `json:"ValidationDomain,omitempty"`
 	ValidationStatus string              `json:"ValidationStatus,omitempty"`
 	ValidationMethod string              `json:"ValidationMethod,omitempty"`
+	ValidationEmails []string            `json:"ValidationEmails,omitempty"`
 	ResourceRecord   *resourceRecordJSON `json:"ResourceRecord,omitempty"`
 }
 
@@ -88,6 +89,7 @@ func certToWire(c *acmdriver.Certificate) certificateDetailJSON {
 		j := domainValidationJSON{
 			DomainName: d.DomainName, ValidationDomain: d.ValidationDomain,
 			ValidationStatus: d.ValidationStatus, ValidationMethod: d.ValidationMethod,
+			ValidationEmails: d.ValidationEmails,
 		}
 
 		if d.ResourceRecordN != "" {
@@ -146,14 +148,33 @@ func certToSummary(c *acmdriver.Certificate) certSummaryJSON {
 
 // --- request shapes ---
 
+type domainValidationOptionJSON struct {
+	DomainName       string `json:"DomainName"`
+	ValidationDomain string `json:"ValidationDomain"`
+}
+
 type requestCertificateRequest struct {
-	DomainName              string           `json:"DomainName"`
-	SubjectAlternativeNames []string         `json:"SubjectAlternativeNames"`
-	ValidationMethod        string           `json:"ValidationMethod"`
-	KeyAlgorithm            string           `json:"KeyAlgorithm"`
-	IdempotencyToken        string           `json:"IdempotencyToken"`
-	Options                 *certOptionsJSON `json:"Options"`
-	Tags                    []tag            `json:"Tags"`
+	DomainName              string                       `json:"DomainName"`
+	SubjectAlternativeNames []string                     `json:"SubjectAlternativeNames"`
+	ValidationMethod        string                       `json:"ValidationMethod"`
+	DomainValidationOptions []domainValidationOptionJSON `json:"DomainValidationOptions"`
+	KeyAlgorithm            string                       `json:"KeyAlgorithm"`
+	IdempotencyToken        string                       `json:"IdempotencyToken"`
+	Options                 *certOptionsJSON             `json:"Options"`
+	Tags                    []tag                        `json:"Tags"`
+}
+
+func (r *requestCertificateRequest) validationOptions() []acmdriver.DomainValidationOption {
+	if len(r.DomainValidationOptions) == 0 {
+		return nil
+	}
+
+	out := make([]acmdriver.DomainValidationOption, 0, len(r.DomainValidationOptions))
+	for _, o := range r.DomainValidationOptions {
+		out = append(out, acmdriver.DomainValidationOption{DomainName: o.DomainName, ValidationDomain: o.ValidationDomain})
+	}
+
+	return out
 }
 
 type importCertificateRequest struct {

--- a/services/acm/driver/driver.go
+++ b/services/acm/driver/driver.go
@@ -55,15 +55,27 @@ const (
 	RenewalIneligible = "INELIGIBLE"
 )
 
-// DomainValidation is the per-domain validation state of a certificate.
+// DomainValidation is the per-domain validation state of a certificate. For DNS
+// validation the ResourceRecord* fields carry the CNAME to add; for EMAIL
+// validation ValidationEmails lists the approver mailboxes the request was sent
+// to (rooted at ValidationDomain). The two sets are mutually exclusive.
 type DomainValidation struct {
 	DomainName       string
 	ValidationDomain string
 	ValidationStatus string
 	ValidationMethod string
-	ResourceRecordN  string // DNS validation record name
-	ResourceRecordT  string // DNS validation record type (CNAME)
-	ResourceRecordV  string // DNS validation record value
+	ResourceRecordN  string   // DNS validation record name
+	ResourceRecordT  string   // DNS validation record type (CNAME)
+	ResourceRecordV  string   // DNS validation record value
+	ValidationEmails []string // EMAIL validation approver addresses
+}
+
+// DomainValidationOption pins the domain an EMAIL validation request is routed
+// to. ValidationDomain must be DomainName or one of its superdomains; when unset
+// ACM defaults it to DomainName.
+type DomainValidationOption struct {
+	DomainName       string
+	ValidationDomain string
 }
 
 // Certificate is the full ACM certificate description plus the material needed
@@ -103,6 +115,7 @@ type RequestCertificateInput struct {
 	DomainName              string
 	SubjectAlternativeNames []string
 	ValidationMethod        string
+	DomainValidationOptions []DomainValidationOption
 	KeyAlgorithm            string
 	IdempotencyToken        string
 	CTLoggingPreference     string


### PR DESCRIPTION
## What

`RequestCertificate` with `ValidationMethod=EMAIL` was not modeled — the provider only built a DNS `ResourceRecord` and never populated the approver mailbox list, so `DescribeCertificate` on an EMAIL-validated cert omitted the `ValidationEmails`/`ValidationDomain` a real ACM user expects.

This threads EMAIL validation through all three layers (driver model -> provider -> wire):

- **Driver** (`services/acm/driver`): add `ValidationEmails []string` to `DomainValidation`; add a `DomainValidationOption{DomainName, ValidationDomain}` type and a `DomainValidationOptions` field on `RequestCertificateInput`.
- **Provider** (`providers/aws/acm`): for EMAIL certs, each domain produces a `DomainValidation` with `ValidationMethod=EMAIL`, a `ValidationDomain` (the request's explicit `ValidationDomain` if given, else the domain with any wildcard label stripped), and the five deterministic well-known approver mailboxes — `admin@`, `administrator@`, `hostmaster@`, `postmaster@`, `webmaster@` — rooted at the validation domain. No `ResourceRecord` is emitted for EMAIL.
- **Wire** (`server/aws/acm`): parse request `DomainValidationOptions`; serialize `ValidationEmails` on the response `DomainValidationOptions`.

## Why

Matches real AWS ACM: an EMAIL-validated certificate reports the approver mailbox list and validation domain per domain, not a DNS CNAME. The DNS path (default when `ValidationMethod` is omitted) is unchanged — still emits the CNAME `ResourceRecord` and no `ValidationEmails`. Certificate `Status` stays `PENDING_VALIDATION` for both methods.

WHOIS-derived approver contacts are intentionally out of scope (an emulator can't perform WHOIS lookups); only the deterministic five well-known mailboxes are modeled.

## Tests

- Provider (hand-rolled helpers): EMAIL cert exposes the five mailboxes + `ValidationDomain` + `ValidationMethod=EMAIL` and no `ResourceRecord`; wildcard roots mailboxes at the base domain; explicit `ValidationDomain` honored; DNS default path unchanged (CNAME present, no `ValidationEmails`).
- Server SDK round-trip: EMAIL request with explicit `ValidationDomain` returns the mailbox list and no `ResourceRecord` over the wire.