### PR TITLE
fix(azure-servicebus): SQL filter LIKE/IN/EXISTS/IS NULL, round-trip queue/topic ARM properties, enforce duplicate detection

### DIFF
--- a/providers/azure/servicebus/servicebus.go
+++ b/providers/azure/servicebus/servicebus.go
@@ -23,6 +23,9 @@ const (
 	defaultVisibilityTimeout = 30
 	maxReceiveMessages       = 10
 	deduplicationWindow      = 5 * time.Minute
+	// defaultDupDetectionWindow is Service Bus' default duplicate-detection
+	// history window when RequiresDuplicateDetection is set without a window.
+	defaultDupDetectionWindow = 10 * time.Minute
 )
 
 // sbMessage represents an internal message stored in a queue.
@@ -59,7 +62,13 @@ type queueData struct {
 	createdAt          time.Time
 	lastModifiedAt     time.Time
 	deduplicationIndex map[string]time.Time
-	dlqConfig          *driver.DeadLetterConfig
+	// requiresDupDetection enables Azure Service Bus MessageId-based duplicate
+	// detection; dedupByMessageID tracks the last-seen time per MessageId and
+	// dupDetectionWindow is the look-back window.
+	requiresDupDetection bool
+	dupDetectionWindow   time.Duration
+	dedupByMessageID     map[string]time.Time
+	dlqConfig            *driver.DeadLetterConfig
 	// deadLetterOnExpiration routes an expired message to the dead-letter queue
 	// instead of dropping it (Service Bus deadLetteringOnMessageExpiration).
 	deadLetterOnExpiration bool
@@ -175,6 +184,11 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 
 	now := m.opts.Clock.Now()
 
+	dupWindow := cfg.DuplicateDetectionWindow
+	if dupWindow <= 0 {
+		dupWindow = defaultDupDetectionWindow
+	}
+
 	qd := &queueData{
 		info:                   info,
 		messages:               make([]*sbMessage, 0),
@@ -185,6 +199,9 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		createdAt:              now,
 		lastModifiedAt:         now,
 		deduplicationIndex:     make(map[string]time.Time),
+		requiresDupDetection:   cfg.RequiresDuplicateDetection,
+		dupDetectionWindow:     dupWindow,
+		dedupByMessageID:       make(map[string]time.Time),
 		dlqConfig:              cfg.DeadLetterQueue,
 		deadLetterOnExpiration: cfg.DeadLetterOnExpiration,
 		metadata:               metadata,
@@ -271,6 +288,12 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		return &driver.SendMessageOutput{MessageID: existingID}, nil
 	}
 
+	// Service Bus duplicate detection: a repeat MessageId inside the configured
+	// window is silently accepted but not re-enqueued.
+	if existingID, found := findMessageIDDuplicate(qd, &input, now); found {
+		return &driver.SendMessageOutput{MessageID: existingID}, nil
+	}
+
 	msgID := idgen.GenerateID("sb-msg-")
 
 	attrs := make(map[string]string, len(input.Attributes))
@@ -322,6 +345,12 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		qd.deduplicationIndex[input.DeduplicationID] = now
 	}
 
+	if qd.requiresDupDetection {
+		if mid := messageIDOf(&input); mid != "" {
+			qd.dedupByMessageID[mid] = now
+		}
+	}
+
 	// Fire Function trigger if registered.
 	m.mu.RLock()
 	trigger := m.triggers[input.QueueURL]
@@ -363,6 +392,45 @@ func validateFIFORequirements(qd *queueData, input *driver.SendMessageInput) err
 	}
 
 	return nil
