### PR TITLE
fix(aws-ec2,rds): validate+apply DescribeInstances filters, atomic RunInstances ClientToken dedup, RDS unknown-filter error

### DIFF
--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -292,9 +292,9 @@ type Mock struct {
 	// releases it on terminate, so the VPC subnet / security-group delete guards
 	// see a running instance's interface. nil until wired by the provider.
 	networking Networking
-	// mu guards managedResourceVisibility, clientTokens and subnetIPCounters,
-	// which are scalar/map shared state that (unlike the memstores) has no
-	// internal locking of their own.
+	// mu guards managedResourceVisibility, clientTokens, clientTokenInflight and
+	// subnetIPCounters, which are scalar/map shared state that (unlike the
+	// memstores) has no internal locking of their own.
 	mu sync.RWMutex
 	// managedResourceVisibility is "visible" or "hidden". When "hidden",
 	// service-provider-managed instances are omitted from DescribeInstances
@@ -305,6 +305,11 @@ type Mock struct {
 	// of double-provisioning (AWS idempotency). Permanent — an emulator needs no
 	// expiry window.
 	clientTokens map[string][]string
+	// clientTokenInflight tracks ClientTokens whose launch is still provisioning,
+	// so two concurrent RunInstances carrying the same token cannot both provision
+	// (one reserves the token and launches; the others wait on its result). An
+	// entry is removed once the launch completes and its ids move to clientTokens.
+	clientTokenInflight map[string]*clientTokenLaunch
 	// subnetIPCounters is the per-subnet host counter used to allocate private
 	// IPv4 addresses from the subnet's CIDR range.
 	subnetIPCounters map[string]int
@@ -392,6 +397,7 @@ func New(opts *config.Options) *Mock {
 
 		managedResourceVisibility: visibilityVisible,
 		clientTokens:              make(map[string][]string),
+		clientTokenInflight:       make(map[string]*clientTokenLaunch),
 		subnetIPCounters:          make(map[string]int),
 	}
 }
@@ -518,13 +524,75 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "count %d exceeds the maximum of %d per call", count, maxRunInstances)
 	}
 
-	// Idempotency: a retry carrying a ClientToken we've already served returns the
-	// same instances rather than launching new ones (real EC2 RunInstances).
-	if dup, ok := m.instancesForClientToken(cfg.ClientToken); ok {
-		return dup, nil
+	// Idempotency: a ClientToken serializes same-token launches so a retry (or a
+	// concurrent duplicate) returns the same instances rather than provisioning a
+	// second set. The empty token opts out.
+	if cfg.ClientToken == "" {
+		return m.launchInstances(ctx, cfg, count)
 	}
 
-	return m.launchInstances(ctx, cfg, count)
+	return m.runInstancesIdempotent(ctx, cfg, count)
+}
+
+// clientTokenLaunch is the shared result of an in-flight tokened RunInstances:
+// waiters block on done, then read ids/err (written before done is closed).
+type clientTokenLaunch struct {
+	done chan struct{}
+	ids  []string
+	err  error
+}
+
+// runInstancesIdempotent provisions at most one instance set per ClientToken.
+// The first caller reserves the token under m.mu and launches; concurrent
+// callers with the same token find the reservation and wait on its result, and
+// a later retry finds the recorded ids — so a token never provisions twice.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) runInstancesIdempotent(ctx context.Context, cfg driver.InstanceConfig, count int) ([]driver.Instance, error) {
+	token := cfg.ClientToken
+
+	m.mu.Lock()
+	if ids, ok := m.clientTokens[token]; ok {
+		m.mu.Unlock()
+
+		return m.renderInstancesByID(ids), nil
+	}
+
+	if inflight, ok := m.clientTokenInflight[token]; ok {
+		m.mu.Unlock()
+		<-inflight.done
+
+		if inflight.err != nil {
+			return nil, inflight.err
+		}
+
+		return m.renderInstancesByID(inflight.ids), nil
+	}
+
+	launch := &clientTokenLaunch{done: make(chan struct{})}
+	m.clientTokenInflight[token] = launch
+	m.mu.Unlock()
+
+	results, err := m.launchInstances(ctx, cfg, count)
+
+	m.mu.Lock()
+	delete(m.clientTokenInflight, token)
+
+	if err == nil {
+		ids := make([]string, len(results))
+		for i := range results {
+			ids[i] = results[i].ID
+		}
+
+		m.clientTokens[token] = ids
+		launch.ids = ids
+	} else {
+		launch.err = err
+	}
+	m.mu.Unlock()
+	close(launch.done)
+
+	return results, err
 }
 
 // launchInstances does the actual provisioning for RunInstances once count and
