### PR TITLE
fix(azure-functions): PATCH site update, derive App Service Plan SKU tier, stable function keys, start/stop state

### DIFF
--- a/providers/azure/functions/app_service_plan.go
+++ b/providers/azure/functions/app_service_plan.go
@@ -30,6 +30,78 @@ type AppServicePlan struct {
 	Tags          map[string]string
 }
 
+// App Service plan pricing tiers, the tier real Azure derives from a SKU name
+// when the caller omits it (azurerm sends only the SKU name + capacity).
+const (
+	tierFree             = "Free"
+	tierShared           = "Shared"
+	tierBasic            = "Basic"
+	tierStandard         = "Standard"
+	tierPremium          = "Premium"
+	tierPremiumV2        = "PremiumV2"
+	tierPremiumV3        = "PremiumV3"
+	tierDynamic          = "Dynamic"
+	tierElasticPremium   = "ElasticPremium"
+	tierIsolated         = "Isolated"
+	tierIsolatedV2       = "IsolatedV2"
+	tierWorkflowStandard = "WorkflowStandard"
+)
+
+// deriveSKUTier maps an App Service plan SKU name to its pricing tier the way
+// real Azure does server-side when a create omits the tier: Y->Dynamic (Consumption),
+// EP->ElasticPremium, WS->WorkflowStandard (Logic Apps), B->Basic, S->Standard,
+// P#v2->PremiumV2, P#v3->PremiumV3, P(other)->Premium, F->Free, D->Shared,
+// I(#v2)->IsolatedV2 else Isolated. An unrecognized name falls back to Standard
+// rather than forcing Dynamic (which would mis-bill a dedicated plan).
+func deriveSKUTier(skuName string) string {
+	name := strings.ToUpper(strings.TrimSpace(skuName))
+	if name == "" {
+		return tierDynamic
+	}
+
+	// Longest prefixes first so EP/WS win over the single-letter matches.
+	prefixes := []struct{ prefix, tier string }{
+		{"EP", tierElasticPremium},
+		{"WS", tierWorkflowStandard},
+		{"Y", tierDynamic},
+		{"F", tierFree},
+		{"D", tierShared},
+		{"B", tierBasic},
+		{"S", tierStandard},
+	}
+	for _, p := range prefixes {
+		if strings.HasPrefix(name, p.prefix) {
+			return p.tier
+		}
+	}
+
+	if strings.HasPrefix(name, "P") {
+		return premiumTier(name)
+	}
+
+	if strings.HasPrefix(name, "I") {
+		if strings.HasSuffix(name, "V2") {
+			return tierIsolatedV2
+		}
+
+		return tierIsolated
+	}
+
+	return tierStandard
+}
+
+// premiumTier resolves the three Premium generations (legacy P#, P#v2, P#v3).
+func premiumTier(name string) string {
+	switch {
+	case strings.HasSuffix(name, "V2"):
+		return tierPremiumV2
+	case strings.HasSuffix(name, "V3"):
+		return tierPremiumV3
+	default:
+		return tierPremium
+	}
+}
+
 // planKey builds the composite key AppServicePlans are stored under, so a
 // plan named "default" in one resource group can never collide with (or be
 // overwritten by) a same-named plan in another resource group.
