### PR TITLE
fix(azure-aks): preserve node pools on cluster PUT, osDiskType/scale-to-zero/UserAssigned identity/inline pool fields

### DIFF
--- a/providers/azure/aks/agentpool_cost_test.go
+++ b/providers/azure/aks/agentpool_cost_test.go
@@ -54,7 +54,7 @@ func TestAgentPoolScaleSetPriority(t *testing.T) {
 		pool, err := m.CreateOrUpdateAgentPool(ctx, "rg-1", "k8s-spot", AgentPoolInput{
 			Name:             "spotpool",
 			VMSize:           "Standard_D2s_v3",
-			Count:            3,
+			Count:            int32Ptr(3),
 			ScaleSetPriority: "Spot",
 		})
 		requireNoError(t, err)
@@ -83,7 +83,7 @@ func TestAgentPoolScaleSetPriority(t *testing.T) {
 		pool, err := m.CreateOrUpdateAgentPool(ctx, "rg-1", "k8s-reg", AgentPoolInput{
 			Name:   "regpool",
 			VMSize: "Standard_D2s_v3",
-			Count:  2,
+			Count:  int32Ptr(2),
 		})
 		requireNoError(t, err)
 		assertEqual(t, "Regular", pool.ScaleSetPriority)

--- a/providers/azure/aks/aks.go
+++ b/providers/azure/aks/aks.go
@@ -12,6 +12,7 @@ package aks
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -82,9 +83,20 @@ type ManagedCluster struct {
 	IdentityType string
 	PrincipalID  string
 	TenantID     string
+	// UserAssignedIdentities echoes identity.userAssignedIdentities: the ARM
+	// resource ID of each assigned identity mapped to its synthesized
+	// principal/client pair. Populated only for a UserAssigned identity.
+	UserAssignedIdentities map[string]UserAssignedIdentity
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
+}
+
+// UserAssignedIdentity is the synthesized principal/client pair echoed for a
+// single user-assigned managed identity.
+type UserAssignedIdentity struct {
+	PrincipalID string
+	ClientID    string
 }
 
 // NetworkProfile captures the cluster network configuration echoed back on read.
@@ -150,9 +162,29 @@ type AgentPool struct {
 	VnetSubnetID       string
 	OSSKU              string
 	EnableNodePublicIP *bool
+	// Additional default_node_pool fields Terraform commonly submits inline.
+	// Echoed verbatim so an inline submission round-trips the same as a
+	// standalone pool; the emulator synthesizes no defaults for them.
+	UpgradeSettings        *AgentPoolUpgradeSettings
+	Tags                   map[string]string
+	EnableFIPS             *bool
+	SpotMaxPrice           *float32
+	ScaleSetEvictionPolicy string
+	NodePublicIPPrefixID   string
+	KubeletDiskType        string
+	KubeletConfig          map[string]any
+	LinuxOSConfig          map[string]any
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
+}
+
+// AgentPoolUpgradeSettings mirrors the subset of
+// armcontainerservice.AgentPoolUpgradeSettings the emulator round-trips.
+type AgentPoolUpgradeSettings struct {
+	MaxSurge                  string
+	DrainTimeoutInMinutes     *int32
+	NodeSoakDurationInMinutes *int32
 }
 
 // MaintenanceConfig is a maintenance window attached to a managed cluster.
@@ -313,9 +345,16 @@ type ClusterInput struct {
 	// Tier is the cluster SKU tier (Free / Standard / Premium); defaults to Free.
 	Tier string
 	Tags map[string]string
+	// IdentityPresent is true when the PUT body carried an identity block. When
+	// false on an update, the stored identity is preserved untouched.
+	IdentityPresent bool
 	// IdentityType echoes the managed-identity block: "SystemAssigned",
 	// "UserAssigned", "None" or "".
 	IdentityType string
+	// UserAssignedIdentityIDs are the ARM resource IDs submitted under
+	// identity.userAssignedIdentities; the mock synthesizes a principal/client
+	// pair for each. Only meaningful when IdentityType includes "UserAssigned".
+	UserAssignedIdentityIDs []string
 	// EnableRBAC mirrors properties.enableRBAC. Nil means "not submitted", which
 	// the mock resolves to the AKS default (true).
 	EnableRBAC *bool
@@ -330,8 +369,11 @@ type ClusterInput struct {
 
 // AgentPoolInput captures the mutable fields of an AgentPool CreateOrUpdate.
 type AgentPoolInput struct {
-	Name             string
-	Count            int32
+	Name string
+	// Count is a pointer so an explicit count of 0 (scale-to-zero on a user
+	// pool) is distinguishable from an omitted count. Nil means "not submitted"
+	// and the mock applies the standard default node count.
+	Count            *int32
 	VMSize           string
 	OSDiskSizeGB     int32
 	OSType           string
@@ -343,6 +385,11 @@ type AgentPoolInput struct {
 	// MaxPods is the submitted max-pods-per-node; 0 means "not submitted" and
 	// the mock applies the standard default.
 	MaxPods int32
+	// OSDiskType (Managed / Ephemeral) and Type (VirtualMachineScaleSets /
+	// AvailabilitySet) round-trip when submitted; the mock applies the standard
+	// default only when the field is empty.
+	OSDiskType string
+	Type       string
 	// Advanced pool fields (autoscaler bounds, availability zones, subnet, OS
 	// SKU, public-IP flag) echoed verbatim; nil/empty when omitted.
 	AvailabilityZones  []string
@@ -352,6 +399,17 @@ type AgentPoolInput struct {
 	VnetSubnetID       string
 	OSSKU              string
 	EnableNodePublicIP *bool
+	// Additional default_node_pool fields echoed verbatim; nil/empty when
+	// omitted so a read round-trips exactly what was submitted.
+	UpgradeSettings        *AgentPoolUpgradeSettings
+	Tags                   map[string]string
+	EnableFIPS             *bool
+	SpotMaxPrice           *float32
+	ScaleSetEvictionPolicy string
+	NodePublicIPPrefixID   string
+	KubeletDiskType        string
+	KubeletConfig          map[string]any
+	LinuxOSConfig          map[string]any
 }
 
 // CreateOrUpdateCluster creates a new managed cluster or updates an existing
@@ -382,22 +440,13 @@ func (m *Mock) CreateOrUpdateCluster(_ context.Context, input ClusterInput) (*Ma
 		}
 	}
 
-	cluster.Location = input.Location
-	cluster.KubernetesVersion = defaultIfEmpty(input.KubernetesVersion, defaultK8sVersion)
-	cluster.DNSPrefix = defaultIfEmpty(input.DNSPrefix, input.Name+"-dns")
-	cluster.NodeResourceGroup = defaultIfEmpty(input.NodeResourceGroup, "MC_"+input.ResourceGroup+"_"+input.Name+"_"+input.Location)
-	cluster.FQDN = cluster.DNSPrefix + ".hcp." + defaultIfEmpty(input.Location, "eastus") + ".azmk8s.io"
-	cluster.ProvisioningState = "Succeeded"
-	cluster.PowerState = "Running"
-	cluster.Tier = defaultIfEmpty(input.Tier, "Free")
-	cluster.Tags = copyTags(input.Tags)
-	cluster.EnableRBAC = input.EnableRBAC == nil || *input.EnableRBAC
-	applyClusterIdentity(&cluster, input.IdentityType)
-	applyNetworkProfile(&cluster, input.NetworkProfile)
+	resolveClusterFields(&cluster, input, existing)
 	cluster.UpdatedAt = now
 
-	// Inline pools — replace what we have for this cluster.
-	cluster.AgentPoolNames = m.replaceInlinePools(input, cluster.KubernetesVersion, now)
+	// Reconcile inline pools by NAME — never wipe. A PUT that omits
+	// agentPoolProfiles leaves every existing pool (including standalone-API
+	// pools) untouched; a PUT that includes them upserts those pools.
+	cluster.AgentPoolNames = m.reconcileInlinePools(input, cluster.KubernetesVersion, now)
 
 	// Wave 2: if a Kubernetes data-plane server is wired and this is a fresh
 	// cluster, register a ClusterState and remember the UID so Kubeconfig can
@@ -420,12 +469,74 @@ func (m *Mock) CreateOrUpdateCluster(_ context.Context, input ClusterInput) (*Ma
 	return &out, nil
 }
 
+// resolveClusterFields merges the submitted input onto cluster. On a create,
+// unset fields resolve to the AKS defaults; on an update, a field the request
+// omits is preserved from the stored value — so a tags-only or version-only PUT
+// never resets networkProfile, identity, dnsPrefix, or the node pools.
+//
+//nolint:gocritic // input is a value-type mirror of the public CreateOrUpdate body.
+func resolveClusterFields(cluster *ManagedCluster, input ClusterInput, existing bool) {
+	cluster.Location = mergeStr(cluster.Location, input.Location, "", existing)
+	cluster.ProvisioningState = "Succeeded"
+	cluster.PowerState = "Running"
+	cluster.Tier = mergeStr(cluster.Tier, input.Tier, "Free", existing)
+	cluster.KubernetesVersion = mergeStr(cluster.KubernetesVersion, input.KubernetesVersion, defaultK8sVersion, existing)
+	cluster.DNSPrefix = mergeStr(cluster.DNSPrefix, input.DNSPrefix, input.Name+"-dns", existing)
+	cluster.NodeResourceGroup = mergeStr(cluster.NodeResourceGroup, input.NodeResourceGroup,
+		"MC_"+input.ResourceGroup+"_"+input.Name+"_"+cluster.Location, existing)
+
+	if input.Tags != nil || !existing {
+		cluster.Tags = copyTags(input.Tags)
+	}
+
+	if input.EnableRBAC != nil || !existing {
+		cluster.EnableRBAC = input.EnableRBAC == nil || *input.EnableRBAC
+	}
+
+	if input.NetworkProfile != nil || !existing {
+		applyNetworkProfile(cluster, input.NetworkProfile)
+	}
+
+	resolveClusterIdentity(cluster, input, existing)
+
+	cluster.FQDN = cluster.DNSPrefix + ".hcp." + defaultIfEmpty(cluster.Location, "eastus") + ".azmk8s.io"
+}
+
+// mergeStr resolves a string field: the submitted value wins when non-empty;
+// otherwise the stored value is preserved on an update, or def applied on a
+// create.
+func mergeStr(cur, in, def string, existing bool) string {
+	if in != "" {
+		return in
+	}
+
+	if existing {
+		return cur
+	}
+
+	return def
+}
+
+// resolveClusterIdentity applies the submitted identity block, or preserves the
+// stored identity when the update omitted identity entirely.
+//
+//nolint:gocritic // input is a value-type mirror of the public CreateOrUpdate body.
+func resolveClusterIdentity(cluster *ManagedCluster, input ClusterInput, existing bool) {
+	if existing && !input.IdentityPresent {
+		return
+	}
+
+	applyClusterIdentity(cluster, input.IdentityType, input.UserAssignedIdentityIDs)
+}
+
 // applyClusterIdentity echoes the submitted managed-identity block, generating
-// a deterministic principal/tenant pair for a system-assigned identity.
-func applyClusterIdentity(cluster *ManagedCluster, identityType string) {
+// a deterministic principal/tenant pair for a system-assigned identity and a
+// synthesized principal/client pair for each user-assigned identity.
+func applyClusterIdentity(cluster *ManagedCluster, identityType string, userAssignedIDs []string) {
 	cluster.IdentityType = identityType
 	cluster.PrincipalID = ""
 	cluster.TenantID = ""
+	cluster.UserAssignedIdentities = nil
 
 	if identityType == "" || identityType == "None" {
 		return
@@ -436,6 +547,28 @@ func applyClusterIdentity(cluster *ManagedCluster, identityType string) {
 			"principal/cluster/" + cluster.ResourceGroup + "/" + cluster.Name)
 		cluster.TenantID = emulatorTenantID
 	}
+
+	if strings.Contains(identityType, "UserAssigned") {
+		cluster.UserAssignedIdentities = synthesizeUserAssigned(userAssignedIDs)
+	}
+}
+
+// synthesizeUserAssigned builds a deterministic principal/client pair for each
+// submitted user-assigned identity ARM resource ID.
+func synthesizeUserAssigned(ids []string) map[string]UserAssignedIdentity {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	out := make(map[string]UserAssignedIdentity, len(ids))
+	for _, id := range ids {
+		out[id] = UserAssignedIdentity{
+			PrincipalID: idgen.SyntheticGUID("principal/uami/" + id),
+			ClientID:    idgen.SyntheticGUID("client/uami/" + id),
+		}
+	}
+
+	return out
 }
 
 // applyNetworkProfile stores the submitted network profile verbatim, or the
@@ -449,38 +582,52 @@ func applyNetworkProfile(cluster *ManagedCluster, np *NetworkProfile) {
 	cluster.NetworkProfile = *np
 }
 
-// replaceInlinePools wipes any pre-existing pools for the cluster and re-adds
-// each input pool. Caller must hold m.mu (write). clusterVersion is inherited
-// by inline pools that omit their own orchestratorVersion.
+// reconcileInlinePools upserts the pools carried in the cluster PUT body by
+// NAME and never wipes pools absent from the body — those may be standalone
+// agentPools-API pools (azurerm_kubernetes_cluster_node_pool), which real AKS
+// leaves intact across a cluster PUT. A PUT that omits agentPoolProfiles leaves
+// every existing pool untouched. Caller must hold m.mu (write). clusterVersion
+// is inherited by inline pools that omit their own orchestratorVersion.
 //
 //nolint:gocritic // input is a value-type mirror of the public CreateOrUpdate body.
-func (m *Mock) replaceInlinePools(input ClusterInput, clusterVersion string, now time.Time) []string {
-	// Drop existing pools for this cluster.
-	prefix := input.ResourceGroup + "/" + input.Name + "/"
+func (m *Mock) reconcileInlinePools(input ClusterInput, clusterVersion string, now time.Time) []string {
+	//nolint:gocritic // pool is a value mirror of the SDK input; copy is intentional.
+	for _, pool := range input.AgentPools {
+		key := poolKey(input.ResourceGroup, input.Name, pool.Name)
+		ap := buildAgentPool(input.ResourceGroup, input.Name, clusterVersion, pool, now)
+
+		if prev, ok := m.pools.Get(key); ok {
+			ap.CreatedAt = prev.CreatedAt
+		}
+
+		m.pools.Set(key, ap)
+	}
+
+	return m.poolNamesForCluster(input.ResourceGroup, input.Name)
+}
+
+// poolNamesForCluster returns the sorted names of every pool currently attached
+// to the cluster. Caller must hold m.mu.
+func (m *Mock) poolNamesForCluster(rg, cluster string) []string {
+	prefix := rg + "/" + cluster + "/"
+	names := make([]string, 0)
 
 	for _, k := range m.pools.Keys() {
-		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
-			m.pools.Delete(k)
+		if strings.HasPrefix(k, prefix) {
+			names = append(names, k[len(prefix):])
 		}
 	}
 
-	names := make([]string, 0, len(input.AgentPools))
-
-	//nolint:gocritic // pool is a value mirror of the SDK input; copy is intentional.
-	for _, pool := range input.AgentPools {
-		ap := buildAgentPool(input.ResourceGroup, input.Name, clusterVersion, pool, now)
-		m.pools.Set(poolKey(input.ResourceGroup, input.Name, pool.Name), ap)
-		names = append(names, pool.Name)
-	}
+	sort.Strings(names)
 
 	return names
 }
 
 //nolint:gocritic // in is a value mirror of the SDK AgentPool body; pointer would invite caller mutation.
 func buildAgentPool(rg, cluster, clusterVersion string, in AgentPoolInput, now time.Time) AgentPool {
-	count := in.Count
-	if count <= 0 {
-		count = defaultNodeCount
+	count := int32(defaultNodeCount)
+	if in.Count != nil {
+		count = *in.Count
 	}
 
 	disk := in.OSDiskSizeGB
@@ -494,33 +641,42 @@ func buildAgentPool(rg, cluster, clusterVersion string, in AgentPoolInput, now t
 	}
 
 	return AgentPool{
-		Name:               in.Name,
-		ClusterName:        cluster,
-		ResourceGroup:      rg,
-		Count:              count,
-		VMSize:             defaultIfEmpty(in.VMSize, defaultVMSize),
-		OSDiskSizeGB:       disk,
-		OSType:             defaultIfEmpty(in.OSType, "Linux"),
-		Mode:               defaultIfEmpty(in.Mode, "User"),
-		OrchestratorVer:    defaultIfEmpty(in.OrchestratorVer, defaultIfEmpty(clusterVersion, defaultK8sVersion)),
-		ProvisioningState:  "Succeeded",
-		ScaleSetPriority:   defaultIfEmpty(in.ScaleSetPriority, "Regular"),
-		NodeLabels:         copyLabels(in.NodeLabels),
-		NodeTaints:         copyTaints(in.NodeTaints),
-		MaxPods:            maxPods,
-		OSDiskType:         defaultOSDiskType,
-		Type:               defaultPoolType,
-		PowerState:         poolPowerRunning,
-		NodeImageVersion:   defaultNodeImage,
-		AvailabilityZones:  copyTaints(in.AvailabilityZones),
-		EnableAutoScaling:  copyBoolPtr(in.EnableAutoScaling),
-		MinCount:           copyInt32Ptr(in.MinCount),
-		MaxCount:           copyInt32Ptr(in.MaxCount),
-		VnetSubnetID:       in.VnetSubnetID,
-		OSSKU:              in.OSSKU,
-		EnableNodePublicIP: copyBoolPtr(in.EnableNodePublicIP),
-		CreatedAt:          now,
-		UpdatedAt:          now,
+		Name:                   in.Name,
+		ClusterName:            cluster,
+		ResourceGroup:          rg,
+		Count:                  count,
+		VMSize:                 defaultIfEmpty(in.VMSize, defaultVMSize),
+		OSDiskSizeGB:           disk,
+		OSType:                 defaultIfEmpty(in.OSType, "Linux"),
+		Mode:                   defaultIfEmpty(in.Mode, "User"),
+		OrchestratorVer:        defaultIfEmpty(in.OrchestratorVer, defaultIfEmpty(clusterVersion, defaultK8sVersion)),
+		ProvisioningState:      "Succeeded",
+		ScaleSetPriority:       defaultIfEmpty(in.ScaleSetPriority, "Regular"),
+		NodeLabels:             copyLabels(in.NodeLabels),
+		NodeTaints:             copyTaints(in.NodeTaints),
+		MaxPods:                maxPods,
+		OSDiskType:             defaultIfEmpty(in.OSDiskType, defaultOSDiskType),
+		Type:                   defaultIfEmpty(in.Type, defaultPoolType),
+		PowerState:             poolPowerRunning,
+		NodeImageVersion:       defaultNodeImage,
+		AvailabilityZones:      copyTaints(in.AvailabilityZones),
+		EnableAutoScaling:      copyBoolPtr(in.EnableAutoScaling),
+		MinCount:               copyInt32Ptr(in.MinCount),
+		MaxCount:               copyInt32Ptr(in.MaxCount),
+		VnetSubnetID:           in.VnetSubnetID,
+		OSSKU:                  in.OSSKU,
+		EnableNodePublicIP:     copyBoolPtr(in.EnableNodePublicIP),
+		UpgradeSettings:        copyUpgradeSettings(in.UpgradeSettings),
+		Tags:                   copyTags(in.Tags),
+		EnableFIPS:             copyBoolPtr(in.EnableFIPS),
+		SpotMaxPrice:           copyFloat32Ptr(in.SpotMaxPrice),
+		ScaleSetEvictionPolicy: in.ScaleSetEvictionPolicy,
+		NodePublicIPPrefixID:   in.NodePublicIPPrefixID,
+		KubeletDiskType:        in.KubeletDiskType,
+		KubeletConfig:          copyAnyMap(in.KubeletConfig),
+		LinuxOSConfig:          copyAnyMap(in.LinuxOSConfig),
+		CreatedAt:              now,
+		UpdatedAt:              now,
 	}
 }
 
@@ -544,13 +700,50 @@ func copyInt32Ptr(p *int32) *int32 {
 	return &v
 }
 
+func copyFloat32Ptr(p *float32) *float32 {
+	if p == nil {
+		return nil
+	}
+
+	v := *p
+
+	return &v
+}
+
+func copyAnyMap(src map[string]any) map[string]any {
+	if src == nil {
+		return nil
+	}
+
+	out := make(map[string]any, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+
+	return out
+}
+
+func copyUpgradeSettings(s *AgentPoolUpgradeSettings) *AgentPoolUpgradeSettings {
+	if s == nil {
+		return nil
+	}
+
+	out := AgentPoolUpgradeSettings{
+		MaxSurge:                  s.MaxSurge,
+		DrainTimeoutInMinutes:     copyInt32Ptr(s.DrainTimeoutInMinutes),
+		NodeSoakDurationInMinutes: copyInt32Ptr(s.NodeSoakDurationInMinutes),
+	}
+
+	return &out
+}
+
 func totalNodeCount(pools []AgentPoolInput) int32 {
 	var total int32
 
 	for i := range pools {
-		c := pools[i].Count
-		if c <= 0 {
-			c = defaultNodeCount
+		c := int32(defaultNodeCount)
+		if pools[i].Count != nil {
+			c = *pools[i].Count
 		}
 
 		total += c

--- a/providers/azure/aks/aks_test.go
+++ b/providers/azure/aks/aks_test.go
@@ -30,7 +30,7 @@ func TestClusterLifecycle(t *testing.T) {
 		Location:          "eastus",
 		KubernetesVersion: "1.29.5",
 		AgentPools: []AgentPoolInput{
-			{Name: "system", Count: 2, VMSize: "Standard_D2s_v3", Mode: "System"},
+			{Name: "system", Count: int32Ptr(2), VMSize: "Standard_D2s_v3", Mode: "System"},
 		},
 	})
 	requireNoError(t, err)
@@ -91,7 +91,7 @@ func TestAgentPoolLifecycle(t *testing.T) {
 
 	pool, err := m.CreateOrUpdateAgentPool(ctx, "rg-1", "k8s-1", AgentPoolInput{
 		Name:   "userpool",
-		Count:  4,
+		Count:  int32Ptr(4),
 		VMSize: "Standard_D4s_v3",
 		Mode:   "User",
 	})
@@ -102,7 +102,7 @@ func TestAgentPoolLifecycle(t *testing.T) {
 	// Update pool — count change.
 	pool, err = m.CreateOrUpdateAgentPool(ctx, "rg-1", "k8s-1", AgentPoolInput{
 		Name:  "userpool",
-		Count: 6,
+		Count: int32Ptr(6),
 	})
 	requireNoError(t, err)
 	assertEqual(t, int32(6), pool.Count)
@@ -171,7 +171,7 @@ func TestDeleteClusterCascades(t *testing.T) {
 		ResourceGroup: "rg-1",
 		Name:          "k8s-1",
 		AgentPools: []AgentPoolInput{
-			{Name: "system", Count: 2},
+			{Name: "system", Count: int32Ptr(2)},
 		},
 	})
 	requireNoError(t, err)
@@ -260,4 +260,8 @@ func assertNotEmpty(t *testing.T, s string) {
 	if s == "" {
 		t.Error("expected non-empty string")
 	}
+}
+
+func int32Ptr(v int32) *int32 {
+	return &v
 }

--- a/providers/azure/kubernetes_discovery_test.go
+++ b/providers/azure/kubernetes_discovery_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+
 	"github.com/stackshy/cloudemu/v2/providers/azure/aks"
 	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
 )
@@ -23,7 +25,7 @@ func TestResourceDiscoverySurfacesAKS(t *testing.T) {
 	}
 
 	if _, err := p.AKS.CreateOrUpdateAgentPool(ctx, "rg-1", "prod", aks.AgentPoolInput{
-		Name: "ap-1", Count: 1,
+		Name: "ap-1", Count: to.Ptr[int32](1),
 	}); err != nil {
 		t.Fatalf("CreateOrUpdateAgentPool: %v", err)
 	}

--- a/server/azure/aks/operations.go
+++ b/server/azure/aks/operations.go
@@ -41,7 +41,9 @@ func buildClusterInput(body *armManagedCluster, rp *azurearm.ResourcePath) aks.C
 	}
 
 	if body.Identity != nil {
+		in.IdentityPresent = true
 		in.IdentityType = body.Identity.Type
+		in.UserAssignedIdentityIDs = identityIDs(body.Identity.UserAssignedIdentities)
 	}
 
 	if body.Properties != nil {
@@ -54,6 +56,22 @@ func buildClusterInput(body *armManagedCluster, rp *azurearm.ResourcePath) aks.C
 	}
 
 	return in
+}
+
+// identityIDs returns the ARM resource IDs (map keys) of the submitted
+// user-assigned identities, so the backend can synthesize a principal/client
+// pair for each. The submitted values are read-only and ignored.
+func identityIDs(in map[string]*armUserAssignedValue) []string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	ids := make([]string, 0, len(in))
+	for id := range in {
+		ids = append(ids, id)
+	}
+
+	return ids
 }
 
 // networkProfileInput maps the submitted ARM networkProfile onto the driver
@@ -100,6 +118,8 @@ func inlineAgentPoolInputs(profiles []armAgentPoolProfile) []aks.AgentPoolInput 
 			NodeLabels:       fromPtrTags(p.NodeLabels),
 			NodeTaints:       p.NodeTaints,
 			MaxPods:          p.MaxPods,
+			OSDiskType:       p.OSDiskType,
+			Type:             p.Type,
 		}
 		p.armAgentPoolAdvanced.applyTo(&in)
 		out = append(out, in)
@@ -201,6 +221,8 @@ func (h *Handler) createOrUpdateAgentPool(w http.ResponseWriter, r *http.Request
 		in.NodeLabels = fromPtrTags(body.Properties.NodeLabels)
 		in.NodeTaints = body.Properties.NodeTaints
 		in.MaxPods = body.Properties.MaxPods
+		in.OSDiskType = body.Properties.OSDiskType
+		in.Type = body.Properties.Type
 		body.Properties.armAgentPoolAdvanced.applyTo(&in)
 	}
 

--- a/server/azure/aks/sdk_identity_test.go
+++ b/server/azure/aks/sdk_identity_test.go
@@ -1,0 +1,58 @@
+package aks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
+)
+
+// TestSDKAKSUserAssignedIdentityRoundTrips asserts a UserAssigned identity is
+// echoed on GET with the submitted identity ARM ID and a synthesized
+// principalId/clientId per identity. The top-level identity block is not
+// covered by the property overlay, so the wire model must carry it.
+func TestSDKAKSUserAssignedIdentityRoundTrips(t *testing.T) {
+	clusters, _, _ := newSDKClients(t)
+
+	const uamiID = "/subscriptions/sub-1/resourceGroups/rg-1/providers/" +
+		"Microsoft.ManagedIdentity/userAssignedIdentities/my-identity"
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+		Identity: &armcontainerservice.ManagedClusterIdentity{
+			Type: to.Ptr(armcontainerservice.ResourceIdentityTypeUserAssigned),
+			UserAssignedIdentities: map[string]*armcontainerservice.ManagedServiceIdentityUserAssignedIdentitiesValue{
+				uamiID: {},
+			},
+		},
+	})
+
+	got, err := clusters.Get(context.Background(), "rg-1", "k8s-1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Identity == nil || got.Identity.Type == nil ||
+		*got.Identity.Type != armcontainerservice.ResourceIdentityTypeUserAssigned {
+		t.Fatalf("identity type: got %+v, want UserAssigned", got.Identity)
+	}
+
+	uai := got.Identity.UserAssignedIdentities
+	if len(uai) != 1 {
+		t.Fatalf("userAssignedIdentities: got %d, want 1", len(uai))
+	}
+
+	val, ok := uai[uamiID]
+	if !ok || val == nil {
+		t.Fatalf("expected identity %q echoed, got %v", uamiID, uai)
+	}
+
+	if val.PrincipalID == nil || *val.PrincipalID == "" {
+		t.Fatal("expected synthesized principalId on user-assigned identity")
+	}
+
+	if val.ClientID == nil || *val.ClientID == "" {
+		t.Fatal("expected synthesized clientId on user-assigned identity")
+	}
+}

--- a/server/azure/aks/sdk_pool_reconcile_test.go
+++ b/server/azure/aks/sdk_pool_reconcile_test.go
@@ -1,0 +1,153 @@
+package aks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
+)
+
+// TestSDKAKSClusterPUTPreservesStandalonePool is the critical data-loss guard:
+// a cluster PUT that omits agentPoolProfiles must NOT wipe pools created via the
+// standalone agentPools API, and must preserve networkProfile + identity. The
+// old replaceInlinePools wiped every pool under the cluster, dropping the
+// standalone user pool and resetting the cluster to zero pools.
+func TestSDKAKSClusterPUTPreservesStandalonePool(t *testing.T) {
+	clusters, pools, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+		Identity: &armcontainerservice.ManagedClusterIdentity{
+			Type: to.Ptr(armcontainerservice.ResourceIdentityTypeSystemAssigned),
+		},
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			KubernetesVersion: to.Ptr("1.29.0"),
+			NetworkProfile: &armcontainerservice.NetworkProfile{
+				NetworkPlugin: to.Ptr(armcontainerservice.NetworkPluginAzure),
+				ServiceCidr:   to.Ptr("10.50.0.0/16"),
+			},
+			AgentPoolProfiles: []*armcontainerservice.ManagedClusterAgentPoolProfile{
+				{
+					Name:   to.Ptr("system"),
+					Count:  to.Ptr[int32](1),
+					VMSize: to.Ptr("Standard_DS2_v2"),
+					Mode:   to.Ptr(armcontainerservice.AgentPoolModeSystem),
+				},
+			},
+		},
+	})
+
+	// Add a standalone user pool (azurerm_kubernetes_cluster_node_pool).
+	poolPoller, err := pools.BeginCreateOrUpdate(ctx, "rg-1", "k8s-1", "userpool", armcontainerservice.AgentPool{
+		Properties: &armcontainerservice.ManagedClusterAgentPoolProfileProperties{
+			Count:  to.Ptr[int32](2),
+			VMSize: to.Ptr("Standard_D4s_v3"),
+			Mode:   to.Ptr(armcontainerservice.AgentPoolModeUser),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("pool BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poolPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("pool PollUntilDone: %v", err)
+	}
+
+	// PUT the cluster bumping ONLY kubernetesVersion — no agentPoolProfiles, no
+	// networkProfile, no identity. This is the version-only full PUT that used
+	// to wipe every pool.
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			KubernetesVersion: to.Ptr("1.30.0"),
+		},
+	})
+
+	pager := pools.NewListPager("rg-1", "k8s-1", nil)
+
+	page, err := pager.NextPage(ctx)
+	if err != nil {
+		t.Fatalf("pool List: %v", err)
+	}
+
+	if len(page.Value) != 2 {
+		t.Fatalf("got %d pools after cluster PUT, want 2 (data-loss regression)", len(page.Value))
+	}
+
+	assertVersionAndNetworkPreserved(t, getClusterProps(t, clusters))
+	assertIdentityPreserved(t, clusters)
+}
+
+func assertVersionAndNetworkPreserved(t *testing.T, props *armcontainerservice.ManagedClusterProperties) {
+	t.Helper()
+
+	if props.KubernetesVersion == nil || *props.KubernetesVersion != "1.30.0" {
+		t.Fatalf("kubernetesVersion: got %v, want 1.30.0", props.KubernetesVersion)
+	}
+
+	if props.NetworkProfile == nil || props.NetworkProfile.ServiceCidr == nil ||
+		*props.NetworkProfile.ServiceCidr != "10.50.0.0/16" {
+		t.Fatalf("networkProfile.serviceCidr not preserved: %+v", props.NetworkProfile)
+	}
+}
+
+func assertIdentityPreserved(t *testing.T, clusters *armcontainerservice.ManagedClustersClient) {
+	t.Helper()
+
+	got, err := clusters.Get(context.Background(), "rg-1", "k8s-1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Identity == nil || got.Identity.Type == nil ||
+		*got.Identity.Type != armcontainerservice.ResourceIdentityTypeSystemAssigned {
+		t.Fatalf("identity not preserved: %+v", got.Identity)
+	}
+
+	if got.Identity.PrincipalID == nil || *got.Identity.PrincipalID == "" {
+		t.Fatal("expected preserved system-assigned principalId")
+	}
+}
+
+// TestSDKAKSClusterPUTNilPropertiesPreservesFields asserts a cluster PUT that
+// omits the properties block entirely (a tags-only full PUT) preserves the
+// stored kubernetesVersion, dnsPrefix, and networkProfile instead of resetting
+// them to defaults.
+func TestSDKAKSClusterPUTNilPropertiesPreservesFields(t *testing.T) {
+	clusters, _, _ := newSDKClients(t)
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			KubernetesVersion: to.Ptr("1.29.3"),
+			DNSPrefix:         to.Ptr("custom-dns"),
+			NetworkProfile: &armcontainerservice.NetworkProfile{
+				NetworkPlugin: to.Ptr(armcontainerservice.NetworkPluginAzure),
+				ServiceCidr:   to.Ptr("10.77.0.0/16"),
+			},
+		},
+	})
+
+	// Full PUT carrying only tags — no properties block at all.
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"team": to.Ptr("infra")},
+	})
+
+	props := getClusterProps(t, clusters)
+
+	if props.KubernetesVersion == nil || *props.KubernetesVersion != "1.29.3" {
+		t.Fatalf("kubernetesVersion reset: got %v, want 1.29.3", props.KubernetesVersion)
+	}
+
+	if props.DNSPrefix == nil || *props.DNSPrefix != "custom-dns" {
+		t.Fatalf("dnsPrefix reset: got %v, want custom-dns", props.DNSPrefix)
+	}
+
+	if props.NetworkProfile == nil || props.NetworkProfile.ServiceCidr == nil ||
+		*props.NetworkProfile.ServiceCidr != "10.77.0.0/16" {
+		t.Fatalf("networkProfile reset: %+v", props.NetworkProfile)
+	}
+}