@@ -630,26 +698,13 @@ func (m *Mock) launchInstances(ctx context.Context, cfg driver.InstanceConfig, c
 		}
 	}
 
-	m.recordClientToken(cfg.ClientToken, created)
-
 	return results, nil
 }
 
-// instancesForClientToken returns the instances previously launched under token
-// (rendered fresh from the store) when token is non-empty and already recorded.
-func (m *Mock) instancesForClientToken(token string) ([]driver.Instance, bool) {
-	if token == "" {
-		return nil, false
-	}
-
-	m.mu.RLock()
-	ids, ok := m.clientTokens[token]
-	m.mu.RUnlock()
-
-	if !ok {
-		return nil, false
-	}
-
+// renderInstancesByID renders the current state of the given instance ids fresh
+// from the store, skipping any that no longer exist. It backs the idempotent
+// ClientToken paths so a retry reflects the instances' latest state.
+func (m *Mock) renderInstancesByID(ids []string) []driver.Instance {
 	hidden := m.visibility() == visibilityHidden
 	out := make([]driver.Instance, 0, len(ids))
 
@@ -659,24 +714,7 @@ func (m *Mock) instancesForClientToken(token string) ([]driver.Instance, bool) {
 		}
 	}
 
-	return out, true
-}
-
-// recordClientToken remembers which instances a ClientToken launched so a retry
-// is served idempotently. A no-op for the empty token.
-func (m *Mock) recordClientToken(token string, created []*instanceData) {
-	if token == "" {
-		return
-	}
-
-	ids := make([]string, 0, len(created))
-	for _, inst := range created {
-		ids = append(ids, inst.ID)
-	}
-
-	m.mu.Lock()
-	m.clientTokens[token] = ids
-	m.mu.Unlock()
+	return out
 }
 
 // resolveSubnet returns the VPC that owns subnetID and the subnet's CIDR block
