### PR TITLE
fix(chaos): bind scenario windows to the engine clock at Apply so FakeClock tests activate

### DIFF
--- a/features/chaos/chaos.go
+++ b/features/chaos/chaos.go
@@ -93,9 +93,21 @@ func New(clock config.Clock) *Engine {
 	}
 }
 
+// clockBinder is implemented by scenarios whose active window is anchored to
+// the engine clock. Apply binds them at registration time so that time-bounded
+// scenarios start "now" on the engine's clock — including a FakeClock — rather
+// than on wall-clock at construction.
+type clockBinder interface {
+	bind(now time.Time)
+}
+
 // Apply registers a scenario. The returned Active can be used to stop it
 // before it expires.
 func (e *Engine) Apply(s Scenario) *Active {
+	if b, ok := s.(clockBinder); ok {
+		b.bind(e.clock.Now())
+	}
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 

--- a/features/chaos/scenarios.go
+++ b/features/chaos/scenarios.go
@@ -8,17 +8,40 @@ import (
 )
 
 // window holds the common "active from start to start+duration" timing logic.
-// All scenarios with a duration embed it.
+// All scenarios with a duration embed it. The start (and thus end) is bound to
+// the engine's clock when the scenario is applied — see bind — so the window is
+// relative to the engine clock, not wall-clock at construction. This keeps
+// FakeClock-driven deterministic tests working. Until bound, the window is
+// inactive.
 type window struct {
-	start time.Time
-	end   time.Time
+	duration time.Duration
+	start    time.Time
+	end      time.Time
+	bound    bool
 }
 
-func newWindow(start time.Time, duration time.Duration) window {
-	return window{start: start, end: start.Add(duration)}
+func newWindow(duration time.Duration) window {
+	return window{duration: duration}
+}
+
+// bind stamps the window's start/end from now (the engine clock at Apply time).
+// It is idempotent: an already-bound window keeps its original start, so a
+// scenario is only ever anchored once.
+func (w *window) bind(now time.Time) {
+	if w.bound {
+		return
+	}
+
+	w.start = now
+	w.end = now.Add(w.duration)
+	w.bound = true
 }
 
 func (w window) active(now time.Time) bool {
+	if !w.bound {
+		return false
+	}
+
 	return !now.Before(w.start) && now.Before(w.end)
 }
 
@@ -33,7 +56,7 @@ type outage struct {
 // after the window, calls succeed normally again.
 func ServiceOutage(svc string, duration time.Duration) Scenario {
 	return &outage{
-		window:  newWindow(nowOrEpoch(), duration),
+		window:  newWindow(duration),
 		service: svc,
 	}
 }
@@ -59,7 +82,7 @@ type latencySpike struct {
 // for the next duration window. Useful for testing client-side timeouts.
 func LatencySpike(svc string, extra, duration time.Duration) Scenario {
 	return &latencySpike{
-		window:  newWindow(nowOrEpoch(), duration),
+		window:  newWindow(duration),
 		service: svc,
 		extra:   extra,
 	}
@@ -89,7 +112,7 @@ type probabilisticFailure struct {
 // to every operation on the service.
 func ProbabilisticFailure(svc, op string, err error, p float64, duration time.Duration) Scenario {
 	return &probabilisticFailure{
-		window:  newWindow(nowOrEpoch(), duration),
+		window:  newWindow(duration),
 		service: svc,
 		op:      op,
 		err:     err,
@@ -137,7 +160,7 @@ func Throttle(svc, op string, qps int, duration time.Duration) Scenario {
 	}
 
 	return &throttle{
-		window:  newWindow(nowOrEpoch(), duration),
+		window:  newWindow(duration),
 		service: svc,
 		op:      op,
 		qps:     qps,
@@ -208,7 +231,12 @@ func (c *composite) Active(now time.Time) bool {
 	return false
 }
 
-// nowOrEpoch returns the wall-clock time. Scenarios constructed by callers
-// outside the engine don't have access to the engine's clock, so they pin
-// their start time at construction; the engine still drives expiry via Active.
-func nowOrEpoch() time.Time { return time.Now() }
+// bind propagates the engine clock to every child that has a time-bounded
+// window, so a composite anchors all its children at Apply time.
+func (c *composite) bind(now time.Time) {
+	for _, s := range c.scenarios {
+		if b, ok := s.(clockBinder); ok {
+			b.bind(now)
+		}
+	}
+}

--- a/features/chaos/scenarios_test.go
+++ b/features/chaos/scenarios_test.go
@@ -298,3 +298,59 @@ func TestCompositeEmptyIsSafe(t *testing.T) {
 		t.Errorf("empty composite should produce zero effect, got %+v", eff)
 	}
 }
+
+// TestServiceOutageFakeClockActivatesAndRecovers proves the documented
+// deterministic-chaos path: a time-bounded scenario applied against a FakeClock
+// activates at the fake "now", stays active as the clock advances inside the
+// window, and auto-recovers once the clock advances past the window. Before the
+// window was bound to the engine clock at Apply time, the scenario's start was
+// stamped from wall-clock and this scenario never activated under a FakeClock.
+func TestServiceOutageFakeClockActivatesAndRecovers(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	e := chaos.New(fc)
+	defer e.Stop()
+
+	e.Apply(chaos.ServiceOutage("storage", 5*time.Minute))
+
+	// Active immediately at fake now.
+	if eff := e.Check("storage", "PutObject"); eff.Error == nil {
+		t.Fatal("expected outage to be active at fake now")
+	}
+
+	// Still active while advancing within the window.
+	fc.Advance(4 * time.Minute)
+
+	if eff := e.Check("storage", "PutObject"); eff.Error == nil {
+		t.Fatal("expected outage to remain active inside the window")
+	}
+
+	// Auto-recovers after advancing past the window.
+	fc.Advance(2 * time.Minute)
+
+	if eff := e.Check("storage", "PutObject"); eff.Error != nil {
+		t.Errorf("expected auto-recovery past the window, got %v", eff.Error)
+	}
+}
+
+// TestCompositeFakeClockBindsChildren ensures a composite anchors its children
+// to the engine clock too, so nested time-bounded scenarios activate under a
+// FakeClock.
+func TestCompositeFakeClockBindsChildren(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	e := chaos.New(fc)
+	defer e.Stop()
+
+	e.Apply(chaos.Composite(
+		chaos.LatencySpike("storage", 10*time.Millisecond, 5*time.Minute),
+	))
+
+	if eff := e.Check("storage", "Op"); eff.Latency != 10*time.Millisecond {
+		t.Fatalf("expected composite child active under FakeClock, got %v", eff.Latency)
+	}
+
+	fc.Advance(6 * time.Minute)
+
+	if eff := e.Check("storage", "Op"); eff.Latency != 0 {
+		t.Errorf("expected composite child to expire past the window, got %v", eff.Latency)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a HIGH-severity determinism bug: time-bounded chaos scenarios never activated under a `config.FakeClock`, silently breaking the documented deterministic-chaos-testing path.

## The bug

Scenario constructors (`ServiceOutage`, `LatencySpike`, `Throttle`, `ProbabilisticFailure`, and `Composite` children) stamped their active-window `start` from raw wall-clock `time.Now()` at **construction** time. But the engine evaluates `window.active(now)` using its **injected clock** (`e.clock.Now()`).

When a caller passes a `FakeClock` pinned to, e.g., 2024-01-01 (as every FakeClock test does), `fakeNow(2024)` is `Before` the wall-clock `start(2026)`, so `window.active()` is always false and no time-bounded scenario ever fires. The `chaos.New` doc comment explicitly advertises "Pass a config.FakeClock for deterministic tests" — a path that was broken and uncaught (no chaos test used a FakeClock).

## The fix

The window `start`/`end` are now bound to the **engine's clock at Apply time** rather than baked from wall-clock at construction:

- `window` now carries a `duration` and binds its absolute `start`/`end` via a new idempotent `bind(now)` method.
- `Engine.Apply` calls `bind(e.clock.Now())` on any scenario implementing the unexported `clockBinder` interface, so the window starts "now" on the engine's clock.
- `Composite` propagates `bind` to its children.

Real-clock behavior is unchanged (constructing then immediately applying binds to a near-identical time). Auto-recovery/expiry, the first-error-wins/latency-sum/composite merge logic, and event recording are all preserved.

## Tests

- Added `TestServiceOutageFakeClockActivatesAndRecovers`: a 5-minute outage under a FakeClock activates at fake now, stays active while the clock advances inside the window, and auto-recovers after it advances past the window. This test **fails against the old code** and passes with the fix.
- Added `TestCompositeFakeClockBindsChildren` covering composite child binding under a FakeClock.
- All existing real-clock tests remain green (behavior unchanged).
