### PR TITLE
fix(kinesis): shard iterators expire after 5 minutes

### DIFF
--- a/providers/aws/kinesis/kinesis_test.go
+++ b/providers/aws/kinesis/kinesis_test.go
@@ -3,6 +3,7 @@ package kinesis_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/providers/aws/kinesis"
@@ -167,5 +168,143 @@ func TestPutRecordsRejectsTooManyRecords(t *testing.T) {
 	apiErr, ok := err.(*driver.APIError)
 	if !ok || apiErr.Exception != driver.ExValidation {
 		t.Fatalf("501-record batch should be ValidationException, got %v", err)
+	}
+}
+
+// newMockClock builds a Kinesis mock driven by a FakeClock so iterator expiry is
+// deterministic.
+func newMockClock(t *testing.T) (*kinesis.Mock, *config.FakeClock) {
+	t.Helper()
+
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	return kinesis.New(config.NewOptions(config.WithClock(clk))), clk
+}
+
+// seedShard creates a single-shard stream, writes n records, and returns the
+// shard id.
+func seedShard(t *testing.T, ctx context.Context, m *kinesis.Mock, n int) string {
+	t.Helper()
+
+	if err := m.CreateStream(ctx, driver.CreateStreamInput{StreamName: "s", ShardCount: 1}); err != nil {
+		t.Fatalf("CreateStream: %v", err)
+	}
+
+	for i := 0; i < n; i++ {
+		if _, err := m.PutRecord(ctx, driver.PutRecordInput{StreamName: "s", PartitionKey: "k", Data: []byte{byte(i)}}); err != nil {
+			t.Fatalf("PutRecord: %v", err)
+		}
+	}
+
+	desc, err := m.DescribeStream(ctx, "s", "", 0, "")
+	if err != nil {
+		t.Fatalf("DescribeStream: %v", err)
+	}
+
+	return desc.Shards[0].ShardID
+}
+
+func trimHorizonIterator(t *testing.T, ctx context.Context, m *kinesis.Mock, shardID string) string {
+	t.Helper()
+
+	it, err := m.GetShardIterator(ctx, driver.GetShardIteratorInput{
+		StreamName: "s", ShardID: shardID, ShardIteratorType: driver.IteratorTrimHorizon,
+	})
+	if err != nil {
+		t.Fatalf("GetShardIterator: %v", err)
+	}
+
+	return it
+}
+
+func TestShardIteratorValidWithinTTL(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newMockClock(t)
+
+	shardID := seedShard(t, ctx, m, 3)
+	it := trimHorizonIterator(t, ctx, m, shardID)
+
+	// Just under the 5-minute window: the iterator still works.
+	clk.Advance(5*time.Minute - time.Second)
+
+	out, err := m.GetRecords(ctx, it, 10)
+	if err != nil {
+		t.Fatalf("GetRecords within TTL: %v", err)
+	}
+
+	if len(out.Records) != 3 {
+		t.Fatalf("want 3 records, got %d", len(out.Records))
+	}
+}
+
+func TestShardIteratorExpiresAfterTTL(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newMockClock(t)
+
+	shardID := seedShard(t, ctx, m, 1)
+	it := trimHorizonIterator(t, ctx, m, shardID)
+
+	// Past the 5-minute window: GetRecords must reject the iterator.
+	clk.Advance(5*time.Minute + time.Second)
+
+	_, err := m.GetRecords(ctx, it, 10)
+
+	apiErr, ok := err.(*driver.APIError)
+	if !ok || apiErr.Exception != driver.ExExpiredIterator {
+		t.Fatalf("expired iterator should be ExpiredIteratorException, got %v", err)
+	}
+}
+
+func TestGetRecordsRefreshesNextShardIterator(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newMockClock(t)
+
+	shardID := seedShard(t, ctx, m, 1)
+	it := trimHorizonIterator(t, ctx, m, shardID)
+
+	// A client polling in a loop: each GetRecords advances the clock by nearly
+	// the full window, but the refreshed NextShardIterator keeps it alive.
+	for i := 0; i < 5; i++ {
+		out, err := m.GetRecords(ctx, it, 10)
+		if err != nil {
+			t.Fatalf("GetRecords poll %d: %v", i, err)
+		}
+
+		clk.Advance(5*time.Minute - time.Second)
+		it = out.NextShardIterator
+	}
+}
+
+func TestExpiredIteratorForMissingShard(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newMockClock(t)
+
+	seedShard(t, ctx, m, 1)
+
+	// Split the single shard so a higher-indexed child shard (shardId-...002)
+	// exists, and grab an iterator positioned on it.
+	if err := m.SplitShard(ctx, "s", "", "shardId-000000000000",
+		"170141183460469231731687303715884105728"); err != nil {
+		t.Fatalf("SplitShard: %v", err)
+	}
+
+	it := trimHorizonIterator(t, ctx, m, "shardId-000000000002")
+
+	// Recreate the stream with a single shard so the token's stream lookup
+	// succeeds but its shard id no longer exists: the missing-shard
+	// ExpiredIterator path must still fire.
+	if err := m.DeleteStream(ctx, "s", "", true); err != nil {
+		t.Fatalf("DeleteStream: %v", err)
+	}
+
+	if err := m.CreateStream(ctx, driver.CreateStreamInput{StreamName: "s", ShardCount: 1}); err != nil {
+		t.Fatalf("CreateStream: %v", err)
+	}
+
+	_, err := m.GetRecords(ctx, it, 10)
+
+	apiErr, ok := err.(*driver.APIError)
+	if !ok || apiErr.Exception != driver.ExExpiredIterator {
+		t.Fatalf("missing shard should be ExpiredIteratorException, got %v", err)
 	}
 }

