### PR TITLE
fix(gcp-gce): list filter match-all + labels filter, enforce update fingerprints (412), setMachineType requires TERMINATED

### DIFF
--- a/server/gcp/compute/instance_actions.go
+++ b/server/gcp/compute/instance_actions.go
@@ -27,6 +27,11 @@ func (h *Handler) setLabels(w http.ResponseWriter, r *http.Request, rp gcprest.R
 		return
 	}
 
+	if !fingerprintMatches(body.LabelFingerprint, labelFingerprintFor(userLabels(inst.Tags))) {
+		writeConditionNotMet(w, "labelFingerprint")
+		return
+	}
+
 	// Remove existing user labels that the new set drops.
 	var remove []string
 
@@ -54,6 +59,11 @@ func (h *Handler) setMetadata(w http.ResponseWriter, r *http.Request, rp gcprest
 		return
 	}
 
+	if !fingerprintMatches(body.Fingerprint, metadataResponse(decodeMetadata(inst.Tags)).Fingerprint) {
+		writeConditionNotMet(w, "metadata fingerprint")
+		return
+	}
+
 	h.applyMutation(w, r, rp, inst.ID, "setMetadata",
 		map[string]string{keyMetadata: encodeJSON(body.Items)}, nil, "")
 }
@@ -73,6 +83,11 @@ func (h *Handler) setTags(w http.ResponseWriter, r *http.Request, rp gcprest.Res
 		return
 	}
 
+	if !fingerprintMatches(body.Fingerprint, fingerprint(strings.Join(decodeNetTags(inst.Tags), ","))) {
+		writeConditionNotMet(w, "tags fingerprint")
+		return
+	}
+
 	h.applyMutation(w, r, rp, inst.ID, "setTags",
 		map[string]string{keyNetTags: encodeJSON(body.Items)}, nil, "")
 }
