### PR TITLE
fix(azure-aks): repair aks_test build break (Count *int32)

### DIFF
--- a/providers/azure/aks/aks_test.go
+++ b/providers/azure/aks/aks_test.go
@@ -73,7 +73,7 @@ func TestListClustersResourceGroupCaseInsensitive(t *testing.T) {
 		ResourceGroup: "rg-1",
 		Name:          "k8s-prod",
 		Location:      "eastus",
-		AgentPools:    []AgentPoolInput{{Name: "system", Count: 1, VMSize: "Standard_D2s_v3", Mode: "System"}},
+		AgentPools:    []AgentPoolInput{{Name: "system", Count: int32Ptr(1), VMSize: "Standard_D2s_v3", Mode: "System"}},
 	})
 	requireNoError(t, err)
 


### PR DESCRIPTION
A silent merge interaction broke the aks test build on development: #766 changed AgentPoolInput.Count to *int32, and #762 (systemic RG-case) added a test at aks_test.go:76 using Count: 1 (untyped int). Textually clean merge, but the aks test package no longer compiles (go vet ./... / go test ./providers/azure/aks/... fail).

Fix: use int32Ptr(1) like the other call-sites. Test-only, one line. Verified: go vet ./... clean, go test ./providers/azure/aks/... passes.