--- a/server/azure/aks/sdk_terraform_drift_test.go
+++ b/server/azure/aks/sdk_terraform_drift_test.go
@@ -205,6 +205,163 @@ func TestSDKAKSServicePrincipalSecretStripped(t *testing.T) {
 	}
 }
 
+// TestSDKAKSInlineOSDiskTypeEphemeralRoundTrips is BUG-2: an inline pool's
+// osDiskType=Ephemeral survives to GET instead of always reading "Managed".
+func TestSDKAKSInlineOSDiskTypeEphemeralRoundTrips(t *testing.T) {
+	clusters, _, _ := newSDKClients(t)
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			AgentPoolProfiles: []*armcontainerservice.ManagedClusterAgentPoolProfile{
+				{
+					Name:       to.Ptr("system"),
+					Count:      to.Ptr[int32](1),
+					VMSize:     to.Ptr("Standard_DS2_v2"),
+					Mode:       to.Ptr(armcontainerservice.AgentPoolModeSystem),
+					OSDiskType: to.Ptr(armcontainerservice.OSDiskTypeEphemeral),
+				},
+			},
+		},
+	})
+
+	pools := getClusterProps(t, clusters).AgentPoolProfiles
+	if len(pools) != 1 || pools[0].OSDiskType == nil ||
+		*pools[0].OSDiskType != armcontainerservice.OSDiskTypeEphemeral {
+		t.Fatalf("inline osDiskType not preserved: %+v", pools)
+	}
+}
+
+// TestSDKAKSStandaloneOSDiskTypeEphemeralRoundTrips is BUG-2 on the standalone
+// path: osDiskType=Ephemeral survives PUT→GET.
+func TestSDKAKSStandaloneOSDiskTypeEphemeralRoundTrips(t *testing.T) {
+	clusters, poolsClient, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{Location: to.Ptr("eastus")})
+
+	poller, err := poolsClient.BeginCreateOrUpdate(ctx, "rg-1", "k8s-1", "ephem", armcontainerservice.AgentPool{
+		Properties: &armcontainerservice.ManagedClusterAgentPoolProfileProperties{
+			Count:      to.Ptr[int32](1),
+			VMSize:     to.Ptr("Standard_DS2_v2"),
+			Mode:       to.Ptr(armcontainerservice.AgentPoolModeUser),
+			OSDiskType: to.Ptr(armcontainerservice.OSDiskTypeEphemeral),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("pool BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("pool PollUntilDone: %v", err)
+	}
+
+	got, err := poolsClient.Get(ctx, "rg-1", "k8s-1", "ephem", nil)
+	if err != nil {
+		t.Fatalf("pool Get: %v", err)
+	}
+
+	if got.Properties.OSDiskType == nil || *got.Properties.OSDiskType != armcontainerservice.OSDiskTypeEphemeral {
+		t.Fatalf("standalone osDiskType not preserved: %v", got.Properties.OSDiskType)
+	}
+}
+
+// TestSDKAKSOSDiskTypeDefaultsManaged asserts the default is still "Managed"
+// when a pool omits osDiskType.
+func TestSDKAKSOSDiskTypeDefaultsManaged(t *testing.T) {
+	clusters, _, _ := newSDKClients(t)
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			AgentPoolProfiles: []*armcontainerservice.ManagedClusterAgentPoolProfile{
+				{Name: to.Ptr("system"), Count: to.Ptr[int32](1), Mode: to.Ptr(armcontainerservice.AgentPoolModeSystem)},
+			},
+		},
+	})
+
+	pools := getClusterProps(t, clusters).AgentPoolProfiles
+	if len(pools) != 1 || pools[0].OSDiskType == nil ||
+		*pools[0].OSDiskType != armcontainerservice.OSDiskTypeManaged {
+		t.Fatalf("default osDiskType: got %+v, want Managed", pools)
+	}
+}
+
+// TestSDKAKSAgentPoolScaleToZero is BUG-3: an explicit count of 0 on a user
+// pool round-trips instead of being forced back to the default node count.
+func TestSDKAKSAgentPoolScaleToZero(t *testing.T) {
+	clusters, poolsClient, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{Location: to.Ptr("eastus")})
+
+	poller, err := poolsClient.BeginCreateOrUpdate(ctx, "rg-1", "k8s-1", "zero", armcontainerservice.AgentPool{
+		Properties: &armcontainerservice.ManagedClusterAgentPoolProfileProperties{
+			Count:  to.Ptr[int32](0),
+			VMSize: to.Ptr("Standard_DS2_v2"),
+			Mode:   to.Ptr(armcontainerservice.AgentPoolModeUser),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("pool BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("pool PollUntilDone: %v", err)
+	}
+
+	got, err := poolsClient.Get(ctx, "rg-1", "k8s-1", "zero", nil)
+	if err != nil {
+		t.Fatalf("pool Get: %v", err)
+	}
+
+	if got.Properties.Count == nil || *got.Properties.Count != 0 {
+		t.Fatalf("count: got %v, want 0 (scale-to-zero)", got.Properties.Count)
+	}
+}
+
+// TestSDKAKSInlineUpgradeSettingsAndTagsRoundTrip is BUG-5: default_node_pool
+// fields submitted inline (upgradeSettings.maxSurge, pool tags, enableFIPS)
+// survive to GET the same as on a standalone pool.
+func TestSDKAKSInlineUpgradeSettingsAndTagsRoundTrip(t *testing.T) {
+	clusters, _, _ := newSDKClients(t)
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			AgentPoolProfiles: []*armcontainerservice.ManagedClusterAgentPoolProfile{
+				{
+					Name:            to.Ptr("system"),
+					Count:           to.Ptr[int32](1),
+					VMSize:          to.Ptr("Standard_DS2_v2"),
+					Mode:            to.Ptr(armcontainerservice.AgentPoolModeSystem),
+					UpgradeSettings: &armcontainerservice.AgentPoolUpgradeSettings{MaxSurge: to.Ptr("33%")},
+					Tags:            map[string]*string{"pool": to.Ptr("system")},
+					EnableFIPS:      to.Ptr(true),
+				},
+			},
+		},
+	})
+
+	pools := getClusterProps(t, clusters).AgentPoolProfiles
+	if len(pools) != 1 {
+		t.Fatalf("got %d pools, want 1", len(pools))
+	}
+
+	p := pools[0]
+	if p.UpgradeSettings == nil || p.UpgradeSettings.MaxSurge == nil || *p.UpgradeSettings.MaxSurge != "33%" {
+		t.Fatalf("upgradeSettings.maxSurge not preserved: %+v", p.UpgradeSettings)
+	}
+
+	if v := p.Tags["pool"]; v == nil || *v != "system" {
+		t.Fatalf("pool tags not preserved: %+v", p.Tags)
+	}
+
+	if p.EnableFIPS == nil || !*p.EnableFIPS {
+		t.Fatalf("enableFIPS not preserved: %v", p.EnableFIPS)
+	}
+}
+
 // assertAdvancedProfile checks the inline-profile advanced fields.
 func assertAdvancedProfile(t *testing.T, p *armcontainerservice.ManagedClusterAgentPoolProfile) {
 	t.Helper()

--- a/server/azure/aks/types.go
+++ b/server/azure/aks/types.go
@@ -29,9 +29,17 @@ type armManagedCluster struct {
 
 // armManagedClusterIdentity mirrors armcontainerservice.ManagedClusterIdentity.
 type armManagedClusterIdentity struct {
-	Type        string `json:"type,omitempty"`
+	Type                   string                           `json:"type,omitempty"`
+	PrincipalID            string                           `json:"principalId,omitempty"`
+	TenantID               string                           `json:"tenantId,omitempty"`
+	UserAssignedIdentities map[string]*armUserAssignedValue `json:"userAssignedIdentities,omitempty"`
+}
+
+// armUserAssignedValue mirrors
+// armcontainerservice.ManagedServiceIdentityUserAssignedIdentitiesValue.
+type armUserAssignedValue struct {
 	PrincipalID string `json:"principalId,omitempty"`
-	TenantID    string `json:"tenantId,omitempty"`
+	ClientID    string `json:"clientId,omitempty"`
 }
 
 // armManagedClusterSKU mirrors armcontainerservice.ManagedClusterSKU. The tier
@@ -72,7 +80,7 @@ type armNetworkProfile struct {
 
 type armAgentPoolProfile struct {
 	Name              string             `json:"name,omitempty"`
-	Count             int32              `json:"count,omitempty"`
+	Count             *int32             `json:"count,omitempty"`
 	VMSize            string             `json:"vmSize,omitempty"`
 	OSDiskSizeGB      int32              `json:"osDiskSizeGB,omitempty"`
 	OSType            string             `json:"osType,omitempty"`
@@ -104,6 +112,25 @@ type armAgentPoolAdvanced struct {
 	VnetSubnetID       string   `json:"vnetSubnetID,omitempty"`
 	OSSKU              string   `json:"osSKU,omitempty"`
 	EnableNodePublicIP *bool    `json:"enableNodePublicIP,omitempty"`
+	// Further default_node_pool fields modeled so an inline submission
+	// round-trips the same as a standalone pool.
+	UpgradeSettings        *armAgentPoolUpgradeSettings `json:"upgradeSettings,omitempty"`
+	Tags                   map[string]*string           `json:"tags,omitempty"`
+	EnableFIPS             *bool                        `json:"enableFIPS,omitempty"`
+	SpotMaxPrice           *float32                     `json:"spotMaxPrice,omitempty"`
+	ScaleSetEvictionPolicy string                       `json:"scaleSetEvictionPolicy,omitempty"`
+	NodePublicIPPrefixID   string                       `json:"nodePublicIPPrefixID,omitempty"`
+	KubeletDiskType        string                       `json:"kubeletDiskType,omitempty"`
+	KubeletConfig          map[string]any               `json:"kubeletConfig,omitempty"`
+	LinuxOSConfig          map[string]any               `json:"linuxOSConfig,omitempty"`
+}
+
+// armAgentPoolUpgradeSettings mirrors the subset of
+// armcontainerservice.AgentPoolUpgradeSettings the emulator round-trips.
+type armAgentPoolUpgradeSettings struct {
+	MaxSurge                  string `json:"maxSurge,omitempty"`
+	DrainTimeoutInMinutes     *int32 `json:"drainTimeoutInMinutes,omitempty"`
+	NodeSoakDurationInMinutes *int32 `json:"nodeSoakDurationInMinutes,omitempty"`
 }
 
 // applyTo copies the submitted advanced fields onto a driver AgentPoolInput.
@@ -117,6 +144,28 @@ func (a *armAgentPoolAdvanced) applyTo(in *aks.AgentPoolInput) {
 	in.VnetSubnetID = a.VnetSubnetID
 	in.OSSKU = a.OSSKU
 	in.EnableNodePublicIP = a.EnableNodePublicIP
+	in.Tags = fromPtrTags(a.Tags)
+	in.EnableFIPS = a.EnableFIPS
+	in.SpotMaxPrice = a.SpotMaxPrice
+	in.ScaleSetEvictionPolicy = a.ScaleSetEvictionPolicy
+	in.NodePublicIPPrefixID = a.NodePublicIPPrefixID
+	in.KubeletDiskType = a.KubeletDiskType
+	in.KubeletConfig = a.KubeletConfig
+	in.LinuxOSConfig = a.LinuxOSConfig
+	in.UpgradeSettings = a.upgradeSettingsInput()
+}
+
+// upgradeSettingsInput maps the submitted upgradeSettings onto the driver type.
+func (a *armAgentPoolAdvanced) upgradeSettingsInput() *aks.AgentPoolUpgradeSettings {
+	if a.UpgradeSettings == nil {
+		return nil
+	}
+
+	return &aks.AgentPoolUpgradeSettings{
+		MaxSurge:                  a.UpgradeSettings.MaxSurge,
+		DrainTimeoutInMinutes:     a.UpgradeSettings.DrainTimeoutInMinutes,
+		NodeSoakDurationInMinutes: a.UpgradeSettings.NodeSoakDurationInMinutes,
+	}
 }
 
 // armAgentPool is the standalone (sub-resource) shape used by the
@@ -130,7 +179,7 @@ type armAgentPool struct {
 }
 
 type armAgentPoolProperties struct {
-	Count             int32              `json:"count,omitempty"`
+	Count             *int32             `json:"count,omitempty"`
 	VMSize            string             `json:"vmSize,omitempty"`
 	OSDiskSizeGB      int32              `json:"osDiskSizeGB,omitempty"`
 	OSType            string             `json:"osType,omitempty"`
@@ -207,10 +256,26 @@ func toARMCluster(c *aks.ManagedCluster, pools []aks.AgentPool, subscription str
 
 	if c.IdentityType != "" && c.IdentityType != "None" {
 		out.Identity = &armManagedClusterIdentity{
-			Type:        c.IdentityType,
-			PrincipalID: c.PrincipalID,
-			TenantID:    c.TenantID,
+			Type:                   c.IdentityType,
+			PrincipalID:            c.PrincipalID,
+			TenantID:               c.TenantID,
+			UserAssignedIdentities: toUserAssignedIdentities(c.UserAssignedIdentities),
 		}
+	}
+
+	return out
+}
+
+// toUserAssignedIdentities renders the stored user-assigned identity map onto
+// the ARM identity shape.
+func toUserAssignedIdentities(in map[string]aks.UserAssignedIdentity) map[string]*armUserAssignedValue {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]*armUserAssignedValue, len(in))
+	for id, v := range in {
+		out[id] = &armUserAssignedValue{PrincipalID: v.PrincipalID, ClientID: v.ClientID}
 	}
 
 	return out
@@ -237,13 +302,35 @@ func toNetworkProfile(np *aks.NetworkProfile) *armNetworkProfile {
 // embedded ARM shape used by both the inline and standalone pool responses.
 func toAgentPoolAdvanced(p *aks.AgentPool) armAgentPoolAdvanced {
 	return armAgentPoolAdvanced{
-		AvailabilityZones:  p.AvailabilityZones,
-		EnableAutoScaling:  p.EnableAutoScaling,
-		MinCount:           p.MinCount,
-		MaxCount:           p.MaxCount,
-		VnetSubnetID:       p.VnetSubnetID,
-		OSSKU:              p.OSSKU,
-		EnableNodePublicIP: p.EnableNodePublicIP,
+		AvailabilityZones:      p.AvailabilityZones,
+		EnableAutoScaling:      p.EnableAutoScaling,
+		MinCount:               p.MinCount,
+		MaxCount:               p.MaxCount,
+		VnetSubnetID:           p.VnetSubnetID,
+		OSSKU:                  p.OSSKU,
+		EnableNodePublicIP:     p.EnableNodePublicIP,
+		Tags:                   toPtrTags(p.Tags),
+		EnableFIPS:             p.EnableFIPS,
+		SpotMaxPrice:           p.SpotMaxPrice,
+		ScaleSetEvictionPolicy: p.ScaleSetEvictionPolicy,
+		NodePublicIPPrefixID:   p.NodePublicIPPrefixID,
+		KubeletDiskType:        p.KubeletDiskType,
+		KubeletConfig:          p.KubeletConfig,
+		LinuxOSConfig:          p.LinuxOSConfig,
+		UpgradeSettings:        toUpgradeSettings(p.UpgradeSettings),
+	}
+}
+
+// toUpgradeSettings renders the stored upgrade settings onto the ARM shape.
+func toUpgradeSettings(s *aks.AgentPoolUpgradeSettings) *armAgentPoolUpgradeSettings {
+	if s == nil {
+		return nil
+	}
+
+	return &armAgentPoolUpgradeSettings{
+		MaxSurge:                  s.MaxSurge,
+		DrainTimeoutInMinutes:     s.DrainTimeoutInMinutes,
+		NodeSoakDurationInMinutes: s.NodeSoakDurationInMinutes,
 	}
 }
 
@@ -256,7 +343,7 @@ func toAgentPoolProfiles(pools []aks.AgentPool) []armAgentPoolProfile {
 	for i := range pools {
 		out = append(out, armAgentPoolProfile{
 			Name:                 pools[i].Name,
-			Count:                pools[i].Count,
+			Count:                ptrInt32(pools[i].Count),
 			VMSize:               pools[i].VMSize,
 			OSDiskSizeGB:         pools[i].OSDiskSizeGB,
 			OSType:               pools[i].OSType,
@@ -286,7 +373,7 @@ func toARMAgentPool(p *aks.AgentPool, subscription string) armAgentPool {
 		Name: p.Name,
 		Type: resourceTypeAgentPool,
 		Properties: &armAgentPoolProperties{
-			Count:                p.Count,
+			Count:                ptrInt32(p.Count),
 			VMSize:               p.VMSize,
 			OSDiskSizeGB:         p.OSDiskSizeGB,
 			OSType:               p.OSType,
@@ -314,6 +401,13 @@ func toARMMaintenance(mc *aks.MaintenanceConfig, subscription string) armMainten
 		Type:       resourceTypeMaintenanceConfig,
 		Properties: mc.Properties,
 	}
+}
+
+// ptrInt32 returns a pointer to v. Agent-pool count is a pointer on the wire so
+// an explicit 0 (scale-to-zero) round-trips; the stored value is always
+// concrete, so the response pointer is always non-nil.
+func ptrInt32(v int32) *int32 {
+	return &v
 }
 
 // toPtrTags converts a flat map[string]string to ARM's map[string]*string.

--- a/server/azure/resourcegraph/arg_cost_fields_test.go
+++ b/server/azure/resourcegraph/arg_cost_fields_test.go
@@ -371,7 +371,7 @@ func TestARGCostFields_AKS(t *testing.T) {
 		AgentPools: []aks.AgentPoolInput{
 			{
 				Name:             "spotpool",
-				Count:            2,
+				Count:            to.Ptr[int32](2),
 				VMSize:           "Standard_DS2_v2",
 				ScaleSetPriority: "Spot",
 			},

--- a/server/azure/resourcegraph/sdk_test.go
+++ b/server/azure/resourcegraph/sdk_test.go
@@ -376,7 +376,7 @@ func TestSDKResourceGraph_KubernetesIndexing(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = cloudP.AKS.CreateOrUpdateAgentPool(ctx, "rg-1", "prod", aks.AgentPoolInput{
-		Name: "ap-1", Count: 1,
+		Name: "ap-1", Count: to.Ptr[int32](1),
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

Fixes five real AKS control-plane bugs found by a confirming audit, all contained to `providers/azure/aks/` + `server/azure/aks/`. The headline fix is a HIGH-severity data-loss bug.

### BUG-1 [HIGH data-loss] — cluster PUT wiped ALL node pools
`CreateOrUpdateCluster` unconditionally wiped every pool under the cluster and re-added only the inline `agentPoolProfiles`. A cluster PUT that omits `agentPoolProfiles` (the SDK has no PATCH — a tags-only or version-only update is a full PUT) therefore dropped the cluster to **zero pools**, destroying pools created via the standalone AgentPools API (`azurerm_kubernetes_cluster_node_pool`). A nil `properties` block additionally reset kubernetesVersion/dnsPrefix/networkProfile/identity to defaults.

Fix: pools are now reconciled **by name** — the PUT upserts the pools it carries and never removes a pool absent from the body (real AKS never drops a cluster to zero pools). Cluster fields are merged: on an update, any field the request omits is preserved from stored state, so a tags-only or version-only PUT no longer resets networkProfile, identity, dnsPrefix, or the node pools.

### BUG-2 [HIGH] — osDiskType (Ephemeral) always read "Managed"
`osDiskType`/`type` were hardcoded on build and never mapped from input, so the overlay treated them as modeled and the hardcoded value won. Added `OSDiskType`/`Type` to the pool input, mapped both on the inline and standalone paths, and defaulted only when empty (Ephemeral now round-trips; Managed/VirtualMachineScaleSets remain the defaults when unset).

### BUG-3 [MED] — count:0 scale-to-zero impossible
`count` used `omitempty` on a non-pointer, so 0 was indistinguishable from omitted and forced back to the default (3). `count` is now `*int32` end-to-end; an explicit 0 is preserved, and the default applies only when count is truly absent (nil).

### BUG-4 [MED] — UserAssigned identity round-trip lossy
The identity wire shape modeled only Type/PrincipalID/TenantID, and the property overlay does not cover the top-level `identity` block, so `userAssignedIdentities` was dropped. Added `userAssignedIdentities` to the wire model; on a UserAssigned PUT the submitted identity IDs are stored and a deterministic principalId/clientId is synthesized per identity and echoed on GET. SystemAssigned path unchanged.

### BUG-5 [MED TF-drift] — inline default_node_pool fields dropped
Fields submitted inline in `agentPoolProfiles[]` (upgradeSettings.maxSurge, pool tags, enableFIPS, spotMaxPrice, scaleSetEvictionPolicy, nodePublicIPPrefixID, kubeletDiskType, kubeletConfig, linuxOSConfig) were lost because the overlay does not descend into arrays, while the same fields survived on a standalone pool. Modeled these on the pool input + wire structs so an inline submission round-trips identically to a standalone pool. (The alternative — teaching the shared `echo_properties.go` overlay to descend into arrays — is broader/riskier and was intentionally not done here.)

## Tests
Real `armcontainerservice` SDK over httptest:
- standalone-pool-survives-cluster-PUT (the critical data-loss guard) + nil-properties-preserves-fields
- osDiskType Ephemeral round-trips (inline + standalone) + defaults-to-Managed
- count:0 scale-to-zero preserved
- userAssignedIdentities echoed with synthesized principalId/clientId
- inline upgradeSettings/tags/enableFIPS round-trip
