### PR TITLE
fix(elbv2): DescribeTargetHealth Target.NotRegistered; LB provisioning->active settle

### DIFF
--- a/internal/settle/settle.go
+++ b/internal/settle/settle.go
@@ -27,6 +27,7 @@ const (
 	DefaultDBRebootSettle    = 1 * time.Second // RDS available->rebooting->available
 	DefaultCertificateSettle = 2 * time.Second // ACM PENDING_VALIDATION->ISSUED
 	DefaultExecutionSettle   = 1 * time.Second // SFN RUNNING->SUCCEEDED
+	DefaultLBSettle          = 2 * time.Second // ELBv2 provisioning->active
 )
 
 // Window is a read-time overlay describing a resource still settling into its

--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	"github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
 )
 
@@ -27,6 +28,13 @@ var (
 
 // defaultIdleTimeoutSec is the default idle timeout for load balancers in seconds.
 const defaultIdleTimeoutSec = 60
+
+// Load balancer provisioning states. A new load balancer starts in
+// provisioning and settles to active after a short window.
+const (
+	lbStateProvisioning = "provisioning"
+	lbStateActive       = "active"
+)
 
 // targetKey is the identity of a registered target within a target group.
 // AWS lets the same instance ID or IP be registered multiple times with
@@ -46,6 +54,7 @@ func keyFor(t driver.Target) targetKey {
 // Mock is an in-memory mock implementation of the AWS ELB service.
 type Mock struct {
 	lbs       *memstore.Store[driver.LBInfo]
+	lbSettle  *memstore.Store[settle.Window] // lbARN -> provisioning->active window
 	tgs       *memstore.Store[driver.TargetGroupInfo]
 	listeners *memstore.Store[driver.ListenerInfo]
 	rules     *memstore.Store[driver.RuleInfo]
@@ -70,6 +79,7 @@ type Mock struct {
 func New(opts *config.Options) *Mock {
 	return &Mock{
 		lbs:       memstore.New[driver.LBInfo](),
+		lbSettle:  memstore.New[settle.Window](),
 		tgs:       memstore.New[driver.TargetGroupInfo](),
 		listeners: memstore.New[driver.ListenerInfo](),
 		rules:     memstore.New[driver.RuleInfo](),
@@ -117,26 +127,35 @@ func (m *Mock) CreateLoadBalancer(ctx context.Context, cfg driver.LBConfig) (*dr
 		ipType = "ipv4"
 	}
 
+	now := m.opts.Clock.Now().UTC()
+
 	lb := driver.LBInfo{
 		ID:                    id,
 		ARN:                   arn,
 		Name:                  cfg.Name,
 		Type:                  cfg.Type,
 		Scheme:                cfg.Scheme,
-		State:                 "active",
+		State:                 lbStateActive,
 		DNSName:               dnsName,
 		Subnets:               subnets,
 		SecurityGroups:        sgs,
 		IPAddressType:         ipType,
 		CanonicalHostedZoneID: canonicalHostedZoneID(m.opts.Region),
 		VPCID:                 m.resolveVPCID(ctx, cfg.Subnets),
-		CreatedTime:           m.opts.Clock.Now().UTC(),
+		CreatedTime:           now,
 		Tags:                  tags,
 	}
 
 	m.lbs.Set(arn, lb)
 
+	// Real ELBv2 returns a new load balancer in "provisioning" and settles it to
+	// "active" a short time later. The window overlays the observed State at read
+	// time; the stored final State stays "active".
+	window := settle.Pending(lbStateProvisioning, now, m.opts.SettleDuration(settle.DefaultLBSettle))
+	m.lbSettle.Set(arn, window)
+
 	result := lb
+	result.State = window.Observe(now, result.State)
 
 	return &result, nil
 }
@@ -195,6 +214,7 @@ func (m *Mock) DeleteLoadBalancer(_ context.Context, arn string) error {
 	}
 
 	m.lbs.Delete(arn)
+	m.lbSettle.Delete(arn)
 
 	// Delete listeners for this load balancer and, with them, the rules under
 	// those listeners. Leaving the rules behind would leak them for the life of
@@ -241,7 +261,17 @@ func (m *Mock) DescribeLoadBalancers(_ context.Context, arns []string) ([]driver
 		}
 	}
 
-	return describeResources(m.lbs, arns), nil
+	out := describeResources(m.lbs, arns)
+
+	now := m.opts.Clock.Now()
+
+	for i := range out {
+		if w, ok := m.lbSettle.Get(out[i].ARN); ok {
+			out[i].State = w.Observe(now, out[i].State)
+		}
+	}
+
+	return out, nil
 }
 
 // CreateTargetGroup creates a new target group.

--- a/providers/aws/elbv2/elb_test.go
+++ b/providers/aws/elbv2/elb_test.go
@@ -64,6 +64,8 @@ func TestCreateLoadBalancer(t *testing.T) {
 			assertNotEmpty(t, info.ARN)
 			assertNotEmpty(t, info.DNSName)
 			assertEqual(t, "my-lb", info.Name)
+			// Async settling is opt-in; with the default options a new load
+			// balancer reports its terminal state immediately.
 			assertEqual(t, "active", info.State)
 		})
 	}
@@ -380,6 +382,33 @@ func TestDescribeTargetHealth(t *testing.T) {
 		_, err := m.DescribeTargetHealth(ctx, "arn:nope")
 		assertError(t, err, true)
 	})
