### PR TITLE
fix(azure-cache): round-trip Redis top-level properties (redisConfiguration, enableNonSslPort, minimumTlsVersion, publicNetworkAccess, redisVersion)

### DIFF
--- a/providers/azure/cache/cache.go
+++ b/providers/azure/cache/cache.go
@@ -114,21 +114,26 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 	}
 
 	info := driver.CacheInfo{
-		Name:               cfg.Name,
-		Scope:              cfg.Scope,
-		Location:           cfg.Location,
-		NodeType:           nodeType,
-		Engine:             engine,
-		Status:             "Running",
-		Endpoint:           endpoint,
-		CreatedAt:          m.opts.Clock.Now().UTC().Format(time.RFC3339),
-		Tags:               tags,
-		SKUFamily:          cfg.SKUFamily,
-		SKUCapacity:        cfg.SKUCapacity,
-		ShardCount:         cfg.ShardCount,
-		ReplicasPerPrimary: cfg.ReplicasPerPrimary,
-		PrimaryKey:         generateAccessKey(),
-		SecondaryKey:       generateAccessKey(),
+		Name:                cfg.Name,
+		Scope:               cfg.Scope,
+		Location:            cfg.Location,
+		NodeType:            nodeType,
+		Engine:              engine,
+		Status:              "Running",
+		Endpoint:            endpoint,
+		CreatedAt:           m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:                tags,
+		SKUFamily:           cfg.SKUFamily,
+		SKUCapacity:         cfg.SKUCapacity,
+		ShardCount:          cfg.ShardCount,
+		ReplicasPerPrimary:  cfg.ReplicasPerPrimary,
+		RedisConfiguration:  cloneStringMap(cfg.RedisConfiguration),
+		EnableNonSSLPort:    cfg.EnableNonSSLPort,
+		MinimumTLSVersion:   cfg.MinimumTLSVersion,
+		PublicNetworkAccess: cfg.PublicNetworkAccess,
+		RedisVersion:        cfg.RedisVersion,
+		PrimaryKey:          generateAccessKey(),
+		SecondaryKey:        generateAccessKey(),
 	}
 
 	// Opt-in: back the cache with a real Redis, replacing the synthetic endpoint
@@ -228,6 +233,28 @@ func (m *Mock) UpdateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 		updated.info.ReplicasPerPrimary = cfg.ReplicasPerPrimary
 	}
 
+	// Nil/empty means "not supplied" on a partial update: a tags-only or
+	// scale-only PATCH must not wipe redisConfiguration/enableNonSslPort/etc.
+	if cfg.RedisConfiguration != nil {
+		updated.info.RedisConfiguration = cloneStringMap(cfg.RedisConfiguration)
+	}
+
+	if cfg.EnableNonSSLPort != nil {
+		updated.info.EnableNonSSLPort = cfg.EnableNonSSLPort
+	}
+
+	if cfg.MinimumTLSVersion != "" {
+		updated.info.MinimumTLSVersion = cfg.MinimumTLSVersion
+	}
+
+	if cfg.PublicNetworkAccess != "" {
+		updated.info.PublicNetworkAccess = cfg.PublicNetworkAccess
+	}
+
+	if cfg.RedisVersion != "" {
+		updated.info.RedisVersion = cfg.RedisVersion
+	}
+
 	if cfg.Tags != nil {
 		updated.info.Tags = maps.Clone(cfg.Tags)
 	}
@@ -278,6 +305,16 @@ func (m *Mock) RegenerateCacheKey(_ context.Context, name, keyType string) (prim
 	m.caches.Set(name, &updated)
 
 	return updated.info.PrimaryKey, updated.info.SecondaryKey, nil
+}
+
+// cloneStringMap returns a copy of m, or nil when m is nil, so stored cache
+// state never aliases the caller's map.
+func cloneStringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+
+	return maps.Clone(m)
 }
 
 // generateAccessKey returns a fresh 44-character base64 Redis access key,

--- a/server/azure/cache/operations.go
+++ b/server/azure/cache/operations.go
@@ -33,6 +33,7 @@ func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp
 		Scope:    scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
 	}
 	applySKUAndClustering(&cfg, &body)
