### PR TITLE
fix(azure-eventgrid): preserve publisher event id + dataVersion, support PATCH on subscriptions/system topics/domains

### DIFF
--- a/providers/azure/eventgrid/delivery.go
+++ b/providers/azure/eventgrid/delivery.go
@@ -22,6 +22,24 @@ import (
 // ServiceBus/Functions delivery is left as a follow-up (see PR notes).
 const endpointTypeWebHook = "WebHook"
 
+// defaultDataVersion is the dataVersion Event Grid stamps on a delivered event
+// when the publisher omitted one; metadataVersion is the read-only schema
+// version Event Grid always reports as "1".
+const (
+	defaultDataVersion = "1.0"
+	metadataVersion    = "1"
+)
+
+// dataVersionOrDefault returns the publisher's dataVersion, defaulting to "1.0"
+// only when the publisher omitted it (matching real Event Grid).
+func dataVersionOrDefault(v string) string {
+	if v == "" {
+		return defaultDataVersion
+	}
+
+	return v
+}
+
 // webhookDeliveryTimeout bounds how long PutEvents waits for a single WebHook
 // destination to respond. Real Event Grid waits up to 30s before queuing a
 // retry; this mock uses a shorter bound so a dead test endpoint can't hang a
@@ -103,13 +121,14 @@ func (m *Mock) deliverToTargets(ctx context.Context, matched []*ruleData, event 
 	dctx := recursionguard.WithDepth(context.Background(), recursionguard.Depth(ctx))
 
 	payload := deliveryEvent{
-		ID:          event.ID,
-		Topic:       topicARN,
-		Subject:     event.Subject,
-		EventType:   event.DetailType,
-		EventTime:   event.Time.UTC().Format(time.RFC3339Nano),
-		Data:        eventDataOrEmpty(event.Detail),
-		DataVersion: "1.0",
+		ID:              event.ID,
+		Topic:           topicARN,
+		Subject:         event.Subject,
+		EventType:       event.DetailType,
+		EventTime:       event.Time.UTC().Format(time.RFC3339Nano),
+		Data:            eventDataOrEmpty(event.Detail),
+		DataVersion:     dataVersionOrDefault(event.DataVersion),
+		MetadataVersion: metadataVersion,
 	}
 
 	body, err := json.Marshal([]deliveryEvent{payload})

--- a/providers/azure/eventgrid/eventgrid.go
+++ b/providers/azure/eventgrid/eventgrid.go
@@ -420,8 +420,12 @@ func (m *Mock) PutEvents(ctx context.Context, events []driver.Event) (*driver.Pu
 	}
 
 	for i := range events {
-		eventID := generateEventID(&events[i], m.opts.Clock.Now())
-		events[i].ID = eventID
+		// Real Event Grid preserves the publisher-supplied event id end-to-end
+		// (subscribers dedup on it); only synthesize one when the publisher
+		// omitted it.
+		if events[i].ID == "" {
+			events[i].ID = generateEventID(&events[i], m.opts.Clock.Now())
+		}
 
 		if events[i].Time.IsZero() {
 			events[i].Time = m.opts.Clock.Now()
@@ -451,7 +455,7 @@ func (m *Mock) PutEvents(ctx context.Context, events []driver.Event) (*driver.Pu
 		})
 
 		result.SuccessCount++
-		result.EventIDs = append(result.EventIDs, eventID)
+		result.EventIDs = append(result.EventIDs, events[i].ID)
 	}
 
 	return result, nil

--- a/providers/azure/eventgrid/id_dataversion_test.go
+++ b/providers/azure/eventgrid/id_dataversion_test.go
@@ -1,0 +1,128 @@
+package eventgrid
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPutEventsPreservesPublisherID locks the fix: a publisher-supplied event id
+// must survive end-to-end — carried onto the delivered payload and recorded in
+// event history unchanged (subscribers dedup on it).
+func TestPutEventsPreservesPublisherID(t *testing.T) {
+	receiver := newWebhookReceiver(t)
+
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "orders")
+
+	_, err := m.PutRule(ctx, &driver.RuleConfig{
+		Name:        "sub1",
+		EventBus:    "orders",
+		Description: destinationJSON(receiver.URL),
+	})
+	require.NoError(t, err)
+
+	res, err := m.PutEvents(ctx, []driver.Event{{
+		ID:         "e1",
+		EventBus:   "orders",
+		DetailType: "Order.Created",
+		Subject:    "orders/1",
+	}})
+	require.NoError(t, err)
+	require.Equal(t, []string{"e1"}, res.EventIDs)
+
+	got := receiver.events()
+	require.Len(t, got, 1)
+	assert.Equal(t, "e1", got[0].ID, "publisher id must be delivered unchanged")
+
+	hist, err := m.GetEventHistory(ctx, "orders", 0)
+	require.NoError(t, err)
+	require.Len(t, hist, 1)
+	assert.Equal(t, "e1", hist[0].ID, "publisher id must appear in event history")
+}
+
+// TestPutEventsSynthesizesMissingID locks the other half: a publish with no id
+// still gets a synthesized one.
+func TestPutEventsSynthesizesMissingID(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "orders")
+
+	res, err := m.PutEvents(ctx, []driver.Event{{
+		EventBus:   "orders",
+		DetailType: "Order.Created",
+	}})
+	require.NoError(t, err)
+	require.Len(t, res.EventIDs, 1)
+	assert.NotEmpty(t, res.EventIDs[0], "a publish without an id must get a synthesized one")
+
+	hist, err := m.GetEventHistory(ctx, "orders", 0)
+	require.NoError(t, err)
+	require.Len(t, hist, 1)
+	assert.NotEmpty(t, hist[0].ID)
+}
+
+// TestDeliveryPreservesDataVersion locks the fix: the publisher's dataVersion is
+// delivered verbatim and metadataVersion is always "1".
+func TestDeliveryPreservesDataVersion(t *testing.T) {
+	receiver := newWebhookReceiver(t)
+
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "orders")
+
+	_, err := m.PutRule(ctx, &driver.RuleConfig{
+		Name:        "sub1",
+		EventBus:    "orders",
+		Description: destinationJSON(receiver.URL),
+	})
+	require.NoError(t, err)
+
+	_, err = m.PutEvents(ctx, []driver.Event{{
+		EventBus:    "orders",
+		DetailType:  "Order.Created",
+		DataVersion: "2.0",
+	}})
+	require.NoError(t, err)
+
+	got := receiver.events()
+	require.Len(t, got, 1)
+	assert.Equal(t, "2.0", got[0].DataVersion, "publisher dataVersion must be preserved")
+	assert.Equal(t, "1", got[0].MetadataVersion, "metadataVersion must be 1")
+}
+
+// TestDeliveryDefaultsDataVersion locks the default: when the publisher omits
+// dataVersion, delivery defaults it to "1.0" (metadataVersion still "1").
+func TestDeliveryDefaultsDataVersion(t *testing.T) {
+	receiver := newWebhookReceiver(t)
+
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "orders")
+
+	_, err := m.PutRule(ctx, &driver.RuleConfig{
+		Name:        "sub1",
+		EventBus:    "orders",
+		Description: destinationJSON(receiver.URL),
+	})
+	require.NoError(t, err)
+
+	_, err = m.PutEvents(ctx, []driver.Event{{
+		EventBus:   "orders",
+		DetailType: "Order.Created",
+	}})
+	require.NoError(t, err)
+
+	got := receiver.events()
+	require.Len(t, got, 1)
+	assert.Equal(t, "1.0", got[0].DataVersion)
+	assert.Equal(t, "1", got[0].MetadataVersion)
+}