@@ -934,6 +972,10 @@ func (m *Mock) GetConsoleOutput(ctx context.Context, instanceID string) ([]byte,
 func (m *Mock) DescribeInstances(
 	_ context.Context, instanceIDs []string, filters []driver.DescribeFilter, opts ...driver.DescribeInstancesOptions,
 ) ([]driver.Instance, error) {
+	if err := validateInstanceFilters(filters); err != nil {
+		return nil, err
+	}
+
 	var includeManaged bool
 	if len(opts) > 0 {
 		includeManaged = opts[0].IncludeManagedResources
@@ -1023,7 +1065,7 @@ func matchesFilters(inst *instanceData, filters []driver.DescribeFilter, now tim
 	defer inst.mu.Unlock()
 
 	for _, f := range filters {
-		if !matchesSingleFilter(inst, f, now) {
+		if matched, _ := instanceFilterMatch(inst, f, now); !matched {
 			return false
 		}
 	}
@@ -1031,32 +1073,105 @@ func matchesFilters(inst *instanceData, filters []driver.DescribeFilter, now tim
 	return true
 }
 
-func matchesSingleFilter(inst *instanceData, f driver.DescribeFilter, now time.Time) bool {
-	switch f.Name {
-	case "instance-id":
-		return containsValue(f.Values, inst.ID)
-	case "instance-type":
-		return containsValue(f.Values, inst.InstanceType)
-	case "instance-state-name":
-		// Filter on the observed state so it agrees with the state Describe
-		// renders (both go through the settle overlay under AsyncSettle).
-		return containsValue(f.Values, inst.settle.Observe(now, inst.State))
+// validateInstanceFilters rejects filter names DescribeInstances does not model,
+// so an unknown filter errors (surfaced as InvalidParameterValue) instead of
+// silently matching every instance. It probes a zero instance for each name and
+// consults only the "known" result, so the accepted set can never drift from
+// what instanceFilterMatch actually honors (mirrors the VPC-family handlers).
+func validateInstanceFilters(filters []driver.DescribeFilter) error {
+	var probe instanceData
+
+	for _, f := range filters {
+		if _, known := instanceFilterMatch(&probe, f, time.Time{}); !known {
+			return cerrors.Newf(cerrors.InvalidArgument, "The filter '%s' is invalid", f.Name)
+		}
+	}
+
+	return nil
+}
+
+// instanceFilterMatch reports whether inst satisfies filter f (values within one
+// filter are OR-ed) and whether f is a filter DescribeInstances recognizes.
+// Scalar filters resolve to a single instance field; tag filters are matched
+// separately.
+func instanceFilterMatch(inst *instanceData, f driver.DescribeFilter, now time.Time) (matched, known bool) {
+	if field, ok := instanceFilterField(inst, f.Name, now); ok {
+		return containsValue(f.Values, field), true
+	}
+
+	return matchesTagFilter(inst, f)
+}
+
+// instanceFilterField maps a scalar DescribeInstances filter name to the
+// instance value it selects, and reports whether the name is one the emulator
+// models. The derived private-dns-name/availability-zone/architecture values
+// mirror what the wire layer renders so a filter agrees with the described
+// instance; instance-lifecycle is empty because the emulator launches only
+// on-demand instances (so spot/scheduled never match).
+func instanceFilterField(inst *instanceData, name string, now time.Time) (field string, known bool) {
+	// Filter on the observed state so instance-state-name agrees with the state
+	// Describe renders (both go through the settle overlay under AsyncSettle).
+	byName := map[string]string{
+		"instance-id":         inst.ID,
+		"instance-type":       inst.InstanceType,
+		"instance-state-name": inst.settle.Observe(now, inst.State),
+		"vpc-id":              inst.VPCID,
+		"subnet-id":           inst.SubnetID,
+		"image-id":            inst.ImageID,
+		"private-ip-address":  inst.PrivateIP,
+		"private-dns-name":    privateDNSNameFor(inst.PrivateIP),
+		"key-name":            inst.keyName,
+		"reservation-id":      inst.reservationID,
+		"availability-zone":   instanceZone,
+		"architecture":        instanceArchitecture,
+		"instance-lifecycle":  "",
+	}
+
+	v, ok := byName[name]
+
+	return v, ok
+}
+
+// instanceZone and instanceArchitecture are the fixed placement zone and CPU
+// architecture the emulator reports for every EC2 instance; they mirror the
+// values the wire layer renders (defaultZone / archX86) so a filter on them
+// agrees with DescribeInstances output.
+const (
+	instanceZone         = "us-east-1a"
+	instanceArchitecture = "x86_64"
+)
+
+// privateDNSNameFor derives the internal DNS name from a private IPv4
+// (10.0.0.5 -> ip-10-0-0-5.ec2.internal), mirroring the wire layer's render so a
+// private-dns-name filter matches the described instance. Empty for no IP.
+func privateDNSNameFor(ip string) string {
+	if ip == "" {
+		return ""
+	}
+
+	return "ip-" + strings.ReplaceAll(ip, ".", "-") + ".ec2.internal"
+}
+
+// matchesTagFilter evaluates "tag:<key>" and "tag-key" filters, returning
+// whether inst matches and whether f was a tag filter at all (so a non-tag name
+// is reported unknown to validateInstanceFilters).
+func matchesTagFilter(inst *instanceData, f driver.DescribeFilter) (matched, known bool) {
+	switch {
+	case len(f.Name) > 4 && f.Name[:4] == "tag:":
+		tagVal, ok := inst.Tags[f.Name[4:]]
+
+		return ok && containsValue(f.Values, tagVal), true
+	case f.Name == "tag-key":
+		for k := range inst.Tags {
+			if containsValue(f.Values, k) {
+				return true, true
+			}
+		}
+
+		return false, true
 	default:
-		return matchesTagFilter(inst, f)
+		return false, false
 	}
-}
-
-func matchesTagFilter(inst *instanceData, f driver.DescribeFilter) bool {
-	if len(f.Name) > 4 && f.Name[:4] == "tag:" {
-		tagKey := f.Name[4:]
-
-		tagVal, ok := inst.Tags[tagKey]
-		if !ok || !containsValue(f.Values, tagVal) {
-			return false
-		}
-	}
-
-	return true
 }
 
 func containsValue(values []string, target string) bool {

--- a/providers/aws/ec2/ec2_test.go
+++ b/providers/aws/ec2/ec2_test.go
@@ -318,10 +318,20 @@ func TestModifyInstance(t *testing.T) {
 
 func TestMatchesFilters(t *testing.T) {
 	inst := &instanceData{
-		ID:           "i-123",
-		InstanceType: "t2.micro",
-		State:        "running",
-		Tags:         map[string]string{"env": "prod"},
+		ID:            "i-123",
+		InstanceType:  "t2.micro",
+		State:         "running",
+		ImageID:       "ami-abc",
+		VPCID:         "vpc-1",
+		SubnetID:      "subnet-1",
+		PrivateIP:     "10.0.0.5",
+		keyName:       "my-key",
+		reservationID: "r-1",
+		Tags:          map[string]string{"env": "prod"},
+	}
+
+	f := func(name string, values ...string) []driver.DescribeFilter {
+		return []driver.DescribeFilter{{Name: name, Values: values}}
 	}
 
 	tests := []struct {
@@ -330,11 +340,26 @@ func TestMatchesFilters(t *testing.T) {
 		expect  bool
 	}{
 		{name: "no filters", filters: nil, expect: true},
-		{name: "match instance-id", filters: []driver.DescribeFilter{{Name: "instance-id", Values: []string{"i-123"}}}, expect: true},
-		{name: "no match instance-id", filters: []driver.DescribeFilter{{Name: "instance-id", Values: []string{"i-999"}}}, expect: false},
-		{name: "match tag", filters: []driver.DescribeFilter{{Name: "tag:env", Values: []string{"prod"}}}, expect: true},
-		{name: "no match tag", filters: []driver.DescribeFilter{{Name: "tag:env", Values: []string{"dev"}}}, expect: false},
-		{name: "unknown filter passes", filters: []driver.DescribeFilter{{Name: "unknown", Values: []string{"x"}}}, expect: true},
+		{name: "match instance-id", filters: f("instance-id", "i-123"), expect: true},
+		{name: "no match instance-id", filters: f("instance-id", "i-999"), expect: false},
+		{name: "match tag", filters: f("tag:env", "prod"), expect: true},
+		{name: "no match tag", filters: f("tag:env", "dev"), expect: false},
+		{name: "match tag-key", filters: f("tag-key", "env"), expect: true},
+		{name: "no match tag-key", filters: f("tag-key", "team"), expect: false},
+		{name: "match vpc-id", filters: f("vpc-id", "vpc-1"), expect: true},
+		{name: "no match vpc-id", filters: f("vpc-id", "vpc-9"), expect: false},
+		{name: "match subnet-id", filters: f("subnet-id", "subnet-1"), expect: true},
+		{name: "no match subnet-id", filters: f("subnet-id", "subnet-9"), expect: false},
+		{name: "match image-id", filters: f("image-id", "ami-abc"), expect: true},
+		{name: "match private-ip-address", filters: f("private-ip-address", "10.0.0.5"), expect: true},
+		{name: "match private-dns-name", filters: f("private-dns-name", "ip-10-0-0-5.ec2.internal"), expect: true},
+		{name: "match key-name", filters: f("key-name", "my-key"), expect: true},
+		{name: "match reservation-id", filters: f("reservation-id", "r-1"), expect: true},
+		{name: "match availability-zone", filters: f("availability-zone", instanceZone), expect: true},
+		{name: "match architecture", filters: f("architecture", instanceArchitecture), expect: true},
+		{name: "no match instance-lifecycle spot", filters: f("instance-lifecycle", "spot"), expect: false},
+		// An unknown filter never matches (DescribeInstances rejects it up front).
+		{name: "unknown filter does not match", filters: f("unknown", "x"), expect: false},
 	}
 
 	for _, tc := range tests {

--- a/providers/aws/ec2/run_instances_client_token_test.go
+++ b/providers/aws/ec2/run_instances_client_token_test.go
@@ -1,0 +1,124 @@
+package ec2
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+// TestRunInstancesClientTokenConcurrent pins that two concurrent RunInstances
+// carrying the same ClientToken provision exactly one instance set — the token
+// check-and-reserve is atomic, so a race cannot double-provision. Run with -race.
+func TestRunInstancesClientTokenConcurrent(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cfg := defaultConfig()
+	cfg.ClientToken = "shared-token"
+
+	const goroutines = 8
+
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		results [][]driver.Instance
+	)
+
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+
+			got, err := m.RunInstances(ctx, cfg, 1)
+			if err != nil {
+				t.Errorf("RunInstances: %v", err)
+				return
+			}
+
+			mu.Lock()
+			results = append(results, got)
+			mu.Unlock()
+		}()
+	}
+
+	wg.Wait()
+
+	// Every caller must observe the same single instance id.
+	wantID := results[0][0].ID
+	for _, r := range results {
+		if len(r) != 1 || r[0].ID != wantID {
+			t.Fatalf("caller saw instances %v, want exactly [%q]", instanceIDsOf(r), wantID)
+		}
+	}
+
+	// The backend must hold exactly one instance, not one per goroutine.
+	all, err := m.DescribeInstances(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	if len(all) != 1 {
+		t.Fatalf("backend holds %d instances, want 1 (no double-provisioning)", len(all))
+	}
+
+	if all[0].ID != wantID {
+		t.Fatalf("backend instance %q, want %q", all[0].ID, wantID)
+	}
+}
+
+// TestRunInstancesClientTokenSequential pins that sequential retries with the
+// same ClientToken keep returning the same instance set (idempotency), and that
+// a different token provisions a distinct instance.
+func TestRunInstancesClientTokenSequential(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cfg := defaultConfig()
+	cfg.ClientToken = "token-a"
+
+	first, err := m.RunInstances(ctx, cfg, 1)
+	if err != nil {
+		t.Fatalf("RunInstances (first): %v", err)
+	}
+
+	retry, err := m.RunInstances(ctx, cfg, 1)
+	if err != nil {
+		t.Fatalf("RunInstances (retry): %v", err)
+	}
+
+	if len(retry) != 1 || retry[0].ID != first[0].ID {
+		t.Fatalf("retry returned %v, want same as first %q", instanceIDsOf(retry), first[0].ID)
+	}
+
+	cfg.ClientToken = "token-b"
+
+	other, err := m.RunInstances(ctx, cfg, 1)
+	if err != nil {
+		t.Fatalf("RunInstances (other token): %v", err)
+	}
+
+	if other[0].ID == first[0].ID {
+		t.Fatal("a different ClientToken returned the same instance, want a new one")
+	}
+
+	all, err := m.DescribeInstances(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	if len(all) != 2 {
+		t.Fatalf("backend holds %d instances, want 2", len(all))
+	}
+}
+
+func instanceIDsOf(insts []driver.Instance) []string {
+	ids := make([]string, len(insts))
+	for i := range insts {
+		ids[i] = insts[i].ID
+	}
+
+	return ids
+}

--- a/server/aws/ec2/describe_instances_filter_test.go
+++ b/server/aws/ec2/describe_instances_filter_test.go
@@ -1,0 +1,115 @@
+package ec2_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestDescribeInstancesFilterAppliesVPCAndSubnet pins that DescribeInstances
+// applies the vpc-id and subnet-id filters, returning only the instance placed
+// in that VPC/subnet rather than the whole fleet (the over-inclusive match-all
+// bug for unmodeled filters).
+func TestDescribeInstancesFilterAppliesVPCAndSubnet(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	vpc, err := c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	vpcID := aws.ToString(vpc.Vpc.VpcId)
+
+	subnet, err := c.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId: aws.String(vpcID), CidrBlock: aws.String("10.0.1.0/24"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSubnet: %v", err)
+	}
+
+	subnetID := aws.ToString(subnet.Subnet.SubnetId)
+
+	inVPC, err := c.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId: aws.String("ami-123"), InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1), SubnetId: aws.String(subnetID),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances (in vpc): %v", err)
+	}
+
+	wantID := aws.ToString(inVPC.Instances[0].InstanceId)
+
+	// A second instance launched with no subnet must NOT satisfy the filters.
+	if _, err = c.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId: aws.String("ami-456"), InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1),
+	}); err != nil {
+		t.Fatalf("RunInstances (no vpc): %v", err)
+	}
+
+	for _, tc := range []struct {
+		name, filterName, filterValue string
+	}{
+		{"vpc-id", "vpc-id", vpcID},
+		{"subnet-id", "subnet-id", subnetID},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, describeErr := c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+				Filters: []ec2types.Filter{{Name: aws.String(tc.filterName), Values: []string{tc.filterValue}}},
+			})
+			if describeErr != nil {
+				t.Fatalf("DescribeInstances: %v", describeErr)
+			}
+
+			ids := instanceIDs(out)
+			if len(ids) != 1 || ids[0] != wantID {
+				t.Fatalf("filter %s=%s returned %v, want only %q", tc.filterName, tc.filterValue, ids, wantID)
+			}
+		})
+	}
+}
+
+// TestDescribeInstancesUnknownFilterErrors pins that an unrecognized filter name
+// is rejected with InvalidParameterValue (real EC2), not silently matching every
+// instance or nothing.
+func TestDescribeInstancesUnknownFilterErrors(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	_ = runOneInstance(t, c)
+
+	_, err := c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("not-a-real-filter"), Values: []string{"x"}}},
+	})
+	if err == nil {
+		t.Fatal("DescribeInstances with an unknown filter succeeded, want an error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not an API error: %v", err)
+	}
+
+	if apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("error code = %q, want InvalidParameterValue", apiErr.ErrorCode())
+	}
+}
+
+// instanceIDs flattens the instance ids across every reservation in a
+// DescribeInstances response.
+func instanceIDs(out *ec2.DescribeInstancesOutput) []string {
+	var ids []string
+	for i := range out.Reservations {
+		for j := range out.Reservations[i].Instances {
+			ids = append(ids, aws.ToString(out.Reservations[i].Instances[j].InstanceId))
+		}
+	}
+
+	return ids
+}

