### PR TITLE
fix(azure-monitor): PATCH on insights resources, fire action groups on alarm breach, model autoscaleSettings

### DIFF
--- a/providers/azure/monitor/actiongroups.go
+++ b/providers/azure/monitor/actiongroups.go
@@ -1,0 +1,218 @@
+package monitor
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+// Receiver type discriminators recorded on a delivery.
+const (
+	receiverEmail         = "email"
+	receiverWebhook       = "webhook"
+	receiverSMS           = "sms"
+	receiverAzureFunction = "azureFunction"
+)
+
+// ActionGroupReceiver is one resolved receiver of an action group. Endpoint is
+// the receiver's address: the email address, webhook URI, phone number, or
+// Azure Function trigger URL, depending on Type.
+type ActionGroupReceiver struct {
+	Type     string
+	Name     string
+	Endpoint string
+}
+
+// ActionGroupDelivery records one action-group receiver fired by an alert
+// breach. It is the observable side effect that lets a caller (or a test)
+// assert an OK->ALARM transition actually reached the action group's receivers,
+// mirroring how an AWS CloudWatch alarm publishes to its SNS topic subscribers.
+type ActionGroupDelivery struct {
+	ActionGroupID string
+	ReceiverType  string
+	ReceiverName  string
+	Endpoint      string
+	AlarmName     string
+	NewState      string
+	Timestamp     time.Time
+}
+
+// actionGroupData is the stored, evaluation-side view of an action group: its
+// resource id and the receivers a breach delivers to.
+type actionGroupData struct {
+	ID        string
+	Enabled   bool
+	Receivers []ActionGroupReceiver
+}
+
+// WebhookDeliverer delivers an alert notification to a webhook receiver's URI.
+// It mirrors the AWS ActionPublisher wiring: nil (the default) records the
+// delivery without a network call, while a wired deliverer additionally
+// performs the real HTTP POST so an end-to-end webhook flow can be exercised.
+type WebhookDeliverer interface {
+	Deliver(ctx context.Context, uri, payload string) error
+}
+
+// SetWebhookDeliverer wires a webhook deliverer so an alert breach that targets
+// an action group with webhook receivers performs the real HTTP POST in
+// addition to recording the delivery. Nil leaves webhook delivery record-only.
+func (m *Mock) SetWebhookDeliverer(d WebhookDeliverer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.webhookDeliverer = d
+}
+
+// RegisterActionGroup registers (or replaces) an action group's receivers under
+// its ARM resource id so an alert that names the id in its actions delivers to
+// the receivers on a breach. The wire handler calls this on an actionGroups
+// create/update; the id is stored case-insensitively because a metric alert may
+// reference it with different casing than it was created under.
+func (m *Mock) RegisterActionGroup(id string, properties map[string]any) {
+	m.actionGroups.Set(strings.ToLower(id), &actionGroupData{
+		ID:        id,
+		Enabled:   actionGroupEnabled(properties),
+		Receivers: parseActionGroupReceivers(properties),
+	})
+}
+
+// UnregisterActionGroup removes an action group so its receivers stop being
+// delivered to. The wire handler calls this on an actionGroups delete.
+func (m *Mock) UnregisterActionGroup(id string) {
+	m.actionGroups.Delete(strings.ToLower(id))
+}
+
+// ActionGroupDeliveries returns a snapshot of every action-group receiver
+// delivery fired so far, in delivery order.
+func (m *Mock) ActionGroupDeliveries() []ActionGroupDelivery {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return append([]ActionGroupDelivery{}, m.deliveries...)
+}
+
+// fireActionGroups delivers an alarm's action groups on a transition into
+// ALARM: each AlarmActions id is resolved against the registered action groups
+// and every receiver is recorded (and, for webhook receivers with a wired
+// deliverer, POSTed). A disabled action group delivers to none of its receivers.
+func (m *Mock) fireActionGroups(alarm *alarmData, newState string, now time.Time) {
+	for _, agID := range alarm.AlarmActions {
+		ag, ok := m.actionGroups.Get(strings.ToLower(agID))
+		if !ok || !ag.Enabled {
+			continue
+		}
+
+		for _, rcv := range ag.Receivers {
+			m.recordDelivery(&ActionGroupDelivery{
+				ActionGroupID: ag.ID,
+				ReceiverType:  rcv.Type,
+				ReceiverName:  rcv.Name,
+				Endpoint:      rcv.Endpoint,
+				AlarmName:     alarm.Name,
+				NewState:      newState,
+				Timestamp:     now,
+			})
+
+			m.deliverWebhook(rcv, alarm, newState, now)
+		}
+	}
+}
+
+// deliverWebhook performs the real HTTP POST for a webhook receiver when a
+// deliverer is wired; it is a no-op for non-webhook receivers or when none is.
+func (m *Mock) deliverWebhook(rcv ActionGroupReceiver, alarm *alarmData, newState string, now time.Time) {
+	if rcv.Type != receiverWebhook || rcv.Endpoint == "" {
+		return
+	}
+
+	m.mu.RLock()
+	deliverer := m.webhookDeliverer
+	m.mu.RUnlock()
+
+	if deliverer == nil {
+		return
+	}
+
+	_ = deliverer.Deliver(context.Background(), rcv.Endpoint, alarmPayload(alarm, newState, now))
+}
+
+// recordDelivery appends one delivery under the store lock.
+func (m *Mock) recordDelivery(d *ActionGroupDelivery) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.deliveries = append(m.deliveries, *d)
+}
+
+// alarmPayload renders the notification body delivered to a webhook receiver.
+func alarmPayload(alarm *alarmData, newState string, now time.Time) string {
+	return `{"alertName":"` + alarm.Name +
+		`","namespace":"` + alarm.Namespace +
+		`","metricName":"` + alarm.MetricName +
+		`","newState":"` + newState +
+		`","timestamp":"` + now.UTC().Format(time.RFC3339) + `"}`
+}
+
+// actionGroupEnabled reads properties.enabled, defaulting to true (real action
+// groups are enabled unless explicitly disabled).
+func actionGroupEnabled(props map[string]any) bool {
+	enabled, ok := props["enabled"].(bool)
+	if !ok {
+		return true
+	}
+
+	return enabled
+}
+
+// parseActionGroupReceivers flattens the typed receiver arrays of an action
+// group's properties into a uniform receiver list.
+func parseActionGroupReceivers(props map[string]any) []ActionGroupReceiver {
+	specs := []struct {
+		key, typ, endpointKey string
+	}{
+		{"emailReceivers", receiverEmail, "emailAddress"},
+		{"webhookReceivers", receiverWebhook, "serviceUri"},
+		{"smsReceivers", receiverSMS, "phoneNumber"},
+		{"azureFunctionReceivers", receiverAzureFunction, "httpTriggerUrl"},
+	}
+
+	out := make([]ActionGroupReceiver, 0, len(specs))
+	for _, s := range specs {
+		out = append(out, receiversOf(props, s.key, s.typ, s.endpointKey)...)
+	}
+
+	return out
+}
+
+// receiversOf extracts the receivers under properties[key], reading each entry's
+// "name" and the endpoint under endpointKey.
+func receiversOf(props map[string]any, key, typ, endpointKey string) []ActionGroupReceiver {
+	raw, ok := props[key].([]any)
+	if !ok {
+		return nil
+	}
+
+	out := make([]ActionGroupReceiver, 0, len(raw))
+
+	for _, entry := range raw {
+		item, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		out = append(out, ActionGroupReceiver{
+			Type:     typ,
+			Name:     mapString(item, "name"),
+			Endpoint: mapString(item, endpointKey),
+		})
+	}
+
+	return out
+}
+
+// mapString reads a string field from a decoded JSON object, empty when absent.
+func mapString(m map[string]any, key string) string {
+	s, _ := m[key].(string)
+
+	return s
+}