+}
+
+// TestCreateLoadBalancerSettlesProvisioningToActive verifies the AWS-realistic
+// provisioning->active transition when async settling is enabled: a new load
+// balancer is observed as "provisioning" until the settle window elapses, then
+// "active". The transition is driven purely by the clock — no wall-clock sleep.
+func TestCreateLoadBalancerSettlesProvisioningToActive(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithAsyncSettle(),
+		config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))
+	m := New(opts)
+	ctx := context.Background()
+
+	lb, err := m.CreateLoadBalancer(ctx, driver.LBConfig{Name: "my-lb", Type: "application"})
+	requireNoError(t, err)
+	assertEqual(t, "provisioning", lb.State)
+
+	// Still provisioning before the window elapses.
+	got, err := m.DescribeLoadBalancers(ctx, []string{lb.ARN})
+	requireNoError(t, err)
+	assertEqual(t, "provisioning", got[0].State)
+
+	// Advancing the clock past the settle window transitions it to active.
+	fc.Advance(5 * time.Second)
+	got, err = m.DescribeLoadBalancers(ctx, []string{lb.ARN})
+	requireNoError(t, err)
+	assertEqual(t, "active", got[0].State)
 }
 
 func TestSetTargetHealth(t *testing.T) {

--- a/server/aws/elbv2/modify_test.go
+++ b/server/aws/elbv2/modify_test.go
@@ -477,6 +477,94 @@ func TestSDKTargetHealthAdvances(t *testing.T) {
 	}
 }
 