--- a/server/azure/eventgrid/domains.go
+++ b/server/azure/eventgrid/domains.go
@@ -172,6 +172,8 @@ func (h *Handler) serveDomainResource(w http.ResponseWriter, r *http.Request, rp
 	switch r.Method {
 	case http.MethodPut:
 		h.createOrUpdateDomain(w, r, rp)
+	case http.MethodPatch:
+		h.updateDomain(w, r, rp)
 	case http.MethodGet:
 		h.getDomain(w, rp)
 	case http.MethodDelete:
@@ -223,6 +225,54 @@ func (h *Handler) createOrUpdateDomain(w http.ResponseWriter, r *http.Request, r
 
 	// Domains.CreateOrUpdate accepts only 201; the terminal provisioningState
 	// completes the SDK's LRO poller on the first response.
+	azurearm.WriteJSON(w, http.StatusCreated, out)
+}
+
+// domainUpdateJSON is the Domains.Update (PATCH) request body: mutable tags plus
+// mutable properties (publicNetworkAccess). Input schema is immutable, matching
+// real Event Grid.
+type domainUpdateJSON struct {
+	Tags       map[string]*string `json:"tags,omitempty"`
+	Properties *struct {
+		PublicNetworkAccess string `json:"publicNetworkAccess,omitempty"`
+	} `json:"properties,omitempty"`
+}
+
+// updateDomain maps Domains.Update (PATCH) onto the wire-owned record: it merges
+// the supplied tags onto the existing tags and applies the mutable
+// publicNetworkAccess, preserving anything the caller omitted, and returns the
+// updated domain (200). 404 when the domain does not exist, before any write.
+func (h *Handler) updateDomain(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body domainUpdateJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.Lock()
+
+	rec := h.domains[key]
+	if rec == nil {
+		h.mu.Unlock()
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "domain not found")
+
+		return
+	}
+
+	if body.Tags != nil {
+		rec.tags = mergeTags(rec.tags, tagsFromPtr(body.Tags))
+	}
+
+	if body.Properties != nil && body.Properties.PublicNetworkAccess != "" {
+		rec.publicNetworkAccess = body.Properties.PublicNetworkAccess
+	}
+
+	out := rec.toJSON(rp)
+	h.mu.Unlock()
+
+	// 201 with a terminal provisioningState completes the SDK's Update LRO
+	// poller on the first response (the poller accepts 200 or 201).
 	azurearm.WriteJSON(w, http.StatusCreated, out)
 }
 

--- a/server/azure/eventgrid/event_subscriptions.go
+++ b/server/azure/eventgrid/event_subscriptions.go
@@ -175,6 +175,80 @@ func (h *Handler) createOrUpdateEventSubscription(w http.ResponseWriter, r *http
 	azurearm.WriteJSON(w, http.StatusCreated, toEventSubscriptionJSON(rp, rule))
 }
 
+// mergeRawProperties overlays the top-level keys of patch onto existing,
+// returning the merged properties JSON. Keys absent from patch are preserved
+// (partial-merge PATCH semantics — no nil-mask data loss); keys present in patch
+// replace their prior value. An empty patch leaves existing untouched. This
+// covers the EventSubscriptionUpdateParameters fields (destination, filter,
+// labels, deadLetterDestination, retryPolicy, eventDeliverySchema) without
+// enumerating them, and preserves any unknown fields the caller round-trips.
+func mergeRawProperties(existing, patch json.RawMessage) json.RawMessage {
+	if len(patch) == 0 {
+		return existing
+	}
+
+	base := map[string]json.RawMessage{}
+	if len(existing) > 0 {
+		_ = json.Unmarshal(existing, &base)
+	}
+
+	over := map[string]json.RawMessage{}
+	if err := json.Unmarshal(patch, &over); err != nil {
+		return existing
+	}
+
+	for k, v := range over {
+		base[k] = v
+	}
+
+	out, err := json.Marshal(base)
+	if err != nil {
+		return existing
+	}
+
+	return out
+}
+
+// updateEventSubscription maps TopicEventSubscriptions.Update (PATCH) onto the
+// rule model: it merges the supplied fields onto the stored properties,
+// preserving fields the caller omitted, and re-stores the subscription (200).
+// The SDK's EventSubscriptionUpdateParameters marshals its fields (destination,
+// filter, labels, deadLetterDestination, retryPolicy, eventDeliverySchema) at
+// the top level — no "properties" wrapper — matching the shape stored for the
+// subscription, so the whole body is merged. 404 when the subscription does not
+// exist, before any write.
+func (h *Handler) updateEventSubscription(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	existing, err := h.bus.GetRule(r.Context(), rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	var patch json.RawMessage
+	if !azurearm.DecodeJSON(w, r, &patch) {
+		return
+	}
+
+	merged := mergeRawProperties(json.RawMessage(existing.Description), patch)
+
+	cfg := &ebdriver.RuleConfig{
+		Name:        rp.SubResourceName,
+		EventBus:    rp.ResourceName,
+		Description: string(merged),
+		State:       existing.State,
+	}
+
+	rule, perr := h.bus.PutRule(r.Context(), cfg)
+	if perr != nil {
+		azurearm.WriteCErr(w, perr)
+		return
+	}
+
+	// The armeventgrid Update LRO poller accepts only 201 for event
+	// subscriptions; the terminal provisioningState completes it inline.
+	azurearm.WriteJSON(w, http.StatusCreated, toEventSubscriptionJSON(rp, rule))
+}
+
 func (h *Handler) getEventSubscription(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	rule, err := h.bus.GetRule(r.Context(), rp.ResourceName, rp.SubResourceName)
 	if err != nil {

--- a/server/azure/eventgrid/handler.go
+++ b/server/azure/eventgrid/handler.go
@@ -212,6 +212,8 @@ func (h *Handler) serveEventSubscription(w http.ResponseWriter, r *http.Request,
 	switch r.Method {
 	case http.MethodPut:
 		h.createOrUpdateEventSubscription(w, r, rp)
+	case http.MethodPatch:
+		h.updateEventSubscription(w, r, rp)
 	case http.MethodGet:
 		h.getEventSubscription(w, r, rp)
 	case http.MethodDelete:

--- a/server/azure/eventgrid/patch_sdk_test.go
+++ b/server/azure/eventgrid/patch_sdk_test.go
@@ -1,0 +1,325 @@
+package eventgrid_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+)
+
+// TestSDKTopicEventSubscriptionPatch drives TopicEventSubscriptions.BeginUpdate
+// (PATCH): the supplied field (filter) is updated while an omitted field
+// (destination) is preserved — no nil-mask data loss.
+func TestSDKTopicEventSubscriptionPatch(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	ctx := context.Background()
+
+	topics := cf.NewTopicsClient()
+	mkTopicLoc(t, topics, "orders", "eastus")
+
+	subs := cf.NewTopicEventSubscriptionsClient()
+
+	createPoller, err := subs.BeginCreateOrUpdate(ctx, testRG, "orders", "sub1", armeventgrid.EventSubscription{
+		Properties: &armeventgrid.EventSubscriptionProperties{
+			Destination: &armeventgrid.WebHookEventSubscriptionDestination{
+				EndpointType: to.Ptr(armeventgrid.EndpointTypeWebHook),
+				Properties: &armeventgrid.WebHookEventSubscriptionDestinationProperties{
+					EndpointURL: to.Ptr("https://example.test/hook"),
+				},
+			},
+			Filter: &armeventgrid.EventSubscriptionFilter{
+				SubjectBeginsWith: to.Ptr("orders/"),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+	if _, err = createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("create PollUntilDone: %v", err)
+	}
+
+	// PATCH only the filter; the destination is omitted and must survive.
+	upPoller, err := subs.BeginUpdate(ctx, testRG, "orders", "sub1", armeventgrid.EventSubscriptionUpdateParameters{
+		Filter: &armeventgrid.EventSubscriptionFilter{
+			SubjectBeginsWith: to.Ptr("invoices/"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate: %v", err)
+	}
+	if _, err = upPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("update PollUntilDone: %v", err)
+	}
+
+	got, err := subs.Get(ctx, testRG, "orders", "sub1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.Filter == nil ||
+		got.Properties.Filter.SubjectBeginsWith == nil ||
+		*got.Properties.Filter.SubjectBeginsWith != "invoices/" {
+		t.Fatalf("filter not updated by PATCH: %+v", got.Properties)
+	}
+
+	dest, ok := got.Properties.Destination.(*armeventgrid.WebHookEventSubscriptionDestination)
+	if !ok {
+		t.Fatalf("destination lost by PATCH (nil-mask): type = %T", got.Properties.Destination)
+	}
+	if dest.Properties == nil || dest.Properties.EndpointURL == nil ||
+		*dest.Properties.EndpointURL != "https://example.test/hook" {
+		t.Fatalf("destination not preserved by PATCH: %+v", dest.Properties)
+	}
+}
+
+// TestSDKTopicEventSubscriptionPatchMissing asserts a PATCH against a
+// non-existent subscription 404s before any write.
+func TestSDKTopicEventSubscriptionPatchMissing(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	ctx := context.Background()
+
+	topics := cf.NewTopicsClient()
+	mkTopicLoc(t, topics, "orders", "eastus")
+
+	subs := cf.NewTopicEventSubscriptionsClient()
+
+	poller, err := subs.BeginUpdate(ctx, testRG, "orders", "no-such-sub",
+		armeventgrid.EventSubscriptionUpdateParameters{
+			Filter: &armeventgrid.EventSubscriptionFilter{SubjectBeginsWith: to.Ptr("x/")},
+		}, nil)
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != http.StatusNotFound {
+		t.Fatalf("PATCH missing subscription: got %v, want 404", err)
+	}
+}
+
+// TestSDKScopedEventSubscriptionPatch drives EventSubscriptions.BeginUpdate
+// (PATCH) on an RG-scoped subscription: the supplied filter is updated while the
+// omitted destination is preserved (no nil-mask).
+func TestSDKScopedEventSubscriptionPatch(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	client := cf.NewEventSubscriptionsClient()
+	ctx := context.Background()
+
+	scope := "/subscriptions/" + testSub + "/resourceGroups/" + testRG
+
+	createPoller, err := client.BeginCreateOrUpdate(ctx, scope, "rg-sub", armeventgrid.EventSubscription{
+		Properties: &armeventgrid.EventSubscriptionProperties{
+			Destination: &armeventgrid.WebHookEventSubscriptionDestination{
+				EndpointType: to.Ptr(armeventgrid.EndpointTypeWebHook),
+				Properties: &armeventgrid.WebHookEventSubscriptionDestinationProperties{
+					EndpointURL: to.Ptr("https://example.test/hook"),
+				},
+			},
+			Filter: &armeventgrid.EventSubscriptionFilter{
+				SubjectBeginsWith: to.Ptr("orders/"),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+	if _, err = createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("create PollUntilDone: %v", err)
+	}
+
+	upPoller, err := client.BeginUpdate(ctx, scope, "rg-sub", armeventgrid.EventSubscriptionUpdateParameters{
+		Filter: &armeventgrid.EventSubscriptionFilter{SubjectBeginsWith: to.Ptr("invoices/")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate: %v", err)
+	}
+	if _, err = upPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("update PollUntilDone: %v", err)
+	}
+
+	got, err := client.Get(ctx, scope, "rg-sub", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.Filter == nil ||
+		got.Properties.Filter.SubjectBeginsWith == nil ||
+		*got.Properties.Filter.SubjectBeginsWith != "invoices/" {
+		t.Fatalf("filter not updated by PATCH: %+v", got.Properties)
+	}
+
+	if _, ok := got.Properties.Destination.(*armeventgrid.WebHookEventSubscriptionDestination); !ok {
+		t.Fatalf("destination lost by PATCH (nil-mask): type = %T", got.Properties.Destination)
+	}
+}
+
+// TestSDKSystemTopicPatch drives SystemTopics.BeginUpdate (PATCH): the supplied
+// tag is merged while the pre-existing tag is preserved.
+func TestSDKSystemTopicPatch(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	st := cf.NewSystemTopicsClient()
+	ctx := context.Background()
+
+	poller, err := st.BeginCreateOrUpdate(ctx, testRG, "storage-events", armeventgrid.SystemTopic{
+		Location: to.Ptr("global"),
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+		Properties: &armeventgrid.SystemTopicProperties{
+			Source:    to.Ptr("/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Storage/storageAccounts/a"),
+			TopicType: to.Ptr("Microsoft.Storage.StorageAccounts"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+	if _, err = poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("create PollUntilDone: %v", err)
+	}
+
+	upPoller, err := st.BeginUpdate(ctx, testRG, "storage-events", armeventgrid.SystemTopicUpdateParameters{
+		Tags: map[string]*string{"team": to.Ptr("a")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate: %v", err)
+	}
+	if _, err = upPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("update PollUntilDone: %v", err)
+	}
+
+	got, err := st.Get(ctx, testRG, "storage-events", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Tags["team"] == nil || *got.Tags["team"] != "a" {
+		t.Fatalf("PATCH did not apply supplied tag: %+v", got.Tags)
+	}
+	if got.Tags["env"] == nil || *got.Tags["env"] != "test" {
+		t.Fatalf("PATCH masked pre-existing tag (nil-mask): %+v", got.Tags)
+	}
+}
+
+// TestSDKDomainPatch drives Domains.BeginUpdate (PATCH): publicNetworkAccess is
+// updated and a supplied tag is merged, while the immutable inputSchema and the
+// pre-existing tag are preserved.
+func TestSDKDomainPatch(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	dc := cf.NewDomainsClient()
+	ctx := context.Background()
+
+	poller, err := dc.BeginCreateOrUpdate(ctx, testRG, "dom1", armeventgrid.Domain{
+		Location: to.Ptr("global"),
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+		Properties: &armeventgrid.DomainProperties{
+			PublicNetworkAccess: to.Ptr(armeventgrid.PublicNetworkAccessEnabled),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+	if _, err = poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("create PollUntilDone: %v", err)
+	}
+
+	upPoller, err := dc.BeginUpdate(ctx, testRG, "dom1", armeventgrid.DomainUpdateParameters{
+		Tags: map[string]*string{"team": to.Ptr("a")},
+		Properties: &armeventgrid.DomainUpdateParameterProperties{
+			PublicNetworkAccess: to.Ptr(armeventgrid.PublicNetworkAccessDisabled),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate: %v", err)
+	}
+	if _, err = upPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("update PollUntilDone: %v", err)
+	}
+
+	got, err := dc.Get(ctx, testRG, "dom1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.PublicNetworkAccess == nil ||
+		*got.Properties.PublicNetworkAccess != armeventgrid.PublicNetworkAccessDisabled {
+		t.Fatalf("PATCH did not update publicNetworkAccess: %+v", got.Properties)
+	}
+	if got.Properties.InputSchema == nil || *got.Properties.InputSchema != armeventgrid.InputSchemaEventGridSchema {
+		t.Fatalf("PATCH lost immutable inputSchema: %+v", got.Properties)
+	}
+	if got.Tags["team"] == nil || *got.Tags["team"] != "a" {
+		t.Fatalf("PATCH did not apply supplied tag: %+v", got.Tags)
+	}
+	if got.Tags["env"] == nil || *got.Tags["env"] != "test" {
+		t.Fatalf("PATCH masked pre-existing tag (nil-mask): %+v", got.Tags)
+	}
+}
+
+// TestSDKPublishPreservesIDAndDataVersion locks the data-plane fixes end-to-end:
+// a publish carrying an explicit id and dataVersion delivers them verbatim, with
+// metadataVersion stamped "1".
+func TestSDKPublishPreservesIDAndDataVersion(t *testing.T) {
+	cf, ts := newEGFactory(t)
+	ctx := context.Background()
+
+	topics := cf.NewTopicsClient()
+	mkTopicLoc(t, topics, "orders", "eastus")
+
+	receiver := newLiveWebhookReceiver(t)
+
+	subs := cf.NewTopicEventSubscriptionsClient()
+	poller, err := subs.BeginCreateOrUpdate(ctx, testRG, "orders", "sub1", armeventgrid.EventSubscription{
+		Properties: &armeventgrid.EventSubscriptionProperties{
+			Destination: &armeventgrid.WebHookEventSubscriptionDestination{
+				EndpointType: to.Ptr(armeventgrid.EndpointTypeWebHook),
+				Properties: &armeventgrid.WebHookEventSubscriptionDestinationProperties{
+					EndpointURL: to.Ptr(receiver.URL),
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("subscription BeginCreateOrUpdate: %v", err)
+	}
+	if _, err = poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("subscription PollUntilDone: %v", err)
+	}
+
+	body := `[{"id":"e1","subject":"orders/1","eventType":"Order.Created",` +
+		`"eventTime":"2024-01-02T03:04:05Z","data":{"total":42},"dataVersion":"2.0"}]`
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/api/events", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("new publish request: %v", err)
+	}
+	req.Host = "orders.eastus-1.eventgrid.azure.net"
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // test cleanup
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("publish status = %d, want 200", resp.StatusCode)
+	}
+
+	got := receiver.all()
+	if len(got) != 1 {
+		t.Fatalf("webhook received %d events, want 1: %+v", len(got), got)
+	}
+	if got[0]["id"] != "e1" {
+		t.Fatalf("delivered id = %v, want e1", got[0]["id"])
+	}
+	if got[0]["dataVersion"] != "2.0" {
+		t.Fatalf("delivered dataVersion = %v, want 2.0", got[0]["dataVersion"])
+	}
+	if got[0]["metadataVersion"] != "1" {
+		t.Fatalf("delivered metadataVersion = %v, want 1", got[0]["metadataVersion"])
+	}
+}

--- a/server/azure/eventgrid/publish.go
+++ b/server/azure/eventgrid/publish.go
@@ -90,13 +90,14 @@ func (h *PublishHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	drvEvents := make([]ebdriver.Event, 0, len(events))
 	for i := range events {
 		drvEvents = append(drvEvents, ebdriver.Event{
-			ID:         events[i].ID,
-			Source:     topic,
-			DetailType: events[i].EventType,
-			Detail:     string(events[i].Data),
-			Time:       parseEventTime(events[i].EventTime),
-			EventBus:   topic,
-			Subject:    events[i].Subject,
+			ID:          events[i].ID,
+			Source:      topic,
+			DetailType:  events[i].EventType,
+			Detail:      string(events[i].Data),
+			Time:        parseEventTime(events[i].EventTime),
+			EventBus:    topic,
+			Subject:     events[i].Subject,
+			DataVersion: events[i].DataVersion,
 		})
 	}
 

--- a/server/azure/eventgrid/scoped_subscriptions.go
+++ b/server/azure/eventgrid/scoped_subscriptions.go
@@ -142,6 +142,8 @@ func (h *Handler) serveScopedEventSubscription(w http.ResponseWriter, r *http.Re
 	switch r.Method {
 	case http.MethodPut:
 		h.putScopedEventSubscription(w, r, sp)
+	case http.MethodPatch:
+		h.patchScopedEventSubscription(w, r, sp)
 	case http.MethodGet:
 		h.getScopedEventSubscription(w, sp)
 	case http.MethodDelete:
@@ -173,6 +175,36 @@ func (h *Handler) putScopedEventSubscription(w http.ResponseWriter, r *http.Requ
 	h.mu.Unlock()
 
 	azurearm.WriteJSON(w, http.StatusCreated, toScopedSubJSON(rec))
+}
+
+// patchScopedEventSubscription maps EventSubscriptions.Update (PATCH) onto a
+// wire-owned scope-bound subscription: it merges the supplied properties onto
+// the stored ones, preserving fields the caller omitted, and returns the updated
+// subscription (200). 404 when the subscription does not exist, before any write.
+func (h *Handler) patchScopedEventSubscription(w http.ResponseWriter, r *http.Request, sp *scopedSubPath) {
+	var patch json.RawMessage
+	if !azurearm.DecodeJSON(w, r, &patch) {
+		return
+	}
+
+	h.mu.Lock()
+
+	rec, ok := h.scopedSubs[scopedSubKey(sp.scope, sp.name)]
+	if !ok {
+		h.mu.Unlock()
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "event subscription not found")
+
+		return
+	}
+
+	rec.properties = mergeRawProperties(rec.properties, patch)
+
+	out := toScopedSubJSON(rec)
+	h.mu.Unlock()
+
+	// The armeventgrid EventSubscriptions Update LRO poller accepts only 201;
+	// the enriched terminal provisioningState completes it inline.
+	azurearm.WriteJSON(w, http.StatusCreated, out)
 }
 
 func (h *Handler) getScopedEventSubscription(w http.ResponseWriter, sp *scopedSubPath) {

--- a/server/azure/eventgrid/system_topics.go
+++ b/server/azure/eventgrid/system_topics.go
@@ -106,6 +106,8 @@ func (h *Handler) serveSystemTopicResource(w http.ResponseWriter, r *http.Reques
 	switch r.Method {
 	case http.MethodPut:
 		h.createOrUpdateSystemTopic(w, r, rp)
+	case http.MethodPatch:
+		h.updateSystemTopic(w, r, rp)
 	case http.MethodGet:
 		h.getSystemTopic(w, rp)
 	case http.MethodDelete:
@@ -154,6 +156,46 @@ func (h *Handler) createOrUpdateSystemTopic(w http.ResponseWriter, r *http.Reque
 
 	// 201 with a terminal provisioningState completes the SDK's LRO poller on
 	// the first response.
+	azurearm.WriteJSON(w, http.StatusCreated, out)
+}
+
+// systemTopicUpdateJSON is the SystemTopics.Update (PATCH) request body: mutable
+// tags. Identity and source are not changed here.
+type systemTopicUpdateJSON struct {
+	Tags map[string]*string `json:"tags,omitempty"`
+}
+
+// updateSystemTopic maps SystemTopics.Update (PATCH) onto the wire-owned record:
+// it merges the supplied tags onto the existing tags, preserving any the caller
+// omitted, and returns the updated system topic (200). 404 when the system topic
+// does not exist, before any write.
+func (h *Handler) updateSystemTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body systemTopicUpdateJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+
+	h.mu.Lock()
+
+	rec := h.systemTopics[key]
+	if rec == nil {
+		h.mu.Unlock()
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "system topic not found")
+
+		return
+	}
+
+	if body.Tags != nil {
+		rec.tags = mergeTags(rec.tags, tagsFromPtr(body.Tags))
+	}
+
+	out := rec.toJSON(rp)
+	h.mu.Unlock()
+
+	// 201 with a terminal provisioningState completes the SDK's Update LRO
+	// poller on the first response (the poller accepts 200 or 201).
 	azurearm.WriteJSON(w, http.StatusCreated, out)
 }
 

--- a/services/eventbus/driver/driver.go
+++ b/services/eventbus/driver/driver.go
@@ -127,6 +127,11 @@ type Event struct {
 	// concept, e.g. "/blobServices/default/containers/x"). Empty for AWS
 	// and GCP.
 	Subject string
+	// DataVersion is the publisher-supplied schema version of Detail (Azure
+	// Event Grid's dataVersion). Preserved end-to-end so subscribers see the
+	// version the publisher declared. Empty for AWS and GCP, and for an Azure
+	// publisher that omitted it (delivery then defaults it to "1.0").
+	DataVersion string
 }
 
 // PublishResult is the result of publishing events.


### PR DESCRIPTION
## What

Fixes three real-cloud-parity gaps in Azure Event Grid found by a confirming audit:

1. **Publisher event `id` was discarded.** `PutEvents` regenerated the event id unconditionally, clobbering the publisher-supplied id that the publish path correctly carried in. Real Event Grid preserves the publisher `id` end-to-end (subscribers dedup on it). Now the id is only synthesized when the publisher omits it.

2. **Publisher `dataVersion` was dropped and `metadataVersion` never set.** The shared `driver.Event` had no `DataVersion`, so the wire `dataVersion` was lost and delivery hardcoded `"1.0"` with an empty `metadataVersion`. Added `DataVersion` to `driver.Event` (additive; Event Grid is the only setter — AWS EventBridge / GCP Eventarc unaffected), threaded it publish -> delivery, and delivery now emits the publisher's `dataVersion` (defaulting to `"1.0"` only when omitted) with `metadataVersion: "1"`.

3. **PATCH (`BeginUpdate`) returned 405** on event subscriptions (topic-scoped and scope-bound), system topics, and domains. `az eventgrid event-subscription update` / SDK `BeginUpdate` send PATCH. Added a PATCH arm to each doing a partial merge (omitted fields preserved — no nil-mask data loss), mirroring the existing topic PATCH. Subscription PATCH merges destination/filter/labels/etc. via a top-level key merge on the round-tripped properties; system-topic/domain PATCH merge tags and mutable properties. 404 on a missing resource before any write. Responses return 201 to satisfy the armeventgrid Update LRO pollers.

## Why

Unmodified apps, CLIs, IaC (Terraform `azurerm_eventgrid_event_subscription` updates), and SDK `BeginUpdate` calls now behave like real Event Grid: publisher ids and data versions survive delivery, and updates no longer 405.

## Tests

Real `armeventgrid` SDK + data-plane publish over `httptest`:
- publisher id `e1` preserved on delivery + in `GetEventHistory`; no-id publish gets a synthesized id
- `dataVersion "2.0"` preserved on delivery + `metadataVersion "1"` (and `"1.0"` default when omitted)
- PATCH on topic + scope-bound event subscriptions updates the supplied field and preserves the omitted one (no nil-mask); 404 on missing
- system topic + domain PATCH merge tags / mutable properties and preserve immutable/pre-existing values
