### PR TITLE
fix(azure-network): idempotent re-PUT for public IP (no duplicate), NSG tags, NAT gateway tags+PIP association

### DIFF
--- a/docs/coverage/aws/vpc.md
+++ b/docs/coverage/aws/vpc.md
@@ -97,6 +97,8 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | `PutAzureNSGMetadata` |  |
 | `PutAzureVNetMetadata` |  |
 | `SetAzureVNetPeeringState` | SetAzureVNetPeeringState atomically updates just the peeringState field of |
+| `UpdateAzureNATGateway` | UpdateAzureNATGateway re-applies the mutable fields of an existing NAT |
+| `UpdateAzurePublicIP` | UpdateAzurePublicIP overwrites the mutable fields of an existing public IP |
 | `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
 | `UpsertAzureVNetPeering` | UpsertAzureVNetPeering creates or replaces a single virtualNetworkPeerings |
 

--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -97,6 +97,8 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | `PutAzureNSGMetadata` |  |
 | `PutAzureVNetMetadata` |  |
 | `SetAzureVNetPeeringState` | SetAzureVNetPeeringState atomically updates just the peeringState field of |
+| `UpdateAzureNATGateway` | UpdateAzureNATGateway re-applies the mutable fields of an existing NAT |
+| `UpdateAzurePublicIP` | UpdateAzurePublicIP overwrites the mutable fields of an existing public IP |
 | `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
 | `UpsertAzureVNetPeering` | UpsertAzureVNetPeering creates or replaces a single virtualNetworkPeerings |
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -6648,6 +6648,14 @@
             "doc": "SetAzureVNetPeeringState atomically updates just the peeringState field of"
           },
           {
+            "name": "UpdateAzureNATGateway",
+            "doc": "UpdateAzureNATGateway re-applies the mutable fields of an existing NAT"
+          },
+          {
+            "name": "UpdateAzurePublicIP",
+            "doc": "UpdateAzurePublicIP overwrites the mutable fields of an existing public IP"
+          },
+          {
             "name": "UpsertAzureNSGRule",
             "doc": "UpsertAzureNSGRule creates or replaces a single custom security rule by"
           },

--- a/docs/coverage/gcp/vpc.md
+++ b/docs/coverage/gcp/vpc.md
@@ -97,6 +97,8 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | `PutAzureNSGMetadata` |  |
 | `PutAzureVNetMetadata` |  |
 | `SetAzureVNetPeeringState` | SetAzureVNetPeeringState atomically updates just the peeringState field of |
+| `UpdateAzureNATGateway` | UpdateAzureNATGateway re-applies the mutable fields of an existing NAT |
+| `UpdateAzurePublicIP` | UpdateAzurePublicIP overwrites the mutable fields of an existing public IP |
 | `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
 | `UpsertAzureVNetPeering` | UpsertAzureVNetPeering creates or replaces a single virtualNetworkPeerings |
 

--- a/docs/coverage/oci/vcn.md
+++ b/docs/coverage/oci/vcn.md
@@ -97,6 +97,8 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | `PutAzureNSGMetadata` |  |
 | `PutAzureVNetMetadata` |  |
 | `SetAzureVNetPeeringState` | SetAzureVNetPeeringState atomically updates just the peeringState field of |
+| `UpdateAzureNATGateway` | UpdateAzureNATGateway re-applies the mutable fields of an existing NAT |
+| `UpdateAzurePublicIP` | UpdateAzurePublicIP overwrites the mutable fields of an existing public IP |
 | `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
 | `UpsertAzureVNetPeering` | UpsertAzureVNetPeering creates or replaces a single virtualNetworkPeerings |
 

--- a/providers/azure/vnet/elastic_ip.go
+++ b/providers/azure/vnet/elastic_ip.go
@@ -70,6 +70,48 @@ func (m *Mock) AllocateAddress(
 	return &info, nil
 }
 