--- a/server/aws/rds/describe_instances_filter_test.go
+++ b/server/aws/rds/describe_instances_filter_test.go
@@ -1,0 +1,98 @@
+package rds_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	smithy "github.com/aws/smithy-go"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+func newRDSClient(t *testing.T) *awsrds.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	ts := httptest.NewServer(awsserver.New(awsserver.Drivers{RDS: cloud.RDS}))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")))
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return awsrds.NewFromConfig(cfg, func(o *awsrds.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+}
+
+// TestDescribeDBInstancesUnknownFilterErrors pins that an unrecognized
+// DescribeDBInstances filter name is rejected with InvalidParameterValue (real
+// RDS), not silently returning an empty result set.
+func TestDescribeDBInstancesUnknownFilterErrors(t *testing.T) {
+	ctx := context.Background()
+	c := newRDSClient(t)
+
+	if _, err := c.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("db1"), Engine: aws.String("mysql"),
+		DBInstanceClass: aws.String("db.t3.micro"), MasterUsername: aws.String("admin"),
+		MasterUserPassword: aws.String("password123"), AllocatedStorage: aws.Int32(20),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	_, err := c.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		Filters: []rdstypes.Filter{{Name: aws.String("not-a-real-filter"), Values: []string{"x"}}},
+	})
+	if err == nil {
+		t.Fatal("DescribeDBInstances with an unknown filter succeeded, want an error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not an API error: %v", err)
+	}
+
+	if apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("error code = %q, want InvalidParameterValue", apiErr.ErrorCode())
+	}
+}
+
+// TestDescribeDBInstancesKnownFilterApplies pins that a modeled filter (engine)
+// still narrows the result set after the unknown-filter validation was added.
+func TestDescribeDBInstancesKnownFilterApplies(t *testing.T) {
+	ctx := context.Background()
+	c := newRDSClient(t)
+
+	create := func(id, engine string) {
+		if _, err := c.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+			DBInstanceIdentifier: aws.String(id), Engine: aws.String(engine),
+			DBInstanceClass: aws.String("db.t3.micro"), MasterUsername: aws.String("admin"),
+			MasterUserPassword: aws.String("password123"), AllocatedStorage: aws.Int32(20),
+		}); err != nil {
+			t.Fatalf("CreateDBInstance(%s): %v", id, err)
+		}
+	}
+
+	create("mysql-db", "mysql")
+	create("pg-db", "postgres")
+
+	out, err := c.DescribeDBInstances(ctx, &awsrds.DescribeDBInstancesInput{
+		Filters: []rdstypes.Filter{{Name: aws.String("engine"), Values: []string{"postgres"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBInstances: %v", err)
+	}
+
+	if len(out.DBInstances) != 1 || aws.ToString(out.DBInstances[0].DBInstanceIdentifier) != "pg-db" {
+		t.Fatalf("engine=postgres returned %d instances, want only pg-db", len(out.DBInstances))
+	}
+}

--- a/server/aws/rds/operations.go
+++ b/server/aws/rds/operations.go
@@ -110,13 +110,21 @@ func (h *Handler) describeDBInstances(w http.ResponseWriter, r *http.Request) {
 		ids = []string{id}
 	}
 
+	filters := parseInstanceFilters(r.Form)
+	if name, ok := unknownInstanceFilter(filters); !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue",
+			"Unrecognized RDS filter: "+name)
+
+		return
+	}
+
 	insts, err := h.db.DescribeInstances(r.Context(), ids)
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	insts = filterInstances(insts, parseInstanceFilters(r.Form))
+	insts = filterInstances(insts, filters)
 
 	page, ok := paginateRDS(w, r, insts, func(i *rdsdriver.Instance) string { return i.ID })
 	if !ok {
@@ -137,8 +145,9 @@ func (h *Handler) describeDBInstances(w http.ResponseWriter, r *http.Request) {
 }
 
 // parseInstanceFilters reads the Filters.Filter.N.{Name,Values.Value.M} entries
-// into a name→values map. Only the DescribeDBInstances-supported filter names
-// are meaningful; unknown names are kept and simply match nothing.
+// into a name→values map. The handler validates the names via
+// unknownInstanceFilter before filtering, so an unrecognized name is rejected
+// with InvalidParameterValue rather than silently matching nothing.
 func parseInstanceFilters(form url.Values) map[string][]string {
 	indices := awsquery.CollectIndices(form, "Filters.Filter")
 	if len(indices) == 0 {
@@ -182,17 +191,11 @@ func filterInstances(insts []rdsdriver.Instance, filters map[string][]string) []
 
 func instanceMatchesFilters(inst *rdsdriver.Instance, filters map[string][]string) bool {
 	for name, values := range filters {
-		var field string
-
-		switch name {
-		case "db-instance-id":
-			field = inst.ID
-		case "engine":
-			field = inst.Engine
-		case "db-cluster-id":
-			field = inst.ClusterID
-		default:
-			return false
+		field, known := instanceFilterField(inst, name)
+		if !known {
+			// Unknown names are rejected up front by unknownInstanceFilter, so a
+			// filter reaching here is always modeled.
+			continue
 		}
 
 		if !containsString(values, field) {
@@ -201,6 +204,37 @@ func instanceMatchesFilters(inst *rdsdriver.Instance, filters map[string][]strin
 	}
 
 	return true
+}
+
+// instanceFilterField returns the instance field a DescribeDBInstances filter
+// name selects, and whether the name is one RDS models. Real RDS errors on any
+// other name rather than silently matching nothing.
+func instanceFilterField(inst *rdsdriver.Instance, name string) (field string, known bool) {
+	switch name {
+	case "db-instance-id":
+		return inst.ID, true
+	case "engine":
+		return inst.Engine, true
+	case "db-cluster-id":
+		return inst.ClusterID, true
+	default:
+		return "", false
+	}
+}
+
+// unknownInstanceFilter reports the first filter name DescribeDBInstances does
+// not recognize (ok=false), so the handler can answer InvalidParameterValue the
+// way real RDS does instead of returning an empty result set.
+func unknownInstanceFilter(filters map[string][]string) (name string, ok bool) {
+	var probe rdsdriver.Instance
+
+	for n := range filters {
+		if _, known := instanceFilterField(&probe, n); !known {
+			return n, false
+		}
+	}
+
+	return "", true
 }
 
 func containsString(values []string, want string) bool {


### PR DESCRIPTION
## Summary

Fixes three AWS data-integrity/fidelity issues found by a cross-check, all in the EC2/RDS describe-filter and RunInstances idempotency paths.

### BUG1 — DescribeInstances ignored unimplemented filters (over-inclusive)
`providers/aws/ec2` `matchesSingleFilter` match-alled any non-tag filter name it did not implement, so a `vpc-id`/`subnet-id`/etc. filter returned the whole fleet, and a truly-unknown filter name was silently accepted. Adopted the sibling `(matched, known)` pattern used by DescribeVolumes/DescribeSubnets:

- `instanceFilterMatch` now resolves scalar filters via `instanceFilterField` and reports whether each name is modeled.
- Implemented the common instance filters: `vpc-id`, `subnet-id`, `image-id`, `private-ip-address`, `private-dns-name`, `key-name`, `reservation-id`, `availability-zone`, `architecture`, `instance-lifecycle` (plus the existing `instance-id`/`instance-type`/`instance-state-name`), and `tag:`/`tag-key`. Derived values (private-dns-name, availability-zone, architecture) mirror what the wire layer renders so a filter agrees with DescribeInstances output.
- `DescribeInstances` now validates filter names up front and returns `InvalidArgument` (surfaced as `InvalidParameterValue`) for an unknown name.

### BUG2 — RunInstances ClientToken dedup was non-atomic under concurrency
The dup-check (RLock) and record (Lock) were separate lock acquisitions with the whole launch in between, so two concurrent same-token RunInstances could both provision. Made check-and-reserve atomic: the first caller reserves the token under a single lock hold and launches; concurrent callers with the same token find the in-flight reservation and wait on its result; a later retry finds the recorded ids. A token never provisions twice; sequential retries still return the same instances.

### BUG3 — RDS DescribeDBInstances unknown filter matched nothing
`instanceMatchesFilters` returned false for an unrecognized filter name, silently emptying the result. It now validates filter names and returns `InvalidParameterValue` for an unknown name, keeping the modeled `db-instance-id`/`engine`/`db-cluster-id` filters working.

## Tests
- EC2 (aws-sdk-go-v2): `vpc-id`/`subnet-id` filters return only the matching instance; unknown filter -> `InvalidParameterValue`.
- Provider unit: expanded filter-match table; concurrent same-ClientToken -> exactly one instance set (`-race`); sequential retry idempotency + distinct token.
- RDS (aws-sdk-go-v2): unknown filter -> `InvalidParameterValue`; `engine` filter still narrows.

## Gates
build ./..., vet, scoped `go test`, `go test -race ./providers/aws/ec2/...`, gofmt, and `golangci-lint --new-from-rev=origin/development` all green. `go generate ./...` and `go run ./internal/compatgen` produce zero diff.