### PR TITLE
fix(redshift): preserve snapshot KmsKeyId across CreateClusterSnapshot/RestoreFromClusterSnapshot

### DIFF
--- a/providers/aws/redshift/redshift.go
+++ b/providers/aws/redshift/redshift.go
@@ -25,9 +25,12 @@ import (
 )
 
 const (
-	defaultEngine            = "redshift"
-	defaultPort              = 5439
-	singleNodeCount          = 1
+	defaultEngine   = "redshift"
+	defaultPort     = 5439
+	singleNodeCount = 1
+	// defaultKMSKeyAlias is the account-default Redshift KMS key real AWS fills in
+	// when a cluster is created encrypted without an explicit KmsKeyId.
+	defaultKMSKeyAlias       = "alias/aws/redshift"
 	snapshotBackupSizeMB     = 100.0
 	cpuUtilizationRunning    = 25.0
 	databaseConnectionsRun   = 5.0
@@ -500,7 +503,7 @@ func (m *Mock) reserveCluster(cfg rdbdriver.ClusterConfig) (rdbdriver.Cluster, e
 		NodeType:                    cfg.NodeType,
 		NumberOfNodes:               numberOfNodes,
 		Encrypted:                   cfg.Encrypted,
-		KmsKeyID:                    cfg.KmsKeyID,
+		KmsKeyID:                    resolveKMSKeyID(cfg.Encrypted, cfg.KmsKeyID),
 		PubliclyAccessible:          cfg.PubliclyAccessible,
 		AvailabilityZone:            cfg.AvailabilityZone,
 		CreatedAt:                   m.opts.Clock.Now().UTC(),
@@ -844,6 +847,7 @@ func (m *Mock) CreateClusterSnapshot(
 		NodeType:                   cluster.NodeType,
 		NumberOfNodes:              cluster.NumberOfNodes,
 		Encrypted:                  cluster.Encrypted,
+		KmsKeyID:                   cluster.KmsKeyID,
 		TotalBackupSizeInMegaBytes: snapshotBackupSizeMB,
 		MasterUsername:             cluster.MasterUsername,
 		DatabaseName:               cluster.DatabaseName,
@@ -940,6 +944,7 @@ func (m *Mock) RestoreClusterFromSnapshot(
 		NodeType:       snap.NodeType,
 		NumberOfNodes:  numberOfNodes,
 		Encrypted:      snap.Encrypted,
+		KmsKeyID:       restoredKMSKeyID(snap.Encrypted, snap.KmsKeyID, input.KmsKeyID),
 		CreatedAt:      now,
 		Tags:           copyTags(input.Tags),
 	}
@@ -952,6 +957,41 @@ func (m *Mock) RestoreClusterFromSnapshot(
 	out := cluster
 
 	return &out, nil
+}
+
+// resolveKMSKeyID mirrors real Redshift: an encrypted cluster created without an
+// explicit KmsKeyId gets the account's default key; an explicit key always wins,
+// and an unencrypted cluster carries no key.
+func resolveKMSKeyID(encrypted bool, kmsKeyID string) string {
+	if !encrypted {
+		return ""
+	}
+
+	if kmsKeyID == "" {
+		return defaultKMSKeyAlias
+	}
+
+	return kmsKeyID
+}
+
+// restoredKMSKeyID picks the encryption key for a cluster restored from a
+// snapshot: an unencrypted snapshot yields no key; a RestoreFromClusterSnapshot
+// KmsKeyId override wins; otherwise the restored cluster inherits the snapshot's
+// key (falling back to the account default if the snapshot predates key capture).
+func restoredKMSKeyID(encrypted bool, snapKmsKeyID, overrideKmsKeyID string) string {
+	if !encrypted {
+		return ""
+	}
+
+	if overrideKmsKeyID != "" {
+		return overrideKmsKeyID
+	}
+
+	if snapKmsKeyID == "" {
+		return defaultKMSKeyAlias
+	}
+
+	return snapKmsKeyID
 }
 
 func stringSet(values []string) map[string]struct{} {

--- a/providers/aws/redshift/redshift_test.go
+++ b/providers/aws/redshift/redshift_test.go
@@ -175,6 +175,122 @@ func TestClusterSnapshotAndRestore(t *testing.T) {
 	requireNoError(t, m.DeleteClusterSnapshot(ctx, "snap-1"))
 }
 
+func TestClusterSnapshotPreservesKmsKeyID(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, rdbdriver.ClusterConfig{
+		ID:        "enc-warehouse",
+		Encrypted: true,
+		KmsKeyID:  "arn:aws:kms:us-east-1:123456789012:key/abc-123",
+	})
+	requireNoError(t, err)
+
+	snap, err := m.CreateClusterSnapshot(ctx, rdbdriver.ClusterSnapshotConfig{
+		ID:        "enc-snap",
+		ClusterID: "enc-warehouse",
+	})
+	requireNoError(t, err)
+
+	// CreateClusterSnapshot captures the source cluster's encryption key.
+	assertEqual(t, true, snap.Encrypted)
+	assertEqual(t, "arn:aws:kms:us-east-1:123456789012:key/abc-123", snap.KmsKeyID)
+
+	// DescribeClusterSnapshots reflects it.
+	snaps, err := m.DescribeClusterSnapshots(ctx, []string{"enc-snap"}, "")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(snaps))
+	assertEqual(t, true, snaps[0].Encrypted)
+	assertEqual(t, "arn:aws:kms:us-east-1:123456789012:key/abc-123", snaps[0].KmsKeyID)
+
+	// Restore inherits the snapshot's key.
+	restored, err := m.RestoreClusterFromSnapshot(ctx, rdbdriver.RestoreClusterInput{
+		NewClusterID: "restored-enc",
+		SnapshotID:   "enc-snap",
+	})
+	requireNoError(t, err)
+	assertEqual(t, true, restored.Encrypted)
+	assertEqual(t, "arn:aws:kms:us-east-1:123456789012:key/abc-123", restored.KmsKeyID)
+
+	// DescribeClusters reflects the preserved key on the restored cluster.
+	clusters, err := m.DescribeClusters(ctx, []string{"restored-enc"})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(clusters))
+	assertEqual(t, "arn:aws:kms:us-east-1:123456789012:key/abc-123", clusters[0].KmsKeyID)
+}
+
+func TestRestoreClusterKmsKeyIDOverride(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, rdbdriver.ClusterConfig{
+		ID:        "enc-warehouse",
+		Encrypted: true,
+		KmsKeyID:  "key/original",
+	})
+	requireNoError(t, err)
+
+	_, err = m.CreateClusterSnapshot(ctx, rdbdriver.ClusterSnapshotConfig{
+		ID:        "enc-snap",
+		ClusterID: "enc-warehouse",
+	})
+	requireNoError(t, err)
+
+	restored, err := m.RestoreClusterFromSnapshot(ctx, rdbdriver.RestoreClusterInput{
+		NewClusterID: "restored-override",
+		SnapshotID:   "enc-snap",
+		KmsKeyID:     "key/override",
+	})
+	requireNoError(t, err)
+	assertEqual(t, true, restored.Encrypted)
+	assertEqual(t, "key/override", restored.KmsKeyID)
+}
+
+func TestEncryptedClusterWithoutKeyGetsDefault(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cluster, err := m.CreateCluster(ctx, rdbdriver.ClusterConfig{
+		ID:        "enc-default",
+		Encrypted: true,
+	})
+	requireNoError(t, err)
+	assertEqual(t, "alias/aws/redshift", cluster.KmsKeyID)
+
+	snap, err := m.CreateClusterSnapshot(ctx, rdbdriver.ClusterSnapshotConfig{
+		ID:        "enc-default-snap",
+		ClusterID: "enc-default",
+	})
+	requireNoError(t, err)
+	assertEqual(t, "alias/aws/redshift", snap.KmsKeyID)
+}
+
+func TestUnencryptedClusterSnapshotHasNoKmsKey(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cluster, err := m.CreateCluster(ctx, rdbdriver.ClusterConfig{ID: "plain-warehouse"})
+	requireNoError(t, err)
+	assertEqual(t, false, cluster.Encrypted)
+	assertEqual(t, "", cluster.KmsKeyID)
+
+	snap, err := m.CreateClusterSnapshot(ctx, rdbdriver.ClusterSnapshotConfig{
+		ID:        "plain-snap",
+		ClusterID: "plain-warehouse",
+	})
+	requireNoError(t, err)
+	assertEqual(t, false, snap.Encrypted)
+	assertEqual(t, "", snap.KmsKeyID)
+
+	restored, err := m.RestoreClusterFromSnapshot(ctx, rdbdriver.RestoreClusterInput{
+		NewClusterID: "restored-plain",
+		SnapshotID:   "plain-snap",
+	})
+	requireNoError(t, err)
+	assertEqual(t, false, restored.Encrypted)
+	assertEqual(t, "", restored.KmsKeyID)
+}
+
 func TestInstanceOpsRejected(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/server/aws/redshift/cluster_snapshot_attributes_sdk_roundtrip_test.go
+++ b/server/aws/redshift/cluster_snapshot_attributes_sdk_roundtrip_test.go
@@ -51,3 +51,75 @@ func TestSDKRedshiftSnapshotAttributes(t *testing.T) {
 		t.Fatalf("snapshot TotalBackupSizeInMegaBytes=%v, want a positive size", snap.TotalBackupSizeInMegaBytes)
 	}
 }
