### PR TITLE
fix(azure-vm): case-insensitive resource-group and resource-name lookup (VM + scale sets)

### DIFF
--- a/server/azure/echo_properties.go
+++ b/server/azure/echo_properties.go
@@ -33,6 +33,8 @@ func newPropertyOverlay() *propertyOverlay {
 // entry. An empty set clears the entry so a resource that no longer carries
 // unmodeled properties (e.g. re-created without them) does not keep stale ones.
 func (o *propertyOverlay) capture(id string, unmodeled map[string]any) {
+	id = normalizeOverlayKey(id)
+
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
@@ -46,10 +48,42 @@ func (o *propertyOverlay) capture(id string, unmodeled map[string]any) {
 
 // lookup returns the unmodeled properties recorded for id, or nil.
 func (o *propertyOverlay) lookup(id string) map[string]any {
+	id = normalizeOverlayKey(id)
+
 	o.mu.RLock()
 	defer o.mu.RUnlock()
 
 	return o.store[id]
+}
+
+// normalizeOverlayKey lowercases the resource-group segment of an ARM resource
+// id so overlay entries key case-insensitively on the resource group, matching
+// ARM's case-insensitive resource-group semantics. A resource created under
+// resourceGroups/rg-1 and read back via resourceGroups/RG-1 must resolve the
+// same overlay entry; without this, the differently-cased read would miss and
+// silently drop unmodeled properties. Only the resource-group segment is
+// touched — the rest of the id (including the resource name) is left byte-for-
+// byte, so distinct resources never collide. Applied identically on capture,
+// lookup and evict, so the internal map key is consistent regardless of the
+// casing a request used; the response body's id is never altered.
+func normalizeOverlayKey(id string) string {
+	const marker = "/resourceGroups/"
+
+	i := strings.Index(id, marker)
+	if i < 0 {
+		return id
+	}
+
+	start := i + len(marker)
+
+	end := strings.IndexByte(id[start:], '/')
+	if end < 0 {
+		return id[:start] + strings.ToLower(id[start:])
+	}
+
+	end += start
+
+	return id[:start] + strings.ToLower(id[start:end]) + id[end:]
 }
 
 // evict drops any entry for id — called when a resource is deleted so the
@@ -58,6 +92,8 @@ func (o *propertyOverlay) evict(id string) {
 	if id == "" {
 		return
 	}
+
+	id = normalizeOverlayKey(id)
 
 	o.mu.Lock()
 	defer o.mu.Unlock()

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -570,7 +570,7 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp azurearm.Resou
 	out := make([]vmResponse, 0, len(instances))
 
 	for i := range instances {
-		if rp.ResourceGroup != "" && instances[i].ResourceGroup != rp.ResourceGroup {
+		if rp.ResourceGroup != "" && !strings.EqualFold(instances[i].ResourceGroup, rp.ResourceGroup) {
 			continue
 		}
 
@@ -989,11 +989,13 @@ func findByName(ctx context.Context, c computedriver.Compute, resourceGroup, nam
 	}
 
 	for i := range instances {
-		if tagOr(instances[i].Tags, armNameTag, "") != name {
+		// ARM resource names and resource-group names are case-insensitive, so a
+		// GET/LIST with differently-cased segments must still resolve the VM.
+		if !strings.EqualFold(tagOr(instances[i].Tags, armNameTag, ""), name) {
 			continue
 		}
 
-		if resourceGroup != "" && instances[i].ResourceGroup != resourceGroup {
+		if resourceGroup != "" && !strings.EqualFold(instances[i].ResourceGroup, resourceGroup) {
 			continue
 		}
 

--- a/server/azure/virtualmachines/resourcegroup_case_insensitive_test.go
+++ b/server/azure/virtualmachines/resourcegroup_case_insensitive_test.go
@@ -1,0 +1,135 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestVMResourceGroupCaseInsensitive verifies that ARM's case-insensitive
+// resource-group semantics hold on GET and LIST: a VM created under "rg-1" is
+// resolvable by a differently-cased "RG-1" path, and its unmodeled overlay
+// properties (here additionalCapabilities, which the handler does not model)
+// survive the differently-cased read. Before the fix, findByName/list compared
+// the resource group with an exact "!=", so the upper-cased read 404'd; the
+// overlay was keyed by the request-path casing, so it also missed.
+func TestVMResourceGroupCaseInsensitive(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSDKClient(t, ts)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "case-vm",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				// additionalCapabilities is not modeled by the handler, so it is
+				// captured by the property overlay — the ideal probe for whether
+				// a differently-cased read still resolves the overlay entry.
+				AdditionalCapabilities: &armcompute.AdditionalCapabilities{
+					HibernationEnabled: to.Ptr(true),
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := pollUntilDone(ctx, poller); err != nil {
+		t.Fatalf("CreateOrUpdate poll: %v", err)
+	}
+
+	// GET with an upper-cased resource group must return the VM (case-insensitive
+	// resource-group lookup), not a spurious 404.
+	got, err := client.Get(ctx, "RG-1", "case-vm", nil)
+	if err != nil {
+		t.Fatalf("Get with upper-cased RG: %v", err)
+	}
+
+	if got.Name == nil || *got.Name != "case-vm" {
+		t.Fatalf("got.Name=%v want case-vm", got.Name)
+	}
+
+	// The unmodeled overlay property must survive the differently-cased read.
+	if got.Properties == nil || got.Properties.AdditionalCapabilities == nil ||
+		got.Properties.AdditionalCapabilities.HibernationEnabled == nil ||
+		!*got.Properties.AdditionalCapabilities.HibernationEnabled {
+		t.Fatalf("additionalCapabilities.hibernationEnabled not echoed on upper-cased GET: %+v",
+			got.Properties)
+	}
+
+	// GET with a differently-cased VM name must also resolve (names are
+	// case-insensitive in ARM).
+	if _, err := client.Get(ctx, "rg-1", "CASE-VM", nil); err != nil {
+		t.Fatalf("Get with upper-cased VM name: %v", err)
+	}
+
+	// LIST scoped by an upper-cased resource group must return the VM.
+	pager := client.NewListPager("RG-1", nil)
+
+	found := false
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		for _, vm := range page.Value {
+			if vm.Name != nil && *vm.Name == "case-vm" {
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		t.Error("List with upper-cased RG did not return case-vm")
+	}
+}
+
+// TestScaleSetResourceNameCaseInsensitive verifies a scale set created as
+// "vmss-1" is resolvable by a differently-cased "VMSS-1" GET. Before the fix,
+// getScaleSet compared the name with an exact "==", spuriously 404ing.
+func TestScaleSetResourceNameCaseInsensitive(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := armcompute.NewVirtualMachineScaleSetsClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatalf("NewVirtualMachineScaleSetsClient: %v", err)
+	}
+
+	ctx := context.Background()
+	createVMSS(ctx, t, client, "rg-1", "vmss-1")
+
+	// GET by a differently-cased scale-set name must resolve.
+	got, err := client.Get(ctx, "rg-1", "VMSS-1", nil)
+	if err != nil {
+		t.Fatalf("Get scale set with upper-cased name: %v", err)
+	}
+
+	if got.Name == nil || !strings.EqualFold(*got.Name, "vmss-1") {
+		t.Fatalf("got.Name=%v want vmss-1", got.Name)
+	}
+
+	// GET by a differently-cased resource group must also resolve.
+	if _, err := client.Get(ctx, "RG-1", "vmss-1", nil); err != nil {
+		t.Fatalf("Get scale set with upper-cased RG: %v", err)
+	}
+}

--- a/server/azure/virtualmachines/scalesets.go
+++ b/server/azure/virtualmachines/scalesets.go
@@ -3,6 +3,7 @@ package virtualmachines
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	providervm "github.com/stackshy/cloudemu/v2/providers/azure/virtualmachines"
@@ -130,7 +131,9 @@ func getScaleSet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePat
 	}
 
 	for i := range sets {
-		if sets[i].Name == rp.ResourceName {
+		// ARM resource names are case-insensitive, so a GET with a
+		// differently-cased scale-set name must still resolve it.
+		if strings.EqualFold(sets[i].Name, rp.ResourceName) {
 			azurearm.WriteJSON(w, http.StatusOK, toVMSSResponse(&sets[i], rp))
 			return
 		}


### PR DESCRIPTION
## What

ARM resource-group names and resource names are **case-insensitive**, but Azure Virtual Machines GET/LIST and scale-set GET compared them with an exact `!=`/`==`. A user who created a VM under `rg-1` and then `GET .../resourceGroups/RG-1/...` got a spurious 404. The cascade-delete path already used `strings.EqualFold`, so the codebase already intended case-insensitivity — GET/LIST just missed it.

## Changes

- `server/azure/virtualmachines/instances.go` — `findByName` and `list` now compare resource group **and** VM name with `strings.EqualFold`.
- `server/azure/virtualmachines/scalesets.go` — `getScaleSet` compares the scale-set name with `strings.EqualFold`.
- `server/azure/echo_properties.go` — the shared property overlay (which preserves unmodeled request properties like `additionalCapabilities`) is keyed by the ARM resource id, which reflects the **request-path** RG casing. Without normalization, a differently-cased GET would resolve the VM but silently drop its unmodeled props. `capture`/`lookup`/`evict` now lowercase the **resource-group segment** of the key only — the response body id is never altered, and the resource-name segment is untouched, so no cross-service collision. This is safe for every service that shares the overlay.

## Why it's correct

Mirrors ARM semantics and the existing `purgeInstances` `EqualFold` intent. The overlay normalization touches only the internal map key, not any response.

## Tests

New `resourcegroup_case_insensitive_test.go` (real `azure-sdk-for-go` armcompute client over TLS httptest):
- GET a VM by an upper-cased RG returns 200 + the VM, **including** the unmodeled `additionalCapabilities` overlay prop.
- GET a VM by an upper-cased name resolves.
- LIST scoped by an upper-cased RG returns the VM.
- Scale-set GET by differently-cased name and RG resolves.

Verified **fail-before / pass-after** (both the findByName and the overlay-normalization halves are independently load-bearing).

## Scope

Focused on Virtual Machines only. The same case-sensitive RG/name anti-pattern exists in several other Azure services (notification hubs, snapshots, images, public IPs, NAT gateways, disks, SSH public keys, load balancer, managed Cassandra, databricks, AKS, ACR, search, AI/ML, functions, cosmos-PG) — reported separately for a batched systemic follow-up, not fixed here.