--- a/providers/aws/kinesis/records.go
+++ b/providers/aws/kinesis/records.go
@@ -19,6 +19,10 @@ const (
 	// maxBatchRecords / maxBatchBytes are the PutRecords request limits.
 	maxBatchRecords = 500
 	maxBatchBytes   = 5 << 20
+	// shardIteratorTTL is how long a shard iterator stays valid after it is
+	// returned. Real Kinesis expires iterators 5 minutes after creation; a
+	// GetRecords call refreshes the NextShardIterator it hands back.
+	shardIteratorTTL = 5 * time.Minute
 )
 
 // recordSizeLimit returns the per-record byte cap for a stream, honoring a
@@ -55,10 +59,14 @@ func validateBatchSize(sd *streamData, entries []driver.PutRecordsRequestEntry) 
 
 // iteratorToken is the opaque state a shard iterator carries. Records are never
 // trimmed in the emulator, so a stable slice index is a sufficient cursor.
+// CreatedAtMillis stamps when the iterator was minted (Unix milliseconds) so
+// GetRecords can reject iterators older than shardIteratorTTL without any extra
+// server-side state.
 type iteratorToken struct {
-	StreamName string `json:"s"`
-	ShardID    string `json:"h"`
-	NextIndex  int    `json:"i"`
+	StreamName      string `json:"s"`
+	ShardID         string `json:"h"`
+	NextIndex       int    `json:"i"`
+	CreatedAtMillis int64  `json:"c"`
 }
 
 func encodeIterator(t iteratorToken) string {
@@ -253,7 +261,18 @@ func (m *Mock) GetShardIterator(_ context.Context, in driver.GetShardIteratorInp
 		return "", err
 	}
 
-	return encodeIterator(iteratorToken{StreamName: sd.desc.StreamName, ShardID: in.ShardID, NextIndex: idx}), nil
+	return m.encodeFreshIterator(sd.desc.StreamName, in.ShardID, idx), nil
+}
+
+// encodeFreshIterator mints an iterator stamped with the current clock time, so
+// its shardIteratorTTL window starts now.
+func (m *Mock) encodeFreshIterator(streamName, shardID string, nextIndex int) string {
+	return encodeIterator(iteratorToken{
+		StreamName:      streamName,
+		ShardID:         shardID,
+		NextIndex:       nextIndex,
+		CreatedAtMillis: m.now().UnixMilli(),
+	})
 }
 
 // findShardByID returns the shard with the given id, or nil.
@@ -320,6 +339,13 @@ func (m *Mock) GetRecords(_ context.Context, shardIterator string, limit int32) 
 		return nil, err
 	}
 
+	createdAt := time.UnixMilli(tok.CreatedAtMillis).UTC()
+	if m.now().Sub(createdAt) > shardIteratorTTL {
+		return nil, expiredIterator(
+			"Iterator expired. The iterator was created at time %s which is now expired.",
+			createdAt.Format(time.RFC1123))
+	}
+
 	sd, ok := m.streams.Get(tok.StreamName)
 	if !ok {
 		return nil, errNotFoundName(tok.StreamName)
@@ -345,7 +371,7 @@ func (m *Mock) GetRecords(_ context.Context, shardIterator string, limit int32) 
 
 	out := &driver.GetRecordsOutput{
 		Records:            recs,
-		NextShardIterator:  encodeIterator(iteratorToken{StreamName: tok.StreamName, ShardID: tok.ShardID, NextIndex: end}),
+		NextShardIterator:  m.encodeFreshIterator(tok.StreamName, tok.ShardID, end),
 		MillisBehindLatest: 0,
 	}
 


### PR DESCRIPTION
## What

AWS Kinesis shard iterators returned by `GetShardIterator` are valid for only **5 minutes**. Using an expired iterator in `GetRecords` must return `ExpiredIteratorException`. The emulator previously never expired iterators — the `iteratorToken` carried no timestamp, and `ExpiredIteratorException` was only raised when the shard itself was missing.

## Changes

- Extend the opaque `iteratorToken` with a `CreatedAtMillis` stamp (encoded into the existing base64/JSON token, so expiry needs no extra server state).
- `GetShardIterator` stamps the iterator with the current clock time.
- `GetRecords` rejects an iterator older than 5 minutes with `ExpiredIteratorException` ("Iterator expired. The iterator was created at time ... which is now expired.").
- The `NextShardIterator` returned by `GetRecords` gets a **fresh** 5-minute window, so a client polling in a loop keeps working — each poll refreshes.

## Why

Matches real Kinesis semantics: iterators are short-lived and refreshed by polling. Long-lived reuse of a stale iterator now fails as it does on AWS.

## Notes

- Uses the package's `config.Clock` (`m.now()`), so `FakeClock` tests are deterministic — no wall-clock `time.Now()`.
- The existing missing-shard `ExpiredIteratorException` path is unchanged.

## Tests

New `FakeClock`-driven tests (provider hand-rolled helpers, no testify): iterator valid within 5 min; expires past 5 min; `NextShardIterator` refreshes across many polls; missing-shard path still fires.