### PR TITLE
fix(azure-acr): PutImage unions tags on same-digest re-push; regenerateCredential requires admin user

### DIFF
--- a/providers/azure/acr/acr.go
+++ b/providers/azure/acr/acr.go
@@ -203,11 +203,22 @@ func (m *Mock) PutImage(_ context.Context, manifest *driver.ImageManifest) (*dri
 	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
 	mediaType := resolveMediaType(manifest.MediaType)
 
+	tags := []string{}
+	if manifest.Tag != "" {
+		tags = append(tags, manifest.Tag)
+	}
+
+	// Content-addressing parity: re-pushing the same digest under a new tag must
+	// preserve the pre-existing tags on that manifest rather than clobbering them.
+	if existing, ok := rd.images.Get(digest); ok {
+		tags = unionTags(existing.detail.Tags, manifest.Tag)
+	}
+
 	detail := driver.ImageDetail{
 		RegistryID: registryName,
 		Repository: manifest.Repository,
 		Digest:     digest,
-		Tags:       []string{manifest.Tag},
+		Tags:       tags,
 		SizeBytes:  manifest.SizeBytes,
 		PushedAt:   now,
 		MediaType:  mediaType,
@@ -711,6 +722,19 @@ func removeTag(tags []string, tag string) []string {
 		if t != tag {
 			result = append(result, t)
 		}
+	}
+
+	return result
+}
+
+// unionTags returns existing tags with tag appended if not already present,
+// preserving order and de-duplicating.
+func unionTags(existing []string, tag string) []string {
+	result := make([]string, len(existing))
+	copy(result, existing)
+
+	if tag != "" && !hasTag(result, tag) {
+		result = append(result, tag)
 	}
 
 	return result

--- a/providers/azure/acr/acr_test.go
+++ b/providers/azure/acr/acr_test.go
@@ -282,6 +282,47 @@ func TestGetImage(t *testing.T) {
 	})
 }
 
+func TestPutImageSameDigestUnionsTags(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+
+	const digest = "sha256:AAA"
+
+	_, err := m.PutImage(ctx, &driver.ImageManifest{
+		Repository: "my-repo",
+		Tag:        "v1",
+		Digest:     digest,
+		SizeBytes:  1024,
+	})
+	require.NoError(t, err)
+
+	// Re-push the identical content under a new tag; v1 must survive.
+	_, err = m.PutImage(ctx, &driver.ImageManifest{
+		Repository: "my-repo",
+		Tag:        "latest",
+		Digest:     digest,
+		SizeBytes:  1024,
+	})
+	require.NoError(t, err)
+
+	byV1, err := m.GetImage(ctx, "my-repo", "v1")
+	require.NoError(t, err)
+	assert.Equal(t, digest, byV1.Digest)
+
+	byLatest, err := m.GetImage(ctx, "my-repo", "latest")
+	require.NoError(t, err)
+	assert.Equal(t, digest, byLatest.Digest)
+
+	assert.ElementsMatch(t, []string{"v1", "latest"}, byLatest.Tags)
+
+	// Single manifest, both tags on it.
+	images, err := m.ListImages(ctx, "my-repo")
+	require.NoError(t, err)
+	assert.Len(t, images, 1)
+}
+
 func TestListImages(t *testing.T) {
 	m, _ := newTestMock()
 	ctx := context.Background()

--- a/providers/azure/acr/registry.go
+++ b/providers/azure/acr/registry.go
@@ -286,6 +286,12 @@ func (m *Mock) RegenerateRegistryCredential(
 		return nil, errors.Newf(errors.NotFound, "registry %q not found in resource group %q", name, rg)
 	}
 
+	if !rd.reg.AdminUserEnabled {
+		return nil, errors.Newf(
+			errors.FailedPrecondition, "admin user is not enabled for registry %q", name,
+		)
+	}
+
 	seed := fmt.Sprintf("%s/%s/%d", rg, name, m.opts.Clock.Now().UnixNano())
 
 	switch passwordName {

--- a/providers/azure/acr/registry_test.go
+++ b/providers/azure/acr/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -117,6 +118,31 @@ func TestRegenerateRegistryCredential(t *testing.T) {
 
 	_, err = m.RegenerateRegistryCredential(ctx, "rg-1", "reg", "bogus")
 	require.Error(t, err)
+}
+
+func TestRegenerateRegistryCredentialRequiresAdmin(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, _, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "noadmin", driver.AzureRegistryConfig{})
+	require.NoError(t, err)
+
+	// Admin user disabled: regenerating a credential is a failed precondition.
+	_, err = m.RegenerateRegistryCredential(ctx, "rg-1", "noadmin", "password")
+	require.Error(t, err)
+	assert.True(t, errors.IsFailedPrecondition(err))
+
+	// Enable admin, then regeneration rotates the password.
+	enabled := true
+	_, err = m.UpdateRegistry(ctx, "rg-1", "noadmin", driver.AzureRegistryUpdate{AdminUserEnabled: &enabled})
+	require.NoError(t, err)
+
+	before, err := m.ListRegistryCredentials(ctx, "rg-1", "noadmin")
+	require.NoError(t, err)
+
+	after, err := m.RegenerateRegistryCredential(ctx, "rg-1", "noadmin", "password")
+	require.NoError(t, err)
+	assert.NotEqual(t, before.Password, after.Password)
 }
 
 func TestDeleteTagKeepsManifest(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes two Azure ACR parity bugs found in a confirming audit, both scoped to `providers/azure/acr/`.

### BUG1 [MED] — PutImage clobbered existing tags on same-digest re-push
`PutImage` built a fresh single-tag `ImageDetail` and `Set` it for the digest, discarding any tags already on that manifest. Pushing `sha256:AAA` as `v1`, then the same content as `latest`, lost `v1` (GetImage `v1` -> 404). Content-addressing parity broke because a manifest can carry multiple tags.

Fix: when the digest already exists, union the incoming tag into the existing tag set (dedup, order-preserving) instead of replacing it with a single-tag detail. New `unionTags` helper.

### BUG2 [LOW] — RegenerateRegistryCredential didn't require admin user
`ListRegistryCredentials` gates on `AdminUserEnabled` (FailedPrecondition when disabled) but `RegenerateRegistryCredential` did not. Added the same guard so credential rotation requires the admin user to be enabled, matching real ACR.

## Tests
- Same-digest re-push under a second tag: both `v1` and `latest` resolve to the one manifest, tags == {v1, latest}, single image in the repo.
- Regenerate with admin disabled -> FailedPrecondition; after enabling -> password rotates.

## Gates
- `go build ./...`, `go vet`, `gofmt` clean
- `go test -p=3 ./providers/azure/acr/... ./server/azure/acr/...` pass
- `go generate ./...` + `go run ./internal/compatgen` produce zero diff
- `golangci-lint --new-from-rev=origin/development ./providers/azure/acr/...` 0 new issues