--- a/providers/azure/monitor/monitor.go
+++ b/providers/azure/monitor/monitor.go
@@ -55,21 +55,25 @@ type alarmData struct {
 
 // Mock is an in-memory mock implementation of the Azure Monitor service.
 type Mock struct {
-	mu       sync.RWMutex
-	metrics  map[metricKey][]driver.MetricDatum
-	alarms   *memstore.Store[*alarmData]
-	channels *memstore.Store[*driver.NotificationChannelInfo]
-	history  []driver.AlarmHistoryEntry
-	opts     *config.Options
+	mu               sync.RWMutex
+	metrics          map[metricKey][]driver.MetricDatum
+	alarms           *memstore.Store[*alarmData]
+	channels         *memstore.Store[*driver.NotificationChannelInfo]
+	actionGroups     *memstore.Store[*actionGroupData]
+	deliveries       []ActionGroupDelivery
+	webhookDeliverer WebhookDeliverer
+	history          []driver.AlarmHistoryEntry
+	opts             *config.Options
 }
 
 // New creates a new Azure Monitor mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		metrics:  make(map[metricKey][]driver.MetricDatum),
-		alarms:   memstore.New[*alarmData](),
-		channels: memstore.New[*driver.NotificationChannelInfo](),
-		opts:     opts,
+		metrics:      make(map[metricKey][]driver.MetricDatum),
+		alarms:       memstore.New[*alarmData](),
+		channels:     memstore.New[*driver.NotificationChannelInfo](),
+		actionGroups: memstore.New[*actionGroupData](),
+		opts:         opts,
 	}
 }
 
