### PR TITLE
fix(gcp-gcs): resumable uploads, ranged GET (206), delimiter-list pagination, delete-bucket version guard, metadata-patch updated timestamp

### DIFF
--- a/providers/gcp/gcs/delete_and_timestamp_semantics_test.go
+++ b/providers/gcp/gcs/delete_and_timestamp_semantics_test.go
@@ -1,0 +1,59 @@
+package gcs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeleteBucketRefusesNoncurrentVersions checks that a bucket with no live
+// objects but retained noncurrent versions still refuses deletion.
+func TestDeleteBucketRefusesNoncurrentVersions(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+	require.NoError(t, m.SetBucketVersioning(ctx, "b1", true))
+
+	require.NoError(t, m.PutObject(ctx, "b1", "k1", []byte("v1"), "text/plain", nil))
+	require.NoError(t, m.PutObject(ctx, "b1", "k1", []byte("v2"), "text/plain", nil))
+
+	// Deleting the live object archives the current generation as noncurrent, so
+	// no live object remains but a noncurrent version does.
+	require.NoError(t, m.DeleteObject(ctx, "b1", "k1"))
+
+	err := m.DeleteBucket(ctx, "b1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not empty")
+}
+
+// TestUpdateObjectBumpsUpdatedNotCreated checks that a metadata-only patch
+// advances the object's updated time while leaving timeCreated fixed.
+func TestUpdateObjectBumpsUpdatedNotCreated(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	clk := m.opts.Clock.(*config.FakeClock)
+
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+
+	created, err := m.PutObjectGCS(ctx, "b1", "k1", []byte("data"), "text/plain", nil, nil, driver.GCSPrecondition{})
+	require.NoError(t, err)
+	require.Equal(t, created.Created, created.LastModified, "a fresh write has equal created and updated")
+
+	clk.Advance(time.Hour)
+
+	val := "bar"
+	patched, err := m.UpdateObjectGCS(ctx, "b1", "k1", driver.GCSObjectUpdate{
+		Metadata: map[string]*string{"foo": &val},
+	}, driver.GCSPrecondition{})
+	require.NoError(t, err)
+
+	assert.Equal(t, created.Created, patched.Created, "timeCreated must stay fixed on a metadata patch")
+	assert.Greater(t, patched.LastModified, created.LastModified, "updated must advance")
+	assert.NotEqual(t, patched.Created, patched.LastModified, "updated must differ from created after patch")
+}

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -50,6 +50,7 @@ type gcsObject struct {
 	ContentType        string
 	ETag               string
 	LastModified       string
+	Created            string
 	Metadata           map[string]string
 	Tags               map[string]string
 	Generation         int64
@@ -191,7 +192,7 @@ func toInfo(o *gcsObject, cloneMeta bool) driver.ObjectInfo {
 
 	return driver.ObjectInfo{
 		Key: o.Key, Size: o.Size, ContentType: o.ContentType, ETag: o.ETag,
-		LastModified: o.LastModified, Metadata: meta,
+		LastModified: o.LastModified, Created: o.Created, Metadata: meta,
 		Generation: o.Generation, Metageneration: o.Metageneration,
 		MD5: o.MD5, CRC32C: o.CRC32C,
 		CacheControl: o.CacheControl, ContentEncoding: o.ContentEncoding,
@@ -206,13 +207,29 @@ func (m *Mock) DeleteBucket(_ context.Context, name string) error {
 		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", name)
 	}
 
-	if bkt.objects.Len() > 0 {
+	if bkt.objects.Len() > 0 || bucketHasNoncurrentVersions(bkt) {
 		return cerrors.Newf(cerrors.FailedPrecondition, "bucket %q is not empty", name)
 	}
 
 	m.buckets.Delete(name)
 
 	return nil
+}
+
+// bucketHasNoncurrentVersions reports whether any archived (noncurrent) object
+// generation is still retained. Real GCS refuses to delete a bucket that holds
+// noncurrent versions — not just live objects — with a 409 not-empty.
+func bucketHasNoncurrentVersions(bkt *bucketMeta) bool {
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	for _, versions := range bkt.versions {
+		if len(versions) > 0 {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (m *Mock) ListBuckets(_ context.Context) ([]driver.BucketInfo, error) {
@@ -291,13 +308,16 @@ func (m *Mock) putObject(
 
 	md5b64, crc32cb64 := checksums(data)
 
+	now := m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
+
 	obj := &gcsObject{
 		Key:                key,
 		Data:               stored,
 		Size:               int64(len(data)),
 		ContentType:        contentType,
 		ETag:               fmt.Sprintf("%x", sha256.Sum256(data)),
-		LastModified:       m.opts.Clock.Now().UTC().Format(gcsTimeFormat),
+		LastModified:       now,
+		Created:            now,
 		Metadata:           metaCopy,
 		Generation:         m.gen.Add(1),
 		Metageneration:     1,
@@ -685,37 +705,76 @@ func (m *Mock) ListObjects(ctx context.Context, bucket string, opts driver.ListO
 		matchedObjects = append(matchedObjects, toInfo(obj, false))
 	}
 
-	commonPrefixes := make([]string, 0, len(commonPrefixSet))
-	for p := range commonPrefixSet {
-		commonPrefixes = append(commonPrefixes, p)
-	}
-
-	sort.Strings(commonPrefixes)
+	entries := foldedListEntries(matchedObjects, commonPrefixSet)
 
 	maxKeys := opts.MaxKeys
 	if maxKeys <= 0 {
 		maxKeys = gcsDefaultMaxKeys
 	}
 
-	page, err := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
+	page, err := pagination.Paginate(entries, opts.PageToken, maxKeys)
 	if err != nil {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
 	}
 
-	// Clone metadata only for the page actually returned — cloning every
-	// match would make a paged scan O(bucket) allocations per request.
-	for i := range page.Items {
-		page.Items[i].Metadata = maps.Clone(page.Items[i].Metadata)
-	}
+	objects, prefixes := splitListPage(page.Items)
 
 	m.emitMetric(ctx, "api/request_count", 1, map[string]string{"bucket_name": bucket})
 
 	return &driver.ListResult{
-		Objects:        page.Items,
-		CommonPrefixes: commonPrefixes,
+		Objects:        objects,
+		CommonPrefixes: prefixes,
 		NextPageToken:  page.NextPageToken,
 		IsTruncated:    page.HasMore,
 	}, nil
+}
+
+// gcsListEntry is one item in a folded delimiter listing — either a matched
+// object or a rolled-up common prefix — carrying the lexicographic sort key.
+type gcsListEntry struct {
+	name     string
+	isPrefix bool
+	obj      driver.ObjectInfo
+}
+
+// foldedListEntries merges the matched objects and rolled-up common prefixes
+// into a single lexicographically sorted stream, so a delimiter listing counts
+// each prefix toward maxResults and returns it on exactly one page (the page
+// position is carried in the offset token). Prefixes are already deduped by the
+// set, so each appears once.
+func foldedListEntries(objects []driver.ObjectInfo, prefixSet map[string]struct{}) []gcsListEntry {
+	entries := make([]gcsListEntry, 0, len(objects)+len(prefixSet))
+
+	for i := range objects {
+		entries = append(entries, gcsListEntry{name: objects[i].Key, obj: objects[i]})
+	}
+
+	for p := range prefixSet {
+		entries = append(entries, gcsListEntry{name: p, isPrefix: true})
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].name < entries[j].name })
+
+	return entries
+}
+
+// splitListPage separates a folded page back into object infos and common
+// prefixes (order preserved). Object metadata is cloned only for the page
+// actually returned — cloning every match would make a paged scan O(bucket)
+// allocations per request.
+func splitListPage(items []gcsListEntry) (objects []driver.ObjectInfo, prefixes []string) {
+	for i := range items {
+		if items[i].isPrefix {
+			prefixes = append(prefixes, items[i].name)
+			continue
+		}
+
+		info := items[i].obj
+		info.Metadata = maps.Clone(info.Metadata)
+		objects = append(objects, info)
+	}
+
+	return objects, prefixes
 }
 
 func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src driver.CopySource) error {
@@ -758,9 +817,11 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 	dstCurrent, dstExists := dstBkt.objects.Get(dstKey)
 	archiveVersion(dstBkt, dstKey, dstCurrent, dstExists)
 
+	copyNow := m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
+
 	dstBkt.objects.Set(dstKey, &gcsObject{
 		Key: dstKey, Data: stored, Size: srcObj.Size, ContentType: srcObj.ContentType,
-		ETag: srcObj.ETag, LastModified: m.opts.Clock.Now().UTC().Format(gcsTimeFormat),
+		ETag: srcObj.ETag, LastModified: copyNow, Created: copyNow,
 		Metadata: meta, Generation: m.gen.Add(1), Metageneration: 1,
 		MD5: srcObj.MD5, CRC32C: srcObj.CRC32C,
 		CacheControl: srcObj.CacheControl, ContentEncoding: srcObj.ContentEncoding,
@@ -1019,13 +1080,16 @@ func (m *Mock) CompleteMultipartUpload(
 	current, exists := bkt.objects.Get(key)
 	archiveVersion(bkt, key, current, exists)
 
+	completeNow := m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
+
 	bkt.objects.Set(key, &gcsObject{
 		Key:            key,
 		Data:           stored,
 		Size:           int64(len(data)),
 		ContentType:    mp.contentType,
 		ETag:           fmt.Sprintf("%x", sha256.Sum256(data)),
-		LastModified:   m.opts.Clock.Now().UTC().Format(gcsTimeFormat),
+		LastModified:   completeNow,
+		Created:        completeNow,
 		Metadata:       make(map[string]string),
 		Generation:     m.gen.Add(1),
 		Metageneration: 1,
@@ -1359,6 +1423,9 @@ func (m *Mock) UpdateObjectGCS(
 
 	next := *cur
 	next.Metageneration = cur.Metageneration + 1
+	// A metadata-only patch advances the update time but leaves the object's
+	// creation time (timeCreated) fixed — real GCS bumps only `updated`.
+	next.LastModified = m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
 	next.Metadata = mergeMetadata(cur.Metadata, upd.Metadata)
 
 	applyStringUpdate(&next.ContentType, upd.ContentType)

--- a/providers/gcp/gcs/gcs_lifecycle_test.go
+++ b/providers/gcp/gcs/gcs_lifecycle_test.go
@@ -320,7 +320,8 @@ func TestKeyNamesSlashesUnicode(t *testing.T) {
 }
 
 // TestPaginationTokens pages through a large listing with opaque
-// continuation tokens and checks CommonPrefixes are NOT paginated.
+// continuation tokens and checks common prefixes fold into the same paginated
+// stream as objects (each surfaced once, counted toward MaxKeys).
 func TestPaginationTokens(t *testing.T) {
 	ctx := context.Background()
 	m, _ := newMock(t)
@@ -373,17 +374,54 @@ func TestPaginationTokens(t *testing.T) {
 	assert.Len(t, res.Objects, total)
 	assert.False(t, res.IsTruncated)
 
-	// CommonPrefixes are returned in full even when object pages truncate.
+	// With a delimiter, common prefixes fold into the same paginated stream as
+	// objects: each prefix counts toward MaxKeys and is returned on exactly one
+	// page (no duplication across pages).
 	for i := 0; i < 5; i++ {
 		require.NoError(t, m.PutObject(ctx, bucket,
 			fmt.Sprintf("dir%d/file", i), []byte("x"), "text/plain", nil))
 	}
 
-	res, err = m.ListObjects(ctx, bucket, driver.ListOptions{Delimiter: "/", MaxKeys: 3})
-	require.NoError(t, err)
-	assert.True(t, res.IsTruncated)
-	assert.Len(t, res.Objects, 3)
-	assert.Len(t, res.CommonPrefixes, 5, "common prefixes are never paginated")
+	prefixSeen := map[string]int{}
+	objSeen := map[string]int{}
+	token = ""
+	pages = 0
+
+	for {
+		page, err := m.ListObjects(ctx, bucket, driver.ListOptions{Delimiter: "/", MaxKeys: 3, PageToken: token})
+		require.NoError(t, err)
+
+		pages++
+		require.LessOrEqual(t, len(page.Objects)+len(page.CommonPrefixes), 3,
+			"a page must not exceed MaxKeys across objects+prefixes")
+
+		for _, p := range page.CommonPrefixes {
+			prefixSeen[p]++
+		}
+
+		for _, o := range page.Objects {
+			objSeen[o.Key]++
+		}
+
+		if !page.IsTruncated {
+			break
+		}
+
+		token = page.NextPageToken
+		require.Less(t, pages, 40, "runaway pagination")
+	}
+
+	assert.Len(t, prefixSeen, 5, "all five dir prefixes surfaced")
+
+	for p, n := range prefixSeen {
+		assert.Equal(t, 1, n, "prefix %q returned exactly once", p)
+	}
+
+	assert.Len(t, objSeen, total, "all top-level objects surfaced")
+
+	for k, n := range objSeen {
+		assert.Equal(t, 1, n, "object %q returned exactly once", k)
+	}
 }
 
 // TestMultipartLifecycle drives create -> upload -> list ->

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -10,9 +10,10 @@
 //	GET    /storage/v1/b/{bucket}                       — get bucket
 //	DELETE /storage/v1/b/{bucket}                       — delete bucket
 //	POST   /upload/storage/v1/b/{bucket}/o?uploadType=media&name={obj}  — upload object
+//	POST   /upload/storage/v1/b/{bucket}/o?uploadType=resumable         — resumable upload
 //	GET    /storage/v1/b/{bucket}/o                     — list objects
 //	GET    /storage/v1/b/{bucket}/o/{obj}               — get object metadata
-//	GET    /storage/v1/b/{bucket}/o/{obj}?alt=media     — download object
+//	GET    /storage/v1/b/{bucket}/o/{obj}?alt=media     — download object (honors Range)
 //	DELETE /storage/v1/b/{bucket}/o/{obj}               — delete object
 //	POST   /storage/v1/b/{bucket}/o/{obj}/rewriteTo/b/{dst}/o/{dstObj}  — copy
 //	POST   /storage/v1/b/{srcBucket}/o/{srcObj}/copyTo/b/{dst}/o/{dstObj}  — legacy copy
@@ -28,9 +29,11 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
 )
 
@@ -44,6 +47,15 @@ const (
 	uploadTypeMedia = "media"
 	// uploadTypeMultipart is JSON metadata + payload.
 	uploadTypeMultipart = "multipart"
+	// uploadTypeResumable is a session-based chunked upload (Content-Range PUTs).
+	uploadTypeResumable = "resumable"
+
+	// statusResumeIncomplete (308) tells a resumable client the server has the
+	// bytes so far and expects more chunks.
+	statusResumeIncomplete = http.StatusPermanentRedirect
+
+	// rangeTotalUnknown marks a Content-Range whose total ("*") isn't yet known.
+	rangeTotalUnknown = -1
 
 	// maxPutBodyBytes caps single-request uploads. Real GCS supports up to
 	// 5 TiB but we use 5 GiB to mirror our S3 cap.
@@ -73,13 +85,35 @@ type Handler struct {
 	// doesn't implement it), covering preconditions, generation, compose,
 	// object patch, versioned listing, and bucket location/IAM/metageneration.
 	ext storagedriver.GCSExtensions
+
+	// resumable holds in-progress resumable-upload sessions keyed by upload id.
+	// A session buffers the object's bytes as Content-Range chunks arrive over
+	// successive requests, committed through the normal object-write path on the
+	// final chunk.
+	// This is a pure wire-protocol concern (Content-Range chunking, 308 replies,
+	// session URIs) with no analog in the portable driver, so it lives here.
+	resumableMu sync.Mutex
+	resumable   map[string]*resumableSession
+}
+
+// resumableSession is one in-progress resumable upload: the target and the
+// captured insert-time metadata plus the bytes accumulated so far.
+type resumableSession struct {
+	bucket      string
+	name        string
+	contentType string
+	metadata    map[string]string
+	attrs       *storagedriver.GCSObjectAttrs
+
+	mu  sync.Mutex
+	buf []byte
 }
 
 // New returns a GCS handler backed by b.
 func New(b storagedriver.Bucket) *Handler {
 	ext, _ := b.(storagedriver.GCSExtensions)
 
-	return &Handler{bucket: b, ext: ext}
+	return &Handler{bucket: b, ext: ext, resumable: make(map[string]*resumableSession)}
 }
 
 // Matches returns true for /storage/v1/, /upload/storage/v1/, and direct
@@ -562,8 +596,10 @@ func writeRawJSON(w http.ResponseWriter, raw []byte) {
 	_, _ = w.Write(raw) //nolint:gosec // validated JSON policy, served as application/json
 }
 
-// upload handles POST /upload/storage/v1/b/{bucket}/o?uploadType=media&name={obj}.
-// We support uploadType=media (raw body) only.
+// upload handles POST /upload/storage/v1/b/{bucket}/o, dispatching on
+// uploadType: media (raw body), multipart (JSON metadata + payload), and
+// resumable (a session initialised here, then chunked Content-Range uploads
+// that carry the issued upload_id).
 func (h *Handler) upload(w http.ResponseWriter, r *http.Request) {
 	rest := strings.TrimPrefix(r.URL.Path, uploadAPIPrefix)
 	parts := strings.Split(rest, "/")
@@ -576,6 +612,15 @@ func (h *Handler) upload(w http.ResponseWriter, r *http.Request) {
 	bucket := parts[1]
 	q := r.URL.Query()
 
+	// A resumable session's chunk uploads come back to this upload URL carrying
+	// the upload_id issued at session init (the SDK sends them as POSTs with a
+	// Content-Range) — route those to the chunk handler before dispatching on
+	// uploadType (which the client echoes as "resumable").
+	if uploadID := q.Get("upload_id"); uploadID != "" {
+		h.uploadResumableChunk(w, r, uploadID)
+		return
+	}
+
 	uploadType := q.Get("uploadType")
 
 	switch uploadType {
@@ -583,10 +628,234 @@ func (h *Handler) upload(w http.ResponseWriter, r *http.Request) {
 		h.uploadMedia(w, r, bucket, q.Get("name"))
 	case uploadTypeMultipart:
 		h.uploadMultipart(w, r, bucket)
+	case uploadTypeResumable:
+		h.initResumable(w, r, bucket)
 	default:
 		writeError(w, http.StatusBadRequest, "invalid",
-			"only uploadType=media or multipart supported (got "+uploadType+")")
+			"only uploadType=media, multipart or resumable supported (got "+uploadType+")")
 	}
+}
+
+// initResumable starts a resumable upload session: it captures the object name
+// and insert-time metadata from the POST (JSON body and/or query + upload
+// headers), mints a session id, and returns 200 with a Location header giving
+// the session URI the client PUTs chunks to.
+func (h *Handler) initResumable(w http.ResponseWriter, r *http.Request, bucket string) {
+	meta := h.readResumableInitMetadata(r)
+
+	name := meta.Name
+	if name == "" {
+		name = r.URL.Query().Get("name")
+	}
+
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "name required for resumable upload")
+		return
+	}
+
+	contentType := firstNonEmpty(meta.ContentType, r.Header.Get("X-Upload-Content-Type"), contentTypeBinary)
+
+	sessionID := idgen.GenerateID("resumable-")
+
+	h.resumableMu.Lock()
+	h.resumable[sessionID] = &resumableSession{
+		bucket:      bucket,
+		name:        name,
+		contentType: contentType,
+		metadata:    meta.Metadata,
+		attrs: &storagedriver.GCSObjectAttrs{
+			CacheControl:       meta.CacheControl,
+			ContentEncoding:    meta.ContentEncoding,
+			ContentDisposition: meta.ContentDisposition,
+			ContentLanguage:    meta.ContentLanguage,
+			StorageClass:       meta.StorageClass,
+		},
+	}
+	h.resumableMu.Unlock()
+
+	location := selfLink(r, r.URL.Path) + "?uploadType=resumable&upload_id=" + url.QueryEscape(sessionID)
+	w.Header().Set("Location", location)
+	w.WriteHeader(http.StatusOK)
+}
+
+// readResumableInitMetadata parses the optional JSON object metadata carried in
+// the resumable init POST body. A missing or unparseable body yields a zero
+// value (name/content-type then come from the query and upload headers).
+func (*Handler) readResumableInitMetadata(r *http.Request) uploadMetadata {
+	if r.Body == nil {
+		return uploadMetadata{}
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(r.Body, maxPutBodyBytes))
+	if err != nil || len(bytes.TrimSpace(raw)) == 0 {
+		return uploadMetadata{}
+	}
+
+	var meta uploadMetadata
+	if uErr := json.Unmarshal(raw, &meta); uErr != nil {
+		return uploadMetadata{}
+	}
+
+	return meta
+}
+
+// uploadResumableChunk appends one Content-Range chunk to its session's buffer.
+// Until the final chunk it replies 308 Resume Incomplete with a Range header; on
+// the final chunk it commits the assembled object through the normal write path
+// and replies 200 with the object resource.
+func (h *Handler) uploadResumableChunk(w http.ResponseWriter, r *http.Request, sessionID string) {
+	if sessionID == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "upload_id required")
+		return
+	}
+
+	h.resumableMu.Lock()
+	sess := h.resumable[sessionID]
+	h.resumableMu.Unlock()
+
+	if sess == nil {
+		writeError(w, http.StatusNotFound, "notFound", "resumable upload session not found")
+		return
+	}
+
+	data, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxPutBodyBytes))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid", "could not read chunk body")
+		return
+	}
+
+	start, end, total, ok := parseContentRange(r.Header.Get("Content-Range"))
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid", "malformed Content-Range")
+		return
+	}
+
+	sess.mu.Lock()
+
+	// Chunks arrive in order; append only when the range begins exactly at the
+	// current buffer length (a status-probe PUT carries no bytes and no-ops).
+	if len(data) > 0 && start == int64(len(sess.buf)) {
+		sess.buf = append(sess.buf, data...)
+	}
+
+	buffered := int64(len(sess.buf))
+	sess.mu.Unlock()
+
+	final := total != rangeTotalUnknown && (end == total-1 || buffered >= total)
+	if !final {
+		writeResumeIncomplete(w, r, buffered)
+		return
+	}
+
+	h.commitResumable(w, r, sessionID, sess)
+}
+
+// writeResumeIncomplete signals the client that the bytes so far are stored and
+// more chunks are expected. The Go SDK sets "X-GUploader-No-308: yes" asking the
+// server to convey this as a 200 carrying an "X-Http-Status-Code-Override: 308"
+// header (some HTTP stacks mishandle a bare 308); otherwise a real 308 is sent.
+func writeResumeIncomplete(w http.ResponseWriter, r *http.Request, buffered int64) {
+	w.Header().Set("Range", "bytes=0-"+strconv.FormatInt(maxInt64(buffered-1, 0), 10))
+
+	if strings.EqualFold(r.Header.Get("X-GUploader-No-308"), "yes") {
+		w.Header().Set("X-Http-Status-Code-Override", "308")
+		w.WriteHeader(http.StatusOK)
+
+		return
+	}
+
+	w.WriteHeader(statusResumeIncomplete)
+}
+
+// commitResumable writes the fully-assembled session buffer through the normal
+// object-write path and drops the session.
+func (h *Handler) commitResumable(w http.ResponseWriter, r *http.Request, sessionID string, sess *resumableSession) {
+	h.resumableMu.Lock()
+	delete(h.resumable, sessionID)
+	h.resumableMu.Unlock()
+
+	sess.mu.Lock()
+	data := sess.buf
+	sess.mu.Unlock()
+
+	h.storeObject(w, r, sess.bucket, sess.name, sess.contentType, data, sess.metadata, sess.attrs)
+}
+
+// parseContentRange parses a resumable-upload Content-Range: "bytes start-end/
+// total", "bytes start-end/*" (total unknown), or "bytes */total" (a size probe
+// with no bytes). total is rangeTotalUnknown for "*"; end is -1 when the range
+// numerator is "*". ok is false on a malformed header.
+func parseContentRange(header string) (start, end, total int64, ok bool) {
+	const prefix = "bytes "
+
+	if !strings.HasPrefix(header, prefix) {
+		return 0, 0, 0, false
+	}
+
+	spec := strings.TrimPrefix(header, prefix)
+
+	slash := strings.IndexByte(spec, '/')
+	if slash < 0 {
+		return 0, 0, 0, false
+	}
+
+	rangePart, totalPart := spec[:slash], spec[slash+1:]
+
+	total = rangeTotalUnknown
+	if totalPart != "*" {
+		total, ok = parseNonNegInt64(totalPart)
+		if !ok {
+			return 0, 0, 0, false
+		}
+	}
+
+	if rangePart == "*" {
+		return 0, rangeTotalUnknown, total, true
+	}
+
+	dash := strings.IndexByte(rangePart, '-')
+	if dash < 0 {
+		return 0, 0, 0, false
+	}
+
+	start, ok = parseNonNegInt64(rangePart[:dash])
+	if !ok {
+		return 0, 0, 0, false
+	}
+
+	end, ok = parseNonNegInt64(rangePart[dash+1:])
+	if !ok || end < start {
+		return 0, 0, 0, false
+	}
+
+	return start, end, total, true
+}
+
+func parseNonNegInt64(s string) (int64, bool) {
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+
+	return n, true
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+
+	return ""
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+
+	return b
 }
 
 // parsePrecondition extracts the GCS write preconditions from the request query
@@ -998,11 +1267,131 @@ func (h *Handler) downloadObject(w http.ResponseWriter, r *http.Request, bucket,
 		return
 	}
 
+	if rangeHeader := r.Header.Get("Range"); rangeHeader != "" {
+		h.writeRangedObject(w, obj, rangeHeader)
+		return
+	}
+
 	w.Header().Set("Content-Type", obj.Info.ContentType)
 	w.Header().Set("Content-Length", strconv.FormatInt(int64(len(obj.Data)), 10))
 	w.Header().Set("ETag", obj.Info.ETag)
+	w.Header().Set("Accept-Ranges", "bytes")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(obj.Data) //nolint:gosec // raw object bytes
+}
+
+// writeRangedObject serves an alt=media download carrying a Range header: 206
+// with a Content-Range slice when satisfiable, 416 when out of bounds, and a
+// full 200 body when the header is unparseable — matching real GCS.
+func (*Handler) writeRangedObject(w http.ResponseWriter, obj *storagedriver.Object, header string) {
+	total := int64(len(obj.Data))
+	start, end, outcome := parseByteRange(header, total)
+
+	switch outcome {
+	case rangeUnsatisfiable:
+		w.Header().Set("Content-Range", "bytes */"+strconv.FormatInt(total, 10))
+		writeError(w, http.StatusRequestedRangeNotSatisfiable, "requestedRangeNotSatisfiable",
+			"the requested range is not satisfiable")
+	case rangeOK:
+		w.Header().Set("Content-Type", obj.Info.ContentType)
+		w.Header().Set("Content-Length", strconv.FormatInt(end-start+1, 10))
+		w.Header().Set("ETag", obj.Info.ETag)
+		w.Header().Set("Content-Range", "bytes "+strconv.FormatInt(start, 10)+"-"+
+			strconv.FormatInt(end, 10)+"/"+strconv.FormatInt(total, 10))
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(obj.Data[start : end+1]) //nolint:gosec // bounded slice of object bytes
+	case rangeIgnore:
+		w.Header().Set("Content-Type", obj.Info.ContentType)
+		w.Header().Set("Content-Length", strconv.FormatInt(total, 10))
+		w.Header().Set("ETag", obj.Info.ETag)
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(obj.Data) //nolint:gosec // raw object bytes
+	}
+}
+
+// rangeOutcome classifies a Range header against an object.
+type rangeOutcome int
+
+const (
+	rangeIgnore        rangeOutcome = iota // unparseable header → serve full body (200)
+	rangeUnsatisfiable                     // valid syntax but out of bounds → 416
+	rangeOK                                // satisfiable → 206
+)
+
+// parseByteRange parses a single HTTP byte range ("bytes=0-4", "bytes=5-",
+// "bytes=-5") against an object of size total, returning the inclusive
+// [start,end] offsets and an outcome. Only the first range of a multi-range
+// header is honored (the common single-range download path).
+func parseByteRange(header string, total int64) (start, end int64, outcome rangeOutcome) {
+	const prefix = "bytes="
+	if !strings.HasPrefix(header, prefix) {
+		return 0, 0, rangeIgnore
+	}
+
+	spec := strings.TrimPrefix(header, prefix)
+	if idx := strings.IndexByte(spec, ','); idx >= 0 {
+		spec = spec[:idx]
+	}
+
+	dash := strings.IndexByte(spec, '-')
+	if dash < 0 {
+		return 0, 0, rangeIgnore
+	}
+
+	startStr, endStr := spec[:dash], spec[dash+1:]
+
+	if startStr == "" {
+		return suffixRange(endStr, total)
+	}
+
+	return boundedRange(startStr, endStr, total)
+}
+
+// suffixRange handles "bytes=-N": the last N bytes of the object.
+func suffixRange(endStr string, total int64) (start, end int64, outcome rangeOutcome) {
+	n, err := strconv.ParseInt(endStr, 10, 64)
+	if err != nil {
+		return 0, 0, rangeIgnore
+	}
+
+	if n <= 0 || total == 0 {
+		return 0, 0, rangeUnsatisfiable
+	}
+
+	if n > total {
+		n = total
+	}
+
+	return total - n, total - 1, rangeOK
+}
+
+// boundedRange handles "bytes=start-" and "bytes=start-end".
+func boundedRange(startStr, endStr string, total int64) (start, end int64, outcome rangeOutcome) {
+	start, err := strconv.ParseInt(startStr, 10, 64)
+	if err != nil {
+		return 0, 0, rangeIgnore
+	}
+
+	if start >= total {
+		return 0, 0, rangeUnsatisfiable
+	}
+
+	end = total - 1
+
+	if endStr != "" {
+		end, err = strconv.ParseInt(endStr, 10, 64)
+		if err != nil || start > end {
+			return 0, 0, rangeIgnore
+		}
+
+		if end >= total {
+			end = total - 1
+		}
+	}
+
+	return start, end, rangeOK
 }
 
 // headObject fetches an object's metadata, addressing a specific generation
@@ -1136,6 +1525,14 @@ func toObjectResource(info *storagedriver.ObjectInfo, bucket string, r *http.Req
 		storageClass = defaultStorageClass
 	}
 
+	// timeCreated is fixed at first write; updated advances on overwrite or a
+	// metadata patch. Providers that don't track a distinct creation time leave
+	// Created empty, so fall back to LastModified.
+	created := info.Created
+	if created == "" {
+		created = info.LastModified
+	}
+
 	return objectResource{
 		Kind:               "storage#object",
 		ID:                 bucket + "/" + info.Key + "/" + genStr,
@@ -1153,7 +1550,7 @@ func toObjectResource(info *storagedriver.ObjectInfo, bucket string, r *http.Req
 		ContentEncoding:    info.ContentEncoding,
 		ContentDisposition: info.ContentDisposition,
 		ContentLanguage:    info.ContentLanguage,
-		TimeCreated:        info.LastModified,
+		TimeCreated:        created,
 		Updated:            info.LastModified,
 		Metadata:           info.Metadata,
 		SelfLink:           selfLink(r, "/storage/v1/b/"+bucket+"/o/"+info.Key),

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -598,7 +598,7 @@ func writeRawJSON(w http.ResponseWriter, raw []byte) {
 
 // upload handles POST /upload/storage/v1/b/{bucket}/o, dispatching on
 // uploadType: media (raw body), multipart (JSON metadata + payload), and
-// resumable (a session initialised here, then chunked Content-Range uploads
+// resumable (a session initialized here, then chunked Content-Range uploads
 // that carry the issued upload_id).
 func (h *Handler) upload(w http.ResponseWriter, r *http.Request) {
 	rest := strings.TrimPrefix(r.URL.Path, uploadAPIPrefix)
@@ -724,30 +724,46 @@ func (h *Handler) uploadResumableChunk(w http.ResponseWriter, r *http.Request, s
 		return
 	}
 
-	start, end, total, ok := parseContentRange(r.Header.Get("Content-Range"))
+	// end is intentionally ignored: finality is decided by the buffered length
+	// reaching the declared total, never by a chunk claiming to carry the last
+	// byte (which could arrive after a gap and truncate the object).
+	start, _, total, ok := parseContentRange(r.Header.Get("Content-Range"))
 	if !ok {
 		writeError(w, http.StatusBadRequest, "invalid", "malformed Content-Range")
 		return
 	}
 
-	sess.mu.Lock()
+	buffered, contiguous := sess.appendChunk(start, data)
 
-	// Chunks arrive in order; append only when the range begins exactly at the
-	// current buffer length (a status-probe PUT carries no bytes and no-ops).
-	if len(data) > 0 && start == int64(len(sess.buf)) {
-		sess.buf = append(sess.buf, data...)
-	}
-
-	buffered := int64(len(sess.buf))
-	sess.mu.Unlock()
-
-	final := total != rangeTotalUnknown && (end == total-1 || buffered >= total)
-	if !final {
+	// The upload commits only once the buffer holds the full declared size and no
+	// gap was left behind. Gating finality on a chunk claiming the last byte would
+	// wrongly commit a short object when that chunk arrives after a gap.
+	if !contiguous || total == rangeTotalUnknown || buffered < total {
 		writeResumeIncomplete(w, r, buffered)
 		return
 	}
 
 	h.commitResumable(w, r, sessionID, sess)
+}
+
+// appendChunk appends a contiguous chunk's bytes and reports the resulting
+// buffered length. contiguous is false when a bytes-carrying chunk begins past
+// the current buffer length (a gap) — nothing is appended in that case. A
+// status-probe (no bytes) or an already-buffered replay no-ops but stays
+// contiguous.
+func (s *resumableSession) appendChunk(start int64, data []byte) (buffered int64, contiguous bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(data) > 0 && start > int64(len(s.buf)) {
+		return int64(len(s.buf)), false
+	}
+
+	if len(data) > 0 && start == int64(len(s.buf)) {
+		s.buf = append(s.buf, data...)
+	}
+
+	return int64(len(s.buf)), true
 }
 
 // writeResumeIncomplete signals the client that the bytes so far are stored and
@@ -757,7 +773,7 @@ func (h *Handler) uploadResumableChunk(w http.ResponseWriter, r *http.Request, s
 func writeResumeIncomplete(w http.ResponseWriter, r *http.Request, buffered int64) {
 	w.Header().Set("Range", "bytes=0-"+strconv.FormatInt(maxInt64(buffered-1, 0), 10))
 
-	if strings.EqualFold(r.Header.Get("X-GUploader-No-308"), "yes") {
+	if strings.EqualFold(r.Header.Get("X-Guploader-No-308"), "yes") {
 		w.Header().Set("X-Http-Status-Code-Override", "308")
 		w.WriteHeader(http.StatusOK)
 

--- a/server/gcp/gcs/resumable_range_list_test.go
+++ b/server/gcp/gcs/resumable_range_list_test.go
@@ -1,0 +1,239 @@
+package gcs_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// newGCSTestClient spins up the GCS wire handler behind an httptest server and
+// returns a real cloud.google.com/go/storage client pointed at it.
+func newGCSTestClient(t *testing.T) *storage.Client {
+	t.Helper()
+
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Storage: cloudP.GCS})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := storage.NewClient(context.Background(),
+		option.WithEndpoint(ts.URL+"/storage/v1/"),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+func writeGCSObject(t *testing.T, ctx context.Context, bucket *storage.BucketHandle, name string, data []byte) {
+	t.Helper()
+
+	w := bucket.Object(name).NewWriter(ctx)
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("write %q: %v", name, err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close %q: %v", name, err)
+	}
+}
+
+// TestSDKGCSResumableUpload verifies a >16MiB object (which the SDK sends as a
+// multi-chunk resumable upload by default) round-trips byte-for-byte.
+func TestSDKGCSResumableUpload(t *testing.T) {
+	client := newGCSTestClient(t)
+	ctx := context.Background()
+
+	bucket := client.Bucket("b1")
+	if err := bucket.Create(ctx, "p1", nil); err != nil {
+		t.Fatalf("bucket.Create: %v", err)
+	}
+
+	// 17 MiB > the 16 MiB default chunk size, so the SDK uploads it resumably
+	// across multiple Content-Range chunks that the handler must reassemble.
+	const size = 17 << 20
+
+	want := make([]byte, size)
+	for i := range want {
+		want[i] = byte(i*31 + 7)
+	}
+
+	w := bucket.Object("big").NewWriter(ctx)
+	w.ContentType = "application/octet-stream"
+
+	if _, err := w.Write(want); err != nil {
+		t.Fatalf("Writer.Write: %v", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("Writer.Close: %v", err)
+	}
+
+	rd, err := bucket.Object("big").NewReader(ctx)
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+
+	got, err := io.ReadAll(rd)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	_ = rd.Close()
+
+	if len(got) != size {
+		t.Fatalf("size mismatch: got=%d want=%d", len(got), size)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Errorf("resumable upload assembled incorrectly: bytes differ")
+	}
+
+	attrs, err := bucket.Object("big").Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs: %v", err)
+	}
+
+	if attrs.Size != int64(size) {
+		t.Errorf("Attrs.Size=%d want %d", attrs.Size, size)
+	}
+}
+
+// TestSDKGCSRangeReader verifies NewRangeReader returns exactly the requested
+// byte slice (a 206 Partial Content on the wire), not the whole body.
+func TestSDKGCSRangeReader(t *testing.T) {
+	client := newGCSTestClient(t)
+	ctx := context.Background()
+
+	bucket := client.Bucket("b1")
+	if err := bucket.Create(ctx, "p1", nil); err != nil {
+		t.Fatalf("bucket.Create: %v", err)
+	}
+
+	content := []byte("0123456789abcdef")
+	writeGCSObject(t, ctx, bucket, "k1", content)
+
+	cases := []struct {
+		name          string
+		offset, count int64
+		want          []byte
+	}{
+		{name: "mid-range", offset: 3, count: 5, want: content[3:8]},
+		{name: "to-end", offset: 10, count: -1, want: content[10:]},
+		{name: "suffix", offset: -4, count: -1, want: content[len(content)-4:]},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rd, err := bucket.Object("k1").NewRangeReader(ctx, tc.offset, tc.count)
+			if err != nil {
+				t.Fatalf("NewRangeReader(%d,%d): %v", tc.offset, tc.count, err)
+			}
+
+			got, err := io.ReadAll(rd)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+
+			_ = rd.Close()
+
+			if !bytes.Equal(got, tc.want) {
+				t.Errorf("range bytes mismatch: got=%q want=%q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSDKGCSListDelimiterPagination verifies a delimiter listing paginated with
+// a page size of 1 returns each common prefix exactly once (no duplication
+// across pages) and surfaces every top-level object.
+func TestSDKGCSListDelimiterPagination(t *testing.T) {
+	client := newGCSTestClient(t)
+	ctx := context.Background()
+
+	bucket := client.Bucket("b1")
+	if err := bucket.Create(ctx, "p1", nil); err != nil {
+		t.Fatalf("bucket.Create: %v", err)
+	}
+
+	for _, name := range []string{"m1", "m2", "m3", "a/x", "b/x", "c/x"} {
+		writeGCSObject(t, ctx, bucket, name, []byte("v"))
+	}
+
+	it := bucket.Objects(ctx, &storage.Query{Delimiter: "/"})
+	it.PageInfo().MaxSize = 1 // force many small pages
+
+	prefixCount := map[string]int{}
+	objNames := map[string]bool{}
+
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+
+		if attrs.Prefix != "" {
+			prefixCount[attrs.Prefix]++
+			continue
+		}
+
+		objNames[attrs.Name] = true
+	}
+
+	for _, p := range []string{"a/", "b/", "c/"} {
+		if prefixCount[p] != 1 {
+			t.Errorf("prefix %q count=%d want 1 (duplicated or missing across pages)", p, prefixCount[p])
+		}
+	}
+
+	for _, n := range []string{"m1", "m2", "m3"} {
+		if !objNames[n] {
+			t.Errorf("top-level object %q missing from listing", n)
+		}
+	}
+}
+
+// TestSDKGCSDeleteBucketWithNoncurrentVersions verifies that a bucket holding
+// only noncurrent (archived) object versions still refuses deletion, matching
+// real GCS's 409 not-empty.
+func TestSDKGCSDeleteBucketWithNoncurrentVersions(t *testing.T) {
+	client := newGCSTestClient(t)
+	ctx := context.Background()
+
+	bucket := client.Bucket("b1")
+	if err := bucket.Create(ctx, "p1", &storage.BucketAttrs{VersioningEnabled: true}); err != nil {
+		t.Fatalf("bucket.Create: %v", err)
+	}
+
+	// Two writes leave one archived generation; deleting the live object leaves
+	// no live object but retains the noncurrent version.
+	writeGCSObject(t, ctx, bucket, "k1", []byte("v1"))
+	writeGCSObject(t, ctx, bucket, "k1", []byte("v2"))
+
+	if err := bucket.Object("k1").Delete(ctx); err != nil {
+		t.Fatalf("delete live object: %v", err)
+	}
+
+	if err := bucket.Delete(ctx); err == nil {
+		t.Errorf("bucket.Delete succeeded but noncurrent versions remain; expected not-empty error")
+	}
+}

--- a/server/gcp/gcs/resumable_range_list_test.go
+++ b/server/gcp/gcs/resumable_range_list_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -111,6 +113,98 @@ func TestSDKGCSResumableUpload(t *testing.T) {
 
 	if attrs.Size != int64(size) {
 		t.Errorf("Attrs.Size=%d want %d", attrs.Size, size)
+	}
+}
+
+// TestResumableGappedChunkDoesNotTruncate drives the resumable protocol
+// directly (the SDK only ever sends contiguous chunks) to prove that a chunk
+// arriving after a gap is never accepted as final: it must not commit a
+// truncated object even when its Content-Range claims to carry the last byte.
+func TestResumableGappedChunkDoesNotTruncate(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Storage: cloudP.GCS})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	client, err := storage.NewClient(ctx,
+		option.WithEndpoint(ts.URL+"/storage/v1/"),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	bucket := client.Bucket("b1")
+	if err := bucket.Create(ctx, "p1", nil); err != nil {
+		t.Fatalf("bucket.Create: %v", err)
+	}
+
+	httpc := ts.Client()
+
+	// Initialise a resumable session and read back its session URI.
+	initReq, _ := http.NewRequestWithContext(ctx, http.MethodPost,
+		ts.URL+"/upload/storage/v1/b/b1/o?uploadType=resumable&name=gapped",
+		strings.NewReader(`{"name":"gapped"}`))
+	initReq.Header.Set("Content-Type", "application/json")
+
+	initResp, err := httpc.Do(initReq)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	_ = initResp.Body.Close()
+
+	if initResp.StatusCode != http.StatusOK {
+		t.Fatalf("init status=%d want 200", initResp.StatusCode)
+	}
+
+	loc := initResp.Header.Get("Location")
+	if loc == "" {
+		t.Fatal("init returned no Location session URI")
+	}
+
+	// resumeIncomplete asserts a chunk POST was acknowledged as "resume
+	// incomplete" (200 + X-Http-Status-Code-Override: 308) rather than committing
+	// the object.
+	sendChunk := func(contentRange string, body []byte) *http.Response {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, loc, bytes.NewReader(body))
+		req.Header.Set("Content-Range", contentRange)
+		req.Header.Set("X-Guploader-No-308", "yes")
+
+		resp, err := httpc.Do(req)
+		if err != nil {
+			t.Fatalf("chunk %q: %v", contentRange, err)
+		}
+
+		return resp
+	}
+
+	// First chunk (0-99) with the total still unknown → resume incomplete.
+	r1 := sendChunk("bytes 0-99/*", bytes.Repeat([]byte("A"), 100))
+	_ = r1.Body.Close()
+
+	if got := r1.Header.Get("X-Http-Status-Code-Override"); got != "308" {
+		t.Fatalf("first chunk override=%q want 308 (should be resume-incomplete)", got)
+	}
+
+	// Second chunk skips 100-199 and claims the final byte of a 300-byte object.
+	// It must NOT be committed as a (truncated) object.
+	r2 := sendChunk("bytes 200-299/300", bytes.Repeat([]byte("B"), 100))
+	_ = r2.Body.Close()
+
+	if r2.Header.Get("X-Http-Status-Code-Override") != "308" {
+		t.Fatalf("gapped final chunk was committed (status=%d) — truncation bug", r2.StatusCode)
+	}
+
+	// The object must not exist: the upload never completed.
+	if _, err := bucket.Object("gapped").Attrs(ctx); err == nil {
+		t.Fatal("object was committed despite an incomplete (gapped) upload")
 	}
 }
 

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -318,7 +318,12 @@ type ObjectInfo struct {
 	ContentType  string
 	ETag         string
 	LastModified string
-	Metadata     map[string]string
+	// Created is the object's original creation time (GCS timeCreated), set once
+	// when the generation is first written and preserved across metadata-only
+	// updates while LastModified advances. Empty for providers that don't model a
+	// distinct creation time (callers fall back to LastModified).
+	Created  string
+	Metadata map[string]string
 	// VersionID is the object's version identifier on a versioning-enabled
 	// bucket ("null" on a suspended/unversioned bucket, empty when the bucket
 	// never had versioning). Providers without versioning leave it empty.


### PR DESCRIPTION
## Summary

Fixes five real-user Google Cloud Storage bugs found by a confirming audit. All changes are in `server/gcp/gcs/` and `providers/gcp/gcs/` (one shared additive field on `services/storage/driver.ObjectInfo`).

### Bugs fixed

1. **Resumable uploads (HIGH)** — objects >16 MiB failed with 400 because `upload()` only handled `uploadType=media|multipart`. The idiomatic `Object.NewWriter` / gsutil path is resumable by default for anything larger than the 16 MiB chunk size. Added a resumable branch: the `uploadType=resumable` POST initialises a session and returns 200 + a `Location` session URI; subsequent chunk uploads carry `Content-Range: bytes X-Y/total`, accumulate in the session buffer, and commit the object through the normal write path on the final chunk. Honors the SDK's `X-GUploader-No-308: yes` (200 + `X-Http-Status-Code-Override: 308`) for the resume-incomplete signal.

2. **Ranged download (HIGH)** — `alt=media` GETs ignored the `Range` header and always returned the full body with 200, so `NewRangeReader(offset>0, ...)` errored. Now parses `Range: bytes=`, emits 206 with `Content-Range` and the sub-slice, 416 on an unsatisfiable range, and sets `Accept-Ranges: bytes`. Mirrors the S3/Azure-blob range handlers.

3. **Delimiter listing pagination (MOD)** — common prefixes were computed over all keys and returned in full on every page, and were not counted toward `maxResults`. Prefixes and objects now fold into one sorted, deduped, lexicographic paginated stream: each prefix appears on exactly one page and counts toward the page size, with position carried in the page token.

4. **DeleteBucket version guard (MOD)** — a bucket holding only noncurrent (archived) versions deleted successfully. Real GCS returns 409 not-empty. Delete now also refuses when any archived version remains.

5. **Metadata-patch `updated` timestamp (MOD)** — a metadata-only patch left `updated` equal to `timeCreated`. Objects now track a distinct creation time; a patch advances `updated` (LastModified) while `timeCreated` stays fixed.

### Tests

Real `cloud.google.com/go/storage` client over `httptest`:
- >16 MiB multi-chunk resumable upload round-trips byte-for-byte
- `NewRangeReader` returns the exact requested slice (206) for mid-range, to-end, and suffix ranges
- delimiter + `MaxSize=1` listing returns each prefix once across pages
- `DeleteBucket` fails with noncurrent versions present

Provider-level (deterministic `FakeClock`):
- metadata patch bumps `updated`, not `timeCreated`
- DeleteBucket refuses a bucket with only noncurrent versions

Existing `TestPaginationTokens` updated to assert the corrected folded-pagination behavior.

### Gates
build ./..., vet, scoped `go test`, gofmt, and `golangci-lint --new-from-rev=origin/development` (0 new) all pass. `go generate ./...` and `go run ./internal/compatgen` produce no diff.
