### PR TITLE
fix(azure-lb): case-insensitive LB+child lookup, PATCH UpdateTags, rule/probe defaults

### DIFF
--- a/providers/azure/loadbalancer/azure_load_balancer.go
+++ b/providers/azure/loadbalancer/azure_load_balancer.go
@@ -12,9 +12,13 @@ import (
 var _ driver.AzureLoadBalancers = (*Mock)(nil)
 
 // azureLBKey keys the native store by (resourceGroup, name), matching ARM's
-// addressing.
+// addressing. ARM resource-group and resource names are case-insensitive, so
+// the key is lower-cased to resolve differently-cased GET/DELETE/sub-resource
+// requests to the same load balancer and keep re-PUT an in-place update rather
+// than a duplicate. Only the internal map key is normalized; the stored body's
+// id/name casing is preserved verbatim.
 func azureLBKey(rg, name string) string {
-	return rg + "/" + name
+	return strings.ToLower(rg) + "/" + strings.ToLower(name)
 }
 
 // CreateOrUpdateAzureLoadBalancer stores the ARM load balancer as a full
@@ -191,7 +195,7 @@ func (m *Mock) UpsertAzureLBNatRule(
 		replaced := false
 
 		for i := range rules {
-			if rules[i].Name == natRuleName {
+			if strings.EqualFold(rules[i].Name, natRuleName) {
 				rules[i] = rule
 				replaced = true
 
@@ -230,7 +234,7 @@ func (m *Mock) DeleteAzureLBNatRule(_ context.Context, rg, name, natRuleName str
 		idx := -1
 
 		for i := range lb.NatRules {
-			if lb.NatRules[i].Name == natRuleName {
+			if strings.EqualFold(lb.NatRules[i].Name, natRuleName) {
 				idx = i
 				break
 			}
@@ -273,10 +277,11 @@ func containsString(in []string, s string) bool {
 	return indexOfString(in, s) != -1
 }
 
-// indexOfString returns the index of s in in, or -1 if absent.
+// indexOfString returns the index of s in in, or -1 if absent. Matching is
+// case-insensitive because ARM child names are case-insensitive.
 func indexOfString(in []string, s string) int {
 	for i, v := range in {
-		if v == s {
+		if strings.EqualFold(v, s) {
 			return i
 		}
 	}

--- a/server/azure/loadbalancer/case_patch_defaults_test.go
+++ b/server/azure/loadbalancer/case_patch_defaults_test.go
@@ -1,0 +1,220 @@
+package loadbalancer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// TestSDKAzureLBCaseInsensitiveAddressing proves the native store keys a load
+// balancer case-insensitively: a load balancer created with lower-case rg/name
+// resolves through differently-cased GET/DELETE/sub-resource requests, and a
+// re-PUT with different casing updates in place instead of creating a duplicate.
+func TestSDKAzureLBCaseInsensitiveAddressing(t *testing.T) {
+	c := newLBSubClients(t)
+	ctx := context.Background()
+
+	const (
+		lowerRG = "myrg"
+		upperRG = "MyRG"
+		lowerLB = "mylb"
+		upperLB = "MyLb"
+	)
+
+	mustCreate := func(rg, name string) {
+		poller, err := c.lb.BeginCreateOrUpdate(ctx, rg, name, armnetwork.LoadBalancer{
+			Location: to.Ptr("eastus"),
+			Properties: &armnetwork.LoadBalancerPropertiesFormat{
+				BackendAddressPools: []*armnetwork.BackendAddressPool{{Name: to.Ptr("pool-a")}},
+			},
+		}, nil)
+		if err != nil {
+			t.Fatalf("BeginCreateOrUpdate(%s/%s): %v", rg, name, err)
+		}
+
+		if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("CreateOrUpdate PollUntilDone(%s/%s): %v", rg, name, err)
+		}
+	}
+
+	mustCreate(lowerRG, lowerLB)
+
+	// GET with differently-cased rg and name resolves the same load balancer.
+	got, err := c.lb.Get(ctx, upperRG, upperLB, nil)
+	if err != nil {
+		t.Fatalf("Get(%s/%s): %v", upperRG, upperLB, err)
+	}
+
+	if got.Properties == nil || len(got.Properties.BackendAddressPools) != 1 {
+		t.Fatalf("cased Get pools = %+v, want 1", got.Properties)
+	}
+
+	// Re-PUT with different casing must update in place, not duplicate. List by
+	// rg (List matches rg case-insensitively) must still show exactly one.
+	mustCreate(upperRG, upperLB)
+
+	var count int
+
+	pager := c.lb.NewListPager(lowerRG, nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("List: %v", perr)
+		}
+
+		count += len(page.Value)
+	}
+
+	if count != 1 {
+		t.Fatalf("list after cased re-PUT = %d load balancers, want 1 (no duplicate)", count)
+	}
+
+	// Sub-resource CRUD addressed by cased rg/lb name resolves the same LB.
+	poolPoller, err := c.pools.BeginCreateOrUpdate(ctx, upperRG, upperLB, "pool-b",
+		armnetwork.BackendAddressPool{}, nil)
+	if err != nil {
+		t.Fatalf("pool BeginCreateOrUpdate (cased): %v", err)
+	}
+
+	if _, err := poolPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("pool PollUntilDone (cased): %v", err)
+	}
+
+	poolGot, err := c.pools.Get(ctx, upperRG, upperLB, "pool-b", nil)
+	if err != nil {
+		t.Fatalf("pool Get (cased): %v", err)
+	}
+
+	if poolGot.Name == nil || *poolGot.Name != "pool-b" {
+		t.Fatalf("pool name = %v, want pool-b", poolGot.Name)
+	}
+
+	delPoolPoller, err := c.pools.BeginDelete(ctx, upperRG, upperLB, "pool-b", nil)
+	if err != nil {
+		t.Fatalf("pool BeginDelete (cased): %v", err)
+	}
+
+	if _, err := delPoolPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("pool delete PollUntilDone (cased): %v", err)
+	}
+
+	// DELETE the whole load balancer by a differently-cased name.
+	delPoller, err := c.lb.BeginDelete(ctx, upperRG, upperLB, nil)
+	if err != nil {
+		t.Fatalf("BeginDelete (cased): %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete PollUntilDone (cased): %v", err)
+	}
+}
+
+// TestSDKAzureLBUpdateTags proves PATCH LoadBalancers.UpdateTags merges the
+// supplied tags into the stored load balancer (keeping existing tags) and
+// returns 200 with the updated resource.
+func TestSDKAzureLBUpdateTags(t *testing.T) {
+	client := newLBClient(t)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, testRG, "lb-tags", armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("test"), "team": to.Ptr("net")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("CreateOrUpdate PollUntilDone: %v", err)
+	}
+
+	updated, err := client.UpdateTags(ctx, testRG, "lb-tags", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("platform"), "cost": to.Ptr("42")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("UpdateTags: %v", err)
+	}
+
+	tags := updated.Tags
+	if tags["env"] == nil || *tags["env"] != "test" {
+		t.Fatalf("merged tags lost env: %v", tags)
+	}
+
+	if tags["team"] == nil || *tags["team"] != "platform" {
+		t.Fatalf("merged tags team = %v, want platform (overwritten)", tags["team"])
+	}
+
+	if tags["cost"] == nil || *tags["cost"] != "42" {
+		t.Fatalf("merged tags missing cost: %v", tags)
+	}
+}
+
+// TestSDKAzureLBRuleProbeDefaults proves omitted rule/probe fields read back
+// with the defaults real Azure synthesizes: loadBalancingRule
+// idleTimeoutInMinutes=4 / loadDistribution=Default, probe intervalInSeconds=15
+// / numberOfProbes=2.
+func TestSDKAzureLBRuleProbeDefaults(t *testing.T) {
+	client := newLBClient(t)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, testRG, "lb-def", armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{
+			Probes: []*armnetwork.Probe{
+				{
+					Name: to.Ptr("probe-a"),
+					Properties: &armnetwork.ProbePropertiesFormat{
+						Protocol: to.Ptr(armnetwork.ProbeProtocolTCP),
+						Port:     to.Ptr(int32(80)),
+					},
+				},
+			},
+			LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+				{
+					Name: to.Ptr("rule-a"),
+					Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+						Protocol:     to.Ptr(armnetwork.TransportProtocolTCP),
+						FrontendPort: to.Ptr(int32(80)),
+						BackendPort:  to.Ptr(int32(80)),
+					},
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate PollUntilDone: %v", err)
+	}
+
+	if len(created.Properties.LoadBalancingRules) != 1 {
+		t.Fatalf("rules = %d, want 1", len(created.Properties.LoadBalancingRules))
+	}
+
+	rp := created.Properties.LoadBalancingRules[0].Properties
+	if rp.IdleTimeoutInMinutes == nil || *rp.IdleTimeoutInMinutes != 4 {
+		t.Fatalf("rule idleTimeoutInMinutes = %v, want 4", rp.IdleTimeoutInMinutes)
+	}
+
+	if rp.LoadDistribution == nil || *rp.LoadDistribution != armnetwork.LoadDistributionDefault {
+		t.Fatalf("rule loadDistribution = %v, want Default", rp.LoadDistribution)
+	}
+
+	if len(created.Properties.Probes) != 1 {
+		t.Fatalf("probes = %d, want 1", len(created.Properties.Probes))
+	}
+
+	pp := created.Properties.Probes[0].Properties
+	if pp.IntervalInSeconds == nil || *pp.IntervalInSeconds != 15 {
+		t.Fatalf("probe intervalInSeconds = %v, want 15", pp.IntervalInSeconds)
+	}
+
+	if pp.NumberOfProbes == nil || *pp.NumberOfProbes != 2 {
+		t.Fatalf("probe numberOfProbes = %v, want 2", pp.NumberOfProbes)
+	}
+}

--- a/server/azure/loadbalancer/handler.go
+++ b/server/azure/loadbalancer/handler.go
@@ -186,6 +186,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.createOrUpdateLoadBalancer(w, r, &rp)
 	case http.MethodGet:
 		h.getLoadBalancer(w, r, &rp)
+	case http.MethodPatch:
+		h.updateLoadBalancerTags(w, r, &rp)
 	case http.MethodDelete:
 		h.deleteLoadBalancer(w, r, &rp)
 	default:

--- a/server/azure/loadbalancer/operations.go
+++ b/server/azure/loadbalancer/operations.go
@@ -75,6 +75,61 @@ func (h *Handler) getLoadBalancer(w http.ResponseWriter, r *http.Request, rp *az
 	azurearm.WriteJSON(w, http.StatusOK, toLBJSON(rp, stored, h.poolMembers(r.Context(), rp.Subscription)))
 }
 
+// updateLoadBalancerTags handles PATCH .../loadBalancers/{name} —
+// LoadBalancers.UpdateTags. The body carries only a tags map; the tags are
+// MERGED into the stored load balancer (existing tags are kept, matching keys
+// overwritten) and every child is preserved. Returns 200 with the updated load
+// balancer, matching the SDK's synchronous UpdateTags.
+func (h *Handler) updateLoadBalancerTags(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body loadBalancerJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	az, ok := h.azureLB()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "load balancer not found")
+		return
+	}
+
+	stored, err := az.GetAzureLoadBalancer(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	merged := *stored
+	merged.Tags = mergeTags(stored.Tags, stripInternalTags(body.Tags))
+
+	updated, err := az.CreateOrUpdateAzureLoadBalancer(r.Context(), rp.ResourceGroup, rp.ResourceName, merged)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toLBJSON(rp, updated, h.poolMembers(r.Context(), rp.Subscription)))
+}
+
+// mergeTags returns base with every key in overlay applied on top (overlay
+// wins on conflict). Neither input is mutated.
+func mergeTags(base, overlay map[string]string) map[string]string {
+	if len(base) == 0 && len(overlay) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(base)+len(overlay))
+
+	for k, v := range base {
+		out[k] = v
+	}
+
+	for k, v := range overlay {
+		out[k] = v
+	}
+
+	return out
+}
+
 // deleteLoadBalancer removes the load balancer from both the native store and
 // the cross-cloud record. LoadBalancers.Delete is an LRO; a 200 with empty body
 // completes the poller.
@@ -243,6 +298,14 @@ func buildProbes(in []probeJSON) []lbdriver.AzureLBProbe {
 			pr.NumberOfProbes = int(p.NumberOfProbes)
 		}
 
+		if pr.IntervalInSeconds == 0 {
+			pr.IntervalInSeconds = defaultProbeIntervalSec
+		}
+
+		if pr.NumberOfProbes == 0 {
+			pr.NumberOfProbes = defaultProbeCount
+		}
+
 		out = append(out, pr)
 	}
 
@@ -279,6 +342,14 @@ func buildRules(in []loadBalancingRuleJSON) []lbdriver.AzureLBRule {
 			}
 		}
 
