### PR TITLE
fix(gcp-gke): honor initialNodeCount=0, cluster labelFingerprint round-trip+enforcement, node-version propagation to pools, scope operation claims

### DIFF
--- a/providers/gcp/gke/gke.go
+++ b/providers/gcp/gke/gke.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"sort"
 	"sync"
 	"time"
 
@@ -73,6 +74,7 @@ type Cluster struct {
 	NetworkPolicy     bool
 	MasterUsername    string
 	ResourceLabels    map[string]string
+	LabelFingerprint  string // opaque hash of ResourceLabels; computed on read.
 	MaintenanceWindow string // RFC-3339 daily window encoding; empty = none.
 	IPRotationActive  bool
 	NodePoolNames     []string
@@ -249,12 +251,15 @@ func (m *Mock) recordOperation(opType, location, target string) Operation {
 
 // CreateClusterInput captures the subset of CreateCluster we honor.
 type CreateClusterInput struct {
-	Name              string
-	Location          string
-	Description       string
-	Network           string
-	Subnetwork        string
-	InitialNodeCount  int64
+	Name        string
+	Location    string
+	Description string
+	Network     string
+	Subnetwork  string
+	// InitialNodeCount is a pointer so an explicitly-requested 0 (autoscale
+	// from zero) is distinguishable from an absent field. nil = unset →
+	// bootstrap the GKE default; non-nil (including *0) is honored verbatim.
+	InitialNodeCount  *int64
 	LoggingService    string
 	MonitoringService string
 	ResourceLabels    map[string]string
@@ -281,8 +286,11 @@ type NodePoolManagement struct {
 // NodePoolSpec captures the node-pool fields we keep when bootstrapping a
 // cluster from a CreateClusterRequest.
 type NodePoolSpec struct {
-	Name             string
-	InitialNodeCount int64
+	Name string
+	// InitialNodeCount is a pointer so an explicit 0 (autoscale-from-zero
+	// pool) survives; nil means the field was absent and the GKE default
+	// applies. See nodePoolFromSpec.
+	InitialNodeCount *int64
 	MachineType      string
 	DiskSizeGB       int64
 	OauthScopes      []string
@@ -318,7 +326,7 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 		Description:       input.Description,
 		Network:           defaultIfEmpty(input.Network, "default"),
 		Subnetwork:        defaultIfEmpty(input.Subnetwork, "default"),
-		InitialNodeCount:  input.InitialNodeCount,
+		InitialNodeCount:  derefInt64(input.InitialNodeCount),
 		NodeIPv4CIDRSize:  defaultNodeIPv4CIDRSize,
 		ClusterIPv4CIDR:   defaultClusterCIDR,
 		ServicesIPv4CIDR:  defaultServicesCIDR,
@@ -335,14 +343,12 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 	// fields fall back to defaults via nodePoolFromSpec.
 	pools := input.NodePools
 	if len(pools) == 0 {
-		count := input.InitialNodeCount
-		if count == 0 {
-			count = defaultNodeCount
-		}
-
+		// Carry the pointer through untouched so an explicit initialNodeCount=0
+		// (autoscale-from-zero) reaches the default pool; nodePoolFromSpec
+		// resolves a nil (absent) count to the GKE default.
 		spec := NodePoolSpec{
 			Name:             "default-pool",
-			InitialNodeCount: count,
+			InitialNodeCount: input.InitialNodeCount,
 			Version:          stubNodeVersion,
 		}
 
@@ -382,9 +388,11 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 }
 
 func nodePoolFromSpec(spec *NodePoolSpec, clusterName, location string, now time.Time) NodePool {
-	count := spec.InitialNodeCount
-	if count == 0 {
-		count = defaultNodeCount
+	// Honor an explicit count (including 0 for autoscale-from-zero); only
+	// backfill the GKE default when the field was genuinely absent (nil).
+	count := int64(defaultNodeCount)
+	if spec.InitialNodeCount != nil {
+		count = *spec.InitialNodeCount
 	}
 
 	// GKE defaults auto-upgrade/auto-repair to true; an explicit management
@@ -425,6 +433,7 @@ func (m *Mock) GetCluster(_ context.Context, location, name string) (*Cluster, e
 	}
 
 	out := c
+	out.LabelFingerprint = labelFingerprint(out.ResourceLabels)
 
 	return &out, nil
 }
@@ -443,6 +452,7 @@ func (m *Mock) ListClusters(_ context.Context, location string) ([]Cluster, erro
 			continue
 		}
 
+		c.LabelFingerprint = labelFingerprint(c.ResourceLabels)
 		out = append(out, c)
 	}
 
@@ -456,13 +466,18 @@ type UpdateClusterInput struct {
 	NodeVersion       string
 	MasterVersion     string
 	ResourceLabels    map[string]string
+	// NodePoolID scopes a desiredNodeVersion roll to a single pool; empty
+	// rolls every pool in the cluster (real GKE ClusterUpdate semantics).
+	NodePoolID string
 }
 
-// UpdateCluster applies a partial update.
+// UpdateCluster applies a partial update. A desiredNodeVersion also rolls the
+// version of the targeted node pool(s), matching real GKE where a cluster-level
+// node-version update propagates to the pools it upgrades.
 func (m *Mock) UpdateCluster(
 	_ context.Context, location, name string, input UpdateClusterInput,
 ) (*Operation, error) {
-	return m.mutateCluster(location, name, func(c *Cluster) {
+	op, err := m.mutateCluster(location, name, func(c *Cluster) {
 		if input.LoggingService != "" {
 			c.LoggingService = input.LoggingService
 		}
@@ -483,6 +498,42 @@ func (m *Mock) UpdateCluster(
 			c.NodeVersion = input.NodeVersion
 		}
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	if input.NodeVersion != "" {
+		m.rollNodePoolVersions(location, name, input.NodePoolID, input.NodeVersion)
+	}
+
+	return op, nil
+}
+
+// rollNodePoolVersions applies version to the cluster's node pools. When
+// nodePoolID is set only that pool rolls; otherwise every pool in the cluster
+// does.
+func (m *Mock) rollNodePoolVersions(location, clusterName, nodePoolID, version string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	prefix := location + "/" + clusterName + "/"
+	for _, k := range m.nodePools.Keys() {
+		if !hasPrefix(k, prefix) {
+			continue
+		}
+
+		np, ok := m.nodePools.Get(k)
+		if !ok {
+			continue
+		}
+
+		if nodePoolID != "" && np.Name != nodePoolID {
+			continue
+		}
+
+		np.Version = version
+		m.nodePools.Set(k, np)
+	}
 }
 
 // DeleteCluster removes a cluster and its node pools.
@@ -559,13 +610,35 @@ func (m *Mock) SetMaintenancePolicy(_ context.Context, location, name, window st
 	})
 }
 
-// SetResourceLabels implements :setResourceLabels.
+// SetResourceLabels implements :setResourceLabels. When fingerprint is
+// non-empty it must match the cluster's current label fingerprint (optimistic
+// concurrency, as real GKE enforces); a stale value fails with
+// FAILED_PRECONDITION. An empty fingerprint skips the check.
 func (m *Mock) SetResourceLabels(
-	_ context.Context, location, name string, labels map[string]string,
+	_ context.Context, location, name string, labels map[string]string, fingerprint string,
 ) (*Operation, error) {
-	return m.mutateCluster(location, name, func(c *Cluster) {
-		c.ResourceLabels = copyLabels(labels)
-	})
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := clusterKey(location, name)
+
+	c, ok := m.clusters.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found in %q", name, location)
+	}
+
+	if fingerprint != "" && fingerprint != labelFingerprint(c.ResourceLabels) {
+		return nil, cerrors.Newf(cerrors.FailedPrecondition,
+			"labelFingerprint %q does not match current labels", fingerprint)
+	}
+
+	c.ResourceLabels = copyLabels(labels)
+	m.clusters.Set(key, c)
+
+	op := m.recordOperation("SET_LABELS", location,
+		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+name)
+
+	return &op, nil
 }
 
 // StartIPRotation implements :startIpRotation.
@@ -882,6 +955,38 @@ func defaultIfZero(v, fallback int64) int64 {
 	}
 
 	return v
+}
+
+func derefInt64(v *int64) int64 {
+	if v == nil {
+		return 0
+	}
+
+	return *v
+}
+
+// labelFingerprint returns a deterministic opaque hash of a cluster's resource
+// labels. Real GKE returns such a fingerprint on cluster reads and requires it
+// on :setResourceLabels for optimistic concurrency; the mock derives it from
+// the sorted key=value pairs so it is stable across reads and changes whenever
+// the labels change. An empty label set hashes deterministically too.
+func labelFingerprint(labels map[string]string) string {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	h := fnv.New64a()
+	for _, k := range keys {
+		_, _ = h.Write([]byte(k))
+		_, _ = h.Write([]byte{'='})
+		_, _ = h.Write([]byte(labels[k]))
+		_, _ = h.Write([]byte{'\n'})
+	}
+
+	return fmt.Sprintf("%016x", h.Sum64())
 }
 
 func copyLabels(src map[string]string) map[string]string {

--- a/providers/gcp/gke/gke_k8s_test.go
+++ b/providers/gcp/gke/gke_k8s_test.go
@@ -21,7 +21,7 @@ func TestSetK8sAPI_CreateRegistersWithAPIServer(t *testing.T) {
 	if _, _, err := m.CreateCluster(context.Background(), &CreateClusterInput{
 		Name:             "c1",
 		Location:         "us-central1",
-		InitialNodeCount: 1,
+		InitialNodeCount: int64Ptr(1),
 	}); err != nil {
 		t.Fatalf("CreateCluster: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestEndpoint_RealURLWhenWired(t *testing.T) {
 	if _, _, err := m.CreateCluster(context.Background(), &CreateClusterInput{
 		Name:             "c1",
 		Location:         "us-central1",
-		InitialNodeCount: 1,
+		InitialNodeCount: int64Ptr(1),
 	}); err != nil {
 		t.Fatalf("CreateCluster: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestEndpoint_NoAPIReturnsControlPlaneIP(t *testing.T) {
 	if _, _, err := m.CreateCluster(context.Background(), &CreateClusterInput{
 		Name:             "c1",
 		Location:         "us-central1",
-		InitialNodeCount: 1,
+		InitialNodeCount: int64Ptr(1),
 	}); err != nil {
 		t.Fatalf("CreateCluster: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestEndpoint_APIWithoutBaseURLReturnsControlPlaneIP(t *testing.T) {
 	if _, _, err := m.CreateCluster(context.Background(), &CreateClusterInput{
 		Name:             "c1",
 		Location:         "us-central1",
-		InitialNodeCount: 1,
+		InitialNodeCount: int64Ptr(1),
 	}); err != nil {
 		t.Fatalf("CreateCluster: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestDeleteCluster_DeregistersK8sState(t *testing.T) {
 	if _, _, err := m.CreateCluster(context.Background(), &CreateClusterInput{
 		Name:             "c1",
 		Location:         "us-central1",
-		InitialNodeCount: 1,
+		InitialNodeCount: int64Ptr(1),
 	}); err != nil {
 		t.Fatalf("CreateCluster: %v", err)
 	}

--- a/providers/gcp/gke/gke_test.go
+++ b/providers/gcp/gke/gke_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 )
 
+func int64Ptr(v int64) *int64 { return &v }
+
 func newTestMock() *Mock {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 	opts := config.NewOptions(
@@ -38,7 +40,7 @@ func TestCreateCluster(t *testing.T) {
 				Name:     "with-np",
 				Location: "us-central1",
 				NodePools: []NodePoolSpec{
-					{Name: "primary", InitialNodeCount: 3, MachineType: "e2-standard-4"},
+					{Name: "primary", InitialNodeCount: int64Ptr(3), MachineType: "e2-standard-4"},
 				},
 			},
 		},
@@ -152,7 +154,7 @@ func TestClusterSetters(t *testing.T) {
 		t.Fatalf("SetMaintenancePolicy: %v", err)
 	}
 
-	if _, err := m.SetResourceLabels(ctx, loc, name, map[string]string{"team": "core"}); err != nil {
+	if _, err := m.SetResourceLabels(ctx, loc, name, map[string]string{"team": "core"}, ""); err != nil {
 		t.Fatalf("SetResourceLabels: %v", err)
 	}
 
@@ -186,7 +188,7 @@ func TestNodePoolLifecycle(t *testing.T) {
 
 	_, _, err = m.CreateNodePool(ctx, loc, cName, &NodePoolSpec{
 		Name:             "extra",
-		InitialNodeCount: 2,
+		InitialNodeCount: int64Ptr(2),
 		MachineType:      "e2-standard-4",
 	})
 	requireNoError(t, err)
@@ -322,6 +324,102 @@ func TestCascadingDelete(t *testing.T) {
 	if _, err := m.GetNodePool(ctx, loc, cName, "extra"); err == nil {
 		t.Fatal("expected node pools to be deleted along with cluster")
 	}
+}
+
+func TestInitialNodeCountZeroHonoredAndNilDefaults(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	loc, cName := "us-central1", "host"
+
+	_, _, err := m.CreateCluster(ctx, &CreateClusterInput{Name: cName, Location: loc})
+	requireNoError(t, err)
+
+	// Explicit 0 survives (autoscale-from-zero).
+	_, _, err = m.CreateNodePool(ctx, loc, cName, &NodePoolSpec{Name: "zero", InitialNodeCount: int64Ptr(0)})
+	requireNoError(t, err)
+
+	zero, err := m.GetNodePool(ctx, loc, cName, "zero")
+	requireNoError(t, err)
+	assertEqual(t, int64(0), zero.NodeCount)
+
+	// A nil (absent) count defaults to the GKE default.
+	_, _, err = m.CreateNodePool(ctx, loc, cName, &NodePoolSpec{Name: "unset"})
+	requireNoError(t, err)
+
+	unset, err := m.GetNodePool(ctx, loc, cName, "unset")
+	requireNoError(t, err)
+	assertEqual(t, int64(defaultNodeCount), unset.NodeCount)
+}
+
+func TestSetResourceLabelsFingerprintEnforcement(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	loc, cName := "us-central1", "host"
+
+	_, _, err := m.CreateCluster(ctx, &CreateClusterInput{
+		Name: cName, Location: loc, ResourceLabels: map[string]string{"env": "prod"},
+	})
+	requireNoError(t, err)
+
+	got, err := m.GetCluster(ctx, loc, cName)
+	requireNoError(t, err)
+
+	if got.LabelFingerprint == "" {
+		t.Fatal("expected non-empty labelFingerprint on GetCluster")
+	}
+
+	// Stale fingerprint is rejected.
+	_, err = m.SetResourceLabels(ctx, loc, cName, map[string]string{"env": "dev"}, "stale")
+	assertError(t, err, true)
+
+	// Empty fingerprint skips the check.
+	_, err = m.SetResourceLabels(ctx, loc, cName, map[string]string{"env": "dev"}, "")
+	requireNoError(t, err)
+
+	// Current fingerprint is accepted and the fingerprint changes with labels.
+	cur, err := m.GetCluster(ctx, loc, cName)
+	requireNoError(t, err)
+
+	if cur.LabelFingerprint == got.LabelFingerprint {
+		t.Fatal("fingerprint should change when labels change")
+	}
+
+	_, err = m.SetResourceLabels(ctx, loc, cName, map[string]string{"env": "qa"}, cur.LabelFingerprint)
+	requireNoError(t, err)
+}
+
+func TestUpdateClusterNodeVersionPropagatesToPools(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	loc, cName := "us-central1", "host"
+
+	_, _, err := m.CreateCluster(ctx, &CreateClusterInput{Name: cName, Location: loc})
+	requireNoError(t, err)
+
+	_, _, err = m.CreateNodePool(ctx, loc, cName, &NodePoolSpec{Name: "extra"})
+	requireNoError(t, err)
+
+	// No NodePoolID rolls every pool.
+	_, err = m.UpdateCluster(ctx, loc, cName, UpdateClusterInput{NodeVersion: "1.29.0-gke.0"})
+	requireNoError(t, err)
+
+	for _, name := range []string{"default-pool", "extra"} {
+		np, gerr := m.GetNodePool(ctx, loc, cName, name)
+		requireNoError(t, gerr)
+		assertEqual(t, "1.29.0-gke.0", np.Version)
+	}
+
+	// A NodePoolID scopes the roll to one pool.
+	_, err = m.UpdateCluster(ctx, loc, cName, UpdateClusterInput{NodeVersion: "1.28.0-gke.0", NodePoolID: "extra"})
+	requireNoError(t, err)
+
+	extra, err := m.GetNodePool(ctx, loc, cName, "extra")
+	requireNoError(t, err)
+	assertEqual(t, "1.28.0-gke.0", extra.Version)
+
+	def, err := m.GetNodePool(ctx, loc, cName, "default-pool")
+	requireNoError(t, err)
+	assertEqual(t, "1.29.0-gke.0", def.Version)
 }
 
 // Hand-rolled helpers per CLAUDE.md (provider tests don't use testify).

--- a/providers/gcp/kubernetes_discovery_test.go
+++ b/providers/gcp/kubernetes_discovery_test.go
@@ -21,8 +21,9 @@ func TestResourceDiscoverySurfacesGKE(t *testing.T) {
 		t.Fatalf("CreateCluster: %v", err)
 	}
 
+	npCount := int64(1)
 	if _, _, err := p.GKE.CreateNodePool(ctx, "us-central1", "prod", &gke.NodePoolSpec{
-		Name: "np-1", InitialNodeCount: 1,
+		Name: "np-1", InitialNodeCount: &npCount,
 	}); err != nil {
 		t.Fatalf("CreateNodePool: %v", err)
 	}

--- a/server/gcp/cloudasset/sdk_test.go
+++ b/server/gcp/cloudasset/sdk_test.go
@@ -318,8 +318,9 @@ func TestSDKCloudAsset_KubernetesIndexing(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	npCount := int64(1)
 	_, _, err = cloudP.GKE.CreateNodePool(ctx, "us-central1", "prod", &gke.NodePoolSpec{
-		Name: "np-1", InitialNodeCount: 1,
+		Name: "np-1", InitialNodeCount: &npCount,
 	})
 	require.NoError(t, err)
 

--- a/server/gcp/gke/handler.go
+++ b/server/gcp/gke/handler.go
@@ -100,10 +100,15 @@ func (h *Handler) Matches(r *http.Request) bool {
 	case resourceClusters, resourceServerConfig:
 		return true
 	case resourceOperations:
-		if p.name != "" && p.action == "" {
+		// A named operation — a GET poll or a :cancel — is claimed only when
+		// this GKE mock actually recorded it, so a foreign-service operation
+		// (artifactregistry, eventarc, memorystore, …) falls through to the
+		// shared LRO handler instead of being falsely 404'd or canceled here.
+		if p.name != "" {
 			return h.gke.HasOperation(p.name)
 		}
 
+		// Unnamed collection GET (operations.list) stays with GKE.
 		return true
 	default:
 		return false

--- a/server/gcp/gke/matches_test.go
+++ b/server/gcp/gke/matches_test.go
@@ -1,0 +1,56 @@
+// Matches-scoping guard for the operations claim: a named operation poll or
+// :cancel is claimed only when the GKE mock recorded that op, so foreign-service
+// operations fall through to the shared LRO handler instead of being shadowed.
+
+package gke_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	providergke "github.com/stackshy/cloudemu/v2/providers/gcp/gke"
+	gke "github.com/stackshy/cloudemu/v2/server/gcp/gke"
+)
+
+func TestHandlerMatchesScopesOperationClaims(t *testing.T) {
+	opts := config.NewOptions(
+		config.WithClock(config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))),
+		config.WithRegion("us-central1"),
+		config.WithProjectID("demo"),
+	)
+	m := providergke.New(opts)
+	h := gke.New(m)
+
+	_, op, err := m.CreateCluster(context.Background(), &providergke.CreateClusterInput{
+		Name:     "k1",
+		Location: "us-central1",
+	})
+	if err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	base := "/v1/projects/demo/locations/us-central1/operations/"
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		want   bool
+	}{
+		{"own op GET", http.MethodGet, base + op.Name, true},
+		{"own op cancel", http.MethodPost, base + op.Name + ":cancel", true},
+		{"foreign op GET", http.MethodGet, base + "op-foreign", false},
+		{"foreign op cancel", http.MethodPost, base + "op-foreign:cancel", false},
+		{"operations list", http.MethodGet, "/v1/projects/demo/locations/us-central1/operations", true},
+	}
+
+	for _, tc := range cases {
+		req, _ := http.NewRequest(tc.method, tc.path, http.NoBody)
+		if got := h.Matches(req); got != tc.want {
+			t.Errorf("%s: Matches(%s) = %v, want %v", tc.name, tc.path, got, tc.want)
+		}
+	}
+}

--- a/server/gcp/gke/operations.go
+++ b/server/gcp/gke/operations.go
@@ -119,6 +119,7 @@ func (h *Handler) updateCluster(w http.ResponseWriter, r *http.Request, p *gkePa
 
 	if body.Update != nil {
 		in.NodeVersion = body.Update.DesiredNodeVersion
+		in.NodePoolID = body.Update.DesiredNodePoolID
 		in.MasterVersion = body.Update.DesiredMasterVersion
 		in.LoggingService = body.Update.DesiredLoggingService
 		in.MonitoringService = body.Update.DesiredMonitoringService
@@ -288,7 +289,7 @@ func (h *Handler) setResourceLabels(w http.ResponseWriter, r *http.Request, p *g
 		return
 	}
 
-	op, err := h.gke.SetResourceLabels(r.Context(), p.location, p.name, body.ResourceLabels)
+	op, err := h.gke.SetResourceLabels(r.Context(), p.location, p.name, body.ResourceLabels, body.LabelFingerprint)
 	if err != nil {
 		writeErr(w, err)
 		return

--- a/server/gcp/gke/sdk_parity_test.go
+++ b/server/gcp/gke/sdk_parity_test.go
@@ -1,0 +1,184 @@
+// Real-container-SDK parity tests for four GKE fidelity fixes: an explicit
+// initialNodeCount=0 surviving create (autoscale-from-zero), cluster
+// labelFingerprint round-trip + optimistic-concurrency enforcement on
+// setResourceLabels, and a cluster desiredNodeVersion propagating to node pools.
+
+package gke_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/api/container/v1"
+	"google.golang.org/api/googleapi"
+)
+
+// TestSDKGKENodePoolInitialNodeCountZero proves an explicitly-requested
+// initialNodeCount=0 (an autoscale-from-zero pool) survives create instead of
+// being clobbered to 1. The SDK omits a zero int unless it is force-sent, so
+// ForceSendFields reproduces what Terraform's provider does.
+func TestSDKGKENodePoolInitialNodeCountZero(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+	parentClus := clusterName(project, loc, "zero")
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "zero"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.NodePools.Create(parentClus, &container.CreateNodePoolRequest{
+		NodePool: &container.NodePool{
+			Name:             "scaler",
+			InitialNodeCount: 0,
+			ForceSendFields:  []string{"InitialNodeCount"},
+			Autoscaling: &container.NodePoolAutoscaling{
+				Enabled:         true,
+				MinNodeCount:    0,
+				MaxNodeCount:    5,
+				ForceSendFields: []string{"MinNodeCount"},
+			},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("nodepool create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.NodePools.Get(nodePoolName(project, loc, "zero", "scaler")).
+		Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("nodepool get: %v", err)
+	}
+
+	if got.InitialNodeCount != 0 {
+		t.Fatalf("initialNodeCount = %d, want 0", got.InitialNodeCount)
+	}
+}
+
+// TestSDKGKEDefaultPoolInitialNodeCountZero proves a cluster created with an
+// explicit initialNodeCount=0 bootstraps its default pool at 0 nodes rather
+// than defaulting to 1.
+func TestSDKGKEDefaultPoolInitialNodeCountZero(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{
+			Name:             "zdef",
+			InitialNodeCount: 0,
+			ForceSendFields:  []string{"InitialNodeCount"},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.Get(clusterName(project, loc, "zdef")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if len(got.NodePools) != 1 {
+		t.Fatalf("got %d pools, want 1 default pool", len(got.NodePools))
+	}
+
+	if got.NodePools[0].InitialNodeCount != 0 {
+		t.Fatalf("default pool initialNodeCount = %d, want 0", got.NodePools[0].InitialNodeCount)
+	}
+}
+
+// TestSDKGKELabelFingerprintRoundTripAndEnforcement proves a cluster GET
+// returns a labelFingerprint, that setResourceLabels rejects a stale
+// fingerprint, and that the current fingerprint is accepted.
+func TestSDKGKELabelFingerprintRoundTripAndEnforcement(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+	name := clusterName(project, loc, "labels")
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "labels", ResourceLabels: map[string]string{"env": "prod"}},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.LabelFingerprint == "" {
+		t.Fatal("expected a non-empty labelFingerprint on cluster GET")
+	}
+
+	// A stale fingerprint must be rejected with FAILED_PRECONDITION (HTTP 409).
+	_, err = svc.Projects.Locations.Clusters.SetResourceLabels(name, &container.SetLabelsRequest{
+		ResourceLabels:   map[string]string{"env": "staging"},
+		LabelFingerprint: "deadbeefdeadbeef",
+	}).Context(ctx).Do()
+	if err == nil {
+		t.Fatal("expected setResourceLabels with stale fingerprint to fail")
+	}
+
+	if gerr, ok := err.(*googleapi.Error); ok && gerr.Code != 409 {
+		t.Fatalf("stale fingerprint error code = %d, want 409", gerr.Code)
+	}
+
+	// The current fingerprint is accepted.
+	if _, err := svc.Projects.Locations.Clusters.SetResourceLabels(name, &container.SetLabelsRequest{
+		ResourceLabels:   map[string]string{"env": "staging"},
+		LabelFingerprint: got.LabelFingerprint,
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("setResourceLabels with current fingerprint: %v", err)
+	}
+
+	after, err := svc.Projects.Locations.Clusters.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("get after label change: %v", err)
+	}
+
+	if after.ResourceLabels["env"] != "staging" {
+		t.Fatalf("labels not applied: %v", after.ResourceLabels)
+	}
+
+	if after.LabelFingerprint == got.LabelFingerprint {
+		t.Fatal("labelFingerprint should change when labels change")
+	}
+}
+
+// TestSDKGKEClusterNodeVersionPropagatesToPools proves a cluster-level
+// desiredNodeVersion update rolls the version of the targeted node pool.
+func TestSDKGKEClusterNodeVersionPropagatesToPools(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+	name := clusterName(project, loc, "ver")
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "ver"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	const newVersion = "1.29.0-gke.0"
+
+	if _, err := svc.Projects.Locations.Clusters.Update(name, &container.UpdateClusterRequest{
+		Update: &container.ClusterUpdate{
+			DesiredNodeVersion: newVersion,
+			DesiredNodePoolId:  "default-pool",
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("update cluster: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.NodePools.Get(nodePoolName(project, loc, "ver", "default-pool")).
+		Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("nodepool get: %v", err)
+	}
+
+	if got.Version != newVersion {
+		t.Fatalf("node pool version = %q, want %q", got.Version, newVersion)
+	}
+}

--- a/server/gcp/gke/types.go
+++ b/server/gcp/gke/types.go
@@ -20,12 +20,13 @@ type gkeCluster struct {
 	Zone              string            `json:"zone,omitempty"`
 	Network           string            `json:"network,omitempty"`
 	Subnetwork        string            `json:"subnetwork,omitempty"`
-	InitialNodeCount  int64             `json:"initialNodeCount,omitempty"`
+	InitialNodeCount  *int64            `json:"initialNodeCount,omitempty"`
 	NodeConfig        *gkeNodeConfig    `json:"nodeConfig,omitempty"`
 	CurrentNodeCount  int64             `json:"currentNodeCount,omitempty"`
 	LoggingService    string            `json:"loggingService,omitempty"`
 	MonitoringService string            `json:"monitoringService,omitempty"`
 	ResourceLabels    map[string]string `json:"resourceLabels,omitempty"`
+	LabelFingerprint  string            `json:"labelFingerprint,omitempty"`
 	NodePools         []gkeNodePool     `json:"nodePools,omitempty"`
 	NodeIpv4CIDRSize  int64             `json:"nodeIpv4CidrSize,omitempty"`
 	ClusterIpv4Cidr   string            `json:"clusterIpv4Cidr,omitempty"`
@@ -50,7 +51,7 @@ type gkeMasterAuth struct {
 type gkeNodePool struct {
 	Name             string             `json:"name,omitempty"`
 	Version          string             `json:"version,omitempty"`
-	InitialNodeCount int64              `json:"initialNodeCount,omitempty"`
+	InitialNodeCount *int64             `json:"initialNodeCount,omitempty"`
 	Locations        []string           `json:"locations,omitempty"`
 	Config           *gkeNodeConfig     `json:"config,omitempty"`
 	Autoscaling      *gkeAutoscaling    `json:"autoscaling,omitempty"`
@@ -87,6 +88,7 @@ type createClusterReq struct {
 type updateClusterReq struct {
 	Update *struct {
 		DesiredNodeVersion       string            `json:"desiredNodeVersion,omitempty"`
+		DesiredNodePoolID        string            `json:"desiredNodePoolId,omitempty"`
 		DesiredMasterVersion     string            `json:"desiredMasterVersion,omitempty"`
 		DesiredLoggingService    string            `json:"desiredLoggingService,omitempty"`
 		DesiredMonitoringService string            `json:"desiredMonitoringService,omitempty"`
@@ -131,7 +133,8 @@ type setMaintenancePolicyReq struct {
 }
 
 type setLabelsReq struct {
-	ResourceLabels map[string]string `json:"resourceLabels,omitempty"`
+	ResourceLabels   map[string]string `json:"resourceLabels,omitempty"`
+	LabelFingerprint string            `json:"labelFingerprint,omitempty"`
 }
 
 type createNodePoolReq struct {
@@ -193,6 +196,10 @@ type gkeServerConfig struct {
 // every selfLink/targetLink it returns.
 const selfLinkBase = "https://container.googleapis.com/v1/"
 
+// int64Ptr wraps v so the wire shape emits it explicitly — including a genuine
+// 0 node count, which a bare int64 with omitempty would silently drop.
+func int64Ptr(v int64) *int64 { return &v }
+
 // toClusterResource converts a provider Cluster into the wire shape. The
 // endpoint argument is what the Mock reported via Endpoint(location, name) —
 // either the in-memory K8s data-plane URL when a data plane is wired, or the
@@ -211,11 +218,12 @@ func toClusterResource(c *gke.Cluster, project, endpoint string, pools []gke.Nod
 		Zone:              c.Location,
 		Network:           c.Network,
 		Subnetwork:        c.Subnetwork,
-		InitialNodeCount:  c.InitialNodeCount,
+		InitialNodeCount:  int64Ptr(c.InitialNodeCount),
 		CurrentNodeCount:  currentNodes,
 		LoggingService:    c.LoggingService,
 		MonitoringService: c.MonitoringService,
 		ResourceLabels:    c.ResourceLabels,
+		LabelFingerprint:  c.LabelFingerprint,
 		NodeIpv4CIDRSize:  c.NodeIPv4CIDRSize,
 		ClusterIpv4Cidr:   c.ClusterIPv4CIDR,
 		ServicesIpv4Cidr:  c.ServicesIPv4CIDR,
@@ -255,7 +263,7 @@ func toNodePoolResource(np *gke.NodePool, project string) gkeNodePool {
 	out := gkeNodePool{
 		Name:             np.Name,
 		Version:          np.Version,
-		InitialNodeCount: np.NodeCount,
+		InitialNodeCount: int64Ptr(np.NodeCount),
 		Config: &gkeNodeConfig{
 			MachineType: np.MachineType,
 			DiskSizeGb:  np.DiskSizeGB,


### PR DESCRIPTION
## Summary

Fixes four GKE control-plane fidelity bugs surfaced by a real-user (container SDK) audit. All in `server/gcp/gke/` + `providers/gcp/gke/`.

### BUG1 — `initialNodeCount=0` clobbered to 1 on create
`nodePoolFromSpec` and the default-pool bootstrap defaulted a `0` count to 1, so autoscale-from-zero pools read back 1 and produced a perpetual `google_container_node_pool` diff in Terraform. `InitialNodeCount` is now a `*int64` end to end (wire → provider spec), so an explicit `0` (esp. with `autoscaling.minNodeCount=0`) persists while a genuinely absent field still defaults to the GKE default. Consistent with `setSize 0`, which already worked.

### BUG2 — cluster `labelFingerprint` missing + not enforced
Added `LabelFingerprint` to the cluster model, computed deterministically from the (sorted) resource labels and returned on cluster GET/List. `setResourceLabels` now enforces optimistic concurrency: a non-empty, stale fingerprint fails with `FAILED_PRECONDITION` (HTTP 409); an empty incoming fingerprint skips the check. The fingerprint changes whenever labels change.

### BUG3 — operations list/`:cancel` over-claimed foreign ops
`Matches` now claims a named operation (GET poll or `:cancel`) only when the GKE mock actually recorded it (`HasOperation`), so foreign-service operations fall through to the shared LRO handler instead of being shadowed/`404`'d. The unnamed collection GET (`operations.list`) still stays with GKE.

### BUG4 — cluster `desiredNodeVersion` not propagated to node pools
`UpdateCluster` now rolls the version of the targeted node pool(s) when `desiredNodeVersion` is set — scoped to one pool via `desiredNodePoolId`, else all pools — matching real GKE, where a cluster node-version update propagates to the pools it upgrades.

## Tests (real container SDK over httptest)
- `initialNodeCount=0` node pool and default pool → GET returns 0
- cluster GET returns `labelFingerprint`; stale fingerprint → 409; current fingerprint accepted and rotates
- `desiredNodeVersion` update rolls the pool version
- handler-level `Matches` scoping for own/foreign op GET + cancel + list
- provider-level coverage for pointer semantics, fingerprint enforcement, and version propagation (incl. scoped `NodePoolID`)

`go generate ./...` and `go run ./internal/compatgen` are zero-diff.
