### PR TITLE
fix(vpc): Subnet AvailableIpAddressCount, public NAT requires EIP, Interface endpoints back ENIs

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -4707,9 +4707,12 @@ func TestNATGateway(t *testing.T) {
 				t.Fatalf("CreateSubnet: %v", err)
 			}
 
+			// A private NAT gateway needs no Elastic IP, so this cross-provider CRUD
+			// check stays uniform: AWS requires an AllocationId only for a public one.
 			nat, err := p.d.CreateNATGateway(ctx, netdriver.NATGatewayConfig{
-				SubnetID: subnet.ID,
-				Tags:     map[string]string{"env": "test"},
+				SubnetID:         subnet.ID,
+				ConnectivityType: "private",
+				Tags:             map[string]string{"env": "test"},
 			})
 			if err != nil {
 				t.Fatalf("CreateNATGateway: %v", err)

--- a/providers/aws/vpc/endpoint.go
+++ b/providers/aws/vpc/endpoint.go
@@ -8,6 +8,16 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
+// vpcEndpointTypeInterface is the endpoint type that provisions a backing ENI in
+// each specified subnet. Gateway-type endpoints hold no interfaces.
+const vpcEndpointTypeInterface = "Interface"
+
+// endpointENIDescription is the description stamped on the ENIs an Interface
+// endpoint occupies, so DeleteVpcEndpoint can release exactly this endpoint's set.
+func endpointENIDescription(endpointID string) string {
+	return "VPC Endpoint Interface " + endpointID
+}
+
 // copyStringSlice creates a shallow copy of a string slice.
 func copyStringSlice(src []string) []string {
 	if src == nil {
@@ -58,21 +68,36 @@ func (m *Mock) CreateVPCEndpoint(
 		Tags:             copyTags(cfg.Tags),
 		CreatedAt:        m.opts.Clock.Now().Format(timeFormat),
 	}
+
+	// An Interface endpoint provisions one requester-managed ENI per subnet, which
+	// consumes a subnet IP and (like a NAT gateway's ENI) blocks a premature subnet
+	// or VPC delete. Gateway endpoints hold none.
+	if cfg.EndpointType == vpcEndpointTypeInterface {
+		for _, subnetID := range ep.SubnetIDs {
+			eni := m.attachManagedENI(cfg.VPCID, subnetID, endpointENIDescription(id))
+			ep.NetworkInterfaceIDs = append(ep.NetworkInterfaceIDs, eni.ID)
+		}
+	}
+
 	m.endpoints.Set(id, ep)
 
 	return copyEndpoint(ep), nil
 }
 
-// DeleteVPCEndpoint deletes the VPC endpoint with the given ID.
+// DeleteVPCEndpoint deletes the VPC endpoint with the given ID, releasing any
+// backing ENIs an Interface endpoint provisioned.
 func (m *Mock) DeleteVPCEndpoint(
 	_ context.Context, id string,
 ) error {
-	if !m.endpoints.Delete(id) {
+	if !m.endpoints.Has(id) {
 		return errors.Newf(
 			errors.NotFound,
 			"vpc endpoint %q not found", id,
 		)
 	}
+
+	m.endpoints.Delete(id)
+	m.releaseManagedENIs(endpointENIDescription(id))
 
 	return nil
 }
@@ -137,15 +162,16 @@ func toEndpointInfo(ep *driver.VPCEndpoint) driver.VPCEndpoint {
 
 func copyEndpoint(ep *driver.VPCEndpoint) *driver.VPCEndpoint {
 	return &driver.VPCEndpoint{
-		ID:               ep.ID,
-		VPCID:            ep.VPCID,
-		ServiceName:      ep.ServiceName,
-		EndpointType:     ep.EndpointType,
-		State:            ep.State,
-		SubnetIDs:        copyStringSlice(ep.SubnetIDs),
-		SecurityGroupIDs: copyStringSlice(ep.SecurityGroupIDs),
-		RouteTableIDs:    copyStringSlice(ep.RouteTableIDs),
-		Tags:             copyTags(ep.Tags),
-		CreatedAt:        ep.CreatedAt,
+		ID:                  ep.ID,
+		VPCID:               ep.VPCID,
+		ServiceName:         ep.ServiceName,
+		EndpointType:        ep.EndpointType,
+		State:               ep.State,
+		SubnetIDs:           copyStringSlice(ep.SubnetIDs),
+		SecurityGroupIDs:    copyStringSlice(ep.SecurityGroupIDs),
+		RouteTableIDs:       copyStringSlice(ep.RouteTableIDs),
+		Tags:                copyTags(ep.Tags),
+		CreatedAt:           ep.CreatedAt,
+		NetworkInterfaceIDs: copyStringSlice(ep.NetworkInterfaceIDs),
 	}
 }

--- a/providers/aws/vpc/endpoint_test.go
+++ b/providers/aws/vpc/endpoint_test.go
@@ -1,0 +1,79 @@
+package vpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// countENIsInSubnet returns how many network interfaces reside in the subnet.
+func countENIsInSubnet(m *Mock, subnetID string) int {
+	n := 0
+
+	for _, eni := range m.enis.All() {
+		if eni.SubnetID == subnetID {
+			n++
+		}
+	}
+
+	return n
+}
+
+// TestInterfaceEndpointBacksENIs pins that an Interface-type VPC endpoint provisions
+// one ENI per specified subnet, that DescribeVpcEndpoints returns their ids, and that
+// deleting the endpoint releases them.
+func TestInterfaceEndpointBacksENIs(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	v := createTestVPC(m)
+
+	subA, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+	requireNoError(t, err)
+	subB, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.2.0/24"})
+	requireNoError(t, err)
+
+	ep, err := m.CreateVPCEndpoint(ctx, driver.VPCEndpointConfig{
+		VPCID:        v.ID,
+		ServiceName:  "com.amazonaws.us-east-1.s3",
+		EndpointType: "Interface",
+		SubnetIDs:    []string{subA.ID, subB.ID},
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, 2, len(ep.NetworkInterfaceIDs))
+	assertEqual(t, 1, countENIsInSubnet(m, subA.ID))
+	assertEqual(t, 1, countENIsInSubnet(m, subB.ID))
+
+	// Describe reflects the ENI ids too.
+	got, err := m.DescribeVPCEndpoints(ctx, []string{ep.ID})
+	requireNoError(t, err)
+	assertEqual(t, 2, len(got[0].NetworkInterfaceIDs))
+
+	// Deleting the endpoint releases its backing ENIs.
+	requireNoError(t, m.DeleteVPCEndpoint(ctx, ep.ID))
+	assertEqual(t, 0, countENIsInSubnet(m, subA.ID))
+	assertEqual(t, 0, countENIsInSubnet(m, subB.ID))
+}
+
+// TestGatewayEndpointHasNoENIs pins that a Gateway-type endpoint provisions no
+// interfaces, matching real EC2 (gateway endpoints are route-table entries).
+func TestGatewayEndpointHasNoENIs(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	v := createTestVPC(m)
+
+	sub, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+	requireNoError(t, err)
+
+	ep, err := m.CreateVPCEndpoint(ctx, driver.VPCEndpointConfig{
+		VPCID:        v.ID,
+		ServiceName:  "com.amazonaws.us-east-1.s3",
+		EndpointType: "Gateway",
+		SubnetIDs:    []string{sub.ID},
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, 0, len(ep.NetworkInterfaceIDs))
+	assertEqual(t, 0, countENIsInSubnet(m, sub.ID))
+}

--- a/providers/aws/vpc/mainroutetable_test.go
+++ b/providers/aws/vpc/mainroutetable_test.go
@@ -156,8 +156,9 @@ func TestDeleteRefusedWhileAnInterfaceIsAttached(t *testing.T) {
 		t.Fatalf("CreateSubnet: %v", err)
 	}
 
-	// A NAT gateway holds an interface for as long as it lives.
-	if _, err := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: sub.ID}); err != nil {
+	// A NAT gateway holds an interface for as long as it lives. A private one
+	// needs no Elastic IP, keeping this teardown check focused on the ENI it holds.
+	if _, err := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: sub.ID, ConnectivityType: "private"}); err != nil {
 		t.Fatalf("CreateNATGateway: %v", err)
 	}
 

--- a/providers/aws/vpc/nat_gateway.go
+++ b/providers/aws/vpc/nat_gateway.go
@@ -15,6 +15,13 @@ const (
 
 	natConnectivityPublic  = "public"
 	natConnectivityPrivate = "private"
+
+	// Error markers so the wire layer can emit the resource-specific EC2 code for
+	// an invalid Elastic IP pairing. A public NAT gateway requires an AllocationId;
+	// a private one must not carry one; a named allocation must exist.
+	natMissingAllocationMsg     = "MissingParameter: a public NAT gateway requires an Elastic IP AllocationId"
+	natUnexpectedAllocationMsg  = "InvalidParameterValue: a private NAT gateway must not have an AllocationId"
+	natAllocationNotFoundErrFmt = "InvalidAllocationID.NotFound: the Elastic IP allocation %q does not exist"
 )
 
 type natGatewayData struct {
@@ -42,21 +49,30 @@ func (m *Mock) CreateNATGateway(_ context.Context, cfg driver.NATGatewayConfig) 
 		return nil, errors.Newf(errors.NotFound, "subnet %q not found", cfg.SubnetID)
 	}
 
+	connectivity := natConnectivityPublic
+	if cfg.ConnectivityType == natConnectivityPrivate {
+		connectivity = natConnectivityPrivate
+	}
+
+	// A public NAT gateway must be given an allocated Elastic IP; a private one
+	// must not carry one. Validate before creating the ENI so a rejected request
+	// leaves no trace.
+	publicIP, err := m.resolveNATElasticIP(connectivity, cfg.AllocationID)
+	if err != nil {
+		return nil, err
+	}
+
 	id := idgen.GenerateID("nat-")
 
 	// A real NAT gateway occupies an ENI in its subnet for as long as it
 	// lives, and that ENI is what refuses a VPC delete issued too early.
 	eni := m.attachManagedENI(subnet.VPCID, cfg.SubnetID, natENIDescription(id))
 
-	connectivity := natConnectivityPublic
-	if cfg.ConnectivityType == natConnectivityPrivate {
-		connectivity = natConnectivityPrivate
-	}
-
 	nat := &natGatewayData{
 		ID:                 id,
 		SubnetID:           cfg.SubnetID,
 		VPCID:              subnet.VPCID,
+		PublicIP:           publicIP,
 		PrivateIP:          mockPublicIP(id + "-private"),
 		AllocationID:       cfg.AllocationID,
 		NetworkInterfaceID: eni.ID,
@@ -65,16 +81,12 @@ func (m *Mock) CreateNATGateway(_ context.Context, cfg driver.NATGatewayConfig) 
 		CreatedAt:          m.opts.Clock.Now().Format(timeFormat),
 		Tags:               copyTags(cfg.Tags),
 	}
-	// A private NAT gateway has no public/Elastic IP address.
-	if connectivity == natConnectivityPublic {
-		nat.PublicIP = mockPublicIP(id)
 
-		// The NAT gateway holds the Elastic IP, so real EC2 refuses to release it
-		// until the NAT gateway is deleted (InvalidIPAddress.InUse).
-		if cfg.AllocationID != "" {
-			if eip, ok := m.eips.Get(cfg.AllocationID); ok {
-				eip.AssociationID = idgen.GenerateID("eipassoc-")
-			}
+	// The NAT gateway holds the Elastic IP, so real EC2 refuses to release it
+	// until the NAT gateway is deleted (InvalidIPAddress.InUse).
+	if connectivity == natConnectivityPublic {
+		if eip, ok := m.eips.Get(cfg.AllocationID); ok {
+			eip.AssociationID = idgen.GenerateID("eipassoc-")
 		}
 	}
 
@@ -103,6 +115,31 @@ func (m *Mock) DeleteNATGateway(_ context.Context, id string) error {
 	}
 
 	return nil
+}
+
+// resolveNATElasticIP enforces the Elastic IP rules a NAT gateway's connectivity
+// type imposes and returns the public IP the gateway advertises. A public gateway
+// requires an existing allocation and reflects that EIP's address; a private
+// gateway must not name an allocation and has no public IP.
+func (m *Mock) resolveNATElasticIP(connectivity, allocationID string) (string, error) {
+	if connectivity == natConnectivityPrivate {
+		if allocationID != "" {
+			return "", errors.New(errors.InvalidArgument, natUnexpectedAllocationMsg)
+		}
+
+		return "", nil
+	}
+
+	if allocationID == "" {
+		return "", errors.New(errors.InvalidArgument, natMissingAllocationMsg)
+	}
+
+	eip, ok := m.eips.Get(allocationID)
+	if !ok {
+		return "", errors.Newf(errors.InvalidArgument, natAllocationNotFoundErrFmt, allocationID)
+	}
+
+	return eip.PublicIP, nil
 }
 
 func natENIDescription(natID string) string {

--- a/providers/aws/vpc/subnet_ip_count_test.go
+++ b/providers/aws/vpc/subnet_ip_count_test.go
@@ -1,0 +1,77 @@
+package vpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// describeSubnetCount returns the AvailableIPAddressCount DescribeSubnets reports
+// for the given subnet.
+func describeSubnetCount(t *testing.T, m *Mock, subnetID string) int {
+	t.Helper()
+
+	subs, err := m.DescribeSubnets(context.Background(), []string{subnetID})
+	requireNoError(t, err)
+
+	if len(subs) != 1 {
+		t.Fatalf("DescribeSubnets returned %d subnets, want 1", len(subs))
+	}
+
+	return subs[0].AvailableIPAddressCount
+}
+
+// TestSubnetAvailableIPAddressCount pins that a fresh subnet advertises its CIDR's
+// host space minus AWS's five reserved addresses, that launching an instance into
+// it consumes one address (its primary ENI), and that terminating the instance
+// gives the address back.
+func TestSubnetAvailableIPAddressCount(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	v := createTestVPC(m)
+
+	// A /24 has 256 addresses; AWS reserves 5, so a fresh subnet reports 251.
+	const wantEmpty = 251
+
+	sub, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+	requireNoError(t, err)
+	assertEqual(t, wantEmpty, sub.AvailableIPAddressCount)
+	assertEqual(t, wantEmpty, describeSubnetCount(t, m, sub.ID))
+
+	// Launching an instance materializes its primary ENI in the subnet, consuming
+	// one address.
+	requireNoError(t, m.CreatePrimaryNetworkInterface(ctx, "i-123", sub.ID, nil))
+	assertEqual(t, wantEmpty-1, describeSubnetCount(t, m, sub.ID))
+
+	// A standalone ENI consumes another.
+	_, err = m.CreateNetworkInterface(ctx, sub.ID, "extra", nil, nil)
+	requireNoError(t, err)
+	assertEqual(t, wantEmpty-2, describeSubnetCount(t, m, sub.ID))
+
+	// Terminating the instance releases its primary ENI, re-incrementing the count.
+	requireNoError(t, m.ReleaseInstanceNetworkInterfaces(ctx, "i-123"))
+	assertEqual(t, wantEmpty-1, describeSubnetCount(t, m, sub.ID))
+}
+
+// TestSubnetAvailableIPAddressCountPrefixSizes pins the reserved-address math across
+// prefix lengths.
+func TestSubnetAvailableIPAddressCountPrefixSizes(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	v := createTestVPC(m)
+
+	cases := []struct {
+		cidr string
+		want int
+	}{
+		{"10.0.0.0/25", 123}, // 128 - 5
+		{"10.0.2.0/28", 11},  // 16 - 5
+	}
+
+	for _, c := range cases {
+		sub, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: c.cidr})
+		requireNoError(t, err)
+		assertEqual(t, c.want, sub.AvailableIPAddressCount)
+	}
+}

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -19,6 +19,10 @@ const (
 	timeFormat                = time.RFC3339
 	maxOctetValue             = 256
 	defaultFlowLogRecordLimit = 10
+	// subnetReservedIPs is the number of addresses AWS reserves in every subnet
+	// CIDR (network, VPC router, DNS, future use, broadcast). A /24 therefore
+	// advertises 256-5 = 251 usable addresses on a fresh subnet.
+	subnetReservedIPs = 5
 )
 
 // VPC IPv4 CIDR netmask bounds. EC2 requires a VPC block between a /16 and a
@@ -569,8 +573,58 @@ func (m *Mock) CreateSubnet(_ context.Context, cfg driver.SubnetConfig) (*driver
 	m.associateDefaultNetworkACL(cfg.VPCID, id)
 
 	info := toSubnetInfo(s)
+	info.AvailableIPAddressCount = m.subnetAvailableIPCount(s.ID, s.CIDRBlock)
 
 	return &info, nil
+}
+
+// subnetAvailableIPCount reports the usable IPv4 addresses left in the subnet:
+// the CIDR's host space minus AWS's five reserved addresses, minus every network
+// interface resident in the subnet (an instance's primary ENI, standalone ENIs,
+// and the ENIs NAT gateways and interface endpoints occupy). A malformed or
+// non-IPv4 CIDR yields 0. The count re-increments when those interfaces are
+// released — a terminated instance's primary ENI is deleted, freeing its address.
+func (m *Mock) subnetAvailableIPCount(subnetID, cidr string) int {
+	base := baseSubnetIPCount(cidr)
+	if base == 0 {
+		return 0
+	}
+
+	used := 0
+
+	for _, eni := range m.enis.All() {
+		if eni.SubnetID == subnetID {
+			used++
+		}
+	}
+
+	if used >= base {
+		return 0
+	}
+
+	return base - used
+}
+
+// baseSubnetIPCount is a subnet CIDR's usable-address count before any ENI
+// consumption: its host space minus AWS's five reserved addresses. A malformed
+// or non-IPv4 CIDR, or one too small to hold the reserved set, yields 0.
+func baseSubnetIPCount(cidr string) int {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return 0
+	}
+
+	ones, bits := ipnet.Mask.Size()
+	if bits != net.IPv4len*8 {
+		return 0
+	}
+
+	total := 1 << (net.IPv4len*8 - ones)
+	if total <= subnetReservedIPs {
+		return 0
+	}
+
+	return total - subnetReservedIPs
 }
 
 // DeleteSubnet deletes the subnet with the given ID.
@@ -755,7 +809,12 @@ func (m *Mock) DescribeSubnets(_ context.Context, ids []string) ([]driver.Subnet
 		}
 	}
 
-	return describeResources(m.subnets, ids, toSubnetInfo), nil
+	out := describeResources(m.subnets, ids, toSubnetInfo)
+	for i := range out {
+		out[i].AvailableIPAddressCount = m.subnetAvailableIPCount(out[i].ID, out[i].CIDRBlock)
+	}
+
+	return out, nil
 }
 
 // CreateSecurityGroup creates a new security group with the given configuration.

