### PR TITLE
fix(aws-s3): paginate ListObjectsV2 keys+CommonPrefixes as one MaxKeys-capped stream (no repeated prefixes)

### DIFF
--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -728,27 +728,38 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 
 	matchedObjects, commonPrefixSet := matchListKeys(bkt, allKeys, opts)
 
-	commonPrefixes := make([]string, 0, len(commonPrefixSet))
-	for p := range commonPrefixSet {
-		commonPrefixes = append(commonPrefixes, p)
-	}
-
-	sort.Strings(commonPrefixes)
-
 	maxKeys := opts.MaxKeys
 	if maxKeys <= 0 {
 		maxKeys = s3DefaultMaxKeys
 	}
 
-	page, err := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
+	// Real S3 caps object keys and rolled-up common prefixes JOINTLY by
+	// MaxKeys over a single lexicographically-ordered stream: each prefix is
+	// returned on exactly one page, and truncation carries an offset in the
+	// continuation token. Merge the two into one ordered stream, paginate
+	// that, then split the returned page back into keys and prefixes.
+	entries := mergeListEntries(matchedObjects, commonPrefixSet)
+
+	page, err := pagination.Paginate(entries, opts.PageToken, maxKeys)
 	if err != nil {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
 	}
 
-	// Clone metadata only for the page actually returned — cloning every
-	// match would make a paged scan O(bucket) allocations per request.
+	objects := make([]driver.ObjectInfo, 0, len(page.Items))
+	commonPrefixes := make([]string, 0, len(page.Items))
+
 	for i := range page.Items {
-		page.Items[i].Metadata = maps.Clone(page.Items[i].Metadata)
+		e := &page.Items[i]
+		if e.isPrefix {
+			commonPrefixes = append(commonPrefixes, e.key)
+			continue
+		}
+
+		// Clone metadata only for the page actually returned — cloning every
+		// match would make a paged scan O(bucket) allocations per request.
+		obj := e.obj
+		obj.Metadata = maps.Clone(obj.Metadata)
+		objects = append(objects, obj)
 	}
 
 	dims := map[string]string{"BucketName": bucket}
@@ -756,11 +767,41 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 	m.emitMetric("ListRequests", 1, "Count", dims)
 
 	return &driver.ListResult{
-		Objects:        page.Items,
+		Objects:        objects,
 		CommonPrefixes: commonPrefixes,
 		NextPageToken:  page.NextPageToken,
 		IsTruncated:    page.HasMore,
 	}, nil
+}
+
+// listEntry is one item in the combined listing stream: either an object key
+// or a rolled-up common prefix. S3 caps keys and common prefixes jointly by
+// MaxKeys over one lexicographic ordering, so pagination runs against the
+// merged stream rather than over keys alone.
+type listEntry struct {
+	key      string
+	isPrefix bool
+	obj      driver.ObjectInfo
+}
+
+// mergeListEntries builds the single lexicographically-sorted stream of object
+// keys and common prefixes. Keys are unique across the two sets — an object
+// that rolls up into a prefix is excluded from matchedObjects — so the merged
+// ordering is total and stable across paged calls, keeping offset tokens valid.
+func mergeListEntries(objects []driver.ObjectInfo, prefixSet map[string]struct{}) []listEntry {
+	entries := make([]listEntry, 0, len(objects)+len(prefixSet))
+
+	for i := range objects {
+		entries = append(entries, listEntry{key: objects[i].Key, obj: objects[i]})
+	}
+
+	for p := range prefixSet {
+		entries = append(entries, listEntry{key: p, isPrefix: true})
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
+
+	return entries
 }
 
 // matchListKeys applies the prefix, start-after, and delimiter filters to the

--- a/providers/aws/s3/s3_lifecycle_test.go
+++ b/providers/aws/s3/s3_lifecycle_test.go
@@ -395,8 +395,9 @@ func TestPaginationTokens(t *testing.T) {
 		}
 	}
 