@@ -149,8 +153,9 @@ func (m *Mock) evaluateSingleAlarm(alarm *alarmData, namespace, metricName strin
 // transitionAlarm sets an alert rule's state and, only on a state change, records
 // a history entry — mirroring CloudWatch, where the history entry happens on a
 // state change whether it came from metric evaluation or a manual SetAlarmState.
-// Azure Monitor action groups aren't delivered by the emulator (no publisher is
-// wired), so the state's actions are a no-op beyond the recorded transition.
+// On a transition into ALARM it also fires the alert's action groups, resolving
+// each AlarmActions id against the registered action groups and delivering to
+// their receivers (mirroring the AWS alarm -> SNS action wiring).
 func (m *Mock) transitionAlarm(alarm *alarmData, newState, reason string, now time.Time) {
 	oldState := alarm.State
 
@@ -161,6 +166,10 @@ func (m *Mock) transitionAlarm(alarm *alarmData, newState, reason string, now ti
 
 	alarm.State = newState
 	alarm.StateReason = reason
+
+	if oldState != newState && newState == alarmeval.StateAlarm {
+		m.fireActionGroups(alarm, newState, now)
+	}
 }
 
 // appendHistory records one alert rule state transition in the history log.

--- a/server/azure/monitor/action_group_firing_test.go
+++ b/server/azure/monitor/action_group_firing_test.go
@@ -1,0 +1,225 @@
+package monitor_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	azmonitor "github.com/stackshy/cloudemu/v2/providers/azure/monitor"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// webhookPoster is a WebhookDeliverer that performs the real HTTP POST to a
+// webhook receiver, so the firing test can assert an action group's webhook
+// receiver was actually hit end-to-end.
+type webhookPoster struct{}
+
+func (webhookPoster) Deliver(ctx context.Context, uri, _ string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uri, http.NoBody)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	return resp.Body.Close()
+}
+
+const (
+	vm1URI = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/vm1"
+	vm2URI = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/vm2"
+	cpuNS  = "Microsoft.Compute/virtualMachines"
+	cpuMet = "Percentage CPU"
+)
+
+// TestSDKAlarmBreachFiresActionGroup is the load-bearing regression for the
+// action-group firing finding: an OK->ALARM transition must resolve the alert's
+// AlarmActions ids against the registered action groups and deliver to each
+// receiver (recorded, and — for webhook receivers — POSTed for real). Both the
+// action group and the alert are created through the real armmonitor SDK; the
+// breach is driven by pushing a datapoint at the fake clock's now.
+func TestSDKAlarmBreachFiresActionGroup(t *testing.T) {
+	clock := config.NewFakeClock(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	cloudP := cloudemu.NewAzure(config.WithClock(clock))
+	cloudP.Monitor.SetWebhookDeliverer(webhookPoster{})
+
+	srv := azureserver.New(azureserver.Drivers{Monitor: cloudP.Monitor})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	var webhookHits int32
+
+	webhookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&webhookHits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(webhookSrv.Close)
+
+	ctx := context.Background()
+
+	agClient, err := armmonitor.NewActionGroupsClient("sub-1", fakeCred{}, armClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := agClient.CreateOrUpdate(ctx, "rg-1", "ops-ag", armmonitor.ActionGroupResource{
+		Location: to.Ptr("global"),
+		Properties: &armmonitor.ActionGroup{
+			GroupShortName: to.Ptr("ops"),
+			Enabled:        to.Ptr(true),
+			EmailReceivers: []*armmonitor.EmailReceiver{
+				{Name: to.Ptr("oncall"), EmailAddress: to.Ptr("oncall@example.com")},
+			},
+			WebhookReceivers: []*armmonitor.WebhookReceiver{
+				{Name: to.Ptr("hook"), ServiceURI: to.Ptr(webhookSrv.URL)},
+			},
+		},
+	}, nil); err != nil {
+		t.Fatalf("action group CreateOrUpdate: %v", err)
+	}
+
+	const agID = "/subscriptions/sub-1/resourceGroups/rg-1/providers/microsoft.insights/actionGroups/ops-ag"
+
+	alertClient, err := armmonitor.NewMetricAlertsClient("sub-1", fakeCred{}, armClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := alertClient.CreateOrUpdate(ctx, "rg-1", "cpu-hot", cpuAlert(vm1URI, agID, 50), nil); err != nil {
+		t.Fatalf("metric alert CreateOrUpdate: %v", err)
+	}
+
+	// A breaching datapoint for vm1 drives the alarm OK->ALARM, which fires the
+	// action group.
+	pushCPU(t, cloudP.Monitor, clock, vm1URI, 95)
+
+	deliveries := cloudP.Monitor.ActionGroupDeliveries()
+	if len(deliveries) != 2 {
+		t.Fatalf("deliveries = %d, want 2 (email + webhook); %+v", len(deliveries), deliveries)
+	}
+
+	types := map[string]bool{}
+	for _, d := range deliveries {
+		if d.AlarmName != "cpu-hot" || d.NewState != "ALARM" {
+			t.Fatalf("delivery = %+v, want alarm cpu-hot -> ALARM", d)
+		}
+
+		types[d.ReceiverType] = true
+	}
+
+	if !types["email"] || !types["webhook"] {
+		t.Fatalf("delivered receiver types = %v, want email+webhook", types)
+	}
+
+	if got := atomic.LoadInt32(&webhookHits); got != 1 {
+		t.Fatalf("webhook receiver hits = %d, want 1 (webhook not delivered)", got)
+	}
+}
+
+// TestSDKDimensionScopedAlertIgnoresOtherResource covers GAP-B: an alert scoped
+// to vm1 must not fire on vm2's datapoints, even though both share the same
+// namespace/metric. Only vm1's breaching datapoint drives it to ALARM.
+func TestSDKDimensionScopedAlertIgnoresOtherResource(t *testing.T) {
+	clock := config.NewFakeClock(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	cloudP := cloudemu.NewAzure(config.WithClock(clock))
+
+	srv := azureserver.New(azureserver.Drivers{Monitor: cloudP.Monitor})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	alertClient, err := armmonitor.NewMetricAlertsClient("sub-1", fakeCred{}, armClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := alertClient.CreateOrUpdate(ctx, "rg-1", "vm1-cpu", cpuAlert(vm1URI, "", 50), nil); err != nil {
+		t.Fatalf("metric alert CreateOrUpdate: %v", err)
+	}
+
+	// vm2 breaches, but the alert is scoped to vm1 — it must stay out of ALARM.
+	pushCPU(t, cloudP.Monitor, clock, vm2URI, 95)
+
+	if state := alarmState(t, cloudP.Monitor, "vm1-cpu"); state == "ALARM" {
+		t.Fatalf("alert fired on another resource's datapoint (state=%s)", state)
+	}
+
+	// vm1 breaches — now it must fire.
+	pushCPU(t, cloudP.Monitor, clock, vm1URI, 95)
+
+	if state := alarmState(t, cloudP.Monitor, "vm1-cpu"); state != "ALARM" {
+		t.Fatalf("alert did not fire on its own resource's datapoint (state=%s)", state)
+	}
+}
+
+// cpuAlert builds a single-resource Percentage CPU alert scoped to scopeURI,
+// firing above threshold; when agID is non-empty it links that action group.
+func cpuAlert(scopeURI, agID string, threshold float64) armmonitor.MetricAlertResource {
+	props := &armmonitor.MetricAlertProperties{
+		Severity:            to.Ptr[int32](3),
+		Enabled:             to.Ptr(true),
+		Scopes:              []*string{to.Ptr(scopeURI)},
+		EvaluationFrequency: to.Ptr("PT1M"),
+		WindowSize:          to.Ptr("PT5M"),
+		Criteria: &armmonitor.MetricAlertSingleResourceMultipleMetricCriteria{
+			AllOf: []*armmonitor.MetricCriteria{{
+				Name:            to.Ptr("cpu"),
+				MetricName:      to.Ptr(cpuMet),
+				MetricNamespace: to.Ptr(cpuNS),
+				Operator:        to.Ptr(armmonitor.OperatorGreaterThan),
+				Threshold:       to.Ptr(threshold),
+				TimeAggregation: to.Ptr(armmonitor.AggregationTypeEnumAverage),
+			}},
+		},
+	}
+
+	if agID != "" {
+		props.Actions = []*armmonitor.MetricAlertAction{{ActionGroupID: to.Ptr(agID)}}
+	}
+
+	return armmonitor.MetricAlertResource{Location: to.Ptr("global"), Properties: props}
+}
+
+// pushCPU publishes one Percentage CPU datapoint for resourceURI at the clock's
+// now, so it lands inside the alarm's evaluation window.
+func pushCPU(t *testing.T, mon *azmonitor.Mock, clock *config.FakeClock, resourceURI string, value float64) {
+	t.Helper()
+
+	if err := mon.PutMetricData(context.Background(), []mondriver.MetricDatum{{
+		Namespace:  cpuNS,
+		MetricName: cpuMet,
+		Value:      value,
+		Timestamp:  clock.Now(),
+		Dimensions: map[string]string{"resourceId": resourceURI},
+	}}); err != nil {
+		t.Fatalf("PutMetricData: %v", err)
+	}
+}
+
+// alarmState returns the current state of the named alarm.
+func alarmState(t *testing.T, mon *azmonitor.Mock, name string) string {
+	t.Helper()
+
+	alarms, err := mon.DescribeAlarms(context.Background(), []string{name})
+	if err != nil {
+		t.Fatalf("DescribeAlarms: %v", err)
+	}
+
+	if len(alarms) != 1 {
+		t.Fatalf("alarms = %d, want 1", len(alarms))
+	}
+
+	return alarms[0].State
+}

--- a/server/azure/monitor/autoscale_settings_test.go
+++ b/server/azure/monitor/autoscale_settings_test.go
@@ -1,0 +1,112 @@
+package monitor_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKAutoscaleSettingRoundTrip covers GAP-A: autoscaleSettings were entirely
+// unserved (the canonicalType map skipped them), so `az monitor autoscale` and
+// azurerm_monitor_autoscale_setting failed. The real armmonitor
+// AutoscaleSettingsClient must create and read back a setting with its profiles,
+// rules (metricTrigger + scaleAction) and capacity intact.
+func TestSDKAutoscaleSettingRoundTrip(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{Monitor: cloudP.Monitor}))
+	t.Cleanup(ts.Close)
+
+	client, err := armmonitor.NewAutoscaleSettingsClient("sub-1", fakeCred{}, armClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	targetURI := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"
+
+	setting := armmonitor.AutoscaleSettingResource{
+		Location: to.Ptr("eastus"),
+		Properties: &armmonitor.AutoscaleSetting{
+			Enabled:           to.Ptr(true),
+			Name:              to.Ptr("cpu-scale"),
+			TargetResourceURI: to.Ptr(targetURI),
+			Profiles: []*armmonitor.AutoscaleProfile{{
+				Name:     to.Ptr("default"),
+				Capacity: &armmonitor.ScaleCapacity{Minimum: to.Ptr("1"), Maximum: to.Ptr("10"), Default: to.Ptr("2")},
+				Rules: []*armmonitor.ScaleRule{{
+					MetricTrigger: &armmonitor.MetricTrigger{
+						MetricName:        to.Ptr("Percentage CPU"),
+						MetricResourceURI: to.Ptr(targetURI),
+						Operator:          to.Ptr(armmonitor.ComparisonOperationTypeGreaterThan),
+						Statistic:         to.Ptr(armmonitor.MetricStatisticTypeAverage),
+						Threshold:         to.Ptr(75.0),
+						TimeAggregation:   to.Ptr(armmonitor.TimeAggregationTypeAverage),
+						TimeGrain:         to.Ptr("PT1M"),
+						TimeWindow:        to.Ptr("PT5M"),
+					},
+					ScaleAction: &armmonitor.ScaleAction{
+						Cooldown:  to.Ptr("PT5M"),
+						Direction: to.Ptr(armmonitor.ScaleDirectionIncrease),
+						Type:      to.Ptr(armmonitor.ScaleTypeChangeCount),
+						Value:     to.Ptr("1"),
+					},
+				}},
+			}},
+		},
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, "rg-1", "vmss-autoscale", setting, nil); err != nil {
+		t.Fatalf("CreateOrUpdate: %v", err)
+	}
+
+	got, err := client.Get(ctx, "rg-1", "vmss-autoscale", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Name == nil || *got.Name != "vmss-autoscale" {
+		t.Fatalf("name = %v, want vmss-autoscale", got.Name)
+	}
+
+	assertAutoscaleRoundTrip(t, got.Properties, targetURI)
+}
+
+func assertAutoscaleRoundTrip(t *testing.T, props *armmonitor.AutoscaleSetting, targetURI string) {
+	t.Helper()
+
+	if props == nil {
+		t.Fatal("properties nil")
+	}
+
+	if props.TargetResourceURI == nil || *props.TargetResourceURI != targetURI {
+		t.Fatalf("targetResourceUri = %v, want %s", props.TargetResourceURI, targetURI)
+	}
+
+	if len(props.Profiles) != 1 {
+		t.Fatalf("profiles = %d, want 1", len(props.Profiles))
+	}
+
+	profile := props.Profiles[0]
+	if profile.Capacity == nil || deref(profile.Capacity.Maximum) != "10" {
+		t.Fatalf("capacity max = %v, want 10", profile.Capacity)
+	}
+
+	if len(profile.Rules) != 1 {
+		t.Fatalf("rules = %d, want 1", len(profile.Rules))
+	}
+
+	rule := profile.Rules[0]
+	if rule.MetricTrigger == nil || deref(rule.MetricTrigger.MetricName) != "Percentage CPU" {
+		t.Fatalf("metricTrigger dropped: %+v", rule.MetricTrigger)
+	}
+
+	if rule.ScaleAction == nil || rule.ScaleAction.Direction == nil ||
+		*rule.ScaleAction.Direction != armmonitor.ScaleDirectionIncrease {
+		t.Fatalf("scaleAction dropped: %+v", rule.ScaleAction)
+	}
+}

--- a/server/azure/monitor/handler.go
+++ b/server/azure/monitor/handler.go
@@ -20,13 +20,24 @@ const (
 	typeAlerts      = "metricAlerts"
 	typeActionGroup = "actionGroups"
 	typeActivityLog = "activityLogAlerts"
+	typeAutoscale   = "autoscaleSettings"
 	defaultLocation = "global"
 )
 
+// actionGroupRegistrar is the optional driver capability that lets the handler
+// wire an action group's receivers into the alarm-evaluation engine, so a metric
+// alert that names the group delivers to its receivers on a breach. The Azure
+// Monitor mock implements it; a driver that does not simply skips the wiring.
+type actionGroupRegistrar interface {
+	RegisterActionGroup(id string, properties map[string]any)
+	UnregisterActionGroup(id string)
+}
+
 // Handler serves the microsoft.insights ARM resource types: metricAlerts,
-// actionGroups and activityLogAlerts. Each is stored in full so reads round-trip
-// the caller's definition; metricAlerts additionally register the named metric
-// with the driver so the alarm evaluates.
+// actionGroups, activityLogAlerts and autoscaleSettings. Each is stored in full
+// so reads round-trip the caller's definition; metricAlerts additionally
+// register the named metric with the driver so the alarm evaluates, and
+// actionGroups register their receivers so a breach delivers to them.
 type Handler struct {
 	mon   mondriver.Monitoring
 	store *resourceStore
@@ -52,6 +63,8 @@ func canonicalType(resourceType string) string {
 		return typeActionGroup
 	case strings.ToLower(typeActivityLog):
 		return typeActivityLog
+	case strings.ToLower(typeAutoscale):
+		return typeAutoscale
 	default:
 		return ""
 	}
@@ -91,6 +104,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPut:
 		h.createOrUpdate(w, r, &rp, kind)
+	case http.MethodPatch:
+		h.patch(w, r, &rp, kind)
 	case http.MethodGet:
 		h.get(w, &rp, kind)
 	case http.MethodDelete:
@@ -114,11 +129,11 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 	res := &armResource{Location: req.Location, Tags: req.Tags, Properties: req.Properties}
 	if kind == typeAlerts {
 		res.Properties = withProvisioningState(res.Properties)
+	}
 
-		if err := h.registerAlarm(r, rp.ResourceName, req.Properties); err != nil {
-			azurearm.WriteCErr(w, err)
-			return
-		}
+	if err := h.applySideEffects(r, rp, kind, res.Properties); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
 	}
 
 	existed := h.store.set(rp.Subscription, rp.ResourceGroup, kind, rp.ResourceName, res)
@@ -178,5 +193,89 @@ func (h *Handler) delete(w http.ResponseWriter, rp *azurearm.ResourcePath, kind 
 		_ = h.mon.DeleteAlarm(context.Background(), rp.ResourceName)
 	}
 
+	if kind == typeActionGroup {
+		h.unregisterActionGroup(rp)
+	}
+
 	w.WriteHeader(http.StatusOK)
+}
+
+// patch applies an ARM Update (HTTP PATCH) over a stored resource under nil-mask
+// semantics: omitted top-level fields (location, tags, properties) are
+// preserved, supplied ones are merged over the stored value. metricAlerts and
+// actionGroups re-run their side-effect wiring against the merged properties so
+// an updated threshold or receiver set takes effect. Update on a missing
+// resource is a 404, matching the real ARM Update contract.
+func (h *Handler) patch(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, kind string) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	existing, ok := h.store.get(rp.Subscription, rp.ResourceGroup, kind, rp.ResourceName)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", kind+" "+rp.ResourceName+" not found")
+		return
+	}
+
+	var req resourceRequest
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	merged := mergeResource(existing, &req)
+	if kind == typeAlerts {
+		merged.Properties = withProvisioningState(merged.Properties)
+	}
+
+	if err := h.applySideEffects(r, rp, kind, merged.Properties); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	h.store.set(rp.Subscription, rp.ResourceGroup, kind, rp.ResourceName, merged)
+
+	azurearm.WriteJSON(w, http.StatusOK, toResourceJSON(rp, kind, merged))
+}
+
+// applySideEffects runs the driver-side wiring a resource's stored properties
+// imply: metricAlerts register/refresh the evaluated alarm, actionGroups
+// register/refresh their receivers. Other kinds (activityLogAlerts,
+// autoscaleSettings) are pure round-trip resources with no side effect.
+func (h *Handler) applySideEffects(r *http.Request, rp *azurearm.ResourcePath, kind string, props map[string]any) error {
+	switch kind {
+	case typeAlerts:
+		return h.registerAlarm(r, rp.ResourceName, props)
+	case typeActionGroup:
+		h.registerActionGroup(rp, props)
+	}
+
+	return nil
+}
+
+// registerActionGroup wires an action group's receivers into the alarm engine
+// under its ARM resource id when the driver supports it.
+func (h *Handler) registerActionGroup(rp *azurearm.ResourcePath, props map[string]any) {
+	reg, ok := h.mon.(actionGroupRegistrar)
+	if !ok {
+		return
+	}
+
+	reg.RegisterActionGroup(actionGroupID(rp), props)
+}
+
+// unregisterActionGroup removes an action group's receiver wiring on delete.
+func (h *Handler) unregisterActionGroup(rp *azurearm.ResourcePath) {
+	reg, ok := h.mon.(actionGroupRegistrar)
+	if !ok {
+		return
+	}
+
+	reg.UnregisterActionGroup(actionGroupID(rp))
+}
+
+// actionGroupID builds the ARM resource id a metric alert references an action
+// group by (properties.actions[].actionGroupId).
+func actionGroupID(rp *azurearm.ResourcePath) string {
+	return azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeActionGroup, rp.ResourceName)
 }

--- a/server/azure/monitor/metric_alerts.go
+++ b/server/azure/monitor/metric_alerts.go
@@ -33,10 +33,50 @@ func (h *Handler) registerAlarm(r *http.Request, name string, props map[string]a
 		Period:             windowSeconds(props),
 		EvaluationPeriods:  1,
 		Stat:               mapAggregation(c.timeAggregation),
+		Dimensions:         alarmDimensions(c.dimensions, props),
 		AlarmActions:       actionGroupIDs(props),
 	}
 
 	return h.mon.CreateAlarm(r.Context(), cfg)
+}
+
+// alarmDimensions maps a metric-alert's evaluation scope onto the driver's
+// dimension filter: the criterion's own dimension filters, plus — when the alert
+// targets exactly one scope — a "resourceId" dimension pinning evaluation to
+// that resource, so the alert does not fire on another resource's datapoints
+// sharing the same namespace/metric. A multi-scope alert leaves resourceId
+// unset (aggregating across its scopes), matching the dimensionless default.
+func alarmDimensions(criteriaDims map[string]string, props map[string]any) map[string]string {
+	out := make(map[string]string, len(criteriaDims)+1)
+	for k, v := range criteriaDims {
+		out[k] = v
+	}
+
+	if scope, ok := singleScope(props); ok {
+		out["resourceId"] = scope
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
+// singleScope returns properties.scopes[0] when the alert targets exactly one
+// scope, reporting ok=false otherwise (no scopes, or multiple scopes).
+func singleScope(props map[string]any) (string, bool) {
+	scopes, ok := props["scopes"].([]any)
+	if !ok || len(scopes) != 1 {
+		return "", false
+	}
+
+	scope, ok := scopes[0].(string)
+	if !ok || scope == "" {
+		return "", false
+	}
+
+	return scope, true
 }
 
 // actionGroupIDs extracts properties.actions[].actionGroupId — the action
@@ -74,6 +114,7 @@ type criterion struct {
 	operator        string
 	threshold       float64
 	timeAggregation string
+	dimensions      map[string]string
 }
 
 // firstCriterion extracts the first entry of properties.criteria.allOf.
@@ -104,7 +145,63 @@ func firstCriterion(props map[string]any) (criterion, bool) {
 		operator:        stringField(item, "operator"),
 		threshold:       floatField(item["threshold"]),
 		timeAggregation: stringField(item, "timeAggregation"),
+		dimensions:      criterionDimensions(item),
 	}, true
+}
+
+// criterionDimensions maps a criterion's dimension filters onto the driver's
+// single-value equality model: an "Include" filter naming exactly one value
+// becomes name -> value. Multi-value or "Exclude" filters can't be expressed as
+// a single equality and are skipped (the alert still evaluates on the remaining
+// filters), an intentional subset of Azure's dimension operators.
+func criterionDimensions(item map[string]any) map[string]string {
+	raw, ok := item["dimensions"].([]any)
+	if !ok || len(raw) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string)
+
+	for _, entry := range raw {
+		if name, value, ok := singleValueDimension(entry); ok {
+			out[name] = value
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
+// singleValueDimension reduces one criterion dimension filter to a name/value
+// equality, reporting ok=false for anything the single-value model can't
+// express: a non-object entry, a missing name, an "Exclude" operator, or a
+// filter that doesn't name exactly one value.
+func singleValueDimension(entry any) (name, value string, ok bool) {
+	dim, ok := entry.(map[string]any)
+	if !ok {
+		return "", "", false
+	}
+
+	name = stringField(dim, "name")
+	values, valuesOK := dim["values"].([]any)
+
+	if name == "" || !valuesOK || len(values) != 1 {
+		return "", "", false
+	}
+
+	if op := stringField(dim, "operator"); op != "" && op != "Include" {
+		return "", "", false
+	}
+
+	value, ok = values[0].(string)
+	if !ok || value == "" {
+		return "", "", false
+	}
+
+	return name, value, true
 }
 
 func stringField(m map[string]any, key string) string {

--- a/server/azure/monitor/patch_test.go
+++ b/server/azure/monitor/patch_test.go
@@ -1,0 +1,187 @@
+package monitor_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKMetricAlertPatchMergesAndPreserves is the load-bearing regression for
+// the PATCH BLOCKER: the armmonitor MetricAlertsClient.Update issues an HTTP
+// PATCH, which the handler used to reject with 405. It must return 200, apply
+// the supplied fields, and preserve fields the patch omits.
+func TestSDKMetricAlertPatchMergesAndPreserves(t *testing.T) {
+	client := newInsightsServer(t).metricAlerts(t)
+	ctx := context.Background()
+
+	create := metricAlertResource(80)
+	create.Tags = map[string]*string{"team": to.Ptr("payments"), "env": to.Ptr("prod")}
+	create.Properties.Description = to.Ptr("cpu alert")
+
+	if _, err := client.CreateOrUpdate(ctx, "rg-1", "cpu", create, nil); err != nil {
+		t.Fatalf("CreateOrUpdate: %v", err)
+	}
+
+	// PATCH only severity and one tag; description, scopes, criteria and the
+	// other tag must survive.
+	patched, err := client.Update(ctx, "rg-1", "cpu", armmonitor.MetricAlertResourcePatch{
+		Tags:       map[string]*string{"env": to.Ptr("staging")},
+		Properties: &armmonitor.MetricAlertPropertiesPatch{Severity: to.Ptr[int32](1)},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Update (PATCH): %v", err)
+	}
+
+	if patched.Properties == nil || patched.Properties.Severity == nil || *patched.Properties.Severity != 1 {
+		t.Fatalf("severity after patch = %v, want 1", patched.Properties.Severity)
+	}
+
+	if patched.Properties.Description == nil || *patched.Properties.Description != "cpu alert" {
+		t.Fatalf("description = %v, want preserved 'cpu alert'", patched.Properties.Description)
+	}
+
+	if patched.Properties.Criteria == nil {
+		t.Fatal("criteria dropped by patch (omitted field not preserved)")
+	}
+
+	if got := deref(patched.Tags["team"]); got != "payments" {
+		t.Fatalf("tag team = %q, want preserved 'payments'", got)
+	}
+
+	if got := deref(patched.Tags["env"]); got != "staging" {
+		t.Fatalf("tag env = %q, want updated 'staging'", got)
+	}
+}
+
+// TestSDKActionGroupPatchReturns200 covers the PATCH BLOCKER for actionGroups:
+// ActionGroupsClient.Update (PATCH) toggling enabled must return 200 and
+// preserve the receivers the patch omits.
+func TestSDKActionGroupPatchReturns200(t *testing.T) {
+	client := newInsightsServer(t).actionGroups(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateOrUpdate(ctx, "rg-1", "ag", armmonitor.ActionGroupResource{
+		Location: to.Ptr("global"),
+		Properties: &armmonitor.ActionGroup{
+			GroupShortName: to.Ptr("ops"),
+			Enabled:        to.Ptr(true),
+			EmailReceivers: []*armmonitor.EmailReceiver{{Name: to.Ptr("oncall"), EmailAddress: to.Ptr("a@b.com")}},
+		},
+	}, nil); err != nil {
+		t.Fatalf("CreateOrUpdate: %v", err)
+	}
+
+	patched, err := client.Update(ctx, "rg-1", "ag", armmonitor.ActionGroupPatchBody{
+		Tags:       map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armmonitor.ActionGroupPatch{Enabled: to.Ptr(false)},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Update (PATCH): %v", err)
+	}
+
+	if patched.Properties == nil || patched.Properties.GroupShortName == nil || *patched.Properties.GroupShortName != "ops" {
+		t.Fatalf("groupShortName = %v, want preserved 'ops'", patched.Properties)
+	}
+
+	if len(patched.Properties.EmailReceivers) != 1 {
+		t.Fatalf("emailReceivers = %d, want 1 (omitted receivers dropped)", len(patched.Properties.EmailReceivers))
+	}
+}
+
+// TestSDKActivityLogAlertPatchReturns200 covers the PATCH BLOCKER for
+// activityLogAlerts: ActivityLogAlertsClient.Update (PATCH) must return 200 and
+// preserve the condition/scopes the patch omits.
+func TestSDKActivityLogAlertPatchReturns200(t *testing.T) {
+	client := newInsightsServer(t).activityLogAlerts(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateOrUpdate(ctx, "rg-1", "ala", armmonitor.ActivityLogAlertResource{
+		Location: to.Ptr("global"),
+		Properties: &armmonitor.AlertRuleProperties{
+			Enabled: to.Ptr(true),
+			Scopes:  []*string{to.Ptr("/subscriptions/sub-1")},
+			Condition: &armmonitor.AlertRuleAllOfCondition{
+				AllOf: []*armmonitor.AlertRuleAnyOfOrLeafCondition{{
+					Field: to.Ptr("category"), Equals: to.Ptr("Administrative"),
+				}},
+			},
+		},
+	}, nil); err != nil {
+		t.Fatalf("CreateOrUpdate: %v", err)
+	}
+
+	patched, err := client.Update(ctx, "rg-1", "ala", armmonitor.AlertRulePatchObject{
+		Tags:       map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armmonitor.AlertRulePatchProperties{Enabled: to.Ptr(false)},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Update (PATCH): %v", err)
+	}
+
+	if patched.Properties == nil || patched.Properties.Condition == nil {
+		t.Fatal("condition dropped by patch (omitted field not preserved)")
+	}
+
+	if len(patched.Properties.Scopes) != 1 {
+		t.Fatalf("scopes = %d, want 1 (omitted field not preserved)", len(patched.Properties.Scopes))
+	}
+}
+
+// insightsServer bundles a running Azure server for the insights ARM clients.
+type insightsServer struct{ ts *httptest.Server }
+
+func newInsightsServer(t *testing.T) *insightsServer {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{Monitor: cloudP.Monitor}))
+	t.Cleanup(ts.Close)
+
+	return &insightsServer{ts: ts}
+}
+
+func (s *insightsServer) metricAlerts(t *testing.T) *armmonitor.MetricAlertsClient {
+	t.Helper()
+
+	c, err := armmonitor.NewMetricAlertsClient("sub-1", fakeCred{}, armClientOptions(s.ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return c
+}
+
+func (s *insightsServer) actionGroups(t *testing.T) *armmonitor.ActionGroupsClient {
+	t.Helper()
+
+	c, err := armmonitor.NewActionGroupsClient("sub-1", fakeCred{}, armClientOptions(s.ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return c
+}
+
+func (s *insightsServer) activityLogAlerts(t *testing.T) *armmonitor.ActivityLogAlertsClient {
+	t.Helper()
+
+	c, err := armmonitor.NewActivityLogAlertsClient("sub-1", fakeCred{}, armClientOptions(s.ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return c
+}
+
+func deref(p *string) string {
+	if p == nil {
+		return ""
+	}
+
+	return *p
+}

--- a/server/azure/monitor/types.go
+++ b/server/azure/monitor/types.go
@@ -63,3 +63,60 @@ func withProvisioningState(props map[string]any) map[string]any {
 
 	return props
 }
+
+// mergeResource applies a PATCH body over a stored resource under nil-mask
+// semantics: a top-level field the caller omits (location, tags, properties) is
+// preserved from the stored resource, while a supplied one is merged key-by-key
+// over the stored value. The merge is a fresh resource, so the stored one is not
+// mutated until the caller commits it.
+func mergeResource(existing *armResource, patch *resourceRequest) *armResource {
+	merged := &armResource{
+		Location:   existing.Location,
+		Tags:       mergeStringMap(existing.Tags, patch.Tags),
+		Properties: mergeAnyMap(existing.Properties, patch.Properties),
+	}
+
+	if patch.Location != "" {
+		merged.Location = patch.Location
+	}
+
+	return merged
+}
+
+// mergeStringMap overlays overlay onto a copy of base, preserving base keys the
+// overlay omits. Returns nil only when both are nil.
+func mergeStringMap(base, overlay map[string]string) map[string]string {
+	if base == nil && overlay == nil {
+		return nil
+	}
+
+	out := make(map[string]string, len(base)+len(overlay))
+	for k, v := range base {
+		out[k] = v
+	}
+
+	for k, v := range overlay {
+		out[k] = v
+	}
+
+	return out
+}
+
+// mergeAnyMap overlays overlay onto a copy of base, preserving base keys the
+// overlay omits. Returns nil only when both are nil.
+func mergeAnyMap(base, overlay map[string]any) map[string]any {
+	if base == nil && overlay == nil {
+		return nil
+	}
+
+	out := make(map[string]any, len(base)+len(overlay))
+	for k, v := range base {
+		out[k] = v
+	}
+
+	for k, v := range overlay {
+		out[k] = v
+	}
+
+	return out
+}


### PR DESCRIPTION
## Summary

Fixes the Azure Monitor (`microsoft.insights`) wire handler and provider so real `armmonitor` SDK clients, `az monitor autoscale`, and `azurerm_monitor_autoscale_setting` work.

### BUG1 — PATCH returned 405 on every insights resource
`ServeHTTP` only switched PUT/GET/DELETE, so `MetricAlerts.Update`, `ActionGroups.Update`, and `ActivityLogAlerts.Update` (all HTTP PATCH) failed. Added a PATCH handler that loads the stored resource and merges non-nil properties + tags over it under nil-mask semantics (omitted fields preserved), re-runs the alarm/action-group side-effect wiring against the merged properties, and returns 200. PATCH on a missing resource is a 404 (real ARM Update contract).

### BUG2 — alarm breach did not fire the action group
Action groups were stored only as opaque ARM resources, disconnected from alarm evaluation. Now the handler registers an action group's receivers into the provider on create/update (and unregisters on delete). On an OK->ALARM transition, `transitionAlarm` resolves each `AlarmActions` id against the registered action groups and delivers to every receiver (email/webhook/sms/azureFunction), recording each delivery so callers can assert it — mirroring the AWS alarm->SNS action wiring. Webhook receivers are additionally POSTed for real when a `WebhookDeliverer` is wired. Clock-driven via `opts.Clock`.

### GAP-A — autoscaleSettings were entirely unserved (501)
Added `autoscaleSettings` as a served `canonicalType`; the generic create/get/list/delete/patch path round-trips the full `properties` (profiles, rules metricTrigger + scaleAction, capacity min/max/default).

### GAP-B — criteria dimensions + scopes ignored on evaluation
`registerAlarm` now maps `criteria.allOf[].dimensions` (Include single-value) onto `AlarmConfig.Dimensions` and pins evaluation to a single `properties.scopes` entry via a `resourceId` dimension, so an alert scoped to one resource no longer fires on another resource's datapoints.

## Tests (real `armmonitor` SDK over httptest)
- PATCH on metricAlert/actionGroup/activityLogAlert returns 200, applies supplied fields, preserves omitted ones.
- Alarm breach fires the action group: asserts recorded email+webhook deliveries and a real webhook receiver hit, clock-driven.
- autoscaleSetting create -> GET round-trip with profiles/rules/capacity intact.
- Dimension/scope-scoped alert does not fire on another resource's data, then fires on its own.

## Gates
- `go build ./...`, `go vet`, scoped `go test` green; `gofmt` clean; `golangci-lint --new-from-rev=origin/development` 0 new issues.
- `go generate ./...` and `go run ./internal/compatgen` both zero-diff.
