### PR TITLE
fix(gcp-cloudrun): preserve container env ordering and port name round-trip

### DIFF
--- a/providers/gcp/cloudrun/cloudrun.go
+++ b/providers/gcp/cloudrun/cloudrun.go
@@ -295,8 +295,8 @@ func cloneContainers(in []driver.Container) []driver.Container {
 			Image:     in[i].Image,
 			Command:   append([]string(nil), in[i].Command...),
 			Args:      append([]string(nil), in[i].Args...),
-			Env:       cloneMap(in[i].Env),
-			Ports:     append([]int(nil), in[i].Ports...),
+			Env:       append([]driver.EnvVar(nil), in[i].Env...),
+			Ports:     append([]driver.ContainerPort(nil), in[i].Ports...),
 			Resources: cloneResources(in[i].Resources),
 		}
 	}

--- a/providers/gcp/cloudrun/cloudrun_test.go
+++ b/providers/gcp/cloudrun/cloudrun_test.go
@@ -65,7 +65,7 @@ func jobCfg() driver.JobConfig {
 			Image:   "busybox",
 			Command: []string{"echo"},
 			Args:    []string{"hi"},
-			Env:     map[string]string{"K": "V"},
+			Env:     []driver.EnvVar{{Name: "K", Value: "V"}},
 		}},
 	}
 }

--- a/providers/gcp/cloudrun/engine.go
+++ b/providers/gcp/cloudrun/engine.go
@@ -197,13 +197,14 @@ func engineContainers(in []driver.Container, taskIndex, taskCount int) []config.
 }
 
 // taskEnv copies a container's env and overlays the CLOUD_RUN_TASK_INDEX and
