### PR TITLE
fix(gcp-cloudsql): apply user password update, dataDiskType patch, deletionProtection delete-guard, PUT full-replace semantics

### DIFF
--- a/providers/gcp/cloudsql/cloudsql.go
+++ b/providers/gcp/cloudsql/cloudsql.go
@@ -277,6 +277,7 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		Port:               port,
 		State:              rdsdriver.StateAvailable,
 		MultiAZ:            cfg.MultiAZ,
+		DeletionProtection: cfg.DeletionProtection,
 		PubliclyAccessible: cfg.PubliclyAccessible,
 		VPCSecurityGroups:  append([]string(nil), cfg.VPCSecurityGroups...),
 		SubnetGroupName:    cfg.SubnetGroupName,
@@ -396,6 +397,14 @@ func (m *Mock) ModifyInstance(
 		inst.AllocatedStorage = input.AllocatedStorage
 	}
 
+	if input.StorageType != "" {
+		inst.StorageType = input.StorageType
+	}
+
+	if input.DeletionProtection != nil {
+		inst.DeletionProtection = *input.DeletionProtection
+	}
+
 	if input.EngineVersion != "" {
 		// Cloud SQL's databaseVersion is stored in Engine (that is the field
 		// toSQLInstance renders as databaseVersion), so a patched databaseVersion
@@ -445,6 +454,13 @@ func (m *Mock) DeleteInstance(ctx context.Context, id string) error {
 	inst, ok := m.instances.Get(id)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "Cloud SQL instance %q not found", id)
+	}
+
+	// Deletion protection blocks the delete until the guard is cleared, matching
+	// real Cloud SQL (settings.deletionProtectionEnabled).
+	if inst.DeletionProtection {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"Cloud SQL instance %q has deletion protection enabled", id)
 	}
 
 	// Tear down the real database backing the instance, if any.

--- a/providers/gcp/cloudsql/cloudsql_test.go
+++ b/providers/gcp/cloudsql/cloudsql_test.go
@@ -517,8 +517,8 @@ func TestSubResourceCRUDCoverage(t *testing.T) {
 		t.Fatalf("CreateUser: %v", err)
 	}
 