+}
+
+// messageIDOf returns the Azure Service Bus MessageId a send carried, or "" when
+// none was set (an empty MessageId is never deduplicated, matching real SB).
+func messageIDOf(input *driver.SendMessageInput) string {
+	if input.SystemProperties == nil {
+		return ""
+	}
+
+	return input.SystemProperties["MessageId"]
+}
+
+// findMessageIDDuplicate reports whether a send repeats a MessageId already seen
+// within the duplicate-detection window on a RequiresDuplicateDetection queue,
+// returning the driver id of the surviving message when it is still enqueued.
+func findMessageIDDuplicate(qd *queueData, input *driver.SendMessageInput, now time.Time) (string, bool) {
+	if !qd.requiresDupDetection {
+		return "", false
+	}
+
+	mid := messageIDOf(input)
+	if mid == "" {
+		return "", false
+	}
+
+	seenAt, ok := qd.dedupByMessageID[mid]
+	if !ok || now.Sub(seenAt) >= qd.dupDetectionWindow {
+		return "", false
+	}
+
+	for _, existing := range qd.messages {
+		if existing.SystemProps["MessageId"] == mid {
+			return existing.ID, true
+		}
+	}
+
+	// The original was already consumed but the MessageId is still within the
+	// detection window, so the duplicate is still dropped.
+	return mid, true
 }
 
 func findDuplicate(qd *queueData, input *driver.SendMessageInput, now time.Time) (string, bool) {

--- a/server/azure/servicebus/dataplane_dedup_test.go
+++ b/server/azure/servicebus/dataplane_dedup_test.go
@@ -1,0 +1,195 @@
+package servicebus_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// sendWithMessageID posts a message carrying the given MessageId (empty for
+// none) and asserts a 201.
+func sendWithMessageID(t *testing.T, srv *httptest.Server, queue, body, messageID string) {
+	t.Helper()
+
+	headers := map[string]string{}
+	if messageID != "" {
+		headers["BrokerProperties"] = `{"MessageId":"` + messageID + `"}`
+	}
+
+	r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/"+queue+"/messages", body, headers)
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("send %q = %d, want 201", body, r.StatusCode)
+	}
+
+	_ = r.Body.Close()
+}
+
+// receiveQueue receive-and-deletes one message from a queue, returning its body
+// and whether one was present.
+func receiveQueue(t *testing.T, srv *httptest.Server, queue string) (string, bool) {
+	t.Helper()
+
+	r := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/"+queue+"/messages/head", "")
+	switch r.StatusCode {
+	case http.StatusOK:
+		return readBody(t, r), true
+	case http.StatusNoContent:
+		return "", false
+	default:
+		t.Fatalf("receive = %d, want 200 or 204", r.StatusCode)
+		return "", false
+	}
+}
+
+// TestQueueDuplicateDetection is the regression for RequiresDuplicateDetection
+// being ignored on the REST send path: a second send with the same MessageId
+// inside the detection window is accepted but not re-enqueued, while a send
+// after the window, and one with a distinct MessageId, both enqueue.
+func TestQueueDuplicateDetection(t *testing.T) {
+	srv, clk := newClockServer(t)
+	seedNamespace(t, srv)
+
+	body := `{"properties":{"requiresDuplicateDetection":true,"duplicateDetectionHistoryTimeWindow":"PT5M"}}`
+	if r := doRequest(t, srv, http.MethodPut, queueURL("dedup")+apiVer, body); r.StatusCode != http.StatusOK {
+		t.Fatalf("create queue = %d", r.StatusCode)
+	}
+
+	// Two sends with the same MessageId inside the window: only one enqueues.
+	sendWithMessageID(t, srv, "dedup", "first", "id-1")
+	sendWithMessageID(t, srv, "dedup", "duplicate", "id-1")
+
+	if got, ok := receiveQueue(t, srv, "dedup"); !ok || got != "first" {
+		t.Fatalf("first receive = %q/%v, want first/true", got, ok)
+	}
+
+	if _, ok := receiveQueue(t, srv, "dedup"); ok {
+		t.Fatal("duplicate was enqueued; want it dropped by duplicate detection")
+	}
+
+	// A distinct MessageId is always enqueued.
+	sendWithMessageID(t, srv, "dedup", "other", "id-2")
+
+	if got, ok := receiveQueue(t, srv, "dedup"); !ok || got != "other" {
+		t.Fatalf("distinct receive = %q/%v, want other/true", got, ok)
+	}
+
+	// Past the detection window the same MessageId enqueues again.
+	clk.Advance(6 * time.Minute)
+	sendWithMessageID(t, srv, "dedup", "after-window", "id-1")
+
+	if got, ok := receiveQueue(t, srv, "dedup"); !ok || got != "after-window" {
+		t.Fatalf("post-window receive = %q/%v, want after-window/true", got, ok)
+	}
+}
+
+// TestQueueDuplicateDetectionRequiresMessageID confirms an empty MessageId is
+// never deduplicated (every send enqueues), matching real Service Bus.
+func TestQueueDuplicateDetectionRequiresMessageID(t *testing.T) {
+	srv, _ := newClockServer(t)
+	seedNamespace(t, srv)
+
+	body := `{"properties":{"requiresDuplicateDetection":true}}`
+	if r := doRequest(t, srv, http.MethodPut, queueURL("nomid")+apiVer, body); r.StatusCode != http.StatusOK {
+		t.Fatalf("create queue = %d", r.StatusCode)
+	}
+
+	sendWithMessageID(t, srv, "nomid", "a", "")
+	sendWithMessageID(t, srv, "nomid", "b", "")
+
+	got := 0
+	for {
+		if _, ok := receiveQueue(t, srv, "nomid"); !ok {
+			break
+		}
+
+		got++
+	}
+
+	if got != 2 {
+		t.Fatalf("received %d messages, want 2 (no dedup without MessageId)", got)
+	}
+}
+
+// TestTopicDuplicateDetection confirms a topic's RequiresDuplicateDetection is
+// honored on the fan-out path: a duplicate MessageId published to the topic
+// reaches each subscription only once.
+func TestTopicDuplicateDetection(t *testing.T) {
+	srv, _ := newClockServer(t)
+	seedNamespace(t, srv)
+
+	if r := doRequest(t, srv, http.MethodPut, topicURL("events")+apiVer,
+		`{"properties":{"requiresDuplicateDetection":true,"duplicateDetectionHistoryTimeWindow":"PT5M"}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create topic = %d", r.StatusCode)
+	}
+
+	if r := doRequest(t, srv, http.MethodPut, subURL("events", "s1")+apiVer, `{"properties":{}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create subscription = %d", r.StatusCode)
+	}
+
+	pub := func(body, messageID string) {
+		t.Helper()
+
+		r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/events/messages", body,
+			map[string]string{"BrokerProperties": `{"MessageId":"` + messageID + `"}`})
+		if r.StatusCode != http.StatusCreated {
+			t.Fatalf("publish = %d, want 201", r.StatusCode)
+		}
+
+		_ = r.Body.Close()
+	}
+
+	pub("first", "id-1")
+	pub("duplicate", "id-1")
+
+	if got, ok := receiveSub(t, srv, "events", "s1"); !ok || got != "first" {
+		t.Fatalf("first receive = %q/%v, want first/true", got, ok)
+	}
+
+	if _, ok := receiveSub(t, srv, "events", "s1"); ok {
+		t.Fatal("duplicate reached the subscription; want it dropped")
+	}
+}
+
+// receiveSub receive-and-deletes one message from a subscription.
+func receiveSub(t *testing.T, srv *httptest.Server, topic, sub string) (string, bool) {
+	t.Helper()
+
+	r := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/"+topic+"/subscriptions/"+sub+"/messages/head", "")
+	switch r.StatusCode {
+	case http.StatusOK:
+		return readBody(t, r), true
+	case http.StatusNoContent:
+		return "", false
+	default:
+		t.Fatalf("receive = %d, want 200 or 204", r.StatusCode)
+		return "", false
+	}
+}
+
+// TestQueueWithoutDuplicateDetection confirms MessageId is NOT deduplicated when
+// the queue does not require duplicate detection.
+func TestQueueWithoutDuplicateDetection(t *testing.T) {
+	srv, _ := newClockServer(t)
+	seedNamespace(t, srv)
+
+	if r := doRequest(t, srv, http.MethodPut, queueURL("plain")+apiVer, `{"properties":{}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create queue = %d", r.StatusCode)
+	}
+
+	sendWithMessageID(t, srv, "plain", "a", "id-1")
+	sendWithMessageID(t, srv, "plain", "b", "id-1")
+
+	got := 0
+	for {
+		if _, ok := receiveQueue(t, srv, "plain"); !ok {
+			break
+		}
+
+		got++
+	}
+
+	if got != 2 {
+		t.Fatalf("received %d messages, want 2 (dedup off)", got)
+	}
+}

--- a/server/azure/servicebus/filter.go
+++ b/server/azure/servicebus/filter.go
@@ -3,6 +3,7 @@ package servicebus
 import (
 	"strconv"
 	"strings"
+	"time"
 )
 
 // messageProps is the subset of a Service Bus message that subscription rule
@@ -143,16 +144,21 @@ func sqlProp(field string, p *messageProps) (string, bool) {
 // application property; and value is a quoted string or a numeric literal.
 // Boolean literals (1=1, 1=0, true, false) work as-is.
 //
-// The no-drop invariant: anything this evaluator cannot fully parse (an
-// unbalanced paren, an unterminated string, an unsupported operator such as
-// LIKE/IN, other malformed syntax, or an unrecognized sys.* identifier) is
-// treated as satisfied rather than silently dropping a message a real broker
-// would deliver -- it can only ever over-deliver. A well-formed comparison that
-// legitimately fails (or references an absent custom property) still excludes
-// the message.
+// Beyond comparisons the grammar also implements the common Service Bus set
+// predicates: "<field> LIKE '<pattern>'" / "NOT LIKE" (with % matching any run
+// and _ a single character, case-sensitive), "<field> IN (list)" / "NOT IN",
+// "<field> IS NULL" / "IS NOT NULL", and "EXISTS(prop)" / "NOT EXISTS(prop)".
 //
-// DEFER: LIKE, IN, EXISTS, IS NULL and arithmetic are not implemented; a clause
-// using them falls back to the no-drop match=true path.
+// The no-drop invariant: anything this evaluator cannot fully parse (an
+// unbalanced paren, an unterminated string, an unsupported operator, arithmetic,
+// other malformed syntax, or an unrecognized sys.* identifier) is treated as
+// satisfied rather than silently dropping a message a real broker would deliver
+// -- it can only ever over-deliver. A well-formed comparison that legitimately
+// fails (or references an absent custom property) still excludes the message.
+//
+// DEFER: arithmetic and LIKE's ESCAPE clause are not implemented; % and _ are
+// always wildcards (no literal-wildcard matching). A clause using them falls
+// back to the no-drop match=true path.
 func sqlMatches(f *sqlFilter, p *messageProps) bool {
 	if f == nil {
 		return true
@@ -326,8 +332,9 @@ func (sp *sqlParser) parseBinary(kw sqlTokenKind, sub func() (bool, bool), combi
 	return val, true
 }
 
-// parseTerm parses a parenthesized sub-expression or a single comparison clause
-// (a maximal run of atom tokens).
+// parseTerm parses a parenthesized sub-expression or a single clause (a maximal
+// run of atom tokens), including the IN/EXISTS set predicates whose value list
+// follows in parentheses.
 func (sp *sqlParser) parseTerm() (val, ok bool) {
 	if sp.peek() == tokLParen {
 		sp.pos++
@@ -346,13 +353,95 @@ func (sp *sqlParser) parseTerm() (val, ok bool) {
 		return false, false
 	}
 
+	parts := sp.collectAtoms()
+
+	if sp.peek() == tokLParen && expectsParenList(parts) {
+		list, listOK := sp.parseParenList()
+		if !listOK {
+			return false, false
+		}
+
+		return evalParenClause(parts, list, sp.props), true
+	}
+
+	return evalClauseParts(parts, sp.props), true
+}
+
+// collectAtoms consumes a maximal run of atom tokens.
+func (sp *sqlParser) collectAtoms() []string {
 	var parts []string
+
 	for sp.peek() == tokAtom {
 		parts = append(parts, sp.toks[sp.pos].text)
 		sp.pos++
 	}
 
-	return evalSQLClause(strings.Join(parts, " "), sp.props), true
+	return parts
+}
+
+// expectsParenList reports whether an atom run is the head of an IN or EXISTS
+// predicate whose value list is the parenthesized group that follows.
+func expectsParenList(parts []string) bool {
+	if len(parts) == 0 {
+		return false
+	}
+
+	last := parts[len(parts)-1]
+
+	return strings.EqualFold(last, "IN") || strings.EqualFold(last, "EXISTS")
+}
+
+// parseParenList consumes "( a , b , ... )", returning the (comma-separated)
+// atom values inside. A quoted literal stays intact; unquoted atoms are split on
+// commas so "(1,2)" and "(1, 2)" both yield two members.
+func (sp *sqlParser) parseParenList() (list []string, ok bool) {
+	sp.pos++ // consume '('
+
+	for sp.peek() == tokAtom {
+		list = append(list, splitListAtom(sp.toks[sp.pos].text)...)
+		sp.pos++
+	}
+
+	if sp.peek() != tokRParen {
+		return nil, false
+	}
+
+	sp.pos++
+
+	if len(list) == 0 {
+		return nil, false
+	}
+
+	return list, true
+}
+
+// splitListAtom breaks one list atom into its comma-separated members, keeping a
+// quoted literal whole (a comma inside quotes is data, not a separator).
+func splitListAtom(atom string) []string {
+	if isQuotedLiteral(atom) {
+		return []string{atom}
+	}
+
+	var out []string
+
+	for _, piece := range strings.Split(atom, ",") {
+		if piece = strings.TrimSpace(piece); piece != "" {
+			out = append(out, piece)
+		}
+	}
+
+	return out
+}
+
+// isQuotedLiteral reports whether s is wrapped in a matching pair of quotes.
+func isQuotedLiteral(s string) bool {
+	if len(s) < minQuotedLiteralLen {
+		return false
+	}
+
+	q := s[0]
+
+	return (q == '\'' || q == '"') && s[len(s)-1] == q
 }
 
 // SQL comparison operators the filter grammar understands.
@@ -365,6 +454,194 @@ const (
 	opLessEqual    = "<="
 	opGreaterEqual = ">="
 )
+
+// evalClauseParts evaluates a clause given as its atom slice (so quoted values
+// keep their internal spaces). It handles the LIKE and IS NULL predicates, then
+// falls back to the operator-comparison path.
+func evalClauseParts(parts []string, p *messageProps) bool {
+	if v, handled := evalLikeParts(parts, p); handled {
+		return v
+	}
+
+	if v, handled := evalIsNullParts(parts, p); handled {
+		return v
+	}
+
+	return evalSQLClause(strings.Join(parts, " "), p)
+}
+
+// evalLikeParts evaluates "<field> LIKE '<pattern>'" and its NOT form. handled
+// is false when the clause has no LIKE keyword so other paths can try it.
+func evalLikeParts(parts []string, p *messageProps) (val, handled bool) {
+	i := indexFold(parts, "LIKE")
+	if i < 0 {
+		return false, false
+	}
+
+	negate := i >= 1 && strings.EqualFold(parts[i-1], "NOT")
+
+	fieldEnd := i
+	if negate {
+		fieldEnd = i - 1
+	}
+
+	// A well-formed LIKE is "<field> [NOT] LIKE <pattern>" with exactly one
+	// pattern atom; anything else is malformed, so keep the no-drop match.
+	if fieldEnd < 1 || i+2 != len(parts) {
+		return true, true
+	}
+
+	field := strings.Join(parts[:fieldEnd], " ")
+
+	got, present, recognized := resolveSQLField(field, p)
+	if !recognized {
+		return true, true
+	}
+
+	if !present {
+		return negate, true // absent value: LIKE false, NOT LIKE true
+	}
+
+	return sqlLike(got, unquoteSQL(parts[i+1])) != negate, true
+}
+
+// evalIsNullParts evaluates "<field> IS NULL" and "<field> IS NOT NULL".
+func evalIsNullParts(parts []string, p *messageProps) (val, handled bool) {
+	i := indexFold(parts, "IS")
+	if i < 1 {
+		return false, false
+	}
+
+	negate, ok := parseIsNullTail(parts[i+1:])
+	if !ok {
+		return false, false
+	}
+
+	field := strings.Join(parts[:i], " ")
+
+	_, present, recognized := resolveSQLField(field, p)
+	if !recognized {
+		return true, true
+	}
+
+	// IS NULL is true when the property is absent; IS NOT NULL when present.
+	isNull := !present
+
+	return isNull != negate, true
+}
+
+// parseIsNullTail matches the "NULL" / "NOT NULL" tail of an IS predicate,
+// reporting whether it negates (IS NOT NULL) and whether it matched at all.
+func parseIsNullTail(rest []string) (negate, ok bool) {
+	switch {
+	case len(rest) == 1 && strings.EqualFold(rest[0], "NULL"):
+		return false, true
+	case len(rest) == minQuotedLiteralLen && strings.EqualFold(rest[0], "NOT") && strings.EqualFold(rest[1], "NULL"):
+		return true, true
+	default:
+		return false, false
+	}
+}
+
+// evalParenClause evaluates an IN or EXISTS predicate whose value list has
+// already been parsed from the following parentheses.
+func evalParenClause(parts, list []string, p *messageProps) bool {
+	if strings.EqualFold(parts[len(parts)-1], "EXISTS") {
+		return evalExists(parts, list, p)
+	}
+
+	return evalIn(parts, list, p)
+}
+
+// evalExists evaluates "EXISTS(prop)" / "NOT EXISTS(prop)": a presence test on
+// the single listed property.
+func evalExists(parts, list []string, p *messageProps) bool {
+	if len(list) != 1 {
+		return true // malformed -> no-drop
+	}
+
+	negate := len(parts) >= minQuotedLiteralLen && strings.EqualFold(parts[len(parts)-2], "NOT")
+
+	_, present, recognized := resolveSQLField(list[0], p)
+	if !recognized {
+		return true
+	}
+
+	return present != negate
+}
+
+// evalIn evaluates "<field> IN (list)" / "NOT IN": a membership test of the
+// field's value against the (numeric-aware) list.
+func evalIn(parts, list []string, p *messageProps) bool {
+	negate := len(parts) >= minQuotedLiteralLen && strings.EqualFold(parts[len(parts)-2], "NOT")
+
+	got, present, recognized := resolveSQLField(parts[0], p)
+	if !recognized {
+		return true
+	}
+
+	member := present && inList(got, list)
+
+	return member != negate
+}
+
+// inList reports whether got equals any list member, comparing numerically when
+// both sides parse as numbers (like the = operator) and lexically otherwise.
+func inList(got string, list []string) bool {
+	for _, item := range list {
+		if sqlEqual(got, unquoteSQL(item)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// indexFold returns the index of the first part equal to word (case-insensitive)
+// or -1.
+func indexFold(parts []string, word string) int {
+	for i, part := range parts {
+		if strings.EqualFold(part, word) {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// sqlLike reports whether value matches a Service Bus LIKE pattern, where %
+// matches any run of characters (including none) and _ matches exactly one.
+// Matching is case-sensitive, per Service Bus.
+func sqlLike(value, pattern string) bool {
+	v := []rune(value)
+	pat := []rune(pattern)
+
+	vi, pi := 0, 0
+	star, mark := -1, 0
+
+	for vi < len(v) {
+		switch {
+		case pi < len(pat) && (pat[pi] == '_' || pat[pi] == v[vi]):
+			vi++
+			pi++
+		case pi < len(pat) && pat[pi] == '%':
+			star, mark = pi, vi
+			pi++
+		case star >= 0:
+			pi = star + 1
+			mark++
+			vi = mark
+		default:
+			return false
+		}
+	}
+
+	for pi < len(pat) && pat[pi] == '%' {
+		pi++
+	}
+
+	return pi == len(pat)
+}
 
 // evalSQLClause evaluates one comparison clause, upholding the no-drop
 // invariant for anything it cannot parse or resolve.
@@ -613,6 +890,26 @@ func lockDurationSeconds(s string) int {
 
 	return total
 }
+
+// dupDetectionWindow converts a duplicateDetectionHistoryTimeWindow ISO-8601
+// duration to a Duration, falling back to Service Bus' 10-minute default for an
+// empty or unparseable value.
+func dupDetectionWindow(s string) time.Duration {
+	if s == "" {
+		return defaultDupDetectionWindowDuration
+	}
+
+	secs := ttlSecondsFromISO(s)
+	if secs <= 0 {
+		return defaultDupDetectionWindowDuration
+	}
+
+	return time.Duration(secs) * time.Second
+}
+
+// defaultDupDetectionWindowDuration mirrors defaultDupDetectionISO ("PT10M") as
+// a Duration for the data-plane dedup window passed to the backing store.
+const defaultDupDetectionWindowDuration = 10 * time.Minute
 
 // secondsPerDay is the whole-seconds length of the ISO-8601 date component "D".
 const secondsPerDay = 86400

--- a/server/azure/servicebus/filter_predicates_test.go
+++ b/server/azure/servicebus/filter_predicates_test.go
@@ -1,0 +1,93 @@
+package servicebus
+
+import "testing"
+
+// TestSQLFilterSetPredicates covers the LIKE / IN / EXISTS / IS NULL SqlFilter
+// predicates that previously fell back to the no-drop match=true path and so
+// over-delivered every message. Real Service Bus delivers only matching
+// messages, so a non-matching predicate must now exclude, while a genuinely
+// unsupported clause keeps the safe fallback.
+func TestSQLFilterSetPredicates(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+		p    *messageProps
+		want bool
+	}{
+		// LIKE with % (any run) and _ (single char), case-sensitive.
+		{"like percent matches", "sys.Label LIKE 'order-%'", &messageProps{Label: "order-1"}, true},
+		{"like percent no match", "sys.Label LIKE 'order-%'", &messageProps{Label: "shipment-1"}, false},
+		{"like underscore matches", "sys.Label LIKE 'a_c'", &messageProps{Label: "abc"}, true},
+		{"like underscore too long", "sys.Label LIKE 'a_c'", &messageProps{Label: "abbc"}, false},
+		{"like case sensitive", "sys.Label LIKE 'Order-%'", &messageProps{Label: "order-1"}, false},
+		{"not like excludes match", "sys.Label NOT LIKE 'order-%'", &messageProps{Label: "order-1"}, false},
+		{"not like keeps non match", "sys.Label NOT LIKE 'order-%'", &messageProps{Label: "shipment"}, true},
+		{"like on custom prop", "region LIKE 'us-%'", &messageProps{Custom: map[string]string{"region": "us-east"}}, true},
+
+		// IN / NOT IN membership over strings and numbers.
+		{"in matches", "user.Region IN ('us','eu')", &messageProps{Custom: map[string]string{"Region": "eu"}}, true},
+		{"in no match", "user.Region IN ('us','eu')", &messageProps{Custom: map[string]string{"Region": "ap"}}, false},
+		{"in numeric matches", "priority IN (1,3,5)", &messageProps{Custom: map[string]string{"priority": "3"}}, true},
+		{"in numeric no match", "priority IN (1,3,5)", &messageProps{Custom: map[string]string{"priority": "2"}}, false},
+		{"not in excludes member", "user.Region NOT IN ('us','eu')", &messageProps{Custom: map[string]string{"Region": "us"}}, false},
+		{"not in keeps non member", "user.Region NOT IN ('us','eu')", &messageProps{Custom: map[string]string{"Region": "ap"}}, true},
+		{"in absent prop", "user.Region IN ('us')", &messageProps{}, false},
+
+		// IS NULL / IS NOT NULL presence tests.
+		{"is null on absent", "user.Region IS NULL", &messageProps{}, true},
+		{"is null on present", "user.Region IS NULL", &messageProps{Custom: map[string]string{"Region": "us"}}, false},
+		{"is not null on present", "user.Region IS NOT NULL", &messageProps{Custom: map[string]string{"Region": "us"}}, true},
+		{"is not null on absent", "user.Region IS NOT NULL", &messageProps{}, false},
+
+		// EXISTS / NOT EXISTS presence tests.
+		{"exists present", "EXISTS(user.Region)", &messageProps{Custom: map[string]string{"Region": "us"}}, true},
+		{"exists absent", "EXISTS(user.Region)", &messageProps{}, false},
+		{"not exists absent", "NOT EXISTS(user.Region)", &messageProps{}, true},
+		{"not exists present", "NOT EXISTS(user.Region)", &messageProps{Custom: map[string]string{"Region": "us"}}, false},
+
+		// Predicates compose with AND/OR and parens.
+		{"like and in", "sys.Label LIKE 'o%' AND user.Region IN ('us')",
+			&messageProps{Label: "order", Custom: map[string]string{"Region": "us"}}, true},
+		{"like or exists", "sys.Label LIKE 'z%' OR EXISTS(user.Region)",
+			&messageProps{Label: "order", Custom: map[string]string{"Region": "us"}}, true},
+
+		// A clause the grammar still cannot parse keeps the safe no-drop path.
+		{"incomplete clause falls to match", "sys.Label", &messageProps{Label: "anything"}, true},
+		{"non-sql falls to match", "totally not sql", &messageProps{Label: "anything"}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := evalSQLExpression(tc.expr, tc.p); got != tc.want {
+				t.Fatalf("evalSQLExpression(%q) = %v, want %v", tc.expr, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSQLLikeWildcards exercises the LIKE matcher directly, including anchoring
+// and multi-wildcard patterns.
+func TestSQLLikeWildcards(t *testing.T) {
+	tests := []struct {
+		value, pattern string
+		want           bool
+	}{
+		{"order-123", "order-%", true},
+		{"order-123", "%-123", true},
+		{"order-123", "%rder%", true},
+		{"order", "order", true},
+		{"order", "orders", false},
+		{"order", "ord_r", true},
+		{"order", "ord__r", false},
+		{"", "%", true},
+		{"anything", "%", true},
+		{"a", "_", true},
+		{"", "_", false},
+	}
+
+	for _, tc := range tests {
+		if got := sqlLike(tc.value, tc.pattern); got != tc.want {
+			t.Fatalf("sqlLike(%q, %q) = %v, want %v", tc.value, tc.pattern, got, tc.want)
+		}
+	}
+}

--- a/server/azure/servicebus/queue.go
+++ b/server/azure/servicebus/queue.go
@@ -75,7 +75,9 @@ func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request, sp sbPath,
 				TargetQueueURL:  dlqURL,
 				MaxReceiveCount: effectiveMaxDeliveryCount(&req.Properties),
 			},
-			DeadLetterOnExpiration: req.Properties.DeadLetteringOnExpiration,
+			DeadLetterOnExpiration:     req.Properties.DeadLetteringOnExpiration,
+			RequiresDuplicateDetection: req.Properties.RequiresDuplicateDetection,
+			DuplicateDetectionWindow:   dupDetectionWindow(req.Properties.DuplicateDetectionHistoryTimeWindow),
 		})
 		if err != nil && !cerrors.IsAlreadyExists(err) {
 			h.mu.Unlock()
@@ -229,12 +231,33 @@ func buildQueueProps(in *queueProperties, created, updated time.Time) queuePrope
 		out.MaxSizeInMegabytes = defaultMaxSizeMB
 	}
 
+	if out.AutoDeleteOnIdle == "" {
+		out.AutoDeleteOnIdle = maxTimeToLive
+	}
+
+	if out.DuplicateDetectionHistoryTimeWindow == "" {
+		out.DuplicateDetectionHistoryTimeWindow = defaultDupDetectionISO
+	}
+
+	if out.EnableBatchedOperations == nil {
+		out.EnableBatchedOperations = defaultBatchedOps()
+	}
+
 	out.CountDetails = &countDetails{}
 	out.CreatedAt = &created
 	out.UpdatedAt = &updated
 	out.AccessedAt = &updated
 
 	return out
+}
+
+// defaultBatchedOps returns a pointer to Service Bus' enableBatchedOperations
+// default (true), used when a create request omits the field. A pointer keeps an
+// explicit "false" from being overwritten by the default.
+func defaultBatchedOps() *bool {
+	v := true
+
+	return &v
 }
 
 func (h *Handler) toQueueResource(sp sbPath, rec *queueRecord) queueResource {

--- a/server/azure/servicebus/queue_properties_test.go
+++ b/server/azure/servicebus/queue_properties_test.go
@@ -1,0 +1,168 @@
+package servicebus_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// armEntityProps is the subset of queue/topic ARM properties the round-trip
+// tests assert on.
+type armEntityProps struct {
+	AutoDeleteOnIdle                    string `json:"autoDeleteOnIdle"`
+	DuplicateDetectionHistoryTimeWindow string `json:"duplicateDetectionHistoryTimeWindow"`
+	ForwardTo                           string `json:"forwardTo"`
+	RequiresDuplicateDetection          bool   `json:"requiresDuplicateDetection"`
+	EnableExpress                       bool   `json:"enableExpress"`
+	EnableBatchedOperations             *bool  `json:"enableBatchedOperations"`
+}
+
+func decodeEntityProps(t *testing.T, resp *http.Response) armEntityProps {
+	t.Helper()
+
+	var got struct {
+		Properties armEntityProps `json:"properties"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	_ = resp.Body.Close()
+
+	return got.Properties
+}
+
+// TestQueueARMPropertiesRoundTrip guards the azurerm perpetual-diff bug: the
+// queue ARM properties azurerm_servicebus_queue sets (autoDeleteOnIdle,
+// duplicateDetectionHistoryTimeWindow, enableBatchedOperations, forwardTo,
+// enableExpress) must survive PUT -> GET so plan-after-apply is clean.
+func TestQueueARMPropertiesRoundTrip(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+
+	body := `{"properties":{` +
+		`"autoDeleteOnIdle":"PT30M",` +
+		`"duplicateDetectionHistoryTimeWindow":"PT20M",` +
+		`"requiresDuplicateDetection":true,` +
+		`"enableBatchedOperations":false,` +
+		`"enableExpress":true,` +
+		`"forwardTo":"other-queue"}}`
+
+	put := doRequest(t, srv, http.MethodPut, queueURL("orders")+apiVer, body)
+	if put.StatusCode != http.StatusOK {
+		t.Fatalf("PUT queue = %d, body: %s", put.StatusCode, readBody(t, put))
+	}
+
+	_ = put.Body.Close()
+
+	get := doRequest(t, srv, http.MethodGet, queueURL("orders")+apiVer, "")
+	if get.StatusCode != http.StatusOK {
+		t.Fatalf("GET queue = %d", get.StatusCode)
+	}
+
+	assertRoundTrip(t, decodeEntityProps(t, get), armEntityProps{
+		AutoDeleteOnIdle:                    "PT30M",
+		DuplicateDetectionHistoryTimeWindow: "PT20M",
+		ForwardTo:                           "other-queue",
+		RequiresDuplicateDetection:          true,
+		EnableExpress:                       true,
+		EnableBatchedOperations:             boolPtr(false),
+	})
+}
+
+// TestQueueARMPropertyDefaults checks the real-Service-Bus defaults a create
+// that omits these fields reports back.
+func TestQueueARMPropertyDefaults(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+
+	if r := doRequest(t, srv, http.MethodPut, queueURL("plain")+apiVer, `{"properties":{}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("PUT queue = %d", r.StatusCode)
+	}
+
+	get := doRequest(t, srv, http.MethodGet, queueURL("plain")+apiVer, "")
+	props := decodeEntityProps(t, get)
+
+	if props.DuplicateDetectionHistoryTimeWindow != "PT10M" {
+		t.Fatalf("default duplicateDetectionHistoryTimeWindow = %q, want PT10M", props.DuplicateDetectionHistoryTimeWindow)
+	}
+
+	if props.AutoDeleteOnIdle == "" {
+		t.Fatal("default autoDeleteOnIdle is empty, want the max sentinel")
+	}
+
+	if props.EnableBatchedOperations == nil || !*props.EnableBatchedOperations {
+		t.Fatalf("default enableBatchedOperations = %v, want true", props.EnableBatchedOperations)
+	}
+}
+
+// TestTopicARMPropertiesRoundTrip mirrors the queue round-trip for the topic
+// properties azurerm_servicebus_topic sets.
+func TestTopicARMPropertiesRoundTrip(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+
+	body := `{"properties":{` +
+		`"autoDeleteOnIdle":"PT45M",` +
+		`"duplicateDetectionHistoryTimeWindow":"PT15M",` +
+		`"requiresDuplicateDetection":true,` +
+		`"enableBatchedOperations":false}}`
+
+	put := doRequest(t, srv, http.MethodPut, topicURL("events")+apiVer, body)
+	if put.StatusCode != http.StatusOK {
+		t.Fatalf("PUT topic = %d, body: %s", put.StatusCode, readBody(t, put))
+	}
+
+	_ = put.Body.Close()
+
+	get := doRequest(t, srv, http.MethodGet, topicURL("events")+apiVer, "")
+	if get.StatusCode != http.StatusOK {
+		t.Fatalf("GET topic = %d", get.StatusCode)
+	}
+
+	got := decodeEntityProps(t, get)
+	if got.AutoDeleteOnIdle != "PT45M" || got.DuplicateDetectionHistoryTimeWindow != "PT15M" {
+		t.Fatalf("topic durations = %q / %q, want PT45M / PT15M",
+			got.AutoDeleteOnIdle, got.DuplicateDetectionHistoryTimeWindow)
+	}
+
+	if !got.RequiresDuplicateDetection {
+		t.Fatal("topic requiresDuplicateDetection = false, want true")
+	}
+
+	if got.EnableBatchedOperations == nil || *got.EnableBatchedOperations {
+		t.Fatalf("topic enableBatchedOperations = %v, want explicit false", got.EnableBatchedOperations)
+	}
+}
+
+func assertRoundTrip(t *testing.T, got, want armEntityProps) {
+	t.Helper()
+
+	if got.AutoDeleteOnIdle != want.AutoDeleteOnIdle {
+		t.Errorf("autoDeleteOnIdle = %q, want %q", got.AutoDeleteOnIdle, want.AutoDeleteOnIdle)
+	}
+
+	if got.DuplicateDetectionHistoryTimeWindow != want.DuplicateDetectionHistoryTimeWindow {
+		t.Errorf("duplicateDetectionHistoryTimeWindow = %q, want %q",
+			got.DuplicateDetectionHistoryTimeWindow, want.DuplicateDetectionHistoryTimeWindow)
+	}
+
+	if got.ForwardTo != want.ForwardTo {
+		t.Errorf("forwardTo = %q, want %q", got.ForwardTo, want.ForwardTo)
+	}
+
+	if got.RequiresDuplicateDetection != want.RequiresDuplicateDetection {
+		t.Errorf("requiresDuplicateDetection = %v, want %v", got.RequiresDuplicateDetection, want.RequiresDuplicateDetection)
+	}
+
+	if got.EnableExpress != want.EnableExpress {
+		t.Errorf("enableExpress = %v, want %v", got.EnableExpress, want.EnableExpress)
+	}
+
+	if got.EnableBatchedOperations == nil || *got.EnableBatchedOperations != *want.EnableBatchedOperations {
+		t.Errorf("enableBatchedOperations = %v, want %v", got.EnableBatchedOperations, *want.EnableBatchedOperations)
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/server/azure/servicebus/state.go
+++ b/server/azure/servicebus/state.go
@@ -31,6 +31,9 @@ const (
 const (
 	defaultLockDuration = "PT1M"
 	maxTimeToLive       = "P10675199DT2H48M5.4775807S"
+	// defaultDupDetectionISO is Service Bus' default duplicate-detection history
+	// time window (10 minutes) reported for queues/topics that omit it.
+	defaultDupDetectionISO = "PT10M"
 
 	statusActive          = "Active"
 	filterTypeSQL         = "SqlFilter"

--- a/server/azure/servicebus/subscription.go
+++ b/server/azure/servicebus/subscription.go
@@ -72,7 +72,13 @@ func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, sp 
 
 	rec, existed := t.Subs[name]
 	if !existed {
-		url, dlqURL, err := h.createSubQueue(r, sp.namespace, topic, name, lockSeconds, &req.Properties)
+		// Duplicate detection is a topic-level property; the subscription backing
+		// store inherits it so a repeated MessageId published to the topic is
+		// deduplicated per subscription (the same observable result as topic-level
+		// detection).
+		dup := topicDupDetection(t)
+
+		url, dlqURL, err := h.createSubQueue(r, sp.namespace, topic, name, lockSeconds, &req.Properties, dup)
 		if err != nil {
 			h.mu.Unlock()
 			azurearm.WriteCErr(w, err)
@@ -146,12 +152,28 @@ func (h *Handler) deleteSubscription(w http.ResponseWriter, sp sbPath, topic, na
 	w.WriteHeader(http.StatusOK)
 }
 
+// dupConfig captures the parent topic's duplicate-detection settings that a
+// subscription backing store inherits.
+type dupConfig struct {
+	enabled bool
+	window  time.Duration
+}
+
+// topicDupDetection resolves a topic's duplicate-detection settings for its
+// subscriptions' backing stores.
+func topicDupDetection(t *topicRecord) dupConfig {
+	return dupConfig{
+		enabled: t.Props.RequiresDuplicateDetection,
+		window:  dupDetectionWindow(t.Props.DuplicateDetectionHistoryTimeWindow),
+	}
+}
+
 // createSubQueue provisions the backing message store for a new subscription
 // plus its paired $DeadLetterQueue, honoring the subscription's LockDuration,
-// MaxDeliveryCount and deadLetteringOnMessageExpiration. It returns the primary
-// and dead-letter store URLs.
+// MaxDeliveryCount and deadLetteringOnMessageExpiration, plus the parent topic's
+// duplicate detection. It returns the primary and dead-letter store URLs.
 func (h *Handler) createSubQueue(
-	r *http.Request, namespace, topic, sub string, lockSeconds int, props *subscriptionProperties,
+	r *http.Request, namespace, topic, sub string, lockSeconds int, props *subscriptionProperties, dup dupConfig,
 ) (url, dlqURL string, err error) {
 	name := namespace + "/" + topic + "/" + segSubs + "/" + sub
 
@@ -167,7 +189,9 @@ func (h *Handler) createSubQueue(
 			TargetQueueURL:  dlqURL,
 			MaxReceiveCount: effectiveSubMaxDeliveryCount(props),
 		},
-		DeadLetterOnExpiration: props.DeadLetteringOnExpiration,
+		DeadLetterOnExpiration:     props.DeadLetteringOnExpiration,
+		RequiresDuplicateDetection: dup.enabled,
+		DuplicateDetectionWindow:   dup.window,
 	})
 	if err != nil && !cerrors.IsAlreadyExists(err) {
 		return "", "", err

--- a/server/azure/servicebus/topic.go
+++ b/server/azure/servicebus/topic.go
@@ -192,6 +192,18 @@ func buildTopicProps(in *topicProperties, created, updated time.Time, subCount i
 		out.MaxSizeInMegabytes = defaultMaxSizeMB
 	}
 
+	if out.AutoDeleteOnIdle == "" {
+		out.AutoDeleteOnIdle = maxTimeToLive
+	}
+
+	if out.DuplicateDetectionHistoryTimeWindow == "" {
+		out.DuplicateDetectionHistoryTimeWindow = defaultDupDetectionISO
+	}
+
+	if out.EnableBatchedOperations == nil {
+		out.EnableBatchedOperations = defaultBatchedOps()
+	}
+
 	out.CountDetails = &countDetails{}
 	out.CreatedAt = &created
 	out.UpdatedAt = &updated

--- a/server/azure/servicebus/types.go
+++ b/server/azure/servicebus/types.go
@@ -44,21 +44,26 @@ type queueResource struct {
 }
 
 type queueProperties struct {
-	Status                     string        `json:"status,omitempty"`
-	CountDetails               *countDetails `json:"countDetails,omitempty"`
-	MessageCount               int64         `json:"messageCount"`
-	SizeInBytes                int64         `json:"sizeInBytes"`
-	MaxSizeInMegabytes         int32         `json:"maxSizeInMegabytes,omitempty"`
-	MaxDeliveryCount           int32         `json:"maxDeliveryCount,omitempty"`
-	LockDuration               string        `json:"lockDuration,omitempty"`
-	DefaultMessageTimeToLive   string        `json:"defaultMessageTimeToLive,omitempty"`
-	RequiresDuplicateDetection bool          `json:"requiresDuplicateDetection"`
-	RequiresSession            bool          `json:"requiresSession"`
-	DeadLetteringOnExpiration  bool          `json:"deadLetteringOnMessageExpiration"`
-	EnablePartitioning         bool          `json:"enablePartitioning"`
-	CreatedAt                  *time.Time    `json:"createdAt,omitempty"`
-	UpdatedAt                  *time.Time    `json:"updatedAt,omitempty"`
-	AccessedAt                 *time.Time    `json:"accessedAt,omitempty"`
+	Status                              string        `json:"status,omitempty"`
+	CountDetails                        *countDetails `json:"countDetails,omitempty"`
+	MessageCount                        int64         `json:"messageCount"`
+	SizeInBytes                         int64         `json:"sizeInBytes"`
+	MaxSizeInMegabytes                  int32         `json:"maxSizeInMegabytes,omitempty"`
+	MaxDeliveryCount                    int32         `json:"maxDeliveryCount,omitempty"`
+	LockDuration                        string        `json:"lockDuration,omitempty"`
+	DefaultMessageTimeToLive            string        `json:"defaultMessageTimeToLive,omitempty"`
+	AutoDeleteOnIdle                    string        `json:"autoDeleteOnIdle,omitempty"`
+	DuplicateDetectionHistoryTimeWindow string        `json:"duplicateDetectionHistoryTimeWindow,omitempty"`
+	ForwardTo                           string        `json:"forwardTo,omitempty"`
+	RequiresDuplicateDetection          bool          `json:"requiresDuplicateDetection"`
+	RequiresSession                     bool          `json:"requiresSession"`
+	DeadLetteringOnExpiration           bool          `json:"deadLetteringOnMessageExpiration"`
+	EnablePartitioning                  bool          `json:"enablePartitioning"`
+	EnableExpress                       bool          `json:"enableExpress"`
+	EnableBatchedOperations             *bool         `json:"enableBatchedOperations,omitempty"`
+	CreatedAt                           *time.Time    `json:"createdAt,omitempty"`
+	UpdatedAt                           *time.Time    `json:"updatedAt,omitempty"`
+	AccessedAt                          *time.Time    `json:"accessedAt,omitempty"`
 }
 
 type countDetails struct {
@@ -78,19 +83,22 @@ type topicResource struct {
 }
 
 type topicProperties struct {
-	Status                     string        `json:"status,omitempty"`
-	CountDetails               *countDetails `json:"countDetails,omitempty"`
-	SubscriptionCount          int32         `json:"subscriptionCount"`
-	SizeInBytes                int64         `json:"sizeInBytes"`
-	MaxSizeInMegabytes         int32         `json:"maxSizeInMegabytes,omitempty"`
-	DefaultMessageTimeToLive   string        `json:"defaultMessageTimeToLive,omitempty"`
-	RequiresDuplicateDetection bool          `json:"requiresDuplicateDetection"`
-	EnablePartitioning         bool          `json:"enablePartitioning"`
-	EnableExpress              bool          `json:"enableExpress"`
-	SupportOrdering            bool          `json:"supportOrdering"`
-	CreatedAt                  *time.Time    `json:"createdAt,omitempty"`
-	UpdatedAt                  *time.Time    `json:"updatedAt,omitempty"`
-	AccessedAt                 *time.Time    `json:"accessedAt,omitempty"`
+	Status                              string        `json:"status,omitempty"`
+	CountDetails                        *countDetails `json:"countDetails,omitempty"`
+	SubscriptionCount                   int32         `json:"subscriptionCount"`
+	SizeInBytes                         int64         `json:"sizeInBytes"`
+	MaxSizeInMegabytes                  int32         `json:"maxSizeInMegabytes,omitempty"`
+	DefaultMessageTimeToLive            string        `json:"defaultMessageTimeToLive,omitempty"`
+	AutoDeleteOnIdle                    string        `json:"autoDeleteOnIdle,omitempty"`
+	DuplicateDetectionHistoryTimeWindow string        `json:"duplicateDetectionHistoryTimeWindow,omitempty"`
+	RequiresDuplicateDetection          bool          `json:"requiresDuplicateDetection"`
+	EnablePartitioning                  bool          `json:"enablePartitioning"`
+	EnableExpress                       bool          `json:"enableExpress"`
+	EnableBatchedOperations             *bool         `json:"enableBatchedOperations,omitempty"`
+	SupportOrdering                     bool          `json:"supportOrdering"`
+	CreatedAt                           *time.Time    `json:"createdAt,omitempty"`
+	UpdatedAt                           *time.Time    `json:"updatedAt,omitempty"`
+	AccessedAt                          *time.Time    `json:"accessedAt,omitempty"`
 }
 
 // subscriptionResource is the ARM JSON shape for .../topics/subscriptions.

--- a/services/messagequeue/driver/driver.go
+++ b/services/messagequeue/driver/driver.go
@@ -25,6 +25,16 @@ type QueueConfig struct {
 	// ignored by non-Azure providers.
 	DeadLetterOnExpiration bool
 
+	// RequiresDuplicateDetection enables Azure Service Bus duplicate detection: a
+	// send whose MessageId (SystemProperties["MessageId"]) matches one seen within
+	// DuplicateDetectionWindow is silently accepted but not re-enqueued. Distinct
+	// from FIFO/DeduplicationID dedup; ignored by non-Azure providers.
+	RequiresDuplicateDetection bool
+	// DuplicateDetectionWindow is the look-back window for
+	// RequiresDuplicateDetection. Zero falls back to the provider default (Service
+	// Bus: 10 minutes).
+	DuplicateDetectionWindow time.Duration
+
 	// AWS SQS extras (ignored by non-AWS providers).
 	ReceiveMessageWaitTimeSeconds int
 	ContentBasedDeduplication     bool


### PR DESCRIPTION
## Summary

Fixes three confirmed Azure Service Bus correctness/parity issues (all in `server/azure/servicebus/` + `providers/azure/servicebus/`), each with real-user tests.

### 1. SQL filter `LIKE` / `IN` / `EXISTS` / `IS NULL` (wrong-result / message over-delivery)
Unsupported SqlFilter clauses parsed to nothing and fell back to the no-drop `match=true` path, so a rule like `sys.Label LIKE 'order-%'` or `user.Region IN ('us','eu')` matched **every** message. The recursive-descent evaluator now implements:
- `LIKE` / `NOT LIKE` with `%` (any run) and `_` (single char) wildcards, case-sensitive per real SB.
- `IN (list)` / `NOT IN` membership (string and numeric members).
- `IS NULL` / `IS NOT NULL` and `EXISTS(prop)` / `NOT EXISTS(prop)` presence tests (an absent property is NULL / not-EXISTS).

The existing operators, AND/OR precedence and parens are unchanged, and a genuinely-unparseable clause still keeps the safe no-drop fallback.

### 2. Round-trip queue/topic ARM properties (Terraform perpetual diff)
`queueProperties` / `topicProperties` lacked `autoDeleteOnIdle`, `duplicateDetectionHistoryTimeWindow`, `enableBatchedOperations`, plus (queue) `forwardTo` and `enableExpress`, which `azurerm_servicebus_queue`/`_topic` set — causing plan-after-apply drift. These now store and round-trip faithfully with real-SB defaults (`autoDeleteOnIdle` max sentinel, `duplicateDetectionHistoryTimeWindow` `PT10M`, `enableBatchedOperations` true, `enableExpress` false). `enableBatchedOperations` is a `*bool` so an explicit `false` is preserved rather than overwritten by the default.

`forwardTo` is **round-trip-only** (stored/echoed faithfully so TF does not drift); it does not yet actually forward messages — that remains a deferred feature.

### 3. Enforce `RequiresDuplicateDetection` (correctness)
`requiresDuplicateDetection` round-tripped but was never enforced on the send path. The backing store now deduplicates on `MessageId` within `duplicateDetectionHistoryTimeWindow` (default `PT10M`, driven by the injected Clock), mirroring the existing FIFO dedup mechanism: a repeat MessageId inside the window is silently accepted but not re-enqueued; an empty MessageId is never deduped. Topics inherit their duplicate-detection setting onto each subscription's backing store, giving the same observable result as topic-level detection.

## Tests
- Filter: LIKE `order-%` matches `order-1` not `shipment-1`; NOT LIKE; IN/NOT IN membership (string + numeric); IS NULL / IS NOT NULL / EXISTS / NOT EXISTS on present + absent props; composition with AND/OR; unsupported clause keeps safe fallback; direct LIKE-matcher table.
- ARM properties: queue + topic PUT -> GET round-trip and defaults (including explicit `enableBatchedOperations:false` preserved).
- Dedup: same-MessageId re-send dropped inside the window and accepted after it (FakeClock); distinct MessageIds accepted; empty MessageId never deduped; dedup off when not required; topic-level dedup on the fan-out path.

## Gates
`go build ./...`, `go vet`, scoped `go test`, gofmt, `golangci-lint --new-from-rev=origin/development` (0 issues), `go generate` + `compatgen` (zero diff) all green.