-	// Survey behavior: CommonPrefixes are NOT paginated — full set on every page
-	// even when object slice is truncated.
+	// Delimited listing: object keys and rolled-up common prefixes are capped
+	// JOINTLY by MaxKeys over one lexicographic stream. Each prefix is returned
+	// on exactly one page (never repeated), and no page exceeds MaxKeys.
 	for i := 0; i < 5; i++ {
 		key := fmt.Sprintf("dir%d/file", i)
 		e2eRequireNoErr(t, m.PutObject(ctx, bucket, key, []byte("x"), "text/plain", nil), "PutObject "+key)
@@ -405,8 +406,65 @@ func TestPaginationTokens(t *testing.T) {
 	first, err := m.ListObjects(ctx, bucket, driver.ListOptions{Delimiter: "/", MaxKeys: 2})
 	e2eRequireNoErr(t, err, "ListObjects delimiter page1")
 
-	if len(first.CommonPrefixes) != 5 {
-		t.Fatalf("first page CommonPrefixes = %d, want all 5 (prefixes are never paginated)", len(first.CommonPrefixes))
+	if got := len(first.Objects) + len(first.CommonPrefixes); got != 2 {
+		t.Fatalf("first page items = %d (objects=%d prefixes=%d), want 2 (MaxKeys caps keys+prefixes jointly)",
+			got, len(first.Objects), len(first.CommonPrefixes))
+	}
+
+	prefixSeen := map[string]int{}
+	keySeen := map[string]int{}
+	token = ""
+	pages = 0
+
+	for {
+		res, perr := m.ListObjects(ctx, bucket, driver.ListOptions{Delimiter: "/", MaxKeys: 2, PageToken: token})
+		e2eRequireNoErr(t, perr, "ListObjects delimiter page")
+
+		pages++
+
+		if n := len(res.Objects) + len(res.CommonPrefixes); n > 2 {
+			t.Fatalf("page %d has %d items, exceeds MaxKeys=2", pages, n)
+		}
+
+		for _, o := range res.Objects {
+			keySeen[o.Key]++
+		}
+
+		for _, p := range res.CommonPrefixes {
+			prefixSeen[p]++
+		}
+
+		if !res.IsTruncated {
+			break
+		}
+
+		token = res.NextPageToken
+	}
+
+	// 25 bare keys + 5 rolled-up prefixes = 30 items over ceil(30/2)=15 pages.
+	if pages != 15 {
+		t.Fatalf("delimited pagination in %d pages, want 15", pages)
+	}
+
+	if len(keySeen) != total {
+		t.Fatalf("distinct keys = %d, want %d", len(keySeen), total)
+	}
+
+	for k, c := range keySeen {
+		if c != 1 {
+			t.Fatalf("key %q returned %d times, want exactly 1", k, c)
+		}
+	}
+
+	if len(prefixSeen) != 5 {
+		t.Fatalf("distinct common prefixes = %d, want 5", len(prefixSeen))
+	}
+
+	for i := 0; i < 5; i++ {
+		p := fmt.Sprintf("dir%d/", i)
+		if prefixSeen[p] != 1 {
+			t.Fatalf("common prefix %q returned %d times, want exactly 1", p, prefixSeen[p])
+		}
 	}
 }
 

--- a/server/aws/s3/list_commonprefixes_pagination_test.go
+++ b/server/aws/s3/list_commonprefixes_pagination_test.go
@@ -1,0 +1,276 @@
+package s3_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// TestSDKListObjectsV2CommonPrefixesPagination asserts a delimited ListObjectsV2
+// listing caps object keys AND rolled-up common prefixes JOINTLY by MaxKeys over
+// one lexicographic stream: every key and every prefix is returned EXACTLY once
+// across all pages, and no single page exceeds MaxKeys. Real S3 does not repeat
+// CommonPrefixes on every page, and counts them toward MaxKeys.
+func TestSDKListObjectsV2CommonPrefixesPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "listv2-cp-page-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	// 2000 top-level keys (no delimiter in them) plus 3 keys that roll up into
+	// the common prefixes dir0/, dir1/, dir2/. With delimiter "/" and
+	// MaxKeys 1000 the listing must span multiple pages.
+	const topLevelKeys = 2000
+	for i := 0; i < topLevelKeys; i++ {
+		key := fmt.Sprintf("key-%05d", i)
+		if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+			Body:   bytes.NewReader([]byte("x")),
+		}); err != nil {
+			t.Fatalf("PutObject %s: %v", key, err)
+		}
+	}
+
+	prefixDirs := []string{"dir0/", "dir1/", "dir2/"}
+	for _, d := range prefixDirs {
+		key := d + "child"
+		if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+			Body:   bytes.NewReader([]byte("x")),
+		}); err != nil {
+			t.Fatalf("PutObject %s: %v", key, err)
+		}
+	}
+
+	const maxKeys = 1000
+	paginator := awss3.NewListObjectsV2Paginator(client, &awss3.ListObjectsV2Input{
+		Bucket:    aws.String(bucket),
+		Delimiter: aws.String("/"),
+		MaxKeys:   aws.Int32(maxKeys),
+	})
+
+	keyCounts := make(map[string]int)
+	prefixCounts := make(map[string]int)
+	pages := 0
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		pages++
+
+		perPage := len(page.Contents) + len(page.CommonPrefixes)
+		if perPage > maxKeys {
+			t.Fatalf("page %d returned %d items (keys=%d prefixes=%d), exceeds MaxKeys=%d",
+				pages, perPage, len(page.Contents), len(page.CommonPrefixes), maxKeys)
+		}
+
+		// KeyCount must count keys AND common prefixes on this page.
+		if got := int(aws.ToInt32(page.KeyCount)); got != perPage {
+			t.Errorf("page %d KeyCount = %d, want %d (keys+prefixes)", pages, got, perPage)
+		}
+
+		for _, o := range page.Contents {
+			keyCounts[aws.ToString(o.Key)]++
+		}
+
+		for _, p := range page.CommonPrefixes {
+			prefixCounts[aws.ToString(p.Prefix)]++
+		}
+	}
+
+	if pages < 2 {
+		t.Fatalf("expected the listing to span multiple pages, got %d", pages)
+	}
+
+	// Every top-level key returned exactly once.
+	if len(keyCounts) != topLevelKeys {
+		t.Errorf("distinct keys returned = %d, want %d", len(keyCounts), topLevelKeys)
+	}
+
+	for i := 0; i < topLevelKeys; i++ {
+		key := fmt.Sprintf("key-%05d", i)
+		if keyCounts[key] != 1 {
+			t.Errorf("key %s returned %d times, want exactly 1", key, keyCounts[key])
+		}
+	}
+
+	// Every common prefix returned exactly once (never repeated per page).
+	if len(prefixCounts) != len(prefixDirs) {
+		t.Errorf("distinct common prefixes = %d, want %d (%v)", len(prefixCounts), len(prefixDirs), prefixCounts)
+	}
+
+	for _, d := range prefixDirs {
+		if prefixCounts[d] != 1 {
+			t.Errorf("common prefix %s returned %d times, want exactly 1", d, prefixCounts[d])
+		}
+	}
+}
+
+// TestSDKListObjectsV2ManyCommonPrefixesTruncate asserts that when the number of
+// rolled-up common prefixes alone exceeds MaxKeys, the listing truncates: the
+// first page is capped and IsTruncated with a continuation token, and resuming
+// returns the remaining prefixes with none repeated or dropped.
+func TestSDKListObjectsV2ManyCommonPrefixesTruncate(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "listv2-many-cp-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	// 1500 distinct directories, each contributing one common prefix under
+	// delimiter "/". No top-level (bare) keys, so the page is prefixes-only.
+	const dirs = 1500
+	for i := 0; i < dirs; i++ {
+		key := fmt.Sprintf("d%05d/child", i)
+		if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+			Body:   bytes.NewReader([]byte("x")),
+		}); err != nil {
+			t.Fatalf("PutObject %s: %v", key, err)
+		}
+	}
+
+	const maxKeys = 1000
+	page1, err := client.ListObjectsV2(ctx, &awss3.ListObjectsV2Input{
+		Bucket:    aws.String(bucket),
+		Delimiter: aws.String("/"),
+		MaxKeys:   aws.Int32(maxKeys),
+	})
+	if err != nil {
+		t.Fatalf("ListObjectsV2 page1: %v", err)
+	}
+
+	if len(page1.Contents) != 0 {
+		t.Errorf("page1 keys = %d, want 0 (all objects roll up into prefixes)", len(page1.Contents))
+	}
+
+	if len(page1.CommonPrefixes) != maxKeys {
+		t.Fatalf("page1 common prefixes = %d, want %d (capped by MaxKeys)", len(page1.CommonPrefixes), maxKeys)
+	}
+
+	if !aws.ToBool(page1.IsTruncated) {
+		t.Fatal("page1 IsTruncated = false, want true (1500 > 1000 prefixes)")
+	}
+
+	if aws.ToString(page1.NextContinuationToken) == "" {
+		t.Fatal("page1 NextContinuationToken is empty, want a resume token")
+	}
+
+	page2, err := client.ListObjectsV2(ctx, &awss3.ListObjectsV2Input{
+		Bucket:            aws.String(bucket),
+		Delimiter:         aws.String("/"),
+		MaxKeys:           aws.Int32(maxKeys),
+		ContinuationToken: page1.NextContinuationToken,
+	})
+	if err != nil {
+		t.Fatalf("ListObjectsV2 page2: %v", err)
+	}
+
+	if len(page2.CommonPrefixes) != dirs-maxKeys {
+		t.Errorf("page2 common prefixes = %d, want %d (remaining)", len(page2.CommonPrefixes), dirs-maxKeys)
+	}
+
+	if aws.ToBool(page2.IsTruncated) {
+		t.Error("page2 IsTruncated = true, want false (remaining prefixes fit)")
+	}
+
+	// No prefix appears on both pages, and every directory appears exactly once.
+	seen := make(map[string]int)
+	for _, p := range page1.CommonPrefixes {
+		seen[aws.ToString(p.Prefix)]++
+	}
+
+	for _, p := range page2.CommonPrefixes {
+		seen[aws.ToString(p.Prefix)]++
+	}
+
+	if len(seen) != dirs {
+		t.Errorf("distinct prefixes across pages = %d, want %d", len(seen), dirs)
+	}
+
+	for i := 0; i < dirs; i++ {
+		d := fmt.Sprintf("d%05d/", i)
+		if seen[d] != 1 {
+			t.Errorf("prefix %s seen %d times across pages, want exactly 1", d, seen[d])
+		}
+	}
+}
+
+// TestSDKListObjectsV2KeysOnlyPaginationUnregressed asserts the non-delimited
+// (keys-only) pagination path still returns every key exactly once across pages
+// with correct truncation — the CommonPrefixes fix must not disturb it.
+func TestSDKListObjectsV2KeysOnlyPaginationUnregressed(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "listv2-keys-only-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	const total = 2500
+	for i := 0; i < total; i++ {
+		key := fmt.Sprintf("obj-%05d", i)
+		if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+			Body:   bytes.NewReader([]byte("x")),
+		}); err != nil {
+			t.Fatalf("PutObject %s: %v", key, err)
+		}
+	}
+
+	const maxKeys = 1000
+	paginator := awss3.NewListObjectsV2Paginator(client, &awss3.ListObjectsV2Input{
+		Bucket:  aws.String(bucket),
+		MaxKeys: aws.Int32(maxKeys),
+	})
+
+	seen := make(map[string]int)
+	pages := 0
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		pages++
+
+		if len(page.Contents) > maxKeys {
+			t.Fatalf("page %d returned %d keys, exceeds MaxKeys=%d", pages, len(page.Contents), maxKeys)
+		}
+
+		if len(page.CommonPrefixes) != 0 {
+			t.Errorf("page %d has common prefixes without a delimiter, want none", pages)
+		}
+
+		for _, o := range page.Contents {
+			seen[aws.ToString(o.Key)]++
+		}
+	}
+
+	if pages != 3 {
+		t.Errorf("pages = %d, want 3 (2500 keys / 1000)", pages)
+	}
+
+	if len(seen) != total {
+		t.Errorf("distinct keys = %d, want %d", len(seen), total)
+	}
+
+	for i := 0; i < total; i++ {
+		key := fmt.Sprintf("obj-%05d", i)
+		if seen[key] != 1 {
+			t.Errorf("key %s returned %d times, want exactly 1", key, seen[key])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`ListObjectsV2`/`ListObjects` with a delimiter repeated every `CommonPrefixes` entry on every page and did not count prefixes toward `MaxKeys`. The provider paginated only the matched object keys while returning the full `commonPrefixes` slice each page, so a delimited listing over a large bucket returned each rolled-up prefix once per page and could exceed `MaxKeys`.

Real S3 caps object keys and rolled-up common prefixes **jointly** by `MaxKeys` over one lexicographically-sorted stream: each prefix appears on exactly one page, no page exceeds `MaxKeys`, and truncation is carried by the continuation token.

## Change

- `providers/aws/s3/s3.go` — `ListObjects` now merges matched object keys and common prefixes into a single lexicographically-sorted stream (`mergeListEntries` / `listEntry`) and paginates that combined stream against `MaxKeys`, carrying the offset in the continuation token. The returned page is split back into `Objects` and `CommonPrefixes`. This mirrors the joint key+prefix treatment already used on the `ListObjectVersions` path. Non-delimited (keys-only) pagination is unchanged in behavior.
- The server handler already computed `KeyCount = len(Objects)+len(CommonPrefixes)` and echoed the provider's prefixes/token, so no handler change was needed — it now yields correct per-page values.

## Tests (real aws-sdk-go-v2)

- `server/aws/s3/list_commonprefixes_pagination_test.go`
  - 2000 keys + 3 common prefixes, delimiter `/`, MaxKeys 1000 via `ListObjectsV2Paginator`: every key and every prefix returned exactly once, no page exceeds MaxKeys, `KeyCount` counts keys+prefixes.
  - >1000 common prefixes (1500 dirs): first page capped at 1000 with `IsTruncated` + continuation token; resume returns the rest with none repeated or dropped.
  - Keys-only pagination (2500 keys) unregressed: 3 pages, each key once.
- Updated `providers/aws/s3/s3_lifecycle_test.go` `TestPaginationTokens`, which previously asserted the buggy "prefixes never paginated" behavior, to assert correct joint pagination.
