### PR TITLE
fix(azure-cosmos): functional ETag/If-Match concurrency, partition-scoped queries, FakeClock TTL, write-time _ts, delete-missing 404

### DIFF
--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -131,6 +131,13 @@ func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
 	m.monitoring = mon
 }
 
+// Clock exposes the mock's injected clock so the Cosmos wire handler can drive
+// its container-TTL expiry and write-time timestamps from the same clock,
+// letting a FakeClock set on the provider make those deterministic in tests.
+func (m *Mock) Clock() config.Clock {
+	return m.opts.Clock
+}
+
 func (m *Mock) emitMetric(container string, metrics map[string]float64) {
 	if m.monitoring == nil {
 		return

--- a/server/azure/cosmosdb/container_attrs.go
+++ b/server/azure/cosmosdb/container_attrs.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/stackshy/cloudemu/v2/config"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 )
 
@@ -37,10 +38,14 @@ type attrsStore struct {
 	// expiry maps an item identity (table|partitionValue|id) to its computed
 	// expiry time. An item absent here never expires.
 	expiry map[string]time.Time
+	// clock computes expiry at write time and evaluates it at read time, so a
+	// FakeClock injected into the provider drives container-TTL deterministically
+	// rather than the wall clock.
+	clock config.Clock
 }
 
-func newAttrsStore() *attrsStore {
-	return &attrsStore{attrs: make(map[string]containerAttrs), expiry: make(map[string]time.Time)}
+func newAttrsStore(clock config.Clock) *attrsStore {
+	return &attrsStore{attrs: make(map[string]containerAttrs), expiry: make(map[string]time.Time), clock: clock}
 }
 
 func (s *attrsStore) set(table string, ttl *int32, uk *uniqueKeyPolicy, indexing map[string]any) {
@@ -120,7 +125,7 @@ func (s *attrsStore) recordWrite(table string, cfg *dbdriver.TableConfig, item m
 		return
 	}
 
-	s.expiry[key] = time.Now().Add(time.Duration(effective) * time.Second)
+	s.expiry[key] = s.clock.Now().Add(time.Duration(effective) * time.Second)
 }
 
 // expired reports whether the item at (table, id, partition value) has
@@ -133,7 +138,7 @@ func (s *attrsStore) expired(table string, cfg *dbdriver.TableConfig, item map[s
 	exp, ok := s.expiry[key]
 	s.mu.RUnlock()
 
-	return ok && time.Now().After(exp)
+	return ok && s.clock.Now().After(exp)
 }
 
 // forget removes an item's TTL bookkeeping, called on delete.

--- a/server/azure/cosmosdb/cosmos_lifecycle_test.go
+++ b/server/azure/cosmosdb/cosmos_lifecycle_test.go
@@ -17,8 +17,6 @@
 //
 // Emulator divergences from real Cosmos that these tests pin down (asserting
 // the emulator's actual, documented behavior, marked DIVERGENCE below):
-//   - ReplaceItem ignores IfMatchEtag (real Cosmos: 412 on stale etag).
-//   - DeleteItem on a missing document returns 204 (real Cosmos: 404).
 //   - PATCH (PatchItem) is not routed at all (405 MethodNotAllowed).
 //   - NOT over a composite predicate (AND/OR of several fields) uses two-valued
 //     logic, so an absent field is not excluded; NOT over a single-field
@@ -346,10 +344,10 @@ func TestCosmosTypedErrors(t *testing.T) {
 
 // TestCosmosWriteDivergences pins down the emulator's write semantics: the
 // (partition key, id) identity model — duplicate create 409s, an upsert of the
-// same id succeeds, and same-pk/different-id documents coexist — plus the
-// remaining knowing divergences from real Cosmos (see file header): etag
-// preconditions are ignored, deleting a missing document succeeds, and PATCH is
-// not routed.
+// same id succeeds, and same-pk/different-id documents coexist — plus
+// optimistic concurrency (a stale If-Match is 412) and a 404 on deleting a
+// missing document. The one remaining knowing divergence is that PATCH is not
+// routed (405).
 func TestCosmosWriteDivergences(t *testing.T) {
 	ctx := context.Background()
 	env := newCosmosEnv(t)
@@ -382,18 +380,17 @@ func TestCosmosWriteDivergences(t *testing.T) {
 		t.Errorf("rev=%v want 2 (upsert should have overwritten)", got["rev"])
 	}
 
-	// DIVERGENCE: ReplaceItem with a deliberately stale IfMatchEtag succeeds
-	// (real Cosmos returns 412 PreconditionFailed). ConditionExpression-style
-	// guards are not implemented anywhere in the driver.
+	// ReplaceItem with a deliberately stale IfMatchEtag is rejected 412
+	// PreconditionFailed, matching real Cosmos optimistic concurrency, and the
+	// stored document is left untouched (still rev 2 from the upsert above).
 	stale := azcore.ETag(`"definitely-stale-etag"`)
 	repl, _ := json.Marshal(map[string]any{"id": "u1", "pk": "team-a", "name": "Alice-3", "rev": 3})
 
-	if _, err := cc.ReplaceItem(ctx, pk, "u1", repl, &azcosmos.ItemOptions{IfMatchEtag: &stale}); err != nil {
-		t.Fatalf("ReplaceItem with stale etag (emulator ignores preconditions): %v", err)
-	}
+	_, staleErr := cc.ReplaceItem(ctx, pk, "u1", repl, &azcosmos.ItemOptions{IfMatchEtag: &stale})
+	wantRespErr(t, staleErr, 412, "ReplaceItem with stale etag")
 
-	if got := readDoc(ctx, t, cc, "team-a", "u1"); got["rev"] != float64(3) {
-		t.Errorf("rev=%v want 3 (stale-etag replace should have applied)", got["rev"])
+	if got := readDoc(ctx, t, cc, "team-a", "u1"); got["rev"] != float64(2) {
+		t.Errorf("rev=%v want 2 (stale-etag replace must not apply)", got["rev"])
 	}
 
 	// DIVERGENCE: PATCH is not routed by the handler → 405 (real Cosmos
@@ -403,16 +400,9 @@ func TestCosmosWriteDivergences(t *testing.T) {
 	_, patchErr := cc.PatchItem(ctx, pk, "u1", patch, nil)
 	wantRespErr(t, patchErr, 405, "PatchItem (unrouted PATCH)")
 
-	// DIVERGENCE: deleting a document that does not exist succeeds with 204
-	// (real Cosmos returns 404) — the driver delete is idempotent.
-	delResp, err := cc.DeleteItem(ctx, pk, "never-existed", nil)
-	if err != nil {
-		t.Fatalf("DeleteItem missing doc (emulator is idempotent): %v", err)
-	}
-
-	if delResp.RawResponse.StatusCode != 204 {
-		t.Errorf("DeleteItem missing doc status=%d want 204", delResp.RawResponse.StatusCode)
-	}
+	// Deleting a document that does not exist is a 404, matching real Cosmos.
+	_, missErr := cc.DeleteItem(ctx, pk, "never-existed", nil)
+	wantRespErr(t, missErr, 404, "DeleteItem missing doc")
 
 	// Item identity is (pk, id): two docs with the same partition key but
 	// different ids coexist, and each point-reads back independently.
@@ -479,15 +469,15 @@ func TestCosmosReplaceSemantics(t *testing.T) {
 // TestCosmosQueryAndPagination drives the SDK query pager: empty container
 // first, then 30 documents across two partitions. The WHERE clause is
 // evaluated faithfully, so `c.part = 'part-a'` returns exactly the 15 part-a
-// documents. The partition-key header is advisory in the emulator (its item
-// model conflates partition and document identity), so cross-partition WHERE
-// does the filtering.
+// documents. Each document has a distinct partition key (pk = its id), so the
+// WHERE filtering is exercised as a cross-partition query (no partition key);
+// a partition-scoped query would only ever see its own partition's document.
 func TestCosmosQueryAndPagination(t *testing.T) {
 	ctx := context.Background()
 	env := newCosmosEnv(t)
 	cc := env.container(ctx, t, "querydb", "events")
 
-	pkA := azcosmos.NewPartitionKeyString("part-a")
+	pkA := azcosmos.NewPartitionKey()
 
 	countAll := func(label string) int {
 		t.Helper()
@@ -840,7 +830,10 @@ func TestCosmosQueryFidelity(t *testing.T) {
 		createDoc(ctx, t, cc, d["pk"].(string), d)
 	}
 
-	pk := azcosmos.NewPartitionKeyString("p1") // advisory in the emulator
+	// Documents live in distinct partitions (pk = p1/p2/p3), so query fidelity is
+	// exercised cross-partition (no partition key); the WHERE/ORDER BY/projection
+	// logic is what's under test, not partition routing.
+	pk := azcosmos.NewPartitionKey()
 
 	rawItems := func(sql string, opts *azcosmos.QueryOptions) [][]byte {
 		t.Helper()

--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -29,8 +29,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 	"github.com/stackshy/cloudemu/v2/services/database/driver/cosmossql"
@@ -75,16 +77,41 @@ type Handler struct {
 	// uniqueness check and its insert must be one uninterruptible step (see
 	// keyedMutex), and a lazy TTL sweep must not race a concurrent write.
 	writeMu *keyedMutex
+
+	// clock stamps write-time system properties (_ts) and drives container-TTL
+	// expiry, sourced from the backing driver when it exposes one (see
+	// clockProvider) so a FakeClock injected into the provider drives the wire
+	// layer too; a RealClock otherwise.
+	clock config.Clock
+
+	// etagSeq backs the rotating document _etag: every write increments it, so a
+	// document's etag changes on each mutation and an If-Match precondition can
+	// actually detect a stale write.
+	etagSeq atomic.Uint64
+}
+
+// clockProvider is the optional capability a backing driver exposes to share its
+// injected clock with the wire layer, so a FakeClock set on the provider drives
+// container-TTL expiry and write-time timestamps here too. The Azure cosmos
+// provider implements it; drivers that don't fall back to a RealClock.
+type clockProvider interface {
+	Clock() config.Clock
 }
 
 // New returns a Cosmos handler backed by db.
 func New(db dbdriver.Database) *Handler {
+	clock := config.Clock(config.RealClock{})
+	if cp, ok := db.(clockProvider); ok && cp.Clock() != nil {
+		clock = cp.Clock()
+	}
+
 	return &Handler{
 		db:        db,
 		offers:    make(map[string]offerState),
 		databases: make(map[string]struct{}),
-		attrs:     newAttrsStore(),
+		attrs:     newAttrsStore(clock),
 		writeMu:   newKeyedMutex(),
+		clock:     clock,
 	}
 }
 
@@ -699,12 +726,14 @@ func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, coll st
 		return
 	}
 
-	if err := h.insertDocument(r.Context(), coll, cfg, item, isUpsert(r)); err != nil {
+	etag, err := h.insertDocument(r.Context(), coll, cfg, item, isUpsert(r))
+	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
 	addSystemProps(item)
+	w.Header().Set("ETag", etag)
 	writeJSON(w, http.StatusCreated, item)
 }
 
@@ -716,33 +745,37 @@ func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, coll st
 // wire layer maps them to a 409.
 func (h *Handler) insertDocument(
 	ctx context.Context, coll string, cfg *dbdriver.TableConfig, item map[string]any, upsert bool,
-) error {
+) (string, error) {
 	unlock := h.writeMu.lock(coll)
 	defer unlock()
 
 	// A plain create (not an upsert) must fail if a document with the same
 	// (partition key, id) already exists, matching real Cosmos's 409 Conflict.
 	if !upsert && h.documentExists(ctx, coll, cfg, item) {
-		return cerrors.New(cerrors.AlreadyExists, "Resource with specified id or name already exists.")
+		return "", cerrors.New(cerrors.AlreadyExists, "Resource with specified id or name already exists.")
 	}
 
 	if err := h.checkUniqueKeys(ctx, coll, cfg, item); err != nil {
-		return err
+		return "", err
 	}
 
+	etag := h.stampWrite(item)
+
 	if err := h.db.PutItem(ctx, coll, item); err != nil {
-		return err
+		return "", err
 	}
 
 	h.attrs.recordWrite(coll, cfg, item)
 
-	return nil
+	return etag, nil
 }
 
 // replaceDocument overwrites a document and refreshes its TTL bookkeeping under
 // the container's write lock, so a concurrent TTL reap cannot delete the item
 // between the write and the expiry update.
-func (h *Handler) replaceDocument(ctx context.Context, coll string, cfg *dbdriver.TableConfig, item map[string]any) error {
+func (h *Handler) replaceDocument(
+	ctx context.Context, coll string, cfg *dbdriver.TableConfig, item map[string]any, ifMatch string,
+) (string, error) {
 	unlock := h.writeMu.lock(coll)
 	defer unlock()
 
@@ -750,28 +783,51 @@ func (h *Handler) replaceDocument(ctx context.Context, coll string, cfg *dbdrive
 	// for a replace of a missing id (creation is the upsert path). The existence
 	// check runs under the write lock already held, so the check and the PutItem
 	// stay atomic and no new race is introduced.
-	if !h.documentExists(ctx, coll, cfg, item) {
-		return cerrors.New(cerrors.NotFound, "Entity with the specified id does not exist in the system.")
+	existing, err := h.db.GetItem(ctx, coll, docKey(cfg, item))
+	if err != nil {
+		return "", cerrors.New(cerrors.NotFound, "Entity with the specified id does not exist in the system.")
 	}
 
-	if err := h.db.PutItem(ctx, coll, item); err != nil {
-		return err
+	// Optimistic concurrency: a stale/mismatched If-Match is a 412 before any
+	// mutation, so the caller's overwrite is rejected rather than clobbering a
+	// newer write.
+	if cerr := checkIfMatch(ifMatch, existing); cerr != nil {
+		return "", cerr
+	}
+
+	etag := h.stampWrite(item)
+
+	if perr := h.db.PutItem(ctx, coll, item); perr != nil {
+		return "", perr
 	}
 
 	h.attrs.recordWrite(coll, cfg, item)
 
-	return nil
+	return etag, nil
 }
 
 // deleteDocument removes a document and its TTL bookkeeping under the
 // container's write lock, keeping the delete and forget serialized against
-// creates, replaces and TTL reaps.
-func (h *Handler) deleteDocument(ctx context.Context, coll string, cfg *dbdriver.TableConfig, keyMap map[string]any) error {
+// creates, replaces and TTL reaps. A delete of a missing (id, partition key) is
+// a 404 (real Cosmos), and a stale If-Match precondition is a 412 — both checked
+// under the same lock so they stay atomic with the delete.
+func (h *Handler) deleteDocument(
+	ctx context.Context, coll string, cfg *dbdriver.TableConfig, keyMap map[string]any, ifMatch string,
+) error {
 	unlock := h.writeMu.lock(coll)
 	defer unlock()
 
-	if err := h.db.DeleteItem(ctx, coll, keyMap); err != nil {
-		return err
+	existing, err := h.db.GetItem(ctx, coll, keyMap)
+	if err != nil {
+		return cerrors.New(cerrors.NotFound, "Entity with the specified id does not exist in the system.")
+	}
+
+	if cerr := checkIfMatch(ifMatch, existing); cerr != nil {
+		return cerr
+	}
+
+	if derr := h.db.DeleteItem(ctx, coll, keyMap); derr != nil {
+		return derr
 	}
 
 	h.attrs.forget(coll, cfg, keyMap)
@@ -784,14 +840,57 @@ func (h *Handler) deleteDocument(ctx context.Context, coll string, cfg *dbdriver
 func (h *Handler) documentExists(
 	ctx context.Context, coll string, cfg *dbdriver.TableConfig, item map[string]any,
 ) bool {
+	_, err := h.db.GetItem(ctx, coll, docKey(cfg, item))
+
+	return err == nil
+}
+
+// docKey builds the (partition key, id) lookup key for item.
+func docKey(cfg *dbdriver.TableConfig, item map[string]any) map[string]any {
 	key := map[string]any{idAttr: item[idAttr]}
 	if cfg != nil && cfg.PartitionKey != "" && cfg.PartitionKey != idAttr {
 		key[cfg.PartitionKey] = item[cfg.PartitionKey]
 	}
 
-	_, err := h.db.GetItem(ctx, coll, key)
+	return key
+}
 
-	return err == nil
+// newETag returns a fresh, rotating entity tag. Each call yields a distinct
+// quoted token, so every write changes the document's _etag the way real Cosmos
+// rotates it on mutation, giving optimistic-concurrency preconditions something
+// to detect.
+func (h *Handler) newETag() string {
+	return `"` + strconv.FormatUint(h.etagSeq.Add(1), 10) + `"`
+}
+
+// stampWrite records the write-time system properties on item: a fresh rotating
+// _etag and the write timestamp _ts (from the injected clock, so both are
+// deterministic under a FakeClock). It returns the etag so the caller can echo
+// it in the ETag response header. Called on every create/replace/upsert so the
+// stored document — and later reads of it — reflect the last write, not the read.
+func (h *Handler) stampWrite(item map[string]any) string {
+	etag := h.newETag()
+	item["_etag"] = etag
+	item["_ts"] = h.clock.Now().Unix()
+
+	return etag
+}
+
+// checkIfMatch enforces an If-Match precondition against the stored document.
+// An empty header means no precondition; "*" matches any existing document;
+// otherwise the header must equal the document's current _etag, else real Cosmos
+// returns 412 PreconditionFailed (mapped from FailedPrecondition in writeErr).
+func checkIfMatch(ifMatch string, existing map[string]any) error {
+	if ifMatch == "" || ifMatch == "*" {
+		return nil
+	}
+
+	cur, _ := existing["_etag"].(string)
+	if ifMatch != cur {
+		return cerrors.New(cerrors.FailedPrecondition, "One of the specified pre-condition is not met.")
+	}
+
+	return nil
 }
 
 // readDocument serves the GET case of documentResource: a point read that
@@ -810,6 +909,11 @@ func (h *Handler) readDocument(w http.ResponseWriter, r *http.Request, coll stri
 	}
 
 	addSystemProps(item)
+
+	if etag, ok := item["_etag"].(string); ok {
+		w.Header().Set("ETag", etag)
+	}
+
 	writeJSON(w, http.StatusOK, item)
 }
 
@@ -929,6 +1033,12 @@ func (h *Handler) queryDocuments(w http.ResponseWriter, r *http.Request, coll st
 		return
 	}
 
+	cfg, derr := h.db.DescribeTable(r.Context(), coll)
+	if derr != nil {
+		writeErr(w, derr)
+		return
+	}
+
 	// Fetch the whole container and evaluate the query here with full fidelity.
 	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: coll, Limit: allResults})
 	if err != nil {
@@ -937,6 +1047,7 @@ func (h *Handler) queryDocuments(w http.ResponseWriter, r *http.Request, coll st
 	}
 
 	items := h.dropExpired(r.Context(), coll, result.Items)
+	items = scopeToPartition(r, cfg, items)
 
 	matched, ferr := cosmosFilter(items, stmt.Where)
 	if ferr != nil {
@@ -994,15 +1105,17 @@ func (h *Handler) documentResource(w http.ResponseWriter, r *http.Request, accou
 			return
 		}
 
-		if err := h.replaceDocument(r.Context(), coll, cfg, item); err != nil {
+		etag, err := h.replaceDocument(r.Context(), coll, cfg, item, ifMatch(r))
+		if err != nil {
 			writeErr(w, err)
 			return
 		}
 
 		addSystemProps(item)
+		w.Header().Set("ETag", etag)
 		writeJSON(w, http.StatusOK, item)
 	case http.MethodDelete:
-		if err := h.deleteDocument(r.Context(), coll, cfg, keyMap); err != nil {
+		if err := h.deleteDocument(r.Context(), coll, cfg, keyMap, ifMatch(r)); err != nil {
 			writeErr(w, err)
 			return
 		}
@@ -1049,6 +1162,39 @@ func docPartitionKey(r *http.Request) string {
 	return fmt.Sprintf("%v", parsed[0])
 }
 
+// scopeToPartition narrows a query's candidate documents to a single logical
+// partition when the request pins one via x-ms-documentdb-partitionkey. A
+// partition-scoped query in real Cosmos only ever sees its own partition's
+// documents; without this filter a scoped `SELECT * FROM c` over a
+// multi-partition container would leak every partition's rows, since the WHERE
+// clause alone does not constrain the partition. The azcosmos SDK sends
+// x-ms-documentdb-query-enablecrosspartition on every query by default, so the
+// presence of the partition-key header — not that flag — is what scopes: a
+// specific partition key always wins over the cross-partition permission, and
+// only a query with no partition key header fans out across the container.
+func scopeToPartition(r *http.Request, cfg *dbdriver.TableConfig, items []map[string]any) []map[string]any {
+	if r.Header.Get("X-Ms-Documentdb-Partitionkey") == "" {
+		return items
+	}
+
+	pkAttr := idAttr
+	if cfg != nil && cfg.PartitionKey != "" {
+		pkAttr = cfg.PartitionKey
+	}
+
+	pkVal := docPartitionKey(r)
+
+	out := make([]map[string]any, 0, len(items))
+
+	for _, it := range items {
+		if fmt.Sprintf("%v", it[pkAttr]) == pkVal {
+			out = append(out, it)
+		}
+	}
+
+	return out
+}
+
 // buildKey constructs the key map the driver expects to look up a document by
 // its (partition key, id) identity. pkAttr is the container's declared
 // partition-key attribute name (e.g. "pk", "category"); pkVal is the value from
@@ -1089,6 +1235,13 @@ func partitionKeyMutated(cfg *dbdriver.TableConfig, headerPK string, item map[st
 // duplicate-id conflict.
 func isUpsert(r *http.Request) bool {
 	return strings.EqualFold(r.Header.Get("X-Ms-Documentdb-Is-Upsert"), "true")
+}
+
+// ifMatch returns the If-Match precondition etag a replace/delete carries, or ""
+// when none is set. The azcosmos SDK sends ItemOptions.IfMatchEtag as this
+// header; the value is compared verbatim against the document's stored _etag.
+func ifMatch(r *http.Request) string {
+	return r.Header.Get("If-Match")
 }
 
 func partitionKeyAttribute(pk *partitionKeyDef) string {
@@ -1241,6 +1394,8 @@ func writeErr(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict, "Conflict", err.Error())
 	case cerrors.IsInvalidArgument(err):
 		writeError(w, http.StatusBadRequest, "BadRequest", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		writeError(w, http.StatusPreconditionFailed, "PreconditionFailed", err.Error())
 	default:
 		writeError(w, http.StatusInternalServerError, "InternalServerError", err.Error())
 	}

--- a/server/azure/cosmosdb/optimistic_concurrency_test.go
+++ b/server/azure/cosmosdb/optimistic_concurrency_test.go
@@ -1,0 +1,122 @@
+// This file exercises Cosmos optimistic concurrency (rotating _etag / ETag
+// response header, If-Match preconditions mapped to 412) and partition-scoped
+// query isolation, driven entirely through the real azcosmos SDK against the
+// CloudEmu Azure server mounted in an httptest TLS server.
+
+package cosmosdb_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+// TestSDKCosmosETagRotates asserts every write returns a fresh ETag (in the
+// response header, surfaced as ItemResponse.ETag), a read echoes the current
+// one, and the etag changes on each mutation.
+func TestSDKCosmosETagRotates(t *testing.T) {
+	ctx := context.Background()
+	env := newCosmosEnv(t)
+	cc := env.container(ctx, t, "etagdb", "docs")
+
+	pk := azcosmos.NewPartitionKeyString("p1")
+
+	create, _ := json.Marshal(map[string]any{"id": "d1", "pk": "p1", "rev": 1})
+	createResp, err := cc.CreateItem(ctx, pk, create, nil)
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	e1 := createResp.ETag
+	if e1 == "" {
+		t.Fatal("CreateItem ETag empty, want a rotating etag")
+	}
+
+	readResp, err := cc.ReadItem(ctx, pk, "d1", nil)
+	if err != nil {
+		t.Fatalf("ReadItem: %v", err)
+	}
+
+	if readResp.ETag != e1 {
+		t.Errorf("ReadItem ETag=%q want %q (read must echo the stored etag)", readResp.ETag, e1)
+	}
+
+	replace, _ := json.Marshal(map[string]any{"id": "d1", "pk": "p1", "rev": 2})
+	replResp, err := cc.ReplaceItem(ctx, pk, "d1", replace, nil)
+	if err != nil {
+		t.Fatalf("ReplaceItem: %v", err)
+	}
+
+	if replResp.ETag == "" || replResp.ETag == e1 {
+		t.Errorf("ReplaceItem ETag=%q want a new non-empty etag (was %q)", replResp.ETag, e1)
+	}
+
+	readResp2, err := cc.ReadItem(ctx, pk, "d1", nil)
+	if err != nil {
+		t.Fatalf("ReadItem after replace: %v", err)
+	}
+
+	if readResp2.ETag != replResp.ETag {
+		t.Errorf("ReadItem ETag=%q want %q (must reflect the last write)", readResp2.ETag, replResp.ETag)
+	}
+}
+
+// TestSDKCosmosIfMatchPreconditions asserts If-Match optimistic concurrency: a
+// matching etag succeeds, a stale one is 412 on both replace and delete, and
+// If-Match "*" matches any existing document.
+func TestSDKCosmosIfMatchPreconditions(t *testing.T) {
+	ctx := context.Background()
+	env := newCosmosEnv(t)
+	cc := env.container(ctx, t, "ifmatchdb", "docs")
+
+	pk := azcosmos.NewPartitionKeyString("p1")
+
+	create, _ := json.Marshal(map[string]any{"id": "d1", "pk": "p1", "rev": 1})
+	createResp, err := cc.CreateItem(ctx, pk, create, nil)
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	current := createResp.ETag
+	stale := azcore.ETag(`"definitely-stale"`)
+
+	// A stale If-Match on replace is rejected 412 and does not mutate the doc.
+	body2, _ := json.Marshal(map[string]any{"id": "d1", "pk": "p1", "rev": 2})
+	_, staleErr := cc.ReplaceItem(ctx, pk, "d1", body2, &azcosmos.ItemOptions{IfMatchEtag: &stale})
+	wantRespErr(t, staleErr, 412, "ReplaceItem stale If-Match")
+
+	if got := readDoc(ctx, t, cc, "p1", "d1"); got["rev"] != float64(1) {
+		t.Errorf("rev=%v want 1 (stale replace must not apply)", got["rev"])
+	}
+
+	// A matching If-Match on replace succeeds and rotates the etag.
+	matchResp, err := cc.ReplaceItem(ctx, pk, "d1", body2, &azcosmos.ItemOptions{IfMatchEtag: &current})
+	if err != nil {
+		t.Fatalf("ReplaceItem matching If-Match: %v", err)
+	}
+
+	newEtag := matchResp.ETag
+	if newEtag == current {
+		t.Errorf("etag=%q did not rotate after matching-If-Match replace", newEtag)
+	}
+
+	// A stale If-Match on delete is rejected 412; the doc survives.
+	_, delStaleErr := cc.DeleteItem(ctx, pk, "d1", &azcosmos.ItemOptions{IfMatchEtag: &current})
+	wantRespErr(t, delStaleErr, 412, "DeleteItem stale If-Match")
+
+	if got := readDoc(ctx, t, cc, "p1", "d1"); got["rev"] != float64(2) {
+		t.Errorf("rev=%v want 2 (stale-If-Match delete must not remove)", got["rev"])
+	}
+
+	// If-Match "*" matches any existing document, so the delete succeeds.
+	star := azcore.ETag("*")
+	if _, err := cc.DeleteItem(ctx, pk, "d1", &azcosmos.ItemOptions{IfMatchEtag: &star}); err != nil {
+		t.Fatalf("DeleteItem If-Match *: %v", err)
+	}
+
+	_, err = cc.ReadItem(ctx, pk, "d1", nil)
+	wantRespErr(t, err, 404, "ReadItem after If-Match * delete")
+}

--- a/server/azure/cosmosdb/partition_query_test.go
+++ b/server/azure/cosmosdb/partition_query_test.go
@@ -1,0 +1,107 @@
+// This file exercises partition-scoped query isolation: a query pinned to a
+// single partition key must see only that partition's documents, while a query
+// with no partition key fans out across the whole container. Driven through the
+// real azcosmos SDK against the CloudEmu Azure server.
+
+package cosmosdb_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+// queryIDs runs a query and collects the "id" of every returned document across
+// all continuation pages.
+func queryIDs(ctx context.Context, t *testing.T, cc *azcosmos.ContainerClient, pk azcosmos.PartitionKey, opts *azcosmos.QueryOptions) []string {
+	t.Helper()
+
+	var ids []string
+
+	pager := cc.NewQueryItemsPager("SELECT * FROM c", pk, opts)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		for _, raw := range page.Items {
+			var doc map[string]any
+			if err := json.Unmarshal(raw, &doc); err != nil {
+				t.Fatalf("unmarshal item: %v", err)
+			}
+
+			ids = append(ids, doc["id"].(string))
+		}
+	}
+
+	return ids
+}
+
+// TestSDKCosmosPartitionScopedQuery asserts a partition-scoped SELECT * FROM c
+// over a multi-partition container returns ONLY the scoped partition's
+// documents, while an unscoped (cross-partition) query returns them all.
+func TestSDKCosmosPartitionScopedQuery(t *testing.T) {
+	ctx := context.Background()
+	env := newCosmosEnv(t)
+	cc := env.container(ctx, t, "pqdb", "events")
+
+	// Three documents in team-a, two in team-b.
+	createDoc(ctx, t, cc, "team-a", map[string]any{"id": "a1", "pk": "team-a"})
+	createDoc(ctx, t, cc, "team-a", map[string]any{"id": "a2", "pk": "team-a"})
+	createDoc(ctx, t, cc, "team-a", map[string]any{"id": "a3", "pk": "team-a"})
+	createDoc(ctx, t, cc, "team-b", map[string]any{"id": "b1", "pk": "team-b"})
+	createDoc(ctx, t, cc, "team-b", map[string]any{"id": "b2", "pk": "team-b"})
+
+	// Scoped to team-a: only its three documents, none from team-b.
+	scoped := queryIDs(ctx, t, cc, azcosmos.NewPartitionKeyString("team-a"), nil)
+	if len(scoped) != 3 {
+		t.Fatalf("scoped query returned %d docs (%v), want 3 (team-a only)", len(scoped), scoped)
+	}
+
+	for _, id := range scoped {
+		if id == "b1" || id == "b2" {
+			t.Errorf("scoped query leaked team-b doc %q", id)
+		}
+	}
+
+	// Continuation paging under the scope must not duplicate or drop rows: with a
+	// page size of 2, the three team-a docs come back across pages exactly once.
+	paged := queryIDs(ctx, t, cc, azcosmos.NewPartitionKeyString("team-a"), &azcosmos.QueryOptions{PageSizeHint: 2})
+	if !sameIDSet(paged, scoped) {
+		t.Errorf("paged scoped query ids=%v want same set as %v", paged, scoped)
+	}
+
+	// Cross-partition (no partition key): every document in the container.
+	all := queryIDs(ctx, t, cc, azcosmos.NewPartitionKey(), nil)
+	if len(all) != 5 {
+		t.Errorf("cross-partition query returned %d docs (%v), want 5 (all partitions)", len(all), all)
+	}
+}
+
+// sameIDSet reports whether a and b hold the same ids (order-independent, no
+// duplicates expected).
+func sameIDSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	seen := make(map[string]int, len(a))
+	for _, id := range a {
+		seen[id]++
+	}
+
+	for _, id := range b {
+		seen[id]--
+	}
+
+	for _, n := range seen {
+		if n != 0 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/server/azure/cosmosdb/ttl_test.go
+++ b/server/azure/cosmosdb/ttl_test.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/stackshy/cloudemu/v2/config"
 )
 
 // ttlContainer creates a container with the given DefaultTimeToLive (nil
@@ -88,12 +90,14 @@ func TestSDKContainerNoDefaultTTL(t *testing.T) {
 }
 
 // TestSDKItemDefaultTTLExpires asserts a document written into a container
-// with a short DefaultTimeToLive is honored: present immediately after
-// create, gone (404) once the TTL elapses.
+// with a DefaultTimeToLive is honored: present immediately after create, gone
+// (404) once the injected clock advances past the TTL. The container-TTL path
+// is clock-driven, so expiry is deterministic rather than wall-clock timed.
 func TestSDKItemDefaultTTLExpires(t *testing.T) {
 	ctx := context.Background()
-	e := newCosmosEnv(t)
-	cc := ttlContainer(ctx, t, e, "ttlexpiredb", "sessions", to.Ptr[int32](1))
+	clk := config.NewFakeClock(time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC))
+	e := newCosmosEnv(t, config.WithClock(clk))
+	cc := ttlContainer(ctx, t, e, "ttlexpiredb", "sessions", to.Ptr[int32](60))
 
 	doc := map[string]any{"id": "s1", "pk": "s1", "user": "alice"}
 	createDoc(ctx, t, cc, "s1", doc)
@@ -103,7 +107,7 @@ func TestSDKItemDefaultTTLExpires(t *testing.T) {
 		t.Errorf("pre-expiry user=%v want alice", got["user"])
 	}
 
-	time.Sleep(1200 * time.Millisecond)
+	clk.Advance(90 * time.Second)
 
 	_, err := cc.ReadItem(ctx, azcosmos.NewPartitionKeyString("s1"), "s1", nil)
 	wantRespErr(t, err, 404, "ReadItem after container defaultTtl elapsed")
@@ -130,8 +134,9 @@ func TestSDKItemDefaultTTLExpires(t *testing.T) {
 // the container's default expiry, matching real Cosmos precedence.
 func TestSDKItemTTLOverride(t *testing.T) {
 	ctx := context.Background()
-	e := newCosmosEnv(t)
-	cc := ttlContainer(ctx, t, e, "ttloverridedb", "sessions", to.Ptr[int32](1))
+	clk := config.NewFakeClock(time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC))
+	e := newCosmosEnv(t, config.WithClock(clk))
+	cc := ttlContainer(ctx, t, e, "ttloverridedb", "sessions", to.Ptr[int32](60))
 
 	doc := map[string]any{"id": "keep", "pk": "keep", "user": "bob", "ttl": -1}
 	b, err := json.Marshal(doc)
@@ -143,7 +148,7 @@ func TestSDKItemTTLOverride(t *testing.T) {
 		t.Fatalf("CreateItem: %v", err)
 	}
 
-	time.Sleep(1200 * time.Millisecond)
+	clk.Advance(90 * time.Second)
 
 	got := readDoc(ctx, t, cc, "keep", "keep")
 	if got["user"] != "bob" {
@@ -156,7 +161,8 @@ func TestSDKItemTTLOverride(t *testing.T) {
 // Cosmos: TTL must first be enabled at the container.
 func TestSDKItemTTLDisabledOnContainer(t *testing.T) {
 	ctx := context.Background()
-	e := newCosmosEnv(t)
+	clk := config.NewFakeClock(time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC))
+	e := newCosmosEnv(t, config.WithClock(clk))
 	cc := ttlContainer(ctx, t, e, "ttldisableddb", "sessions", nil)
 
 	doc := map[string]any{"id": "s1", "pk": "s1", "user": "alice", "ttl": 1}
@@ -169,7 +175,7 @@ func TestSDKItemTTLDisabledOnContainer(t *testing.T) {
 		t.Fatalf("CreateItem: %v", err)
 	}
 
-	time.Sleep(1200 * time.Millisecond)
+	clk.Advance(90 * time.Second)
 
 	got := readDoc(ctx, t, cc, "s1", "s1")
 	if got["user"] != "alice" {


### PR DESCRIPTION
## Summary

Fixes five real Azure Cosmos DB bugs in `server/azure/cosmosdb/`, all confirmed against the real `azcosmos` SDK.

### Bugs fixed

1. **Optimistic concurrency was completely inert (HIGH, lost-update).** No `ETag` response header was emitted, the body `_etag` was a static function of the id, `If-Match` was never parsed, and `writeErr` had no 412 mapping — so `ItemOptions{IfMatchEtag}` never triggered a 412 and `ItemResponse.ETag` was always empty. Now every write stamps a **rotating** `_etag` at write time (persisted with the item), create/read/replace emit the `ETag` header, the replace (PUT) and delete paths parse `If-Match` (`*` matches any existing), and a stale/mismatched precondition returns `FailedPrecondition` → **412 PreconditionFailed**.

2. **Partition-scoped queries leaked across partitions (HIGH, wrong-result).** `queryDocuments` scanned the whole container and relied only on the WHERE clause, so a scoped `SELECT * FROM c` over a multi-partition container returned every partition's rows. Now a query pinned to a partition (via `x-ms-documentdb-partitionkey`) is filtered to that partition value before evaluation; a query with no partition key still fans out. Note: the azcosmos SDK sets `x-ms-documentdb-query-enablecrosspartition: true` on **every** query by default, so the *presence of the partition-key header* is the correct discriminator (a specific partition key always wins over the cross-partition permission), not that flag.

3. **Container TTL used the wall clock (MED, determinism).** `attrsStore` computed and evaluated expiry with raw `time.Now()`, so a `FakeClock` couldn't drive it. The clock is now threaded from the driver (new optional `Clock()` capability on the Azure cosmos `Mock`, mirroring how `AccountTables`/`PurgeAccount` are exposed) into `attrsStore`; both call sites use `clock.Now()`, defaulting to a `RealClock` when the driver doesn't expose one.

4. **`_ts` reflected read-time, not write-time (MINOR).** `addSystemProps` stamped `_ts = time.Now()` at response time. `_ts` is now persisted at write time from the injected clock (deterministic) and returned as-stored on read.

5. **DELETE of a missing document returned 204 (MINOR, error-code).** `deleteDocument` now existence-checks the `(id, partition-key)` under the write lock and returns **404 NotFound** for a missing document, matching real Cosmos.

### Existing tests corrected from wrong → correct behavior

These encoded the bugs above and were updated to assert real-Cosmos semantics:

- `cosmos_lifecycle_test.go` `TestCosmosWriteDivergences` — the "stale `IfMatchEtag` succeeds" block now asserts **412** and that the doc is unchanged; the "delete-missing → 204" block now asserts **404**. File-header and test doc comments updated to drop those two divergences (only the PATCH-unrouted divergence remains).
- `cosmos_lifecycle_test.go` `TestCosmosQueryAndPagination` and `TestCosmosQueryFidelity` — both stored documents in per-id partitions but issued a **partition-scoped** query while expecting cross-partition WHERE results (explicitly commented "advisory in the emulator"). With scoping now enforced these must be **cross-partition** queries (`azcosmos.NewPartitionKey()`); switched and re-commented. Their purpose (WHERE / ORDER BY / projection / aggregate fidelity) is unchanged.
- `ttl_test.go` — the three container-`DefaultTimeToLive` tests replaced `time.Sleep` with a `FakeClock` `Advance`, now that the container-TTL path is clock-driven.

### New tests

- `optimistic_concurrency_test.go` — ETag rotates across writes and is returned in the response header/`ItemResponse.ETag`; a matching `If-Match` succeeds, a stale one is 412 on both replace and delete, and `*` matches any existing.
- `partition_query_test.go` — a partition-scoped `SELECT * FROM c` over a multi-partition container returns only that partition (including correct continuation paging), while a cross-partition query returns all.

### Gates

`go build ./...`, scoped `go vet`, `go test -p=3 ./server/azure/cosmosdb/... ./services/database/... ./providers/azure/cosmosdb/...` (plus `-race` on the cosmos package and the adjacent cosmosaccount/compat tests), gofmt, `golangci-lint --new-from-rev=origin/development` (0 issues), `go generate ./...` and `go run ./internal/compatgen` — all green, zero unexpected diff.