+
+// TestSDKRedshiftSnapshotPreservesKmsKeyId proves the source cluster's KmsKeyId
+// is captured on the snapshot, reported on DescribeClusterSnapshots, and carried
+// onto a restored cluster — the encryption key survives snapshot/restore so
+// aws_redshift_cluster / snapshot Terraform does not drift.
+func TestSDKRedshiftSnapshotPreservesKmsKeyId(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const kmsARN = "arn:aws:kms:us-east-1:123456789012:key/enc-key-1"
+
+	if _, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:  aws.String("kmssrc"),
+		MasterUsername:     aws.String("admin"),
+		MasterUserPassword: aws.String("Sup3rSecret!"),
+		NodeType:           aws.String("ra3.xlplus"),
+		Encrypted:          aws.Bool(true),
+		KmsKeyId:           aws.String(kmsARN),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	snapOut, err := client.CreateClusterSnapshot(ctx, &awsredshift.CreateClusterSnapshotInput{
+		SnapshotIdentifier: aws.String("kms-snap"),
+		ClusterIdentifier:  aws.String("kmssrc"),
+	})
+	if err != nil {
+		t.Fatalf("CreateClusterSnapshot: %v", err)
+	}
+
+	if !aws.ToBool(snapOut.Snapshot.Encrypted) || aws.ToString(snapOut.Snapshot.KmsKeyId) != kmsARN {
+		t.Fatalf("snapshot Encrypted/KmsKeyId = %v/%q, want true/%q",
+			aws.ToBool(snapOut.Snapshot.Encrypted), aws.ToString(snapOut.Snapshot.KmsKeyId), kmsARN)
+	}
+
+	list, err := client.DescribeClusterSnapshots(ctx, &awsredshift.DescribeClusterSnapshotsInput{
+		SnapshotIdentifier: aws.String("kms-snap"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusterSnapshots: %v", err)
+	}
+
+	if len(list.Snapshots) != 1 || aws.ToString(list.Snapshots[0].KmsKeyId) != kmsARN {
+		t.Fatalf("describe snapshot KmsKeyId = %q, want %q",
+			aws.ToString(list.Snapshots[0].KmsKeyId), kmsARN)
+	}
+
+	restored, err := client.RestoreFromClusterSnapshot(ctx, &awsredshift.RestoreFromClusterSnapshotInput{
+		ClusterIdentifier:  aws.String("kms-restored"),
+		SnapshotIdentifier: aws.String("kms-snap"),
+	})
+	if err != nil {
+		t.Fatalf("RestoreFromClusterSnapshot: %v", err)
+	}
+
+	if !aws.ToBool(restored.Cluster.Encrypted) || aws.ToString(restored.Cluster.KmsKeyId) != kmsARN {
+		t.Fatalf("restored Encrypted/KmsKeyId = %v/%q, want true/%q",
+			aws.ToBool(restored.Cluster.Encrypted), aws.ToString(restored.Cluster.KmsKeyId), kmsARN)
+	}
+
+	got, err := client.DescribeClusters(ctx, &awsredshift.DescribeClustersInput{
+		ClusterIdentifier: aws.String("kms-restored"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusters: %v", err)
+	}
+
+	if len(got.Clusters) != 1 || aws.ToString(got.Clusters[0].KmsKeyId) != kmsARN {
+		t.Fatalf("restored cluster describe KmsKeyId = %q, want %q",
+			aws.ToString(got.Clusters[0].KmsKeyId), kmsARN)
+	}
+}

--- a/server/aws/redshift/operations.go
+++ b/server/aws/redshift/operations.go
@@ -287,6 +287,7 @@ func (h *Handler) restoreFromClusterSnapshot(w http.ResponseWriter, r *http.Requ
 	input := rdbdriver.RestoreClusterInput{
 		NewClusterID: form.Get("ClusterIdentifier"),
 		SnapshotID:   form.Get("SnapshotIdentifier"),
+		KmsKeyID:     form.Get("KmsKeyId"),
 		Tags:         parseRedshiftTags(form),
 	}
 

--- a/server/aws/redshift/xml.go
+++ b/server/aws/redshift/xml.go
@@ -92,6 +92,7 @@ type snapshotXML struct {
 	NodeType                   string   `xml:"NodeType,omitempty"`
 	NumberOfNodes              int      `xml:"NumberOfNodes,omitempty"`
 	Encrypted                  bool     `xml:"Encrypted"`
+	KmsKeyID                   string   `xml:"KmsKeyId,omitempty"`
 	TotalBackupSizeInMegaBytes float64  `xml:"TotalBackupSizeInMegaBytes,omitempty"`
 	Tags                       *tagsXML `xml:"Tags,omitempty"`
 }
@@ -296,6 +297,7 @@ func toSnapshotXML(snap *rdbdriver.ClusterSnapshot) snapshotXML {
 		NodeType:                   snap.NodeType,
 		NumberOfNodes:              snap.NumberOfNodes,
 		Encrypted:                  snap.Encrypted,
+		KmsKeyID:                   snap.KmsKeyID,
 		TotalBackupSizeInMegaBytes: snap.TotalBackupSizeInMegaBytes,
 		Tags:                       toTagsXML(snap.Tags),
 	}

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -416,9 +416,14 @@ type ClusterSnapshot struct {
 	// NodeType / NumberOfNodes / Encrypted / TotalBackupSizeInMegaBytes echo the
 	// AWS Redshift snapshot attributes on read (copied from the source cluster);
 	// zero for RDS/Aurora/Azure/GCP cluster snapshots.
-	NodeType                   string
-	NumberOfNodes              int
-	Encrypted                  bool
+	NodeType      string
+	NumberOfNodes int
+	Encrypted     bool
+	// KmsKeyID is the KMS key protecting an encrypted Redshift snapshot, copied
+	// from the source cluster at snapshot time so a restore preserves the
+	// encryption key (AWS Redshift Snapshot KmsKeyId). Empty for unencrypted
+	// snapshots and for RDS/Aurora/Azure/GCP cluster snapshots.
+	KmsKeyID                   string
 	TotalBackupSizeInMegaBytes float64
 	// MasterUsername / DatabaseName capture the source cluster's admin user and
 	// database at snapshot time so a Redshift restore is a self-contained image
@@ -445,7 +450,11 @@ type RestoreInstanceInput struct {
 type RestoreClusterInput struct {
 	NewClusterID string
 	SnapshotID   string
-	Tags         map[string]string
+	// KmsKeyID overrides the encryption key on the restored cluster. When empty,
+	// the restored cluster inherits the snapshot's KmsKeyId (AWS Redshift
+	// RestoreFromClusterSnapshot KmsKeyId). Zero for RDS/Aurora/Azure/GCP.
+	KmsKeyID string
+	Tags     map[string]string
 }
 
 // RelationalDB is the interface that relational-database providers must satisfy.


### PR DESCRIPTION
## What
Redshift cluster snapshots now carry the encryption key. `ClusterSnapshot` gained a `KmsKeyID` field that:

- `CreateClusterSnapshot` copies from the source cluster (alongside the existing `Encrypted` flag).
- `DescribeClusterSnapshots` returns via the wire `snapshotXML` (`KmsKeyId`, omitempty).
- `RestoreFromClusterSnapshot` reads back onto the restored cluster — inheriting the snapshot's key, or honoring a `KmsKeyId` override supplied on the restore request.

An encrypted cluster created without an explicit key now gets the account-default `alias/aws/redshift` (mirroring the existing RDS `resolveKMSKeyID` behavior), so there is always a key to preserve.

## Why
Previously a `ClusterSnapshot` had only `Encrypted bool` and no `KmsKeyId`, so the KMS key was lost across CreateClusterSnapshot -> RestoreFromClusterSnapshot and omitted from DescribeClusterSnapshots. Real Redshift preserves the encryption key; the gap drove `aws_redshift_cluster`/snapshot Terraform drift.

## Scope / safety
`ClusterSnapshot` is shared with RDS. RDS never sets the new field, so its cluster-snapshot output is unchanged (field is `omitempty`); RDS provider + server tests pass.

## Tests
- Provider (hand-rolled helpers): encrypted cluster -> snapshot captures KmsKeyId -> Describe shows it -> restore preserves it on the new cluster (verified via DescribeClusters); restore with explicit KmsKeyId override honored; encrypted-without-key gets the default alias; unencrypted -> empty KmsKeyId + Encrypted=false through snapshot and restore.
- Server SDK round-trip: KmsKeyId survives Create -> Describe -> Restore -> DescribeClusters over the real wire.