--- a/providers/aws/vpc/vpc_test.go
+++ b/providers/aws/vpc/vpc_test.go
@@ -705,13 +705,47 @@ func TestCreateNATGateway(t *testing.T) {
 	s, _ := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
 
 	t.Run("success", func(t *testing.T) {
-		nat, err := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s.ID})
+		eip, err := m.AllocateAddress(ctx, driver.ElasticIPConfig{})
+		requireNoError(t, err)
+
+		nat, err := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s.ID, AllocationID: eip.AllocationID})
 		requireNoError(t, err)
 		assertNotEmpty(t, nat.ID)
 		assertEqual(t, s.ID, nat.SubnetID)
 		assertEqual(t, v.ID, nat.VPCID)
 		assertEqual(t, "available", nat.State)
-		assertNotEmpty(t, nat.PublicIP)
+		// A public NAT gateway reflects its Elastic IP's public address, not a
+		// fabricated one.
+		assertEqual(t, eip.PublicIP, nat.PublicIP)
+		assertEqual(t, eip.AllocationID, nat.AllocationID)
+	})
+
+	t.Run("public without allocation rejected", func(t *testing.T) {
+		_, err := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s.ID})
+		assertError(t, err, true)
+	})
+
+	t.Run("public with unknown allocation rejected", func(t *testing.T) {
+		_, err := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s.ID, AllocationID: "eipalloc-nope"})
+		assertError(t, err, true)
+	})
+
+	t.Run("private without allocation succeeds", func(t *testing.T) {
+		nat, err := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s.ID, ConnectivityType: "private"})
+		requireNoError(t, err)
+		assertEqual(t, "private", nat.ConnectivityType)
+		// A private NAT gateway has no public IP.
+		assertEqual(t, "", nat.PublicIP)
+	})
+
+	t.Run("private with allocation rejected", func(t *testing.T) {
+		eip, err := m.AllocateAddress(ctx, driver.ElasticIPConfig{})
+		requireNoError(t, err)
+
+		_, err = m.CreateNATGateway(ctx, driver.NATGatewayConfig{
+			SubnetID: s.ID, ConnectivityType: "private", AllocationID: eip.AllocationID,
+		})
+		assertError(t, err, true)
 	})
 
 	t.Run("empty subnet ID", func(t *testing.T) {
@@ -730,7 +764,7 @@ func TestDeleteNATGateway(t *testing.T) {
 	ctx := context.Background()
 	v := createTestVPC(m)
 	s, _ := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
-	nat, _ := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s.ID})
+	nat, _ := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s.ID, ConnectivityType: "private"})
 
 	t.Run("success", func(t *testing.T) {
 		err := m.DeleteNATGateway(ctx, nat.ID)
@@ -748,8 +782,8 @@ func TestDescribeNATGateways(t *testing.T) {
 	ctx := context.Background()
 	v := createTestVPC(m)
 	s, _ := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
-	nat1, _ := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s.ID})
-	_, _ = m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s.ID})
+	nat1, _ := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s.ID, ConnectivityType: "private"})
+	_, _ = m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s.ID, ConnectivityType: "private"})
 
 	t.Run("all", func(t *testing.T) {
 		nats, err := m.DescribeNATGateways(ctx, nil)

--- a/server/aws/ec2/ec2_phase2_test.go
+++ b/server/aws/ec2/ec2_phase2_test.go
@@ -370,18 +370,19 @@ func TestToVpcXMLStateDefaults(t *testing.T) {
 }
 
 func TestToSubnetXMLStateDefaults(t *testing.T) {
-	in := &netdriver.SubnetInfo{ID: "subnet-x", VPCID: "vpc-x"}
+	const usableIPs = 251
+
+	in := &netdriver.SubnetInfo{ID: "subnet-x", VPCID: "vpc-x", AvailableIPAddressCount: usableIPs}
 
 	got := toSubnetXML(in, "us-east-1")
 	if got.State != "available" {
 		t.Errorf("default state: %q", got.State)
 	}
 
-	// No CIDR set falls back to a /24's usable-address count.
-	const fallbackAvailableIPs = 251
-	if got.AvailableIPCount != fallbackAvailableIPs {
-		t.Errorf("AvailableIPCount = %d, want %d",
-			got.AvailableIPCount, fallbackAvailableIPs)
+	// toSubnetXML reflects the provider-computed usable-address count verbatim;
+	// the provider derives it from the CIDR minus reserved and consumed addresses.
+	if got.AvailableIPCount != usableIPs {
+		t.Errorf("AvailableIPCount = %d, want %d", got.AvailableIPCount, usableIPs)
 	}
 }
 

--- a/server/aws/ec2/endpoint.go
+++ b/server/aws/ec2/endpoint.go
@@ -13,16 +13,17 @@ import (
 const defaultVPCEndpointType = "Gateway"
 
 type vpcEndpointXML struct {
-	VpcEndpointID   string    `xml:"vpcEndpointId"`
-	VpcEndpointType string    `xml:"vpcEndpointType"`
-	VpcID           string    `xml:"vpcId"`
-	ServiceName     string    `xml:"serviceName"`
-	State           string    `xml:"state"`
-	RouteTableIDs   []string  `xml:"routeTableIdSet>item,omitempty"`
-	SubnetIDs       []string  `xml:"subnetIdSet>item,omitempty"`
-	Groups          []string  `xml:"groupSet>item,omitempty"`
-	CreationTime    string    `xml:"creationTimestamp,omitempty"`
-	Tags            []tagItem `xml:"tagSet>item,omitempty"`
+	VpcEndpointID       string    `xml:"vpcEndpointId"`
+	VpcEndpointType     string    `xml:"vpcEndpointType"`
+	VpcID               string    `xml:"vpcId"`
+	ServiceName         string    `xml:"serviceName"`
+	State               string    `xml:"state"`
+	RouteTableIDs       []string  `xml:"routeTableIdSet>item,omitempty"`
+	SubnetIDs           []string  `xml:"subnetIdSet>item,omitempty"`
+	Groups              []string  `xml:"groupSet>item,omitempty"`
+	NetworkInterfaceIDs []string  `xml:"networkInterfaceIdSet>item,omitempty"`
+	CreationTime        string    `xml:"creationTimestamp,omitempty"`
+	Tags                []tagItem `xml:"tagSet>item,omitempty"`
 }
 
 func (h *Handler) routeVPCEndpoints(w http.ResponseWriter, r *http.Request, action string) bool {
@@ -214,16 +215,17 @@ func vpcEndpointMatchesFilter(ep *netdriver.VPCEndpoint, f awsquery.Filter) bool
 
 func toVPCEndpointXML(ep *netdriver.VPCEndpoint) vpcEndpointXML {
 	return vpcEndpointXML{
-		VpcEndpointID:   ep.ID,
-		VpcEndpointType: nonEmpty(ep.EndpointType, defaultVPCEndpointType),
-		VpcID:           ep.VPCID,
-		ServiceName:     ep.ServiceName,
-		State:           nonEmpty(ep.State, stateAvailable),
-		RouteTableIDs:   ep.RouteTableIDs,
-		SubnetIDs:       ep.SubnetIDs,
-		Groups:          ep.SecurityGroupIDs,
-		CreationTime:    ep.CreatedAt,
-		Tags:            toTagItems(ep.Tags),
+		VpcEndpointID:       ep.ID,
+		VpcEndpointType:     nonEmpty(ep.EndpointType, defaultVPCEndpointType),
+		VpcID:               ep.VPCID,
+		ServiceName:         ep.ServiceName,
+		State:               nonEmpty(ep.State, stateAvailable),
+		RouteTableIDs:       ep.RouteTableIDs,
+		SubnetIDs:           ep.SubnetIDs,
+		Groups:              ep.SecurityGroupIDs,
+		NetworkInterfaceIDs: ep.NetworkInterfaceIDs,
+		CreationTime:        ep.CreatedAt,
+		Tags:                toTagItems(ep.Tags),
 	}
 }
 

--- a/server/aws/ec2/nat_gateway.go
+++ b/server/aws/ec2/nat_gateway.go
@@ -161,14 +161,21 @@ func writeNatErr(w http.ResponseWriter, err error) {
 	writeErrWithNotFound(w, err, "NatGatewayNotFound", "DependencyViolation")
 }
 
-// writeCreateNatErr maps CreateNatGateway's not-found: the NAT does not exist yet,
-// so a not-found on create is the target subnet — InvalidSubnetID.NotFound, not
-// the NatGatewayNotFound the generic mapper would emit.
+// writeCreateNatErr maps CreateNatGateway's create-only codes. A not-found on
+// create is the target subnet — InvalidSubnetID.NotFound, not the NatGatewayNotFound
+// the generic mapper would emit. The Elastic IP pairing errors carry a marker so a
+// missing or mismatched AllocationId surfaces the resource-specific EC2 code
+// (MissingParameter / InvalidAllocationID.NotFound) rather than a bare
+// InvalidParameterValue.
 func writeCreateNatErr(w http.ResponseWriter, err error) {
-	if cerrors.IsNotFound(err) && strings.Contains(err.Error(), "subnet") {
+	switch {
+	case cerrors.IsNotFound(err) && strings.Contains(err.Error(), "subnet"):
 		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSubnetID.NotFound", cerrors.Message(err))
-		return
+	case strings.Contains(err.Error(), "InvalidAllocationID.NotFound:"):
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAllocationID.NotFound", cerrors.Message(err))
+	case strings.Contains(err.Error(), "MissingParameter:"):
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "MissingParameter", cerrors.Message(err))
+	default:
+		writeNatErr(w, err)
 	}
-
-	writeNatErr(w, err)
 }

--- a/server/aws/ec2/nat_gateway_test.go
+++ b/server/aws/ec2/nat_gateway_test.go
@@ -63,6 +63,20 @@ func mkVPCSubnet(t *testing.T, c *ec2.Client) (vpcID, subnetID string) {
 	return vpcID, aws.ToString(sub.Subnet.SubnetId)
 }
 
+// allocEIP allocates an Elastic IP and returns its allocation id. A public NAT
+// gateway requires a real allocation — real EC2 rejects a fabricated one with
+// InvalidAllocationID.NotFound.
+func allocEIP(ctx context.Context, t *testing.T, c *ec2.Client) string {
+	t.Helper()
+
+	out, err := c.AllocateAddress(ctx, &ec2.AllocateAddressInput{})
+	if err != nil {
+		t.Fatalf("AllocateAddress: %v", err)
+	}
+
+	return aws.ToString(out.AllocationId)
+}
+
 // TestNatGatewayAddressSetRoundTrip pins that a public NAT gateway reports its
 // address set (allocationId, networkInterfaceId, privateIp, publicIp) and
 // connectivityType, both on create and describe. Terraform's aws_nat_gateway
@@ -72,17 +86,18 @@ func TestNatGatewayAddressSetRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	c := newRoutingEdgeEC2(t)
 	_, subnetID := mkVPCSubnet(t, c)
+	alloc := allocEIP(ctx, t, c)
 
 	created, err := c.CreateNatGateway(ctx, &ec2.CreateNatGatewayInput{
 		SubnetId:     aws.String(subnetID),
-		AllocationId: aws.String("eipalloc-12345678"),
+		AllocationId: aws.String(alloc),
 	})
 	if err != nil {
 		t.Fatalf("CreateNatGateway: %v", err)
 	}
 
 	natID := aws.ToString(created.NatGateway.NatGatewayId)
-	assertNatAddresses(t, "create", created.NatGateway)
+	assertNatAddresses(t, "create", created.NatGateway, alloc)
 
 	desc, err := c.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
 		NatGatewayIds: []string{natID},
@@ -95,10 +110,10 @@ func TestNatGatewayAddressSetRoundTrip(t *testing.T) {
 		t.Fatalf("DescribeNatGateways returned %d, want 1", len(desc.NatGateways))
 	}
 
-	assertNatAddresses(t, "describe", &desc.NatGateways[0])
+	assertNatAddresses(t, "describe", &desc.NatGateways[0], alloc)
 }
 
-func assertNatAddresses(t *testing.T, phase string, n *ec2types.NatGateway) {
+func assertNatAddresses(t *testing.T, phase string, n *ec2types.NatGateway, wantAlloc string) {
 	t.Helper()
 
 	if got := string(n.ConnectivityType); got != "public" {
@@ -110,8 +125,8 @@ func assertNatAddresses(t *testing.T, phase string, n *ec2types.NatGateway) {
 	}
 
 	addr := n.NatGatewayAddresses[0]
-	if aws.ToString(addr.AllocationId) != "eipalloc-12345678" {
-		t.Errorf("%s: allocationId = %q, want eipalloc-12345678", phase, aws.ToString(addr.AllocationId))
+	if aws.ToString(addr.AllocationId) != wantAlloc {
+		t.Errorf("%s: allocationId = %q, want %q", phase, aws.ToString(addr.AllocationId), wantAlloc)
 	}
 
 	if aws.ToString(addr.NetworkInterfaceId) == "" {
@@ -159,13 +174,81 @@ func TestNatGatewayPrivateConnectivity(t *testing.T) {
 	}
 }
 
-// mkNat creates a public NAT gateway in the given subnet and returns its id.
-func mkNat(ctx context.Context, t *testing.T, c *ec2.Client, subnetID, alloc string) string {
+// TestNatGatewayPublicRequiresAllocation pins that a public NAT gateway without an
+// AllocationId is rejected (MissingParameter), an unknown allocation is
+// InvalidAllocationID.NotFound, and a private gateway carrying an AllocationId is
+// rejected — matching real EC2's Elastic IP rules.
+func TestNatGatewayPublicRequiresAllocation(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	_, subnetID := mkVPCSubnet(t, c)
+
+	_, err := c.CreateNatGateway(ctx, &ec2.CreateNatGatewayInput{SubnetId: aws.String(subnetID)})
+	if err == nil {
+		t.Fatal("public NAT gateway without an AllocationId succeeded, want an error")
+	}
+	if got := apiCode(t, err); got != "MissingParameter" {
+		t.Errorf("code = %q, want MissingParameter", got)
+	}
+
+	_, err = c.CreateNatGateway(ctx, &ec2.CreateNatGatewayInput{
+		SubnetId:     aws.String(subnetID),
+		AllocationId: aws.String("eipalloc-doesnotexist"),
+	})
+	if err == nil {
+		t.Fatal("public NAT gateway with an unknown AllocationId succeeded, want an error")
+	}
+	if got := apiCode(t, err); got != "InvalidAllocationID.NotFound" {
+		t.Errorf("code = %q, want InvalidAllocationID.NotFound", got)
+	}
+
+	_, err = c.CreateNatGateway(ctx, &ec2.CreateNatGatewayInput{
+		SubnetId:         aws.String(subnetID),
+		ConnectivityType: ec2types.ConnectivityTypePrivate,
+		AllocationId:     aws.String(allocEIP(ctx, t, c)),
+	})
+	if err == nil {
+		t.Fatal("private NAT gateway with an AllocationId succeeded, want an error")
+	}
+}
+
+// TestNatGatewayPublicReflectsElasticIP pins that a public NAT gateway advertises
+// its Elastic IP's public address rather than a fabricated one.
+func TestNatGatewayPublicReflectsElasticIP(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	_, subnetID := mkVPCSubnet(t, c)
+
+	alloc := allocEIP(ctx, t, c)
+
+	addrs, err := c.DescribeAddresses(ctx, &ec2.DescribeAddressesInput{AllocationIds: []string{alloc}})
+	if err != nil {
+		t.Fatalf("DescribeAddresses: %v", err)
+	}
+	wantIP := aws.ToString(addrs.Addresses[0].PublicIp)
+
+	created, err := c.CreateNatGateway(ctx, &ec2.CreateNatGatewayInput{
+		SubnetId:     aws.String(subnetID),
+		AllocationId: aws.String(alloc),
+	})
+	if err != nil {
+		t.Fatalf("CreateNatGateway: %v", err)
+	}
+
+	got := aws.ToString(created.NatGateway.NatGatewayAddresses[0].PublicIp)
+	if got != wantIP {
+		t.Errorf("NAT publicIp = %q, want the Elastic IP's %q", got, wantIP)
+	}
+}
+
+// mkNat creates a public NAT gateway in the given subnet, allocating the Elastic
+// IP it requires, and returns its id.
+func mkNat(ctx context.Context, t *testing.T, c *ec2.Client, subnetID string) string {
 	t.Helper()
 
 	out, err := c.CreateNatGateway(ctx, &ec2.CreateNatGatewayInput{
 		SubnetId:     aws.String(subnetID),
-		AllocationId: aws.String(alloc),
+		AllocationId: aws.String(allocEIP(ctx, t, c)),
 	})
 	if err != nil {
 		t.Fatalf("CreateNatGateway: %v", err)
@@ -185,8 +268,8 @@ func TestDescribeNatGatewaysFilters(t *testing.T) {
 	vpcA, subnetA := mkVPCSubnet(t, c)
 	_, subnetB := mkVPCSubnet(t, c)
 
-	natA := mkNat(ctx, t, c, subnetA, "eipalloc-aaaa1111")
-	natB := mkNat(ctx, t, c, subnetB, "eipalloc-bbbb2222")
+	natA := mkNat(ctx, t, c, subnetA)
+	natB := mkNat(ctx, t, c, subnetB)
 
 	byVPC, err := c.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
 		Filter: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcA}}},
@@ -252,7 +335,7 @@ func TestDescribeNatGatewaysPaginates(t *testing.T) {
 
 	for range 3 {
 		_, subnetID := mkVPCSubnet(t, c)
-		want[mkNat(ctx, t, c, subnetID, "eipalloc-page")] = 0
+		want[mkNat(ctx, t, c, subnetID)] = 0
 	}
 
 	first, err := c.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{MaxResults: aws.Int32(1)})

--- a/server/aws/ec2/network_interface_test.go
+++ b/server/aws/ec2/network_interface_test.go
@@ -16,7 +16,7 @@ func TestNATGatewayHoldsENIUntilDeleted(t *testing.T) {
 	vpcID, subnetID := mkVPCAndSubnet(t, h)
 
 	natResp := do(t, h, http.MethodPost, "/", url.Values{
-		"Action": {"CreateNatGateway"}, "SubnetId": {subnetID},
+		"Action": {"CreateNatGateway"}, "SubnetId": {subnetID}, "ConnectivityType": {"private"},
 	})
 	if natResp.Code != http.StatusOK {
 		t.Fatalf("CreateNatGateway = %d: %s", natResp.Code, natResp.Body.String())
@@ -76,7 +76,7 @@ func TestDescribeNetworkInterfacesHonoursVPCFilter(t *testing.T) {
 
 	for _, sub := range []string{subnetA, subnetB} {
 		resp := do(t, h, http.MethodPost, "/", url.Values{
-			"Action": {"CreateNatGateway"}, "SubnetId": {sub},
+			"Action": {"CreateNatGateway"}, "SubnetId": {sub}, "ConnectivityType": {"private"},
 		})
 		if resp.Code != http.StatusOK {
 			t.Fatalf("CreateNatGateway(%s) = %d: %s", sub, resp.Code, resp.Body.String())
@@ -106,7 +106,7 @@ func TestDetachThenDeleteNetworkInterface(t *testing.T) {
 	vpcID, subnetID := mkVPCAndSubnet(t, h)
 
 	do(t, h, http.MethodPost, "/", url.Values{
-		"Action": {"CreateNatGateway"}, "SubnetId": {subnetID},
+		"Action": {"CreateNatGateway"}, "SubnetId": {subnetID}, "ConnectivityType": {"private"},
 	})
 
 	desc := do(t, h, http.MethodPost, "/", url.Values{
@@ -155,7 +155,7 @@ func TestDescribeNetworkInterfacesRejectsUnknownFilter(t *testing.T) {
 	vpcID, subnetID := mkVPCAndSubnet(t, h)
 
 	do(t, h, http.MethodPost, "/", url.Values{
-		"Action": {"CreateNatGateway"}, "SubnetId": {subnetID},
+		"Action": {"CreateNatGateway"}, "SubnetId": {subnetID}, "ConnectivityType": {"private"},
 	})
 
 	resp := do(t, h, http.MethodPost, "/", url.Values{

--- a/server/aws/ec2/subnet.go
+++ b/server/aws/ec2/subnet.go
@@ -2,7 +2,6 @@ package ec2
 
 import (
 	"encoding/xml"
-	"net"
 	"net/http"
 	"strings"
 
@@ -11,14 +10,6 @@ import (
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
-
-// AWS reserves 5 addresses in every subnet CIDR (network, VPC router, DNS,
-// future use, broadcast), so a /24 reports 251 usable addresses.
-const subnetReservedIPs = 5
-
-// ipv4Bits is the address width used to size a subnet's host space from its
-// prefix length.
-const ipv4Bits = 32
 
 type subnetXML struct {
 	SubnetID            string    `xml:"subnetId"`
@@ -167,7 +158,7 @@ func toSubnetXML(s *netdriver.SubnetInfo, region string) subnetXML {
 		State:               state,
 		VpcID:               s.VPCID,
 		CidrBlock:           s.CIDRBlock,
-		AvailableIPCount:    availableIPCount(s.CIDRBlock),
+		AvailableIPCount:    s.AvailableIPAddressCount,
 		AvailabilityZone:    s.AvailabilityZone,
 		AvailabilityZoneID:  zoneIDFor(s.AvailabilityZone),
 		MapPublicIPOnLaunch: s.MapPublicIPOnLaunch,
@@ -180,28 +171,6 @@ func toSubnetXML(s *netdriver.SubnetInfo, region string) subnetXML {
 	}
 
 	return x
-}
-
-// availableIPCount reports the usable-address count AWS advertises for a CIDR:
-// the host space minus the five addresses AWS reserves. A malformed or missing
-// CIDR falls back to a /24's 251 rather than zero.
-func availableIPCount(cidr string) int {
-	_, ipnet, err := net.ParseCIDR(cidr)
-	if err != nil {
-		return (1 << (ipv4Bits - 24)) - subnetReservedIPs
-	}
-
-	ones, bits := ipnet.Mask.Size()
-	if bits != ipv4Bits {
-		return 0
-	}
-
-	total := 1 << (ipv4Bits - ones)
-	if total <= subnetReservedIPs {
-		return 0
-	}
-
-	return total - subnetReservedIPs
 }
 
 // zoneIDFor maps an availability-zone name to its zone id (us-east-1a ->

--- a/server/aws/ec2/vpc_endpoint_test.go
+++ b/server/aws/ec2/vpc_endpoint_test.go
@@ -48,6 +48,10 @@ func TestVPCEndpointGatewayLifecycle(t *testing.T) {
 	if string(ep.State) != "available" {
 		t.Errorf("State = %q, want available", ep.State)
 	}
+	// A Gateway endpoint is a route-table entry and provisions no ENIs.
+	if len(ep.NetworkInterfaceIds) != 0 {
+		t.Errorf("Gateway endpoint NetworkInterfaceIds = %v, want none", ep.NetworkInterfaceIds)
+	}
 
 	desc, err := client.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
 		VpcEndpointIds: []string{epID},
@@ -112,6 +116,23 @@ func TestVPCEndpointInterfaceCarriesSubnetsAndGroups(t *testing.T) {
 	ep := create.VpcEndpoint
 	if len(ep.SubnetIds) != 1 || ep.SubnetIds[0] != subnetID {
 		t.Errorf("SubnetIds = %v, want [%s]", ep.SubnetIds, subnetID)
+	}
+
+	// An Interface endpoint provisions one backing ENI per subnet; Terraform's
+	// aws_vpc_endpoint reads network_interface_ids off the response.
+	if len(ep.NetworkInterfaceIds) != 1 {
+		t.Fatalf("NetworkInterfaceIds = %v, want one per subnet", ep.NetworkInterfaceIds)
+	}
+
+	// The ENI is a real interface DescribeNetworkInterfaces can see.
+	enis, err := client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		NetworkInterfaceIds: []string{ep.NetworkInterfaceIds[0]},
+	})
+	if err != nil {
+		t.Fatalf("DescribeNetworkInterfaces: %v", err)
+	}
+	if len(enis.NetworkInterfaces) != 1 {
+		t.Errorf("endpoint ENI %q not found via DescribeNetworkInterfaces", ep.NetworkInterfaceIds[0])
 	}
 }
 

--- a/server/aws/ec2_test.go
+++ b/server/aws/ec2_test.go
@@ -2044,7 +2044,8 @@ func TestNatGatewayLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	nat, err := client.CreateNatGateway(ctx, &ec2.CreateNatGatewayInput{
-		SubnetId: sub.Subnet.SubnetId,
+		SubnetId:         sub.Subnet.SubnetId,
+		ConnectivityType: ec2types.ConnectivityTypePrivate,
 	})
 	require.NoError(t, err)
 	natID := aws.ToString(nat.NatGateway.NatGatewayId)

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -52,6 +52,13 @@ type SubnetInfo struct {
 	// non-default subnet and lets ModifySubnetAttribute flip it — the only way
 	// to turn a subnet public.
 	MapPublicIPOnLaunch bool
+	// AvailableIPAddressCount is the number of usable IPv4 addresses left in the
+	// subnet: the CIDR's host space minus the five addresses AWS reserves in
+	// every subnet, minus the addresses already consumed by resident network
+	// interfaces (instance primary ENIs, standalone ENIs, NAT gateways, interface
+	// endpoints). Populated by the provider on Create/Describe; DescribeSubnets
+	// returns it as availableIpAddressCount, which IaC tools read for drift.
+	AvailableIPAddressCount int
 }
 
 // SecurityGroupConfig describes a security group to create.
@@ -465,6 +472,10 @@ type VPCEndpoint struct {
 	RouteTableIDs    []string
 	Tags             map[string]string
 	CreatedAt        string
+	// NetworkInterfaceIDs holds the ENIs an Interface-type endpoint provisions,
+	// one per subnet. Gateway-type endpoints hold none. DescribeVpcEndpoints
+	// returns these as networkInterfaceIdSet.
+	NetworkInterfaceIDs []string
 }
 
 // Networking is the interface that networking provider

--- a/services/resourcediscovery/networking_subtypes_walk_test.go
+++ b/services/resourcediscovery/networking_subtypes_walk_test.go
@@ -25,7 +25,8 @@ func TestWalkNetworkingSubTypes(t *testing.T) {
 		t.Fatalf("create subnet: %v", err)
 	}
 
-	if _, err := n.CreateNATGateway(ctx, netdriver.NATGatewayConfig{SubnetID: sub.ID}); err != nil {
+	if _, err := n.CreateNATGateway(ctx,
+		netdriver.NATGatewayConfig{SubnetID: sub.ID, ConnectivityType: "private"}); err != nil {
 		t.Fatalf("create nat gateway: %v", err)
 	}
 

--- a/services/resourcediscovery/networking_walk_test.go
+++ b/services/resourcediscovery/networking_walk_test.go
@@ -34,8 +34,10 @@ func TestWalkNetworkingIncludesAddressesAndInterfaces(t *testing.T) {
 		t.Fatalf("AllocateAddress: %v", err)
 	}
 
-	// A NAT gateway holds an interface for as long as it lives.
-	if _, err := vpcMock.CreateNATGateway(ctx, netdriver.NATGatewayConfig{SubnetID: sub.ID}); err != nil {
+	// A NAT gateway holds an interface for as long as it lives. A private one
+	// needs no Elastic IP, leaving the allocated EIP above standalone for the walk.
+	if _, err := vpcMock.CreateNATGateway(ctx,
+		netdriver.NATGatewayConfig{SubnetID: sub.ID, ConnectivityType: "private"}); err != nil {
 		t.Fatalf("CreateNATGateway: %v", err)
 	}
 


### PR DESCRIPTION
Fixes three AWS VPC/EC2 gaps that drove Terraform drift and missing validation on core networking resources. All three are independent and land together.

## GAP 1 — Subnet AvailableIpAddressCount now moves
Real EC2 DescribeSubnets returns `availableIpAddressCount` = CIDR host space minus 5 AWS-reserved addresses minus IPs consumed by resident interfaces. Previously the wire layer computed a static CIDR-5 value that never decremented.

- The provider (`providers/aws/vpc`) is now the source of truth: base = 2^(32-prefix) - 5, minus the ENIs resident in the subnet. Populated on CreateSubnet and DescribeSubnets.
- Because instance launches materialize a primary ENI in the subnet (and NAT gateways / interface endpoints occupy ENIs too), the count decrements on launch and re-increments on terminate automatically.
- The wire layer reflects the provider value; the old static CIDR-only computation was removed.

## GAP 2 — Public NAT gateway requires an EIP AllocationId
Real AWS requires a `public` NAT gateway to reference an allocated EIP, and forbids one on a `private` gateway.

- connectivityType defaults to `public`.
- public + no AllocationId -> `MissingParameter`.
- public + unknown AllocationId -> `InvalidAllocationID.NotFound`.
- private + AllocationId -> `InvalidParameterValue`.
- A public NAT now reflects the looked-up EIP's public IP instead of fabricating one.

## GAP 3 — Interface VPC endpoints create backing ENIs
Real AWS creates one ENI per specified subnet for an `Interface`-type endpoint and returns `networkInterfaceIds`; Gateway endpoints create none.

- CreateVpcEndpoint (Interface) provisions one ENI per subnet through the existing ENI store, so DescribeNetworkInterfaces sees them and they block premature subnet/VPC deletes.
- DescribeVpcEndpoints returns `networkInterfaceIdSet`.
- DeleteVpcEndpoint releases the backing ENIs. Gateway endpoints create none.

## Notes / simplifications
- Subnet IP accounting counts resident ENIs rather than modeling every AWS edge (secondary private IPs, prefix delegation); the count is correct for real launches, standalone ENIs, NAT gateways and interface endpoints.
- ModifyVpcEndpoint does not add/remove ENIs when an Interface endpoint's subnet set changes (out of scope here).

## Tests
Provider (hand-rolled helpers) and wire (real SDK) tests: empty-subnet CIDR-5, decrement on instance launch + standalone ENI, re-increment on terminate; public NAT without/with-unknown allocation rejected, public NAT reflects the EIP's IP, private NAT with allocation rejected; Interface endpoint returns one networkInterfaceId per subnet (visible via DescribeNetworkInterfaces) and Gateway endpoint returns none. Existing NAT tests updated to allocate real EIPs / use private connectivity.

Gates (scoped): build, vet, gofmt, `go generate` + compatgen zero-diff, scoped tests, and `golangci-lint --new-from-rev=origin/development` all clean.