### PR TITLE
fix(azure-sql): round-trip elastic pool sku.capacity, default server version 12.0 when omitted

### DIFF
--- a/providers/azure/sql/subresources.go
+++ b/providers/azure/sql/subresources.go
@@ -274,6 +274,7 @@ func (m *Mock) CreateElasticPool(_ context.Context, cfg rdsdriver.ElasticPoolCon
 		Location:     location,
 		SKUName:      cfg.SKUName,
 		SKUTier:      cfg.SKUTier,
+		SKUCapacity:  cfg.SKUCapacity,
 		MaxSizeBytes: cfg.MaxSizeBytes,
 		MinCapacity:  cfg.MinCapacity,
 		MaxCapacity:  cfg.MaxCapacity,
@@ -425,6 +426,10 @@ func (m *Mock) UpdateElasticPool(_ context.Context, cfg rdsdriver.ElasticPoolCon
 
 	if cfg.SKUTier != "" {
 		pool.SKUTier = cfg.SKUTier
+	}
+
+	if cfg.SKUCapacity != 0 {
+		pool.SKUCapacity = cfg.SKUCapacity
 	}
 
 	if cfg.MaxSizeBytes != 0 {

--- a/server/azure/sql/elasticpool_capacity_sdk_test.go
+++ b/server/azure/sql/elasticpool_capacity_sdk_test.go
@@ -1,0 +1,205 @@
+package sql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
+)
+
+const (
+	poolCapacity        = int32(4)
+	poolCapacityUpdated = int32(8)
+)
+
+// createPool creates an elastic pool with the given SKU and waits for the
+// long-running create to finish.
+func createPool(ctx context.Context, t *testing.T, ep *armsql.ElasticPoolsClient, name string, sku *armsql.SKU) {
+	t.Helper()
+
+	poller, err := ep.BeginCreateOrUpdate(ctx, "rg-1", "srv1", name, armsql.ElasticPool{
+		Location: to.Ptr("eastus"),
+		SKU:      sku,
+	}, nil)
+	if err != nil {
+		t.Fatalf("pool BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("pool PollUntilDone: %v", err)
+	}
+}
+
+// TestSDKAzureSQLElasticPoolCapacityRoundTrip covers the elastic-pool analogue
+// of the database B1 fix: a pool's sku.capacity must round-trip on GET and
+// List. azurerm_mssql_elasticpool makes sku.capacity REQUIRED, so dropping it
+// causes perpetual Terraform drift.
+func TestSDKAzureSQLElasticPoolCapacityRoundTrip(t *testing.T) {
+	cf := newFactory(t)
+	ctx := context.Background()
+	mustCreateSQLServer(t, cf)
+
+	ep := cf.NewElasticPoolsClient()
+
+	createPool(ctx, t, ep, "pool1", &armsql.SKU{
+		Name:     to.Ptr("GP_Gen5"),
+		Tier:     to.Ptr("GeneralPurpose"),
+		Capacity: to.Ptr(poolCapacity),
+	})
+
+	got, err := ep.Get(ctx, "rg-1", "srv1", "pool1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.ElasticPool.SKU == nil || got.ElasticPool.SKU.Capacity == nil {
+		t.Fatal("expected sku.capacity set on GET")
+	}
+
+	if *got.ElasticPool.SKU.Capacity != poolCapacity {
+		t.Fatalf("sku.capacity = %d, want %d", *got.ElasticPool.SKU.Capacity, poolCapacity)
+	}
+
+	// List must reflect the capacity too.
+	page, err := ep.NewListByServerPager("rg-1", "srv1", nil).NextPage(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(page.Value) != 1 {
+		t.Fatalf("got %d pools, want 1", len(page.Value))
+	}
+
+	if page.Value[0].SKU == nil || page.Value[0].SKU.Capacity == nil ||
+		*page.Value[0].SKU.Capacity != poolCapacity {
+		t.Fatalf("list sku.capacity = %+v, want %d", page.Value[0].SKU, poolCapacity)
+	}
+}
+
+// TestSDKAzureSQLElasticPoolCapacityPatch covers PATCH semantics: a PATCH that
+// changes capacity applies it, and a later PATCH that omits capacity preserves
+// the existing value (guarded merge).
+func TestSDKAzureSQLElasticPoolCapacityPatch(t *testing.T) {
+	cf := newFactory(t)
+	ctx := context.Background()
+	mustCreateSQLServer(t, cf)
+
+	ep := cf.NewElasticPoolsClient()
+
+	createPool(ctx, t, ep, "pool1", &armsql.SKU{
+		Name:     to.Ptr("GP_Gen5"),
+		Tier:     to.Ptr("GeneralPurpose"),
+		Capacity: to.Ptr(poolCapacity),
+	})
+
+	// PATCH changing capacity applies.
+	updPoller, err := ep.BeginUpdate(ctx, "rg-1", "srv1", "pool1", armsql.ElasticPoolUpdate{
+		SKU: &armsql.SKU{Capacity: to.Ptr(poolCapacityUpdated)},
+	}, nil)
+	if err != nil {
+		t.Fatalf("pool BeginUpdate: %v", err)
+	}
+
+	if _, err := updPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("pool update PollUntilDone: %v", err)
+	}
+
+	got, err := ep.Get(ctx, "rg-1", "srv1", "pool1", nil)
+	if err != nil {
+		t.Fatalf("Get after capacity PATCH: %v", err)
+	}
+
+	if got.ElasticPool.SKU == nil || got.ElasticPool.SKU.Capacity == nil ||
+		*got.ElasticPool.SKU.Capacity != poolCapacityUpdated {
+		t.Fatalf("sku.capacity after PATCH = %+v, want %d", got.ElasticPool.SKU, poolCapacityUpdated)
+	}
+
+	// PATCH omitting capacity preserves the existing value.
+	preservePoller, err := ep.BeginUpdate(ctx, "rg-1", "srv1", "pool1", armsql.ElasticPoolUpdate{
+		Properties: &armsql.ElasticPoolUpdateProperties{MaxSizeBytes: to.Ptr(int64(1 << 30))},
+	}, nil)
+	if err != nil {
+		t.Fatalf("pool BeginUpdate (preserve): %v", err)
+	}
+
+	if _, err := preservePoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("pool update (preserve) PollUntilDone: %v", err)
+	}
+
+	got, err = ep.Get(ctx, "rg-1", "srv1", "pool1", nil)
+	if err != nil {
+		t.Fatalf("Get after preserve PATCH: %v", err)
+	}
+
+	if got.ElasticPool.SKU == nil || got.ElasticPool.SKU.Capacity == nil ||
+		*got.ElasticPool.SKU.Capacity != poolCapacityUpdated {
+		t.Fatalf("sku.capacity after capacity-omitting PATCH = %+v, want preserved %d",
+			got.ElasticPool.SKU, poolCapacityUpdated)
+	}
+}
+
+// TestSDKAzureSQLServerVersionDefault covers G3: a server create that omits
+// properties.version reports Azure's synthesized default "12.0", while an
+// explicit version round-trips unchanged.
+func TestSDKAzureSQLServerVersionDefault(t *testing.T) {
+	cf := newFactory(t)
+	ctx := context.Background()
+	servers := cf.NewServersClient()
+
+	// Create omitting version -> GET reports "12.0".
+	poller, err := servers.BeginCreateOrUpdate(ctx, "rg-1", "noversion", armsql.Server{
+		Location: to.Ptr("eastus"),
+		Properties: &armsql.ServerProperties{
+			AdministratorLogin:         to.Ptr("admin"),
+			AdministratorLoginPassword: to.Ptr("Sup3rs3cret!"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("server BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("server PollUntilDone: %v", err)
+	}
+
+	got, err := servers.Get(ctx, "rg-1", "noversion", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Server.Properties == nil || got.Server.Properties.Version == nil {
+		t.Fatal("expected version set on GET")
+	}
+
+	if *got.Server.Properties.Version != "12.0" {
+		t.Fatalf("version = %q, want %q", *got.Server.Properties.Version, "12.0")
+	}
+
+	// Explicit version round-trips unchanged.
+	exPoller, err := servers.BeginCreateOrUpdate(ctx, "rg-1", "withversion", armsql.Server{
+		Location: to.Ptr("eastus"),
+		Properties: &armsql.ServerProperties{
+			AdministratorLogin:         to.Ptr("admin"),
+			AdministratorLoginPassword: to.Ptr("Sup3rs3cret!"),
+			Version:                    to.Ptr("2.0"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("explicit server BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := exPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("explicit server PollUntilDone: %v", err)
+	}
+
+	gotEx, err := servers.Get(ctx, "rg-1", "withversion", nil)
+	if err != nil {
+		t.Fatalf("Get explicit: %v", err)
+	}
+
+	if gotEx.Server.Properties == nil || gotEx.Server.Properties.Version == nil ||
+		*gotEx.Server.Properties.Version != "2.0" {
+		t.Fatalf("explicit version = %+v, want %q", gotEx.Server.Properties, "2.0")
+	}
+}

--- a/server/azure/sql/handler.go
+++ b/server/azure/sql/handler.go
@@ -45,6 +45,10 @@ const (
 
 	actionFailover      = "failover"
 	actionForceFailover = "forceFailoverAllowDataLoss"
+
+	// defaultServerVersion is the logical-server version Azure SQL synthesizes
+	// when a server create omits properties.version.
+	defaultServerVersion = "12.0"
 )
 
 // Handler serves Microsoft.Sql ARM requests against a relationaldb driver.

--- a/server/azure/sql/operations.go
+++ b/server/azure/sql/operations.go
@@ -17,6 +17,8 @@ func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
+	reqVersion := stringFrom(body.Properties, func(p *armServerProps) string { return p.Version })
+
 	cfg := rdsdriver.ClusterConfig{
 		ID:             rp.ResourceName,
 		Engine:         "SQLServer",
@@ -25,8 +27,13 @@ func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, r
 		MasterUserPassword: stringFrom(body.Properties, func(p *armServerProps) string {
 			return p.AdministratorLoginPassword
 		}),
-		EngineVersion: stringFrom(body.Properties, func(p *armServerProps) string { return p.Version }),
+		EngineVersion: reqVersion,
 		Tags:          body.Tags,
+	}
+
+	// Azure SQL synthesizes version "12.0" when a server create omits it.
+	if cfg.EngineVersion == "" {
+		cfg.EngineVersion = defaultServerVersion
 	}
 
 	cluster, err := h.db.CreateCluster(r.Context(), cfg)
@@ -37,9 +44,11 @@ func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, r
 		}
 
 		// Upsert: PUT on an existing server applies the body (admin/version/tags)
-		// rather than returning the stale record.
+		// rather than returning the stale record. Use the raw request version so
+		// a PUT that omits version preserves the existing one (ModifyCluster
+		// guards empty), not the create-time "12.0" default.
 		cluster, err = h.db.ModifyCluster(r.Context(), rp.ResourceName, rdsdriver.ModifyInstanceInput{
-			EngineVersion: cfg.EngineVersion,
+			EngineVersion: reqVersion,
 			Tags:          body.Tags,
 		})
 		if err != nil {

--- a/server/azure/sql/subresources.go
+++ b/server/azure/sql/subresources.go
@@ -336,6 +336,7 @@ func (*Handler) writeElasticPool(
 	if body.SKU != nil {
 		cfg.SKUName = body.SKU.Name
 		cfg.SKUTier = body.SKU.Tier
+		cfg.SKUCapacity = body.SKU.Capacity
 	}
 
 	if body.Properties != nil {
@@ -401,7 +402,7 @@ func toARMElasticPool(ep *rdsdriver.ElasticPool, rp *azurearm.ResourcePath) armE
 		Name:     ep.Name,
 		Type:     providerName + "/" + resourceServers + "/" + subElasticPools,
 		Location: ep.Location,
-		SKU:      &armSKU{Name: ep.SKUName, Tier: ep.SKUTier},
+		SKU:      &armSKU{Name: ep.SKUName, Tier: ep.SKUTier, Capacity: ep.SKUCapacity},
 		Properties: &armElasticPoolCfg{
 			MaxSizeBytes:       ep.MaxSizeBytes,
 			State:              ep.State,

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -695,11 +695,15 @@ type VNetRules interface {
 
 // ElasticPoolConfig describes an elastic pool to create (Azure SQL).
 type ElasticPoolConfig struct {
-	Server       string
-	Name         string
-	Location     string
-	SKUName      string
-	SKUTier      string
+	Server   string
+	Name     string
+	Location string
+	SKUName  string
+	SKUTier  string
+	// SKUCapacity is the vCore/DTU count on the pool SKU (sku.capacity).
+	// Optional — zero means unset, so a request that omits it carries no
+	// capacity. Only the Azure SQL provider populates it.
+	SKUCapacity  int
 	MaxSizeBytes int64
 	MinCapacity  float64
 	MaxCapacity  float64
@@ -707,11 +711,14 @@ type ElasticPoolConfig struct {
 
 // ElasticPool is a shared-resource pool that databases on a server draw from.
 type ElasticPool struct {
-	Server       string
-	Name         string
-	Location     string
-	SKUName      string
-	SKUTier      string
+	Server   string
+	Name     string
+	Location string
+	SKUName  string
+	SKUTier  string
+	// SKUCapacity echoes the vCore/DTU count on read (sku.capacity); zero
+	// when unset. Azure SQL only.
+	SKUCapacity  int
 	MaxSizeBytes int64
 	MinCapacity  float64
 	MaxCapacity  float64


### PR DESCRIPTION
## What

Two Azure SQL wire-protocol round-trip fixes found by a real-SDK (armsql) audit.

### Elastic pool `sku.capacity` silently dropped (MED/HIGH — Terraform drift)
Creating an elastic pool with `sku={name,tier,capacity:N}` returned `sku.capacity=null` on GET/List. `azurerm_mssql_elasticpool` makes `sku.capacity` REQUIRED, so the missing field caused perpetual Terraform drift. Unlike `properties`, `sku` is a top-level sibling, so it could not fall back to the `echo_properties` overlay. The database path already carried capacity (the merged B1 fix); the pool path was never given the same treatment.

Fixed across all three layers, mirroring the database B1 capacity fix exactly:
- `services/relationaldb/driver/driver.go` — added `SKUCapacity int` to the shared `ElasticPoolConfig` and `ElasticPool` structs (additive; other consumers like RDS/Redshift simply don't set it).
- `server/azure/sql/subresources.go` — `writeElasticPool` now copies `body.SKU.Capacity` (both PUT and PATCH), and `toARMElasticPool` emits it.
- `providers/azure/sql/subresources.go` — `CreateElasticPool` stores it; `UpdateElasticPool` carries it guarded by `!= 0`, so a PATCH omitting capacity preserves the existing value.

### Server `version` default "12.0" not synthesized when omitted (LOW — G3)
A server create that omitted `properties.version` returned an empty version instead of Azure's default `"12.0"`. Now defaulted on create only; the upsert (PUT-on-existing) path still passes the raw request version so a PUT that omits version preserves the existing one rather than clobbering it with the default. An explicit version continues to round-trip unchanged.

## Result
- Pool create with `capacity:4` -> GET/List returns `sku.capacity=4`.
- PATCH changing capacity applies; PATCH omitting capacity preserves.
- Server create omitting version -> GET version `"12.0"`; explicit version preserved.

## Tests
New real-armsql-over-httptest coverage in `server/azure/sql/elasticpool_capacity_sdk_test.go`: pool capacity round-trip (Get + List), PATCH change + PATCH-omit-preserve, and server version default + explicit round-trip.

Gates (scoped): build, vet, `go test` on azure sql + relationaldb + AWS rds/redshift spot-check, gofmt, `go generate` (zero diff), compatgen (exit 0, zero diff), golangci-lint new-from-development (0 issues).