+	applyRedisProperties(&cfg, &body)
 
 	if _, err := h.cache.GetCache(r.Context(), rp.ResourceName); err == nil {
 		info, uerr := h.cache.UpdateCache(r.Context(), cfg)
@@ -121,6 +122,23 @@ func applySKUAndClustering(cfg *cachedriver.CacheConfig, body *redisJSON) {
 	if cfg.ReplicasPerPrimary == 0 {
 		cfg.ReplicasPerPrimary = body.Properties.ReplicasPerMaster
 	}
+}
+
+// applyRedisProperties copies the remaining top-level Redis properties
+// (redisConfiguration, enableNonSslPort, minimumTlsVersion, publicNetworkAccess,
+// redisVersion) from the request onto the driver config so they round-trip
+// instead of being dropped. Absent fields stay zero/nil, which the driver's
+// UpdateCache treats as "leave unchanged" so a partial PATCH does not wipe them.
+func applyRedisProperties(cfg *cachedriver.CacheConfig, body *redisJSON) {
+	if body.Properties == nil {
+		return
+	}
+
+	cfg.RedisConfiguration = body.Properties.RedisConfiguration
+	cfg.EnableNonSSLPort = body.Properties.EnableNonSSLPort
+	cfg.MinimumTLSVersion = body.Properties.MinimumTLSVersion
+	cfg.PublicNetworkAccess = body.Properties.PublicNetworkAccess
+	cfg.RedisVersion = body.Properties.RedisVersion
 }
 
 // nodeTypeFromBody derives the driver's node-type string from the request SKU.

--- a/server/azure/cache/properties_sdk_test.go
+++ b/server/azure/cache/properties_sdk_test.go
@@ -91,3 +91,158 @@ func TestSDKAzureCacheGetWrongResourceGroup(t *testing.T) {
 		t.Fatalf("Get(wrong rg): got %v, want 404", err)
 	}
 }
