### PR TITLE
fix(gcp-pubsub): round-trip topic fields + enableExactlyOnceDelivery, support subscriptions:detach, validate topic/ackDeadline

### DIFF
--- a/server/gcp/pubsub/handler.go
+++ b/server/gcp/pubsub/handler.go
@@ -195,12 +195,14 @@ func (h *Handler) createTopic(w http.ResponseWriter, r *http.Request, project, n
 	ts := h.topicLog(name)
 	ts.labels = copyLabels(info.Tags)
 	ts.labelsSet = true
+	ts.msgRetentionDuration = body.MessageRetentionDuration
+	ts.schemaSettings = body.SchemaSettings
+	ts.kmsKeyName = body.KmsKeyName
+	ts.messageStoragePolicy = body.MessageStoragePolicy
+	ts.satisfiesPzs = body.SatisfiesPzs
 	h.mu.Unlock()
 
-	writeJSON(w, http.StatusOK, topic{
-		Name:   topicName(project, info.Name),
-		Labels: info.Tags,
-	})
+	writeJSON(w, http.StatusOK, h.topicView(project, name, info.Tags))
 }
 
 func (h *Handler) getTopic(w http.ResponseWriter, r *http.Request, project, name string) {
@@ -210,10 +212,7 @@ func (h *Handler) getTopic(w http.ResponseWriter, r *http.Request, project, name
 		return
 	}
 
-	writeJSON(w, http.StatusOK, topic{
-		Name:   topicName(project, q.Name),
-		Labels: h.topicLabels(name, q.Tags),
-	})
+	writeJSON(w, http.StatusOK, h.topicView(project, q.Name, q.Tags))
 }
 
 // patchTopic applies topics.patch: only the fields named by updateMask are