+		if rule.IdleTimeoutMin == 0 {
+			rule.IdleTimeoutMin = defaultIdleTimeoutMin
+		}
+
+		if rule.LoadDistribution == "" {
+			rule.LoadDistribution = defaultLoadDistribution
+		}
+
 		out = append(out, rule)
 	}
 
@@ -306,6 +377,10 @@ func buildNatRules(in []inboundNatRuleJSON) []lbdriver.AzureLBNatRule {
 			if p.EnableFloatingIP != nil {
 				rule.EnableFloatingIP = *p.EnableFloatingIP
 			}
+		}
+
+		if rule.IdleTimeoutMin == 0 {
+			rule.IdleTimeoutMin = defaultIdleTimeoutMin
 		}
 
 		out = append(out, rule)

--- a/server/azure/loadbalancer/subresource.go
+++ b/server/azure/loadbalancer/subresource.go
@@ -2,6 +2,7 @@ package loadbalancer
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
@@ -311,7 +312,7 @@ func findChild(
 
 func findFrontend(lbID string, in []lbdriver.AzureLBFrontend, name string) (any, bool) {
 	for i := range in {
-		if in[i].Name == name {
+		if strings.EqualFold(in[i].Name, name) {
 			return frontendsJSON(lbID, []lbdriver.AzureLBFrontend{in[i]})[0], true
 		}
 	}
@@ -321,7 +322,7 @@ func findFrontend(lbID string, in []lbdriver.AzureLBFrontend, name string) (any,
 
 func findPool(lbID string, in []string, name string, members map[string][]string) (any, bool) {
 	for _, p := range in {
-		if p == name {
+		if strings.EqualFold(p, name) {
 			return poolsJSON(lbID, []string{p}, members)[0], true
 		}
 	}
@@ -331,7 +332,7 @@ func findPool(lbID string, in []string, name string, members map[string][]string
 
 func findRule(lbID string, in []lbdriver.AzureLBRule, name string) (any, bool) {
 	for i := range in {
-		if in[i].Name == name {
+		if strings.EqualFold(in[i].Name, name) {
 			return rulesJSON(lbID, []lbdriver.AzureLBRule{in[i]})[0], true
 		}
 	}
@@ -341,7 +342,7 @@ func findRule(lbID string, in []lbdriver.AzureLBRule, name string) (any, bool) {
 
 func findProbe(lbID string, in []lbdriver.AzureLBProbe, name string) (any, bool) {
 	for i := range in {
-		if in[i].Name == name {
+		if strings.EqualFold(in[i].Name, name) {
 			return probesJSON(lbID, []lbdriver.AzureLBProbe{in[i]})[0], true
 		}
 	}
@@ -351,7 +352,7 @@ func findProbe(lbID string, in []lbdriver.AzureLBProbe, name string) (any, bool)
 
 func findNatRule(lbID string, in []lbdriver.AzureLBNatRule, name string) (any, bool) {
 	for i := range in {
-		if in[i].Name == name {
+		if strings.EqualFold(in[i].Name, name) {
 			return natRulesJSON(lbID, []lbdriver.AzureLBNatRule{in[i]})[0], true
 		}
 	}
@@ -361,7 +362,7 @@ func findNatRule(lbID string, in []lbdriver.AzureLBNatRule, name string) (any, b
 
 func findOutboundRule(lbID string, in []lbdriver.AzureLBOutboundRule, name string) (any, bool) {
 	for i := range in {
-		if in[i].Name == name {
+		if strings.EqualFold(in[i].Name, name) {
 			return outboundRulesJSON(lbID, []lbdriver.AzureLBOutboundRule{in[i]})[0], true
 		}
 	}

--- a/server/azure/loadbalancer/types.go
+++ b/server/azure/loadbalancer/types.go
@@ -37,6 +37,13 @@ const (
 	defaultSKUTier = "Regional"
 
 	protocolTCP = "Tcp"
+
+	// Defaults Azure synthesizes for rule/probe fields omitted from the request,
+	// echoed back on GET so the emulator matches real-cloud output.
+	defaultIdleTimeoutMin   = 4         // loadBalancingRule / inboundNatRule idleTimeoutInMinutes
+	defaultLoadDistribution = "Default" // loadBalancingRule loadDistribution
+	defaultProbeIntervalSec = 15        // probe intervalInSeconds
+	defaultProbeCount       = 2         // probe numberOfProbes
 )
 
 // subResource is Azure's {"id": "..."} reference shape.


### PR DESCRIPTION
## Summary

Fixes four Azure Load Balancer parity bugs found in a real-SDK (armnetwork) audit of `providers/azure/loadbalancer/` + `server/azure/loadbalancer/`. All whole-LB-replace semantics and in-sync standalone sub-resource CRUD are preserved.

### BUG1 [MED] — case-insensitive native store key
`azureLBKey(rg, name)` was case-SENSITIVE, so a GET/DELETE/sub-resource request using a differently-cased resource group or LB name 404'd, and a re-PUT with different casing created a DUPLICATE store entry. ARM addressing is case-insensitive. Fix: the internal map key is now `strings.ToLower(rg)+"/"+strings.ToLower(name)`. Response body `id`/`name` casing is unchanged — only the map key is normalized. (#762 fixed only the List RG-filter, not this primary key.)

### BUG4 [LOW] — case-insensitive child-name matching
`indexOfString`/`containsString` (backend pools), NAT-rule upsert/delete name matching, and the `findChild` sub-resource helpers (frontend/pool/rule/probe/nat/outbound) used exact `==`. ARM child names are case-insensitive. Fix: `strings.EqualFold` throughout.

### BUG3 [LOW-MED] — PATCH LoadBalancers.UpdateTags
A PATCH on the whole LB previously fell through to 405. Fix: added a `PATCH` branch that MERGES the request's tags into the stored LB (existing tags kept, matching keys overwritten), preserves every child, and returns 200 with the LB.

### BUG5 [LOW] — synthesize omitted rule/probe defaults
Omitted fields read back as Go-zero instead of the defaults real Azure applies. Fix: loadBalancingRule `idleTimeoutInMinutes=4` / `loadDistribution=Default`; probe `intervalInSeconds=15` / `numberOfProbes=2` (inbound NAT rule `idleTimeoutInMinutes=4` applied for consistency).

### Deferred
- BUG2 (`loadBalancerBackendAddresses` round-trip) — DEFERRED: it requires extending the native pool model beyond a `[]string` of names to carry backend-address entries, a larger model change than fits this focused PR.

## Tests
New real-armnetwork tests over `httptest` (`case_patch_defaults_test.go`): cased GET/DELETE + sub-resource CRUD resolve the same LB; cased re-PUT does not duplicate (List stays at 1); UpdateTags merges tags -> 200; a minimal rule/probe reads back idleTimeout=4/loadDistribution=Default/interval=15/count=2.

Gates: build, vet, `go test ./server/azure/loadbalancer/... ./providers/azure/loadbalancer/...`, gofmt, `go generate`/compatgen (zero diff), and `golangci-lint --new-from-rev=origin/development` (0 new) all green.