+// UpdateAzurePublicIP overwrites the mutable fields of an existing public IP in
+// place (keyed by its allocation id), applying the same SKU/allocation-method
+// defaults as AllocateAddress and recomputing the DNS FQDN, so a repeat ARM
+// CreateOrUpdate PUT mutates the resource instead of minting a duplicate. The
+// allocation id, address and any existing association are preserved.
+//
+//nolint:gocritic // hugeParam: cfg mirrors AllocateAddress's driver signature.
+func (m *Mock) UpdateAzurePublicIP(_ context.Context, allocationID string, cfg driver.ElasticIPConfig) error {
+	sku := cfg.SKU
+	if sku == "" {
+		sku = "Standard"
+	}
+
+	allocMethod := cfg.AllocationMethod
+	if allocMethod == "" {
+		allocMethod = "Static"
+	}
+
+	found := m.eips.Update(allocationID, func(e *eipData) *eipData {
+		e.Tags = copyTags(cfg.Tags)
+		e.SKU = sku
+		e.AllocationMethod = allocMethod
+		e.IdleTimeoutMinutes = cfg.IdleTimeoutMinutes
+		e.DNSDomainNameLabel = cfg.DNSDomainNameLabel
+
+		e.Zones = append([]string(nil), cfg.Zones...)
+
+		if cfg.DNSDomainNameLabel != "" {
+			e.DNSFQDN = cfg.DNSDomainNameLabel + "." + defaultFQDNRegion + ".cloudapp.azure.com"
+		} else {
+			e.DNSFQDN = ""
+		}
+
+		return e
+	})
+	if !found {
+		return cerrors.Newf(cerrors.NotFound, "public IP %q not found", allocationID)
+	}
+
+	return nil
+}
+
 // ReleaseAddress releases a public IP address.
 func (m *Mock) ReleaseAddress(
 	_ context.Context, allocationID string,

--- a/providers/azure/vnet/nat_gateway.go
+++ b/providers/azure/vnet/nat_gateway.go
@@ -128,6 +128,54 @@ func (m *Mock) DeleteNATGateway(_ context.Context, id string) error {
 	return nil
 }
 
+// UpdateAzureNATGateway re-applies the mutable fields of an existing NAT gateway
+// (its bound public-IP allocation and tags) in place, so a repeat ARM
+// CreateOrUpdate PUT re-associates the public IP and reflects tag changes rather
+// than discarding them. When the requested allocation differs from the current
+// one it binds the new public IP first (rejecting one already in use) and only
+// then frees the previous binding, so a failed rebind leaves the gateway
+// untouched. An empty allocationID detaches any bound public IP.
+func (m *Mock) UpdateAzureNATGateway(_ context.Context, id, allocationID string, tags map[string]string) error {
+	nat, ok := m.natGateways.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "NAT gateway %q not found", id)
+	}
+
+	if allocationID != nat.AllocationID {
+		newPublicIP := ""
+
+		if allocationID != "" {
+			address, err := m.bindNATGatewayAllocation(allocationID)
+			if err != nil {
+				return err
+			}
+
+			newPublicIP = address
+		}
+
+		if nat.AllocationID != "" {
+			m.eips.Update(nat.AllocationID, func(e *eipData) *eipData {
+				e.AssociationID = ""
+				return e
+			})
+		}
+
+		m.natGateways.Update(id, func(n *natGatewayData) *natGatewayData {
+			n.AllocationID = allocationID
+			n.PublicIP = newPublicIP
+
+			return n
+		})
+	}
+
+	m.natGateways.Update(id, func(n *natGatewayData) *natGatewayData {
+		n.Tags = copyTags(tags)
+		return n
+	})
+
+	return nil
+}
+
 // DescribeNATGateways returns NAT gateways matching the given IDs, or all if empty.
 func (m *Mock) DescribeNATGateways(_ context.Context, ids []string) ([]driver.NATGateway, error) {
 	return describeResources(m.natGateways, ids, toNATGatewayInfo), nil

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -1146,6 +1146,14 @@ func (h *Handler) upsertNSG(ctx context.Context, rg, name string,
 	tags map[string]string,
 ) (*netdriver.SecurityGroupInfo, error) {
 	if existing, err := findNSGInGroup(ctx, h.net, rg, name); err == nil {
+		if len(tags) > 0 {
+			_ = h.net.UpdateSecurityGroupTags(ctx, existing.ID, tags)
+
+			if refreshed, rerr := findNSGInGroup(ctx, h.net, rg, name); rerr == nil {
+				existing = refreshed
+			}
+		}
+
 		return existing, nil
 	}
 
@@ -1287,7 +1295,7 @@ func (h *Handler) createPublicIP(w http.ResponseWriter, r *http.Request, rp azur
 		cfg.DNSDomainNameLabel = req.Properties.DNSSettings.DomainNameLabel
 	}
 
-	info, err := h.net.AllocateAddress(r.Context(), cfg)
+	info, err := h.upsertPublicIP(r.Context(), rp.ResourceGroup, rp.ResourceName, cfg)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -1301,6 +1309,37 @@ func (h *Handler) createPublicIP(w http.ResponseWriter, r *http.Request, rp azur
 	body := h.toPublicIPResponse(r.Context(), info, rp, loc)
 
 	writeAcceptedAsync(w, r, rp.Subscription, "publicip-create-"+rp.ResourceName, body)
+}
+
+// upsertPublicIP reuses an existing public IP of the same name (idempotent
+// re-PUT — real ARM CreateOrUpdate) or allocates a new one. On the found branch
+// it mutates the existing allocation in place rather than allocating a second,
+// hidden one, so LIST returns exactly one entry per name and the allocation
+// never leaks.
+//
+//nolint:gocritic // hugeParam: cfg mirrors AllocateAddress's driver signature.
+func (h *Handler) upsertPublicIP(ctx context.Context, rg, name string,
+	cfg netdriver.ElasticIPConfig,
+) (*netdriver.ElasticIP, error) {
+	existing, err := findPublicIPByName(ctx, h.net, rg, name)
+	if err != nil {
+		return h.net.AllocateAddress(ctx, cfg)
+	}
+
+	meta, ok := h.azureMeta()
+	if !ok {
+		return existing, nil
+	}
+
+	if uerr := meta.UpdateAzurePublicIP(ctx, existing.AllocationID, cfg); uerr != nil {
+		return nil, uerr
+	}
+
+	if refreshed, rerr := findPublicIPByName(ctx, h.net, rg, name); rerr == nil {
+		existing = refreshed
+	}
+
+	return existing, nil
 }
 
 //nolint:gocritic // rp is a request-scoped value

--- a/server/azure/vnet/nat_gateway.go
+++ b/server/azure/vnet/nat_gateway.go
@@ -174,6 +174,16 @@ func (h *Handler) resolveNATGatewayAllocation(ctx context.Context, publicIPAddre
 // re-PUT) or creates one.
 func (h *Handler) upsertNATGateway(ctx context.Context, rg, name string, cfg netdriver.NATGatewayConfig) (*netdriver.NATGateway, error) {
 	if existing, err := findNATGatewayByName(ctx, h.net, rg, name); err == nil {
+		if meta, ok := h.azureMeta(); ok {
+			if uerr := meta.UpdateAzureNATGateway(ctx, existing.ID, cfg.AllocationID, cfg.Tags); uerr != nil {
+				return nil, uerr
+			}
+
+			if refreshed, rerr := findNATGatewayByName(ctx, h.net, rg, name); rerr == nil {
+				existing = refreshed
+			}
+		}
+
 		return existing, nil
 	}
 

--- a/server/azure/vnet/nat_gateway_test.go
+++ b/server/azure/vnet/nat_gateway_test.go
@@ -263,3 +263,98 @@ func TestSDKNATGatewayResourceGroupIsolation(t *testing.T) {
 		t.Errorf("List(rg-a) returned %d NAT gateways, want 1 (rg-b's must not leak in)", count)
 	}
 }
+
+// TestSDKNATGatewayRePUTUpdatesTagsAndPIP guards the re-PUT idempotency fix for
+// NAT gateways: a second CreateOrUpdate re-applies the public-IP association and
+// tag changes (previously the found branch returned the gateway unchanged,
+// discarding both). It swaps the bound public IP and updates tags, then asserts
+// GET reflects the new association and tags, and that the freed public IP can be
+// rebound to another gateway.
+func TestSDKNATGatewayRePUTUpdatesTagsAndPIP(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	pips, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"pip-a", "pip-b"} {
+		pp, cErr := pips.BeginCreateOrUpdate(ctx, "rg-1", name, armnetwork.PublicIPAddress{
+			Location: to.Ptr("eastus"),
+			SKU:      &armnetwork.PublicIPAddressSKU{Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard)},
+			Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+				PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+			},
+		}, nil)
+		if cErr != nil {
+			t.Fatalf("create %s: %v", name, cErr)
+		}
+
+		pollDone(t, pp)
+	}
+
+	pipAID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/publicIPAddresses/pip-a"
+	pipBID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/publicIPAddresses/pip-b"
+
+	natClient, err := armnetwork.NewNatGatewaysClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := natClient.BeginCreateOrUpdate(ctx, "rg-1", "natgw-reput", armnetwork.NatGateway{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("dev")},
+		Properties: &armnetwork.NatGatewayPropertiesFormat{
+			PublicIPAddresses: []*armnetwork.SubResource{{ID: to.Ptr(pipAID)}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+
+	pollDone(t, first)
+
+	// Re-PUT: swap the bound public IP (pip-a -> pip-b) and change the tags.
+	second, err := natClient.BeginCreateOrUpdate(ctx, "rg-1", "natgw-reput", armnetwork.NatGateway{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armnetwork.NatGatewayPropertiesFormat{
+			PublicIPAddresses: []*armnetwork.SubResource{{ID: to.Ptr(pipBID)}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("second create: %v", err)
+	}
+
+	pollDone(t, second)
+
+	got, err := natClient.Get(ctx, "rg-1", "natgw-reput", nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.Properties == nil || len(got.Properties.PublicIPAddresses) != 1 ||
+		got.Properties.PublicIPAddresses[0].ID == nil || *got.Properties.PublicIPAddresses[0].ID != pipBID {
+		t.Errorf("publicIpAddresses=%v want [%s] (re-associated by re-PUT)", got.Properties, pipBID)
+	}
+
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" {
+		t.Errorf("tags[env]=%v want prod (updated by re-PUT)", got.Tags["env"])
+	}
+
+	// The freed pip-a must be reusable: binding it to a fresh NAT gateway
+	// succeeds, proving the old association was released rather than leaked.
+	other, err := natClient.BeginCreateOrUpdate(ctx, "rg-1", "natgw-other", armnetwork.NatGateway{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.NatGatewayPropertiesFormat{
+			PublicIPAddresses: []*armnetwork.SubResource{{ID: to.Ptr(pipAID)}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("bind freed pip-a to another gateway: %v", err)
+	}
+
+	pollDone(t, other)
+}

--- a/server/azure/vnet/public_ip_test.go
+++ b/server/azure/vnet/public_ip_test.go
@@ -288,3 +288,92 @@ func TestSDKPublicIPIPConfigurationBackref(t *testing.T) {
 		t.Errorf("ipConfiguration.id=%q want %q", *got.Properties.IPConfiguration.ID, wantIPConfig)
 	}
 }
+
+// TestSDKPublicIPRePUTUpdatesInPlace guards the re-PUT idempotency fix: a
+// second CreateOrUpdate to the same publicIPAddresses/{name} must mutate the
+// existing allocation in place, not mint a duplicate. It asserts the critical
+// invariant — LIST returns exactly ONE entry for the name — plus the updated
+// idleTimeout and tags round-tripping on GET, and the address staying stable.
+func TestSDKPublicIPRePUTUpdatesInPlace(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	pips, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := pips.BeginCreateOrUpdate(ctx, "rg-reput", "pip-reput", armnetwork.PublicIPAddress{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("dev")},
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+			IdleTimeoutInMinutes:     to.Ptr(int32(4)),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+
+	created := pollDone(t, first)
+
+	// Second PUT to the same name with changed idleTimeout and tags.
+	second, err := pips.BeginCreateOrUpdate(ctx, "rg-reput", "pip-reput", armnetwork.PublicIPAddress{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("prod"), "team": to.Ptr("net")},
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+			IdleTimeoutInMinutes:     to.Ptr(int32(20)),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("second create: %v", err)
+	}
+
+	pollDone(t, second)
+
+	// The critical invariant: LIST returns exactly one entry for the name.
+	count := 0
+
+	pager := pips.NewListPager("rg-reput", nil)
+	for pager.More() {
+		page, pErr := pager.NextPage(ctx)
+		if pErr != nil {
+			t.Fatalf("list: %v", pErr)
+		}
+
+		for _, v := range page.Value {
+			if v.Name != nil && *v.Name == "pip-reput" {
+				count++
+			}
+		}
+	}
+
+	if count != 1 {
+		t.Fatalf("List returned %d entries for pip-reput, want 1 (re-PUT must not duplicate)", count)
+	}
+
+	got, err := pips.Get(ctx, "rg-reput", "pip-reput", nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	// Identity (address) preserved across the re-PUT.
+	if created.Properties == nil || created.Properties.IPAddress == nil ||
+		got.Properties == nil || got.Properties.IPAddress == nil ||
+		*got.Properties.IPAddress != *created.Properties.IPAddress {
+		t.Errorf("ipAddress changed across re-PUT: created=%v got=%v", created.Properties, got.Properties)
+	}
+
+	if got.Properties.IdleTimeoutInMinutes == nil || *got.Properties.IdleTimeoutInMinutes != 20 {
+		t.Errorf("idleTimeoutInMinutes=%v want 20 (updated by re-PUT)", got.Properties.IdleTimeoutInMinutes)
+	}
+
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" {
+		t.Errorf("tags[env]=%v want prod (updated by re-PUT)", got.Tags["env"])
+	}
+
+	if got.Tags["team"] == nil || *got.Tags["team"] != "net" {
+		t.Errorf("tags[team]=%v want net (added by re-PUT)", got.Tags["team"])
+	}
+}

--- a/server/azure/vnet/vnet_nsg_regression_test.go
+++ b/server/azure/vnet/vnet_nsg_regression_test.go
@@ -318,3 +318,83 @@ func TestSDKCheckIPAddressAvailability(t *testing.T) {
 		t.Fatalf("CheckIPAddressAvailability(10.0.1.20).available = %v, want true (free)", free.Available)
 	}
 }
+
+// TestSDKNSGRePUTUpdatesTags guards the re-PUT idempotency fix for network
+// security groups: a second CreateOrUpdate with changed tags must reflect on a
+// subsequent GET (previously the found branch returned the NSG unchanged and
+// dropped tag edits), while the security rules stay correct.
+func TestSDKNSGRePUTUpdatesTags(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	nsgs, err := armnetwork.NewSecurityGroupsClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := armnetwork.SecurityGroup{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("dev")},
+		Properties: &armnetwork.SecurityGroupPropertiesFormat{
+			SecurityRules: []*armnetwork.SecurityRule{{
+				Name: to.Ptr("allow-ssh"),
+				Properties: &armnetwork.SecurityRulePropertiesFormat{
+					Priority: to.Ptr(int32(100)), Direction: to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+					Access: to.Ptr(armnetwork.SecurityRuleAccessAllow), Protocol: to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+					SourceAddressPrefix: to.Ptr("*"), DestinationAddressPrefix: to.Ptr("*"),
+					SourcePortRange: to.Ptr("*"), DestinationPortRange: to.Ptr("22"),
+				},
+			}},
+		},
+	}
+
+	first, err := nsgs.BeginCreateOrUpdate(ctx, "rg-1", "nsg-reput", body, nil)
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+
+	pollDone(t, first)
+
+	// Re-PUT with a changed tag value and a new tag.
+	body.Tags = map[string]*string{"env": to.Ptr("prod"), "team": to.Ptr("net")}
+
+	second, err := nsgs.BeginCreateOrUpdate(ctx, "rg-1", "nsg-reput", body, nil)
+	if err != nil {
+		t.Fatalf("second create: %v", err)
+	}
+
+	pollDone(t, second)
+
+	got, err := nsgs.Get(ctx, "rg-1", "nsg-reput", nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" {
+		t.Errorf("tags[env]=%v want prod (updated by re-PUT)", got.Tags["env"])
+	}
+
+	if got.Tags["team"] == nil || *got.Tags["team"] != "net" {
+		t.Errorf("tags[team]=%v want net (added by re-PUT)", got.Tags["team"])
+	}
+
+	// Rules must still be correct: the seeded allow-ssh rule survives.
+	found := false
+
+	if got.Properties != nil {
+		for _, rule := range got.Properties.SecurityRules {
+			if rule.Name != nil && *rule.Name == "allow-ssh" {
+				found = true
+
+				if rule.Properties == nil || rule.Properties.DestinationPortRange == nil ||
+					*rule.Properties.DestinationPortRange != "22" {
+					t.Errorf("allow-ssh destinationPortRange=%v want 22", rule.Properties)
+				}
+			}
+		}
+	}
+
+	if !found {
+		t.Error("allow-ssh security rule missing after re-PUT")
+	}
+}

--- a/services/networking/driver/azure_network_metadata.go
+++ b/services/networking/driver/azure_network_metadata.go
@@ -118,4 +118,20 @@ type AzureNetworkMetadata interface {
 	// Returns NotFound when either the virtual network or the named peering
 	// doesn't exist.
 	SetAzureVNetPeeringState(ctx context.Context, vnetID, peeringName, state string) error
+
+	// UpdateAzurePublicIP overwrites the mutable fields of an existing public IP
+	// (SKU, allocation method, idle timeout, DNS label, tags) in place, keyed by
+	// its allocation id, so a repeat ARM CreateOrUpdate PUT to the same
+	// publicIPAddresses/{name} updates the resource rather than allocating a
+	// duplicate. Its allocation id, address and any association are preserved.
+	// Returns NotFound when no public IP has that allocation id.
+	UpdateAzurePublicIP(ctx context.Context, allocationID string, cfg ElasticIPConfig) error
+
+	// UpdateAzureNATGateway re-applies the mutable fields of an existing NAT
+	// gateway (its bound public-IP allocation and tags), keyed by its id, so a
+	// repeat ARM CreateOrUpdate PUT re-associates the public IP and reflects tag
+	// changes rather than discarding them. A changed allocation id rebinds the
+	// public IP (freeing the previous one); an empty one detaches it. Returns
+	// NotFound when the NAT gateway doesn't exist.
+	UpdateAzureNATGateway(ctx context.Context, id, allocationID string, tags map[string]string) error
 }


### PR DESCRIPTION
## Summary

Fixes three re-PUT idempotency bugs in Azure networking. Real ARM `PUT` is `CreateOrUpdate`, but these handlers treated a repeated PUT to an existing resource as create-only, so a second apply either duplicated the resource or silently dropped changes.

### Bug 1 (HIGH — duplicate resource + leak): Public IP re-PUT created a duplicate
`createPublicIP` called `AllocateAddress` unconditionally. `AllocateAddress` mints a fresh allocation every call, so a second PUT to the same `publicIPAddresses/{name}` allocated a new hidden address: GET returned the stale one, LIST returned the same name twice, and the old allocation leaked. Added an `upsertPublicIP` path that updates the existing allocation in place (SKU, allocation method, idle timeout, DNS label, tags) via a new Azure-only `UpdateAzurePublicIP`, preserving the allocation id/address. LIST now returns exactly one entry per name.

### Bug 2 (MED): NSG re-PUT dropped tag changes
`upsertNSG` returned the existing NSG unchanged, never applying tag edits. Now calls `UpdateSecurityGroupTags` on the found branch, mirroring `upsertVNet`. Security rules were already rewritten unconditionally and stay correct.

### Bug 3 (MED): NAT gateway re-PUT dropped tags + public-IP re-association
`upsertNATGateway` returned the existing gateway unchanged, discarding the freshly-resolved public-IP binding and tags. Now re-applies both via a new Azure-only `UpdateAzureNATGateway`, which rebinds the public IP (freeing the previous allocation) and updates tags.

## Design

The two new mutation methods are added to the existing Azure-only, type-asserted `AzureNetworkMetadata` surface (AWS/GCP do not implement it), consistent with the peering-subresource CRUD already living there — so the shared cross-cloud `Networking` interface and the AWS/GCP providers are untouched.

## Tests

Real `armnetwork` SDK over `httptest`, each verified fail-before / pass-after:
- Public IP re-PUT updates in place — GET returns new idleTimeout/tags, address stable, and LIST returns exactly ONE entry (the critical duplicate-prevention assertion).
- NSG re-PUT with changed tags reflects on GET while security rules stay correct.
- NAT gateway re-PUT swaps the bound public IP and updates tags; the freed public IP is reusable (no leak).

## Gates
build, vet, scoped tests, gofmt, `go generate` (coverage docs regenerated, idempotent), and compatgen all green; scoped `golangci-lint --new-from-rev` reports 0 issues.
