### PR TITLE
fix(azure): case-insensitive resource-group/name lookup across services

### DIFF
--- a/providers/azure/acr/registry.go
+++ b/providers/azure/acr/registry.go
@@ -241,7 +241,7 @@ func (m *Mock) ListRegistries(_ context.Context, rg string) ([]driver.AzureRegis
 	out := make([]driver.AzureRegistry, 0, len(all))
 
 	for _, rd := range all {
-		if rg != "" && rd.reg.ResourceGroup != rg {
+		if rg != "" && !strings.EqualFold(rd.reg.ResourceGroup, rg) {
 			continue
 		}
 

--- a/providers/azure/acr/registry_test.go
+++ b/providers/azure/acr/registry_test.go
@@ -36,6 +36,21 @@ func TestCreateOrUpdateRegistry(t *testing.T) {
 	assert.Equal(t, "Standard", updated.SKUName) // default when SKU omitted
 }
 
+func TestListRegistriesResourceGroupCaseInsensitive(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, _, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "MyReg", driver.AzureRegistryConfig{Location: "eastus"})
+	require.NoError(t, err)
+
+	// ARM resource-group names are case-insensitive: a list against "RG-1"
+	// must still return the registry created in "rg-1".
+	got, err := m.ListRegistries(ctx, "RG-1")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "rg-1", got[0].ResourceGroup)
+}
+
 func TestUpdateRegistryPartialMerge(t *testing.T) {
 	m, _ := newTestMock()
 	ctx := context.Background()
@@ -58,10 +73,10 @@ func TestUpdateRegistryPartialMerge(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.False(t, updated.AdminUserEnabled)
-	assert.Equal(t, "Premium", updated.SKUName)      // untouched
-	assert.Equal(t, "eastus", updated.Location)      // untouched
+	assert.Equal(t, "Premium", updated.SKUName) // untouched
+	assert.Equal(t, "eastus", updated.Location) // untouched
 	assert.Equal(t, "SystemAssigned", updated.IdentityType)
-	assert.Equal(t, "core", updated.Tags["team"])    // untouched
+	assert.Equal(t, "core", updated.Tags["team"]) // untouched
 
 	// PATCH on a missing registry is a NotFound.
 	_, err = m.UpdateRegistry(ctx, "rg-1", "ghost", driver.AzureRegistryUpdate{AdminUserEnabled: &disabled})

--- a/providers/azure/ai/ai.go
+++ b/providers/azure/ai/ai.go
@@ -257,7 +257,7 @@ func (m *Mock) ListAccountsByResourceGroup(_ context.Context, resourceGroup stri
 	out := make([]driver.Account, 0)
 
 	for _, a := range m.accounts.All() {
-		if a.ResourceGroup == resourceGroup {
+		if strings.EqualFold(a.ResourceGroup, resourceGroup) {
 			out = append(out, *cloneAccount(a))
 		}
 	}

--- a/providers/azure/ai/machine_learning.go
+++ b/providers/azure/ai/machine_learning.go
@@ -125,7 +125,7 @@ func (m *Mock) ListMLWorkspacesByResourceGroup(_ context.Context, resourceGroup 
 	out := make([]driver.MLWorkspace, 0)
 
 	for _, w := range m.mlWorkspaces.All() {
-		if w.ResourceGroup == resourceGroup {
+		if strings.EqualFold(w.ResourceGroup, resourceGroup) {
 			out = append(out, *cloneMLWorkspace(w))
 		}
 	}

--- a/providers/azure/aks/aks.go
+++ b/providers/azure/aks/aks.go
@@ -641,7 +641,7 @@ func (m *Mock) ListClustersByResourceGroup(_ context.Context, rg string) ([]Mana
 	defer m.mu.RUnlock()
 
 	all := m.clusters.Filter(func(_ string, c ManagedCluster) bool {
-		return c.ResourceGroup == rg
+		return strings.EqualFold(c.ResourceGroup, rg)
 	})
 
 	out := make([]ManagedCluster, 0, len(all))
@@ -788,7 +788,7 @@ func (m *Mock) ListAgentPools(_ context.Context, rg, cluster string) ([]AgentPoo
 	}
 
 	all := m.pools.Filter(func(_ string, p AgentPool) bool {
-		return p.ResourceGroup == rg && p.ClusterName == cluster
+		return strings.EqualFold(p.ResourceGroup, rg) && strings.EqualFold(p.ClusterName, cluster)
 	})
 
 	out := make([]AgentPool, 0, len(all))
@@ -877,7 +877,7 @@ func (m *Mock) ListMaintenanceConfigs(_ context.Context, rg, cluster string) ([]
 	}
 
 	all := m.maintenance.Filter(func(_ string, mc MaintenanceConfig) bool {
-		return mc.ResourceGroup == rg && mc.ClusterName == cluster
+		return strings.EqualFold(mc.ResourceGroup, rg) && strings.EqualFold(mc.ClusterName, cluster)
 	})
 
 	out := make([]MaintenanceConfig, 0, len(all))

--- a/providers/azure/aks/aks_test.go
+++ b/providers/azure/aks/aks_test.go
@@ -61,6 +61,28 @@ func TestClusterLifecycle(t *testing.T) {
 	}
 }
 
+// TestListClustersResourceGroupCaseInsensitive verifies a subscription-scoped
+// list with a differently-cased resource group still returns the cluster — ARM
+// resource-group names are case-insensitive.
+func TestListClustersResourceGroupCaseInsensitive(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateOrUpdateCluster(ctx, ClusterInput{
+		Subscription:  "sub-1",
+		ResourceGroup: "rg-1",
+		Name:          "k8s-prod",
+		Location:      "eastus",
+		AgentPools:    []AgentPoolInput{{Name: "system", Count: 1, VMSize: "Standard_D2s_v3", Mode: "System"}},
+	})
+	requireNoError(t, err)
+
+	list, err := m.ListClustersByResourceGroup(ctx, "RG-1")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(list))
+	assertEqual(t, "rg-1", list[0].ResourceGroup)
+}
+
 func TestClusterRequiresName(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/providers/azure/cosmospostgresql/cosmospostgresql.go
+++ b/providers/azure/cosmospostgresql/cosmospostgresql.go
@@ -415,7 +415,7 @@ func (m *Mock) ListClustersByResourceGroup(_ context.Context, rg string) ([]cpgd
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	return m.filterClusters(func(c *cpgdriver.Cluster) bool { return c.ResourceGroup == rg }), nil
+	return m.filterClusters(func(c *cpgdriver.Cluster) bool { return strings.EqualFold(c.ResourceGroup, rg) }), nil
 }
 
 // ListClustersBySubscription returns all clusters (the mock serves one

--- a/providers/azure/databricks/arm_accessconnectors.go
+++ b/providers/azure/databricks/arm_accessconnectors.go
@@ -123,7 +123,7 @@ func (m *Mock) ListAccessConnectorsByResourceGroup(
 	out := make([]driver.AccessConnector, 0)
 
 	for _, ac := range m.accessConnectors.All() {
-		if ac.ResourceGroup == resourceGroup {
+		if strings.EqualFold(ac.ResourceGroup, resourceGroup) {
 			out = append(out, *cloneAccessConnector(ac))
 		}
 	}

--- a/providers/azure/databricks/databricks.go
+++ b/providers/azure/databricks/databricks.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -189,7 +190,7 @@ func (m *Mock) ListWorkspacesByResourceGroup(_ context.Context, resourceGroup st
 	out := make([]driver.Workspace, 0)
 
 	for _, ws := range m.workspaces.All() {
-		if ws.ResourceGroup == resourceGroup {
+		if strings.EqualFold(ws.ResourceGroup, resourceGroup) {
 			out = append(out, *cloneWorkspace(ws))
 		}
 	}

--- a/providers/azure/functions/app_service_plan.go
+++ b/providers/azure/functions/app_service_plan.go
@@ -143,7 +143,7 @@ func (m *Mock) ListAppServicePlans(_ context.Context, subscription, resourceGrou
 			continue
 		}
 
-		if resourceGroup != "" && p.ResourceGroup != resourceGroup {
+		if resourceGroup != "" && !strings.EqualFold(p.ResourceGroup, resourceGroup) {
 			continue
 		}
 

--- a/providers/azure/functions/site_meta.go
+++ b/providers/azure/functions/site_meta.go
@@ -218,7 +218,7 @@ func (m *Mock) GetSiteMeta(_ context.Context, subscription, resourceGroup, name 
 	defer m.sitesMu.RUnlock()
 
 	meta, ok := m.sites.Get(name)
-	if !ok || meta.Subscription != subscription || meta.ResourceGroup != resourceGroup {
+	if !ok || meta.Subscription != subscription || !strings.EqualFold(meta.ResourceGroup, resourceGroup) {
 		return nil, cerrors.Newf(cerrors.NotFound, "site %s not found", name)
 	}
 
@@ -236,7 +236,7 @@ func (m *Mock) DeleteSiteMeta(_ context.Context, subscription, resourceGroup, na
 	defer m.sitesMu.Unlock()
 
 	meta, ok := m.sites.Get(name)
-	if !ok || meta.Subscription != subscription || meta.ResourceGroup != resourceGroup {
+	if !ok || meta.Subscription != subscription || !strings.EqualFold(meta.ResourceGroup, resourceGroup) {
 		return nil
 	}
 
@@ -256,7 +256,7 @@ func (m *Mock) UpdateAppSettings(
 	defer m.sitesMu.Unlock()
 
 	meta, ok := m.sites.Get(name)
-	if !ok || meta.Subscription != subscription || meta.ResourceGroup != resourceGroup {
+	if !ok || meta.Subscription != subscription || !strings.EqualFold(meta.ResourceGroup, resourceGroup) {
 		return nil, cerrors.Newf(cerrors.NotFound, "site %s not found", name)
 	}
 
@@ -278,7 +278,7 @@ func (m *Mock) GetFunctionScoped(ctx context.Context, subscription, resourceGrou
 	meta, ok := m.sites.Get(name)
 	m.sitesMu.RUnlock()
 
-	if !ok || meta.Subscription != subscription || meta.ResourceGroup != resourceGroup {
+	if !ok || meta.Subscription != subscription || !strings.EqualFold(meta.ResourceGroup, resourceGroup) {
 		return nil, cerrors.Newf(cerrors.NotFound, "site %s not found", name)
 	}
 
@@ -296,7 +296,7 @@ func (m *Mock) DeleteFunctionScoped(ctx context.Context, subscription, resourceG
 	defer m.sitesMu.Unlock()
 
 	meta, ok := m.sites.Get(name)
-	if !ok || meta.Subscription != subscription || meta.ResourceGroup != resourceGroup {
+	if !ok || meta.Subscription != subscription || !strings.EqualFold(meta.ResourceGroup, resourceGroup) {
 		return cerrors.Newf(cerrors.NotFound, "site %s not found", name)
 	}
 
@@ -323,7 +323,7 @@ func (m *Mock) ListSiteMeta(_ context.Context, subscription, resourceGroup strin
 			continue
 		}
 
-		if resourceGroup != "" && meta.ResourceGroup != resourceGroup {
+		if resourceGroup != "" && !strings.EqualFold(meta.ResourceGroup, resourceGroup) {
 			continue
 		}
 

--- a/providers/azure/functions/site_meta_test.go
+++ b/providers/azure/functions/site_meta_test.go
@@ -163,6 +163,27 @@ func TestGetSiteMetaScoped(t *testing.T) {
 	}
 }
 
+// TestGetSiteMetaResourceGroupCaseInsensitive verifies that a GET with a
+// differently-cased resource group resolves the site — ARM resource-group
+// names are case-insensitive.
+func TestGetSiteMetaResourceGroupCaseInsensitive(t *testing.T) {
+	m := newMetaMock()
+	ctx := context.Background()
+
+	if _, err := m.UpsertSiteMeta(ctx, SiteMeta{Name: "app1", Subscription: "sub1", ResourceGroup: "rgA"}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, err := m.GetSiteMeta(ctx, "sub1", "RGA", "app1")
+	if err != nil {
+		t.Fatalf("get with differently-cased rg: %v", err)
+	}
+
+	if got.ResourceGroup != "rgA" {
+		t.Fatalf("stored rg casing = %q, want %q (comparison case-insensitive, storage unchanged)", got.ResourceGroup, "rgA")
+	}
+}
+
 // TestDeleteSiteMetaScoped covers the deep-sweep BLOCKER: DELETE against the
 // wrong resource group must not remove another resource group's site.
 func TestDeleteSiteMetaScoped(t *testing.T) {

--- a/providers/azure/loadbalancer/azure_load_balancer.go
+++ b/providers/azure/loadbalancer/azure_load_balancer.go
@@ -2,6 +2,7 @@ package loadbalancer
 
 import (
 	"context"
+	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
@@ -69,7 +70,7 @@ func (m *Mock) ListAzureLoadBalancers(_ context.Context, rg string) ([]driver.Az
 	out := make([]driver.AzureLoadBalancer, 0, len(all))
 
 	for i := range all {
-		if rg != "" && all[i].ResourceGroup != rg {
+		if rg != "" && !strings.EqualFold(all[i].ResourceGroup, rg) {
 			continue
 		}
 
@@ -259,7 +260,7 @@ func (m *Mock) DeleteAzureLBNatRule(_ context.Context, rg, name, natRuleName str
 // hasFrontend reports whether name matches a frontend IP configuration in in.
 func hasFrontend(in []driver.AzureLBFrontend, name string) bool {
 	for i := range in {
-		if in[i].Name == name {
+		if strings.EqualFold(in[i].Name, name) {
 			return true
 		}
 	}

--- a/providers/azure/managedcassandra/managedcassandra.go
+++ b/providers/azure/managedcassandra/managedcassandra.go
@@ -186,7 +186,7 @@ func (m *Mock) ListClustersByResourceGroup(_ context.Context, rg string) ([]mcdr
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	return m.filterClusters(func(c *mcdriver.Cluster) bool { return c.ResourceGroup == rg }), nil
+	return m.filterClusters(func(c *mcdriver.Cluster) bool { return strings.EqualFold(c.ResourceGroup, rg) }), nil
 }
 
 // ListClustersBySubscription returns all clusters (the mock serves one

--- a/providers/azure/search/search.go
+++ b/providers/azure/search/search.go
@@ -243,7 +243,7 @@ func (m *Mock) ListServicesByResourceGroup(_ context.Context, resourceGroup stri
 	out := make([]driver.Service, 0)
 
 	for _, s := range m.services.All() {
-		if s.ResourceGroup == resourceGroup {
+		if strings.EqualFold(s.ResourceGroup, resourceGroup) {
 			out = append(out, *cloneService(s))
 		}
 	}

--- a/server/azure/disks/disks_test.go
+++ b/server/azure/disks/disks_test.go
@@ -133,3 +133,57 @@ func TestSDKDiskRoundTrip(t *testing.T) {
 		t.Errorf("delete poll: %v", err)
 	}
 }
+
+// TestSDKDiskListResourceGroupCaseInsensitive verifies that a disk created in
+// "rg-1" is returned by a list against "RG-1" — ARM resource-group names are
+// case-insensitive.
+func TestSDKDiskListResourceGroupCaseInsensitive(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		Disks:           cloudP.VirtualMachines,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newDisksClient(t, ts)
+	ctx := context.Background()
+
+	createPoller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "data-disk-1",
+		armcompute.Disk{
+			Location: to.Ptr("eastus"),
+			SKU:      &armcompute.DiskSKU{Name: to.Ptr(armcompute.DiskStorageAccountTypesPremiumLRS)},
+			Properties: &armcompute.DiskProperties{
+				CreationData: &armcompute.CreationData{CreateOption: to.Ptr(armcompute.DiskCreateOptionEmpty)},
+				DiskSizeGB:   to.Ptr[int32](64),
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := createPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("create poll: %v", err)
+	}
+
+	pager := client.NewListByResourceGroupPager("RG-1", nil)
+
+	found := false
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		for _, d := range page.Value {
+			if d.Name != nil && *d.Name == "data-disk-1" {
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		t.Error("List against differently-cased resource group did not return data-disk-1")
+	}
+}

--- a/server/azure/disks/handler.go
+++ b/server/azure/disks/handler.go
@@ -216,7 +216,7 @@ func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp azu
 	out := make([]diskResponse, 0, len(vols))
 
 	for i := range vols {
-		if rp.ResourceGroup != "" && tagOr(vols[i].Tags, rgTag, "") != rp.ResourceGroup {
+		if rp.ResourceGroup != "" && !strings.EqualFold(tagOr(vols[i].Tags, rgTag, ""), rp.ResourceGroup) {
 			continue
 		}
 

--- a/server/azure/images/handler.go
+++ b/server/azure/images/handler.go
@@ -91,7 +91,7 @@ func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp azu
 	out := make([]imageResponse, 0, len(imgs))
 
 	for i := range imgs {
-		if rp.ResourceGroup != "" && tagOr(imgs[i].Tags, rgTag, "") != rp.ResourceGroup {
+		if rp.ResourceGroup != "" && !strings.EqualFold(tagOr(imgs[i].Tags, rgTag, ""), rp.ResourceGroup) {
 			continue
 		}
 

--- a/server/azure/notificationhubs/operations.go
+++ b/server/azure/notificationhubs/operations.go
@@ -117,7 +117,7 @@ func (h *Handler) getNamespace(w http.ResponseWriter, r *http.Request, rp *azure
 // with the namespace's stored resource group.
 func wrongResourceGroup(rp *azurearm.ResourcePath, info *notifdriver.TopicInfo) bool {
 	return rp.ResourceGroup != "" && info.Scope.ResourceGroup != "" &&
-		info.Scope.ResourceGroup != rp.ResourceGroup
+		!strings.EqualFold(info.Scope.ResourceGroup, rp.ResourceGroup)
 }
 
 // deleteNamespace removes the namespace topic and every hub topic nested under

--- a/server/azure/snapshots/handler.go
+++ b/server/azure/snapshots/handler.go
@@ -91,7 +91,7 @@ func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp azu
 	out := make([]snapshotResponse, 0, len(snaps))
 
 	for i := range snaps {
-		if rp.ResourceGroup != "" && tagOr(snaps[i].Tags, rgTag, "") != rp.ResourceGroup {
+		if rp.ResourceGroup != "" && !strings.EqualFold(tagOr(snaps[i].Tags, rgTag, ""), rp.ResourceGroup) {
 			continue
 		}
 

--- a/server/azure/sshpublickeys/handler.go
+++ b/server/azure/sshpublickeys/handler.go
@@ -91,7 +91,7 @@ func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp azu
 	out := make([]sshKeyResponse, 0, len(keys))
 
 	for i := range keys {
-		if rp.ResourceGroup != "" && tagOr(keys[i].Tags, rgTag, "") != rp.ResourceGroup {
+		if rp.ResourceGroup != "" && !strings.EqualFold(tagOr(keys[i].Tags, rgTag, ""), rp.ResourceGroup) {
 			continue
 		}
 

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -1367,7 +1367,7 @@ func (h *Handler) listPublicIPs(w http.ResponseWriter, r *http.Request, rp azure
 	out := publicIPListResponse{}
 
 	for i := range infos {
-		if rp.ResourceGroup != "" && tagOr(infos[i].Tags, armPublicIPRGTag, "") != rp.ResourceGroup {
+		if rp.ResourceGroup != "" && !strings.EqualFold(tagOr(infos[i].Tags, armPublicIPRGTag, ""), rp.ResourceGroup) {
 			continue
 		}
 

--- a/server/azure/vnet/nat_gateway.go
+++ b/server/azure/vnet/nat_gateway.go
@@ -218,7 +218,7 @@ func (h *Handler) listNATGateways(w http.ResponseWriter, r *http.Request, rp azu
 	out := natGatewayListResponse{}
 
 	for i := range infos {
-		if rp.ResourceGroup != "" && tagOr(infos[i].Tags, armNATGatewayRGTag, "") != rp.ResourceGroup {
+		if rp.ResourceGroup != "" && !strings.EqualFold(tagOr(infos[i].Tags, armNATGatewayRGTag, ""), rp.ResourceGroup) {
 			continue
 		}
 


### PR DESCRIPTION
## What

Fixes a systemic bug where Azure GET/LIST paths returned a spurious 404 when a
user supplied a resource-group (or a case-insensitive resource name) with
different casing than what was stored. Azure ARM resource-group names — and
almost all resource names — are **case-insensitive**, but ~20 get/list sites
used exact `==`/`!=` string compares.

This replaces those exact compares with `strings.EqualFold` across the affected
services. Only the **comparison** changes — stored casing and response bodies
are untouched. The shared overlay-key half of this bug was already fixed
globally in #760 (`echo_properties.go`); this PR closes the remaining
per-service exact-compare sites.

## Why

Real ARM treats `rg-1` and `RG-1` as the same resource group; a CLI/SDK/IaC
tool that lists or gets with different casing than a create used must still
resolve the resource. The exact compares caused false NotFound results.

## Services touched

Resource-group compares (server handlers): notificationhubs, disks, images,
snapshots, sshpublickeys, vnet (public IP + NAT gateway).

Resource-group + case-insensitive name compares (provider backends): aks
(cluster/pool/maintenance list + cluster & node-pool names), acr, search, ai
(+ machine learning), functions (site metadata + app service plan), databricks
(workspaces + access connectors), loadbalancer (list + frontend IP config
name), managedcassandra, cosmospostgresql.

## Not touched (intentionally)

Azure **Blob names are case-sensitive** — the blob-name compares in
`storageaccount/handler.go` are left as-is.

## Tests

Added representative fail-before/pass-after tests across structurally-distinct
layers:
- `aks`: `ListClustersByResourceGroup` with differently-cased RG
- `functions`: `GetSiteMeta` with differently-cased RG
- `disks` (server handler, tag-based): SDK list-by-resource-group with
  differently-cased RG
- `acr` (provider backend): `ListRegistries` with differently-cased RG

Remaining sites rely on the mechanical, identical transformation plus existing
tests passing.