@@ -89,6 +104,15 @@ func (h *Handler) setMachineType(w http.ResponseWriter, r *http.Request, rp gcpr
 	inst, err := findInZone(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	// Real GCP rejects changing the machine type of an instance that is not
+	// TERMINATED (stopped) with a 400 — the VM must be stopped first.
+	if gcpStatusFor(inst.State) != statusTerminated {
+		gcprest.WriteError(w, http.StatusBadRequest, "conditionNotMet",
+			"Instance "+rp.ResourceName+" must be stopped before the machine type can be changed.")
+
 		return
 	}
 
@@ -169,6 +193,21 @@ func (h *Handler) applyMutation(
 	gcprest.WriteJSON(w, http.StatusOK, op)
 }
 
+// fingerprintMatches enforces optimistic-concurrency on the update verbs: an
+// incoming fingerprint must equal the resource's current one. An empty incoming
+// fingerprint skips the check, matching real GCP's leniency when a client omits
+// it.
+func fingerprintMatches(incoming, current string) bool {
+	return incoming == "" || incoming == current
+}
+
+// writeConditionNotMet responds with GCP's 412 conditionNotMet, returned when a
+// stale fingerprint loses the optimistic-concurrency check on an update verb.
+func writeConditionNotMet(w http.ResponseWriter, what string) {
+	gcprest.WriteError(w, http.StatusPreconditionFailed, "conditionNotMet",
+		what+" does not match; the resource was modified concurrently")
+}
+
 // parseMaxResults parses the maxResults query param, defaulting to GCP's page
 // size when absent or invalid.
 func parseMaxResults(raw string) int {
@@ -186,8 +225,11 @@ func parseMaxResults(raw string) int {
 
 // parseFilter compiles a GCP list filter into a predicate. It supports the
 // common single-clause forms "<field> <op> <value>" where op is one of
-// "=", "!=", "eq", "ne" and field is name/status/machineType/zone. An
-// unrecognized or empty filter matches everything.
+// "=", "!=", "eq", "ne" and field is name/status/machineType/zone or a
+// "labels.<key>" selector. An empty filter, an unparseable clause, or a
+// clause naming a field the emulator does not model all match everything —
+// mirroring real GCP's leniency (and gcprest.NameMatches) so an unknown
+// field never silently excludes every instance.
 func parseFilter(raw string) func(*instanceResponse) bool {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -202,7 +244,11 @@ func parseFilter(raw string) func(*instanceResponse) bool {
 	negate := op == "!=" || op == "ne"
 
 	return func(resp *instanceResponse) bool {
-		got := filterField(resp, field)
+		got, known := filterField(resp, field)
+		if !known {
+			return true
+		}
+
 		eq := got == value
 
 		return eq != negate
@@ -223,17 +269,24 @@ func splitFilter(raw string) (field, op, value string, ok bool) {
 	return "", "", "", false
 }
 
-func filterField(resp *instanceResponse, field string) string {
+// filterField resolves a filter field to its value on resp. The second return
+// reports whether the field is one the emulator models: an unknown field
+// returns known=false so the caller can match-all rather than exclude all.
+func filterField(resp *instanceResponse, field string) (value string, known bool) {
 	switch field {
 	case "name":
-		return resp.Name
+		return resp.Name, true
 	case "status":
-		return resp.Status
+		return resp.Status, true
 	case "machineType":
-		return lastSegment(resp.MachineType)
+		return lastSegment(resp.MachineType), true
 	case "zone":
-		return lastSegment(resp.Zone)
-	default:
-		return ""
+		return lastSegment(resp.Zone), true
 	}
+
+	if key := strings.TrimPrefix(field, "labels."); key != field {
+		return resp.Labels[key], true
+	}
+
+	return "", false
 }

--- a/server/gcp/compute/instances.go
+++ b/server/gcp/compute/instances.go
@@ -151,10 +151,15 @@ func (h *Handler) aggregatedListInstances(w http.ResponseWriter, r *http.Request
 	}
 
 	host := hostFromRequest(r)
+	pred := parseFilter(r.URL.Query().Get("filter"))
 	items := make(map[string]instancesScopedList)
 
 	for i := range instances {
 		resp := toInstanceResponse(&instances[i], rp.Project, host)
+		if !pred(&resp) {
+			continue
+		}
+
 		scope := "zones/" + tagOr(instances[i].Tags, keyZone, "unknown")
 		bucket := items[scope]
 		bucket.Instances = append(bucket.Instances, resp)

--- a/server/gcp/compute/instances_sdk_test.go
+++ b/server/gcp/compute/instances_sdk_test.go
@@ -162,6 +162,19 @@ func TestSDKGCEInstanceUpdateVerbs(t *testing.T) {
 		t.Fatalf("SetLabels wait: %v", err)
 	}
 
+	// Real GCP requires the instance to be stopped (TERMINATED) before its
+	// machine type can be changed, so stop it first.
+	stopOp, err := client.Stop(ctx, &computepb.StopInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "upd-vm",
+	})
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if err := stopOp.Wait(ctx); err != nil {
+		t.Fatalf("Stop wait: %v", err)
+	}
+
 	mtOp, err := client.SetMachineType(ctx, &computepb.SetMachineTypeInstanceRequest{
 		Project: testProject, Zone: testZone, Instance: "upd-vm",
 		InstancesSetMachineTypeRequestResource: &computepb.InstancesSetMachineTypeRequest{
@@ -479,6 +492,186 @@ func TestGCEInstanceListFilterAndPagination(t *testing.T) {
 
 	if page.NextPageToken == "" {
 		t.Error("nextPageToken empty with more pages remaining")
+	}
+}
+
+// TestGCEInstanceListFilterLabelsAndUnknownField covers BUG3: a "labels.<k>=<v>"
+// filter returns only the matching instances, and a filter naming a field the
+// emulator does not model matches everything (never silently excludes all).
+func TestGCEInstanceListFilterLabelsAndUnknownField(t *testing.T) {
+	client, _, ctx := newInstancesEnv(t)
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name: ptrStr("prod-vm"), MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+		Labels: map[string]string{"env": "prod"},
+	})
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name: ptrStr("dev-vm"), MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+		Labels: map[string]string{"env": "dev"},
+	})
+
+	prod := listNames(t, client.List(ctx, &computepb.ListInstancesRequest{
+		Project: testProject, Zone: testZone, Filter: ptrStr("labels.env=prod"),
+	}))
+	if len(prod) != 1 || prod[0] != "prod-vm" {
+		t.Errorf("labels.env=prod returned %v, want [prod-vm]", prod)
+	}
+
+	// An unrecognized field must match everything, not exclude all.
+	all := listNames(t, client.List(ctx, &computepb.ListInstancesRequest{
+		Project: testProject, Zone: testZone, Filter: ptrStr("someUnknownField=whatever"),
+	}))
+	if len(all) != 2 {
+		t.Errorf("unknown-field filter returned %v, want both instances", all)
+	}
+}
+
+// TestGCEInstanceFingerprintPrecondition covers BUG1: setLabels/setMetadata/
+// setTags enforce the incoming fingerprint — a stale one is rejected 412
+// conditionNotMet, the current one succeeds.
+func TestGCEInstanceFingerprintPrecondition(t *testing.T) {
+	client, _, ctx := newInstancesEnv(t)
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name: ptrStr("fp-vm"), MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+	})
+
+	const stale = "c3RhbGU=" // base64("stale"), never a real fingerprint
+
+	// setLabels: stale rejected, current accepted.
+	_, err := client.SetLabels(ctx, &computepb.SetLabelsInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "fp-vm",
+		InstancesSetLabelsRequestResource: &computepb.InstancesSetLabelsRequest{
+			Labels: map[string]string{"env": "prod"}, LabelFingerprint: ptrStr(stale),
+		},
+	})
+	assertConditionNotMet(t, "setLabels", err)
+
+	labelFp := mustGet(t, client, testZone, "fp-vm").GetLabelFingerprint()
+	mustWait(t, ctx, mustSetLabels(t, ctx, client, "fp-vm", map[string]string{"env": "prod"}, labelFp))
+
+	// setMetadata: stale rejected, current accepted.
+	_, err = client.SetMetadata(ctx, &computepb.SetMetadataInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "fp-vm",
+		MetadataResource: &computepb.Metadata{
+			Items:       []*computepb.Items{{Key: ptrStr("k"), Value: ptrStr("v")}},
+			Fingerprint: ptrStr(stale),
+		},
+	})
+	assertConditionNotMet(t, "setMetadata", err)
+
+	metaFp := mustGet(t, client, testZone, "fp-vm").GetMetadata().GetFingerprint()
+	mdOp, err := client.SetMetadata(ctx, &computepb.SetMetadataInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "fp-vm",
+		MetadataResource: &computepb.Metadata{
+			Items:       []*computepb.Items{{Key: ptrStr("k"), Value: ptrStr("v")}},
+			Fingerprint: ptrStr(metaFp),
+		},
+	})
+	if err != nil {
+		t.Fatalf("setMetadata current fingerprint: %v", err)
+	}
+
+	mustWait(t, ctx, mdOp)
+
+	// setTags: stale rejected, current accepted.
+	_, err = client.SetTags(ctx, &computepb.SetTagsInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "fp-vm",
+		TagsResource: &computepb.Tags{Items: []string{"web"}, Fingerprint: ptrStr(stale)},
+	})
+	assertConditionNotMet(t, "setTags", err)
+
+	tagsFp := mustGet(t, client, testZone, "fp-vm").GetTags().GetFingerprint()
+	tagsOp, err := client.SetTags(ctx, &computepb.SetTagsInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "fp-vm",
+		TagsResource: &computepb.Tags{Items: []string{"web"}, Fingerprint: ptrStr(tagsFp)},
+	})
+	if err != nil {
+		t.Fatalf("setTags current fingerprint: %v", err)
+	}
+
+	mustWait(t, ctx, tagsOp)
+}
+
+// TestGCEInstanceSetMachineTypeRequiresStopped covers BUG2: setMachineType is
+// rejected 400 on a running instance and succeeds once it is stopped.
+func TestGCEInstanceSetMachineTypeRequiresStopped(t *testing.T) {
+	client, _, ctx := newInstancesEnv(t)
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name: ptrStr("mt-vm"), MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+	})
+
+	req := &computepb.SetMachineTypeInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "mt-vm",
+		InstancesSetMachineTypeRequestResource: &computepb.InstancesSetMachineTypeRequest{
+			MachineType: ptrStr("zones/" + testZone + "/machineTypes/n2-standard-4"),
+		},
+	}
+
+	if _, err := client.SetMachineType(ctx, req); err == nil {
+		t.Fatal("setMachineType on running instance succeeded, want 400")
+	} else if !strings.Contains(err.Error(), "400") && !strings.Contains(err.Error(), "must be stopped") {
+		t.Errorf("err=%v want 400/must be stopped", err)
+	}
+
+	stopOp, err := client.Stop(ctx, &computepb.StopInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "mt-vm",
+	})
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	mustWait(t, ctx, stopOp)
+
+	mtOp, err := client.SetMachineType(ctx, req)
+	if err != nil {
+		t.Fatalf("setMachineType on stopped instance: %v", err)
+	}
+
+	mustWait(t, ctx, mtOp)
+
+	if !strings.HasSuffix(mustGet(t, client, testZone, "mt-vm").GetMachineType(), "/machineTypes/n2-standard-4") {
+		t.Error("machineType not updated after stop")
+	}
+}
+
+func assertConditionNotMet(t *testing.T, verb string, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("%s with stale fingerprint succeeded, want 412 conditionNotMet", verb)
+	}
+
+	if !strings.Contains(err.Error(), "412") && !strings.Contains(err.Error(), "conditionNotMet") {
+		t.Errorf("%s err=%v want 412/conditionNotMet", verb, err)
+	}
+}
+
+func mustSetLabels(
+	t *testing.T, ctx context.Context, client *gcpcompute.InstancesClient,
+	name string, labels map[string]string, fingerprint string,
+) *gcpcompute.Operation {
+	t.Helper()
+
+	op, err := client.SetLabels(ctx, &computepb.SetLabelsInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: name,
+		InstancesSetLabelsRequestResource: &computepb.InstancesSetLabelsRequest{
+			Labels: labels, LabelFingerprint: ptrStr(fingerprint),
+		},
+	})
+	if err != nil {
+		t.Fatalf("setLabels current fingerprint: %v", err)
+	}
+
+	return op
+}
+
+func mustWait(t *testing.T, ctx context.Context, op *gcpcompute.Operation) {
+	t.Helper()
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("operation wait: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes three real-user GCP Compute Engine bugs in the wire handler, confirmed against real `cloud.google.com/go/compute` SDK behavior. All scoped to `server/gcp/compute/`.

### BUG3 [MED-HIGH] — `list --filter` on an unknown field returned an empty list
`filterField` returned `""` for any field it did not model (name/status/machineType/zone), so the predicate compared `"" == value` and excluded **every** instance. `gcloud compute instances list --filter="labels.env=prod"` returned nothing.
- Unrecognized field now **matches all** (mirrors `gcprest.NameMatches` leniency) instead of excluding all.
- Added `labels.<key>=<value>` filter support (reads `resp.Labels[key]`).
- `aggregatedListInstances` now applies the filter too (previously ignored it entirely).

### BUG1 [MED] — fingerprints not enforced on update (lost-update)
`setLabels` / `setMetadata` / `setTags` never checked the incoming fingerprint, so concurrent stale writes silently clobbered each other with no 412 path.
- Each setter now compares the incoming fingerprint (`LabelFingerprint` / `Fingerprint`) against the current computed one and returns **412 conditionNotMet** on mismatch.
- An empty incoming fingerprint skips the check (real GCP leniency).

### BUG2 [MED] — `setMachineType` succeeded on a RUNNING instance
Real GCP requires the instance to be TERMINATED (stopped) before its machine type can change.
- `setMachineType` now rejects a non-TERMINATED instance with **400**.
- Corrected the existing `TestSDKGCEInstanceUpdateVerbs`, which asserted the wrong success-on-running behavior — it now stops the instance first.

### Deferred: BUG4 [LOW] — unknown zone/global operation returns DONE instead of 404
A naive 404 in `serveOperations` breaks VPC and LoadBalancer compat: the compute handler is registered ahead of `vpc`/`loadbalancer` and its `Matches` claims **every** `operations` path, so it is the de-facto operations poller for the whole compute API space. 404ing "unregistered" names 404s siblings' real operations (reproduced: `compatgen` red cells in `compat/gcp` loadbalancer + networking). A correct fix needs a shared operations registry across compute+vpc+loadbalancer (mirroring `server/gcp/lro`), which is a cross-package refactor out of scope here. Deferred to a dedicated change.

## Tests (real compute SDK over httptest)
- `labels.env=prod` filter returns only matching; unknown-field filter matches all.
- `setLabels`/`setMetadata`/`setTags` with a stale fingerprint → 412; with the current one → ok.
- `setMachineType` on a running instance → 400; on a stopped instance → ok.

## Gates
- `go build ./...`, `go vet`, `go test -p=3 ./server/gcp/compute/... ./providers/gcp/compute/...` green
- `gofmt` clean; `golangci-lint --new-from-rev=origin/development ./server/gcp/compute/...` 0 new issues
- `go generate ./...` and `go run ./internal/compatgen` produce zero diff (idempotent, suite green)