@@ -245,15 +244,22 @@ func (h *Handler) patchTopic(w http.ResponseWriter, r *http.Request, project, na
 	}
 
 	for _, m := range masks {
-		if m == "labels" {
+		switch m {
+		case "labels":
 			ts.labels = copyLabels(req.Topic.Labels)
+		case "messageRetentionDuration":
+			ts.msgRetentionDuration = req.Topic.MessageRetentionDuration
+		case "schemaSettings":
+			ts.schemaSettings = req.Topic.SchemaSettings
+		case "kmsKeyName":
+			ts.kmsKeyName = req.Topic.KmsKeyName
+		case "messageStoragePolicy":
+			ts.messageStoragePolicy = req.Topic.MessageStoragePolicy
 		}
 	}
-
-	labels := ts.labels
 	h.mu.Unlock()
 
-	writeJSON(w, http.StatusOK, topic{Name: topicName(project, name), Labels: labels})
+	writeJSON(w, http.StatusOK, h.topicView(project, name, q.Tags))
 }
 
 func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request, name string) {
@@ -291,10 +297,7 @@ func (h *Handler) listTopics(w http.ResponseWriter, r *http.Request, project str
 
 	items := make([]topic, 0, len(queues))
 	for i := range queues {
-		items = append(items, topic{
-			Name:   topicName(project, queues[i].Name),
-			Labels: h.topicLabels(queues[i].Name, queues[i].Tags),
-		})
+		items = append(items, h.topicView(project, queues[i].Name, queues[i].Tags))
 	}
 
 	page, err := pagination.PaginateSorted(items, func(a, b topic) bool { return a.Name < b.Name },
@@ -371,17 +374,31 @@ func snapshotName(project, name string) string {
 	return "projects/" + project + "/snapshots/" + name
 }
 
-// topicLabels returns a topic's effective labels: the handler-side override
-// (set on create/patch) when present, otherwise the messagequeue driver's tags.
-func (h *Handler) topicLabels(name string, fallback map[string]string) map[string]string {
+// topicView builds a topic response: name plus the effective labels (the
+// handler-side override set on create/patch when present, otherwise the
+// messagequeue driver's tags) and the extended fields persisted on create/patch.
+func (h *Handler) topicView(project, name string, fallbackTags map[string]string) topic {
+	t := topic{Name: topicName(project, name), Labels: fallbackTags}
+
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
-	if ts, ok := h.topics[name]; ok && ts.labelsSet {
-		return ts.labels
+	ts, ok := h.topics[name]
+	if !ok {
+		return t
 	}
 
-	return fallback
+	if ts.labelsSet {
+		t.Labels = ts.labels
+	}
+
+	t.MessageRetentionDuration = ts.msgRetentionDuration
+	t.SchemaSettings = ts.schemaSettings
+	t.KmsKeyName = ts.kmsKeyName
+	t.MessageStoragePolicy = ts.messageStoragePolicy
+	t.SatisfiesPzs = ts.satisfiesPzs
+
+	return t
 }
 
 // parseMask splits a comma-separated updateMask into trimmed, non-empty paths.

--- a/server/gcp/pubsub/model.go
+++ b/server/gcp/pubsub/model.go
@@ -45,6 +45,14 @@ type topicState struct {
 	// "no override, fall back to the driver's tags".
 	labels    map[string]string
 	labelsSet bool
+
+	// Extended topic config the SQS-style driver cannot express, persisted here so
+	// create/patch round-trip on subsequent Get/List.
+	msgRetentionDuration string
+	schemaSettings       json.RawMessage
+	kmsKeyName           string
+	messageStoragePolicy json.RawMessage
+	satisfiesPzs         bool
 }
 
 // lease is an outstanding (delivered, not-yet-acked) message on a subscription.

--- a/server/gcp/pubsub/sdk_config_test.go
+++ b/server/gcp/pubsub/sdk_config_test.go
@@ -1,0 +1,188 @@
+package pubsub_test
+
+import (
+	"context"
+	"testing"
+
+	pubsubv1 "google.golang.org/api/pubsub/v1"
+)
+
+// TestSDKPubSubTopicFieldsRoundTrip guards that extended topic fields
+// (messageRetentionDuration, schemaSettings) round-trip through create and Get,
+// rather than being silently dropped.
+func TestSDKPubSubTopicFieldsRoundTrip(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	const name = "projects/demo/topics/cfg"
+
+	created, err := svc.Projects.Topics.Create(name, &pubsubv1.Topic{
+		MessageRetentionDuration: "604800s",
+		SchemaSettings: &pubsubv1.SchemaSettings{
+			Schema:   "projects/demo/schemas/s1",
+			Encoding: "JSON",
+		},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if created.MessageRetentionDuration != "604800s" {
+		t.Errorf("create messageRetentionDuration=%q, want 604800s", created.MessageRetentionDuration)
+	}
+
+	got, err := svc.Projects.Topics.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.MessageRetentionDuration != "604800s" {
+		t.Errorf("get messageRetentionDuration=%q, want 604800s", got.MessageRetentionDuration)
+	}
+
+	if got.SchemaSettings == nil || got.SchemaSettings.Schema != "projects/demo/schemas/s1" {
+		t.Fatalf("get schemaSettings=%+v, want schema projects/demo/schemas/s1", got.SchemaSettings)
+	}
+
+	if got.SchemaSettings.Encoding != "JSON" {
+		t.Errorf("get schemaSettings.Encoding=%q, want JSON", got.SchemaSettings.Encoding)
+	}
+}
+
+// TestSDKPubSubTopicPatchUpdateMask guards that topics.patch honors updateMask:
+// only the masked field is updated; unmasked fields are left unchanged.
+func TestSDKPubSubTopicPatchUpdateMask(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	const name = "projects/demo/topics/patchcfg"
+
+	if _, err := svc.Projects.Topics.Create(name, &pubsubv1.Topic{
+		MessageRetentionDuration: "3600s",
+		Labels:                   map[string]string{"team": "core"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if _, err := svc.Projects.Topics.Patch(name, &pubsubv1.UpdateTopicRequest{
+		Topic: &pubsubv1.Topic{
+			MessageRetentionDuration: "7200s",
+			Labels:                   map[string]string{"team": "changed"},
+		},
+		UpdateMask: "messageRetentionDuration",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got, err := svc.Projects.Topics.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.MessageRetentionDuration != "7200s" {
+		t.Errorf("messageRetentionDuration=%q, want 7200s (masked, updated)", got.MessageRetentionDuration)
+	}
+
+	if got.Labels["team"] != "core" {
+		t.Errorf("labels[team]=%q, want core (not in mask, must be unchanged)", got.Labels["team"])
+	}
+}
+
+// TestSDKPubSubExactlyOnceRoundTrip guards that enableExactlyOnceDelivery
+// round-trips through subscription create and patch.
+func TestSDKPubSubExactlyOnceRoundTrip(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/eos")
+	mustSub(t, svc, "projects/demo/subscriptions/eos", &pubsubv1.Subscription{
+		Topic:                     "projects/demo/topics/eos",
+		EnableExactlyOnceDelivery: true,
+	})
+
+	got, err := svc.Projects.Subscriptions.Get("projects/demo/subscriptions/eos").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if !got.EnableExactlyOnceDelivery {
+		t.Fatal("create: enableExactlyOnceDelivery=false, want true")
+	}
+
+	if _, err := svc.Projects.Subscriptions.Patch("projects/demo/subscriptions/eos",
+		&pubsubv1.UpdateSubscriptionRequest{
+			Subscription: &pubsubv1.Subscription{EnableExactlyOnceDelivery: false, ForceSendFields: []string{"EnableExactlyOnceDelivery"}},
+			UpdateMask:   "enableExactlyOnceDelivery",
+		}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got, err = svc.Projects.Subscriptions.Get("projects/demo/subscriptions/eos").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if got.EnableExactlyOnceDelivery {
+		t.Error("patch: enableExactlyOnceDelivery=true, want false after masked patch")
+	}
+}
+
+// TestSDKPubSubDetach guards subscriptions:detach: it returns 200 and marks the
+// subscription detached.
+func TestSDKPubSubDetach(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/dtch")
+	mustSub(t, svc, "projects/demo/subscriptions/dtch",
+		&pubsubv1.Subscription{Topic: "projects/demo/topics/dtch"})
+
+	if _, err := svc.Projects.Subscriptions.Detach("projects/demo/subscriptions/dtch").Context(ctx).Do(); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+
+	got, err := svc.Projects.Subscriptions.Get("projects/demo/subscriptions/dtch").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if !got.Detached {
+		t.Fatal("detached=false, want true after Detach")
+	}
+}
+
+// TestSDKPubSubCreateSubEmptyTopic guards that a subscription create without a
+// topic is rejected with 400 INVALID_ARGUMENT.
+func TestSDKPubSubCreateSubEmptyTopic(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Subscriptions.Create("projects/demo/subscriptions/notopic",
+		&pubsubv1.Subscription{}).Context(ctx).Do(); err == nil {
+		t.Fatal("create with empty topic returned nil error, want 400 INVALID_ARGUMENT")
+	}
+}
+
+// TestSDKPubSubAckDeadlineRange guards that ackDeadlineSeconds outside the valid
+// 10..600 range is rejected on create, and an in-range value is accepted.
+func TestSDKPubSubAckDeadlineRange(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/adl")
+
+	for _, bad := range []int64{5, 5000} {
+		_, err := svc.Projects.Subscriptions.Create("projects/demo/subscriptions/adl-bad",
+			&pubsubv1.Subscription{Topic: "projects/demo/topics/adl", AckDeadlineSeconds: bad}).
+			Context(ctx).Do()
+		if err == nil {
+			t.Fatalf("create with ackDeadlineSeconds=%d returned nil error, want 400", bad)
+		}
+	}
+
+	if _, err := svc.Projects.Subscriptions.Create("projects/demo/subscriptions/adl-ok",
+		&pubsubv1.Subscription{Topic: "projects/demo/topics/adl", AckDeadlineSeconds: 60}).
+		Context(ctx).Do(); err != nil {
+		t.Fatalf("create with ackDeadlineSeconds=60: %v", err)
+	}
+}

--- a/server/gcp/pubsub/subscription.go
+++ b/server/gcp/pubsub/subscription.go
@@ -44,6 +44,8 @@ func (h *Handler) serveSubscriptionVerb(w http.ResponseWriter, r *http.Request, 
 		h.modifyPushConfig(w, r, name)
 	case "seek":
 		h.seek(w, r, name)
+	case "detach":
+		h.detachSubscription(w, r, name)
 	case verbGetIamPolicy, verbSetIamPolicy, verbTestIamPermissions:
 		h.serveIam(w, r, resSubscriptions, name, action)
 	default:
@@ -59,10 +61,12 @@ func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, pro
 		return
 	}
 
-	topicShort := shortName(body.Topic)
-	if topicShort == "" {
-		topicShort = name
+	if body.Topic == "" {
+		writeError(w, http.StatusBadRequest, reasonInvalidArgument, "topic must be specified")
+		return
 	}
+
+	topicShort := shortName(body.Topic)
 
 	if _, err := h.findQueueByName(r, topicShort); err != nil {
 		writeErr(w, err)
@@ -71,6 +75,9 @@ func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, pro
 
 	if body.AckDeadlineSeconds == 0 {
 		body.AckDeadlineSeconds = defaultAckDeadlineSeconds
+	} else if !validAckDeadline(body.AckDeadlineSeconds) {
+		writeError(w, http.StatusBadRequest, reasonInvalidArgument, ackDeadlineRangeMsg)
+		return
 	}
 
 	filter, err := parseFilter(body.Filter)
@@ -144,6 +151,10 @@ func applySubMask(dst, src *subscription, masks []string) error {
 		switch m {
 		case "filter", "topic", "name":
 			return cerrors.Newf(cerrors.InvalidArgument, "field %q is immutable and cannot be updated", m)
+		case "ackDeadlineSeconds":
+			if !validAckDeadline(src.AckDeadlineSeconds) {
+				return cerrors.New(cerrors.InvalidArgument, ackDeadlineRangeMsg)
+			}
 		}
 
 		if set, ok := setters[m]; ok {
@@ -152,6 +163,18 @@ func applySubMask(dst, src *subscription, masks []string) error {
 	}
 
 	return nil
+}
+
+const (
+	minAckDeadlineSeconds = 10
+	maxAckDeadlineSeconds = 600
+	ackDeadlineRangeMsg   = "ackDeadlineSeconds must be between 10 and 600"
+)
+
+// validAckDeadline reports whether s is within Pub/Sub's allowed ack-deadline
+// range (10..600 seconds inclusive).
+func validAckDeadline(s int) bool {
+	return s >= minAckDeadlineSeconds && s <= maxAckDeadlineSeconds
 }
 
 // subMaskSetters maps a subscriptions.patch field-mask path to the merge that
@@ -168,6 +191,9 @@ func subMaskSetters() map[string]func(dst, src *subscription) {
 		"retainAckedMessages":      func(d, s *subscription) { d.RetainAckedMessages = s.RetainAckedMessages },
 		"enableMessageOrdering":    func(d, s *subscription) { d.EnableMessageOrdering = s.EnableMessageOrdering },
 		"detached":                 func(d, s *subscription) { d.Detached = s.Detached },
+		"enableExactlyOnceDelivery": func(d, s *subscription) {
+			d.EnableExactlyOnceDelivery = s.EnableExactlyOnceDelivery
+		},
 	}
 }
 
@@ -193,6 +219,31 @@ func (h *Handler) deleteSubscription(w http.ResponseWriter, name string) {
 	h.mu.Lock()
 	_, ok := h.subs[name]
 	delete(h.subs, name)
+	h.mu.Unlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, reasonNotFound, "subscription "+name+" not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+// detachSubscription applies subscriptions.detach: it marks the subscription
+// detached (it stops receiving messages) and returns an empty body, matching the
+// real DetachSubscriptionResponse.
+func (h *Handler) detachSubscription(w http.ResponseWriter, r *http.Request, name string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	h.mu.Lock()
+	sub, ok := h.subs[name]
+
+	if ok {
+		sub.cfg.Detached = true
+	}
 	h.mu.Unlock()
 
 	if !ok {

--- a/server/gcp/pubsub/types.go
+++ b/server/gcp/pubsub/types.go
@@ -2,29 +2,37 @@ package pubsub
 
 import "encoding/json"
 
-// topic is the GCP Pub/Sub Topic resource shape.
+// topic is the GCP Pub/Sub Topic resource shape. Extended fields
+// (schemaSettings/messageStoragePolicy) are kept as raw JSON so they round-trip
+// verbatim without modeling every nested member.
 type topic struct {
-	Name   string            `json:"name"`
-	Labels map[string]string `json:"labels,omitempty"`
+	Name                     string            `json:"name"`
+	Labels                   map[string]string `json:"labels,omitempty"`
+	MessageRetentionDuration string            `json:"messageRetentionDuration,omitempty"`
+	SchemaSettings           json.RawMessage   `json:"schemaSettings,omitempty"`
+	KmsKeyName               string            `json:"kmsKeyName,omitempty"`
+	MessageStoragePolicy     json.RawMessage   `json:"messageStoragePolicy,omitempty"`
+	SatisfiesPzs             bool              `json:"satisfiesPzs,omitempty"`
 }
 
 // subscription is the GCP Pub/Sub Subscription resource shape. Extended fields
 // (pushConfig/retryPolicy/deadLetterPolicy/expirationPolicy) are kept as raw
 // JSON so they round-trip verbatim without modeling every nested member.
 type subscription struct {
-	Name                     string            `json:"name"`
-	Topic                    string            `json:"topic"`
-	PushConfig               json.RawMessage   `json:"pushConfig,omitempty"`
-	AckDeadlineSeconds       int               `json:"ackDeadlineSeconds,omitempty"`
-	RetainAckedMessages      bool              `json:"retainAckedMessages,omitempty"`
-	MessageRetentionDuration string            `json:"messageRetentionDuration,omitempty"`
-	Labels                   map[string]string `json:"labels,omitempty"`
-	EnableMessageOrdering    bool              `json:"enableMessageOrdering,omitempty"`
-	ExpirationPolicy         json.RawMessage   `json:"expirationPolicy,omitempty"`
-	Filter                   string            `json:"filter,omitempty"`
-	DeadLetterPolicy         json.RawMessage   `json:"deadLetterPolicy,omitempty"`
-	RetryPolicy              json.RawMessage   `json:"retryPolicy,omitempty"`
-	Detached                 bool              `json:"detached,omitempty"`
+	Name                      string            `json:"name"`
+	Topic                     string            `json:"topic"`
+	PushConfig                json.RawMessage   `json:"pushConfig,omitempty"`
+	AckDeadlineSeconds        int               `json:"ackDeadlineSeconds,omitempty"`
+	RetainAckedMessages       bool              `json:"retainAckedMessages,omitempty"`
+	MessageRetentionDuration  string            `json:"messageRetentionDuration,omitempty"`
+	Labels                    map[string]string `json:"labels,omitempty"`
+	EnableMessageOrdering     bool              `json:"enableMessageOrdering,omitempty"`
+	ExpirationPolicy          json.RawMessage   `json:"expirationPolicy,omitempty"`
+	Filter                    string            `json:"filter,omitempty"`
+	DeadLetterPolicy          json.RawMessage   `json:"deadLetterPolicy,omitempty"`
+	RetryPolicy               json.RawMessage   `json:"retryPolicy,omitempty"`
+	Detached                  bool              `json:"detached,omitempty"`
+	EnableExactlyOnceDelivery bool              `json:"enableExactlyOnceDelivery,omitempty"`
 }
 
 // updateTopicRequest is PATCH topics/{name} (topics.patch): the topic fields to


### PR DESCRIPTION
## Summary
Fixes GCP Pub/Sub wire-handler bugs found in a confirming audit, in `server/gcp/pubsub/`. All fixes target real-cloud round-trip fidelity against `cloud.google.com/go/pubsub` / `google.golang.org/api/pubsub/v1`.

### Fixed
- **BUG1 (HIGH)** Topic resource dropped every field except name+labels. `topic` now carries `messageRetentionDuration`, `schemaSettings`, `kmsKeyName`, `messageStoragePolicy`, `satisfiesPzs`; these are persisted in `topicState` (mirroring the existing labels/labelsSet override pattern) and echoed on get/list via a new `topicView` helper. `topics.patch` honors `updateMask` for the new fields (only masked fields updated). Prevents the `google_pubsub_topic` perpetual diff.
- **BUG2 (MED-HIGH)** Subscription dropped `enableExactlyOnceDelivery`. Added the field plus a `subMaskSetters` entry so it round-trips on create + patch.
- **BUG3 (MED)** `subscriptions:detach` returned 405. Added a `detach` verb case that sets `Detached=true` and returns 200 with an empty body (matching `DetachSubscriptionResponse`).
- **BUG5 (LOW)** `createSubscription` silently defaulted an empty `topic` to the subscription name. Now rejected with 400 INVALID_ARGUMENT.
- **BUG6 (LOW)** `ackDeadlineSeconds` was unvalidated. Now range-checked (10..600) in create and in `applySubMask` -> 400 out-of-range.

### Deferred (noted, not in this PR)
- **BUG4** ordering-key head-of-line blocking, push delivery, and schema validation — larger behavioral changes, deferred.

### Tests
New `sdk_config_test.go` (real SDK over httptest): topic field round-trip (retention + schemaSettings), topic patch updateMask isolation, `enableExactlyOnceDelivery` create+patch round-trip, detach sets detached=true (200), empty-topic create -> 400, ackDeadline 5/5000 -> 400 and 60 ok.

### Gates
- `go build ./...`, `go vet ./server/gcp/pubsub/...` clean
- `go test -p=3 ./server/gcp/pubsub/... ./providers/gcp/pubsub/...` pass
- `gofmt` clean; `golangci-lint --new-from-rev=origin/development ./server/gcp/pubsub/...` 0 new issues
- `go generate ./...` and `go run ./internal/compatgen` (exit 0) produce zero diff