-	if got, err := m.GetUser(ctx, "inst", "u1"); err != nil || got.Name != "u1" {
-		t.Fatalf("GetUser: %+v %v", got, err)
+	if got, err := m.GetUser(ctx, "inst", "u1"); err != nil || got.Name != "u1" || got.Password != "p1" {
+		t.Fatalf("GetUser: %+v %v (want password p1)", got, err)
 	}
 
 	if us, err := m.ListUsers(ctx, "inst"); err != nil || len(us) != 1 {
@@ -527,6 +527,12 @@ func TestSubResourceCRUDCoverage(t *testing.T) {
 
 	if _, err := m.UpdateUser(ctx, rdsdriver.UserConfig{Instance: "inst", Name: "u1", Host: "%", Password: "p2"}); err != nil {
 		t.Fatalf("UpdateUser: %v", err)
+	}
+
+	// The password change must actually be applied, not a silent no-op that
+	// returns success while leaving the credential unchanged.
+	if got, err := m.GetUser(ctx, "inst", "u1"); err != nil || got.Password != "p2" {
+		t.Fatalf("after UpdateUser password = %q (%v), want p2", got.Password, err)
 	}
 
 	if _, err := m.UpdateUser(ctx, rdsdriver.UserConfig{Instance: "inst", Name: "ghost", Host: "%"}); err == nil {

--- a/providers/gcp/cloudsql/subresources.go
+++ b/providers/gcp/cloudsql/subresources.go
@@ -212,7 +212,7 @@ func (m *Mock) CreateUser(_ context.Context, cfg rdsdriver.UserConfig) (*rdsdriv
 		host = defaultUserHost
 	}
 
-	user := rdsdriver.User{Instance: cfg.Instance, Name: cfg.Name, Host: host}
+	user := rdsdriver.User{Instance: cfg.Instance, Name: cfg.Name, Host: host, Password: cfg.Password}
 	m.users.Set(key, user)
 
 	out := user
@@ -255,8 +255,10 @@ func (m *Mock) ListUsers(_ context.Context, instance string) ([]rdsdriver.User, 
 	return out, nil
 }
 
-// UpdateUser updates an existing user's host (the only mutable field the mock
-// tracks) and returns NotFound when the user does not exist.
+// UpdateUser updates an existing user's host and/or password and returns
+// NotFound when the user does not exist. A non-empty password is applied so the
+// change is actually reflected in state (users.update on a real Cloud SQL
+// rotates the login credential rather than returning a silent no-op).
 func (m *Mock) UpdateUser(_ context.Context, cfg rdsdriver.UserConfig) (*rdsdriver.User, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -274,6 +276,10 @@ func (m *Mock) UpdateUser(_ context.Context, cfg rdsdriver.UserConfig) (*rdsdriv
 
 	if cfg.Host != "" {
 		user.Host = cfg.Host
+	}
+
+	if cfg.Password != "" {
+		user.Password = cfg.Password
 	}
 
 	m.users.Set(key, user)

--- a/server/gcp/cloudsql/handler.go
+++ b/server/gcp/cloudsql/handler.go
@@ -261,8 +261,10 @@ func (h *Handler) serveInstance(w http.ResponseWriter, r *http.Request, p *sqlPa
 	switch r.Method {
 	case http.MethodGet:
 		h.getInstance(w, r, p)
-	case http.MethodPatch, http.MethodPut:
-		h.patchInstance(w, r, p)
+	case http.MethodPatch:
+		h.patchInstance(w, r, p, false)
+	case http.MethodPut:
+		h.patchInstance(w, r, p, true)
 	case http.MethodDelete:
 		h.deleteInstance(w, r, p)
 	default:

--- a/server/gcp/cloudsql/instance_update_sdk_test.go
+++ b/server/gcp/cloudsql/instance_update_sdk_test.go
@@ -1,0 +1,177 @@
+package cloudsql_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	sqladmin "google.golang.org/api/sqladmin/v1"
+)
+
+// TestSDKCloudSQLPatchDataDiskType verifies a patched settings.dataDiskType is
+// reflected on the following Get (previously double-dropped: the wire layer never
+// mapped it onto the modify input and the backend never applied it).
+func TestSDKCloudSQLPatchDataDiskType(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := svc.Instances.Insert(project, &sqladmin.DatabaseInstance{
+		Name:            "disktype",
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings:        &sqladmin.Settings{Tier: "db-custom-2-8192", DataDiskType: "PD_SSD"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if _, err := svc.Instances.Patch(project, "disktype", &sqladmin.DatabaseInstance{
+		Settings: &sqladmin.Settings{DataDiskType: "PD_HDD"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got, err := svc.Instances.Get(project, "disktype").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Settings.DataDiskType != "PD_HDD" {
+		t.Fatalf("after patch dataDiskType = %q, want PD_HDD", got.Settings.DataDiskType)
+	}
+
+	// A patch that omits dataDiskType must not revert it (merge semantics).
+	if _, err := svc.Instances.Patch(project, "disktype", &sqladmin.DatabaseInstance{
+		Settings: &sqladmin.Settings{Tier: "db-custom-4-16384"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch (tier only): %v", err)
+	}
+
+	got, err = svc.Instances.Get(project, "disktype").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after tier patch: %v", err)
+	}
+
+	if got.Settings.DataDiskType != "PD_HDD" {
+		t.Fatalf("dataDiskType after unrelated patch = %q, want PD_HDD (preserved)", got.Settings.DataDiskType)
+	}
+}
+
+// TestSDKCloudSQLDeletionProtection verifies deletionProtectionEnabled blocks a
+// delete with HTTP 400 FAILED_PRECONDITION, and that clearing it via patch allows
+// the delete to proceed.
+func TestSDKCloudSQLDeletionProtection(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := svc.Instances.Insert(project, &sqladmin.DatabaseInstance{
+		Name:            "protected",
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings: &sqladmin.Settings{
+			Tier:                      "db-custom-2-8192",
+			DeletionProtectionEnabled: true,
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	got, err := svc.Instances.Get(project, "protected").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Settings == nil || !got.Settings.DeletionProtectionEnabled {
+		t.Fatalf("deletionProtectionEnabled = %+v, want true", got.Settings)
+	}
+
+	// Delete is refused while protection is on.
+	_, err = svc.Instances.Delete(project, "protected").Context(ctx).Do()
+	if err == nil {
+		t.Fatal("Delete of a protected instance: expected error")
+	}
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != http.StatusBadRequest {
+		t.Fatalf("Delete error = %v, want HTTP 400", err)
+	}
+
+	// Clearing protection requires ForceSendFields (false is otherwise omitted).
+	if _, err := svc.Instances.Patch(project, "protected", &sqladmin.DatabaseInstance{
+		Settings: &sqladmin.Settings{
+			DeletionProtectionEnabled: false,
+			ForceSendFields:           []string{"DeletionProtectionEnabled"},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch clearing protection: %v", err)
+	}
+
+	if _, err := svc.Instances.Delete(project, "protected").Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete after clearing protection: %v", err)
+	}
+}
+
+// TestSDKCloudSQLUpdateVsPatch verifies the PUT (Instances.Update) full-replace
+// semantics differ from PATCH (Instances.Patch) merge semantics: an omitted
+// setting reverts to its default on PUT but is preserved on PATCH.
+func TestSDKCloudSQLUpdateVsPatch(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := svc.Instances.Insert(project, &sqladmin.DatabaseInstance{
+		Name:            "replace",
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings: &sqladmin.Settings{
+			Tier:           "db-custom-4-16384",
+			DataDiskSizeGb: 50,
+			DataDiskType:   "PD_HDD",
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	// PATCH omitting dataDiskSizeGb/dataDiskType preserves them (merge).
+	if _, err := svc.Instances.Patch(project, "replace", &sqladmin.DatabaseInstance{
+		Settings: &sqladmin.Settings{Tier: "db-custom-2-8192"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	afterPatch, err := svc.Instances.Get(project, "replace").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if afterPatch.Settings.DataDiskSizeGb != 50 || afterPatch.Settings.DataDiskType != "PD_HDD" {
+		t.Fatalf("after patch diskSize=%d diskType=%q, want 50 / PD_HDD (preserved)",
+			afterPatch.Settings.DataDiskSizeGb, afterPatch.Settings.DataDiskType)
+	}
+
+	// PUT omitting dataDiskSizeGb/dataDiskType reverts them to defaults (replace).
+	if _, err := svc.Instances.Update(project, "replace", &sqladmin.DatabaseInstance{
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings:        &sqladmin.Settings{Tier: "db-custom-8-32768"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Update (PUT): %v", err)
+	}
+
+	afterPut, err := svc.Instances.Get(project, "replace").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after update: %v", err)
+	}
+
+	if afterPut.Settings.Tier != "db-custom-8-32768" {
+		t.Fatalf("after PUT tier = %q, want db-custom-8-32768", afterPut.Settings.Tier)
+	}
+
+	if afterPut.Settings.DataDiskSizeGb != 10 {
+		t.Fatalf("after PUT dataDiskSizeGb = %d, want 10 (reverted to default)", afterPut.Settings.DataDiskSizeGb)
+	}
+
+	if afterPut.Settings.DataDiskType != "PD_SSD" {
+		t.Fatalf("after PUT dataDiskType = %q, want PD_SSD (reverted to default)", afterPut.Settings.DataDiskType)
+	}
+}

--- a/server/gcp/cloudsql/operations.go
+++ b/server/gcp/cloudsql/operations.go
@@ -48,6 +48,9 @@ func instanceFromBody(body *sqlInstance) rdsdriver.InstanceConfig {
 		// the three settings sub-objects are stored as opaque JSON so they
 		// round-trip on the next Get.
 		cfg.MultiAZ = strings.EqualFold(s.AvailabilityType, availabilityRegional)
+		if s.DeletionProtectionEnabled != nil {
+			cfg.DeletionProtection = *s.DeletionProtectionEnabled
+		}
 		cfg.GCPDatabaseFlags = string(s.DatabaseFlags)
 		cfg.GCPBackupConfig = string(s.BackupConfiguration)
 		cfg.GCPIPConfig = string(s.IPConfiguration)
@@ -56,34 +59,74 @@ func instanceFromBody(body *sqlInstance) rdsdriver.InstanceConfig {
 	return cfg
 }
 
-// modifyInputFromBody builds the driver ModifyInstanceInput for a Patch: only
-// fields present in the request body are set, so absent fields mean "no change"
-// (Cloud SQL patch merges the request onto the current configuration).
-func modifyInputFromBody(body *sqlInstance) rdsdriver.ModifyInstanceInput {
+// modifyInputFromBody builds the driver ModifyInstanceInput for an instances
+// update. With replace=false (PATCH) only fields present in the request body are
+// set, so absent fields mean "no change" (Cloud SQL patch merges the request
+// onto the current configuration). With replace=true (PUT) omitted settings
+// revert to their defaults, matching Cloud SQL's full-resource update semantics.
+func modifyInputFromBody(body *sqlInstance, replace bool) rdsdriver.ModifyInstanceInput {
 	var input rdsdriver.ModifyInstanceInput
 
 	if body.DatabaseVersion != "" {
 		input.EngineVersion = body.DatabaseVersion
 	}
 
-	if body.Settings == nil {
-		return input
+	s := body.Settings
+	if s == nil {
+		if !replace {
+			return input
+		}
+
+		s = &sqlSettings{}
 	}
 
-	s := body.Settings
-	input.InstanceClass = s.Tier
-	input.AllocatedStorage = s.DataDiskSizeGb
-	input.Tags = s.UserLabels
+	input.InstanceClass = orDefaultStr(s.Tier, defaultTier, replace)
+	input.AllocatedStorage = orDefaultInt(s.DataDiskSizeGb, defaultStorage, replace)
+	input.StorageType = orDefaultStr(s.DataDiskType, defaultStorageType, replace)
 	input.GCPDatabaseFlags = string(s.DatabaseFlags)
 	input.GCPBackupConfig = string(s.BackupConfiguration)
 	input.GCPIPConfig = string(s.IPConfiguration)
 
-	if s.AvailabilityType != "" {
+	// On replace an absent userLabels clears the labels (empty non-nil map),
+	// while on merge an absent map leaves them unchanged (nil).
+	switch {
+	case s.UserLabels != nil:
+		input.Tags = s.UserLabels
+	case replace:
+		input.Tags = map[string]string{}
+	}
+
+	if s.AvailabilityType != "" || replace {
 		multiAZ := strings.EqualFold(s.AvailabilityType, availabilityRegional)
 		input.MultiAZ = &multiAZ
 	}
 
+	if s.DeletionProtectionEnabled != nil {
+		input.DeletionProtection = s.DeletionProtectionEnabled
+	} else if replace {
+		off := false
+		input.DeletionProtection = &off
+	}
+
 	return input
+}
+
+// orDefaultStr returns v, or def when v is empty and replace is set (a PUT
+// reverts an omitted field to its default; a PATCH leaves it as "no change").
+func orDefaultStr(v, def string, replace bool) string {
+	if v == "" && replace {
+		return def
+	}
+
+	return v
+}
+
+func orDefaultInt(v, def int, replace bool) int {
+	if v == 0 && replace {
+		return def
+	}
+
+	return v
 }
 
 func (h *Handler) insertInstance(w http.ResponseWriter, r *http.Request, p *sqlPath) {
@@ -148,7 +191,10 @@ func (h *Handler) getInstance(w http.ResponseWriter, r *http.Request, p *sqlPath
 	writeJSON(w, http.StatusOK, toSQLInstance(&insts[0], p.project))
 }
 
-func (h *Handler) patchInstance(w http.ResponseWriter, r *http.Request, p *sqlPath) {
+// patchInstance handles both instances.patch (replace=false, merge) and
+// instances.update / PUT (replace=true, full-resource replace where omitted
+// settings revert to their defaults).
+func (h *Handler) patchInstance(w http.ResponseWriter, r *http.Request, p *sqlPath, replace bool) {
 	var body sqlInstance
 	if !decodeJSON(w, r, &body) {
 		return
@@ -170,7 +216,7 @@ func (h *Handler) patchInstance(w http.ResponseWriter, r *http.Request, p *sqlPa
 		}
 	}
 
-	if _, err := h.db.ModifyInstance(r.Context(), p.name, modifyInputFromBody(&body)); err != nil {
+	if _, err := h.db.ModifyInstance(r.Context(), p.name, modifyInputFromBody(&body, replace)); err != nil {
 		writeErr(w, err)
 		return
 	}

--- a/server/gcp/cloudsql/types.go
+++ b/server/gcp/cloudsql/types.go
@@ -40,6 +40,13 @@ const (
 	// rfc3339Milli is the millisecond RFC3339 layout Cloud SQL uses for its
 	// timestamp fields (createTime, insertTime, startTime, endTime).
 	rfc3339Milli = "2006-01-02T15:04:05.000Z"
+
+	// defaultTier / defaultStorage / defaultStorageType are the values an omitted
+	// setting reverts to on a PUT (full-resource update). They mirror the provider
+	// backend's insert defaults so a PUT and a fresh insert converge.
+	defaultTier        = "db-f1-micro"
+	defaultStorage     = 10
+	defaultStorageType = "PD_SSD"
 )
 
 // sqlInstance is the JSON shape Cloud SQL expects for DatabaseInstance.
@@ -69,6 +76,10 @@ type sqlSettings struct {
 	DataDiskType     string            `json:"dataDiskType,omitempty"`
 	AvailabilityType string            `json:"availabilityType,omitempty"`
 	UserLabels       map[string]string `json:"userLabels,omitempty"`
+	// DeletionProtectionEnabled guards the instance from deletion while true. A
+	// pointer so an absent field on a Patch means "no change" (merge) rather than
+	// clobbering the current value to false; it is always populated on a Get.
+	DeletionProtectionEnabled *bool `json:"deletionProtectionEnabled,omitempty"`
 	// databaseFlags, backupConfiguration and ipConfiguration are carried as
 	// opaque JSON so they round-trip unchanged on Insert->Get and Patch without
 	// the wire layer modeling every nested field real Cloud SQL exposes.
@@ -178,15 +189,16 @@ func toSQLInstance(inst *rdsdriver.Instance, project string) sqlInstance {
 			{IPAddress: inst.Endpoint, Type: "PRIMARY"},
 		},
 		Settings: &sqlSettings{
-			Tier:                inst.InstanceClass,
-			DataDiskSizeGb:      inst.AllocatedStorage,
-			DataDiskType:        inst.StorageType,
-			UserLabels:          inst.Tags,
-			ActivationPolicy:    activationFromState(inst.State),
-			AvailabilityType:    availabilityType(inst.MultiAZ),
-			DatabaseFlags:       rawJSONOrNil(inst.GCPDatabaseFlags),
-			BackupConfiguration: rawJSONOrNil(inst.GCPBackupConfig),
-			IPConfiguration:     rawJSONOrNil(inst.GCPIPConfig),
+			Tier:                      inst.InstanceClass,
+			DataDiskSizeGb:            inst.AllocatedStorage,
+			DataDiskType:              inst.StorageType,
+			UserLabels:                inst.Tags,
+			ActivationPolicy:          activationFromState(inst.State),
+			AvailabilityType:          availabilityType(inst.MultiAZ),
+			DeletionProtectionEnabled: boolPtr(inst.DeletionProtection),
+			DatabaseFlags:             rawJSONOrNil(inst.GCPDatabaseFlags),
+			BackupConfiguration:       rawJSONOrNil(inst.GCPBackupConfig),
+			IPConfiguration:           rawJSONOrNil(inst.GCPIPConfig),
 		},
 		ServerCaCert: serverCaCertFor(inst),
 		CreateTime:   inst.CreatedAt.UTC().Format(rfc3339Milli),
@@ -202,6 +214,12 @@ func availabilityType(multiAZ bool) string {
 	}
 
 	return availabilityZonal
+}
+
+// boolPtr returns a pointer to b, used to always populate deletionProtectionEnabled
+// on a Get (Terraform reads it as a computed attribute).
+func boolPtr(b bool) *bool {
+	return &b
 }
 
 // rawJSONOrNil returns the stored opaque JSON as a RawMessage, or nil when empty
@@ -318,7 +336,9 @@ func writeErr(w http.ResponseWriter, err error) {
 	case cerrors.IsInvalidArgument(err):
 		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
 	case cerrors.IsFailedPrecondition(err):
-		writeError(w, http.StatusConflict, "FAILED_PRECONDITION", err.Error())
+		// Google's canonical error mapping puts FAILED_PRECONDITION at HTTP 400
+		// (e.g. Cloud SQL's deletion-protection guard), not 409.
+		writeError(w, http.StatusBadRequest, "FAILED_PRECONDITION", err.Error())
 	default:
 		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
 	}

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -894,6 +894,11 @@ type User struct {
 	Instance string
 	Name     string
 	Host     string
+	// Password is the user's login credential. It is write-only: set on
+	// CreateUser/UpdateUser and used to authenticate against a real backing
+	// engine, but never surfaced back on the wire (Cloud SQL, like AWS/Azure,
+	// does not echo passwords). RDS/Redshift/Azure-SQL consumers leave it empty.
+	Password string
 }
 
 // Users is an OPTIONAL capability for managing database user accounts,


### PR DESCRIPTION
## Summary

Fixes four confirmed GCP Cloud SQL parity bugs, all in the Cloud SQL wire handler, the in-memory provider, and the shared relationaldb driver.

### BUG1 — users.update password change was a silent no-op
`users.update` returned a DONE operation while never applying the new password. The driver `User` had no `Password` field and the provider `UpdateUser` only touched `Host`. Added a write-only `Password` field to `relationaldb/driver.User` and apply it in `CreateUser`/`UpdateUser`. The password is never surfaced on a read (`toWireUser` still omits it), matching Cloud SQL/AWS/Azure semantics.

### BUG2 — settings.dataDiskType patch double-dropped
A patched `dataDiskType` never reached the instance (the wire layer never mapped it onto the modify input, and the backend never applied `input.StorageType`), so a later Get returned the stale value. Now mapped in `modifyInputFromBody` and applied in `ModifyInstance` (guarded non-empty, so patch-preserve holds).

### BUG3 — deletionProtectionEnabled not modeled
`settings.deletionProtectionEnabled` was not on the wire settings, so a protected instance still deleted. Modeled it on the wire settings (pointer, so absent = no-change on patch) and the driver, populate on insert/patch, and guard `DeleteInstance` — returning HTTP 400 FAILED_PRECONDITION when protection is on. Also corrected the wire error mapping so FAILED_PRECONDITION is 400 (Google's canonical mapping), not 409.

### BUG4 — instances.update (PUT) behaved as merge, not full-replace
PUT and PATCH both routed to the merge handler. PUT now uses full-replace semantics: omitted scalar settings (tier, dataDiskSizeGb, dataDiskType, availabilityType, deletionProtectionEnabled, userLabels) revert to their defaults, while PATCH continues to merge.

## Tests
Real `sqladmin` SDK over `httptest`:
- dataDiskType patch reflected on Get (and preserved by an unrelated patch)
- deletionProtectionEnabled=true blocks delete with HTTP 400; clearing it allows delete
- PUT full-replace vs PATCH merge distinction (omitted disk settings revert on PUT, preserved on PATCH)

Provider-level assertion that a user password update is actually applied (not just DONE).

## Notes
- The `Password` field on the shared `relationaldb/driver.User` is additive; RDS/Redshift/Azure-SQL consumers leave it empty and are unaffected (spot-checked `providers/aws/rds` + `providers/azure/sql` tests green).
- PUT full-replace reverts scalar settings; the opaque `databaseFlags`/`backupConfiguration`/`ipConfiguration` blobs remain merge-only (present overwrites, absent no-change).