@@ -59,7 +131,7 @@ func (m *Mock) CreateAppServicePlan(_ context.Context, p AppServicePlan) (*AppSe
 	}
 
 	if p.SKUTier == "" {
-		p.SKUTier = "Dynamic"
+		p.SKUTier = deriveSKUTier(p.SKUName)
 	}
 
 	if p.Capacity == 0 {

--- a/providers/azure/functions/app_service_plan_test.go
+++ b/providers/azure/functions/app_service_plan_test.go
@@ -28,6 +28,67 @@ func TestCreateAppServicePlanDefaults(t *testing.T) {
 	assert.NotEmpty(t, plan.Location)
 }
 
+func TestDeriveSKUTier(t *testing.T) {
+	cases := []struct {
+		name, sku, want string
+	}{
+		{"consumption Y1", "Y1", "Dynamic"},
+		{"basic B1", "B1", "Basic"},
+		{"standard S1", "S1", "Standard"},
+		{"premium legacy P1", "P1", "Premium"},
+		{"premium v2 P1v2", "P1v2", "PremiumV2"},
+		{"premium v3 P1v3", "P1v3", "PremiumV3"},
+		{"elastic premium EP1", "EP1", "ElasticPremium"},
+		{"free F1", "F1", "Free"},
+		{"shared D1", "D1", "Shared"},
+		{"isolated I1", "I1", "Isolated"},
+		{"isolated v2 I1v2", "I1v2", "IsolatedV2"},
+		{"workflow standard WS1", "WS1", "WorkflowStandard"},
+		{"lowercase b1", "b1", "Basic"},
+		{"empty defaults to Dynamic", "", "Dynamic"},
+		{"unknown falls back to Standard, not Dynamic", "ZZ9", "Standard"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, deriveSKUTier(tc.sku))
+		})
+	}
+}
+
+// TestCreateAppServicePlanDerivesTierFromSKU covers the fix for a hardcoded
+// "Dynamic" tier: when the tier is omitted, Azure derives it from the SKU name.
+func TestCreateAppServicePlanDerivesTierFromSKU(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct{ sku, want string }{
+		{"B1", "Basic"},
+		{"S1", "Standard"},
+		{"P1v3", "PremiumV3"},
+		{"Y1", "Dynamic"},
+		{"EP1", "ElasticPremium"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.sku, func(t *testing.T) {
+			m := newTestMock()
+
+			plan, err := m.CreateAppServicePlan(ctx, AppServicePlan{Name: "p", SKUName: tc.sku})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, plan.SKUTier)
+		})
+	}
+}
+
+// TestCreateAppServicePlanPreservesExplicitTier confirms an explicitly-provided
+// tier is never overwritten by the SKU-name derivation.
+func TestCreateAppServicePlanPreservesExplicitTier(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	plan, err := m.CreateAppServicePlan(ctx, AppServicePlan{Name: "p", SKUName: "B1", SKUTier: "Standard"})
+	require.NoError(t, err)
+	assert.Equal(t, "Standard", plan.SKUTier)
+}
+
 func TestCreateAppServicePlanEmptyName(t *testing.T) {
 	ctx := context.Background()
 	m := newTestMock()

--- a/providers/azure/functions/site_meta.go
+++ b/providers/azure/functions/site_meta.go
@@ -28,6 +28,13 @@ const emulatorTenantID = "11111111-1111-1111-1111-111111111111"
 // attached.
 const identityTypeNone = "None"
 
+// siteStateRunning is the state a freshly-created site reports; a stop switches
+// it to siteStateStopped and a start switches it back.
+const (
+	siteStateRunning = "Running"
+	siteStateStopped = "Stopped"
+)
+
 // SiteIdentity is the managed-service-identity attached to a function app
 // (Microsoft.Web/sites identity envelope). For a system-assigned identity the
 // PrincipalID/TenantID are synthesized on store; for each user-assigned
@@ -120,6 +127,9 @@ type SiteMeta struct {
 	Reserved          bool
 	LinuxFxVersion    string
 	ProvisioningState string
+	// State is the running state reported on the ARM site ("Running" on create,
+	// "Stopped" after a stop). Start/stop toggle it; a plain update leaves it.
+	State string
 	// Identity is the resolved managed-service-identity, nil when the site has
 	// none attached. It is resolved (synthesized) on upsert.
 	Identity         *SiteIdentity
@@ -194,6 +204,7 @@ func (m *Mock) UpsertSiteMeta(_ context.Context, in SiteMeta) (*SiteMeta, error)
 	meta := in.clone()
 	meta.Identity = resolveSiteIdentity(in.Identity, identitySeed(&in))
 	meta.ProvisioningState = "Succeeded"
+	meta.State = siteStateRunning
 	meta.MasterKey = generateKey()
 	meta.HostFunctionKeys = map[string]string{defaultKeyName: generateKey()}
 	meta.SystemKeys = map[string]string{}
@@ -203,6 +214,98 @@ func (m *Mock) UpsertSiteMeta(_ context.Context, in SiteMeta) (*SiteMeta, error)
 	}
 
 	m.sites.Set(in.Name, meta)
+
+	return meta.clone(), nil
+}
+
+// SiteMetaPatch carries only the fields a PATCH (WebApps_Update) request
+// supplied. A nil field is left as stored — this is what distinguishes PATCH's
+// partial-update semantics from PUT's full replace: real Azure preserves any
+// property the PATCH body omits.
+type SiteMetaPatch struct {
+	Location       *string
+	Kind           *string
+	ServerFarmID   *string
+	HTTPSOnly      *bool
+	Reserved       *bool
+	LinuxFxVersion *string
+	// Identity, when non-nil, replaces the attached identity (a Type of "None"
+	// detaches it, matching `az functionapp identity remove`); nil preserves the
+	// current identity.
+	Identity *SiteIdentity
+	// AppSettings, when non-nil, replaces the stored settings; nil preserves them.
+	AppSettings *map[string]string
+}
+
+// PatchSiteMeta applies a partial update to a site's metadata, scoped like
+// GetSiteMeta, preserving every field the patch leaves nil (unlike UpsertSiteMeta,
+// which is a full replace suited to PUT). Generated keys, deployed functions and
+// the running state are untouched.
+func (m *Mock) PatchSiteMeta(
+	_ context.Context, subscription, resourceGroup, name string, patch SiteMetaPatch,
+) (*SiteMeta, error) {
+	m.sitesMu.Lock()
+	defer m.sitesMu.Unlock()
+
+	meta, ok := m.sites.Get(name)
+	if !ok || meta.Subscription != subscription || meta.ResourceGroup != resourceGroup {
+		return nil, cerrors.Newf(cerrors.NotFound, "site %s not found", name)
+	}
+
+	applySiteMetaPatch(meta, patch)
+	m.sites.Set(name, meta)
+
+	return meta.clone(), nil
+}
+
+// applySiteMetaPatch overlays the supplied (non-nil) patch fields onto meta.
+func applySiteMetaPatch(meta *SiteMeta, patch SiteMetaPatch) {
+	if patch.Location != nil {
+		meta.Location = *patch.Location
+	}
+
+	if patch.Kind != nil {
+		meta.Kind = *patch.Kind
+	}
+
+	if patch.ServerFarmID != nil {
+		meta.ServerFarmID = *patch.ServerFarmID
+	}
+
+	if patch.HTTPSOnly != nil {
+		meta.HTTPSOnly = *patch.HTTPSOnly
+	}
+
+	if patch.Reserved != nil {
+		meta.Reserved = *patch.Reserved
+	}
+
+	if patch.LinuxFxVersion != nil {
+		meta.LinuxFxVersion = *patch.LinuxFxVersion
+	}
+
+	if patch.Identity != nil {
+		meta.Identity = resolveSiteIdentity(patch.Identity, identitySeed(meta))
+	}
+
+	if patch.AppSettings != nil {
+		meta.AppSettings = maps.Clone(*patch.AppSettings)
+	}
+}
+
+// SetSiteState toggles a site's running state (start/stop), scoped like
+// GetSiteMeta. It leaves every other field untouched.
+func (m *Mock) SetSiteState(_ context.Context, subscription, resourceGroup, name, state string) (*SiteMeta, error) {
+	m.sitesMu.Lock()
+	defer m.sitesMu.Unlock()
+
+	meta, ok := m.sites.Get(name)
+	if !ok || meta.Subscription != subscription || meta.ResourceGroup != resourceGroup {
+		return nil, cerrors.Newf(cerrors.NotFound, "site %s not found", name)
+	}
+
+	meta.State = state
+	m.sites.Set(name, meta)
 
 	return meta.clone(), nil
 }
