### PR TITLE
fix(azure-blob): Range/206, content-property round-trip, committed-block refs, delimiter pagination, time conditionals

### DIFF
--- a/docs/coverage/aws/s3.md
+++ b/docs/coverage/aws/s3.md
@@ -75,6 +75,7 @@ AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
 | `DeleteBlobSnapshots` | DeleteBlobSnapshots applies the Azure delete-snapshots directive |
 | `GetBlobSnapshot` | GetBlobSnapshot reads a previously captured snapshot (GET ?snapshot=…). |
 | `GetBlockList` | GetBlockList returns the blob's committed and uncommitted blocks (Get |
+| `PutBlockBlob` | PutBlockBlob writes a block blob's content together with its system content |
 | `ReleaseLease` | ReleaseLease releases the blob's current lease. |
 | `RenewLease` | RenewLease renews the blob's current lease. |
 | `SetBlobMetadata` | SetBlobMetadata replaces only a blob's metadata (Set Blob Metadata, |

--- a/docs/coverage/azure/blobstorage.md
+++ b/docs/coverage/azure/blobstorage.md
@@ -75,6 +75,7 @@ AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
 | `DeleteBlobSnapshots` | DeleteBlobSnapshots applies the Azure delete-snapshots directive |
 | `GetBlobSnapshot` | GetBlobSnapshot reads a previously captured snapshot (GET ?snapshot=…). |
 | `GetBlockList` | GetBlockList returns the blob's committed and uncommitted blocks (Get |
+| `PutBlockBlob` | PutBlockBlob writes a block blob's content together with its system content |
 | `ReleaseLease` | ReleaseLease releases the blob's current lease. |
 | `RenewLease` | RenewLease renews the blob's current lease. |
 | `SetBlobMetadata` | SetBlobMetadata replaces only a blob's metadata (Set Blob Metadata, |

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -10688,6 +10688,10 @@
             "doc": "GetBlockList returns the blob's committed and uncommitted blocks (Get"
           },
           {
+            "name": "PutBlockBlob",
+            "doc": "PutBlockBlob writes a block blob's content together with its system content"
+          },
+          {
             "name": "ReleaseLease",
             "doc": "ReleaseLease releases the blob's current lease."
           },

--- a/docs/coverage/gcp/gcs.md
+++ b/docs/coverage/gcp/gcs.md
@@ -75,6 +75,7 @@ AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
 | `DeleteBlobSnapshots` | DeleteBlobSnapshots applies the Azure delete-snapshots directive |
 | `GetBlobSnapshot` | GetBlobSnapshot reads a previously captured snapshot (GET ?snapshot=…). |
 | `GetBlockList` | GetBlockList returns the blob's committed and uncommitted blocks (Get |
+| `PutBlockBlob` | PutBlockBlob writes a block blob's content together with its system content |
 | `ReleaseLease` | ReleaseLease releases the blob's current lease. |
 | `RenewLease` | RenewLease renews the blob's current lease. |
 | `SetBlobMetadata` | SetBlobMetadata replaces only a blob's metadata (Set Blob Metadata, |

--- a/providers/azure/blobstorage/blob_extensions.go
+++ b/providers/azure/blobstorage/blob_extensions.go
@@ -68,16 +68,22 @@ func (m *Mock) StageBlock(_ context.Context, container, blob, blockID string, da
 	return nil
 }
 
-// CommitBlockList assembles a block blob from previously-staged blocks.
+// CommitBlockList assembles a block blob from the given block entries. Each
+// entry is resolved against its source list (Committed/Uncommitted/Latest), so
+// a commit can re-reference blocks already committed on the blob — the "append
+// by re-committing existing blocks plus a new one" pattern.
 func (m *Mock) CommitBlockList(
-	ctx context.Context, container, blob string, blockIDs []string, contentType string, metadata map[string]string,
+	ctx context.Context, container, blob string, blocks []driver.BlockListEntry,
+	contentType string, props *driver.BlobProperties, metadata map[string]string,
 ) (*driver.ObjectInfo, error) {
 	ctr, ok := m.containers.Get(container)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
 	}
 
-	data, blocks, err := assembleStagedBlocks(ctr, blob, blockIDs)
+	existing, _ := ctr.objects.Get(blob)
+
+	data, blockInfos, committedData, err := assembleBlocks(ctr, blob, blocks, existing)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +96,16 @@ func (m *Mock) CommitBlockList(
 		Key: blob, Size: int64(len(data)), ContentType: contentType,
 		LastModified: m.opts.Clock.Now().UTC().Format(blobTimeFormat),
 		Metadata:     maps.Clone(metadata), BlobType: blobTypeBlock,
-		CommittedBlocks: blocks,
+		CommittedBlocks: blockInfos, committedBlockData: committedData,
 	}
