### PR TITLE
fix(gcp-vpc): 409 on duplicate subnet/firewall, PATCH network/subnet/firewall, firewall egress/advanced round-trip

### DIFF
--- a/server/gcp/vpc/handler.go
+++ b/server/gcp/vpc/handler.go
@@ -70,6 +70,9 @@ const (
 	defaultSubnetPurpose = "PRIVATE"
 	defaultStackType     = "IPV4_ONLY"
 	internalNetCIDR      = "10.0.0.0/16"
+
+	defaultFirewallDirection = "INGRESS"
+	defaultFirewallPriority  = 1000
 )
 
 // nowRFC3339 returns the current time formatted the way GCP stamps
@@ -168,6 +171,8 @@ func (h *Handler) routeNetworks(w http.ResponseWriter, r *http.Request, rp gcpre
 	switch r.Method {
 	case http.MethodGet:
 		h.getNetwork(w, r, rp)
+	case http.MethodPatch, http.MethodPut:
+		h.patchNetwork(w, r, rp)
 	case http.MethodDelete:
 		h.deleteNetwork(w, r, rp)
 	default:
@@ -214,6 +219,8 @@ func (h *Handler) routeSubnetworks(w http.ResponseWriter, r *http.Request, rp gc
 	switch r.Method {
 	case http.MethodGet:
 		h.getSubnetwork(w, r, rp)
+	case http.MethodPatch, http.MethodPut:
+		h.patchSubnetwork(w, r, rp)
 	case http.MethodDelete:
 		h.deleteSubnetwork(w, r, rp)
 	default:
@@ -239,6 +246,8 @@ func (h *Handler) routeFirewalls(w http.ResponseWriter, r *http.Request, rp gcpr
 	switch r.Method {
 	case http.MethodGet:
 		h.getFirewall(w, r, rp)
+	case http.MethodPatch, http.MethodPut:
+		h.patchFirewall(w, r, rp)
 	case http.MethodDelete:
 		h.deleteFirewall(w, r, rp)
 	default:
@@ -409,6 +418,51 @@ func (h *Handler) deleteNetwork(w http.ResponseWriter, r *http.Request, rp gcpre
 	gcprest.WriteJSON(w, http.StatusOK, op)
 }
 
+// patchNetwork applies GCP merge-patch semantics to the mutable network fields
+// (description, routingConfig.routingMode, mtu). Only fields present in the
+// patch body are updated; the rest ride unchanged in the network's tag set.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) patchNetwork(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	v, err := findNetByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	var req networkRequest
+
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	tags := map[string]string{}
+
+	if req.Description != "" {
+		tags[netDescTag] = req.Description
+	}
+
+	if req.RoutingConfig != nil && req.RoutingConfig.RoutingMode != "" {
+		tags[netRoutingModeTag] = req.RoutingConfig.RoutingMode
+	}
+
+	if req.Mtu > 0 {
+		tags[netMtuTag] = strconv.Itoa(int(req.Mtu))
+	}
+
+	if len(tags) > 0 {
+		if err := h.net.UpdateVPCTags(r.Context(), v.ID, tags); err != nil {
+			gcprest.WriteCErr(w, err)
+			return
+		}
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+		"networks", rp.ResourceName, "patch")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
 // Subnetwork operations.
 
 //nolint:gocritic // rp is a request-scoped value
@@ -426,6 +480,16 @@ func (h *Handler) insertSubnetwork(w http.ResponseWriter, r *http.Request, rp gc
 
 	if req.Name == "" {
 		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "name required")
+		return
+	}
+
+	// Subnetwork names are unique per region; a duplicate insert in the same
+	// region must 409. Without this the shadow subnet leaks — get/delete resolve
+	// only the first match, so the second one can never be reached or removed.
+	if _, err := findSubnetByName(r.Context(), h.net, req.Name, rp.ScopeName); err == nil {
+		gcprest.WriteError(w, http.StatusConflict, "alreadyExists",
+			"subnetwork "+req.Name+" already exists")
+
 		return
 	}
 
@@ -564,6 +628,82 @@ func (h *Handler) deleteSubnetwork(w http.ResponseWriter, r *http.Request, rp gc
 		"subnetworks", rp.ResourceName, "delete")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// patchSubnetwork applies merge-patch semantics to the mutable subnetwork
+// fields (privateIpGoogleAccess, secondaryIpRanges, description). GCP guards
+// the patch with the resource fingerprint: a caller echoes the fingerprint it
+// read, and a stale one (the subnet changed underneath it) is rejected 412.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) patchSubnetwork(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	s, err := findSubnetByName(r.Context(), h.net, rp.ResourceName, rp.ScopeName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	var req subnetworkRequest
+
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	name := tagOr(s.Tags, subnetNameTag, s.ID)
+	if req.Fingerprint != "" && req.Fingerprint != fingerprintOf(name, s.CIDRBlock) {
+		gcprest.WriteError(w, http.StatusPreconditionFailed, "conditionNotMet",
+			"subnetwork fingerprint does not match the current resource")
+
+		return
+	}
+
+	set, remove := subnetPatchTags(&req)
+
+	if len(set) > 0 {
+		if err := h.net.UpdateSubnetTags(r.Context(), s.ID, set); err != nil {
+			gcprest.WriteCErr(w, err)
+			return
+		}
+	}
+
+	if len(remove) > 0 {
+		if err := h.net.RemoveSubnetTags(r.Context(), s.ID, remove); err != nil {
+			gcprest.WriteCErr(w, err)
+			return
+		}
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
+		"subnetworks", rp.ResourceName, "patch")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// subnetPatchTags translates a subnetwork patch into the tag keys to set and
+// the keys to remove. privateIpGoogleAccess=false clears its tag rather than
+// storing a falsey marker, so the read path stays a simple presence check.
+func subnetPatchTags(req *subnetworkRequest) (set map[string]string, remove []string) {
+	set = map[string]string{}
+
+	if req.PrivateIPGoogleAccess != nil {
+		if *req.PrivateIPGoogleAccess {
+			set[subnetPGATag] = trueValue
+		} else {
+			remove = append(remove, subnetPGATag)
+		}
+	}
+
+	if len(req.SecondaryIPRanges) > 0 {
+		if b, err := json.Marshal(req.SecondaryIPRanges); err == nil {
+			set[subnetSecondaryTag] = string(b)
+		}
+	}
+
+	if req.Description != "" {
+		set[subnetDescTag] = req.Description
+	}
+
+	return set, remove
 }
 
 // subnetCIDRExpander is the optional provider capability for widening a
@@ -710,6 +850,26 @@ func (h *Handler) insertFirewall(w http.ResponseWriter, r *http.Request, rp gcpr
 		return
 	}
 
+	// A firewall name is unique per project; a duplicate insert must 409 rather
+	// than silently shadow the existing rule (get/delete would only ever resolve
+	// the first match, leaking the shadow).
+	if _, err := findFirewallByName(r.Context(), h.net, req.Name); err == nil {
+		gcprest.WriteError(w, http.StatusConflict, "alreadyExists",
+			"firewall "+req.Name+" already exists")
+
+		return
+	}
+
+	// GCP stamps defaults a minimal firewall omits; populate them at insert so
+	// the resource reads back with a concrete direction/priority.
+	if req.Direction == "" {
+		req.Direction = defaultFirewallDirection
+	}
+
+	if req.Priority == 0 {
+		req.Priority = defaultFirewallPriority
+	}
+
 	// Firewalls map onto driver SecurityGroups; the driver requires a VPC ID.
 	// A supplied network MUST exist — real GCP rejects a firewall insert that
 	// references an unknown network. Propagate the resolve error (404) rather
@@ -832,6 +992,111 @@ func (h *Handler) deleteFirewall(w http.ResponseWriter, r *http.Request, rp gcpr
 		"firewalls", rp.ResourceName, "delete")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// patchFirewall applies GCP merge-patch semantics to the stored firewall spec:
+// only fields present in the patch body overwrite the existing rule, so a
+// caller adjusting one field (e.g. allowed) keeps everything else intact.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) patchFirewall(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	f, err := findFirewallByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	var req firewallRequest
+
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	spec, _ := unmarshalFirewallSpec(f.Tags[firewallSpecTag])
+	mergeFirewallPatch(&spec, &req)
+
+	b, mErr := json.Marshal(spec)
+	if mErr != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "malformed firewall body")
+		return
+	}
+
+	if err := h.net.UpdateSecurityGroupTags(r.Context(), f.ID,
+		map[string]string{firewallSpecTag: string(b)}); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+		"firewalls", rp.ResourceName, "patch")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// mergeFirewallPatch overwrites only the spec fields the patch actually
+// carries. Scalars merge when non-empty; slices and pointers merge when
+// present (non-nil), matching GCP's JSON merge-patch handling.
+func mergeFirewallPatch(spec *firewallSpec, req *firewallRequest) {
+	mergeFirewallScalars(spec, req)
+	mergeFirewallCollections(spec, req)
+}
+
+// mergeFirewallScalars merges the scalar and single-value firewall fields.
+func mergeFirewallScalars(spec *firewallSpec, req *firewallRequest) {
+	if req.Network != "" {
+		spec.Network = req.Network
+	}
+
+	if req.Direction != "" {
+		spec.Direction = req.Direction
+	}
+
+	if req.Priority != 0 {
+		spec.Priority = req.Priority
+	}
+
+	if req.LogConfig != nil {
+		spec.LogConfig = req.LogConfig
+	}
+
+	if req.Disabled != nil {
+		spec.Disabled = req.Disabled
+	}
+}
+
+// mergeFirewallCollections merges the rule and list-valued firewall fields.
+func mergeFirewallCollections(spec *firewallSpec, req *firewallRequest) {
+	if req.Allowed != nil {
+		spec.Allowed = req.Allowed
+	}
+
+	if req.Denied != nil {
+		spec.Denied = req.Denied
+	}
+
+	if req.SourceRanges != nil {
+		spec.SourceRanges = req.SourceRanges
+	}
+
+	if req.DestinationRanges != nil {
+		spec.DestinationRanges = req.DestinationRanges
+	}
+
+	if req.SourceTags != nil {
+		spec.SourceTags = req.SourceTags
+	}
+
+	if req.TargetTags != nil {
+		spec.TargetTags = req.TargetTags
+	}
+
+	if req.SourceServiceAccounts != nil {
+		spec.SourceServiceAccounts = req.SourceServiceAccounts
+	}
+
+	if req.TargetServiceAccounts != nil {
+		spec.TargetServiceAccounts = req.TargetServiceAccounts
+	}
 }
 
 // Lookup helpers.
@@ -1088,7 +1353,13 @@ func toFirewallResponse(info *netdriver.SecurityGroupInfo, rp gcprest.ResourcePa
 		resp.Allowed = spec.Allowed
 		resp.Denied = spec.Denied
 		resp.SourceRanges = spec.SourceRanges
+		resp.DestinationRanges = spec.DestinationRanges
+		resp.SourceTags = spec.SourceTags
 		resp.TargetTags = spec.TargetTags
+		resp.SourceServiceAccounts = spec.SourceServiceAccounts
+		resp.TargetServiceAccounts = spec.TargetServiceAccounts
+		resp.LogConfig = spec.LogConfig
+		resp.Disabled = spec.Disabled
 	}
 
 	return resp
@@ -1097,25 +1368,23 @@ func toFirewallResponse(info *netdriver.SecurityGroupInfo, rp gcprest.ResourcePa
 // firewallSpec is the GCP firewall rule shape persisted verbatim (as JSON in a
 // reserved tag) because the driver's SecurityGroup model can't express it.
 type firewallSpec struct {
-	Network      string         `json:"network,omitempty"`
-	Priority     int            `json:"priority,omitempty"`
-	Direction    string         `json:"direction,omitempty"`
-	Allowed      []firewallRule `json:"allowed,omitempty"`
-	Denied       []firewallRule `json:"denied,omitempty"`
-	SourceRanges []string       `json:"sourceRanges,omitempty"`
-	TargetTags   []string       `json:"targetTags,omitempty"`
+	Network               string             `json:"network,omitempty"`
+	Priority              int                `json:"priority,omitempty"`
+	Direction             string             `json:"direction,omitempty"`
+	Allowed               []firewallRule     `json:"allowed,omitempty"`
+	Denied                []firewallRule     `json:"denied,omitempty"`
+	SourceRanges          []string           `json:"sourceRanges,omitempty"`
+	DestinationRanges     []string           `json:"destinationRanges,omitempty"`
+	SourceTags            []string           `json:"sourceTags,omitempty"`
+	TargetTags            []string           `json:"targetTags,omitempty"`
+	SourceServiceAccounts []string           `json:"sourceServiceAccounts,omitempty"`
+	TargetServiceAccounts []string           `json:"targetServiceAccounts,omitempty"`
+	LogConfig             *firewallLogConfig `json:"logConfig,omitempty"`
+	Disabled              *bool              `json:"disabled,omitempty"`
 }
 
 func marshalFirewallSpec(req *firewallRequest) string {
-	spec := firewallSpec{
-		Network:      req.Network,
-		Priority:     req.Priority,
-		Direction:    req.Direction,
-		Allowed:      req.Allowed,
-		Denied:       req.Denied,
-		SourceRanges: req.SourceRanges,
-		TargetTags:   req.TargetTags,
-	}
+	spec := specFromFirewallRequest(req)
 
 	b, err := json.Marshal(spec)
 	if err != nil {
@@ -1123,6 +1392,25 @@ func marshalFirewallSpec(req *firewallRequest) string {
 	}
 
 	return string(b)
+}
+
+// specFromFirewallRequest projects a wire request onto the stored spec shape.
+func specFromFirewallRequest(req *firewallRequest) firewallSpec {
+	return firewallSpec{
+		Network:               req.Network,
+		Priority:              req.Priority,
+		Direction:             req.Direction,
+		Allowed:               req.Allowed,
+		Denied:                req.Denied,
+		SourceRanges:          req.SourceRanges,
+		DestinationRanges:     req.DestinationRanges,
+		SourceTags:            req.SourceTags,
+		TargetTags:            req.TargetTags,
+		SourceServiceAccounts: req.SourceServiceAccounts,
+		TargetServiceAccounts: req.TargetServiceAccounts,
+		LogConfig:             req.LogConfig,
+		Disabled:              req.Disabled,
+	}
 }
 
 func unmarshalFirewallSpec(s string) (firewallSpec, bool) {

--- a/server/gcp/vpc/patch_test.go
+++ b/server/gcp/vpc/patch_test.go
@@ -1,0 +1,338 @@
+package vpc_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/option"
+)
+
+func ptrBool(b bool) *bool { return &b }
+
+func newSubClient(t *testing.T, url string, hc *http.Client) *gcpcompute.SubnetworksClient {
+	t.Helper()
+
+	c, err := gcpcompute.NewSubnetworksRESTClient(context.Background(),
+		option.WithEndpoint(url), option.WithoutAuthentication(), option.WithHTTPClient(hc))
+	if err != nil {
+		t.Fatalf("NewSubnetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = c.Close() })
+
+	return c
+}
+
+func newFwClient(t *testing.T, url string, hc *http.Client) *gcpcompute.FirewallsClient {
+	t.Helper()
+
+	c, err := gcpcompute.NewFirewallsRESTClient(context.Background(),
+		option.WithEndpoint(url), option.WithoutAuthentication(), option.WithHTTPClient(hc))
+	if err != nil {
+		t.Fatalf("NewFirewallsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = c.Close() })
+
+	return c
+}
+
+func insertNet(t *testing.T, ctx context.Context, c *gcpcompute.NetworksClient, name string) {
+	t.Helper()
+	mustInsertNetwork(t, ctx, c, &computepb.Network{
+		Name:                  ptrStr(name),
+		AutoCreateSubnetworks: ptrBool(false),
+	})
+}
+
+// TestSDKDuplicateSubnetworkConflict covers BUG1: a second subnetwork insert
+// with the same name+region must 409, not silently shadow the first.
+func TestSDKDuplicateSubnetworkConflict(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	netClient := newNetClient(t, ts.URL, ts.Client())
+	insertNet(t, ctx, netClient, "vpc-a")
+
+	subClient := newSubClient(t, ts.URL, ts.Client())
+	insertSubnet(t, ctx, subClient, testRegion, "dup", "10.9.0.0/16")
+
+	_, err := subClient.Insert(ctx, &computepb.InsertSubnetworkRequest{
+		Project: testProject,
+		Region:  testRegion,
+		SubnetworkResource: &computepb.Subnetwork{
+			Name:        ptrStr("dup"),
+			Network:     ptrStr("projects/" + testProject + "/global/networks/vpc-a"),
+			IpCidrRange: ptrStr("10.10.0.0/16"),
+		},
+	})
+	if err == nil {
+		t.Fatal("duplicate subnetwork Insert succeeded, want 409")
+	}
+}
+
+// TestSDKDuplicateFirewallConflict covers BUG2: a duplicate firewall insert
+// must 409.
+func TestSDKDuplicateFirewallConflict(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	client := newFwClient(t, ts.URL, ts.Client())
+
+	insertFw := func() error {
+		op, err := client.Insert(ctx, &computepb.InsertFirewallRequest{
+			Project: testProject,
+			FirewallResource: &computepb.Firewall{
+				Name:    ptrStr("fw-dup"),
+				Allowed: []*computepb.Allowed{{IPProtocol: ptrStr("tcp"), Ports: []string{"22"}}},
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		return op.Wait(ctx)
+	}
+
+	if err := insertFw(); err != nil {
+		t.Fatalf("first firewall Insert: %v", err)
+	}
+
+	if err := insertFw(); err == nil {
+		t.Fatal("duplicate firewall Insert succeeded, want 409")
+	}
+}
+
+// TestSDKNetworkPatch covers BUG3: PATCH network updates routingMode and the
+// change is reflected on GET.
+func TestSDKNetworkPatch(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	client := newNetClient(t, ts.URL, ts.Client())
+	insertNet(t, ctx, client, "net-p")
+
+	op, err := client.Patch(ctx, &computepb.PatchNetworkRequest{
+		Project: testProject,
+		Network: "net-p",
+		NetworkResource: &computepb.Network{
+			RoutingConfig: &computepb.NetworkRoutingConfig{RoutingMode: ptrStr("GLOBAL")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("network Patch: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("network Patch wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetNetworkRequest{Project: testProject, Network: "net-p"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetRoutingConfig().GetRoutingMode() != "GLOBAL" {
+		t.Errorf("routingMode=%q want GLOBAL", got.GetRoutingConfig().GetRoutingMode())
+	}
+}
+
+// TestSDKSubnetworkPatch covers BUG3: PATCH subnetwork with a valid fingerprint
+// applies privateIpGoogleAccess; a stale fingerprint is rejected 412.
+func TestSDKSubnetworkPatch(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	netClient := newNetClient(t, ts.URL, ts.Client())
+	insertNet(t, ctx, netClient, "vpc-a")
+
+	subClient := newSubClient(t, ts.URL, ts.Client())
+	insertSubnet(t, ctx, subClient, testRegion, "sub-p", "10.20.0.0/16")
+
+	got, err := subClient.Get(ctx, &computepb.GetSubnetworkRequest{
+		Project: testProject, Region: testRegion, Subnetwork: "sub-p",
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	fp := got.GetFingerprint()
+	if fp == "" {
+		t.Fatal("fingerprint empty, cannot patch")
+	}
+
+	// Stale fingerprint must be rejected (412 conditionNotMet).
+	_, err = subClient.Patch(ctx, &computepb.PatchSubnetworkRequest{
+		Project: testProject, Region: testRegion, Subnetwork: "sub-p",
+		SubnetworkResource: &computepb.Subnetwork{
+			Fingerprint:           ptrStr("c3RhbGVmcA=="),
+			PrivateIpGoogleAccess: ptrBool(true),
+		},
+	})
+	if err == nil {
+		t.Fatal("patch with stale fingerprint succeeded, want 412")
+	}
+
+	// Valid fingerprint applies the change.
+	op, err := subClient.Patch(ctx, &computepb.PatchSubnetworkRequest{
+		Project: testProject, Region: testRegion, Subnetwork: "sub-p",
+		SubnetworkResource: &computepb.Subnetwork{
+			Fingerprint:           ptrStr(fp),
+			PrivateIpGoogleAccess: ptrBool(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("subnet Patch: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("subnet Patch wait: %v", err)
+	}
+
+	after, err := subClient.Get(ctx, &computepb.GetSubnetworkRequest{
+		Project: testProject, Region: testRegion, Subnetwork: "sub-p",
+	})
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if !after.GetPrivateIpGoogleAccess() {
+		t.Error("privateIpGoogleAccess not applied by patch")
+	}
+}
+
+// TestSDKFirewallPatch covers BUG3: PATCH firewall updates the allowed rules
+// and preserves the rest of the spec.
+func TestSDKFirewallPatch(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	client := newFwClient(t, ts.URL, ts.Client())
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertFirewallRequest{
+		Project: testProject,
+		FirewallResource: &computepb.Firewall{
+			Name:         ptrStr("fw-patch"),
+			Allowed:      []*computepb.Allowed{{IPProtocol: ptrStr("tcp"), Ports: []string{"80"}}},
+			SourceRanges: []string{"10.0.0.0/8"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	patchOp, err := client.Patch(ctx, &computepb.PatchFirewallRequest{
+		Project: testProject, Firewall: "fw-patch",
+		FirewallResource: &computepb.Firewall{
+			Allowed: []*computepb.Allowed{{IPProtocol: ptrStr("tcp"), Ports: []string{"443"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	if err := patchOp.Wait(ctx); err != nil {
+		t.Fatalf("Patch wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetFirewallRequest{Project: testProject, Firewall: "fw-patch"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	allowed := got.GetAllowed()
+	if len(allowed) != 1 || len(allowed[0].GetPorts()) != 1 || allowed[0].GetPorts()[0] != "443" {
+		t.Fatalf("patched allowed not reflected: %+v", allowed)
+	}
+
+	// Untouched fields survive the merge patch.
+	if len(got.GetSourceRanges()) != 1 || got.GetSourceRanges()[0] != "10.0.0.0/8" {
+		t.Errorf("sourceRanges lost on patch: %v", got.GetSourceRanges())
+	}
+}
+
+// TestSDKFirewallEgressAdvancedFields covers BUG4/BUG5: EGRESS + advanced
+// firewall fields round-trip, and a minimal firewall reads back with the GCP
+// defaults (direction INGRESS, priority 1000).
+func TestSDKFirewallEgressAdvancedFields(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	client := newFwClient(t, ts.URL, ts.Client())
+
+	egressOp, err := client.Insert(ctx, &computepb.InsertFirewallRequest{
+		Project: testProject,
+		FirewallResource: &computepb.Firewall{
+			Name:              ptrStr("fw-egress"),
+			Direction:         ptrStr("EGRESS"),
+			Denied:            []*computepb.Denied{{IPProtocol: ptrStr("tcp"), Ports: []string{"25"}}},
+			DestinationRanges: []string{"0.0.0.0/0"},
+			SourceTags:        []string{"web"},
+			Disabled:          ptrBool(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert egress: %v", err)
+	}
+
+	if err := egressOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert egress wait: %v", err)
+	}
+
+	eg, err := client.Get(ctx, &computepb.GetFirewallRequest{Project: testProject, Firewall: "fw-egress"})
+	if err != nil {
+		t.Fatalf("Get egress: %v", err)
+	}
+
+	if eg.GetDirection() != "EGRESS" {
+		t.Errorf("direction=%q want EGRESS", eg.GetDirection())
+	}
+
+	if len(eg.GetDestinationRanges()) != 1 || eg.GetDestinationRanges()[0] != "0.0.0.0/0" {
+		t.Errorf("destinationRanges=%v", eg.GetDestinationRanges())
+	}
+
+	if len(eg.GetSourceTags()) != 1 || eg.GetSourceTags()[0] != "web" {
+		t.Errorf("sourceTags=%v", eg.GetSourceTags())
+	}
+
+	if !eg.GetDisabled() {
+		t.Error("disabled did not round-trip")
+	}
+
+	// A minimal firewall reads back with GCP defaults.
+	minOp, err := client.Insert(ctx, &computepb.InsertFirewallRequest{
+		Project: testProject,
+		FirewallResource: &computepb.Firewall{
+			Name:    ptrStr("fw-min"),
+			Allowed: []*computepb.Allowed{{IPProtocol: ptrStr("tcp"), Ports: []string{"22"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert min: %v", err)
+	}
+
+	if err := minOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert min wait: %v", err)
+	}
+
+	mn, err := client.Get(ctx, &computepb.GetFirewallRequest{Project: testProject, Firewall: "fw-min"})
+	if err != nil {
+		t.Fatalf("Get min: %v", err)
+	}
+
+	if mn.GetDirection() != "INGRESS" {
+		t.Errorf("default direction=%q want INGRESS", mn.GetDirection())
+	}
+
+	if mn.GetPriority() != 1000 {
+		t.Errorf("default priority=%d want 1000", mn.GetPriority())
+	}
+}

--- a/server/gcp/vpc/types.go
+++ b/server/gcp/vpc/types.go
@@ -57,6 +57,9 @@ type subnetworkRequest struct {
 	StackType             string           `json:"stackType,omitempty"`
 	PrivateIPGoogleAccess *bool            `json:"privateIpGoogleAccess,omitempty"`
 	SecondaryIPRanges     []secondaryRange `json:"secondaryIpRanges,omitempty"`
+	// Fingerprint is the concurrency token a caller echoes back on patch; GCP
+	// rejects a patch whose fingerprint no longer matches the live resource.
+	Fingerprint string `json:"fingerprint,omitempty"`
 }
 
 type subnetworkResponse struct {
@@ -128,15 +131,21 @@ type subnetworkListResponse struct {
 }
 
 type firewallRequest struct {
-	Name         string         `json:"name"`
-	Network      string         `json:"network,omitempty"`
-	Description  string         `json:"description,omitempty"`
-	Priority     int            `json:"priority,omitempty"`
-	Direction    string         `json:"direction,omitempty"`
-	Allowed      []firewallRule `json:"allowed,omitempty"`
-	Denied       []firewallRule `json:"denied,omitempty"`
-	SourceRanges []string       `json:"sourceRanges,omitempty"`
-	TargetTags   []string       `json:"targetTags,omitempty"`
+	Name                  string             `json:"name"`
+	Network               string             `json:"network,omitempty"`
+	Description           string             `json:"description,omitempty"`
+	Priority              int                `json:"priority,omitempty"`
+	Direction             string             `json:"direction,omitempty"`
+	Allowed               []firewallRule     `json:"allowed,omitempty"`
+	Denied                []firewallRule     `json:"denied,omitempty"`
+	SourceRanges          []string           `json:"sourceRanges,omitempty"`
+	DestinationRanges     []string           `json:"destinationRanges,omitempty"`
+	SourceTags            []string           `json:"sourceTags,omitempty"`
+	TargetTags            []string           `json:"targetTags,omitempty"`
+	SourceServiceAccounts []string           `json:"sourceServiceAccounts,omitempty"`
+	TargetServiceAccounts []string           `json:"targetServiceAccounts,omitempty"`
+	LogConfig             *firewallLogConfig `json:"logConfig,omitempty"`
+	Disabled              *bool              `json:"disabled,omitempty"`
 }
 
 type firewallRule struct {
@@ -144,20 +153,32 @@ type firewallRule struct {
 	Ports      []string `json:"ports,omitempty"`
 }
 
+// firewallLogConfig mirrors GCP's firewall logConfig block.
+type firewallLogConfig struct {
+	Enable   bool   `json:"enable"`
+	Metadata string `json:"metadata,omitempty"`
+}
+
 type firewallResponse struct {
-	Kind              string         `json:"kind"`
-	ID                string         `json:"id"`
-	Name              string         `json:"name"`
-	Network           string         `json:"network,omitempty"`
-	Description       string         `json:"description,omitempty"`
-	Priority          int            `json:"priority,omitempty"`
-	Direction         string         `json:"direction,omitempty"`
-	Allowed           []firewallRule `json:"allowed,omitempty"`
-	Denied            []firewallRule `json:"denied,omitempty"`
-	SourceRanges      []string       `json:"sourceRanges,omitempty"`
-	TargetTags        []string       `json:"targetTags,omitempty"`
-	SelfLink          string         `json:"selfLink"`
-	CreationTimestamp string         `json:"creationTimestamp,omitempty"`
+	Kind                  string             `json:"kind"`
+	ID                    string             `json:"id"`
+	Name                  string             `json:"name"`
+	Network               string             `json:"network,omitempty"`
+	Description           string             `json:"description,omitempty"`
+	Priority              int                `json:"priority,omitempty"`
+	Direction             string             `json:"direction,omitempty"`
+	Allowed               []firewallRule     `json:"allowed,omitempty"`
+	Denied                []firewallRule     `json:"denied,omitempty"`
+	SourceRanges          []string           `json:"sourceRanges,omitempty"`
+	DestinationRanges     []string           `json:"destinationRanges,omitempty"`
+	SourceTags            []string           `json:"sourceTags,omitempty"`
+	TargetTags            []string           `json:"targetTags,omitempty"`
+	SourceServiceAccounts []string           `json:"sourceServiceAccounts,omitempty"`
+	TargetServiceAccounts []string           `json:"targetServiceAccounts,omitempty"`
+	LogConfig             *firewallLogConfig `json:"logConfig,omitempty"`
+	Disabled              *bool              `json:"disabled,omitempty"`
+	SelfLink              string             `json:"selfLink"`
+	CreationTimestamp     string             `json:"creationTimestamp,omitempty"`
 }
 
 type firewallListResponse struct {


### PR DESCRIPTION
## Summary

Fixes five GCP VPC networking bugs in the wire handler (`server/gcp/vpc/`), all mirroring the existing networks/addresses/routes/routers patterns. Purely additive — no driver-interface or provider changes (PATCH reuses the existing `UpdateVPCTags`/`UpdateSubnetTags`/`UpdateSecurityGroupTags` methods already on the `Networking` interface).

### Bugs fixed
- **BUG1 (HIGH):** duplicate subnetwork insert (same name+region) now returns `409 alreadyExists` instead of silently shadowing the first (get/delete only ever resolved the first match, leaking the shadow). Mirrors `insertNetwork`'s dup-check.
- **BUG2 (HIGH):** duplicate firewall insert now returns `409 alreadyExists`.
- **BUG3 (MED-HIGH):** added PATCH/PUT for networks (routingMode/mtu/description), subnetworks (privateIpGoogleAccess/secondaryIpRanges/description) and firewalls (merge-patch of allowed/denied/sourceRanges/etc), mirroring `patchRouter`. Update-in-place previously 405'd. The subnet `fingerprint` is now **enforced**: a stale fingerprint on patch returns `412 conditionNotMet`.
- **BUG4 (MED):** firewall EGRESS/advanced fields (`destinationRanges`, `sourceTags`, `sourceServiceAccounts`, `targetServiceAccounts`, `logConfig`, `disabled`) now round-trip instead of being dropped — the spec is stored verbatim as JSON.
- **BUG5 (MED):** a minimal firewall now reads back with GCP defaults — `direction=INGRESS`, `priority=1000` — populated at insert.

### Tests
Real `cloud.google.com/go/compute` SDK over `httptest`:
- duplicate subnet (same region) → 409; duplicate firewall → 409
- PATCH network(routingMode) / subnet(privateIpGoogleAccess) / firewall(allowed) apply and GET reflects
- subnet patch with stale fingerprint → 412
- EGRESS firewall `destinationRanges` + `disabled` + `sourceTags` round-trip
- minimal firewall reads `direction=INGRESS`, `priority=1000`

### Gates
`go build ./...`, `go vet`, scoped `go test`, `gofmt`, `golangci-lint --new-from-rev` (0 new) all green. `go generate ./...` and `go run ./internal/compatgen` produce zero diff.