+// TestSDKDescribeTargetHealthUnregisteredTarget proves DescribeTargetHealth
+// with an explicit target that is not registered returns a description with
+// State=unused and Reason=Target.NotRegistered (rather than silently dropping
+// it), while a registered target in the same call keeps its real health. With
+// no explicit Targets, only registered targets come back.
+func TestSDKDescribeTargetHealthUnregisteredTarget(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	tgOut, err := client.CreateTargetGroup(ctx, &elb.CreateTargetGroupInput{
+		Name:     aws.String("nr-tg"),
+		Protocol: elbtypes.ProtocolEnumHttp,
+		Port:     aws.Int32(80),
+		VpcId:    aws.String("vpc-1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	tgARN := aws.ToString(tgOut.TargetGroups[0].TargetGroupArn)
+
+	if _, err := client.RegisterTargets(ctx, &elb.RegisterTargetsInput{
+		TargetGroupArn: aws.String(tgARN),
+		Targets:        []elbtypes.TargetDescription{{Id: aws.String("i-1"), Port: aws.Int32(80)}},
+	}); err != nil {
+		t.Fatalf("RegisterTargets: %v", err)
+	}
+
+	// Explicit query mixing a registered and an unregistered target.
+	out, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(tgARN),
+		Targets: []elbtypes.TargetDescription{
+			{Id: aws.String("i-1"), Port: aws.Int32(80)},
+			{Id: aws.String("i-missing"), Port: aws.Int32(80)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DescribeTargetHealth: %v", err)
+	}
+
+	if len(out.TargetHealthDescriptions) != 2 {
+		t.Fatalf("descriptions = %d, want 2", len(out.TargetHealthDescriptions))
+	}
+
+	byID := map[string]elbtypes.TargetHealthDescription{}
+	for _, d := range out.TargetHealthDescriptions {
+		byID[aws.ToString(d.Target.Id)] = d
+	}
+
+	reg, ok := byID["i-1"]
+	if !ok {
+		t.Fatal("registered target i-1 missing from response")
+	}
+
+	if reg.TargetHealth.State != elbtypes.TargetHealthStateEnumInitial {
+		t.Errorf("registered state = %q, want initial", reg.TargetHealth.State)
+	}
+
+	nr, ok := byID["i-missing"]
+	if !ok {
+		t.Fatal("unregistered target i-missing missing from response")
+	}
+
+	if nr.TargetHealth.State != elbtypes.TargetHealthStateEnumUnused {
+		t.Errorf("unregistered state = %q, want unused", nr.TargetHealth.State)
+	}
+
+	if nr.TargetHealth.Reason != elbtypes.TargetHealthReasonEnumNotRegistered {
+		t.Errorf("unregistered reason = %q, want Target.NotRegistered", nr.TargetHealth.Reason)
+	}
+
+	// With no explicit Targets, only the registered target is returned.
+	all, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(tgARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeTargetHealth (all): %v", err)
+	}
+
+	if len(all.TargetHealthDescriptions) != 1 {
+		t.Fatalf("no-filter descriptions = %d, want 1", len(all.TargetHealthDescriptions))
+	}
+
+	if got := aws.ToString(all.TargetHealthDescriptions[0].Target.Id); got != "i-1" {
+		t.Errorf("no-filter target = %q, want i-1", got)
+	}
+}
+
 // TestSDKTargetGroupAttributes proves DescribeTargetGroupAttributes and
 // ModifyTargetGroupAttributes dispatch (instead of returning InvalidAction) and
 // that a modified attribute merges over the ELBv2 defaults and round-trips.

--- a/server/aws/elbv2/operations.go
+++ b/server/aws/elbv2/operations.go
@@ -743,18 +743,47 @@ func filterListeners(lis []lbdriver.ListenerInfo, wanted []string) []lbdriver.Li
 	return out
 }
 
-// filterHealth keeps only the health entries whose target ID appears in wanted.
+// healthKey identifies a registered target by (ID, Port). AWS lets the same
+// instance ID be registered on multiple ports, so a bare ID is not unique.
+type healthKey struct {
+	id   string
+	port int
+}
+
+// filterHealth resolves the health for the explicitly requested targets. Real
+// ELBv2 does not silently drop a requested target that isn't registered: it
+// returns a TargetHealthDescription with State=unused and
+// Reason=Target.NotRegistered. Registered targets keep their real health. A
+// requested target with no port matches every registration of that instance ID.
 func filterHealth(health []lbdriver.TargetHealth, wanted []lbdriver.Target) []lbdriver.TargetHealth {
-	set := make(map[string]struct{}, len(wanted))
-	for _, t := range wanted {
-		set[t.ID] = struct{}{}
+	byKey := make(map[healthKey]lbdriver.TargetHealth, len(health))
+	byID := make(map[string][]lbdriver.TargetHealth, len(health))
+
+	for i := range health {
+		t := health[i].Target
+		byKey[healthKey{t.ID, t.Port}] = health[i]
+		byID[t.ID] = append(byID[t.ID], health[i])
 	}
 
-	out := health[:0]
-	for i := range health {
-		if _, ok := set[health[i].Target.ID]; ok {
-			out = append(out, health[i])
+	out := make([]lbdriver.TargetHealth, 0, len(wanted))
+
+	for _, w := range wanted {
+		if w.Port != 0 {
+			if h, ok := byKey[healthKey{w.ID, w.Port}]; ok {
+				out = append(out, h)
+				continue
+			}
+		} else if hs, ok := byID[w.ID]; ok {
+			out = append(out, hs...)
+			continue
 		}
+
+		out = append(out, lbdriver.TargetHealth{
+			Target:      w,
+			State:       "unused",
+			Reason:      "Target.NotRegistered",
+			Description: "Target is not registered to the target group",
+		})
 	}
 
 	return out


### PR DESCRIPTION
## What

Two AWS ELBv2 fidelity fixes to match real cloud behavior.

**GAP 1 — DescribeTargetHealth on an unregistered target.** Real ELBv2 does not silently drop a target that an explicit `Targets` query names but that isn't registered to the target group — it returns a `TargetHealthDescription` with `State=unused` and `Reason=Target.NotRegistered`. The wire handler's `filterHealth` previously dropped such targets. It now iterates the requested targets, returns real health for registered ones (matching on `(ID, Port)`, or all registrations of an ID when no port is given), and emits a synthetic `unused` / `Target.NotRegistered` description for the rest. With no explicit `Targets`, only registered targets are returned (unchanged).

**GAP 2 — Load balancer provisioning -> active.** Real ELBv2 returns a new load balancer in `provisioning` and settles it to `active` shortly after. `CreateLoadBalancer` now registers a `settle.Window` (intermediate `provisioning`, final `active`); `CreateLoadBalancer` and `DescribeLoadBalancers` overlay the observed state at read time. This reuses the existing `internal/settle` read-time overlay (same pattern as EC2 instance/volume and ACM cert settling), is clock-driven with no wall-clock sleeps, and is gated behind the opt-in `WithAsyncSettle()` option — default behavior reports the terminal state immediately.

## Why

Matches real AWS semantics so SDK waiters and health-polling flows behave as they do against the real service.

## Tests

- Provider: `CreateLoadBalancer` with `WithAsyncSettle` reports `provisioning`, then `active` after the clock advances past the settle window (FakeClock, deterministic).
- Server (SDK roundtrip): `DescribeTargetHealth` with a mixed registered + unregistered explicit target returns `initial` for the registered one and `unused` / `Target.NotRegistered` for the unregistered one; with no explicit targets, only the registered target is returned.

Gates: build, vet, scoped tests, gofmt, golangci-lint (0 issues), `go generate` + compatgen zero-diff.