+
+	if props != nil {
+		obj.ContentEncoding = props.ContentEncoding
+		obj.ContentLanguage = props.ContentLanguage
+		obj.ContentDisposition = props.ContentDisposition
+		obj.CacheControl = props.CacheControl
+	}
+
 	obj.ETag = fmt.Sprintf("%x", sha256.Sum256(data))
 
 	if m.opts.StorageEngine != nil {
@@ -115,32 +129,81 @@ func (m *Mock) CommitBlockList(
 	return &info, nil
 }
 
-// assembleStagedBlocks concatenates the named staged blocks in order and
-// records each block's id/size for Get Block List.
-func assembleStagedBlocks(ctr *containerMeta, blob string, blockIDs []string) ([]byte, []driver.BlockInfo, error) {
+// assembleBlocks concatenates the requested blocks in order, resolving each
+// against its source list, and returns the assembled bytes, the per-block
+// id/size list for Get Block List, and the retained per-block bytes so a later
+// commit can re-reference these now-committed blocks.
+func assembleBlocks(
+	ctr *containerMeta, blob string, entries []driver.BlockListEntry, existing *blobObject,
+) (data []byte, blocks []driver.BlockInfo, committedData map[string][]byte, err error) {
+	staged := snapshotStagedBlocks(ctr, blob)
+
+	var committed map[string][]byte
+	if existing != nil {
+		committed = existing.committedBlockData
+	}
+
+	committedData = make(map[string][]byte, len(entries))
+	blocks = make([]driver.BlockInfo, 0, len(entries))
+
+	for _, e := range entries {
+		block, ok := resolveBlock(e, staged, committed)
+		if !ok {
+			return nil, nil, nil, cerrors.Newf(cerrors.InvalidArgument,
+				"block %q (%s) not found for blob %q", e.ID, e.List, blob)
+		}
+
+		data = append(data, block...)
+		blocks = append(blocks, driver.BlockInfo{Name: e.ID, Size: int64(len(block))})
+		committedData[e.ID] = block
+	}
+
+	return data, blocks, committedData, nil
+}
+
+// resolveBlock returns a block's bytes from the source list named by the entry:
+// Committed reads the blob's existing committed blocks, Uncommitted reads the
+// freshly staged blocks, and Latest (the default) prefers a staged block, then
+// falls back to a committed one.
+func resolveBlock(e driver.BlockListEntry, staged, committed map[string][]byte) ([]byte, bool) {
+	switch e.List {
+	case driver.BlockListCommitted:
+		block, ok := committed[e.ID]
+		return block, ok
+	case driver.BlockListUncommitted:
+		block, ok := staged[e.ID]
+		return block, ok
+	default: // Latest: staged first, else committed.
+		if block, ok := staged[e.ID]; ok {
+			return block, true
+		}
+
+		block, ok := committed[e.ID]
+
+		return block, ok
+	}
+}
+
+// snapshotStagedBlocks copies a blob's staged blocks under the staging lock so
+// block resolution runs without holding it.
+func snapshotStagedBlocks(ctr *containerMeta, blob string) map[string][]byte {
 	stg, ok := ctr.staging.Get(blob)
 	if !ok {
-		return nil, nil, cerrors.Newf(cerrors.InvalidArgument, "no staged blocks for blob %q", blob)
+		return nil
 	}
 
 	stg.mu.Lock()
 	defer stg.mu.Unlock()
 
-	var data []byte
+	staged := make(map[string][]byte, len(stg.blocks))
 
-	blocks := make([]driver.BlockInfo, 0, len(blockIDs))
-
-	for _, id := range blockIDs {
-		block, ok := stg.blocks[id]
-		if !ok {
-			return nil, nil, cerrors.Newf(cerrors.InvalidArgument, "block %q not staged for blob %q", id, blob)
-		}
-
-		data = append(data, block...)
-		blocks = append(blocks, driver.BlockInfo{Name: id, Size: int64(len(block))})
+	for id, block := range stg.blocks {
+		cp := make([]byte, len(block))
+		copy(cp, block)
+		staged[id] = cp
 	}
 
-	return data, blocks, nil
+	return staged
 }
 
 // SetBlobMetadata replaces only a blob's metadata, preserving its content.

--- a/providers/azure/blobstorage/blob_extensions_test.go
+++ b/providers/azure/blobstorage/blob_extensions_test.go
@@ -5,9 +5,21 @@ import (
 	"testing"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// latestBlocks builds a Put Block List that references each id from the Latest
+// source list (the azblob default).
+func latestBlocks(ids ...string) []driver.BlockListEntry {
+	entries := make([]driver.BlockListEntry, len(ids))
+	for i, id := range ids {
+		entries[i] = driver.BlockListEntry{ID: id, List: driver.BlockListLatest}
+	}
+
+	return entries
+}
 
 func TestStageAndCommitBlockList(t *testing.T) {
 	ctx := context.Background()
@@ -17,7 +29,7 @@ func TestStageAndCommitBlockList(t *testing.T) {
 	require.NoError(t, m.StageBlock(ctx, "c1", "k1", "b1", []byte("foo")))
 	require.NoError(t, m.StageBlock(ctx, "c1", "k1", "b2", []byte("bar")))
 
-	info, err := m.CommitBlockList(ctx, "c1", "k1", []string{"b1", "b2"}, "text/plain", nil)
+	info, err := m.CommitBlockList(ctx, "c1", "k1", latestBlocks("b1", "b2"), "text/plain", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(6), info.Size)
 
@@ -27,13 +39,88 @@ func TestStageAndCommitBlockList(t *testing.T) {
 	assert.Equal(t, "text/plain", obj.Info.ContentType)
 }
 
+func TestPutBlockBlobContentPropertiesRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+
+	props := &driver.BlobProperties{
+		ContentType: "text/plain", ContentEncoding: "gzip", CacheControl: "no-cache",
+		ContentLanguage: "en-US", ContentDisposition: "attachment",
+	}
+
+	info, err := m.PutBlockBlob(ctx, "c1", "k1", []byte("payload"), props, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "gzip", info.ContentEncoding)
+	assert.Equal(t, "no-cache", info.CacheControl)
+	assert.Equal(t, "en-US", info.ContentLanguage)
+	assert.Equal(t, "attachment", info.ContentDisposition)
+
+	obj, err := m.GetObject(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, "payload", string(obj.Data))
+	assert.Equal(t, "gzip", obj.Info.ContentEncoding)
+	assert.Equal(t, "en-US", obj.Info.ContentLanguage)
+	assert.Equal(t, "attachment", obj.Info.ContentDisposition)
+	assert.Equal(t, "no-cache", obj.Info.CacheControl)
+}
+
+func TestCommitBlockListReferencesCommittedBlocks(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+
+	require.NoError(t, m.StageBlock(ctx, "c1", "k1", "b1", []byte("foo")))
+	require.NoError(t, m.StageBlock(ctx, "c1", "k1", "b2", []byte("bar")))
+
+	_, err := m.CommitBlockList(ctx, "c1", "k1", latestBlocks("b1", "b2"), "text/plain", nil, nil)
+	require.NoError(t, err)
+
+	// Stage one new block, then re-commit the two already-committed blocks
+	// (referenced from the Committed source list) plus the new one.
+	require.NoError(t, m.StageBlock(ctx, "c1", "k1", "b3", []byte("baz")))
+
+	entries := []driver.BlockListEntry{
+		{ID: "b1", List: driver.BlockListCommitted},
+		{ID: "b2", List: driver.BlockListCommitted},
+		{ID: "b3", List: driver.BlockListUncommitted},
+	}
+
+	info, err := m.CommitBlockList(ctx, "c1", "k1", entries, "text/plain", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(9), info.Size)
+
+	obj, err := m.GetObject(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, "foobarbaz", string(obj.Data))
+}
+
+func TestCommitBlockListContentProperties(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+	require.NoError(t, m.StageBlock(ctx, "c1", "k1", "b1", []byte("foo")))
+
+	props := &driver.BlobProperties{ContentEncoding: "gzip", CacheControl: "max-age=42"}
+
+	info, err := m.CommitBlockList(ctx, "c1", "k1", latestBlocks("b1"), "text/plain", props, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "gzip", info.ContentEncoding)
+	assert.Equal(t, "max-age=42", info.CacheControl)
+
+	head, err := m.HeadObject(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, "gzip", head.ContentEncoding)
+	assert.Equal(t, "max-age=42", head.CacheControl)
+}
+
 func TestCommitBlockListMissingBlock(t *testing.T) {
 	ctx := context.Background()
 	m := newTestMock()
 	require.NoError(t, m.CreateBucket(ctx, "c1"))
 	require.NoError(t, m.StageBlock(ctx, "c1", "k1", "b1", []byte("foo")))
 
-	_, err := m.CommitBlockList(ctx, "c1", "k1", []string{"b1", "missing"}, "", nil)
+	_, err := m.CommitBlockList(ctx, "c1", "k1", latestBlocks("b1", "missing"), "", nil, nil)
 	require.Error(t, err)
 	assert.True(t, cerrors.IsInvalidArgument(err))
 }

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -55,6 +55,10 @@ type blobObject struct {
 	// CommittedBlocks records the block id/size pairs assembled by the most
 	// recent Put Block List commit, in commit order, for Get Block List.
 	CommittedBlocks []driver.BlockInfo
+	// committedBlockData retains the bytes of each committed block by id, so a
+	// later Put Block List can re-reference an already-committed block
+	// (<Committed>/<Latest>) instead of only freshly staged ones.
+	committedBlockData map[string][]byte
 	// mu guards the in-place mutations of the new Azure ops (append, metadata /
 	// property / tier updates, leases). Whole-object replacements via the
 	// container store don't need it.
@@ -351,9 +355,35 @@ func (m *Mock) ListBuckets(_ context.Context) ([]driver.BucketInfo, error) {
 // PutObject stores a blob in a container. When a real StorageEngine is wired the
 // bytes flow through it and the in-memory object holds metadata only (Data nil).
 func (m *Mock) PutObject(ctx context.Context, bucket, key string, data []byte, contentType string, metadata map[string]string) error {
+	_, err := m.putBlockBlobInternal(ctx, bucket, key, data, contentType, nil, metadata)
+
+	return err
+}
+
+// PutBlockBlob writes a block blob's content together with its system content
+// properties (Put Blob), so Content-Encoding/Cache-Control/Content-Language/
+// Content-Disposition round-trip on a later read. props may be nil.
+func (m *Mock) PutBlockBlob(
+	ctx context.Context, bucket, key string, data []byte, props *driver.BlobProperties, metadata map[string]string,
+) (*driver.ObjectInfo, error) {
+	contentType := ""
+	if props != nil {
+		contentType = props.ContentType
+	}
+
+	return m.putBlockBlobInternal(ctx, bucket, key, data, contentType, props, metadata)
+}
+
+// putBlockBlobInternal is the shared Put Blob path: it stores the content,
+// optional content properties (props may be nil), and metadata, carrying over
+// any active lease, and returns the new object info.
+func (m *Mock) putBlockBlobInternal(
+	ctx context.Context, bucket, key string, data []byte, contentType string,
+	props *driver.BlobProperties, metadata map[string]string,
+) (*driver.ObjectInfo, error) {
 	ctr, ok := m.containers.Get(bucket)
 	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
 	}
 
 	size := int64(len(data))
@@ -368,11 +398,18 @@ func (m *Mock) PutObject(ctx context.Context, bucket, key string, data []byte, c
 		Metadata:     meta,
 	}
 
+	if props != nil {
+		obj.ContentEncoding = props.ContentEncoding
+		obj.ContentLanguage = props.ContentLanguage
+		obj.ContentDisposition = props.ContentDisposition
+		obj.CacheControl = props.CacheControl
+	}
+
 	if m.opts.StorageEngine != nil {
 		if err := storageengine.Put(ctx, m.opts.StorageEngine, config.StorageObject{
 			Bucket: bucket, Key: key, Data: data, ContentType: contentType, Metadata: meta,
 		}); err != nil {
-			return err
+			return nil, err
 		}
 	} else {
 		dataCopy := make([]byte, len(data))
@@ -385,7 +422,9 @@ func (m *Mock) PutObject(ctx context.Context, bucket, key string, data []byte, c
 
 	m.emitMetric(bucket, map[string]float64{"Transactions": 1, "Ingress": float64(size)})
 
-	return nil
+	info := objectInfo(obj)
+
+	return &info, nil
 }
 
 // GetObject retrieves a blob from a container.
@@ -431,6 +470,8 @@ func objectInfo(obj *blobObject) driver.ObjectInfo {
 		Key: obj.Key, Size: obj.Size, ContentType: obj.ContentType,
 		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 		BlobType: obj.BlobType, AccessTier: obj.AccessTier,
+		CacheControl: obj.CacheControl, ContentEncoding: obj.ContentEncoding,
+		ContentDisposition: obj.ContentDisposition, ContentLanguage: obj.ContentLanguage,
 	}
 }
 
@@ -495,6 +536,15 @@ func (m *Mock) HeadObject(_ context.Context, bucket, key string) (*driver.Object
 	return &info, nil
 }
 
+// listEntry is one item in the merged list stream — either a blob or a
+// delimiter-rolled-up common prefix — so both count toward maxresults and
+// paginate together (matching real Azure's List Blobs).
+type listEntry struct {
+	name     string
+	isPrefix bool
+	obj      *blobObject
+}
+
 // ListObjects lists blobs in a container with optional prefix/delimiter filtering.
 func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOptions) (*driver.ListResult, error) {
 	ctr, ok := m.containers.Get(bucket)
@@ -502,12 +552,47 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
 	}
 
+	entries := collectListEntries(ctr, opts)
+
+	maxKeys := opts.MaxKeys
+	if maxKeys <= 0 {
+		maxKeys = blobDefaultMaxKeys
+	}
+
+	// Blobs and common prefixes fold into ONE sorted stream so both count
+	// toward maxresults and neither is duplicated nor skipped across pages.
+	page, err := pagination.PaginateSorted(entries, func(a, b listEntry) bool {
+		if a.name != b.name {
+			return a.name < b.name
+		}
+
+		return !a.isPrefix && b.isPrefix
+	}, opts.PageToken, maxKeys)
+	if err != nil {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+	}
+
+	objects, commonPrefixes := splitListPage(page.Items)
+
+	m.emitMetric(bucket, map[string]float64{"Transactions": 1})
+
+	return &driver.ListResult{
+		Objects:        objects,
+		CommonPrefixes: commonPrefixes,
+		NextPageToken:  page.NextPageToken,
+		IsTruncated:    page.HasMore,
+	}, nil
+}
+
+// collectListEntries builds the unsorted merged blob+prefix stream for a list
+// request, applying the prefix filter and (when set) the delimiter rollup.
+func collectListEntries(ctr *containerMeta, opts driver.ListOptions) []listEntry {
 	allKeys := ctr.objects.Keys()
 	sort.Strings(allKeys)
 
-	var matchedObjects []driver.ObjectInfo
+	var entries []listEntry
 
-	commonPrefixSet := make(map[string]struct{})
+	seenPrefix := make(map[string]struct{})
 
 	for _, k := range allKeys {
 		if opts.Prefix != "" && !strings.HasPrefix(k, opts.Prefix) {
@@ -517,9 +602,14 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 		if opts.Delimiter != "" {
 			rest := k[len(opts.Prefix):]
 
-			idx := strings.Index(rest, opts.Delimiter)
-			if idx >= 0 {
-				commonPrefixSet[opts.Prefix+rest[:idx+len(opts.Delimiter)]] = struct{}{}
+			if idx := strings.Index(rest, opts.Delimiter); idx >= 0 {
+				prefix := opts.Prefix + rest[:idx+len(opts.Delimiter)]
+				if _, dup := seenPrefix[prefix]; !dup {
+					seenPrefix[prefix] = struct{}{}
+
+					entries = append(entries, listEntry{name: prefix, isPrefix: true})
+				}
+
 				continue
 			}
 		}
@@ -529,44 +619,27 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 			continue
 		}
 
-		matchedObjects = append(matchedObjects, driver.ObjectInfo{
-			Key: obj.Key, Size: obj.Size, ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
-			BlobType: obj.BlobType, AccessTier: obj.AccessTier,
-		})
+		entries = append(entries, listEntry{name: obj.Key, obj: obj})
 	}
 
-	commonPrefixes := make([]string, 0, len(commonPrefixSet))
-	for p := range commonPrefixSet {
-		commonPrefixes = append(commonPrefixes, p)
+	return entries
+}
+
+// splitListPage separates a paginated merged page back into the blob objects
+// and common prefixes the driver.ListResult reports, preserving page order.
+// objectInfo (which clones metadata) runs only for the page actually returned,
+// not for every match, keeping a paged scan cheap on a large container.
+func splitListPage(items []listEntry) (objects []driver.ObjectInfo, commonPrefixes []string) {
+	for i := range items {
+		if items[i].isPrefix {
+			commonPrefixes = append(commonPrefixes, items[i].name)
+			continue
+		}
+
+		objects = append(objects, objectInfo(items[i].obj))
 	}
 
-	sort.Strings(commonPrefixes)
-
-	maxKeys := opts.MaxKeys
-	if maxKeys <= 0 {
-		maxKeys = blobDefaultMaxKeys
-	}
-
-	page, err := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
-	if err != nil {
-		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
-	}
-
-	// Clone metadata only for the page actually returned — cloning every
-	// match would make a paged scan O(bucket) allocations per request.
-	for i := range page.Items {
-		page.Items[i].Metadata = maps.Clone(page.Items[i].Metadata)
-	}
-
-	m.emitMetric(bucket, map[string]float64{"Transactions": 1})
-
-	return &driver.ListResult{
-		Objects:        page.Items,
-		CommonPrefixes: commonPrefixes,
-		NextPageToken:  page.NextPageToken,
-		IsTruncated:    page.HasMore,
-	}, nil
+	return objects, commonPrefixes
 }
 
 // CopyObject copies a blob from one location to another, inheriting the source

--- a/providers/azure/blobstorage/blobstorage_lifecycle_test.go
+++ b/providers/azure/blobstorage/blobstorage_lifecycle_test.go
@@ -380,11 +380,44 @@ func TestDelimiterRollup(t *testing.T) {
 		assert.Empty(t, res.Objects)
 	})
 
-	t.Run("prefixes not paginated even with MaxKeys 1", func(t *testing.T) {
+	t.Run("prefixes count toward maxresults and paginate with blobs", func(t *testing.T) {
+		// Merged stream sorted by name: "data/", "logs/", "root.txt". At
+		// MaxKeys=1 the first page is just the "data/" prefix, and the rest
+		// arrive over later pages with no dup or skip.
 		res, err := m.ListObjects(ctx, bucket, driver.ListOptions{Delimiter: "/", MaxKeys: 1})
 		require.NoError(t, err)
-		// full prefix set regardless of page size (documented mock behavior)
-		assert.Equal(t, []string{"data/", "logs/"}, res.CommonPrefixes)
+		assert.Equal(t, []string{"data/"}, res.CommonPrefixes)
+		assert.Empty(t, res.Objects)
+		require.True(t, res.IsTruncated)
+		require.NotEmpty(t, res.NextPageToken)
+
+		var (
+			prefixes []string
+			blobs    []string
+		)
+
+		prefixes = append(prefixes, res.CommonPrefixes...)
+
+		token := res.NextPageToken
+		for range 10 {
+			page, perr := m.ListObjects(ctx, bucket, driver.ListOptions{Delimiter: "/", MaxKeys: 1, PageToken: token})
+			require.NoError(t, perr)
+			prefixes = append(prefixes, page.CommonPrefixes...)
+
+			for _, o := range page.Objects {
+				blobs = append(blobs, o.Key)
+			}
+
+			if !page.IsTruncated {
+				assert.Empty(t, page.NextPageToken)
+				break
+			}
+
+			token = page.NextPageToken
+		}
+
+		assert.Equal(t, []string{"data/", "logs/"}, prefixes)
+		assert.Equal(t, []string{"root.txt"}, blobs)
 	})
 }
 

--- a/server/azure/blobstorage/blob_extensions.go
+++ b/server/azure/blobstorage/blob_extensions.go
@@ -57,13 +57,15 @@ func (h *Handler) commitBlockList(w http.ResponseWriter, r *http.Request, ext bl
 		return
 	}
 
-	blockIDs, err := parseBlockListXML(body)
+	blocks, err := parseBlockListXML(body)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "InvalidBlockList", err.Error())
 		return
 	}
 
-	info, err := ext.CommitBlockList(r.Context(), container, blob, blockIDs, blobContentType(r), extractMetadata(r.Header))
+	info, err := ext.CommitBlockList(
+		r.Context(), container, blob, blocks, blobContentType(r), blobContentProps(r), extractMetadata(r.Header),
+	)
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -253,14 +255,16 @@ func readLimitedBody(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
 	return data, true
 }
 
-// parseBlockListXML extracts the ordered block IDs from a Put Block List body,
-// preserving document order across Latest/Committed/Uncommitted elements.
-func parseBlockListXML(body []byte) ([]string, error) {
+// parseBlockListXML extracts the ordered block entries from a Put Block List
+// body, preserving both document order and each block's source list
+// (Latest/Committed/Uncommitted) so the commit can resolve a block against the
+// correct source rather than collapsing all three into one list.
+func parseBlockListXML(body []byte) ([]storagedriver.BlockListEntry, error) {
 	dec := xml.NewDecoder(bytes.NewReader(body))
 
 	var (
-		ids     []string
-		capture bool
+		entries []storagedriver.BlockListEntry
+		list    string
 	)
 
 	for {
@@ -275,25 +279,36 @@ func parseBlockListXML(body []byte) ([]string, error) {
 
 		switch t := tok.(type) {
 		case xml.StartElement:
-			capture = isBlockElement(t.Name.Local)
+			list = blockListSource(t.Name.Local)
 		case xml.CharData:
-			if capture {
+			if list != "" {
 				if id := string(bytes.TrimSpace([]byte(t))); id != "" {
-					ids = append(ids, id)
+					entries = append(entries, storagedriver.BlockListEntry{ID: id, List: list})
 				}
 			}
 		case xml.EndElement:
-			capture = false
+			list = ""
 		}
 	}
 
-	if len(ids) == 0 {
+	if len(entries) == 0 {
 		return nil, cerrors.New(cerrors.InvalidArgument, "block list is empty")
 	}
 
-	return ids, nil
+	return entries, nil
 }
 
-func isBlockElement(name string) bool {
-	return name == "Latest" || name == "Committed" || name == "Uncommitted"
+// blockListSource maps a Put Block List element name to its source-list value,
+// returning "" for any non-block element.
+func blockListSource(name string) string {
+	switch name {
+	case "Latest":
+		return storagedriver.BlockListLatest
+	case "Committed":
+		return storagedriver.BlockListCommitted
+	case "Uncommitted":
+		return storagedriver.BlockListUncommitted
+	default:
+		return ""
+	}
 }

--- a/server/azure/blobstorage/blob_range_test.go
+++ b/server/azure/blobstorage/blob_range_test.go
@@ -1,0 +1,256 @@
+package blobstorage_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+)
+
+// blockID base64-encodes a block name into the fixed-length id the azblob
+// block-blob client requires.
+func blockID(name string) string {
+	return base64.StdEncoding.EncodeToString([]byte(name))
+}
+
+// streamOf wraps a string as the ReadSeekCloser StageBlock expects.
+func streamOf(s string) io.ReadSeekCloser {
+	return streaming.NopCloser(bytes.NewReader([]byte(s)))
+}
+
+// rawResponse issues a bare HTTP request through the test transport and returns
+// the status, response headers, and body, so wire behaviors the typed SDK
+// hides (partial-content status, Content-Range) can be asserted directly.
+func (e *blobEnv) rawResponse(t *testing.T, method, path string, headers map[string]string) (int, http.Header, []byte) {
+	t.Helper()
+
+	req, err := http.NewRequest(method, e.base+path, nil)
+	if err != nil {
+		t.Fatalf("new request %s %s: %v", method, path, err)
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := e.tr.Do(req)
+	if err != nil {
+		t.Fatalf("do %s %s: %v", method, path, err)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if err != nil {
+		t.Fatalf("read body %s %s: %v", method, path, err)
+	}
+
+	return resp.StatusCode, resp.Header, body
+}
+
+func TestSDKRangedGetReturns206(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	const content = "0123456789abcdef"
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte(content), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	status, hdr, body := e.rawResponse(t, http.MethodGet, "/c1/k1", map[string]string{"x-ms-range": "bytes=4-9"})
+	if status != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", status)
+	}
+
+	if got := hdr.Get("Content-Range"); got != "bytes 4-9/16" {
+		t.Fatalf("Content-Range = %q, want %q", got, "bytes 4-9/16")
+	}
+
+	if got := hdr.Get("Content-Length"); got != "6" {
+		t.Fatalf("Content-Length = %q, want 6", got)
+	}
+
+	if string(body) != "456789" {
+		t.Fatalf("body = %q, want %q", body, "456789")
+	}
+
+	if got := hdr.Get("Accept-Ranges"); got != "bytes" {
+		t.Fatalf("Accept-Ranges = %q, want bytes", got)
+	}
+}
+
+func TestSDKRangedGetOpenEnded(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	const content = "0123456789abcdef"
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte(content), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	status, hdr, body := e.rawResponse(t, http.MethodGet, "/c1/k1", map[string]string{"Range": "bytes=10-"})
+	if status != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", status)
+	}
+
+	if got := hdr.Get("Content-Range"); got != "bytes 10-15/16" {
+		t.Fatalf("Content-Range = %q, want %q", got, "bytes 10-15/16")
+	}
+
+	if string(body) != "abcdef" {
+		t.Fatalf("body = %q, want %q", body, "abcdef")
+	}
+}
+
+func TestSDKUnsatisfiableRangeReturns416(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	const content = "0123456789"
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte(content), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	status, hdr, _ := e.rawResponse(t, http.MethodGet, "/c1/k1", map[string]string{"x-ms-range": "bytes=100-200"})
+	if status != http.StatusRequestedRangeNotSatisfiable {
+		t.Fatalf("status = %d, want 416", status)
+	}
+
+	if got := hdr.Get("Content-Range"); got != "bytes */10" {
+		t.Fatalf("Content-Range = %q, want %q", got, "bytes */10")
+	}
+}
+
+// TestSDKRangedDownloadAssemblesOriginal is the data-corruption guard: the
+// azblob DownloadBuffer issues many small parallel ranged GETs and copies each
+// into the destination at its offset. If a ranged GET returned the full blob
+// (the bug) instead of just its slice, the assembled buffer would be corrupt.
+func TestSDKRangedDownloadAssemblesOriginal(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	original := make([]byte, 1024)
+	for i := range original {
+		original[i] = byte('A' + (i % 26))
+	}
+
+	if _, err := e.svc.UploadBuffer(ctx, "c1", "big", original, nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	dst := make([]byte, len(original))
+
+	n, err := e.svc.DownloadBuffer(ctx, "c1", "big", dst, &azblob.DownloadBufferOptions{
+		BlockSize:   64,
+		Concurrency: 8,
+	})
+	if err != nil {
+		t.Fatalf("DownloadBuffer: %v", err)
+	}
+
+	if n != int64(len(original)) {
+		t.Fatalf("downloaded %d bytes, want %d", n, len(original))
+	}
+
+	if !bytes.Equal(dst, original) {
+		t.Fatalf("assembled buffer does not equal original")
+	}
+}
+
+func TestSDKContentPropertiesRoundTrip(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	_, err := e.svc.UploadBuffer(ctx, "c1", "k1", []byte("payload"), &azblob.UploadBufferOptions{
+		HTTPHeaders: &blob.HTTPHeaders{
+			BlobCacheControl:       to.Ptr("max-age=99"),
+			BlobContentEncoding:    to.Ptr("gzip"),
+			BlobContentLanguage:    to.Ptr("en-US"),
+			BlobContentDisposition: to.Ptr("attachment; filename=x.txt"),
+			BlobContentType:        to.Ptr("text/plain"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	props, err := e.blob(t, "/c1/k1").GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties: %v", err)
+	}
+
+	assertPtr(t, "CacheControl", props.CacheControl, "max-age=99")
+	assertPtr(t, "ContentEncoding", props.ContentEncoding, "gzip")
+	assertPtr(t, "ContentLanguage", props.ContentLanguage, "en-US")
+	assertPtr(t, "ContentDisposition", props.ContentDisposition, "attachment; filename=x.txt")
+
+	// The same properties must also come back as headers on a read. Use HEAD:
+	// a GET carries Content-Encoding: gzip, which the Go transport would try to
+	// transparently gunzip over the (uncompressed) test payload.
+	_, hdr, _ := e.rawResponse(t, http.MethodHead, "/c1/k1", nil)
+	if got := hdr.Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("HEAD Content-Encoding = %q, want gzip", got)
+	}
+
+	if got := hdr.Get("Cache-Control"); got != "max-age=99" {
+		t.Fatalf("HEAD Cache-Control = %q, want max-age=99", got)
+	}
+
+	if got := hdr.Get("Content-Disposition"); got != "attachment; filename=x.txt" {
+		t.Fatalf("HEAD Content-Disposition = %q, want %q", got, "attachment; filename=x.txt")
+	}
+}
+
+func assertPtr(t *testing.T, name string, got *string, want string) {
+	t.Helper()
+
+	if got == nil {
+		t.Fatalf("%s = nil, want %q", name, want)
+	}
+
+	if *got != want {
+		t.Fatalf("%s = %q, want %q", name, *got, want)
+	}
+}
+
+// TestSDKCommitBlockListAppendsCommittedBlock exercises the "append by
+// re-committing an existing committed block plus a freshly staged one" pattern:
+// after the first commit clears staging, the second commit still resolves the
+// old block from the committed list (Latest falls back to committed).
+func TestSDKCommitBlockListAppendsCommittedBlock(t *testing.T) {
+	e := newBlobEnv(t)
+	ctx := context.Background()
+
+	bb := e.blockBlob(t, "/c1/appended")
+
+	idA := blockID("block-000a")
+	idB := blockID("block-000b")
+
+	if _, err := bb.StageBlock(ctx, idA, streamOf("hello "), nil); err != nil {
+		t.Fatalf("StageBlock a: %v", err)
+	}
+
+	if _, err := bb.CommitBlockList(ctx, []string{idA}, nil); err != nil {
+		t.Fatalf("CommitBlockList a: %v", err)
+	}
+
+	if _, err := bb.StageBlock(ctx, idB, streamOf("world"), nil); err != nil {
+		t.Fatalf("StageBlock b: %v", err)
+	}
+
+	// Re-commit the already-committed block A plus the new block B.
+	if _, err := bb.CommitBlockList(ctx, []string{idA, idB}, nil); err != nil {
+		t.Fatalf("CommitBlockList a+b: %v", err)
+	}
+
+	if got := e.download(t, "appended"); got != "hello world" {
+		t.Fatalf("appended blob = %q, want %q", got, "hello world")
+	}
+}

--- a/server/azure/blobstorage/blob_time_conditional_test.go
+++ b/server/azure/blobstorage/blob_time_conditional_test.go
@@ -1,0 +1,66 @@
+package blobstorage_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+const (
+	pastDate   = "Wed, 01 Jan 2020 00:00:00 GMT"
+	futureDate = "Fri, 01 Jan 2100 00:00:00 GMT"
+)
+
+func uploadK1(t *testing.T, e *blobEnv) {
+	t.Helper()
+
+	if _, err := e.svc.UploadBuffer(context.Background(), "c1", "k1", []byte("payload"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+}
+
+func TestSDKIfModifiedSinceRead(t *testing.T) {
+	e := newBlobEnv(t)
+	uploadK1(t, e)
+
+	// Blob was written "now"; it has NOT been modified since the far future -> 304.
+	if got := e.rawStatus(t, http.MethodGet, "/c1/k1", map[string]string{"If-Modified-Since": futureDate}); got != http.StatusNotModified {
+		t.Fatalf("If-Modified-Since(future) status = %d, want 304", got)
+	}
+
+	// It HAS been modified since 2020 -> full 200.
+	if got := e.rawStatus(t, http.MethodGet, "/c1/k1", map[string]string{"If-Modified-Since": pastDate}); got != http.StatusOK {
+		t.Fatalf("If-Modified-Since(past) status = %d, want 200", got)
+	}
+}
+
+func TestSDKIfUnmodifiedSinceRead(t *testing.T) {
+	e := newBlobEnv(t)
+	uploadK1(t, e)
+
+	// Modified after 2020 -> 412.
+	if got := e.rawStatus(t, http.MethodGet, "/c1/k1", map[string]string{"If-Unmodified-Since": pastDate}); got != http.StatusPreconditionFailed {
+		t.Fatalf("If-Unmodified-Since(past) status = %d, want 412", got)
+	}
+
+	// Not modified after 2100 -> 200.
+	if got := e.rawStatus(t, http.MethodGet, "/c1/k1", map[string]string{"If-Unmodified-Since": futureDate}); got != http.StatusOK {
+		t.Fatalf("If-Unmodified-Since(future) status = %d, want 200", got)
+	}
+}
+
+func TestSDKIfUnmodifiedSinceWrite(t *testing.T) {
+	e := newBlobEnv(t)
+	uploadK1(t, e)
+
+	// Overwrite gated on If-Unmodified-Since in the past: the blob has been
+	// modified after that time -> 412.
+	if got := e.rawStatus(t, http.MethodPut, "/c1/k1", map[string]string{"If-Unmodified-Since": pastDate}); got != http.StatusPreconditionFailed {
+		t.Fatalf("PUT If-Unmodified-Since(past) status = %d, want 412", got)
+	}
+
+	// With a future guard the overwrite proceeds.
+	if got := e.rawStatus(t, http.MethodPut, "/c1/k1", map[string]string{"If-Unmodified-Since": futureDate}); got != http.StatusCreated {
+		t.Fatalf("PUT If-Unmodified-Since(future) status = %d, want 201", got)
+	}
+}

--- a/server/azure/blobstorage/handler.go
+++ b/server/azure/blobstorage/handler.go
@@ -539,7 +539,7 @@ func (h *Handler) putBlob(w http.ResponseWriter, r *http.Request, container, blo
 
 	metadata := extractMetadata(r.Header)
 
-	if err := h.bucket.PutObject(r.Context(), container, blob, data, contentType, metadata); err != nil {
+	if err := h.storePutBlob(r, container, blob, data, contentType, metadata); err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -559,6 +559,49 @@ func (h *Handler) putBlob(w http.ResponseWriter, r *http.Request, container, blo
 	w.WriteHeader(http.StatusCreated)
 }
 
+// storePutBlob writes a Put Blob's content. When the driver implements the
+// Azure extensions it routes through PutBlockBlob so the request's system
+// content properties (Content-Encoding/Cache-Control/Content-Language/
+// Content-Disposition) are persisted and round-trip on a later read; otherwise
+// it falls back to the plain PutObject path.
+func (h *Handler) storePutBlob(r *http.Request, container, blob string, data []byte, contentType string, metadata map[string]string) error {
+	if ext, ok := h.bucket.(storagedriver.AzureBlobExtensions); ok {
+		props := &storagedriver.BlobProperties{ContentType: contentType}
+		if cp := blobContentProps(r); cp != nil {
+			props.ContentEncoding = cp.ContentEncoding
+			props.CacheControl = cp.CacheControl
+			props.ContentLanguage = cp.ContentLanguage
+			props.ContentDisposition = cp.ContentDisposition
+		}
+
+		_, err := ext.PutBlockBlob(r.Context(), container, blob, data, props, metadata)
+
+		return err
+	}
+
+	return h.bucket.PutObject(r.Context(), container, blob, data, contentType, metadata)
+}
+
+// blobContentProps reads the four x-ms-blob-* system content-property headers
+// (Content-Encoding/Cache-Control/Content-Language/Content-Disposition) into a
+// BlobProperties, or returns nil when none are set. ContentType is left to the
+// caller, which has its own x-ms-blob-content-type fallback chain.
+func blobContentProps(r *http.Request) *storagedriver.BlobProperties {
+	enc := r.Header.Get("X-Ms-Blob-Content-Encoding")
+	cache := r.Header.Get("X-Ms-Blob-Cache-Control")
+	lang := r.Header.Get("X-Ms-Blob-Content-Language")
+	disp := r.Header.Get("X-Ms-Blob-Content-Disposition")
+
+	if enc == "" && cache == "" && lang == "" && disp == "" {
+		return nil
+	}
+
+	return &storagedriver.BlobProperties{
+		ContentEncoding: enc, CacheControl: cache,
+		ContentLanguage: lang, ContentDisposition: disp,
+	}
+}
+
 // conditionFailed evaluates the If-None-Match / If-Match conditional write
 // headers against the current blob and, if a condition is not met, writes the
 // Azure error and returns true. Every mutating data-plane op must call this so
@@ -568,22 +611,27 @@ func (h *Handler) putBlob(w http.ResponseWriter, r *http.Request, container, blo
 // 409 BlobAlreadyExists, every other write returns 412 (per the write-operations
 // response-code table). A mismatched If-Match always yields 412.
 func (h *Handler) conditionFailed(w http.ResponseWriter, r *http.Request, container, blob string, isCreate bool) bool {
-	ifNoneMatch := r.Header.Get("If-None-Match")
-	ifMatch := r.Header.Get("If-Match")
+	c := writeConditions{
+		ifNoneMatch:       r.Header.Get("If-None-Match"),
+		ifMatch:           r.Header.Get("If-Match"),
+		ifUnmodifiedSince: r.Header.Get("If-Unmodified-Since"),
+		ifModifiedSince:   r.Header.Get("If-Modified-Since"),
+	}
 
-	if ifNoneMatch == "" && ifMatch == "" {
+	if c.empty() {
 		return false
 	}
 
-	var curETag string
+	var curETag, lastModified string
 
 	exists := false
 	if info, err := h.bucket.HeadObject(r.Context(), container, blob); err == nil {
 		exists = true
 		curETag = info.ETag
+		lastModified = info.LastModified
 	}
 
-	status, code := evalWriteConditions(ifNoneMatch, ifMatch, curETag, exists, isCreate)
+	status, code := evalWriteConditions(c, curETag, lastModified, exists, isCreate)
 	if status == 0 {
 		return false
 	}
@@ -593,13 +641,38 @@ func (h *Handler) conditionFailed(w http.ResponseWriter, r *http.Request, contai
 	return true
 }
 
-// evalWriteConditions evaluates the If-None-Match / If-Match write conditions
-// against the current blob state. It returns the HTTP status and Azure error
-// code to fail with, or (0, "") when the write may proceed.
-func evalWriteConditions(ifNoneMatch, ifMatch, curETag string, exists, isCreate bool) (status int, code string) {
+// writeConditions bundles the conditional headers evaluated on a mutating
+// data-plane op: the two ETag conditions plus the two time-based conditions.
+type writeConditions struct {
+	ifNoneMatch       string
+	ifMatch           string
+	ifUnmodifiedSince string
+	ifModifiedSince   string
+}
+
+func (c writeConditions) empty() bool {
+	return c.ifNoneMatch == "" && c.ifMatch == "" && c.ifUnmodifiedSince == "" && c.ifModifiedSince == ""
+}
+
+// evalWriteConditions evaluates the If-None-Match / If-Match / If-Unmodified-
+// Since / If-Modified-Since write conditions against the current blob state. It
+// returns the HTTP status and Azure error code to fail with, or (0, "") when
+// the write may proceed. ETag conditions are evaluated first (they take
+// precedence), then the time-based conditions.
+func evalWriteConditions(c writeConditions, curETag, lastModified string, exists, isCreate bool) (status int, code string) {
+	if status, code := evalWriteETagConditions(c, curETag, exists, isCreate); status != 0 {
+		return status, code
+	}
+
+	return evalWriteTimeConditions(c, lastModified, exists)
+}
+
+// evalWriteETagConditions evaluates the If-None-Match / If-Match write ETag
+// conditions, which take precedence over the time-based ones.
+func evalWriteETagConditions(c writeConditions, curETag string, exists, isCreate bool) (status int, code string) {
 	const conditionNotMet = "ConditionNotMet"
 
-	if ifNoneMatch == "*" && exists {
+	if c.ifNoneMatch == "*" && exists {
 		if isCreate {
 			return http.StatusConflict, "BlobAlreadyExists"
 		}
@@ -607,15 +680,52 @@ func evalWriteConditions(ifNoneMatch, ifMatch, curETag string, exists, isCreate 
 		return http.StatusPreconditionFailed, conditionNotMet
 	}
 
-	if ifMatch != "" && (!exists || !etagMatches(ifMatch, curETag)) {
+	if c.ifMatch != "" && (!exists || !etagMatches(c.ifMatch, curETag)) {
 		return http.StatusPreconditionFailed, conditionNotMet
 	}
 
-	if ifNoneMatch != "" && exists && etagMatches(ifNoneMatch, curETag) {
+	if c.ifNoneMatch != "" && exists && etagMatches(c.ifNoneMatch, curETag) {
 		return http.StatusPreconditionFailed, conditionNotMet
 	}
 
 	return 0, ""
+}
+
+// evalWriteTimeConditions evaluates the If-Unmodified-Since / If-Modified-Since
+// write conditions against the blob's LastModified.
+func evalWriteTimeConditions(c writeConditions, lastModified string, exists bool) (status int, code string) {
+	const conditionNotMet = "ConditionNotMet"
+
+	if !exists {
+		return 0, ""
+	}
+
+	if c.ifUnmodifiedSince != "" && blobModifiedSince(lastModified, c.ifUnmodifiedSince) {
+		return http.StatusPreconditionFailed, conditionNotMet
+	}
+
+	if c.ifModifiedSince != "" && !blobModifiedSince(lastModified, c.ifModifiedSince) {
+		return http.StatusPreconditionFailed, conditionNotMet
+	}
+
+	return 0, ""
+}
+
+// blobModifiedSince reports whether a blob's stored LastModified (RFC3339) is
+// strictly after the HTTP-date value of a conditional header. An unparseable
+// timestamp on either side yields false so the condition does not fire.
+func blobModifiedSince(lastModified, header string) bool {
+	ht, err := http.ParseTime(strings.TrimSpace(header))
+	if err != nil {
+		return false
+	}
+
+	lm, err := time.Parse(time.RFC3339, lastModified)
+	if err != nil {
+		return false
+	}
+
+	return lm.After(ht)
 }
 
 // conditionMessage maps a conditional-failure status to its Azure message.
@@ -649,9 +759,113 @@ func (h *Handler) getBlob(w http.ResponseWriter, r *http.Request, container, blo
 		return
 	}
 
-	writeBlobHeaders(w, &obj.Info, int64(len(obj.Data)))
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(obj.Data) //nolint:gosec // raw object bytes
+	serveBlobContent(w, r, &obj.Info, obj.Data)
+}
+
+// serveBlobContent writes a blob's body, honoring an optional byte range
+// (x-ms-range preferred, else the standard Range header). With no range it
+// returns the full body with 200 OK; a satisfiable range returns 206 Partial
+// Content with a Content-Range header and only the requested slice; a
+// syntactically invalid or unsatisfiable range returns 416 with
+// Content-Range: bytes * /total, matching Azure. (x-ms-range-get-content-md5 is
+// not honored — cloudemu does not compute the per-range MD5.)
+func serveBlobContent(w http.ResponseWriter, r *http.Request, info *storagedriver.ObjectInfo, data []byte) {
+	total := int64(len(data))
+
+	rangeHeader := r.Header.Get("X-Ms-Range")
+	if rangeHeader == "" {
+		rangeHeader = r.Header.Get("Range")
+	}
+
+	if rangeHeader == "" {
+		writeBlobHeaders(w, info, total)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data) //nolint:gosec // raw object bytes
+
+		return
+	}
+
+	start, end, ok := parseByteRange(rangeHeader, total)
+	if !ok {
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", total))
+		writeError(w, http.StatusRequestedRangeNotSatisfiable, "InvalidRange",
+			"the range specified is invalid for the current size of the resource")
+
+		return
+	}
+
+	writeBlobHeaders(w, info, end-start+1)
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, total))
+	w.WriteHeader(http.StatusPartialContent)
+	_, _ = w.Write(data[start : end+1]) //nolint:gosec // bounded slice of object bytes
+}
+
+// parseByteRange parses a single HTTP/Azure byte-range spec ("bytes=start-end",
+// "bytes=start-", or the suffix form "bytes=-N") against a total size, returning
+// the inclusive [start,end] bounds. ok is false for a malformed, multi-range,
+// or unsatisfiable spec (which the caller turns into a 416).
+func parseByteRange(header string, total int64) (start, end int64, ok bool) {
+	const prefix = "bytes="
+
+	if !strings.HasPrefix(header, prefix) {
+		return 0, 0, false
+	}
+
+	spec := strings.TrimSpace(strings.TrimPrefix(header, prefix))
+	if spec == "" || strings.Contains(spec, ",") {
+		return 0, 0, false // multi-range is not supported.
+	}
+
+	dash := strings.IndexByte(spec, '-')
+	if dash < 0 {
+		return 0, 0, false
+	}
+
+	startStr := strings.TrimSpace(spec[:dash])
+	endStr := strings.TrimSpace(spec[dash+1:])
+
+	if startStr == "" {
+		return suffixRange(endStr, total)
+	}
+
+	return boundedRange(startStr, endStr, total)
+}
+
+// suffixRange resolves a "bytes=-N" spec (the final N bytes) against total.
+func suffixRange(nStr string, total int64) (start, end int64, ok bool) {
+	n, err := strconv.ParseInt(nStr, 10, 64)
+	if err != nil || n <= 0 || total == 0 {
+		return 0, 0, false
+	}
+
+	if n > total {
+		n = total
+	}
+
+	return total - n, total - 1, true
+}
+
+// boundedRange resolves a "bytes=start-" or "bytes=start-end" spec against total.
+func boundedRange(startStr, endStr string, total int64) (start, end int64, ok bool) {
+	start, err := strconv.ParseInt(startStr, 10, 64)
+	if err != nil || start < 0 || start >= total {
+		return 0, 0, false
+	}
+
+	if endStr == "" {
+		return start, total - 1, true
+	}
+
+	end, err = strconv.ParseInt(endStr, 10, 64)
+	if err != nil || end < start {
+		return 0, 0, false
+	}
+
+	if end >= total {
+		end = total - 1
+	}
+
+	return start, end, true
 }
 
 // readConditionHandled evaluates the If-Match / If-None-Match read conditional
@@ -661,24 +875,59 @@ func (h *Handler) getBlob(w http.ResponseWriter, r *http.Request, container, blo
 // matches the current ETag (including the wildcard *) yields 304 Not Modified
 // with no body. Returns false to let the read proceed.
 func readConditionHandled(w http.ResponseWriter, r *http.Request, curETag, lastModified string) bool {
-	ifNoneMatch := r.Header.Get("If-None-Match")
-	ifMatch := r.Header.Get("If-Match")
-
-	if ifNoneMatch == "" && ifMatch == "" {
+	if !hasReadConditions(r) {
 		return false
 	}
 
-	if ifMatch != "" && !etagCondMatches(ifMatch, curETag) {
+	if readPreconditionFailed(r, curETag, lastModified) {
 		writeError(w, http.StatusPreconditionFailed, "ConditionNotMet", conditionMessage(http.StatusPreconditionFailed))
 		return true
 	}
 
-	if ifNoneMatch != "" && etagCondMatches(ifNoneMatch, curETag) {
+	if readNotModified(r, curETag, lastModified) {
 		w.Header().Set("ETag", fmt.Sprintf("%q", curETag))
 		w.Header().Set("Last-Modified", httpDate(lastModified))
 		w.WriteHeader(http.StatusNotModified)
 
 		return true
+	}
+
+	return false
+}
+
+// hasReadConditions reports whether the request carries any read conditional
+// header (the two ETag conditions or the two time-based conditions).
+func hasReadConditions(r *http.Request) bool {
+	return r.Header.Get("If-None-Match") != "" || r.Header.Get("If-Match") != "" ||
+		r.Header.Get("If-Modified-Since") != "" || r.Header.Get("If-Unmodified-Since") != ""
+}
+
+// readPreconditionFailed reports whether a read must fail 412: a mismatched
+// If-Match, or (when no If-Match is set) an If-Unmodified-Since the blob was
+// modified after. If-Match takes precedence over If-Unmodified-Since.
+func readPreconditionFailed(r *http.Request, curETag, lastModified string) bool {
+	if ifMatch := r.Header.Get("If-Match"); ifMatch != "" {
+		return !etagCondMatches(ifMatch, curETag)
+	}
+
+	if unmod := r.Header.Get("If-Unmodified-Since"); unmod != "" {
+		return blobModifiedSince(lastModified, unmod)
+	}
+
+	return false
+}
+
+// readNotModified reports whether a read must short-circuit to 304: an
+// If-None-Match that matches the current ETag, or (when no If-None-Match is set)
+// an If-Modified-Since the blob has not been modified since. If-None-Match takes
+// precedence over If-Modified-Since.
+func readNotModified(r *http.Request, curETag, lastModified string) bool {
+	if ifNoneMatch := r.Header.Get("If-None-Match"); ifNoneMatch != "" {
+		return etagCondMatches(ifNoneMatch, curETag)
+	}
+
+	if mod := r.Header.Get("If-Modified-Since"); mod != "" {
+		return !blobModifiedSince(lastModified, mod)
 	}
 
 	return false
@@ -710,9 +959,7 @@ func (h *Handler) getBlobSnapshot(w http.ResponseWriter, r *http.Request, contai
 	}
 
 	w.Header().Set("X-Ms-Snapshot", snapshot)
-	writeBlobHeaders(w, &obj.Info, int64(len(obj.Data)))
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(obj.Data) //nolint:gosec // raw snapshot bytes
+	serveBlobContent(w, r, &obj.Info, obj.Data)
 }
 
 func (h *Handler) headBlob(w http.ResponseWriter, r *http.Request, container, blob string) {
@@ -735,6 +982,7 @@ func writeBlobHeaders(w http.ResponseWriter, info *storagedriver.ObjectInfo, siz
 	w.Header().Set("ETag", fmt.Sprintf("%q", info.ETag))
 	w.Header().Set("Last-Modified", httpDate(info.LastModified))
 	w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+	w.Header().Set("Accept-Ranges", "bytes")
 
 	blobType := info.BlobType
 	if blobType == "" {
@@ -747,8 +995,23 @@ func writeBlobHeaders(w http.ResponseWriter, info *storagedriver.ObjectInfo, siz
 		w.Header().Set("X-Ms-Access-Tier", info.AccessTier)
 	}
 
+	// System content properties round-trip on read (Get Blob / Get Blob
+	// Properties) so tools like Terraform's azurerm_storage_blob don't see drift.
+	setIfNonEmpty(w, "Cache-Control", info.CacheControl)
+	setIfNonEmpty(w, "Content-Encoding", info.ContentEncoding)
+	setIfNonEmpty(w, "Content-Language", info.ContentLanguage)
+	setIfNonEmpty(w, "Content-Disposition", info.ContentDisposition)
+
 	for k, v := range info.Metadata {
 		w.Header().Set("x-ms-meta-"+k, v)
+	}
+}
+
+// setIfNonEmpty sets header key to v only when v is non-empty, so an unset
+// property does not emit a blank header.
+func setIfNonEmpty(w http.ResponseWriter, key, v string) {
+	if v != "" {
+		w.Header().Set(key, v)
 	}
 }
 

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -161,6 +161,24 @@ type BlockInfo struct {
 	Size int64
 }
 
+// BlockListEntry is one entry in a Put Block List request: a block id together
+// with the source list Azure must resolve it against. List is "Committed"
+// (a block already committed on the blob), "Uncommitted" (a freshly staged
+// block), or "Latest" (the staged block if present, else the committed one).
+// Preserving the source list lets a commit reference already-committed blocks,
+// so the "re-commit existing blocks + a new one" append pattern works.
+type BlockListEntry struct {
+	ID   string
+	List string
+}
+
+// Block source-list values for BlockListEntry.List.
+const (
+	BlockListCommitted   = "Committed"
+	BlockListUncommitted = "Uncommitted"
+	BlockListLatest      = "Latest"
+)
+
 // BlobLeaseResult is the outcome of a successful Lease Blob acquire, renew, or
 // change operation.
 type BlobLeaseResult struct {
@@ -189,9 +207,21 @@ type AzureBlobExtensions interface {
 	// under blockID; the blob need not exist yet.
 	StageBlock(ctx context.Context, container, blob, blockID string, data []byte) error
 	// CommitBlockList assembles a block blob (Put Block List, ?comp=blocklist)
-	// from the previously-staged blocks named by blockIDs, in the given order.
+	// from the given block entries, in order. Each entry names a block id and the
+	// source list to resolve it against (Committed/Uncommitted/Latest), so a
+	// commit can reference blocks already committed on the blob, not just freshly
+	// staged ones. Content properties from props (nil when none supplied) are
+	// persisted on the blob.
 	CommitBlockList(
-		ctx context.Context, container, blob string, blockIDs []string, contentType string, metadata map[string]string,
+		ctx context.Context, container, blob string, blocks []BlockListEntry,
+		contentType string, props *BlobProperties, metadata map[string]string,
+	) (*ObjectInfo, error)
+
+	// PutBlockBlob writes a block blob's content together with its system content
+	// properties (Put Blob), so Content-Encoding/Cache-Control/Content-Language/
+	// Content-Disposition round-trip on a later read. props may be nil.
+	PutBlockBlob(
+		ctx context.Context, container, blob string, data []byte, props *BlobProperties, metadata map[string]string,
 	) (*ObjectInfo, error)
 
 	// SetBlobMetadata replaces only a blob's metadata (Set Blob Metadata,


### PR DESCRIPTION
Fixes five real Azure Blob Storage residue bugs found by a deep confirming audit. All in `server/azure/blobstorage/` + `providers/azure/blobstorage/` (+ driver types in `services/storage/driver/`), batched into one PR since they touch the same packages.

## Bugs fixed

1. **[HIGH data-corruption] Get Blob ignored Range / x-ms-range.** `getBlob` always wrote the full body with 200, so the azblob SDK's parallel ranged `DownloadFile`/`DownloadBuffer` (each chunk a ranged GET) received the whole blob per chunk and assembled a corrupt file. Now parses `x-ms-range` (preferred) then `Range` (`bytes=start-end`, `bytes=start-`, `bytes=-N`), returns `206 Partial Content` with `Content-Range`/partial `Content-Length` and only the requested slice, sets `Accept-Ranges: bytes`, and returns `416` with `Content-Range: bytes */total` for an unsatisfiable range. No-range GET stays a full-body 200.

2. **[MED] Content properties never round-tripped.** Put Blob dropped `Content-Encoding`/`Cache-Control`/`Content-Language`/`Content-Disposition`; `objectInfo()` omitted them and `writeBlobHeaders` never emitted them. Put Blob now persists all four (via a new `PutBlockBlob` extension), `objectInfo()` carries them, and GET/HEAD/Get Blob Properties emit them. Terraform `azurerm_storage_blob` cache_control/content_encoding no longer drifts.

3. **[MED] Commit Block List couldn't reference committed blocks.** Committed block bytes were discarded and assembly looked only in staging, and the parser collapsed `<Committed>`/`<Uncommitted>`/`<Latest>` into one list. Now committed block bytes are retained, the per-element source list is preserved through parsing, and each id resolves against the correct source — so the "append by re-committing existing blocks plus a new one" pattern works.

4. **[MED pagination] List Blobs delimiter returned all BlobPrefixes on every page.** Prefixes were computed over all keys and never counted toward `maxresults`. Blobs and prefixes now fold into one sorted, marker-paginated stream (both count toward `maxresults`, stable-sorted, no dup/skip across pages) with `NextMarker` when truncated.

5. **[LOW-MED] If-Modified-Since / If-Unmodified-Since ignored.** Only ETag conditionals were handled. Reads now honor `If-Modified-Since` (304) and `If-Unmodified-Since` (412); writes honor `If-Unmodified-Since`/`If-Modified-Since` (412) against the blob's LastModified. ETag conditions keep precedence.

## Tests
Provider-level (committed-block re-commit, content-property round-trip) and wire-level with the real azure-sdk-for-go azblob client: ranged GET 206 + correct bytes + Content-Range, open-ended range, 416, a multi-chunk `DownloadBuffer` that asserts the assembled buffer equals the original (the data-corruption guard), content-property round-trip via GetProperties + read headers, commit-block-list re-commit referencing a committed block, delimiter+maxresults pagination without dup/skip, and If-Modified-Since 304 / If-Unmodified-Since 412.

## Gates
`go build ./...`, `go vet`, scoped `go test` (server+providers+services/storage), gofmt, `golangci-lint --new-from-rev=origin/development` (0 issues), `go generate` + `compatgen` regenerated and idempotent.