@@ -335,25 +438,36 @@ func (m *Mock) ListSiteMeta(_ context.Context, subscription, resourceGroup strin
 	return out, nil
 }
 
-// CreateSiteFunction adds a function to a site, generating its default key.
-func (m *Mock) CreateSiteFunction(_ context.Context, site string, fn SiteFunction) (*SiteFunction, error) {
+// CreateSiteFunction adds a function to a site (ARM CreateOrUpdate is a PUT, so
+// this also updates an existing function). It reports created=true only when the
+// function is new. A newly-created function gets a generated default key; an
+// overwrite preserves the existing function's keys (unless the request supplies
+// its own), so a re-PUT with no keys — the shape the wire handler sends — never
+// silently rotates the caller's function key.
+func (m *Mock) CreateSiteFunction(_ context.Context, site string, fn SiteFunction) (*SiteFunction, bool, error) {
 	m.sitesMu.Lock()
 	defer m.sitesMu.Unlock()
 
 	meta, ok := m.sites.Get(site)
 	if !ok {
-		return nil, cerrors.Newf(cerrors.NotFound, "site %s not found", site)
+		return nil, false, cerrors.Newf(cerrors.NotFound, "site %s not found", site)
 	}
+
+	existing, existed := meta.Functions[fn.Name]
 
 	stored := fn.clone()
 	if len(stored.Keys) == 0 {
-		stored.Keys = map[string]string{defaultKeyName: generateKey()}
+		if existed {
+			stored.Keys = maps.Clone(existing.Keys)
+		} else {
+			stored.Keys = map[string]string{defaultKeyName: generateKey()}
+		}
 	}
 
 	meta.Functions[fn.Name] = stored
 	m.sites.Set(site, meta)
 
-	return stored.clone(), nil
+	return stored.clone(), !existed, nil
 }
 
 // GetSiteFunction returns one function of a site, or NotFound.

--- a/providers/azure/functions/site_meta_test.go
+++ b/providers/azure/functions/site_meta_test.go
@@ -108,13 +108,31 @@ func TestSiteFunctionsLifecycle(t *testing.T) {
 	}
 
 	// Create one and read it back with a generated default key.
-	created, err := m.CreateSiteFunction(ctx, "app1", SiteFunction{Name: "fn1", Language: "python"})
+	created, wasCreated, err := m.CreateSiteFunction(ctx, "app1", SiteFunction{Name: "fn1", Language: "python"})
 	if err != nil {
 		t.Fatalf("create function: %v", err)
 	}
 
+	if !wasCreated {
+		t.Fatal("first CreateSiteFunction reported created=false, want true")
+	}
+
 	if created.Keys["default"] == "" {
 		t.Fatalf("function default key not generated: %+v", created)
+	}
+
+	// A re-PUT with no keys preserves the generated key and reports created=false.
+	reput, wasCreated, err := m.CreateSiteFunction(ctx, "app1", SiteFunction{Name: "fn1", Language: "python"})
+	if err != nil {
+		t.Fatalf("re-put function: %v", err)
+	}
+
+	if wasCreated {
+		t.Fatal("re-PUT CreateSiteFunction reported created=true, want false")
+	}
+
+	if reput.Keys["default"] != created.Keys["default"] {
+		t.Fatalf("re-PUT rotated the function key: %q -> %q", created.Keys["default"], reput.Keys["default"])
 	}
 
 	keys, err := m.FunctionKeys(ctx, "app1", "fn1")
@@ -135,7 +153,7 @@ func TestSiteFunctionsLifecycle(t *testing.T) {
 	}
 
 	// Operations on a missing site are NotFound.
-	if _, err := m.CreateSiteFunction(ctx, "ghost", SiteFunction{Name: "fn"}); !cerrors.IsNotFound(err) {
+	if _, _, err := m.CreateSiteFunction(ctx, "ghost", SiteFunction{Name: "fn"}); !cerrors.IsNotFound(err) {
 		t.Fatalf("create on missing site = %v, want NotFound", err)
 	}
 }

--- a/server/azure/functions/functions_reput_test.go
+++ b/server/azure/functions/functions_reput_test.go
@@ -1,0 +1,107 @@
+package functions_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestFunctionRePUTPreservesKeysAnd200 verifies, at the wire level, the fix for
+// the audit finding that a function PUT-as-update rotated the default key and
+// always answered 201: the first PUT creates (201) and the re-PUT updates (200)
+// while keeping the same key. The status codes are observed with a raw client
+// because the generated SDK's BeginCreateFunction only accepts 201.
+func TestFunctionRePUTPreservesKeysAnd200(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{Functions: cloudP.Functions}))
+	t.Cleanup(ts.Close)
+
+	hc := ts.Client()
+	ctx := context.Background()
+	base := ts.URL + "/subscriptions/" + subID + "/resourceGroups/" + rgName +
+		"/providers/Microsoft.Web/sites/reput-app"
+
+	// The site must exist before a function can be deployed to it.
+	if st := doJSON(t, ctx, hc, http.MethodPut, base, `{"location":"eastus","properties":{"siteConfig":{}}}`); st != http.StatusOK {
+		t.Fatalf("site create status = %d, want 200", st)
+	}
+
+	fnURL := base + "/functions/fn1"
+
+	if st := doJSON(t, ctx, hc, http.MethodPut, fnURL, `{"properties":{"config":{}}}`); st != http.StatusCreated {
+		t.Fatalf("first function PUT status = %d, want 201", st)
+	}
+
+	key1 := functionDefaultKey(t, ctx, hc, fnURL+"/listkeys")
+	if key1 == "" {
+		t.Fatal("function default key empty after create")
+	}
+
+	// Re-PUT the same function: an update, so 200 and the key is unchanged.
+	if st := doJSON(t, ctx, hc, http.MethodPut, fnURL, `{"properties":{"config":{}}}`); st != http.StatusOK {
+		t.Fatalf("re-PUT function status = %d, want 200", st)
+	}
+
+	key2 := functionDefaultKey(t, ctx, hc, fnURL+"/listkeys")
+	if key2 != key1 {
+		t.Fatalf("re-PUT rotated the function key: %q -> %q", key1, key2)
+	}
+}
+
+func doJSON(t *testing.T, ctx context.Context, hc *http.Client, method, url, body string) int {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(ctx, method, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := hc.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	return resp.StatusCode
+}
+
+func functionDefaultKey(t *testing.T, ctx context.Context, hc *http.Client, url string) string {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		t.Fatalf("new listkeys request: %v", err)
+	}
+
+	resp, err := hc.Do(req)
+	if err != nil {
+		t.Fatalf("listkeys: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("listkeys status = %d, want 200", resp.StatusCode)
+	}
+
+	var out struct {
+		Properties map[string]string `json:"properties"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode listkeys: %v", err)
+	}
+
+	return out.Properties["default"]
+}

--- a/server/azure/functions/functions_subroutes.go
+++ b/server/azure/functions/functions_subroutes.go
@@ -86,7 +86,7 @@ func createFunction(w http.ResponseWriter, r *http.Request, rp azurearm.Resource
 		return
 	}
 
-	fn, err := store.CreateSiteFunction(r.Context(), rp.ResourceName, azfunctions.SiteFunction{
+	fn, created, err := store.CreateSiteFunction(r.Context(), rp.ResourceName, azfunctions.SiteFunction{
 		Name:       rp.SubResourceName,
 		Config:     req.Properties.Config,
 		Language:   req.Properties.Language,
@@ -97,7 +97,14 @@ func createFunction(w http.ResponseWriter, r *http.Request, rp azurearm.Resource
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusCreated, toFunctionEnvelope(rp, fn))
+	// 201 only when the function was newly created; a re-PUT that updates an
+	// existing function answers 200 (and keeps its keys, per CreateSiteFunction).
+	status := http.StatusOK
+	if created {
+		status = http.StatusCreated
+	}
+
+	azurearm.WriteJSON(w, status, toFunctionEnvelope(rp, fn))
 }
 
 //nolint:gocritic // rp travels the dispatch chain once per request.

--- a/server/azure/functions/handler.go
+++ b/server/azure/functions/handler.go
@@ -74,10 +74,14 @@ type appServicePlanStore interface {
 // portable behavior (or 501 for Azure-only sub-routes).
 type azureFunctionApps interface {
 	UpsertSiteMeta(ctx context.Context, in azfunctions.SiteMeta) (*azfunctions.SiteMeta, error)
+	PatchSiteMeta(
+		ctx context.Context, subscription, resourceGroup, name string, patch azfunctions.SiteMetaPatch,
+	) (*azfunctions.SiteMeta, error)
+	SetSiteState(ctx context.Context, subscription, resourceGroup, name, state string) (*azfunctions.SiteMeta, error)
 	GetSiteMeta(ctx context.Context, subscription, resourceGroup, name string) (*azfunctions.SiteMeta, error)
 	DeleteSiteMeta(ctx context.Context, subscription, resourceGroup, name string) error
 	ListSiteMeta(ctx context.Context, subscription, resourceGroup string) ([]azfunctions.SiteMeta, error)
-	CreateSiteFunction(ctx context.Context, site string, fn azfunctions.SiteFunction) (*azfunctions.SiteFunction, error)
+	CreateSiteFunction(ctx context.Context, site string, fn azfunctions.SiteFunction) (*azfunctions.SiteFunction, bool, error)
 	GetSiteFunction(ctx context.Context, site, name string) (*azfunctions.SiteFunction, error)
 	ListSiteFunctions(ctx context.Context, site string) ([]azfunctions.SiteFunction, error)
 	DeleteSiteFunction(ctx context.Context, site, name string) error
@@ -191,6 +195,8 @@ func (h *Handler) serveResource(w http.ResponseWriter, r *http.Request, rp azure
 	switch r.Method {
 	case http.MethodPut:
 		h.createOrUpdate(w, r, rp)
+	case http.MethodPatch:
+		h.patch(w, r, rp)
 	case http.MethodGet:
 		h.get(w, r, rp)
 	case http.MethodDelete:
@@ -280,6 +286,125 @@ func (h *Handler) upsertSiteMeta(
 		Identity:       toSiteMetaIdentity(req.Identity),
 		AppSettings:    appSettingsToMap(settings),
 	})
+	if err != nil {
+		return nil
+	}
+
+	return meta
+}
+
+// patch serves PATCH .../sites/{name} — WebApps_Update (`az functionapp update`,
+// `az functionapp identity assign`, SDK .Update()). Unlike PUT, PATCH is a
+// partial update: only the fields the body carries are applied; everything else
+// is left as stored. The site must already exist (404 otherwise).
+//
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func (h *Handler) patch(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	// PATCH targets an existing resource; resolving it first (scoped) yields the
+	// 404 real Azure returns for a PATCH against a missing site or the wrong
+	// resource group, before any partial write lands.
+	if _, err := h.getFunction(r.Context(), rp); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxControlBytes)
+
+	var req patchSiteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidRequestContent", err.Error())
+		return
+	}
+
+	handler, settings, hasSettings := extractPatchSettings(req)
+
+	info, err := h.fn.UpdateFunction(r.Context(), rp.ResourceName, patchFunctionConfig(rp, req, handler, settings, hasSettings))
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	meta := h.patchSiteMeta(r, rp, req, settings, hasSettings)
+
+	azurearm.WriteJSON(w, http.StatusOK, toSiteResource(rp, info, meta))
+}
+
+// extractPatchSettings splits the handler entrypoint out of a PATCH body's app
+// settings (as createOrUpdate does for PUT). hasSettings reports whether the
+// body carried a siteConfig.appSettings block at all, so an omitted block
+// preserves the stored settings instead of clearing them.
+func extractPatchSettings(req patchSiteRequest) (handler string, settings []nameValue, hasSettings bool) {
+	if req.Properties == nil || req.Properties.SiteConfig == nil || req.Properties.SiteConfig.AppSettings == nil {
+		return "", nil, false
+	}
+
+	handler, settings = extractHandlerSetting(req.Properties.SiteConfig.AppSettings)
+
+	return handler, settings, true
+}
+
+// patchFunctionConfig builds the partial FunctionConfig a PATCH applies to the
+// portable function. Only fields the body supplied are set; UpdateFunction's
+// applyConfigUpdates then preserves every zero field, so an omitted runtime,
+// handler, tags or app-settings block is left untouched.
+//
+//nolint:gocritic // rp/req travel the dispatch chain once per request.
+func patchFunctionConfig(
+	rp azurearm.ResourcePath, req patchSiteRequest, handler string, settings []nameValue, hasSettings bool,
+) sdrv.FunctionConfig {
+	cfg := sdrv.FunctionConfig{Name: rp.ResourceName, Handler: handler, Tags: req.Tags}
+
+	if req.Properties != nil && req.Properties.SiteConfig != nil && req.Properties.SiteConfig.LinuxFxVersion != nil {
+		cfg.Runtime = *req.Properties.SiteConfig.LinuxFxVersion
+	}
+
+	if hasSettings {
+		cfg.Environment = appSettingsToMap(settings)
+	}
+
+	return cfg
+}
+
+// patchSiteMeta applies the PATCH's partial site metadata when the backend
+// supports the Azure site surface, returning the stored view for the response.
+// A nil field in the built patch preserves the stored value.
+//
+//nolint:gocritic // rp/req travel the dispatch chain once per request.
+func (h *Handler) patchSiteMeta(
+	r *http.Request, rp azurearm.ResourcePath, req patchSiteRequest, settings []nameValue, hasSettings bool,
+) *azfunctions.SiteMeta {
+	store, ok := h.siteStore()
+	if !ok {
+		return nil
+	}
+
+	patch := azfunctions.SiteMetaPatch{Location: req.Location, Kind: req.Kind}
+
+	if req.Identity != nil {
+		patch.Identity = toSiteMetaIdentity(req.Identity)
+	}
+
+	if req.Properties != nil {
+		patch.ServerFarmID = req.Properties.ServerFarmID
+		patch.HTTPSOnly = req.Properties.HTTPSOnly
+		patch.Reserved = req.Properties.Reserved
+
+		if req.Properties.SiteConfig != nil {
+			patch.LinuxFxVersion = req.Properties.SiteConfig.LinuxFxVersion
+		}
+	}
+
+	if hasSettings {
+		m := appSettingsToMap(settings)
+		patch.AppSettings = &m
+	}
+
+	meta, err := store.PatchSiteMeta(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName, patch)
 	if err != nil {
 		return nil
 	}
@@ -735,6 +860,7 @@ func toSiteResource(rp azurearm.ResourcePath, info *sdrv.FunctionInfo, meta *azf
 	location := defaultLocation
 	provisioningState := "Succeeded"
 	kind := functionAppKind
+	state := siteStateRunning
 
 	var serverFarmID string
 
@@ -753,6 +879,10 @@ func toSiteResource(rp azurearm.ResourcePath, info *sdrv.FunctionInfo, meta *azf
 		if meta.Kind != "" {
 			kind = meta.Kind
 		}
+
+		if meta.State != "" {
+			state = meta.State
+		}
 	}
 
 	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup,
@@ -769,7 +899,7 @@ func toSiteResource(rp azurearm.ResourcePath, info *sdrv.FunctionInfo, meta *azf
 		Identity: identity,
 		Tags:     info.Tags,
 		Properties: siteProperties{
-			State:             "Running",
+			State:             state,
 			ProvisioningState: provisioningState,
 			HostNames:         []string{hostName},
 			DefaultHostName:   hostName,

--- a/server/azure/functions/sites_patch_sdk_test.go
+++ b/server/azure/functions/sites_patch_sdk_test.go
@@ -1,0 +1,175 @@
+package functions_test
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3"
+)
+
+// TestSDKSitePatchPartialUpdate drives WebApps_Update (PATCH) through the real
+// client: a PATCH that touches only httpsOnly must leave the location, kind,
+// runtime, app settings and an unmodeled (overlay) property exactly as stored.
+func TestSDKSitePatchPartialUpdate(t *testing.T) {
+	client, ctx := newFunctionsTestServer(t)
+
+	createSite(t, ctx, client, "sdk-patch", armappservice.Site{
+		Kind:     to.Ptr("functionapp,linux"),
+		Location: to.Ptr("eastus"),
+		Properties: &armappservice.SiteProperties{
+			// ClientAffinityEnabled is not modeled by the handler, so it survives
+			// only through the unmodeled-property overlay — the PATCH must not drop it.
+			ClientAffinityEnabled: to.Ptr(true),
+			SiteConfig: &armappservice.SiteConfig{
+				LinuxFxVersion: to.Ptr("Python|3.11"),
+				AppSettings: []*armappservice.NameValuePair{
+					{Name: to.Ptr("FOO"), Value: to.Ptr("bar")},
+				},
+			},
+		},
+	})
+
+	// PATCH only httpsOnly.
+	updated, err := client.Update(ctx, rgName, "sdk-patch", armappservice.SitePatchResource{
+		Properties: &armappservice.SitePatchResourceProperties{HTTPSOnly: to.Ptr(true)},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Update(PATCH): %v", err)
+	}
+
+	if updated.Properties == nil || updated.Properties.HTTPSOnly == nil || !*updated.Properties.HTTPSOnly {
+		t.Fatalf("PATCH did not set httpsOnly: %+v", updated.Properties)
+	}
+
+	got, err := client.Get(ctx, rgName, "sdk-patch", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Location == nil || *got.Location != "eastus" {
+		t.Fatalf("PATCH clobbered location = %v, want eastus", got.Location)
+	}
+
+	if got.Kind == nil || *got.Kind != "functionapp,linux" {
+		t.Fatalf("PATCH clobbered kind = %v, want functionapp,linux", got.Kind)
+	}
+
+	if got.Properties == nil || got.Properties.SiteConfig == nil ||
+		got.Properties.SiteConfig.LinuxFxVersion == nil || *got.Properties.SiteConfig.LinuxFxVersion != "Python|3.11" {
+		t.Fatalf("PATCH clobbered linuxFxVersion: %+v", got.Properties)
+	}
+
+	if got.Properties.HTTPSOnly == nil || !*got.Properties.HTTPSOnly {
+		t.Fatalf("PATCH httpsOnly not persisted: %+v", got.Properties)
+	}
+
+	if got.Properties.ClientAffinityEnabled == nil || !*got.Properties.ClientAffinityEnabled {
+		t.Fatalf("PATCH dropped the unmodeled overlay property clientAffinityEnabled: %+v", got.Properties)
+	}
+
+	// App settings the PATCH never mentioned must still be there.
+	settings, err := client.ListApplicationSettings(ctx, rgName, "sdk-patch", nil)
+	if err != nil {
+		t.Fatalf("ListApplicationSettings: %v", err)
+	}
+
+	if v := settings.Properties["FOO"]; v == nil || *v != "bar" {
+		t.Fatalf("PATCH clobbered app setting FOO = %v, want bar", v)
+	}
+}
+
+// TestSDKSitePatchIdentityAssign confirms `az functionapp identity assign` (a
+// PATCH carrying only the identity block) attaches a system-assigned identity
+// without disturbing the rest of the site.
+func TestSDKSitePatchIdentityAssign(t *testing.T) {
+	client, ctx := newFunctionsTestServer(t)
+
+	createSite(t, ctx, client, "sdk-patch-id", armappservice.Site{
+		Location:   to.Ptr("eastus"),
+		Properties: &armappservice.SiteProperties{SiteConfig: &armappservice.SiteConfig{}},
+	})
+
+	updated, err := client.Update(ctx, rgName, "sdk-patch-id", armappservice.SitePatchResource{
+		Identity: &armappservice.ManagedServiceIdentity{
+			Type: to.Ptr(armappservice.ManagedServiceIdentityTypeSystemAssigned),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Update(identity assign): %v", err)
+	}
+
+	if updated.Identity == nil || updated.Identity.PrincipalID == nil || *updated.Identity.PrincipalID == "" {
+		t.Fatalf("PATCH identity assign did not synthesize a principalId: %+v", updated.Identity)
+	}
+
+	got, err := client.Get(ctx, rgName, "sdk-patch-id", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Identity == nil || got.Identity.Type == nil ||
+		*got.Identity.Type != armappservice.ManagedServiceIdentityTypeSystemAssigned {
+		t.Fatalf("identity not persisted after PATCH: %+v", got.Identity)
+	}
+}
+
+// TestSDKSitePatchMissing confirms a PATCH against a site that does not exist is
+// a 404 rather than a 405 or a silent create.
+func TestSDKSitePatchMissing(t *testing.T) {
+	client, ctx := newFunctionsTestServer(t)
+
+	if _, err := client.Update(ctx, rgName, "ghost", armappservice.SitePatchResource{
+		Properties: &armappservice.SitePatchResourceProperties{HTTPSOnly: to.Ptr(true)},
+	}, nil); err == nil {
+		t.Fatal("PATCH on missing site returned nil error, want 404")
+	}
+}
+
+// TestSDKSiteStartStop drives WebApps_Stop / WebApps_Start and confirms the
+// running state a subsequent GET reports follows the last action.
+func TestSDKSiteStartStop(t *testing.T) {
+	client, ctx := newFunctionsTestServer(t)
+
+	created := createSite(t, ctx, client, "sdk-startstop", armappservice.Site{
+		Location:   to.Ptr("eastus"),
+		Properties: &armappservice.SiteProperties{SiteConfig: &armappservice.SiteConfig{}},
+	})
+	if created.Properties == nil || created.Properties.State == nil || *created.Properties.State != "Running" {
+		t.Fatalf("fresh site state = %v, want Running", stateOf(created))
+	}
+
+	if _, err := client.Stop(ctx, rgName, "sdk-startstop", nil); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	got, err := client.Get(ctx, rgName, "sdk-startstop", nil)
+	if err != nil {
+		t.Fatalf("Get after stop: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.State == nil || *got.Properties.State != "Stopped" {
+		t.Fatalf("state after stop = %v, want Stopped", stateOf(got.Site))
+	}
+
+	if _, err := client.Start(ctx, rgName, "sdk-startstop", nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	got, err = client.Get(ctx, rgName, "sdk-startstop", nil)
+	if err != nil {
+		t.Fatalf("Get after start: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.State == nil || *got.Properties.State != "Running" {
+		t.Fatalf("state after start = %v, want Running", stateOf(got.Site))
+	}
+}
+
+// stateOf renders a site's State pointer for test failure messages.
+func stateOf(s armappservice.Site) string {
+	if s.Properties == nil || s.Properties.State == nil {
+		return "<nil>"
+	}
+
+	return *s.Properties.State
+}

--- a/server/azure/functions/sites_subroutes.go
+++ b/server/azure/functions/sites_subroutes.go
@@ -14,6 +14,13 @@ const (
 	subResourceHost      = "host"
 	subResourceFunctions = "functions"
 	subResourceRestart   = "restart"
+	subResourceStart     = "start"
+	subResourceStop      = "stop"
+
+	// siteStateRunning/siteStateStopped are the ARM site running states reflected
+	// on GET; start/stop toggle the stored state between them.
+	siteStateRunning = "Running"
+	siteStateStopped = "Stopped"
 
 	configNameWeb         = "web"
 	configNameAppSettings = "appsettings"
@@ -47,9 +54,34 @@ func (h *Handler) serveSiteSubResource(w http.ResponseWriter, r *http.Request, r
 		h.serveFunctions(w, r, rp, store)
 	case subResourceRestart:
 		h.serveRestart(w, r, rp)
+	case subResourceStart:
+		h.serveSiteState(w, r, rp, store, siteStateRunning)
+	case subResourceStop:
+		h.serveSiteState(w, r, rp, store, siteStateStopped)
 	default:
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "unsupported sub-resource")
 	}
+}
+
+// serveSiteState handles POST .../sites/{name}/start and .../stop
+// (WebApps_Start / WebApps_Stop), toggling the stored running state so a
+// subsequent GET reflects it. Real Azure answers 200 with an empty body.
+//
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func (*Handler) serveSiteState(
+	w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store azureFunctionApps, state string,
+) {
+	if r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "start/stop requires POST")
+		return
+	}
+
+	if _, err := store.SetSiteState(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName, state); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
 //nolint:gocritic // rp travels the dispatch chain once per request.

--- a/server/azure/functions/types.go
+++ b/server/azure/functions/types.go
@@ -99,6 +99,32 @@ type createSiteConfig struct {
 	AppSettings    []nameValue `json:"appSettings"`
 }
 
+// patchSiteRequest captures a PATCH (WebApps_Update / SitePatchResource) body.
+// Every field is a pointer (or a nil-able map/slice) so an omitted field is
+// distinguishable from one explicitly set to its zero value — PATCH must apply
+// only the fields the caller supplied and leave the rest as stored.
+type patchSiteRequest struct {
+	Kind       *string              `json:"kind"`
+	Location   *string              `json:"location"`
+	Identity   *siteIdentity        `json:"identity"`
+	Tags       map[string]string    `json:"tags"`
+	Properties *patchSiteProperties `json:"properties"`
+}
+
+type patchSiteProperties struct {
+	SiteConfig   *patchSiteConfig `json:"siteConfig"`
+	Reserved     *bool            `json:"reserved"`
+	ServerFarmID *string          `json:"serverFarmId"`
+	HTTPSOnly    *bool            `json:"httpsOnly"`
+}
+
+type patchSiteConfig struct {
+	LinuxFxVersion *string `json:"linuxFxVersion"`
+	// AppSettings is nil when the PATCH omitted the block (settings preserved) and
+	// non-nil (possibly empty) when it supplied one (settings replaced).
+	AppSettings []nameValue `json:"appSettings"`
+}
+
 // serverFarmResource is the ARM JSON shape for Microsoft.Web/serverfarms (App
 // Service plans) returned to the SDK. The SKU carries the pricing tier a plan
 // bills on — the fields an armappservice PlansClient reads back.


### PR DESCRIPTION
## Summary

Fixes four Azure Functions / App Service parity bugs found by a confirming real-SDK audit, all in `server/azure/functions/` + `providers/azure/functions/`.

### Bugs fixed

1. **PATCH on `Microsoft.Web/sites` returned 405.** `serveResource` only switched PUT/GET/DELETE, so `WebApps_Update` (PATCH — `az functionapp update`, `az functionapp identity assign`, SDK `.Update()`) fell through to 405. Added a PATCH arm with true partial-update semantics: only the fields the body carries are applied, everything else is left as stored (a new `PatchSiteMeta` provider method + partial `FunctionConfig` that rides `applyConfigUpdates`' zero-field preservation). Identity assign/remove via PATCH works; unmodeled (overlay) properties are preserved via the existing PATCH-union path; a PATCH against a missing site (or wrong resource group) is 404, not a silent create.

2. **App Service Plan SKU tier hardcoded `"Dynamic"`.** When the tier was omitted, every plan was tagged `Dynamic` regardless of SKU name. Now derived server-side from the SKU-name prefix the way real Azure does: `Y`→Dynamic, `EP`→ElasticPremium, `WS`→WorkflowStandard, `B`→Basic, `S`→Standard, `P#v2`→PremiumV2, `P#v3`→PremiumV3, `P`→Premium, `F`→Free, `D`→Shared, `I(#v2)`→IsolatedV2/Isolated; unknown falls back to Standard (never forced to Dynamic). An explicitly-provided tier is preserved.

3. **Function PUT-as-update rotated keys and always returned 201.** A re-PUT of an existing function regenerated its `default` key and always answered 201. Now an overwrite preserves the existing function's keys (keys generated only on first create) and returns **200** when the function already existed, **201** when newly created.

4. **Site start/stop returned 405; state pinned to `Running`.** `/stop` and `/start` weren't routed, and `toSiteResource` always reported `State: "Running"`. Added POST `.../sites/{name}/stop` → `Stopped` and `.../start` → `Running`, backed by a `SetSiteState` provider method and a stored `State` (default `Running` on create) that a subsequent GET reflects. `restart` still works.

## Tests

- PATCH: partial update touches only the supplied field and preserves location/kind/runtime/app-settings + an unmodeled overlay property; system-assigned identity assign via PATCH; 404 on a missing site (real armappservice `WebAppsClient` over httptest).
- SKU tier derived for B1/S1/P1v3/Y1/EP1 when tier omitted; explicit tier preserved; table-driven `deriveSKUTier` coverage.
- Function re-PUT preserves the key and returns 200 (raw wire client, since the generated SDK's `BeginCreateFunction` only accepts 201).
- stop → GET reports `Stopped`, start → `Running`.

Gates: `go build ./...`, `go vet`, scoped `go test`, gofmt, `go generate` (zero doc diff), compatgen (exit 0, zero diff), and `golangci-lint --new-from-rev=origin/development` all green.