-// CLOUD_RUN_TASK_COUNT variables the real Cloud Run injects for each task.
-func taskEnv(base map[string]string, taskIndex, taskCount int) map[string]string {
+// CLOUD_RUN_TASK_COUNT variables the real Cloud Run injects for each task. The
+// engine consumes env as a map; later entries win on duplicate names.
+func taskEnv(base []driver.EnvVar, taskIndex, taskCount int) map[string]string {
 	const injectedVars = 2 // CLOUD_RUN_TASK_INDEX + CLOUD_RUN_TASK_COUNT
 
 	env := make(map[string]string, len(base)+injectedVars)
-	for k, v := range base {
-		env[k] = v
+	for _, e := range base {
+		env[e.Name] = e.Value
 	}
 
 	env["CLOUD_RUN_TASK_INDEX"] = strconv.Itoa(taskIndex)

--- a/providers/gcp/cloudrun/services_test.go
+++ b/providers/gcp/cloudrun/services_test.go
@@ -16,7 +16,7 @@ func svcCfg() driver.ServiceConfig {
 		ServiceAccount: "web@demo.iam.gserviceaccount.com",
 		Timeout:        "300s",
 		Scaling:        &driver.ServiceScaling{MinInstanceCount: 1, MaxInstanceCount: 3},
-		Containers:     []driver.Container{{Image: "gcr.io/demo/web:v1", Ports: []int{8080}}},
+		Containers:     []driver.Container{{Image: "gcr.io/demo/web:v1", Ports: []driver.ContainerPort{{ContainerPort: 8080}}}},
 	}
 }
 
@@ -54,7 +54,7 @@ func TestCreateServiceReconciles(t *testing.T) {
 		t.Fatalf("GetService: %v", err)
 	}
 
-	if len(got.Containers) != 1 || len(got.Containers[0].Ports) != 1 || got.Containers[0].Ports[0] != 8080 {
+	if len(got.Containers) != 1 || len(got.Containers[0].Ports) != 1 || got.Containers[0].Ports[0].ContainerPort != 8080 {
 		t.Fatalf("container ports lost on round-trip: %+v", got.Containers)
 	}
 

--- a/server/gcp/cloudrun/conv.go
+++ b/server/gcp/cloudrun/conv.go
@@ -34,7 +34,7 @@ func toDriverContainers(in []container) []driver.Container {
 			Image:     in[i].Image,
 			Command:   in[i].Command,
 			Args:      in[i].Args,
-			Env:       envToMap(in[i].Env),
+			Env:       toDriverEnv(in[i].Env),
 			Ports:     toDriverPorts(in[i].Ports),
 			Resources: toDriverResources(in[i].Resources),
 		})
@@ -43,53 +43,53 @@ func toDriverContainers(in []container) []driver.Container {
 	return out
 }
 
-func toDriverPorts(in []containerPort) []int {
+func toDriverPorts(in []containerPort) []driver.ContainerPort {
 	if len(in) == 0 {
 		return nil
 	}
 
-	out := make([]int, 0, len(in))
+	out := make([]driver.ContainerPort, 0, len(in))
 	for _, p := range in {
-		out = append(out, p.ContainerPort)
+		out = append(out, driver.ContainerPort{Name: p.Name, ContainerPort: p.ContainerPort})
 	}
 
 	return out
 }
 
-func toWirePorts(in []int) []containerPort {
+func toWirePorts(in []driver.ContainerPort) []containerPort {
 	if len(in) == 0 {
 		return nil
 	}
 
 	out := make([]containerPort, 0, len(in))
 	for _, p := range in {
-		out = append(out, containerPort{ContainerPort: p})
+		out = append(out, containerPort{Name: p.Name, ContainerPort: p.ContainerPort})
 	}
 
 	return out
 }
 
-func envToMap(in []envVar) map[string]string {
+func toDriverEnv(in []envVar) []driver.EnvVar {
 	if len(in) == 0 {
 		return nil
 	}
 
-	out := make(map[string]string, len(in))
+	out := make([]driver.EnvVar, 0, len(in))
 	for _, e := range in {
-		out[e.Name] = e.Value
+		out = append(out, driver.EnvVar{Name: e.Name, Value: e.Value})
 	}
 
 	return out
 }
 
-func envToList(in map[string]string) []envVar {
+func toWireEnv(in []driver.EnvVar) []envVar {
 	if len(in) == 0 {
 		return nil
 	}
 
 	out := make([]envVar, 0, len(in))
-	for k, v := range in {
-		out = append(out, envVar{Name: k, Value: v})
+	for _, e := range in {
+		out = append(out, envVar{Name: e.Name, Value: e.Value})
 	}
 
 	return out
@@ -103,7 +103,7 @@ func toContainers(in []driver.Container) []container {
 			Image:     in[i].Image,
 			Command:   in[i].Command,
 			Args:      in[i].Args,
-			Env:       envToList(in[i].Env),
+			Env:       toWireEnv(in[i].Env),
 			Ports:     toWirePorts(in[i].Ports),
 			Resources: toWireResources(in[i].Resources),
 		})

--- a/server/gcp/cloudrun/services_sdk_test.go
+++ b/server/gcp/cloudrun/services_sdk_test.go
@@ -220,6 +220,69 @@ func TestSDKServiceRevisions(t *testing.T) {
 	}
 }
 
+// TestSDKServiceEnvOrderStable covers BUG1: container env is an ordered list, so
+// [A,B,C] round-trips in declaration order — stably across repeated GETs — rather
+// than being re-shuffled through a map (which caused a perpetual Terraform diff).
+func TestSDKServiceEnvOrderStable(t *testing.T) {
+	svc := newRun(t, nil)
+	ctx := context.Background()
+
+	in := sdkService()
+	in.Template.Containers[0].Env = []*run.GoogleCloudRunV2EnvVar{
+		{Name: "A", Value: "1"},
+		{Name: "B", Value: "2"},
+		{Name: "C", Value: "3"},
+	}
+
+	if _, err := svc.Projects.Locations.Services.Create(parent, in).ServiceId("web").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	want := []string{"A", "B", "C"}
+
+	for range 2 {
+		got, err := svc.Projects.Locations.Services.Get(parent + "/services/web").Context(ctx).Do()
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+
+		env := got.Template.Containers[0].Env
+		if len(env) != len(want) {
+			t.Fatalf("env len = %d, want %d: %+v", len(env), len(want), env)
+		}
+
+		for i, name := range want {
+			if env[i].Name != name {
+				t.Fatalf("env[%d].Name = %q, want %q (order not preserved): %+v", i, env[i].Name, name, env)
+			}
+		}
+	}
+}
+
+// TestSDKServiceContainerPortName covers BUG2: a container port's optional name
+// (e.g. "h2c" to enable HTTP/2 cleartext) round-trips instead of being dropped.
+func TestSDKServiceContainerPortName(t *testing.T) {
+	svc := newRun(t, nil)
+	ctx := context.Background()
+
+	in := sdkService()
+	in.Template.Containers[0].Ports = []*run.GoogleCloudRunV2ContainerPort{{Name: "h2c", ContainerPort: 8080}}
+
+	if _, err := svc.Projects.Locations.Services.Create(parent, in).ServiceId("web").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Services.Get(parent + "/services/web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	ports := got.Template.Containers[0].Ports
+	if len(ports) != 1 || ports[0].Name != "h2c" || ports[0].ContainerPort != 8080 {
+		t.Fatalf("port name/number not preserved: %+v", ports)
+	}
+}
+
 // TestSDKServiceIam covers the service IAM surface (getIamPolicy/setIamPolicy).
 func TestSDKServiceIam(t *testing.T) {
 	svc := newRun(t, nil)

--- a/services/cloudrun/driver/driver.go
+++ b/services/cloudrun/driver/driver.go
@@ -98,9 +98,24 @@ type Container struct {
 	Image     string
 	Command   []string              // entrypoint override
 	Args      []string              // arguments to the entrypoint
-	Env       map[string]string     // environment variables
-	Ports     []int                 // container ports (services)
+	Env       []EnvVar              // environment variables, in declaration order
+	Ports     []ContainerPort       // container ports (services)
 	Resources *ResourceRequirements // cpu/memory limits and CPU behavior
+}
+
+// EnvVar is one container environment variable. Cloud Run env is an ordered
+// list (not a map), so it round-trips in declaration order across GETs.
+type EnvVar struct {
+	Name  string
+	Value string
+}
+
+// ContainerPort is one exposed container port. Name is optional and selects the
+// application protocol (e.g. "h2c" for HTTP/2 cleartext); ContainerPort is the
+// port the container listens on.
+type ContainerPort struct {
+	Name          string
+	ContainerPort int
 }
 
 // ResourceRequirements is a container's compute allocation — the limits map


### PR DESCRIPTION
## Summary

Two GCP Cloud Run container fidelity bugs, fixed end-to-end through the driver, provider, and wire layers in one change.

### BUG1 [MED] — container env vars returned in nondeterministic order
`driver.Container.Env` was a `map[string]string`, so `envToMap`/`envToList` ranged an unordered Go map — env came back reshuffled across GETs and duplicate names silently collapsed. Real Cloud Run env is an ordered `[]EnvVar` that is stable across reads. This caused a perpetual env-ordering diff in `google_cloud_run_v2_service`/`_job`.

Fix: `Container.Env` is now an ordered `[]driver.EnvVar` (name/value pairs) through the driver, the provider `cloneContainers`, and `conv.go` (the map hop is gone). Declaration order is preserved on round-trip.

### BUG2 [LOW-MED] — container port `name` dropped (h2c unconfigurable)
`driver.Container.Ports` was `[]int`, so the wire `containerPort.Name` (e.g. `"h2c"` for HTTP/2 cleartext) had nowhere to live and was discarded.

Fix: `Ports` is now `[]driver.ContainerPort{Name, ContainerPort}` through the driver, conv, and provider clone; the port name round-trips.

## Scope / safety
- `services/cloudrun/driver` change is structural; Cloud Run is the only consumer, so nothing else breaks.
- updateMask / revision / traffic / LRO paths untouched — existing tests remain green.
- `go generate` + `compatgen` produce zero diff.

## Tests (real `google.golang.org/api/run/v2` SDK over httptest)
- `TestSDKServiceEnvOrderStable` — env `[A,B,C]` returns in `[A,B,C]` order stably across 2 GETs.
- `TestSDKServiceContainerPortName` — port `{name:"h2c",containerPort:8080}` round-trips with the name.
- Existing provider tests updated to the new ordered types.