+
+// TestSDKAzureCacheRedisPropertiesRoundTrip verifies the top-level Redis
+// properties that azurerm_redis_cache sets — redisConfiguration (typed and
+// passthrough keys), enableNonSslPort, minimumTlsVersion, publicNetworkAccess,
+// and redisVersion — are echoed back on Get instead of being dropped, which
+// would otherwise cause a perpetual Terraform diff.
+func TestSDKAzureCacheRedisPropertiesRoundTrip(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreate(ctx, testRG, "props-cache", armredis.CreateParameters{
+		Location: to.Ptr("eastus"),
+		Properties: &armredis.CreateProperties{
+			SKU: &armredis.SKU{
+				Name:     to.Ptr(armredis.SKUNameStandard),
+				Family:   to.Ptr(armredis.SKUFamilyC),
+				Capacity: to.Ptr(int32(1)),
+			},
+			RedisConfiguration: &armredis.CommonPropertiesRedisConfiguration{
+				MaxmemoryPolicy:      to.Ptr("allkeys-lru"),
+				MaxmemoryReserved:    to.Ptr("50"),
+				AdditionalProperties: map[string]any{"custom-passthrough-key": "kept"},
+			},
+			EnableNonSSLPort:    to.Ptr(true),
+			MinimumTLSVersion:   to.Ptr(armredis.TLSVersionOne2),
+			PublicNetworkAccess: to.Ptr(armredis.PublicNetworkAccessDisabled),
+			RedisVersion:        to.Ptr("6.0"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	got, err := client.Get(ctx, testRG, "props-cache", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	props := got.Properties
+	if props == nil {
+		t.Fatal("expected properties on response")
+	}
+
+	assertRedisConfig(t, props.RedisConfiguration)
+
+	if props.EnableNonSSLPort == nil || !*props.EnableNonSSLPort {
+		t.Errorf("enableNonSslPort = %v, want true", props.EnableNonSSLPort)
+	}
+
+	if props.MinimumTLSVersion == nil || *props.MinimumTLSVersion != armredis.TLSVersionOne2 {
+		t.Errorf("minimumTlsVersion = %v, want 1.2", props.MinimumTLSVersion)
+	}
+
+	if props.PublicNetworkAccess == nil || *props.PublicNetworkAccess != armredis.PublicNetworkAccessDisabled {
+		t.Errorf("publicNetworkAccess = %v, want Disabled", props.PublicNetworkAccess)
+	}
+
+	if props.RedisVersion == nil || *props.RedisVersion != "6.0" {
+		t.Errorf("redisVersion = %v, want 6.0", props.RedisVersion)
+	}
+}
+
+// assertRedisConfig checks both a typed key (maxmemory-policy) and an
+// unmodeled passthrough key (maxmemory-reserved, decoded into
+// AdditionalProperties) survive the round-trip.
+func assertRedisConfig(t *testing.T, cfg *armredis.CommonPropertiesRedisConfiguration) {
+	t.Helper()
+
+	if cfg == nil {
+		t.Fatal("expected redisConfiguration on response")
+	}
+
+	if cfg.MaxmemoryPolicy == nil || *cfg.MaxmemoryPolicy != "allkeys-lru" {
+		t.Errorf("maxmemory-policy = %v, want allkeys-lru", cfg.MaxmemoryPolicy)
+	}
+
+	if cfg.MaxmemoryReserved == nil || *cfg.MaxmemoryReserved != "50" {
+		t.Errorf("maxmemory-reserved = %v, want 50", cfg.MaxmemoryReserved)
+	}
+
+	if got, _ := cfg.AdditionalProperties["custom-passthrough-key"].(string); got != "kept" {
+		t.Errorf("custom-passthrough-key = %v, want kept", cfg.AdditionalProperties["custom-passthrough-key"])
+	}
+}
+
+// TestSDKAzureCacheScaleUpdatePreservesProperties verifies a partial PATCH that
+// only scales capacity does NOT wipe the previously-set redisConfiguration and
+// enableNonSslPort — the nil-mask discipline in UpdateCache.
+func TestSDKAzureCacheScaleUpdatePreservesProperties(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	cPoller, err := client.BeginCreate(ctx, testRG, "scale-cache", armredis.CreateParameters{
+		Location: to.Ptr("eastus"),
+		Properties: &armredis.CreateProperties{
+			SKU: &armredis.SKU{
+				Name:     to.Ptr(armredis.SKUNameStandard),
+				Family:   to.Ptr(armredis.SKUFamilyC),
+				Capacity: to.Ptr(int32(1)),
+			},
+			RedisConfiguration: &armredis.CommonPropertiesRedisConfiguration{
+				MaxmemoryPolicy: to.Ptr("allkeys-lru"),
+			},
+			EnableNonSSLPort: to.Ptr(true),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := cPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Create PollUntilDone: %v", err)
+	}
+
+	// Scale-only PATCH: bump capacity, supply no redisConfiguration/enableNonSslPort.
+	uPoller, err := client.BeginUpdate(ctx, testRG, "scale-cache", armredis.UpdateParameters{
+		Properties: &armredis.UpdateProperties{
+			SKU: &armredis.SKU{
+				Name:     to.Ptr(armredis.SKUNameStandard),
+				Family:   to.Ptr(armredis.SKUFamilyC),
+				Capacity: to.Ptr(int32(2)),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate: %v", err)
+	}
+
+	if _, err := uPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Update PollUntilDone: %v", err)
+	}
+
+	got, err := client.Get(ctx, testRG, "scale-cache", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	props := got.Properties
+	if props == nil || props.SKU == nil || props.SKU.Capacity == nil || *props.SKU.Capacity != 2 {
+		t.Fatalf("capacity not scaled to 2: %+v", props)
+	}
+
+	if props.RedisConfiguration == nil || props.RedisConfiguration.MaxmemoryPolicy == nil ||
+		*props.RedisConfiguration.MaxmemoryPolicy != "allkeys-lru" {
+		t.Errorf("scale-only PATCH wiped redisConfiguration: %+v", props.RedisConfiguration)
+	}
+
+	if props.EnableNonSSLPort == nil || !*props.EnableNonSSLPort {
+		t.Errorf("scale-only PATCH wiped enableNonSslPort: %v", props.EnableNonSSLPort)
+	}
+}

--- a/server/azure/cache/types.go
+++ b/server/azure/cache/types.go
@@ -46,6 +46,20 @@ type redisProperties struct {
 	// response carries the current replicasPerPrimary field.
 	ReplicasPerMaster int `json:"replicasPerMaster,omitempty"`
 
+	// RedisConfiguration is the arbitrary Redis settings map (maxmemory-policy,
+	// maxmemory-reserved, and unmodeled passthrough keys). Decoded from the
+	// request and echoed back verbatim so IaC converges.
+	RedisConfiguration map[string]string `json:"redisConfiguration,omitempty"`
+
+	// EnableNonSSLPort is the enableNonSslPort flag; a pointer so an unset value
+	// is omitted rather than emitted as a spurious false.
+	EnableNonSSLPort *bool `json:"enableNonSslPort,omitempty"`
+
+	// MinimumTLSVersion and PublicNetworkAccess mirror the armredis fields of the
+	// same name and round-trip whatever the request supplied.
+	MinimumTLSVersion   string `json:"minimumTlsVersion,omitempty"`
+	PublicNetworkAccess string `json:"publicNetworkAccess,omitempty"`
+
 	// AccessKeys carries the cache's access keys. Real Azure populates it only
 	// on the Create/Update response (never on Get/List), so it is set by the
 	// create-or-update handler and omitted elsewhere.
@@ -137,6 +151,11 @@ func toRedisJSON(rp *azurearm.ResourcePath, info *cachedriver.CacheInfo) redisJS
 		location = defaultLocation
 	}
 
+	redisVersion := info.RedisVersion
+	if redisVersion == "" {
+		redisVersion = defaultRedisVersion
+	}
+
 	return redisJSON{
 		ID:       azurearm.BuildResourceID(sub, rg, providerName, typeRedis, info.Name),
 		Name:     info.Name,
@@ -144,14 +163,18 @@ func toRedisJSON(rp *azurearm.ResourcePath, info *cachedriver.CacheInfo) redisJS
 		Location: location,
 		Tags:     info.Tags,
 		Properties: &redisProperties{
-			ProvisioningState:  provisioningStateSucceeded,
-			RedisVersion:       defaultRedisVersion,
-			SKU:                skuFromInfo(info),
-			HostName:           host,
-			Port:               defaultRedisPort,
-			SSLPort:            sslPort,
-			ShardCount:         info.ShardCount,
-			ReplicasPerPrimary: info.ReplicasPerPrimary,
+			ProvisioningState:   provisioningStateSucceeded,
+			RedisVersion:        redisVersion,
+			SKU:                 skuFromInfo(info),
+			HostName:            host,
+			Port:                defaultRedisPort,
+			SSLPort:             sslPort,
+			ShardCount:          info.ShardCount,
+			ReplicasPerPrimary:  info.ReplicasPerPrimary,
+			RedisConfiguration:  info.RedisConfiguration,
+			EnableNonSSLPort:    info.EnableNonSSLPort,
+			MinimumTLSVersion:   info.MinimumTLSVersion,
+			PublicNetworkAccess: info.PublicNetworkAccess,
 		},
 	}
 }

--- a/services/cache/driver/driver.go
+++ b/services/cache/driver/driver.go
@@ -68,6 +68,28 @@ type CacheInfo struct {
 	// custom group converges. Empty means the backend reports the engine's
 	// default (default.<family>). AWS-only and left empty by other callers.
 	ParameterGroupName string
+
+	// RedisConfiguration mirrors the Azure Redis `redisConfiguration` map
+	// (maxmemory-policy, maxmemory-reserved, and unmodeled passthrough keys),
+	// echoed back verbatim so azurerm_redis_cache converges. Nil for providers
+	// that do not model it.
+	RedisConfiguration map[string]string
+
+	// EnableNonSSLPort mirrors the Azure Redis `enableNonSslPort` flag. A pointer
+	// so a partial (tags/scale-only) update that omits it leaves the stored value
+	// unchanged. Nil for providers that do not model it.
+	EnableNonSSLPort *bool
+
+	// MinimumTLSVersion / PublicNetworkAccess mirror the Azure Redis
+	// `minimumTlsVersion` ("1.0"/"1.1"/"1.2") and `publicNetworkAccess`
+	// ("Enabled"/"Disabled") fields. Empty for providers that do not model them.
+	MinimumTLSVersion   string
+	PublicNetworkAccess string
+
+	// RedisVersion is the Azure Redis engine version the cache was created with
+	// (`redisVersion`), echoed back instead of a hardcoded default. Empty for
+	// providers that do not model it.
+	RedisVersion string
 }
 
 // CacheConfig describes a cache instance to create.
@@ -110,6 +132,27 @@ type CacheConfig struct {
 	// to attach; empty means the backend reports the engine's default
 	// (default.<family>). AWS-only and left empty by other callers.
 	ParameterGroupName string
+
+	// RedisConfiguration carries the Azure Redis `redisConfiguration` map
+	// (maxmemory-policy, maxmemory-reserved, and unmodeled passthrough keys). On
+	// UpdateCache, nil means "not supplied" and leaves the stored value
+	// unchanged. Nil for non-Azure callers.
+	RedisConfiguration map[string]string
+
+	// EnableNonSSLPort carries the Azure Redis `enableNonSslPort` flag. A pointer
+	// so a partial update that omits it (nil) leaves the stored value unchanged.
+	// Nil for non-Azure callers.
+	EnableNonSSLPort *bool
+
+	// MinimumTLSVersion / PublicNetworkAccess carry the Azure Redis
+	// `minimumTlsVersion` and `publicNetworkAccess` fields. On UpdateCache, empty
+	// leaves the stored value unchanged. Empty for non-Azure callers.
+	MinimumTLSVersion   string
+	PublicNetworkAccess string
+
+	// RedisVersion is the requested Azure Redis engine version (`redisVersion`);
+	// empty defaults to the backend's default. Empty for non-Azure callers.
+	RedisVersion string
 }
 
 // ModifyCacheConfig carries the mutable fields of an AWS ElastiCache


### PR DESCRIPTION
## Summary

Azure Cache for Redis dropped every top-level Redis property except SKU and clustering on round-trip, causing a perpetual `azurerm_redis_cache` diff. The `redisProperties` wire type and the driver `CacheConfig`/`CacheInfo` only modeled SKU + shardCount/replicasPerPrimary; everything else the client sent was silently discarded on Create/Get.

This models the missing properties end to end (wire decode -> driver store -> wire emit):

- **redisConfiguration** (`map[string]string`) — full passthrough, including typed keys (maxmemory-policy, maxmemory-reserved) and unmodeled/custom keys.
- **enableNonSslPort** (`*bool`) — pointer so an unset value is omitted rather than emitted as a spurious `false`.
- **minimumTlsVersion**, **publicNetworkAccess** (strings).
- **redisVersion** — previously hardcoded to `6.0`; now honors the request and falls back to the default only when unset.

## Nil-mask discipline

`UpdateCache` (ARM PATCH / CreateOrUpdate-on-existing) already guarded SKU/clustering behind non-empty checks. The same discipline is extended to all new fields: a tags-only or scale-only PATCH that omits `redisConfiguration`/`enableNonSslPort`/etc. leaves the stored values untouched (nil map / nil `*bool` / empty string = "not supplied").

## Shared-driver safety

Fields are additive to the shared `services/cache/driver`. AWS ElastiCache and GCP Memorystore simply do not set them; their test suites pass unchanged.

## Tests (real armredis SDK over httptest)

- `TestSDKAzureCacheRedisPropertiesRoundTrip` — create with redisConfiguration{maxmemory-policy, maxmemory-reserved, custom passthrough key} + enableNonSslPort=true + minimumTlsVersion=1.2 + publicNetworkAccess=Disabled + redisVersion=6.0; Get echoes all.
- `TestSDKAzureCacheScaleUpdatePreservesProperties` — a capacity-only PATCH preserves the previously-set redisConfiguration and enableNonSslPort (nil-mask).

## Gates

- `go build ./...`, `go vet`, scoped `go test` (server/azure/cache, providers/azure/cache, services/cache) all green.
- Spot-checked `providers/aws/elasticache` + `providers/gcp/memorystore` — unregressed.
- `go generate ./...` and `go run ./internal/compatgen` — zero diff.
- `golangci-lint --new-from-rev=origin/development` on changed packages — 0 new issues; gofmt clean.