### PR TITLE
fix(route53): paginate ListHostedZonesByVPC (MaxItems/NextToken)

### DIFF
--- a/server/aws/route53/vpc.go
+++ b/server/aws/route53/vpc.go
@@ -172,17 +172,17 @@ func (h *Handler) listHostedZonesByVPC(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	maxItems := listMaxItems
-
-	if v := q.Get("maxitems"); v != "" {
-		if n, cerr := strconv.Atoi(v); cerr == nil && n > 0 {
-			maxItems = n
-		}
-	}
+	// ListHostedZonesByVPC paginates NextToken-style: maxitems bounds the page and
+	// NextToken (echoed back as nexttoken) resumes at the following zone id. Reuse
+	// the shared marker paginator keyed by the unique HostedZoneId so tokens never
+	// duplicate or skip a summary.
+	maxItems := parseMaxItems(q.Get("maxitems"))
+	page, next := markerPage(summaries, q.Get("nexttoken"), maxItems, func(s hostedZoneSummaryXML) string { return s.HostedZoneId })
 
 	wire.WriteXML(w, http.StatusOK, listHostedZonesByVPCResponse{
 		Xmlns:               xmlns,
-		HostedZoneSummaries: summaries,
+		HostedZoneSummaries: page,
 		MaxItems:            strconv.Itoa(maxItems),
+		NextToken:           next,
 	})
 }

--- a/server/aws/route53/vpc_association_test.go
+++ b/server/aws/route53/vpc_association_test.go
@@ -3,6 +3,7 @@ package route53_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -292,5 +293,112 @@ func TestSDKListHostedZonesByVPC(t *testing.T) {
 	if out.HostedZoneSummaries[0].Owner == nil ||
 		aws.ToString(out.HostedZoneSummaries[0].Owner.OwningAccount) == "" {
 		t.Errorf("summary Owner = %+v, want an OwningAccount", out.HostedZoneSummaries[0].Owner)
+	}
+}
+
+// TestSDKListHostedZonesByVPCPaginates associates several private zones with one
+// VPC and walks ListHostedZonesByVPC with a small MaxItems, asserting each page
+// is bounded by MaxItems, NextToken continues, and every zone is returned exactly
+// once — no duplicate, no skip — across the NextToken walk.
+func TestSDKListHostedZonesByVPCPaginates(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	const total = 5
+	want := make(map[string]int, total)
+	for i := range total {
+		id := createPrivateZone(t, client,
+			fmt.Sprintf("vpczone-%d.internal.", i), fmt.Sprintf("vpc-page-ref-%d", i), "vpc-page")
+		want[id] = 0
+	}
+
+	got := make(map[string]int, total)
+	var token *string
+	for pages := 0; ; pages++ {
+		if pages > pageWalkLimit {
+			t.Fatal("ListHostedZonesByVPC did not terminate — NextToken never cleared")
+		}
+
+		out, err := client.ListHostedZonesByVPC(ctx, &awsr53.ListHostedZonesByVPCInput{
+			VPCId:     aws.String("vpc-page"),
+			VPCRegion: r53types.VPCRegionUsEast1,
+			MaxItems:  aws.Int32(2),
+			NextToken: token,
+		})
+		if err != nil {
+			t.Fatalf("ListHostedZonesByVPC: %v", err)
+		}
+
+		if n := len(out.HostedZoneSummaries); n > 2 {
+			t.Fatalf("page returned %d summaries, want <= MaxItems 2", n)
+		}
+
+		if aws.ToInt32(out.MaxItems) != 2 {
+			t.Errorf("echoed MaxItems = %d, want 2", aws.ToInt32(out.MaxItems))
+		}
+
+		for i := range out.HostedZoneSummaries {
+			got[aws.ToString(out.HostedZoneSummaries[i].HostedZoneId)]++
+		}
+
+		if aws.ToString(out.NextToken) == "" {
+			break
+		}
+
+		token = out.NextToken
+	}
+
+	assertEachOnce(t, want, got)
+}
+
+// TestSDKListHostedZonesByVPCStableOrder proves the summaries come back in a
+// stable HostedZoneId order across the paginated walk, so a NextToken resumes at
+// exactly the next zone.
+func TestSDKListHostedZonesByVPCStableOrder(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	const total = 4
+	for i := range total {
+		createPrivateZone(t, client,
+			fmt.Sprintf("ordered-%d.internal.", i), fmt.Sprintf("vpc-order-ref-%d", i), "vpc-order")
+	}
+
+	var ids []string
+	var token *string
+	for pages := 0; ; pages++ {
+		if pages > pageWalkLimit {
+			t.Fatal("ListHostedZonesByVPC did not terminate")
+		}
+
+		out, err := client.ListHostedZonesByVPC(ctx, &awsr53.ListHostedZonesByVPCInput{
+			VPCId:     aws.String("vpc-order"),
+			VPCRegion: r53types.VPCRegionUsEast1,
+			MaxItems:  aws.Int32(1),
+			NextToken: token,
+		})
+		if err != nil {
+			t.Fatalf("ListHostedZonesByVPC: %v", err)
+		}
+
+		for i := range out.HostedZoneSummaries {
+			ids = append(ids, aws.ToString(out.HostedZoneSummaries[i].HostedZoneId))
+		}
+
+		if aws.ToString(out.NextToken) == "" {
+			break
+		}
+
+		token = out.NextToken
+	}
+
+	if len(ids) != total {
+		t.Fatalf("walked %d summaries, want %d", len(ids), total)
+	}
+
+	for i := 1; i < len(ids); i++ {
+		if ids[i-1] >= ids[i] {
+			t.Errorf("summaries not in strictly increasing id order: %q then %q", ids[i-1], ids[i])
+		}
 	}
 }


### PR DESCRIPTION
## Summary

`ListHostedZonesByVPC` read `maxitems` but never truncated the result or emitted a `NextToken`, so it always returned every matching private hosted zone in one unbounded, unordered page. Real Route 53 returns at most `MaxItems` `HostedZoneSummary` entries and, when more remain, a `NextToken` that a follow-up call resumes from.

## What changed
- `server/aws/route53/vpc.go`: `listHostedZonesByVPC` now paginates via the package's shared `markerPage` helper (the same one backing `ListHostedZones`/`ListHealthChecks`), keyed by the unique `HostedZoneId` for a deterministic, stable order. Reads the `nexttoken` query param, echoes the clamped `MaxItems`, and returns `NextToken` only when the page is truncated.
- `maxitems` is now parsed through the shared `parseMaxItems` (clamped to [1,100]) for consistency with the other Route 53 list ops.

## Tests
- `TestSDKListHostedZonesByVPCPaginates`: walks 5 zones on one VPC with `MaxItems=2`; asserts each page is bounded, `NextToken` continues, and every zone is returned exactly once (no dup/skip).
- `TestSDKListHostedZonesByVPCStableOrder`: `MaxItems=1` walk asserts strictly increasing `HostedZoneId` order across pages.

## Note on the apex SOA/NS ordering (deferred)
This branch was also scoped to flip the apex record tiebreak to SOA-before-NS. Verified against the AWS Route 53 API reference: `ListResourceRecordSets` is documented to return records "in ASCII order" sorted by name then type, and in ASCII "NS" < "SOA", so NS sorts before SOA — which is exactly what the current code does. The docs do not support the SOA-first claim, so the apex ordering is left unchanged and this gap is deferred pending a real-cloud capture.

## Gates
build / vet / scoped tests / gofmt / golangci-lint (new-from-development) all green; `go generate` and `compatgen` produce zero doc diff.